### PR TITLE
fmt: keep call arguments expanded when written one per line with a trailing comma

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -950,6 +950,7 @@ pub mut:
 	is_c_variadic          bool // it is a C variadic
 	is_c_type_cast         bool // unresolved `C.Type(x)` reclassified by checker after imports are parsed
 	args                   []CallArg
+	args_start_on_new_line bool // the arguments each start on their own line (a newline right after `(`); vfmt keeps them expanded, one per line with a trailing comma
 	expected_arg_types     []Type
 	comptime_ret_val       bool
 	language               Language

--- a/vlib/v/checker/tests/fn_call_with_extra_parenthesis.out
+++ b/vlib/v/checker/tests/fn_call_with_extra_parenthesis.out
@@ -11,9 +11,9 @@ vlib/v/checker/tests/fn_call_with_extra_parenthesis.vv:5:2: error: expected 1 ar
     6 | }
 Details: have ()
          want (int)
-vlib/v/checker/tests/fn_call_with_extra_parenthesis.vv:5:9: error: unknown function: 
+vlib/v/checker/tests/fn_call_with_extra_parenthesis.vv:5:2: error: unknown function: 
     3 | 
     4 | fn main() {
     5 |     doit()(1)
-      |            ^
+      |     ~~~~~~~~~
     6 | }

--- a/vlib/v/fmt/fmt.v
+++ b/vlib/v/fmt/fmt.v
@@ -52,6 +52,7 @@ pub mut:
 	has_import_stmt          bool
 	use_short_fn_args        bool
 	single_line_fields       bool // should struct fields be on a single line
+	expand_call_args         bool // one-shot: the next call_args() keeps each argument on its own line
 	in_lambda_depth          int
 	inside_const             bool
 	inside_unsafe            bool
@@ -2649,6 +2650,7 @@ pub fn (mut f Fmt) call_expr(node ast.CallExpr) {
 	}
 	f.write_generic_call_if_require(node)
 	f.write('(')
+	f.expand_call_args = node.args_start_on_new_line
 	f.call_args(node.args)
 	f.write(')')
 	f.or_expr(node.or_block)
@@ -2743,16 +2745,34 @@ pub fn (mut f Fmt) call_args(args []ast.CallArg) {
 	old_short_arg_state := f.use_short_fn_args
 	f.single_line_fields = true
 	f.use_short_fn_args = false
+	// When the user starts a call's arguments on a line after `(` and ends them with a
+	// trailing comma, vfmt keeps the call expanded (#27909). Like gofmt, it preserves
+	// the source line grouping: arguments the user placed on the same line stay
+	// together, the rest go on their own line, and a trailing comma is written before
+	// the closing `)`. The trailing comma is the explicit opt-in — vfmt never emits one
+	// otherwise, so already-formatted calls are left untouched. The trailing short-struct
+	// syntax `f(a, b, c: 1)` has its own multiline layout (use_short_fn_args below), so
+	// it is left untouched.
+	last_is_short_struct := args.len > 0 && args.last().expr is ast.StructInit
+		&& (args.last().expr as ast.StructInit).typ == ast.void_type
+	expand := f.expand_call_args && args.len > 0 && !last_is_short_struct
+	f.expand_call_args = false
 	defer {
 		f.single_line_fields = old_single_line_fields_state
 		f.use_short_fn_args = old_short_arg_state
+	}
+	if expand {
+		f.writeln('')
+		f.indent++
 	}
 	for i, arg in args {
 		pre_comments := arg.comments.filter(it.pos.pos < arg.expr.pos().pos)
 		post_comments := arg.comments[pre_comments.len..]
 		if pre_comments.len > 0 {
 			f.comments(pre_comments)
-			f.write(' ')
+			if !expand {
+				f.write(' ')
+			}
 		}
 		if i == args.len - 1 && arg.expr is ast.StructInit {
 			if arg.expr.typ == ast.void_type {
@@ -2762,7 +2782,8 @@ pub fn (mut f Fmt) call_args(args []ast.CallArg) {
 		if arg.is_mut {
 			f.write(arg.share.str() + ' ')
 		}
-		if i > 0 && !f.single_line_if && !f.use_short_fn_args && arg.expr !is ast.StructInit {
+		if !expand && i > 0 && !f.single_line_if && !f.use_short_fn_args
+			&& arg.expr !is ast.StructInit {
 			arg_str := f.node_str(arg.expr)
 			tail_len := if i < args.len - 1 { 2 } else { 1 }
 			is_tiny_last_assign_arg := f.is_assign && i == args.len - 1 && arg_str.len <= 4
@@ -2772,13 +2793,31 @@ pub fn (mut f Fmt) call_args(args []ast.CallArg) {
 			}
 		}
 		f.expr(arg.expr)
-		if post_comments.len > 0 {
-			f.comments(post_comments)
-			f.write(' ')
+		if expand {
+			f.write(',')
+			if post_comments.len > 0 {
+				f.comments(post_comments, same_line: true, has_nl: false)
+			}
+			// Preserve the source line grouping: keep the next argument on this line
+			// if the user wrote them together, otherwise start a new line. The last
+			// argument always ends the line, so the closing `)` lands on its own line.
+			if i == args.len - 1 || args[i + 1].pos.line_nr > arg.pos.last_line {
+				f.writeln('')
+			} else {
+				f.write(' ')
+			}
+		} else {
+			if post_comments.len > 0 {
+				f.comments(post_comments)
+				f.write(' ')
+			}
+			if i < args.len - 1 {
+				f.write(', ')
+			}
 		}
-		if i < args.len - 1 {
-			f.write(', ')
-		}
+	}
+	if expand {
+		f.indent--
 	}
 }
 

--- a/vlib/v/fmt/tests/call_args_each_on_new_line_expected.vv
+++ b/vlib/v/fmt/tests/call_args_each_on_new_line_expected.vv
@@ -1,0 +1,36 @@
+module main
+
+fn many(a int, b int, c int, d int) int {
+	return a
+}
+
+fn adder(base int) fn (int, int) int {
+	return fn (a int, b int) int {
+		return a + b
+	}
+}
+
+fn run() {
+	// a trailing comma after the last argument keeps the arguments expanded
+	x := many(
+		1,
+		2,
+		3,
+		4,
+	)
+	// the source line grouping is preserved (like gofmt), not forced one per line
+	y := many(
+		1, 2,
+		3, 4,
+	)
+	// without a trailing comma, the call is collapsed/wrapped as before
+	z := many(1, 2, 3, 4)
+	// a returned-function call expands its own arguments too
+	r := adder(1)(
+		2,
+		3,
+	)
+	// and collapses without a trailing comma
+	s := adder(1)(4, 5)
+	_ := x + y + z + r + s
+}

--- a/vlib/v/fmt/tests/call_args_each_on_new_line_input.vv
+++ b/vlib/v/fmt/tests/call_args_each_on_new_line_input.vv
@@ -1,0 +1,42 @@
+module main
+
+fn many(a int, b int, c int, d int) int {
+	return a
+}
+
+fn adder(base int) fn (int, int) int {
+	return fn (a int, b int) int {
+		return a + b
+	}
+}
+
+fn run() {
+	// a trailing comma after the last argument keeps the arguments expanded
+	x := many(
+		1,
+		2,
+		3,
+		4,
+	)
+	// the source line grouping is preserved (like gofmt), not forced one per line
+	y := many(
+		1, 2,
+		3, 4,
+	)
+	// without a trailing comma, the call is collapsed/wrapped as before
+	z := many(
+		1,
+		2,
+		3,
+		4)
+	// a returned-function call expands its own arguments too
+	r := adder(1)(
+		2,
+		3,
+	)
+	// and collapses without a trailing comma
+	s := adder(1)(
+		4,
+		5)
+	_ := x + y + z + r + s
+}

--- a/vlib/v/fmt/tests/call_args_each_on_new_line_keep.vv
+++ b/vlib/v/fmt/tests/call_args_each_on_new_line_keep.vv
@@ -1,0 +1,64 @@
+// A trailing comma after the last call argument, with the arguments starting on a
+// new line after `(`, keeps the call expanded, preserving the source line grouping
+// like gofmt (see issue #27909).
+module main
+
+struct Data {
+	password_details PasswordDetails
+	user             User
+}
+
+struct User {
+	password_hash string
+	password_salt string
+}
+
+struct PasswordDetails {
+	function_name string
+	parameters    string
+}
+
+fn verify_password(password string, hash string, salt string, function_name string, parameters string) ! {
+}
+
+fn (d Data) check(password string, a int, b int) ! {
+	verify_password(
+		password,
+		d.user.password_hash,
+		d.user.password_salt,
+		d.password_details.function_name,
+		d.password_details.parameters,
+	)!
+	d.log(
+		a,
+		b,
+	)
+	single(
+		password,
+	)
+	// a returned-function call keeps its own arguments expanded too
+	make_adder(a)(
+		b,
+		a,
+	)
+	// arguments the user grouped on one line stay grouped
+	d.log2(
+		a, b,
+		b, a,
+	)
+}
+
+fn (d Data) log2(w int, x int, y int, z int) {
+}
+
+fn (d Data) log(a int, b int) {
+}
+
+fn single(s string) {
+}
+
+fn make_adder(base int) fn (int, int) int {
+	return fn (x int, y int) int {
+		return x + y
+	}
+}

--- a/vlib/v/parser/expr.v
+++ b/vlib/v/parser/expr.v
@@ -433,18 +433,22 @@ fn (mut p Parser) check_expr(precedence int) !ast.Expr {
 				// but this would take a bit of modification
 				if p.tok.kind == .lpar {
 					p.next()
+					lpar_line := p.prev_tok.pos().line_nr
 					pos := p.tok.pos()
 					args := p.call_args()
+					args_trailing_comma := p.call_args_trailing_comma
 					p.check(.rpar)
 					or_block := p.gen_or_block()
 					node = ast.CallExpr{
-						name:           'anon'
-						left:           node
-						args:           args
-						pos:            pos
-						or_block:       or_block
-						scope:          p.scope
-						is_return_used: p.expecting_value
+						name:                   'anon'
+						left:                   node
+						args:                   args
+						args_start_on_new_line: call_args_are_multiline(lpar_line,
+							args_trailing_comma, args)
+						pos:                    pos
+						or_block:               or_block
+						scope:                  p.scope
+						is_return_used:         p.expecting_value
 					}
 				}
 				return node
@@ -860,8 +864,10 @@ fn unwrap_parenthesized_call_left(expr ast.Expr) ast.Expr {
 
 fn (mut p Parser) call_expr_with_left(left ast.Expr) ast.CallExpr {
 	p.next()
+	lpar_line := p.prev_tok.pos().line_nr
 	pos := p.tok.pos()
 	args := p.call_args()
+	args_trailing_comma := p.call_args_trailing_comma
 	p.check(.rpar)
 	or_block := p.gen_or_block()
 	unwrapped_left := unwrap_parenthesized_call_left(left)
@@ -885,17 +891,18 @@ fn (mut p Parser) call_expr_with_left(left ast.Expr) ast.CallExpr {
 		kind = p.call_kind(fn_name)
 	}
 	return ast.CallExpr{
-		name:                  name
-		name_pos:              name_pos
-		mod:                   mod
-		kind:                  kind
-		left:                  unwrapped_left
-		args:                  args
-		pos:                   pos
-		scope:                 p.scope
-		or_block:              or_block
-		is_return_used:        p.expecting_value
-		is_paren_wrapped_call: left is ast.ParExpr
+		name:                   name
+		name_pos:               name_pos
+		mod:                    mod
+		kind:                   kind
+		left:                   unwrapped_left
+		args:                   args
+		args_start_on_new_line: call_args_are_multiline(lpar_line, args_trailing_comma, args)
+		pos:                    pos
+		scope:                  p.scope
+		or_block:               or_block
+		is_return_used:         p.expecting_value
+		is_paren_wrapped_call:  left is ast.ParExpr
 	}
 }
 

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -76,7 +76,9 @@ fn (mut p Parser) call_expr(language ast.Language, mod string) ast.CallExpr {
 		concrete_list_pos = concrete_list_pos.extend(p.prev_tok.pos())
 	}
 	p.check(.lpar)
+	lpar_line := p.prev_tok.pos().line_nr
 	args := p.call_args()
+	args_trailing_comma := p.call_args_trailing_comma
 	if p.tok.kind != .rpar && !p.pref.is_vls {
 		mut params := []ast.Param{}
 		fn_info, has_fn_info := table_fn_lookup(p.table, fn_name)
@@ -138,27 +140,47 @@ fn (mut p Parser) call_expr(language ast.Language, mod string) ast.CallExpr {
 	comments := p.eat_comments(same_line: true)
 	pos.update_last_line(p.prev_tok.line_nr)
 	return ast.CallExpr{
-		name:               fn_name
-		name_pos:           first_pos
-		args:               args
-		mod:                p.mod
-		kind:               p.call_kind(fn_name)
-		pos:                pos
-		language:           language
-		concrete_types:     concrete_types
-		concrete_list_pos:  concrete_list_pos
-		raw_concrete_types: concrete_types
-		or_block:           ast.OrExpr{
+		name:                   fn_name
+		name_pos:               first_pos
+		args:                   args
+		args_start_on_new_line: call_args_are_multiline(lpar_line, args_trailing_comma, args)
+		mod:                    p.mod
+		kind:                   p.call_kind(fn_name)
+		pos:                    pos
+		language:               language
+		concrete_types:         concrete_types
+		concrete_list_pos:      concrete_list_pos
+		raw_concrete_types:     concrete_types
+		or_block:               ast.OrExpr{
 			stmts: or_stmts
 			kind:  or_kind
 			pos:   or_pos
 			scope: or_scope
 		}
-		scope:              p.scope
-		comments:           comments
-		is_return_used:     p.expecting_value
-		is_static_method:   is_static_type_method
+		scope:                  p.scope
+		comments:               comments
+		is_return_used:         p.expecting_value
+		is_static_method:       is_static_type_method
 	}
+}
+
+// call_args_are_multiline reports whether the user asked for the call's arguments to
+// be kept expanded: the argument list begins on a line after the opening `(` (which
+// is on lpar_line) and ends with a trailing comma before `)`, e.g.
+//
+// 	f(
+// 		a,
+// 		b,
+// 	)
+//
+// vfmt then preserves the multi-line layout, keeping the source line grouping of the
+// arguments (like gofmt), with a trailing comma (see Fmt.call_args and #27909). The
+// trailing comma is the explicit opt-in: vfmt never emits one otherwise, so this
+// leaves every existing call untouched. A long single argument merely wrapped across
+// lines (e.g. `panic('...' + long_expr)`) has no trailing comma and is
+// collapsed/wrapped as before.
+fn call_args_are_multiline(lpar_line int, has_trailing_comma bool, args []ast.CallArg) bool {
+	return has_trailing_comma && args.len > 0 && args[0].pos.line_nr > lpar_line
 }
 
 fn min_required_call_args(params []ast.Param) int {
@@ -474,9 +496,11 @@ fn (mut p Parser) call_args() []ast.CallArg {
 	defer {
 		p.inside_call_args = prev_inside_call_args
 	}
+	mut trailing_comma := false
 	mut args := []ast.CallArg{}
 	for p.tok.kind != .rpar {
 		if p.tok.kind == .eof {
+			p.call_args_trailing_comma = trailing_comma
 			return args
 		}
 		is_shared := p.tok.kind == .key_shared
@@ -532,7 +556,10 @@ fn (mut p Parser) call_args() []ast.CallArg {
 			continue
 		}
 		p.next()
+		// a comma directly before `)` is a trailing comma: `f(a, b,)`
+		trailing_comma = p.tok.kind == .rpar
 	}
+	p.call_args_trailing_comma = trailing_comma
 	return args
 }
 

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -47,6 +47,7 @@ mut:
 	inside_fn_param             bool // true while parsing function parameter types
 	inside_fn_concrete_type     bool // parsing fn_name[concrete_type]() call expr
 	inside_call_args            bool // true inside f(  ....  )
+	call_args_trailing_comma    bool // set by call_args(): the last parsed argument list ended with a trailing comma before `)`
 	inside_unsafe_fn            bool
 	inside_str_interp           bool
 	inside_array_lit            bool
@@ -1982,18 +1983,23 @@ fn (mut p Parser) name_expr() ast.Expr {
 			} else {
 				node = p.call_expr(language, mod)
 				if p.tok.kind == .lpar && p.prev_tok.line_nr == p.tok.line_nr {
+					left_pos := node.pos()
 					p.next()
-					pos := p.tok.pos()
+					lpar_line := p.prev_tok.pos().line_nr
 					args := p.call_args()
+					args_trailing_comma := p.call_args_trailing_comma
 					p.check(.rpar)
+					rpar_pos := p.prev_tok.pos()
 					or_block := p.gen_or_block()
 					node = ast.CallExpr{
-						left:           node
-						args:           args
-						pos:            pos
-						scope:          p.scope
-						or_block:       or_block
-						is_return_used: p.expecting_value
+						left:                   node
+						args:                   args
+						args_start_on_new_line: call_args_are_multiline(lpar_line,
+							args_trailing_comma, args)
+						pos:                    left_pos.extend(rpar_pos)
+						scope:                  p.scope
+						or_block:               or_block
+						is_return_used:         p.expecting_value
 					}
 				}
 			}
@@ -2370,7 +2376,9 @@ fn (mut p Parser) dot_expr(left ast.Expr) ast.Expr {
 	}
 	if p.tok.kind == .lpar {
 		p.next()
+		lpar_line := p.prev_tok.pos().line_nr
 		args := p.call_args()
+		args_trailing_comma := p.call_args_trailing_comma
 		p.check(.rpar)
 		or_block := p.gen_or_block()
 		end_pos := p.prev_tok.pos()
@@ -2398,20 +2406,21 @@ fn (mut p Parser) dot_expr(left ast.Expr) ast.Expr {
 		}
 		p.maybe_register_implied_vlib_import(left)
 		mcall_expr := ast.CallExpr{
-			left:               left
-			name:               field_name
-			kind:               p.call_kind(field_name)
-			args:               args
-			name_pos:           name_pos
-			pos:                pos
-			is_method:          true
-			concrete_types:     concrete_types
-			concrete_list_pos:  concrete_list_pos
-			raw_concrete_types: concrete_types
-			or_block:           or_block
-			scope:              p.scope
-			comments:           comments
-			is_return_used:     p.expecting_value
+			left:                   left
+			name:                   field_name
+			kind:                   p.call_kind(field_name)
+			args:                   args
+			args_start_on_new_line: call_args_are_multiline(lpar_line, args_trailing_comma, args)
+			name_pos:               name_pos
+			pos:                    pos
+			is_method:              true
+			concrete_types:         concrete_types
+			concrete_list_pos:      concrete_list_pos
+			raw_concrete_types:     concrete_types
+			or_block:               or_block
+			scope:                  p.scope
+			comments:               comments
+			is_return_used:         p.expecting_value
 		}
 		return mcall_expr
 	}


### PR DESCRIPTION
## What

Fixes #27909.

`v fmt` now keeps a call's arguments expanded (instead of reflowing them to fit the
line-length limit) when the argument list starts on a new line after `(` and ends
with a **trailing comma**:

```v
verify_password(
	p.password,
	data.user.password_hash,
	data.user.password_salt,
	data.password_details.function_name,
	data.password_details.parameters,
) or {
	return ctx.handle_error(err)
}
```

## Behaviour (gofmt-like)

Like `gofmt`, the **source line grouping is preserved** — arguments the user placed
on the same line stay grouped, the rest go on their own line; it does not force one
argument per line:

```v
m(
	a, b,
	c, d,
)
```

- **Trailing comma + line break after `(`** → the call is kept expanded, grouping
  preserved, trailing comma kept before `)`.
- **No trailing comma** → collapsed/wrapped exactly as before.
- A long single argument merely wrapped across lines (e.g. `panic('...' + long)`)
  has no trailing comma and is unaffected.
- The trailing short-struct syntax `f(a, b, c: 1)` keeps its existing layout.

### How this differs from gofmt, and why

`gofmt` keys purely on source positions (a line break after `(` is enough, because
Go's grammar then requires the trailing comma). vfmt, unlike gofmt, **also reflows
long lines to a width limit**, so a line break after `(` is not by itself a reliable
signal of intent — vfmt itself produces such breaks when wrapping a long first
argument. The **trailing comma is the unambiguous opt-in**: vfmt never emits one on
its own, so keying on it means **no already-formatted file changes**. Verified by
diffing `v fmt -l` over all of `vlib/` — zero existing files are reformatted.

## Implementation

- The parser records whether a call's argument list ended with a trailing comma and
  whether it began on a line after `(`, stored in `CallExpr.args_start_on_new_line`
  (threaded through all five call-parsing sites, including method calls and
  `foo()(...)` returned-function calls).
- `Fmt.call_args` lays the arguments out preserving their source line grouping.

## Tests

`vlib/v/fmt/tests/call_args_each_on_new_line_{keep,input,expected}.vv` cover
expansion, grouping preservation, the no-trailing-comma collapse, and
returned-function calls. `fmt_test`, `fmt_keep_test`, and the parser suite pass; the
compiler self-hosts.