### PR TITLE
checker, cgen: fix fixed array struct initialization

### DIFF
--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -1157,7 +1157,7 @@ or use an explicit `unsafe{ a[..] }`, if you do not want a copy of the slice.',
 						}
 					}
 				} else if c.table.final_sym(exp_type).kind == .array_fixed && got_type.is_ptr()
-					&& !exp_type.is_any_kind_of_pointer() {
+					&& !exp_type.is_any_kind_of_pointer() && !init_field.expr.is_auto_deref_var() {
 					c.error('cannot assign to field `${field_info.name}`: ${c.expected_msg(got_type,
 						exp_type)}', init_field.pos)
 				} else if got_type != ast.void_type && got_type_sym.kind != .placeholder

--- a/vlib/v/checker/struct.v
+++ b/vlib/v/checker/struct.v
@@ -1156,6 +1156,10 @@ or use an explicit `unsafe{ a[..] }`, if you do not want a copy of the slice.',
 							c.mark_as_referenced(mut &init_field.expr, true)
 						}
 					}
+				} else if c.table.final_sym(exp_type).kind == .array_fixed && got_type.is_ptr()
+					&& !exp_type.is_any_kind_of_pointer() {
+					c.error('cannot assign to field `${field_info.name}`: ${c.expected_msg(got_type,
+						exp_type)}', init_field.pos)
 				} else if got_type != ast.void_type && got_type_sym.kind != .placeholder
 					&& !exp_type.has_flag(.generic) {
 					mut needs_sum_type_cast := false

--- a/vlib/v/checker/tests/struct_field_init_ref_to_fixed_array_alias_err.out
+++ b/vlib/v/checker/tests/struct_field_init_ref_to_fixed_array_alias_err.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/struct_field_init_ref_to_fixed_array_alias_err.vv:14:3: error: cannot assign to field `arr`: expected `Arr`, not `&Arr`
+   12 |     original := Original{}
+   13 |     _ := Copy{
+   14 |         arr: &original.arr
+      |         ~~~~~~
+   15 |     }
+   16 | }

--- a/vlib/v/checker/tests/struct_field_init_ref_to_fixed_array_alias_err.vv
+++ b/vlib/v/checker/tests/struct_field_init_ref_to_fixed_array_alias_err.vv
@@ -1,0 +1,16 @@
+type Arr = [8]u8
+
+struct Original {
+	arr Arr
+}
+
+struct Copy {
+	arr Arr
+}
+
+fn main() {
+	original := Original{}
+	_ := Copy{
+		arr: &original.arr
+	}
+}

--- a/vlib/v/gen/c/struct.v
+++ b/vlib/v/gen/c/struct.v
@@ -524,7 +524,7 @@ fn (mut g Gen) struct_init(node ast.StructInit) {
 	}
 
 	if !initialized && !is_generic_default {
-		if nr_fields > 0 {
+		if nr_fields > 0 && !sym.is_empty_struct_array() {
 			g.write('0')
 		} else {
 			g.write('E_STRUCT')

--- a/vlib/v/tests/aliases/alias_fixed_array_of_struct_test.v
+++ b/vlib/v/tests/aliases/alias_fixed_array_of_struct_test.v
@@ -40,6 +40,11 @@ fn test_fixed_array_alias_of_empty_struct() {
 	assert nested[0].len == 2
 }
 
+fn test_direct_fixed_array_alias_of_empty_struct_init() {
+	fixed := EmptyFixed{}
+	assert fixed.len == 2
+}
+
 fn test_nested_fixed_array_alias_in_struct_init() {
 	v_box := Box{}
 	assert v_box.len == 2

--- a/vlib/v3/tests/fixed_array_local_zero_init_codegen_test.v
+++ b/vlib/v3/tests/fixed_array_local_zero_init_codegen_test.v
@@ -22,6 +22,10 @@ fn test_local_fixed_array_zero_init_declarations_use_direct_c_arrays() {
 
 type Handle = voidptr
 
+struct Empty {}
+
+type EmptyFixed = [2]Empty
+
 fn local_score() int {
 	mut direct := [4]int{}
 	direct[0] = 1
@@ -31,8 +35,9 @@ fn local_score() int {
 	handles[0] = voidptr(0)
 	mut nested := unsafe { [2][3]int{} }
 	nested[1][2] = 3
+	empty := EmptyFixed{}
 	handle_score := if handles[0] == voidptr(0) { 4 } else { 0 }
-	return direct[0] + wrapped[1] + nested[1][2] + handle_score
+	return direct[0] + wrapped[1] + nested[1][2] + empty.len + handle_score
 }
 
 fn main() {
@@ -46,7 +51,7 @@ fn main() {
 	assert compile.exit_code == 0, compile.output
 	run := os.execute(bin)
 	assert run.exit_code == 0, run.output
-	assert run.output.trim_space() == '10'
+	assert run.output.trim_space() == '12'
 	generated := os.read_file(bin + '.c') or { panic(err) }
 	compact := generated.replace('\t', '').replace(' ', '').replace('\n', '')
 	assert compact.contains('intdirect[4]={0};')
@@ -60,4 +65,33 @@ fn main() {
 		|| compact.contains('intnested[2][3]={{0,0,0},{0,0,0}};'), generated
 	assert !generated.contains(' = (Array_fixed_'), generated
 	assert !generated.contains('Array_fixed_voidptr_32 handles'), generated
+}
+
+fn test_struct_field_rejects_pointer_to_fixed_array_alias() {
+	v3_bin := local_fixed_array_build_v3()
+	src := os.join_path(os.temp_dir(), 'v3_fixed_array_struct_field_${os.getpid()}.v')
+	os.write_file(src, 'module main
+
+type Arr = [2]int
+
+struct Foo {
+	arr Arr
+}
+
+fn main() {
+	a := Arr{}
+	foo := Foo{
+		arr: &a
+	}
+	println(foo.arr.len)
+}
+') or {
+		panic(err)
+	}
+	bin := os.join_path(os.temp_dir(), 'v3_fixed_array_struct_field_${os.getpid()}')
+	compile := os.execute('${v3_bin} -nocache ${src} -b c -o ${bin}')
+	assert compile.exit_code != 0, compile.output
+	assert compile.output.contains('cannot initialize field `arr` with `&Arr`; expected `Arr`'), compile.output
+
+	assert !compile.output.contains('C compilation failed'), compile.output
 }

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -22460,9 +22460,13 @@ fn (mut tc TypeChecker) check_struct_init(id flat.NodeId, node flat.Node) {
 						actual = semantic_mut_param
 					}
 				}
-				if !tc.expr_compatible(value_id, actual, expected)
+				pointer_to_value_fixed_array := actual is Pointer
+					&& unalias_type(actual.base_type) is ArrayFixed
+					&& unalias_type(expected) is ArrayFixed
+				if pointer_to_value_fixed_array
+					|| (!tc.expr_compatible(value_id, actual, expected)
 					&& !tc.method_value_matches_voidptr_callback(value_id, actual, expected)
-					&& !tc.pointer_value_compatible(actual, expected) {
+					&& !tc.pointer_value_compatible(actual, expected)) {
 					tc.type_mismatch(.assignment_mismatch,
 						'cannot initialize field `${field.value}` with `${actual.name()}`; expected `${expected.name()}`',
 						field_id)


### PR DESCRIPTION
## Summary

- use the empty-struct initializer sentinel for direct fixed-array aliases of empty structs
- reject references assigned to non-pointer fixed-array struct fields before C generation
- mirror the checker fix in v3 and cover both fixed-array cases there
- add regression coverage for both cases

Fixes #27894
Fixes #27957

## Tests

- `./vnew vlib/v/tests/aliases/alias_fixed_array_of_struct_test.v`
- `./vnew -cc tcc vlib/v/tests/aliases/alias_fixed_array_of_struct_test.v`
- `./vnew -silent vlib/v/compiler_errors_test.v`
- `./vnew -silent test vlib/v/checker/`
- `./vnew -silent vlib/v/slow_tests/inout/compiler_test.v`
- `./vnew -silent vlib/v/gen/c/coutput_test.v`
- `./vnew -silent vlib/v3/tests/fixed_array_local_zero_init_codegen_test.v`

The full `vlib/v/` suite was skipped as requested.