### PR TITLE
checker: detect assigning a reference to a non-pointer struct field

### DIFF
--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -1231,6 +1231,15 @@ or use an explicit `unsafe{ a[..] }`, if you do not want a copy of the slice.',
 						exp_typ_str := c.table.type_to_str(exp_type)
 						c.error('cannot assign to field `${field_info.name}`: expected a pointer `${exp_typ_str}`, but got `${got_typ_str}`',
 							init_field.pos)
+					} else if !c.inside_unsafe && type_sym.language == .v && !(c.file.is_translated
+						|| c.pref.translated) && !exp_type.is_any_kind_of_pointer()
+						&& got_type.is_any_kind_of_pointer() && !exp_type_is_option
+						&& exp_final_sym.kind !in [.interface, .array, .function, .map]
+						&& init_field.expr.is_reference() {
+						got_typ_str := c.table.type_to_str(got_type)
+						exp_typ_str := c.table.type_to_str(exp_type)
+						c.error('cannot assign to field `${field_info.name}`: expected `${exp_typ_str}`, but got `${got_typ_str}`',
+							init_field.pos.extend(node.pos))
 					}
 				}
 				node.init_fields[i].typ = got_type

--- a/vlib/v/checker/tests/struct_init_non_ptr_field_assign_ref_err.out
+++ b/vlib/v/checker/tests/struct_init_non_ptr_field_assign_ref_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/struct_init_non_ptr_field_assign_ref_err.vv:14:3: error: cannot assign to field `arr`: expected `Arr`, but got `&Arr`
+   12 |     o := Original{}
+   13 |     _ := Copy{
+   14 |         arr: &o.arr
+      |         ~~~~~~~~~~~
+   15 |     }
+   16 | }

--- a/vlib/v/checker/tests/struct_init_non_ptr_field_assign_ref_err.vv
+++ b/vlib/v/checker/tests/struct_init_non_ptr_field_assign_ref_err.vv
@@ -1,0 +1,16 @@
+type Arr = [8]u8
+
+struct Original {
+	arr Arr
+}
+
+struct Copy {
+	arr Arr
+}
+
+fn main() {
+	o := Original{}
+	_ := Copy{
+		arr: &o.arr
+	}
+}


### PR DESCRIPTION
Fixes #27957

## Problem
Assigning a reference (`&x`) to a struct field whose declared type is not a pointer is silently accepted by the checker, instead of being rejected as a type mismatch.

## Cause
Struct init field values are checked via `check_expected()` / `check_types()`, which short-circuits on `expected.idx() == got.idx()`. Since `Type.idx()` only encodes the base type symbol and ignores the pointer/reference flags (`nr_muls`), `Arr` and `&Arr` are treated as equal and the mismatch is never caught. The existing pointer-mismatch handling in `struct_init` (`vlib/v/checker/struct.v`) only covers the opposite direction (expected type is a pointer but the value isn't); there was no branch for a non-pointer field receiving a reference, unlike the equivalent check already present in `check_expected_call_arg` for function call arguments.

## Fix
Added the missing branch in `struct_init` that reports an error when a non-pointer field is initialized with a `&expr` reference, mirroring the existing call-argument check. Interface, array, function, map, and option fields are excluded (legitimate patterns), as are `unsafe` blocks, C-language struct types, and translated (c2v) files, consistent with the guards used by the neighboring pointer-mismatch checks in the same function.

## Test
Test added.