### PR TITLE
arrays: handles arrays.window invalid attributes

### DIFF
--- a/vlib/arrays/arrays.v
+++ b/vlib/arrays/arrays.v
@@ -208,20 +208,21 @@ pub fn chunk_while[T](a []T, predicate fn (before T, after T) bool) [][]T {
 	return chunks
 }
 
+// WindowAttribute configures the windows produced by arrays.window
 pub struct WindowAttribute {
 pub:
-	size int
-	step int = 1
+	size int     // number of elements in each window; must be positive
+	step int = 1 // amount added to the starting index after each window; must be positive
 }
 
-// get snapshots of the window of the given size sliding along array with the given step, where each snapshot is an array.
-// - `size` - snapshot size
-// - `step` - gap size between each snapshot, default is 1.
+// window returns fixed-size windows over `array`.
+// Each window starts `attr.step` positions after the previous window.
+// It returns an empty array when the input or attributes cannot produce a window.
 //
 // Example: arrays.window([1, 2, 3, 4], size: 2) // => [[1, 2], [2, 3], [3, 4]]
 // Example: arrays.window([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], size: 3, step: 2) // => [[1, 2, 3], [3, 4, 5], [5, 6, 7], [7, 8, 9]]
 pub fn window[T](array []T, attr WindowAttribute) [][]T {
-	if array.len == 0 {
+	if array.len == 0 || attr.size <= 0 || attr.step <= 0 || attr.size > array.len {
 		return [][]T{}
 	}
 	// allocate snapshot array

--- a/vlib/arrays/arrays.v
+++ b/vlib/arrays/arrays.v
@@ -211,7 +211,7 @@ pub fn chunk_while[T](a []T, predicate fn (before T, after T) bool) [][]T {
 // WindowAttribute configures the windows produced by arrays.window
 pub struct WindowAttribute {
 pub:
-	size int     // number of elements in each window; must be positive
+	size int // number of elements in each window; must be positive
 	step int = 1 // amount added to the starting index after each window; must be positive
 }
 

--- a/vlib/arrays/arrays_test.v
+++ b/vlib/arrays/arrays_test.v
@@ -170,6 +170,10 @@ fn test_window() {
 		[4, 5, 6]]
 	assert window[int](x, size: 3, step: 2) == [[1, 2, 3], [3, 4, 5]]
 	assert window[int]([]int{}, size: 2) == [][]int{}
+	assert window([1, 2, 3], size: 2, step: 0) == [][]int{}
+	assert window([1, 2, 3], size: 2, step: -1) == [][]int{}
+	assert window([1, 2, 3], size: 0) == [][]int{}
+	assert window([1, 2, 3], size: 4) == [][]int{}
 }
 
 /////////////////////////////


### PR DESCRIPTION
# Summary
Makes `arrays.window` return an empty array when its attributes cannot produce a valid window:
- `step == 0` previously caused an infinite loop when `size` fit the input.                                                                                                                                                                                                                                                                                                                         
- `step < 0` previously moved the index backward and caused an out-of-range slice panic.
- `size == 0` previously returned `array.len + 1` empty windows.
- `size < 0` previously caused an invalid-slice panic.
- `size > array.len` previously requested a negative initial capacity.                                                                                                                                                                                               

# Tests
*  ./vnew vlib/arrays/arrays_test.v  

