### PR TITLE
cgen: fix five invalid C edge cases

### DIFF
--- a/vlib/v/builder/c_error_reproducer.v
+++ b/vlib/v/builder/c_error_reproducer.v
@@ -1139,10 +1139,10 @@ fn repro_uses_local_resource(source string) bool {
 // V tokenizes the call, so whitespace between the name and its `(` is valid
 // (`$embed_file ('asset.bin')`) and an exact-substring check would miss it.
 fn repro_has_comptime_call(source string, name string) bool {
-	pat := '\$' + name
+	pat := '$' + name
 	mut i := 0
 	for i + pat.len <= source.len {
-		if source[i] != `\$` || source[i..i + pat.len] != pat {
+		if source[i] != `$` || source[i..i + pat.len] != pat {
 			i++
 			continue
 		}

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -5492,18 +5492,11 @@ fn (mut c Checker) cast_expr(mut node ast.CastExpr) ast.Type {
 
 	unaliased_from_type := c.table.fully_unaliased_type(from_type)
 	unaliased_to_type := c.table.fully_unaliased_type(to_type)
-	if unaliased_from_type.is_ptr() && !unaliased_to_type.is_any_kind_of_pointer()
+	if unaliased_from_type.is_any_kind_of_pointer() && !unaliased_to_type.is_any_kind_of_pointer()
 		&& final_to_sym.kind in [.array, .array_fixed] {
-		to_elem_type := if final_to_sym.kind == .array {
-			final_to_sym.array_info().elem_type
-		} else {
-			final_to_sym.array_fixed_info().elem_type
-		}
-		if c.table.fully_unaliased_type(unaliased_from_type.deref()) == c.table.fully_unaliased_type(to_elem_type) {
-			ft := c.table.type_to_str(from_type)
-			tt := c.table.type_to_str(to_type)
-			c.error('cannot cast pointer type `${ft}` to array type `${tt}`', node.pos)
-		}
+		ft := c.table.type_to_str(from_type)
+		tt := c.table.type_to_str(to_type)
+		c.error('cannot cast pointer type `${ft}` to array type `${tt}`', node.pos)
 	}
 
 	final_to_is_ptr := to_type.is_ptr() || final_to_type.is_ptr()

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -5492,11 +5492,18 @@ fn (mut c Checker) cast_expr(mut node ast.CastExpr) ast.Type {
 
 	unaliased_from_type := c.table.fully_unaliased_type(from_type)
 	unaliased_to_type := c.table.fully_unaliased_type(to_type)
-	if unaliased_from_type.is_any_kind_of_pointer() && !unaliased_to_type.is_any_kind_of_pointer()
+	if unaliased_from_type.is_ptr() && !unaliased_to_type.is_any_kind_of_pointer()
 		&& final_to_sym.kind in [.array, .array_fixed] {
-		ft := c.table.type_to_str(from_type)
-		tt := c.table.type_to_str(to_type)
-		c.error('cannot cast pointer type `${ft}` to array type `${tt}`', node.pos)
+		to_elem_type := if final_to_sym.kind == .array {
+			final_to_sym.array_info().elem_type
+		} else {
+			final_to_sym.array_fixed_info().elem_type
+		}
+		if c.table.fully_unaliased_type(unaliased_from_type.deref()) == c.table.fully_unaliased_type(to_elem_type) {
+			ft := c.table.type_to_str(from_type)
+			tt := c.table.type_to_str(to_type)
+			c.error('cannot cast pointer type `${ft}` to array type `${tt}`', node.pos)
+		}
 	}
 
 	final_to_is_ptr := to_type.is_ptr() || final_to_type.is_ptr()

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -5490,6 +5490,15 @@ fn (mut c Checker) cast_expr(mut node ast.CastExpr) ast.Type {
 		return node.typ
 	}
 
+	unaliased_from_type := c.table.fully_unaliased_type(from_type)
+	unaliased_to_type := c.table.fully_unaliased_type(to_type)
+	if unaliased_from_type.is_any_kind_of_pointer() && !unaliased_to_type.is_any_kind_of_pointer()
+		&& final_to_sym.kind in [.array, .array_fixed] {
+		ft := c.table.type_to_str(from_type)
+		tt := c.table.type_to_str(to_type)
+		c.error('cannot cast pointer type `${ft}` to array type `${tt}`', node.pos)
+	}
+
 	final_to_is_ptr := to_type.is_ptr() || final_to_type.is_ptr()
 	c.markused_castexpr(mut node, to_type, mut final_to_sym)
 	if to_type.has_flag(.result) {

--- a/vlib/v/checker/for.v
+++ b/vlib/v/checker/for.v
@@ -284,7 +284,9 @@ fn (mut c Checker) for_in_stmt(mut node ast.ForInStmt) {
 			} else if sym.kind == .aggregate&& (sym.info as ast.Aggregate).types.all(c.table.type_kind(it) in [.array, .array_fixed, .string, .map]) {
 				value_type = c.table.value_type((sym.info as ast.Aggregate).types[0])
 			}
-			if value_type == ast.void_type || typ.has_flag(.result) {
+			cannot_index_option_map_expr := !is_comptime && typ.has_flag(.option)
+				&& sym.kind == .map && node.cond !is ast.Ident
+			if value_type == ast.void_type || typ.has_flag(.result) || cannot_index_option_map_expr {
 				if typ != ast.void_type {
 					c.error('for in: cannot index `${c.table.type_to_str(typ)}`', node.cond.pos())
 				}

--- a/vlib/v/checker/tests/cast_pointer_to_array_err.out
+++ b/vlib/v/checker/tests/cast_pointer_to_array_err.out
@@ -12,3 +12,24 @@ vlib/v/checker/tests/cast_pointer_to_array_err.vv:6:8: error: cannot cast pointe
       |              ^
     7 |     }
     8 | }
+vlib/v/checker/tests/cast_pointer_to_array_err.vv:13:8: error: cannot cast pointer type `&u8` to array type `[]int`
+   11 |     unsafe {
+   12 |         byte_value := u8(1)
+   13 |         _ := []int(&byte_value)
+      |              ^
+   14 |         value := 1
+   15 |         p := &value
+vlib/v/checker/tests/cast_pointer_to_array_err.vv:17:8: error: cannot cast pointer type `&&int` to array type `[]int`
+   15 |         p := &value
+   16 |         pp := &p
+   17 |         _ := []int(pp)
+      |              ^
+   18 |         raw := voidptr(p)
+   19 |         _ := []int(raw)
+vlib/v/checker/tests/cast_pointer_to_array_err.vv:19:8: error: cannot cast pointer type `voidptr` to array type `[]int`
+   17 |         _ := []int(pp)
+   18 |         raw := voidptr(p)
+   19 |         _ := []int(raw)
+      |              ^
+   20 |     }
+   21 | }

--- a/vlib/v/checker/tests/cast_pointer_to_array_err.out
+++ b/vlib/v/checker/tests/cast_pointer_to_array_err.out
@@ -1,0 +1,14 @@
+vlib/v/checker/tests/cast_pointer_to_array_err.vv:5:8: error: cannot cast pointer type `&int` to array type `[]int`
+    3 |         values := [1, 2, 3]!
+    4 |         p := &values[0]
+    5 |         _ := []int(p)
+      |              ^
+    6 |         _ := [3]int(p)
+    7 |     }
+vlib/v/checker/tests/cast_pointer_to_array_err.vv:6:8: error: cannot cast pointer type `&int` to array type `[3]int`
+    4 |         p := &values[0]
+    5 |         _ := []int(p)
+    6 |         _ := [3]int(p)
+      |              ^
+    7 |     }
+    8 | }

--- a/vlib/v/checker/tests/cast_pointer_to_array_err.vv
+++ b/vlib/v/checker/tests/cast_pointer_to_array_err.vv
@@ -7,6 +7,19 @@ fn main() {
 	}
 }
 
+fn reject_other_pointer_sources() {
+	unsafe {
+		byte_value := u8(1)
+		_ := []int(&byte_value)
+		value := 1
+		p := &value
+		pp := &p
+		_ := []int(pp)
+		raw := voidptr(p)
+		_ := []int(raw)
+	}
+}
+
 fn preserve_pointer_to_array_reinterpret_casts() {
 	unsafe {
 		dynamic := [1, 2, 3]

--- a/vlib/v/checker/tests/cast_pointer_to_array_err.vv
+++ b/vlib/v/checker/tests/cast_pointer_to_array_err.vv
@@ -1,0 +1,8 @@
+fn main() {
+	unsafe {
+		values := [1, 2, 3]!
+		p := &values[0]
+		_ := []int(p)
+		_ := [3]int(p)
+	}
+}

--- a/vlib/v/checker/tests/cast_pointer_to_array_err.vv
+++ b/vlib/v/checker/tests/cast_pointer_to_array_err.vv
@@ -6,3 +6,12 @@ fn main() {
 		_ := [3]int(p)
 	}
 }
+
+fn preserve_pointer_to_array_reinterpret_casts() {
+	unsafe {
+		dynamic := [1, 2, 3]
+		_ := *&[]int(&dynamic)
+		fixed := [1, 2, 3]!
+		_ := *&[3]int(&fixed)
+	}
+}

--- a/vlib/v/checker/tests/for_in_index_option.out
+++ b/vlib/v/checker/tests/for_in_index_option.out
@@ -5,3 +5,10 @@ vlib/v/checker/tests/for_in_index_option.vv:4:17: error: for in: cannot index `!
       |                    ~~~~~~~
     5 |         println(file)
     6 |     }
+vlib/v/checker/tests/for_in_index_option.vv:7:18: error: for in: cannot index `?map[string]int`
+    5 |         println(file)
+    6 |     }
+    7 |     for _, value in maybe_values(true) {
+      |                     ~~~~~~~~~~~~~~~~~~
+    8 |         println(value)
+    9 |     }

--- a/vlib/v/checker/tests/for_in_index_option.vv
+++ b/vlib/v/checker/tests/for_in_index_option.vv
@@ -4,4 +4,16 @@ fn main() {
 	for file in os.ls('.') {
 		println(file)
 	}
+	for _, value in maybe_values(true) {
+		println(value)
+	}
+}
+
+fn maybe_values(ok bool) ?map[string]int {
+	if ok {
+		return {
+			'one': 1
+		}
+	}
+	return none
 }

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4099,12 +4099,18 @@ fn (mut g Gen) stmts_with_tmp_var(stmts []ast.Stmt, tmp_var string) bool {
 							inside_assign_context := g.inside_struct_init
 								|| g.inside_assign
 								|| (!g.inside_return && g.inside_match_option)
-							ret_expr_typ := if inside_assign_context {
+							expected_if_option_type := g.unwrap_generic(g.last_if_option_type)
+							has_expected_if_option_type := expected_if_option_type.has_flag(.option)
+							ret_expr_typ := if has_expected_if_option_type {
+								expected_if_option_type
+							} else if inside_assign_context {
 								stmt.typ
 							} else {
 								g.fn_decl.return_type
 							}
-							ret_typ := if inside_assign_context {
+							ret_typ := if has_expected_if_option_type {
+								expected_if_option_type.clear_flag(.option)
+							} else if inside_assign_context {
 								stmt.typ
 							} else {
 								g.fn_decl.return_type.clear_flag(.option)
@@ -8330,6 +8336,7 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 	}
 	// struct embedding
 	mut has_embed := false
+	mut last_embed_is_ptr := false
 	if sym.info in [ast.Alias, ast.Struct, ast.Aggregate] {
 		if selector_embed_types.len > 0 && sym.info is ast.Aggregate {
 			// For aggregate types, check per-variant whether the field is
@@ -8339,18 +8346,18 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 			agg_sym := g.table.sym(sym.info.types[g.aggregate_type_idx])
 			if !g.table.struct_has_field(agg_sym, field_name) {
 				has_embed = node.from_embed_types.len > 0
-				g.write_selector_expr_embed_name(node, node.from_embed_types)
+				last_embed_is_ptr = g.write_selector_expr_embed_name(node, node.from_embed_types)
 			}
 		} else if selector_embed_types.len > 0 {
 			has_embed = true
-			g.write_selector_expr_embed_name(node, selector_embed_types)
+			last_embed_is_ptr = g.write_selector_expr_embed_name(node, selector_embed_types)
 		} else if node.generic_from_embed_types.len > 0 && sym.info is ast.Struct {
 			if sym.info.embeds.len > 0 {
 				mut is_find := false
 				for arr_val in node.generic_from_embed_types {
 					if arr_val.len > 0 {
 						if arr_val[0] == sym.info.embeds[0] {
-							g.write_selector_expr_embed_name(node, arr_val)
+							last_embed_is_ptr = g.write_selector_expr_embed_name(node, arr_val)
 							is_find = true
 							has_embed = true
 							break
@@ -8359,21 +8366,22 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 				}
 				if !is_find {
 					has_embed = node.from_embed_types.len > 0
-					g.write_selector_expr_embed_name(node, node.from_embed_types)
+					last_embed_is_ptr = g.write_selector_expr_embed_name(node,
+						node.from_embed_types)
 				}
 			} else {
 				has_embed = node.from_embed_types.len > 0
-				g.write_selector_expr_embed_name(node, node.from_embed_types)
+				last_embed_is_ptr = g.write_selector_expr_embed_name(node, node.from_embed_types)
 			}
 		} else if sym.info is ast.Aggregate {
 			agg_sym := g.table.sym(sym.info.types[g.aggregate_type_idx])
 			if !g.table.struct_has_field(agg_sym, field_name) {
 				has_embed = node.from_embed_types.len > 0
-				g.write_selector_expr_embed_name(node, node.from_embed_types)
+				last_embed_is_ptr = g.write_selector_expr_embed_name(node, node.from_embed_types)
 			}
 		} else {
 			has_embed = node.from_embed_types.len > 0
-			g.write_selector_expr_embed_name(node, node.from_embed_types)
+			last_embed_is_ptr = g.write_selector_expr_embed_name(node, node.from_embed_types)
 		}
 	}
 	alias_to_ptr := sym.info is ast.Alias && sym.info.parent_type.is_ptr()
@@ -8440,7 +8448,7 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 			|| (!opt_ptr_already_deref && unwrapped_expr_type.is_ptr()
 			&& !is_interface_smartcast_lhs && !smartcast_ident_already_dereferenced)
 	}
-	if !has_embed && left_is_ptr {
+	if (!has_embed && left_is_ptr) || (has_embed && last_embed_is_ptr) {
 		g.write('->')
 	} else {
 		g.write('.')
@@ -8645,7 +8653,7 @@ fn (mut g Gen) gen_closure_fn(expr_styp string, m ast.Fn, name string) {
 	g.nr_closures++
 }
 
-fn (mut g Gen) write_selector_expr_embed_name(node ast.SelectorExpr, embed_types []ast.Type) {
+fn (mut g Gen) write_selector_expr_embed_name(node ast.SelectorExpr, embed_types []ast.Type) bool {
 	mut is_shared := g.type_resolves_to_shared(node.expr_type)
 	mut lhs_expr_type := node.expr_type
 	if node.expr is ast.Ident && node.expr.obj is ast.Var && (node.expr.obj.typ.has_flag(.generic)
@@ -8676,7 +8684,7 @@ fn (mut g Gen) write_selector_expr_embed_name(node ast.SelectorExpr, embed_types
 		is_left_ptr := if i == 0 {
 			(resolved_selector_expr_type.is_ptr() || is_auto_heap) && !is_shared
 		} else {
-			embed_types[i - 1].is_ptr()
+			g.table.fully_unaliased_type(embed_types[i - 1]).is_ptr()
 		}
 		if i == 0 && is_shared {
 			g.write('->val')
@@ -8688,6 +8696,7 @@ fn (mut g Gen) write_selector_expr_embed_name(node ast.SelectorExpr, embed_types
 		}
 		g.write(embed_name)
 	}
+	return embed_types.len > 0 && g.table.fully_unaliased_type(embed_types.last()).is_ptr()
 }
 
 // check_var_scope checks if the variable has its value known from the node position

--- a/vlib/v/tests/project_issue_27901_test.v
+++ b/vlib/v/tests/project_issue_27901_test.v
@@ -1,0 +1,16 @@
+struct Issue27901Inner {
+	value int = 3
+}
+
+type Issue27901InnerPtr = &Issue27901Inner
+
+struct Issue27901Outer {
+	Issue27901InnerPtr
+}
+
+fn test_embedded_pointer_alias_field_access() {
+	a := Issue27901Outer{
+		value: 7
+	}
+	assert a.value == 7
+}

--- a/vlib/v/tests/project_issue_27903_test.v
+++ b/vlib/v/tests/project_issue_27903_test.v
@@ -1,0 +1,12 @@
+fn issue27903_value(x ?string) string {
+	return x or { 'NONE' }
+}
+
+fn issue27903_condition(value bool) bool {
+	return value
+}
+
+fn test_if_expression_passed_as_option_argument() {
+	assert issue27903_value(if issue27903_condition(true) { 'a' } else { none }) == 'a'
+	assert issue27903_value(if issue27903_condition(false) { 'a' } else { none }) == 'NONE'
+}


### PR DESCRIPTION
## Summary

- preserve the inferred option payload type when an `if` expression is passed directly as an option argument
- use pointer field access after embedded pointer aliases
- reject unsupported pointer-to-dynamic-array and pointer-to-fixed-array value casts in the checker
- reject non-identifier optional map expressions in `for in` before they reach C generation
- add checker and runtime regressions for all five cases

Fixes #27899
Fixes #27900
Fixes #27901
Fixes #27902
Fixes #27903

## Tests

- `./vnew -silent vlib/v/compiler_errors_test.v` — 1594 passed, 1 skipped
- `./vnew -silent vlib/v/gen/c/coutput_test.v` — 97 output fixtures and 127 C-pattern fixtures passed
- `./vnew -silent vlib/v/slow_tests/inout/compiler_test.v` — 81 passed, 9 expected panics, 1 skipped
- strict Clang builds for `project_issue_27901_test.v` and `project_issue_27903_test.v`
- targeted optional-array, optional-map-variable, and comptime-selector compatibility tests
- `VTEST_HIDE_OK=1 ./vnew -silent test vlib/v/` — 2313 passed, 23 skipped; 9 unrelated checkout/environment failures (removed eval backend, stale native JS artifacts, help extra target, and the pre-existing option equality helper failure)
