### PR TITLE
ci: harden update_tccbin rebuild matrix

### DIFF
--- a/.github/workflows/update_tccbin.yml
+++ b/.github/workflows/update_tccbin.yml
@@ -64,7 +64,16 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          git clone --quiet https://repo.or.cz/tinycc.git /tmp/tinycc-ref
+          for attempt in 1 2 3; do
+            if git clone --quiet https://repo.or.cz/tinycc.git /tmp/tinycc-ref; then
+              break
+            fi
+            rm -rf /tmp/tinycc-ref
+            if [ "$attempt" -eq 3 ]; then
+              exit 1
+            fi
+            sleep "$((attempt * 5))"
+          done
           git -C /tmp/tinycc-ref checkout --quiet "$TCC_COMMIT"
           hash="$(git -C /tmp/tinycc-ref rev-parse HEAD)"
           echo "hash=$hash" >> "$GITHUB_OUTPUT"
@@ -112,12 +121,23 @@ jobs:
         shell: bash
         env:
           BUILD_CMD: TCC_COMMIT=${{ env.TCC_COMMIT }} TCC_FOLDER=thirdparty/tcc bash ${{ matrix.script }}
+          TCC_REPO: /tmp/tinycc-ref
         run: |
           set -euo pipefail
           TCC_FOLDER=thirdparty/tcc bash "${{ matrix.script }}"
           test "$(cat thirdparty/tcc/build_source_hash.txt)" = "${{ steps.tinycc.outputs.hash }}"
           thirdparty/tcc/tcc.exe --version
           thirdparty/tcc/tcc.exe -v -v
+          cat > /tmp/tcc-stdatomic-smoke.c <<'EOF'
+          #include <stdatomic.h>
+          int main(void) {
+              atomic_int value = ATOMIC_VAR_INIT(0);
+              atomic_store(&value, 1);
+              return atomic_load(&value) == 1 ? 0 : 1;
+          }
+          EOF
+          thirdparty/tcc/tcc.exe /tmp/tcc-stdatomic-smoke.c -o /tmp/tcc-stdatomic-smoke
+          /tmp/tcc-stdatomic-smoke
 
       - name: Upload TCC bundle artifact
         if: steps.rebuild.outputs.skip != 'true'
@@ -182,7 +202,16 @@ jobs:
           git config --global user.email vlang-bot@users.noreply.github.com
           git config --global --add safe.directory "$PWD"
 
-          git clone --quiet https://repo.or.cz/tinycc.git /tmp/tinycc-ref
+          for attempt in 1 2 3; do
+            if git clone --quiet https://repo.or.cz/tinycc.git /tmp/tinycc-ref; then
+              break
+            fi
+            rm -rf /tmp/tinycc-ref
+            if [ "$attempt" -eq 3 ]; then
+              exit 1
+            fi
+            sleep "$((attempt * 5))"
+          done
           git -C /tmp/tinycc-ref checkout --quiet "$TCC_COMMIT"
           tinycc_hash="$(git -C /tmp/tinycc-ref rev-parse HEAD)"
           echo "TinyCC $TCC_COMMIT resolves to $tinycc_hash"
@@ -206,10 +235,20 @@ jobs:
           fi
 
           BUILD_CMD="TCC_COMMIT=$TCC_COMMIT TCC_FOLDER=thirdparty/tcc CC=${{ matrix.cc }} bash ${{ matrix.script }}" \
-            TCC_FOLDER=thirdparty/tcc CC="${{ matrix.cc }}" bash "${{ matrix.script }}"
+            TCC_REPO=/tmp/tinycc-ref TCC_FOLDER=thirdparty/tcc CC="${{ matrix.cc }}" bash "${{ matrix.script }}"
           test "$(cat thirdparty/tcc/build_source_hash.txt)" = "$tinycc_hash"
           thirdparty/tcc/tcc.exe --version
           thirdparty/tcc/tcc.exe -v -v
+          cat > /tmp/tcc-stdatomic-smoke.c <<'EOF'
+          #include <stdatomic.h>
+          int main(void) {
+              atomic_int value = ATOMIC_VAR_INIT(0);
+              atomic_store(&value, 1);
+              return atomic_load(&value) == 1 ? 0 : 1;
+          }
+          EOF
+          thirdparty/tcc/tcc.exe /tmp/tcc-stdatomic-smoke.c -o /tmp/tcc-stdatomic-smoke
+          /tmp/tcc-stdatomic-smoke
 
           if [ "$PUBLISH" = 'true' ]; then
             git -C thirdparty/tcc push origin HEAD:${{ matrix.branch }}

--- a/thirdparty/build_scripts/thirdparty-freebsd-amd64_tcc.sh
+++ b/thirdparty/build_scripts/thirdparty-freebsd-amd64_tcc.sh
@@ -31,6 +31,7 @@ export CURRENT_SCRIPT_PATH=$(realpath "$0")
 
 export TCC_COMMIT="${TCC_COMMIT:-mob}"
 export TCC_FOLDER="${TCC_FOLDER:-thirdparty/tcc.$TCC_COMMIT}"
+export TCC_REPO="${TCC_REPO:-https://repo.or.cz/tinycc.git}"
 export CC="${CC:-gcc}"
 
 echo " BUILD_CMD: \`$BUILD_CMD\`"
@@ -46,7 +47,7 @@ rsync -a thirdparty/tcc/ thirdparty/tcc.original/
 
 pushd .
 
-git clone https://repo.or.cz/tinycc.git
+git clone "$TCC_REPO" tinycc
 
 cd tinycc
 

--- a/thirdparty/build_scripts/thirdparty-linux-amd64_tcc.sh
+++ b/thirdparty/build_scripts/thirdparty-linux-amd64_tcc.sh
@@ -30,6 +30,7 @@ export CURRENT_SCRIPT_PATH=$(realpath "$0")
 
 export TCC_COMMIT="${TCC_COMMIT:-mob}"
 export TCC_FOLDER="${TCC_FOLDER:-thirdparty/tcc.$TCC_COMMIT}"
+export TCC_REPO="${TCC_REPO:-https://repo.or.cz/tinycc.git}"
 export CC="${CC:-gcc}"
 
 echo " BUILD_CMD: \`$BUILD_CMD\`"
@@ -45,7 +46,7 @@ rsync -a thirdparty/tcc/ thirdparty/tcc.original/
 
 pushd .
 
-git clone https://repo.or.cz/tinycc.git
+git clone "$TCC_REPO" tinycc
 
 cd tinycc
 

--- a/thirdparty/build_scripts/thirdparty-macos-amd64_tcc.sh
+++ b/thirdparty/build_scripts/thirdparty-macos-amd64_tcc.sh
@@ -35,6 +35,7 @@ export CURRENT_SCRIPT_PATH=$(realpath "$0")
 
 export TCC_COMMIT="${TCC_COMMIT:-mob}"
 export TCC_FOLDER="${TCC_FOLDER:-thirdparty/tcc.$TCC_COMMIT}"
+export TCC_REPO="${TCC_REPO:-https://repo.or.cz/tinycc.git}"
 export CC="${CC:-clang}"
 
 echo " BUILD_CMD: \`$BUILD_CMD\`"
@@ -50,7 +51,7 @@ rsync -a thirdparty/tcc/ thirdparty/tcc.original/
 
 pushd .
 
-git clone https://repo.or.cz/tinycc.git
+git clone "$TCC_REPO" tinycc
 
 cd tinycc
 
@@ -88,7 +89,11 @@ popd
 rsync -a --delete tinycc/$TCC_FOLDER/*                $TCC_FOLDER/
 rsync -a          thirdparty/tcc.original/.git/       $TCC_FOLDER/.git/
 rsync -a          thirdparty/tcc.original/lib/libgc*  $TCC_FOLDER/lib/
-rsync -a          thirdparty/tcc.original/lib/build*  $TCC_FOLDER/lib/
+for build_file in thirdparty/tcc.original/lib/build*; do
+  if test -e "$build_file"; then
+    rsync -a "$build_file" "$TCC_FOLDER/lib/"
+  fi
+done
 rsync -a          thirdparty/tcc.original/README.md   $TCC_FOLDER/README.md
 rsync -a          $CURRENT_SCRIPT_PATH                $TCC_FOLDER/build.sh
 mv                $TCC_FOLDER/tcc                     $TCC_FOLDER/tcc.exe

--- a/thirdparty/build_scripts/thirdparty-macos-arm64_tcc.sh
+++ b/thirdparty/build_scripts/thirdparty-macos-arm64_tcc.sh
@@ -35,6 +35,7 @@ export CURRENT_SCRIPT_PATH=$(realpath "$0")
 
 export TCC_COMMIT="${TCC_COMMIT:-mob}"
 export TCC_FOLDER="${TCC_FOLDER:-thirdparty/tcc.$TCC_COMMIT}"
+export TCC_REPO="${TCC_REPO:-https://repo.or.cz/tinycc.git}"
 export CC="${CC:-clang}"
 
 echo " BUILD_CMD: \`$BUILD_CMD\`"
@@ -50,7 +51,7 @@ rsync -a thirdparty/tcc/ thirdparty/tcc.original/
 
 pushd .
 
-git clone https://repo.or.cz/tinycc.git
+git clone "$TCC_REPO" tinycc
 
 cd tinycc
 

--- a/thirdparty/build_scripts/thirdparty-openbsd-amd64_tcc.sh
+++ b/thirdparty/build_scripts/thirdparty-openbsd-amd64_tcc.sh
@@ -31,6 +31,7 @@ export CURRENT_SCRIPT_PATH=$(realpath "$0")
 
 export TCC_COMMIT="${TCC_COMMIT:-mob}"
 export TCC_FOLDER="${TCC_FOLDER:-thirdparty/tcc.$TCC_COMMIT}"
+export TCC_REPO="${TCC_REPO:-https://repo.or.cz/tinycc.git}"
 export CC="${CC:-clang}"
 
 echo " BUILD_CMD: \`$BUILD_CMD\`"
@@ -45,7 +46,7 @@ rsync -a thirdparty/tcc/ thirdparty/tcc.original/
 
 pushd .
 
-git clone https://repo.or.cz/tinycc.git
+git clone "$TCC_REPO" tinycc
 
 cd tinycc
 
@@ -56,7 +57,7 @@ export TCC_COMMIT_FULL_HASH=$(git rev-parse HEAD)
             --prefix=$TCC_FOLDER \
             --bindir=$TCC_FOLDER \
             --crtprefix=$TCC_FOLDER/lib:/usr/lib \
-            --sysincludepaths=$TCC_FOLDER/lib/tcc/include:/usr/local/include:/usr/include \
+            --sysincludepaths="{B}/include:/usr/local/include:/usr/include" \
             --libpaths=$TCC_FOLDER/lib/tcc:$TCC_FOLDER/lib:/usr/lib:/usr/local/lib \
             --cc="$CC" \
             --extra-cflags="$CFLAGS" \


### PR DESCRIPTION
## Summary

- Resolve the requested TinyCC commit with bounded retries and reuse that exact source checkout across every platform builder.
- Fix optional build-directory handling on macOS Intel.
- Use the canonical system include paths required by OpenBSD.
- Add a compile-and-run `stdatomic.h` probe to every target before publishing artifacts.

Related to #27934 

This PR fixes the cross-platform rebuild failures. Publication credentials and `VLANG_BOT_SECRET` validation remain a separate follow-up.

The existing publication and authentication behavior remains unchanged.

## Validation

The complete rebuild matrix passed for all five targets:

- Linux AMD64
- macOS AMD64
- macOS ARM64
- FreeBSD AMD64
- OpenBSD AMD64

Tested TinyCC commit:

`85ba3ae8f1e22044255d54c28be04e5fc3e88ae0`