### PR TITLE
v3: reset resolution cache after scoped transform

### DIFF
--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -3766,6 +3766,9 @@ fn main() {
 				}
 				transform_texts_canonical = true
 			}
+			// Type-resolution views can grow their by-file map while the transform arena
+			// is active. Recreate it in the compilation arena before later phases use it.
+			pre_tc.reset_resolution_type_view_cache()
 		} else {
 			transform_used_fns, transform_was_parallel, transform_errors = transform.transform_with_used_opt_config_scoped_workers_checked(mut a,
 				&pre_tc, transform_used_fns, current_parallel_transform, skip_transform_generics,


### PR DESCRIPTION
## What this fixes

Prealloc self-host builds can leave `resolution_type_views.by_file` backed by the disposable transform arena. After that arena is released, `-building-v` skips monomorphization and reaches C generation with the stale map, causing a segmentation fault in `TypeChecker.parse_resolution_type`.

Reset the resolution-type view cache after every scoped transform region has been released so later phases use compilation-owned storage.

## Validation

- Reproduced the original optimized prealloc self-host crash.
- Re-ran the same self-host sequence and produced a working `v4`.
- `./vnew -silent test vlib/v3/tests/parallel_cgen_test.v -run-only test_parallel_transform_selfhost_builds_v3`
- `git diff --check`