### PR TITLE
fix(tccbin_tests): surface compile errors instead of swallowing them

### DIFF
--- a/thirdparty/tccbin_tests/run.ps1
+++ b/thirdparty/tccbin_tests/run.ps1
@@ -52,9 +52,9 @@ foreach ($dir in (Get-TestDirs)) {
         $expectSubstr = if ($lines.Count -gt 1) { $lines[1] } else { "" }
 
         $exe = Join-Path $work "$name.exe"
-        & $Tcc $src.FullName @ExtraArgs -o $exe 2>&1 | Out-Null
+        $compileOut = (& $Tcc $src.FullName @ExtraArgs -o $exe 2>&1 | Out-String).Trim()
         if ($LASTEXITCODE -ne 0) {
-            Write-Host "FAIL $name (compile error)"
+            Write-Host "FAIL $name (compile error: $compileOut)"
             $failed++
             continue
         }

--- a/thirdparty/tccbin_tests/run.sh
+++ b/thirdparty/tccbin_tests/run.sh
@@ -54,8 +54,9 @@ for dir in "${dirs[@]}"; do
         expect_substr=$(sed -n '2p' "$expected")
 
         exe="$work/$name.exe"
-        if ! "$tcc" "$src" "${extra_args[@]}" -o "$exe" >/dev/null 2>&1; then
-            echo "FAIL $name (compile error)"
+        compile_out=$("$tcc" "$src" "${extra_args[@]}" -o "$exe" 2>&1)
+        if [ $? -ne 0 ]; then
+            echo "FAIL $name (compile error: $compile_out)"
             failed=$((failed + 1))
             continue
         fi


### PR DESCRIPTION
`run.sh`/`run.ps1` redirected the compile step's stderr to `/dev/null`
(or `Out-Null`) and just reported `compile error` on failure, with no
way to see why. This made diagnosing a genuine failure on a new
platform (e.g. a real tcc/libgc linking gap, discovered while wiring
up freebsd-amd64's CI) require re-running the compile manually outside
the harness every time.

Both now capture and include the actual compiler output in the FAIL
line, matching how runtime failures already report exit code + output.

Verified: a deliberately incomplete GC flag set now shows the real
`undefined symbol`/`unresolved reference` text instead of a bare
`compile error`, on both a real Linux `tcc.exe` (WSL) and a real
Windows `tcc.exe`, with no regression in the full correctly-flagged
4/4 pass.