### PR TITLE
v3: fix native declarations in self-hosting

### DIFF
--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -94,6 +94,13 @@ struct SumUniqueFieldInfo {
 	typ     types.Type
 }
 
+struct ParallelChunkWrapperDefs {
+	chunk_idx int
+mut:
+	spawn    []string
+	callback []string
+}
+
 // FlatGen emits flat gen output used by c.
 pub struct FlatGen {
 mut:
@@ -106,6 +113,8 @@ mut:
 	top_level_node_ids             []int
 	fn_segs                        []string
 	fn_seg_chunk_indexes           []int
+	parallel_chunk_wrapper_defs    []ParallelChunkWrapperDefs
+	parallel_chunk_wrapper_capture int = -1
 	parallel_type_decls            string
 	parallel_forward_decls         string
 	parallel_const_code            string
@@ -670,6 +679,7 @@ pub fn FlatGen.new() FlatGen {
 		top_level_node_ids:             []int{}
 		fn_segs:                        []string{}
 		fn_seg_chunk_indexes:           []int{}
+		parallel_chunk_wrapper_defs:    []ParallelChunkWrapperDefs{}
 		test_files:                     map[string]bool{}
 		cache_program_files:            map[string]bool{}
 		incremental_fn_names:           map[string]bool{}
@@ -1548,6 +1558,8 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	g.unsafe_depth = 0
 	g.fn_segs = []string{}
 	g.fn_seg_chunk_indexes = []int{}
+	g.parallel_chunk_wrapper_defs = []ParallelChunkWrapperDefs{}
+	g.parallel_chunk_wrapper_capture = -1
 	g.parallel_type_decls = ''
 	g.parallel_forward_decls = ''
 	g.parallel_const_code = ''

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -2533,6 +2533,9 @@ fn (mut g FlatGen) spawn_wrapper_decls() {
 }
 
 fn (mut g FlatGen) add_spawn_wrapper_def(def string) {
+	if g.parallel_chunk_wrapper_capture >= 0 {
+		g.parallel_chunk_wrapper_defs[g.parallel_chunk_wrapper_capture].spawn << def.clone()
+	}
 	if g.spawn_wrapper_defs_seen[def] {
 		return
 	}
@@ -2541,6 +2544,9 @@ fn (mut g FlatGen) add_spawn_wrapper_def(def string) {
 }
 
 fn (mut g FlatGen) add_callback_wrapper_def(def string) {
+	if g.parallel_chunk_wrapper_capture >= 0 {
+		g.parallel_chunk_wrapper_defs[g.parallel_chunk_wrapper_capture].callback << def.clone()
+	}
 	if g.callback_wrapper_defs_seen[def] {
 		return
 	}
@@ -12767,7 +12773,11 @@ fn (g &FlatGen) should_emit_c_extern_decl(cfn string) bool {
 	if cfn.contains('.') {
 		return false
 	}
-	if g.c_directives_use_system_libc() && cfn in c_system_libc_preamble_declared_fns {
+	if cfn in ['sem_destroy', 'sem_init', 'sem_post', 'sem_timedwait', 'sem_trywait', 'sem_wait']
+		&& g.target.os in ['linux', 'android', 'termux'] && g.c_directives_use_system_libc() {
+		return false
+	}
+	if cfn in c_system_libc_preamble_declared_fns && g.c_directives_use_system_libc() {
 		return false
 	}
 	if g.cache_split && cfn in c_cache_system_header_declared_fns {

--- a/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
@@ -397,6 +397,13 @@ fn (mut g FlatGen) absorb_scoped_cgen_batch(batch &FlatGen, output_streamed bool
 			g.add_callback_wrapper_def(def.clone())
 		}
 	}
+	for wrappers in batch.parallel_chunk_wrapper_defs {
+		g.parallel_chunk_wrapper_defs << ParallelChunkWrapperDefs{
+			chunk_idx: wrappers.chunk_idx
+			spawn:     clone_cgen_string_list(wrappers.spawn)
+			callback:  clone_cgen_string_list(wrappers.callback)
+		}
+	}
 }
 
 // gen_fn_items_scoped_batches bounds helper scratch without adding worker-pool
@@ -448,8 +455,13 @@ fn (mut g FlatGen) gen_fn_chunks_scoped_dynamic(chunks [][]FlatFnGenItem, chunk_
 	mut output_lengths := []int{cap: 16}
 	for {
 		chunk_idx := <-chunk_queue or { break }
+		batch.parallel_chunk_wrapper_defs << ParallelChunkWrapperDefs{
+			chunk_idx: chunk_idx
+		}
+		batch.parallel_chunk_wrapper_capture = batch.parallel_chunk_wrapper_defs.len - 1
 		output_start := batch.sb.len
 		batch.gen_fn_items(chunks[chunk_idx])
+		batch.parallel_chunk_wrapper_capture = -1
 		chunk_indexes << chunk_idx
 		output_starts << output_start
 		output_lengths << batch.sb.len - output_start
@@ -611,6 +623,7 @@ fn (mut g FlatGen) gen_fns_dispatch(no_parallel bool) {
 			worker_count := if static_dispatch { chunk_count } else { n_jobs }
 			mut cgen_workers := []voidptr{cap: worker_count}
 			mut ordered_chunk_outputs := []string{}
+			mut ordered_wrapper_defs := []ParallelChunkWrapperDefs{}
 			worker_setup_scope := cgen_worker_scope_begin(true)
 			for ci := 0; ci < worker_count; ci++ {
 				mut w := g.new_parallel_dispatch_worker(ci)
@@ -643,6 +656,7 @@ fn (mut g FlatGen) gen_fns_dispatch(no_parallel bool) {
 				// queue. This balances expression-cost and scheduler variation without
 				// rebuilding the generator caches for every chunk.
 				ordered_chunk_outputs = []string{len: chunk_count}
+				ordered_wrapper_defs = []ParallelChunkWrapperDefs{len: chunk_count}
 				chunk_queue := chan int{cap: chunk_count}
 				for ci in 0 .. chunk_count {
 					chunk_queue <- ci
@@ -678,7 +692,8 @@ fn (mut g FlatGen) gen_fns_dispatch(no_parallel bool) {
 			for worker_ptr in cgen_workers {
 				mut w := unsafe { &FlatGen(worker_ptr) }
 				if ordered_chunk_outputs.len > 0 {
-					g.merge_parallel_worker_ordered(w, mut ordered_chunk_outputs)
+					g.merge_parallel_worker_ordered(w, mut ordered_chunk_outputs, mut
+						ordered_wrapper_defs)
 				} else {
 					g.merge_parallel_worker(w)
 				}
@@ -687,6 +702,7 @@ fn (mut g FlatGen) gen_fns_dispatch(no_parallel bool) {
 					w.worker_scope = unsafe { nil }
 				}
 			}
+			g.replay_ordered_parallel_wrapper_defs(ordered_wrapper_defs)
 			for output in ordered_chunk_outputs {
 				if output.len > 0 {
 					g.fn_segs << output
@@ -1561,14 +1577,15 @@ fn remap_scoped_worker_string_symbols(source string, remap map[int]int, user_c_s
 // merge_parallel_worker supports merge parallel worker handling for FlatGen.
 fn (mut g FlatGen) merge_parallel_worker(w &FlatGen) {
 	mut unordered := []string{}
-	g.merge_parallel_worker_into(w, mut unordered)
+	mut unordered_wrapper_defs := []ParallelChunkWrapperDefs{}
+	g.merge_parallel_worker_into(w, mut unordered, mut unordered_wrapper_defs)
 }
 
-fn (mut g FlatGen) merge_parallel_worker_ordered(w &FlatGen, mut ordered []string) {
-	g.merge_parallel_worker_into(w, mut ordered)
+fn (mut g FlatGen) merge_parallel_worker_ordered(w &FlatGen, mut ordered []string, mut ordered_wrapper_defs []ParallelChunkWrapperDefs) {
+	g.merge_parallel_worker_into(w, mut ordered, mut ordered_wrapper_defs)
 }
 
-fn (mut g FlatGen) merge_parallel_worker_into(w &FlatGen, mut ordered []string) {
+fn (mut g FlatGen) merge_parallel_worker_into(w &FlatGen, mut ordered []string, mut ordered_wrapper_defs []ParallelChunkWrapperDefs) {
 	mut ww := unsafe { w }
 	if g.output_error.len == 0 && w.output_error.len > 0 {
 		g.output_error = w.output_error.clone()
@@ -1654,14 +1671,32 @@ fn (mut g FlatGen) merge_parallel_worker_into(w &FlatGen, mut ordered []string) 
 			g.spawn_wrapper_names[key.clone()] = name.clone()
 		}
 	}
-	for def in w.spawn_wrapper_defs {
-		if g.cache_split {
-			g.add_spawn_wrapper_def(ww.rewrite_cache_string_symbols(def))
-		} else if string_id_remap.len > 0 {
-			g.add_spawn_wrapper_def(remap_scoped_worker_string_symbols(def, string_id_remap,
-				user_c_symbols))
-		} else {
-			g.add_spawn_wrapper_def(def.clone())
+	if ordered.len > 0 {
+		for wrappers in w.parallel_chunk_wrapper_defs {
+			if wrappers.chunk_idx < 0 || wrappers.chunk_idx >= ordered_wrapper_defs.len {
+				continue
+			}
+			for def in wrappers.spawn {
+				normalized := if g.cache_split {
+					ww.rewrite_cache_string_symbols(def)
+				} else if string_id_remap.len > 0 {
+					remap_scoped_worker_string_symbols(def, string_id_remap, user_c_symbols)
+				} else {
+					def.clone()
+				}
+				ordered_wrapper_defs[wrappers.chunk_idx].spawn << normalized
+			}
+		}
+	} else {
+		for def in w.spawn_wrapper_defs {
+			if g.cache_split {
+				g.add_spawn_wrapper_def(ww.rewrite_cache_string_symbols(def))
+			} else if string_id_remap.len > 0 {
+				g.add_spawn_wrapper_def(remap_scoped_worker_string_symbols(def, string_id_remap,
+					user_c_symbols))
+			} else {
+				g.add_spawn_wrapper_def(def.clone())
+			}
 		}
 	}
 	for key, name in w.callback_wrapper_names {
@@ -1669,14 +1704,43 @@ fn (mut g FlatGen) merge_parallel_worker_into(w &FlatGen, mut ordered []string) 
 			g.callback_wrapper_names[key.clone()] = name.clone()
 		}
 	}
-	for def in w.callback_wrapper_defs {
-		if g.cache_split {
-			g.add_callback_wrapper_def(ww.rewrite_cache_string_symbols(def))
-		} else if string_id_remap.len > 0 {
-			g.add_callback_wrapper_def(remap_scoped_worker_string_symbols(def, string_id_remap,
-				user_c_symbols))
-		} else {
-			g.add_callback_wrapper_def(def.clone())
+	if ordered.len > 0 {
+		for wrappers in w.parallel_chunk_wrapper_defs {
+			if wrappers.chunk_idx < 0 || wrappers.chunk_idx >= ordered_wrapper_defs.len {
+				continue
+			}
+			for def in wrappers.callback {
+				normalized := if g.cache_split {
+					ww.rewrite_cache_string_symbols(def)
+				} else if string_id_remap.len > 0 {
+					remap_scoped_worker_string_symbols(def, string_id_remap, user_c_symbols)
+				} else {
+					def.clone()
+				}
+				ordered_wrapper_defs[wrappers.chunk_idx].callback << normalized
+			}
+		}
+	} else {
+		for def in w.callback_wrapper_defs {
+			if g.cache_split {
+				g.add_callback_wrapper_def(ww.rewrite_cache_string_symbols(def))
+			} else if string_id_remap.len > 0 {
+				g.add_callback_wrapper_def(remap_scoped_worker_string_symbols(def, string_id_remap,
+					user_c_symbols))
+			} else {
+				g.add_callback_wrapper_def(def.clone())
+			}
+		}
+	}
+}
+
+fn (mut g FlatGen) replay_ordered_parallel_wrapper_defs(wrapper_defs []ParallelChunkWrapperDefs) {
+	for wrappers in wrapper_defs {
+		for def in wrappers.spawn {
+			g.add_spawn_wrapper_def(def)
+		}
+		for def in wrappers.callback {
+			g.add_callback_wrapper_def(def)
 		}
 	}
 }

--- a/vlib/v3/gen/c/parallel_worker_test.v
+++ b/vlib/v3/gen/c/parallel_worker_test.v
@@ -236,8 +236,74 @@ fn test_dynamic_parallel_merge_preserves_chunk_order() {
 	second.fn_segs = ['chunk-3;', 'chunk-1;']
 	second.fn_seg_chunk_indexes = [3, 1]
 	mut ordered := []string{len: 4}
+	mut ordered_wrapper_defs := []ParallelChunkWrapperDefs{len: 4}
 
-	g.merge_parallel_worker_ordered(first, mut ordered)
-	g.merge_parallel_worker_ordered(second, mut ordered)
+	g.merge_parallel_worker_ordered(first, mut ordered, mut ordered_wrapper_defs)
+	g.merge_parallel_worker_ordered(second, mut ordered, mut ordered_wrapper_defs)
 	assert ordered == ['chunk-0;', 'chunk-1;', 'chunk-2;', 'chunk-3;']
+}
+
+fn test_dynamic_parallel_merge_replays_wrapper_defs_in_chunk_order() {
+	mut g, _ := parallel_worker_test_gen(true)
+	mut high := g.new_parallel_dispatch_worker(1)
+	high.fn_segs = ['chunk-3;', 'chunk-2;']
+	high.fn_seg_chunk_indexes = [3, 2]
+	high.parallel_chunk_wrapper_defs = [
+		ParallelChunkWrapperDefs{
+			chunk_idx: 3
+			spawn:     ['spawn-3-typedef;', 'spawn-3-trampoline;', 'spawn-shared;']
+			callback:  ['callback-3;']
+		},
+		ParallelChunkWrapperDefs{
+			chunk_idx: 2
+			spawn:     ['spawn-2-typedef;', 'spawn-2-trampoline;']
+			callback:  ['callback-2;']
+		},
+	]
+
+	mut low := g.new_parallel_dispatch_worker(2)
+	low.fn_segs = ['chunk-1;', 'chunk-0;']
+	low.fn_seg_chunk_indexes = [1, 0]
+	low.parallel_chunk_wrapper_defs = [
+		ParallelChunkWrapperDefs{
+			chunk_idx: 1
+			spawn:     ['spawn-1-typedef;', 'spawn-1-trampoline;']
+			callback:  ['callback-1;']
+		},
+		ParallelChunkWrapperDefs{
+			chunk_idx: 0
+			spawn:     ['spawn-0-typedef;', 'spawn-0-trampoline;', 'spawn-shared;']
+			callback:  ['callback-0;']
+		},
+	]
+
+	mut ordered := []string{len: 4}
+	mut ordered_wrapper_defs := []ParallelChunkWrapperDefs{len: 4}
+	g.merge_parallel_worker_ordered(high, mut ordered, mut ordered_wrapper_defs)
+	g.merge_parallel_worker_ordered(low, mut ordered, mut ordered_wrapper_defs)
+	g.replay_ordered_parallel_wrapper_defs(ordered_wrapper_defs)
+
+	assert ordered == ['chunk-0;', 'chunk-1;', 'chunk-2;', 'chunk-3;']
+	assert g.spawn_wrapper_defs == ['spawn-0-typedef;', 'spawn-0-trampoline;', 'spawn-shared;',
+		'spawn-1-typedef;', 'spawn-1-trampoline;', 'spawn-2-typedef;', 'spawn-2-trampoline;',
+		'spawn-3-typedef;', 'spawn-3-trampoline;']
+	assert g.callback_wrapper_defs == ['callback-0;', 'callback-1;', 'callback-2;', 'callback-3;']
+}
+
+fn test_dynamic_parallel_chunk_capture_keeps_deduplicated_wrapper_attempts() {
+	mut g, _ := parallel_worker_test_gen(true)
+	g.parallel_chunk_wrapper_defs << ParallelChunkWrapperDefs{
+		chunk_idx: 2
+	}
+	g.parallel_chunk_wrapper_capture = 0
+	g.add_spawn_wrapper_def('spawn-shared;')
+	g.add_spawn_wrapper_def('spawn-shared;')
+	g.add_callback_wrapper_def('callback-shared;')
+	g.add_callback_wrapper_def('callback-shared;')
+	g.parallel_chunk_wrapper_capture = -1
+
+	assert g.spawn_wrapper_defs == ['spawn-shared;']
+	assert g.callback_wrapper_defs == ['callback-shared;']
+	assert g.parallel_chunk_wrapper_defs[0].spawn == ['spawn-shared;', 'spawn-shared;']
+	assert g.parallel_chunk_wrapper_defs[0].callback == ['callback-shared;', 'callback-shared;']
 }

--- a/vlib/v3/gen/c/source_directive_test.v
+++ b/vlib/v3/gen/c/source_directive_test.v
@@ -1,5 +1,9 @@
 module c
 
+import v3.flat
+import v3.pref
+import v3.types
+
 fn test_late_source_does_not_reemit_multiline_header_context() {
 	header := '#if defined(HEADER_IMPL)\n' + 'typedef struct { int value; } header_value;\n' +
 		'#endif'
@@ -84,6 +88,50 @@ fn test_cache_extern_filter_uses_pthread_preamble_declarations() {
 	assert !g.should_emit_c_extern_decl('pthread_getspecific')
 	assert !g.should_emit_c_extern_decl('pthread_setspecific')
 	assert g.should_emit_c_extern_decl('pthread_key_delete')
+}
+
+fn posix_declaration_filter_gen(target_os string, system_libc bool) FlatGen {
+	mut ast := &flat.FlatAst{}
+	mut tc := types.TypeChecker.new(ast)
+	mut g := FlatGen.new()
+	g.a = ast
+	g.tc = &tc
+	g.set_target(pref.target_from(target_os, 'amd64') or { panic(err) })
+	if system_libc {
+		g.add_c_directive('main', '#include <semaphore.h>', false)
+	}
+	return g
+}
+
+fn test_linux_family_system_libc_owns_itimerspec_and_semaphore_declarations() {
+	for target_os in ['linux', 'android', 'termux'] {
+		g := posix_declaration_filter_gen(target_os, true)
+		assert g.c_directives_use_system_libc()
+		assert g.skip_builtin_struct('C.itimerspec'), target_os
+		for name in ['sem_destroy', 'sem_init', 'sem_post', 'sem_timedwait', 'sem_trywait',
+			'sem_wait'] {
+			assert !g.should_emit_c_extern_decl(name), '${target_os}: ${name}'
+		}
+	}
+}
+
+fn test_headerless_and_cross_target_keep_itimerspec_and_semaphore_declarations() {
+	for target_os in ['linux', 'android', 'termux'] {
+		headerless := posix_declaration_filter_gen(target_os, false)
+		assert !headerless.c_directives_use_system_libc()
+		assert !headerless.skip_builtin_struct('C.itimerspec'), target_os
+		for name in ['sem_destroy', 'sem_init', 'sem_post', 'sem_timedwait', 'sem_trywait',
+			'sem_wait'] {
+			assert headerless.should_emit_c_extern_decl(name), '${target_os}: ${name}'
+		}
+	}
+
+	cross_target := posix_declaration_filter_gen('freebsd', true)
+	assert cross_target.c_directives_use_system_libc()
+	assert !cross_target.skip_builtin_struct('C.itimerspec')
+	for name in ['sem_destroy', 'sem_init', 'sem_post', 'sem_timedwait', 'sem_trywait', 'sem_wait'] {
+		assert cross_target.should_emit_c_extern_decl(name), name
+	}
 }
 
 fn test_builtin_abi_compat_macros_precede_late_c_source() {

--- a/vlib/v3/gen/c/struct.v
+++ b/vlib/v3/gen/c/struct.v
@@ -4487,7 +4487,11 @@ fn (g &FlatGen) skip_builtin_struct(name string) bool {
 				return true
 			}
 		}
-		if g.c_directives_use_system_libc() && name[2..] in c_system_header_struct_names {
+		if name == 'C.itimerspec' && g.target.os in ['linux', 'android', 'termux']
+			&& g.c_directives_use_system_libc() {
+			return true
+		}
+		if name[2..] in c_system_header_struct_names && g.c_directives_use_system_libc() {
 			return true
 		}
 	}

--- a/vlib/v3/modulecache/file_metadata.h
+++ b/vlib/v3/modulecache/file_metadata.h
@@ -6,33 +6,33 @@
 #if defined(__APPLE__) || defined(__linux__)
 #include <sys/stat.h>
 
-static int v3_modulecache_file_metadata(const char *path, uint64_t *device, uint64_t *inode,
-	uint64_t *size, uint64_t *mtime_seconds, uint64_t *mtime_nanoseconds,
-	uint64_t *ctime_seconds, uint64_t *ctime_nanoseconds) {
+static int v3_modulecache_file_metadata(const char *path, u64 *device, u64 *inode,
+	u64 *size, u64 *mtime_seconds, u64 *mtime_nanoseconds,
+	u64 *ctime_seconds, u64 *ctime_nanoseconds) {
 	struct stat info;
 	if (stat(path, &info) != 0) {
 		return 0;
 	}
-	*device = (uint64_t)info.st_dev;
-	*inode = (uint64_t)info.st_ino;
-	*size = (uint64_t)info.st_size;
+	*device = (u64)info.st_dev;
+	*inode = (u64)info.st_ino;
+	*size = (u64)info.st_size;
 #if defined(__APPLE__)
-	*mtime_seconds = (uint64_t)info.st_mtimespec.tv_sec;
-	*mtime_nanoseconds = (uint64_t)info.st_mtimespec.tv_nsec;
-	*ctime_seconds = (uint64_t)info.st_ctimespec.tv_sec;
-	*ctime_nanoseconds = (uint64_t)info.st_ctimespec.tv_nsec;
+	*mtime_seconds = (u64)info.st_mtimespec.tv_sec;
+	*mtime_nanoseconds = (u64)info.st_mtimespec.tv_nsec;
+	*ctime_seconds = (u64)info.st_ctimespec.tv_sec;
+	*ctime_nanoseconds = (u64)info.st_ctimespec.tv_nsec;
 #else
-	*mtime_seconds = (uint64_t)info.st_mtim.tv_sec;
-	*mtime_nanoseconds = (uint64_t)info.st_mtim.tv_nsec;
-	*ctime_seconds = (uint64_t)info.st_ctim.tv_sec;
-	*ctime_nanoseconds = (uint64_t)info.st_ctim.tv_nsec;
+	*mtime_seconds = (u64)info.st_mtim.tv_sec;
+	*mtime_nanoseconds = (u64)info.st_mtim.tv_nsec;
+	*ctime_seconds = (u64)info.st_ctim.tv_sec;
+	*ctime_nanoseconds = (u64)info.st_ctim.tv_nsec;
 #endif
 	return 1;
 }
 #else
-static int v3_modulecache_file_metadata(const char *path, uint64_t *device, uint64_t *inode,
-	uint64_t *size, uint64_t *mtime_seconds, uint64_t *mtime_nanoseconds,
-	uint64_t *ctime_seconds, uint64_t *ctime_nanoseconds) {
+static int v3_modulecache_file_metadata(const char *path, u64 *device, u64 *inode,
+	u64 *size, u64 *mtime_seconds, u64 *mtime_nanoseconds,
+	u64 *ctime_seconds, u64 *ctime_nanoseconds) {
 	(void)path;
 	(void)device;
 	(void)inode;

--- a/vlib/v3/modulecache/file_metadata_test.v
+++ b/vlib/v3/modulecache/file_metadata_test.v
@@ -1,0 +1,50 @@
+module modulecache
+
+import os
+
+fn test_file_metadata_helper_uses_generated_u64_abi() {
+	header_path := os.join_path(@VEXEROOT, 'vlib', 'v3', 'modulecache', 'file_metadata.h')
+	header := os.read_file(header_path) or { panic(err) }
+	signature := 'static int v3_modulecache_file_metadata(const char *path, u64 *device, u64 *inode,
+	u64 *size, u64 *mtime_seconds, u64 *mtime_nanoseconds,
+	u64 *ctime_seconds, u64 *ctime_nanoseconds)'
+	assert header.count(signature) == 2
+	assert !header.contains('uint64_t *')
+
+	cc := os.find_abs_path_of_executable('cc') or { return }
+	temp_dir := os.join_path(os.temp_dir(), 'v3_modulecache_file_metadata_${os.getpid()}')
+	os.mkdir_all(temp_dir) or { panic(err) }
+	defer {
+		os.rmdir_all(temp_dir) or {}
+	}
+
+	header_include := header_path.replace('\\', '/')
+	aliases := ['typedef unsigned long long u64;', 'typedef uint64_t u64;']
+	branches := ['', '#undef __APPLE__\n#undef __linux__']
+	for alias_index, alias in aliases {
+		for branch_index, branch in branches {
+			source_path := os.join_path(temp_dir, 'abi_${alias_index}_${branch_index}.c')
+			source := '#include <stdint.h>
+${alias}
+${branch}
+#include "${header_include}"
+
+int main(void) {
+	u64 device = 0;
+	u64 inode = 0;
+	u64 size = 0;
+	u64 mtime_seconds = 0;
+	u64 mtime_nanoseconds = 0;
+	u64 ctime_seconds = 0;
+	u64 ctime_nanoseconds = 0;
+	return v3_modulecache_file_metadata("", &device, &inode, &size, &mtime_seconds,
+		&mtime_nanoseconds, &ctime_seconds, &ctime_nanoseconds);
+}
+'
+			os.write_file(source_path, source) or { panic(err) }
+			result :=
+				os.execute('${os.quoted_path(cc)} -D_DEFAULT_SOURCE -std=c99 -fsyntax-only -Werror=incompatible-pointer-types ${os.quoted_path(source_path)}')
+			assert result.exit_code == 0, result.output
+		}
+	}
+}

--- a/vlib/v3/types/checker_parallel.v
+++ b/vlib/v3/types/checker_parallel.v
@@ -666,6 +666,10 @@ fn (mut tc TypeChecker) install_type_cache_overlay() {
 		base:          tc.type_cache
 		parse_enabled: tc.type_cache.parse_enabled
 	}
+	if !isnil(tc.resolution_type_views) {
+		// Cached parse views still point at the cache that is now the shared base.
+		tc.reset_resolution_type_view_cache()
+	}
 }
 
 // restore_type_cache_base folds the master's private overlay back into the
@@ -720,6 +724,9 @@ fn (mut tc TypeChecker) restore_type_cache_base() {
 		base.local_fn_decl_last_module = overlay.local_fn_decl_last_module
 	}
 	tc.type_cache = base
+	if !isnil(tc.resolution_type_views) {
+		tc.reset_resolution_type_view_cache()
+	}
 }
 
 fn (tc &TypeChecker) fork_for_parallel_check() &TypeChecker {

--- a/vlib/v3/types/type_cache_test.v
+++ b/vlib/v3/types/type_cache_test.v
@@ -21,6 +21,57 @@ fn test_parse_type_cache_keeps_context_components_without_joined_keys() {
 	assert tc.type_cache.parse_entries.len == 3
 }
 
+fn test_type_cache_overlay_rebinds_resolution_type_views() {
+	a := flat.FlatAst.new()
+	mut tc := TypeChecker.new(&a)
+	tc.type_cache.parse_enabled = true
+	tc.cur_file = 'main.v'
+	tc.cur_module = 'main'
+
+	assert tc.parse_resolution_type('int').name() == 'int'
+	base := tc.type_cache
+	base_view := tc.resolution_type_views.by_file['main.v'] or { panic('missing base view') }
+	assert base_view.type_cache == base
+
+	tc.freeze_type_cache_for_forks()
+	overlay := tc.type_cache
+	assert overlay != base
+	assert overlay.base == base
+	assert tc.resolution_type_views.by_file.len == 0
+	assert tc.parse_resolution_type('string').name() == 'string'
+	overlay_view := tc.resolution_type_views.by_file['main.v'] or { panic('missing overlay view') }
+	assert overlay_view.type_cache == overlay
+
+	tc.unfreeze_type_cache_after_forks()
+	assert tc.type_cache == base
+	assert tc.resolution_type_views.by_file.len == 0
+	assert tc.parse_resolution_type('bool').name() == 'bool'
+	restored_view := tc.resolution_type_views.by_file['main.v'] or {
+		panic('missing restored view')
+	}
+	assert restored_view.type_cache == base
+}
+
+fn test_type_cache_restore_preserves_disabled_resolution_type_views() {
+	a := flat.FlatAst.new()
+	mut tc := TypeChecker.new(&a)
+
+	tc.disable_resolution_type_view_cache()
+	tc.freeze_type_cache_for_forks()
+	assert isnil(tc.resolution_type_views)
+	tc.unfreeze_type_cache_after_forks()
+	assert isnil(tc.resolution_type_views)
+
+	tc.reset_resolution_type_view_cache()
+	tc.freeze_type_cache_for_forks()
+	assert !isnil(tc.resolution_type_views)
+	tc.disable_resolution_type_view_cache()
+	assert isnil(tc.resolution_type_views)
+
+	tc.unfreeze_type_cache_after_forks()
+	assert isnil(tc.resolution_type_views)
+}
+
 fn test_c_type_cache_uses_existing_named_type_identity() {
 	a := flat.FlatAst.new()
 	mut tc := TypeChecker.new(&a)


### PR DESCRIPTION
## Summary

Restore native V3 self-compilation by fixing declaration ownership and ABI mismatches in generated C code.

- Let Linux system headers own `struct itimerspec` and the six semaphore declarations when the system-libc preamble is active.
- Preserve the existing generated declarations for headerless and non-Linux targets.
- Align `v3_modulecache_file_metadata` with the generated `u64` ABI for both V1 and V3.
- Add focused regression coverage for declaration ownership and metadata helper compatibility.

## Validation

- `v fmt -verify` on all modified V files
- Declaration ownership regression tests
- Metadata ABI regression tests
- GCC, Clang and TCC metadata probes
- Successful native V3 self-compilation with `v3 -o v3new vlib/v3/v3.v`
- Successful `V3 -> V4 -> V5 -> V6` self-host chain
- Byte-for-byte convergence between `v5.c` and `v6.c`

Fix #27929 