### PR TITLE
builtin: prevent prealloc recycle cache bootstrap race

### DIFF
--- a/vlib/builtin/prealloc.c.v
+++ b/vlib/builtin/prealloc.c.v
@@ -40,7 +40,6 @@ const prealloc_scope_block_size = 256 * 1024
 const prealloc_default_align = sizeof(voidptr) * 2
 
 __global g_memory_block &VMemoryBlock
-__global g_prealloc_block_cache &VPreallocBlockCache
 __global g_prealloc_allocation_count i64
 __global g_prealloc_allocated_bytes i64
 
@@ -92,12 +91,13 @@ pub fn prealloc_stats_snapshot() PreallocStats {
 @[heap]
 struct VMemoryBlock {
 mut:
-	current        &u8             = 0 // 8
-	stop           &u8             = 0 // 8
-	start          &u8             = 0 // 8
-	previous       &VMemoryBlock   = 0 // 8
-	next           &VMemoryBlock   = 0 // 8
-	scope          &VPreallocScope = 0
+	current        &u8                  = 0 // 8
+	stop           &u8                  = 0 // 8
+	start          &u8                  = 0 // 8
+	previous       &VMemoryBlock        = 0 // 8
+	next           &VMemoryBlock        = 0 // 8
+	scope          &VPreallocScope      = 0
+	recycle_cache  &VPreallocBlockCache = 0
 	min_block_size isize
 	is_scope       bool
 	mmap_allocated bool
@@ -245,6 +245,7 @@ fn vmemory_block_new_sized(prev &VMemoryBlock, at_least isize, align isize, min_
 	if unsafe { prev != 0 } {
 		prev.next = v
 		v.is_scope = prev.is_scope
+		v.recycle_cache = prev.recycle_cache
 	}
 	effective_min_block_size := if min_block_size > 0 {
 		min_block_size
@@ -281,7 +282,7 @@ fn vmemory_block_new_sized(prev &VMemoryBlock, at_least isize, align isize, min_
 				$if !prealloc_no_recycle ? {
 					if prealloc_recyclable_block_size(block_size) {
 						unsafe {
-							mut cache := g_prealloc_block_cache
+							mut cache := v.recycle_cache
 							if cache != 0 {
 								for ci := 0; ci < cache.count; ci++ {
 									if cache.sizes[ci] == block_size {
@@ -351,6 +352,8 @@ fn vmemory_block_malloc(n isize, align isize) &u8 {
 			// thread-local, new threads start with a null pointer and need
 			// their own arena.
 			mb = vmemory_block_new(nil, isize(prealloc_block_size), 0)
+			mb.recycle_cache = &VPreallocBlockCache(C.calloc(1, sizeof(VPreallocBlockCache)))
+			vmemory_abort_on_nil(mb.recycle_cache, sizeof(VPreallocBlockCache))
 			g_memory_block = mb
 		}
 		$if prealloc_trace_malloc ? {
@@ -428,13 +431,9 @@ fn vmemory_block_free(mb &VMemoryBlock) {
 				$if !prealloc_no_recycle ? {
 					if prealloc_recyclable_block_size(isize(size)) {
 						unsafe {
-							mut cache := g_prealloc_block_cache
-							if cache == 0 {
-								cache = &VPreallocBlockCache(C.calloc(1,
-									sizeof(VPreallocBlockCache)))
-								if cache != 0 {
-									g_prealloc_block_cache = cache
-								}
+							mut cache := &VPreallocBlockCache(nil)
+							if g_memory_block != 0 {
+								cache = g_memory_block.recycle_cache
 							}
 							if cache != 0 && cache.count < 64
 								&& cache.bytes + isize(size) <= isize(prealloc_scope_block_size) * 64 {
@@ -495,7 +494,10 @@ fn prealloc_vinit() {
 		C.fprintf(C.stderr, c'prealloc_vinit started\n')
 	}
 	unsafe {
-		g_memory_block = vmemory_block_new(nil, isize(prealloc_block_size), 0)
+		mut root := vmemory_block_new(nil, isize(prealloc_block_size), 0)
+		root.recycle_cache = &VPreallocBlockCache(C.calloc(1, sizeof(VPreallocBlockCache)))
+		vmemory_abort_on_nil(root.recycle_cache, sizeof(VPreallocBlockCache))
+		g_memory_block = root
 		at_exit(prealloc_vcleanup) or {}
 	}
 }

--- a/vlib/builtin/prealloc_scope_ownership_test.v
+++ b/vlib/builtin/prealloc_scope_ownership_test.v
@@ -31,3 +31,33 @@ fn test_prealloc_scope_suspend_allocates_in_parent() {
 		assert parent == 'parent allocation'
 	}
 }
+
+fn recycle_scopes_on_worker(worker_id int) int {
+	$if prealloc {
+		for iteration in 0 .. 256 {
+			scope := unsafe { prealloc_scope_begin() }
+			mut data := []u8{len: 384 * 1024}
+			data[0] = u8(worker_id)
+			data[data.len - 1] = u8(iteration)
+			checksum := int(data[0]) + int(data[data.len - 1])
+			unsafe { prealloc_scope_leave(scope) }
+			unsafe { prealloc_scope_free_after(scope) }
+			if checksum != worker_id + int(u8(iteration)) {
+				return -1
+			}
+		}
+	}
+	return worker_id
+}
+
+fn test_prealloc_scope_recycling_is_thread_local() {
+	$if prealloc {
+		mut threads := []thread int{}
+		for worker_id in 1 .. 9 {
+			threads << spawn recycle_scopes_on_worker(worker_id)
+		}
+		for worker_id, handle in threads {
+			assert handle.wait() == worker_id + 1
+		}
+	}
+}

--- a/vlib/v/gen/c/consts_and_globals.v
+++ b/vlib/v/gen/c/consts_and_globals.v
@@ -602,7 +602,7 @@ fn (mut g Gen) global_decl(node ast.GlobalDecl) {
 			continue
 		}
 		if field.is_extern {
-			tls_kw := if field.name in ['g_memory_block', 'g_prealloc_block_cache'] && g.pref.prealloc {
+			tls_kw := if field.name == 'g_memory_block' && g.pref.prealloc {
 				'_Thread_local '
 			} else {
 				''
@@ -617,7 +617,7 @@ fn (mut g Gen) global_decl(node ast.GlobalDecl) {
 		}
 		mut needs_ending_semicolon := false
 		if field.language != .c || field.has_expr {
-			tls_kw := if field.name in ['g_memory_block', 'g_prealloc_block_cache'] && g.pref.prealloc {
+			tls_kw := if field.name == 'g_memory_block' && g.pref.prealloc {
 				'_Thread_local '
 			} else {
 				''

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -15468,15 +15468,13 @@ fn (mut g FlatGen) global_decls() {
 			g.writeln('#endif')
 			continue
 		}
-		// With -prealloc the arena base block and the block-recycle cache are
-		// per-thread; a shared pointer would make all threads bump the same
-		// block without synchronization. cc gets real TLS; tcc implements no
-		// _Thread_local, so each gets a pthread-key emulation behind an lvalue
-		// macro. The keys are created from a constructor (same pattern as the
-		// shared-storage TLS emulation above), so worker threads can never
-		// race a lazy pthread_key_create - unlike the arena base, the recycle
-		// cache has no first-touch-on-main-thread guarantee.
-		if g.prealloc && name in ['g_memory_block', 'g_prealloc_block_cache'] {
+		// With -prealloc the arena base block is per-thread; a shared pointer
+		// would make all threads bump the same block without synchronization.
+		// The block-recycle cache hangs off this TLS root, keeping bootstrap
+		// compilers that only know about g_memory_block safe as well.
+		// cc gets real TLS; tcc implements no _Thread_local, so it gets a
+		// pthread-key emulation behind an lvalue macro.
+		if g.prealloc && name == 'g_memory_block' {
 			cn := g.cname(name)
 			g.writeln('#if defined(__TINYC__)')
 			g.writeln('static pthread_key_t ${cn}_key;')


### PR DESCRIPTION
Older bootstrap compilers only know that `g_memory_block` must be emitted as thread-local storage. When the recycle cache was added as a separate `g_prealloc_block_cache` global, those compilers emitted it as process-global state. Parallel v3 parser/checker workers could then recycle the same scoped blocks concurrently, causing a SIGBUS or SIGSEGV immediately after parsing during a self-host build.

Store the recycle-cache pointer on `VMemoryBlock` instead. Every block inherits it from the existing TLS arena chain, so the cache stays thread-local even when the source is compiled by an older bootstrap compiler. Remove the no-longer-needed cache-name special cases from both C generators and add a concurrent scoped-recycling regression test.

Validation:

- reproduced the crash with an older bootstrap compiler and confirmed `g_prealloc_block_cache` was emitted in `__DATA,__bss`
- rebuilt with that same compiler after this change; the standalone cache symbol is gone and nine consecutive v3 self-builds passed
- `../../v -gc none -prealloc -prod -o v3 v3.v && ./v3 -nocache -building-v -o v4 v3.v`
- `./vnew -prealloc test vlib/builtin/prealloc_scope_ownership_test.v`
- `./vnew -silent vlib/v/compiler_errors_test.v`
- `./vnew -silent vlib/v/gen/c/coutput_test.v`
- `./vnew -silent test vlib/v/` (2306 passed, 22 skipped)

`test-all` was not run.