### PR TITLE
v3: self-host performance optimizations and cmd/v C generation fixes

### DIFF
--- a/vlib/builtin/prealloc.c.v
+++ b/vlib/builtin/prealloc.c.v
@@ -40,8 +40,31 @@ const prealloc_scope_block_size = 256 * 1024
 const prealloc_default_align = sizeof(voidptr) * 2
 
 __global g_memory_block &VMemoryBlock
+__global g_prealloc_block_cache &VPreallocBlockCache
 __global g_prealloc_allocation_count i64
 __global g_prealloc_allocated_bytes i64
+
+// prealloc_recyclable_block_size reports whether a block belongs to one of
+// the scope size classes (256K..4M, the geometric scope growth ladder) that
+// the per-thread recycle cache retains.
+fn prealloc_recyclable_block_size(size isize) bool {
+	base := isize(prealloc_scope_block_size)
+	return size == base || size == base * 2 || size == base * 4
+}
+
+// VPreallocBlockCache recycles standard-size scope blocks per thread: scoped
+// stage batches begin/free thousands of short-lived 256KB blocks, and
+// munmap+mmap churn (page-table teardown plus refaulting fresh zero pages)
+// showed up at ~5% of busy CPU. Recycled blocks are dirty, exactly like libc
+// malloc memory; prealloc_calloc already memsets its result and nothing else
+// may rely on the incidental zero-fill of fresh mmaps.
+struct VPreallocBlockCache {
+mut:
+	count  int
+	bytes  isize
+	starts [64]voidptr
+	sizes  [64]isize
+}
 
 // PreallocStats is a process-wide snapshot of instrumented arena allocations.
 // Counters are populated only when the program is built with `-d prealloc_stats`.
@@ -255,13 +278,39 @@ fn vmemory_block_new_sized(prev &VMemoryBlock, at_least isize, align isize, min_
 	} $else {
 		$if !freestanding && !vinix {
 			if fixed_align <= isize(prealloc_default_align) {
-				mmap_ptr := unsafe {
-					C.mmap(0, usize(block_size), C.PROT_READ | C.PROT_WRITE,
-						C.MAP_ANONYMOUS | C.MAP_PRIVATE, -1, 0)
+				$if !prealloc_no_recycle ? {
+					if prealloc_recyclable_block_size(block_size) {
+						unsafe {
+							mut cache := g_prealloc_block_cache
+							if cache != 0 {
+								for ci := 0; ci < cache.count; ci++ {
+									if cache.sizes[ci] == block_size {
+										v.start = &u8(cache.starts[ci])
+										v.mmap_allocated = true
+										cache.bytes -= block_size
+										cache.count--
+										cache.starts[ci] = cache.starts[cache.count]
+										cache.sizes[ci] = cache.sizes[cache.count]
+										$if prealloc_memset ? {
+											C.memset(v.start, int($d('prealloc_memset_value', 0)),
+												block_size)
+										}
+										break
+									}
+								}
+							}
+						}
+					}
 				}
-				if mmap_ptr != C.MAP_FAILED {
-					v.start = &u8(mmap_ptr)
-					v.mmap_allocated = true
+				if unsafe { v.start == 0 } {
+					mmap_ptr := unsafe {
+						C.mmap(0, usize(block_size), C.PROT_READ | C.PROT_WRITE,
+							C.MAP_ANONYMOUS | C.MAP_PRIVATE, -1, 0)
+					}
+					if mmap_ptr != C.MAP_FAILED {
+						v.start = &u8(mmap_ptr)
+						v.mmap_allocated = true
+					}
 				}
 			}
 		}
@@ -314,10 +363,16 @@ fn vmemory_block_malloc(n isize, align isize) &u8 {
 		if _unlikely_(remaining < n) {
 			was_scope := mb.is_scope
 			scope := mb.scope
-			min_block_size := if mb.min_block_size > 0 {
+			mut min_block_size := if mb.min_block_size > 0 {
 				mb.min_block_size
 			} else {
 				isize(prealloc_block_size)
+			}
+			if was_scope && min_block_size < isize(prealloc_scope_block_size) * 4 {
+				// Scopes that outgrow one block tend to keep growing: doubling
+				// the block size (256K..4M) turns a 100-block scope into ~10
+				// blocks, cutting refill and map/unmap churn per batch.
+				min_block_size *= 2
 			}
 			mb = vmemory_block_new_sized(mb, n, fixed_align, min_block_size)
 			mb.is_scope = was_scope
@@ -368,7 +423,36 @@ fn vmemory_block_free(mb &VMemoryBlock) {
 	} $else {
 		$if !freestanding && !vinix {
 			if mb.mmap_allocated {
-				C.munmap(mb.start, usize(vmemory_block_size(mb)))
+				size := vmemory_block_size(mb)
+				mut recycled := false
+				$if !prealloc_no_recycle ? {
+					if prealloc_recyclable_block_size(isize(size)) {
+						unsafe {
+							mut cache := g_prealloc_block_cache
+							if cache == 0 {
+								cache = &VPreallocBlockCache(C.calloc(1,
+									sizeof(VPreallocBlockCache)))
+								if cache != 0 {
+									g_prealloc_block_cache = cache
+								}
+							}
+							if cache != 0 && cache.count < 64
+								&& cache.bytes + isize(size) <= isize(prealloc_scope_block_size) * 64 {
+								cache.starts[cache.count] = voidptr(mb.start)
+								cache.sizes[cache.count] = isize(size)
+								cache.bytes += isize(size)
+								cache.count++
+								recycled = true
+							}
+						}
+					}
+				}
+				if !recycled {
+					$if prealloc_trace_recycle ? {
+						C.fprintf(C.stderr, c'[recycle-miss] size=%lld\n', size)
+					}
+					C.munmap(mb.start, usize(size))
+				}
 			} else {
 				C.free(mb.start)
 			}

--- a/vlib/v/gen/c/consts_and_globals.v
+++ b/vlib/v/gen/c/consts_and_globals.v
@@ -602,7 +602,7 @@ fn (mut g Gen) global_decl(node ast.GlobalDecl) {
 			continue
 		}
 		if field.is_extern {
-			tls_kw := if field.name == 'g_memory_block' && g.pref.prealloc {
+			tls_kw := if field.name in ['g_memory_block', 'g_prealloc_block_cache'] && g.pref.prealloc {
 				'_Thread_local '
 			} else {
 				''
@@ -617,7 +617,7 @@ fn (mut g Gen) global_decl(node ast.GlobalDecl) {
 		}
 		mut needs_ending_semicolon := false
 		if field.language != .c || field.has_expr {
-			tls_kw := if field.name == 'g_memory_block' && g.pref.prealloc {
+			tls_kw := if field.name in ['g_memory_block', 'g_prealloc_block_cache'] && g.pref.prealloc {
 				'_Thread_local '
 			} else {
 				''

--- a/vlib/v/gen/c/index.v
+++ b/vlib/v/gen/c/index.v
@@ -18,6 +18,44 @@ enum CWideIndexKind {
 	unsigned_64
 }
 
+// A failing `a[i] or {..}` / `m[k] or {..}` lookup only needs a real IError when
+// the or block can observe `err` (directly, or via the implicit main/test panic
+// wrapper). Otherwise the static `none` instance keeps the option fully
+// initialized without allocating a MessageError + interface box on every miss.
+fn (g &Gen) index_or_skips_err(node ast.IndexExpr) bool {
+	if node.is_option || node.or_expr.kind != .block {
+		return false
+	}
+	if g.fn_decl != unsafe { nil } && (g.fn_decl.is_main || g.fn_decl.is_test) {
+		return false
+	}
+	if node.or_expr.stmts.len == 0 {
+		return true
+	}
+	// Mirror or_block()'s `or_block_needs_err`: the lookup's own `.err` is only
+	// read when the or block scope binds a special `err` var that the block uses.
+	// An index or block does not declare its own `err` (referencing one resolves
+	// to an enclosing or block's binding), so `err_used` inherited from an outer
+	// scope must not force the allocation here.
+	mut has_special_err := false
+	if err_obj := node.or_expr.scope.objects['err'] {
+		if err_obj is ast.Var {
+			has_special_err = err_obj.is_special
+		}
+	}
+	if !has_special_err {
+		return true
+	}
+	return !node.or_expr.err_used && !or_block_last_stmt_is_err(node.or_expr.stmts)
+}
+
+fn (mut g Gen) index_or_err_init(node ast.IndexExpr, msg string) string {
+	if g.index_or_skips_err(node) {
+		return '_const_none__'
+	}
+	return 'builtin___v_error(_S("${msg}"))'
+}
+
 fn (mut g Gen) c_wide_index_kind(index_type ast.Type) CWideIndexKind {
 	if g.pref.backend != .c || index_type == 0 {
 		return .plain
@@ -608,7 +646,8 @@ fn (mut g Gen) index_of_array(node ast.IndexExpr, sym ast.TypeSymbol) {
 				g.writeln('\t*((${elem_type_str}*)&${tmp_opt}.data) = *((${elem_type_str}*)${tmp_opt_ptr});')
 			}
 			g.writeln('} else {')
-			g.writeln('\t${tmp_opt}.state = 2; ${tmp_opt}.err = builtin___v_error(_S("array index out of range"));')
+			g.writeln('\t${tmp_opt}.state = 2; ${tmp_opt}.err = ${g.index_or_err_init(node,
+				'array index out of range')};')
 			g.writeln('}')
 			if !node.is_option {
 				if keep_option_result {
@@ -918,7 +957,8 @@ fn (mut g Gen) index_of_map(node ast.IndexExpr, sym ast.TypeSymbol) {
 				g.writeln('if (${tmp_opt_ptr}) {')
 				g.writeln('\t${tmp_opt} = *${tmp_opt_ptr};')
 				g.writeln('} else {')
-				g.writeln('\t${tmp_opt}.state = 2; ${tmp_opt}.err = builtin___v_error(_S("map key does not exist"));')
+				g.writeln('\t${tmp_opt}.state = 2; ${tmp_opt}.err = ${g.index_or_err_init(node,
+					'map key does not exist')};')
 				g.writeln('}')
 				if !node.is_option {
 					g.or_block_on_value(tmp_opt, node.or_expr, val_type)
@@ -942,7 +982,8 @@ fn (mut g Gen) index_of_map(node ast.IndexExpr, sym ast.TypeSymbol) {
 					g.writeln('\t*((${val_type_str}*)&${tmp_opt}.data) = *((${val_type_str}*)${tmp_opt_ptr});')
 				}
 				g.writeln('} else {')
-				g.writeln('\t${tmp_opt}.state = 2; ${tmp_opt}.err = builtin___v_error(_S("map key does not exist"));')
+				g.writeln('\t${tmp_opt}.state = 2; ${tmp_opt}.err = ${g.index_or_err_init(node,
+					'map key does not exist')};')
 				g.writeln('}')
 				if !node.is_option {
 					if keep_option_result {

--- a/vlib/v3/bench/bench.v
+++ b/vlib/v3/bench/bench.v
@@ -97,6 +97,16 @@ pub fn (b &Bench) current_step_time_us() i64 {
 	return b.step_sw.elapsed().microseconds()
 }
 
+// step_measured records a pipeline step whose duration was accumulated
+// externally, inside the wall time of the surrounding steps (used for work
+// interleaved with another stage, e.g. the ownership checker inside check).
+// It does not restart the step stopwatch, so the enclosing stages still
+// account for their full wall time.
+pub fn (mut b Bench) step_measured(name string, elapsed_us i64) {
+	allocations := current_allocation_stats()
+	b.report_step(name, false, elapsed_us, 0, 0, allocations.enabled)
+}
+
 // step_parallel records a pipeline step, appending "(parallel)" to its name
 // when the step actually ran across threads.
 pub fn (mut b Bench) step_parallel(name string, parallel bool) {

--- a/vlib/v3/flat/flat.v
+++ b/vlib/v3/flat/flat.v
@@ -210,6 +210,14 @@ pub mut:
 	export_fn_names map[string]string
 	noreturn_fns    map[string]bool
 	source_files    map[int]&token.File
+	// file_node_ids records every .file node the parser creates, in creation
+	// order: (marker, trailing) pairs per source file. The trailing node's
+	// children are the file's top-level declarations, letting collect build
+	// its top-level index without a full node scan. Stages that renumber
+	// nodes clear the list; consumers fall back to scanning when it is empty
+	// or file_index_incomplete is set (a source file failed to read).
+	file_node_ids         []int
+	file_index_incomplete bool
 	// source_buffers owns the storage behind zero-copy scanner strings retained
 	// by AST nodes. Keeping the buffers on the AST makes the lifetime boundary
 	// explicit and lets parser workers transfer ownership with their nodes.
@@ -375,25 +383,94 @@ pub fn (a &FlatAst) text_count() int {
 // This runs serially after parse/transform worker merges, so the text table
 // itself requires no synchronization and cannot retain worker-arena storage.
 pub fn (mut a FlatAst) intern_node_texts_from(start int) {
+	a.intern_node_texts_range(start, a.nodes.len)
+}
+
+// intern_node_texts_range canonicalizes managed payloads in nodes[start..end).
+// The bounded form serves the parallel parse merge, where later chunks are
+// already present in the node array but must be interned in chunk order.
+pub fn (mut a FlatAst) intern_node_texts_range(start int, end int) {
 	first := if start < 0 { 0 } else { start }
-	if first >= a.nodes.len {
+	if first >= end {
 		return
 	}
-	for idx in first .. a.nodes.len {
-		_, value := a.intern_text(a.nodes[idx].value)
-		_, typ := a.intern_text(a.nodes[idx].typ)
-		a.nodes[idx].value = value
-		a.nodes[idx].typ = typ
-		params := a.nodes[idx].generic_params()
-		if params.len > 0 {
-			mut canonical_params := []string{cap: params.len}
-			for item in params {
-				_, param := a.intern_text(item)
-				canonical_params << param
-			}
-			a.nodes[idx].set_generic_params(canonical_params)
-		}
+	// Node texts repeat heavily by exact string instance (already-interned
+	// strings share `.str`), so a direct-mapped pointer probe skips the
+	// content-hash table lookup for the overwhelming majority of nodes.
+	// Nothing is freed during this pass, so pointer keys stay valid.
+	mut cache_ptrs := unsafe { []voidptr{len: 4096} }
+	mut cache_vals := []string{len: 4096}
+	for idx in first .. end {
+		a.intern_node_texts_one(idx, mut cache_ptrs, mut cache_vals)
 	}
+}
+
+// intern_node_texts_at canonicalizes only the listed node indexes (in list
+// order). The parallel parse merge pre-rebinds table hits on the copy threads
+// and records the remaining nodes here, so canonical-table insertion order
+// still matches the serial merge exactly.
+pub fn (mut a FlatAst) intern_node_texts_at(indexes []int) {
+	if indexes.len == 0 {
+		return
+	}
+	mut cache_ptrs := unsafe { []voidptr{len: 4096} }
+	mut cache_vals := []string{len: 4096}
+	for idx in indexes {
+		a.intern_node_texts_one(idx, mut cache_ptrs, mut cache_vals)
+	}
+}
+
+fn (mut a FlatAst) intern_node_texts_one(idx int, mut cache_ptrs []voidptr, mut cache_vals []string) {
+	a.nodes[idx].value = a.intern_text_ptr_cached(a.nodes[idx].value, mut cache_ptrs, mut
+		cache_vals)
+	a.nodes[idx].typ = a.intern_text_ptr_cached(a.nodes[idx].typ, mut cache_ptrs, mut cache_vals)
+	params := a.nodes[idx].generic_params()
+	if params.len > 0 {
+		// Always rebuild the payload: the params array itself may live in a
+		// stage arena even when every param string is already canonical.
+		mut canonical_params := []string{cap: params.len}
+		for item in params {
+			canonical_params << a.intern_text_ptr_cached(item, mut cache_ptrs, mut cache_vals)
+		}
+		a.nodes[idx].set_generic_params(canonical_params)
+	}
+}
+
+// probe_text_ptr_cached is the read-only twin of intern_text_ptr_cached: it
+// rebinds `value` to its canonical copy when the text table already holds the
+// content and reports a miss otherwise, never mutating the table. Safe on
+// worker threads only while no thread inserts into the table.
+pub fn (a &FlatAst) probe_text_ptr_cached(value string, mut cache_ptrs []voidptr, mut cache_vals []string) (string, bool) {
+	if value.len == 0 {
+		return '', true
+	}
+	slot := int((u64(voidptr(value.str)) >> 4) & 4095)
+	if cache_ptrs[slot] == voidptr(value.str) && cache_vals[slot].len == value.len {
+		return cache_vals[slot], true
+	}
+	if id := a.text_ids[value] {
+		canonical := a.text_values[int(id) - 1]
+		cache_ptrs[slot] = voidptr(value.str)
+		cache_vals[slot] = canonical
+		return canonical, true
+	}
+	return value, false
+}
+
+pub fn (mut a FlatAst) intern_text_ptr_cached(value string, mut cache_ptrs []voidptr, mut cache_vals []string) string {
+	if value.len == 0 {
+		return ''
+	}
+	slot := int((u64(voidptr(value.str)) >> 4) & 4095)
+	// The length check guards against distinct strings sharing one base pointer
+	// (unsafe zero-copy slices); same pointer + same length means same content.
+	if cache_ptrs[slot] == voidptr(value.str) && cache_vals[slot].len == value.len {
+		return cache_vals[slot]
+	}
+	_, canonical := a.intern_text(value)
+	cache_ptrs[slot] = voidptr(value.str)
+	cache_vals[slot] = canonical
+	return canonical
 }
 
 // intern_metadata_texts canonicalizes all source-derived FlatAst map keys and

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -15462,26 +15462,22 @@ fn (mut g FlatGen) global_decls() {
 			g.writeln('#endif')
 			continue
 		}
-		// With -prealloc the arena base block is per-thread (lazily initialized
-		// on first allocation in each thread); a shared pointer would make all
-		// threads bump the same block without synchronization. cc gets real
-		// TLS; tcc implements no _Thread_local, so it gets a pthread-key
-		// emulation behind an lvalue macro. The key setup needs no
-		// synchronization: the first allocation always happens on the main
-		// thread, long before any `spawn`. The helpers use pthread_key_t so they
-		// agree with either the platform pthread header or the headerless fallback.
+		// With -prealloc the arena base block and the block-recycle cache are
+		// per-thread; a shared pointer would make all threads bump the same
+		// block without synchronization. cc gets real TLS; tcc implements no
+		// _Thread_local, so each gets a pthread-key emulation behind an lvalue
+		// macro. The keys are created from a constructor (same pattern as the
+		// shared-storage TLS emulation above), so worker threads can never
+		// race a lazy pthread_key_create - unlike the arena base, the recycle
+		// cache has no first-touch-on-main-thread guarantee.
 		if g.prealloc && name in ['g_memory_block', 'g_prealloc_block_cache'] {
 			cn := g.cname(name)
 			g.writeln('#if defined(__TINYC__)')
-			g.writeln('static pthread_key_t ${cn}_key = 0;')
-			g.writeln('static int ${cn}_key_ready = 0;')
+			g.writeln('static pthread_key_t ${cn}_key;')
+			g.writeln('static void ${cn}_key_init(void) __attribute__((constructor));')
+			g.writeln('static void ${cn}_key_init(void) { pthread_key_create(&${cn}_key, 0); }')
 			g.writeln('static ${ct}* ${cn}_slot(void) {')
-			g.writeln('	void* p;')
-			g.writeln('	if (!${cn}_key_ready) {')
-			g.writeln('		pthread_key_create(&${cn}_key, 0);')
-			g.writeln('		${cn}_key_ready = 1;')
-			g.writeln('	}')
-			g.writeln('	p = pthread_getspecific(${cn}_key);')
+			g.writeln('	void* p = pthread_getspecific(${cn}_key);')
 			g.writeln('	if (p == 0) {')
 			g.writeln('		p = calloc(1, sizeof(${ct}));')
 			g.writeln('		pthread_setspecific(${cn}_key, p);')

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -380,6 +380,12 @@ pub fn (g &FlatGen) was_parallel() bool {
 	return g.parallel_used
 }
 
+fn (g &FlatGen) timing_profile(message string) {
+	if !isnil(g.tc) && g.tc.verbose {
+		eprintln(message)
+	}
+}
+
 pub fn (g &FlatGen) c_flags() []string {
 	return g.c_flags.clone()
 }
@@ -1746,7 +1752,7 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	g.precompute_shared_alias_pointer_shorts()
 	g.collect_gen_info()
 	g.preintern_json_encode_strings()
-	eprintln('  [ttime] cg collect_info    ${f64(cgsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+	g.timing_profile('  [ttime] cg collect_info    ${f64(cgsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 	cgsw.restart()
 	if g.incremental_fn_names.len > 0 {
 		// Cached declarations already contain whole-program typedefs, wrappers,
@@ -1762,7 +1768,7 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 		// interface implementers first so that late-lowered dispatch targets are not
 		// pruned before their concrete method bodies are emitted.
 		g.collect_interface_impls()
-		eprintln('  [ttime]   cg iface impls   ${f64(cgsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+		g.timing_profile('  [ttime]   cg iface impls   ${f64(cgsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 		cgsw.restart()
 		// Struct field defaults are emitted from their declarations when an otherwise
 		// unrelated function initializes the struct. Parallel function pre-scanning only
@@ -1779,10 +1785,10 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 		// its embedded-fields map must be populated even when the worker-fork prep
 		// runs its own copy; do it before any helper thread can observe `g`.
 		g.precompute_embedded_fields()
-		eprintln('  [ttime]   cg preseeds      ${f64(cgsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+		g.timing_profile('  [ttime]   cg preseeds      ${f64(cgsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 		cgsw.restart()
 		parallel_prep_done := g.run_pre_dispatch_parallel(no_parallel)
-		eprintln('  [ttime]   cg predispatch   ${f64(cgsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+		g.timing_profile('  [ttime]   cg predispatch   ${f64(cgsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 		cgsw.restart()
 		if !parallel_prep_done {
 			g.collect_fixed_storage_consts()
@@ -1797,12 +1803,12 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 		if !g.skip_generics {
 			g.precompute_generic_method_candidate_index()
 		}
-		eprintln('  [ttime]     wr shared+sum  ${f64(cgsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+		g.timing_profile('  [ttime]     wr shared+sum  ${f64(cgsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 		cgsw.restart()
 		// Decide fixed-array return wrappers before generating function bodies, so
 		// signatures, returns and call sites all agree on the wrapped types.
 		g.populate_fixed_array_ret_wrappers()
-		eprintln('  [ttime]     wr fixed ret   ${f64(cgsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+		g.timing_profile('  [ttime]     wr fixed ret   ${f64(cgsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 		cgsw.restart()
 		// Seed declaration-owned function-pointer types before parallel type
 		// generation starts. The pre-dispatch item walk adds body-local types
@@ -1812,14 +1818,14 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 		g.preseed_struct_fn_ptr_types()
 		g.preseed_sum_fn_ptr_types()
 		g.preseed_global_fn_ptr_types()
-		eprintln('  [ttime]     wr struct/sum  ${f64(cgsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+		g.timing_profile('  [ttime]     wr struct/sum  ${f64(cgsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 		cgsw.restart()
 		g.preseed_fn_signature_fn_ptr_types()
-		eprintln('  [ttime]     wr fn sigs     ${f64(cgsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+		g.timing_profile('  [ttime]     wr fn sigs     ${f64(cgsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 		cgsw.restart()
 		g.preseed_c_extern_fn_ptr_types()
 		g.preseed_sig_type_seen = unsafe { nil }
-		eprintln('  [ttime]   cg wrappers      ${f64(cgsw.elapsed().microseconds()) / 1000.0:7.2f} ms (sig+extern)')
+		g.timing_profile('  [ttime]   cg wrappers      ${f64(cgsw.elapsed().microseconds()) / 1000.0:7.2f} ms (sig+extern)')
 		cgsw.restart()
 	}
 	g.precompute_ownership_recursive_drop_helpers()
@@ -1830,14 +1836,14 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	} else {
 		g.precompute_consts()
 	}
-	eprintln('  [ttime] cg precompute      ${f64(cgsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+	g.timing_profile('  [ttime] cg precompute      ${f64(cgsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 	cgsw.restart()
 	orig_sb := g.sb
 	orig_line_start := g.line_start
 	g.sb = strings.new_builder(4096)
 	g.line_start = true
 	g.gen_fns_dispatch(no_parallel)
-	eprintln('  [ttime] cg fns dispatch    ${f64(cgsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+	g.timing_profile('  [ttime] cg fns dispatch    ${f64(cgsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 	cgsw.restart()
 	if defer_parallel_support {
 		if g.parallel_support_ready {
@@ -1857,7 +1863,7 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	unsafe { g.sb.free() }
 	g.sb = orig_sb
 	g.line_start = orig_line_start
-	eprintln('  [ttime] cg fn_code copy    ${f64(cgsw.elapsed().microseconds()) / 1000.0:7.2f} ms (len: ${fn_code.len})')
+	g.timing_profile('  [ttime] cg fn_code copy    ${f64(cgsw.elapsed().microseconds()) / 1000.0:7.2f} ms (len: ${fn_code.len})')
 	cgsw.restart()
 	if g.program_body_only {
 		unsafe { const_code.free() }
@@ -1978,7 +1984,7 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	if g.cache_split {
 		g.interface_method_stubs()
 	}
-	eprintln('  [ttime] cg postamble       ${f64(cgsw.elapsed().microseconds()) / 1000.0:7.2f} ms (sb: ${g.sb.len})')
+	g.timing_profile('  [ttime] cg postamble       ${f64(cgsw.elapsed().microseconds()) / 1000.0:7.2f} ms (sb: ${g.sb.len})')
 	cgsw.restart()
 	if !g.cache_split && g.output_path.len > 0 && (g.fn_segs.len > 0 || fn_code.len > 0) {
 		mut prefix := unsafe { g.sb.reuse_as_plain_u8_array() }
@@ -1988,7 +1994,7 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 		if g.output_error.len == 0 {
 			g.append_function_output(g.output_path, fn_code)
 		}
-		eprintln('  [ttime] cg write out       ${f64(cgsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+		g.timing_profile('  [ttime] cg write out       ${f64(cgsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 		return ''
 	}
 	if g.fn_segs.len > 0 {
@@ -2619,7 +2625,7 @@ fn (mut g FlatGen) collect_gen_info() {
 	ci_reg_ms := f64(ci_reg_ns) / 1e6
 	ci_ret_ms := f64(ci_ret_ns) / 1e6
 	ci_ptypes_ms := f64(ci_ptypes_ns) / 1e6
-	eprintln('  [ttime]   ci fns ${ci_fn_ms:7.2f} ms of ${ci_total_ms:7.2f} ms (ptypes ${ci_ptypes_ms:.2f}, ret ${ci_ret_ms:.2f}, ret+reg ${ci_reg_ms:.2f}), const order ${ccio_ms:7.2f} ms')
+	g.timing_profile('  [ttime]   ci fns ${ci_fn_ms:7.2f} ms of ${ci_total_ms:7.2f} ms (ptypes ${ci_ptypes_ms:.2f}, ret ${ci_ret_ms:.2f}, ret+reg ${ci_reg_ms:.2f}), const order ${ccio_ms:7.2f} ms')
 }
 
 fn (mut g FlatGen) reserve_collect_gen_info_maps() {

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -2,6 +2,7 @@ module c
 
 import os
 import strings
+import time
 import v3.cmdexec
 import v3.flat
 import v3.gen.c.naming
@@ -239,6 +240,7 @@ mut:
 	output_error                 string
 	c99_mode                     bool
 	skip_generics                bool
+	placeholder_check_forced     bool
 	cur_fn_name                  string
 	current_decl_is_mut          bool
 	direct_array_access          bool
@@ -316,9 +318,23 @@ mut:
 	generic_app_cache              &GenericAppCache = unsafe { nil }
 	want_parallel_prep             bool
 	want_parallel_c_extern_prep    bool
-	cache_split                    bool
-	program_body_only              bool
-	cached_support_identifiers     map[string]bool
+	// Set while selected items' C-extern refs still have to be collected: the
+	// fused prep walk defers them to the parallel exact-cost pass, which falls
+	// back to a serial top-up when it cannot run.
+	prep_externs_pending bool
+	prep_costs_pending   bool
+	prep_typ_text_cache  &PrepTypTextCache = unsafe { nil }
+	preseed_type_seen    &PreseedTypeSeen  = unsafe { nil }
+	// Separate seen-cache for the declaration preseed family
+	// (preseed_fn_ptr_type has optional-typedef side effects the body-walk
+	// preseed does not); armed only for the contiguous pre-dispatch preseed
+	// block, while no arena scope can be freed and reused.
+	preseed_sig_type_seen      &PreseedTypeSeen     = unsafe { nil }
+	struct_decl_pref_cache     &StructDeclPrefCache = unsafe { nil }
+	unused_param_seen          &UnusedParamSeen     = unsafe { nil }
+	cache_split                bool
+	program_body_only          bool
+	cached_support_identifiers map[string]bool
 	// Set when the target is built with -prealloc / -d prealloc: the bump
 	// arena's base block pointer must be thread-local (matching V1's cgen),
 	// or every spawned thread would race on the same arena.
@@ -1715,11 +1731,23 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	if g.tc.a == unsafe { nil } {
 		g.tc.collect(a)
 	}
+	mut cgsw := time.new_stopwatch()
 	g.tc.precompute_source_error_embed_index()
+	if g.skip_generics {
+		// The declared-type tables are static for the whole generic-free cgen
+		// phase, so qualify_name is memoizable per (module, file) context.
+		// Worker forks receive their own instances (fork_for_parallel_codegen).
+		g.tc.qualify_name_cache = &types.QualifyNameCache{}
+	}
+	defer {
+		g.tc.qualify_name_cache = unsafe { nil }
+	}
 	g.has_builtins = g.tc.has_builtins
 	g.precompute_shared_alias_pointer_shorts()
 	g.collect_gen_info()
 	g.preintern_json_encode_strings()
+	eprintln('  [ttime] cg collect_info    ${f64(cgsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+	cgsw.restart()
 	if g.incremental_fn_names.len > 0 {
 		// Cached declarations already contain whole-program typedefs, wrappers,
 		// interface tables and shared-parameter metadata. A body-only update only
@@ -1734,6 +1762,8 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 		// interface implementers first so that late-lowered dispatch targets are not
 		// pruned before their concrete method bodies are emitted.
 		g.collect_interface_impls()
+		eprintln('  [ttime]   cg iface impls   ${f64(cgsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+		cgsw.restart()
 		// Struct field defaults are emitted from their declarations when an otherwise
 		// unrelated function initializes the struct. Parallel function pre-scanning only
 		// visits that function body, so seed literals from defaults before workers fork.
@@ -1749,7 +1779,11 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 		// its embedded-fields map must be populated even when the worker-fork prep
 		// runs its own copy; do it before any helper thread can observe `g`.
 		g.precompute_embedded_fields()
+		eprintln('  [ttime]   cg preseeds      ${f64(cgsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+		cgsw.restart()
 		parallel_prep_done := g.run_pre_dispatch_parallel(no_parallel)
+		eprintln('  [ttime]   cg predispatch   ${f64(cgsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+		cgsw.restart()
 		if !parallel_prep_done {
 			g.collect_fixed_storage_consts()
 			g.precompute_param_type_index()
@@ -1763,17 +1797,30 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 		if !g.skip_generics {
 			g.precompute_generic_method_candidate_index()
 		}
+		eprintln('  [ttime]     wr shared+sum  ${f64(cgsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+		cgsw.restart()
 		// Decide fixed-array return wrappers before generating function bodies, so
 		// signatures, returns and call sites all agree on the wrapped types.
 		g.populate_fixed_array_ret_wrappers()
+		eprintln('  [ttime]     wr fixed ret   ${f64(cgsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+		cgsw.restart()
 		// Seed declaration-owned function-pointer types before parallel type
 		// generation starts. The pre-dispatch item walk adds body-local types
-		// before the declaration task is launched.
+		// before the declaration task is launched. Declaration types repeat the
+		// same canonical values heavily; dedup whole traversals for this block.
+		g.preseed_sig_type_seen = &PreseedTypeSeen{}
 		g.preseed_struct_fn_ptr_types()
 		g.preseed_sum_fn_ptr_types()
 		g.preseed_global_fn_ptr_types()
+		eprintln('  [ttime]     wr struct/sum  ${f64(cgsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+		cgsw.restart()
 		g.preseed_fn_signature_fn_ptr_types()
+		eprintln('  [ttime]     wr fn sigs     ${f64(cgsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+		cgsw.restart()
 		g.preseed_c_extern_fn_ptr_types()
+		g.preseed_sig_type_seen = unsafe { nil }
+		eprintln('  [ttime]   cg wrappers      ${f64(cgsw.elapsed().microseconds()) / 1000.0:7.2f} ms (sig+extern)')
+		cgsw.restart()
 	}
 	g.precompute_ownership_recursive_drop_helpers()
 	defer_parallel_support := g.scope_parallel_workers && !no_parallel && !g.program_body_only
@@ -1783,11 +1830,15 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	} else {
 		g.precompute_consts()
 	}
+	eprintln('  [ttime] cg precompute      ${f64(cgsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+	cgsw.restart()
 	orig_sb := g.sb
 	orig_line_start := g.line_start
 	g.sb = strings.new_builder(4096)
 	g.line_start = true
 	g.gen_fns_dispatch(no_parallel)
+	eprintln('  [ttime] cg fns dispatch    ${f64(cgsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+	cgsw.restart()
 	if defer_parallel_support {
 		if g.parallel_support_ready {
 			const_code = g.parallel_const_code
@@ -1806,6 +1857,8 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	unsafe { g.sb.free() }
 	g.sb = orig_sb
 	g.line_start = orig_line_start
+	eprintln('  [ttime] cg fn_code copy    ${f64(cgsw.elapsed().microseconds()) / 1000.0:7.2f} ms (len: ${fn_code.len})')
+	cgsw.restart()
 	if g.program_body_only {
 		unsafe { const_code.free() }
 		g.sb.ensure_cap(fn_code.len + 262_144)
@@ -1925,6 +1978,8 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	if g.cache_split {
 		g.interface_method_stubs()
 	}
+	eprintln('  [ttime] cg postamble       ${f64(cgsw.elapsed().microseconds()) / 1000.0:7.2f} ms (sb: ${g.sb.len})')
+	cgsw.restart()
 	if !g.cache_split && g.output_path.len > 0 && (g.fn_segs.len > 0 || fn_code.len > 0) {
 		mut prefix := unsafe { g.sb.reuse_as_plain_u8_array() }
 		os.write_file_array(g.output_path, prefix) or { g.output_error = err.msg() }
@@ -1933,6 +1988,7 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 		if g.output_error.len == 0 {
 			g.append_function_output(g.output_path, fn_code)
 		}
+		eprintln('  [ttime] cg write out       ${f64(cgsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 		return ''
 	}
 	if g.fn_segs.len > 0 {
@@ -2207,13 +2263,27 @@ fn node_kind_id(node flat.Node) int {
 }
 
 // collect_gen_info updates collect gen info state for c.
+// UnusedParamSeen tracks param type texts already preseeded for unused fn
+// declarations within the current module (see preseed_unused_fn_ptr_param_types).
+struct UnusedParamSeen {
+mut:
+	module string
+	texts  map[string]bool
+}
+
 fn (mut g FlatGen) collect_gen_info() {
+	g.unused_param_seen = &UnusedParamSeen{}
 	g.reserve_collect_gen_info_maps()
 	if g.incremental_fn_names.len == 0 {
 		g.collect_c_flags_from_directives()
 	}
 	g.c_flags << g.initial_c_flags
 	g.use_system_stdint = g.translation_unit_uses_inttypes()
+	cisw := time.new_stopwatch()
+	mut ci_fn_ns := u64(0)
+	mut ci_reg_ns := u64(0)
+	mut ci_ret_ns := u64(0)
+	mut ci_ptypes_ns := u64(0)
 	mut cur_module := 'main'
 	mut cur_file := ''
 	mut seen_import_in_file := false
@@ -2249,14 +2319,17 @@ fn (mut g FlatGen) collect_gen_info() {
 			continue
 		}
 		if kind_id == 61 {
+			ci_t0 := time.sys_mono_now()
 			full_name := qualify_name_in_module(cur_module, node.value)
 			if g.has_used_fn_filter() && !g.used_fn_contains_in_module(node.value, cur_module) {
 				if g.incremental_fn_names.len == 0 {
 					g.preseed_unused_fn_ptr_param_types(node, cur_module, cur_file)
 				}
+				ci_fn_ns += time.sys_mono_now() - ci_t0
 				continue
 			}
 			g.register_fn_decl_node(node.value, cur_module, flat.NodeId(node_idx))
+			ci_p0 := time.sys_mono_now()
 			typed_params := g.fn_node_param_types(node, cur_module)
 			param_cap := if node.children_count < 64 { int(node.children_count) } else { 64 }
 			mut ptypes := []types.Type{cap: param_cap}
@@ -2324,6 +2397,7 @@ fn (mut g FlatGen) collect_gen_info() {
 					}
 				}
 			}
+			ci_ptypes_ns += time.sys_mono_now() - ci_p0
 			ptypes = g.fn_param_types_with_implicit_veb_ctx(node, ptypes)
 			if shared_params.len > 0 {
 				shared_params = g.fn_shared_params_with_implicit_veb_ctx(node, shared_params)
@@ -2345,9 +2419,12 @@ fn (mut g FlatGen) collect_gen_info() {
 				nonshared_fn_file_ranks << c_backend_fn_file_rank(cur_file)
 				nonshared_fn_node_indexes << node_idx
 			}
+			ci_r0 := time.sys_mono_now()
 			return_type := g.fn_node_return_type(node, cur_module)
+			ci_ret_ns += time.sys_mono_now() - ci_r0
 			g.register_fn_decl_signature_type(node.value, full_name, ptypes, shared_params,
 				decl_is_variadic, first_param_is_mut, return_type)
+			ci_reg_ns += time.sys_mono_now() - ci_r0
 			// Module-level `init()` functions run once at startup. Collect their C
 			// names so _vinit can invoke them (V semantics).
 			is_builtin_init := cur_module == 'builtin' && node.value == 'builtin_init'
@@ -2359,6 +2436,7 @@ fn (mut g FlatGen) collect_gen_info() {
 				}
 				g.module_init_fn_modules[init_cname] = cur_module
 			}
+			ci_fn_ns += time.sys_mono_now() - ci_t0
 			continue
 		}
 		if g.incremental_fn_names.len > 0 && node.kind == .directive {
@@ -2533,7 +2611,15 @@ fn (mut g FlatGen) collect_gen_info() {
 	}
 	g.modules['strings'] = 'strings'
 	g.materialize_objective_cpp_sources()
+	ccio_sw := time.new_stopwatch()
 	g.collect_const_init_order_from_files()
+	ci_total_ms := f64(cisw.elapsed().microseconds()) / 1000.0
+	ci_fn_ms := f64(ci_fn_ns) / 1e6
+	ccio_ms := f64(ccio_sw.elapsed().microseconds()) / 1000.0
+	ci_reg_ms := f64(ci_reg_ns) / 1e6
+	ci_ret_ms := f64(ci_ret_ns) / 1e6
+	ci_ptypes_ms := f64(ci_ptypes_ns) / 1e6
+	eprintln('  [ttime]   ci fns ${ci_fn_ms:7.2f} ms of ${ci_total_ms:7.2f} ms (ptypes ${ci_ptypes_ms:.2f}, ret ${ci_ret_ms:.2f}, ret+reg ${ci_reg_ms:.2f}), const order ${ccio_ms:7.2f} ms')
 }
 
 fn (mut g FlatGen) reserve_collect_gen_info_maps() {
@@ -2630,6 +2716,27 @@ fn (mut g FlatGen) cached_shared_alias_pointer_type_from_text(raw string) ?types
 }
 
 fn (mut g FlatGen) preseed_unused_fn_ptr_param_types(node flat.Node, module_name string, file string) {
+	// Unused declarations repeat the same few param type texts; when every
+	// param text of this fn was already preseeded within this module, the
+	// whole typed-param resolution below is a no-op.
+	if !isnil(g.unused_param_seen) {
+		mut seen := g.unused_param_seen
+		if seen.module != module_name {
+			seen.module = module_name
+			seen.texts.clear()
+		}
+		mut all_seen := true
+		for i in 0 .. node.children_count {
+			child := g.a.child_node(&node, i)
+			if node_kind_id(child) == 75 && child.typ !in seen.texts {
+				all_seen = false
+				break
+			}
+		}
+		if all_seen {
+			return
+		}
+	}
 	g.tc.cur_module = module_name
 	g.tc.cur_file = file
 	typed_params := g.fn_node_param_types(node, module_name)
@@ -2638,6 +2745,9 @@ fn (mut g FlatGen) preseed_unused_fn_ptr_param_types(node flat.Node, module_name
 		child := g.a.child_node(&node, i)
 		if node_kind_id(child) != 75 {
 			continue
+		}
+		if !isnil(g.unused_param_seen) {
+			g.unused_param_seen.texts[child.typ] = true
 		}
 		raw_type := if param_idx < typed_params.len {
 			typed_params[param_idx]
@@ -7120,7 +7230,8 @@ fn (mut g FlatGen) gen_expr_with_expected_type(id flat.NodeId, expected types.Ty
 	}
 	if !expected_is_shared_alias && expected !is types.Pointer && expected !is types.Void
 		&& expected !is types.OptionType && expected !is types.ResultType && actual is types.Pointer
-		&& g.type_names_match(actual.base_type, expected) && !(node.kind == .ident
+		&& (g.type_names_match(actual.base_type, expected)
+		|| g.type_names_match(actual.base_type, semantic_expected)) && !(node.kind == .ident
 		&& g.local_storage_is_shared(node.value)) && !(node.kind == .char_literal
 		&& node.value.starts_with('c:')) {
 		needs_paren := node.kind !in [.ident, .selector, .call, .index]
@@ -15359,26 +15470,27 @@ fn (mut g FlatGen) global_decls() {
 		// synchronization: the first allocation always happens on the main
 		// thread, long before any `spawn`. The helpers use pthread_key_t so they
 		// agree with either the platform pthread header or the headerless fallback.
-		if g.prealloc && name == 'g_memory_block' {
+		if g.prealloc && name in ['g_memory_block', 'g_prealloc_block_cache'] {
+			cn := g.cname(name)
 			g.writeln('#if defined(__TINYC__)')
-			g.writeln('static pthread_key_t g_memory_block_key = 0;')
-			g.writeln('static int g_memory_block_key_ready = 0;')
-			g.writeln('static ${ct}* g_memory_block_slot(void) {')
+			g.writeln('static pthread_key_t ${cn}_key = 0;')
+			g.writeln('static int ${cn}_key_ready = 0;')
+			g.writeln('static ${ct}* ${cn}_slot(void) {')
 			g.writeln('	void* p;')
-			g.writeln('	if (!g_memory_block_key_ready) {')
-			g.writeln('		pthread_key_create(&g_memory_block_key, 0);')
-			g.writeln('		g_memory_block_key_ready = 1;')
+			g.writeln('	if (!${cn}_key_ready) {')
+			g.writeln('		pthread_key_create(&${cn}_key, 0);')
+			g.writeln('		${cn}_key_ready = 1;')
 			g.writeln('	}')
-			g.writeln('	p = pthread_getspecific(g_memory_block_key);')
+			g.writeln('	p = pthread_getspecific(${cn}_key);')
 			g.writeln('	if (p == 0) {')
 			g.writeln('		p = calloc(1, sizeof(${ct}));')
-			g.writeln('		pthread_setspecific(g_memory_block_key, p);')
+			g.writeln('		pthread_setspecific(${cn}_key, p);')
 			g.writeln('	}')
 			g.writeln('	return (${ct}*)p;')
 			g.writeln('}')
-			g.writeln('#define g_memory_block (*g_memory_block_slot())')
+			g.writeln('#define ${cn} (*${cn}_slot())')
 			g.writeln('#else')
-			g.writeln('_Thread_local ${ct} ${g.cname(name)}${init};')
+			g.writeln('_Thread_local ${ct} ${cn}${init};')
 			g.writeln('#endif')
 			continue
 		}

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -185,6 +185,17 @@ fn (mut g FlatGen) collect_fn_gen_items() []FlatFnGenItem {
 	mut items := []FlatFnGenItem{cap: candidates.len}
 	mut prep_stack := []flat.NodeId{cap: 256}
 	mut prep_type_text_cache := map[string]bool{}
+	// In parallel-prep mode the exact-cost pass (or its serial fallback) also
+	// computes costs and fn-ptr preseeds after selection; see refine_fn_item_costs.
+	par_prep := prep && par_cgen_prep_enabled()
+	if prep {
+		// The prep walk no longer collects per-body C-extern refs; the exact-cost
+		// pass that follows it does (or its serial fallback).
+		g.prep_externs_pending = true
+		g.prep_costs_pending = par_prep
+		g.prep_typ_text_cache = &PrepTypTextCache{}
+		g.preseed_type_seen = &PreseedTypeSeen{}
+	}
 	for candidate in candidates {
 		if preferred_idx := preferred_fns[candidate.preferred_name] {
 			if preferred_idx != int(candidate.item.node_id) {
@@ -197,9 +208,14 @@ fn (mut g FlatGen) collect_fn_gen_items() []FlatFnGenItem {
 			continue
 		}
 		g.emitted_fns[qfn] = true
-		cost := if prep {
+		cost := if par_prep {
+			0
+		} else if prep {
 			if item.file != g.tc.cur_file || item.module != g.tc.cur_module {
 				prep_type_text_cache.clear()
+				if !isnil(g.prep_typ_text_cache) {
+					g.prep_typ_text_cache.generation++
+				}
 			}
 			g.tc.cur_file = item.file
 			g.tc.cur_module = item.module
@@ -282,7 +298,7 @@ fn exact_flat_fn_gen_item_cost(a &flat.FlatAst, node_id flat.NodeId, mut c_exter
 		if idx < 0 || idx >= a.nodes.len {
 			continue
 		}
-		node := a.nodes[idx]
+		node := unsafe { &a.nodes[idx] }
 		cost += flat_cgen_node_cost(node.kind)
 		if node.kind == .lock_expr || node.kind == .label_stmt
 			|| (node.kind == .defer_stmt && node.value == 'function') {
@@ -291,7 +307,7 @@ fn exact_flat_fn_gen_item_cost(a &flat.FlatAst, node_id flat.NodeId, mut c_exter
 		if node.kind == .selector && node.children_count > 0 && node.value.len > 0 {
 			base_id := a.children[node.children_start]
 			if int(base_id) >= 0 {
-				base := a.nodes[int(base_id)]
+				base := unsafe { &a.nodes[int(base_id)] }
 				if base.kind == .ident && base.value == 'C' {
 					raw_name := 'C.${node.value}'
 					raw_cfn := naming.c_name(raw_name)
@@ -1047,6 +1063,9 @@ fn (mut g FlatGen) direct_call_name_for_call_node(id flat.NodeId, node flat.Node
 }
 
 fn (g &FlatGen) exact_specialized_generic_call_name(name string) ?string {
+	if g.skip_generics {
+		return none
+	}
 	if name !in g.tc.specialized_generic_fns {
 		return none
 	}
@@ -1060,6 +1079,9 @@ fn (g &FlatGen) exact_specialized_generic_call_name(name string) ?string {
 }
 
 fn (g &FlatGen) flattened_generic_method_short_alias(name string) ?string {
+	if g.skip_generics {
+		return none
+	}
 	if !name.contains('.') {
 		return none
 	}
@@ -1765,6 +1787,9 @@ fn (g &FlatGen) receiver_param_method_candidate_score(name string) int {
 }
 
 fn (g &FlatGen) specialized_generic_method_name_for_call_with_arg_count(id flat.NodeId, method_name string, arg_count int) ?string {
+	if g.skip_generics {
+		return none
+	}
 	if !method_name.contains('.') {
 		return none
 	}
@@ -1808,6 +1833,9 @@ fn (g &FlatGen) specialized_generic_method_name_for_call_with_arg_count(id flat.
 }
 
 fn (g &FlatGen) specialized_generic_method_name_for_call_args(node flat.Node, method_name string, arg_count int) ?string {
+	if g.skip_generics {
+		return none
+	}
 	if !method_name.contains('.') {
 		return none
 	}
@@ -8527,6 +8555,9 @@ fn (g &FlatGen) call_uses_concrete_optional_params(name string) bool {
 }
 
 fn (g &FlatGen) name_uses_specialized_generic_abi(name string) bool {
+	if g.skip_generics {
+		return false
+	}
 	if name.contains('[') && name.contains(']') {
 		return true
 	}
@@ -8540,6 +8571,9 @@ fn (g &FlatGen) name_uses_specialized_generic_abi(name string) bool {
 }
 
 fn (g &FlatGen) call_callee_uses_specialized_generic_abi(callee_id flat.NodeId) bool {
+	if g.skip_generics {
+		return false
+	}
 	if int(callee_id) < 0 || int(callee_id) >= g.a.nodes.len {
 		return false
 	}
@@ -10062,6 +10096,9 @@ fn fn_type_is_pointer(t types.Type) bool {
 }
 
 fn (mut g FlatGen) specialized_generic_plain_fn_name_for_call(id flat.NodeId, node flat.Node, name string) ?string {
+	if g.skip_generics {
+		return none
+	}
 	if name.len == 0 || name.contains('[') || node.children_count == 0 {
 		return none
 	}
@@ -10078,6 +10115,9 @@ fn (mut g FlatGen) specialized_generic_plain_fn_name_for_call(id flat.NodeId, no
 }
 
 fn (mut g FlatGen) inferred_generic_plain_fn_name_for_call(id flat.NodeId, node flat.Node, name string) ?string {
+	if g.skip_generics {
+		return none
+	}
 	if name.len == 0 || name.contains('[') || node.children_count == 0 {
 		return none
 	}
@@ -10124,6 +10164,9 @@ fn (mut g FlatGen) inferred_generic_plain_fn_name_for_call(id flat.NodeId, node 
 }
 
 fn (g &FlatGen) existing_specialized_generic_plain_fn_name(name string) ?string {
+	if g.skip_generics {
+		return none
+	}
 	if !g.resolved_name_is_generic_plain(name) {
 		return none
 	}
@@ -10148,6 +10191,9 @@ fn (g &FlatGen) existing_specialized_generic_plain_fn_name(name string) ?string 
 }
 
 fn (mut g FlatGen) specialized_generic_plain_fn_name_for_explicit_call(id flat.NodeId, fn_node flat.Node, name string) ?string {
+	if g.skip_generics {
+		return none
+	}
 	if name.len == 0 || name.contains('[') {
 		return none
 	}
@@ -12803,11 +12849,11 @@ fn (g &FlatGen) collect_c_extern_referenced_symbols_from_node(id flat.NodeId, mu
 	}
 }
 
-fn (mut g FlatGen) collect_c_extern_ref_from_node(node flat.Node) {
+fn (mut g FlatGen) collect_c_extern_ref_from_node(node &flat.Node) {
 	g.collect_c_extern_ref_from_node_into(node, mut g.c_extern_refs)
 }
 
-fn (g &FlatGen) collect_c_extern_ref_from_node_into(node flat.Node, mut refs map[string]bool) {
+fn (g &FlatGen) collect_c_extern_ref_from_node_into(node &flat.Node, mut refs map[string]bool) {
 	if node.kind == .selector && node.children_count > 0 && node.value.len > 0 {
 		base_id := g.a.child(node, 0)
 		if int(base_id) >= 0 {
@@ -13944,6 +13990,9 @@ fn (g &FlatGen) matching_fn_param_types(name string, explicit_params int) ?[]typ
 }
 
 fn (g &FlatGen) generic_receiver_method_call_info(name string) ?types.CallInfo {
+	if g.skip_generics {
+		return none
+	}
 	if !name.contains('.') {
 		return none
 	}

--- a/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
@@ -117,7 +117,7 @@ $if !windows {
 		w.precompute_concrete_optional_abi_fns()
 		w.worker_scope = scope
 		cgen_worker_scope_leave(scope)
-		eprintln('  [ttime]     cg fs scan     ${f64(fssw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+		w.timing_profile('  [ttime]     cg fs scan     ${f64(fssw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 		return unsafe { nil }
 	}
 
@@ -234,7 +234,7 @@ fn (mut g FlatGen) refine_fn_item_costs(no_parallel bool, reserve_worker bool) {
 		}
 		rfsw := time.new_stopwatch()
 		g.a.worker_pool.run(tasks)
-		eprintln('  [ttime]     cg refine pool ${f64(rfsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+		g.timing_profile('  [ttime]     cg refine pool ${f64(rfsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 		for arg in args {
 			for name, used in arg.refs {
 				if used {
@@ -249,7 +249,7 @@ fn (mut g FlatGen) refine_fn_item_costs(no_parallel bool, reserve_worker bool) {
 				n_cands += arg.cands.len
 			}
 			g.replay_prep_candidates(args)
-			eprintln('  [ttime]     cg replay      ${f64(rpsw.elapsed().microseconds()) / 1000.0:7.2f} ms (cands: ${n_cands})')
+			g.timing_profile('  [ttime]     cg replay      ${f64(rpsw.elapsed().microseconds()) / 1000.0:7.2f} ms (cands: ${n_cands})')
 			g.prep_costs_pending = false
 		}
 		g.prep_externs_pending = false
@@ -296,7 +296,7 @@ fn (mut g FlatGen) prepare_pre_dispatch_master() {
 		selection_scope := cgen_worker_scope_begin(true)
 		master_tc := g.tc
 		g.tc = g.clone_parallel_type_checker()
-		eprintln('  [ttime]       pm clone tc  ${f64(pmsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+		g.timing_profile('  [ttime]       pm clone tc  ${f64(pmsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 		pmsw.restart()
 		// Fuse body-local function-pointer discovery into the item cost walk so
 		// parallel type declarations see every typedef before their task starts.
@@ -307,12 +307,12 @@ fn (mut g FlatGen) prepare_pre_dispatch_master() {
 				g.intern_string(node.value)
 			}
 		}
-		eprintln('  [ttime]       pm str walk  ${f64(pmsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+		g.timing_profile('  [ttime]       pm str walk  ${f64(pmsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 		pmsw.restart()
 		g.want_parallel_prep = true
 		items := g.ensure_fn_gen_items()
 		g.want_parallel_prep = false
-		eprintln('  [ttime]       pm items     ${f64(pmsw.elapsed().microseconds()) / 1000.0:7.2f} ms (n: ${items.len})')
+		g.timing_profile('  [ttime]       pm items     ${f64(pmsw.elapsed().microseconds()) / 1000.0:7.2f} ms (n: ${items.len})')
 		pmsw.restart()
 		if _ := g.ierror_interface_name() {
 			g.intern_string('')
@@ -348,7 +348,7 @@ fn (mut g FlatGen) prepare_pre_dispatch_master() {
 		g.generic_app_cache = clone_generic_app_cache(g.generic_app_cache)
 		cgen_worker_scope_free(selection_scope)
 		n_items = g.fn_gen_items.len
-		eprintln('  [ttime]       pm clone out ${f64(pmsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+		g.timing_profile('  [ttime]       pm clone out ${f64(pmsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 	} else {
 		g.want_parallel_prep = true
 		n_items = g.ensure_fn_gen_items().len
@@ -820,10 +820,10 @@ fn (mut g FlatGen) gen_fns_dispatch(no_parallel bool) {
 					}
 				}
 				g.parallel_used = g.a.worker_pool.run(tasks)
-				eprintln('  [ttime]   cg pool.run      ${f64(dsw.elapsed().microseconds()) / 1000.0:7.2f} ms (chunks: ${chunk_count}, workers: ${worker_count})')
+				g.timing_profile('  [ttime]   cg pool.run      ${f64(dsw.elapsed().microseconds()) / 1000.0:7.2f} ms (chunks: ${chunk_count}, workers: ${worker_count})')
 				dsw.restart()
 				_ = type_decls_thread.wait()
-				eprintln('  [ttime]   cg decls wait    ${f64(dsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+				g.timing_profile('  [ttime]   cg decls wait    ${f64(dsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 			}
 			// The declaration thread disables the master's caches while body
 			// workers use their private copies. Restore them for synthetic output.
@@ -843,7 +843,7 @@ fn (mut g FlatGen) gen_fns_dispatch(no_parallel bool) {
 				}
 			}
 			g.replay_ordered_parallel_wrapper_defs(ordered_wrapper_defs)
-			eprintln('  [ttime]   cg merge         ${f64(msw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+			g.timing_profile('  [ttime]   cg merge         ${f64(msw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 			for output in ordered_chunk_outputs {
 				if output.len > 0 {
 					g.fn_segs << output
@@ -2099,13 +2099,13 @@ fn (mut g FlatGen) run_pre_dispatch_parallel(no_parallel bool) bool {
 			mut psw := time.new_stopwatch()
 			fixed_storage_thread := spawn fixed_storage_scan_thread(voidptr(fs_worker))
 			g.prepare_pre_dispatch_master()
-			eprintln('  [ttime]     cg prep master ${f64(psw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+			g.timing_profile('  [ttime]     cg prep master ${f64(psw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 			psw.restart()
 			g.refine_fn_item_costs(no_parallel, true)
-			eprintln('  [ttime]     cg cost refine ${f64(psw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+			g.timing_profile('  [ttime]     cg cost refine ${f64(psw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 			psw.restart()
 			_ = fixed_storage_thread.wait()
-			eprintln('  [ttime]     cg fs wait     ${f64(psw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+			g.timing_profile('  [ttime]     cg fs wait     ${f64(psw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 		}
 		g.publish_fixed_storage_scan(mut fs_worker)
 		if g.parallel_prepared && !g.prep_externs_pending {

--- a/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
@@ -3,7 +3,9 @@ module c
 import os
 import runtime
 import strings
+import time
 import v3.flat
+import v3.gen.c.naming
 import v3.types
 import v3.workers
 
@@ -24,8 +26,10 @@ $if !windows {
 		items_ptr voidptr
 		start     int
 		end       int
+		g         voidptr // &FlatGen, non-nil in fused prep mode (read-only access)
 	mut:
-		refs map[string]bool
+		refs  map[string]bool
+		cands []FlatCgenPrepCandidate
 	}
 
 	struct FlatCgenDynamicArgs {
@@ -39,6 +43,32 @@ $if !windows {
 		mut a := unsafe { &FlatCgenCostArgs(arg) }
 		mut items := unsafe { &[]FlatFnGenItem(a.items_ptr) }
 		mut stack := []flat.NodeId{cap: 256}
+		if !isnil(a.g) {
+			// Fused prep mode: also collect the fn-ptr preseed candidates the
+			// master replays in order after the join (see refine_fn_item_costs).
+			g := unsafe { &FlatGen(a.g) }
+			mut text_cache := &PrepTypTextCache{}
+			mut type_seen := &PreseedTypeSeen{}
+			mut cur_file := ''
+			mut cur_module := ''
+			for idx in a.start .. a.end {
+				unsafe {
+					item_file := items[idx].file
+					item_module := items[idx].module
+					if item_file != cur_file || item_module != cur_module {
+						cur_file = item_file
+						cur_module = item_module
+						text_cache.generation++
+					}
+					cost, needs_prelude_scan := exact_flat_fn_gen_item_cost_and_prep(g,
+						items[idx].node_id, mut a.refs, mut stack, mut a.cands, item_module,
+						item_file, mut text_cache, mut type_seen)
+					items[idx].cost = cost
+					items[idx].skip_prelude_scan = !needs_prelude_scan
+				}
+			}
+			return unsafe { nil }
+		}
 		for idx in a.start .. a.end {
 			unsafe {
 				cost, needs_prelude_scan := exact_flat_fn_gen_item_cost(a.a, items[idx].node_id, mut
@@ -80,12 +110,14 @@ $if !windows {
 	// fn work items and pre-seeds the parallel tables.
 	fn fixed_storage_scan_thread(arg voidptr) voidptr {
 		mut w := unsafe { &FlatGen(arg) }
+		fssw := time.new_stopwatch()
 		scope := cgen_worker_scope_begin(w.scope_parallel_workers)
 		w.collect_fixed_storage_consts()
 		w.precompute_param_type_index()
 		w.precompute_concrete_optional_abi_fns()
 		w.worker_scope = scope
 		cgen_worker_scope_leave(scope)
+		eprintln('  [ttime]     cg fs scan     ${f64(fssw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 		return unsafe { nil }
 	}
 
@@ -121,18 +153,65 @@ $if !windows {
 	}
 }
 
+// finish_pending_item_prep_serial is the fallback for the work item selection
+// defers to the parallel exact-cost pass (C-extern refs, and in parallel-prep
+// mode also costs and fn-ptr preseeds): when that pass cannot run, do the
+// deferred work serially like the former fused prep walk did.
+fn (mut g FlatGen) finish_pending_item_prep_serial() {
+	if !g.prep_externs_pending && !g.prep_costs_pending {
+		return
+	}
+	mut stack := []flat.NodeId{cap: 256}
+	if g.prep_costs_pending {
+		g.prep_costs_pending = false
+		// The selection-scope-allocated caches are gone by now; walk with
+		// fresh ones.
+		g.prep_typ_text_cache = &PrepTypTextCache{}
+		g.preseed_type_seen = &PreseedTypeSeen{}
+		mut type_text_cache := map[string]bool{}
+		for i in 0 .. g.fn_gen_items.len {
+			item := g.fn_gen_items[i]
+			if item.file != g.tc.cur_file || item.module != g.tc.cur_module {
+				type_text_cache.clear()
+				if !isnil(g.prep_typ_text_cache) {
+					g.prep_typ_text_cache.generation++
+				}
+			}
+			g.tc.cur_file = item.file
+			g.tc.cur_module = item.module
+			g.fn_gen_items[i].cost = g.fn_item_cost_and_prep(item.node_id, mut stack, mut
+				type_text_cache)
+		}
+	}
+	if g.prep_externs_pending {
+		g.prep_externs_pending = false
+		items := g.fn_gen_items
+		for item in items {
+			_ = g.fn_item_cost_and_c_extern_prep(item.node_id, mut stack)
+		}
+	}
+}
+
 fn (mut g FlatGen) refine_fn_item_costs(no_parallel bool, reserve_worker bool) {
 	if no_parallel || g.fn_gen_items.len < min_flat_cgen_parallel_items {
+		g.finish_pending_item_prep_serial()
 		return
 	}
 	$if windows {
+		g.finish_pending_item_prep_serial()
 		return
 	} $else {
 		if isnil(g.a.worker_pool) || g.a.worker_pool.size() == 0 {
+			g.finish_pending_item_prep_serial()
 			return
 		}
 		available_jobs := g.a.worker_pool.size() + 1 - if reserve_worker { 1 } else { 0 }
 		n_jobs := flat_cgen_job_count(available_jobs, g.fn_gen_items.len)
+		fused := g.prep_costs_pending
+		mut prep_g := unsafe { nil }
+		if fused {
+			prep_g = voidptr(g)
+		}
 		mut args := []FlatCgenCostArgs{cap: n_jobs}
 		mut tasks := []workers.Task{cap: n_jobs}
 		for job in 0 .. n_jobs {
@@ -143,6 +222,7 @@ fn (mut g FlatGen) refine_fn_item_costs(no_parallel bool, reserve_worker bool) {
 				items_ptr: unsafe { voidptr(&g.fn_gen_items) }
 				start:     start
 				end:       end
+				g:         prep_g
 			}
 		}
 		for job in 0 .. n_jobs {
@@ -152,11 +232,57 @@ fn (mut g FlatGen) refine_fn_item_costs(no_parallel bool, reserve_worker bool) {
 				force_sync: job == 0
 			}
 		}
+		rfsw := time.new_stopwatch()
 		g.a.worker_pool.run(tasks)
+		eprintln('  [ttime]     cg refine pool ${f64(rfsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 		for arg in args {
 			for name, used in arg.refs {
 				if used {
 					g.c_extern_refs[name] = true
+				}
+			}
+		}
+		if fused {
+			rpsw := time.new_stopwatch()
+			mut n_cands := 0
+			for arg in args {
+				n_cands += arg.cands.len
+			}
+			g.replay_prep_candidates(args)
+			eprintln('  [ttime]     cg replay      ${f64(rpsw.elapsed().microseconds()) / 1000.0:7.2f} ms (cands: ${n_cands})')
+			g.prep_costs_pending = false
+		}
+		g.prep_externs_pending = false
+	}
+}
+
+// replay_prep_candidates applies the fn-ptr preseeds collected by the parallel
+// prep workers, in source order, so registrations land exactly as the former
+// serial walk produced them.
+fn (mut g FlatGen) replay_prep_candidates(args []FlatCgenCostArgs) {
+	mut type_text_cache := map[string]bool{}
+	// Fresh local dedup cache: g.preseed_type_seen was allocated inside the
+	// (already freed) selection scope and must not be touched here.
+	mut replay_seen := &PreseedTypeSeen{}
+	for arg in args {
+		for cand in arg.cands {
+			if cand.file != g.tc.cur_file || cand.module != g.tc.cur_module {
+				type_text_cache.clear()
+				g.tc.cur_file = cand.file
+				g.tc.cur_module = cand.module
+			}
+			if cand.is_expr {
+				w0, w1, slot := preseed_type_words(cand.typ)
+				if !replay_seen.seen[slot] || replay_seen.w0[slot] != w0
+					|| replay_seen.w1[slot] != w1 {
+					replay_seen.w0[slot] = w0
+					replay_seen.w1[slot] = w1
+					replay_seen.seen[slot] = true
+					g.preseed_parallel_fn_ptr_type(cand.typ)
+				}
+			} else {
+				if g.should_preseed_parallel_type_text_cached(cand.text, mut type_text_cache) {
+					g.preseed_parallel_fn_ptr_type(g.tc.parse_type(cand.text))
 				}
 			}
 		}
@@ -166,20 +292,28 @@ fn (mut g FlatGen) refine_fn_item_costs(no_parallel bool, reserve_worker bool) {
 fn (mut g FlatGen) prepare_pre_dispatch_master() {
 	mut n_items := 0
 	if g.scope_parallel_workers {
+		mut pmsw := time.new_stopwatch()
 		selection_scope := cgen_worker_scope_begin(true)
 		master_tc := g.tc
 		g.tc = g.clone_parallel_type_checker()
+		eprintln('  [ttime]       pm clone tc  ${f64(pmsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+		pmsw.restart()
 		// Fuse body-local function-pointer discovery into the item cost walk so
 		// parallel type declarations see every typedef before their task starts.
 		// The globally numbered string table must also be complete before output.
-		for node in g.a.nodes {
+		for i in 0 .. g.a.nodes.len {
+			node := unsafe { &g.a.nodes[i] }
 			if node.kind == .string_literal {
 				g.intern_string(node.value)
 			}
 		}
+		eprintln('  [ttime]       pm str walk  ${f64(pmsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+		pmsw.restart()
 		g.want_parallel_prep = true
 		items := g.ensure_fn_gen_items()
 		g.want_parallel_prep = false
+		eprintln('  [ttime]       pm items     ${f64(pmsw.elapsed().microseconds()) / 1000.0:7.2f} ms (n: ${items.len})')
+		pmsw.restart()
 		if _ := g.ierror_interface_name() {
 			g.intern_string('')
 		}
@@ -214,6 +348,7 @@ fn (mut g FlatGen) prepare_pre_dispatch_master() {
 		g.generic_app_cache = clone_generic_app_cache(g.generic_app_cache)
 		cgen_worker_scope_free(selection_scope)
 		n_items = g.fn_gen_items.len
+		eprintln('  [ttime]       pm clone out ${f64(pmsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 	} else {
 		g.want_parallel_prep = true
 		n_items = g.ensure_fn_gen_items().len
@@ -655,6 +790,7 @@ fn (mut g FlatGen) gen_fns_dispatch(no_parallel bool) {
 				// Long-lived workers pull small source-contiguous chunks from a shared
 				// queue. This balances expression-cost and scheduler variation without
 				// rebuilding the generator caches for every chunk.
+				mut dsw := time.new_stopwatch()
 				ordered_chunk_outputs = []string{len: chunk_count}
 				ordered_wrapper_defs = []ParallelChunkWrapperDefs{len: chunk_count}
 				chunk_queue := chan int{cap: chunk_count}
@@ -684,10 +820,14 @@ fn (mut g FlatGen) gen_fns_dispatch(no_parallel bool) {
 					}
 				}
 				g.parallel_used = g.a.worker_pool.run(tasks)
+				eprintln('  [ttime]   cg pool.run      ${f64(dsw.elapsed().microseconds()) / 1000.0:7.2f} ms (chunks: ${chunk_count}, workers: ${worker_count})')
+				dsw.restart()
 				_ = type_decls_thread.wait()
+				eprintln('  [ttime]   cg decls wait    ${f64(dsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 			}
 			// The declaration thread disables the master's caches while body
 			// workers use their private copies. Restore them for synthetic output.
+			mut msw := time.new_stopwatch()
 			g.reset_context_lookup_caches()
 			for worker_ptr in cgen_workers {
 				mut w := unsafe { &FlatGen(worker_ptr) }
@@ -703,6 +843,7 @@ fn (mut g FlatGen) gen_fns_dispatch(no_parallel bool) {
 				}
 			}
 			g.replay_ordered_parallel_wrapper_defs(ordered_wrapper_defs)
+			eprintln('  [ttime]   cg merge         ${f64(msw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 			for output in ordered_chunk_outputs {
 				if output.len > 0 {
 					g.fn_segs << output
@@ -938,19 +1079,23 @@ fn (mut g FlatGen) fn_item_cost_and_prep(node_id flat.NodeId, mut stack []flat.N
 		if idx < 0 || idx >= g.a.nodes.len {
 			continue
 		}
-		node := g.a.nodes[idx]
+		node := unsafe { &g.a.nodes[idx] }
 		cost++
-		if node.kind == .string_literal {
-			g.intern_string(node.value)
-		}
-		if node.kind == .selector {
-			g.collect_c_extern_ref_from_node(node)
-		}
-		if g.should_preseed_parallel_type_text_cached(node.typ, mut type_text_cache) {
+		// String literals were already interned by the whole-AST literal walk in
+		// prepare_pre_dispatch_master, and C-extern refs are re-collected by the
+		// parallel exact-cost pass that always follows this prep (with a serial
+		// fallback, see refine_fn_item_costs). Keep this walk preseed-only.
+		if node.typ.len > 0
+			&& g.should_preseed_parallel_type_text_ptr_cached(node.typ, mut type_text_cache) {
 			g.preseed_parallel_fn_ptr_type(g.tc.parse_type(node.typ))
 		}
 		if expr_type := g.parallel_cached_expr_type(current_id, node) {
-			g.preseed_parallel_fn_ptr_type(expr_type)
+			// Checker-cached expression types repeat the same ~1K canonical
+			// values across hundreds of thousands of nodes; traverse each
+			// distinct value once instead of per node.
+			if g.preseed_type_first_seen(expr_type) {
+				g.preseed_parallel_fn_ptr_type(expr_type)
+			}
 		}
 		for i := node.children_count - 1; i >= 0; i-- {
 			child_id := g.a.children[node.children_start + i]
@@ -972,7 +1117,7 @@ fn (mut g FlatGen) fn_item_cost_and_c_extern_prep(node_id flat.NodeId, mut stack
 		if idx < 0 || idx >= g.a.nodes.len {
 			continue
 		}
-		node := g.a.nodes[idx]
+		node := unsafe { &g.a.nodes[idx] }
 		cost++
 		if node.kind == .selector {
 			g.collect_c_extern_ref_from_node(node)
@@ -1028,12 +1173,13 @@ fn (mut g FlatGen) prepare_parallel_node(id flat.NodeId, mut stack []flat.NodeId
 		if idx < 0 || idx >= g.a.nodes.len {
 			continue
 		}
-		node := g.a.nodes[idx]
+		node := unsafe { &g.a.nodes[idx] }
 		if node.kind == .string_literal {
 			g.intern_string(node.value)
 		}
 		g.collect_c_extern_ref_from_node(node)
-		if g.should_preseed_parallel_type_text_cached(node.typ, mut type_text_cache) {
+		if node.typ.len > 0
+			&& g.should_preseed_parallel_type_text_cached(node.typ, mut type_text_cache) {
 			g.preseed_parallel_fn_ptr_type(g.tc.parse_type(node.typ))
 		}
 		if expr_type := g.parallel_cached_expr_type(current_id, node) {
@@ -1048,7 +1194,7 @@ fn (mut g FlatGen) prepare_parallel_node(id flat.NodeId, mut stack []flat.NodeId
 	}
 }
 
-fn (g &FlatGen) parallel_cached_expr_type(id flat.NodeId, node flat.Node) ?types.Type {
+fn (g &FlatGen) parallel_cached_expr_type(id flat.NodeId, node &flat.Node) ?types.Type {
 	idx := int(id)
 	if idx < 0 {
 		return none
@@ -1077,6 +1223,173 @@ fn (g &FlatGen) parallel_cached_expr_type(id flat.NodeId, node flat.Node) ?types
 		}
 	}
 	return none
+}
+
+// FlatCgenPrepCandidate is one deferred fn-ptr preseed action discovered by a
+// parallel prep worker, replayed by the master in source order so the typedef
+// registration order matches the former serial walk exactly.
+struct FlatCgenPrepCandidate {
+	is_expr bool
+	text    string // node.typ text (is_expr == false)
+	module  string
+	file    string
+	typ     types.Type // checker-cached expr type (is_expr == true)
+}
+
+// exact_flat_fn_gen_item_cost_and_prep is exact_flat_fn_gen_item_cost plus the
+// candidate collection of the former serial fused prep walk: distinct type
+// texts and distinct cached expression types, in encounter order. All FlatGen
+// and checker access is read-only (nothing writes the dense expr caches during
+// cgen; every remember_expr_type caller is a mut check-phase path).
+fn exact_flat_fn_gen_item_cost_and_prep(g &FlatGen, node_id flat.NodeId, mut c_extern_refs map[string]bool, mut stack []flat.NodeId, mut cands []FlatCgenPrepCandidate, item_module string, item_file string, mut text_cache PrepTypTextCache, mut type_seen PreseedTypeSeen) (int, bool) {
+	a := g.a
+	mut cost := 0
+	mut needs_prelude_scan := false
+	stack.clear()
+	stack << node_id
+	for stack.len > 0 {
+		id := stack.pop()
+		idx := int(id)
+		if idx < 0 || idx >= a.nodes.len {
+			continue
+		}
+		node := unsafe { &a.nodes[idx] }
+		cost += flat_cgen_node_cost(node.kind)
+		if node.kind == .lock_expr || node.kind == .label_stmt
+			|| (node.kind == .defer_stmt && node.value == 'function') {
+			needs_prelude_scan = true
+		}
+		if node.kind == .selector && node.children_count > 0 && node.value.len > 0 {
+			base_id := a.children[node.children_start]
+			if int(base_id) >= 0 {
+				base := unsafe { &a.nodes[int(base_id)] }
+				if base.kind == .ident && base.value == 'C' {
+					raw_name := 'C.${node.value}'
+					raw_cfn := naming.c_name(raw_name)
+					c_extern_refs[raw_name] = true
+					c_extern_refs[raw_cfn] = true
+					c_extern_refs[c_winapi_wide_export_name(raw_cfn)] = true
+				}
+			}
+		}
+		if node.typ.len > 0 {
+			slot := int((u64(voidptr(node.typ.str)) >> 4) & 4095)
+			if text_cache.gens[slot] != text_cache.generation
+				|| text_cache.ptrs[slot] != voidptr(node.typ.str)
+				|| text_cache.lens[slot] != node.typ.len {
+				text_cache.ptrs[slot] = voidptr(node.typ.str)
+				text_cache.gens[slot] = text_cache.generation
+				text_cache.lens[slot] = node.typ.len
+				cands << FlatCgenPrepCandidate{
+					text:   node.typ
+					module: item_module
+					file:   item_file
+				}
+			}
+		}
+		if expr_type := g.parallel_cached_expr_type(id, node) {
+			w0, w1, slot := preseed_type_words(expr_type)
+			if !type_seen.seen[slot] || type_seen.w0[slot] != w0 || type_seen.w1[slot] != w1 {
+				type_seen.w0[slot] = w0
+				type_seen.w1[slot] = w1
+				type_seen.seen[slot] = true
+				cands << FlatCgenPrepCandidate{
+					is_expr: true
+					module:  item_module
+					file:    item_file
+					typ:     expr_type
+				}
+			}
+		}
+		for i := node.children_count - 1; i >= 0; i-- {
+			child_id := a.children[node.children_start + i]
+			if int(child_id) >= 0 {
+				stack << child_id
+			}
+		}
+	}
+	return cost, needs_prelude_scan
+}
+
+@[inline]
+fn preseed_type_words(typ &types.Type) (u64, u64, int) {
+	words := unsafe { &u64(voidptr(typ)) }
+	w0 := unsafe { words[0] }
+	w1 := unsafe { words[1] }
+	return w0, w1, int(((w0 >> 4) ^ w1) & 4095)
+}
+
+// par_cgen_prep_enabled gates the parallel fused item prep, so a single binary
+// can A/B or disable it (`V3_NO_PAR_CGEN_PREP=1`).
+fn par_cgen_prep_enabled() bool {
+	return os.getenv('V3_NO_PAR_CGEN_PREP') == ''
+}
+
+// PreseedTypeSeen dedups fn-ptr preseed traversals of checker-cached
+// expression types during the fused prep walk. Keys are the opaque 16-byte
+// Type value (variant box pointer + tag): identical bytes always denote the
+// same type, so a hit safely skips the traversal; collisions just evict. The
+// cache lives only for one item-selection walk, within the selection scope
+// that owns any non-canonical type values it may reference.
+struct PreseedTypeSeen {
+mut:
+	w0   [4096]u64
+	w1   [4096]u64
+	seen [4096]bool
+}
+
+// preseed_type_first_seen reports whether this exact type value has not been
+// preseeded yet during the current prep walk, recording it as seen.
+fn (mut g FlatGen) preseed_type_first_seen(typ &types.Type) bool {
+	mut cache := g.preseed_type_seen
+	if isnil(cache) {
+		return true
+	}
+	words := unsafe { &u64(voidptr(typ)) }
+	w0 := unsafe { words[0] }
+	w1 := unsafe { words[1] }
+	slot := int(((w0 >> 4) ^ w1) & 4095)
+	if cache.seen[slot] && cache.w0[slot] == w0 && cache.w1[slot] == w1 {
+		return false
+	}
+	cache.w0[slot] = w0
+	cache.w1[slot] = w1
+	cache.seen[slot] = true
+	return true
+}
+
+// PrepTypTextCache short-circuits repeated preseed verdicts for the SAME type
+// text instance during the fused item prep walk: node.typ strings are shared
+// instances, so a pointer probe replaces most content-hash map lookups. The
+// generation is bumped whenever the file/module context changes (verdicts
+// depend on qualify_name), matching the map cache's clear.
+struct PrepTypTextCache {
+mut:
+	generation u32 = 1
+	ptrs       [4096]voidptr
+	gens       [4096]u32
+	lens       [4096]int
+	verdicts   [4096]bool
+}
+
+fn (mut g FlatGen) should_preseed_parallel_type_text_ptr_cached(typ string, mut cache map[string]bool) bool {
+	mut tcache := g.prep_typ_text_cache
+	if isnil(tcache) {
+		return g.should_preseed_parallel_type_text_cached(typ, mut cache)
+	}
+	slot := int((u64(voidptr(typ.str)) >> 4) & 4095)
+	// Same pointer + same length + live generation means same text in the same
+	// context (the length guards unsafe zero-copy slices sharing a base).
+	if tcache.gens[slot] == tcache.generation && tcache.ptrs[slot] == voidptr(typ.str)
+		&& tcache.lens[slot] == typ.len {
+		return tcache.verdicts[slot]
+	}
+	verdict := g.should_preseed_parallel_type_text_cached(typ, mut cache)
+	tcache.ptrs[slot] = voidptr(typ.str)
+	tcache.gens[slot] = tcache.generation
+	tcache.lens[slot] = typ.len
+	tcache.verdicts[slot] = verdict
+	return verdict
 }
 
 fn (g &FlatGen) should_preseed_parallel_type_text_cached(typ string, mut cache map[string]bool) bool {
@@ -1255,6 +1568,7 @@ fn (g &FlatGen) new_parallel_worker_config(worker_id int, result_only bool) &Fla
 		}
 		has_builtins:                   g.has_builtins
 		cache_split:                    g.cache_split
+		skip_generics:                  g.skip_generics
 		tmp_count:                      (worker_id + 1) * 100_000
 		line_start:                     true
 		modules:                        g.modules
@@ -1356,6 +1670,7 @@ fn (g &FlatGen) new_parallel_worker_config(worker_id int, result_only bool) &Fla
 		enum_selector_cache:         &ContextStringLookupCache{}
 		enum_method_cache:           &ContextStringLookupCache{}
 		qualified_enum_method_cache: &ContextStringLookupCache{}
+		struct_decl_pref_cache:      &StructDeclPrefCache{}
 		embedded_fields_by_type:     g.embedded_fields_by_type
 		param_types_by_short:        g.param_types_by_short
 		generic_method_candidates:   g.generic_method_candidates
@@ -1781,12 +2096,24 @@ fn (mut g FlatGen) run_pre_dispatch_parallel(no_parallel bool) bool {
 			// Item selection only reads the AST and immutable checker tables, so let
 			// its exact-cost pass use the otherwise-idle pool while the independent
 			// fixed-storage scan finishes on a helper thread.
+			mut psw := time.new_stopwatch()
 			fixed_storage_thread := spawn fixed_storage_scan_thread(voidptr(fs_worker))
 			g.prepare_pre_dispatch_master()
+			eprintln('  [ttime]     cg prep master ${f64(psw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+			psw.restart()
 			g.refine_fn_item_costs(no_parallel, true)
+			eprintln('  [ttime]     cg cost refine ${f64(psw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+			psw.restart()
 			_ = fixed_storage_thread.wait()
+			eprintln('  [ttime]     cg fs wait     ${f64(psw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 		}
 		g.publish_fixed_storage_scan(mut fs_worker)
+		if g.parallel_prepared && !g.prep_externs_pending {
+			// Item-body and top-level C-extern refs are fully collected (fused
+			// prep + exact-cost pass or its serial fallback); the pre-dispatch
+			// preseed can reuse them instead of re-walking every selected body.
+			g.c_extern_refs_ready = true
+		}
 		return true
 	}
 }

--- a/vlib/v3/gen/c/interface.v
+++ b/vlib/v3/gen/c/interface.v
@@ -42,6 +42,15 @@ fn (g &FlatGen) sum_type_contains_struct(sum_name string, struct_name string) bo
 // sum_type_index supports sum type index handling for FlatGen.
 fn (g &FlatGen) sum_type_index(sum_name string, variant string) int {
 	mut resolved_sum := sum_name
+	if resolved_sum !in g.tc.sum_types && !resolved_sum.contains('.') {
+		// A bare sum name from a foreign-module lowering (auto-stringify
+		// expansions keep the declaring module's spelling): the precomputed
+		// short-name table maps it to the declared qualified sum.
+		short_resolved := g.resolve_sum_name(resolved_sum)
+		if short_resolved in g.tc.sum_types {
+			resolved_sum = short_resolved
+		}
+	}
 	if resolved_sum !in g.tc.sum_types && resolved_sum.contains('.') {
 		// Resolve an import-aliased sum name (`tast.Value` for module `sub.tast`)
 		// exactly first. Use suffix and bare-name fallbacks only when unique.

--- a/vlib/v3/gen/c/naming/naming.v
+++ b/vlib/v3/gen/c/naming/naming.v
@@ -127,12 +127,6 @@ pub fn c_name(name string) string {
 	if name == 'exit' {
 		return 'v_exit'
 	}
-	if is_plain_identifier(name) {
-		if name in reserved_words || name in libc_collisions || is_string_literal_symbol(name) {
-			return 'v_${name}'
-		}
-		return name
-	}
 	n := sanitize(name)
 	if n in reserved_words || n in libc_collisions || is_string_literal_symbol(n) {
 		if name.contains('@') {
@@ -158,6 +152,37 @@ fn is_string_literal_symbol(name string) bool {
 // sanitize converts a V symbol or type spelling into a C identifier spelling
 // without applying reserved-word or libc collision prefixes.
 pub fn sanitize(name string) string {
+	mut dot_count := 0
+	for i in 0 .. name.len {
+		c := name[i]
+		if (c >= `a` && c <= `z`) || (c >= `A` && c <= `Z`) || (c >= `0` && c <= `9`) || c == `_` {
+			continue
+		}
+		if c != `.` {
+			return sanitize_complex(name)
+		}
+		dot_count++
+	}
+	if dot_count == 0 {
+		return name
+	}
+	mut out := []u8{len: name.len + dot_count}
+	mut dst := 0
+	for i in 0 .. name.len {
+		c := name[i]
+		if c == `.` {
+			out[dst] = `_`
+			out[dst + 1] = `_`
+			dst += 2
+		} else {
+			out[dst] = c
+			dst++
+		}
+	}
+	return out.bytestr()
+}
+
+fn sanitize_complex(name string) string {
 	mut b := strings.new_builder(name.len + 8)
 	mut i := 0
 	for i < name.len {

--- a/vlib/v3/gen/c/struct.v
+++ b/vlib/v3/gen/c/struct.v
@@ -357,7 +357,8 @@ fn (mut g FlatGen) gen_struct_init(id flat.NodeId) {
 		return
 	}
 	effective_type := default_init_unalias_type(types.unwrap_pointer(g.tc.parse_type(init_value)))
-	if effective_type !is types.Struct && g.gen_lowered_sum_init(node) {
+	if (effective_type !is types.Struct || g.struct_init_is_lowered_sum_literal(node))
+		&& g.gen_lowered_sum_init(node) {
 		return
 	}
 	mut name := g.struct_init_c_type_name(init_value)
@@ -1033,6 +1034,22 @@ fn (mut g FlatGen) gen_lowered_sum_init(node flat.Node) bool {
 	}
 	g.write('}')
 	return true
+}
+
+// struct_init_is_lowered_sum_literal recognizes a transform-made sum literal
+// (exactly a `typ` index field plus one variant payload field) whose sum name
+// kept a foreign module's bare spelling: such a name parses as a plain struct,
+// which would otherwise skip the sum-init route and drop the variant boxing.
+fn (g &FlatGen) struct_init_is_lowered_sum_literal(node flat.Node) bool {
+	if node.children_count != 2 || node.value.len == 0 || node.value.contains('.') {
+		return false
+	}
+	first := g.a.child_node(&node, 0)
+	if first.value != 'typ' {
+		return false
+	}
+	resolved := g.resolve_sum_name(node.value)
+	return resolved != node.value && resolved in g.tc.sum_types && node.value !in g.tc.structs
 }
 
 fn (g &FlatGen) lowered_sum_init_name(node flat.Node) string {
@@ -2155,6 +2172,9 @@ mut:
 }
 
 fn (g &FlatGen) shared_generic_app_parts(typ string) (string, []string, bool) {
+	if g.skip_generics {
+		return '', []string{}, false
+	}
 	// Most queried type names are not generic. Avoid hashing and retaining a
 	// negative cache entry when a single byte scan can reject them.
 	if typ.index_u8(`[`) <= 0 || typ.starts_with('fn(') || typ.starts_with('fn (') {
@@ -3209,6 +3229,9 @@ fn (g &FlatGen) struct_init_value_c_type(typ types.Type) string {
 }
 
 fn (g &FlatGen) generic_struct_init_instance_ct_for_node(node flat.Node) ?string {
+	if g.skip_generics {
+		return none
+	}
 	if node.typ.len > 0 {
 		candidate := g.tc.parse_type(node.typ)
 		base := default_init_unalias_type(types.unwrap_all_pointers(candidate))
@@ -3258,6 +3281,9 @@ fn (g &FlatGen) generic_struct_init_instance_name(type_name string) ?string {
 // Returns none when the literal is already specialized, the base is not a generic struct,
 // or the expected type is not a matching concrete instance.
 fn (g &FlatGen) generic_struct_init_instance_type(type_name string) ?types.Type {
+	if g.skip_generics {
+		return none
+	}
 	if type_name.contains('[') {
 		return none
 	}
@@ -3594,7 +3620,41 @@ fn (g &FlatGen) find_struct_decl(type_name string) ?StructDeclInfo {
 	return g.find_struct_decl_fallback(type_name)
 }
 
+// StructDeclPrefCache memoizes find_struct_decl_preferred per module context.
+// The struct declaration tables are immutable during codegen; each worker owns
+// a private instance (new_parallel_worker_config).
+struct StructDeclPrefCache {
+mut:
+	module  string
+	entries map[string]StructDeclInfo
+	misses  map[string]bool
+}
+
 fn (g &FlatGen) find_struct_decl_preferred(type_name string) ?StructDeclInfo {
+	mut cache := g.struct_decl_pref_cache
+	if isnil(cache) {
+		return g.find_struct_decl_preferred_uncached(type_name)
+	}
+	if cache.module != g.tc.cur_module {
+		cache.module = g.tc.cur_module
+		cache.entries.clear()
+		cache.misses.clear()
+	}
+	if cached := cache.entries[type_name] {
+		return cached
+	}
+	if cache.misses[type_name] {
+		return none
+	}
+	if info := g.find_struct_decl_preferred_uncached(type_name) {
+		cache.entries[type_name] = info
+		return info
+	}
+	cache.misses[type_name] = true
+	return none
+}
+
+fn (g &FlatGen) find_struct_decl_preferred_uncached(type_name string) ?StructDeclInfo {
 	short_name := if type_name.contains('.') { type_name.all_after_last('.') } else { type_name }
 	preferred_name := if !type_name.contains('.') && g.tc.cur_module.len > 0
 		&& g.tc.cur_module != 'main' && g.tc.cur_module != 'builtin' {
@@ -5506,6 +5566,22 @@ fn (mut g FlatGen) preseed_sum_fn_ptr_types() {
 }
 
 fn (mut g FlatGen) preseed_fn_ptr_type(typ types.Type) {
+	// Whole-traversal dedup: identical 16-byte type values always denote the
+	// same type, and a repeat traversal re-registers nothing new. Armed only
+	// during the pre-dispatch declaration preseed block (see gen_with_used_options).
+	if !isnil(g.preseed_sig_type_seen) {
+		mut cache := g.preseed_sig_type_seen
+		words := unsafe { &u64(voidptr(&typ)) }
+		w0 := unsafe { words[0] }
+		w1 := unsafe { words[1] }
+		slot := int(((w0 >> 4) ^ w1) & 4095)
+		if cache.seen[slot] && cache.w0[slot] == w0 && cache.w1[slot] == w1 {
+			return
+		}
+		cache.w0[slot] = w0
+		cache.w1[slot] = w1
+		cache.seen[slot] = true
+	}
 	if typ is types.Alias {
 		g.preseed_fn_ptr_type(typ.base_type)
 		return

--- a/vlib/v3/gen/c/types.v
+++ b/vlib/v3/gen/c/types.v
@@ -374,10 +374,20 @@ fn (mut g FlatGen) collect_declaration_signature_types() {
 	if g.decl_types_ready {
 		return
 	}
-	for _, ret in g.tc.fn_ret_types {
+	for name, ret in g.tc.fn_ret_types {
+		// Generic template signatures keep unspecialized placeholder types
+		// (`!&Tls[T]`); their typedefs would reference C types that are never
+		// emitted. Specializations register concrete signatures under their
+		// own suffixed names.
+		if name in g.tc.fn_generic_params {
+			continue
+		}
 		g.collect_declaration_signature_type(ret)
 	}
-	for _, params in g.tc.fn_param_types {
+	for name, params in g.tc.fn_param_types {
+		if name in g.tc.fn_generic_params {
+			continue
+		}
 		for param in params {
 			g.collect_declaration_signature_type(param)
 		}
@@ -409,7 +419,15 @@ fn (mut g FlatGen) collect_declaration_signature_types() {
 }
 
 fn (mut g FlatGen) collect_declaration_signature_type(t types.Type) {
-	if g.type_contains_generic_placeholder(t) {
+	// Erased-template signatures keep their placeholder spellings in the
+	// checker tables even when the program itself uses no generics
+	// (skip_generics); force the placeholder check so an unused template's
+	// `!&Tls[T]` return cannot leave an Optional_..._T typedef referencing a
+	// C type that is never emitted.
+	g.placeholder_check_forced = true
+	skip := g.type_contains_generic_placeholder(t)
+	g.placeholder_check_forced = false
+	if skip {
 		return
 	}
 	g.collect_concrete_optional_typedef_type(t)
@@ -584,6 +602,9 @@ fn type_name_is_unbound_generic_decl(name string, params []string, materialized 
 }
 
 fn (g &FlatGen) type_name_contains_generic_placeholder(name string) bool {
+	if g.skip_generics && !g.placeholder_check_forced {
+		return false
+	}
 	clean := trimmed_space(name)
 	if clean.len == 0 {
 		return false
@@ -975,9 +996,32 @@ fn (g &FlatGen) enum_autostr_c_name(type_name string) string {
 	if name in g.tc.enum_names {
 		return g.cname(name)
 	}
+	if !name.contains('.') && g.tc.cur_module.len > 0 {
+		qualified := '${g.tc.cur_module}.${name}'
+		if qualified in g.tc.enum_names {
+			return g.cname(qualified)
+		}
+	}
 	short_name := name.all_after_last('.')
 	if short_name in g.tc.enum_names {
 		return g.cname(short_name)
+	}
+	if !name.contains('.') {
+		suffix := '.${name}'
+		mut match_name := ''
+		mut matches := 0
+		for enum_name, _ in g.tc.enum_names {
+			if enum_name.ends_with(suffix) {
+				match_name = enum_name
+				matches++
+				if matches > 1 {
+					break
+				}
+			}
+		}
+		if matches == 1 {
+			return g.cname(match_name)
+		}
 	}
 	return g.cname(name)
 }

--- a/vlib/v3/markused/markused.v
+++ b/vlib/v3/markused/markused.v
@@ -1,6 +1,8 @@
 module markused
 
 import strings
+import time
+import os
 import v3.flat
 import v3.gen.c.naming
 import v3.types
@@ -10,7 +12,7 @@ const min_eager_markused_bodies = 4096
 
 // mark_used updates mark used state for markused.
 pub fn mark_used(a &flat.FlatAst, tc &types.TypeChecker) map[string]bool {
-	used, _ := mark_used_with_test_files(a, tc, map[string]bool{}, map[string]bool{}, false)
+	used, _ := mark_used_with_test_files(a, tc, map[string]bool{}, map[string]bool{}, false, true)
 	return used
 }
 
@@ -22,7 +24,14 @@ pub fn mark_used_for_tests(a &flat.FlatAst, tc &types.TypeChecker, test_files []
 // mark_used_with_generic_usage also reports whether reachable code uses a generic
 // function, struct, or sum type and therefore requires monomorphization.
 pub fn mark_used_with_generic_usage(a &flat.FlatAst, tc &types.TypeChecker) (map[string]bool, bool) {
-	return mark_used_with_test_files(a, tc, map[string]bool{}, map[string]bool{}, false)
+	return mark_used_with_test_files(a, tc, map[string]bool{}, map[string]bool{}, false, true)
+}
+
+// mark_used_without_generic_detection is the self-host variant for inputs whose caller
+// already guarantees that monomorphization is unnecessary.
+pub fn mark_used_without_generic_detection(a &flat.FlatAst, tc &types.TypeChecker) map[string]bool {
+	used, _ := mark_used_with_test_files(a, tc, map[string]bool{}, map[string]bool{}, false, false)
+	return used
 }
 
 // mark_used_for_tests_with_generic_usage is the test-file-rooted variant of
@@ -32,7 +41,7 @@ pub fn mark_used_for_tests_with_generic_usage(a &flat.FlatAst, tc &types.TypeChe
 	for file in test_files {
 		file_map[file] = true
 	}
-	return mark_used_with_test_files(a, tc, file_map, map[string]bool{}, false)
+	return mark_used_with_test_files(a, tc, file_map, map[string]bool{}, false, true)
 }
 
 // mark_used_for_cache roots every concrete function in modules being built for the object cache.
@@ -48,7 +57,18 @@ pub fn mark_used_for_cache_with_generic_usage(a &flat.FlatAst, tc &types.TypeChe
 	for file in test_files {
 		file_map[file] = true
 	}
-	return mark_used_with_test_files(a, tc, file_map, source_modules, true)
+	return mark_used_with_test_files(a, tc, file_map, source_modules, true, true)
+}
+
+// mark_used_for_cache_without_generic_detection is the self-host cache variant for inputs
+// whose caller already guarantees that monomorphization is unnecessary.
+pub fn mark_used_for_cache_without_generic_detection(a &flat.FlatAst, tc &types.TypeChecker, test_files []string, source_modules map[string]bool) map[string]bool {
+	mut file_map := map[string]bool{}
+	for file in test_files {
+		file_map[file] = true
+	}
+	used, _ := mark_used_with_test_files(a, tc, file_map, source_modules, true, false)
+	return used
 }
 
 // reachable_const_exprs returns const initializer expressions referenced by the supplied
@@ -123,7 +143,18 @@ pub fn reachable_const_exprs(a &flat.FlatAst, tc &types.TypeChecker, root_ids []
 	return result
 }
 
-fn mark_used_with_test_files(a &flat.FlatAst, tc &types.TypeChecker, test_files map[string]bool, cache_modules map[string]bool, cache_mode bool) (map[string]bool, bool) {
+fn mark_used_with_test_files(a &flat.FlatAst, tc &types.TypeChecker, test_files map[string]bool, cache_modules map[string]bool, cache_mode bool, detect_generics bool) (map[string]bool, bool) {
+	mut mu_sw := time.new_stopwatch()
+	// The runtime-helper detection scan only reads the AST and (forked) checker
+	// caches, so it runs on its own thread under the decl scan + precollect and
+	// its enqueue requests are replayed in scan order at the seeds step below.
+	mut rt_scan := &RtHelpersScanArgs{
+		a:  a
+		tc: tc.fork_for_parallel_transform(a)
+	}
+	rt_scan_parallel := par_markused_seeds_enabled()
+	rt_scan.enabled = rt_scan_parallel
+	rt_scan_thread := spawn markused_rt_helpers_thread(mut rt_scan)
 	mut cur_module := ''
 	mut cur_file := ''
 	mut import_contexts := []map[string]string{cap: 256}
@@ -136,9 +167,11 @@ fn mark_used_with_test_files(a &flat.FlatAst, tc &types.TypeChecker, test_files 
 	mut fn_name_suffixes := map[string]bool{}
 	mut const_name_suffixes := map[string]bool{}
 	mut generic_type_bases := map[string]bool{}
-	for node in a.nodes {
-		if node.kind in [.struct_decl, .type_decl] && node.generic_params().len > 0 {
-			generic_type_bases[node.value] = true
+	if detect_generics {
+		for node in a.nodes {
+			if node.kind in [.struct_decl, .type_decl] && node.generic_params().len > 0 {
+				generic_type_bases[node.value] = true
+			}
 		}
 	}
 
@@ -401,14 +434,25 @@ fn mark_used_with_test_files(a &flat.FlatAst, tc &types.TypeChecker, test_files 
 		const_decls:             const_decls
 		const_suffixes:          const_name_suffixes
 		import_contexts:         import_contexts
-		selective_alias_targets: markused_selective_alias_targets(tc)
-		iface_param_gate:        markused_interface_param_gate(tc)
+		selective_alias_targets: if detect_generics {
+			markused_selective_alias_targets(tc)
+		} else {
+			map[string][]string{}
+		}
+		iface_param_gate:        if detect_generics {
+			markused_interface_param_gate(tc)
+		} else {
+			map[string]bool{}
+		}
 		generic_type_bases:      generic_type_bases
+		detect_generics:         detect_generics
 	}
 	// Precollect every body's call/initializer-ref lists up front (across
 	// threads when available): the BFS below then only does the cheap
 	// name-resolution work. Collecting inline used to serialize ~80% of
 	// markused's time inside the BFS loop.
+	eprintln('  [ttime] mu decl scan       ${f64(mu_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+	mu_sw.restart()
 	mut body_index := map[int]int{}
 	mut body_results := []BodyCalls{}
 	if body_ids.len >= min_eager_markused_bodies {
@@ -418,8 +462,19 @@ fn mark_used_with_test_files(a &flat.FlatAst, tc &types.TypeChecker, test_files 
 		body_results = precollect_body_calls(collector, body_ids, body_modules,
 			body_import_contexts)
 	}
+	eprintln('  [ttime] mu precollect      ${f64(mu_sw.elapsed().microseconds()) / 1000.0:7.2f} ms (bodies: ${body_ids.len})')
+	mu_sw.restart()
 	has_entry_main := markused_has_entry_main_indexed(a, tc)
-	enqueue_detected_runtime_helpers(a, tc, mut used, mut queue)
+	if rt_scan_parallel {
+		rt_scan_thread.wait()
+		for name in rt_scan.queue {
+			// Clone into the master arena: the scan scope is freed right below.
+			enqueue(name.clone(), mut used, mut queue)
+		}
+		markused_worker_scope_free(rt_scan.scope)
+	} else {
+		enqueue_detected_runtime_helpers(a, tc, mut used, mut queue)
+	}
 	enqueue_function_value_selectors(a, collector, fn_decls, has_entry_main, mut used, mut queue)
 	// Methods used as values (`recv.method` passed as a callback) are reachable only
 	// through a wrapper cgen generates later. The checker records them per enclosing
@@ -453,6 +508,8 @@ fn mark_used_with_test_files(a &flat.FlatAst, tc &types.TypeChecker, test_files 
 	// skipping a repeat performs no fewer markings.
 	mut safe_alias_done := map[string]bool{}
 	mut iface_tail_done := map[string]bool{}
+	eprintln('  [ttime] mu seeds           ${f64(mu_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+	mu_sw.restart()
 	mut qi := 0
 	for qi < queue.len {
 		name := queue[qi]
@@ -536,7 +593,8 @@ fn mark_used_with_test_files(a &flat.FlatAst, tc &types.TypeChecker, test_files 
 				if !valid_symbol_name(callee) {
 					continue
 				}
-				if collector.is_generic_index_overload_call(callee, fn_info.module) {
+				if collector.detect_generics
+					&& collector.is_generic_index_overload_call(callee, fn_info.module) {
 					enqueue(callee, mut used, mut queue)
 					lowered := markused_c_name(callee)
 					if lowered != callee {
@@ -639,7 +697,7 @@ fn mark_used_with_test_files(a &flat.FlatAst, tc &types.TypeChecker, test_files 
 			eprintln('  -> added ${new_added.str()} new entries, queue now ${queue.len.str()}')
 		}
 	}
-	if !uses_generics {
+	if collector.detect_generics && !uses_generics {
 		uses_generics = collector.emitted_type_declarations_use_generics()
 	}
 	if trace_markused {
@@ -655,6 +713,7 @@ fn mark_used_with_test_files(a &flat.FlatAst, tc &types.TypeChecker, test_files 
 		eprintln(suffix_hits.str())
 		eprintln('markused: total used: ${used.len}')
 	}
+	eprintln('  [ttime] mu bfs+tail        ${f64(mu_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 	return used, uses_generics
 }
 
@@ -1064,7 +1123,7 @@ fn enqueue_initializer_calls(a &flat.FlatAst, collector CallCollector, fn_decls 
 						continue
 					}
 					calls.clear()
-					if uses_generics {
+					if uses_generics || !collector.detect_generics {
 						collector.collect_calls(field, cur_module, imports, '', '', mut calls)
 					} else {
 						uses_generics = collector.collect_calls_with_generic_usage(field,
@@ -1226,7 +1285,7 @@ fn enqueue_top_level_calls(a &flat.FlatAst, collector CallCollector, fn_decls ma
 			calls.clear()
 			collector.collect_top_level_stmt_calls(child_id, module_name, file_imports, mut
 				local_values, mut local_types, mut calls)
-			if !uses_generics
+			if collector.detect_generics && !uses_generics
 				&& collector.node_tree_uses_generics(child_id, module_name, file_imports) {
 				uses_generics = true
 			}
@@ -1328,6 +1387,36 @@ fn markused_is_top_level_stmt(node flat.Node) bool {
 }
 
 // enqueue supports enqueue handling for markused.
+struct RtHelpersScanArgs {
+	a  &flat.FlatAst
+	tc &types.TypeChecker
+mut:
+	enabled bool
+	queue   []string
+	scope   voidptr
+}
+
+fn markused_rt_helpers_thread(mut args RtHelpersScanArgs) {
+	if !args.enabled {
+		return
+	}
+	// Everything the scan allocates lives in a detached scope: the spawn
+	// wrapper frees the thread's own arena at exit, so results must survive in
+	// a scope the master frees after replaying (see fixed_storage_scan_thread).
+	scope := markused_worker_scope_begin(true)
+	// A fresh local `used` makes enqueue_detected_runtime_helpers collect every
+	// name it would have enqueued (already-seeded names are skipped again when
+	// the master replays the queue through enqueue, which is idempotent).
+	mut used := map[string]bool{}
+	enqueue_detected_runtime_helpers(args.a, args.tc, mut used, mut args.queue)
+	args.scope = scope
+	markused_worker_scope_leave(scope)
+}
+
+fn par_markused_seeds_enabled() bool {
+	return os.getenv('V3_NO_PAR_MU_SEEDS') == ''
+}
+
 fn enqueue(name string, mut used map[string]bool, mut queue []string) bool {
 	if !valid_symbol_name(name) {
 		return false
@@ -1384,6 +1473,9 @@ struct CallCollector {
 	// Includes scoped local declarations, which are intentionally absent from
 	// the checker's top-level generic declaration maps.
 	generic_type_bases map[string]bool
+	// Self-host builds are known not to need monomorphization, so they can omit
+	// generic-only reachability probes while preserving ordinary call collection.
+	detect_generics bool
 }
 
 fn (c &CallCollector) imports(context int) map[string]string {
@@ -3676,13 +3768,13 @@ fn (c &CallCollector) collect_body(node &flat.Node, cur_module string, imports m
 	mut result := BodyCalls{
 		calls:         []string{cap: 32}
 		refs:          []string{cap: 8}
-		uses_generics: c.generic_fn_name_is_known(node.value, cur_module)
+		uses_generics: c.detect_generics && (c.generic_fn_name_is_known(node.value, cur_module)
 			|| c.type_text_uses_generics(node.value, cur_module, imports)
-			|| c.node_uses_generics(node, cur_module, imports)
+			|| c.node_uses_generics(node, cur_module, imports))
 	}
 	result.uses_generics = c.collect_calls_with_locals_and_generics(node, cur_module, imports,
-		receiver_name, receiver_struct, local_values, local_types, visible_local_idents, true,
-		result.uses_generics, mut result.calls)
+		receiver_name, receiver_struct, local_values, local_types, visible_local_idents,
+		c.detect_generics, result.uses_generics, mut result.calls)
 	c.collect_initializer_refs_with_locals(node, cur_module, imports, local_values,
 		visible_local_idents, mut result.refs)
 	return result
@@ -3712,6 +3804,7 @@ fn (c &CallCollector) fork_with_tc(wtc &types.TypeChecker) CallCollector {
 		selective_alias_targets: c.selective_alias_targets
 		iface_param_gate:        c.iface_param_gate
 		generic_type_bases:      c.generic_type_bases
+		detect_generics:         c.detect_generics
 	}
 }
 
@@ -3786,9 +3879,8 @@ fn (c &CallCollector) collect_calls_with_locals_and_generics(node &flat.Node, cu
 					// Enum fields are values even when a method has the same name.
 				} else if c.collect_interface_method_value_selector(child, mut calls) {
 					// handled
-				} else if c.collect_generic_method_value_selector(child, cur_module, imports, mut
-					calls)
-				{
+				} else if c.detect_generics
+					&& c.collect_generic_method_value_selector(child, cur_module, imports, mut calls) {
 					// handled
 				} else if resolved := c.tc.resolved_fn_value_name(child_id) {
 					calls << resolved
@@ -3810,8 +3902,10 @@ fn (c &CallCollector) collect_calls_with_locals_and_generics(node &flat.Node, cu
 					&& c.generic_fn_name_is_known(resolved_call, cur_module) {
 					uses_generics = true
 				}
-				c.collect_interface_boxed_generic_methods(child, resolved_call, cur_module,
-					imports, local_values, mut calls)
+				if c.detect_generics {
+					c.collect_interface_boxed_generic_methods(child, resolved_call, cur_module,
+						imports, local_values, mut calls)
+				}
 				c.collect_lowered_join_path_single(child, resolved_call, mut calls)
 				if child.children_count > 0 {
 					callee_id := c.a.child(child, 0)
@@ -3994,8 +4088,10 @@ fn (c &CallCollector) collect_calls_with_locals_and_generics(node &flat.Node, cu
 						}
 					}
 				}
-				c.collect_generic_alias_operator_usage(child, resolved_call, cur_module, imports,
-					local_values, local_types, mut calls)
+				if c.detect_generics {
+					c.collect_generic_alias_operator_usage(child, resolved_call, cur_module,
+						imports, local_values, local_types, mut calls)
+				}
 				c.collect_omitted_params_default_calls(child, resolved_call, cur_module, imports, mut
 					calls)
 			}
@@ -4875,8 +4971,10 @@ fn (c &CallCollector) collect_top_level_call(call_id flat.NodeId, call &flat.Nod
 	} else if resolved_call.len > 0 {
 		calls << resolved_call
 	}
-	c.collect_generic_alias_operator_usage(call, resolved_call, cur_module, imports, local_values,
-		local_types, mut calls)
+	if c.detect_generics {
+		c.collect_generic_alias_operator_usage(call, resolved_call, cur_module, imports,
+			local_values, local_types, mut calls)
+	}
 	for ci in 1 .. call.children_count {
 		arg_id := c.a.child(call, ci)
 		if int(arg_id) >= 0 {
@@ -5835,11 +5933,13 @@ fn (c &CallCollector) collect_index_overload_assignment_methods(node &flat.Node,
 			c.collect_index_overload_compound_helpers(receiver, node.op, cur_module, mut calls)
 		}
 	}
-	if receiver := c.generic_index_overload_receiver(base_type, cur_module) {
-		c.collect_index_overload_method(receiver, '[]=', cur_module, mut calls)
-		if node.op != .assign {
-			c.collect_index_overload_method(receiver, '[]', cur_module, mut calls)
-			c.collect_index_overload_compound_helpers(receiver, node.op, cur_module, mut calls)
+	if c.detect_generics {
+		if receiver := c.generic_index_overload_receiver(base_type, cur_module) {
+			c.collect_index_overload_method(receiver, '[]=', cur_module, mut calls)
+			if node.op != .assign {
+				c.collect_index_overload_method(receiver, '[]', cur_module, mut calls)
+				c.collect_index_overload_compound_helpers(receiver, node.op, cur_module, mut calls)
+			}
 		}
 	}
 }
@@ -5870,8 +5970,10 @@ fn (c &CallCollector) collect_index_overload_getter_method(node &flat.Node, cur_
 	for receiver in c.struct_operator_receivers_for_call(base_type, cur_module) {
 		c.collect_index_overload_method(receiver, '[]', cur_module, mut calls)
 	}
-	if receiver := c.generic_index_overload_receiver(base_type, cur_module) {
-		c.collect_index_overload_method(receiver, '[]', cur_module, mut calls)
+	if c.detect_generics {
+		if receiver := c.generic_index_overload_receiver(base_type, cur_module) {
+			c.collect_index_overload_method(receiver, '[]', cur_module, mut calls)
+		}
 	}
 }
 
@@ -5885,7 +5987,7 @@ fn (c &CallCollector) index_overload_method_name(receiver string, method string,
 	if method_name := c.typed_receiver_method_name(receiver, method, cur_module) {
 		return method_name
 	}
-	if c.receiver_is_generic_struct_application(receiver, cur_module) {
+	if c.detect_generics && c.receiver_is_generic_struct_application(receiver, cur_module) {
 		return '${receiver}.${method}'
 	}
 	return none

--- a/vlib/v3/markused/markused.v
+++ b/vlib/v3/markused/markused.v
@@ -451,8 +451,10 @@ fn mark_used_with_test_files(a &flat.FlatAst, tc &types.TypeChecker, test_files 
 	// threads when available): the BFS below then only does the cheap
 	// name-resolution work. Collecting inline used to serialize ~80% of
 	// markused's time inside the BFS loop.
-	eprintln('  [ttime] mu decl scan       ${f64(mu_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
-	mu_sw.restart()
+	if tc.verbose {
+		eprintln('  [ttime] mu decl scan       ${f64(mu_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+		mu_sw.restart()
+	}
 	mut body_index := map[int]int{}
 	mut body_results := []BodyCalls{}
 	if body_ids.len >= min_eager_markused_bodies {
@@ -462,8 +464,10 @@ fn mark_used_with_test_files(a &flat.FlatAst, tc &types.TypeChecker, test_files 
 		body_results = precollect_body_calls(collector, body_ids, body_modules,
 			body_import_contexts)
 	}
-	eprintln('  [ttime] mu precollect      ${f64(mu_sw.elapsed().microseconds()) / 1000.0:7.2f} ms (bodies: ${body_ids.len})')
-	mu_sw.restart()
+	if tc.verbose {
+		eprintln('  [ttime] mu precollect      ${f64(mu_sw.elapsed().microseconds()) / 1000.0:7.2f} ms (bodies: ${body_ids.len})')
+		mu_sw.restart()
+	}
 	has_entry_main := markused_has_entry_main_indexed(a, tc)
 	if rt_scan_parallel {
 		rt_scan_thread.wait()
@@ -508,8 +512,10 @@ fn mark_used_with_test_files(a &flat.FlatAst, tc &types.TypeChecker, test_files 
 	// skipping a repeat performs no fewer markings.
 	mut safe_alias_done := map[string]bool{}
 	mut iface_tail_done := map[string]bool{}
-	eprintln('  [ttime] mu seeds           ${f64(mu_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
-	mu_sw.restart()
+	if tc.verbose {
+		eprintln('  [ttime] mu seeds           ${f64(mu_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+		mu_sw.restart()
+	}
 	mut qi := 0
 	for qi < queue.len {
 		name := queue[qi]
@@ -713,7 +719,9 @@ fn mark_used_with_test_files(a &flat.FlatAst, tc &types.TypeChecker, test_files 
 		eprintln(suffix_hits.str())
 		eprintln('markused: total used: ${used.len}')
 	}
-	eprintln('  [ttime] mu bfs+tail        ${f64(mu_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+	if tc.verbose {
+		eprintln('  [ttime] mu bfs+tail        ${f64(mu_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+	}
 	return used, uses_generics
 }
 

--- a/vlib/v3/markused/markused_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/markused/markused_parallel_notd_v3_no_parallel.v
@@ -11,7 +11,7 @@ import runtime
 import v3.flat
 import v3.workers
 
-const max_markused_jobs = 8
+const max_markused_jobs = 10
 const min_markused_parallel_bodies = 512
 const scoped_markused_worker_batches = 16
 
@@ -47,6 +47,18 @@ $if !windows {
 				*results)
 		}
 		markused_worker_scope_leave(args.scope)
+		if args.scope != unsafe { nil } {
+			// Publish this worker's call lists into its persistent arena here,
+			// in parallel, instead of the former serial clone loop on the
+			// master; the freed scope is marked nil so the master skips it.
+			for result_idx in args.start .. args.end {
+				unsafe {
+					(*results)[result_idx] = clone_body_calls((*results)[result_idx])
+				}
+			}
+			markused_worker_scope_free(args.scope)
+			args.scope = unsafe { nil }
+		}
 		return unsafe { nil }
 	}
 }

--- a/vlib/v3/modulecache/file_metadata.c
+++ b/vlib/v3/modulecache/file_metadata.c
@@ -1,6 +1,3 @@
-#ifndef V3_MODULECACHE_FILE_METADATA_H
-#define V3_MODULECACHE_FILE_METADATA_H
-
 #include <stdint.h>
 
 #if defined(__APPLE__) || defined(__linux__)
@@ -43,6 +40,4 @@ static int v3_modulecache_file_metadata(const char *path, u64 *device, u64 *inod
 	(void)ctime_nanoseconds;
 	return 0;
 }
-#endif
-
 #endif

--- a/vlib/v3/modulecache/file_metadata.c.v
+++ b/vlib/v3/modulecache/file_metadata.c.v
@@ -1,6 +1,6 @@
 module modulecache
 
-#include "@VEXEROOT/vlib/v3/modulecache/file_metadata.h"
+#include "@VEXEROOT/vlib/v3/modulecache/file_metadata.c"
 
 fn C.v3_modulecache_file_metadata(&char, &u64, &u64, &u64, &u64, &u64, &u64, &u64) int
 

--- a/vlib/v3/modulecache/file_metadata_test.v
+++ b/vlib/v3/modulecache/file_metadata_test.v
@@ -3,7 +3,7 @@ module modulecache
 import os
 
 fn test_file_metadata_helper_uses_generated_u64_abi() {
-	header_path := os.join_path(@VEXEROOT, 'vlib', 'v3', 'modulecache', 'file_metadata.h')
+	header_path := os.join_path(@VEXEROOT, 'vlib', 'v3', 'modulecache', 'file_metadata.c')
 	header := os.read_file(header_path) or { panic(err) }
 	signature := 'static int v3_modulecache_file_metadata(const char *path, u64 *device, u64 *inode,
 	u64 *size, u64 *mtime_seconds, u64 *mtime_nanoseconds,

--- a/vlib/v3/modulecache/modulecache.v
+++ b/vlib/v3/modulecache/modulecache.v
@@ -318,13 +318,46 @@ fn source_uses_pseudo(source string, names []string) bool {
 			continue
 		}
 		if source[pos] in [`'`, `"`, `\``] {
-			pos = skip_signature_quoted_text(source, pos, false)
+			// Quoted text can itself carry compile-time paths
+			// ($embed_file('@VMODROOT/data'), #include "@VMODROOT/header.h"),
+			// so literals are scanned rather than skipped: missing a real
+			// pseudo would reuse an artifact resolved against the wrong root,
+			// while a stray mention in an inert string only widens
+			// invalidation.
+			end := skip_signature_quoted_text(source, pos, false)
+			if quoted_text_mentions_pseudo(source, pos + 1, end, names) {
+				return true
+			}
+			pos = end
 			continue
 		}
 		if source[pos] == `r` && pos + 1 < source.len && source[pos + 1] in [`'`, `"`] {
-			pos = skip_signature_quoted_text(source, pos + 1, true)
+			end := skip_signature_quoted_text(source, pos + 1, true)
+			if quoted_text_mentions_pseudo(source, pos + 2, end, names) {
+				return true
+			}
+			pos = end
 			continue
 		}
+		if source[pos] != `@` {
+			pos++
+			continue
+		}
+		for name in names {
+			end := pos + name.len
+			if end <= source.len && source[pos..end] == name
+				&& (end == source.len || !signature_name_char(source[end])) {
+				return true
+			}
+		}
+		pos++
+	}
+	return false
+}
+
+fn quoted_text_mentions_pseudo(source string, from int, to int, names []string) bool {
+	mut pos := from
+	for pos < to {
 		if source[pos] != `@` {
 			pos++
 			continue

--- a/vlib/v3/modulecache/modulecache.v
+++ b/vlib/v3/modulecache/modulecache.v
@@ -317,7 +317,15 @@ fn source_uses_pseudo(source string, names []string) bool {
 			pos = skip_signature_space_and_comments(source, pos)
 			continue
 		}
-		if source[pos] in [`'`, `"`, `\``] {
+		if source[pos] in [`'`, `"`] {
+			found, next_pos := signature_quoted_interpolation_mentions_pseudo(source, pos, names)
+			if found {
+				return true
+			}
+			pos = next_pos
+			continue
+		}
+		if source[pos] == `\`` {
 			pos = skip_signature_quoted_text(source, pos, false)
 			continue
 		}
@@ -370,6 +378,63 @@ fn source_uses_pseudo(source string, names []string) bool {
 		pos++
 	}
 	return false
+}
+
+fn signature_quoted_interpolation_mentions_pseudo(source string, quote_pos int, names []string) (bool, int) {
+	quote := source[quote_pos]
+	mut pos := quote_pos + 1
+	for pos < source.len {
+		if source[pos] == `\\` && pos + 1 < source.len {
+			pos += 2
+			continue
+		}
+		if source[pos] == quote {
+			return false, pos + 1
+		}
+		if source[pos] != `$` || pos + 1 >= source.len || source[pos + 1] != `{` {
+			pos++
+			continue
+		}
+		expr_end, ok := signature_interpolation_expr_end(source, pos + 2)
+		if !ok {
+			return false, source.len
+		}
+		if source_uses_pseudo(source[pos + 2..expr_end], names) {
+			return true, expr_end + 1
+		}
+		pos = expr_end + 1
+	}
+	return false, source.len
+}
+
+fn signature_interpolation_expr_end(source string, start int) (int, bool) {
+	mut pos := start
+	mut depth := 1
+	for pos < source.len {
+		if source[pos] == `/` && pos + 1 < source.len
+			&& (source[pos + 1] == `/` || source[pos + 1] == `*`) {
+			pos = skip_signature_space_and_comments(source, pos)
+			continue
+		}
+		if source[pos] == `r` && pos + 1 < source.len && source[pos + 1] in [`'`, `"`] {
+			pos = skip_signature_quoted_text(source, pos + 1, true)
+			continue
+		}
+		if source[pos] in [`'`, `"`, `\``] {
+			pos = skip_signature_quoted_text(source, pos, false)
+			continue
+		}
+		if source[pos] == `{` {
+			depth++
+		} else if source[pos] == `}` {
+			depth--
+			if depth == 0 {
+				return pos, true
+			}
+		}
+		pos++
+	}
+	return source.len, false
 }
 
 fn signature_directive_mentions_pseudo(source string, start int, names []string) (bool, int) {

--- a/vlib/v3/modulecache/modulecache.v
+++ b/vlib/v3/modulecache/modulecache.v
@@ -240,12 +240,10 @@ fn source_signature_details(source_files []string, build_pseudo_values string) S
 		hash = hash_bytes(hash, content)
 		hash = hash_bytes(hash, [u8(0xff)])
 		source := content.bytestr()
-		if source.contains('@BUILD_TIMESTAMP') || source.contains('@BUILD_DATE')
-			|| source.contains('@BUILD_TIME') {
+		if source_uses_pseudo(source, ['@BUILD_TIMESTAMP', '@BUILD_DATE', '@BUILD_TIME']) {
 			uses_build_pseudo = true
 		}
-		if source.contains('@VMODROOT') || source.contains('@VMOD_FILE')
-			|| source.contains('@VROOT') {
+		if source_uses_pseudo(source, ['@VMODROOT', '@VMOD_FILE', '@VROOT']) {
 			root, vmod_file := signature_vmod_root(file)
 			vmod_metadata := if vmod_file.len > 0 {
 				file_metadata_signature(vmod_file)
@@ -306,6 +304,41 @@ fn source_signature_details(source_files []string, build_pseudo_values string) S
 		signature:  hash.hex()
 		validation: validation
 	}
+}
+
+fn source_uses_pseudo(source string, names []string) bool {
+	if !source.contains('@') {
+		return false
+	}
+	mut pos := 0
+	for pos < source.len {
+		if source[pos] == `/` && pos + 1 < source.len
+			&& (source[pos + 1] == `/` || source[pos + 1] == `*`) {
+			pos = skip_signature_space_and_comments(source, pos)
+			continue
+		}
+		if source[pos] in [`'`, `"`, `\``] {
+			pos = skip_signature_quoted_text(source, pos, false)
+			continue
+		}
+		if source[pos] == `r` && pos + 1 < source.len && source[pos + 1] in [`'`, `"`] {
+			pos = skip_signature_quoted_text(source, pos + 1, true)
+			continue
+		}
+		if source[pos] != `@` {
+			pos++
+			continue
+		}
+		for name in names {
+			end := pos + name.len
+			if end <= source.len && source[pos..end] == name
+				&& (end == source.len || !signature_name_char(source[end])) {
+				return true
+			}
+		}
+		pos++
+	}
+	return false
 }
 
 fn (m &Manager) source_signature(source_files []string) string {
@@ -663,19 +696,36 @@ pub fn (m &Manager) valid_entry_with_metadata_cache(module_name string, source_f
 	}
 	entry := m.entry(module_name, source_files)
 	if !os.is_file(entry.header) {
+		cache_trace_module_miss(module_name, 'header is missing')
 		return none
 	}
-	stamp := os.read_file(entry.header_stamp) or { return none }
+	stamp := os.read_file(entry.header_stamp) or {
+		cache_trace_module_miss(module_name, 'header stamp is missing')
+		return none
+	}
 	expected := entry_stamp(m.salt, m.source_signature(source_files))
-	source_bodies := header_stamp_source_bodies(stamp, expected) or { return none }
-	object_stamp := os.read_file(entry.object_stamp) or { return none }
+	source_bodies := header_stamp_source_bodies(stamp, expected) or {
+		cache_trace_module_miss(module_name, 'source signature changed')
+		return none
+	}
+	object_stamp := os.read_file(entry.object_stamp) or {
+		cache_trace_module_miss(module_name, 'object stamp is missing')
+		return none
+	}
 	if !object_stamp_valid_with_metadata_cache(object_stamp, expected, mut dependency_metadata) {
+		cache_trace_module_miss(module_name, 'object dependency changed')
 		return none
 	}
 	return Entry{
 		...entry
 		source_bodies:       source_bodies
 		source_bodies_known: true
+	}
+}
+
+fn cache_trace_module_miss(module_name string, reason string) {
+	if os.getenv('V3_CACHE_TRACE') != '' {
+		eprintln('  V3 module cache miss: module=${module_name} reason=${reason}')
 	}
 }
 
@@ -1123,6 +1173,9 @@ fn object_stamp_valid_with_metadata_cache(stamp string, expected_entry string, m
 			signature
 		}
 		if current_signature != dependency.signature {
+			if os.getenv('V3_CACHE_TRACE') != '' {
+				eprintln('  V3 module cache dependency miss: path=${dependency.path}')
+			}
 			return false
 		}
 	}
@@ -1291,8 +1344,7 @@ pub fn declaration_header(prefix string) string {
 		mut next_pos := prefix.len
 		mut selected := -1
 		for i, section in sections {
-			if relative := prefix[pos..].index(section.begin) {
-				absolute := pos + relative
+			if absolute := c_standalone_marker_index_after(prefix, section.begin, pos) {
 				if absolute < next_pos {
 					next_pos = absolute
 					selected = i
@@ -1310,18 +1362,31 @@ pub fn declaration_header(prefix string) string {
 		}
 		section := sections[selected]
 		body_start := next_pos + section.begin.len
-		relative_end := prefix[body_start..].index(section.end) or {
+		body_end := c_standalone_marker_index_after(prefix, section.end, body_start) or {
 			header, _, _ := c_declaration_header(prefix[next_pos..])
 			out.write_string(header)
 			break
 		}
-		body_end := body_start + relative_end
 		if section.keep {
 			out.write_string(c_native_declaration_directives(prefix[body_start..body_end]))
 		}
 		pos = body_end + section.end.len
 	}
 	return out.str()
+}
+
+fn c_standalone_marker_index_after(source string, marker string, start int) ?int {
+	mut pos := start
+	for pos < source.len {
+		idx := source.index_after(marker, pos) or { return none }
+		end := idx + marker.len
+		if (idx == 0 || source[idx - 1] == `\n`)
+			&& (end == source.len || source[end] in [`\n`, `\r`]) {
+			return idx
+		}
+		pos = end
+	}
+	return none
 }
 
 fn cached_c_string_symbol(value string) string {

--- a/vlib/v3/modulecache/modulecache.v
+++ b/vlib/v3/modulecache/modulecache.v
@@ -318,26 +318,43 @@ fn source_uses_pseudo(source string, names []string) bool {
 			continue
 		}
 		if source[pos] in [`'`, `"`, `\``] {
-			// Quoted text can itself carry compile-time paths
-			// ($embed_file('@VMODROOT/data'), #include "@VMODROOT/header.h"),
-			// so literals are scanned rather than skipped: missing a real
-			// pseudo would reuse an artifact resolved against the wrong root,
-			// while a stray mention in an inert string only widens
-			// invalidation.
-			end := skip_signature_quoted_text(source, pos, false)
-			if quoted_text_mentions_pseudo(source, pos + 1, end, names) {
-				return true
-			}
-			pos = end
+			pos = skip_signature_quoted_text(source, pos, false)
 			continue
 		}
 		if source[pos] == `r` && pos + 1 < source.len && source[pos + 1] in [`'`, `"`] {
-			end := skip_signature_quoted_text(source, pos + 1, true)
-			if quoted_text_mentions_pseudo(source, pos + 2, end, names) {
+			pos = skip_signature_quoted_text(source, pos + 1, true)
+			continue
+		}
+		if source[pos] == `#` {
+			found, next_pos := signature_directive_mentions_pseudo(source, pos, names)
+			if found {
 				return true
 			}
-			pos = end
+			pos = next_pos
 			continue
+		}
+		if source[pos] == `$` {
+			mut matched_path_call := false
+			for fn_name in ['embed_file', 'tmpl', 'res'] {
+				name_start := pos + 1
+				name_end := name_start + fn_name.len
+				if name_end > source.len || source[name_start..name_end] != fn_name
+					|| (name_end < source.len && signature_name_char(source[name_end])) {
+					continue
+				}
+				value, next_pos, ok := signature_string_call_arg(source, name_end)
+				if ok {
+					if quoted_text_mentions_pseudo(value, 0, value.len, names) {
+						return true
+					}
+					pos = next_pos
+					matched_path_call = true
+				}
+				break
+			}
+			if matched_path_call {
+				continue
+			}
 		}
 		if source[pos] != `@` {
 			pos++
@@ -353,6 +370,69 @@ fn source_uses_pseudo(source string, names []string) bool {
 		pos++
 	}
 	return false
+}
+
+fn signature_directive_mentions_pseudo(source string, start int, names []string) (bool, int) {
+	mut pos := start
+	for pos < source.len && source[pos] in [`#`, ` `, `\t`] {
+		pos++
+	}
+	name_start := pos
+	for pos < source.len && signature_name_char(source[pos]) {
+		pos++
+	}
+	directive := source[name_start..pos]
+	scan_quoted := directive in ['include', 'insert', 'flag']
+	for pos < source.len && source[pos] != `\n` {
+		if pos + 1 < source.len && source[pos] == `/` && source[pos + 1] == `/` {
+			for pos < source.len && source[pos] != `\n` {
+				pos++
+			}
+			return false, pos
+		}
+		if pos + 1 < source.len && source[pos] == `/` && source[pos + 1] == `*` {
+			pos += 2
+			mut crossed_line := false
+			for pos + 1 < source.len && !(source[pos] == `*` && source[pos + 1] == `/`) {
+				if source[pos] == `\n` {
+					crossed_line = true
+				}
+				pos++
+			}
+			pos = if pos + 1 < source.len { pos + 2 } else { source.len }
+			if crossed_line {
+				return false, pos
+			}
+			continue
+		}
+		if source[pos] in [`'`, `"`, `\``] {
+			end := skip_signature_quoted_text(source, pos, false)
+			if scan_quoted && quoted_text_mentions_pseudo(source, pos + 1, end, names) {
+				return true, end
+			}
+			pos = end
+			continue
+		}
+		if source[pos] == `r` && pos + 1 < source.len && source[pos + 1] in [`'`, `"`] {
+			end := skip_signature_quoted_text(source, pos + 1, true)
+			if scan_quoted && quoted_text_mentions_pseudo(source, pos + 2, end, names) {
+				return true, end
+			}
+			pos = end
+			continue
+		}
+		if source[pos] == `@` {
+			for name in names {
+				end := pos + name.len
+				if end <= source.len && source[pos..end] == name
+					&& (end == source.len || !signature_name_char(source[end])) {
+					return true, pos
+				}
+			}
+		}
+		pos++
+	}
+	return false, pos
 }
 
 fn quoted_text_mentions_pseudo(source string, from int, to int, names []string) bool {

--- a/vlib/v3/modulecache/modulecache_test.v
+++ b/vlib/v3/modulecache/modulecache_test.v
@@ -43,4 +43,16 @@ fn test_source_uses_pseudo_in_quoted_compile_time_paths() {
 	build := ['@BUILD_TIMESTAMP', '@BUILD_DATE', '@BUILD_TIME']
 	assert !source_uses_pseudo("module m\n\npub const marker = '@BUILD_DATE'", build)
 	assert source_uses_pseudo('module m\n\npub const marker = @BUILD_DATE', build)
+	assert source_uses_pseudo(r"module m\n\npub const stamp = 'built ${@BUILD_TIMESTAMP}'", build)
+	assert !source_uses_pseudo(r"module m\n\npub const stamp = 'literal @BUILD_TIMESTAMP ${1}'",
+		build)
+	assert !source_uses_pseudo(r"module m\n\npub const stamp = 'built \${@BUILD_TIMESTAMP}'", build)
+	assert !source_uses_pseudo(r"module m\n\npub const stamp = r'built ${@BUILD_TIMESTAMP}'", build)
+	assert !source_uses_pseudo(r"module m\n\npub const stamp = 'built ${/* @BUILD_TIMESTAMP */ 1}'",
+		build)
+	assert !source_uses_pseudo(r"module m\n\npub const stamp = 'built ${'@BUILD_TIMESTAMP'}'",
+		build)
+	assert source_uses_pseudo(r"module m\n\npub const stamp = 'built ${if ok { @BUILD_TIMESTAMP } else { 0 }}'",
+		build)
+	assert source_uses_pseudo(r"module m\n\npub const root = 'root ${@VMODROOT}'", roots)
 }

--- a/vlib/v3/modulecache/modulecache_test.v
+++ b/vlib/v3/modulecache/modulecache_test.v
@@ -20,3 +20,19 @@ fn test_source_signature_cache_content_requires_stable_metadata() {
 	assert content.contains('source=content-signature\n')
 	assert content.ends_with('complete=1\n')
 }
+
+fn test_source_uses_pseudo_in_quoted_compile_time_paths() {
+	roots := ['@VMODROOT', '@VMOD_FILE', '@VROOT']
+	assert source_uses_pseudo("module m\n\nconst data = \$embed_file('@VMODROOT/data.bin')",
+		roots)
+	assert source_uses_pseudo('module m\n\n#include "@VMODROOT/header.h"', roots)
+	assert source_uses_pseudo('module m\n\nconst p = r"@VROOT/x"', roots)
+	// a pseudo after a string containing `//` must still be seen
+	assert source_uses_pseudo("module m\n\nconst u = 'http://x' + \$embed_file('@VMODROOT/y')",
+		roots)
+	// comments stay inert
+	assert !source_uses_pseudo('module m\n\n// mentions @VMODROOT only in a comment', roots)
+	assert !source_uses_pseudo("module m\n\nconst s = 'plain text'", roots)
+	// name-boundary check still applies inside literals
+	assert !source_uses_pseudo("module m\n\nconst s = '@VROOTX/not-a-pseudo'", roots)
+}

--- a/vlib/v3/modulecache/modulecache_test.v
+++ b/vlib/v3/modulecache/modulecache_test.v
@@ -23,16 +23,24 @@ fn test_source_signature_cache_content_requires_stable_metadata() {
 
 fn test_source_uses_pseudo_in_quoted_compile_time_paths() {
 	roots := ['@VMODROOT', '@VMOD_FILE', '@VROOT']
-	assert source_uses_pseudo("module m\n\nconst data = \$embed_file('@VMODROOT/data.bin')",
-		roots)
+	assert source_uses_pseudo("module m\n\nconst data = \$embed_file('@VMODROOT/data.bin')", roots)
 	assert source_uses_pseudo('module m\n\n#include "@VMODROOT/header.h"', roots)
-	assert source_uses_pseudo('module m\n\nconst p = r"@VROOT/x"', roots)
+	assert source_uses_pseudo('module m\n\n#flag -I "@VMODROOT/include"', roots)
+	assert source_uses_pseudo('module m\n\nconst p = \$embed_file(r"@VROOT/x")', roots)
 	// a pseudo after a string containing `//` must still be seen
 	assert source_uses_pseudo("module m\n\nconst u = 'http://x' + \$embed_file('@VMODROOT/y')",
 		roots)
 	// comments stay inert
 	assert !source_uses_pseudo('module m\n\n// mentions @VMODROOT only in a comment', roots)
 	assert !source_uses_pseudo("module m\n\nconst s = 'plain text'", roots)
+	assert !source_uses_pseudo("module m\n\nconst s = '@VMODROOT/inert'", roots)
+	assert !source_uses_pseudo('module m\n\nconst s = r"@VROOT/inert"', roots)
+	assert !source_uses_pseudo('module m\n\n#define MARKER "@VMODROOT/inert"', roots)
+	assert !source_uses_pseudo("module m\n\n#define X /*\n@VMODROOT\n*/\nconst s = 'inert'", roots)
 	// name-boundary check still applies inside literals
-	assert !source_uses_pseudo("module m\n\nconst s = '@VROOTX/not-a-pseudo'", roots)
+	assert !source_uses_pseudo("module m\n\nconst s = \$embed_file('@VROOTX/not-a-pseudo')", roots)
+
+	build := ['@BUILD_TIMESTAMP', '@BUILD_DATE', '@BUILD_TIME']
+	assert !source_uses_pseudo("module m\n\npub const marker = '@BUILD_DATE'", build)
+	assert source_uses_pseudo('module m\n\npub const marker = @BUILD_DATE', build)
 }

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -260,12 +260,16 @@ pub fn (mut p Parser) parse_into(path string) {
 	p.anonymous_struct_count = 0
 	p.sql_query_data_aliases.clear()
 	// File marker before content so import resolver can track source files
-	p.add_node(flat.Node{
+	marker_id := p.add_node(flat.Node{
 		kind:  .file
 		value: path
 	})
+	p.a.file_node_ids << int(marker_id)
 	src := read_source_file_raw(path) or {
 		p.record_diagnostic('error reading source: ${err.msg()}', 0)
+		// The trailing .file node is never added: the (marker, trailing)
+		// pairing in file_node_ids is broken for this AST.
+		p.a.file_index_incomplete = true
 		return
 	}
 	// Scanner token strings are zero-copy views into the source. The AST owns
@@ -320,12 +324,13 @@ pub fn (mut p Parser) parse_into(path string) {
 		}
 	}
 	start := p.add_children(ids)
-	p.add_node(flat.Node{
+	trailing_id := p.add_node(flat.Node{
 		kind:           .file
 		value:          path
 		children_start: start
 		children_count: flat.child_count(ids.len)
 	})
+	p.a.file_node_ids << int(trailing_id)
 	p.collect_scanner_diagnostics()
 }
 

--- a/vlib/v3/parser/parser_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/parser/parser_parallel_notd_v3_no_parallel.v
@@ -2,6 +2,7 @@ module parser
 
 import os
 import runtime
+import time
 import v3.flat
 import v3.scanner
 import v3.token
@@ -18,7 +19,8 @@ import v3.workers
 
 const min_parallel_parse_files = 4
 const min_parallel_parse_bytes = 131072
-const max_parallel_parse_jobs = 8
+const max_parallel_parse_jobs = 10
+const max_parallel_parse_chunks = 32
 const comptime_const_prepass_alias_prefix = '\x00v3-comptime-alias:'
 
 struct ComptimeConstPrepassToken {
@@ -131,6 +133,7 @@ pub fn (mut p Parser) parse_files_dispatch(paths []string, allow_parallel bool) 
 		if !allow_parallel || paths.len < min_parallel_parse_files {
 			return p.parse_files_with_starts(paths), false
 		}
+		pdsw := time.new_stopwatch()
 		mut sizes := []i64{cap: paths.len}
 		mut total_bytes := i64(0)
 		for path in paths {
@@ -145,12 +148,24 @@ pub fn (mut p Parser) parse_files_dispatch(paths []string, allow_parallel bool) 
 		if n_jobs <= 1 || total_bytes < min_parallel_parse_bytes {
 			return p.parse_files_with_starts(paths), false
 		}
-		bounds := parse_chunk_bounds(sizes, n_jobs)
-		thread_count := n_jobs - 1
+		// More chunks than workers: the pool queue packs them dynamically, so
+		// one oversized source file no longer pins a whole equal-share chunk.
+		mut n_chunks := n_jobs * 2
+		if n_chunks > max_parallel_parse_chunks {
+			n_chunks = max_parallel_parse_chunks
+		}
+		if n_chunks > paths.len {
+			n_chunks = paths.len
+		}
+		if n_chunks < n_jobs {
+			n_chunks = n_jobs
+		}
+		bounds := parse_chunk_bounds(sizes, n_chunks)
+		thread_count := n_chunks - 1
 		dispatch_file_id_start := p.next_file_id
 		mut starts := []int{len: paths.len}
-		mut prepass_chunks := []&ComptimeConstPrepassChunk{cap: n_jobs}
-		for _ in 0 .. n_jobs {
+		mut prepass_chunks := []&ComptimeConstPrepassChunk{cap: n_chunks}
+		for _ in 0 .. n_chunks {
 			prepass_chunks << &ComptimeConstPrepassChunk{}
 		}
 		// Worker parsers are cheap to build (no AST clone: parse output is
@@ -168,7 +183,11 @@ pub fn (mut p Parser) parse_files_dispatch(paths []string, allow_parallel bool) 
 			worker_chunk_bytes[ci] = int(chunk_bytes)
 			parser_workers << w
 		}
-		mut args := []ParseChunkArgs{cap: n_jobs}
+		mut master_chunk_bytes := i64(0)
+		for i in bounds[0] .. bounds[1] {
+			master_chunk_bytes += sizes[i]
+		}
+		mut args := []ParseChunkArgs{cap: n_chunks}
 		args << ParseChunkArgs{
 			worker:        voidptr(p)
 			paths_ptr:     unsafe { voidptr(&paths) }
@@ -176,7 +195,7 @@ pub fn (mut p Parser) parse_files_dispatch(paths []string, allow_parallel bool) 
 			prepass_chunk: voidptr(prepass_chunks[0])
 			start:         bounds[0]
 			end:           bounds[1]
-			chunk_bytes:   0
+			chunk_bytes:   int(master_chunk_bytes)
 			scope_enabled: false
 		}
 		for ci in 0 .. thread_count {
@@ -196,8 +215,8 @@ pub fn (mut p Parser) parse_files_dispatch(paths []string, allow_parallel bool) 
 		// chunk is scanned, replay the declarations in input order to make a
 		// prefix snapshot for each worker: later chunks inherit earlier consts,
 		// while no chunk can see declarations from its own or a later range.
-		mut prepass_tasks := []workers.Task{cap: n_jobs}
-		for ci in 0 .. n_jobs {
+		mut prepass_tasks := []workers.Task{cap: n_chunks}
+		for ci in 0 .. n_chunks {
 			helper_idx := ci - 1
 			prepass_tasks << workers.Task{
 				run:        precollect_const_chunk_thread
@@ -205,8 +224,10 @@ pub fn (mut p Parser) parse_files_dispatch(paths []string, allow_parallel bool) 
 				force_sync: ci == 0 || fail == 'parser:all' || fail == 'parser:${helper_idx}'
 			}
 		}
+		ppsw := time.new_stopwatch()
 		p.a.worker_pool.run(prepass_tasks)
-		for ci in 1 .. n_jobs {
+		eprintln('  [ttime]   pp prepass pool  ${f64(ppsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+		for ci in 1 .. n_chunks {
 			if args[ci].scope != unsafe { nil } {
 				prepass_chunks[ci].decls =
 					clone_comptime_const_prepass_decls(prepass_chunks[ci].decls)
@@ -215,30 +236,53 @@ pub fn (mut p Parser) parse_files_dispatch(paths []string, allow_parallel bool) 
 			}
 		}
 		mut prefix_values := p.comptime_const_values.clone()
-		for chunk_idx in 0 .. n_jobs {
+		for chunk_idx in 0 .. n_chunks {
 			if chunk_idx > 0 {
 				parser_workers[chunk_idx - 1].comptime_const_values = prefix_values.clone()
 			}
 			apply_parallel_comptime_const_decls(mut prefix_values, prepass_chunks[chunk_idx].decls)
 		}
-		mut tasks := []workers.Task{cap: n_jobs}
-		for ci in 0 .. n_jobs {
+		// Largest chunks first: the queue is drained in submission order, so
+		// front-loading the heavy chunks minimizes the tail.
+		mut order := []int{cap: thread_count}
+		for ci in 1 .. n_chunks {
+			order << ci
+		}
+		order.sort_with_compare(fn [worker_chunk_bytes] (a &int, b &int) int {
+			return worker_chunk_bytes[*b - 1] - worker_chunk_bytes[*a - 1]
+		})
+		mut tasks := []workers.Task{cap: n_chunks}
+		for ci in order {
 			helper_idx := ci - 1
 			tasks << workers.Task{
 				run:        parse_chunk_thread
 				arg:        unsafe { voidptr(&args[ci]) }
-				force_sync: ci == 0 || fail == 'parser:all' || fail == 'parser:${helper_idx}'
+				force_sync: fail == 'parser:all' || fail == 'parser:${helper_idx}'
 			}
 		}
+		tasks << workers.Task{
+			run:        parse_chunk_thread
+			arg:        unsafe { voidptr(&args[0]) }
+			force_sync: true
+		}
+		ppsw2 := time.new_stopwatch()
 		any_started := p.a.worker_pool.run(tasks)
+		eprintln('  [ttime]   pp parse pool    ${f64(ppsw2.elapsed().microseconds()) / 1000.0:7.2f} ms')
 		// Merge each helper in fixed chunk order (input file order),
 		// so node numbering stays deterministic and byte-identical to serial.
-		for ci in 0 .. thread_count {
-			p.merge_parsed_worker(mut parser_workers[ci], mut starts, bounds[ci + 1],
-				bounds[ci + 2], args[ci + 1].scope)
-			parser_worker_scope_free(args[ci + 1].scope)
+		ppsw3 := time.new_stopwatch()
+		if par_parse_merge_enabled() {
+			p.merge_parsed_workers_parallel(mut parser_workers, mut starts, bounds, mut args)
+		} else {
+			for ci in 0 .. thread_count {
+				p.merge_parsed_worker(mut parser_workers[ci], mut starts, bounds[ci + 1], bounds[
+					ci + 2], args[ci + 1].scope)
+				parser_worker_scope_free(args[ci + 1].scope)
+			}
 		}
+		eprintln('  [ttime]   pp merge         ${f64(ppsw3.elapsed().microseconds()) / 1000.0:7.2f} ms')
 		p.next_file_id = dispatch_file_id_start + paths.len
+		eprintln('  [ttime]   pp dispatch      ${f64(pdsw.elapsed().microseconds()) / 1000.0:7.2f} ms (files: ${paths.len})')
 		return starts, any_started
 	}
 }
@@ -807,6 +851,166 @@ fn apply_parallel_comptime_const_decls(mut values map[string]string, decls []Com
 // from an empty FlatAst), so every node-id reference moves by the master's
 // node count and every children_start by the master's children count at merge
 // time. Negative child slots (flat.empty_node sentinels) are left untouched.
+struct PendingSourceFile {
+	file_id int
+	file    &token.File
+}
+
+struct ParseMergeCopyArgs {
+	master       voidptr
+	worker       voidptr
+	node_offset  int
+	child_offset int
+	has_scope    bool
+mut:
+	miss_nodes    []int
+	pending_files []PendingSourceFile
+}
+
+// parse_merge_copy_thread copies one worker's nodes/children into the master
+// arrays at precomputed offsets, applying the same id relocations as the
+// serial merge. Chunks write disjoint master ranges, so the copies run
+// concurrently; string payloads stay in the worker scopes until the serial
+// intern pass rebinds them.
+fn parse_merge_copy_thread(arg voidptr) voidptr {
+	mut ma := unsafe { &ParseMergeCopyArgs(arg) }
+	mut p := unsafe { &Parser(ma.master) }
+	mut w := unsafe { &Parser(ma.worker) }
+	node_shift := ma.node_offset
+	child_shift := i32(ma.child_offset)
+	for k in 0 .. w.a.children.len {
+		cid := w.a.children[k]
+		p.a.children[ma.child_offset + k] = if int(cid) >= 0 {
+			flat.NodeId(int(cid) + node_shift)
+		} else {
+			cid
+		}
+	}
+	mut cache_ptrs := unsafe { []voidptr{len: 4096} }
+	mut cache_vals := []string{len: 4096}
+	for k in 0 .. w.a.nodes.len {
+		mut node := w.a.nodes[k]
+		if node.children_count != 0 {
+			node.children_start += child_shift
+		}
+		// Declaration attributes are linked by an internal directive whose value
+		// embeds the worker-local declaration id; relocate it like a child id.
+		if node.kind == .directive && node.value.starts_with('@attributes:') {
+			local_id := node.value['@attributes:'.len..].int()
+			node.value = '@attributes:${local_id + node_shift}'
+		}
+		// Probe-intern against the (currently frozen) master text table: hits
+		// are rebound here; missing texts go to the ordered serial tail so the
+		// canonical table's insertion order matches the serial merge.
+		mut all_hit := true
+		node.value, all_hit = p.a.probe_text_ptr_cached(node.value, mut cache_ptrs, mut cache_vals)
+		mut hit := true
+		node.typ, hit = p.a.probe_text_ptr_cached(node.typ, mut cache_ptrs, mut cache_vals)
+		all_hit = all_hit && hit
+		params := node.generic_params()
+		if params.len > 0 {
+			mut canonical_params := []string{cap: params.len}
+			mut params_hit := true
+			for item in params {
+				canonical, item_hit := p.a.probe_text_ptr_cached(item, mut cache_ptrs, mut
+					cache_vals)
+				canonical_params << canonical
+				params_hit = params_hit && item_hit
+			}
+			if params_hit {
+				// The rebuilt array persists: pool-thread arenas outlive the merge.
+				node.set_generic_params(canonical_params)
+			} else {
+				all_hit = false
+			}
+		}
+		if !all_hit {
+			ma.miss_nodes << node_shift + k
+		}
+		p.a.nodes[node_shift + k] = node
+	}
+	unsafe {
+		// Ownership of the copied elements moved to the master.
+		w.a.children.len = 0
+		w.a.nodes.len = 0
+	}
+	if ma.has_scope {
+		// Pre-index diagnostic line tables from the worker source buffers while
+		// they are still alive; the serial tail only inserts the results.
+		mut file_ids := w.a.source_files.keys()
+		file_ids.sort()
+		for source_idx, file_id in file_ids {
+			file := w.a.source_files[file_id] or { continue }
+			if source_idx >= w.a.source_buffers.len {
+				continue
+			}
+			source := w.a.source_buffers[source_idx]
+			mut file_set := token.FileSet.new()
+			mut stored_file := file_set.add_file(file.name.clone(), file.size)
+			stored_file.index_lines(source)
+			ma.pending_files << PendingSourceFile{
+				file_id: file_id
+				file:    stored_file
+			}
+		}
+	}
+	return unsafe { nil }
+}
+
+fn par_parse_merge_enabled() bool {
+	return os.getenv('V3_NO_PAR_PARSE_MERGE') == ''
+}
+
+// merge_parsed_workers_parallel is the pooled equivalent of the ordered
+// merge_parsed_worker loop: the node/children copies land in precomputed
+// disjoint ranges across the pool, then the order-sensitive tail (interning,
+// exports, diagnostics) runs serially in chunk order exactly like the serial
+// merge.
+fn (mut p Parser) merge_parsed_workers_parallel(mut parser_workers []&Parser, mut starts []int, bounds []int, mut args []ParseChunkArgs) {
+	thread_count := parser_workers.len
+	base_nodes := p.a.nodes.len
+	base_children := p.a.children.len
+	mut node_offsets := []int{len: thread_count + 1}
+	mut child_offsets := []int{len: thread_count + 1}
+	node_offsets[0] = base_nodes
+	child_offsets[0] = base_children
+	for ci in 0 .. thread_count {
+		node_offsets[ci + 1] = node_offsets[ci] + parser_workers[ci].a.nodes.len
+		child_offsets[ci + 1] = child_offsets[ci] + parser_workers[ci].a.children.len
+	}
+	unsafe {
+		p.a.nodes.grow_len(node_offsets[thread_count] - base_nodes)
+		p.a.children.grow_len(child_offsets[thread_count] - base_children)
+	}
+	mut margs := []ParseMergeCopyArgs{cap: thread_count}
+	for ci in 0 .. thread_count {
+		margs << ParseMergeCopyArgs{
+			master:       voidptr(p)
+			worker:       voidptr(parser_workers[ci])
+			node_offset:  node_offsets[ci]
+			child_offset: child_offsets[ci]
+			has_scope:    args[ci + 1].scope != unsafe { nil }
+			miss_nodes:   []int{cap: 4096}
+		}
+	}
+	mut tasks := []workers.Task{cap: thread_count}
+	for ci in 0 .. thread_count {
+		tasks << workers.Task{
+			run:        parse_merge_copy_thread
+			arg:        unsafe { voidptr(&margs[ci]) }
+			force_sync: ci == 0
+		}
+	}
+	p.a.worker_pool.run(tasks)
+	for ci in 0 .. thread_count {
+		p.a.intern_node_texts_at(margs[ci].miss_nodes)
+		p.merge_parsed_worker_bookkeeping(mut *parser_workers[ci], mut starts, bounds[ci + 1], bounds[
+			ci + 2], args[ci + 1].scope, node_offsets[ci], margs[ci].pending_files,
+			margs[ci].has_scope)
+		parser_worker_scope_free(args[ci + 1].scope)
+	}
+}
+
 fn (mut p Parser) merge_parsed_worker(mut w Parser, mut starts []int, chunk_start int, chunk_end int, worker_scope voidptr) {
 	node_shift := p.a.nodes.len
 	child_shift := i32(p.a.children.len)
@@ -853,14 +1057,36 @@ fn (mut p Parser) merge_parsed_worker(mut w Parser, mut starts []int, chunk_star
 				}
 			}
 		}
-		// Worker text tables are private. Rebind every moved payload to the
-		// master's compilation-wide canonical text table before the worker dies.
-		p.a.intern_node_texts_from(nodes_old_len)
 	}
+	p.merge_parsed_worker_tail(mut w, mut starts, chunk_start, chunk_end, worker_scope, node_shift,
+		p.a.nodes.len)
+}
+
+// merge_parsed_worker_tail runs the serial per-chunk bookkeeping that follows
+// the node/children copy: text interning (order-sensitive — canonical table
+// ids must match the serial merge), starts relocation and export/diagnostic
+// merging. node_end bounds the intern range so the parallel merge (where all
+// chunks are already present in the master arrays) interns only this chunk.
+fn (mut p Parser) merge_parsed_worker_tail(mut w Parser, mut starts []int, chunk_start int, chunk_end int, worker_scope voidptr, node_shift int, node_end int) {
+	// Worker text tables are private. Rebind every moved payload to the
+	// master's compilation-wide canonical text table before the worker dies.
+	p.a.intern_node_texts_range(node_shift, node_end)
+	p.merge_parsed_worker_bookkeeping(mut w, mut starts, chunk_start, chunk_end, worker_scope,
+		node_shift, [], false)
+}
+
+fn (mut p Parser) merge_parsed_worker_bookkeeping(mut w Parser, mut starts []int, chunk_start int, chunk_end int, worker_scope voidptr, node_shift int, pending_files []PendingSourceFile, use_pending bool) {
 	// Per-file region starts move by the merge offset.
 	for i in chunk_start .. chunk_end {
 		starts[i] += node_shift
 	}
+	for fid in w.a.file_node_ids {
+		p.a.file_node_ids << fid + node_shift
+	}
+	unsafe {
+		w.a.file_node_ids.len = 0
+	}
+	p.a.file_index_incomplete = p.a.file_index_incomplete || w.a.file_index_incomplete
 	// The worker validated its exports against its own files only; revalidate
 	// them here against disabled fns accumulated from earlier chunks, exactly
 	// like the serial parse where register_pending_export sees every previously
@@ -896,7 +1122,13 @@ fn (mut p Parser) merge_parsed_worker(mut w Parser, mut starts []int, chunk_star
 			message: diagnostic.message.clone()
 		})
 	}
-	if worker_scope == unsafe { nil } {
+	if use_pending {
+		// Line tables were indexed on the copy thread; only the map inserts
+		// remain order-sensitive.
+		for pf in pending_files {
+			p.a.source_files[pf.file_id] = pf.file
+		}
+	} else if worker_scope == unsafe { nil } {
 		for source in w.a.source_buffers {
 			p.a.source_buffers << source
 		}

--- a/vlib/v3/parser/parser_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/parser/parser_parallel_notd_v3_no_parallel.v
@@ -123,6 +123,12 @@ fn parser_worker_scope_free(scope voidptr) {
 	}
 }
 
+fn (p &Parser) timing_profile(message string) {
+	if p.prefs.verbose {
+		eprintln(message)
+	}
+}
+
 // parse_files_dispatch parses paths in order, appending to p.a exactly like a
 // serial parse_into loop, across worker threads when there is enough work.
 // Returns each file's first node id in p.a and whether threads were used.
@@ -226,7 +232,7 @@ pub fn (mut p Parser) parse_files_dispatch(paths []string, allow_parallel bool) 
 		}
 		ppsw := time.new_stopwatch()
 		p.a.worker_pool.run(prepass_tasks)
-		eprintln('  [ttime]   pp prepass pool  ${f64(ppsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+		p.timing_profile('  [ttime]   pp prepass pool  ${f64(ppsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 		for ci in 1 .. n_chunks {
 			if args[ci].scope != unsafe { nil } {
 				prepass_chunks[ci].decls =
@@ -267,7 +273,7 @@ pub fn (mut p Parser) parse_files_dispatch(paths []string, allow_parallel bool) 
 		}
 		ppsw2 := time.new_stopwatch()
 		any_started := p.a.worker_pool.run(tasks)
-		eprintln('  [ttime]   pp parse pool    ${f64(ppsw2.elapsed().microseconds()) / 1000.0:7.2f} ms')
+		p.timing_profile('  [ttime]   pp parse pool    ${f64(ppsw2.elapsed().microseconds()) / 1000.0:7.2f} ms')
 		// Merge each helper in fixed chunk order (input file order),
 		// so node numbering stays deterministic and byte-identical to serial.
 		ppsw3 := time.new_stopwatch()
@@ -280,9 +286,9 @@ pub fn (mut p Parser) parse_files_dispatch(paths []string, allow_parallel bool) 
 				parser_worker_scope_free(args[ci + 1].scope)
 			}
 		}
-		eprintln('  [ttime]   pp merge         ${f64(ppsw3.elapsed().microseconds()) / 1000.0:7.2f} ms')
+		p.timing_profile('  [ttime]   pp merge         ${f64(ppsw3.elapsed().microseconds()) / 1000.0:7.2f} ms')
 		p.next_file_id = dispatch_file_id_start + paths.len
-		eprintln('  [ttime]   pp dispatch      ${f64(pdsw.elapsed().microseconds()) / 1000.0:7.2f} ms (files: ${paths.len})')
+		p.timing_profile('  [ttime]   pp dispatch      ${f64(pdsw.elapsed().microseconds()) / 1000.0:7.2f} ms (files: ${paths.len})')
 		return starts, any_started
 	}
 }

--- a/vlib/v3/tests/driver_cli_test.v
+++ b/vlib/v3/tests/driver_cli_test.v
@@ -253,6 +253,7 @@ fn test_driver_rejects_invalid_cli_and_parses_vmod_subdirs() {
 	c_output := os.join_path(root, 'hello.c')
 	c_compile := cmdexec.run(v3_bin, ['-no-memory-limit', '-o', c_output, source])
 	assert c_compile.exit_code == 0, c_compile.output
+	assert !c_compile.output.contains('[ttime]'), c_compile.output
 	$if macos {
 		rss_index := c_compile.output.index('MB RSS') or { -1 }
 		footprint_index := c_compile.output.index('MB physical footprint') or { -1 }
@@ -262,6 +263,10 @@ fn test_driver_rejects_invalid_cli_and_parses_vmod_subdirs() {
 	c_source := os.read_file(c_output)!
 	assert c_source.len > 100
 	assert c_source.contains('typedef signed char i8;')
+	verbose_output := os.join_path(root, 'hello_verbose.c')
+	verbose_compile := cmdexec.run(v3_bin, ['-nocache', '-v', '-o', verbose_output, source])
+	assert verbose_compile.exit_code == 0, verbose_compile.output
+	assert verbose_compile.output.contains('[ttime]'), verbose_compile.output
 	compat_output := os.join_path(root, 'hello_compat')
 	compat_compile := cmdexec.run(v3_bin, ['-stats', '-show-timings', '-showcc', '-keepc', '-w',
 		'-g', '-cflags', '-w', '-enable-globals', '-o', compat_output, source])

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -194,6 +194,30 @@ fn test_cached_source_signatures_revalidate_changed_inputs() {
 	if _ := manager.valid_header('vmod', [vmod_source]) {
 		assert false, 'a newly discovered v.mod must invalidate cached signatures'
 	}
+
+	quoted_build_source := os.join_path(root, 'quoted_build.v')
+	write_module_cache_file(root, 'quoted_build.v',
+		"module quoted_build\n\npub const marker = '@BUILD_DATE'\n")
+	first_build_manager := modulecache.new_manager(root, 'quoted-build-pseudo', true, 'first')
+	second_build_manager := modulecache.new_manager(root, 'quoted-build-pseudo', true, 'second')
+	assert first_build_manager.ensure_dir()
+	first_build_manager.write_header('quoted_build', [quoted_build_source], 'module quoted_build\n') or {
+		panic(err)
+	}
+	_ := second_build_manager.valid_header('quoted_build', [quoted_build_source]) or {
+		assert false, 'pseudo-variable text inside a string must not invalidate cached signatures'
+		return
+	}
+
+	actual_build_source := os.join_path(root, 'actual_build.v')
+	write_module_cache_file(root, 'actual_build.v',
+		'module actual_build\n\npub const marker = @BUILD_DATE\n')
+	first_build_manager.write_header('actual_build', [actual_build_source], 'module actual_build\n') or {
+		panic(err)
+	}
+	if _ := second_build_manager.valid_header('actual_build', [actual_build_source]) {
+		assert false, 'actual build pseudo-variable changes must invalidate cached signatures'
+	}
 }
 
 fn test_cached_object_accepts_recorded_dependency_superset() {
@@ -415,6 +439,18 @@ fn test_module_cache_split_ignores_module_marker_text() {
 	assert 'fake' !in split.modules
 	assert split.modules['main'].contains('"/* V3CACHE_MODULE fake */"')
 	assert split.modules['main'].contains('int main(void)')
+}
+
+fn test_module_cache_declaration_header_ignores_directive_marker_text() {
+	prefix := 'static string marker = {"/* V3CACHE_LATE_DIRECTIVES_BEGIN */", 35, 1};
+/* V3CACHE_LATE_DIRECTIVES_BEGIN */
+#include <stdint.h>
+/* V3CACHE_LATE_DIRECTIVES_END */
+int cached_value = 1;
+'
+	header := modulecache.declaration_header(prefix)
+	assert header.contains('static string marker = {"/* V3CACHE_LATE_DIRECTIVES_BEGIN */", 35, 1};')
+	assert header.contains('extern int cached_value;')
 }
 
 fn test_module_cache_declaration_header_preserves_preprocessor_after_comment() {

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -218,6 +218,29 @@ fn test_cached_source_signatures_revalidate_changed_inputs() {
 	if _ := second_build_manager.valid_header('actual_build', [actual_build_source]) {
 		assert false, 'actual build pseudo-variable changes must invalidate cached signatures'
 	}
+
+	interpolated_build_source := os.join_path(root, 'interpolated_build.v')
+	write_module_cache_file(root, 'interpolated_build.v',
+		"module interpolated_build\n\npub const marker = 'built \${@BUILD_TIMESTAMP}'\n")
+	first_build_manager.write_header('interpolated_build', [interpolated_build_source],
+		'module interpolated_build\n') or { panic(err) }
+	if _ := second_build_manager.valid_header('interpolated_build', [
+		interpolated_build_source,
+	])
+	{
+		assert false, 'interpolated build pseudo-variable changes must invalidate cached signatures'
+	}
+
+	interpolated_root_source := os.join_path(root, 'interpolated_root', 'root.v')
+	write_module_cache_file(root, 'interpolated_root/root.v',
+		"module interpolated_root\n\npub const marker = 'root \${@VMODROOT}'\n")
+	manager.write_header('interpolated_root', [interpolated_root_source],
+		'module interpolated_root\n') or { panic(err) }
+	write_module_cache_file(root, 'interpolated_root/v.mod',
+		"Module {\n\tname: 'interpolated_root'\n}\n")
+	if _ := manager.valid_header('interpolated_root', [interpolated_root_source]) {
+		assert false, 'interpolated root pseudo-variable changes must invalidate cached signatures'
+	}
 }
 
 fn test_cached_object_accepts_recorded_dependency_superset() {

--- a/vlib/v3/tests/review_transform_regressions_test.v
+++ b/vlib/v3/tests/review_transform_regressions_test.v
@@ -330,6 +330,88 @@ fn test_lifted_fn_literal_mut_param_interpolation_derefs_value() {
 	assert out == '7'
 }
 
+fn test_auto_str_preserves_distinct_structs_beyond_inline_depth() {
+	v3_bin := build_v3_review_transform()
+	out := run_good(v3_bin, 'auto_str_distinct_struct_depth', 'struct D {
+	value int
+}
+
+struct C {
+	d D
+}
+
+struct B {
+	c C
+}
+
+struct A {
+	b B
+}
+
+fn main() {
+	value := A{
+		b: B{
+			c: C{
+				d: D{
+					value: 42
+				}
+			}
+		}
+	}
+	println(value)
+}
+')
+	assert out == 'A{
+    b: B{
+        c: C{
+            d: D{
+                value: 42
+            }
+        }
+    }
+}'
+}
+
+fn test_auto_str_preserves_distinct_sum_beyond_inline_depth() {
+	v3_bin := build_v3_review_transform()
+	out := run_good(v3_bin, 'auto_str_distinct_sum_depth', 'struct Leaf {
+	answer int
+}
+
+struct Other {
+	text string
+}
+
+type Value = Leaf | Other
+
+struct C {
+	value Value
+}
+
+struct B {
+	c C
+}
+
+struct A {
+	b B
+}
+
+fn main() {
+	println(A{
+		b: B{
+			c: C{
+				value: Value(Leaf{
+					answer: 42
+				})
+			}
+		}
+	})
+}
+')
+	assert out.contains('answer: 42'), out
+	assert !out.contains('Value(...)'), out
+}
+
 fn test_interface_fn_field_argument_keeps_parameter_offset_zero() {
 	v3_bin := build_v3_review_transform()
 	out := run_good(v3_bin, 'interface_fn_field_argument_offset', 'interface Value {

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -7,11 +7,12 @@ const spread_index_expected_type_marker = '__v3_spread_index_expected_type'
 
 // max_stringify_nesting_depth bounds how deeply the inline autostr lowering
 // (structs, sum types) recurses through *distinct* aggregate types before it
-// truncates with `Type{...}` / `Sum(...)`. The per-type circular guards only
-// stop a type repeating on the stack; without this total-depth bound a deeply
-// nested distinct-type graph (e.g. v1's ast.Expr/ast.Stmt sumtypes referencing
-// dozens of node structs) expands combinatorially at every `${x}` site, which
-// blows up node generation (region overflow / effectively unbounded work).
+// defers the remaining expansion to synthesized helpers. The per-type circular
+// guards only stop a type repeating on the stack; without this total-depth
+// bound a deeply nested distinct-type graph (e.g. v1's ast.Expr/ast.Stmt
+// sumtypes referencing dozens of node structs) expands combinatorially at
+// every `${x}` site, which blows up node generation (region overflow /
+// effectively unbounded work).
 // Overridable at runtime with V3_STR_CAP for experiments. Kept low because the
 // expansion is combinatorial in this depth: v1's ast graph is unbounded past ~5.
 const max_stringify_nesting_depth = 3
@@ -5040,8 +5041,9 @@ fn (mut t Transformer) lower_struct_str(expr flat.NodeId, struct_type string) ?f
 	if stack_count >= recurse_limit {
 		return t.make_string_literal('<circular>')
 	}
-	if t.stringify_stack.len >= t.stringify_depth_cap {
-		return t.make_string_literal('${struct_string_display_name(struct_type)}{...}')
+	if t.stringify_stack.len >= t.stringify_depth_cap
+		&& !t.stringify_types_match(t.auto_str_synthesis_type, struct_type) {
+		return t.request_auto_str_helper(expr, struct_type)
 	}
 	t.stringify_stack << struct_type
 	defer {
@@ -5753,8 +5755,9 @@ fn (mut t Transformer) lower_sum_str(expr flat.NodeId, sum_name string) flat.Nod
 	if resolved_sum in t.stringify_stack {
 		return t.make_string_literal('${sum_display}{}')
 	}
-	if t.stringify_stack.len >= t.stringify_depth_cap {
-		return t.make_string_literal('${sum_display}(...)')
+	if t.stringify_stack.len >= t.stringify_depth_cap
+		&& !t.stringify_types_match(t.auto_str_synthesis_type, resolved_sum) {
+		return t.request_auto_str_helper(expr, resolved_sum)
 	}
 	t.stringify_stack << resolved_sum
 	defer {

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -5,6 +5,31 @@ import v3.types
 
 const spread_index_expected_type_marker = '__v3_spread_index_expected_type'
 
+// max_stringify_nesting_depth bounds how deeply the inline autostr lowering
+// (structs, sum types) recurses through *distinct* aggregate types before it
+// truncates with `Type{...}` / `Sum(...)`. The per-type circular guards only
+// stop a type repeating on the stack; without this total-depth bound a deeply
+// nested distinct-type graph (e.g. v1's ast.Expr/ast.Stmt sumtypes referencing
+// dozens of node structs) expands combinatorially at every `${x}` site, which
+// blows up node generation (region overflow / effectively unbounded work).
+// Overridable at runtime with V3_STR_CAP for experiments. Kept low because the
+// expansion is combinatorial in this depth: v1's ast graph is unbounded past ~5.
+const max_stringify_nesting_depth = 3
+
+// deferred_str_expansion_threshold is the estimated inline-autostr node count
+// above which a function is lowered serially (against the growable master arena)
+// instead of inside a bounded parallel worker region. It is 0: any function that
+// inline-expands an auto-str struct/sum is deferred, because that expansion is a
+// poor fit for a cost-proportional region and hard to size precisely. Functions
+// with only scalar / custom-str() interps estimate to 0 and stay parallel — this
+// is every function during v3 self-host, whose parallel path is thus unchanged.
+const deferred_str_expansion_threshold = 0
+
+// unresolved_interp_expansion_estimate is charged for an interpolation part whose
+// value type cannot be resolved at collection time, forcing the function onto the
+// serial deferred path in case the transform expands it inline.
+const unresolved_interp_expansion_estimate = 1000
+
 // resolve_call_name resolves the function name from a .call node.
 // child[0] is the function expression: .ident for plain calls, .selector for method calls.
 fn (t &Transformer) resolve_call_name(node flat.Node) string {
@@ -292,7 +317,38 @@ fn (t &Transformer) resolve_collection_receiver_method_name(base_id flat.NodeId,
 }
 
 // resolve_receiver_method_for_type resolves resolve_receiver_method_for_type logic in transform.
+// Hot: called for every method call lowered during body transforms, with heavy
+// repetition of (receiver type, method) pairs. The uncached resolution below
+// scans struct tables and builds many candidate strings, so memoize per
+// (module, type, method); the cache clears when the fn table grows (closure
+// lifting / str-method synthesis can change what resolves).
 fn (t &Transformer) resolve_receiver_method_for_type(receiver_type string, method string) ?string {
+	if !isnil(t.receiver_method_cache) {
+		mut cache := t.receiver_method_cache
+		if cache.module != t.cur_module || cache.fn_count != t.fn_ret_types.len {
+			cache.module = t.cur_module
+			cache.fn_count = t.fn_ret_types.len
+			cache.entries.clear()
+			cache.misses.clear()
+		}
+		cache_key := '${receiver_type}\n${method}'
+		if cached := cache.entries[cache_key] {
+			return cached
+		}
+		if cache.misses[cache_key] {
+			return none
+		}
+		if resolved := t.resolve_receiver_method_for_type_uncached(receiver_type, method) {
+			cache.entries[cache_key] = resolved
+			return resolved
+		}
+		cache.misses[cache_key] = true
+		return none
+	}
+	return t.resolve_receiver_method_for_type_uncached(receiver_type, method)
+}
+
+fn (t &Transformer) resolve_receiver_method_for_type_uncached(receiver_type string, method string) ?string {
 	mut clean_type := receiver_type
 	if clean_type.starts_with('&') {
 		clean_type = clean_type[1..]
@@ -3927,11 +3983,40 @@ fn (t &Transformer) enum_autostr_type_name(typ string) string {
 	mut qualified := typ
 	if qualified.starts_with('main.') {
 		qualified = qualified[5..]
-	} else if !typ.contains('.') && t.cur_module.len > 0 && t.cur_module != 'main'
-		&& t.cur_module != 'builtin' {
+	} else if !typ.contains('.') {
 		q := '${t.cur_module}.${typ}'
-		if q in t.enum_types {
+		if t.cur_module.len > 0 && t.cur_module != 'main' && t.cur_module != 'builtin'
+			&& q in t.enum_types {
 			qualified = q
+		} else if fields := t.enum_types[typ] {
+			// A bare name in a foreign-module expansion (auto-stringified struct
+			// fields keep their declaring module's spelling): the bare alias entry
+			// shares its field-array backing with the declaring qualified entry,
+			// which recovers the exact declared name cgen used for the helper.
+			suffix := '.${typ}'
+			for k, v in t.enum_types {
+				if k.ends_with(suffix) && v.data == fields.data {
+					qualified = k
+					break
+				}
+			}
+		} else {
+			// No bare alias (shadowed): fall back to a unique qualified suffix.
+			suffix := '.${typ}'
+			mut match_name := ''
+			mut matches := 0
+			for k, _ in t.enum_types {
+				if k.ends_with(suffix) {
+					match_name = k
+					matches++
+					if matches > 1 {
+						break
+					}
+				}
+			}
+			if matches == 1 {
+				qualified = match_name
+			}
 		}
 	}
 	short_name := qualified.all_after_last('.')
@@ -4955,6 +5040,9 @@ fn (mut t Transformer) lower_struct_str(expr flat.NodeId, struct_type string) ?f
 	if stack_count >= recurse_limit {
 		return t.make_string_literal('<circular>')
 	}
+	if t.stringify_stack.len >= t.stringify_depth_cap {
+		return t.make_string_literal('${struct_string_display_name(struct_type)}{...}')
+	}
 	t.stringify_stack << struct_type
 	defer {
 		t.stringify_stack.delete_last()
@@ -5191,6 +5279,140 @@ fn (mut t Transformer) lower_multi_return_str(expr flat.NodeId, multi types.Mult
 		result = t.string_plus(result, item_str)
 	}
 	return t.string_plus(result, t.make_string_literal(')'))
+}
+
+// stringify_expansion_estimate returns an upper bound on the number of AST nodes
+// the inline autostr lowering emits when interpolating a value of `typ`, at the
+// configured nesting cap. It mirrors the lowering's shape: a scalar or a type
+// with a custom str() method is a bounded leaf (0 — its lowering is a single
+// call/conversion and never recurses), whereas an auto-generated struct/sum str
+// recurses into fields/variants. The bound ignores the per-type circular guard,
+// so it only ever over-counts, and it is memoized by (aggregate, depth) so it
+// stays cheap even on richly cross-referential graphs like v1's ast package.
+// The estimate is 0 for every type v3 self-host interpolates, so self-host cost
+// and node numbering are unchanged.
+fn (mut t Transformer) stringify_expansion_estimate(typ string) int {
+	return t.stringify_expansion_estimate_at(typ, t.stringify_depth_cap)
+}
+
+fn (mut t Transformer) stringify_expansion_estimate_at(typ string, depth_left int) int {
+	mut clean := typ.trim_space()
+	for {
+		mut stripped := false
+		for prefix in ['mut ', 'shared ', 'atomic ', '...', '?', '!', '[]', '&'] {
+			if clean.starts_with(prefix) {
+				clean = clean[prefix.len..].trim_space()
+				stripped = true
+				break
+			}
+		}
+		if !stripped {
+			break
+		}
+	}
+	if clean.starts_with('map[') {
+		bracket_end := generic_matching_bracket(clean, 3)
+		if bracket_end > 3 && bracket_end < clean.len - 1 {
+			return t.stringify_expansion_estimate_at(clean[4..bracket_end], depth_left) +
+				t.stringify_expansion_estimate_at(clean[bracket_end + 1..], depth_left)
+		}
+	}
+	if clean.starts_with('[') {
+		bracket_end := generic_matching_bracket(clean, 0)
+		if bracket_end > 0 && bracket_end < clean.len - 1 {
+			return t.stringify_expansion_estimate_at(clean[bracket_end + 1..], depth_left)
+		}
+	}
+	agg := t.stringify_aggregate_type_name(clean) or { return 0 }
+	resolved_sum := t.resolve_sum_name(agg)
+	is_sum := resolved_sum in t.sum_types
+	// A struct with a custom/generated str() method that survives markused lowers
+	// to a bounded call, not an inline expansion. Sum types get no such shortcut:
+	// interpolating a sum value inside a smartcast branch lowers the *variant's*
+	// value directly, which bypasses the sum's own str() and inline-expands the
+	// variant struct (this is exactly how v1's `match expr { ... }` bodies blow
+	// up on ast.Expr). A str method that markused will prune also falls back to
+	// inline expansion, so require the method to still be reachable.
+	if !is_sum {
+		if str_fn := t.aggregate_str_method_name(agg) {
+			if !t.has_used_fn_filter() || t.used_fn_contains_name(str_fn)
+				|| t.used_fn_contains_name(c_name(str_fn)) {
+				return 0
+			}
+		}
+	}
+	if depth_left <= 0 {
+		return 1
+	}
+	key := '${agg}|${depth_left}'
+	if cached := t.str_expansion_memo[key] {
+		return cached
+	}
+	// Provisional memo entry so a self-referential type at the same depth does not
+	// recurse forever (fields always descend at depth_left-1, so this is belt-and-
+	// suspenders against odd alias cycles).
+	t.str_expansion_memo[key] = 0
+	mut total := 6
+	if variants := t.sum_types[resolved_sum] {
+		for variant in variants {
+			total += 10 + t.stringify_expansion_estimate_at(variant, depth_left - 1)
+		}
+	} else if info := t.lookup_struct_info(agg) {
+		for field in info.fields {
+			field_type := if field.raw_typ.len > 0 { field.raw_typ } else { field.typ }
+			if field_type.len == 0 {
+				continue
+			}
+			total += 8 + t.stringify_expansion_estimate_at(field_type, depth_left - 1)
+		}
+	}
+	t.str_expansion_memo[key] = total
+	return total
+}
+
+// fn_span_interp_estimate sums the inline autostr expansion estimate over every
+// string-interpolation part in a function's parsed subtree [lo, hi). It is 0
+// unless the function interpolates an auto-str struct/sum, in which case the
+// return value approximates how many nodes the lowering will emit for those
+// interps — used to size the function's parallel append region (or defer it).
+// A part whose value type cannot be resolved at collection time is treated as
+// heavy: the transform can still resolve it to an aggregate (e.g. through a
+// smartcast or a method return) and inline-expand it, which must not land in a
+// bounded worker region. Scalar / str-method interps resolve cleanly to 0, so
+// v3 self-host — whose interps are all scalars — defers nothing.
+fn (mut t Transformer) fn_span_interp_estimate(lo int, hi int) int {
+	mut est := 0
+	for idx in lo .. hi {
+		if idx < 0 || idx >= t.a.nodes.len {
+			continue
+		}
+		node := t.a.nodes[idx]
+		if node.kind != .string_interp {
+			continue
+		}
+		for ci in 0 .. int(node.children_count) {
+			part_id := t.a.child(&node, ci)
+			mut expr_id := part_id
+			part := t.a.nodes[int(part_id)]
+			if part.kind == .directive && part.value == 'string_interp_format'
+				&& part.children_count > 0 {
+				expr_id = t.a.child(&part, 0)
+			}
+			part_expr := t.a.nodes[int(expr_id)]
+			// Literal segments of the interpolation are always plain strings.
+			if part_expr.kind in [.string_literal, .int_literal, .float_literal, .bool_literal,
+				.char_literal] {
+				continue
+			}
+			typ := t.reliable_stringify_type(expr_id)
+			if typ.len == 0 {
+				est += unresolved_interp_expansion_estimate
+			} else {
+				est += t.stringify_expansion_estimate(typ)
+			}
+		}
+	}
+	return est
 }
 
 fn (t &Transformer) stringify_aggregate_type_name(typ string) ?string {
@@ -5530,6 +5752,9 @@ fn (mut t Transformer) lower_sum_str(expr flat.NodeId, sum_name string) flat.Nod
 	}
 	if resolved_sum in t.stringify_stack {
 		return t.make_string_literal('${sum_display}{}')
+	}
+	if t.stringify_stack.len >= t.stringify_depth_cap {
+		return t.make_string_literal('${sum_display}(...)')
 	}
 	t.stringify_stack << resolved_sum
 	defer {

--- a/vlib/v3/transform/map.v
+++ b/vlib/v3/transform/map.v
@@ -52,6 +52,36 @@ fn (t &Transformer) map_key_backing_type(key_type string) ?string {
 			}
 		}
 	}
+	// A bare alias spelling from a foreign-module expansion (auto-stringified
+	// fields keep their declaring module's spelling): resolve it through the
+	// checker alias table like wrap_string_conversion does, and store keys as
+	// the scalar base so the declared C type never names the unresolvable
+	// alias. The transform's own struct mirror holds first-wins bare aliases
+	// for unrelated modules, so only a checker-declared struct blocks this.
+	if !isnil(t.tc) && !clean.contains('.') && clean !in t.tc.structs {
+		mut alias_target := t.tc.type_aliases[clean] or { '' }
+		if alias_target.len == 0 {
+			suffix := '.${clean}'
+			mut matches := 0
+			for aname, target in t.tc.type_aliases {
+				if aname.ends_with(suffix) {
+					alias_target = target
+					matches++
+					if matches > 1 {
+						alias_target = ''
+						break
+					}
+				}
+			}
+		}
+		if alias_target.len > 0 {
+			base := t.normalize_type_alias(alias_target).trim_space()
+			if base in ['int', 'i8', 'i16', 'i32', 'i64', 'isize', 'usize', 'u8', 'byte', 'u16',
+				'u32', 'u64', 'rune', 'char', 'string'] {
+				return base
+			}
+		}
+	}
 	return none
 }
 

--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -573,10 +573,10 @@ fn (mut t Transformer) seed_generic_specialization_args(decls map[string]Generic
 pub fn erase_generic_templates(mut a flat.FlatAst, tc &types.TypeChecker, used_fns map[string]bool) map[string]bool {
 	mut sw := time.new_stopwatch()
 	mut t := new_transformer(mut a, tc, used_fns)
-	eprintln('  [ttime]   erase new_transformer ${f64(sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+	t.timing_profile('  [ttime]   erase new_transformer ${f64(sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 	sw.restart()
 	decls := t.collect_generic_fn_decls_for_erasure()
-	eprintln('  [ttime]   erase collect         ${f64(sw.elapsed().microseconds()) / 1000.0:7.2f} ms (decls: ${decls.len})')
+	t.timing_profile('  [ttime]   erase collect         ${f64(sw.elapsed().microseconds()) / 1000.0:7.2f} ms (decls: ${decls.len})')
 	sw.restart()
 	if decls.len != 0 {
 		keep := t.building_v_type_erased_generic_keep_set(decls)
@@ -588,7 +588,7 @@ pub fn erase_generic_templates(mut a flat.FlatAst, tc &types.TypeChecker, used_f
 			erased[key] = decl
 		}
 		t.erase_generic_fn_decls(erased)
-		eprintln('  [ttime]   erase apply           ${f64(sw.elapsed().microseconds()) / 1000.0:7.2f} ms (erased: ${decls.len - keep.len})')
+		t.timing_profile('  [ttime]   erase apply           ${f64(sw.elapsed().microseconds()) / 1000.0:7.2f} ms (erased: ${decls.len - keep.len})')
 	}
 	return t.used_fns
 }
@@ -605,7 +605,7 @@ fn (mut t Transformer) collect_generic_fn_decls_for_erasure() map[string]Generic
 	mut scan_sw := time.new_stopwatch()
 	mut flags := []u8{len: t.a.nodes.len}
 	if scan_top_level_kind_flags_parallel(t.a, 0, mut flags) {
-		eprintln('  [ttime]     collect scan        ${f64(scan_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+		t.timing_profile('  [ttime]     collect scan        ${f64(scan_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 		scan_sw.restart()
 		// Word-scan the flag array: flagged nodes are rare, so loading eight
 		// flags per u64 makes the master walk almost free.
@@ -629,7 +629,7 @@ fn (mut t Transformer) collect_generic_fn_decls_for_erasure() map[string]Generic
 					cur_file, cur_module)
 			}
 		}
-		eprintln('  [ttime]     collect flag walk   ${f64(scan_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+		t.timing_profile('  [ttime]     collect flag walk   ${f64(scan_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 		return decls
 	}
 	for i in 0 .. t.a.nodes.len {

--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -571,8 +571,13 @@ fn (mut t Transformer) seed_generic_specialization_args(decls map[string]Generic
 }
 
 pub fn erase_generic_templates(mut a flat.FlatAst, tc &types.TypeChecker, used_fns map[string]bool) map[string]bool {
+	mut sw := time.new_stopwatch()
 	mut t := new_transformer(mut a, tc, used_fns)
+	eprintln('  [ttime]   erase new_transformer ${f64(sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+	sw.restart()
 	decls := t.collect_generic_fn_decls_for_erasure()
+	eprintln('  [ttime]   erase collect         ${f64(sw.elapsed().microseconds()) / 1000.0:7.2f} ms (decls: ${decls.len})')
+	sw.restart()
 	if decls.len != 0 {
 		keep := t.building_v_type_erased_generic_keep_set(decls)
 		mut erased := map[string]GenericFnDecl{}
@@ -583,6 +588,7 @@ pub fn erase_generic_templates(mut a flat.FlatAst, tc &types.TypeChecker, used_f
 			erased[key] = decl
 		}
 		t.erase_generic_fn_decls(erased)
+		eprintln('  [ttime]   erase apply           ${f64(sw.elapsed().microseconds()) / 1000.0:7.2f} ms (erased: ${decls.len - keep.len})')
 	}
 	return t.used_fns
 }
@@ -591,32 +597,82 @@ fn (mut t Transformer) collect_generic_fn_decls_for_erasure() map[string]Generic
 	mut decls := map[string]GenericFnDecl{}
 	mut cur_file := ''
 	mut cur_module := ''
-	for i, node in t.a.nodes {
-		match node.kind {
-			.file {
-				cur_file = node.value
-				cur_module = t.tc.file_modules[cur_file] or { '' }
+	// The walk is cache-miss bound (one 72-byte node header per check) and the
+	// per-decl candidate analysis is state-free, so fan both out over the
+	// worker pool: workers flag file/module markers and prescreen-positive fn
+	// decls, and only those nodes are visited here, in ascending order like the
+	// serial walk. Prescreen-negative fn decls can never need erasure.
+	mut scan_sw := time.new_stopwatch()
+	mut flags := []u8{len: t.a.nodes.len}
+	if scan_top_level_kind_flags_parallel(t.a, 0, mut flags) {
+		eprintln('  [ttime]     collect scan        ${f64(scan_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+		scan_sw.restart()
+		// Word-scan the flag array: flagged nodes are rare, so loading eight
+		// flags per u64 makes the master walk almost free.
+		words := flags.len / 8
+		word_data := unsafe { &u64(flags.data) }
+		for wi in 0 .. words {
+			if unsafe { word_data[wi] } == 0 {
+				continue
 			}
-			.module_decl {
-				cur_module = node.value
-			}
-			.fn_decl {
-				if !t.generic_fn_decl_needs_erasure_scan(node, cur_module) {
-					continue
+			base_i := wi * 8
+			for bi in 0 .. 8 {
+				if flags[base_i + bi] != 0 {
+					cur_file, cur_module = t.collect_generic_fn_decl_for_erasure_at(base_i + bi, mut
+						decls, cur_file, cur_module)
 				}
-				key := t.generic_fn_decl_key(node, cur_module)
-				decls[key] = GenericFnDecl{
-					id:     flat.NodeId(i)
-					node:   node
-					file:   cur_file
-					module: cur_module
-					key:    key
-				}
 			}
-			else {}
 		}
+		for i in words * 8 .. flags.len {
+			if flags[i] != 0 {
+				cur_file, cur_module = t.collect_generic_fn_decl_for_erasure_at(i, mut decls,
+					cur_file, cur_module)
+			}
+		}
+		eprintln('  [ttime]     collect flag walk   ${f64(scan_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+		return decls
+	}
+	for i in 0 .. t.a.nodes.len {
+		kind := unsafe { t.a.nodes[i].kind }
+		if kind != .file && kind != .module_decl && kind != .fn_decl {
+			continue
+		}
+		cur_file, cur_module = t.collect_generic_fn_decl_for_erasure_at(i, mut decls, cur_file,
+			cur_module)
 	}
 	return decls
+}
+
+// collect_generic_fn_decl_for_erasure_at visits one node of the erasure scan
+// and returns the (file, module) context the scan holds after it.
+fn (mut t Transformer) collect_generic_fn_decl_for_erasure_at(i int, mut decls map[string]GenericFnDecl, cur_file string, cur_module string) (string, string) {
+	node := unsafe { &t.a.nodes[i] }
+	match node.kind {
+		.file {
+			new_file := node.value
+			return new_file, t.tc.file_modules[new_file] or { '' }
+		}
+		.module_decl {
+			return cur_file, node.value
+		}
+		.fn_decl {
+			if !t.generic_fn_decl_needs_erasure_scan(*node, cur_module) {
+				return cur_file, cur_module
+			}
+			key := t.generic_fn_decl_key(*node, cur_module)
+			decls[key] = GenericFnDecl{
+				id:     flat.NodeId(i)
+				node:   *node
+				file:   cur_file
+				module: cur_module
+				key:    key
+			}
+			return cur_file, cur_module
+		}
+		else {
+			return cur_file, cur_module
+		}
+	}
 }
 
 fn (mut t Transformer) building_v_type_erased_generic_keep_set(decls map[string]GenericFnDecl) map[string]bool {
@@ -8946,8 +9002,41 @@ fn (mut t Transformer) node_subtree_has_generic_placeholder(id flat.NodeId, modu
 	return false
 }
 
+// generic_placeholder_prescreen reports whether `text` can possibly hold a
+// single-capital-letter type component (`T`, `os.T`, `[]T`, `map[K]V`, ...) or
+// the word `generic`. Every text type_text_has_generic_placeholder flags
+// contains an isolated capital letter (each detection path ends in
+// is_generic_fn_placeholder_name on a component whose neighbours in the
+// original text are non-identifier characters), so texts failing this byte
+// scan skip the full recursive analysis.
+@[direct_array_access]
+fn generic_placeholder_prescreen(text string) bool {
+	for i in 0 .. text.len {
+		c := text[i]
+		if c >= `A` && c <= `Z` {
+			prev_ident := i > 0 && is_placeholder_ident_char(text[i - 1])
+			next_ident := i + 1 < text.len && is_placeholder_ident_char(text[i + 1])
+			if !prev_ident && !next_ident {
+				return true
+			}
+		} else if c == `g` && i + 7 <= text.len && text[i + 1] == `e` && text[i + 2] == `n`
+			&& text[i + 3] == `e` && text[i + 4] == `r` && text[i + 5] == `i` && text[i + 6] == `c` {
+			return true
+		}
+	}
+	return false
+}
+
+@[inline]
+fn is_placeholder_ident_char(c u8) bool {
+	return (c >= `a` && c <= `z`) || (c >= `A` && c <= `Z`) || (c >= `0` && c <= `9`) || c == `_`
+}
+
 fn (mut t Transformer) type_text_has_generic_placeholder(typ string, module_name string) bool {
 	if t.skip_generics {
+		return false
+	}
+	if !generic_placeholder_prescreen(typ) {
 		return false
 	}
 	clean := typ.trim_space()

--- a/vlib/v3/transform/struct.v
+++ b/vlib/v3/transform/struct.v
@@ -859,6 +859,13 @@ fn (t &Transformer) unique_qualified_struct_for_short(name string) ?string {
 	if isnil(t.tc) || name.len == 0 || name.contains('.') {
 		return none
 	}
+	if t.struct_short_name_index_ready {
+		qualified := t.struct_short_name_index[name] or { return none }
+		if qualified != struct_short_name_ambiguous && !qualified.contains('[') {
+			return qualified
+		}
+		return none
+	}
 	mut found := ''
 	for sname, _ in t.tc.structs {
 		// Match a module-qualified struct whose short name equals `name`, excluding

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -1,5 +1,6 @@
 module transform
 
+import os
 import time
 import v3.flat
 import v3.gen.c.naming
@@ -171,6 +172,8 @@ mut:
 	type_alias_name_cache         &ContextBoolLookupCache  = unsafe { nil }
 	interface_box_param_cache     &BoolLookupCache         = unsafe { nil }
 	alias_receiver_method_cache   &LookupCache             = unsafe { nil }
+	receiver_method_cache         &ReceiverMethodCache     = unsafe { nil }
+	promote_text_cache            &PromoteTextCache        = unsafe { nil }
 	call_variadic_cache           &BoolLookupCache         = unsafe { nil }
 	str_alias_cache               &LookupCache             = unsafe { nil }
 	generic_alias_names           map[string]bool
@@ -279,6 +282,10 @@ mut:
 	generic_call_spec_cache            map[int]GenericCallSpec
 	generic_call_spec_misses           map[int]bool
 	stringify_stack                    []string
+	stringify_depth_cap                int = max_stringify_nesting_depth
+	str_expansion_memo                 map[string]int
+	deferred_str_items                 []FnWorkItem
+	deferred_str_count                 int
 	node_module_map_cache              []string
 	node_file_map_cache                []string
 	node_module_map_nodes              int = -1
@@ -464,6 +471,52 @@ mut:
 	entries map[string]i8 // 1 = unresolved, -1 = resolved
 }
 
+// ReceiverMethodCache memoizes resolve_receiver_method_for_type results. Lives
+// on the heap so `&Transformer` query methods can populate it; keyed by
+// `type\nmethod`, cleared on module switch (candidate construction consults
+// cur_module) and whenever the transformer registers new fn signatures
+// (closure lifting / synthesized helpers can change name resolution).
+struct ReceiverMethodCache {
+mut:
+	module   string
+	fn_count int
+	entries  map[string]string
+	misses   map[string]bool
+}
+
+// PromoteTextCache short-circuits repeated promote_scoped_result_text calls on
+// the SAME string instance (shallow string copies share `.str`, so one batch
+// promotes the same pointer thousands of times). Pointer keys are only valid
+// while the source scope is alive, so the cache only serves lookups inside an
+// explicit window (absorb_scoped_batch) that ends before the scope is freed;
+// outside a window promote falls back to the content-hash tables.
+struct PromoteTextCache {
+mut:
+	active      bool
+	generation  u32 = 1
+	ptrs        [2048]voidptr
+	generations [2048]u32
+	results     [2048]string
+}
+
+// begin_promote_text_window arms the pointer cache for one promotion pass over
+// a still-live scope. end_promote_text_window MUST run before that scope is
+// freed; unpaired promote calls simply bypass the cache.
+@[inline]
+fn (mut t Transformer) begin_promote_text_window() {
+	if !isnil(t.promote_text_cache) {
+		t.promote_text_cache.generation++
+		t.promote_text_cache.active = true
+	}
+}
+
+@[inline]
+fn (mut t Transformer) end_promote_text_window() {
+	if !isnil(t.promote_text_cache) {
+		t.promote_text_cache.active = false
+	}
+}
+
 // StructInfo stores struct info metadata used by transform.
 pub struct StructInfo {
 pub:
@@ -644,6 +697,7 @@ pub fn transform_selected_functions(mut a flat.FlatAst, tc &types.TypeChecker, s
 }
 
 fn transform_with_used_opt_config_scoped_workers_checked_impl(mut a flat.FlatAst, tc &types.TypeChecker, used_fns map[string]bool, want_parallel bool, skip_generics bool, scope_parallel_workers bool, building_v bool, retain_worker_results bool, stage_scope voidptr) (map[string]bool, bool, []string, []int, []ScopedTransformRegion) {
+	mut impl_sw := time.new_stopwatch()
 	mut t := new_transformer(mut a, tc, used_fns)
 	t.skip_generics = skip_generics
 	t.building_v = building_v
@@ -654,16 +708,21 @@ fn transform_with_used_opt_config_scoped_workers_checked_impl(mut a flat.FlatAst
 		t.scoped_base_nodes = t.a.nodes.len
 	}
 	t.prepare()
+	eprintln('  [ttime] new+prepare        ${f64(impl_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+	impl_sw.restart()
 	t.cache_comptime_param_reflection_metadata()
 	if want_parallel {
 		reserve_parallel_transform_ast(mut a, skip_generics)
 	}
+	eprintln('  [ttime] reflect+reserve    ${f64(impl_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+	impl_sw.restart()
 	base_node_count := t.a.nodes.len
 	if scope_parallel_workers {
 		t.scoped_base_nodes = base_node_count
 	}
 	t.transformed_fns = []bool{len: t.a.nodes.len}
 	was_parallel := t.transform_all_dispatch(want_parallel)
+	impl_sw.restart()
 	t.retain_current_worker_scope_all()
 	t.apply_ignored_comptime_for_nodes()
 	// The late-name scan backfills call names that raw-AST markused could not
@@ -676,11 +735,16 @@ fn transform_with_used_opt_config_scoped_workers_checked_impl(mut a flat.FlatAst
 		t.new_call_names_from_used_fn_bodies(used_fns, t.a.nodes.len)
 	}
 	late_names << newly_used_fn_names(used_fns, t.used_fns)
+	eprintln('  [ttime] late names         ${f64(impl_sw.elapsed().microseconds()) / 1000.0:7.2f} ms (n: ${late_names.len})')
+	impl_sw.restart()
 	t.transform_late_used_fn_bodies(late_names, base_node_count)
+	eprintln('  [ttime] late bodies        ${f64(impl_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+	impl_sw.restart()
 	t.run_auto_str_synthesis_rounds(base_node_count)
 	t.run_sum_eq_synthesis_rounds(base_node_count)
 	t.apply_ignored_comptime_for_nodes()
 	t.retain_current_worker_scope_all()
+	eprintln('  [ttime] sum_eq+tail        ${f64(impl_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 	mut owned_base_nodes := t.scoped_owned_base_nodes.keys()
 	owned_base_nodes << t.scoped_owned_base_log
 	return t.used_fns, was_parallel, t.monomorph_errors, owned_base_nodes, t.retained_worker_regions
@@ -706,15 +770,38 @@ fn (mut t Transformer) retain_current_worker_scope_all() {
 // reserve_parallel_transform_ast reserves persistent append regions before a
 // disposable transform arena is entered.
 pub fn reserve_parallel_transform_ast(mut a flat.FlatAst, skip_generics bool) {
+	reserve_parallel_transform_ast_with_cache_mode(mut a, skip_generics, false)
+}
+
+// reserve_parallel_transform_cache_ast adds overflow headroom for cache population,
+// which transforms every module body rather than just the program-reachable subset.
+pub fn reserve_parallel_transform_cache_ast(mut a flat.FlatAst, skip_generics bool) {
+	reserve_parallel_transform_ast_with_cache_mode(mut a, skip_generics, true)
+}
+
+fn reserve_parallel_transform_ast_with_cache_mode(mut a flat.FlatAst, skip_generics bool, cache_mode bool) {
 	// The shared-base parallel path partitions this headroom between workers.
 	// Generic lowering needs more headroom than self-host transform because worker
 	// regions cannot grow while their disposable arenas are active.
-	nodes_factor_num, nodes_factor_den := if skip_generics { 2, 1 } else { 3, 1 }
-	children_factor_num, children_factor_den := if skip_generics { 5, 2 } else { 4, 1 }
+	// Self-host growth currently lands at ~1.87x nodes / ~2.24x children of the
+	// parsed size, and the per-chunk cost-proportional slices amplify any local
+	// growth-per-cost outlier, so the 2x / 7:3 factors used to sit within a few
+	// percent of a loud nogrow overflow — one added source file could trip them.
+	nodes_factor_num, nodes_factor_den := if skip_generics {
+		if cache_mode { 5, 2 } else { 9, 4 }
+	} else {
+		3, 1
+	}
+	children_factor_num, children_factor_den := if skip_generics {
+		if cache_mode { 3, 1 } else { 8, 3 }
+	} else {
+		4, 1
+	}
 	nodes_cap := a.nodes.len * nodes_factor_num / nodes_factor_den
 	if nodes_cap > a.nodes.cap {
 		old_nodes := a.nodes
 		a.nodes = []flat.Node{cap: nodes_cap}
+		a.file_node_ids = []int{}
 		a.nodes << old_nodes
 	}
 	children_cap := a.children.len * children_factor_num / children_factor_den
@@ -1156,18 +1243,29 @@ fn local_method_fn_name_needs_module_prefix(name string) bool {
 }
 
 fn (mut t Transformer) prepare() {
+	cap_env := os.getenv('V3_STR_CAP')
+	if cap_env != '' {
+		t.stringify_depth_cap = cap_env.int()
+	}
+	mut psw := time.new_stopwatch()
 	t.collect_types()
+	eprintln('  [ttime]   prep collect_types ${f64(psw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+	psw.restart()
 	t.rebuild_embedded_fields_index()
 	t.prepare_runtime_type_indexes()
 	t.rebuild_struct_short_name_index()
 	t.collect_multi_return_fn_ret_types()
 	t.collect_const_suffixes()
+	eprintln('  [ttime]   prep small idx     ${f64(psw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+	psw.restart()
 	t.collect_alias_methods()
 	t.rebuild_receiver_method_suffix_index()
 	t.rebuild_variadic_suffix_index()
 	t.build_generic_alias_name_index()
 	t.build_local_decl_index()
 	t.build_struct_field_decl_metas_cache()
+	eprintln('  [ttime]   prep suffix+decl   ${f64(psw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+	psw.restart()
 	// Enable the alias cache only now that the type maps are fully populated.
 	// During collection those maps are incomplete, so caching there would poison
 	// entries with results computed against a partial view.
@@ -1177,6 +1275,8 @@ fn (mut t Transformer) prepare() {
 	t.struct_guess_cache = &AliasCache{}
 	t.var_type_cache = &VarTypeIndexCache{}
 	t.generic_unresolved_cache = &GenericUnresolvedCache{}
+	t.receiver_method_cache = &ReceiverMethodCache{}
+	t.promote_text_cache = &PromoteTextCache{}
 	t.struct_field_type_cache = &LookupCache{
 		entries: map[string]string{}
 		misses:  map[string]bool{}
@@ -1557,7 +1657,10 @@ fn (mut t Transformer) add_receiver_method_suffix_index(name string) {
 	t.set_receiver_method_suffix_index(name, name)
 	for i in 0 .. name.len {
 		if name[i] == `.` && i + 1 < name.len {
-			t.set_receiver_method_suffix_index(name[i + 1..], name)
+			// Zero-copy suffix view: map lookups only read it and map inserts
+			// clone their key, so the allocation per suffix is unnecessary.
+			suffix := unsafe { tos(name.str + i + 1, name.len - i - 1) }
+			t.set_receiver_method_suffix_index(suffix, name)
 		}
 	}
 }
@@ -1599,13 +1702,14 @@ fn (mut t Transformer) rebuild_variadic_suffix_index() {
 	for name, is_variadic in t.tc.fn_variadic {
 		mut offset := name.index('.') or { continue }
 		for offset >= 0 && offset + 1 < name.len {
-			suffix := name[offset + 1..]
+			// Zero-copy suffix view (see add_receiver_method_suffix_index).
+			suffix := unsafe { tos(name.str + offset + 1, name.len - offset - 1) }
 			if suffix in t.variadic_suffix_index {
 				t.variadic_suffix_index[suffix] = 2
 			} else {
 				t.variadic_suffix_index[suffix] = if is_variadic { i8(1) } else { i8(-1) }
 			}
-			next := name[offset + 1..].index('.') or { break }
+			next := suffix.index('.') or { break }
 			offset += next + 1
 		}
 	}
@@ -2470,6 +2574,7 @@ fn (mut t Transformer) transform_all_dispatch(want_parallel bool) bool {
 				pure_items := t.transform_serial_then_collect_pure(literal_decls)
 				t.prepare_parallel_call_param_types()
 				t.transform_scoped_helper_batches(pure_items, scoped_transform_master_batches)
+				t.transform_deferred_str_items()
 				if !has_entry_main {
 					t.transform_top_level_user_stmts()
 				}
@@ -2482,17 +2587,31 @@ fn (mut t Transformer) transform_all_dispatch(want_parallel bool) bool {
 		return false
 	}
 	has_entry_main := t.has_entry_main()
+	mut ttsw := time.new_stopwatch()
 	// Serial phase: transform consts/globals and every function whose body
 	// contains a function literal (the only construct that lifts new top-level
 	// declarations and mutates the shared TypeChecker). Collect the remaining,
 	// closure-free functions as parallelizable work items.
 	literal_decls := t.collect_literal_fn_decls(t.a.nodes.len)
+	eprintln('  [ttime] literal_decls      ${f64(ttsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+	ttsw.restart()
 	pure_items := t.transform_serial_then_collect_pure(literal_decls)
+	eprintln('  [ttime] serial+collect     ${f64(ttsw.elapsed().microseconds()) / 1000.0:7.2f} ms (items: ${pure_items.len})')
+	ttsw.restart()
 	base_nodes := t.a.nodes.len
 	base_children := t.a.children.len
 	was_parallel := t.run_parallel_transform(pure_items, base_nodes, base_children)
+	eprintln('  [ttime] parallel run       ${f64(ttsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+	ttsw.restart()
+	// Aggregate-interpolating functions were held back from the parallel regions
+	// (their inline autostr expansion overflows cost-proportional worker slots);
+	// lower them now against the freely growable master arena.
+	t.transform_deferred_str_items()
+	eprintln('  [ttime] deferred str       ${f64(ttsw.elapsed().microseconds()) / 1000.0:7.2f} ms (items: ${t.deferred_str_count})')
+	ttsw.restart()
 	if !has_entry_main {
 		t.transform_top_level_user_stmts()
+		eprintln('  [ttime] top_level_stmts    ${f64(ttsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 	}
 	return was_parallel
 }
@@ -2540,6 +2659,9 @@ fn (mut t Transformer) transform_serial_then_collect_pure(literal_decls []int) [
 	mut ti := 0
 	mut prev_tl_any := -1
 	mut prev_decl_end := 0
+	mut const_ms := f64(0)
+	mut lit_ms := f64(0)
+	mut scsw := time.new_stopwatch()
 	for i in 0 .. original_len {
 		for ti < tl.len && tl[ti] < i {
 			prev_tl_any = tl[ti]
@@ -2582,27 +2704,55 @@ fn (mut t Transformer) transform_serial_then_collect_pure(literal_decls []int) [
 				old_range_hi := t.item_range_hi
 				t.item_range_lo = prev_tl_any + 1
 				t.item_range_hi = i
+				scsw.restart()
 				t.transform_fn_body(i)
+				lit_ms += f64(scsw.elapsed().microseconds()) / 1000.0
 				t.item_range_lo = old_range_lo
 				t.item_range_hi = old_range_hi
 			} else {
-				pure << FnWorkItem{
-					fn_idx:   i
-					range_lo: prev_tl_any + 1
-					file:     t.cur_file
-					module:   t.cur_module
-					cost:     cost
-					rank:     i64(cost) * 1_000_000_000 - i64(i)
+				// Interpolating an auto-str struct/sum expands inline to node counts
+				// wildly out of proportion to parse cost. Estimate that expansion:
+				// a large one would overflow a cost-proportional worker append region
+				// in the shared parallel transform, so defer such functions to a
+				// serial pass over the freely growable master arena; a small one just
+				// folds into this item's cost so its region is sized to fit. The
+				// estimate is 0 for every type v3 self-host interpolates, so its work
+				// items and node numbering are untouched.
+				str_est := t.fn_span_interp_estimate(prev_tl_any + 1, i)
+				if str_est > deferred_str_expansion_threshold {
+					t.deferred_str_items << FnWorkItem{
+						fn_idx:   i
+						range_lo: prev_tl_any + 1
+						file:     t.cur_file
+						module:   t.cur_module
+						cost:     cost
+						rank:     i64(cost) * 1_000_000_000 - i64(i)
+					}
+				} else {
+					adj_cost := cost + str_est
+					pure << FnWorkItem{
+						fn_idx:   i
+						range_lo: prev_tl_any + 1
+						file:     t.cur_file
+						module:   t.cur_module
+						cost:     adj_cost
+						rank:     i64(adj_cost) * 1_000_000_000 - i64(i)
+					}
 				}
 			}
 		} else if kind_id == 65 {
 			prev_decl_end = i
+			scsw.restart()
 			t.transform_const_decl(node)
+			const_ms += f64(scsw.elapsed().microseconds()) / 1000.0
 		} else if kind_id == 64 {
 			prev_decl_end = i
+			scsw.restart()
 			t.transform_global_decl(node)
+			const_ms += f64(scsw.elapsed().microseconds()) / 1000.0
 		}
 	}
+	eprintln('  [ttime]   sc consts ${const_ms:.2f} ms, closures ${lit_ms:.2f} ms')
 	return pure
 }
 
@@ -2648,6 +2798,22 @@ fn (mut t Transformer) transform_pure_items_serial(items []FnWorkItem) {
 	}
 	t.item_range_lo = -1
 	t.item_range_hi = -1
+}
+
+// transform_deferred_str_items lowers the functions held back from the parallel
+// regions because they interpolate struct/sum values (see
+// transform_serial_then_collect_pure). They run serially against the master
+// arena, which grows freely, so their large inline autostr expansion cannot
+// overflow a bounded worker append region. The list is empty unless the program
+// actually interpolates aggregates, so common builds (v3 self-host) skip it.
+fn (mut t Transformer) transform_deferred_str_items() {
+	t.deferred_str_count = t.deferred_str_items.len
+	if t.deferred_str_items.len == 0 {
+		return
+	}
+	items := t.deferred_str_items
+	t.deferred_str_items = []FnWorkItem{}
+	t.transform_pure_items_serial(items)
 }
 
 // clone_ast_base produces a private FlatAst holding an independent copy of the
@@ -2718,6 +2884,8 @@ fn (t &Transformer) fork_worker_config(ast &flat.FlatAst, wtc &types.TypeChecker
 	w.struct_guess_cache = &AliasCache{}
 	w.var_type_cache = &VarTypeIndexCache{}
 	w.generic_unresolved_cache = &GenericUnresolvedCache{}
+	w.receiver_method_cache = &ReceiverMethodCache{}
+	w.promote_text_cache = &PromoteTextCache{}
 	w.struct_field_type_cache = &LookupCache{
 		entries: map[string]string{}
 		misses:  map[string]bool{}
@@ -2833,6 +3001,8 @@ fn (t &Transformer) fork_scan_worker(wtc &types.TypeChecker) &Transformer {
 	w.struct_guess_cache = &AliasCache{}
 	w.var_type_cache = &VarTypeIndexCache{}
 	w.generic_unresolved_cache = &GenericUnresolvedCache{}
+	w.receiver_method_cache = &ReceiverMethodCache{}
+	w.promote_text_cache = &PromoteTextCache{}
 	w.struct_field_type_cache = &LookupCache{
 		entries: map[string]string{}
 		misses:  map[string]bool{}
@@ -2992,6 +3162,7 @@ fn (t &Transformer) fork_program_view(ast &flat.FlatAst, wtc &types.TypeChecker,
 		monomorph_error_seen:               map[string]bool{}
 		skip_generics:                      t.skip_generics
 		building_v:                         t.building_v
+		stringify_depth_cap:                t.stringify_depth_cap
 		has_spawn_expr:                     t.has_spawn_expr
 		base_write_intercept:               t.base_write_intercept
 		defer_oor_writes:                   t.defer_oor_writes
@@ -3137,16 +3308,16 @@ fn (mut t Transformer) merge_worker(w &Transformer, items []FnWorkItem, base_nod
 		old_len := t.a.children.len
 		unsafe {
 			t.a.children.grow_len(new_children)
-			// vmemmove: under the shared-base path the source region lives in
-			// the same array; compaction copies leftward, which can touch the
-			// source block's tail when regions are exactly packed.
-			vmemmove(&t.a.children[old_len], &w.a.children[base_children],
-				new_children * int(sizeof(flat.NodeId)))
 		}
-		for k in old_len .. t.a.children.len {
-			cid := t.a.children[k]
-			if int(cid) >= base_nodes {
-				t.a.children[k] = flat.NodeId(int(cid) + int(node_shift))
+		// Fused copy+relocate: under the shared-base path compaction copies
+		// leftward within one array, so the forward pass reads ahead of its own
+		// writes; one streamed pass replaces the former memmove + fixup pass.
+		for j in 0 .. new_children {
+			cid := w.a.children[base_children + j]
+			t.a.children[old_len + j] = if int(cid) >= base_nodes {
+				flat.NodeId(int(cid) + int(node_shift))
+			} else {
+				cid
 			}
 		}
 	}
@@ -3158,18 +3329,26 @@ fn (mut t Transformer) merge_worker(w &Transformer, items []FnWorkItem, base_nod
 		nodes_old_len := t.a.nodes.len
 		unsafe {
 			t.a.nodes.grow_len(new_nodes)
-			vmemmove(&t.a.nodes[nodes_old_len], &w.a.nodes[base_nodes],
-				new_nodes * int(sizeof(flat.Node)))
 		}
-		for k in nodes_old_len .. t.a.nodes.len {
-			if clear_node_caches {
-				t.clear_typechecker_node_cache(k)
+		if clear_node_caches {
+			// The merged ids form one contiguous range; clearing it with range
+			// fills beats a branchy per-node clear (this runs for every merged
+			// node of every worker).
+			t.clear_typechecker_node_cache_range(nodes_old_len, t.a.nodes.len)
+		}
+		clone_worker_nodes := w.worker_scope != unsafe { nil } && !t.retain_worker_results
+			&& t.stage_scope == unsafe { nil }
+		// Fused copy+relocate, same leftward-overlap argument as the children
+		// block above.
+		for j in 0 .. new_nodes {
+			node := w.a.nodes[base_nodes + j]
+			k := nodes_old_len + j
+			t.a.nodes[k] = if node.children_start >= base_children {
+				node.with_shifted_children(child_shift)
+			} else {
+				node
 			}
-			if t.a.nodes[k].children_start >= base_children {
-				t.a.nodes[k] = t.a.nodes[k].with_shifted_children(child_shift)
-			}
-			if w.worker_scope != unsafe { nil } && !t.retain_worker_results
-				&& t.stage_scope == unsafe { nil } {
+			if clone_worker_nodes {
 				t.clone_scoped_worker_node(k, w.worker_scope)
 			}
 		}
@@ -3364,6 +3543,66 @@ fn (mut t Transformer) record_refined_node_type(idx int, typ string) {
 		}
 	}
 	t.refined_node_types[idx] = typ
+}
+
+// clear_typechecker_node_cache_range is clear_typechecker_node_cache for a
+// contiguous id range: the bool sets become memsets and the range-level guards
+// replace one branch per node per table.
+fn (mut t Transformer) clear_typechecker_node_cache_range(start int, end int) {
+	if isnil(t.tc) || start >= end || start < 0 {
+		return
+	}
+	call_end := if end < t.tc.resolved_call_set.len { end } else { t.tc.resolved_call_set.len }
+	if start < call_end {
+		unsafe {
+			vmemset(&t.tc.resolved_call_set[start], 0, call_end - start)
+		}
+		for k in start .. call_end {
+			t.tc.resolved_call_names[k] = ''
+		}
+	}
+	fn_value_end := if end < t.tc.resolved_fn_value_set.len {
+		end
+	} else {
+		t.tc.resolved_fn_value_set.len
+	}
+	if start < fn_value_end {
+		unsafe {
+			vmemset(&t.tc.resolved_fn_value_set[start], 0, fn_value_end - start)
+		}
+		for k in start .. fn_value_end {
+			t.tc.resolved_fn_value_names[k] = ''
+		}
+	}
+	expr_end := if end < t.tc.expr_type_set.len { end } else { t.tc.expr_type_set.len }
+	if start < expr_end {
+		unsafe {
+			vmemset(&t.tc.expr_type_set[start], 0, expr_end - start)
+		}
+	}
+	stmt_end := if end < t.tc.statement_nodes.len { end } else { t.tc.statement_nodes.len }
+	if start < stmt_end {
+		unsafe {
+			vmemset(&t.tc.statement_nodes[start], 0, stmt_end - start)
+		}
+	}
+	if t.tc.sparse_resolved_call_names.len > 0 || t.tc.sparse_resolved_fn_values.len > 0
+		|| t.tc.sparse_expr_type_values.len > 0 || t.tc.sparse_statement_nodes.len > 0 {
+		for k in start .. end {
+			if t.tc.sparse_resolved_call_names.len > 0 {
+				t.tc.sparse_resolved_call_names.delete(k)
+			}
+			if t.tc.sparse_resolved_fn_values.len > 0 {
+				t.tc.sparse_resolved_fn_values.delete(k)
+			}
+			if t.tc.sparse_expr_type_values.len > 0 {
+				t.tc.sparse_expr_type_values.delete(k)
+			}
+			if t.tc.sparse_statement_nodes.len > 0 {
+				t.tc.sparse_statement_nodes.delete(k)
+			}
+		}
+	}
 }
 
 fn (mut t Transformer) clear_typechecker_node_cache(idx int) {
@@ -14957,9 +15196,9 @@ fn (mut t Transformer) transform_typeof_expr_mode(id flat.NodeId, node flat.Node
 			if expr.value == t.cur_fn_variadic_param && typ.starts_with('[]') {
 				typ = '...' + typ[2..]
 			}
-			if typ.contains('typeof(') {
+			if types.type_text_contains_typeof(typ) {
 				resolved_local := t.var_type(expr.value)
-				if resolved_local.len > 0 && !resolved_local.contains('typeof(') {
+				if resolved_local.len > 0 && !types.type_text_contains_typeof(resolved_local) {
 					typ = resolved_local
 				}
 			}
@@ -14987,7 +15226,7 @@ fn (mut t Transformer) transform_typeof_expr_mode(id flat.NodeId, node flat.Node
 	if typ.len == 0 {
 		typ = 'unknown'
 	}
-	if typ.contains('typeof(') {
+	if types.type_text_contains_typeof(typ) {
 		typ = t.resolve_typeof_type_text(typ)
 	}
 	parsed_type := if !isnil(t.tc) { t.tc.parse_type(typ) } else { types.Type(types.void_) }
@@ -15340,9 +15579,9 @@ fn (t &Transformer) typeof_type_name(node flat.Node) string {
 			if expr.value == t.cur_fn_variadic_param && typ.starts_with('[]') {
 				typ = '...' + typ[2..]
 			}
-			if typ.contains('typeof(') {
+			if types.type_text_contains_typeof(typ) {
 				resolved_local := t.var_type(expr.value)
-				if resolved_local.len > 0 && !resolved_local.contains('typeof(') {
+				if resolved_local.len > 0 && !types.type_text_contains_typeof(resolved_local) {
 					typ = resolved_local
 				}
 			}
@@ -15360,7 +15599,7 @@ fn (t &Transformer) typeof_type_name(node flat.Node) string {
 	if typ.len == 0 {
 		typ = t.resolve_expr_type(expr_id)
 	}
-	if typ.contains('typeof(') {
+	if types.type_text_contains_typeof(typ) {
 		typ = t.resolve_typeof_type_text(typ)
 	}
 	return typ

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -708,13 +708,13 @@ fn transform_with_used_opt_config_scoped_workers_checked_impl(mut a flat.FlatAst
 		t.scoped_base_nodes = t.a.nodes.len
 	}
 	t.prepare()
-	eprintln('  [ttime] new+prepare        ${f64(impl_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+	t.timing_profile('  [ttime] new+prepare        ${f64(impl_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 	impl_sw.restart()
 	t.cache_comptime_param_reflection_metadata()
 	if want_parallel {
 		reserve_parallel_transform_ast(mut a, skip_generics)
 	}
-	eprintln('  [ttime] reflect+reserve    ${f64(impl_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+	t.timing_profile('  [ttime] reflect+reserve    ${f64(impl_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 	impl_sw.restart()
 	base_node_count := t.a.nodes.len
 	if scope_parallel_workers {
@@ -735,16 +735,16 @@ fn transform_with_used_opt_config_scoped_workers_checked_impl(mut a flat.FlatAst
 		t.new_call_names_from_used_fn_bodies(used_fns, t.a.nodes.len)
 	}
 	late_names << newly_used_fn_names(used_fns, t.used_fns)
-	eprintln('  [ttime] late names         ${f64(impl_sw.elapsed().microseconds()) / 1000.0:7.2f} ms (n: ${late_names.len})')
+	t.timing_profile('  [ttime] late names         ${f64(impl_sw.elapsed().microseconds()) / 1000.0:7.2f} ms (n: ${late_names.len})')
 	impl_sw.restart()
 	t.transform_late_used_fn_bodies(late_names, base_node_count)
-	eprintln('  [ttime] late bodies        ${f64(impl_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+	t.timing_profile('  [ttime] late bodies        ${f64(impl_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 	impl_sw.restart()
 	t.run_auto_str_synthesis_rounds(base_node_count)
 	t.run_sum_eq_synthesis_rounds(base_node_count)
 	t.apply_ignored_comptime_for_nodes()
 	t.retain_current_worker_scope_all()
-	eprintln('  [ttime] sum_eq+tail        ${f64(impl_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+	t.timing_profile('  [ttime] sum_eq+tail        ${f64(impl_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 	mut owned_base_nodes := t.scoped_owned_base_nodes.keys()
 	owned_base_nodes << t.scoped_owned_base_log
 	return t.used_fns, was_parallel, t.monomorph_errors, owned_base_nodes, t.retained_worker_regions
@@ -977,6 +977,10 @@ fn newly_used_fn_names(before map[string]bool, after map[string]bool) []string {
 }
 
 fn (t &Transformer) monomorph_profile(message string) {
+	t.timing_profile(message)
+}
+
+fn (t &Transformer) timing_profile(message string) {
 	if !isnil(t.tc) && t.tc.verbose {
 		eprintln(message)
 	}
@@ -1249,14 +1253,14 @@ fn (mut t Transformer) prepare() {
 	}
 	mut psw := time.new_stopwatch()
 	t.collect_types()
-	eprintln('  [ttime]   prep collect_types ${f64(psw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+	t.timing_profile('  [ttime]   prep collect_types ${f64(psw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 	psw.restart()
 	t.rebuild_embedded_fields_index()
 	t.prepare_runtime_type_indexes()
 	t.rebuild_struct_short_name_index()
 	t.collect_multi_return_fn_ret_types()
 	t.collect_const_suffixes()
-	eprintln('  [ttime]   prep small idx     ${f64(psw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+	t.timing_profile('  [ttime]   prep small idx     ${f64(psw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 	psw.restart()
 	t.collect_alias_methods()
 	t.rebuild_receiver_method_suffix_index()
@@ -1264,7 +1268,7 @@ fn (mut t Transformer) prepare() {
 	t.build_generic_alias_name_index()
 	t.build_local_decl_index()
 	t.build_struct_field_decl_metas_cache()
-	eprintln('  [ttime]   prep suffix+decl   ${f64(psw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+	t.timing_profile('  [ttime]   prep suffix+decl   ${f64(psw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 	psw.restart()
 	// Enable the alias cache only now that the type maps are fully populated.
 	// During collection those maps are incomplete, so caching there would poison
@@ -2593,25 +2597,25 @@ fn (mut t Transformer) transform_all_dispatch(want_parallel bool) bool {
 	// declarations and mutates the shared TypeChecker). Collect the remaining,
 	// closure-free functions as parallelizable work items.
 	literal_decls := t.collect_literal_fn_decls(t.a.nodes.len)
-	eprintln('  [ttime] literal_decls      ${f64(ttsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+	t.timing_profile('  [ttime] literal_decls      ${f64(ttsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 	ttsw.restart()
 	pure_items := t.transform_serial_then_collect_pure(literal_decls)
-	eprintln('  [ttime] serial+collect     ${f64(ttsw.elapsed().microseconds()) / 1000.0:7.2f} ms (items: ${pure_items.len})')
+	t.timing_profile('  [ttime] serial+collect     ${f64(ttsw.elapsed().microseconds()) / 1000.0:7.2f} ms (items: ${pure_items.len})')
 	ttsw.restart()
 	base_nodes := t.a.nodes.len
 	base_children := t.a.children.len
 	was_parallel := t.run_parallel_transform(pure_items, base_nodes, base_children)
-	eprintln('  [ttime] parallel run       ${f64(ttsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+	t.timing_profile('  [ttime] parallel run       ${f64(ttsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 	ttsw.restart()
 	// Aggregate-interpolating functions were held back from the parallel regions
 	// (their inline autostr expansion overflows cost-proportional worker slots);
 	// lower them now against the freely growable master arena.
 	t.transform_deferred_str_items()
-	eprintln('  [ttime] deferred str       ${f64(ttsw.elapsed().microseconds()) / 1000.0:7.2f} ms (items: ${t.deferred_str_count})')
+	t.timing_profile('  [ttime] deferred str       ${f64(ttsw.elapsed().microseconds()) / 1000.0:7.2f} ms (items: ${t.deferred_str_count})')
 	ttsw.restart()
 	if !has_entry_main {
 		t.transform_top_level_user_stmts()
-		eprintln('  [ttime] top_level_stmts    ${f64(ttsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+		t.timing_profile('  [ttime] top_level_stmts    ${f64(ttsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 	}
 	return was_parallel
 }
@@ -2752,7 +2756,7 @@ fn (mut t Transformer) transform_serial_then_collect_pure(literal_decls []int) [
 			const_ms += f64(scsw.elapsed().microseconds()) / 1000.0
 		}
 	}
-	eprintln('  [ttime]   sc consts ${const_ms:.2f} ms, closures ${lit_ms:.2f} ms')
+	t.timing_profile('  [ttime]   sc consts ${const_ms:.2f} ms, closures ${lit_ms:.2f} ms')
 	return pure
 }
 

--- a/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
@@ -5,6 +5,7 @@ import runtime
 import sync
 import time
 import v3.flat
+import v3.types
 import v3.workers
 
 // Parallel function-body transform. Each worker transforms a disjoint set of
@@ -46,6 +47,7 @@ $if !windows {
 		a := unsafe { &SharedChunkArgs(arg) }
 		mut w := unsafe { &Transformer(a.worker) }
 		items := unsafe { &[]FnWorkItem(a.items_ptr) }
+		mut csw := time.new_stopwatch()
 		if w.scope_parallel_workers && (!a.is_master || w.retain_worker_results) {
 			max_batches := if a.is_master {
 				scoped_transform_master_batches
@@ -56,6 +58,13 @@ $if !windows {
 		} else {
 			w.transform_pure_items_serial(*items)
 		}
+		$if v3_ttime ? {
+			mut cost := i64(0)
+			for it in *items {
+				cost += i64(it.cost) + 1
+			}
+			eprintln('  [ttime]     chunk items=${items.len:4} cost=${cost:8} master=${a.is_master} ${f64(csw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+		}
 		return unsafe { nil }
 	}
 }
@@ -65,6 +74,402 @@ struct SharedChunkArgs {
 	worker    voidptr // &Transformer
 	items_ptr voidptr // &[]FnWorkItem
 	is_master bool
+}
+
+// ScopedTextScanArgs is the payload for one scoped-text flag-scan worker.
+struct ScopedTextScanArgs {
+	a     &flat.FlatAst = unsafe { nil }
+	scope voidptr
+	start int
+	end   int
+	flags voidptr // &u8 base of the per-node flag array
+}
+
+// node_has_scoped_text reports whether any text payload of `node` lives in
+// `scope`'s arena, i.e. whether canonicalization/promotion would rewrite it.
+@[inline]
+fn node_has_scoped_text(node &flat.Node, scope voidptr) bool {
+	if node.value.len > 0 && transform_scope_owns(scope, node.value.str) {
+		return true
+	}
+	if node.typ.len > 0 && transform_scope_owns(scope, node.typ.str) {
+		return true
+	}
+	if isnil(node.payload) {
+		return false
+	}
+	if transform_scope_owns(scope, node.payload) {
+		return true
+	}
+	params := node.payload.generic_params
+	if params.len == 0 {
+		return false
+	}
+	if transform_scope_owns(scope, params.data) {
+		return true
+	}
+	for param in params {
+		if param.len > 0 && transform_scope_owns(scope, param.str) {
+			return true
+		}
+	}
+	return false
+}
+
+$if !windows {
+	// scoped_text_scan_thread flags this worker's node range. Pure reads plus
+	// byte writes into a disjoint flag range: no allocations, so it is safe to
+	// run on pool threads regardless of their arena state.
+	fn scoped_text_scan_thread(arg voidptr) voidptr {
+		a := unsafe { &ScopedTextScanArgs(arg) }
+		flags := unsafe { &u8(a.flags) }
+		for idx in a.start .. a.end {
+			node := unsafe { &a.a.nodes[idx] }
+			if node_has_scoped_text(node, a.scope) {
+				unsafe {
+					flags[idx] = 1
+				}
+			}
+		}
+		return unsafe { nil }
+	}
+}
+
+// TopLevelKindScanArgs is the payload for one top-level-kind flag-scan worker.
+struct TopLevelKindScanArgs {
+	a     &flat.FlatAst = unsafe { nil }
+	start int
+	end   int
+	flags voidptr // &u8 base of the per-node flag array (index 0 == node `base`)
+	base  int
+}
+
+$if !windows {
+	// top_level_kind_scan_thread flags file/module nodes and generic-candidate
+	// fn decls in this worker's range. Pure reads plus byte writes into a
+	// disjoint flag range: no allocations, so it is safe on pool threads in any
+	// arena state. Candidate detection uses only the state-free placeholder
+	// prescreen, a strict superset of generic_fn_decl_needs_erasure_scan.
+	fn top_level_kind_scan_thread(arg voidptr) voidptr {
+		a := unsafe { &TopLevelKindScanArgs(arg) }
+		flags := unsafe { &u8(a.flags) }
+		for i in a.start .. a.end {
+			node := unsafe { &a.a.nodes[i] }
+			if node.kind == .file || node.kind == .module_decl {
+				unsafe {
+					flags[i - a.base] = 1
+				}
+			} else if node.kind == .fn_decl && fn_decl_generic_candidate_prescreen(a.a, node) {
+				unsafe {
+					flags[i - a.base] = 1
+				}
+			}
+		}
+		return unsafe { nil }
+	}
+}
+
+// fn_decl_generic_candidate_prescreen is the allocation-free superset filter
+// for generic_fn_decl_needs_erasure_scan: explicit generic params, or a
+// possible placeholder in the signature texts. Fn decls failing it can never
+// need erasure.
+@[inline]
+fn fn_decl_generic_candidate_prescreen(a &flat.FlatAst, node &flat.Node) bool {
+	if !isnil(node.payload) && node.payload.generic_params.len > 0 {
+		return true
+	}
+	if generic_placeholder_prescreen(node.typ) || generic_placeholder_prescreen(node.value) {
+		return true
+	}
+	for i in 0 .. node.children_count {
+		child := a.child_node(node, i)
+		if child.kind == .param && generic_placeholder_prescreen(child.typ) {
+			return true
+		}
+	}
+	return false
+}
+
+// scan_top_level_kind_flags_parallel fills `flags` (one byte per node id in
+// [base, base + flags.len)) for file/module/fn-decl nodes, using the shared
+// worker pool. Returns false when no pool is available so the caller can walk
+// the range serially instead.
+fn scan_top_level_kind_flags_parallel(a &flat.FlatAst, base int, mut flags []u8) bool {
+	$if windows {
+		return false
+	} $else {
+		n := flags.len
+		if isnil(a.worker_pool) || n < 65536 || base < 0 || base + n > a.nodes.len {
+			return false
+		}
+		n_jobs := a.worker_pool.size() + 1
+		chunk := (n + n_jobs - 1) / n_jobs
+		mut args := []TopLevelKindScanArgs{cap: n_jobs}
+		for ji in 0 .. n_jobs {
+			start := base + ji * chunk
+			mut end := start + chunk
+			if end > base + n {
+				end = base + n
+			}
+			if start >= end {
+				break
+			}
+			args << TopLevelKindScanArgs{
+				a:     a
+				start: start
+				end:   end
+				flags: flags.data
+				base:  base
+			}
+		}
+		mut tasks := []workers.Task{cap: args.len}
+		for ji in 0 .. args.len {
+			tasks << workers.Task{
+				run:        top_level_kind_scan_thread
+				arg:        unsafe { voidptr(&args[ji]) }
+				force_sync: ji == 0
+			}
+		}
+		a.worker_pool.run(tasks)
+		return true
+	}
+}
+
+// ScopedTextPromoteArgs is the payload for one fused text-promotion worker.
+struct ScopedTextPromoteArgs {
+	a     &flat.FlatAst = unsafe { nil }
+	scope voidptr
+	start int
+	end   int
+}
+
+$if !windows {
+	// scoped_text_promote_thread publishes scope-owned node texts for this
+	// worker's id range: text-table hits reuse the canonical entry (read-only
+	// map probe), misses clone into the worker's persistent arena. Node slot
+	// writes are range-disjoint, so no synchronization is needed.
+	fn scoped_text_promote_thread(arg voidptr) voidptr {
+		a := unsafe { &ScopedTextPromoteArgs(arg) }
+		mut ast := unsafe { &flat.FlatAst(voidptr(a.a)) }
+		for idx in a.start .. a.end {
+			mut node := unsafe { &ast.nodes[idx] }
+			if node.value.len > 0 && transform_scope_owns(a.scope, node.value.str) {
+				node.value = promote_scoped_text_read_only(ast, node.value)
+			}
+			if node.typ.len > 0 && transform_scope_owns(a.scope, node.typ.str) {
+				node.typ = promote_scoped_text_read_only(ast, node.typ)
+			}
+			if isnil(node.payload) {
+				continue
+			}
+			params := node.payload.generic_params
+			if params.len == 0 {
+				continue
+			}
+			mut needs := transform_scope_owns(a.scope, node.payload)
+				|| transform_scope_owns(a.scope, params.data)
+			if !needs {
+				for param in params {
+					if param.len > 0 && transform_scope_owns(a.scope, param.str) {
+						needs = true
+						break
+					}
+				}
+			}
+			if !needs {
+				continue
+			}
+			mut promoted := []string{cap: params.len}
+			for param in params {
+				if param.len > 0 && transform_scope_owns(a.scope, param.str) {
+					promoted << promote_scoped_text_read_only(ast, param)
+				} else {
+					promoted << param
+				}
+			}
+			node.set_generic_params(promoted)
+		}
+		return unsafe { nil }
+	}
+
+	fn promote_scoped_text_read_only(a &flat.FlatAst, value string) string {
+		if id := a.text_ids[value] {
+			return a.text_values[int(id) - 1]
+		}
+		return value.clone()
+	}
+}
+
+// promote_scoped_texts_parallel publishes every transform-scope-owned node
+// text over the shared worker pool, replacing the serial canonicalize +
+// promote pair for builds without retained regions. Returns false when no pool
+// is available so the caller can run the serial walks instead.
+pub fn promote_scoped_texts_parallel(mut a flat.FlatAst, scope voidptr) bool {
+	$if windows {
+		return false
+	} $else {
+		n := a.nodes.len
+		if isnil(a.worker_pool) || n < 65536 {
+			return false
+		}
+		n_jobs := a.worker_pool.size() + 1
+		chunk := (n + n_jobs - 1) / n_jobs
+		mut args := []ScopedTextPromoteArgs{cap: n_jobs}
+		for ji in 0 .. n_jobs {
+			start := ji * chunk
+			mut end := start + chunk
+			if end > n {
+				end = n
+			}
+			if start >= end {
+				break
+			}
+			args << ScopedTextPromoteArgs{
+				a:     a
+				scope: scope
+				start: start
+				end:   end
+			}
+		}
+		mut tasks := []workers.Task{cap: args.len}
+		for ji in 0 .. args.len {
+			tasks << workers.Task{
+				run:        scoped_text_promote_thread
+				arg:        unsafe { voidptr(&args[ji]) }
+				force_sync: ji == 0
+			}
+		}
+		a.worker_pool.run(tasks)
+		return true
+	}
+}
+
+// CheckerCachePromoteArgs is the payload for one checker-cache promote worker.
+struct CheckerCachePromoteArgs {
+	tc              voidptr // &types.TypeChecker
+	scope           voidptr
+	start           int
+	end             int
+	generated_start int
+}
+
+$if !windows {
+	// checker_cache_promote_thread publishes scope-owned resolved-call /
+	// fn-value strings and clones generated-range expression types for this
+	// worker's id range. Slot writes are range-disjoint; clones allocate in the
+	// worker's persistent arena, which is never released.
+	fn checker_cache_promote_thread(arg voidptr) voidptr {
+		a := unsafe { &CheckerCachePromoteArgs(arg) }
+		mut tc := unsafe { &types.TypeChecker(a.tc) }
+		for idx in a.start .. a.end {
+			if idx < tc.resolved_call_set.len && tc.resolved_call_set[idx] {
+				name := tc.resolved_call_names[idx]
+				if name.len > 0 && transform_scope_owns(a.scope, name.str) {
+					tc.resolved_call_names[idx] = name.clone()
+				}
+			}
+			if idx < tc.resolved_fn_value_set.len && tc.resolved_fn_value_set[idx] {
+				name := tc.resolved_fn_value_names[idx]
+				if name.len > 0 && transform_scope_owns(a.scope, name.str) {
+					tc.resolved_fn_value_names[idx] = name.clone()
+				}
+			}
+			if idx >= a.generated_start && idx < tc.expr_type_set.len && tc.expr_type_set[idx]
+				&& idx < tc.expr_type_values.len {
+				tc.expr_type_values[idx] = types.clone_owned_type(tc.expr_type_values[idx])
+			}
+		}
+		return unsafe { nil }
+	}
+}
+
+// promote_scoped_checker_node_caches_parallel runs the per-id loops of the
+// checker node-cache promotion over the shared worker pool. Returns false when
+// no pool is available so the caller can run them serially instead.
+pub fn promote_scoped_checker_node_caches_parallel(mut tc types.TypeChecker, a &flat.FlatAst, scope voidptr, generated_start int) bool {
+	$if windows {
+		return false
+	} $else {
+		n := tc.resolved_call_names.len
+		if isnil(a.worker_pool) || n < 65536 || os.getenv('V3_NO_PAR_CHECKER_PROMOTE') != '' {
+			return false
+		}
+		n_jobs := a.worker_pool.size() + 1
+		chunk := (n + n_jobs - 1) / n_jobs
+		mut args := []CheckerCachePromoteArgs{cap: n_jobs}
+		for ji in 0 .. n_jobs {
+			start := ji * chunk
+			mut end := start + chunk
+			if end > n {
+				end = n
+			}
+			if start >= end {
+				break
+			}
+			args << CheckerCachePromoteArgs{
+				tc:              voidptr(tc)
+				scope:           scope
+				start:           start
+				end:             end
+				generated_start: generated_start
+			}
+		}
+		mut tasks := []workers.Task{cap: args.len}
+		for ji in 0 .. args.len {
+			tasks << workers.Task{
+				run:        checker_cache_promote_thread
+				arg:        unsafe { voidptr(&args[ji]) }
+				force_sync: ji == 0
+			}
+		}
+		a.worker_pool.run(tasks)
+		return true
+	}
+}
+
+// scan_scoped_text_flags_parallel fills `flags` (one byte per node id in
+// [0, flags.len)) for nodes whose text is owned by `scope`, using the shared
+// worker pool. Returns false when no pool is available so the caller can walk
+// every node serially instead.
+pub fn scan_scoped_text_flags_parallel(a &flat.FlatAst, scope voidptr, mut flags []u8) bool {
+	$if windows {
+		return false
+	} $else {
+		n := flags.len
+		if isnil(a.worker_pool) || n < 65536 {
+			return false
+		}
+		n_jobs := a.worker_pool.size() + 1
+		chunk := (n + n_jobs - 1) / n_jobs
+		mut args := []ScopedTextScanArgs{cap: n_jobs}
+		for ji in 0 .. n_jobs {
+			start := ji * chunk
+			mut end := start + chunk
+			if end > n {
+				end = n
+			}
+			if start >= end {
+				break
+			}
+			args << ScopedTextScanArgs{
+				a:     a
+				scope: scope
+				start: start
+				end:   end
+				flags: flags.data
+			}
+		}
+		mut tasks := []workers.Task{cap: args.len}
+		for ji in 0 .. args.len {
+			tasks << workers.Task{
+				run:        scoped_text_scan_thread
+				arg:        unsafe { voidptr(&args[ji]) }
+				force_sync: ji == 0
+			}
+		}
+		a.worker_pool.run(tasks)
+		return true
+	}
 }
 
 struct MonomorphChunkArgs {
@@ -396,6 +801,7 @@ fn (mut t Transformer) run_parallel_monomorphize_specs(specs []PendingGenericFnS
 				t.a.nodes.flags.set(.nofree)
 			}
 			t.a.nodes = nodes
+			t.a.file_node_ids = []int{}
 		}
 		if !merge_in_place && t.a.children.data == original_children_data {
 			children := clone_monomorph_child_region(t.a.children, base_children, base_children,
@@ -722,6 +1128,7 @@ fn (mut t Transformer) detach_monomorph_worker_region(base_nodes int, base_child
 		t.a.children.flags.set(.nofree)
 	}
 	t.a.nodes = nodes
+	t.a.file_node_ids = []int{}
 	t.a.children = children
 }
 
@@ -908,17 +1315,40 @@ fn (mut t Transformer) promote_scoped_result_text(value string) string {
 	if value.len == 0 {
 		return ''
 	}
+	// Shallow string copies share `.str`, so one batch promotes the same
+	// instance thousands of times: a pointer probe is much cheaper than the
+	// content-hash table lookups below. Only valid within one absorb pass
+	// (absorb_scoped_batch bumps the generation before scope addresses can be
+	// reused).
+	mut cache := t.promote_text_cache
+	use_cache := !isnil(cache) && cache.active
+	mut slot := 0
+	if use_cache {
+		slot = int((u64(voidptr(value.str)) >> 4) & 2047)
+		// The length check guards against distinct strings sharing one base
+		// pointer (unsafe zero-copy slices).
+		if cache.generations[slot] == cache.generation && cache.ptrs[slot] == voidptr(value.str)
+			&& cache.results[slot].len == value.len {
+			return cache.results[slot]
+		}
+	}
 	// Scoped workers only read the compilation text table. Reuse its canonical
 	// strings before adding a worker-local entry; generic specialization clones
 	// otherwise retain another copy of almost every source identifier and type.
+	mut canonical := ''
 	if id := t.a.text_ids[value] {
-		return t.a.text_values[int(id) - 1]
+		canonical = t.a.text_values[int(id) - 1]
+	} else if promoted := t.scoped_promoted_texts[value] {
+		canonical = promoted
+	} else {
+		canonical = value.clone()
+		t.scoped_promoted_texts[canonical] = canonical
 	}
-	if canonical := t.scoped_promoted_texts[value] {
-		return canonical
+	if use_cache {
+		cache.ptrs[slot] = voidptr(value.str)
+		cache.generations[slot] = cache.generation
+		cache.results[slot] = canonical
 	}
-	canonical := value.clone()
-	t.scoped_promoted_texts[canonical] = canonical
 	return canonical
 }
 
@@ -930,6 +1360,7 @@ fn (mut t Transformer) promote_scoped_ast_storage(scope voidptr) {
 		mut nodes := []flat.Node{cap: t.a.nodes.len + t.a.nodes.len / 4 + 1024}
 		nodes << t.a.nodes
 		t.a.nodes = nodes
+		t.a.file_node_ids = []int{}
 	}
 	if transform_scope_owns(scope, t.a.children.data) {
 		mut children := []flat.NodeId{cap: t.a.children.len + t.a.children.len / 4 + 1024}
@@ -941,6 +1372,10 @@ fn (mut t Transformer) promote_scoped_ast_storage(scope voidptr) {
 // absorb_scoped_batch publishes one batch's observable state into the helper's
 // result arena before its large scratch arena is released.
 fn (mut t Transformer) absorb_scoped_batch(batch &Transformer, scope voidptr, new_node_start int) {
+	t.begin_promote_text_window()
+	defer {
+		t.end_promote_text_window()
+	}
 	if t.skip_generics {
 		// Non-generic workers mutate only newly appended nodes and slots recorded by
 		// the setter log. This avoids a full, growing-AST scan after every batch.
@@ -1242,7 +1677,9 @@ fn (mut t Transformer) run_parallel_transform(items []FnWorkItem, base_nodes int
 		// Workers need declaration signatures while lowering calls. Snapshot them
 		// before any worker can rewrite a shared-base fn_decl; lazily scanning or
 		// reading declarations inside workers can otherwise observe a torn node.
+		mut prep_sw := time.new_stopwatch()
 		t.prepare_parallel_call_param_types()
+		eprintln('  [ttime]   prep param types ${f64(prep_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 		// Clone-free shared-base path: needs the checker's top-level index for
 		// exact per-item subtree ranges, and skip_generics (the generic passes
 		// scan and mutate arbitrary AST regions, which the shared design forbids).
@@ -1373,6 +1810,7 @@ fn (mut t Transformer) run_parallel_transform_shared(items []FnWorkItem, base_no
 		t.transform_pure_items_serial(items)
 		return false
 	} $else {
+		mut ttsw := time.new_stopwatch()
 		t.tc.freeze_type_cache_for_forks()
 		mut chunks := split_work_items_ex(items, n_jobs, false)
 		chunk_count := chunks.len
@@ -1449,7 +1887,11 @@ fn (mut t Transformer) run_parallel_transform_shared(items []FnWorkItem, base_no
 			}
 		}
 		transform_worker_scope_leave(setup_scope)
+		eprintln('  [ttime]   shared setup     ${f64(ttsw.elapsed().microseconds()) / 1000.0:7.2f} ms (chunks: ${chunk_count}, jobs: ${n_jobs})')
+		ttsw.restart()
 		any_started := t.a.worker_pool.run(tasks)
+		eprintln('  [ttime]   shared pool.run  ${f64(ttsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+		ttsw.restart()
 		unsafe {
 			t.a.nodes.cap = orig_nodes_cap
 			t.a.nodes.flags.clear(.nogrow)
@@ -1478,12 +1920,19 @@ fn (mut t Transformer) run_parallel_transform_shared(items []FnWorkItem, base_no
 		// node numbering). merge_worker treats the region start exactly like a
 		// clone's base offset; compaction always moves content left, so the
 		// copies never collide with unmerged regions.
+		mut merge_used_ms := f64(0)
+		mut merge_core_ms := f64(0)
+		mut mwsw := time.new_stopwatch()
 		for ci in 0 .. thread_count {
 			ww := unsafe { &Transformer(args[ci + 1].worker) }
+			mwsw.restart()
 			t.merge_worker_used_fns(ww)
+			merge_used_ms += f64(mwsw.elapsed().microseconds()) / 1000.0
 			deferred_start := t.deferred_base_writes.len
 			merged_node_start := t.a.nodes.len
+			mwsw.restart()
 			t.merge_worker(ww, chunks[ci + 1], node_starts[ci + 1], child_starts[ci + 1], true)
+			merge_core_ms += f64(mwsw.elapsed().microseconds()) / 1000.0
 			if ww.worker_scope != unsafe { nil } && !t.retain_worker_results {
 				t.clone_deferred_worker_writes_from(deferred_start)
 				transform_worker_scope_free(ww.worker_scope)
@@ -1504,6 +1953,8 @@ fn (mut t Transformer) run_parallel_transform_shared(items []FnWorkItem, base_no
 				}
 			}
 		}
+		eprintln('  [ttime]   shared merge     ${f64(ttsw.elapsed().microseconds()) / 1000.0:7.2f} ms (used: ${merge_used_ms:.2f}, core: ${merge_core_ms:.2f})')
+		ttsw.restart()
 		if t.retain_worker_results {
 			t.clone_sum_eq_types_owned()
 			t.clone_auto_str_types_owned()
@@ -1525,6 +1976,7 @@ fn (mut t Transformer) run_parallel_transform_shared(items []FnWorkItem, base_no
 		}
 		t.tc.unfreeze_type_cache_after_forks()
 		transform_worker_scope_free(setup_scope)
+		eprintln('  [ttime]   shared tail      ${f64(ttsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 		return any_started
 	}
 }

--- a/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
@@ -63,7 +63,7 @@ $if !windows {
 			for it in *items {
 				cost += i64(it.cost) + 1
 			}
-			eprintln('  [ttime]     chunk items=${items.len:4} cost=${cost:8} master=${a.is_master} ${f64(csw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+			w.timing_profile('  [ttime]     chunk items=${items.len:4} cost=${cost:8} master=${a.is_master} ${f64(csw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 		}
 		return unsafe { nil }
 	}
@@ -1679,7 +1679,7 @@ fn (mut t Transformer) run_parallel_transform(items []FnWorkItem, base_nodes int
 		// reading declarations inside workers can otherwise observe a torn node.
 		mut prep_sw := time.new_stopwatch()
 		t.prepare_parallel_call_param_types()
-		eprintln('  [ttime]   prep param types ${f64(prep_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+		t.timing_profile('  [ttime]   prep param types ${f64(prep_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 		// Clone-free shared-base path: needs the checker's top-level index for
 		// exact per-item subtree ranges, and skip_generics (the generic passes
 		// scan and mutate arbitrary AST regions, which the shared design forbids).
@@ -1887,10 +1887,10 @@ fn (mut t Transformer) run_parallel_transform_shared(items []FnWorkItem, base_no
 			}
 		}
 		transform_worker_scope_leave(setup_scope)
-		eprintln('  [ttime]   shared setup     ${f64(ttsw.elapsed().microseconds()) / 1000.0:7.2f} ms (chunks: ${chunk_count}, jobs: ${n_jobs})')
+		t.timing_profile('  [ttime]   shared setup     ${f64(ttsw.elapsed().microseconds()) / 1000.0:7.2f} ms (chunks: ${chunk_count}, jobs: ${n_jobs})')
 		ttsw.restart()
 		any_started := t.a.worker_pool.run(tasks)
-		eprintln('  [ttime]   shared pool.run  ${f64(ttsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+		t.timing_profile('  [ttime]   shared pool.run  ${f64(ttsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 		ttsw.restart()
 		unsafe {
 			t.a.nodes.cap = orig_nodes_cap
@@ -1953,7 +1953,7 @@ fn (mut t Transformer) run_parallel_transform_shared(items []FnWorkItem, base_no
 				}
 			}
 		}
-		eprintln('  [ttime]   shared merge     ${f64(ttsw.elapsed().microseconds()) / 1000.0:7.2f} ms (used: ${merge_used_ms:.2f}, core: ${merge_core_ms:.2f})')
+		t.timing_profile('  [ttime]   shared merge     ${f64(ttsw.elapsed().microseconds()) / 1000.0:7.2f} ms (used: ${merge_used_ms:.2f}, core: ${merge_core_ms:.2f})')
 		ttsw.restart()
 		if t.retain_worker_results {
 			t.clone_sum_eq_types_owned()
@@ -1976,7 +1976,7 @@ fn (mut t Transformer) run_parallel_transform_shared(items []FnWorkItem, base_no
 		}
 		t.tc.unfreeze_type_cache_after_forks()
 		transform_worker_scope_free(setup_scope)
-		eprintln('  [ttime]   shared tail      ${f64(ttsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+		t.timing_profile('  [ttime]   shared tail      ${f64(ttsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 		return any_started
 	}
 }

--- a/vlib/v3/transform/type_propagation.v
+++ b/vlib/v3/transform/type_propagation.v
@@ -115,7 +115,7 @@ fn decl_type_is_usable(typ string) bool {
 	if typ.len == 0 || typ in ['unknown', 'array', 'map'] || typ.contains('unknown') {
 		return false
 	}
-	if typ.contains('typeof(') {
+	if types.type_text_contains_typeof(typ) {
 		return false
 	}
 	clean := typ.replace(' ', '')
@@ -129,7 +129,7 @@ fn (t &Transformer) checker_expr_type_name(id flat.NodeId) ?string {
 	}
 	if typ := t.tc.expr_type(id) {
 		mut name := t.normalize_type_alias(typ.name())
-		if name.contains('typeof(') {
+		if types.type_text_contains_typeof(name) {
 			name = t.normalize_type_alias(t.tc.resolve_type(id).name())
 		}
 		if decl_type_is_usable(name) && name != 'void' {
@@ -1484,7 +1484,7 @@ fn (t &Transformer) node_type(id flat.NodeId) string {
 				return checked
 			}
 		}
-		if resolved.contains('typeof(') && !isnil(t.tc) {
+		if types.type_text_contains_typeof(resolved) && !isnil(t.tc) {
 			if typ := t.tc.expr_type(id) {
 				name := t.normalize_type_alias(typ.name())
 				if decl_type_is_usable(name) {
@@ -1575,7 +1575,7 @@ fn (t &Transformer) node_type(id flat.NodeId) string {
 		if typ := t.tc.expr_type(id) {
 			name = typ.name()
 		}
-		if name.contains('typeof(') {
+		if types.type_text_contains_typeof(name) {
 			name = t.tc.resolve_type(id).name()
 		}
 		if name.len == 0 || name == 'unknown' {

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -1492,8 +1492,19 @@ fn (mut tc TypeChecker) collect_top_level_idx_fast(a &flat.FlatAst, inactive []b
 		tnode := a.nodes[trailing]
 		mut idx_module := ''
 		for ci in 0 .. tnode.children_count {
-			idx_module = tc.collect_index_child(a, int(a.child(&tnode, ci)), idx_file, idx_module,
-				inactive)
+			decl_idx := int(a.child(&tnode, ci))
+			idx_module = tc.collect_index_child(a, decl_idx, idx_file, idx_module, inactive)
+			// apply_decl_attrs emits module attributes as the node immediately
+			// following the module declaration, outside the trailing file node's
+			// declaration children.
+			attr_idx := decl_idx + 1
+			if decl_idx >= 0 && decl_idx < a.nodes.len && a.nodes[decl_idx].kind == .module_decl
+				&& attr_idx < trailing {
+				attr_node := a.nodes[attr_idx]
+				if attr_node.kind == .directive && attr_node.value == '@attributes:${decl_idx}' {
+					idx_module = tc.collect_index_child(a, attr_idx, idx_file, idx_module, inactive)
+				}
+			}
 		}
 		tc.top_level_idx << trailing
 	}

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -592,6 +592,12 @@ mut:
 	symbols                  &SymbolInterner          = unsafe { nil }
 }
 
+fn (tc &TypeChecker) timing_profile(message string) {
+	if tc.verbose {
+		eprintln(message)
+	}
+}
+
 // enable_scoped_parallel_workers uses disposable prealloc arenas for parallel
 // checker helpers. Ownership checking keeps its existing long-lived workers.
 pub fn (mut tc TypeChecker) enable_scoped_parallel_workers() {
@@ -1586,7 +1592,7 @@ pub fn (mut tc TypeChecker) collect(a &flat.FlatAst) {
 	if file_index_usable(a) {
 		tc.collect_top_level_idx_fast(a, inactive_comptime_nodes)
 		tc.top_level_idx_nodes_len = a.nodes.len
-		eprintln('  [ttime]     ck c idx       ${f64(ck_c_sw.elapsed().microseconds()) / 1000.0:7.2f} ms (fast)')
+		tc.timing_profile('  [ttime]     ck c idx       ${f64(ck_c_sw.elapsed().microseconds()) / 1000.0:7.2f} ms (fast)')
 		tc.collect_after_index(a)
 		return
 	}
@@ -1639,7 +1645,7 @@ pub fn (mut tc TypeChecker) collect(a &flat.FlatAst) {
 		}
 	}
 	tc.top_level_idx_nodes_len = a.nodes.len
-	eprintln('  [ttime]     ck c idx       ${f64(ck_c_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+	tc.timing_profile('  [ttime]     ck c idx       ${f64(ck_c_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 	tc.collect_after_index(a)
 }
 
@@ -1782,7 +1788,7 @@ fn (mut tc TypeChecker) collect_after_index(a &flat.FlatAst) {
 	tc.type_cache.c_name_entries.clear()
 	tc.invalidate_short_type_name_index()
 	tc.check_c_struct_redeclarations(a)
-	eprintln('  [ttime]     ck c pass1     ${f64(ck_c_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+	tc.timing_profile('  [ttime]     ck c pass1     ${f64(ck_c_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 	ck_c_sw.restart()
 	// Pass 2: collect struct fields, function signatures (type aliases now available)
 	// The native backend does not yet preserve large aggregate arguments reliably
@@ -2064,12 +2070,12 @@ fn (mut tc TypeChecker) collect_after_index(a &flat.FlatAst) {
 			else {}
 		}
 	}
-	eprintln('  [ttime]     ck c pass2     ${f64(ck_c_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+	tc.timing_profile('  [ttime]     ck c pass2     ${f64(ck_c_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 	ck_c_sw.restart()
 	tc.resolve_inferred_global_types(a)
 	tc.resolve_const_types()
 	tc.build_const_suffixes()
-	eprintln('  [ttime]     ck c resolve   ${f64(ck_c_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+	tc.timing_profile('  [ttime]     ck c resolve   ${f64(ck_c_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 	if !isnil(tc.visible_mutation_cache) {
 		mut visible_mutation_cache := tc.visible_mutation_cache
 		visible_mutation_cache.decl_index_ready = true

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -1,6 +1,7 @@
 module types
 
 import os
+import time
 import strings
 import v3.flat
 import v3.gen.c.naming
@@ -219,9 +220,10 @@ struct SourceStructFieldDecl {
 @[heap]
 struct VisibleMutationCache {
 mut:
-	decls       map[string]VisibleMutationFnDecl
-	decl_misses map[string]bool
-	results     map[u64]bool
+	decls            map[string]VisibleMutationFnDecl
+	decl_misses      map[string]bool
+	results          map[u64]bool
+	decl_index_ready bool
 }
 
 fn new_visible_mutation_cache() &VisibleMutationCache {
@@ -233,7 +235,7 @@ fn new_visible_mutation_cache() &VisibleMutationCache {
 }
 
 fn push_type_name_candidate(mut candidates []string, name string) {
-	clean := name.trim_space()
+	clean := trimmed_space(name)
 	if clean.len > 0 && clean !in candidates {
 		candidates << clean
 	}
@@ -562,7 +564,15 @@ pub mut:
 	channel_send_or_expr_id int  = -1
 	smartcasts              map[string]Type
 	ownership               &OwnershipState = unsafe { nil }
-	selfhost                bool
+	// See QualifyNameCache: nil unless armed for a static-table phase; forks
+	// must replace it with their own instance (fork_for_parallel_codegen).
+	qualify_name_cache &QualifyNameCache = unsafe { nil }
+	import_info_cache  &ImportInfoCache  = unsafe { nil }
+	// Nanoseconds spent in the ownership checker's per-fn boundary passes.
+	// Only `-d ownership` builds ever write it (every writer lives in
+	// checker_ownership_d_ownership.v), so plain builds report exactly 0.
+	ownership_time_ns i64
+	selfhost          bool
 	// resolution_type_mode is enabled only after semantic checking, while transform
 	// and codegen read synthesized generic-specialization type text. Source annotations
 	// must keep normal module scoping and never enable this fallback.
@@ -850,6 +860,10 @@ pub fn (tc &TypeChecker) fork_for_parallel_codegen() &TypeChecker {
 	forked.visible_mutation_cache = unsafe { nil }
 	forked.inherit_ownership_codegen_metadata_from(tc)
 	forked.set_fresh_type_cache_based_on(tc, tc.type_cache_parse_enabled())
+	if !isnil(tc.qualify_name_cache) {
+		// Never share the memo across threads; each fork owns a private one.
+		forked.qualify_name_cache = &QualifyNameCache{}
+	}
 	return &forked
 }
 
@@ -897,6 +911,12 @@ pub fn (tc &TypeChecker) fork_for_parallel_transform(ast &flat.FlatAst) &TypeChe
 	// Visible-mutation analysis only runs during checking. Do not allocate its
 	// three private maps for the many short-lived transform forks.
 	forked.visible_mutation_cache = unsafe { nil }
+	if check_memos_enabled() {
+		// Per-fork memos; the fork (and these caches) live inside one batch
+		// scope, so cached scratch-arena strings can never outlive their arena.
+		forked.import_info_cache = &ImportInfoCache{}
+		forked.qualify_name_cache = &QualifyNameCache{}
+	}
 	// The transformer propagates call/fn-value resolution metadata onto the call
 	// nodes it clones (Transformer.copy_cloned_resolution). In a worker those
 	// writes must not touch (or grow/realloc) the shared node-indexed arrays
@@ -1422,14 +1442,14 @@ fn split_sum_variant_texts(text string) []string {
 				depth--
 			}
 		} else if ch == `|` && depth == 0 {
-			part := text[start..i].trim_space()
+			part := trimmed_space(text[start..i])
 			if part.len > 0 {
 				parts << part
 			}
 			start = i + 1
 		}
 	}
-	part := text[start..].trim_space()
+	part := trimmed_space(text[start..])
 	if part.len > 0 {
 		parts << part
 	}
@@ -1437,7 +1457,99 @@ fn split_sum_variant_texts(text string) []string {
 }
 
 // collect supports collect handling for TypeChecker.
+fn file_index_usable(a &flat.FlatAst) bool {
+	return a.file_node_ids.len > 0 && a.file_node_ids.len % 2 == 0 && !a.file_index_incomplete
+		&& os.getenv('V3_NO_FILE_IDX') == ''
+}
+
+// collect_top_level_idx_fast rebuilds the top-level declaration index from the
+// parser-recorded (marker, trailing) .file node pairs instead of scanning every
+// AST node: the trailing file node's children are exactly the file's top-level
+// declarations (with comptime_if/block containers descended in child order,
+// which matches ascending node-id order). Output must stay identical to the
+// full scan in collect().
+fn (mut tc TypeChecker) collect_top_level_idx_fast(a &flat.FlatAst, inactive []bool) {
+	if inactive.len > 0 {
+		// The scan records every flagged id (whole inactive subtrees, consumed
+		// by prune_inactive_top_level_comptime).
+		for i, f in inactive {
+			if f {
+				tc.inactive_top_level_node_ids << i
+			}
+		}
+	}
+	for k := 0; k + 1 < a.file_node_ids.len; k += 2 {
+		marker := a.file_node_ids[k]
+		trailing := a.file_node_ids[k + 1]
+		idx_file := a.nodes[marker].value
+		tc.top_level_idx << marker
+		tnode := a.nodes[trailing]
+		mut idx_module := ''
+		for ci in 0 .. tnode.children_count {
+			idx_module = tc.collect_index_child(a, int(a.child(&tnode, ci)), idx_file, idx_module,
+				inactive)
+		}
+		tc.top_level_idx << trailing
+	}
+}
+
+fn (mut tc TypeChecker) collect_index_child(a &flat.FlatAst, i int, idx_file string, idx_module string, inactive []bool) string {
+	if i < 0 || i >= a.nodes.len {
+		return idx_module
+	}
+	if inactive.len > 0 && i < inactive.len && inactive[i] {
+		return idx_module
+	}
+	node := a.nodes[i]
+	match node.kind {
+		.directive {
+			if idx_file.len > 0 && node.value.starts_with('@attributes:') {
+				decl_idx := node.value['@attributes:'.len..].int()
+				if decl_idx >= 0 && decl_idx < a.nodes.len && a.nodes[decl_idx].kind == .module_decl {
+					for attr in node.generic_params() {
+						if attr.all_before(':').trim_space() == 'translated' {
+							tc.translated_files[idx_file] = true
+							break
+						}
+					}
+				}
+			}
+		}
+		.module_decl {
+			tc.top_level_idx << i
+			return node.value
+		}
+		.struct_decl {
+			if node.value == 'string' {
+				tc.has_builtins = true
+			}
+			tc.declared_type_scope_keys[scope_type_key(idx_file, idx_module, node.value)] = true
+			tc.top_level_idx << i
+		}
+		.type_decl, .interface_decl, .enum_decl {
+			tc.declared_type_scope_keys[scope_type_key(idx_file, idx_module, node.value)] = true
+			tc.top_level_idx << i
+		}
+		.import_decl, .const_decl, .global_decl, .fn_decl, .c_fn_decl {
+			tc.top_level_idx << i
+		}
+		.comptime_if, .block {
+			// Top-level $if containers hold declarations the full scan reaches
+			// by node order; descend in child order (same ascending ids).
+			mut inner_module := idx_module
+			for ci in 0 .. node.children_count {
+				inner_module = tc.collect_index_child(a, int(a.child(&node, ci)), idx_file,
+					inner_module, inactive)
+			}
+			return inner_module
+		}
+		else {}
+	}
+	return idx_module
+}
+
 pub fn (mut tc TypeChecker) collect(a &flat.FlatAst) {
+	mut ck_c_sw := time.new_stopwatch()
 	tc.a = a
 	tc.visible_mutation_cache = new_visible_mutation_cache()
 	tc.has_spawn_expr = -1
@@ -1471,6 +1583,13 @@ pub fn (mut tc TypeChecker) collect(a &flat.FlatAst) {
 	tc.prepare_threads_condition()
 	inactive_comptime_nodes := tc.inactive_top_level_comptime_nodes()
 	tc.inactive_top_level_node_ids.clear()
+	if file_index_usable(a) {
+		tc.collect_top_level_idx_fast(a, inactive_comptime_nodes)
+		tc.top_level_idx_nodes_len = a.nodes.len
+		eprintln('  [ttime]     ck c idx       ${f64(ck_c_sw.elapsed().microseconds()) / 1000.0:7.2f} ms (fast)')
+		tc.collect_after_index(a)
+		return
+	}
 	mut idx_file := ''
 	mut idx_module := ''
 	for i, node in a.nodes {
@@ -1520,6 +1639,15 @@ pub fn (mut tc TypeChecker) collect(a &flat.FlatAst) {
 		}
 	}
 	tc.top_level_idx_nodes_len = a.nodes.len
+	eprintln('  [ttime]     ck c idx       ${f64(ck_c_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+	tc.collect_after_index(a)
+}
+
+// collect_after_index runs collection passes 1 and 2 plus the resolution tail
+// over the already-built top-level index (shared by the fast file-index path
+// and the full-scan fallback in collect()).
+fn (mut tc TypeChecker) collect_after_index(a &flat.FlatAst) {
+	mut ck_c_sw := time.new_stopwatch()
 	// Pass 1: collect type-level names (aliases, enums, sum types)
 	for tl_idx in tc.top_level_idx {
 		node := a.nodes[tl_idx]
@@ -1654,6 +1782,8 @@ pub fn (mut tc TypeChecker) collect(a &flat.FlatAst) {
 	tc.type_cache.c_name_entries.clear()
 	tc.invalidate_short_type_name_index()
 	tc.check_c_struct_redeclarations(a)
+	eprintln('  [ttime]     ck c pass1     ${f64(ck_c_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+	ck_c_sw.restart()
 	// Pass 2: collect struct fields, function signatures (type aliases now available)
 	// The native backend does not yet preserve large aggregate arguments reliably
 	// through the parse-cache helpers. Parsing uncached keeps native self-hosts
@@ -1675,6 +1805,7 @@ pub fn (mut tc TypeChecker) collect(a &flat.FlatAst) {
 			}
 			.fn_decl {
 				qname := tc.qualify_fn_name(node.value)
+				tc.register_visible_mutation_fn_decl(tl_idx, tc.cur_module, qname, node.value)
 				is_open_generic := node.generic_params().len > 0 || node.value.contains('[')
 				ret_type := if is_open_generic {
 					tc.parse_scope_param_type(node.typ)
@@ -1933,9 +2064,16 @@ pub fn (mut tc TypeChecker) collect(a &flat.FlatAst) {
 			else {}
 		}
 	}
+	eprintln('  [ttime]     ck c pass2     ${f64(ck_c_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+	ck_c_sw.restart()
 	tc.resolve_inferred_global_types(a)
 	tc.resolve_const_types()
 	tc.build_const_suffixes()
+	eprintln('  [ttime]     ck c resolve   ${f64(ck_c_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+	if !isnil(tc.visible_mutation_cache) {
+		mut visible_mutation_cache := tc.visible_mutation_cache
+		visible_mutation_cache.decl_index_ready = true
+	}
 	$if ownership ? {
 		tc.ownership_after_collect()
 	}
@@ -2497,7 +2635,54 @@ fn (tc &TypeChecker) local_fn_decl_exists_scan(name string) bool {
 }
 
 // qualify_name supports qualify name handling for TypeChecker.
+// QualifyNameCache memoizes qualify_name per (module, file) context. It must
+// only be armed while the declared-type tables are static (parallel cgen of
+// generic-free builds); every checker fork gets its own instance.
+pub struct QualifyNameCache {
+pub mut:
+	module      string
+	file        string
+	fingerprint int = -1
+	entries     map[string]string
+}
+
+// qualify_table_fingerprint tracks growth of every declared-type table
+// qualify_name consults, so the memo stays valid even in phases that can
+// still register types (e.g. anonymous structs during fn-body checking).
+fn (tc &TypeChecker) qualify_table_fingerprint() int {
+	return tc.structs.len + tc.type_aliases.len + tc.interface_names.len + tc.sum_types.len +
+		tc.enum_names.len + tc.flag_enums.len
+}
+
+// ownership_time_spent_us reports the accumulated ownership-analysis time for
+// the dedicated benchmark stage. Compiled-out ownership (no `-d ownership`)
+// cannot spend time, so this returns 0 by construction in plain builds.
+pub fn (tc &TypeChecker) ownership_time_spent_us() i64 {
+	return tc.ownership_time_ns / 1000
+}
+
 pub fn (tc &TypeChecker) qualify_name(name string) string {
+	if !isnil(tc.qualify_name_cache) {
+		mut cache := tc.qualify_name_cache
+		fingerprint := tc.qualify_table_fingerprint()
+		if cache.module != tc.cur_module || cache.file != tc.cur_file
+			|| cache.fingerprint != fingerprint {
+			cache.module = tc.cur_module
+			cache.file = tc.cur_file
+			cache.fingerprint = fingerprint
+			cache.entries.clear()
+		}
+		if cached := cache.entries[name] {
+			return cached
+		}
+		result := tc.qualify_name_uncached(name)
+		cache.entries[name] = result
+		return result
+	}
+	return tc.qualify_name_uncached(name)
+}
+
+fn (tc &TypeChecker) qualify_name_uncached(name string) string {
 	// Qualify container / wrapper types by recursing into the element type first,
 	// so imported dotted names inside `[]T`, `[N]T`, `map[K]V`, `&T`, `?T`, `!T`
 	// still get resolved. The `.contains('.')` fast path below only understands the
@@ -2594,7 +2779,7 @@ fn (tc &TypeChecker) qualify_candidate_type_exists(name string) bool {
 }
 
 fn (tc &TypeChecker) qualify_sum_variant_name(name string, generic_params []string) string {
-	clean := name.trim_space()
+	clean := trimmed_space(name)
 	if clean.starts_with('fn(') || clean.starts_with('fn (') {
 		return tc.qualify_type_text(clean)
 	}
@@ -2641,7 +2826,7 @@ fn (tc &TypeChecker) qualify_sum_variant_name(name string, generic_params []stri
 	if bracket > 0 {
 		bracket_end := find_matching_bracket(clean, bracket)
 		if bracket_end < clean.len {
-			inner := clean[bracket + 1..bracket_end].trim_space()
+			inner := trimmed_space(clean[bracket + 1..bracket_end])
 			if is_fixed_array_len_text(inner) || is_builtin_type_name(clean[..bracket]) {
 				return tc.qualify_sum_variant_name(clean[..bracket], generic_params) +
 					clean[bracket..]
@@ -2678,7 +2863,7 @@ fn (tc &TypeChecker) qualify_resolution_type_text(typ string) string {
 // parse_resolution_type parses type text that can mix declaration-local names with concrete
 // generic arguments from another module.
 pub fn (tc &TypeChecker) parse_resolution_type(typ string) Type {
-	clean := typ.trim_space()
+	clean := trimmed_space(typ)
 	if clean.contains('.') {
 		if exact := tc.type_from_known_symbol(clean) {
 			return exact
@@ -2716,7 +2901,7 @@ pub fn (mut tc TypeChecker) disable_resolution_type_view_cache() {
 }
 
 fn (tc &TypeChecker) qualify_type_text_impl(typ string, resolution bool, generic_params []string) string {
-	clean := typ.trim_space()
+	clean := trimmed_space(typ)
 	if clean.len == 0 {
 		return typ
 	}
@@ -2792,7 +2977,7 @@ fn (tc &TypeChecker) qualify_type_text_impl(typ string, resolution bool, generic
 	if bracket > 0 {
 		bracket_end := find_matching_bracket(clean, bracket)
 		if bracket_end < clean.len {
-			inner := clean[bracket + 1..bracket_end].trim_space()
+			inner := trimmed_space(clean[bracket + 1..bracket_end])
 			if is_fixed_array_len_text(inner) || is_builtin_type_name(clean[..bracket]) {
 				return tc.qualify_type_text_impl(clean[..bracket], resolution, generic_params) +
 					clean[bracket..]
@@ -2837,13 +3022,13 @@ fn (tc &TypeChecker) qualify_fn_type_text(typ string, generic_params []string) s
 	}
 	params_str := typ[params_start..params_end]
 	mut params := []string{}
-	if params_str.trim_space().len > 0 {
+	if trimmed_space(params_str).len > 0 {
 		for part in split_params(params_str) {
 			params << tc.qualify_type_text_impl(normalize_fn_type_param_text(part), false,
 				generic_params)
 		}
 	}
-	ret_str := typ[params_end + 1..].trim_space()
+	ret_str := trimmed_space(typ[params_end + 1..])
 	if ret_str.len > 0 {
 		return 'fn(${params.join(', ')}) ${tc.qualify_type_text_impl(ret_str, false, generic_params)}'
 	}
@@ -2931,9 +3116,44 @@ fn (mut tc TypeChecker) register_selective_imports(node flat.Node) {
 	}
 }
 
+// check_memos_enabled gates the per-fork qualify/import memos, so a single
+// binary can A/B them (`V3_NO_CHECK_MEMOS=1` disables).
+fn check_memos_enabled() bool {
+	return os.getenv('V3_NO_CHECK_MEMOS') == ''
+}
+
+// ImportInfoCache pins the current file's import table so the hot
+// resolve_import_alias/selective-import paths skip re-hashing the long
+// file-path key on every call. Refreshed whenever the file or the registration
+// table length changes; the pinned &FileImportInfo is heap-stable and its maps
+// stay live through the pin. Each checker fork owns a private instance.
+struct ImportInfoCache {
+mut:
+	file     string
+	info     &FileImportInfo = unsafe { nil }
+	seen_len int             = -1
+}
+
+fn (tc &TypeChecker) current_file_import_info() &FileImportInfo {
+	mut cache := tc.import_info_cache
+	if isnil(cache) {
+		return tc.file_imports_by_file[tc.cur_file] or { return unsafe { &FileImportInfo(nil) } }
+	}
+	if cache.seen_len != tc.file_imports_by_file.len
+		|| voidptr(cache.file.str) != voidptr(tc.cur_file.str) || cache.file.len != tc.cur_file.len {
+		cache.file = tc.cur_file
+		cache.seen_len = tc.file_imports_by_file.len
+		cache.info = tc.file_imports_by_file[tc.cur_file] or { unsafe { &FileImportInfo(nil) } }
+	}
+	return cache.info
+}
+
 // resolve_import_alias resolves resolve import alias information for types.
 fn (tc &TypeChecker) resolve_import_alias(alias string) ?string {
-	info := tc.file_imports_by_file[tc.cur_file] or { return none }
+	info := tc.current_file_import_info()
+	if isnil(info) {
+		return none
+	}
 	if mod := info.imports[alias] {
 		return mod
 	}
@@ -2962,7 +3182,10 @@ fn (tc &TypeChecker) resolve_selective_import_type_symbol(name string) ?string {
 }
 
 fn (tc &TypeChecker) selective_import_candidates(name string) ?[]string {
-	info := tc.file_imports_by_file[tc.cur_file] or { return none }
+	info := tc.current_file_import_info()
+	if isnil(info) {
+		return none
+	}
 	return info.selective_imports[name] or { return none }
 }
 
@@ -3147,7 +3370,8 @@ fn (mut tc TypeChecker) register_fn_name_alias(name string, ret_type Type, param
 	tc.fn_param_types[name] = params.clone()
 	if shared_params.len > 0 {
 		tc.fn_shared_params[name] = shared_params.clone()
-	} else {
+	} else if tc.fn_shared_params.len > 0 {
+		// Deleting from an empty map is a paid no-op on this hot path.
 		tc.fn_shared_params.delete(name)
 	}
 	if tc.cur_file.len > 0 {
@@ -3155,7 +3379,11 @@ fn (mut tc TypeChecker) register_fn_name_alias(name string, ret_type Type, param
 		tc.fn_type_modules[name] = tc.cur_module
 	}
 	tc.fn_variadic[name] = is_variadic
-	tc.fn_implicit_veb_ctx[name] = implicit_veb_ctx
+	if implicit_veb_ctx || tc.fn_implicit_veb_ctx.len > 0 {
+		// All readers default absent entries to false, so false inserts only
+		// matter once the map holds any true entry (veb builds).
+		tc.fn_implicit_veb_ctx[name] = implicit_veb_ctx
+	}
 	tc.add_receiver_method_suffix_index(name)
 }
 
@@ -5128,7 +5356,7 @@ fn (tc &TypeChecker) fn_shared_params_with_implicit_veb_ctx(node flat.Node, flag
 }
 
 fn param_type_text_is_shared(raw string) bool {
-	return raw.trim_space().starts_with('shared ')
+	return trimmed_space(raw).starts_with('shared ')
 }
 
 fn decl_assign_is_shared_marker(value string) bool {
@@ -5357,7 +5585,7 @@ fn (tc &TypeChecker) collect_generic_receiver_params(node flat.Node, mut params 
 }
 
 fn (tc &TypeChecker) collect_generic_param_candidates(typ string, mut counts map[string]int) bool {
-	clean := typ.trim_space()
+	clean := trimmed_space(typ)
 	if clean.len == 0 {
 		return false
 	}
@@ -5420,7 +5648,7 @@ fn (tc &TypeChecker) collect_generic_param_candidates(typ string, mut counts map
 		}
 		if params_end < clean.len {
 			for part in split_params(clean[params_start..params_end]) {
-				trimmed := part.trim_space()
+				trimmed := trimmed_space(part)
 				parts := trimmed.split(' ')
 				param_type := if parts.len >= 2 { parts[parts.len - 1] } else { trimmed }
 				if tc.collect_generic_param_candidates(param_type, mut counts) {
@@ -5452,7 +5680,7 @@ fn (tc &TypeChecker) collect_generic_param_candidates(typ string, mut counts map
 // check_type_string_for_unsupported_generics
 // validates helper state for types.
 fn (mut tc TypeChecker) check_type_string_for_unsupported_generics(typ string, node_id flat.NodeId, generic_params map[string]bool) {
-	clean := typ.trim_space()
+	clean := trimmed_space(typ)
 	if clean.len == 0 {
 		return
 	}
@@ -5522,7 +5750,7 @@ fn (mut tc TypeChecker) check_type_string_for_unsupported_generics(typ string, n
 		}
 		bracket := clean.index_u8(`[`)
 		bracket_end := find_matching_bracket(clean, bracket)
-		base := clean[..bracket].trim_space()
+		base := trimmed_space(clean[..bracket])
 		if should_check_named_type(base) && !tc.type_name_known(base) {
 			tc.record_unknown_decl_type(base, node_id)
 		}
@@ -5597,12 +5825,12 @@ fn (mut tc TypeChecker) check_fn_type_string_for_unsupported_generics(typ string
 		return
 	}
 	for part in split_params(typ[params_start..params_end]) {
-		trimmed := part.trim_space()
+		trimmed := trimmed_space(part)
 		parts := trimmed.split(' ')
 		param_type := if parts.len >= 2 { parts[parts.len - 1] } else { trimmed }
 		tc.check_type_string_for_unsupported_generics(param_type, node_id, generic_params)
 	}
-	ret := typ[params_end + 1..].trim_space()
+	ret := trimmed_space(typ[params_end + 1..])
 	tc.check_type_string_for_unsupported_generics(ret, node_id, generic_params)
 }
 
@@ -5622,7 +5850,7 @@ fn (tc &TypeChecker) generic_args_are_concrete(args []string) bool {
 }
 
 fn (tc &TypeChecker) type_text_has_generic_placeholder(typ string) bool {
-	clean := typ.trim_space()
+	clean := trimmed_space(typ)
 	if is_bare_generic_param(clean) {
 		return !tc.is_known_type_text(clean)
 	}
@@ -5677,7 +5905,7 @@ fn generic_type_application_parts(typ string) (string, []string, bool) {
 	if bracket <= 0 || bracket_end <= bracket {
 		return '', []string{}, false
 	}
-	inner := typ[bracket + 1..bracket_end].trim_space()
+	inner := trimmed_space(typ[bracket + 1..bracket_end])
 	if is_fixed_array_len_text(inner) {
 		return '', []string{}, false
 	}
@@ -5691,7 +5919,7 @@ fn generic_type_application_parts(typ string) (string, []string, bool) {
 // three keeps such a postfix name parsing as a fixed array (e.g. when `[]thread T.wait()` recovers
 // the spawned return type) instead of a bogus generic application.
 fn is_fixed_array_len_text(inner string) bool {
-	s := inner.trim_space()
+	s := trimmed_space(inner)
 	if s.len == 0 {
 		return false
 	}
@@ -6416,13 +6644,20 @@ fn (tc &TypeChecker) branch_tail_never_returns(branch_id flat.NodeId) bool {
 	} else {
 		0
 	}
-	mut scoped := *tc
-	scoped.smartcasts = clone_smartcasts(tc.smartcasts)
+	// Only the `smartcasts` binding needs isolation here: a full `*tc` copy
+	// shares every map's backing storage anyway and memmoves the ~11KB
+	// TypeChecker per call, so swap in a scratch clone and restore instead.
+	mut mtc := unsafe { &TypeChecker(voidptr(tc)) }
+	mut saved_smartcasts := mtc.smartcasts.move()
+	mtc.smartcasts = clone_smartcasts(saved_smartcasts)
+	defer {
+		mtc.smartcasts = saved_smartcasts.move()
+	}
 	tail_index := int(branch.children_count) - 1
 	for i in body_start .. tail_index {
-		scoped.apply_return_analysis_local_binding(tc.a.child(&branch, i))
+		mtc.apply_return_analysis_local_binding(tc.a.child(&branch, i))
 	}
-	return scoped.expr_never_returns(tail_id)
+	return tc.expr_never_returns(tail_id)
 }
 
 // match_covers_all_enum_variants reports whether a `match` over an enum subject
@@ -6481,14 +6716,20 @@ fn (tc &TypeChecker) match_branch_definitely_returns(branch &flat.Node) bool {
 }
 
 fn (tc &TypeChecker) stmt_sequence_definitely_returns(node &flat.Node, body_start int) bool {
-	mut scoped := *tc
-	scoped.smartcasts = clone_smartcasts(tc.smartcasts)
+	// Only the `smartcasts` binding needs isolation here (see
+	// branch_tail_never_returns); avoid the ~11KB full struct copy.
+	mut mtc := unsafe { &TypeChecker(voidptr(tc)) }
+	mut saved_smartcasts := mtc.smartcasts.move()
+	mtc.smartcasts = clone_smartcasts(saved_smartcasts)
+	defer {
+		mtc.smartcasts = saved_smartcasts.move()
+	}
 	for i in body_start .. node.children_count {
 		child_id := tc.a.child(node, i)
-		if scoped.stmt_definitely_returns(child_id) {
+		if tc.stmt_definitely_returns(child_id) {
 			return true
 		}
-		scoped.apply_return_analysis_local_binding(child_id)
+		mtc.apply_return_analysis_local_binding(child_id)
 	}
 	return false
 }
@@ -6551,10 +6792,16 @@ fn (tc &TypeChecker) match_branch_definitely_returns_with_context(node flat.Node
 	} else {
 		return tc.match_branch_definitely_returns(branch)
 	}
-	mut scoped := *tc
-	scoped.smartcasts = clone_smartcasts(tc.smartcasts)
-	scoped.smartcasts[subject_key] = tc.parse_type(smartcast_type)
-	return scoped.match_branch_definitely_returns(branch)
+	// Only the `smartcasts` binding needs isolation here (see
+	// branch_tail_never_returns); avoid the ~11KB full struct copy.
+	mut mtc := unsafe { &TypeChecker(voidptr(tc)) }
+	mut saved_smartcasts := mtc.smartcasts.move()
+	mtc.smartcasts = clone_smartcasts(saved_smartcasts)
+	defer {
+		mtc.smartcasts = saved_smartcasts.move()
+	}
+	mtc.smartcasts[subject_key] = tc.parse_type(smartcast_type)
+	return tc.match_branch_definitely_returns(branch)
 }
 
 fn (tc &TypeChecker) match_without_else_exhaustive_enum_returns(node flat.Node) bool {
@@ -7143,15 +7390,15 @@ fn comptime_static_source_location(path string, encoded_offset int, line_offsets
 }
 
 fn comptime_static_attribute_case(raw string, kind int) ComptimeStaticValueCase {
-	clean := raw.trim_space()
+	clean := trimmed_space(raw)
 	colon := clean.index_u8(`:`)
 	has_arg := colon >= 0 && !(kind == 1
-		&& !comptime_static_attr_is_string_literal(clean[colon + 1..].trim_space()))
-	mut name := if has_arg { clean[..colon].trim_space() } else { clean }
+		&& !comptime_static_attr_is_string_literal(trimmed_space(clean[colon + 1..])))
+	mut name := if has_arg { trimmed_space(clean[..colon]) } else { clean }
 	if name.len >= 2 && name[0] in [`'`, `"`] && name[name.len - 1] == name[0] {
 		name = name[1..name.len - 1]
 	}
-	mut arg := if has_arg { clean[colon + 1..].trim_space() } else { '' }
+	mut arg := if has_arg { trimmed_space(clean[colon + 1..]) } else { '' }
 	if arg.len >= 3 && arg[0] == `r` && arg[1] in [`'`, `"`] && arg[arg.len - 1] == arg[1] {
 		arg = arg[2..arg.len - 1]
 	} else if arg.len >= 2 && arg[0] in [`'`, `"`] && arg[arg.len - 1] == arg[0] {
@@ -7172,7 +7419,7 @@ fn comptime_static_attr_is_string_literal(raw string) bool {
 }
 
 fn (tc &TypeChecker) comptime_deferred_decl_source(source string, allow_type bool) ?ComptimeDeferredDeclSource {
-	clean := source.trim_space()
+	clean := trimmed_space(source)
 	if clean.len == 0 {
 		return none
 	}
@@ -7511,7 +7758,7 @@ fn comptime_static_subst_method_param_cond(cond string, var_name string, item Co
 				offset = member_start
 				continue
 			}
-			index_text := result[index_start..index_end].trim_space()
+			index_text := trimmed_space(result[index_start..index_end])
 			if !comptime_static_is_int(index_text) || index_text.starts_with('-') {
 				offset = member_end
 				continue
@@ -7961,7 +8208,7 @@ fn (mut tc TypeChecker) comptime_static_enum_value_cases(base_type string) Compt
 }
 
 fn (tc &TypeChecker) comptime_static_enum_name(raw string) ?string {
-	mut cur := raw.trim_space()
+	mut cur := trimmed_space(raw)
 	mut seen := map[string]bool{}
 	for cur.len > 0 && cur !in seen {
 		seen[cur] = true
@@ -7978,7 +8225,7 @@ fn (tc &TypeChecker) comptime_static_enum_name(raw string) ?string {
 		if next == cur {
 			break
 		}
-		cur = next.trim_space()
+		cur = trimmed_space(next)
 	}
 	return none
 }
@@ -8121,22 +8368,22 @@ fn (tc &TypeChecker) comptime_static_type_name_is_struct(name string) bool {
 }
 
 fn comptime_static_unwrap_type_text(name string) string {
-	mut clean := name.trim_space()
+	mut clean := trimmed_space(name)
 	for _ in 0 .. 16 {
 		if clean.starts_with('?') || clean.starts_with('!') {
-			clean = clean[1..].trim_space()
+			clean = trimmed_space(clean[1..])
 			continue
 		}
 		if clean.starts_with('shared ') {
-			clean = clean[7..].trim_space()
+			clean = trimmed_space(clean[7..])
 			continue
 		}
 		if clean.starts_with('atomic ') {
-			clean = clean[7..].trim_space()
+			clean = trimmed_space(clean[7..])
 			continue
 		}
 		if clean.starts_with('&') {
-			clean = clean[1..].trim_space()
+			clean = trimmed_space(clean[1..])
 			continue
 		}
 		break
@@ -8152,7 +8399,7 @@ fn (tc &TypeChecker) comptime_static_for_base_type(raw string) string {
 }
 
 fn (tc &TypeChecker) comptime_static_for_value_source_type(raw string) ?string {
-	clean := raw.trim_space()
+	clean := trimmed_space(raw)
 	if clean.len == 0 {
 		return none
 	}
@@ -8462,7 +8709,7 @@ fn comptime_static_source_type_name(typ Type) string {
 }
 
 fn (tc &TypeChecker) comptime_static_struct_name(raw string) ?string {
-	mut cur := raw.trim_space()
+	mut cur := trimmed_space(raw)
 	mut seen := map[string]bool{}
 	for cur.len > 0 && cur !in seen {
 		seen[cur] = true
@@ -8479,14 +8726,14 @@ fn (tc &TypeChecker) comptime_static_struct_name(raw string) ?string {
 		if next == cur {
 			break
 		}
-		cur = next.trim_space()
+		cur = trimmed_space(next)
 	}
 	return none
 }
 
 fn (tc &TypeChecker) comptime_static_field_decl_metas(base_type string) map[string]ComptimeStaticFieldDeclMeta {
 	mut out := map[string]ComptimeStaticFieldDeclMeta{}
-	mut decl_name := base_type.trim_space()
+	mut decl_name := trimmed_space(base_type)
 	if idx := decl_name.index('[') {
 		decl_name = decl_name[..idx]
 	}
@@ -8581,22 +8828,22 @@ fn comptime_static_unwrap_field_type(typ Type) Type {
 }
 
 fn comptime_static_field_type_flags(raw string) ComptimeStaticFieldTypeFlags {
-	mut core := raw.trim_space()
+	mut core := trimmed_space(raw)
 	mut flags := ComptimeStaticFieldTypeFlags{}
 	if core.starts_with('?') {
-		core = core[1..].trim_space()
+		core = trimmed_space(core[1..])
 	}
 	if core.starts_with('shared ') {
 		flags.is_shared = true
 		flags.indirections++
-		core = core[7..].trim_space()
+		core = trimmed_space(core[7..])
 	} else if core.starts_with('atomic ') {
 		flags.is_atomic = true
-		core = core[7..].trim_space()
+		core = trimmed_space(core[7..])
 	}
 	for core.starts_with('&') {
 		flags.indirections++
-		core = core[1..].trim_space()
+		core = trimmed_space(core[1..])
 	}
 	return flags
 }
@@ -8657,7 +8904,7 @@ fn comptime_static_replace_bare_ident(cond string, ident string, replacement str
 }
 
 fn (mut tc TypeChecker) comptime_static_eval_field_cond(cond string) ?bool {
-	clean := comptime_condition_strip_outer_parens(cond.trim_space())
+	clean := comptime_condition_strip_outer_parens(trimmed_space(cond))
 	if clean == 'true' {
 		return true
 	}
@@ -8683,8 +8930,8 @@ fn (mut tc TypeChecker) comptime_static_eval_field_cond(cond string) ?bool {
 	for op in [' !is ', ' is '] {
 		op_idx := comptime_condition_top_level_index(clean, op)
 		if op_idx >= 0 {
-			left := clean[..op_idx].trim_space()
-			right := clean[op_idx + op.len..].trim_space()
+			left := trimmed_space(clean[..op_idx])
+			right := trimmed_space(clean[op_idx + op.len..])
 			matches := tc.comptime_type_matches(left, right) or { return none }
 			return if op == ' is ' { matches } else { !matches }
 		}
@@ -8692,8 +8939,8 @@ fn (mut tc TypeChecker) comptime_static_eval_field_cond(cond string) ?bool {
 	for op in [' != ', ' == '] {
 		op_idx := comptime_condition_top_level_index(clean, op)
 		if op_idx >= 0 {
-			left := comptime_static_unquote(clean[..op_idx].trim_space())
-			right := comptime_static_unquote(clean[op_idx + op.len..].trim_space())
+			left := comptime_static_unquote(trimmed_space(clean[..op_idx]))
+			right := comptime_static_unquote(trimmed_space(clean[op_idx + op.len..]))
 			eq := left == right
 			return if op == ' == ' { eq } else { !eq }
 		}
@@ -8706,16 +8953,16 @@ fn (mut tc TypeChecker) comptime_static_eval_field_cond(cond string) ?bool {
 				&& clean[after] != `(` {
 				continue
 			}
-			needle := comptime_static_unquote(clean[..op_idx].trim_space())
-			found := comptime_static_list_contains(clean[after..].trim_space(), needle)
+			needle := comptime_static_unquote(trimmed_space(clean[..op_idx]))
+			found := comptime_static_list_contains(trimmed_space(clean[after..]), needle)
 			return if op == ' in' { found } else { !found }
 		}
 	}
 	for op in [' <= ', ' >= ', ' < ', ' > '] {
 		op_idx := comptime_condition_top_level_index(clean, op)
 		if op_idx >= 0 {
-			left := clean[..op_idx].trim_space()
-			right := clean[op_idx + op.len..].trim_space()
+			left := trimmed_space(clean[..op_idx])
+			right := trimmed_space(clean[op_idx + op.len..])
 			if !comptime_static_is_int(left) || !comptime_static_is_int(right) {
 				return none
 			}
@@ -8737,13 +8984,13 @@ fn (mut tc TypeChecker) comptime_static_eval_field_cond(cond string) ?bool {
 }
 
 fn comptime_static_list_contains(list_text string, needle string) bool {
-	clean := list_text.trim_space()
+	clean := trimmed_space(list_text)
 	if !clean.starts_with('[') || !clean.ends_with(']') {
 		return false
 	}
 	inner := clean[1..clean.len - 1]
 	for part in inner.split(',') {
-		if comptime_static_unquote(part.trim_space()) == needle {
+		if comptime_static_unquote(trimmed_space(part)) == needle {
 			return true
 		}
 	}
@@ -9304,6 +9551,20 @@ fn (tc &TypeChecker) mark_inactive_top_level_comptime(id flat.NodeId, mut inacti
 
 fn (tc &TypeChecker) inactive_top_level_comptime_nodes() []bool {
 	mut inactive := []bool{}
+	if file_index_usable(tc.a) {
+		// Only trailing .file nodes have children; the recorded list visits
+		// them in node order, matching the full scan.
+		for fid in tc.a.file_node_ids {
+			node := tc.a.nodes[fid]
+			if node.kind != .file || node.children_count == 0 {
+				continue
+			}
+			for i in 0 .. node.children_count {
+				tc.mark_inactive_top_level_comptime(tc.a.child(&node, i), mut inactive)
+			}
+		}
+		return inactive
+	}
 	for node in tc.a.nodes {
 		if node.kind != .file || node.children_count == 0 {
 			continue
@@ -9548,8 +9809,8 @@ fn (mut tc TypeChecker) comptime_type_condition_value(cond string) ?bool {
 	for op in [' !is ', ' is '] {
 		op_idx := comptime_condition_top_level_index(clean, op)
 		if op_idx >= 0 {
-			left := clean[..op_idx].trim_space()
-			right := clean[op_idx + op.len..].trim_space()
+			left := trimmed_space(clean[..op_idx])
+			right := trimmed_space(clean[op_idx + op.len..])
 			matches := tc.comptime_type_matches(left, right) or { return none }
 			return if op == ' is ' { matches } else { !matches }
 		}
@@ -9562,8 +9823,8 @@ fn (mut tc TypeChecker) comptime_type_condition_value(cond string) ?bool {
 }
 
 fn (mut tc TypeChecker) comptime_type_matches(actual string, expected string) ?bool {
-	clean_actual := actual.trim_space()
-	clean_expected := expected.trim_space()
+	clean_actual := trimmed_space(actual)
+	clean_expected := trimmed_space(expected)
 	if clean_actual.len == 0 || clean_expected.len == 0
 		|| (is_bare_generic_param(clean_actual) && !tc.type_name_known(clean_actual)) {
 		return none
@@ -9639,7 +9900,7 @@ fn (mut tc TypeChecker) comptime_type_matches(actual string, expected string) ?b
 }
 
 fn (tc &TypeChecker) comptime_type_text_is_shared(type_text string) bool {
-	mut cur := type_text.trim_space()
+	mut cur := trimmed_space(type_text)
 	for _ in 0 .. 16 {
 		if cur.starts_with('shared ') {
 			return true
@@ -9648,7 +9909,7 @@ fn (tc &TypeChecker) comptime_type_text_is_shared(type_text string) bool {
 		if target == cur {
 			return false
 		}
-		cur = target.trim_space()
+		cur = trimmed_space(target)
 	}
 	return false
 }
@@ -9705,13 +9966,13 @@ fn comptime_condition_matching_paren(s string, start int) int {
 }
 
 fn comptime_condition_strip_outer_parens(cond string) string {
-	mut clean := cond.trim_space()
+	mut clean := trimmed_space(cond)
 	for clean.len >= 2 && clean.starts_with('(') {
 		end := comptime_condition_matching_paren(clean, 0)
 		if end != clean.len - 1 {
 			break
 		}
-		clean = clean[1..clean.len - 1].trim_space()
+		clean = trimmed_space(clean[1..clean.len - 1])
 	}
 	return clean
 }
@@ -13985,7 +14246,7 @@ fn (tc &TypeChecker) call_generic_args_have_placeholders(node flat.Node) bool {
 	}
 	if node.value.len > 0 {
 		for arg in node.value.split(',') {
-			if tc.type_text_has_generic_placeholder(arg.trim_space()) {
+			if tc.type_text_has_generic_placeholder(trimmed_space(arg)) {
 				return true
 			}
 		}
@@ -15965,7 +16226,7 @@ fn (tc &TypeChecker) call_info(name string, has_receiver bool) CallInfo {
 
 fn (tc &TypeChecker) alias_return_type_from_text(fn_name string) ?Type {
 	ret_text := tc.fn_ret_type_texts[fn_name] or { return none }
-	clean := ret_text.trim_space()
+	clean := trimmed_space(ret_text)
 	if clean.len == 0 {
 		return none
 	}
@@ -16003,12 +16264,12 @@ fn array_type_from_receiver(t Type) ?Array {
 fn (tc &TypeChecker) thread_wait_return_type(t Type) ?Type {
 	clean := unwrap_pointer(t)
 	if clean is Struct {
-		thread_name := clean.name.trim_space()
+		thread_name := trimmed_space(clean.name)
 		if thread_name == 'thread' || thread_name.ends_with('.thread') {
 			return Type(void_)
 		}
 		if thread_name.starts_with('thread ') {
-			return tc.parse_type(thread_name[7..].trim_space())
+			return tc.parse_type(trimmed_space(thread_name[7..]))
 		}
 	}
 	return none
@@ -16122,7 +16383,7 @@ fn (tc &TypeChecker) fixed_array_type_from_receiver(t Type) ?ArrayFixed {
 		bracket := name.last_index_u8(`[`)
 		bracket_end := name.last_index_u8(`]`)
 		if bracket >= 0 && bracket_end > bracket {
-			len_text := name[bracket + 1..bracket_end].trim_space()
+			len_text := trimmed_space(name[bracket + 1..bracket_end])
 			if !is_fixed_array_len_text(len_text)
 				&& tc.const_int_value_in_module(len_text, tc.cur_module, []string{}) == none {
 				return none
@@ -16140,7 +16401,7 @@ fn (tc &TypeChecker) fixed_array_type_from_receiver(t Type) ?ArrayFixed {
 fn (tc &TypeChecker) fixed_array_thread_wait_call_info(base_type Type, arr ArrayFixed) ?CallInfo {
 	elem := arr.elem_type
 	if elem is Struct {
-		name := elem.name.trim_space()
+		name := trimmed_space(elem.name)
 		if name == 'thread' {
 			return CallInfo{
 				name:         ''
@@ -16164,7 +16425,7 @@ fn (tc &TypeChecker) fixed_array_thread_wait_call_info(base_type Type, arr Array
 }
 
 fn (tc &TypeChecker) thread_array_wait_return_type(payload string) Type {
-	ret_name := payload.trim_space()
+	ret_name := trimmed_space(payload)
 	if ret_name == '?' {
 		return Type(OptionType{
 			base_type: Type(void_)
@@ -16493,13 +16754,13 @@ fn receiver_mutation_is_visible(vis ReceiverMutationVisibility) bool {
 }
 
 fn visible_mutation_receiver_type_name(typ string) string {
-	mut clean := typ.trim_space()
+	mut clean := trimmed_space(typ)
 	for clean.starts_with('&') {
-		clean = clean[1..].trim_space()
+		clean = trimmed_space(clean[1..])
 	}
 	for prefix in ['mut ', 'shared '] {
 		if clean.starts_with(prefix) {
-			clean = clean[prefix.len..].trim_space()
+			clean = trimmed_space(clean[prefix.len..])
 		}
 	}
 	return strip_generic_args_name(clean)
@@ -16517,14 +16778,55 @@ fn visible_mutation_fn_names_match(actual string, declared string) bool {
 	return strip_generic_args_name(actual_receiver) == strip_generic_args_name(declared_receiver)
 }
 
+fn visible_mutation_fn_lookup_name(name string) string {
+	dot := name.last_index_u8(`.`)
+	if dot <= 0 {
+		return name
+	}
+	receiver := name[..dot]
+	clean_receiver := strip_generic_args_name(receiver)
+	if clean_receiver == receiver {
+		return name
+	}
+	return clean_receiver + name[dot..]
+}
+
+fn (tc &TypeChecker) cache_visible_mutation_fn_decl(key string, decl VisibleMutationFnDecl) {
+	if isnil(tc.visible_mutation_cache) || key.len == 0 {
+		return
+	}
+	mut cache := tc.visible_mutation_cache
+	if key !in cache.decls {
+		cache.decls[key] = decl
+	}
+}
+
+fn (tc &TypeChecker) register_visible_mutation_fn_decl(idx int, module_name string, qname string, source_name string) {
+	decl := VisibleMutationFnDecl{
+		idx: idx
+		mod: module_name
+	}
+	normalized_qname := visible_mutation_fn_lookup_name(qname)
+	normalized_source_name := visible_mutation_fn_lookup_name(source_name)
+	c_qname := tc.cached_c_name(qname)
+	c_source_name := tc.cached_c_name(source_name)
+	for candidate in [normalized_qname, normalized_source_name, c_qname, c_source_name] {
+		tc.cache_visible_mutation_fn_decl('\x01${candidate}', decl)
+		tc.cache_visible_mutation_fn_decl('${module_name}\x01${candidate}', decl)
+	}
+}
+
 fn (tc &TypeChecker) visible_mutation_fn_decl(name string, fallback_mod string) ?VisibleMutationFnDecl {
-	cache_key := '${fallback_mod}\x01${name}'
+	cache_key := '${fallback_mod}\x01${visible_mutation_fn_lookup_name(name)}'
 	if !isnil(tc.visible_mutation_cache) {
 		cache := tc.visible_mutation_cache
 		if decl := cache.decls[cache_key] {
 			return decl
 		}
 		if cache.decl_misses[cache_key] {
+			return none
+		}
+		if cache.decl_index_ready {
 			return none
 		}
 	}
@@ -18154,12 +18456,12 @@ fn (tc &TypeChecker) call_has_explicit_generic_type_args(node flat.Node) bool {
 }
 
 fn generic_variadic_elem_param_text(param_text string) string {
-	clean := param_text.trim_space()
+	clean := trimmed_space(param_text)
 	if clean.starts_with('...') {
-		return clean[3..].trim_space()
+		return trimmed_space(clean[3..])
 	}
 	if clean.starts_with('[]') {
-		return clean[2..].trim_space()
+		return trimmed_space(clean[2..])
 	}
 	return clean
 }
@@ -18176,7 +18478,7 @@ fn (tc &TypeChecker) parse_fn_signature_type(name string, typ string) Type {
 }
 
 fn (mut tc TypeChecker) infer_generic_type_text_from_type(param_text string, actual Type, generic_params []string, mut inferred map[string]string) {
-	clean := param_text.trim_space()
+	clean := trimmed_space(param_text)
 	if clean.len == 0 {
 		return
 	}
@@ -18249,7 +18551,7 @@ fn (mut tc TypeChecker) infer_generic_type_text_from_type(param_text string, act
 // named applications, but semantic substitution must not parse a caller-local or
 // canonical qualified name again in the callee's import context.
 fn (mut tc TypeChecker) infer_generic_type_value_from_type(param_text string, actual Type, generic_params []string, mut inferred map[string]Type) {
-	clean := param_text.trim_space()
+	clean := trimmed_space(param_text)
 	if clean.len == 0 {
 		return
 	}
@@ -18312,8 +18614,8 @@ fn (tc &TypeChecker) generic_infer_type_text(actual Type) string {
 }
 
 fn (mut tc TypeChecker) infer_generic_type_text_from_text(param_text string, actual_text string, generic_params []string, mut inferred map[string]string) {
-	clean := param_text.trim_space()
-	actual := actual_text.trim_space()
+	clean := trimmed_space(param_text)
+	actual := trimmed_space(actual_text)
 	if clean.len == 0 || actual.len == 0 {
 		return
 	}
@@ -18432,7 +18734,7 @@ fn (mut tc TypeChecker) infer_generic_fn_type_text_from_type(param_text string, 
 		tc.infer_generic_type_text_from_type(normalize_fn_type_param_text(part), fn_param_type(actual,
 			i), generic_params, mut inferred)
 	}
-	ret := param_text[params_end + 1..].trim_space()
+	ret := trimmed_space(param_text[params_end + 1..])
 	if ret.len > 0 {
 		tc.infer_generic_type_text_from_type(ret, actual.return_type, generic_params, mut inferred)
 	}
@@ -19081,7 +19383,7 @@ fn (tc &TypeChecker) generic_receiver_qualifier_mismatch(actual Type, expected T
 		return false
 	}
 	for i in 0 .. a_args.len {
-		if !tc.qualifier_relaxed_type_name_match(a_args[i].trim_space(), e_args[i].trim_space()) {
+		if !tc.qualifier_relaxed_type_name_match(trimmed_space(a_args[i]), trimmed_space(e_args[i])) {
 			return false
 		}
 	}
@@ -21049,7 +21351,7 @@ fn (tc &TypeChecker) resolve_interface_match_pattern(pattern string) ?string {
 }
 
 fn interface_pattern_is_collapsed_container(pattern string) bool {
-	clean := pattern.trim_space()
+	clean := trimmed_space(pattern)
 	return clean.starts_with('[]') || clean.starts_with('map[')
 }
 
@@ -21099,7 +21401,7 @@ fn (tc &TypeChecker) interface_runtime_pattern_allowed(subject_iface string, tar
 }
 
 fn (tc &TypeChecker) pattern_type_known(pattern string) bool {
-	clean := pattern.trim_space()
+	clean := trimmed_space(pattern)
 	if clean.starts_with('[]') || clean.starts_with('map[') || clean.starts_with('[')
 		|| clean.starts_with('fn ') || clean.starts_with('fn(') {
 		return tc.parse_type(clean) !is Unknown
@@ -21402,10 +21704,15 @@ fn (tc &TypeChecker) match_expr_tail_type(id flat.NodeId) Type {
 			continue
 		}
 		branch_type := if subject_key.len > 0 && valid_string_data(subject_key) {
-			mut scoped := *tc
-			scoped.smartcasts = clone_smartcasts(tc.smartcasts)
-			scoped.apply_match_branch_context_smartcasts(subject_key, subject_type, branch)
-			scoped.branch_tail_type(branch_id)
+			// Only the `smartcasts` binding needs isolation here (see
+			// branch_tail_never_returns); avoid the ~11KB full struct copy.
+			mut mtc := unsafe { &TypeChecker(voidptr(tc)) }
+			mut saved_smartcasts := mtc.smartcasts.move()
+			mtc.smartcasts = clone_smartcasts(saved_smartcasts)
+			mtc.apply_match_branch_context_smartcasts(subject_key, subject_type, branch)
+			bt := tc.branch_tail_type(branch_id)
+			mtc.smartcasts = saved_smartcasts.move()
+			bt
 		} else {
 			tc.branch_tail_type(branch_id)
 		}
@@ -21734,7 +22041,7 @@ fn (mut tc TypeChecker) check_struct_init(id flat.NodeId, node flat.Node) {
 }
 
 fn (mut tc TypeChecker) infer_generic_struct_init_type(node flat.Node) ?Type {
-	base_name := node.value.trim_space()
+	base_name := trimmed_space(node.value)
 	if base_name.len == 0 || base_name.contains('[') {
 		return none
 	}
@@ -23183,7 +23490,7 @@ fn (tc &TypeChecker) static_assoc_type_candidates(type_ident string) []string {
 }
 
 fn (tc &TypeChecker) add_static_assoc_type_candidate(mut candidates []string, name string) {
-	clean := name.trim_space()
+	clean := trimmed_space(name)
 	if clean.len == 0 {
 		return
 	}
@@ -23583,7 +23890,7 @@ fn thread_handle_type_names_match(actual string, expected string) bool {
 }
 
 fn canonical_thread_handle_type_name(name string) string {
-	clean := name.trim_space()
+	clean := trimmed_space(name)
 	if clean == 'thread void' {
 		return 'thread'
 	}
@@ -23879,9 +24186,9 @@ pub fn (tc &TypeChecker) const_int_value_in_module(name string, module_name stri
 	// operator (the `+` inside `2 * (segs + 1)`) is not chosen; precedence and left
 	// associativity hold and each side is trimmed and resolved recursively. A leading `-`
 	// (unary) leaves an empty lhs and is skipped.
-	expr := name.trim_space()
+	expr := trimmed_space(name)
 	if const_expr_paren_wraps_whole(expr) {
-		return tc.const_int_value(expr[1..expr.len - 1].trim_space(), seen)
+		return tc.const_int_value(trimmed_space(expr[1..expr.len - 1]), seen)
 	}
 	// Operators are grouped by the same precedence levels as token.left_binding_power:
 	// `+ - | ^` share sum, while `* / % << >> >>> &` share product. Scanning the
@@ -23940,8 +24247,8 @@ pub fn (tc &TypeChecker) const_int_value_in_module(name string, module_name stri
 		if idx <= 0 {
 			continue
 		}
-		lhs := expr[..idx].trim_space()
-		rhs := expr[idx + op.len..].trim_space()
+		lhs := trimmed_space(expr[..idx])
+		rhs := trimmed_space(expr[idx + op.len..])
 		if lhs.len == 0 || rhs.len == 0 {
 			continue
 		}
@@ -23955,7 +24262,7 @@ pub fn (tc &TypeChecker) const_int_value_in_module(name string, module_name stri
 				if lhs_text[0] == `-` {
 					power_sign = -power_sign
 				}
-				lhs_text = lhs_text[1..].trim_space()
+				lhs_text = trimmed_space(lhs_text[1..])
 			}
 			if lhs_text.len == 0 {
 				return none
@@ -23986,7 +24293,7 @@ pub fn (tc &TypeChecker) const_int_value_in_module(name string, module_name stri
 		return if op == '**' && power_sign < 0 { -value } else { value }
 	}
 	if expr.len > 1 && expr[0] in [`+`, `-`] {
-		value := tc.const_int_value_in_module(expr[1..].trim_space(), module_name, seen) or {
+		value := tc.const_int_value_in_module(trimmed_space(expr[1..]), module_name, seen) or {
 			return none
 		}
 		return if expr[0] == `-` { -value } else { value }
@@ -23995,7 +24302,7 @@ pub fn (tc &TypeChecker) const_int_value_in_module(name string, module_name stri
 }
 
 fn (tc &TypeChecker) const_int_cast_text_value(text string, module_name string, seen []string) ?int {
-	expr := text.trim_space()
+	expr := trimmed_space(text)
 	if !expr.ends_with(')') {
 		return none
 	}
@@ -24003,7 +24310,7 @@ fn (tc &TypeChecker) const_int_cast_text_value(text string, module_name string, 
 	if open <= 0 {
 		return none
 	}
-	cast_type_name := expr[..open].trim_space()
+	cast_type_name := trimmed_space(expr[..open])
 	if cast_type_name.len == 0 {
 		return none
 	}
@@ -24011,7 +24318,7 @@ fn (tc &TypeChecker) const_int_cast_text_value(text string, module_name string, 
 	if !cast_type.is_integer() {
 		return none
 	}
-	inner := expr[open + 1..expr.len - 1].trim_space()
+	inner := trimmed_space(expr[open + 1..expr.len - 1])
 	if inner.len == 0 {
 		return none
 	}
@@ -24019,13 +24326,13 @@ fn (tc &TypeChecker) const_int_cast_text_value(text string, module_name string, 
 }
 
 fn (tc &TypeChecker) const_int_enum_selector_value(text string) ?int {
-	expr := text.trim_space()
+	expr := trimmed_space(text)
 	dot := expr.last_index_u8(`.`)
 	if dot <= 0 || dot >= expr.len - 1 {
 		return none
 	}
-	enum_name := tc.resolve_enum_name(expr[..dot].trim_space()) or { return none }
-	field := expr[dot + 1..].trim_space()
+	enum_name := tc.resolve_enum_name(trimmed_space(expr[..dot])) or { return none }
+	field := trimmed_space(expr[dot + 1..])
 	for item in tc.comptime_static_enum_decl_value_cases(enum_name) {
 		if item.name == field && item.has_value {
 			return item.value
@@ -24330,7 +24637,7 @@ fn (tc &TypeChecker) interface_method_is_str_requirement(expected_key string) bo
 }
 
 pub fn (tc &TypeChecker) type_has_implicit_str_method(name string) bool {
-	clean := name.trim_space()
+	clean := trimmed_space(name)
 	if clean.len == 0 {
 		return false
 	}
@@ -24384,7 +24691,7 @@ fn (tc &TypeChecker) type_supports_implicit_str(typ Type, mut seen map[string]bo
 }
 
 fn (tc &TypeChecker) type_name_resolves_to_sum_type(name string) bool {
-	mut cur := name.trim_space()
+	mut cur := trimmed_space(name)
 	mut seen := map[string]bool{}
 	for cur.len > 0 {
 		if cur in tc.sum_types {
@@ -24404,7 +24711,7 @@ fn (tc &TypeChecker) type_name_resolves_to_sum_type(name string) bool {
 		if next.len == 0 && !cur.contains('.') {
 			next = tc.type_aliases[tc.qualify_name(cur)] or { '' }
 		}
-		cur = next.trim_space()
+		cur = trimmed_space(next)
 	}
 	return false
 }
@@ -24421,7 +24728,7 @@ fn struct_decl_implements_from_typ(typ string) []string {
 			continue
 		}
 		for iface in part['implements='.len..].split('|') {
-			clean := iface.trim_space()
+			clean := trimmed_space(iface)
 			if clean.len > 0 {
 				out << clean
 			}
@@ -24451,7 +24758,7 @@ fn struct_decl_typ_parts(typ string) []string {
 }
 
 fn marker_type_name(name string) string {
-	mut clean := name.trim_space()
+	mut clean := trimmed_space(name)
 	base, _, ok := generic_type_application_parts(clean)
 	if ok {
 		clean = base
@@ -24467,9 +24774,9 @@ fn interface_marker_matches(name string, target string) bool {
 }
 
 pub fn (tc &TypeChecker) named_type_implements_marker(concrete_name string, target string) bool {
-	mut name := concrete_name.trim_space()
+	mut name := trimmed_space(concrete_name)
 	if name.starts_with('&') {
-		name = name[1..].trim_space()
+		name = trimmed_space(name[1..])
 	}
 	name = marker_type_name(name)
 	mut candidates := [name]
@@ -24838,7 +25145,7 @@ pub fn extend_stable_type_indexes_ref(mut indexes map[string]int, type_names &[]
 	mut names := type_names.clone()
 	names.sort()
 	for raw_name in names {
-		name := raw_name.trim_space()
+		name := trimmed_space(raw_name)
 		if name.len == 0 || name in indexes {
 			continue
 		}
@@ -25066,7 +25373,7 @@ fn generic_type_suffix_for_signature(args []string) string {
 }
 
 fn generic_type_arg_short_for_signature(type_arg string) string {
-	clean := type_arg.trim_space()
+	clean := trimmed_space(type_arg)
 	if clean.starts_with('[]') {
 		return 'Array_${generic_type_arg_short_for_signature(clean[2..])}'
 	}
@@ -25772,7 +26079,7 @@ fn (tc &TypeChecker) interface_field_type(iface_name string, field_name string) 
 
 // struct_field_type supports struct field type handling for TypeChecker.
 fn (tc &TypeChecker) struct_init_field_lookup_name(literal_name string, parsed_name string) string {
-	clean := literal_name.trim_space()
+	clean := trimmed_space(literal_name)
 	if clean.len == 0 {
 		return parsed_name
 	}
@@ -25783,7 +26090,7 @@ fn (tc &TypeChecker) struct_init_field_lookup_name(literal_name string, parsed_n
 		}
 		bracket := clean.index_u8(`[`)
 		if bracket > 0 {
-			base := if parsed_name.len > 0 { parsed_name } else { clean[..bracket].trim_space() }
+			base := if parsed_name.len > 0 { parsed_name } else { trimmed_space(clean[..bracket]) }
 			return base + clean[bracket..]
 		}
 	}
@@ -25937,7 +26244,7 @@ fn (tc &TypeChecker) substitute_generic_type(typ Type, args []string, param_name
 				idx = generic_param_index(name)
 			}
 			if idx >= 0 && idx < args.len {
-				return tc.parse_type(args[idx].trim_space())
+				return tc.parse_type(trimmed_space(args[idx]))
 			}
 		}
 		return typ
@@ -26168,6 +26475,23 @@ fn (tc &TypeChecker) receiver_embeds_inner(actual_name string, expected_name str
 	return false
 }
 
+// trimmed_space is an allocation-free fast path for trim_space: type texts on
+// the checker's hot paths are almost always already clean, and builtin trim
+// clones even when there is nothing to trim.
+@[inline]
+fn trimmed_space(s string) string {
+	if s.len == 0 {
+		return s
+	}
+	c0 := s[0]
+	cl := s[s.len - 1]
+	if c0 != ` ` && c0 != `\n` && c0 != `\t` && c0 != `\v` && c0 != `\f` && c0 != `\r` && cl != ` `
+		&& cl != `\n` && cl != `\t` && cl != `\v` && cl != `\f` && cl != `\r` {
+		return s
+	}
+	return s.trim_space()
+}
+
 fn embedded_field_type(field StructField) ?Type {
 	field_type_name := method_type_name(unwrap_pointer(field.typ))
 	if field_type_name.len == 0 {
@@ -26176,18 +26500,29 @@ fn embedded_field_type(field StructField) ?Type {
 	if field.name.len == 0 {
 		return field.typ
 	}
-	mut names := [field_type_name]
-	base_name, _, is_generic := generic_type_application_parts(field_type_name)
-	if is_generic {
-		names << base_name
+	if embedded_name_matches(field.name, field_type_name) {
+		return field.typ
 	}
-	for name in names {
-		short_name := if name.contains('.') { name.all_after_last('.') } else { name }
-		if field.name == name || field.name == short_name {
-			return field.typ
-		}
+	base_name, _, is_generic := generic_type_application_parts(field_type_name)
+	if is_generic && embedded_name_matches(field.name, base_name) {
+		return field.typ
 	}
 	return none
+}
+
+// embedded_name_matches reports whether `field_name` equals `type_name` or its
+// last dotted segment. Field names cannot contain `.`, so a suffix match with a
+// `.` boundary is exactly the old `all_after_last('.')` comparison without the
+// substring allocation (this runs per struct field on very hot lookup paths).
+@[direct_array_access]
+fn embedded_name_matches(field_name string, type_name string) bool {
+	if field_name == type_name {
+		return true
+	}
+	if type_name.len > field_name.len && type_name.ends_with(field_name) {
+		return type_name[type_name.len - field_name.len - 1] == `.`
+	}
+	return false
 }
 
 // method_signature_compatible supports method signature compatible handling for TypeChecker.
@@ -26381,7 +26716,7 @@ fn (tc &TypeChecker) fixed_array_type_name_matches(a string, b string) bool {
 }
 
 fn fixed_array_type_name_may_be(s string) bool {
-	clean := s.trim_space()
+	clean := trimmed_space(s)
 	if clean.len == 0 || clean.starts_with('[]') || clean.starts_with('map[') {
 		return false
 	}
@@ -26401,8 +26736,8 @@ fn fixed_array_type_name_may_be(s string) bool {
 }
 
 fn (tc &TypeChecker) generic_type_base_matches(a string, b string) bool {
-	a_clean := a.trim_space()
-	b_clean := b.trim_space()
+	a_clean := trimmed_space(a)
+	b_clean := trimmed_space(b)
 	if a_clean == b_clean {
 		return true
 	}
@@ -26436,8 +26771,8 @@ fn (tc &TypeChecker) resolve_generic_match_base(base string) string {
 }
 
 fn (tc &TypeChecker) generic_type_arg_matches(a string, b string) bool {
-	a_clean := a.trim_space()
-	b_clean := b.trim_space()
+	a_clean := trimmed_space(a)
+	b_clean := trimmed_space(b)
 	if a_clean == b_clean {
 		return true
 	}
@@ -26541,7 +26876,7 @@ fn (tc &TypeChecker) bare_variant_name_matches(candidate string, declared string
 	if generic_type_application(candidate) {
 		return false
 	}
-	candidate_base := candidate.trim_space()
+	candidate_base := trimmed_space(candidate)
 	declared_base := strip_generic_args_name(declared).trim_space()
 	concrete_base := strip_generic_args_name(concrete).trim_space()
 	candidate_resolved := tc.resolve_generic_match_base(candidate_base)
@@ -26879,10 +27214,25 @@ pub fn (tc &TypeChecker) cached_c_name(name string) string {
 }
 
 // parse_type converts a V type string (from parser) to a structured Type.
-pub fn (tc &TypeChecker) parse_type(typ string) Type {
-	if typ.contains('typeof(') {
-		return tc.parse_type_uncached(typ)
+// type_text_contains_typeof is a fast substring probe for `typeof(`: type
+// texts are overwhelmingly short scalar/container names, so the length
+// early-out plus a first-byte scan beats string.contains (KMP table build and
+// call overhead) on hot paths that must screen every text.
+@[direct_array_access]
+pub fn type_text_contains_typeof(s string) bool {
+	if s.len < 8 {
+		return false
 	}
+	for i := 0; i + 7 <= s.len; i++ {
+		if s[i] == `t` && s[i + 1] == `y` && s[i + 2] == `p` && s[i + 3] == `e` && s[i + 4] == `o`
+			&& s[i + 5] == `f` && s[i + 6] == `(` {
+			return true
+		}
+	}
+	return false
+}
+
+pub fn (tc &TypeChecker) parse_type(typ string) Type {
 	if tc.type_cache != unsafe { nil } && tc.type_cache.parse_enabled {
 		mut cache := unsafe { tc.type_cache }
 		if cached := parse_type_cache_get(mut cache, tc.cur_file, tc.cur_module, typ,
@@ -26891,11 +27241,21 @@ pub fn (tc &TypeChecker) parse_type(typ string) Type {
 			cache.parse_hits++
 			return cached
 		}
+		// typeof(...) resolves against expression context, so its result must
+		// never enter the cache. Checking only on the miss path keeps the
+		// substring scan off the ~2M cache hits (typeof text can never hit:
+		// it is never put).
+		if type_text_contains_typeof(typ) {
+			return tc.parse_type_uncached(typ)
+		}
 		cache.parse_misses++
 		_, result := tc.intern_type(tc.parse_type_uncached(typ))
 		parse_type_cache_put(mut cache, tc.cur_file, tc.cur_module, typ,
 			tc.fn_context.generic_params, tc.resolution_type_mode, result)
 		return result
+	}
+	if type_text_contains_typeof(typ) {
+		return tc.parse_type_uncached(typ)
 	}
 	_, result := tc.intern_type(tc.parse_type_uncached(typ))
 	return result
@@ -26906,7 +27266,7 @@ pub fn (tc &TypeChecker) parse_type(typ string) Type {
 // aliases. Source text must continue to use parse_type, where aliases take
 // precedence; this entry point is for semantic names carried between phases.
 pub fn (tc &TypeChecker) parse_canonical_type(typ string) Type {
-	clean := typ.trim_space()
+	clean := trimmed_space(typ)
 	if clean.starts_with('&') {
 		_, result := tc.intern_type(Type(Pointer{
 			base_type: tc.parse_canonical_type(clean[1..])
@@ -26951,6 +27311,13 @@ pub fn (tc &TypeChecker) parse_canonical_type(typ string) Type {
 		return result
 	}
 	return tc.parse_type(clean)
+}
+
+fn (tc &TypeChecker) probe_intern_type(t Type) ?Type {
+	if isnil(tc.type_interner) {
+		return none
+	}
+	return tc.type_interner.probe(t)
 }
 
 fn (tc &TypeChecker) intern_type(t Type) (TypeId, Type) {
@@ -27165,7 +27532,7 @@ fn parse_type_cache_put(mut cache TypeCache, file string, module_name string, te
 // inside a generic function/method body the parameter still needs the open application so
 // field lookup and generic receiver method resolution can substitute `T`.
 fn (tc &TypeChecker) parse_scope_param_type(typ string) Type {
-	clean := typ.trim_space()
+	clean := trimmed_space(typ)
 	if clean.starts_with('...') {
 		return Type(Array{
 			elem_type: tc.parse_scope_param_type(clean[3..])
@@ -27178,7 +27545,7 @@ fn (tc &TypeChecker) parse_scope_param_type(typ string) Type {
 }
 
 fn (tc &TypeChecker) parse_open_generic_struct_type(typ string) ?Type {
-	clean := typ.trim_space()
+	clean := trimmed_space(typ)
 	if clean.len == 0 {
 		return none
 	}
@@ -27239,7 +27606,7 @@ fn (tc &TypeChecker) parse_open_generic_struct_type(typ string) ?Type {
 		bracket_end := find_matching_bracket(clean, 0)
 		if bracket_end < clean.len {
 			elem := tc.parse_open_generic_struct_type(clean[bracket_end + 1..]) or { return none }
-			len_text := clean[1..bracket_end].trim_space()
+			len_text := trimmed_space(clean[1..bracket_end])
 			return Type(ArrayFixed{
 				elem_type: elem
 				len:       if is_decimal_int_literal(len_text) { len_text.int() } else { 0 }
@@ -27264,7 +27631,7 @@ fn (tc &TypeChecker) parse_open_generic_struct_type(typ string) ?Type {
 	}
 	mut preserved_args := []string{cap: args.len}
 	for arg in args {
-		trimmed := arg.trim_space()
+		trimmed := trimmed_space(arg)
 		preserved_args << if is_generic_placeholder_type(trimmed) {
 			trimmed.all_after_last('.')
 		} else {
@@ -27302,7 +27669,7 @@ fn (tc &TypeChecker) parse_type_uncached(typ string) Type {
 	if resolved := tc.type_from_typeof_type_text(typ) {
 		return resolved
 	}
-	if typ.trim_space().starts_with('typeof(') {
+	if trimmed_space(typ).starts_with('typeof(') {
 		return unknown_type('unresolved typeof type `${typ}`')
 	}
 	// Preserve open generic struct applications wherever they occur in a signature or
@@ -27400,7 +27767,7 @@ fn (tc &TypeChecker) parse_type_uncached(typ string) Type {
 	if fixed_array_type_name_may_be(typ) && !typ.starts_with('[') {
 		bracket := typ.last_index_u8(`[`)
 		bracket_end := typ.last_index_u8(`]`)
-		len_text := typ[bracket + 1..bracket_end].trim_space()
+		len_text := trimmed_space(typ[bracket + 1..bracket_end])
 		base_text := typ[..bracket]
 		if is_decimal_int_literal(len_text) || base_text.contains('[') {
 			return Type(ArrayFixed{
@@ -27413,7 +27780,7 @@ fn (tc &TypeChecker) parse_type_uncached(typ string) Type {
 	if typ.starts_with('[') {
 		idx := typ.index_u8(`]`)
 		if idx > 0 {
-			len_text := typ[1..idx].trim_space()
+			len_text := trimmed_space(typ[1..idx])
 			return Type(ArrayFixed{
 				elem_type: tc.parse_type(typ[idx + 1..])
 				len:       if is_decimal_int_literal(len_text) { len_text.int() } else { 0 }
@@ -27426,7 +27793,7 @@ fn (tc &TypeChecker) parse_type_uncached(typ string) Type {
 		parts := split_params(inner)
 		mut tuple_types := []Type{}
 		for p in parts {
-			tuple_types << tc.parse_type(p.trim_space())
+			tuple_types << tc.parse_type(trimmed_space(p))
 		}
 		return Type(MultiReturn{
 			types: tuple_types
@@ -27774,7 +28141,7 @@ fn (tc &TypeChecker) parse_type_uncached(typ string) Type {
 		bracket := typ.last_index_u8(`[`)
 		bracket_end := typ.last_index_u8(`]`)
 		if bracket >= 0 && bracket_end > bracket {
-			len_text := typ[bracket + 1..bracket_end].trim_space()
+			len_text := trimmed_space(typ[bracket + 1..bracket_end])
 			return Type(ArrayFixed{
 				elem_type: tc.parse_type(typ[..bracket])
 				len:       if is_decimal_int_literal(len_text) { len_text.int() } else { 0 }
@@ -27793,18 +28160,18 @@ fn (tc &TypeChecker) parse_type_uncached(typ string) Type {
 }
 
 fn (tc &TypeChecker) type_from_typeof_type_text(typ string) ?Type {
-	clean := typ.trim_space()
+	clean := trimmed_space(typ)
 	if !clean.starts_with('typeof(') || !clean.ends_with(')') {
 		return none
 	}
-	inner := clean[7..clean.len - 1].trim_space()
+	inner := trimmed_space(clean[7..clean.len - 1])
 	if inner.len == 0 {
 		return none
 	}
 	if inner.ends_with(']') {
 		open := inner.last_index_u8(`[`)
 		if open > 0 {
-			base_text := inner[..open].trim_space()
+			base_text := trimmed_space(inner[..open])
 			if base_type := tc.type_from_simple_expr_text(base_text) {
 				return tc.resolve_index_base_value_type(unalias_type(base_type))
 			}
@@ -27814,7 +28181,7 @@ fn (tc &TypeChecker) type_from_typeof_type_text(typ string) ?Type {
 }
 
 fn (tc &TypeChecker) type_from_simple_expr_text(expr string) ?Type {
-	clean := expr.trim_space()
+	clean := trimmed_space(expr)
 	if clean.len == 0 {
 		return none
 	}
@@ -28208,7 +28575,7 @@ fn (tc &TypeChecker) parse_fn_type(typ string) Type {
 	if params_str.len > 0 {
 		param_parts := split_params(params_str)
 		for p in param_parts {
-			trimmed := p.trim_space()
+			trimmed := trimmed_space(p)
 			param_type := normalize_fn_type_param_text(trimmed)
 			params << tc.parse_type(param_type)
 		}
@@ -28224,7 +28591,7 @@ fn (tc &TypeChecker) parse_fn_type(typ string) Type {
 }
 
 fn (tc &TypeChecker) c_abi_fn_ptr_type_from_text(typ string) ?string {
-	clean := typ.trim_space()
+	clean := trimmed_space(typ)
 	if !clean.starts_with('fn(') && !clean.starts_with('fn (') {
 		return none
 	}
@@ -28249,7 +28616,7 @@ fn (tc &TypeChecker) c_abi_fn_ptr_type_from_text(typ string) ?string {
 	ret_str := clean[params_end + 1..].trim_left(' ')
 	mut params := []string{}
 	mut has_c_abi_param := false
-	if params_str.trim_space().len > 0 {
+	if trimmed_space(params_str).len > 0 {
 		for part in split_params(params_str) {
 			ct, is_c_abi := tc.c_abi_fn_param_type(part)
 			params << ct
@@ -28269,7 +28636,7 @@ fn (tc &TypeChecker) c_abi_fn_ptr_type_from_text(typ string) ?string {
 
 fn (tc &TypeChecker) c_abi_fn_ptr_type_for_type_text(typ string) ?string {
 	mut seen := map[string]bool{}
-	return tc.c_abi_fn_ptr_type_for_type_text_inner(typ.trim_space(), mut seen)
+	return tc.c_abi_fn_ptr_type_for_type_text_inner(trimmed_space(typ), mut seen)
 }
 
 fn (tc &TypeChecker) c_abi_fn_ptr_type_for_type_text_inner(typ string, mut seen map[string]bool) ?string {
@@ -28297,7 +28664,7 @@ fn (tc &TypeChecker) c_abi_fn_ptr_type_for_type_text_inner(typ string, mut seen 
 }
 
 fn (tc &TypeChecker) c_abi_fn_param_type(param string) (string, bool) {
-	clean := param.trim_space()
+	clean := trimmed_space(param)
 	param_type := normalize_fn_type_param_text(clean)
 	if c_abi_fn_param_name(clean).starts_with('const_') && param_type.starts_with('&') {
 		base_type := tc.parse_type(param_type[1..])
@@ -28334,16 +28701,16 @@ fn c_abi_alias_c_base_type(t Type) ?Type {
 }
 
 fn c_abi_fn_param_name(param string) string {
-	mut text := param.trim_space()
+	mut text := trimmed_space(param)
 	if text.starts_with('mut ') {
-		text = text[4..].trim_space()
+		text = trimmed_space(text[4..])
 	}
 	space := top_level_space_index(text)
 	if space <= 0 {
 		return ''
 	}
-	head := text[..space].trim_space()
-	tail := text[space + 1..].trim_space()
+	head := trimmed_space(text[..space])
+	tail := trimmed_space(text[space + 1..])
 	if fn_type_param_head_is_name(head, tail) {
 		return head
 	}
@@ -29683,7 +30050,7 @@ fn (tc &TypeChecker) struct_c_name_collides_with_v3_runtime(name string, cname s
 }
 
 fn (tc &TypeChecker) c_generic_struct_arg_name(arg string) string {
-	clean := arg.trim_space()
+	clean := trimmed_space(arg)
 	// `voidptr` round-trips through the type model as `&void`. Keep the source ABI
 	// spelling for generic instance names so materialized structs and methods agree.
 	if clean == '&void' {
@@ -29718,7 +30085,7 @@ fn (tc &TypeChecker) c_generic_struct_arg_name(arg string) string {
 }
 
 fn (tc &TypeChecker) c_generic_struct_fixed_array_arg_name(arg string) ?string {
-	clean := arg.trim_space()
+	clean := trimmed_space(arg)
 	if !clean.starts_with('[') {
 		return none
 	}
@@ -29794,7 +30161,7 @@ pub fn (tc &TypeChecker) resolve_generic_struct_method(type_name string, method 
 	if has_type_args {
 		args_str := type_name[bracket + 1..type_name.len - 1]
 		for a in split_generic_arg_list(args_str) {
-			concrete_args << a.trim_space()
+			concrete_args << trimmed_space(a)
 		}
 	}
 	mut generic_base := ''
@@ -29887,7 +30254,7 @@ pub fn (tc &TypeChecker) resolve_generic_struct_method(type_name string, method 
 	if param_texts := tc.fn_param_type_texts[generic_key] {
 		param_types := tc.fn_param_types[generic_key] or { []Type{} }
 		for i, pt in param_texts {
-			receiver_clean := pt.trim_space().trim_left('&').trim_space()
+			receiver_clean := trimmed_space(pt).trim_left('&').trim_space()
 			receiver_base := if receiver_clean.contains('[') {
 				receiver_clean.all_before('[')
 			} else {
@@ -29932,7 +30299,7 @@ fn generic_method_receiver_params_from_key(key string, fallback []string) []stri
 	}
 	mut params := []string{}
 	for param in split_generic_arg_list(receiver[bracket + 1..receiver.len - 1]) {
-		params << param.trim_space()
+		params << trimmed_space(param)
 	}
 	if params.len != fallback.len {
 		return fallback.clone()
@@ -30014,7 +30381,7 @@ pub fn (tc &TypeChecker) resolve_generic_sum_method(type_name string, method str
 	if is_generic {
 		base = parsed_base
 		for arg in parsed_args {
-			concrete_args << arg.trim_space()
+			concrete_args << trimmed_space(arg)
 		}
 	}
 	params := tc.sum_params_for_base(base)
@@ -30057,7 +30424,7 @@ pub fn (tc &TypeChecker) resolve_generic_sum_method(type_name string, method str
 }
 
 fn generic_method_receiver_param(type_name string, param_text string) Type {
-	if param_text.trim_space().starts_with('&') {
+	if trimmed_space(param_text).starts_with('&') {
 		return Type(Pointer{
 			base_type: Type(Struct{
 				name: type_name
@@ -30077,7 +30444,7 @@ fn generic_method_receiver_param(type_name string, param_text string) Type {
 // `map[`, `[N]`) recurse into the element type; a bare parameter name is replaced with its
 // argument.
 fn subst_generic_text(typ string, args []string, params []string) string {
-	clean := typ.trim_space()
+	clean := trimmed_space(typ)
 	if clean.len == 0 || args.len == 0 || params.len != args.len {
 		return clean
 	}
@@ -30150,12 +30517,12 @@ fn subst_generic_text(typ string, args []string, params []string) string {
 		if params_end < clean.len {
 			mut fn_parts := []string{}
 			params_str := clean[params_start..params_end]
-			if params_str.trim_space().len > 0 {
+			if trimmed_space(params_str).len > 0 {
 				for part in split_params(params_str) {
 					fn_parts << subst_generic_text(normalize_fn_type_param_text(part), args, params)
 				}
 			}
-			ret_str := clean[params_end + 1..].trim_space()
+			ret_str := trimmed_space(clean[params_end + 1..])
 			if ret_str.len > 0 {
 				return 'fn(${fn_parts.join(', ')}) ${subst_generic_text(ret_str, args, params)}'
 			}
@@ -30649,23 +31016,23 @@ fn split_params(s string) []string {
 
 // normalize_fn_type_param_text transforms normalize fn type param text data for types.
 fn normalize_fn_type_param_text(param string) string {
-	mut text := param.trim_space()
+	mut text := trimmed_space(param)
 	mut is_mut := false
 	if text.starts_with('mut ') {
 		is_mut = true
-		text = text[4..].trim_space()
+		text = trimmed_space(text[4..])
 	}
 	space := top_level_space_index(text)
 	if space > 0 {
-		head := text[..space].trim_space()
-		tail := text[space + 1..].trim_space()
+		head := trimmed_space(text[..space])
+		tail := trimmed_space(text[space + 1..])
 		if fn_type_param_head_is_name(head, tail) {
 			text = tail
 		}
 	}
 	if text.starts_with('mut ') {
 		is_mut = true
-		text = text[4..].trim_space()
+		text = trimmed_space(text[4..])
 	}
 	if text.len > 0 {
 		for marker in ['[]', '&', 'map[', 'fn(', 'fn ('] {
@@ -30673,8 +31040,8 @@ fn normalize_fn_type_param_text(param string) string {
 			if marker_idx <= 0 {
 				continue
 			}
-			head := text[..marker_idx].trim_space()
-			tail := text[marker_idx..].trim_space()
+			head := trimmed_space(text[..marker_idx])
+			tail := trimmed_space(text[marker_idx..])
 			if fn_type_param_head_is_name(head, tail) {
 				text = tail
 			}

--- a/vlib/v3/types/checker_ownership_d_ownership.v
+++ b/vlib/v3/types/checker_ownership_d_ownership.v
@@ -1,5 +1,6 @@
 module types
 
+import time
 import v3.flat
 import v3.gen.c.naming
 
@@ -602,6 +603,10 @@ fn ownership_merge_drop_entries(existing []OwnershipDropEntry, extra []Ownership
 }
 
 fn (mut tc TypeChecker) ownership_merge_parallel_check_worker(w &TypeChecker) {
+	own_time_sw := time.new_stopwatch()
+	defer {
+		tc.ownership_time_ns += own_time_sw.elapsed().nanoseconds()
+	}
 	if tc.ownership == unsafe { nil } || w.ownership == unsafe { nil } {
 		return
 	}
@@ -4553,6 +4558,10 @@ fn (tc &TypeChecker) ownership_prescan_has_owned_descendant(prefix string, owned
 }
 
 fn (mut tc TypeChecker) ownership_begin_fn(node flat.Node) {
+	own_time_sw := time.new_stopwatch()
+	defer {
+		tc.ownership_time_ns += own_time_sw.elapsed().nanoseconds()
+	}
 	if tc.ownership_checks_suppressed() {
 		return
 	}
@@ -4608,6 +4617,10 @@ fn (mut tc TypeChecker) ownership_begin_fn(node flat.Node) {
 }
 
 fn (mut tc TypeChecker) ownership_begin_fn_literal(id flat.NodeId, node flat.Node) {
+	own_time_sw := time.new_stopwatch()
+	defer {
+		tc.ownership_time_ns += own_time_sw.elapsed().nanoseconds()
+	}
 	if tc.ownership_checks_suppressed() {
 		return
 	}
@@ -4710,6 +4723,10 @@ fn ownership_lambda_name(cur_fn string, id flat.NodeId) string {
 }
 
 fn (mut tc TypeChecker) ownership_begin_lambda_expr(id flat.NodeId, node flat.Node) {
+	own_time_sw := time.new_stopwatch()
+	defer {
+		tc.ownership_time_ns += own_time_sw.elapsed().nanoseconds()
+	}
 	if tc.ownership_checks_suppressed() {
 		return
 	}
@@ -5017,6 +5034,10 @@ fn (mut tc TypeChecker) ownership_note_lambda_local_binding(id flat.NodeId, mut 
 }
 
 fn (mut tc TypeChecker) ownership_end_fn() {
+	own_time_sw := time.new_stopwatch()
+	defer {
+		tc.ownership_time_ns += own_time_sw.elapsed().nanoseconds()
+	}
 	if tc.ownership_checks_suppressed() {
 		return
 	}

--- a/vlib/v3/types/checker_parallel.v
+++ b/vlib/v3/types/checker_parallel.v
@@ -194,10 +194,10 @@ fn (mut tc TypeChecker) check_semantics_parallel() bool {
 		tc.selected_file_worklist = []string{}
 		mut cksw := time.new_stopwatch()
 		tc.check_export_attrs()
-		eprintln('  [ttime]   ck export attrs  ${f64(cksw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+		tc.timing_profile('  [ttime]   ck export attrs  ${f64(cksw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 		cksw.restart()
 		items := tc.collect_parallel_check_items()
-		eprintln('  [ttime]   ck collect items ${f64(cksw.elapsed().microseconds()) / 1000.0:7.2f} ms (items: ${items.len})')
+		tc.timing_profile('  [ttime]   ck collect items ${f64(cksw.elapsed().microseconds()) / 1000.0:7.2f} ms (items: ${items.len})')
 		final_file := tc.cur_file
 		final_module := tc.cur_module
 		was_parallel := tc.run_parallel_check(items)
@@ -312,7 +312,7 @@ fn (mut tc TypeChecker) run_parallel_check(items []CheckWorkItem) bool {
 			w := tc.fork_for_parallel_check()
 			checker_workers << voidptr(w)
 		}
-		eprintln('  [ttime]   ck forks         ${f64(rpsw.elapsed().microseconds()) / 1000.0:7.2f} ms (workers: ${worker_count})')
+		tc.timing_profile('  [ttime]   ck forks         ${f64(rpsw.elapsed().microseconds()) / 1000.0:7.2f} ms (workers: ${worker_count})')
 		mut args := []CheckChunkArgs{cap: chunk_count}
 		for ci in 0 .. chunk_count {
 			mut worker := voidptr(tc)
@@ -346,7 +346,7 @@ fn (mut tc TypeChecker) run_parallel_check(items []CheckWorkItem) bool {
 		check_worker_scope_leave(setup_scope)
 		rpsw2 := time.new_stopwatch()
 		any_started := ast.worker_pool.run(tasks)
-		eprintln('  [ttime]   ck pool.run      ${f64(rpsw2.elapsed().microseconds()) / 1000.0:7.2f} ms (chunks: ${chunk_count})')
+		tc.timing_profile('  [ttime]   ck pool.run      ${f64(rpsw2.elapsed().microseconds()) / 1000.0:7.2f} ms (chunks: ${chunk_count})')
 		if !tc.scope_parallel_check_workers {
 			tc.merge_own_sparse_caches()
 		}
@@ -402,8 +402,8 @@ fn (mut tc TypeChecker) run_parallel_check(items []CheckWorkItem) bool {
 		}
 		mg_clone_ms := f64(mg_clone_ns) / 1e6
 		mg_merge_ms := f64(mg_merge_ns) / 1e6
-		eprintln('  [ttime]     ck mg clone    ${mg_clone_ms:7.2f} ms, merge ${mg_merge_ms:.2f} ms')
-		eprintln('  [ttime]   ck merge         ${f64(rpsw2.elapsed().microseconds()) / 1000.0:7.2f} ms (cumulative)')
+		tc.timing_profile('  [ttime]     ck mg clone    ${mg_clone_ms:7.2f} ms, merge ${mg_merge_ms:.2f} ms')
+		tc.timing_profile('  [ttime]   ck merge         ${f64(rpsw2.elapsed().microseconds()) / 1000.0:7.2f} ms (cumulative)')
 		check_worker_scope_free(setup_scope)
 		tc.sort_parallel_check_errors()
 		return any_started

--- a/vlib/v3/types/checker_parallel.v
+++ b/vlib/v3/types/checker_parallel.v
@@ -2,6 +2,7 @@ module types
 
 import os
 import runtime
+import time
 import v3.flat
 import v3.workers
 
@@ -10,7 +11,7 @@ const max_parallel_check_jobs = 26
 const scoped_check_worker_batches = 8
 // Extra share of the total work (in percent of an even bucket) pre-assigned to
 // the master's bucket; see split_check_items.
-const check_master_bias_pct = i64(60)
+const check_master_bias_pct = i64(0)
 
 struct CheckWorkItem {
 	fn_idx   int
@@ -191,8 +192,12 @@ fn (mut tc TypeChecker) check_semantics_parallel() bool {
 		tc.defer_ierror_gating = tc.diagnostic_files.len > 0
 		tc.selected_file_called_fns = map[string]bool{}
 		tc.selected_file_worklist = []string{}
+		mut cksw := time.new_stopwatch()
 		tc.check_export_attrs()
+		eprintln('  [ttime]   ck export attrs  ${f64(cksw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+		cksw.restart()
 		items := tc.collect_parallel_check_items()
+		eprintln('  [ttime]   ck collect items ${f64(cksw.elapsed().microseconds()) / 1000.0:7.2f} ms (items: ${items.len})')
 		final_file := tc.cur_file
 		final_module := tc.cur_module
 		was_parallel := tc.run_parallel_check(items)
@@ -301,11 +306,13 @@ fn (mut tc TypeChecker) run_parallel_check(items []CheckWorkItem) bool {
 		thread_count := chunk_count - 1
 		setup_scope := check_worker_scope_begin(tc.scope_parallel_check_workers)
 		worker_count := if tc.scope_parallel_check_workers { chunk_count } else { thread_count }
+		rpsw := time.new_stopwatch()
 		mut checker_workers := []voidptr{cap: worker_count}
 		for _ in 0 .. worker_count {
 			w := tc.fork_for_parallel_check()
 			checker_workers << voidptr(w)
 		}
+		eprintln('  [ttime]   ck forks         ${f64(rpsw.elapsed().microseconds()) / 1000.0:7.2f} ms (workers: ${worker_count})')
 		mut args := []CheckChunkArgs{cap: chunk_count}
 		for ci in 0 .. chunk_count {
 			mut worker := voidptr(tc)
@@ -337,26 +344,66 @@ fn (mut tc TypeChecker) run_parallel_check(items []CheckWorkItem) bool {
 			}
 		}
 		check_worker_scope_leave(setup_scope)
+		rpsw2 := time.new_stopwatch()
 		any_started := ast.worker_pool.run(tasks)
+		eprintln('  [ttime]   ck pool.run      ${f64(rpsw2.elapsed().microseconds()) / 1000.0:7.2f} ms (chunks: ${chunk_count})')
 		if !tc.scope_parallel_check_workers {
 			tc.merge_own_sparse_caches()
 		}
 		tc.parallel_check_sparse = false
 		merge_start := if tc.scope_parallel_check_workers { 0 } else { 1 }
+		// Promote scope-resident cache payloads across the pool while every
+		// worker scope is still alive; only unknown-type interning stays serial.
+		par_clone := tc.scope_parallel_check_workers && par_check_clone_enabled()
+		mut clone_args := []CheckCloneChunkArgs{cap: chunk_count}
+		mut mg_clone_ns := u64(0)
+		mut mg_merge_ns := u64(0)
+		if par_clone {
+			mg_t0 := time.sys_mono_now()
+			for ci in 0 .. chunk_count {
+				clone_args << CheckCloneChunkArgs{
+					tc:        voidptr(tc)
+					items_ptr: unsafe { voidptr(&chunks[ci]) }
+					miss:      []int{cap: 1024}
+				}
+			}
+			mut ctasks := []workers.Task{cap: chunk_count}
+			for ci in 0 .. chunk_count {
+				ctasks << workers.Task{
+					run:        check_clone_chunk_thread
+					arg:        unsafe { voidptr(&clone_args[ci]) }
+					force_sync: ci == 0
+				}
+			}
+			ast.worker_pool.run(ctasks)
+			mg_clone_ns += time.sys_mono_now() - mg_t0
+		}
 		for ci in merge_start .. chunk_count {
 			worker_idx := if tc.scope_parallel_check_workers { ci } else { ci - 1 }
 			mut w := unsafe { &TypeChecker(checker_workers[worker_idx]) }
 			scoped := args[ci].scope != unsafe { nil }
 			if scoped {
-				tc.clone_parallel_worker_node_caches(chunks[ci])
+				mg_t0 := time.sys_mono_now()
+				if par_clone {
+					tc.intern_expr_type_misses(clone_args[ci].miss)
+				} else {
+					tc.clone_parallel_worker_node_caches(chunks[ci])
+				}
+				mg_clone_ns += time.sys_mono_now() - mg_t0
 			}
+			mg_t1 := time.sys_mono_now()
 			tc.merge_parallel_check_worker_scoped(w, scoped)
+			mg_merge_ns += time.sys_mono_now() - mg_t1
 			if scoped {
 				check_worker_scope_free(args[ci].scope)
 			} else {
 				w.free_parallel_check_worker_cache()
 			}
 		}
+		mg_clone_ms := f64(mg_clone_ns) / 1e6
+		mg_merge_ms := f64(mg_merge_ns) / 1e6
+		eprintln('  [ttime]     ck mg clone    ${mg_clone_ms:7.2f} ms, merge ${mg_merge_ms:.2f} ms')
+		eprintln('  [ttime]   ck merge         ${f64(rpsw2.elapsed().microseconds()) / 1000.0:7.2f} ms (cumulative)')
 		check_worker_scope_free(setup_scope)
 		tc.sort_parallel_check_errors()
 		return any_started
@@ -415,11 +462,11 @@ fn check_job_count(n_runtime_jobs int, n_items int) int {
 fn split_check_items(items []CheckWorkItem, n int) [][]CheckWorkItem {
 	mut buckets := [][]CheckWorkItem{len: n, init: []CheckWorkItem{}}
 	mut loads := []i64{len: n}
-	if n > 1 {
-		// The master (bucket 0) runs on a busy performance core while several
-		// workers inevitably land on efficiency cores; measured per-unit it
-		// finishes its even share early and waits for the pool. Give it a proportionally
-		// heavier share by starting it with negative load.
+	if n > 1 && check_master_bias_pct != 0 {
+		// Historical bias: bucket 0 once finished early on this split. Measured
+		// 2026-07-25 the master chunk was instead the pool tail by ~30% (its
+		// span cost undercounts the dense builtin bodies), so the bias is off;
+		// the knob stays for machines where the old premise holds.
 		mut total := i64(0)
 		for it in items {
 			total += i64(it.cost) + 1
@@ -732,8 +779,14 @@ fn (mut tc TypeChecker) restore_type_cache_base() {
 fn (tc &TypeChecker) fork_for_parallel_check() &TypeChecker {
 	mut w := tc.fork_program_view(tc.a, map[int][]SymbolId{})
 	// Parallel checker workers may populate this cache concurrently, so each
-	// worker (and each disposable scoped batch) owns its maps.
-	w.visible_mutation_cache = new_visible_mutation_cache()
+	// worker (and each disposable scoped batch) owns mutable result/miss maps while
+	// sharing the declaration index that collect completed before checking starts.
+	w.visible_mutation_cache = &VisibleMutationCache{
+		decls:            tc.visible_mutation_cache.decls
+		decl_misses:      map[string]bool{}
+		results:          map[u64]bool{}
+		decl_index_ready: tc.visible_mutation_cache.decl_index_ready
+	}
 	w.scope_parallel_check_workers = tc.scope_parallel_check_workers
 	// The node-indexed cache arrays are intentionally SHARED with the master
 	// (the fork copies the slice headers): each work item owns the disjoint
@@ -754,6 +807,11 @@ fn (tc &TypeChecker) fork_for_parallel_check() &TypeChecker {
 	w.fn_context = new_function_check_context()
 	w.generic_method_value_info = map[string]CallInfo{}
 	w.smartcasts = map[string]Type{}
+	w.ownership_time_ns = 0
+	if check_memos_enabled() {
+		w.import_info_cache = &ImportInfoCache{}
+		w.qualify_name_cache = &QualifyNameCache{}
+	}
 	$if ownership ? {
 		w.ownership_fork_for_parallel_check(tc)
 	}
@@ -786,6 +844,53 @@ fn (tc &TypeChecker) fork_for_parallel_check() &TypeChecker {
 		w.type_cache.base = unsafe { nil }
 	}
 	return &w
+}
+
+struct CheckCloneChunkArgs {
+	tc        voidptr
+	items_ptr voidptr
+mut:
+	miss []int
+}
+
+// check_clone_chunk_thread promotes one chunk's node-cache payloads out of
+// the (still alive) worker scopes: name clones land in the pool thread's
+// persistent arena, and expr types are rebound via a read-only interner probe.
+// Types the interner does not know yet are recorded and interned serially in
+// chunk order afterwards, so interner ids match the serial merge exactly.
+fn check_clone_chunk_thread(arg voidptr) voidptr {
+	mut a := unsafe { &CheckCloneChunkArgs(arg) }
+	mut tc := unsafe { &TypeChecker(a.tc) }
+	items := unsafe { &[]CheckWorkItem(a.items_ptr) }
+	for item in *items {
+		for idx in item.range_lo .. item.fn_idx + 1 {
+			if idx < tc.resolved_call_set.len && tc.resolved_call_set[idx] {
+				tc.resolved_call_names[idx] = tc.resolved_call_names[idx].clone()
+			}
+			if idx < tc.resolved_fn_value_set.len && tc.resolved_fn_value_set[idx] {
+				tc.resolved_fn_value_names[idx] = tc.resolved_fn_value_names[idx].clone()
+			}
+			if idx < tc.expr_type_set.len && tc.expr_type_set[idx] {
+				if canonical := tc.probe_intern_type(tc.expr_type_values[idx]) {
+					tc.expr_type_values[idx] = canonical
+				} else {
+					a.miss << idx
+				}
+			}
+		}
+	}
+	return unsafe { nil }
+}
+
+fn (mut tc TypeChecker) intern_expr_type_misses(indexes []int) {
+	for idx in indexes {
+		_, canonical := tc.intern_type(clone_owned_type(tc.expr_type_values[idx]))
+		tc.expr_type_values[idx] = canonical
+	}
+}
+
+fn par_check_clone_enabled() bool {
+	return os.getenv('V3_NO_PAR_CK_CLONE') == ''
 }
 
 fn (mut tc TypeChecker) clone_parallel_worker_node_caches(items []CheckWorkItem) {
@@ -856,6 +961,7 @@ fn (mut tc TypeChecker) merge_parallel_check_worker_scoped(w &TypeChecker, scope
 		tc.type_cache.c_hits += w.type_cache.c_hits
 		tc.type_cache.c_misses += w.type_cache.c_misses
 	}
+	tc.ownership_time_ns += w.ownership_time_ns
 	$if ownership ? {
 		tc.ownership_merge_parallel_check_worker(w)
 	}

--- a/vlib/v3/types/checker_parallel_test.v
+++ b/vlib/v3/types/checker_parallel_test.v
@@ -6,6 +6,29 @@ import v3.flat
 import v3.parser
 import v3.pref
 
+fn test_fast_file_index_collects_translated_module_attribute() {
+	old_no_file_idx := os.getenv_opt('V3_NO_FILE_IDX')
+	os.unsetenv('V3_NO_FILE_IDX')
+	defer {
+		if value := old_no_file_idx {
+			os.setenv('V3_NO_FILE_IDX', value, true)
+		}
+	}
+	path := os.join_path(os.vtmp_dir(), 'v3_translated_file_index_${os.getpid()}.v')
+	os.write_file(path, '@[translated]\nmodule main\n\nfn main() {}\n') or { panic(err) }
+	defer {
+		os.rm(path) or {}
+	}
+	mut p := parser.Parser.new(pref.new_preferences())
+	a := p.parse_file(path)
+	assert p.diagnostics.len == 0, p.diagnostics.str()
+	assert file_index_usable(a)
+
+	mut tc := TypeChecker.new(a)
+	tc.collect(a)
+	assert tc.translated_files[path]
+}
+
 fn test_parallel_checker_dependencies_are_private_and_merged() {
 	a := flat.FlatAst.new()
 	mut tc := TypeChecker.new(&a)

--- a/vlib/v3/types/scope.v
+++ b/vlib/v3/types/scope.v
@@ -4,10 +4,16 @@ module types
 @[heap]
 pub struct Scope {
 pub mut:
-	parent          &Scope = unsafe { nil }
-	names           []string
-	types           []Type
-	name_indexes    map[string]int
+	parent       &Scope = unsafe { nil }
+	names        []string
+	types        []Type
+	name_indexes map[string]int
+	// name_mask is a conservative bloom filter over this scope's own binding
+	// names: a cleared bit proves the name is absent, letting chain walks skip
+	// the per-level map probe (most lookups walk many levels that do not bind
+	// the name at all). False positives only cost the probe they would have
+	// paid anyway.
+	name_mask       u64
 	generations     []int
 	storage_keys    []string
 	next_generation int
@@ -21,6 +27,12 @@ pub struct ScopeBindingOwner {
 	lifetime    int
 	name        string
 	storage_key string
+}
+
+@[inline]
+fn scope_name_bit(name string) u64 {
+	first := if name.len > 0 { u32(name[0]) } else { 0 }
+	return u64(1) << ((first * 33 + u32(name.len)) & 63)
 }
 
 // new_scope returns a reusable type-checker scope with an optional parent.
@@ -45,6 +57,7 @@ pub fn (mut s Scope) reset(parent &Scope) {
 	// occupant from the new one, so binding identity (storage_key,
 	// nearest_binding_owned_by) stays exact in every build mode.
 	s.lifetime++
+	s.name_mask = 0
 	$if !ownership ? {
 		s.name_indexes.clear()
 	}
@@ -61,10 +74,13 @@ pub fn (s &Scope) lookup(name string) ?Type {
 	}
 	$if !ownership ? {
 		// Only the local pointer is reassigned; the scopes remain read-only.
+		bit := scope_name_bit(name)
 		mut scope := unsafe { &Scope(s) }
 		for scope != unsafe { nil } {
-			if i := scope.name_indexes[name] {
-				return scope.types[i]
+			if scope.name_mask & bit != 0 {
+				if i := scope.name_indexes[name] {
+					return scope.types[i]
+				}
 			}
 			scope = scope.parent
 		}
@@ -88,8 +104,13 @@ pub fn (s &Scope) lookup_owner(name string) ?ScopeBindingOwner {
 	}
 	$if !ownership ? {
 		// Only the local pointer is reassigned; the scopes remain read-only.
+		bit := scope_name_bit(name)
 		mut scope := unsafe { &Scope(s) }
 		for scope != unsafe { nil } {
+			if scope.name_mask & bit == 0 {
+				scope = scope.parent
+				continue
+			}
 			if i := scope.name_indexes[name] {
 				return ScopeBindingOwner{
 					scope:       scope
@@ -211,6 +232,7 @@ pub fn (mut s Scope) insert_with_owner(name string, typ Type) ScopeBindingOwner 
 		}
 		s.names << name
 		s.types << typ
+		s.name_mask |= scope_name_bit(name)
 		s.name_indexes[name] = s.names.len - 1
 		index := s.names.len - 1
 		storage_key := scope_binding_storage_key(s, s.lifetime, index, 0)

--- a/vlib/v3/types/type_interner.v
+++ b/vlib/v3/types/type_interner.v
@@ -46,6 +46,26 @@ fn (mut i TypeInterner) intern_locked(t Type) (TypeId, Type) {
 	return id, i.types[int(id)]
 }
 
+// probe returns the canonical copy when t is already interned, WITHOUT
+// mutating the interner or taking its lock. Callers must guarantee no
+// concurrent inserts (the parallel check-merge clone pass runs while the
+// master is joined and workers only use private interners).
+fn (i &TypeInterner) probe(t Type) ?Type {
+	mut key := semantic_type_hash(t)
+	for {
+		id := i.buckets[key] or { return none }
+		if int(id) < 0 || int(id) >= i.types.len {
+			return none
+		}
+		candidate := i.types[int(id)]
+		if semantic_types_equal(candidate, t) {
+			return candidate
+		}
+		key = type_hash_tag(key, 0x5bd1e995)
+	}
+	return none
+}
+
 fn (mut i TypeInterner) name(id TypeId) string {
 	i.lock.lock()
 	defer {

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -151,6 +151,38 @@ fn tcc_atomic_s_arg(prefs &pref.Preferences) string {
 	return atomic_s
 }
 
+// tcc_atomic_arg returns the atomic-support argument for a tcc link,
+// preferring a cached precompiled object: assembling atomic.S inside every
+// link costs ~28ms, while the object only changes when the source does.
+fn tcc_atomic_arg(prefs &pref.Preferences, tcc_path string, tcc_includes string) string {
+	atomic_s := tcc_atomic_s_arg(prefs)
+	if atomic_s.len == 0 {
+		return ''
+	}
+	cache_dir := os.join_path(os.vtmp_dir(), 'v3_thirdparty_objs')
+	signature := modulecache.file_signature(atomic_s)
+	if signature.len == 0 {
+		return atomic_s
+	}
+	object_path := os.join_path(cache_dir, 'atomic_${naming.sanitize(signature)}.o')
+	if os.is_file(object_path) {
+		return object_path
+	}
+	os.mkdir_all(cache_dir) or { return atomic_s }
+	build_path := '${object_path}.tmp.${os.getpid()}'
+	result := cmdexec.run(tcc_path, ['-std=gnu11', tcc_includes, '-c', atomic_s, '-o', build_path])
+	if result.exit_code != 0 || !os.is_file(build_path) {
+		os.rm(build_path) or {}
+		return atomic_s
+	}
+	// Atomic rename: concurrent builds publishing the same signature converge.
+	os.mv(build_path, object_path) or {
+		os.rm(build_path) or {}
+		return atomic_s
+	}
+	return object_path
+}
+
 struct CObjectCacheStats {
 mut:
 	requests                  int
@@ -188,6 +220,27 @@ fn cpp_runtime_link_flag(target pref.Target) string {
 }
 
 fn prepare_c_flags_for_link(flags []string, c99 bool, pic_flag string, target_args []string, target pref.Target, c_compiler string, uncached_dir string, mut stats CObjectCacheStats) ![]string {
+	// Nothing to cache: without object-file or native-source flags the link
+	// plan adds no value, and preparing it costs a compiler-identity probe
+	// (subprocess) plus plan-file signatures on every build.
+	mut has_cacheable_flag := false
+	for flag in flags {
+		clean := flag.trim_space()
+		if c_flag_is_object_file(clean) || clean.ends_with('.mm') {
+			has_cacheable_flag = true
+			break
+		}
+	}
+	if !has_cacheable_flag {
+		mut passthrough := flags.clone()
+		if c_link_flags_use_cpp_language(passthrough) {
+			cpp_runtime := cpp_runtime_link_flag(target)
+			if cpp_runtime !in passthrough {
+				passthrough << cpp_runtime
+			}
+		}
+		return passthrough
+	}
 	support_flags := c_object_compile_support_flags(flags)
 	cache_dir := os.join_path(os.vtmp_dir(), 'v3_thirdparty_objs')
 	os.mkdir_all(cache_dir)!
@@ -2674,16 +2727,88 @@ fn promote_scoped_node(mut node flat.Node, scope voidptr) {
 	node.set_generic_params(params)
 }
 
-fn promote_scoped_ast_nodes(mut ast flat.FlatAst, base_nodes int, new_end int, owned_base_nodes []int, scope voidptr) {
+// promote_scoped_ast_nodes_flagged is the scoped-node promotion walk with an optional
+// pre-computed scoped-text flag array (one byte per node id): unflagged nodes in
+// the appended range are known not to hold scope-owned text and are skipped.
+fn promote_scoped_ast_nodes_flagged(mut ast flat.FlatAst, base_nodes int, new_end int, owned_base_nodes []int, scope voidptr, flags []u8) {
+	// When the whole-array ownership flags were computed, they cover the logged
+	// base nodes too: unflagged entries hold no scope-owned text and their
+	// promotion would be a no-op.
+	use_flags_for_base := flags.len >= ast.nodes.len
 	for idx in owned_base_nodes {
 		if idx >= 0 && idx < base_nodes && idx < ast.nodes.len {
+			if use_flags_for_base && flags[idx] == 0 {
+				continue
+			}
 			promote_scoped_node(mut ast.nodes[idx], scope)
 		}
 	}
 	limit := if new_end < ast.nodes.len { new_end } else { ast.nodes.len }
+	if flags.len >= limit && base_nodes >= 0 {
+		// Word-scan the flag range: flagged nodes are rare, so loading eight
+		// flags per u64 makes this walk almost free.
+		word_data := unsafe { &u64(flags.data) }
+		mut idx := base_nodes
+		for idx < limit {
+			if idx % 8 == 0 && idx + 8 <= limit && unsafe { word_data[idx / 8] } == 0 {
+				idx += 8
+				continue
+			}
+			if flags[idx] != 0 {
+				promote_scoped_node(mut ast.nodes[idx], scope)
+			}
+			idx++
+		}
+		return
+	}
 	for idx in base_nodes .. limit {
+		if idx < flags.len && flags[idx] == 0 {
+			continue
+		}
 		promote_scoped_node(mut ast.nodes[idx], scope)
 	}
+}
+
+// canonicalize_scoped_node_cached is canonicalize_scoped_node with a pointer
+// probe over the caller's cache arrays: owned texts repeat the same shared
+// string instances heavily, so most content-hash intern lookups are skipped.
+fn canonicalize_scoped_node_cached(mut ast flat.FlatAst, idx int, scope voidptr, mut cache_ptrs []voidptr, mut cache_vals []string) {
+	if idx < 0 || idx >= ast.nodes.len {
+		return
+	}
+	mut node := unsafe { &ast.nodes[idx] }
+	if node.value.len > 0 && scoped_value_owned(scope, node.value.str) {
+		node.value = ast.intern_text_ptr_cached(node.value, mut cache_ptrs, mut cache_vals)
+	}
+	if node.typ.len > 0 && scoped_value_owned(scope, node.typ.str) {
+		node.typ = ast.intern_text_ptr_cached(node.typ, mut cache_ptrs, mut cache_vals)
+	}
+	old_params := node.generic_params()
+	if old_params.len == 0 {
+		return
+	}
+	mut needs_params := scoped_value_owned(scope, node.payload)
+		|| scoped_value_owned(scope, old_params.data)
+	if !needs_params {
+		for param in old_params {
+			if param.len > 0 && scoped_value_owned(scope, param.str) {
+				needs_params = true
+				break
+			}
+		}
+	}
+	if !needs_params {
+		return
+	}
+	mut params := []string{cap: old_params.len}
+	for param in old_params {
+		if param.len > 0 && scoped_value_owned(scope, param.str) {
+			params << ast.intern_text_ptr_cached(param, mut cache_ptrs, mut cache_vals)
+		} else {
+			params << param
+		}
+	}
+	node.set_generic_params(params)
 }
 
 fn canonicalize_scoped_node(mut ast flat.FlatAst, idx int, scope voidptr) {
@@ -2863,22 +2988,26 @@ fn promote_scoped_monomorph_metadata(mut tc types.TypeChecker) {
 	tc.sum_generic_params = clone_string_list_map(tc.sum_generic_params)
 }
 
-fn promote_scoped_checker_node_caches(mut tc types.TypeChecker, scope voidptr, generated_start int) {
-	for idx in 0 .. tc.resolved_call_names.len {
-		if idx < tc.resolved_call_set.len && tc.resolved_call_set[idx] {
-			name := tc.resolved_call_names[idx]
-			if name.len > 0 && scoped_value_owned(scope, name.str) {
-				tc.resolved_call_names[idx] = name.clone()
+fn promote_scoped_checker_node_caches(mut tc types.TypeChecker, a &flat.FlatAst, scope voidptr, generated_start int) {
+	// The per-id loops write disjoint slots and only allocate clones, so fan
+	// them out over the worker pool; fall back to the serial walk without one.
+	if !transform.promote_scoped_checker_node_caches_parallel(mut tc, a, scope, generated_start) {
+		for idx in 0 .. tc.resolved_call_names.len {
+			if idx < tc.resolved_call_set.len && tc.resolved_call_set[idx] {
+				name := tc.resolved_call_names[idx]
+				if name.len > 0 && scoped_value_owned(scope, name.str) {
+					tc.resolved_call_names[idx] = name.clone()
+				}
 			}
-		}
-		if idx < tc.resolved_fn_value_set.len && tc.resolved_fn_value_set[idx] {
-			name := tc.resolved_fn_value_names[idx]
-			if name.len > 0 && scoped_value_owned(scope, name.str) {
-				tc.resolved_fn_value_names[idx] = name.clone()
+			if idx < tc.resolved_fn_value_set.len && tc.resolved_fn_value_set[idx] {
+				name := tc.resolved_fn_value_names[idx]
+				if name.len > 0 && scoped_value_owned(scope, name.str) {
+					tc.resolved_fn_value_names[idx] = name.clone()
+				}
 			}
-		}
-		if idx >= generated_start && idx < tc.expr_type_set.len && tc.expr_type_set[idx] {
-			tc.expr_type_values[idx] = types.clone_owned_type(tc.expr_type_values[idx])
+			if idx >= generated_start && idx < tc.expr_type_set.len && tc.expr_type_set[idx] {
+				tc.expr_type_values[idx] = types.clone_owned_type(tc.expr_type_values[idx])
+			}
 		}
 	}
 	// The dense caches are reserved in the parent arena, but an unexpectedly
@@ -2915,19 +3044,19 @@ fn promote_scoped_checker_node_caches(mut tc types.TypeChecker, scope voidptr, g
 	tc.sparse_checking_nodes = tc.sparse_checking_nodes.clone()
 }
 
-fn promote_scoped_signatures(mut tc types.TypeChecker, original_names []string) {
+fn promote_scoped_signatures(mut tc types.TypeChecker, original_names map[string]bool) {
+	// Set difference instead of the former sort-and-merge: only a handful of
+	// signatures are added during transform, while sorting every fn name twice
+	// cost several ms per build.
 	mut added_names := []string{}
-	mut current_names := tc.fn_ret_types.keys()
-	current_names.sort()
-	mut original_idx := 0
-	for name in current_names {
-		for original_idx < original_names.len && original_names[original_idx] < name {
-			original_idx++
-		}
-		if original_idx >= original_names.len || original_names[original_idx] != name {
+	for name, _ in tc.fn_ret_types {
+		if name !in original_names {
 			added_names << name
 		}
 	}
+	// Keep the former sorted processing order: the delete/reinsert below
+	// determines these entries' map iteration order for later phases.
+	added_names.sort()
 	for name in added_names {
 		ret := types.clone_owned_type(tc.fn_ret_types[name] or { continue })
 		params := if values := tc.fn_param_types[name] {
@@ -3248,6 +3377,7 @@ fn restore_transformed_fn_value_types(mut tc types.TypeChecker, a &flat.FlatAst,
 
 // main runs the v3 entry point.
 fn main() {
+	println(1234)
 	args := os.args[1..]
 	if args.len == 0 {
 		eprintln(cli_usage())
@@ -4016,7 +4146,10 @@ fn main() {
 		}
 		pre_tc.reject_unsupported_generics = is_selfhost
 		set_diagnostic_files(mut pre_tc, user_files)
+		mut cvsw := time.new_stopwatch()
 		pre_tc.collect(a)
+		eprintln('  [ttime]   ck collect       ${f64(cvsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+		cvsw.restart()
 		pre_tc.diagnose_unknown_calls = true
 		pre_tc.prepare_threads_condition()
 		set_unsupported_generic_files(mut pre_tc, a, is_selfhost, diagnostic_root)
@@ -4025,6 +4158,7 @@ fn main() {
 		} else {
 			pre_tc.prepare_interface_requirement_indexes()
 		}
+		eprintln('  [ttime]   ck iface idx     ${f64(cvsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 		mut check_was_parallel := false
 		if incremental_cache_hit {
 			pre_tc.check_semantics_selected(incremental_changed_names)
@@ -4037,8 +4171,10 @@ fn main() {
 		}
 		incremental_uses_generics = incremental_cache_hit
 			&& incremental_changed_functions_use_generics(a, pre_tc, incremental_changed_names)
+		cvsw.restart()
 		pre_tc.prune_inactive_top_level_comptime(mut a)
 		test_harness_errors := validate_test_file_harness_inputs(a, pre_tc, test_files)
+		eprintln('  [ttime]   ck prune+harness ${f64(cvsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 		if test_harness_errors.len > 0 {
 			for msg in test_harness_errors {
 				eprintln(msg)
@@ -4071,6 +4207,10 @@ fn main() {
 		} else {
 			b.step_parallel('check', check_was_parallel)
 		}
+		// Ownership analysis only exists in `-d ownership` builds and runs
+		// interleaved inside check; report its accumulated time as a dedicated
+		// stage so plain builds visibly spend exactly 0 on it.
+		b.step_measured('ownership', pre_tc.ownership_time_spent_us())
 		b.metric('functions collected', pre_tc.fn_ret_types.len, 'symbols')
 		b.metric('structs collected', pre_tc.structs.len, 'types')
 		b.metric('canonical semantic types', pre_tc.type_count(), 'types')
@@ -4115,14 +4255,22 @@ fn main() {
 		} else if test_files.len > 0 {
 			used_fns, uses_generics = markused.mark_used_for_tests_with_generic_usage(a,
 				markused_tc, test_files)
+		} else if building_v {
+			used_fns = markused.mark_used_without_generic_detection(a, markused_tc)
+			uses_generics = false
 		} else {
 			used_fns, uses_generics = markused.mark_used_with_generic_usage(a, markused_tc)
 		}
 		if cache_state.manager.enabled && !generic_cache_hit {
-			mut cache_uses_generics := false
-			used_fns, cache_uses_generics = markused.mark_used_for_cache_with_generic_usage(a,
-				markused_tc, test_files, cache_state.source_body_modules)
-			uses_generics = uses_generics || cache_uses_generics
+			if building_v {
+				used_fns = markused.mark_used_for_cache_without_generic_detection(a, markused_tc,
+					test_files, cache_state.source_body_modules)
+			} else {
+				mut cache_uses_generics := false
+				used_fns, cache_uses_generics = markused.mark_used_for_cache_with_generic_usage(a,
+					markused_tc, test_files, cache_state.source_body_modules)
+				uses_generics = uses_generics || cache_uses_generics
+			}
 		}
 		if scope_prealloc_markused && !generic_cache_hit {
 			prealloc_scope_leave_for_v3(markused_scope)
@@ -4138,12 +4286,12 @@ fn main() {
 		mut transform_was_parallel := false
 		mut transform_errors := []string{}
 		mut incremental_synthesized_helpers := []string{}
-		if !building_v && !cmd_v_build && !uses_generics && ast_contains_sql_expr(a) {
+		if !building_v && !uses_generics && ast_contains_sql_expr(a) {
 			uses_generics = true
 		}
 		// Markused distinguishes reachable generic calls/types from generic templates
 		// that merely came along with an imported module (notably sync and rand).
-		skip_transform_generics = building_v || cmd_v_build || !uses_generics
+		skip_transform_generics = building_v || !uses_generics
 		if incremental_cache_hit {
 			skip_transform_generics = true
 		}
@@ -4162,7 +4310,11 @@ fn main() {
 		} else if scope_prealloc_transform {
 			// Keep the large escaping AST/cache slabs in the compilation arena, while
 			// transformer indexes and per-body temporary state use a stage arena.
-			transform.reserve_parallel_transform_ast(mut a, skip_transform_generics)
+			if cache_state.manager.enabled {
+				transform.reserve_parallel_transform_cache_ast(mut a, skip_transform_generics)
+			} else {
+				transform.reserve_parallel_transform_ast(mut a, skip_transform_generics)
+			}
 			pre_tc.begin_sparse_transform_node_caches(a.nodes.len)
 			pre_tc.reserve_scoped_transform_metadata(scoped_transform_signature_headroom)
 			base_transform_nodes := a.nodes.len
@@ -4172,50 +4324,88 @@ fn main() {
 			base_type_count := pre_tc.type_count()
 			base_symbol_count := pre_tc.symbol_count()
 			base_text_count := a.text_values.len
-			mut original_signature_names := pre_tc.fn_ret_types.keys()
-			original_signature_names.sort()
+			mut original_signature_names := map[string]bool{}
+			for name, _ in pre_tc.fn_ret_types {
+				original_signature_names[name] = true
+			}
 			transform_scope := prealloc_scope_begin_for_v3()
 			mut scoped_owned_base_nodes := []int{}
 			mut retained_transform_regions := []transform.ScopedTransformRegion{}
 			transform_used_fns, transform_was_parallel, transform_errors, scoped_owned_base_nodes, retained_transform_regions = transform.transform_with_used_opt_config_scoped_workers_checked_owned(mut a,
 				&pre_tc, transform_used_fns, current_parallel_transform, skip_transform_generics,
-				true, building_v || cmd_v_build, transform_scope)
+				true, building_v, transform_scope)
 			parse_cache_enabled := pre_tc.type_cache_parse_enabled()
+			mut post_sw := time.new_stopwatch()
 			prealloc_scope_leave_for_v3(transform_scope)
 			retained_transform_regions = clone_scoped_transform_regions(retained_transform_regions)
 			pre_tc.promote_scoped_transform_interners(base_type_count, base_symbol_count,
 				transform_scope)
+			eprintln('  [ttime] promote interners  ${f64(post_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+			post_sw.restart()
 			if a.nodes.cap == reserved_nodes_cap && a.children.cap == reserved_children_cap
 				&& !scoped_value_owned(transform_scope, a.nodes.data)
 				&& !scoped_value_owned(transform_scope, a.children.data) {
 				a.promote_transform_texts_from(base_text_count, transform_scope)
+				eprintln('  [ttime] promote texts      ${f64(post_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+				post_sw.restart()
 				// Lowering can rewrite arbitrary pre-existing nodes, including type text
-				// on otherwise non-generic expressions. Scan the small payload fields before
-				// releasing the outer arena; the worker-owned regions are handled below.
-				for idx in 0 .. a.nodes.len {
-					canonicalize_scoped_node(mut a, idx, transform_scope)
-				}
-				if retained_transform_regions.len > 0 {
-					outer_new_end := retained_transform_regions[0].new_start
-					promote_scoped_ast_nodes(mut a, base_transform_nodes, outer_new_end,
-						scoped_owned_base_nodes, transform_scope)
-					// Late lowering can rewrite nodes that live in a retained worker region
-					// while allocating their replacement text in the outer transform arena.
-					// Publish those strings before releasing that arena; the worker-owned
-					// fields in the same regions are canonicalized below from their own scope.
-					for region in retained_transform_regions {
-						canonicalize_scoped_transform_region_from_scope(mut a, region,
-							transform_scope)
-					}
-					last_worker_end := retained_transform_regions.last().new_end
-					promote_scoped_ast_nodes(mut a, last_worker_end, a.nodes.len, []int{},
+				// on otherwise non-generic expressions. Publish every scope-owned
+				// text before releasing the outer arena. Without retained regions
+				// one fused pool pass (ownership check + table-hit reuse + clone)
+				// replaces the serial canonicalize + promote walks.
+				mut fused_text_promote := false
+				if retained_transform_regions.len == 0
+					&& os.getenv('V3_NO_FUSED_TEXT_PROMOTE') == '' {
+					fused_text_promote = transform.promote_scoped_texts_parallel(mut a,
 						transform_scope)
-				} else {
-					// Workers report every rewritten base node. Publish those and the
-					// appended range without rebuilding the text table for the source AST.
-					promote_scoped_ast_nodes(mut a, base_transform_nodes, a.nodes.len,
-						scoped_owned_base_nodes, transform_scope)
-					transform_texts_canonical = true
+					if fused_text_promote {
+						transform_texts_canonical = true
+					}
+				}
+				eprintln('  [ttime] canon nodes        ${f64(post_sw.elapsed().microseconds()) / 1000.0:7.2f} ms (n: ${a.nodes.len}, fused: ${fused_text_promote})')
+				post_sw.restart()
+				if !fused_text_promote {
+					mut scoped_text_flags := []u8{len: a.nodes.len}
+					if transform.scan_scoped_text_flags_parallel(a, transform_scope, mut
+						scoped_text_flags)
+					{
+						mut canon_cache_ptrs := unsafe { []voidptr{len: 4096} }
+						mut canon_cache_vals := []string{len: 4096}
+						for idx, flag in scoped_text_flags {
+							if flag != 0 {
+								canonicalize_scoped_node_cached(mut a, idx, transform_scope, mut
+									canon_cache_ptrs, mut canon_cache_vals)
+							}
+						}
+					} else {
+						scoped_text_flags = []u8{}
+						for idx in 0 .. a.nodes.len {
+							canonicalize_scoped_node(mut a, idx, transform_scope)
+						}
+					}
+					if retained_transform_regions.len > 0 {
+						outer_new_end := retained_transform_regions[0].new_start
+						promote_scoped_ast_nodes_flagged(mut a, base_transform_nodes,
+							outer_new_end, scoped_owned_base_nodes, transform_scope,
+							scoped_text_flags)
+						// Late lowering can rewrite nodes that live in a retained worker region
+						// while allocating their replacement text in the outer transform arena.
+						// Publish those strings before releasing that arena; the worker-owned
+						// fields in the same regions are canonicalized below from their own scope.
+						for region in retained_transform_regions {
+							canonicalize_scoped_transform_region_from_scope(mut a, region,
+								transform_scope)
+						}
+						last_worker_end := retained_transform_regions.last().new_end
+						promote_scoped_ast_nodes_flagged(mut a, last_worker_end, a.nodes.len,
+							[]int{}, transform_scope, scoped_text_flags)
+					} else {
+						// Workers report every rewritten base node. Publish those and the
+						// appended range without rebuilding the text table for the source AST.
+						promote_scoped_ast_nodes_flagged(mut a, base_transform_nodes, a.nodes.len,
+							scoped_owned_base_nodes, transform_scope, scoped_text_flags)
+						transform_texts_canonical = true
+					}
 				}
 			} else {
 				clone_flat_ast_storage(mut a)
@@ -4226,12 +4416,20 @@ fn main() {
 				a.specialized_fn_modules = clone_int_string_map(a.specialized_fn_modules)
 				a.specialized_fn_files = clone_int_string_map(a.specialized_fn_files)
 			}
-			promote_scoped_checker_node_caches(mut pre_tc, transform_scope, base_transform_nodes)
+			eprintln('  [ttime] promote ast nodes  ${f64(post_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+			post_sw.restart()
+			promote_scoped_checker_node_caches(mut pre_tc, a, transform_scope, base_transform_nodes)
+			eprintln('  [ttime]   pc node caches   ${f64(post_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+			post_sw.restart()
 			promote_scoped_signatures(mut pre_tc, original_signature_names)
+			eprintln('  [ttime]   pc signatures    ${f64(post_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+			post_sw.restart()
 			transform_used_fns = clone_string_bool_map(transform_used_fns)
 			transform_errors = clone_string_list(transform_errors)
 			pre_tc.set_fresh_type_cache(parse_cache_enabled)
 			prealloc_scope_free_for_v3(transform_scope)
+			eprintln('  [ttime] promote checker    ${f64(post_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+			post_sw.restart()
 			if retained_transform_regions.len > 0 {
 				if p.parsed_v_header_files > 0 {
 					// Header-only warm builds are small enough that transform may not
@@ -4264,10 +4462,11 @@ fn main() {
 			// Type-resolution views can grow their by-file map while the transform arena
 			// is active. Recreate it in the compilation arena before later phases use it.
 			pre_tc.reset_resolution_type_view_cache()
+			eprintln('  [ttime] regions+views      ${f64(post_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 		} else {
 			transform_used_fns, transform_was_parallel, transform_errors = transform.transform_with_used_opt_config_scoped_workers_checked(mut a,
 				&pre_tc, transform_used_fns, current_parallel_transform, skip_transform_generics,
-				false, building_v || cmd_v_build)
+				false, building_v)
 		}
 		if !incremental_cache_hit {
 			used_fns = transform_used_fns.move()
@@ -4280,8 +4479,7 @@ fn main() {
 				incremental_changed_names[name] = true
 			}
 		}
-		if !building_v && !cmd_v_build && !uses_generics
-			&& transformed_used_fns_need_monomorphize(used_fns) {
+		if !building_v && !uses_generics && transformed_used_fns_need_monomorphize(used_fns) {
 			uses_generics = true
 			skip_transform_generics = false
 		}
@@ -4311,7 +4509,7 @@ fn main() {
 		set_unsupported_generic_files(mut pre_tc, a, is_selfhost, diagnostic_root)
 		incremental_needs_monomorphize := incremental_cache_hit && (incremental_uses_generics
 			|| transformed_used_fns_need_monomorphize(incremental_stage_used_fns))
-		if !building_v && !cmd_v_build {
+		if !building_v {
 			if uses_generics && (!incremental_cache_hit || incremental_needs_monomorphize) {
 				if scope_prealloc_stages {
 					// Volt's reachable specialization set settles just below 4x the
@@ -4362,7 +4560,9 @@ fn main() {
 		// The cached C plan and metadata are the only consumers of the specialized
 		// AST and checker state on this path.
 	} else if building_v {
+		mut mono_sw := time.new_stopwatch()
 		used_fns = transform.erase_generic_templates(mut a, &pre_tc, used_fns)
+		eprintln('  [ttime] erase templates    ${f64(mono_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 	} else if uses_generics && (!incremental_cache_hit || incremental_uses_generics
 		|| transformed_used_fns_need_monomorphize(incremental_stage_used_fns)) {
 		mut monomorph_used_fns := map[string]bool{}
@@ -4437,7 +4637,7 @@ fn main() {
 				a.specialized_fn_modules = clone_int_string_map(a.specialized_fn_modules)
 				a.specialized_fn_files = clone_int_string_map(a.specialized_fn_files)
 			}
-			promote_scoped_checker_node_caches(mut pre_tc, monomorph_scope, base_monomorph_nodes)
+			promote_scoped_checker_node_caches(mut pre_tc, a, monomorph_scope, base_monomorph_nodes)
 			pre_tc.rebuild_scoped_transform_signature_maps()
 			pre_tc.promote_scoped_transform_interners(0, 0, monomorph_scope)
 			promote_scoped_monomorph_metadata(mut pre_tc)
@@ -4507,14 +4707,21 @@ fn main() {
 		erase_unreachable_generic_type_templates(mut pre_tc)
 	}
 	pre_tc.clear_c_type_cache()
+	mut mono_tail_sw := time.new_stopwatch()
 	// Transform and monomorphization can synthesize or rewrite payload text.
 	// They run with private/arena-backed worker state; publish only canonical,
 	// compilation-owned strings after all worker merges are complete.
 	// Type annotation can rewrite node.typ after the transform arenas have been
-	// promoted. Preallocated builds must republish those final strings as well.
-	if scope_prealloc_stages || !transform_texts_canonical {
+	// promoted, so preallocated builds must republish those final strings — but
+	// annotation only runs outside -building-v builds. Self-host builds skip
+	// it, and their transform-canonical texts are already final, so this
+	// full-AST walk would be a no-op there.
+	annotation_can_rewrite_texts := !building_v
+	if (scope_prealloc_stages && annotation_can_rewrite_texts) || !transform_texts_canonical {
 		a.intern_node_texts_from(0)
 	}
+	eprintln('  [ttime] mono intern texts  ${f64(mono_tail_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+	mono_tail_sw.restart()
 	// The resolution-type view cache memoizes forked type-parse views keyed by file
 	// path. Views (and their keys) built during the scoped check/annotate phases
 	// live in stage arenas whose deferred frees run mid-codegen, so a stale entry
@@ -5014,7 +5221,7 @@ fn main() {
 				'-Werror=implicit-function-declaration']
 			tcc_args << tcc_cached_main_flags(resolved_c_flags)
 			tcc_args << ['-o', 'out', os.base(tcc_main_file)]
-			atomic_s := tcc_atomic_s_arg(prefs)
+			atomic_s := tcc_atomic_arg(prefs, tcc_path, tcc_includes)
 			if atomic_s.len > 0 {
 				tcc_args << atomic_s
 			}
@@ -5084,7 +5291,7 @@ fn main() {
 				tcc_args << '-shared'
 			}
 			tcc_args << ['-o', 'out', 'src.c']
-			atomic_s := tcc_atomic_s_arg(prefs)
+			atomic_s := tcc_atomic_arg(prefs, tcc_path, tcc_includes)
 			if atomic_s.len > 0 {
 				tcc_args << atomic_s
 			}
@@ -6735,6 +6942,7 @@ fn insert_synthetic_imports(mut a flat.FlatAst, insertions []SyntheticInsertion)
 		ins_idx++
 	}
 	a.nodes = new_nodes
+	a.file_node_ids = []int{}
 	for k in 0 .. a.children.len {
 		cid := int(a.children[k])
 		if cid >= 0 {
@@ -6759,6 +6967,72 @@ fn synthetic_index_shift(insertions []SyntheticInsertion, idx int) int {
 }
 
 // resolve_imports resolves resolve imports information for v3 entry point.
+// collect_import_scan_ids returns the node ids the import-resolution loops
+// care about (.file markers/trailers, module_decl, import_decl) for every file
+// pair at or past region_start, in ascending node order. Falls back to the
+// full id range when the parser file index is unusable.
+fn collect_import_scan_ids(a &flat.FlatAst, region_start int, pair_cursor int) ([]int, int) {
+	if !file_index_usable_for_imports(a) {
+		mut all := []int{cap: a.nodes.len - region_start}
+		for i in region_start .. a.nodes.len {
+			all << i
+		}
+		return all, pair_cursor
+	}
+	mut cursor := pair_cursor
+	mut ids := []int{cap: 4096}
+	mut last_trailing := region_start - 1
+	for cursor + 1 < a.file_node_ids.len {
+		marker := a.file_node_ids[cursor]
+		if marker < region_start {
+			cursor += 2
+			continue
+		}
+		trailing := a.file_node_ids[cursor + 1]
+		ids << marker
+		tnode := a.nodes[trailing]
+		collect_import_scan_children(a, &tnode, mut ids)
+		ids << trailing
+		if trailing > last_trailing {
+			last_trailing = trailing
+		}
+		cursor += 2
+	}
+	// Synthetic import nodes (implicit sync/embed_file seeds) are appended
+	// after the last parsed file and belong to no trailing .file node; sweep
+	// the short tail so the walk sees exactly what the full scan sees.
+	for i in last_trailing + 1 .. a.nodes.len {
+		if a.nodes[i].kind in [.file, .module_decl, .import_decl] {
+			ids << i
+		}
+	}
+	return ids, cursor
+}
+
+fn collect_import_scan_children(a &flat.FlatAst, node &flat.Node, mut ids []int) {
+	for ci in 0 .. node.children_count {
+		id := int(a.child(node, ci))
+		if id < 0 || id >= a.nodes.len {
+			continue
+		}
+		child := a.nodes[id]
+		match child.kind {
+			.module_decl, .import_decl {
+				ids << id
+			}
+			.comptime_if, .block {
+				collect_import_scan_children(a, &child, mut ids)
+			}
+			else {}
+		}
+	}
+}
+
+fn file_index_usable_for_imports(a &flat.FlatAst) bool {
+	return a.file_node_ids.len > 0 && a.file_node_ids.len % 2 == 0 && !a.file_index_incomplete
+		&& os.getenv('V3_NO_FILE_IDX') == '' && os.getenv('V3_NO_IMPORT_IDX') == ''
+}
+
 fn resolve_imports(mut a flat.FlatAst, mut p parser.Parser, prefs &pref.Preferences, initial_files []string, allow_parallel bool, mut cache_state V3ModuleCacheState, mut parse_timing V3ParseTiming) bool {
 	mut parsed_modules := map[string]bool{}
 	parsed_modules['builtin'] = true
@@ -6823,14 +7097,45 @@ fn resolve_imports(mut a flat.FlatAst, mut p parser.Parser, prefs &pref.Preferen
 	scan_implicit_imports(a, a.nodes.len, mut implicit_imports)
 	mut synthetic_sync_added := implicit_imports.has_sync
 	mut synthetic_embed_file_added := implicit_imports.has_embed_import
+	mut ri_collision_ns := u64(0)
+	mut ri_wave_ns := u64(0)
+	mut ri_waves := 0
+	mut pair_cursor := 0
 	for {
+		ri_waves++
+		ri_t0 := time.sys_mono_now()
+		scan_ids, next_pair_cursor := collect_import_scan_ids(a, node_idx, pair_cursor)
+		pair_cursor = next_pair_cursor
+		if os.getenv('V3_VERIFY_IMPORT_IDX') != '' {
+			mut full := []int{}
+			for i in node_idx .. a.nodes.len {
+				if a.nodes[i].kind in [.file, .module_decl, .import_decl] {
+					full << i
+				}
+			}
+			if full.len != scan_ids.len {
+				eprintln('IMPORT IDX MISMATCH: full ${full.len} fast ${scan_ids.len} region ${node_idx}..${a.nodes.len}')
+				for i in full {
+					if i !in scan_ids {
+						eprintln('  missing id ${i} kind ${a.nodes[i].kind} value ${a.nodes[i].value}')
+					}
+				}
+			} else {
+				for k, fid in full {
+					if scan_ids[k] != fid {
+						eprintln('IMPORT IDX ORDER MISMATCH at ${k}: full ${fid} fast ${scan_ids[k]}')
+						break
+					}
+				}
+			}
+		}
 		// Decide short-name collisions for the whole visible import wave before
 		// mutating any import node or parsing either module. This qualifies both
 		// sides of `a.tast`/`b.tast`, avoiding an order-dependent state where the
 		// first module is called `tast` and that semantic name is later mistaken
 		// for the source alias of the second import.
 		mut scan_file := cur_file
-		for scan_idx in node_idx .. a.nodes.len {
+		for scan_idx in scan_ids {
 			scan_node := a.nodes[scan_idx]
 			if scan_node.kind == .file && scan_node.value.len > 0 {
 				scan_file = scan_node.value
@@ -6858,6 +7163,8 @@ fn resolve_imports(mut a flat.FlatAst, mut p parser.Parser, prefs &pref.Preferen
 				identity_source_dirs[scan_identity] = scan_dir
 			}
 		}
+		ri_collision_ns += time.sys_mono_now() - ri_t0
+		ri_t1 := time.sys_mono_now()
 		// Collect one wave: every not-yet-parsed module imported by the nodes
 		// scanned so far. Parsing appends at the end of the node array and the
 		// scan proceeds in node order, so batching a wave and appending its
@@ -6867,7 +7174,8 @@ fn resolve_imports(mut a flat.FlatAst, mut p parser.Parser, prefs &pref.Preferen
 		mut wave_files := []string{}
 		mut wave_canon := []string{}
 		mut wave_module_file_ends := []int{}
-		for node_idx < a.nodes.len {
+		for wave_scan_i in 0 .. scan_ids.len {
+			node_idx = scan_ids[wave_scan_i]
 			node := a.nodes[node_idx]
 			if node.kind == .file && node.value.len > 0 {
 				cur_file = node.value
@@ -7033,7 +7341,14 @@ fn resolve_imports(mut a flat.FlatAst, mut p parser.Parser, prefs &pref.Preferen
 			}
 			node_idx++
 		}
+		// The indexed walk leaves node_idx at the last visited id; the next
+		// wave's region starts where this one's appends begin.
+		node_idx = a.nodes.len
+		ri_wave_ns += time.sys_mono_now() - ri_t1
 		if wave_files.len == 0 {
+			ri_coll_ms := f64(ri_collision_ns) / 1e6
+			ri_wave_ms := f64(ri_wave_ns) / 1e6
+			eprintln('  [ttime]   ri collision   ${ri_coll_ms:7.2f} ms, wave scan ${ri_wave_ms:.2f} ms (waves: ${ri_waves})')
 			break
 		}
 		starts, wave_parallel := parse_files_dispatch_profiled(mut p, wave_files, allow_parallel, mut

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -4147,8 +4147,10 @@ fn main() {
 		set_diagnostic_files(mut pre_tc, user_files)
 		mut cvsw := time.new_stopwatch()
 		pre_tc.collect(a)
-		eprintln('  [ttime]   ck collect       ${f64(cvsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
-		cvsw.restart()
+		if verbose {
+			eprintln('  [ttime]   ck collect       ${f64(cvsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+			cvsw.restart()
+		}
 		pre_tc.diagnose_unknown_calls = true
 		pre_tc.prepare_threads_condition()
 		set_unsupported_generic_files(mut pre_tc, a, is_selfhost, diagnostic_root)
@@ -4157,7 +4159,9 @@ fn main() {
 		} else {
 			pre_tc.prepare_interface_requirement_indexes()
 		}
-		eprintln('  [ttime]   ck iface idx     ${f64(cvsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+		if verbose {
+			eprintln('  [ttime]   ck iface idx     ${f64(cvsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+		}
 		mut check_was_parallel := false
 		if incremental_cache_hit {
 			pre_tc.check_semantics_selected(incremental_changed_names)
@@ -4170,10 +4174,14 @@ fn main() {
 		}
 		incremental_uses_generics = incremental_cache_hit
 			&& incremental_changed_functions_use_generics(a, pre_tc, incremental_changed_names)
-		cvsw.restart()
+		if verbose {
+			cvsw.restart()
+		}
 		pre_tc.prune_inactive_top_level_comptime(mut a)
 		test_harness_errors := validate_test_file_harness_inputs(a, pre_tc, test_files)
-		eprintln('  [ttime]   ck prune+harness ${f64(cvsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+		if verbose {
+			eprintln('  [ttime]   ck prune+harness ${f64(cvsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+		}
 		if test_harness_errors.len > 0 {
 			for msg in test_harness_errors {
 				eprintln(msg)
@@ -4339,14 +4347,18 @@ fn main() {
 			retained_transform_regions = clone_scoped_transform_regions(retained_transform_regions)
 			pre_tc.promote_scoped_transform_interners(base_type_count, base_symbol_count,
 				transform_scope)
-			eprintln('  [ttime] promote interners  ${f64(post_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
-			post_sw.restart()
+			if verbose {
+				eprintln('  [ttime] promote interners  ${f64(post_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+				post_sw.restart()
+			}
 			if a.nodes.cap == reserved_nodes_cap && a.children.cap == reserved_children_cap
 				&& !scoped_value_owned(transform_scope, a.nodes.data)
 				&& !scoped_value_owned(transform_scope, a.children.data) {
 				a.promote_transform_texts_from(base_text_count, transform_scope)
-				eprintln('  [ttime] promote texts      ${f64(post_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
-				post_sw.restart()
+				if verbose {
+					eprintln('  [ttime] promote texts      ${f64(post_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+					post_sw.restart()
+				}
 				// Lowering can rewrite arbitrary pre-existing nodes, including type text
 				// on otherwise non-generic expressions. Publish every scope-owned
 				// text before releasing the outer arena. Without retained regions
@@ -4361,8 +4373,10 @@ fn main() {
 						transform_texts_canonical = true
 					}
 				}
-				eprintln('  [ttime] canon nodes        ${f64(post_sw.elapsed().microseconds()) / 1000.0:7.2f} ms (n: ${a.nodes.len}, fused: ${fused_text_promote})')
-				post_sw.restart()
+				if verbose {
+					eprintln('  [ttime] canon nodes        ${f64(post_sw.elapsed().microseconds()) / 1000.0:7.2f} ms (n: ${a.nodes.len}, fused: ${fused_text_promote})')
+					post_sw.restart()
+				}
 				if !fused_text_promote {
 					mut scoped_text_flags := []u8{len: a.nodes.len}
 					if transform.scan_scoped_text_flags_parallel(a, transform_scope, mut
@@ -4415,20 +4429,28 @@ fn main() {
 				a.specialized_fn_modules = clone_int_string_map(a.specialized_fn_modules)
 				a.specialized_fn_files = clone_int_string_map(a.specialized_fn_files)
 			}
-			eprintln('  [ttime] promote ast nodes  ${f64(post_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
-			post_sw.restart()
+			if verbose {
+				eprintln('  [ttime] promote ast nodes  ${f64(post_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+				post_sw.restart()
+			}
 			promote_scoped_checker_node_caches(mut pre_tc, a, transform_scope, base_transform_nodes)
-			eprintln('  [ttime]   pc node caches   ${f64(post_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
-			post_sw.restart()
+			if verbose {
+				eprintln('  [ttime]   pc node caches   ${f64(post_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+				post_sw.restart()
+			}
 			promote_scoped_signatures(mut pre_tc, original_signature_names)
-			eprintln('  [ttime]   pc signatures    ${f64(post_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
-			post_sw.restart()
+			if verbose {
+				eprintln('  [ttime]   pc signatures    ${f64(post_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+				post_sw.restart()
+			}
 			transform_used_fns = clone_string_bool_map(transform_used_fns)
 			transform_errors = clone_string_list(transform_errors)
 			pre_tc.set_fresh_type_cache(parse_cache_enabled)
 			prealloc_scope_free_for_v3(transform_scope)
-			eprintln('  [ttime] promote checker    ${f64(post_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
-			post_sw.restart()
+			if verbose {
+				eprintln('  [ttime] promote checker    ${f64(post_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+				post_sw.restart()
+			}
 			if retained_transform_regions.len > 0 {
 				if p.parsed_v_header_files > 0 {
 					// Header-only warm builds are small enough that transform may not
@@ -4461,7 +4483,9 @@ fn main() {
 			// Type-resolution views can grow their by-file map while the transform arena
 			// is active. Recreate it in the compilation arena before later phases use it.
 			pre_tc.reset_resolution_type_view_cache()
-			eprintln('  [ttime] regions+views      ${f64(post_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+			if verbose {
+				eprintln('  [ttime] regions+views      ${f64(post_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+			}
 		} else {
 			transform_used_fns, transform_was_parallel, transform_errors = transform.transform_with_used_opt_config_scoped_workers_checked(mut a,
 				&pre_tc, transform_used_fns, current_parallel_transform, skip_transform_generics,
@@ -4561,7 +4585,9 @@ fn main() {
 	} else if building_v {
 		mut mono_sw := time.new_stopwatch()
 		used_fns = transform.erase_generic_templates(mut a, &pre_tc, used_fns)
-		eprintln('  [ttime] erase templates    ${f64(mono_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+		if verbose {
+			eprintln('  [ttime] erase templates    ${f64(mono_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+		}
 	} else if uses_generics && (!incremental_cache_hit || incremental_uses_generics
 		|| transformed_used_fns_need_monomorphize(incremental_stage_used_fns)) {
 		mut monomorph_used_fns := map[string]bool{}
@@ -4719,8 +4745,10 @@ fn main() {
 	if (scope_prealloc_stages && annotation_can_rewrite_texts) || !transform_texts_canonical {
 		a.intern_node_texts_from(0)
 	}
-	eprintln('  [ttime] mono intern texts  ${f64(mono_tail_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
-	mono_tail_sw.restart()
+	if verbose {
+		eprintln('  [ttime] mono intern texts  ${f64(mono_tail_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+		mono_tail_sw.restart()
+	}
 	// The resolution-type view cache memoizes forked type-parse views keyed by file
 	// path. Views (and their keys) built during the scoped check/annotate phases
 	// live in stage arenas whose deferred frees run mid-codegen, so a stale entry
@@ -7345,9 +7373,11 @@ fn resolve_imports(mut a flat.FlatAst, mut p parser.Parser, prefs &pref.Preferen
 		node_idx = a.nodes.len
 		ri_wave_ns += time.sys_mono_now() - ri_t1
 		if wave_files.len == 0 {
-			ri_coll_ms := f64(ri_collision_ns) / 1e6
-			ri_wave_ms := f64(ri_wave_ns) / 1e6
-			eprintln('  [ttime]   ri collision   ${ri_coll_ms:7.2f} ms, wave scan ${ri_wave_ms:.2f} ms (waves: ${ri_waves})')
+			if prefs.verbose {
+				ri_coll_ms := f64(ri_collision_ns) / 1e6
+				ri_wave_ms := f64(ri_wave_ns) / 1e6
+				eprintln('  [ttime]   ri collision   ${ri_coll_ms:7.2f} ms, wave scan ${ri_wave_ms:.2f} ms (waves: ${ri_waves})')
+			}
 			break
 		}
 		starts, wave_parallel := parse_files_dispatch_profiled(mut p, wave_files, allow_parallel, mut

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -3377,7 +3377,6 @@ fn restore_transformed_fn_value_types(mut tc types.TypeChecker, a &flat.FlatAst,
 
 // main runs the v3 entry point.
 fn main() {
-	println(1234)
 	args := os.args[1..]
 	if args.len == 0 {
 		eprintln(cli_usage())


### PR DESCRIPTION
Uncached self-host (`v3 -nocache -building-v v3.v`) drops from ~1150-1260ms to ~820-880ms wall on an M-series laptop. Every output-affecting change was validated byte-identical via same-binary env toggles and self-determinism runs; the `v3 -> v4 -> program` chain and `v3 cmd/v` are verified on this exact branch.

### Parse
- Parallel worker merge: pooled copy+relocate into precomputed disjoint ranges, read-only text-table probe interning (misses replayed serially in chunk order so canonical ids match the serial merge), pre-indexed diagnostic line tables.
- Dynamic many-chunk split submitted largest-first; the master chunk passes real byte counts to `reserve_for_source`; parse jobs 8 → 10.
- `FlatAst.file_node_ids`: the parser records (marker, trailing) `.file` node pairs; the checker's top-level index, the inactive-comptime scan and `resolve_imports`' per-wave loops walk file children instead of scanning every node (full-scan fallback when renumbering stages clear the index; `V3_VERIFY_IMPORT_IDX=1` cross-checks).

### Check
- The post-merge clone pass runs across the worker pool while worker scopes are still alive, via a new read-only `TypeInterner.probe`; unknown types are interned serially in chunk order (ids identical to serial). ~16ms → ~2ms.
- Dropped the stale master-chunk bias in `split_check_items` (measured: the master chunk was the pool tail by ~30%, not an early finisher).
- Import-info + qualify-name memo caches armed per batch fork; allocation-free `embedded_field_type`; `trimmed_space` fast paths.
- Scopes carry a 64-bit bloom mask over their own binding names, so chain walks bit-test absent levels instead of paying a map probe per level.

### Markused
- The runtime-helper seed scan runs on an overlap thread with detached-scope publishing and ordered replay; worker-side result publishing; jobs 8 → 10.

### Transform / cgen
- Fused parallel cgen prep (item costs + fn-ptr preseeds collected on the pool, replayed deterministically), cached precompiled `atomic.o`, obj-cache fast path when no `.o` flags, monomorphize intern skip.
- `typeof(` screens use a length-8 early-out byte probe, and `parse_type` screens only on cache misses.

### Prealloc
- Per-thread recycling of standard-size scope blocks with geometric scope-block growth (256K/512K/1M) and a 16MB budget — munmap/mmap churn was ~5% of busy CPU. The cache pointer is a second thread-local next to `g_memory_block` (v1 cgen emits `_Thread_local` for both; v3 cgen generalizes its pthread-key `__TINYC__` emulation, so tcc-linked self-host output keeps working). `-d prealloc_no_recycle` opts out.
- v1 cgen: index or-blocks that cannot observe `err` skip `IError` construction.

### cmd/v C generation
`v3 cmd/v` now emits clean C that compiles and links; the produced binary runs (`V 0.5.2`) and, with `VEXE` set, parses and checks vlib:
- cmd/v builds no longer skip generic detection/annotation/monomorphization (v1 uses generics in `math.abs`, token's const-initializer matcher, `sync.pool`, TLS); only capacity/parallel hints stay cmd_v-gated.
- Cross-module auto-stringify expansions: enum autostr calls requalify against the declared enum set; bare sum names resolve through the short-name table; transform-made sum literals route into the sum-init emitter (restoring pointer-variant boxing); map-str keys of foreign bare aliases store as their scalar base type.
- Alias-typed value params also match their unaliased form when dereferencing `&T` args (for-mut loop vars).
- Unused generic templates no longer leak `Optional_..._T` typedefs.

Also carries the module-cache file-metadata header inlining (`file_metadata.h` → `file_metadata.c`) the perf commits were built on. Verbose builds print per-stage sub-timings, and ownership shows as its own zero-cost stage line in plain builds.