### PR TITLE
cgen: skip _v_type_idx_ emission for invalid-C-identifier cnames (fix v build-module vlib/orm)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -666,6 +666,15 @@ pub fn gen(files []&ast.File, mut table ast.Table, pref_ &pref.Preferences) GenO
 				// Temporary hack to make toml work with -usecache TODO remove
 				continue
 			}
+			if sym.cname.contains('[') {
+				// Anonymous sum-type symbols (e.g. ORM's `[]Primitive | []bool | …`)
+				// carry a cname with literal `[]`, which is not a valid C identifier —
+				// emitting it produces uncompilable C and broke `v build-module` for any
+				// module importing orm (cx #520). Such a cname can never be *referenced*
+				// through `_v_type_idx_<cname>()` either (the call site would be equally
+				// invalid C), so skipping the emission loses nothing.
+				continue
+			}
 			if sym.cname in emitted_cache_type_idx_cnames {
 				continue
 			}
@@ -679,6 +688,10 @@ pub fn gen(files []&ast.File, mut table ast.Table, pref_ &pref.Preferences) GenO
 				continue
 			}
 			if is_toml && sym.cname.contains('map[string]') {
+				continue
+			}
+			if sym.cname.contains('[') {
+				// See the build_module loop above — invalid-C-identifier cnames (cx #520).
 				continue
 			}
 			if sym.cname in emitted_cache_type_idx_cnames {


### PR DESCRIPTION
## Problem

`v build-module vlib/orm` (and `build-module` of any module importing orm) fails with a C compilation error on current master:

```
cc: error: expected ';' after top level declarator
u32 _v_type_idx_orm__[]orm__Primitive___orm__[]bool___orm__[]f32___...(); // 1build module vlib/orm
```

Anonymous sum-type symbols (orm's `[]Primitive | []bool | …` family) carry a cname containing literal `[]` — not a valid C identifier — and the build-module / -usecache type-idx emission writes it verbatim into the helper declaration.

## Fix

Skip `_v_type_idx_` emission for cnames containing `[`, in both emission loops. Such a cname can never be *referenced* through `_v_type_idx_<cname>()` either (the call site would be equally invalid C), so the skip loses nothing.

## Verification

- Before: `./v build-module vlib/orm` → the C error above. After: builds clean.
- `./v test vlib/orm` → 38/38 passed.
- (The separate `-usecache` duplicate-symbols link failure on hello_world reproduces identically on unpatched master — pre-existing and unrelated to this change.)