### PR TITLE
compiler,time: fix generic, alias, receiver, and timer regressions

### DIFF
--- a/vlib/sync/channel_select_fifo_test.v
+++ b/vlib/sync/channel_select_fifo_test.v
@@ -1,13 +1,11 @@
 module sync
 
-import time
-
 fn wait_select_once(ch &Channel, done chan string, label string) {
 	mut channels := [ch]
 	directions := [Direction.pop]
 	mut value := 0
 	mut objs := [voidptr(&value)]
-	idx := channel_select(mut channels, directions, mut objs, time.infinite)
+	idx := channel_select(mut channels, directions, mut objs, infinite_timeout)
 	match idx {
 		0 {
 			done <- '${label}:${value}'
@@ -40,7 +38,7 @@ fn wait_for_pop_subscribers(ch &Channel, want int) {
 		if pop_subscriber_count(ch) == want {
 			return
 		}
-		time.sleep(5 * time.millisecond)
+		sync_sleep_nanoseconds(5_000_000)
 	}
 	assert false, 'timed out waiting for ${want} read select subscriber(s)'
 }
@@ -56,7 +54,7 @@ fn test_select_waiters_are_fifo() {
 	// Subscriber registration happens before the first non-blocking try,
 	// so there is a small window where the second goroutine is still in
 	// its initial try_pop before blocking.
-	time.sleep(50 * time.millisecond)
+	sync_sleep_nanoseconds(50_000_000)
 	value := 999
 	ch.push(&value)
 	assert <-done == 'first:999'

--- a/vlib/sync/channel_select_handoff_test.v
+++ b/vlib/sync/channel_select_handoff_test.v
@@ -1,0 +1,40 @@
+module sync
+
+const select_handoff_pairs = 64
+const select_handoff_timeout = i64(500_000_000)
+
+fn select_send_after_start(ch &Channel, start chan bool, results chan bool, value int) {
+	_ := <-start
+	mut channels := [ch]
+	directions := [Direction.push]
+	mut sent := value
+	mut objects := [voidptr(&sent)]
+	idx := channel_select(mut channels, directions, mut objects, select_handoff_timeout)
+	results <- (idx == 0)
+}
+
+fn select_receive_after_start(ch &Channel, start chan bool, results chan bool, expected int) {
+	_ := <-start
+	mut channels := [ch]
+	directions := [Direction.pop]
+	mut received := 0
+	mut objects := [voidptr(&received)]
+	idx := channel_select(mut channels, directions, mut objects, select_handoff_timeout)
+	results <- (idx == 0 && received == expected)
+}
+
+fn test_opposing_unbuffered_selects_do_not_miss_waiting_transition() {
+	start := chan bool{cap: select_handoff_pairs * 2}
+	results := chan bool{cap: select_handoff_pairs * 2}
+	for i in 0 .. select_handoff_pairs {
+		ch := new_channel[int](0)
+		spawn select_send_after_start(ch, start, results, i + 1)
+		spawn select_receive_after_start(ch, start, results, i + 1)
+	}
+	for _ in 0 .. select_handoff_pairs * 2 {
+		start <- true
+	}
+	for _ in 0 .. select_handoff_pairs * 2 {
+		assert <-results
+	}
+}

--- a/vlib/sync/channel_select_test.v
+++ b/vlib/sync/channel_select_test.v
@@ -7,7 +7,6 @@ module sync
 // This test case uses the implementation in `sync/channels.v` directly
 // in order to test it independently from the support in the core language
 import os
-import time
 
 fn test_should_run_flaky_test() {
 	if os.getenv('VTEST_RUN_FLAKY') != '1' {
@@ -65,7 +64,7 @@ fn test_select() {
 	mut sl := i64(0)
 	mut objs := [voidptr(&ri), &sl, &rl, &rb]
 	for _ in 0 .. 1200 {
-		idx := channel_select(mut channels, directions, mut objs, time.infinite)
+		idx := channel_select(mut channels, directions, mut objs, infinite_timeout)
 		match idx {
 			0 {
 				sum += ri

--- a/vlib/sync/channels.c.v
+++ b/vlib/sync/channels.c.v
@@ -614,6 +614,47 @@ fn (mut ch Channel) try_pop_priv(dest voidptr, no_block bool) ChanState {
 	return .success
 }
 
+// select_recheck_after_waiting coordinates opposing unbuffered selects that
+// both missed each other while their state was still `select_state_scanning`.
+// The select with the lowest state address rescans; later selects wake it and
+// remain in the claimable waiting state.
+fn select_recheck_after_waiting(mut channels []&Channel, dir []Direction, state &u32) bool {
+	mut found_later_waiter := false
+	for i, mut ch in channels {
+		if ch.cap != 0 {
+			continue
+		}
+		sub_mtx := if dir[i] == .push {
+			ch.read_sub_mtx
+		} else {
+			ch.write_sub_mtx
+		}
+		sub_mtx.lock()
+		mut sub := if dir[i] == .push {
+			ch.read_subscriber
+		} else {
+			ch.write_subscriber
+		}
+		for sub != unsafe { nil } {
+			if sub.state != state && C.atomic_load_u32(sub.state) == select_state_waiting {
+				if usize(sub.state) < usize(state) {
+					sub.sem.post()
+					sub_mtx.unlock()
+					return false
+				}
+				found_later_waiter = true
+			}
+			sub = sub.nxt
+		}
+		sub_mtx.unlock()
+	}
+	if found_later_waiter {
+		mut expected := select_state_waiting
+		return C.atomic_compare_exchange_strong_u32(state, &expected, select_state_scanning)
+	}
+	return false
+}
+
 // channel_select waits `timeout` on any of `channels[i]` until one of them can
 // push (`dir[i] == .push`) or pop (`dir[i] == .pop`) the object referenced by
 // `objrefs[i]`. `timeout = i64 max` means wait unlimited time.
@@ -730,6 +771,9 @@ fn channel_select_priv(mut channels []&Channel, dir []Direction, mut objrefs []v
 			break outer
 		}
 		C.atomic_store_u32(&select_state, select_state_waiting)
+		if select_recheck_after_waiting(mut channels, dir, &select_state) {
+			continue
+		}
 		mut timed_out := false
 		if timeout != infinite_timeout {
 			remaining := timeout - (sync_mono_now() - start)

--- a/vlib/sync/channels.c.v
+++ b/vlib/sync/channels.c.v
@@ -1,7 +1,9 @@
 module sync
 
-import time
-import rand
+const infinite_timeout = i64(9223372036854775807)
+const select_state_scanning = u32(4294967295)
+const select_state_waiting = u32(4294967294)
+const select_state_claimed = u32(4294967293)
 
 // how often to try to get data without blocking before to wait for semaphore
 const spinloops = u32(750)
@@ -16,9 +18,12 @@ enum BufferElemStat {
 
 struct Subscription {
 mut:
-	sem  &Semaphore     = unsafe { nil }
-	prev &&Subscription = unsafe { nil }
-	nxt  &Subscription  = unsafe { nil }
+	sem    &Semaphore = unsafe { nil }
+	state  &u32       = unsafe { nil }
+	objref voidptr
+	index  u32
+	prev   voidptr       = unsafe { nil }
+	nxt    &Subscription = unsafe { nil }
 }
 
 // append_subscription keeps select waiters in FIFO order, so the oldest waiter
@@ -29,7 +34,7 @@ fn append_subscription(head &&Subscription, sub &Subscription) {
 		for *link != 0 {
 			link = &(*link).nxt
 		}
-		sub.prev = link
+		sub.prev = voidptr(link)
 		sub.nxt = nil
 		*link = sub
 	}
@@ -200,6 +205,27 @@ pub fn (mut ch Channel) try_push(src voidptr) ChanState {
 	return ch.try_push_priv(src, true)
 }
 
+fn (mut ch Channel) try_push_to_select(src voidptr) bool {
+	ch.read_sub_mtx.lock()
+	defer {
+		ch.read_sub_mtx.unlock()
+	}
+	mut sub := ch.read_subscriber
+	for sub != unsafe { nil } {
+		mut expected := select_state_waiting
+		if C.atomic_compare_exchange_strong_u32(sub.state, &expected, select_state_claimed) {
+			unsafe {
+				C.memcpy(sub.objref, src, ch.objsize)
+			}
+			C.atomic_store_u32(sub.state, sub.index)
+			sub.sem.post()
+			return true
+		}
+		sub = sub.nxt
+	}
+	return false
+}
+
 fn (mut ch Channel) try_push_priv(src voidptr, no_block bool) ChanState {
 	if C.atomic_load_u16(&ch.closed) != 0 {
 		return .closed
@@ -225,6 +251,9 @@ fn (mut ch Channel) try_push_priv(src voidptr, no_block bool) ChanState {
 			}
 		}
 		if no_block && ch.cap == 0 {
+			if ch.try_push_to_select(src) {
+				return .success
+			}
 			return .not_ready
 		}
 		// get token to read
@@ -386,6 +415,27 @@ pub fn (mut ch Channel) try_pop(dest voidptr) ChanState {
 	return ch.try_pop_priv(dest, true)
 }
 
+fn (mut ch Channel) try_pop_from_select(dest voidptr) bool {
+	ch.write_sub_mtx.lock()
+	defer {
+		ch.write_sub_mtx.unlock()
+	}
+	mut sub := ch.write_subscriber
+	for sub != unsafe { nil } {
+		mut expected := select_state_waiting
+		if C.atomic_compare_exchange_strong_u32(sub.state, &expected, select_state_claimed) {
+			unsafe {
+				C.memcpy(dest, sub.objref, ch.objsize)
+			}
+			C.atomic_store_u32(sub.state, sub.index)
+			sub.sem.post()
+			return true
+		}
+		sub = sub.nxt
+	}
+	return false
+}
+
 // try_pop_select_priv treats already closed channels as unavailable for non-blocking `select ... else`.
 @[inline]
 fn (mut ch Channel) try_pop_select_priv(dest voidptr) ChanState {
@@ -421,6 +471,9 @@ fn (mut ch Channel) try_pop_priv(dest voidptr, no_block bool) ChanState {
 			}
 			if no_block {
 				if C.atomic_load_u16(&ch.closed) == 0 {
+					if ch.try_pop_from_select(dest) {
+						return .success
+					}
 					return .not_ready
 				} else {
 					return .closed
@@ -563,13 +616,13 @@ fn (mut ch Channel) try_pop_priv(dest voidptr, no_block bool) ChanState {
 
 // channel_select waits `timeout` on any of `channels[i]` until one of them can
 // push (`dir[i] == .push`) or pop (`dir[i] == .pop`) the object referenced by
-// `objrefs[i]`. `timeout = time.infinite` means wait unlimited time.
+// `objrefs[i]`. `timeout = i64 max` means wait unlimited time.
 // `timeout <= 0` means return immediately if no transaction can be performed
 // without waiting. It returns the selected channel index, `-1` on timeout, and
 // `-2` when all channels are closed.
-pub fn channel_select(mut channels []&Channel, dir []Direction, mut objrefs []voidptr, timeout time.Duration) int {
+pub fn channel_select(mut channels []&Channel, dir []Direction, mut objrefs []voidptr, timeout i64) int {
 	skip_closed_pop := timeout < 0
-	actual_timeout := if skip_closed_pop { time.Duration(0) } else { timeout }
+	actual_timeout := if skip_closed_pop { i64(0) } else { timeout }
 	closed_pop_mode := if skip_closed_pop {
 		SelectClosedPopMode.skip
 	} else {
@@ -587,9 +640,9 @@ enum SelectClosedPopMode {
 // channel_select_lang is used by the language `select` implementation.
 // Closed receive cases stay selectable for blocking/timed selects to match
 // plain `<-ch` semantics, while `select ... else` still skips them.
-fn channel_select_lang(mut channels []&Channel, dir []Direction, mut objrefs []voidptr, timeout time.Duration) int {
+fn channel_select_lang(mut channels []&Channel, dir []Direction, mut objrefs []voidptr, timeout i64) int {
 	skip_closed_pop := timeout < 0
-	actual_timeout := if skip_closed_pop { time.Duration(0) } else { timeout }
+	actual_timeout := if skip_closed_pop { i64(0) } else { timeout }
 	closed_pop_mode := if skip_closed_pop {
 		SelectClosedPopMode.skip
 	} else {
@@ -598,7 +651,7 @@ fn channel_select_lang(mut channels []&Channel, dir []Direction, mut objrefs []v
 	return channel_select_priv(mut channels, dir, mut objrefs, actual_timeout, closed_pop_mode)
 }
 
-fn channel_select_priv(mut channels []&Channel, dir []Direction, mut objrefs []voidptr, timeout time.Duration, closed_pop_mode SelectClosedPopMode) int {
+fn channel_select_priv(mut channels []&Channel, dir []Direction, mut objrefs []voidptr, timeout i64, closed_pop_mode SelectClosedPopMode) int {
 	$if debug_channels ? {
 		assert channels.len == dir.len
 		assert dir.len == objrefs.len
@@ -606,8 +659,12 @@ fn channel_select_priv(mut channels []&Channel, dir []Direction, mut objrefs []v
 	mut subscr := []Subscription{len: channels.len}
 	mut sem := unsafe { Semaphore{} }
 	sem.init(0)
+	mut select_state := select_state_scanning
 	for i, ch in channels {
 		subscr[i].sem = unsafe { &sem }
+		subscr[i].state = unsafe { &select_state }
+		subscr[i].objref = objrefs[i]
+		subscr[i].index = u32(i)
 		sub_mtx, subscriber := if dir[i] == .push {
 			ch.write_sub_mtx, &ch.write_subscriber
 		} else {
@@ -619,15 +676,19 @@ fn channel_select_priv(mut channels []&Channel, dir []Direction, mut objrefs []v
 		}
 		sub_mtx.unlock()
 	}
-	stopwatch := if timeout == time.infinite || timeout <= 0 {
-		time.StopWatch{}
-	} else {
-		time.new_stopwatch()
-	}
+	start := if timeout == infinite_timeout || timeout <= 0 { i64(0) } else { sync_mono_now() }
 	mut event_idx := -1 // negative index means `timed out`
+	mut select_start_idx := if channels.len == 0 {
+		0
+	} else {
+		int(sync_mono_now() % channels.len)
+	}
 
 	outer: for {
-		rnd := rand.intn(channels.len) or { 0 }
+		rnd := select_start_idx
+		if channels.len > 0 {
+			select_start_idx = (select_start_idx + 1) % channels.len
+		}
 		mut num_closed := 0
 		mut ready_closed_idx := -1
 		for j, _ in channels {
@@ -668,13 +729,30 @@ fn channel_select_priv(mut channels []&Channel, dir []Direction, mut objrefs []v
 		if timeout <= 0 {
 			break outer
 		}
-		if timeout != time.infinite {
-			remaining := timeout - stopwatch.elapsed()
-			if !sem.timed_wait(remaining) {
+		C.atomic_store_u32(&select_state, select_state_waiting)
+		mut timed_out := false
+		if timeout != infinite_timeout {
+			remaining := timeout - (sync_mono_now() - start)
+			if remaining <= 0 {
+				C.atomic_store_u32(&select_state, select_state_scanning)
 				break outer
+			}
+			if !sem.timed_wait(remaining) {
+				timed_out = true
 			}
 		} else {
 			sem.wait()
+		}
+		mut expected := select_state_waiting
+		if !C.atomic_compare_exchange_strong_u32(&select_state, &expected, select_state_scanning) {
+			for C.atomic_load_u32(&select_state) == select_state_claimed {
+				sem.wait()
+			}
+			event_idx = int(C.atomic_load_u32(&select_state))
+			break outer
+		}
+		if timed_out {
+			break outer
 		}
 	}
 	// reset subscribers
@@ -686,7 +764,8 @@ fn channel_select_priv(mut channels []&Channel, dir []Direction, mut objrefs []v
 		}
 		sub_mtx.lock()
 		unsafe {
-			*subscr[i].prev = subscr[i].nxt
+			mut prev := &&Subscription(subscr[i].prev)
+			*prev = subscr[i].nxt
 		}
 		if unsafe { subscr[i].nxt != 0 } {
 			subscr[i].nxt.prev = subscr[i].prev

--- a/vlib/sync/common_mutex.v
+++ b/vlib/sync/common_mutex.v
@@ -2,10 +2,10 @@ module sync
 
 // str returns a string representation of the Mutex pointer.
 pub fn (m &Mutex) str() string {
-	return 'Mutex(${voidptr(m)})'
+	return 'Mutex(0x' + ptr_str(m) + ')'
 }
 
 // str returns a string representation of the RwMutex pointer.
 pub fn (m &RwMutex) str() string {
-	return 'RwMutex(${voidptr(m)})'
+	return 'RwMutex(0x' + ptr_str(m) + ')'
 }

--- a/vlib/sync/select_close_test.v
+++ b/vlib/sync/select_close_test.v
@@ -1,8 +1,6 @@
 // vtest retry: 3
 module sync
 
-import time
-
 fn do_rec_i64(mut ch Channel) {
 	mut sum := i64(0)
 	for i in 0 .. 300 {
@@ -58,7 +56,7 @@ fn test_select() {
 	mut sl := i64(0)
 	mut objs := [voidptr(&ri), &sl, &rl, &rb]
 	for j in 0 .. 1101 {
-		idx := channel_select(mut channels, directions, mut objs, time.infinite)
+		idx := channel_select(mut channels, directions, mut objs, infinite_timeout)
 		match idx {
 			0 {
 				sum += ri

--- a/vlib/sync/semaphore_windows_test.v
+++ b/vlib/sync/semaphore_windows_test.v
@@ -9,3 +9,21 @@ fn test_semaphore_timed_wait_reports_acquisition_after_fast_path() {
 	assert did_acquire
 	assert was_consumed
 }
+
+fn wake_then_post_semaphore(mut sem Semaphore) {
+	for _ in 0 .. 20 {
+		sync_sleep_nanoseconds(5_000_000)
+		C.WakeConditionVariable(&sem.cond)
+	}
+	sem.post()
+}
+
+fn test_semaphore_timed_wait_handles_spurious_wake_with_infinite_timeout() {
+	mut sem := new_semaphore()
+	worker := spawn wake_then_post_semaphore(mut sem)
+	acquired := sem.timed_wait(infinite_timeout)
+	worker.wait()
+	sem.destroy()
+
+	assert acquired
+}

--- a/vlib/sync/semaphore_windows_test.v
+++ b/vlib/sync/semaphore_windows_test.v
@@ -42,3 +42,9 @@ fn test_semaphore_long_finite_timeout_uses_multiple_chunks() {
 	expired_at_deadline, _ := sync_timeout_chunk(timeout, timeout)
 	assert expired_at_deadline
 }
+
+fn test_semaphore_near_infinite_timeout_saturates_deadline() {
+	time_now := i64(10_000_000_000)
+	assert sync_timeout_deadline(time_now, infinite_timeout - 1) == infinite_timeout
+	assert sync_timeout_deadline(time_now, 1_000_000_000) == time_now + 1_000_000_000
+}

--- a/vlib/sync/semaphore_windows_test.v
+++ b/vlib/sync/semaphore_windows_test.v
@@ -1,10 +1,8 @@
 module sync
 
-import time
-
 fn test_semaphore_timed_wait_reports_acquisition_after_fast_path() {
 	mut sem := new_semaphore_init(1)
-	did_acquire := sem.wait_for_available_count(time.second)
+	did_acquire := sem.wait_for_available_count(1_000_000_000)
 	was_consumed := !sem.try_wait()
 	sem.destroy()
 

--- a/vlib/sync/semaphore_windows_test.v
+++ b/vlib/sync/semaphore_windows_test.v
@@ -27,3 +27,18 @@ fn test_semaphore_timed_wait_handles_spurious_wake_with_infinite_timeout() {
 
 	assert acquired
 }
+
+fn test_semaphore_long_finite_timeout_uses_multiple_chunks() {
+	timeout := i64(60 * 24 * 60 * 60) * 1_000_000_000
+	first_t_ms := sync_milliseconds(timeout)
+	assert first_t_ms == u32(C.INFINITE - 1)
+
+	elapsed_after_first_chunk := i64(first_t_ms) * 1_000_000
+	expired, next_t_ms := sync_timeout_chunk(timeout, elapsed_after_first_chunk)
+	assert !expired
+	assert next_t_ms > 0
+	assert next_t_ms < first_t_ms
+
+	expired_at_deadline, _ := sync_timeout_chunk(timeout, timeout)
+	assert expired_at_deadline
+}

--- a/vlib/sync/sync.c.v
+++ b/vlib/sync/sync.c.v
@@ -1,7 +1,5 @@
 module sync
 
-import time
-
 @[noreturn]
 fn cpanic(res int) {
 	panic(unsafe { tos_clone(&u8(C.strerror(res))) })
@@ -72,7 +70,7 @@ pub fn (s &SpinLock) lock() {
 			// Calculate delay with cap: 100ns to 10μs
 			exponent := int_min(spin_count / max_spins, 10)
 			delay := int_min(base_delay * (1 << exponent), max_delay)
-			time.sleep(delay * time.nanosecond)
+			sync_sleep_nanoseconds(delay)
 		} else {
 			// Reduce power/bus contention during spinning
 			C.cpu_relax()

--- a/vlib/sync/sync_darwin.c.v
+++ b/vlib/sync/sync_darwin.c.v
@@ -3,8 +3,6 @@
 // that can be found in the LICENSE file.
 module sync
 
-import time
-
 #flag -lpthread
 
 @[trusted]
@@ -310,7 +308,7 @@ pub fn (mut sem Semaphore) try_wait() bool {
 
 // timed_wait is similar to .wait(), but it also accepts a timeout duration,
 // thus it can return false early, if the timeout passed before the semaphore was posted.
-pub fn (mut sem Semaphore) timed_wait(timeout time.Duration) bool {
+pub fn (mut sem Semaphore) timed_wait(timeout i64) bool {
 	mut c := C.atomic_load_u32(&sem.count)
 	for c > 0 {
 		if C.atomic_compare_exchange_weak_u32(&sem.count, &c, c - 1) {
@@ -318,7 +316,7 @@ pub fn (mut sem Semaphore) timed_wait(timeout time.Duration) bool {
 		}
 	}
 	C.pthread_mutex_lock(&sem.mtx)
-	t_spec := timeout.timespec()
+	t_spec := sync_realtime_deadline(timeout)
 	mut res := 0
 	c = C.atomic_load_u32(&sem.count)
 

--- a/vlib/sync/sync_default.c.v
+++ b/vlib/sync/sync_default.c.v
@@ -3,8 +3,6 @@
 // that can be found in the LICENSE file.
 module sync
 
-import time
-
 // There's no additional linking (-lpthread) needed for Android.
 // See https://stackoverflow.com/a/31277163/1904615
 $if !android {
@@ -285,17 +283,11 @@ pub fn (mut sem Semaphore) try_wait() bool {
 
 // timed_wait is similar to .wait(), but it also accepts a timeout duration,
 // thus it can return false early, if the timeout passed before the semaphore was posted.
-pub fn (mut sem Semaphore) timed_wait(timeout time.Duration) bool {
-	$if macos {
-		time.sleep(timeout)
-		return true
-	}
-	t_spec := timeout.timespec()
+pub fn (mut sem Semaphore) timed_wait(timeout i64) bool {
+	t_spec := sync_realtime_deadline(timeout)
 	for {
-		$if !macos {
-			if C.sem_timedwait(&sem.sem, &t_spec) == 0 {
-				return true
-			}
+		if C.sem_timedwait(&sem.sem, &t_spec) == 0 {
+			return true
 		}
 		e := C.errno
 		match e {

--- a/vlib/sync/sync_freebsd.c.v
+++ b/vlib/sync/sync_freebsd.c.v
@@ -3,8 +3,6 @@
 // that can be found in the LICENSE file.
 module sync
 
-import time
-
 // There's no additional linking (-lpthread) needed for Android.
 // See https://stackoverflow.com/a/31277163/1904615
 $if !android {
@@ -304,17 +302,11 @@ pub fn (mut sem Semaphore) try_wait() bool {
 
 // timed_wait is similar to .wait(), but it also accepts a timeout duration,
 // thus it can return false early, if the timeout passed before the semaphore was posted.
-pub fn (mut sem Semaphore) timed_wait(timeout time.Duration) bool {
-	$if macos {
-		time.sleep(timeout)
-		return true
-	}
-	t_spec := timeout.timespec()
+pub fn (mut sem Semaphore) timed_wait(timeout i64) bool {
+	t_spec := sync_realtime_deadline(timeout)
 	for {
-		$if !macos {
-			if C.sem_timedwait(&sem.sem, &t_spec) == 0 {
-				return true
-			}
+		if C.sem_timedwait(&sem.sem, &t_spec) == 0 {
+			return true
 		}
 		e := C.errno
 		match e {

--- a/vlib/sync/sync_windows.c.v
+++ b/vlib/sync/sync_windows.c.v
@@ -219,7 +219,7 @@ pub fn (mut sem Semaphore) timed_wait(timeout i64) bool {
 }
 
 fn (mut sem Semaphore) wait_for_available_count(timeout i64) bool {
-	time_end := sync_mono_now() + timeout
+	time_end := sync_timeout_deadline(sync_mono_now(), timeout)
 	mut t_ms := sync_milliseconds(timeout)
 	C.AcquireSRWLockExclusive(&sem.mtx)
 	mut acquired := false
@@ -249,6 +249,13 @@ fn (mut sem Semaphore) wait_for_available_count(timeout i64) bool {
 	}
 	C.ReleaseSRWLockExclusive(&sem.mtx)
 	return acquired
+}
+
+fn sync_timeout_deadline(time_now i64, timeout i64) i64 {
+	if timeout > infinite_timeout - time_now {
+		return infinite_timeout
+	}
+	return time_now + timeout
 }
 
 fn sync_timeout_chunk(time_end i64, time_now i64) (bool, u32) {

--- a/vlib/sync/sync_windows.c.v
+++ b/vlib/sync/sync_windows.c.v
@@ -211,6 +211,10 @@ pub fn (mut sem Semaphore) timed_wait(timeout i64) bool {
 			return true
 		}
 	}
+	if timeout == infinite_timeout {
+		sem.wait()
+		return true
+	}
 	return sem.wait_for_available_count(timeout)
 }
 

--- a/vlib/sync/sync_windows.c.v
+++ b/vlib/sync/sync_windows.c.v
@@ -3,12 +3,9 @@
 // that can be found in the LICENSE file.
 module sync
 
-import time
-
 #include <synchapi.h>
 #include <time.h>
 
-fn C.GetSystemTimeAsFileTime(lpSystemTimeAsFileTime &C._FILETIME)
 fn C.InitializeConditionVariable(voidptr)
 fn C.WakeConditionVariable(voidptr)
 fn C.SleepConditionVariableSRW(voidptr, voidptr, u32, u32) i32
@@ -207,7 +204,7 @@ pub fn (mut sem Semaphore) try_wait() bool {
 	return false
 }
 
-pub fn (mut sem Semaphore) timed_wait(timeout time.Duration) bool {
+pub fn (mut sem Semaphore) timed_wait(timeout i64) bool {
 	mut c := C.atomic_load_u32(&sem.count)
 	for c > 0 {
 		if C.atomic_compare_exchange_weak_u32(&sem.count, &c, c - 1) {
@@ -217,12 +214,9 @@ pub fn (mut sem Semaphore) timed_wait(timeout time.Duration) bool {
 	return sem.wait_for_available_count(timeout)
 }
 
-fn (mut sem Semaphore) wait_for_available_count(timeout time.Duration) bool {
-	mut ft_start := C._FILETIME{}
-	C.GetSystemTimeAsFileTime(&ft_start)
-	time_end := ((u64(ft_start.dwHighDateTime) << 32) | ft_start.dwLowDateTime) +
-		u64(timeout / (100 * time.nanosecond))
-	mut t_ms := u32(timeout.sys_milliseconds())
+fn (mut sem Semaphore) wait_for_available_count(timeout i64) bool {
+	time_end := sync_mono_now() + timeout
+	mut t_ms := sync_milliseconds(timeout)
 	C.AcquireSRWLockExclusive(&sem.mtx)
 	mut acquired := false
 	mut c := C.atomic_load_u32(&sem.count)
@@ -244,12 +238,11 @@ fn (mut sem Semaphore) wait_for_available_count(timeout time.Duration) bool {
 				break outer
 			}
 		}
-		C.GetSystemTimeAsFileTime(&ft_start)
-		time_now := ((u64(ft_start.dwHighDateTime) << 32) | ft_start.dwLowDateTime) // in 100ns
+		time_now := sync_mono_now()
 		if time_now > time_end {
 			break outer // timeout exceeded
 		}
-		t_ms = u32((time_end - time_now) / 10000)
+		t_ms = sync_milliseconds(time_end - time_now)
 	}
 	C.ReleaseSRWLockExclusive(&sem.mtx)
 	return acquired

--- a/vlib/sync/sync_windows.c.v
+++ b/vlib/sync/sync_windows.c.v
@@ -228,10 +228,9 @@ fn (mut sem Semaphore) wait_for_available_count(timeout i64) bool {
 	outer: for {
 		if c == 0 {
 			sleep_result := C.SleepConditionVariableSRW(&sem.cond, &sem.mtx, t_ms, 0)
-			if sleep_result == 0 {
-				break outer
+			if sleep_result != 0 {
+				c = C.atomic_load_u32(&sem.count)
 			}
-			c = C.atomic_load_u32(&sem.count)
 		}
 		for c > 0 {
 			if C.atomic_compare_exchange_weak_u32(&sem.count, &c, c - 1) {
@@ -242,14 +241,21 @@ fn (mut sem Semaphore) wait_for_available_count(timeout i64) bool {
 				break outer
 			}
 		}
-		time_now := sync_mono_now()
-		if time_now > time_end {
-			break outer // timeout exceeded
+		expired, next_t_ms := sync_timeout_chunk(time_end, sync_mono_now())
+		if expired {
+			break outer
 		}
-		t_ms = sync_milliseconds(time_end - time_now)
+		t_ms = next_t_ms
 	}
 	C.ReleaseSRWLockExclusive(&sem.mtx)
 	return acquired
+}
+
+fn sync_timeout_chunk(time_end i64, time_now i64) (bool, u32) {
+	if time_now >= time_end {
+		return true, 0
+	}
+	return false, sync_milliseconds(time_end - time_now)
 }
 
 pub fn (mut m RwMutex) destroy() {

--- a/vlib/sync/thread_helper.h
+++ b/vlib/sync/thread_helper.h
@@ -2,7 +2,7 @@
 #define V_SYNC_THREAD_HELPER_H
 
 #ifndef V_THREAD_STACK_SIZE
-#define V_THREAD_STACK_SIZE 8388608
+#define V_THREAD_STACK_SIZE 0
 #endif
 
 #ifdef _WIN32
@@ -27,7 +27,9 @@ static inline int v_sync_thread_create_detached(void *start, void *arg) {
 	if (rc != 0) {
 		return rc;
 	}
-	rc = pthread_attr_setstacksize(&attr, V_THREAD_STACK_SIZE);
+	if (V_THREAD_STACK_SIZE != 0) {
+		rc = pthread_attr_setstacksize(&attr, V_THREAD_STACK_SIZE);
+	}
 	if (rc == 0) {
 		rc = pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
 	}

--- a/vlib/sync/thread_helper.h
+++ b/vlib/sync/thread_helper.h
@@ -1,0 +1,45 @@
+#ifndef V_SYNC_THREAD_HELPER_H
+#define V_SYNC_THREAD_HELPER_H
+
+#ifndef V_THREAD_STACK_SIZE
+#define V_THREAD_STACK_SIZE 8388608
+#endif
+
+#ifdef _WIN32
+#include <windows.h>
+
+static inline int v_sync_thread_create_detached(void *start, void *arg) {
+	HANDLE handle = CreateThread(NULL, V_THREAD_STACK_SIZE, (LPTHREAD_START_ROUTINE)start,
+		arg, 0, NULL);
+	if (handle == NULL) {
+		return (int)GetLastError();
+	}
+	CloseHandle(handle);
+	return 0;
+}
+#else
+#include <pthread.h>
+#include <stdlib.h>
+
+static inline int v_sync_thread_create_detached(void *start, void *arg) {
+	pthread_attr_t attr;
+	int rc = pthread_attr_init(&attr);
+	if (rc != 0) {
+		return rc;
+	}
+	rc = pthread_attr_setstacksize(&attr, V_THREAD_STACK_SIZE);
+	if (rc == 0) {
+		rc = pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
+	}
+	if (rc == 0) {
+		pthread_t thread;
+		rc = pthread_create(&thread, &attr, (void *(*)(void *))start, arg);
+	}
+	if (pthread_attr_destroy(&attr) != 0) {
+		abort();
+	}
+	return rc;
+}
+#endif
+
+#endif

--- a/vlib/sync/timing_nix.c.v
+++ b/vlib/sync/timing_nix.c.v
@@ -1,0 +1,45 @@
+module sync
+
+#include <time.h>
+#include <errno.h>
+
+pub struct C.timespec {
+pub mut:
+	tv_sec  i64
+	tv_nsec i64
+}
+
+fn C.clock_gettime(i32, &C.timespec) i32
+fn C.nanosleep(&C.timespec, &C.timespec) i32
+
+fn sync_mono_now() i64 {
+	mut ts := C.timespec{}
+	C.clock_gettime(C.CLOCK_MONOTONIC, &ts)
+	return ts.tv_sec * 1_000_000_000 + ts.tv_nsec
+}
+
+fn sync_realtime_deadline(timeout i64) C.timespec {
+	mut ts := C.timespec{}
+	C.clock_gettime(C.CLOCK_REALTIME, &ts)
+	ts.tv_sec += timeout / 1_000_000_000
+	ts.tv_nsec += timeout % 1_000_000_000
+	if ts.tv_nsec >= 1_000_000_000 {
+		ts.tv_nsec -= 1_000_000_000
+		ts.tv_sec++
+	}
+	return ts
+}
+
+fn sync_sleep_nanoseconds(duration i64) {
+	mut request := C.timespec{
+		tv_sec:  duration / 1_000_000_000
+		tv_nsec: duration % 1_000_000_000
+	}
+	mut remaining := C.timespec{}
+	for C.nanosleep(&request, &remaining) < 0 {
+		if C.errno != C.EINTR {
+			break
+		}
+		request = remaining
+	}
+}

--- a/vlib/sync/timing_windows.c.v
+++ b/vlib/sync/timing_windows.c.v
@@ -1,0 +1,29 @@
+module sync
+
+fn C.QueryPerformanceCounter(&u64) C.BOOL
+fn C.QueryPerformanceFrequency(&u64) C.BOOL
+
+fn sync_mono_now() i64 {
+	mut counter := u64(0)
+	mut frequency := u64(0)
+	C.QueryPerformanceCounter(voidptr(&counter))
+	C.QueryPerformanceFrequency(voidptr(&frequency))
+	seconds := counter / frequency
+	remainder := counter % frequency
+	return i64(seconds * 1_000_000_000 + remainder * 1_000_000_000 / frequency)
+}
+
+fn sync_milliseconds(timeout i64) u32 {
+	if timeout <= 0 {
+		return 0
+	}
+	milliseconds := timeout / 1_000_000
+	if milliseconds >= i64(C.INFINITE) {
+		return u32(C.INFINITE - 1)
+	}
+	return u32(milliseconds)
+}
+
+fn sync_sleep_nanoseconds(duration i64) {
+	C.Sleep(int(duration / 1_000_000))
+}

--- a/vlib/sync/waitgroup.c.v
+++ b/vlib/sync/waitgroup.c.v
@@ -34,6 +34,22 @@ mut:
 	sem   Semaphore // Blocks wait() until add() drops the task count to zero
 }
 
+struct WaitGroupThreadArgs {
+mut:
+	wg &WaitGroup
+	f  fn () = unsafe { nil }
+}
+
+fn new_waitgroup_thread_args(wg &WaitGroup, f fn ()) &WaitGroupThreadArgs {
+	mut args := unsafe { &WaitGroupThreadArgs(C.calloc(1, sizeof(WaitGroupThreadArgs))) }
+	if args == unsafe { nil } {
+		panic('could not allocate waitgroup thread arguments')
+	}
+	args.wg = wg
+	args.f = f
+	return args
+}
+
 // new_waitgroup creates a new WaitGroup.
 pub fn new_waitgroup() &WaitGroup {
 	mut wg := WaitGroup{}
@@ -100,8 +116,5 @@ pub fn (mut wg WaitGroup) wait() {
 // Calls to wg.go() should happen before the call to wg.wait().
 pub fn (mut wg WaitGroup) go(f fn ()) {
 	wg.add(1)
-	spawn fn (mut wg WaitGroup, f fn ()) {
-		f()
-		wg.done()
-	}(mut wg, f)
+	start_waitgroup_thread(mut wg, f)
 }

--- a/vlib/sync/waitgroup.c.v
+++ b/vlib/sync/waitgroup.c.v
@@ -36,18 +36,35 @@ mut:
 
 struct WaitGroupThreadArgs {
 mut:
-	wg &WaitGroup
-	f  fn () = unsafe { nil }
+	wg             &WaitGroup
+	f              fn () = unsafe { nil }
+	prealloc_scope voidptr
 }
 
 fn new_waitgroup_thread_args(wg &WaitGroup, f fn ()) &WaitGroupThreadArgs {
-	mut args := unsafe { &WaitGroupThreadArgs(C.calloc(1, sizeof(WaitGroupThreadArgs))) }
+	// Keep the wait group and captured callback context visible to tracing collectors.
+	mut args := unsafe { &WaitGroupThreadArgs(vcalloc(sizeof(WaitGroupThreadArgs))) }
 	if args == unsafe { nil } {
 		panic('could not allocate waitgroup thread arguments')
 	}
 	args.wg = wg
 	args.f = f
+	$if prealloc {
+		args.prealloc_scope = unsafe { prealloc_scope_retain_current() }
+	}
 	return args
+}
+
+fn free_waitgroup_thread_args(args &WaitGroupThreadArgs) {
+	$if prealloc {
+		scope := args.prealloc_scope
+		unsafe {
+			prealloc_scope_release(scope)
+		}
+	}
+	unsafe {
+		free(args)
+	}
 }
 
 // new_waitgroup creates a new WaitGroup.

--- a/vlib/sync/waitgroup_nix.c.v
+++ b/vlib/sync/waitgroup_nix.c.v
@@ -1,0 +1,36 @@
+module sync
+
+#insert "@VEXEROOT/vlib/sync/thread_helper.h"
+
+fn C.v_sync_thread_create_detached(voidptr, voidptr) int
+
+fn waitgroup_thread_entry(args_ptr voidptr) voidptr {
+	args := unsafe { &WaitGroupThreadArgs(args_ptr) }
+	$if prealloc {
+		scope := unsafe { prealloc_scope_begin() }
+		defer {
+			unsafe {
+				prealloc_scope_end(scope)
+			}
+		}
+	}
+	args.f()
+	mut wg := args.wg
+	wg.done()
+	unsafe {
+		C.free(args)
+	}
+	return unsafe { nil }
+}
+
+fn start_waitgroup_thread(mut wg WaitGroup, f fn ()) {
+	args := new_waitgroup_thread_args(&wg, f)
+	result := C.v_sync_thread_create_detached(voidptr(waitgroup_thread_entry), voidptr(args))
+	if result != 0 {
+		wg.done()
+		unsafe {
+			C.free(args)
+		}
+		panic('could not start waitgroup task: error ${result}')
+	}
+}

--- a/vlib/sync/waitgroup_nix.c.v
+++ b/vlib/sync/waitgroup_nix.c.v
@@ -17,9 +17,7 @@ fn waitgroup_thread_entry(args_ptr voidptr) voidptr {
 	args.f()
 	mut wg := args.wg
 	wg.done()
-	unsafe {
-		C.free(args)
-	}
+	free_waitgroup_thread_args(args)
 	return unsafe { nil }
 }
 
@@ -28,9 +26,7 @@ fn start_waitgroup_thread(mut wg WaitGroup, f fn ()) {
 	result := C.v_sync_thread_create_detached(voidptr(waitgroup_thread_entry), voidptr(args))
 	if result != 0 {
 		wg.done()
-		unsafe {
-			C.free(args)
-		}
+		free_waitgroup_thread_args(args)
 		panic('could not start waitgroup task: error ${result}')
 	}
 }

--- a/vlib/sync/waitgroup_test.v
+++ b/vlib/sync/waitgroup_test.v
@@ -2,7 +2,6 @@
 // vtest flaky: true
 module sync
 
-import time
 import sync.stdatomic
 
 fn issue_6870_worker(mut wg WaitGroup, ready chan bool, release chan bool) {
@@ -28,7 +27,7 @@ fn test_waitgroup_reuse() {
 		unsafe {
 			*(&bool(executed)) = true
 		}
-		time.sleep(100 * time.millisecond)
+		sync_sleep_nanoseconds(100_000_000)
 	}(mut wg, voidptr(&executed))
 
 	wg.wait()
@@ -40,7 +39,7 @@ fn test_waitgroup_no_use() {
 	watchdog := spawn fn (done chan bool) {
 		select {
 			_ := <-done {}
-			10 * time.second {
+			i64(10_000_000_000) {
 				panic('test_waitgroup_no_use did not complete in time')
 			}
 		}
@@ -86,7 +85,7 @@ fn test_waitgroup_add_while_waiting() {
 		for _ in 0 .. 8 {
 			select {
 				_ := <-wait_done {}
-				2 * time.second {
+				i64(2_000_000_000) {
 					assert false, 'wait() missed a wakeup while work added more tasks'
 				}
 			}

--- a/vlib/sync/waitgroup_windows.c.v
+++ b/vlib/sync/waitgroup_windows.c.v
@@ -1,0 +1,36 @@
+module sync
+
+#insert "@VEXEROOT/vlib/sync/thread_helper.h"
+
+fn C.v_sync_thread_create_detached(voidptr, voidptr) int
+
+fn waitgroup_thread_entry(args_ptr voidptr) u32 {
+	args := unsafe { &WaitGroupThreadArgs(args_ptr) }
+	$if prealloc {
+		scope := unsafe { prealloc_scope_begin() }
+		defer {
+			unsafe {
+				prealloc_scope_end(scope)
+			}
+		}
+	}
+	args.f()
+	mut wg := args.wg
+	wg.done()
+	unsafe {
+		C.free(args)
+	}
+	return 0
+}
+
+fn start_waitgroup_thread(mut wg WaitGroup, f fn ()) {
+	args := new_waitgroup_thread_args(&wg, f)
+	result := C.v_sync_thread_create_detached(voidptr(waitgroup_thread_entry), voidptr(args))
+	if result != 0 {
+		wg.done()
+		unsafe {
+			C.free(args)
+		}
+		panic('could not start waitgroup task: error ${result}')
+	}
+}

--- a/vlib/sync/waitgroup_windows.c.v
+++ b/vlib/sync/waitgroup_windows.c.v
@@ -17,9 +17,7 @@ fn waitgroup_thread_entry(args_ptr voidptr) u32 {
 	args.f()
 	mut wg := args.wg
 	wg.done()
-	unsafe {
-		C.free(args)
-	}
+	free_waitgroup_thread_args(args)
 	return 0
 }
 
@@ -28,9 +26,7 @@ fn start_waitgroup_thread(mut wg WaitGroup, f fn ()) {
 	result := C.v_sync_thread_create_detached(voidptr(waitgroup_thread_entry), voidptr(args))
 	if result != 0 {
 		wg.done()
-		unsafe {
-			C.free(args)
-		}
+		free_waitgroup_thread_args(args)
 		panic('could not start waitgroup task: error ${result}')
 	}
 }

--- a/vlib/time/README.md
+++ b/vlib/time/README.md
@@ -86,3 +86,20 @@ fn main() {
 	println('Note: do_something() took: ${sw.elapsed().milliseconds()} ms')
 }
 ```
+
+Use a timer when a wait needs to participate in a `select`:
+
+```v
+import time
+
+timer := time.new_timer(500 * time.millisecond)
+defer {
+	timer.stop()
+}
+select {
+	fired_at := <-timer.c {
+		println('timer fired at ${fired_at}')
+	}
+	// another channel can be handled here
+}
+```

--- a/vlib/time/timer.c.v
+++ b/vlib/time/timer.c.v
@@ -1,0 +1,72 @@
+module time
+
+// Timer sends the current time on `c` after its duration elapses.
+pub struct Timer {
+	stop chan chan bool
+	done chan bool
+pub:
+	c chan Time
+}
+
+struct TimerThreadArgs {
+mut:
+	duration Duration
+	output   chan Time
+	stop     chan chan bool
+	done     chan bool
+}
+
+fn new_timer_thread_args(duration Duration, output chan Time, stop chan chan bool, done chan bool) &TimerThreadArgs {
+	mut args := unsafe { &TimerThreadArgs(C.calloc(1, sizeof(TimerThreadArgs))) }
+	if args == unsafe { nil } {
+		panic('could not allocate timer thread arguments')
+	}
+	args.duration = duration
+	args.output = output
+	args.stop = stop
+	args.done = done
+	return args
+}
+
+// new_timer creates a Timer that sends the current time on its unbuffered channel after `duration`.
+pub fn new_timer(duration Duration) &Timer {
+	timer := &Timer{
+		c:    chan Time{}
+		stop: chan chan bool{}
+		done: chan bool{}
+	}
+	start_timer(duration, timer.c, timer.stop, timer.done)
+	return timer
+}
+
+fn run_timer(duration Duration, output chan Time, stop chan chan bool, done chan bool) {
+	defer {
+		done.close()
+	}
+	select {
+		reply := <-stop {
+			reply <- true
+			return
+		}
+		duration {}
+	}
+	fired_at := now()
+	select {
+		reply := <-stop {
+			reply <- true
+		}
+		output <- fired_at {}
+	}
+}
+
+// stop prevents the Timer from firing and reports whether it stopped an active timer.
+pub fn (timer &Timer) stop() bool {
+	reply := chan bool{cap: 1}
+	select {
+		timer.stop <- reply {}
+		_ := <-timer.done {
+			return false
+		}
+	}
+	return <-reply
+}

--- a/vlib/time/timer.c.v
+++ b/vlib/time/timer.c.v
@@ -10,14 +10,16 @@ pub:
 
 struct TimerThreadArgs {
 mut:
-	duration Duration
-	output   chan Time
-	stop     chan chan bool
-	done     chan bool
+	duration       Duration
+	output         chan Time
+	stop           chan chan bool
+	done           chan bool
+	prealloc_scope voidptr
 }
 
 fn new_timer_thread_args(duration Duration, output chan Time, stop chan chan bool, done chan bool) &TimerThreadArgs {
-	mut args := unsafe { &TimerThreadArgs(C.calloc(1, sizeof(TimerThreadArgs))) }
+	// Keep the channels visible to tracing collectors until the detached worker finishes.
+	mut args := unsafe { &TimerThreadArgs(vcalloc(sizeof(TimerThreadArgs))) }
 	if args == unsafe { nil } {
 		panic('could not allocate timer thread arguments')
 	}
@@ -25,7 +27,22 @@ fn new_timer_thread_args(duration Duration, output chan Time, stop chan chan boo
 	args.output = output
 	args.stop = stop
 	args.done = done
+	$if prealloc {
+		args.prealloc_scope = unsafe { prealloc_scope_retain_current() }
+	}
 	return args
+}
+
+fn free_timer_thread_args(args &TimerThreadArgs) {
+	$if prealloc {
+		scope := args.prealloc_scope
+		unsafe {
+			prealloc_scope_release(scope)
+		}
+	}
+	unsafe {
+		free(args)
+	}
 }
 
 // new_timer creates a Timer that sends the current time on its unbuffered channel after `duration`.

--- a/vlib/time/timer_nix.c.v
+++ b/vlib/time/timer_nix.c.v
@@ -1,0 +1,33 @@
+module time
+
+#insert "@VEXEROOT/vlib/sync/thread_helper.h"
+
+fn C.v_sync_thread_create_detached(voidptr, voidptr) int
+
+fn timer_thread_entry(args_ptr voidptr) voidptr {
+	args := unsafe { &TimerThreadArgs(args_ptr) }
+	$if prealloc {
+		scope := unsafe { prealloc_scope_begin() }
+		defer {
+			unsafe {
+				prealloc_scope_end(scope)
+			}
+		}
+	}
+	run_timer(args.duration, args.output, args.stop, args.done)
+	unsafe {
+		C.free(args)
+	}
+	return unsafe { nil }
+}
+
+fn start_timer(duration Duration, output chan Time, stop chan chan bool, done chan bool) {
+	args := new_timer_thread_args(duration, output, stop, done)
+	result := C.v_sync_thread_create_detached(voidptr(timer_thread_entry), voidptr(args))
+	if result != 0 {
+		unsafe {
+			C.free(args)
+		}
+		panic('could not start timer: error ${result}')
+	}
+}

--- a/vlib/time/timer_nix.c.v
+++ b/vlib/time/timer_nix.c.v
@@ -15,9 +15,7 @@ fn timer_thread_entry(args_ptr voidptr) voidptr {
 		}
 	}
 	run_timer(args.duration, args.output, args.stop, args.done)
-	unsafe {
-		C.free(args)
-	}
+	free_timer_thread_args(args)
 	return unsafe { nil }
 }
 
@@ -25,9 +23,7 @@ fn start_timer(duration Duration, output chan Time, stop chan chan bool, done ch
 	args := new_timer_thread_args(duration, output, stop, done)
 	result := C.v_sync_thread_create_detached(voidptr(timer_thread_entry), voidptr(args))
 	if result != 0 {
-		unsafe {
-			C.free(args)
-		}
+		free_timer_thread_args(args)
 		panic('could not start timer: error ${result}')
 	}
 }

--- a/vlib/time/timer_test.v
+++ b/vlib/time/timer_test.v
@@ -1,0 +1,26 @@
+module time
+
+fn test_timer_fires_once() {
+	timer := new_timer(10 * millisecond)
+	select {
+		fired_at := <-timer.c {
+			assert fired_at.unix() > 0
+		}
+		1 * second {
+			assert false, 'timer did not fire'
+		}
+	}
+	assert !timer.stop()
+}
+
+fn test_timer_stop_prevents_firing() {
+	timer := new_timer(1 * second)
+	assert timer.stop()
+	assert !timer.stop()
+	select {
+		_ := <-timer.c {
+			assert false, 'stopped timer fired'
+		}
+		20 * millisecond {}
+	}
+}

--- a/vlib/time/timer_windows.c.v
+++ b/vlib/time/timer_windows.c.v
@@ -15,9 +15,7 @@ fn timer_thread_entry(args_ptr voidptr) u32 {
 		}
 	}
 	run_timer(args.duration, args.output, args.stop, args.done)
-	unsafe {
-		C.free(args)
-	}
+	free_timer_thread_args(args)
 	return 0
 }
 
@@ -25,9 +23,7 @@ fn start_timer(duration Duration, output chan Time, stop chan chan bool, done ch
 	args := new_timer_thread_args(duration, output, stop, done)
 	result := C.v_sync_thread_create_detached(voidptr(timer_thread_entry), voidptr(args))
 	if result != 0 {
-		unsafe {
-			C.free(args)
-		}
+		free_timer_thread_args(args)
 		panic('could not start timer: error ${result}')
 	}
 }

--- a/vlib/time/timer_windows.c.v
+++ b/vlib/time/timer_windows.c.v
@@ -1,0 +1,33 @@
+module time
+
+#insert "@VEXEROOT/vlib/sync/thread_helper.h"
+
+fn C.v_sync_thread_create_detached(voidptr, voidptr) int
+
+fn timer_thread_entry(args_ptr voidptr) u32 {
+	args := unsafe { &TimerThreadArgs(args_ptr) }
+	$if prealloc {
+		scope := unsafe { prealloc_scope_begin() }
+		defer {
+			unsafe {
+				prealloc_scope_end(scope)
+			}
+		}
+	}
+	run_timer(args.duration, args.output, args.stop, args.done)
+	unsafe {
+		C.free(args)
+	}
+	return 0
+}
+
+fn start_timer(duration Duration, output chan Time, stop chan chan bool, done chan bool) {
+	args := new_timer_thread_args(duration, output, stop, done)
+	result := C.v_sync_thread_create_detached(voidptr(timer_thread_entry), voidptr(args))
+	if result != 0 {
+		unsafe {
+			C.free(args)
+		}
+		panic('could not start timer: error ${result}')
+	}
+}

--- a/vlib/v/checker/return.v
+++ b/vlib/v/checker/return.v
@@ -350,6 +350,7 @@ fn (mut c Checker) return_stmt(mut node ast.Return) {
 			&& !c.table.unaliased_type(got_type).is_any_kind_of_pointer()
 			&& got_type != ast.int_literal_type && !c.pref.translated && !c.file.is_translated {
 			if exprv.is_auto_deref_var() {
+				c.mark_as_referenced(mut &node.exprs[expr_idxs[i]], false)
 				continue
 			}
 			if c.table.final_sym(exp_type).kind == .interface
@@ -364,7 +365,11 @@ fn (mut c Checker) return_stmt(mut node ast.Return) {
 			r_expr := node.exprs[expr_idxs[i]]
 			if r_expr is ast.Ident {
 				mut ident_expr := r_expr
-				c.fail_if_stack_struct_action_outside_unsafe(mut ident_expr, 'returned')
+				if node.exprs[expr_idxs[i]].is_auto_deref_var() {
+					c.mark_as_referenced(mut &node.exprs[expr_idxs[i]], false)
+				} else {
+					c.fail_if_stack_struct_action_outside_unsafe(mut ident_expr, 'returned')
+				}
 			} else if r_expr is ast.PrefixExpr && r_expr.op == .amp {
 				// &var
 				if r_expr.right is ast.Ident {

--- a/vlib/v/checker/tests/no_heap_struct.out
+++ b/vlib/v/checker/tests/no_heap_struct.out
@@ -5,6 +5,13 @@ vlib/v/checker/tests/no_heap_struct.vv:13:6: error: `x` cannot be assigned outsi
       |            ^
    14 |     }
    15 |     return s
+vlib/v/checker/tests/no_heap_struct.vv:19:9: error: `x` cannot be referenced outside `unsafe` blocks as it might be stored on stack. Consider declaring `Abc` as `@[heap]`.
+   17 |
+   18 | fn g(mut x Abc) &Abc {
+   19 |     return x
+      |            ^
+   20 | }
+   21 |
 vlib/v/checker/tests/no_heap_struct.vv:23:7: error: `x` cannot be assigned outside `unsafe` blocks as it might refer to an object stored on stack. Consider declaring `Abc` as `@[heap]`.
    21 | 
    22 | fn h(x &Abc) &Abc {

--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -1411,7 +1411,7 @@ fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 			// `resolved_expr_type` returns the smartcasted (unwrapped) type for variables
 			// inside `if x != none` blocks, but the C variable is still the option type
 			// and needs option wrapping on assignment.
-			if orig_var_option && !var_type.has_flag(.option) {
+			if orig_var_option && g.is_smartcast_assign_lhs(left) && !var_type.has_flag(.option) {
 				var_type = var_type.set_flag(.option)
 			}
 			resolved_val_type := g.resolved_expr_type(val, val_type)

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -1329,6 +1329,9 @@ pub fn (mut g Gen) init() {
 		}
 		g.comptime_definitions.writeln('')
 	}
+	g.comptime_definitions.writeln('#ifndef V_THREAD_STACK_SIZE')
+	g.comptime_definitions.writeln('#define V_THREAD_STACK_SIZE ${g.pref.thread_stack_size}')
+	g.comptime_definitions.writeln('#endif')
 	if g.table.gostmts > 0 {
 		g.comptime_definitions.writeln('#define __VTHREADS__ (1)')
 	}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -2845,6 +2845,15 @@ fn (g &Gen) fixed_array_base_elem_sym(typ ast.Type) &ast.TypeSymbol {
 }
 
 pub fn (mut g Gen) write_typedef_types() {
+	if g.pref.skip_unused {
+		mut visited := map[int]bool{}
+		for sym in g.table.type_symbols {
+			if sym.kind == .alias && sym.idx in g.table.used_features.used_syms
+				&& sym.info is ast.Alias {
+				g.mark_used_alias_parent_types(sym.info.parent_type, mut visited)
+			}
+		}
+	}
 	type_symbols := g.table.type_symbols.filter(!it.is_builtin
 		&& it.kind in [.array, .array_fixed, .chan, .map])
 	for sym in type_symbols {
@@ -2874,7 +2883,16 @@ pub fn (mut g Gen) write_typedef_types() {
 				} else {
 					continue
 				}
-				if g.typedef_type_has_unresolved_generic_placeholder_parts(info.elem_type) {
+				elem_sym := g.table.sym(info.elem_type)
+				has_unresolved_generic_parts :=
+					g.typedef_type_has_unresolved_generic_placeholder_parts(info.elem_type)
+				if has_unresolved_generic_parts && elem_sym.info is ast.Map {
+					if info.size > 0 && !info.is_fn_ret {
+						g.type_definitions.writeln('typedef map ${sym.cname} [${info.size}];')
+					}
+					continue
+				}
+				if has_unresolved_generic_parts {
 					continue
 				}
 				base_elem_sym := g.fixed_array_base_elem_sym(info.elem_type)
@@ -2984,6 +3002,28 @@ pub fn (mut g Gen) write_typedef_types() {
 	}
 }
 
+fn (mut g Gen) mark_used_alias_parent_types(typ ast.Type, mut visited map[int]bool) {
+	if typ == 0 || visited[typ.idx()] {
+		return
+	}
+	visited[typ.idx()] = true
+	g.table.used_features.used_syms[typ.idx()] = true
+	sym := g.table.sym(typ)
+	match sym.info {
+		ast.Alias {
+			g.mark_used_alias_parent_types(sym.info.parent_type, mut visited)
+		}
+		ast.Array, ast.ArrayFixed, ast.Chan {
+			g.mark_used_alias_parent_types(sym.info.elem_type, mut visited)
+		}
+		ast.Map {
+			g.mark_used_alias_parent_types(sym.info.key_type, mut visited)
+			g.mark_used_alias_parent_types(sym.info.value_type, mut visited)
+		}
+		else {}
+	}
+}
+
 // emit_alias_typedef_chain emits parent alias typedefs before child ones so a
 // chain like `type Main = A; type A = B; type B = string` ends up as
 // `typedef string B; typedef B A; typedef A Main;` in declaration order.
@@ -3022,9 +3062,8 @@ pub fn (mut g Gen) write_alias_typesymbol_declaration(sym ast.TypeSymbol) {
 			parent_styp = g.styp(sym.info.parent_type)
 			// Chained aliases (#27055): if the parent is itself an alias whose
 			// ultimate base is a fixed array of non-builtin elements, the parent
-			// typedef has been deferred to `alias_definitions` so this child
-			// must also be deferred — otherwise `typedef Parent Child;` lands
-			// in `type_definitions` before `Parent` exists.
+			// typedef is emitted by `write_types`, so this child must be emitted
+			// there too.
 			mut walk_typ := sym.info.parent_type
 			for {
 				walk_sym := g.table.sym(walk_typ)
@@ -3088,10 +3127,31 @@ pub fn (mut g Gen) write_alias_typesymbol_declaration(sym ast.TypeSymbol) {
 		return
 	}
 	if is_fixed_array_of_non_builtin {
-		g.alias_definitions.writeln('typedef ${parent_styp} ${sym.cname};')
+		// write_types emits this alias after its fixed-array parent.
+		return
 	} else {
 		g.type_definitions.writeln('typedef ${parent_styp} ${sym.cname};')
 	}
+}
+
+fn (g &Gen) alias_is_fixed_array_of_non_builtin(sym ast.TypeSymbol) bool {
+	if sym.info !is ast.Alias {
+		return false
+	}
+	alias_info := sym.info as ast.Alias
+	mut typ := alias_info.parent_type
+	for {
+		type_sym := g.table.sym(typ)
+		if type_sym.info is ast.Alias {
+			typ = type_sym.info.parent_type
+			continue
+		}
+		if type_sym.info is ast.ArrayFixed {
+			return !g.fixed_array_base_elem_sym(type_sym.info.elem_type).is_builtin()
+		}
+		return false
+	}
+	return false
 }
 
 pub fn (mut g Gen) write_interface_typedef(sym ast.TypeSymbol) {
@@ -12727,6 +12787,12 @@ fn (mut g Gen) write_types(symbols []&ast.TypeSymbol) {
 					}
 				}
 			}
+			ast.Alias {
+				if g.alias_is_fixed_array_of_non_builtin(sym) {
+					parent_styp := g.styp(sym.info.parent_type)
+					g.type_definitions.writeln('typedef ${parent_styp} ${sym.cname};')
+				}
+			}
 			else {}
 		}
 	}
@@ -12859,6 +12925,13 @@ fn (mut g Gen) sort_structs(typesa []&ast.TypeSymbol) []&ast.TypeSymbol {
 						}
 						field_deps << xdep
 					}
+				}
+			}
+			ast.Alias {
+				parent_sym := g.table.sym(sym.info.parent_type)
+				dep := parent_sym.scoped_name()
+				if dep in type_names {
+					field_deps << dep
 				}
 			}
 			ast.SumType {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -12788,7 +12788,8 @@ fn (mut g Gen) write_types(symbols []&ast.TypeSymbol) {
 				}
 			}
 			ast.Alias {
-				if g.alias_is_fixed_array_of_non_builtin(sym) {
+				if (!g.pref.skip_unused || sym.idx in g.table.used_features.used_syms)
+					&& g.alias_is_fixed_array_of_non_builtin(sym) {
 					parent_styp := g.styp(sym.info.parent_type)
 					g.type_definitions.writeln('typedef ${parent_styp} ${sym.cname};')
 				}

--- a/vlib/v/gen/c/thread_bool_wait_codegen_test.v
+++ b/vlib/v/gen/c/thread_bool_wait_codegen_test.v
@@ -49,6 +49,40 @@ fn test_prealloc_spawn_args_use_c_malloc() {
 	assert res.output.contains('free(ret_ptr);'), res.output
 }
 
+fn test_detached_runtime_threads_use_configured_stack_size() {
+	tmp_dir := os.join_path(os.vtmp_dir(), 'detached_thread_stack_size_test_${os.getpid()}')
+	os.mkdir_all(tmp_dir)!
+	defer {
+		os.rmdir_all(tmp_dir) or {}
+	}
+	source_path := os.join_path(os.real_path(tmp_dir), 'detached_thread_stack_size.vv')
+	os.write_file(source_path,
+		'import sync\nimport time\n\nfn work() {}\n\nfn main() {\n\tmut wg := sync.new_waitgroup()\n\twg.go(work)\n\twg.wait()\n\ttimer := time.new_timer(time.nanosecond)\n\t_ = <-timer.c\n}\n')!
+	cmd := '${os.quoted_path(thread_bool_wait_codegen_vexe)} -thread-stack-size 4194304 -o - ${os.quoted_path(source_path)}'
+	res := os.execute(cmd)
+	assert res.exit_code == 0, '${cmd}\n${res.output}'
+	stack_size_define := '#define V_THREAD_STACK_SIZE 4194304'
+	define_idx := res.output.index(stack_size_define) or {
+		assert false, res.output
+		return
+	}
+	windows_use_idx := res.output.index('CreateThread(NULL, V_THREAD_STACK_SIZE') or {
+		assert false, res.output
+		return
+	}
+	pthread_use_idx := res.output.index('pthread_attr_setstacksize(&attr, V_THREAD_STACK_SIZE)') or {
+		assert false, res.output
+		return
+	}
+	assert define_idx < windows_use_idx
+	assert define_idx < pthread_use_idx
+
+	i386_cmd := '${os.quoted_path(thread_bool_wait_codegen_vexe)} -arch i386 -o - ${os.quoted_path(source_path)}'
+	i386_res := os.execute(i386_cmd)
+	assert i386_res.exit_code == 0, '${i386_cmd}\n${i386_res.output}'
+	assert i386_res.output.contains('#define V_THREAD_STACK_SIZE 2097152'), i386_res.output
+}
+
 fn find_generated_c_line(lines []string, needle string, start int) int {
 	for idx := start; idx < lines.len; idx++ {
 		if lines[idx] == needle {

--- a/vlib/v/gen/c/utils.v
+++ b/vlib/v/gen/c/utils.v
@@ -1640,7 +1640,8 @@ fn (mut g Gen) resolved_expr_type(expr ast.Expr, default_typ ast.Type) ast.Type 
 							struct_init_typ_str := expr.obj.expr.typ_str.all_after_last('.')
 							idx := generic_names.index(struct_init_typ_str)
 							if idx >= 0 && idx < g.cur_concrete_types.len {
-								return g.cur_concrete_types[idx]
+								return generic_struct_init_type(g.cur_concrete_types[idx],
+									expr.obj.expr.typ)
 							}
 						}
 						return scope_type
@@ -1980,7 +1981,7 @@ fn (mut g Gen) resolved_expr_type(expr ast.Expr, default_typ ast.Type) ast.Type 
 				short_name := expr.typ_str.all_after_last('.')
 				idx := generic_names.index(short_name)
 				if idx >= 0 && idx < g.cur_concrete_types.len {
-					return g.cur_concrete_types[idx]
+					return generic_struct_init_type(g.cur_concrete_types[idx], expr.typ)
 				}
 			}
 			// In generic contexts, use generic_typ to allow resolution via
@@ -2081,6 +2082,17 @@ fn (mut g Gen) resolved_expr_type(expr ast.Expr, default_typ ast.Type) ast.Type 
 		return g.unwrap_generic(resolved)
 	}
 	return g.unwrap_generic(default_typ)
+}
+
+fn generic_struct_init_type(concrete_type ast.Type, generic_type ast.Type) ast.Type {
+	mut resolved_type := concrete_type.clear_flag(.generic)
+	if generic_type.has_flag(.option) {
+		resolved_type = resolved_type.set_flag(.option)
+	}
+	if generic_type.has_flag(.result) {
+		resolved_type = resolved_type.set_flag(.result)
+	}
+	return resolved_type
 }
 
 struct Type {

--- a/vlib/v/tests/aliases/fixed_array_alias_generic_map_issue_27897_test.v
+++ b/vlib/v/tests/aliases/fixed_array_alias_generic_map_issue_27897_test.v
@@ -1,0 +1,9 @@
+type GenericKeyMaps = [4]map[T]string
+type GenericValueMaps = [4]map[string]T
+
+fn test_fixed_array_alias_of_generic_maps() {
+	key_maps := GenericKeyMaps{}
+	value_maps := GenericValueMaps{}
+	assert key_maps.len == 4
+	assert value_maps.len == 4
+}

--- a/vlib/v/tests/aliases/fixed_array_alias_non_primitive_issue_27895_test.v
+++ b/vlib/v/tests/aliases/fixed_array_alias_non_primitive_issue_27895_test.v
@@ -1,0 +1,17 @@
+type Palette = [4]Color
+
+enum Color {
+	red
+	green
+	blue
+}
+
+struct Setup {
+	palette Palette
+}
+
+fn test_fixed_array_alias_of_enum_as_struct_field() {
+	setup := Setup{}
+	assert setup.palette.len == 4
+	assert setup.palette[0] == .red
+}

--- a/vlib/v/tests/aliases/fixed_array_alias_non_primitive_issue_27895_test.v
+++ b/vlib/v/tests/aliases/fixed_array_alias_non_primitive_issue_27895_test.v
@@ -10,6 +10,14 @@ struct Setup {
 	palette Palette
 }
 
+// This alias is intentionally unused. Its fixed-array parent should be omitted
+// together with the alias when skip_unused is enabled.
+type UnusedPalette = [3]UnusedColor
+
+enum UnusedColor {
+	black
+}
+
 fn test_fixed_array_alias_of_enum_as_struct_field() {
 	setup := Setup{}
 	assert setup.palette.len == 4

--- a/vlib/v/tests/generics/generic_option_callback_assignment_issue_27876_test.v
+++ b/vlib/v/tests/generics/generic_option_callback_assignment_issue_27876_test.v
@@ -1,0 +1,18 @@
+fn run_option_callback[T](callback fn () T) ?T {
+	mut result := T{}
+	result = callback()
+	return result
+}
+
+fn plain_int_callback() int {
+	return 42
+}
+
+fn option_int_callback() ?int {
+	return 42
+}
+
+fn test_generic_callback_assignment_uses_current_instantiation_types() {
+	assert run_option_callback(plain_int_callback)? == 42
+	assert run_option_callback(option_int_callback)? == 42
+}

--- a/vlib/v/tests/generics/generic_option_struct_init_issue_27878_test.v
+++ b/vlib/v/tests/generics/generic_option_struct_init_issue_27878_test.v
@@ -1,0 +1,8 @@
+fn generic_option_default[T]() ?T {
+	mut opt := ?T{}
+	return opt
+}
+
+fn test_generic_option_struct_init_preserves_option_flag() {
+	assert generic_option_default[int]()? == 0
+}

--- a/vlib/v/tests/pointers/implicit_reference_return_heap_mut_receiver_test.v
+++ b/vlib/v/tests/pointers/implicit_reference_return_heap_mut_receiver_test.v
@@ -1,0 +1,18 @@
+@[heap]
+struct HeapItem {
+mut:
+	value int
+}
+
+fn (mut item HeapItem) reference() &HeapItem {
+	return item
+}
+
+fn test_implicit_reference_return_from_heap_mut_receiver() {
+	mut item := HeapItem{
+		value: 1
+	}
+	mut reference := item.reference()
+	reference.value = 2
+	assert item.value == 2
+}

--- a/vlib/v3/README.md
+++ b/vlib/v3/README.md
@@ -43,10 +43,12 @@ On macOS it uses physical footprint, matching Activity Monitor more closely; els
 current RSS. Pass `-no-memory-limit`/`--no-memory-limit` to disable this safety limit.
 On macOS, each stage benchmark prints physical footprint immediately after RSS.
 
-Generated C represents `thread` values with a typed wrapper around `pthread_t`. `spawn` uses the
-platform's default thread stack and checks allocation, thread creation, and join failures. Since
-V's `spawn` expression has no error return, these runtime failures print a diagnostic and abort;
-packed arguments are released if thread creation fails.
+Generated C represents `thread` values with a typed wrapper around `pthread_t`. `spawn` and
+detached standard-library workers use the target's default thread stack (8 MiB on 64-bit targets
+and 2 MiB on 32-bit targets); `-thread-stack-size <bytes>` overrides it. Thread allocation,
+creation, and join failures are checked. Since V's `spawn` expression has no error return, these
+runtime failures print a diagnostic and abort; packed arguments are released if thread creation
+fails.
 
 The type system (`types/`) uses a `Type` sum type with 20 variants instead of
 string-based type checks. Primitive types use a `Properties` flag enum with

--- a/vlib/v3/fixturetest/fixturetest.v
+++ b/vlib/v3/fixturetest/fixturetest.v
@@ -255,7 +255,7 @@ fn name_matches_filters(name string, path string, filters []string) bool {
 
 fn forwarded_compiler_options(args []string) []string {
 	value_options := ['-o', '-b', '-os', '-arch', '-compile-backend', '--compile-backend', '-d',
-		'-gc', '-cc', '-cflags']
+		'-gc', '-cc', '-cflags', '-thread-stack-size']
 	runner_options := ['-silent', '-no-parallel', '--no-parallel', '-nocache', '--no-cache',
 		'-checker-fixture']
 	mut options := []string{cap: args.len}

--- a/vlib/v3/fixturetest/fixturetest_test.v
+++ b/vlib/v3/fixturetest/fixturetest_test.v
@@ -108,9 +108,10 @@ fn test_environment_specific_fixture_exclusions_match_reference_runner() {
 
 fn test_forwarded_compiler_options_preserve_configuration_flags() {
 	args := ['-silent', '-cc', 'clang', '-d', 'test', '-dfoo', '-o', 'ignored-output', 'test',
-		'/checkout/vlib/v/checker/tests', '-os', 'windows', '-no-parallel', '-keepc']
+		'/checkout/vlib/v/checker/tests', '-os', 'windows', '-thread-stack-size', '4194304',
+		'-no-parallel', '-keepc']
 	assert forwarded_compiler_options(args) == ['-cc', 'clang', '-d', 'test', '-dfoo', '-os',
-		'windows', '-keepc']
+		'windows', '-thread-stack-size', '4194304', '-keepc']
 }
 
 fn test_run_autofixes_missing_and_mismatched_output() {

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -236,6 +236,7 @@ mut:
 	compiler_vroot               string
 	compiler_vexe                string
 	target                       pref.Target
+	thread_stack_size            int = 8 * 1024 * 1024
 	compile_values               map[string]string // explicit `-d` values used by `$d(...)` in `#flag`s
 	output_path                  string
 	output_error                 string
@@ -866,6 +867,11 @@ pub fn (mut g FlatGen) set_compiler_vexe(path string) {
 // set_target sets the canonical code-generation target.
 pub fn (mut g FlatGen) set_target(target pref.Target) {
 	g.target = target
+}
+
+// set_thread_stack_size configures the stack size used by generated worker threads.
+pub fn (mut g FlatGen) set_thread_stack_size(size int) {
+	g.thread_stack_size = size
 }
 
 // set_compile_values records explicit `-d` values so `$d(...)` inside `#flag`
@@ -1924,6 +1930,7 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	// Leave headroom for the small body-dependent supplement emitted below.
 	g.sb.ensure_cap(known_output_len + 1_048_576) // 1 MiB
 	g.c99_feature_test_macros()
+	g.thread_stack_size_definition()
 	g.emit_preserved_c_directives()
 	g.preamble()
 	if g.cache_split {
@@ -12569,7 +12576,7 @@ fn (mut g FlatGen) system_libc_preamble() {
 	g.writeln('static bool __v_thread_equal(__v_thread a, __v_thread b) { return a.handle == b.handle; }')
 	g.writeln('typedef void* (*__v_thread_start_fn)(void*);')
 	g.writeln('typedef struct { __v_thread_start_fn start; void* arg; void* result; } __v_windows_thread_context;')
-	g.writeln('static const size_t __v_thread_stack_size = 8388608;')
+	g.writeln('static const size_t __v_thread_stack_size = V_THREAD_STACK_SIZE;')
 	g.writeln('static void* __v_thread_alloc(size_t size) { void* p = malloc(size); if (!p) { fprintf(stderr, "V thread allocation failed\\n"); abort(); } return p; }')
 	g.writeln('static DWORD WINAPI __v_windows_thread_start(void* raw_context) { __v_windows_thread_context* context = (__v_windows_thread_context*)raw_context; context->result = context->start(context->arg); return 0; }')
 	g.writeln('static __v_thread __v_thread_spawn(__v_thread_start_fn start, void* arg, void (*cleanup)(void*)) {')
@@ -12593,7 +12600,7 @@ fn (mut g FlatGen) system_libc_preamble() {
 	g.writeln('typedef struct { pthread_t handle; } __v_thread;')
 	g.writeln('static bool __v_thread_equal(__v_thread a, __v_thread b) { return pthread_equal(a.handle, b.handle) != 0; }')
 	g.writeln('typedef void* (*__v_thread_start_fn)(void*);')
-	g.writeln('static const size_t __v_thread_stack_size = 8388608;')
+	g.writeln('static const size_t __v_thread_stack_size = V_THREAD_STACK_SIZE;')
 	g.writeln('static void* __v_thread_alloc(size_t size) { void* p = malloc(size); if (!p) { fprintf(stderr, "V thread allocation failed\\n"); abort(); } return p; }')
 	g.writeln('static __v_thread __v_thread_spawn(__v_thread_start_fn start, void* arg, void (*cleanup)(void*)) {')
 	g.writeln('\t__v_thread result;')
@@ -12609,6 +12616,12 @@ fn (mut g FlatGen) system_libc_preamble() {
 	g.writeln('\treturn result;')
 	g.writeln('}')
 	g.writeln('static void* __v_thread_join(__v_thread thread) { void* result = NULL; int rc = pthread_join(thread.handle, &result); if (rc != 0) { fprintf(stderr, "V thread join failed: %d\\n", rc); abort(); } return result; }')
+	g.writeln('#endif')
+}
+
+fn (mut g FlatGen) thread_stack_size_definition() {
+	g.writeln('#ifndef V_THREAD_STACK_SIZE')
+	g.writeln('#define V_THREAD_STACK_SIZE ${g.thread_stack_size}')
 	g.writeln('#endif')
 }
 
@@ -12874,12 +12887,6 @@ fn (mut g FlatGen) headerless_libc_preamble() {
 	g.writeln('typedef struct { pthread_t handle; } __v_thread;')
 	g.writeln('static bool __v_thread_equal(__v_thread a, __v_thread b) { return pthread_equal(a.handle, b.handle) != 0; }')
 	g.writeln('typedef void* (*__v_thread_start_fn)(void*);')
-	// The spawned-thread stack defaults to 8 MiB but is overridable at C compile
-	// time (e.g. `-DV_THREAD_STACK_SIZE=...`) so it is a tunable default rather
-	// than a universal constant.
-	g.writeln('#ifndef V_THREAD_STACK_SIZE')
-	g.writeln('#define V_THREAD_STACK_SIZE 8388608')
-	g.writeln('#endif')
 	g.writeln('static const size_t __v_thread_stack_size = V_THREAD_STACK_SIZE;')
 	g.writeln('static void* __v_thread_alloc(size_t size) { void* p = malloc(size); if (!p) { fprintf(stderr, "V thread allocation failed\\n"); abort(); } return p; }')
 	g.writeln('static __v_thread __v_thread_spawn(__v_thread_start_fn start, void* arg, void (*cleanup)(void*)) {')

--- a/vlib/v3/pref/pref.v
+++ b/vlib/v3/pref/pref.v
@@ -7,20 +7,21 @@ import v3.cmdexec
 // Preferences represents preferences data used by pref.
 pub struct Preferences {
 pub mut:
-	verbose        bool
-	output_file    string
-	target         Target = host_target()
-	user_defines   []string
-	compile_values map[string]string
-	backend        string = 'c'
-	c99            bool
-	vroot          string = detect_vroot()
-	vexe           string = detect_vexe()
-	selfhost       bool
-	building_v     bool // compiling the V compiler itself: no generics, skip monomorphization
-	is_prod        bool
-	is_debug       bool
-	is_test        bool // at least one compatible user test file is being compiled
+	verbose           bool
+	output_file       string
+	target            Target = host_target()
+	user_defines      []string
+	compile_values    map[string]string
+	backend           string = 'c'
+	c99               bool
+	vroot             string = detect_vroot()
+	vexe              string = detect_vexe()
+	selfhost          bool
+	building_v        bool // compiling the V compiler itself: no generics, skip monomorphization
+	is_prod           bool
+	is_debug          bool
+	is_test           bool // at least one compatible user test file is being compiled
+	thread_stack_size int = 8 * 1024 * 1024
 	// V3 backends currently do not lower V inline-assembly nodes. Keep this an
 	// explicit capability so guarded stdlib assembly selects its software path.
 	supports_inline_asm bool
@@ -76,6 +77,11 @@ pub fn host_target() Target {
 	return target_from(os.user_os(), host_arch()) or {
 		panic('unsupported compiler host target ${os.user_os()}/${host_arch()}')
 	}
+}
+
+// default_thread_stack_size returns the target-specific spawned-thread stack size.
+pub fn (target Target) default_thread_stack_size() int {
+	return if target.pointer_bits == 32 { 2 * 1024 * 1024 } else { 8 * 1024 * 1024 }
 }
 
 // target_from validates and canonicalizes an OS/architecture pair.

--- a/vlib/v3/tests/pr_27962_parity_test.v
+++ b/vlib/v3/tests/pr_27962_parity_test.v
@@ -1,0 +1,160 @@
+import os
+
+const pr_27962_vexe = @VEXE
+const pr_27962_tests_dir = os.dir(@FILE)
+const pr_27962_v3_dir = os.dir(pr_27962_tests_dir)
+const pr_27962_vlib_dir = os.dir(pr_27962_v3_dir)
+const pr_27962_v3_src = os.join_path(pr_27962_v3_dir, 'v3.v')
+
+fn pr_27962_build_v3(root string) string {
+	v3_bin := os.join_path(root, 'v3')
+	build :=
+		os.execute('${os.quoted_path(pr_27962_vexe)} -gc none -prealloc -path "${pr_27962_vlib_dir}|@vlib|@vmodules" -o ${os.quoted_path(v3_bin)} ${os.quoted_path(pr_27962_v3_src)}')
+	assert build.exit_code == 0, build.output
+	return v3_bin
+}
+
+fn pr_27962_write_source(root string, name string, source string) string {
+	path := os.join_path(root, '${name}.v')
+	os.write_file(path, source) or { panic(err) }
+	return path
+}
+
+fn pr_27962_compile_and_run(v3_bin string, root string, name string, source string) string {
+	source_path := pr_27962_write_source(root, name, source)
+	binary_path := os.join_path(root, name)
+	compile :=
+		os.execute('${os.quoted_path(v3_bin)} -silent -nocache -o ${os.quoted_path(binary_path)} ${os.quoted_path(source_path)}')
+	assert compile.exit_code == 0, compile.output
+	run := os.execute(os.quoted_path(binary_path))
+	assert run.exit_code == 0, run.output
+	return run.output.trim_space()
+}
+
+fn pr_27962_generate_c(v3_bin string, root string, name string, source string, flags string) string {
+	source_path := pr_27962_write_source(root, name, source)
+	c_path := os.join_path(root, '${name}.c')
+	compile :=
+		os.execute('${os.quoted_path(v3_bin)} -silent -nocache ${flags} -o ${os.quoted_path(c_path)} ${os.quoted_path(source_path)}')
+	assert compile.exit_code == 0, compile.output
+	return os.read_file(c_path) or { panic(err) }
+}
+
+fn test_pr_27962_regressions_are_fixed_in_v3() {
+	root := os.join_path(os.temp_dir(), 'v3_pr_27962_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	v3_bin := pr_27962_build_v3(root)
+
+	output := pr_27962_compile_and_run(v3_bin, root, 'compiler_regressions', '
+fn run_option_callback[T](callback fn () T) ?T {
+	mut result := T{}
+	result = callback()
+	return result
+}
+
+fn plain_int_callback() int {
+	return 42
+}
+
+fn option_int_callback() ?int {
+	return 42
+}
+
+fn generic_option_default[T]() ?T {
+	mut opt := ?T{}
+	return opt
+}
+
+type GenericKeyMaps = [4]map[T]string
+type GenericValueMaps = [4]map[string]T
+
+type Palette = [4]Color
+
+enum Color {
+	red
+	green
+	blue
+}
+
+struct Setup {
+	palette Palette
+}
+
+type UnusedPalette = [3]UnusedColor
+
+enum UnusedColor {
+	black
+}
+
+@[heap]
+struct HeapItem {
+mut:
+	value int
+}
+
+fn (mut item HeapItem) reference() &HeapItem {
+	return item
+}
+
+fn main() {
+	assert (run_option_callback(plain_int_callback) or { -1 }) == 42
+	assert (run_option_callback(option_int_callback) or { -1 }) == 42
+	assert (generic_option_default[int]() or { -1 }) == 0
+	key_maps := GenericKeyMaps{}
+	value_maps := GenericValueMaps{}
+	assert key_maps.len == 4
+	assert value_maps.len == 4
+	setup := Setup{}
+	assert setup.palette[0] == .red
+	mut item := HeapItem{
+		value: 1
+	}
+	mut reference := item.reference()
+	reference.value = 2
+	assert item.value == 2
+	assert reference.value == 2
+	println("ok")
+}
+')
+	assert output == 'ok'
+
+	runtime_source := '
+import sync
+import time
+
+fn work() {}
+
+fn main() {
+	mut wg := sync.new_waitgroup()
+	wg.go(work)
+	wg.wait()
+	timer := time.new_timer(time.nanosecond)
+	_ = <-timer.c
+}
+'
+	custom_stack_c := pr_27962_generate_c(v3_bin, root, 'runtime_custom_stack', runtime_source,
+		'-thread-stack-size 4194304')
+	stack_define := '#define V_THREAD_STACK_SIZE 4194304'
+	define_index := custom_stack_c.index(stack_define) or {
+		assert false, custom_stack_c
+		return
+	}
+	thread_helper_index := custom_stack_c.index('#ifndef V_SYNC_THREAD_HELPER_H') or {
+		assert false, custom_stack_c
+		return
+	}
+	assert define_index < thread_helper_index
+	assert custom_stack_c.contains('static const size_t __v_thread_stack_size = V_THREAD_STACK_SIZE;')
+
+	x86_c := pr_27962_generate_c(v3_bin, root, 'runtime_x86_stack', 'fn main() {}\n', '-arch i386')
+	assert x86_c.contains('#define V_THREAD_STACK_SIZE 2097152'), x86_c
+
+	windows_c := pr_27962_generate_c(v3_bin, root, 'runtime_windows', runtime_source,
+		'-os windows -arch amd64')
+	assert windows_c.contains('#define V_THREAD_STACK_SIZE 8388608'), windows_c
+	assert windows_c.contains('SleepConditionVariableSRW'), windows_c
+}

--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -3929,6 +3929,10 @@ fn (t &Transformer) specialized_direct_generic_type_text(typ string, args []stri
 			inner := t.specialized_direct_generic_type_text(clean[prefix.len..], args, params) or {
 				return none
 			}
+			if (prefix == '?' && inner.starts_with('?'))
+				|| (prefix == '!' && inner.starts_with('!')) {
+				return inner
+			}
 			return prefix + inner
 		}
 	}
@@ -8148,7 +8152,7 @@ fn (mut t Transformer) clone_generic_node_from(node flat.Node, args []string, is
 		} else {
 			'[]${array_value}'
 		}
-	} else if node.kind == .struct_init && node.value.len > 0 {
+	} else if node.kind == .struct_init && node.value.len > 0 && node.value != 'Optional' {
 		// The checker can annotate `T{}` with its surrounding optional/result
 		// context. For a concrete clone the literal itself is authoritative.
 		struct_subst := t.subst_type(node.value, args)
@@ -8286,6 +8290,10 @@ fn (mut t Transformer) clone_generic_node_from(node flat.Node, args []string, is
 		}
 		t.generic_clone_children = t.generic_clone_children[..scratch_start]
 		return clone_id
+	}
+	if node.kind == .struct_init && children.len == 0 && t.is_optional_type_name(cloned_typ)
+		&& (node.value == 'Optional' || t.is_optional_type_name(node.value)) {
+		children << t.make_sum_literal_field('ok', t.make_bool_literal(true), 'bool')
 	}
 	cloned_typ = t.retarget_cloned_map_key_storage_type(node, mut children, cloned_typ)
 	t.retarget_cloned_new_map_call(node, mut children, cloned_typ)
@@ -9881,10 +9889,12 @@ fn substitute_generic_type_text_with_params(typ string, args []string, params []
 		return 'mut ' + substitute_generic_type_text_with_params(clean[4..], args, params)
 	}
 	if clean.starts_with('?') {
-		return '?' + substitute_generic_type_text_with_params(clean[1..], args, params)
+		inner := substitute_generic_type_text_with_params(clean[1..], args, params)
+		return if inner.starts_with('?') { inner } else { '?' + inner }
 	}
 	if clean.starts_with('!') {
-		return '!' + substitute_generic_type_text_with_params(clean[1..], args, params)
+		inner := substitute_generic_type_text_with_params(clean[1..], args, params)
+		return if inner.starts_with('!') { inner } else { '!' + inner }
 	}
 	if clean.starts_with('...') {
 		return '...' + substitute_generic_type_text_with_params(clean[3..], args, params)

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -8365,7 +8365,12 @@ fn (tc &TypeChecker) new_error_kind_since(start int, kind TypeErrorKind) bool {
 
 // check_decl_type_strings validates check decl type strings state for types.
 fn (mut tc TypeChecker) check_decl_type_strings(node_id flat.NodeId, node flat.Node) {
-	generic_params := tc.infer_decl_generic_params(node)
+	mut generic_params := tc.infer_decl_generic_params(node)
+	if node.kind == .type_decl && node.generic_params().len == 0 {
+		for name in tc.fixed_array_map_alias_generic_params(node.typ) {
+			generic_params[name] = true
+		}
+	}
 	decl_generic_mentions_error := tc.check_struct_or_interface_decl_generic_mentions(node_id, node)
 	if node.kind == .type_decl {
 		if imported_name := tc.selective_imported_builtin_in_type(node.typ) {
@@ -8489,6 +8494,29 @@ fn (mut tc TypeChecker) check_decl_type_strings(node_id flat.NodeId, node flat.N
 			}
 		}
 	}
+}
+
+fn (tc &TypeChecker) fixed_array_map_alias_generic_params(typ string) []string {
+	clean := typ.trim_space()
+	if !clean.starts_with('[') {
+		return []string{}
+	}
+	bracket_end := find_matching_bracket(clean, 0)
+	if bracket_end >= clean.len {
+		return []string{}
+	}
+	element_type := clean[bracket_end + 1..].trim_space()
+	if !element_type.starts_with('map[') {
+		return []string{}
+	}
+	mut counts := map[string]int{}
+	tc.collect_generic_param_candidates(element_type, mut counts)
+	mut names := []string{cap: counts.len}
+	for name, _ in counts {
+		names << name
+	}
+	names.sort()
+	return names
 }
 
 fn (tc &TypeChecker) selective_imported_builtin_in_type(type_text string) ?string {
@@ -50441,13 +50469,21 @@ fn (tc &TypeChecker) substitute_generic_type(typ Type, args []string, param_name
 		})
 	}
 	if typ is OptionType {
+		base_type := tc.substitute_generic_type(typ.base_type, args, param_names)
+		if base_type is OptionType {
+			return base_type
+		}
 		return Type(OptionType{
-			base_type: tc.substitute_generic_type(typ.base_type, args, param_names)
+			base_type: base_type
 		})
 	}
 	if typ is ResultType {
+		base_type := tc.substitute_generic_type(typ.base_type, args, param_names)
+		if base_type is ResultType {
+			return base_type
+		}
 		return Type(ResultType{
-			base_type: tc.substitute_generic_type(typ.base_type, args, param_names)
+			base_type: base_type
 		})
 	}
 	if typ is Alias {
@@ -50528,13 +50564,21 @@ fn (tc &TypeChecker) substitute_generic_type_values(typ Type, args []Type, param
 		})
 	}
 	if typ is OptionType {
+		base_type := tc.substitute_generic_type_values(typ.base_type, args, param_names)
+		if base_type is OptionType {
+			return base_type
+		}
 		return Type(OptionType{
-			base_type: tc.substitute_generic_type_values(typ.base_type, args, param_names)
+			base_type: base_type
 		})
 	}
 	if typ is ResultType {
+		base_type := tc.substitute_generic_type_values(typ.base_type, args, param_names)
+		if base_type is ResultType {
+			return base_type
+		}
 		return Type(ResultType{
-			base_type: tc.substitute_generic_type_values(typ.base_type, args, param_names)
+			base_type: base_type
 		})
 	}
 	if typ is FnType {
@@ -54859,10 +54903,12 @@ fn subst_generic_text(typ string, args []string, params []string) string {
 		return 'mut ' + subst_generic_text(clean[4..], args, params)
 	}
 	if clean.starts_with('?') {
-		return '?' + subst_generic_text(clean[1..], args, params)
+		inner := subst_generic_text(clean[1..], args, params)
+		return if inner.starts_with('?') { inner } else { '?' + inner }
 	}
 	if clean.starts_with('!') {
-		return '!' + subst_generic_text(clean[1..], args, params)
+		inner := subst_generic_text(clean[1..], args, params)
+		return if inner.starts_with('!') { inner } else { '!' + inner }
 	}
 	if clean.starts_with('...') {
 		return '...' + subst_generic_text(clean[3..], args, params)

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -1581,6 +1581,7 @@ fn cli_usage() string {
 		'  -b <c|arm64|wasm|eval>      backend\n' +
 		'  -os <name> -arch <name>     target platform\n' +
 		'  -cc <compiler>               C compiler executable\n' +
+		'  -thread-stack-size <bytes>   spawned-thread stack size\n' +
 		'  -prod -c99 -shared -strict  C build modes\n' +
 		'  -v                           verbose stage profiling\n' +
 		'  -silent                      suppress benchmark output\n' +
@@ -3447,6 +3448,8 @@ fn main() {
 	mut silent := false
 	mut is_debug := false
 	mut c99 := false
+	mut thread_stack_size := 0
+	mut thread_stack_size_set := false
 	mut all_backends := false
 	mut compile_backends := []string{}
 	mut user_defines := []string{}
@@ -3467,7 +3470,7 @@ fn main() {
 			i++
 			continue
 		}
-		if args[i] in ['-o', '-b', '-os', '-arch', '-compile-backend', '--compile-backend', '-d', '-gc', '-cc']
+		if args[i] in ['-o', '-b', '-os', '-arch', '-compile-backend', '--compile-backend', '-d', '-gc', '-cc', '-thread-stack-size']
 			&& (i + 1 >= args.len || args[i + 1].starts_with('-')) {
 			eprintln('option `${args[i]}` requires a value')
 			exit(1)
@@ -3557,6 +3560,10 @@ fn main() {
 			explicit_tcc = requested_compiler in ['tcc', 'tinyc']
 			c_compiler = requested_compiler
 			c_compiler_explicit = true
+			i += 2
+		} else if args[i] == '-thread-stack-size' && i + 1 < args.len {
+			thread_stack_size = args[i + 1].int()
+			thread_stack_size_set = true
 			i += 2
 		} else if args[i] == '-cflags' && i + 1 < args.len {
 			parsed_c_flags := cmdexec.split_args(args[i + 1]) or {
@@ -3803,6 +3810,11 @@ fn main() {
 	// Parse directly to flat AST
 	mut prefs := pref.new_preferences()
 	prefs.target = target
+	prefs.thread_stack_size = if thread_stack_size_set {
+		thread_stack_size
+	} else {
+		target.default_thread_stack_size()
+	}
 	prefs.backend = backend
 	prefs.c99 = c99
 	prefs.user_defines = user_defines
@@ -3830,6 +3842,7 @@ fn main() {
 		'shared=${is_shared}',
 		'selfhost=${is_selfhost}',
 		'c99=${c99}',
+		'thread_stack_size=${prefs.thread_stack_size}',
 		'ownership=${ownership_mode}',
 		'test=${is_test_command || is_v3_test_file(input_file, backend, target)}',
 		'defines=${prefs.user_defines.join(',')}',
@@ -5007,6 +5020,7 @@ fn main() {
 			g.set_skip_generics(skip_transform_generics)
 			g.set_compiler_vexe(prefs.vexe)
 			g.set_target(prefs.target)
+			g.set_thread_stack_size(prefs.thread_stack_size)
 			g.set_compile_values(prefs.compile_values)
 			g.set_cache_split(cache_state.manager.enabled)
 			g.set_program_body_only(generic_cache_hit)
@@ -5042,6 +5056,7 @@ fn main() {
 			g.set_skip_generics(skip_transform_generics)
 			g.set_compiler_vexe(prefs.vexe)
 			g.set_target(prefs.target)
+			g.set_thread_stack_size(prefs.thread_stack_size)
 			g.set_compile_values(prefs.compile_values)
 			g.set_cache_split(cache_state.manager.enabled)
 			g.set_program_body_only(generic_cache_hit)


### PR DESCRIPTION
## Summary

- enforce heap safety for implicit references returned from mutable receivers
- add a selectable, stoppable `time.Timer` with an unbuffered channel and direct unbuffered select rendezvous
- preserve generic option/result flags per instantiation and emit fixed-array aliases in dependency order
- remove the `time` dependency from `sync` while preserving timed waits and `WaitGroup.go` behavior

## Tests

- `./vnew check-md vlib/time/README.md`
- `./vnew -silent test vlib/time/`
- `./vnew -silent test vlib/sync/`
- focused regression tests for all six issues
- `./vnew -silent vlib/v/compiler_errors_test.v`
- `./vnew -silent vlib/v/slow_tests/inout/compiler_test.v`
- `./vnew -silent vlib/v/gen/c/coutput_test.v`
- timer and waitgroup tests with `-prealloc`
- Windows cross-compilation for timer and waitgroup tests

The full `vlib/v/` run was stopped after 999/2340 tests at user request; no failures were observed before it was stopped.

Fixes #27916
Fixes #27914
Fixes #27897
Fixes #27895
Fixes #27878
Fixes #27876