### PR TITLE
net.urllib: reject backslashes in URL authorities

### DIFF
--- a/vlib/net/urllib/urllib.v
+++ b/vlib/net/urllib/urllib.v
@@ -51,7 +51,7 @@ fn should_escape(c u8, mode EncodingMode) bool {
 		// we could possibly allow, and parse will reject them if we
 		// escape them (because hosts can`t use %-encoding for
 		// ASCII bytes).
-		if c in [`!`, `$`, `&`, `\\`, `(`, `)`, `*`, `+`, `,`, `;`, `=`, `:`, `[`, `]`, `<`, `>`,
+		if c in [`!`, `$`, `&`, `'`, `(`, `)`, `*`, `+`, `,`, `;`, `=`, `:`, `[`, `]`, `<`, `>`,
 			`"`] {
 			return false
 		}
@@ -203,7 +203,7 @@ fn unescape(s_ string, mode EncodingMode) !string {
 			else {
 				if (mode == .encode_host || mode == .encode_zone) && s[i] < 0x80
 					&& should_escape(s[i], mode) {
-					error(error_msg('unescape: invalid character in host name', s[i..i + 1]))
+					return error(error_msg('unescape: invalid character in host name', s[i..i + 1]))
 				}
 				i++
 			}
@@ -1025,7 +1025,7 @@ pub fn valid_userinfo(s string) bool {
 			continue
 		}
 		match r {
-			`-`, `.`, `_`, `:`, `~`, `!`, `$`, `&`, `\\`, `(`, `)`, `*`, `+`, `,`, `;`, `=`, `%`,
+			`-`, `.`, `_`, `:`, `~`, `!`, `$`, `&`, `'`, `(`, `)`, `*`, `+`, `,`, `;`, `=`, `%`,
 			`@` {
 				continue
 			}

--- a/vlib/net/urllib/urllib_test.v
+++ b/vlib/net/urllib/urllib_test.v
@@ -140,6 +140,27 @@ fn test_parse_authority() {
 	}
 }
 
+fn test_parse_rejects_backslash_in_authority() {
+	invalid_urls := [
+		r'http://127.0.0.1\@google.com/',
+		r'http://user@google.com\path',
+		r'http://google.com\path',
+	]
+	for url in invalid_urls {
+		if _ := urllib.parse(url) {
+			assert false, 'parser must reject "${url}"'
+		}
+	}
+}
+
+fn test_parse_allows_apostrophe_in_authority() {
+	url := urllib.parse("http://o'connor@example'host/")!
+	assert url.host == "example'host"
+	if user := url.user {
+		assert user.username == "o'connor"
+	}
+}
+
 fn test_parse_slashes() {
 	assert urllib.parse('/')!.str() == '/'
 	assert urllib.parse('//')!.str() == '//'


### PR DESCRIPTION
Fixes #27945.

Raw backslashes are not valid RFC 3986 authority characters, but `net.urllib` allowed them in both host and userinfo character sets. This could make a backslash before `@` change which host callers believed they had validated.

This change:
- restores apostrophe as the RFC-valid sub-delimiter in the host and userinfo allowlists;
- returns the invalid-host error that `unescape` previously constructed but discarded;
- adds regression coverage for backslashes before and after userinfo delimiters and in bare hosts.

Tests:
- `./vnew -silent test vlib/net/urllib/`
- `./vnew -silent test vlib/net/http/http_test.v`
- `./vnew -silent test vlib/net/http/request_test.v`