### PR TITLE
v3: fix generic-method decl type and void-optional or-expr so v3 can compile v1

### DIFF
--- a/vlib/v3/gen/c/stmt.v
+++ b/vlib/v3/gen/c/stmt.v
@@ -4363,7 +4363,12 @@ fn (mut g FlatGen) gen_decl_assign(node flat.Node) {
 					g.usable_expr_type(rhs_id)
 				} else if sum_field_type := g.selector_sum_shared_field_type(rhs_id) {
 					sum_field_type
-				} else if decl_annotation_is_unusable(decl_type, node.typ) {
+				} else if decl_type is types.Unknown
+					|| decl_annotation_is_unusable(decl_type, node.typ) {
+					// An unresolvable annotation (e.g. a leftover generic type parameter such
+					// as `T` inlined verbatim from a generic function body) parses to Unknown,
+					// whose C type would degrade to `int`. Recover the concrete type from the
+					// RHS expression, which still carries the specialized type.
 					rhs_type := g.decl_rhs_fallback_type(rhs_id, rhs)
 					if rhs_type is types.Unknown {
 						types.Type(decl_type)

--- a/vlib/v3/transform/or.v
+++ b/vlib/v3/transform/or.v
@@ -1083,6 +1083,12 @@ fn (mut t Transformer) thread_wait_or_expr_type(call flat.Node) ?string {
 }
 
 fn (t &Transformer) canonical_or_expr_types(expr_type string) (string, string) {
+	// A bare `!` or `?` (a result/option of `void`, e.g. `fn f() !`) carries no payload.
+	// Falling through would run `optional_base_type('!')` -> `'!'`, then resolve `'!'` as
+	// the `Optional` wrapper struct and double-wrap the temporary as `Optional_Optional`.
+	if expr_type == '!' || expr_type == '?' {
+		return '${expr_type}void', 'void'
+	}
 	mut clean_expr_type := expr_type
 	if !t.is_optional_type_name(clean_expr_type) {
 		normalized := t.normalize_type_alias(clean_expr_type)


### PR DESCRIPTION
## Summary

Building v1 (`v3 cmd/v`) failed at the C-compilation stage with **6 errors in two categories**, both bugs in v3's C backend. Fixed entirely within `vlib/v3/` — **no changes to v1** (`cmd/v` / `vlib/`).

### Bug 1 — inlined generic-method declaration degraded to `int`
`cmd := p.get_item[string](idx)` (and `p.get_item[&ast.File]`) generated:
```c
int cmd = *(string*)((*(void**)array_get(p->items, idx)));
```
The RHS cast is substituted correctly, but the decl kept the raw generic parameter `T` as its type annotation, which parses to `types.Unknown` and lowers to `int`.

**Fix** (`gen/c/stmt.v`, `gen_decl_assign`): treat an `Unknown`-parsed decl annotation as unusable and recover the concrete type from the RHS via the existing `decl_rhs_fallback_type` path.

### Bug 2 — `!`/`?`-of-void `or {}` double-wrapped as `Optional_Optional`
Calling a `!`-returning method on a smart-cast sumtype receiver as a bare `expr or {}` (e.g. `cond.resolve_compile_value(...) or {}`) declared the temp as `Optional_Optional` instead of `Optional`. The call resolves to a bare `"!"`; `canonical_or_expr_types("!")` then resolved `"!"` as the `Optional` wrapper struct and wrapped it again.

**Fix** (`transform/or.v`, `canonical_or_expr_types`): handle a bare `!`/`?` as `!void`/`?void` up front (matching the existing guard elsewhere in the file).

## Verification
- `v3 cmd/v` now exits 0; the produced v1 binary compiles and runs programs correctly.
- A C-diff of v1's generated output (before vs after) shows **only** the intended changes (`int`→`string`/`ast__File*`, `Optional_Optional`→`Optional`) — zero collateral changes.
- Both bugs reproduced in minimal standalone cases, now fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)