### PR TITLE
v3: fix cached pthread externs and parallel self-hosting

### DIFF
--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -12946,11 +12946,14 @@ const c_preamble_declared_extern_symbols = {
 	'pthread_cond_wait':             true
 	'pthread_create':                true
 	'pthread_detach':                true
+	'pthread_getspecific':           true
 	'pthread_join':                  true
+	'pthread_key_create':            true
 	'pthread_mutex_destroy':         true
 	'pthread_mutex_init':            true
 	'pthread_mutex_lock':            true
 	'pthread_mutex_unlock':          true
+	'pthread_setspecific':           true
 	'malloc':                        true
 	'calloc':                        true
 	'realloc':                       true

--- a/vlib/v3/gen/c/source_directive_test.v
+++ b/vlib/v3/gen/c/source_directive_test.v
@@ -68,6 +68,24 @@ fn test_cache_extern_declaration_avoids_tgmath_macro_expansion() {
 	assert c_macro_safe_extern_decl('custom', 'int custom(int x);') == 'int custom(int x);'
 }
 
+fn test_cache_extern_filter_uses_pthread_preamble_declarations() {
+	mut preamble_gen := FlatGen.new()
+	preamble_gen.preamble()
+	preamble := preamble_gen.sb.str()
+	assert preamble.contains('int pthread_key_create(pthread_key_t* key, void (*dtor)(void*));')
+	assert preamble.contains('void* pthread_getspecific(pthread_key_t key);')
+	assert preamble.contains('int pthread_setspecific(pthread_key_t key, const void* const_ptr);')
+	assert !preamble.contains('pthread_key_delete(')
+
+	mut g := FlatGen.new()
+	g.set_cache_split(true)
+
+	assert !g.should_emit_c_extern_decl('pthread_key_create')
+	assert !g.should_emit_c_extern_decl('pthread_getspecific')
+	assert !g.should_emit_c_extern_decl('pthread_setspecific')
+	assert g.should_emit_c_extern_decl('pthread_key_delete')
+}
+
 fn test_builtin_abi_compat_macros_precede_late_c_source() {
 	mut g := FlatGen.new()
 	g.has_builtins = true

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -56,6 +56,45 @@ fn run_module_cache_binary(path string) string {
 	return result.output.trim_space()
 }
 
+fn test_cached_sync_module_uses_preamble_pthread_declarations() {
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_module_cache_sync_pthread_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'module main
+
+import sync
+
+fn main() {
+	mut m := sync.new_mutex()
+	m.lock()
+	m.unlock()
+	m.destroy()
+	println("V3_CACHE_SYNC_OK")
+}
+')
+	cache_dir := os.join_path(root, 'cache')
+	first_output := os.join_path(root, 'first')
+	first :=
+		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -o ${os.quoted_path(first_output)} ${os.quoted_path(main_file)}')
+	assert first.exit_code == 0, first.output
+	assert !first.output.contains('check (cached)'), first.output
+	assert run_module_cache_binary(first_output) == 'V3_CACHE_SYNC_OK'
+
+	second_output := os.join_path(root, 'second')
+	second :=
+		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -o ${os.quoted_path(second_output)} ${os.quoted_path(main_file)}')
+	assert second.exit_code == 0, second.output
+	assert second.output.contains('check (cached)'), second.output
+	assert second.output.contains('C module plan (cached)'), second.output
+	assert second.output.contains('cgen (cached)'), second.output
+	assert run_module_cache_binary(second_output) == 'V3_CACHE_SYNC_OK'
+}
+
 fn test_cached_header_preserves_mutable_pointer_parameters() {
 	v3_bin := build_module_cache_v3()
 	root := os.join_path(os.temp_dir(), 'v3_cached_mut_pointer_param_${os.getpid()}')

--- a/vlib/v3/tests/parallel_cgen_test.v
+++ b/vlib/v3/tests/parallel_cgen_test.v
@@ -369,23 +369,32 @@ fn test_prealloc_keeps_parallel_transform_enabled() {
 	assert compile.output.contains('cgen (parallel)'), compile.output
 }
 
-fn test_parallel_transform_selfhost_builds_v3() {
+fn test_parallel_transform_generates_v3_c_with_vjobs_4_and_12() {
 	v3_bin := build_parallel_prod_v3()
-	bin_out := os.join_path(os.temp_dir(), 'v3_parallel_selfhost_out_${os.getpid()}')
-	os.rm(bin_out) or {}
-	os.rm(bin_out + '.c') or {}
-	compile := os.execute('VJOBS=2 ${v3_bin} -nocache -building-v -o ${bin_out} ${parallel_v3_src}')
-	assert compile.exit_code == 0, compile.output
-	assert compile.output.contains('transform'), compile.output
-	assert compile.output.contains('cgen (parallel)'), compile.output
-	assert os.exists(bin_out), compile.output
-	c_code := os.read_file(bin_out + '.c') or { panic(err) }
+	c_out_4 := os.join_path(os.temp_dir(), 'v3_parallel_selfhost_out_4_${os.getpid()}.c')
+	os.rm(c_out_4) or {}
+	cgen_4 :=
+		os.execute('VJOBS=4 ${v3_bin} -nocache -building-v -b c -o ${c_out_4} ${parallel_v3_src}')
+	assert cgen_4.exit_code == 0, cgen_4.output
+	assert cgen_4.output.contains('transform (parallel)'), cgen_4.output
+	assert cgen_4.output.contains('cgen (parallel)'), cgen_4.output
+	assert os.exists(c_out_4), cgen_4.output
+	c_code := os.read_file(c_out_4) or { panic(err) }
 	assert c_code.contains('Array_u8__bytestr'), c_code
 	assert c_code.contains('Array_u8__hex'), c_code
 	assert c_code.contains('typedef void* pthread_t;'), c_code
 	assert !c_code.contains('typedef struct pthread_t pthread_t;'), c_code
 	assert c_code.contains('flat_cgen_chunk_thread'), c_code
 	assert c_code.contains('run_parallel_transform'), c_code
+
+	c_out_12 := os.join_path(os.temp_dir(), 'v3_parallel_selfhost_out_12_${os.getpid()}.c')
+	os.rm(c_out_12) or {}
+	cgen_12 :=
+		os.execute('VJOBS=12 ${v3_bin} -nocache -building-v -b c -o ${c_out_12} ${parallel_v3_src}')
+	assert cgen_12.exit_code == 0, cgen_12.output
+	assert cgen_12.output.contains('transform (parallel)'), cgen_12.output
+	assert cgen_12.output.contains('cgen (parallel)'), cgen_12.output
+	assert os.exists(c_out_12), cgen_12.output
 }
 
 fn test_no_parallel_directory_selfhost_omits_parallel_support() {

--- a/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
@@ -18,14 +18,6 @@ const max_parallel_transform_jobs = 7
 // append into pre-partitioned capacity regions, so extra threads cost no
 // clone memory; cap by core count only.
 const max_shared_transform_jobs = 10
-// Split the shared-base transform into more chunks than pool threads: the
-// persistent pool hands queued chunks to whichever worker frees up first, so
-// finer chunks level the load across asymmetric (performance/efficiency)
-// cores while the fixed region merge order keeps node ids deterministic.
-const shared_transform_chunk_factor = 3
-// Keep enough items per chunk that per-chunk append-region headroom (sized
-// proportionally to estimated cost) still averages out expansion variance.
-const min_shared_transform_chunk_items = 24
 const max_parallel_monomorph_jobs = 10
 const scoped_transform_worker_batches = 1
 const scoped_transform_master_batches = 1
@@ -1373,21 +1365,9 @@ fn (mut t Transformer) run_parallel_transform_shared(items []FnWorkItem, base_no
 		return false
 	} $else {
 		t.tc.freeze_type_cache_for_forks()
-		mut chunk_target := n_jobs * shared_transform_chunk_factor
-		max_chunks_by_items := items.len / min_shared_transform_chunk_items
-		if chunk_target > max_chunks_by_items {
-			chunk_target = max_chunks_by_items
-		}
-		if chunk_target < n_jobs {
-			chunk_target = n_jobs
-		}
-		mut chunks := split_work_items_ex(items, chunk_target, false)
+		mut chunks := split_work_items_ex(items, n_jobs, false)
 		chunk_count := chunks.len
 		thread_count := chunk_count - 1
-		// The master transforms chunk 0 in place and then this many additional
-		// forked chunks synchronously (keeping its former ~1/n_jobs share),
-		// while the pool workers drain the rest of the queue dynamically.
-		master_sync_chunks := chunk_count / n_jobs - 1
 		// Partition the reserved capacity into per-chunk append regions,
 		// proportional to chunk cost (the caller reserved ~2x the expected
 		// total growth for this pool).
@@ -1456,8 +1436,7 @@ fn (mut t Transformer) run_parallel_transform_shared(items []FnWorkItem, base_no
 			tasks << workers.Task{
 				run:        shared_chunk_thread
 				arg:        unsafe { voidptr(&args[ci]) }
-				force_sync: ci <= master_sync_chunks || fail == 'transform:all'
-					|| fail == 'transform:${helper_idx}'
+				force_sync: ci == 0 || fail == 'transform:all' || fail == 'transform:${helper_idx}'
 			}
 		}
 		transform_worker_scope_leave(setup_scope)


### PR DESCRIPTION
## Summary

This fixes the two V3 failures reported in #27929.

- Treat `pthread_key_create`, `pthread_getspecific`, and `pthread_setspecific` as declarations owned by the V3 C preamble during cache-split generation.
- Keep `pthread_key_delete` emitted separately because it is not declared by the preamble.
- Remove the artificial 3x transform chunk oversplitting and restore one shared append region per worker job.
- Preserve the `.nogrow` ownership guard, deterministic merge order, and the existing maximum worker count.
- Add regressions for pthread declaration ownership, cold/warm cached module compilation, and parallel V3 C generation with `VJOBS=4` and `VJOBS=12`.

## Validation

- Cold and warm V3 cache builds pass and run with TCC, GCC, and Clang.
- The generated C contains one compatible pthread declaration without conflicting `u64` prototypes.
- Parallel V3 C generation passes with `VJOBS=4` and `VJOBS=12`.
- Targeted tests, `v fmt -verify`, and `git diff --check` pass.

Fixes #27929