### PR TITLE
v3: fix pass-list compilation regressions

### DIFF
--- a/vlib/v3/flat/flat.v
+++ b/vlib/v3/flat/flat.v
@@ -216,7 +216,9 @@ pub mut:
 	worker_pool &workers.Pool = unsafe { nil }
 	// specialized_fn_nodes identifies program-specific monomorphized function
 	// declarations appended after parsing. Module-cache cgen keeps them with main.
-	specialized_fn_nodes map[int]bool
+	specialized_fn_nodes   map[int]bool
+	specialized_fn_modules map[int]string
+	specialized_fn_files   map[int]string
 }
 
 // close_workers stops the compilation-owned persistent worker pool.
@@ -265,14 +267,16 @@ pub fn (mut a FlatAst) set_node_is_mut(id NodeId, is_mut bool) {
 // new creates a FlatAst value for flat.
 pub fn FlatAst.new() FlatAst {
 	return FlatAst{
-		nodes:                []Node{cap: 256}
-		children:             []NodeId{cap: 512}
-		disabled_fns:         map[string]bool{}
-		export_fn_names:      map[string]string{}
-		noreturn_fns:         map[string]bool{}
-		source_files:         map[int]&token.File{}
-		text_ids:             map[string]TextId{}
-		specialized_fn_nodes: map[int]bool{}
+		nodes:                  []Node{cap: 256}
+		children:               []NodeId{cap: 512}
+		disabled_fns:           map[string]bool{}
+		export_fn_names:        map[string]string{}
+		noreturn_fns:           map[string]bool{}
+		source_files:           map[int]&token.File{}
+		text_ids:               map[string]TextId{}
+		specialized_fn_nodes:   map[int]bool{}
+		specialized_fn_modules: map[int]string{}
+		specialized_fn_files:   map[int]string{}
 	}
 }
 

--- a/vlib/v3/gen/c/array.v
+++ b/vlib/v3/gen/c/array.v
@@ -251,7 +251,9 @@ fn (mut g FlatGen) gen_fixed_array_data_arg(id flat.NodeId, arr types.ArrayFixed
 			return
 		}
 	}
-	if fixed_array_option_payload_type(types.unwrap_pointer(g.usable_expr_type(id))) != none {
+	annotated_is_fixed := node.typ.len > 0 && array_fixed_type(g.tc.parse_type(node.typ)) != none
+	if !annotated_is_fixed
+		&& fixed_array_option_payload_type(types.unwrap_pointer(g.usable_expr_type(id))) != none {
 		g.gen_expr(id)
 		g.write('.value')
 		return
@@ -266,6 +268,23 @@ fn (mut g FlatGen) gen_fixed_array_data_arg(id flat.NodeId, arr types.ArrayFixed
 		return
 	}
 	g.gen_expr(id)
+}
+
+fn (mut g FlatGen) gen_new_array_fixed_data_arg(call flat.Node, arg_start int, arg_idx int, arg_id flat.NodeId, names []string) bool {
+	if arg_idx != 3 || !names.any(it in ['new_array_from_c_array', 'array__new_array_from_c_array'])
+		|| arg_start + 2 >= call.children_count {
+		return false
+	}
+	sizeof_id := g.a.child(&call, arg_start + 2)
+	sizeof_node := g.a.nodes[int(sizeof_id)]
+	if sizeof_node.kind != .sizeof_expr || sizeof_node.value.len == 0 {
+		return false
+	}
+	elem_type := g.tc.parse_type(sizeof_node.value)
+	g.gen_fixed_array_data_arg(arg_id, types.ArrayFixed{
+		elem_type: elem_type
+	})
+	return true
 }
 
 // gen_nested_fixed_array_literal_copy materializes nested fixed-array elements that cannot be
@@ -1600,7 +1619,7 @@ fn (g &FlatGen) array_assign_base_is_shared_value_selector(base_id flat.NodeId) 
 		return false
 	}
 	node := g.a.nodes[int(base_id)]
-	if node.kind == .ident && node.typ.starts_with('shared ') {
+	if node.kind == .ident {
 		return g.local_ident_is_shared_wrapper(node.value)
 	}
 	if node.kind != .selector || node.value != 'val' || node.children_count == 0 {

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -15533,12 +15533,12 @@ fn startup_module_key(mod string) string {
 	return mod
 }
 
-fn (g &FlatGen) is_const_expr(id flat.NodeId) bool {
+fn (mut g FlatGen) is_const_expr(id flat.NodeId) bool {
 	mut visiting := map[int]bool{}
 	return g.is_const_expr_inner(id, mut visiting)
 }
 
-fn (g &FlatGen) is_const_expr_inner(id flat.NodeId, mut visiting map[int]bool) bool {
+fn (mut g FlatGen) is_const_expr_inner(id flat.NodeId, mut visiting map[int]bool) bool {
 	if int(id) < 0 || int(id) >= g.a.nodes.len {
 		return false
 	}
@@ -15590,14 +15590,8 @@ fn (g &FlatGen) is_const_expr_inner(id flat.NodeId, mut visiting map[int]bool) b
 			all_const
 		}
 		.struct_init {
-			if fields := g.struct_fields_for_type(node.value) {
-				for field in fields {
-					clean_type := default_init_unalias_type(field.typ)
-					if clean_type is types.Array || clean_type is types.Channel
-						|| clean_type is types.Map {
-						return false
-					}
-				}
+			if g.struct_needs_default_init(node.value) {
+				return false
 			}
 			mut all_const := true
 			for ci in 0 .. node.children_count {
@@ -15624,7 +15618,7 @@ fn (g &FlatGen) is_const_expr_inner(id flat.NodeId, mut visiting map[int]bool) b
 	}
 }
 
-fn (g &FlatGen) const_ref_is_static(name string, mut visiting map[int]bool) bool {
+fn (mut g FlatGen) const_ref_is_static(name string, mut visiting map[int]bool) bool {
 	const_name := g.const_ref_name(name)
 	if const_name.len == 0 {
 		return false

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -15125,7 +15125,8 @@ fn (mut g FlatGen) name_collides_with_struct_field(name string) bool {
 
 fn (g &FlatGen) const_expr_needs_runtime_storage(expr string) bool {
 	return expr.contains('array_new(') || expr.contains('new_map(') || expr.contains('({')
-		|| expr.contains('__map_') || expr.contains('_str_')
+		|| expr.contains('sync__new_channel_st(') || expr.contains('__map_')
+		|| expr.contains('_str_')
 }
 
 fn (mut g FlatGen) queue_map_literal_sets(target string, val_id flat.NodeId, map_type types.Map) {
@@ -15589,6 +15590,15 @@ fn (g &FlatGen) is_const_expr_inner(id flat.NodeId, mut visiting map[int]bool) b
 			all_const
 		}
 		.struct_init {
+			if fields := g.struct_fields_for_type(node.value) {
+				for field in fields {
+					clean_type := default_init_unalias_type(field.typ)
+					if clean_type is types.Array || clean_type is types.Channel
+						|| clean_type is types.Map {
+						return false
+					}
+				}
+			}
 			mut all_const := true
 			for ci in 0 .. node.children_count {
 				child := g.a.child_node(&node, ci)

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -125,10 +125,11 @@ mut:
 	iface_type_ids                 map[string]int      // "${iface}::${concrete}" -> 1-based type id
 	interface_boxed_types          map[string]bool
 	interface_boxed_types_done     bool
-	ierror_method_emit_names       map[string]bool     // names/lowered names of concrete IError msg/code methods
-	ierror_stack_pointer_aliases   []map[string]bool   // scoped local pointer aliases to stack subobjects
-	local_pointer_storage_by_owner map[string]bool     // exact scope binding owner -> C storage is already a pointer
-	local_c_type_by_owner          map[string]string   // exact scope binding owner -> emitted C declaration type
+	ierror_method_emit_names       map[string]bool   // names/lowered names of concrete IError msg/code methods
+	ierror_stack_pointer_aliases   []map[string]bool // scoped local pointer aliases to stack subobjects
+	local_pointer_storage_by_owner map[string]bool   // exact scope binding owner -> C storage is already a pointer
+	local_c_type_by_owner          map[string]string // exact scope binding owner -> emitted C declaration type
+	local_mutable_by_owner         map[string]bool
 	local_pointer_alias_by_owner   map[string]string   // exact scope binding owner -> stack local whose address is stored
 	local_pointer_alias_mut_param  map[string]bool     // exact scope binding owner -> alias source is a mut parameter
 	local_raw_type_by_owner        map[string]string   // exact scope binding owner -> source-level raw type text
@@ -194,6 +195,7 @@ mut:
 	generic_fn_key_ordinal       map[string]int
 	struct_decl_infos            map[string]StructDeclInfo
 	struct_decl_short_infos      map[string]StructDeclInfo
+	decl_attrs                   map[int][]string
 	shared_type_names            map[string]SharedTypeInfo // __shared__ wrapper name -> wrapped type metadata
 	needs_shared_runtime         bool
 	const_runtime_inits          []string
@@ -208,7 +210,10 @@ mut:
 	c99_mode                     bool
 	skip_generics                bool
 	cur_fn_name                  string
+	current_decl_is_mut          bool
+	direct_array_access          bool
 	struct_default_module        string
+	default_value_stack          map[string]bool
 	shadowed_global_locals       map[string]bool
 	cur_param_names              []string
 	cur_param_type_values        []types.Type
@@ -220,6 +225,7 @@ mut:
 	cur_fn_ret_is_optional       bool
 	cur_fn_ret_base              types.Type = types.Type(types.void_)
 	active_locks                 []ActiveLock
+	unsafe_depth                 int
 	loop_depth                   int
 	conditional_branch_scopes    []&types.Scope
 	conditional_branch_depths    []int
@@ -454,6 +460,23 @@ fn (mut g FlatGen) declare_local_c_type(owner types.ScopeBindingOwner, c_type st
 	}
 }
 
+fn (mut g FlatGen) declare_local_mutability(owner types.ScopeBindingOwner, is_mut bool) {
+	key := owner.storage_key()
+	if key.len == 0 {
+		return
+	}
+	if is_mut {
+		g.local_mutable_by_owner[key] = true
+	} else {
+		g.local_mutable_by_owner.delete(key)
+	}
+}
+
+fn (g &FlatGen) local_storage_is_mutable(name string) bool {
+	owner := g.local_storage_owner(name) or { return false }
+	return g.local_mutable_by_owner[owner.storage_key()] or { false }
+}
+
 fn (mut g FlatGen) declare_local_pointer_alias_source(owner types.ScopeBindingOwner, source string) {
 	g.declare_local_pointer_alias_source_kind(owner, source, false)
 }
@@ -618,6 +641,7 @@ pub fn FlatGen.new() FlatGen {
 		ierror_stack_pointer_aliases:   []map[string]bool{}
 		local_pointer_storage_by_owner: map[string]bool{}
 		local_c_type_by_owner:          map[string]string{}
+		local_mutable_by_owner:         map[string]bool{}
 		local_pointer_alias_by_owner:   map[string]string{}
 		local_pointer_alias_mut_param:  map[string]bool{}
 		local_raw_type_by_owner:        map[string]string{}
@@ -664,7 +688,9 @@ pub fn FlatGen.new() FlatGen {
 		generic_fn_key_ordinal:         map[string]int{}
 		struct_decl_infos:              map[string]StructDeclInfo{}
 		struct_decl_short_infos:        map[string]StructDeclInfo{}
+		decl_attrs:                     map[int][]string{}
 		shared_type_names:              map[string]SharedTypeInfo{}
+		default_value_stack:            map[string]bool{}
 		cur_param_names:                []string{}
 		cur_param_type_values:          []types.Type{}
 		cur_param_types:                map[string]types.Type{}
@@ -1188,6 +1214,8 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	g.used_fns = &used_fns
 	g.used_fn_names = []string{}
 	g.fn_gen_items = []FlatFnGenItem{}
+	g.direct_array_access = false
+	g.unsafe_depth = 0
 	g.fn_segs = []string{}
 	g.str_lits = []string{}
 	g.str_lits_shared = false
@@ -1223,6 +1251,7 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	g.ierror_stack_pointer_aliases = []map[string]bool{}
 	g.local_pointer_storage_by_owner.clear()
 	g.local_c_type_by_owner.clear()
+	g.local_mutable_by_owner.clear()
 	g.local_pointer_alias_by_owner.clear()
 	g.local_pointer_alias_mut_param.clear()
 	g.local_raw_type_by_owner.clear()
@@ -1325,6 +1354,14 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	}
 	g.has_builtins = g.tc.has_builtins
 	g.collect_gen_info()
+	// Function-item selection can run during pre-dispatch preparation. Populate
+	// interface implementers first so that late-lowered dispatch targets are not
+	// pruned before their concrete method bodies are emitted.
+	g.collect_interface_impls()
+	// Struct field defaults are emitted from their declarations when an otherwise
+	// unrelated function initializes the struct. Parallel function pre-scanning only
+	// visits that function body, so seed literals from defaults before workers fork.
+	g.preseed_struct_default_string_literals()
 	g.precompute_shared_param_index()
 	if !g.skip_generics {
 		g.precompute_non_generic_fn_index()
@@ -1343,14 +1380,12 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 		g.precompute_concrete_optional_abi_fns()
 	}
 	g.collect_shared_type_names()
-	g.collect_interface_impls()
 	g.precompute_sum_name_lookup()
 	g.preseed_struct_fn_ptr_types()
 	g.preseed_sum_fn_ptr_types()
 	g.preseed_global_fn_ptr_types()
 	g.preseed_fn_signature_fn_ptr_types()
 	g.preseed_c_extern_fn_ptr_types()
-	g.preseed_struct_default_string_literals()
 	g.preseed_libc_compat_fns()
 	if !g.skip_generics {
 		g.precompute_generic_method_candidate_index()
@@ -1776,6 +1811,11 @@ fn (mut g FlatGen) collect_gen_info() {
 		}
 
 		kind_id := node_kind_id(node)
+		if node.kind == .directive && node.value.starts_with('@attributes:') {
+			target_idx := node.value['@attributes:'.len..].int()
+			g.decl_attrs[target_idx] = node.generic_params().clone()
+			continue
+		}
 		if kind_id == 77 {
 			cur_file = node.value
 			g.note_compiler_source_file(node.value)
@@ -1886,9 +1926,10 @@ fn (mut g FlatGen) collect_gen_info() {
 				decl_is_variadic, first_param_is_mut, node.typ)
 			// Module-level `init()` functions run once at startup. Collect their C
 			// names so _vinit can invoke them (V semantics).
-			if node.value == 'init' && ptypes.len == 0
+			is_builtin_init := cur_module == 'builtin' && node.value == 'builtin_init'
+			if (node.value == 'init' || is_builtin_init) && ptypes.len == 0
 				&& (!g.has_used_fn_filter() || g.used_fn_contains_in_module(node.value, cur_module)) {
-				init_cname := g.qualified_fn_name_in_module_c(cur_module, 'init')
+				init_cname := g.qualified_fn_name_in_module_c(cur_module, node.value)
 				if init_cname !in g.module_init_fns {
 					g.module_init_fns << init_cname
 				}
@@ -1909,7 +1950,8 @@ fn (mut g FlatGen) collect_gen_info() {
 			full_name := qualify_name_in_module(cur_module, node.value)
 			g.tc.cur_file = cur_file
 			g.tc.cur_module = cur_module
-			g.register_struct_decl_info(node.value, full_name, cur_module, cur_file, node)
+			g.register_struct_decl_info_at(node_idx, node.value, full_name, cur_module, cur_file,
+				node)
 			continue
 		}
 		if kind_id == 64 {
@@ -1980,6 +2022,9 @@ fn (mut g FlatGen) collect_gen_info() {
 					field_values[f.value] = i64(val)
 					val++
 				} else {
+					// Keep enum expressions symbolic so explicit values that come from C
+					// macros (and therefore cannot be folded by V) survive at use sites.
+					g.enum_value_exprs[key] = '${g.cname(enum_name)}__${g.cname(f.value)}'
 					g.enum_vals[key] = val
 					field_values[f.value] = val
 					val++
@@ -3646,11 +3691,21 @@ fn c_header_macro_wrapped_declared_fn_name(line string) ?string {
 
 fn c_header_defined_fn_name(line string) string {
 	if line.len == 0 || line[0] == `#` || line.ends_with(';') || !line.contains('(')
-		|| line.contains('=') || line.contains('(*') {
+		|| line.contains('=') {
 		return ''
 	}
-	for prefix in ['typedef ', 'struct ', 'union ', 'enum ', 'extern ', 'return ', 'if ', 'if(',
-		'for ', 'for(', 'while ', 'while(', 'switch ', 'switch(', 'case ', 'do ', 'else '] {
+	paren_idx := line.index_u8(`(`)
+	mut after := paren_idx + 1
+	for after < line.len && line[after].is_space() {
+		after++
+	}
+	// Reject a function-pointer variable/return declarator (`int (*fp)(...)`),
+	// while allowing ordinary functions that take a function-pointer parameter.
+	if after < line.len && line[after] == `*` {
+		return ''
+	}
+	for prefix in ['typedef ', 'enum ', 'extern ', 'return ', 'if ', 'if(', 'for ', 'for(', 'while ',
+		'while(', 'switch ', 'switch(', 'case ', 'do ', 'else '] {
 		if line.starts_with(prefix) {
 			return ''
 		}
@@ -5407,8 +5462,13 @@ fn (mut g FlatGen) register_fn_decl_node(name string, module_name string, id fla
 
 // register_struct_decl_info updates register struct decl info state for c.
 fn (mut g FlatGen) register_struct_decl_info(name string, full_name string, module_name string, source_file string, node flat.Node) {
+	g.register_struct_decl_info_at(-1, name, full_name, module_name, source_file, node)
+}
+
+fn (mut g FlatGen) register_struct_decl_info_at(node_id int, name string, full_name string, module_name string, source_file string, node flat.Node) {
 	info := StructDeclInfo{
 		node:      node
+		node_id:   node_id
 		module:    module_name
 		file:      source_file
 		full_name: full_name
@@ -5424,6 +5484,7 @@ fn (mut g FlatGen) register_struct_decl_info(name string, full_name string, modu
 // declaration nodes are outside function subtrees, so parallel function prep
 // does not otherwise see them before worker-local string IDs are assigned.
 fn (mut g FlatGen) preseed_struct_default_string_literals() {
+	mut seen := map[int]bool{}
 	mut stack := []flat.NodeId{cap: 32}
 	for _, info in g.struct_decl_infos {
 		for i in 0 .. info.node.children_count {
@@ -5436,15 +5497,16 @@ fn (mut g FlatGen) preseed_struct_default_string_literals() {
 			for stack.len > 0 {
 				id := stack.pop()
 				idx := int(id)
-				if idx < 0 || idx >= g.a.nodes.len {
+				if idx < 0 || idx >= g.a.nodes.len || seen[idx] {
 					continue
 				}
+				seen[idx] = true
 				node := g.a.nodes[idx]
 				if node.kind == .string_literal {
 					g.intern_string(node.value)
 				}
 				for child_idx := node.children_count - 1; child_idx >= 0; child_idx-- {
-					stack << g.a.children[node.children_start + child_idx]
+					stack << g.a.child(&node, child_idx)
 				}
 			}
 		}
@@ -5539,6 +5601,18 @@ fn (g &FlatGen) enum_selector_base_name(name string) ?string {
 	if name in g.tc.enum_names || name in g.tc.flag_enums {
 		return name
 	}
+	if name.contains('.') {
+		alias := name.all_before('.')
+		if module_name := g.import_alias_module(alias) {
+			resolved := '${module_name}.${name.all_after('.')}'
+			if resolved in g.tc.enum_names || resolved in g.tc.flag_enums {
+				return resolved
+			}
+			if target := g.enum_selector_alias_target(resolved) {
+				return target
+			}
+		}
+	}
 	qname := g.tc.qualify_name(name)
 	if qname in g.tc.enum_names || qname in g.tc.flag_enums {
 		return qname
@@ -5594,7 +5668,7 @@ fn (mut g FlatGen) expr_to_string(id flat.NodeId) string {
 
 // const_block_init_to_string renders a lowered const initializer block as a
 // braced statement sequence assigning the final expression to the const.
-fn (mut g FlatGen) const_block_init_to_string(qname string, val_node flat.Node) string {
+fn (mut g FlatGen) const_block_init_to_string(qname string, val_node flat.Node, expected types.Type) string {
 	orig := g.sb
 	orig_line_start := g.line_start
 	orig_indent := g.indent
@@ -5611,9 +5685,9 @@ fn (mut g FlatGen) const_block_init_to_string(qname string, val_node flat.Node) 
 	last_id := g.a.child(&val_node, int(val_node.children_count) - 1)
 	last := g.a.nodes[int(last_id)]
 	if last.kind == .expr_stmt && last.children_count > 0 {
-		g.gen_expr(g.a.child(&last, 0))
+		g.gen_expr_with_expected_type(g.a.child(&last, 0), expected)
 	} else {
-		g.gen_expr(last_id)
+		g.gen_expr_with_expected_type(last_id, expected)
 	}
 	g.writeln(';')
 	g.indent--
@@ -6101,8 +6175,8 @@ fn (mut g FlatGen) gen_expr_with_expected_type(id flat.NodeId, expected types.Ty
 	}
 	mut actual := g.usable_expr_type(id)
 	if node.kind == .ident {
-		if param_type := g.current_param_type(node.value) {
-			actual = param_type
+		if local_type := g.local_ident_type(node.value) {
+			actual = local_type
 		}
 	}
 	if expected is types.String && actual is types.Pointer
@@ -6121,6 +6195,20 @@ fn (mut g FlatGen) gen_expr_with_expected_type(id flat.NodeId, expected types.Ty
 		return
 	}
 	semantic_actual := cgen_unalias_type(actual)
+	if node.kind == .cast_expr && actual is types.Pointer
+		&& cgen_unalias_type(types.unwrap_all_pointers(actual)) is types.Interface
+		&& semantic_expected !is types.Interface && semantic_expected !is types.Pointer {
+		// A generic method body may have been transformed while its receiver was
+		// still a placeholder, boxing an explicit argument against the receiver
+		// slot. Once specialized, recover the concrete value stored in that box.
+		value_ct := g.value_c_type(semantic_expected)
+		g.write('(*(${value_ct}*)(')
+		g.gen_expr(id)
+		g.write(')->_object)')
+		g.expected_expr_type = old_expected
+		g.expected_enum = old_expected_enum
+		return
+	}
 	if semantic_expected is types.String && g.gen_map_str_expr(id, semantic_actual) {
 		g.expected_expr_type = old_expected
 		g.expected_enum = old_expected_enum
@@ -6203,10 +6291,22 @@ fn (mut g FlatGen) gen_expr_with_expected_type(id flat.NodeId, expected types.Ty
 			}
 		}
 	}
+	// Box concrete pointers for interface parameters before the general pointer-to-value
+	// conversion below. An alias-backed concrete type can otherwise look name-compatible
+	// with the interface and be dereferenced into an incompatible C value.
+	if semantic_expected is types.Interface {
+		if g.gen_embedded_interface_receiver(id, actual, expected, false)
+			|| g.gen_interface_value_expr(id, expected) {
+			g.expected_expr_type = old_expected
+			g.expected_enum = old_expected_enum
+			return
+		}
+	}
 	if !expected_is_shared_alias && expected !is types.Pointer && expected !is types.Void
 		&& expected !is types.OptionType && expected !is types.ResultType && actual is types.Pointer
 		&& g.type_names_match(actual.base_type, expected) && !(node.kind == .ident
-		&& g.local_storage_is_shared(node.value)) {
+		&& g.local_storage_is_shared(node.value)) && !(node.kind == .char_literal
+		&& node.value.starts_with('c:')) {
 		needs_paren := node.kind !in [.ident, .selector, .call, .index]
 		g.write('*')
 		if needs_paren {
@@ -6446,7 +6546,7 @@ fn (mut g FlatGen) gen_sum_pointer_value_expr(id flat.NodeId, expected types.Typ
 	if sum_type0 !is types.SumType {
 		return false
 	}
-	sum_type_name := sum_type0.name()
+	sum_type_name := types.Type(sum_type0).name()
 	node := g.a.nodes[int(id)]
 	if node.kind != .prefix || node.op != .amp || node.children_count == 0 {
 		return false
@@ -6530,7 +6630,12 @@ fn (mut g FlatGen) gen_sum_value_expr(id flat.NodeId, expected types.Type) bool 
 	raw_actual0 := g.sum_cast_actual_type(id)
 	raw_actual_type := cgen_unalias_type(raw_actual0)
 	if raw_actual_type is types.SumType {
-		return false
+		// A sum type can itself be a variant of a wider sum type (for example
+		// `ast.Stmt` inside `ast.Node`). Only skip wrapping when the value is
+		// already the expected sum.
+		if g.type_names_match(raw_actual_type, sum_type0) {
+			return false
+		}
 	}
 	if declared := g.selector_declared_type(id) {
 		declared0 := cgen_unalias_type(declared)
@@ -6694,6 +6799,11 @@ fn (mut g FlatGen) sum_cast_actual_type(id flat.NodeId) types.Type {
 			if scope_type := g.tc.cur_scope.lookup(node.value) {
 				if scope_type !is types.Void && scope_type !is types.Unknown {
 					return scope_type
+				}
+			}
+			if const_type := g.const_ident_type(node.value) {
+				if const_type !is types.Void && const_type !is types.Unknown {
+					return const_type
 				}
 			}
 		}
@@ -6884,12 +6994,41 @@ fn (g &FlatGen) selector_declared_type(id flat.NodeId) ?types.Type {
 		return none
 	}
 	base_id := g.a.child(&node, 0)
-	base_type0 := types.unwrap_pointer(g.tc.resolve_type(base_id))
+	mut resolved_base_type := g.selector_base_expr_type(base_id)
+	base_node := g.a.nodes[int(base_id)]
+	if base_node.typ.len > 0 {
+		annotated_base_type := g.tc.parse_type(base_node.typ)
+		if annotated_base_type !is types.Unknown && annotated_base_type !is types.Void
+			&& !g.type_contains_generic_placeholder(annotated_base_type)
+			&& (resolved_base_type is types.Unknown
+			|| resolved_base_type is types.Void
+			|| g.type_contains_generic_placeholder(resolved_base_type)) {
+			resolved_base_type = annotated_base_type
+		}
+	}
+	base_type0 := types.unwrap_pointer(resolved_base_type)
 	base_type := if base_type0 is types.Alias { base_type0.base_type } else { base_type0 }
 	if base_type is types.Struct {
 		return g.struct_field_type(base_type.name, node.value)
 	}
 	return none
+}
+
+fn (g &FlatGen) selector_base_expr_type(id flat.NodeId) types.Type {
+	if int(id) >= 0 && int(id) < g.a.nodes.len {
+		node := g.a.nodes[int(id)]
+		if node.kind == .or_expr && node.children_count > 0 {
+			source_id := g.a.child(&node, 0)
+			source_type := g.or_expr_source_type(source_id, g.a.nodes[int(source_id)])
+			if source_type is types.OptionType {
+				return source_type.base_type
+			}
+			if source_type is types.ResultType {
+				return source_type.base_type
+			}
+		}
+	}
+	return g.usable_expr_type(id)
 }
 
 fn (g &FlatGen) sum_type_name_for_type(base_type0 types.Type) ?string {
@@ -6949,7 +7088,7 @@ fn (g &FlatGen) sum_shared_field_type_inner(base_type0 types.Type, field string,
 }
 
 fn (g &FlatGen) sum_variant_shared_field_type(variant string, field string, seen []string) ?types.Type {
-	if variant_field_type := g.struct_field_type(variant, field) {
+	if variant_field_type := g.usable_struct_field_type(variant, field) {
 		return variant_field_type
 	}
 	if variant_field_type := g.struct_promoted_field_type(variant, field) {
@@ -6970,7 +7109,7 @@ fn (g &FlatGen) struct_promoted_field_type(type_name string, field string) ?type
 	if owner.len == 0 {
 		return none
 	}
-	return g.struct_field_type(owner, field)
+	return g.usable_struct_field_type(owner, field)
 }
 
 fn (g &FlatGen) struct_promoted_field_suffix(type_name string, field string, initial_ptr bool) ?string {
@@ -7074,7 +7213,7 @@ fn (mut g FlatGen) gen_pointer_pointer_struct_selector(base_id flat.NodeId, base
 fn (mut g FlatGen) gen_sum_shared_field_selector(base_id flat.NodeId, base_type0 types.Type, field string) bool {
 	sum_name := g.sum_type_name_for_type(base_type0) or { return false }
 	common_type := g.sum_shared_field_type(base_type0, field) or { return false }
-	ct := g.tc.c_type(common_type)
+	ct := g.value_c_type(common_type)
 	sum_ct := g.tc.c_type(g.tc.parse_type(sum_name))
 	g.write('({ ${sum_ct} __sum = ')
 	if base_type0 is types.Pointer {
@@ -7294,6 +7433,18 @@ fn (mut g FlatGen) sizeof_target(value string) string {
 	if parsed is types.Enum {
 		return g.value_sizeof_target(parsed)
 	}
+	// An exact registered type name remains a type even when its module qualifier is
+	// shadowed by a local (for example `sizeof(hash.Hash)` inside `mut hash := h()`).
+	// Only unresolved dotted spellings should fall through to selector lookup below.
+	if (value in g.tc.structs || value in g.tc.interface_names || value in g.tc.sum_types
+		|| value in g.tc.type_aliases) && (parsed is types.Struct
+		|| parsed is types.Interface || parsed is types.SumType
+		|| parsed is types.Alias) {
+		return g.value_sizeof_target(parsed)
+	}
+	// A dotted `sizeof` target can be either a qualified type (`time.Time`) or a
+	// selector expression (`bf.p`). Resolve visible values before interpreting the
+	// spelling as a type; parse_type accepts both shapes and cannot disambiguate them.
 	if value.contains('.') {
 		parts := value.split('.')
 		if parts.len > 1 {
@@ -7304,6 +7455,12 @@ fn (mut g FlatGen) sizeof_target(value string) string {
 				return sizeof_selector_target(global, parts[1..])
 			}
 		}
+	}
+	if (value.contains('.') || value in g.tc.structs || value in g.tc.interface_names
+		|| value in g.tc.sum_types || value in g.tc.type_aliases) && (parsed is types.Struct
+		|| parsed is types.Interface || parsed is types.SumType
+		|| parsed is types.Alias) {
+		return g.value_sizeof_target(parsed)
 	}
 	if fixed := array_fixed_type(g.tc.parse_type(value)) {
 		c_elem, dims := g.fixed_array_decl_parts(fixed)
@@ -7450,7 +7607,7 @@ fn (g &FlatGen) is_const_alias_name(name string) bool {
 
 // const_ref_name supports const ref name handling for FlatGen.
 fn (g &FlatGen) const_ref_name(name string) string {
-	if !name.contains('.') && !name.contains('__') {
+	if !name.contains('.') {
 		cur_qname := g.const_storage_name(g.tc.cur_module, name)
 		if cur_qname in g.const_vals {
 			return cur_qname
@@ -7462,10 +7619,12 @@ fn (g &FlatGen) const_ref_name(name string) string {
 				return g.const_primary_name(name)
 			}
 		}
-		if unique := g.unique_const_ref_name(name) {
-			return unique
+		if !name.contains('__') {
+			if unique := g.unique_const_ref_name(name) {
+				return unique
+			}
+			return ''
 		}
-		return ''
 	}
 	if name in g.const_vals {
 		return g.const_primary_name(name)
@@ -7930,6 +8089,10 @@ fn (mut g FlatGen) mark_const_ref_descendants(mut ids map[int]bool, id flat.Node
 }
 
 fn (mut g FlatGen) const_storage_type_from_node(node flat.Node) ?types.Type {
+	if node.kind == .ident
+		&& (g.current_param_type(node.value) != none || g.cur_scope_has_local_name(node.value)) {
+		return none
+	}
 	const_name := g.const_ref_name_from_node(node)
 	if const_name.len > 0 {
 		return g.const_storage_type_from_name(const_name)
@@ -8038,7 +8201,8 @@ fn (mut g FlatGen) const_array_literal_storage_type_for_name(name string, val_id
 	} else {
 		elem_type = g.tc.resolve_type(g.a.child(&node, 0))
 	}
-	if elem_type is types.Array || elem_type is types.Map || elem_type is types.Void
+	if elem_type is types.Array || elem_type is types.Map || elem_type is types.Struct
+		|| elem_type is types.Interface || elem_type is types.SumType || elem_type is types.Void
 		|| elem_type is types.Unknown {
 		return none
 	}
@@ -8483,7 +8647,10 @@ fn (mut g FlatGen) fixed_array_elem_c_type(elem types.Type) string {
 
 fn (mut g FlatGen) fixed_array_c_type(arr types.ArrayFixed) string {
 	len_text := g.fixed_array_len_value(arr)
-	len_name := naming.type_name_part(len_text)
+	// Const-expression rendering can inherit the current writer indentation.
+	// Whitespace is immaterial to the C dimension and must not change the typedef name.
+	len_name :=
+		naming.type_name_part(len_text.replace(' ', '').replace('\t', '').replace('\n', '').replace('\r', ''))
 	elem_name := g.fixed_array_elem_name_part(arr.elem_type)
 	return 'Array_fixed_${naming.type_name_part(elem_name)}_${len_name}'
 }
@@ -8569,6 +8736,23 @@ fn (mut g FlatGen) gen_assoc_infix_chain(node flat.Node) {
 			g.gen_expr(oid)
 		}
 	}
+}
+
+fn (g &FlatGen) infix_channel_type(id flat.NodeId, fallback types.Type) types.Type {
+	clean_fallback := concrete_receiver_type(fallback)
+	if clean_fallback is types.Channel {
+		return clean_fallback
+	}
+	if int(id) >= 0 && int(id) < g.a.nodes.len {
+		node := g.a.nodes[int(id)]
+		if node.typ.len > 0 {
+			annotated := concrete_receiver_type(g.tc.parse_type(node.typ))
+			if annotated is types.Channel {
+				return annotated
+			}
+		}
+	}
+	return fallback
 }
 
 // gen_expr emits expr output for c.
@@ -8754,13 +8938,11 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 			// unwrap `.ret_arr` so the result behaves as the array value everywhere
 			// (indexing, arg passing, memcpy into a destination).
 			ret_t := g.declared_call_return_type(id)
-			if ret_fixed := array_fixed_type(ret_t) {
-				if g.tc.c_type(ret_fixed) in g.fixed_array_ret_wrappers {
-					g.write('(')
-					g.gen_call(id, node)
-					g.write(').ret_arr')
-					return
-				}
+			if _ := array_fixed_type(ret_t) {
+				g.write('(')
+				g.gen_call(id, node)
+				g.write(').ret_arr')
+				return
 			}
 			g.gen_call(id, node)
 		}
@@ -8805,7 +8987,7 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 				return
 			}
 			if node.op == .arrow {
-				channel_type := concrete_receiver_type(lhs_type)
+				channel_type := g.infix_channel_type(lhs_id, lhs_type)
 				if channel_type is types.Channel {
 					rhs_node := g.a.nodes[int(rhs_id)]
 					if rhs_node.kind == .or_expr && rhs_node.children_count >= 2 {
@@ -9079,7 +9261,9 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 						}
 						elem_id := g.a.child(&rhs, i)
 						elem_type := g.usable_expr_type(elem_id)
-						if lhs_type is types.String || elem_type is types.String {
+						if (lhs_type is types.String || elem_type is types.String)
+							&& !g.expr_is_non_string_scalar_value(lhs_id)
+							&& !g.expr_is_non_string_scalar_value(elem_id) {
 							g.write('string__eq(')
 							g.gen_expr(lhs_id)
 							g.write(', ')
@@ -9165,6 +9349,7 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 				}
 			}
 			base_type0 := g.usable_expr_type(base_id)
+			base_type_clean := types.unwrap_pointer(base_type0)
 			if base_type0 is types.Channel && node.value in ['closed', 'len', 'cap'] {
 				if node.value == 'closed' {
 					g.write('(atomic_load_u16(&')
@@ -9186,10 +9371,36 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 			} else {
 				false
 			}
+			// An exact import in the active file takes precedence over unrelated
+			// file-scope symbols with the same short name. Keep lexical locals as
+			// the authority so a local can still shadow an import alias.
+			mut imported_selector_module := ''
+			if base.kind == .ident && base.value != 'C' {
+				mut is_lexical_local := false
+				if owner := g.tc.cur_scope.lookup_owner(base.value) {
+					is_lexical_local = !owner.belongs_to_scope(g.tc.file_scope)
+				}
+				if !is_lexical_local {
+					imported_selector_module = g.tc.file_imports['${g.tc.cur_file}\n${base.value}'] or {
+						''
+					}
+				}
+			}
 			// A method used as a value (e.g. `game.draw` passed as a callback) rather
 			// than a field access — bind the receiver and yield a wrapper function.
 			if g.gen_method_value_closure(base_id, base_type0, node.value) {
 				return
+			}
+			// The expected type belongs to the selected field, not to its base. In
+			// particular, propagating a sum payload expectation into an `Optional{}`
+			// base rewrites the wrapper literal as the sum itself before `.ok`/`.value`.
+			old_selector_expected := g.expected_expr_type
+			old_selector_enum := g.expected_enum
+			g.expected_expr_type = types.Type(types.void_)
+			g.expected_enum = ''
+			defer {
+				g.expected_expr_type = old_selector_expected
+				g.expected_enum = old_selector_enum
 			}
 			mut enum_selector_qbase := if base.kind == .ident && base.value != 'C' && !base_is_local {
 				g.enum_selector_base_name(base.value) or { '' }
@@ -9220,6 +9431,18 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 				} else {
 					g.write('0')
 				}
+			} else if imported_selector_module.len > 0 {
+				short_mod := if imported_selector_module.contains('.') {
+					imported_selector_module.all_after_last('.')
+				} else {
+					imported_selector_module
+				}
+				full_qname := g.const_storage_name(imported_selector_module, node.value)
+				if full_qname in g.const_vals {
+					g.write(g.cname(full_qname))
+				} else {
+					g.write(g.cname('${short_mod}.${node.value}'))
+				}
 			} else if g.gen_local_shared_value_selector(base_id, node.value) {
 				// handled
 			} else if g.gen_shared_field_value_selector(base_id, base_type0, node.value, node.op) {
@@ -9238,8 +9461,13 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 					g.write(')')
 				}
 				g.write('.len')
-			} else if types.unwrap_pointer(base_type0) is types.Array && node.value == 'len' {
-				needs_paren := base.kind !in [.ident, .selector, .call]
+			} else if node.value == 'len' && (base_type_clean is types.Array
+				|| base_type_clean is types.Map || (base_type_clean is types.Struct
+				&& base_type_clean.name in ['array', 'map'])) {
+				// Array accessors such as `last()` are calls in the flat tree, but
+				// emit a dereference expression in C. Parenthesize that value before
+				// selecting `.len`, otherwise the member access binds inside `array_get`.
+				needs_paren := base.kind !in [.ident, .selector]
 				if needs_paren {
 					g.write('(')
 				}
@@ -9254,6 +9482,8 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 				}
 			} else if node.value == '__v_sum_type_tag__'
 				&& g.gen_sum_type_tag_selector(base_id, base_type0, node.op) {
+				// handled
+			} else if g.gen_generated_variant_access_selector(node, base_id, base_type0) {
 				// handled
 			} else if g.gen_sum_unique_variant_field_selector(base_id, base_type0, node.value) {
 				// handled
@@ -9409,9 +9639,11 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 					g.write(')')
 				}
 				mut is_ptr := false
+				mut local_type_known := false
 				if base.kind == .ident {
 					if typ := g.tc.cur_scope.lookup(base.value) {
-						is_ptr = typ is types.Pointer
+						local_type_known = true
+						is_ptr = typ is types.Pointer || cgen_unalias_type(typ) is types.Pointer
 					}
 				} else if base.kind == .selector {
 					if declared := g.selector_declared_type(base_id) {
@@ -9424,7 +9656,7 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 					resolved := g.tc.resolve_type(base_id)
 					is_ptr = resolved is types.Pointer
 				}
-				if node.op == .arrow || is_ptr {
+				if (node.op == .arrow && !local_type_known) || is_ptr {
 					g.write('->')
 				} else {
 					g.write('.')
@@ -9438,6 +9670,9 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 			}
 			base_id := g.a.child(&node, 0)
 			mut base_type := g.usable_expr_type(base_id)
+			if storage_type := g.const_storage_type_from_node(g.a.nodes[int(base_id)]) {
+				base_type = storage_type
+			}
 			if info := g.tc.index_overload_call_info(base_type, false) {
 				g.gen_index_overload_call(node, base_id, base_type, info)
 			} else if node.value == 'range' {
@@ -9504,6 +9739,15 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 							g.array_index_type_for_expected_arg(arr_type.elem_type, node)
 						}
 						c_elem := g.value_c_type(index_type)
+						if g.direct_array_access || g.unsafe_depth > 0 {
+							g.write('(*((${c_elem}*)((')
+							g.gen_expr(base_id)
+							g.write(if is_ptr { ')->data' } else { ').data' })
+							g.write(') + (')
+							g.gen_expr(g.a.child(&node, 1))
+							g.write(')))')
+							return
+						}
 						g.write('(*(${c_elem}*)array_get(')
 						base_node := g.a.nodes[int(base_id)]
 						if is_ptr && !(base_node.kind == .ident
@@ -10452,6 +10696,15 @@ fn builtin_ast_type_idx(name string) int {
 }
 
 fn (mut g FlatGen) gen_string_infix_fallback(node flat.Node, lhs_id flat.NodeId, rhs_id flat.NodeId) bool {
+	if node.op in [.eq, .ne]
+		&& (g.expr_is_non_string_scalar_value(lhs_id) || g.expr_is_non_string_scalar_value(rhs_id)) {
+		g.write('(')
+		g.gen_expr(lhs_id)
+		g.write(if node.op == .eq { ' == ' } else { ' != ' })
+		g.gen_expr(rhs_id)
+		g.write(')')
+		return true
+	}
 	match node.op {
 		.plus {
 			g.write('string__plus(')
@@ -10558,9 +10811,9 @@ fn (mut g FlatGen) gen_array_infix_eq(node flat.Node, lhs_id flat.NodeId, rhs_id
 	} else {
 		g.write('array_eq_raw(')
 	}
-	g.gen_array_value_arg(lhs_id, lhs_type)
+	g.gen_array_value_arg(lhs_id, lhs_type, lhs_arr)
 	g.write(', ')
-	g.gen_array_value_arg(rhs_id, rhs_type)
+	g.gen_array_value_arg(rhs_id, rhs_type, rhs_arr)
 	if elem_type !is types.String {
 		g.write(', sizeof(${g.sizeof_target(g.tc.c_type(elem_type))})')
 	}
@@ -10599,11 +10852,18 @@ fn (mut g FlatGen) gen_fixed_array_infix_eq(node flat.Node, lhs_id flat.NodeId, 
 		g.write('!')
 	}
 	g.write('(memcmp(')
-	g.gen_expr_with_expected_type(lhs_id, types.Type(fixed))
+	g.gen_fixed_array_eq_arg(lhs_id, fixed)
 	g.write(', ')
-	g.gen_expr_with_expected_type(rhs_id, types.Type(fixed))
+	g.gen_fixed_array_eq_arg(rhs_id, fixed)
 	g.write(', sizeof(${g.value_sizeof_target(types.Type(fixed))})) == 0)')
 	return true
+}
+
+fn (mut g FlatGen) gen_fixed_array_eq_arg(id flat.NodeId, fixed types.ArrayFixed) {
+	if g.expr_can_be_fixed_array_literal(id) {
+		g.write('(${g.fixed_array_c_type(fixed)})')
+	}
+	g.gen_expr_with_expected_type(id, types.Type(fixed))
 }
 
 fn (g &FlatGen) expr_can_be_fixed_array_literal(id flat.NodeId) bool {
@@ -10621,11 +10881,16 @@ fn (g &FlatGen) expr_can_be_fixed_array_literal(id flat.NodeId) bool {
 	return false
 }
 
-fn (mut g FlatGen) gen_array_value_arg(id flat.NodeId, typ types.Type) {
+fn (mut g FlatGen) gen_array_value_arg(id flat.NodeId, typ types.Type, fallback types.Array) {
 	if typ is types.Pointer {
 		g.write('*')
 	}
-	g.gen_expr(id)
+	node := g.a.nodes[int(id)]
+	if node.kind == .array_literal {
+		g.gen_expr_with_expected_type(id, types.Type(fallback))
+	} else {
+		g.gen_expr(id)
+	}
 }
 
 fn (g &FlatGen) fixed_array_literal_index_type(base_id flat.NodeId, node flat.Node) ?types.ArrayFixed {
@@ -10657,6 +10922,9 @@ fn (g &FlatGen) fixed_array_literal_index_type(base_id flat.NodeId, node flat.No
 }
 
 fn char_escape_codepoint(s string) ?int {
+	if s.starts_with('\\x') && s.len > 2 {
+		return parse_hex_codepoint(s[2..])
+	}
 	if s.starts_with('\\u{') {
 		end := s.index('}') or { return none }
 		return parse_hex_codepoint(s[3..end])
@@ -10858,7 +11126,10 @@ fn (g &FlatGen) c_directives_use_system_libc() bool {
 			clean := trimmed_space(line)
 			if c_directive_name(clean) in ['include', 'import'] {
 				arg := c_directive_arg(clean)
-				if arg.starts_with('<') && arg.ends_with('>') {
+				// A quoted local header can include system headers itself. Emit the
+				// system preamble first so its declarations do not conflict with the
+				// standalone declarations from the headerless preamble.
+				if arg.len > 0 {
 					return true
 				}
 			}
@@ -10873,6 +11144,9 @@ fn (mut g FlatGen) system_libc_headers() {
 		'stdio.h', 'stdlib.h', 'string.h', 'time.h', 'wchar.h'] {
 		g.writeln('#include <${header}>')
 	}
+	g.writeln('#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__DragonFly__)')
+	g.writeln('#include <sys/event.h>')
+	g.writeln('#endif')
 	g.writeln('#ifdef _WIN32')
 	g.writeln('#include <io.h>')
 	g.writeln('#include <process.h>')
@@ -13014,6 +13288,9 @@ fn (mut g FlatGen) atomic_builtin_compat_decls() {
 	g.writeln('static inline u32 atomic_load_u32(void* ptr) { return __atomic_fetch_add((u32*)ptr, 0, 5); }')
 	g.writeln('static inline u64 atomic_load_u64(void* ptr) { return __atomic_fetch_add((u64*)ptr, 0, 5); }')
 	g.writeln('#ifdef __TINYC__')
+	// Without a declaration TCC applies the C89 implicit `int` return type to the
+	// 64-bit libcall, truncating exchanged pointers and large u64 values.
+	g.writeln('extern u64 __atomic_exchange_8(u64* ptr, u64 val, int order);')
 	g.writeln('static inline void* atomic_load_ptr(void* ptr) { return (void*)(uintptr_t)__atomic_fetch_add((uintptr_t*)ptr, (uintptr_t)0, 5); }')
 	g.writeln('static inline byte atomic_exchange_byte(void* ptr, byte val) { return __atomic_exchange_1((byte*)ptr, val, 5); }')
 	g.writeln('static inline u16 atomic_exchange_u16(void* ptr, u16 val) { return __atomic_exchange_2((u16*)ptr, val, 5); }')
@@ -13173,16 +13450,17 @@ fn (mut g FlatGen) builtin_abi_decls() {
 	g.writeln('static inline int v3_codepoint_is_wide(int cp) { return (cp >= 0x1100 && cp <= 0x115F) || (cp >= 0x2329 && cp <= 0x232A) || (cp >= 0x2E80 && cp <= 0xA4CF) || (cp >= 0xAC00 && cp <= 0xD7A3) || (cp >= 0xF900 && cp <= 0xFAFF) || (cp >= 0xFE10 && cp <= 0xFE19) || (cp >= 0xFE30 && cp <= 0xFE6F) || (cp >= 0xFF00 && cp <= 0xFF60) || (cp >= 0xFFE0 && cp <= 0xFFE6) || (cp >= 0x1F000 && cp <= 0x1FAFF); }')
 	g.writeln('static inline int v3_string_display_width(string s) { int width = 0; int join = 0; for (int i = 0; i < s.len;) { int cp = v3_utf8_next_cp(s.str, s.len, &i); if (cp == 0x200D) { join = 1; continue; } if (v3_codepoint_is_combining(cp)) continue; if (join) { join = 0; continue; } width += v3_codepoint_is_wide(cp) ? 2 : 1; } return width; }')
 	g.writeln("static inline string v3_string_pad(string s, int width, int left) { if (width < 0) { left = 1; width = -width; } int visible = v3_string_display_width(s); if (visible >= width) return s; int pad = width - visible; int out_len = s.len + pad; u8* out = malloc_noscan((ptrdiff_t)out_len + 1); if (left) { memcpy(out, s.str, (size_t)s.len); memset(out + s.len, ' ', (size_t)pad); } else { memset(out, ' ', (size_t)pad); memcpy(out + pad, s.str, (size_t)s.len); } out[out_len] = 0; return (string){.str = out, .len = out_len, .is_lit = 0}; }")
-	g.writeln("static inline string v3_string_upper_ascii(string s) { u8* out = malloc_noscan((ptrdiff_t)s.len + 1); for (int i = 0; i < s.len; ++i) { u8 c = s.str[i]; out[i] = c >= 'a' && c <= 'f' ? (u8)(c - ('a' - 'A')) : c; } out[s.len] = 0; return (string){.str = out, .len = s.len, .is_lit = 0}; }")
+	g.writeln("static inline string v3_string_upper_ascii(string s) { u8* out = malloc_noscan((ptrdiff_t)s.len + 1); for (int i = 0; i < s.len; ++i) { u8 c = s.str[i]; out[i] = c >= 'a' && c <= 'z' ? (u8)(c - ('a' - 'A')) : c; } out[s.len] = 0; return (string){.str = out, .len = s.len, .is_lit = 0}; }")
 	g.writeln('static inline string v3_char_string(int c) { return rune__str((u32)c); }')
 	g.writeln('static inline string v3_chan_str(chan ch, string elem) { if (ch == NULL) return string__plus(string__plus(v3_c_lit("chan ", 5), elem), v3_c_lit("(nil)", 5)); string out = string__plus(string__plus(v3_c_lit("chan ", 5), elem), v3_c_lit("{\\n    cap: ", 11)); out = string__plus(out, int__str(ch->cap)); out = string__plus(out, ch->closed != 0 ? v3_c_lit(", closed: true\\n}", 16) : v3_c_lit(", closed: false\\n}", 17)); return out; }')
 	g.writeln('static inline double v3_f64_fixed_value(double x, int precision) { if (precision == 0) return x < 0.0 ? ceil(x - 0.5) : floor(x + 0.5); if (precision == 6) { double scale = 1000000.0; double ax = fabs(x) * scale; double base = floor(ax); double frac = ax - base; if (frac == 0.5) { double rounded = floor(ax + 0.5) / scale; return x < 0.0 ? -rounded : rounded; } } return x; }')
 	g.writeln('static inline string v3_f64_fixed(double x, int precision) { if (precision > 16) { char base[128]; int b = snprintf(base, sizeof(base), "%.16g", x); if (b >= 0 && b < (int)sizeof(base)) { int dot = -1; int has_exp = 0; for (int i = 0; i < b; ++i) { if (base[i] == \'.\') dot = i; if (base[i] == \'e\' || base[i] == \'E\') has_exp = 1; } if (!has_exp) { int frac = dot >= 0 ? b - dot - 1 : 0; if (frac <= precision) { int n = b + (dot < 0 ? 1 : 0) + (precision - frac); u8* out = malloc_noscan(n + 1); memcpy(out, base, b); int pos = b; if (dot < 0) out[pos++] = \'.\'; while (frac++ < precision) out[pos++] = \'0\'; out[pos] = 0; return (string){.str = out, .len = n, .is_lit = 0}; } } } } double y = v3_f64_fixed_value(x, precision); char tmp[128]; int n = snprintf(tmp, sizeof(tmp), "%.*f", precision, y); if (n < 0) return v3_c_lit("", 0); if (n < (int)sizeof(tmp)) { u8* out = malloc_noscan(n + 1); memcpy(out, tmp, n + 1); return (string){.str = out, .len = n, .is_lit = 0}; } u8* out = malloc_noscan(n + 1); snprintf((char*)out, (size_t)n + 1, "%.*f", precision, y); return (string){.str = out, .len = n, .is_lit = 0}; }')
 	g.writeln('static inline string v3_f64_exp(double x, int precision, int upper) { char tmp[128]; int n = upper ? snprintf(tmp, sizeof(tmp), "%.*E", precision, x) : snprintf(tmp, sizeof(tmp), "%.*e", precision, x); if (n < 0) return v3_c_lit("", 0); if (n < (int)sizeof(tmp)) { u8* out = malloc_noscan(n + 1); memcpy(out, tmp, n + 1); return (string){.str = out, .len = n, .is_lit = 0}; } u8* out = malloc_noscan(n + 1); if (upper) snprintf((char*)out, (size_t)n + 1, "%.*E", precision, x); else snprintf((char*)out, (size_t)n + 1, "%.*e", precision, x); return (string){.str = out, .len = n, .is_lit = 0}; }')
-	g.writeln('static inline string v3_int_zpad(int n, int width) { string s = int__str(n); if (n < 0) return s; while (s.len < width) s = string__plus(v3_c_lit("0", 1), s); return s; }')
-	g.writeln('static inline string v3_i64_zpad(i64 n, int width) { string s = i64__str(n); if (n < 0) return s; while (s.len < width) s = string__plus(v3_c_lit("0", 1), s); return s; }')
-	g.writeln('static inline string v3_u64_zpad(u64 n, int width) { string s = u64__str(n); while (s.len < width) s = string__plus(v3_c_lit("0", 1), s); return s; }')
+	g.writeln('static inline string v3_f64_general(double x, int precision, int upper) { char tmp[128]; int n = upper ? snprintf(tmp, sizeof(tmp), "%.*G", precision, x) : snprintf(tmp, sizeof(tmp), "%.*g", precision, x); if (n < 0) return v3_c_lit("", 0); if (n < (int)sizeof(tmp)) { u8* out = malloc_noscan(n + 1); memcpy(out, tmp, n + 1); return (string){.str = out, .len = n, .is_lit = 0}; } u8* out = malloc_noscan(n + 1); if (upper) snprintf((char*)out, (size_t)n + 1, "%.*G", precision, x); else snprintf((char*)out, (size_t)n + 1, "%.*g", precision, x); return (string){.str = out, .len = n, .is_lit = 0}; }')
 	g.writeln("static inline string v3_string_zpad(string s, int width) { if (s.len >= width) return s; int sign = s.len > 0 && s.str[0] == '-'; int pad = width - s.len; u8* out = malloc_noscan((ptrdiff_t)width + 1); int pos = 0; if (sign) out[pos++] = '-'; memset(out + pos, '0', (size_t)pad); pos += pad; memcpy(out + pos, s.str + sign, (size_t)(s.len - sign)); out[width] = 0; return (string){.str = out, .len = width, .is_lit = 0}; }")
+	g.writeln('static inline string v3_int_zpad(int n, int width) { return v3_string_zpad(int__str(n), width); }')
+	g.writeln('static inline string v3_i64_zpad(i64 n, int width) { return v3_string_zpad(i64__str(n), width); }')
+	g.writeln('static inline string v3_u64_zpad(u64 n, int width) { return v3_string_zpad(u64__str(n), width); }')
 	g.writeln("static inline string v3_string_rpad_zero(string s, int width) { if (s.len >= width) return s; u8* out = malloc_noscan((ptrdiff_t)width + 1); memcpy(out, s.str, (size_t)s.len); memset(out + s.len, '0', (size_t)(width - s.len)); out[width] = 0; return (string){.str = out, .len = width, .is_lit = 0}; }")
 	// Length-aware JSON string escaper: honors string.len so embedded NUL bytes are
 	// escaped rather than truncating like a C NUL-terminated string. ASCII
@@ -13461,7 +13739,7 @@ fn (mut g FlatGen) populate_fixed_array_ret_wrappers() {
 
 fn (mut g FlatGen) collect_fixed_array_return_wrapper(typ types.Type) {
 	if typ is types.ArrayFixed {
-		g.fixed_array_ret_wrappers[g.tc.c_type(typ)] = true
+		g.fixed_array_ret_wrappers[g.fixed_array_c_type(typ)] = true
 	} else if typ is types.Alias {
 		g.collect_fixed_array_return_wrapper(typ.base_type)
 	}
@@ -13585,10 +13863,8 @@ fn fixed_array_elem_is_early_complete(elem types.Type) bool {
 // substituting the fixed-array wrapper struct when one exists.
 fn (mut g FlatGen) fn_return_type_name(t types.Type) string {
 	if fixed := array_fixed_type(t) {
-		bare := g.tc.c_type(fixed)
-		if bare in g.fixed_array_ret_wrappers {
-			return fixed_array_ret_wrapper_name(bare)
-		}
+		bare := g.fixed_array_c_type(fixed)
+		return fixed_array_ret_wrapper_name(bare)
 	}
 	ct := g.optional_type_name(t)
 	// A function/fn-ptr-valued return (`fn f() fn () int`) has the internal `fn_ptr:...`
@@ -14754,13 +15030,26 @@ fn (mut g FlatGen) emit_const(name string, val_id flat.NodeId) {
 		// compute temps, the last child is the value expression.
 		if ct != 'void' {
 			g.writeln('${ct} ${qname};')
-			g.queue_const_runtime_init(g.const_block_init_to_string(qname, val_node))
+			g.queue_const_runtime_init(g.const_block_init_to_string(qname, val_node, v_type))
 		}
 		g.tc.cur_module = old_module
 		return
 	}
-	expr_str := if v_type is types.Array && val_node.kind == .array_literal {
-		g.expr_to_string_with_expected_type(val_id, v_type)
+	expr_str := if v_type !is types.ArrayFixed && ct == 'Array' {
+		arr := array_like_type(default_init_unalias_type(v_type)) or {
+			types.Array{
+				elem_type: types.Type(types.void_)
+			}
+		}
+		elem_type := if (arr.elem_type is types.Void || arr.elem_type is types.Unknown)
+			&& val_node.children_count > 0 {
+			g.usable_expr_type(g.a.child(&val_node, 0))
+		} else {
+			arr.elem_type
+		}
+		g.expr_to_string_with_expected_type(val_id, types.Type(types.Array{
+			elem_type: elem_type
+		}))
 	} else if g.is_const_expr(val_id) {
 		g.const_expr_to_string(val_id, []string{})
 	} else {
@@ -14771,7 +15060,7 @@ fn (mut g FlatGen) emit_const(name string, val_id flat.NodeId) {
 		return
 	}
 	mut is_static_const := g.is_const_expr(val_id) && !g.const_expr_needs_runtime_storage(expr_str)
-	if v_type is types.Array {
+	if v_type is types.Array || ct == 'Array' {
 		is_static_const = false
 	}
 	if v_type is types.ArrayFixed && v_type.elem_type is types.ArrayFixed {
@@ -14805,10 +15094,10 @@ fn (mut g FlatGen) emit_const(name string, val_id flat.NodeId) {
 		|| ct in ['bool', 'char', 'i8', 'i16', 'i32', 'int', 'i64', 'u8', 'u16', 'u32', 'u64', 'f32', 'f64', 'float', 'double', 'isize', 'usize'] {
 		if qname == 'max_len' && ct == 'int' {
 			g.writeln('enum { ${qname} = ${expr_str} };')
-		} else if g.name_collides_with_struct_field(qname) {
+		} else if ct == 'u8' || g.name_collides_with_struct_field(qname) {
 			// A `#define` whose name matches a struct field would wrongly expand every
-			// `.field` access; emit a real `const` variable instead (C keeps member and
-			// ordinary-identifier namespaces separate, so there is no collision).
+			// `.field` access. Byte constants are also passed by reference by generic
+			// binary I/O helpers, so they need addressable storage rather than a macro.
 			g.writeln('static const ${ct} ${qname} = ${expr_str};')
 		} else {
 			g.writeln('#define ${qname} (${expr_str})')
@@ -14836,7 +15125,7 @@ fn (mut g FlatGen) name_collides_with_struct_field(name string) bool {
 
 fn (g &FlatGen) const_expr_needs_runtime_storage(expr string) bool {
 	return expr.contains('array_new(') || expr.contains('new_map(') || expr.contains('({')
-		|| expr.contains('__map_')
+		|| expr.contains('__map_') || expr.contains('_str_')
 }
 
 fn (mut g FlatGen) queue_map_literal_sets(target string, val_id flat.NodeId, map_type types.Map) {

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -57,6 +57,7 @@ struct FlatFnGenItem {
 	c_name                    string
 	cost                      int
 	is_program_specialization bool
+	direct_array_access       bool
 }
 
 struct FlatFnGenCandidate {
@@ -79,6 +80,7 @@ fn (mut g FlatGen) ensure_fn_gen_items() []FlatFnGenItem {
 // collect_fn_gen_items updates collect fn gen items state for c.
 fn (mut g FlatGen) collect_fn_gen_items() []FlatFnGenItem {
 	mut candidates := []FlatFnGenCandidate{}
+	direct_array_access_positions := g.direct_array_access_fn_positions()
 	mut preferred_fns := map[string]int{}
 	mut ranks := map[string]int{}
 	mut program_specializations := map[string]bool{}
@@ -106,21 +108,16 @@ fn (mut g FlatGen) collect_fn_gen_items() []FlatFnGenItem {
 		}
 
 		if kind_id == 61 {
-			is_specialization := g.a.specialized_fn_nodes[i]
-			fn_module := cur_module
-			fn_file := if is_specialization {
-				g.tc.fn_type_files[node.value] or { cur_file }
-			} else {
-				cur_file
-			}
-			if !g.should_emit_fn_node_in_module(node, i, fn_module, fn_file) {
+			item_module := g.a.specialized_fn_modules[i] or { cur_module }
+			item_file := g.a.specialized_fn_files[i] or { cur_file }
+			if !g.should_emit_fn_node_in_module(node, i, item_module, item_file) {
 				continue
 			}
-			preferred_name := g.fn_c_name_in_module(fn_module, node.value)
-			if g.is_program_specialization_fn_node(node, i, fn_module) {
+			preferred_name := g.fn_c_name_in_module(item_module, node.value)
+			if g.is_program_specialization_fn_node(node, i, item_module) {
 				program_specializations[preferred_name] = true
 			}
-			rank := c_backend_fn_file_rank(fn_file)
+			rank := c_backend_fn_file_rank(item_file)
 			is_program_specialization := program_specializations[preferred_name]
 			if preferred_name !in preferred_fns || rank > ranks[preferred_name]
 				|| (rank == ranks[preferred_name] && is_program_specialization
@@ -132,10 +129,11 @@ fn (mut g FlatGen) collect_fn_gen_items() []FlatFnGenItem {
 			candidates << FlatFnGenCandidate{
 				preferred_name: preferred_name
 				item:           FlatFnGenItem{
-					node_id: flat.NodeId(i)
-					file:    fn_file
-					module:  fn_module
-					c_name:  g.fn_c_name_in_module(fn_module, node.value)
+					node_id:             flat.NodeId(i)
+					file:                item_file
+					module:              item_module
+					c_name:              g.fn_c_name_in_module(item_module, node.value)
+					direct_array_access: direct_array_access_positions[fn_source_position_key(node)]
 				}
 			}
 		}
@@ -172,9 +170,42 @@ fn (mut g FlatGen) collect_fn_gen_items() []FlatFnGenItem {
 			c_name:                    item.c_name
 			cost:                      cost
 			is_program_specialization: program_specializations[candidate.preferred_name]
+			direct_array_access:       item.direct_array_access
 		}
 	}
 	return items
+}
+
+fn fn_source_position_key(node flat.Node) string {
+	return '${node.pos.id}:${node.pos.offset}'
+}
+
+fn (g &FlatGen) direct_array_access_fn_positions() map[string]bool {
+	mut positions := map[string]bool{}
+	for directive in g.a.nodes {
+		if directive.kind != .directive || !directive.value.starts_with('@attributes:') {
+			continue
+		}
+		mut has_direct_array_access := false
+		for raw_attr in directive.generic_params() {
+			if raw_attr.all_before(':').trim_space() == 'direct_array_access' {
+				has_direct_array_access = true
+				break
+			}
+		}
+		if !has_direct_array_access {
+			continue
+		}
+		target_idx := directive.value['@attributes:'.len..].int()
+		if target_idx < 0 || target_idx >= g.a.nodes.len {
+			continue
+		}
+		target := g.a.nodes[target_idx]
+		if target.kind == .fn_decl {
+			positions[fn_source_position_key(target)] = true
+		}
+	}
+	return positions
 }
 
 fn flat_fn_gen_item_cost(a &flat.FlatAst, node_id flat.NodeId) int {
@@ -226,7 +257,10 @@ fn (mut g FlatGen) gen_fn_items(items []FlatFnGenItem) {
 			}
 			g.writeln('/* V3CACHE_MODULE ${module_name} */')
 		}
+		old_direct_array_access := g.direct_array_access
+		g.direct_array_access = item.direct_array_access
 		g.gen_fn_in_module(node, item.module)
+		g.direct_array_access = old_direct_array_access
 	}
 }
 
@@ -401,10 +435,44 @@ fn (mut g FlatGen) should_emit_fn_node_in_module(node flat.Node, node_index int,
 	if g.is_program_specialization_fn_node(node, node_index, module_name) {
 		return true
 	}
-	if g.has_used_fn_filter() && !g.used_fn_contains_in_module(node.value, module_name) {
+	if g.fn_node_is_open_generic_template(node, module_name) {
+		return false
+	}
+	is_interface_dispatch_target := g.interface_dispatch_method_is_required(node.value)
+		|| g.interface_dispatch_method_is_required(dotted_fn_name_in_module(module_name, node.value))
+		|| g.interface_dispatch_method_is_required(qfn)
+	if g.has_used_fn_filter() && !g.used_fn_contains_in_module(node.value, module_name)
+		&& !is_interface_dispatch_target {
 		return false
 	}
 	return true
+}
+
+fn (g &FlatGen) fn_node_is_open_generic_template(node flat.Node, module_name string) bool {
+	if node.generic_params().len > 0 {
+		return true
+	}
+	if !node.value.contains('.') {
+		return false
+	}
+	receiver := node.value.all_before_last('.')
+	base, args, ok := shared_generic_app_parts(receiver)
+	if !ok || args.len == 0 {
+		return false
+	}
+	mut candidates := [base]
+	if !base.contains('.') && module_name.len > 0 && module_name !in ['main', 'builtin'] {
+		candidates << '${module_name}.${base}'
+	}
+	for candidate in candidates {
+		params := g.tc.struct_generic_params[candidate] or { continue }
+		for arg in args {
+			if arg.trim_space() in params {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 fn (g &FlatGen) is_program_specialization_fn_node(node flat.Node, node_index int, module_name string) bool {
@@ -704,6 +772,15 @@ fn (g &FlatGen) operator_overload_collision_c_name(module_name string, name stri
 }
 
 fn (mut g FlatGen) direct_call_name_for_call(id flat.NodeId, name string) string {
+	if !name.contains('.') && g.tc.cur_module.len > 0 && g.tc.cur_module !in ['main', 'builtin'] {
+		qname := '${g.tc.cur_module}.${name}'
+		qcname := g.qualified_fn_name_in_module_c(g.tc.cur_module, name)
+		if qname in g.tc.specialized_generic_fns || qcname in g.tc.specialized_generic_fns
+			|| qname in g.tc.fn_generic_params
+			|| g.non_generic_fn_decl_exists_in_module(name, g.tc.cur_module) {
+			return qcname
+		}
+	}
 	if g.test_files.len > 0 && (name == 'main' || name == 'main.main') {
 		if resolved := g.tc.resolved_call_name(id) {
 			if resolved == 'main' || resolved == 'main.main' {
@@ -728,7 +805,35 @@ fn (mut g FlatGen) direct_call_name_for_call(id flat.NodeId, name string) string
 }
 
 fn (mut g FlatGen) direct_call_name_for_call_node(id flat.NodeId, node flat.Node, name string) string {
+	// A bracketed callee is the exact specialization selected by monomorphization.
+	// Its runtime arguments may expose only the alias target (`string` for a
+	// `MyString` alias), so re-inferring here would silently select another body.
+	if name.contains('[') && name.contains(']') && (name in g.tc.fn_ret_types
+		|| name in g.tc.fn_param_types
+		|| g.cname(name) in g.tc.specialized_generic_fns) {
+		// Keep the exact type arguments, while still allowing the ordinary direct-call
+		// path to select the current module's concrete receiver specialization.
+		return g.direct_call_name_for_call(id, name)
+	}
 	if specialized := g.exact_specialized_generic_call_name(name) {
+		// A comptime-expanded call node can retain the first clone's specialization.
+		// Prefer the specialization inferred from this clone's concrete arguments.
+		if specialized.contains('_T_') {
+			call_ret := g.call_default_return_type(id)
+			if declared_ret := g.tc.fn_ret_types[specialized] {
+				// Transformed explicit generic calls already carry the correct concrete
+				// callee. Preserve it when its signature agrees with the call node; literal
+				// arguments alone are insufficient to recover `new_tls[i8](-3)`.
+				if declared_ret.name().len > 0
+					&& cgen_types_equal_after_alias_erasure(declared_ret, call_ret) {
+					return g.direct_call_name(specialized)
+				}
+			}
+			base := specialized.all_before('_T_')
+			if inferred := g.inferred_generic_plain_fn_name_for_call(id, node, base) {
+				return g.direct_call_name(inferred)
+			}
+		}
 		return g.direct_call_name(specialized)
 	}
 	if specialized := g.specialized_generic_method_name_for_call_args(node, name,
@@ -972,7 +1077,7 @@ fn (mut g FlatGen) gen_channel_try_call(node flat.Node, fn_node flat.Node) bool 
 		return false
 	}
 	channel_type := base_type as types.Channel
-	arg_id := g.a.child(&node, 1)
+	arg_id := g.channel_try_push_source_arg(g.a.child(&node, 1))
 	if fn_node.value == 'try_push' {
 		elem_ct := g.value_c_type(channel_type.elem_type)
 		if fixed := array_fixed_type(channel_type.elem_type) {
@@ -998,6 +1103,27 @@ fn (mut g FlatGen) gen_channel_try_call(node flat.Node, fn_node flat.Node) bool 
 	g.gen_channel_try_pop_arg(arg_id)
 	g.write(')')
 	return true
+}
+
+fn (g &FlatGen) channel_try_push_source_arg(arg_id flat.NodeId) flat.NodeId {
+	if int(arg_id) < 0 || int(arg_id) >= g.a.nodes.len {
+		return arg_id
+	}
+	cast := g.a.nodes[int(arg_id)]
+	if cast.kind != .cast_expr || cast.children_count == 0
+		|| !type_is_void_pointer(g.tc.parse_type(cast.value)) {
+		return arg_id
+	}
+	addr_id := g.a.child(&cast, 0)
+	addr := g.a.nodes[int(addr_id)]
+	if addr.kind != .prefix || addr.op != .amp || addr.children_count == 0 {
+		return arg_id
+	}
+	value_id := g.a.child(&addr, 0)
+	// The transform wrapped a non-pointer channel value as `voidptr(&value)`
+	// solely for the runtime method's opaque parameter. The channel C lowering
+	// supplies that address itself, so recover the original value here.
+	return value_id
 }
 
 fn (mut g FlatGen) gen_channel_try_receiver(base_id flat.NodeId) {
@@ -1735,6 +1861,8 @@ fn generic_receiver_type_suffix_variants(args []string) []string {
 		parts << c_name(raw)
 	}
 	mut variants := []string{}
+	codegen_push_unique(mut variants, raw_parts.join('__'))
+	codegen_push_unique(mut variants, parts.join('__'))
 	codegen_push_unique(mut variants, raw_parts.join('_'))
 	codegen_push_unique(mut variants, parts.join('_'))
 	return variants
@@ -1906,7 +2034,7 @@ fn c_string_pointer_base_arg(base types.Type) bool {
 	if clean is types.Char {
 		return true
 	}
-	return clean is types.Primitive && clean.name() == 'u8'
+	return clean is types.Primitive && types.Type(clean).name() == 'u8'
 }
 
 fn c_type_is_pointer_like(typ types.Type) bool {
@@ -1928,7 +2056,7 @@ fn (g &FlatGen) voidptr_value_arg_needs_address(arg_id flat.NodeId, arg_node fla
 	if !type_is_void_pointer(expected) || c_type_is_pointer_like(actual)
 		|| g.arg_is_null_pointer_literal(arg_id, arg_node)
 		|| g.fn_value_arg_passes_direct_to_voidptr(arg_id, arg_node, actual, expected)
-		|| !g.expr_is_addressable(arg_id) {
+		|| g.voidptr_method_value_arg(arg_id, expected) || !g.expr_is_addressable(arg_id) {
 		return false
 	}
 	if is_c_call && cgen_unalias_type(actual) !is types.Struct {
@@ -2050,7 +2178,7 @@ fn pointer_builtin_receiver_name_for_c(typ types.Type) string {
 		if base is types.Void {
 			return 'voidptr'
 		}
-		if base is types.Primitive && base.name() == 'u8' {
+		if base is types.Primitive && types.Type(base).name() == 'u8' {
 			return 'byteptr'
 		}
 	}
@@ -2060,7 +2188,7 @@ fn pointer_builtin_receiver_name_for_c(typ types.Type) string {
 	if typ is types.Void {
 		return 'voidptr'
 	}
-	if typ is types.Primitive && typ.name() == 'u8' {
+	if typ is types.Primitive && types.Type(typ).name() == 'u8' {
 		return 'byteptr'
 	}
 	return ''
@@ -2080,6 +2208,9 @@ fn (mut g FlatGen) gen_special_c_callback_arg(fn_name string, arg_idx int, arg_i
 	// typed `voidptr` slots) still need it, because C uses the header prototype.
 	// `fn_type_from` is alias-aware, so a `type Cb = fn ()` parameter is recognised too.
 	if _ := fn_type_from(expected_param) {
+		return false
+	}
+	if expected_param !is types.Pointer {
 		return false
 	}
 	if _ := g.sum_type_for_expected_value(expected_param) {
@@ -2306,7 +2437,7 @@ fn (mut g FlatGen) gen_sum_storage_lvalue_arg(arg_id flat.NodeId) bool {
 // values should be reworked (e.g. capture into an explicit struct + free fn) until
 // closure support lands.
 fn (mut g FlatGen) gen_method_value_closure(base_id flat.NodeId, base_type types.Type, method string) bool {
-	clean := types.unwrap_pointer(base_type)
+	clean := types.unwrap_all_pointers(base_type)
 	mut receiver_name := ''
 	mut is_interface_receiver := false
 	if clean is types.Struct {
@@ -2323,7 +2454,8 @@ fn (mut g FlatGen) gen_method_value_closure(base_id flat.NodeId, base_type types
 		&& (clean is types.Primitive || clean is types.Char || clean is types.Rune) {
 		receiver_name = clean.name()
 	} else {
-		return false
+		alias_method := g.find_alias_method(clean.name(), method) or { return false }
+		receiver_name = alias_method.all_before_last('.')
 	}
 	// A real field shadows any same-named method: that's a field access, not a value.
 	if _ := g.field_type(base_type, method) {
@@ -2385,7 +2517,6 @@ fn (mut g FlatGen) gen_method_value_closure(base_id flat.NodeId, base_type types
 	if params.len == 0 {
 		return false
 	}
-	recv_is_ptr := params[0] is types.Pointer
 	recv_ct := g.tc.c_type(params[0])
 	// Use the method's ABI return type (matching `cname`'s signature and the callback
 	// fn-pointer typedef): an option/result is `Optional_T`, a fixed array its
@@ -2404,12 +2535,20 @@ fn (mut g FlatGen) gen_method_value_closure(base_id flat.NodeId, base_type types
 		call_args << 'a${i}'
 	}
 	wparam_str := if wparams.len == 0 { 'void' } else { wparams.join(', ') }
+	if !is_interface_receiver {
+		mut method_param_types := []string{cap: params.len}
+		for param in params {
+			method_param_types << g.tc.c_type(param)
+		}
+		g.add_spawn_wrapper_def('${ret_ct} ${cname}(${method_param_types.join(', ')});')
+	}
 	g.add_spawn_wrapper_def('static ${recv_ct} ${ctx_name};')
 	ret_prefix := if ret_ct == 'void' { '' } else { 'return ' }
 	g.add_spawn_wrapper_def('static ${ret_ct} ${wrap_name}(${wparam_str}) { ${ret_prefix}${cname}(${call_args.join(', ')}); }')
-	base_is_ptr := base_type is types.Pointer
+	base_pointer_depth := cgen_type_pointer_depth(base_type)
+	receiver_pointer_depth := cgen_type_pointer_depth(params[0])
 	// Set the context global to the receiver, then yield the wrapper as the value.
-	if recv_is_ptr && !base_is_ptr && !g.expr_is_addressable(base_id) {
+	if receiver_pointer_depth > base_pointer_depth && !g.expr_is_addressable(base_id) {
 		// Pointer receiver bound to an rvalue base (`Foo{..}.tick`, `make_foo().tick`): taking
 		// `&(rvalue)` captures a temporary that dies with the enclosing statement expression,
 		// before the callback runs. Copy the receiver into a durable static slot and point at it.
@@ -2420,14 +2559,22 @@ fn (mut g FlatGen) gen_method_value_closure(base_id flat.NodeId, base_type types
 		g.write('; ${ctx_name} = &${ctx_name}_recv')
 	} else {
 		g.write('({ ${ctx_name} = ')
-		if recv_is_ptr && !base_is_ptr {
-			g.write('&(')
+		if receiver_pointer_depth > base_pointer_depth {
+			for _ in base_pointer_depth .. receiver_pointer_depth {
+				g.write('&(')
+			}
 			g.gen_expr(base_id)
-			g.write(')')
-		} else if !recv_is_ptr && base_is_ptr {
-			g.write('*(')
+			for _ in base_pointer_depth .. receiver_pointer_depth {
+				g.write(')')
+			}
+		} else if base_pointer_depth > receiver_pointer_depth {
+			for _ in receiver_pointer_depth .. base_pointer_depth {
+				g.write('*(')
+			}
 			g.gen_expr(base_id)
-			g.write(')')
+			for _ in receiver_pointer_depth .. base_pointer_depth {
+				g.write(')')
+			}
 		} else {
 			g.gen_expr(base_id)
 		}
@@ -2783,13 +2930,14 @@ fn (mut g FlatGen) spawn_fn_value_captures(fn_node flat.Node) []SpawnClosureCapt
 }
 
 fn (mut g FlatGen) spawn_fn_literal_captures(cfn string) []SpawnClosureCapture {
-	if !cfn.contains('__anon_fn_') {
-		return []SpawnClosureCapture{}
-	}
-	prefix := '${cfn}_'
+	_ = cfn
 	mut names := []string{}
 	for name, _ in g.global_types {
-		if g.cname(name).starts_with(prefix) {
+		// Capture slots form the closure environment available to the current
+		// thread. A spawned closure can itself hold another capturing callback,
+		// so copying only slots whose prefix matches the immediate function loses
+		// that nested callback's environment in the worker thread.
+		if g.cname(name).contains('__anon_fn_') {
 			names << name
 		}
 	}
@@ -3142,7 +3290,8 @@ fn (g &FlatGen) spawn_stack_address_value(id flat.NodeId) ?flat.NodeId {
 	}
 	child_id := g.a.child(node, 0)
 	child := g.a.node(child_id)
-	if child.kind != .ident || node.is_mut || child.is_mut {
+	if child.kind != .ident || node.is_mut || child.is_mut
+		|| g.local_storage_is_mutable(child.value) {
 		return none
 	}
 	local_type := g.local_ident_type(child.value) or { return none }
@@ -4038,7 +4187,9 @@ fn (mut g FlatGen) trim_defers(start int) {
 // gen_ierror_from_error_call converts gen ierror from error call data for c.
 fn (mut g FlatGen) gen_ierror_from_error_call(node flat.Node) {
 	fn_node := g.a.child_node(&node, 0)
-	g.write('(IError){._typ = 0, ._object = NULL, .message = ')
+	type_id := g.ierror_type_id_for_pattern('MessageError')
+	empty_sid := g.intern_string('')
+	g.write('(IError){._typ = ${type_id}, ._object = (MessageError*)memdup(&(MessageError){.msg = ')
 	if node.children_count > 1 {
 		g.gen_expr(g.a.child(&node, 1))
 	} else {
@@ -4050,7 +4201,7 @@ fn (mut g FlatGen) gen_ierror_from_error_call(node flat.Node) {
 	} else {
 		g.write('0')
 	}
-	g.write('}')
+	g.write('}, sizeof(MessageError)), ._object_is_boxed = true, .message = _str_${empty_sid}, .code = 0}')
 }
 
 // gen_optional_error_from_call converts gen optional error from call data for c.
@@ -4160,6 +4311,18 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 			return
 		}
 	}
+	if node.children_count == 3 && (target_name == 'string__eq' || fn_name == 'string__eq') {
+		lhs_id := g.a.child(&node, 1)
+		rhs_id := g.a.child(&node, 2)
+		if g.expr_is_non_string_scalar_value(lhs_id) || g.expr_is_non_string_scalar_value(rhs_id) {
+			g.write('(')
+			g.gen_expr(lhs_id)
+			g.write(' == ')
+			g.gen_expr(rhs_id)
+			g.write(')')
+			return
+		}
+	}
 	if target_name == 'array.pointers' || fn_name == 'array.pointers' {
 		if node.children_count > 1 {
 			arg_id := g.a.child(&node, 1)
@@ -4177,6 +4340,30 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 		return
 	}
 	resolved_target_name := g.tc.resolved_call_name(id) or { '' }
+	// Generic templates are transformed before their concrete type arguments are
+	// known. A builtin print call can therefore reach cgen with an unconverted `T`
+	// argument that monomorphization has since made concrete. Stringify that final
+	// value here, using the same recursive conversion used by implicit interface
+	// stringification, instead of passing a scalar directly to `println(string)`.
+	if node.children_count == 2 && fn_name in ['println', 'eprintln', 'print', 'eprint']
+		&& (resolved_target_name.len == 0 || resolved_target_name == fn_name
+		|| resolved_target_name == 'builtin.${fn_name}') {
+		arg_id := g.a.child(&node, 1)
+		arg_type := g.usable_expr_type(arg_id)
+		if g.interface_unaliased_type(arg_type) !is types.String {
+			arg_expr := g.expr_to_string(arg_id)
+			mut stringify_stack := []string{}
+			if str_expr := g.interface_implicit_str_expr(arg_type, arg_expr, false, mut
+				stringify_stack)
+			{
+				g.write(fn_name)
+				g.write('(')
+				g.write(str_expr)
+				g.write(')')
+				return
+			}
+		}
+	}
 	drop_target_name := if resolved_target_name.len > 0 {
 		resolved_target_name
 	} else {
@@ -4421,6 +4608,17 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 		return
 	}
 	callee_is_fn_value := g.fn_value_call_param_types(g.a.child(&node, 0)) != none
+	// Monomorphization's concrete callee is authoritative. A transformed clone can
+	// retain the template's resolved-call entry, whose alias-erased specialization
+	// (`Bar`) must not replace an explicit alias specialization (`BarAlias`).
+	if fn_node.kind == .ident && fn_name in g.tc.specialized_generic_fns && !callee_is_fn_value {
+		emitted_name := g.direct_call_name_for_call_node(id, node, fn_name)
+		g.write(emitted_name)
+		g.write('(')
+		g.gen_call_args(fn_name, node, 1)
+		g.write(')')
+		return
+	}
 	if resolved := g.tc.resolved_call_name(id) {
 		if arg_start := g.resolved_selector_module_arg_start(resolved, node) {
 			emitted_resolved := g.direct_call_name_for_call_node(id, node, resolved)
@@ -4433,10 +4631,20 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 		if !(fn_node.kind == .ident && g.resolved_name_is_generic_plain(resolved)
 			&& g.plain_concrete_fn_name_shadows_generic(fn_node.value) && resolved != fn_node.value)
 			&& !callee_is_fn_value && g.selector_call_can_emit_direct(resolved, node) {
-			emitted_resolved := g.direct_call_name_for_call_node(id, node, resolved)
+			// Comptime expansion can clone one generic call site for fields of different
+			// concrete types while retaining the first clone's resolved name. Re-infer a
+			// plain generic from the current clone's arguments before trusting that name.
+			resolved_for_call := if fn_node.kind == .ident {
+				g.specialized_generic_plain_fn_name_for_call(id, node, fn_node.value) or {
+					resolved
+				}
+			} else {
+				resolved
+			}
+			emitted_resolved := g.direct_call_name_for_call_node(id, node, resolved_for_call)
 			g.write(emitted_resolved)
 			g.write('(')
-			g.gen_call_args(resolved, node, 1)
+			g.gen_call_args(resolved_for_call, node, 1)
 			g.write(')')
 			return
 		}
@@ -4478,12 +4686,25 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 			return
 		}
 		'new_map' {
-			if g.is_runtime_new_map_call(node) && node.typ.starts_with('map[') {
-				map_type := g.tc.parse_type(node.typ)
-				if map_type is types.Map {
-					g.write_new_map(map_type.key_type, map_type.value_type)
-					return
+			if g.is_runtime_new_map_call(node) {
+				if node.typ.starts_with('map[') {
+					map_type := g.tc.parse_type(node.typ)
+					if map_type is types.Map {
+						g.write_new_map(map_type.key_type, map_type.value_type)
+						return
+					}
 				}
+				// Alias map types do not expose their underlying map type here. Keep the
+				// synthesized runtime call instead of resolving it as a user `new_map`.
+				g.write('new_map(')
+				for i in 1 .. node.children_count {
+					if i > 1 {
+						g.write(', ')
+					}
+					g.gen_expr(g.a.child(&node, i))
+				}
+				g.write(')')
+				return
 			}
 			mut call_args_name := fn_name
 			call_name := if user_name := g.main_runtime_shadow_call_c_name(node, fn_node) {
@@ -5053,7 +5274,17 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 						emitted_callee_name = g.cname(specialized)
 						g.write(emitted_callee_name)
 					} else {
-						emitted_callee_name = g.cname(fn_ident.value)
+						local_name := if g.tc.cur_module !in ['', 'main', 'builtin'] {
+							'${g.tc.cur_module}.${fn_ident.value}'
+						} else {
+							fn_ident.value
+						}
+						emitted_callee_name = if local_name in g.tc.fn_ret_types
+							|| local_name in g.tc.fn_param_types {
+							g.direct_call_name(local_name)
+						} else {
+							g.direct_call_name_for_call(id, fn_ident.value)
+						}
 						g.write(emitted_callee_name)
 					}
 				} else {
@@ -5294,6 +5525,13 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 					&& g.gen_fixed_array_pointer_lvalue_arg(arg_id, param_types[arg_idx]) {
 					continue
 				}
+				if g.gen_new_array_fixed_data_arg(node, arg_start, arg_idx, arg_id, [
+					emitted_callee_name,
+					actual_fn,
+				])
+				{
+					continue
+				}
 				if fixed := array_fixed_type(g.tc.resolve_type(arg_id)) {
 					g.gen_fixed_array_data_arg(arg_id, fixed)
 					continue
@@ -5325,7 +5563,8 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 					&& g.gen_callback_fn_value_for_expected_type(arg_id, param_types[arg_idx]) {
 					continue
 				}
-				if g.gen_generated_storage_pointer_arg(arg_idx, arg_id, arg_node) {
+				if is_storage_pointer_arg
+					&& g.gen_generated_storage_pointer_arg(arg_idx, arg_id, arg_node) {
 					continue
 				}
 				if !is_storage_pointer_arg && type_is_void_pointer(cb_param)
@@ -5333,8 +5572,7 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 					g.gen_expr(arg_id)
 					continue
 				}
-				if arg_node.kind == .prefix && arg_node.op == .amp && !is_storage_pointer_arg
-					&& type_is_void_pointer(cb_param)
+				if !is_storage_pointer_arg && type_is_void_pointer(cb_param)
 					&& g.gen_voidptr_fn_value_arg(arg_id, arg_node) {
 					continue
 				}
@@ -5394,7 +5632,8 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 						&& arg_node.kind == .ident && !g.local_storage_is_pointer(arg_node.value)
 						&& !arg_is_pointer_param && !arg_is_pointer_global
 						&& !c_type_is_pointer_like(arg_type)
-					if (!c_type_is_pointer_like(arg_type) || value_local_mut_receiver)
+					if !g.fn_value_arg_passes_direct_to_voidptr(arg_id, arg_node, arg_type, param_types[arg_idx])
+						&& (!c_type_is_pointer_like(arg_type) || value_local_mut_receiver)
 						&& !g.c_string_pointer_arg(arg_node, param_types[arg_idx]) {
 						needs_addr = !(arg_node.kind == .ident
 							&& (g.local_storage_is_pointer(arg_node.value) || arg_is_pointer_global))
@@ -5522,6 +5761,56 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 	}
 }
 
+fn (g &FlatGen) expr_is_non_string_scalar_value(id flat.NodeId) bool {
+	if int(id) < 0 || int(id) >= g.a.nodes.len {
+		return false
+	}
+	node := g.a.nodes[int(id)]
+	if node.kind in [.paren, .expr_stmt] && node.children_count > 0 {
+		return g.expr_is_non_string_scalar_value(g.a.child(&node, 0))
+	}
+	if node.kind in [.string_literal, .string_interp] {
+		return false
+	}
+	usable := cgen_unalias_type(g.usable_expr_type(id))
+	if usable is types.String || usable.name().all_after_last('.') == 'string' {
+		return false
+	}
+	if node.kind in [.char_literal, .int_literal, .float_literal, .bool_literal] {
+		return true
+	}
+	if node.kind == .ident {
+		if c_type := g.local_storage_c_type(node.value) {
+			return c_type in ['bool', 'char', 'i8', 'i16', 'int', 'i64', 'isize', 'u8', 'u16',
+				'u32', 'u64', 'usize', 'f32', 'f64', 'rune']
+		}
+		if raw_type := g.local_storage_raw_type(node.value) {
+			clean := cgen_unalias_type(g.tc.parse_type(raw_type))
+			if clean is types.String || clean.name() == 'string' {
+				return false
+			}
+			if clean is types.Primitive || clean is types.Char || clean is types.Rune
+				|| clean is types.ISize || clean is types.USize || clean is types.Enum {
+				return true
+			}
+		}
+	}
+	const_name := g.const_ref_name_from_node(node)
+	if const_name.len > 0 {
+		if const_id := g.const_vals[const_name] {
+			if const_id != id {
+				return g.expr_is_non_string_scalar_value(const_id)
+			}
+		}
+	}
+	clean := cgen_unalias_type(g.usable_expr_type(id))
+	if clean is types.String || clean.name() == 'string' {
+		return false
+	}
+	return clean is types.Primitive || clean is types.Char || clean is types.Rune
+		|| clean is types.ISize || clean is types.USize || clean is types.Enum
+}
+
 fn (g &FlatGen) ownership_drop_intrinsic_name(name string) bool {
 	if name in ['builtin.drop_owned', 'builtin__drop_owned']
 		|| name.starts_with('builtin.drop_owned_T_') || name.starts_with('builtin__drop_owned_T_') {
@@ -5576,6 +5865,9 @@ fn (mut g FlatGen) fixed_array_type_for_expr(id flat.NodeId) ?types.ArrayFixed {
 	}
 	node := g.a.nodes[int(id)]
 	if node.kind != .ident || node.value.len == 0 {
+		return none
+	}
+	if g.current_param_type(node.value) != none || g.cur_scope_has_local_name(node.value) {
 		return none
 	}
 	mut candidates := []string{cap: 4}
@@ -6057,6 +6349,13 @@ fn (g &FlatGen) call_target_name(id flat.NodeId) string {
 	node := g.a.nodes[int(id)]
 	match node.kind {
 		.ident {
+			// A bare call target resolves to a function in the current module before a
+			// same-spelled imported or module constant. For example, builtin.f32_max()
+			// must not be rewritten to the math.internal.f32_max constant.
+			if node.value in g.tc.fn_ret_types || node.value in g.tc.fn_param_types
+				|| g.non_generic_fn_decl_exists_in_module(node.value, g.tc.cur_module) {
+				return node.value
+			}
 			if target := g.const_fn_call_target_name(node) {
 				return target
 			}
@@ -6115,6 +6414,14 @@ fn (g &FlatGen) const_fn_call_target_name(node flat.Node) ?string {
 			return none
 		}
 		else {
+			typ := if node.kind == .selector {
+				g.tc.selector_const_type(node) or { g.tc.const_types[key] or { return none } }
+			} else {
+				g.tc.const_types[key] or { return none }
+			}
+			if _ := fn_type_from(typ) {
+				return g.const_ident_c_name(key)
+			}
 			return none
 		}
 	}
@@ -7270,7 +7577,7 @@ fn (g &FlatGen) type_embeds_veb_context(typ types.Type) bool {
 	if clean !is types.Struct {
 		return false
 	}
-	struct_name := clean.name()
+	struct_name := types.Type(clean).name()
 	if struct_name == 'veb.Context' {
 		return true
 	}
@@ -7307,11 +7614,12 @@ fn (g &FlatGen) is_missing_middleware_use_call(fn_node flat.Node) bool {
 	if clean_type !is types.Struct {
 		return false
 	}
-	method_name := '${clean_type.name()}.use'
+	clean_name := types.Type(clean_type).name()
+	method_name := '${clean_name}.use'
 	if method_name in g.tc.fn_param_types || method_name in g.tc.fn_ret_types {
 		return false
 	}
-	return g.struct_has_middleware_receiver(clean_type.name())
+	return g.struct_has_middleware_receiver(clean_name)
 }
 
 fn (g &FlatGen) struct_has_middleware_receiver(type_name string) bool {
@@ -7364,6 +7672,12 @@ fn (g &FlatGen) call_default_return_type(id flat.NodeId) types.Type {
 }
 
 fn (g &FlatGen) json_decode_result_type_for_call(node flat.Node) ?types.Type {
+	if node.typ.len > 0 {
+		ret_type := g.tc.parse_type(node.typ)
+		if ret_type is types.ResultType {
+			return ret_type
+		}
+	}
 	if node.children_count == 0 {
 		return none
 	}
@@ -8304,6 +8618,13 @@ fn (mut g FlatGen) param_types_for_uncached(name string, fallback string) []type
 		}
 	}
 	if name.contains('__') {
+		exact_decl_types := g.fn_decl_param_types[name] or { []types.Type{} }
+		if params := g.tc.fn_param_types[name] {
+			return merge_decl_pointer_param_abi(params, exact_decl_types)
+		}
+		if exact_decl_types.len > 0 {
+			return exact_decl_types
+		}
 		dotted_name := name.replace('__', '.')
 		dotted_decl_types := g.param_types_from_decl(dotted_name, dotted_name)
 		for candidate in [dotted_name, dotted_name.all_after_last('.')] {
@@ -8545,6 +8866,20 @@ fn (mut g FlatGen) gen_interface_pointer_arg(arg_id flat.NodeId, expected types.
 	if node.kind == .ident {
 		if param_type := g.current_param_type(node.value) {
 			actual = param_type
+		}
+	}
+	actual_depth := cgen_type_pointer_depth(actual)
+	expected_depth := cgen_type_pointer_depth(expected)
+	if actual_depth > expected_depth {
+		actual_root := cgen_unalias_unwrap_all_pointers(actual)
+		expected_root := cgen_unalias_unwrap_all_pointers(expected)
+		if actual_root is types.Interface && expected_root is types.Interface
+			&& g.tc.c_type(actual_root) == g.tc.c_type(expected_root) {
+			for _ in expected_depth .. actual_depth {
+				g.write('*')
+			}
+			g.gen_expr(arg_id)
+			return true
 		}
 	}
 	if actual is types.Pointer {
@@ -8966,7 +9301,10 @@ fn (mut g FlatGen) gen_optional_arg_with_abi(arg_id flat.NodeId, expected types.
 		}
 		collapsed_type := g.usable_expr_type(collapsed)
 		if g.optional_type_name_for_expr(collapsed, collapsed_type) == g.optional_type_name(expected) {
-			g.gen_expr(collapsed)
+			// Preserve the concrete destination optional while emitting a literal that
+			// originated in a generic clone (`?T` -> `?string`). Without this context,
+			// the nested struct initializer falls back to the erased `Optional` ABI.
+			g.gen_expr_with_expected_type(collapsed, expected)
 		} else {
 			g.gen_expr_with_expected_type(collapsed, expected)
 		}
@@ -8987,7 +9325,7 @@ fn (mut g FlatGen) gen_optional_arg_with_abi(arg_id flat.NodeId, expected types.
 				return true
 			}
 			if g.type_names_match(raw_arg_type, expected) || g.expr_really_returns_optional(arg_id) {
-				g.gen_expr_with_expected_type(arg_id, expected)
+				g.gen_expr(arg_id)
 				return true
 			}
 		}
@@ -9151,6 +9489,9 @@ fn (g &FlatGen) optional_error_payload_err_expr(id flat.NodeId) ?flat.NodeId {
 		}
 	}
 	if has_false_ok && int(err_id) >= 0 {
+		if nested := g.optional_error_payload_err_expr(err_id) {
+			return nested
+		}
 		return err_id
 	}
 	return none
@@ -9276,6 +9617,19 @@ fn (mut g FlatGen) specialized_generic_plain_fn_name_for_call(id flat.NodeId, no
 	}
 	if specialized := g.existing_specialized_generic_plain_fn_name(name) {
 		return specialized
+	}
+	// A transformed `_T_` callee already carries its explicit specialization.
+	// Do not replace it by re-inferring from default-typed literals (`i8(-3)`
+	// would otherwise be retargeted to the `int` specialization during cgen).
+	if name.contains('_T_') && g.resolved_name_is_generic_plain(name) {
+		return name
+	}
+	return g.inferred_generic_plain_fn_name_for_call(id, node, name)
+}
+
+fn (mut g FlatGen) inferred_generic_plain_fn_name_for_call(id flat.NodeId, node flat.Node, name string) ?string {
+	if name.len == 0 || name.contains('[') || node.children_count == 0 {
+		return none
 	}
 	// A transformed receiver call is an already-resolved qualified concrete
 	// function. Do not reinterpret its short method name as an unrelated plain
@@ -9699,10 +10053,25 @@ fn (g &FlatGen) generic_call_arg_type_text(id flat.NodeId) string {
 	}
 	node := g.a.nodes[int(id)]
 	if node.kind == .ident {
+		if raw_type := g.local_storage_raw_type(node.value) {
+			if codegen_type_text_is_usable_for_generic_inference(raw_type) {
+				return raw_type
+			}
+		}
 		typ := g.usable_expr_type(id)
 		name := typ.name()
 		if codegen_type_text_is_usable_for_generic_inference(name) {
 			return name
+		}
+	}
+	if node.kind == .prefix && node.op == .amp && node.children_count > 0 {
+		child := g.a.child_node(&node, 0)
+		if child.kind == .ident {
+			if raw_type := g.local_storage_raw_type(child.value) {
+				if codegen_type_text_is_usable_for_generic_inference(raw_type) {
+					return '&${raw_type}'
+				}
+			}
 		}
 	}
 	if node.kind == .call {
@@ -9905,9 +10274,12 @@ fn codegen_generic_type_suffix_variants(args []string) []string {
 		short_parts << c_name(short_raw)
 		full_parts << c_name(clean.replace('[]', 'Array_').replace('&', 'ptr_'))
 	}
+	codegen_push_unique(mut suffixes, full_parts.join('__'))
+	codegen_push_unique(mut suffixes, short_raw_parts.join('__'))
+	codegen_push_unique(mut suffixes, short_parts.join('__'))
+	codegen_push_unique(mut suffixes, full_parts.join('_'))
 	codegen_push_unique(mut suffixes, short_raw_parts.join('_'))
 	codegen_push_unique(mut suffixes, short_parts.join('_'))
-	codegen_push_unique(mut suffixes, full_parts.join('_'))
 	return suffixes
 }
 
@@ -10242,6 +10614,24 @@ fn (g &FlatGen) selector_module_call_name(id flat.NodeId, fn_node flat.Node, nod
 	if base.kind != .ident {
 		return none
 	}
+	if source_file := g.a.source_files[fn_node.pos.id] {
+		if lexical_module := g.tc.file_imports[source_file.name + '\n' + base.value] {
+			call_name := '${lexical_module}.${fn_node.value}'
+			arg_start := g.selector_module_call_arg_start(fn_node, node)
+			params := g.tc.fn_param_types[call_name] or {
+				if call_name in g.tc.fn_ret_types && node.children_count == arg_start {
+					return call_name
+				}
+				return none
+			}
+			if g.module_call_arg_count_matches(call_name, params, node.children_count - arg_start) {
+				return call_name
+			}
+		}
+	}
+	if g.selector_base_is_value(base.value) {
+		return none
+	}
 	mod_name := g.selector_base_module(base.value) or {
 		if base.value == g.tc.cur_module {
 			base.value
@@ -10521,7 +10911,7 @@ fn (mut g FlatGen) gen_call_args(fn_name string, node flat.Node, start int) {
 		arg_expected_is_voidptr := arg_idx >= 0 && arg_idx < typed_param_count
 			&& type_is_void_pointer(param_types[arg_idx])
 		is_storage_pointer_arg := g.call_arg_is_storage_pointer_arg(arg_idx, [fn_name, callee_name])
-		if g.gen_generated_storage_pointer_arg(arg_idx, arg_id, arg_node) {
+		if is_storage_pointer_arg && g.gen_generated_storage_pointer_arg(arg_idx, arg_id, arg_node) {
 			continue
 		}
 		if arg_expected_is_voidptr && !is_storage_pointer_arg && arg_node.kind == .ident
@@ -10588,8 +10978,8 @@ fn (mut g FlatGen) gen_call_args(fn_name string, node flat.Node, start int) {
 			&& g.gen_isnil_fn_value_arg(arg_id, arg_node) {
 			continue
 		}
-		if arg_expected_is_voidptr && !is_storage_pointer_arg && arg_node.kind == .prefix
-			&& arg_node.op == .amp && g.gen_voidptr_fn_value_arg(arg_id, arg_node) {
+		if arg_expected_is_voidptr && !is_storage_pointer_arg
+			&& g.gen_voidptr_fn_value_arg(arg_id, arg_node) {
 			continue
 		}
 		if arg_node.kind == .sizeof_expr {
@@ -10605,6 +10995,9 @@ fn (mut g FlatGen) gen_call_args(fn_name string, node flat.Node, start int) {
 		}
 		if arg_idx < typed_param_count
 			&& g.gen_fixed_array_pointer_lvalue_arg(arg_id, param_types[arg_idx]) {
+			continue
+		}
+		if g.gen_new_array_fixed_data_arg(node, start, arg_idx, arg_id, [fn_name, callee_name]) {
 			continue
 		}
 		if fixed := array_fixed_type(g.tc.resolve_type(arg_id)) {
@@ -10637,6 +11030,13 @@ fn (mut g FlatGen) gen_call_args(fn_name string, node flat.Node, start int) {
 			continue
 		}
 		if is_c_call {
+			if arg_node.kind == .prefix && arg_node.op == .amp && arg_node.children_count > 0 {
+				inner := g.a.child_node(&arg_node, 0)
+				if inner.kind == .int_literal && inner.value in ['', '0'] {
+					g.write('0')
+					continue
+				}
+			}
 			if g.c_char_literal_arg(arg_id) {
 				if arg_idx < typed_param_count {
 					g.gen_expr_with_expected_type(arg_id, param_types[arg_idx])
@@ -10793,7 +11193,7 @@ fn (mut g FlatGen) gen_call_args(fn_name string, node flat.Node, start int) {
 					// handled
 				} else if arg_idx < typed_param_count && param_types[arg_idx] is types.Struct
 					&& arg_node.kind == .struct_init {
-					g.gen_struct_init(arg_node)
+					g.gen_expr_with_expected_type(arg_id, param_types[arg_idx])
 				} else if arg_idx < typed_param_count {
 					g.gen_expr_with_expected_type(arg_id, param_types[arg_idx])
 				} else {
@@ -10917,12 +11317,22 @@ fn (mut g FlatGen) gen_isnil_fn_value_arg(arg_id flat.NodeId, arg_node flat.Node
 fn (mut g FlatGen) gen_voidptr_fn_value_arg(arg_id flat.NodeId, arg_node flat.Node) bool {
 	mut value_id := arg_id
 	mut value_node := arg_node
-	if arg_node.kind == .prefix && arg_node.op == .amp && arg_node.children_count > 0 {
-		value_id = g.a.child(&arg_node, 0)
-		value_node = g.a.nodes[int(value_id)]
+	for value_node.children_count > 0 {
+		if value_node.kind in [.cast_expr, .paren]
+			|| (value_node.kind == .prefix && value_node.op == .amp) {
+			value_id = g.a.child(&value_node, 0)
+			value_node = g.a.nodes[int(value_id)]
+			continue
+		}
+		break
 	}
 	if !g.node_is_fn_value_for_voidptr(value_id, value_node) {
-		return false
+		voidptr_type := types.Type(types.Pointer{
+			base_type: types.Type(types.void_)
+		})
+		if !g.voidptr_method_value_arg(value_id, voidptr_type) {
+			return false
+		}
 	}
 	g.gen_expr(value_id)
 	return true
@@ -11006,6 +11416,14 @@ fn type_is_void_pointer(typ types.Type) bool {
 fn (mut g FlatGen) gen_transformed_method_ident_call(id flat.NodeId, node flat.Node, fn_node flat.Node) bool {
 	if fn_node.kind != .ident || node.children_count < 2 || !fn_node.value.contains('.') {
 		return false
+	}
+	// A transformed module selector can retain its module ident as the first child.
+	// Let module-call generation discard that pseudo-argument before considering a
+	// same-named mutable receiver method.
+	if _ := g.target_module_call_name(fn_node.value, node) {
+		if g.target_module_call_arg_start(fn_node.value, node) == 2 {
+			return false
+		}
 	}
 	receiver_id := g.a.child(&node, 1)
 	emitted_name := g.direct_call_name_for_call_node(id, node, fn_node.value)
@@ -11487,14 +11905,26 @@ fn (g &FlatGen) spread_arg_child(arg_node flat.Node) ?flat.NodeId {
 }
 
 fn (g &FlatGen) arg_is_const_ident(arg_node flat.Node) bool {
+	if arg_node.kind == .selector {
+		return g.const_ref_name_from_node(arg_node).len > 0
+			|| g.const_type_for_arg_node(arg_node) != none
+	}
 	if arg_node.kind != .ident || arg_node.value.len == 0 {
 		return false
 	}
-	looked_up := g.tc.cur_scope.lookup(arg_node.value) or { types.Type(types.void_) }
-	if looked_up !is types.Void {
+	if _ := g.current_param_type(arg_node.value) {
 		return false
 	}
-	if g.const_ref_name(arg_node.value).len > 0 {
+	const_name := g.const_ref_name(arg_node.value)
+	if owner := g.tc.cur_scope.lookup_owner(arg_node.value) {
+		key := owner.storage_key()
+		if !owner.belongs_to_scope(g.tc.file_scope) && key.len > 0
+			&& (key in g.local_c_type_by_owner || key in g.local_raw_type_by_owner
+			|| key in g.shadowed_global_locals) {
+			return false
+		}
+	}
+	if const_name.len > 0 {
 		return true
 	}
 	if _ := g.const_ident_type(arg_node.value) {
@@ -11959,6 +12389,7 @@ const c_system_libc_preamble_declared_fns = {
 	'getaddrinfo':                   true
 	'getcwd':                        true
 	'getpeername':                   true
+	'getline':                       true
 	'getpid':                        true
 	'gettimeofday':                  true
 	'getuid':                        true
@@ -11969,6 +12400,7 @@ const c_system_libc_preamble_declared_fns = {
 	'localtime_r':                   true
 	'log':                           true
 	'lstat':                         true
+	'mkstemp':                       true
 	'mkdir':                         true
 	'mmap':                          true
 	'opendir':                       true
@@ -11985,6 +12417,7 @@ const c_system_libc_preamble_declared_fns = {
 	'kevent':                        true
 	'kqueue':                        true
 	'rand':                          true
+	'readlink':                      true
 	'readdir':                       true
 	'recv':                          true
 	'recvfrom':                      true
@@ -11999,8 +12432,11 @@ const c_system_libc_preamble_declared_fns = {
 	'socket':                        true
 	'sscanf':                        true
 	'strerror':                      true
+	'symlink':                       true
 	'sysconf':                       true
 	'system':                        true
+	'unlink':                        true
+	'unsetenv':                      true
 	'waitpid':                       true
 	'write':                         true
 }
@@ -12101,6 +12537,7 @@ const c_preamble_declared_extern_symbols = {
 
 const c_libc_compat_extern_symbols = {
 	'gettid': true
+	'puts':   true
 }
 
 const c_libc_compat_syscall_decl_key = 'syscall_decl'

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -1111,7 +1111,7 @@ fn (g &FlatGen) channel_try_push_source_arg(arg_id flat.NodeId) flat.NodeId {
 	}
 	cast := g.a.nodes[int(arg_id)]
 	if cast.kind != .cast_expr || cast.children_count == 0
-		|| !type_is_void_pointer(g.tc.parse_type(cast.value)) {
+		|| !type_is_void_pointer(g.tc.parse_type(cast.value)) || cast.pos.is_valid() {
 		return arg_id
 	}
 	addr_id := g.a.child(&cast, 0)
@@ -1120,9 +1120,10 @@ fn (g &FlatGen) channel_try_push_source_arg(arg_id flat.NodeId) flat.NodeId {
 		return arg_id
 	}
 	value_id := g.a.child(&addr, 0)
-	// The transform wrapped a non-pointer channel value as `voidptr(&value)`
-	// solely for the runtime method's opaque parameter. The channel C lowering
-	// supplies that address itself, so recover the original value here.
+	// A synthetic cast has no source position. The transform wrapped this
+	// non-pointer channel value as `voidptr(&value)` solely for the runtime
+	// method's opaque parameter. The channel C lowering supplies that address
+	// itself, so recover the original value here. Preserve explicit source casts.
 	return value_id
 }
 

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -4202,7 +4202,9 @@ fn (mut g FlatGen) gen_ierror_from_error_call(node flat.Node) {
 	} else {
 		g.write('0')
 	}
-	g.write('}, sizeof(MessageError)), ._object_is_boxed = true, .message = _str_${empty_sid}, .code = 0}')
+	// The boxed MessageError owns the payload; semantic consumers use dynamic dispatch.
+	g.write('}, sizeof(MessageError)), ._object_is_boxed = true')
+	g.write(', .message = _str_${empty_sid}, .code = 0}')
 }
 
 // gen_optional_error_from_call converts gen optional error from call data for c.

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -10614,6 +10614,9 @@ fn (g &FlatGen) selector_module_call_name(id flat.NodeId, fn_node flat.Node, nod
 	if base.kind != .ident {
 		return none
 	}
+	if g.selector_base_is_value(base.value) {
+		return none
+	}
 	if source_file := g.a.source_files[fn_node.pos.id] {
 		if lexical_module := g.tc.file_imports[source_file.name + '\n' + base.value] {
 			call_name := '${lexical_module}.${fn_node.value}'
@@ -10628,9 +10631,6 @@ fn (g &FlatGen) selector_module_call_name(id flat.NodeId, fn_node flat.Node, nod
 				return call_name
 			}
 		}
-	}
-	if g.selector_base_is_value(base.value) {
-		return none
 	}
 	mod_name := g.selector_base_module(base.value) or {
 		if base.value == g.tc.cur_module {

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -3291,8 +3291,7 @@ fn (g &FlatGen) spawn_stack_address_value(id flat.NodeId) ?flat.NodeId {
 	}
 	child_id := g.a.child(node, 0)
 	child := g.a.node(child_id)
-	if child.kind != .ident || node.is_mut || child.is_mut
-		|| g.local_storage_is_mutable(child.value) {
+	if child.kind != .ident || node.is_mut || child.is_mut {
 		return none
 	}
 	local_type := g.local_ident_type(child.value) or { return none }

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -5091,12 +5091,12 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 					}
 					if !is_method && clean_type is types.Struct && clean_type.name == 'IError' {
 						if fn_node.value == 'msg' {
-							g.gen_expr(g.a.child(fn_node, 0))
-							g.write('.message')
+							g.gen_ierror_dynamic_method_expr(g.a.child(fn_node, 0), base_type,
+								'msg')
 							return
 						} else if fn_node.value == 'code' {
-							g.gen_expr(g.a.child(fn_node, 0))
-							g.write('.code')
+							g.gen_ierror_dynamic_method_expr(g.a.child(fn_node, 0), base_type,
+								'code')
 							return
 						}
 					}

--- a/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
@@ -830,6 +830,7 @@ fn (g &FlatGen) new_parallel_worker_config(worker_id int, result_only bool) &Fla
 		struct_decl_infos:              g.struct_decl_infos
 		struct_decl_short_infos:        g.struct_decl_short_infos
 		shared_type_names:              g.shared_type_names
+		default_value_stack:            map[string]bool{}
 		const_runtime_inits:            if result_only {
 			g.const_runtime_inits
 		} else {

--- a/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
@@ -78,6 +78,7 @@ fn (mut g FlatGen) prepare_pre_dispatch_master() {
 				c_name:                    item.c_name.clone()
 				cost:                      item.cost
 				is_program_specialization: item.is_program_specialization
+				direct_array_access:       item.direct_array_access
 			}
 		}
 		g.fn_gen_items = owned_items

--- a/vlib/v3/gen/c/for.v
+++ b/vlib/v3/gen/c/for.v
@@ -196,7 +196,9 @@ fn (mut g FlatGen) gen_for_in(node flat.Node) {
 				c_val := g.value_c_type(clean_container_type.value_type)
 				map_value_by_ref := node.op == .amp || container_type is types.Pointer
 				container_str := g.expr_to_string(g.a.child(&node, 2))
-				original_map_ref := if container_type is types.Pointer {
+				storage_container_type := g.usable_expr_type(g.a.child(&node, 2))
+				container_storage_is_pointer := storage_container_type is types.Pointer
+				original_map_ref := if container_storage_is_pointer {
 					container_str
 				} else {
 					'&${container_str}'
@@ -211,7 +213,7 @@ fn (mut g FlatGen) gen_for_in(node flat.Node) {
 				key_values := if use_snapshot {
 					map_snapshot_var = '__for_map_${g.tmp_count}'
 					g.tmp_count++
-					if container_type is types.Pointer {
+					if container_storage_is_pointer {
 						g.writeln('map ${map_snapshot_var} = map__clone(${container_str});')
 					} else {
 						map_src := '__for_map_src_${g.tmp_count}'
@@ -221,7 +223,7 @@ fn (mut g FlatGen) gen_for_in(node flat.Node) {
 					}
 					'${map_snapshot_var}.key_values'
 				} else {
-					access := if container_type is types.Pointer { '->' } else { '.' }
+					access := if container_storage_is_pointer { '->' } else { '.' }
 					'(${container_str})${access}key_values'
 				}
 				g.writeln('for (int ${iter_var} = 0; ${iter_var} < ${key_values}.len; ${iter_var}++) {')
@@ -280,7 +282,7 @@ fn (mut g FlatGen) gen_for_in(node flat.Node) {
 					|| (!val_is_fixed_copy && clean_container_type.value_type is types.Pointer)
 					|| c_type_is_pointer_storage(c_val))
 				if node.op == .amp && val_is_fixed_copy {
-					map_writeback_target = if container_type is types.Pointer {
+					map_writeback_target = if container_storage_is_pointer {
 						container_str
 					} else {
 						'&${container_str}'

--- a/vlib/v3/gen/c/interface.v
+++ b/vlib/v3/gen/c/interface.v
@@ -239,6 +239,9 @@ fn (g &FlatGen) interface_dispatch_target_is_emitted(concrete_key string) bool {
 	if g.used_interface_dispatch_key(concrete_key) {
 		return true
 	}
+	if g.interface_dispatch_method_is_required(concrete_key) {
+		return true
+	}
 	receiver_name := concrete_key.all_before_last('.')
 	if receiver_name.contains('.') {
 		return false
@@ -248,6 +251,30 @@ fn (g &FlatGen) interface_dispatch_target_is_emitted(concrete_key string) bool {
 	return short_key != concrete_key
 		&& g.interface_dispatch_target_short_name_is_unambiguous(short_key, method)
 		&& g.used_interface_dispatch_key(short_key)
+}
+
+fn (g &FlatGen) interface_dispatch_method_is_required(concrete_key string) bool {
+	if !concrete_key.contains('.') {
+		return false
+	}
+	method := concrete_key.all_after_last('.')
+	concrete_c_name := g.cname(concrete_key)
+	for iface_name, impls in g.iface_impls {
+		if !g.should_emit_interface_dispatch(iface_name, method) {
+			continue
+		}
+		for concrete in impls {
+			concrete_method := '${concrete}.${method}'
+			if concrete_method == concrete_key || g.cname(concrete_method) == concrete_c_name {
+				return true
+			}
+			expected := g.tc.concrete_method_signature_key(concrete, method) or { concrete_method }
+			if expected == concrete_key || g.cname(expected) == concrete_c_name {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 fn (g &FlatGen) interface_dispatch_target_short_name_is_unambiguous(short_name string, method string) bool {
@@ -1739,11 +1766,18 @@ fn (g &FlatGen) interface_dispatch_boxed_value_expr(concrete string) string {
 
 fn (g &FlatGen) interface_concrete_storage_c_type(concrete string) string {
 	concrete_type := g.interface_concrete_type(concrete)
-	return if concrete_type is types.Unknown {
+	ct := if concrete_type is types.Unknown {
 		g.cname(concrete)
 	} else {
 		g.tc.c_type(concrete_type)
 	}
+	if ct.starts_with('fn_ptr:') {
+		return naming.fn_ptr_type_name(ct)
+	}
+	if concrete.starts_with('fn_ptr:') {
+		return naming.fn_ptr_type_name(concrete)
+	}
+	return ct
 }
 
 fn (g &FlatGen) interface_concrete_type(concrete string) types.Type {

--- a/vlib/v3/gen/c/interface.v
+++ b/vlib/v3/gen/c/interface.v
@@ -701,6 +701,17 @@ fn (g &FlatGen) is_ierror_type_name(name string) bool {
 	return name == 'IError' || name == 'builtin.IError'
 }
 
+fn (mut g FlatGen) gen_ierror_dynamic_method_expr(id flat.NodeId, typ types.Type, method string) {
+	tmp := g.tmp_count
+	g.tmp_count++
+	g.write('({ IError _ierror_${method}${tmp} = ')
+	if typ is types.Pointer {
+		g.write('*')
+	}
+	g.gen_expr(id)
+	g.write('; IError__${method}(&_ierror_${method}${tmp}); })')
+}
+
 fn (g &FlatGen) ierror_direct_method_name(concrete string, method string) ?string {
 	direct := '${concrete}.${method}'
 	if g.ierror_method_signature_matches(direct, concrete, method) {

--- a/vlib/v3/gen/c/parallel_worker_test.v
+++ b/vlib/v3/gen/c/parallel_worker_test.v
@@ -144,3 +144,25 @@ fn test_fused_parallel_prep_interns_body_string_literals() {
 	assert g.str_lits == ['worker literal']
 	assert g.str_lit_ids['worker literal'] == 0
 }
+
+fn test_scoped_pre_dispatch_preserves_direct_array_access_flag() {
+	mut g, _ := parallel_worker_test_gen(true)
+	fn_id := g.a.add_node(flat.Node{
+		kind:  .fn_decl
+		value: 'unchecked_index'
+	})
+	g.fn_gen_items = [
+		FlatFnGenItem{
+			node_id:             fn_id
+			file:                'direct_array_access.v'
+			module:              'main'
+			c_name:              'main__unchecked_index'
+			cost:                1
+			direct_array_access: true
+		},
+	]
+	g.prepare_pre_dispatch_master()
+	assert g.fn_gen_items.len == 1
+	assert g.fn_gen_items[0].direct_array_access
+	g.release_scoped_fn_items()
+}

--- a/vlib/v3/gen/c/stmt.v
+++ b/vlib/v3/gen/c/stmt.v
@@ -2012,16 +2012,20 @@ fn (mut g FlatGen) gen_node(id flat.NodeId) {
 				if g.cur_fn_ret_is_optional {
 					ct := g.optional_type_name(g.cur_fn_ret)
 					base := g.cur_fn_ret_base
-					if optional_id := g.optional_literal_wrapped_expr(ret_id, g.cur_fn_ret) {
-						g.write('return ')
-						g.gen_expr(optional_id)
-						g.writeln(';')
-						return
-					}
 					if err_id := g.optional_error_payload_err_expr(ret_id) {
 						g.write('return (${ct}){.ok = false, .err = ')
-						g.gen_expr(err_id)
+						if err := g.result_error_from_expr_string(err_id) {
+							g.write(err)
+						} else {
+							g.gen_expr_with_expected_type(err_id, g.tc.parse_type('IError'))
+						}
 						g.writeln('};')
+						return
+					}
+					if optional_id := g.optional_literal_wrapped_expr(ret_id, g.cur_fn_ret) {
+						g.write('return ')
+						g.gen_expr_with_expected_type(optional_id, g.cur_fn_ret)
+						g.writeln(';')
 						return
 					}
 					if base is types.MultiReturn && node.children_count > 1 {
@@ -2216,15 +2220,9 @@ fn (mut g FlatGen) gen_node(id flat.NodeId) {
 				} else if ret_node.kind == .assoc {
 					g.gen_return_assoc(ret_node)
 				} else if ret_fixed := array_fixed_type(g.cur_fn_ret) {
-					if g.tc.c_type(ret_fixed) in g.fixed_array_ret_wrappers {
-						g.write('return ')
-						g.gen_fixed_array_return_wrap(ret_fixed, ret_id)
-						g.writeln(';')
-					} else {
-						g.write('return ')
-						g.gen_expr_with_expected_type(ret_id, g.cur_fn_ret)
-						g.writeln(';')
-					}
+					g.write('return ')
+					g.gen_fixed_array_return_wrap(ret_fixed, ret_id)
+					g.writeln(';')
 				} else {
 					g.write('return ')
 					// Most interface returns are already boxed by the transform pass into
@@ -2297,6 +2295,10 @@ fn (mut g FlatGen) gen_node(id flat.NodeId) {
 		.block {
 			g.writeln('{')
 			g.push_scope()
+			is_unsafe := node.value == 'unsafe'
+			if is_unsafe {
+				g.unsafe_depth++
+			}
 			defer_start := g.defers.len
 			g.indent++
 			for i in 0 .. node.children_count {
@@ -2307,6 +2309,9 @@ fn (mut g FlatGen) gen_node(id flat.NodeId) {
 				g.gen_scope_ownership_drops()
 			}
 			g.trim_defers(defer_start)
+			if is_unsafe {
+				g.unsafe_depth--
+			}
 			g.indent--
 			g.pop_scope()
 			g.writeln('}')
@@ -2538,17 +2543,15 @@ fn (mut g FlatGen) gen_return_with_defers(node flat.Node) {
 		return
 	}
 	if ret_fixed := array_fixed_type(g.cur_fn_ret) {
-		if g.tc.c_type(ret_fixed) in g.fixed_array_ret_wrappers {
-			wrapper := fixed_array_ret_wrapper_name(g.tc.c_type(ret_fixed))
-			tmp := g.tmp_name()
-			g.gen_return_expr_loop_control_copybacks()
-			g.write('${wrapper} ${tmp} = ')
-			g.gen_fixed_array_return_wrap(ret_fixed, ret_id)
-			g.writeln(';')
-			g.gen_return_cleanup()
-			g.writeln('return ${tmp};')
-			return
-		}
+		wrapper := fixed_array_ret_wrapper_name(g.fixed_array_c_type(ret_fixed))
+		tmp := g.tmp_name()
+		g.gen_return_expr_loop_control_copybacks()
+		g.write('${wrapper} ${tmp} = ')
+		g.gen_fixed_array_return_wrap(ret_fixed, ret_id)
+		g.writeln(';')
+		g.gen_return_cleanup()
+		g.writeln('return ${tmp};')
+		return
 	}
 	ct := g.return_c_type()
 	if g.cur_fn_ret is types.MultiReturn && node.children_count > 1 {
@@ -2574,7 +2577,8 @@ fn (mut g FlatGen) gen_return_with_defers(node flat.Node) {
 // sizeof(...)); __fa_ret; })`. C cannot return raw arrays, so the array is copied
 // into the wrapper's `ret_arr` field and the struct is returned by value.
 fn (mut g FlatGen) gen_fixed_array_return_wrap(ret_type types.Type, ret_id flat.NodeId) {
-	wrapper := fixed_array_ret_wrapper_name(g.tc.c_type(ret_type))
+	fixed := array_fixed_type(ret_type) or { return }
+	wrapper := fixed_array_ret_wrapper_name(g.fixed_array_c_type(fixed))
 	g.write('({ ${wrapper} __fa_ret; memcpy(__fa_ret.ret_arr, ')
 	g.gen_fixed_array_copy_source(ret_id, ret_type)
 	g.write(', sizeof(__fa_ret.ret_arr)); __fa_ret; })')
@@ -2608,7 +2612,7 @@ fn (mut g FlatGen) gen_default_return_stmt() {
 	if g.cur_fn_ret_is_optional {
 		ct := g.optional_type_name(g.cur_fn_ret)
 		g.writeln('return (${ct}){.ok = true};')
-	} else if g.cur_fn_name == 'main' {
+	} else if g.cur_fn_name == 'main' && g.test_files.len == 0 {
 		g.writeln('return 0;')
 	} else if g.cur_fn_ret is types.Void {
 		g.writeln('return;')
@@ -2867,11 +2871,38 @@ fn (mut g FlatGen) heap_local_address_expr(ret_id flat.NodeId, expected types.Ty
 			if g.local_pointer_alias_source_is_mut_param(root_name) {
 				return '&${local_expr}'
 			}
+			return g.heap_local_memdup_expr(local_expr, local_type, base_ct, false)
 		} else {
 			return '&${local_expr}'
 		}
 	}
+	if child.kind == .selector && g.selector_address_crosses_pointer(child_id) {
+		return '&${local_expr}'
+	}
 	return g.heap_local_memdup_expr(local_expr, local_type, base_ct, false)
+}
+
+fn (g &FlatGen) selector_address_crosses_pointer(id flat.NodeId) bool {
+	if int(id) < 0 || int(id) >= g.a.nodes.len {
+		return false
+	}
+	mut node := g.a.nodes[int(id)]
+	for node.kind == .selector && node.children_count > 0 {
+		base_id := g.a.child(&node, 0)
+		if int(base_id) < 0 || int(base_id) >= g.a.nodes.len {
+			return false
+		}
+		base := g.a.nodes[int(base_id)]
+		mut base_type := g.usable_expr_type(base_id)
+		if base_type is types.Unknown || base_type is types.Void {
+			base_type = g.tc.parse_type(base.typ)
+		}
+		if cgen_unalias_type(base_type) is types.Pointer {
+			return true
+		}
+		node = base
+	}
+	return false
 }
 
 fn (g &FlatGen) selector_root_local_name(id flat.NodeId) ?string {
@@ -2927,11 +2958,14 @@ fn (mut g FlatGen) return_expr_string(node flat.Node, ret_id flat.NodeId, ret_no
 	}
 	if g.cur_fn_ret_is_optional {
 		base := g.cur_fn_ret_base
-		if optional_id := g.optional_literal_wrapped_expr(ret_id, g.cur_fn_ret) {
-			return g.expr_to_string(optional_id)
-		}
 		if err_id := g.optional_error_payload_err_expr(ret_id) {
-			return '(${ct}){.ok = false, .err = ${g.expr_to_string(err_id)}}'
+			err := g.result_error_from_expr_string(err_id) or {
+				g.expr_to_string_with_expected_type(err_id, g.tc.parse_type('IError'))
+			}
+			return '(${ct}){.ok = false, .err = ${err}}'
+		}
+		if optional_id := g.optional_literal_wrapped_expr(ret_id, g.cur_fn_ret) {
+			return g.expr_to_string_with_expected_type(optional_id, g.cur_fn_ret)
 		}
 		if base is types.MultiReturn && node.children_count > 1 {
 			base_ct := g.value_c_type(base)
@@ -3318,6 +3352,9 @@ fn (g &FlatGen) selector_call_return_type(fn_node flat.Node) ?types.Type {
 	if receiver_name.len == 0 {
 		return none
 	}
+	if ret := g.selector_fn_field_return_type(fn_node) {
+		return ret
+	}
 	if decl_key := g.interface_method_signature_key(receiver_name, fn_node.value) {
 		if ret := g.tc.fn_ret_types[decl_key] {
 			return ret
@@ -3335,6 +3372,20 @@ fn (g &FlatGen) selector_call_return_type(fn_node flat.Node) ?types.Type {
 		}
 	}
 	return none
+}
+
+fn (g &FlatGen) selector_fn_field_return_type(fn_node flat.Node) ?types.Type {
+	if fn_node.kind != .selector || fn_node.children_count == 0 || fn_node.value.len == 0 {
+		return none
+	}
+	base_type := types.unwrap_all_pointers(g.usable_expr_type(g.a.child(&fn_node, 0)))
+	receiver_name := base_type.name()
+	if receiver_name.len == 0 {
+		return none
+	}
+	field_type := g.struct_field_type(receiver_name, fn_node.value) or { return none }
+	fn_type := fn_type_from(field_type) or { return none }
+	return fn_type.return_type
 }
 
 fn (g &FlatGen) fn_decl_return_type_for_call_name(name string) ?types.Type {
@@ -3556,9 +3607,85 @@ fn (g &FlatGen) expr_is_nil_value(id flat.NodeId) bool {
 }
 
 // usable_expr_type supports usable expr type handling for FlatGen.
+fn (g &FlatGen) generated_variant_access_type(id flat.NodeId) ?types.Type {
+	if int(id) < 0 || int(id) >= g.a.nodes.len {
+		return none
+	}
+	node := g.a.nodes[int(id)]
+	if node.kind == .selector {
+		params := node.generic_params()
+		for i, param in params {
+			if param == '__v3_generated_variant_access' && i + 1 < params.len {
+				if node.typ.starts_with('&') {
+					return g.tc.parse_type(node.typ)
+				}
+				return g.tc.parse_type(params[i + 1])
+			}
+		}
+	}
+	if node.kind in [.prefix, .paren] && node.children_count > 0 {
+		if typ := g.generated_variant_access_type(g.a.child(&node, 0)) {
+			if node.kind == .prefix && node.op == .mul && typ is types.Pointer {
+				return typ.base_type
+			}
+			return typ
+		}
+	}
+	return none
+}
+
+fn (mut g FlatGen) gen_generated_variant_access_selector(node flat.Node, base_id flat.NodeId, base_type types.Type) bool {
+	params := node.generic_params()
+	mut generated := false
+	for param in params {
+		if param == '__v3_generated_variant_access' {
+			generated = true
+			break
+		}
+	}
+	if !generated {
+		return false
+	}
+	base := g.a.nodes[int(base_id)]
+	needs_paren := base.kind !in [.ident, .selector]
+	if needs_paren {
+		g.write('(')
+	}
+	g.gen_expr(base_id)
+	if needs_paren {
+		g.write(')')
+	}
+	generated_base_type := g.generated_variant_access_type(base_id) or { base_type }
+	g.write(if node.op == .arrow || base_type is types.Pointer
+		|| generated_base_type is types.Pointer {
+		'->'
+	} else {
+		'.'
+	})
+	g.write(g.cname(node.value))
+	return true
+}
+
 fn (g &FlatGen) usable_expr_type(id flat.NodeId) types.Type {
 	if int(id) >= 0 && int(id) < g.a.nodes.len {
 		node := g.a.nodes[int(id)]
+		if node.kind in [.string_literal, .string_interp] {
+			return types.Type(types.String{})
+		}
+		if node.kind == .prefix && node.children_count > 0 {
+			child_type := g.usable_expr_type(g.a.child(&node, 0))
+			if node.op == .amp {
+				return types.Type(types.Pointer{
+					base_type: child_type
+				})
+			}
+			if node.op == .mul && child_type is types.Pointer {
+				return child_type.base_type
+			}
+		}
+		if typ := g.generated_variant_access_type(id) {
+			return typ
+		}
 		if node.kind in [.expr_stmt, .paren] && node.children_count > 0 {
 			return g.usable_expr_type(g.a.child(&node, 0))
 		}
@@ -3586,6 +3713,9 @@ fn (g &FlatGen) usable_expr_type(id flat.NodeId) types.Type {
 			}
 		}
 		if node.kind == .ident {
+			if typ := g.current_param_type(node.value) {
+				return typ
+			}
 			if typ := g.current_param_map_type(node.value) {
 				return typ
 			}
@@ -3961,6 +4091,11 @@ fn (g &FlatGen) lock_expr_multi_return_type(node flat.Node, count int) ?types.Mu
 
 // gen_decl_assign emits decl assign output for c.
 fn (mut g FlatGen) gen_decl_assign(node flat.Node) {
+	old_decl_is_mut := g.current_decl_is_mut
+	g.current_decl_is_mut = node.is_mut
+	defer {
+		g.current_decl_is_mut = old_decl_is_mut
+	}
 	if node.children_count >= 3 {
 		if _ := g.multi_return_expr_type_for_lhs_count(g.a.child(&node, 1), node.children_count - 1) {
 			g.gen_multi_return_decl(node)
@@ -4139,7 +4274,13 @@ fn (mut g FlatGen) gen_decl_assign(node flat.Node) {
 					g.track_local_pointer_storage_decl(lhs, owner, raw_init_type, '')
 				}
 			} else {
-				c_elem := g.value_sizeof_target(init_type)
+				raw_decl_type := g.decl_raw_type_text(node, lhs, rhs)
+				c_elem := if shared_inner := shared_array_inner_type_text(raw_decl_type) {
+					qualified := g.shared_qualify_type_text(shared_inner, g.tc.cur_module)
+					'${g.shared_wrapper_c_name(qualified)}*'
+				} else {
+					g.value_sizeof_target(init_type)
+				}
 				mut init_len := '0'
 				mut init_cap := '0'
 				mut init_val := ''
@@ -4176,7 +4317,7 @@ fn (mut g FlatGen) gen_decl_assign(node flat.Node) {
 					}
 					owner := g.tc.cur_scope.insert_with_owner(lhs.value, arr_type)
 					g.track_local_pointer_storage_decl(lhs, owner, arr_type, 'Array')
-					g.declare_local_raw_type(owner, g.decl_raw_type_text(node, lhs, rhs))
+					g.declare_local_raw_type(owner, raw_decl_type)
 				}
 			}
 		} else if init_type := g.fixed_array_zero_init_block_type(rhs) {
@@ -4237,6 +4378,14 @@ fn (mut g FlatGen) gen_decl_assign(node flat.Node) {
 			} else {
 				g.usable_expr_type(rhs_id)
 			}
+			if rhs.kind == .call && rhs.children_count > 0 {
+				callee := g.a.child_node(&rhs, 0)
+				if callee.kind == .selector {
+					if ret := g.selector_fn_field_return_type(callee) {
+						v_type = ret
+					}
+				}
+			}
 			if rhs.kind == .cast_expr && rhs.value.len > 0 {
 				cast_type := g.tc.parse_type(rhs.value)
 				if cast_type is types.SumType {
@@ -4250,6 +4399,28 @@ fn (mut g FlatGen) gen_decl_assign(node flat.Node) {
 					&& rhs_type !is types.Unknown && rhs_type !is types.Void {
 					v_type = rhs_type
 				}
+			}
+			if rhs.kind == .struct_init {
+				init_name := g.struct_init_effective_type_name(rhs)
+				if init_name.starts_with('&') {
+					pointer_init_type := g.tc.parse_resolution_type(init_name)
+					if pointer_init_type is types.Pointer {
+						v_type = pointer_init_type
+					}
+				} else if init_name.starts_with('chan ') {
+					channel_type := g.tc.parse_resolution_type(init_name)
+					if channel_type is types.Channel {
+						v_type = channel_type
+					}
+				}
+			}
+			// A bare struct literal always creates a value. Pointer context can leak back
+			// from a later `return &local` while specializing a generic function; keeping
+			// that contextual pointer here would declare `local` as `T*` but initialize it
+			// with a `T` compound literal.
+			if rhs.kind == .struct_init && v_type is types.Pointer
+				&& !g.struct_init_effective_type_name(rhs).starts_with('&') {
+				v_type = types.unwrap_all_pointers(v_type)
 			}
 			if rhs.kind == .lock_expr && v_type !is types.MultiReturn {
 				lock_type := g.usable_expr_type(rhs_id)
@@ -4270,6 +4441,11 @@ fn (mut g FlatGen) gen_decl_assign(node flat.Node) {
 				v_type = types.Type(fixed)
 			}
 			if rhs.kind == .ident {
+				if rhs.value.starts_with('${g.cur_fn_name}_') {
+					if capture_type := g.global_type_for_ident(rhs.value) {
+						v_type = capture_type
+					}
+				}
 				mut should_infer_fn_value := node.typ.len == 0
 				if node.typ.len > 0 {
 					decl_type := g.tc.parse_resolution_type(node.typ)
@@ -4298,6 +4474,10 @@ fn (mut g FlatGen) gen_decl_assign(node flat.Node) {
 			}
 			v_type = g.optional_source_type_for_expr(rhs_id, v_type)
 			v_type = g.preserve_specialized_alias_decl_type(rhs_id, rhs, v_type)
+			if rhs.kind == .struct_init && v_type is types.Pointer
+				&& !g.struct_init_effective_type_name(rhs).starts_with('&') {
+				v_type = types.unwrap_all_pointers(v_type)
+			}
 			if fixed := array_fixed_type(v_type) {
 				lhs_str := g.decl_lhs_str(lhs_id)
 				if !lhs_is_defer_capture {
@@ -4313,7 +4493,10 @@ fn (mut g FlatGen) gen_decl_assign(node flat.Node) {
 				continue
 			}
 			semantic_v_type := cgen_unalias_type(v_type)
-			ct0 := if semantic_v_type is types.MultiReturn {
+			ct0 := if rhs.kind == .struct_init
+				&& g.struct_init_effective_type_name(rhs).starts_with('chan ') {
+				'chan'
+			} else if semantic_v_type is types.MultiReturn {
 				g.value_c_type(v_type)
 			} else if fn_ptr_decl_pointer_depth(v_type) > 0 {
 				// Keep the encoded fn type until the declarator is split below. Resolving
@@ -4322,15 +4505,8 @@ fn (mut g FlatGen) gen_decl_assign(node flat.Node) {
 				g.tc.c_type(v_type)
 			} else if v_type is types.SumType {
 				g.tc.c_type(v_type)
-			} else if rhs.kind == .struct_init
-				&& g.struct_init_decl_type_is_bare_generic_instance(rhs, v_type) {
-				g.tc.c_type(v_type)
 			} else if rhs.kind == .struct_init {
-				if ct := g.generic_struct_init_instance_ct_for_node(rhs) {
-					ct
-				} else {
-					g.struct_init_c_type_name(rhs.value)
-				}
+				g.struct_init_decl_c_type(rhs, v_type)
 			} else if semantic_v_type is types.Enum {
 				g.value_c_type(v_type)
 			} else {
@@ -4515,6 +4691,7 @@ fn (mut g FlatGen) track_local_pointer_storage_decl(lhs flat.Node, owner types.S
 	}
 	g.track_shadowed_global_local(lhs.value, owner)
 	g.declare_local_c_type(owner, c_type)
+	g.declare_local_mutability(owner, g.current_decl_is_mut || lhs.is_mut)
 	g.declare_local_pointer_storage(owner,
 		typ is types.Pointer || c_type_is_pointer_storage(c_type))
 }
@@ -4712,6 +4889,26 @@ fn (g &FlatGen) struct_init_decl_type_is_bare_generic_instance(rhs flat.Node, v_
 	return rhs.value.all_after_last('.') == type_name.all_before('[').all_after_last('.')
 }
 
+fn (mut g FlatGen) struct_init_decl_c_type(rhs flat.Node, v_type types.Type) string {
+	if g.struct_init_effective_type_name(rhs).starts_with('&') && v_type is types.Pointer {
+		return g.value_c_type(v_type)
+	}
+	clean := default_init_unalias_type(types.unwrap_all_pointers(v_type))
+	if clean is types.Struct {
+		if ct := g.concrete_generic_struct_init_ct(clean.name) {
+			return ct
+		}
+		return g.struct_init_value_c_type(clean)
+	}
+	if g.struct_init_decl_type_is_bare_generic_instance(rhs, v_type) {
+		return g.struct_init_value_c_type(v_type)
+	}
+	if ct := g.generic_struct_init_instance_ct_for_node(rhs) {
+		return ct
+	}
+	return g.struct_init_c_type_name(rhs.value)
+}
+
 fn (g &FlatGen) alias_base_matches_type(alias_type types.Alias, typ types.Type) bool {
 	base := types.unwrap_pointer(alias_type.base_type)
 	clean := types.unwrap_pointer(typ)
@@ -4881,6 +5078,20 @@ fn (mut g FlatGen) gen_decl_init_expr(rhs_id flat.NodeId, rhs flat.Node, v_type 
 		g.write('&(${g.local_cname(rhs.value)}->val)')
 		return
 	}
+	if v_type is types.Pointer && rhs.kind == .ident && !g.local_storage_is_pointer(rhs.value) {
+		if local_type := g.local_ident_type(rhs.value) {
+			if local_type !is types.Pointer
+				&& g.type_names_match(select_receive_unalias_type(local_type), select_receive_unalias_type(v_type.base_type)) {
+				expr := g.expr_to_string(rhs_id)
+				if trimmed_space(expr).starts_with('&') {
+					g.write(expr)
+				} else {
+					g.write('&${expr}')
+				}
+				return
+			}
+		}
+	}
 	g.gen_expr_with_expected_type(rhs_id, v_type)
 }
 
@@ -5014,6 +5225,12 @@ fn (mut g FlatGen) gen_multi_return_or_rhs(or_node flat.Node, rhs_multi types.Mu
 	or_body := g.a.nodes[int(or_body_id)]
 	expr_node := g.a.nodes[int(expr_id)]
 	expr_type := g.optional_source_type_for_expr(expr_id, g.or_expr_source_type(expr_id, expr_node))
+	if !type_is_optional_result(expr_type) {
+		g.write('${ct} ${tmp} = ')
+		g.gen_expr_with_expected_type(expr_id, types.Type(rhs_multi))
+		g.writeln(';')
+		return
+	}
 	opt_ct := g.optional_type_name_for_expr(expr_id, expr_type)
 	opt_tmp := g.tmp_name()
 	g.write('${opt_ct} ${opt_tmp} = ')
@@ -5183,7 +5400,11 @@ fn (mut g FlatGen) gen_assign(node flat.Node) {
 				g.gen_array_literal_value(rhs_node, elem_type)
 				g.writeln(';')
 			} else {
-				lhs_type := g.usable_expr_type(lhs_id)
+				lhs_type := if lhs.kind == .ident {
+					g.local_ident_type(lhs.value) or { g.usable_expr_type(lhs_id) }
+				} else {
+					g.usable_expr_type(lhs_id)
+				}
 				rhs_type := g.usable_expr_type(rhs_id)
 				if node.op == .assign {
 					if lhs_fixed := array_fixed_type(lhs_type) {
@@ -5198,8 +5419,7 @@ fn (mut g FlatGen) gen_assign(node flat.Node) {
 							g.writeln('memmove(${dst}, ${g.expr_to_string(rhs_id)}, sizeof(${dst}));')
 							i += 2
 							continue
-						} else if rhs_node.kind == .array_init || rhs_node.kind == .array_literal
-							|| rhs_node.kind == .postfix {
+						} else {
 							dst := g.expr_to_string(lhs_id)
 							g.write('memmove(${dst}, ')
 							g.gen_fixed_array_data_arg(rhs_id, lhs_fixed)
@@ -5502,6 +5722,13 @@ fn (mut g FlatGen) gen_assign_or_expr(node flat.Node, lhs_idx int, or_node flat.
 	expr_node := g.a.nodes[int(expr_id)]
 	tmp := g.tmp_name()
 	expr_type := g.optional_source_type_for_expr(expr_id, g.or_expr_source_type(expr_id, expr_node))
+	if !type_is_optional_result(expr_type) {
+		g.gen_expr(g.a.child(&node, lhs_idx))
+		g.write(' = ')
+		g.gen_expr_with_expected_type(expr_id, expr_type)
+		g.writeln(';')
+		return
+	}
 	opt_ct := g.optional_type_name_for_expr(expr_id, expr_type)
 	g.write('${opt_ct} ${tmp} = ')
 	g.gen_expr(expr_id)
@@ -5554,6 +5781,16 @@ fn (mut g FlatGen) gen_decl_or_expr(lhs flat.Node, or_node flat.Node) {
 	}
 	tmp := g.tmp_name()
 	expr_type := g.optional_source_type_for_expr(expr_id, g.or_expr_source_type(expr_id, expr_node))
+	if !type_is_optional_result(expr_type) {
+		lhs_name := g.local_decl_cname(lhs.value)
+		val_ct := g.value_c_type(expr_type)
+		owner := g.tc.cur_scope.insert_with_owner(lhs.value, expr_type)
+		g.track_local_pointer_storage_decl(lhs, owner, expr_type, val_ct)
+		g.write('${val_ct} ${lhs_name} = ')
+		g.gen_expr_with_expected_type(expr_id, expr_type)
+		g.writeln(';')
+		return
+	}
 	opt_ct := g.optional_type_name_for_expr(expr_id, expr_type)
 	val_ct0, val_type := g.optional_value_ct(expr_type)
 	mut val_ct := if val_type is types.MultiReturn {
@@ -5739,6 +5976,10 @@ fn (mut g FlatGen) gen_or_expr(node flat.Node) {
 	}
 	tmp := g.tmp_name()
 	expr_type := g.optional_source_type_for_expr(expr_id, g.or_expr_source_type(expr_id, expr_node))
+	if !type_is_optional_result(expr_type) {
+		g.gen_expr_with_expected_type(expr_id, expr_type)
+		return
+	}
 	opt_ct := g.optional_type_name_for_expr(expr_id, expr_type)
 	no_value := if expr_type is types.OptionType {
 		expr_type.base_type is types.Void
@@ -5855,7 +6096,25 @@ fn (g &FlatGen) or_expr_source_type(expr_id flat.NodeId, expr_node flat.Node) ty
 	if ret_type := g.json_decode_call_expr_result_type(expr_id) {
 		return ret_type
 	}
+	if expr_node.kind in [.paren, .expr_stmt] && expr_node.children_count > 0 {
+		inner_id := g.a.child(&expr_node, 0)
+		return g.or_expr_source_type(inner_id, g.a.nodes[int(inner_id)])
+	}
 	if expr_node.kind == .call {
+		if thread_ret := g.thread_wait_expr_return_type(expr_node) {
+			return thread_ret
+		}
+		if expr_node.typ.len > 0 {
+			node_type := g.tc.parse_type(expr_node.typ)
+			if node_type is types.OptionType || node_type is types.ResultType {
+				return node_type
+			}
+		}
+		if resolved := g.tc.expr_type(expr_id) {
+			if resolved is types.OptionType || resolved is types.ResultType {
+				return resolved
+			}
+		}
 		local_type := g.local_fn_call_return_type(expr_id, expr_node)
 		if local_type is types.OptionType || local_type is types.ResultType {
 			return local_type
@@ -5865,7 +6124,68 @@ fn (g &FlatGen) or_expr_source_type(expr_id flat.NodeId, expr_node flat.Node) ty
 			return decl_type
 		}
 	}
+	if expr_node.kind == .selector {
+		decl_type := g.selector_declared_type(expr_id) or { types.Type(types.Unknown{}) }
+		if decl_type is types.OptionType || decl_type is types.ResultType {
+			return decl_type
+		}
+	}
 	return g.usable_expr_type(expr_id)
+}
+
+fn (g &FlatGen) thread_wait_expr_return_type(call flat.Node) ?types.Type {
+	if call.children_count == 0 {
+		return none
+	}
+	callee := g.a.child_node(&call, 0)
+	if callee.kind != .selector || callee.value != 'wait' || callee.children_count == 0 {
+		return none
+	}
+	base_type := types.unwrap_pointer(g.usable_expr_type(g.a.child(callee, 0)))
+	mut thread_type := base_type
+	if base_type is types.Array {
+		thread_type = types.unwrap_pointer(base_type.elem_type)
+	} else if base_type is types.ArrayFixed {
+		thread_type = types.unwrap_pointer(base_type.elem_type)
+	}
+	if thread_type !is types.Struct {
+		return none
+	}
+	thread_struct := thread_type as types.Struct
+	thread_name := trimmed_space(thread_struct.name)
+	if thread_name == 'thread' {
+		return types.Type(types.void_)
+	}
+	if !thread_name.starts_with('thread ') {
+		return none
+	}
+	payload := g.tc.parse_type(trimmed_space(thread_name[7..]))
+	if base_type !is types.Array && base_type !is types.ArrayFixed {
+		return payload
+	}
+	if payload is types.OptionType {
+		if payload.base_type is types.Void {
+			return payload
+		}
+		return types.Type(types.OptionType{
+			base_type: types.Type(types.Array{
+				elem_type: payload.base_type
+			})
+		})
+	}
+	if payload is types.ResultType {
+		if payload.base_type is types.Void {
+			return payload
+		}
+		return types.Type(types.ResultType{
+			base_type: types.Type(types.Array{
+				elem_type: payload.base_type
+			})
+		})
+	}
+	return types.Type(types.Array{
+		elem_type: payload
+	})
 }
 
 fn (g &FlatGen) json_decode_call_expr_result_type(id flat.NodeId) ?types.Type {
@@ -6013,7 +6333,8 @@ fn (mut g FlatGen) gen_or_expr_stmt(node flat.Node) {
 	or_body_id := g.a.child(&node, 1)
 	or_body := g.a.nodes[int(or_body_id)]
 	tmp := g.tmp_name()
-	expr_type := g.optional_source_type_for_expr(expr_id, g.tc.resolve_type(expr_id))
+	expr_node := g.a.nodes[int(expr_id)]
+	expr_type := g.optional_source_type_for_expr(expr_id, g.or_expr_source_type(expr_id, expr_node))
 	opt_ct := g.optional_type_name_for_expr(expr_id, expr_type)
 	g.writeln('${opt_ct} ${tmp} = ')
 	g.gen_expr_with_expected_type(expr_id, expr_type)

--- a/vlib/v3/gen/c/str_intp.v
+++ b/vlib/v3/gen/c/str_intp.v
@@ -44,10 +44,9 @@ fn (mut g FlatGen) gen_string_interp(node flat.Node) {
 			} else if g.gen_map_str_expr(expr_id, typ) {
 				// emitted by gen_map_str_expr
 			} else if g.is_ierror_type_name(typ_name) {
-				// IError may resolve as Interface/Alias/Struct depending on context; match by
-				// name and interpolate its `.message` (mirrors the transformer's IError path).
-				g.gen_string_interp_child_expr(expr_id)
-				g.write('.message')
+				// IError may resolve as Interface/Alias/Struct depending on context. Dispatch
+				// through msg() so boxed MessageError values do not depend on the legacy cache.
+				g.gen_ierror_dynamic_method_expr(expr_id, typ, 'msg')
 			} else if typ is types.Primitive {
 				prim_name := types.Type(typ).name()
 				g.write('${g.cname('${prim_name}.str')}(')

--- a/vlib/v3/gen/c/str_intp_test.v
+++ b/vlib/v3/gen/c/str_intp_test.v
@@ -22,3 +22,27 @@ fn test_width_only_enum_interpolation_uses_enum_text() {
 	assert formatted_enum_interp_c_expr('08') == 'v3_string_zpad(Color__autostr(5), 8)'
 	assert formatted_enum_interp_c_expr('8d') == 'v3_string_pad(i64__str((i64)(5)), 8, 0)'
 }
+
+fn test_ierror_interpolation_uses_dynamic_message_dispatch() {
+	mut a := flat.FlatAst.new()
+	err_id := a.add_node(flat.Node{
+		kind:  .ident
+		value: 'err'
+		typ:   'IError'
+	})
+	a.children << err_id
+	interp_id := a.add_node(flat.Node{
+		kind:           .string_interp
+		children_start: 0
+		children_count: 1
+	})
+	mut tc := types.TypeChecker.new(&a)
+	tc.register_synth_type(err_id, types.Type(types.Interface{
+		name: 'IError'
+	}))
+	mut g := FlatGen.new()
+	g.a = &a
+	g.tc = &tc
+	g.gen_string_interp(a.nodes[int(interp_id)])
+	assert g.sb.str() == 'string_plus_many(1, (string[1]){({ IError _ierror_msg0 = err; IError__msg(&_ierror_msg0); })})'
+}

--- a/vlib/v3/gen/c/struct.v
+++ b/vlib/v3/gen/c/struct.v
@@ -240,6 +240,13 @@ fn (mut g FlatGen) gen_unset_struct_field_default(struct_name string, field_name
 		g.write('.${field_c_name} = array_new(sizeof(${c_elem}), 0, 0)')
 		return true
 	}
+	if clean_type is types.Channel {
+		if has {
+			g.write(', ')
+		}
+		g.write('.${field_c_name} = sync__new_channel_st((u32)(0), (u32)(sizeof(${g.tc.c_type(clean_type.elem_type)})))')
+		return true
+	}
 	if clean_type is types.String {
 		if has {
 			g.write(', ')
@@ -286,6 +293,16 @@ fn (mut g FlatGen) gen_struct_init(node flat.Node) {
 	// A generic `T{}` can specialize to `&Struct`. The literal must then escape
 	// on the heap; `(Struct*){...}` is neither valid C nor durable storage.
 	if init_value.starts_with('&') {
+		pointer_type := g.tc.parse_type(init_value)
+		if pointer_type is types.Pointer && node.children_count == 0 {
+			base_type := default_init_unalias_type(pointer_type.base_type)
+			// The default value of a pointer to a scalar is nil. Pointer-to-struct
+			// defaults retain V's heap-initialized `T{}` behavior below.
+			if base_type is types.Primitive || base_type is types.String || base_type is types.Enum {
+				g.write('NULL')
+				return
+			}
+		}
 		mut heap_node := node
 		heap_node.value = init_value[1..]
 		g.gen_heap_struct_init(heap_node)
@@ -296,11 +313,31 @@ fn (mut g FlatGen) gen_struct_init(node flat.Node) {
 		return
 	}
 	mut name := g.struct_init_c_type_name(init_value)
+	if init_value.contains('[') {
+		if qualified_name := g.unique_qualified_struct_c_type(name) {
+			name = qualified_name
+		}
+	}
 	// A bare generic struct literal (`Vec4{..}`) carries no type args; when the
 	// surrounding expected type fixes them (e.g. a `Vec4[f32]` return), emit the
 	// concrete instance name so it matches the materialized struct.
 	if inst := g.generic_struct_init_instance_ct_for_node(node) {
 		name = inst
+	}
+	mut contextual_lookup_name := ''
+	expected_init_type := default_init_unalias_type(types.unwrap_all_pointers(g.expected_expr_type))
+	if expected_init_type is types.Struct {
+		expected_name := expected_init_type.name
+		expected_ct := g.value_c_type(expected_init_type)
+		if g.generic_struct_init_context_matches(init_value, expected_name)
+			|| (init_value.contains('_')
+			&& flattened_generic_struct_c_type_short_name(expected_ct) == init_value) {
+			// The same semantic nested generic can be materialized once with a
+			// qualified inner argument and once with its in-module shorthand. Emit
+			// the instance required by the call/field context and use its fields.
+			name = expected_ct
+			contextual_lookup_name = expected_name
+		}
 	}
 	init_type := g.tc.parse_type(init_value)
 	node_type := g.tc.parse_type(node.typ)
@@ -320,8 +357,10 @@ fn (mut g FlatGen) gen_struct_init(node flat.Node) {
 	if is_optional_init {
 		if err_id := g.optional_success_error_payload_err_expr(node) {
 			g.write('(${name}){.ok = false, .err = ')
-			if !g.gen_ierror_from_expr(err_id) {
-				g.gen_expr(err_id)
+			if err := g.result_error_from_expr_string(err_id) {
+				g.write(err)
+			} else {
+				g.gen_expr_with_expected_type(err_id, g.tc.parse_type('IError'))
 			}
 			g.write('}')
 			return
@@ -339,6 +378,8 @@ fn (mut g FlatGen) gen_struct_init(node flat.Node) {
 	// instance for the fixed-array-field test, field-type lookups, and omitted-default emission.
 	lookup_source_name := if is_optional_init {
 		''
+	} else if contextual_lookup_name.len > 0 {
+		contextual_lookup_name
 	} else if inst := g.generic_struct_init_instance_name_for_node(node) {
 		inst
 	} else {
@@ -351,6 +392,11 @@ fn (mut g FlatGen) gen_struct_init(node flat.Node) {
 	}
 	is_union_init := init_value in g.tc.unions || lookup_source_name in g.tc.unions
 		|| lookup_name in g.tc.unions
+	if init_value.contains('[') {
+		if qualified_name := g.unique_qualified_struct_c_type(name) {
+			name = qualified_name
+		}
+	}
 	if node.children_count == 0 && g.is_scalar_zero_init_type(lookup_source_name, name) {
 		g.write(g.scalar_zero_init(name))
 		return
@@ -507,6 +553,45 @@ fn (mut g FlatGen) gen_struct_init(node flat.Node) {
 		}
 	}
 	g.write('}')
+}
+
+fn (g &FlatGen) unique_qualified_struct_c_type(short_ct string) ?string {
+	if short_ct.len == 0 || short_ct.starts_with('C.') || short_ct.starts_with('struct ')
+		|| short_ct.starts_with('union ') {
+		return none
+	}
+	mut matches := []string{}
+	for type_name, _ in g.tc.structs {
+		candidate_ct := g.struct_cname(type_name)
+		if candidate_ct != short_ct && !candidate_ct.ends_with('__${short_ct}') {
+			continue
+		}
+		if candidate_ct !in matches {
+			matches << candidate_ct
+		}
+	}
+	if matches.len == 1 && matches[0] != short_ct {
+		return matches[0]
+	}
+	return none
+}
+
+fn (g &FlatGen) generic_struct_init_context_matches(init_name string, expected_name string) bool {
+	init_base, init_args, init_ok := shared_generic_app_parts(init_name)
+	expected_base, expected_args, expected_ok := shared_generic_app_parts(expected_name)
+	if !init_ok || !expected_ok || init_args.len != expected_args.len
+		|| init_base.all_after_last('.') != expected_base.all_after_last('.') {
+		return false
+	}
+	for i, init_arg in init_args {
+		actual := g.tc.parse_resolution_type(init_arg)
+		expected := g.tc.parse_resolution_type(expected_args[i])
+		if actual is types.Unknown || expected is types.Unknown
+			|| g.tc.c_type(actual) != g.tc.c_type(expected) {
+			return false
+		}
+	}
+	return true
 }
 
 fn (mut g FlatGen) gen_optional_fixed_array_struct_init(node flat.Node, name string, init_type types.Type) bool {
@@ -748,8 +833,8 @@ fn (mut g FlatGen) gen_fixed_array_copy_source(value_id flat.NodeId, field_type 
 				g.write(literal)
 				return
 			}
-			c_elem, dims := g.fixed_array_decl_parts(fixed)
-			g.write('(${c_elem}${dims})')
+			g.gen_expr_with_expected_type(value_id, fixed)
+			return
 		} else {
 			g.write('(${g.tc.c_type(field_type)})')
 		}
@@ -998,7 +1083,13 @@ fn channel_init_field(node flat.Node, a &flat.FlatAst, name string) ?flat.NodeId
 // gen_heap_struct_init emits heap struct init output for c.
 fn (mut g FlatGen) gen_heap_struct_init(node flat.Node) {
 	init_module := g.tc.cur_module
-	mut name := g.struct_init_c_type_name(node.value)
+	parsed_init_type := g.tc.parse_type(node.value)
+	clean_init_type := default_init_unalias_type(types.unwrap_all_pointers(parsed_init_type))
+	mut name := if clean_init_type is types.Struct {
+		g.struct_init_value_c_type(clean_init_type)
+	} else {
+		g.struct_init_c_type_name(node.value)
+	}
 	// A bare generic heap literal (`&Vec4{..}`) carries no type args; when the
 	// surrounding expected type fixes them (e.g. a `&Vec4[f32]` return), emit the
 	// concrete instance name so the materialized struct matches the value path.
@@ -1399,6 +1490,28 @@ fn (mut g FlatGen) struct_default_field_type(info StructDeclInfo, field flat.Nod
 // gen_default_value_for_type emits default value for type output for c.
 fn (mut g FlatGen) gen_default_value_for_type(typ types.Type) {
 	clean_typ := default_init_unalias_type(typ)
+	tracks_recursive_default := clean_typ is types.Struct || clean_typ is types.SumType
+		|| clean_typ is types.Pointer
+	if tracks_recursive_default {
+		key := clean_typ.name()
+		if g.default_value_stack[key] {
+			if clean_typ is types.Pointer {
+				g.write('NULL')
+			} else {
+				ct := g.value_c_type(clean_typ)
+				g.write('(${ct}){0}')
+			}
+			return
+		}
+		g.default_value_stack[key] = true
+		g.gen_default_value_for_clean_type(clean_typ)
+		g.default_value_stack.delete(key)
+		return
+	}
+	g.gen_default_value_for_clean_type(clean_typ)
+}
+
+fn (mut g FlatGen) gen_default_value_for_clean_type(clean_typ types.Type) {
 	if clean_typ is types.Map {
 		g.write_new_map(clean_typ.key_type, clean_typ.value_type)
 		return
@@ -1406,6 +1519,10 @@ fn (mut g FlatGen) gen_default_value_for_type(typ types.Type) {
 	if clean_typ is types.Array {
 		c_elem := g.value_c_type(clean_typ.elem_type)
 		g.write('array_new(sizeof(${c_elem}), 0, 0)')
+		return
+	}
+	if clean_typ is types.Channel {
+		g.write('sync__new_channel_st((u32)(0), (u32)(sizeof(${g.tc.c_type(clean_typ.elem_type)})))')
 		return
 	}
 	if clean_typ is types.String {
@@ -1561,7 +1678,7 @@ fn (mut g FlatGen) field_needs_default_init(typ types.Type) bool {
 // literal would set any field that C's `{0}` would not: a field with an explicit
 // default (`x int = 5`), an omitted dynamic array/map, or a by-value struct field
 // whose own type needs those defaults.
-// Returns false for structs with interface/sum-typed field defaults, since the
+// Returns false for structs with interface-typed field defaults, since the
 // codegen default path cannot box those values.
 fn (mut g FlatGen) struct_needs_default_init(type_name string) bool {
 	mut visited := map[string]bool{}
@@ -1584,11 +1701,11 @@ fn (mut g FlatGen) struct_needs_default_init_inner(type_name string, mut visited
 			}
 			ftyp := g.struct_default_field_type(info, field)
 			clean_ftyp := default_init_unalias_type(ftyp)
-			// Defaults for interface/sum-typed fields require boxing the value into
-			// the interface/sum representation, which the codegen default path cannot
-			// do. Treat the whole struct as unsafe to default-emit (leave it
-			// zero-initialized, as before) rather than emit an unboxed value.
-			if clean_ftyp is types.SumType || clean_ftyp is types.Interface {
+			// Interface defaults still require conversion metadata that is not
+			// available in this late fallback. Sum defaults are supported by
+			// gen_struct_field_expr_for_field and must keep the enclosing struct's
+			// default initialization active.
+			if clean_ftyp is types.Interface {
 				g.tc.cur_module = old_module
 				return false
 			}
@@ -1599,7 +1716,7 @@ fn (mut g FlatGen) struct_needs_default_init_inner(type_name string, mut visited
 	fields := g.struct_fields_for_type(type_name) or { return found }
 	for field in fields {
 		clean_ftyp := default_init_unalias_type(field.typ)
-		if clean_ftyp is types.Array || clean_ftyp is types.Map {
+		if clean_ftyp is types.Array || clean_ftyp is types.Channel || clean_ftyp is types.Map {
 			found = true
 			continue
 		}
@@ -1768,6 +1885,7 @@ fn (g &FlatGen) scalar_zero_init(c_type string) string {
 // StructDeclInfo stores struct decl info metadata used by c.
 struct StructDeclInfo {
 	node      flat.Node
+	node_id   int
 	module    string
 	file      string
 	full_name string
@@ -2444,6 +2562,23 @@ fn (mut g FlatGen) gen_shared_array_index_storage_expr(base_id flat.NodeId, inde
 }
 
 fn (mut g FlatGen) gen_shared_array_index_value_expr(base_id flat.NodeId, index_id flat.NodeId) bool {
+	if int(base_id) >= 0 && int(base_id) < g.a.nodes.len {
+		base := g.a.nodes[int(base_id)]
+		if base.kind == .ident && g.local_storage_is_shared(base.value) {
+			mut typ := types.unwrap_pointer(g.usable_expr_type(base_id))
+			if typ is types.Alias {
+				typ = types.unwrap_pointer(typ.base_type)
+			}
+			if typ is types.Array {
+				g.write('(*(${g.value_c_type(typ.elem_type)}*)array_get(')
+				g.gen_expr(base_id)
+				g.write(', ')
+				g.gen_expr(index_id)
+				g.write('))')
+				return true
+			}
+		}
+	}
 	if !g.gen_shared_array_index_storage_expr(base_id, index_id) {
 		return false
 	}
@@ -2696,6 +2831,12 @@ fn (mut g FlatGen) gen_shared_field_storage_selector(base_id flat.NodeId, base_t
 	struct_type := base_type as types.Struct
 	_ = g.shared_field_info(struct_type.name, field) or { return false }
 	base := g.a.nodes[int(base_id)]
+	if base.kind == .ident && g.local_storage_is_shared(base.value) {
+		g.write(g.cname(base.value))
+		g.write('->val.')
+		g.write(c_field_name(field))
+		return true
+	}
 	needs_paren := base.kind !in [.ident, .selector]
 	if needs_paren {
 		g.write('(')
@@ -2816,18 +2957,42 @@ fn (mut g FlatGen) gen_shared_default_value_for_field(struct_name string, field_
 // the literal is already specialized, the base is not a generic struct, or the
 // expected type is not a matching concrete instance.
 fn (g &FlatGen) generic_struct_init_instance_ct(type_name string) ?string {
-	return g.tc.c_type(g.generic_struct_init_instance_type(type_name)?)
+	return g.struct_init_value_c_type(g.generic_struct_init_instance_type(type_name)?)
+}
+
+fn (g &FlatGen) struct_init_value_c_type(typ types.Type) string {
+	clean := default_init_unalias_type(types.unwrap_all_pointers(typ))
+	if clean is types.Struct && !clean.name.starts_with('C.') {
+		// Route through the struct type mapper so user declarations that collide
+		// with runtime C names (`Array`, `map`, ...) keep their collision-safe name.
+		return g.struct_cname(clean.name)
+	}
+	if info := g.find_struct_decl(typ.name()) {
+		return if info.full_name.starts_with('C.') {
+			g.struct_cname(info.full_name)
+		} else {
+			g.cname(info.full_name)
+		}
+	}
+	return g.tc.c_type(typ)
 }
 
 fn (g &FlatGen) generic_struct_init_instance_ct_for_node(node flat.Node) ?string {
 	if node.typ.len > 0 {
 		candidate := g.tc.parse_type(node.typ)
-		base := default_init_unalias_type(types.unwrap_pointer(candidate))
+		base := default_init_unalias_type(types.unwrap_all_pointers(candidate))
 		if base !is types.Array && base !is types.ArrayFixed {
 			name := base.name()
-			if name.contains('[')
-				&& name.all_before('[').all_after_last('.') == node.value.all_after_last('.') {
-				return g.tc.c_type(base)
+			if name.contains('[') {
+				if ct := g.concrete_generic_struct_init_ct(name) {
+					if name.all_before('[').all_after_last('.') == node.value.all_after_last('.')
+						|| flattened_generic_struct_c_type_short_name(ct) == node.value {
+						return ct
+					}
+				}
+				if name.all_before('[').all_after_last('.') == node.value.all_after_last('.') {
+					return g.struct_init_value_c_type(base)
+				}
 			}
 		}
 	}
@@ -2837,7 +3002,7 @@ fn (g &FlatGen) generic_struct_init_instance_ct_for_node(node flat.Node) ?string
 fn (g &FlatGen) generic_struct_init_instance_name_for_node(node flat.Node) ?string {
 	if node.typ.len > 0 {
 		candidate := g.tc.parse_type(node.typ)
-		base := default_init_unalias_type(types.unwrap_pointer(candidate))
+		base := default_init_unalias_type(types.unwrap_all_pointers(candidate))
 		if base !is types.Array && base !is types.ArrayFixed {
 			name := base.name()
 			if name.contains('[')
@@ -2884,7 +3049,7 @@ fn (g &FlatGen) generic_struct_init_instance_type(type_name string) ?types.Type 
 		// Unwrap a pointer so a `&Box[int]` expected type still matches a bare `Box`
 		// literal — the heap path (`&Box{..}`) needs the struct (`Box_int`), not the
 		// pointer, type name.
-		base_cand := default_init_unalias_type(types.unwrap_pointer(cand))
+		base_cand := default_init_unalias_type(types.unwrap_all_pointers(cand))
 		// A fixed/dynamic array type is not a generic struct instance even though its
 		// `.name()` renders like one (`[2]Foo` -> `Foo[2]`); skip it so a `Foo{..}` element
 		// of a `[2]Foo` literal keeps its element type instead of adopting the array type.
@@ -2923,6 +3088,19 @@ fn (mut g FlatGen) struct_init_c_type_name(type_name string) string {
 		return ct
 	}
 	if init_type_name.contains('[') {
+		if ct := g.concrete_generic_struct_init_ct(init_type_name) {
+			return ct
+		}
+		if info := g.find_struct_decl(init_type_name) {
+			return if info.full_name.starts_with('C.') {
+				g.struct_cname(info.full_name)
+			} else {
+				g.cname(info.full_name)
+			}
+		}
+		if typ is types.Struct && !typ.name.starts_with('C.') {
+			return g.cname(typ.name)
+		}
 		return g.tc.c_type(typ)
 	}
 	if ct := g.flattened_generic_struct_init_ct_from_context(init_type_name) {
@@ -2940,8 +3118,79 @@ fn (mut g FlatGen) struct_init_c_type_name(type_name string) string {
 	return g.struct_cname(info.full_name)
 }
 
+fn (g &FlatGen) concrete_generic_struct_init_ct(type_name string) ?string {
+	base, args, ok := shared_generic_app_parts(type_name)
+	if !ok || args.len == 0 {
+		return none
+	}
+	wanted_suffix := generic_receiver_type_suffixes(args)
+	mut matches := []string{}
+	mut base_matches := []string{}
+	for candidate in g.tc.structs.keys() {
+		candidate_base, candidate_args, candidate_ok := shared_generic_app_parts(candidate)
+		if !candidate_ok || candidate_args.len != args.len
+			|| candidate_base.all_after_last('.') != base.all_after_last('.') {
+			continue
+		}
+		ct := g.struct_cname(candidate)
+		if ct !in base_matches {
+			base_matches << ct
+		}
+		if generic_receiver_type_suffixes(candidate_args).replace('_', '') != wanted_suffix.replace('_',
+			'') {
+			continue
+		}
+		if ct !in matches {
+			matches << ct
+		}
+	}
+	if matches.len == 1 {
+		return matches[0]
+	}
+	if base_matches.len == 1 {
+		return base_matches[0]
+	}
+	return none
+}
+
 fn (g &FlatGen) struct_init_import_alias_type_name(type_name string) string {
+	base, args, is_generic := shared_generic_app_parts(type_name)
+	if is_generic && args.len > 0 && !base.contains('.') {
+		mut resolved := []string{}
+		if g.tc.cur_file.len > 0 {
+			if candidates := g.tc.file_selective_imports['${g.tc.cur_file}\n${base}'] {
+				for candidate in candidates {
+					if candidate.len > 0 && candidate !in resolved {
+						resolved << candidate
+					}
+				}
+			}
+		}
+		if resolved.len == 0 {
+			// Specialized function bodies can be emitted after the top-level file
+			// cursor has moved. Recover a selective type import only when its short
+			// name has one unambiguous target across the checked files.
+			suffix := '\n${base}'
+			for key, candidates in g.tc.file_selective_imports {
+				if !key.ends_with(suffix) {
+					continue
+				}
+				for candidate in candidates {
+					if candidate.len > 0 && candidate !in resolved
+						&& g.generic_struct_import_candidate_is_materialized(candidate, args) {
+						resolved << candidate
+					}
+				}
+			}
+		}
+		if resolved.len == 1 {
+			return '${resolved[0]}[${args.join(',')}]'
+		}
+	}
 	if !type_name.contains('.') {
+		return type_name
+	}
+	if type_name in g.struct_decl_infos || type_name in g.tc.structs {
 		return type_name
 	}
 	alias := type_name.all_before('.')
@@ -2953,6 +3202,36 @@ fn (g &FlatGen) struct_init_import_alias_type_name(type_name string) string {
 		return '${mod}.${suffix}'
 	}
 	return type_name
+}
+
+fn (g &FlatGen) generic_struct_import_candidate_is_materialized(base string, args []string) bool {
+	wanted_suffix := generic_receiver_type_suffixes(args).replace('_', '')
+	base_info := g.find_struct_decl(base) or { return false }
+	for candidate in g.tc.structs.keys() {
+		candidate_base, candidate_args, ok := shared_generic_app_parts(candidate)
+		if !ok || candidate_base.all_after_last('.') != base.all_after_last('.')
+			|| (candidate_base != base && base_info.module != base.all_before_last('.'))
+			|| candidate_args.len != args.len {
+			continue
+		}
+		if generic_receiver_type_suffixes(candidate_args).replace('_', '') == wanted_suffix {
+			return true
+		}
+		mut same_args := true
+		for i, candidate_arg in candidate_args {
+			candidate_type := g.tc.parse_resolution_type(candidate_arg)
+			requested_type := g.tc.parse_resolution_type(args[i])
+			if candidate_type is types.Unknown || requested_type is types.Unknown
+				|| g.tc.c_type(candidate_type) != g.tc.c_type(requested_type) {
+				same_args = false
+				break
+			}
+		}
+		if same_args {
+			return true
+		}
+	}
+	return false
 }
 
 fn (g &FlatGen) generic_struct_init_app_ct_from_context(type_name string) ?string {
@@ -2984,7 +3263,21 @@ fn (g &FlatGen) generic_struct_init_app_ct_from_context(type_name string) ?strin
 			continue
 		}
 		if generic_receiver_type_suffixes(candidate_args) == arg_suffix {
-			return g.tc.c_type(candidate_type)
+			context_ct := g.tc.c_type(candidate_type)
+			mut matches := []string{}
+			for _, info in g.struct_decl_infos {
+				candidate_ct := g.struct_cname(info.full_name)
+				if candidate_ct == context_ct
+					|| flattened_generic_struct_c_type_short_name(candidate_ct) == context_ct {
+					if candidate_ct !in matches {
+						matches << candidate_ct
+					}
+				}
+			}
+			if matches.len == 1 {
+				return matches[0]
+			}
+			return context_ct
 		}
 	}
 	return none
@@ -3997,6 +4290,29 @@ fn (g &FlatGen) struct_decl_head(name string) string {
 	return '${tag} ${cn}'
 }
 
+fn (g &FlatGen) struct_decl_value_dependency_c_type(typ types.Type) string {
+	match typ {
+		types.Pointer {
+			return ''
+		}
+		types.ArrayFixed {
+			return g.struct_decl_value_dependency_c_type(typ.elem_type)
+		}
+		types.OptionType {
+			return g.struct_decl_value_dependency_c_type(typ.base_type)
+		}
+		types.ResultType {
+			return g.struct_decl_value_dependency_c_type(typ.base_type)
+		}
+		types.Alias {
+			return g.struct_decl_value_dependency_c_type(typ.base_type)
+		}
+		else {
+			return g.tc.c_type(typ)
+		}
+	}
+}
+
 // emit_interface_struct emits emit interface struct output for c.
 fn (mut g FlatGen) emit_interface_struct(name string) {
 	iface_fields := g.interface_cached_fields(name)
@@ -4091,6 +4407,12 @@ fn (mut g FlatGen) struct_decls() {
 		cn := g.struct_cname(name)
 		if cn == 'mach_timebase_info_data_t' || cn.starts_with('struct ')
 			|| cn.starts_with('union ') {
+			continue
+		}
+		// Some C tags deliberately have no typedef (`struct Foo`). The C type
+		// renderer already includes their tag, so wrapping that spelling in a
+		// typedef would produce `typedef struct struct Foo struct Foo`.
+		if cn.starts_with('struct ') || cn.starts_with('union ') {
 			continue
 		}
 		g.writeln('typedef ${tag} ${cn} ${cn};')
@@ -4375,6 +4697,9 @@ fn (mut g FlatGen) type_forward_decls() {
 			|| cn.starts_with('union ') {
 			continue
 		}
+		if cn.starts_with('struct ') || cn.starts_with('union ') {
+			continue
+		}
 		g.writeln('typedef ${tag} ${cn} ${cn};')
 	}
 	for name in g.tc.sum_types.keys() {
@@ -4404,6 +4729,10 @@ fn (mut g FlatGen) emit_struct(name string) {
 	g.tc.cur_module = g.fixed_array_typedef_type_module(name, old_module)
 	if name in g.tc.structs {
 		fields := g.tc.structs[name]
+		pack := g.struct_decl_pack_for_name(name)
+		if pack.len > 0 {
+			g.writeln('#pragma pack(push, ${pack})')
+		}
 		g.writeln('${g.struct_decl_head(name)} {')
 		if fields.len == 0 {
 			g.writeln('\tu8 _dummy;')
@@ -4412,9 +4741,31 @@ fn (mut g FlatGen) emit_struct(name string) {
 			g.write_struct_field(name, f)
 		}
 		g.writeln('};')
+		if pack.len > 0 {
+			g.writeln('#pragma pack(pop)')
+		}
 		g.writeln('')
 	}
 	g.tc.cur_module = old_module
+}
+
+fn (g &FlatGen) struct_decl_pack_for_name(name string) string {
+	info := g.find_struct_decl(name) or { return '' }
+	attrs := g.decl_attrs[info.node_id] or { return '' }
+	for raw_attr in attrs {
+		attr := raw_attr.trim_space()
+		attr_name := attr.all_before(':').trim_space()
+		if attr_name in ['packed', '_packed'] {
+			return '1'
+		}
+		if attr_name == '_pack' && attr.contains(':') {
+			value := attr.all_after(':').trim_space().trim('\'"')
+			if value.len > 0 {
+				return value
+			}
+		}
+	}
+	return ''
 }
 
 // is_generic_struct reports whether is generic struct applies in c.
@@ -4748,16 +5099,16 @@ fn (mut g FlatGen) write_struct_field(_struct_name string, f types.StructField) 
 		}
 		ct := g.resolve_fn_ptr_type(c_abi_fn)
 		g.writeln('\t${ct} ${g.cname(f.name)};')
-	} else if f.typ is types.ArrayFixed {
-		c_elem, dims := g.fixed_array_decl_parts(f.typ)
+	} else if field_type is types.ArrayFixed {
+		c_elem, dims := g.fixed_array_decl_parts(field_type)
 		g.writeln('\t${c_elem} ${g.cname(f.name)}${dims};')
 	} else {
-		mut ct := if f.typ is types.OptionType || f.typ is types.ResultType {
-			g.optional_type_name(f.typ)
-		} else if f.typ is types.Enum {
-			g.enum_value_c_type(f.typ)
+		mut ct := if field_type is types.OptionType || field_type is types.ResultType {
+			g.optional_type_name(field_type)
+		} else if field_type is types.Enum {
+			g.enum_value_c_type(field_type)
 		} else {
-			g.tc.c_type(f.typ)
+			g.tc.c_type(field_type)
 		}
 		if ct.starts_with('fn_ptr:') {
 			ct = g.resolve_fn_ptr_type(ct)

--- a/vlib/v3/gen/c/types.v
+++ b/vlib/v3/gen/c/types.v
@@ -603,8 +603,9 @@ fn (mut g FlatGen) enum_decls() {
 	for node in g.a.nodes {
 		match node.kind {
 			.file {
-				cur_module = ''
+				cur_module = 'main'
 				g.tc.cur_file = node.value
+				g.tc.cur_module = 'main'
 			}
 			.module_decl {
 				cur_module = node.value

--- a/vlib/v3/gen/c/types.v
+++ b/vlib/v3/gen/c/types.v
@@ -154,6 +154,9 @@ fn (mut g FlatGen) value_c_type(t types.Type) string {
 	if clean_type is types.ArrayFixed {
 		return g.fixed_array_c_type(clean_type)
 	}
+	if clean_type is types.Channel {
+		return 'chan'
+	}
 	mut ct := g.tc.c_type(clean_type)
 	if ct.starts_with('fn_ptr:') {
 		ct = g.resolve_fn_ptr_type(ct)
@@ -171,6 +174,66 @@ fn cgen_unalias_type(typ types.Type) types.Type {
 		return current
 	}
 	return current
+}
+
+fn cgen_types_equal_after_alias_erasure(left types.Type, right types.Type) bool {
+	l := cgen_unalias_type(left)
+	r := cgen_unalias_type(right)
+	if l is types.OptionType {
+		return r is types.OptionType
+			&& cgen_types_equal_after_alias_erasure(l.base_type, r.base_type)
+	}
+	if l is types.ResultType {
+		return r is types.ResultType
+			&& cgen_types_equal_after_alias_erasure(l.base_type, r.base_type)
+	}
+	if l is types.Pointer {
+		return r is types.Pointer && cgen_types_equal_after_alias_erasure(l.base_type, r.base_type)
+	}
+	if l is types.Array {
+		return r is types.Array && cgen_types_equal_after_alias_erasure(l.elem_type, r.elem_type)
+	}
+	if l is types.ArrayFixed {
+		return r is types.ArrayFixed && l.len == r.len
+			&& cgen_types_equal_after_alias_erasure(l.elem_type, r.elem_type)
+	}
+	if l is types.Channel {
+		return r is types.Channel && cgen_types_equal_after_alias_erasure(l.elem_type, r.elem_type)
+	}
+	if l is types.Map {
+		return r is types.Map && cgen_types_equal_after_alias_erasure(l.key_type, r.key_type)
+			&& cgen_types_equal_after_alias_erasure(l.value_type, r.value_type)
+	}
+	if l is types.FnType {
+		if r !is types.FnType {
+			return false
+		}
+		if l.params.len != r.params.len
+			|| !cgen_types_equal_after_alias_erasure(l.return_type, r.return_type) {
+			return false
+		}
+		for i, param in l.params {
+			if !cgen_types_equal_after_alias_erasure(param, r.params[i]) {
+				return false
+			}
+		}
+		return true
+	}
+	if l is types.MultiReturn {
+		if r !is types.MultiReturn {
+			return false
+		}
+		if l.types.len != r.types.len {
+			return false
+		}
+		for i, item in l.types {
+			if !cgen_types_equal_after_alias_erasure(item, r.types[i]) {
+				return false
+			}
+		}
+		return true
+	}
+	return l.name() == r.name()
 }
 
 fn (mut g FlatGen) multi_return_c_type_name(t types.MultiReturn) string {
@@ -529,15 +592,23 @@ fn (mut g FlatGen) emit_optional_typedef(opt_name string, val_type string) bool 
 
 // enum_decls supports enum decls handling for FlatGen.
 fn (mut g FlatGen) enum_decls() {
+	old_file := g.tc.cur_file
+	old_module := g.tc.cur_module
+	defer {
+		g.tc.cur_file = old_file
+		g.tc.cur_module = old_module
+	}
 	mut cur_module := ''
 	mut emitted := map[string]bool{}
 	for node in g.a.nodes {
 		match node.kind {
 			.file {
 				cur_module = ''
+				g.tc.cur_file = node.value
 			}
 			.module_decl {
 				cur_module = node.value
+				g.tc.cur_module = node.value
 			}
 			.enum_decl {
 				name := if cur_module.len > 0 && cur_module != 'main' && cur_module != 'builtin' {
@@ -629,33 +700,76 @@ fn (mut g FlatGen) enum_decls() {
 					continue
 				}
 				g.writeln('typedef enum {')
-				mut val := 0
 				mut field_values := map[string]i64{}
 				mut field_exprs := map[string]flat.NodeId{}
+				mut field_names := map[string]bool{}
 				for i in 0 .. node.children_count {
 					f := g.a.child_node(&node, i)
+					field_names[f.value] = true
 					if f.children_count > 0 {
 						field_exprs[f.value] = g.a.child(f, 0)
 					}
 				}
-				for i in 0 .. node.children_count {
-					f := g.a.child_node(&node, i)
-					if f.children_count > 0 {
-						mut resolving := map[string]bool{}
-						if enum_val := g.enum_field_expr_value_with_enum(g.a.child(f, 0),
-							cur_module, node.value, mut field_values, field_exprs, mut resolving)
-						{
-							val = int(enum_val)
+				if is_flag {
+					mut val := 0
+					for i in 0 .. node.children_count {
+						f := g.a.child_node(&node, i)
+						if f.children_count > 0 {
+							mut resolving := map[string]bool{}
+							if enum_val := g.enum_field_expr_value_with_enum(g.a.child(f, 0),
+								cur_module, node.value, mut field_values, field_exprs, mut
+								resolving)
+							{
+								val = int(enum_val)
+							}
 						}
-					}
-					field_values[f.value] = i64(val)
-					cfield := g.cname(f.value)
-					if is_flag {
+						field_values[f.value] = i64(val)
+						cfield := g.cname(f.value)
 						g.writeln('\t${cn}__${cfield} = ${1 << val},')
 						val++
-					} else {
-						g.writeln('\t${cn}__${cfield} = ${val},')
-						val++
+					}
+				} else {
+					mut next_value := i64(0)
+					mut next_value_known := true
+					mut next_value_expr := '0'
+					for i in 0 .. node.children_count {
+						f := g.a.child_node(&node, i)
+						mut value := next_value
+						mut value_known := next_value_known
+						mut value_expr := if next_value_known {
+							value.str()
+						} else {
+							next_value_expr
+						}
+						if f.children_count > 0 {
+							expr_id := g.a.child(f, 0)
+							mut resolving := map[string]bool{}
+							if enum_val := g.enum_field_expr_value_with_enum(expr_id, cur_module,
+								node.value, mut field_values, field_exprs, mut resolving)
+							{
+								value = enum_val
+								value_known = true
+								value_expr = enum_val.str()
+							} else {
+								value_known = false
+								value_expr = g.enum_field_expr_to_string_with_enum(expr_id,
+									cur_module, node.value, cn, field_names) or {
+									g.expr_to_string(expr_id)
+								}
+							}
+						}
+						if value_known {
+							field_values[f.value] = value
+						}
+						g.writeln('\t${cn}__${g.cname(f.value)} = ${value_expr},')
+						if value_known {
+							next_value = value + 1
+							next_value_known = true
+							next_value_expr = next_value.str()
+						} else {
+							next_value_known = false
+							next_value_expr = '(${value_expr}) + 1'
+						}
 					}
 				}
 				g.writeln('} ${cn};')
@@ -735,8 +849,9 @@ fn (mut g FlatGen) enum_str_defs() {
 					g.writeln('string ${cn}__autostr(${cn} it) {')
 					for i in 0 .. node.children_count {
 						f := g.a.child_node(&node, i)
-						fname := f.value
-						cfield := g.cname(fname)
+						raw_fname := f.value
+						fname := enum_field_display_name(raw_fname)
+						cfield := g.cname(raw_fname)
 						g.writeln('\tif (it == ${cn}__${cfield}) return (string){.str = (u8*)"${fname}", .len = ${fname.len}, .is_lit = 1};')
 					}
 					if enum_storage_c_type_is_unsigned(storage_ct) {
@@ -750,8 +865,9 @@ fn (mut g FlatGen) enum_str_defs() {
 					g.writeln('string ${cn}__autostr(${cn} it) {')
 					for i in 0 .. node.children_count {
 						f := g.a.child_node(&node, i)
-						fname := f.value
-						cfield := g.cname(fname)
+						raw_fname := f.value
+						fname := enum_field_display_name(raw_fname)
+						cfield := g.cname(raw_fname)
 						// Use ordered comparisons instead of switch cases: enums may opt in
 						// to duplicate values, and the first declared name is their auto-str.
 						g.writeln('\tif (it == ${cn}__${cfield}) return (string){.str = (u8*)"${fname}", .len = ${fname.len}, .is_lit = 1};')
@@ -807,8 +923,9 @@ fn (mut g FlatGen) emit_flag_enum_autostr(node flat.Node, name string, cn string
 		}
 		seen[val] = true
 		val++
-		fname := f.value
-		cfield := g.cname(fname)
+		raw_fname := f.value
+		fname := enum_field_display_name(raw_fname)
+		cfield := g.cname(raw_fname)
 		field_expr := '${cn}__${cfield}'
 		g.writeln('\tif (${field_expr} != 0 && (__fe_v & (${storage_ct})${field_expr}) == (${storage_ct})${field_expr}) {')
 		g.writeln('\t\tif (!__fe_first) { __fe_res = string__plus(__fe_res, (string){.str = (u8*)" | ", .len = 3, .is_lit = 1}); }')
@@ -821,6 +938,10 @@ fn (mut g FlatGen) emit_flag_enum_autostr(node flat.Node, name string, cn string
 	g.writeln('\treturn __fe_res;')
 	g.writeln('}')
 	g.writeln('')
+}
+
+fn enum_field_display_name(name string) string {
+	return if name.starts_with('@') { name[1..] } else { name }
 }
 
 // enum_field_expr_value supports enum field expr value handling for FlatGen.
@@ -993,6 +1114,12 @@ fn (g &FlatGen) enum_field_expr_value_with_enum(id flat.NodeId, enum_module stri
 			if field := g.enum_decl_selector_ref_field(id, enum_module, enum_name) {
 				return g.enum_decl_field_ref_value(field, enum_module, enum_name, mut field_values,
 					field_exprs, mut resolving)
+			}
+			prefix := g.enum_decl_selector_base_text(g.a.child(&node, 0))
+			if enum_type := g.enum_selector_base_name(prefix) {
+				if value := g.enum_value_for_type(enum_type, node.value) {
+					return i64(value)
+				}
 			}
 			return none
 		}

--- a/vlib/v3/gen/c/types_test.v
+++ b/vlib/v3/gen/c/types_test.v
@@ -1,0 +1,55 @@
+module c
+
+import os
+import v3.parser
+import v3.pref
+import v3.types
+
+fn test_enum_decls_resets_checker_module_at_file_boundary() {
+	test_dir := os.join_path(os.vtmp_dir(), 'v3_enum_decls_module_reset_${os.getpid()}')
+	os.rmdir_all(test_dir) or {}
+	os.mkdir_all(test_dir) or { panic(err) }
+	defer {
+		os.rmdir_all(test_dir) or {}
+	}
+	main_path := os.join_path(test_dir, 'main.v')
+	shadow_path := os.join_path(test_dir, 'shadow.v')
+	os.write_file(main_path, 'type Storage = u64
+
+const base = 300
+
+enum E as Storage {
+	a = base + 2
+	b
+}
+') or {
+		panic(err)
+	}
+	os.write_file(shadow_path, 'module shadow
+
+type Storage = u8
+
+const base = 4
+') or {
+		panic(err)
+	}
+
+	prefs := pref.new_preferences()
+	mut p := parser.Parser.new(prefs)
+	mut a := p.parse_files([main_path, shadow_path])
+	mut tc := types.TypeChecker.new(a)
+	tc.collect(a)
+	tc.check_semantics()
+	assert tc.errors.len == 0, tc.errors.str()
+	tc.cur_file = main_path
+	tc.cur_module = 'shadow'
+
+	mut g := FlatGen.new()
+	g.a = a
+	g.tc = &tc
+	g.enum_decls()
+	c_source := g.sb.str()
+	assert c_source.contains('typedef u64 E;'), c_source
+	assert c_source.contains('#define E__a ((E)(302))'), c_source
+	assert tc.cur_module == 'shadow'
+}

--- a/vlib/v3/markused/markused.v
+++ b/vlib/v3/markused/markused.v
@@ -353,6 +353,10 @@ fn mark_used_with_test_files(a &flat.FlatAst, tc &types.TypeChecker, test_files 
 		false)
 	uses_generics = enqueue_top_level_calls(a, collector, fn_decls, has_entry_main, mut used, mut
 		queue, uses_generics)
+	// Interface method values and other roots can enter the queue as abstract
+	// dispatch keys that have no function declaration of their own. Seed their
+	// concrete implementations before the declaration-driven BFS skips those keys.
+	enqueue_used_interface_dispatch_implementers(tc, mut used, mut queue)
 	// Interface dispatch reachability: calling an interface method `Foo.m` may
 	// dispatch to any concrete `T.m` for a type `T` that implements `Foo`. Those
 	// concrete methods are only referenced from the generated dispatch switch, so
@@ -1032,12 +1036,15 @@ fn markused_reachable_modules(a &flat.FlatAst, tc &types.TypeChecker) map[string
 	mut module_imports := map[string][]string{}
 	mut roots := []string{}
 	mut has_user_root := false
+	file_modules := markused_top_level_file_modules(a, tc)
 	for file_idx in tc.top_level_idx {
 		file_node := a.nodes[file_idx]
 		if file_node.kind != .file {
 			continue
 		}
-		module_name := markused_top_level_file_module_name(a, file_node)
+		module_name := file_modules[file_node.value] or {
+			markused_top_level_file_module_name(a, file_node)
+		}
 		if file_idx >= a.user_code_start
 			&& (!markused_file_is_vlib(file_node.value) || !has_user_root) {
 			has_user_root = true
@@ -1080,6 +1087,26 @@ fn markused_reachable_modules(a &flat.FlatAst, tc &types.TypeChecker) map[string
 		}
 	}
 	return reachable
+}
+
+fn markused_top_level_file_modules(a &flat.FlatAst, tc &types.TypeChecker) map[string]string {
+	mut modules := map[string]string{}
+	mut current_file := ''
+	for node_idx in tc.top_level_idx {
+		node := a.nodes[node_idx]
+		match node.kind {
+			.file {
+				current_file = node.value
+			}
+			.module_decl {
+				if current_file.len > 0 {
+					modules[current_file] = node.value
+				}
+			}
+			else {}
+		}
+	}
+	return modules
 }
 
 fn markused_file_is_vlib(file string) bool {
@@ -1535,7 +1562,7 @@ fn enqueue_main_module_roots(fn_decls map[string]FnDeclInfo, mut used map[string
 // is_auto_root_fn reports whether is auto root fn applies in markused.
 fn is_auto_root_fn(name string) bool {
 	short_name := name.all_after_last('.')
-	return short_name == 'init'
+	return short_name in ['init', 'builtin_init']
 }
 
 // enqueue_detected_runtime_helpers supports enqueue detected runtime helpers handling for markused.
@@ -2761,6 +2788,8 @@ fn (c &CallCollector) node_uses_generics(node &flat.Node, cur_module string, imp
 	return match node.kind {
 		.struct_init, .array_init, .cast_expr, .as_expr, .sizeof_expr, .typeof_expr, .is_expr {
 			c.type_text_uses_generics(node.value, cur_module, imports)
+				|| (!node.value.contains('[') && node.generic_params().len > 0
+				&& c.type_text_uses_generics('${node.value}[${node.generic_params().join(', ')}]', cur_module, imports))
 		}
 		else {
 			false
@@ -3663,6 +3692,10 @@ fn (c &CallCollector) collect_calls_with_locals_and_generics(node &flat.Node, cu
 			.selector {
 				if c.collect_interface_method_value_selector(child, mut calls) {
 					// handled
+				} else if c.collect_generic_method_value_selector(child, cur_module, imports, mut
+					calls)
+				{
+					// handled
 				} else if resolved := c.tc.resolved_fn_value_name(child_id) {
 					calls << resolved
 				} else {
@@ -3726,6 +3759,10 @@ fn (c &CallCollector) collect_calls_with_locals_and_generics(node &flat.Node, cu
 							if callee.children_count > 0 {
 								base_id := c.a.child(&callee, 0)
 								if int(base_id) >= 0 {
+									if detect_generics && !uses_generics
+										&& c.node_tree_uses_generics(base_id, cur_module, imports) {
+										uses_generics = true
+									}
 									base := c.a.nodes[int(base_id)]
 									base_is_local_value := base.kind == .ident
 										&& base.value in local_values
@@ -3737,6 +3774,10 @@ fn (c &CallCollector) collect_calls_with_locals_and_generics(node &flat.Node, cu
 										has_exact_selector_call = c.collect_typed_receiver_method(base_id,
 											callee.value, cur_module, imports, local_values,
 											local_types, mut calls)
+										if declared_type := local_types[base.value] {
+											c.collect_sum_variant_receiver_methods_for_type_name(declared_type,
+												callee.value, cur_module, mut calls)
+										}
 									}
 									if !has_exact_selector_call && !base_is_local_value {
 										has_exact_selector_call = c.collect_checker_selected_call(resolved_call, mut
@@ -5118,6 +5159,10 @@ fn (c &CallCollector) collect_top_level_selector_call(callee &flat.Node, method 
 			if base_is_local_value {
 				has_exact_selector_call = c.collect_top_level_typed_receiver_method(base_id,
 					method, cur_module, imports, local_values, local_types, mut calls)
+				if declared_type := local_types[base.value] {
+					c.collect_sum_variant_receiver_methods_for_type_name(declared_type, method,
+						cur_module, mut calls)
+				}
 			}
 			if !has_exact_selector_call && !base_is_local_value {
 				has_exact_selector_call = c.collect_checker_selected_call(resolved_call, mut calls)
@@ -5855,6 +5900,9 @@ fn (c &CallCollector) collect_fn_value_selector(id flat.NodeId, node &flat.Node,
 	if c.collect_interface_method_value_selector(node, mut calls) {
 		return
 	}
+	if c.collect_generic_method_value_selector(node, cur_module, imports, mut calls) {
+		return
+	}
 	if resolved := c.tc.resolved_fn_value_name(id) {
 		calls << resolved
 		return
@@ -5872,6 +5920,21 @@ fn (c &CallCollector) collect_fn_value_selector(id flat.NodeId, node &flat.Node,
 	}
 }
 
+fn (c &CallCollector) collect_generic_method_value_selector(node &flat.Node, cur_module string, imports map[string]string, mut calls []string) bool {
+	// A generic receiver method value is resolved to its open declaration name,
+	// but monomorphization also needs the concrete receiver application in the
+	// reachable set so it emits the wrapper's target specialization.
+	mut has_generic_method_value := false
+	for name in c.fn_value_selector_names(node, cur_module, imports) {
+		if info := c.tc.generic_method_value_info[name] {
+			calls << name
+			calls << info.name
+			has_generic_method_value = true
+		}
+	}
+	return has_generic_method_value
+}
+
 fn (c &CallCollector) fn_value_selector_names(node &flat.Node, cur_module string, imports map[string]string) []string {
 	if node.children_count == 0 || node.value.len == 0 {
 		return []string{}
@@ -5885,9 +5948,22 @@ fn (c &CallCollector) fn_value_selector_names(node &flat.Node, cur_module string
 			markused_push_fn_value_selector_name(mut names, '${imports[base.value]}.${node.value}')
 		}
 	}
-	type_name := resolve_type_name(c.node_type(base_id))
-	if method_name := c.typed_receiver_method_name(type_name, node.value, cur_module) {
-		markused_push_fn_value_selector_name(mut names, method_name)
+	mut type_names := [resolve_type_name(c.node_type(base_id))]
+	if base.typ.len > 0 {
+		annotated_name := resolve_type_name(c.tc.parse_type(base.typ))
+		if annotated_name.len > 0 && annotated_name !in type_names {
+			type_names << annotated_name
+		}
+	}
+	for type_name in type_names {
+		concrete_method := '${type_name}.${node.value}'
+		if info := c.tc.generic_method_value_info[concrete_method] {
+			markused_push_fn_value_selector_name(mut names, concrete_method)
+			markused_push_fn_value_selector_name(mut names, info.name)
+		}
+		if method_name := c.typed_receiver_method_name(type_name, node.value, cur_module) {
+			markused_push_fn_value_selector_name(mut names, method_name)
+		}
 	}
 	return names
 }
@@ -6398,16 +6474,35 @@ fn (c &CallCollector) collect_sum_variant_receiver_methods(base_id flat.NodeId, 
 		return false
 	}
 	sum_name := (base_type as types.SumType).name
-	variants := c.tc.sum_types[sum_name] or { return false }
+	return c.collect_sum_variant_receiver_methods_for_type_name(sum_name, method, cur_module, mut
+		calls)
+}
+
+fn (c &CallCollector) collect_sum_variant_receiver_methods_for_type_name(type_name string, method string, cur_module string, mut calls []string) bool {
+	mut clean := markused_clean_receiver_type_name(type_name)
+	for clean.starts_with('?') || clean.starts_with('!') {
+		clean = clean[1..].trim_space()
+	}
+	mut sum_names := [clean]
+	qualified := qualify_fn(cur_module, clean)
+	if qualified != clean {
+		sum_names << qualified
+	}
+	mut variants := []string{}
+	for sum_name in sum_names {
+		if known := c.tc.sum_types[sum_name] {
+			variants = known.clone()
+			break
+		}
+	}
+	if variants.len == 0 {
+		return false
+	}
 	mut added := false
 	for variant in variants {
-		for candidate in [variant + '.' + method, qualify_fn(cur_module, variant + '.' + method)] {
-			if candidate.len == 0 || !c.is_known_fn_name(candidate) {
-				continue
-			}
+		if candidate := c.typed_receiver_method_name(variant, method, cur_module) {
 			c.add_typed_receiver_method_name(candidate, mut calls)
 			added = true
-			break
 		}
 	}
 	return added

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -82,6 +82,7 @@ mut:
 	in_for_container                  bool
 	in_array_literal                  int
 	in_map_value                      int
+	in_struct_init_value              int
 	unsupported_inline_asm_guards     map[int]bool
 	parsing_inferred_fixed_array_type bool
 	diagnostic_limit_reached          bool
@@ -138,13 +139,15 @@ pub fn Parser.new(prefs &pref.Preferences) &Parser {
 		unsupported_inline_asm_guards: map[int]bool{}
 		sql_query_data_aliases:        map[string]bool{}
 		a:                             &flat.FlatAst{
-			nodes:                []flat.Node{cap: 256}
-			children:             []flat.NodeId{cap: 512}
-			disabled_fns:         map[string]bool{}
-			export_fn_names:      map[string]string{}
-			source_files:         map[int]&token.File{}
-			text_ids:             map[string]flat.TextId{}
-			specialized_fn_nodes: map[int]bool{}
+			nodes:                  []flat.Node{cap: 256}
+			children:               []flat.NodeId{cap: 512}
+			disabled_fns:           map[string]bool{}
+			export_fn_names:        map[string]string{}
+			source_files:           map[int]&token.File{}
+			text_ids:               map[string]flat.TextId{}
+			specialized_fn_nodes:   map[int]bool{}
+			specialized_fn_modules: map[int]string{}
+			specialized_fn_files:   map[int]string{}
 		}
 	}
 }
@@ -3087,6 +3090,9 @@ fn (p &Parser) comptime_cond_token_text() string {
 	if tok == .and {
 		return '&&'
 	}
+	if tok == .amp {
+		return '&'
+	}
 	if tok == .logical_or {
 		return '||'
 	}
@@ -3179,7 +3185,7 @@ fn comptime_cond_needs_space(prev string, cur string) bool {
 	if prev == 'is' || prev == '!is' {
 		return true
 	}
-	if prev == '?' || prev == '!' {
+	if prev == '?' || prev == '!' || prev == '&' {
 		return false
 	}
 	if cur == '?' || cur == ']' || cur == '[' || cur == '.' || cur == ',' {
@@ -6331,6 +6337,10 @@ fn (mut p Parser) stmt_expr() flat.NodeId {
 fn (mut p Parser) expr_with_lhs_context(first flat.NodeId, min_bp token.BindingPower, is_stmt_ident bool) flat.NodeId {
 	mut lhs := first
 	for {
+		if p.in_struct_init_value > 0 && (p.tok == .name || p.tok.is_keyword())
+			&& p.peek() == .colon {
+			break
+		}
 		// A newline (scanned as `;`) directly followed by `.` continues the
 		// expression: `expr or { ... }` / `expr` on one line, `.method()` on
 		// the next. Inside a map literal, however, `.member:` can begin the next
@@ -6342,7 +6352,8 @@ fn (mut p Parser) expr_with_lhs_context(first flat.NodeId, min_bp token.BindingP
 			p.next()
 			continue
 		}
-		if p.tok == .semicolon && p.peek() == .lpar && p.expr_can_continue_with_newline_call(lhs) {
+		if min_bp == .lowest && p.tok == .semicolon && p.peek() == .lpar
+			&& p.expr_can_continue_with_newline_call(lhs) {
 			p.next()
 			continue
 		}
@@ -6366,9 +6377,7 @@ fn (mut p Parser) expr_with_lhs_context(first flat.NodeId, min_bp token.BindingP
 			if lhs_node.kind == .selector && lhs_node.value.len > 0 {
 				base := p.a.child_node(&lhs_node, 0)
 				is_c_struct := base.kind == .ident && base.value == 'C'
-					&& !is_all_upper_ident(lhs_node.value)
-					&& (p.peek() == .rcbr || p.peek() == .name
-					|| p.peek() == .ellipsis)
+					&& (!is_all_upper_ident(lhs_node.value) || p.current_lcbr_looks_struct_init())
 				is_v_struct := base.kind == .ident && base.value != 'C' && lhs_node.value[0] >= `A`
 					&& lhs_node.value[0] <= `Z`
 				if is_c_struct || is_v_struct {
@@ -6626,6 +6635,13 @@ fn (mut p Parser) expr_with_lhs_context(first flat.NodeId, min_bp token.BindingP
 			peek_tok := p.peek()
 			if (token_is_infix(peek_tok) || peek_tok == .key_as) && peek_tok != .mul
 				&& peek_tok != .amp {
+				// At the same indentation, a leading `+`/`-` starts the next
+				// expression (commonly the value expression in an `or` block).
+				// More deeply indented operators continue a multiline infix.
+				if peek_tok in [.plus, .minus]
+					&& p.column_for_pos(p.peek_pos) <= p.column_for_pos(p.a.nodes[int(lhs)].pos.offset) {
+					break
+				}
 				p.next()
 				continue
 			}
@@ -6684,7 +6700,7 @@ fn (p &Parser) expr_can_continue_with_newline_call(id flat.NodeId) bool {
 	if node.kind !in [.ident, .selector] {
 		return false
 	}
-	return p.column_for_pos(p.peek_pos) > p.line_indent_for_pos(node.pos.offset)
+	return p.column_for_pos(p.peek_pos) > p.column_for_pos(node.pos.offset)
 }
 
 fn (p &Parser) spaced_dot_starts_array_enum_value(id flat.NodeId) bool {
@@ -8241,7 +8257,14 @@ fn (mut p Parser) index_part_expr() flat.NodeId {
 		}
 		return p.make_index_range_part(low, high, dotdot_start)
 	}
-	low := p.expr(.logical_or)
+	mut low := p.expr(.logical_or)
+	// An option/result handler before the closing bracket belongs to the index
+	// expression (`a[f() or { 0 }]`), not to the completed `a[f()]` node. Resume
+	// only for `or`; parsing the whole part at `.lowest` would consume `..` and
+	// prevent the slice-specific representation below.
+	if p.tok == .key_or {
+		low = p.expr_with_lhs(low, .lowest)
+	}
 	if p.tok == .dotdot {
 		low_start := p.node_start(low)
 		start := if low_start >= 0 { low_start } else { p.span_start() }
@@ -8451,7 +8474,9 @@ fn (mut p Parser) struct_init(name string) flat.NodeId {
 			}
 			fname := p.expect_name_or_keyword()
 			p.check(.colon)
+			p.in_struct_init_value++
 			val := p.expr(.lowest)
+			p.in_struct_init_value--
 			vstart := p.add_child(val)
 			field_ids << p.add_node(flat.Node{
 				kind:           .field_init
@@ -8481,7 +8506,9 @@ fn (mut p Parser) struct_init(name string) flat.NodeId {
 		if (p.tok == .name || p.tok.is_keyword()) && p.peek() == .colon {
 			fname := p.expect_name_or_keyword()
 			p.check(.colon)
+			p.in_struct_init_value++
 			val := p.expr(.lowest)
+			p.in_struct_init_value--
 			vstart := p.add_child(val)
 			ids << p.add_node(flat.Node{
 				kind:           .field_init
@@ -8878,7 +8905,7 @@ fn (mut p Parser) parse_fixed_array_literal_type_name() string {
 		}
 		if name == 'thread' {
 			if p.tok == .name || p.tok == .amp || p.tok == .lsbr || p.tok == .question
-				|| p.tok == .not {
+				|| p.tok == .lpar || p.tok == .not || p.tok == .key_fn {
 				return 'thread ${p.parse_fixed_array_literal_type_name()}'
 			}
 			return 'thread'
@@ -10691,6 +10718,16 @@ fn unescape_string(s string) string {
 					i += 10
 					continue
 				}
+			}
+			if i + 3 < s.len && s[i + 1] >= `0` && s[i + 1] <= `7` && s[i + 2] >= `0`
+				&& s[i + 2] <= `7` && s[i + 3] >= `0` && s[i + 3] <= `7` {
+				octal := u8(int(s[i + 1] - `0`) * 64 + int(s[i + 2] - `0`) * 8 + int(s[i + 3] - `0`))
+				unsafe {
+					buf[j] = octal
+				}
+				j++
+				i += 4
+				continue
 			}
 			c := match s[i + 1] {
 				`n` { u8(`\n`) }

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -6639,7 +6639,7 @@ fn (mut p Parser) expr_with_lhs_context(first flat.NodeId, min_bp token.BindingP
 				// expression (commonly the value expression in an `or` block).
 				// More deeply indented operators continue a multiline infix.
 				if peek_tok in [.plus, .minus]
-					&& p.column_for_pos(p.peek_pos) <= p.column_for_pos(p.a.nodes[int(lhs)].pos.offset) {
+					&& p.line_indent_for_pos(p.peek_pos) <= p.line_indent_for_pos(p.a.nodes[int(lhs)].pos.offset) {
 					break
 				}
 				p.next()

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -3203,6 +3203,9 @@ fn comptime_cond_has_type_test(cond string) bool {
 }
 
 fn comptime_cond_has_type_metadata(cond string) bool {
+	if cond.contains('typeof[') && cond.contains('.idx') {
+		return true
+	}
 	for member in ['.indirections', '.typ', '.unaliased_typ', '.key_type', '.value_type',
 		'.element_type', '.pointee_type', '.payload_type', '.variant_types'] {
 		if cond.contains(member) {

--- a/vlib/v3/tests/driver_cli_test.v
+++ b/vlib/v3/tests/driver_cli_test.v
@@ -73,6 +73,26 @@ fn test_standard_v3_excludes_ownership_checker() {
 		'ownership support is not compiled into this v3 executable')
 }
 
+fn test_explicit_arm64_import_unskips_ssa_dependencies() {
+	root := os.join_path(os.vtmp_dir(), 'v3_driver_arm64_import_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	v3_bin := build_driver_cli_v3(root)
+	source := os.join_path(root, 'main.v')
+	os.write_file(source, 'module main
+
+import v3.gen.arm64
+
+fn main() {}
+')!
+	output := os.join_path(root, 'arm64_import')
+	compile := cmdexec.run(v3_bin, ['-o', output, source])
+	assert compile.exit_code == 0, compile.output
+}
+
 fn test_driver_cflags_include_dir_is_visible_to_header_inliner() {
 	root := os.join_path(os.vtmp_dir(), 'v3_driver_cflags_include_${os.getpid()}')
 	os.rmdir_all(root) or {}

--- a/vlib/v3/tests/or_expr_transform_review_test.v
+++ b/vlib/v3/tests/or_expr_transform_review_test.v
@@ -153,6 +153,13 @@ fn test_pointer_channel_try_call_derefs_receiver() {
 	assert c_source.contains('sync__Channel__try_pop(*(ch),'), 'try_pop on pointer channel receiver does not dereference the channel handle'
 }
 
+fn test_channel_try_push_preserves_explicit_voidptr_cast() {
+	v3_bin := build_v3_or_review()
+	out := or_review_run(v3_bin, 'channel_try_push_explicit_voidptr',
+		'fn main() {\n\tch := chan voidptr{cap: 1}\n\tx := 42\n\tassert ch.try_push(voidptr(&x)) == .success\n\treceived := <-ch\n\tprintln(int_str(unsafe { *(&int(received)) }))\n}\n')
+	assert out == '42'
+}
+
 fn test_pointer_channel_send_or_derefs_receiver() {
 	v3_bin := build_v3_or_review()
 	out := or_review_run(v3_bin, 'pointer_channel_send_or_receiver',

--- a/vlib/v3/tests/or_expr_transform_review_test.v
+++ b/vlib/v3/tests/or_expr_transform_review_test.v
@@ -50,6 +50,14 @@ fn or_review_run(v3_bin string, name string, src string) string {
 	return run.output.trim_space()
 }
 
+fn or_review_compile_bad(v3_bin string, name string, src string) string {
+	src_path := os.join_path(os.temp_dir(), 'v3_${name}.v')
+	os.write_file(src_path, src) or { panic(err) }
+	compile := os.execute('${v3_bin} ${src_path} -b c')
+	assert compile.exit_code != 0, '${name}: invalid source compiled successfully'
+	return compile.output
+}
+
 fn test_channel_receive_or_stabilizes_side_effectful_source() {
 	v3_bin := build_v3_or_review()
 	c_source := or_review_gen_c(v3_bin, 'channel_receive_or_source_once',
@@ -60,12 +68,11 @@ fn test_channel_receive_or_stabilizes_side_effectful_source() {
 	assert c_source.contains('sync__Channel__closed_error(__chan_src_'), 'closed_error does not use channel source temp'
 }
 
-fn test_bare_channel_or_is_not_lowered_to_receive() {
+fn test_bare_channel_or_is_rejected() {
 	v3_bin := build_v3_or_review()
-	c_source := or_review_gen_c(v3_bin, 'bare_channel_or_not_receive',
+	output := or_review_compile_bad(v3_bin, 'bare_channel_or_rejected',
 		'fn main() {\n\tch := chan int{}\n\t_ := ch or { ch }\n}\n')
-	assert !c_source.contains('sync__Channel__pop((sync__Channel*)'), 'bare channel or was lowered to a direct receive'
-	assert !c_source.contains('sync__Channel__pop(__chan_src_'), 'bare channel or was lowered to a temp receive'
+	assert output.contains('unexpected `or` block'), output
 }
 
 fn test_array_optional_element_or_uses_loaded_element_error() {
@@ -82,6 +89,13 @@ fn test_map_optional_element_or_uses_loaded_element_error() {
 		"fn main() {\n\tmut m := map[string]?int{}\n\tm['x'] = none\n\tvalue := m['x'] or {\n\t\tprintln(err.msg())\n\t\t0\n\t}\n\tprintln(int_str(value))\n}\n")
 	assert c_source.contains('Optional __map_opt_'), 'missing loaded map optional temp'
 	assert c_source.contains('IError err = __map_opt_'), 'map element failure branch does not use loaded optional err'
+}
+
+fn test_map_index_address_or_nil_remains_valid() {
+	v3_bin := build_v3_or_review()
+	out := or_review_run(v3_bin, 'map_index_address_or_nil',
+		"fn main() {\n\tmut values := {\n\t\t'x': 7\n\t}\n\tpresent := unsafe { &values['x'] or { nil } }\n\tmissing := unsafe { &values['missing'] or { nil } }\n\tprintln(int_str(*present))\n\tprintln(missing == unsafe { nil })\n}\n")
+	assert out == '7\ntrue'
 }
 
 fn test_nested_optional_infix_or_uses_whole_expression_fallback() {

--- a/vlib/v3/tests/or_expr_transform_review_test.v
+++ b/vlib/v3/tests/or_expr_transform_review_test.v
@@ -174,9 +174,12 @@ fn test_channel_send_or_binds_error_during_fallback_transform() {
 	assert out == 'channel closed\n7'
 }
 
-fn test_optional_pointer_selector_or_dereferences_wrapper() {
+fn test_optional_result_pointers_or_are_rejected() {
 	v3_bin := build_v3_or_review()
-	out := or_review_run(v3_bin, 'optional_pointer_selector_or',
-		'struct Holder {\n\tfield &?int\n}\n\nfn holder(field &?int) Holder {\n\treturn Holder{\n\t\tfield: field\n\t}\n}\n\nfn main() {\n\tpresent := ?int(7)\n\tpresent_holder := holder(&present)\n\tpresent_holder.field or { println("unexpected") }\n\tprintln("present")\n\n\tmissing := ?int(none)\n\tmissing_holder := holder(&missing)\n\tmissing_holder.field or { println("missing") }\n}\n')
-	assert out == 'present\nmissing'
+	option_output := or_review_compile_bad(v3_bin, 'optional_pointer_or_rejected',
+		'fn invalid(ptr &?int) {\n\t_ := ptr or { 0 }\n}\n\nfn main() {}\n')
+	assert option_output.contains('unexpected `or` block'), option_output
+	result_output := or_review_compile_bad(v3_bin, 'result_pointer_or_rejected',
+		'fn invalid(ptr &!int) {\n\t_ := ptr or { 0 }\n}\n\nfn main() {}\n')
+	assert result_output.contains('unexpected `or` block'), result_output
 }

--- a/vlib/v3/tests/parser_regression_test.v
+++ b/vlib/v3/tests/parser_regression_test.v
@@ -510,6 +510,28 @@ fn test_multiline_keyword_infix_expressions_continue_after_semicolon() {
 	assert as_count == 1
 }
 
+fn test_indented_plus_minus_continue_before_operand_column() {
+	a := parse_parser_regression_source('indented_plus_minus_continuation',
+		"module main\n\nfn main() {\n\tfirst := 7\n\tsecond := 2\n\ttotal := first\n\t\t+ second\n\tdifference := first\n\t\t- second\n\tfallback := none or {\n\t\tprintln('fallback')\n\t\t-1\n\t}\n\t_ = total\n\t_ = difference\n\t_ = fallback\n}\n")
+	mut infix_plus := 0
+	mut infix_minus := 0
+	mut prefix_minus := 0
+	for node in a.nodes {
+		if node.kind == .infix && node.op == .plus {
+			infix_plus++
+		}
+		if node.kind == .infix && node.op == .minus {
+			infix_minus++
+		}
+		if node.kind == .prefix && node.op == .minus {
+			prefix_minus++
+		}
+	}
+	assert infix_plus == 1
+	assert infix_minus == 1
+	assert prefix_minus == 1
+}
+
 fn test_parenthesized_statement_after_call_is_not_call_continuation() {
 	a := parse_parser_regression_source('parenthesized_statement_after_call',
 		"module main\n\nfn foo() int {\n\treturn 1\n}\n\nfn main() {\n\tprintln('a')\n\t(foo())\n}\n")

--- a/vlib/v3/tests/post_merge_review_fixes_test.v
+++ b/vlib/v3/tests/post_merge_review_fixes_test.v
@@ -5739,6 +5739,28 @@ fn test_review_shadowed_global_pointer_str_and_setter_only_compound() {
 	assert fixed_field_out == '7'
 }
 
+fn test_cross_module_mut_receiver_checks_visible_mutation() {
+	v3_bin := build_v3()
+	run_bad_project(v3_bin, 'review_cross_module_public_mut_receiver', {
+		'v.mod':          "Module { name: 'review_cross_module_public_mut_receiver' }\n"
+		'other/config.v': 'module other\n\npub struct Config {\npub mut:\n\tvalue int\n}\n\npub fn (mut cfg Config) reset() {\n\tcfg.value = 0\n}\n'
+		'main.v':         'module main\n\nimport other\n\nfn main() {\n\tcfg := other.Config{\n\t\tvalue: 1\n\t}\n\tcfg.reset()\n}\n'
+	}, ['main.v'], 'method `reset` requires a mutable receiver')
+	private_out := run_good_project(v3_bin, 'review_cross_module_private_mut_receiver', {
+		'v.mod':         "Module { name: 'review_cross_module_private_mut_receiver' }\n"
+		'other/state.v': 'module other\n\npub struct State {\nmut:\n\thidden int\n}\n\npub fn (mut state State) bump() {\n\tstate.hidden++\n}\n\npub fn (state State) value() int {\n\treturn state.hidden\n}\n'
+		'main.v':        'module main\n\nimport other\n\nfn main() {\n\tstate := other.State{}\n\tstate.bump()\n\tprintln(int_str(state.value()))\n}\n'
+	}, 'main.v')
+	assert private_out == '1'
+}
+
+fn test_implicit_reference_materializes_required_pointer_levels() {
+	v3_bin := build_v3()
+	out := run_good(v3_bin, 'review_multi_level_implicit_addresses',
+		'fn set_double(pp &&int) {\n\tunsafe {\n\t\t**pp = 5\n\t}\n}\n\nfn set_triple(pp &&&int) {\n\tunsafe {\n\t\t***pp = 7\n\t}\n}\n\nfn main() {\n\tmut x := 1\n\tset_double(x)\n\tmut y := 2\n\tp := &y\n\tset_triple(p)\n\tprintln(int_str(x))\n\tprintln(int_str(y))\n}\n')
+	assert out == '5\n7'
+}
+
 fn test_discard_assignment_preserves_array_return_type() {
 	v3_bin := build_v3()
 	out := run_good(v3_bin, 'discard_array_return_no_context',

--- a/vlib/v3/tests/review_checker_regressions_test.v
+++ b/vlib/v3/tests/review_checker_regressions_test.v
@@ -229,6 +229,13 @@ fn test_fn_value_integer_returns_require_matching_c_abi() {
 	assert out == '65'
 }
 
+fn test_fn_value_aggregate_returns_require_compatible_payloads() {
+	v3_bin := build_v3_review_checker()
+	run_bad(v3_bin, 'bad_fn_value_array_return_payload',
+		'fn numbers() []int {\n\treturn [1, 2]\n}\n\nfn invoke(callback fn () []string) []string {\n\treturn callback()\n}\n\nfn main() {\n\t_ := invoke(numbers)\n}\n',
+		'cannot use `fn() []int`')
+}
+
 fn test_alias_with_nested_type_separator_stays_alias() {
 	v3_bin := build_v3_review_checker()
 	out := run_good(v3_bin, 'good_alias_nested_type_separator',

--- a/vlib/v3/tests/review_checker_regressions_test.v
+++ b/vlib/v3/tests/review_checker_regressions_test.v
@@ -259,6 +259,9 @@ fn test_shared_receiver_and_arg_require_shared_bindings() {
 	run_bad(v3_bin, 'bad_mut_receiver_immutable_pointer_binding',
 		'struct St {\nmut:\n\tvalue int\n}\n\nfn (mut s St) bump() {\n\ts.value++\n}\n\nfn main() {\n\tmut s := St{}\n\tp := &s\n\tp.bump()\n}\n',
 		'method `bump` requires a mutable receiver')
+	run_bad(v3_bin, 'bad_mut_receiver_or_temporary',
+		'struct St {\nmut:\n\tvalue int\n}\n\nfn (mut s St) bump() {\n\ts.value++\n}\n\nfn main() {\n\tmut values := {\n\t\t"item": St{}\n\t}\n\t(values["item"] or { St{} }).bump()\n}\n',
+		'method `bump` requires a mutable receiver')
 	run_bad(v3_bin, 'bad_shared_receiver_plain_value',
 		'struct St {}\n\nfn (shared s St) f() {}\n\nfn main() {\n\ts := St{}\n\ts.f()\n}\n',
 		'cannot use non-shared `St` as receiver')

--- a/vlib/v3/tests/review_checker_regressions_test.v
+++ b/vlib/v3/tests/review_checker_regressions_test.v
@@ -216,6 +216,16 @@ fn test_numeric_alias_returns_preserve_integer_float_direction() {
 	assert explicit_out == '1'
 }
 
+fn test_fn_value_integer_returns_require_matching_c_abi() {
+	v3_bin := build_v3_review_checker()
+	run_bad(v3_bin, 'bad_fn_value_integer_return_abi',
+		'fn wide() u64 {\n\treturn 257\n}\n\nfn invoke(callback fn () u8) u8 {\n\treturn callback()\n}\n\nfn main() {\n\t_ := invoke(wide)\n}\n',
+		'cannot use `fn() u64`')
+	out := run_good(v3_bin, 'good_fn_value_matching_integer_return_abi',
+		'fn letter() rune {\n\treturn `A`\n}\n\nfn invoke(callback fn () u32) u32 {\n\treturn callback()\n}\n\nfn main() {\n\tprintln(int_str(int(invoke(letter))))\n}\n')
+	assert out == '65'
+}
+
 fn test_alias_with_nested_type_separator_stays_alias() {
 	v3_bin := build_v3_review_checker()
 	out := run_good(v3_bin, 'good_alias_nested_type_separator',

--- a/vlib/v3/tests/review_checker_regressions_test.v
+++ b/vlib/v3/tests/review_checker_regressions_test.v
@@ -512,6 +512,45 @@ fn test_reject_unsmartcasted_unique_sum_variant_field() {
 	assert out == '7'
 }
 
+fn test_smartcasted_fn_sum_call_keeps_active_variant_arity() {
+	v3_bin := build_v3_review_checker()
+	run_bad(v3_bin, 'bad_smartcasted_fn_sum_variant_arity', 'type Callback = fn () int | fn (int) int
+
+fn no_args() int {
+	return 7
+}
+
+fn invoke(cb Callback) {
+	if cb is fn () int {
+		_ := cb(1)
+	}
+}
+
+fn main() {
+	invoke(Callback(no_args))
+}
+',
+		'argument count mismatch')
+	out := run_good(v3_bin, 'good_smartcasted_fn_sum_variant_arity', 'type Callback = fn () int | fn (int) int
+
+fn with_arg(value int) int {
+	return value
+}
+
+fn invoke(cb Callback) int {
+	if cb is fn (int) int {
+		return cb(7)
+	}
+	return 0
+}
+
+fn main() {
+	println(int_str(invoke(Callback(with_arg))))
+}
+')
+	assert out == '7'
+}
+
 fn test_generic_functions_report_missing_return() {
 	v3_bin := build_v3_review_checker()
 	run_bad(v3_bin, 'bad_generic_missing_return', 'fn f[T]() int {\n}\nfn main() {}\n',

--- a/vlib/v3/tests/review_checker_regressions_test.v
+++ b/vlib/v3/tests/review_checker_regressions_test.v
@@ -285,6 +285,61 @@ fn test_shared_receiver_and_arg_require_shared_bindings() {
 	assert ptr_out == '2'
 }
 
+fn test_method_receiver_rejects_extra_pointer_layers() {
+	v3_bin := build_v3_review_checker()
+	run_bad(v3_bin, 'bad_value_receiver_extra_pointer_layers', 'struct S {}
+
+fn (s S) value() int {
+	return 1
+}
+
+fn main() {
+	s := S{}
+	p := &s
+	pp := &p
+	_ := pp.value()
+}
+',
+		'cannot use receiver `&&S` as `S`')
+	run_bad(v3_bin, 'bad_pointer_receiver_extra_pointer_layers', 'struct S {}
+
+fn (s &S) value() int {
+	return 1
+}
+
+fn main() {
+	s := S{}
+	p := &s
+	pp := &p
+	ppp := &pp
+	_ := ppp.value()
+}
+',
+		'cannot use receiver `&&&S` as `&S`')
+	out := run_good(v3_bin, 'good_receiver_single_pointer_adjustment', 'struct S {
+	value int
+}
+
+fn (s S) by_value() int {
+	return s.value
+}
+
+fn (s &S) by_pointer() int {
+	return s.value
+}
+
+fn main() {
+	s := S{
+		value: 7
+	}
+	p := &s
+	println(int_str(p.by_value()))
+	println(int_str(s.by_pointer()))
+}
+')
+	assert out == '7\n7'
+}
+
 fn test_restrict_synthetic_hex_fallback_receivers() {
 	v3_bin := build_v3_review_checker()
 	run_bad(v3_bin, 'bad_struct_hex_method', 'struct S {}\nfn main() {\n\t_ := S{}.hex()\n}\n',

--- a/vlib/v3/tests/review_checker_regressions_test.v
+++ b/vlib/v3/tests/review_checker_regressions_test.v
@@ -179,6 +179,9 @@ fn test_reject_non_optional_or_and_wrapped_string_concat() {
 	run_bad(v3_bin, 'bad_non_optional_call_or_block',
 		'fn value() int {\n\treturn 1\n}\n\nfn main() {\n\tvalue() or { panic(err) }\n}\n',
 		'unexpected `or` block')
+	run_bad(v3_bin, 'bad_non_optional_infix_or_block',
+		'fn maybe() ?int {\n\treturn 1\n}\n\nfn main() {\n\t_ := maybe() == none or { false }\n}\n',
+		'unexpected `or` block, expression of type `bool` is not an Option or a Result')
 	run_bad(v3_bin, 'bad_optional_string_concat',
 		"fn maybe_name() ?string {\n\treturn 'Ada'\n}\n\nfn main() {\n\t_ := 'hello ' + maybe_name()\n}\n",
 		'operator `+` cannot concatenate `string` and `?string`')

--- a/vlib/v3/tests/review_checker_regressions_test.v
+++ b/vlib/v3/tests/review_checker_regressions_test.v
@@ -547,6 +547,9 @@ fn test_no_return_analysis_requires_resolved_builtin_target() {
 	run_bad(v3_bin, 'bad_shadowed_os_exit_missing_return',
 		'struct OsLike {}\nfn (x OsLike) exit() {}\nfn f(os OsLike) int {\n\tos.exit()\n}\nfn main() {}\n',
 		'missing return at end of function `f`')
+	run_bad(v3_bin, 'bad_local_os_exit_missing_return',
+		'struct OsLike {}\nfn (x OsLike) exit() {}\nfn f() int {\n\tos := OsLike{}\n\tos.exit()\n}\nfn main() {}\n',
+		'missing return at end of function `f`')
 }
 
 fn test_no_return_analysis_rejects_shadowed_builtin_fn_values() {

--- a/vlib/v3/tests/review_checker_regressions_test.v
+++ b/vlib/v3/tests/review_checker_regressions_test.v
@@ -172,6 +172,24 @@ fn test_none_ierror_values_lower_to_builtin_none() {
 	assert out == 'option'
 }
 
+fn test_reject_non_optional_or_and_wrapped_string_concat() {
+	v3_bin := build_v3_review_checker()
+	run_bad(v3_bin, 'bad_non_optional_literal_or_block', 'fn main() {\n\t_ := 1 or { 2 }\n}\n',
+		'unexpected `or` block')
+	run_bad(v3_bin, 'bad_non_optional_call_or_block',
+		'fn value() int {\n\treturn 1\n}\n\nfn main() {\n\tvalue() or { panic(err) }\n}\n',
+		'unexpected `or` block')
+	run_bad(v3_bin, 'bad_optional_string_concat',
+		"fn maybe_name() ?string {\n\treturn 'Ada'\n}\n\nfn main() {\n\t_ := 'hello ' + maybe_name()\n}\n",
+		'operator `+` cannot concatenate `string` and `?string`')
+	run_bad(v3_bin, 'bad_result_string_concat',
+		"fn result_name() !string {\n\treturn 'Ada'\n}\n\nfn main() {\n\t_ := result_name() + '!'\n}\n",
+		'operator `+` cannot concatenate `!string` and `string`')
+	out := run_good(v3_bin, 'good_map_or_and_unwrapped_string_concat',
+		"fn maybe_name() ?string {\n\treturn 'Ada'\n}\n\nfn main() {\n\tnames := {\n\t\t'first': 'Grace'\n\t}\n\tprintln(names['first'] or { 'unknown' })\n\tprintln('hello ' + (maybe_name() or { 'unknown' }))\n}\n")
+	assert out == 'Grace\nhello Ada'
+}
+
 fn test_rune_receiver_methods_resolve() {
 	v3_bin := build_v3_review_checker()
 	out := run_good(v3_bin, 'good_rune_receiver_methods',

--- a/vlib/v3/tests/review_checker_regressions_test.v
+++ b/vlib/v3/tests/review_checker_regressions_test.v
@@ -488,6 +488,25 @@ fn test_no_return_analysis_requires_resolved_builtin_target() {
 		'missing return at end of function `f`')
 }
 
+fn test_no_return_analysis_rejects_shadowed_builtin_fn_values() {
+	v3_bin := build_v3_review_checker()
+	run_bad(v3_bin, 'bad_shadowed_exit_fn_value_missing_return',
+		'fn f() int {\n\texit := fn () int { return 1 }\n\texit()\n}\nfn main() {}\n',
+		'missing return at end of function `f`')
+	run_bad(v3_bin, 'bad_shadowed_panic_fn_value_missing_return',
+		'fn f() int {\n\tpanic := fn () int { return 1 }\n\tpanic()\n}\nfn main() {}\n',
+		'missing return at end of function `f`')
+	run_bad(v3_bin, 'bad_nested_shadowed_exit_fn_value_missing_return',
+		'fn f() int {\n\t{\n\t\texit := fn () int { return 1 }\n\t\texit()\n\t}\n}\nfn main() {}\n',
+		'missing return at end of function `f`')
+	run_bad(v3_bin, 'bad_shadowed_exit_multi_return_branch',
+		'fn main() {\n\texit := fn () int { return 1 }\n\tflag := true\n\ta, b := if flag {\n\t\t1\n\t\t2\n\t} else {\n\t\texit()\n\t}\n\tprintln(int_str(a + b))\n}\n',
+		'multi-return assignment mismatch')
+	run_bad(v3_bin, 'bad_nested_shadowed_exit_multi_return_branch',
+		'fn main() {\n\tflag := true\n\ta, b := if flag {\n\t\t1\n\t\t2\n\t} else {\n\t\texit := fn () int { return 1 }\n\t\texit()\n\t}\n\tprintln(int_str(a + b))\n}\n',
+		'multi-return assignment mismatch')
+}
+
 fn test_returning_receiver_method_named_exit_keeps_value() {
 	v3_bin := build_v3_review_checker()
 	out := run_good(v3_bin, 'good_receiver_exit_return_value',

--- a/vlib/v3/tests/review_transform_regressions_test.v
+++ b/vlib/v3/tests/review_transform_regressions_test.v
@@ -544,6 +544,26 @@ fn main() {
 	assert out == 'ok'
 }
 
+fn test_const_nested_struct_channel_default_uses_runtime_init() {
+	v3_bin := build_v3_review_transform()
+	out := run_good(v3_bin, 'const_nested_struct_channel_default_runtime_init', 'struct Inner {
+	ch chan int
+}
+
+struct Outer {
+	inner Inner
+}
+
+const outer = Outer{}
+
+fn main() {
+	outer.inner.ch.close()
+	println("ok")
+}
+')
+	assert out == 'ok'
+}
+
 fn test_mut_pointer_capture_is_not_over_dereferenced() {
 	v3_bin := build_v3_review_transform()
 	// A `[mut p]` capture whose original type is already a pointer (`&S`) must stay a

--- a/vlib/v3/tests/review_transform_regressions_test.v
+++ b/vlib/v3/tests/review_transform_regressions_test.v
@@ -269,6 +269,35 @@ fn main() {
 	assert out == '9'
 }
 
+fn test_mut_interface_argument_shares_concrete_source() {
+	v3_bin := build_v3_review_transform()
+	out := run_good(v3_bin, 'mut_interface_argument_concrete_source', 'interface Counter {
+mut:
+	inc()
+}
+
+struct State {
+mut:
+	n int
+}
+
+fn (mut s State) inc() {
+	s.n++
+}
+
+fn bump(mut counter Counter) {
+	counter.inc()
+}
+
+fn main() {
+	mut state := State{}
+	bump(mut state)
+	println(int_str(state.n))
+}
+')
+	assert out == '1'
+}
+
 fn test_nested_generic_main_type_does_not_emit_imported_homonym_specialization() {
 	v3_bin := build_v3_review_transform()
 	generated := gen_c_from_project(v3_bin, 'nested_generic_main_type_collision', {

--- a/vlib/v3/tests/review_transform_regressions_test.v
+++ b/vlib/v3/tests/review_transform_regressions_test.v
@@ -144,6 +144,40 @@ fn test_lifted_fn_literal_mut_param_interpolation_derefs_value() {
 	assert out == '7'
 }
 
+fn test_interface_fn_field_argument_keeps_parameter_offset_zero() {
+	v3_bin := build_v3_review_transform()
+	out := run_good(v3_bin, 'interface_fn_field_argument_offset', 'interface Value {
+	value() int
+}
+
+struct Item {
+	n int
+}
+
+fn (item Item) value() int {
+	return item.n
+}
+
+struct Handler {
+	callback fn (Value)
+}
+
+fn print_value(value Value) {
+	println(int_str(value.value()))
+}
+
+fn main() {
+	handler := Handler{
+		callback: print_value
+	}
+	handler.callback(Item{
+		n: 7
+	})
+}
+')
+	assert out == '7'
+}
+
 fn test_folded_string_constant_ifs_keep_branch_scopes() {
 	v3_bin := build_v3_review_transform()
 	out := run_good(v3_bin, 'folded_string_constant_if_branch_scopes',

--- a/vlib/v3/tests/review_transform_regressions_test.v
+++ b/vlib/v3/tests/review_transform_regressions_test.v
@@ -659,6 +659,13 @@ fn test_struct_pointer_equality_is_semantic() {
 	assert out == 'true\nfalse\ntrue'
 }
 
+fn test_multilevel_struct_pointer_equality_uses_pointer_identity() {
+	v3_bin := build_v3_review_transform()
+	out := run_good(v3_bin, 'multilevel_struct_pointer_identity_equality',
+		"struct Person {\n\tname string\n}\n\nfn main() {\n\tmut left := &Person{\n\t\tname: 'same'\n\t}\n\tmut right := &Person{\n\t\tname: 'same'\n\t}\n\tleft_slot := &left\n\tright_slot := &right\n\tsame_slot := left_slot\n\tprintln(left_slot == right_slot)\n\tprintln(left_slot != right_slot)\n\tprintln(left_slot == same_slot)\n\tprintln(*left_slot == *right_slot)\n}\n")
+	assert out == 'false\ntrue\ntrue\ntrue'
+}
+
 fn test_struct_equality_with_interface_field_compiles() {
 	v3_bin := build_v3_review_transform()
 	out := run_good(v3_bin, 'struct_eq_interface_field',

--- a/vlib/v3/tests/review_transform_regressions_test.v
+++ b/vlib/v3/tests/review_transform_regressions_test.v
@@ -1872,6 +1872,38 @@ fn test_comptime_field_generic_calls_keep_resolved_field_types() {
 	assert out == '0'
 }
 
+fn test_comptime_field_generic_call_prefers_shadowing_local_type() {
+	v3_bin := build_v3_review_transform()
+	out := run_good(v3_bin, 'comptime_field_generic_shadowing_local', 'struct Sample {
+	values map[string]int
+}
+
+fn inferred_type[T](value T) string {
+	_ = value
+	return typeof[T]().name
+}
+
+fn main() {
+	sample := Sample{
+		values: {
+			"one": 1
+		}
+	}
+	$for field in Sample.fields {
+		$if field.is_map {
+			for key, value in sample.$(field.name) {
+				_ = key
+				_ = value
+			}
+			key := 1.5
+			println(inferred_type(key))
+		}
+	}
+}
+')
+	assert out == 'f64'
+}
+
 fn test_comptime_pointer_field_generic_local_uses_call_return_type() {
 	v3_bin := build_v3_review_transform()
 	out := run_good_project(v3_bin, 'comptime_pointer_field_call_return_type', {

--- a/vlib/v3/tests/review_transform_regressions_test.v
+++ b/vlib/v3/tests/review_transform_regressions_test.v
@@ -216,6 +216,45 @@ fn test_array_stringification_prefers_local_struct_over_imported_alias() {
 	assert out == "[Event{\n    kind: 7\n    arg: 'ok'\n}]"
 }
 
+fn test_imported_generic_alias_expands_in_declaration_module() {
+	v3_bin := build_v3_review_transform()
+	out := run_good_project(v3_bin, 'imported_generic_alias_decl_module', {
+		'v.mod':     "Module { name: 'imported_generic_alias_decl_module' }\n"
+		'a/types.v': 'module a
+
+pub struct Inner[T] {
+pub:
+	value T
+}
+
+pub type Box[T] = Inner[T]
+
+pub fn make() Box[int] {
+	return Inner[int]{
+		value: 7
+	}
+}
+'
+		'main.v':    'module main
+
+import a
+
+struct Inner[T] {
+	wrong T
+}
+
+fn read(box a.Box[int]) int {
+	return box.value
+}
+
+fn main() {
+	println(int_str(read(a.make())))
+}
+'
+	}, 'main.v')
+	assert out == '7'
+}
+
 fn test_for_in_smartcast_interface_field_keeps_interface_element_type() {
 	v3_bin := build_v3_review_transform()
 	out := run_good(v3_bin, 'for_in_smartcast_interface_field',

--- a/vlib/v3/tests/review_transform_regressions_test.v
+++ b/vlib/v3/tests/review_transform_regressions_test.v
@@ -455,6 +455,22 @@ fn test_const_array_allows_newline_separators_with_line_comments() {
 	assert out == '3\n2'
 }
 
+fn test_const_struct_channel_default_uses_runtime_init() {
+	v3_bin := build_v3_review_transform()
+	out := run_good(v3_bin, 'const_struct_channel_default_runtime_init', 'struct Holder {
+	ch chan int
+}
+
+const holder = Holder{}
+
+fn main() {
+	holder.ch.close()
+	println("ok")
+}
+')
+	assert out == 'ok'
+}
+
 fn test_mut_pointer_capture_is_not_over_dereferenced() {
 	v3_bin := build_v3_review_transform()
 	// A `[mut p]` capture whose original type is already a pointer (`&S`) must stay a

--- a/vlib/v3/tests/review_transform_regressions_test.v
+++ b/vlib/v3/tests/review_transform_regressions_test.v
@@ -1195,6 +1195,32 @@ fn main() {
 	assert out == 'Foo\ntrue\nBar\ntrue'
 }
 
+fn test_generic_typeof_idx_comparison_prunes_dead_branch() {
+	v3_bin := build_v3_review_transform()
+	out := run_good(v3_bin, 'generic_typeof_idx_comparison', 'fn pick_idx[T]() int {
+	$if typeof[T]().idx == typeof[int]().idx {
+		return 42
+	} $else {
+		return T.missing_method()
+	}
+}
+
+fn concrete_idx() int {
+	$if typeof[int]().idx == typeof[int]().idx {
+		return 1
+	} $else {
+		return 2
+	}
+}
+
+fn main() {
+	println(concrete_idx())
+	println(pick_idx[int]())
+}
+')
+	assert out == '1\n42'
+}
+
 fn test_mut_map_for_in_writeback_survives_continue_and_break() {
 	v3_bin := build_v3_review_transform()
 	out := run_good(v3_bin, 'mut_map_for_in_writeback_continue_break', 'struct Box {

--- a/vlib/v3/tests/single_file_test_input_test.v
+++ b/vlib/v3/tests/single_file_test_input_test.v
@@ -1,0 +1,50 @@
+import os
+import v3.cmdexec
+
+const single_file_test_v3_dir = os.dir(os.dir(@FILE))
+const single_file_test_vlib_dir = os.dir(single_file_test_v3_dir)
+const single_file_test_v3_src = os.join_path(single_file_test_v3_dir, 'v3.v')
+
+fn test_explicit_main_test_excludes_moduleless_sibling() {
+	root := os.join_path(os.vtmp_dir(), 'v3_single_file_test_input_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	v3_bin := os.join_path(root, 'v3')
+	build := cmdexec.run(@VEXE, ['-gc', 'none', '-path',
+		'${single_file_test_vlib_dir}|@vlib|@vmodules', '-o', v3_bin, single_file_test_v3_src])
+	assert build.exit_code == 0, build.output
+
+	test_file := os.join_path(root, 'selected_test.v')
+	os.write_file(test_file, 'module main
+
+fn test_selected_value() {
+	assert helper_value() == 42
+}
+') or {
+		panic(err)
+	}
+	os.write_file(os.join_path(root, 'helper.v'), 'module main
+
+fn helper_value() int {
+	return 42
+}
+') or {
+		panic(err)
+	}
+	os.write_file(os.join_path(root, 'bench.v'), 'fn helper_value() int {
+	return -1
+}
+
+fn main() {
+	println(helper_value())
+}
+') or {
+		panic(err)
+	}
+
+	result := cmdexec.run(v3_bin, ['-nocache', 'test', test_file])
+	assert result.exit_code == 0, result.output
+}

--- a/vlib/v3/tests/spawn_args_test.v
+++ b/vlib/v3/tests/spawn_args_test.v
@@ -184,6 +184,30 @@ fn main() {
 	assert !c_compact.contains('typedefstruct{int*a0;}takes_ptr_thread_args'), c_code
 }
 
+fn test_spawn_mutable_local_address_copies_value_into_heap_packet() {
+	v3_bin := build_v3()
+	c_code := gen_c(v3_bin, 'v3_spawn_mutable_local_address', '
+fn takes_ptr(value &int) {
+	println(*value)
+}
+
+fn main() {
+	for i in 0 .. 1 {
+		mut value := i + 9
+		_ := spawn takes_ptr(&value)
+		value = 10
+	}
+	println("ok")
+}
+	')
+	c_compact := compact_c(c_code)
+	assert c_compact.contains('typedefstruct{inta0;}takes_ptr_thread_args'), c_code
+	assert c_compact.contains('->a0=value;'), c_code
+	assert c_compact.contains('takes_ptr(&p->a0)'), c_code
+	assert !c_compact.contains('typedefstruct{int*a0;}takes_ptr_thread_args'), c_code
+	assert !c_compact.contains('->a0=&value;'), c_code
+}
+
 fn test_spawn_result_uses_checked_allocation_and_typed_join() {
 	v3_bin := build_v3()
 	c_code := gen_c(v3_bin, 'v3_spawn_checked_result', '

--- a/vlib/v3/transform/array.v
+++ b/vlib/v3/transform/array.v
@@ -58,6 +58,9 @@ fn (mut t Transformer) try_lower_array_repeat_call(_id flat.NodeId, node flat.No
 	base_id := t.a.child(&fn_node, 0)
 	base_type := t.node_type(base_id)
 	count_id := t.a.child(&node, 1)
+	if expanded := t.try_expand_interface_array_literal_repeat(base_id, count_id, base_type) {
+		return expanded
+	}
 	clean_base_type := t.normalize_type_alias(base_type.trim_left('&'))
 	if !isnil(t.tc) && clean_base_type.starts_with('[]') {
 		elem_type := clean_base_type[2..]
@@ -74,9 +77,6 @@ fn (mut t Transformer) try_lower_array_repeat_call(_id flat.NodeId, node flat.No
 		if base_is_owned_temporary {
 			return t.make_plain_array_repeat_value(base_id, count_id, clean_base_type)
 		}
-	}
-	if expanded := t.try_expand_interface_array_literal_repeat(base_id, count_id, base_type) {
-		return expanded
 	}
 	depth := array_repeat_clone_depth(base_type)
 	if depth == 0 {
@@ -97,8 +97,9 @@ fn (mut t Transformer) make_plain_array_repeat_value(base_id flat.NodeId, count_
 		'plain_array_repeat_source')
 	count := t.transform_expr_for_type(count_id, 'int')
 	repeat_selector := t.make_selector(stable_source, 'repeat_to_depth', '')
-	repeated := t.make_call_expr_typed(repeat_selector, arr2(count, t.make_int_literal(0)),
-		array_type)
+	clone_depth := array_repeat_clone_depth(array_type)
+	repeated := t.make_call_expr_typed(repeat_selector,
+		arr2(count, t.make_int_literal(clone_depth)), array_type)
 	out_name := t.new_temp('plain_array_repeat')
 	t.pending_stmts << t.make_decl_assign_typed(out_name, repeated, array_type)
 	t.pending_stmts << t.make_expr_stmt(t.make_call_typed('drop_owned', arr1(stable_source), 'void'))
@@ -1214,7 +1215,8 @@ fn (mut t Transformer) try_lower_array_append_stmt(id flat.NodeId) ?[]flat.NodeI
 		return result
 	}
 	value_name := t.new_temp('arr_val')
-	result << t.make_decl_assign_typed(value_name, rhs, elem_type)
+	value_type := t.shared_array_lhs_inner_type(lhs_id) or { elem_type }
+	result << t.make_decl_assign_typed(value_name, rhs, value_type)
 	push_call := t.make_call_typed('array_push', arr2(lhs_addr, t.make_prefix(.amp,
 		t.make_ident(value_name))), 'void')
 	if shared_inner := t.shared_array_lhs_inner_type(lhs_id) {
@@ -1622,6 +1624,13 @@ fn (t &Transformer) array_append_rhs_is_sum_variant_value(rhs_id flat.NodeId, rh
 	if !t.is_sum_type_name(elem_type) {
 		return false
 	}
+	mut clean_rhs := rhs_type.trim_space()
+	if clean_rhs.starts_with('!') || clean_rhs.starts_with('?') {
+		clean_rhs = clean_rhs[1..].trim_space()
+	}
+	if clean_rhs.starts_with('[]') && t.array_append_elem_types_match(clean_rhs[2..], elem_type) {
+		return false
+	}
 	candidate := t.array_append_rhs_variant_candidate(rhs_id, rhs_type)
 	if candidate.len == 0 {
 		return false
@@ -1679,6 +1688,11 @@ fn (t &Transformer) array_append_literal_should_push_many(rhs_id flat.NodeId, el
 	if !elem_type.starts_with('[]') && !t.is_fixed_array_type(elem_type) {
 		return true
 	}
+	// With an array-shaped destination element, an empty literal is the single empty
+	// element (`mut a := [][]int{}; a << []`), not a zero-element spread.
+	if node.children_count == 0 {
+		return false
+	}
 	return t.array_append_literal_children_match_elem(rhs_id, elem_type)
 }
 
@@ -1690,6 +1704,13 @@ fn (t &Transformer) array_append_rhs_is_sum_array_variant(rhs_type string, elem_
 		clean_rhs = clean_rhs[3..].trim_space()
 	}
 	if clean_rhs.len == 0 {
+		return false
+	}
+	// An array with exactly the destination's element type is the push-many
+	// form (`[]Value << []Value`), even when `[]Value` also appears recursively
+	// as a variant of `Value`. Distinct array variants such as `[]int` appended
+	// to `[]Any` remain single sum-type elements.
+	if clean_rhs.starts_with('[]') && t.array_append_elem_types_match(clean_rhs[2..], elem_type) {
 		return false
 	}
 	for variant in variants {
@@ -1896,7 +1917,12 @@ fn (mut t Transformer) array_get_ptr(base flat.NodeId, index flat.NodeId, elem_t
 }
 
 fn (t &Transformer) array_get_base_is_fixed_array(base flat.NodeId) bool {
-	mut base_type := t.node_type(base).trim_space()
+	node := t.a.node(base)
+	mut base_type := if node.kind == .ident && t.var_type(node.value).len > 0 {
+		t.var_type(node.value).trim_space()
+	} else {
+		t.node_type(base).trim_space()
+	}
 	if base_type.len == 0 {
 		base_type = t.original_expr_type(base).trim_space()
 	}
@@ -2130,7 +2156,9 @@ fn (mut t Transformer) lower_array_map_call(node flat.Node, fn_node flat.Node, b
 		}
 	}
 	if mapped_source_node.kind == .selector {
-		selector_type := t.resolve_selector_type(mapped_source_node)
+		selector_type := t.lookup_struct_field_type(elem_type, mapped_source_node.value) or {
+			t.resolve_selector_type(mapped_source_node)
+		}
 		if selector_type.len > 0 {
 			direct_selector_type = selector_type
 			result_elem_type = selector_type
@@ -2195,10 +2223,12 @@ fn (mut t Transformer) lower_array_map_call(node flat.Node, fn_node flat.Node, b
 	if direct_selector_type.len > 0 && map_fn_name.len == 0 {
 		result_elem_type = direct_selector_type
 	}
-	if mapped_expr_node := t.selector_expr_node(mapped_expr) {
-		selector_type := t.resolve_selector_type(mapped_expr_node)
-		if selector_type.len > 0 {
-			result_elem_type = selector_type
+	if direct_selector_type.len == 0 {
+		if mapped_expr_node := t.selector_expr_node(mapped_expr) {
+			selector_type := t.resolve_selector_type(mapped_expr_node)
+			if selector_type.len > 0 {
+				result_elem_type = selector_type
+			}
 		}
 	}
 	if result_elem_type.len == 0 {

--- a/vlib/v3/transform/comptime.v
+++ b/vlib/v3/transform/comptime.v
@@ -2076,8 +2076,10 @@ fn (mut t Transformer) comptime_field_call_generic_args(node flat.Node, mut chil
 		}
 		arg := t.a.nodes[int(arg_id)]
 		mut arg_type := if arg.kind == .ident {
-			t.local_decl_type_before(arg.value, arg_id) or {
-				t.generic_call_arg_type_for_inference(arg_id)
+			t.comptime_reflected_for_in_local_type(arg.value, fm) or {
+				t.local_decl_type_before(arg.value, arg_id) or {
+					t.generic_call_arg_type_for_inference(arg_id)
+				}
 			}
 		} else {
 			t.generic_call_arg_type_for_inference(arg_id)
@@ -2119,6 +2121,50 @@ fn (mut t Transformer) comptime_field_call_generic_args(node flat.Node, mut chil
 		t.set_node_value(int(children[0]), spec_name)
 	}
 	return ''
+}
+
+fn (t &Transformer) comptime_reflected_for_in_local_type(name string, fm FieldMeta) ?string {
+	if name.len == 0 {
+		return none
+	}
+	iter_type := t.comptime_normalize_type_alias_chain(fm.comptime_typ)
+	if !iter_type.starts_with('map[') {
+		return none
+	}
+	for node in t.a.nodes {
+		if node.kind != .for_in_stmt || node.children_count < 3 {
+			continue
+		}
+		key := t.a.child_node(&node, 0)
+		value := t.a.child_node(&node, 1)
+		container_id := t.a.child(&node, 2)
+		if !t.subtree_has_comptime_field_selector(container_id) {
+			continue
+		}
+		if key.kind == .ident && key.value == name {
+			return t.map_key_type(iter_type)
+		}
+		if value.kind == .ident && value.value == name {
+			return t.map_value_type(iter_type)
+		}
+	}
+	return none
+}
+
+fn (t &Transformer) subtree_has_comptime_field_selector(id flat.NodeId) bool {
+	if int(id) < 0 || int(id) >= t.a.nodes.len {
+		return false
+	}
+	node := t.a.nodes[int(id)]
+	if node.kind == .selector && node.value == '$' {
+		return true
+	}
+	for i in 0 .. node.children_count {
+		if t.subtree_has_comptime_field_selector(t.a.child(&node, i)) {
+			return true
+		}
+	}
+	return false
 }
 
 fn (mut t Transformer) make_comptime_enum_value(item EnumValueMeta) flat.NodeId {
@@ -2985,6 +3031,45 @@ fn (mut t Transformer) clone_field_subst_scoped(id flat.NodeId, var_name string,
 	if node.children_count == 0 {
 		return t.a.add_node(node)
 	}
+	if node.kind == .match_stmt && node.children_count > 1 {
+		subject := t.a.child_node(&node, 0)
+		if subject.kind == .selector && subject.value == 'typ' && subject.children_count > 0 {
+			base := t.a.child_node(subject, 0)
+			if base.kind == .ident && base.value == var_name {
+				mut else_branch := flat.empty_node
+				for i in 1 .. node.children_count {
+					branch_id := t.a.child(&node, i)
+					branch := t.a.nodes[int(branch_id)]
+					if branch.kind != .match_branch {
+						continue
+					}
+					if branch.value == 'else' {
+						else_branch = branch_id
+						continue
+					}
+					n_conds := t.count_conds(branch)
+					mut selected := false
+					for j in 0 .. n_conds {
+						pattern := t.type_pattern_name(t.a.child(&branch, j))
+						matches := t.comptime_type_matches(fm.comptime_typ, pattern) or { false }
+						if pattern.len > 0 && matches {
+							selected = true
+							break
+						}
+					}
+					if selected {
+						return t.clone_field_match_branch_body(branch, n_conds, var_name, fm,
+							inner_vars)
+					}
+				}
+				if int(else_branch) >= 0 {
+					branch := t.a.nodes[int(else_branch)]
+					return t.clone_field_match_branch_body(branch, 0, var_name, fm, inner_vars)
+				}
+				return none
+			}
+		}
+	}
 	if node.kind == .prefix && node.op == .amp && node.children_count > 0
 		&& t.subtree_has_reflected_typeof_idx(t.a.child(&node, 0), var_name) {
 		mut pointee := fm.comptime_typ.trim_space()
@@ -3110,6 +3195,16 @@ fn (mut t Transformer) clone_field_subst_scoped(id flat.NodeId, var_name string,
 		return t.clone_field_subst_children_with_value(node, var_name, fm, inner_vars, cond)
 	}
 	return t.clone_field_subst_children(node, var_name, fm, inner_vars)
+}
+
+fn (mut t Transformer) clone_field_match_branch_body(branch flat.Node, body_start int, var_name string, fm FieldMeta, inner_vars []string) flat.NodeId {
+	mut body := []flat.NodeId{}
+	for i in body_start .. branch.children_count {
+		if child := t.clone_field_subst_scoped(t.a.child(&branch, i), var_name, fm, inner_vars) {
+			body << child
+		}
+	}
+	return t.make_block(body)
 }
 
 fn (t &Transformer) comptime_field_attrs_condition(id flat.NodeId, var_name string, fm FieldMeta) ?bool {

--- a/vlib/v3/transform/comptime.v
+++ b/vlib/v3/transform/comptime.v
@@ -2082,8 +2082,8 @@ fn (mut t Transformer) comptime_field_call_generic_args(node flat.Node, mut chil
 		}
 		arg := t.a.nodes[int(arg_id)]
 		mut arg_type := if arg.kind == .ident {
-			t.comptime_reflected_for_in_local_type(arg.value, fm) or {
-				t.local_decl_type_before(arg.value, arg_id) or {
+			t.local_decl_type_before(arg.value, arg_id) or {
+				t.comptime_reflected_for_in_local_type(arg.value, fm) or {
 					t.generic_call_arg_type_for_inference(arg_id)
 				}
 			}

--- a/vlib/v3/transform/expr.v
+++ b/vlib/v3/transform/expr.v
@@ -18,6 +18,9 @@ fn (mut t Transformer) transform_infix_string_ops(_id flat.NodeId, node flat.Nod
 
 	lhs_id := t.a.children[node.children_start]
 	rhs_id := t.a.children[node.children_start + 1]
+	if node.op in [.eq, .ne] && (t.expr_is_char_const(lhs_id) || t.expr_is_char_const(rhs_id)) {
+		return none
+	}
 	lhs_raw_type := t.node_type(lhs_id)
 	rhs_raw_type := t.node_type(rhs_id)
 	lhs_clean_type := t.normalize_type_alias(lhs_raw_type)
@@ -137,6 +140,31 @@ fn (mut t Transformer) transform_infix_string_ops(_id flat.NodeId, node flat.Nod
 	return result
 }
 
+fn (t &Transformer) expr_is_char_const(id flat.NodeId) bool {
+	if int(id) < 0 || int(id) >= t.a.nodes.len {
+		return false
+	}
+	node := t.a.nodes[int(id)]
+	if node.kind == .char_literal {
+		return true
+	}
+	mut name := ''
+	if node.kind == .ident {
+		name = node.value
+	} else if node.kind == .selector && node.children_count > 0 {
+		base := t.a.child_node(&node, 0)
+		if base.kind == .ident {
+			name = '${base.value}.${node.value}'
+		}
+	}
+	if name.len == 0 || isnil(t.tc) {
+		return false
+	}
+	key := t.const_type_key_in_context(name, t.cur_module, t.cur_file) or { return false }
+	expr_id := t.tc.const_exprs[key] or { return false }
+	return t.a.nodes[int(expr_id)].kind == .char_literal
+}
+
 fn (t &Transformer) expr_or_selector_base_has_smartcast(id flat.NodeId) bool {
 	if int(id) < 0 || int(id) >= t.a.nodes.len {
 		return false
@@ -160,16 +188,38 @@ fn (mut t Transformer) transform_infix_array_ops(_id flat.NodeId, node flat.Node
 	rhs_id := t.a.children[node.children_start + 1]
 	lhs_raw_type := t.node_type(lhs_id)
 	rhs_raw_type := t.node_type(rhs_id)
-	lhs_is_array_ptr := t.equality_type_is_array_pointer(lhs_raw_type)
-	rhs_is_array_ptr := t.equality_type_is_array_pointer(rhs_raw_type)
+	mut effective_lhs_raw_type := lhs_raw_type
+	mut effective_rhs_raw_type := rhs_raw_type
+	checker_lhs_type := t.raw_checker_node_type(lhs_id)
+	checker_rhs_type := t.raw_checker_node_type(rhs_id)
+	if !t.is_fixed_array_type(t.membership_container_type(effective_lhs_raw_type))
+		&& t.is_fixed_array_type(t.membership_container_type(checker_lhs_type)) {
+		effective_lhs_raw_type = checker_lhs_type
+	}
+	if !t.is_fixed_array_type(t.membership_container_type(effective_lhs_raw_type)) {
+		if map_value_type := t.array_comparison_map_index_value_type(lhs_id) {
+			effective_lhs_raw_type = map_value_type
+		}
+	}
+	if !t.is_fixed_array_type(t.membership_container_type(effective_rhs_raw_type))
+		&& t.is_fixed_array_type(t.membership_container_type(checker_rhs_type)) {
+		effective_rhs_raw_type = checker_rhs_type
+	}
+	if !t.is_fixed_array_type(t.membership_container_type(effective_rhs_raw_type)) {
+		if map_value_type := t.array_comparison_map_index_value_type(rhs_id) {
+			effective_rhs_raw_type = map_value_type
+		}
+	}
+	lhs_is_array_ptr := t.equality_type_is_array_pointer(effective_lhs_raw_type)
+	rhs_is_array_ptr := t.equality_type_is_array_pointer(effective_rhs_raw_type)
 	if lhs_is_array_ptr && rhs_is_array_ptr {
 		return none
 	}
 	if _ := t.operator_alias_type_for_operand(lhs_id, node.op) {
 		return none
 	}
-	mut lhs_type := t.membership_container_type(lhs_raw_type)
-	mut rhs_type := t.membership_container_type(rhs_raw_type)
+	mut lhs_type := t.membership_container_type(effective_lhs_raw_type)
+	mut rhs_type := t.membership_container_type(effective_rhs_raw_type)
 	mut lhs_is_fixed := t.is_fixed_array_type(lhs_type)
 	mut rhs_is_fixed := t.is_fixed_array_type(rhs_type)
 	mut fixed_lhs_as_array := flat.empty_node
@@ -271,6 +321,30 @@ fn (mut t Transformer) transform_infix_array_ops(_id flat.NodeId, node flat.Node
 		return t.make_prefix(.not, eq_call)
 	}
 	return eq_call
+}
+
+fn (t &Transformer) array_comparison_map_index_value_type(id flat.NodeId) ?string {
+	if int(id) < 0 || int(id) >= t.a.nodes.len {
+		return none
+	}
+	node := t.a.nodes[int(id)]
+	if node.kind != .index || node.children_count == 0 {
+		return none
+	}
+	base_id := t.a.child(&node, 0)
+	base := t.a.nodes[int(base_id)]
+	mut base_type := if base.kind == .ident { t.var_type(base.value) } else { '' }
+	if base_type.len == 0 || base_type == 'unknown' {
+		base_type = t.raw_checker_node_type(base_id)
+	}
+	if base_type.len == 0 || base_type == 'unknown' {
+		base_type = t.node_type(base_id)
+	}
+	_, value_type := t.map_type_parts(t.normalize_type_alias(base_type))
+	if t.is_fixed_array_type(value_type) {
+		return value_type
+	}
+	return none
 }
 
 fn (t &Transformer) contextual_array_comparison_type(id flat.NodeId, own_type string, other_type string) string {
@@ -614,18 +688,18 @@ fn (mut t Transformer) transform_infix_struct_ops(_id flat.NodeId, node flat.Nod
 			lhs_type = lhs_type[1..]
 		}
 	}
-	mut struct_type := t.struct_lookup_name(lhs_type)
+	mut struct_type := ''
+	mut is_alias_operator := false
+	if alias_type := t.operator_alias_type_for_operand(lhs_id, node.op) {
+		struct_type = alias_type
+		is_alias_operator = true
+	} else {
+		struct_type = t.struct_lookup_name(lhs_type)
+	}
 	if struct_type.len == 0 {
 		// Generic-struct instance operand (e.g. `Vec4[f32]`): keep the instance type
 		// so the operator lowers to the monomorphized method (`vec__Vec4_f32__plus`).
 		struct_type = t.generic_struct_instance_name(lhs_type)
-	}
-	mut is_alias_operator := false
-	if struct_type.len == 0 {
-		if alias_type := t.operator_alias_type_for_operand(lhs_id, node.op) {
-			struct_type = alias_type
-			is_alias_operator = true
-		}
 	}
 	if struct_type.len == 0 {
 		return none
@@ -725,8 +799,8 @@ fn (mut t Transformer) transform_pointer_value_struct_eq(node flat.Node, lhs_id 
 	}
 	lhs_type := t.node_type(lhs_id)
 	rhs_type := t.node_type(rhs_id)
-	lhs_clean := if lhs_type.starts_with('&') { lhs_type[1..] } else { lhs_type }
-	rhs_clean := if rhs_type.starts_with('&') { rhs_type[1..] } else { rhs_type }
+	lhs_clean := t.trim_all_pointer_type(lhs_type)
+	rhs_clean := t.trim_all_pointer_type(rhs_type)
 	lhs_struct := t.struct_lookup_name(lhs_clean)
 	rhs_struct := t.struct_lookup_name(rhs_clean)
 	if lhs_struct.len == 0 || rhs_struct.len == 0 {
@@ -887,9 +961,7 @@ fn (t &Transformer) infix_operand_is_pointer(id flat.NodeId) bool {
 	}
 	if !isnil(t.tc) {
 		if typ := t.tc.expr_type(id) {
-			if typ is types.Pointer {
-				return true
-			}
+			return typ is types.Pointer
 		}
 		if t.tc.resolve_type(id) is types.Pointer {
 			return true
@@ -963,6 +1035,33 @@ fn (t &Transformer) operator_alias_type_for_operand(id flat.NodeId, op flat.Op) 
 		return none
 	}
 	node := t.a.nodes[int(id)]
+	if node.kind == .index && node.children_count > 0 {
+		base_id := t.a.child(&node, 0)
+		if raw_base := t.raw_var_type_for_expr(base_id) {
+			mut elem := raw_base.trim_space()
+			if elem.starts_with('mut ') {
+				elem = elem[4..].trim_space()
+			}
+			elem = t.normalize_type_alias(elem)
+			if elem.starts_with('&') {
+				elem = t.normalize_type_alias(elem[1..].trim_space())
+			}
+			if elem.starts_with('[]') {
+				elem = elem[2..].trim_space()
+			} else if elem.starts_with('map[') {
+				if bracket_end := elem.index(']') {
+					elem = elem[bracket_end + 1..].trim_space()
+				}
+			}
+			clean := t.trim_pointer_type(elem)
+			if clean.len > 0 && t.is_type_alias_name(clean) {
+				if _ := t.struct_operator_call_info_any(clean, op) {
+					return clean
+				}
+			}
+			return none
+		}
+	}
 	mut candidates := []string{cap: 3}
 	raw_type := t.raw_checker_node_type(id)
 	if raw_type.len > 0 {
@@ -1384,8 +1483,21 @@ fn (mut t Transformer) transform_infix_sum_ops(_id flat.NodeId, node flat.Node) 
 	}
 	lhs_type = t.normalize_type_alias(lhs_type)
 	rhs_type = t.normalize_type_alias(rhs_type)
-	if !t.is_sum_type_name(lhs_type) || !t.is_sum_type_name(rhs_type) {
+	// A specialized generic call can retain its open `T` return type on the
+	// call node, even though the surrounding comparison has already resolved
+	// the other operand to the concrete sum type.  The checker has validated
+	// the comparison, so one concrete sum operand is enough to provide the
+	// lowering type for both sides.
+	lhs_is_sum := t.is_sum_type_name(lhs_type)
+	rhs_is_sum := t.is_sum_type_name(rhs_type)
+	if !lhs_is_sum && !rhs_is_sum {
 		return none
+	}
+	if lhs_is_sum != rhs_is_sum {
+		unresolved_type := if lhs_is_sum { rhs_type } else { lhs_type }
+		if !t.generic_arg_is_unresolved(unresolved_type) {
+			return none
+		}
 	}
 	sum_type := t.sum_eq_type_for_operands(lhs_type, rhs_type)
 	if sum_type.len == 0 {
@@ -1446,13 +1558,24 @@ fn (mut t Transformer) transform_infix_optional_none_ops(_id flat.NodeId, node f
 	} else if rhs.kind == .nil_literal && t.is_optional_type_name(t.node_type(lhs_id)) {
 		opt_id = lhs_id
 	} else {
-		lhs_type := t.node_type(lhs_id)
-		rhs_type := t.node_type(rhs_id)
+		mut lhs_type := t.raw_expr_type_without_smartcast(lhs_id)
+		mut rhs_type := t.raw_expr_type_without_smartcast(rhs_id)
+		if !t.is_optional_type_name(lhs_type) {
+			lhs_type = t.node_type(lhs_id)
+		}
+		if !t.is_optional_type_name(rhs_type) {
+			rhs_type = t.node_type(rhs_id)
+		}
 		if !t.is_optional_type_name(lhs_type) || !t.is_optional_type_name(rhs_type) {
 			return none
 		}
-		lhs_value := t.stable_expr_for_reuse(lhs_id)
-		rhs_value := t.stable_expr_for_reuse(rhs_id)
+		// This operation compares the Optional_T wrappers themselves. A payload
+		// smartcast left by an earlier assignment must not leak into this comparison
+		// or into a following wrapper comparison in the same logical condition.
+		t.invalidate_smartcast_for_lvalue(lhs_id)
+		t.invalidate_smartcast_for_lvalue(rhs_id)
+		lhs_value := t.stable_optional_wrapper_expr_for_reuse(lhs_id, lhs_type, 'opt_eq_lhs')
+		rhs_value := t.stable_optional_wrapper_expr_for_reuse(rhs_id, rhs_type, 'opt_eq_rhs')
 		eq := t.make_optional_semantic_eq_expr(lhs_value, rhs_value, lhs_type, rhs_type, []string{})
 		if node.op == .ne {
 			return t.make_prefix(.not, t.make_paren(eq))
@@ -1490,7 +1613,7 @@ fn (mut t Transformer) transform_infix_optional_none_ops(_id flat.NodeId, node f
 		opt_id = transformed_opt
 		opt_type = transformed_type
 	}
-	mut opt_expr := t.transform_expr(opt_id)
+	mut opt_expr := t.transform_optional_wrapper_expr(opt_id)
 	opt_expr = t.optional_source_value_expr(opt_id, opt_expr, opt_type)
 	ok := t.make_selector(opt_expr, 'ok', 'bool')
 	if node.op == .eq {
@@ -1499,10 +1622,63 @@ fn (mut t Transformer) transform_infix_optional_none_ops(_id flat.NodeId, node f
 	return ok
 }
 
+// transform_optional_wrapper_expr preserves the Optional_T wrapper when a prior
+// payload assignment has left an option smartcast active for the same expression.
+// Wrapper-level operations such as `x == none` and optional equality must inspect
+// `.ok` on the wrapper, not on the smartcasted `.value` payload.
+fn (mut t Transformer) transform_optional_wrapper_expr(id flat.NodeId) flat.NodeId {
+	if int(id) < 0 || int(id) >= t.a.nodes.len {
+		return id
+	}
+	mut source_id := id
+	for int(source_id) >= 0 && int(source_id) < t.a.nodes.len {
+		source := t.a.nodes[int(source_id)]
+		if source.kind != .selector || source.value != 'value' || source.children_count == 0 {
+			break
+		}
+		base_id := t.a.child(&source, 0)
+		if !t.is_optional_type_name(t.raw_expr_type_without_smartcast(base_id)) {
+			break
+		}
+		source_id = base_id
+	}
+	raw_type := t.raw_expr_type_without_smartcast(source_id)
+	if t.is_optional_type_name(raw_type) && t.a.nodes[int(id)].kind in [.ident, .selector] {
+		// `source_id` is already the wrapper expression with any redundant top-level
+		// payload selectors removed. Rebuilding a selector here would transform its
+		// base again and could apply the same assignment smartcast a second time
+		// (`foo?.field` becoming `foo.value.value.field`).
+		plain := source_id
+		t.set_node_typ(int(plain), raw_type)
+		mut params := t.a.nodes[int(plain)].generic_params().clone()
+		params << optional_wrapper_access_marker
+		t.set_node_generic_params(int(plain), params)
+		return plain
+	}
+	return t.transform_expr(id)
+}
+
+fn (mut t Transformer) stable_optional_wrapper_expr_for_reuse(id flat.NodeId, typ string, prefix string) flat.NodeId {
+	expr := t.transform_optional_wrapper_expr(id)
+	tmp_name := t.new_temp(prefix)
+	t.pending_stmts << t.make_decl_assign_typed(tmp_name, expr, typ)
+	return t.make_ident(tmp_name)
+}
+
 // struct_lookup_name supports struct lookup name handling for Transformer.
 fn (t &Transformer) struct_lookup_name(type_name string) string {
 	if type_name.len == 0 {
 		return ''
+	}
+	// Resolve aliases before consulting the struct indexes. Large programs can
+	// contain a struct whose short name collides with an imported alias (notably
+	// `Type` beside `ast.Type = u32`). Treating the alias as that struct expands a
+	// scalar equality into field selectors on the generated C integer.
+	if t.is_type_alias_name(type_name) {
+		unalias := t.normalize_type_alias(type_name)
+		if unalias != type_name {
+			return t.struct_lookup_name(unalias)
+		}
 	}
 	// Primitives, arrays and maps are never struct names. Bail before the qualified-name
 	// concatenation below — this runs for every infix operand, so the saved allocation
@@ -1709,6 +1885,28 @@ fn (mut t Transformer) transform_in_expr(id flat.NodeId, node flat.Node) flat.No
 }
 
 fn (t &Transformer) array_literal_membership_elem_type(lhs_id flat.NodeId, rhs_id flat.NodeId, rhs flat.Node) string {
+	if rhs.children_count > 0 {
+		first := t.a.nodes[int(t.a.children[rhs.children_start])]
+		if first.kind == .enum_val && first.typ.len == 0 {
+			// An unqualified enum shorthand has no standalone type; its membership
+			// needle provides the context before the literal defaults to `[]int`.
+			lhs_type := t.node_type(lhs_id)
+			if lhs_type.len > 0 && lhs_type != 'unknown' {
+				return lhs_type
+			}
+		}
+	}
+	// The flat literal type can lose a module qualifier in a large import graph
+	// (`[]ast.Type` becoming `[]Type`) and collide with an unrelated local struct.
+	// When the checker's literal element agrees with the needle after unaliasing,
+	// retain the needle's authoritative spelling.
+	lhs_type := t.node_type(lhs_id)
+	checker_rhs_type := t.membership_container_type(t.raw_checker_node_type(rhs_id))
+	if lhs_type.len > 0 && lhs_type != 'unknown' && checker_rhs_type.starts_with('[]')
+		&& checker_rhs_type.len > 2
+		&& t.normalize_type_alias(lhs_type) == t.normalize_type_alias(checker_rhs_type[2..]) {
+		return lhs_type
+	}
 	rhs_type := t.membership_container_type(t.node_type(rhs_id))
 	if rhs_type.starts_with('[]') && rhs_type.len > 2 {
 		return rhs_type[2..]
@@ -1716,15 +1914,17 @@ fn (t &Transformer) array_literal_membership_elem_type(lhs_id flat.NodeId, rhs_i
 	if rhs.typ.starts_with('[]') && rhs.typ.len > 2 {
 		return rhs.typ[2..]
 	}
+	// In `value in [.a, .b]`, the value determines which enum owns the
+	// shorthand fields. Resolving the first shorthand on its own is ambiguous
+	// in large programs where many enums contain the same field name.
+	if lhs_type.len > 0 && lhs_type != 'unknown' {
+		return lhs_type
+	}
 	if rhs.children_count > 0 {
 		first_type := t.node_type(t.a.children[rhs.children_start])
 		if first_type.len > 0 && first_type != 'unknown' {
 			return first_type
 		}
-	}
-	lhs_type := t.node_type(lhs_id)
-	if lhs_type.len > 0 && lhs_type != 'unknown' {
-		return lhs_type
 	}
 	return 'int'
 }
@@ -1757,7 +1957,13 @@ fn (mut t Transformer) lower_type_pattern_membership(lhs_id flat.NodeId, rhs fla
 		return none
 	}
 	mut patterns := []string{cap: int(rhs.children_count)}
-	mut sum_name := t.trim_pointer_type(t.original_expr_type(lhs_id))
+	mut sum_name := ''
+	if sc := t.find_smartcast(t.expr_key(lhs_id)) {
+		sum_name = t.trim_pointer_type(t.smartcast_target_type(sc))
+	}
+	if sum_name.len == 0 {
+		sum_name = t.trim_pointer_type(t.original_expr_type(lhs_id))
+	}
 	if !t.is_sum_type_name(sum_name) {
 		sum_name = t.trim_pointer_type(t.node_type(lhs_id))
 	}
@@ -1781,8 +1987,14 @@ fn (mut t Transformer) lower_type_pattern_membership(lhs_id flat.NodeId, rhs fla
 	if !t.is_sum_type_name(sum_name) {
 		return none
 	}
-	lhs_type := t.original_expr_type(lhs_id)
 	base := t.stable_expr_for_reuse(lhs_id)
+	// A non-trivial lhs is materialized as a value temp above. Use that temp's
+	// storage type for the tag checks; retaining the source pointer type here
+	// makes the generated checks dereference the value temp a second time.
+	mut lhs_type := t.node_type(base)
+	if lhs_type.len == 0 || lhs_type == 'unknown' {
+		lhs_type = t.original_expr_type(lhs_id)
+	}
 	mut chain := flat.empty_node
 	for pattern in patterns {
 		cmp := t.make_sum_type_pattern_check(base, lhs_type, sum_name, pattern) or { return none }
@@ -1861,17 +2073,20 @@ fn (mut t Transformer) lower_array_membership_expr(base_id flat.NodeId, needle_i
 	}
 	mut base := flat.empty_node
 	mut needle := flat.empty_node
+	mut prefix := []flat.NodeId{}
 	if receiver_first {
 		base = t.stable_array_expr_for_membership(base_id, base_type, clean_base_type)
+		t.drain_pending(mut prefix)
 		needle = t.stable_transformed_expr_for_reuse(t.transform_expr_for_type(needle_id, elem_type),
 			elem_type, 'contains_needle')
+		t.drain_pending(mut prefix)
 	} else {
 		needle = t.stable_transformed_expr_for_reuse(t.transform_expr_for_type(needle_id, elem_type),
 			elem_type, 'contains_needle')
+		t.drain_pending(mut prefix)
 		base = t.stable_array_expr_for_membership(base_id, base_type, clean_base_type)
+		t.drain_pending(mut prefix)
 	}
-	mut prefix := []flat.NodeId{}
-	t.drain_pending(mut prefix)
 	result_name := t.new_temp('contains')
 	idx_name := t.new_temp('contains_idx')
 	prefix << t.make_decl_assign_typed(result_name, t.make_bool_literal(false), 'bool')
@@ -1924,15 +2139,18 @@ fn (mut t Transformer) lower_array_index_expr(base_id flat.NodeId, needle_id fla
 	}
 	mut base := flat.empty_node
 	mut needle := flat.empty_node
+	mut prefix := []flat.NodeId{}
 	if receiver_first {
 		base = t.stable_array_expr_for_membership(base_id, base_type, clean_base_type)
+		t.drain_pending(mut prefix)
 		needle = t.stable_expr_for_reuse(needle_id)
+		t.drain_pending(mut prefix)
 	} else {
 		needle = t.stable_expr_for_reuse(needle_id)
+		t.drain_pending(mut prefix)
 		base = t.stable_array_expr_for_membership(base_id, base_type, clean_base_type)
+		t.drain_pending(mut prefix)
 	}
-	mut prefix := []flat.NodeId{}
-	t.drain_pending(mut prefix)
 	result_name := t.new_temp('index')
 	idx_name := t.new_temp('index_idx')
 	prefix << t.make_decl_assign_typed(result_name, t.make_int_literal(-1), 'int')
@@ -1986,15 +2204,18 @@ fn (mut t Transformer) lower_array_last_index_expr(base_id flat.NodeId, needle_i
 	}
 	mut base := flat.empty_node
 	mut needle := flat.empty_node
+	mut prefix := []flat.NodeId{}
 	if receiver_first {
 		base = t.stable_array_expr_for_membership(base_id, base_type, clean_base_type)
+		t.drain_pending(mut prefix)
 		needle = t.stable_expr_for_reuse(needle_id)
+		t.drain_pending(mut prefix)
 	} else {
 		needle = t.stable_expr_for_reuse(needle_id)
+		t.drain_pending(mut prefix)
 		base = t.stable_array_expr_for_membership(base_id, base_type, clean_base_type)
+		t.drain_pending(mut prefix)
 	}
-	mut prefix := []flat.NodeId{}
-	t.drain_pending(mut prefix)
 	result_name := t.new_temp('last_index')
 	idx_name := t.new_temp('last_index_idx')
 	prefix << t.make_decl_assign_typed(result_name, t.make_int_literal(-1), 'int')
@@ -2543,7 +2764,10 @@ fn (t &Transformer) type_needs_semantic_eq(typ string) bool {
 		return true
 	}
 	if clean.starts_with('[]') {
-		return t.type_needs_semantic_eq(clean[2..])
+		// A dynamic array is a descriptor that points at its elements. Comparing the
+		// descriptor bytes only compares storage addresses, even when its elements
+		// are primitive and can themselves use raw equality.
+		return true
 	}
 	if t.is_fixed_array_type(clean) {
 		elem_type := fixed_array_elem_type(clean)
@@ -3056,6 +3280,16 @@ fn (mut t Transformer) runtime_addr(expr flat.NodeId, typ string) flat.NodeId {
 		}
 		return expr
 	}
+	if int(expr) >= 0 && int(expr) < t.a.nodes.len {
+		node := t.a.nodes[int(expr)]
+		if node.kind == .cast_expr && node.children_count > 0 {
+			child_id := t.a.child(&node, 0)
+			child_type := t.node_type(child_id)
+			if t.normalize_type_alias(typ) == t.normalize_type_alias(child_type) {
+				return t.runtime_addr(child_id, child_type)
+			}
+		}
+	}
 	if !t.expr_can_take_address(expr) {
 		stable := t.stable_transformed_expr_for_reuse(expr, typ, 'addr')
 		return t.make_prefix(.amp, stable)
@@ -3439,7 +3673,20 @@ fn fixed_array_canonical_type(s string) string {
 	}
 	elem_type := fixed_array_canonical_type(fixed_array_elem_type(s))
 	len_text := fixed_array_len_text(s)
+	// Postfix dimensions can bind inside composite elements (for example, to a
+	// map's value type in `map[string]int[2]`). Keep prefix syntax when postfix
+	// notation would change which type the dimension belongs to.
+	if fixed_array_elem_requires_prefix_syntax(elem_type) {
+		return '[${len_text}]${elem_type}'
+	}
 	return '${elem_type}[${len_text}]'
+}
+
+fn fixed_array_elem_requires_prefix_syntax(elem_type string) bool {
+	return elem_type.starts_with('[]') || elem_type.starts_with('map[')
+		|| elem_type.starts_with('[') || elem_type.starts_with('?') || elem_type.starts_with('!')
+		|| elem_type.starts_with('&') || elem_type.starts_with('chan ')
+		|| elem_type.starts_with('shared ') || elem_type.starts_with('fn ')
 }
 
 fn (t &Transformer) resolved_fixed_array_canonical_type(s string) string {
@@ -3455,10 +3702,19 @@ fn (t &Transformer) resolved_fixed_array_canonical_type(s string) string {
 	}
 	len_text := fixed_array_len_text(clean)
 	if is_decimal_text(len_text) || isnil(t.tc) {
+		if fixed_array_elem_requires_prefix_syntax(resolved_elem) {
+			return '[${len_text}]${resolved_elem}'
+		}
 		return '${resolved_elem}[${len_text}]'
 	}
 	if v := t.tc.const_int_value_in_module(len_text, t.cur_module, []string{}) {
+		if fixed_array_elem_requires_prefix_syntax(resolved_elem) {
+			return '[${v}]${resolved_elem}'
+		}
 		return '${resolved_elem}[${v}]'
+	}
+	if fixed_array_elem_requires_prefix_syntax(resolved_elem) {
+		return '[${len_text}]${resolved_elem}'
 	}
 	return '${resolved_elem}[${len_text}]'
 }

--- a/vlib/v3/transform/expr.v
+++ b/vlib/v3/transform/expr.v
@@ -799,8 +799,8 @@ fn (mut t Transformer) transform_pointer_value_struct_eq(node flat.Node, lhs_id 
 	}
 	lhs_type := t.node_type(lhs_id)
 	rhs_type := t.node_type(rhs_id)
-	lhs_clean := t.trim_all_pointer_type(lhs_type)
-	rhs_clean := t.trim_all_pointer_type(rhs_type)
+	lhs_clean := t.trim_pointer_type(lhs_type)
+	rhs_clean := t.trim_pointer_type(rhs_type)
 	lhs_struct := t.struct_lookup_name(lhs_clean)
 	rhs_struct := t.struct_lookup_name(rhs_clean)
 	if lhs_struct.len == 0 || rhs_struct.len == 0 {

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -2466,10 +2466,10 @@ fn (mut t Transformer) transform_call_arg_for_param(arg_id flat.NodeId, param_ty
 		return t.transform_expr(arg_id)
 	}
 	if param_type.starts_with('&') && t.is_interface_type(param_type) {
-		// Pointer arguments already alias their concrete value when boxed. A value
-		// argument, however, must be copied: the callee may retain the `&Interface`
+		// Explicit `mut` arguments must alias the caller's storage. Other value
+		// arguments are copied because the callee may retain the `&Interface`
 		// after this call (for example `log.set_logger(local_logger)`).
-		if boxed := t.transform_interface_value_for_type(arg_id, param_type, false) {
+		if boxed := t.transform_interface_value_for_type(arg_id, param_type, arg_node.is_mut) {
 			return boxed
 		}
 	}

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -845,7 +845,7 @@ fn (mut t Transformer) transform_call_args(id flat.NodeId, node flat.Node) flat.
 		}
 	}
 	mut param_offset := t.call_param_offset(call_name, node, params)
-	if param_offset == 0 && params.len > 0 {
+	if param_offset == 0 && call_name.len > 0 && params.len > 0 {
 		if selector_id := t.call_selector_callee_id(node) {
 			selector := t.a.nodes[int(selector_id)]
 			if selector.children_count > 0 {

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -401,6 +401,11 @@ fn (t &Transformer) resolve_specialized_generic_receiver_method(receiver_type st
 	short_args := generic_type_args_short(args)
 	suffix := generic_type_suffixes(args)
 	mut candidates := []string{}
+	if !base.contains('.') && t.cur_module.len > 0 && t.cur_module !in ['main', 'builtin'] {
+		candidates << '${t.cur_module}.${base}[${short_args}].${method}'
+		candidates << '${t.cur_module}.${base}_${suffix}.${method}'
+		candidates << c_name('${t.cur_module}.${base}_${suffix}.${method}')
+	}
 	candidates << '${base}[${short_args}].${method}'
 	candidates << '${base}_${suffix}.${method}'
 	candidates << c_name('${base}_${suffix}.${method}')
@@ -425,8 +430,9 @@ fn (t &Transformer) resolve_alias_receiver_method(base_type string, method strin
 	if isnil(t.tc) || base_type.len == 0 || method.len == 0 {
 		return none
 	}
+	raw_base := base_type.trim_space().trim_left('&')
 	clean_base := t.normalize_type_alias(base_type)
-	cache_key := '${t.cur_module}\n${clean_base}\n${method}'
+	cache_key := '${t.cur_module}\n${raw_base}\n${method}'
 	if !isnil(t.alias_receiver_method_cache) {
 		mut cache := t.alias_receiver_method_cache
 		if cached := cache.entries[cache_key] {
@@ -434,6 +440,23 @@ fn (t &Transformer) resolve_alias_receiver_method(base_type string, method strin
 		}
 		if cache.misses[cache_key] {
 			return none
+		}
+	}
+	mut exact_aliases := [raw_base]
+	if !raw_base.contains('.') && t.cur_module.len > 0 && t.cur_module !in ['main', 'builtin'] {
+		exact_aliases << '${t.cur_module}.${raw_base}'
+	}
+	if imported := t.resolve_imported_type_name(raw_base) {
+		exact_aliases << imported
+	}
+	for alias in exact_aliases {
+		alias_method := '${alias}.${method}'
+		if alias in t.tc.type_aliases && t.is_known_fn_name(alias_method) {
+			if !isnil(t.alias_receiver_method_cache) {
+				mut cache := t.alias_receiver_method_cache
+				cache.entries[cache_key] = alias_method
+			}
+			return alias_method
 		}
 	}
 	if alias_method := t.alias_methods['${clean_base}.${method}'] {
@@ -542,6 +565,11 @@ fn (t &Transformer) raw_var_type_for_expr(id flat.NodeId) ?string {
 	}
 	if node.kind == .cast_expr && node.value.len > 0 {
 		return node.value
+	}
+	if node.kind == .selector {
+		if raw_type := t.raw_selector_field_type(id) {
+			return raw_type
+		}
 	}
 	if node.typ.len > 0 {
 		return node.typ
@@ -816,7 +844,24 @@ fn (mut t Transformer) transform_call_args(id flat.NodeId, node flat.Node) flat.
 			param_type_names = t.call_param_type_names(params)
 		}
 	}
-	param_offset := t.call_param_offset(call_name, node, params)
+	mut param_offset := t.call_param_offset(call_name, node, params)
+	if param_offset == 0 && params.len > 0 {
+		if selector_id := t.call_selector_callee_id(node) {
+			selector := t.a.nodes[int(selector_id)]
+			if selector.children_count > 0 {
+				base_id := t.a.child(&selector, 0)
+				base := t.a.nodes[int(base_id)]
+				first := types.unwrap_all_pointers(params[0])
+				base_is_value := base.kind != .ident || t.raw_var_type(base.value).len > 0
+				if first is types.Interface && base_is_value && !t.is_import_alias_ident(base_id) {
+					// Interface method signatures include the receiver in slot zero. A
+					// generic receiver can still be spelled `H` here, so name matching in
+					// call_param_offset cannot recognize it; keep explicit args aligned.
+					param_offset = 1
+				}
+			}
+		}
+	}
 	explicit_args := int(node.children_count) - 1
 	expected_explicit := params.len - param_offset
 	variadic_arg_pos := 1 + params.len - 1 - param_offset
@@ -908,7 +953,8 @@ fn (mut t Transformer) transform_call_args(id flat.NodeId, node flat.Node) flat.
 					arg_type := t.node_type(arg_id)
 					if arg_type.starts_with('[]')
 						&& !t.variadic_interface_single_array_should_box(arg_type, variadic_type) {
-						new_children << t.transform_call_arg_for_param(arg_id, param_type)
+						new_children << t.transform_call_arg_for_named_param(arg_id, param_type,
+							call_name)
 					} else {
 						new_children << t.pack_variadic_args(node, i, variadic_type.elem_type)
 					}
@@ -927,12 +973,12 @@ fn (mut t Transformer) transform_call_args(id flat.NodeId, node flat.Node) flat.
 				expected := params[param_idx + spread_offset].name()
 				index_arg := t.make_spread_index_for_expected_param(spread_base, spread_offset,
 					expected)
-				new_children << t.transform_call_arg_for_param(index_arg, expected)
+				new_children << t.transform_call_arg_for_named_param(index_arg, expected, call_name)
 			}
 			i++
 			continue
 		}
-		new_children << t.transform_call_arg_for_param(arg_id, param_type)
+		new_children << t.transform_call_arg_for_named_param(arg_id, param_type, call_name)
 		i++
 	}
 	if variadic_idx >= 0 && !variadic_tail_supplied && explicit_args == variadic_idx - param_offset {
@@ -967,9 +1013,18 @@ fn (mut t Transformer) transform_call_args(id flat.NodeId, node flat.Node) flat.
 	})
 	t.copy_cloned_resolution(id, new_id)
 	if spec := t.generic_call_spec_cache[int(id)] {
+		mut cached_args := spec.args.clone()
+		if new_children.len > 0 {
+			callee := t.a.nodes[int(new_children[0])]
+			if callee.kind == .ident {
+				if exact := t.recorded_generic_specialization_args(callee.value) {
+					cached_args = exact.clone()
+				}
+			}
+		}
 		t.generic_call_spec_cache[int(new_id)] = GenericCallSpec{
 			decl_key: spec.decl_key
-			args:     spec.args.clone()
+			args:     cached_args
 		}
 	}
 	return new_id
@@ -1052,6 +1107,17 @@ fn (mut t Transformer) transform_spread_arg_over_fixed_variadic_tail(arg_node fl
 			variadic_array_type)
 	}
 	return args
+}
+
+fn (mut t Transformer) transform_call_arg_for_named_param(arg_id flat.NodeId, param_type string, call_name string) flat.NodeId {
+	// C declarations often use `voidptr` as an intentionally opaque placeholder
+	// for a native by-value type whose full declaration lives in an inserted C or
+	// Objective-C source. Match the legacy backend by leaving such C arguments in
+	// value form; callers that need an actual pointer spell `&value` explicitly.
+	if call_name.starts_with('C.') && transform_param_type_is_void_pointer(param_type) {
+		return t.transform_expr(arg_id)
+	}
+	return t.transform_call_arg_for_param(arg_id, param_type)
 }
 
 fn (mut t Transformer) transform_variadic_spread_arg_for_param(spread_id flat.NodeId, variadic_type types.Array, param_type string) flat.NodeId {
@@ -1432,9 +1498,6 @@ fn (t &Transformer) is_import_alias_ident(id flat.NodeId) bool {
 	if node.kind != .ident || node.value !in t.tc.imports {
 		return false
 	}
-	if t.var_type(node.value).len > 0 {
-		return false
-	}
 	if typ := t.tc.expr_type(id) {
 		name := typ.name()
 		if name.len > 0 && name != 'unknown' && name != 'void' {
@@ -1528,6 +1591,11 @@ fn (mut t Transformer) try_lower_static_assoc_call(id flat.NodeId, node flat.Nod
 	call := t.make_call_typed(static_fn, args, ret_type)
 	if generic_args.len > 0 {
 		t.set_node_value(int(call), generic_args)
+	} else if node.value.len > 0 {
+		t.set_node_value(int(call), node.value)
+	}
+	if node.generic_params().len > 0 {
+		t.set_node_generic_params(int(call), node.generic_params())
 	}
 	return call
 }
@@ -1950,7 +2018,7 @@ fn (mut t Transformer) wrap_sum_ref_arg(arg_id flat.NodeId, target_sum string) ?
 	}
 	qvariant := t.resolve_variant(resolved_sum, clean_arg_type)
 	if arg_type.starts_with('&') {
-		ptr := t.transform_expr(arg_id)
+		ptr := t.transform_expr_preserving_pointer_value(arg_id)
 		t.set_node_typ(int(ptr), '&${qvariant}')
 		return t.make_sum_ref_literal(resolved_sum, qvariant, ptr)
 	}
@@ -2210,8 +2278,70 @@ fn (mut t Transformer) transform_call_arg_for_param(arg_id flat.NodeId, param_ty
 		&& t.call_arg_is_fn_pointer_value(arg_id, *arg_node) {
 		return t.transform_expr(arg_id)
 	}
+	if transform_param_type_is_void_pointer(param_type) {
+		// C APIs commonly spell a null callback/data pointer as the integer
+		// literal `0`.  It is already a pointer value in that context; taking
+		// the address of a temporary integer instead produces a non-null,
+		// dangling pointer.
+		if t.expr_is_nil_like(arg_id) || (arg_node.kind == .int_literal && arg_node.value == '0') {
+			return t.make_cast(param_type, t.transform_expr(arg_id), param_type)
+		}
+		// A `c'...'` literal denotes a C string pointer even though its flat
+		// literal node retains the character type used for byte contexts.
+		if arg_node.kind == .char_literal && arg_node.value.starts_with('c:') {
+			return t.transform_expr(arg_id)
+		}
+		arg_type := t.node_type(arg_id)
+		clean_arg_type := t.normalize_type_alias(arg_type)
+		if clean_arg_type.len > 0 && !clean_arg_type.starts_with('&')
+			&& clean_arg_type !in ['voidptr', 'byteptr', 'charptr', 'nil'] {
+			value := t.transform_expr(arg_id)
+			mut addr := flat.empty_node
+			if t.expr_can_take_address(value) {
+				addr = t.make_prefix(.amp, value)
+			} else {
+				tmp_name := t.new_temp('voidptr_arg')
+				t.pending_stmts << t.make_decl_assign_typed(tmp_name, value, clean_arg_type)
+				addr = t.make_prefix(.amp, t.make_ident(tmp_name))
+			}
+			return t.make_cast(param_type, addr, param_type)
+		}
+	}
 	if arg_node.kind == .enum_val && param_type in t.enum_types {
 		return t.transform_enum_shorthand(arg_id, *arg_node, param_type)
+	}
+	if param_type.starts_with('&') && arg_node.kind == .prefix && arg_node.op == .amp
+		&& arg_node.children_count > 0 {
+		child_id := t.a.child(arg_node, 0)
+		child := t.a.nodes[int(child_id)]
+		if child.kind == .ident && t.has_smartcast(child.value) {
+			sc := t.find_smartcast(child.value) or { SmartcastContext{} }
+			target := t.smartcast_target_type(sc)
+			if target.len > 0
+				&& t.normalize_type_alias(t.trim_pointer_type(target)) == t.normalize_type_alias(param_type[1..]) {
+				if narrowed := t.smartcast_ident_value(child.value) {
+					narrowed_node := t.a.nodes[int(narrowed)]
+					if narrowed_node.kind == .prefix && narrowed_node.op == .mul
+						&& narrowed_node.children_count > 0 {
+						pointer := t.a.child(&narrowed_node, 0)
+						t.set_node_typ(int(pointer), param_type)
+						return pointer
+					}
+				}
+			}
+		}
+	}
+	if param_type.starts_with('&') && arg_node.kind == .ident && arg_node.is_mut
+		&& t.mut_param_values[arg_node.value] {
+		storage_type := t.var_type(arg_node.value)
+		if storage_type.starts_with('&')
+			&& t.normalize_type_alias(storage_type) == t.normalize_type_alias(param_type) {
+			// Forwarding `mut val` from a `mut T` parameter reuses the parameter's
+			// existing pointer-backed storage. Taking another address would pass `T**`.
+			storage := t.make_ident(arg_node.value)
+			t.set_node_typ(int(storage), storage_type)
+			return storage
+		}
 	}
 	if param_type.starts_with('&') && arg_node.kind == .selector
 		&& t.selector_chain_has_sum_variant_field(arg_id) {
@@ -2310,6 +2440,13 @@ fn (mut t Transformer) transform_call_arg_for_param(arg_id flat.NodeId, param_ty
 		}
 	}
 	if t.is_sum_type_name(param_type) {
+		arg_key := t.expr_key(arg_id)
+		if t.has_smartcast(arg_key) {
+			raw_arg_type := t.raw_expr_type_without_smartcast(arg_id)
+			if t.resolve_sum_name(t.trim_pointer_type(raw_arg_type)) == t.resolve_sum_name(param_type) {
+				return t.make_plain_expr_for_smartcast(arg_id)
+			}
+		}
 		return t.wrap_sum_value(arg_id, param_type)
 	}
 	if param_type.starts_with('[]') {
@@ -2329,11 +2466,10 @@ fn (mut t Transformer) transform_call_arg_for_param(arg_id flat.NodeId, param_ty
 		return t.transform_expr(arg_id)
 	}
 	if param_type.starts_with('&') && t.is_interface_type(param_type) {
-		// A `mut`/reference interface parameter must alias the caller's concrete
-		// value so mutations through the interface are visible to the caller.
-		// The caller's frame outlives the call, so boxing a reference to the
-		// source (instead of a heap copy) is safe here.
-		if boxed := t.transform_interface_value_for_type(arg_id, param_type, true) {
+		// Pointer arguments already alias their concrete value when boxed. A value
+		// argument, however, must be copied: the callee may retain the `&Interface`
+		// after this call (for example `log.set_logger(local_logger)`).
+		if boxed := t.transform_interface_value_for_type(arg_id, param_type, false) {
 			return boxed
 		}
 	}
@@ -3272,6 +3408,22 @@ fn (mut t Transformer) stringify_expr(expr_id flat.NodeId) flat.NodeId {
 			typ = t.reliable_stringify_type(expr_id)
 		}
 	}
+	// A selector of a concrete generic instance can retain the declaration's raw
+	// placeholder spelling (for example `&Node[T]`) even though its checked node
+	// type is already `&Node[int]`. Auto-stringification must use the concrete
+	// instance; otherwise the synthesized locals leak `Node_T` into generated C.
+	if stringify_type_has_generic_placeholder(typ) {
+		mut concrete_typ := t.lvalue_type(expr_id)
+		if concrete_typ.len == 0 || stringify_type_has_generic_placeholder(concrete_typ) {
+			concrete_typ = t.node_type(expr_id)
+		}
+		if concrete_typ.len == 0 || stringify_type_has_generic_placeholder(concrete_typ) {
+			concrete_typ = t.lvalue_type(expr)
+		}
+		if concrete_typ.len > 0 && !stringify_type_has_generic_placeholder(concrete_typ) {
+			typ = concrete_typ
+		}
+	}
 	if raw_alias_type.len > 0 {
 		typ = raw_alias_type
 	}
@@ -3648,13 +3800,13 @@ fn (mut t Transformer) wrap_string_conversion(expr flat.NodeId, typ string) flat
 	if normalized_stringify_type != clean_typ {
 		return t.wrap_string_conversion(expr, normalized_stringify_type)
 	}
-	if t.is_optional_type_name(clean_typ) {
-		return t.wrap_optional_string_conversion(expr, clean_typ)
-	}
 	if t.is_fixed_array_type(clean_typ) {
 		elem_type := fixed_array_elem_type(clean_typ)
 		arr := t.fixed_array_value_to_array(expr, clean_typ, '[]${elem_type}')
 		return t.wrap_string_conversion(arr, '[]${elem_type}')
+	}
+	if t.is_optional_type_name(clean_typ) {
+		return t.wrap_optional_string_conversion(expr, clean_typ)
 	}
 	if clean_typ.len == 0 || clean_typ == 'unknown' {
 		inferred := t.resolve_expr_type(expr)
@@ -3811,6 +3963,10 @@ fn (mut t Transformer) wrap_string_conversion(expr flat.NodeId, typ string) flat
 		}
 		'i64' {
 			return t.make_call_typed('i64.str', arr1(expr), 'string')
+		}
+		'char' {
+			return t.make_call_typed('v3_char_string', arr1(t.make_cast('int', expr, 'int')),
+				'string')
 		}
 		'isize' {
 			return t.make_call_typed('strconv__format_int', arr2(expr, t.make_int_literal(10)),
@@ -4994,19 +5150,31 @@ fn (t &Transformer) normalize_runtime_array_stringify_type(typ string) string {
 }
 
 fn (mut t Transformer) mark_interface_method_implementers_used(iface_name string, method string) {
+	for name in t.interface_method_implementer_names(iface_name, method) {
+		t.mark_fn_used_name(name)
+	}
+}
+
+fn (t &Transformer) interface_method_implementer_names(iface_name string, method string) []string {
 	if isnil(t.tc) {
-		return
+		return []string{}
 	}
-	for concrete, _ in t.tc.structs {
-		if t.tc.named_type_implements_interface(concrete, iface_name) {
-			t.mark_fn_used_name('${concrete}.${method}')
+	impls := if t.is_builtin_ierror_interface_name(iface_name) {
+		t.tc.ierror_impl_names()
+	} else {
+		t.tc.interface_impl_names(iface_name)
+	}
+	mut names := []string{cap: impls.len * 2}
+	for concrete in impls {
+		concrete_method := '${concrete}.${method}'
+		names << concrete_method
+		if method_name := t.tc.concrete_method_signature_key(concrete, method) {
+			if method_name != concrete_method {
+				names << method_name
+			}
 		}
 	}
-	for concrete, _ in t.tc.type_aliases {
-		if t.tc.named_type_implements_interface(concrete, iface_name) {
-			t.mark_fn_used_name('${concrete}.${method}')
-		}
-	}
+	return names
 }
 
 fn (mut t Transformer) lower_sum_str(expr flat.NodeId, sum_name string) flat.NodeId {
@@ -5039,8 +5207,10 @@ fn (mut t Transformer) build_sum_str_chain(base flat.NodeId, tag flat.NodeId, su
 	}
 	variant := variants[idx]
 	field := t.sum_field_name(variant)
-	field_sel := t.make_selector_op(base, field, '&${variant}', .dot)
 	variant_base := t.normalize_type_alias(variant)
+	direct_pointer := t.sum_variant_is_direct_pointer(variant)
+	field_sel := t.make_selector_op(base, field,
+		if direct_pointer { variant } else { '&${variant}' }, .dot)
 	// Only statements created for THIS branch's payload conversion belong inside
 	// the branch; earlier pending statements (e.g. the base temp decl from
 	// lower_sum_str) must stay with the caller so they precede the whole if-chain.
@@ -5054,6 +5224,8 @@ fn (mut t Transformer) build_sum_str_chain(base flat.NodeId, tag flat.NodeId, su
 			field_sel,
 		], '[]${elem_type}')
 		t.wrap_string_conversion(arr, '[]${elem_type}')
+	} else if direct_pointer {
+		t.wrap_string_conversion(field_sel, variant)
 	} else {
 		value := t.make_prefix(.mul, field_sel)
 		t.set_node_typ(int(value), variant)
@@ -5116,6 +5288,18 @@ fn (mut t Transformer) wrap_formatted_string_conversion(expr flat.NodeId, typ st
 		clean_typ = clean_typ.all_after_last('.')
 	}
 	normalized_typ := t.normalize_type_alias(typ)
+	if repeat_count, upper := string_repeat_format(format) {
+		if clean_typ == 'string' || normalized_typ == 'string' {
+			t.mark_fn_used('string__repeat')
+			repeated := t.make_call_typed('string__repeat', arr2(expr,
+				t.make_int_literal(repeat_count)), 'string')
+			return if upper {
+				t.make_call_typed('v3_string_upper_ascii', arr1(repeated), 'string')
+			} else {
+				repeated
+			}
+		}
+	}
 	if format == 'p' && (normalized_typ.starts_with('&')
 		|| clean_typ in ['voidptr', 'byteptr', 'charptr']
 		|| t.expr_is_mut_param_pointer_value(expr)) {
@@ -5179,6 +5363,42 @@ fn (mut t Transformer) wrap_formatted_string_conversion(expr flat.NodeId, typ st
 			return formatted
 		}
 	}
+	if format in ['g', 'G'] && clean_typ in ['f32', 'f64', 'float_literal'] {
+		fn_name := if clean_typ == 'f32' { 'f32__strg' } else { 'f64__strg' }
+		arg := if clean_typ == 'float_literal' {
+			t.make_cast('f64', expr, 'f64')
+		} else {
+			expr
+		}
+		t.mark_fn_used(fn_name)
+		formatted := t.make_call_typed(fn_name, arr1(arg), 'string')
+		return if format == 'G' {
+			t.make_call_typed('v3_string_upper_ascii', arr1(formatted), 'string')
+		} else {
+			formatted
+		}
+	}
+	if general_format := general_float_format(format) {
+		if clean_typ in ['f32', 'f64', 'float_literal'] {
+			arg := if clean_typ == 'f64' {
+				expr
+			} else {
+				t.make_cast('f64', expr, 'f64')
+			}
+			mut formatted := t.make_call_typed('v3_f64_general', arr3(arg,
+				t.make_int_literal(general_format.precision), t.make_int_literal(if general_format.upper {
+				1
+			} else {
+				0
+			})), 'string')
+			if general_format.width > 0 || general_format.left {
+				left := if general_format.left { 1 } else { 0 }
+				formatted = t.make_call_typed('v3_string_pad', arr3(formatted,
+					t.make_int_literal(general_format.width), t.make_int_literal(left)), 'string')
+			}
+			return formatted
+		}
+	}
 	if format == 'c' {
 		if clean_typ in ['u8', 'byte', 'char', 'rune', 'int'] {
 			arg := if clean_typ == 'int' {
@@ -5191,7 +5411,8 @@ fn (mut t Transformer) wrap_formatted_string_conversion(expr flat.NodeId, typ st
 	}
 	if base := integer_format_base(format) {
 		if clean_typ in ['u8', 'byte', 'u16', 'u32', 'u64', 'usize'] {
-			formatted := t.make_call_typed('strconv__format_uint', arr2(expr,
+			arg := t.widened_unsigned_format_arg(expr, clean_typ)
+			formatted := t.make_call_typed('strconv__format_uint', arr2(arg,
 				t.make_int_literal(base)), 'string')
 			return if format == 'X' {
 				t.make_call_typed('v3_string_upper_ascii', arr1(formatted), 'string')
@@ -5211,11 +5432,7 @@ fn (mut t Transformer) wrap_formatted_string_conversion(expr flat.NodeId, typ st
 	}
 	if base_format := zero_padded_integer_base_format(format) {
 		converted := if clean_typ in ['u8', 'byte', 'u16', 'u32', 'u64', 'usize'] {
-			arg := if clean_typ == 'u64' {
-				expr
-			} else {
-				t.make_cast('u64', expr, 'u64')
-			}
+			arg := t.widened_unsigned_format_arg(expr, clean_typ)
 			t.make_call_typed('strconv__format_uint', arr2(arg,
 				t.make_int_literal(base_format.base)), 'string')
 		} else if clean_typ in ['int', 'i8', 'i16', 'i32', 'i64', 'isize', 'rune'] {
@@ -5241,11 +5458,7 @@ fn (mut t Transformer) wrap_formatted_string_conversion(expr flat.NodeId, typ st
 		if clean_typ in ['int', 'i8', 'i16', 'i32', 'i64', 'isize', 'rune', 'usize', 'u8', 'byte',
 			'u16', 'u32', 'u64'] {
 			if clean_typ in ['u64', 'usize', 'u32', 'u16', 'u8', 'byte'] {
-				arg := if clean_typ == 'u64' {
-					expr
-				} else {
-					t.make_cast('u64', expr, 'u64')
-				}
+				arg := t.widened_unsigned_format_arg(expr, clean_typ)
 				return t.make_call_typed('v3_u64_zpad', arr2(arg, t.make_int_literal(width)),
 					'string')
 			}
@@ -5264,7 +5477,8 @@ fn (mut t Transformer) wrap_formatted_string_conversion(expr flat.NodeId, typ st
 	if width := static_format_width(format) {
 		mut converted := if base := integer_format_base_suffix(format) {
 			if clean_typ in ['u8', 'byte', 'u16', 'u32', 'u64', 'usize'] {
-				t.make_call_typed('strconv__format_uint', arr2(expr, t.make_int_literal(base)),
+				arg := t.widened_unsigned_format_arg(expr, clean_typ)
+				t.make_call_typed('strconv__format_uint', arr2(arg, t.make_int_literal(base)),
 					'string')
 			} else if clean_typ in ['int', 'i8', 'i16', 'i32', 'i64', 'isize', 'rune'] {
 				t.make_call_typed('strconv__format_int', arr2(expr, t.make_int_literal(base)),
@@ -5279,6 +5493,15 @@ fn (mut t Transformer) wrap_formatted_string_conversion(expr flat.NodeId, typ st
 			t.make_int_literal(0)), 'string')
 	}
 	return t.wrap_string_conversion(expr, typ)
+}
+
+fn (mut t Transformer) widened_unsigned_format_arg(expr flat.NodeId, typ string) flat.NodeId {
+	if typ == 'u64' {
+		return expr
+	}
+	name := t.new_temp('fmt_unsigned')
+	t.pending_stmts << t.make_decl_assign_typed(name, expr, typ)
+	return t.make_cast('u64', t.make_ident(name), 'u64')
 }
 
 fn (t &Transformer) expr_is_mut_param_pointer_value(expr flat.NodeId) bool {
@@ -5420,6 +5643,27 @@ struct ExponentDecimalFormat {
 	upper     bool
 }
 
+struct GeneralFloatFormat {
+	width     int
+	precision int
+	left      bool
+	upper     bool
+}
+
+fn string_repeat_format(format string) ?(int, bool) {
+	if format.len == 0 || format[format.len - 1] !in [`r`, `R`] {
+		return none
+	}
+	mut count := 0
+	for i in 0 .. format.len - 1 {
+		if format[i] < `0` || format[i] > `9` {
+			return none
+		}
+		count = count * 10 + int(format[i] - `0`)
+	}
+	return count, format[format.len - 1] == `R`
+}
+
 fn fixed_decimal_format(format string) ?FixedDecimalFormat {
 	if format.len < 2 {
 		return none
@@ -5508,6 +5752,51 @@ fn exponent_decimal_format(format string) ?ExponentDecimalFormat {
 		return none
 	}
 	return ExponentDecimalFormat{
+		width:     width
+		precision: precision
+		left:      left
+		upper:     upper
+	}
+}
+
+fn general_float_format(format string) ?GeneralFloatFormat {
+	if format.len < 2 {
+		return none
+	}
+	mut i := 0
+	mut left := false
+	if format[i] == `-` {
+		left = true
+		i++
+	}
+	if i < format.len && format[i] == `0` {
+		i++
+	}
+	mut width := 0
+	for i < format.len && format[i] >= `0` && format[i] <= `9` {
+		width = width * 10 + int(format[i] - `0`)
+		i++
+	}
+	if i >= format.len || format[i] != `.` {
+		return none
+	}
+	i++
+	mut precision := 0
+	mut has_precision := false
+	for i < format.len && format[i] >= `0` && format[i] <= `9` {
+		has_precision = true
+		precision = precision * 10 + int(format[i] - `0`)
+		i++
+	}
+	if !has_precision || i >= format.len || format[i] !in [`g`, `G`] {
+		return none
+	}
+	upper := format[i] == `G`
+	i++
+	if i != format.len {
+		return none
+	}
+	return GeneralFloatFormat{
 		width:     width
 		precision: precision
 		left:      left
@@ -5739,10 +6028,10 @@ fn (mut t Transformer) lower_array_str(arr_expr flat.NodeId, base_type string) f
 			for field_base_type.starts_with('shared ') {
 				field_base_type = field_base_type[7..].trim_space()
 			}
-			if raw_type := t.lookup_struct_field_raw_type(field_base_type, selector.value) {
-				selector_type = raw_type
-			} else if field_type := t.lookup_struct_field_type(field_base_type, selector.value) {
+			if field_type := t.lookup_struct_field_type(field_base_type, selector.value) {
 				selector_type = field_type
+			} else if raw_type := t.lookup_struct_field_raw_type(field_base_type, selector.value) {
+				selector_type = raw_type
 			}
 		}
 		for selector_type.starts_with('shared ') {
@@ -6118,7 +6407,8 @@ fn (mut t Transformer) wrap_optional_string_conversion(expr flat.NodeId, typ str
 	}
 	opt_name := t.new_temp('opt_str')
 	res_name := t.new_temp('opt_str_text')
-	t.pending_stmts << t.make_decl_assign_typed(opt_name, expr, opt_type)
+	t.pending_stmts << t.make_decl_assign_typed(opt_name, t.transform_optional_wrapper_expr(expr),
+		opt_type)
 	t.pending_stmts << t.make_decl_assign_typed(res_name, t.make_string_literal('Option(none)'),
 		'string')
 	value := t.make_selector(t.make_ident(opt_name), 'value', value_type)
@@ -6780,6 +7070,16 @@ fn (mut t Transformer) try_lower_array_method_call(call_id flat.NodeId, node fla
 				early_base_type
 			})
 			if early_clean_type.starts_with('[]') || t.is_fixed_array_type(early_clean_type) {
+				if smartcast_method := t.resolve_smartcast_target_receiver_method(base_id,
+					fn_node.value)
+				{
+					if !t.receiver_method_name_is_open_generic(smartcast_method) {
+						args := t.transform_receiver_method_args(node, base_id, smartcast_method)
+						ret_type := t.receiver_method_return_type(smartcast_method, node.typ)
+						t.mark_fn_used_name(smartcast_method)
+						return t.make_call_typed(smartcast_method, args, ret_type)
+					}
+				}
 				if exact_call := t.lower_checker_selected_receiver_method(call_id, node, base_id,
 					'')
 				{
@@ -6915,8 +7215,12 @@ fn (mut t Transformer) try_lower_array_method_call(call_id flat.NodeId, node fla
 		elem_type := fixed_array_elem_type(clean_base_type)
 		array_type := '[]${elem_type}'
 		tmp_name := t.new_temp('fixed_arr')
-		t.pending_stmts << t.make_decl_assign_typed(tmp_name, t.fixed_array_value_to_array(base_id,
-			clean_base_type, array_type), array_type)
+		array_value := if fn_node.value in ['reverse_in_place', 'sort', 'sort_with_compare'] {
+			t.fixed_array_value_to_array_no_alloc(base_id, clean_base_type, array_type)
+		} else {
+			t.fixed_array_value_to_array(base_id, clean_base_type, array_type)
+		}
+		t.pending_stmts << t.make_decl_assign_typed(tmp_name, array_value, array_type)
 		selector := t.make_selector(t.make_ident(tmp_name), fn_node.value, '')
 		if fn_node.value == 'wait' {
 			wait_type := fixed_thread_array_wait_return_type(elem_type)
@@ -8084,7 +8388,10 @@ fn (mut t Transformer) lift_fn_literal(_id flat.NodeId, node flat.Node) flat.Nod
 				continue
 			}
 			if child.value.len > 0 && child.value !in capture_names {
-				mut capture_type := t.var_type(child.value)
+				mut capture_type := t.raw_var_type(child.value)
+				if capture_type.len == 0 {
+					capture_type = t.var_type(child.value)
+				}
 				if capture_type.len == 0 {
 					capture_type = t.node_type(child_id)
 				}
@@ -8096,8 +8403,17 @@ fn (mut t Transformer) lift_fn_literal(_id flat.NodeId, node flat.Node) flat.Nod
 				if capture_type.len == 0 || capture_type == 'unknown' {
 					capture_type = 'int'
 				}
+				if t.active_specialization_args.len > 0 {
+					specialized_capture_type := t.subst_type(capture_type,
+						t.active_specialization_args)
+					if specialized_capture_type.len > 0
+						&& !t.generic_arg_is_unresolved(specialized_capture_type) {
+						capture_type = specialized_capture_type
+					}
+				}
 				normalized_capture_type := t.normalize_type_alias(capture_type)
-				if normalized_capture_type.len > 0 && normalized_capture_type != 'unknown' {
+				if !capture_type.starts_with('shared ') && normalized_capture_type.len > 0
+					&& normalized_capture_type != 'unknown' {
 					capture_type = normalized_capture_type
 				}
 				capture_names << child.value
@@ -8442,7 +8758,10 @@ fn (mut t Transformer) try_lower_builtin_call(_id flat.NodeId, node flat.Node) ?
 	}
 	match name {
 		'copy' {
-			return t.try_lower_copy_call(node)
+			if t.is_builtin_copy_call(_id) {
+				return t.try_lower_copy_call(node)
+			}
+			return none
 		}
 		'println', 'eprintln', 'print', 'eprint' {
 			if node.children_count < 2 {
@@ -8579,6 +8898,14 @@ fn (mut t Transformer) try_lower_smartcast_target_receiver_method_call(_call_id 
 	return t.make_call_typed(method_name, args, ret_type)
 }
 
+fn (t &Transformer) is_builtin_copy_call(id flat.NodeId) bool {
+	if isnil(t.tc) {
+		return true
+	}
+	resolved := t.tc.resolved_call_name(id) or { return true }
+	return resolved in ['copy', 'builtin.copy']
+}
+
 fn (t &Transformer) is_std_minmaxof_call(id flat.NodeId, name string) bool {
 	if isnil(t.tc) {
 		return false
@@ -8637,6 +8964,15 @@ fn (mut t Transformer) try_lower_pointer_str_method_call(call_id flat.NodeId, no
 		return none
 	}
 	base_id := t.a.child(&fn_node, 0)
+	if smartcast_str := t.smartcast_sum_str_call(base_id) {
+		return smartcast_str
+	}
+	// Mutable for-in bindings and mutable parameters use pointer-backed storage,
+	// but an ordinary receiver expression is the auto-dereferenced value. Do not
+	// lower their `.str()` call as an explicit pointer stringification.
+	if _ := t.pointer_value_expr_type(base_id) {
+		return none
+	}
 	base_type := t.pointer_str_receiver_type(base_id) or { return none }
 	clean_type := base_type[1..]
 	if aggregate := t.stringify_aggregate_type_name(clean_type) {
@@ -9071,6 +9407,18 @@ fn (mut t Transformer) try_lower_receiver_method_call(id flat.NodeId, node flat.
 	if base_node.kind == .ident && base_node.value == 'C' {
 		return none
 	}
+	if base_node.kind == .ident && !isnil(t.tc) {
+		imported_module := t.tc.file_imports[file_import_key(t.cur_file, base_node.value)] or {
+			t.tc.imports[base_node.value] or { '' }
+		}
+		if imported_module.len > 0 {
+			if resolved := t.tc.resolved_call_name(id) {
+				if resolved == '${imported_module}.${method}' {
+					return none
+				}
+			}
+		}
+	}
 	if t.is_import_alias_ident(base_id) {
 		return none
 	}
@@ -9092,6 +9440,9 @@ fn (mut t Transformer) try_lower_receiver_method_call(id flat.NodeId, node flat.
 		base_type = base_type[1..]
 	}
 	if base_type.len == 0 {
+		return none
+	}
+	if method == 'wait' && (base_type == 'thread' || base_type.starts_with('thread ')) {
 		return none
 	}
 	iface_name := t.resolve_interface_type_name(base_type)
@@ -9597,6 +9948,9 @@ fn transform_fn_type(typ types.Type) ?types.FnType {
 fn (mut t Transformer) fn_field_arg_compatible(actual_type string, expected_type string) bool {
 	actual := t.normalize_type_alias(actual_type)
 	expected := t.normalize_type_alias(expected_type)
+	if t.is_integer_type_name(actual) && t.is_integer_type_name(expected) {
+		return true
+	}
 	if actual == expected {
 		return true
 	}
@@ -9619,6 +9973,12 @@ fn (mut t Transformer) validate_specialized_call_result(id flat.NodeId, actual_t
 		return true
 	}
 	expected_type := t.expected_expr_type
+	// An unsubstituted single-letter generic return still lacks a concrete type
+	// at this validation point. The specialized function signature/C compiler
+	// will validate it once monomorphization has supplied the concrete argument.
+	if expected_type.len == 1 && expected_type[0] >= `A` && expected_type[0] <= `Z` {
+		return true
+	}
 	if t.resolved_receiver_arg_compatible(id, actual_type, expected_type) {
 		return true
 	}
@@ -9730,6 +10090,9 @@ fn (mut t Transformer) resolved_receiver_arg_compatible(arg_id flat.NodeId, actu
 	}
 	actual := t.normalize_type_alias(actual_type)
 	expected := t.normalize_type_alias(expected_type)
+	if t.is_integer_type_name(actual) && t.is_integer_type_name(expected) {
+		return true
+	}
 	if t.is_integer_type_name(expected) {
 		if literal := t.specialized_int_literal(arg_id) {
 			return specialized_int_literal_fits_type(literal, expected)
@@ -10247,13 +10610,15 @@ fn (t &Transformer) embedded_receiver_path(base_type string, receiver_type strin
 // receiver_method_return_type supports receiver method return type handling for Transformer.
 fn (t &Transformer) receiver_method_return_type(method_name string, fallback string) string {
 	if !isnil(t.tc) {
+		if typ := t.tc.fn_ret_types[method_name] {
+			if typ !is types.Unknown && typ !is types.Void {
+				return typ.name()
+			}
+		}
 		if ret_text := t.tc.fn_ret_type_texts[method_name] {
 			if alias_text := t.fn_return_alias_type_text(method_name, ret_text) {
 				return alias_text
 			}
-		}
-		if typ := t.tc.fn_ret_types[method_name] {
-			return typ.name()
 		}
 	}
 	if ret := t.fn_ret_types[method_name] {
@@ -10365,6 +10730,12 @@ fn (t &Transformer) receiver_method_matches_type_name(method_name string, typ st
 	mut clean := typ.trim_space()
 	for clean.starts_with('&') {
 		clean = clean[1..]
+	}
+	if clean.starts_with('[]') || clean.starts_with('map[') {
+		method := method_name.all_after_last('.')
+		if method_name in t.receiver_method_candidates(clean, method) {
+			return true
+		}
 	}
 	mut candidates := [clean]
 	if clean.contains('.') {
@@ -11492,6 +11863,12 @@ fn (t &Transformer) checker_resolved_non_builtin_return_type(id flat.NodeId, nod
 	if is_builtin_collection_resolved_call(name) {
 		return none
 	}
+	if typ := t.tc.expr_type(id) {
+		if typ !is types.Unknown && typ !is types.Void {
+			ret := t.call_return_type_name(typ.name(), node)
+			return ret
+		}
+	}
 	if node.children_count > 0 && t.cur_module.len > 0 && t.cur_module !in ['main', 'builtin'] {
 		fn_node := t.a.child_node(&node, 0)
 		short_name := name.all_after_last('.')
@@ -11506,13 +11883,29 @@ fn (t &Transformer) checker_resolved_non_builtin_return_type(id flat.NodeId, nod
 			}
 		}
 	}
-	if typ := t.tc.expr_type(id) {
-		if typ !is types.Unknown && typ !is types.Void {
-			return t.call_return_type_name(typ.name(), node)
+	decl_module := t.tc.fn_type_modules[name] or { '' }
+	if ret_text := t.tc.fn_ret_type_texts[name] {
+		if ret_text.len > 0 {
+			return t.call_return_type_name_in_module(ret_text, node, decl_module)
 		}
 	}
-	ret := t.tc.fn_ret_types[name] or { return none }
-	return t.call_return_type_name(ret.name(), node)
+	if ret := t.tc.fn_ret_types[name] {
+		if ret !is types.Unknown && ret !is types.Void {
+			return t.call_return_type_name_in_module(ret.name(), node, decl_module)
+		}
+	}
+	return none
+}
+
+fn (t &Transformer) call_return_type_name_in_module(ret_name string, node flat.Node, module_name string) string {
+	mut typ := ret_name
+	if node.value.len > 0 {
+		generic_arg := t.normalize_type_in_module(node.value, t.cur_module)
+		if generic_arg.len > 0 {
+			typ = t.specialize_generic_type_name(typ, generic_arg)
+		}
+	}
+	return t.normalize_type_in_module(typ, module_name)
 }
 
 // call_return_type_name updates call return type name state for Transformer.

--- a/vlib/v3/transform/for.v
+++ b/vlib/v3/transform/for.v
@@ -751,9 +751,13 @@ fn (t &Transformer) iterator_for_in_info(iter_type string) ?IteratorForInInfo {
 	iter_type_value := t.tc.parse_type(clean)
 	info := t.tc.iterator_for_in_next_call_info(iter_type_value) or { return none }
 	elem_type := t.iterator_for_in_elem_type_from_next_return(info.return_type) or { return none }
+	mut next_method := info.name
+	if !for_iter_type_has_generic_placeholder(clean) && info.name.contains('.') {
+		next_method = '${clean}.${info.name.all_after_last('.')}'
+	}
 	return IteratorForInInfo{
 		elem_type:   elem_type
-		next_method: info.name
+		next_method: next_method
 	}
 }
 
@@ -976,7 +980,7 @@ fn (mut t Transformer) lower_indexed_for_in(id flat.NodeId, node flat.Node, key_
 		had_pointer_value_lvalue := t.pointer_value_lvalues[elem_name] or { false }
 		had_pointer_value_rvalue := t.pointer_value_rvalues[elem_name] or { false }
 		t.pointer_value_lvalues[elem_name] = true
-		t.pointer_value_rvalues.delete(elem_name)
+		t.pointer_value_rvalues[elem_name] = true
 		transformed_body = t.transform_stmts(body_ids)
 		if had_pointer_value_lvalue {
 			t.pointer_value_lvalues[elem_name] = true
@@ -1095,7 +1099,14 @@ fn (mut t Transformer) detect_for_in_type(node flat.Node) string {
 		}
 		iter_node := t.a.nodes[int(iter_id)]
 		if iter_node.kind == .ident && iter_node.value.len > 0 {
-			local_type := t.normalize_type_alias(t.var_type(iter_node.value))
+			mut local_type := t.normalize_type_alias(t.var_type(iter_node.value))
+			// A `mut` parameter is stored as a pointer by the C ABI, but iterating it
+			// without `mut value` still binds map values by value. Preserve real source
+			// `&map` expressions while removing only this implicit storage pointer.
+			if t.mut_param_values[iter_node.value] && local_type.starts_with('&')
+				&& for_iter_type_is_container(local_type[1..]) {
+				local_type = local_type[1..]
+			}
 			if local_type.len > 0 && for_iter_type_is_container(local_type) {
 				t.set_node_typ(int(iter_id), local_type)
 				return local_type
@@ -1116,7 +1127,8 @@ fn (mut t Transformer) detect_for_in_type(node flat.Node) string {
 		checker_type := t.raw_checker_node_type(iter_id)
 		if checker_type.len > 0 {
 			checker_payload := for_iter_payload_type(checker_type)
-			if for_iter_type_is_container(checker_payload) {
+			if for_iter_type_is_container(checker_payload)
+				|| t.iterator_for_in_info(checker_payload) != none {
 				if checker_payload == checker_type {
 					t.set_node_typ(int(iter_id), checker_type)
 				}
@@ -1168,11 +1180,11 @@ fn (t &Transformer) detect_for_in_global_fixed_array_type(id flat.NodeId) ?strin
 	if node.kind != .ident || node.value.len == 0 {
 		return none
 	}
-	if fixed_storage_type := t.const_array_literal_storage_type_name_for_expr(id) {
-		return fixed_storage_type
-	}
 	if t.var_type(node.value).len > 0 {
 		return none
+	}
+	if fixed_storage_type := t.const_array_literal_storage_type_name_for_expr(id) {
+		return fixed_storage_type
 	}
 	mut candidates := []string{}
 	if t.cur_module.len > 0 && t.cur_module != 'main' && t.cur_module != 'builtin' {

--- a/vlib/v3/transform/if.v
+++ b/vlib/v3/transform/if.v
@@ -564,6 +564,10 @@ fn (t &Transformer) if_expr_result_type(id flat.NodeId, node flat.Node) string {
 		}
 	}
 	branch_typ := t.if_expr_branch_result_type(node)
+	if branch_typ in ['', 'unknown'] && checked_typ in ['', 'unknown']
+		&& node_typ in ['', 'unknown'] && t.if_expr_has_c_macro_values(node) {
+		return 'int'
+	}
 	if branch_typ.starts_with('[]') && t.is_fixed_array_type(checked_typ)
 		&& fixed_array_elem_type(checked_typ) == branch_typ[2..] {
 		return branch_typ
@@ -591,6 +595,32 @@ fn (t &Transformer) if_expr_result_type(id flat.NodeId, node flat.Node) string {
 		return branch_typ
 	}
 	return ''
+}
+
+fn (t &Transformer) if_expr_has_c_macro_values(node flat.Node) bool {
+	if node.kind != .if_expr || node.children_count < 3 {
+		return false
+	}
+	return t.if_branch_is_c_macro_value(t.a.child(&node, 1))
+		&& t.if_branch_is_c_macro_value(t.a.child(&node, 2))
+}
+
+fn (t &Transformer) if_branch_is_c_macro_value(id flat.NodeId) bool {
+	if int(id) < 0 || int(id) >= t.a.nodes.len {
+		return false
+	}
+	node := t.a.nodes[int(id)]
+	if node.kind == .if_expr {
+		return t.if_expr_has_c_macro_values(node)
+	}
+	if node.kind in [.block, .expr_stmt, .paren] && node.children_count > 0 {
+		return t.if_branch_is_c_macro_value(t.a.child(&node, node.children_count - 1))
+	}
+	if node.kind != .selector || node.children_count == 0 {
+		return false
+	}
+	base := t.a.child_node(&node, 0)
+	return base.kind == .ident && base.value == 'C'
 }
 
 // if_expr_branch_type_overrides supports if expr branch type overrides handling for Transformer.

--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -2474,7 +2474,14 @@ fn (mut t Transformer) materialize_generic_struct_spec(spec_name string, decl Ge
 		}
 		field_type := substitute_generic_type_text_with_params(field.typ, args,
 			decl.node.generic_params())
-		normalized_field_type := t.normalize_type_alias(field_type)
+		// A field declared directly as its type parameter keeps the concrete
+		// argument's identity (and therefore alias methods/operators). Composite
+		// declarations still need normalization to expand aliases such as `Values[T]`.
+		normalized_field_type := if field.typ.trim_space() in decl.node.generic_params() {
+			field_type
+		} else {
+			t.normalize_type_alias(field_type)
+		}
 		fields << types.StructField{
 			name: field.value
 			typ:  t.tc.parse_resolution_type(normalized_field_type)

--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -2007,6 +2007,10 @@ fn (mut t Transformer) collect_generic_struct_specs_from_node(node flat.Node, mo
 		.struct_init, .array_init, .cast_expr, .as_expr, .sizeof_expr, .typeof_expr, .is_expr {
 			t.collect_generic_struct_spec_from_type(node.value, module_name, file_name, decls, mut
 				specs)
+			if !node.value.contains('[') && node.generic_params().len > 0 {
+				t.collect_generic_struct_spec_from_type('${node.value}[${node.generic_params().join(', ')}]',
+					module_name, file_name, decls, mut specs)
+			}
 		}
 		else {}
 	}
@@ -2184,6 +2188,10 @@ fn (mut t Transformer) collect_generic_sum_specs_from_node(node flat.Node, modul
 		.struct_init, .array_init, .cast_expr, .as_expr, .sizeof_expr, .typeof_expr, .is_expr {
 			t.collect_generic_sum_spec_from_type(node.value, module_name, file_name, decls, mut
 				specs)
+			if !node.value.contains('[') && node.generic_params().len > 0 {
+				t.collect_generic_sum_spec_from_type('${node.value}[${node.generic_params().join(', ')}]',
+					module_name, file_name, decls, mut specs)
+			}
 		}
 		else {}
 	}
@@ -2466,9 +2474,10 @@ fn (mut t Transformer) materialize_generic_struct_spec(spec_name string, decl Ge
 		}
 		field_type := substitute_generic_type_text_with_params(field.typ, args,
 			decl.node.generic_params())
+		normalized_field_type := t.normalize_type_alias(field_type)
 		fields << types.StructField{
 			name: field.value
-			typ:  t.tc.parse_resolution_type(field_type)
+			typ:  t.tc.parse_resolution_type(normalized_field_type)
 		}
 	}
 	t.tc.structs[spec_name] = fields
@@ -2783,6 +2792,8 @@ fn (mut t Transformer) emit_generic_fn_specialization(decl GenericFnDecl, args [
 	t.cur_fn_ret_type = old_clone_ret_type
 	t.cloning_generic_fn_depth--
 	t.a.specialized_fn_nodes[int(clone_id)] = true
+	t.a.specialized_fn_modules[int(clone_id)] = decl.module
+	t.a.specialized_fn_files[int(clone_id)] = decl.file
 	t.generic_fn_spec_nodes[spec_key] = clone_id
 	t.restore_var_types(old_clone_var_types)
 	t.specialize_cloned_fn_signature(clone_id, decl, concrete_args)
@@ -3031,22 +3042,22 @@ fn (mut t Transformer) seed_generated_decl_assign_binding(node flat.Node) {
 	if lhs.kind != .ident || lhs.value.len == 0 {
 		return
 	}
-	typ := t.generated_decl_assign_binding_type(node, lhs, rhs_id)
-	if typ.len > 0 {
-		t.set_var_type_with_raw(lhs.value, typ, typ)
+	raw_typ := t.generated_decl_assign_binding_type(node, lhs, rhs_id)
+	if raw_typ.len > 0 {
+		t.set_var_type_with_raw(lhs.value, t.normalize_type_alias(raw_typ), raw_typ)
 	}
 }
 
 fn (mut t Transformer) generated_decl_assign_binding_type(node flat.Node, lhs flat.Node, rhs_id flat.NodeId) string {
 	for candidate in [lhs.typ, node.typ] {
 		if candidate.len > 0 {
-			return t.normalize_type_alias(candidate)
+			return candidate
 		}
 	}
 	if int(rhs_id) >= 0 && int(rhs_id) < t.a.nodes.len {
 		rhs := t.a.nodes[int(rhs_id)]
 		if rhs.typ.len > 0 {
-			return t.normalize_type_alias(rhs.typ)
+			return rhs.typ
 		}
 		rhs_type := t.node_type(rhs_id)
 		if rhs_type.len > 0 {
@@ -3878,9 +3889,16 @@ fn (mut t Transformer) infer_generic_call_args_from_params(decl GenericFnDecl, c
 				}
 			}
 		}
-		arg_type := generic_arg_type_for_param(child.typ, inferred_arg_type)
+		inference_param_type := generic_inference_param_type(child)
+		if (child.is_mut || child.op == .amp || child.typ.starts_with('mut '))
+			&& inferred_arg_type.starts_with('&') {
+			// A mutable parameter's leading pointer is its storage ABI, whether the
+			// generic placeholder is direct (`T`) or nested (`Container[T]`).
+			inferred_arg_type = inferred_arg_type[1..]
+		}
+		arg_type := generic_arg_type_for_param(inference_param_type, inferred_arg_type)
 		if arg_type.len > 0 {
-			infer_generic_type_args(child.typ, arg_type, mut inferred)
+			infer_generic_type_args(inference_param_type, arg_type, mut inferred)
 			t.infer_generic_sum_variant_args(child.typ, arg_type, mut inferred)
 			if is_recv_param {
 				t.infer_generic_receiver_suffix_args(child.typ, arg_type, mut inferred)
@@ -4312,6 +4330,7 @@ fn (mut t Transformer) rewrite_method_level_generic_call(id flat.NodeId, node fl
 	concrete_args := t.canonical_generic_specialization_args(args)
 	spec_value := specialized_generic_fn_value(decl.node.value, concrete_args)
 	spec_name := transform_qualified_fn_name(decl.module, spec_value)
+	t.record_generic_specialization_args_for_names([spec_name, c_name(spec_name)], concrete_args)
 	ret_typ := t.specialized_signature_type_text(decl, decl.node.typ, concrete_args,
 		t.active_generic_params)
 	t.active_generic_params = old_params
@@ -4495,6 +4514,9 @@ fn (mut t Transformer) cached_generic_call_specialization(id flat.NodeId, node f
 						if generic_type_args_equal(resolved_raw, exact) {
 							return none
 						}
+						if t.generic_alias_erased_args_equal(exact, resolved_raw, module_name) {
+							return none
+						}
 						if generic_type_args_equal(resolved_raw, spec.args) {
 							return spec.decl_key, spec.args
 						}
@@ -4536,6 +4558,9 @@ fn (mut t Transformer) cached_generic_call_specialization(id flat.NodeId, node f
 			if raw := t.infer_generic_call_args_from_raw_node_types(decl, node) {
 				resolved_raw := t.resolved_live_generic_call_args(raw, module_name, decl.module)
 				if exact := t.recorded_generic_specialization_args(callee.value) {
+					if t.generic_alias_erased_args_equal(exact, resolved_raw, module_name) {
+						return none
+					}
 					if !generic_type_args_equal(resolved_raw, exact)
 						&& !t.generic_args_have_placeholders(resolved_raw) {
 						t.generic_call_spec_cache[idx] = GenericCallSpec{
@@ -4564,7 +4589,7 @@ fn (mut t Transformer) cached_generic_call_specialization(id flat.NodeId, node f
 		}
 		return spec.decl_key, spec.args
 	}
-	if t.generic_call_spec_misses[idx] {
+	if t.generic_call_spec_misses[idx] && !t.in_monomorphize_scan {
 		return none
 	}
 	decl_key, args := t.generic_call_specialization(id, node, module_name, decls) or { return none }
@@ -4599,6 +4624,19 @@ fn generic_type_args_equal(left []string, right []string) bool {
 	return true
 }
 
+fn (t &Transformer) generic_alias_erased_args_equal(exact []string, inferred []string, module_name string) bool {
+	if exact.len != inferred.len || !t.generic_args_contain_alias(exact, module_name) {
+		return false
+	}
+	for i, arg in exact {
+		if t.generic_inference_alias_target(arg, module_name) != t.generic_inference_alias_target(inferred[i],
+			module_name) {
+			return false
+		}
+	}
+	return true
+}
+
 fn (mut t Transformer) infer_generic_call_args_from_raw_node_types(decl GenericFnDecl, node flat.Node) ?[]string {
 	params := t.generic_fn_param_names(decl.node, decl.module)
 	if params.len == 0 {
@@ -4618,9 +4656,18 @@ fn (mut t Transformer) infer_generic_call_args_from_raw_node_types(decl GenericF
 			continue
 		}
 		arg := t.a.nodes[int(arg_id)]
-		raw_type := generic_arg_type_for_param(param.typ, arg.typ)
+		inference_param_type := generic_inference_param_type(param)
+		mut raw_arg_type := arg.typ
+		if (param.is_mut || param.op == .amp || param.typ.starts_with('mut '))
+			&& arg.kind == .prefix && arg.op == .amp && raw_arg_type.starts_with('&') {
+			// A rewritten `mut value` call stores the C ABI address on the argument
+			// node. Infer the generic from the language-level value, removing exactly
+			// that storage pointer (and preserving a pointer-valued `T`).
+			raw_arg_type = raw_arg_type[1..]
+		}
+		raw_type := generic_arg_type_for_param(inference_param_type, raw_arg_type)
 		if raw_type.len > 0 {
-			infer_generic_type_args(param.typ, raw_type, mut inferred)
+			infer_generic_type_args(inference_param_type, raw_type, mut inferred)
 		}
 		param_idx++
 	}
@@ -4802,16 +4849,14 @@ fn (mut t Transformer) generic_call_decl_key(id flat.NodeId, node flat.Node, mod
 	}
 	if !isnil(t.tc) {
 		if resolved := t.tc.resolved_call_name(id) {
-			key := t.generic_resolved_call_decl_key(resolved, callee, node, module_name, decls) or {
-				return none
-			}
-			if decl := decls[key] {
-				if !t.generic_call_arg_count_matches_decl(node, decl) {
-					return none
+			if key := t.generic_resolved_call_decl_key(resolved, callee, node, module_name, decls) {
+				if decl := decls[key] {
+					if !t.generic_call_arg_count_matches_decl(node, decl) {
+						return none
+					}
+					return key
 				}
-				return key
 			}
-			return none
 		}
 	}
 	if callee.kind == .ident {
@@ -5641,9 +5686,10 @@ fn (mut t Transformer) infer_generic_call_args_seeded(decl GenericFnDecl, _id fl
 				}
 			}
 		}
-		arg_type := generic_arg_type_for_param(child.typ, inferred_arg_type)
+		inference_param_type := generic_inference_param_type(child)
+		arg_type := generic_arg_type_for_param(inference_param_type, inferred_arg_type)
 		if arg_type.len > 0 {
-			infer_generic_type_args(child.typ, arg_type, mut inferred)
+			infer_generic_type_args(inference_param_type, arg_type, mut inferred)
 			t.infer_generic_sum_variant_args(child.typ, arg_type, mut inferred)
 			if is_recv_param {
 				t.infer_generic_receiver_suffix_args(child.typ, arg_type, mut inferred)
@@ -6491,15 +6537,27 @@ fn (mut t Transformer) generic_call_arg_type_for_inference(id flat.NodeId) strin
 	}
 	node := t.a.nodes[int(id)]
 	if node.kind == .prefix && node.op == .amp && node.children_count > 0 {
-		// `mut val T` is represented internally as `&T`, but taking its address
-		// passes `&T`, not `&&T`. Infer from the value type of the child so nested
-		// generic calls do not specialize their payload as a pointer.
-		inner := t.generic_call_arg_type_for_inference(t.a.child(&node, 0))
+		child_id := t.a.child(&node, 0)
+		child := t.a.nodes[int(child_id)]
+		inner := t.generic_call_arg_type_for_inference(child_id)
 		if inner.len > 0 {
+			// `mut value` is lowered to an address for the C calling convention, but
+			// generic inference still sees the value's language-level type. A source
+			// `&value` is a real pointer expression and retains the extra indirection.
+			if child.is_mut {
+				return inner
+			}
 			return '&${inner}'
 		}
 	}
 	if node.kind == .call {
+		map_type := t.new_map_call_type(node)
+		if map_type.len > 0 {
+			return map_type
+		}
+		if array_type := t.array_call_type_name(node) {
+			return array_type
+		}
 		concrete_ret := t.concrete_generic_call_return_type(id, node)
 		if concrete_ret.len > 0 && !t.generic_arg_is_unresolved(concrete_ret) {
 			return concrete_ret
@@ -6522,13 +6580,20 @@ fn (mut t Transformer) generic_call_arg_type_for_inference(id flat.NodeId) strin
 		}
 	}
 	if node.kind == .ident {
+		if t.mut_value_ident_nodes[int(id)] && generic_inference_arg_type_usable(node.typ) {
+			return node.typ
+		}
+		if sc := t.find_smartcast(node.value) {
+			target := t.smartcast_target_type(sc)
+			if generic_inference_arg_type_usable(target)
+				&& !t.generic_arg_is_unresolved(t.normalize_type_alias(target)) {
+				return t.canonical_generic_specialization_arg(target)
+			}
+		}
 		if refined := t.refined_node_types[int(id)] {
 			if refined.len > 0 && !t.generic_arg_is_unresolved(refined) {
 				return refined
 			}
-		}
-		if t.mut_value_ident_nodes[int(id)] && node.typ.starts_with('&') {
-			return node.typ[1..]
 		}
 		// During the ordinary monomorphize node scan there is no live function
 		// scope: var_types holds bindings from whatever function was transformed
@@ -6538,18 +6603,15 @@ fn (mut t Transformer) generic_call_arg_type_for_inference(id flat.NodeId) strin
 		if t.in_monomorphize_scan && t.cloning_generic_fn_depth == 0
 			&& generic_inference_arg_type_usable(node.typ)
 			&& !t.generic_arg_is_unresolved(t.normalize_type_alias(node.typ)) {
-			return t.generic_inference_alias_target(node.typ, t.node_module_or(int(id),
+			return t.generic_inference_argument_type(node.typ, t.node_module_or(int(id),
 				t.cur_module))
 		}
 		var_typ := t.var_type(node.value)
 		raw_var_typ := t.raw_var_type(node.value)
-		mut scoped_var_typ := if raw_var_typ.len > 0 { raw_var_typ } else { var_typ }
+		scoped_var_typ := if raw_var_typ.len > 0 { raw_var_typ } else { var_typ }
 		// Cloned generic bodies have a live specialization scope. Prefer that
 		// binding over the source node's checker cache, which belongs to the shared
 		// template and can reflect a previously emitted specialization.
-		if scoped_var_typ.starts_with('&') && t.mut_param_values[node.value] {
-			scoped_var_typ = scoped_var_typ[1..]
-		}
 		if t.cloning_generic_fn_depth > 0 && scoped_var_typ.len > 0 {
 			return t.canonical_generic_specialization_arg(scoped_var_typ)
 		}
@@ -6558,17 +6620,17 @@ fn (mut t Transformer) generic_call_arg_type_for_inference(id flat.NodeId) strin
 				checked_name := checked.name()
 				if generic_inference_arg_type_usable(checked_name)
 					&& !t.generic_arg_is_unresolved(t.normalize_type_alias(checked_name)) {
-					return t.generic_inference_alias_target(checked_name, t.node_module_or(int(id),
+					return t.generic_inference_argument_type(checked_name, t.node_module_or(int(id),
 						t.cur_module))
 				}
 			}
 		}
 		if scoped_var_typ.len > 0 {
-			return t.generic_inference_alias_target(scoped_var_typ, t.node_module_or(int(id),
+			return t.generic_inference_argument_type(scoped_var_typ, t.node_module_or(int(id),
 				t.cur_module))
 		}
 		if decl_type := t.local_decl_type_before(node.value, id) {
-			return t.generic_inference_alias_target(decl_type, t.node_module_or(int(id),
+			return t.generic_inference_argument_type(decl_type, t.node_module_or(int(id),
 				t.cur_module))
 		}
 	}
@@ -6593,6 +6655,14 @@ fn generic_inference_arg_type_usable(typ string) bool {
 	return decl_type_is_usable(clean) && clean != 'void'
 }
 
+fn (t &Transformer) generic_inference_argument_type(typ string, module_name string) string {
+	clean := typ.trim_space()
+	if t.generic_type_text_contains_alias(clean, module_name) {
+		return t.generic_arg_for_call_and_decl_module(clean, module_name, module_name)
+	}
+	return t.generic_inference_alias_target(clean, module_name)
+}
+
 fn (mut t Transformer) generic_receiver_needs_decl_type_fallback(param_type string, arg_type string) bool {
 	if !generic_inference_arg_type_usable(arg_type) {
 		return true
@@ -6607,7 +6677,15 @@ fn (mut t Transformer) generic_receiver_needs_decl_type_fallback(param_type stri
 		t.infer_generic_receiver_suffix_args(param_type, probe_arg_type, mut inferred)
 		t.infer_generic_embedded_receiver_args(param_type, probe_arg_type, mut inferred)
 	}
-	return inferred.len == 0
+	if inferred.len == 0 {
+		return true
+	}
+	for name, arg in inferred {
+		if arg == name || t.generic_arg_is_unresolved(arg) {
+			return true
+		}
+	}
+	return false
 }
 
 fn (t &Transformer) generic_inference_alias_target(typ string, module_name string) string {
@@ -7369,6 +7447,14 @@ fn (mut t Transformer) clone_generic_node_from(node flat.Node, args []string, is
 			cloned_op = .arrow
 		}
 	}
+	if node.kind == .prefix && children.len > 0 {
+		child_type := t.node_type(children[0])
+		if node.op == .mul && child_type.starts_with('&') {
+			cloned_typ = child_type[1..]
+		} else if node.op == .amp && child_type.len > 0 {
+			cloned_typ = '&${child_type}'
+		}
+	}
 	// Record the local's substituted type as the body is cloned: later sibling
 	// clones (nested generic calls) infer their type args from these locals, and
 	// without a binding the lookup falls back to an arena scan that can land in
@@ -7376,6 +7462,11 @@ fn (mut t Transformer) clone_generic_node_from(node flat.Node, args []string, is
 	if node.kind == .decl_assign && node.children_count == 2 && t.cloning_comptime_for_depth == 0 {
 		lhs_clone := t.a.nodes[int(children[0])]
 		if lhs_clone.kind == .ident && lhs_clone.value.len > 0 {
+			// Synthetic declarations created while transforming a generic template
+			// carry their intended type on the declaration itself. Once substituted,
+			// that concrete type is more precise than a helper call's broad checker type.
+			has_concrete_substituted_type := substituted_node_type != node.typ
+				&& decl_type_is_usable(cloned_typ) && !t.generic_arg_is_unresolved(cloned_typ)
 			rhs_node := t.a.nodes[int(children[1])]
 			rhs_raw_typ := if t.generic_type_text_contains_alias(rhs_node.typ, t.cur_module) {
 				rhs_node.typ
@@ -7390,11 +7481,21 @@ fn (mut t Transformer) clone_generic_node_from(node flat.Node, args []string, is
 			if rhs_typ.len == 0 {
 				rhs_typ = t.node_type(children[1])
 			}
-			if rhs_typ.len > 0 && !t.generic_arg_is_unresolved(rhs_typ) {
+			if !has_concrete_substituted_type && rhs_typ.len > 0
+				&& !t.generic_arg_is_unresolved(rhs_typ) {
 				cloned_typ = rhs_typ
 				t.set_node_typ(int(children[0]), rhs_typ)
 			}
-			lhs_typ := if rhs_typ.len > 0 { rhs_typ } else { cloned_typ }
+			lhs_typ := if has_concrete_substituted_type {
+				cloned_typ
+			} else if rhs_typ.len > 0 {
+				rhs_typ
+			} else {
+				cloned_typ
+			}
+			if has_concrete_substituted_type {
+				t.set_node_typ(int(children[0]), cloned_typ)
+			}
 			if lhs_typ.len > 0 && !t.generic_arg_is_unresolved(lhs_typ) {
 				t.set_var_type_with_raw(lhs_clone.value, t.normalize_type_alias(lhs_typ), lhs_typ)
 			}
@@ -7572,6 +7673,12 @@ fn (mut t Transformer) generic_comptime_typeof_target(node flat.Node, args []str
 	if typ := generic_type_name_from_marker(node.value) {
 		idx := t.active_generic_param_index(typ)
 		if idx < args.len {
+			if node.children_count > 0 {
+				child := t.a.child_node(&node, 0)
+				if child.kind == .ident && t.mut_param_values[child.value] {
+					return '&${args[idx]}'
+				}
+			}
 			return args[idx]
 		}
 	}
@@ -7816,10 +7923,6 @@ fn (mut t Transformer) retarget_cloned_generic_call(node flat.Node, mut children
 			return ''
 		}
 		mut inferred := map[string]string{}
-		if t.cur_fn_ret_type.len > 0 {
-			infer_generic_type_args(decl.node.typ,
-				t.generic_inference_expected_type(t.cur_fn_ret_type), mut inferred)
-		}
 		mut param_idx := 0
 		for i in 0 .. decl.node.children_count {
 			child := t.a.child_node(&decl.node, i)
@@ -7831,12 +7934,26 @@ fn (mut t Transformer) retarget_cloned_generic_call(node flat.Node, mut children
 				param_idx++
 				continue
 			}
-			arg_type := generic_arg_type_for_param(child.typ,
-				t.generic_call_arg_type_for_inference(children[arg_pos]))
+			inference_param_type := generic_inference_param_type(child)
+			mut raw_arg_type := t.generic_call_arg_type_for_inference(children[arg_pos])
+			if !is_generic_fn_placeholder_name(inference_param_type) {
+				raw_arg_type = t.generic_inference_alias_target(raw_arg_type, t.cur_module)
+			}
+			arg_type := generic_arg_type_for_param(inference_param_type, raw_arg_type)
 			if arg_type.len > 0 {
-				infer_generic_type_args(child.typ, arg_type, mut inferred)
+				infer_generic_type_args(inference_param_type, arg_type, mut inferred)
 			}
 			param_idx++
+		}
+		if inferred.len < param_names.len && t.cur_fn_ret_type.len > 0 {
+			mut return_inferred := map[string]string{}
+			infer_generic_type_args(decl.node.typ,
+				t.generic_inference_expected_type(t.cur_fn_ret_type), mut return_inferred)
+			for name, inferred_type in return_inferred {
+				if name !in inferred {
+					inferred[name] = inferred_type
+				}
+			}
 		}
 		for name in param_names {
 			arg := inferred[name] or {
@@ -7985,6 +8102,9 @@ fn (mut t Transformer) retarget_cloned_implicit_generic_call(clone_id flat.NodeI
 		|| (source_has_explicit_args && !is_receiver) {
 		return
 	}
+	// Re-infer receiver-only parameters too. Calls inside a cloned generic closure
+	// may be the first concrete use of that method, so no receiver specialization
+	// necessarily exists yet to retarget the call.
 	mut callee_id := t.a.child(&clone, 0)
 	if int(callee_id) < 0 || int(callee_id) >= t.a.nodes.len {
 		return
@@ -8022,10 +8142,6 @@ fn (mut t Transformer) retarget_cloned_implicit_generic_call(clone_id flat.NodeI
 		} else {
 			[]string{}
 		}
-		if t.cur_fn_ret_type.len > 0 {
-			t.infer_generic_return_type_args(decl,
-				t.generic_inference_expected_type(t.cur_fn_ret_type), mut inferred, receiver_params)
-		}
 		mut param_idx := 0
 		for i in 0 .. decl.node.children_count {
 			child := t.a.child_node(&decl.node, i)
@@ -8057,15 +8173,43 @@ fn (mut t Transformer) retarget_cloned_implicit_generic_call(clone_id flat.NodeI
 				&& !t.generic_arg_is_unresolved(source_arg_type) {
 				arg_type = source_arg_type
 			}
-			if arg_type.starts_with('&') && !child.typ.starts_with('&')
+			is_recv_param := is_receiver && param_idx == 0
+			inference_param_type := generic_inference_param_type(child)
+			clone_arg := t.a.nodes[int(clone_arg_id)]
+			if clone_arg.kind == .ident && t.mut_value_ident_nodes[int(clone_arg_id)]
+				&& arg_type.starts_with('&') && !inference_param_type.starts_with('&')
+				&& !inference_param_type.starts_with('mut ') {
+				// A mutable outer parameter is stored through a pointer, but passing
+				// its value to an ordinary generic parameter must infer the payload.
+				arg_type = arg_type[1..]
+			}
+			if is_recv_param && arg_type.starts_with('&') && !child.typ.starts_with('&')
 				&& !child.typ.starts_with('mut ') {
 				arg_type = arg_type[1..]
 			}
-			arg_type = generic_arg_type_for_param(child.typ, arg_type)
+			if (child.is_mut || child.op == .amp || child.typ.starts_with('mut '))
+				&& arg_type.starts_with('&') {
+				arg_type = arg_type[1..]
+			}
+			if !is_generic_fn_placeholder_name(inference_param_type) {
+				arg_type = t.generic_inference_alias_target(arg_type, t.cur_module)
+			}
+			arg_type = generic_arg_type_for_param(inference_param_type, arg_type)
 			if arg_type.len > 0 {
-				infer_generic_type_args(child.typ, arg_type, mut inferred)
+				infer_generic_type_args(inference_param_type, arg_type, mut inferred)
 			}
 			param_idx++
+		}
+		if inferred.len < param_names.len && t.cur_fn_ret_type.len > 0 {
+			mut return_inferred := map[string]string{}
+			t.infer_generic_return_type_args(decl,
+				t.generic_inference_expected_type(t.cur_fn_ret_type), mut return_inferred,
+				receiver_params)
+			for name, inferred_type in return_inferred {
+				if name !in inferred {
+					inferred[name] = inferred_type
+				}
+			}
 		}
 		for name in param_names {
 			arg := inferred[name] or { return }
@@ -8097,25 +8241,9 @@ fn (mut t Transformer) retarget_cloned_implicit_generic_call(clone_id flat.NodeI
 }
 
 fn (t &Transformer) generic_specialization_registered(decl GenericFnDecl, args []string) bool {
-	spec_value := specialized_generic_fn_value(decl.node.value, args)
-	qname := transform_qualified_fn_name(decl.module, spec_value)
-	cspec_value := c_name(spec_value)
-	for name in [spec_value, qname, cspec_value, c_name(qname)] {
-		if !isnil(t.tc) && (name == spec_value || name == cspec_value) {
-			if registered_module := t.tc.fn_type_modules[name] {
-				if registered_module != decl.module {
-					continue
-				}
-			}
-		}
-		if name in t.fn_ret_types {
-			return true
-		}
-		if !isnil(t.tc) && (name in t.tc.fn_ret_types || name in t.tc.fn_param_types) {
-			return true
-		}
-	}
-	return false
+	// Signatures are registered as soon as a specialization is queued, before its
+	// body is cloned. Only the emitted-node index proves that the body exists.
+	return t.generic_specialization_progress_key(decl, args) in t.generic_fn_spec_nodes
 }
 
 fn (t &Transformer) generic_specialization_in_progress(decl GenericFnDecl, args []string) bool {
@@ -8146,7 +8274,8 @@ fn (mut t Transformer) copy_cloned_resolution(src_id flat.NodeId, dst_id flat.No
 		return
 	}
 	if call_name := t.tc.resolved_call_name(src_id) {
-		if !t.resolved_call_is_generic_fn(call_name) {
+		if !t.cloned_call_has_exact_generic_callee(dst_idx)
+			&& !t.resolved_call_is_generic_fn(call_name) {
 			t.set_resolved_call_entry(dst_idx, call_name)
 		}
 	}
@@ -8161,7 +8290,8 @@ fn (mut t Transformer) copy_cloned_resolution_forked(src_idx int, dst_idx int) {
 	if call_name.len == 0 && src_idx < t.tc.resolved_call_set.len && t.tc.resolved_call_set[src_idx] {
 		call_name = t.tc.resolved_call_names[src_idx]
 	}
-	if call_name.len > 0 && !t.resolved_call_is_generic_fn(call_name) {
+	if call_name.len > 0 && !t.cloned_call_has_exact_generic_callee(dst_idx)
+		&& !t.resolved_call_is_generic_fn(call_name) {
 		overlay.resolved_call_names[dst_idx] = call_name
 	}
 	mut fn_value := overlay.resolved_fn_values[src_idx] or { '' }
@@ -8172,6 +8302,19 @@ fn (mut t Transformer) copy_cloned_resolution_forked(src_idx int, dst_idx int) {
 	if fn_value.len > 0 {
 		overlay.resolved_fn_values[dst_idx] = fn_value
 	}
+}
+
+fn (t &Transformer) cloned_call_has_exact_generic_callee(idx int) bool {
+	if idx < 0 || idx >= t.a.nodes.len {
+		return false
+	}
+	node := t.a.nodes[idx]
+	if node.kind != .call || node.children_count == 0 {
+		return false
+	}
+	callee := t.a.child_node(&node, 0)
+	return callee.kind == .ident && ((callee.value.contains('[') && callee.value.contains(']'))
+		|| t.generic_callee_is_specialization(callee.value))
 }
 
 fn (t &Transformer) resolved_call_is_generic_fn(name string) bool {
@@ -8213,6 +8356,9 @@ fn (mut t Transformer) fn_decl_has_unresolved_generics(node flat.Node, module_na
 	if generic_params_have_runtime_type_param(node.generic_params()) {
 		return true
 	}
+	if t.fn_decl_receiver_is_open_generic(node, module_name) {
+		return true
+	}
 	if t.skip_generics {
 		return false
 	}
@@ -8224,6 +8370,30 @@ fn (mut t Transformer) fn_decl_has_unresolved_generics(node flat.Node, module_na
 		child := t.a.child_node(&node, i)
 		if child.kind == .param && t.type_text_has_generic_placeholder(child.typ, module_name) {
 			return true
+		}
+	}
+	return false
+}
+
+fn (t &Transformer) fn_decl_receiver_is_open_generic(node flat.Node, module_name string) bool {
+	if !node.value.contains('.') || isnil(t.tc) {
+		return false
+	}
+	receiver := node.value.all_before_last('.')
+	base, args, ok := generic_app_parts(receiver)
+	if !ok || args.len == 0 {
+		return false
+	}
+	mut candidates := [base]
+	if !base.contains('.') && module_name.len > 0 && module_name !in ['main', 'builtin'] {
+		candidates << '${module_name}.${base}'
+	}
+	for candidate in candidates {
+		params := t.tc.struct_generic_params[candidate] or { continue }
+		for arg in args {
+			if arg.trim_space() in params {
+				return true
+			}
 		}
 	}
 	return false
@@ -9248,6 +9418,17 @@ fn generic_arg_type_for_param(param_type string, arg_type string) string {
 	return actual
 }
 
+fn generic_inference_param_type(param &flat.Node) string {
+	clean := param.typ.trim_space()
+	if (param.is_mut || param.op == .amp) && clean.starts_with('&') {
+		return clean[1..]
+	}
+	if clean.starts_with('mut ') {
+		return clean[4..].trim_space()
+	}
+	return clean
+}
+
 fn (t &Transformer) generic_inference_expected_type(typ string) string {
 	if source := t.generic_specialized_source_type_name(typ) {
 		return source
@@ -9281,6 +9462,14 @@ fn (t &Transformer) subst_comptime_type_operand(raw string, args []string) strin
 		// `$int`, `$struct`, ... are metatype keywords, not type names; they must
 		// not be substituted or module-qualified (`mymod.$int` breaks matching).
 		return clean
+	}
+	if reflected_type, reflected_member := generic_comptime_typeof_operand(clean) {
+		substituted := t.resolve_substituted_type_text(t.subst_type(reflected_type, args))
+		return match reflected_member {
+			'unaliased_typ' { t.comptime_normalize_type_alias_chain(substituted) }
+			'typ' { substituted + '.typ' }
+			else { substituted }
+		}
 	}
 	if t.cloning_comptime_for_depth > 0 && !clean.contains('.') && t.raw_var_type(clean).len > 0 {
 		// A runtime value can be smartcast by the current comptime loop variant.
@@ -9329,6 +9518,31 @@ fn (t &Transformer) subst_comptime_type_operand(raw string, args []string) strin
 		}
 	}
 	return t.resolve_substituted_type_text(t.subst_type(clean, args))
+}
+
+fn generic_comptime_typeof_operand(raw string) ?(string, string) {
+	clean := raw.trim_space()
+	if !clean.starts_with('typeof[') {
+		return none
+	}
+	open := 'typeof'.len
+	close := generic_matching_bracket(clean, open)
+	if close >= clean.len {
+		return none
+	}
+	type_name := clean[open + 1..close].trim_space()
+	if type_name.len == 0 {
+		return none
+	}
+	mut suffix := clean[close + 1..].replace(' ', '')
+	if suffix.starts_with('()') {
+		suffix = suffix[2..]
+	}
+	member := if suffix.starts_with('.') { suffix[1..] } else { suffix }
+	if member !in ['', 'idx', 'typ', 'unaliased_typ'] {
+		return none
+	}
+	return type_name, member
 }
 
 // active_generic_param_index returns the position of a placeholder name within the
@@ -9586,6 +9800,11 @@ fn (t &Transformer) canonical_generic_specialization_arg(arg string) string {
 	if clean.len == 0 {
 		return clean
 	}
+	if clean.starts_with('map_') {
+		if source := t.source_composite_type_from_c_name(clean) {
+			return t.canonical_generic_specialization_arg(source)
+		}
+	}
 	if t.substituted_type_belongs_to_main_generic(clean)
 		&& t.current_specialization_has_generic_arg(clean) {
 		return clean
@@ -9685,6 +9904,50 @@ fn (t &Transformer) canonical_generic_specialization_arg(arg string) string {
 		return decoded_array
 	}
 	return clean
+}
+
+fn (t &Transformer) source_composite_type_from_c_name(encoded string) ?string {
+	for node in t.a.nodes {
+		if source := source_composite_type_candidate(encoded, node.typ) {
+			return source
+		}
+	}
+	for _, info in t.structs {
+		for field in info.fields {
+			if source := source_composite_type_candidate(encoded, field.raw_typ) {
+				return source
+			}
+			if source := source_composite_type_candidate(encoded, field.typ) {
+				return source
+			}
+		}
+	}
+	return none
+}
+
+fn source_composite_type_candidate(encoded string, raw string) ?string {
+	clean := raw.trim_space()
+	if clean.len == 0 {
+		return none
+	}
+	if clean.starts_with('map[') && c_name(clean) == encoded {
+		return clean
+	}
+	for prefix in ['mut ', 'shared ', 'atomic ', '...', '[]', '?', '!', '&', 'chan '] {
+		if clean.starts_with(prefix) {
+			return source_composite_type_candidate(encoded, clean[prefix.len..])
+		}
+	}
+	if clean.starts_with('map[') {
+		bracket_end := generic_matching_bracket(clean, 3)
+		if bracket_end > 3 && bracket_end + 1 < clean.len {
+			if source := source_composite_type_candidate(encoded, clean[4..bracket_end]) {
+				return source
+			}
+			return source_composite_type_candidate(encoded, clean[bracket_end + 1..])
+		}
+	}
+	return none
 }
 
 fn (t &Transformer) canonical_suffix_fixed_array_arg(arg string) ?string {

--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -9473,6 +9473,7 @@ fn (t &Transformer) subst_comptime_type_operand(raw string, args []string) strin
 	if reflected_type, reflected_member := generic_comptime_typeof_operand(clean) {
 		substituted := t.resolve_substituted_type_text(t.subst_type(reflected_type, args))
 		return match reflected_member {
+			'idx' { t.comptime_field_type_id(substituted, t.cur_module).str() }
 			'unaliased_typ' { t.comptime_normalize_type_alias_chain(substituted) }
 			'typ' { substituted + '.typ' }
 			else { substituted }

--- a/vlib/v3/transform/monomorphize_test.v
+++ b/vlib/v3/transform/monomorphize_test.v
@@ -1,0 +1,61 @@
+module transform
+
+import v3.flat
+import v3.types
+
+fn test_materialized_generic_struct_fields_preserve_plain_alias_arguments() {
+	mut a := flat.FlatAst.new()
+	mut values_alias := flat.Node{
+		kind:  .type_decl
+		value: 'Values'
+		typ:   '[]T'
+	}
+	values_alias.set_generic_params(['T'])
+	a.add_node(values_alias)
+
+	value_field := a.add_node(flat.Node{
+		kind:  .field_decl
+		value: 'value'
+		typ:   'T'
+	})
+	values_field := a.add_node(flat.Node{
+		kind:  .field_decl
+		value: 'values'
+		typ:   'Values[T]'
+	})
+	children_start := a.children.len
+	a.children << value_field
+	a.children << values_field
+	mut box_decl := flat.Node{
+		kind:           .struct_decl
+		value:          'Box'
+		children_start: children_start
+		children_count: 2
+	}
+	box_decl.set_generic_params(['T'])
+	box_id := a.add_node(box_decl)
+
+	mut tc := types.TypeChecker.new(&a)
+	tc.cur_module = 'main'
+	tc.type_aliases['UserId'] = 'int'
+	tc.type_aliases['Values'] = '[]T'
+	tc.type_alias_generic_params['Values'] = ['T']
+	mut t := new_transformer(mut a, &tc, map[string]bool{})
+	t.cur_module = 'main'
+	t.materialize_generic_struct_spec('Box[UserId]', GenericStructDecl{
+		id:     box_id
+		node:   box_decl
+		module: 'main'
+		key:    'Box'
+	})
+
+	fields := tc.structs['Box[UserId]'] or {
+		assert false, 'missing materialized Box[UserId] fields'
+		return
+	}
+	assert fields.len == 2
+	assert fields[0].typ is types.Alias
+	assert fields[0].typ.name() == 'UserId'
+	assert fields[1].typ is types.Array
+	assert fields[1].typ.name() == '[]int'
+}

--- a/vlib/v3/transform/or.v
+++ b/vlib/v3/transform/or.v
@@ -106,6 +106,9 @@ fn (mut t Transformer) array_get_call_info(call_id flat.NodeId) ?ArrayIndexInfo 
 	if fn_node.kind != .selector || fn_node.value != 'get' || fn_node.children_count == 0 {
 		return none
 	}
+	if _ := t.checker_selected_receiver_method_name(call_id, 'array.get') {
+		return none
+	}
 	return t.array_index_info_from_parts(t.a.child(fn_node, 0), t.a.child(&call, 1))
 }
 
@@ -267,7 +270,7 @@ fn (mut t Transformer) channel_receive_info(expr_id flat.NodeId) ?ChannelReceive
 		clean_type := types.unwrap_pointer(raw_type)
 		if clean_type is types.Channel {
 			value_type := t.normalize_type_alias(clean_type.elem_type.name())
-			if value_type.len > 0 {
+			if value_type.len > 0 && value_type !in ['void', 'unknown'] {
 				return ChannelReceiveInfo{
 					channel_id:  channel_id
 					value_type:  value_type
@@ -939,6 +942,9 @@ fn (mut t Transformer) or_expr_types(expr_id flat.NodeId, fallback_type string) 
 	}
 	if !isnil(t.tc) {
 		if expr_node.kind == .call {
+			if thread_ret := t.thread_wait_or_expr_type(expr_node) {
+				return t.canonical_or_expr_types(thread_ret)
+			}
 			if expr_node.children_count > 0 {
 				callee := t.a.child_node(&expr_node, 0)
 				if callee.kind == .ident && t.generic_callee_is_specialization(callee.value)
@@ -957,6 +963,19 @@ fn (mut t Transformer) or_expr_types(expr_id flat.NodeId, fallback_type string) 
 			concrete_ret := t.concrete_generic_call_return_type(expr_id, expr_node)
 			if t.is_optional_type_name(concrete_ret) && !t.generic_arg_is_unresolved(concrete_ret) {
 				return t.canonical_or_expr_types(concrete_ret)
+			}
+			if typ := t.tc.expr_type(expr_id) {
+				mut prefix := ''
+				if typ is types.OptionType {
+					prefix = '?'
+				} else if typ is types.ResultType {
+					prefix = '!'
+				}
+				if prefix.len > 0 {
+					if multi_types := multi_return_types_from_type(typ, 0) {
+						return t.canonical_or_expr_types('${prefix}${t.multi_return_type_name(multi_types)}')
+					}
+				}
 			}
 			call_ret := t.get_call_return_type(expr_id, expr_node)
 			if t.is_optional_type_name(call_ret) && !t.generic_arg_is_unresolved(call_ret) {
@@ -1029,6 +1048,40 @@ fn (mut t Transformer) or_expr_types(expr_id flat.NodeId, fallback_type string) 
 	return expr_type, value_type
 }
 
+fn (mut t Transformer) thread_wait_or_expr_type(call flat.Node) ?string {
+	if call.children_count == 0 {
+		return none
+	}
+	callee := t.a.child_node(&call, 0)
+	if callee.kind != .selector || callee.value != 'wait' || callee.children_count == 0 {
+		return none
+	}
+	base_id := t.a.child(callee, 0)
+	base := t.a.nodes[int(base_id)]
+	mut base_type := if base.kind == .ident { t.raw_var_type(base.value) } else { '' }
+	if base_type.len == 0 {
+		base_type = t.resolve_expr_type(base_id)
+	}
+	clean := base_type.trim_space().trim_left('&').trim_space()
+	if t.is_fixed_array_type(clean) {
+		return thread_array_wait_return_type(fixed_array_elem_type(clean))
+	}
+	if clean.starts_with('[]') {
+		return thread_array_wait_return_type(clean[2..].trim_space())
+	}
+	if !clean.starts_with('thread ') {
+		return none
+	}
+	payload := clean[7..].trim_space()
+	if payload == '?' || payload == '!' {
+		return '${payload}void'
+	}
+	if payload.starts_with('?') || payload.starts_with('!') {
+		return payload
+	}
+	return none
+}
+
 fn (t &Transformer) canonical_or_expr_types(expr_type string) (string, string) {
 	mut clean_expr_type := expr_type
 	if !t.is_optional_type_name(clean_expr_type) {
@@ -1041,11 +1094,29 @@ fn (t &Transformer) canonical_or_expr_types(expr_type string) (string, string) {
 		return clean_expr_type, t.optional_base_type(clean_expr_type)
 	}
 	prefix := clean_expr_type[..1]
-	base := t.optional_base_type(clean_expr_type)
+	mut base := t.optional_base_type(clean_expr_type)
 	if base.len == 0 || base == 'void' || base == 'Optional' {
 		return '${prefix}void', 'void'
 	}
-	return clean_expr_type, base
+	// Monomorphized collection arguments can reach an or-expression in their
+	// flattened receiver spelling. Decode those names back to semantic V types so
+	// option wrappers use the runtime Array/map ABI instead of imaginary structs.
+	if base.starts_with('Array_') || base.starts_with('Map_') {
+		decoded := generic_type_arg_from_suffix_with_containers(base)
+		if decoded != base {
+			base = decoded
+		}
+	}
+	// Resolve import aliases and nested generic arguments in the payload. The
+	// optional wrapper and its lowered value temporary must use one canonical
+	// spelling (`json2.Any`, not the source alias `json.Any`).
+	if !isnil(t.tc) {
+		resolved := t.tc.parse_resolution_type(base)
+		if resolved !is types.Unknown && resolved !is types.Void {
+			base = resolved.name()
+		}
+	}
+	return '${prefix}${base}', base
 }
 
 fn (t &Transformer) json_decode_or_expr_type(expr_id flat.NodeId, expr_node flat.Node) ?string {
@@ -1533,7 +1604,7 @@ fn (mut t Transformer) lower_nested_optional_logical_infix_part(expr flat.Node, 
 	}
 }
 
-fn (mut t Transformer) lower_optional_leaf_with_outer_or(expr_id flat.NodeId, or_node flat.Node, result_name string, result_type string, ok_name string) ?NestedOptionalPart {
+fn (mut t Transformer) lower_optional_leaf_with_outer_or(expr_id flat.NodeId, or_node flat.Node, _result_name string, _result_type string, ok_name string) ?NestedOptionalPart {
 	if or_node.children_count < 2 {
 		return none
 	}
@@ -1561,9 +1632,10 @@ fn (mut t Transformer) lower_optional_leaf_with_outer_or(expr_id flat.NodeId, or
 	ok_cond := t.make_selector(opt_ident, 'ok', 'bool')
 	value_expr := t.make_selector(t.make_ident(opt_tmp), 'value', value_type)
 	then_block := t.make_block(arr1(t.make_assign(t.make_ident(val_tmp), value_expr)))
-	mut else_stmts := t.lower_or_body_to_stmts(body_id, result_name, result_type, or_node.value,
-		opt_tmp)
-	else_stmts << t.make_assign(t.make_ident(ok_name), t.make_bool_literal(false))
+	// The `or` body replaces this optional leaf, not the enclosing expression.
+	// For `lhs == optional() or { fallback }`, assign `fallback` to the leaf's
+	// value temp and let the outer comparison run normally.
+	else_stmts := t.lower_or_body_to_stmts(body_id, val_tmp, value_type, or_node.value, opt_tmp)
 	eval_stmts << t.make_if(ok_cond, then_block, t.make_block(else_stmts))
 	return NestedOptionalPart{
 		expr:    t.make_ident(val_tmp)
@@ -2075,6 +2147,8 @@ fn (mut t Transformer) lower_or_body_to_stmts_with_err_expr(body_id flat.NodeId,
 			} else if t.is_optional_type_name(t.cur_fn_ret_type)
 				&& t.return_expr_is_propagated_err(inner_id, target_type) {
 				result << t.make_none_return_stmt_with_err_expr(t.transform_expr(inner_id))
+			} else if inner.kind == .block && target_name.len > 0 {
+				result << t.if_value_branch_block(inner_id, target_name, target_type)
 			} else if t.node_type(inner_id) == 'void' && target_name.len == 0 {
 				expanded := t.transform_stmt(child_id)
 				t.drain_pending(mut result)
@@ -2097,6 +2171,8 @@ fn (mut t Transformer) lower_or_body_to_stmts_with_err_expr(body_id flat.NodeId,
 				t.drain_pending(mut result)
 				result << t.make_assign(t.make_ident(target_name), value)
 			}
+		} else if is_last && target_name.len > 0 && child.kind == .block {
+			result << t.if_value_branch_block(child_id, target_name, target_type)
 		} else if is_last && target_name.len > 0 && child.kind in [.if_expr, .match_stmt] {
 			value := if target_type in t.sum_types || t.resolve_sum_name(target_type) in t.sum_types {
 				t.wrap_sum_value(child_id, target_type)
@@ -2147,9 +2223,10 @@ fn (t &Transformer) is_noreturn_call(id flat.NodeId) bool {
 	if t.tc.resolved_call_name(id) != none {
 		return t.tc.resolved_call_never_returns(id)
 	}
-	fn_node := t.a.child_node(&node, 0)
-	if fn_node.kind == .ident && fn_node.value in ['panic', 'exit'] {
-		return t.var_type(fn_node.value).len == 0
+	callee := t.a.child_node(&node, 0)
+	if callee.kind == .ident && callee.value in ['panic', 'exit', 'v_panic'] {
+		return t.var_type(callee.value).len == 0
 	}
-	return false
+	name := t.resolve_call_name(node)
+	return name in ['panic', 'exit', 'os.exit', 'C.exit', 'builtin.panic']
 }

--- a/vlib/v3/transform/or.v
+++ b/vlib/v3/transform/or.v
@@ -1604,7 +1604,7 @@ fn (mut t Transformer) lower_nested_optional_logical_infix_part(expr flat.Node, 
 	}
 }
 
-fn (mut t Transformer) lower_optional_leaf_with_outer_or(expr_id flat.NodeId, or_node flat.Node, _result_name string, _result_type string, ok_name string) ?NestedOptionalPart {
+fn (mut t Transformer) lower_optional_leaf_with_outer_or(expr_id flat.NodeId, or_node flat.Node, result_name string, result_type string, ok_name string) ?NestedOptionalPart {
 	if or_node.children_count < 2 {
 		return none
 	}
@@ -1632,10 +1632,9 @@ fn (mut t Transformer) lower_optional_leaf_with_outer_or(expr_id flat.NodeId, or
 	ok_cond := t.make_selector(opt_ident, 'ok', 'bool')
 	value_expr := t.make_selector(t.make_ident(opt_tmp), 'value', value_type)
 	then_block := t.make_block(arr1(t.make_assign(t.make_ident(val_tmp), value_expr)))
-	// The `or` body replaces this optional leaf, not the enclosing expression.
-	// For `lhs == optional() or { fallback }`, assign `fallback` to the leaf's
-	// value temp and let the outer comparison run normally.
-	else_stmts := t.lower_or_body_to_stmts(body_id, val_tmp, value_type, or_node.value, opt_tmp)
+	mut else_stmts := t.lower_or_body_to_stmts(body_id, result_name, result_type, or_node.value,
+		opt_tmp)
+	else_stmts << t.make_assign(t.make_ident(ok_name), t.make_bool_literal(false))
 	eval_stmts << t.make_if(ok_cond, then_block, t.make_block(else_stmts))
 	return NestedOptionalPart{
 		expr:    t.make_ident(val_tmp)

--- a/vlib/v3/transform/return.v
+++ b/vlib/v3/transform/return.v
@@ -306,7 +306,8 @@ fn (mut t Transformer) try_convert_forwarded_wrapped_multi_return(value_id flat.
 	}
 	mut needs_conversion := false
 	for i, actual_type in actual_types {
-		if actual_type.name() != expected_types[i].name() {
+		if actual_type.name() != expected_types[i].name()
+			&& t.forwarded_slot_conversion_supported(actual_type, expected_types[i]) {
 			needs_conversion = true
 			break
 		}
@@ -361,7 +362,8 @@ fn (mut t Transformer) try_expand_forwarded_multi_return(source_return_id flat.N
 	actual_types := t.multi_return_types_for_expr(value_id, expected_types.len) or { return none }
 	mut needs_conversion := false
 	for i, actual_type in actual_types {
-		if actual_type.name() != expected_types[i].name() {
+		if actual_type.name() != expected_types[i].name()
+			&& t.forwarded_slot_conversion_supported(actual_type, expected_types[i]) {
 			needs_conversion = true
 			break
 		}
@@ -385,6 +387,9 @@ fn (mut t Transformer) try_expand_forwarded_multi_return(source_return_id flat.N
 }
 
 fn (mut t Transformer) transform_forwarded_return_slot(value_id flat.NodeId, actual types.Type, expected types.Type) flat.NodeId {
+	if !t.forwarded_slot_conversion_supported(actual, expected) {
+		return t.transform_expr(value_id)
+	}
 	actual_base := forwarded_return_unalias_type(actual)
 	expected_base := forwarded_return_unalias_type(expected)
 	if actual_base is types.OptionType && expected_base is types.OptionType
@@ -426,6 +431,9 @@ fn (mut t Transformer) transform_forwarded_return_slot(value_id flat.NodeId, act
 }
 
 fn (t &Transformer) forwarded_slot_conversion_supported(actual types.Type, expected types.Type) bool {
+	if forwarded_return_type_is_unresolved(actual) || forwarded_return_type_is_unresolved(expected) {
+		return false
+	}
 	actual_base := forwarded_return_unalias_type(actual)
 	expected_base := forwarded_return_unalias_type(expected)
 	if actual_base.name() == expected_base.name() {
@@ -460,6 +468,31 @@ fn (t &Transformer) forwarded_slot_conversion_supported(actual types.Type, expec
 	if actual_base is types.Map && expected_base is types.Map {
 		return t.forwarded_slot_conversion_supported(actual_base.key_type, expected_base.key_type)
 			|| t.forwarded_slot_conversion_supported(actual_base.value_type, expected_base.value_type)
+	}
+	return false
+}
+
+fn forwarded_return_type_is_unresolved(typ types.Type) bool {
+	base := forwarded_return_unalias_type(typ)
+	name := base.name().trim_space()
+	if name == 'unknown' || name.ends_with('.unknown') || is_generic_placeholder_type_name(name) {
+		return true
+	}
+	if base is types.OptionType {
+		return forwarded_return_type_is_unresolved(base.base_type)
+	}
+	if base is types.ResultType {
+		return forwarded_return_type_is_unresolved(base.base_type)
+	}
+	if base is types.Array {
+		return forwarded_return_type_is_unresolved(base.elem_type)
+	}
+	if base is types.ArrayFixed {
+		return forwarded_return_type_is_unresolved(base.elem_type)
+	}
+	if base is types.Map {
+		return forwarded_return_type_is_unresolved(base.key_type)
+			|| forwarded_return_type_is_unresolved(base.value_type)
 	}
 	return false
 }

--- a/vlib/v3/transform/struct.v
+++ b/vlib/v3/transform/struct.v
@@ -643,6 +643,18 @@ fn (mut t Transformer) add_missing_struct_defaults(id flat.NodeId, node flat.Nod
 	if info.module.len > 0 {
 		t.cur_module = info.module
 	}
+	// Field defaults are declaration-scope expressions. Caller locals with the same
+	// name as an imported module (for example `seed`) must not turn module calls in a
+	// reused default into receiver calls.
+	saved_var_types := t.var_types.clone()
+	saved_fn_value_locals := t.fn_value_locals.clone()
+	saved_mut_param_values := t.mut_param_values.clone()
+	saved_fixed_array_param_values := t.fixed_array_param_values.clone()
+	saved_interface_var_concrete_types := t.interface_var_concrete_types.clone()
+	saved_addr_lvalue_pointer_locals := t.addr_lvalue_pointer_locals.clone()
+	saved_orm_initialized_fields := t.orm_initialized_fields.clone()
+	saved_sql_query_data_aliases := t.sql_query_data_aliases.clone()
+	t.reset_var_types()
 	mut added := false
 	for field in info.fields {
 		if field.name in provided || int(field.default_expr) < 0 {
@@ -674,6 +686,14 @@ fn (mut t Transformer) add_missing_struct_defaults(id flat.NodeId, node flat.Nod
 		provided[field.name] = true
 		added = true
 	}
+	t.restore_var_types(saved_var_types)
+	t.fn_value_locals = saved_fn_value_locals.clone()
+	t.mut_param_values = saved_mut_param_values.clone()
+	t.fixed_array_param_values = saved_fixed_array_param_values.clone()
+	t.interface_var_concrete_types = saved_interface_var_concrete_types.clone()
+	t.addr_lvalue_pointer_locals = saved_addr_lvalue_pointer_locals.clone()
+	t.orm_initialized_fields = saved_orm_initialized_fields.clone()
+	t.sql_query_data_aliases = saved_sql_query_data_aliases.clone()
 	t.cur_module = old_module
 	if !added {
 		for stmt in prelude {
@@ -1031,7 +1051,11 @@ fn (mut t Transformer) transform_assoc_expr(id flat.NodeId, node flat.Node) flat
 
 	mut prelude := []flat.NodeId{}
 	transformed_base := t.transform_expr(base_id)
-	base := if base_type.starts_with('&') {
+	transformed_base_type := t.node_type(transformed_base)
+	base_is_loaded_pointer_value := base_node.kind == .ident
+		&& t.pointer_value_rvalues[base_node.value]
+	base := if base_type.starts_with('&') && transformed_base_type.starts_with('&')
+		&& !base_is_loaded_pointer_value {
 		t.make_prefix(.mul, transformed_base)
 	} else {
 		transformed_base
@@ -1302,6 +1326,18 @@ fn (t &Transformer) sum_type_for_field_variant(field_name string, val_id flat.No
 // fixed_array_value_to_array converts fixed array value to array data for transform.
 fn (mut t Transformer) fixed_array_value_to_array(value_id flat.NodeId, fixed_type string, array_type string) flat.NodeId {
 	return t.fixed_array_data_to_array(t.transform_expr(value_id), fixed_type, array_type)
+}
+
+fn (mut t Transformer) fixed_array_value_to_array_no_alloc(value_id flat.NodeId, fixed_type string, array_type string) flat.NodeId {
+	elem_type := fixed_array_elem_type(fixed_type)
+	len_expr := t.make_fixed_array_len_expr(fixed_type)
+	t.mark_fn_used('new_array_from_c_array_no_alloc')
+	return t.make_call_typed('new_array_from_c_array_no_alloc', [
+		len_expr,
+		len_expr,
+		t.make_sizeof_type(elem_type),
+		t.transform_expr(value_id),
+	], array_type)
 }
 
 fn (mut t Transformer) fixed_array_data_to_array(data_id flat.NodeId, fixed_type string, array_type string) flat.NodeId {

--- a/vlib/v3/transform/sum.v
+++ b/vlib/v3/transform/sum.v
@@ -142,6 +142,12 @@ fn (t &Transformer) resolve_sum_name_uncached(sum_name string) string {
 	if sum_name in t.sum_types {
 		return sum_name
 	}
+	// Do not let a short/suffix fallback reinterpret an exact concrete type as an
+	// unrelated same-named sum type from another module.
+	if sum_name in t.structs || (!isnil(t.tc) && (sum_name in t.tc.structs
+		|| sum_name in t.tc.interface_names || sum_name in t.tc.enum_names)) {
+		return ''
+	}
 	if resolved_c_name := t.resolve_sum_name_from_c_name(sum_name) {
 		return resolved_c_name
 	}
@@ -756,12 +762,21 @@ fn (mut t Transformer) transform_is_expr(id flat.NodeId, node flat.Node) flat.No
 		return t.make_bool_literal(true)
 	}
 	new_expr := t.transform_expr(expr_id)
+	// Mutable array/map loop bindings are storage pointers, but their rvalue
+	// transform above already loads the sum value. Build the tag/path checks from
+	// the transformed storage type so the value is not dereferenced twice.
+	mut check_expr_type := t.node_type(new_expr)
+	if check_expr_type.len == 0 || check_expr_type == 'unknown' {
+		check_expr_type = expr_type
+	}
 	if node.typ != 'match_exact' {
-		if check := t.make_sum_type_alias_pattern_check(new_expr, expr_type, clean_type, node.value) {
+		if check := t.make_sum_type_alias_pattern_check(new_expr, check_expr_type, clean_type,
+			node.value)
+		{
 			return check
 		}
 	}
-	if check := t.make_sum_type_pattern_check(new_expr, expr_type, clean_type, node.value) {
+	if check := t.make_sum_type_pattern_check(new_expr, check_expr_type, clean_type, node.value) {
 		return check
 	}
 	return t.make_bool_literal(true)
@@ -808,12 +823,12 @@ fn (t &Transformer) sum_alias_equivalent_variants(sum_name string, pattern strin
 
 fn (t &Transformer) type_name_matches_any_alias_equivalent(name string, candidates []string) bool {
 	normalized := t.normalize_type_in_module(name, t.cur_module)
-	short := name.all_after_last('.')
-	normalized_short := normalized.all_after_last('.')
+	short := t.variant_short_name(name)
+	normalized_short := t.variant_short_name(normalized)
 	for candidate in candidates {
 		candidate_normalized := t.normalize_type_in_module(candidate, t.cur_module)
-		candidate_short := candidate.all_after_last('.')
-		candidate_normalized_short := candidate_normalized.all_after_last('.')
+		candidate_short := t.variant_short_name(candidate)
+		candidate_normalized_short := t.variant_short_name(candidate_normalized)
 		if name == candidate || name == candidate_normalized || normalized == candidate
 			|| normalized == candidate_normalized || short == candidate_short
 			|| short == candidate_normalized_short || normalized_short == candidate_short
@@ -1037,16 +1052,18 @@ fn (t &Transformer) interface_alias_equivalent_names(name string) []string {
 	if normalized.len > 0 {
 		t.push_interface_alias_equivalent_name(mut names, mut seen, normalized)
 	}
-	name_short := name.all_after_last('.')
-	normalized_short := normalized.all_after_last('.')
+	allow_short_match := !name.contains('.') && !normalized.contains('.')
+	name_short := t.variant_short_name(name)
+	normalized_short := t.variant_short_name(normalized)
 	for alias, target in t.tc.type_aliases {
 		target_normalized := t.normalize_type_in_module(target, t.cur_module)
-		target_short := target.all_after_last('.')
-		target_normalized_short := target_normalized.all_after_last('.')
+		target_short := t.variant_short_name(target)
+		target_normalized_short := t.variant_short_name(target_normalized)
 		if target == name || target == normalized || target_normalized == name
-			|| target_normalized == normalized || target_short == name_short
-			|| target_short == normalized_short || target_normalized_short == name_short
-			|| target_normalized_short == normalized_short {
+			|| target_normalized == normalized || (allow_short_match && (target_short == name_short
+			|| target_short == normalized_short
+			|| target_normalized_short == name_short
+			|| target_normalized_short == normalized_short)) {
 			t.push_interface_alias_equivalent_name(mut names, mut seen, alias)
 			t.push_interface_alias_equivalent_name(mut names, mut seen, target)
 			t.push_interface_alias_equivalent_name(mut names, mut seen, target_normalized)
@@ -1061,13 +1078,6 @@ fn (t &Transformer) push_interface_alias_equivalent_name(mut names []string, mut
 	}
 	seen[name] = true
 	names << name
-	if name.contains('.') {
-		short := name.all_after_last('.')
-		if short.len > 0 && !seen[short] {
-			seen[short] = true
-			names << short
-		}
-	}
 }
 
 fn (t &Transformer) interface_concrete_impl_name(name string) ?string {
@@ -1242,7 +1252,7 @@ fn (mut t Transformer) make_sum_type_pattern_check(expr flat.NodeId, expr_type s
 			break
 		}
 		qv := t.resolve_variant(current_sum, path_variant)
-		use_ptr := t.variant_references_sum(qv, current_sum)
+		use_ptr := t.variant_references_sum(qv, current_sum) && !t.sum_variant_is_direct_pointer(qv)
 		field_type := if use_ptr { '&${qv}' } else { qv }
 		current = t.make_selector_op(current, t.sum_field_name(qv), field_type, if current_type.starts_with('&') {
 			.arrow
@@ -1272,10 +1282,32 @@ fn (mut t Transformer) transform_as_expr(id flat.NodeId, node flat.Node) flat.No
 	if t.is_optional_type_name(expr_type) {
 		optional_type := t.qualify_optional_type(expr_type)
 		payload_type := t.optional_base_type(optional_type)
-		source := t.transform_expr(expr_id)
+		// `as` starts from the option's storage value. Inside nested `x != none`
+		// and `x is Variant` branches, transforming `x` normally would apply both
+		// smartcasts before this code selects `.value`, then extract the variant a
+		// second time.
+		source := if t.expr_has_smartcast(expr_id) {
+			t.make_plain_expr_for_smartcast(expr_id)
+		} else {
+			t.transform_expr(expr_id)
+		}
 		value := t.make_selector(source, 'value', payload_type)
 		if t.normalize_type_alias(payload_type) == t.normalize_type_alias(node.value) {
 			return value
+		}
+		resolved_payload := t.resolve_sum_name(t.trim_pointer_type(payload_type))
+		if resolved_payload in t.sum_types {
+			qv := t.resolve_variant(resolved_payload, node.value)
+			if qv.len > 0 && t.sum_target_accepts_variant_type(resolved_payload, qv) {
+				use_ptr := t.variant_references_sum(qv, resolved_payload)
+					&& !t.sum_variant_is_direct_pointer(qv)
+				field_type := if use_ptr { '&${qv}' } else { qv }
+				field := t.make_selector_op(value, t.sum_field_name(qv), field_type, .dot)
+				if use_ptr {
+					return t.make_prefix(.mul, field)
+				}
+				return field
+			}
 		}
 		start := t.a.children.len
 		t.a.children << value
@@ -1305,6 +1337,12 @@ fn (mut t Transformer) transform_as_expr(id flat.NodeId, node flat.Node) flat.No
 			}
 		}
 		if qv := t.resolve_interface_pattern(node.value, clean_type0) {
+			if sc := t.find_smartcast(t.expr_key(expr_id)) {
+				target := t.trim_pointer_type(t.smartcast_target_type(sc))
+				if t.variant_names_match(target, qv) {
+					return t.transform_expr(expr_id)
+				}
+			}
 			child := t.transform_expr(expr_id)
 			field_op := if expr_type.starts_with('&') { flat.Op.arrow } else { flat.Op.dot }
 			object := t.make_selector_op(child, '_object', 'voidptr', field_op)
@@ -1384,7 +1422,7 @@ fn (mut t Transformer) transform_as_expr(id flat.NodeId, node flat.Node) flat.No
 	}
 	field := t.sum_field_name(qv)
 	new_expr := t.transform_expr(expr_id)
-	use_ptr := t.variant_references_sum(qv, clean_type)
+	use_ptr := t.variant_references_sum(qv, clean_type) && !t.sum_variant_is_direct_pointer(qv)
 	field_typ := if use_ptr { '&${qv}' } else { qv }
 	field_sel := t.make_selector_op(new_expr, field, field_typ, if expr_type.starts_with('&') {
 		.arrow
@@ -1507,10 +1545,17 @@ fn (mut t Transformer) wrap_sum_value(expr_id flat.NodeId, target_sum string) fl
 	if expr.typ.len > 0 && t.sum_target_accepts_variant_type(resolved_sum, expr.typ) {
 		expr_type = expr.typ
 	}
-	if expr.kind == .ident && expr.value.len > 0 {
-		local_type := t.raw_var_type(expr.value)
-		if local_type.len > 0 && t.sum_target_accepts_variant_type(resolved_sum, local_type) {
-			expr_type = local_type
+	if expr.kind in [.ident, .selector] {
+		if expr.kind == .ident && expr.value.len > 0 {
+			local_type := t.raw_var_type(expr.value)
+			if local_type.len > 0 && t.sum_target_accepts_variant_type(resolved_sum, local_type) {
+				expr_type = local_type
+			}
+		}
+		if const_type := t.raw_const_type_name_for_expr(expr_id) {
+			if t.sum_target_accepts_variant_type(resolved_sum, const_type) {
+				expr_type = const_type
+			}
 		}
 	}
 	mut variant := expr_type
@@ -1552,10 +1597,17 @@ fn (mut t Transformer) wrap_sum_value(expr_id flat.NodeId, target_sum string) fl
 	}
 	if expr.kind !in [.assoc, .as_expr, .prefix] && !has_expr_smartcast
 		&& t.resolve_sum_name(expr_type) == resolved_sum {
+		if storage := t.pointer_storage_expr_for_value_target(expr_id, resolved_sum) {
+			return storage
+		}
 		return t.transform_expr(expr_id)
 	}
-	if expr_type.starts_with('&') && t.resolve_sum_name(expr_type[1..]) == resolved_sum {
-		inner := t.transform_expr(expr_id)
+	if !has_expr_smartcast && expr_type.starts_with('&')
+		&& t.resolve_sum_name(expr_type[1..]) == resolved_sum {
+		if expr.kind == .prefix && expr.op == .mul {
+			return t.transform_expr(expr_id)
+		}
+		inner := t.transform_expr_preserving_pointer_value(expr_id)
 		deref := t.make_prefix(.mul, inner)
 		t.set_node_typ(int(deref), resolved_sum)
 		return deref
@@ -1647,6 +1699,7 @@ fn (mut t Transformer) wrap_sum_value(expr_id flat.NodeId, target_sum string) fl
 		return t.transform_expr(expr_id)
 	}
 	ref_variant := t.variant_references_sum(matched_variant, resolved_sum)
+		&& !t.sum_variant_is_direct_pointer(matched_variant)
 	mut pointer_variant_child := flat.empty_node
 	if expr.kind == .prefix && expr.op == .mul && expr.children_count > 0 {
 		pointer_variant_child = t.a.child(&expr, 0)
@@ -1655,18 +1708,27 @@ fn (mut t Transformer) wrap_sum_value(expr_id flat.NodeId, target_sum string) fl
 	value_clean := t.trim_pointer_type(t.normalize_type_alias(clean_variant))
 	needs_variant_conversion := matched_clean != value_clean
 		&& t.sum_variant_type_accepts_value_type(matched_clean, value_clean)
-	inner := if int(pointer_variant_child) >= 0 && ref_variant {
-		t.transform_expr(pointer_variant_child)
+	mut source_pointer_value := false
+	mut source_pointer_type := ''
+	if expr.kind == .ident && expr.value.len > 0 {
+		source_type := t.var_type(expr.value)
+		source_pointer_type = source_type
+		source_pointer_value = source_type.starts_with('&')
+			&& t.variant_names_match(source_type[1..], matched_variant)
+	}
+	mut inner := if int(pointer_variant_child) >= 0 && ref_variant {
+		t.transform_expr_preserving_pointer_value(pointer_variant_child)
+	} else if ref_variant && source_pointer_value {
+		value := t.make_ident(expr.value)
+		t.set_node_typ(int(value), source_pointer_type)
+		value
+	} else if ref_variant && !has_expr_smartcast
+		&& (expr_type.starts_with('&') || source_pointer_value) {
+		t.transform_expr_preserving_pointer_value(expr_id)
 	} else if needs_variant_conversion {
 		t.transform_expr_for_type(expr_id, matched_variant)
 	} else {
 		t.transform_expr(expr_id)
-	}
-	if expr_type.starts_with('&') {
-		return t.make_sum_literal(storage_sum, matched_variant, inner)
-	}
-	if int(pointer_variant_child) >= 0 && ref_variant {
-		return t.make_sum_literal(storage_sum, matched_variant, inner)
 	}
 	if ref_variant {
 		return t.make_sum_literal(storage_sum, matched_variant, inner)
@@ -1698,8 +1760,21 @@ fn (t &Transformer) sum_literal_type_name(target_sum string, resolved_sum string
 }
 
 fn (mut t Transformer) single_value_wrapper_sum_value(expr_id flat.NodeId, wrapper_type string, target_sum string) ?flat.NodeId {
+	if wrapper_type.len == 0 || isnil(t.tc) {
+		return none
+	}
+	lookup := t.lookup_struct_info_for_field(wrapper_type, 'value') or { return none }
+	if lookup.info.fields.len != 1 {
+		return none
+	}
+	value_type := t.lookup_struct_field_type(wrapper_type, 'value') or { return none }
+	if t.resolve_sum_name(t.normalize_type_alias(value_type)) != target_sum {
+		return none
+	}
 	wrapper := t.transform_expr(expr_id)
-	return t.single_value_wrapper_expr_value(wrapper, wrapper_type, target_sum)
+	value := t.make_selector(wrapper, 'value', value_type)
+	t.set_node_typ(int(value), value_type)
+	return value
 }
 
 fn (mut t Transformer) single_value_wrapper_expr_value(wrapper flat.NodeId, wrapper_type string, target_sum string) ?flat.NodeId {
@@ -1729,7 +1804,7 @@ fn (mut t Transformer) ensure_sum_variant_ref(value flat.NodeId, variant string)
 	if value_type.len == 0 {
 		value_type = clean_variant
 	}
-	if t.expr_can_take_address(value) || t.a.nodes[int(value)].kind == .struct_init {
+	if t.a.nodes[int(value)].kind != .struct_init && t.expr_can_take_address(value) {
 		ref := t.make_prefix(.amp, value)
 		t.set_node_typ(int(ref), '&${clean_variant}')
 		return ref
@@ -1763,7 +1838,8 @@ fn (mut t Transformer) make_sum_literal(sum_name string, variant string, value f
 	} else {
 		qvariant
 	}
-	if t.variant_references_sum(qvariant, sum_name) && !value_type.starts_with('&') {
+	if t.variant_references_sum(qvariant, sum_name) && !t.sum_variant_is_direct_pointer(qvariant)
+		&& !value_type.starts_with('&') {
 		value_type = '&${qvariant}'
 	}
 	value_field := t.make_sum_literal_field(t.sum_field_name(qvariant), value, value_type)

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -2233,7 +2233,9 @@ fn (mut t Transformer) transform_pure_items_serial(items []FnWorkItem) {
 // clone_ast_base produces a private FlatAst holding an independent copy of the
 // first base_nodes nodes / base_children children, so a worker can append its own
 // transformed nodes without racing the master or other workers. Read-only metadata
-// (disabled_fns) is shared. The copies carry headroom for the worker's own appends:
+// (disabled_fns) is shared, while per-node specialization maps are private because
+// worker-local appended ids need relocation during merge. The copies carry headroom
+// for the worker's own appends:
 // an exact-size clone (cap == len) would double on the first push, transiently
 // copying the whole array again and keeping the doubled capacity resident for the
 // rest of the build (worker memory is never freed under -gc none). Transform grows
@@ -2254,9 +2256,9 @@ fn (t &Transformer) clone_ast_base(base_nodes int, base_children int) &flat.Flat
 		text_values:            t.a.text_values
 		text_ids:               t.a.text_ids
 		worker_pool:            t.a.worker_pool
-		specialized_fn_nodes:   t.a.specialized_fn_nodes
-		specialized_fn_modules: t.a.specialized_fn_modules
-		specialized_fn_files:   t.a.specialized_fn_files
+		specialized_fn_nodes:   t.a.specialized_fn_nodes.clone()
+		specialized_fn_modules: t.a.specialized_fn_modules.clone()
+		specialized_fn_files:   t.a.specialized_fn_files.clone()
 	}
 }
 
@@ -2691,6 +2693,39 @@ fn (mut t Transformer) merge_worker(w &Transformer, items []FnWorkItem, base_nod
 			if w.worker_scope != unsafe { nil } && !t.retain_worker_results {
 				t.clone_scoped_worker_node(k, w.worker_scope)
 			}
+		}
+	}
+	// Specializations emitted by this worker are keyed by worker-local appended
+	// node ids. Replay only those new entries under the same shift as the nodes;
+	// entries below base_nodes were copied from the master when the worker forked.
+	for idx, specialized in w.a.specialized_fn_nodes {
+		if idx < base_nodes || !specialized {
+			continue
+		}
+		t.a.specialized_fn_nodes[idx + int(node_shift)] = true
+	}
+	for idx, module_name in w.a.specialized_fn_modules {
+		if idx < base_nodes {
+			continue
+		}
+		shifted := idx + int(node_shift)
+		t.a.specialized_fn_modules[shifted] = if w.worker_scope != unsafe { nil }
+			&& !t.retain_worker_results {
+			module_name.clone()
+		} else {
+			module_name
+		}
+	}
+	for idx, file in w.a.specialized_fn_files {
+		if idx < base_nodes {
+			continue
+		}
+		shifted := idx + int(node_shift)
+		t.a.specialized_fn_files[shifted] = if w.worker_scope != unsafe { nil }
+			&& !t.retain_worker_results {
+			file.clone()
+		} else {
+			file
 		}
 	}
 	// Rewritten top-level function nodes keep their original index in the master.

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -52,6 +52,7 @@ const skip_scope_drops_block_value = '__v3_skip_scope_drops'
 const prefix_scope_drops_block_value = '__v3_prefix_scope_drops'
 
 const generated_variant_access_marker = '__v3_generated_variant_access'
+const optional_wrapper_access_marker = '__v3_optional_wrapper_access'
 
 // SumEqRequest records where a sum type's equality helper was first requested,
 // so the helper body is built under that module/file resolution context. The
@@ -481,16 +482,11 @@ fn transform_with_used_opt_config_scoped_workers_checked_impl(mut a flat.FlatAst
 		}
 	}
 	t.apply_ignored_comptime_for_nodes()
-	// The late-name scan backfills call names that markused's raw-AST resolution
-	// missed and generic-specialization names. When building the V compiler
-	// itself (skip_generics: no generics, fully resolvable calls) it provably
-	// contributes nothing — the emitted function set is identical with and
-	// without it — so skip the full-AST rescan there. A genuine future gap would
-	// fail loudly (missing C symbol), not silently.
-	mut late_names := []string{}
-	if !skip_generics {
-		late_names = t.new_call_names_from_used_fn_bodies(used_fns, t.a.nodes.len)
-	}
+	// The late-name scan backfills call names that raw-AST markused could not
+	// resolve before narrowing and other type-aware lowering. This is needed for
+	// non-generic programs too: a call on a narrowed sum-type variant can become a
+	// concrete primitive method only after transform.
+	mut late_names := t.new_call_names_from_used_fn_bodies(used_fns, t.a.nodes.len)
 	late_names << newly_used_fn_names(used_fns, t.used_fns)
 	t.transform_late_used_fn_bodies(late_names, base_node_count)
 	t.run_sum_eq_synthesis_rounds(base_node_count)
@@ -2248,17 +2244,19 @@ fn (t &Transformer) clone_ast_base(base_nodes int, base_children int) &flat.Flat
 	mut children := []flat.NodeId{cap: base_children + base_children / 4}
 	children << t.a.children[0..base_children]
 	return &flat.FlatAst{
-		nodes:                nodes
-		children:             children
-		user_code_start:      t.a.user_code_start
-		disabled_fns:         t.a.disabled_fns
-		noreturn_fns:         t.a.noreturn_fns
-		source_files:         t.a.source_files
-		source_buffers:       t.a.source_buffers
-		text_values:          t.a.text_values
-		text_ids:             t.a.text_ids
-		worker_pool:          t.a.worker_pool
-		specialized_fn_nodes: t.a.specialized_fn_nodes
+		nodes:                  nodes
+		children:               children
+		user_code_start:        t.a.user_code_start
+		disabled_fns:           t.a.disabled_fns
+		noreturn_fns:           t.a.noreturn_fns
+		source_files:           t.a.source_files
+		source_buffers:         t.a.source_buffers
+		text_values:            t.a.text_values
+		text_ids:               t.a.text_ids
+		worker_pool:            t.a.worker_pool
+		specialized_fn_nodes:   t.a.specialized_fn_nodes
+		specialized_fn_modules: t.a.specialized_fn_modules
+		specialized_fn_files:   t.a.specialized_fn_files
 	}
 }
 
@@ -2272,9 +2270,7 @@ fn (t &Transformer) fork_worker(ast &flat.FlatAst, wtc &types.TypeChecker) &Tran
 }
 
 fn (t &Transformer) fork_scoped_batch_worker(ast &flat.FlatAst, wtc &types.TypeChecker) &Transformer {
-	mut w := t.fork_worker_config(ast, wtc, false)
-	w.used_struct_operator_fns = t.used_struct_operator_fns.clone()
-	return w
+	return t.fork_worker_config(ast, wtc, false)
 }
 
 fn (t &Transformer) fork_worker_config(ast &flat.FlatAst, wtc &types.TypeChecker, copy_used_fns bool) &Transformer {
@@ -2284,6 +2280,7 @@ fn (t &Transformer) fork_worker_config(ast &flat.FlatAst, wtc &types.TypeChecker
 		map[string]bool{}
 	}
 	mut w := t.fork_program_view(ast, wtc, used)
+	w.used_struct_operator_fns = t.used_struct_operator_fns.clone()
 	if !copy_used_fns {
 		w.used_fns_parent = unsafe { &t.used_fns }
 		w.used_fns_root = if !isnil(t.used_fns_root) {
@@ -2558,6 +2555,12 @@ fn (mut t Transformer) merge_worker_used_fns(w &Transformer) {
 		if used {
 			owned_name := if scoped && !t.retain_worker_results { name.clone() } else { name }
 			t.used_fns[owned_name] = true
+		}
+	}
+	for name, used in w.used_struct_operator_fns {
+		if used && name !in t.used_struct_operator_fns {
+			owned_name := if scoped && !t.retain_worker_results { name.clone() } else { name }
+			t.used_struct_operator_fns[owned_name] = true
 		}
 	}
 	for name, req in w.sum_eq_types {
@@ -2981,7 +2984,18 @@ fn (mut t Transformer) transform_late_used_fn_bodies(names []string, node_limit 
 	old_file := t.cur_file
 	t.cur_module = ''
 	t.cur_file = ''
+	mut seed_names := names.clone()
 	for name in names {
+		if !name.contains('.') {
+			continue
+		}
+		method := name.all_after_last('.')
+		iface_name := t.resolve_interface_type_name(name.all_before_last('.'))
+		if iface_name.len > 0 {
+			seed_names << t.interface_method_implementer_names(iface_name, method)
+		}
+	}
+	for name in seed_names {
 		t.mark_fn_used_name(name)
 		add_late_used_fn_name(name, mut late, mut pending, mut queued)
 	}
@@ -3722,6 +3736,12 @@ fn (mut t Transformer) transform_string_interp_part(child_id flat.NodeId) flat.N
 	mut typ := t.raw_alias_type_for_expr(expr_id)
 	if typ.len == 0 {
 		typ = t.declared_selector_pointer_alias_type(expr_id) or { '' }
+	}
+	if typ.len == 0 {
+		raw_type := t.raw_expr_type_without_smartcast(expr_id)
+		if t.is_optional_type_name(raw_type) {
+			typ = raw_type
+		}
 	}
 	if typ.len == 0 {
 		typ = t.node_type(transformed)
@@ -5118,6 +5138,9 @@ pub fn (mut t Transformer) transform_expr(id flat.NodeId) flat.NodeId {
 		return id
 	}
 	node := t.a.nodes[int(id)]
+	if optional_wrapper_access_marker in node.generic_params() {
+		return id
+	}
 	kind_id := node_kind_id(node)
 	if kind_id == 8 {
 		return t.transform_infix_expr(id, node)
@@ -5797,6 +5820,31 @@ fn (mut t Transformer) transform_spawn_expr(id flat.NodeId, node flat.Node) flat
 	spawn_id := t.rewrite_spawn_fn_value_alias(id, node)
 	spawn_node := t.a.nodes[int(spawn_id)]
 	result := t.transform_children_expr(spawn_id, spawn_node)
+	result_node := t.a.node(result)
+	if result_node.kind == .spawn_expr && result_node.children_count > 0 {
+		call_id := t.a.child(result_node, 0)
+		mut call_type := t.node_type(call_id)
+		if call_type.len == 0 || call_type == 'unknown' {
+			call_node := t.a.node(call_id)
+			if call_node.kind == .call && call_node.children_count > 0 {
+				callee := t.a.child_node(call_node, 0)
+				if callee.kind == .selector && callee.children_count > 0 && !isnil(t.tc) {
+					base := t.a.child_node(callee, 0)
+					base_type := if base.kind == .ident {
+						t.var_type(base.value)
+					} else {
+						t.node_type(t.a.child(callee, 0))
+					}
+					if info := t.tc.resolve_generic_struct_method(base_type, callee.value) {
+						call_type = info.return_type.name()
+					}
+				}
+			}
+		}
+		if call_type.len > 0 && call_type !in ['void', 'unknown'] {
+			t.set_node_typ(int(result), 'thread ${call_type}')
+		}
+	}
 	t.in_spawn_expr = old_in_spawn_expr
 	return result
 }
@@ -5997,7 +6045,13 @@ pub fn (mut t Transformer) transform_lvalue(id flat.NodeId) flat.NodeId {
 				if value := t.transform_pointer_optional_unwrap_lvalue(child_id) {
 					return value
 				}
-				child := t.transform_expr(child_id)
+				child_node := t.a.nodes[int(child_id)]
+				mut child := t.transform_expr(child_id)
+				if child_node.kind == .ident && t.mut_param_values[child_node.value]
+					&& t.var_type(child_node.value).starts_with('&&') {
+					child = t.make_prefix(.mul, child)
+					t.set_node_typ(int(child), t.var_type(child_node.value)[1..])
+				}
 				start := t.a.children.len
 				t.a.children << child
 				return t.a.add_node(flat.Node{
@@ -6204,7 +6258,7 @@ fn (mut t Transformer) local_address_return_type(inner_id flat.NodeId, inner fla
 		}
 		return t.var_type(inner.value)
 	}
-	if inner.kind != .selector || !t.expr_can_take_address(inner_id)
+	if inner.kind !in [.selector, .index] || !t.expr_can_take_address(inner_id)
 		|| !t.selector_root_is_local(inner_id) {
 		return none
 	}
@@ -6220,15 +6274,20 @@ fn (t &Transformer) selector_root_is_local(id flat.NodeId) bool {
 		return false
 	}
 	mut cur := t.a.nodes[int(id)]
-	for cur.kind == .selector && cur.children_count > 0 {
+	for cur.kind in [.selector, .index] && cur.children_count > 0 {
 		next_id := t.a.child(&cur, 0)
 		if int(next_id) < 0 || int(next_id) >= t.a.nodes.len {
 			return false
 		}
-		if address_expr_base_is_indirect_storage(t.address_expr_type_name(next_id)) {
+		next := t.a.nodes[int(next_id)]
+		mut next_type := t.address_expr_type_name(next_id)
+		if !address_expr_base_is_indirect_storage(next_type) && next.kind == .selector {
+			next_type = t.resolve_selector_type(next)
+		}
+		if address_expr_base_is_indirect_storage(next_type) {
 			return false
 		}
-		cur = t.a.nodes[int(next_id)]
+		cur = next
 	}
 	if cur.kind != .ident || cur.value.len == 0 {
 		return false
@@ -6815,6 +6874,14 @@ fn (mut t Transformer) transform_assign_stmt(id flat.NodeId, node flat.Node) []f
 	if node.kind == .assign && node.op == .left_shift_assign {
 		t.annotate_left_shift_assign(new_id)
 	}
+	for i := 0; i < int(node.children_count); i += 2 {
+		lhs_id := t.a.child(&node, i)
+		preserves_smartcast := node.op == .assign && i + 1 < int(node.children_count)
+			&& t.assignment_preserves_smartcast(lhs_id, t.a.child(&node, i + 1))
+		if !preserves_smartcast {
+			t.invalidate_smartcast_for_lvalue(lhs_id)
+		}
+	}
 	mut result := t.with_pending_before(new_id)
 	if post_assign := t.fn_value_self_capture_refresh_stmt(node, new_children) {
 		result << post_assign
@@ -6910,6 +6977,14 @@ fn (t &Transformer) assignment_preserves_smartcast(lhs_id flat.NodeId, rhs_id fl
 		return false
 	}
 	rhs := t.a.nodes[int(rhs_id)]
+	if sc.sum_type_name == option_unwrap_marker {
+		mut rhs_type := t.node_type(rhs_id)
+		if rhs_type.len == 0 {
+			rhs_type = t.resolve_expr_type(rhs_id)
+		}
+		return !t.is_optional_type_name(rhs_type)
+			&& t.normalize_type_alias(rhs_type) == t.normalize_type_alias(sc.variant_name)
+	}
 	if rhs.kind != .cast_expr || rhs.children_count == 0 {
 		return false
 	}
@@ -7503,18 +7578,22 @@ fn (mut t Transformer) lower_interface_field_selector(base flat.NodeId, base_typ
 	} else {
 		t.zero_value_for_type(field_type)
 	}
-	return t.build_interface_field_selector_chain(base, base_type, impl_index, field, field_type,
-		fallback, 0)
+	return t.build_interface_field_selector_chain(base, base_type, iface_name, impl_index, field,
+		field_type, fallback, 0)
 }
 
-fn (mut t Transformer) build_interface_field_selector_chain(base flat.NodeId, base_type string, impl_index &types.InterfaceImplIndex, field string, field_type string, fallback flat.NodeId, idx int) flat.NodeId {
+fn (mut t Transformer) build_interface_field_selector_chain(base flat.NodeId, base_type string, iface_name string, impl_index &types.InterfaceImplIndex, field string, field_type string, fallback flat.NodeId, idx int) flat.NodeId {
 	if idx >= impl_index.names.len {
 		return fallback
 	}
 	impl := impl_index.names[idx]
+	if t.has_used_fn_filter() && !t.interface_boxed_type_used(iface_name, impl) {
+		return t.build_interface_field_selector_chain(base, base_type, iface_name, impl_index,
+			field, field_type, fallback, idx + 1)
+	}
 	type_id := impl_index.ids[impl] or {
-		return t.build_interface_field_selector_chain(base, base_type, impl_index, field,
-			field_type, fallback, idx + 1)
+		return t.build_interface_field_selector_chain(base, base_type, iface_name, impl_index,
+			field, field_type, fallback, idx + 1)
 	}
 	base_op := if base_type.starts_with('&') { flat.Op.arrow } else { flat.Op.dot }
 	tag := t.make_selector_op(base, '_typ', 'int', base_op)
@@ -7522,12 +7601,12 @@ fn (mut t Transformer) build_interface_field_selector_chain(base flat.NodeId, ba
 	object := t.make_selector_op(base, '_object', 'voidptr', base_op)
 	object_ptr := t.make_cast('&${impl}', object, '&${impl}')
 	value := t.struct_field_selector_for_type(object_ptr, impl, field, field_type, true) or {
-		return t.build_interface_field_selector_chain(base, base_type, impl_index, field,
-			field_type, fallback, idx + 1)
+		return t.build_interface_field_selector_chain(base, base_type, iface_name, impl_index,
+			field, field_type, fallback, idx + 1)
 	}
 	then_block := t.make_block(arr1(t.make_expr_stmt(value)))
-	else_expr := t.build_interface_field_selector_chain(base, base_type, impl_index, field,
-		field_type, fallback, idx + 1)
+	else_expr := t.build_interface_field_selector_chain(base, base_type, iface_name, impl_index,
+		field, field_type, fallback, idx + 1)
 	else_block := t.make_block(arr1(t.make_expr_stmt(else_expr)))
 	start := t.a.children.len
 	t.a.children << cond
@@ -7603,7 +7682,7 @@ fn (mut t Transformer) build_sum_shared_field_assign_chain(base flat.NodeId, sum
 	cond := t.make_infix(.eq, tag, t.make_int_literal(t.sum_type_index(resolved_sum, variant)))
 	qv := t.resolve_variant(resolved_sum, variant)
 	sum_field := t.sum_field_name(qv)
-	use_ptr := t.variant_references_sum(qv, resolved_sum)
+	use_ptr := t.variant_references_sum(qv, resolved_sum) && !t.sum_variant_is_direct_pointer(qv)
 	variant_base := t.make_selector_op(base, sum_field, if use_ptr { '&${qv}' } else { qv }, if sum_type.starts_with('&') {
 		.arrow
 	} else {
@@ -7715,6 +7794,7 @@ fn (mut t Transformer) try_lower_pointer_value_assign(node flat.Node) ?[]flat.No
 	}
 	rhs_id := t.a.child(&node, 1)
 	lhs_value_type_raw := lhs_type[1..]
+	lhs_value_type := t.normalize_type_alias(lhs_value_type_raw)
 	if node.op != .assign {
 		if !t.pointer_value_lvalues[lhs.value] {
 			return none
@@ -7723,6 +7803,20 @@ fn (mut t Transformer) try_lower_pointer_value_assign(node flat.Node) ?[]flat.No
 		return arr1(t.make_assign_op(new_lhs, t.transform_expr(rhs_id), node.op))
 	}
 	if !t.pointer_value_lvalues[lhs.value] {
+		return none
+	}
+	rhs_node := t.a.nodes[int(rhs_id)]
+	if rhs_node.kind == .prefix && rhs_node.op == .amp {
+		return none
+	}
+	mut rhs_type := t.normalize_type_alias(t.node_type(rhs_id))
+	if rhs_type.len == 0 || rhs_type == 'unknown' {
+		rhs_type = t.normalize_type_alias(t.resolve_expr_type(rhs_id))
+	}
+	// A pointer-valued RHS rebinds the local pointer (`p = &other`); only a
+	// value RHS writes through it (`p = value`). Let the regular assignment path
+	// handle pointer rebinding so its lvalue remains `p` instead of `*p`.
+	if !t.pointer_value_assign_rhs_matches(lhs_value_type_raw, lhs_value_type, rhs_type) {
 		return none
 	}
 	new_lhs := t.make_prefix(.mul, t.make_ident(lhs.value))
@@ -7775,6 +7869,15 @@ fn (mut t Transformer) transform_expr_for_type(id flat.NodeId, target_type strin
 	}
 	if int(id) >= 0 && target_type.len > 0 {
 		node := t.a.nodes[int(id)]
+		if node.kind == .enum_val {
+			resolved := t.transform_enum_shorthand(id, node, target_type)
+			if resolved != id {
+				return resolved
+			}
+		}
+		if storage := t.pointer_storage_expr_for_value_target(id, target_type) {
+			return storage
+		}
 		if node.kind == .none_expr && t.is_optional_type_name(target_type) {
 			return t.make_optional_none(t.qualify_optional_type(target_type))
 		}
@@ -7840,7 +7943,8 @@ fn (mut t Transformer) transform_expr_for_type(id flat.NodeId, target_type strin
 			target_payload := t.optional_base_type(optional_target)
 			source_type := t.optional_conversion_source_type(id)
 			if t.is_optional_type_name(source_type)
-				&& t.qualify_optional_type(source_type) == optional_target {
+				&& t.qualify_optional_type(source_type) == optional_target
+				&& node.kind !in [.block, .if_expr, .match_stmt] {
 				return t.transform_expr(id)
 			}
 			if !t.is_optional_type_name(source_type) && t.is_interface_type(target_payload) {
@@ -7876,6 +7980,15 @@ fn (mut t Transformer) transform_expr_for_type(id flat.NodeId, target_type strin
 		if target_type.starts_with('&') && node.kind == .ident
 			&& t.pointer_global_arg_matches_param(node.value, target_type) {
 			return t.transform_expr(id)
+		}
+		if target_type.starts_with('&') && node.kind == .struct_init
+			&& (node.value.starts_with('&') || node.typ.starts_with('&')) {
+			// A generic `T{}` retains pointer type when T specializes to `&U`.
+			// Keep that storage type authoritative instead of letting the template's
+			// pre-specialization checker type coerce the pointer back to `U`.
+			value := t.transform_struct_init(id, node)
+			t.set_node_typ(int(value), target_type)
+			return value
 		}
 		if target_type.starts_with('&') {
 			if expr := t.transform_amp_struct_init_for_type(id, node, target_type) {
@@ -7951,8 +8064,20 @@ fn (mut t Transformer) transform_expr_for_type(id flat.NodeId, target_type strin
 				lhs_type = t.resolve_expr_type(lhs_id)
 			}
 			if t.infix_struct_operator_result_type(node, lhs_type).len == 0 {
-				lhs := t.transform_expr_for_type(lhs_id, target_type)
-				rhs := t.transform_expr_for_type(t.a.child(&node, 1), target_type)
+				// Mutable for-in values are pointer-backed locals. Inside an infix
+				// expression there is no outer expected-type load for each operand,
+				// so keep the explicit rvalue dereference produced by transform_expr.
+				lhs := if _ := t.pointer_value_expr_type(lhs_id) {
+					t.transform_expr(lhs_id)
+				} else {
+					t.transform_expr_for_type(lhs_id, target_type)
+				}
+				rhs_id := t.a.child(&node, 1)
+				rhs := if _ := t.pointer_value_expr_type(rhs_id) {
+					t.transform_expr(rhs_id)
+				} else {
+					t.transform_expr_for_type(rhs_id, target_type)
+				}
 				start := t.a.children.len
 				t.a.children << lhs
 				t.a.children << rhs
@@ -7981,6 +8106,33 @@ fn (mut t Transformer) transform_expr_for_type(id flat.NodeId, target_type strin
 	return t.coerce_transformed_expr_to_type(expr, id, target_type)
 }
 
+// pointer_storage_expr_for_value_target keeps the storage pointer of a mutable
+// container binding when the surrounding typed context already performs the
+// value load. Returning an eagerly dereferenced node here makes C generation
+// apply that expected-type load a second time.
+fn (mut t Transformer) pointer_storage_expr_for_value_target(id flat.NodeId, target_type string) ?flat.NodeId {
+	if int(id) < 0 || target_type.len == 0 || target_type.starts_with('&') {
+		return none
+	}
+	mut source_id := id
+	mut source := t.a.nodes[int(source_id)]
+	if source.kind == .prefix && source.op == .mul && source.children_count == 1 {
+		source_id = t.a.child(&source, 0)
+		source = t.a.nodes[int(source_id)]
+	}
+	if source.kind != .ident || !t.pointer_value_rvalues[source.value] {
+		return none
+	}
+	storage_type := t.var_type(source.value)
+	if !storage_type.starts_with('&')
+		|| t.normalize_type_alias(storage_type[1..]) != t.normalize_type_alias(target_type) {
+		return none
+	}
+	value := t.make_ident(source.value)
+	t.set_node_typ(int(value), storage_type)
+	return value
+}
+
 fn (mut t Transformer) transform_array_value_for_type(id flat.NodeId, target_type string) ?flat.NodeId {
 	if isnil(t.tc) || int(id) < 0 || target_type.len == 0 {
 		return none
@@ -8002,6 +8154,9 @@ fn (mut t Transformer) transform_array_value_for_type(id flat.NodeId, target_typ
 		}
 	}
 	expected_type := t.tc.parse_type(expected_type_name)
+	if forwarded_return_type_is_unresolved(expected_type) {
+		return none
+	}
 	expected_base := forwarded_return_unalias_type(expected_type)
 	if expected_base is types.Array {
 		node := t.a.nodes[int(id)]
@@ -8021,6 +8176,9 @@ fn (mut t Transformer) transform_array_value_for_type(id flat.NodeId, target_typ
 			t.tc.parse_type(actual_type_name)
 		} else {
 			t.tc.expr_type(id) or { t.tc.resolve_type(id) }
+		}
+		if forwarded_return_type_is_unresolved(actual_type) {
+			return none
 		}
 		actual_base := forwarded_return_unalias_type(actual_type)
 		if actual_base is types.Array {
@@ -8084,6 +8242,7 @@ fn (mut t Transformer) transform_block_expr_for_type(_id flat.NodeId, node flat.
 		new_children << stmt
 	}
 	new_block := t.make_block(new_children)
+	t.set_node_value(int(new_block), node.value)
 	block_typ := t.stmt_value_type(new_block)
 	t.set_node_typ(int(new_block), if block_typ.len > 0 { block_typ } else { node.typ })
 	return new_block
@@ -8250,6 +8409,9 @@ fn (mut t Transformer) coerce_transformed_expr_to_type(expr flat.NodeId, source_
 				return t.make_cast(target, expr, target)
 			}
 		}
+		if expr_type in ['voidptr', '&void', 'byteptr', 'charptr'] {
+			return t.make_cast(target, expr, target)
+		}
 		target_value_type := t.normalize_type_alias(target[1..])
 		expr_value_type := if expr_type.starts_with('&') {
 			t.normalize_type_alias(expr_type[1..])
@@ -8340,6 +8502,10 @@ fn (t &Transformer) expr_is_nil_like(id flat.NodeId) bool {
 	}
 	if node.kind in [.cast_expr, .paren, .expr_stmt] && node.children_count > 0 {
 		return t.expr_is_nil_like(t.a.child(&node, 0))
+	}
+	if node.kind == .selector && node.value == 'NULL' && node.children_count > 0 {
+		base := t.a.child_node(&node, 0)
+		return base.kind == .ident && base.value == 'C'
 	}
 	if node.kind != .block || node.children_count == 0 {
 		return false
@@ -8784,7 +8950,7 @@ fn (mut t Transformer) transform_decl_assign_stmt(id flat.NodeId, node flat.Node
 					}
 				}
 				if raw_typ.len == 0 {
-					raw_typ = t.raw_decl_type_for_rhs(rhs, typ)
+					raw_typ = t.raw_decl_type_for_rhs(rhs_id, rhs, typ)
 				}
 				if rhs.kind == .call {
 					generic_raw_typ := t.raw_generic_call_return_type(rhs_id, rhs)
@@ -8980,6 +9146,10 @@ fn (mut t Transformer) try_expand_plain_multi_decl(node flat.Node) ?[]flat.NodeI
 		}
 		rhs_authority := t.decl_rhs_type(rhs_id)
 		mut typ := if t.is_fn_pointer_type_name(rhs_authority) { rhs_authority } else { '' }
+		if typ.len == 0 && decl_type_is_usable(rhs_authority)
+			&& !t.generic_arg_is_unresolved(rhs_authority) {
+			typ = rhs_authority
+		}
 		if typ.len == 0 {
 			typ = generic_rhs_typ
 		}
@@ -9041,6 +9211,11 @@ fn (mut t Transformer) try_expand_multi_return_decl(node flat.Node) ?[]flat.Node
 			return expanded
 		}
 	}
+	if rhs.kind == .match_stmt {
+		if expanded := t.expand_multi_return_match_decl(rhs_id, rhs, lhs_ids) {
+			return expanded
+		}
+	}
 	if rhs_types := t.multi_return_types_for_expr(rhs_id, lhs_ids.len) {
 		tmp_name := t.new_temp('multi_ret')
 		mut result := []flat.NodeId{}
@@ -9081,6 +9256,11 @@ fn (mut t Transformer) try_expand_multi_return_assign(node flat.Node) ?[]flat.No
 	if rhs.kind == .if_expr {
 		if expanded := t.expand_multi_return_if_assign(rhs_id, rhs, lhs_ids) {
 			return expanded
+		}
+	}
+	if rhs.kind == .match_stmt {
+		if expanded := t.expand_multi_return_match_assign(rhs_id, rhs, lhs_ids) {
+			return arr1(expanded)
 		}
 	}
 	if rhs_types := t.multi_return_types_for_expr(rhs_id, lhs_ids.len) {
@@ -9290,11 +9470,12 @@ fn (t &Transformer) match_multi_return_types(node flat.Node, expected_count int)
 		return none
 	}
 	for i in 1 .. node.children_count {
-		branch := t.a.child_node(&node, i)
+		branch_id := t.a.child(&node, i)
+		branch := t.a.nodes[int(branch_id)]
 		if branch.kind != .match_branch {
 			continue
 		}
-		body_start := if branch.value == 'else' { 0 } else { t.count_conds(*branch) }
+		body_start := if branch.value == 'else' { 0 } else { t.count_conds(branch) }
 		if branch.children_count <= body_start {
 			continue
 		}
@@ -9522,6 +9703,95 @@ fn (mut t Transformer) expand_multi_return_if_assign(rhs_id flat.NodeId, rhs fla
 		return none
 	}
 	return t.lower_multi_if_assign(rhs, lhs_ids)
+}
+
+fn (mut t Transformer) expand_multi_return_match_decl(rhs_id flat.NodeId, rhs flat.Node, lhs_ids []flat.NodeId) ?[]flat.NodeId {
+	if lhs_ids.len == 0 {
+		return none
+	}
+	value_types := t.tc.multi_expr_tail_types_for_transform(rhs_id, lhs_ids.len) or { return none }
+	mut result := []flat.NodeId{}
+	for i, lhs_id in lhs_ids {
+		lhs := t.a.nodes[int(lhs_id)]
+		if lhs.kind != .ident || lhs.value == '_' {
+			continue
+		}
+		typ := if i < value_types.len { value_types[i].name() } else { 'int' }
+		t.set_var_type(lhs.value, t.normalize_type_alias(typ))
+		result << t.make_decl_assign_typed(lhs.value, t.zero_value_for_type(typ), typ)
+	}
+	result << t.expand_multi_return_match_assign(rhs_id, rhs, lhs_ids) or { return none }
+	return result
+}
+
+fn (mut t Transformer) expand_multi_return_match_assign(_rhs_id flat.NodeId, rhs flat.Node, lhs_ids []flat.NodeId) ?flat.NodeId {
+	rewritten := t.rewrite_multi_return_match_assign(rhs, lhs_ids) or { return none }
+	return t.lower_one_match(rewritten)
+}
+
+fn (mut t Transformer) rewrite_multi_return_match_assign(node flat.Node, lhs_ids []flat.NodeId) ?flat.Node {
+	if node.kind != .match_stmt || node.children_count < 2 || lhs_ids.len == 0 {
+		return none
+	}
+	mut match_children := []flat.NodeId{cap: int(node.children_count)}
+	match_children << t.a.child(&node, 0)
+	for i in 1 .. node.children_count {
+		branch := t.a.child_node(&node, i)
+		if branch.kind != .match_branch {
+			return none
+		}
+		body_start := if branch.value == 'else' { 0 } else { t.count_conds(branch) }
+		parts := t.match_branch_tuple_parts(branch, body_start, lhs_ids.len) or { return none }
+		mut branch_children := []flat.NodeId{cap: body_start + parts.prefix.len + 1}
+		for j in 0 .. body_start {
+			branch_children << t.a.child(branch, j)
+		}
+		branch_children << parts.prefix
+		branch_children << t.make_multi_value_assign(lhs_ids, parts.values)
+		start := t.a.children.len
+		t.a.children << branch_children
+		match_children << t.a.add_node(flat.Node{
+			kind:                 branch.kind
+			op:                   branch.op
+			value:                branch.value
+			typ:                  branch.typ
+			payload:              branch.payload
+			children_start:       start
+			children_count:       flat.child_count(branch_children.len)
+			pos:                  branch.pos
+			is_mut:               branch.is_mut
+			skip_ownership_drops: branch.skip_ownership_drops
+		})
+	}
+	start := t.a.children.len
+	t.a.children << match_children
+	return flat.Node{
+		kind:                 node.kind
+		op:                   node.op
+		value:                node.value
+		typ:                  node.typ
+		payload:              node.payload
+		children_start:       start
+		children_count:       flat.child_count(match_children.len)
+		pos:                  node.pos
+		is_mut:               node.is_mut
+		skip_ownership_drops: node.skip_ownership_drops
+	}
+}
+
+fn (mut t Transformer) make_multi_value_assign(lhs_ids []flat.NodeId, values []flat.NodeId) flat.NodeId {
+	start := t.a.children.len
+	for i, lhs_id in lhs_ids {
+		t.a.children << lhs_id
+		t.a.children << values[i]
+	}
+	return t.a.add_node(flat.Node{
+		kind:           .assign
+		op:             .assign
+		value:          lhs_ids.len.str()
+		children_start: start
+		children_count: flat.child_count(lhs_ids.len * 2)
+	})
 }
 
 fn (t &Transformer) if_expr_has_tuple_tail_values(expr_id flat.NodeId, count int) bool {
@@ -10168,6 +10438,7 @@ fn (mut t Transformer) transform_block_stmt(_id flat.NodeId, node flat.Node) []f
 	}
 	new_children := t.transform_stmts(child_ids)
 	new_block := t.make_block(new_children)
+	t.set_node_value(int(new_block), node.value)
 	return arr1(new_block)
 }
 
@@ -10619,6 +10890,7 @@ fn (mut t Transformer) transform_block_expr(_id flat.NodeId, node flat.Node) fla
 	}
 	new_children := t.transform_stmts(child_ids)
 	new_block := t.make_block(new_children)
+	t.set_node_value(int(new_block), node.value)
 	block_typ := t.stmt_value_type(new_block)
 	t.set_node_typ(int(new_block), if block_typ.len > 0 { block_typ } else { node.typ })
 	return new_block
@@ -11414,7 +11686,7 @@ fn transform_is_anonymous_struct_name(name string) bool {
 
 // transform_struct_init transforms transform struct init data for transform.
 fn (mut t Transformer) transform_struct_init(id flat.NodeId, node flat.Node) flat.NodeId {
-	if node.value == 'struct' {
+	if node.value == 'struct' || transform_is_anonymous_struct_name(node.value) {
 		mut concrete_type := t.raw_checker_node_type(id)
 		if !transform_is_anonymous_struct_name(concrete_type) && t.expected_expr_node == int(id)
 			&& transform_is_anonymous_struct_name(t.expected_expr_type) {
@@ -11786,6 +12058,12 @@ fn (t &Transformer) string_interp_child_has_unresolved_generic_part(id flat.Node
 		return false
 	}
 	node := t.a.nodes[int(id)]
+	if node.kind == .directive && node.value == 'string_interp_format' {
+		if node.children_count == 0 {
+			return false
+		}
+		return t.string_interp_child_has_unresolved_generic_part(t.a.child(&node, 0))
+	}
 	mut candidates := []string{cap: 5}
 	candidates << t.node_type(id)
 	if node.typ.len > 0 {
@@ -12124,6 +12402,14 @@ fn (t &Transformer) selector_base_is_ident_receiver(id flat.NodeId) bool {
 	return node.kind == .ident
 }
 
+fn (t &Transformer) selector_base_is_explicit_as_expr(id flat.NodeId) bool {
+	mut node := t.a.nodes[int(id)]
+	for node.kind == .paren && node.children_count > 0 {
+		node = t.a.nodes[int(t.a.child(&node, 0))]
+	}
+	return node.kind == .as_expr
+}
+
 fn (t &Transformer) transformed_selector_type(node flat.Node) string {
 	resolved := t.resolve_selector_type(node)
 	if resolved.starts_with('&') && !node.typ.starts_with('&') {
@@ -12188,7 +12474,7 @@ fn (mut t Transformer) transform_selector_expr(id flat.NodeId, node flat.Node) f
 	}
 	base_id := base_id0
 	sc_key := t.expr_key(base_id)
-	if sc_key.len > 0 {
+	if !t.selector_base_is_explicit_as_expr(base_id) && sc_key.len > 0 {
 		contexts := t.smartcasts_for(sc_key)
 		if contexts.len > 0 {
 			plain_base := t.make_plain_expr_for_smartcast(base_id)
@@ -12500,7 +12786,7 @@ fn (mut t Transformer) build_sum_shared_field_chain(base flat.NodeId, sum_type s
 	cond := t.make_infix(.eq, tag, t.make_int_literal(t.sum_type_index(resolved_sum, variant)))
 	qv := t.resolve_variant(resolved_sum, variant)
 	sum_field := t.sum_field_name(qv)
-	use_ptr := t.variant_references_sum(qv, resolved_sum)
+	use_ptr := t.variant_references_sum(qv, resolved_sum) && !t.sum_variant_is_direct_pointer(qv)
 	variant_base := t.make_selector_op(base, sum_field, if use_ptr { '&${qv}' } else { qv }, if sum_type.starts_with('&') {
 		.arrow
 	} else {
@@ -12541,6 +12827,9 @@ fn (mut t Transformer) transform_or_expr(id flat.NodeId, node flat.Node) flat.No
 		return lowered
 	}
 	expr_id := t.a.child(&node, 0)
+	if addr := t.transform_map_index_address_or_nil(node, expr_id) {
+		return addr
+	}
 	if node.value == '?' && t.expr_has_option_unwrap_smartcast(expr_id) {
 		return t.transform_expr(expr_id)
 	}
@@ -12586,6 +12875,25 @@ fn (mut t Transformer) transform_or_expr(id flat.NodeId, node flat.Node) flat.No
 		return t.preserve_or_expr_for_codegen(id, node)
 	}
 	return t.lower_or_expr_to_temp(id, node)
+}
+
+fn (mut t Transformer) transform_map_index_address_or_nil(node flat.Node, expr_id flat.NodeId) ?flat.NodeId {
+	if node.children_count < 2 || !t.or_body_is_nil(t.a.child(&node, 1)) || int(expr_id) < 0 {
+		return none
+	}
+	source := t.a.nodes[int(expr_id)]
+	if source.kind != .prefix || source.op != .amp || source.children_count != 1 {
+		return none
+	}
+	index_id := t.a.child(&source, 0)
+	info := t.map_index_info(index_id) or { return none }
+	map_expr := t.stable_expr_for_reuse(info.base_id)
+	key_name := t.new_temp('map_key')
+	t.pending_stmts << t.make_decl_assign_typed(key_name, t.transform_expr_for_type(info.key_id,
+		info.key_type), info.key_storage_type)
+	ptr := t.make_map_get_check_expr(map_expr, info.base_type, key_name)
+	target_type := if node.typ.starts_with('&') { node.typ } else { '&${info.value_type}' }
+	return t.make_cast(target_type, ptr, target_type)
 }
 
 fn (mut t Transformer) transform_match_trailing_or_expr(_id flat.NodeId, node flat.Node) ?flat.NodeId {
@@ -12667,14 +12975,20 @@ fn (t &Transformer) mut_param_amp_decl_type(rhs_id flat.NodeId) ?string {
 	if vt.starts_with('mut ') {
 		vt = '&' + vt[4..].trim_space()
 	}
-	if !vt.starts_with('&') {
-		return none
+	if !vt.starts_with('&') && vt.len > 0 {
+		vt = '&${vt}'
 	}
-	return vt
+	return if vt.starts_with('&') { vt } else { none }
 }
 
 fn (mut t Transformer) transform_prefix_expr(id flat.NodeId, node flat.Node) flat.NodeId {
 	if node.children_count == 0 {
+		return id
+	}
+	// Smartcast payload accesses are fully lowered when they are built. Rewalking
+	// their dereference would smartcast the original sum receiver a second time
+	// (for example `*a._int` becoming `*(*a._int)._int` in a nested match).
+	if _ := t.generated_variant_access_type(id) {
 		return id
 	}
 	if node.op in [.plus, .minus] && node.children_count == 1 {
@@ -12686,6 +13000,15 @@ fn (mut t Transformer) transform_prefix_expr(id flat.NodeId, node flat.Node) fla
 	if node.op == .mul && node.children_count == 1 {
 		child_id := t.a.child(&node, 0)
 		child := t.a.nodes[int(child_id)]
+		if child.kind == .ident && t.pointer_value_rvalues[child.value] {
+			value := t.transform_expr_preserving_pointer_value(child_id)
+			result := t.make_prefix(.mul, value)
+			value_type := t.node_type(value)
+			if value_type.starts_with('&') {
+				t.set_node_typ(int(result), value_type[1..])
+			}
+			return result
+		}
 		// A shared value is represented by a pointer to a lock wrapper, but an
 		// expression naming it already lowers to the wrapper's `.val`. The generic
 		// `T.indirections == 1` branch can still spell that expression as `*val`;
@@ -12741,6 +13064,9 @@ fn (mut t Transformer) transform_prefix_expr(id flat.NodeId, node flat.Node) fla
 			if vt.starts_with('mut ') {
 				vt = '&' + vt[4..].trim_space()
 			}
+			if !vt.starts_with('&') && vt.len > 0 {
+				vt = '&${vt}'
+			}
 			if vt.starts_with('&') {
 				new_id := t.transform_expr(child_id)
 				t.set_node_typ(int(new_id), vt)
@@ -12765,6 +13091,18 @@ fn (mut t Transformer) transform_prefix_expr(id flat.NodeId, node flat.Node) fla
 			value := t.transform_expr(child_id)
 			result_type := if node.typ.len > 0 { node.typ } else { '&${child_type}' }
 			return t.make_call_typed('v3_heap_array', arr1(value), result_type)
+		}
+		if child.kind == .map_init && t.normalize_type_alias(child_type).starts_with('map[') {
+			// Like `&[]T{}`, `&map[K]V{}` owns a heap-allocated container header.
+			// A stabilized stack header can escape through a sum type (for example
+			// `Value(&map[string]Value{})`), leaving the stored pointer dangling.
+			value := t.transform_expr(child_id)
+			stable := t.stable_transformed_expr_for_reuse(value, child_type, 'addr')
+			addr := t.make_prefix(.amp, stable)
+			t.set_node_typ(int(addr), '&${child_type}')
+			dup := t.make_memdup_call_for_type(addr, child_type)
+			result_type := if node.typ.len > 0 { node.typ } else { '&${child_type}' }
+			return t.make_cast(result_type, dup, result_type)
 		}
 		if expr := t.transform_amp_assoc_expr_for_type(id, node, node.typ) {
 			return expr
@@ -13204,7 +13542,7 @@ fn (t &Transformer) raw_expr_type_without_smartcast(id flat.NodeId) string {
 	node := t.a.nodes[int(id)]
 	match node.kind {
 		.ident {
-			typ := t.normalize_type_alias(t.var_type(node.value))
+			typ := t.normalize_type_alias(t.raw_var_type(node.value))
 			if typ.len > 0 {
 				return typ
 			}
@@ -13466,10 +13804,17 @@ fn (mut t Transformer) transform_cast_expr(id flat.NodeId, node flat.Node) flat.
 			typ:            node.typ
 		})
 	}
-	if t.is_optional_type_name(node.value) {
+	optional_cast_type := if t.is_optional_type_name(node.value) {
+		node.value
+	} else if t.is_optional_type_name(node.typ) {
+		node.typ
+	} else {
+		''
+	}
+	if optional_cast_type.len > 0 {
 		child_id := t.a.child(&node, 0)
 		child := t.a.node(child_id)
-		optional_target := t.qualify_optional_type(node.value)
+		optional_target := t.qualify_optional_type(optional_cast_type)
 		payload_type := t.optional_base_type(optional_target)
 		if child.kind == .none_expr {
 			return t.make_optional_none(optional_target)
@@ -13479,17 +13824,21 @@ fn (mut t Transformer) transform_cast_expr(id flat.NodeId, node flat.Node) flat.
 			value := t.wrap_sum_value(child_id, payload_type)
 			return t.make_optional_some(value, optional_target)
 		}
-		expr := if t.is_optional_type_name(child_type) {
-			t.transform_expr_for_type(child_id, node.value)
+		expr_target := if child.kind == .or_expr && child.children_count > 1
+			&& t.or_body_is_none(t.a.child(child, 1)) {
+			optional_target
+		} else if t.is_optional_type_name(child_type) {
+			optional_target
 		} else {
-			t.transform_expr_for_type(child_id, payload_type)
+			payload_type
 		}
+		expr := t.transform_expr_for_type(child_id, expr_target)
 		mut expr_type := t.node_type(expr)
 		if expr_type.len == 0 {
 			expr_type = t.resolve_expr_type(child_id)
 		}
 		if t.is_optional_type_name(expr_type) {
-			return t.coerce_transformed_expr_to_type(expr, child_id, node.value)
+			return t.coerce_transformed_expr_to_type(expr, child_id, optional_target)
 		}
 		return t.make_optional_some(expr, optional_target)
 	}
@@ -13632,10 +13981,22 @@ fn (mut t Transformer) transform_array_literal(id flat.NodeId, node flat.Node) f
 	if node.children_count == 0 {
 		return id
 	}
+	array_type := t.node_type(id)
+	elem_type := if array_type.starts_with('[]') && array_type.len > 2 {
+		array_type[2..]
+	} else if node.typ.starts_with('[]') && node.typ.len > 2 {
+		node.typ[2..]
+	} else {
+		''
+	}
 	mut new_children := []flat.NodeId{cap: int(node.children_count)}
 	for i in 0 .. node.children_count {
 		child_id := t.a.child(&node, i)
-		new_children << t.transform_expr(child_id)
+		new_children << if elem_type.len > 0 {
+			t.transform_expr_for_type(child_id, elem_type)
+		} else {
+			t.transform_expr(child_id)
+		}
 	}
 	start := t.a.children.len
 	for nc in new_children {
@@ -13789,7 +14150,9 @@ fn (mut t Transformer) transform_typeof_expr_mode(id flat.NodeId, node flat.Node
 				}
 			}
 			if t.mut_param_values[expr.value] {
-				typ = typ.trim_string_left('&')
+				if !typ.starts_with('&') {
+					typ = '&${typ}'
+				}
 			}
 		}
 	}
@@ -14280,8 +14643,10 @@ fn (mut t Transformer) transform_ident_expr(id flat.NodeId, node flat.Node) flat
 					return id
 				}
 			}
-			typ := t.var_type(node.value)
-			if typ.len == 0 {
+			mut typ := t.var_type(node.value)
+			is_file_import_selector_base := t.in_selector_base
+				&& file_import_key(t.cur_file, node.value) in t.tc.file_imports
+			if typ.len == 0 && !t.in_call_callee && !is_file_import_selector_base {
 				if key := t.const_type_key_in_context(node.value, t.cur_module, t.cur_file) {
 					t.tc.clear_resolved_fn_value(id)
 					mut const_name := key
@@ -14294,6 +14659,12 @@ fn (mut t Transformer) transform_ident_expr(id flat.NodeId, node flat.Node) flat
 					}
 					return id
 				}
+			}
+			if t.mut_value_ident_nodes[int(id)] && typ.starts_with('&') {
+				// A `mut T` parameter is stored as `&T`, but ordinary identifier uses
+				// still have the language-level type `T`. Keep that distinction stable
+				// across repeated transform/monomorphize scans.
+				typ = typ[1..]
 			}
 			// Idents are the most common node; re-annotating them in place (rather than
 			// allocating a fresh node) avoids cascading rebuilds of every enclosing
@@ -14348,6 +14719,7 @@ fn (mut t Transformer) smartcast_ident_value(name string) ?flat.NodeId {
 fn (mut t Transformer) apply_smartcast_contexts(base flat.NodeId, typ string, contexts []SmartcastContext) flat.NodeId {
 	mut current := base
 	mut current_type := typ
+	mut applied_path := []string{}
 	for i, sc in contexts {
 		if sc.sum_type_name == option_unwrap_marker {
 			// current is the Optional_T struct value itself. Type annotations on
@@ -14387,11 +14759,15 @@ fn (mut t Transformer) apply_smartcast_contexts(base flat.NodeId, typ string, co
 			continue
 		}
 		clean_current_type := t.trim_pointer_type(current_type)
-		sum_for_path := if clean_current_type.len > 0
-			&& t.resolve_sum_name(clean_current_type) == t.resolve_sum_name(sc.sum_type_name) {
+		continues_from_current_sum := clean_current_type.len > 0
+			&& t.resolve_sum_name(clean_current_type) == t.resolve_sum_name(sc.sum_type_name)
+		sum_for_path := if continues_from_current_sum {
 			clean_current_type
 		} else {
 			sc.sum_type_name
+		}
+		if continues_from_current_sum {
+			applied_path.clear()
 		}
 		mut path := t.sum_variant_path(sum_for_path, sc.variant_name)
 		if path.len == 0 {
@@ -14399,13 +14775,30 @@ fn (mut t Transformer) apply_smartcast_contexts(base flat.NodeId, typ string, co
 		}
 		mut current_sum := sum_for_path
 		for j, qv in path {
-			if t.expr_is_variant_access(current, qv) {
+			// Nested `is` checks are recorded against the original expression. Their
+			// paths are cumulative (`Node -> Stmt`, then `Node -> Stmt -> TypeDecl`).
+			// Keep the common prefix already selected instead of rebuilding it for
+			// every deeper context.
+			if !continues_from_current_sum && j < applied_path.len
+				&& t.variant_names_match(applied_path[j], qv) {
 				current_type = qv
 				current_sum = qv
 				continue
 			}
+			if t.expr_is_variant_access(current, qv) {
+				current_type = qv
+				current_sum = qv
+				if j == applied_path.len {
+					applied_path << qv
+				}
+				continue
+			}
+			if !continues_from_current_sum && j < applied_path.len {
+				applied_path = applied_path[..j].clone()
+			}
 			field := t.sum_field_name(qv)
 			use_ptr := t.variant_references_sum(qv, current_sum)
+				&& !t.sum_variant_is_direct_pointer(qv)
 			field_typ := if use_ptr { '&${qv}' } else { qv }
 			for current_type.starts_with('&&') {
 				current = t.make_prefix(.mul, current)
@@ -14424,6 +14817,7 @@ fn (mut t Transformer) apply_smartcast_contexts(base flat.NodeId, typ string, co
 				current_type = field_typ
 			}
 			current_sum = qv
+			applied_path << qv
 		}
 	}
 	return current
@@ -14579,6 +14973,17 @@ fn (t &Transformer) smartcasts_for(expr_name string) []SmartcastContext {
 	mut result := []SmartcastContext{cap: 1}
 	for sc in t.smartcast_stack {
 		if sc.expr_name == expr_name {
+			mut duplicate := false
+			for existing in result {
+				if t.variant_names_match(existing.variant_name, sc.variant_name)
+					&& t.resolve_sum_name(existing.sum_type_name) == t.resolve_sum_name(sc.sum_type_name) {
+					duplicate = true
+					break
+				}
+			}
+			if duplicate {
+				continue
+			}
 			result << sc
 		}
 	}
@@ -15364,7 +15769,12 @@ fn (t &Transformer) sum_constructor_call_type(node flat.Node) string {
 	return ''
 }
 
-fn (t &Transformer) raw_decl_type_for_rhs(rhs flat.Node, fallback string) string {
+fn (t &Transformer) raw_decl_type_for_rhs(rhs_id flat.NodeId, rhs flat.Node, fallback string) string {
+	if rhs.kind == .selector {
+		if raw_type := t.raw_selector_field_type(rhs_id) {
+			return raw_type
+		}
+	}
 	if rhs.kind == .cast_expr && rhs.value.len > 0 && !isnil(t.tc) {
 		if rhs.value in t.tc.type_aliases {
 			return rhs.value
@@ -15436,7 +15846,7 @@ fn (t &Transformer) raw_infix_operator_decl_return_type(node flat.Node) ?string 
 	if receiver.starts_with('&') {
 		receiver = receiver[1..]
 	}
-	if receiver.len == 0 || !t.generic_type_text_contains_alias(receiver, t.cur_module) {
+	if receiver.len == 0 {
 		return none
 	}
 	for candidate in t.operator_receiver_candidates(receiver) {
@@ -15517,6 +15927,9 @@ fn (t &Transformer) resolve_expr_type(id flat.NodeId) string {
 		.call {
 			if sum_ctor_type := t.generic_sum_constructor_call_type(node) {
 				return sum_ctor_type
+			}
+			if declared_ret := t.checker_resolved_non_builtin_return_type(id, node) {
+				return declared_ret
 			}
 			concrete_typ := t.concrete_node_type_name(node)
 			if concrete_typ.len > 0 {

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -10654,11 +10654,8 @@ fn (mut t Transformer) comptime_type_condition_value(cond string) ?bool {
 		}
 		left := clean[..op_idx].trim_space()
 		right := clean[op_idx + op.len..].trim_space()
-		if !comptime_is_int(left) || !comptime_is_int(right) {
-			continue
-		}
-		l := left.int()
-		r := right.int()
+		l := t.comptime_condition_int_value(left) or { continue }
+		r := t.comptime_condition_int_value(right) or { continue }
 		return match op {
 			' != ' { l != r }
 			' == ' { l == r }
@@ -10673,6 +10670,25 @@ fn (mut t Transformer) comptime_type_condition_value(cond string) ?bool {
 		return !value
 	}
 	return none
+}
+
+fn (t &Transformer) comptime_condition_int_value(raw string) ?int {
+	clean := raw.trim_space()
+	if comptime_is_int(clean) {
+		return clean.int()
+	}
+	if t.cur_fn_is_generic {
+		return none
+	}
+	reflected_type, reflected_member := generic_comptime_typeof_operand(clean) or { return none }
+	if reflected_member != 'idx' {
+		return none
+	}
+	resolved := t.resolve_substituted_type_text(reflected_type)
+	if resolved.len == 0 {
+		return none
+	}
+	return t.comptime_field_type_id(resolved, t.cur_module)
 }
 
 fn (mut t Transformer) comptime_type_matches(actual string, expected string) ?bool {

--- a/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
@@ -1140,9 +1140,9 @@ fn shared_region_view(a &flat.FlatAst, nstart int, nend int, cstart int, cend in
 		text_values:            a.text_values
 		text_ids:               a.text_ids
 		worker_pool:            a.worker_pool
-		specialized_fn_nodes:   a.specialized_fn_nodes
-		specialized_fn_modules: a.specialized_fn_modules
-		specialized_fn_files:   a.specialized_fn_files
+		specialized_fn_nodes:   a.specialized_fn_nodes.clone()
+		specialized_fn_modules: a.specialized_fn_modules.clone()
+		specialized_fn_files:   a.specialized_fn_files.clone()
 	}
 }
 

--- a/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
@@ -293,6 +293,8 @@ fn (mut t Transformer) run_parallel_monomorphize_specs(specs []PendingGenericFnS
 			mut view := shared_region_view(t.a, node_starts[ci], node_starts[ci + 1],
 				child_starts[ci], child_starts[ci + 1])
 			view.specialized_fn_nodes = map[int]bool{}
+			view.specialized_fn_modules = map[int]string{}
+			view.specialized_fn_files = map[int]string{}
 			mut wtc := t.tc.fork_for_parallel_transform(view)
 			wtc.fn_ret_types = t.tc.fn_ret_types.clone()
 			wtc.fn_param_types = t.tc.fn_param_types.clone()
@@ -441,6 +443,8 @@ fn (mut t Transformer) run_parallel_monomorphize_specs(specs []PendingGenericFnS
 				}
 				t.generic_fn_spec_nodes[spec.key.clone()] = root
 				t.a.specialized_fn_nodes[int(root)] = true
+				t.a.specialized_fn_modules[int(root)] = spec.decl.module
+				t.a.specialized_fn_files[int(root)] = spec.decl.file
 				t.mark_node_context(root, spec.decl.module, spec.decl.file)
 				emitted[generic_fn_spec_key(spec.decl.key, spec.args)] = true
 				t.pending_generic_fn_spec_keys.delete(spec.key)
@@ -1036,16 +1040,6 @@ fn (mut t Transformer) run_parallel_transform(items []FnWorkItem, base_nodes int
 		// before any worker can rewrite a shared-base fn_decl; lazily scanning or
 		// reading declarations inside workers can otherwise observe a torn node.
 		t.prepare_parallel_call_param_types()
-		// Clone-free shared-base path: needs the checker's top-level index for
-		// exact per-item subtree ranges, and skip_generics (the generic passes
-		// scan and mutate arbitrary AST regions, which the shared design forbids).
-		if t.skip_generics && !isnil(t.tc) && t.tc.top_level_idx.len > 0 {
-			shared_jobs := shared_transform_job_count(t.a.worker_pool.size() + 1, items.len)
-			if shared_jobs > 1 {
-				return t.run_parallel_transform_shared(items, base_nodes, base_children,
-					shared_jobs)
-			}
-		}
 		// Freeze the checker's warm type cache (fully populated by the check
 		// phase) as the shared read-only base for every worker fork, so workers
 		// do not re-parse every type text from a cold cache; the master itself
@@ -1136,17 +1130,19 @@ fn shared_region_view(a &flat.FlatAst, nstart int, nend int, cstart int, cend in
 		children.flags.set(.nogrow)
 	}
 	return &flat.FlatAst{
-		nodes:                nodes
-		children:             children
-		user_code_start:      a.user_code_start
-		disabled_fns:         a.disabled_fns
-		noreturn_fns:         a.noreturn_fns
-		source_files:         a.source_files
-		source_buffers:       a.source_buffers
-		text_values:          a.text_values
-		text_ids:             a.text_ids
-		worker_pool:          a.worker_pool
-		specialized_fn_nodes: a.specialized_fn_nodes
+		nodes:                  nodes
+		children:               children
+		user_code_start:        a.user_code_start
+		disabled_fns:           a.disabled_fns
+		noreturn_fns:           a.noreturn_fns
+		source_files:           a.source_files
+		source_buffers:         a.source_buffers
+		text_values:            a.text_values
+		text_ids:               a.text_ids
+		worker_pool:            a.worker_pool
+		specialized_fn_nodes:   a.specialized_fn_nodes
+		specialized_fn_modules: a.specialized_fn_modules
+		specialized_fn_files:   a.specialized_fn_files
 	}
 }
 

--- a/vlib/v3/transform/transform_parallel_test.v
+++ b/vlib/v3/transform/transform_parallel_test.v
@@ -1,6 +1,7 @@
 module transform
 
 import v3.flat
+import v3.types
 
 fn test_deferred_worker_node_clone_preserves_skip_ownership_drops() {
 	$if !v3_no_parallel ? {
@@ -22,4 +23,48 @@ fn test_deferred_worker_node_clone_preserves_skip_ownership_drops() {
 		assert cloned.kind == .for_stmt
 		assert cloned.skip_ownership_drops
 	}
+}
+
+fn test_merge_worker_shifts_private_specialization_metadata() {
+	mut a := flat.FlatAst.new()
+	base_id := a.add_node(flat.Node{
+		kind:  .fn_decl
+		value: 'base_specialization'
+	})
+	a.specialized_fn_nodes[int(base_id)] = true
+	a.specialized_fn_modules[int(base_id)] = 'base_module'
+	a.specialized_fn_files[int(base_id)] = 'base.v'
+	mut tc := types.TypeChecker.new(&a)
+	mut master := new_transformer(mut a, &tc, map[string]bool{})
+	base_nodes := master.a.nodes.len
+	base_children := master.a.children.len
+
+	worker_ast := master.clone_ast_base(base_nodes, base_children)
+	worker_tc := tc.fork_for_parallel_transform(worker_ast)
+	mut worker := master.fork_worker(worker_ast, worker_tc)
+	assert worker.a.specialized_fn_modules[int(base_id)] == 'base_module'
+	worker_id := worker.a.add_node(flat.Node{
+		kind:  .fn_decl
+		value: 'worker_specialization'
+	})
+	worker.a.specialized_fn_nodes[int(worker_id)] = true
+	worker.a.specialized_fn_modules[int(worker_id)] = 'worker_module'
+	worker.a.specialized_fn_files[int(worker_id)] = 'worker.v'
+	assert int(worker_id) == base_nodes
+	assert int(worker_id) !in master.a.specialized_fn_nodes
+
+	master.a.add_node(flat.Node{
+		kind:  .fn_decl
+		value: 'earlier_master_append'
+	})
+	shifted_id := master.a.nodes.len
+	master.merge_worker(worker, []FnWorkItem{}, base_nodes, base_children, false)
+
+	assert master.a.nodes[shifted_id].value == 'worker_specialization'
+	assert master.a.specialized_fn_nodes[shifted_id]
+	assert master.a.specialized_fn_modules[shifted_id] == 'worker_module'
+	assert master.a.specialized_fn_files[shifted_id] == 'worker.v'
+	assert int(worker_id) !in master.a.specialized_fn_nodes
+	assert master.a.specialized_fn_modules[int(base_id)] == 'base_module'
+	assert master.a.specialized_fn_files[int(base_id)] == 'base.v'
 }

--- a/vlib/v3/transform/type_propagation.v
+++ b/vlib/v3/transform/type_propagation.v
@@ -1107,34 +1107,13 @@ fn (t &Transformer) expand_generic_type_alias(typ string) ?string {
 			candidates << qualified
 		}
 	}
-	mut has_alias := false
 	for candidate in candidates {
-		if candidate in t.tc.type_aliases {
-			has_alias = true
-			break
-		}
-	}
-	if !has_alias {
-		return none
-	}
-	for i, node in t.a.nodes {
-		if node.kind != .type_decl || node.children_count > 0 {
+		target := t.tc.type_aliases[candidate] or { continue }
+		params := t.tc.type_alias_generic_params[candidate] or { continue }
+		if params.len != args.len {
 			continue
 		}
-		params := node.generic_params()
-		if params.len == 0 || params.len != args.len {
-			continue
-		}
-		module_name := t.node_module_or(i, '')
-		qualified_name := if module_name.len > 0 && module_name !in ['main', 'builtin'] {
-			'${module_name}.${node.value}'
-		} else {
-			node.value
-		}
-		if qualified_name !in candidates && node.value !in candidates {
-			continue
-		}
-		return substitute_generic_type_text_with_params(node.typ, args, params)
+		return substitute_generic_type_text_with_params(target, args, params)
 	}
 	return none
 }

--- a/vlib/v3/transform/type_propagation.v
+++ b/vlib/v3/transform/type_propagation.v
@@ -62,6 +62,21 @@ fn (t &Transformer) decl_type_should_override_fallback(authority string, fallbac
 	if rhs.kind == .as_expr {
 		return true
 	}
+	if rhs.kind == .ident && authority != fallback {
+		if t.has_smartcast(rhs.value) {
+			return true
+		}
+		if t.var_type(rhs.value) == authority {
+			return true
+		}
+	}
+	if rhs.kind == .call && authority != fallback && authority.contains('.')
+		&& authority.all_after_last('.') == fallback.all_after_last('.') {
+		return true
+	}
+	if rhs.kind == .spawn_expr && fallback == 'thread' && authority.starts_with('thread ') {
+		return true
+	}
 	if rhs.kind == .infix && rhs.op == .right_shift_unsigned {
 		return true
 	}
@@ -133,6 +148,11 @@ fn (t &Transformer) decl_rhs_type(id flat.NodeId) string {
 	}
 	if int(id) >= 0 {
 		node := t.a.nodes[int(id)]
+		if node.kind == .spawn_expr {
+			if spawn_type := t.spawn_expr_decl_type(node) {
+				return spawn_type
+			}
+		}
 		if node.kind == .as_expr && node.value.len > 0 {
 			return t.normalize_type_alias(node.value)
 		}
@@ -142,9 +162,21 @@ fn (t &Transformer) decl_rhs_type(id flat.NodeId) string {
 				return target
 			}
 		}
+		if node.kind == .selector {
+			selector_type := t.resolve_selector_type(node)
+			if decl_type_is_usable(selector_type) {
+				return selector_type
+			}
+		}
 		if node.kind == .call {
 			if ret := t.checker_resolved_non_builtin_return_type(id, node) {
 				return ret
+			}
+		}
+		if node.kind == .ident {
+			local_type := t.resolve_expr_type(id)
+			if decl_type_is_usable(local_type) {
+				return local_type
 			}
 		}
 		if node.kind == .prefix && node.op == .amp && node.children_count > 0 {
@@ -164,6 +196,39 @@ fn (t &Transformer) decl_rhs_type(id flat.NodeId) string {
 		}
 	}
 	return t.node_type(id)
+}
+
+fn (t &Transformer) spawn_expr_decl_type(node flat.Node) ?string {
+	if node.children_count == 0 {
+		return none
+	}
+	call_id := t.a.child(&node, 0)
+	call := t.a.node(call_id)
+	if call.kind != .call || call.children_count == 0 {
+		return none
+	}
+	mut ret_type := t.node_type(call_id)
+	if (ret_type.len == 0 || ret_type == 'unknown') && !isnil(t.tc) {
+		callee := t.a.child_node(call, 0)
+		if callee.kind == .selector && callee.children_count > 0 {
+			base := t.a.child_node(callee, 0)
+			base_type := if base.kind == .ident {
+				t.var_type(base.value)
+			} else {
+				t.node_type(t.a.child(callee, 0))
+			}
+			if info := t.tc.resolve_generic_struct_method(base_type, callee.value) {
+				ret_type = info.return_type.name()
+			}
+		}
+	}
+	if ret_type.len == 0 || ret_type == 'unknown' {
+		return none
+	}
+	if ret_type == 'void' {
+		return 'thread'
+	}
+	return 'thread ${ret_type}'
 }
 
 fn (t &Transformer) map_expr_decl_type(id flat.NodeId) ?string {
@@ -749,42 +814,57 @@ fn (t &Transformer) lookup_unique_field_type(field_name string) ?string {
 
 // normalize_field_type transforms normalize field type data for transform.
 fn (t &Transformer) normalize_field_type(typ string, owner_type string) string {
+	return t.normalize_field_type_with_owner_substitution(typ, owner_type, true)
+}
+
+fn (t &Transformer) normalize_field_type_with_owner_substitution(typ string, owner_type string, allow_owner_substitution bool) string {
 	if typ.len == 0 {
 		return typ
 	}
 	if typ.starts_with('mut ') {
-		return 'mut ' + t.normalize_field_type(typ[4..], owner_type)
+		return 'mut ' +
+			t.normalize_field_type_with_owner_substitution(typ[4..], owner_type, allow_owner_substitution)
 	}
 	if typ.starts_with('shared ') {
-		return 'shared ' + t.normalize_field_type(typ[7..], owner_type)
+		return 'shared ' +
+			t.normalize_field_type_with_owner_substitution(typ[7..], owner_type, allow_owner_substitution)
 	}
 	if typ.starts_with('atomic ') {
-		return 'atomic ' + t.normalize_field_type(typ[7..], owner_type)
+		return 'atomic ' +
+			t.normalize_field_type_with_owner_substitution(typ[7..], owner_type, allow_owner_substitution)
 	}
 	if typ.starts_with('&') {
-		return '&' + t.normalize_field_type(typ[1..], owner_type)
+		return '&' +
+			t.normalize_field_type_with_owner_substitution(typ[1..], owner_type, allow_owner_substitution)
 	}
 	if typ.starts_with('[]') {
-		return '[]' + t.normalize_field_type(typ[2..], owner_type)
+		return '[]' +
+			t.normalize_field_type_with_owner_substitution(typ[2..], owner_type, allow_owner_substitution)
 	}
 	if typ.starts_with('?') {
-		return '?' + t.normalize_field_type(typ[1..], owner_type)
+		return '?' +
+			t.normalize_field_type_with_owner_substitution(typ[1..], owner_type, allow_owner_substitution)
 	}
 	if typ.starts_with('!') {
-		return '!' + t.normalize_field_type(typ[1..], owner_type)
+		return '!' +
+			t.normalize_field_type_with_owner_substitution(typ[1..], owner_type, allow_owner_substitution)
 	}
 	if typ.starts_with('map[') {
 		bracket_end := typ.index(']') or { return t.normalize_type_alias(typ) }
-		key_type := t.normalize_field_type(typ[4..bracket_end], owner_type)
-		value_type := t.normalize_field_type(typ[bracket_end + 1..], owner_type)
+		key_type := t.normalize_field_type_with_owner_substitution(typ[4..bracket_end], owner_type,
+			allow_owner_substitution)
+		value_type := t.normalize_field_type_with_owner_substitution(typ[bracket_end + 1..],
+			owner_type, allow_owner_substitution)
 		return 'map[${key_type}]${value_type}'
 	}
 	if typ.starts_with('[') {
 		bracket_end := typ.index(']') or { return t.normalize_type_alias(typ) }
-		return typ[..bracket_end + 1] + t.normalize_field_type(typ[bracket_end + 1..], owner_type)
+		return typ[..bracket_end + 1] +
+			t.normalize_field_type_with_owner_substitution(typ[bracket_end +
+			1..], owner_type, allow_owner_substitution)
 	}
 	owner_base, owner_args, owner_is_generic_app := generic_app_parts(owner_type)
-	if owner_is_generic_app {
+	if allow_owner_substitution && owner_is_generic_app {
 		if owner_base.len > 0 {
 			params := t.generic_struct_param_names_for_base(owner_base)
 			substituted := if params.len > 0 {
@@ -793,7 +873,8 @@ fn (t &Transformer) normalize_field_type(typ string, owner_type string) string {
 				substitute_generic_type_text(typ, owner_args)
 			}
 			if substituted != typ {
-				return t.normalize_field_type(substituted, owner_type)
+				return t.normalize_field_type_with_owner_substitution(substituted, owner_type,
+					false)
 			}
 		}
 	}
@@ -809,7 +890,8 @@ fn (t &Transformer) normalize_field_type(typ string, owner_type string) string {
 		}
 		mut normalized_args := []string{cap: args.len}
 		for arg in args {
-			mut normalized_arg := t.normalize_field_type(arg, owner_type)
+			mut normalized_arg := t.normalize_field_type_with_owner_substitution(arg, owner_type,
+				allow_owner_substitution)
 			if field_base.contains('.') {
 				field_mod := field_base.all_before_last('.')
 				normalized_arg = strip_field_module_prefix_from_type(normalized_arg, field_mod)
@@ -937,6 +1019,21 @@ fn (t &Transformer) normalize_type_alias_uncached(typ string) string {
 	if typ.starts_with('!') {
 		return '!' + t.normalize_type_alias(typ[1..])
 	}
+	if expanded := t.expand_generic_type_alias(typ) {
+		return t.normalize_type_alias(expanded)
+	}
+	// A fully qualified type is already canonical. Resolve its exact alias before
+	// consulting imports from the current file; otherwise an unrelated import with
+	// the same trailing type name can steal the identity (for example
+	// `v3.ssa.TypeID` being resolved as `v3.types.Type`).
+	if typ.contains('.') {
+		if target := t.tc.type_aliases[typ] {
+			return t.normalize_type_alias(target)
+		}
+		if t.type_authority_has(typ) {
+			return typ
+		}
+	}
 	// Resolve the importing file's alias before any short-name or suffix fallback.
 	// Two packages can both expose `tast.Value`; `other_tast.Value` and
 	// `tast.Value` must retain their exact canonical module identities.
@@ -991,6 +1088,55 @@ fn (t &Transformer) normalize_type_alias_uncached(typ string) string {
 		}
 	}
 	return typ
+}
+
+fn (t &Transformer) expand_generic_type_alias(typ string) ?string {
+	base, args, ok := generic_app_parts(typ)
+	if !ok || args.len == 0 {
+		return none
+	}
+	mut candidates := [base]
+	if imported := t.resolve_imported_type_name(base) {
+		if imported !in candidates {
+			candidates << imported
+		}
+	}
+	if !base.contains('.') && t.cur_module.len > 0 && t.cur_module !in ['main', 'builtin'] {
+		qualified := '${t.cur_module}.${base}'
+		if qualified !in candidates {
+			candidates << qualified
+		}
+	}
+	mut has_alias := false
+	for candidate in candidates {
+		if candidate in t.tc.type_aliases {
+			has_alias = true
+			break
+		}
+	}
+	if !has_alias {
+		return none
+	}
+	for i, node in t.a.nodes {
+		if node.kind != .type_decl || node.children_count > 0 {
+			continue
+		}
+		params := node.generic_params()
+		if params.len == 0 || params.len != args.len {
+			continue
+		}
+		module_name := t.node_module_or(i, '')
+		qualified_name := if module_name.len > 0 && module_name !in ['main', 'builtin'] {
+			'${module_name}.${node.value}'
+		} else {
+			node.value
+		}
+		if qualified_name !in candidates && node.value !in candidates {
+			continue
+		}
+		return substitute_generic_type_text_with_params(node.typ, args, params)
+	}
+	return none
 }
 
 fn strip_field_module_prefix_from_type(typ string, module_name string) string {
@@ -1254,6 +1400,9 @@ fn (t &Transformer) node_type(id flat.NodeId) string {
 	}
 	resolved := t.resolve_expr_type(id)
 	if resolved.len > 0 {
+		if checked := t.checker_type_over_struct_guess(id, resolved) {
+			return checked
+		}
 		if resolved.contains('typeof(') && !isnil(t.tc) {
 			if typ := t.tc.expr_type(id) {
 				name := t.normalize_type_alias(typ.name())
@@ -1360,6 +1509,42 @@ fn (t &Transformer) node_type(id flat.NodeId) string {
 		return deferred_call_typ
 	}
 	return ''
+}
+
+fn (t &Transformer) checker_type_over_struct_guess(id flat.NodeId, guessed string) ?string {
+	if isnil(t.tc) || int(id) < 0 || guessed.len == 0 {
+		return none
+	}
+	node := t.a.nodes[int(id)]
+	if node.kind == .ident {
+		local_type := t.normalize_type_alias(t.var_type(node.value))
+		if local_type.len > 0 && local_type == t.normalize_type_alias(guessed) {
+			// Function-local bindings are authoritative after lowering. The checker
+			// cache still describes the source node and can retain a mutable
+			// parameter's pointer storage type after that node is reused for a value
+			// local with the same expression shape.
+			return none
+		}
+	}
+	guessed_type := t.tc.parse_type(guessed)
+	guessed_base := types.unwrap_all_pointers(guessed_type)
+	guessed_is_struct := guessed_base is types.Struct
+		|| (guessed_base is types.Alias && guessed_base.base_type is types.Struct)
+	if !guessed_is_struct {
+		return none
+	}
+	checked_type := t.tc.expr_type(id) or { return none }
+	if checked_type is types.Unknown || checked_type is types.Void {
+		return none
+	}
+	if t.tc.c_type(guessed_type) == t.tc.c_type(checked_type) {
+		return none
+	}
+	checked := t.normalize_type_alias(checked_type.name())
+	if !decl_type_is_usable(checked) {
+		return none
+	}
+	return checked
 }
 
 fn (t &Transformer) array_call_type_name(node flat.Node) ?string {
@@ -1496,6 +1681,28 @@ fn (t &Transformer) is_string_type(id flat.NodeId) bool {
 	node := t.a.nodes[int(id)]
 	if node.kind == .string_literal || node.kind == .string_interp {
 		return true
+	}
+	if node.kind == .ident {
+		raw_var_type := t.raw_var_type(node.value)
+		if raw_var_type.len > 0 {
+			return t.normalize_type_alias(raw_var_type) == 'string'
+		}
+	}
+	if node.kind == .ident && !isnil(t.tc) {
+		if key := t.const_type_key_in_context(node.value, t.cur_module, t.cur_file) {
+			if expr_id := t.tc.const_exprs[key] {
+				const_expr := t.a.nodes[int(expr_id)]
+				if const_expr.kind == .char_literal {
+					return false
+				}
+				if const_expr.kind == .string_literal || const_expr.kind == .string_interp {
+					return true
+				}
+			}
+		}
+	}
+	if raw_const_type := t.raw_const_type_name_for_expr(id) {
+		return t.normalize_type_alias(raw_const_type) == 'string'
 	}
 	mut typ := ''
 	if sc := t.find_smartcast(t.expr_key(id)) {

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -6048,11 +6048,24 @@ fn (tc &TypeChecker) call_never_returns(id flat.NodeId) bool {
 	}
 	callee := tc.a.child_node(&call, 0)
 	if callee.kind == .ident {
+		if callee.value in ['panic', 'exit'] && tc.no_return_builtin_is_shadowed(callee.value) {
+			return false
+		}
 		return callee.value in ['panic', 'exit', '__v_compile_error']
 	}
 	if callee.kind == .selector && callee.children_count > 0 {
 		base := tc.a.child_node(callee, 0)
 		return base.kind == .ident && callee.value == 'exit' && base.value in ['os', 'C']
+	}
+	return false
+}
+
+fn (tc &TypeChecker) no_return_builtin_is_shadowed(name string) bool {
+	if name in tc.smartcasts {
+		return true
+	}
+	if _ := tc.non_file_scope_type(name) {
+		return true
 	}
 	return false
 }
@@ -6115,6 +6128,32 @@ fn (tc &TypeChecker) expr_never_returns(id flat.NodeId) bool {
 			return false
 		}
 	}
+}
+
+fn (tc &TypeChecker) branch_tail_never_returns(branch_id flat.NodeId) bool {
+	if !tc.valid_node_id(branch_id) {
+		return false
+	}
+	branch := tc.a.nodes[int(branch_id)]
+	tail_id := tc.branch_tail_expr_id(branch_id)
+	if !tc.valid_node_id(tail_id) {
+		return false
+	}
+	if branch.kind !in [.block, .match_branch] {
+		return tc.expr_never_returns(tail_id)
+	}
+	body_start := if branch.kind == .match_branch {
+		if branch.value == 'else' { 0 } else { branch.value.int() }
+	} else {
+		0
+	}
+	mut scoped := *tc
+	scoped.smartcasts = clone_smartcasts(tc.smartcasts)
+	tail_index := int(branch.children_count) - 1
+	for i in body_start .. tail_index {
+		scoped.apply_return_analysis_local_binding(tc.a.child(&branch, i))
+	}
+	return scoped.expr_never_returns(tail_id)
 }
 
 // match_covers_all_enum_variants reports whether a `match` over an enum subject
@@ -11145,7 +11184,7 @@ fn (tc &TypeChecker) multi_expr_branch_tail_type_groups(branch_id flat.NodeId, c
 	if !tc.valid_node_id(tail_id) {
 		return none
 	}
-	if tc.expr_never_returns(tail_id) {
+	if tc.branch_tail_never_returns(branch_id) {
 		return [][]Type{}
 	}
 	tail := tc.a.nodes[int(tail_id)]
@@ -11216,7 +11255,7 @@ fn (tc &TypeChecker) match_multi_return_types(expr_id flat.NodeId, count int) ?[
 			return none
 		}
 		tail := tc.a.nodes[int(tail_id)]
-		if tail.kind == .return_stmt || tc.expr_never_returns(tail_id) {
+		if tail.kind == .return_stmt || tc.branch_tail_never_returns(branch_id) {
 			continue
 		}
 		multi := multi_return_payload_type(tc.resolve_type(tail_id)) or { return none }
@@ -11463,7 +11502,7 @@ fn (tc &TypeChecker) wrapped_multi_return_tail_is_error(branch_id flat.NodeId, w
 	if !tc.valid_node_id(tail_id) {
 		return false
 	}
-	if tc.expr_never_returns(tail_id) {
+	if tc.branch_tail_never_returns(branch_id) {
 		return true
 	}
 	raw_type := tc.resolve_type(tail_id)
@@ -11492,7 +11531,7 @@ fn (tc &TypeChecker) tuple_tail_value_groups(body_id flat.NodeId, count int, exp
 		if last.kind == .return_stmt {
 			return [][]flat.NodeId{}
 		}
-		if tc.expr_never_returns(last_id) {
+		if tc.branch_tail_never_returns(body_id) {
 			return [][]flat.NodeId{}
 		}
 	}

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -4018,7 +4018,11 @@ pub fn (mut tc TypeChecker) copy_cloned_resolution(src_id flat.NodeId, dst_id fl
 // resolve_fn_value_name_for_expected resolves and records a function value in an expected FnType context.
 fn (mut tc TypeChecker) resolve_fn_value_name_for_expected(id flat.NodeId, expected Type) ?string {
 	if name := tc.resolved_fn_value_name(id) {
-		return name
+		actual := tc.fn_type_from_key(name) or { return none }
+		if tc.fn_value_signature_compatible(actual, expected) {
+			return name
+		}
+		return none
 	}
 	if int(id) < 0 || int(id) >= tc.a.nodes.len {
 		return none
@@ -22077,25 +22081,28 @@ fn (mut tc TypeChecker) resolve_expr(id flat.NodeId, expected Type) Type {
 
 // fn_value_match_key returns the single exact function declaration key accepted for a function value.
 fn (tc &TypeChecker) fn_value_match_key(node flat.Node, expected Type) ?string {
-	expected_fn := fn_type_from_type(expected) or { return none }
 	key := tc.fn_value_key(node) or { return none }
 	actual := tc.fn_type_from_key(key) or { return none }
-	if actual is FnType {
-		if actual.params.len != expected_fn.params.len {
-			return none
-		}
-		for i in 0 .. actual.params.len {
-			actual_param := fn_param_type(actual, i)
-			expected_param := fn_param_type(expected_fn, i)
-			if !tc.fn_param_compatible(actual_param, expected_param) {
-				return none
-			}
-		}
-		if tc.fn_return_compatible(actual.return_type, expected_fn.return_type) {
-			return key
-		}
+	if tc.fn_value_signature_compatible(actual, expected) {
+		return key
 	}
 	return none
+}
+
+fn (tc &TypeChecker) fn_value_signature_compatible(actual Type, expected Type) bool {
+	actual_fn := fn_type_from_type(actual) or { return false }
+	expected_fn := fn_type_from_type(expected) or { return false }
+	if actual_fn.params.len != expected_fn.params.len {
+		return false
+	}
+	for i in 0 .. actual_fn.params.len {
+		actual_param := fn_param_type(actual_fn, i)
+		expected_param := fn_param_type(expected_fn, i)
+		if !tc.fn_param_compatible(actual_param, expected_param) {
+			return false
+		}
+	}
+	return tc.fn_return_compatible(actual_fn.return_type, expected_fn.return_type)
 }
 
 // fn_value_key resolves a function value expression to one exact function declaration key.
@@ -22422,6 +22429,9 @@ fn (tc &TypeChecker) type_compatible(actual Type, expected Type) bool {
 	if type_contains_unknown(actual) || type_contains_unknown(expected) {
 		return true
 	}
+	if actual is FnType && expected is FnType {
+		return tc.fn_value_signature_compatible(Type(actual), Type(expected))
+	}
 	if (actual.name().contains('[') || expected.name().contains('['))
 		&& tc.generic_type_name_matches(actual.name(), expected.name()) {
 		return true
@@ -22674,7 +22684,7 @@ fn (tc &TypeChecker) fn_return_compatible(actual Type, expected Type) bool {
 	if actual.name() == expected.name() {
 		return true
 	}
-	if tc.c_type(actual) == tc.c_type(expected) {
+	if tc.c_type(actual) == tc.c_type(expected) && tc.type_compatible(actual, expected) {
 		return true
 	}
 	return fn_return_canonical_type_name(actual) == fn_return_canonical_type_name(expected)

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -6055,7 +6055,13 @@ fn (tc &TypeChecker) call_never_returns(id flat.NodeId) bool {
 	}
 	if callee.kind == .selector && callee.children_count > 0 {
 		base := tc.a.child_node(callee, 0)
-		return base.kind == .ident && callee.value == 'exit' && base.value in ['os', 'C']
+		if base.kind != .ident || callee.value != 'exit' || base.value !in ['os', 'C'] {
+			return false
+		}
+		if base.value == 'os' && tc.no_return_builtin_is_shadowed(base.value) {
+			return false
+		}
+		return true
 	}
 	return false
 }

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -13772,14 +13772,16 @@ fn (mut tc TypeChecker) resolve_call_info(id flat.NodeId, node flat.Node) ?CallI
 			binding_type = typ
 		}
 		mut fn_type := Type(void_)
+		mut is_smartcasted := false
 		if smart_type := tc.smartcast_type(fn_id) {
 			fn_type = smart_type
+			is_smartcasted = true
 		} else {
 			fn_type = binding_type
 		}
 		if fn_typ := fn_type_from_type(fn_type) {
 			actual_count := node.children_count - 1
-			selected := if fn_typ.params.len != actual_count {
+			selected := if !is_smartcasted && fn_typ.params.len != actual_count {
 				tc.sum_fn_variant_for_arg_count(binding_type, actual_count) or { fn_typ }
 			} else {
 				fn_typ

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -18187,7 +18187,9 @@ fn (tc &TypeChecker) method_receiver_compatible(actual Type, expected Type, meth
 	}
 	actual_depth, actual_base := type_pointer_depth_and_base(actual)
 	expected_depth, expected_base := type_pointer_depth_and_base(expected)
-	if actual_depth > expected_depth && (tc.type_compatible(actual_base, expected_base)
+	// C receiver lowering can dereference a pointer for a value receiver, but it
+	// does not adjust depth when both the actual and expected receivers are pointers.
+	if actual_depth == 1 && expected_depth == 0 && (tc.type_compatible(actual_base, expected_base)
 		|| tc.generic_receiver_base_match(actual_base, expected_base)
 		|| tc.receiver_embeds(actual_base, expected_base)) {
 		return true

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -9773,10 +9773,6 @@ fn (tc &TypeChecker) or_expr_source_can_fail(id flat.NodeId) bool {
 	if node.kind == .or_expr && node.value in ['!', '?'] && node.children_count > 0 {
 		return tc.or_expr_source_can_fail(tc.a.child(node, 0))
 	}
-	if node.kind == .infix && node.children_count >= 2 {
-		return tc.or_expr_source_can_fail(tc.a.child(node, 0))
-			|| tc.or_expr_source_can_fail(tc.a.child(node, 1))
-	}
 	if node.kind == .index && node.children_count > 0 {
 		base_type := unalias_and_unwrap_pointer_type(tc.resolve_type(tc.a.child(node, 0)))
 		return base_type is Map || base_type is Array || base_type is ArrayFixed
@@ -12628,9 +12624,6 @@ fn (mut tc TypeChecker) return_type_compatible(expr_id flat.NodeId, actual Type,
 					return true
 				}
 			}
-		}
-		if actual is ResultType && tc.type_compatible(actual.base_type, expected.base_type) {
-			return true
 		}
 		if tc.pointer_value_compatible(actual, expected.base_type) {
 			return true

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -15690,7 +15690,7 @@ fn (tc &TypeChecker) mut_receiver_expr_is_mutable_lvalue(id flat.NodeId) bool {
 		.ident {
 			return tc.ident_is_mutable_lvalue(node.value)
 		}
-		.index, .selector, .paren, .or_expr {
+		.index, .selector, .paren {
 			return node.children_count > 0
 				&& tc.mut_receiver_expr_is_mutable_lvalue(tc.a.child(&node, 0))
 		}

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -22637,9 +22637,6 @@ fn (tc &TypeChecker) fn_return_compatible(actual Type, expected Type) bool {
 	if tc.c_type(actual) == tc.c_type(expected) {
 		return true
 	}
-	if actual.is_integer() && expected.is_integer() {
-		return true
-	}
 	return fn_return_canonical_type_name(actual) == fn_return_canonical_type_name(expected)
 }
 

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -9754,18 +9754,12 @@ fn (tc &TypeChecker) or_expr_source_can_fail(id flat.NodeId) bool {
 			return base_type is Map
 		}
 	}
-	return type_contains_option_or_result(tc.resolve_type(id))
+	return type_is_option_or_result(tc.resolve_type(id))
 }
 
-fn type_contains_option_or_result(typ Type) bool {
+fn type_is_option_or_result(typ Type) bool {
 	clean := unalias_type(typ)
-	if clean is OptionType || clean is ResultType {
-		return true
-	}
-	if clean is Pointer {
-		return type_contains_option_or_result(clean.base_type)
-	}
-	return false
+	return clean is OptionType || clean is ResultType
 }
 
 fn (tc &TypeChecker) sql_aggregate_or_expr_type(node flat.Node) ?Type {

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -20643,6 +20643,12 @@ fn (mut tc TypeChecker) check_struct_init(id flat.NodeId, node flat.Node) {
 			} else if i < fields.len {
 				expected = fields[i].typ
 			}
+			// A method value stored in a struct field escapes the evaluation site (several
+			// instances from the same `Foo{cb: obj.method}` site would share one receiver).
+			if !tc.stored_method_value_matches_voidptr_callback(value_id, expected) {
+				tc.reject_stored_method_value(value_id)
+			}
+			tc.reject_stored_or_returned_capturing_fn_literal(value_id)
 			if expected !is Void {
 				tc.check_node_with_expected_context(value_id, expected)
 			} else {

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -15705,6 +15705,409 @@ fn (tc &TypeChecker) binding_owner_is_file_scope(owner ScopeBindingOwner) bool {
 	return false
 }
 
+enum ReceiverMutationVisibility {
+	none
+	direct
+	private_path
+	public_path
+}
+
+struct VisibleMutationFnDecl {
+	idx int
+	mod string
+}
+
+fn receiver_mutation_is_visible(vis ReceiverMutationVisibility) bool {
+	return vis in [.direct, .public_path]
+}
+
+fn visible_mutation_receiver_type_name(typ string) string {
+	mut clean := typ.trim_space()
+	for clean.starts_with('&') {
+		clean = clean[1..].trim_space()
+	}
+	for prefix in ['mut ', 'shared '] {
+		if clean.starts_with(prefix) {
+			clean = clean[prefix.len..].trim_space()
+		}
+	}
+	return strip_generic_args_name(clean)
+}
+
+fn visible_mutation_fn_names_match(actual string, declared string) bool {
+	if actual == declared {
+		return true
+	}
+	if actual.all_after_last('.') != declared.all_after_last('.') {
+		return false
+	}
+	actual_receiver := actual.all_before_last('.')
+	declared_receiver := declared.all_before_last('.')
+	return strip_generic_args_name(actual_receiver) == strip_generic_args_name(declared_receiver)
+}
+
+fn (tc &TypeChecker) visible_mutation_fn_decl(name string, fallback_mod string) ?VisibleMutationFnDecl {
+	mut cur_mod := ''
+	for i in tc.top_level_idx {
+		node := tc.a.nodes[i]
+		match node.kind {
+			.file {
+				cur_mod = tc.file_modules[node.value] or { '' }
+			}
+			.module_decl {
+				cur_mod = node.value
+			}
+			.fn_decl {
+				if fallback_mod.len > 0 && cur_mod != fallback_mod {
+					continue
+				}
+				qname := checker_qualified_fn_name(cur_mod, node.value)
+				if visible_mutation_fn_names_match(name, qname)
+					|| visible_mutation_fn_names_match(name, node.value)
+					|| tc.cached_c_name(qname) == name || tc.cached_c_name(node.value) == name {
+					return VisibleMutationFnDecl{
+						idx: i
+						mod: cur_mod
+					}
+				}
+			}
+			else {}
+		}
+	}
+	return none
+}
+
+fn (tc &TypeChecker) visible_mutation_fn_param(decl VisibleMutationFnDecl, param_idx int) ?flat.Node {
+	if decl.idx < 0 || decl.idx >= tc.a.nodes.len || param_idx < 0 {
+		return none
+	}
+	fn_node := tc.a.nodes[decl.idx]
+	mut idx := 0
+	for i in 0 .. fn_node.children_count {
+		child := tc.a.child_node(&fn_node, i)
+		if child.kind != .param {
+			break
+		}
+		if idx == param_idx {
+			return *child
+		}
+		idx++
+	}
+	return none
+}
+
+fn (tc &TypeChecker) visible_mutation_struct_field_is_public(receiver_type string, field_name string, decl_mod string) ?bool {
+	type_name := visible_mutation_receiver_type_name(receiver_type)
+	short_name := type_name.all_after_last('.')
+	mut cur_mod := ''
+	for i in tc.top_level_idx {
+		node := tc.a.nodes[i]
+		match node.kind {
+			.file {
+				cur_mod = tc.file_modules[node.value] or { '' }
+			}
+			.module_decl {
+				cur_mod = node.value
+			}
+			.struct_decl {
+				if decl_mod.len > 0 && cur_mod != decl_mod {
+					continue
+				}
+				qname := if cur_mod in ['', 'main', 'builtin'] {
+					node.value
+				} else {
+					'${cur_mod}.${node.value}'
+				}
+				if node.value != short_name && qname != type_name {
+					continue
+				}
+				for j in 0 .. node.children_count {
+					field := tc.a.child_node(&node, j)
+					if field.kind != .field_decl || field.value != field_name {
+						continue
+					}
+					meta := field.generic_params()
+					return meta.len > 0 && meta[0].contains('p')
+				}
+				return none
+			}
+			else {}
+		}
+	}
+	return none
+}
+
+fn (tc &TypeChecker) receiver_expr_mutation_visibility(expr_id flat.NodeId, root_name string, receiver_type string, decl_mod string) ReceiverMutationVisibility {
+	if int(expr_id) < 0 || int(expr_id) >= tc.a.nodes.len {
+		return .none
+	}
+	node := tc.a.nodes[int(expr_id)]
+	match node.kind {
+		.ident {
+			return if node.value == root_name { .direct } else { .none }
+		}
+		.paren, .prefix, .postfix, .cast_expr, .as_expr, .expr_stmt {
+			if node.children_count > 0 {
+				return tc.receiver_expr_mutation_visibility(tc.a.child(&node, 0), root_name,
+					receiver_type, decl_mod)
+			}
+		}
+		.selector {
+			if node.children_count == 0 {
+				return .none
+			}
+			mut parent_id := tc.a.child(&node, 0)
+			for int(parent_id) >= 0 && int(parent_id) < tc.a.nodes.len {
+				parent := tc.a.nodes[int(parent_id)]
+				if parent.kind != .paren || parent.children_count == 0 {
+					break
+				}
+				parent_id = tc.a.child(&parent, 0)
+			}
+			if int(parent_id) >= 0 && int(parent_id) < tc.a.nodes.len {
+				parent := tc.a.nodes[int(parent_id)]
+				if parent.kind == .ident && parent.value == root_name {
+					is_pub := tc.visible_mutation_struct_field_is_public(receiver_type, node.value,
+						decl_mod) or { true }
+					return if is_pub { .public_path } else { .private_path }
+				}
+			}
+			return tc.receiver_expr_mutation_visibility(parent_id, root_name, receiver_type,
+				decl_mod)
+		}
+		.index {
+			if node.children_count > 0 {
+				return tc.receiver_expr_mutation_visibility(tc.a.child(&node, 0), root_name,
+					receiver_type, decl_mod)
+			}
+		}
+		.call {
+			if node.children_count > 0 {
+				mut fn_node := tc.a.child_node(&node, 0)
+				if fn_node.kind == .index && fn_node.children_count > 0 {
+					fn_node = tc.a.child_node(fn_node, 0)
+				}
+				if fn_node.kind == .selector && fn_node.children_count > 0 {
+					return tc.receiver_expr_mutation_visibility(tc.a.child(fn_node, 0), root_name,
+						receiver_type, decl_mod)
+				}
+			}
+		}
+		else {}
+	}
+	return .none
+}
+
+fn (tc &TypeChecker) visible_mutation_call_name(call_id flat.NodeId, call flat.Node, root_type string, decl_mod string) string {
+	if name := tc.resolved_call_name(call_id) {
+		return name
+	}
+	if call.children_count == 0 {
+		return ''
+	}
+	mut fn_node := tc.a.child_node(&call, 0)
+	if fn_node.kind == .index && fn_node.children_count > 0 {
+		fn_node = tc.a.child_node(fn_node, 0)
+	}
+	if fn_node.kind == .ident {
+		return checker_qualified_fn_name(decl_mod, fn_node.value)
+	}
+	if fn_node.kind == .selector && fn_node.children_count > 0 {
+		base := tc.a.child_node(fn_node, 0)
+		if base.kind == .ident && base.value.len > 0 && base.value[0] >= `A` && base.value[0] <= `Z` {
+			return checker_qualified_fn_name(decl_mod, '${base.value}.${fn_node.value}')
+		}
+		receiver_name := visible_mutation_receiver_type_name(root_type)
+		return checker_qualified_fn_name(decl_mod, '${receiver_name}.${fn_node.value}')
+	}
+	return ''
+}
+
+fn (tc &TypeChecker) call_has_visible_receiver_mutation(call_id flat.NodeId, call flat.Node, root_name string, root_type string, decl_mod string, mut visiting map[string]bool, mut cache map[string]bool) bool {
+	if call.children_count == 0 {
+		return false
+	}
+	mut fn_node := tc.a.child_node(&call, 0)
+	if fn_node.kind == .index && fn_node.children_count > 0 {
+		fn_node = tc.a.child_node(fn_node, 0)
+	}
+	called_name := tc.visible_mutation_call_name(call_id, call, root_type, decl_mod)
+	called_mod := tc.fn_type_modules[called_name] or { decl_mod }
+	decl := tc.visible_mutation_fn_decl(called_name, called_mod) or {
+		if fn_node.kind == .selector && fn_node.children_count > 0 {
+			recv_vis := tc.receiver_expr_mutation_visibility(tc.a.child(fn_node, 0), root_name,
+				root_type, decl_mod)
+			if receiver_mutation_is_visible(recv_vis) && tc.mut_receiver_methods[called_name] {
+				return true
+			}
+		}
+		for i in 1 .. call.children_count {
+			arg_id := tc.a.child(&call, i)
+			arg := tc.a.nodes[int(arg_id)]
+			if arg.is_mut
+				&& receiver_mutation_is_visible(tc.receiver_expr_mutation_visibility(arg_id, root_name, root_type, decl_mod)) {
+				return true
+			}
+		}
+		return false
+	}
+	mut is_method := false
+	mut receiver_param_is_mut := false
+	if first_param := tc.visible_mutation_fn_param(decl, 0) {
+		is_method = first_param.op == .dot
+		receiver_param_is_mut = first_param.is_mut
+	}
+	mut param_offset := 0
+	if is_method {
+		param_offset = 1
+		if fn_node.kind == .selector && fn_node.children_count > 0 && receiver_param_is_mut {
+			recv_vis := tc.receiver_expr_mutation_visibility(tc.a.child(fn_node, 0), root_name,
+				root_type, decl_mod)
+			match recv_vis {
+				.direct {
+					if tc.visible_mutation_fn_param_has_visible_mutation(decl, 0, mut visiting, mut
+						cache)
+					{
+						return true
+					}
+				}
+				.public_path {
+					return true
+				}
+				else {}
+			}
+		}
+	}
+	for i in 1 .. call.children_count {
+		arg_id := tc.a.child(&call, i)
+		arg := tc.a.nodes[int(arg_id)]
+		if !arg.is_mut {
+			continue
+		}
+		param_idx := i - 1 + param_offset
+		param := tc.visible_mutation_fn_param(decl, param_idx) or { continue }
+		if !param.is_mut {
+			continue
+		}
+		arg_vis := tc.receiver_expr_mutation_visibility(arg_id, root_name, root_type, decl_mod)
+		match arg_vis {
+			.direct {
+				if tc.visible_mutation_fn_param_has_visible_mutation(decl, param_idx, mut visiting, mut
+					cache)
+				{
+					return true
+				}
+			}
+			.public_path {
+				return true
+			}
+			else {}
+		}
+	}
+	return false
+}
+
+fn (tc &TypeChecker) node_has_visible_receiver_mutation(id flat.NodeId, root_name string, root_type string, decl_mod string, mut visiting map[string]bool, mut cache map[string]bool) bool {
+	if int(id) < 0 || int(id) >= tc.a.nodes.len {
+		return false
+	}
+	node := tc.a.nodes[int(id)]
+	match node.kind {
+		.fn_decl, .fn_literal {
+			return false
+		}
+		.assign {
+			lhs_count_value := node.value.int()
+			lhs_count := if lhs_count_value > 0 { lhs_count_value } else { 1 }
+			rhs_count := int(node.children_count) - lhs_count
+			mut child_offset := 0
+			for i in 0 .. lhs_count {
+				if child_offset >= int(node.children_count) {
+					break
+				}
+				lhs_id := tc.a.child(&node, child_offset)
+				if receiver_mutation_is_visible(tc.receiver_expr_mutation_visibility(lhs_id,
+					root_name, root_type, decl_mod))
+				{
+					return true
+				}
+				child_offset++
+				if i < rhs_count {
+					child_offset++
+				}
+			}
+		}
+		.selector_assign, .index_assign {
+			if node.children_count > 0
+				&& receiver_mutation_is_visible(tc.receiver_expr_mutation_visibility(tc.a.child(&node, 0), root_name, root_type, decl_mod)) {
+				return true
+			}
+		}
+		.postfix {
+			if node.op in [.inc, .dec] && node.children_count > 0
+				&& receiver_mutation_is_visible(tc.receiver_expr_mutation_visibility(tc.a.child(&node, 0), root_name, root_type, decl_mod)) {
+				return true
+			}
+		}
+		.call {
+			if tc.call_has_visible_receiver_mutation(id, node, root_name, root_type, decl_mod, mut
+				visiting, mut cache)
+			{
+				return true
+			}
+		}
+		else {}
+	}
+	for i in 0 .. node.children_count {
+		if tc.node_has_visible_receiver_mutation(tc.a.child(&node, i), root_name, root_type,
+			decl_mod, mut visiting, mut cache)
+		{
+			return true
+		}
+	}
+	return false
+}
+
+fn (tc &TypeChecker) visible_mutation_fn_param_has_visible_mutation(decl VisibleMutationFnDecl, param_idx int, mut visiting map[string]bool, mut cache map[string]bool) bool {
+	key := '${decl.idx}|${param_idx}'
+	if key in cache {
+		return cache[key]
+	}
+	if key in visiting {
+		return true
+	}
+	param := tc.visible_mutation_fn_param(decl, param_idx) or { return true }
+	if !param.is_mut {
+		return false
+	}
+	fn_node := tc.a.nodes[decl.idx]
+	mut param_count := 0
+	for i in 0 .. fn_node.children_count {
+		if tc.a.child_node(&fn_node, i).kind != .param {
+			break
+		}
+		param_count++
+	}
+	if param_count == int(fn_node.children_count) {
+		// A source method with `{}` has no visible mutation. Header declarations use
+		// `is_mut` as the parser's cached-body marker and remain conservative.
+		return fn_node.is_mut
+	}
+	visiting[key] = true
+	mut result := false
+	for i in param_count .. fn_node.children_count {
+		if tc.node_has_visible_receiver_mutation(tc.a.child(&fn_node, i), param.value, param.typ,
+			decl.mod, mut visiting, mut cache)
+		{
+			result = true
+			break
+		}
+	}
+	visiting.delete(key)
+	cache[key] = result
+	return result
+}
+
 fn (tc &TypeChecker) mut_receiver_call_requires_mutable_lvalue(info CallInfo, recv_id flat.NodeId) bool {
 	if tc.expr_is_shared_arg(recv_id) {
 		return false
@@ -15712,12 +16115,14 @@ fn (tc &TypeChecker) mut_receiver_call_requires_mutable_lvalue(info CallInfo, re
 	if tc.expr_root_is_global_binding(recv_id) {
 		return false
 	}
-	// Outside the declaring module, a public mut-receiver method may only mutate
-	// fields that its caller cannot access directly. V intentionally permits that
-	// private-mutation API on an immutable binding.
 	method_module := tc.fn_type_modules[info.name] or { '' }
 	if method_module.len > 0 && method_module != tc.cur_module {
-		return false
+		// Match V's private-mutability rule: an immutable binding is accepted across a
+		// module boundary only when the method cannot mutate caller-visible state.
+		mut visiting := map[string]bool{}
+		mut cache := map[string]bool{}
+		decl := tc.visible_mutation_fn_decl(info.name, method_module) or { return true }
+		return tc.visible_mutation_fn_param_has_visible_mutation(decl, 0, mut visiting, mut cache)
 	}
 	return true
 }
@@ -17886,6 +18291,8 @@ fn (tc &TypeChecker) implicit_ref_arg_compatible(expr_id flat.NodeId, actual Typ
 	}
 	actual_depth, actual_base := type_pointer_depth_and_base(actual)
 	expected_depth, expected_base := type_pointer_depth_and_base(expected)
+	// V permits implicit reference arguments to add every missing pointer layer.
+	// Cgen materializes a typed `__ref_arg_N` chain rather than emitting only `&expr`.
 	if expected_depth <= actual_depth {
 		return false
 	}

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -531,6 +531,7 @@ pub mut:
 	expected_expr_id        int  = -1
 	expected_expr_type      Type = Type(void_)
 	cur_fn_ret_type         Type = Type(void_)
+	channel_send_or_expr_id int  = -1
 	smartcasts              map[string]Type
 	ownership               &OwnershipState = unsafe { nil }
 	selfhost                bool
@@ -8666,7 +8667,7 @@ fn (mut tc TypeChecker) check_node(id flat.NodeId) {
 		return
 	}
 	if kind_id == 22 {
-		tc.check_or_expr(node)
+		tc.check_or_expr(id, node)
 		return
 	}
 	if kind_id == 50 {
@@ -8777,6 +8778,13 @@ fn (mut tc TypeChecker) check_node(id flat.NodeId) {
 
 	for i in 0 .. node.children_count {
 		child_id := tc.a.child(&node, i)
+		previous_channel_send_or_expr_id := tc.channel_send_or_expr_id
+		if node.kind == .infix && node.op == .arrow && i == 1 {
+			child := tc.a.node(child_id)
+			if child.kind == .or_expr {
+				tc.channel_send_or_expr_id = int(child_id)
+			}
+		}
 		$if ownership ? {
 			defer_append_rhs := node.kind == .infix && node.op == .left_shift
 				&& node.children_count >= 2 && i == 1
@@ -8785,6 +8793,7 @@ fn (mut tc TypeChecker) check_node(id flat.NodeId) {
 		} $else {
 			tc.check_node(child_id)
 		}
+		tc.channel_send_or_expr_id = previous_channel_send_or_expr_id
 	}
 	if node.kind == .infix {
 		tc.check_infix(id, node)
@@ -9431,11 +9440,6 @@ fn (mut tc TypeChecker) check_infix(id flat.NodeId, node flat.Node) {
 	rhs_type := tc.infix_read_type(rhs_id)
 	lhs_is_string := type_is_string_like(lhs_type)
 	rhs_is_string := type_is_string_like(rhs_type)
-	lhs_is_optional_string := optional_payload_is_string(lhs_type)
-	rhs_is_optional_string := optional_payload_is_string(rhs_type)
-	if (lhs_is_string && rhs_is_optional_string) || (rhs_is_string && lhs_is_optional_string) {
-		return
-	}
 	if lhs_is_string == rhs_is_string {
 		return
 	}
@@ -9680,12 +9684,21 @@ fn (mut tc TypeChecker) check_array_init(node flat.Node) {
 }
 
 // check_or_expr validates check or expr state for types.
-fn (mut tc TypeChecker) check_or_expr(node flat.Node) {
+fn (mut tc TypeChecker) check_or_expr(id flat.NodeId, node flat.Node) {
 	if node.children_count == 0 {
 		return
 	}
 	inner_id := tc.a.child(&node, 0)
 	tc.check_node(inner_id)
+	if node.children_count >= 2 && node.value !in ['!', '?']
+		&& int(id) != tc.channel_send_or_expr_id && !tc.or_expr_source_can_fail(inner_id) {
+		source_type := unalias_type(tc.resolve_type(inner_id))
+		if source_type !is Unknown && tc.should_diagnose(inner_id) {
+			tc.record_error(.assignment_mismatch,
+				'unexpected `or` block, expression of type `${source_type.name()}` is not an Option or a Result',
+				inner_id)
+		}
+	}
 	$if ownership ? {
 		if node.value in ['!', '?'] {
 			tc.ownership_record_propagation_drops()
@@ -9708,6 +9721,51 @@ fn (mut tc TypeChecker) check_or_expr(node flat.Node) {
 		tc.ownership_add_branch_group_base()
 		tc.ownership_end_branch_group()
 	}
+}
+
+fn (tc &TypeChecker) or_expr_source_can_fail(id flat.NodeId) bool {
+	if !tc.valid_node_id(id) {
+		return false
+	}
+	node := tc.a.node(id)
+	if node.kind in [.paren, .expr_stmt] && node.children_count > 0 {
+		return tc.or_expr_source_can_fail(tc.a.child(node, 0))
+	}
+	if node.kind == .or_expr && node.value in ['!', '?'] && node.children_count > 0 {
+		return tc.or_expr_source_can_fail(tc.a.child(node, 0))
+	}
+	if node.kind == .infix && node.children_count >= 2 {
+		return tc.or_expr_source_can_fail(tc.a.child(node, 0))
+			|| tc.or_expr_source_can_fail(tc.a.child(node, 1))
+	}
+	if node.kind == .index && node.children_count > 0 {
+		base_type := unalias_and_unwrap_pointer_type(tc.resolve_type(tc.a.child(node, 0)))
+		return base_type is Map || base_type is Array || base_type is ArrayFixed
+			|| base_type is String
+	}
+	if node.kind == .prefix && node.op == .arrow && node.children_count > 0 {
+		source_type := unalias_and_unwrap_pointer_type(tc.resolve_type(tc.a.child(node, 0)))
+		return source_type is Channel
+	}
+	if node.kind == .prefix && node.op == .amp && node.children_count > 0 {
+		index := tc.a.child_node(node, 0)
+		if index.kind == .index && index.children_count > 0 {
+			base_type := unalias_and_unwrap_pointer_type(tc.resolve_type(tc.a.child(index, 0)))
+			return base_type is Map
+		}
+	}
+	return type_contains_option_or_result(tc.resolve_type(id))
+}
+
+fn type_contains_option_or_result(typ Type) bool {
+	clean := unalias_type(typ)
+	if clean is OptionType || clean is ResultType {
+		return true
+	}
+	if clean is Pointer {
+		return type_contains_option_or_result(clean.base_type)
+	}
+	return false
 }
 
 fn (tc &TypeChecker) sql_aggregate_or_expr_type(node flat.Node) ?Type {

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -1407,7 +1407,7 @@ pub fn (mut tc TypeChecker) collect(a &flat.FlatAst) {
 				for i in 0 .. node.children_count {
 					f := a.child_node(&node, i)
 					if f.kind == .enum_field {
-						fields << f.value
+						fields << escaped_identifier_name(f.value)
 					}
 				}
 				tc.enum_fields[qn] = fields
@@ -1912,7 +1912,7 @@ fn (tc &TypeChecker) c_struct_decl_is_vlib_termios_shim(file string, module_name
 		return false
 	}
 	normalized := file.replace('\\', '/')
-	return normalized.contains('/vlib/term/')
+	return normalized.starts_with('vlib/term/') || normalized.contains('/vlib/term/')
 		|| (normalized.contains('/v3_module_cache_')
 		&& normalized.all_after_last('/').starts_with('termios_') && normalized.ends_with('.vh'))
 }
@@ -2033,7 +2033,12 @@ fn (mut tc TypeChecker) resolve_const_types() {
 		for name, expr_id in tc.const_exprs {
 			tc.cur_module = tc.const_modules[name] or { '' }
 			tc.cur_file = tc.const_files[name] or { '' }
+			// Const dependencies are not guaranteed to be visited in declaration order.
+			// Re-resolve the initializer on every pass so an array DSL call that was
+			// first seen through a still-pending const does not retain `[]unknown`.
+			tc.invalidate_const_initializer_type(expr_id)
 			mut new_type := tc.resolve_type(expr_id)
+			new_type = tc.refine_const_initializer_type(expr_id, new_type)
 			new_type = tc.const_type_from_initializer(name, new_type)
 			if new_type is Unknown {
 				continue
@@ -2050,6 +2055,40 @@ fn (mut tc TypeChecker) resolve_const_types() {
 	}
 	tc.cur_module = saved_module
 	tc.cur_file = saved_file
+}
+
+fn (mut tc TypeChecker) invalidate_const_initializer_type(expr_id flat.NodeId) {
+	idx := int(expr_id)
+	if idx < 0 || idx >= tc.a.nodes.len {
+		return
+	}
+	if idx < tc.expr_type_set.len {
+		tc.expr_type_set[idx] = false
+	}
+	tc.sparse_expr_type_values.delete(idx)
+	node := tc.a.nodes[idx]
+	for i in 0 .. node.children_count {
+		tc.invalidate_const_initializer_type(tc.a.child(&node, i))
+	}
+}
+
+fn (mut tc TypeChecker) refine_const_initializer_type(expr_id flat.NodeId, typ Type) Type {
+	if typ is Array && typ.elem_type is Unknown && int(expr_id) >= 0
+		&& int(expr_id) < tc.a.nodes.len {
+		expr := tc.a.nodes[int(expr_id)]
+		if expr.kind == .call && expr.children_count >= 2 {
+			callee := tc.a.child_node(&expr, 0)
+			if callee.kind == .selector && callee.value == 'map' {
+				elem_type := tc.array_map_return_elem_type(expr)
+				if elem_type !is Unknown && elem_type !is Void {
+					return Type(Array{
+						elem_type: elem_type
+					})
+				}
+			}
+		}
+	}
+	return typ
 }
 
 // const_type_from_initializer converts const type from initializer data for types.
@@ -2473,6 +2512,12 @@ fn (tc &TypeChecker) qualify_resolution_type_text(typ string) string {
 // parse_resolution_type parses type text that can mix declaration-local names with concrete
 // generic arguments from another module.
 pub fn (tc &TypeChecker) parse_resolution_type(typ string) Type {
+	clean := typ.trim_space()
+	if clean.contains('.') {
+		if exact := tc.type_from_known_symbol(clean) {
+			return exact
+		}
+	}
 	qualified := tc.qualify_resolution_type_text(typ)
 	if isnil(tc.resolution_type_views) {
 		mut direct_view := tc.fork_type_parse_view(tc.cur_file, '')
@@ -2593,6 +2638,9 @@ fn (tc &TypeChecker) qualify_type_text_impl(typ string, resolution bool, generic
 			return tc.qualify_type_text_impl(clean[..bracket], resolution, generic_params) + '[' +
 				parts.join(', ') + ']' + clean[bracket_end + 1..]
 		}
+	}
+	if resolution && clean.contains('.') && tc.qualify_candidate_type_exists(clean) {
+		return clean
 	}
 	if !clean.contains('.') {
 		if resolved := tc.resolve_selective_import_type_symbol(clean) {
@@ -3072,7 +3120,7 @@ fn (mut tc TypeChecker) annotate_node(id flat.NodeId) {
 			lhs_count := tc.multi_assign_lhs_count(node)
 			rhs_count := tc.multi_assign_rhs_count(node)
 			if rhs_count == 1 && lhs_count > 1 {
-				tc.annotate_node(tc.a.child(&node, 1))
+				tc.annotate_multi_return_decl_assign(node)
 				return
 			}
 			pair_count := if lhs_count < rhs_count { lhs_count } else { rhs_count }
@@ -3104,14 +3152,68 @@ fn (mut tc TypeChecker) annotate_node(id flat.NodeId) {
 			tc.annotate_for_in(id, node)
 			return
 		}
+		.comptime_for {
+			return
+		}
+		.fn_literal {
+			tc.annotate_fn_literal(node)
+			return
+		}
+		.selector {
+			if node.children_count > 0 {
+				base_id := tc.a.child(&node, 0)
+				base_type := tc.resolve_type(base_id)
+				if type_contains_unknown(base_type)
+					|| ((base_type is OptionType || base_type is ResultType)
+					&& node.value !in ['ok', 'value', 'err'])
+					|| (tc.fn_context.generic_params.len > 0 && (base_type is OptionType
+					|| base_type is ResultType)) {
+					tc.annotate_node(base_id)
+					return
+				}
+			}
+		}
 		.assign, .selector_assign, .index_assign {
+			if node.children_count > 0
+				&& tc.annotation_storage_path_has_unknown(tc.a.child(&node, 0)) {
+				for i in 0 .. node.children_count {
+					tc.annotate_node(tc.a.child(&node, i))
+				}
+				return
+			}
 			tc.annotate_assign_expected_exprs(node)
 		}
 		.struct_init {
 			tc.annotate_struct_init_expected_exprs(node)
 		}
 		.call {
+			if tc.fn_context.generic_params.len > 0 {
+				dsl_name := tc.unresolved_array_dsl_call_name(node)
+				if dsl_name.len > 0 {
+					tc.push_array_dsl_scope(node, dsl_name)
+				}
+				for i in 0 .. node.children_count {
+					tc.annotate_node(tc.a.child(&node, i))
+				}
+				tc.annotate_call_expected_exprs(id, node)
+				if info := tc.resolve_call_info(id, node) {
+					tc.remember_expr_type(id, info.return_type)
+				}
+				if dsl_name.len > 0 {
+					tc.pop_scope()
+				}
+				return
+			}
 			tc.annotate_call_expected_exprs(id, node)
+		}
+		.index {
+			if node.children_count > 0
+				&& type_contains_unknown(tc.resolve_type(tc.a.child(&node, 0))) {
+				for i in 0 .. node.children_count {
+					tc.annotate_node(tc.a.child(&node, i))
+				}
+				return
+			}
 		}
 		else {}
 	}
@@ -3120,6 +3222,67 @@ fn (mut tc TypeChecker) annotate_node(id flat.NodeId) {
 	for i in 0 .. node.children_count {
 		tc.annotate_node(tc.a.child(&node, i))
 	}
+}
+
+fn (mut tc TypeChecker) annotation_storage_path_has_unknown(id flat.NodeId) bool {
+	if !tc.valid_node_id(id) {
+		return false
+	}
+	node := tc.a.node(id)
+	if node.kind !in [.selector, .index] || node.children_count == 0 {
+		return false
+	}
+	base_type := tc.resolve_type(tc.a.child(node, 0))
+	return type_contains_unknown(base_type) || base_type is OptionType || base_type is ResultType
+}
+
+fn (mut tc TypeChecker) annotate_multi_return_decl_assign(node flat.Node) {
+	rhs_id := tc.a.child(&node, 1)
+	tc.annotate_node(rhs_id)
+	lhs_ids := tc.multi_assign_lhs_ids(node)
+	mut item_types := []Type{}
+	rhs := tc.a.node(rhs_id)
+	if rhs.kind == .match_stmt {
+		item_types = tc.match_multi_return_types(rhs_id, lhs_ids.len) or { []Type{} }
+	}
+	if item_types.len == 0 {
+		rhs_type := tc.resolve_type(rhs_id)
+		if multi := tc.multi_return_assignment_type(rhs_id, rhs_type) {
+			item_types = multi.types.clone()
+		}
+	}
+	if item_types.len != lhs_ids.len {
+		return
+	}
+	for i, lhs_id in lhs_ids {
+		lhs := tc.a.node(lhs_id)
+		if lhs.kind != .ident || lhs.value.len == 0 || lhs.value == '_' {
+			continue
+		}
+		tc.cur_scope.insert(lhs.value, item_types[i])
+		tc.remember_expr_type(lhs_id, item_types[i])
+	}
+}
+
+fn (mut tc TypeChecker) annotate_fn_literal(node flat.Node) {
+	saved_fn_context := tc.fn_context
+	tc.fn_context = new_function_check_context()
+	tc.fn_context.node_id = saved_fn_context.node_id
+	tc.fn_context.generic_params = saved_fn_context.generic_params.clone()
+	tc.fn_context.return_type = tc.parse_type(node.typ)
+	tc.push_scope()
+	for i in 0 .. node.children_count {
+		tc.insert_fn_param_binding(tc.a.child_node(&node, i))
+	}
+	for i in 0 .. node.children_count {
+		child_id := tc.a.child(&node, i)
+		child := tc.a.node(child_id)
+		if child.kind !in [.param, .ident] {
+			tc.annotate_node(child_id)
+		}
+	}
+	tc.pop_scope()
+	tc.fn_context = saved_fn_context
 }
 
 fn (mut tc TypeChecker) annotate_expected_expr(id flat.NodeId, expected Type) {
@@ -3269,7 +3432,19 @@ fn (mut tc TypeChecker) annotate_call_expected_exprs(id flat.NodeId, node flat.N
 			continue
 		}
 		expected := tc.call_arg_expected_type(info, param_idx)
+		dsl_name := if is_array_dsl_call_name(info.name) {
+			info.name
+		} else {
+			tc.unresolved_array_dsl_call_name(node)
+		}
+		needs_dsl_scope := tc.call_arg_needs_array_dsl_scope(dsl_name, param_idx)
+		if needs_dsl_scope {
+			tc.push_array_dsl_scope(node, dsl_name)
+		}
 		tc.annotate_expected_expr(arg_id, expected)
+		if needs_dsl_scope {
+			tc.pop_scope()
+		}
 	}
 }
 
@@ -3587,14 +3762,14 @@ fn for_in_ref_binding_type(typ Type, yields_ref bool) Type {
 
 // expr_type returns the resolved type recorded for a node during annotate_types.
 pub fn (tc &TypeChecker) expr_type(id flat.NodeId) ?Type {
+	if t := tc.resolved_call_type(id) {
+		return t
+	}
 	if int(id) >= 0 {
 		node := tc.a.nodes[int(id)]
 		if node.kind == .call && node.typ.len > 0 && node.typ !in ['int', 'array', 'map', 'unknown'] {
 			return tc.parse_type(node.typ)
 		}
-	}
-	if t := tc.resolved_call_type(id) {
-		return t
 	}
 	if t := tc.cached_expr_type(id) {
 		return t
@@ -5860,7 +6035,25 @@ fn (tc &TypeChecker) subtree_contains_break(id flat.NodeId) bool {
 }
 
 fn (tc &TypeChecker) call_never_returns(id flat.NodeId) bool {
-	return tc.resolved_call_never_returns(id)
+	if tc.resolved_call_never_returns(id) {
+		return true
+	}
+	if !tc.valid_node_id(id) {
+		return false
+	}
+	call := tc.a.nodes[int(id)]
+	if call.kind != .call || call.children_count == 0 {
+		return false
+	}
+	callee := tc.a.child_node(&call, 0)
+	if callee.kind == .ident {
+		return callee.value in ['panic', 'exit', '__v_compile_error']
+	}
+	if callee.kind == .selector && callee.children_count > 0 {
+		base := tc.a.child_node(callee, 0)
+		return base.kind == .ident && callee.value == 'exit' && base.value in ['os', 'C']
+	}
+	return false
 }
 
 fn (mut tc TypeChecker) call_never_returns_resolving(id flat.NodeId) bool {
@@ -6735,7 +6928,8 @@ fn (mut tc TypeChecker) check_comptime_members(id flat.NodeId, var_name string, 
 		base_id := tc.a.child(&node, 0)
 		if tc.valid_node_id(base_id) {
 			base := tc.a.nodes[int(base_id)]
-			if base.kind == .ident && base.value == var_name && node.value !in members {
+			if base.kind == .ident && base.value == var_name && node.value != '$'
+				&& node.value !in members {
 				tc.record_error(.unknown_field, 'unknown ${meta_name} member `${node.value}`', id)
 			}
 		}
@@ -6866,11 +7060,49 @@ fn (mut tc TypeChecker) check_comptime_static_body(id flat.NodeId, var_name stri
 			if lhs.kind != .ident || lhs.value.len == 0 || lhs.value == '_' {
 				continue
 			}
-			rhs_typ := tc.resolve_type(tc.a.child(&node, i + 1))
-			typ := if rhs_typ is Void { Type(Unknown{}) } else { rhs_typ }
+			rhs_id := tc.a.child(&node, i + 1)
+			rhs_typ := tc.resolve_type(rhs_id)
+			typ := if rhs_typ is Unknown {
+				tc.comptime_static_reflected_field_expr_type(rhs_id, var_name, field_cases) or {
+					Type(Unknown{})
+				}
+			} else if rhs_typ is Void {
+				Type(Unknown{})
+			} else {
+				rhs_typ
+			}
 			tc.cur_scope.insert(lhs.value, typ)
 		}
 	}
+}
+
+fn (tc &TypeChecker) comptime_static_reflected_field_expr_type(id flat.NodeId, var_name string, field_cases ComptimeStaticFieldCases) ?Type {
+	if !tc.valid_node_id(id) || !field_cases.known || field_cases.cases.len == 0 {
+		return none
+	}
+	node := tc.a.nodes[int(id)]
+	if node.kind == .paren && node.children_count > 0 {
+		return tc.comptime_static_reflected_field_expr_type(tc.a.child(&node, 0), var_name,
+			field_cases)
+	}
+	if node.kind == .call && node.children_count == 1 {
+		callee := tc.a.child_node(&node, 0)
+		if callee.kind == .selector && callee.value == 'clone' && callee.children_count > 0 {
+			return tc.comptime_static_reflected_field_expr_type(tc.a.child(callee, 0), var_name,
+				field_cases)
+		}
+	}
+	if node.kind != .selector || node.value != '$' || node.children_count < 2
+		|| !tc.comptime_subtree_references_var(tc.a.child(&node, 1), var_name) {
+		return none
+	}
+	first := field_cases.cases[0].typ
+	for field in field_cases.cases[1..] {
+		if field.typ != first {
+			return none
+		}
+	}
+	return tc.parse_type(first)
 }
 
 fn (mut tc TypeChecker) check_comptime_static_deferred_metadata_if(node flat.Node, var_name string, loop_kind string, field_cases ComptimeStaticFieldCases, value_cases ComptimeStaticValueCases) {
@@ -7054,33 +7286,37 @@ fn (mut tc TypeChecker) check_comptime_static_metadata_if(node flat.Node, var_na
 		}
 		return
 	}
-	mut check_then := false
-	mut check_else := false
+	mut then_cases := []ComptimeStaticFieldCase{}
+	mut else_cases := []ComptimeStaticFieldCase{}
 	for f in field_cases.cases {
 		cond := tc.comptime_static_subst_field_cond(node.value, var_name, f)
 		if comptime_text_references_var(cond, var_name) {
-			check_then = true
-			check_else = true
+			then_cases << f
+			else_cases << f
 			continue
 		}
 		taken := tc.comptime_static_eval_field_cond(cond) or {
-			check_then = true
-			check_else = true
+			then_cases << f
+			else_cases << f
 			continue
 		}
 		if taken {
-			check_then = true
+			then_cases << f
 		} else {
-			check_else = true
+			else_cases << f
 		}
 	}
-	if check_then && node.children_count > 0 {
-		tc.check_comptime_static_body(tc.a.child(&node, 0), var_name, loop_kind, field_cases,
-			value_cases)
+	if then_cases.len > 0 && node.children_count > 0 {
+		tc.check_comptime_static_body(tc.a.child(&node, 0), var_name, loop_kind, ComptimeStaticFieldCases{
+			known: true
+			cases: then_cases
+		}, value_cases)
 	}
-	if check_else && node.children_count > 1 {
-		tc.check_comptime_static_body(tc.a.child(&node, 1), var_name, loop_kind, field_cases,
-			value_cases)
+	if else_cases.len > 0 && node.children_count > 1 {
+		tc.check_comptime_static_body(tc.a.child(&node, 1), var_name, loop_kind, ComptimeStaticFieldCases{
+			known: true
+			cases: else_cases
+		}, value_cases)
 	}
 }
 
@@ -7228,6 +7464,9 @@ fn (mut tc TypeChecker) check_comptime_static_call_metadata_arg_types(id flat.No
 			}
 			if !info.name.starts_with('C.') && fn_param_is_voidptr_type(expected)
 				&& tc.expr_can_take_address(arg_id) {
+				continue
+			}
+			if fn_param_is_voidptr_type(expected) && info.name.ends_with('Channel.push') {
 				continue
 			}
 			tc.type_mismatch(.call_arg_mismatch, 'cannot use `${actual.name()}` as argument ${
@@ -9192,6 +9431,11 @@ fn (mut tc TypeChecker) check_infix(id flat.NodeId, node flat.Node) {
 	rhs_type := tc.infix_read_type(rhs_id)
 	lhs_is_string := type_is_string_like(lhs_type)
 	rhs_is_string := type_is_string_like(rhs_type)
+	lhs_is_optional_string := optional_payload_is_string(lhs_type)
+	rhs_is_optional_string := optional_payload_is_string(rhs_type)
+	if (lhs_is_string && rhs_is_optional_string) || (rhs_is_string && lhs_is_optional_string) {
+		return
+	}
 	if lhs_is_string == rhs_is_string {
 		return
 	}
@@ -9200,6 +9444,16 @@ fn (mut tc TypeChecker) check_infix(id flat.NodeId, node flat.Node) {
 	}
 	tc.record_error(.assignment_mismatch,
 		'operator `+` cannot concatenate `${lhs_type.name()}` and `${rhs_type.name()}`', id)
+}
+
+fn optional_payload_is_string(typ Type) bool {
+	if typ is OptionType {
+		return type_is_string_like(typ.base_type)
+	}
+	if typ is ResultType {
+		return type_is_string_like(typ.base_type)
+	}
+	return false
 }
 
 fn (tc &TypeChecker) infix_read_type(id flat.NodeId) Type {
@@ -9635,7 +9889,11 @@ fn (mut tc TypeChecker) check_lambda_expr(id flat.NodeId, node flat.Node) {
 			} else {
 				unknown_type('lambda parameter `${child.value}`')
 			}
-			tc.cur_scope.insert(child.value, param_type)
+			owner := tc.cur_scope.insert_with_owner(child.value, param_type)
+			if child.is_mut {
+				tc.fn_context.mut_param_base_types[child.value] = mut_param_base_type(param_type)
+				tc.fn_context.mut_param_owners[child.value] = owner
+			}
 		}
 	}
 	body_id := tc.a.child(&node, node.children_count - 1)
@@ -10086,6 +10344,7 @@ fn (mut tc TypeChecker) check_decl_assign(id flat.NodeId, node flat.Node) {
 			tc.ownership_after_decl_assign(lhs_id, rhs_id, expected, id)
 		}
 		tc.track_method_value_local(lhs_id, rhs_id)
+		tc.track_variadic_fn_value_local(lhs_id, rhs_id)
 		tc.track_capturing_fn_literal_local(lhs_id, rhs_id, owner)
 		i += 2
 	}
@@ -10458,6 +10717,16 @@ fn (mut tc TypeChecker) decl_assign_inferred_type(rhs_id flat.NodeId) Type {
 			return typ
 		}
 	}
+	if smartcast := tc.smartcast_type(rhs_id) {
+		return smartcast
+	}
+	if rhs.kind == .selector {
+		if declared := tc.selector_declared_value_type(rhs) {
+			if declared is OptionType || declared is ResultType {
+				return declared
+			}
+		}
+	}
 	if typ := tc.infer_fn_value_decl_type(rhs_id) {
 		return typ
 	}
@@ -10732,18 +11001,12 @@ fn (mut tc TypeChecker) check_multi_return_decl_assign(id flat.NodeId, node flat
 }
 
 fn (tc &TypeChecker) multi_expr_tail_types(expr_id flat.NodeId, count int) ?[]Type {
-	groups := tc.multi_expr_tail_value_groups(expr_id, count, false) or {
-		return tc.mixed_multi_expr_tail_types(expr_id, count)
-	}
+	groups := tc.multi_expr_tail_type_groups(expr_id, count) or { return none }
 	if groups.len == 0 {
 		return none
 	}
 	mut tail_types := []Type{cap: count}
-	for value_id in groups[0] {
-		typ := tc.expr_type(value_id) or { tc.resolve_type(value_id) }
-		if !type_has_runtime_value(typ) {
-			return none
-		}
+	for typ in groups[0] {
 		tail_types << typ
 	}
 	for i in 1 .. groups.len {
@@ -10751,11 +11014,7 @@ fn (tc &TypeChecker) multi_expr_tail_types(expr_id flat.NodeId, count int) ?[]Ty
 		if group.len != tail_types.len {
 			return none
 		}
-		for j, value_id in group {
-			actual := tc.expr_type(value_id) or { tc.resolve_type(value_id) }
-			if !type_has_runtime_value(actual) {
-				return none
-			}
+		for j, actual in group {
 			promoted := tc.promoted_multi_tail_type(tail_types[j], actual) or { return none }
 			tail_types[j] = promoted
 		}
@@ -10763,68 +11022,95 @@ fn (tc &TypeChecker) multi_expr_tail_types(expr_id flat.NodeId, count int) ?[]Ty
 	return tail_types
 }
 
-fn (tc &TypeChecker) mixed_multi_expr_tail_types(expr_id flat.NodeId, count int) ?[]Type {
+fn (tc &TypeChecker) multi_expr_tail_type_groups(expr_id flat.NodeId, count int) ?[][]Type {
 	if count <= 0 || !tc.valid_node_id(expr_id) {
 		return none
 	}
 	node := tc.a.nodes[int(expr_id)]
-	if node.kind != .if_expr || node.children_count < 3 {
-		return tc.multi_expr_branch_types(expr_id, count)
-	}
-	then_types := tc.multi_expr_branch_types(tc.a.child(&node, 1), count) or { return none }
-	else_types := tc.mixed_multi_expr_tail_types(tc.a.child(&node, 2), count) or { return none }
-	if then_types.len != count || else_types.len != count {
-		return none
-	}
-	mut result := then_types.clone()
-	for i, actual in else_types {
-		result[i] = tc.promoted_multi_tail_type(result[i], actual) or { return none }
-	}
-	return result
-}
-
-fn (tc &TypeChecker) multi_expr_branch_types(id flat.NodeId, count int) ?[]Type {
-	if groups := tc.tuple_tail_value_groups(id, count, false) {
-		if groups.len == 0 || groups[0].len != count {
-			return none
-		}
-		mut result := []Type{cap: count}
-		for value_id in groups[0] {
-			typ := tc.expr_type(value_id) or { tc.resolve_type(value_id) }
-			if !type_has_runtime_value(typ) {
+	match node.kind {
+		.if_expr {
+			if node.children_count < 3 {
 				return none
 			}
-			result << typ
-		}
-		for i in 1 .. groups.len {
-			group := groups[i]
-			if group.len != result.len {
+			mut groups := tc.multi_expr_branch_tail_type_groups(tc.a.child(&node, 1), count) or {
 				return none
 			}
-			for j, value_id in group {
-				actual := tc.expr_type(value_id) or { tc.resolve_type(value_id) }
-				if !type_has_runtime_value(actual) {
+			else_groups := tc.multi_expr_tail_type_groups(tc.a.child(&node, 2), count) or {
+				return none
+			}
+			groups << else_groups
+			return groups
+		}
+		.match_stmt {
+			if node.children_count < 2 || !tc.match_has_else_or_exhaustive_coverage(node) {
+				return none
+			}
+			mut groups := [][]Type{}
+			for i in 1 .. node.children_count {
+				branch_groups := tc.multi_expr_branch_tail_type_groups(tc.a.child(&node, i), count) or {
 					return none
 				}
-				promoted := tc.promoted_multi_tail_type(result[j], actual) or { return none }
-				result[j] = promoted
+				groups << branch_groups
 			}
+			return groups
+		}
+		.block, .match_branch {
+			return tc.multi_expr_branch_tail_type_groups(expr_id, count)
+		}
+		.lock_expr {
+			if node.children_count > 0 {
+				return tc.multi_expr_tail_type_groups(tc.a.child(&node, node.children_count - 1),
+					count)
+			}
+		}
+		.expr_stmt {
+			if node.children_count > 0 {
+				return tc.multi_expr_tail_type_groups(tc.a.child(&node, 0), count)
+			}
+		}
+		else {}
+	}
+	return none
+}
+
+fn (tc &TypeChecker) multi_expr_branch_tail_type_groups(branch_id flat.NodeId, count int) ?[][]Type {
+	if groups := tc.tuple_tail_value_groups(branch_id, count, false) {
+		mut result := [][]Type{cap: groups.len}
+		for group in groups {
+			mut types := []Type{cap: group.len}
+			for value_id in group {
+				typ := tc.expr_type(value_id) or { tc.resolve_type(value_id) }
+				if !type_has_runtime_value(typ) {
+					return none
+				}
+				types << typ
+			}
+			result << types
 		}
 		return result
 	}
-	tail_id := tc.branch_tail_expr_id(id)
+	tail_id := tc.branch_tail_expr_id(branch_id)
 	if !tc.valid_node_id(tail_id) {
 		return none
 	}
-	tail := tc.a.nodes[int(tail_id)]
-	if tail.kind == .if_expr {
-		return tc.mixed_multi_expr_tail_types(tail_id, count)
+	if tc.expr_never_returns(tail_id) {
+		return [][]Type{}
 	}
-	multi := multi_return_payload_type(tc.resolve_type(tail_id)) or { return none }
+	tail := tc.a.nodes[int(tail_id)]
+	if tail.kind in [.if_expr, .match_stmt] {
+		return tc.multi_expr_tail_type_groups(tail_id, count)
+	}
+	tail_type := tc.expr_type(tail_id) or { tc.resolve_type(tail_id) }
+	multi := tc.multi_return_assignment_type(tail_id, tail_type) or { return none }
 	if multi.types.len != count {
 		return none
 	}
-	return multi.types.clone()
+	for typ in multi.types {
+		if !type_has_runtime_value(typ) {
+			return none
+		}
+	}
+	return [multi.types.clone()]
 }
 
 fn (mut tc TypeChecker) multi_expr_tail_assign_types(id flat.NodeId, expr_id flat.NodeId, lhs_ids []flat.NodeId) ?[]Type {
@@ -11357,10 +11643,12 @@ fn (mut tc TypeChecker) check_assign(id flat.NodeId, node flat.Node) {
 			} else {
 				tc.track_capturing_fn_literal_local(lhs_id, rhs_id, ScopeBindingOwner{})
 			}
+			tc.track_variadic_fn_value_local(lhs_id, rhs_id)
 		}
 		lhs_key := tc.expr_key(lhs_id)
 		if lhs_key.len > 0 {
-			if expected_type is OptionType && rhs_type !is OptionType
+			lhs := tc.a.node(lhs_id)
+			if lhs.kind == .ident && expected_type is OptionType && rhs_type !is OptionType
 				&& tc.expr_compatible(rhs_id, rhs_type, expected_type.base_type) {
 				tc.smartcasts[lhs_key] = expected_type.base_type
 			} else if !tc.assignment_preserves_smartcast(lhs_id, rhs_id, rhs_type) {
@@ -11453,8 +11741,17 @@ fn assignment_op_reads_lhs(op flat.Op) bool {
 }
 
 fn (tc &TypeChecker) assignment_types_compatible(rhs_id flat.NodeId, rhs_type Type, expected_type Type, op flat.Op) bool {
+	if fn_param_unalias_type(expected_type).is_integer() && tc.c_scalar_byte_literal_arg(rhs_id) {
+		return true
+	}
 	if tc.expr_tail_is_nil(rhs_id) {
 		if _ := fn_type_from_type(expected_type) {
+			return true
+		}
+	}
+	if base := tc.mut_param_expr_base(rhs_id, rhs_type) {
+		if tc.type_compatible(base, expected_type)
+			|| tc.pointer_value_compatible(base, expected_type) {
 			return true
 		}
 	}
@@ -11881,14 +12178,14 @@ fn (mut tc TypeChecker) resolve_index_lvalue_type(lhs_id flat.NodeId, op flat.Op
 			tc.register_synth_type(lhs_id, unknown_type('invalid overloaded index setter'))
 			return unknown_type('invalid overloaded index setter')
 		}
-		if !tc.check_index_overload_arg(lhs_id, lhs, setter, '[]=') {
+		if !tc.check_index_overload_args_ok(lhs_id, lhs, setter) {
 			invalid_type := unknown_type('invalid overloaded index setter')
 			tc.register_synth_type(lhs_id, invalid_type)
 			return invalid_type
 		}
 		if op != .assign {
 			if getter := tc.index_operator_call_info(base_type, '[]') {
-				if !tc.check_index_overload_arg(lhs_id, lhs, getter, '[]') {
+				if !tc.check_index_overload_args_ok(lhs_id, lhs, getter) {
 					invalid_type := unknown_type('invalid overloaded index getter')
 					tc.register_synth_type(lhs_id, invalid_type)
 					return invalid_type
@@ -12046,12 +12343,6 @@ fn (mut tc TypeChecker) check_return(id flat.NodeId, node flat.Node) {
 				tc.ownership_check_node_with_deferred_aggregate_consumption(child_id)
 			} $else {
 				tc.check_node(child_id)
-			}
-			if msg := tc.tuple_tail_return_error(child_id, multi.types) {
-				if tc.should_diagnose(id) {
-					tc.record_error(.return_mismatch, msg, id)
-				}
-				return
 			}
 			actual := tc.resolve_expr(child_id, expected)
 			if tc.return_type_compatible(child_id, actual, expected) {
@@ -12222,56 +12513,6 @@ fn (tc &TypeChecker) result_return_uses_multi_tail(expr_id flat.NodeId, expected
 	return tc.expr_has_tuple_tail_values(expr_id, multi.types.len)
 }
 
-fn tuple_tail_return_lowering_allowed(expected []Type) bool {
-	for typ in expected {
-		if tuple_tail_return_type_allows_lowering(typ) {
-			return true
-		}
-	}
-	return false
-}
-
-fn tuple_tail_return_type_allows_lowering(typ Type) bool {
-	if typ is ArrayFixed || typ is Struct {
-		return true
-	}
-	if typ is Alias {
-		return tuple_tail_return_type_allows_lowering(typ.base_type)
-	}
-	return false
-}
-
-fn (tc &TypeChecker) tuple_tail_return_error(expr_id flat.NodeId, expected []Type) ?string {
-	if tuple_tail_return_lowering_allowed(expected) {
-		return none
-	}
-	if !tc.valid_node_id(expr_id) {
-		return none
-	}
-	count := expected.len
-	node := tc.a.nodes[int(expr_id)]
-	match node.kind {
-		.expr_stmt, .paren {
-			if node.children_count > 0 {
-				return tc.tuple_tail_return_error(tc.a.child(&node, 0), expected)
-			}
-		}
-		.if_expr {
-			if tc.expr_has_tuple_tail_values(expr_id, count) {
-				return 'if expression branches cannot produce multiple return values'
-			}
-		}
-		.match_stmt {
-			if tc.expr_has_tuple_tail_values(expr_id, count) {
-				return 'match expression branches cannot produce multiple return values'
-			}
-		}
-		else {}
-	}
-
-	return none
-}
-
 fn (mut tc TypeChecker) return_type_compatible(expr_id flat.NodeId, actual Type, expected Type) bool {
 	if tc.expr_compatible(expr_id, actual, expected) {
 		return true
@@ -12288,6 +12529,16 @@ fn (mut tc TypeChecker) return_type_compatible(expr_id flat.NodeId, actual Type,
 	}
 	if expected is OptionType {
 		if tc.type_compatible(actual, expected.base_type) {
+			return true
+		}
+		if expected.base_type is Pointer {
+			if smart_type := tc.smartcast_type(expr_id) {
+				if tc.type_compatible(smart_type, expected.base_type.base_type) {
+					return true
+				}
+			}
+		}
+		if actual is ResultType && tc.type_compatible(actual.base_type, expected.base_type) {
 			return true
 		}
 		if tc.pointer_value_compatible(actual, expected.base_type) {
@@ -13080,6 +13331,14 @@ fn (tc &TypeChecker) explicit_generic_call_target_is_known(node flat.Node) bool 
 	if base.kind != .selector || base.value.len == 0 {
 		return false
 	}
+	if base.children_count > 0 {
+		receiver_type := unalias_and_unwrap_pointer_type(tc.resolve_type(tc.a.child(base, 0)))
+		if receiver_type is Struct {
+			if _ := tc.resolve_generic_struct_method(receiver_type.name, base.value) {
+				return true
+			}
+		}
+	}
 	// A method on an unresolved generic receiver cannot be tied to a concrete
 	// receiver yet, but it still has to name a real method declaration. The
 	// concrete specialization is validated after monomorphization.
@@ -13297,6 +13556,26 @@ fn (tc &TypeChecker) ident_resolves_to_value(name string) bool {
 	return false
 }
 
+fn (tc &TypeChecker) sum_fn_variant_for_arg_count(typ Type, arg_count int) ?FnType {
+	clean := unalias_and_unwrap_pointer_type(typ)
+	if clean !is SumType {
+		return none
+	}
+	clean_name := Type(clean).name()
+	base := tc.sum_base_name(clean_name)
+	variants := tc.sum_types[base] or { return none }
+	for variant in variants {
+		concrete := tc.concrete_sum_variant_name(clean_name, variant)
+		variant_type := tc.parse_type(concrete)
+		if fn_type := fn_type_from_type(variant_type) {
+			if fn_type.params.len == arg_count {
+				return fn_type
+			}
+		}
+	}
+	return none
+}
+
 // resolve_call_info resolves resolve call info information for types.
 fn (mut tc TypeChecker) resolve_call_info(id flat.NodeId, node flat.Node) ?CallInfo {
 	if node.children_count == 0 {
@@ -13331,21 +13610,31 @@ fn (mut tc TypeChecker) resolve_call_info(id flat.NodeId, node flat.Node) ?CallI
 	}
 	if fn_node.kind == .ident {
 		fn_id := tc.a.child(&node, 0)
+		mut binding_type := Type(void_)
+		if typ := tc.cur_scope.lookup(fn_node.value) {
+			binding_type = typ
+		} else if typ := tc.file_scope.lookup(fn_node.value) {
+			binding_type = typ
+		} else if typ := tc.const_type_for_name(fn_node.value) {
+			binding_type = typ
+		}
 		mut fn_type := Type(void_)
 		if smart_type := tc.smartcast_type(fn_id) {
 			fn_type = smart_type
-		} else if typ := tc.cur_scope.lookup(fn_node.value) {
-			fn_type = typ
-		} else if typ := tc.file_scope.lookup(fn_node.value) {
-			fn_type = typ
-		} else if typ := tc.const_type_for_name(fn_node.value) {
-			fn_type = typ
+		} else {
+			fn_type = binding_type
 		}
 		if fn_typ := fn_type_from_type(fn_type) {
+			actual_count := node.children_count - 1
+			selected := if fn_typ.params.len != actual_count {
+				tc.sum_fn_variant_for_arg_count(binding_type, actual_count) or { fn_typ }
+			} else {
+				fn_typ
+			}
 			return CallInfo{
 				name:         ''
-				params:       fn_typ.params.clone()
-				return_type:  fn_typ.return_type
+				params:       selected.params.clone()
+				return_type:  selected.return_type
 				is_variadic:  tc.expr_is_variadic_fn_value(fn_id)
 				params_known: true
 			}
@@ -13378,6 +13667,21 @@ fn (mut tc TypeChecker) resolve_call_info(id flat.NodeId, node flat.Node) ?CallI
 		base_is_imported_module := base_node.kind == .ident
 			&& !tc.ident_resolves_to_value(base_node.value)
 			&& tc.resolve_import_alias(base_node.value) != none
+		// A selector on an imported module is a direct module function before it is
+		// considered as a function-valued field/constant. Keeping the qualified
+		// CallInfo is also required by compiler-magic calls such as json.decode,
+		// whose result type is inferred from the leading type argument.
+		if base_is_imported_module {
+			if resolved_mod := tc.resolve_import_alias(base_node.value) {
+				mod_name := '${resolved_mod}.${fn_node.value}'
+				if mod_name in tc.fn_ret_types {
+					if info := tc.decode_call_info_from_type_arg(node, mod_name, false) {
+						return info
+					}
+					return tc.call_info(mod_name, false)
+				}
+			}
+		}
 		if base_node.kind == .call {
 			tc.check_node(base_id)
 		}
@@ -13478,6 +13782,9 @@ fn (mut tc TypeChecker) resolve_call_info(id flat.NodeId, node flat.Node) ?CallI
 						params_known: true
 					}
 				}
+				if fn_node.value == 'from' && qbase in tc.enum_names {
+					return tc.enum_from_call_info(qbase)
+				}
 				if fn_node.value == 'from' {
 					enum_name := tc.resolve_enum_name(base_node.value) or { '' }
 					if enum_name.len > 0 {
@@ -13523,7 +13830,7 @@ fn (mut tc TypeChecker) resolve_call_info(id flat.NodeId, node flat.Node) ?CallI
 				}
 			}
 		}
-		if fn_typ := tc.selector_fn_type(fn_node) {
+		if fn_typ := tc.selector_const_fn_type(fn_node) {
 			return CallInfo{
 				name:         ''
 				params:       fn_typ.params.clone()
@@ -13531,8 +13838,16 @@ fn (mut tc TypeChecker) resolve_call_info(id flat.NodeId, node flat.Node) ?CallI
 				params_known: true
 			}
 		}
-		base_type := tc.resolve_type(base_id)
-		clean := unwrap_pointer(base_type)
+		base_type := tc.selector_fn_base_type(base_id) or { tc.resolve_type(base_id) }
+		if fn_typ := tc.selector_field_fn_type(fn_node, base_type) {
+			return CallInfo{
+				name:         ''
+				params:       fn_typ.params.clone()
+				return_type:  fn_typ.return_type
+				params_known: true
+			}
+		}
+		clean := unwrap_all_pointers(base_type)
 		if fn_node.value == 'type_name' && tc.receiver_is_sum_type(clean) {
 			return CallInfo{
 				name:         ''
@@ -13672,6 +13987,28 @@ fn (mut tc TypeChecker) resolve_call_info(id flat.NodeId, node flat.Node) ?CallI
 			}
 		}
 		if clean_array := array_type_from_receiver(clean) {
+			if fn_node.value == 'bytestr' && is_byte_type(clean_array.elem_type) {
+				return CallInfo{
+					name:         'array.bytestr'
+					params:       tarr1(base_type)
+					return_type:  Type(string_)
+					has_receiver: true
+					params_known: true
+				}
+			}
+			if fn_node.value == 'to_fixed_size' && base_node.kind == .array_literal {
+				return CallInfo{
+					name:         'array.to_fixed_size'
+					params:       tarr1(base_type)
+					return_type:  Type(ArrayFixed{
+						elem_type: clean_array.elem_type
+						len:       int(base_node.children_count)
+						len_expr:  '${base_node.children_count}'
+					})
+					has_receiver: true
+					params_known: true
+				}
+			}
 			array_candidates := exact_array_receiver_method_candidates(clean_array, fn_node.value,
 				tc.cur_module)
 			for mname in array_candidates {
@@ -13962,9 +14299,7 @@ fn (mut tc TypeChecker) resolve_call_info(id flat.NodeId, node flat.Node) ?CallI
 					return CallInfo{
 						name:         'array.sort_with_compare'
 						params:       [
-							Type(Pointer{
-								base_type: base_type
-							}),
+							mutating_receiver_param_type(base_type),
 							Type(FnType{
 								params:      [
 									Type(Pointer{
@@ -14003,9 +14338,7 @@ fn (mut tc TypeChecker) resolve_call_info(id flat.NodeId, node flat.Node) ?CallI
 					}
 				}
 				'sort' {
-					mut params := tarr1(Type(Pointer{
-						base_type: base_type
-					}))
+					mut params := tarr1(mutating_receiver_param_type(base_type))
 					if call_explicit_arg_count(node) > 0 {
 						params << Type(bool_)
 					}
@@ -14721,6 +15054,9 @@ fn (tc &TypeChecker) generic_call_base_type_name(base_node flat.Node) ?string {
 	if base_node.kind == .selector && base_node.children_count > 0 {
 		inner := tc.a.child_node(&base_node, 0)
 		if inner.kind == .ident {
+			if static_name := tc.static_assoc_fn_key_for_base(inner.value, base_node.value) {
+				return static_name
+			}
 			mod_name := tc.resolve_import_alias(inner.value) or { inner.value }
 			full_name := '${mod_name}.${base_node.value}'
 			if tc.type_symbol_known(full_name) {
@@ -14781,6 +15117,9 @@ fn (tc &TypeChecker) generic_call_base_name(base_node flat.Node) ?string {
 	if base_node.kind == .selector && base_node.children_count > 0 {
 		inner := tc.a.child_node(&base_node, 0)
 		if inner.kind == .ident {
+			if static_name := tc.static_assoc_fn_key_for_base(inner.value, base_node.value) {
+				return static_name
+			}
 			mod_name := tc.resolve_import_alias(inner.value) or { inner.value }
 			full_name := '${mod_name}.${base_node.value}'
 			if is_veb_run_at_call_name(full_name) {
@@ -14848,6 +15187,9 @@ fn (tc &TypeChecker) generic_call_type_arg_name(id flat.NodeId) string {
 		}
 		.array_init {
 			if node.value.len > 0 {
+				if node.value.starts_with('[') {
+					return node.value
+				}
 				return '[]${node.value}'
 			}
 			return ''
@@ -15264,7 +15606,7 @@ fn (tc &TypeChecker) mut_receiver_expr_is_mutable_lvalue(id flat.NodeId) bool {
 		.ident {
 			return tc.ident_is_mutable_lvalue(node.value)
 		}
-		.index, .selector, .paren {
+		.index, .selector, .paren, .or_expr {
 			return node.children_count > 0
 				&& tc.mut_receiver_expr_is_mutable_lvalue(tc.a.child(&node, 0))
 		}
@@ -15314,6 +15656,70 @@ fn (tc &TypeChecker) ident_is_mutable_lvalue(name string) bool {
 		return false
 	}
 	return tc.cur_scope.nearest_binding_owned_by(name, owner)
+}
+
+fn (tc &TypeChecker) ident_is_global_binding(name string) bool {
+	if name.len == 0 || tc.cur_scope == unsafe { nil } || tc.file_scope == unsafe { nil } {
+		return false
+	}
+	if owner := tc.cur_scope.lookup_owner(name) {
+		return tc.binding_owner_is_file_scope(owner)
+	}
+	qname := tc.qualify_name(name)
+	if qname != name {
+		if owner := tc.cur_scope.lookup_owner(qname) {
+			return tc.binding_owner_is_file_scope(owner)
+		}
+	}
+	return false
+}
+
+fn (tc &TypeChecker) expr_root_is_global_binding(id flat.NodeId) bool {
+	if int(id) < 0 || int(id) >= tc.a.nodes.len {
+		return false
+	}
+	node := tc.a.nodes[int(id)]
+	match node.kind {
+		.ident {
+			return tc.ident_is_global_binding(node.value)
+		}
+		.index, .selector, .paren {
+			return node.children_count > 0 && tc.expr_root_is_global_binding(tc.a.child(&node, 0))
+		}
+		else {
+			return false
+		}
+	}
+}
+
+fn (tc &TypeChecker) binding_owner_is_file_scope(owner ScopeBindingOwner) bool {
+	// Parallel checker views put a private file scope in front of the collected
+	// program scope, so globals can belong to either that scope or an ancestor.
+	mut scope := unsafe { &Scope(tc.file_scope) }
+	for scope != unsafe { nil } {
+		if owner.belongs_to_scope(scope) {
+			return true
+		}
+		scope = scope.parent
+	}
+	return false
+}
+
+fn (tc &TypeChecker) mut_receiver_call_requires_mutable_lvalue(info CallInfo, recv_id flat.NodeId) bool {
+	if tc.expr_is_shared_arg(recv_id) {
+		return false
+	}
+	if tc.expr_root_is_global_binding(recv_id) {
+		return false
+	}
+	// Outside the declaring module, a public mut-receiver method may only mutate
+	// fields that its caller cannot access directly. V intentionally permits that
+	// private-mutation API on an immutable binding.
+	method_module := tc.fn_type_modules[info.name] or { '' }
+	if method_module.len > 0 && method_module != tc.cur_module {
+		return false
+	}
+	return true
 }
 
 fn (tc &TypeChecker) map_builtin_call_info(base_type Type, m Map, method string, mname string) ?CallInfo {
@@ -15673,6 +16079,7 @@ fn (mut tc TypeChecker) check_call_arg_types(id flat.NodeId, node flat.Node, inf
 			}
 		}
 		if tc.unsafe_depth == 0 && tc.mut_receiver_methods[info.name]
+			&& tc.mut_receiver_call_requires_mutable_lvalue(info, recv_id)
 			&& !tc.mut_receiver_expr_is_mutable_lvalue(recv_id) && tc.should_diagnose(id) {
 			tc.record_error(.call_arg_mismatch,
 				'method `${fn_node.value}` requires a mutable receiver', id)
@@ -15858,6 +16265,16 @@ fn (mut tc TypeChecker) check_call_arg_types(id flat.NodeId, node flat.Node, inf
 			}
 			expected = elem_type
 		}
+		// Integer arguments are implicitly converted at a concrete call boundary.
+		// Resolve this before applying the expected type, since contextual resolution
+		// would otherwise diagnose the conversion while resolving the argument itself.
+		if !call_param_is_shared(info, param_idx) && !tc.expr_is_explicit_shared_arg(arg_id)
+			&& call_arg_integer_type(expected) && call_arg_integer_type(tc.resolve_type(arg_id)) {
+			if has_dsl_scope {
+				tc.pop_scope()
+			}
+			continue
+		}
 		mut actual := Type(void_)
 		if has_dsl_scope {
 			actual = tc.resolve_expr(arg_id, expected)
@@ -15879,7 +16296,9 @@ fn (mut tc TypeChecker) check_call_arg_types(id flat.NodeId, node flat.Node, inf
 			}
 			continue
 		}
-		if !param_is_shared && tc.expr_is_explicit_shared_arg(arg_id) {
+		callee_is_fn_literal := node.children_count > 0
+			&& tc.a.child_node(&node, 0).kind in [.fn_literal, .lambda_expr]
+		if !param_is_shared && tc.expr_is_explicit_shared_arg(arg_id) && !callee_is_fn_literal {
 			if tc.should_diagnose(id) {
 				tc.record_error(.call_arg_mismatch, 'cannot use explicit shared argument `${actual.name()}` as argument ${
 					param_idx + 1} to `${tc.call_display_name(node)}`; expected `${expected.name()}`',
@@ -15904,6 +16323,10 @@ fn (mut tc TypeChecker) check_call_arg_types(id flat.NodeId, node flat.Node, inf
 		}
 		if !tc.expr_receiver_compatible(arg_id, actual, expected)
 			&& !tc.expr_compatible(arg_id, actual, expected) {
+			if tc.a.nodes[int(arg_id)].is_mut && expected is Pointer
+				&& tc.type_compatible(actual, expected.base_type) {
+				continue
+			}
 			if base := tc.mut_param_expr_base(arg_id, actual) {
 				if tc.type_compatible(base, expected)
 					|| tc.pointer_value_compatible(actual, expected) {
@@ -15929,7 +16352,7 @@ fn (mut tc TypeChecker) check_call_arg_types(id flat.NodeId, node flat.Node, inf
 			if param_is_shared && tc.shared_arg_pointer_compatible(actual, expected) {
 				continue
 			}
-			if json_encode_accepts_arg(info.name, param_idx, expected, actual) {
+			if json_runtime_voidptr_accepts_arg(call_name, param_idx, expected, actual) {
 				continue
 			}
 			if free_array_arg_compatible(info.name, param_idx, expected, actual) {
@@ -15940,6 +16363,9 @@ fn (mut tc TypeChecker) check_call_arg_types(id flat.NodeId, node flat.Node, inf
 			}
 			if !info.name.starts_with('C.') && fn_param_is_voidptr_type(expected)
 				&& tc.expr_can_take_address(arg_id) {
+				continue
+			}
+			if fn_param_is_voidptr_type(expected) && info.name.ends_with('Channel.push') {
 				continue
 			}
 			if tc.array_insert_prepend_many_arg_compatible(node, info, param_idx, actual) {
@@ -16020,8 +16446,8 @@ fn (tc &TypeChecker) chan_try_pop_destination_is_valid(arg_id flat.NodeId, actua
 	return tc.expr_can_take_address(arg_id) && tc.expr_root_is_mutable_lvalue(arg_id)
 }
 
-fn json_encode_accepts_arg(name string, param_idx int, expected Type, actual Type) bool {
-	if param_idx != 0 || name !in ['json.encode', 'json.encode_pretty'] {
+fn json_runtime_voidptr_accepts_arg(name string, param_idx int, expected Type, actual Type) bool {
+	if param_idx != 0 || name !in ['json.decode', 'json.encode', 'json.encode_pretty'] {
 		return false
 	}
 	if expected is Pointer {
@@ -17263,6 +17689,13 @@ fn (tc &TypeChecker) method_receiver_compatible(actual Type, expected Type, meth
 	if tc.receiver_compatible(actual, expected) {
 		return true
 	}
+	actual_depth, actual_base := type_pointer_depth_and_base(actual)
+	expected_depth, expected_base := type_pointer_depth_and_base(expected)
+	if actual_depth > expected_depth && (tc.type_compatible(actual_base, expected_base)
+		|| tc.generic_receiver_base_match(actual_base, expected_base)
+		|| tc.receiver_embeds(actual_base, expected_base)) {
+		return true
+	}
 	// Runtime array builtins are declared with the internal `array` receiver, which is
 	// represented here as `[]void`. Keep that erasure scoped to raw `array.*`
 	// methods; user receivers like `fn (xs []void) touch()` must not accept `[]int`.
@@ -17453,7 +17886,7 @@ fn (tc &TypeChecker) implicit_ref_arg_compatible(expr_id flat.NodeId, actual Typ
 	}
 	actual_depth, actual_base := type_pointer_depth_and_base(actual)
 	expected_depth, expected_base := type_pointer_depth_and_base(expected)
-	if actual_depth > 0 || expected_depth != actual_depth + 1 {
+	if expected_depth <= actual_depth {
 		return false
 	}
 	return tc.type_compatible(actual_base, expected_base)
@@ -17478,9 +17911,13 @@ fn type_pointer_depth_and_base(typ Type) (int, Type) {
 }
 
 fn (tc &TypeChecker) explicit_address_arg_compatible(expr_id flat.NodeId, actual Type, expected Type) bool {
-	if actual is Pointer {
-		return tc.type_compatible(actual.base_type, expected)
-			&& tc.expr_is_addressed_byvalue_arg(expr_id)
+	if actual is Pointer && expected is Pointer && tc.valid_node_id(expr_id) {
+		node := tc.a.nodes[int(expr_id)]
+		if node.kind == .prefix && node.op == .amp && node.children_count > 0 {
+			child_id := tc.a.child(&node, 0)
+			child_type := tc.smartcast_type(child_id) or { actual.base_type }
+			return tc.type_compatible(child_type, expected.base_type)
+		}
 	}
 	return false
 }
@@ -17628,6 +18065,28 @@ fn (tc &TypeChecker) selector_declared_value_type(node flat.Node) ?Type {
 	return none
 }
 
+fn (tc &TypeChecker) selector_const_fn_type(node flat.Node) ?FnType {
+	if typ := tc.const_type_for_selector(node) {
+		return fn_type_from_type(typ)
+	}
+	return none
+}
+
+fn (tc &TypeChecker) selector_field_fn_type(node flat.Node, base_type Type) ?FnType {
+	clean := unalias_and_unwrap_pointer_type(base_type)
+	if clean is Struct {
+		if typ := tc.struct_field_type(clean.name, node.value) {
+			return fn_type_from_type(typ)
+		}
+	}
+	if clean is Interface {
+		if typ := tc.interface_field_type(clean.name, node.value) {
+			return fn_type_from_type(typ)
+		}
+	}
+	return none
+}
+
 // selector_fn_type supports selector fn type handling for TypeChecker.
 fn (tc &TypeChecker) selector_fn_type(node flat.Node) ?FnType {
 	typ := tc.selector_declared_value_type(node) or { return none }
@@ -17687,6 +18146,9 @@ fn (tc &TypeChecker) builtin_method_value_type(base_type Type, method string) ?T
 
 // selector_fn_base_type supports selector fn base type handling for TypeChecker.
 fn (tc &TypeChecker) selector_fn_base_type(base_id flat.NodeId) ?Type {
+	if typ := tc.smartcast_type(base_id) {
+		return typ
+	}
 	if typ := tc.cached_expr_type(base_id) {
 		return typ
 	}
@@ -17776,6 +18238,20 @@ fn (tc &TypeChecker) spawn_child_call_return_type(node flat.Node) ?Type {
 		return none
 	}
 	fn_node := tc.a.child_node(&node, 0)
+	if fn_node.kind == .selector && fn_node.children_count > 0 {
+		base_type := tc.resolve_type(tc.a.child(fn_node, 0))
+		clean_base := unwrap_all_pointers(base_type)
+		for candidate in receiver_method_name_candidates(clean_base, fn_node.value, tc.cur_module) {
+			if ret := tc.fn_ret_types[candidate] {
+				return ret
+			}
+		}
+		if method_key := tc.concrete_method_signature_key(clean_base.name(), fn_node.value) {
+			if ret := tc.fn_ret_types[method_key] {
+				return ret
+			}
+		}
+	}
 	if fn_node.kind != .ident {
 		return none
 	}
@@ -18176,10 +18652,14 @@ fn (tc &TypeChecker) is_known_call(node flat.Node) bool {
 				}
 			}
 		}
-		if _ := tc.selector_fn_type(fn_node) {
+		if _ := tc.selector_const_fn_type(fn_node) {
 			return true
 		}
-		base_type := tc.resolve_type(tc.a.child(fn_node, 0))
+		base_id := tc.a.child(fn_node, 0)
+		base_type := tc.selector_fn_base_type(base_id) or { tc.resolve_type(base_id) }
+		if _ := tc.selector_field_fn_type(fn_node, base_type) {
+			return true
+		}
 		if fn_node.value == 'hex' && tc.type_is_pointer_receiver(base_type) {
 			return false
 		}
@@ -18265,7 +18745,7 @@ fn (tc &TypeChecker) is_known_array_receiver_method(receiver Type, method string
 		return method in ['first', 'last', 'pop', 'pop_left', 'contains', 'join', 'index',
 			'last_index', 'repeat', 'repeat_to_depth', 'delete', 'delete_last', 'clear', 'insert',
 			'prepend', 'filter', 'map', 'any', 'all', 'count', 'sort_with_compare',
-			'sorted_with_compare', 'sort', 'sorted', 'clone', 'reverse', 'equals', 'wait']
+			'sorted_with_compare', 'sort', 'sorted', 'clone', 'reverse', 'equals', 'bytestr', 'wait']
 	}
 	if receiver is ArrayFixed {
 		array_type := Type(Array{
@@ -18421,6 +18901,9 @@ fn (mut tc TypeChecker) check_if_expr(id flat.NodeId, node flat.Node) {
 		else_id := tc.a.child(&node, 2)
 		if tc.branch_has_value_tail(then_id) && tc.branch_has_value_tail(else_id)
 			&& !tc.if_branch_types_compatible(then_type, else_type, tc.branch_tail_is_array_literal(then_id), tc.branch_tail_is_array_literal(else_id)) {
+			if tc.if_branch_empty_array_compatible(then_type, then_id, else_type, else_id) {
+				return
+			}
 			then_tail := tc.branch_tail_expr_id(then_id)
 			else_tail := tc.branch_tail_expr_id(else_id)
 			if tc.if_branch_none_has_option_context(then_type, then_tail, else_type, else_tail) {
@@ -18455,6 +18938,21 @@ fn (mut tc TypeChecker) check_if_expr(id flat.NodeId, node flat.Node) {
 			}
 		}
 	}
+}
+
+fn (tc &TypeChecker) if_branch_empty_array_compatible(a Type, a_branch flat.NodeId, b Type, b_branch flat.NodeId) bool {
+	a_empty := tc.expr_is_empty_bare_array_literal(tc.branch_tail_expr_id(a_branch))
+	b_empty := tc.expr_is_empty_bare_array_literal(tc.branch_tail_expr_id(b_branch))
+	return (a_empty && array_like_elem_type(b) != none)
+		|| (b_empty && array_like_elem_type(a) != none)
+}
+
+fn (tc &TypeChecker) expr_is_empty_bare_array_literal(id flat.NodeId) bool {
+	if !tc.valid_node_id(id) {
+		return false
+	}
+	node := tc.a.nodes[int(id)]
+	return node.kind == .array_literal && node.children_count == 0
 }
 
 fn (tc &TypeChecker) if_branch_none_has_option_context(a Type, a_tail flat.NodeId, b Type, b_tail flat.NodeId) bool {
@@ -18739,7 +19237,15 @@ fn (mut tc TypeChecker) check_if_guard(id flat.NodeId, node flat.Node) []LocalBi
 	}
 	rhs_id := tc.a.child(&node, 1)
 	tc.check_node(rhs_id)
-	rhs_type := tc.resolve_type(rhs_id)
+	mut rhs_type := tc.resolve_type(rhs_id)
+	rhs_node := tc.a.node(rhs_id)
+	if rhs_node.kind == .selector {
+		if declared := tc.selector_declared_value_type(*rhs_node) {
+			if declared is OptionType || declared is ResultType {
+				rhs_type = declared
+			}
+		}
+	}
 	mut payload := Type(void_)
 	is_optional_result := rhs_type is OptionType || rhs_type is ResultType
 	if rhs_type is OptionType {
@@ -19730,12 +20236,6 @@ fn (mut tc TypeChecker) check_struct_init(id flat.NodeId, node flat.Node) {
 			} else if i < fields.len {
 				expected = fields[i].typ
 			}
-			// A method value stored in a struct field escapes the evaluation site (several
-			// instances from the same `Foo{cb: obj.method}` site would share one receiver).
-			if !tc.stored_method_value_matches_voidptr_callback(value_id, expected) {
-				tc.reject_stored_method_value(value_id)
-			}
-			tc.reject_stored_or_returned_capturing_fn_literal(value_id)
 			if expected !is Void {
 				tc.check_node_with_expected_context(value_id, expected)
 			} else {
@@ -20134,6 +20634,7 @@ fn (mut tc TypeChecker) check_selector(id flat.NodeId, node flat.Node) {
 	if clean_recv is Struct {
 		if tc.struct_field_type(clean_recv.name, node.value) == none {
 			mut mkey := '${clean_recv.name}.${node.value}'
+			mut is_generic_method_value := false
 			if mkey !in tc.fn_param_types {
 				// Generic receiver methods are registered under the open key
 				// (`Box[T].method`); mark that one reachable for the wrapper, and stash
@@ -20141,9 +20642,10 @@ fn (mut tc TypeChecker) check_selector(id flat.NodeId, node flat.Node) {
 				if ci := tc.resolve_generic_struct_method(clean_recv.name, node.value) {
 					tc.generic_method_value_info['${clean_recv.name}.${node.value}'] = ci
 					mkey = ci.name
+					is_generic_method_value = true
 				}
 			}
-			if mkey in tc.fn_param_types && tc.fn_context.node_id >= 0 {
+			if (mkey in tc.fn_param_types || is_generic_method_value) && tc.fn_context.node_id >= 0 {
 				// Record per enclosing function so markused marks it only when that
 				// function is reachable; over-marking an unreachable method value can pull
 				// in (and fail to compile) an otherwise-unused specialization. A method
@@ -20616,6 +21118,12 @@ fn (mut tc TypeChecker) check_index_overload_args(id flat.NodeId, node flat.Node
 	}
 }
 
+fn (mut tc TypeChecker) check_index_overload_args_ok(id flat.NodeId, node flat.Node, info CallInfo) bool {
+	error_count := tc.errors.len
+	tc.check_index_overload_args(id, node, info)
+	return tc.errors.len == error_count
+}
+
 fn (mut tc TypeChecker) check_index_overload_part_with_expected(id flat.NodeId, expected Type) {
 	if int(id) < 0 {
 		return
@@ -20787,6 +21295,23 @@ fn (mut tc TypeChecker) resolve_expr(id flat.NodeId, expected Type) Type {
 		if is_ierror_type(expected) {
 			tc.register_synth_type(id, expected)
 			return expected
+		}
+	}
+	if node.kind == .or_expr && node.children_count >= 2
+		&& (expected is OptionType || expected is ResultType) {
+		payload := match expected {
+			OptionType { expected.base_type }
+			ResultType { expected.base_type }
+			else { Type(void_) }
+		}
+		source_type := tc.resolve_type(tc.a.child(&node, 0))
+		body_tail := tc.branch_tail_expr_id(tc.a.child(&node, 1))
+		if tc.type_compatible(source_type, payload) && tc.valid_node_id(body_tail) {
+			body_type := tc.resolve_expr(body_tail, expected)
+			if tc.type_compatible(body_type, expected) || tc.type_compatible(body_type, payload) {
+				tc.register_synth_type(id, expected_raw)
+				return expected_raw
+			}
 		}
 	}
 	if payload := contextual_payload_type(expected) {
@@ -21160,6 +21685,9 @@ fn (tc &TypeChecker) static_assoc_type_candidates(type_ident string) []string {
 	}
 	mut candidates := []string{}
 	tc.add_static_assoc_type_candidate(mut candidates, type_ident)
+	if resolved := tc.resolve_selective_import_type_symbol(type_ident) {
+		tc.add_static_assoc_type_candidate(mut candidates, resolved)
+	}
 	if resolved := tc.resolve_import_alias(type_ident) {
 		tc.add_static_assoc_type_candidate(mut candidates, resolved)
 	}
@@ -21641,6 +22169,12 @@ fn (tc &TypeChecker) fn_return_compatible(actual Type, expected Type) bool {
 	if actual.name() == expected.name() {
 		return true
 	}
+	if tc.c_type(actual) == tc.c_type(expected) {
+		return true
+	}
+	if actual.is_integer() && expected.is_integer() {
+		return true
+	}
 	return fn_return_canonical_type_name(actual) == fn_return_canonical_type_name(expected)
 }
 
@@ -21675,6 +22209,16 @@ fn fn_param_unalias_type(typ Type) Type {
 		return fn_param_unalias_type(typ.base_type)
 	}
 	return typ
+}
+
+fn call_arg_integer_type(typ Type) bool {
+	clean := fn_param_unalias_type(typ)
+	return clean.is_integer()
+		|| clean.name() in ['int', 'i8', 'i16', 'i32', 'i64', 'isize', 'u8', 'u16', 'u32', 'u64', 'usize', 'rune']
+}
+
+fn escaped_identifier_name(name string) string {
+	return if name.starts_with('@') { name[1..] } else { name }
 }
 
 fn fn_return_canonical_type_name(typ Type) string {
@@ -22103,11 +22647,33 @@ fn (tc &TypeChecker) type_implements_interface(actual Type, expected Interface) 
 	if clean is Interface {
 		return tc.interface_implements_interface(clean.name, expected.name)
 	}
+	if clean is Array {
+		if tc.interface_abstract_method_names(expected.name).len > 0 {
+			return false
+		}
+		for field in tc.interface_field_list(expected.name) {
+			actual_field := tc.builtin_array_field_type(field.name) or { return false }
+			if !tc.type_compatible(actual_field, field.typ)
+				|| !tc.type_compatible(field.typ, actual_field) {
+				return false
+			}
+		}
+		return true
+	}
 	concrete_name := method_type_name(clean)
 	if concrete_name.len == 0 {
 		return false
 	}
 	return tc.named_type_implements_interface(concrete_name, expected.name)
+}
+
+fn (tc &TypeChecker) builtin_array_field_type(name string) ?Type {
+	return match name {
+		'element_size', 'offset', 'len', 'cap' { Type(int_) }
+		'data' { Type(voidptr_) }
+		'flags' { tc.parse_type('ArrayFlags') }
+		else { none }
+	}
 }
 
 // interface_implements_interface supports interface implements interface handling for TypeChecker.
@@ -22669,11 +23235,51 @@ pub fn (tc &TypeChecker) concrete_method_signature_key(concrete_name string, met
 	if key in tc.fn_param_types || key in tc.fn_ret_types {
 		return key
 	}
+	qualified_name := tc.qualify_name(concrete_name)
+	if concrete_name !in tc.type_aliases && qualified_name != concrete_name {
+		qualified_key := '${qualified_name}.${method}'
+		if qualified_key in tc.fn_param_types || qualified_key in tc.fn_ret_types {
+			return qualified_key
+		}
+	}
+	// The current module can make parse_type(`Connection`) select the imported
+	// `orm.Connection` interface even when the implementation candidate is a
+	// same-named alias from another module. Consult the alias table by its
+	// collected concrete name before doing suffix-based method lookup.
+	for alias_name in [concrete_name, qualified_name] {
+		if alias_target := tc.type_aliases[alias_name] {
+			if alias_target != alias_name && alias_target != concrete_name {
+				if inherited := tc.concrete_method_signature_key(alias_target, method) {
+					return inherited
+				}
+			}
+		}
+	}
 	receiver_type := tc.parse_type(concrete_name)
-	for candidate in receiver_method_name_candidates(receiver_type, method, tc.cur_module) {
+	receiver_candidates := receiver_method_name_candidates(receiver_type, method, tc.cur_module)
+	// Prefer a method declared directly on the alias when one exists, but do not
+	// let an unqualified alias name resolve through the suffix index to an
+	// unrelated interface with the same name. Aliases otherwise inherit the
+	// methods of their base type.
+	for candidate in receiver_candidates {
 		if candidate in tc.fn_param_types || candidate in tc.fn_ret_types {
 			return candidate
 		}
+	}
+	if receiver_type is Alias {
+		for candidate in receiver_method_name_candidates(receiver_type.base_type, method,
+			tc.cur_module) {
+			if candidate in tc.fn_param_types || candidate in tc.fn_ret_types {
+				return candidate
+			}
+			if indexed := tc.receiver_method_suffix_index[candidate] {
+				if indexed != receiver_method_suffix_ambiguous {
+					return indexed
+				}
+			}
+		}
+	}
+	for candidate in receiver_candidates {
 		if indexed := tc.receiver_method_suffix_index[candidate] {
 			if indexed != receiver_method_suffix_ambiguous {
 				return indexed
@@ -23379,11 +23985,24 @@ fn (tc &TypeChecker) interface_field_list_inner(iface_name string, mut seen map[
 	}
 	seen[name] = true
 	mut fields := []StructField{}
+	mut field_indexes := map[string]int{}
 	for embed in tc.interface_embeds[name] or { []string{} } {
-		fields << tc.interface_field_list_inner(embed, mut seen)
+		for field in tc.interface_field_list_inner(embed, mut seen) {
+			if idx := field_indexes[field.name] {
+				fields[idx] = field
+			} else {
+				field_indexes[field.name] = fields.len
+				fields << field
+			}
+		}
 	}
 	for field in tc.interface_fields[name] or { []StructField{} } {
-		fields << field
+		if idx := field_indexes[field.name] {
+			fields[idx] = field
+		} else {
+			field_indexes[field.name] = fields.len
+			fields << field
+		}
 	}
 	return fields
 }
@@ -23767,8 +24386,8 @@ fn is_middleware_type_name(name string) bool {
 }
 
 fn (tc &TypeChecker) receiver_embeds(actual Type, expected Type) bool {
-	actual_name := method_type_name(unwrap_pointer(actual))
-	expected_name := method_type_name(unwrap_pointer(expected))
+	actual_name := method_type_name(unwrap_all_pointers(actual))
+	expected_name := method_type_name(unwrap_all_pointers(expected))
 	if actual_name.len == 0 || expected_name.len == 0 {
 		return false
 	}
@@ -24731,6 +25350,12 @@ fn parse_type_cache_put(mut cache TypeCache, file string, module_name string, te
 // inside a generic function/method body the parameter still needs the open application so
 // field lookup and generic receiver method resolution can substitute `T`.
 fn (tc &TypeChecker) parse_scope_param_type(typ string) Type {
+	clean := typ.trim_space()
+	if clean.starts_with('...') {
+		return Type(Array{
+			elem_type: tc.parse_scope_param_type(clean[3..])
+		})
+	}
 	if preserved := tc.parse_open_generic_struct_type(typ) {
 		return preserved
 	}
@@ -25416,10 +26041,10 @@ fn (tc &TypeChecker) array_literal_child_elem_type(child_id flat.NodeId) Type {
 			return spread_type.elem_type
 		}
 	}
-	if fn_type := tc.array_literal_child_fn_value_type(child_id) {
-		return fn_type
+	if alias_type := tc.explicit_alias_constructor_type(child_id) {
+		return alias_type
 	}
-	return tc.explicit_alias_constructor_type(child_id) or { tc.resolve_type(child_id) }
+	return tc.array_literal_child_fn_value_type(child_id) or { tc.resolve_type(child_id) }
 }
 
 fn (tc &TypeChecker) array_literal_child_fn_value_type(child_id flat.NodeId) ?Type {
@@ -25450,6 +26075,12 @@ fn (tc &TypeChecker) explicit_alias_constructor_type(id flat.NodeId) ?Type {
 		return none
 	}
 	qname := tc.qualify_name(type_name)
+	if type_name in tc.sum_types {
+		return tc.parse_type(type_name)
+	}
+	if qname in tc.sum_types {
+		return tc.parse_type(qname)
+	}
 	if type_name in tc.type_aliases || qname in tc.type_aliases {
 		return tc.parse_type(type_name)
 	}
@@ -26132,10 +26763,14 @@ pub fn (tc &TypeChecker) resolve_type(id flat.NodeId) Type {
 						}
 					}
 				}
-				if fn_typ := tc.selector_fn_type(fn_node) {
+				if fn_typ := tc.selector_const_fn_type(fn_node) {
 					return fn_typ.return_type
 				}
-				base_type := tc.resolve_type(tc.a.child(fn_node, 0))
+				base_id := tc.a.child(fn_node, 0)
+				base_type := tc.selector_fn_base_type(base_id) or { tc.resolve_type(base_id) }
+				if fn_typ := tc.selector_field_fn_type(fn_node, base_type) {
+					return fn_typ.return_type
+				}
 				clean_type := unwrap_pointer(base_type)
 				if fn_node.value == 'wait' {
 					if ret_type := tc.thread_wait_return_type(base_type) {
@@ -26416,6 +27051,14 @@ pub fn (tc &TypeChecker) resolve_type(id flat.NodeId) Type {
 			if node.op == .right_shift_unsigned {
 				return unsigned_shift_result_type(lt)
 			}
+			if node.op == .plus {
+				if lt is String && optional_payload_is_string(rt) {
+					return rt_raw
+				}
+				if rt is String && optional_payload_is_string(lt) {
+					return lt_raw
+				}
+			}
 			if lt is String {
 				return lt_raw
 			}
@@ -26444,6 +27087,9 @@ pub fn (tc &TypeChecker) resolve_type(id flat.NodeId) Type {
 		.prefix {
 			if node.typ.len > 0 {
 				return tc.parse_type(node.typ)
+			}
+			if node.op == .not {
+				return Type(bool_)
 			}
 			if node.op == .amp {
 				child_id := tc.a.child(&node, 0)
@@ -27111,6 +27757,11 @@ fn (tc &TypeChecker) struct_c_name_collides_with_v3_runtime(name string, cname s
 
 fn (tc &TypeChecker) c_generic_struct_arg_name(arg string) string {
 	clean := arg.trim_space()
+	// `voidptr` round-trips through the type model as `&void`. Keep the source ABI
+	// spelling for generic instance names so materialized structs and methods agree.
+	if clean == '&void' {
+		return 'voidptr'
+	}
 	if fixed := tc.c_generic_struct_fixed_array_arg_name(clean) {
 		return fixed
 	}
@@ -27239,31 +27890,42 @@ pub fn (tc &TypeChecker) resolve_generic_struct_method(type_name string, method 
 			}
 		}
 		for method_base in method_bases {
-			candidate_key := '${method_base}[${candidate_params.join(', ')}].${method}'
-			if candidate_key in tc.fn_ret_types {
-				generic_base = candidate
-				params = generic_method_receiver_params_from_key(candidate_key, candidate_params)
-				concrete_args = candidate_concrete_args.clone()
-				generic_key = candidate_key
-				break
-			}
-			plain_candidate_key := '${method_base}.${method}'
-			if plain_candidate_key in tc.fn_ret_types {
-				generic_base = candidate
-				params = candidate_params.clone()
-				concrete_args = candidate_concrete_args.clone()
-				generic_key = plain_candidate_key
-				break
-			}
-			if indexed := tc.receiver_method_suffix_index['${method_base}.${method}'] {
-				if indexed != receiver_method_suffix_ambiguous && indexed in tc.fn_ret_types
-					&& indexed.all_before_last('.').contains('[') {
+			for method_spelling in [method, '@${method}'] {
+				candidate_key := '${method_base}[${candidate_params.join(', ')}].${method_spelling}'
+				if candidate_key in tc.fn_ret_types {
 					generic_base = candidate
-					params = generic_method_receiver_params_from_key(indexed, candidate_params)
+					params = generic_method_receiver_params_from_key(candidate_key,
+						candidate_params)
 					concrete_args = candidate_concrete_args.clone()
-					generic_key = indexed
+					generic_key = candidate_key
 					break
 				}
+				plain_candidate_key := '${method_base}.${method_spelling}'
+				if plain_candidate_key in tc.fn_ret_types {
+					generic_base = candidate
+					params = candidate_params.clone()
+					concrete_args = candidate_concrete_args.clone()
+					generic_key = plain_candidate_key
+					break
+				}
+			}
+			if generic_key.len > 0 {
+				break
+			}
+			for method_spelling in [method, '@${method}'] {
+				if indexed := tc.receiver_method_suffix_index['${method_base}.${method_spelling}'] {
+					if indexed != receiver_method_suffix_ambiguous && indexed in tc.fn_ret_types
+						&& indexed.all_before_last('.').contains('[') {
+						generic_base = candidate
+						params = generic_method_receiver_params_from_key(indexed, candidate_params)
+						concrete_args = candidate_concrete_args.clone()
+						generic_key = indexed
+						break
+					}
+				}
+			}
+			if generic_key.len > 0 {
+				break
 			}
 		}
 		if generic_key.len > 0 {
@@ -27839,6 +28501,7 @@ fn receiver_method_name_candidates(t Type, method string, module_name string) []
 	type_name := resolve_type_name_for_method(t)
 	if type_name.len > 0 {
 		push_receiver_method_candidate(mut names, '${type_name}.${method}')
+		push_receiver_method_candidate(mut names, '${type_name}.@${method}')
 	}
 	mut clean := t
 	if clean is Alias {
@@ -27886,8 +28549,15 @@ fn int_literal_promoted_infix_type(lit flat.Node, other flat.Node, other_type Ty
 		return none
 	}
 	value := v_int_literal_value(lit.value) or { return none }
-	if unsigned_type_accepts_int_literal(other_type, value) {
-		return other_type
+	clean_type := unalias_type(other_type)
+	if unsigned_type_accepts_int_literal(clean_type, value) {
+		return clean_type
+	}
+	// An untyped integer literal adopts the other integer operand's concrete storage
+	// type. In particular, `24 * time.hour` is `i64`, not `int`; map literal
+	// inference relies on that distinction when it chooses its value type.
+	if clean_type.is_integer() && clean_type.name() != Type(int_).name() {
+		return clean_type
 	}
 	return none
 }

--- a/vlib/v3/types/checker_parallel.v
+++ b/vlib/v3/types/checker_parallel.v
@@ -438,6 +438,7 @@ fn (mut tc TypeChecker) check_fn_decl_semantics(fn_idx int, node flat.Node, file
 	tc.cur_scope = tc.file_scope
 	tc.cur_fn_ret_type = tc.parse_type(node.typ)
 	tc.fn_context.return_type = tc.cur_fn_ret_type
+	tc.fn_context.node_id = fn_idx
 	tc.cur_fn_node_id = fn_idx
 	tc.method_value_locals = map[string]bool{}
 	tc.method_value_local_depth = map[string]int{}

--- a/vlib/v3/types/type.v
+++ b/vlib/v3/types/type.v
@@ -320,6 +320,15 @@ pub fn unwrap_pointer(t Type) Type {
 	return t
 }
 
+// unwrap_all_pointers removes every pointer layer from t.
+pub fn unwrap_all_pointers(t Type) Type {
+	mut clean := t
+	for clean is Pointer {
+		clean = clean.base_type
+	}
+	return clean
+}
+
 // generic_base_name returns the declaration part of a concrete generic type name.
 pub fn generic_base_name(name string) string {
 	if name.starts_with('[') {
@@ -424,10 +433,9 @@ pub fn (t Type) name() string {
 			len_text = t.len_expr
 		}
 		elem_type := nested_type_name(t.elem_type)
-		if t.elem_type is FnType {
-			return '[${len_text}]${elem_type}'
-		}
-		return '${elem_type}[${len_text}]'
+		// Keep fixed arrays in canonical prefix form. Suffix form loses nesting:
+		// both `?[3]u8` and `[3]?u8` otherwise collapse to the ambiguous `?u8[3]`.
+		return '[${len_text}]${elem_type}'
 	}
 	if t is Channel {
 		return 'chan ${nested_type_name(t.elem_type)}'

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -2007,6 +2007,8 @@ fn main() {
 		}
 		if a.specialized_fn_nodes.len != base_specialized_fns {
 			a.specialized_fn_nodes = a.specialized_fn_nodes.clone()
+			a.specialized_fn_modules = clone_int_string_map(a.specialized_fn_modules)
+			a.specialized_fn_files = clone_int_string_map(a.specialized_fn_files)
 		}
 		promote_scoped_checker_node_caches(mut pre_tc)
 		promote_scoped_signatures(mut pre_tc, original_signature_names)

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -5760,22 +5760,20 @@ fn path_is_in_dir(path string, dir string) bool {
 	return real_path == real_dir || real_path.starts_with(real_dir + os.path_separator)
 }
 
-// skipped_backend_modules lists the importable backend module names that the current
+// skipped_backend_module_groups lists the importable backend module groups that the current
 // configuration excludes (driven by the same `skip_*` defines that gate the dispatch in
-// main()). The arm64 backend is the only consumer of the SSA pipeline, so skipping it also
-// skips v3.ssa and v3.ssa.optimize.
-fn skipped_backend_modules(prefs &pref.Preferences) []string {
-	mut skipped := []string{}
+// main()). The arm64 backend is the only consumer of the SSA pipeline, so it shares a group
+// with v3.ssa and v3.ssa.optimize.
+fn skipped_backend_module_groups(prefs &pref.Preferences) [][]string {
+	mut skipped := [][]string{}
 	if 'skip_arm64' in prefs.user_defines {
-		skipped << 'v3.gen.arm64'
-		skipped << 'v3.ssa'
-		skipped << 'v3.ssa.optimize'
+		skipped << ['v3.gen.arm64', 'v3.ssa', 'v3.ssa.optimize']
 	}
 	if 'skip_wasm' in prefs.user_defines {
-		skipped << 'v3.gen.wasm'
+		skipped << ['v3.gen.wasm']
 	}
 	if 'skip_eval' in prefs.user_defines {
-		skipped << 'v3.eval'
+		skipped << ['v3.eval']
 	}
 	return skipped
 }
@@ -5970,8 +5968,18 @@ fn resolve_imports(mut a flat.FlatAst, mut p parser.Parser, prefs &pref.Preferen
 	// them as already handled, so neither v3.v's top-level imports nor any transitive
 	// import pulls them in. Skipping the arm64 group (v3.gen.arm64 + the v3.ssa SSA
 	// pipeline) and the wasm/eval backends avoids ~30k lines of work when self-hosting.
-	for skipped in skipped_backend_modules(prefs) {
-		if skipped !in explicit_initial_imports {
+	for skipped_group in skipped_backend_module_groups(prefs) {
+		mut group_requested := false
+		for skipped in skipped_group {
+			if skipped in explicit_initial_imports {
+				group_requested = true
+				break
+			}
+		}
+		if group_requested {
+			continue
+		}
+		for skipped in skipped_group {
 			parsed_modules[skipped] = true
 		}
 	}

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -30,6 +30,9 @@ $if !skip_wasm ? {
 
 const cache_bundle_import_file_name = '.v3_cache_bundle_imports.vh'
 const scoped_transform_signature_headroom = 2048
+const v3_vvmrc_file_name = '.vvmrc'
+const v3_vvmrc_skip_env = 'V_SKIP_VVMRC'
+const v3_vvmrc_stop_paths = ['.git', '.hg', '.svn', '.v.mod.stop']
 
 struct V3ModuleCacheState {
 	manager             modulecache.Manager
@@ -597,6 +600,114 @@ fn run_binary(bin_file string, args []string) int {
 	return exit_code
 }
 
+fn maybe_delegate_v3_to_vvmrc(input_file string, verbose bool) {
+	if os.getenv(v3_vvmrc_skip_env) != '' || input_file in ['', '-'] {
+		return
+	}
+	vvmrc_path := find_v3_project_vvmrc(input_file)
+	if vvmrc_path.len == 0 {
+		return
+	}
+	requested_version := parse_v3_vvmrc_version(os.read_file(vvmrc_path) or { '' })
+	if requested_version.len == 0
+		|| normalize_v3_vvmrc_version(requested_version).to_lower_ascii() in ['latest', 'current'] {
+		return
+	}
+	requested_exe := resolve_v3_version_executable(requested_version) or {
+		eprintln('v3: warning: `${vvmrc_path}` requests V `${requested_version}`, but no matching compiler executable was found; continuing with `${os.executable()}`')
+		return
+	}
+	if os.real_path(requested_exe) == os.real_path(os.executable()) {
+		return
+	}
+	if verbose {
+		eprintln('v3: `.vvmrc` selected V `${requested_version}` from `${vvmrc_path}` => ${requested_exe}')
+	}
+	mut process := os.new_process(requested_exe)
+	process.set_args(os.args[1..])
+	mut envs := os.environ()
+	envs[v3_vvmrc_skip_env] = '1'
+	envs['VEXE'] = requested_exe
+	process.set_environment(envs)
+	process.wait()
+	exit_code := if process.code >= 0 { process.code } else { 1 }
+	process.close()
+	exit(exit_code)
+}
+
+fn find_v3_project_vvmrc(target_path string) string {
+	mut folder := if os.is_dir(target_path) { target_path } else { os.dir(target_path) }
+	if folder.len == 0 {
+		folder = os.getwd()
+	}
+	mut current := os.real_path(folder)
+	for _ in 0 .. 256 {
+		vvmrc_path := os.join_path(current, v3_vvmrc_file_name)
+		if os.is_file(vvmrc_path) {
+			return vvmrc_path
+		}
+		if v3_vvmrc_stop_paths.any(os.exists(os.join_path(current, it))) {
+			break
+		}
+		parent := os.dir(current)
+		if parent.len == 0 || parent == current {
+			break
+		}
+		current = parent
+	}
+	return ''
+}
+
+fn parse_v3_vvmrc_version(content string) string {
+	for raw_line in content.split_into_lines() {
+		line := raw_line.all_before('#').trim_space()
+		if line.len > 0 {
+			return line
+		}
+	}
+	return ''
+}
+
+fn normalize_v3_vvmrc_version(version_name string) string {
+	mut normalized := version_name.trim_space()
+	if normalized.len > 1 && normalized[0] in [`v`, `V`] && normalized[1].is_digit() {
+		normalized = normalized[1..]
+	}
+	return normalized
+}
+
+fn resolve_v3_version_executable(version_name string) !string {
+	raw_version := version_name.trim_space()
+	if raw_version.len == 0 {
+		return error('empty version')
+	}
+	mut names := [raw_version, 'v${raw_version}']
+	if raw_version.starts_with('v') && raw_version.len > 1 {
+		names << raw_version[1..]
+	}
+	for name in names {
+		if found_path := os.find_abs_path_of_executable(name) {
+			return found_path
+		}
+	}
+	normalized := normalize_v3_vvmrc_version(raw_version)
+	mut paths := [os.join_path('/usr/lib/v', normalized, 'bin', 'v'),
+		os.join_path('/usr/local/bin', 'v${normalized}')]
+	for env_name in ['VVM_HOME', 'VVM_DIR'] {
+		vvm_root := os.getenv(env_name).trim_space()
+		if vvm_root.len > 0 {
+			paths << os.join_path(vvm_root, normalized, 'bin', 'v')
+			paths << os.join_path(vvm_root, 'versions', normalized, 'bin', 'v')
+		}
+	}
+	for path in paths {
+		if os.is_file(path) {
+			return path
+		}
+	}
+	return error('V executable for `${raw_version}` was not found')
+}
+
 fn executable_path_for_run(path string) string {
 	mut run_path := path
 	if !os.is_abs_path(path) && !path.contains('/') && !path.contains('\\') {
@@ -866,18 +977,20 @@ fn clone_flat_ast_after_transform(ast &flat.FlatAst) &flat.FlatAst {
 	children << ast.children
 	text_values, text_ids := ast.clone_text_table_owned()
 	return &flat.FlatAst{
-		nodes:                nodes
-		children:             children
-		user_code_start:      ast.user_code_start
-		disabled_fns:         ast.disabled_fns
-		export_fn_names:      ast.export_fn_names
-		noreturn_fns:         ast.noreturn_fns
-		source_files:         ast.source_files
-		source_buffers:       ast.source_buffers
-		text_values:          text_values
-		text_ids:             text_ids
-		worker_pool:          ast.worker_pool
-		specialized_fn_nodes: ast.specialized_fn_nodes.clone()
+		nodes:                  nodes
+		children:               children
+		user_code_start:        ast.user_code_start
+		disabled_fns:           ast.disabled_fns
+		export_fn_names:        ast.export_fn_names
+		noreturn_fns:           ast.noreturn_fns
+		source_files:           ast.source_files
+		source_buffers:         ast.source_buffers
+		text_values:            text_values
+		text_ids:               text_ids
+		worker_pool:            ast.worker_pool
+		specialized_fn_nodes:   ast.specialized_fn_nodes.clone()
+		specialized_fn_modules: clone_int_string_map(ast.specialized_fn_modules)
+		specialized_fn_files:   clone_int_string_map(ast.specialized_fn_files)
 	}
 }
 
@@ -1201,6 +1314,7 @@ fn main() {
 	mut target_arch_explicit := false
 	mut c_compiler := 'cc'
 	mut c_compiler_explicit := false
+	mut explicit_tcc := false
 	mut gc_mode := 'none'
 	mut enable_globals_compat := false
 	mut is_prod := false
@@ -1317,7 +1431,9 @@ fn main() {
 			gc_mode = args[i + 1]
 			i += 2
 		} else if args[i] == '-cc' && i + 1 < args.len {
-			c_compiler = args[i + 1]
+			requested_compiler := args[i + 1]
+			explicit_tcc = requested_compiler in ['tcc', 'tinyc']
+			c_compiler = requested_compiler
 			c_compiler_explicit = true
 			i += 2
 		} else if args[i] == '-cflags' && i + 1 < args.len {
@@ -1327,14 +1443,20 @@ fn main() {
 			}
 			user_c_flags << parsed_c_flags
 			i += 2
-		} else if args[i] == '-g' {
+		} else if args[i] in ['-g', '-cg'] {
 			is_debug = true
 			user_c_flags << '-g'
+			i++
+		} else if args[i] == '-autofree' {
+			if 'autofree' !in user_defines {
+				user_defines << 'autofree'
+			}
 			i++
 		} else if args[i] == '-v' {
 			verbose = true
 			i++
-		} else if args[i] in ['-stats', '-show-timings', '-showcc', '-keepc', '-w'] {
+		} else if args[i] in ['-stats', '-show-timings', '-showcc', '-keepc', '-w',
+			'-no-retry-compilation'] {
 			// v3 already reports phase metrics, prints the C command, retains generated C,
 			// and suppresses C warnings. Accept the corresponding V flags for compatibility.
 			i++
@@ -1382,6 +1504,7 @@ fn main() {
 		eprintln('no input file')
 		exit(1)
 	}
+	maybe_delegate_v3_to_vvmrc(input_file, verbose)
 	if gc_mode != 'none' {
 		eprintln('unsupported garbage collector `${gc_mode}`; v3 currently supports only `-gc none`')
 		exit(1)
@@ -2246,10 +2369,18 @@ fn main() {
 		// the much smaller cached main unit with the system C compiler so the same
 		// undeclared-function diagnostics remain enforced.
 		if !is_prod && !needs_objective_c && !link_uses_non_c_language && target_args.len == 0
-			&& !c_compiler_explicit && !cache_state.manager.enabled {
+			&& (!c_compiler_explicit || explicit_tcc) && !cache_state.manager.enabled {
 			tried_tcc = true
 			tcc_dir := os.join_path_single(os.join_path_single(prefs.vroot, 'thirdparty'), 'tcc')
-			tcc_path := os.join_path_single(tcc_dir, 'tcc.exe')
+			bundled_tcc_path := os.join_path_single(tcc_dir, 'tcc.exe')
+			tcc_path := if explicit_tcc && c_compiler in ['tcc', 'tinyc']
+				&& os.is_executable(bundled_tcc_path) {
+				bundled_tcc_path
+			} else if explicit_tcc {
+				c_compiler
+			} else {
+				bundled_tcc_path
+			}
 			tcc_lib_dir := os.join_path_single(tcc_dir, 'lib')
 			tcc_includes := '-I${os.join_path_single(tcc_lib_dir, 'include')}'
 			tcc_lib := '-L${tcc_lib_dir}'
@@ -2781,7 +2912,7 @@ fn expand_single_test_file_inputs(user_files []string, prefs &pref.Preferences) 
 	for file in user_files {
 		if pref.is_test_file_for_backend(file, prefs.backend) {
 			module_name := declared_module_in_file(file)
-			if module_name.len > 0 && module_name != 'builtin' {
+			if module_name != 'builtin' {
 				for module_file in same_dir_module_source_files(file, module_name, prefs) {
 					append_unique_file(mut expanded, mut seen, module_file)
 				}
@@ -2794,13 +2925,93 @@ fn expand_single_test_file_inputs(user_files []string, prefs &pref.Preferences) 
 
 fn same_dir_module_source_files(test_file string, module_name string, prefs &pref.Preferences) []string {
 	dir := os.dir(test_file)
+	all_files := pref.get_v_files_from_dir_for_target(dir, prefs.user_defines, prefs.target)
 	mut files := []string{}
-	for file in pref.get_v_files_from_dir_for_target(dir, prefs.user_defines, prefs.target) {
-		if declared_module_in_file(file) == module_name {
+	mut imported_modules := map[string]bool{}
+	if module_name.len > 0 {
+		for file in all_files {
+			declared_module := declared_module_in_file(file)
+			// Omitting a module declaration means `main`. A test that spells
+			// `module main` explicitly still needs its module-less tool siblings.
+			if declared_module != module_name && !(module_name == 'main'
+				&& declared_module.len == 0) {
+				continue
+			}
+			files << file
+			for imported in declared_imports_in_file(file) {
+				imported_modules[imported] = true
+			}
+		}
+	} else {
+		// A module-less test is a standalone `main` file. Do not pull every other
+		// module-less tool in its directory into the same program.
+		for imported in declared_imports_in_file(test_file) {
+			imported_modules[imported] = true
+		}
+	}
+	// V permits a small project fixture to put an imported module beside its
+	// main/test files. Include those directly imported, differently-declared
+	// files in the initial parse so resolving `import localmod` sees the same
+	// sources as the regular compiler.
+	for file in all_files {
+		if file in files {
+			continue
+		}
+		if imported_modules[declared_module_in_file(file)] {
 			files << file
 		}
 	}
 	return files
+}
+
+fn declared_imports_in_file(path string) []string {
+	source := os.read_file(path) or { return []string{} }
+	mut imports := []string{}
+	mut in_group := false
+	for raw_line in source.split_into_lines() {
+		mut line := raw_line.trim_space()
+		if comment := line.index('//') {
+			line = line[..comment].trim_space()
+		}
+		if line.len == 0 {
+			continue
+		}
+		if in_group {
+			if line.starts_with(')') {
+				in_group = false
+				continue
+			}
+			append_declared_import(mut imports, line)
+			continue
+		}
+		if !line.starts_with('import ') {
+			continue
+		}
+		line = line[7..].trim_space()
+		if line.starts_with('(') {
+			in_group = true
+			line = line[1..].trim_space()
+			if line.len == 0 {
+				continue
+			}
+		}
+		append_declared_import(mut imports, line)
+	}
+	return imports
+}
+
+fn append_declared_import(mut imports []string, line string) {
+	mut end := 0
+	for end < line.len && line[end] !in [` `, `\t`, `{`, `,`, `)`] {
+		end++
+	}
+	if end == 0 {
+		return
+	}
+	name := line[..end]
+	if name !in imports {
+		imports << name
+	}
 }
 
 fn append_unique_file(mut files []string, mut seen map[string]bool, file string) {
@@ -3368,6 +3579,7 @@ fn resolve_imports(mut a flat.FlatAst, mut p parser.Parser, prefs &pref.Preferen
 	parsed_modules['builtin'] = true
 	parsed_modules['main'] = true
 	seed_initial_modules(a, initial_files, mut parsed_modules)
+	explicit_initial_imports := imports_from_files(a, initial_files)
 
 	// Backend modules excluded by the active configuration are never parsed: their
 	// dispatch in main() is gated out by the matching `$if !skip_* ?`, so nothing
@@ -3376,7 +3588,9 @@ fn resolve_imports(mut a flat.FlatAst, mut p parser.Parser, prefs &pref.Preferen
 	// import pulls them in. Skipping the arm64 group (v3.gen.arm64 + the v3.ssa SSA
 	// pipeline) and the wasm/eval backends avoids ~30k lines of work when self-hosting.
 	for skipped in skipped_backend_modules(prefs) {
-		parsed_modules[skipped] = true
+		if skipped !in explicit_initial_imports {
+			parsed_modules[skipped] = true
+		}
 	}
 
 	mut first_file := ''
@@ -3692,6 +3906,30 @@ fn seed_initial_modules(a &flat.FlatAst, initial_files []string, mut parsed_modu
 			parsed_modules[module_name] = true
 		}
 	}
+}
+
+fn imports_from_files(a &flat.FlatAst, files []string) map[string]bool {
+	mut selected_files := map[string]bool{}
+	for file in files {
+		selected_files[file] = true
+		selected_files[os.real_path(file)] = true
+	}
+	mut imports := map[string]bool{}
+	for file_idx, file_node in a.nodes {
+		if file_idx < a.user_code_start || file_node.kind != .file || file_node.value.len == 0 {
+			continue
+		}
+		if !selected_files[file_node.value] && !selected_files[os.real_path(file_node.value)] {
+			continue
+		}
+		for i in 0 .. file_node.children_count {
+			child := a.child_node(&file_node, i)
+			if child.kind == .import_decl && child.value.len > 0 {
+				imports[child.value] = true
+			}
+		}
+	}
+	return imports
 }
 
 fn canonicalize_imported_module_name(mut a flat.FlatAst, first_node int, end_node int, import_path string) {

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -2933,10 +2933,7 @@ fn same_dir_module_source_files(test_file string, module_name string, prefs &pre
 	if module_name.len > 0 {
 		for file in all_files {
 			declared_module := declared_module_in_file(file)
-			// Omitting a module declaration means `main`. A test that spells
-			// `module main` explicitly still needs its module-less tool siblings.
-			if declared_module != module_name && !(module_name == 'main'
-				&& declared_module.len == 0) {
+			if declared_module != module_name {
 				continue
 			}
 			files << file

--- a/vlib/v3/v3_test_passes.txt
+++ b/vlib/v3/v3_test_passes.txt
@@ -47,7 +47,6 @@ cmd/tools/vtimeout_test.v
 cmd/tools/vvet/vet_test.v
 cmd/tools/vwatch_test.v
 cmd/tools/vwhere/vwhere_test.v
-cmd/v/v2_test.v
 cmd/v/vvm_test.v
 examples/dynamic_library_loader/use_test.v
 examples/dynamic_library_loading/use_library_test.v
@@ -618,7 +617,6 @@ vlib/v/ast/cflags_test.v
 vlib/v/ast/table_test.v
 vlib/v/ast/types_test.v
 vlib/v/build_constraint/constraint_test.v
-vlib/v/builder/interpreterbuilder/v_interpret_test.v
 vlib/v/builder/parallel_cc_failure_test.v
 vlib/v/cflag/cflags_test.v
 vlib/v/compiler_errors_test.v
@@ -632,12 +630,6 @@ vlib/v/embed_file/tests/embed_file_to_string_test.v
 vlib/v/embed_file/tests/embed_file_with_import_test.v
 vlib/v/embed_file/tests/embed_file_with_variable_arg_test.v
 vlib/v/embed_file/tests/embed_v_logo_using_vexeroot_test.v
-vlib/v/eval/interpret_test.v
-vlib/v/eval/tests/comptime_if_test.v
-vlib/v/eval/tests/const_test.v
-vlib/v/eval/tests/func_call_test.v
-vlib/v/eval/tests/if_test.v
-vlib/v/eval/tests/push_val_test.v
 vlib/v/gen/c/autofree_labeled_continue_boehm_leak_test.v
 vlib/v/gen/c/autofree_labeled_continue_codegen_test.v
 vlib/v/gen/c/cheaders_manual_stdlib_decls_test.v
@@ -1505,7 +1497,6 @@ vlib/v/tests/enums/short_enum_syntax_across_module_test.v
 vlib/v/tests/enums/vargs_with_enum_value_test.v
 vlib/v/tests/error_sentinel_test.v
 vlib/v/tests/error_void_test.v
-vlib/v/tests/eval_shared_library_tcc_test.v
 vlib/v/tests/failing_tests_test.v
 vlib/v/tests/filtering_tests/filtering_android_outside_termux_test.v
 vlib/v/tests/filtering_tests/filtering_macos_test.v
@@ -2686,10 +2677,6 @@ vlib/v/util/vflags/vflags_test.v
 vlib/v/vcache/vcache_test.v
 vlib/v/vmod/encoder_test.v
 vlib/v/vmod/parser_test.v
-vlib/v2/ssa/array_init_elem_type_tracking_test.v
-vlib/v2/ssa/selector_module_shadow_test.v
-vlib/v2/ssa/sumtype_address_wrap_test.v
-vlib/v2/transformer/sumtype_wrap_regression_test.v
 vlib/v3/eval/eval_test.v
 vlib/v3/gen/c/names_test.v
 vlib/v3/markused/custom_str_test.v
@@ -2782,7 +2769,6 @@ vlib/veb/tests/memory_leak_test.v
 vlib/veb/tests/persistent_connection_test.v
 vlib/veb/tests/ssl_test.v
 vlib/veb/tests/static_handler_test.v
-vlib/veb/tests/use_openssl_no_mbedtls_test.v
 vlib/veb/tests/veb_app_test.v
 vlib/veb/tests/veb_test.v
 vlib/veb/tr_test.v


### PR DESCRIPTION
## Summary

- restore V3 checker, transformer, mark-used, parser, and C backend support for constructs exercised by the compilation allowlist
- preserve file-local import aliases during serial C generation, fix pointer/local selector handling, and support delegated `.vvmrc` execution
- remove 14 stale entries whose source files no longer exist, leaving 2,852 unique existing allowlist paths

## Why

Recent V3 changes exposed 233 compilation regressions in `vlib/v3/v3_test_passes.txt`. The failures came from missing or inconsistent type propagation and lowering paths, plus symbol resolution that could select an import alias from the wrong source file during serial C generation.

## Impact

All 2,852 entries in the V3 compilation allowlist now compile. The V3-driven runtime sweep has no failures among runnable tests.

## Validation

- rebuilt `vnew` with `./v -g -keepc -o ./vnew cmd/v`
- rebuilt V3 with `VJOBS=2 ./vnew -gc none -path vlib -o ./v3_test_compiler vlib/v3/v3.v`
- full V3 allowlist compilation sweep: 2,852/2,852 passed
- V3-driven runtime sweep: 2,825 passed, 27 intentional platform/toolchain skips, 0 failed
- `VJOBS=2 ./vnew test vlib/v3/gen/c/stmt_test.v`: 1 passed
- V3-hosted `vlib/gg/m4/m4_test.v` and `cmd/v/vvm_test.v`: 2 passed
- `VJOBS=2 ./vnew -silent vlib/v/compiler_errors_test.v`: 1,592 passed, 1 skipped
- `git diff --check`

## Additional audit

A separate V2-hosted run of the 77 V3 meta-test files reported 52 passed and 25 failed. That is a broader harness mode than the V3 compilation allowlist and is not claimed as fixed by this PR.