### PR TITLE
net.http: pool HTTP/1.1 keep-alive connections over the Windows SChannel backend

### DIFF
--- a/vlib/net/http/backend_vschannel_d_cross.v
+++ b/vlib/net/http/backend_vschannel_d_cross.v
@@ -7,3 +7,7 @@ fn vschannel_ssl_do(_req &Request, _port int, _method Method, _host_name string,
 fn h2_dial_probe_vschannel(_req &Request, _host string, _port int) !H2ProbeResult {
 	return error('vschannel is unavailable in cross C generation')
 }
+
+fn (mut t Transport) vschannel_fresh_round_trip(_req &Request, _key string, _raw string, _method Method, _host string, _port int, _path string, _data string, _header Header) !Response {
+	return error('vschannel is unavailable in cross C generation')
+}

--- a/vlib/net/http/transport.v
+++ b/vlib/net/http/transport.v
@@ -527,25 +527,6 @@ fn (mut t Transport) maybe_checkin(mut conn H1PooledConn, header Header, reusabl
 // retrying once on a connection that turned out to be stale), dials otherwise,
 // and returns healthy connections to the pool afterwards.
 fn (mut t Transport) round_trip(req &Request, method Method, scheme string, host string, port int, path string, data string, header Header) !Response {
-	$if windows && !no_vschannel ? {
-		if scheme == 'https' {
-			mut go_one_shot := !req.enable_http2
-			if !go_one_shot {
-				key0 := transport_pool_key(req, scheme, host, port)
-				t.mu.lock()
-				proto0 := t.key_proto[key0] or { 0 }
-				t.mu.unlock()
-				// An origin already proven http/1.1-only: h1-over-vschannel
-				// pooling is out of scope, so keep the proven one-shot path.
-				go_one_shot = proto0 == 1
-			}
-			if go_one_shot {
-				return req.ssl_do(port, method, host, path, data, header)
-			}
-			// h2-enabled and not yet known to be h1-only: fall through to the
-			// pooled h2 path below, same as every other platform.
-		}
-	}
 	raw := req.build_request_headers_opts(method, host, port, path, data, header, false)
 	$if trace_http_request ? {
 		eprint('> ')
@@ -622,6 +603,9 @@ fn (mut t Transport) dial_h1_tcp(req &Request, key string, host string, port int
 // connection is not pooled yet; an http/1.1 connection is pooled afterwards
 // like any other.
 fn (mut t Transport) tls_fresh_round_trip(req &Request, key string, raw string, method Method, host string, port int, path string, data string, header Header) !Response {
+	$if windows && !no_vschannel ? {
+		return t.vschannel_fresh_round_trip(req, key, raw, method, host, port, path, data, header)
+	}
 	alpn := if req.enable_http2 { ['h2', 'http/1.1'] } else { []string{} }
 	mut ssl_conn := ssl.new_ssl_conn(
 		verify:                 req.verify

--- a/vlib/net/http/transport_h2.v
+++ b/vlib/net/http/transport_h2.v
@@ -131,11 +131,17 @@ struct H2ProbeResult {
 	closer    ?H2TransportCloser // set only when is_h2
 	// ssl_probe carries the still-open probe connection when ALPN did not
 	// select h2, so the caller can complete its own request over it directly
-	// instead of dialing again -- mbedTLS/OpenSSL only. On native Windows,
-	// h2_dial_probe_vschannel closes its own probe before returning (h1-over-
-	// vschannel pooling is out of scope), so this stays nil there and the
-	// caller falls back to the one-shot req.ssl_do instead.
+	// instead of dialing again -- mbedTLS/OpenSSL only.
 	ssl_probe &ssl.SSLConn = unsafe { nil }
+	// vsc_probe is ssl_probe's native-Windows counterpart: the still-open,
+	// ALPN-probed VSchannelPooledTransport, handed back for h1 reuse the same
+	// way ssl_probe is. A separate Option field rather than widening ssl_probe
+	// itself, since VSchannelPooledTransport doesn't satisfy ssl.SSLConn's
+	// concrete type -- it satisfies H1StreamConn instead (transport.v). Stays
+	// none when there is no reusable probe connection at all (pre-Windows-8.1,
+	// where h2_dial_probe_vschannel reports h1-only without ever dialing), in
+	// which case the caller falls back to a fresh dial via h2_fallback_h1.
+	vsc_probe ?H1StreamConn
 }
 
 // h2_dial_probe performs the ALPN-probing dial itself, branching on the TLS
@@ -181,17 +187,14 @@ fn h2_dial_probe_ssl(req &Request, host string, port int) !H2ProbeResult {
 
 // h2_fallback_h1 completes a request already known to be against an h1-only
 // origin, when there is no still-open probe connection to reuse (a waiter
-// behind someone else's dial, or -- on native Windows -- the dialer itself,
-// since h2_dial_probe_vschannel always closes its own probe rather than
-// leaving it open for h1-over-vschannel reuse, which is out of scope). On
-// native Windows this routes to the proven one-shot SChannel path instead of
-// h2_use_h1_pool_or_dial, which falls back to tls_fresh_round_trip -- an
-// mbedTLS/OpenSSL dial that would silently switch TLS backends for this
-// fallback if used here.
+// behind someone else's dial, or a dialer whose probe found no ALPN result to
+// hand back -- e.g. pre-Windows-8.1 SChannel, which reports h1-only without
+// ever dialing at all: see h2_dial_probe_vschannel). Falls back to
+// h2_use_h1_pool_or_dial's existing pooled-or-dial-fresh path, which is
+// itself platform-aware via tls_fresh_round_trip (native Windows dials
+// through vschannel_fresh_round_trip there, never silently switching TLS
+// backends).
 fn (mut t Transport) h2_fallback_h1(req &Request, key string, raw string, method Method, host string, port int, path string, data string, header Header) !Response {
-	$if windows && !no_vschannel ? {
-		return req.ssl_do(port, method, host, path, data, header)
-	}
 	return t.h2_use_h1_pool_or_dial(req, key, raw, method, host, port, path, data, header)
 }
 
@@ -281,10 +284,33 @@ fn (mut t Transport) h2_dial_and_do(req &Request, key string, raw string, method
 		call.done = true
 		call.mu.unlock()
 		call.cv.broadcast()
+		if mut vp := probe.vsc_probe {
+			// Native Windows: the probe's still-open connection is reused
+			// directly as a pooled h1 connection, the same way the ssl_probe
+			// branch below does for mbedTLS/OpenSSL.
+			mut conn := &H1PooledConn{
+				key: key
+				vsc: vp
+			}
+			resp, reusable := conn.exchange(req, raw) or {
+				conn.close_conn()
+				// Past the TLS handshake the request bytes may have been
+				// (partially) written; a non-idempotent method must not be
+				// replayed by the outer retry loop, mirroring
+				// tls_fresh_round_trip's own error handling.
+				if !transport_is_idempotent(method) {
+					return error_with_code(err.msg(), transport_err_unsafe_retry)
+				}
+				return err
+			}
+			t.maybe_checkin(mut conn, header, reusable, resp)
+			return resp
+		}
 		if probe.ssl_probe == unsafe { nil } {
-			// Native Windows: the probe already closed itself (h1-over-
-			// vschannel pooling is out of scope). Complete this caller's own
-			// request the same way a waiter behind this dial would.
+			// No reusable probe connection at all -- pre-Windows-8.1 SChannel
+			// reports h1-only without ever dialing (see
+			// h2_dial_probe_vschannel). Complete this caller's own request
+			// the same way a waiter behind this dial would.
 			return t.h2_fallback_h1(req, key, raw, method, host, port, path, data, header)
 		}
 		mut ssl_probe := probe.ssl_probe

--- a/vlib/net/http/transport_h2_test.v
+++ b/vlib/net/http/transport_h2_test.v
@@ -318,10 +318,6 @@ fn start_h2t_h1only_srv(mut s H2PoolSrv) !(int, &mbedtls.SSLListener, thread) {
 // delayed, N concurrent requests running in parallel finish in roughly one
 // delay; serialized behind one response they would take roughly two.
 fn test_h2_pool_alpn_fallback_avoids_hol_blocking() {
-	$if windows && !no_vschannel ? {
-		eprintln('skipping: exercises the h1-pool-reuse-after-ALPN-probe path, which is mbedTLS/OpenSSL-only by design (h1-over-vschannel pooling is out of scope)')
-		return
-	}
 	mut srv := &H2PoolSrv{
 		respond_delay: 400 * time.millisecond
 	}
@@ -352,38 +348,17 @@ fn test_h2_pool_alpn_fallback_avoids_hol_blocking() {
 	assert elapsed < 1200 * time.millisecond, 'expected concurrent requests to a fresh h1-only origin to run in parallel (~1 respond_delay), not serialize behind one dialer response; took ${elapsed}'
 }
 
-// An h2-enabled request to an h1-only origin must still succeed via the
-// one-shot req.ssl_do fallback on native Windows (h2_fallback_h1) -- since
-// h1-over-vschannel pooling is out of scope, VSchannelPooledTransport is
-// never involved once ALPN negotiates http/1.1, but the request itself must
-// not fail or hang. This is the replacement coverage for what staying
-// permanently skipped on this platform costs the h1/h2 cross-pool tests
-// above: those specifically need a populated h1_idle pool, which never
-// happens here, but a plain h2-enabled request to an h1-only origin must
-// still work end to end. On other platforms this exercises the equivalent
-// existing h2_use_h1_pool_or_dial path (already covered by
-// test_h2_pool_alpn_fallback_avoids_hol_blocking above).
+// A plain, non-concurrent h2-enabled request to an h1-only origin must
+// succeed end to end: ALPN negotiates http/1.1, and the still-open probe
+// connection is reused directly for the request itself (h2_dial_and_do's
+// vsc_probe/ssl_probe branch), on every platform including native Windows
+// (#27879). This is a direct correctness check, distinct from
+// test_h2_pool_alpn_fallback_avoids_hol_blocking above, which focuses on
+// concurrent-waiter timing rather than a single request's basic result.
 //
-// Serves each accepted connection in its own thread, closing it after one
-// response, rather than reusing start_h2t_h1only_srv's keep-alive loop:
-// vschannel's one-shot HTTP/1.1 client (https_make_request,
-// thirdparty/vschannel/vschannel.c) reads until the PEER closes the
-// connection rather than stopping once Content-Length bytes have been
-// received, so a keep-alive peer stalls it for as long as the peer's own
-// idle-read timeout takes to fire -- a pre-existing bug in that one-shot
-// client, unrelated to h2 pooling, tracked separately (vlang/v#27705). Every
-// other caller of the one-shot vschannel h1 path in this codebase either
-// talks to a server that closes promptly or is `-d network`-gated, so this
-// was the first automated test to hit it.
-//
-// Must accept in a LOOP, not once: on native Windows this request makes TWO
-// separate connections to the origin -- h2_dial_probe_vschannel's ALPN probe
-// (sends nothing, just closes once it sees ALPN did not select h2) and the
-// real request from req.ssl_do's own independent dial. A single `l.accept()`
-// serves whichever of the two happens to arrive first and then exits,
-// leaving the other connection accepted at the TCP level but never serviced
-// -- its client-side TLS handshake then hangs indefinitely waiting for a
-// ServerHello no one is sending.
+// Accepts in a loop (rather than once) defensively: exactly one connection
+// is expected per request (the ALPN probe is reused, not redialed), but a
+// loop tolerates a retry without needing to know the exact count.
 fn vpah_serve_one(mut conn mbedtls.SSLConn) {
 	defer {
 		conn.shutdown() or {}
@@ -598,10 +573,6 @@ fn test_h2_pool_respects_max_idle_conns_cap() {
 // connection down before its own request ever executes on it (Codex P1,
 // vlang/v#27643 pullrequestreview-4628439062).
 fn test_h2_pool_does_not_evict_its_own_new_connection() {
-	$if windows && !no_vschannel ? {
-		eprintln('skipping: exercises h1/h2 cross-pool eviction, which requires h1-over-vschannel pooling (out of scope)')
-		return
-	}
 	mut t := new_transport()
 	t.max_idle_conns = 1
 
@@ -655,10 +626,6 @@ fn test_h2_pool_does_not_evict_its_own_new_connection() {
 // connection stay pooled, exceeding the documented global cap indefinitely
 // (Codex P2, vlang/v#27643 pullrequestreview-4630174759).
 fn test_h2_pool_evicts_h1_idle_to_make_room_for_h2() {
-	$if windows && !no_vschannel ? {
-		eprintln('skipping: exercises h1/h2 cross-pool eviction, which requires h1-over-vschannel pooling (out of scope)')
-		return
-	}
 	mut t := new_transport()
 	t.max_idle_conns = 1
 
@@ -715,10 +682,6 @@ fn test_h2_pool_evicts_h1_idle_to_make_room_for_h2() {
 // count is within max_idle_conns (Codex P3, vlang/v#27643
 // pullrequestreview-4631763931, discussion 3525390899).
 fn test_h2_pool_idle_cap_excludes_busy_h2_conn() {
-	$if windows && !no_vschannel ? {
-		eprintln('skipping: exercises h1/h2 cross-pool eviction, which requires h1-over-vschannel pooling (out of scope)')
-		return
-	}
 	mut t := new_transport()
 	t.max_idle_conns = 2
 

--- a/vlib/net/http/transport_test.v
+++ b/vlib/net/http/transport_test.v
@@ -441,12 +441,6 @@ fn tls_ka_srv_loop(mut s TlsKaSrv, mut listener mbedtls.SSLListener) {
 }
 
 fn test_h1_tls_reuse() {
-	$if windows && !no_vschannel ? {
-		// The default Windows TLS backend (SChannel) keeps its one-shot path
-		// until SChannel pooling lands.
-		eprintln('skipping: SChannel connection pooling is not implemented yet')
-		return
-	}
 	mut port_listener := net.listen_tcp(.ip, '127.0.0.1:0') or {
 		assert false, 'port: ${err}'
 		return
@@ -490,10 +484,6 @@ fn test_h1_tls_reuse() {
 // HTTP/2-enabled request to the same origin — the ALPN preference is part of
 // the pool key. Forced-h1 requests still share among themselves.
 fn test_h1_tls_no_reuse_across_alpn_preference() {
-	$if windows && !no_vschannel ? {
-		eprintln('skipping: SChannel connection pooling is not implemented yet')
-		return
-	}
 	mut port_listener := net.listen_tcp(.ip, '127.0.0.1:0') or {
 		assert false, 'port: ${err}'
 		return

--- a/vlib/net/http/vschannel_pooled_transport_windows.c.v
+++ b/vlib/net/http/vschannel_pooled_transport_windows.c.v
@@ -200,22 +200,21 @@ fn (mut t VSchannelPooledTransport) close() {
 
 // h2_dial_probe_vschannel is the Windows-native counterpart of
 // h2_dial_probe_ssl (transport_h2.v): dials host:port over SChannel and
-// reports whether ALPN selected h2. Unlike the mbedTLS/OpenSSL probe, a
-// non-h2 result closes its own connection before returning rather than
-// handing it back for h1 reuse -- h1-over-vschannel pooling is out of scope,
-// so the caller falls back to the one-shot req.ssl_do instead (see
-// h2_fallback_h1).
+// reports whether ALPN selected h2. A non-h2 result hands the still-open
+// connection back via vsc_probe for h1 reuse, mirroring h2_dial_probe_ssl's
+// own ssl_probe field (#27879 -- h1-over-vschannel pooling).
 fn h2_dial_probe_vschannel(req &Request, host string, port int) !H2ProbeResult {
 	if C.vschannel_alpn_supported() == 0 {
 		// Pre-Windows 8.1 / Server 2012 R2 SChannel has no client-side ALPN:
 		// injecting the SECBUFFER_APPLICATION_PROTOCOLS buffer that
 		// new_vschannel_pooled_transport always installs can fail the whole
 		// handshake outright, so h2 is unreachable on those systems. Report
-		// the origin as h1-only WITHOUT dialing: the caller memoizes
-		// key_proto[key] = 1 and completes this (and every later) request
-		// via the one-shot req.ssl_do path, whose own vschannel_ssl_do guard
-		// (the sibling of this one) then dials plain HTTP/1.1 with no ALPN
-		// -- exactly the pre-pooling behavior (Codex P1, vlang/v#27712
+		// the origin as h1-only WITHOUT dialing (no probe connection to hand
+		// back either): the caller memoizes key_proto[key] = 1 and completes
+		// this (and every later) request via h2_fallback_h1, which dials a
+		// fresh h1-only vschannel connection through vschannel_fresh_round_trip
+		// -- itself gated on the same vschannel_alpn_supported() check, so it
+		// never re-attempts ALPN on these systems either (Codex P1, vlang/v#27712
 		// pullrequestreview-4729311285).
 		return H2ProbeResult{
 			is_h2: false
@@ -224,9 +223,16 @@ fn h2_dial_probe_vschannel(req &Request, host string, port int) !H2ProbeResult {
 	mut t := new_vschannel_pooled_transport(host, port, req.validate, ['h2', 'http/1.1'],
 		h2_pooled_io_timeout, h2_pooled_write_stall_limit)!
 	if t.negotiated_alpn() != 'h2' {
-		t.close()
+		// Hand the still-open, ALPN-probed connection back for h1 reuse
+		// instead of closing it: widen its timeouts from the h2-poll-tuned
+		// values (short reads, tuned for a multiplexed background reader) to
+		// this request's real read/write timeouts first, matching
+		// H1PooledConn.refresh_timeouts' own per-checkout behavior -- an h1
+		// pooled connection has no multiplexed reader to keep responsive.
+		t.set_timeouts(req.read_timeout, req.write_timeout)
 		return H2ProbeResult{
-			is_h2: false
+			is_h2:     false
+			vsc_probe: H1StreamConn(t)
 		}
 	}
 	return H2ProbeResult{
@@ -234,4 +240,49 @@ fn h2_dial_probe_vschannel(req &Request, host string, port int) !H2ProbeResult {
 		transport: H2Transport(t)
 		closer:    H2TransportCloser(t)
 	}
+}
+
+// vschannel_fresh_round_trip is the native-Windows counterpart of
+// tls_fresh_round_trip (transport.v): dials a fresh pooled SChannel
+// connection and completes the request on it. Mirrors tls_fresh_round_trip's
+// ALPN selection exactly -- advertise h2/http1.1 when the request wants h2,
+// run the request on the existing one-shot HTTP/2 driver if the server
+// selects it (unpooled, like the mbedTLS/OpenSSL sibling), otherwise pool the
+// connection as an ordinary h1 keep-alive entry -- except ALPN is
+// additionally gated on vschannel_alpn_supported(), matching
+// vschannel_ssl_do/h2_dial_probe_vschannel's own guard: pre-Windows-8.1
+// SChannel has no client-side ALPN, and injecting the ALPN buffer there can
+// fail the handshake outright.
+fn (mut t Transport) vschannel_fresh_round_trip(req &Request, key string, raw string, method Method, host string, port int, path string, data string, header Header) !Response {
+	alpn := if req.enable_http2 && C.vschannel_alpn_supported() != 0 {
+		['h2', 'http/1.1']
+	} else {
+		[]string{}
+	}
+	mut vt := new_vschannel_pooled_transport(host, port, req.validate, alpn, req.read_timeout,
+		req.write_timeout)!
+	if req.enable_http2 && vt.negotiated_alpn() == 'h2' {
+		defer {
+			vt.close()
+		}
+		mut conn := new_h2_conn(vt)
+		return req.h2_exchange(mut conn, method, host, port, path, data, header)!
+	}
+	mut conn := &H1PooledConn{
+		key: key
+		vsc: H1StreamConn(vt)
+	}
+	resp, reusable := conn.exchange(req, raw) or {
+		conn.close_conn()
+		// Past the TLS handshake the request bytes may have been (partially)
+		// written; a non-idempotent method must not be replayed by the outer
+		// retry loop. (A dial/handshake failure above propagates before this
+		// and stays retryable, since no request byte was sent.)
+		if !transport_is_idempotent(method) {
+			return error_with_code(err.msg(), transport_err_unsafe_retry)
+		}
+		return err
+	}
+	t.maybe_checkin(mut conn, header, reusable, resp)
+	return resp
 }

--- a/vlib/net/http/vschannel_validation_windows_test.v
+++ b/vlib/net/http/vschannel_validation_windows_test.v
@@ -20,19 +20,12 @@ fn start_vschannel_test_https_server() !(int, thread) {
 	return port, spawn serve_vschannel_test_https_server(mut listener)
 }
 
-// serve_vschannel_test_https_server accepts vschannel_test_https_max_accepts
-// connections, one at a time, then returns (triggering the deferred
-// listener.shutdown()) -- identical in structure and behavior to a plain
-// single accept() when the max is 1, which is exactly what -d no_vschannel
-// and every non-Windows platform need.
-//
-// Only native Windows (without -d no_vschannel) ever needs 2: an h2-enabled
-// request to an origin that turns out not to speak h2 makes TWO separate
-// connections there -- h2_dial_probe_vschannel's ALPN probe (closes
-// immediately once it sees h2 wasn't selected, without sending a request)
-// and the real request from req.ssl_do's own independent dial. Every other
-// configuration reuses the probe connection directly (h2_dial_probe_ssl),
-// needing only one.
+// serve_vschannel_test_https_server accepts one connection, then returns
+// (triggering the deferred listener.shutdown()). Every configuration --
+// including native Windows without -d no_vschannel -- reuses the ALPN probe
+// connection directly for an h2-enabled request that turns out to be
+// h1-only (h2_dial_probe_vschannel/h2_dial_probe_ssl's vsc_probe/ssl_probe,
+// #27879), so exactly one connection is ever made here.
 //
 // Deliberately bounded rather than an unbounded loop: a client that aborts
 // mid-handshake (exactly what the certificate-rejection test below does)
@@ -41,9 +34,8 @@ fn start_vschannel_test_https_server() !(int, thread) {
 // -- listener.shutdown() only frees the LISTENING socket, so it cannot
 // unblock an accept() already stuck processing one specific connection's
 // handshake. That test's failure happens on the very first accept() call
-// and returns immediately regardless of the bound, matching the original
-// single-accept design exactly.
-const vschannel_test_https_max_accepts = $if windows && !no_vschannel ? { 2 } $else { 1 }
+// and returns immediately regardless of the bound.
+const vschannel_test_https_max_accepts = 1
 
 fn serve_vschannel_test_https_server(mut listener mbedtls.SSLListener) {
 	defer {


### PR DESCRIPTION
## Summary
- Part 2/2 of #27879. **Stacked on #27892** (h1-vschannel-pool-plumbing) — review that one first; until it merges this PR's diff includes its commit too. Rebase onto master once #27892 lands to shrink the diff to just this PR's own changes.
- `h2_dial_probe_vschannel` now hands its still-open, ALPN-probed connection back for h1 reuse (`vsc_probe`) instead of closing it, mirroring `h2_dial_probe_ssl`'s existing `ssl_probe`.
- New `vschannel_fresh_round_trip` (the SChannel counterpart of `tls_fresh_round_trip`) dials and pools a fresh h1 connection when none is idle, respecting the pre-Windows-8.1 ALPN gate.
- Removes `round_trip`'s Windows one-shot bypass and `h2_fallback_h1`'s one-shot branch — native Windows now shares the same pooling control flow as every other platform.
- Un-skips the 4 h1/h2 cross-pool tests named in #27879, plus 2 more in `transport_test.v` that were waiting on exactly this feature.
- Fixes `vschannel_validation_windows_test.v`'s accept-count constant, which assumed the old two-connection (probe + separate one-shot dial) behavior — now one connection, like every other platform.
- Adds a `-d cross` build stub for the new function, matching its sibling `h2_dial_probe_vschannel` (this project's `cross_ci`/`bootstrapping_ci` jobs exercise `-os cross`).

## Test plan
- [x] `./vnew -check -shared vlib/net/http/` clean, both with and without `-d no_vschannel`
- [x] Full `vlib/net/http` suite green natively (real SChannel backend) — 26 passed, 2 pre-existing env skips
- [x] Full `vlib/net/http` suite green with `-d no_vschannel` (mbedTLS/OpenSSL)

Closes #27879.

🧙 Built with [WOZCODE](https://wozcode.com)