### PR TITLE
cgen: fix invalid C for type-alias'd fixed array struct-init literals

### DIFF
--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -1177,6 +1177,9 @@ pub fn (t &TypeSymbol) is_empty_struct_array() bool {
 		if elem_sym.info is Struct {
 			return elem_sym.info.is_empty_struct()
 		}
+		if elem_sym.info is ArrayFixed {
+			return elem_sym.is_empty_struct_array()
+		}
 	}
 	return false
 }

--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -554,7 +554,18 @@ fn (mut g Gen) fixed_array_init(node ast.ArrayInit, array_type Type, var_name st
 			g.add_commas_and_prevent_long_lines(i, info.size)
 		}
 	} else if is_amp {
-		g.write('0')
+		is_empty := if elem_sym.info is ast.Struct {
+			elem_sym.info.is_empty_struct()
+		} else {
+			// covers nested fixed arrays of empty structs
+			elem_sym.is_empty_struct_array()
+		}
+		if is_empty {
+			// A fixed array of empty structs has no elements to zero-init in C
+			g.write('E_STRUCT')
+		} else {
+			g.write('0')
+		}
 	} else {
 		if elem_sym.kind == .map {
 			// fixed array for map -- [N]map[key_type]value_type

--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -1444,9 +1444,9 @@ fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 			&& (val in [ast.Ident, ast.IndexExpr, ast.CallExpr, ast.SelectorExpr, ast.ComptimeSelector, ast.DumpExpr, ast.InfixExpr, ast.IfExpr, ast.MatchExpr]
 			|| (val is ast.CastExpr && val.expr !is ast.ArrayInit)
 			|| (val is ast.PrefixExpr && val.op == .arrow)
-			|| (val is ast.UnsafeExpr && val.expr in [ast.SelectorExpr, ast.Ident, ast.CallExpr]))
-			&& !((g.pref.translated || g.file.is_translated)
-			&& unaliased_left_sym.kind != .array_fixed)
+			|| (val is ast.UnsafeExpr && val.expr in [ast.SelectorExpr, ast.Ident, ast.CallExpr])
+			|| (val is ast.StructInit && !is_decl && !blank_assign)) && !((g.pref.translated
+			|| g.file.is_translated) && unaliased_left_sym.kind != .array_fixed)
 		g.is_assign_lhs = true
 		g.assign_op = node.op
 
@@ -1596,6 +1596,16 @@ fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 						right_var := g.new_tmp_var()
 						g.write('${arr_typ} ${right_var} = ')
 						g.expr(right)
+						g.writeln(';')
+						fixed_right_expr = right_var
+					} else if val is ast.StructInit {
+						// e.g. `c = Arr{}`, where `type Arr = [n]Box`
+						// struct_init() emits a bare brace-init list with no cast prefix
+						// for fixed arrays, which is only valid as a declaration initializer,
+						// not as a memcpy() argument expression.
+						right_var := g.new_tmp_var()
+						g.write('${arr_typ} ${right_var} = ')
+						g.expr(val)
 						g.writeln(';')
 						fixed_right_expr = right_var
 					} else {

--- a/vlib/v/gen/c/struct.v
+++ b/vlib/v/gen/c/struct.v
@@ -524,7 +524,10 @@ fn (mut g Gen) struct_init(node ast.StructInit) {
 	}
 
 	if !initialized && !is_generic_default {
-		if nr_fields > 0 {
+		if sym.kind == .array_fixed && sym.is_empty_struct_array() {
+			// A fixed array of empty structs has no elements to zero-init in C
+			g.write('E_STRUCT')
+		} else if nr_fields > 0 {
 			g.write('0')
 		} else {
 			g.write('E_STRUCT')

--- a/vlib/v/tests/project_issue_27894_test.v
+++ b/vlib/v/tests/project_issue_27894_test.v
@@ -1,0 +1,48 @@
+type EmptyBoxArr = [4]EmptyBox
+type NestedEmptyBoxArr = [4][2]EmptyBox
+
+struct EmptyBox {}
+
+fn test_alias_fixed_array_of_empty_structs() {
+	_ := EmptyBoxArr{}
+	a := EmptyBoxArr{}
+	assert a.len == 4
+
+	b := &EmptyBoxArr{}
+	assert b.len == 4
+}
+
+fn test_alias_nested_fixed_array_of_empty_structs() {
+	_ := NestedEmptyBoxArr{}
+	a := NestedEmptyBoxArr{}
+	assert a.len == 4
+	assert a[0].len == 2
+
+	b := &NestedEmptyBoxArr{}
+	assert b.len == 4
+}
+
+fn test_blank_plain_assign_nested_fixed_array_of_empty_structs() {
+	// Regression for `_ = Arr{}` (blank plain-assign, not `_ := Arr{}`), which
+	// exercises a different codegen path (expr_with_var) than blank decl-assign.
+	_ = NestedEmptyBoxArr{}
+}
+
+type NonEmptyBoxArr = [4]NonEmptyBox
+
+struct NonEmptyBox {
+	n int
+}
+
+fn test_reassign_alias_fixed_array() {
+	// Reassigning (not declaring) a fixed-array type alias via its struct-init
+	// literal syntax used to generate invalid C, regardless of whether the
+	// element type was an empty struct.
+	mut c := EmptyBoxArr{}
+	c = EmptyBoxArr{}
+	assert c.len == 4
+
+	mut d := NonEmptyBoxArr{}
+	d = NonEmptyBoxArr{}
+	assert d.len == 4
+}


### PR DESCRIPTION
Fixes #27894

## Problem

Struct-init literal syntax (`Arr{}`) on a type alias for a fixed array (`type Arr = [N]T`) generates invalid C in two situations:

1. When `T` is an empty struct, declaring, taking the address of, or discarding such a value emits `{0}` as initializer. This is invalid on gcc/clang, since the underlying C array has zero size. Also applies recursively to nested arrays (`[2][3]Box`).
2. Reassigning (not declaring) such an alias, e.g. `c = Arr{}` after `mut c := Arr{}`, emits a bare brace-init list outside of a declaration context (`c = {0};`), which is invalid regardless of element type.

## Cause

1. `struct_init()` (`struct.v`) and `fixed_array_init()` (`array.v`) each fall back to writing a literal `0` to zero-init an aggregate, without checking if the element type is itself an empty struct. The `E_STRUCT` macro already exists for this (expands to nothing on gcc/clang, `0` + padding field on msvc/tcc) and is already used by `type_default_impl()`, but not by these two call sites. `is_empty_struct_array()` also only checked one level deep.
2. `Arr{}` parses as `ast.StructInit`, not `ast.ArrayInit`, even though its type is a fixed array. `assign_stmt()` (`assign.v`) only routes `ast.ArrayInit` or specific lvalue-like expressions through the memcpy-based fixed-array assignment path; a `StructInit` here fell through to the generic `left = <expr>;` codegen.

## Fix

1. `struct_init()` and `fixed_array_init()` now check `sym.is_empty_struct_array()` (made recursive to cover nested arrays) and emit `E_STRUCT` instead of `0` when the element type is an empty struct.
2. `assign_stmt()` now also routes a `StructInit` fixed-array alias through the memcpy path on reassignment, materializing it into a temp var first (like the existing `ArrayInit` case). Declarations and blank assignments (`_ = Arr{}`, handled correctly by a separate path) are excluded.

## Test

Tests added.