### PR TITLE
v3: restore fast cached Volt rebuilds

### DIFF
--- a/vlib/os/execute_capture_nix.h
+++ b/vlib/os/execute_capture_nix.h
@@ -6,7 +6,7 @@
 // empty (seen on macOS arm64 in CI). Setting CLOEXEC closes the fd
 // automatically across exec, which fixes the race for both fork/execvp and
 // posix_spawn paths.
-static void v_os_execute_set_cloexec(int fd) {
+static inline void v_os_execute_set_cloexec(int fd) {
 	int flags = fcntl(fd, F_GETFD, 0);
 	if (flags >= 0) {
 		fcntl(fd, F_SETFD, flags | FD_CLOEXEC);
@@ -17,7 +17,7 @@ static void v_os_execute_set_cloexec(int fd) {
 // Android API levels below 28 do not provide posix_spawn(). Fall back to
 // fork()/execvp() with a pipe; this is what popen() does internally and
 // is sufficient for capturing the merged stdout+stderr of a shell command.
-static int v_os_execute_capture_start(const char *cmd, int *child_pid, int *read_fd) {
+static inline int v_os_execute_capture_start(const char *cmd, int *child_pid, int *read_fd) {
 	int pipefd[2];
 	if (pipe(pipefd) != 0) {
 		return -1;
@@ -47,7 +47,7 @@ static int v_os_execute_capture_start(const char *cmd, int *child_pid, int *read
 	return 0;
 }
 
-static int v_os_exec_capture_start(char *const argv[], int *child_pid, int *read_fd) {
+static inline int v_os_exec_capture_start(char *const argv[], int *child_pid, int *read_fd) {
 	if (argv == NULL || argv[0] == NULL) {
 		return -1;
 	}
@@ -102,7 +102,7 @@ extern char **environ;
 }
 #endif
 
-static int v_os_execute_capture_start(const char *cmd, int *child_pid, int *read_fd) {
+static inline int v_os_execute_capture_start(const char *cmd, int *child_pid, int *read_fd) {
 	int pipefd[2];
 	if (pipe(pipefd) != 0) {
 		return -1;
@@ -138,7 +138,7 @@ static int v_os_execute_capture_start(const char *cmd, int *child_pid, int *read
 	return 0;
 }
 
-static int v_os_exec_capture_start(char *const argv[], int *child_pid, int *read_fd) {
+static inline int v_os_exec_capture_start(char *const argv[], int *child_pid, int *read_fd) {
 	if (argv == NULL || argv[0] == NULL) {
 		return -1;
 	}

--- a/vlib/v3/bench/bench.v
+++ b/vlib/v3/bench/bench.v
@@ -18,6 +18,14 @@ pub:
 	allocated_bytes  u64
 }
 
+// StepPart describes one measured part of a pipeline step.
+pub struct StepPart {
+pub:
+	name     string
+	time_us  i64
+	parallel bool
+}
+
 // Metric represents one structural compiler counter reported with a build.
 pub struct Metric {
 pub:
@@ -84,10 +92,57 @@ pub fn (mut b Bench) step(name string) {
 	b.step_parallel(name, false)
 }
 
+// current_step_time_us returns the elapsed wall time in the current pipeline step.
+pub fn (b &Bench) current_step_time_us() i64 {
+	return b.step_sw.elapsed().microseconds()
+}
+
 // step_parallel records a pipeline step, appending "(parallel)" to its name
 // when the step actually ran across threads.
 pub fn (mut b Bench) step_parallel(name string, parallel bool) {
 	elapsed_us := b.step_sw.elapsed().microseconds()
+	allocations := current_allocation_stats()
+	b.report_step(name, parallel, elapsed_us,
+		allocations.allocation_count - b.last_allocation_count,
+		allocations.allocated_bytes - b.last_allocated_bytes, allocations.enabled)
+	b.finish_step_report()
+}
+
+// step_parts records measured parts that together make up the current pipeline step.
+pub fn (mut b Bench) step_parts(parts []StepPart) {
+	if parts.len == 0 {
+		return
+	}
+	allocations := current_allocation_stats()
+	total_allocation_count := allocations.allocation_count - b.last_allocation_count
+	total_allocated_bytes := allocations.allocated_bytes - b.last_allocated_bytes
+	mut total_us := i64(0)
+	for part in parts {
+		total_us += part.time_us
+	}
+	mut reported_allocation_count := u64(0)
+	mut reported_allocated_bytes := u64(0)
+	for idx, part in parts {
+		is_last := idx == parts.len - 1
+		allocation_count := if is_last || total_us <= 0 {
+			total_allocation_count - reported_allocation_count
+		} else {
+			u64(i64(total_allocation_count) * part.time_us / total_us)
+		}
+		allocated_bytes := if is_last || total_us <= 0 {
+			total_allocated_bytes - reported_allocated_bytes
+		} else {
+			u64(i64(total_allocated_bytes) * part.time_us / total_us)
+		}
+		b.report_step(part.name, part.parallel, part.time_us, allocation_count, allocated_bytes,
+			allocations.enabled)
+		reported_allocation_count += allocation_count
+		reported_allocated_bytes += allocated_bytes
+	}
+	b.finish_step_report()
+}
+
+fn (mut b Bench) report_step(name string, parallel bool, elapsed_us i64, allocation_count u64, allocated_bytes u64, allocations_enabled bool) {
 	label := if parallel { '${name} (parallel)' } else { name }
 	ram_kb := current_rss_kb()
 	peak_ram_kb := peak_rss_kb()
@@ -103,10 +158,7 @@ pub fn (mut b Bench) step_parallel(name string, parallel bool) {
 	peak_ram_mb := f64(peak_ram_kb) / 1024.0
 	footprint_suffix := physical_footprint_suffix(memory)
 	ms := f64(elapsed_us) / 1000.0
-	allocations := current_allocation_stats()
-	allocation_count := allocations.allocation_count - b.last_allocation_count
-	allocated_bytes := allocations.allocated_bytes - b.last_allocated_bytes
-	allocation_suffix := if allocations.enabled {
+	allocation_suffix := if allocations_enabled {
 		allocated_mb := f64(allocated_bytes) / (1024.0 * 1024.0)
 		'   ${allocation_count} allocs   ${allocated_mb:8.2f} MB allocated'
 	} else {
@@ -121,6 +173,9 @@ pub fn (mut b Bench) step_parallel(name string, parallel bool) {
 		allocation_count: allocation_count
 		allocated_bytes:  allocated_bytes
 	}
+}
+
+fn (mut b Bench) finish_step_report() {
 	// Exclude the benchmark line's own formatting allocations from the next phase.
 	after_report := current_allocation_stats()
 	b.last_allocation_count = after_report.allocation_count

--- a/vlib/v3/bench/bench_test.v
+++ b/vlib/v3/bench/bench_test.v
@@ -22,6 +22,27 @@ fn test_disable_memory_limit() {
 	assert memory_limit_error(default_memory_limit_kb, b.memory_limit_kb, 'after check', 'RSS') == ''
 }
 
+fn test_step_parts_record_individual_timings() {
+	mut b := new()
+	b.disable_memory_limit()
+	b.step_parts([
+		StepPart{
+			name:     'parse .vh'
+			time_us:  1250
+			parallel: true
+		},
+		StepPart{
+			name:    'parse .v'
+			time_us: 2750
+		},
+	])
+	assert b.steps.len == 2
+	assert b.steps[0].name == 'parse .vh (parallel)'
+	assert b.steps[0].time_us == 1250
+	assert b.steps[1].name == 'parse .v'
+	assert b.steps[1].time_us == 2750
+}
+
 fn test_limit_memory_metric_is_available() {
 	memory := current_limit_memory()
 	assert memory.kb > 0

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -1106,9 +1106,8 @@ fn c_collect_external_input_tree(path string, vroot string, include_dirs []strin
 				continue
 			}
 			include_args = include_macros[macro_name].clone()
-			// An undefined include macro can only occur in an inactive preprocessor
-			// branch in a translation unit that compiles successfully.
 			if include_args.len == 0 {
+				has_untracked_include = true
 				continue
 			}
 		}

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -1131,7 +1131,11 @@ fn c_record_cache_resolution_path(path string, mut resolution_dirs map[string]bo
 			if first_missing.len > 0 {
 				missing_resolution_paths[first_missing] = true
 			} else {
-				resolution_dirs[os.real_path(dir)] = true
+				resolution_dirs[dir] = true
+				real_dir := os.real_path(dir)
+				if real_dir.len > 0 {
+					resolution_dirs[real_dir] = true
+				}
 			}
 			return
 		}

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -860,6 +860,8 @@ pub fn cache_external_input_files(a &flat.FlatAst, vroot string, source_modules 
 	}
 	c_flags << initial_c_flags
 	include_dirs := c_flag_include_dirs(c_flags)
+	flag_inputs, flags_have_untracked_include, mut include_macros, mut dynamic_include_macros :=
+		cache_c_flag_input_files_with_status(c_flags)
 	mut collect_modules := map[string]bool{}
 	for module_name, enabled in source_modules {
 		if enabled {
@@ -906,7 +908,9 @@ pub fn cache_external_input_files(a &flat.FlatAst, vroot string, source_modules 
 				}
 				mut seen := map[string]bool{}
 				mut files := []string{}
-				if c_collect_external_input_tree(path, vroot, include_dirs, mut seen, mut files) {
+				if c_collect_external_input_tree(path, vroot, include_dirs, mut seen, mut files, mut
+					include_macros, mut dynamic_include_macros)
+				{
 					has_untracked_include = true
 				}
 				for file in files {
@@ -920,7 +924,6 @@ pub fn cache_external_input_files(a &flat.FlatAst, vroot string, source_modules 
 			c_add_cache_external_input(mut inputs, owner_module, path)
 		}
 	}
-	flag_inputs, flags_have_untracked_include := cache_c_flag_input_files_with_status(c_flags)
 	if flags_have_untracked_include {
 		has_untracked_include = true
 	}
@@ -938,28 +941,31 @@ pub fn cache_external_input_files(a &flat.FlatAst, vroot string, source_modules 
 // cache_c_flag_input_files returns forced include/macro files whose contents
 // affect every cached object compiled with the supplied C flags.
 pub fn cache_c_flag_input_files(flags []string) []string {
-	files, _ := cache_c_flag_input_files_with_status(flags)
+	files, _, _, _ := cache_c_flag_input_files_with_status(flags)
 	return files
 }
 
-fn cache_c_flag_input_files_with_status(flags []string) ([]string, bool) {
+fn cache_c_flag_input_files_with_status(flags []string) ([]string, bool, map[string][]string, map[string]bool) {
 	include_dirs := c_flag_include_dirs(flags)
 	mut seen := map[string]bool{}
 	mut files := []string{}
 	mut has_untracked_include := false
+	mut include_macros, mut dynamic_include_macros := c_flag_include_macro_definitions(flags)
 	for forced_input in c_forced_include_inputs(flags) {
 		for path in c_include_file_paths('"${forced_input}"', '', '', include_dirs) {
 			if !os.is_file(path) {
 				continue
 			}
-			if c_collect_external_input_tree(path, '', include_dirs, mut seen, mut files) {
+			if c_collect_external_input_tree(path, '', include_dirs, mut seen, mut files, mut
+				include_macros, mut dynamic_include_macros)
+			{
 				has_untracked_include = true
 			}
 			break
 		}
 	}
 	files.sort()
-	return files, has_untracked_include
+	return files, has_untracked_include, include_macros, dynamic_include_macros
 }
 
 fn c_forced_include_inputs(flags []string) []string {
@@ -1039,7 +1045,7 @@ fn c_add_cache_external_input(mut inputs map[string][]string, module_name string
 	}
 }
 
-fn c_collect_external_input_tree(path string, vroot string, include_dirs []string, mut seen map[string]bool, mut files []string) bool {
+fn c_collect_external_input_tree(path string, vroot string, include_dirs []string, mut seen map[string]bool, mut files []string, mut include_macros map[string][]string, mut dynamic_include_macros map[string]bool) bool {
 	if path.len == 0 || !os.is_file(path) {
 		return false
 	}
@@ -1056,24 +1062,95 @@ fn c_collect_external_input_tree(path string, vroot string, include_dirs []strin
 		clean, next_in_block_comment := c_preprocessor_directive_scan_line(line, in_block_comment)
 		in_block_comment = next_in_block_comment
 		if c_directive_name(clean) !in ['include', 'import'] {
+			c_record_include_macro_definition(clean, mut include_macros, mut dynamic_include_macros)
 			continue
 		}
-		include_arg := c_include_arg(c_directive_arg(clean), vroot, real_path)
-		if !c_include_arg_is_literal(include_arg) {
-			has_untracked_include = true
-			continue
-		}
-		for nested_path in c_include_file_paths(include_arg, vroot, real_path, include_dirs) {
-			if !os.is_file(nested_path) {
+		mut include_args := [c_include_arg(c_directive_arg(clean), vroot, real_path)]
+		if !c_include_arg_is_literal(include_args[0]) {
+			macro_name := include_args[0].trim_space()
+			if dynamic_include_macros[macro_name] {
+				has_untracked_include = true
 				continue
 			}
-			if c_collect_external_input_tree(nested_path, vroot, include_dirs, mut seen, mut files) {
-				has_untracked_include = true
+			include_args = include_macros[macro_name].clone()
+			// An undefined include macro can only occur in an inactive preprocessor
+			// branch in a translation unit that compiles successfully.
+			if include_args.len == 0 {
+				continue
 			}
-			break
+		}
+		for include_arg in include_args {
+			for nested_path in c_include_file_paths(include_arg, vroot, real_path, include_dirs) {
+				if !os.is_file(nested_path) {
+					continue
+				}
+				if c_collect_external_input_tree(nested_path, vroot, include_dirs, mut seen, mut
+					files, mut include_macros, mut dynamic_include_macros)
+				{
+					has_untracked_include = true
+				}
+				break
+			}
 		}
 	}
 	return has_untracked_include
+}
+
+fn c_flag_include_macro_definitions(flags []string) (map[string][]string, map[string]bool) {
+	mut include_macros := map[string][]string{}
+	mut dynamic_include_macros := map[string]bool{}
+	mut i := 0
+	for i < flags.len {
+		clean := flags[i].trim_space()
+		mut definition := ''
+		if clean == '-D' && i + 1 < flags.len {
+			i++
+			definition = flags[i].trim_space()
+		} else if clean.starts_with('-D') {
+			definition = clean[2..].trim_space()
+		}
+		if definition.len > 0 {
+			name := definition.all_before('=').trim_space()
+			value := if definition.contains('=') {
+				definition.all_after('=').trim_space()
+			} else {
+				''
+			}
+			c_record_include_macro_value(name, value, mut include_macros, mut
+				dynamic_include_macros)
+		}
+		i++
+	}
+	return include_macros, dynamic_include_macros
+}
+
+fn c_record_include_macro_definition(directive string, mut include_macros map[string][]string, mut dynamic_include_macros map[string]bool) {
+	if c_directive_name(directive) != 'define' {
+		return
+	}
+	definition := c_directive_arg(directive)
+	parts := definition.fields()
+	if parts.len < 2 || parts[0].contains('(') {
+		return
+	}
+	name := parts[0]
+	value := definition[name.len..].trim_space()
+	c_record_include_macro_value(name, value, mut include_macros, mut dynamic_include_macros)
+}
+
+fn c_record_include_macro_value(name string, value string, mut include_macros map[string][]string, mut dynamic_include_macros map[string]bool) {
+	if name.len == 0 || value.len == 0 {
+		return
+	}
+	if !c_include_arg_is_literal(value) {
+		dynamic_include_macros[name] = true
+		return
+	}
+	mut values := include_macros[name]
+	if value !in values {
+		values << value
+		include_macros[name] = values
+	}
 }
 
 fn c_embed_external_input_path(a &flat.FlatAst, node flat.Node) ?string {

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -859,8 +859,18 @@ pub fn cache_external_input_files(a &flat.FlatAst, vroot string, source_modules 
 		}
 	}
 	c_flags << initial_c_flags
+	inputs, native_source_roots, _, _, has_untracked_include := cache_external_input_files_with_resolved_flags(a,
+		vroot, source_modules, c_flags, target)
+	return inputs, native_source_roots, has_untracked_include
+}
+
+// cache_external_input_files_with_resolved_flags collects cache inputs without
+// resolving source `#flag` directives a second time. resolution_dirs contains
+// every searched include directory whose contents can change path resolution;
+// missing_resolution_paths are the first nonexistent path components searched.
+pub fn cache_external_input_files_with_resolved_flags(a &flat.FlatAst, vroot string, source_modules map[string]bool, c_flags []string, target pref.Target) (map[string][]string, map[string][]string, []string, []string, bool) {
 	include_dirs := c_flag_include_dirs(c_flags)
-	flag_inputs, flags_have_untracked_include, mut include_macros, mut dynamic_include_macros :=
+	flag_inputs, flags_have_untracked_include, mut include_macros, mut dynamic_include_macros, mut resolution_dirs, mut missing_resolution_paths :=
 		cache_c_flag_input_files_with_status(c_flags)
 	mut collect_modules := map[string]bool{}
 	for module_name, enabled in source_modules {
@@ -873,7 +883,7 @@ pub fn cache_external_input_files(a &flat.FlatAst, vroot string, source_modules 
 	mut native_source_roots := map[string][]string{}
 	mut has_untracked_include := false
 	mut cur_module := ''
-	cur_file = ''
+	mut cur_file := ''
 	for node in a.nodes {
 		if node.kind == .file {
 			cur_file = node.value
@@ -898,6 +908,8 @@ pub fn cache_external_input_files(a &flat.FlatAst, vroot string, source_modules 
 				continue
 			}
 			for path in c_include_file_paths(include_arg, vroot, cur_file, include_dirs) {
+				c_record_cache_resolution_path(path, mut resolution_dirs, mut
+					missing_resolution_paths)
 				if !os.is_file(path) {
 					continue
 				}
@@ -909,7 +921,8 @@ pub fn cache_external_input_files(a &flat.FlatAst, vroot string, source_modules 
 				mut seen := map[string]bool{}
 				mut files := []string{}
 				if c_collect_external_input_tree(path, vroot, include_dirs, mut seen, mut files, mut
-					include_macros, mut dynamic_include_macros)
+					include_macros, mut dynamic_include_macros, mut resolution_dirs, mut
+					missing_resolution_paths)
 				{
 					has_untracked_include = true
 				}
@@ -935,29 +948,37 @@ pub fn cache_external_input_files(a &flat.FlatAst, vroot string, source_modules 
 		sorted.sort()
 		inputs[module_name] = sorted
 	}
-	return inputs, native_source_roots, has_untracked_include
+	mut sorted_resolution_dirs := resolution_dirs.keys()
+	sorted_resolution_dirs.sort()
+	mut sorted_missing_resolution_paths := missing_resolution_paths.keys()
+	sorted_missing_resolution_paths.sort()
+	return inputs, native_source_roots, sorted_resolution_dirs, sorted_missing_resolution_paths, has_untracked_include
 }
 
 // cache_c_flag_input_files returns forced include/macro files whose contents
 // affect every cached object compiled with the supplied C flags.
 pub fn cache_c_flag_input_files(flags []string) []string {
-	files, _, _, _ := cache_c_flag_input_files_with_status(flags)
+	files, _, _, _, _, _ := cache_c_flag_input_files_with_status(flags)
 	return files
 }
 
-fn cache_c_flag_input_files_with_status(flags []string) ([]string, bool, map[string][]string, map[string]bool) {
+fn cache_c_flag_input_files_with_status(flags []string) ([]string, bool, map[string][]string, map[string]bool, map[string]bool, map[string]bool) {
 	include_dirs := c_flag_include_dirs(flags)
 	mut seen := map[string]bool{}
 	mut files := []string{}
+	mut resolution_dirs := map[string]bool{}
+	mut missing_resolution_paths := map[string]bool{}
 	mut has_untracked_include := false
 	mut include_macros, mut dynamic_include_macros := c_flag_include_macro_definitions(flags)
 	for forced_input in c_forced_include_inputs(flags) {
 		for path in c_include_file_paths('"${forced_input}"', '', '', include_dirs) {
+			c_record_cache_resolution_path(path, mut resolution_dirs, mut missing_resolution_paths)
 			if !os.is_file(path) {
 				continue
 			}
 			if c_collect_external_input_tree(path, '', include_dirs, mut seen, mut files, mut
-				include_macros, mut dynamic_include_macros)
+				include_macros, mut dynamic_include_macros, mut resolution_dirs, mut
+				missing_resolution_paths)
 			{
 				has_untracked_include = true
 			}
@@ -965,7 +986,7 @@ fn cache_c_flag_input_files_with_status(flags []string) ([]string, bool, map[str
 		}
 	}
 	files.sort()
-	return files, has_untracked_include, include_macros, dynamic_include_macros
+	return files, has_untracked_include, include_macros, dynamic_include_macros, resolution_dirs, missing_resolution_paths
 }
 
 fn c_forced_include_inputs(flags []string) []string {
@@ -1045,7 +1066,7 @@ fn c_add_cache_external_input(mut inputs map[string][]string, module_name string
 	}
 }
 
-fn c_collect_external_input_tree(path string, vroot string, include_dirs []string, mut seen map[string]bool, mut files []string, mut include_macros map[string][]string, mut dynamic_include_macros map[string]bool) bool {
+fn c_collect_external_input_tree(path string, vroot string, include_dirs []string, mut seen map[string]bool, mut files []string, mut include_macros map[string][]string, mut dynamic_include_macros map[string]bool, mut resolution_dirs map[string]bool, mut missing_resolution_paths map[string]bool) bool {
 	if path.len == 0 || !os.is_file(path) {
 		return false
 	}
@@ -1081,11 +1102,14 @@ fn c_collect_external_input_tree(path string, vroot string, include_dirs []strin
 		}
 		for include_arg in include_args {
 			for nested_path in c_include_file_paths(include_arg, vroot, real_path, include_dirs) {
+				c_record_cache_resolution_path(nested_path, mut resolution_dirs, mut
+					missing_resolution_paths)
 				if !os.is_file(nested_path) {
 					continue
 				}
 				if c_collect_external_input_tree(nested_path, vroot, include_dirs, mut seen, mut
-					files, mut include_macros, mut dynamic_include_macros)
+					files, mut include_macros, mut dynamic_include_macros, mut resolution_dirs, mut
+					missing_resolution_paths)
 				{
 					has_untracked_include = true
 				}
@@ -1094,6 +1118,30 @@ fn c_collect_external_input_tree(path string, vroot string, include_dirs []strin
 		}
 	}
 	return has_untracked_include
+}
+
+fn c_record_cache_resolution_path(path string, mut resolution_dirs map[string]bool, mut missing_resolution_paths map[string]bool) {
+	if path.len == 0 {
+		return
+	}
+	mut dir := os.dir(os.abs_path(path))
+	mut first_missing := ''
+	for dir.len > 0 {
+		if os.is_dir(dir) {
+			if first_missing.len > 0 {
+				missing_resolution_paths[first_missing] = true
+			} else {
+				resolution_dirs[os.real_path(dir)] = true
+			}
+			return
+		}
+		first_missing = dir
+		parent := os.dir(dir)
+		if parent == dir {
+			return
+		}
+		dir = parent
+	}
 }
 
 fn c_flag_include_macro_definitions(flags []string) (map[string][]string, map[string]bool) {

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -859,16 +859,18 @@ pub fn cache_external_input_files(a &flat.FlatAst, vroot string, source_modules 
 		}
 	}
 	c_flags << initial_c_flags
-	inputs, native_source_roots, _, _, has_untracked_include := cache_external_input_files_with_resolved_flags(a,
+	inputs, native_source_roots, _, _, _, has_untracked_include := cache_external_input_files_with_resolved_flags(a,
 		vroot, source_modules, c_flags, target)
 	return inputs, native_source_roots, has_untracked_include
 }
 
 // cache_external_input_files_with_resolved_flags collects cache inputs without
-// resolving source `#flag` directives a second time. resolution_dirs contains
-// every searched include directory whose contents can change path resolution;
-// missing_resolution_paths are the first nonexistent path components searched.
-pub fn cache_external_input_files_with_resolved_flags(a &flat.FlatAst, vroot string, source_modules map[string]bool, c_flags []string, target pref.Target) (map[string][]string, map[string][]string, []string, []string, bool) {
+// resolving source `#flag` directives a second time. unscoped_inputs contains
+// the dependency trees of direct non-source includes that remain in the program
+// unit. resolution_dirs contains every searched include directory whose contents
+// can change path resolution; missing_resolution_paths are the first nonexistent
+// path components searched.
+pub fn cache_external_input_files_with_resolved_flags(a &flat.FlatAst, vroot string, source_modules map[string]bool, c_flags []string, target pref.Target) (map[string][]string, map[string][]string, map[string][]string, []string, []string, bool) {
 	include_dirs := c_flag_include_dirs(c_flags)
 	flag_inputs, flags_have_untracked_include, mut include_macros, mut dynamic_include_macros, mut resolution_dirs, mut missing_resolution_paths :=
 		cache_c_flag_input_files_with_status(c_flags)
@@ -881,6 +883,7 @@ pub fn cache_external_input_files_with_resolved_flags(a &flat.FlatAst, vroot str
 	}
 	mut inputs := map[string][]string{}
 	mut native_source_roots := map[string][]string{}
+	mut unscoped_inputs := map[string][]string{}
 	mut has_untracked_include := false
 	mut cur_module := ''
 	mut cur_file := ''
@@ -913,7 +916,8 @@ pub fn cache_external_input_files_with_resolved_flags(a &flat.FlatAst, vroot str
 				if !os.is_file(path) {
 					continue
 				}
-				if c_include_arg_is_source_file(include_arg) {
+				is_source_input := c_include_arg_is_source_file(include_arg)
+				if is_source_input {
 					mut roots := native_source_roots[owner_module]
 					roots << os.real_path(path)
 					native_source_roots[owner_module] = roots
@@ -928,6 +932,9 @@ pub fn cache_external_input_files_with_resolved_flags(a &flat.FlatAst, vroot str
 				}
 				for file in files {
 					c_add_cache_external_input(mut inputs, owner_module, file)
+					if !is_source_input {
+						c_add_cache_external_input(mut unscoped_inputs, owner_module, file)
+					}
 				}
 				break
 			}
@@ -948,11 +955,16 @@ pub fn cache_external_input_files_with_resolved_flags(a &flat.FlatAst, vroot str
 		sorted.sort()
 		inputs[module_name] = sorted
 	}
+	for module_name, paths in unscoped_inputs {
+		mut sorted := paths.clone()
+		sorted.sort()
+		unscoped_inputs[module_name] = sorted
+	}
 	mut sorted_resolution_dirs := resolution_dirs.keys()
 	sorted_resolution_dirs.sort()
 	mut sorted_missing_resolution_paths := missing_resolution_paths.keys()
 	sorted_missing_resolution_paths.sort()
-	return inputs, native_source_roots, sorted_resolution_dirs, sorted_missing_resolution_paths, has_untracked_include
+	return inputs, native_source_roots, unscoped_inputs, sorted_resolution_dirs, sorted_missing_resolution_paths, has_untracked_include
 }
 
 // cache_c_flag_input_files returns forced include/macro files whose contents

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -8485,6 +8485,13 @@ fn (g &FlatGen) fixed_storage_candidate_primary_from_matched_node_for_collect(no
 }
 
 fn (mut g FlatGen) collect_fixed_storage_consts() {
+	// Cached module headers deliberately materialize inferred array constants as
+	// dynamic arrays. Keep cached objects on the same ABI: promoting one of those
+	// constants to a C fixed array would make warm users read an Array header as
+	// element storage.
+	if g.cache_split {
+		return
+	}
 	old_module := g.tc.cur_module
 	old_file := g.tc.cur_file
 	mut cur_module := 'main'
@@ -10373,8 +10380,9 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 								g.gen_expr(g.a.child(&node, 1))
 								g.write(']')
 							} else {
+								g.write('(')
 								g.gen_expr(base_id)
-								g.write('[')
+								g.write(')[')
 								g.gen_expr(g.a.child(&node, 1))
 								g.write(']')
 							}

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -1636,7 +1636,6 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	g.line_start = orig_line_start
 	if g.program_body_only {
 		unsafe { const_code.free() }
-		g.release_scoped_fn_items()
 		g.sb.ensure_cap(fn_code.len + 262_144)
 		g.writeln('#define V3CACHE_PROGRAM_UNIT 1')
 		g.string_literals()
@@ -1646,8 +1645,10 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 			g.fn_ptr_typedefs()
 			g.fixed_array_typedefs()
 			g.optional_typedefs()
+			g.forward_decls()
 			g.writeln('/* V3CACHE_SUPPORT_END */')
 		}
+		g.release_scoped_fn_items()
 		g.writeln('/* V3CACHE_BODY_BEGIN */')
 		g.writeln('/* V3CACHE_MODULE main */')
 		for segment in g.fn_segs {

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -117,7 +117,7 @@ fn (mut g FlatGen) collect_fn_gen_items() []FlatFnGenItem {
 					cur_file
 				}
 			}
-			if g.program_body_only && !g.cache_program_files[item_file]
+			if g.program_body_only && !is_specialization && !g.cache_program_files[item_file]
 				&& item_module !in ['', 'main'] {
 				continue
 			}

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -11893,6 +11893,26 @@ fn (mut g FlatGen) gen_mut_pointer_slot_arg(arg_id flat.NodeId, arg_node flat.No
 	if expected !is types.Pointer {
 		return false
 	}
+	// A mutable parameter is already the address of its caller-owned storage. In
+	// particular, `mut p &T` is represented as `T**`; forwarding `mut p` to
+	// another such parameter must pass that slot directly, not read `*p` first.
+	if arg_node.is_mut && arg_node.kind == .ident && g.current_param_is_mut(arg_node.value) {
+		g.write(g.cname(arg_node.value))
+		return true
+	}
+	// Transform lowers a forwarded `mut p` argument to the lvalue `*p`. When p
+	// is itself a mutable parameter, its C variable is already the slot expected
+	// by the callee, so emitting the lowered dereference would lose one level.
+	if arg_node.kind == .prefix && arg_node.op == .mul && arg_node.children_count == 1 {
+		child := g.a.child_node(&arg_node, 0)
+		if child.kind == .ident && g.current_param_is_mut(child.value) {
+			param_type := g.current_param_type(child.value) or { types.Type(types.void_) }
+			if g.tc.c_type(param_type) == g.tc.c_type(expected) {
+				g.write(g.cname(child.value))
+				return true
+			}
+		}
+	}
 	expected_base := (expected as types.Pointer).base_type
 
 	if !c_type_is_pointer_like(expected_base) {

--- a/vlib/v3/gen/c/target_test.v
+++ b/vlib/v3/gen/c/target_test.v
@@ -264,8 +264,10 @@ fn test_cache_input_scan_uses_initial_cflags() {
 	}
 	header := os.join_path(include_dir, 'cli_only.h')
 	forced_header := os.join_path(include_dir, 'forced_cli.h')
-	os.write_file(header, '#define CLI_ONLY_VALUE 1\n') or { panic(err) }
-	os.write_file(forced_header, '#define FORCED_CLI_VALUE 2\n') or { panic(err) }
+	forced_nested_header := os.join_path(include_dir, 'forced_nested.h')
+	os.write_file(header, '#include FORCED_CLI_HEADER\n') or { panic(err) }
+	os.write_file(forced_header, '#define FORCED_CLI_HEADER "forced_nested.h"\n') or { panic(err) }
+	os.write_file(forced_nested_header, '#define FORCED_CLI_VALUE 2\n') or { panic(err) }
 	source := os.join_path(dir, 'sample.v')
 	os.write_file(source, 'module sample
 #include "cli_only.h"
@@ -279,7 +281,9 @@ fn test_cache_input_scan_uses_initial_cflags() {
 		'sample': true
 	}, ['-I', include_dir, '-include', 'forced_cli.h'], target)
 	assert !has_untracked
-	assert inputs['sample'] == [os.real_path(header)]
+	mut expected := [os.real_path(header), os.real_path(forced_nested_header)]
+	expected.sort()
+	assert inputs['sample'] == expected
 	assert inputs['__v3_c_flags__'] == [os.real_path(forced_header)]
 }
 
@@ -309,6 +313,61 @@ fn test_cache_input_scan_tracks_imported_headers() {
 	mut expected := [os.real_path(outer_header), os.real_path(imported_header)]
 	expected.sort()
 	assert inputs['sample'] == expected
+}
+
+fn test_cache_input_scan_tracks_literal_include_macros() {
+	dir := os.join_path(os.vtmp_dir(), 'v3_macro_header_cache_inputs_${os.getpid()}')
+	os.rmdir_all(dir) or {}
+	os.mkdir_all(dir) or { panic(err) }
+	defer {
+		os.rmdir_all(dir) or {}
+	}
+	definitions_header := os.join_path(dir, 'definitions.h')
+	outer_header := os.join_path(dir, 'outer.h')
+	nested_header := os.join_path(dir, 'nested.h')
+	os.write_file(definitions_header, '#define V3_NESTED_HEADER "nested.h"\n') or { panic(err) }
+	os.write_file(outer_header, '#include V3_NESTED_HEADER\n') or { panic(err) }
+	os.write_file(nested_header, '#define NESTED_VALUE 1\n') or { panic(err) }
+	source := os.join_path(dir, 'sample.v')
+	os.write_file(source, 'module sample\n#include "definitions.h"\n#include "outer.h"\n') or {
+		panic(err)
+	}
+	mut prefs := pref.new_preferences()
+	prefs.target = pref.host_target()
+	mut p := parser.Parser.new(prefs)
+	a := p.parse_file(source)
+	inputs, _, has_untracked := cache_external_input_files(a, '', {
+		'sample': true
+	}, [], prefs.target)
+	assert !has_untracked
+	mut expected := [os.real_path(definitions_header), os.real_path(outer_header),
+		os.real_path(nested_header)]
+	expected.sort()
+	assert inputs['sample'] == expected
+}
+
+fn test_cache_input_scan_rejects_dynamic_include_macros() {
+	dir := os.join_path(os.vtmp_dir(), 'v3_dynamic_macro_cache_inputs_${os.getpid()}')
+	os.rmdir_all(dir) or {}
+	os.mkdir_all(dir) or { panic(err) }
+	defer {
+		os.rmdir_all(dir) or {}
+	}
+	header := os.join_path(dir, 'outer.h')
+	os.write_file(header,
+		'#define V3_NESTED_HEADER V3_SELECTED_HEADER\n#include V3_NESTED_HEADER\n') or {
+		panic(err)
+	}
+	source := os.join_path(dir, 'sample.v')
+	os.write_file(source, 'module sample\n#include "outer.h"\n') or { panic(err) }
+	mut prefs := pref.new_preferences()
+	prefs.target = pref.host_target()
+	mut p := parser.Parser.new(prefs)
+	a := p.parse_file(source)
+	_, _, has_untracked := cache_external_input_files(a, '', {
+		'sample': true
+	}, [], prefs.target)
+	assert has_untracked
 }
 
 fn test_cache_input_scan_separates_native_source_roots_from_dependencies() {

--- a/vlib/v3/gen/c/target_test.v
+++ b/vlib/v3/gen/c/target_test.v
@@ -370,6 +370,33 @@ fn test_cache_input_scan_rejects_dynamic_include_macros() {
 	assert has_untracked
 }
 
+fn test_cache_input_scan_rejects_unresolved_include_macros() {
+	dir := os.join_path(os.vtmp_dir(), 'v3_unresolved_macro_cache_inputs_${os.getpid()}')
+	os.rmdir_all(dir) or {}
+	os.mkdir_all(dir) or { panic(err) }
+	defer {
+		os.rmdir_all(dir) or {}
+	}
+	outer_header := os.join_path(dir, 'outer.h')
+	nested_header := os.join_path(dir, 'nested.h')
+	os.write_file(outer_header, '#include V3_EXTERNAL_HEADER\n') or { panic(err) }
+	os.write_file(nested_header, '#define NESTED_VALUE 1\n') or { panic(err) }
+	source := os.join_path(dir, 'sample.v')
+	os.write_file(source,
+		'module sample\n#define V3_EXTERNAL_HEADER "nested.h"\n#include "outer.h"\n') or {
+		panic(err)
+	}
+	mut prefs := pref.new_preferences()
+	prefs.target = pref.host_target()
+	mut p := parser.Parser.new(prefs)
+	a := p.parse_file(source)
+	inputs, _, has_untracked := cache_external_input_files(a, '', {
+		'sample': true
+	}, [], prefs.target)
+	assert has_untracked
+	assert inputs['sample'] == [os.real_path(outer_header)]
+}
+
 fn test_cache_input_scan_separates_native_source_roots_from_dependencies() {
 	dir := os.join_path(os.vtmp_dir(), 'v3_native_source_root_inputs_${os.getpid()}')
 	os.rmdir_all(dir) or {}

--- a/vlib/v3/gen/c/target_test.v
+++ b/vlib/v3/gen/c/target_test.v
@@ -379,22 +379,34 @@ fn test_cache_input_scan_separates_native_source_roots_from_dependencies() {
 	}
 	root_source := os.join_path(dir, 'root.c')
 	nested_source := os.join_path(dir, 'nested.c')
+	direct_header := os.join_path(dir, 'direct.h')
+	nested_header := os.join_path(dir, 'nested.h')
 	os.write_file(root_source, '#include "nested.c"\n') or { panic(err) }
 	os.write_file(nested_source, 'static int nested_value(void) { return 42; }\n') or { panic(err) }
+	os.write_file(direct_header, '#include "nested.h"\n') or { panic(err) }
+	os.write_file(nested_header, 'static int header_value(void) { return 1; }\n') or { panic(err) }
 	source := os.join_path(dir, 'sample.v')
-	os.write_file(source, 'module sample\n#include "root.c"\n') or { panic(err) }
+	os.write_file(source, 'module sample\n#include "root.c"\n#include "direct.h"\n') or {
+		panic(err)
+	}
 	mut prefs := pref.new_preferences()
 	prefs.target = pref.host_target()
 	mut p := parser.Parser.new(prefs)
 	a := p.parse_file(source)
-	inputs, native_roots, has_untracked := cache_external_input_files(a, '', {
+	inputs, native_roots, unscoped_inputs, _, _, has_untracked := cache_external_input_files_with_resolved_flags(a,
+		'', {
 		'sample': true
 	}, [], prefs.target)
 	assert !has_untracked
-	mut expected_inputs := [os.real_path(root_source), os.real_path(nested_source)]
+	mut expected_inputs := [os.real_path(root_source), os.real_path(nested_source),
+		os.real_path(direct_header), os.real_path(nested_header)]
 	expected_inputs.sort()
 	assert inputs['sample'] == expected_inputs
 	assert native_roots['sample'] == [os.real_path(root_source)]
+	mut expected_unscoped_inputs := [os.real_path(direct_header),
+		os.real_path(nested_header)]
+	expected_unscoped_inputs.sort()
+	assert unscoped_inputs['sample'] == expected_unscoped_inputs
 }
 
 fn test_termux_comptime_branch_uses_canonical_target() {

--- a/vlib/v3/markused/markused.v
+++ b/vlib/v3/markused/markused.v
@@ -609,19 +609,10 @@ fn enqueue_used_interface_dispatch_implementers(tc &types.TypeChecker, mut used 
 				continue
 			}
 			for impl in impls {
-				impl_method := tc.concrete_method_signature_key(impl, method) or {
-					'${impl}.${method}'
-				}
-				if enqueue(impl_method, mut used, mut queue) {
-					added = true
-				}
-				lowered := markused_c_name(impl_method)
-				if lowered != impl_method && enqueue(lowered, mut used, mut queue) {
-					added = true
-				}
-				short_impl := '${impl_method.all_before_last('.').all_after_last('.')}.${method}'
-				if short_impl != impl_method && enqueue(short_impl, mut used, mut queue) {
-					added = true
+				for alias in interface_implementer_method_aliases(impl, method, tc) {
+					if enqueue(alias, mut used, mut queue) {
+						added = true
+					}
 				}
 				enqueue_implicit_interface_str_helpers_for_impl(iface_name, method, impl, tc, mut
 					used, mut queue)
@@ -629,6 +620,20 @@ fn enqueue_used_interface_dispatch_implementers(tc &types.TypeChecker, mut used 
 		}
 	}
 	return added
+}
+
+fn interface_implementer_method_aliases(impl string, method string, tc &types.TypeChecker) []string {
+	impl_method := tc.concrete_method_signature_key(impl, method) or { '${impl}.${method}' }
+	mut aliases := [impl_method]
+	lowered := markused_c_name(impl_method)
+	if lowered != impl_method {
+		aliases << lowered
+	}
+	short_impl := '${impl_method.all_before_last('.').all_after_last('.')}.${method}'
+	if short_impl != impl_method {
+		aliases << short_impl
+	}
+	return aliases
 }
 
 fn markused_is_interface_dispatch_call(name string, cur_module string, tc &types.TypeChecker) bool {
@@ -729,6 +734,28 @@ fn interface_dispatch_dotted_name(name string, tc &types.TypeChecker) ?string {
 		}
 	}
 	return none
+}
+
+// interface_dispatch_implementer_aliases returns the function-name aliases
+// markused enqueues for each concrete implementation of an interface dispatch.
+pub fn interface_dispatch_implementer_aliases(name string, cur_module string, tc &types.TypeChecker) [][]string {
+	dotted_name := interface_dispatch_dotted_name(name, tc) or { return [][]string{} }
+	recv := dotted_name.all_before_last('.')
+	method := dotted_name.all_after_last('.')
+	iface_name := interface_name_for_receiver(recv, cur_module, tc) or { return [][]string{} }
+	if tc.interface_method_signature_key(iface_name, method) == none {
+		return [][]string{}
+	}
+	impls := if markused_is_ierror_interface_name(iface_name) {
+		tc.ierror_impl_names()
+	} else {
+		tc.interface_impl_names(iface_name)
+	}
+	mut result := [][]string{cap: impls.len}
+	for impl in impls {
+		result << interface_implementer_method_aliases(impl, method, tc)
+	}
+	return result
 }
 
 fn markused_is_ierror_interface_name(name string) bool {

--- a/vlib/v3/markused/markused.v
+++ b/vlib/v3/markused/markused.v
@@ -736,28 +736,6 @@ fn interface_dispatch_dotted_name(name string, tc &types.TypeChecker) ?string {
 	return none
 }
 
-// interface_dispatch_implementer_aliases returns the function-name aliases
-// markused enqueues for each concrete implementation of an interface dispatch.
-pub fn interface_dispatch_implementer_aliases(name string, cur_module string, tc &types.TypeChecker) [][]string {
-	dotted_name := interface_dispatch_dotted_name(name, tc) or { return [][]string{} }
-	recv := dotted_name.all_before_last('.')
-	method := dotted_name.all_after_last('.')
-	iface_name := interface_name_for_receiver(recv, cur_module, tc) or { return [][]string{} }
-	if tc.interface_method_signature_key(iface_name, method) == none {
-		return [][]string{}
-	}
-	impls := if markused_is_ierror_interface_name(iface_name) {
-		tc.ierror_impl_names()
-	} else {
-		tc.interface_impl_names(iface_name)
-	}
-	mut result := [][]string{cap: impls.len}
-	for impl in impls {
-		result << interface_implementer_method_aliases(impl, method, tc)
-	}
-	return result
-}
-
 fn markused_is_ierror_interface_name(name string) bool {
 	return name == 'IError' || name == 'builtin.IError'
 }

--- a/vlib/v3/modulecache/modulecache.v
+++ b/vlib/v3/modulecache/modulecache.v
@@ -9,7 +9,7 @@ import v3.types
 pub const builtin_bundle_imports = ['strconv', 'strings', 'hash', 'math.bits']
 pub const builtin_bundle_modules = ['builtin', 'strconv', 'strings', 'hash', 'bits', 'math.bits']
 
-const cache_format = 'v3-module-cache-44'
+const cache_format = 'v3-module-cache-45'
 const c_body_begin = '/* V3CACHE_BODY_BEGIN */'
 const c_body_end = '/* V3CACHE_BODY_END */'
 const c_module_prefix = '/* V3CACHE_MODULE '
@@ -33,6 +33,8 @@ pub:
 
 // Entry contains the persistent artifacts for one V module.
 pub struct Entry {
+	source_bodies       bool
+	source_bodies_known bool
 pub:
 	header       string
 	object       string
@@ -646,20 +648,21 @@ pub fn (m &Manager) valid_entry_with_metadata_cache(module_name string, source_f
 		return none
 	}
 	entry := m.entry(module_name, source_files)
-	if !os.is_file(entry.header) || !os.is_file(entry.header_stamp)
-		|| !os.is_file(entry.object_stamp) {
+	if !os.is_file(entry.header) {
 		return none
 	}
 	stamp := os.read_file(entry.header_stamp) or { return none }
 	expected := entry_stamp(m.salt, m.source_signature(source_files))
-	if stamp != expected {
-		return none
-	}
+	source_bodies := header_stamp_source_bodies(stamp, expected) or { return none }
 	object_stamp := os.read_file(entry.object_stamp) or { return none }
 	if !object_stamp_valid_with_metadata_cache(object_stamp, expected, mut dependency_metadata) {
 		return none
 	}
-	return entry
+	return Entry{
+		...entry
+		source_bodies:       source_bodies
+		source_bodies_known: true
+	}
 }
 
 // valid_header reports whether a declaration header matches its module sources.
@@ -668,21 +671,27 @@ pub fn (m &Manager) valid_header(module_name string, source_files []string) ?Ent
 		return none
 	}
 	entry := m.entry(module_name, source_files)
-	if !os.is_file(entry.header) || !os.is_file(entry.header_stamp) {
+	if !os.is_file(entry.header) {
 		return none
 	}
 	stamp := os.read_file(entry.header_stamp) or { return none }
-	if stamp != entry_stamp(m.salt, m.source_signature(source_files)) {
-		return none
+	expected := entry_stamp(m.salt, m.source_signature(source_files))
+	source_bodies := header_stamp_source_bodies(stamp, expected) or { return none }
+	return Entry{
+		...entry
+		source_bodies:       source_bodies
+		source_bodies_known: true
 	}
-	return entry
 }
 
 // header_needs_source reports whether a declaration header has bodies that must
 // remain available to per-program monomorphization.
 pub fn header_needs_source(entry Entry) bool {
-	header := os.read_file(entry.header) or { return true }
-	return header.contains(source_body_marker)
+	if !entry.source_bodies_known {
+		header := os.read_file(entry.header) or { return true }
+		return header.contains(source_body_marker)
+	}
+	return entry.source_bodies
 }
 
 // valid_object reports whether a cached object matches the supplied sources.
@@ -708,7 +717,8 @@ pub fn (m &Manager) write_entry(module_name string, source_files []string, heade
 	}
 	entry := m.entry(module_name, source_files)
 	write_atomic(entry.header, header)!
-	write_atomic(entry.header_stamp, entry_stamp(m.salt, m.source_signature(source_files)))!
+	write_atomic(entry.header_stamp, header_entry_stamp(m.salt, m.source_signature(source_files),
+		header))!
 	return entry
 }
 
@@ -719,7 +729,8 @@ pub fn (m &Manager) write_header(module_name string, source_files []string, head
 	}
 	entry := m.entry(module_name, source_files)
 	write_atomic(entry.header, header)!
-	write_atomic(entry.header_stamp, entry_stamp(m.salt, m.source_signature(source_files)))!
+	write_atomic(entry.header_stamp, header_entry_stamp(m.salt, m.source_signature(source_files),
+		header))!
 	return entry
 }
 
@@ -955,6 +966,21 @@ fn entry_stamp(salt string, source_hash string) string {
 	return 'format=${cache_format}\nconfig=${hash_text(salt)}\nsource=${source_hash}\n'
 }
 
+fn header_entry_stamp(salt string, source_hash string, header string) string {
+	return entry_stamp(salt, source_hash) +
+		'source_bodies=${int(header.contains(source_body_marker))}\n'
+}
+
+fn header_stamp_source_bodies(stamp string, expected_entry string) ?bool {
+	if stamp == expected_entry + 'source_bodies=0\n' {
+		return false
+	}
+	if stamp == expected_entry + 'source_bodies=1\n' {
+		return true
+	}
+	return none
+}
+
 fn object_entry_stamp(salt string, source_hash string, dependency_inputs map[string]string, compile_signature string) string {
 	mut out := strings.new_builder(256 + dependency_inputs.len * 96)
 	out.write_string(entry_stamp(salt, source_hash))
@@ -1012,7 +1038,16 @@ fn object_stamp_valid_with_metadata_cache(stamp string, expected_entry string, m
 		if dependency.metadata.len > 0 && current_metadata == dependency.metadata {
 			continue
 		}
-		if file_signature(dependency.path) != dependency.signature {
+		// Headers produced later in a cold cache build can have no metadata in an
+		// earlier module's stamp. Hash each such dependency only once per compiler
+		// run even when it appears in many transitive object stamps.
+		signature_key := '\x00${dependency.path}'
+		current_signature := dependency_metadata[signature_key] or {
+			signature := file_signature(dependency.path)
+			dependency_metadata[signature_key] = signature
+			signature
+		}
+		if current_signature != dependency.signature {
 			return false
 		}
 	}

--- a/vlib/v3/modulecache/modulecache.v
+++ b/vlib/v3/modulecache/modulecache.v
@@ -20,6 +20,7 @@ const c_source_directives_end = '/* V3CACHE_SOURCE_DIRECTIVES_END */'
 const c_late_directives_begin = '/* V3CACHE_LATE_DIRECTIVES_BEGIN */'
 const c_late_directives_end = '/* V3CACHE_LATE_DIRECTIVES_END */'
 const source_body_marker = '// v3cache: source bodies required'
+const source_signature_cache_format = 'v3-source-signature-cache-1'
 
 // Manager owns persistent v3 module cache paths for one compiler configuration.
 pub struct Manager {
@@ -206,21 +207,27 @@ fn (m &Manager) incremental_program_entry(source_files []string) IncrementalProg
 // source_signature hashes selected source paths, contents, resolved module roots,
 // build/environment values, and pkg-config probe results in stable order.
 pub fn source_signature(source_files []string) string {
-	return source_signature_with_build_values(source_files, '')
+	return source_signature_details(source_files, '').signature
 }
 
-fn source_signature_with_build_values(source_files []string, build_pseudo_values string) string {
+struct SourceSignatureDetails {
+	signature  string
+	validation []string
+}
+
+fn source_signature_details(source_files []string, build_pseudo_values string) SourceSignatureDetails {
 	mut files := source_files.clone()
 	files.sort()
 	mut hash := u64(1469598103934665603)
 	mut env_names := map[string]bool{}
 	mut pkgconfig_names := map[string]bool{}
 	mut uses_build_pseudo := false
+	mut validation := []string{}
 	for file in files {
 		path := os.real_path(file)
 		hash = hash_bytes(hash, path.bytes())
 		hash = hash_bytes(hash, [u8(0)])
-		content := os.read_bytes(file) or { return '' }
+		content := os.read_bytes(file) or { return SourceSignatureDetails{} }
 		hash = hash_bytes(hash, content)
 		hash = hash_bytes(hash, [u8(0xff)])
 		source := content.bytestr()
@@ -231,11 +238,17 @@ fn source_signature_with_build_values(source_files []string, build_pseudo_values
 		if source.contains('@VMODROOT') || source.contains('@VMOD_FILE')
 			|| source.contains('@VROOT') {
 			root, vmod_file := signature_vmod_root(file)
+			vmod_metadata := if vmod_file.len > 0 {
+				file_metadata_signature(vmod_file)
+			} else {
+				''
+			}
+			validation << 'vmod=${path}\t${root}\t${vmod_file}\t${vmod_metadata}'
 			hash = hash_bytes(hash, [u8(0xfc)])
 			hash = hash_bytes(hash, root.bytes())
 			hash = hash_bytes(hash, [u8(0)])
 			if vmod_file.len > 0 {
-				vmod_content := os.read_bytes(vmod_file) or { return '' }
+				vmod_content := os.read_bytes(vmod_file) or { return SourceSignatureDetails{} }
 				hash = hash_bytes(hash, [u8(1)])
 				hash = hash_bytes(hash, vmod_file.bytes())
 				hash = hash_bytes(hash, [u8(0)])
@@ -253,6 +266,7 @@ fn source_signature_with_build_values(source_files []string, build_pseudo_values
 		}
 	}
 	if uses_build_pseudo {
+		validation << 'build=${hash_text(build_pseudo_values)}'
 		hash = hash_bytes(hash, [u8(0xfb)])
 		hash = hash_bytes(hash, build_pseudo_values.bytes())
 		hash = hash_bytes(hash, [u8(0xff)])
@@ -260,27 +274,156 @@ fn source_signature_with_build_values(source_files []string, build_pseudo_values
 	mut names := env_names.keys()
 	names.sort()
 	for name in names {
+		value := os.getenv(name)
+		validation << 'env=${name}\t${hash_text(value)}'
 		hash = hash_bytes(hash, [u8(0xfe)])
 		hash = hash_bytes(hash, name.bytes())
 		hash = hash_bytes(hash, [u8(0)])
-		hash = hash_bytes(hash, os.getenv(name).bytes())
+		hash = hash_bytes(hash, value.bytes())
 		hash = hash_bytes(hash, [u8(0xff)])
 	}
 	mut packages := pkgconfig_names.keys()
 	packages.sort()
 	for name in packages {
 		available := os.execute('pkg-config --exists ${name}').exit_code == 0
+		validation << 'pkg=${name}\t${if available { 1 } else { 0 }}'
 		hash = hash_bytes(hash, [u8(0xfd)])
 		hash = hash_bytes(hash, name.bytes())
 		hash = hash_bytes(hash, [u8(0)])
 		hash = hash_bytes(hash, [u8(if available { 1 } else { 0 })])
 		hash = hash_bytes(hash, [u8(0xff)])
 	}
-	return hash.hex()
+	return SourceSignatureDetails{
+		signature:  hash.hex()
+		validation: validation
+	}
 }
 
 fn (m &Manager) source_signature(source_files []string) string {
-	return source_signature_with_build_values(source_files, m.build_pseudo_values)
+	return cached_source_signature_with_build_values(m.dir, 'module', source_files,
+		m.build_pseudo_values)
+}
+
+// cached_source_signature returns a content signature while using precise file
+// metadata to avoid rereading unchanged inputs on subsequent compiler runs.
+pub fn cached_source_signature(cache_dir string, namespace string, source_files []string) string {
+	return cached_source_signature_with_build_values(cache_dir, namespace, source_files, '')
+}
+
+fn cached_source_signature_with_build_values(cache_dir string, namespace string, source_files []string, build_pseudo_values string) string {
+	mut paths := source_files.map(os.real_path(it))
+	paths.sort()
+	cache_key := hash_text(namespace + '\n' + paths.join('\n'))
+	cache_path := os.join_path(cache_dir, '.source_signature_${cache_key}')
+	metadata := source_files_metadata_signature(paths)
+	if metadata.len > 0 {
+		cached := os.read_file(cache_path) or { '' }
+		if signature := valid_cached_source_signature(cached, metadata, build_pseudo_values) {
+			return signature
+		}
+	}
+	details := source_signature_details(paths, build_pseudo_values)
+	if details.signature.len == 0 {
+		return ''
+	}
+	fresh_metadata := source_files_metadata_signature(paths)
+	if fresh_metadata.len > 0 {
+		mut out := strings.new_builder(192 + details.validation.len * 96)
+		out.writeln('format=${source_signature_cache_format}')
+		out.writeln('metadata=${fresh_metadata}')
+		for input in details.validation {
+			out.writeln(input)
+		}
+		out.writeln('source=${details.signature}')
+		out.writeln('complete=1')
+		os.mkdir_all(cache_dir) or {}
+		if os.is_dir(cache_dir) {
+			write_atomic(cache_path, out.str()) or {}
+		}
+	}
+	return details.signature
+}
+
+fn source_files_metadata_signature(paths []string) string {
+	mut hash := u64(1469598103934665603)
+	for path in paths {
+		metadata := file_metadata_signature(path)
+		if metadata.len == 0 {
+			return ''
+		}
+		hash = hash_bytes(hash, path.bytes())
+		hash = hash_bytes(hash, [u8(0)])
+		hash = hash_bytes(hash, metadata.bytes())
+		hash = hash_bytes(hash, [u8(0xff)])
+	}
+	return hash.hex()
+}
+
+fn valid_cached_source_signature(content string, metadata string, build_pseudo_values string) ?string {
+	lines := content.split_into_lines()
+	if lines.len < 4 || lines[0] != 'format=${source_signature_cache_format}'
+		|| lines[1] != 'metadata=${metadata}' || lines.last() != 'complete=1' {
+		return none
+	}
+	mut signature := ''
+	for line in lines[2..lines.len - 1] {
+		if line.starts_with('source=') {
+			if signature.len > 0 {
+				return none
+			}
+			signature = line.all_after('source=')
+			continue
+		}
+		if line.starts_with('build=') {
+			if line != 'build=${hash_text(build_pseudo_values)}' {
+				return none
+			}
+			continue
+		}
+		if line.starts_with('env=') {
+			parts := line['env='.len..].split('\t')
+			if parts.len != 2 || parts[0].len == 0 || hash_text(os.getenv(parts[0])) != parts[1] {
+				return none
+			}
+			continue
+		}
+		if line.starts_with('pkg=') {
+			parts := line['pkg='.len..].split('\t')
+			if parts.len != 2 || parts[0].len == 0 {
+				return none
+			}
+			available := os.execute('pkg-config --exists ${parts[0]}').exit_code == 0
+			if parts[1] != '${if available {
+				1
+			} else {
+				0
+			}}' {
+				return none
+			}
+			continue
+		}
+		if line.starts_with('vmod=') {
+			parts := line['vmod='.len..].split('\t')
+			if parts.len != 4 || parts[0].len == 0 {
+				return none
+			}
+			root, vmod_file := signature_vmod_root(parts[0])
+			vmod_metadata := if vmod_file.len > 0 {
+				file_metadata_signature(vmod_file)
+			} else {
+				''
+			}
+			if root != parts[1] || vmod_file != parts[2] || vmod_metadata != parts[3] {
+				return none
+			}
+			continue
+		}
+		return none
+	}
+	if signature.len == 0 {
+		return none
+	}
+	return signature
 }
 
 fn signature_vmod_root(source_file string) (string, string) {

--- a/vlib/v3/modulecache/modulecache.v
+++ b/vlib/v3/modulecache/modulecache.v
@@ -774,6 +774,57 @@ pub fn (m &Manager) valid_cgen(source_files []string, generation_signature strin
 	return entry
 }
 
+// cached_cgen_dependency_inputs restores dependency records whose prefixes are
+// allowed to vary, after validating the program sources, generation signature,
+// and every fixed dependency supplied by the caller.
+pub fn (m &Manager) cached_cgen_dependency_inputs(source_files []string, generation_signature string, fixed_dependencies map[string]string, restored_prefixes []string) ?map[string]string {
+	if !m.enabled || source_files.len == 0 {
+		return none
+	}
+	entry := m.cgen_entry(source_files)
+	if !os.is_file(entry.source) || !os.is_file(entry.metadata) || !os.is_file(entry.stamp) {
+		return none
+	}
+	stamp := os.read_file(entry.stamp) or { return none }
+	expected_head := entry_stamp(m.salt, m.source_signature(source_files)) +
+		'generation=${hash_text(generation_signature)}\n'
+	if !stamp.starts_with(expected_head) {
+		return none
+	}
+	mut restored := map[string]string{}
+	mut fixed_seen := map[string]bool{}
+	for line in stamp[expected_head.len..].split_into_lines() {
+		if !line.starts_with('dependency=') {
+			return none
+		}
+		value := line['dependency='.len..]
+		tab := value.index_u8(`\t`)
+		if tab <= 0 || tab + 1 >= value.len {
+			return none
+		}
+		key := value[..tab]
+		signature := value[tab + 1..]
+		if key in restored || fixed_seen[key] {
+			return none
+		}
+		if expected := fixed_dependencies[key] {
+			if expected != signature {
+				return none
+			}
+			fixed_seen[key] = true
+			continue
+		}
+		if !restored_prefixes.any(key.starts_with(it)) {
+			return none
+		}
+		restored[key] = signature
+	}
+	if fixed_seen.len != fixed_dependencies.len {
+		return none
+	}
+	return restored
+}
+
 // valid_generic_program reports whether cached dependency specializations match
 // the program's type/call shape and all module cache inputs.
 pub fn (m &Manager) valid_generic_program(source_files []string, semantic_signature string, generation_signature string, dependency_inputs map[string]string) ?GenericProgramEntry {

--- a/vlib/v3/modulecache/modulecache.v
+++ b/vlib/v3/modulecache/modulecache.v
@@ -9,7 +9,7 @@ import v3.types
 pub const builtin_bundle_imports = ['strconv', 'strings', 'hash', 'math.bits']
 pub const builtin_bundle_modules = ['builtin', 'strconv', 'strings', 'hash', 'bits', 'math.bits']
 
-const cache_format = 'v3-module-cache-43'
+const cache_format = 'v3-module-cache-44'
 const c_body_begin = '/* V3CACHE_BODY_BEGIN */'
 const c_body_end = '/* V3CACHE_BODY_END */'
 const c_module_prefix = '/* V3CACHE_MODULE '
@@ -954,7 +954,7 @@ fn object_entry_stamp(salt string, source_hash string, dependency_inputs map[str
 	mut paths := dependency_inputs.keys()
 	paths.sort()
 	for path in paths {
-		out.writeln('dependency=${path}\t${dependency_inputs[path]}')
+		out.writeln('dependency=${path}\t${dependency_inputs[path]}\t${file_metadata_signature(path)}')
 	}
 	return out.str()
 }
@@ -990,18 +990,43 @@ fn object_stamp_valid(stamp string, expected_entry string) bool {
 		if !line.starts_with('dependency=') {
 			return false
 		}
-		value := line['dependency='.len..]
-		tab := value.last_index_u8(`\t`)
-		if tab <= 0 || tab + 1 >= value.len {
-			return false
+		dependency := parse_object_stamp_dependency(line) or { return false }
+		if dependency.metadata.len > 0
+			&& file_metadata_signature(dependency.path) == dependency.metadata {
+			continue
 		}
-		path := value[..tab]
-		expected_signature := value[tab + 1..]
-		if file_signature(path) != expected_signature {
+		if file_signature(dependency.path) != dependency.signature {
 			return false
 		}
 	}
 	return has_compile_signature
+}
+
+struct ObjectStampDependency {
+	path      string
+	signature string
+	metadata  string
+}
+
+fn parse_object_stamp_dependency(line string) ?ObjectStampDependency {
+	if !line.starts_with('dependency=') {
+		return none
+	}
+	value := line['dependency='.len..]
+	metadata_tab := value.last_index_u8(`\t`)
+	if metadata_tab <= 0 {
+		return none
+	}
+	path_and_signature := value[..metadata_tab]
+	signature_tab := path_and_signature.last_index_u8(`\t`)
+	if signature_tab <= 0 || signature_tab + 1 >= path_and_signature.len {
+		return none
+	}
+	return ObjectStampDependency{
+		path:      path_and_signature[..signature_tab]
+		signature: path_and_signature[signature_tab + 1..]
+		metadata:  value[metadata_tab + 1..]
+	}
 }
 
 fn object_stamp_dependencies_match(stamp string, expected map[string]string) bool {
@@ -1010,16 +1035,11 @@ fn object_stamp_dependencies_match(stamp string, expected map[string]string) boo
 		if !line.starts_with('dependency=') {
 			continue
 		}
-		value := line['dependency='.len..]
-		tab := value.last_index_u8(`\t`)
-		if tab <= 0 || tab + 1 >= value.len {
+		dependency := parse_object_stamp_dependency(line) or { return false }
+		if dependency.path in actual {
 			return false
 		}
-		path := value[..tab]
-		if path in actual {
-			return false
-		}
-		actual[path] = value[tab + 1..]
+		actual[dependency.path] = dependency.signature
 	}
 	for path, signature in expected {
 		if path !in actual {

--- a/vlib/v3/modulecache/modulecache.v
+++ b/vlib/v3/modulecache/modulecache.v
@@ -634,6 +634,14 @@ fn skip_signature_quoted_text(source string, quote_pos int, is_raw bool) int {
 
 // valid_entry reports whether both interface and object artifacts match their sources.
 pub fn (m &Manager) valid_entry(module_name string, source_files []string) ?Entry {
+	mut dependency_metadata := map[string]string{}
+	return m.valid_entry_with_metadata_cache(module_name, source_files, mut dependency_metadata)
+}
+
+// valid_entry_with_metadata_cache reports whether both interface and object
+// artifacts match their sources, reusing dependency metadata already observed
+// during this compiler run.
+pub fn (m &Manager) valid_entry_with_metadata_cache(module_name string, source_files []string, mut dependency_metadata map[string]string) ?Entry {
 	if !m.enabled || source_files.len == 0 {
 		return none
 	}
@@ -648,7 +656,7 @@ pub fn (m &Manager) valid_entry(module_name string, source_files []string) ?Entr
 		return none
 	}
 	object_stamp := os.read_file(entry.object_stamp) or { return none }
-	if !object_stamp_valid(object_stamp, expected) {
+	if !object_stamp_valid_with_metadata_cache(object_stamp, expected, mut dependency_metadata) {
 		return none
 	}
 	return entry
@@ -972,6 +980,11 @@ fn cgen_entry_stamp(salt string, source_hash string, dependency_inputs map[strin
 }
 
 fn object_stamp_valid(stamp string, expected_entry string) bool {
+	mut dependency_metadata := map[string]string{}
+	return object_stamp_valid_with_metadata_cache(stamp, expected_entry, mut dependency_metadata)
+}
+
+fn object_stamp_valid_with_metadata_cache(stamp string, expected_entry string, mut dependency_metadata map[string]string) bool {
 	if !stamp.starts_with(expected_entry) {
 		return false
 	}
@@ -991,8 +1004,12 @@ fn object_stamp_valid(stamp string, expected_entry string) bool {
 			return false
 		}
 		dependency := parse_object_stamp_dependency(line) or { return false }
-		if dependency.metadata.len > 0
-			&& file_metadata_signature(dependency.path) == dependency.metadata {
+		current_metadata := dependency_metadata[dependency.path] or {
+			metadata := file_metadata_signature(dependency.path)
+			dependency_metadata[dependency.path] = metadata
+			metadata
+		}
+		if dependency.metadata.len > 0 && current_metadata == dependency.metadata {
 			continue
 		}
 		if file_signature(dependency.path) != dependency.signature {

--- a/vlib/v3/modulecache/modulecache.v
+++ b/vlib/v3/modulecache/modulecache.v
@@ -9,7 +9,7 @@ import v3.types
 pub const builtin_bundle_imports = ['strconv', 'strings', 'hash', 'math.bits']
 pub const builtin_bundle_modules = ['builtin', 'strconv', 'strings', 'hash', 'bits', 'math.bits']
 
-const cache_format = 'v3-module-cache-42'
+const cache_format = 'v3-module-cache-43'
 const c_body_begin = '/* V3CACHE_BODY_BEGIN */'
 const c_body_end = '/* V3CACHE_BODY_END */'
 const c_module_prefix = '/* V3CACHE_MODULE '
@@ -3394,7 +3394,13 @@ fn node_creates_generic_specialization(a &flat.FlatAst, tc &types.TypeChecker, i
 	}
 	node := a.nodes[int(id)]
 	if node.kind == .call && node.children_count > 0 {
-		callee := a.child_node(&node, 0)
+		callee_id := a.child(&node, 0)
+		if name := generic_call_source_name(a, callee_id) {
+			if generic_callees[name] {
+				return true
+			}
+		}
+		callee := a.nodes[int(callee_id)]
 		if callee.kind == .selector && callee.children_count > 0 {
 			receiver_type := tc.resolve_type(a.child(callee, 0)).name().trim_left('&?')
 			receiver_base := receiver_type.all_before('[')
@@ -3410,6 +3416,34 @@ fn node_creates_generic_specialization(a &flat.FlatAst, tc &types.TypeChecker, i
 		}
 	}
 	return false
+}
+
+fn generic_call_source_name(a &flat.FlatAst, id flat.NodeId) ?string {
+	if int(id) < 0 || int(id) >= a.nodes.len {
+		return none
+	}
+	node := a.nodes[int(id)]
+	match node.kind {
+		.ident {
+			return node.value
+		}
+		.selector {
+			if node.children_count == 0 {
+				return none
+			}
+			base := a.child_node(&node, 0)
+			if base.kind == .ident && base.value.len > 0 && node.value.len > 0 {
+				return '${base.value}.${node.value}'
+			}
+		}
+		.index, .paren {
+			if node.children_count > 0 {
+				return generic_call_source_name(a, a.child(&node, 0))
+			}
+		}
+		else {}
+	}
+	return none
 }
 
 fn generic_specialization_callee_names(tc &types.TypeChecker) map[string]bool {
@@ -3841,7 +3875,12 @@ fn fn_text(a &flat.FlatAst, module_name string, node flat.Node, is_c bool, decla
 		}
 		mut ptype := p.typ
 		mut prefix := ''
-		if ptype.starts_with('&') && p.is_mut {
+		if p.is_mut && p.op == .amp {
+			prefix = 'mut '
+			if !ptype.starts_with('&') {
+				ptype = '&${ptype}'
+			}
+		} else if ptype.starts_with('&') && p.is_mut {
 			prefix = 'mut '
 			ptype = ptype[1..].trim_space()
 		}

--- a/vlib/v3/modulecache/modulecache.v
+++ b/vlib/v3/modulecache/modulecache.v
@@ -329,21 +329,28 @@ fn cached_source_signature_with_build_values(cache_dir string, namespace string,
 		return ''
 	}
 	fresh_metadata := source_files_metadata_signature(paths)
-	if fresh_metadata.len > 0 {
-		mut out := strings.new_builder(192 + details.validation.len * 96)
-		out.writeln('format=${source_signature_cache_format}')
-		out.writeln('metadata=${fresh_metadata}')
-		for input in details.validation {
-			out.writeln(input)
-		}
-		out.writeln('source=${details.signature}')
-		out.writeln('complete=1')
+	if content := source_signature_cache_content(metadata, fresh_metadata, details) {
 		os.mkdir_all(cache_dir) or {}
 		if os.is_dir(cache_dir) {
-			write_atomic(cache_path, out.str()) or {}
+			write_atomic(cache_path, content) or {}
 		}
 	}
 	return details.signature
+}
+
+fn source_signature_cache_content(metadata string, fresh_metadata string, details SourceSignatureDetails) ?string {
+	if metadata.len == 0 || fresh_metadata != metadata {
+		return none
+	}
+	mut out := strings.new_builder(192 + details.validation.len * 96)
+	out.writeln('format=${source_signature_cache_format}')
+	out.writeln('metadata=${metadata}')
+	for input in details.validation {
+		out.writeln(input)
+	}
+	out.writeln('source=${details.signature}')
+	out.writeln('complete=1')
+	return out.str()
 }
 
 fn source_files_metadata_signature(paths []string) string {

--- a/vlib/v3/modulecache/modulecache.v
+++ b/vlib/v3/modulecache/modulecache.v
@@ -1392,7 +1392,8 @@ fn c_native_localize_function_definitions(source string) string {
 		if brace_depth == 0 {
 			if pending.len == 0
 				&& (in_block_comment || trimmed.len == 0 || trimmed.starts_with('//')
-				|| trimmed.starts_with('#')) {
+				|| trimmed.starts_with('#')
+				|| trim_leading_c_comments(trimmed).len == 0) {
 				out.writeln(raw_line)
 				in_block_comment = next_comment
 				continue

--- a/vlib/v3/modulecache/modulecache_test.v
+++ b/vlib/v3/modulecache/modulecache_test.v
@@ -1,0 +1,22 @@
+module modulecache
+
+fn test_source_signature_cache_content_requires_stable_metadata() {
+	details := SourceSignatureDetails{
+		signature:  'content-signature'
+		validation: ['env=NAME\tvalue']
+	}
+	if _ := source_signature_cache_content('before', 'after', details) {
+		assert false, 'changed metadata must prevent source signature caching'
+	}
+	if _ := source_signature_cache_content('', '', details) {
+		assert false, 'missing metadata must prevent source signature caching'
+	}
+
+	content := source_signature_cache_content('stable', 'stable', details) or {
+		assert false, 'stable metadata should allow source signature caching'
+		return
+	}
+	assert content.contains('metadata=stable\n')
+	assert content.contains('source=content-signature\n')
+	assert content.ends_with('complete=1\n')
+}

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -234,6 +234,24 @@ fn module_cache_artifact(cache_dir string, prefix string, extension string) stri
 	return ''
 }
 
+fn module_cache_configuration_dirs(cache_dir string) []string {
+	mut dirs := []string{}
+	for entry in os.ls(cache_dir) or { return dirs } {
+		if !entry.starts_with('v3_module_cache_') {
+			continue
+		}
+		root := os.join_path(cache_dir, entry)
+		for config in os.ls(root) or { continue } {
+			path := os.join_path(root, config)
+			if os.is_dir(path) {
+				dirs << path
+			}
+		}
+	}
+	dirs.sort()
+	return dirs
+}
+
 fn changed_module_cache_objects(before map[string]u64, after map[string]u64) []string {
 	mut changed := []string{}
 	for name, hash in before {
@@ -1366,6 +1384,55 @@ fn main() {
 	assert second.exit_code == 0, second.output
 	assert !second.output.contains('cgen (cached)'), second.output
 	assert run_module_cache_binary(second_output) == '42'
+}
+
+fn test_module_cache_salt_tracks_default_cc_wrapper_version() {
+	$if windows {
+		return
+	}
+	v3_bin := build_module_cache_v3()
+	real_cc := os.find_abs_path_of_executable('cc') or { panic('default cc not found') }
+	root := os.join_path(os.temp_dir(), 'v3_default_cc_wrapper_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	old_path := os.getenv('PATH')
+	defer {
+		os.setenv('PATH', old_path, true)
+		os.rmdir_all(root) or {}
+	}
+	version_state := os.join_path(root, 'cc-version')
+	write_module_cache_file(root, 'cc-version', 'wrapper toolchain one\n')
+	cc_wrapper := os.join_path(root, 'cc')
+	write_module_cache_file(root, 'cc', '#!/bin/sh
+if [ "\$1" = "--version" ]; then
+	cat ${os.quoted_path(version_state)}
+	exit 0
+fi
+exec ${os.quoted_path(real_cc)} "\$@"
+')
+	os.chmod(cc_wrapper, 0o700) or { panic(err) }
+	os.setenv('PATH', '${root}${os.path_delimiter}${old_path}', true)
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'module main
+
+fn main() {
+	println(42)
+}
+')
+	cache_dir := os.join_path(root, 'cache')
+	first_output := os.join_path(root, 'first')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, first_output)
+	assert run_module_cache_binary(first_output) == '42'
+	first_configs := module_cache_configuration_dirs(cache_dir)
+	assert first_configs.len == 1, first_configs.str()
+
+	write_module_cache_file(root, 'cc-version', 'wrapper toolchain two\n')
+	second_output := os.join_path(root, 'second')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, second_output)
+	assert run_module_cache_binary(second_output) == '42'
+	second_configs := module_cache_configuration_dirs(cache_dir)
+	assert second_configs.len == first_configs.len + 1, second_configs.str()
+	assert second_configs.any(it !in first_configs), second_configs.str()
 }
 
 fn test_module_cache_restart_preserves_compiler_stderr() {

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -4665,6 +4665,62 @@ fn main() {
 	assert run_module_cache_binary(second_output) == 'called'
 }
 
+fn test_incremental_program_cache_falls_back_for_newly_reachable_stringifier() {
+	$if !macos {
+		return
+	}
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_incremental_stringifier_reachability_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', "module main
+
+struct Value {
+	n int
+}
+
+fn (value Value) str() string {
+	return 'value \${value.n}'
+}
+
+fn main() {
+	println('before')
+}
+")
+	cache_dir := os.join_path(root, 'cache')
+	first_output := os.join_path(root, 'first')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, first_output)
+	assert run_module_cache_binary(first_output) == 'before'
+
+	write_module_cache_file(root, 'main.v', "module main
+
+struct Value {
+	n int
+}
+
+fn (value Value) str() string {
+	return 'value \${value.n}'
+}
+
+fn main() {
+	value := Value{
+		n: 42
+	}
+	println('\${value}')
+}
+")
+	second_output := os.join_path(root, 'second')
+	second :=
+		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -o ${os.quoted_path(second_output)} ${os.quoted_path(main_file)}')
+	assert second.exit_code == 0, second.output
+	assert !second.output.contains('cgen (incremental)'), second.output
+	assert run_module_cache_binary(second_output) == 'value 42'
+}
+
 fn test_incremental_program_cache_falls_back_for_newly_reachable_non_main_function() {
 	$if !macos {
 		return

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -1790,6 +1790,66 @@ fn main() {
 	assert run_module_cache_binary(second_output) == '2'
 }
 
+fn test_whole_program_cgen_invalidates_when_symlinked_include_dir_changes() {
+	$if windows {
+		return
+	}
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_cgen_symlinked_include_resolution_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	first_target := os.join_path(root, 'first_target')
+	second_target := os.join_path(root, 'second_target')
+	for dir in [first_target, second_target, os.join_path(root, 'fallback')] {
+		os.mkdir_all(dir) or { panic(err) }
+	}
+	include_link := os.join_path(root, 'first')
+	os.symlink(first_target, include_link) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	write_module_cache_file(root, 'fallback/value.h', 'static inline int v3_include_value(void) {
+	return 1;
+}
+')
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'module main
+
+#flag -I @DIR/first
+#flag -I @DIR/fallback
+#include <value.h>
+
+fn C.v3_include_value() int
+
+fn main() {
+	println(C.v3_include_value())
+}
+')
+	cache_dir := os.join_path(root, 'cache')
+	first_output := os.join_path(root, 'first-output')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, first_output)
+	assert run_module_cache_binary(first_output) == '1'
+
+	warm_output := os.join_path(root, 'warm-output')
+	warm :=
+		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -o ${os.quoted_path(warm_output)} ${os.quoted_path(main_file)}')
+	assert warm.exit_code == 0, warm.output
+	assert warm.output.contains('cgen (cached)'), warm.output
+	assert run_module_cache_binary(warm_output) == '1'
+
+	write_module_cache_file(root, 'second_target/value.h', 'static inline int v3_include_value(void) {
+	return 2;
+}
+')
+	os.rm(include_link) or { panic(err) }
+	os.symlink(second_target, include_link) or { panic(err) }
+	second_output := os.join_path(root, 'second-output')
+	second :=
+		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -o ${os.quoted_path(second_output)} ${os.quoted_path(main_file)}')
+	assert second.exit_code == 0, second.output
+	assert !second.output.contains('cgen (cached)'), second.output
+	assert run_module_cache_binary(second_output) == '2'
+}
+
 fn test_module_cache_rebuilds_modules_when_comptime_env_changes() {
 	v3_bin := build_module_cache_v3()
 	root := os.join_path(os.temp_dir(), 'v3_module_cache_comptime_env_${os.getpid()}')
@@ -3837,6 +3897,75 @@ fn main() {
 		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -o ${os.quoted_path(changed_output)} ${os.quoted_path(main_file)}')
 	assert changed.exit_code == 0, changed.output
 	assert run_module_cache_binary(changed_output) == 'stable\nafter'
+}
+
+fn test_generic_program_cache_invalidates_function_metadata() {
+	$if !macos {
+		return
+	}
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_generic_function_metadata_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', "module main
+
+fn identity[T](value T) T {
+	return value
+}
+
+@[export: 'v3_cache_export_before']
+fn exported_value() int {
+	return identity(42)
+}
+
+fn main() {
+	println(exported_value())
+}
+")
+	cache_dir := os.join_path(root, 'cache')
+	first_output := os.join_path(root, 'first')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, first_output)
+	assert run_module_cache_binary(first_output) == '42'
+	first_symbols := os.execute('nm -gU ${os.quoted_path(first_output)}')
+	assert first_symbols.exit_code == 0, first_symbols.output
+	assert first_symbols.output.contains('_v3_cache_export_before'), first_symbols.output
+	warm_output := os.join_path(root, 'warm')
+	warm :=
+		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -o ${os.quoted_path(warm_output)} ${os.quoted_path(main_file)}')
+	assert warm.exit_code == 0, warm.output
+	assert warm.output.contains('monomorphize (cached)'), warm.output
+	assert run_module_cache_binary(warm_output) == '42'
+
+	write_module_cache_file(root, 'main.v', "module main
+
+fn identity[T](value T) T {
+	return value
+}
+
+@[export: 'v3_cache_export_after']
+fn exported_value() int {
+	return identity(42)
+}
+
+fn main() {
+	println(exported_value())
+}
+")
+	second_output := os.join_path(root, 'second')
+	second :=
+		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -o ${os.quoted_path(second_output)} ${os.quoted_path(main_file)}')
+	assert second.exit_code == 0, second.output
+	assert !second.output.contains('monomorphize (cached)'), second.output
+	assert !second.output.contains('monomorphize (dependency cache)'), second.output
+	assert run_module_cache_binary(second_output) == '42'
+	second_symbols := os.execute('nm -gU ${os.quoted_path(second_output)}')
+	assert second_symbols.exit_code == 0, second_symbols.output
+	assert second_symbols.output.contains('_v3_cache_export_after'), second_symbols.output
+	assert !second_symbols.output.contains('_v3_cache_export_before'), second_symbols.output
 }
 
 fn test_incremental_program_cache_recompiles_real_main_logic() {

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -56,6 +56,54 @@ fn run_module_cache_binary(path string) string {
 	return result.output.trim_space()
 }
 
+fn test_cached_header_preserves_mutable_pointer_parameters() {
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_cached_mut_pointer_param_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	write_module_cache_file(root, 'wrapper/wrapper.v', 'module wrapper
+
+pub fn write_byte(mut bytes &u8, value u8) {
+	bytes[0] = value
+}
+
+pub fn terminate(mut bytes &u8) {
+	write_byte(mut bytes, `Z`)
+	bytes[1] = 0
+}
+')
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'module main
+
+import wrapper
+
+fn main() {
+	mut storage := [2]u8{}
+	mut bytes := &storage[0]
+	wrapper.terminate(mut bytes)
+	assert storage[0] == `Z`
+	assert storage[1] == 0
+	println("ok")
+}
+')
+	cache_dir := os.join_path(root, 'cache')
+	first_output := os.join_path(root, 'first')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, first_output)
+	assert run_module_cache_binary(first_output) == 'ok'
+	header_path := module_cache_artifact(cache_dir, 'wrapper_', '.vh')
+	assert header_path.len > 0
+	header := os.read_file(header_path) or { panic(err) }
+	assert header.contains('pub fn write_byte(mut bytes &u8, value u8)'), header
+	assert header.contains('pub fn terminate(mut bytes &u8)'), header
+
+	second_output := os.join_path(root, 'second')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, second_output)
+	assert run_module_cache_binary(second_output) == 'ok'
+}
+
 fn module_cache_object_hash(path string) u64 {
 	bytes := os.read_bytes(path) or { panic(err) }
 	mut hash := u64(1469598103934665603)
@@ -2969,6 +3017,111 @@ fn main() {
 	second_output := os.join_path(root, 'second')
 	compile_module_cache_project(v3_bin, cache_dir, main_file, second_output)
 	assert run_module_cache_binary(second_output) == '41\n41'
+}
+
+fn test_cached_dynamic_const_array_keeps_object_abi() {
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_module_cache_dynamic_const_array_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	write_module_cache_file(root, 'validators/validators.v', 'module validators
+
+type Validator = fn (u8) bool
+
+struct Entry {
+	value     u8
+	validator Validator
+}
+
+fn is_a(value u8) bool {
+	return value == `a`
+}
+
+fn is_b(value u8) bool {
+	return value == `b`
+}
+
+const entries = [Entry{`a`, is_a}, Entry{`b`, is_b}]
+
+pub fn validate(index int, value u8) bool {
+	return entries[index].validator(value)
+}
+')
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'module main
+
+import validators
+
+fn main() {
+	assert validators.validate(0, `a`)
+	assert validators.validate(1, `b`)
+	assert !validators.validate(0, `b`)
+	println("ok")
+}
+')
+	cache_dir := os.join_path(root, 'cache')
+	first_output := os.join_path(root, 'first')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, first_output)
+	assert run_module_cache_binary(first_output) == 'ok'
+	header_path := module_cache_artifact(cache_dir, 'validators_', '.vh')
+	assert header_path.len > 0
+	header := os.read_file(header_path) or { panic(err) }
+	assert header.contains('entries = [Entry{`a`, is_a}, Entry{`b`, is_b}].clone()'), header
+
+	second_output := os.join_path(root, 'second')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, second_output)
+	assert run_module_cache_binary(second_output) == 'ok'
+}
+
+fn test_cached_module_keeps_generic_specializations() {
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_module_cache_generic_specialization_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	write_module_cache_file(root, 'headers/headers.v', 'module headers
+
+import arrays
+
+pub fn unique(values []string) []string {
+	return arrays.uniq(values)
+}
+')
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'module main
+
+import headers
+
+fn main() {
+	values := headers.unique(["a", "a", "b"])
+	assert values == ["a", "b"]
+	println("ok")
+}
+')
+	cache_dir := os.join_path(root, 'cache')
+	first_output := os.join_path(root, 'first')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, first_output)
+	assert run_module_cache_binary(first_output) == 'ok'
+	// Exercise the generic-program cache independently of the exact Cgen plan.
+	// A large program can legitimately miss that plan on its first header-only
+	// build, while cached module objects already require the cold specializations.
+	for path in os.walk_ext(cache_dir, '.stamp') {
+		if os.file_name(path).starts_with('program_') && path.ends_with('.c.stamp') {
+			os.rm(path) or { panic(err) }
+		}
+	}
+
+	second_output := os.join_path(root, 'second')
+	second :=
+		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -o ${os.quoted_path(second_output)} ${os.quoted_path(main_file)}')
+	assert second.exit_code == 0, second.output
+	assert second.output.contains('monomorphize (dependency cache)'), second.output
+	assert run_module_cache_binary(second_output) == 'ok'
 }
 
 fn test_cached_global_with_unsupported_initializer_is_embedded() {

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -65,6 +65,50 @@ fn module_cache_object_hash(path string) u64 {
 	return hash
 }
 
+fn test_cached_source_signatures_revalidate_changed_inputs() {
+	root := os.join_path(os.temp_dir(), 'v3_source_signature_cache_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	manager := modulecache.new_manager(root, 'source-signature-metadata', true, '')
+	assert manager.ensure_dir()
+
+	source := os.join_path(root, 'foo.v')
+	write_module_cache_file(root, 'foo.v', 'module foo\n\npub fn value() int { return 1 }\n')
+	manager.write_header('foo', [source], 'module foo\n') or { panic(err) }
+	_ := manager.valid_header('foo', [source]) or {
+		assert false, 'an unchanged source should retain its cached header'
+		return
+	}
+	write_module_cache_file(root, 'foo.v', 'module foo\n\npub fn value() int { return 2 }\n')
+	if _ := manager.valid_header('foo', [source]) {
+		assert false, 'source metadata changes must trigger full content revalidation'
+	}
+
+	env_name := 'V3_SOURCE_SIGNATURE_TEST_${os.getpid()}'
+	os.setenv(env_name, 'first', true)
+	defer {
+		os.unsetenv(env_name)
+	}
+	write_module_cache_file(root, 'env.v', "module envmod\n\nconst value = \$env('${env_name}')\n")
+	env_source := os.join_path(root, 'env.v')
+	manager.write_header('envmod', [env_source], 'module envmod\n') or { panic(err) }
+	os.setenv(env_name, 'second', true)
+	if _ := manager.valid_header('envmod', [env_source]) {
+		assert false, 'compile-time environment changes must invalidate cached signatures'
+	}
+
+	write_module_cache_file(root, 'nested/vmod.v', 'module vmod\n\npub const root = @VMODROOT\n')
+	vmod_source := os.join_path(root, 'nested', 'vmod.v')
+	manager.write_header('vmod', [vmod_source], 'module vmod\n') or { panic(err) }
+	write_module_cache_file(root, 'v.mod', "Module {\n\tname: 'cache_test'\n}\n")
+	if _ := manager.valid_header('vmod', [vmod_source]) {
+		assert false, 'a newly discovered v.mod must invalidate cached signatures'
+	}
+}
+
 fn test_cached_object_accepts_recorded_dependency_superset() {
 	root := os.join_path(os.temp_dir(), 'v3_module_cache_dependency_superset_${os.getpid()}')
 	os.rmdir_all(root) or {}

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -4493,6 +4493,66 @@ fn main() {
 	assert run_module_cache_binary(struct_output) == '44'
 }
 
+fn test_incremental_program_cache_rebuilds_for_new_generic_struct_type() {
+	$if !macos {
+		return
+	}
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_incremental_generic_struct_type_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	write_module_cache_file(root, 'generic/generic.v', 'module generic
+
+pub struct Box[T] {
+pub:
+	value T
+}
+')
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'module main
+
+import generic
+
+fn value() i64 {
+	return i64(generic.Box[int]{
+		value: 40
+	}.value)
+}
+
+fn main() {
+	println(value())
+}
+')
+	cache_dir := os.join_path(root, 'cache')
+	first_output := os.join_path(root, 'first')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, first_output)
+	assert run_module_cache_binary(first_output) == '40'
+
+	write_module_cache_file(root, 'main.v', 'module main
+
+import generic
+
+fn value() i64 {
+	return generic.Box[i64]{
+		value: 41
+	}.value
+}
+
+fn main() {
+	println(value())
+}
+')
+	second_output := os.join_path(root, 'second')
+	second :=
+		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -o ${os.quoted_path(second_output)} ${os.quoted_path(main_file)}')
+	assert second.exit_code == 0, second.output
+	assert !second.output.contains('cgen (incremental)'), second.output
+	assert run_module_cache_binary(second_output) == '41'
+}
+
 fn test_incremental_program_cache_falls_back_for_newly_reachable_function() {
 	$if !macos {
 		return

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -4081,7 +4081,7 @@ fn main() {
 	assert run_module_cache_binary(incremental_output) == 'haha'
 }
 
-fn test_incremental_program_cache_falls_back_for_new_generic_type_argument() {
+fn test_incremental_program_cache_materializes_new_generic_type_argument() {
 	$if !macos {
 		return
 	}
@@ -4094,8 +4094,23 @@ fn test_incremental_program_cache_falls_back_for_new_generic_type_argument() {
 	}
 	write_module_cache_file(root, 'generic/generic.v', 'module generic
 
-pub fn identity[T](value T) T {
+fn pass[T](value T) T {
 	return value
+}
+
+pub struct Box[T] {
+pub:
+	value T
+}
+
+pub fn identity[T](value T) T {
+	return pass[T](value)
+}
+
+pub fn boxed[T](value T) Box[T] {
+	return Box[T]{
+		value: value
+	}
 }
 ')
 	main_file := os.join_path(root, 'main.v')
@@ -4104,6 +4119,7 @@ pub fn identity[T](value T) T {
 import generic
 
 fn value() int {
+	_ = generic.boxed[int](1)
 	return generic.identity[int](40)
 }
 
@@ -4121,6 +4137,7 @@ fn main() {
 import generic
 
 fn value() int {
+	_ = generic.boxed[int](1)
 	return generic.identity[int](41)
 }
 
@@ -4137,6 +4154,7 @@ fn main() {
 import generic
 
 fn value() int {
+	_ = generic.boxed[int](1)
 	return generic.identity[int](42)
 }
 
@@ -4158,6 +4176,7 @@ fn main() {
 import generic
 
 fn value() int {
+	_ = generic.boxed[int](1)
 	return int(generic.identity[i64](43))
 }
 
@@ -4170,9 +4189,30 @@ fn main() {
 		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -o ${os.quoted_path(second_output)} ${os.quoted_path(main_file)}')
 	assert second.exit_code == 0, second.output
 	assert second.output.contains('check (incremental)'), second.output
-	assert !second.output.contains('monomorphize (incremental)'), second.output
-	assert !second.output.contains('cgen (incremental)'), second.output
+	assert second.output.contains('monomorphize (incremental)'), second.output
+	assert second.output.contains('cgen (incremental)'), second.output
 	assert run_module_cache_binary(second_output) == '43'
+
+	write_module_cache_file(root, 'main.v', 'module main
+
+import generic
+
+fn value() int {
+	return int(generic.boxed[i64](44).value)
+}
+
+fn main() {
+	println(value())
+}
+')
+	struct_output := os.join_path(root, 'struct')
+	struct_result :=
+		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -o ${os.quoted_path(struct_output)} ${os.quoted_path(main_file)}')
+	assert struct_result.exit_code == 0, struct_result.output
+	assert struct_result.output.contains('check (incremental)'), struct_result.output
+	assert !struct_result.output.contains('monomorphize (incremental)'), struct_result.output
+	assert !struct_result.output.contains('cgen (incremental)'), struct_result.output
+	assert run_module_cache_binary(struct_output) == '44'
 }
 
 fn test_incremental_program_cache_falls_back_for_newly_reachable_function() {

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -864,6 +864,102 @@ fn main() {
 	assert line_fields.len >= 5 && line_fields[3].int() == expected_v_lines, second.output
 }
 
+fn test_static_storage_header_disables_module_cache_split() {
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_module_cache_static_header_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	write_module_cache_file(root, 'state.h', '#ifndef V3_STATIC_HEADER_STATE_H
+#define V3_STATIC_HEADER_STATE_H
+
+static int v3_static_header_state = 40;
+
+static int v3_static_header_next(void) {
+	return ++v3_static_header_state;
+}
+
+#endif
+')
+	write_module_cache_file(root, 'native/native.v', 'module native
+
+#include "@DIR/../state.h"
+
+fn C.v3_static_header_next() int
+
+pub fn next() int {
+	return C.v3_static_header_next()
+}
+')
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'module main
+
+import native
+
+fn C.v3_static_header_next() int
+
+fn main() {
+	println(native.next() + C.v3_static_header_next())
+}
+')
+	cache_dir := os.join_path(root, 'cache')
+	output := os.join_path(root, 'program')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, output)
+	assert run_module_cache_binary(output) == '83'
+	assert module_cache_artifact(cache_dir, 'native_', '.o').len == 0
+}
+
+fn test_shared_static_storage_header_disables_module_cache_split() {
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_module_cache_shared_static_header_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	write_module_cache_file(root, 'state.h', '#ifndef V3_SHARED_STATIC_HEADER_STATE_H
+#define V3_SHARED_STATIC_HEADER_STATE_H
+
+static int v3_shared_static_header_state = 40;
+
+static int v3_shared_static_header_next(void) {
+	return ++v3_shared_static_header_state;
+}
+
+#endif
+')
+	for module_name in ['leftmod', 'rightmod'] {
+		write_module_cache_file(root, '${module_name}/${module_name}.v', 'module ${module_name}
+
+#include "@DIR/../state.h"
+
+fn C.v3_shared_static_header_next() int
+
+pub fn next() int {
+	return C.v3_shared_static_header_next()
+}
+')
+	}
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'module main
+
+import leftmod
+import rightmod
+
+fn main() {
+	println(leftmod.next() + rightmod.next())
+}
+')
+	cache_dir := os.join_path(root, 'cache')
+	output := os.join_path(root, 'program')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, output)
+	assert run_module_cache_binary(output) == '83'
+	assert module_cache_artifact(cache_dir, 'leftmod_', '.o').len == 0
+	assert module_cache_artifact(cache_dir, 'rightmod_', '.o').len == 0
+}
+
 fn test_cold_module_cache_prints_reuse_hint_only_once() {
 	v3_bin := build_module_cache_v3()
 	root := os.join_path(os.temp_dir(), 'v3_module_cache_cold_hint_${os.getpid()}')

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -4034,6 +4034,53 @@ fn main() {
 	assert run_module_cache_binary(fn_pointer_output) == '42'
 }
 
+fn test_incremental_program_cache_adds_println_to_main() {
+	$if !macos {
+		return
+	}
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_incremental_add_println_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'module main
+
+fn main() {}
+')
+	cache_dir := os.join_path(root, 'cache')
+	first_output := os.join_path(root, 'first')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, first_output)
+	assert run_module_cache_binary(first_output) == ''
+
+	write_module_cache_file(root, 'main.v', 'module main
+
+fn main() {
+	value := 1
+	_ = value
+}
+')
+	baseline_output := os.join_path(root, 'baseline')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, baseline_output)
+	assert run_module_cache_binary(baseline_output) == ''
+
+	write_module_cache_file(root, 'main.v', "module main
+
+fn main() {
+	println('haha')
+}
+")
+	incremental_output := os.join_path(root, 'incremental')
+	incremental :=
+		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -o ${os.quoted_path(incremental_output)} ${os.quoted_path(main_file)}')
+	assert incremental.exit_code == 0, incremental.output
+	assert incremental.output.contains('check (incremental)'), incremental.output
+	assert incremental.output.contains('cgen (incremental)'), incremental.output
+	assert run_module_cache_binary(incremental_output) == 'haha'
+}
+
 fn test_incremental_program_cache_falls_back_for_new_generic_type_argument() {
 	$if !macos {
 		return
@@ -4090,7 +4137,28 @@ fn main() {
 import generic
 
 fn value() int {
-	return int(generic.identity[i64](42))
+	return generic.identity[int](42)
+}
+
+fn main() {
+	println(value())
+}
+')
+	incremental_output := os.join_path(root, 'incremental')
+	incremental :=
+		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -o ${os.quoted_path(incremental_output)} ${os.quoted_path(main_file)}')
+	assert incremental.exit_code == 0, incremental.output
+	assert incremental.output.contains('check (incremental)'), incremental.output
+	assert incremental.output.contains('monomorphize (incremental)'), incremental.output
+	assert incremental.output.contains('cgen (incremental)'), incremental.output
+	assert run_module_cache_binary(incremental_output) == '42'
+
+	write_module_cache_file(root, 'main.v', 'module main
+
+import generic
+
+fn value() int {
+	return int(generic.identity[i64](43))
 }
 
 fn main() {
@@ -4101,10 +4169,10 @@ fn main() {
 	second :=
 		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -o ${os.quoted_path(second_output)} ${os.quoted_path(main_file)}')
 	assert second.exit_code == 0, second.output
-	assert !second.output.contains('check (incremental)'), second.output
+	assert second.output.contains('check (incremental)'), second.output
 	assert !second.output.contains('monomorphize (incremental)'), second.output
 	assert !second.output.contains('cgen (incremental)'), second.output
-	assert run_module_cache_binary(second_output) == '42'
+	assert run_module_cache_binary(second_output) == '43'
 }
 
 fn test_incremental_program_cache_falls_back_for_newly_reachable_function() {

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -573,6 +573,47 @@ fn main() {
 	assert run_module_cache_binary(second_output) == '42'
 }
 
+fn test_cached_cgen_dependency_inputs_restore_only_allowed_groups() {
+	root := os.join_path(os.temp_dir(), 'v3_cgen_dependency_restore_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	manager := modulecache.new_manager(root, 'cgen-dependency-restore', true, '')
+	assert manager.ensure_dir()
+	write_module_cache_file(root, 'main.v', 'println(1)\n')
+	source := os.join_path(root, 'main.v')
+	dependencies := {
+		'fixed':                      'fixed-signature'
+		'external:main:/tmp/input.h': 'external-signature'
+	}
+	manager.write_cgen([source], 'generation', dependencies, 'generated C', 'metadata') or {
+		panic(err)
+	}
+	restored := manager.cached_cgen_dependency_inputs([source], 'generation', {
+		'fixed': 'fixed-signature'
+	}, ['external:']) or {
+		assert false, 'matching fixed dependencies should restore the allowed group'
+		return
+	}
+	assert restored == {
+		'external:main:/tmp/input.h': 'external-signature'
+	}
+	if _ := manager.cached_cgen_dependency_inputs([source], 'generation', {
+		'fixed': 'changed-signature'
+	}, ['external:'])
+	{
+		assert false, 'changed fixed dependencies must reject the cached manifest'
+	}
+	if _ := manager.cached_cgen_dependency_inputs([source], 'generation', map[string]string{}, [
+		'external:',
+	])
+	{
+		assert false, 'unaccounted fixed dependencies must reject the cached manifest'
+	}
+}
+
 fn test_module_cache_declaration_header_keeps_column_zero_inner_block_closes() {
 	prefix := 'int cached_nested(int value) {
 if (value) {
@@ -1599,6 +1640,55 @@ fn main() {
 	second_output := os.join_path(root, 'second')
 	second :=
 		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -cflags ${os.quoted_path(c_flags)} -o ${os.quoted_path(second_output)} ${os.quoted_path(main_file)}')
+	assert second.exit_code == 0, second.output
+	assert !second.output.contains('cgen (cached)'), second.output
+	assert run_module_cache_binary(second_output) == '2'
+}
+
+fn test_whole_program_cgen_invalidates_when_include_resolution_changes() {
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_cgen_include_resolution_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(os.join_path(root, 'fallback')) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	write_module_cache_file(root, 'fallback/value.h', 'static inline int v3_include_value(void) {
+	return 1;
+}
+')
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'module main
+
+#flag -I @DIR/first
+#flag -I @DIR/fallback
+#include <value.h>
+
+fn C.v3_include_value() int
+
+fn main() {
+	println(C.v3_include_value())
+}
+')
+	cache_dir := os.join_path(root, 'cache')
+	first_output := os.join_path(root, 'first-output')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, first_output)
+	assert run_module_cache_binary(first_output) == '1'
+
+	warm_output := os.join_path(root, 'warm-output')
+	warm :=
+		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -o ${os.quoted_path(warm_output)} ${os.quoted_path(main_file)}')
+	assert warm.exit_code == 0, warm.output
+	assert warm.output.contains('cgen (cached)'), warm.output
+	assert run_module_cache_binary(warm_output) == '1'
+
+	write_module_cache_file(root, 'first/value.h', 'static inline int v3_include_value(void) {
+	return 2;
+}
+')
+	second_output := os.join_path(root, 'second-output')
+	second :=
+		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -o ${os.quoted_path(second_output)} ${os.quoted_path(main_file)}')
 	assert second.exit_code == 0, second.output
 	assert !second.output.contains('cgen (cached)'), second.output
 	assert run_module_cache_binary(second_output) == '2'

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -4538,6 +4538,64 @@ fn main() {
 	assert run_module_cache_binary(second_output) == 'called'
 }
 
+fn test_incremental_program_cache_falls_back_for_new_interface_dispatch() {
+	$if !macos {
+		return
+	}
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_incremental_interface_dispatch_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', "module main
+
+interface Speaker {
+	speak() string
+}
+
+struct Dog {}
+
+fn (_ Dog) speak() string {
+	return 'woof'
+}
+
+fn main() {
+	println('before')
+}
+")
+	cache_dir := os.join_path(root, 'cache')
+	first_output := os.join_path(root, 'first')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, first_output)
+	assert run_module_cache_binary(first_output) == 'before'
+
+	write_module_cache_file(root, 'main.v', "module main
+
+interface Speaker {
+	speak() string
+}
+
+struct Dog {}
+
+fn (_ Dog) speak() string {
+	return 'woof'
+}
+
+fn main() {
+	speaker := Speaker(Dog{})
+	println(speaker.speak())
+}
+")
+	second_output := os.join_path(root, 'second')
+	second :=
+		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -o ${os.quoted_path(second_output)} ${os.quoted_path(main_file)}')
+	assert second.exit_code == 0, second.output
+	assert !second.output.contains('cgen (incremental)'), second.output
+	assert run_module_cache_binary(second_output) == 'woof'
+}
+
 fn test_incremental_program_cache_invalidates_for_top_level_statement_change() {
 	$if !macos {
 		return

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -911,6 +911,59 @@ fn main() {
 	assert module_cache_artifact(cache_dir, 'native_', '.o').len == 0
 }
 
+fn test_mixed_native_root_and_static_header_disables_module_cache_split() {
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_module_cache_mixed_static_header_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	write_module_cache_file(root, 'state.h', '#ifndef V3_MIXED_STATIC_HEADER_STATE_H
+#define V3_MIXED_STATIC_HEADER_STATE_H
+
+static int v3_mixed_static_header_state = 40;
+
+static int v3_mixed_static_header_next(void) {
+	return ++v3_mixed_static_header_state;
+}
+
+#endif
+')
+	write_module_cache_file(root, 'native/root.c', 'int v3_mixed_native_root_value(void) {
+	return 0;
+}
+')
+	write_module_cache_file(root, 'native/native.v', 'module native
+
+#include "@DIR/root.c"
+#include "@DIR/../state.h"
+
+fn C.v3_mixed_native_root_value() int
+fn C.v3_mixed_static_header_next() int
+
+pub fn next() int {
+	return C.v3_mixed_native_root_value() + C.v3_mixed_static_header_next()
+}
+')
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'module main
+
+import native
+
+fn C.v3_mixed_static_header_next() int
+
+fn main() {
+	println(native.next() + C.v3_mixed_static_header_next())
+}
+')
+	cache_dir := os.join_path(root, 'cache')
+	output := os.join_path(root, 'program')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, output)
+	assert run_module_cache_binary(output) == '83'
+	assert module_cache_artifact(cache_dir, 'native_', '.o').len == 0
+}
+
 fn test_shared_static_storage_header_disables_module_cache_split() {
 	v3_bin := build_module_cache_v3()
 	root := os.join_path(os.temp_dir(), 'v3_module_cache_shared_static_header_${os.getpid()}')

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -194,12 +194,23 @@ fn test_cached_object_accepts_recorded_dependency_superset() {
 		assert false, 'a recorded dependency superset should remain valid'
 		return
 	}
+	stamp := os.read_file(entry.object_stamp) or { panic(err) }
+	dependency_lines := stamp.split_into_lines().filter(it.starts_with('dependency='))
+	assert dependency_lines.len == 2
+	assert dependency_lines.all(it.count('\t') == 2)
 	if _ := manager.valid_object_for_compile_signature('foo', [source], compile_signature, {
 		first_dependency: modulecache.file_signature(first_dependency)
 		new_dependency:   modulecache.file_signature(new_dependency)
 	})
 	{
 		assert false, 'a newly discovered dependency must invalidate the object'
+	}
+	write_module_cache_file(root, 'first.h', '#define FIRST 2')
+	if _ := manager.valid_object_for_compile_signature('foo', [source], compile_signature, {
+		first_dependency: modulecache.file_signature(first_dependency)
+	})
+	{
+		assert false, 'a changed dependency must invalidate the object'
 	}
 }
 

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -371,6 +371,7 @@ int generated_fn(void) { return 3; }
 	assert header.contains('/* Usage:\n   #define STB_IMAGE_IMPLEMENTATION\n*/')
 	assert header.contains('/* v3 cache omitted SOKOL_APP_IMPL */')
 	assert header.contains('/* v3 cache omitted STB_IMAGE_IMPLEMENTATION */')
+	assert !header.contains('static /* v3 cache omitted')
 	assert !header.contains('#define SOKOL_APP_IMPL')
 	assert header.count('#define STB_IMAGE_IMPLEMENTATION') == 1
 	assert !header.contains('native_source_body')
@@ -4412,10 +4413,15 @@ pub fn value() int {
 	return C.native_nested_value()
 }
 ')
-	write_module_cache_file(root, 'native/root.c', '#include "nested.c"
+	write_module_cache_file(root, 'native/root.c', '#include "helper.h"
+#include "nested.c"
 
 int native_nested_value(void) {
-	return nested_static_value();
+	return nested_static_value() + header_static_value() - 1;
+}
+')
+	write_module_cache_file(root, 'native/helper.h', 'static int header_static_value(void) {
+	return 1;
 }
 ')
 	write_module_cache_file(root, 'native/nested.c', 'static int nested_static_value(void) {

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -772,6 +772,8 @@ fn main() {
 		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -o ${os.quoted_path(second_output)} ${os.quoted_path(main_file)}')
 	assert second.exit_code == 0, second.output
 	assert run_module_cache_binary(second_output) == '42'
+	assert second.output.split_into_lines().any(it.trim_space().starts_with('parse .vh')), second.output
+	assert second.output.split_into_lines().any(it.trim_space().starts_with('parse .v')), second.output
 	vh_lines := second.output.split_into_lines().filter(it.contains('parsed .vh files'))
 	assert vh_lines.len == 1, second.output
 	fields := vh_lines[0].fields()

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -4665,6 +4665,63 @@ fn main() {
 	assert run_module_cache_binary(second_output) == 'called'
 }
 
+fn test_incremental_program_cache_falls_back_for_newly_reachable_non_main_function() {
+	$if !macos {
+		return
+	}
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_incremental_non_main_reachability_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	write_module_cache_file(root, 'v.mod', "Module {
+	name: 'incremental_non_main_reachability'
+	subdirs: ['worker']
+}
+")
+	write_module_cache_file(root, 'worker/worker.v', "module worker
+
+fn newly_reachable() string {
+	return 'called'
+}
+
+pub fn value() string {
+	return 'before'
+}
+")
+	write_module_cache_file(root, 'main.v', 'module main
+
+import worker
+
+fn main() {
+	println(worker.value())
+}
+')
+	cache_dir := os.join_path(root, 'cache')
+	first_output := os.join_path(root, 'first')
+	compile_module_cache_project(v3_bin, cache_dir, root, first_output)
+	assert run_module_cache_binary(first_output) == 'before'
+
+	write_module_cache_file(root, 'worker/worker.v', "module worker
+
+fn newly_reachable() string {
+	return 'called'
+}
+
+pub fn value() string {
+	return newly_reachable()
+}
+")
+	second_output := os.join_path(root, 'second')
+	second :=
+		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -o ${os.quoted_path(second_output)} ${os.quoted_path(root)}')
+	assert second.exit_code == 0, second.output
+	assert !second.output.contains('cgen (incremental)'), second.output
+	assert run_module_cache_binary(second_output) == 'called'
+}
+
 fn test_incremental_program_cache_falls_back_for_new_interface_dispatch() {
 	$if !macos {
 		return

--- a/vlib/v3/tests/mut_param_reassign_codegen_test.v
+++ b/vlib/v3/tests/mut_param_reassign_codegen_test.v
@@ -302,6 +302,25 @@ fn main() {
 }
 ')
 	assert out_lvalues == '9\n7'
+	out_forwarded := mut_param_reassign_run_good(v3_bin, 'mut_pointer_param_forward_and_index', 'fn write_byte(mut bytes &u8, value u8) {
+	bytes[0] = value
+}
+
+fn terminate(mut bytes &u8) {
+	write_byte(mut bytes, `Z`)
+	bytes[1] = 0
+}
+
+fn main() {
+	mut storage := [2]u8{}
+	mut bytes := &storage[0]
+	terminate(mut bytes)
+	assert storage[0] == `Z`
+	assert storage[1] == 0
+	println("ok")
+}
+')
+	assert out_forwarded == 'ok'
 	mut_param_reassign_run_bad(v3_bin, 'generic_mut_pointer_param_requires_pointer_slot', 'struct Item {
 	value int
 }

--- a/vlib/v3/tests/parallel_parser_test.v
+++ b/vlib/v3/tests/parallel_parser_test.v
@@ -346,7 +346,7 @@ fn test_parallel_parser_compiles_multi_module_project() {
 	compile := os.execute('VJOBS=4 ${v3_bin} ${main_path} -b c -o ${bin_out}')
 	assert compile.exit_code == 0, compile.output
 	$if !windows {
-		assert compile.output.contains('parse (parallel)'), compile.output
+		assert compile.output.contains('parse .v (parallel)'), compile.output
 	}
 	run := os.execute(bin_out)
 	assert run.exit_code == 0, run.output
@@ -643,7 +643,8 @@ fn test_no_parallel_parser_keeps_parse_serial() {
 	bin_out := os.join_path(os.temp_dir(), 'v3_parallel_parser_serial_out_${os.getpid()}')
 	compile := os.execute('VJOBS=4 ${v3_bin} --no-parallel ${main_path} -b c -o ${bin_out}')
 	assert compile.exit_code == 0, compile.output
-	assert !compile.output.contains('parse (parallel)'), compile.output
+	assert !compile.output.contains('parse .v (parallel)'), compile.output
+	assert !compile.output.contains('parse .vh (parallel)'), compile.output
 	run := os.execute(bin_out)
 	assert run.exit_code == 0, run.output
 }

--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -354,6 +354,50 @@ fn (mut t Transformer) seed_cached_monomorph_specs(specs []MonomorphCacheSpec) {
 	}
 }
 
+fn (mut t Transformer) materialize_cached_monomorph_signature_types(specs []MonomorphCacheSpec) {
+	if isnil(t.tc) || specs.len == 0 {
+		return
+	}
+	fn_decls := t.cached_generic_fn_decls()
+	struct_decls := t.collect_generic_struct_decls()
+	sum_decls := t.collect_generic_sum_decls()
+	if struct_decls.len == 0 && sum_decls.len == 0 {
+		return
+	}
+	mut struct_specs := map[string]string{}
+	mut sum_specs := map[string]GenericSpecContext{}
+	for spec in specs {
+		decl := fn_decls[spec.decl_key] or { continue }
+		args := t.canonical_generic_specialization_args(spec.args)
+		if args.len == 0 || t.generic_args_have_placeholders(args) {
+			continue
+		}
+		generic_params := t.generic_fn_param_names(decl.node, decl.module)
+		mut signature_types := [
+			t.specialized_signature_type_text(decl, decl.node.typ, args, generic_params),
+		]
+		for i in 0 .. decl.node.children_count {
+			param := t.a.child_node(&decl.node, i)
+			if param.kind == .param {
+				signature_types << t.specialized_signature_type_text(decl, param.typ, args,
+					generic_params)
+			}
+		}
+		for typ in signature_types {
+			t.collect_generic_struct_spec_from_type(typ, decl.module, decl.file, struct_decls, mut
+				struct_specs)
+			t.collect_generic_sum_spec_from_type(typ, decl.module, decl.file, sum_decls, mut
+				sum_specs)
+		}
+	}
+	t.expand_generic_materialization_specs(struct_decls, sum_decls, mut struct_specs, mut sum_specs)
+	for spec, context in sum_specs {
+		decl := sum_decls[context.base] or { continue }
+		t.materialize_generic_sum_spec(spec, decl, context)
+	}
+	t.materialize_generic_struct_specs(struct_specs, struct_decls)
+}
+
 fn (t &Transformer) sorted_monomorph_cache_specs() []MonomorphCacheSpec {
 	mut keys := t.monomorph_cache_specs.keys()
 	keys.sort()

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -836,7 +836,8 @@ pub fn monomorphize_with_used_checked_config_scoped_cached(mut a flat.FlatAst, t
 }
 
 // register_cached_monomorph_signatures installs persistent concrete signatures
-// before the disposable monomorphization arena is entered.
+// and their named signature types before the disposable monomorphization arena
+// is entered.
 pub fn register_cached_monomorph_signatures(a &flat.FlatAst, tc &types.TypeChecker, used_fns map[string]bool, cached_specs []MonomorphCacheSpec) {
 	if cached_specs.len == 0 {
 		return
@@ -844,6 +845,7 @@ pub fn register_cached_monomorph_signatures(a &flat.FlatAst, tc &types.TypeCheck
 	mut t := new_transformer_view(a, tc, used_fns)
 	t.prepare()
 	t.seed_cached_monomorph_specs(cached_specs)
+	t.materialize_cached_monomorph_signature_types(cached_specs)
 }
 
 fn new_transformer(mut a flat.FlatAst, tc &types.TypeChecker, used_fns map[string]bool) Transformer {

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -24466,12 +24466,11 @@ fn (tc &TypeChecker) is_builtin_error_struct_name_in_scope(name string, file str
 // prepare_interface_query_indexes publishes immutable interface requirements for
 // transform workers. Interface declarations no longer change after semantic
 // checking, so compatibility scans can reuse these lists safely across threads.
-pub fn (mut tc TypeChecker) prepare_interface_query_indexes() {
+pub fn (mut tc TypeChecker) prepare_interface_requirement_indexes() {
 	tc.interface_query_indexes_ready = false
 	tc.interface_method_names_index = map[string][]string{}
 	tc.interface_abstract_index = map[string][]string{}
 	tc.interface_field_list_index = map[string][]StructField{}
-	tc.interface_impl_indexes = map[string]&InterfaceImplIndex{}
 	for iface_name in tc.interface_names.keys() {
 		mut seen_methods := map[string]bool{}
 		methods := tc.interface_method_names_inner(iface_name, mut seen_methods)
@@ -24490,6 +24489,13 @@ pub fn (mut tc TypeChecker) prepare_interface_query_indexes() {
 		}
 	}
 	tc.interface_query_indexes_ready = true
+}
+
+// prepare_interface_query_indexes publishes immutable interface requirements and
+// implementer lists for transform workers.
+pub fn (mut tc TypeChecker) prepare_interface_query_indexes() {
+	tc.prepare_interface_requirement_indexes()
+	tc.interface_impl_indexes = map[string]&InterfaceImplIndex{}
 	for iface_name in tc.interface_names.keys() {
 		impls := if is_builtin_ierror_name(iface_name) {
 			tc.ierror_impl_names()

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -1985,14 +1985,11 @@ struct V3IncrementalFn {
 	key       string
 	name      string
 	signature string
-mut:
-	generic_signature string
 }
 
 struct V3IncrementalSnapshot {
 	declaration_signature string
-mut:
-	functions []V3IncrementalFn
+	functions             []V3IncrementalFn
 }
 
 fn incremental_cache_fn_key(file string, module_name string, name string) string {
@@ -2208,32 +2205,27 @@ fn incremental_program_snapshot(a &flat.FlatAst) V3IncrementalSnapshot {
 
 fn encode_incremental_manifest(snapshot V3IncrementalSnapshot) string {
 	mut lines := []string{cap: snapshot.functions.len + 1}
-	lines << 'v3-incremental-functions-v2'
+	lines << 'v3-incremental-functions-v3'
 	for function in snapshot.functions {
-		lines << '${function.key}\t${function.signature}\t${function.generic_signature}\t${function.name}'
+		lines << '${function.key}\t${function.signature}\t${function.name}'
 	}
 	return lines.join('\n')
 }
 
-fn decode_incremental_manifest(encoded string) ?map[string]V3IncrementalFn {
+fn decode_incremental_manifest(encoded string) ?map[string]string {
 	lines := encoded.split_into_lines()
-	if lines.len == 0 || lines[0] != 'v3-incremental-functions-v2' {
+	if lines.len == 0 || lines[0] != 'v3-incremental-functions-v3' {
 		return none
 	}
-	mut functions := map[string]V3IncrementalFn{}
+	mut signatures := map[string]string{}
 	for line in lines[1..] {
 		parts := line.split('\t')
-		if parts.len != 4 || parts[0].len == 0 || parts[1].len == 0 || parts[2].len == 0 {
+		if parts.len != 3 || parts[0].len == 0 || parts[1].len == 0 {
 			return none
 		}
-		functions[parts[0]] = V3IncrementalFn{
-			key:               parts[0]
-			signature:         parts[1]
-			generic_signature: parts[2]
-			name:              parts[3]
-		}
+		signatures[parts[0]] = parts[1]
 	}
-	return functions
+	return signatures
 }
 
 struct V3IncrementalCFunctionSections {
@@ -2241,95 +2233,20 @@ struct V3IncrementalCFunctionSections {
 	keys     []string
 }
 
-fn incremental_changed_functions(snapshot V3IncrementalSnapshot, old map[string]V3IncrementalFn) ?([]string, map[string]bool) {
+fn incremental_changed_functions(snapshot V3IncrementalSnapshot, old map[string]string) ?([]string, map[string]bool) {
 	if snapshot.functions.len != old.len {
 		return none
 	}
 	mut keys := []string{}
 	mut names := map[string]bool{}
 	for function in snapshot.functions {
-		old_function := old[function.key] or { return none }
-		if old_function.signature != function.signature {
+		old_signature := old[function.key] or { return none }
+		if old_signature != function.signature {
 			keys << function.key
 			names[function.name] = true
 		}
 	}
 	return keys, names
-}
-
-fn incremental_generic_call_signature(a &flat.FlatAst, tc &types.TypeChecker, root flat.NodeId) string {
-	mut hash := u64(1469598103934665603)
-	mut stack := [root]
-	mut count := 0
-	for stack.len > 0 {
-		id := stack.pop()
-		idx := int(id)
-		if idx < 0 || idx >= a.nodes.len {
-			continue
-		}
-		node := a.nodes[idx]
-		if node.kind == .call {
-			if name := tc.resolved_call_name(id) {
-				if name in tc.fn_generic_params || name.contains('[') {
-					count++
-					hash = c_hash_bytes(hash, name.bytes())
-					hash = c_hash_bytes(hash, [u8(0xff)])
-					if node.children_count > 0 {
-						callee_signature := incremental_node_tree_signature(a, a.child(&node, 0))
-						hash = c_hash_bytes(hash, callee_signature.bytes())
-						hash = c_hash_bytes(hash, [u8(0xfc)])
-					}
-					for param in node.generic_params() {
-						hash = c_hash_bytes(hash, param.bytes())
-						hash = c_hash_bytes(hash, [u8(0xfe)])
-					}
-					for child_idx in 1 .. node.children_count {
-						child_id := a.child(&node, child_idx)
-						if typ := tc.expr_type(child_id) {
-							hash = c_hash_bytes(hash, tc.type_name(typ).bytes())
-						}
-						hash = c_hash_bytes(hash, [u8(0xfd)])
-					}
-				}
-			}
-		}
-		for child_idx := node.children_count - 1; child_idx >= 0; child_idx-- {
-			stack << a.child(&node, child_idx)
-		}
-	}
-	return '${count}:${hash.hex()}'
-}
-
-fn populate_incremental_generic_signatures(mut snapshot V3IncrementalSnapshot, a &flat.FlatAst, tc &types.TypeChecker) {
-	mut function_idx := 0
-	for idx, node in a.nodes {
-		if node.kind != .fn_decl {
-			continue
-		}
-		if function_idx >= snapshot.functions.len {
-			return
-		}
-		snapshot.functions[function_idx].generic_signature = incremental_generic_call_signature(a,
-			tc, flat.NodeId(idx))
-		function_idx++
-	}
-}
-
-fn incremental_generic_calls_changed(snapshot V3IncrementalSnapshot, old map[string]V3IncrementalFn, changed_keys []string) bool {
-	mut changed := map[string]bool{}
-	for key in changed_keys {
-		changed[key] = true
-	}
-	for function in snapshot.functions {
-		if !changed[function.key] {
-			continue
-		}
-		old_function := old[function.key] or { return true }
-		if function.generic_signature != old_function.generic_signature {
-			return true
-		}
-	}
-	return false
 }
 
 fn incremental_changed_functions_require_reachability_rebuild(a &flat.FlatAst, tc &types.TypeChecker, changed_names map[string]bool, cached map[string]bool) bool {
@@ -2617,25 +2534,6 @@ fn decode_monomorph_cache_specs(encoded string) []transform.MonomorphCacheSpec {
 		}
 	}
 	return specs
-}
-
-fn monomorph_cache_spec_identity(spec transform.MonomorphCacheSpec) string {
-	return '${spec.decl_key}\t${spec.module}\t${spec.args.join('\x1f')}'
-}
-
-fn incremental_monomorph_has_new_specs(generated []transform.MonomorphCacheSpec, cached []transform.MonomorphCacheSpec) bool {
-	mut cached_identities := map[string]bool{}
-	for spec in cached {
-		cached_identities[monomorph_cache_spec_identity(spec)] = true
-	}
-	for spec in generated {
-		// Main-module specializations live in the replaceable program body and are
-		// deliberately absent from the dependency specialization manifest.
-		if spec.module in ['', 'main'] || !cached_identities[monomorph_cache_spec_identity(spec)] {
-			return true
-		}
-	}
-	return false
 }
 
 fn encode_cached_used_fns(used map[string]bool) string {
@@ -3873,11 +3771,9 @@ fn main() {
 	mut incremental_snapshot := V3IncrementalSnapshot{}
 	mut incremental_snapshot_ready := false
 	mut incremental_cache_hit := false
-	mut incremental_cached_functions := map[string]V3IncrementalFn{}
 	mut incremental_changed_keys := []string{}
 	mut incremental_changed_names := map[string]bool{}
 	mut incremental_calls_generics := false
-	mut incremental_generic_specs_changed := false
 	mut incremental_cached_body := ''
 	mut incremental_tcc_declarations_path := ''
 	if backend == 'c' && cache_state.manager.enabled && !cache_state.force_source
@@ -3958,7 +3854,6 @@ fn main() {
 						decoded_used := decode_cached_used_fns(used_text)
 						if decoded_metadata := decode_v3_cgen_metadata(metadata) {
 							if decoded_used.len > 0 && body_text.len > 0 {
-								incremental_cached_functions = old_manifest.clone()
 								incremental_cache_hit = changed_keys.len > 0
 								incremental_changed_keys = changed_keys.clone()
 								incremental_changed_names = changed_names.clone()
@@ -4045,13 +3940,8 @@ fn main() {
 			print_type_errors(pre_tc.errors)
 			exit(1)
 		}
-		if incremental_snapshot.declaration_signature.len > 0 {
-			populate_incremental_generic_signatures(mut incremental_snapshot, a, pre_tc)
-		}
 		incremental_calls_generics = incremental_cache_hit
 			&& incremental_changed_functions_call_generics(a, pre_tc, incremental_changed_names)
-		incremental_generic_specs_changed = incremental_calls_generics
-			&& incremental_generic_calls_changed(incremental_snapshot, incremental_cached_functions, incremental_changed_keys)
 		pre_tc.prune_inactive_top_level_comptime(mut a)
 		test_harness_errors := validate_test_file_harness_inputs(a, pre_tc, test_files)
 		if test_harness_errors.len > 0 {
@@ -4395,6 +4285,27 @@ fn main() {
 		|| transformed_used_fns_need_monomorphize(incremental_stage_used_fns)) {
 		mut monomorph_used_fns := map[string]bool{}
 		mut monomorph_errors := []string{}
+		incremental_monomorph_node_start := a.nodes.len
+		// Incremental C can append function specializations, but new named types
+		// need a rebuilt prefix containing their layout declarations.
+		mut incremental_struct_names := map[string]bool{}
+		mut incremental_sum_names := map[string]bool{}
+		mut incremental_alias_names := map[string]bool{}
+		mut incremental_interface_names := map[string]bool{}
+		if incremental_cache_hit {
+			for name in pre_tc.structs.keys() {
+				incremental_struct_names[name] = true
+			}
+			for name in pre_tc.sum_types.keys() {
+				incremental_sum_names[name] = true
+			}
+			for name in pre_tc.type_aliases.keys() {
+				incremental_alias_names[name] = true
+			}
+			for name in pre_tc.interface_names.keys() {
+				incremental_interface_names[name] = true
+			}
+		}
 		monomorph_input_used := if incremental_cache_hit {
 			incremental_stage_used_fns
 		} else {
@@ -4459,11 +4370,46 @@ fn main() {
 				&& cache_state.parsed_from_source.len == 0, unsafe { nil }, cached_monomorph_specs)
 		}
 		if incremental_cache_hit {
-			incremental_stage_used_fns = monomorph_used_fns.move()
-			if incremental_generic_specs_changed
-				&& incremental_monomorph_has_new_specs(generated_monomorph_specs, cached_monomorph_specs) {
+			mut added_named_type := false
+			for name in pre_tc.structs.keys() {
+				if !incremental_struct_names[name] {
+					added_named_type = true
+					break
+				}
+			}
+			if !added_named_type {
+				for name in pre_tc.sum_types.keys() {
+					if !incremental_sum_names[name] {
+						added_named_type = true
+						break
+					}
+				}
+			}
+			if !added_named_type {
+				for name in pre_tc.type_aliases.keys() {
+					if !incremental_alias_names[name] {
+						added_named_type = true
+						break
+					}
+				}
+			}
+			if !added_named_type {
+				for name in pre_tc.interface_names.keys() {
+					if !incremental_interface_names[name] {
+						added_named_type = true
+						break
+					}
+				}
+			}
+			if added_named_type {
 				os.setenv('V3_CACHE_DISABLE_INCREMENTAL', '1', true)
 				restart_v3_after_cache_invalidation()
+			}
+			incremental_stage_used_fns = monomorph_used_fns.move()
+			for idx in incremental_monomorph_node_start .. a.nodes.len {
+				if a.specialized_fn_nodes[idx] && a.nodes[idx].kind == .fn_decl {
+					incremental_changed_names[a.nodes[idx].value] = true
+				}
 			}
 		} else {
 			used_fns = monomorph_used_fns.move()

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -5650,18 +5650,26 @@ fn cache_external_input_owner_modules(state &V3ModuleCacheState, unscoped_inputs
 		}
 	}
 	for raw_module_name, paths in state.module_external_inputs {
+		roots := state.module_native_roots[raw_module_name] or { []string{} }
+		mut root_paths := map[string]bool{}
+		for root in roots {
+			root_paths[os.real_path(root)] = true
+		}
 		mut has_static_storage := false
 		for path in paths {
 			source := os.read_file(path) or { continue }
 			if modulecache.c_source_has_static_storage(source) {
+				// Only root native source includes are removed from the program unit.
+				// Static storage in any other input would be emitted in both units.
+				if !root_paths[os.real_path(path)] {
+					return modules, false
+				}
 				has_static_storage = true
-				break
 			}
 		}
 		if !has_static_storage {
 			continue
 		}
-		roots := state.module_native_roots[raw_module_name] or { return modules, false }
 		if roots.len == 0 {
 			return modules, false
 		}

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -3,6 +3,7 @@ module main
 import os
 import rand
 import strings
+import time
 import v3.bench
 import v3.cmdexec
 import v3.modulecache
@@ -75,6 +76,14 @@ mut:
 	native_source_modules  map[string]bool
 	objects                map[string]string
 	headers                map[string]string
+}
+
+struct V3ParseTiming {
+mut:
+	header_us       i64
+	source_us       i64
+	header_parallel bool
+	source_parallel bool
 }
 
 struct V3PreparedModuleCache {
@@ -3341,9 +3350,8 @@ fn main() {
 		cache_state.source_body_modules['builtin'] = true
 		files << builtin_files
 	}
-	mut parse_was_parallel := false
-	_, builtin_parse_parallel := p.parse_files_dispatch(files, !current_no_parallel)
-	parse_was_parallel = parse_was_parallel || builtin_parse_parallel
+	mut parse_timing := V3ParseTiming{}
+	parse_files_dispatch_profiled(mut p, files, !current_no_parallel, mut parse_timing)
 	mut a := p.a
 	defer {
 		a.close_workers()
@@ -3387,17 +3395,15 @@ fn main() {
 		user_files << input_file
 	}
 	prefs.is_test = user_files.any(pref.is_test_file_for_platform(it, backend, prefs.target))
-	_, user_parse_parallel := p.parse_files_dispatch(user_files, !current_no_parallel)
-	parse_was_parallel = parse_was_parallel || user_parse_parallel
+	parse_files_dispatch_profiled(mut p, user_files, !current_no_parallel, mut parse_timing)
 	test_files := test_input_files(user_files, backend, prefs.target)
 
 	seed_implicit_imports(mut a)
 	seed_cached_builtin_bundle_imports(mut a, cache_state.manager.enabled, builtin_dir)
 
 	// Resolve imports recursively
-	import_parse_parallel := resolve_imports(mut a, mut p, prefs, user_files, !current_no_parallel, mut
-		cache_state)
-	parse_was_parallel = parse_was_parallel || import_parse_parallel
+	resolve_imports(mut a, mut p, prefs, user_files, !current_no_parallel, mut cache_state, mut
+		parse_timing)
 	if p.diagnostics.len > 0 {
 		for diagnostic in p.diagnostics {
 			eprintln('${diagnostic.file}:${diagnostic.line}:${diagnostic.column}: error: ${diagnostic.message}')
@@ -3413,7 +3419,24 @@ fn main() {
 		''
 	}
 
-	b.step_parallel('parse', parse_was_parallel)
+	parse_total_us := b.current_step_time_us()
+	header_parse_us := if parse_timing.header_us < parse_total_us {
+		parse_timing.header_us
+	} else {
+		parse_total_us
+	}
+	b.step_parts([
+		bench.StepPart{
+			name:     'parse .vh'
+			time_us:  header_parse_us
+			parallel: parse_timing.header_parallel
+		},
+		bench.StepPart{
+			name:     'parse .v'
+			time_us:  parse_total_us - header_parse_us
+			parallel: parse_timing.source_parallel
+		},
+	])
 	b.metric_items('parsed .vh files', p.parsed_v_header_files, 'files', '.vh files',
 		p.parsed_v_header_file_paths)
 	println('    ${'parsed .vh lines':-28s} ${source_file_line_count(p.parsed_v_header_file_paths)} lines')
@@ -6037,7 +6060,7 @@ fn synthetic_index_shift(insertions []SyntheticInsertion, idx int) int {
 }
 
 // resolve_imports resolves resolve imports information for v3 entry point.
-fn resolve_imports(mut a flat.FlatAst, mut p parser.Parser, prefs &pref.Preferences, initial_files []string, allow_parallel bool, mut cache_state V3ModuleCacheState) bool {
+fn resolve_imports(mut a flat.FlatAst, mut p parser.Parser, prefs &pref.Preferences, initial_files []string, allow_parallel bool, mut cache_state V3ModuleCacheState, mut parse_timing V3ParseTiming) bool {
 	mut parsed_modules := map[string]bool{}
 	parsed_modules['builtin'] = true
 	parsed_modules['main'] = true
@@ -6312,7 +6335,8 @@ fn resolve_imports(mut a flat.FlatAst, mut p parser.Parser, prefs &pref.Preferen
 		if wave_files.len == 0 {
 			break
 		}
-		starts, wave_parallel := p.parse_files_dispatch(wave_files, allow_parallel)
+		starts, wave_parallel := parse_files_dispatch_profiled(mut p, wave_files, allow_parallel, mut
+			parse_timing)
 		was_parallel = was_parallel || wave_parallel
 		wave_end_nodes := a.nodes.len
 		for i, canon in wave_canon {
@@ -6364,6 +6388,40 @@ fn resolve_imports(mut a flat.FlatAst, mut p parser.Parser, prefs &pref.Preferen
 		implicit_imports.node_idx += insertions.len
 	}
 	return was_parallel
+}
+
+fn parse_files_dispatch_profiled(mut p parser.Parser, paths []string, allow_parallel bool, mut timing V3ParseTiming) ([]int, bool) {
+	sw := time.new_stopwatch()
+	starts, parallel := p.parse_files_dispatch(paths, allow_parallel)
+	elapsed_us := sw.elapsed().microseconds()
+	mut header_weight := i64(0)
+	mut source_weight := i64(0)
+	for path in paths {
+		size := i64(os.file_size(path))
+		weight := if size > 0 { size } else { i64(1) }
+		if path.ends_with('.vh') {
+			header_weight += weight
+		} else {
+			source_weight += weight
+		}
+	}
+	total_weight := header_weight + source_weight
+	// A partially warm import wave can parse headers and sources concurrently.
+	// Attribute that shared wall time by input size without changing AST parse order.
+	header_us := if header_weight == 0 || total_weight == 0 {
+		i64(0)
+	} else if source_weight == 0 {
+		elapsed_us
+	} else {
+		elapsed_us * header_weight / total_weight
+	}
+	timing.header_us += header_us
+	timing.source_us += elapsed_us - header_us
+	if parallel {
+		timing.header_parallel = timing.header_parallel || header_weight > 0
+		timing.source_parallel = timing.source_parallel || source_weight > 0
+	}
+	return starts, parallel
 }
 
 fn record_cache_module_dependency(mut state V3ModuleCacheState, owner string, dependency string) {

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -71,6 +71,7 @@ mut:
 	module_dependencies    map[string][]string
 	module_external_inputs map[string][]string
 	module_native_roots    map[string][]string
+	dependency_metadata    map[string]string
 	parsed_from_source     map[string]bool
 	source_body_modules    map[string]bool
 	native_source_modules  map[string]bool
@@ -2648,13 +2649,18 @@ fn promote_scoped_signatures(mut tc types.TypeChecker, original_names []string) 
 	}
 }
 
-// default_cc_identity returns the resolved path and version banner of the
-// default `cc`. Module objects in the persistent cache are compiled with literal
-// `cc` (only the default compiler is cacheable), so this must be part of the
-// cache salt: a `cc` upgrade or a retargeted `cc` symlink otherwise leaves stale
-// objects certified as current.
+// default_cc_identity returns a precise identity for the resolved default `cc`.
+// Module objects in the persistent cache are compiled with literal `cc` (only
+// the default compiler is cacheable), so a changed binary or retargeted symlink
+// must invalidate them. File identity avoids launching `cc --version` on every
+// warm build; fall back to the version banner on filesystems without precise
+// metadata support.
 fn default_cc_identity() string {
-	cc_path := os.find_abs_path_of_executable('cc') or { 'cc' }
+	cc_path := os.real_path(os.find_abs_path_of_executable('cc') or { 'cc' })
+	metadata := modulecache.file_metadata_signature(cc_path)
+	if metadata.len > 0 {
+		return '${cc_path}\t${metadata}'
+	}
 	cc_version := cmdexec.run('cc', ['--version']).output
 	return '${cc_path}\t${cc_version.replace('\n', ' ')}'
 }
@@ -3321,6 +3327,7 @@ fn main() {
 		module_dependencies:    map[string][]string{}
 		module_external_inputs: map[string][]string{}
 		module_native_roots:    map[string][]string{}
+		dependency_metadata:    map[string]string{}
 		parsed_from_source:     map[string]bool{}
 		source_body_modules:    map[string]bool{}
 		native_source_modules:  map[string]bool{}
@@ -3402,8 +3409,18 @@ fn main() {
 	seed_cached_builtin_bundle_imports(mut a, cache_state.manager.enabled, builtin_dir)
 
 	// Resolve imports recursively
+	resolve_imports_started_us := b.current_step_time_us()
+	resolve_imports_parse_started_us := parse_timing.header_us + parse_timing.source_us
 	resolve_imports(mut a, mut p, prefs, user_files, !current_no_parallel, mut cache_state, mut
 		parse_timing)
+	resolve_imports_elapsed_us := b.current_step_time_us() - resolve_imports_started_us
+	resolve_imports_parse_us := parse_timing.header_us + parse_timing.source_us -
+		resolve_imports_parse_started_us
+	resolve_imports_coordination_us := if resolve_imports_parse_us < resolve_imports_elapsed_us {
+		resolve_imports_elapsed_us - resolve_imports_parse_us
+	} else {
+		i64(0)
+	}
 	if p.diagnostics.len > 0 {
 		for diagnostic in p.diagnostics {
 			eprintln('${diagnostic.file}:${diagnostic.line}:${diagnostic.column}: error: ${diagnostic.message}')
@@ -3421,19 +3438,21 @@ fn main() {
 
 	parse_total_us := b.current_step_time_us()
 	profiled_parse_us := parse_timing.header_us + parse_timing.source_us
-	parse_coordination_us := if profiled_parse_us < parse_total_us {
-		parse_total_us - profiled_parse_us
-	} else {
-		i64(0)
-	}
-	parse_scale_denominator := if profiled_parse_us > parse_total_us {
-		profiled_parse_us
+	accounted_parse_us := profiled_parse_us + resolve_imports_coordination_us
+	parse_scale_denominator := if accounted_parse_us > parse_total_us {
+		accounted_parse_us
 	} else {
 		parse_total_us
 	}
 	header_parse_us := parse_timing.header_us * parse_total_us / parse_scale_denominator
 	source_parse_us := parse_timing.source_us * parse_total_us / parse_scale_denominator
+	resolve_coordination_us := resolve_imports_coordination_us * parse_total_us / parse_scale_denominator
+	parse_setup_us := parse_total_us - header_parse_us - source_parse_us - resolve_coordination_us
 	b.step_parts([
+		bench.StepPart{
+			name:    'parse setup/cache'
+			time_us: parse_setup_us
+		},
 		bench.StepPart{
 			name:     'parse .vh'
 			time_us:  header_parse_us
@@ -3445,8 +3464,8 @@ fn main() {
 			parallel: parse_timing.source_parallel
 		},
 		bench.StepPart{
-			name:    'parse setup/imports'
-			time_us: parse_coordination_us
+			name:    'resolve imports'
+			time_us: resolve_coordination_us
 		},
 	])
 	b.metric_items('parsed .vh files', p.parsed_v_header_files, 'files', '.vh files',
@@ -6317,7 +6336,9 @@ fn resolve_imports(mut a flat.FlatAst, mut p parser.Parser, prefs &pref.Preferen
 						cache_state.source_body_modules[cache_module] = true
 					}
 				} else if !cache_state.force_source {
-					if cached := cache_state.manager.valid_entry(cache_module, mod_files) {
+					if cached := cache_state.manager.valid_entry_with_metadata_cache(cache_module,
+						mod_files, mut cache_state.dependency_metadata)
+					{
 						if !modulecache.header_needs_source(cached) {
 							parse_files = [cached.header]
 							if mod_files.len > 0 {
@@ -6406,6 +6427,25 @@ fn parse_files_dispatch_profiled(mut p parser.Parser, paths []string, allow_para
 	sw := time.new_stopwatch()
 	starts, parallel := p.parse_files_dispatch(paths, allow_parallel)
 	elapsed_us := sw.elapsed().microseconds()
+	mut has_headers := false
+	mut has_sources := false
+	for path in paths {
+		if path.ends_with('.vh') {
+			has_headers = true
+		} else {
+			has_sources = true
+		}
+	}
+	if !has_headers || !has_sources {
+		if has_headers {
+			timing.header_us += elapsed_us
+			timing.header_parallel = timing.header_parallel || parallel
+		} else {
+			timing.source_us += elapsed_us
+			timing.source_parallel = timing.source_parallel || parallel
+		}
+		return starts, parallel
+	}
 	mut header_weight := i64(0)
 	mut source_weight := i64(0)
 	for path in paths {

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -1697,30 +1697,51 @@ fn monomorph_cache_runtime_strings(a &flat.FlatAst) []string {
 	return values
 }
 
-fn monomorph_cache_semantic_signature(a &flat.FlatAst) string {
+fn monomorph_cache_semantic_signature(a &flat.FlatAst, source_files []string) string {
 	cacheable_strings := cacheable_runtime_string_nodes(a)
 	mut hash := u64(1469598103934665603)
+	mut source_paths := map[string]bool{}
+	for path in source_files {
+		source_paths[os.real_path(path)] = true
+	}
+	mut file_ids := []int{}
 	for idx, node in a.nodes {
-		hash = c_hash_bytes(hash, [u8(node.kind), u8(node.op), u8(node.is_mut),
-			u8(node.skip_ownership_drops)])
-		hash = c_hash_tag(hash, node.children_start)
-		hash = c_hash_tag(hash, node.children_count)
-		hash = c_hash_bytes(hash, node.typ.bytes())
-		hash = c_hash_bytes(hash, [u8(0)])
-		if !cacheable_strings[idx] {
-			hash = c_hash_bytes(hash, node.value.bytes())
-		}
-		hash = c_hash_bytes(hash, [u8(0xff)])
-		for param in node.generic_params() {
-			hash = c_hash_bytes(hash, param.bytes())
-			hash = c_hash_bytes(hash, [u8(0xfe)])
+		if node.kind == .file && os.real_path(node.value) in source_paths {
+			file_ids << idx
 		}
 	}
-	hash = c_hash_tag(hash, a.user_code_start)
-	for child in a.children {
-		hash = c_hash_tag(hash, int(child))
+	file_ids.sort_with_compare(fn [a] (left &int, right &int) int {
+		return a.nodes[*left].value.compare(a.nodes[*right].value)
+	})
+	for idx in file_ids {
+		hash = c_hash_monomorph_node(hash, a, flat.NodeId(idx), cacheable_strings)
 	}
-	return c_hash_function_metadata(hash, a).hex()
+	return hash.hex()
+}
+
+fn c_hash_monomorph_node(initial u64, a &flat.FlatAst, id flat.NodeId, cacheable_strings []bool) u64 {
+	idx := int(id)
+	if idx < 0 || idx >= a.nodes.len {
+		return initial
+	}
+	node := a.nodes[idx]
+	mut hash := c_hash_bytes(initial, [u8(node.kind), u8(node.op), u8(node.is_mut),
+		u8(node.skip_ownership_drops)])
+	hash = c_hash_tag(hash, node.children_count)
+	hash = c_hash_bytes(hash, node.typ.bytes())
+	hash = c_hash_bytes(hash, [u8(0)])
+	if idx >= cacheable_strings.len || !cacheable_strings[idx] {
+		hash = c_hash_bytes(hash, node.value.bytes())
+	}
+	hash = c_hash_bytes(hash, [u8(0xff)])
+	for param in node.generic_params() {
+		hash = c_hash_bytes(hash, param.bytes())
+		hash = c_hash_bytes(hash, [u8(0xfe)])
+	}
+	for child_idx in 0 .. node.children_count {
+		hash = c_hash_monomorph_node(hash, a, a.child(&node, child_idx), cacheable_strings)
+	}
+	return hash
 }
 
 fn c_hash_function_metadata(initial u64, a &flat.FlatAst) u64 {
@@ -2085,6 +2106,52 @@ fn merge_incremental_program_body(cached_source string, changed_source string, c
 	declaration_text := additions.str()
 	marker := '/* V3CACHE_BODY_BEGIN */'
 	marker_idx := merged.index(marker) or { return none }
+	if declaration_text.len > 0 {
+		merged = merged[..marker_idx] + declaration_text + merged[marker_idx..]
+	}
+	mut new_sections := strings.new_builder(1024)
+	for key in changed_sections.keys {
+		if key !in cached_sections.sections {
+			new_sections.write_string(changed_sections.sections[key])
+		}
+	}
+	new_section_text := new_sections.str()
+	if new_section_text.len == 0 {
+		return merged
+	}
+	body_marker_idx := merged.index(marker) or { return none }
+	mut body_start := body_marker_idx + marker.len
+	if body_start < merged.len && merged[body_start] == `\n` {
+		body_start++
+	}
+	return merged[..body_start] + new_section_text + merged[body_start..]
+}
+
+fn merge_cached_generic_program_body(cached_source string, changed_source string) ?string {
+	cached_sections := incremental_c_function_sections(cached_source) or { return none }
+	changed_sections := incremental_c_function_sections(changed_source) or { return none }
+	mut merged := cached_source
+	for key in changed_sections.keys {
+		old_section := cached_sections.sections[key] or { continue }
+		merged = merged.replace(old_section, changed_sections.sections[key])
+	}
+	support_declarations := incremental_c_support_declarations(changed_source) or { '' }
+	new_definitions := modulecache.static_string_definitions(changed_source)
+	mut additions := strings.new_builder(support_declarations.len + new_definitions.len)
+	if support_declarations.trim_space().len > 0 {
+		additions.write_string(support_declarations)
+		if !support_declarations.ends_with('\n') {
+			additions.writeln('')
+		}
+	}
+	for line in new_definitions.split_into_lines() {
+		if line.len > 0 && !merged.contains(line) {
+			additions.writeln(line)
+		}
+	}
+	marker := '/* V3CACHE_BODY_BEGIN */'
+	marker_idx := merged.index(marker) or { return none }
+	declaration_text := additions.str()
 	if declaration_text.len > 0 {
 		merged = merged[..marker_idx] + declaration_text + merged[marker_idx..]
 	}
@@ -3367,7 +3434,6 @@ fn main() {
 	mut cgen_cache_hit := false
 	mut cgen_prepared_entry := modulecache.CgenPreparedEntry{}
 	mut cgen_prepared_hit := false
-	mut generic_cache_input := V3CgenCacheInput{}
 	mut generic_cache_entry := modulecache.GenericProgramEntry{}
 	mut generic_cache_hit := false
 	mut generic_cache_signature := ''
@@ -3378,6 +3444,11 @@ fn main() {
 	mut cache_c_flags := user_c_flags.clone()
 	if backend == 'c' && cache_state.manager.enabled {
 		cache_c_flags << cgen.cache_directive_flags(a, prefs.vroot, prefs.target)
+	}
+	if backend == 'c' && cache_state.manager.enabled && !is_prod && !is_shared && !is_selfhost
+		&& prefs.normalized_target_os() == 'macos' {
+		generic_cache_signature = monomorph_cache_semantic_signature(a, user_files)
+		generic_cache_runtime_strings = monomorph_cache_runtime_strings(a)
 	}
 	incremental_snapshot := incremental_program_snapshot(a)
 	mut incremental_cache_hit := false
@@ -3407,9 +3478,6 @@ fn main() {
 		}
 		if !cgen_cache_hit && !is_prod && !is_shared && !is_selfhost
 			&& prefs.normalized_target_os() == 'macos' {
-			generic_cache_signature = monomorph_cache_semantic_signature(a)
-			generic_cache_runtime_strings = monomorph_cache_runtime_strings(a)
-			generic_cache_input = input
 			if entry := cache_state.manager.valid_generic_program(input.source_files,
 				generic_cache_signature, input.generation_signature, input.dependency_inputs)
 			{
@@ -3949,16 +4017,9 @@ fn main() {
 			pre_tc.set_fresh_type_cache(parse_cache_enabled)
 			prealloc_scope_free_for_v3(monomorph_scope)
 		} else {
-			if cached_monomorph_specs.len > 0 {
-				monomorph_used_fns, monomorph_errors, generated_monomorph_specs = transform.monomorphize_with_used_checked_config_scoped_cached(mut a,
-					&pre_tc, monomorph_input_used, should_parallel_monomorphize()
-					&& cache_state.parsed_from_source.len == 0, unsafe { nil },
-					cached_monomorph_specs)
-			} else {
-				monomorph_used_fns, monomorph_errors = transform.monomorphize_with_used_checked_config(mut a,
-					&pre_tc, monomorph_input_used, should_parallel_monomorphize()
-					&& cache_state.parsed_from_source.len == 0)
-			}
+			monomorph_used_fns, monomorph_errors, generated_monomorph_specs = transform.monomorphize_with_used_checked_config_scoped_cached(mut a,
+				&pre_tc, monomorph_input_used, should_parallel_monomorphize()
+				&& cache_state.parsed_from_source.len == 0, unsafe { nil }, cached_monomorph_specs)
 		}
 		if incremental_cache_hit {
 			incremental_stage_used_fns = monomorph_used_fns.move()
@@ -4262,8 +4323,14 @@ fn main() {
 							cleanup_c_build_dir(cc_dir)
 							exit(1)
 						}
+						cached_body := os.read_file(generic_cache_entry.body) or {
+							eprintln('error reading cached generic body ${generic_cache_entry.body}: ${err.msg()}')
+							cleanup_c_build_dir(cc_dir)
+							exit(1)
+						}
 						prepared_cache = prepare_v3_cached_generic_body(generated_source,
-							cached_prefix, cached_declarations, compile_signature, mut cache_state) or {
+							cached_prefix, cached_declarations, cached_body, compile_signature, mut
+							cache_state) or {
 							eprintln(err.msg())
 							cleanup_c_build_dir(cc_dir)
 							exit(1)
@@ -4318,9 +4385,11 @@ fn main() {
 				}
 				if !generic_cache_hit && generic_cache_signature.len > 0
 					&& generated_monomorph_specs.len > 0 {
-					cache_state.manager.write_generic_program(generic_cache_input.source_files,
-						generic_cache_signature, generic_cache_input.generation_signature,
-						generic_cache_input.dependency_inputs,
+					published_generic_input := v3_cgen_cache_input(cache_state, user_files,
+						cache_c_flags)
+					cache_state.manager.write_generic_program(published_generic_input.source_files,
+						generic_cache_signature, published_generic_input.generation_signature,
+						published_generic_input.dependency_inputs,
 						encode_monomorph_cache_specs(generated_monomorph_specs),
 						encode_cached_used_fns(used_fns), prepared_cache.program_prefix_source,
 						modulecache.prune_unreferenced_static_string_definitions(prepared_cache.program_declarations),
@@ -4330,10 +4399,12 @@ fn main() {
 				}
 				if !incremental_cache_hit && !generic_cache_hit
 					&& incremental_snapshot.declaration_signature.len > 0 {
-					cache_state.manager.write_incremental_program(generic_cache_input.source_files,
+					published_incremental_input := v3_cgen_cache_input(cache_state, user_files,
+						cache_c_flags)
+					cache_state.manager.write_incremental_program(published_incremental_input.source_files,
 						incremental_snapshot.declaration_signature,
-						generic_cache_input.generation_signature,
-						generic_cache_input.dependency_inputs,
+						published_incremental_input.generation_signature,
+						published_incremental_input.dependency_inputs,
 						encode_incremental_manifest(incremental_snapshot),
 						prepared_cache.program_body_cache, encode_cached_used_fns(used_fns),
 						encode_monomorph_cache_specs(generated_monomorph_specs),
@@ -4673,7 +4744,7 @@ fn prepare_v3_incremental_cached_body(body_path string, tcc_declarations_path st
 	}
 }
 
-fn prepare_v3_cached_generic_body(generated_source string, cached_prefix string, cached_declarations string, compile_signature string, mut state V3ModuleCacheState) !V3PreparedModuleCache {
+fn prepare_v3_cached_generic_body(generated_source string, cached_prefix string, cached_declarations string, cached_body string, compile_signature string, mut state V3ModuleCacheState) !V3PreparedModuleCache {
 	if !state.manager.ensure_dir() {
 		return error('v3 module cache directory is unavailable')
 	}
@@ -4681,7 +4752,12 @@ fn prepare_v3_cached_generic_body(generated_source string, cached_prefix string,
 		os.setenv('V3_CACHE_FORCE_SOURCE', '1', true)
 		restart_v3_after_cache_invalidation()
 	}
-	materialized_source := modulecache.materialize_cached_body_string_definitions(generated_source)
+	incremental_c_function_sections(generated_source) or {
+		return error('v3 generic C function sections are unavailable')
+	}
+	materialized_cached_body := modulecache.materialize_cached_body_string_definitions(cached_body)
+	materialized_source := merge_cached_generic_program_body(materialized_cached_body,
+		generated_source) or { return error('v3 generic C body could not be reconstructed') }
 	split := modulecache.split_generated_c(materialized_source)!
 	main_body := split.modules['main'] or { '' }
 	current_string_definitions := modulecache.static_string_definitions(split.prefix)

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -1639,7 +1639,7 @@ fn v3_cgen_cache_input(state &V3ModuleCacheState, user_files []string, user_c_fl
 		}
 	}
 	if state.external_inputs_ready {
-		dependencies['external-state:manifest'] = 'v3-external-inputs-1'
+		dependencies['external-state:manifest'] = 'v3-external-inputs-2'
 		mut root_modules := state.module_native_roots.keys()
 		root_modules.sort()
 		for module_name in root_modules {
@@ -1676,7 +1676,7 @@ fn prepare_v3_cache_external_inputs(mut state V3ModuleCacheState, a &flat.FlatAs
 		cache_input_modules[module_name] = true
 	}
 	cache_input_modules['main'] = true
-	external_inputs, native_source_roots, resolution_dirs, missing_resolution_paths, has_untracked_c_include := cgen.cache_external_input_files_with_resolved_flags(a,
+	external_inputs, native_source_roots, unscoped_inputs, resolution_dirs, missing_resolution_paths, has_untracked_c_include := cgen.cache_external_input_files_with_resolved_flags(a,
 		prefs.vroot, cache_input_modules, user_c_flags, prefs.target)
 	state.module_external_inputs = external_inputs.clone()
 	state.module_native_roots = native_source_roots.clone()
@@ -1687,7 +1687,8 @@ fn prepare_v3_cache_external_inputs(mut state V3ModuleCacheState, a &flat.FlatAs
 		&& !v3_path_is_within(it, real_cache_dir))
 	state.external_missing_paths = missing_resolution_paths.filter(
 		!v3_path_is_within(it, cache_dir) && !v3_path_is_within(it, real_cache_dir))
-	native_source_modules, can_scope_static_inputs := cache_external_input_owner_modules(state)
+	native_source_modules, can_scope_static_inputs := cache_external_input_owner_modules(state,
+		unscoped_inputs)
 	state.native_source_modules = native_source_modules.clone()
 	state.external_inputs_ready = true
 	return !has_untracked_c_include && can_scope_static_inputs
@@ -1723,7 +1724,7 @@ fn restore_v3_cache_external_inputs(mut state V3ModuleCacheState, user_files []s
 		'external-root:', 'external-owner:', 'external-dir:', 'external-missing:', 'external-state:']) or {
 		return false
 	}
-	if restored['external-state:manifest'] or { '' } != 'v3-external-inputs-1' {
+	if restored['external-state:manifest'] or { '' } != 'v3-external-inputs-2' {
 		return false
 	}
 	mut external_inputs := map[string][]string{}
@@ -5638,8 +5639,16 @@ fn restart_v3_with_args(extra_args []string) {
 	}
 }
 
-fn cache_external_input_owner_modules(state &V3ModuleCacheState) (map[string]bool, bool) {
+fn cache_external_input_owner_modules(state &V3ModuleCacheState, unscoped_inputs map[string][]string) (map[string]bool, bool) {
 	mut modules := map[string]bool{}
+	for _, paths in unscoped_inputs {
+		for path in paths {
+			source := os.read_file(path) or { continue }
+			if modulecache.c_source_has_static_storage(source) {
+				return modules, false
+			}
+		}
+	}
 	for raw_module_name, paths in state.module_external_inputs {
 		mut has_static_storage := false
 		for path in paths {

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -2933,17 +2933,13 @@ fn promote_scoped_signatures(mut tc types.TypeChecker, original_names []string) 
 // default_cc_identity returns a precise identity for the resolved default `cc`.
 // Module objects in the persistent cache are compiled with literal `cc` (only
 // the default compiler is cacheable), so a changed binary or retargeted symlink
-// must invalidate them. File identity avoids launching `cc --version` on every
-// warm build; fall back to the version banner on filesystems without precise
-// metadata support.
+// must invalidate them. The version probe also identifies the selected backend
+// behind stable compiler shims and wrappers.
 fn default_cc_identity() string {
 	cc_path := os.real_path(os.find_abs_path_of_executable('cc') or { 'cc' })
 	metadata := modulecache.file_metadata_signature(cc_path)
-	if metadata.len > 0 {
-		return '${cc_path}\t${metadata}'
-	}
-	cc_version := cmdexec.run('cc', ['--version']).output
-	return '${cc_path}\t${cc_version.replace('\n', ' ')}'
+	version := cmdexec.run(cc_path, ['--version'])
+	return '${cc_path}\t${metadata}\t${version.exit_code}\t${version.output.replace('\n', ' ')}'
 }
 
 fn v3_cache_compiler_signature(vroot string) string {

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -5174,24 +5174,29 @@ fn restart_v3_with_args(extra_args []string) {
 
 fn cache_external_input_owner_modules(state &V3ModuleCacheState) (map[string]bool, bool) {
 	mut modules := map[string]bool{}
-	for raw_module_name, paths in state.module_external_inputs {
-		for path in paths {
+	for raw_module_name, roots in state.module_native_roots {
+		mut has_static_storage := false
+		for path in state.module_external_inputs[raw_module_name] {
 			source := os.read_file(path) or { continue }
-			if !modulecache.c_source_has_static_storage(source) {
-				continue
+			if modulecache.c_source_has_static_storage(source) {
+				has_static_storage = true
+				break
 			}
-			if !c_flag_is_c_source_file(path) {
-				return modules, false
-			}
-			if raw_module_name == 'main' {
-				modules['main'] = true
-				continue
-			}
-			module_name := cache_state_module_name(state, raw_module_name) or {
-				return modules, false
-			}
-			modules[module_name] = true
 		}
+		if !has_static_storage {
+			continue
+		}
+		for root in roots {
+			if !c_flag_is_c_source_file(root) {
+				return modules, false
+			}
+		}
+		if raw_module_name == 'main' {
+			modules['main'] = true
+			continue
+		}
+		module_name := cache_state_module_name(state, raw_module_name) or { return modules, false }
+		modules[module_name] = true
 	}
 	return modules, true
 }

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -1917,6 +1917,7 @@ fn monomorph_cache_semantic_signature(a &flat.FlatAst, source_files []string) st
 	for idx in file_ids {
 		hash = c_hash_monomorph_node(hash, a, flat.NodeId(idx), cacheable_strings)
 	}
+	hash = c_hash_function_metadata(hash, a)
 	return hash.hex()
 }
 

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -3003,7 +3003,7 @@ fn transformed_used_fns_need_monomorphize(used_fns map[string]bool) bool {
 	return false
 }
 
-fn incremental_changed_functions_call_generics(a &flat.FlatAst, tc &types.TypeChecker, changed_names map[string]bool) bool {
+fn incremental_changed_functions_use_generics(a &flat.FlatAst, tc &types.TypeChecker, changed_names map[string]bool) bool {
 	if changed_names.len == 0 {
 		return false
 	}
@@ -3019,7 +3019,7 @@ fn incremental_changed_functions_call_generics(a &flat.FlatAst, tc &types.TypeCh
 			.fn_decl {
 				name := incremental_qualified_fn_name(cur_module, node.value)
 				if changed_names[name]
-					&& incremental_node_tree_calls_generic(a, tc, flat.NodeId(idx)) {
+					&& incremental_node_tree_uses_generics(a, tc, flat.NodeId(idx), cur_module) {
 					return true
 				}
 			}
@@ -3029,7 +3029,7 @@ fn incremental_changed_functions_call_generics(a &flat.FlatAst, tc &types.TypeCh
 	return false
 }
 
-fn incremental_node_tree_calls_generic(a &flat.FlatAst, tc &types.TypeChecker, root flat.NodeId) bool {
+fn incremental_node_tree_uses_generics(a &flat.FlatAst, tc &types.TypeChecker, root flat.NodeId, module_name string) bool {
 	mut stack := [root]
 	for stack.len > 0 {
 		id := stack.pop()
@@ -3045,8 +3045,58 @@ fn incremental_node_tree_calls_generic(a &flat.FlatAst, tc &types.TypeChecker, r
 				}
 			}
 		}
+		mut type_names := [node.typ, node.value]
+		if node.generic_params().len > 0 && node.value.len > 0 {
+			type_names << '${node.value}[${node.generic_params().join(', ')}]'
+		}
+		for type_name in type_names {
+			if incremental_type_is_generic_named_application(type_name, module_name, tc) {
+				return true
+			}
+		}
 		for child_idx in 0 .. node.children_count {
 			stack << a.child(&node, child_idx)
+		}
+	}
+	return false
+}
+
+fn incremental_type_is_generic_named_application(type_name string, module_name string, tc &types.TypeChecker) bool {
+	mut offset := 0
+	for offset < type_name.len {
+		relative_bracket := type_name[offset..].index_u8(`[`)
+		if relative_bracket < 0 {
+			return false
+		}
+		bracket := offset + relative_bracket
+		mut start := bracket
+		for start > 0 {
+			c := type_name[start - 1]
+			if !((c >= `a` && c <= `z`) || (c >= `A` && c <= `Z`)
+				|| (c >= `0` && c <= `9`) || c in [`_`, `.`]) {
+				break
+			}
+			start--
+		}
+		if start < bracket
+			&& incremental_generic_type_base_is_known(type_name[start..bracket], module_name, tc) {
+			return true
+		}
+		offset = bracket + 1
+	}
+	return false
+}
+
+fn incremental_generic_type_base_is_known(base string, module_name string, tc &types.TypeChecker) bool {
+	if base in tc.struct_generic_params || base in tc.sum_generic_params
+		|| base in tc.type_alias_generic_params {
+		return true
+	}
+	if !base.contains('.') && module_name !in ['', 'main', 'builtin'] {
+		qualified := '${module_name}.${base}'
+		if qualified in tc.struct_generic_params || qualified in tc.sum_generic_params
+			|| qualified in tc.type_alias_generic_params {
+			return true
 		}
 	}
 	return false
@@ -3791,7 +3841,7 @@ fn main() {
 	mut incremental_cache_hit := false
 	mut incremental_changed_keys := []string{}
 	mut incremental_changed_names := map[string]bool{}
-	mut incremental_calls_generics := false
+	mut incremental_uses_generics := false
 	mut incremental_cached_body := ''
 	mut incremental_tcc_declarations_path := ''
 	if backend == 'c' && cache_state.manager.enabled && !cache_state.force_source
@@ -3958,8 +4008,8 @@ fn main() {
 			print_type_errors(pre_tc.errors)
 			exit(1)
 		}
-		incremental_calls_generics = incremental_cache_hit
-			&& incremental_changed_functions_call_generics(a, pre_tc, incremental_changed_names)
+		incremental_uses_generics = incremental_cache_hit
+			&& incremental_changed_functions_use_generics(a, pre_tc, incremental_changed_names)
 		pre_tc.prune_inactive_top_level_comptime(mut a)
 		test_harness_errors := validate_test_file_harness_inputs(a, pre_tc, test_files)
 		if test_harness_errors.len > 0 {
@@ -4225,7 +4275,7 @@ fn main() {
 		pre_tc.reject_unlowered_map_mutation = true
 		set_diagnostic_files(mut pre_tc, user_files)
 		set_unsupported_generic_files(mut pre_tc, a, is_selfhost, diagnostic_root)
-		incremental_needs_monomorphize := incremental_cache_hit && (incremental_calls_generics
+		incremental_needs_monomorphize := incremental_cache_hit && (incremental_uses_generics
 			|| transformed_used_fns_need_monomorphize(incremental_stage_used_fns))
 		if !building_v && !cmd_v_build {
 			if uses_generics && (!incremental_cache_hit || incremental_needs_monomorphize) {
@@ -4299,7 +4349,7 @@ fn main() {
 		// AST and checker state on this path.
 	} else if building_v {
 		used_fns = transform.erase_generic_templates(mut a, &pre_tc, used_fns)
-	} else if uses_generics && (!incremental_cache_hit || incremental_calls_generics
+	} else if uses_generics && (!incremental_cache_hit || incremental_uses_generics
 		|| transformed_used_fns_need_monomorphize(incremental_stage_used_fns)) {
 		mut monomorph_used_fns := map[string]bool{}
 		mut monomorph_errors := []string{}

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -2274,9 +2274,6 @@ fn incremental_changed_functions_require_reachability_rebuild(a &flat.FlatAst, t
 					changed_roots << flat.NodeId(node_idx)
 					changed_root_modules[node_idx] = cur_module
 				}
-				if cur_module !in ['', 'main'] {
-					continue
-				}
 				aliases := [node.value, name, restored_fn_c_name(node.value),
 					restored_fn_c_name(name)]
 				for alias in aliases {

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -64,19 +64,23 @@ struct V3ModuleCacheState {
 	bundle_sources      []string
 	bundle_source_paths map[string]bool
 mut:
-	force_source           bool
-	bundle_valid           bool
-	module_sources         map[string][]string
-	module_import_paths    map[string]string
-	module_dependencies    map[string][]string
-	module_external_inputs map[string][]string
-	module_native_roots    map[string][]string
-	dependency_metadata    map[string]string
-	parsed_from_source     map[string]bool
-	source_body_modules    map[string]bool
-	native_source_modules  map[string]bool
-	objects                map[string]string
-	headers                map[string]string
+	force_source              bool
+	bundle_valid              bool
+	module_sources            map[string][]string
+	module_import_paths       map[string]string
+	module_dependencies       map[string][]string
+	module_external_inputs    map[string][]string
+	module_native_roots       map[string][]string
+	external_input_signatures map[string]string
+	external_resolution_dirs  []string
+	external_missing_paths    []string
+	external_inputs_ready     bool
+	dependency_metadata       map[string]string
+	parsed_from_source        map[string]bool
+	source_body_modules       map[string]bool
+	native_source_modules     map[string]bool
+	objects                   map[string]string
+	headers                   map[string]string
 }
 
 struct V3ParseTiming {
@@ -110,6 +114,17 @@ struct V3CgenCacheMetadata {
 	interface_impl_signature string
 	prefix_source_identity   string
 	flags                    []string
+}
+
+struct V3ExternalCachePath {
+	module_name string
+	path        string
+}
+
+struct V3ExternalNativeRoot {
+	module_name string
+	path        string
+	index       int
 }
 
 fn tcc_atomic_s_arg(prefs &pref.Preferences) string {
@@ -1615,7 +1630,35 @@ fn v3_cgen_cache_input(state &V3ModuleCacheState, user_files []string, user_c_fl
 		mut paths := state.module_external_inputs[module_name].clone()
 		paths.sort()
 		for path in paths {
-			dependencies['external:${module_name}:${path}'] = modulecache.file_signature(path)
+			key := v3_external_input_key(module_name, path)
+			dependencies['external:${module_name}:${path}'] = state.external_input_signatures[key] or {
+				modulecache.file_signature(path)
+			}
+			dependencies['external-meta:${module_name}:${path}'] =
+				modulecache.file_metadata_signature(path)
+		}
+	}
+	if state.external_inputs_ready {
+		dependencies['external-state:manifest'] = 'v3-external-inputs-1'
+		mut root_modules := state.module_native_roots.keys()
+		root_modules.sort()
+		for module_name in root_modules {
+			for index, path in state.module_native_roots[module_name] {
+				dependencies['external-root:${module_name}:${index}'] = '${path}\t${modulecache.file_metadata_signature(path)}'
+			}
+		}
+		mut owner_modules := state.native_source_modules.keys()
+		owner_modules.sort()
+		for module_name in owner_modules {
+			if state.native_source_modules[module_name] {
+				dependencies['external-owner:${module_name}'] = '1'
+			}
+		}
+		for path in state.external_resolution_dirs {
+			dependencies['external-dir:${path}'] = modulecache.file_metadata_signature(path)
+		}
+		for path in state.external_missing_paths {
+			dependencies['external-missing:${path}'] = 'missing'
 		}
 	}
 	mut source_files := source_set.keys()
@@ -1633,13 +1676,161 @@ fn prepare_v3_cache_external_inputs(mut state V3ModuleCacheState, a &flat.FlatAs
 		cache_input_modules[module_name] = true
 	}
 	cache_input_modules['main'] = true
-	external_inputs, native_source_roots, has_untracked_c_include := cgen.cache_external_input_files(a,
+	external_inputs, native_source_roots, resolution_dirs, missing_resolution_paths, has_untracked_c_include := cgen.cache_external_input_files_with_resolved_flags(a,
 		prefs.vroot, cache_input_modules, user_c_flags, prefs.target)
 	state.module_external_inputs = external_inputs.clone()
 	state.module_native_roots = native_source_roots.clone()
+	state.external_input_signatures = map[string]string{}
+	cache_dir := os.abs_path(state.manager.dir)
+	real_cache_dir := os.real_path(state.manager.dir)
+	state.external_resolution_dirs = resolution_dirs.filter(!v3_path_is_within(it, cache_dir)
+		&& !v3_path_is_within(it, real_cache_dir))
+	state.external_missing_paths = missing_resolution_paths.filter(
+		!v3_path_is_within(it, cache_dir) && !v3_path_is_within(it, real_cache_dir))
 	native_source_modules, can_scope_static_inputs := cache_external_input_owner_modules(state)
 	state.native_source_modules = native_source_modules.clone()
+	state.external_inputs_ready = true
 	return !has_untracked_c_include && can_scope_static_inputs
+}
+
+fn v3_path_is_within(path string, dir string) bool {
+	return dir.len > 0 && (path == dir || path.starts_with(dir + os.path_separator))
+}
+
+fn v3_external_input_key(module_name string, path string) string {
+	return '${module_name}\x00${path}'
+}
+
+fn v3_external_cache_path(key string, prefix string) ?V3ExternalCachePath {
+	if !key.starts_with(prefix) {
+		return none
+	}
+	value := key[prefix.len..]
+	colon := value.index_u8(`:`)
+	if colon <= 0 || colon + 1 >= value.len {
+		return none
+	}
+	return V3ExternalCachePath{
+		module_name: value[..colon]
+		path:        value[colon + 1..]
+	}
+}
+
+fn restore_v3_cache_external_inputs(mut state V3ModuleCacheState, user_files []string, user_c_flags []string) bool {
+	base_input := v3_cgen_cache_input(state, user_files, user_c_flags)
+	restored := state.manager.cached_cgen_dependency_inputs(base_input.source_files,
+		base_input.generation_signature, base_input.dependency_inputs, ['external:', 'external-meta:',
+		'external-root:', 'external-owner:', 'external-dir:', 'external-missing:', 'external-state:']) or {
+		return false
+	}
+	if restored['external-state:manifest'] or { '' } != 'v3-external-inputs-1' {
+		return false
+	}
+	mut external_inputs := map[string][]string{}
+	mut external_signatures := map[string]string{}
+	for key, signature in restored {
+		input := v3_external_cache_path(key, 'external:') or { continue }
+		metadata_key := 'external-meta:${input.module_name}:${input.path}'
+		metadata := restored[metadata_key] or { return false }
+		if metadata.len == 0 || modulecache.file_metadata_signature(input.path) != metadata {
+			return false
+		}
+		mut paths := external_inputs[input.module_name]
+		paths << input.path
+		external_inputs[input.module_name] = paths
+		external_signatures[v3_external_input_key(input.module_name, input.path)] = signature
+	}
+	for key, _ in restored {
+		if input := v3_external_cache_path(key, 'external-meta:') {
+			if 'external:${input.module_name}:${input.path}' !in restored {
+				return false
+			}
+		}
+	}
+	mut root_records := []V3ExternalNativeRoot{}
+	for key, value in restored {
+		input := v3_external_cache_path(key, 'external-root:') or { continue }
+		if input.path.len == 0 || input.path.bytes().any(!it.is_digit()) {
+			return false
+		}
+		index := input.path.int()
+		tab := value.last_index_u8(`\t`)
+		if index < 0 || tab <= 0 || tab + 1 >= value.len {
+			return false
+		}
+		path := value[..tab]
+		metadata := value[tab + 1..]
+		if metadata.len == 0 || modulecache.file_metadata_signature(path) != metadata
+			|| path !in external_inputs[input.module_name] {
+			return false
+		}
+		root_records << V3ExternalNativeRoot{
+			module_name: input.module_name
+			path:        path
+			index:       index
+		}
+	}
+	root_records.sort_with_compare(fn (a &V3ExternalNativeRoot, b &V3ExternalNativeRoot) int {
+		if a.module_name != b.module_name {
+			return a.module_name.compare(b.module_name)
+		}
+		return a.index - b.index
+	})
+	mut native_roots := map[string][]string{}
+	for record in root_records {
+		mut roots := native_roots[record.module_name]
+		if record.index != roots.len {
+			return false
+		}
+		roots << record.path
+		native_roots[record.module_name] = roots
+	}
+	mut native_source_modules := map[string]bool{}
+	for key, value in restored {
+		if key.starts_with('external-owner:') {
+			module_name := key['external-owner:'.len..]
+			if module_name.len == 0 || value != '1' {
+				return false
+			}
+			native_source_modules[module_name] = true
+		}
+	}
+	mut resolution_dirs := []string{}
+	for key, metadata in restored {
+		if key.starts_with('external-dir:') {
+			path := key['external-dir:'.len..]
+			if path.len == 0 || metadata.len == 0
+				|| modulecache.file_metadata_signature(path) != metadata {
+				return false
+			}
+			resolution_dirs << path
+		}
+	}
+	mut missing_resolution_paths := []string{}
+	for key, value in restored {
+		if key.starts_with('external-missing:') {
+			path := key['external-missing:'.len..]
+			if path.len == 0 || value != 'missing' || os.exists(path) {
+				return false
+			}
+			missing_resolution_paths << path
+		}
+	}
+	for module_name, paths in external_inputs {
+		mut sorted := paths.clone()
+		sorted.sort()
+		external_inputs[module_name] = sorted
+	}
+	resolution_dirs.sort()
+	missing_resolution_paths.sort()
+	state.module_external_inputs = external_inputs.clone()
+	state.external_input_signatures = external_signatures.clone()
+	state.module_native_roots = native_roots.clone()
+	state.native_source_modules = native_source_modules.clone()
+	state.external_resolution_dirs = resolution_dirs.clone()
+	state.external_missing_paths = missing_resolution_paths.clone()
+	state.external_inputs_ready = true
+	return true
 }
 
 fn encode_v3_cgen_metadata(flags []string, interface_impl_signature string, prefix_source_identity string) string {
@@ -3318,21 +3509,22 @@ fn main() {
 		prefs.target)
 	bundle_sources := builtin_bundle_source_files(prefs, builtin_files)
 	mut cache_state := V3ModuleCacheState{
-		manager:                cache_manager
-		bundle_sources:         bundle_sources
-		bundle_source_paths:    module_cache_source_path_set(bundle_sources)
-		force_source:           force_cache_source
-		module_sources:         map[string][]string{}
-		module_import_paths:    map[string]string{}
-		module_dependencies:    map[string][]string{}
-		module_external_inputs: map[string][]string{}
-		module_native_roots:    map[string][]string{}
-		dependency_metadata:    map[string]string{}
-		parsed_from_source:     map[string]bool{}
-		source_body_modules:    map[string]bool{}
-		native_source_modules:  map[string]bool{}
-		objects:                map[string]string{}
-		headers:                map[string]string{}
+		manager:                   cache_manager
+		bundle_sources:            bundle_sources
+		bundle_source_paths:       module_cache_source_path_set(bundle_sources)
+		force_source:              force_cache_source
+		module_sources:            map[string][]string{}
+		module_import_paths:       map[string]string{}
+		module_dependencies:       map[string][]string{}
+		module_external_inputs:    map[string][]string{}
+		module_native_roots:       map[string][]string{}
+		external_input_signatures: map[string]string{}
+		dependency_metadata:       map[string]string{}
+		parsed_from_source:        map[string]bool{}
+		source_body_modules:       map[string]bool{}
+		native_source_modules:     map[string]bool{}
+		objects:                   map[string]string{}
+		headers:                   map[string]string{}
 	}
 	cache_state.module_sources['builtin'] = builtin_files
 	mut files := []string{}
@@ -3513,7 +3705,8 @@ fn main() {
 	mut incremental_tcc_declarations_path := ''
 	if backend == 'c' && cache_state.manager.enabled && !cache_state.force_source
 		&& cache_state.parsed_from_source.len == 0 {
-		if !prepare_v3_cache_external_inputs(mut cache_state, a, prefs, cache_c_flags) {
+		if !restore_v3_cache_external_inputs(mut cache_state, user_files, cache_c_flags)
+			&& !prepare_v3_cache_external_inputs(mut cache_state, a, prefs, cache_c_flags) {
 			restart_v3_without_cache()
 		}
 		input := v3_cgen_cache_input(cache_state, user_files, cache_c_flags)

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -2257,6 +2257,7 @@ fn incremental_changed_functions_require_reachability_rebuild(a &flat.FlatAst, t
 	}
 	mut program_aliases := map[string][]string{}
 	mut changed_roots := []flat.NodeId{}
+	mut changed_root_modules := map[int]string{}
 	mut cur_module := ''
 	for node_idx in tc.top_level_idx {
 		node := a.nodes[node_idx]
@@ -2271,6 +2272,7 @@ fn incremental_changed_functions_require_reachability_rebuild(a &flat.FlatAst, t
 				name := incremental_qualified_fn_name(cur_module, node.value)
 				if changed_names[name] {
 					changed_roots << flat.NodeId(node_idx)
+					changed_root_modules[node_idx] = cur_module
 				}
 				if cur_module !in ['', 'main'] {
 					continue
@@ -2286,6 +2288,7 @@ fn incremental_changed_functions_require_reachability_rebuild(a &flat.FlatAst, t
 	}
 	mut stack := []flat.NodeId{cap: 256}
 	for root in changed_roots {
+		root_module := changed_root_modules[int(root)] or { '' }
 		stack.clear()
 		stack << root
 		for stack.len > 0 {
@@ -2302,6 +2305,19 @@ fn incremental_changed_functions_require_reachability_rebuild(a &flat.FlatAst, t
 				referenced_name = tc.resolved_fn_value_names[idx]
 			}
 			if referenced_name.len > 0 {
+				for aliases in markused.interface_dispatch_implementer_aliases(referenced_name,
+					root_module, tc) {
+					mut was_cached := false
+					for alias in aliases {
+						if cached[alias] {
+							was_cached = true
+							break
+						}
+					}
+					if !was_cached {
+						return true
+					}
+				}
 				if aliases := program_aliases[referenced_name] {
 					mut was_cached := false
 					for alias in aliases {

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -2251,86 +2251,44 @@ fn incremental_changed_functions(snapshot V3IncrementalSnapshot, old map[string]
 	return keys, names
 }
 
-fn incremental_changed_functions_require_reachability_rebuild(a &flat.FlatAst, tc &types.TypeChecker, changed_names map[string]bool, cached map[string]bool) bool {
+fn incremental_changed_functions_require_reachability_rebuild(a &flat.FlatAst, tc &types.TypeChecker, changed_names map[string]bool, cached map[string]bool, user_files []string) bool {
 	if changed_names.len == 0 {
 		return false
 	}
-	mut program_aliases := map[string][]string{}
-	mut changed_roots := []flat.NodeId{}
-	mut changed_root_modules := map[int]string{}
+	current, _ := markused.mark_used_with_generic_usage(a, tc)
+	mut program_files := map[string]bool{}
+	for file in user_files {
+		program_files[file] = true
+		program_files[os.real_path(file)] = true
+	}
 	mut cur_module := ''
+	mut is_program_file := false
 	for node_idx in tc.top_level_idx {
 		node := a.nodes[node_idx]
 		match node.kind {
 			.file {
 				cur_module = ''
+				is_program_file = program_files[node.value]
+					|| program_files[os.real_path(node.value)]
 			}
 			.module_decl {
 				cur_module = node.value
 			}
 			.fn_decl {
-				name := incremental_qualified_fn_name(cur_module, node.value)
-				if changed_names[name] {
-					changed_roots << flat.NodeId(node_idx)
-					changed_root_modules[node_idx] = cur_module
+				if !is_program_file {
+					continue
 				}
+				name := incremental_qualified_fn_name(cur_module, node.value)
 				aliases := [node.value, name, restored_fn_c_name(node.value),
 					restored_fn_c_name(name)]
-				for alias in aliases {
-					program_aliases[alias] = aliases
+				if !aliases.any(current[it]) {
+					continue
+				}
+				if !aliases.any(cached[it]) {
+					return true
 				}
 			}
 			else {}
-		}
-	}
-	mut stack := []flat.NodeId{cap: 256}
-	for root in changed_roots {
-		root_module := changed_root_modules[int(root)] or { '' }
-		stack.clear()
-		stack << root
-		for stack.len > 0 {
-			id := stack.pop()
-			idx := int(id)
-			if idx < 0 || idx >= a.nodes.len {
-				continue
-			}
-			node := a.nodes[idx]
-			mut referenced_name := ''
-			if node.kind == .call {
-				referenced_name = tc.resolved_call_name(id) or { '' }
-			} else if idx < tc.resolved_fn_value_set.len && tc.resolved_fn_value_set[idx] {
-				referenced_name = tc.resolved_fn_value_names[idx]
-			}
-			if referenced_name.len > 0 {
-				for aliases in markused.interface_dispatch_implementer_aliases(referenced_name,
-					root_module, tc) {
-					mut was_cached := false
-					for alias in aliases {
-						if cached[alias] {
-							was_cached = true
-							break
-						}
-					}
-					if !was_cached {
-						return true
-					}
-				}
-				if aliases := program_aliases[referenced_name] {
-					mut was_cached := false
-					for alias in aliases {
-						if cached[alias] {
-							was_cached = true
-							break
-						}
-					}
-					if !was_cached {
-						return true
-					}
-				}
-			}
-			for child_idx in 0 .. node.children_count {
-				stack << a.child(&node, child_idx)
-			}
 		}
 	}
 	return false
@@ -4071,7 +4029,7 @@ fn main() {
 			used_fns = clone_string_bool_map(cached_program_used_fns)
 			uses_generics = true
 			if incremental_cache_hit
-				&& incremental_changed_functions_require_reachability_rebuild(a, markused_tc, incremental_changed_names, cached_program_used_fns) {
+				&& incremental_changed_functions_require_reachability_rebuild(a, markused_tc, incremental_changed_names, cached_program_used_fns, user_files) {
 				os.setenv('V3_CACHE_DISABLE_INCREMENTAL', '1', true)
 				restart_v3_after_cache_invalidation()
 			}

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -5713,19 +5713,12 @@ fn cache_external_input_owner_modules(state &V3ModuleCacheState, unscoped_inputs
 	}
 	for raw_module_name, paths in state.module_external_inputs {
 		roots := state.module_native_roots[raw_module_name] or { []string{} }
-		mut root_paths := map[string]bool{}
-		for root in roots {
-			root_paths[os.real_path(root)] = true
-		}
 		mut has_static_storage := false
 		for path in paths {
 			source := os.read_file(path) or { continue }
 			if modulecache.c_source_has_static_storage(source) {
-				// Only root native source includes are removed from the program unit.
-				// Static storage in any other input would be emitted in both units.
-				if !root_paths[os.real_path(path)] {
-					return modules, false
-				}
+				// Direct non-source include trees were rejected through unscoped_inputs
+				// above. Remaining dependencies are removed with their native root.
 				has_static_storage = true
 			}
 		}

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -6572,7 +6572,11 @@ fn source_file_line_count(paths []string) int {
 }
 
 fn import_module_identity_cached(prefs &pref.Preferences, import_path string, importing_file string, project_root string, import_dir string, mut path_cache map[string]string, mut identity_cache map[string]string) string {
-	key := '${importing_file}\n${import_path}\n${import_dir}'
+	// Module lookup depends on the importer's directory, not its filename. A
+	// program commonly has many files in one directory importing the same module;
+	// using the full filename here defeated almost every cache lookup.
+	importing_dir := if importing_file.len > 0 { os.dir(importing_file) } else { '' }
+	key := '${importing_dir}\n${import_path}\n${import_dir}'
 	if identity := identity_cache[key] {
 		return identity
 	}
@@ -6645,16 +6649,22 @@ fn module_root_for_import_dir(import_path string, import_dir string) string {
 }
 
 fn resolve_project_or_pref_module_path_cached(prefs &pref.Preferences, mod_name string, importing_file string, project_root string, mut cache map[string]string) string {
-	key := '${importing_file}\n${mod_name}'
+	// Every resolution input derived from `importing_file` is directory scoped.
+	// Share the result between sibling source files instead of walking all module
+	// search roots once per file.
+	importing_dir := if importing_file.len > 0 { os.dir(importing_file) } else { '' }
+	key := '${importing_dir}\n${mod_name}'
 	if path := cache[key] {
 		return path
 	}
-	path := resolve_project_or_pref_module_path(prefs, mod_name, importing_file, project_root)
+	path := resolve_project_or_pref_module_path(prefs, mod_name, importing_file, project_root, mut
+		cache)
 	cache[key] = path
 	return path
 }
 
-fn resolve_project_or_pref_module_path(prefs &pref.Preferences, mod_name string, importing_file string, project_root string) string {
+fn resolve_project_or_pref_module_path(prefs &pref.Preferences, mod_name string, importing_file string, project_root string, mut cache map[string]string) string {
+	mod_path := mod_name.replace('.', os.path_separator)
 	if importing_file.len > 0 {
 		importer_dir := os.dir(importing_file)
 		if alias_path := pref.resolve_module_alias_path(importer_dir, mod_name) {
@@ -6664,8 +6674,7 @@ fn resolve_project_or_pref_module_path(prefs &pref.Preferences, mod_name string,
 		if alias_path := pref.resolve_module_alias_path(local_modules_root, mod_name) {
 			return alias_path
 		}
-		local_modules_path := os.join_path_single(local_modules_root, mod_name.replace('.',
-			os.path_separator))
+		local_modules_path := os.join_path_single(local_modules_root, mod_path)
 		if os.is_dir(local_modules_path) {
 			return local_modules_path
 		}
@@ -6674,10 +6683,64 @@ fn resolve_project_or_pref_module_path(prefs &pref.Preferences, mod_name string,
 		if alias_path := pref.resolve_module_alias_path(project_root, mod_name) {
 			return alias_path
 		}
-		project_path := os.join_path_single(project_root, mod_name.replace('.', os.path_separator))
+		project_path := os.join_path_single(project_root, mod_path)
 		if os.is_dir(project_path) {
 			return project_path
 		}
 	}
+	// Preserve the existing resolver priority: explicit local `modules/` and
+	// project-root modules precede a module beside the importing file.
+	if importing_file.len > 0 {
+		relative_path := os.join_path_single(os.dir(importing_file), mod_path)
+		if module_path_has_v_sources(relative_path) {
+			return relative_path
+		}
+	}
+	// vlib and the global module directory do not depend on the importing file.
+	// Resolve them once per import name instead of repeating the same alias probes
+	// and directory scans for every module that imports them.
+	global_key := '@global\n${mod_name}'
+	if global_key in cache {
+		global_path := cache[global_key]
+		if global_path.len > 0 {
+			return global_path
+		}
+	} else {
+		global_path := resolve_global_module_path(prefs, mod_name, mod_path)
+		cache[global_key] = global_path
+		if global_path.len > 0 {
+			return global_path
+		}
+	}
 	return prefs.get_module_path(mod_name, importing_file)
+}
+
+fn resolve_global_module_path(prefs &pref.Preferences, mod_name string, mod_path string) string {
+	vlib_root := os.join_path_single(prefs.vroot, 'vlib')
+	if alias_path := pref.resolve_module_alias_path(vlib_root, mod_name) {
+		return alias_path
+	}
+	vlib_path := os.join_path_single(vlib_root, mod_path)
+	if module_path_has_v_sources(vlib_path) {
+		return vlib_path
+	}
+	vmodules_root := os.getenv_opt('VMODULES') or {
+		os.join_path_single(os.home_dir(), '.vmodules')
+	}
+	if alias_path := pref.resolve_module_alias_path(vmodules_root, mod_name) {
+		return alias_path
+	}
+	vmodules_path := os.join_path_single(vmodules_root, mod_path)
+	if module_path_has_v_sources(vmodules_path) {
+		return vmodules_path
+	}
+	return ''
+}
+
+fn module_path_has_v_sources(path string) bool {
+	if path.len == 0 || !os.is_dir(path) {
+		return false
+	}
+	entries := os.ls(path) or { return false }
+	return entries.any(it.ends_with('.v'))
 }

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -2597,7 +2597,8 @@ fn v3_cache_compiler_signature(vroot string) string {
 		files << file
 	}
 	files << os.walk_ext(dir, '.h')
-	return modulecache.source_signature(files)
+	cache_dir := os.join_path(os.vtmp_dir(), 'v3_source_signatures')
+	return modulecache.cached_source_signature(cache_dir, os.real_path(vroot), files)
 }
 
 fn restored_fn_c_name(name string) string {

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -1985,11 +1985,14 @@ struct V3IncrementalFn {
 	key       string
 	name      string
 	signature string
+mut:
+	generic_signature string
 }
 
 struct V3IncrementalSnapshot {
 	declaration_signature string
-	functions             []V3IncrementalFn
+mut:
+	functions []V3IncrementalFn
 }
 
 fn incremental_cache_fn_key(file string, module_name string, name string) string {
@@ -2205,27 +2208,32 @@ fn incremental_program_snapshot(a &flat.FlatAst) V3IncrementalSnapshot {
 
 fn encode_incremental_manifest(snapshot V3IncrementalSnapshot) string {
 	mut lines := []string{cap: snapshot.functions.len + 1}
-	lines << 'v3-incremental-functions-v1'
+	lines << 'v3-incremental-functions-v2'
 	for function in snapshot.functions {
-		lines << '${function.key}\t${function.signature}\t${function.name}'
+		lines << '${function.key}\t${function.signature}\t${function.generic_signature}\t${function.name}'
 	}
 	return lines.join('\n')
 }
 
-fn decode_incremental_manifest(encoded string) ?map[string]string {
+fn decode_incremental_manifest(encoded string) ?map[string]V3IncrementalFn {
 	lines := encoded.split_into_lines()
-	if lines.len == 0 || lines[0] != 'v3-incremental-functions-v1' {
+	if lines.len == 0 || lines[0] != 'v3-incremental-functions-v2' {
 		return none
 	}
-	mut signatures := map[string]string{}
+	mut functions := map[string]V3IncrementalFn{}
 	for line in lines[1..] {
 		parts := line.split('\t')
-		if parts.len != 3 || parts[0].len == 0 || parts[1].len == 0 {
+		if parts.len != 4 || parts[0].len == 0 || parts[1].len == 0 || parts[2].len == 0 {
 			return none
 		}
-		signatures[parts[0]] = parts[1]
+		functions[parts[0]] = V3IncrementalFn{
+			key:               parts[0]
+			signature:         parts[1]
+			generic_signature: parts[2]
+			name:              parts[3]
+		}
 	}
-	return signatures
+	return functions
 }
 
 struct V3IncrementalCFunctionSections {
@@ -2233,20 +2241,167 @@ struct V3IncrementalCFunctionSections {
 	keys     []string
 }
 
-fn incremental_changed_functions(snapshot V3IncrementalSnapshot, old map[string]string) ?([]string, map[string]bool) {
+fn incremental_changed_functions(snapshot V3IncrementalSnapshot, old map[string]V3IncrementalFn) ?([]string, map[string]bool) {
 	if snapshot.functions.len != old.len {
 		return none
 	}
 	mut keys := []string{}
 	mut names := map[string]bool{}
 	for function in snapshot.functions {
-		old_signature := old[function.key] or { return none }
-		if old_signature != function.signature {
+		old_function := old[function.key] or { return none }
+		if old_function.signature != function.signature {
 			keys << function.key
 			names[function.name] = true
 		}
 	}
 	return keys, names
+}
+
+fn incremental_generic_call_signature(a &flat.FlatAst, tc &types.TypeChecker, root flat.NodeId) string {
+	mut hash := u64(1469598103934665603)
+	mut stack := [root]
+	mut count := 0
+	for stack.len > 0 {
+		id := stack.pop()
+		idx := int(id)
+		if idx < 0 || idx >= a.nodes.len {
+			continue
+		}
+		node := a.nodes[idx]
+		if node.kind == .call {
+			if name := tc.resolved_call_name(id) {
+				if name in tc.fn_generic_params || name.contains('[') {
+					count++
+					hash = c_hash_bytes(hash, name.bytes())
+					hash = c_hash_bytes(hash, [u8(0xff)])
+					if node.children_count > 0 {
+						callee_signature := incremental_node_tree_signature(a, a.child(&node, 0))
+						hash = c_hash_bytes(hash, callee_signature.bytes())
+						hash = c_hash_bytes(hash, [u8(0xfc)])
+					}
+					for param in node.generic_params() {
+						hash = c_hash_bytes(hash, param.bytes())
+						hash = c_hash_bytes(hash, [u8(0xfe)])
+					}
+					for child_idx in 1 .. node.children_count {
+						child_id := a.child(&node, child_idx)
+						if typ := tc.expr_type(child_id) {
+							hash = c_hash_bytes(hash, tc.type_name(typ).bytes())
+						}
+						hash = c_hash_bytes(hash, [u8(0xfd)])
+					}
+				}
+			}
+		}
+		for child_idx := node.children_count - 1; child_idx >= 0; child_idx-- {
+			stack << a.child(&node, child_idx)
+		}
+	}
+	return '${count}:${hash.hex()}'
+}
+
+fn populate_incremental_generic_signatures(mut snapshot V3IncrementalSnapshot, a &flat.FlatAst, tc &types.TypeChecker) {
+	mut function_idx := 0
+	for idx, node in a.nodes {
+		if node.kind != .fn_decl {
+			continue
+		}
+		if function_idx >= snapshot.functions.len {
+			return
+		}
+		snapshot.functions[function_idx].generic_signature = incremental_generic_call_signature(a,
+			tc, flat.NodeId(idx))
+		function_idx++
+	}
+}
+
+fn incremental_generic_calls_changed(snapshot V3IncrementalSnapshot, old map[string]V3IncrementalFn, changed_keys []string) bool {
+	mut changed := map[string]bool{}
+	for key in changed_keys {
+		changed[key] = true
+	}
+	for function in snapshot.functions {
+		if !changed[function.key] {
+			continue
+		}
+		old_function := old[function.key] or { return true }
+		if function.generic_signature != old_function.generic_signature {
+			return true
+		}
+	}
+	return false
+}
+
+fn incremental_changed_functions_require_reachability_rebuild(a &flat.FlatAst, tc &types.TypeChecker, changed_names map[string]bool, cached map[string]bool) bool {
+	if changed_names.len == 0 {
+		return false
+	}
+	mut program_aliases := map[string][]string{}
+	mut changed_roots := []flat.NodeId{}
+	mut cur_module := ''
+	for node_idx in tc.top_level_idx {
+		node := a.nodes[node_idx]
+		match node.kind {
+			.file {
+				cur_module = ''
+			}
+			.module_decl {
+				cur_module = node.value
+			}
+			.fn_decl {
+				name := incremental_qualified_fn_name(cur_module, node.value)
+				if changed_names[name] {
+					changed_roots << flat.NodeId(node_idx)
+				}
+				if cur_module !in ['', 'main'] {
+					continue
+				}
+				aliases := [node.value, name, restored_fn_c_name(node.value),
+					restored_fn_c_name(name)]
+				for alias in aliases {
+					program_aliases[alias] = aliases
+				}
+			}
+			else {}
+		}
+	}
+	mut stack := []flat.NodeId{cap: 256}
+	for root in changed_roots {
+		stack.clear()
+		stack << root
+		for stack.len > 0 {
+			id := stack.pop()
+			idx := int(id)
+			if idx < 0 || idx >= a.nodes.len {
+				continue
+			}
+			node := a.nodes[idx]
+			mut referenced_name := ''
+			if node.kind == .call {
+				referenced_name = tc.resolved_call_name(id) or { '' }
+			} else if idx < tc.resolved_fn_value_set.len && tc.resolved_fn_value_set[idx] {
+				referenced_name = tc.resolved_fn_value_names[idx]
+			}
+			if referenced_name.len > 0 {
+				if aliases := program_aliases[referenced_name] {
+					mut was_cached := false
+					for alias in aliases {
+						if cached[alias] {
+							was_cached = true
+							break
+						}
+					}
+					if !was_cached {
+						return true
+					}
+				}
+			}
+			for child_idx in 0 .. node.children_count {
+				stack << a.child(&node, child_idx)
+			}
+		}
+	}
+	return false
 }
 
 fn incremental_c_function_sections(source string) ?V3IncrementalCFunctionSections {
@@ -2462,6 +2617,25 @@ fn decode_monomorph_cache_specs(encoded string) []transform.MonomorphCacheSpec {
 		}
 	}
 	return specs
+}
+
+fn monomorph_cache_spec_identity(spec transform.MonomorphCacheSpec) string {
+	return '${spec.decl_key}\t${spec.module}\t${spec.args.join('\x1f')}'
+}
+
+fn incremental_monomorph_has_new_specs(generated []transform.MonomorphCacheSpec, cached []transform.MonomorphCacheSpec) bool {
+	mut cached_identities := map[string]bool{}
+	for spec in cached {
+		cached_identities[monomorph_cache_spec_identity(spec)] = true
+	}
+	for spec in generated {
+		// Main-module specializations live in the replaceable program body and are
+		// deliberately absent from the dependency specialization manifest.
+		if spec.module in ['', 'main'] || !cached_identities[monomorph_cache_spec_identity(spec)] {
+			return true
+		}
+	}
+	return false
 }
 
 fn encode_cached_used_fns(used map[string]bool) string {
@@ -3699,8 +3873,11 @@ fn main() {
 	mut incremental_snapshot := V3IncrementalSnapshot{}
 	mut incremental_snapshot_ready := false
 	mut incremental_cache_hit := false
+	mut incremental_cached_functions := map[string]V3IncrementalFn{}
 	mut incremental_changed_keys := []string{}
 	mut incremental_changed_names := map[string]bool{}
+	mut incremental_calls_generics := false
+	mut incremental_generic_specs_changed := false
 	mut incremental_cached_body := ''
 	mut incremental_tcc_declarations_path := ''
 	if backend == 'c' && cache_state.manager.enabled && !cache_state.force_source
@@ -3781,6 +3958,7 @@ fn main() {
 						decoded_used := decode_cached_used_fns(used_text)
 						if decoded_metadata := decode_v3_cgen_metadata(metadata) {
 							if decoded_used.len > 0 && body_text.len > 0 {
+								incremental_cached_functions = old_manifest.clone()
 								incremental_cache_hit = changed_keys.len > 0
 								incremental_changed_keys = changed_keys.clone()
 								incremental_changed_names = changed_names.clone()
@@ -3854,6 +4032,8 @@ fn main() {
 		set_unsupported_generic_files(mut pre_tc, a, is_selfhost, diagnostic_root)
 		if !incremental_cache_hit {
 			pre_tc.prepare_interface_query_indexes()
+		} else {
+			pre_tc.prepare_interface_requirement_indexes()
 		}
 		mut check_was_parallel := false
 		if incremental_cache_hit {
@@ -3865,11 +4045,13 @@ fn main() {
 			print_type_errors(pre_tc.errors)
 			exit(1)
 		}
-		if incremental_cache_hit
-			&& incremental_changed_functions_call_generics(a, pre_tc, incremental_changed_names) {
-			os.setenv('V3_CACHE_DISABLE_INCREMENTAL', '1', true)
-			restart_v3_after_cache_invalidation()
+		if incremental_snapshot.declaration_signature.len > 0 {
+			populate_incremental_generic_signatures(mut incremental_snapshot, a, pre_tc)
 		}
+		incremental_calls_generics = incremental_cache_hit
+			&& incremental_changed_functions_call_generics(a, pre_tc, incremental_changed_names)
+		incremental_generic_specs_changed = incremental_calls_generics
+			&& incremental_generic_calls_changed(incremental_snapshot, incremental_cached_functions, incremental_changed_keys)
 		pre_tc.prune_inactive_top_level_comptime(mut a)
 		test_harness_errors := validate_test_file_harness_inputs(a, pre_tc, test_files)
 		if test_harness_errors.len > 0 {
@@ -3937,21 +4119,10 @@ fn main() {
 		if generic_cache_hit && test_files.len == 0 {
 			used_fns = clone_string_bool_map(cached_program_used_fns)
 			uses_generics = true
-			if incremental_cache_hit {
-				current_used_fns, current_uses_generics := markused.mark_used_with_generic_usage(a,
-					markused_tc)
-				uses_generics = uses_generics || current_uses_generics
-				mut gained_reachability := false
-				for name, is_used in current_used_fns {
-					if is_used && !cached_program_used_fns[name] {
-						gained_reachability = true
-						break
-					}
-				}
-				if gained_reachability {
-					os.setenv('V3_CACHE_DISABLE_INCREMENTAL', '1', true)
-					restart_v3_after_cache_invalidation()
-				}
+			if incremental_cache_hit
+				&& incremental_changed_functions_require_reachability_rebuild(a, markused_tc, incremental_changed_names, cached_program_used_fns) {
+				os.setenv('V3_CACHE_DISABLE_INCREMENTAL', '1', true)
+				restart_v3_after_cache_invalidation()
 			}
 		} else if test_files.len > 0 {
 			used_fns, uses_generics = markused.mark_used_for_tests_with_generic_usage(a,
@@ -4146,8 +4317,8 @@ fn main() {
 		pre_tc.reject_unlowered_map_mutation = true
 		set_diagnostic_files(mut pre_tc, user_files)
 		set_unsupported_generic_files(mut pre_tc, a, is_selfhost, diagnostic_root)
-		incremental_needs_monomorphize := incremental_cache_hit
-			&& transformed_used_fns_need_monomorphize(incremental_stage_used_fns)
+		incremental_needs_monomorphize := incremental_cache_hit && (incremental_calls_generics
+			|| transformed_used_fns_need_monomorphize(incremental_stage_used_fns))
 		if !building_v && !cmd_v_build {
 			if uses_generics && (!incremental_cache_hit || incremental_needs_monomorphize) {
 				if scope_prealloc_stages {
@@ -4220,7 +4391,7 @@ fn main() {
 		// AST and checker state on this path.
 	} else if building_v {
 		used_fns = transform.erase_generic_templates(mut a, &pre_tc, used_fns)
-	} else if uses_generics && (!incremental_cache_hit
+	} else if uses_generics && (!incremental_cache_hit || incremental_calls_generics
 		|| transformed_used_fns_need_monomorphize(incremental_stage_used_fns)) {
 		mut monomorph_used_fns := map[string]bool{}
 		mut monomorph_errors := []string{}
@@ -4289,6 +4460,11 @@ fn main() {
 		}
 		if incremental_cache_hit {
 			incremental_stage_used_fns = monomorph_used_fns.move()
+			if incremental_generic_specs_changed
+				&& incremental_monomorph_has_new_specs(generated_monomorph_specs, cached_monomorph_specs) {
+				os.setenv('V3_CACHE_DISABLE_INCREMENTAL', '1', true)
+				restart_v3_after_cache_invalidation()
+			}
 		} else {
 			used_fns = monomorph_used_fns.move()
 		}

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -3499,12 +3499,13 @@ fn main() {
 	if backend == 'c' && cache_state.manager.enabled {
 		cache_c_flags << cgen.cache_directive_flags(a, prefs.vroot, prefs.target)
 	}
-	if backend == 'c' && cache_state.manager.enabled && !is_prod && !is_shared && !is_selfhost
-		&& prefs.normalized_target_os() == 'macos' {
-		generic_cache_signature = monomorph_cache_semantic_signature(a, user_files)
-		generic_cache_runtime_strings = monomorph_cache_runtime_strings(a)
-	}
-	incremental_snapshot := incremental_program_snapshot(a)
+	use_macos_dev_program_cache := backend == 'c' && cache_state.manager.enabled && !is_prod
+		&& !is_shared && !is_selfhost && prefs.normalized_target_os() == 'macos'
+	incremental_cache_enabled := use_macos_dev_program_cache
+		&& os.getenv('V3_CACHE_DISABLE_INCREMENTAL') != '1'
+	mut generic_cache_inputs_ready := false
+	mut incremental_snapshot := V3IncrementalSnapshot{}
+	mut incremental_snapshot_ready := false
 	mut incremental_cache_hit := false
 	mut incremental_changed_keys := []string{}
 	mut incremental_changed_names := map[string]bool{}
@@ -3530,8 +3531,10 @@ fn main() {
 				}
 			}
 		}
-		if !cgen_cache_hit && !is_prod && !is_shared && !is_selfhost
-			&& prefs.normalized_target_os() == 'macos' {
+		if !cgen_cache_hit && use_macos_dev_program_cache {
+			generic_cache_signature = monomorph_cache_semantic_signature(a, user_files)
+			generic_cache_runtime_strings = monomorph_cache_runtime_strings(a)
+			generic_cache_inputs_ready = true
 			if entry := cache_state.manager.valid_generic_program(input.source_files,
 				generic_cache_signature, input.generation_signature, input.dependency_inputs)
 			{
@@ -3565,8 +3568,9 @@ fn main() {
 				}
 			}
 		}
-		if !cgen_cache_hit && os.getenv('V3_CACHE_DISABLE_INCREMENTAL') != '1' && !is_prod
-			&& !is_shared && !is_selfhost && prefs.normalized_target_os() == 'macos' {
+		if !cgen_cache_hit && incremental_cache_enabled {
+			incremental_snapshot = incremental_program_snapshot(a)
+			incremental_snapshot_ready = true
 			if entry := cache_state.manager.valid_incremental_program(input.source_files,
 				incremental_snapshot.declaration_signature, input.generation_signature,
 				input.dependency_inputs)
@@ -3618,6 +3622,21 @@ fn main() {
 				}
 			}
 		}
+	}
+	// Exact whole-program cache hits do not consume the generic or incremental
+	// snapshots. Build those AST-wide signatures only on a miss, while retaining
+	// them for publishing a fresh development cache after a cold build.
+	if !cgen_cache_hit && use_macos_dev_program_cache {
+		if !generic_cache_inputs_ready {
+			generic_cache_signature = monomorph_cache_semantic_signature(a, user_files)
+			generic_cache_runtime_strings = monomorph_cache_runtime_strings(a)
+		}
+		if incremental_cache_enabled && !incremental_snapshot_ready {
+			incremental_snapshot = incremental_program_snapshot(a)
+		}
+	}
+	if backend == 'c' && cache_state.manager.enabled {
+		b.step('cache lookup')
 	}
 
 	// Type-collect + check BEFORE transform, so the transformer is type-aware

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -5639,9 +5639,9 @@ fn restart_v3_with_args(extra_args []string) {
 
 fn cache_external_input_owner_modules(state &V3ModuleCacheState) (map[string]bool, bool) {
 	mut modules := map[string]bool{}
-	for raw_module_name, roots in state.module_native_roots {
+	for raw_module_name, paths in state.module_external_inputs {
 		mut has_static_storage := false
-		for path in state.module_external_inputs[raw_module_name] {
+		for path in paths {
 			source := os.read_file(path) or { continue }
 			if modulecache.c_source_has_static_storage(source) {
 				has_static_storage = true
@@ -5650,6 +5650,10 @@ fn cache_external_input_owner_modules(state &V3ModuleCacheState) (map[string]boo
 		}
 		if !has_static_storage {
 			continue
+		}
+		roots := state.module_native_roots[raw_module_name] or { return modules, false }
+		if roots.len == 0 {
+			return modules, false
 		}
 		for root in roots {
 			if !c_flag_is_c_source_file(root) {

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -3420,11 +3420,19 @@ fn main() {
 	}
 
 	parse_total_us := b.current_step_time_us()
-	header_parse_us := if parse_timing.header_us < parse_total_us {
-		parse_timing.header_us
+	profiled_parse_us := parse_timing.header_us + parse_timing.source_us
+	parse_coordination_us := if profiled_parse_us < parse_total_us {
+		parse_total_us - profiled_parse_us
+	} else {
+		i64(0)
+	}
+	parse_scale_denominator := if profiled_parse_us > parse_total_us {
+		profiled_parse_us
 	} else {
 		parse_total_us
 	}
+	header_parse_us := parse_timing.header_us * parse_total_us / parse_scale_denominator
+	source_parse_us := parse_timing.source_us * parse_total_us / parse_scale_denominator
 	b.step_parts([
 		bench.StepPart{
 			name:     'parse .vh'
@@ -3433,8 +3441,12 @@ fn main() {
 		},
 		bench.StepPart{
 			name:     'parse .v'
-			time_us:  parse_total_us - header_parse_us
+			time_us:  source_parse_us
 			parallel: parse_timing.source_parallel
+		},
+		bench.StepPart{
+			name:    'parse setup/imports'
+			time_us: parse_coordination_us
 		},
 	])
 	b.metric_items('parsed .vh files', p.parsed_v_header_files, 'files', '.vh files',


### PR DESCRIPTION
## Summary

- restore reliable Volt module-cache reuse after the initial v3 caching merge
- validate cached source, headers, native inputs, ABI-sensitive runtime data, and exact cache dependencies without repeating expensive filesystem work
- report cached-header parsing separately and speed cached parse setup/import resolution
- keep ordinary main-function body edits on the incremental path while falling back safely for new reachability
- materialize new function-only generic specializations incrementally, including nested generic calls
- rebuild the cached prefix when a generic edit introduces a new concrete named-type layout
- keep production monomorphization unchanged
- precompute interface requirement indexes so incremental C generation does not repeatedly rescan interface metadata

## Why

This is the follow-up to #27883. Cached Volt builds had regressed to full compilation, and after restoring cache reuse, small body edits still restarted the full checker/transform/monomorph/cgen pipeline.

The incremental path now reuses cached generic specializations and can append newly required function specializations to the replaceable program body. New generic structs, aliases, sum types, or interfaces still trigger a full rebuild because their C layout declarations belong in the cached prefix. This avoids introducing a second runtime-generics ABI while preserving the existing production monomorphizer.

An isolated warm Volt build using this branch completed in 608 ms. The resulting binary launched successfully and continued through normal initialization.

## Validation

- `../../v -gc none -prealloc -prod -o v3 v3.v`
- focused incremental module-cache tests covering new and nested generic function specializations
- fallback coverage for new generic named-type layouts
- incremental tests covering real main logic, newly reachable functions, C support typedefs, sum equality helpers, compile-signature artifacts, and interface type IDs
- `./vnew vlib/v3/types/interface_impl_test.v`
- `./vnew vlib/v3/gen/c/target_test.v`
- clean-cache and warm-cache builds of `~/code/volt`
- launched the warm-built Volt binary and verified normal startup
