### PR TITLE
cgen: fix fixed array spawn, vlines, and inline fn casts

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -126,9 +126,11 @@ mut:
 	options_pos_forward                  int               // insertion point to forward
 	options_forward                      []string          // to forward
 	options                              map[string]string // to avoid duplicates
+	spawn_arg_options                    []string          // option payloads needed by spawn wrappers
 	emitted_extern_sig_typedefs          map[int]bool      // type idx → already-emitted forward typedef (for C extern decls)
 	results_forward                      []string          // to forward
 	results                              map[string]string // to avoid duplicates
+	spawn_arg_results                    []string          // result payloads needed by spawn wrappers
 	done_options                         shared []string   // to avoid duplicates
 	done_results                         shared []string   // to avoid duplicates
 	array_typedefs                       []string          // to avoid duplicate array typedefs
@@ -474,6 +476,7 @@ pub fn gen(files []&ast.File, mut table ast.Table, pref_ &pref.Preferences) GenO
 	util.timing_measure('cgen init')
 	global_g.tests_inited = false
 	global_g.file = files.last()
+	file_type_definitions_pos := global_g.type_definitions.len
 	if !pref_.no_parallel {
 		util.timing_start('cgen parallel processing')
 		mut pp := pool.new_pool_processor(callback: cgen_process_one_file_cb)
@@ -532,6 +535,16 @@ pub fn gen(files []&ast.File, mut table ast.Table, pref_ &pref.Preferences) GenO
 			}
 			for k, v in g.results {
 				global_g.results[k] = v
+			}
+			for base in g.spawn_arg_options {
+				if base !in global_g.spawn_arg_options {
+					global_g.spawn_arg_options << base
+				}
+			}
+			for base in g.spawn_arg_results {
+				if base !in global_g.spawn_arg_results {
+					global_g.spawn_arg_results << base
+				}
 			}
 			for k, v in g.as_cast_type_names {
 				global_g.as_cast_type_names[k] = v
@@ -642,6 +655,7 @@ pub fn gen(files []&ast.File, mut table ast.Table, pref_ &pref.Preferences) GenO
 	global_g.gen_map_key_fns()
 	global_g.gen_free_methods()
 	global_g.register_iface_return_types()
+	global_g.write_spawn_arg_option_or_result_types(file_type_definitions_pos)
 	global_g.write_results()
 	global_g.write_options()
 	global_g.write_late_array_typedefs()
@@ -2039,6 +2053,36 @@ fn (mut g Gen) register_result(t ast.Type) string {
 		g.results[base] = styp
 	}
 	return styp
+}
+
+fn (mut g Gen) write_spawn_arg_option_or_result_types(insert_pos int) {
+	if g.spawn_arg_options.len == 0 && g.spawn_arg_results.len == 0 {
+		return
+	}
+	tail := g.type_definitions.cut_to(insert_pos)
+	for base in g.spawn_arg_options {
+		if styp := g.options[base] {
+			lock g.done_options {
+				if base !in g.done_options {
+					g.done_options << base
+					g.typedefs.writeln('typedef struct ${styp} ${styp};')
+					g.type_definitions.writeln('${g.option_type_text(styp, base)};')
+				}
+			}
+		}
+	}
+	for base in g.spawn_arg_results {
+		if styp := g.results[base] {
+			lock g.done_results {
+				if base !in g.done_results {
+					g.done_results << base
+					g.typedefs.writeln('typedef struct ${styp} ${styp};')
+					g.type_definitions.writeln('${g.result_type_text(styp, base)};')
+				}
+			}
+		}
+	}
+	g.type_definitions.write_string(tail)
 }
 
 fn (mut g Gen) write_options() {

--- a/vlib/v/gen/c/ctempvars.v
+++ b/vlib/v/gen/c/ctempvars.v
@@ -19,9 +19,15 @@ fn (mut g Gen) new_ctemp_var_then_gen(expr ast.Expr, expr_type ast.Type) ast.CTe
 
 fn (mut g Gen) expr_to_ctemp_before_stmt(expr ast.Expr, expr_type ast.Type) ast.CTempVar {
 	mut stmt_str := if g.inside_ternary > 0 {
-		g.go_before_ternary().trim_space()
+		g.go_before_ternary()
 	} else {
-		g.go_before_last_stmt().trim_space()
+		g.go_before_last_stmt()
+	}
+	if g.pref.is_vlines {
+		// A nested statement offset can split `#line` from its number.
+		stmt_str = stmt_str.trim_right(' \n\t\v\f\r').trim_left('\n\t\v\f\r')
+	} else {
+		stmt_str = stmt_str.trim_space()
 	}
 	if g.inside_return && stmt_str.ends_with('return') {
 		stmt_str += ' '

--- a/vlib/v/gen/c/ctempvars_line_info_codegen_test.v
+++ b/vlib/v/gen/c/ctempvars_line_info_codegen_test.v
@@ -1,0 +1,23 @@
+import os
+
+const ctempvars_line_info_vexe = @VEXE
+
+fn test_ctemp_hoisting_preserves_vline_directive_spaces() {
+	tmp_dir := os.join_path(os.vtmp_dir(), 'ctempvars_line_info_test_${os.getpid()}')
+	os.mkdir_all(tmp_dir)!
+	defer {
+		os.rmdir_all(tmp_dir) or {}
+	}
+	source_path := os.join_path(os.real_path(tmp_dir), 'ctempvars_line_info.vv')
+	os.write_file(source_path,
+		'interface Value {}\n\nstruct Item {}\n\nfn get_value() Value {\n\treturn Item{}\n}\n\nfn main() {\n\titem := get_value() as Item\n\tprintln(item)\n}\n')!
+	cmd := '${os.quoted_path(ctempvars_line_info_vexe)} -g -gc boehm -o - ${os.quoted_path(source_path)}'
+	res := os.execute(cmd)
+	assert res.exit_code == 0, '${cmd}\n${res.output}'
+	for line in res.output.replace('\r\n', '\n').split_into_lines() {
+		trimmed := line.trim_space()
+		if trimmed.starts_with('#line') {
+			assert trimmed.starts_with('#line '), 'malformed line directive `${trimmed}`\n${res.output}'
+		}
+	}
+}

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -2307,9 +2307,8 @@ fn (mut g Gen) call_expr(node ast.CallExpr) {
 			g.write2(line, '*(${g.base_type(ret_typ)}*)${tmp_res}.data')
 			return
 		}
-	} else if !g.inside_curry_call && node.left is ast.CastExpr && node.name == '' {
-		g.expr(ast.Expr(node.left))
-	} else if !g.inside_curry_call && node.left is ast.SelectorExpr && node.name == '' {
+	} else if !g.inside_curry_call && node.name == ''
+		&& (node.left is ast.CastExpr || node.left is ast.SelectorExpr) {
 		if node.or_block.kind == .absent {
 			g.expr(ast.Expr(node.left))
 		} else {

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -2307,6 +2307,8 @@ fn (mut g Gen) call_expr(node ast.CallExpr) {
 			g.write2(line, '*(${g.base_type(ret_typ)}*)${tmp_res}.data')
 			return
 		}
+	} else if !g.inside_curry_call && node.left is ast.CastExpr && node.name == '' {
+		g.expr(ast.Expr(node.left))
 	} else if !g.inside_curry_call && node.left is ast.SelectorExpr && node.name == '' {
 		if node.or_block.kind == .absent {
 			g.expr(ast.Expr(node.left))

--- a/vlib/v/gen/c/spawn_and_go.v
+++ b/vlib/v/gen/c/spawn_and_go.v
@@ -141,7 +141,7 @@ fn (mut g Gen) spawn_and_go_expr(node ast.SpawnExpr, mode SpawnGoMode) {
 	for i, arg in expr.args {
 		arg_field := '${arg_tmp_var}${dot}arg${i + 1}'
 		arg_type := g.unwrap_generic(g.recheck_concrete_type(arg.typ))
-		if g.table.final_sym(arg_type).kind == .array_fixed {
+		if !arg_type.is_ptr() && g.table.final_sym(arg_type).kind == .array_fixed {
 			g.write('memcpy(${arg_field}, ')
 			g.expr(arg.expr)
 			g.writeln(', sizeof(${arg_field}));')

--- a/vlib/v/gen/c/spawn_and_go.v
+++ b/vlib/v/gen/c/spawn_and_go.v
@@ -11,30 +11,16 @@ enum SpawnGoMode {
 	go_
 }
 
-fn (mut g Gen) write_spawn_arg_option_or_result_type(typ ast.Type, insert_pos int) {
+fn (mut g Gen) mark_spawn_arg_option_or_result_type(typ ast.Type) {
 	if typ.has_flag(.option) {
-		styp, base := g.option_type_name(typ)
-		lock g.done_options {
-			if base !in g.done_options {
-				g.done_options << base
-				wrapper_text := g.type_definitions.after(insert_pos).clone()
-				g.type_definitions.go_back_to(insert_pos)
-				g.typedefs.writeln('typedef struct ${styp} ${styp};')
-				g.type_definitions.writeln('${g.option_type_text(styp, base)};')
-				g.type_definitions.write_string(wrapper_text)
-			}
+		_, base := g.option_type_name(typ)
+		if base !in g.spawn_arg_options {
+			g.spawn_arg_options << base
 		}
 	} else if typ.has_flag(.result) {
-		styp, base := g.result_type_name(typ)
-		lock g.done_results {
-			if base !in g.done_results {
-				g.done_results << base
-				wrapper_text := g.type_definitions.after(insert_pos).clone()
-				g.type_definitions.go_back_to(insert_pos)
-				g.typedefs.writeln('typedef struct ${styp} ${styp};')
-				g.type_definitions.writeln('${g.result_type_text(styp, base)};')
-				g.type_definitions.write_string(wrapper_text)
-			}
+		_, base := g.result_type_name(typ)
+		if base !in g.spawn_arg_results {
+			g.spawn_arg_results << base
 		}
 	}
 }
@@ -283,7 +269,6 @@ fn (mut g Gen) spawn_and_go_expr(node ast.SpawnExpr, mode SpawnGoMode) {
 		}
 	}
 	if should_register {
-		wrapper_start_pos := g.type_definitions.len
 		g.type_definitions.writeln('\ntypedef struct ${wrapper_struct_name} {')
 		mut fn_var := ''
 		mut wrapper_return_type := call_ret_type
@@ -401,7 +386,7 @@ fn (mut g Gen) spawn_and_go_expr(node ast.SpawnExpr, mode SpawnGoMode) {
 					arg_sym.info.func.params.map(it.typ), 'arg${i + 1}')
 				g.type_definitions.writeln('\t' + sig + ';')
 			} else {
-				g.write_spawn_arg_option_or_result_type(arg_typ, wrapper_start_pos)
+				g.mark_spawn_arg_option_or_result_type(arg_typ)
 				styp := g.styp(arg_typ)
 				g.type_definitions.writeln('\t${styp} arg${i + 1};')
 			}

--- a/vlib/v/gen/c/spawn_and_go.v
+++ b/vlib/v/gen/c/spawn_and_go.v
@@ -11,6 +11,34 @@ enum SpawnGoMode {
 	go_
 }
 
+fn (mut g Gen) write_spawn_arg_option_or_result_type(typ ast.Type, insert_pos int) {
+	if typ.has_flag(.option) {
+		styp, base := g.option_type_name(typ)
+		lock g.done_options {
+			if base !in g.done_options {
+				g.done_options << base
+				wrapper_text := g.type_definitions.after(insert_pos).clone()
+				g.type_definitions.go_back_to(insert_pos)
+				g.typedefs.writeln('typedef struct ${styp} ${styp};')
+				g.type_definitions.writeln('${g.option_type_text(styp, base)};')
+				g.type_definitions.write_string(wrapper_text)
+			}
+		}
+	} else if typ.has_flag(.result) {
+		styp, base := g.result_type_name(typ)
+		lock g.done_results {
+			if base !in g.done_results {
+				g.done_results << base
+				wrapper_text := g.type_definitions.after(insert_pos).clone()
+				g.type_definitions.go_back_to(insert_pos)
+				g.typedefs.writeln('typedef struct ${styp} ${styp};')
+				g.type_definitions.writeln('${g.result_type_text(styp, base)};')
+				g.type_definitions.write_string(wrapper_text)
+			}
+		}
+	}
+}
+
 fn (mut g Gen) spawn_and_go_expr(node ast.SpawnExpr, mode SpawnGoMode) {
 	if node.call_expr.should_be_skipped {
 		return
@@ -141,13 +169,21 @@ fn (mut g Gen) spawn_and_go_expr(node ast.SpawnExpr, mode SpawnGoMode) {
 	for i, arg in expr.args {
 		arg_field := '${arg_tmp_var}${dot}arg${i + 1}'
 		arg_type := g.unwrap_generic(g.recheck_concrete_type(arg.typ))
-		if !arg_type.is_ptr() && g.table.final_sym(arg_type).kind == .array_fixed {
+		if !arg_type.is_ptr() && !arg_type.has_option_or_result()
+			&& g.table.final_sym(arg_type).kind == .array_fixed {
 			g.write('memcpy(${arg_field}, ')
 			g.expr(arg.expr)
 			g.writeln(', sizeof(${arg_field}));')
 		} else {
 			g.write('${arg_field} = ')
-			g.expr(arg.expr)
+			if arg_type.has_option_or_result() {
+				old_inside_opt_or_res := g.inside_opt_or_res
+				g.inside_opt_or_res = true
+				g.expr(arg.expr)
+				g.inside_opt_or_res = old_inside_opt_or_res
+			} else {
+				g.expr(arg.expr)
+			}
 			g.writeln(';')
 		}
 	}
@@ -247,6 +283,7 @@ fn (mut g Gen) spawn_and_go_expr(node ast.SpawnExpr, mode SpawnGoMode) {
 		}
 	}
 	if should_register {
+		wrapper_start_pos := g.type_definitions.len
 		g.type_definitions.writeln('\ntypedef struct ${wrapper_struct_name} {')
 		mut fn_var := ''
 		mut wrapper_return_type := call_ret_type
@@ -364,6 +401,7 @@ fn (mut g Gen) spawn_and_go_expr(node ast.SpawnExpr, mode SpawnGoMode) {
 					arg_sym.info.func.params.map(it.typ), 'arg${i + 1}')
 				g.type_definitions.writeln('\t' + sig + ';')
 			} else {
+				g.write_spawn_arg_option_or_result_type(arg_typ, wrapper_start_pos)
 				styp := g.styp(arg_typ)
 				g.type_definitions.writeln('\t${styp} arg${i + 1};')
 			}

--- a/vlib/v/gen/c/spawn_and_go.v
+++ b/vlib/v/gen/c/spawn_and_go.v
@@ -139,9 +139,17 @@ fn (mut g Gen) spawn_and_go_expr(node ast.SpawnExpr, mode SpawnGoMode) {
 		g.writeln(';')
 	}
 	for i, arg in expr.args {
-		g.write('${arg_tmp_var}${dot}arg${i + 1} = ')
-		g.expr(arg.expr)
-		g.writeln(';')
+		arg_field := '${arg_tmp_var}${dot}arg${i + 1}'
+		arg_type := g.unwrap_generic(g.recheck_concrete_type(arg.typ))
+		if g.table.final_sym(arg_type).kind == .array_fixed {
+			g.write('memcpy(${arg_field}, ')
+			g.expr(arg.expr)
+			g.writeln(', sizeof(${arg_field}));')
+		} else {
+			g.write('${arg_field} = ')
+			g.expr(arg.expr)
+			g.writeln(';')
+		}
 	}
 	if is_spawn && g.pref.prealloc {
 		g.writeln('${arg_tmp_var}->prealloc_scope = builtin__prealloc_scope_retain_current();')

--- a/vlib/v/tests/project_issue_27921_test.v
+++ b/vlib/v/tests/project_issue_27921_test.v
@@ -1,10 +1,24 @@
 type Issue27921Fn = fn ()
 
+type Issue27921ResultFn = fn () !int
+
 fn issue27921_plugin_main() {}
+
+fn issue27921_fallible_plugin_main() !int {
+	return 21
+}
 
 fn test_inline_function_alias_cast_call() {
 	sym := voidptr(issue27921_plugin_main)
 	// vfmt off
 	(Issue27921Fn(sym))()
 	// vfmt on
+}
+
+fn test_inline_fallible_function_alias_cast_call() {
+	sym := voidptr(issue27921_fallible_plugin_main)
+	// vfmt off
+	res := (Issue27921ResultFn(sym))() or { panic(err) }
+	// vfmt on
+	assert res == 21
 }

--- a/vlib/v/tests/project_issue_27921_test.v
+++ b/vlib/v/tests/project_issue_27921_test.v
@@ -1,0 +1,10 @@
+type Issue27921Fn = fn ()
+
+fn issue27921_plugin_main() {}
+
+fn test_inline_function_alias_cast_call() {
+	sym := voidptr(issue27921_plugin_main)
+	// vfmt off
+	(Issue27921Fn(sym))()
+	// vfmt on
+}

--- a/vlib/v/tests/project_issue_27932_parallel/first.v
+++ b/vlib/v/tests/project_issue_27932_parallel/first.v
@@ -1,0 +1,11 @@
+module main
+
+fn issue27932_parallel_first_worker(a ?[2]int) int {
+	arr := a or { return 0 }
+	return arr[0] + arr[1]
+}
+
+fn issue27932_parallel_spawn_first(a ?[2]int) int {
+	handle := spawn issue27932_parallel_first_worker(a)
+	return handle.wait()
+}

--- a/vlib/v/tests/project_issue_27932_parallel/project_compiles_test.v
+++ b/vlib/v/tests/project_issue_27932_parallel/project_compiles_test.v
@@ -1,0 +1,7 @@
+module main
+
+fn test_spawn_option_fixed_array_wrappers_across_files() {
+	a := ?[2]int(none)
+	assert issue27932_parallel_spawn_first(a) == 0
+	assert issue27932_parallel_spawn_second(a) == 0
+}

--- a/vlib/v/tests/project_issue_27932_parallel/second.v
+++ b/vlib/v/tests/project_issue_27932_parallel/second.v
@@ -1,0 +1,11 @@
+module main
+
+fn issue27932_parallel_second_worker(a ?[2]int) int {
+	arr := a or { return 0 }
+	return arr[0] + arr[1]
+}
+
+fn issue27932_parallel_spawn_second(a ?[2]int) int {
+	handle := spawn issue27932_parallel_second_worker(a)
+	return handle.wait()
+}

--- a/vlib/v/tests/project_issue_27932_test.v
+++ b/vlib/v/tests/project_issue_27932_test.v
@@ -1,0 +1,9 @@
+fn issue27932_worker(a [3]int) int {
+	return a[0] + a[1] + a[2]
+}
+
+fn test_spawn_with_fixed_array_argument() {
+	a := [1, 2, 3]!
+	handle := spawn issue27932_worker(a)
+	assert handle.wait() == 6
+}

--- a/vlib/v/tests/project_issue_27932_test.v
+++ b/vlib/v/tests/project_issue_27932_test.v
@@ -9,6 +9,11 @@ fn issue27932_pointer_worker(a &[3]int) int {
 	}
 }
 
+fn issue27932_optional_worker(a ?[2]int) int {
+	arr := a or { return 0 }
+	return arr[0] + arr[1]
+}
+
 fn test_spawn_with_fixed_array_argument() {
 	a := [1, 2, 3]!
 	handle := spawn issue27932_worker(a)
@@ -18,5 +23,11 @@ fn test_spawn_with_fixed_array_argument() {
 fn test_spawn_with_fixed_array_pointer_argument() {
 	a := &[3]int{}
 	handle := spawn issue27932_pointer_worker(a)
+	assert handle.wait() == 0
+}
+
+fn test_spawn_with_optional_fixed_array_argument() {
+	a := ?[2]int(none)
+	handle := spawn issue27932_optional_worker(a)
 	assert handle.wait() == 0
 }

--- a/vlib/v/tests/project_issue_27932_test.v
+++ b/vlib/v/tests/project_issue_27932_test.v
@@ -2,8 +2,21 @@ fn issue27932_worker(a [3]int) int {
 	return a[0] + a[1] + a[2]
 }
 
+fn issue27932_pointer_worker(a &[3]int) int {
+	unsafe {
+		// Fixed-array pointer indexing requires an unsafe block.
+		return a[0] + a[1] + a[2]
+	}
+}
+
 fn test_spawn_with_fixed_array_argument() {
 	a := [1, 2, 3]!
 	handle := spawn issue27932_worker(a)
 	assert handle.wait() == 6
+}
+
+fn test_spawn_with_fixed_array_pointer_argument() {
+	a := &[3]int{}
+	handle := spawn issue27932_pointer_worker(a)
+	assert handle.wait() == 0
 }


### PR DESCRIPTION
## Summary

- copy fixed-array spawn arguments into thread wrappers with `memcpy`
- preserve the separator in nested `#line` directives when hoisting ctemps in debug builds
- emit cast expressions used directly as function callees
- add regression coverage for all three cases

Closes #27932
Closes #27922
Closes #27921

## Testing

- `./vnew vlib/v/tests/project_issue_27921_test.v`
- `./vnew vlib/v/tests/project_issue_27932_test.v`
- `./vnew vlib/v/gen/c/ctempvars_line_info_codegen_test.v`
- `./vnew -silent vlib/v/gen/c/coutput_test.v` (224 passed, 17 skipped)
- `./vnew -silent vlib/v/compiler_errors_test.v` (1593 passed, 1 skipped)
- `./vnew -silent test vlib/v/` (2309 passed, 23 skipped; 9 unrelated failures from pre-existing local workspace artifacts/tests)