### PR TITLE
v3: scope template if-guard declarations per branch

### DIFF
--- a/vlib/v3/parser/span_test.v
+++ b/vlib/v3/parser/span_test.v
@@ -579,3 +579,38 @@ fn main() {
 	assert saw_map
 	assert saw_generic
 }
+
+// The local-binding scope powers template-closure callee classification: a bare callee is
+// captured only when it names an in-scope local binding, never a module/top-level function.
+fn test_local_binding_scopes_track_shadowing_and_nesting() {
+	mut p := Parser.new(pref.new_preferences())
+	assert !p.is_local_binding('render')
+	// declare_local_binding is a no-op until a scope is open.
+	p.declare_local_binding('render')
+	assert !p.is_local_binding('render')
+
+	p.begin_local_binding_scope()
+	p.declare_local_binding('render')
+	p.declare_local_binding('row')
+	assert p.is_local_binding('render')
+	assert p.is_local_binding('row')
+	// A module/top-level function name is never an in-scope binding.
+	assert !p.is_local_binding('helper')
+	// `_` and empty names are not bindings.
+	p.declare_local_binding('_')
+	assert !p.is_local_binding('_')
+
+	// A nested scope's bindings disappear when it closes; the outer binding survives.
+	p.begin_local_binding_scope()
+	p.declare_local_binding('render')
+	p.declare_local_binding('inner')
+	assert p.is_local_binding('render')
+	assert p.is_local_binding('inner')
+	p.end_local_binding_scope()
+	assert p.is_local_binding('render')
+	assert !p.is_local_binding('inner')
+
+	p.end_local_binding_scope()
+	assert !p.is_local_binding('render')
+	assert !p.is_local_binding('row')
+}

--- a/vlib/v3/parser/tmpl.v
+++ b/vlib/v3/parser/tmpl.v
@@ -1611,31 +1611,38 @@ fn (p &Parser) collect_template_free_idents(id flat.NodeId, mut declared map[str
 			}
 		}
 		.if_expr {
-			// An `@if item := maybe() { … }` guard (and any `:=` declared inside a branch
-			// body) binds names that are scoped to the if/else branches, not to the
-			// enclosing template. Snapshot the outer declared names, collect through the
-			// whole if-subtree so a use of the guard binding inside a branch is treated as
-			// local, then drop those branch-local names once the branches end — otherwise a
-			// later OUTER use of a shadowed name (`@item` after the guard) would stay
-			// "declared" and be omitted from the closure's capture list, leaving the
-			// reference undefined (or resolving a wrong outer/global name).
+			// In V, a guard binding `@if item := maybe() { ... }` is scoped to the THEN branch
+			// only: the ELSE branch, and code after the whole `if`, see the OUTER `item`. So
+			// collect the guard, then branch, and else branch with SEPARATE declared scopes.
+			// Declaring the guard binding while collecting the then branch keeps `@item` there
+			// guard-local, but it must be dropped before the else branch -- otherwise an `@item`
+			// in the else is wrongly treated as guard-local and omitted from the closure's
+			// capture list, leaving it unresolved or bound to the wrong symbol. Any `:=` inside
+			// a branch body is likewise local to that branch only.
 			mut outer_declared := map[string]bool{}
 			for name in declared.keys() {
 				outer_declared[name] = true
 			}
-			for i in 0 .. int(node.children_count) {
+			// Child 0 is the condition/guard; a guard `:=` declares its binding here. Child 1 is
+			// the then branch, collected with that binding in scope. The guard RHS is evaluated
+			// in the outer scope (see `.decl_assign`), so an outer name reused there is captured.
+			if node.children_count > 0 {
+				p.collect_template_free_idents(p.a.child(&node, 0), mut declared, mut seen, mut
+					out, mut mut_names)
+			}
+			if node.children_count > 1 {
+				p.collect_template_free_idents(p.a.child(&node, 1), mut declared, mut seen, mut
+					out, mut mut_names)
+			}
+			// The else branch (children 2+: a block or nested `else if`) does not see the guard
+			// binding or the then-branch locals.
+			restore_template_declared(mut declared, outer_declared)
+			for i in 2 .. int(node.children_count) {
 				p.collect_template_free_idents(p.a.child(&node, i), mut declared, mut seen, mut
 					out, mut mut_names)
 			}
-			mut branch_local := []string{}
-			for name in declared.keys() {
-				if name !in outer_declared {
-					branch_local << name
-				}
-			}
-			for name in branch_local {
-				declared.delete(name)
-			}
+			// Drop else-branch locals so a use AFTER the whole `if` captures the outer name.
+			restore_template_declared(mut declared, outer_declared)
 		}
 		.lambda_expr {
 			// A lambda's parameters are scoped to its body, not the enclosing template, so
@@ -1756,6 +1763,22 @@ fn (p &Parser) declare_template_ident(id flat.NodeId, mut declared map[string]bo
 	node := p.a.nodes[int(id)]
 	if node.kind == .ident && node.value.len > 0 {
 		declared[node.value] = true
+	}
+}
+
+// restore_template_declared drops every name in `declared` that was not present in
+// `outer_declared`, i.e. everything introduced by a just-collected inner scope (a guard binding
+// or a branch/loop-body `:=`), returning `declared` to its pre-scope state so later collection
+// sees the outer bindings again.
+fn restore_template_declared(mut declared map[string]bool, outer_declared map[string]bool) {
+	mut to_drop := []string{}
+	for name in declared.keys() {
+		if name !in outer_declared {
+			to_drop << name
+		}
+	}
+	for name in to_drop {
+		declared.delete(name)
 	}
 }
 

--- a/vlib/v3/tests/tmpl_if_guard_else_scope_codegen_test.v
+++ b/vlib/v3/tests/tmpl_if_guard_else_scope_codegen_test.v
@@ -1,0 +1,53 @@
+import os
+
+const gelse_vexe = @VEXE
+const gelse_tests_dir = os.dir(@FILE)
+const gelse_v3_dir = os.dir(gelse_tests_dir)
+const gelse_vlib_dir = os.dir(gelse_v3_dir)
+const gelse_v3_src = os.join_path(gelse_v3_dir, 'v3.v')
+
+fn gelse_build_v3() string {
+	pid := os.getpid()
+	v3_bin := os.join_path(os.temp_dir(), 'v3_tmpl_if_guard_else_scope_test_${pid}')
+	os.rm(v3_bin) or {}
+	build :=
+		os.execute('${gelse_vexe} -gc none -path "${gelse_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${gelse_v3_src}')
+	assert build.exit_code == 0, build.output
+	return v3_bin
+}
+
+// A template lowered into an IIFE that opens an `@if item := find(items)` guard and references
+// `@{item}` in BOTH the then and the else branch. In V the guard binding is scoped to the then
+// branch only, so the `@{item}` in the else branch must capture the OUTER `item`. The capture
+// collector must therefore walk the guard/then/else with separate declared scopes and drop the
+// guard binding before the else branch: without that, the else use is treated as guard-local,
+// the closure omits `item` from its capture list, and the else reference is left undefined (or
+// bound to the wrong symbol), so the guard binding — unbound in the else branch — is what the
+// generated code reaches for.
+fn test_template_if_guard_var_does_not_shadow_outer_capture_in_else_branch() {
+	v3_bin := gelse_build_v3()
+	pid := os.getpid()
+	root := os.join_path(os.temp_dir(), 'v3_tmpl_if_guard_else_scope_${pid}_project')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	os.write_file(os.join_path(root, 'v.mod'), "Module { name: 'gelse' }\n") or { panic(err) }
+	// Guard-bind `item` to the first element (then branch prints it); the else branch prints the
+	// OUTER `item`, which is NOT the guard binding.
+	os.write_file(os.join_path(root, 't.html'),
+		'@if item := find(items)\nthen:@{item}\n@else\nelse:@{item}\n@end\n') or { panic(err) }
+	source := "module main\n\nfn find(items []string) ?string {\n\tif items.len > 0 {\n\t\treturn items[0]\n\t}\n\treturn none\n}\n\nfn build(item string, items []string) string {\n\treturn ('[' + \$tmpl('t.html') + ']').replace('\\n', '')\n}\n\nfn main() {\n\tprintln(build('OUTER', ['a', 'b']))\n\tprintln(build('OUTER', []string{}))\n}\n"
+	os.write_file(os.join_path(root, 'main.v'), source) or { panic(err) }
+	bin := os.join_path(os.temp_dir(), 'v3_tmpl_if_guard_else_scope_bin_${pid}')
+	compile := os.execute('${v3_bin} ${os.join_path(root, 'main.v')} -b c -o ${bin}')
+	assert compile.exit_code == 0, compile.output
+	assert !compile.output.contains('C compilation failed'), compile.output
+	run := os.execute(bin)
+	assert run.exit_code == 0, run.output
+	lines := run.output.trim_space().split('\n')
+	assert lines.len == 2, run.output
+	// Non-empty items: the guard succeeds, the then branch prints the guard-bound first element.
+	assert lines[0] == '[then:a]', run.output
+	// Empty items: the guard fails, the else branch prints the OUTER `item` (captured), not the
+	// unbound guard variable.
+	assert lines[1] == '[else:OUTER]', run.output
+}


### PR DESCRIPTION
## What

The `$tmpl`/`$veb.html` free-identifier collector (`collect_template_free_idents` in `vlib/v3/parser/tmpl.v`) walked an `@if` guard, then-branch, and else-branch with a single shared `declared` map. A guard binding — `@if item := maybe()` — was therefore left "declared" while the else branch was collected.

In V, a guard binding is scoped to the **then branch only**; the else branch (and code after the whole `if`) sees the *outer* `item`. So for a template lowered into an IIFE like:

```
@if item := find(items)
then:@{item}
@else
else:@{item}
@end
```

the `@{item}` in the else branch must capture the **outer** `item`. The shared map treated it as guard-local and dropped it from the closure's capture list, so the generated C reached for the (unbound) guard variable instead:

```
error: use of undeclared identifier 'item'
```

## Fix

Collect the guard/then/else portions with **separate declared scopes**: declare the guard binding while collecting the then branch, then restore `declared` to its outer state before collecting the else branch, and again after the whole `if` (so a use after the guard also captures the outer name). A small `restore_template_declared` helper drops the names introduced by a just-collected inner scope.

## Test

Adds `vlib/v3/tests/tmpl_if_guard_else_scope_codegen_test.v`, which renders a template that uses `@{item}` in both the then and else branch and asserts the else branch prints the outer value (`[then:a]` / `[else:OUTER]`). Fails without the fix (`use of undeclared identifier 'item'`), passes with it.

The existing if-guard/scoping template tests (`tmpl_if_guard_var_scope`, `tmpl_if_guard_capture`, `tmpl_multi_decl_guard`, `tmpl_if_guard_rhs_capture`) still pass.

Addresses review feedback from #27911 (thread r3639279430). The companion checker.v feedback (r3639279423) was already resolved upstream by #27938, so it is not included here.