### PR TITLE
v3: speed up the parallel transform stage and cut its peak memory

### DIFF
--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -430,9 +430,9 @@ fn (t &Transformer) resolve_alias_receiver_method(base_type string, method strin
 	if isnil(t.tc) || base_type.len == 0 || method.len == 0 {
 		return none
 	}
-	raw_base := base_type.trim_space().trim_left('&')
-	clean_base := t.normalize_type_alias(base_type)
-	cache_key := '${t.cur_module}\n${raw_base}\n${method}'
+	// Key the memo on the raw spelling so cache hits skip the trim/normalize
+	// allocations below; the result is a pure function of the spelling anyway.
+	cache_key := '${t.cur_module}\n${base_type}\n${method}'
 	if !isnil(t.alias_receiver_method_cache) {
 		mut cache := t.alias_receiver_method_cache
 		if cached := cache.entries[cache_key] {
@@ -442,6 +442,8 @@ fn (t &Transformer) resolve_alias_receiver_method(base_type string, method strin
 			return none
 		}
 	}
+	raw_base := base_type.trim_space().trim_left('&')
+	clean_base := t.normalize_type_alias(base_type)
 	mut exact_aliases := [raw_base]
 	if !raw_base.contains('.') && t.cur_module.len > 0 && t.cur_module !in ['main', 'builtin'] {
 		exact_aliases << '${t.cur_module}.${raw_base}'
@@ -3056,6 +3058,18 @@ fn (t &Transformer) is_fn_pointer_type_name(type_name string) bool {
 }
 
 fn transform_param_type_is_void_pointer(type_name string) bool {
+	if type_name.len < 5 {
+		return false
+	}
+	// Fast path: nothing to trim (the common spelling), so compare directly
+	// instead of allocating a trimmed copy per call.
+	if type_name[0] > ` ` && type_name[type_name.len - 1] > ` ` {
+		if type_name.len > 7 {
+			return false
+		}
+		return type_name == '&void' || type_name == 'voidptr' || type_name == 'byteptr'
+			|| type_name == 'charptr'
+	}
 	clean := type_name.trim_space()
 	return clean == '&void' || clean == 'voidptr' || clean == 'byteptr' || clean == 'charptr'
 }

--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -10346,6 +10346,20 @@ fn generic_param_index(name string) int {
 }
 
 fn is_generic_fn_placeholder_name(typ string) bool {
+	if typ.len == 0 {
+		return false
+	}
+	if typ.len == 1 {
+		return typ[0] >= `A` && typ[0] <= `Z`
+	}
+	// Fast path: nothing to trim, so a placeholder is exactly one capital
+	// letter after the final '.' — no trimmed/suffix copies needed.
+	if typ[0] > ` ` && typ[typ.len - 1] > ` ` {
+		if typ[typ.len - 1] < `A` || typ[typ.len - 1] > `Z` {
+			return false
+		}
+		return typ[typ.len - 2] == `.`
+	}
 	clean := typ.trim_space()
 	if clean.contains('.') {
 		return is_generic_fn_placeholder_name(clean.all_after_last('.'))

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -2416,6 +2416,12 @@ struct DeferredBaseWrite {
 // enough work, with closure-free function bodies transformed across threads.
 // Returns whether function bodies were actually transformed in parallel.
 fn (mut t Transformer) transform_all_dispatch(want_parallel bool) bool {
+	// Every forked worker checker otherwise lazily rebuilds the source-error
+	// embedding index by rescanning all struct declarations; build it once in
+	// the master cache so forks inherit it through the frozen base.
+	if !isnil(t.tc) {
+		t.tc.precompute_source_error_embed_index()
+	}
 	// Collect source-level interface conversions before any worker rewrites its
 	// private AST. Equality and automatic string lowering can then generate the
 	// same bounded tag dispatch independently of worker scheduling.

--- a/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
@@ -18,6 +18,14 @@ const max_parallel_transform_jobs = 7
 // append into pre-partitioned capacity regions, so extra threads cost no
 // clone memory; cap by core count only.
 const max_shared_transform_jobs = 10
+// Split the shared-base transform into more chunks than pool threads: the
+// persistent pool hands queued chunks to whichever worker frees up first, so
+// finer chunks level the load across asymmetric (performance/efficiency)
+// cores while the fixed region merge order keeps node ids deterministic.
+const shared_transform_chunk_factor = 3
+// Keep enough items per chunk that per-chunk append-region headroom (sized
+// proportionally to estimated cost) still averages out expansion variance.
+const min_shared_transform_chunk_items = 24
 const max_parallel_monomorph_jobs = 10
 const scoped_transform_worker_batches = 1
 const scoped_transform_master_batches = 1
@@ -1422,9 +1430,21 @@ fn (mut t Transformer) run_parallel_transform_shared(items []FnWorkItem, base_no
 		return false
 	} $else {
 		t.tc.freeze_type_cache_for_forks()
-		mut chunks := split_work_items_ex(items, n_jobs, false)
+		mut chunk_target := n_jobs * shared_transform_chunk_factor
+		max_chunks_by_items := items.len / min_shared_transform_chunk_items
+		if chunk_target > max_chunks_by_items {
+			chunk_target = max_chunks_by_items
+		}
+		if chunk_target < n_jobs {
+			chunk_target = n_jobs
+		}
+		mut chunks := split_work_items_ex(items, chunk_target, false)
 		chunk_count := chunks.len
 		thread_count := chunk_count - 1
+		// The master transforms chunk 0 in place and then this many additional
+		// forked chunks synchronously (keeping its former ~1/n_jobs share),
+		// while the pool workers drain the rest of the queue dynamically.
+		master_sync_chunks := chunk_count / n_jobs - 1
 		// Partition the reserved capacity into per-chunk append regions,
 		// proportional to chunk cost (the caller reserved ~2x the expected
 		// total growth for this pool).
@@ -1493,7 +1513,8 @@ fn (mut t Transformer) run_parallel_transform_shared(items []FnWorkItem, base_no
 			tasks << workers.Task{
 				run:        shared_chunk_thread
 				arg:        unsafe { voidptr(&args[ci]) }
-				force_sync: ci == 0 || fail == 'transform:all' || fail == 'transform:${helper_idx}'
+				force_sync: ci <= master_sync_chunks || fail == 'transform:all'
+					|| fail == 'transform:${helper_idx}'
 			}
 		}
 		transform_worker_scope_leave(setup_scope)

--- a/vlib/v3/transform/type_propagation.v
+++ b/vlib/v3/transform/type_propagation.v
@@ -1235,6 +1235,10 @@ fn (t &Transformer) is_known_type_name(typ string) bool {
 // is_plain_builtin_alias_type reports whether is plain builtin alias type applies in transform.
 @[inline]
 fn is_plain_builtin_alias_type(typ string) bool {
+	// 'i8'..'voidptr': every plain builtin spelling is 2..7 bytes long.
+	if typ.len < 2 || typ.len > 7 {
+		return false
+	}
 	return match typ {
 		'bool', 'string', 'void', 'int', 'i8', 'i16', 'i32', 'i64', 'u8', 'u16', 'u32', 'u64',
 		'f32', 'f64', 'rune', 'isize', 'usize', 'voidptr', 'byteptr', 'charptr' {

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -2390,8 +2390,14 @@ fn (tc &TypeChecker) local_fn_decl_exists(name string) bool {
 	if lookup_key in cache.local_fn_decl_index {
 		return true
 	}
-	if !isnil(cache.base) && lookup_key in cache.base.local_fn_decl_index {
-		return true
+	// The base chain can be more than one level deep during transform (the
+	// scoped-transform overlay sits between forks and the warm check cache).
+	mut fallback := cache.base
+	for !isnil(fallback) {
+		if lookup_key in fallback.local_fn_decl_index {
+			return true
+		}
+		fallback = fallback.base
 	}
 	// Parallel forks only append transformed expressions to their private AST
 	// regions; declarations remain the frozen master's authority. Scanning the
@@ -24296,8 +24302,12 @@ pub fn (tc &TypeChecker) ierror_impl_names() []string {
 		if cache.ierror_impl_names_set {
 			return cache.ierror_impl_names.clone()
 		}
-		if !isnil(cache.base) && cache.base.ierror_impl_names_set {
-			return cache.base.ierror_impl_names.clone()
+		mut fallback := cache.base
+		for !isnil(fallback) {
+			if fallback.ierror_impl_names_set {
+				return fallback.ierror_impl_names.clone()
+			}
+			fallback = fallback.base
 		}
 	}
 	mut struct_names := []string{}
@@ -24466,10 +24476,12 @@ pub fn (tc &TypeChecker) named_type_compatible_with_ierror(concrete_name string)
 	cache_key := tc.ierror_compat_cache_key(concrete_name)
 	if tc.type_cache != unsafe { nil } {
 		mut cache := unsafe { tc.type_cache }
-		if !isnil(cache.base) {
-			if cached := cache.base.ierror_compat_entries[cache_key] {
+		mut fallback := cache.base
+		for !isnil(fallback) {
+			if cached := fallback.ierror_compat_entries[cache_key] {
 				return cached > 0
 			}
+			fallback = fallback.base
 		}
 		if cached := cache.ierror_compat_entries[cache_key] {
 			return cached > 0
@@ -24650,8 +24662,12 @@ fn (tc &TypeChecker) source_struct_has_non_builtin_error_embed(concrete_name str
 	if tc.type_cache != unsafe { nil } {
 		mut cache := unsafe { tc.type_cache }
 		if !cache.source_error_embed_indexed {
-			if !isnil(cache.base) && cache.base.source_error_embed_indexed {
-				return cache.base.source_error_embed_entries[key] > 0
+			mut fallback := cache.base
+			for !isnil(fallback) {
+				if fallback.source_error_embed_indexed {
+					return fallback.source_error_embed_entries[key] > 0
+				}
+				fallback = fallback.base
 			}
 			cache.source_error_embed_entries = tc.collect_source_error_embed_entries()
 			cache.source_error_embed_indexed = true
@@ -24672,8 +24688,12 @@ pub fn (tc &TypeChecker) precompute_source_error_embed_index() {
 	if cache.source_error_embed_indexed {
 		return
 	}
-	if !isnil(cache.base) && cache.base.source_error_embed_indexed {
-		return
+	mut fallback := cache.base
+	for !isnil(fallback) {
+		if fallback.source_error_embed_indexed {
+			return
+		}
+		fallback = fallback.base
 	}
 	cache.source_error_embed_entries = tc.collect_source_error_embed_entries()
 	cache.source_error_embed_indexed = true
@@ -25182,13 +25202,15 @@ pub fn (tc &TypeChecker) struct_fields_for_type(struct_name string) []StructFiel
 fn (tc &TypeChecker) struct_field_type(struct_name string, field_name string) ?Type {
 	cache_key := '${struct_name}\n${field_name}'
 	if !isnil(tc.type_cache) {
-		if !isnil(tc.type_cache.base) {
-			if typ := tc.type_cache.base.struct_field_entries[cache_key] {
+		mut fallback := tc.type_cache.base
+		for !isnil(fallback) {
+			if typ := fallback.struct_field_entries[cache_key] {
 				return typ
 			}
-			if tc.type_cache.base.struct_field_misses[cache_key] {
+			if fallback.struct_field_misses[cache_key] {
 				return none
 			}
+			fallback = fallback.base
 		}
 		if typ := tc.type_cache.struct_field_entries[cache_key] {
 			return typ
@@ -26220,10 +26242,12 @@ pub fn (tc &TypeChecker) cached_c_name(name string) string {
 		return naming.c_name(name)
 	}
 	mut cache := unsafe { tc.type_cache }
-	if !isnil(cache.base) {
-		if cached := cache.base.c_name_entries[name] {
+	mut fallback := cache.base
+	for !isnil(fallback) {
+		if cached := fallback.c_name_entries[name] {
 			return cached
 		}
+		fallback = fallback.base
 	}
 	if cached := cache.c_name_entries[name] {
 		return cached
@@ -26443,8 +26467,10 @@ fn parse_type_cache_get(mut cache TypeCache, file string, module_name string, te
 			key = parse_type_cache_next_key(key)
 			continue
 		}
-		if !isnil(cache.base) {
-			if entry := cache.base.parse_entries[key] {
+		mut fallback := cache.base
+		mut fallback_collision := false
+		for !isnil(fallback) {
+			if entry := fallback.parse_entries[key] {
 				if parse_type_cache_entry_matches(entry, file, module_name, text, generic_params,
 					resolution)
 				{
@@ -26452,9 +26478,14 @@ fn parse_type_cache_get(mut cache TypeCache, file string, module_name string, te
 					cache.parse_last_valid = true
 					return entry.typ
 				}
-				key = parse_type_cache_next_key(key)
-				continue
+				fallback_collision = true
+				break
 			}
+			fallback = fallback.base
+		}
+		if fallback_collision {
+			key = parse_type_cache_next_key(key)
+			continue
 		}
 		return none
 	}
@@ -26475,16 +26506,23 @@ fn parse_type_cache_put(mut cache TypeCache, file string, module_name string, te
 			key = parse_type_cache_next_key(key)
 			continue
 		}
-		if !isnil(cache.base) {
-			if entry := cache.base.parse_entries[key] {
+		mut fallback := cache.base
+		mut fallback_collision := false
+		for !isnil(fallback) {
+			if entry := fallback.parse_entries[key] {
 				if parse_type_cache_entry_matches(entry, file, module_name, text, generic_params,
 					resolution)
 				{
 					return
 				}
-				key = parse_type_cache_next_key(key)
-				continue
+				fallback_collision = true
+				break
 			}
+			fallback = fallback.base
+		}
+		if fallback_collision {
+			key = parse_type_cache_next_key(key)
+			continue
 		}
 		entry := ParseTypeCacheEntry{
 			file:           file
@@ -27302,12 +27340,16 @@ fn (tc &TypeChecker) unique_qualified_type_name(short_name string) ?string {
 		return tc.unique_qualified_type_name_scan(short_name)
 	}
 	if !cache.short_type_name_index_built {
-		if !isnil(cache.base) && cache.base.short_type_name_index_built {
-			found := cache.base.short_type_name_index[short_name] or { return none }
-			if found.len == 0 {
-				return none
+		mut fallback := cache.base
+		for !isnil(fallback) {
+			if fallback.short_type_name_index_built {
+				found := fallback.short_type_name_index[short_name] or { return none }
+				if found.len == 0 {
+					return none
+				}
+				return found
 			}
-			return found
+			fallback = fallback.base
 		}
 		cache.short_type_name_index_built = true
 		tc.build_short_type_name_index(mut cache.short_type_name_index)
@@ -27346,10 +27388,14 @@ pub fn (tc &TypeChecker) register_short_type_name(name string) {
 		return
 	}
 	if !cache.short_type_name_index_built {
-		if isnil(cache.base) || !cache.base.short_type_name_index_built {
+		mut fallback := cache.base
+		for !isnil(fallback) && !fallback.short_type_name_index_built {
+			fallback = fallback.base
+		}
+		if isnil(fallback) {
 			return
 		}
-		cache.short_type_name_index = cache.base.short_type_name_index.clone()
+		cache.short_type_name_index = fallback.short_type_name_index.clone()
 		cache.short_type_name_index_built = true
 	}
 	index_short_type_name(name, mut cache.short_type_name_index)
@@ -27364,10 +27410,14 @@ pub fn (tc &TypeChecker) unregister_short_type_name(name string) {
 		return
 	}
 	if !cache.short_type_name_index_built {
-		if isnil(cache.base) || !cache.base.short_type_name_index_built {
+		mut fallback := cache.base
+		for !isnil(fallback) && !fallback.short_type_name_index_built {
+			fallback = fallback.base
+		}
+		if isnil(fallback) {
 			return
 		}
-		cache.short_type_name_index = cache.base.short_type_name_index.clone()
+		cache.short_type_name_index = fallback.short_type_name_index.clone()
 		cache.short_type_name_index_built = true
 	}
 	short := name.all_after_last('.')


### PR DESCRIPTION
## Summary

Self-host transform stage (`v3 -building-v -o v4 v3.v`, 4P+6E-core Mac, `-gc none -prealloc -prod` build):

- **transform (parallel) wall time ~5-6% faster** (~192 → ~184 ms median on the pre-#27913 tree; best interleaved runs 177 ms vs 188 ms — measurements were noise-limited by a concurrent workload)
- **peak footprint during transform reduced ~35%** (was 1030-1100 MB → 655-700 MB on the pre-#27913 tree; on this branch the whole stage peaks around 640 MB)

## What was slow

1. **Forked transform workers ran with cold type caches.** During transform the checker's cache chain is two levels deep (scoped-transform overlay → warm check cache), but every `cache.base` read only consulted one level, so per-batch forks saw an empty overlay instead of the warm cache. Each fork rebuilt the source-error embedding index by rescanning every struct declaration (~7% of transform CPU in `sample` profiles) and re-derived parse-type/c-name/short-type-name memoizations. All read sites now walk the base chain, and the master builds the source-error embed index once before forking (mirroring what cgen already does in `cleanc.v`).

2. **Static equal-cost chunks on asymmetric cores.** Equal-cost buckets finish unevenly on performance/efficiency-core CPUs; sampling showed the master idle ~25% of the stage waiting for the slowest efficiency-core worker. The worker pool already dispatches queued tasks dynamically, so the shared-base transform now splits work into 3× n_jobs chunks (≥24 items each) that free workers claim as they finish. The merge loop still folds regions in fixed order, so node ids stay deterministic per configuration. The finer scoped batches are also what cut the peak footprint. (Chunk factor 4 and a larger master share were measured and rejected — both slower.)

3. Allocation-free fast paths on hot type-spelling helpers (`transform_param_type_is_void_pointer`, `is_generic_fn_placeholder_name`, `is_plain_builtin_alias_type`) and a memo-first reorder in `resolve_alias_receiver_method`.

## Validation

- `v test vlib/v3/transform/` 6/6 and `v test vlib/v3/types/` 6/6 pass on this branch
- Repeated runs produce identical AST node counts; output differs across job counts, which is pre-existing behavior on master
- Two-generation self-compile verified on the pre-#27913 tree

Note: the full self-host C compile currently fails on the **base** commit (9b4bdbdad3, #27913) with `member reference type 'map' is not a pointer` on the generated code for the `current_sums` map iteration in `monomorphize.v` — reproduced identically on clean master with this branch's changes absent, so it is unrelated to this PR (base CI for #27913 was still queued at the time of writing).
