### PR TITLE
parser: report a clear error for the `if if cond {` typo (fix #27907)

### DIFF
--- a/vlib/v/parser/if_match.v
+++ b/vlib/v/parser/if_match.v
@@ -184,6 +184,17 @@ fn (mut p Parser) if_expr(is_comptime bool, is_expr bool) ast.IfExpr {
 			p.comptime_if_cond = false
 		}
 		comments << p.eat_comments()
+		// catch the common typo `if if cond {` / `} else if if cond {`, where a
+		// second `if` was written by mistake. The inner `if` gets parsed as the
+		// condition expression, so bail out with a helpful message instead of the
+		// confusing `expecting {` error that appears further down the file.
+		if !is_comptime && p.tok.kind != .lcbr {
+			if cond is ast.IfExpr && !cond.has_else {
+				p.error_with_pos('the condition of an `if` should be a boolean expression, not another `if` statement; did you write `if` twice by mistake?',
+					cond.pos)
+				return ast.IfExpr{}
+			}
+		}
 		end_pos := p.prev_tok.pos()
 		body_pos := p.tok.pos()
 		p.inside_if = false

--- a/vlib/v/parser/tests/if_double_if_cond_err.out
+++ b/vlib/v/parser/tests/if_double_if_cond_err.out
@@ -1,0 +1,7 @@
+vlib/v/parser/tests/if_double_if_cond_err.vv:6:12: error: the condition of an `if` should be a boolean expression, not another `if` statement; did you write `if` twice by mistake?
+    4 |     if x == 1 {
+    5 |         commands << 'a'
+    6 |     } else if if x == 2 {
+      |               ~~
+    7 |         commands << 'b'
+    8 |     }

--- a/vlib/v/parser/tests/if_double_if_cond_err.vv
+++ b/vlib/v/parser/tests/if_double_if_cond_err.vv
@@ -1,0 +1,14 @@
+fn get_commands() []string {
+	mut commands := []string{}
+	x := 1
+	if x == 1 {
+		commands << 'a'
+	} else if if x == 2 {
+		commands << 'b'
+	}
+	return commands
+}
+
+fn main() {
+	println(get_commands())
+}


### PR DESCRIPTION
## What

Fixes #27907.

Accidentally writing `if` twice (e.g. `} else if if x == 2 {`) produced a confusing, misplaced error, because the second `if` was parsed as an *if-expression used as the condition*, and the failure only surfaced later when the parser could not find the body `{`:

```
piper.v:69:3: error: unexpected token `}`, expecting `{`
```

Now the parser detects this typo directly and points at the offending `if`:

```
x.v:6:12: error: the condition of an `if` should be a boolean expression, not another `if` statement; did you write `if` twice by mistake?
    4 |     if x == 1 {
    5 |         commands << 'a'
    6 |     } else if if x == 2 {
      |               ~~
    7 |         commands << 'b'
    8 |     }
```

## How

In `if_expr`, after parsing the condition, if the next token is not the body `{` and the condition itself parsed into an `ast.IfExpr` with no `else` branch, we emit the targeted error pointing at the inner `if`.

This is precise and does not regress legitimate code: a real if-expression used as a condition (e.g. `if if x == 1 { true } else { false } { ... }`) has an `else` branch and is followed by the body `{`, so neither guard fires.

## Test

Added `vlib/v/parser/tests/if_double_if_cond_err.{vv,out}`. The full `vlib/v/compiler_errors_test.v` suite passes, and the compiler still self-compiles.