### PR TITLE
Add io.BufferedReader.peek (fixes #27915)

### DIFF
--- a/vlib/io/buffered_reader.v
+++ b/vlib/io/buffered_reader.v
@@ -44,21 +44,11 @@ pub fn new_buffered_reader(o BufferedReaderConfig) &BufferedReader {
 	return r
 }
 
-// read fufills the Reader interface.
-pub fn (mut r BufferedReader) read(mut buf []u8) !int {
+fn (mut r BufferedReader) copy_unread(mut buf []u8) !int {
 	if buf.len == 0 {
 		return 0
 	}
-	if r.end_of_stream {
-		return Eof{}
-	}
-	// read data out of the buffer if we dont have any
-	if r.needs_fill() {
-		if !r.fill_buffer() {
-			// end of stream
-			return Eof{}
-		}
-	}
+
 	read := copy(mut buf, r.buf[r.offset..r.len])
 	if read == 0 {
 		return NotExpected{
@@ -69,6 +59,77 @@ pub fn (mut r BufferedReader) read(mut buf []u8) !int {
 	r.offset += read
 	r.total_read += read
 	return read
+}
+
+// read fufills the Reader interface.
+pub fn (mut r BufferedReader) read(mut buf []u8) !int {
+	if r.end_of_stream {
+		if r.offset < r.len {
+			return r.copy_unread(mut buf)
+		}
+		return Eof{}
+	}
+	// read data out of the buffer if we dont have any
+	if r.needs_fill() {
+		if !r.fill_buffer() {
+			// end of stream
+			return Eof{}
+		}
+	}
+	return r.copy_unread(mut buf)
+}
+
+// fill buffer but keep unread data
+fn (mut r BufferedReader) fill_buffer_keep_unread() ! {
+	// shift unread bytes to front
+	unread := r.len - r.offset
+	for i := 0; i < unread; i++ {
+		r.buf[i] = r.buf[r.offset + i]
+	}
+	mut rest := r.buf[unread..]
+	read_len := r.reader.read(mut rest) or {
+		r.end_of_stream = true // read must check if there are unread bytes even though r.end_of_stream
+		return Eof{}
+	}
+	r.len = unread + read_len
+	r.offset = 0
+}
+
+// peek reads n bytes without advancing the cursor.
+// returns Eof if reached the end of the stream.
+// returns an error if n < 0.
+// returns an array with less than n bytes if n > capacity.
+pub fn (mut r BufferedReader) peek(n int) ![]u8 {
+	if n < 0 {
+		return error('cannot read a negative number of bytes')
+	}
+
+	if r.end_of_stream {
+		return Eof{}
+	}
+
+	// refill buffer if no more bytes in buffer
+	if r.needs_fill() {
+		if !r.fill_buffer() {
+			return Eof{}
+		}
+	}
+
+	// enough data in buffer, re refill
+	if n <= r.buf.len - r.offset {
+		return r.buf[r.offset..r.offset + n].clone()
+	}
+
+	r.fill_buffer_keep_unread() or {
+		// reached Eof
+		return r.buf[r.offset..].clone()
+	}
+
+	// asking for more bytes than buffer can contain
+	if n > r.buf.len {
+		return r.buf[r.offset..].clone()
+	}
+	return r.buf[r.offset..r.offset + n].clone()
 }
 
 // free deallocates the memory for a buffered reader's internal buffer.

--- a/vlib/io/buffered_reader.v
+++ b/vlib/io/buffered_reader.v
@@ -45,10 +45,6 @@ pub fn new_buffered_reader(o BufferedReaderConfig) &BufferedReader {
 }
 
 fn (mut r BufferedReader) copy_unread(mut buf []u8) !int {
-	if buf.len == 0 {
-		return 0
-	}
-
 	read := copy(mut buf, r.buf[r.offset..r.len])
 	if read == 0 {
 		return NotExpected{
@@ -63,12 +59,17 @@ fn (mut r BufferedReader) copy_unread(mut buf []u8) !int {
 
 // read fufills the Reader interface.
 pub fn (mut r BufferedReader) read(mut buf []u8) !int {
+	if buf.len == 0 {
+		return 0
+	}
+
 	if r.end_of_stream {
 		if r.offset < r.len {
 			return r.copy_unread(mut buf)
 		}
 		return Eof{}
 	}
+
 	// read data out of the buffer if we dont have any
 	if r.needs_fill() {
 		if !r.fill_buffer() {
@@ -116,7 +117,7 @@ pub fn (mut r BufferedReader) peek(n int) ![]u8 {
 	}
 
 	// enough data in buffer, re refill
-	if n <= r.buf.len - r.offset {
+	if n <= r.len - r.offset {
 		return r.buf[r.offset..r.offset + n].clone()
 	}
 
@@ -125,9 +126,9 @@ pub fn (mut r BufferedReader) peek(n int) ![]u8 {
 		return r.buf[r.offset..].clone()
 	}
 
-	// asking for more bytes than buffer can contain
-	if n > r.buf.len {
-		return r.buf[r.offset..].clone()
+	// asking for more bytes than buffer contains after refill
+	if n > r.len {
+		return r.buf[r.offset..r.len].clone()
 	}
 	return r.buf[r.offset..r.offset + n].clone()
 }

--- a/vlib/io/buffered_reader.v
+++ b/vlib/io/buffered_reader.v
@@ -121,12 +121,11 @@ pub fn (mut r BufferedReader) peek(n int) ![]u8 {
 		return error('cannot peek a negative number of bytes')
 	}
 
-	if r.end_of_stream {
-		return Eof{}
-	}
+	if r.needs_fill() { // has no unread bytes
+		if r.end_of_stream {
+			return Eof{}
+		}
 
-	// refill buffer if no more bytes in buffer
-	if r.needs_fill() {
 		if !r.fill_buffer() {
 			return Eof{}
 		}
@@ -200,7 +199,7 @@ pub fn (r BufferedReader) end_of_stream() bool {
 // With the default delimiter `\n`, both `\n` and `\r\n` line endings are
 // accepted, and neither terminator byte is included in the returned string.
 pub fn (mut r BufferedReader) read_line(config BufferedReadLineConfig) !string {
-	if r.end_of_stream {
+	if r.end_of_stream && r.offset == r.len {
 		return Eof{}
 	}
 	mut line := []u8{}

--- a/vlib/io/buffered_reader.v
+++ b/vlib/io/buffered_reader.v
@@ -102,7 +102,7 @@ fn (mut r BufferedReader) fill_buffer_keep_unread() ! {
 // returns an array with less than n bytes if n > capacity.
 pub fn (mut r BufferedReader) peek(n int) ![]u8 {
 	if n < 0 {
-		return error('cannot read a negative number of bytes')
+		return error('cannot peek a negative number of bytes')
 	}
 
 	if r.end_of_stream {

--- a/vlib/io/buffered_reader.v
+++ b/vlib/io/buffered_reader.v
@@ -82,18 +82,34 @@ pub fn (mut r BufferedReader) read(mut buf []u8) !int {
 
 // fill buffer but keep unread data
 fn (mut r BufferedReader) fill_buffer_keep_unread() ! {
-	// shift unread bytes to front
-	unread := r.len - r.offset
-	for i := 0; i < unread; i++ {
-		r.buf[i] = r.buf[r.offset + i]
-	}
-	mut rest := r.buf[unread..]
-	read_len := r.reader.read(mut rest) or {
-		r.end_of_stream = true // read must check if there are unread bytes even though r.end_of_stream
+	if r.end_of_stream {
 		return Eof{}
 	}
-	r.len = unread + read_len
+
+	// shift unread bytes to front
+	r.len = r.len - r.offset
+	for i := 0; i < r.len; i++ {
+		r.buf[i] = r.buf[r.offset + i]
+	}
 	r.offset = 0
+
+	for r.len < r.buf.len {
+		read := r.reader.read(mut r.buf[r.len..]) or {
+			r.end_of_stream = true
+			return Eof{}
+		}
+
+		if read == 0 {
+			r.fails++
+			if r.fails >= r.mfails {
+				r.end_of_stream = true
+				return Eof{}
+			}
+		} else {
+			r.fails = 0
+			r.len += read
+		}
+	}
 }
 
 // peek reads n bytes without advancing the cursor.
@@ -116,15 +132,12 @@ pub fn (mut r BufferedReader) peek(n int) ![]u8 {
 		}
 	}
 
-	// enough data in buffer, re refill
+	// enough data in buffer
 	if n <= r.len - r.offset {
 		return r.buf[r.offset..r.offset + n].clone()
 	}
 
-	r.fill_buffer_keep_unread() or {
-		// reached Eof
-		return r.buf[r.offset..].clone()
-	}
+	r.fill_buffer_keep_unread() or { return r.buf[r.offset..r.len].clone() }
 
 	// asking for more bytes than buffer contains after refill
 	if n > r.len {

--- a/vlib/io/buffered_reader_test.v
+++ b/vlib/io/buffered_reader_test.v
@@ -207,7 +207,7 @@ fn test_peek_refills_buffer() {
 	}
 }
 
-fn test_read_hadnles_eof_with_unread_data() {
+fn test_read_handles_eof_with_unread_data() {
 	data := rand.bytes(8)!
 	mut br := new_one_byte_buffered_reader(data, 16)
 	mut p := br.peek(10)!
@@ -223,7 +223,7 @@ fn test_read_hadnles_eof_with_unread_data() {
 	br.read(mut res) or { assert err is Eof }
 }
 
-fn test_read_line_hadnles_eof_with_unread_data() {
+fn test_read_line_handles_eof_with_unread_data() {
 	b := rand.bytes(8)!
 	data := arrays.concat(b, `\n`)
 	mut br := new_one_byte_buffered_reader(data, 16)
@@ -234,7 +234,7 @@ fn test_read_line_hadnles_eof_with_unread_data() {
 	assert p.len == 9
 
 	line := br.read_line()!
-	assert line.len == 8
+	assert line.len == 8 // read_line return doesn't include \n
 
 	br.read_line() or { assert err is Eof }
 }

--- a/vlib/io/buffered_reader_test.v
+++ b/vlib/io/buffered_reader_test.v
@@ -28,7 +28,7 @@ fn new_array_buffered_reader(a []u8, cap ?int) &BufferedReader {
 	return new_buffered_reader(reader: r)
 }
 
-fn test_buffered_reader_read_basic() {
+fn test_read_basic() {
 	data := rand.bytes(16)!
 	mut br := new_array_buffered_reader(data)
 	mut res := []u8{len: 16}
@@ -39,14 +39,14 @@ fn test_buffered_reader_read_basic() {
 	}
 }
 
-fn test_buffered_reader_empty() {
+fn test_empty() {
 	data := []u8{}
 	mut br := new_array_buffered_reader(data)
 	mut res := []u8{len: 16}
 	br.read(mut res) or { assert err is Eof }
 }
 
-fn test_buffered_reader_peek_basic() {
+fn test_peek_basic() {
 	data := rand.bytes(16)!
 	mut br := new_array_buffered_reader(data)
 	mut p := br.peek(4)!
@@ -63,7 +63,7 @@ fn test_buffered_reader_peek_basic() {
 	}
 }
 
-fn test_buffered_reader_peek_does_not_advance_offset() {
+fn test_peek_does_not_advance_offset() {
 	data := rand.bytes(16)!
 	mut br := new_array_buffered_reader(data)
 	p := br.peek(8)!
@@ -75,7 +75,7 @@ fn test_buffered_reader_peek_does_not_advance_offset() {
 	}
 }
 
-fn test_buffered_reader_peek_refill_buffer() {
+fn test_peek_refill_buffer() {
 	data := rand.bytes(16)!
 	mut br := new_array_buffered_reader(data, 6)
 	mut p := br.peek(4)!
@@ -92,7 +92,7 @@ fn test_buffered_reader_peek_refill_buffer() {
 	}
 }
 
-fn test_buffered_reader_peek_reaches_eof() {
+fn test_peek_reaches_eof() {
 	data := rand.bytes(8)!
 	mut br := new_array_buffered_reader(data, 6)
 	mut res := []u8{len: 4}
@@ -105,7 +105,7 @@ fn test_buffered_reader_peek_reaches_eof() {
 	br.read(mut res) or { assert err is Eof }
 }
 
-fn test_buffered_reader_peek_too_many_bytes() {
+fn test_peek_too_many_bytes() {
 	data := rand.bytes(8)!
 	mut br := new_array_buffered_reader(data)
 	mut p := br.peek(16)!
@@ -115,7 +115,7 @@ fn test_buffered_reader_peek_too_many_bytes() {
 	}
 }
 
-fn test_buffered_reader_peek_repeated() {
+fn test_peek_repeated() {
 	data := rand.bytes(8)!
 	mut br := new_array_buffered_reader(data)
 	for j := 0; j < 8; j++ {
@@ -132,4 +132,24 @@ fn test_buffered_reader_peek_repeated() {
 	for i, byte in res {
 		assert data[i] == res[i]
 	}
+}
+
+fn test_peek_zero_and_negative() {
+	data := rand.bytes(8)!
+	mut br := new_array_buffered_reader(data, none)
+	p := br.peek(0)!
+	assert p.len == 0
+	br.peek(-1) or { assert true }
+}
+
+fn test_peek_does_not_advance_total_read() {
+	data := rand.bytes(8)!
+	mut br := new_array_buffered_reader(data, none)
+	br.peek(4)!
+	assert br.total_read == 0
+	mut res := []u8{len: 4}
+	br.read(mut res)!
+	assert br.total_read == 4
+	br.peek(4)!
+	assert br.total_read == 4
 }

--- a/vlib/io/buffered_reader_test.v
+++ b/vlib/io/buffered_reader_test.v
@@ -1,0 +1,135 @@
+module io
+
+import rand
+
+struct ArrayReader {
+	a []u8
+mut:
+	i int
+}
+
+fn new_array_reader(a []u8) &ArrayReader {
+	return &ArrayReader{
+		a: a
+	}
+}
+
+fn (mut r ArrayReader) read(mut buf []u8) !int {
+	read := copy(mut buf, r.a[r.i..])
+	r.i += read
+	return read
+}
+
+fn new_array_buffered_reader(a []u8, cap ?int) &BufferedReader {
+	r := new_array_reader(a)
+	if c := cap {
+		return new_buffered_reader(reader: r, cap: c)
+	}
+	return new_buffered_reader(reader: r)
+}
+
+fn test_buffered_reader_read_basic() {
+	data := rand.bytes(16)!
+	mut br := new_array_buffered_reader(data)
+	mut res := []u8{len: 16}
+	r := br.read(mut res)!
+	assert r == 16
+	for i, byte in res {
+		assert data[i] == res[i]
+	}
+}
+
+fn test_buffered_reader_empty() {
+	data := []u8{}
+	mut br := new_array_buffered_reader(data)
+	mut res := []u8{len: 16}
+	br.read(mut res) or { assert err is Eof }
+}
+
+fn test_buffered_reader_peek_basic() {
+	data := rand.bytes(16)!
+	mut br := new_array_buffered_reader(data)
+	mut p := br.peek(4)!
+	for i, byte in p {
+		assert data[i] == p[i]
+	}
+
+	mut read := []u8{len: 2}
+	br.read(mut read)!
+
+	p = br.peek(4)!
+	for i, byte in p {
+		assert data[i + 2] == p[i]
+	}
+}
+
+fn test_buffered_reader_peek_does_not_advance_offset() {
+	data := rand.bytes(16)!
+	mut br := new_array_buffered_reader(data)
+	p := br.peek(8)!
+	mut res := []u8{len: 8}
+	r := br.read(mut res)!
+	assert r == 8
+	for i, byte in res {
+		assert data[i] == res[i]
+	}
+}
+
+fn test_buffered_reader_peek_refill_buffer() {
+	data := rand.bytes(16)!
+	mut br := new_array_buffered_reader(data, 6)
+	mut p := br.peek(4)!
+	for i, byte in p {
+		assert data[i] == p[i]
+	}
+
+	mut read := []u8{len: 4}
+	br.read(mut read)!
+
+	p = br.peek(4)!
+	for i, byte in p {
+		assert data[i + 4] == p[i]
+	}
+}
+
+fn test_buffered_reader_peek_reaches_eof() {
+	data := rand.bytes(8)!
+	mut br := new_array_buffered_reader(data, 6)
+	mut res := []u8{len: 4}
+	br.read(mut res)!
+
+	p := br.peek(4)!
+
+	r := br.read(mut res)!
+	assert r == 4
+	br.read(mut res) or { assert err is Eof }
+}
+
+fn test_buffered_reader_peek_too_many_bytes() {
+	data := rand.bytes(8)!
+	mut br := new_array_buffered_reader(data)
+	mut p := br.peek(16)!
+	assert p.len == 8
+	for i, byte in p {
+		assert data[i] == p[i]
+	}
+}
+
+fn test_buffered_reader_peek_repeated() {
+	data := rand.bytes(8)!
+	mut br := new_array_buffered_reader(data)
+	for j := 0; j < 8; j++ {
+		mut p := br.peek(6)!
+		assert p.len == 6
+		for i, byte in p {
+			assert data[i] == p[i]
+		}
+	}
+
+	mut res := []u8{len: 8}
+	r := br.read(mut res)!
+	assert r == 8
+	for i, byte in res {
+		assert data[i] == res[i]
+	}
+}

--- a/vlib/io/buffered_reader_test.v
+++ b/vlib/io/buffered_reader_test.v
@@ -34,7 +34,7 @@ fn test_read_basic() {
 	mut res := []u8{len: 16}
 	r := br.read(mut res)!
 	assert r == 16
-	for i, byte in res {
+	for i, _ in res {
 		assert data[i] == res[i]
 	}
 }
@@ -50,7 +50,7 @@ fn test_peek_basic() {
 	data := rand.bytes(16)!
 	mut br := new_array_buffered_reader(data)
 	mut p := br.peek(4)!
-	for i, byte in p {
+	for i, _ in p {
 		assert data[i] == p[i]
 	}
 
@@ -58,7 +58,7 @@ fn test_peek_basic() {
 	br.read(mut read)!
 
 	p = br.peek(4)!
-	for i, byte in p {
+	for i, _ in p {
 		assert data[i + 2] == p[i]
 	}
 }
@@ -70,7 +70,7 @@ fn test_peek_does_not_advance_offset() {
 	mut res := []u8{len: 8}
 	r := br.read(mut res)!
 	assert r == 8
-	for i, byte in res {
+	for i, _ in res {
 		assert data[i] == res[i]
 	}
 }
@@ -79,7 +79,7 @@ fn test_peek_refill_buffer() {
 	data := rand.bytes(16)!
 	mut br := new_array_buffered_reader(data, 6)
 	mut p := br.peek(4)!
-	for i, byte in p {
+	for i, _ in p {
 		assert data[i] == p[i]
 	}
 
@@ -87,7 +87,7 @@ fn test_peek_refill_buffer() {
 	br.read(mut read)!
 
 	p = br.peek(4)!
-	for i, byte in p {
+	for i, _ in p {
 		assert data[i + 4] == p[i]
 	}
 }
@@ -98,7 +98,8 @@ fn test_peek_reaches_eof() {
 	mut res := []u8{len: 4}
 	br.read(mut res)!
 
-	p := br.peek(4)!
+	p := br.peek(4)! // offset now at 4, buffer has 2 bytes, need to read source for more
+	assert p.len == 4
 
 	r := br.read(mut res)!
 	assert r == 4
@@ -110,7 +111,7 @@ fn test_peek_too_many_bytes() {
 	mut br := new_array_buffered_reader(data)
 	mut p := br.peek(16)!
 	assert p.len == 8
-	for i, byte in p {
+	for i, _ in p {
 		assert data[i] == p[i]
 	}
 }
@@ -121,7 +122,7 @@ fn test_peek_repeated() {
 	for j := 0; j < 8; j++ {
 		mut p := br.peek(6)!
 		assert p.len == 6
-		for i, byte in p {
+		for i, _ in p {
 			assert data[i] == p[i]
 		}
 	}
@@ -129,14 +130,14 @@ fn test_peek_repeated() {
 	mut res := []u8{len: 8}
 	r := br.read(mut res)!
 	assert r == 8
-	for i, byte in res {
+	for i, _ in res {
 		assert data[i] == res[i]
 	}
 }
 
 fn test_peek_zero_and_negative() {
 	data := rand.bytes(8)!
-	mut br := new_array_buffered_reader(data, none)
+	mut br := new_array_buffered_reader(data)
 	p := br.peek(0)!
 	assert p.len == 0
 	br.peek(-1) or { assert true }
@@ -144,7 +145,7 @@ fn test_peek_zero_and_negative() {
 
 fn test_peek_does_not_advance_total_read() {
 	data := rand.bytes(8)!
-	mut br := new_array_buffered_reader(data, none)
+	mut br := new_array_buffered_reader(data)
 	br.peek(4)!
 	assert br.total_read == 0
 	mut res := []u8{len: 4}
@@ -152,4 +153,79 @@ fn test_peek_does_not_advance_total_read() {
 	assert br.total_read == 4
 	br.peek(4)!
 	assert br.total_read == 4
+}
+
+struct OneByteReader {
+	a []u8
+mut:
+	i int
+}
+
+fn new_one_byte_reader(a []u8) &OneByteReader {
+	return &OneByteReader{
+		a: a
+	}
+}
+
+fn new_one_byte_buffered_reader(a []u8, cap ?int) &BufferedReader {
+	r := new_one_byte_reader(a)
+	return new_buffered_reader(reader: r)
+}
+
+fn (mut r OneByteReader) read(mut buf []u8) !int {
+	if r.i == r.a.len {
+		return Eof{}
+	}
+	read := copy(mut buf, [r.a[r.i]])
+	r.i++
+	return read
+}
+
+fn test_read_refills_buffer() {
+	data := 'abc'.bytes()
+	mut br := new_one_byte_buffered_reader(data)
+	mut res := []u8{len: 4}
+	read := br.read(mut res)!
+	assert read == data.len
+	for i := 0; i < read; i++ {
+		assert data[i] == res[i]
+	}
+}
+
+fn test_peek_refills_buffer() {
+	data := 'abc'.bytes()
+	mut br := new_one_byte_buffered_reader(data)
+	p := br.peek(4)!
+	assert p.len == 3
+
+	mut res := []u8{len: 4}
+	read := br.read(mut res)!
+	assert read == data.len
+	for i := 0; i < read; i++ {
+		assert data[i] == res[i]
+	}
+}
+
+// https://github.com/vlang/v/pull/27928#issuecomment-5079703057
+struct EofAfterDataReader {
+	data []u8
+mut:
+	offset int
+}
+
+fn (mut r EofAfterDataReader) read(mut buf []u8) !int {
+	if r.offset >= r.data.len {
+		return Eof{}
+	}
+	n := copy(mut buf, r.data[r.offset..])
+	r.offset += n
+	return n
+}
+
+fn test_peek_does_not_return_stale_bytes() {
+	mut source := &EofAfterDataReader{
+		data: 'abc'.bytes()
+	}
+	mut reader := new_buffered_reader(reader: source, cap: 4)
+	assert reader.peek(4)! == 'abc'.bytes()
 }

--- a/vlib/io/buffered_reader_test.v
+++ b/vlib/io/buffered_reader_test.v
@@ -182,6 +182,22 @@ fn (mut r OneByteReader) read(mut buf []u8) !int {
 	return read
 }
 
+fn test_peek_zero_bytes() {
+	data := rand.bytes(4)!
+	mut br := new_one_byte_buffered_reader(data)
+	mut p := br.peek(0)!
+	assert p.len == 0
+
+	p = br.peek(0)!
+	assert p.len == 0
+
+	p = br.peek(1)!
+	assert p.len == 1
+
+	p = br.peek(0)!
+	assert p.len == 0
+}
+
 fn test_read_refills_buffer() {
 	data := 'abc'.bytes()
 	mut br := new_one_byte_buffered_reader(data)

--- a/vlib/io/buffered_reader_test.v
+++ b/vlib/io/buffered_reader_test.v
@@ -1,6 +1,7 @@
 module io
 
 import rand
+import arrays
 
 struct ArrayReader {
 	a []u8
@@ -204,6 +205,38 @@ fn test_peek_refills_buffer() {
 	for i := 0; i < read; i++ {
 		assert data[i] == res[i]
 	}
+}
+
+fn test_read_hadnles_eof_with_unread_data() {
+	data := rand.bytes(8)!
+	mut br := new_one_byte_buffered_reader(data, 16)
+	mut p := br.peek(10)!
+	assert p.len == 8
+
+	p = br.peek(8)!
+	assert p.len == 8
+
+	mut res := []u8{len: 10}
+	mut read := br.read(mut res)!
+	assert read == 8
+
+	br.read(mut res) or { assert err is Eof }
+}
+
+fn test_read_line_hadnles_eof_with_unread_data() {
+	b := rand.bytes(8)!
+	data := arrays.concat(b, `\n`)
+	mut br := new_one_byte_buffered_reader(data, 16)
+	mut p := br.peek(10)!
+	assert p.len == 9
+
+	p = br.peek(9)!
+	assert p.len == 9
+
+	line := br.read_line()!
+	assert line.len == 8
+
+	br.read_line() or { assert err is Eof }
 }
 
 // https://github.com/vlang/v/pull/27928#issuecomment-5079703057


### PR DESCRIPTION
Fix #27915 
Lacks tests, looking for feedback, please take over this pull request.

Adds peek method: this method reads n bytes from the buffer without advancing the cursor (offset). Unlike read, it returns a clone of the byte slice.
This method refills the buffer if there is not enough data to satisfy the request.
Handles when the requests asks for too much data: more than the buffer can hold, and more than the reader can read.
Refactors the read method to read bytes even though the enf of the stream has been reached: this is because peek may refill the buffer and encounted the end of stream, a situation that wasn't possible before.
This method should not lose any unread data from the internal buffer, it can discard read data to get more unread data. It should return the exact number of u8 requested, or less when reaching eof or when n is larger than the internal buffer capacity.