### PR TITLE
os: handle dangling file symlinks in Windows lstat

### DIFF
--- a/vlib/os/os_stat_windows.c.v
+++ b/vlib/os/os_stat_windows.c.v
@@ -1,5 +1,10 @@
 module os
 
+const windows_file_attribute_reparse_point = u32(0x00000400)
+const windows_io_reparse_tag_symlink = u32(0xa000000c)
+const windows_filetime_ticks_per_second = u64(10_000_000)
+const windows_filetime_unix_epoch_seconds = i64(11_644_473_600)
+
 // stat returns metadata for the given file/folder.
 // It will return a POSIX error message, if it can not do so.
 // C._wstat64() can be used on 32- and 64-bit Windows per
@@ -27,10 +32,78 @@ pub fn stat(path string) !Stat {
 	}
 }
 
-// lstat is the same as stat() for Windows.
+// lstat is the same as stat() for Windows, including reporting symbolic links as regular files.
+// Unlike stat(), it can also report a dangling symbolic link.
 @[inline]
 pub fn lstat(path string) !Stat {
-	return stat(path)
+	return stat(path) or {
+		if !windows_should_try_dangling_symlink_stat(err.code()) {
+			return err
+		}
+		if link_stat := windows_dangling_symlink_stat(path) {
+			return link_stat
+		}
+		return err
+	}
+}
+
+fn windows_should_try_dangling_symlink_stat(error_code int) bool {
+	return error_code == C.ENOENT
+}
+
+fn windows_dangling_symlink_stat(path string) ?Stat {
+	normalized_path := path.replace('/', '\\')
+	wildcard_start := if normalized_path.starts_with('\\\\?\\') { 4 } else { 0 }
+	if normalized_path[wildcard_start..].contains_any('*?') {
+		return none
+	}
+	w_path := normalized_path.to_wide()
+	defer {
+		// `to_wide` allocates this buffer outside V's managed memory.
+		unsafe { free(voidptr(w_path)) }
+	}
+
+	mut find_data := Win32finddata{}
+	find_handle := C.FindFirstFileW(w_path, voidptr(&find_data))
+	if find_handle == C.INVALID_HANDLE_VALUE {
+		return none
+	}
+	defer {
+		C.FindClose(find_handle)
+	}
+	if find_data.dw_file_attributes & windows_file_attribute_reparse_point == 0
+		|| find_data.dw_file_attributes & u32(C.FILE_ATTRIBUTE_DIRECTORY) != 0
+		|| find_data.dw_reserved0 != windows_io_reparse_tag_symlink {
+		return none
+	}
+	return windows_stat_from_find_data(normalized_path, find_data)
+}
+
+fn windows_stat_from_find_data(path string, find_data Win32finddata) Stat {
+	mut mode := u32(C.S_IFREG) | u32(C.S_IREAD)
+	if find_data.dw_file_attributes & u32(C.FILE_ATTRIBUTE_READONLY) == 0 {
+		mode |= u32(C.S_IWRITE)
+	}
+	match file_ext(path).to_lower() {
+		'.exe', '.com', '.bat', '.cmd' { mode |= u32(C.S_IEXEC) }
+		else {}
+	}
+	return Stat{
+		nlink: 1
+		mode:  mode
+		size:  (u64(find_data.n_file_size_high) << 32) | u64(find_data.n_file_size_low)
+		atime: windows_filetime_to_unix_seconds(find_data.ft_last_access_time)
+		mtime: windows_filetime_to_unix_seconds(find_data.ft_last_write_time)
+		ctime: windows_filetime_to_unix_seconds(find_data.ft_creation_time)
+	}
+}
+
+fn windows_filetime_to_unix_seconds(filetime Filetime) i64 {
+	ticks := (u64(filetime.dw_high_date_time) << 32) | u64(filetime.dw_low_date_time)
+	if ticks == 0 {
+		return 0
+	}
+	return i64(ticks / windows_filetime_ticks_per_second) - windows_filetime_unix_epoch_seconds
 }
 
 // get_filetype returns the FileType from the Stat struct.

--- a/vlib/os/os_stat_windows_test.v
+++ b/vlib/os/os_stat_windows_test.v
@@ -1,0 +1,58 @@
+module os
+
+fn windows_filetime_for_test(ticks u64) Filetime {
+	return Filetime{
+		dw_low_date_time:  u32(ticks)
+		dw_high_date_time: u32(ticks >> 32)
+	}
+}
+
+fn test_windows_lstat_fallback_error_gate() {
+	assert windows_should_try_dangling_symlink_stat(C.ENOENT)
+	assert !windows_should_try_dangling_symlink_stat(C.EINVAL)
+	assert !windows_should_try_dangling_symlink_stat(C.EACCES)
+}
+
+fn test_windows_filetime_to_unix_seconds() {
+	epoch_ticks := u64(windows_filetime_unix_epoch_seconds) * windows_filetime_ticks_per_second
+	assert windows_filetime_to_unix_seconds(windows_filetime_for_test(0)) == 0
+	assert windows_filetime_to_unix_seconds(windows_filetime_for_test(epoch_ticks)) == 0
+	assert windows_filetime_to_unix_seconds(windows_filetime_for_test(epoch_ticks - 1)) == -1
+	assert windows_filetime_to_unix_seconds(windows_filetime_for_test(epoch_ticks +
+		windows_filetime_ticks_per_second)) == 1
+}
+
+fn test_windows_stat_from_find_data() {
+	epoch_ticks := u64(windows_filetime_unix_epoch_seconds) * windows_filetime_ticks_per_second
+	find_data := Win32finddata{
+		ft_last_access_time: windows_filetime_for_test(epoch_ticks - 1)
+		ft_last_write_time:  windows_filetime_for_test(epoch_ticks)
+		ft_creation_time:    windows_filetime_for_test(epoch_ticks +
+			2 * windows_filetime_ticks_per_second)
+		n_file_size_high:    1
+		n_file_size_low:     7
+	}
+	link_stat := windows_stat_from_find_data(r'C:\tmp\DANGLING.EXE', find_data)
+
+	assert link_stat.get_filetype() == .regular
+	assert link_stat.nlink == 1
+	assert link_stat.mode & u32(C.S_IREAD) != 0
+	assert link_stat.mode & u32(C.S_IWRITE) != 0
+	assert link_stat.mode & u32(C.S_IEXEC) != 0
+	assert link_stat.size == (u64(1) << 32) | 7
+	assert link_stat.atime == -1
+	assert link_stat.mtime == 0
+	assert link_stat.ctime == 2
+
+	for extension in ['EXE', 'COM', 'BAT', 'CMD'] {
+		executable_stat := windows_stat_from_find_data('dangling.${extension}', find_data)
+		assert executable_stat.mode & u32(C.S_IEXEC) != 0
+	}
+
+	mut read_only_data := find_data
+	read_only_data.dw_file_attributes = u32(C.FILE_ATTRIBUTE_READONLY)
+	read_only_stat := windows_stat_from_find_data('dangling.TXT', read_only_data)
+	assert read_only_stat.mode & u32(C.S_IREAD) != 0
+	assert read_only_stat.mode & u32(C.S_IWRITE) == 0
+	assert read_only_stat.mode & u32(C.S_IEXEC) == 0
+}

--- a/vlib/os/os_test.c.v
+++ b/vlib/os/os_test.c.v
@@ -527,6 +527,17 @@ fn handle_privilege_error(err IError) ! {
 	panic(err)
 }
 
+fn windows_extended_path_for_test(path string) string {
+	normalized_path := path.replace('/', '\\')
+	if normalized_path.starts_with('\\\\?\\') {
+		return normalized_path
+	}
+	if normalized_path.starts_with('\\\\') {
+		return '\\\\?\\UNC\\' + normalized_path[2..]
+	}
+	return '\\\\?\\' + normalized_path
+}
+
 fn test_realpath_absolutepath_symlink() ! {
 	file_name := 'tolink_file.txt'
 	symlink_name := 'symlink.txt'
@@ -645,20 +656,81 @@ fn test_readlink() {
 }
 
 fn test_exists_symlink_dangling() {
-	$if msvc {
-		eprintln('skipping ${@METHOD} on windows + msvc; TODO: investigate why os.lstat/1 behaves differently than for gcc/clang')
-		return
+	target := 'nonexistent'
+	link := 'dangling_symlink'
+	os.rm(link) or {}
+	os.rm(target) or {}
+	defer {
+		os.rm(link) or {}
+		os.rm(target) or {}
 	}
-	os.symlink('nonexistent', 'dangling_symlink') or { handle_privilege_error(err) or { return } }
-	// sanity check that the symlink truly does exist.  the lack of error alone is the check.
-	// (on linux, `.get_filetype() == os.FileType.symbolic_link` is true, but on windows, a dangling symlink is reported as a regular file.)
-	os.lstat('dangling_symlink')!
+	assert !os.exists(target)
+	if _ := os.lstat(target) {
+		assert false, 'os.lstat should fail for a path that does not exist'
+	}
+	os.symlink(target, link) or { handle_privilege_error(err) or { return } }
+	assert os.is_link(link)
+	link_stat := os.lstat(link)!
+	$if windows {
+		assert link_stat.get_filetype() == .regular
+		assert link_stat.nlink == 1
+
+		executable_links := ['dangling_symlink.exe', 'dangling_symlink.com', 'dangling_symlink.bat',
+			'dangling_symlink.cmd']
+		non_executable_link := 'dangling_symlink.txt'
+		wildcard_dir := 'dangling_symlink_patterns'
+		wildcard_link := os.join_path(wildcard_dir, 'only_dangling_link')
+		for executable_link in executable_links {
+			os.rm(executable_link) or {}
+		}
+		os.rm(non_executable_link) or {}
+		os.rmdir_all(wildcard_dir) or {}
+		defer {
+			for executable_link in executable_links {
+				os.rm(executable_link) or {}
+			}
+			os.rm(non_executable_link) or {}
+			os.rmdir_all(wildcard_dir) or {}
+		}
+
+		for executable_link in executable_links {
+			os.symlink(target, executable_link)!
+			executable_stat := os.lstat(executable_link)!
+			assert executable_stat.get_mode().owner.execute, '${executable_link} should be executable'
+		}
+		os.symlink(target, non_executable_link)!
+		assert !os.lstat(non_executable_link)!.get_mode().owner.execute
+
+		os.mkdir(wildcard_dir)!
+		os.symlink(target, wildcard_link)!
+		assert os.ls(wildcard_dir)! == [os.file_name(wildcard_link)]
+		wildcard_question_pattern := os.join_path(wildcard_dir, 'only_dangling_lin?')
+		wildcard_star_pattern := os.join_path(wildcard_dir, 'only_dangling_*')
+		for wildcard_pattern in [wildcard_question_pattern, wildcard_star_pattern] {
+			if wildcard_stat := os.lstat(wildcard_pattern) {
+				assert false, 'os.lstat should reject wildcard path "${wildcard_pattern}", got ${wildcard_stat}'
+			}
+		}
+
+		assert windows_extended_path_for_test(r'C:\fixture\link') == r'\\?\C:\fixture\link'
+		assert windows_extended_path_for_test(r'\\server\share\link') == r'\\?\UNC\server\share\link'
+		assert windows_extended_path_for_test(r'\\?\C:\fixture\link') == r'\\?\C:\fixture\link'
+		extended_exact_path := windows_extended_path_for_test(os.join_path(os.getwd(), link))
+		assert os.lstat(extended_exact_path)!.get_filetype() == .regular
+		extended_question_pattern := windows_extended_path_for_test(os.join_path(os.getwd(),
+			wildcard_question_pattern))
+		if wildcard_stat := os.lstat(extended_question_pattern) {
+			assert false, 'os.lstat should reject extended wildcard path "${extended_question_pattern}", got ${wildcard_stat}'
+		}
+	} $else {
+		assert link_stat.get_filetype() == .symbolic_link
+	}
 	// the exists function says false in this scenario... on linux and linux-like systems.
 	// it says true on windows!
 	$if windows {
-		assert os.exists('dangling_symlink') == true
+		assert os.exists(link) == true
 	} $else {
-		assert os.exists('dangling_symlink') == false
+		assert os.exists(link) == false
 	}
 }
 


### PR DESCRIPTION
## Summary

- preserve the existing Windows `stat()` and `lstat()` fast path
- add an `lstat()` fallback for dangling file symlinks when `_wstat64` returns `ENOENT`
- use `FindFirstFileW` to inspect the link itself
- accept only non-directory reparse points tagged with `IO_REPARSE_TAG_SYMLINK`
- preserve the original error for missing paths and unrelated reparse points
- enable the existing regression on MSVC and add a true missing-path control

## Implementation basis

Microsoft documents that `_wstat` does not correctly handle Windows symbolic links. It also documents that `FindFirstFileW` returns information about the link itself rather than its target, and that `WIN32_FIND_DATAW.dwReserved0` contains the reparse tag when `FILE_ATTRIBUTE_REPARSE_POINT` is set.

This implementation follows that documented behavior:

- https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/stat-functions?view=msvc-170
- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-findfirstfilew
- https://learn.microsoft.com/en-us/windows/win32/api/minwinbase/ns-minwinbase-win32_find_dataw

## CI context

- The missing `WSAConnectByNameW` declaration previously seen by `tcc-windows` was addressed by the merged https://github.com/vlang/tccbin/pull/77.
- That update also removes the first fallback cause seen by `tools-windows (tcc)`.
- This PR fixes the independent `space-paths-windows` failure where `os.lstat()` rejected a dangling file symlink.
- Other independent Windows TCC header gaps still remain, including `inet_ntop` and `_fseeki64`. They are not caused by this PR and will be handled progressively in follow-up Windows TCC work.

## Validation

- `space-paths-windows` passed its complete historical path-with-spaces test sequence
- native Windows x64 `os.lstat()` acceptance passed with TCC, GCC, and MSVC
- the focused regression passed with GCC and MSVC without compiler fallback
- the minimal TCC acceptance passed without compiler fallback
- `vlib/os/os_test.c.v` and `vlib/os/os_stat_test.v` passed on Linux
- `v fmt -verify` and `git diff --check` passed