### PR TITLE
checker, cgen: fix three interface regressions

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -278,7 +278,8 @@ fn fn_type_calling_convention(f &Fn) string {
 }
 
 fn (t &Table) fn_types_are_compatible(left &Fn, right &Fn, depth int) bool {
-	if t.fn_type_source_signature(left) != t.fn_type_source_signature(right)
+	if left.params.len != right.params.len || left.is_variadic != right.is_variadic
+		|| left.is_c_variadic != right.is_c_variadic
 		|| fn_type_calling_convention(left) != fn_type_calling_convention(right) {
 		return false
 	}
@@ -286,7 +287,10 @@ fn (t &Table) fn_types_are_compatible(left &Fn, right &Fn, depth int) bool {
 		return false
 	}
 	for i, param in left.params {
-		if !t.fn_type_components_are_compatible(param.typ, right.params[i].typ, depth + 1) {
+		right_param := right.params[i]
+		if param.is_mut != right_param.is_mut || param.is_shared != right_param.is_shared
+			|| param.is_atomic != right_param.is_atomic
+			|| !t.fn_type_components_are_compatible(param.typ, right_param.typ, depth + 1) {
 			return false
 		}
 	}
@@ -382,16 +386,26 @@ fn (t &Table) fn_type_components_are_compatible(left_type Type, right_type Type,
 				return false
 			}
 		}
+		return true
 	}
-	if left_sym.generic_types.len != right_sym.generic_types.len {
-		return false
-	}
-	for i, typ in left_sym.generic_types {
-		if !t.fn_type_components_are_compatible(typ, right_sym.generic_types[i], depth + 1) {
+	if left_sym.info is GenericInst {
+		if right_sym.info !is GenericInst {
 			return false
 		}
+		left_info := left_sym.info as GenericInst
+		right_info := right_sym.info as GenericInst
+		if left_info.parent_idx != right_info.parent_idx
+			|| left_info.concrete_types.len != right_info.concrete_types.len {
+			return false
+		}
+		for i, typ in left_info.concrete_types {
+			if !t.fn_type_components_are_compatible(typ, right_info.concrete_types[i], depth + 1) {
+				return false
+			}
+		}
+		return true
 	}
-	return true
+	return false
 }
 
 pub fn (t &Table) is_same_method(f &Fn, func &Fn) string {

--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -303,6 +303,9 @@ fn (t &Table) fn_type_components_are_compatible(left_type Type, right_type Type,
 	}
 	left := t.fully_unaliased_type(left_type)
 	right := t.fully_unaliased_type(right_type)
+	if left.has_option_or_result() || right.has_option_or_result() {
+		return false
+	}
 	if left == right {
 		return true
 	}

--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -274,7 +274,7 @@ fn fn_type_calling_convention(f &Fn) string {
 			return attr.arg
 		}
 	}
-	return ''
+	return 'cdecl'
 }
 
 pub fn (t &Table) is_same_method(f &Fn, func &Fn) string {

--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -269,7 +269,20 @@ pub fn (t &Table) fn_type_source_signature(f &Fn) string {
 }
 
 pub fn (t &Table) is_same_method(f &Fn, func &Fn) string {
-	if f.return_type != func.return_type {
+	f_return_type := t.fully_unaliased_type(f.return_type)
+	func_return_type := t.fully_unaliased_type(func.return_type)
+	f_return_sym := t.sym(f_return_type)
+	func_return_sym := t.sym(func_return_type)
+	mut same_return_type := f_return_type == func_return_type
+	if !same_return_type && f_return_type.nr_muls() == func_return_type.nr_muls()
+		&& f_return_type.has_flag(.option) == func_return_type.has_flag(.option)
+		&& f_return_type.has_flag(.result) == func_return_type.has_flag(.result)
+		&& f_return_sym.info is FnType {
+		if func_return_sym.info is FnType {
+			same_return_type = t.fn_type_source_signature(f_return_sym.info.func) == t.fn_type_source_signature(func_return_sym.info.func)
+		}
+	}
+	if !same_return_type {
 		s := t.type_to_str(f.return_type)
 		return 'expected return type `${s}`'
 	}

--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -409,18 +409,18 @@ fn (t &Table) fn_type_components_are_compatible(left_type Type, right_type Type,
 }
 
 pub fn (t &Table) is_same_method(f &Fn, func &Fn) string {
-	f_return_type := t.fully_unaliased_type(f.return_type)
-	func_return_type := t.fully_unaliased_type(func.return_type)
-	f_return_sym := t.sym(f_return_type)
-	func_return_sym := t.sym(func_return_type)
-	mut same_return_type := f_return_type == func_return_type
-	if !same_return_type && f_return_type.nr_muls() == func_return_type.nr_muls()
-		&& f_return_type.has_flag(.option) == func_return_type.has_flag(.option)
-		&& f_return_type.has_flag(.result) == func_return_type.has_flag(.result)
-		&& f_return_sym.info is FnType {
-		if func_return_sym.info is FnType {
-			same_return_type = t.fn_types_are_compatible(f_return_sym.info.func,
-				func_return_sym.info.func, 0)
+	mut same_return_type := f.return_type == func.return_type
+	if !same_return_type {
+		f_return_type := t.fully_unaliased_type(f.return_type)
+		func_return_type := t.fully_unaliased_type(func.return_type)
+		if !f_return_type.has_option_or_result() && !func_return_type.has_option_or_result()
+			&& f_return_type.nr_muls() == func_return_type.nr_muls() {
+			f_return_sym := t.sym(f_return_type)
+			func_return_sym := t.sym(func_return_type)
+			if f_return_sym.info is FnType && func_return_sym.info is FnType {
+				same_return_type = t.fn_types_are_compatible(f_return_sym.info.func,
+					func_return_sym.info.func, 0)
+			}
 		}
 	}
 	if !same_return_type {

--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -268,6 +268,15 @@ pub fn (t &Table) fn_type_source_signature(f &Fn) string {
 	return sig
 }
 
+fn fn_type_calling_convention(f &Fn) string {
+	for attr in f.attrs {
+		if attr.name == 'callconv' {
+			return attr.arg
+		}
+	}
+	return ''
+}
+
 pub fn (t &Table) is_same_method(f &Fn, func &Fn) string {
 	f_return_type := t.fully_unaliased_type(f.return_type)
 	func_return_type := t.fully_unaliased_type(func.return_type)
@@ -279,7 +288,9 @@ pub fn (t &Table) is_same_method(f &Fn, func &Fn) string {
 		&& f_return_type.has_flag(.result) == func_return_type.has_flag(.result)
 		&& f_return_sym.info is FnType {
 		if func_return_sym.info is FnType {
-			same_return_type = t.fn_type_source_signature(f_return_sym.info.func) == t.fn_type_source_signature(func_return_sym.info.func)
+			same_return_type =
+				t.fn_type_source_signature(f_return_sym.info.func) == t.fn_type_source_signature(func_return_sym.info.func)
+				&& fn_type_calling_convention(f_return_sym.info.func) == fn_type_calling_convention(func_return_sym.info.func)
 		}
 	}
 	if !same_return_type {

--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -277,6 +277,123 @@ fn fn_type_calling_convention(f &Fn) string {
 	return 'cdecl'
 }
 
+fn (t &Table) fn_types_are_compatible(left &Fn, right &Fn, depth int) bool {
+	if t.fn_type_source_signature(left) != t.fn_type_source_signature(right)
+		|| fn_type_calling_convention(left) != fn_type_calling_convention(right) {
+		return false
+	}
+	if depth >= max_alias_chain_depth {
+		return false
+	}
+	for i, param in left.params {
+		if !t.fn_type_components_are_compatible(param.typ, right.params[i].typ, depth + 1) {
+			return false
+		}
+	}
+	return t.fn_type_components_are_compatible(left.return_type, right.return_type, depth + 1)
+}
+
+fn (t &Table) fn_type_components_are_compatible(left_type Type, right_type Type, depth int) bool {
+	if left_type == right_type {
+		return true
+	}
+	left := t.fully_unaliased_type(left_type)
+	right := t.fully_unaliased_type(right_type)
+	if left == right {
+		return true
+	}
+	if depth >= max_alias_chain_depth {
+		return false
+	}
+	if left.flags() != right.flags() {
+		return false
+	}
+	left_sym := t.sym(left)
+	right_sym := t.sym(right)
+	if left_sym.kind != right_sym.kind {
+		return false
+	}
+	if left_sym.info is FnType {
+		if right_sym.info !is FnType {
+			return false
+		}
+		left_info := left_sym.info as FnType
+		right_info := right_sym.info as FnType
+		return t.fn_types_are_compatible(left_info.func, right_info.func, depth)
+	}
+	if left_sym.info is Array {
+		if right_sym.info !is Array {
+			return false
+		}
+		left_info := left_sym.info as Array
+		right_info := right_sym.info as Array
+		return left_info.nr_dims == right_info.nr_dims
+			&& t.fn_type_components_are_compatible(left_info.elem_type, right_info.elem_type, depth + 1)
+	}
+	if left_sym.info is ArrayFixed {
+		if right_sym.info !is ArrayFixed {
+			return false
+		}
+		left_info := left_sym.info as ArrayFixed
+		right_info := right_sym.info as ArrayFixed
+		return left_info.size == right_info.size
+			&& t.fn_type_components_are_compatible(left_info.elem_type, right_info.elem_type, depth + 1)
+	}
+	if left_sym.info is Map {
+		if right_sym.info !is Map {
+			return false
+		}
+		left_info := left_sym.info as Map
+		right_info := right_sym.info as Map
+		return
+			t.fn_type_components_are_compatible(left_info.key_type, right_info.key_type, depth + 1)
+			&& t.fn_type_components_are_compatible(left_info.value_type, right_info.value_type, depth + 1)
+	}
+	if left_sym.info is Chan {
+		if right_sym.info !is Chan {
+			return false
+		}
+		left_info := left_sym.info as Chan
+		right_info := right_sym.info as Chan
+		return left_info.is_mut == right_info.is_mut
+			&& t.fn_type_components_are_compatible(left_info.elem_type, right_info.elem_type, depth + 1)
+	}
+	if left_sym.info is Thread {
+		if right_sym.info !is Thread {
+			return false
+		}
+		left_info := left_sym.info as Thread
+		right_info := right_sym.info as Thread
+		return_type_matches := t.fn_type_components_are_compatible(left_info.return_type,
+			right_info.return_type, depth + 1)
+		return return_type_matches
+	}
+	if left_sym.info is MultiReturn {
+		if right_sym.info !is MultiReturn {
+			return false
+		}
+		left_info := left_sym.info as MultiReturn
+		right_info := right_sym.info as MultiReturn
+		if left_info.types.len != right_info.types.len {
+			return false
+		}
+		for i, typ in left_info.types {
+			if !t.fn_type_components_are_compatible(typ, right_info.types[i], depth + 1) {
+				return false
+			}
+		}
+	}
+	if left_sym.generic_types.len != right_sym.generic_types.len {
+		return false
+	}
+	for i, typ in left_sym.generic_types {
+		if !t.fn_type_components_are_compatible(typ, right_sym.generic_types[i], depth + 1) {
+			return false
+		}
+	}
+	return true
+}
+
 pub fn (t &Table) is_same_method(f &Fn, func &Fn) string {
 	f_return_type := t.fully_unaliased_type(f.return_type)
 	func_return_type := t.fully_unaliased_type(func.return_type)
@@ -288,9 +405,8 @@ pub fn (t &Table) is_same_method(f &Fn, func &Fn) string {
 		&& f_return_type.has_flag(.result) == func_return_type.has_flag(.result)
 		&& f_return_sym.info is FnType {
 		if func_return_sym.info is FnType {
-			same_return_type =
-				t.fn_type_source_signature(f_return_sym.info.func) == t.fn_type_source_signature(func_return_sym.info.func)
-				&& fn_type_calling_convention(f_return_sym.info.func) == fn_type_calling_convention(func_return_sym.info.func)
+			same_return_type = t.fn_types_are_compatible(f_return_sym.info.func,
+				func_return_sym.info.func, 0)
 		}
 	}
 	if !same_return_type {

--- a/vlib/v/checker/containers.v
+++ b/vlib/v/checker/containers.v
@@ -1169,6 +1169,9 @@ fn (mut c Checker) check_append(mut node ast.InfixExpr, left_type ast.Type, righ
 		}
 	}
 	if left_value_sym.kind == .interface {
+		is_empty_interface := left_value_sym.info is ast.Interface
+			&& left_value_sym.info.methods.len == 0 && left_value_sym.info.fields.len == 0
+			&& left_value_sym.info.embeds.len == 0
 		if right is ast.ArrayInit && right.is_fixed {
 			c.error('cannot append `${right_sym.name}` to `${left_sym.name}`', right_pos)
 			return ast.void_type
@@ -1177,7 +1180,7 @@ fn (mut c Checker) check_append(mut node ast.InfixExpr, left_type ast.Type, righ
 			left_value_type)
 		if right_is_interface_value {
 			if !right_type.is_any_kind_of_pointer() && !c.inside_unsafe
-				&& right_sym.kind != .interface {
+				&& right_sym.kind != .interface && !is_empty_interface {
 				c.mark_as_referenced(mut &node.right, true)
 			}
 		} else if right_final_sym.kind == .array {
@@ -1187,7 +1190,7 @@ fn (mut c Checker) check_append(mut node ast.InfixExpr, left_type ast.Type, righ
 			// []Animal << Cat
 			if c.type_implements(right_type, left_value_type, right_pos) {
 				if !right_type.is_any_kind_of_pointer() && !c.inside_unsafe
-					&& right_sym.kind != .interface {
+					&& right_sym.kind != .interface && !is_empty_interface {
 					c.mark_as_referenced(mut &node.right, true)
 				}
 			}

--- a/vlib/v/checker/containers.v
+++ b/vlib/v/checker/containers.v
@@ -1171,7 +1171,6 @@ fn (mut c Checker) check_append(mut node ast.InfixExpr, left_type ast.Type, righ
 	if left_value_sym.kind == .interface {
 		is_empty_interface := left_value_sym.info is ast.Interface
 			&& left_value_sym.info.methods.len == 0 && left_value_sym.info.fields.len == 0
-			&& left_value_sym.info.embeds.len == 0
 		if right is ast.ArrayInit && right.is_fixed {
 			c.error('cannot append `${right_sym.name}` to `${left_sym.name}`', right_pos)
 			return ast.void_type

--- a/vlib/v/checker/tests/interface_method_fn_type_alias_callconv_mismatch_err.out
+++ b/vlib/v/checker/tests/interface_method_fn_type_alias_callconv_mismatch_err.out
@@ -1,0 +1,14 @@
+vlib/v/checker/tests/interface_method_fn_type_alias_callconv_mismatch_err.vv:20:7: error: `CdeclProvider` incorrectly implements method `callback` of interface `CallbackProvider`: expected return type `fn (int) int`
+   18 |
+   19 | fn main() {
+   20 |     _ := CallbackProvider(CdeclProvider{})
+      |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   21 | }
+Details: main.CallbackProvider has `fn callback(x main.CallbackProvider) fn (int) int`
+         main.CdeclProvider has `fn callback(_ main.CdeclProvider) fn (int) int`
+vlib/v/checker/tests/interface_method_fn_type_alias_callconv_mismatch_err.vv:20:7: error: `CdeclProvider` does not implement interface `CallbackProvider`, cannot cast `CdeclProvider` to interface `CallbackProvider`
+   18 |
+   19 | fn main() {
+   20 |     _ := CallbackProvider(CdeclProvider{})
+      |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   21 | }

--- a/vlib/v/checker/tests/interface_method_fn_type_alias_callconv_mismatch_err.vv
+++ b/vlib/v/checker/tests/interface_method_fn_type_alias_callconv_mismatch_err.vv
@@ -1,0 +1,21 @@
+@[callconv: stdcall]
+type StdcallCallback = fn (int) int
+
+@[callconv: cdecl]
+type CdeclCallback = fn (int) int
+
+interface CallbackProvider {
+	callback() StdcallCallback
+}
+
+struct CdeclProvider {}
+
+fn (_ CdeclProvider) callback() CdeclCallback {
+	return fn (value int) int {
+		return value
+	}
+}
+
+fn main() {
+	_ := CallbackProvider(CdeclProvider{})
+}

--- a/vlib/v/checker/tests/interface_method_fn_type_nested_option_result_alias_mismatch_err.out
+++ b/vlib/v/checker/tests/interface_method_fn_type_nested_option_result_alias_mismatch_err.out
@@ -1,0 +1,30 @@
+vlib/v/checker/tests/interface_method_fn_type_nested_option_result_alias_mismatch_err.vv:36:7: error: `OptionalIntCallbackProvider` incorrectly implements method `callback` of interface `OptionalCallbackProvider`: expected return type `fn () ?MyInt`
+   34 |
+   35 | fn main() {
+   36 |     _ := OptionalCallbackProvider(OptionalIntCallbackProvider{})
+      |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   37 |     _ := ResultCallbackProvider(ResultIntCallbackProvider{})
+   38 | }
+Details: main.OptionalCallbackProvider has `fn callback(x main.OptionalCallbackProvider) fn () ?main.MyInt`
+         main.OptionalIntCallbackProvider has `fn callback(_ main.OptionalIntCallbackProvider) fn () ?int`
+vlib/v/checker/tests/interface_method_fn_type_nested_option_result_alias_mismatch_err.vv:36:7: error: `OptionalIntCallbackProvider` does not implement interface `OptionalCallbackProvider`, cannot cast `OptionalIntCallbackProvider` to interface `OptionalCallbackProvider`
+   34 |
+   35 | fn main() {
+   36 |     _ := OptionalCallbackProvider(OptionalIntCallbackProvider{})
+      |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   37 |     _ := ResultCallbackProvider(ResultIntCallbackProvider{})
+   38 | }
+vlib/v/checker/tests/interface_method_fn_type_nested_option_result_alias_mismatch_err.vv:37:7: error: `ResultIntCallbackProvider` incorrectly implements method `callback` of interface `ResultCallbackProvider`: expected return type `fn () !MyInt`
+   35 | fn main() {
+   36 |     _ := OptionalCallbackProvider(OptionalIntCallbackProvider{})
+   37 |     _ := ResultCallbackProvider(ResultIntCallbackProvider{})
+      |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   38 | }
+Details: main.ResultCallbackProvider has `fn callback(x main.ResultCallbackProvider) fn () !main.MyInt`
+         main.ResultIntCallbackProvider has `fn callback(_ main.ResultIntCallbackProvider) fn () !int`
+vlib/v/checker/tests/interface_method_fn_type_nested_option_result_alias_mismatch_err.vv:37:7: error: `ResultIntCallbackProvider` does not implement interface `ResultCallbackProvider`, cannot cast `ResultIntCallbackProvider` to interface `ResultCallbackProvider`
+   35 | fn main() {
+   36 |     _ := OptionalCallbackProvider(OptionalIntCallbackProvider{})
+   37 |     _ := ResultCallbackProvider(ResultIntCallbackProvider{})
+      |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   38 | }

--- a/vlib/v/checker/tests/interface_method_fn_type_nested_option_result_alias_mismatch_err.vv
+++ b/vlib/v/checker/tests/interface_method_fn_type_nested_option_result_alias_mismatch_err.vv
@@ -1,0 +1,38 @@
+type MyInt = int
+
+type OptionalAliasCallback = fn () ?MyInt
+
+type OptionalIntCallback = fn () ?int
+
+interface OptionalCallbackProvider {
+	callback() OptionalAliasCallback
+}
+
+struct OptionalIntCallbackProvider {}
+
+fn (_ OptionalIntCallbackProvider) callback() OptionalIntCallback {
+	return fn () ?int {
+		return 1
+	}
+}
+
+type ResultAliasCallback = fn () !MyInt
+
+type ResultIntCallback = fn () !int
+
+interface ResultCallbackProvider {
+	callback() ResultAliasCallback
+}
+
+struct ResultIntCallbackProvider {}
+
+fn (_ ResultIntCallbackProvider) callback() ResultIntCallback {
+	return fn () !int {
+		return 2
+	}
+}
+
+fn main() {
+	_ := OptionalCallbackProvider(OptionalIntCallbackProvider{})
+	_ := ResultCallbackProvider(ResultIntCallbackProvider{})
+}

--- a/vlib/v/checker/tests/interface_method_nested_fn_type_alias_callconv_mismatch_err.out
+++ b/vlib/v/checker/tests/interface_method_nested_fn_type_alias_callconv_mismatch_err.out
@@ -1,0 +1,14 @@
+vlib/v/checker/tests/interface_method_nested_fn_type_alias_callconv_mismatch_err.vv:28:7: error: `CdeclFactoryProvider` incorrectly implements method `factory` of interface `FactoryProvider`: expected return type `fn () fn (int) int`
+   26 |
+   27 | fn main() {
+   28 |     _ := FactoryProvider(CdeclFactoryProvider{})
+      |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   29 | }
+Details: main.FactoryProvider has `fn factory(x main.FactoryProvider) fn () fn (int) int`
+         main.CdeclFactoryProvider has `fn factory(_ main.CdeclFactoryProvider) fn () fn (int) int`
+vlib/v/checker/tests/interface_method_nested_fn_type_alias_callconv_mismatch_err.vv:28:7: error: `CdeclFactoryProvider` does not implement interface `FactoryProvider`, cannot cast `CdeclFactoryProvider` to interface `FactoryProvider`
+   26 |
+   27 | fn main() {
+   28 |     _ := FactoryProvider(CdeclFactoryProvider{})
+      |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   29 | }

--- a/vlib/v/checker/tests/interface_method_nested_fn_type_alias_callconv_mismatch_err.vv
+++ b/vlib/v/checker/tests/interface_method_nested_fn_type_alias_callconv_mismatch_err.vv
@@ -1,0 +1,29 @@
+@[callconv: stdcall]
+type StdcallNestedCallback = fn (int) int
+
+@[callconv: cdecl]
+type CdeclNestedCallback = fn (int) int
+
+@[callconv: cdecl]
+type StdcallFactory = fn () StdcallNestedCallback
+
+@[callconv: cdecl]
+type CdeclFactory = fn () CdeclNestedCallback
+
+interface FactoryProvider {
+	factory() StdcallFactory
+}
+
+struct CdeclFactoryProvider {}
+
+fn (_ CdeclFactoryProvider) factory() CdeclFactory {
+	return fn () CdeclNestedCallback {
+		return fn (value int) int {
+			return value
+		}
+	}
+}
+
+fn main() {
+	_ := FactoryProvider(CdeclFactoryProvider{})
+}

--- a/vlib/v/checker/tests/interface_method_option_result_alias_return_mismatch_err.out
+++ b/vlib/v/checker/tests/interface_method_option_result_alias_return_mismatch_err.out
@@ -1,0 +1,30 @@
+vlib/v/checker/tests/interface_method_option_result_alias_return_mismatch_err.vv:24:7: error: `OptionalIntProvider` incorrectly implements method `value` of interface `OptionalProvider`: expected return type `?MyInt`
+   22 |
+   23 | fn main() {
+   24 |     _ := OptionalProvider(OptionalIntProvider{})
+      |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   25 |     _ := ResultProvider(ResultIntProvider{})
+   26 | }
+Details: main.OptionalProvider has `fn value(x main.OptionalProvider) ?main.MyInt`
+         main.OptionalIntProvider has `fn value(_ main.OptionalIntProvider) ?int`
+vlib/v/checker/tests/interface_method_option_result_alias_return_mismatch_err.vv:24:7: error: `OptionalIntProvider` does not implement interface `OptionalProvider`, cannot cast `OptionalIntProvider` to interface `OptionalProvider`
+   22 |
+   23 | fn main() {
+   24 |     _ := OptionalProvider(OptionalIntProvider{})
+      |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   25 |     _ := ResultProvider(ResultIntProvider{})
+   26 | }
+vlib/v/checker/tests/interface_method_option_result_alias_return_mismatch_err.vv:25:7: error: `ResultIntProvider` incorrectly implements method `value` of interface `ResultProvider`: expected return type `!MyInt`
+   23 | fn main() {
+   24 |     _ := OptionalProvider(OptionalIntProvider{})
+   25 |     _ := ResultProvider(ResultIntProvider{})
+      |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   26 | }
+Details: main.ResultProvider has `fn value(x main.ResultProvider) !main.MyInt`
+         main.ResultIntProvider has `fn value(_ main.ResultIntProvider) !int`
+vlib/v/checker/tests/interface_method_option_result_alias_return_mismatch_err.vv:25:7: error: `ResultIntProvider` does not implement interface `ResultProvider`, cannot cast `ResultIntProvider` to interface `ResultProvider`
+   23 | fn main() {
+   24 |     _ := OptionalProvider(OptionalIntProvider{})
+   25 |     _ := ResultProvider(ResultIntProvider{})
+      |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   26 | }

--- a/vlib/v/checker/tests/interface_method_option_result_alias_return_mismatch_err.vv
+++ b/vlib/v/checker/tests/interface_method_option_result_alias_return_mismatch_err.vv
@@ -1,0 +1,26 @@
+type MyInt = int
+
+interface OptionalProvider {
+	value() ?MyInt
+}
+
+struct OptionalIntProvider {}
+
+fn (_ OptionalIntProvider) value() ?int {
+	return 1
+}
+
+interface ResultProvider {
+	value() !MyInt
+}
+
+struct ResultIntProvider {}
+
+fn (_ ResultIntProvider) value() !int {
+	return 2
+}
+
+fn main() {
+	_ := OptionalProvider(OptionalIntProvider{})
+	_ := ResultProvider(ResultIntProvider{})
+}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2753,14 +2753,25 @@ fn (mut g Gen) alias_shared_parent_type(typ ast.Type) ast.Type {
 }
 
 fn (mut g Gen) exposed_smartcast_type(orig_type ast.Type, smartcast_type ast.Type, is_mut bool) ast.Type {
-	if is_mut || orig_type == 0 || smartcast_type == 0 || orig_type.is_ptr() {
+	if orig_type == 0 || smartcast_type == 0 || orig_type.is_ptr() {
 		return smartcast_type
 	}
 	orig_sym := g.table.final_sym(orig_type)
+	if is_mut {
+		if orig_sym.kind == .interface && smartcast_type.nr_muls() > 1 {
+			// Interface storage adds one pointer level on top of the pointer variant.
+			return smartcast_type.deref()
+		}
+		return smartcast_type
+	}
 	resolved_smartcast_type := g.unwrap_generic(smartcast_type)
 	smartcast_sym := g.table.final_sym(resolved_smartcast_type)
 	if orig_sym.kind == .interface && smartcast_sym.kind != .interface {
 		if smartcast_sym.kind in [.struct, .aggregate] && !smartcast_sym.is_builtin() {
+			if smartcast_type.nr_muls() > 1 {
+				// Expose `&T`, not the interface's internal `&&T` representation.
+				return smartcast_type.deref()
+			}
 			return if smartcast_type.is_ptr() { smartcast_type } else { smartcast_type.ref() }
 		}
 		if smartcast_type.is_ptr() {
@@ -7895,6 +7906,11 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 				lhs_expr_type = g.unwrap_generic(selector_ident.obj.typ)
 			}
 		}
+	} else if selector_expr_expr is ast.SelectorExpr {
+		resolved_smartcast_type := g.resolve_selector_smartcast_type(selector_expr_expr)
+		if resolved_smartcast_type != 0 {
+			lhs_expr_type = resolved_smartcast_type
+		}
 	}
 	if lhs_expr_type == 0 {
 		lhs_expr_type = node.expr_type
@@ -10284,7 +10300,7 @@ fn (mut g Gen) ident(node ast.Ident) {
 				current_smartcast_type := g.exposed_smartcast_type(resolved_var.orig_type,
 					smartcast_types.last(), resolved_var.is_mut)
 				mut needs_interface_smartcast_deref := g.table.is_interface_smartcast(resolved_var)
-					&& current_smartcast_type != 0
+					&& current_smartcast_type != 0 && !current_smartcast_type.is_ptr()
 					&& smartcast_types.last().nr_muls() == current_smartcast_type.nr_muls() + 1
 				// When inside_interface_deref is set (e.g. string interpolation),
 				// interface smartcast to non-pointer builtins also needs deref since

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -4475,7 +4475,8 @@ fn (mut g Gen) unwrap_receiver_type(node ast.CallExpr) (ast.Type, &ast.TypeSymbo
 					unwrapped_rec_type =
 						g.unwrap_generic(g.type_resolver.get_type(ast.Expr(node.left)))
 				} else {
-					unwrapped_rec_type = g.unwrap_generic(node.left.obj.smartcasts.last())
+					unwrapped_rec_type = g.unwrap_generic(g.exposed_smartcast_type(node.left.obj.orig_type,
+						node.left.obj.smartcasts.last(), node.left.obj.is_mut))
 					cast_sym := g.table.sym(unwrapped_rec_type)
 					if cast_sym.info is ast.Aggregate {
 						unwrapped_rec_type = cast_sym.info.types[g.aggregate_type_idx]
@@ -4640,6 +4641,12 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 			}
 		}
 		else {}
+	}
+	if node.left is ast.Ident && node.left.obj is ast.Var && node.left.obj.smartcasts.len > 0
+		&& node.left.obj.orig_type != 0
+		&& g.table.final_sym(g.unwrap_generic(node.left.obj.orig_type)).kind == .interface {
+		left_type = g.unwrap_generic(g.exposed_smartcast_type(node.left.obj.orig_type,
+			node.left.obj.smartcasts.last(), node.left.obj.is_mut))
 	}
 
 	if left_type == g.unwrap_generic(node.left_type) {

--- a/vlib/v/tests/interfaces/interface_array_append_for_struct_fields_test.v
+++ b/vlib/v/tests/interfaces/interface_array_append_for_struct_fields_test.v
@@ -1,4 +1,8 @@
-interface Value {}
+interface EmptyValue {}
+
+interface Value {
+	EmptyValue
+}
 
 struct Empty {}
 
@@ -20,7 +24,7 @@ fn geoadd(key string, geo_locations ...GeoLocation) []Value {
 	return args
 }
 
-fn test_append_for_struct_fields_to_empty_interface_array() {
+fn test_append_for_struct_fields_to_embedded_empty_interface_array() {
 	args := geoadd('places', GeoLocation{
 		name:      'home'
 		longitude: 1.25

--- a/vlib/v/tests/interfaces/interface_array_append_for_struct_fields_test.v
+++ b/vlib/v/tests/interfaces/interface_array_append_for_struct_fields_test.v
@@ -1,0 +1,30 @@
+interface Value {}
+
+struct Empty {}
+
+struct GeoLocation {
+	name      string
+	longitude f64
+	latitude  f64
+}
+
+fn geoadd(key string, geo_locations ...GeoLocation) []Value {
+	mut args := []Value{len: 0, cap: geo_locations.len * 3 + 2, init: Empty{}}
+	args << 'GEOADD'
+	args << key
+	for _, location in geo_locations {
+		args << location.longitude
+		args << location.latitude
+		args << location.name
+	}
+	return args
+}
+
+fn test_append_for_struct_fields_to_empty_interface_array() {
+	args := geoadd('places', GeoLocation{
+		name:      'home'
+		longitude: 1.25
+		latitude:  2.5
+	})
+	assert args.len == 5
+}

--- a/vlib/v/tests/interfaces/interface_method_fn_type_alias_return_test.v
+++ b/vlib/v/tests/interfaces/interface_method_fn_type_alias_return_test.v
@@ -3,12 +3,21 @@ type MathOp = fn (int, int) int
 @[callconv: cdecl]
 type CdeclMathOp = fn (int, int) int
 
+type MathFactory = fn () MathOp
+
+@[callconv: cdecl]
+type CdeclMathFactory = fn () CdeclMathOp
+
 interface Calculator {
 	get_operation() MathOp
 }
 
 interface CdeclCalculator {
 	get_operation() CdeclMathOp
+}
+
+interface FactoryCalculator {
+	get_factory() MathFactory
 }
 
 struct SimpleCalc {}
@@ -38,6 +47,17 @@ fn (c PlainCalc) get_operation() MathOp {
 	}
 }
 
+struct CdeclFactoryCalc {}
+
+fn (c CdeclFactoryCalc) get_factory() CdeclMathFactory {
+	_ = c
+	return fn () CdeclMathOp {
+		return fn (a int, b int) int {
+			return a / b
+		}
+	}
+}
+
 fn test_interface_method_fn_type_alias_return() {
 	calc := Calculator(SimpleCalc{})
 	operation := calc.get_operation()
@@ -52,4 +72,11 @@ fn test_interface_method_fn_type_alias_omitted_callconv_matches_cdecl() {
 	plain_calc := CdeclCalculator(PlainCalc{})
 	plain_operation := plain_calc.get_operation()
 	assert plain_operation(5, 3) == 15
+}
+
+fn test_interface_method_nested_fn_type_alias_omitted_callconv_matches_cdecl() {
+	calc := FactoryCalculator(CdeclFactoryCalc{})
+	factory := calc.get_factory()
+	operation := factory()
+	assert operation(12, 3) == 4
 }

--- a/vlib/v/tests/interfaces/interface_method_fn_type_alias_return_test.v
+++ b/vlib/v/tests/interfaces/interface_method_fn_type_alias_return_test.v
@@ -1,7 +1,14 @@
 type MathOp = fn (int, int) int
 
+@[callconv: cdecl]
+type CdeclMathOp = fn (int, int) int
+
 interface Calculator {
 	get_operation() MathOp
+}
+
+interface CdeclCalculator {
+	get_operation() CdeclMathOp
 }
 
 struct SimpleCalc {}
@@ -13,8 +20,36 @@ fn (s SimpleCalc) get_operation() MathOp {
 	}
 }
 
+struct CdeclCalc {}
+
+fn (c CdeclCalc) get_operation() CdeclMathOp {
+	_ = c
+	return fn (a int, b int) int {
+		return a - b
+	}
+}
+
+struct PlainCalc {}
+
+fn (c PlainCalc) get_operation() MathOp {
+	_ = c
+	return fn (a int, b int) int {
+		return a * b
+	}
+}
+
 fn test_interface_method_fn_type_alias_return() {
 	calc := Calculator(SimpleCalc{})
 	operation := calc.get_operation()
 	assert operation(2, 3) == 5
+}
+
+fn test_interface_method_fn_type_alias_omitted_callconv_matches_cdecl() {
+	cdecl_calc := Calculator(CdeclCalc{})
+	cdecl_operation := cdecl_calc.get_operation()
+	assert cdecl_operation(5, 3) == 2
+
+	plain_calc := CdeclCalculator(PlainCalc{})
+	plain_operation := plain_calc.get_operation()
+	assert plain_operation(5, 3) == 15
 }

--- a/vlib/v/tests/interfaces/interface_method_fn_type_alias_return_test.v
+++ b/vlib/v/tests/interfaces/interface_method_fn_type_alias_return_test.v
@@ -1,0 +1,20 @@
+type MathOp = fn (int, int) int
+
+interface Calculator {
+	get_operation() MathOp
+}
+
+struct SimpleCalc {}
+
+fn (s SimpleCalc) get_operation() MathOp {
+	_ = s
+	return fn (a int, b int) int {
+		return a + b
+	}
+}
+
+fn test_interface_method_fn_type_alias_return() {
+	calc := Calculator(SimpleCalc{})
+	operation := calc.get_operation()
+	assert operation(2, 3) == 5
+}

--- a/vlib/v/tests/interfaces/interface_method_fn_type_alias_return_test.v
+++ b/vlib/v/tests/interfaces/interface_method_fn_type_alias_return_test.v
@@ -1,5 +1,9 @@
 type MathOp = fn (int, int) int
 
+type MyInt = int
+
+type AliasedMathOp = fn (MyInt, MyInt) MyInt
+
 @[callconv: cdecl]
 type CdeclMathOp = fn (int, int) int
 
@@ -14,6 +18,10 @@ interface Calculator {
 
 interface CdeclCalculator {
 	get_operation() CdeclMathOp
+}
+
+interface AliasedCalculator {
+	get_operation() AliasedMathOp
 }
 
 interface FactoryCalculator {
@@ -47,6 +55,15 @@ fn (c PlainCalc) get_operation() MathOp {
 	}
 }
 
+struct AliasCalc {}
+
+fn (c AliasCalc) get_operation() MathOp {
+	_ = c
+	return fn (a int, b int) int {
+		return a - b
+	}
+}
+
 struct CdeclFactoryCalc {}
 
 fn (c CdeclFactoryCalc) get_factory() CdeclMathFactory {
@@ -72,6 +89,12 @@ fn test_interface_method_fn_type_alias_omitted_callconv_matches_cdecl() {
 	plain_calc := CdeclCalculator(PlainCalc{})
 	plain_operation := plain_calc.get_operation()
 	assert plain_operation(5, 3) == 15
+}
+
+fn test_interface_method_fn_type_component_alias_matches_parent() {
+	calc := AliasedCalculator(AliasCalc{})
+	operation := calc.get_operation()
+	assert operation(8, 3) == 5
 }
 
 fn test_interface_method_nested_fn_type_alias_omitted_callconv_matches_cdecl() {

--- a/vlib/v/tests/interfaces/interface_pointer_smartcast_test.v
+++ b/vlib/v/tests/interfaces/interface_pointer_smartcast_test.v
@@ -1,0 +1,81 @@
+interface Actor {
+	marker()
+}
+
+struct Entity {
+	name string
+}
+
+fn (_ &Entity) marker() {}
+
+struct Mob {
+	id   u64
+	name string
+}
+
+fn (_ &Mob) marker() {}
+
+fn (mob &Mob) info() string {
+	return '${mob.id}: ${mob.name}'
+}
+
+struct Entry {
+	actor Actor
+}
+
+struct ValueEntity {
+	name string
+}
+
+fn (_ ValueEntity) marker() {}
+
+fn test_interface_value_smartcast_field_access() {
+	actor := Actor(ValueEntity{
+		name: 'value entity'
+	})
+	if actor is ValueEntity {
+		assert actor.name == 'value entity'
+	} else {
+		assert false
+	}
+}
+
+fn test_interface_pointer_smartcast_field_access() {
+	entry := Entry{
+		actor: &Entity{
+			name: 'entity'
+		}
+	}
+	if entry.actor is &Entity {
+		assert entry.actor.name == 'entity'
+	} else {
+		assert false
+	}
+}
+
+fn test_interface_pointer_smartcast_method_call() {
+	mut actors := map[u64]Actor{}
+	actors[1] = &Mob{
+		id:   1
+		name: 'cow'
+	}
+	entry := actors[1] or { panic('missing actor') }
+	actor := entry
+	if actor is &Mob {
+		assert actor.info() == '1: cow'
+	} else {
+		assert false
+	}
+}
+
+fn test_mut_interface_pointer_smartcast_method_call() {
+	mut actor := Actor(&Mob{
+		id:   2
+		name: 'bull'
+	})
+	if mut actor is &Mob {
+		assert actor.info() == '2: bull'
+	} else {
+		assert false
+	}
+}


### PR DESCRIPTION
## Summary

- allow struct field values to be appended to empty-interface arrays without falsely treating the enclosing loop value as escaping
- compare function-valued interface method return types structurally after unaliasing
- preserve the user-visible pointer depth for `is &T` interface smartcasts in field access and method calls

Fixes #27944
Fixes #27950
Fixes #27952

## Tests

- `./vnew -silent test vlib/v/tests/interfaces/`
- `./vnew -silent test vlib/v/checker/`
- `./vnew -silent vlib/v/compiler_errors_test.v`
- `./vnew -silent vlib/v/gen/c/coutput_test.v`
- focused regressions with `-cstrict -cc clang`