### PR TITLE
net.http: add H1StreamConn plumbing for pooled Windows h1 connections

### DIFF
--- a/vlib/net/http/transport.v
+++ b/vlib/net/http/transport.v
@@ -6,6 +6,7 @@ module http
 
 import net
 import net.ssl
+import strings
 import sync
 import time
 
@@ -23,14 +24,82 @@ import time
 // loop. is_no_need_retry_error recognizes this code so the outer loop honors it.
 const transport_err_unsafe_retry = -20013
 
+// H1StreamConn abstracts a platform-specific streaming h1 connection that can
+// be pooled the same way H1PooledConn already pools ssl.SSLConn/net.TcpConn —
+// currently implemented only by VSchannelPooledTransport
+// (vschannel_pooled_transport_windows.c.v), for native-Windows h1 pooling.
+// Kept separate from H2Transport (h2_conn.v) even though read/write have the
+// same shape: h1 pooling needs a per-request read/write timeout knob that
+// H2Transport's multiplexed background reader has no use for, and h2_conn.v
+// documents H2Transport as deliberately minimal for testability.
+interface H1StreamConn {
+mut:
+	read(mut buf []u8) !int
+	write(buf []u8) !int
+	close()
+	set_timeouts(read_timeout time.Duration, write_timeout time.Duration)
+}
+
+// H1StreamConnBox lets a boxed H1StreamConn interface value be threaded
+// through receive_all_data_from_cb_in_builder's voidptr+FnReceiveChunk
+// callback convention (request.v), the same convention read_from_ssl_connection_cb/
+// read_from_tcp_connection_cb already use for their own concrete connection
+// types. A concrete box struct is used instead of casting a raw voidptr
+// directly back to &H1StreamConn: an interface value is a fat pointer
+// (type tag + data + method table), and reinterpreting arbitrary bytes as one
+// via unsafe cast would be undefined behavior — boxing it in an ordinary,
+// single-field struct keeps the voidptr round-trip a plain pointer
+// reinterpret, exactly like the existing ssl.SSLConn/net.TcpConn callbacks.
+struct H1StreamConnBox {
+mut:
+	conn H1StreamConn
+}
+
+// read_from_h1stream_cb is the H1StreamConn FnReceiveChunk adapter (see
+// H1StreamConnBox), the h1-pool counterpart of read_from_ssl_connection_cb/
+// read_from_tcp_connection_cb.
+fn read_from_h1stream_cb(con voidptr, buf &u8, bufsize int) !int {
+	mut box := unsafe { &H1StreamConnBox(con) }
+	mut bytes := unsafe { buf.vbytes(bufsize) }
+	return box.conn.read(mut bytes)
+}
+
+// h1_exchange_stream runs one request/response over a pooled H1StreamConn,
+// leaving it open. Mirrors h1_exchange_ssl/h1_exchange_tcp exactly, sharing
+// the same response-framing implementation via receive_all_data_from_cb_in_builder.
+fn (req &Request) h1_exchange_stream(mut conn H1StreamConn, raw string) !(Response, bool) {
+	conn.write(raw.bytes()) or {
+		return error('http.transport: connection write failed: ${err.msg()}')
+	}
+	mut content := strings.new_builder(4096)
+	mut box := &H1StreamConnBox{
+		conn: conn
+	}
+	response_info := req.receive_all_data_from_cb_in_builder(mut content, voidptr(box),
+		read_from_h1stream_cb)!
+	response_text := content.str()
+	$if trace_http_response ? {
+		eprint('< ')
+		eprint(response_text)
+		eprintln('')
+	}
+	if req.on_finish != unsafe { nil } {
+		req.on_finish(req, u64(response_text.len))!
+	}
+	resp := parse_received_response(response_text, response_info)!
+	return resp, response_info.reusable
+}
+
 // H1PooledConn is one keep-alive HTTP/1.1 connection in a Transport pool:
-// either a plain TCP connection or a TLS one (exactly one of the two is set).
+// exactly one of tcp/ssl/vsc is set — a plain TCP connection, an mbedTLS/
+// OpenSSL TLS one, or (native Windows only) a pooled SChannel connection.
 @[heap]
 struct H1PooledConn {
 mut:
 	key        string
 	tcp        &net.TcpConn = unsafe { nil }
 	ssl        &ssl.SSLConn = unsafe { nil }
+	vsc        ?H1StreamConn
 	idle_since time.Time
 }
 
@@ -44,6 +113,10 @@ fn (mut c H1PooledConn) close_conn() {
 		c.tcp.close() or {}
 		c.tcp = unsafe { nil }
 	}
+	if mut v := c.vsc {
+		v.close()
+		c.vsc = none
+	}
 }
 
 // refresh_timeouts applies the current request's timeouts to a pooled
@@ -56,6 +129,15 @@ fn (mut c H1PooledConn) refresh_timeouts(req &Request) {
 		if req.read_timeout > 0 {
 			c.ssl.set_read_timeout(req.read_timeout)
 		}
+	} else if mut v := c.vsc {
+		// Unlike the ssl branch above (read-only, guarded on > 0 — 0 there
+		// means "leave whatever timeout this connection already has"), both
+		// directions are applied unconditionally here: SO_RCVTIMEO/SO_SNDTIMEO
+		// are independent Winsock options where 0 has its own well-defined
+		// meaning ("block indefinitely"), so forwarding it is correct, not a
+		// missing guard — matching the tcp branch's convention (also
+		// unconditional, both directions) rather than ssl's.
+		v.set_timeouts(req.read_timeout, req.write_timeout)
 	}
 }
 
@@ -65,6 +147,9 @@ fn (mut c H1PooledConn) refresh_timeouts(req &Request) {
 fn (mut c H1PooledConn) exchange(req &Request, raw string) !(Response, bool) {
 	if c.ssl != unsafe { nil } {
 		return req.h1_exchange_ssl(mut c.ssl, raw)
+	}
+	if mut v := c.vsc {
+		return req.h1_exchange_stream(mut v, raw)
 	}
 	return req.h1_exchange_tcp(mut c.tcp, raw)
 }

--- a/vlib/net/http/vschannel_pooled_transport_windows.c.v
+++ b/vlib/net/http/vschannel_pooled_transport_windows.c.v
@@ -31,25 +31,39 @@ mut:
 	ctx    C.TlsContext
 	io_mu  &sync.Mutex = sync.new_mutex()
 	closed bool
+	// write_stall_limit is how long write() waits for the socket to become
+	// writable before failing the connection — set alongside the SO_RCVTIMEO/
+	// SO_SNDTIMEO pair by set_timeouts(), so an h1-pool caller (a per-request
+	// req.write_timeout, no multiplexed reader to keep responsive) and an
+	// h2-pool caller (the fixed h2_pooled_write_stall_limit budget) each get
+	// the value appropriate to how the connection is being used.
+	write_stall_limit time.Duration = h2_pooled_write_stall_limit
 }
 
 fn C.vschannel_set_io_timeouts(tls_ctx &C.TlsContext, recv_timeout_ms u32, send_timeout_ms u32)
 fn C.vschannel_wait_writable(tls_ctx &C.TlsContext, timeout_ms int) int
 
 // new_vschannel_pooled_transport dials host:port over SChannel, advertising
-// ALPN h2/http/1.1, and wraps the open connection for pooled H2MuxConn use.
-// Mirrors vschannel_h2_do's connect sequence (vschannel_h2_windows.c.v), but
-// leaves ALPN-selection branching to the caller (h2_dial_probe_vschannel)
-// instead of driving the h2-vs-h1 fork itself, since the caller also needs
-// the h1 fallback to go through the one-shot path, not this adapter.
-fn new_vschannel_pooled_transport(req &Request, host string, port int) !&VSchannelPooledTransport {
+// `alpn_protocols` (skipped entirely when empty, matching the original
+// one-shot vschannel_h1_do's no-ALPN dial), and wraps the open connection for
+// pooled use — either as an H2Transport (H2MuxConn, when ALPN selects h2) or
+// as an H1StreamConn (H1PooledConn, plain h1 pooling — transport.v). Mirrors
+// vschannel_h2_do's connect sequence (vschannel_h2_windows.c.v), but leaves
+// ALPN-selection branching to the caller instead of driving the h2-vs-h1 fork
+// itself, since different callers do different things with a non-h2 result
+// (h2_dial_probe_vschannel hands the connection back for h1 reuse;
+// vschannel_fresh_round_trip never advertises h2 at all when the request
+// doesn't want it).
+fn new_vschannel_pooled_transport(host string, port int, validate bool, alpn_protocols []string, read_timeout time.Duration, write_timeout time.Duration) !&VSchannelPooledTransport {
 	mut t := &VSchannelPooledTransport{
 		ctx: C.new_tls_context()
 	}
 	C.vschannel_use_tls12_client_protocol()
-	C.vschannel_init(&t.ctx, C.BOOL(if req.validate { 1 } else { 0 }))
-	wire := alpn_wire(['h2', 'http/1.1'])
-	C.vschannel_set_alpn(&t.ctx, &char(wire.data), wire.len)
+	C.vschannel_init(&t.ctx, C.BOOL(if validate { 1 } else { 0 }))
+	if alpn_protocols.len > 0 {
+		wire := alpn_wire(alpn_protocols)
+		C.vschannel_set_alpn(&t.ctx, &char(wire.data), wire.len)
+	}
 	if C.vschannel_h2_connect(&t.ctx, port, host.to_wide()) != 0 {
 		err_code := C.vschannel_last_error(&t.ctx)
 		C.vschannel_cleanup(&t.ctx)
@@ -58,13 +72,24 @@ fn new_vschannel_pooled_transport(req &Request, host string, port int) !&VSchann
 		}
 		return error('http: vschannel connect failed')
 	}
-	// Unlike mbedTLS/OpenSSL (one shared duration field reused for both
-	// directions' internal retry loop, needing widen-then-restore around
-	// every write -- see h2_pooled_transport.v), SO_RCVTIMEO/SO_SNDTIMEO are
-	// independent Winsock options: set once here, never touched again.
-	C.vschannel_set_io_timeouts(&t.ctx, u32(h2_pooled_io_timeout / time.millisecond),
-		u32(h2_pooled_write_stall_limit / time.millisecond))
+	t.set_timeouts(read_timeout, write_timeout)
 	return t
+}
+
+// set_timeouts (re)applies the pooled connection's socket-level read/write
+// timeouts and write()'s stall budget together. Unlike mbedTLS/OpenSSL (one
+// shared duration field reused for both directions' internal retry loop,
+// needing widen-then-restore around every write -- see h2_pooled_transport.v),
+// SO_RCVTIMEO/SO_SNDTIMEO are independent Winsock options that stay in effect
+// until changed again. Called once at dial time with the caller's intended
+// timeouts, and again by h2_dial_probe_vschannel when repurposing a probe
+// connection dialed for h2 (short poll reads, long write stall) for h1
+// pooling (a per-request read_timeout, no multiplexed reader to keep
+// responsive) instead of dialing a second time.
+fn (mut t VSchannelPooledTransport) set_timeouts(read_timeout time.Duration, write_timeout time.Duration) {
+	t.write_stall_limit = write_timeout
+	C.vschannel_set_io_timeouts(&t.ctx, u32(read_timeout / time.millisecond),
+		u32(write_timeout / time.millisecond))
 }
 
 // negotiated_alpn returns the protocol SChannel selected during the
@@ -123,7 +148,7 @@ fn (mut t VSchannelPooledTransport) write(buf []u8) !int {
 	if buf.len == 0 {
 		return 0
 	}
-	deadline := time.now().add(h2_pooled_write_stall_limit)
+	deadline := time.now().add(t.write_stall_limit)
 	for {
 		ready := C.vschannel_wait_writable(&t.ctx, int(h2_pooled_poll_interval / time.millisecond))
 		if ready < 0 {
@@ -139,7 +164,7 @@ fn (mut t VSchannelPooledTransport) write(buf []u8) !int {
 			return error('vschannel pooled transport: closed')
 		}
 		if time.now() >= deadline {
-			return error('vschannel pooled transport: write stalled for ${h2_pooled_write_stall_limit}')
+			return error('vschannel pooled transport: write stalled for ${t.write_stall_limit}')
 		}
 	}
 	t.io_mu.lock()
@@ -196,7 +221,8 @@ fn h2_dial_probe_vschannel(req &Request, host string, port int) !H2ProbeResult {
 			is_h2: false
 		}
 	}
-	mut t := new_vschannel_pooled_transport(req, host, port)!
+	mut t := new_vschannel_pooled_transport(host, port, req.validate, ['h2', 'http/1.1'],
+		h2_pooled_io_timeout, h2_pooled_write_stall_limit)!
 	if t.negotiated_alpn() != 'h2' {
 		t.close()
 		return H2ProbeResult{

--- a/vlib/net/http/vschannel_pooled_transport_windows_test.v
+++ b/vlib/net/http/vschannel_pooled_transport_windows_test.v
@@ -100,7 +100,8 @@ fn vpt_start_listener() (int, &mbedtls.SSLListener) {
 fn test_vschannel_pooled_transport_stable_address() {
 	port, mut listener := vpt_start_listener()
 	th := spawn vpt_echo_loop(mut listener)
-	mut t := new_vschannel_pooled_transport(&Request{ validate: false }, '127.0.0.1', port) or {
+	mut t := new_vschannel_pooled_transport('127.0.0.1', port, false, ['h2', 'http/1.1'],
+		h2_pooled_io_timeout, h2_pooled_write_stall_limit) or {
 		assert false, 'connect: ${err}'
 		return
 	}
@@ -124,7 +125,8 @@ fn test_vschannel_pooled_transport_concurrent_read_write_close() {
 	for round in 0 .. 3 {
 		port, mut listener := vpt_start_listener()
 		th := spawn vpt_echo_loop(mut listener)
-		mut t := new_vschannel_pooled_transport(&Request{ validate: false }, '127.0.0.1', port) or {
+		mut t := new_vschannel_pooled_transport('127.0.0.1', port, false, ['h2', 'http/1.1'],
+			h2_pooled_io_timeout, h2_pooled_write_stall_limit) or {
 			assert false, 'round ${round}: connect: ${err}'
 			return
 		}
@@ -150,7 +152,8 @@ fn test_vschannel_pooled_transport_concurrent_read_write_close() {
 fn test_vschannel_pooled_transport_read_times_out() {
 	port, mut listener := vpt_start_listener()
 	th := spawn vpt_echo_loop(mut listener)
-	mut t := new_vschannel_pooled_transport(&Request{ validate: false }, '127.0.0.1', port) or {
+	mut t := new_vschannel_pooled_transport('127.0.0.1', port, false, ['h2', 'http/1.1'],
+		h2_pooled_io_timeout, h2_pooled_write_stall_limit) or {
 		assert false, 'connect: ${err}'
 		return
 	}
@@ -186,7 +189,8 @@ fn test_vschannel_pooled_transport_write_survives_stall_past_io_timeout() {
 		sconn.shutdown() or {}
 	}(mut listener)
 
-	mut t := new_vschannel_pooled_transport(&Request{ validate: false }, '127.0.0.1', port) or {
+	mut t := new_vschannel_pooled_transport('127.0.0.1', port, false, ['h2', 'http/1.1'],
+		h2_pooled_io_timeout, h2_pooled_write_stall_limit) or {
 		assert false, 'connect: ${err}'
 		return
 	}


### PR DESCRIPTION
## Summary
- Part 1/2 of pooling HTTP/1.1 keep-alive connections over the native Windows SChannel backend (#27879). Today h2 traffic is pooled (#27712) but h1-only requests still pay a fresh dial+handshake per call.
- Introduces the `H1StreamConn` interface and a third `H1PooledConn` variant for it, generalizes `new_vschannel_pooled_transport`'s ALPN/timeout params, and adds `VSchannelPooledTransport.set_timeouts()`.
- Pure plumbing: nothing yet constructs an `H1PooledConn.vsc`, so behavior is unchanged on every platform. Stacked PR #2 (h1-vschannel-pool-wiring) wires it into the actual request paths.

## Test plan
- [x] `./vnew -check -shared vlib/net/http/` clean, both with and without `-d no_vschannel`
- [x] Full `vlib/net/http` suite green natively (real SChannel backend)
- [x] Full `vlib/net/http` suite green with `-d no_vschannel` (mbedTLS/OpenSSL, confirming zero behavior change there)

🧙 Built with [WOZCODE](https://wozcode.com)