### PR TITLE
builder: upload a self-contained reproducer for C error bug reports

### DIFF
--- a/vlib/v/builder/c_error_report.v
+++ b/vlib/v/builder/c_error_report.v
@@ -109,7 +109,16 @@ fn (mut v Builder) new_c_error_bug_report(ccompiler string, c_output string) CEr
 	// `v_context` shows the lines of whatever file the C error maps to (which can be an
 	// included header, not V source).
 	mapped_source := if v_file != '' { os.read_file(v_file) or { '' } } else { '' }
-	v_chunk := selected_v_source(v_file, mapped_source.split_into_lines(), v_line)
+	// Prefer a self-contained reproducer (the failing declaration plus the closure of the user
+	// declarations it references). It already keeps itself within the byte budget, returning ''
+	// when it cannot, so it is uploaded verbatim; otherwise fall back to a plain source window.
+	repro := v.v_source_reproducer(v_file, v_line, c_error_bug_report_max_v_source_bytes)
+	v_source := if repro != '' {
+		repro
+	} else {
+		v_chunk := selected_v_source(v_file, mapped_source.split_into_lines(), v_line)
+		bounded_v_source(v_chunk.text, c_error_bug_report_max_v_source_bytes, v_chunk.focus)
+	}
 	return CErrorBugReport{
 		kind:           'v-c-compiler-error'
 		v_version:      version.full_v_version(true)
@@ -126,8 +135,7 @@ fn (mut v Builder) new_c_error_bug_report(ccompiler string, c_output string) CEr
 		v_line:         v_line
 		v_context:      numbered_context_lines(mapped_source.split_into_lines(), v_line,
 			c_error_context_radius)
-		v_source:       bounded_v_source(v_chunk.text, c_error_bug_report_max_v_source_bytes,
-			v_chunk.focus)
+		v_source:       v_source
 	}
 }
 

--- a/vlib/v/builder/c_error_reproducer.v
+++ b/vlib/v/builder/c_error_reproducer.v
@@ -84,6 +84,7 @@ fn (v &Builder) v_source_reproducer(v_file string, v_line int, max_bytes int) st
 	mut main_id := -1
 	mut extra_seeds := []int{} // skip_unused roots (init/cleanup/@[markused]/@[export])
 	mut file_headers := map[int]string{} // per-file `module` header (attributes are per-file)
+	mut start_to_decl := map[string]int{} // '<file_id>:<start line>' -> decl id (solver clone dedup)
 	mut file_id := -1
 	for pf in v.parsed_files {
 		file := pf
@@ -164,14 +165,44 @@ fn (v &Builder) v_source_reproducer(v_file string, v_line int, max_bytes int) st
 			if names.len == 0 {
 				continue
 			}
-			id := decls.len
-			decls << ReproDecl{
-				names:   names
-				source:  source
-				file_id: file_id
+			// `-new-generic-solver` (generics.solve_files) removes a generic `fn foo[T]`
+			// declaration and appends concrete clones named `foo_T_int` that keep the original
+			// position. The copied source and its call sites still say `foo`, so also index the
+			// name the source text itself declares.
+			if stmt is ast.FnDecl {
+				src_name := repro_source_fn_name(source)
+				if src_name != '' && src_name !in names {
+					names << src_name
+				}
 			}
-			for n in names {
-				name_to_decl[n] << id
+			// ... and collapse clones sharing one source range into a single declaration:
+			// emitting the same copied source once per concrete instantiation would not compile
+			start_key := '${file_id}:${start}'
+			mut id := -1
+			if prev := start_to_decl[start_key] {
+				id = prev
+				mut merged_names := decls[id].names.clone()
+				for n in names {
+					if n !in merged_names {
+						merged_names << n
+						name_to_decl[n] << id
+					}
+				}
+				decls[id] = ReproDecl{
+					...decls[id]
+					names: merged_names
+				}
+			} else {
+				id = decls.len
+				start_to_decl[start_key] = id
+				decls << ReproDecl{
+					names:   names
+					source:  source
+					file_id: file_id
+				}
+				for n in names {
+					name_to_decl[n] << id
+				}
 			}
 			// index instance methods under a synthetic `<ReceiverType>#methods` key too, so a
 			// declaration that reflects over `<Type>.methods` (`$for m in Foo.methods`) can pull in
@@ -451,6 +482,15 @@ fn repro_closure(decls []ReproDecl, name_to_decl map[string][]int, seeds []int) 
 		// overloaded operators are indexed under their punctuation method name (`+`, `[]`, ...),
 		// which is not an identifier token, so add the operator methods a declaration may use
 		refs << repro_operator_refs(decls[id].source)
+		// string interpolation and the print/dump/assert family invoke custom `str` methods
+		// implicitly: the token scan sees `Foo` in `'\${Foo{}}'` but never the method name, and
+		// replaying with the default `skip_unused` would then drop `Foo.str` (and anything only
+		// it reaches), making the C error vanish. Retain every custom `str` method instead —
+		// a safe over-approximation, mirroring the mark-used walker, which roots string methods
+		// for interpolation.
+		if repro_source_stringifies(decls[id].source, refs) {
+			refs << 'str'
+		}
 		// `$for m in Foo.methods` reflection needs Foo's methods, which are indexed under the
 		// synthetic `Foo#methods` key; add those refs so the whole method set is retained
 		for t in repro_reflection_method_targets(decls[id].source) {
@@ -493,6 +533,21 @@ fn repro_operator_refs(source string) []string {
 		}
 	}
 	return ops
+}
+
+// repro_source_stringifies reports whether a declaration may implicitly invoke `str` methods:
+// it interpolates values into a string, or calls one of the print/dump functions (whose
+// arguments are stringified), or asserts (failure messages stringify the operands).
+fn repro_source_stringifies(source string, refs []string) bool {
+	if source.contains('\${') {
+		return true
+	}
+	for r in refs {
+		if r in ['println', 'eprintln', 'print', 'eprint', 'dump', 'assert'] {
+			return true
+		}
+	}
+	return false
 }
 
 // repro_reflection_method_targets returns the names a declaration reflects over with
@@ -821,6 +876,62 @@ fn scan_string_literal(source string, start int, mut ids []string) int {
 @[inline]
 fn is_ident_char(c u8) bool {
 	return c == `_` || c.is_letter() || c.is_digit()
+}
+
+// repro_source_fn_name parses the function name out of a declaration's copied source text. The
+// AST name can differ from the source when a pass rewrites declarations in place — notably
+// `-new-generic-solver`, whose concrete clones are named `foo_T_int` while the copied source and
+// every call site still say `foo` — so the closure indexes the source-level name as well.
+// Returns '' when the declaration has no source-visible plain name (operator overloads), or when
+// no `fn` line is found.
+fn repro_source_fn_name(source string) string {
+	for line in source.split_into_lines() {
+		t := line.trim_space()
+		if t == '' || t.starts_with('@[') || t.starts_with('//') {
+			continue
+		}
+		mut rest := t
+		if rest.starts_with('pub ') {
+			rest = rest['pub '.len..].trim_space()
+		}
+		if !rest.starts_with('fn ') && !rest.starts_with('fn(') {
+			return ''
+		}
+		mut i := 2
+		for i < rest.len && (rest[i] == ` ` || rest[i] == `\t`) {
+			i++
+		}
+		// skip a method's parenthesized receiver
+		if i < rest.len && rest[i] == `(` {
+			for i < rest.len && rest[i] != `)` {
+				i++
+			}
+			i++
+			for i < rest.len && (rest[i] == ` ` || rest[i] == `\t`) {
+				i++
+			}
+		}
+		// the name: an identifier, possibly dotted (`C.puts`, `JS.alert`); keep the last segment
+		// to match how AST names are indexed (repro_short_name)
+		mut last := ''
+		for {
+			name_start := i
+			for i < rest.len && is_ident_char(rest[i]) {
+				i++
+			}
+			if i == name_start {
+				return ''
+			}
+			last = rest[name_start..i]
+			if i < rest.len && rest[i] == `.` {
+				i++
+				continue
+			}
+			break
+		}
+		return last
+	}
+	return ''
 }
 
 // repro_short_name returns the last, unqualified component of a possibly module-qualified name

--- a/vlib/v/builder/c_error_reproducer.v
+++ b/vlib/v/builder/c_error_reproducer.v
@@ -76,8 +76,8 @@ fn (v &Builder) v_source_reproducer(v_file string, v_line int, max_bytes int) st
 	mut hashes := []ReproHash{}
 	mut root_id := -1
 	mut main_id := -1
-	mut extra_seeds := []int{} // module-lifecycle roots (`init`/`cleanup`) that must stay reachable
-	mut mod_header := 'module main'
+	mut extra_seeds := []int{} // skip_unused roots (init/cleanup/@[markused]/@[export])
+	mut file_headers := map[int]string{} // per-file `module` header (attributes are per-file)
 	mut file_id := -1
 	for pf in v.parsed_files {
 		file := pf
@@ -91,16 +91,16 @@ fn (v &Builder) v_source_reproducer(v_file string, v_line int, max_bytes int) st
 		if lines.len == 0 {
 			continue
 		}
-		// keep the failing file's `module` declaration verbatim, including any leading attributes
-		// (`@[has_globals]`, `@[manualfree]`, ...), which affect whether the source even checks
-		if is_root_file {
-			for li, ln in lines {
-				if ln.trim_space().starts_with('module ') {
-					mod_header = lines[repro_attr_start(lines, li)..li + 1].join('\n')
-					break
-				}
+		// capture this file's `module` declaration verbatim, including any leading attributes
+		// (`@[has_globals]`, `@[manualfree]`, ...), which the parser treats as per-file
+		mut header := 'module main'
+		for li, ln in lines {
+			if ln.trim_space().starts_with('module ') {
+				header = lines[repro_attr_start(lines, li)..li + 1].join('\n')
+				break
 			}
 		}
+		file_headers[file_id] = header
 		for imp in file.imports {
 			mut triggers := [repro_import_alias(imp)]
 			for s in imp.syms {
@@ -163,10 +163,9 @@ fn (v &Builder) v_source_reproducer(v_file string, v_line int, max_bytes int) st
 			if stmt is ast.FnDecl && stmt.is_main {
 				main_id = id
 			}
-			// `init`/`cleanup` are called automatically, so keep them (and thus any helper they
-			// reach) even though nothing references them by name
-			if stmt is ast.FnDecl && !stmt.is_method
-				&& repro_short_name(stmt.name) in ['init', 'cleanup'] {
+			// skip_unused roots (init/cleanup, and `@[markused]`/`@[export]` functions) are kept
+			// regardless of references, so a failing helper reached only from one stays reachable
+			if stmt is ast.FnDecl && repro_is_markused_root(stmt) {
 				extra_seeds << id
 			}
 			if is_root_file && v_line - 1 >= start && v_line - 1 < end {
@@ -197,17 +196,31 @@ fn (v &Builder) v_source_reproducer(v_file string, v_line int, max_bytes int) st
 	if ordered.len == 0 {
 		return ''
 	}
-	mut referenced := map[string]bool{}
+	// track which files contributed a declaration, and the identifiers each such file references,
+	// so imports are judged only against declarations from their own file (a same-named local var
+	// in another file must not make an unrelated import look needed)
+	mut included_files := map[int]bool{}
+	mut file_referenced := map[string]bool{} // key: "<file_id>\x00<name>"
 	for id in ordered {
+		fid := decls[id].file_id
+		included_files[fid] = true
 		for name in repro_identifiers(decls[id].source) {
-			referenced[name] = true
+			file_referenced['${fid}\x00${name}'] = true
 		}
 	}
-	// imports are file-scoped: only consider imports from files that actually contributed an
-	// inlined declaration, so a same-alias import from an unselected file is never emitted
-	mut included_files := map[int]bool{}
-	for id in ordered {
-		included_files[decls[id].file_id] = true
+	// the flattened file can carry only one module header: if contributing files disagree on their
+	// module attributes (e.g. one has `@[has_globals]`), we cannot faithfully merge them, so fall back
+	mut mod_header := ''
+	for fid, _ in included_files {
+		h := file_headers[fid]
+		if mod_header == '' {
+			mod_header = h
+		} else if h != mod_header {
+			return ''
+		}
+	}
+	if mod_header == '' {
+		mod_header = 'module main'
 	}
 	mut scoped_imports := []ReproImport{}
 	mut bound := map[string]string{} // binding name -> the import source that provides it
@@ -215,7 +228,7 @@ fn (v &Builder) v_source_reproducer(v_file string, v_line int, max_bytes int) st
 		if imp.file_id !in included_files {
 			continue
 		}
-		if !imp.side_effect && !imp.triggers.any(referenced[it]) {
+		if !imp.side_effect && !imp.triggers.any('${imp.file_id}\x00${it}' in file_referenced) {
 			continue
 		}
 		// a needed project-local import cannot be satisfied by the single uploaded file
@@ -231,13 +244,18 @@ fn (v &Builder) v_source_reproducer(v_file string, v_line int, max_bytes int) st
 		}
 		scoped_imports << imp
 	}
-	// hash directives are file-scoped too: only include `#include`/`#flag`/... from files that
-	// contributed a declaration, so an unrelated file's project-local directive is not emitted
+	// hash directives are file-scoped too. A project-local dependency (`#include "private.h"`, a
+	// path/`@V...`-based `#flag`, ...) references a file we do not upload, so fall back instead of
+	// emitting a directive the receiver cannot satisfy.
 	mut scoped_hashes := []string{}
 	for h in hashes {
-		if h.file_id in included_files {
-			scoped_hashes << h.source
+		if h.file_id !in included_files {
+			continue
 		}
+		if repro_hash_is_local(h.source) {
+			return ''
+		}
+		scoped_hashes << h.source
 	}
 	// every declaration in the closure is required, so an over-budget reproducer is dropped whole
 	// (the caller then falls back to a source window) rather than emitting a partial program
@@ -361,6 +379,36 @@ fn repro_import_stmt(imp ast.Import) string {
 		s += ' { ${imp.syms.map(it.name).join(', ')} }'
 	}
 	return s
+}
+
+// repro_is_markused_root reports whether a function is a `skip_unused` root that is retained even
+// when nothing references it: an `init`/`cleanup` lifecycle function, or one tagged `@[markused]`
+// or `@[export]`. Such a function must be inlined so any helper it alone reaches stays reachable.
+fn repro_is_markused_root(f ast.FnDecl) bool {
+	if !f.is_method && repro_short_name(f.name) in ['init', 'cleanup'] {
+		return true
+	}
+	return f.attrs.any(it.name == 'markused' || it.name == 'export')
+}
+
+// repro_hash_is_local reports whether a `#`-directive depends on a project-local file or path that
+// is not uploaded with the reproducer (a quoted/relative `#include`, or a `#flag`/other directive
+// naming a path or `@V...` root), as opposed to a system header or library.
+fn repro_hash_is_local(directive string) bool {
+	t := directive.trim_space()
+	if t.starts_with('#include') || t.starts_with('#insert') || t.starts_with('#preinclude') {
+		// system headers use `<...>`; a quoted or relative include is project-local
+		return !t.contains('<')
+	}
+	if t.starts_with('#flag') {
+		return t.contains('"') || t.contains('@V') || t.contains('./') || t.contains('../')
+			|| t.contains('-I') || t.contains('-L')
+	}
+	if t.starts_with('#pkgconfig') {
+		return false // resolved from installed pkg-config packages, like a system library
+	}
+	// any other directive: be conservative and treat it as a local dependency
+	return t.starts_with('#')
 }
 
 // repro_render assembles the given declaration ids into a single-file source string, headed by

--- a/vlib/v/builder/c_error_reproducer.v
+++ b/vlib/v/builder/c_error_reproducer.v
@@ -37,6 +37,12 @@ struct ReproImport {
 	file_id     int      // the file this import belongs to (imports are file-scoped)
 }
 
+// ReproHash is a top-level `#include` / `#flag` / ... C-interop directive and the file it is in.
+struct ReproHash {
+	source  string
+	file_id int
+}
+
 // v_source_reproducer builds a self-contained reproducer for the failing V line, or '' when it
 // cannot (no mapping, the failure is not in an ordinary single-module `main` program, or the
 // reproducer would not fit the byte budget).
@@ -67,9 +73,11 @@ fn (v &Builder) v_source_reproducer(v_file string, v_line int, max_bytes int) st
 	mut decls := []ReproDecl{}
 	mut name_to_decl := map[string][]int{}
 	mut imports := []ReproImport{}
-	mut hashes := []string{}
+	mut hashes := []ReproHash{}
 	mut root_id := -1
 	mut main_id := -1
+	mut extra_seeds := []int{} // module-lifecycle roots (`init`/`cleanup`) that must stay reachable
+	mut mod_header := 'module main'
 	mut file_id := -1
 	for pf in v.parsed_files {
 		file := pf
@@ -82,6 +90,16 @@ fn (v &Builder) v_source_reproducer(v_file string, v_line int, max_bytes int) st
 		lines := src.split_into_lines()
 		if lines.len == 0 {
 			continue
+		}
+		// keep the failing file's `module` declaration verbatim, including any leading attributes
+		// (`@[has_globals]`, `@[manualfree]`, ...), which affect whether the source even checks
+		if is_root_file {
+			for li, ln in lines {
+				if ln.trim_space().starts_with('module ') {
+					mod_header = lines[repro_attr_start(lines, li)..li + 1].join('\n')
+					break
+				}
+			}
 		}
 		for imp in file.imports {
 			mut triggers := [repro_import_alias(imp)]
@@ -118,10 +136,18 @@ fn (v &Builder) v_source_reproducer(v_file string, v_line int, max_bytes int) st
 				continue
 			}
 			if stmt is ast.HashStmt {
-				hashes << source
+				hashes << ReproHash{
+					source:  source
+					file_id: file_id
+				}
 				continue
 			}
-			names := repro_top_decl_names(stmt)
+			mut names := repro_top_decl_names(stmt)
+			if names.len == 0 {
+				// declarations nested in a top-level comptime `$if` block are wrapped in an
+				// ExprStmt; index them under the whole block so referencing one keeps the block
+				names = repro_comptime_decl_names(stmt)
+			}
 			if names.len == 0 {
 				continue
 			}
@@ -137,6 +163,12 @@ fn (v &Builder) v_source_reproducer(v_file string, v_line int, max_bytes int) st
 			if stmt is ast.FnDecl && stmt.is_main {
 				main_id = id
 			}
+			// `init`/`cleanup` are called automatically, so keep them (and thus any helper they
+			// reach) even though nothing references them by name
+			if stmt is ast.FnDecl && !stmt.is_method
+				&& repro_short_name(stmt.name) in ['init', 'cleanup'] {
+				extra_seeds << id
+			}
 			if is_root_file && v_line - 1 >= start && v_line - 1 < end {
 				root_id = id
 			}
@@ -151,6 +183,13 @@ fn (v &Builder) v_source_reproducer(v_file string, v_line int, max_bytes int) st
 	mut seeds := [root_id]
 	if main_id != root_id {
 		seeds << main_id
+	}
+	// plus the module-lifecycle roots, so a failing helper reached only from `init`/`cleanup`
+	// stays reachable under the default `skip_unused`
+	for s in extra_seeds {
+		if s !in seeds {
+			seeds << s
+		}
 	}
 	// `none` means the closure hit the declaration cap, i.e. it is incomplete; fall back rather
 	// than upload a program with missing symbols
@@ -192,9 +231,17 @@ fn (v &Builder) v_source_reproducer(v_file string, v_line int, max_bytes int) st
 		}
 		scoped_imports << imp
 	}
+	// hash directives are file-scoped too: only include `#include`/`#flag`/... from files that
+	// contributed a declaration, so an unrelated file's project-local directive is not emitted
+	mut scoped_hashes := []string{}
+	for h in hashes {
+		if h.file_id in included_files {
+			scoped_hashes << h.source
+		}
+	}
 	// every declaration in the closure is required, so an over-budget reproducer is dropped whole
 	// (the caller then falls back to a source window) rather than emitting a partial program
-	out := repro_render(scoped_imports, hashes, decls, ordered)
+	out := repro_render(mod_header, scoped_imports, scoped_hashes, decls, ordered)
 	if out == '' || (max_bytes > 0 && out.len > max_bytes) {
 		return ''
 	}
@@ -316,8 +363,9 @@ fn repro_import_stmt(imp ast.Import) string {
 	return s
 }
 
-// repro_render assembles the given declaration ids into a single `module main` source string.
-fn repro_render(imports []ReproImport, hashes []string, decls []ReproDecl, ids []int) string {
+// repro_render assembles the given declaration ids into a single-file source string, headed by
+// `mod_header` (the failing file's `module` line, including any module attributes).
+fn repro_render(mod_header string, imports []ReproImport, hashes []string, decls []ReproDecl, ids []int) string {
 	mut parts := []string{cap: ids.len}
 	for id in ids {
 		if id >= 0 && id < decls.len {
@@ -329,7 +377,7 @@ fn repro_render(imports []ReproImport, hashes []string, decls []ReproDecl, ids [
 	for name in repro_identifiers(body) {
 		referenced[name] = true
 	}
-	mut out := 'module main\n\n'
+	mut out := '${mod_header}\n\n'
 	mut emitted := map[string]bool{}
 	for imp in imports {
 		if imp.source == '' || imp.source in emitted {
@@ -457,6 +505,31 @@ fn repro_import_alias(imp ast.Import) string {
 		return imp.alias
 	}
 	return imp.mod.all_after_last('.')
+}
+
+// repro_comptime_decl_names returns the names declared inside a top-level comptime `$if` block
+// (which the parser wraps in an `ExprStmt`), so the whole block is inlined when one is referenced.
+// Returns [] for anything that is not such a block.
+fn repro_comptime_decl_names(stmt ast.Stmt) []string {
+	if stmt is ast.ExprStmt {
+		if stmt.expr is ast.IfExpr {
+			if stmt.expr.is_comptime {
+				mut names := []string{}
+				for branch in stmt.expr.branches {
+					for s in branch.stmts {
+						inner := repro_top_decl_names(s)
+						if inner.len > 0 {
+							names << inner
+						} else {
+							names << repro_comptime_decl_names(s)
+						}
+					}
+				}
+				return names
+			}
+		}
+	}
+	return []
 }
 
 // repro_top_decl_names returns the top-level names a statement defines, or [] when it is not an

--- a/vlib/v/builder/c_error_reproducer.v
+++ b/vlib/v/builder/c_error_reproducer.v
@@ -160,13 +160,24 @@ fn (v &Builder) v_source_reproducer(v_file string, v_line int, max_bytes int) st
 				continue
 			}
 			mut names := repro_top_decl_names(stmt)
+			mut force_seed := false
 			if names.len == 0 {
 				// declarations nested in a top-level comptime `$if` block are wrapped in an
 				// ExprStmt; index them under the whole block so referencing one keeps the block
 				names = repro_comptime_decl_names(stmt)
 			}
 			if names.len == 0 {
-				continue
+				// an active hash-only comptime block declares no symbol, but its `#flag`/
+				// `#include` directives still apply module-wide in the original build; keep the
+				// block verbatim as an always-included declaration (the embedded local-path scan
+				// below still forces the fallback for project-local directives). The synthetic
+				// name starts with `#`, so no identifier token can ever reference it.
+				if repro_is_comptime_block_stmt(stmt) && repro_source_has_hash_directive(source) {
+					names = ['#condhash']
+					force_seed = true
+				} else {
+					continue
+				}
 			}
 			// `-new-generic-solver` (generics.solve_files) removes a generic `fn foo[T]`
 			// declaration and appends concrete clones named `foo_T_int` that keep the original
@@ -214,6 +225,12 @@ fn (v &Builder) v_source_reproducer(v_file string, v_line int, max_bytes int) st
 				recv := repro_short_name(v.table.sym(stmt.receiver.typ).name)
 				if recv != '' {
 					name_to_decl['${recv}#methods'] << id
+					// the mark-used finalizer roots these operator methods whenever their
+					// receiver type is used, even without a source-level use of the operator;
+					// index them under `<Recv>#op` so the closure can do the same
+					if repro_short_name(stmt.name) in ['+', '-', '*', '%', '/', '<', '=='] {
+						name_to_decl['${recv}#op'] << id
+					}
 				}
 			}
 			if stmt is ast.FnDecl && stmt.is_main {
@@ -237,7 +254,7 @@ fn (v &Builder) v_source_reproducer(v_file string, v_line int, max_bytes int) st
 					is_root = true
 				}
 			}
-			if is_root {
+			if is_root || force_seed {
 				extra_seeds << id
 			}
 			if is_root_file && v_line - 1 >= start && v_line - 1 < end {
@@ -641,6 +658,12 @@ fn repro_closure(decls []ReproDecl, name_to_decl map[string][]int, seeds []int) 
 		for t in repro_reflection_method_targets(decls[id].source) {
 			refs << '${t}#methods'
 		}
+		// the mark-used finalizer roots `+`/`-`/`*`/`%`/`/`/`<`/`==` methods whose receiver
+		// type is used even when the operator never appears in source (walker.v); mirror it by
+		// referencing every retained name's `#op` set (only type names index anything there)
+		for n in decls[id].names {
+			refs << '${n}#op'
+		}
 		for name in refs {
 			for ref in name_to_decl[name] {
 				if ref >= 0 && ref < decls.len && !included[ref] {
@@ -845,7 +868,9 @@ fn repro_decl_attrs(stmt ast.Stmt) []ast.Attr {
 // reachable when `skip_unused` runs again on the replayed reproducer.
 fn repro_is_markused_root(f ast.FnDecl, veb_res_idx int, translated bool) bool {
 	short := repro_short_name(f.name)
-	if !f.is_method && short in ['init', 'cleanup'] {
+	// the mark-used pass roots every function key ending in `.init`/`.cleanup` (markused.v),
+	// which covers plain lifecycle functions and methods like `Foo.init` alike
+	if short in ['init', 'cleanup'] {
 		return true
 	}
 	// lock helpers for `shared` types are rooted by name regardless of references
@@ -937,13 +962,42 @@ fn repro_embedded_local_hash(source string) bool {
 	return false
 }
 
+// repro_is_comptime_block_stmt reports whether a top-level statement is a comptime conditional
+// block: a bare `ast.Block` (an active branch hoisted by comptime.solve_files) or an
+// unsolved comptime `$if`/`$match` expression statement.
+fn repro_is_comptime_block_stmt(stmt ast.Stmt) bool {
+	if stmt is ast.Block {
+		return true
+	}
+	if stmt is ast.ExprStmt {
+		if stmt.expr is ast.IfExpr {
+			return stmt.expr.is_comptime
+		}
+		if stmt.expr is ast.MatchExpr {
+			return stmt.expr.is_comptime
+		}
+	}
+	return false
+}
+
+// repro_source_has_hash_directive reports whether any line of a declaration's copied source is a
+// `#` directive.
+fn repro_source_has_hash_directive(source string) bool {
+	for line in source.split_into_lines() {
+		if line.trim_space().starts_with('#') {
+			return true
+		}
+	}
+	return false
+}
+
 // repro_uses_local_resource reports whether a declaration uses a compile-time construct whose
 // value depends on the build machine and is not carried by the report: a project-local file
 // (`$embed_file`, `$tmpl`, `$res`) or the builder's environment (`$env`, baked in at compile
 // time - replaying it against the receiver's environment can change the generated C and lose
 // the error).
 fn repro_uses_local_resource(source string) bool {
-	for name in ['embed_file', 'tmpl', 'res', 'env', 'veb.html'] {
+	for name in ['embed_file', 'tmpl', 'res', 'env', 'veb.html', 'pkgconfig'] {
 		if repro_has_comptime_call(source, name) {
 			return true
 		}

--- a/vlib/v/builder/c_error_reproducer.v
+++ b/vlib/v/builder/c_error_reproducer.v
@@ -125,7 +125,13 @@ fn (v &Builder) v_source_reproducer(v_file string, v_line int, max_bytes int) st
 		// top-level attributes are parsed before the declaration, so extend each start up over them
 		mut starts := []int{}
 		for stmt in file.stmts {
-			starts << repro_attr_start(lines, ast.Node(stmt).pos().line_nr)
+			mut line_nr := ast.Node(stmt).pos().line_nr
+			if stmt is ast.Block {
+				// a comptime `$if <os>` block that `comptime.solve_files` already hoisted becomes a
+				// bare `ast.Block` with no pos of its own; locate its `$if`/`$match` opener instead
+				line_nr = repro_block_opener_line(stmt, lines)
+			}
+			starts << if line_nr < 0 { -1 } else { repro_attr_start(lines, line_nr) }
 		}
 		for i, stmt in file.stmts {
 			start := starts[i]
@@ -320,6 +326,31 @@ fn (v &Builder) v_source_reproducer(v_file string, v_line int, max_bytes int) st
 		return ''
 	}
 	return out
+}
+
+// repro_block_opener_line returns the 0-based source line of the `$if`/`$match` opener of a solved
+// comptime `ast.Block` (whose own pos is unset), found by scanning up from its first inner
+// declaration. Returns -1 when the block is empty or no opener line is found.
+fn repro_block_opener_line(block ast.Block, lines []string) int {
+	mut first := -1
+	for s in block.stmts {
+		ln := ast.Node(s).pos().line_nr
+		if ln >= 0 && (first < 0 || ln < first) {
+			first = ln
+		}
+	}
+	if first < 0 {
+		return -1
+	}
+	mut j := if first < lines.len { first } else { lines.len - 1 }
+	for j >= 0 {
+		t := lines[j].trim_space()
+		if t.starts_with('\$if ') || t.starts_with('\$match ') {
+			return j
+		}
+		j--
+	}
+	return -1
 }
 
 // repro_attr_start returns the first line (0-based) of the declaration at `line_nr`, walking up
@@ -722,16 +753,36 @@ fn scan_string_literal(source string, start int, mut ids []string) int {
 			mut depth := 1
 			for i < source.len && depth > 0 {
 				ci := source[i]
-				if ci == `{` {
-					depth++
+				if ci == `/` && i + 1 < source.len && source[i + 1] == `/` {
+					// a line comment inside the interpolation: skip it so `}` in the comment text
+					// does not close the scan
+					for i < source.len && source[i] != `\n` {
+						i++
+					}
+				} else if ci == `/` && i + 1 < source.len && source[i + 1] == `*` {
+					// a block comment: skip to its `*/`
+					i += 2
+					for i + 1 < source.len && !(source[i] == `*` && source[i + 1] == `/`) {
+						i++
+					}
+					i += 2
+				} else if ci == 96 {
+					// a backtick rune literal (e.g. `` `}` ``): skip it so its brace is not counted
 					i++
-				} else if ci == `}` {
-					depth--
+					for i < source.len && source[i] != 96 {
+						i += if source[i] == `\\` { 2 } else { 1 }
+					}
 					i++
 				} else if ci == `'` || ci == `"` {
 					// a nested string inside the interpolation: skip its contents (its own braces
 					// must not be counted) while still collecting its `${...}` identifiers
 					i = scan_string_literal(source, i, mut ids)
+				} else if ci == `{` {
+					depth++
+					i++
+				} else if ci == `}` {
+					depth--
+					i++
 				} else if ci == `_` || ci.is_letter() {
 					st := i
 					for i < source.len && is_ident_char(source[i]) {
@@ -769,9 +820,13 @@ fn repro_import_alias(imp ast.Import) string {
 }
 
 // repro_comptime_decl_names returns the names declared inside a top-level comptime `$if` or
-// `$match` block (which the parser wraps in an `ExprStmt` holding an `IfExpr`/`MatchExpr`), so the
-// whole block is inlined when one of its declarations is referenced. Returns [] for anything else.
+// `$match` block, so the whole block is inlined when one of its declarations is referenced. Such a
+// block appears either as an `ExprStmt` holding an `IfExpr`/`MatchExpr` (unsolved) or, after
+// `comptime.solve_files` hoists an active single branch, as a bare `ast.Block`. Returns [] otherwise.
 fn repro_comptime_decl_names(stmt ast.Stmt) []string {
+	if stmt is ast.Block {
+		return repro_comptime_branch_names(stmt.stmts)
+	}
 	if stmt is ast.ExprStmt {
 		if stmt.expr is ast.IfExpr {
 			if stmt.expr.is_comptime {

--- a/vlib/v/builder/c_error_reproducer.v
+++ b/vlib/v/builder/c_error_reproducer.v
@@ -278,8 +278,11 @@ fn (v &Builder) v_source_reproducer(v_file string, v_line int, max_bytes int) st
 		fid := decls[id].file_id
 		included_files[fid] = true
 		// a retained declaration using a compile-time resource (`$embed_file`/`$tmpl`/`$res`)
-		// needs a project-local file we do not upload, so the reproducer cannot be standalone
-		if repro_uses_local_resource(decls[id].source) {
+		// needs a project-local file we do not upload, so the reproducer cannot be standalone;
+		// a machine- or layout-dependent pseudo variable (`@FILE`, `@LINE`, `@VMODROOT`, ...)
+		// would likewise evaluate differently in the flattened replay
+		if repro_uses_local_resource(decls[id].source)
+			|| repro_uses_machine_pseudo(decls[id].source) {
 			return ''
 		}
 		// a retained top-level comptime block (`$if`/`$match`) that carries its own conditional
@@ -428,19 +431,8 @@ fn repro_attr_start(lines []string, line_nr int) int {
 		if !lines[end].trim_space().ends_with(']') {
 			break // the line above the declaration does not close an attribute group
 		}
-		// find the line that opens this group by balancing brackets from `end` upward
-		mut open := end
-		mut bal := 0
-		for open >= 0 {
-			bal += repro_bracket_delta(lines[open])
-			if bal == 0 {
-				break
-			}
-			open--
-		}
-		// only treat it as an attribute group when the balancing line actually opens with `@[`
-		// (this stops a preceding array/const declaration ending in `]` from being swallowed)
-		if open < 0 || bal != 0 || !lines[open].trim_space().starts_with('@[') {
+		open := repro_attr_open_line(lines, end)
+		if open < 0 {
 			break
 		}
 		s = open
@@ -448,16 +440,108 @@ fn repro_attr_start(lines []string, line_nr int) int {
 	return s
 }
 
-// repro_bracket_delta returns the net bracket balance of a line: the count of `[` minus the count
-// of `]`. Used to locate where a possibly multi-line `@[...]` attribute group opens.
+// repro_attr_open_line locates the line that opens the attribute group closing on line `end`, or
+// -1 when the closing bracket does not belong to an attribute. The per-line bracket balance walk
+// resolves single-line and stacked attributes (and stops a preceding const array ending in `]`
+// from being swallowed); an attribute string spanning source lines defeats per-line balances, so
+// the nearest `@[` line above is then verified by a forward scan of the joined candidate text.
+fn repro_attr_open_line(lines []string, end int) int {
+	mut open := end
+	mut bal := 0
+	for open >= 0 {
+		bal += repro_bracket_delta(lines[open])
+		if bal == 0 {
+			break
+		}
+		open--
+	}
+	if open >= 0 && bal == 0 && lines[open].trim_space().starts_with('@[') {
+		return open
+	}
+	mut cand := end
+	for cand >= 0 && end - cand < 16 {
+		if lines[cand].trim_space().starts_with('@[') {
+			if repro_attr_group_spans(lines[cand..end + 1].join('\n')) {
+				return cand
+			}
+			break
+		}
+		cand--
+	}
+	return -1
+}
+
+// repro_attr_group_spans reports whether `text` is one uninterrupted `@[...]` attribute group:
+// it opens with `@[`, its structural bracket depth only returns to zero at the very end, and
+// string literals (which may span lines and contain brackets) are skipped. Ordinary code between
+// an unrelated attribute above and the closing line fails this scan, because the earlier
+// attribute's own `]` returns the depth to zero early.
+fn repro_attr_group_spans(text string) bool {
+	t := text.trim_space()
+	if !t.starts_with('@[') {
+		return false
+	}
+	mut i := 0
+	mut depth := 0
+	for i < t.len {
+		c := t[i]
+		if c == `'` || c == `"` {
+			i++
+			for i < t.len && t[i] != c {
+				i += if t[i] == `\\` { 2 } else { 1 }
+			}
+			i++
+			continue
+		}
+		if c == `/` && i + 1 < t.len && t[i + 1] == `/` {
+			for i < t.len && t[i] != `\n` {
+				i++
+			}
+			continue
+		}
+		if c == `[` {
+			depth++
+		} else if c == `]` {
+			depth--
+			if depth == 0 {
+				// the group must end here (only whitespace may follow)
+				return t[i + 1..].trim_space() == ''
+			}
+			if depth < 0 {
+				return false
+			}
+		}
+		i++
+	}
+	return false
+}
+
+// repro_bracket_delta returns the net structural bracket balance of a line: the count of `[`
+// minus the count of `]`, ignoring brackets inside string literals (an attribute value like
+// `@[footer: 'World]']` must not skew the balance) and after a `//` comment. Used to locate
+// where a possibly multi-line `@[...]` attribute group opens.
 fn repro_bracket_delta(line string) int {
 	mut d := 0
-	for c in line {
+	mut i := 0
+	for i < line.len {
+		c := line[i]
+		if c == `'` || c == `"` {
+			i++
+			for i < line.len && line[i] != c {
+				i += if line[i] == `\\` { 2 } else { 1 }
+			}
+			i++
+			continue
+		}
+		if c == `/` && i + 1 < line.len && line[i + 1] == `/` {
+			break
+		}
 		if c == `[` {
 			d++
 		} else if c == `]` {
 			d--
 		}
+		i++
 	}
 	return d
 }
@@ -773,8 +857,72 @@ fn repro_source_has_toplevel_import(source string) bool {
 // time - replaying it against the receiver's environment can change the generated C and lose
 // the error).
 fn repro_uses_local_resource(source string) bool {
-	return source.contains('\$embed_file(') || source.contains('\$tmpl(')
-		|| source.contains('\$res(') || source.contains('\$env(')
+	for name in ['embed_file', 'tmpl', 'res', 'env'] {
+		if repro_has_comptime_call(source, name) {
+			return true
+		}
+	}
+	return false
+}
+
+// repro_has_comptime_call reports whether `source` calls the compile-time function `$<name>`.
+// V tokenizes the call, so whitespace between the name and its `(` is valid
+// (`$embed_file ('asset.bin')`) and an exact-substring check would miss it.
+fn repro_has_comptime_call(source string, name string) bool {
+	pat := '\$' + name
+	mut i := 0
+	for i + pat.len <= source.len {
+		if source[i] != `\$` || source[i..i + pat.len] != pat {
+			i++
+			continue
+		}
+		mut j := i + pat.len
+		// the name must end here: `$reserve(` must not match `$res`
+		if j < source.len && is_ident_char(source[j]) {
+			i++
+			continue
+		}
+		for j < source.len && (source[j] == ` ` || source[j] == `\t`) {
+			j++
+		}
+		if j < source.len && source[j] == `(` {
+			return true
+		}
+		i++
+	}
+	return false
+}
+
+// Pseudo variables whose compile-time value depends on the file layout, the project root or the
+// builder installation: flattening the declarations into one uploaded file changes path and line
+// values, and replaying on another machine changes the root/hash/build values, so retained code
+// using one can generate different C and lose the error. (`@FN`/`@METHOD`/`@MOD`/`@STRUCT` and
+// `@COLUMN` survive the verbatim flatten, and `@OS`/`@PLATFORM`/`@BACKEND`/`@CCOMPILER` are
+// reproducible from the recorded build options, so those stay allowed.)
+const c_error_repro_machine_pseudos = ['@VROOT', '@VMODROOT', '@VEXEROOT', '@VEXE', '@FILE_LINE',
+	'@FILE', '@DIR', '@LINE', '@LOCATION', '@VHASH', '@VCURRENTHASH', '@VMOD_FILE', '@VMODHASH',
+	'@BUILD_DATE', '@BUILD_TIME', '@BUILD_TIMESTAMP']
+
+// repro_uses_machine_pseudo reports whether a declaration uses one of the machine- or
+// layout-dependent pseudo variables above. Occurrences are matched with an identifier boundary,
+// so `bob@FILEserver` inside a string does not count, while a real `@FILE` token does; a stray
+// mention in a plain string only causes a harmless fallback.
+fn repro_uses_machine_pseudo(source string) bool {
+	mut i := 0
+	for i < source.len {
+		if source[i] != `@` {
+			i++
+			continue
+		}
+		for p in c_error_repro_machine_pseudos {
+			if i + p.len <= source.len && source[i..i + p.len] == p
+				&& (i + p.len == source.len || !is_ident_char(source[i + p.len])) {
+				return true
+			}
+		}
+		i++
+	}
+	return false
 }
 
 // repro_render assembles the given declaration ids into a single-file source string, headed by

--- a/vlib/v/builder/c_error_reproducer.v
+++ b/vlib/v/builder/c_error_reproducer.v
@@ -696,6 +696,16 @@ fn repro_closure(decls []ReproDecl, name_to_decl map[string][]int, seeds []int) 
 			refs << 'to_json'
 			refs << 'json_str'
 		}
+		// the json2 decoders likewise invoke a local type's decoding hooks implicitly
+		// (from_json_string/_number/_boolean/_null); retain them when a decode API is
+		// referenced, or the replay stops recognizing the decoder interface (or drops a
+		// helper only a hook reaches)
+		if 'decode' in refs || 'raw_decode' in refs {
+			refs << 'from_json_string'
+			refs << 'from_json_number'
+			refs << 'from_json_boolean'
+			refs << 'from_json_null'
+		}
 		// `$for m in Foo.methods` reflection needs Foo's methods, which are indexed under the
 		// synthetic `Foo#methods` key; add those refs so the whole method set is retained
 		for t in repro_reflection_method_targets(decls[id].source) {
@@ -1010,7 +1020,8 @@ fn repro_hash_is_local(directive string) bool {
 	}
 	if t.starts_with('#flag') {
 		return t.contains('"') || t.contains('@V') || t.contains('./') || t.contains('../')
-			|| t.contains('-I') || t.contains('-L') || repro_flag_has_abs_path(t)
+			|| t.contains('-I') || t.contains('-L') || t.contains('-include')
+			|| repro_flag_has_abs_path(t) || repro_flag_has_bare_file(t)
 	}
 	if t.starts_with('#pkgconfig') {
 		return false // resolved from installed pkg-config packages, like a system library
@@ -1030,6 +1041,23 @@ fn repro_flag_has_abs_path(directive string) bool {
 		// windows drive-absolute path: `C:\lib\x.a` or `C:/lib/x.a`
 		if field.len >= 3 && field[1] == `:` && (field[2] == `\\` || field[2] == `/`)
 			&& u8(field[0]).is_letter() {
+			return true
+		}
+	}
+	return false
+}
+
+// repro_flag_has_bare_file reports whether a `#flag` directive names a bare relative file
+// argument (`#flag helper.o`, `#flag -include config.h`'s header is caught by the `-include`
+// check): a non-option field containing a `.` is a filename, which the receiver does not have.
+// Platform prefixes (`linux`, `windows`, ...) carry no dot and option fields start with `-`.
+fn repro_flag_has_bare_file(directive string) bool {
+	fields := directive.fields()
+	for field in fields[1..] {
+		if field.starts_with('-') || field.starts_with('$') || field.starts_with('@') {
+			continue
+		}
+		if field.contains('.') {
 			return true
 		}
 	}

--- a/vlib/v/builder/c_error_reproducer.v
+++ b/vlib/v/builder/c_error_reproducer.v
@@ -710,8 +710,8 @@ fn repro_is_markused_root(f ast.FnDecl) bool {
 	}
 	// veb `before_request` hooks are invoked by the framework without any source-level call;
 	// the mark-used pass roots every function whose name ends with `before_request`
-	// (see markused.v), so mirror that here
-	if short == 'before_request' {
+	// (markused.v: `k.ends_with('before_request')`), so mirror that suffix match here
+	if short.ends_with('before_request') {
 		return true
 	}
 	return f.attrs.any(it.name == 'markused' || it.name == 'export')

--- a/vlib/v/builder/c_error_reproducer.v
+++ b/vlib/v/builder/c_error_reproducer.v
@@ -239,6 +239,15 @@ fn (v &Builder) v_source_reproducer(v_file string, v_line int, max_bytes int) st
 	if root_id < 0 || main_id < 0 {
 		return ''
 	}
+	// under -autofree, generated cleanup calls custom `free` methods without any source-level
+	// reference; the mark-used pass retains them (see markused/walker.v), so seed them here too,
+	// or a helper reachable only from a `Foo.free()` is dropped on replay (the recorded build
+	// options include -autofree) and the C error vanishes
+	if v.pref.autofree {
+		for id in name_to_decl['free'] {
+			extra_seeds << id
+		}
+	}
 	// seed from the failing declaration (for its dependencies) and from `main` (so the failing
 	// code stays reachable and the program is runnable); the failing declaration is seeded first
 	mut seeds := [root_id]
@@ -310,6 +319,14 @@ fn (v &Builder) v_source_reproducer(v_file string, v_line int, max_bytes int) st
 	if mod_header == '' {
 		mod_header = 'module main'
 	}
+	// which names each file binds through its own imports: a name used in a file that also
+	// imports it is an import reference, not a local binding
+	mut file_binds := map[string]bool{} // key: "<file_id>\x00<name>"
+	for imp in imports {
+		for t in imp.triggers {
+			file_binds['${imp.file_id}\x00${t}'] = true
+		}
+	}
 	mut scoped_imports := []ReproImport{}
 	mut bound := map[string]string{} // binding name -> the import source that provides it
 	for imp in imports {
@@ -331,6 +348,15 @@ fn (v &Builder) v_source_reproducer(v_file string, v_line int, max_bytes int) st
 			// a file-scoped import binding (e.g. `import time { Time }`) that clashes with an
 			// inlined declaration of the same name would, when flattened, shadow it module-wide
 			if t != '_' && t in included_names {
+				return ''
+			}
+			// the binding may also collide with a parameter or local variable in a retained
+			// declaration from another contributing file (the checker rejects those as duplicate
+			// import symbols once the import becomes file-visible after flattening). Token-level
+			// scanning cannot tell a local binding from a reference, so any use of the name in a
+			// file that does not import it itself is treated as a collision.
+			if t != '_'
+				&& repro_import_collides(t, imp.file_id, included_files, file_referenced, file_binds) {
 				return ''
 			}
 			bound[t] = imp.source
@@ -599,6 +625,24 @@ fn repro_reflection_method_targets(source string) []string {
 		i++
 	}
 	return targets
+}
+
+// repro_import_collides reports whether an import-bound name is also used in a retained
+// declaration from a contributing file that does not import it itself: after flattening, the
+// import becomes visible there and the checker rejects same-named parameters and locals as
+// duplicate import symbols. Uses of the name in files carrying an equivalent import are ordinary
+// references and do not collide.
+fn repro_import_collides(name string, imp_file_id int, included_files map[int]bool, file_referenced map[string]bool, file_binds map[string]bool) bool {
+	for fid, _ in included_files {
+		if fid == imp_file_id {
+			continue
+		}
+		key := '${fid}\x00${name}'
+		if key in file_referenced && key !in file_binds {
+			return true
+		}
+	}
+	return false
 }
 
 // repro_import_stmt reconstructs a single valid `import` line from the AST, so multi-line, aliased

--- a/vlib/v/builder/c_error_reproducer.v
+++ b/vlib/v/builder/c_error_reproducer.v
@@ -611,6 +611,14 @@ fn repro_closure(decls []ReproDecl, name_to_decl map[string][]int, seeds []int) 
 		if repro_source_stringifies(decls[id].source, refs) {
 			refs << 'str'
 		}
+		// `for item in Iterator{}` invokes the iterator's `next` method implicitly: the token
+		// scan sees the type but never `next`, and the replayed check then fails on the loop
+		// (or replayed `skip_unused` drops a helper only `next` reaches). Retain every custom
+		// `next` method when a declaration iterates, mirroring the mark-used walker's struct
+		// iteration handling — the same safe over-approximation as `str` above.
+		if repro_source_iterates(decls[id].source) {
+			refs << 'next'
+		}
 		// `$for m in Foo.methods` reflection needs Foo's methods, which are indexed under the
 		// synthetic `Foo#methods` key; add those refs so the whole method set is retained
 		for t in repro_reflection_method_targets(decls[id].source) {
@@ -666,6 +674,31 @@ fn repro_source_stringifies(source string, refs []string) bool {
 		if r in ['println', 'eprintln', 'print', 'eprint', 'dump', 'assert'] {
 			return true
 		}
+	}
+	return false
+}
+
+// repro_source_iterates reports whether a declaration contains a `for ... in ...` loop, whose
+// iterable may be a custom iterator (invoking its `next` method implicitly). Matched on the
+// keyword sequence with identifier boundaries; `$for` comptime loops iterate metadata, not
+// values, so they do not count.
+fn repro_source_iterates(source string) bool {
+	mut i := 0
+	for i + 3 < source.len {
+		if source[i] == `f` && source[i..i + 3] == 'for'
+			&& (i == 0 || (!is_ident_char(source[i - 1]) && source[i - 1] != `$`))
+			&& !is_ident_char(source[i + 3]) {
+			// a `for` header runs to its `{`; an ` in ` inside it marks iteration
+			mut j := i + 3
+			for j < source.len && source[j] != `{` && source[j] != `\n` {
+				if source[j] == ` ` && j + 3 < source.len && source[j + 1] == `i`
+					&& source[j + 2] == `n` && source[j + 3] == ` ` {
+					return true
+				}
+				j++
+			}
+		}
+		i++
 	}
 	return false
 }

--- a/vlib/v/builder/c_error_reproducer.v
+++ b/vlib/v/builder/c_error_reproducer.v
@@ -227,7 +227,7 @@ fn (v &Builder) v_source_reproducer(v_file string, v_line int, max_bytes int) st
 			// roots (see markused/walker.v mark_markused_consts/mark_markused_globals).
 			mut is_root := false
 			if stmt is ast.FnDecl {
-				is_root = repro_is_markused_root(stmt, int(veb_result_idx))
+				is_root = repro_is_markused_root(stmt, int(veb_result_idx), v.pref.translated)
 					|| (v.pref.is_shared && stmt.is_pub)
 			} else {
 				is_root = repro_decl_attrs(stmt).any(it.name in ['markused', 'export'])
@@ -619,6 +619,15 @@ fn repro_closure(decls []ReproDecl, name_to_decl map[string][]int, seeds []int) 
 		if repro_source_iterates(decls[id].source) {
 			refs << 'next'
 		}
+		// json2.encode invokes a user type's `to_json`/`json_str` hook implicitly when the type
+		// implements the JsonEncoder/Encodable interface: the token scan sees the type and
+		// `encode` but never the hook name, and replaying without the hook selects ordinary
+		// field encoding (dropping a helper only the hook reaches). Retain the hooks whenever a
+		// declaration references `encode`, mirroring the mark-used walker.
+		if 'encode' in refs {
+			refs << 'to_json'
+			refs << 'json_str'
+		}
 		// `$for m in Foo.methods` reflection needs Foo's methods, which are indexed under the
 		// synthetic `Foo#methods` key; add those refs so the whole method set is retained
 		for t in repro_reflection_method_targets(decls[id].source) {
@@ -826,7 +835,7 @@ fn repro_decl_attrs(stmt ast.Stmt) []ast.Attr {
 // `runlock` method (the mark-used pass roots all of these — see markused.v), or one tagged
 // `@[markused]`/`@[export]`. Such a function must be inlined so any helper it alone reaches stays
 // reachable when `skip_unused` runs again on the replayed reproducer.
-fn repro_is_markused_root(f ast.FnDecl, veb_res_idx int) bool {
+fn repro_is_markused_root(f ast.FnDecl, veb_res_idx int, translated bool) bool {
 	short := repro_short_name(f.name)
 	if !f.is_method && short in ['init', 'cleanup'] {
 		return true
@@ -845,6 +854,11 @@ fn repro_is_markused_root(f ast.FnDecl, veb_res_idx int) bool {
 	// mark-used pass roots every function returning `veb.Result`
 	// (walker.v mark_markused_fns), identified by the table's cached type index
 	if veb_res_idx > 0 && int(f.return_type) == veb_res_idx {
+		return true
+	}
+	// a -translated build roots every function carrying a `c` attribute (markused.v), so a
+	// helper called only from one must stay reachable in the replay
+	if translated && f.attrs.any(it.name == 'c') {
 		return true
 	}
 	return f.attrs.any(it.name == 'markused' || it.name == 'export')

--- a/vlib/v/builder/c_error_reproducer.v
+++ b/vlib/v/builder/c_error_reproducer.v
@@ -85,6 +85,9 @@ fn (v &Builder) v_source_reproducer(v_file string, v_line int, max_bytes int) st
 	mut extra_seeds := []int{} // skip_unused roots (init/cleanup/@[markused]/@[export])
 	mut file_headers := map[int]string{} // per-file `module` header (attributes are per-file)
 	mut start_to_decl := map[string]int{} // '<file_id>:<start line>' -> decl id (solver clone dedup)
+	// the `veb.Result` type index, used to seed veb route actions (functions returning `veb.Result`,
+	// which the mark-used pass roots even though nothing in source calls them); 0 when veb is unused
+	veb_result_idx := v.table.find_type('veb.Result')
 	mut file_id := -1
 	for pf in v.parsed_files {
 		file := pf
@@ -218,14 +221,16 @@ fn (v &Builder) v_source_reproducer(v_file string, v_line int, max_bytes int) st
 			}
 			// skip_unused roots are kept regardless of references, so a failing declaration reached
 			// only from one stays reachable. For functions: init/cleanup, `@[markused]`/`@[export]`,
-			// and — for a `-shared` build — every public function. For other declaration kinds
-			// (consts, globals, structs/interfaces, enums, declared types): those tagged
-			// `@[markused]`, which the mark-used pass also roots (see markused.v).
+			// veb hooks and actions, and — for a `-shared` build — every public function. For
+			// other declaration kinds (consts, globals, structs/interfaces, enums, declared
+			// types): those tagged `@[markused]` or `@[export]`, both of which the mark-used pass
+			// roots (see markused/walker.v mark_markused_consts/mark_markused_globals).
 			mut is_root := false
 			if stmt is ast.FnDecl {
-				is_root = repro_is_markused_root(stmt) || (v.pref.is_shared && stmt.is_pub)
+				is_root = repro_is_markused_root(stmt, v.table.veb_res_idx_cache)
+					|| (v.pref.is_shared && stmt.is_pub)
 			} else {
-				is_root = repro_decl_attrs(stmt).any(it.name == 'markused')
+				is_root = repro_decl_attrs(stmt).any(it.name in ['markused', 'export'])
 			}
 			if is_root {
 				extra_seeds << id
@@ -783,7 +788,7 @@ fn repro_decl_attrs(stmt ast.Stmt) []ast.Attr {
 // `runlock` method (the mark-used pass roots all of these — see markused.v), or one tagged
 // `@[markused]`/`@[export]`. Such a function must be inlined so any helper it alone reaches stays
 // reachable when `skip_unused` runs again on the replayed reproducer.
-fn repro_is_markused_root(f ast.FnDecl) bool {
+fn repro_is_markused_root(f ast.FnDecl, veb_res_idx int) bool {
 	short := repro_short_name(f.name)
 	if !f.is_method && short in ['init', 'cleanup'] {
 		return true
@@ -796,6 +801,12 @@ fn repro_is_markused_root(f ast.FnDecl) bool {
 	// the mark-used pass roots every function whose name ends with `before_request`
 	// (markused.v: `k.ends_with('before_request')`), so mirror that suffix match here
 	if short.ends_with('before_request') {
+		return true
+	}
+	// veb route actions are invoked by the router, again without a source-level call: the
+	// mark-used pass roots every function returning `veb.Result`
+	// (walker.v mark_markused_fns), identified by the table's cached type index
+	if veb_res_idx > 0 && int(f.return_type) == veb_res_idx {
 		return true
 	}
 	return f.attrs.any(it.name == 'markused' || it.name == 'export')

--- a/vlib/v/builder/c_error_reproducer.v
+++ b/vlib/v/builder/c_error_reproducer.v
@@ -31,6 +31,7 @@ struct ReproDecl {
 // (including multi-line ones) as a single valid line.
 struct ReproImport {
 	source      string   // the reconstructed import statement
+	mod         string   // the imported module (imports of one module must merge after flattening)
 	triggers    []string // the names that make this import needed (alias + selected symbols)
 	side_effect bool     // `import x as _`: always keep, it is imported for its side effects
 	is_local    bool     // the imported module's source is not uploaded (another parsed user module,
@@ -76,6 +77,9 @@ fn (v &Builder) v_source_reproducer(v_file string, v_line int, max_bytes int) st
 			vmodule_mods[pf.mod.name] = true
 		}
 	}
+	// `-d used_fns=main.entry,glob*` explicitly roots functions in the mark-used pass, and the
+	// report replays the recorded define, so those functions must be seeded here too
+	used_fns_patterns := v.pref.compile_values['used_fns'].split_any(',').filter(it != '')
 	mut decls := []ReproDecl{}
 	mut name_to_decl := map[string][]int{}
 	mut imports := []ReproImport{}
@@ -118,6 +122,7 @@ fn (v &Builder) v_source_reproducer(v_file string, v_line int, max_bytes int) st
 			}
 			imports << ReproImport{
 				source:      repro_import_stmt(imp)
+				mod:         imp.mod
 				triggers:    triggers
 				side_effect: imp.alias == '_'
 				is_local:    (imp.mod in local_mods && imp.mod != root_mod)
@@ -246,6 +251,7 @@ fn (v &Builder) v_source_reproducer(v_file string, v_line int, max_bytes int) st
 			if stmt is ast.FnDecl {
 				is_root = repro_is_markused_root(stmt, int(veb_result_idx), v.pref.translated)
 					|| (v.pref.is_shared && stmt.is_pub)
+					|| repro_fn_in_used_fns(stmt.name, used_fns_patterns)
 			} else {
 				is_root = repro_decl_attrs(stmt).any(it.name in ['markused', 'export'])
 				// a -shared build also retains every public constant and walks its initializer
@@ -399,6 +405,10 @@ fn (v &Builder) v_source_reproducer(v_file string, v_line int, max_bytes int) st
 		}
 		scoped_imports << imp
 	}
+	// imports are file-scoped in the original program, but the flattened file has one scope: two
+	// import statements naming the same module are rejected by the checker as a duplicate import
+	// even when their trigger names differ (`import log` + `import log as _`)
+	scoped_imports = repro_merge_module_imports(scoped_imports) or { return '' }
 	// hash directives are module-wide: the original build applies `#flag`/`#include`/... from
 	// every parsed file of the module, whether or not any of that file's declarations are
 	// retained (a hash-only `.c.v` companion file is common), so all of them are kept. A
@@ -812,6 +822,39 @@ fn repro_import_collides(name string, imp_file_id int, included_files map[int]bo
 	return false
 }
 
+// repro_merge_module_imports collapses retained imports of the same module into one statement:
+// exact duplicates are dropped, and a side-effect-only import (`import x as _`) is subsumed by
+// any other import of the module (importing it at all runs its initializers). Returns none when
+// two genuinely different forms of one module remain (`import log` + `import log as l`), which
+// one flattened file cannot express.
+fn repro_merge_module_imports(imports []ReproImport) ?[]ReproImport {
+	mut primary := map[string]string{} // module -> its non-side-effect import statement
+	for imp in imports {
+		if !imp.side_effect {
+			if existing := primary[imp.mod] {
+				if existing != imp.source {
+					return none
+				}
+			} else {
+				primary[imp.mod] = imp.source
+			}
+		}
+	}
+	mut merged := []ReproImport{}
+	mut seen := map[string]bool{}
+	for imp in imports {
+		if imp.side_effect && imp.mod in primary {
+			continue
+		}
+		if imp.source in seen {
+			continue
+		}
+		seen[imp.source] = true
+		merged << imp
+	}
+	return merged
+}
+
 // repro_import_stmt reconstructs a single valid `import` line from the AST, so multi-line, aliased
 // and selective imports (including the combined `import x as y { Sym }` form) survive as one
 // syntactically complete statement.
@@ -895,6 +938,22 @@ fn repro_is_markused_root(f ast.FnDecl, veb_res_idx int, translated bool) bool {
 		return true
 	}
 	return f.attrs.any(it.name == 'markused' || it.name == 'export')
+}
+
+// repro_fn_in_used_fns reports whether a function's qualified name is selected by the
+// `-d used_fns=...` define, matching exactly like the mark-used pass: literal names compare
+// against the full key, and patterns containing `*` glob-match it.
+fn repro_fn_in_used_fns(name string, patterns []string) bool {
+	for p in patterns {
+		if p.contains('*') {
+			if name.match_glob(p) {
+				return true
+			}
+		} else if name == p {
+			return true
+		}
+	}
+	return false
 }
 
 // repro_hash_is_local reports whether a `#`-directive depends on a project-local file or path that

--- a/vlib/v/builder/c_error_reproducer.v
+++ b/vlib/v/builder/c_error_reproducer.v
@@ -231,6 +231,11 @@ fn (v &Builder) v_source_reproducer(v_file string, v_line int, max_bytes int) st
 					|| (v.pref.is_shared && stmt.is_pub)
 			} else {
 				is_root = repro_decl_attrs(stmt).any(it.name in ['markused', 'export'])
+				// a -shared build also retains every public constant and walks its initializer
+				// (markused.v), so a helper called only from one must stay reachable
+				if !is_root && v.pref.is_shared && stmt is ast.ConstDecl && stmt.is_pub {
+					is_root = true
+				}
 			}
 			if is_root {
 				extra_seeds << id
@@ -1097,53 +1102,86 @@ fn is_ident_char(c u8) bool {
 // Returns '' when the declaration has no source-visible plain name (operator overloads), or when
 // no `fn` line is found.
 fn repro_source_fn_name(source string) string {
-	for line in source.split_into_lines() {
-		t := line.trim_space()
-		if t == '' || t.starts_with('@[') || t.starts_with('//') {
+	// skip leading whitespace, comments and attribute groups; attributes are scanned as bracket
+	// groups with string-aware depth, so a multiline value (`@[footer: 'Hello\nWorld']`) is
+	// skipped whole instead of its continuation line being mistaken for the declaration
+	mut i := 0
+	for i < source.len {
+		c := source[i]
+		if c == ` ` || c == `\t` || c == `\n` || c == `\r` {
+			i++
 			continue
 		}
-		mut rest := t
-		if rest.starts_with('pub ') {
-			rest = rest['pub '.len..].trim_space()
+		if c == `/` && i + 1 < source.len && source[i + 1] == `/` {
+			for i < source.len && source[i] != `\n` {
+				i++
+			}
+			continue
 		}
-		if !rest.starts_with('fn ') && !rest.starts_with('fn(') {
+		if c == `@` && i + 1 < source.len && source[i + 1] == `[` {
+			i += 2
+			mut depth := 1
+			for i < source.len && depth > 0 {
+				ch := source[i]
+				if ch == `'` || ch == `"` {
+					i++
+					for i < source.len && source[i] != ch {
+						i += if source[i] == `\\` { 2 } else { 1 }
+					}
+					i++
+					continue
+				}
+				if ch == `[` {
+					depth++
+				} else if ch == `]` {
+					depth--
+				}
+				i++
+			}
+			continue
+		}
+		break
+	}
+	mut rest := source[i..]
+	if rest.starts_with('pub ') {
+		rest = rest['pub '.len..].trim_left(' \t')
+	}
+	if !rest.starts_with('fn ') && !rest.starts_with('fn(') {
+		return ''
+	}
+	mut j := 2
+	for j < rest.len && (rest[j] == ` ` || rest[j] == `\t`) {
+		j++
+	}
+	// skip a method's parenthesized receiver
+	if j < rest.len && rest[j] == `(` {
+		for j < rest.len && rest[j] != `)` {
+			j++
+		}
+		j++
+		for j < rest.len && (rest[j] == ` ` || rest[j] == `\t`) {
+			j++
+		}
+	}
+	// the name: an identifier, possibly dotted (`C.puts`, `JS.alert`); keep the last segment
+	// to match how AST names are indexed (repro_short_name)
+	mut last := ''
+	for {
+		name_start := j
+		for j < rest.len && is_ident_char(rest[j]) {
+			j++
+		}
+		if j == name_start {
 			return ''
 		}
-		mut i := 2
-		for i < rest.len && (rest[i] == ` ` || rest[i] == `\t`) {
-			i++
+		last = rest[name_start..j]
+		if j < rest.len && rest[j] == `.` {
+			j++
+			continue
 		}
-		// skip a method's parenthesized receiver
-		if i < rest.len && rest[i] == `(` {
-			for i < rest.len && rest[i] != `)` {
-				i++
-			}
-			i++
-			for i < rest.len && (rest[i] == ` ` || rest[i] == `\t`) {
-				i++
-			}
-		}
-		// the name: an identifier, possibly dotted (`C.puts`, `JS.alert`); keep the last segment
-		// to match how AST names are indexed (repro_short_name)
-		mut last := ''
-		for {
-			name_start := i
-			for i < rest.len && is_ident_char(rest[i]) {
-				i++
-			}
-			if i == name_start {
-				return ''
-			}
-			last = rest[name_start..i]
-			if i < rest.len && rest[i] == `.` {
-				i++
-				continue
-			}
-			break
-		}
-		return last
+		break
 	}
-	return ''
+	return last
 }
 
 // repro_short_name returns the last, unqualified component of a possibly module-qualified name

--- a/vlib/v/builder/c_error_reproducer.v
+++ b/vlib/v/builder/c_error_reproducer.v
@@ -227,7 +227,7 @@ fn (v &Builder) v_source_reproducer(v_file string, v_line int, max_bytes int) st
 			// roots (see markused/walker.v mark_markused_consts/mark_markused_globals).
 			mut is_root := false
 			if stmt is ast.FnDecl {
-				is_root = repro_is_markused_root(stmt, v.table.veb_res_idx_cache)
+				is_root = repro_is_markused_root(stmt, int(veb_result_idx))
 					|| (v.pref.is_shared && stmt.is_pub)
 			} else {
 				is_root = repro_decl_attrs(stmt).any(it.name in ['markused', 'export'])

--- a/vlib/v/builder/c_error_reproducer.v
+++ b/vlib/v/builder/c_error_reproducer.v
@@ -1,0 +1,506 @@
+module builder
+
+import os
+import v.ast
+
+// Building a self-contained reproducer for a C error: starting from the failing V declaration
+// (the one the C error's `#line` maps back to), inline the transitive closure of the declarations
+// it references (types, consts, globals, functions), together with the imports and C-interop `#`
+// directives they need, into a single `module main` file.
+//
+// To stay correct and to keep the amount of uploaded source down, this only ever inlines
+// declarations from the *single module* that the failing file belongs to, and only when that
+// module contains `fn main` (i.e. an ordinary single-module program). Anything that would need
+// declarations from another module — a failure inside an imported local module, a cross-module
+// call chain — makes it give up and return '', so the caller falls back to a plain source window
+// rather than emitting a broken multi-module flatten. The reference graph is approximated by
+// matching identifier tokens (ignoring string and comment contents) against the module's top-level
+// names, and the assembled output is bounded as whole declarations.
+
+const c_error_repro_max_decls = 80
+
+// ReproDecl is one top-level declaration, ready to be inlined into a reproducer.
+struct ReproDecl {
+	names   []string // the (short, unqualified) top-level names it defines
+	source  string   // its exact source text, including any leading attributes
+	file_id int      // which contributing file it came from (imports are file-scoped)
+}
+
+// ReproImport is an `import` statement, reconstructed from the AST so selective symbols
+// (`import x { a }`), aliases (`import x as y`) and side-effect imports (`import x as _`) survive
+// (including multi-line ones) as a single valid line.
+struct ReproImport {
+	source      string   // the reconstructed import statement
+	triggers    []string // the names that make this import needed (alias + selected symbols)
+	side_effect bool     // `import x as _`: always keep, it is imported for its side effects
+	is_local    bool     // the imported module is another parsed user module (not inlinable here)
+	file_id     int      // the file this import belongs to (imports are file-scoped)
+}
+
+// v_source_reproducer builds a self-contained reproducer for the failing V line, or '' when it
+// cannot (no mapping, the failure is not in an ordinary single-module `main` program, or the
+// reproducer would not fit the byte budget).
+fn (v &Builder) v_source_reproducer(v_file string, v_line int, max_bytes int) string {
+	if v_file == '' || v_line <= 0 || v.parsed_files.len == 0 || !is_user_repro_file(v_file) {
+		return ''
+	}
+	target_path := os.real_path(v_file)
+	// find the failing file and its module; only that module's declarations are inlined
+	mut root_mod := ''
+	for pf in v.parsed_files {
+		if os.real_path(pf.path) == target_path {
+			root_mod = pf.mod.name
+			break
+		}
+	}
+	if root_mod == '' {
+		return ''
+	}
+	// modules backed by parsed user files: importing one of these (other than `root_mod`) means
+	// the reproducer would depend on source we do not inline, so it cannot be standalone.
+	mut local_mods := map[string]bool{}
+	for pf in v.parsed_files {
+		if is_user_repro_file(pf.path) {
+			local_mods[pf.mod.name] = true
+		}
+	}
+	mut decls := []ReproDecl{}
+	mut name_to_decl := map[string][]int{}
+	mut imports := []ReproImport{}
+	mut hashes := []string{}
+	mut root_id := -1
+	mut main_id := -1
+	mut file_id := -1
+	for pf in v.parsed_files {
+		file := pf
+		if file.mod.name != root_mod || !is_user_repro_file(file.path) {
+			continue
+		}
+		file_id++
+		is_root_file := os.real_path(file.path) == target_path
+		src := os.read_file(file.path) or { continue }
+		lines := src.split_into_lines()
+		if lines.len == 0 {
+			continue
+		}
+		for imp in file.imports {
+			mut triggers := [repro_import_alias(imp)]
+			for s in imp.syms {
+				triggers << s.name
+			}
+			imports << ReproImport{
+				source:      repro_import_stmt(imp)
+				triggers:    triggers
+				side_effect: imp.alias == '_'
+				is_local:    imp.mod in local_mods && imp.mod != root_mod
+				file_id:     file_id
+			}
+		}
+		// attribute-aware start line (0-based) of every top-level statement partitions the file;
+		// top-level attributes are parsed before the declaration, so extend each start up over them
+		mut starts := []int{}
+		for stmt in file.stmts {
+			starts << repro_attr_start(lines, ast.Node(stmt).pos().line_nr)
+		}
+		for i, stmt in file.stmts {
+			start := starts[i]
+			if start < 0 || start >= lines.len {
+				continue
+			}
+			mut end := lines.len
+			for s in starts {
+				if s > start && s < end {
+					end = s
+				}
+			}
+			source := repro_decl_source(lines, start, end)
+			if source == '' {
+				continue
+			}
+			if stmt is ast.HashStmt {
+				hashes << source
+				continue
+			}
+			names := repro_top_decl_names(stmt)
+			if names.len == 0 {
+				continue
+			}
+			id := decls.len
+			decls << ReproDecl{
+				names:   names
+				source:  source
+				file_id: file_id
+			}
+			for n in names {
+				name_to_decl[n] << id
+			}
+			if stmt is ast.FnDecl && stmt.is_main {
+				main_id = id
+			}
+			if is_root_file && v_line - 1 >= start && v_line - 1 < end {
+				root_id = id
+			}
+		}
+	}
+	// only ordinary single-module `main` programs are handled; otherwise fall back
+	if root_id < 0 || main_id < 0 {
+		return ''
+	}
+	// seed from the failing declaration (for its dependencies) and from `main` (so the failing
+	// code stays reachable and the program is runnable); the failing declaration is seeded first
+	mut seeds := [root_id]
+	if main_id != root_id {
+		seeds << main_id
+	}
+	// `none` means the closure hit the declaration cap, i.e. it is incomplete; fall back rather
+	// than upload a program with missing symbols
+	ordered := repro_closure(decls, name_to_decl, seeds) or { return '' }
+	if ordered.len == 0 {
+		return ''
+	}
+	mut referenced := map[string]bool{}
+	for id in ordered {
+		for name in repro_identifiers(decls[id].source) {
+			referenced[name] = true
+		}
+	}
+	// imports are file-scoped: only consider imports from files that actually contributed an
+	// inlined declaration, so a same-alias import from an unselected file is never emitted
+	mut included_files := map[int]bool{}
+	for id in ordered {
+		included_files[decls[id].file_id] = true
+	}
+	mut scoped_imports := []ReproImport{}
+	mut bound := map[string]string{} // binding name -> the import source that provides it
+	for imp in imports {
+		if imp.file_id !in included_files {
+			continue
+		}
+		if !imp.side_effect && !imp.triggers.any(referenced[it]) {
+			continue
+		}
+		// a needed project-local import cannot be satisfied by the single uploaded file
+		if imp.is_local {
+			return ''
+		}
+		// two files binding the same name to different modules cannot be flattened into one file
+		for t in imp.triggers {
+			if t in bound && bound[t] != imp.source {
+				return ''
+			}
+			bound[t] = imp.source
+		}
+		scoped_imports << imp
+	}
+	// every declaration in the closure is required, so an over-budget reproducer is dropped whole
+	// (the caller then falls back to a source window) rather than emitting a partial program
+	out := repro_render(scoped_imports, hashes, decls, ordered)
+	if out == '' || (max_bytes > 0 && out.len > max_bytes) {
+		return ''
+	}
+	return out
+}
+
+// repro_attr_start returns the first line (0-based) of the declaration at `line_nr`, walking up
+// over any leading `@[...]` attribute lines (which are parsed before the declaration node).
+fn repro_attr_start(lines []string, line_nr int) int {
+	mut s := if line_nr < 0 {
+		0
+	} else if line_nr >= lines.len {
+		lines.len
+	} else {
+		line_nr
+	}
+	for s > 0 && lines[s - 1].trim_space().starts_with('@[') {
+		s--
+	}
+	return s
+}
+
+// repro_decl_source returns lines `[start, end)` (0-based) joined, with trailing blank lines trimmed.
+fn repro_decl_source(lines []string, start int, end int) string {
+	mut e := if end > lines.len { lines.len } else { end }
+	for e > start + 1 && lines[e - 1].trim_space() == '' {
+		e--
+	}
+	if start < 0 || start >= e {
+		return ''
+	}
+	return lines[start..e].join('\n')
+}
+
+// repro_closure returns the indices of declarations reachable from `seeds` by identifier reference.
+// The seeds are always kept. It returns `none` when the closure would exceed
+// `c_error_repro_max_decls` declarations: every reached declaration is required, so a truncated
+// closure would be a program with missing symbols and the caller should fall back instead.
+fn repro_closure(decls []ReproDecl, name_to_decl map[string][]int, seeds []int) ?[]int {
+	mut included := []bool{len: decls.len}
+	mut order := []int{}
+	mut queue := []int{}
+	mut is_seed := []bool{len: decls.len}
+	for s in seeds {
+		if s >= 0 && s < decls.len {
+			queue << s
+			is_seed[s] = true
+		}
+	}
+	if queue.len == 0 {
+		return []
+	}
+	for queue.len > 0 {
+		id := queue[0]
+		queue.delete(0)
+		if id < 0 || id >= decls.len || included[id] {
+			continue
+		}
+		if !is_seed[id] && order.len >= c_error_repro_max_decls {
+			// a required declaration cannot be included within the cap
+			return none
+		}
+		included[id] = true
+		order << id
+		mut refs := repro_identifiers(decls[id].source)
+		// overloaded operators are indexed under their punctuation method name (`+`, `[]`, ...),
+		// which is not an identifier token, so add the operator methods a declaration may use
+		refs << repro_operator_refs(decls[id].source)
+		for name in refs {
+			for ref in name_to_decl[name] {
+				if ref >= 0 && ref < decls.len && !included[ref] {
+					queue << ref
+				}
+			}
+		}
+	}
+	order.sort()
+	return order
+}
+
+// repro_operator_refs returns the operator-overload method names (`+`, `[]`, ...) that `source`
+// might use, so their declarations are pulled into the closure. It over-approximates (a `+` on
+// ints also lists `+`), which is harmless: unmatched operator names simply resolve to nothing.
+fn repro_operator_refs(source string) []string {
+	mut ops := []string{}
+	if source.contains('[') {
+		ops << '[]'
+		ops << '[]='
+	}
+	if source.contains('==') || source.contains('!=') {
+		ops << '=='
+	}
+	if source.contains('<') || source.contains('>') {
+		ops << '<'
+		ops << '=='
+	}
+	if source.contains('**') {
+		ops << '**'
+	}
+	for c in ['+', '-', '*', '/', '%'] {
+		if source.contains(c) {
+			ops << c
+		}
+	}
+	return ops
+}
+
+// repro_import_stmt reconstructs a single valid `import` line from the AST, so multi-line, aliased
+// and selective imports (including the combined `import x as y { Sym }` form) survive as one
+// syntactically complete statement.
+fn repro_import_stmt(imp ast.Import) string {
+	mut s := 'import ${imp.source_name}'
+	if imp.alias != '' && imp.alias != imp.source_name.all_after_last('.') {
+		s += ' as ${imp.alias}'
+	}
+	if imp.syms.len > 0 {
+		s += ' { ${imp.syms.map(it.name).join(', ')} }'
+	}
+	return s
+}
+
+// repro_render assembles the given declaration ids into a single `module main` source string.
+fn repro_render(imports []ReproImport, hashes []string, decls []ReproDecl, ids []int) string {
+	mut parts := []string{cap: ids.len}
+	for id in ids {
+		if id >= 0 && id < decls.len {
+			parts << decls[id].source
+		}
+	}
+	body := parts.join('\n\n')
+	mut referenced := map[string]bool{}
+	for name in repro_identifiers(body) {
+		referenced[name] = true
+	}
+	mut out := 'module main\n\n'
+	mut emitted := map[string]bool{}
+	for imp in imports {
+		if imp.source == '' || imp.source in emitted {
+			continue
+		}
+		mut needed := imp.side_effect
+		for t in imp.triggers {
+			if referenced[t] {
+				needed = true
+				break
+			}
+		}
+		if !needed {
+			continue
+		}
+		emitted[imp.source] = true
+		out += imp.source + '\n'
+	}
+	for h in hashes {
+		out += h + '\n'
+	}
+	out += '\n' + body
+	return out
+}
+
+// repro_identifiers returns the identifier tokens in `source`, skipping the contents of comments,
+// string and rune literals (so incidental words there do not pull unrelated declarations into the
+// reproducer). Identifiers inside `${...}` string interpolations are still collected.
+fn repro_identifiers(source string) []string {
+	mut ids := []string{}
+	mut i := 0
+	for i < source.len {
+		c := source[i]
+		if c == `/` && i + 1 < source.len && source[i + 1] == `/` {
+			for i < source.len && source[i] != `\n` {
+				i++
+			}
+			continue
+		}
+		if c == `/` && i + 1 < source.len && source[i + 1] == `*` {
+			i += 2
+			for i + 1 < source.len && !(source[i] == `*` && source[i + 1] == `/`) {
+				i++
+			}
+			i += 2
+			continue
+		}
+		if c == `'` || c == `"` {
+			i = scan_string_literal(source, i, mut ids)
+			continue
+		}
+		if c == 96 { // backtick rune literal
+			i++
+			for i < source.len && source[i] != 96 {
+				i += if source[i] == `\\` { 2 } else { 1 }
+			}
+			i++
+			continue
+		}
+		if c == `_` || c.is_letter() {
+			start := i
+			for i < source.len && is_ident_char(source[i]) {
+				i++
+			}
+			ids << source[start..i]
+			continue
+		}
+		i++
+	}
+	return ids
+}
+
+// scan_string_literal skips a `'`/`"` string starting at `start`, collecting identifiers found in
+// its `${...}` interpolations into `ids`, and returns the index just past the closing quote.
+fn scan_string_literal(source string, start int, mut ids []string) int {
+	quote := source[start]
+	mut i := start + 1
+	for i < source.len && source[i] != quote {
+		if source[i] == `\\` {
+			i += 2
+			continue
+		}
+		if source[i] == `$` && i + 1 < source.len && source[i + 1] == `{` {
+			i += 2
+			mut depth := 1
+			for i < source.len && depth > 0 {
+				ci := source[i]
+				if ci == `{` {
+					depth++
+					i++
+				} else if ci == `}` {
+					depth--
+					i++
+				} else if ci == `_` || ci.is_letter() {
+					st := i
+					for i < source.len && is_ident_char(source[i]) {
+						i++
+					}
+					ids << source[st..i]
+				} else {
+					i++
+				}
+			}
+			continue
+		}
+		i++
+	}
+	return i + 1
+}
+
+@[inline]
+fn is_ident_char(c u8) bool {
+	return c == `_` || c.is_letter() || c.is_digit()
+}
+
+// repro_short_name returns the last, unqualified component of a possibly module-qualified name
+// (`main.Foo.bar` -> `bar`, `math.abs` -> `abs`, `Foo` -> `Foo`).
+fn repro_short_name(name string) string {
+	return name.all_after_last('.')
+}
+
+// repro_import_alias returns the name an import is referred to by in code.
+fn repro_import_alias(imp ast.Import) string {
+	if imp.alias != '' {
+		return imp.alias
+	}
+	return imp.mod.all_after_last('.')
+}
+
+// repro_top_decl_names returns the top-level names a statement defines, or [] when it is not an
+// inlinable top-level declaration.
+fn repro_top_decl_names(stmt ast.Stmt) []string {
+	match stmt {
+		ast.FnDecl {
+			return [repro_short_name(stmt.name)]
+		}
+		ast.StructDecl {
+			return [repro_short_name(stmt.name)]
+		}
+		ast.EnumDecl {
+			return [repro_short_name(stmt.name)]
+		}
+		ast.InterfaceDecl {
+			return [repro_short_name(stmt.name)]
+		}
+		ast.TypeDecl {
+			match stmt {
+				ast.AliasTypeDecl { return [repro_short_name(stmt.name)] }
+				ast.SumTypeDecl { return [repro_short_name(stmt.name)] }
+				ast.FnTypeDecl { return [repro_short_name(stmt.name)] }
+			}
+		}
+		ast.ConstDecl {
+			return stmt.fields.map(repro_short_name(it.name))
+		}
+		ast.GlobalDecl {
+			return stmt.fields.map(repro_short_name(it.name))
+		}
+		else {
+			return []
+		}
+	}
+}
+
+// is_user_repro_file reports whether `path` is user code that is safe to inline into a reproducer
+// (as opposed to vlib/stdlib or an installed module, which are referenced via `import` instead).
+fn is_user_repro_file(path string) bool {
+	if path == '' || !is_v_source_file(path) {
+		return false
+	}
+	norm := path.replace('\\', '/')
+	return !norm.contains('/vlib/') && !norm.contains('/.vmodules/')
+		&& !norm.contains('/thirdparty/')
+}

--- a/vlib/v/builder/c_error_reproducer.v
+++ b/vlib/v/builder/c_error_reproducer.v
@@ -708,6 +708,12 @@ fn repro_is_markused_root(f ast.FnDecl) bool {
 	if f.is_method && short in ['lock', 'unlock', 'rlock', 'runlock'] {
 		return true
 	}
+	// veb `before_request` hooks are invoked by the framework without any source-level call;
+	// the mark-used pass roots every function whose name ends with `before_request`
+	// (see markused.v), so mirror that here
+	if short == 'before_request' {
+		return true
+	}
 	return f.attrs.any(it.name == 'markused' || it.name == 'export')
 }
 
@@ -761,11 +767,14 @@ fn repro_source_has_toplevel_import(source string) bool {
 	return false
 }
 
-// repro_uses_local_resource reports whether a declaration uses a compile-time construct that reads
-// a project-local file (`$embed_file`, `$tmpl`, `$res`) which is not uploaded with the reproducer.
+// repro_uses_local_resource reports whether a declaration uses a compile-time construct whose
+// value depends on the build machine and is not carried by the report: a project-local file
+// (`$embed_file`, `$tmpl`, `$res`) or the builder's environment (`$env`, baked in at compile
+// time - replaying it against the receiver's environment can change the generated C and lose
+// the error).
 fn repro_uses_local_resource(source string) bool {
 	return source.contains('\$embed_file(') || source.contains('\$tmpl(')
-		|| source.contains('\$res(')
+		|| source.contains('\$res(') || source.contains('\$env(')
 }
 
 // repro_render assembles the given declaration ids into a single-file source string, headed by

--- a/vlib/v/builder/c_error_reproducer.v
+++ b/vlib/v/builder/c_error_reproducer.v
@@ -302,6 +302,12 @@ fn (v &Builder) v_source_reproducer(v_file string, v_line int, max_bytes int) st
 		if repro_source_has_toplevel_import(decls[id].source) {
 			return ''
 		}
+		// a retained top-level comptime block can likewise embed its own `#` directive; a
+		// project-local one (`#include "private.h"`, `#flag ./local.o`) references a file that
+		// is not uploaded, so the flattened program cannot be standalone
+		if repro_embedded_local_hash(decls[id].source) {
+			return ''
+		}
 		reflection_targets << repro_reflection_method_targets(decls[id].source)
 		for n in decls[id].names {
 			included_names[n] = true
@@ -376,18 +382,20 @@ fn (v &Builder) v_source_reproducer(v_file string, v_line int, max_bytes int) st
 		}
 		scoped_imports << imp
 	}
-	// hash directives are file-scoped too. A project-local dependency (`#include "private.h"`, a
-	// path/`@V...`-based `#flag`, ...) references a file we do not upload, so fall back instead of
-	// emitting a directive the receiver cannot satisfy.
+	// hash directives are module-wide: the original build applies `#flag`/`#include`/... from
+	// every parsed file of the module, whether or not any of that file's declarations are
+	// retained (a hash-only `.c.v` companion file is common), so all of them are kept. A
+	// project-local dependency (`#include "private.h"`, a path/`@V...`-based `#flag`, ...)
+	// references a file we do not upload, so fall back instead of emitting a directive the
+	// receiver cannot satisfy.
 	mut scoped_hashes := []string{}
 	for h in hashes {
-		if h.file_id !in included_files {
-			continue
-		}
 		if repro_hash_is_local(h.source) {
 			return ''
 		}
-		scoped_hashes << h.source
+		if h.source !in scoped_hashes {
+			scoped_hashes << h.source
+		}
 	}
 	// every declaration in the closure is required, so an over-budget reproducer is dropped whole
 	// (the caller then falls back to a source window) rather than emitting a partial program
@@ -914,13 +922,28 @@ fn repro_source_has_toplevel_import(source string) bool {
 	return false
 }
 
+// repro_embedded_local_hash reports whether a declaration's copied source embeds a
+// project-local `#` directive. Ordinary top-level hash statements are separate declarations and
+// never appear inside another declaration's source, so any `#` line here comes from a retained
+// comptime `$if`/`$match` block (they are uploaded verbatim, which is fine for system headers
+// and libraries, but a local path cannot be satisfied on the receiver).
+fn repro_embedded_local_hash(source string) bool {
+	for line in source.split_into_lines() {
+		t := line.trim_space()
+		if t.starts_with('#') && repro_hash_is_local(t) {
+			return true
+		}
+	}
+	return false
+}
+
 // repro_uses_local_resource reports whether a declaration uses a compile-time construct whose
 // value depends on the build machine and is not carried by the report: a project-local file
 // (`$embed_file`, `$tmpl`, `$res`) or the builder's environment (`$env`, baked in at compile
 // time - replaying it against the receiver's environment can change the generated C and lose
 // the error).
 fn repro_uses_local_resource(source string) bool {
-	for name in ['embed_file', 'tmpl', 'res', 'env'] {
+	for name in ['embed_file', 'tmpl', 'res', 'env', 'veb.html'] {
 		if repro_has_comptime_call(source, name) {
 			return true
 		}

--- a/vlib/v/builder/c_error_reproducer.v
+++ b/vlib/v/builder/c_error_reproducer.v
@@ -33,8 +33,9 @@ struct ReproImport {
 	source      string   // the reconstructed import statement
 	triggers    []string // the names that make this import needed (alias + selected symbols)
 	side_effect bool     // `import x as _`: always keep, it is imported for its side effects
-	is_local    bool     // the imported module is another parsed user module (not inlinable here)
-	file_id     int      // the file this import belongs to (imports are file-scoped)
+	is_local    bool     // the imported module's source is not uploaded (another parsed user module,
+	// or an installed `.vmodules` package): needs the source-window fallback
+	file_id int // the file this import belongs to (imports are file-scoped)
 }
 
 // ReproHash is a top-level `#include` / `#flag` / ... C-interop directive and the file it is in.
@@ -63,11 +64,16 @@ fn (v &Builder) v_source_reproducer(v_file string, v_line int, max_bytes int) st
 		return ''
 	}
 	// modules backed by parsed user files: importing one of these (other than `root_mod`) means
-	// the reproducer would depend on source we do not inline, so it cannot be standalone.
+	// the reproducer would depend on source we do not inline, so it cannot be standalone. Likewise,
+	// modules backed by installed `~/.vmodules` packages are kept out of the upload (no sources, no
+	// version metadata), so importing one also forces the source-window fallback.
 	mut local_mods := map[string]bool{}
+	mut vmodule_mods := map[string]bool{}
 	for pf in v.parsed_files {
 		if is_user_repro_file(pf.path) {
 			local_mods[pf.mod.name] = true
+		} else if pf.path.replace('\\', '/').contains('/.vmodules/') {
+			vmodule_mods[pf.mod.name] = true
 		}
 	}
 	mut decls := []ReproDecl{}
@@ -110,7 +116,8 @@ fn (v &Builder) v_source_reproducer(v_file string, v_line int, max_bytes int) st
 				source:      repro_import_stmt(imp)
 				triggers:    triggers
 				side_effect: imp.alias == '_'
-				is_local:    imp.mod in local_mods && imp.mod != root_mod
+				is_local:    (imp.mod in local_mods && imp.mod != root_mod)
+					|| imp.mod in vmodule_mods
 				file_id:     file_id
 			}
 		}
@@ -163,11 +170,18 @@ fn (v &Builder) v_source_reproducer(v_file string, v_line int, max_bytes int) st
 			if stmt is ast.FnDecl && stmt.is_main {
 				main_id = id
 			}
-			// skip_unused roots are kept regardless of references, so a failing helper reached only
-			// from one stays reachable: init/cleanup, `@[markused]`/`@[export]`, and — for a
-			// `-shared` build — every public function (markused roots all of them).
-			if stmt is ast.FnDecl
-				&& (repro_is_markused_root(stmt) || (v.pref.is_shared && stmt.is_pub)) {
+			// skip_unused roots are kept regardless of references, so a failing declaration reached
+			// only from one stays reachable. For functions: init/cleanup, `@[markused]`/`@[export]`,
+			// and — for a `-shared` build — every public function. For other declaration kinds
+			// (consts, globals, structs/interfaces, enums, declared types): those tagged
+			// `@[markused]`, which the mark-used pass also roots (see markused.v).
+			mut is_root := false
+			if stmt is ast.FnDecl {
+				is_root = repro_is_markused_root(stmt) || (v.pref.is_shared && stmt.is_pub)
+			} else {
+				is_root = repro_decl_attrs(stmt).any(it.name == 'markused')
+			}
+			if is_root {
 				extra_seeds << id
 			}
 			if is_root_file && v_line - 1 >= start && v_line - 1 < end {
@@ -283,7 +297,10 @@ fn (v &Builder) v_source_reproducer(v_file string, v_line int, max_bytes int) st
 }
 
 // repro_attr_start returns the first line (0-based) of the declaration at `line_nr`, walking up
-// over any leading `@[...]` attribute lines (which are parsed before the declaration node).
+// over any leading `@[...]` attribute groups (which are parsed before the declaration node). An
+// attribute may span several lines (`@[footer: 'Hello\nWorld']`), so the line directly above a
+// declaration can be an attribute *continuation* rather than one starting with `@[`; balance the
+// `[`/`]` brackets upward to find the line that opens the group instead of checking only prefixes.
 fn repro_attr_start(lines []string, line_nr int) int {
 	mut s := if line_nr < 0 {
 		0
@@ -292,10 +309,43 @@ fn repro_attr_start(lines []string, line_nr int) int {
 	} else {
 		line_nr
 	}
-	for s > 0 && lines[s - 1].trim_space().starts_with('@[') {
-		s--
+	for s > 0 {
+		end := s - 1
+		if !lines[end].trim_space().ends_with(']') {
+			break // the line above the declaration does not close an attribute group
+		}
+		// find the line that opens this group by balancing brackets from `end` upward
+		mut open := end
+		mut bal := 0
+		for open >= 0 {
+			bal += repro_bracket_delta(lines[open])
+			if bal == 0 {
+				break
+			}
+			open--
+		}
+		// only treat it as an attribute group when the balancing line actually opens with `@[`
+		// (this stops a preceding array/const declaration ending in `]` from being swallowed)
+		if open < 0 || bal != 0 || !lines[open].trim_space().starts_with('@[') {
+			break
+		}
+		s = open
 	}
 	return s
+}
+
+// repro_bracket_delta returns the net bracket balance of a line: the count of `[` minus the count
+// of `]`. Used to locate where a possibly multi-line `@[...]` attribute group opens.
+fn repro_bracket_delta(line string) int {
+	mut d := 0
+	for c in line {
+		if c == `[` {
+			d++
+		} else if c == `]` {
+			d--
+		}
+	}
+	return d
 }
 
 // repro_decl_source returns lines `[start, end)` (0-based) joined, with trailing blank lines trimmed.
@@ -397,6 +447,41 @@ fn repro_import_stmt(imp ast.Import) string {
 	return s
 }
 
+// repro_decl_attrs returns the attributes attached to a top-level declaration, for any of the
+// declaration kinds that can carry `@[markused]` and become a mark-used root.
+fn repro_decl_attrs(stmt ast.Stmt) []ast.Attr {
+	match stmt {
+		ast.FnDecl {
+			return stmt.attrs
+		}
+		ast.StructDecl {
+			return stmt.attrs
+		}
+		ast.InterfaceDecl {
+			return stmt.attrs
+		}
+		ast.EnumDecl {
+			return stmt.attrs
+		}
+		ast.ConstDecl {
+			return stmt.attrs
+		}
+		ast.GlobalDecl {
+			return stmt.attrs
+		}
+		ast.TypeDecl {
+			match stmt {
+				ast.AliasTypeDecl { return stmt.attrs }
+				ast.SumTypeDecl { return stmt.attrs }
+				ast.FnTypeDecl { return stmt.attrs }
+			}
+		}
+		else {
+			return []
+		}
+	}
+}
+
 // repro_is_markused_root reports whether a function is a `skip_unused` root that is retained even
 // when nothing references it: an `init`/`cleanup` lifecycle function, or one tagged `@[markused]`
 // or `@[export]`. Such a function must be inlined so any helper it alone reaches stays reachable.
@@ -418,13 +503,30 @@ fn repro_hash_is_local(directive string) bool {
 	}
 	if t.starts_with('#flag') {
 		return t.contains('"') || t.contains('@V') || t.contains('./') || t.contains('../')
-			|| t.contains('-I') || t.contains('-L')
+			|| t.contains('-I') || t.contains('-L') || repro_flag_has_abs_path(t)
 	}
 	if t.starts_with('#pkgconfig') {
 		return false // resolved from installed pkg-config packages, like a system library
 	}
 	// any other directive: be conservative and treat it as a local dependency
 	return t.starts_with('#')
+}
+
+// repro_flag_has_abs_path reports whether a `#flag` directive names a bare absolute path argument
+// (e.g. `#flag /path/to/ffi.a`, or a Windows `C:\...`/`C:/...` path), which points at a file that is
+// absent on the receiver and would fail linking before the original C error is reached.
+fn repro_flag_has_abs_path(directive string) bool {
+	for field in directive.fields() {
+		if field.starts_with('/') {
+			return true
+		}
+		// windows drive-absolute path: `C:\lib\x.a` or `C:/lib/x.a`
+		if field.len >= 3 && field[1] == `:` && (field[2] == `\\` || field[2] == `/`)
+			&& u8(field[0]).is_letter() {
+			return true
+		}
+	}
+	return false
 }
 
 // repro_uses_local_resource reports whether a declaration uses a compile-time construct that reads
@@ -582,29 +684,45 @@ fn repro_import_alias(imp ast.Import) string {
 	return imp.mod.all_after_last('.')
 }
 
-// repro_comptime_decl_names returns the names declared inside a top-level comptime `$if` block
-// (which the parser wraps in an `ExprStmt`), so the whole block is inlined when one is referenced.
-// Returns [] for anything that is not such a block.
+// repro_comptime_decl_names returns the names declared inside a top-level comptime `$if` or
+// `$match` block (which the parser wraps in an `ExprStmt` holding an `IfExpr`/`MatchExpr`), so the
+// whole block is inlined when one of its declarations is referenced. Returns [] for anything else.
 fn repro_comptime_decl_names(stmt ast.Stmt) []string {
 	if stmt is ast.ExprStmt {
 		if stmt.expr is ast.IfExpr {
 			if stmt.expr.is_comptime {
 				mut names := []string{}
 				for branch in stmt.expr.branches {
-					for s in branch.stmts {
-						inner := repro_top_decl_names(s)
-						if inner.len > 0 {
-							names << inner
-						} else {
-							names << repro_comptime_decl_names(s)
-						}
-					}
+					names << repro_comptime_branch_names(branch.stmts)
+				}
+				return names
+			}
+		} else if stmt.expr is ast.MatchExpr {
+			if stmt.expr.is_comptime {
+				mut names := []string{}
+				for branch in stmt.expr.branches {
+					names << repro_comptime_branch_names(branch.stmts)
 				}
 				return names
 			}
 		}
 	}
 	return []
+}
+
+// repro_comptime_branch_names collects the top-level declaration names in a comptime branch body,
+// recursing into any further nested comptime blocks.
+fn repro_comptime_branch_names(stmts []ast.Stmt) []string {
+	mut names := []string{}
+	for s in stmts {
+		inner := repro_top_decl_names(s)
+		if inner.len > 0 {
+			names << inner
+		} else {
+			names << repro_comptime_decl_names(s)
+		}
+	}
+	return names
 }
 
 // repro_top_decl_names returns the top-level names a statement defines, or [] when it is not an

--- a/vlib/v/builder/c_error_reproducer.v
+++ b/vlib/v/builder/c_error_reproducer.v
@@ -495,9 +495,13 @@ fn repro_operator_refs(source string) []string {
 	return ops
 }
 
-// repro_reflection_method_targets returns the type names a declaration reflects over with
-// `<Type>.methods` (as in `$for m in Foo.methods`). Method names never appear as identifier tokens
-// in such a loop, so these targets are used to pull the type's methods into the closure.
+// repro_reflection_method_targets returns the names a declaration reflects over with
+// `<target>.methods`, i.e. the iterables of `$for m in <target>.methods` loops. The target may be a
+// concrete type (`Foo`), a generic parameter (`T`), or a metadata variable from an outer `$for`
+// (`field`, as in the nested `$for field in C.fields { $for m in field.methods {} }` form). Method
+// names never appear as identifier tokens in such a loop, so these targets are used to pull the
+// type's methods into the closure — or, when a target cannot be resolved to an inlined type (a
+// generic parameter or metadata variable), to trigger the source-window fallback.
 fn repro_reflection_method_targets(source string) []string {
 	// method reflection only appears inside a comptime `$for` loop; without one, any `.methods`
 	// is an ordinary member access (`registry.methods()`) and must not drive retention or fallback
@@ -512,13 +516,27 @@ fn repro_reflection_method_targets(source string) []string {
 			after := i + suffix.len
 			// `.methods` must be a whole token (not `.methodsX`) to be reflection
 			if after >= source.len || !is_ident_char(source[after]) {
+				// a following `(` is a runtime call to a method named `methods`, not reflection
+				mut k := after
+				for k < source.len && (source[k] == ` ` || source[k] == `\t`) {
+					k++
+				}
+				is_call := k < source.len && source[k] == `(`
+				// the target identifier immediately before `.methods`
 				mut j := i
 				for j > 0 && is_ident_char(source[j - 1]) {
 					j--
 				}
-				// require a capitalized identifier (a type name or generic parameter), so a runtime
-				// `.methods` member access on a lowercase variable is not mistaken for reflection
-				if j < i && source[j].is_capital() {
+				// only a `$for <var> in <target>.methods` iterable is reflection: require the `in`
+				// keyword right before the target, so an ordinary `obj.methods` member access is
+				// not mistaken for it (this admits lowercase metadata variables like `field`)
+				mut p := j
+				for p > 0 && (source[p - 1] == ` ` || source[p - 1] == `\t`) {
+					p--
+				}
+				preceded_by_in := p >= 2 && source[p - 1] == `n` && source[p - 2] == `i`
+					&& (p == 2 || !is_ident_char(source[p - 3]))
+				if j < i && !is_call && preceded_by_in {
 					targets << source[j..i]
 				}
 			}

--- a/vlib/v/builder/c_error_reproducer.v
+++ b/vlib/v/builder/c_error_reproducer.v
@@ -163,9 +163,11 @@ fn (v &Builder) v_source_reproducer(v_file string, v_line int, max_bytes int) st
 			if stmt is ast.FnDecl && stmt.is_main {
 				main_id = id
 			}
-			// skip_unused roots (init/cleanup, and `@[markused]`/`@[export]` functions) are kept
-			// regardless of references, so a failing helper reached only from one stays reachable
-			if stmt is ast.FnDecl && repro_is_markused_root(stmt) {
+			// skip_unused roots are kept regardless of references, so a failing helper reached only
+			// from one stays reachable: init/cleanup, `@[markused]`/`@[export]`, and — for a
+			// `-shared` build — every public function (markused roots all of them).
+			if stmt is ast.FnDecl
+				&& (repro_is_markused_root(stmt) || (v.pref.is_shared && stmt.is_pub)) {
 				extra_seeds << id
 			}
 			if is_root_file && v_line - 1 >= start && v_line - 1 < end {
@@ -201,9 +203,18 @@ fn (v &Builder) v_source_reproducer(v_file string, v_line int, max_bytes int) st
 	// in another file must not make an unrelated import look needed)
 	mut included_files := map[int]bool{}
 	mut file_referenced := map[string]bool{} // key: "<file_id>\x00<name>"
+	mut included_names := map[string]bool{} // all names the inlined declarations define
 	for id in ordered {
 		fid := decls[id].file_id
 		included_files[fid] = true
+		// a retained declaration using a compile-time resource (`$embed_file`/`$tmpl`/`$res`)
+		// needs a project-local file we do not upload, so the reproducer cannot be standalone
+		if repro_uses_local_resource(decls[id].source) {
+			return ''
+		}
+		for n in decls[id].names {
+			included_names[n] = true
+		}
 		for name in repro_identifiers(decls[id].source) {
 			file_referenced['${fid}\x00${name}'] = true
 		}
@@ -235,9 +246,14 @@ fn (v &Builder) v_source_reproducer(v_file string, v_line int, max_bytes int) st
 		if imp.is_local {
 			return ''
 		}
-		// two files binding the same name to different modules cannot be flattened into one file
 		for t in imp.triggers {
+			// two files binding the same name to different modules cannot be flattened into one file
 			if t in bound && bound[t] != imp.source {
+				return ''
+			}
+			// a file-scoped import binding (e.g. `import time { Time }`) that clashes with an
+			// inlined declaration of the same name would, when flattened, shadow it module-wide
+			if t != '_' && t in included_names {
 				return ''
 			}
 			bound[t] = imp.source
@@ -411,6 +427,13 @@ fn repro_hash_is_local(directive string) bool {
 	return t.starts_with('#')
 }
 
+// repro_uses_local_resource reports whether a declaration uses a compile-time construct that reads
+// a project-local file (`$embed_file`, `$tmpl`, `$res`) which is not uploaded with the reproducer.
+fn repro_uses_local_resource(source string) bool {
+	return source.contains('\$embed_file(') || source.contains('\$tmpl(')
+		|| source.contains('\$res(')
+}
+
 // repro_render assembles the given declaration ids into a single-file source string, headed by
 // `mod_header` (the failing file's `module` line, including any module attributes).
 fn repro_render(mod_header string, imports []ReproImport, hashes []string, decls []ReproDecl, ids []int) string {
@@ -519,6 +542,10 @@ fn scan_string_literal(source string, start int, mut ids []string) int {
 				} else if ci == `}` {
 					depth--
 					i++
+				} else if ci == `'` || ci == `"` {
+					// a nested string inside the interpolation: skip its contents (its own braces
+					// must not be counted) while still collecting its `${...}` identifiers
+					i = scan_string_literal(source, i, mut ids)
 				} else if ci == `_` || ci.is_letter() {
 					st := i
 					for i < source.len && is_ident_char(source[i]) {

--- a/vlib/v/builder/c_error_reproducer.v
+++ b/vlib/v/builder/c_error_reproducer.v
@@ -167,6 +167,15 @@ fn (v &Builder) v_source_reproducer(v_file string, v_line int, max_bytes int) st
 			for n in names {
 				name_to_decl[n] << id
 			}
+			// index instance methods under a synthetic `<ReceiverType>#methods` key too, so a
+			// declaration that reflects over `<Type>.methods` (`$for m in Foo.methods`) can pull in
+			// the type's methods even though their names never appear as identifier tokens
+			if stmt is ast.FnDecl && stmt.is_method {
+				recv := repro_short_name(v.table.sym(stmt.receiver.typ).name)
+				if recv != '' {
+					name_to_decl['${recv}#methods'] << id
+				}
+			}
 			if stmt is ast.FnDecl && stmt.is_main {
 				main_id = id
 			}
@@ -218,6 +227,7 @@ fn (v &Builder) v_source_reproducer(v_file string, v_line int, max_bytes int) st
 	mut included_files := map[int]bool{}
 	mut file_referenced := map[string]bool{} // key: "<file_id>\x00<name>"
 	mut included_names := map[string]bool{} // all names the inlined declarations define
+	mut reflection_targets := []string{} // types reflected over with `<Type>.methods`
 	for id in ordered {
 		fid := decls[id].file_id
 		included_files[fid] = true
@@ -226,11 +236,27 @@ fn (v &Builder) v_source_reproducer(v_file string, v_line int, max_bytes int) st
 		if repro_uses_local_resource(decls[id].source) {
 			return ''
 		}
+		// a retained top-level comptime block (`$if`/`$match`) that carries its own conditional
+		// `import` would collide with the same import re-emitted at the top of the flattened file
+		// (`file.imports` also lists it), which the checker rejects as "module already imported";
+		// only such a block can hold an `import` in its copied source, so fall back on it
+		if repro_source_has_toplevel_import(decls[id].source) {
+			return ''
+		}
+		reflection_targets << repro_reflection_method_targets(decls[id].source)
 		for n in decls[id].names {
 			included_names[n] = true
 		}
 		for name in repro_identifiers(decls[id].source) {
 			file_referenced['${fid}\x00${name}'] = true
+		}
+	}
+	// `$for m in T.methods` over a target we did not inline as a concrete type (a generic parameter,
+	// or a type resolved from another module) cannot be modelled here: the replayed loop would then
+	// iterate a different method set and the C error may vanish, so fall back instead
+	for t in reflection_targets {
+		if t !in included_names {
+			return ''
 		}
 	}
 	// the flattened file can carry only one module header: if contributing files disagree on their
@@ -394,6 +420,11 @@ fn repro_closure(decls []ReproDecl, name_to_decl map[string][]int, seeds []int) 
 		// overloaded operators are indexed under their punctuation method name (`+`, `[]`, ...),
 		// which is not an identifier token, so add the operator methods a declaration may use
 		refs << repro_operator_refs(decls[id].source)
+		// `$for m in Foo.methods` reflection needs Foo's methods, which are indexed under the
+		// synthetic `Foo#methods` key; add those refs so the whole method set is retained
+		for t in repro_reflection_method_targets(decls[id].source) {
+			refs << '${t}#methods'
+		}
 		for name in refs {
 			for ref in name_to_decl[name] {
 				if ref >= 0 && ref < decls.len && !included[ref] {
@@ -431,6 +462,39 @@ fn repro_operator_refs(source string) []string {
 		}
 	}
 	return ops
+}
+
+// repro_reflection_method_targets returns the type names a declaration reflects over with
+// `<Type>.methods` (as in `$for m in Foo.methods`). Method names never appear as identifier tokens
+// in such a loop, so these targets are used to pull the type's methods into the closure.
+fn repro_reflection_method_targets(source string) []string {
+	// method reflection only appears inside a comptime `$for` loop; without one, any `.methods`
+	// is an ordinary member access (`registry.methods()`) and must not drive retention or fallback
+	if !source.contains('\$for') {
+		return []
+	}
+	suffix := '.methods'
+	mut targets := []string{}
+	mut i := 0
+	for i + suffix.len <= source.len {
+		if source[i] == `.` && source[i..i + suffix.len] == suffix {
+			after := i + suffix.len
+			// `.methods` must be a whole token (not `.methodsX`) to be reflection
+			if after >= source.len || !is_ident_char(source[after]) {
+				mut j := i
+				for j > 0 && is_ident_char(source[j - 1]) {
+					j--
+				}
+				// require a capitalized identifier (a type name or generic parameter), so a runtime
+				// `.methods` member access on a lowercase variable is not mistaken for reflection
+				if j < i && source[j].is_capital() {
+					targets << source[j..i]
+				}
+			}
+		}
+		i++
+	}
+	return targets
 }
 
 // repro_import_stmt reconstructs a single valid `import` line from the AST, so multi-line, aliased
@@ -483,10 +547,17 @@ fn repro_decl_attrs(stmt ast.Stmt) []ast.Attr {
 }
 
 // repro_is_markused_root reports whether a function is a `skip_unused` root that is retained even
-// when nothing references it: an `init`/`cleanup` lifecycle function, or one tagged `@[markused]`
-// or `@[export]`. Such a function must be inlined so any helper it alone reaches stays reachable.
+// when nothing references it: an `init`/`cleanup` lifecycle function, a `lock`/`unlock`/`rlock`/
+// `runlock` method (the mark-used pass roots all of these — see markused.v), or one tagged
+// `@[markused]`/`@[export]`. Such a function must be inlined so any helper it alone reaches stays
+// reachable when `skip_unused` runs again on the replayed reproducer.
 fn repro_is_markused_root(f ast.FnDecl) bool {
-	if !f.is_method && repro_short_name(f.name) in ['init', 'cleanup'] {
+	short := repro_short_name(f.name)
+	if !f.is_method && short in ['init', 'cleanup'] {
+		return true
+	}
+	// lock helpers for `shared` types are rooted by name regardless of references
+	if f.is_method && short in ['lock', 'unlock', 'rlock', 'runlock'] {
 		return true
 	}
 	return f.attrs.any(it.name == 'markused' || it.name == 'export')
@@ -523,6 +594,19 @@ fn repro_flag_has_abs_path(directive string) bool {
 		// windows drive-absolute path: `C:\lib\x.a` or `C:/lib/x.a`
 		if field.len >= 3 && field[1] == `:` && (field[2] == `\\` || field[2] == `/`)
 			&& u8(field[0]).is_letter() {
+			return true
+		}
+	}
+	return false
+}
+
+// repro_source_has_toplevel_import reports whether a declaration's copied source contains an
+// `import` statement. In valid V, `import` may only appear at the top of a file or inside a
+// beginning-of-file comptime `$if`/`$match` block, so a non-empty result means a retained comptime
+// block carries a conditional import (which the flattener would otherwise duplicate at the top).
+fn repro_source_has_toplevel_import(source string) bool {
+	for line in source.split_into_lines() {
+		if line.trim_space().starts_with('import ') {
 			return true
 		}
 	}

--- a/vlib/v/builder/c_error_reproducer.v
+++ b/vlib/v/builder/c_error_reproducer.v
@@ -437,25 +437,49 @@ fn (v &Builder) v_source_reproducer(v_file string, v_line int, max_bytes int) st
 // comptime `ast.Block` (whose own pos is unset), found by scanning up from its first inner
 // declaration. Returns -1 when the block is empty or no opener line is found.
 fn repro_block_opener_line(block ast.Block, lines []string) int {
-	mut first := -1
-	for s in block.stmts {
-		ln := ast.Node(s).pos().line_nr
-		if ln >= 0 && (first < 0 || ln < first) {
-			first = ln
-		}
-	}
+	first, depth := repro_block_first_positioned_line(block)
 	if first < 0 {
 		return -1
 	}
+	// the first positioned statement may sit inside `depth` nested solved blocks: walk up past
+	// their openers to the one that belongs to this block
 	mut j := if first < lines.len { first } else { lines.len - 1 }
+	mut openers := 0
 	for j >= 0 {
 		t := lines[j].trim_space()
 		if t.starts_with('\$if ') || t.starts_with('\$match ') {
-			return j
+			openers++
+			if openers > depth {
+				return j
+			}
 		}
 		j--
 	}
 	return -1
+}
+
+// repro_block_first_positioned_line returns the smallest source line of any statement inside a
+// solved comptime block together with how many nested solved blocks enclose it, descending into
+// nested blocks (whose own pos is unset too: `$if linux { $if linux { fn helper() {} } }` nests
+// one positionless block in another) so the outer block still finds a usable line. Returns
+// (-1, 0) when nothing inside carries a position.
+fn repro_block_first_positioned_line(block ast.Block) (int, int) {
+	mut first := -1
+	mut first_depth := 0
+	for s in block.stmts {
+		mut ln := ast.Node(s).pos().line_nr
+		mut depth := 0
+		if s is ast.Block {
+			inner_ln, inner_depth := repro_block_first_positioned_line(s)
+			ln = inner_ln
+			depth = inner_depth + 1
+		}
+		if ln >= 0 && (first < 0 || ln < first) {
+			first = ln
+			first_depth = depth
+		}
+	}
+	return first, first_depth
 }
 
 // repro_attr_start returns the first line (0-based) of the declaration at `line_nr`, walking up
@@ -472,7 +496,16 @@ fn repro_attr_start(lines []string, line_nr int) int {
 		line_nr
 	}
 	for s > 0 {
-		end := s - 1
+		// the parser skips blank and comment lines between an attribute group and its
+		// declaration, so walk over that trivia before looking for the group's closing `]`
+		mut end := s - 1
+		for end > 0 {
+			t := lines[end].trim_space()
+			if t != '' && !t.starts_with('//') {
+				break
+			}
+			end--
+		}
 		if !lines[end].trim_space().ends_with(']') {
 			break // the line above the declaration does not close an attribute group
 		}
@@ -961,9 +994,19 @@ fn repro_fn_in_used_fns(name string, patterns []string) bool {
 // naming a path or `@V...` root), as opposed to a system header or library.
 fn repro_hash_is_local(directive string) bool {
 	t := directive.trim_space()
-	if t.starts_with('#include') || t.starts_with('#insert') || t.starts_with('#preinclude') {
-		// system headers use `<...>`; a quoted or relative include is project-local
-		return !t.contains('<')
+	for kw in ['#include', '#insert', '#preinclude'] {
+		if !t.starts_with(kw) {
+			continue
+		}
+		// system headers use `<...>`; a quoted or relative include is project-local. Only the
+		// first delimiter after the keyword decides: a trailing comment containing `<`
+		// (`#include "private.h" // see <API>`) must not make a quoted include look like a
+		// system one.
+		mut i := kw.len
+		for i < t.len && (t[i] == ` ` || t[i] == `\t`) {
+			i++
+		}
+		return i >= t.len || t[i] != `<`
 	}
 	if t.starts_with('#flag') {
 		return t.contains('"') || t.contains('@V') || t.contains('./') || t.contains('../')

--- a/vlib/v/builder/c_error_reproducer_test.v
+++ b/vlib/v/builder/c_error_reproducer_test.v
@@ -295,23 +295,46 @@ fn test_repro_is_markused_root() {
 			scope:     unsafe { nil }
 		}
 	}
-	assert repro_is_markused_root(mk('main.init', false, []))
-	assert repro_is_markused_root(mk('main.cleanup', false, []))
-	assert !repro_is_markused_root(mk('main.helper', false, []))
+	assert repro_is_markused_root(mk('main.init', false, []), 0)
+	assert repro_is_markused_root(mk('main.cleanup', false, []), 0)
+	assert !repro_is_markused_root(mk('main.helper', false, []), 0)
 	// `init` as a method is not a lifecycle root
-	assert !repro_is_markused_root(mk('main.Foo.init', true, []))
+	assert !repro_is_markused_root(mk('main.Foo.init', true, []), 0)
 	// `@[export]` / `@[markused]` functions are roots
-	assert repro_is_markused_root(mk('main.exp', false, [ast.Attr{ name: 'export' }]))
-	assert repro_is_markused_root(mk('main.mu', false, [ast.Attr{ name: 'markused' }]))
+	assert repro_is_markused_root(mk('main.exp', false, [ast.Attr{ name: 'export' }]), 0)
+	assert repro_is_markused_root(mk('main.mu', false, [ast.Attr{ name: 'markused' }]), 0)
 	// `lock`/`unlock`/`rlock`/`runlock` methods (shared-type helpers) are roots
-	assert repro_is_markused_root(mk('main.Foo.lock', true, []))
-	assert repro_is_markused_root(mk('main.Foo.unlock', true, []))
-	assert repro_is_markused_root(mk('main.Foo.rlock', true, []))
-	assert repro_is_markused_root(mk('main.Foo.runlock', true, []))
+	assert repro_is_markused_root(mk('main.Foo.lock', true, []), 0)
+	assert repro_is_markused_root(mk('main.Foo.unlock', true, []), 0)
+	assert repro_is_markused_root(mk('main.Foo.rlock', true, []), 0)
+	assert repro_is_markused_root(mk('main.Foo.runlock', true, []), 0)
 	// an ordinary method is not a root
-	assert !repro_is_markused_root(mk('main.Foo.bar', true, []))
+	assert !repro_is_markused_root(mk('main.Foo.bar', true, []), 0)
 	// a plain function named `lock` (not a method) is not a lock helper root
-	assert !repro_is_markused_root(mk('main.lock', false, []))
+	assert !repro_is_markused_root(mk('main.lock', false, []), 0)
+}
+
+fn test_repro_is_markused_root_veb_action() {
+	// a fn returning `veb.Result` (identified by the table's cached type index) is a
+	// router-invoked action: the mark-used pass roots every such function
+	assert repro_is_markused_root(ast.FnDecl{
+		name:        'main.App.index'
+		is_method:   true
+		return_type: ast.idx_to_type(123)
+		scope:       unsafe { nil }
+	}, 123)
+	assert !repro_is_markused_root(ast.FnDecl{
+		name:        'main.App.helper'
+		is_method:   true
+		return_type: ast.idx_to_type(50)
+		scope:       unsafe { nil }
+	}, 123)
+	// no veb in the program: the cache index is unset and roots nothing
+	assert !repro_is_markused_root(ast.FnDecl{
+		name:      'main.App.index'
+		is_method: true
+		scope:     unsafe { nil }
+	}, 0)
 }
 
 fn test_repro_hash_is_local() {
@@ -626,13 +649,16 @@ fn test_repro_uses_local_resource_env() {
 }
 
 fn test_repro_is_markused_root_before_request() {
-	assert repro_is_markused_root(ast.FnDecl{ name: 'main.App.before_request', is_method: true })
-	assert repro_is_markused_root(ast.FnDecl{ name: 'main.before_request' })
+	assert repro_is_markused_root(ast.FnDecl{ name: 'main.App.before_request', is_method: true }, 0)
+	assert repro_is_markused_root(ast.FnDecl{ name: 'main.before_request' }, 0)
 	// mark-used matches by suffix (`k.ends_with('before_request')`), so a `*_before_request` name
 	// that the original build retains must be seeded too
-	assert repro_is_markused_root(ast.FnDecl{ name: 'main.App.admin_before_request', is_method: true })
-	assert !repro_is_markused_root(ast.FnDecl{ name: 'main.App.handle', is_method: true })
-	assert !repro_is_markused_root(ast.FnDecl{ name: 'main.before_request_handler' })
+	assert repro_is_markused_root(ast.FnDecl{
+		name:      'main.App.admin_before_request'
+		is_method: true
+	}, 0)
+	assert !repro_is_markused_root(ast.FnDecl{ name: 'main.App.handle', is_method: true }, 0)
+	assert !repro_is_markused_root(ast.FnDecl{ name: 'main.before_request_handler' }, 0)
 }
 
 fn test_repro_has_comptime_call_allows_spacing() {

--- a/vlib/v/builder/c_error_reproducer_test.v
+++ b/vlib/v/builder/c_error_reproducer_test.v
@@ -1,6 +1,7 @@
 module builder
 
 import v.ast
+import v.token
 
 fn test_repro_short_name() {
 	assert repro_short_name('main.Foo.bar') == 'bar'
@@ -963,4 +964,56 @@ fn test_repro_fn_in_used_fns() {
 	assert repro_fn_in_used_fns('main.handle_thing', ['main.handle_*'])
 	assert !repro_fn_in_used_fns('main.other', ['main.entry', 'main.handle_*'])
 	assert !repro_fn_in_used_fns('main.entry', [])
+}
+
+fn test_repro_block_opener_line_nested_blocks() {
+	// `$if linux { $if linux { fn helper() {} } }`: both solved blocks have unset positions,
+	// so the outer block must descend into the inner one to find a usable line
+	lines := ['$if linux {', '\t$if linux {', '\t\tfn helper() {}', '\t}', '}']
+	inner := ast.Block{
+		scope: unsafe { nil }
+		stmts: [
+			ast.Stmt(ast.FnDecl{
+				name:  'main.helper'
+				pos:   token.Pos{
+					line_nr: 2
+				}
+				scope: unsafe { nil }
+			}),
+		]
+	}
+	outer := ast.Block{
+		scope: unsafe { nil }
+		stmts: [ast.Stmt(inner)]
+	}
+	assert repro_block_opener_line(outer, lines) == 0
+	// an empty nested chain still reports no opener
+	empty := ast.Block{
+		scope: unsafe { nil }
+		stmts: [
+			ast.Stmt(ast.Block{
+				scope: unsafe { nil }
+			}),
+		]
+	}
+	assert repro_block_opener_line(empty, lines) == -1
+}
+
+fn test_repro_attr_start_over_trivia() {
+	// the parser attaches an attribute group across blank and comment lines
+	lines := ['@[markused]', '', 'fn keep() {}']
+	assert repro_attr_start(lines, 2) == 0
+	lines2 := ['@[export]', '// exported for the C side', 'fn exp() {}']
+	assert repro_attr_start(lines2, 2) == 0
+	// a const array above a blank line is still not swallowed as an attribute
+	lines3 := ['const arr = [1, 2]', '', 'fn f() {}']
+	assert repro_attr_start(lines3, 2) == 2
+}
+
+fn test_repro_hash_is_local_include_delimiter() {
+	// only the first delimiter after the keyword decides; trailing comments do not
+	assert repro_hash_is_local('#include "private.h" // see <API>')
+	assert !repro_hash_is_local('#include <stdio.h> // has "quotes"')
+	assert !repro_hash_is_local('#include   <sys/epoll.h>')
+	assert repro_hash_is_local('#include "local.h"')
 }

--- a/vlib/v/builder/c_error_reproducer_test.v
+++ b/vlib/v/builder/c_error_reproducer_test.v
@@ -473,15 +473,26 @@ fn test_repro_source_has_toplevel_import() {
 fn test_repro_reflection_method_targets() {
 	t1 := repro_reflection_method_targets('fn f() { \$for m in Foo.methods { } }')
 	assert 'Foo' in t1
-	// a generic parameter target is captured too (it is capitalized)
+	// a generic parameter target is captured too
 	t2 := repro_reflection_method_targets('fn f[T]() { \$for m in T.methods { } }')
 	assert 'T' in t2
+	// a lowercase metadata variable from an outer `$for field in C.fields` is captured (so it can
+	// trigger the fallback, since `field` is not an inlined type)
+	t3 :=
+		repro_reflection_method_targets('\$for field in C.fields { \$for m in field.methods { } }')
+	assert 'field' in t3
 	// `.methods` must be a whole token, so `.methods_count` is not reflection
 	assert repro_reflection_method_targets('\$for x in T.methods_count { }') == []
 	// a runtime member access on a lowercase variable (no `$for`) is not reflection
 	assert repro_reflection_method_targets('fn f(r Registry) { r.methods() }') == []
-	// even with a `$for` present, a lowercase receiver is an ordinary access, not a type reflection
+	// a runtime `.methods()` call inside a `$for` body is a call, not reflection
 	assert repro_reflection_method_targets('\$for i in 0 .. 3 { registry.methods() }') == []
+	// iterating a runtime `.methods()` result is a call, not reflection
+	assert repro_reflection_method_targets('\$for f in T.fields { for x in reg.methods() {} }') == []
+	// an ordinary member access after `:=` (not an `in` iterable) is not reflection
+	assert repro_reflection_method_targets('fn f() { \$for m in Foo.methods {} \n y := obj.methods }') == [
+		'Foo',
+	]
 	// no reflection at all
 	assert repro_reflection_method_targets('fn f() {}') == []
 }

--- a/vlib/v/builder/c_error_reproducer_test.v
+++ b/vlib/v/builder/c_error_reproducer_test.v
@@ -1017,3 +1017,48 @@ fn test_repro_hash_is_local_include_delimiter() {
 	assert !repro_hash_is_local('#include   <sys/epoll.h>')
 	assert repro_hash_is_local('#include "local.h"')
 }
+
+fn test_repro_closure_retains_json_decode_hooks() {
+	decls := [
+		ReproDecl{
+			names:  ['main']
+			source: "fn main() {\n\tf := json2.decode[Foo]('{}') or { Foo{} }\n\tprintln(f)\n}"
+		},
+		ReproDecl{
+			names:  ['Foo']
+			source: 'struct Foo {}'
+		},
+		ReproDecl{
+			names:  ['from_json_string']
+			source: 'fn (mut f Foo) from_json_string(raw string) ! {\n\tdecode_helper(raw)!\n}'
+		},
+		ReproDecl{
+			names:  ['decode_helper']
+			source: 'fn decode_helper(raw string) ! {\n}'
+		},
+	]
+	mut name_to_decl := map[string][]int{}
+	for i, d in decls {
+		for n in d.names {
+			name_to_decl[n] << i
+		}
+	}
+	ordered := repro_closure(decls, name_to_decl, [0]) or {
+		assert false, 'closure returned none'
+		return
+	}
+	assert 2 in ordered // Foo.from_json_string, selected implicitly by the decoder
+	assert 3 in ordered // reachable only through the hook
+}
+
+fn test_repro_flag_has_bare_file() {
+	assert repro_flag_has_bare_file('#flag helper.o')
+	assert repro_flag_has_bare_file('#flag linux extra.a')
+	assert !repro_flag_has_bare_file('#flag -lssl')
+	assert !repro_flag_has_bare_file('#flag windows -lgdi32')
+	assert !repro_flag_has_bare_file('#flag -DVERSION=1.2')
+	// locality classification end to end
+	assert repro_hash_is_local('#flag -include config.h')
+	assert repro_hash_is_local('#flag helper.o')
+	assert !repro_hash_is_local('#flag -lm')
+}

--- a/vlib/v/builder/c_error_reproducer_test.v
+++ b/vlib/v/builder/c_error_reproducer_test.v
@@ -634,3 +634,50 @@ fn test_repro_is_markused_root_before_request() {
 	assert !repro_is_markused_root(ast.FnDecl{ name: 'main.App.handle', is_method: true })
 	assert !repro_is_markused_root(ast.FnDecl{ name: 'main.before_request_handler' })
 }
+
+fn test_repro_has_comptime_call_allows_spacing() {
+	assert repro_has_comptime_call("x := \$embed_file ('asset.bin')", 'embed_file')
+	assert repro_has_comptime_call("x := \$env\t('HOME')", 'env')
+	assert repro_uses_local_resource("t := \$tmpl ('page.html')")
+	assert repro_uses_local_resource("r := \$res ('icon')")
+	// `$reserve(` must not be mistaken for `$res`
+	assert !repro_has_comptime_call('x := \$reserve(3)', 'res')
+	// `$env` without a call is not the compile-time function
+	assert !repro_has_comptime_call('// mentions \$env only', 'env')
+}
+
+fn test_repro_uses_machine_pseudo() {
+	assert repro_uses_machine_pseudo('const here = @FILE')
+	assert repro_uses_machine_pseudo('fn f() int {\n\treturn @LINE.int()\n}')
+	assert repro_uses_machine_pseudo("const root = @VMODROOT + '/data'")
+	assert repro_uses_machine_pseudo('const built = @BUILD_TIMESTAMP')
+	// identifier boundary: not a pseudo variable
+	assert !repro_uses_machine_pseudo("const mail = 'bob@FILEserver.example'")
+	// stable pseudos survive the verbatim flatten and recorded build options
+	assert !repro_uses_machine_pseudo('fn f() {\n\tprintln(@FN)\n\tprintln(@OS)\n}')
+}
+
+fn test_repro_bracket_delta_skips_strings_and_comments() {
+	assert repro_bracket_delta('@[footer:eval]') == 0
+	assert repro_bracket_delta("@[footer: 'Hello\\nWorld]']") == 0
+	assert repro_bracket_delta("@[deprecated: 'use y[0]']") == 0
+	assert repro_bracket_delta('@[unsafe] // note]') == 0
+	assert repro_bracket_delta('x := arr[') == 1
+	assert repro_bracket_delta(']') == -1
+}
+
+fn test_repro_attr_start_with_bracket_in_attr_string() {
+	lines := [
+		'module main',
+		'',
+		"@[footer: 'Hello\\nWorld]']",
+		'struct Config {}',
+	]
+	assert repro_attr_start(lines, 3) == 2
+	// the combined case: the attribute string spans source lines AND contains brackets
+	lines2 := ["@[cfg: 'a[b", "c']", 'fn f() {}']
+	assert repro_attr_start(lines2, 2) == 0
+	// an unrelated attribute above ordinary code is still not treated as this group's opener
+	lines3 := ['@[inline]', 'fn a() {}', 'const c = [', '1,', ']', 'fn b() {}']
+	assert repro_attr_start(lines3, 5) == 5
+}

--- a/vlib/v/builder/c_error_reproducer_test.v
+++ b/vlib/v/builder/c_error_reproducer_test.v
@@ -537,3 +537,64 @@ fn test_repro_closure_retains_reflected_methods() {
 	assert 3 in order // Foo.bar retained via `.methods` reflection
 	assert 4 !in order
 }
+
+fn test_repro_source_fn_name() {
+	assert repro_source_fn_name('fn compare(a int, b int) int {\n\treturn 0\n}') == 'compare'
+	assert repro_source_fn_name('pub fn max[T](a T, b T) T {\n\treturn a\n}') == 'max'
+	assert repro_source_fn_name('@[inline]\nfn (mut f Foo) grow[T](x T) {\n}') == 'grow'
+	assert repro_source_fn_name('fn C.puts(s &char) int') == 'puts'
+	// operator overloads have no source-visible plain name
+	assert repro_source_fn_name('fn (a Vec) + (b Vec) Vec {\n\treturn a\n}') == ''
+	assert repro_source_fn_name('struct NotAFn {}') == ''
+}
+
+fn test_repro_closure_retains_str_methods_for_stringification() {
+	// `println('${Foo{}}')` only mentions `Foo` as a token: the implicit `Foo.str` call (and the
+	// helper only it reaches) must still be retained, or replaying with default `skip_unused`
+	// drops them and the C error vanishes
+	decls := [
+		ReproDecl{
+			names:  ['main']
+			source: "fn main() {\n\tprintln('\${Foo{}}')\n}"
+		},
+		ReproDecl{
+			names:  ['Foo']
+			source: 'struct Foo {}'
+		},
+		ReproDecl{
+			names:  ['str']
+			source: 'fn (f Foo) str() string {\n\treturn str_helper()\n}'
+		},
+		ReproDecl{
+			names:  ['str_helper']
+			source: "fn str_helper() string {\n\treturn 'foo'\n}"
+		},
+		ReproDecl{
+			names:  ['unrelated']
+			source: 'fn unrelated() {}'
+		},
+	]
+	mut name_to_decl := map[string][]int{}
+	for i, d in decls {
+		for n in d.names {
+			name_to_decl[n] << i
+		}
+	}
+	ordered := repro_closure(decls, name_to_decl, [0]) or {
+		assert false
+		return
+	}
+	assert 0 in ordered
+	assert 1 in ordered
+	assert 2 in ordered // Foo.str, referenced only implicitly by the interpolation
+	assert 3 in ordered // reachable only through Foo.str
+	assert 4 !in ordered
+}
+
+fn test_repro_source_stringifies() {
+	assert repro_source_stringifies("fn f() {\n\tprintln('\${x}')\n}", [])
+	assert repro_source_stringifies('fn f() {}', ['println'])
+	assert repro_source_stringifies('fn f() {}', ['dump'])
+	assert repro_source_stringifies('fn f() {}', ['assert'])
+	assert !repro_source_stringifies("fn f() {\n\ty := 'plain'\n}", ['f', 'y'])
+}

--- a/vlib/v/builder/c_error_reproducer_test.v
+++ b/vlib/v/builder/c_error_reproducer_test.v
@@ -720,3 +720,54 @@ fn test_repro_source_fn_name_multiline_attribute() {
 	src3 := '@[inline]\n@[direct_array_access]\nfn fast() {}'
 	assert repro_source_fn_name(src3) == 'fast'
 }
+
+fn test_repro_source_iterates() {
+	assert repro_source_iterates('fn f() {\n\tfor item in Iterator{} {\n\t\tprintln(item)\n\t}\n}')
+	assert repro_source_iterates('fn f() {\n\tfor i, x in arr {\n\t}\n}')
+	// C-style and condition loops do not iterate a container
+	assert !repro_source_iterates('fn f() {\n\tfor i := 0; i < 3; i++ {\n\t}\n}')
+	assert !repro_source_iterates('fn f() {\n\tfor running {\n\t}\n}')
+	// `$for` iterates compile-time metadata, not values
+	assert !repro_source_iterates('fn f() {\n\t\$for m in Foo.methods {\n\t}\n}')
+	// `informal` must not be mistaken for the `in` keyword, nor `xfor` for `for`
+	assert !repro_source_iterates('fn f() {\n\tfor informal() {\n\t}\n}')
+	assert !repro_source_iterates('fn f() {\n\txfor in y {\n\t}\n}')
+}
+
+fn test_repro_closure_retains_next_for_iteration() {
+	decls := [
+		ReproDecl{
+			names:  ['main']
+			source: 'fn main() {\n\tfor item in Iter{} {\n\t\tprintln(item)\n\t}\n}'
+		},
+		ReproDecl{
+			names:  ['Iter']
+			source: 'struct Iter {\nmut:\n\ti int\n}'
+		},
+		ReproDecl{
+			names:  ['next']
+			source: 'fn (mut it Iter) next() ?int {\n\treturn iter_helper(it.i)\n}'
+		},
+		ReproDecl{
+			names:  ['iter_helper']
+			source: 'fn iter_helper(i int) ?int {\n\treturn none\n}'
+		},
+		ReproDecl{
+			names:  ['unrelated']
+			source: 'fn unrelated() {}'
+		},
+	]
+	mut name_to_decl := map[string][]int{}
+	for i, d in decls {
+		for n in d.names {
+			name_to_decl[n] << i
+		}
+	}
+	ordered := repro_closure(decls, name_to_decl, [0]) or {
+		assert false, 'closure returned none'
+		return
+	}
+	assert 2 in ordered // Iter.next, invoked only implicitly by the for-in loop
+	assert 3 in ordered // reachable only through next
+	assert 4 !in ordered
+}

--- a/vlib/v/builder/c_error_reproducer_test.v
+++ b/vlib/v/builder/c_error_reproducer_test.v
@@ -619,3 +619,14 @@ fn test_repro_import_collides() {
 	// a name unused outside the importing file cannot collide
 	assert !repro_import_collides('y', 0, included, referenced, binds)
 }
+
+fn test_repro_uses_local_resource_env() {
+	assert repro_uses_local_resource("const build_host = \$env('HOSTNAME')")
+	assert !repro_uses_local_resource("fn f() {\n\tx := os.getenv('HOSTNAME')\n}")
+}
+
+fn test_repro_is_markused_root_before_request() {
+	assert repro_is_markused_root(ast.FnDecl{ name: 'main.App.before_request', is_method: true })
+	assert repro_is_markused_root(ast.FnDecl{ name: 'main.before_request' })
+	assert !repro_is_markused_root(ast.FnDecl{ name: 'main.App.handle', is_method: true })
+}

--- a/vlib/v/builder/c_error_reproducer_test.v
+++ b/vlib/v/builder/c_error_reproducer_test.v
@@ -254,6 +254,35 @@ fn test_repro_render_includes_hash_directives() {
 	assert out.contains('#include <stdio.h>')
 }
 
+fn test_repro_is_markused_root() {
+	mk := fn (name string, is_method bool, attrs []ast.Attr) ast.FnDecl {
+		return ast.FnDecl{
+			name:      name
+			is_method: is_method
+			attrs:     attrs
+			scope:     unsafe { nil }
+		}
+	}
+	assert repro_is_markused_root(mk('main.init', false, []))
+	assert repro_is_markused_root(mk('main.cleanup', false, []))
+	assert !repro_is_markused_root(mk('main.helper', false, []))
+	// `init` as a method is not a lifecycle root
+	assert !repro_is_markused_root(mk('main.Foo.init', true, []))
+	// `@[export]` / `@[markused]` functions are roots
+	assert repro_is_markused_root(mk('main.exp', false, [ast.Attr{ name: 'export' }]))
+	assert repro_is_markused_root(mk('main.mu', false, [ast.Attr{ name: 'markused' }]))
+}
+
+fn test_repro_hash_is_local() {
+	assert !repro_hash_is_local('#include <stdio.h>')
+	assert repro_hash_is_local('#include "private.h"')
+	assert !repro_hash_is_local('#flag -lssl')
+	assert !repro_hash_is_local('#flag darwin -framework Cocoa')
+	assert repro_hash_is_local('#flag -I@VMODROOT/c')
+	assert repro_hash_is_local('#flag -L./libs -lfoo')
+	assert repro_hash_is_local('#flag "./local.o"')
+}
+
 fn test_repro_render_preserves_module_attributes() {
 	decls := [
 		ReproDecl{

--- a/vlib/v/builder/c_error_reproducer_test.v
+++ b/vlib/v/builder/c_error_reproducer_test.v
@@ -211,7 +211,7 @@ fn test_repro_render_emits_module_and_referenced_imports() {
 			triggers: ['math']
 		},
 	]
-	out := repro_render(imports, [], decls, [0])
+	out := repro_render('module main', imports, [], decls, [0])
 	assert out.starts_with('module main')
 	assert out.contains('import os')
 	assert !out.contains('import math')
@@ -236,7 +236,7 @@ fn test_repro_render_keeps_selective_and_side_effect_imports() {
 			side_effect: true
 		},
 	]
-	out := repro_render(imports, [], decls, [0])
+	out := repro_render('module main', imports, [], decls, [0])
 	// the selective import is kept because `abs` (its selected symbol) is referenced
 	assert out.contains('import math { abs }')
 	// the side-effect import is always kept
@@ -250,8 +250,42 @@ fn test_repro_render_includes_hash_directives() {
 			source: 'fn main() { C.puts(c"hi".str) }'
 		},
 	]
-	out := repro_render([], ['#include <stdio.h>'], decls, [0])
+	out := repro_render('module main', [], ['#include <stdio.h>'], decls, [0])
 	assert out.contains('#include <stdio.h>')
+}
+
+fn test_repro_render_preserves_module_attributes() {
+	decls := [
+		ReproDecl{
+			names:  ['main']
+			source: 'fn main() {}'
+		},
+	]
+	// a `@[has_globals] module main` header must survive, or `__global` fails the checker
+	out := repro_render('@[has_globals]\nmodule main', [], [], decls, [0])
+	assert out.starts_with('@[has_globals]\nmodule main')
+}
+
+fn test_repro_comptime_decl_names_indexes_nested_decls() {
+	block := ast.ExprStmt{
+		expr: ast.IfExpr{
+			is_comptime: true
+			branches:    [
+				ast.IfBranch{
+					stmts: [
+						ast.Stmt(ast.FnDecl{
+							name:  'main.linux_only'
+							scope: unsafe { nil }
+						}),
+					]
+				},
+			]
+		}
+	}
+	names := repro_comptime_decl_names(block)
+	assert 'linux_only' in names
+	// a plain (non-comptime) statement yields nothing
+	assert repro_comptime_decl_names(ast.ExprStmt{ expr: ast.BoolLiteral{} }) == []
 }
 
 fn test_repro_render_excludes_unreferenced_local_import() {
@@ -270,6 +304,6 @@ fn test_repro_render_excludes_unreferenced_local_import() {
 			is_local: true
 		},
 	]
-	out := repro_render(imports, [], decls, [0])
+	out := repro_render('module main', imports, [], decls, [0])
 	assert !out.contains('import foo')
 }

--- a/vlib/v/builder/c_error_reproducer_test.v
+++ b/vlib/v/builder/c_error_reproducer_test.v
@@ -825,3 +825,20 @@ fn test_repro_closure_retains_json_hooks_for_encode() {
 	assert 3 in ordered // reachable only through the hook
 	assert 4 !in ordered
 }
+
+fn test_repro_uses_local_resource_veb_html() {
+	// `$veb.html()` resolves and reads a project-local template at parse time
+	assert repro_uses_local_resource('fn (mut app App) page() veb.Result {\n\treturn \$veb.html()\n}')
+	assert repro_uses_local_resource("return \$veb.html ('views/index.html')")
+	assert !repro_uses_local_resource("s := 'mentions veb.html in text'")
+}
+
+fn test_repro_embedded_local_hash() {
+	// a retained comptime block can embed its own directive; local ones cannot be satisfied
+	assert repro_embedded_local_hash('\$if linux {\n\t#include "private.h"\n}')
+	assert repro_embedded_local_hash('\$if freebsd {\n\t#flag ./local.o\n}')
+	// system headers and libraries embedded in a block are uploadable as-is
+	assert !repro_embedded_local_hash('\$if linux {\n\t#include <sys/epoll.h>\n}')
+	assert !repro_embedded_local_hash('\$if linux {\n\t#flag -lm\n}')
+	assert !repro_embedded_local_hash('fn plain() {}')
+}

--- a/vlib/v/builder/c_error_reproducer_test.v
+++ b/vlib/v/builder/c_error_reproducer_test.v
@@ -628,5 +628,9 @@ fn test_repro_uses_local_resource_env() {
 fn test_repro_is_markused_root_before_request() {
 	assert repro_is_markused_root(ast.FnDecl{ name: 'main.App.before_request', is_method: true })
 	assert repro_is_markused_root(ast.FnDecl{ name: 'main.before_request' })
+	// mark-used matches by suffix (`k.ends_with('before_request')`), so a `*_before_request` name
+	// that the original build retains must be seeded too
+	assert repro_is_markused_root(ast.FnDecl{ name: 'main.App.admin_before_request', is_method: true })
 	assert !repro_is_markused_root(ast.FnDecl{ name: 'main.App.handle', is_method: true })
+	assert !repro_is_markused_root(ast.FnDecl{ name: 'main.before_request_handler' })
 }

--- a/vlib/v/builder/c_error_reproducer_test.v
+++ b/vlib/v/builder/c_error_reproducer_test.v
@@ -34,6 +34,24 @@ fn test_repro_identifiers_collects_string_interpolation() {
 	assert 'helper' in ids
 }
 
+fn test_repro_identifiers_skips_nested_literals_in_interpolation() {
+	// a string/char literal nested inside a `${...}` interpolation must be skipped just like a
+	// top-level literal, while a real reference in the same interpolation is still collected
+	ids := repro_identifiers("println('\${pick(cond, 'word_in_nested_str', other_ref)}')")
+	assert 'pick' in ids
+	assert 'other_ref' in ids
+	assert 'word_in_nested_str' !in ids
+}
+
+fn test_repro_uses_local_resource() {
+	assert repro_uses_local_resource('const data = \$embed_file("logo.png")')
+	assert repro_uses_local_resource('x := \$tmpl("page.html")')
+	assert repro_uses_local_resource('s := \$res("a.txt")')
+	// ordinary source, and unrelated comptime constructs, are not local resources
+	assert !repro_uses_local_resource('fn main() { println(1) }')
+	assert !repro_uses_local_resource('\$if linux { println("x") }')
+}
+
 fn test_repro_attr_start_walks_over_attributes() {
 	lines := ['fn a() {}', '', '@[direct_array_access]', '@[inline]', 'fn b() {}']
 	// `b` is on line 4 (0-based), its attributes start on line 2

--- a/vlib/v/builder/c_error_reproducer_test.v
+++ b/vlib/v/builder/c_error_reproducer_test.v
@@ -298,8 +298,9 @@ fn test_repro_is_markused_root() {
 	assert repro_is_markused_root(mk('main.init', false, []), 0, false)
 	assert repro_is_markused_root(mk('main.cleanup', false, []), 0, false)
 	assert !repro_is_markused_root(mk('main.helper', false, []), 0, false)
-	// `init` as a method is not a lifecycle root
-	assert !repro_is_markused_root(mk('main.Foo.init', true, []), 0, false)
+	// lifecycle METHODS are roots too: mark-used matches any key ending in `.init`/`.cleanup`
+	assert repro_is_markused_root(mk('main.Foo.init', true, []), 0, false)
+	assert repro_is_markused_root(mk('main.Foo.cleanup', true, []), 0, false)
 	// `@[export]` / `@[markused]` functions are roots
 	assert repro_is_markused_root(mk('main.exp', false, [ast.Attr{ name: 'export' }]), 0, false)
 	assert repro_is_markused_root(mk('main.mu', false, [ast.Attr{ name: 'markused' }]), 0, false)
@@ -841,4 +842,54 @@ fn test_repro_embedded_local_hash() {
 	assert !repro_embedded_local_hash('\$if linux {\n\t#include <sys/epoll.h>\n}')
 	assert !repro_embedded_local_hash('\$if linux {\n\t#flag -lm\n}')
 	assert !repro_embedded_local_hash('fn plain() {}')
+}
+
+fn test_repro_closure_retains_operator_methods_of_used_types() {
+	// `Vec` is used without any source-level `+`: the mark-used finalizer still roots `Vec.+`,
+	// so the closure must retain it (and the helper only it reaches) via the `Vec#op` key
+	decls := [
+		ReproDecl{
+			names:  ['main']
+			source: 'fn main() {\n\tv := Vec{}\n\tprintln(v)\n}'
+		},
+		ReproDecl{
+			names:  ['Vec']
+			source: 'struct Vec {}'
+		},
+		ReproDecl{
+			names:  ['+']
+			source: 'fn (a Vec) + (b Vec) Vec {\n\treturn op_helper(a, b)\n}'
+		},
+		ReproDecl{
+			names:  ['op_helper']
+			source: 'fn op_helper(a Vec, b Vec) Vec {\n\treturn a\n}'
+		},
+	]
+	mut name_to_decl := map[string][]int{}
+	for i, d in decls {
+		for n in d.names {
+			name_to_decl[n] << i
+		}
+	}
+	name_to_decl['Vec#op'] << 2
+	ordered := repro_closure(decls, name_to_decl, [0]) or {
+		assert false, 'closure returned none'
+		return
+	}
+	assert 2 in ordered // Vec.+, rooted by the used receiver type
+	assert 3 in ordered // reachable only through the operator method
+}
+
+fn test_repro_source_has_hash_directive() {
+	assert repro_source_has_hash_directive('\$if linux {\n\t#flag -DFOO\n}')
+	assert repro_source_has_hash_directive('\$if windows {\n\t#include <windows.h>\n}')
+	assert !repro_source_has_hash_directive('\$if linux {\n\tprintln(1)\n}')
+}
+
+fn test_repro_uses_local_resource_pkgconfig() {
+	// package availability is evaluated on the build machine; replaying elsewhere can select
+	// the opposite branch
+	assert repro_uses_local_resource("\$if \$pkgconfig('openssl') {\n\tx()\n}")
+	// the `#pkgconfig` directive form resolves on the receiver like a system library
+	assert !repro_uses_local_resource('#pkgconfig openssl')
 }

--- a/vlib/v/builder/c_error_reproducer_test.v
+++ b/vlib/v/builder/c_error_reproducer_test.v
@@ -598,3 +598,24 @@ fn test_repro_source_stringifies() {
 	assert repro_source_stringifies('fn f() {}', ['assert'])
 	assert !repro_source_stringifies("fn f() {\n\ty := 'plain'\n}", ['f', 'y'])
 }
+
+fn test_repro_import_collides() {
+	included := {
+		0: true
+		1: true
+	}
+	// file 0 imports `x`; file 1 uses `x` as a parameter/local without importing it
+	mut referenced := {
+		'0\x00x': true
+		'1\x00x': true
+	}
+	mut binds := {
+		'0\x00x': true
+	}
+	assert repro_import_collides('x', 0, included, referenced, binds)
+	// once file 1 carries an equivalent import, its uses are references, not bindings
+	binds['1\x00x'] = true
+	assert !repro_import_collides('x', 0, included, referenced, binds)
+	// a name unused outside the importing file cannot collide
+	assert !repro_import_collides('y', 0, included, referenced, binds)
+}

--- a/vlib/v/builder/c_error_reproducer_test.v
+++ b/vlib/v/builder/c_error_reproducer_test.v
@@ -893,3 +893,74 @@ fn test_repro_uses_local_resource_pkgconfig() {
 	// the `#pkgconfig` directive form resolves on the receiver like a system library
 	assert !repro_uses_local_resource('#pkgconfig openssl')
 }
+
+fn test_repro_merge_module_imports() {
+	// a side-effect import is subsumed by a real import of the same module
+	merged := repro_merge_module_imports([
+		ReproImport{
+			source: 'import log'
+			mod:    'log'
+		},
+		ReproImport{
+			source:      'import log as _'
+			mod:         'log'
+			side_effect: true
+		},
+	]) or {
+		assert false, 'merge unexpectedly failed'
+		return
+	}
+	assert merged.map(it.source) == ['import log']
+	// exact duplicates collapse
+	dup := repro_merge_module_imports([
+		ReproImport{
+			source: 'import os'
+			mod:    'os'
+		},
+		ReproImport{
+			source: 'import os'
+			mod:    'os'
+		},
+	]) or {
+		assert false, 'merge unexpectedly failed'
+		return
+	}
+	assert dup.len == 1
+	// side-effect imports with no real counterpart stay
+	side := repro_merge_module_imports([
+		ReproImport{
+			source:      'import sqlite as _'
+			mod:         'sqlite'
+			side_effect: true
+		},
+	]) or {
+		assert false, 'merge unexpectedly failed'
+		return
+	}
+	assert side.map(it.source) == ['import sqlite as _']
+	// genuinely different forms of one module cannot be flattened
+	mut conflicted := false
+	if _ := repro_merge_module_imports([
+		ReproImport{
+			source: 'import log'
+			mod:    'log'
+		},
+		ReproImport{
+			source: 'import log as l'
+			mod:    'log'
+		},
+	])
+	{
+		conflicted = false
+	} else {
+		conflicted = true
+	}
+	assert conflicted
+}
+
+fn test_repro_fn_in_used_fns() {
+	assert repro_fn_in_used_fns('main.entry', ['main.entry'])
+	assert repro_fn_in_used_fns('main.handle_thing', ['main.handle_*'])
+	assert !repro_fn_in_used_fns('main.other', ['main.entry', 'main.handle_*'])
+	assert !repro_fn_in_used_fns('main.entry', [])
+}

--- a/vlib/v/builder/c_error_reproducer_test.v
+++ b/vlib/v/builder/c_error_reproducer_test.v
@@ -707,3 +707,16 @@ fn test_repro_attr_start_with_bracket_in_attr_string() {
 	lines3 := ['@[inline]', 'fn a() {}', 'const c = [', '1,', ']', 'fn b() {}']
 	assert repro_attr_start(lines3, 5) == 5
 }
+
+fn test_repro_source_fn_name_multiline_attribute() {
+	// a multiline attribute value must be skipped whole: its continuation line is not the
+	// declaration line, and the generic fn behind it must still be indexed under `pick`
+	src := "@[footer: 'Hello\nWorld']\npub fn pick[T](a T, b T) T {\n\treturn a\n}"
+	assert repro_source_fn_name(src) == 'pick'
+	// a bracket inside the attribute string must not derail the group scan either
+	src2 := "@[cfg: 'a[b\nc]']\nfn choose(a int) int {\n\treturn a\n}"
+	assert repro_source_fn_name(src2) == 'choose'
+	// stacked single-line attributes still skip correctly
+	src3 := '@[inline]\n@[direct_array_access]\nfn fast() {}'
+	assert repro_source_fn_name(src3) == 'fast'
+}

--- a/vlib/v/builder/c_error_reproducer_test.v
+++ b/vlib/v/builder/c_error_reproducer_test.v
@@ -1,0 +1,275 @@
+module builder
+
+import v.ast
+
+fn test_repro_short_name() {
+	assert repro_short_name('main.Foo.bar') == 'bar'
+	assert repro_short_name('math.abs') == 'abs'
+	assert repro_short_name('Foo') == 'Foo'
+}
+
+fn test_is_user_repro_file() {
+	assert is_user_repro_file('/home/me/project/main.v')
+	assert !is_user_repro_file('/usr/local/lib/v/vlib/os/os.v')
+	assert !is_user_repro_file('/home/me/.vmodules/pcre/pcre.v')
+	assert !is_user_repro_file('/opt/v/thirdparty/tcc/x.v')
+	assert !is_user_repro_file('/home/me/project/notes.txt')
+	assert !is_user_repro_file('')
+}
+
+fn test_repro_identifiers_skips_strings_and_comments() {
+	ids :=
+		repro_identifiers("fn foo() {\n\t// call bar_in_comment here\n\tx := 'str word_in_str'\n\tbaz(x)\n}")
+	assert 'foo' in ids
+	assert 'baz' in ids
+	assert 'x' in ids
+	// words inside a comment or a plain string must not be treated as references
+	assert 'bar_in_comment' !in ids
+	assert 'word_in_str' !in ids
+}
+
+fn test_repro_identifiers_collects_string_interpolation() {
+	ids := repro_identifiers("println('value is \${my_const} and \${helper()}')")
+	assert 'my_const' in ids
+	assert 'helper' in ids
+}
+
+fn test_repro_attr_start_walks_over_attributes() {
+	lines := ['fn a() {}', '', '@[direct_array_access]', '@[inline]', 'fn b() {}']
+	// `b` is on line 4 (0-based), its attributes start on line 2
+	assert repro_attr_start(lines, 4) == 2
+	// `a` has no attributes
+	assert repro_attr_start(lines, 0) == 0
+}
+
+fn test_repro_decl_source_trims_trailing_blanks() {
+	lines := ['fn a() {', '\tx := 1', '}', '', '', 'fn b() {}']
+	assert repro_decl_source(lines, 0, 5) == 'fn a() {\n\tx := 1\n}'
+	assert repro_decl_source(lines, 5, 6) == 'fn b() {}'
+}
+
+fn test_repro_closure_follows_references() {
+	decls := [
+		ReproDecl{
+			names:  ['main']
+			source: 'fn main() { helper(Thing{}) }'
+		},
+		ReproDecl{
+			names:  ['helper']
+			source: 'fn helper(t Thing) {}'
+		},
+		ReproDecl{
+			names:  ['Thing']
+			source: 'struct Thing {}'
+		},
+		ReproDecl{
+			names:  ['unrelated']
+			source: 'fn unrelated() {}'
+		},
+	]
+	name_to_decl := {
+		'main':      [0]
+		'helper':    [1]
+		'Thing':     [2]
+		'unrelated': [3]
+	}
+	order := repro_closure(decls, name_to_decl, [0]) or {
+		assert false, 'closure returned none'
+		return
+	}
+	assert order == [0, 1, 2]
+	assert 3 !in order
+}
+
+fn test_repro_closure_seeds_from_main_for_reachability() {
+	decls := [
+		ReproDecl{
+			names:  ['main']
+			source: 'fn main() { println(helper().len) }'
+		},
+		ReproDecl{
+			names:  ['helper']
+			source: 'fn helper() []Thing { return []Thing{} }'
+		},
+		ReproDecl{
+			names:  ['Thing']
+			source: 'struct Thing {}'
+		},
+	]
+	name_to_decl := {
+		'main':   [0]
+		'helper': [1]
+		'Thing':  [2]
+	}
+	order := repro_closure(decls, name_to_decl, [1, 0]) or {
+		assert false, 'closure returned none'
+		return
+	}
+	assert 0 in order
+	assert 1 in order
+	assert 2 in order
+}
+
+fn test_repro_closure_falls_back_when_cap_exceeded() {
+	// a chain `main -> d0 -> d1 -> ...` longer than the declaration cap: every link is required,
+	// so the closure must report incomplete (none) rather than return a truncated program
+	n := c_error_repro_max_decls + 5
+	mut decls := [ReproDecl{
+		names:  ['main']
+		source: 'fn main() { d0() }'
+	}]
+	mut name_to_decl := {
+		'main': [0]
+	}
+	for i in 0 .. n {
+		next := if i + 1 < n { 'd${i + 1}' } else { 'end' }
+		decls << ReproDecl{
+			names:  ['d${i}']
+			source: 'fn d${i}() { ${next}() }'
+		}
+		name_to_decl['d${i}'] = [decls.len - 1]
+	}
+	mut hit_cap := true
+	if _ := repro_closure(decls, name_to_decl, [0]) {
+		hit_cap = false
+	}
+	assert hit_cap
+}
+
+fn test_repro_import_stmt_reconstructs_forms() {
+	assert repro_import_stmt(ast.Import{ mod: 'os', source_name: 'os' }) == 'import os'
+	assert repro_import_stmt(ast.Import{ mod: 'math.bits', source_name: 'math.bits' }) == 'import math.bits'
+	assert repro_import_stmt(ast.Import{ mod: 'os', source_name: 'os', alias: 'o' }) == 'import os as o'
+	assert repro_import_stmt(ast.Import{ mod: 'log', source_name: 'log', alias: '_' }) == 'import log as _'
+	selective := repro_import_stmt(ast.Import{
+		mod:         'math'
+		source_name: 'math'
+		syms:        [ast.ImportSymbol{ name: 'abs' }, ast.ImportSymbol{ name: 'max' }]
+	})
+	assert selective == 'import math { abs, max }'
+	// combined alias + selective form must keep both, or a `t.month_days` reference breaks
+	combined := repro_import_stmt(ast.Import{
+		mod:         'time'
+		source_name: 'time'
+		alias:       't'
+		syms:        [ast.ImportSymbol{ name: 'Time' }]
+	})
+	assert combined == 'import time as t { Time }'
+}
+
+fn test_repro_operator_refs() {
+	plus := repro_operator_refs('return a + b')
+	assert '+' in plus
+	index := repro_operator_refs('return a[i]')
+	assert '[]' in index
+	assert '[]=' in index
+	cmp := repro_operator_refs('return a < b')
+	assert '<' in cmp
+	eq := repro_operator_refs('return a == b')
+	assert '==' in eq
+	// an operator method is pulled into the closure when the operator is used
+	decls := [
+		ReproDecl{
+			names:  ['main']
+			source: 'fn main() { _ := Vec{} + Vec{} }'
+		},
+		ReproDecl{
+			names:  ['Vec']
+			source: 'struct Vec {}'
+		},
+		ReproDecl{
+			names:  ['+']
+			source: 'fn (a Vec) + (b Vec) Vec { return a }'
+		},
+	]
+	name_to_decl := {
+		'main': [0]
+		'Vec':  [1]
+		'+':    [2]
+	}
+	order := repro_closure(decls, name_to_decl, [0]) or {
+		assert false, 'closure returned none'
+		return
+	}
+	assert 2 in order // the `+` operator method is included
+}
+
+fn test_repro_render_emits_module_and_referenced_imports() {
+	decls := [
+		ReproDecl{
+			names:  ['main']
+			source: 'fn main() {\n\tprintln(os.args.len)\n}'
+		},
+	]
+	imports := [
+		ReproImport{
+			source:   'import os'
+			triggers: ['os']
+		},
+		ReproImport{
+			source:   'import math'
+			triggers: ['math']
+		},
+	]
+	out := repro_render(imports, [], decls, [0])
+	assert out.starts_with('module main')
+	assert out.contains('import os')
+	assert !out.contains('import math')
+	assert out.contains('fn main() {')
+}
+
+fn test_repro_render_keeps_selective_and_side_effect_imports() {
+	decls := [
+		ReproDecl{
+			names:  ['main']
+			source: 'fn main() { println(abs(-1)) }'
+		},
+	]
+	imports := [
+		ReproImport{
+			source:   'import math { abs }'
+			triggers: ['math', 'abs']
+		},
+		ReproImport{
+			source:      'import log as _'
+			triggers:    ['_']
+			side_effect: true
+		},
+	]
+	out := repro_render(imports, [], decls, [0])
+	// the selective import is kept because `abs` (its selected symbol) is referenced
+	assert out.contains('import math { abs }')
+	// the side-effect import is always kept
+	assert out.contains('import log as _')
+}
+
+fn test_repro_render_includes_hash_directives() {
+	decls := [
+		ReproDecl{
+			names:  ['main']
+			source: 'fn main() { C.puts(c"hi".str) }'
+		},
+	]
+	out := repro_render([], ['#include <stdio.h>'], decls, [0])
+	assert out.contains('#include <stdio.h>')
+}
+
+fn test_repro_render_excludes_unreferenced_local_import() {
+	// a local import that nothing references must not be emitted (and if it were referenced, the
+	// builder path falls back entirely — see v_source_reproducer)
+	decls := [
+		ReproDecl{
+			names:  ['main']
+			source: 'fn main() { println(1) }'
+		},
+	]
+	imports := [
+		ReproImport{
+			source:   'import foo'
+			triggers: ['foo']
+			is_local: true
+		},
+	]
+	out := repro_render(imports, [], decls, [0])
+	assert !out.contains('import foo')
+}

--- a/vlib/v/builder/c_error_reproducer_test.v
+++ b/vlib/v/builder/c_error_reproducer_test.v
@@ -295,23 +295,23 @@ fn test_repro_is_markused_root() {
 			scope:     unsafe { nil }
 		}
 	}
-	assert repro_is_markused_root(mk('main.init', false, []), 0)
-	assert repro_is_markused_root(mk('main.cleanup', false, []), 0)
-	assert !repro_is_markused_root(mk('main.helper', false, []), 0)
+	assert repro_is_markused_root(mk('main.init', false, []), 0, false)
+	assert repro_is_markused_root(mk('main.cleanup', false, []), 0, false)
+	assert !repro_is_markused_root(mk('main.helper', false, []), 0, false)
 	// `init` as a method is not a lifecycle root
-	assert !repro_is_markused_root(mk('main.Foo.init', true, []), 0)
+	assert !repro_is_markused_root(mk('main.Foo.init', true, []), 0, false)
 	// `@[export]` / `@[markused]` functions are roots
-	assert repro_is_markused_root(mk('main.exp', false, [ast.Attr{ name: 'export' }]), 0)
-	assert repro_is_markused_root(mk('main.mu', false, [ast.Attr{ name: 'markused' }]), 0)
+	assert repro_is_markused_root(mk('main.exp', false, [ast.Attr{ name: 'export' }]), 0, false)
+	assert repro_is_markused_root(mk('main.mu', false, [ast.Attr{ name: 'markused' }]), 0, false)
 	// `lock`/`unlock`/`rlock`/`runlock` methods (shared-type helpers) are roots
-	assert repro_is_markused_root(mk('main.Foo.lock', true, []), 0)
-	assert repro_is_markused_root(mk('main.Foo.unlock', true, []), 0)
-	assert repro_is_markused_root(mk('main.Foo.rlock', true, []), 0)
-	assert repro_is_markused_root(mk('main.Foo.runlock', true, []), 0)
+	assert repro_is_markused_root(mk('main.Foo.lock', true, []), 0, false)
+	assert repro_is_markused_root(mk('main.Foo.unlock', true, []), 0, false)
+	assert repro_is_markused_root(mk('main.Foo.rlock', true, []), 0, false)
+	assert repro_is_markused_root(mk('main.Foo.runlock', true, []), 0, false)
 	// an ordinary method is not a root
-	assert !repro_is_markused_root(mk('main.Foo.bar', true, []), 0)
+	assert !repro_is_markused_root(mk('main.Foo.bar', true, []), 0, false)
 	// a plain function named `lock` (not a method) is not a lock helper root
-	assert !repro_is_markused_root(mk('main.lock', false, []), 0)
+	assert !repro_is_markused_root(mk('main.lock', false, []), 0, false)
 }
 
 fn test_repro_is_markused_root_veb_action() {
@@ -322,19 +322,19 @@ fn test_repro_is_markused_root_veb_action() {
 		is_method:   true
 		return_type: ast.idx_to_type(123)
 		scope:       unsafe { nil }
-	}, 123)
+	}, 123, false)
 	assert !repro_is_markused_root(ast.FnDecl{
 		name:        'main.App.helper'
 		is_method:   true
 		return_type: ast.idx_to_type(50)
 		scope:       unsafe { nil }
-	}, 123)
+	}, 123, false)
 	// no veb in the program: the cache index is unset and roots nothing
 	assert !repro_is_markused_root(ast.FnDecl{
 		name:      'main.App.index'
 		is_method: true
 		scope:     unsafe { nil }
-	}, 0)
+	}, 0, false)
 }
 
 fn test_repro_hash_is_local() {
@@ -649,16 +649,17 @@ fn test_repro_uses_local_resource_env() {
 }
 
 fn test_repro_is_markused_root_before_request() {
-	assert repro_is_markused_root(ast.FnDecl{ name: 'main.App.before_request', is_method: true }, 0)
-	assert repro_is_markused_root(ast.FnDecl{ name: 'main.before_request' }, 0)
+	assert repro_is_markused_root(ast.FnDecl{ name: 'main.App.before_request', is_method: true },
+		0, false)
+	assert repro_is_markused_root(ast.FnDecl{ name: 'main.before_request' }, 0, false)
 	// mark-used matches by suffix (`k.ends_with('before_request')`), so a `*_before_request` name
 	// that the original build retains must be seeded too
 	assert repro_is_markused_root(ast.FnDecl{
 		name:      'main.App.admin_before_request'
 		is_method: true
-	}, 0)
-	assert !repro_is_markused_root(ast.FnDecl{ name: 'main.App.handle', is_method: true }, 0)
-	assert !repro_is_markused_root(ast.FnDecl{ name: 'main.before_request_handler' }, 0)
+	}, 0, false)
+	assert !repro_is_markused_root(ast.FnDecl{ name: 'main.App.handle', is_method: true }, 0, false)
+	assert !repro_is_markused_root(ast.FnDecl{ name: 'main.before_request_handler' }, 0, false)
 }
 
 fn test_repro_has_comptime_call_allows_spacing() {
@@ -769,5 +770,58 @@ fn test_repro_closure_retains_next_for_iteration() {
 	}
 	assert 2 in ordered // Iter.next, invoked only implicitly by the for-in loop
 	assert 3 in ordered // reachable only through next
+	assert 4 !in ordered
+}
+
+fn test_repro_is_markused_root_translated_c_attr() {
+	// a -translated build roots every function carrying a `c` attribute
+	assert repro_is_markused_root(ast.FnDecl{
+		name:  'main.wrapped'
+		attrs: [ast.Attr{ name: 'c', arg: 'real_name' }]
+		scope: unsafe { nil }
+	}, 0, true)
+	// without -translated the attribute alone is not a root
+	assert !repro_is_markused_root(ast.FnDecl{
+		name:  'main.wrapped'
+		attrs: [ast.Attr{ name: 'c', arg: 'real_name' }]
+		scope: unsafe { nil }
+	}, 0, false)
+}
+
+fn test_repro_closure_retains_json_hooks_for_encode() {
+	decls := [
+		ReproDecl{
+			names:  ['main']
+			source: 'fn main() {\n\tprintln(json2.encode(Foo{}))\n}'
+		},
+		ReproDecl{
+			names:  ['Foo']
+			source: 'struct Foo {}'
+		},
+		ReproDecl{
+			names:  ['to_json']
+			source: 'fn (f Foo) to_json() string {\n\treturn json_helper()\n}'
+		},
+		ReproDecl{
+			names:  ['json_helper']
+			source: "fn json_helper() string {\n\treturn '{}'\n}"
+		},
+		ReproDecl{
+			names:  ['unrelated']
+			source: 'fn unrelated() {}'
+		},
+	]
+	mut name_to_decl := map[string][]int{}
+	for i, d in decls {
+		for n in d.names {
+			name_to_decl[n] << i
+		}
+	}
+	ordered := repro_closure(decls, name_to_decl, [0]) or {
+		assert false, 'closure returned none'
+		return
+	}
+	assert 2 in ordered // Foo.to_json, selected only implicitly by json2.encode
+	assert 3 in ordered // reachable only through the hook
 	assert 4 !in ordered
 }

--- a/vlib/v/builder/c_error_reproducer_test.v
+++ b/vlib/v/builder/c_error_reproducer_test.v
@@ -289,6 +289,15 @@ fn test_repro_is_markused_root() {
 	// `@[export]` / `@[markused]` functions are roots
 	assert repro_is_markused_root(mk('main.exp', false, [ast.Attr{ name: 'export' }]))
 	assert repro_is_markused_root(mk('main.mu', false, [ast.Attr{ name: 'markused' }]))
+	// `lock`/`unlock`/`rlock`/`runlock` methods (shared-type helpers) are roots
+	assert repro_is_markused_root(mk('main.Foo.lock', true, []))
+	assert repro_is_markused_root(mk('main.Foo.unlock', true, []))
+	assert repro_is_markused_root(mk('main.Foo.rlock', true, []))
+	assert repro_is_markused_root(mk('main.Foo.runlock', true, []))
+	// an ordinary method is not a root
+	assert !repro_is_markused_root(mk('main.Foo.bar', true, []))
+	// a plain function named `lock` (not a method) is not a lock helper root
+	assert !repro_is_markused_root(mk('main.lock', false, []))
 }
 
 fn test_repro_hash_is_local() {
@@ -414,4 +423,70 @@ fn test_repro_attr_start_walks_over_multiline_attribute() {
 	// a multi-line array const above the declaration is likewise preserved
 	lines3 := ['const arr = [', '\t1,', '\t2,', ']', 'fn f() {}']
 	assert repro_attr_start(lines3, 4) == 4
+}
+
+fn test_repro_source_has_toplevel_import() {
+	// a retained comptime block that carries its own conditional import is detectable
+	block := '\$if linux {\n\timport os\n\tconst x = 1\n}'
+	assert repro_source_has_toplevel_import(block)
+	// ordinary declarations never contain an import statement
+	assert !repro_source_has_toplevel_import('fn main() { println(1) }')
+	assert !repro_source_has_toplevel_import('struct Foo {\n\tx int\n}')
+}
+
+fn test_repro_reflection_method_targets() {
+	t1 := repro_reflection_method_targets('fn f() { \$for m in Foo.methods { } }')
+	assert 'Foo' in t1
+	// a generic parameter target is captured too (it is capitalized)
+	t2 := repro_reflection_method_targets('fn f[T]() { \$for m in T.methods { } }')
+	assert 'T' in t2
+	// `.methods` must be a whole token, so `.methods_count` is not reflection
+	assert repro_reflection_method_targets('\$for x in T.methods_count { }') == []
+	// a runtime member access on a lowercase variable (no `$for`) is not reflection
+	assert repro_reflection_method_targets('fn f(r Registry) { r.methods() }') == []
+	// even with a `$for` present, a lowercase receiver is an ordinary access, not a type reflection
+	assert repro_reflection_method_targets('\$for i in 0 .. 3 { registry.methods() }') == []
+	// no reflection at all
+	assert repro_reflection_method_targets('fn f() {}') == []
+}
+
+fn test_repro_closure_retains_reflected_methods() {
+	// `describe` reflects over `Foo.methods`; its methods (indexed under `Foo#methods`) must be
+	// pulled into the closure even though their names never appear as identifier tokens
+	decls := [
+		ReproDecl{
+			names:  ['main']
+			source: 'fn main() { describe(Foo{}) }'
+		},
+		ReproDecl{
+			names:  ['describe']
+			source: 'fn describe(f Foo) { \$for m in Foo.methods {} }'
+		},
+		ReproDecl{
+			names:  ['Foo']
+			source: 'struct Foo {}'
+		},
+		ReproDecl{
+			names:  ['bar']
+			source: 'fn (f Foo) bar() {}'
+		},
+		ReproDecl{
+			names:  ['unrelated']
+			source: 'fn unrelated() {}'
+		},
+	]
+	name_to_decl := {
+		'main':        [0]
+		'describe':    [1]
+		'Foo':         [2]
+		'bar':         [3]
+		'Foo#methods': [3]
+		'unrelated':   [4]
+	}
+	order := repro_closure(decls, name_to_decl, [0]) or {
+		assert false, 'closure returned none'
+		return
+	}
+	assert 3 in order // Foo.bar retained via `.methods` reflection
+	assert 4 !in order
 }

--- a/vlib/v/builder/c_error_reproducer_test.v
+++ b/vlib/v/builder/c_error_reproducer_test.v
@@ -43,6 +43,20 @@ fn test_repro_identifiers_skips_nested_literals_in_interpolation() {
 	assert 'word_in_nested_str' !in ids
 }
 
+fn test_repro_identifiers_skips_rune_and_comment_in_interpolation() {
+	// a `}` inside a backtick rune literal must not prematurely close the interpolation scan, so a
+	// reference that follows it still enters the closure
+	ids1 := repro_identifiers("_ := '\${ f(`}`) + helper() }'")
+	assert 'f' in ids1
+	assert 'helper' in ids1
+	// a `}` inside a block comment inside the interpolation likewise
+	ids2 := repro_identifiers("_ := '\${ a /* } */ + helper() }'")
+	assert 'helper' in ids2
+	// a `}` inside a line comment inside the interpolation likewise
+	ids3 := repro_identifiers("_ := '\${ a // }\n + helper() }'")
+	assert 'helper' in ids3
+}
+
 fn test_repro_uses_local_resource() {
 	assert repro_uses_local_resource('const data = \$embed_file("logo.png")')
 	assert repro_uses_local_resource('x := \$tmpl("page.html")')
@@ -386,6 +400,28 @@ fn test_repro_comptime_decl_names_indexes_match_decls() {
 	assert 'arm_only' in names
 	// a non-comptime match yields nothing
 	assert repro_comptime_decl_names(ast.ExprStmt{ expr: ast.MatchExpr{} }) == []
+}
+
+fn test_repro_comptime_decl_names_indexes_solved_block() {
+	// after `comptime.solve_files` hoists an active single branch, a top-level `$if <os>` block
+	// appears as a bare ast.Block; its inner declaration names must still be indexed
+	block := ast.Block{
+		scope: unsafe { nil }
+		stmts: [
+			ast.Stmt(ast.FnDecl{
+				name:  'main.plat_helper'
+				scope: unsafe { nil }
+			}),
+			ast.Stmt(ast.ConstDecl{
+				fields: [ast.ConstField{
+					name: 'main.plat_const'
+				}]
+			}),
+		]
+	}
+	names := repro_comptime_decl_names(block)
+	assert 'plat_helper' in names
+	assert 'plat_const' in names
 }
 
 fn test_repro_decl_attrs_covers_marked_decl_kinds() {

--- a/vlib/v/builder/c_error_reproducer_test.v
+++ b/vlib/v/builder/c_error_reproducer_test.v
@@ -354,3 +354,64 @@ fn test_repro_render_excludes_unreferenced_local_import() {
 	out := repro_render('module main', imports, [], decls, [0])
 	assert !out.contains('import foo')
 }
+
+fn test_repro_comptime_decl_names_indexes_match_decls() {
+	// a declaration inside a top-level comptime `$match` is wrapped in an ExprStmt holding a
+	// MatchExpr; its name must be indexed so referencing it keeps the whole block
+	block := ast.ExprStmt{
+		expr: ast.MatchExpr{
+			is_comptime: true
+			branches:    [
+				ast.MatchBranch{
+					stmts: [
+						ast.Stmt(ast.FnDecl{
+							name:  'main.arm_only'
+							scope: unsafe { nil }
+						}),
+					]
+				},
+			]
+		}
+	}
+	names := repro_comptime_decl_names(block)
+	assert 'arm_only' in names
+	// a non-comptime match yields nothing
+	assert repro_comptime_decl_names(ast.ExprStmt{ expr: ast.MatchExpr{} }) == []
+}
+
+fn test_repro_decl_attrs_covers_marked_decl_kinds() {
+	m := [ast.Attr{ name: 'markused' }]
+	assert repro_decl_attrs(ast.ConstDecl{ attrs: m }).any(it.name == 'markused')
+	assert repro_decl_attrs(ast.GlobalDecl{ attrs: m }).any(it.name == 'markused')
+	assert repro_decl_attrs(ast.StructDecl{ attrs: m }).any(it.name == 'markused')
+	assert repro_decl_attrs(ast.InterfaceDecl{ attrs: m }).any(it.name == 'markused')
+	assert repro_decl_attrs(ast.EnumDecl{ attrs: m }).any(it.name == 'markused')
+	assert repro_decl_attrs(ast.TypeDecl(ast.AliasTypeDecl{ attrs: m })).any(it.name == 'markused')
+	// a non-declaration statement carries no attributes
+	assert repro_decl_attrs(ast.ExprStmt{ expr: ast.BoolLiteral{} }) == []
+}
+
+fn test_repro_hash_is_local_rejects_absolute_flag_paths() {
+	// a bare absolute path argument names a file absent on the receiver
+	assert repro_hash_is_local('#flag /path/to/ffi.a')
+	assert repro_hash_is_local('#flag linux /abs/lib/x.o')
+	assert repro_hash_is_local('#flag C:\\libs\\x.a')
+	assert repro_hash_is_local('#flag C:/libs/x.a')
+	// system libraries and platform-only flags stay non-local
+	assert !repro_hash_is_local('#flag -lm')
+	assert !repro_hash_is_local('#flag darwin -framework Cocoa')
+	assert !repro_hash_is_local('#flag windows -DX=1')
+}
+
+fn test_repro_attr_start_walks_over_multiline_attribute() {
+	// `@[footer: 'Hello\nWorld']` spans two lines; the line above the struct is a continuation,
+	// so the walk must balance brackets back to the `@[` opener on line 0
+	lines := ["@[footer: 'Hello", "World']", 'struct Foo {', '\tx int', '}']
+	assert repro_attr_start(lines, 2) == 0
+	// a preceding declaration ending in `]` (a const array) must NOT be swallowed as an attribute
+	lines2 := ['const arr = [1, 2, 3]', 'struct Bar {}']
+	assert repro_attr_start(lines2, 1) == 1
+	// a multi-line array const above the declaration is likewise preserved
+	lines3 := ['const arr = [', '\t1,', '\t2,', ']', 'fn f() {}']
+	assert repro_attr_start(lines3, 4) == 4
+}


### PR DESCRIPTION
### Background

The C error bug reporter already maps the failing C line back to the exact V line (via the generated `#line` directives), but the uploaded `v_source` was only a fixed **±40-line window** around that line. For anything but a tiny single-file program that window is a mid-function fragment that does not compile standalone — so in practice the large majority of reports could not be reproduced without hand-reconstructing the program. (In a sweep of a recent batch, ~90% of `v_source`-bearing reports were unusable truncated fragments.)

Knowing the failing *line* is not enough; a reproducer needs the failing line's **dependency closure** — the enclosing declaration plus the types/consts/globals/functions/imports it transitively uses.

### What this does

At report time the builder still has the parsed AST (`v.parsed_files`) available (the `-g`/vlines path already uses it), so this builds a self-contained reproducer from it:

- Index every **user** top-level declaration (fn/struct/enum/interface/type/const/global) by the names it defines, with its exact source span; collect each file's imports and the failing file's C-interop `#` directives.
- Find the declaration the failing line maps into, and compute the transitive closure of the declarations it references. The reference graph is approximated by matching identifier tokens against the set of top-level names (bounded by a declaration count + byte budget).
- Seed the closure from **both** the failing declaration **and** `main`, so the reproducer stays runnable and the failing code stays reachable (not dropped by `skip_unused`). The failing declaration is seeded first, so its own dependencies win the byte budget.
- Emit a single `module main` file: referenced imports, the failing file's `#`-directives, then the inlined declarations. Only user code is inlined; vlib/installed modules are referenced via `import`. Paths are compared with `real_path` (so a `/tmp` vs `/private/tmp` symlink mismatch does not hide the failing declaration).
- Anything unexpected (no mapping, no user declaration found, nothing to inline) falls back to the previous source window.

### Verified end to end

Compiling a program whose failing `[]u8(ptr)` cast lives in a **helper** (with an unrelated function and an import only that function uses) produces:

```v
module main

const three = 3

fn to_slice(p voidptr) []u8 {
	return unsafe { ([]u8(&u8(p)))[0..three] }
}

fn main() {
	s := 'hello'
	a := to_slice(voidptr(s.str))
	println(a.len)
}
```

i.e. `main` + the helper + the `const` it uses — with the unrelated function **and** its now-unused `import os` correctly dropped — and this file compiles standalone and reproduces the original C error.

### Tests

`c_error_reproducer_test.v` covers the pure logic (identifier extraction, decl-source slicing, closure following references / bounded / seeded-from-main, assembly with import filtering and `#` prelude). The AST-extraction layer is defensive (bounds-checked, `or {}` on I/O) and never panics; on any failure it returns `''` and the caller keeps the old behaviour.