### PR TITLE
v3: use as default compiler on macOS

### DIFF
--- a/cmd/v/macos_v3_darwin.c.v
+++ b/cmd/v/macos_v3_darwin.c.v
@@ -11,11 +11,14 @@ const macos_v3_bootstrap_env = 'V_MACOS_V3_BOOTSTRAP'
 const macos_v3_executable_env = 'V_MACOS_V3_EXECUTABLE'
 
 fn maybe_delegate_to_macos_v3(command string, prefs &pref.Preferences) {
+	all_args := util.join_env_vflags_and_os_args()
+	forwarded_args := all_args[1..]
 	if os.getenv(macos_v3_bootstrap_env) != '' || !is_macos_v3_default_executable(os.executable())
-		|| !is_macos_v3_relevant_command(command, prefs) {
+		|| !is_macos_v3_relevant_command(command, prefs)
+		|| !macos_v3_args_are_supported(forwarded_args) {
 		return
 	}
-	launch_macos_v3_compiler(prefs)
+	launch_macos_v3_compiler(prefs, forwarded_args)
 }
 
 fn is_macos_v3_default_executable(vexe string) bool {
@@ -26,34 +29,91 @@ fn is_macos_v3_relevant_command(command string, prefs &pref.Preferences) bool {
 	if prefs.path == '' || prefs.backend != .c || prefs.os != .macos {
 		return false
 	}
+	normalized_path := prefs.path.replace('\\', '/').trim_right('/')
+	is_direct_vsh := normalized_path.ends_with('.vsh') && command != 'crun'
 	if command in external_tools
 		|| command in ['help', 'version', 'new', 'init', 'install', 'link', 'list', 'outdated', 'remove', 'search', 'show', 'unlink', 'update', 'upgrade', 'vlib-docs', 'interpret', 'get', 'translate'] {
 		return false
 	}
-	if prefs.is_crun || prefs.is_test || prefs.is_prod || prefs.autofree
-		|| prefs.build_mode == .build_module || prefs.is_cstrict || prefs.use_cache
-		|| prefs.parallel_cc || prefs.exclude.len > 0 {
+	if (prefs.is_crun && !is_direct_vsh) || prefs.is_test || prefs.is_prod
+		|| prefs.autofree || prefs.build_mode == .build_module || prefs.is_cstrict
+		|| prefs.use_cache || prefs.parallel_cc || prefs.exclude.len > 0 {
 		return false
 	}
 	if prefs.gc_set_by_flag && prefs.gc_mode != .no_gc {
 		return false
 	}
-	normalized_path := prefs.path.replace('\\', '/').trim_right('/')
 	if normalized_path == 'cmd/v' || normalized_path.ends_with('/cmd/v')
 		|| normalized_path.ends_with('/cmd/v/v.v') || normalized_path.starts_with('cmd/tools/')
-		|| normalized_path.contains('/cmd/tools/') {
+		|| normalized_path.contains('/cmd/tools/') || normalized_path.ends_with('.vv')
+		|| os.is_dir(prefs.path) {
 		// Keep the established compiler available as the compatibility fallback.
 		// V3 does not compile all of cmd/v yet, and command tools are built on
-		// demand while dispatching CLI commands such as `fmt` and `test`.
+		// demand while dispatching CLI commands such as `fmt` and `test`. Legacy
+		// .vv fixtures and directory builds also retain established semantics.
 		return false
 	}
 	return command == 'run' || command == 'build' || prefs.is_script
-		|| normalized_path.ends_with('.v') || normalized_path.ends_with('.vv')
-		|| normalized_path.ends_with('.vsh') || os.is_dir(prefs.path)
+		|| normalized_path.ends_with('.v') || normalized_path.ends_with('.vsh')
+}
+
+fn macos_v3_args_are_supported(args []string) bool {
+	mut input_seen := false
+	mut should_run := false
+	mut i := 0
+	for i < args.len {
+		arg := args[i]
+		if should_run && input_seen {
+			// Everything after the input to `run`, or after a direct V script,
+			// belongs to the program rather than the compiler.
+			i++
+			continue
+		}
+		if arg == 'run' && !input_seen {
+			should_run = true
+			i++
+			continue
+		}
+		if arg in ['build', 'test'] && !input_seen {
+			i++
+			continue
+		}
+		if arg in ['-o', '-b', '-os', '-arch', '-compile-backend', '--compile-backend', '-d', '-gc',
+			'-cc', '-cflags'] {
+			if i + 1 >= args.len {
+				return false
+			}
+			i += 2
+			continue
+		}
+		if arg.starts_with('-d') && arg.len > 2 {
+			i++
+			continue
+		}
+		if arg in ['-prod', '-shared', '--shared', '-selfhost', '-building-v', '-building_v', '-c99',
+			'--c99', '-strict', '-cstrict', '-ownership', '--ownership', '-no-parallel',
+			'--no-parallel', '-parallel-transform', '--parallel-transform', '-all-backends',
+			'--all-backends', '-g', '-cg', '-autofree', '-v', '-silent', '-checker-fixture', '-stats',
+			'-show-timings', '-showcc', '-keepc', '-w', '-no-retry-compilation', '-skip-running',
+			'-usecache', '-no-prealloc', '--no-prealloc', '-nocache', '--no-cache',
+			'-no-memory-limit', '--no-memory-limit', '-prealloc', '-enable-globals', '-h', '--help'] {
+			i++
+			continue
+		}
+		if arg.starts_with('-') || input_seen {
+			return false
+		}
+		input_seen = true
+		if arg.ends_with('.vsh') {
+			should_run = true
+		}
+		i++
+	}
+	return input_seen
 }
 
 @[noreturn]
-fn launch_macos_v3_compiler(prefs &pref.Preferences) {
+fn launch_macos_v3_compiler(prefs &pref.Preferences, raw_args []string) {
 	vexe := pref.vexe_path()
 	vroot := os.dir(vexe)
 	util.set_vroot_folder(vroot)
@@ -76,7 +136,7 @@ fn launch_macos_v3_compiler(prefs &pref.Preferences) {
 		}
 		build_lock.release()
 	}
-	mut forwarded_args := util.join_env_vflags_and_os_args()[1..].clone()
+	mut forwarded_args := raw_args.clone()
 	if !prefs.is_verbose && !prefs.is_stats && !prefs.show_timings && !prefs.show_cc {
 		forwarded_args.insert(0, '-silent')
 	}

--- a/cmd/v/macos_v3_darwin.c.v
+++ b/cmd/v/macos_v3_darwin.c.v
@@ -121,9 +121,7 @@ fn macos_v3_args_are_supported(args []string) bool {
 			if arg == '-o' && args[i + 1].starts_with('-') {
 				return false
 			}
-			// The established CLI treats this legacy alias as amd64, while V3
-			// uses x86 for its 32-bit target.
-			if arg == '-arch' && args[i + 1] == 'x86' {
+			if arg == '-arch' && !macos_v3_arch_is_supported(args[i + 1]) {
 				return false
 			}
 			i += 2
@@ -160,6 +158,17 @@ fn macos_v3_args_are_supported(args []string) bool {
 		i++
 	}
 	return input_seen
+}
+
+fn macos_v3_arch_is_supported(arch_name string) bool {
+	// The established CLI treats this legacy alias as amd64, while V3 uses
+	// x86 for its 32-bit target.
+	if arch_name == 'x86' {
+		return false
+	}
+	arch := pref.arch_from_string(arch_name) or { return false }
+	return arch in [.amd64, .arm64, .arm32, .rv64, .i386, .s390x, .ppc64le, .loongarch64, .ppc64,
+		.wasm32]
 }
 
 fn macos_v3_needs_compatible_default_output(path string) bool {

--- a/cmd/v/macos_v3_darwin.c.v
+++ b/cmd/v/macos_v3_darwin.c.v
@@ -106,7 +106,7 @@ fn macos_v3_args_are_supported(args []string) bool {
 			'--all-backends', '-g', '-cg', '-autofree', '-v', '-silent', '-checker-fixture', '-stats',
 			'-show-timings', '-showcc', '-keepc', '-w', '-no-retry-compilation', '-skip-running',
 			'-usecache', '-no-prealloc', '--no-prealloc', '-nocache', '--no-cache',
-			'-no-memory-limit', '--no-memory-limit', '-prealloc', '-enable-globals', '-h', '--help'] {
+			'-no-memory-limit', '--no-memory-limit', '-prealloc', '-enable-globals'] {
 			i++
 			continue
 		}

--- a/cmd/v/macos_v3_darwin.c.v
+++ b/cmd/v/macos_v3_darwin.c.v
@@ -53,14 +53,18 @@ fn is_macos_v3_relevant_command(command string, prefs &pref.Preferences) bool {
 		return false
 	}
 	if normalized_path == 'cmd/v' || normalized_path.ends_with('/cmd/v')
-		|| normalized_path.ends_with('/cmd/v/v.v') || normalized_path.starts_with('cmd/tools/')
-		|| normalized_path.contains('/cmd/tools/') || normalized_path.ends_with('.vv')
-		|| os.is_dir(prefs.path) || macos_v3_source_path_resolves_differently(prefs.path)
+		|| normalized_path.ends_with('/cmd/v/v.v')
+		|| normalized_path.starts_with('cmd/tools/')
+		|| normalized_path.contains('/cmd/tools/')
+		|| normalized_path.ends_with('.vv')
+		|| (!normalized_path.ends_with('.v') && !normalized_path.ends_with('.vsh'))
+		|| os.is_dir(prefs.path)
+		|| macos_v3_source_path_resolves_differently(prefs.path)
 		|| macos_v3_needs_compatible_default_output(prefs.path) {
 		// Keep the established compiler available as the compatibility fallback.
 		// V3 does not compile all of cmd/v yet, and command tools are built on
 		// demand while dispatching CLI commands such as `fmt` and `test`. Legacy
-		// .vv fixtures, directory builds, and sources needing compatibility
+		// .vv fixtures, directory/non-V builds, and sources needing compatibility
 		// output-name derivation also retain established semantics.
 		return false
 	}

--- a/cmd/v/macos_v3_darwin.c.v
+++ b/cmd/v/macos_v3_darwin.c.v
@@ -38,8 +38,7 @@ fn is_macos_v3_relevant_command(command string, prefs &pref.Preferences) bool {
 	if (prefs.is_crun && !is_direct_vsh) || prefs.is_test || prefs.is_prod
 		|| prefs.autofree || prefs.build_mode == .build_module || prefs.is_cstrict
 		|| prefs.use_cache || prefs.parallel_cc || prefs.out_name_is_dir
-		|| prefs.exclude.len > 0 || prefs.coverage_dir != ''
-		|| (prefs.show_cc && prefs.output_mode == .silent) {
+		|| prefs.exclude.len > 0 || prefs.coverage_dir != '' {
 		return false
 	}
 	if prefs.gc_mode != .no_gc {
@@ -94,7 +93,7 @@ fn macos_v3_args_are_supported(args []string) bool {
 			if i + 1 >= args.len {
 				return false
 			}
-			if arg == '-o' && args[i + 1] == '-' {
+			if arg == '-o' && args[i + 1].starts_with('-') {
 				return false
 			}
 			i += 2
@@ -152,7 +151,7 @@ fn macos_v3_forwarded_args(prefs &pref.Preferences, raw_args []string) []string 
 	if prefs.skip_running && '-skip-running' !in forwarded_args {
 		forwarded_args.insert(0, '-skip-running')
 	}
-	if !prefs.is_verbose && !prefs.is_stats && !prefs.show_timings && !prefs.show_cc {
+	if !prefs.is_verbose && !prefs.is_stats && !prefs.show_timings {
 		forwarded_args.insert(0, '-silent')
 	}
 	// Serial stages keep cold-cache builds of larger programs below V3's

--- a/cmd/v/macos_v3_darwin.c.v
+++ b/cmd/v/macos_v3_darwin.c.v
@@ -121,6 +121,11 @@ fn macos_v3_args_are_supported(args []string) bool {
 			if arg == '-o' && args[i + 1].starts_with('-') {
 				return false
 			}
+			// The established CLI treats this legacy alias as amd64, while V3
+			// uses x86 for its 32-bit target.
+			if arg == '-arch' && args[i + 1] == 'x86' {
+				return false
+			}
 			i += 2
 			continue
 		}

--- a/cmd/v/macos_v3_darwin.c.v
+++ b/cmd/v/macos_v3_darwin.c.v
@@ -10,6 +10,8 @@ import v.util
 const macos_v3_bootstrap_env = 'V_MACOS_V3_BOOTSTRAP'
 const macos_v3_executable_env = 'V_MACOS_V3_EXECUTABLE'
 const macos_v3_fallback_file_env = 'V_MACOS_V3_FALLBACK_FILE'
+const macos_v3_vhash_env = 'V_MACOS_V3_VHASH'
+const macos_v3_vcurrent_hash_env = 'V_MACOS_V3_VCURRENT_HASH'
 const macos_v3_inline_asm_fallback = 'inline_asm'
 
 fn maybe_delegate_to_macos_v3(command string, prefs &pref.Preferences) {
@@ -217,12 +219,9 @@ fn launch_macos_v3_compiler(prefs &pref.Preferences, raw_args []string) {
 	}
 	mut process := os.new_process(v3_exe)
 	process.set_args(forwarded_args)
-	mut environment := os.environ()
 	fallback_file := os.join_path(os.vtmp_dir(), 'macos_v3_fallback_${os.getpid()}')
 	os.rm(fallback_file) or {}
-	environment['VCHILD'] = 'true'
-	environment['VEXE'] = os.real_path(vexe)
-	environment[macos_v3_fallback_file_env] = fallback_file
+	environment := macos_v3_child_environment(vexe, fallback_file)
 	process.set_environment(environment)
 	process.run()
 	process.wait()
@@ -237,6 +236,16 @@ fn launch_macos_v3_compiler(prefs &pref.Preferences, raw_args []string) {
 		return
 	}
 	exit(exit_code)
+}
+
+fn macos_v3_child_environment(vexe string, fallback_file string) map[string]string {
+	mut environment := os.environ()
+	environment['VCHILD'] = 'true'
+	environment['VEXE'] = os.real_path(vexe)
+	environment[macos_v3_fallback_file_env] = fallback_file
+	environment[macos_v3_vhash_env] = @VHASH
+	environment[macos_v3_vcurrent_hash_env] = @VCURRENTHASH
+	return environment
 }
 
 fn build_macos_v3_compiler(vexe string, vroot string, v3_source string, v3_exe string, is_verbose bool) {

--- a/cmd/v/macos_v3_darwin.c.v
+++ b/cmd/v/macos_v3_darwin.c.v
@@ -18,6 +18,7 @@ const macos_v3_caller_vexe_present_env = 'V_MACOS_V3_CALLER_VEXE_PRESENT'
 const macos_v3_caller_vchild_env = 'V_MACOS_V3_CALLER_VCHILD'
 const macos_v3_caller_vchild_present_env = 'V_MACOS_V3_CALLER_VCHILD_PRESENT'
 const macos_v3_inline_asm_fallback = 'inline_asm'
+const macos_v3_compiler_error_fallback = 'compiler_error'
 const macos_v3_c_error_fallback = 'c_compilation_error'
 const macos_v3_c_error_compiler_file = 'compiler'
 const macos_v3_c_error_output_file = 'output'
@@ -273,6 +274,11 @@ fn launch_macos_v3_compiler(prefs &pref.Preferences, raw_args []string) ?MacosV3
 			eprintln(report.c_output.trim_right('\r\n'))
 		}
 		return report
+	}
+	if exit_code != 0 && fallback_reason == macos_v3_compiler_error_fallback {
+		os.rmdir_all(c_error_dir) or {}
+		eprintln('V3 compilation failed; retrying with `-old-compiler`.')
+		return none
 	}
 	os.rmdir_all(c_error_dir) or {}
 	exit(exit_code)

--- a/cmd/v/macos_v3_darwin.c.v
+++ b/cmd/v/macos_v3_darwin.c.v
@@ -10,6 +10,7 @@ import v.util
 const macos_v3_bootstrap_env = 'V_MACOS_V3_BOOTSTRAP'
 const macos_v3_executable_env = 'V_MACOS_V3_EXECUTABLE'
 const macos_v3_fallback_file_env = 'V_MACOS_V3_FALLBACK_FILE'
+const macos_v3_c_error_dir_env = 'V_MACOS_V3_C_ERROR_DIR'
 const macos_v3_vhash_env = 'V_MACOS_V3_VHASH'
 const macos_v3_vcurrent_hash_env = 'V_MACOS_V3_VCURRENT_HASH'
 const macos_v3_caller_vexe_env = 'V_MACOS_V3_CALLER_VEXE'
@@ -17,17 +18,21 @@ const macos_v3_caller_vexe_present_env = 'V_MACOS_V3_CALLER_VEXE_PRESENT'
 const macos_v3_caller_vchild_env = 'V_MACOS_V3_CALLER_VCHILD'
 const macos_v3_caller_vchild_present_env = 'V_MACOS_V3_CALLER_VCHILD_PRESENT'
 const macos_v3_inline_asm_fallback = 'inline_asm'
+const macos_v3_c_error_fallback = 'c_compilation_error'
+const macos_v3_c_error_compiler_file = 'compiler'
+const macos_v3_c_error_output_file = 'output'
+const macos_v3_c_error_source_name_file = 'source_name'
 
-fn maybe_delegate_to_macos_v3(command string, prefs &pref.Preferences) {
+fn maybe_delegate_to_macos_v3(command string, prefs &pref.Preferences) ?MacosV3CErrorReport {
 	all_args := util.join_env_vflags_and_os_args()
 	forwarded_args := all_args[1..]
 	if os.getenv(macos_v3_bootstrap_env) != '' || !is_macos_v3_default_executable(os.executable())
 		|| !is_macos_v3_relevant_command(command, prefs)
 		|| !macos_v3_environment_flags_are_supported(os.getenv('CFLAGS'), os.getenv('LDFLAGS'))
 		|| !macos_v3_args_are_supported(forwarded_args) {
-		return
+		return none
 	}
-	launch_macos_v3_compiler(prefs, forwarded_args)
+	return launch_macos_v3_compiler(prefs, forwarded_args)
 }
 
 fn macos_v3_environment_flags_are_supported(cflags string, ldflags string) bool {
@@ -39,7 +44,7 @@ fn is_macos_v3_default_executable(vexe string) bool {
 }
 
 fn is_macos_v3_relevant_command(command string, prefs &pref.Preferences) bool {
-	if prefs.path == '' || prefs.backend != .c || prefs.os != .macos {
+	if prefs.old_compiler || prefs.path == '' || prefs.backend != .c || prefs.os != .macos {
 		return false
 	}
 	normalized_path := prefs.path.replace('\\', '/').trim_right('/')
@@ -208,7 +213,7 @@ fn macos_v3_forwarded_args(prefs &pref.Preferences, raw_args []string) []string 
 	return forwarded_args
 }
 
-fn launch_macos_v3_compiler(prefs &pref.Preferences, raw_args []string) {
+fn launch_macos_v3_compiler(prefs &pref.Preferences, raw_args []string) ?MacosV3CErrorReport {
 	caller_environment := os.environ()
 	vexe := pref.vexe_path()
 	vroot := os.dir(vexe)
@@ -240,6 +245,8 @@ fn launch_macos_v3_compiler(prefs &pref.Preferences, raw_args []string) {
 	process.set_args(forwarded_args)
 	fallback_file := os.join_path(os.vtmp_dir(), 'macos_v3_fallback_${os.getpid()}')
 	os.rm(fallback_file) or {}
+	c_error_dir := macos_v3_c_error_report_dir(fallback_file)
+	os.rmdir_all(c_error_dir) or {}
 	environment := macos_v3_child_environment(vexe, fallback_file, caller_environment)
 	process.set_environment(environment)
 	process.run()
@@ -249,12 +256,56 @@ fn launch_macos_v3_compiler(prefs &pref.Preferences, raw_args []string) {
 	fallback_reason := os.read_file(fallback_file) or { '' }
 	os.rm(fallback_file) or {}
 	if exit_code != 0 && fallback_reason == macos_v3_inline_asm_fallback {
+		os.rmdir_all(c_error_dir) or {}
 		if prefs.is_verbose {
 			println('V3 requested the compatibility compiler for inline assembly')
 		}
-		return
+		return none
 	}
+	if exit_code != 0 && fallback_reason == macos_v3_c_error_fallback {
+		report := read_macos_v3_c_error_report(c_error_dir) or {
+			os.rmdir_all(c_error_dir) or {}
+			eprintln('V3 requested a C-error fallback, but its diagnostics could not be read')
+			exit(exit_code)
+		}
+		eprintln('V3 C compilation failed; retrying with `-old-compiler`.')
+		if report.c_output != '' {
+			eprintln(report.c_output.trim_right('\r\n'))
+		}
+		return report
+	}
+	os.rmdir_all(c_error_dir) or {}
 	exit(exit_code)
+}
+
+fn macos_v3_c_error_report_dir(fallback_file string) string {
+	return fallback_file + '.c_error'
+}
+
+fn read_macos_v3_c_error_report(report_dir string) ?MacosV3CErrorReport {
+	source_name := os.read_file(os.join_path(report_dir, macos_v3_c_error_source_name_file)) or {
+		return none
+	}
+	clean_source_name := source_name.trim_space()
+	if clean_source_name == '' || os.base(clean_source_name) != clean_source_name {
+		return none
+	}
+	ccompiler := os.read_file(os.join_path(report_dir, macos_v3_c_error_compiler_file)) or {
+		return none
+	}
+	c_output := os.read_file(os.join_path(report_dir, macos_v3_c_error_output_file)) or {
+		return none
+	}
+	c_file := os.join_path(report_dir, clean_source_name)
+	if !os.is_file(c_file) {
+		return none
+	}
+	return MacosV3CErrorReport{
+		ccompiler:  ccompiler.trim_space()
+		c_output:   c_output
+		c_file:     c_file
+		report_dir: report_dir
+	}
 }
 
 fn macos_v3_child_environment(vexe string, fallback_file string, caller_environment map[string]string) map[string]string {
@@ -266,6 +317,7 @@ fn macos_v3_child_environment(vexe string, fallback_file string, caller_environm
 	environment['VCHILD'] = 'true'
 	environment['VEXE'] = os.real_path(vexe)
 	environment[macos_v3_fallback_file_env] = fallback_file
+	environment[macos_v3_c_error_dir_env] = macos_v3_c_error_report_dir(fallback_file)
 	environment[macos_v3_vhash_env] = @VHASH
 	environment[macos_v3_vcurrent_hash_env] = @VCURRENTHASH
 	return environment

--- a/cmd/v/macos_v3_darwin.c.v
+++ b/cmd/v/macos_v3_darwin.c.v
@@ -105,6 +105,10 @@ fn macos_v3_args_are_supported(args []string) bool {
 			i += 2
 			continue
 		}
+		if arg in ['-debug', '-debug-tcc', '-define', '-disable-explicit-mutability',
+			'-div-by-zero-is-zero', '-dump-c-flags', '-dump-modules', '-dump-files', '-dump-defines'] {
+			return false
+		}
 		if arg.starts_with('-d') && arg.len > 2 {
 			i++
 			continue

--- a/cmd/v/macos_v3_darwin.c.v
+++ b/cmd/v/macos_v3_darwin.c.v
@@ -24,17 +24,42 @@ const macos_v3_c_error_fallback = 'c_compilation_error'
 const macos_v3_c_error_compiler_file = 'compiler'
 const macos_v3_c_error_output_file = 'output'
 const macos_v3_c_error_source_name_file = 'source_name'
+const macos_v3_enabled_product_version_major = 26
+const macos_v3_enabled_product_version_minor = 2
 
 fn maybe_delegate_to_macos_v3(command string, prefs &pref.Preferences) ?MacosV3CErrorReport {
 	all_args := util.join_env_vflags_and_os_args()
 	forwarded_args := all_args[1..]
 	if os.getenv(macos_v3_bootstrap_env) != '' || !is_macos_v3_default_executable(os.executable())
-		|| !is_macos_v3_relevant_command(command, prefs)
+		|| !is_macos_v3_relevant_command(command, prefs) || !macos_v3_default_is_enabled_for_host()
 		|| !macos_v3_environment_flags_are_supported(os.getenv('CFLAGS'), os.getenv('LDFLAGS'))
 		|| !macos_v3_args_are_supported(forwarded_args) {
 		return none
 	}
 	return launch_macos_v3_compiler(prefs, forwarded_args)
+}
+
+fn macos_v3_default_is_enabled_for_host() bool {
+	if os.getenv('GITHUB_ACTIONS') == 'true' {
+		return true
+	}
+	version := os.execute('/usr/bin/sw_vers -productVersion')
+	if version.exit_code != 0 {
+		return false
+	}
+	return macos_v3_default_is_enabled(version.output, '')
+}
+
+fn macos_v3_default_is_enabled(product_version string, github_actions string) bool {
+	if github_actions == 'true' {
+		return true
+	}
+	parts := product_version.trim_space().split('.')
+	if parts.len < 2 || !parts[0].is_int() || !parts[1].is_int() {
+		return false
+	}
+	return parts[0].int() == macos_v3_enabled_product_version_major
+		&& parts[1].int() == macos_v3_enabled_product_version_minor
 }
 
 fn macos_v3_environment_flags_are_supported(cflags string, ldflags string) bool {

--- a/cmd/v/macos_v3_darwin.c.v
+++ b/cmd/v/macos_v3_darwin.c.v
@@ -41,13 +41,14 @@ fn is_macos_v3_relevant_command(command string, prefs &pref.Preferences) bool {
 		|| prefs.exclude.len > 0 {
 		return false
 	}
-	if prefs.gc_set_by_flag && prefs.gc_mode != .no_gc {
+	if prefs.gc_mode != .no_gc {
 		return false
 	}
 	if normalized_path == 'cmd/v' || normalized_path.ends_with('/cmd/v')
 		|| normalized_path.ends_with('/cmd/v/v.v') || normalized_path.starts_with('cmd/tools/')
 		|| normalized_path.contains('/cmd/tools/') || normalized_path.ends_with('.vv')
-		|| os.is_dir(prefs.path) || macos_v3_needs_compatible_default_output(prefs.path) {
+		|| os.is_dir(prefs.path) || macos_v3_source_path_resolves_differently(prefs.path)
+		|| macos_v3_needs_compatible_default_output(prefs.path) {
 		// Keep the established compiler available as the compatibility fallback.
 		// V3 does not compile all of cmd/v yet, and command tools are built on
 		// demand while dispatching CLI commands such as `fmt` and `test`. Legacy
@@ -57,6 +58,13 @@ fn is_macos_v3_relevant_command(command string, prefs &pref.Preferences) bool {
 	}
 	return command == 'run' || command == 'build' || prefs.is_script
 		|| normalized_path.ends_with('.v') || normalized_path.ends_with('.vsh')
+}
+
+fn macos_v3_source_path_resolves_differently(path string) bool {
+	if !os.exists(path) {
+		return false
+	}
+	return os.norm_path(os.real_path(path)) != os.norm_path(os.abs_path(path))
 }
 
 fn macos_v3_args_are_supported(args []string) bool {

--- a/cmd/v/macos_v3_darwin.c.v
+++ b/cmd/v/macos_v3_darwin.c.v
@@ -100,7 +100,14 @@ fn macos_v3_args_are_supported(args []string) bool {
 			i++
 			continue
 		}
-		if arg in ['-o', '-b', '-os', '-arch', '-compile-backend', '--compile-backend', '-d', '-gc',
+		if arg == '-d' {
+			if i + 1 >= args.len || args[i + 1].contains('=') {
+				return false
+			}
+			i += 2
+			continue
+		}
+		if arg in ['-o', '-b', '-os', '-arch', '-compile-backend', '--compile-backend', '-gc',
 			'-cflags'] {
 			if i + 1 >= args.len {
 				return false
@@ -116,6 +123,9 @@ fn macos_v3_args_are_supported(args []string) bool {
 			return false
 		}
 		if arg.starts_with('-d') && arg.len > 2 {
+			if arg.contains('=') {
+				return false
+			}
 			i++
 			continue
 		}

--- a/cmd/v/macos_v3_darwin.c.v
+++ b/cmd/v/macos_v3_darwin.c.v
@@ -13,6 +13,7 @@ const macos_v3_fallback_file_env = 'V_MACOS_V3_FALLBACK_FILE'
 const macos_v3_c_error_dir_env = 'V_MACOS_V3_C_ERROR_DIR'
 const macos_v3_vhash_env = 'V_MACOS_V3_VHASH'
 const macos_v3_vcurrent_hash_env = 'V_MACOS_V3_VCURRENT_HASH'
+const macos_v3_compat_c99_flag = '-macos-v3-compat-c99'
 const macos_v3_caller_vexe_env = 'V_MACOS_V3_CALLER_VEXE'
 const macos_v3_caller_vexe_present_env = 'V_MACOS_V3_CALLER_VEXE_PRESENT'
 const macos_v3_caller_vchild_env = 'V_MACOS_V3_CALLER_VCHILD'
@@ -147,10 +148,10 @@ fn macos_v3_args_are_supported(args []string) bool {
 		if arg in ['-prod', '-shared', '--shared', '-selfhost', '-building-v', '-building_v', '-c99',
 			'--c99', '-strict', '-cstrict', '-ownership', '--ownership', '-no-parallel',
 			'--no-parallel', '-parallel-transform', '--parallel-transform', '-all-backends',
-			'--all-backends', '-g', '-cg', '-autofree', '-v', '-checker-fixture', '-stats',
-			'-show-timings', '-showcc', '-keepc', '-skip-running', '-usecache', '-no-prealloc',
-			'--no-prealloc', '-nocache', '--no-cache', '-no-memory-limit', '--no-memory-limit',
-			'-prealloc', '-enable-globals'] {
+			'--all-backends', '-cg', '-autofree', '-v', '-checker-fixture', '-stats', '-show-timings',
+			'-showcc', '-keepc', '-skip-running', '-usecache', '-no-prealloc', '--no-prealloc',
+			'-nocache', '--no-cache', '-no-memory-limit', '--no-memory-limit', '-prealloc',
+			'-enable-globals'] {
 			i++
 			continue
 		}
@@ -200,6 +201,9 @@ fn macos_v3_needs_compatible_default_output(path string) bool {
 
 fn macos_v3_forwarded_args(prefs &pref.Preferences, raw_args []string) []string {
 	mut forwarded_args := raw_args.clone()
+	if macos_v3_compat_c99_flag !in forwarded_args {
+		forwarded_args.insert(0, macos_v3_compat_c99_flag)
+	}
 	if prefs.skip_running && '-skip-running' !in forwarded_args {
 		forwarded_args.insert(0, '-skip-running')
 	}

--- a/cmd/v/macos_v3_darwin.c.v
+++ b/cmd/v/macos_v3_darwin.c.v
@@ -52,7 +52,7 @@ fn is_macos_v3_relevant_command(command string, prefs &pref.Preferences) bool {
 		|| prefs.autofree || prefs.build_mode == .build_module || prefs.is_cstrict
 		|| prefs.use_cache || prefs.parallel_cc || prefs.out_name_is_dir
 		|| prefs.exclude.len > 0 || prefs.coverage_dir != '' || prefs.is_o
-		|| prefs.is_vlines || (prefs.is_shared && (prefs.is_run || prefs.is_crun)) {
+		|| prefs.is_vlines || prefs.is_shared {
 		return false
 	}
 	if prefs.gc_mode != .no_gc {

--- a/cmd/v/macos_v3_darwin.c.v
+++ b/cmd/v/macos_v3_darwin.c.v
@@ -9,6 +9,8 @@ import v.util
 
 const macos_v3_bootstrap_env = 'V_MACOS_V3_BOOTSTRAP'
 const macos_v3_executable_env = 'V_MACOS_V3_EXECUTABLE'
+const macos_v3_fallback_file_env = 'V_MACOS_V3_FALLBACK_FILE'
+const macos_v3_inline_asm_fallback = 'inline_asm'
 
 fn maybe_delegate_to_macos_v3(command string, prefs &pref.Preferences) {
 	all_args := util.join_env_vflags_and_os_args()
@@ -95,7 +97,7 @@ fn macos_v3_args_are_supported(args []string) bool {
 			continue
 		}
 		if arg in ['-o', '-b', '-os', '-arch', '-compile-backend', '--compile-backend', '-d', '-gc',
-			'-cc', '-cflags'] {
+			'-cflags'] {
 			if i + 1 >= args.len {
 				return false
 			}
@@ -172,7 +174,6 @@ fn macos_v3_forwarded_args(prefs &pref.Preferences, raw_args []string) []string 
 	return forwarded_args
 }
 
-@[noreturn]
 fn launch_macos_v3_compiler(prefs &pref.Preferences, raw_args []string) {
 	vexe := pref.vexe_path()
 	vroot := os.dir(vexe)
@@ -203,13 +204,24 @@ fn launch_macos_v3_compiler(prefs &pref.Preferences, raw_args []string) {
 	mut process := os.new_process(v3_exe)
 	process.set_args(forwarded_args)
 	mut environment := os.environ()
+	fallback_file := os.join_path(os.vtmp_dir(), 'macos_v3_fallback_${os.getpid()}')
+	os.rm(fallback_file) or {}
 	environment['VCHILD'] = 'true'
 	environment['VEXE'] = os.real_path(vexe)
+	environment[macos_v3_fallback_file_env] = fallback_file
 	process.set_environment(environment)
 	process.run()
 	process.wait()
 	exit_code := if process.code >= 0 { process.code } else { 1 }
 	process.close()
+	fallback_reason := os.read_file(fallback_file) or { '' }
+	os.rm(fallback_file) or {}
+	if exit_code != 0 && fallback_reason == macos_v3_inline_asm_fallback {
+		if prefs.is_verbose {
+			println('V3 requested the compatibility compiler for inline assembly')
+		}
+		return
+	}
 	exit(exit_code)
 }
 

--- a/cmd/v/macos_v3_darwin.c.v
+++ b/cmd/v/macos_v3_darwin.c.v
@@ -38,7 +38,8 @@ fn is_macos_v3_relevant_command(command string, prefs &pref.Preferences) bool {
 	if (prefs.is_crun && !is_direct_vsh) || prefs.is_test || prefs.is_prod
 		|| prefs.autofree || prefs.build_mode == .build_module || prefs.is_cstrict
 		|| prefs.use_cache || prefs.parallel_cc || prefs.out_name_is_dir
-		|| prefs.exclude.len > 0 {
+		|| prefs.exclude.len > 0 || prefs.coverage_dir != ''
+		|| (prefs.show_cc && prefs.output_mode == .silent) {
 		return false
 	}
 	if prefs.gc_mode != .no_gc {

--- a/cmd/v/macos_v3_darwin.c.v
+++ b/cmd/v/macos_v3_darwin.c.v
@@ -112,7 +112,7 @@ fn macos_v3_args_are_supported(args []string) bool {
 		if arg in ['-prod', '-shared', '--shared', '-selfhost', '-building-v', '-building_v', '-c99',
 			'--c99', '-strict', '-cstrict', '-ownership', '--ownership', '-no-parallel',
 			'--no-parallel', '-parallel-transform', '--parallel-transform', '-all-backends',
-			'--all-backends', '-g', '-cg', '-autofree', '-v', '-silent', '-checker-fixture', '-stats',
+			'--all-backends', '-g', '-cg', '-autofree', '-v', '-checker-fixture', '-stats',
 			'-show-timings', '-showcc', '-keepc', '-no-retry-compilation', '-skip-running',
 			'-usecache', '-no-prealloc', '--no-prealloc', '-nocache', '--no-cache',
 			'-no-memory-limit', '--no-memory-limit', '-prealloc', '-enable-globals'] {
@@ -217,10 +217,7 @@ fn build_macos_v3_compiler(vexe string, vroot string, v3_source string, v3_exe s
 	mut process := os.new_process(vexe)
 	process.set_work_folder(vroot)
 	process.set_args(args)
-	mut environment := os.environ()
-	environment[macos_v3_bootstrap_env] = '1'
-	environment['VFLAGS'] = ''
-	process.set_environment(environment)
+	process.set_environment(macos_v3_bootstrap_environment())
 	process.set_redirect_stdio()
 	process.run()
 	process.wait()
@@ -234,6 +231,14 @@ fn build_macos_v3_compiler(vexe string, vroot string, v3_source string, v3_exe s
 	if is_verbose && output != '' {
 		print(output)
 	}
+}
+
+fn macos_v3_bootstrap_environment() map[string]string {
+	mut environment := os.environ()
+	environment[macos_v3_bootstrap_env] = '1'
+	environment['VFLAGS'] = ''
+	environment['VOSARGS'] = ''
+	return environment
 }
 
 fn cached_macos_v3_executable_path(vroot string) string {

--- a/cmd/v/macos_v3_darwin.c.v
+++ b/cmd/v/macos_v3_darwin.c.v
@@ -15,10 +15,15 @@ fn maybe_delegate_to_macos_v3(command string, prefs &pref.Preferences) {
 	forwarded_args := all_args[1..]
 	if os.getenv(macos_v3_bootstrap_env) != '' || !is_macos_v3_default_executable(os.executable())
 		|| !is_macos_v3_relevant_command(command, prefs)
+		|| !macos_v3_environment_flags_are_supported(os.getenv('CFLAGS'), os.getenv('LDFLAGS'))
 		|| !macos_v3_args_are_supported(forwarded_args) {
 		return
 	}
 	launch_macos_v3_compiler(prefs, forwarded_args)
+}
+
+fn macos_v3_environment_flags_are_supported(cflags string, ldflags string) bool {
+	return cflags == '' && ldflags == ''
 }
 
 fn is_macos_v3_default_executable(vexe string) bool {
@@ -38,8 +43,8 @@ fn is_macos_v3_relevant_command(command string, prefs &pref.Preferences) bool {
 	if (prefs.is_crun && !is_direct_vsh) || prefs.is_test || prefs.is_prod
 		|| prefs.autofree || prefs.build_mode == .build_module || prefs.is_cstrict
 		|| prefs.use_cache || prefs.parallel_cc || prefs.out_name_is_dir
-		|| prefs.exclude.len > 0 || prefs.coverage_dir != '' || prefs.is_vlines
-		|| (prefs.is_shared && (prefs.is_run || prefs.is_crun)) {
+		|| prefs.exclude.len > 0 || prefs.coverage_dir != '' || prefs.is_o
+		|| prefs.is_vlines || (prefs.is_shared && (prefs.is_run || prefs.is_crun)) {
 		return false
 	}
 	if prefs.gc_mode != .no_gc {

--- a/cmd/v/macos_v3_darwin.c.v
+++ b/cmd/v/macos_v3_darwin.c.v
@@ -12,6 +12,10 @@ const macos_v3_executable_env = 'V_MACOS_V3_EXECUTABLE'
 const macos_v3_fallback_file_env = 'V_MACOS_V3_FALLBACK_FILE'
 const macos_v3_vhash_env = 'V_MACOS_V3_VHASH'
 const macos_v3_vcurrent_hash_env = 'V_MACOS_V3_VCURRENT_HASH'
+const macos_v3_caller_vexe_env = 'V_MACOS_V3_CALLER_VEXE'
+const macos_v3_caller_vexe_present_env = 'V_MACOS_V3_CALLER_VEXE_PRESENT'
+const macos_v3_caller_vchild_env = 'V_MACOS_V3_CALLER_VCHILD'
+const macos_v3_caller_vchild_present_env = 'V_MACOS_V3_CALLER_VCHILD_PRESENT'
 const macos_v3_inline_asm_fallback = 'inline_asm'
 
 fn maybe_delegate_to_macos_v3(command string, prefs &pref.Preferences) {
@@ -191,6 +195,7 @@ fn macos_v3_forwarded_args(prefs &pref.Preferences, raw_args []string) []string 
 }
 
 fn launch_macos_v3_compiler(prefs &pref.Preferences, raw_args []string) {
+	caller_environment := os.environ()
 	vexe := pref.vexe_path()
 	vroot := os.dir(vexe)
 	util.set_vroot_folder(vroot)
@@ -221,7 +226,7 @@ fn launch_macos_v3_compiler(prefs &pref.Preferences, raw_args []string) {
 	process.set_args(forwarded_args)
 	fallback_file := os.join_path(os.vtmp_dir(), 'macos_v3_fallback_${os.getpid()}')
 	os.rm(fallback_file) or {}
-	environment := macos_v3_child_environment(vexe, fallback_file)
+	environment := macos_v3_child_environment(vexe, fallback_file, caller_environment)
 	process.set_environment(environment)
 	process.run()
 	process.wait()
@@ -238,14 +243,28 @@ fn launch_macos_v3_compiler(prefs &pref.Preferences, raw_args []string) {
 	exit(exit_code)
 }
 
-fn macos_v3_child_environment(vexe string, fallback_file string) map[string]string {
-	mut environment := os.environ()
+fn macos_v3_child_environment(vexe string, fallback_file string, caller_environment map[string]string) map[string]string {
+	mut environment := caller_environment.clone()
+	preserve_macos_v3_caller_environment_value(mut environment, caller_environment, 'VEXE',
+		macos_v3_caller_vexe_env, macos_v3_caller_vexe_present_env)
+	preserve_macos_v3_caller_environment_value(mut environment, caller_environment, 'VCHILD',
+		macos_v3_caller_vchild_env, macos_v3_caller_vchild_present_env)
 	environment['VCHILD'] = 'true'
 	environment['VEXE'] = os.real_path(vexe)
 	environment[macos_v3_fallback_file_env] = fallback_file
 	environment[macos_v3_vhash_env] = @VHASH
 	environment[macos_v3_vcurrent_hash_env] = @VCURRENTHASH
 	return environment
+}
+
+fn preserve_macos_v3_caller_environment_value(mut environment map[string]string, caller_environment map[string]string, name string, value_name string, present_name string) {
+	if value := caller_environment[name] {
+		environment[value_name] = value
+		environment[present_name] = '1'
+	} else {
+		environment[value_name] = ''
+		environment[present_name] = '0'
+	}
 }
 
 fn build_macos_v3_compiler(vexe string, vroot string, v3_source string, v3_exe string, is_verbose bool) {

--- a/cmd/v/macos_v3_darwin.c.v
+++ b/cmd/v/macos_v3_darwin.c.v
@@ -1,0 +1,135 @@
+module main
+
+import hash
+import os
+import os.filelock
+import time
+import v.pref
+import v.util
+
+const macos_v3_bootstrap_env = 'V_MACOS_V3_BOOTSTRAP'
+const macos_v3_executable_env = 'V_MACOS_V3_EXECUTABLE'
+
+fn maybe_delegate_to_macos_v3(command string, prefs &pref.Preferences) {
+	if os.getenv(macos_v3_bootstrap_env) != '' || !is_macos_v3_default_executable(os.executable())
+		|| !is_macos_v3_relevant_command(command, prefs) {
+		return
+	}
+	launch_macos_v3_compiler(prefs)
+}
+
+fn is_macos_v3_default_executable(vexe string) bool {
+	return os.base(vexe) in ['v', 'v.exe', 'vnew', 'vnew.exe']
+}
+
+fn is_macos_v3_relevant_command(command string, prefs &pref.Preferences) bool {
+	if prefs.path == '' || prefs.backend != .c || prefs.os != .macos {
+		return false
+	}
+	if command in external_tools
+		|| command in ['help', 'version', 'new', 'init', 'install', 'link', 'list', 'outdated', 'remove', 'search', 'show', 'unlink', 'update', 'upgrade', 'vlib-docs', 'interpret', 'get', 'translate'] {
+		return false
+	}
+	if prefs.is_crun || prefs.is_test || prefs.is_prod || prefs.autofree
+		|| prefs.build_mode == .build_module || prefs.is_cstrict || prefs.use_cache
+		|| prefs.parallel_cc || prefs.exclude.len > 0 {
+		return false
+	}
+	if prefs.gc_set_by_flag && prefs.gc_mode != .no_gc {
+		return false
+	}
+	normalized_path := prefs.path.replace('\\', '/').trim_right('/')
+	if normalized_path == 'cmd/v' || normalized_path.ends_with('/cmd/v')
+		|| normalized_path.ends_with('/cmd/v/v.v') || normalized_path.starts_with('cmd/tools/')
+		|| normalized_path.contains('/cmd/tools/') {
+		// Keep the established compiler available as the compatibility fallback.
+		// V3 does not compile all of cmd/v yet, and command tools are built on
+		// demand while dispatching CLI commands such as `fmt` and `test`.
+		return false
+	}
+	return command == 'run' || command == 'build' || prefs.is_script
+		|| normalized_path.ends_with('.v') || normalized_path.ends_with('.vv')
+		|| normalized_path.ends_with('.vsh') || os.is_dir(prefs.path)
+}
+
+@[noreturn]
+fn launch_macos_v3_compiler(prefs &pref.Preferences) {
+	vexe := pref.vexe_path()
+	vroot := os.dir(vexe)
+	util.set_vroot_folder(vroot)
+	v3_source := os.join_path(vroot, 'vlib', 'v3', 'v3.v')
+	v3_source_dir := os.dir(v3_source)
+	mut v3_exe := os.getenv(macos_v3_executable_env)
+	if v3_exe == '' {
+		v3_exe = cached_macos_v3_executable_path(vroot)
+		os.mkdir_all(os.dir(v3_exe)) or {
+			eprintln('cannot create `${os.dir(v3_exe)}`: ${err}')
+			exit(1)
+		}
+		mut build_lock := filelock.new(v3_exe + '.lock')
+		if !build_lock.wait_acquire(10 * time.minute) {
+			eprintln('timed out waiting to build `${v3_source}`')
+			exit(1)
+		}
+		if util.should_recompile_tool(vexe, v3_source_dir, 'v3', v3_exe) {
+			build_macos_v3_compiler(vexe, vroot, v3_source, v3_exe, prefs.is_verbose)
+		}
+		build_lock.release()
+	}
+	mut forwarded_args := util.join_env_vflags_and_os_args()[1..].clone()
+	if !prefs.is_verbose && !prefs.is_stats && !prefs.show_timings && !prefs.show_cc {
+		forwarded_args.insert(0, '-silent')
+	}
+	// Serial stages keep cold-cache builds of larger programs below V3's
+	// physical-memory safety limit.
+	if '-no-parallel' !in forwarded_args {
+		forwarded_args.insert(0, '-no-parallel')
+	}
+	if prefs.is_verbose {
+		println('Launching macOS V3 compiler: ${os.quoted_path(v3_exe)} ${util.args_quote_paths(forwarded_args)}')
+	}
+	mut process := os.new_process(v3_exe)
+	process.set_args(forwarded_args)
+	mut environment := os.environ()
+	environment['VCHILD'] = 'true'
+	environment['VEXE'] = os.real_path(vexe)
+	process.set_environment(environment)
+	process.run()
+	process.wait()
+	exit_code := if process.code >= 0 { process.code } else { 1 }
+	process.close()
+	exit(exit_code)
+}
+
+fn build_macos_v3_compiler(vexe string, vroot string, v3_source string, v3_exe string, is_verbose bool) {
+	args := ['-prealloc', '-o', v3_exe, v3_source]
+	if is_verbose {
+		println('Compiling macOS V3 compiler with: ${os.quoted_path(vexe)} ${util.args_quote_paths(args)}')
+	}
+	mut process := os.new_process(vexe)
+	process.set_work_folder(vroot)
+	process.set_args(args)
+	mut environment := os.environ()
+	environment[macos_v3_bootstrap_env] = '1'
+	environment['VFLAGS'] = ''
+	process.set_environment(environment)
+	process.set_redirect_stdio()
+	process.run()
+	process.wait()
+	output := process.stdout_slurp() + process.stderr_slurp()
+	exit_code := if process.code >= 0 { process.code } else { 1 }
+	process.close()
+	if exit_code != 0 {
+		eprintln('cannot compile `${v3_source}`: ${exit_code}\n${output}')
+		exit(1)
+	}
+	if is_verbose && output != '' {
+		print(output)
+	}
+}
+
+fn cached_macos_v3_executable_path(vroot string) string {
+	vroot_hash := hash.sum64_string(os.real_path(vroot), 0).hex_full()
+	return util.path_of_executable(os.join_path(os.vtmp_dir(), 'v', 'delegated_v3', vroot_hash,
+		'v3'))
+}

--- a/cmd/v/macos_v3_darwin.c.v
+++ b/cmd/v/macos_v3_darwin.c.v
@@ -113,9 +113,9 @@ fn macos_v3_args_are_supported(args []string) bool {
 			'--c99', '-strict', '-cstrict', '-ownership', '--ownership', '-no-parallel',
 			'--no-parallel', '-parallel-transform', '--parallel-transform', '-all-backends',
 			'--all-backends', '-g', '-cg', '-autofree', '-v', '-checker-fixture', '-stats',
-			'-show-timings', '-showcc', '-keepc', '-no-retry-compilation', '-skip-running',
-			'-usecache', '-no-prealloc', '--no-prealloc', '-nocache', '--no-cache',
-			'-no-memory-limit', '--no-memory-limit', '-prealloc', '-enable-globals'] {
+			'-show-timings', '-showcc', '-keepc', '-skip-running', '-usecache', '-no-prealloc',
+			'--no-prealloc', '-nocache', '--no-cache', '-no-memory-limit', '--no-memory-limit',
+			'-prealloc', '-enable-globals'] {
 			i++
 			continue
 		}

--- a/cmd/v/macos_v3_darwin.c.v
+++ b/cmd/v/macos_v3_darwin.c.v
@@ -47,11 +47,12 @@ fn is_macos_v3_relevant_command(command string, prefs &pref.Preferences) bool {
 	if normalized_path == 'cmd/v' || normalized_path.ends_with('/cmd/v')
 		|| normalized_path.ends_with('/cmd/v/v.v') || normalized_path.starts_with('cmd/tools/')
 		|| normalized_path.contains('/cmd/tools/') || normalized_path.ends_with('.vv')
-		|| os.is_dir(prefs.path) {
+		|| os.is_dir(prefs.path) || macos_v3_needs_compatible_default_output(prefs.path) {
 		// Keep the established compiler available as the compatibility fallback.
 		// V3 does not compile all of cmd/v yet, and command tools are built on
 		// demand while dispatching CLI commands such as `fmt` and `test`. Legacy
-		// .vv fixtures and directory builds also retain established semantics.
+		// .vv fixtures, directory builds, and sources needing compatibility
+		// output-name derivation also retain established semantics.
 		return false
 	}
 	return command == 'run' || command == 'build' || prefs.is_script
@@ -113,6 +114,43 @@ fn macos_v3_args_are_supported(args []string) bool {
 	return input_seen
 }
 
+fn macos_v3_needs_compatible_default_output(path string) bool {
+	raw_filename := os.file_name(path)
+	filename := raw_filename.trim_space()
+	if filename != raw_filename {
+		return true
+	}
+	base := filename.all_before_last('.')
+	if base == '' || base in ['.', '..', '-'] || os.file_ext(base) in ['.c', '.js', '.wasm'] {
+		return true
+	}
+	if base == filename && filename.starts_with('.') {
+		return true
+	}
+	for c in base {
+		if c < ` ` || c == 127 {
+			return true
+		}
+	}
+	return base.ends_with('.c') || base.ends_with('.js') || base.ends_with('.wasm')
+}
+
+fn macos_v3_forwarded_args(prefs &pref.Preferences, raw_args []string) []string {
+	mut forwarded_args := raw_args.clone()
+	if prefs.skip_running && '-skip-running' !in forwarded_args {
+		forwarded_args.insert(0, '-skip-running')
+	}
+	if !prefs.is_verbose && !prefs.is_stats && !prefs.show_timings && !prefs.show_cc {
+		forwarded_args.insert(0, '-silent')
+	}
+	// Serial stages keep cold-cache builds of larger programs below V3's
+	// physical-memory safety limit.
+	if '-no-parallel' !in forwarded_args {
+		forwarded_args.insert(0, '-no-parallel')
+	}
+	return forwarded_args
+}
+
 @[noreturn]
 fn launch_macos_v3_compiler(prefs &pref.Preferences, raw_args []string) {
 	vexe := pref.vexe_path()
@@ -137,15 +175,7 @@ fn launch_macos_v3_compiler(prefs &pref.Preferences, raw_args []string) {
 		}
 		build_lock.release()
 	}
-	mut forwarded_args := raw_args.clone()
-	if !prefs.is_verbose && !prefs.is_stats && !prefs.show_timings && !prefs.show_cc {
-		forwarded_args.insert(0, '-silent')
-	}
-	// Serial stages keep cold-cache builds of larger programs below V3's
-	// physical-memory safety limit.
-	if '-no-parallel' !in forwarded_args {
-		forwarded_args.insert(0, '-no-parallel')
-	}
+	forwarded_args := macos_v3_forwarded_args(prefs, raw_args)
 	if prefs.is_verbose {
 		println('Launching macOS V3 compiler: ${os.quoted_path(v3_exe)} ${util.args_quote_paths(forwarded_args)}')
 	}

--- a/cmd/v/macos_v3_darwin.c.v
+++ b/cmd/v/macos_v3_darwin.c.v
@@ -38,7 +38,8 @@ fn is_macos_v3_relevant_command(command string, prefs &pref.Preferences) bool {
 	if (prefs.is_crun && !is_direct_vsh) || prefs.is_test || prefs.is_prod
 		|| prefs.autofree || prefs.build_mode == .build_module || prefs.is_cstrict
 		|| prefs.use_cache || prefs.parallel_cc || prefs.out_name_is_dir
-		|| prefs.exclude.len > 0 || prefs.coverage_dir != '' {
+		|| prefs.exclude.len > 0 || prefs.coverage_dir != '' || prefs.is_vlines
+		|| (prefs.is_shared && (prefs.is_run || prefs.is_crun)) {
 		return false
 	}
 	if prefs.gc_mode != .no_gc {

--- a/cmd/v/macos_v3_darwin.c.v
+++ b/cmd/v/macos_v3_darwin.c.v
@@ -93,6 +93,9 @@ fn macos_v3_args_are_supported(args []string) bool {
 			if i + 1 >= args.len {
 				return false
 			}
+			if arg == '-o' && args[i + 1] == '-' {
+				return false
+			}
 			i += 2
 			continue
 		}
@@ -104,7 +107,7 @@ fn macos_v3_args_are_supported(args []string) bool {
 			'--c99', '-strict', '-cstrict', '-ownership', '--ownership', '-no-parallel',
 			'--no-parallel', '-parallel-transform', '--parallel-transform', '-all-backends',
 			'--all-backends', '-g', '-cg', '-autofree', '-v', '-silent', '-checker-fixture', '-stats',
-			'-show-timings', '-showcc', '-keepc', '-w', '-no-retry-compilation', '-skip-running',
+			'-show-timings', '-showcc', '-keepc', '-no-retry-compilation', '-skip-running',
 			'-usecache', '-no-prealloc', '--no-prealloc', '-nocache', '--no-cache',
 			'-no-memory-limit', '--no-memory-limit', '-prealloc', '-enable-globals'] {
 			i++

--- a/cmd/v/macos_v3_darwin.c.v
+++ b/cmd/v/macos_v3_darwin.c.v
@@ -37,7 +37,8 @@ fn is_macos_v3_relevant_command(command string, prefs &pref.Preferences) bool {
 	}
 	if (prefs.is_crun && !is_direct_vsh) || prefs.is_test || prefs.is_prod
 		|| prefs.autofree || prefs.build_mode == .build_module || prefs.is_cstrict
-		|| prefs.use_cache || prefs.parallel_cc || prefs.exclude.len > 0 {
+		|| prefs.use_cache || prefs.parallel_cc || prefs.out_name_is_dir
+		|| prefs.exclude.len > 0 {
 		return false
 	}
 	if prefs.gc_set_by_flag && prefs.gc_mode != .no_gc {

--- a/cmd/v/macos_v3_default.c.v
+++ b/cmd/v/macos_v3_default.c.v
@@ -2,7 +2,8 @@ module main
 
 import v.pref
 
-fn maybe_delegate_to_macos_v3(command string, prefs &pref.Preferences) {
+fn maybe_delegate_to_macos_v3(command string, prefs &pref.Preferences) ?MacosV3CErrorReport {
 	_ = command
 	_ = prefs
+	return none
 }

--- a/cmd/v/macos_v3_default.c.v
+++ b/cmd/v/macos_v3_default.c.v
@@ -1,0 +1,8 @@
+module main
+
+import v.pref
+
+fn maybe_delegate_to_macos_v3(command string, prefs &pref.Preferences) {
+	_ = command
+	_ = prefs
+}

--- a/cmd/v/macos_v3_test.v
+++ b/cmd/v/macos_v3_test.v
@@ -239,7 +239,7 @@ fn test_macos_v3_reads_c_error_fallback_report() {
 	}
 }
 
-fn test_macos_v3_c_error_falls_back_to_old_compiler() {
+fn test_macos_v3_compiler_failures_fall_back_to_old_compiler() {
 	$if macos {
 		root := os.join_path(os.real_path(os.vtmp_dir()), 'macos_v3_c_error_retry_${os.getpid()}')
 		os.rmdir_all(root) or {}
@@ -253,6 +253,10 @@ fn test_macos_v3_c_error_falls_back_to_old_compiler() {
 
 fn main() {
 	fallback_file := os.getenv('V_MACOS_V3_FALLBACK_FILE')
+	if os.getenv('V_MACOS_V3_TEST_GENERAL_FAILURE') == '1' {
+		os.write_file(fallback_file, 'compiler_error')!
+		exit(1)
+	}
 	report_dir := os.getenv('V_MACOS_V3_C_ERROR_DIR')
 	os.mkdir_all(report_dir)!
 	os.write_file(os.join_path(report_dir, 'compiler'), 'clang')!
@@ -315,6 +319,25 @@ fn main() {
 			'macos_v3_fallback_${run_compiler_pid}.c_error')
 		assert !os.exists(run_report_dir), 'run fallback report directory was not cleaned: ${run_report_dir}'
 		assert !os.exists(output), 'run fallback executable was not cleaned: ${output}'
+
+		general_output := os.join_path(root, 'general_fallback')
+		environment['V_MACOS_V3_TEST_GENERAL_FAILURE'] = '1'
+		mut general_process := os.new_process(@VEXE)
+		general_process.set_args(['-gc', 'none', '-o', general_output, target])
+		general_process.set_environment(environment)
+		general_process.set_redirect_stdio()
+		general_process.run()
+		general_process.wait()
+		general_output_text := general_process.stdout_slurp() + general_process.stderr_slurp()
+		general_exit_code := general_process.code
+		general_process.close()
+		assert general_exit_code == 0, general_output_text
+		assert general_output_text.contains('V3 compilation failed; retrying with `-old-compiler`.'), general_output_text
+
+		assert os.is_executable(general_output)
+		general_run := os.execute(os.quoted_path(general_output))
+		assert general_run.exit_code == 0
+		assert general_run.output.trim_space() == 'old compiler retry succeeded'
 	}
 }
 

--- a/cmd/v/macos_v3_test.v
+++ b/cmd/v/macos_v3_test.v
@@ -22,6 +22,9 @@ fn test_macos_v3_relevant_command_only_selects_supported_native_c_builds() {
 		assert is_macos_v3_relevant_command('main.v', prefs)
 		prefs.output_mode = .stdout
 		prefs.show_cc = false
+		prefs.is_o = true
+		assert !is_macos_v3_relevant_command('main.v', prefs)
+		prefs.is_o = false
 		prefs.is_vlines = true
 		assert !is_macos_v3_relevant_command('main.v', prefs)
 		prefs.is_vlines = false
@@ -92,6 +95,14 @@ fn test_macos_v3_relevant_command_only_selects_supported_native_c_builds() {
 		os.symlink(source, alias) or { panic(err) }
 		prefs.path = alias
 		assert !is_macos_v3_relevant_command(alias, prefs)
+	}
+}
+
+fn test_macos_v3_environment_flags_require_compatibility_compiler() {
+	$if macos {
+		assert macos_v3_environment_flags_are_supported('', '')
+		assert !macos_v3_environment_flags_are_supported('-DMACOS_V3_CFLAGS', '')
+		assert !macos_v3_environment_flags_are_supported('', '-framework Cocoa')
 	}
 }
 

--- a/cmd/v/macos_v3_test.v
+++ b/cmd/v/macos_v3_test.v
@@ -1,5 +1,6 @@
 module main
 
+import os
 import v.pref
 
 fn test_macos_v3_relevant_command_only_selects_supported_native_c_builds() {
@@ -9,8 +10,12 @@ fn test_macos_v3_relevant_command_only_selects_supported_native_c_builds() {
 			backend:   .c
 			os:        .macos
 			is_script: true
+			gc_mode:   .no_gc
 		}
 		assert is_macos_v3_relevant_command('main.v', prefs)
+		prefs.gc_mode = .boehm_full_opt
+		assert !is_macos_v3_relevant_command('main.v', prefs)
+		prefs.gc_mode = .no_gc
 		prefs.is_run = true
 		assert is_macos_v3_relevant_command('run', prefs)
 		prefs.os = .linux
@@ -52,6 +57,18 @@ fn test_macos_v3_relevant_command_only_selects_supported_native_c_builds() {
 			prefs.path = path
 			assert !is_macos_v3_relevant_command(path, prefs)
 		}
+		root := os.join_path(os.vtmp_dir(), 'macos_v3_symlink_${os.getpid()}')
+		os.rmdir_all(root) or {}
+		os.mkdir_all(root) or { panic(err) }
+		defer {
+			os.rmdir_all(root) or {}
+		}
+		source := os.join_path(root, 'source.v')
+		alias := os.join_path(root, 'alias.v')
+		os.write_file(source, 'fn main() {}\n') or { panic(err) }
+		os.symlink(source, alias) or { panic(err) }
+		prefs.path = alias
+		assert !is_macos_v3_relevant_command(alias, prefs)
 	}
 }
 

--- a/cmd/v/macos_v3_test.v
+++ b/cmd/v/macos_v3_test.v
@@ -338,6 +338,28 @@ fn main() {
 		general_run := os.execute(os.quoted_path(general_output))
 		assert general_run.exit_code == 0
 		assert general_run.output.trim_space() == 'old compiler retry succeeded'
+
+		environment.delete('V_MACOS_V3_TEST_GENERAL_FAILURE')
+		failing_target := os.join_path(root, 'failing_target.v')
+		failing_output := os.join_path(root, 'failing_target')
+		os.write_file(failing_target, '#flag -lmacos_v3_missing_library_${os.getpid()}
+
+fn main() {}
+')!
+		mut failing_process := os.new_process(@VEXE)
+		failing_process.set_args(['-gc', 'none', '-o', failing_output, failing_target])
+		failing_process.set_environment(environment)
+		failing_process.set_redirect_stdio()
+		failing_process.run()
+		failing_compiler_pid := failing_process.pid
+		failing_process.wait()
+		failing_output_text := failing_process.stdout_slurp() + failing_process.stderr_slurp()
+		failing_exit_code := failing_process.code
+		failing_process.close()
+		assert failing_exit_code != 0, failing_output_text
+		failing_report_dir := os.join_path(os.vtmp_dir(),
+			'macos_v3_fallback_${failing_compiler_pid}.c_error')
+		assert !os.exists(failing_report_dir), 'failed compatibility build left staged report directory: ${failing_report_dir}'
 	}
 }
 

--- a/cmd/v/macos_v3_test.v
+++ b/cmd/v/macos_v3_test.v
@@ -13,6 +13,15 @@ fn test_macos_v3_relevant_command_only_selects_supported_native_c_builds() {
 			gc_mode:   .no_gc
 		}
 		assert is_macos_v3_relevant_command('main.v', prefs)
+		prefs.coverage_dir = '/tmp/vcovdir'
+		assert !is_macos_v3_relevant_command('main.v', prefs)
+		prefs.coverage_dir = ''
+		prefs.show_cc = true
+		assert is_macos_v3_relevant_command('main.v', prefs)
+		prefs.output_mode = .silent
+		assert !is_macos_v3_relevant_command('main.v', prefs)
+		prefs.output_mode = .stdout
+		prefs.show_cc = false
 		prefs.gc_mode = .boehm_full_opt
 		assert !is_macos_v3_relevant_command('main.v', prefs)
 		prefs.gc_mode = .no_gc

--- a/cmd/v/macos_v3_test.v
+++ b/cmd/v/macos_v3_test.v
@@ -172,6 +172,14 @@ fn test_macos_v3_bootstrap_clears_argument_environment() {
 	}
 }
 
+fn test_macos_v3_child_environment_forwards_compiler_hashes() {
+	$if macos {
+		environment := macos_v3_child_environment(@VEXE, '/tmp/macos_v3_fallback')
+		assert environment[macos_v3_vhash_env] == @VHASH
+		assert environment[macos_v3_vcurrent_hash_env] == @VCURRENTHASH
+	}
+}
+
 fn test_macos_v3_default_executable_excludes_temporary_self_hosted_compilers() {
 	$if macos {
 		assert is_macos_v3_default_executable('/tmp/v')

--- a/cmd/v/macos_v3_test.v
+++ b/cmd/v/macos_v3_test.v
@@ -95,6 +95,8 @@ fn test_macos_v3_args_only_accept_options_implemented_by_v3() {
 		assert !macos_v3_args_are_supported(['-path', '@vlib', 'main.v'])
 		assert !macos_v3_args_are_supported(['-show-c-output', 'main.v'])
 		assert !macos_v3_args_are_supported(['-output', 'main', 'main.v'])
+		assert !macos_v3_args_are_supported(['-o', '-', 'main.v'])
+		assert !macos_v3_args_are_supported(['-w', 'main.v'])
 		for help_flag in ['-?', '-h', '-help', '--help'] {
 			assert !macos_v3_args_are_supported(['-gc', 'none', help_flag, 'main.v'])
 		}

--- a/cmd/v/macos_v3_test.v
+++ b/cmd/v/macos_v3_test.v
@@ -174,9 +174,29 @@ fn test_macos_v3_bootstrap_clears_argument_environment() {
 
 fn test_macos_v3_child_environment_forwards_compiler_hashes() {
 	$if macos {
-		environment := macos_v3_child_environment(@VEXE, '/tmp/macos_v3_fallback')
+		caller_environment := {
+			'PATH':   '/usr/bin'
+			'VEXE':   'caller-vexe'
+			'VCHILD': 'caller-vchild'
+		}
+		environment := macos_v3_child_environment(@VEXE, '/tmp/macos_v3_fallback',
+			caller_environment)
 		assert environment[macos_v3_vhash_env] == @VHASH
 		assert environment[macos_v3_vcurrent_hash_env] == @VCURRENTHASH
+		assert environment['VEXE'] == os.real_path(@VEXE)
+		assert environment['VCHILD'] == 'true'
+		assert environment[macos_v3_caller_vexe_present_env] == '1'
+		assert environment[macos_v3_caller_vexe_env] == 'caller-vexe'
+		assert environment[macos_v3_caller_vchild_present_env] == '1'
+		assert environment[macos_v3_caller_vchild_env] == 'caller-vchild'
+
+		unset_environment := macos_v3_child_environment(@VEXE, '/tmp/macos_v3_fallback', {
+			'PATH': '/usr/bin'
+		})
+		assert unset_environment[macos_v3_caller_vexe_present_env] == '0'
+		assert unset_environment[macos_v3_caller_vexe_env] == ''
+		assert unset_environment[macos_v3_caller_vchild_present_env] == '0'
+		assert unset_environment[macos_v3_caller_vchild_env] == ''
 	}
 }
 

--- a/cmd/v/macos_v3_test.v
+++ b/cmd/v/macos_v3_test.v
@@ -186,6 +186,42 @@ fn test_macos_v3_bootstrap_clears_argument_environment() {
 	}
 }
 
+fn test_macos_v3_external_tool_children_do_not_inherit_bootstrap() {
+	$if macos {
+		root := os.join_path(os.vtmp_dir(), 'macos_v3_external_tool_env_${os.getpid()}')
+		os.rmdir_all(root) or {}
+		os.mkdir_all(root) or { panic(err) }
+		defer {
+			os.rmdir_all(root) or {}
+		}
+		target := os.join_path(root, 'bootstrap_environment_test.v')
+		os.write_file(target, "import os
+
+const compile_bootstrap = \$env('V_MACOS_V3_BOOTSTRAP')
+
+fn test_bootstrap_is_private() {
+	assert compile_bootstrap == ''
+	assert os.getenv('V_MACOS_V3_BOOTSTRAP') == ''
+}
+")!
+		mut environment := os.environ()
+		environment.delete(macos_v3_bootstrap_env)
+		environment[macos_v3_executable_env] = os.join_path(root, 'missing_v3')
+		environment['VFLAGS'] = ''
+		environment['VOSARGS'] = ''
+		mut process := os.new_process(@VEXE)
+		process.set_args(['test', target])
+		process.set_environment(environment)
+		process.set_redirect_stdio()
+		process.run()
+		process.wait()
+		output := process.stdout_slurp() + process.stderr_slurp()
+		exit_code := process.code
+		process.close()
+		assert exit_code == 0, output
+	}
+}
+
 fn test_macos_v3_child_environment_forwards_compiler_hashes() {
 	$if macos {
 		caller_environment := {

--- a/cmd/v/macos_v3_test.v
+++ b/cmd/v/macos_v3_test.v
@@ -43,6 +43,10 @@ fn test_macos_v3_relevant_command_only_selects_supported_native_c_builds() {
 		prefs.is_crun = true
 		assert is_macos_v3_relevant_command('script.vsh', prefs)
 		assert !is_macos_v3_relevant_command('crun', prefs)
+		prefs.is_crun = false
+		prefs.path = 'main.v'
+		prefs.out_name_is_dir = true
+		assert !is_macos_v3_relevant_command('main.v', prefs)
 	}
 }
 

--- a/cmd/v/macos_v3_test.v
+++ b/cmd/v/macos_v3_test.v
@@ -142,10 +142,20 @@ fn test_macos_v3_args_only_accept_options_implemented_by_v3() {
 		assert !macos_v3_args_are_supported(['-output', 'main', 'main.v'])
 		assert !macos_v3_args_are_supported(['-o', '-', 'main.v'])
 		assert !macos_v3_args_are_supported(['-o', '-foo', 'main.v'])
+		assert !macos_v3_args_are_supported(['-silent', 'main.v'])
 		assert !macos_v3_args_are_supported(['-w', 'main.v'])
 		for help_flag in ['-?', '-h', '-help', '--help'] {
 			assert !macos_v3_args_are_supported(['-gc', 'none', help_flag, 'main.v'])
 		}
+	}
+}
+
+fn test_macos_v3_bootstrap_clears_argument_environment() {
+	$if macos {
+		environment := macos_v3_bootstrap_environment()
+		assert environment[macos_v3_bootstrap_env] == '1'
+		assert environment['VFLAGS'] == ''
+		assert environment['VOSARGS'] == ''
 	}
 }
 

--- a/cmd/v/macos_v3_test.v
+++ b/cmd/v/macos_v3_test.v
@@ -3,6 +3,18 @@ module main
 import os
 import v.pref
 
+fn test_macos_v3_default_is_limited_to_macos_26_2_or_github_actions() {
+	$if macos {
+		assert macos_v3_default_is_enabled('26.2', '')
+		assert macos_v3_default_is_enabled('26.2.1', '')
+		for version in ['', '26', '25.7', '26.1', '26.3', '27.0', 'invalid'] {
+			assert !macos_v3_default_is_enabled(version, '')
+		}
+		assert macos_v3_default_is_enabled('', 'true')
+		assert macos_v3_default_is_enabled('25.7', 'true')
+	}
+}
+
 fn test_macos_v3_relevant_command_only_selects_supported_native_c_builds() {
 	$if macos {
 		mut prefs := &pref.Preferences{
@@ -327,6 +339,7 @@ fn main() {
 ")!
 		mut environment := os.environ()
 		environment[macos_v3_executable_env] = fake_v3
+		environment['GITHUB_ACTIONS'] = 'true'
 		environment['V_C_ERROR_BUG_REPORT_DISABLED'] = '1'
 		environment[macos_v3_bootstrap_env] = ''
 		environment['VFLAGS'] = ''

--- a/cmd/v/macos_v3_test.v
+++ b/cmd/v/macos_v3_test.v
@@ -35,6 +35,27 @@ fn test_macos_v3_relevant_command_only_selects_supported_native_c_builds() {
 		prefs.is_prod = false
 		prefs.path = 'version'
 		assert !is_macos_v3_relevant_command('version', prefs)
+		prefs.path = 'vlib/v3'
+		assert !is_macos_v3_relevant_command('vlib/v3', prefs)
+		prefs.path = 'fixture.vv'
+		assert !is_macos_v3_relevant_command('run', prefs)
+		prefs.path = 'script.vsh'
+		prefs.is_crun = true
+		assert is_macos_v3_relevant_command('script.vsh', prefs)
+		assert !is_macos_v3_relevant_command('crun', prefs)
+	}
+}
+
+fn test_macos_v3_args_only_accept_options_implemented_by_v3() {
+	$if macos {
+		assert macos_v3_args_are_supported(['main.v'])
+		assert macos_v3_args_are_supported(['-keepc', '-o', 'main', 'build', 'main.v'])
+		assert macos_v3_args_are_supported(['run', 'main.v', '--program-option'])
+		assert macos_v3_args_are_supported(['script.vsh', '--script-option'])
+		assert !macos_v3_args_are_supported(['-ldflags', '-framework Cocoa', 'main.v'])
+		assert !macos_v3_args_are_supported(['-path', '@vlib', 'main.v'])
+		assert !macos_v3_args_are_supported(['-show-c-output', 'main.v'])
+		assert !macos_v3_args_are_supported(['-output', 'main', 'main.v'])
 	}
 }
 

--- a/cmd/v/macos_v3_test.v
+++ b/cmd/v/macos_v3_test.v
@@ -36,7 +36,7 @@ fn test_macos_v3_relevant_command_only_selects_supported_native_c_builds() {
 		prefs.is_shared = true
 		assert !is_macos_v3_relevant_command('run', prefs)
 		prefs.is_run = false
-		assert is_macos_v3_relevant_command('main.v', prefs)
+		assert !is_macos_v3_relevant_command('main.v', prefs)
 		prefs.path = 'script.vsh'
 		prefs.is_crun = true
 		assert !is_macos_v3_relevant_command('script.vsh', prefs)

--- a/cmd/v/macos_v3_test.v
+++ b/cmd/v/macos_v3_test.v
@@ -95,6 +95,9 @@ fn test_macos_v3_args_only_accept_options_implemented_by_v3() {
 		assert !macos_v3_args_are_supported(['-path', '@vlib', 'main.v'])
 		assert !macos_v3_args_are_supported(['-show-c-output', 'main.v'])
 		assert !macos_v3_args_are_supported(['-output', 'main', 'main.v'])
+		for help_flag in ['-?', '-h', '-help', '--help'] {
+			assert !macos_v3_args_are_supported(['-gc', 'none', help_flag, 'main.v'])
+		}
 	}
 }
 

--- a/cmd/v/macos_v3_test.v
+++ b/cmd/v/macos_v3_test.v
@@ -134,6 +134,8 @@ fn test_macos_v3_args_only_accept_options_implemented_by_v3() {
 	$if macos {
 		assert macos_v3_args_are_supported(['main.v'])
 		assert macos_v3_args_are_supported(['-keepc', '-o', 'main', 'build', 'main.v'])
+		assert macos_v3_args_are_supported(['-dcompact_define', 'main.v'])
+		assert macos_v3_args_are_supported(['-dcompact_value=enabled', 'main.v'])
 		assert macos_v3_args_are_supported(['run', 'main.v', '--program-option'])
 		assert macos_v3_args_are_supported(['script.vsh', '--script-option'])
 		assert !macos_v3_args_are_supported(['-ldflags', '-framework Cocoa', 'main.v'])
@@ -145,6 +147,10 @@ fn test_macos_v3_args_only_accept_options_implemented_by_v3() {
 		assert !macos_v3_args_are_supported(['-no-retry-compilation', 'main.v'])
 		assert !macos_v3_args_are_supported(['-silent', 'main.v'])
 		assert !macos_v3_args_are_supported(['-w', 'main.v'])
+		for named_d_flag in ['-debug', '-debug-tcc', '-define', '-disable-explicit-mutability',
+			'-div-by-zero-is-zero', '-dump-c-flags', '-dump-modules', '-dump-files', '-dump-defines'] {
+			assert !macos_v3_args_are_supported([named_d_flag, 'main.v'])
+		}
 		for help_flag in ['-?', '-h', '-help', '--help'] {
 			assert !macos_v3_args_are_supported(['-gc', 'none', help_flag, 'main.v'])
 		}

--- a/cmd/v/macos_v3_test.v
+++ b/cmd/v/macos_v3_test.v
@@ -70,6 +70,9 @@ fn test_macos_v3_relevant_command_only_selects_supported_native_c_builds() {
 		assert !is_macos_v3_relevant_command('vlib/v3', prefs)
 		prefs.path = 'fixture.vv'
 		assert !is_macos_v3_relevant_command('run', prefs)
+		prefs.path = 'program.txt'
+		assert !is_macos_v3_relevant_command('run', prefs)
+		assert !is_macos_v3_relevant_command('build', prefs)
 		prefs.path = 'script.vsh'
 		prefs.is_crun = true
 		assert is_macos_v3_relevant_command('script.vsh', prefs)

--- a/cmd/v/macos_v3_test.v
+++ b/cmd/v/macos_v3_test.v
@@ -150,8 +150,15 @@ fn test_macos_v3_args_only_accept_options_implemented_by_v3() {
 		assert !macos_v3_args_are_supported(['-output', 'main', 'main.v'])
 		assert !macos_v3_args_are_supported(['-o', '-', 'main.v'])
 		assert !macos_v3_args_are_supported(['-o', '-foo', 'main.v'])
-		assert !macos_v3_args_are_supported(['-arch', 'x86', 'main.v'])
-		assert macos_v3_args_are_supported(['-arch', 'x86_64', 'main.v'])
+		for arch in ['x86', 'rv32', 'riscv32', 'sparc64', 'ppc', 'ppc32', 'powerpc', 'js', 'js_node',
+			'js_browser', 'js_freestanding'] {
+			assert !macos_v3_args_are_supported(['-arch', arch, 'main.v'])
+		}
+		for arch in ['amd64', 'x86_64', 'x64', 'arm64', 'aarch64', 'arm32', 'aarch32', 'arm', 'rv64',
+			'riscv64', 'risc-v64', 'riscv', 'risc-v', 'i386', 'x86_32', 'x32', 'IA-32', 'ia-32',
+			'ia32', 's390x', 'ppc64le', 'loongarch64', 'ppc64', 'wasm32', 'wasm'] {
+			assert macos_v3_args_are_supported(['-arch', arch, 'main.v'])
+		}
 		assert macos_v3_args_are_supported(['-no-memory-limit', 'main.v'])
 		assert macos_v3_args_are_supported(['--no-memory-limit', 'main.v'])
 		assert !macos_v3_args_are_supported(['-no-retry-compilation', 'main.v'])

--- a/cmd/v/macos_v3_test.v
+++ b/cmd/v/macos_v3_test.v
@@ -152,6 +152,8 @@ fn test_macos_v3_args_only_accept_options_implemented_by_v3() {
 		assert !macos_v3_args_are_supported(['-o', '-foo', 'main.v'])
 		assert !macos_v3_args_are_supported(['-arch', 'x86', 'main.v'])
 		assert macos_v3_args_are_supported(['-arch', 'x86_64', 'main.v'])
+		assert macos_v3_args_are_supported(['-no-memory-limit', 'main.v'])
+		assert macos_v3_args_are_supported(['--no-memory-limit', 'main.v'])
 		assert !macos_v3_args_are_supported(['-no-retry-compilation', 'main.v'])
 		assert !macos_v3_args_are_supported(['-silent', 'main.v'])
 		assert !macos_v3_args_are_supported(['-w', 'main.v'])

--- a/cmd/v/macos_v3_test.v
+++ b/cmd/v/macos_v3_test.v
@@ -19,7 +19,7 @@ fn test_macos_v3_relevant_command_only_selects_supported_native_c_builds() {
 		prefs.show_cc = true
 		assert is_macos_v3_relevant_command('main.v', prefs)
 		prefs.output_mode = .silent
-		assert !is_macos_v3_relevant_command('main.v', prefs)
+		assert is_macos_v3_relevant_command('main.v', prefs)
 		prefs.output_mode = .stdout
 		prefs.show_cc = false
 		prefs.gc_mode = .boehm_full_opt
@@ -88,9 +88,20 @@ fn test_macos_v3_forwards_environment_driven_skip_running() {
 		}
 		forwarded := macos_v3_forwarded_args(prefs, ['script.vsh'])
 		assert '-skip-running' in forwarded
-		assert forwarded.count('-skip-running') == 1
+		assert forwarded.count(it == '-skip-running') == 1
 		already_explicit := macos_v3_forwarded_args(prefs, ['-skip-running', 'script.vsh'])
-		assert already_explicit.count('-skip-running') == 1
+		assert already_explicit.count(it == '-skip-running') == 1
+	}
+}
+
+fn test_macos_v3_forwards_showcc_with_quiet_benchmarks() {
+	$if macos {
+		prefs := &pref.Preferences{
+			show_cc: true
+		}
+		forwarded := macos_v3_forwarded_args(prefs, ['-showcc', 'main.v'])
+		assert '-silent' in forwarded
+		assert '-showcc' in forwarded
 	}
 }
 
@@ -105,6 +116,7 @@ fn test_macos_v3_args_only_accept_options_implemented_by_v3() {
 		assert !macos_v3_args_are_supported(['-show-c-output', 'main.v'])
 		assert !macos_v3_args_are_supported(['-output', 'main', 'main.v'])
 		assert !macos_v3_args_are_supported(['-o', '-', 'main.v'])
+		assert !macos_v3_args_are_supported(['-o', '-foo', 'main.v'])
 		assert !macos_v3_args_are_supported(['-w', 'main.v'])
 		for help_flag in ['-?', '-h', '-help', '--help'] {
 			assert !macos_v3_args_are_supported(['-gc', 'none', help_flag, 'main.v'])

--- a/cmd/v/macos_v3_test.v
+++ b/cmd/v/macos_v3_test.v
@@ -150,6 +150,8 @@ fn test_macos_v3_args_only_accept_options_implemented_by_v3() {
 		assert !macos_v3_args_are_supported(['-output', 'main', 'main.v'])
 		assert !macos_v3_args_are_supported(['-o', '-', 'main.v'])
 		assert !macos_v3_args_are_supported(['-o', '-foo', 'main.v'])
+		assert !macos_v3_args_are_supported(['-arch', 'x86', 'main.v'])
+		assert macos_v3_args_are_supported(['-arch', 'x86_64', 'main.v'])
 		assert !macos_v3_args_are_supported(['-no-retry-compilation', 'main.v'])
 		assert !macos_v3_args_are_supported(['-silent', 'main.v'])
 		assert !macos_v3_args_are_supported(['-w', 'main.v'])

--- a/cmd/v/macos_v3_test.v
+++ b/cmd/v/macos_v3_test.v
@@ -47,6 +47,24 @@ fn test_macos_v3_relevant_command_only_selects_supported_native_c_builds() {
 		prefs.path = 'main.v'
 		prefs.out_name_is_dir = true
 		assert !is_macos_v3_relevant_command('main.v', prefs)
+		prefs.out_name_is_dir = false
+		for path in ['foo.c.v', 'foo.js.v', 'foo.wasm.v', '.v'] {
+			prefs.path = path
+			assert !is_macos_v3_relevant_command(path, prefs)
+		}
+	}
+}
+
+fn test_macos_v3_forwards_environment_driven_skip_running() {
+	$if macos {
+		prefs := &pref.Preferences{
+			skip_running: true
+		}
+		forwarded := macos_v3_forwarded_args(prefs, ['script.vsh'])
+		assert '-skip-running' in forwarded
+		assert forwarded.count('-skip-running') == 1
+		already_explicit := macos_v3_forwarded_args(prefs, ['-skip-running', 'script.vsh'])
+		assert already_explicit.count('-skip-running') == 1
 	}
 }
 

--- a/cmd/v/macos_v3_test.v
+++ b/cmd/v/macos_v3_test.v
@@ -13,6 +13,9 @@ fn test_macos_v3_relevant_command_only_selects_supported_native_c_builds() {
 			gc_mode:   .no_gc
 		}
 		assert is_macos_v3_relevant_command('main.v', prefs)
+		prefs.old_compiler = true
+		assert !is_macos_v3_relevant_command('main.v', prefs)
+		prefs.old_compiler = false
 		prefs.coverage_dir = '/tmp/vcovdir'
 		assert !is_macos_v3_relevant_command('main.v', prefs)
 		prefs.coverage_dir = ''
@@ -194,6 +197,7 @@ fn test_macos_v3_child_environment_forwards_compiler_hashes() {
 			caller_environment)
 		assert environment[macos_v3_vhash_env] == @VHASH
 		assert environment[macos_v3_vcurrent_hash_env] == @VCURRENTHASH
+		assert environment[macos_v3_c_error_dir_env] == '/tmp/macos_v3_fallback.c_error'
 		assert environment['VEXE'] == os.real_path(@VEXE)
 		assert environment['VCHILD'] == 'true'
 		assert environment[macos_v3_caller_vexe_present_env] == '1'
@@ -208,6 +212,87 @@ fn test_macos_v3_child_environment_forwards_compiler_hashes() {
 		assert unset_environment[macos_v3_caller_vexe_env] == ''
 		assert unset_environment[macos_v3_caller_vchild_present_env] == '0'
 		assert unset_environment[macos_v3_caller_vchild_env] == ''
+	}
+}
+
+fn test_macos_v3_reads_c_error_fallback_report() {
+	$if macos {
+		root := os.join_path(os.vtmp_dir(), 'macos_v3_c_error_report_${os.getpid()}')
+		os.rmdir_all(root) or {}
+		os.mkdir_all(root) or { panic(err) }
+		defer {
+			os.rmdir_all(root) or {}
+		}
+		os.write_file(os.join_path(root, macos_v3_c_error_source_name_file), 'src.c')!
+		os.write_file(os.join_path(root, macos_v3_c_error_compiler_file), 'clang')!
+		os.write_file(os.join_path(root, macos_v3_c_error_output_file),
+			'src.c:2:1: error: generated failure')!
+		os.write_file(os.join_path(root, 'src.c'), 'int main(void) { return missing; }\n')!
+		report := read_macos_v3_c_error_report(root) or {
+			assert false
+			return
+		}
+		assert report.ccompiler == 'clang'
+		assert report.c_output.contains('generated failure')
+		assert report.c_file == os.join_path(root, 'src.c')
+		assert report.report_dir == root
+	}
+}
+
+fn test_macos_v3_c_error_falls_back_to_old_compiler() {
+	$if macos {
+		root := os.join_path(os.real_path(os.vtmp_dir()), 'macos_v3_c_error_retry_${os.getpid()}')
+		os.rmdir_all(root) or {}
+		os.mkdir_all(root) or { panic(err) }
+		defer {
+			os.rmdir_all(root) or {}
+		}
+		fake_source := os.join_path(root, 'fake_v3.v')
+		fake_v3 := os.join_path(root, 'fake_v3')
+		os.write_file(fake_source, "import os
+
+fn main() {
+	fallback_file := os.getenv('V_MACOS_V3_FALLBACK_FILE')
+	report_dir := os.getenv('V_MACOS_V3_C_ERROR_DIR')
+	os.mkdir_all(report_dir)!
+	os.write_file(os.join_path(report_dir, 'compiler'), 'clang')!
+	os.write_file(os.join_path(report_dir, 'output'), 'src.c:1:1: error: simulated V3 failure')!
+	os.write_file(os.join_path(report_dir, 'source_name'), 'src.c')!
+	os.write_file(os.join_path(report_dir, 'src.c'), 'int simulated_v3_failure;\\n')!
+	os.write_file(fallback_file, 'c_compilation_error')!
+	exit(1)
+}
+")!
+		fake_build :=
+			os.execute('${os.quoted_path(@VEXE)} -old-compiler -o ${os.quoted_path(fake_v3)} ${os.quoted_path(fake_source)}')
+		assert fake_build.exit_code == 0, fake_build.output
+		target := os.join_path(root, 'target.v')
+		output := os.join_path(root, 'target')
+		os.write_file(target, "fn main() {
+	println('old compiler retry succeeded')
+}
+")!
+		mut environment := os.environ()
+		environment[macos_v3_executable_env] = fake_v3
+		environment['V_C_ERROR_BUG_REPORT_DISABLED'] = '1'
+		environment[macos_v3_bootstrap_env] = ''
+		environment['VFLAGS'] = ''
+		environment['VOSARGS'] = ''
+		mut process := os.new_process(@VEXE)
+		process.set_args(['-gc', 'none', '-o', output, target])
+		process.set_environment(environment)
+		process.set_redirect_stdio()
+		process.run()
+		process.wait()
+		compiler_output := process.stdout_slurp() + process.stderr_slurp()
+		exit_code := process.code
+		process.close()
+		assert exit_code == 0, compiler_output
+		assert compiler_output.contains('retrying with `-old-compiler`'), compiler_output
+		assert os.is_executable(output)
+		run := os.execute(os.quoted_path(output))
+		assert run.exit_code == 0
+		assert run.output.trim_space() == 'old compiler retry succeeded'
 	}
 }
 

--- a/cmd/v/macos_v3_test.v
+++ b/cmd/v/macos_v3_test.v
@@ -137,8 +137,10 @@ fn test_macos_v3_args_only_accept_options_implemented_by_v3() {
 	$if macos {
 		assert macos_v3_args_are_supported(['main.v'])
 		assert macos_v3_args_are_supported(['-keepc', '-o', 'main', 'build', 'main.v'])
+		assert macos_v3_args_are_supported(['-d', 'spaced_define', 'main.v'])
 		assert macos_v3_args_are_supported(['-dcompact_define', 'main.v'])
-		assert macos_v3_args_are_supported(['-dcompact_value=enabled', 'main.v'])
+		assert !macos_v3_args_are_supported(['-d', 'spaced_value=enabled', 'main.v'])
+		assert !macos_v3_args_are_supported(['-dcompact_value=enabled', 'main.v'])
 		assert macos_v3_args_are_supported(['run', 'main.v', '--program-option'])
 		assert macos_v3_args_are_supported(['script.vsh', '--script-option'])
 		assert !macos_v3_args_are_supported(['-ldflags', '-framework Cocoa', 'main.v'])

--- a/cmd/v/macos_v3_test.v
+++ b/cmd/v/macos_v3_test.v
@@ -136,6 +136,17 @@ fn test_macos_v3_forwards_showcc_with_quiet_benchmarks() {
 	}
 }
 
+fn test_macos_v3_forwards_compatibility_c99_mode() {
+	$if macos {
+		prefs := &pref.Preferences{}
+		forwarded := macos_v3_forwarded_args(prefs, ['main.v'])
+		assert macos_v3_compat_c99_flag in forwarded
+		assert forwarded.count(it == macos_v3_compat_c99_flag) == 1
+		already_present := macos_v3_forwarded_args(prefs, [macos_v3_compat_c99_flag, 'main.v'])
+		assert already_present.count(it == macos_v3_compat_c99_flag) == 1
+	}
+}
+
 fn test_macos_v3_args_only_accept_options_implemented_by_v3() {
 	$if macos {
 		assert macos_v3_args_are_supported(['main.v'])
@@ -153,6 +164,8 @@ fn test_macos_v3_args_only_accept_options_implemented_by_v3() {
 		assert !macos_v3_args_are_supported(['-output', 'main', 'main.v'])
 		assert !macos_v3_args_are_supported(['-o', '-', 'main.v'])
 		assert !macos_v3_args_are_supported(['-o', '-foo', 'main.v'])
+		assert !macos_v3_args_are_supported(['-g', 'main.v'])
+		assert macos_v3_args_are_supported(['-cg', 'main.v'])
 		for arch in ['x86', 'rv32', 'riscv32', 'sparc64', 'ppc', 'ppc32', 'powerpc', 'js', 'js_node',
 			'js_browser', 'js_freestanding'] {
 			assert !macos_v3_args_are_supported(['-arch', arch, 'main.v'])

--- a/cmd/v/macos_v3_test.v
+++ b/cmd/v/macos_v3_test.v
@@ -283,16 +283,38 @@ fn main() {
 		process.set_environment(environment)
 		process.set_redirect_stdio()
 		process.run()
+		compiler_pid := process.pid
 		process.wait()
 		compiler_output := process.stdout_slurp() + process.stderr_slurp()
 		exit_code := process.code
 		process.close()
 		assert exit_code == 0, compiler_output
 		assert compiler_output.contains('retrying with `-old-compiler`'), compiler_output
+		report_dir := os.join_path(os.vtmp_dir(), 'macos_v3_fallback_${compiler_pid}.c_error')
+		assert !os.exists(report_dir), 'fallback report directory was not cleaned: ${report_dir}'
 		assert os.is_executable(output)
 		run := os.execute(os.quoted_path(output))
 		assert run.exit_code == 0
 		assert run.output.trim_space() == 'old compiler retry succeeded'
+
+		os.rm(output)!
+		mut run_process := os.new_process(@VEXE)
+		run_process.set_args(['-gc', 'none', 'run', target])
+		run_process.set_environment(environment)
+		run_process.set_redirect_stdio()
+		run_process.run()
+		run_compiler_pid := run_process.pid
+		run_process.wait()
+		run_output := run_process.stdout_slurp() + run_process.stderr_slurp()
+		run_exit_code := run_process.code
+		run_process.close()
+		assert run_exit_code == 0, run_output
+		assert run_output.contains('retrying with `-old-compiler`'), run_output
+		assert run_output.contains('old compiler retry succeeded'), run_output
+		run_report_dir := os.join_path(os.vtmp_dir(),
+			'macos_v3_fallback_${run_compiler_pid}.c_error')
+		assert !os.exists(run_report_dir), 'run fallback report directory was not cleaned: ${run_report_dir}'
+		assert !os.exists(output), 'run fallback executable was not cleaned: ${output}'
 	}
 }
 

--- a/cmd/v/macos_v3_test.v
+++ b/cmd/v/macos_v3_test.v
@@ -140,6 +140,7 @@ fn test_macos_v3_args_only_accept_options_implemented_by_v3() {
 		assert macos_v3_args_are_supported(['script.vsh', '--script-option'])
 		assert !macos_v3_args_are_supported(['-ldflags', '-framework Cocoa', 'main.v'])
 		assert !macos_v3_args_are_supported(['-path', '@vlib', 'main.v'])
+		assert !macos_v3_args_are_supported(['-cc', 'clang', 'main.v'])
 		assert !macos_v3_args_are_supported(['-show-c-output', 'main.v'])
 		assert !macos_v3_args_are_supported(['-output', 'main', 'main.v'])
 		assert !macos_v3_args_are_supported(['-o', '-', 'main.v'])

--- a/cmd/v/macos_v3_test.v
+++ b/cmd/v/macos_v3_test.v
@@ -22,11 +22,25 @@ fn test_macos_v3_relevant_command_only_selects_supported_native_c_builds() {
 		assert is_macos_v3_relevant_command('main.v', prefs)
 		prefs.output_mode = .stdout
 		prefs.show_cc = false
+		prefs.is_vlines = true
+		assert !is_macos_v3_relevant_command('main.v', prefs)
+		prefs.is_vlines = false
 		prefs.gc_mode = .boehm_full_opt
 		assert !is_macos_v3_relevant_command('main.v', prefs)
 		prefs.gc_mode = .no_gc
 		prefs.is_run = true
 		assert is_macos_v3_relevant_command('run', prefs)
+		prefs.is_shared = true
+		assert !is_macos_v3_relevant_command('run', prefs)
+		prefs.is_run = false
+		assert is_macos_v3_relevant_command('main.v', prefs)
+		prefs.path = 'script.vsh'
+		prefs.is_crun = true
+		assert !is_macos_v3_relevant_command('script.vsh', prefs)
+		prefs.is_crun = false
+		prefs.is_shared = false
+		prefs.is_run = true
+		prefs.path = 'main.v'
 		prefs.os = .linux
 		assert !is_macos_v3_relevant_command('run', prefs)
 		prefs.os = .macos

--- a/cmd/v/macos_v3_test.v
+++ b/cmd/v/macos_v3_test.v
@@ -142,6 +142,7 @@ fn test_macos_v3_args_only_accept_options_implemented_by_v3() {
 		assert !macos_v3_args_are_supported(['-output', 'main', 'main.v'])
 		assert !macos_v3_args_are_supported(['-o', '-', 'main.v'])
 		assert !macos_v3_args_are_supported(['-o', '-foo', 'main.v'])
+		assert !macos_v3_args_are_supported(['-no-retry-compilation', 'main.v'])
 		assert !macos_v3_args_are_supported(['-silent', 'main.v'])
 		assert !macos_v3_args_are_supported(['-w', 'main.v'])
 		for help_flag in ['-?', '-h', '-help', '--help'] {

--- a/cmd/v/macos_v3_test.v
+++ b/cmd/v/macos_v3_test.v
@@ -1,0 +1,49 @@
+module main
+
+import v.pref
+
+fn test_macos_v3_relevant_command_only_selects_supported_native_c_builds() {
+	$if macos {
+		mut prefs := &pref.Preferences{
+			path:      'main.v'
+			backend:   .c
+			os:        .macos
+			is_script: true
+		}
+		assert is_macos_v3_relevant_command('main.v', prefs)
+		prefs.is_run = true
+		assert is_macos_v3_relevant_command('run', prefs)
+		prefs.os = .linux
+		assert !is_macos_v3_relevant_command('run', prefs)
+		prefs.os = .macos
+		prefs.path = 'cmd/v'
+		assert !is_macos_v3_relevant_command('cmd/v', prefs)
+		prefs.path = 'cmd/tools/vfmt.v'
+		assert !is_macos_v3_relevant_command('cmd/tools/vfmt.v', prefs)
+		prefs.path = 'main.v'
+		prefs.is_cstrict = true
+		assert !is_macos_v3_relevant_command('main.v', prefs)
+		prefs.is_cstrict = false
+		prefs.is_test = true
+		assert !is_macos_v3_relevant_command('test', prefs)
+		prefs.is_test = false
+		prefs.autofree = true
+		assert !is_macos_v3_relevant_command('main.v', prefs)
+		prefs.autofree = false
+		prefs.is_prod = true
+		assert !is_macos_v3_relevant_command('main.v', prefs)
+		prefs.is_prod = false
+		prefs.path = 'version'
+		assert !is_macos_v3_relevant_command('version', prefs)
+	}
+}
+
+fn test_macos_v3_default_executable_excludes_temporary_self_hosted_compilers() {
+	$if macos {
+		assert is_macos_v3_default_executable('/tmp/v')
+		assert is_macos_v3_default_executable('/tmp/vnew')
+		assert !is_macos_v3_default_executable('/tmp/v2')
+		assert !is_macos_v3_default_executable('/tmp/vstrict1')
+		assert !is_macos_v3_default_executable('/tmp/vp')
+	}
+}

--- a/cmd/v/v.v
+++ b/cmd/v/v.v
@@ -118,6 +118,7 @@ fn main() {
 	prefs, command := pref.parse_args_and_show_errors(external_tools, args_and_flags, true)
 	maybe_delegate_to_vvmrc(command, prefs)
 	maybe_delegate_to_ownership(command, prefs)
+	maybe_delegate_to_macos_v3(command, prefs)
 	if prefs.use_cache && os.user_os() == 'windows' {
 		eprintln('-usecache is currently disabled on windows')
 		exit(1)
@@ -130,6 +131,10 @@ fn main() {
 	// Note for future contributors: Please add new subcommands in the `match` block below.
 	if command in external_tools {
 		// External tools
+		$if macos {
+			// Tool-managed child compilations are part of the compatibility path too.
+			os.setenv(macos_v3_bootstrap_env, '1', true)
+		}
 		util.launch_tool(prefs.is_verbose, 'v' + command, os.args[1..])
 		return
 	}

--- a/cmd/v/v.v
+++ b/cmd/v/v.v
@@ -66,6 +66,13 @@ const external_tools = [
 	'where',
 ]
 
+struct MacosV3CErrorReport {
+	ccompiler  string
+	c_output   string
+	c_file     string
+	report_dir string
+}
+
 @[unsafe]
 fn timers_pointer(p &util.Timers) &util.Timers {
 	// TODO: the static variable here is used as a workaround for the current incompatibility of -usecache and globals in the main module:
@@ -118,7 +125,7 @@ fn main() {
 	prefs, command := pref.parse_args_and_show_errors(external_tools, args_and_flags, true)
 	maybe_delegate_to_vvmrc(command, prefs)
 	maybe_delegate_to_ownership(command, prefs)
-	maybe_delegate_to_macos_v3(command, prefs)
+	macos_v3_c_error_report := maybe_delegate_to_macos_v3(command, prefs)
 	if prefs.use_cache && os.user_os() == 'windows' {
 		eprintln('-usecache is currently disabled on windows')
 		exit(1)
@@ -141,6 +148,7 @@ fn main() {
 	match command {
 		'run', 'crun', 'build', 'build-module' {
 			rebuild(prefs)
+			submit_macos_v3_c_error_report(prefs, macos_v3_c_error_report)
 			return
 		}
 		'help' {
@@ -180,6 +188,7 @@ fn main() {
 				// println('command')
 				// println(prefs.path)
 				rebuild(prefs)
+				submit_macos_v3_c_error_report(prefs, macos_v3_c_error_report)
 				return
 			}
 		}
@@ -199,6 +208,15 @@ fn main() {
 	eprintln(util.new_suggestion(command, all_commands, similarity_threshold: 0.2).say('v: unknown command `${command}`'))
 	eprintln('Run ${term.highlight_command('v help')} for usage.')
 	exit(1)
+}
+
+fn submit_macos_v3_c_error_report(prefs &pref.Preferences, report ?MacosV3CErrorReport) {
+	failed := report or { return }
+	defer {
+		os.rmdir_all(failed.report_dir) or {}
+	}
+	builder.submit_external_c_error_bug_report(prefs, failed.ccompiler, failed.c_output,
+		failed.c_file, 'V3')
 }
 
 fn invoke_help_and_exit(remaining []string) {

--- a/cmd/v/v.v
+++ b/cmd/v/v.v
@@ -147,8 +147,7 @@ fn main() {
 	}
 	match command {
 		'run', 'crun', 'build', 'build-module' {
-			rebuild(prefs)
-			submit_macos_v3_c_error_report(prefs, macos_v3_c_error_report)
+			rebuild(prefs, macos_v3_c_error_report)
 			return
 		}
 		'help' {
@@ -187,8 +186,7 @@ fn main() {
 			if command.ends_with('.v') || os.exists(command) {
 				// println('command')
 				// println(prefs.path)
-				rebuild(prefs)
-				submit_macos_v3_c_error_report(prefs, macos_v3_c_error_report)
+				rebuild(prefs, macos_v3_c_error_report)
 				return
 			}
 		}
@@ -208,15 +206,6 @@ fn main() {
 	eprintln(util.new_suggestion(command, all_commands, similarity_threshold: 0.2).say('v: unknown command `${command}`'))
 	eprintln('Run ${term.highlight_command('v help')} for usage.')
 	exit(1)
-}
-
-fn submit_macos_v3_c_error_report(prefs &pref.Preferences, report ?MacosV3CErrorReport) {
-	failed := report or { return }
-	defer {
-		os.rmdir_all(failed.report_dir) or {}
-	}
-	builder.submit_external_c_error_bug_report(prefs, failed.ccompiler, failed.c_output,
-		failed.c_file, 'V3')
 }
 
 fn invoke_help_and_exit(remaining []string) {
@@ -298,7 +287,7 @@ fn cached_v3_ownership_executable_path(vroot string) string {
 		'v3_ownership'))
 }
 
-fn rebuild(prefs &pref.Preferences) {
+fn rebuild(prefs &pref.Preferences, macos_v3_c_error_report ?MacosV3CErrorReport) {
 	match prefs.backend {
 		.c {
 			$if no_bootstrapv ? {
@@ -308,7 +297,17 @@ fn rebuild(prefs &pref.Preferences) {
 				// `v -os cross -o v.c cmd/v` having a functional C codegen inside instead.
 				util.launch_tool(prefs.is_verbose, 'builders/c_builder', os.args[1..])
 			}
-			builder.compile('build', prefs, cbuilder.compile_c)
+			if failed := macos_v3_c_error_report {
+				builder.compile_with_external_c_error_report('build', prefs, cbuilder.compile_c, builder.ExternalCErrorBugReport{
+					ccompiler:   failed.ccompiler
+					c_output:    failed.c_output
+					c_file:      failed.c_file
+					tag:         'V3'
+					cleanup_dir: failed.report_dir
+				})
+			} else {
+				builder.compile('build', prefs, cbuilder.compile_c)
+			}
 		}
 		.js_node, .js_freestanding, .js_browser {
 			util.launch_tool(prefs.is_verbose, 'builders/js_builder', os.args[1..])

--- a/cmd/v/v.v
+++ b/cmd/v/v.v
@@ -138,10 +138,6 @@ fn main() {
 	// Note for future contributors: Please add new subcommands in the `match` block below.
 	if command in external_tools {
 		// External tools
-		$if macos {
-			// Tool-managed child compilations are part of the compatibility path too.
-			os.setenv(macos_v3_bootstrap_env, '1', true)
-		}
 		util.launch_tool(prefs.is_verbose, 'v' + command, os.args[1..])
 		return
 	}

--- a/vlib/v/builder/builder_test.v
+++ b/vlib/v/builder/builder_test.v
@@ -105,6 +105,19 @@ fn test_existing_vsh_executable_uses_cache_until_source_is_newer() {
 	assert warm_cache_res.exit_code == 0, warm_cache_res.output
 	assert warm_cache_res.output.trim_space() == 'Hello from cached vsh'
 
+	replacement_source := os.join_path(project_dir, 'replacement.v')
+	os.write_file(replacement_source, "fn main() {
+	println('foreign executable')
+}
+")!
+	replacement_res :=
+		os.execute('${os.quoted_path(vexe)} -old-compiler -o ${os.quoted_path(executable)} ${os.quoted_path(replacement_source)}')
+	assert replacement_res.exit_code == 0, replacement_res.output
+	assert os.execute(os.quoted_path(executable)).output.trim_space() == 'foreign executable'
+	rebound_cache_res := os.execute(cmd)
+	assert rebound_cache_res.exit_code == 0, rebound_cache_res.output
+	assert rebound_cache_res.output.trim_space() == 'Hello from cached vsh'
+
 	cache_stamp := os.file_last_mod_unix(executable) + 3600
 	os.utime(executable, cache_stamp, cache_stamp)!
 

--- a/vlib/v/builder/c_error_report.v
+++ b/vlib/v/builder/c_error_report.v
@@ -51,14 +51,18 @@ pub:
 }
 
 fn (mut v Builder) submit_c_error_bug_report(ccompiler string, c_output string) {
+	v.submit_c_error_bug_report_with_tag(ccompiler, c_output, '', true)
+}
+
+fn (mut v Builder) submit_c_error_bug_report_with_tag(ccompiler string, c_output string, tag string, retry_with_vlines bool) {
 	if !should_submit_c_error_bug_report(v.pref.c_error_bug_report_url) {
 		return
 	}
 	// Snapshot the user's real flags now: the vlines fallback below temporarily flips
 	// `pref.is_vlines`, so computing this after it would misreport `vlines` for plain builds.
-	build_options := codegen_build_options(v.pref)
+	build_options := c_error_report_build_options(v.pref, tag)
 	mut raw_report := v.new_c_error_bug_report(ccompiler, c_output)
-	if raw_report.v_file == '' {
+	if retry_with_vlines && raw_report.v_file == '' {
 		// The default `.tmp.c` has no `#line` directives, so the C error could not be
 		// traced back to a V line. Regenerate the C with `#line` info (as `-g` would),
 		// recompile, and reuse the richer report when it does map to a V source line.
@@ -83,6 +87,29 @@ fn (mut v Builder) submit_c_error_bug_report(ccompiler string, c_output string) 
 	println('V ${report.v_version}, ${report.target_os}/${report.arch}, cc: ${report.ccompiler}, build options: ${report.build_options}')
 	print_c_error_bug_report_context(report)
 	println('='.repeat('================== C compiler bug report =============='.len))
+}
+
+// submit_external_c_error_bug_report submits C diagnostics and generated source produced by
+// another compiler implementation after the established compiler has confirmed the build.
+pub fn submit_external_c_error_bug_report(prefs &pref.Preferences, ccompiler string, c_output string, c_file string, tag string) {
+	if !c_error_should_send_bug_report(c_output) {
+		return
+	}
+	mut b := new_builder(prefs)
+	b.out_name_c = c_file
+	b.submit_c_error_bug_report_with_tag(ccompiler, c_output, tag, false)
+}
+
+fn c_error_report_build_options(prefs &pref.Preferences, tag string) string {
+	options := codegen_build_options(prefs)
+	trimmed_tag := tag.trim_space()
+	if trimmed_tag == '' {
+		return options
+	}
+	if options == '' {
+		return trimmed_tag
+	}
+	return '${trimmed_tag} ${options}'
 }
 
 fn (mut v Builder) new_c_error_bug_report(ccompiler string, c_output string) CErrorBugReport {

--- a/vlib/v/builder/c_error_report.v
+++ b/vlib/v/builder/c_error_report.v
@@ -50,6 +50,17 @@ pub:
 	v_source       string // a small chunk of V source around the failing line (bounded), never the whole file
 }
 
+// ExternalCErrorBugReport describes a generated-C failure produced by another compiler
+// implementation and confirmed by a successful build with the established compiler.
+pub struct ExternalCErrorBugReport {
+pub:
+	ccompiler   string
+	c_output    string
+	c_file      string
+	tag         string
+	cleanup_dir string
+}
+
 fn (mut v Builder) submit_c_error_bug_report(ccompiler string, c_output string) {
 	v.submit_c_error_bug_report_with_tag(ccompiler, c_output, '', true)
 }
@@ -98,6 +109,16 @@ pub fn submit_external_c_error_bug_report(prefs &pref.Preferences, ccompiler str
 	mut b := new_builder(prefs)
 	b.out_name_c = c_file
 	b.submit_c_error_bug_report_with_tag(ccompiler, c_output, tag, false)
+}
+
+fn consume_external_c_error_bug_report(prefs &pref.Preferences, report ExternalCErrorBugReport) {
+	defer {
+		if report.cleanup_dir != '' {
+			os.rmdir_all(report.cleanup_dir) or {}
+		}
+	}
+	submit_external_c_error_bug_report(prefs, report.ccompiler, report.c_output, report.c_file,
+		report.tag)
 }
 
 fn c_error_report_build_options(prefs &pref.Preferences, tag string) string {

--- a/vlib/v/builder/c_error_report.v
+++ b/vlib/v/builder/c_error_report.v
@@ -61,6 +61,43 @@ pub:
 	cleanup_dir string
 }
 
+@[unsafe]
+fn external_c_error_report_cleanup_dir(dir string, update bool) string {
+	mut static pending_dir := ''
+	if update {
+		pending_dir = dir
+	}
+	return pending_dir
+}
+
+fn register_external_c_error_report_cleanup(dir string) {
+	if dir == '' {
+		return
+	}
+	unsafe {
+		external_c_error_report_cleanup_dir(dir, true)
+	}
+	at_exit(cleanup_pending_external_c_error_report) or {}
+}
+
+fn cleanup_external_c_error_report(dir string) {
+	if dir == '' {
+		return
+	}
+	os.rmdir_all(dir) or { return }
+	pending_dir := unsafe { external_c_error_report_cleanup_dir('', false) }
+	if pending_dir == dir {
+		unsafe {
+			external_c_error_report_cleanup_dir('', true)
+		}
+	}
+}
+
+fn cleanup_pending_external_c_error_report() {
+	pending_dir := unsafe { external_c_error_report_cleanup_dir('', false) }
+	cleanup_external_c_error_report(pending_dir)
+}
+
 fn (mut v Builder) submit_c_error_bug_report(ccompiler string, c_output string) {
 	v.submit_c_error_bug_report_with_tag(ccompiler, c_output, '', true)
 }
@@ -113,9 +150,7 @@ pub fn submit_external_c_error_bug_report(prefs &pref.Preferences, ccompiler str
 
 fn consume_external_c_error_bug_report(prefs &pref.Preferences, report ExternalCErrorBugReport) {
 	defer {
-		if report.cleanup_dir != '' {
-			os.rmdir_all(report.cleanup_dir) or {}
-		}
+		cleanup_external_c_error_report(report.cleanup_dir)
 	}
 	submit_external_c_error_bug_report(prefs, report.ccompiler, report.c_output, report.c_file,
 		report.tag)

--- a/vlib/v/builder/c_error_report_test.v
+++ b/vlib/v/builder/c_error_report_test.v
@@ -119,6 +119,15 @@ fn test_codegen_build_options_reports_flags_and_custom_defines() {
 	assert !opts.contains('-cc gcc')
 }
 
+fn test_external_c_error_report_build_options_include_v3_tag() {
+	prefs := pref.Preferences{
+		gc_mode: .no_gc
+	}
+	options := c_error_report_build_options(&prefs, 'V3')
+	assert options.split(' ').first() == 'V3'
+	assert options.contains('gc:no_gc')
+}
+
 fn test_codegen_build_options_reports_no_skip_unused_override() {
 	// a C build with skip_unused off means `-no-skip-unused` was passed (it defaults to true);
 	// replay must disable it too, or a smaller C program could miss the error

--- a/vlib/v/builder/compile.v
+++ b/vlib/v/builder/compile.v
@@ -21,6 +21,16 @@ fn resolve_ccompiler_type_and_pkgconfig_mode(mut prefs pref.Preferences) {
 }
 
 pub fn compile(command string, pref_ &pref.Preferences, backend_cb FnBackend) {
+	compile_with_optional_external_c_error_report(pref_, backend_cb, none)
+}
+
+// compile_with_external_c_error_report compiles with the established compiler and submits
+// `report` only after that build succeeds.
+pub fn compile_with_external_c_error_report(command string, pref_ &pref.Preferences, backend_cb FnBackend, report ExternalCErrorBugReport) {
+	compile_with_optional_external_c_error_report(pref_, backend_cb, report)
+}
+
+fn compile_with_optional_external_c_error_report(pref_ &pref.Preferences, backend_cb FnBackend, report ?ExternalCErrorBugReport) {
 	if pref_.is_test {
 		disable_c_error_bug_reports()
 	}
@@ -41,6 +51,11 @@ pub fn compile(command string, pref_ &pref.Preferences, backend_cb FnBackend) {
 	mut b := new_builder(pref_)
 	if b.should_rebuild() {
 		b.rebuild(backend_cb)
+	}
+	if failed := report {
+		// Do this before run_compiled_executable_and_exit: successful builds and run
+		// commands exit there, so the caller cannot reliably submit the report later.
+		consume_external_c_error_bug_report(pref_, failed)
 	}
 	b.exit_on_invalid_syntax()
 	// running does not require the parsers anymore

--- a/vlib/v/builder/compile.v
+++ b/vlib/v/builder/compile.v
@@ -31,6 +31,11 @@ pub fn compile_with_external_c_error_report(command string, pref_ &pref.Preferen
 }
 
 fn compile_with_optional_external_c_error_report(pref_ &pref.Preferences, backend_cb FnBackend, report ?ExternalCErrorBugReport) {
+	if failed := report {
+		// The compatibility compiler may exit from any validation, parser, checker, or
+		// C compilation path below. Register cleanup before entering those paths.
+		register_external_c_error_report_cleanup(failed.cleanup_dir)
+	}
 	if pref_.is_test {
 		disable_c_error_bug_reports()
 	}

--- a/vlib/v/builder/rebuilding.v
+++ b/vlib/v/builder/rebuilding.v
@@ -11,7 +11,7 @@ import v.pref
 import v.vcache
 import runtime
 
-const crun_cache_format_version = 'crun_cache_v2'
+const crun_cache_format_version = 'crun_cache_v3'
 
 pub fn (mut b Builder) rebuild_modules() {
 	if !b.pref.use_cache || b.pref.build_mode == .build_module {
@@ -269,10 +269,7 @@ fn (mut b Builder) handle_usecache(vexe string) {
 }
 
 pub fn (mut b Builder) should_rebuild() bool {
-	mut exe_name := b.pref.out_name
-	$if windows {
-		exe_name += '.exe'
-	}
+	exe_name := crun_executable_path(b.pref.out_name)
 	if !os.is_file(exe_name) {
 		return true
 	}
@@ -304,6 +301,10 @@ pub fn (mut b Builder) should_rebuild() bool {
 	// always rebuild, when the compilation options changed between 2 sequential cruns:
 	sbuild_options := cm.load('.build_options', '.crun') or { return true }
 	if sbuild_options != b.crun_build_options_signature() {
+		return true
+	}
+	sexecutable := cm.load('.executable', '.crun') or { return true }
+	if sexecutable != crun_executable_signature(exe_name) {
 		return true
 	}
 	sdependencies := cm.load('.dependencies', '.crun') or {
@@ -343,6 +344,8 @@ pub fn (mut b Builder) rebuild(backend_cb FnBackend) {
 		dependency_files := b.crun_dependency_files()
 		cm.save('.dependencies', '.crun', dependency_files.join('\n')) or {}
 		cm.save('.build_options', '.crun', b.crun_build_options_signature()) or {}
+		cm.save('.executable', '.crun',
+			crun_executable_signature(crun_executable_path(b.pref.out_name))) or {}
 	}
 	mut timers := util.get_timers()
 	timers.show_remaining()
@@ -394,6 +397,20 @@ pub fn (mut b Builder) rebuild(backend_cb FnBackend) {
 		used_cgen_threads := if b.pref.no_parallel { 1 } else { runtime.nr_jobs() }
 		println('compilation took: ${scompilation_time_ms} ms, compilation speed: ${svlines_per_second} vlines/s, cgen threads: ${used_cgen_threads}')
 	}
+}
+
+fn crun_executable_path(out_name string) string {
+	$if windows {
+		if !out_name.ends_with('.exe') {
+			return out_name + '.exe'
+		}
+	}
+	return out_name
+}
+
+fn crun_executable_signature(path string) string {
+	content := os.read_bytes(path) or { return '' }
+	return hash.sum64(content, 7).hex_full()
 }
 
 fn (b &Builder) crun_build_options_signature() string {

--- a/vlib/v/help/build/build-c.txt
+++ b/vlib/v/help/build/build-c.txt
@@ -13,6 +13,11 @@ see also `v help build`.
       Officially supported/tested C compilers include:
       `clang`, `gcc`, `tcc` (also accepted as `tinyc`), `mingw-w64` and `msvc`.
 
+   -old-compiler
+      On macOS, bypass the V3 compiler dispatcher and compile with the established
+      compiler in vlib/v. This is useful as a temporary compatibility workaround
+      when an eligible build behaves differently under V3.
+
    -cflags <flag>
       Pass the provided flag as is to the C compiler.
       Can be specified multiple times to provide multiple flags.

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -157,6 +157,7 @@ pub mut:
 	show_callgraph         bool // -show-callgraph, print the program callgraph, in a Graphviz DOT format to stdout
 	show_depgraph          bool // -show-depgraph, print the program module dependency graph, in a Graphviz DOT format to stdout
 	show_unused_params     bool = true // regular function params should report as unused by default.
+	old_compiler           bool   // `-old-compiler` - bypass experimental compiler dispatchers.
 	c_error_bug_report_url string // `-bug-report-url url` - override the automatic C compiler bug report endpoint.
 	dump_c_flags           string // `-dump-c-flags file.txt` - let V store all C flags, passed to the backend C compiler in `file.txt`, one C flag/value per line.
 	dump_modules           string // `-dump-modules modules.txt` - let V store all V modules, that were used by the compiled program in `modules.txt`, one module per line.
@@ -535,6 +536,9 @@ pub fn parse_args_and_show_errors(known_external_commands []string, args []strin
 			}
 			'-ownership' {
 				// Passed through to the V3 ownership compiler by cmd/v.
+			}
+			'-old-compiler' {
+				res.old_compiler = true
 			}
 			'-no-memory-limit', '--no-memory-limit' {
 				// Passed through to V3 dispatchers by cmd/v.

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -1182,6 +1182,10 @@ pub fn parse_args_and_show_errors(known_external_commands []string, args []strin
 					// store for future iterations
 					res.is_vsh = true
 				}
+				if arg.starts_with('-d') && arg.len > 2 {
+					res.parse_define(arg[2..])
+					continue
+				}
 				if !arg.starts_with('-') {
 					if command == '' {
 						command, command_idx = arg, i

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -536,6 +536,9 @@ pub fn parse_args_and_show_errors(known_external_commands []string, args []strin
 			'-ownership' {
 				// Passed through to the V3 ownership compiler by cmd/v.
 			}
+			'-no-memory-limit', '--no-memory-limit' {
+				// Passed through to V3 dispatchers by cmd/v.
+			}
 			'-progress' {
 				// processed by testing tools in cmd/tools/modules/testing/common.v
 			}

--- a/vlib/v/pref/pref_test.v
+++ b/vlib/v/pref/pref_test.v
@@ -488,6 +488,15 @@ fn test_m32_does_not_override_explicit_arch() {
 	assert prefs.build_options.contains('-m32')
 }
 
+fn test_v3_memory_limit_passthrough_flags_are_accepted() {
+	target := os.join_path(vroot, 'examples', 'hello_world.v')
+	for flag in ['-no-memory-limit', '--no-memory-limit'] {
+		prefs, command := pref.parse_args_and_show_errors([], [flag, target], false)
+		assert command == target
+		assert flag !in prefs.build_options
+	}
+}
+
 fn test_v_cmds_and_flags() {
 	build_cmd_res := os.execute('${vexe} build ${vroot}/examples/hello_world.v')
 	assert build_cmd_res.output.trim_space() == 'Use `v ${vroot}/examples/hello_world.v` instead.'

--- a/vlib/v/pref/pref_test.v
+++ b/vlib/v/pref/pref_test.v
@@ -497,6 +497,15 @@ fn test_v3_memory_limit_passthrough_flags_are_accepted() {
 	}
 }
 
+fn test_compact_boolean_define_is_accepted() {
+	target := os.join_path(vroot, 'examples', 'hello_world.v')
+	prefs, command := pref.parse_args_and_show_errors([], ['-dfeature', target], false)
+	assert command == target
+	assert prefs.compile_values['feature'] == 'true'
+	assert 'feature' in prefs.compile_defines
+	assert prefs.build_options.contains('-d feature')
+}
+
 fn test_v_cmds_and_flags() {
 	build_cmd_res := os.execute('${vexe} build ${vroot}/examples/hello_world.v')
 	assert build_cmd_res.output.trim_space() == 'Use `v ${vroot}/examples/hello_world.v` instead.'

--- a/vlib/v/pref/pref_test.v
+++ b/vlib/v/pref/pref_test.v
@@ -497,6 +497,14 @@ fn test_v3_memory_limit_passthrough_flags_are_accepted() {
 	}
 }
 
+fn test_old_compiler_flag_is_accepted() {
+	target := os.join_path(vroot, 'examples', 'hello_world.v')
+	prefs, command := pref.parse_args_and_show_errors([], ['-old-compiler', target], false)
+	assert command == target
+	assert prefs.old_compiler
+	assert '-old-compiler' !in prefs.build_options
+}
+
 fn test_compact_boolean_define_is_accepted() {
 	target := os.join_path(vroot, 'examples', 'hello_world.v')
 	prefs, command := pref.parse_args_and_show_errors([], ['-dfeature', target], false)

--- a/vlib/v3/README.md
+++ b/vlib/v3/README.md
@@ -39,6 +39,10 @@ self-hosted temporary compilers, cross-compilation, and modes not yet supported 
 continue through the established compiler. Pass `-old-compiler` to explicitly use that
 compatibility path for an otherwise eligible macOS build. Other operating systems are unchanged.
 
+When delegated V3 compilation rejects a source before producing its output, `cmd/v` automatically
+retries the command through the established compiler. Exit codes from successfully compiled
+`run` programs are returned unchanged and do not trigger a retry.
+
 When V3's generated C fails to compile, `cmd/v` automatically retries the command through the
 established compiler. If that retry succeeds, the existing automatic C-error reporter submits the
 V3 diagnostics to bugs.vlang.io with `V3` in the report's build options. The usual

--- a/vlib/v3/README.md
+++ b/vlib/v3/README.md
@@ -115,15 +115,16 @@ Third-party C objects retain dependency manifests, so warm builds verify each un
 header once without launching a dependency-scanner process per object. Unchanged inputs use
 nanosecond-resolution file metadata; a metadata change falls back to the recorded content hash.
 This work is reported as the separate `C object cache` benchmark stage before `cc`.
-On macOS, cached non-production executable builds combine the imported-module objects and
+On macOS, cached non-production implicit `run` builds combine the imported-module objects and
 generated runtime prefix into a content-keyed dylib with the system C compiler. The remaining
 current-directory program unit is compiled and linked against that dylib with bundled TinyCC.
 Objective-C and framework compilation flags stay on the cached dylib side. This work is reported
-as `C dylib cache`; the resulting development executable retains an absolute runtime dependency
-on that cache artifact. An exact warm plan also restores its content-keyed TinyCC executable and
-reports `cc (cached)`; project source, module object, C dependency, TinyCC input, argument, or
-dylib changes invalidate it. Production, shared-library, self-host, explicit `-cc`, and
-`-nocache` builds keep their existing direct-link behavior.
+as `C dylib cache`; the temporary executable retains an absolute runtime dependency on that cache
+artifact and is removed after the run. An exact warm plan also restores its content-keyed TinyCC
+executable and reports `cc (cached)`; project source, module object, C dependency, TinyCC input,
+argument, or dylib changes invalidate it. Persistent outputs—including ordinary compilation,
+explicit `run -o` output, and `-keepc` runs—are standalone. Production, shared-library, self-host,
+explicit `-cc`, and `-nocache` builds also keep their existing direct-link behavior.
 When the whole-program C plan is unchanged, v3 validates it immediately after parsing and reports
 the check, mark-used, transform, type-annotation, monomorphization, and C generation stages as
 cached. This avoids semantic and lowering work whose only consumer would be the cached C plan.

--- a/vlib/v3/README.md
+++ b/vlib/v3/README.md
@@ -25,6 +25,17 @@ builtin `map` type name and API (`new_map`, `map__set`, `map__get`,
 `map__delete`, etc.) with a simplified open-addressing implementation until v3
 can compile the full builtin map.v.
 
+## macOS default compiler
+
+On macOS, the top-level `v` command dispatches supported native C source builds to a cached
+compiler built from `vlib/v3/v3.v`. This includes unflagged `v file.v`, `v run file.v`, and V
+scripts. The cached compiler is rebuilt when V3 sources change and runs serial stages to stay
+within its memory safety limit.
+
+`cmd/v` remains the CLI and compatibility dispatcher. Tests, command tools, self-hosted temporary
+compilers, cross-compilation, and modes not yet supported by V3 continue through the established
+compiler. Other operating systems are unchanged.
+
 ## Target selection
 
 The C backend accepts `-os <name>` and `-arch <name>`. The target controls source-file suffix
@@ -38,7 +49,7 @@ The command line rejects unknown options, missing option values, unsupported bac
 multiple input paths. `-cc <executable>` selects the C compiler and `-gc none` is the only
 currently supported collector mode. Directory builds read `subdirs` through the canonical
 `v.mod` parser, including when other manifest strings contain punctuation resembling fields.
-The driver monitors compiler memory throughout the build and exits when it reaches 10 GiB.
+The driver monitors compiler memory throughout the build and exits when it reaches 2 GiB.
 On macOS it uses physical footprint, matching Activity Monitor more closely; elsewhere it uses
 current RSS. Pass `-no-memory-limit`/`--no-memory-limit` to disable this safety limit.
 On macOS, each stage benchmark prints physical footprint immediately after RSS.

--- a/vlib/v3/README.md
+++ b/vlib/v3/README.md
@@ -51,6 +51,9 @@ The command line rejects unknown options, missing option values, unsupported bac
 multiple input paths. `-cc <executable>` selects the C compiler and `-gc none` is the only
 currently supported collector mode. Directory builds read `subdirs` through the canonical
 `v.mod` parser, including when other manifest strings contain punctuation resembling fields.
+Native C compilation uses `-fwrapv` on supported targets so signed integer overflow retains V's
+two's-complement semantics. On macOS, `-cg` links executables with exported symbols for symbolic
+backtraces while plain `-g` retains its V-source debug behavior.
 The driver monitors compiler memory throughout the build and exits when it reaches 2 GiB.
 On macOS it uses physical footprint, matching Activity Monitor more closely; elsewhere it uses
 current RSS. Pass `-no-memory-limit`/`--no-memory-limit` to disable this safety limit.

--- a/vlib/v3/README.md
+++ b/vlib/v3/README.md
@@ -25,16 +25,18 @@ builtin `map` type name and API (`new_map`, `map__set`, `map__get`,
 `map__delete`, etc.) with a simplified open-addressing implementation until v3
 can compile the full builtin map.v.
 
-## macOS default compiler
+## macOS V3 dispatch
 
 On macOS, the top-level `v` command dispatches supported native C source builds to a cached
-compiler built from `vlib/v3/v3.v`. This includes unflagged `v file.v`, `v run file.v`, and V
-scripts. The cached compiler is rebuilt when V3 sources change and runs serial stages to stay
-within its memory safety limit.
+compiler built from `vlib/v3/v3.v` when the effective garbage collector mode is `none`. For
+example, `v -gc none file.v`, `v -gc none run file.v`, and `v -gc none script.vsh` are eligible;
+`-prealloc` also selects the no-GC mode. The cached compiler is rebuilt when V3 sources change and
+runs serial stages to stay within its memory safety limit.
 
-`cmd/v` remains the CLI and compatibility dispatcher. Tests, command tools, self-hosted temporary
-compilers, cross-compilation, and modes not yet supported by V3 continue through the established
-compiler. Other operating systems are unchanged.
+`cmd/v` remains the CLI and compatibility dispatcher. Ordinary unflagged C builds use the
+established compiler because their default GC mode is `boehm_full_opt`. Tests, command tools,
+self-hosted temporary compilers, cross-compilation, and modes not yet supported by V3 also
+continue through the established compiler. Other operating systems are unchanged.
 
 ## Target selection
 

--- a/vlib/v3/README.md
+++ b/vlib/v3/README.md
@@ -36,7 +36,13 @@ runs serial stages to stay within its memory safety limit.
 `cmd/v` remains the CLI and compatibility dispatcher. Ordinary unflagged C builds use the
 established compiler because their default GC mode is `boehm_full_opt`. Tests, command tools,
 self-hosted temporary compilers, cross-compilation, and modes not yet supported by V3 also
-continue through the established compiler. Other operating systems are unchanged.
+continue through the established compiler. Pass `-old-compiler` to explicitly use that
+compatibility path for an otherwise eligible macOS build. Other operating systems are unchanged.
+
+When V3's generated C fails to compile, `cmd/v` automatically retries the command through the
+established compiler. If that retry succeeds, the existing automatic C-error reporter submits the
+V3 diagnostics to bugs.vlang.io with `V3` in the report's build options. The usual
+`V_C_ERROR_BUG_REPORT_DISABLED` and GitHub CI safeguards still apply.
 
 ## Target selection
 

--- a/vlib/v3/README.md
+++ b/vlib/v3/README.md
@@ -27,17 +27,18 @@ can compile the full builtin map.v.
 
 ## macOS V3 dispatch
 
-On macOS, the top-level `v` command dispatches supported native C source builds to a cached
-compiler built from `vlib/v3/v3.v` when the effective garbage collector mode is `none`. For
-example, `v -gc none file.v`, `v -gc none run file.v`, and `v -gc none script.vsh` are eligible;
-`-prealloc` also selects the no-GC mode. The cached compiler is rebuilt when V3 sources change and
-runs serial stages to stay within its memory safety limit.
+On macOS 26.2, or in a macOS GitHub Actions job, the top-level `v` command dispatches supported
+native C source builds to a cached compiler built from `vlib/v3/v3.v` when the effective garbage
+collector mode is `none`. For example, `v -gc none file.v`, `v -gc none run file.v`, and
+`v -gc none script.vsh` are eligible; `-prealloc` also selects the no-GC mode. The cached compiler
+is rebuilt when V3 sources change and runs serial stages to stay within its memory safety limit.
 
 `cmd/v` remains the CLI and compatibility dispatcher. Ordinary unflagged C builds use the
 established compiler because their default GC mode is `boehm_full_opt`. Tests, command tools,
 self-hosted temporary compilers, cross-compilation, and modes not yet supported by V3 also
 continue through the established compiler. Pass `-old-compiler` to explicitly use that
-compatibility path for an otherwise eligible macOS build. Other operating systems are unchanged.
+compatibility path for an otherwise eligible macOS build. Local macOS releases other than 26.2
+also use the established compiler. Other operating systems are unchanged.
 
 When delegated V3 compilation rejects a source before producing its output, `cmd/v` automatically
 retries the command through the established compiler. Exit codes from successfully compiled

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -235,6 +235,7 @@ mut:
 	runtime_init_modules         []string
 	compiler_vroot               string
 	compiler_vexe                string
+	compiler_vexe_env_setup      bool = true
 	target                       pref.Target
 	thread_stack_size            int = 8 * 1024 * 1024
 	compile_values               map[string]string // explicit `-d` values used by `$d(...)` in `#flag`s
@@ -862,6 +863,11 @@ fn (g &FlatGen) top_level_nodes() []int {
 // set_compiler_vexe sets the V executable path baked into generated test/runtime helpers.
 pub fn (mut g FlatGen) set_compiler_vexe(path string) {
 	g.compiler_vexe = path
+}
+
+// set_compiler_vexe_env_setup controls whether generated programs populate an unset VEXE.
+pub fn (mut g FlatGen) set_compiler_vexe_env_setup(enabled bool) {
+	g.compiler_vexe_env_setup = enabled
 }
 
 // set_target sets the canonical code-generation target.

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -4425,7 +4425,7 @@ fn (mut g FlatGen) set_cur_fn_ret(ret_type types.Type) {
 
 // gen_compiler_vexe_env_setup emits compiler vexe env setup output for c.
 fn (mut g FlatGen) gen_compiler_vexe_env_setup() {
-	if g.compiler_vexe.len == 0 && g.compiler_vroot.len == 0 {
+	if !g.compiler_vexe_env_setup || (g.compiler_vexe.len == 0 && g.compiler_vroot.len == 0) {
 		return
 	}
 	root := c_escape(g.compiler_vroot)

--- a/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
@@ -1612,6 +1612,7 @@ fn (g &FlatGen) new_parallel_worker_config(worker_id int, result_only bool) &Fla
 		}
 		compiler_vroot:                 g.compiler_vroot
 		compiler_vexe:                  g.compiler_vexe
+		compiler_vexe_env_setup:        g.compiler_vexe_env_setup
 		cur_param_names:                if result_only {
 			g.cur_param_names
 		} else {

--- a/vlib/v3/modulecache/modulecache.v
+++ b/vlib/v3/modulecache/modulecache.v
@@ -240,7 +240,14 @@ fn source_signature_details(source_files []string, build_pseudo_values string) S
 		hash = hash_bytes(hash, content)
 		hash = hash_bytes(hash, [u8(0xff)])
 		source := content.bytestr()
-		if source_uses_pseudo(source, ['@BUILD_TIMESTAMP', '@BUILD_DATE', '@BUILD_TIME']) {
+		if source_uses_pseudo(source, [
+			'@BUILD_TIMESTAMP',
+			'@BUILD_DATE',
+			'@BUILD_TIME',
+			'@VHASH',
+			'@VCURRENTHASH',
+		])
+		{
 			uses_build_pseudo = true
 		}
 		if source_uses_pseudo(source, ['@VMODROOT', '@VMOD_FILE', '@VROOT']) {

--- a/vlib/v3/modulecache/modulecache.v
+++ b/vlib/v3/modulecache/modulecache.v
@@ -6,6 +6,7 @@ import strings
 import v3.flat
 import v3.pref
 import v3.types
+import v.util.version
 
 pub const builtin_bundle_imports = ['strconv', 'strings', 'hash', 'math.bits']
 pub const builtin_bundle_modules = ['builtin', 'strconv', 'strings', 'hash', 'bits', 'math.bits']
@@ -21,7 +22,7 @@ const c_source_directives_end = '/* V3CACHE_SOURCE_DIRECTIVES_END */'
 const c_late_directives_begin = '/* V3CACHE_LATE_DIRECTIVES_BEGIN */'
 const c_late_directives_end = '/* V3CACHE_LATE_DIRECTIVES_END */'
 const source_body_marker = '// v3cache: source bodies required'
-const source_signature_cache_format = 'v3-source-signature-cache-1'
+const source_signature_cache_format = 'v3-source-signature-cache-2'
 
 // Manager owns persistent v3 module cache paths for one compiler configuration.
 pub struct Manager {
@@ -251,7 +252,8 @@ fn source_signature_details(source_files []string, build_pseudo_values string) S
 		{
 			uses_build_pseudo = true
 		}
-		if source_uses_pseudo(source, ['@VMODROOT', '@VMOD_FILE', '@VROOT']) {
+		uses_vmod_hash := source_uses_pseudo(source, ['@VMODHASH'])
+		if uses_vmod_hash || source_uses_pseudo(source, ['@VMODROOT', '@VMOD_FILE', '@VROOT']) {
 			root, vmod_file := signature_vmod_root(file)
 			vmod_metadata := if vmod_file.len > 0 {
 				file_metadata_signature(vmod_file)
@@ -272,6 +274,13 @@ fn source_signature_details(source_files []string, build_pseudo_values string) S
 				hash = hash_bytes(hash, [u8(0)])
 			}
 			hash = hash_bytes(hash, [u8(0xff)])
+			if uses_vmod_hash {
+				vmod_hash := signature_vmod_hash(root, vmod_file)
+				validation << 'vmodhash=${path}\t${root}\t${vmod_file}\t${hash_text(vmod_hash)}'
+				hash = hash_bytes(hash, [u8(0xfa)])
+				hash = hash_bytes(hash, vmod_hash.bytes())
+				hash = hash_bytes(hash, [u8(0xff)])
+			}
 		}
 		for name in compile_time_env_names(source) {
 			env_names[name] = true
@@ -654,6 +663,18 @@ fn valid_cached_source_signature(content string, metadata string, build_pseudo_v
 			}
 			continue
 		}
+		if line.starts_with('vmodhash=') {
+			parts := line['vmodhash='.len..].split('\t')
+			if parts.len != 4 || parts[0].len == 0 {
+				return none
+			}
+			root, vmod_file := signature_vmod_root(parts[0])
+			vmod_hash := signature_vmod_hash(root, vmod_file)
+			if root != parts[1] || vmod_file != parts[2] || hash_text(vmod_hash) != parts[3] {
+				return none
+			}
+			continue
+		}
 		return none
 	}
 	if signature.len == 0 {
@@ -677,6 +698,13 @@ fn signature_vmod_root(source_file string) (string, string) {
 		dir = parent
 	}
 	return os.real_path(original_dir), ''
+}
+
+fn signature_vmod_hash(root string, vmod_file string) string {
+	if vmod_file.len == 0 {
+		return ''
+	}
+	return version.githash(root) or { '' }
 }
 
 fn compile_time_env_names(source string) []string {

--- a/vlib/v3/modulecache/modulecache.v
+++ b/vlib/v3/modulecache/modulecache.v
@@ -3326,7 +3326,7 @@ fn cached_source_pseudo_edit(source string, start int, source_file string, line_
 			vmod_root
 		}
 		'@FILE_LINE' {
-			'${file}:${line_nr}'
+			'${os.file_name(source_file)}:${line_nr}'
 		}
 		'@FILE' {
 			file

--- a/vlib/v3/modulecache/modulecache.v
+++ b/vlib/v3/modulecache/modulecache.v
@@ -4,6 +4,7 @@ import os
 import rand
 import strings
 import v3.flat
+import v3.pref
 import v3.types
 
 pub const builtin_bundle_imports = ['strconv', 'strings', 'hash', 'math.bits']
@@ -288,7 +289,7 @@ fn source_signature_details(source_files []string, build_pseudo_values string) S
 	mut names := env_names.keys()
 	names.sort()
 	for name in names {
-		value := os.getenv(name)
+		value := pref.macos_v3_caller_env_value(name)
 		validation << 'env=${name}\t${hash_text(value)}'
 		hash = hash_bytes(hash, [u8(0xfe)])
 		hash = hash_bytes(hash, name.bytes())
@@ -616,7 +617,8 @@ fn valid_cached_source_signature(content string, metadata string, build_pseudo_v
 		}
 		if line.starts_with('env=') {
 			parts := line['env='.len..].split('\t')
-			if parts.len != 2 || parts[0].len == 0 || hash_text(os.getenv(parts[0])) != parts[1] {
+			if parts.len != 2 || parts[0].len == 0
+				|| hash_text(pref.macos_v3_caller_env_value(parts[0])) != parts[1] {
 				return none
 			}
 			continue

--- a/vlib/v3/modulecache/modulecache.v
+++ b/vlib/v3/modulecache/modulecache.v
@@ -221,6 +221,17 @@ pub fn source_signature(source_files []string) string {
 	return source_signature_details(source_files, '').signature
 }
 
+// source_files_use_build_time_pseudo reports whether selected sources depend on build time.
+pub fn source_files_use_build_time_pseudo(source_files []string) bool {
+	for file in source_files {
+		source := os.read_file(file) or { continue }
+		if source_uses_pseudo(source, ['@BUILD_TIMESTAMP', '@BUILD_DATE', '@BUILD_TIME']) {
+			return true
+		}
+	}
+	return false
+}
+
 struct SourceSignatureDetails {
 	signature  string
 	validation []string

--- a/vlib/v3/modulecache/modulecache_test.v
+++ b/vlib/v3/modulecache/modulecache_test.v
@@ -40,9 +40,11 @@ fn test_source_uses_pseudo_in_quoted_compile_time_paths() {
 	// name-boundary check still applies inside literals
 	assert !source_uses_pseudo("module m\n\nconst s = \$embed_file('@VROOTX/not-a-pseudo')", roots)
 
-	build := ['@BUILD_TIMESTAMP', '@BUILD_DATE', '@BUILD_TIME']
+	build := ['@BUILD_TIMESTAMP', '@BUILD_DATE', '@BUILD_TIME', '@VHASH', '@VCURRENTHASH']
 	assert !source_uses_pseudo("module m\n\npub const marker = '@BUILD_DATE'", build)
 	assert source_uses_pseudo('module m\n\npub const marker = @BUILD_DATE', build)
+	assert source_uses_pseudo('module m\n\npub const build_hash = @VHASH', build)
+	assert source_uses_pseudo('module m\n\npub const current_hash = @VCURRENTHASH', build)
 	assert source_uses_pseudo(r"module m\n\npub const stamp = 'built ${@BUILD_TIMESTAMP}'", build)
 	assert !source_uses_pseudo(r"module m\n\npub const stamp = 'literal @BUILD_TIMESTAMP ${1}'",
 		build)

--- a/vlib/v3/modulecache/modulecache_test.v
+++ b/vlib/v3/modulecache/modulecache_test.v
@@ -2,6 +2,13 @@ module modulecache
 
 import os
 
+fn test_cached_file_line_uses_source_file_name() {
+	source := 'return [@FILE, @FILE_LINE, @LINE]'
+	source_file := os.join_path(os.vtmp_dir(), 'nested', 'origin.v')
+	rewritten := cached_embedded_source_paths(source, '', source_file, 5)
+	assert rewritten == "return ['${os.real_path(source_file)}', 'origin.v:5', '5']"
+}
+
 fn test_source_signature_cache_content_requires_stable_metadata() {
 	details := SourceSignatureDetails{
 		signature:  'content-signature'

--- a/vlib/v3/modulecache/modulecache_test.v
+++ b/vlib/v3/modulecache/modulecache_test.v
@@ -1,5 +1,7 @@
 module modulecache
 
+import os
+
 fn test_source_signature_cache_content_requires_stable_metadata() {
 	details := SourceSignatureDetails{
 		signature:  'content-signature'
@@ -57,4 +59,30 @@ fn test_source_uses_pseudo_in_quoted_compile_time_paths() {
 	assert source_uses_pseudo(r"module m\n\npub const stamp = 'built ${if ok { @BUILD_TIMESTAMP } else { 0 }}'",
 		build)
 	assert source_uses_pseudo(r"module m\n\npub const root = 'root ${@VMODROOT}'", roots)
+}
+
+fn test_vmodhash_changes_cached_source_signature_without_source_edits() {
+	root := os.join_path(os.vtmp_dir(), 'v3_modulecache_vmodhash_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(os.join_path(root, '.git', 'refs', 'heads')) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	os.write_file(os.join_path(root, 'v.mod'), "Module { name: 'cache_vmodhash' }\n")!
+	os.write_file(os.join_path(root, '.git', 'HEAD'), 'ref: refs/heads/main\n')!
+	ref_file := os.join_path(root, '.git', 'refs', 'heads', 'main')
+	os.write_file(ref_file, '0123456789abcdef0123456789abcdef01234567\n')!
+	source := os.join_path(root, 'main.v')
+	os.write_file(source, 'module main\n\nconst project_hash = @VMODHASH\n')!
+	cache_dir := os.join_path(root, 'cache')
+
+	first := cached_source_signature(cache_dir, 'vmodhash', [source])
+	assert first.len > 0
+	details := source_signature_details([source], '')
+	assert details.validation.any(it.starts_with('vmodhash='))
+
+	os.write_file(ref_file, 'abcdef0123456789abcdef0123456789abcdef01\n')!
+	second := cached_source_signature(cache_dir, 'vmodhash', [source])
+	assert second.len > 0
+	assert second != first
 }

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -3411,7 +3411,7 @@ fn (mut p Parser) resolve_comptime_at_values_at(cond string, pseudo_pos int) str
 				}
 				'@FILE_LINE' {
 					write_comptime_cond_string(mut out,
-						'${os.real_path(p.cur_file)}:${p.line_nr_for_pos(pseudo_pos)}')
+						'${os.file_name(p.cur_file)}:${p.line_nr_for_pos(pseudo_pos)}')
 				}
 				'@METHOD' {
 					write_comptime_cond_string(mut out, method_name)
@@ -8626,7 +8626,7 @@ fn (mut p Parser) prefix_expr() flat.NodeId {
 				return p.add_val_id(5, p.column_for_pos(name_pos).str())
 			}
 			if name == '@FILE_LINE' {
-				return p.add_val_id(5, '${os.real_path(p.cur_file)}:${p.line_nr_for_pos(name_pos)}')
+				return p.add_val_id(5, '${os.file_name(p.cur_file)}:${p.line_nr_for_pos(name_pos)}')
 			}
 			if name == '@MOD' {
 				if p.cur_module.len == 0 {

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -8,6 +8,7 @@ import v3.flat
 import v3.pref
 import v3.scanner
 import v3.token
+import v.util
 import v.util.version
 
 const max_parse_diagnostics = 100
@@ -3395,7 +3396,7 @@ fn (mut p Parser) resolve_comptime_at_values_at(cond string, pseudo_pos int) str
 					}
 					write_comptime_cond_string(mut out, hash)
 				}
-				'@VEXEROOT' {
+				'@VEXEROOT', '@VROOT' {
 					write_comptime_cond_string(mut out, p.prefs.vroot)
 				}
 				'@VEXE' {
@@ -5080,12 +5081,13 @@ fn (mut p Parser) parse_comptime_expr() flat.NodeId {
 			mut value_expr := p.expr(.lowest)
 			default := p.a.node(value_expr)
 			if value := p.prefs.compile_values[define_name] {
-				if default.kind == .bool_literal && value in ['true', 'false'] {
-					value_expr = p.a.add_node(flat.Node{
-						kind:  .bool_literal
-						value: value
-						pos:   default.pos
-					})
+				if default.kind in [.bool_literal, .char_literal, .float_literal, .string_literal,
+					.int_literal] {
+					resolved := resolve_comptime_define_literal(default, value) or {
+						p.record_diagnostic(err.msg(), dollar_pos)
+						*default
+					}
+					value_expr = p.a.add_node(resolved)
 				}
 			}
 			for p.tok != .rpar && p.tok != .eof {
@@ -5208,6 +5210,45 @@ fn (mut p Parser) parse_comptime_expr() flat.NodeId {
 	// `empty_node`, so consumers (e.g. const initializers) never store an
 	// invalid (-1) child node.
 	return p.add_val_id(5, '')
+}
+
+fn resolve_comptime_define_literal(default &flat.Node, value string) !flat.Node {
+	match default.kind {
+		.bool_literal {
+			if value !in ['true', 'false'] {
+				return error('bool literal `true` or `false` expected, found "${value}"')
+			}
+		}
+		.char_literal {
+			if value.starts_with('\\') {
+				if value.len <= 1 {
+					return error('empty escape sequence found')
+				}
+				if !util.is_escape_sequence(value[1]) {
+					return error('char literal escape sequence expected, found "${value}"')
+				}
+			} else if value.len != 1 {
+				return error('char literal expected, found "${value}"')
+			}
+		}
+		.float_literal {
+			if value.count('.') != 1 {
+				return error('f64 literal expected, found "${value}"')
+			}
+		}
+		.int_literal {
+			if !value.is_int() {
+				return error('i64 literal expected, found "${value}"')
+			}
+		}
+		.string_literal {}
+		else {
+			return error('expected pure literal, found "${value}"')
+		}
+	}
+	mut resolved := *default
+	resolved.value = value
+	return resolved
 }
 
 fn defer_result_index_literal(value string) ?int {
@@ -8568,7 +8609,7 @@ fn (mut p Parser) prefix_expr() flat.NodeId {
 				}
 				return p.add_val_id(5, hash)
 			}
-			if name == '@VEXEROOT' {
+			if name in ['@VEXEROOT', '@VROOT'] {
 				return p.add_val_id(5, p.prefs.vroot)
 			}
 			if name == '@VEXE' {

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -3433,7 +3433,7 @@ fn (mut p Parser) resolve_comptime_at_values_at(cond string, pseudo_pos int) str
 					write_comptime_cond_string(mut out, p.prefs.backend)
 				}
 				'@PLATFORM' {
-					write_comptime_cond_string(mut out, @PLATFORM)
+					write_comptime_cond_string(mut out, p.prefs.comptime_platform())
 				}
 				'@VCURRENTHASH', '@VHASH' {
 					hash := if name == '@VHASH' {
@@ -8597,7 +8597,7 @@ fn (mut p Parser) prefix_expr() flat.NodeId {
 				return p.add_val_id(5, p.prefs.backend)
 			}
 			if name == '@PLATFORM' {
-				return p.add_val_id(5, @PLATFORM)
+				return p.add_val_id(5, p.prefs.comptime_platform())
 			}
 			if name == '@VCURRENTHASH' || name == '@VHASH' {
 				return p.add_val_id(5, if name == '@VHASH' {

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -3427,7 +3427,7 @@ fn (mut p Parser) resolve_comptime_at_values_at(cond string, pseudo_pos int) str
 					write_comptime_cond_string(mut out, p.prefs.normalized_target_os())
 				}
 				'@CCOMPILER' {
-					write_comptime_cond_string(mut out, @CCOMPILER)
+					write_comptime_cond_string(mut out, p.prefs.ccompiler)
 				}
 				'@BACKEND' {
 					write_comptime_cond_string(mut out, p.prefs.backend)
@@ -3436,7 +3436,12 @@ fn (mut p Parser) resolve_comptime_at_values_at(cond string, pseudo_pos int) str
 					write_comptime_cond_string(mut out, @PLATFORM)
 				}
 				'@VCURRENTHASH', '@VHASH' {
-					write_comptime_cond_string(mut out, '')
+					hash := if name == '@VHASH' {
+						p.prefs.vhash
+					} else {
+						p.prefs.vcurrent_hash
+					}
+					write_comptime_cond_string(mut out, hash)
 				}
 				else {
 					out.write_string(name)
@@ -4489,9 +4494,9 @@ fn (p &Parser) comptime_cond_name_is_flag(cond string, name string, end int) boo
 		'android', 'termux', 'wasm32_emscripten', 'posix', 'unix', 'bsd', 'x64', 'x32', 'amd64',
 		'i386', 'x86', 'arm64', 'aarch64', 'arm32', 'rv64', 'riscv64', 's390x', 'ppc64', 'ppc64le',
 		'loongarch64', 'wasm32', 'little_endian', 'big_endian', 'debug', 'test', 'native',
-		'builtin_write_buf_to_fd_should_use_c_write', 'tinyc', 'no_backtrace', 'gcboehm',
-		'gcboehm_opt', 'prealloc', 'autofree', 'no_bounds_checking', 'freestanding', 'nofloat',
-		'threads' {
+		'builtin_write_buf_to_fd_should_use_c_write', 'tinyc', 'no_backtrace', 'gcboehm', 'gcc',
+		'clang', 'mingw', 'msvc', 'cplusplus', 'gcboehm_opt', 'prealloc', 'autofree',
+		'no_bounds_checking', 'freestanding', 'nofloat', 'threads' {
 			return true
 		}
 		else {}
@@ -8586,7 +8591,7 @@ fn (mut p Parser) prefix_expr() flat.NodeId {
 				return p.add_val_id(5, p.prefs.normalized_target_os())
 			}
 			if name == '@CCOMPILER' {
-				return p.add_val_id(5, @CCOMPILER)
+				return p.add_val_id(5, p.prefs.ccompiler)
 			}
 			if name == '@BACKEND' {
 				return p.add_val_id(5, p.prefs.backend)
@@ -8595,7 +8600,11 @@ fn (mut p Parser) prefix_expr() flat.NodeId {
 				return p.add_val_id(5, @PLATFORM)
 			}
 			if name == '@VCURRENTHASH' || name == '@VHASH' {
-				return p.add_val_id(5, '')
+				return p.add_val_id(5, if name == '@VHASH' {
+					p.prefs.vhash
+				} else {
+					p.prefs.vcurrent_hash
+				})
 			}
 			if name == 'chan' && p.can_start_type_name() {
 				if p.tok == .not {

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -8,6 +8,7 @@ import v3.flat
 import v3.pref
 import v3.scanner
 import v3.token
+import v.util.version
 
 const max_parse_diagnostics = 100
 
@@ -544,6 +545,14 @@ fn vmod_root_for_file(path string) string {
 		dir = parent
 	}
 	return dir
+}
+
+fn vmod_hash_for_file(path string) !string {
+	root := vmod_root_for_file(path)
+	if !os.is_file(os.join_path_single(root, 'v.mod')) {
+		return error('@VMODHASH can only be used in projects that have a v.mod file')
+	}
+	return version.githash(root)
 }
 
 // next supports next handling for Parser.
@@ -3376,6 +3385,16 @@ fn (mut p Parser) resolve_comptime_at_values_at(cond string, pseudo_pos int) str
 					}
 					write_comptime_cond_string(mut out, content.replace('\r\n', '\n'))
 				}
+				'@VMODHASH' {
+					hash := vmod_hash_for_file(p.cur_file) or {
+						message := p.a.add_val_id(5, err.msg())
+						call := p.make_compile_error_call(message, pseudo_pos + start, pseudo_pos +
+							i)
+						_ = p.make_top_level_compile_error(call)
+						''
+					}
+					write_comptime_cond_string(mut out, hash)
+				}
 				'@VEXEROOT' {
 					write_comptime_cond_string(mut out, p.prefs.vroot)
 				}
@@ -3385,6 +3404,9 @@ fn (mut p Parser) resolve_comptime_at_values_at(cond string, pseudo_pos int) str
 				}
 				'@LINE' {
 					write_comptime_cond_string(mut out, p.line_nr_for_pos(pseudo_pos).str())
+				}
+				'@COLUMN' {
+					write_comptime_cond_string(mut out, p.column_for_pos(pseudo_pos + start).str())
 				}
 				'@FILE_LINE' {
 					write_comptime_cond_string(mut out,
@@ -5048,14 +5070,24 @@ fn (mut p Parser) parse_comptime_expr() flat.NodeId {
 			return flat.empty_node
 		}
 		p.next()
-		// First argument is the compile-time define name. v3 currently only
-		// uses the default expression, so consume the name expression.
+		define_name := if p.tok == .string { strip_quotes(p.lit) } else { '' }
+		// The first argument is the compile-time define name.
 		if p.tok != .comma && p.tok != .rpar && p.tok != .eof {
 			p.expr(.lowest)
 		}
 		if p.tok == .comma {
 			p.next()
-			default_expr := p.expr(.lowest)
+			mut value_expr := p.expr(.lowest)
+			default := p.a.node(value_expr)
+			if value := p.prefs.compile_values[define_name] {
+				if default.kind == .bool_literal && value in ['true', 'false'] {
+					value_expr = p.a.add_node(flat.Node{
+						kind:  .bool_literal
+						value: value
+						pos:   default.pos
+					})
+				}
+			}
 			for p.tok != .rpar && p.tok != .eof {
 				p.next()
 			}
@@ -5063,7 +5095,7 @@ fn (mut p Parser) parse_comptime_expr() flat.NodeId {
 			return p.add_node(flat.Node{
 				kind:           .paren
 				value:          '__v3_comptime_d'
-				children_start: p.add_child(default_expr)
+				children_start: p.add_child(value_expr)
 				children_count: 1
 				pos:            p.span_to(dollar_pos)
 			})
@@ -8529,6 +8561,13 @@ fn (mut p Parser) prefix_expr() flat.NodeId {
 				}
 				return p.add_val_id(5, content.replace('\r\n', '\n'))
 			}
+			if name == '@VMODHASH' {
+				hash := vmod_hash_for_file(p.cur_file) or {
+					message := p.add_val_id(5, err.msg())
+					return p.make_compile_error_call(message, name_pos, p.prev_tok_end)
+				}
+				return p.add_val_id(5, hash)
+			}
 			if name == '@VEXEROOT' {
 				return p.add_val_id(5, p.prefs.vroot)
 			}
@@ -8541,6 +8580,9 @@ fn (mut p Parser) prefix_expr() flat.NodeId {
 			if name == '@LINE' {
 				// like V1, `@LINE` is a string literal holding the 1-based line number
 				return p.add_val_id(5, p.line_nr_for_pos(name_pos).str())
+			}
+			if name == '@COLUMN' {
+				return p.add_val_id(5, p.column_for_pos(name_pos).str())
 			}
 			if name == '@FILE_LINE' {
 				return p.add_val_id(5, '${os.real_path(p.cur_file)}:${p.line_nr_for_pos(name_pos)}')

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -2397,7 +2397,7 @@ fn (mut p Parser) skip_attrs() {
 		p.next()
 		if p.tok == .key_if {
 			p.next()
-			if !p.eval_comptime_cond(p.parse_attribute_comptime_cond()) {
+			if !p.eval_attribute_comptime_cond(p.parse_attribute_comptime_cond()) {
 				p.skip_next_decl = true
 			}
 		}
@@ -2564,7 +2564,7 @@ fn (mut p Parser) parse_field_attrs_with_kinds() ParsedFieldAttrs {
 		p.next() // consume `@[` / `[`
 		if p.tok == .key_if {
 			p.next()
-			if !p.eval_comptime_cond(p.parse_attribute_comptime_cond()) {
+			if !p.eval_attribute_comptime_cond(p.parse_attribute_comptime_cond()) {
 				p.skip_next_decl = true
 			}
 			p.check(.rsbr)
@@ -3859,6 +3859,27 @@ fn (mut p Parser) parse_top_level_comptime_else() flat.NodeId {
 fn (p &Parser) eval_comptime_cond(cond string) bool {
 	return p.eval_comptime_cond_with_target_override(cond,
 		p.tok_pos in p.unsupported_inline_asm_guards)
+}
+
+fn (p &Parser) eval_attribute_comptime_cond(cond string) bool {
+	name := comptime_cond_strip_outer_parens(cond.trim_space())
+	mut is_name := name.len > 0
+	for c in name {
+		if !c.is_letter() && !c.is_digit() && c != `_` {
+			is_name = false
+			break
+		}
+	}
+	if is_name {
+		for define in p.prefs.user_defines {
+			if define == name || define.starts_with('${name}=') {
+				// Attribute guards allow explicit `-d` overrides even when the
+				// name is also a built-in flag. `$if debug` still follows -g/-cg.
+				return true
+			}
+		}
+	}
+	return p.eval_comptime_cond(cond)
 }
 
 fn (p &Parser) eval_comptime_cond_with_target_override(cond string, disable_target_arch bool) bool {

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -5129,7 +5129,7 @@ fn (mut p Parser) parse_comptime_expr() flat.NodeId {
 		if p.tok == .lpar {
 			p.next() // skip (
 			if p.tok == .string {
-				env_val = os.getenv(strip_quotes(p.lit))
+				env_val = pref.macos_v3_caller_env_value(strip_quotes(p.lit))
 				p.next()
 			}
 			for p.tok != .rpar && p.tok != .eof {

--- a/vlib/v3/pref/pref.v
+++ b/vlib/v3/pref/pref.v
@@ -13,9 +13,12 @@ pub mut:
 	user_defines      []string
 	compile_values    map[string]string
 	backend           string = 'c'
+	ccompiler         string = 'gcc'
 	c99               bool
 	vroot             string = detect_vroot()
 	vexe              string = detect_vexe()
+	vhash             string
+	vcurrent_hash     string
 	selfhost          bool
 	building_v        bool // compiling the V compiler itself: no generics, skip monomorphization
 	is_prod           bool
@@ -860,8 +863,11 @@ pub fn comptime_flag_value(p &Preferences, name string) bool {
 		'builtin_write_buf_to_fd_should_use_c_write' {
 			return p.backend == 'arm64'
 		}
+		'gcc', 'clang', 'mingw', 'msvc', 'cplusplus' {
+			return p.backend == 'c' && p.ccompiler == name
+		}
 		'tinyc' {
-			return p.backend == 'arm64'
+			return p.backend == 'arm64' || (p.backend == 'c' && p.ccompiler == 'tinyc')
 		}
 		'no_backtrace' {
 			return p.backend == 'arm64' || name in p.user_defines

--- a/vlib/v3/pref/pref.v
+++ b/vlib/v3/pref/pref.v
@@ -771,6 +771,15 @@ pub fn (p &Preferences) normalized_target_arch() string {
 	return p.target.arch
 }
 
+// comptime_platform returns the established @PLATFORM name for the selected target.
+pub fn (p &Preferences) comptime_platform() string {
+	return match p.target.arch {
+		'x86' { 'i386' }
+		'riscv64' { 'rv64' }
+		else { p.target.arch }
+	}
+}
+
 // is_cross_target reports whether is cross target applies in pref.
 pub fn (p &Preferences) is_cross_target() bool {
 	host := host_target()

--- a/vlib/v3/pref/pref.v
+++ b/vlib/v3/pref/pref.v
@@ -10,6 +10,7 @@ const macos_v3_caller_vchild_env = 'V_MACOS_V3_CALLER_VCHILD'
 const macos_v3_caller_vchild_present_env = 'V_MACOS_V3_CALLER_VCHILD_PRESENT'
 const macos_v3_private_environment_names = [
 	'V_MACOS_V3_FALLBACK_FILE',
+	'V_MACOS_V3_C_ERROR_DIR',
 	'V_MACOS_V3_VHASH',
 	'V_MACOS_V3_VCURRENT_HASH',
 	macos_v3_caller_vexe_env,

--- a/vlib/v3/pref/pref.v
+++ b/vlib/v3/pref/pref.v
@@ -164,11 +164,11 @@ pub fn has_macos_v3_caller_environment() bool {
 
 // macos_v3_caller_env_value returns the caller-visible value for compile-time `$env`.
 pub fn macos_v3_caller_env_value(name string) string {
-	if !has_macos_v3_caller_environment() {
-		return os.getenv(name)
-	}
 	if name in macos_v3_private_environment_names {
 		return ''
+	}
+	if !has_macos_v3_caller_environment() {
+		return os.getenv(name)
 	}
 	if name == 'VEXE' {
 		return if os.getenv(macos_v3_caller_vexe_present_env) == '1' {
@@ -190,13 +190,12 @@ pub fn macos_v3_caller_env_value(name string) string {
 // macos_v3_caller_environment returns the environment that delegated run children should see.
 pub fn macos_v3_caller_environment() map[string]string {
 	mut environment := os.environ()
-	if !has_macos_v3_caller_environment() {
-		return environment
+	if has_macos_v3_caller_environment() {
+		restore_macos_v3_caller_environment_value(mut environment, 'VEXE',
+			macos_v3_caller_vexe_env, macos_v3_caller_vexe_present_env)
+		restore_macos_v3_caller_environment_value(mut environment, 'VCHILD',
+			macos_v3_caller_vchild_env, macos_v3_caller_vchild_present_env)
 	}
-	restore_macos_v3_caller_environment_value(mut environment, 'VEXE', macos_v3_caller_vexe_env,
-		macos_v3_caller_vexe_present_env)
-	restore_macos_v3_caller_environment_value(mut environment, 'VCHILD',
-		macos_v3_caller_vchild_env, macos_v3_caller_vchild_present_env)
 	for name in macos_v3_private_environment_names {
 		environment.delete(name)
 	}

--- a/vlib/v3/pref/pref.v
+++ b/vlib/v3/pref/pref.v
@@ -13,6 +13,8 @@ const macos_v3_private_environment_names = [
 	'V_MACOS_V3_C_ERROR_DIR',
 	'V_MACOS_V3_VHASH',
 	'V_MACOS_V3_VCURRENT_HASH',
+	'V3_CRUN_BUILD_IDENTITY',
+	'V3_INTERNAL_RESTART',
 	macos_v3_caller_vexe_env,
 	macos_v3_caller_vexe_present_env,
 	macos_v3_caller_vchild_env,

--- a/vlib/v3/pref/pref.v
+++ b/vlib/v3/pref/pref.v
@@ -4,6 +4,20 @@ import os
 import time
 import v3.cmdexec
 
+const macos_v3_caller_vexe_env = 'V_MACOS_V3_CALLER_VEXE'
+const macos_v3_caller_vexe_present_env = 'V_MACOS_V3_CALLER_VEXE_PRESENT'
+const macos_v3_caller_vchild_env = 'V_MACOS_V3_CALLER_VCHILD'
+const macos_v3_caller_vchild_present_env = 'V_MACOS_V3_CALLER_VCHILD_PRESENT'
+const macos_v3_private_environment_names = [
+	'V_MACOS_V3_FALLBACK_FILE',
+	'V_MACOS_V3_VHASH',
+	'V_MACOS_V3_VCURRENT_HASH',
+	macos_v3_caller_vexe_env,
+	macos_v3_caller_vexe_present_env,
+	macos_v3_caller_vchild_env,
+	macos_v3_caller_vchild_present_env,
+]
+
 // Preferences represents preferences data used by pref.
 pub struct Preferences {
 pub mut:
@@ -137,6 +151,62 @@ pub fn new_preferences() &Preferences {
 		build_date:      build_time.strftime('%Y-%m-%d')
 		build_time:      build_time.strftime('%H:%M:%S')
 		build_timestamp: build_time.unix().str()
+	}
+}
+
+// has_macos_v3_caller_environment reports whether the macOS driver transported
+// the environment that should remain visible to compiled programs.
+pub fn has_macos_v3_caller_environment() bool {
+	return os.getenv(macos_v3_caller_vexe_present_env) in ['0', '1']
+		&& os.getenv(macos_v3_caller_vchild_present_env) in ['0', '1']
+}
+
+// macos_v3_caller_env_value returns the caller-visible value for compile-time `$env`.
+pub fn macos_v3_caller_env_value(name string) string {
+	if !has_macos_v3_caller_environment() {
+		return os.getenv(name)
+	}
+	if name in macos_v3_private_environment_names {
+		return ''
+	}
+	if name == 'VEXE' {
+		return if os.getenv(macos_v3_caller_vexe_present_env) == '1' {
+			os.getenv(macos_v3_caller_vexe_env)
+		} else {
+			''
+		}
+	}
+	if name == 'VCHILD' {
+		return if os.getenv(macos_v3_caller_vchild_present_env) == '1' {
+			os.getenv(macos_v3_caller_vchild_env)
+		} else {
+			''
+		}
+	}
+	return os.getenv(name)
+}
+
+// macos_v3_caller_environment returns the environment that delegated run children should see.
+pub fn macos_v3_caller_environment() map[string]string {
+	mut environment := os.environ()
+	if !has_macos_v3_caller_environment() {
+		return environment
+	}
+	restore_macos_v3_caller_environment_value(mut environment, 'VEXE', macos_v3_caller_vexe_env,
+		macos_v3_caller_vexe_present_env)
+	restore_macos_v3_caller_environment_value(mut environment, 'VCHILD',
+		macos_v3_caller_vchild_env, macos_v3_caller_vchild_present_env)
+	for name in macos_v3_private_environment_names {
+		environment.delete(name)
+	}
+	return environment
+}
+
+fn restore_macos_v3_caller_environment_value(mut environment map[string]string, name string, value_name string, present_name string) {
+	if os.getenv(present_name) == '1' {
+		environment[name] = os.getenv(value_name)
+	} else {
+		environment.delete(name)
 	}
 }
 

--- a/vlib/v3/pref/target_test.v
+++ b/vlib/v3/pref/target_test.v
@@ -95,6 +95,23 @@ fn test_debug_comptime_flag_uses_target_preferences() {
 	assert comptime_flag_value(prefs, 'debug')
 }
 
+fn test_c_compiler_comptime_flags_use_effective_compiler() {
+	mut prefs := new_preferences()
+	prefs.backend = 'c'
+	prefs.ccompiler = 'clang'
+	assert comptime_flag_value(prefs, 'clang')
+	assert !comptime_flag_value(prefs, 'gcc')
+	assert !comptime_flag_value(prefs, 'tinyc')
+	prefs.ccompiler = 'gcc'
+	assert comptime_flag_value(prefs, 'gcc')
+	assert !comptime_flag_value(prefs, 'clang')
+	prefs.ccompiler = 'tinyc'
+	assert comptime_flag_value(prefs, 'tinyc')
+	prefs.backend = 'arm64'
+	assert comptime_flag_value(prefs, 'tinyc')
+	assert !comptime_flag_value(prefs, 'gcc')
+}
+
 fn test_source_selection_uses_target_os_and_arch() {
 	dir := os.join_path(os.vtmp_dir(), 'v3_target_pref_${os.getpid()}')
 	os.rmdir_all(dir) or {}

--- a/vlib/v3/pref/target_test.v
+++ b/vlib/v3/pref/target_test.v
@@ -10,6 +10,9 @@ fn test_target_from_normalizes_and_derives_platform_properties() {
 	assert target.endian == 'little'
 	assert target.pointer_bits == 64
 	assert target.object_format == 'macho'
+	mut prefs := new_preferences()
+	prefs.target = target
+	assert prefs.comptime_platform() == 'amd64'
 
 	wasm_target := target_from('emscripten', 'wasm32') or { panic(err) }
 	assert wasm_target.pointer_bits == 32
@@ -25,6 +28,8 @@ fn test_target_from_normalizes_and_derives_platform_properties() {
 	assert termux_target.arch == 'arm64'
 	assert termux_target.abi == 'android'
 	assert termux_target.object_format == 'elf'
+	prefs.target = termux_target
+	assert prefs.comptime_platform() == 'arm64'
 }
 
 fn test_native_arch_aliases_normalize_to_supported_targets() {
@@ -37,6 +42,11 @@ fn test_native_arch_aliases_normalize_to_supported_targets() {
 	assert target_from('linux', 'ppc64le')!.arch == 'ppc64le'
 	assert target_from('linux', 'loongarch64')!.arch == 'loongarch64'
 	assert target_from('wasm32_emscripten', 'wasm')!.arch == 'wasm32'
+	mut prefs := new_preferences()
+	prefs.target = target_from('linux', 'i386')!
+	assert prefs.comptime_platform() == 'i386'
+	prefs.target = target_from('linux', 'rv64')!
+	assert prefs.comptime_platform() == 'rv64'
 }
 
 fn test_remaining_native_os_targets_are_supported() {

--- a/vlib/v3/tests/c_flag_target_filter_codegen_test.v
+++ b/vlib/v3/tests/c_flag_target_filter_codegen_test.v
@@ -82,7 +82,7 @@ fn test_c_flag_target_filter_drops_termux_off_termux() {
 	assert run.output.trim_space() == 'termux-filter-ok'
 }
 
-fn test_objective_c_flags_are_confined_to_cached_dylib() {
+fn test_objective_c_flags_are_applied_to_standalone_build() {
 	$if !macos {
 		return
 	}
@@ -90,7 +90,7 @@ fn test_objective_c_flags_are_confined_to_cached_dylib() {
 	v3_bin := os.join_path(os.temp_dir(), 'v3_objective_c_flag_test_${pid}')
 	os.rm(v3_bin) or {}
 	build :=
-		os.execute('${vexe} -gc none -path "${vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${v3_src}')
+		os.execute('${vexe} -gc none -prealloc -path "${vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${v3_src}')
 	assert build.exit_code == 0, build.output
 
 	src := os.join_path(os.temp_dir(), 'v3_objective_c_flag_input_${pid}.v')
@@ -101,15 +101,14 @@ fn test_objective_c_flags_are_confined_to_cached_dylib() {
 	bin := os.join_path(os.temp_dir(), 'v3_objective_c_flag_input_${pid}')
 	os.rm(bin) or {}
 	os.rmdir_all(bin) or {}
-	compile := os.execute('${v3_bin} ${src} -b c -o ${bin}')
+	compile := os.execute('${v3_bin} -no-memory-limit -b c -o ${bin} ${src}')
 	assert compile.exit_code == 0, compile.output
-	tcc_lines := compile.output.split_into_lines().filter(it.contains('tcc.exe'))
-	assert tcc_lines.len == 1, compile.output
-	tcc_line := tcc_lines[0]
-	assert tcc_line.contains('.dylib'), tcc_line
-	assert !tcc_line.contains('-fobjc-arc'), tcc_line
-	assert !tcc_line.contains('-x objective-c'), tcc_line
-	assert compile.output.contains('C dylib cache'), compile.output
+	cc_lines := compile.output.split_into_lines().filter(it.contains('> cc '))
+	assert cc_lines.len == 1, compile.output
+	cc_line := cc_lines[0]
+	assert cc_line.contains('-fobjc-arc'), cc_line
+	assert cc_line.contains('-x objective-c'), cc_line
+	assert !compile.output.contains('C dylib cache'), compile.output
 
 	run := os.execute(bin)
 	assert run.exit_code == 0, run.output

--- a/vlib/v3/tests/comptime_review_round4_test.v
+++ b/vlib/v3/tests/comptime_review_round4_test.v
@@ -23,7 +23,7 @@ fn round4_build_v3() string {
 		return v3_bin
 	}
 	build :=
-		os.execute('${round4_vexe} -gc none -path "${round4_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${round4_v3_src}')
+		os.execute('${round4_vexe} -gc none -prealloc -path "${round4_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${round4_v3_src}')
 	assert build.exit_code == 0, build.output
 	return v3_bin
 }
@@ -2185,7 +2185,7 @@ fn test_comptime_line_pseudo_values_use_their_token_positions() {
 	v3_bin := round4_build_v3()
 	if_name := 'comptime_line_pseudo_token_positions_if'
 	src_path := '${round4_tmp_path(if_name)}.v'
-	real_src_path := os.join_path(os.real_path(os.dir(src_path)), os.file_name(src_path))
+	src_file_name := os.file_name(src_path)
 	mut lines := ['fn main() {', '\tmut rows := []string{}']
 	if_line := lines.len + 1
 	lines << "\t\$if @LINE == '${if_line}'"
@@ -2193,7 +2193,7 @@ fn test_comptime_line_pseudo_values_use_their_token_positions() {
 	lines << "\t\trows << 'if-line'"
 	lines << '\t}'
 	file_line := lines.len + 1
-	lines << "\t\$if @FILE_LINE == '${real_src_path}:${file_line}'"
+	lines << "\t\$if @FILE_LINE == '${src_file_name}:${file_line}'"
 	lines << '\t{'
 	lines << "\t\trows << 'if-file-line'"
 	lines << '\t}'
@@ -2217,13 +2217,12 @@ fn test_comptime_line_pseudo_values_use_their_token_positions() {
 
 	match_file_name := 'comptime_line_pseudo_token_positions_match_file'
 	match_file_src_path := '${round4_tmp_path(match_file_name)}.v'
-	match_file_real_src_path := os.join_path(os.real_path(os.dir(match_file_src_path)),
-		os.file_name(match_file_src_path))
+	match_file_src_name := os.file_name(match_file_src_path)
 	mut match_file_lines := ['fn main() {', '\tmut rows := []string{}']
 	match_file_line := match_file_lines.len + 1
 	match_file_lines << '\t\$match @FILE_LINE'
 	match_file_lines << '\t{'
-	match_file_lines << "\t\t'${match_file_real_src_path}:${match_file_line}' { rows << 'match-file-line' }"
+	match_file_lines << "\t\t'${match_file_src_name}:${match_file_line}' { rows << 'match-file-line' }"
 	match_file_lines << "\t\t\$else { rows << 'wrong-match-file-line' }"
 	match_file_lines << '\t}'
 	match_file_lines << "\tprintln(rows.join('|'))"
@@ -2236,14 +2235,14 @@ fn test_attribute_line_pseudo_values_use_their_token_positions() {
 	v3_bin := round4_build_v3()
 	name := 'attribute_line_pseudo_token_positions'
 	src_path := '${round4_tmp_path(name)}.v'
-	real_src_path := os.join_path(os.real_path(os.dir(src_path)), os.file_name(src_path))
+	src_file_name := os.file_name(src_path)
 	mut lines := []string{}
 	line := lines.len + 1
 	lines << "@[if @LINE == '${line}'"
 	lines << ']'
 	lines << "const selected_line = 'line'"
 	file_line := lines.len + 1
-	lines << "@[if @FILE_LINE == '${real_src_path}:${file_line}'"
+	lines << "@[if @FILE_LINE == '${src_file_name}:${file_line}'"
 	lines << ']'
 	lines << "const selected_file_line = 'file-line'"
 	lines << ''

--- a/vlib/v3/tests/driver_cli_test.v
+++ b/vlib/v3/tests/driver_cli_test.v
@@ -198,6 +198,37 @@ fn run_driver_with_environment(v3_bin string, args []string, environment map[str
 	return collect_driver_process_result(mut process)
 }
 
+fn test_driver_persistent_macos_output_survives_cache_removal() {
+	$if !macos {
+		return
+	}
+	root := os.join_path(os.vtmp_dir(), 'v3_driver_persistent_output_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	v3_bin := build_driver_cli_v3_with_flags(root, ['-prealloc'])
+	source := os.join_path(root, 'persistent.v')
+	os.write_file(source, "fn main() {
+	println('persistent-output-ok')
+}
+")!
+	output := source.all_before_last('.v')
+	cache_dir := os.join_path(root, 'cache')
+	os.mkdir_all(cache_dir) or { panic(err) }
+	mut environment := os.environ()
+	environment['V3CACHE'] = cache_dir
+	compile := run_driver_with_environment(v3_bin, ['-silent', '-no-parallel', '-no-memory-limit',
+		source], environment)
+	assert compile.exit_code == 0, compile.output
+	assert os.is_file(output)
+	os.rmdir_all(cache_dir) or { panic(err) }
+	run := cmdexec.run(output, [])
+	assert run.exit_code == 0, run.output
+	assert run.output == 'persistent-output-ok\n', run.output
+}
+
 fn kept_c_files(dir string) []string {
 	mut files := (os.ls(dir) or { return []string{} }).filter(it.ends_with('.tmp.c'))
 	files.sort()

--- a/vlib/v3/tests/driver_cli_test.v
+++ b/vlib/v3/tests/driver_cli_test.v
@@ -204,9 +204,48 @@ fn test_driver_accepts_dispatcher_arguments_and_runs_vsh_files() {
 	build := cmdexec.run(v3_bin, ['-silent', '-no-parallel', '-cstrict', '-skip-running', '-usecache',
 		'build', '-o', binary, program])
 	assert build.exit_code == 0, build.output
+	assert !os.exists(binary + '.c')
 	built := cmdexec.run(binary, [])
 	assert built.exit_code == 0, built.output
 	assert built.output == 'built\n', built.output
+	implicit_program := os.join_path(root, 'implicit_build.v')
+	implicit_binary := os.join_path(root, 'implicit_build')
+	implicit_c := implicit_binary + '.c'
+	os.write_file(implicit_program, "println('implicit')")!
+	os.write_file(implicit_c, 'existing C source')!
+	implicit_build := cmdexec.run(v3_bin, ['-silent', '-no-parallel', implicit_program])
+	assert implicit_build.exit_code == 0, implicit_build.output
+	assert os.is_file(implicit_binary)
+	assert os.read_file(implicit_c)! == 'existing C source'
+	os.rm(implicit_c)!
+	keep_c_build := cmdexec.run(v3_bin, ['-silent', '-no-parallel', '-keepc', implicit_program])
+	assert keep_c_build.exit_code == 0, keep_c_build.output
+	assert os.file_size(implicit_c) > 0
+	run_program := os.join_path(root, 'implicit_run.v')
+	run_binary := run_program.all_before_last('.v')
+	os.write_file(run_program, "println('ran once')")!
+	implicit_run := cmdexec.run(v3_bin, ['-silent', '-no-parallel', 'run', run_program])
+	assert implicit_run.exit_code == 0, implicit_run.output
+	assert implicit_run.output == 'ran once\n', implicit_run.output
+	assert !os.exists(run_binary)
+	assert !os.exists(run_binary + '.c')
+	debug_define_program := os.join_path(root, 'debug_define.v')
+	os.write_file(debug_define_program, '@[if debug]
+fn enabled_by_define() {
+	println("attribute debug")
+}
+
+fn main() {
+	$if debug {
+		println("comptime debug")
+	}
+	enabled_by_define()
+}
+')!
+	debug_define_run := cmdexec.run(v3_bin, ['-silent', '-no-parallel', '-d', 'debug', 'run',
+		debug_define_program])
+	assert debug_define_run.exit_code == 0, debug_define_run.output
+	assert debug_define_run.output == 'attribute debug\n', debug_define_run.output
 	source := os.join_path(root, 'implicit_script.vsh')
 	os.write_file(source, "import os
 
@@ -216,6 +255,8 @@ println(os.args[1..].join('|'))
 	run := cmdexec.run(v3_bin, ['-silent', '-no-parallel', source, 'one', '--two'])
 	assert run.exit_code == 0, run.output
 	assert run.output == 'false\none|--two\n', run.output
+	assert !os.exists(source.all_before_last('.vsh'))
+	assert !os.exists(source.all_before_last('.vsh') + '.c')
 }
 
 fn assert_driver_wasm_output(path string) {

--- a/vlib/v3/tests/driver_cli_test.v
+++ b/vlib/v3/tests/driver_cli_test.v
@@ -16,7 +16,14 @@ fn build_driver_cli_v3_with_flags(root string, flags []string) string {
 	mut args := ['-gc', 'none']
 	args << flags
 	args << ['-path', '${driver_cli_vlib_dir}|@vlib|@vmodules', '-o', bin, driver_cli_v3_src]
-	result := cmdexec.run(@VEXE, args)
+	mut result := os.Result{}
+	$if macos {
+		mut environment := os.environ()
+		environment['V_MACOS_V3_BOOTSTRAP'] = '1'
+		result = run_driver_with_environment(@VEXE, args, environment)
+	} $else {
+		result = cmdexec.run(@VEXE, args)
+	}
 	assert result.exit_code == 0, result.output
 	return bin
 }
@@ -267,6 +274,78 @@ pub fn selected() string {
 	run := cmdexec.run(output, [])
 	assert run.exit_code == 0, run.output
 	assert run.output == 'debug\n', run.output
+}
+
+fn test_driver_propagates_default_compiler_and_hash_pseudos() {
+	$if macos {
+		root := os.join_path(os.vtmp_dir(), 'v3_driver_compiler_hashes_${os.getpid()}')
+		os.rmdir_all(root) or {}
+		os.mkdir_all(root) or { panic(err) }
+		defer {
+			os.rmdir_all(root) or {}
+		}
+		v3_bin := build_driver_cli_v3(root)
+		project := os.join_path(root, 'project')
+		module_dir := os.join_path(project, 'compilerinfo')
+		os.mkdir_all(module_dir) or { panic(err) }
+		os.write_file(os.join_path(project, 'v.mod'), "Module {
+	name: 'compiler_hash_selection'
+}
+")!
+		os.write_file(os.join_path(project, 'main.v'), 'module main
+
+import compilerinfo
+import os
+
+fn main() {
+	println(compilerinfo.values().join("|"))
+	println(os.getenv("V_MACOS_V3_VHASH") + "|" + os.getenv("V_MACOS_V3_VCURRENT_HASH"))
+}
+')!
+		os.write_file(os.join_path(module_dir, 'compilerinfo.v'), 'module compilerinfo
+
+pub fn values() []string {
+	mut rows := []string{}
+	$if clang {
+		rows << "clang"
+	} $else $if gcc {
+		rows << "gcc"
+	} $else {
+		rows << "other"
+	}
+	rows << @CCOMPILER
+	rows << @VHASH
+	rows << @VCURRENTHASH
+	$if @VHASH == "delegated-build-hash" && @VCURRENTHASH == "delegated-current-hash" {
+		rows << "hash-condition"
+	}
+	return rows
+}
+')!
+		output := os.join_path(root, 'compiler_hash_selection')
+		mut environment := os.environ()
+		environment['V_MACOS_V3_VHASH'] = 'delegated-build-hash'
+		environment['V_MACOS_V3_VCURRENT_HASH'] = 'delegated-current-hash'
+		environment['V3CACHE'] = os.join_path(root, 'cache')
+		compile := run_driver_with_environment(v3_bin, ['-silent', '-no-parallel', '-no-memory-limit',
+			'-o', output, 'run', project], environment)
+		assert compile.exit_code == 0, compile.output
+		assert compile.output == 'clang|clang|delegated-build-hash|delegated-current-hash|hash-condition\n|\n', compile.output
+
+		run := cmdexec.run(output, [])
+		assert run.exit_code == 0, run.output
+		assert run.output == 'clang|clang|delegated-build-hash|delegated-current-hash|hash-condition\n|\n', run.output
+
+		environment['V_MACOS_V3_VHASH'] = 'second-build-hash'
+		environment['V_MACOS_V3_VCURRENT_HASH'] = 'second-current-hash'
+		second_output := os.join_path(root, 'compiler_hash_selection_second')
+		second_compile := run_driver_with_environment(v3_bin, ['-silent', '-no-parallel',
+			'-no-memory-limit', '-o', second_output, project], environment)
+		assert second_compile.exit_code == 0, second_compile.output
+		second_run := cmdexec.run(second_output, [])
+		assert second_run.exit_code == 0, second_run.output
+		assert second_run.output == 'clang|clang|second-build-hash|second-current-hash\n|\n', second_run.output
+	}
 }
 
 fn test_driver_run_preserves_stdin() {

--- a/vlib/v3/tests/driver_cli_test.v
+++ b/vlib/v3/tests/driver_cli_test.v
@@ -149,10 +149,17 @@ fn main() {
 		panic(err)
 	}
 	output := os.join_path(root, 'cli_header_program')
-	compile := cmdexec.run(v3_bin, ['-nocache', '-keepc', '-cflags', '-I "${include_dir}"', '-o',
-		output, source])
+	keep_c_dir := os.join_path(root, 'kept_c')
+	os.mkdir(keep_c_dir)!
+	mut environment := os.environ()
+	environment['VTMP'] = keep_c_dir
+	compile := run_driver_with_environment(v3_bin, ['-nocache', '-keepc', '-cflags',
+		'-I "${include_dir}"', '-o', output, source], environment)
 	assert compile.exit_code == 0, compile.output
-	generated_c := os.read_file(output + '.c')!
+	assert !os.exists(output + '.c')
+	kept_files := kept_c_files(keep_c_dir)
+	assert kept_files.len == 1, kept_files.str()
+	generated_c := os.read_file(kept_files[0])!
 	assert !generated_c.contains('#include "cli_header.h"'), generated_c
 	assert generated_c.contains('static inline int cli_header_value(CliHeaderValue* item)')
 	run := cmdexec.run(output, [])
@@ -189,6 +196,12 @@ fn run_driver_with_environment(v3_bin string, args []string, environment map[str
 	process.set_args(args)
 	process.set_environment(environment)
 	return collect_driver_process_result(mut process)
+}
+
+fn kept_c_files(dir string) []string {
+	mut files := (os.ls(dir) or { return []string{} }).filter(it.ends_with('.tmp.c'))
+	files.sort()
+	return files.map(os.join_path_single(dir, it))
 }
 
 fn test_driver_requests_macos_compatibility_for_inline_assembly() {
@@ -400,10 +413,18 @@ fn test_driver_accepts_dispatcher_arguments_and_runs_vsh_files() {
 	assert showcc_build.output.contains('  > '), showcc_build.output
 	assert !showcc_build.output.contains('=== v3 benchmark ==='), showcc_build.output
 	assert !showcc_build.output.contains('MB RSS'), showcc_build.output
-	os.rm(implicit_c)!
-	keep_c_build := cmdexec.run(v3_bin, ['-silent', '-no-parallel', '-keepc', implicit_program])
+	keep_c_dir := os.join_path(root, 'kept_c')
+	os.mkdir(keep_c_dir)!
+	mut keep_c_environment := os.environ()
+	keep_c_environment['VTMP'] = keep_c_dir
+	keep_c_build := run_driver_with_environment(v3_bin, ['-silent', '-no-parallel', '-keepc',
+		implicit_program], keep_c_environment)
 	assert keep_c_build.exit_code == 0, keep_c_build.output
-	assert os.file_size(implicit_c) > 0
+	assert os.read_file(implicit_c)! == 'existing C source'
+	kept_files := kept_c_files(keep_c_dir)
+	assert kept_files.len == 1, kept_files.str()
+	assert os.file_size(kept_files[0]) > 0
+	assert os.file_name(kept_files[0]).starts_with('implicit_build.')
 	run_program := os.join_path(root, 'implicit_run.v')
 	run_binary := run_program.all_before_last('.v')
 	os.write_file(run_program, "println('ran once')")!
@@ -513,6 +534,40 @@ fn assert_driver_wasm_output(path string) {
 	assert bytes[..4] == [u8(0), 0x61, 0x73, 0x6d]
 }
 
+fn test_driver_platform_pseudo_uses_selected_target_arch() {
+	root := os.join_path(os.vtmp_dir(), 'v3_driver_platform_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	v3_bin := build_driver_cli_v3(root)
+	source := os.join_path(root, 'platform.v')
+	os.write_file(source, "fn main() {
+	println(@PLATFORM)
+	\$if @PLATFORM == 'amd64' {
+		println('selected-amd64')
+	} \$else \$if @PLATFORM == 'arm64' {
+		println('selected-arm64')
+	}
+}
+")!
+	for target_arch, platform in {
+		'x86_64': 'amd64'
+		'arm64':  'arm64'
+	} {
+		output := os.join_path(root, 'platform_${platform}.c')
+		compile := cmdexec.run(v3_bin, ['-nocache', '-no-parallel', '-os', 'macos', '-arch',
+			target_arch, '-o', output, source])
+		assert compile.exit_code == 0, compile.output
+		generated_c := os.read_file(output)!
+		assert generated_c.contains('{"${platform}", ${platform.len}'), generated_c
+		assert generated_c.contains('selected-${platform}'), generated_c
+		other_platform := if platform == 'amd64' { 'arm64' } else { 'amd64' }
+		assert !generated_c.contains('selected-${other_platform}'), generated_c
+	}
+}
+
 fn test_wasm_backend_defaults_target_unless_explicit() {
 	root := os.join_path(os.vtmp_dir(), 'v3_driver_wasm_target_${os.getpid()}')
 	os.rmdir_all(root) or {}
@@ -591,11 +646,16 @@ fn test_driver_rejects_invalid_cli_and_parses_vmod_subdirs() {
 	assert verbose_compile.exit_code == 0, verbose_compile.output
 	assert verbose_compile.output.contains('[ttime]'), verbose_compile.output
 	compat_output := os.join_path(root, 'hello_compat')
+	kept_before := kept_c_files(os.vtmp_dir())
 	compat_compile := cmdexec.run(v3_bin, ['-stats', '-show-timings', '-showcc', '-keepc', '-w',
 		'-g', '-cflags', '-w', '-enable-globals', '-o', compat_output, source])
 	assert compat_compile.exit_code == 0, compat_compile.output
 	assert os.is_file(compat_output)
-	assert os.is_file(compat_output + '.c')
+	assert !os.exists(compat_output + '.c')
+	new_kept_files := kept_c_files(os.vtmp_dir()).filter(it !in kept_before
+		&& os.file_name(it).starts_with('hello_compat.'))
+	assert new_kept_files.len == 1, new_kept_files.str()
+	os.rm(new_kept_files[0])!
 	debug_source := os.join_path(root, 'debug_comptime.v')
 	os.write_file(debug_source,
 		"fn main() {\n\t\$if debug {\n\t\tprintln('debug')\n\t} \$else {\n\t\tprintln('release')\n\t}\n}\n") or {

--- a/vlib/v3/tests/driver_cli_test.v
+++ b/vlib/v3/tests/driver_cli_test.v
@@ -7,9 +7,15 @@ const driver_cli_v3_dir = os.dir(os.dir(@FILE))
 const driver_cli_v3_src = os.join_path(driver_cli_v3_dir, 'v3.v')
 
 fn build_driver_cli_v3(root string) string {
+	return build_driver_cli_v3_with_flags(root, [])
+}
+
+fn build_driver_cli_v3_with_flags(root string, flags []string) string {
 	bin := os.join_path(root, 'v3_driver_cli')
-	result := cmdexec.run(@VEXE, ['-gc', 'none', '-path', '${driver_cli_vlib_dir}|@vlib|@vmodules',
-		'-o', bin, driver_cli_v3_src])
+	mut args := ['-gc', 'none']
+	args << flags
+	args << ['-path', '${driver_cli_vlib_dir}|@vlib|@vmodules', '-o', bin, driver_cli_v3_src]
+	result := cmdexec.run(@VEXE, args)
 	assert result.exit_code == 0, result.output
 	return bin
 }
@@ -182,6 +188,34 @@ fn test_driver_run_preserves_stdin() {
 	result := run_driver_with_stdin_file(v3_bin, ['-o', output, 'run', source], input_file)
 	assert result.exit_code == 0, result.output
 	assert result.output.contains('read:from-stdin'), result.output
+}
+
+fn test_driver_accepts_dispatcher_arguments_and_runs_vsh_files() {
+	root := os.join_path(os.vtmp_dir(), 'v3_driver_vsh_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	v3_bin := build_driver_cli_v3_with_flags(root, ['-prealloc'])
+	program := os.join_path(root, 'dispatcher_build.v')
+	binary := os.join_path(root, 'dispatcher_build')
+	os.write_file(program, "println('built')")!
+	build := cmdexec.run(v3_bin, ['-silent', '-no-parallel', '-cstrict', '-skip-running', '-usecache',
+		'build', '-o', binary, program])
+	assert build.exit_code == 0, build.output
+	built := cmdexec.run(binary, [])
+	assert built.exit_code == 0, built.output
+	assert built.output == 'built\n', built.output
+	source := os.join_path(root, 'implicit_script.vsh')
+	os.write_file(source, "import os
+
+println(os.executable().ends_with('.vsh'))
+println(os.args[1..].join('|'))
+")!
+	run := cmdexec.run(v3_bin, ['-silent', '-no-parallel', source, 'one', '--two'])
+	assert run.exit_code == 0, run.output
+	assert run.output == 'false\none|--two\n', run.output
 }
 
 fn assert_driver_wasm_output(path string) {

--- a/vlib/v3/tests/driver_cli_test.v
+++ b/vlib/v3/tests/driver_cli_test.v
@@ -327,6 +327,65 @@ fn main() {
 	}
 }
 
+fn test_driver_requests_macos_compatibility_for_language_errors() {
+	root := os.join_path(os.vtmp_dir(), 'v3_driver_language_fallback_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	v3_bin := build_driver_cli_v3(root)
+	source := os.join_path(root, 'generic_fn_call.v')
+	os.write_file(source, 'struct Opt[T] {
+	val T
+	some bool
+}
+
+fn some[T](val T) Opt[T] {
+	return Opt[T]{
+		val: val
+		some: true
+	}
+}
+
+fn (f Opt[T]) map[U](op fn (T) U) Opt[U] {
+	if f.some {
+		return some[U](op(f.val))
+	}
+	return Opt[U]{}
+}
+
+fn main() {
+	result := some("hello").map(|s| s.len)
+	assert result.some && result.val == 5
+}
+')!
+	fallback_file := os.join_path(root, 'fallback')
+	mut environment := os.environ()
+	environment['V_MACOS_V3_FALLBACK_FILE'] = fallback_file
+	result := run_driver_with_environment(v3_bin, ['-silent', '-no-parallel', '-nocache',
+		'-no-memory-limit', source], environment)
+	assert result.exit_code != 0
+	assert os.read_file(fallback_file)! == 'compiler_error'
+
+	compat_output := os.join_path(root, 'compat')
+	compat := cmdexec.run(@VEXE, ['-old-compiler', '-o', compat_output, source])
+	assert compat.exit_code == 0, compat.output
+	compat_run := cmdexec.run(compat_output, [])
+	assert compat_run.exit_code == 0, compat_run.output
+
+	os.rm(fallback_file)!
+	nonzero_source := os.join_path(root, 'nonzero_run.v')
+	os.write_file(nonzero_source, 'fn main() {
+	exit(23)
+}
+')!
+	nonzero_run := run_driver_with_environment(v3_bin, ['-silent', '-no-parallel', '-nocache',
+		'-no-memory-limit', 'run', nonzero_source], environment)
+	assert nonzero_run.exit_code == 23, nonzero_run.output
+	assert !os.exists(fallback_file)
+}
+
 fn test_driver_requests_macos_compatibility_for_c_compilation_errors() {
 	root := os.join_path(os.vtmp_dir(), 'v3_driver_c_error_fallback_${os.getpid()}')
 	os.rmdir_all(root) or {}

--- a/vlib/v3/tests/driver_cli_test.v
+++ b/vlib/v3/tests/driver_cli_test.v
@@ -583,6 +583,8 @@ const compile_vexe = \$env('VEXE')
 const compile_vchild = \$env('VCHILD')
 const compile_private = \$env('V_MACOS_V3_CALLER_VEXE')
 const compile_c_error_dir = \$env('V_MACOS_V3_C_ERROR_DIR')
+const compile_crun_identity = \$env('V3_CRUN_BUILD_IDENTITY')
+const compile_internal_restart = \$env('V3_INTERNAL_RESTART')
 
 fn env_value(name string) string {
 	return os.getenv_opt(name) or { '<unset>' }
@@ -594,6 +596,8 @@ fn main() {
 	println('private:' + compile_private + '|' + env_value('V_MACOS_V3_CALLER_VEXE') + '|' +
 		env_value('V_MACOS_V3_CALLER_VCHILD'))
 	println('c-error-dir:' + compile_c_error_dir + '|' + env_value('V_MACOS_V3_C_ERROR_DIR'))
+	println('crun-private:' + compile_crun_identity + '|' + compile_internal_restart + '|' +
+		env_value('V3_CRUN_BUILD_IDENTITY') + '|' + env_value('V3_INTERNAL_RESTART'))
 }
 ")!
 	cache_dir := os.join_path(root, 'cache')
@@ -605,12 +609,14 @@ fn main() {
 	unset_environment['V_MACOS_V3_CALLER_VCHILD'] = ''
 	unset_environment['V_MACOS_V3_CALLER_VCHILD_PRESENT'] = '0'
 	unset_environment['V_MACOS_V3_C_ERROR_DIR'] = os.join_path(root, 'private-c-error')
+	unset_environment['V3_CRUN_BUILD_IDENTITY'] = 'private-crun-identity'
+	unset_environment['V3_INTERNAL_RESTART'] = '1'
 	unset_environment['V3CACHE'] = cache_dir
 	unset_output := os.join_path(root, 'caller_unset')
 	unset_run := run_driver_with_environment(v3_bin, ['-silent', '-no-parallel', '-no-memory-limit',
 		'-o', unset_output, 'run', source], unset_environment)
 	assert unset_run.exit_code == 0, unset_run.output
-	assert unset_run.output == 'compile:|\nruntime:<unset>|<unset>\nprivate:|<unset>|<unset>\nc-error-dir:|<unset>\n', unset_run.output
+	assert unset_run.output == 'compile:|\nruntime:<unset>|<unset>\nprivate:|<unset>|<unset>\nc-error-dir:|<unset>\ncrun-private:||<unset>|<unset>\n', unset_run.output
 
 	mut set_environment := unset_environment.clone()
 	set_environment['V_MACOS_V3_CALLER_VEXE'] = 'caller-vexe'
@@ -621,7 +627,7 @@ fn main() {
 	set_run := run_driver_with_environment(v3_bin, ['-silent', '-no-parallel', '-no-memory-limit',
 		'-o', set_output, 'run', source], set_environment)
 	assert set_run.exit_code == 0, set_run.output
-	assert set_run.output == 'compile:caller-vexe|caller-vchild\nruntime:caller-vexe|caller-vchild\nprivate:|<unset>|<unset>\nc-error-dir:|<unset>\n', set_run.output
+	assert set_run.output == 'compile:caller-vexe|caller-vchild\nruntime:caller-vexe|caller-vchild\nprivate:|<unset>|<unset>\nc-error-dir:|<unset>\ncrun-private:||<unset>|<unset>\n', set_run.output
 }
 
 fn test_driver_resolves_boolean_d_and_documented_pseudos() {
@@ -895,17 +901,55 @@ fn main() {
 		debug_define_program])
 	assert debug_define_run.exit_code == 0, debug_define_run.output
 	assert debug_define_run.output == 'attribute debug\n', debug_define_run.output
+	crun_module_dir := os.join_path(root, 'crunmod')
+	crun_module_file := os.join_path(crun_module_dir, 'crunmod.v')
+	os.mkdir_all(crun_module_dir)!
+	os.write_file(crun_module_file, "module crunmod
+
+pub fn message() string {
+	return 'cached module'
+}
+")!
 	source := os.join_path(root, 'implicit_script.vsh')
-	os.write_file(source, "import os
+	os.write_file(source, "import crunmod
+import os
 
 println(os.executable().ends_with('.vsh'))
+println(crunmod.message())
 println(os.args[1..].join('|'))
 ")!
 	run := cmdexec.run(v3_bin, ['-silent', '-no-parallel', source, 'one', '--two'])
 	assert run.exit_code == 0, run.output
-	assert run.output == 'false\none|--two\n', run.output
-	assert !os.exists(source.all_before_last('.vsh'))
+	assert run.output == 'false\ncached module\none|--two\n', run.output
+	script_binary := source.all_before_last('.vsh')
+	assert os.is_file(script_binary)
 	assert !os.exists(source.all_before_last('.vsh') + '.c')
+	warm_cache_run := cmdexec.run(v3_bin, ['-silent', '-no-parallel', source, 'warm'])
+	assert warm_cache_run.exit_code == 0, warm_cache_run.output
+	assert warm_cache_run.output == 'false\ncached module\nwarm\n', warm_cache_run.output
+	cache_stamp := os.file_last_mod_unix(script_binary) + 3600
+	os.utime(script_binary, cache_stamp, cache_stamp)!
+	cached_run := cmdexec.run(v3_bin, ['-silent', '-no-parallel', source, 'cached'])
+	assert cached_run.exit_code == 0, cached_run.output
+	assert cached_run.output == 'false\ncached module\ncached\n', cached_run.output
+	assert os.file_last_mod_unix(script_binary) == cache_stamp
+	os.write_file(crun_module_file, "module crunmod
+
+pub fn message() string {
+	return 'rebuilt module'
+}
+")!
+	rebuilt_run := cmdexec.run(v3_bin, ['-silent', '-no-parallel', source, 'new'])
+	assert rebuilt_run.exit_code == 0, rebuilt_run.output
+	assert rebuilt_run.output == 'false\nrebuilt module\nnew\n', rebuilt_run.output
+	assert os.file_last_mod_unix(script_binary) != cache_stamp
+	explicit_run_source := os.join_path(root, 'explicit_run_script.vsh')
+	explicit_run_binary := explicit_run_source.all_before_last('.vsh')
+	os.write_file(explicit_run_source, "println('explicit run')")!
+	explicit_run := cmdexec.run(v3_bin, ['-silent', '-no-parallel', 'run', explicit_run_source])
+	assert explicit_run.exit_code == 0, explicit_run.output
+	assert explicit_run.output == 'explicit run\n', explicit_run.output
+	assert !os.exists(explicit_run_binary)
 	compile_only_source := os.join_path(root, 'compile_only.vsh')
 	compile_only_binary := compile_only_source.all_before_last('.vsh')
 	run_marker := os.join_path(root, 'compile_only_ran')

--- a/vlib/v3/tests/driver_cli_test.v
+++ b/vlib/v3/tests/driver_cli_test.v
@@ -157,6 +157,10 @@ fn run_driver_with_stdin_file(v3_bin string, args []string, stdin_path string) o
 	mut process := os.new_process(v3_bin)
 	process.set_args(args)
 	process.set_stdin_path(stdin_path)
+	return collect_driver_process_result(mut process)
+}
+
+fn collect_driver_process_result(mut process os.Process) os.Result {
 	process.set_redirect_stdio()
 	process.run()
 	process.wait()
@@ -170,6 +174,54 @@ fn run_driver_with_stdin_file(v3_bin string, args []string, stdin_path string) o
 	return os.Result{
 		exit_code: exit_code
 		output:    output
+	}
+}
+
+fn run_driver_with_environment(v3_bin string, args []string, environment map[string]string) os.Result {
+	mut process := os.new_process(v3_bin)
+	process.set_args(args)
+	process.set_environment(environment)
+	return collect_driver_process_result(mut process)
+}
+
+fn test_driver_requests_macos_compatibility_for_inline_assembly() {
+	$if amd64 || arm64 {
+		root := os.join_path(os.vtmp_dir(), 'v3_driver_inline_asm_fallback_${os.getpid()}')
+		os.rmdir_all(root) or {}
+		os.mkdir_all(root) or { panic(err) }
+		defer {
+			os.rmdir_all(root) or {}
+		}
+		v3_bin := build_driver_cli_v3(root)
+		source := os.join_path(root, 'inline_asm.v')
+		arch := pref.host_arch()
+		os.write_file(source, 'fn main() {
+	asm ${arch} {
+		nop
+	}
+}
+')!
+		fallback_file := os.join_path(root, 'fallback')
+		mut environment := os.environ()
+		environment['V_MACOS_V3_FALLBACK_FILE'] = fallback_file
+		result := run_driver_with_environment(v3_bin, ['-silent', '-no-parallel', source],
+			environment)
+		assert result.exit_code != 0
+		assert result.output == '', result.output
+		assert os.read_file(fallback_file)! == 'inline_asm'
+		os.rm(fallback_file)!
+		environment_source := os.join_path(root, 'fallback_environment.v')
+		os.write_file(environment_source, "import os
+
+fn main() {
+	println(os.getenv('V_MACOS_V3_FALLBACK_FILE'))
+}
+")!
+		environment_run := run_driver_with_environment(v3_bin, ['-silent', '-no-parallel',
+			'-no-memory-limit', 'run', environment_source], environment)
+		assert environment_run.exit_code == 0, environment_run.output
+		assert environment_run.output == '\n', environment_run.output
+		assert !os.exists(fallback_file)
 	}
 }
 

--- a/vlib/v3/tests/driver_cli_test.v
+++ b/vlib/v3/tests/driver_cli_test.v
@@ -284,6 +284,38 @@ fn main() {
 		'-o', g_output, source])
 	assert g_compile.exit_code == 0, g_compile.output
 	assert !g_compile.output.contains('-Wl,-export_dynamic'), g_compile.output
+
+	c99_c_source := os.join_path(root, 'compat_c99.c')
+	os.write_file(c99_c_source, '#if !defined(__STDC_VERSION__) || __STDC_VERSION__ != 199901L
+#error expected strict C99
+#endif
+
+int v3_compat_c99_probe(void) {
+	return 99;
+}
+')!
+	c99_source := os.join_path(root, 'compat_c99.v')
+	os.write_file(c99_source, "#flag @DIR/compat_c99.c
+
+fn C.v3_compat_c99_probe() int
+
+fn main() {
+	\$if c99 ? {
+		println('defined')
+	} \$else {
+		println(C.v3_compat_c99_probe())
+	}
+}
+")!
+	c99_output := os.join_path(root, 'compat_c99')
+	c99_compile := cmdexec.run(v3_bin, ['-nocache', '-no-memory-limit', '-prod', '-showcc',
+		'-macos-v3-compat-c99', '-o', c99_output, c99_source])
+	assert c99_compile.exit_code == 0, c99_compile.output
+	assert c99_compile.output.contains('-std=c99'), c99_compile.output
+	assert !c99_compile.output.contains('-std=gnu11'), c99_compile.output
+	c99_run := cmdexec.run(c99_output, [])
+	assert c99_run.exit_code == 0, c99_run.output
+	assert c99_run.output == '99\n', c99_run.output
 }
 
 fn test_driver_requests_macos_compatibility_for_inline_assembly() {

--- a/vlib/v3/tests/driver_cli_test.v
+++ b/vlib/v3/tests/driver_cli_test.v
@@ -315,14 +315,16 @@ fn test_driver_requests_macos_compatibility_for_inline_assembly() {
 		environment_source := os.join_path(root, 'fallback_environment.v')
 		os.write_file(environment_source, "import os
 
+const compile_fallback = \$env('V_MACOS_V3_FALLBACK_FILE')
+
 fn main() {
-	println(os.getenv('V_MACOS_V3_FALLBACK_FILE'))
+	println(compile_fallback + '|' + os.getenv('V_MACOS_V3_FALLBACK_FILE'))
 }
 ")!
 		environment_run := run_driver_with_environment(v3_bin, ['-silent', '-no-parallel',
 			'-no-memory-limit', 'run', environment_source], environment)
 		assert environment_run.exit_code == 0, environment_run.output
-		assert environment_run.output == '\n', environment_run.output
+		assert environment_run.output == '|\n', environment_run.output
 		assert !os.exists(fallback_file)
 	}
 }

--- a/vlib/v3/tests/driver_cli_test.v
+++ b/vlib/v3/tests/driver_cli_test.v
@@ -218,6 +218,13 @@ fn test_driver_accepts_dispatcher_arguments_and_runs_vsh_files() {
 	assert implicit_build.exit_code == 0, implicit_build.output
 	assert os.is_file(implicit_binary)
 	assert os.read_file(implicit_c)! == 'existing C source'
+	showcc_binary := os.join_path(root, 'showcc_build')
+	showcc_build := cmdexec.run(v3_bin, ['-silent', '-showcc', '-no-parallel', '-o', showcc_binary,
+		implicit_program])
+	assert showcc_build.exit_code == 0, showcc_build.output
+	assert showcc_build.output.contains('  > '), showcc_build.output
+	assert !showcc_build.output.contains('=== v3 benchmark ==='), showcc_build.output
+	assert !showcc_build.output.contains('MB RSS'), showcc_build.output
 	os.rm(implicit_c)!
 	keep_c_build := cmdexec.run(v3_bin, ['-silent', '-no-parallel', '-keepc', implicit_program])
 	assert keep_c_build.exit_code == 0, keep_c_build.output

--- a/vlib/v3/tests/driver_cli_test.v
+++ b/vlib/v3/tests/driver_cli_test.v
@@ -257,6 +257,23 @@ println(os.args[1..].join('|'))
 	assert run.output == 'false\none|--two\n', run.output
 	assert !os.exists(source.all_before_last('.vsh'))
 	assert !os.exists(source.all_before_last('.vsh') + '.c')
+	compile_only_source := os.join_path(root, 'compile_only.vsh')
+	compile_only_binary := compile_only_source.all_before_last('.vsh')
+	run_marker := os.join_path(root, 'compile_only_ran')
+	os.write_file(compile_only_source, "import os
+
+os.write_file('${run_marker}', 'ran')!
+")!
+	skip_run := cmdexec.run(v3_bin,
+		['-silent', '-no-parallel', '-skip-running', compile_only_source])
+	assert skip_run.exit_code == 0, skip_run.output
+	assert os.is_file(compile_only_binary)
+	assert !os.exists(run_marker)
+	os.rm(compile_only_binary)!
+	build_script := cmdexec.run(v3_bin, ['-silent', '-no-parallel', 'build', compile_only_source])
+	assert build_script.exit_code == 0, build_script.output
+	assert os.is_file(compile_only_binary)
+	assert !os.exists(run_marker)
 }
 
 fn assert_driver_wasm_output(path string) {

--- a/vlib/v3/tests/driver_cli_test.v
+++ b/vlib/v3/tests/driver_cli_test.v
@@ -327,6 +327,38 @@ fn main() {
 	}
 }
 
+fn test_driver_requests_macos_compatibility_for_c_compilation_errors() {
+	root := os.join_path(os.vtmp_dir(), 'v3_driver_c_error_fallback_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	v3_bin := build_driver_cli_v3(root)
+	source := os.join_path(root, 'missing_symbol.c.v')
+	os.write_file(source, 'fn C.v3_missing_symbol()
+
+fn main() {
+	C.v3_missing_symbol()
+}
+')!
+	fallback_file := os.join_path(root, 'fallback')
+	report_dir := os.join_path(root, 'c_error')
+	mut environment := os.environ()
+	environment['V_MACOS_V3_FALLBACK_FILE'] = fallback_file
+	environment['V_MACOS_V3_C_ERROR_DIR'] = report_dir
+	result := run_driver_with_environment(v3_bin, ['-silent', '-no-parallel', '-nocache',
+		'-no-memory-limit', source], environment)
+	assert result.exit_code != 0
+	assert result.output == '', result.output
+	assert os.read_file(fallback_file)! == 'c_compilation_error'
+	assert os.read_file(os.join_path(report_dir, 'compiler'))!.trim_space() != ''
+	assert os.read_file(os.join_path(report_dir, 'output'))!.to_lower().contains('v3_missing_symbol')
+	source_name := os.read_file(os.join_path(report_dir, 'source_name'))!.trim_space()
+	assert source_name == 'src.c'
+	assert os.is_file(os.join_path(report_dir, source_name))
+}
+
 fn test_driver_cg_selects_debug_module_files() {
 	root := os.join_path(os.vtmp_dir(), 'v3_driver_cg_debug_files_${os.getpid()}')
 	os.rmdir_all(root) or {}

--- a/vlib/v3/tests/driver_cli_test.v
+++ b/vlib/v3/tests/driver_cli_test.v
@@ -235,6 +235,57 @@ fn kept_c_files(dir string) []string {
 	return files.map(os.join_path_single(dir, it))
 }
 
+fn test_driver_macos_wrapv_and_cg_link_flags() {
+	$if !macos {
+		return
+	}
+	root := os.join_path(os.vtmp_dir(), 'v3_driver_macos_c_flags_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	v3_bin := build_driver_cli_v3_with_flags(root, ['-prealloc'])
+	source := os.join_path(root, 'signed_overflow.v')
+	os.write_file(source, '#flag -O2
+
+fn increment_is_greater(value int) bool {
+	return value + 1 > value
+}
+
+fn main() {
+	println(increment_is_greater(int(2147483647)))
+}
+')!
+	output := os.join_path(root, 'signed_overflow')
+	compile := cmdexec.run(v3_bin, ['-nocache', '-no-memory-limit', '-prod', '-showcc', '-o', output,
+		source])
+	assert compile.exit_code == 0, compile.output
+	assert compile.output.contains('-fwrapv'), compile.output
+	run := cmdexec.run(output, [])
+	assert run.exit_code == 0, run.output
+	assert run.output == 'false\n', run.output
+
+	tcc_output := os.join_path(root, 'signed_overflow_tcc')
+	tcc_compile := cmdexec.run(v3_bin, ['-nocache', '-no-memory-limit', '-showcc', '-o', tcc_output,
+		source])
+	assert tcc_compile.exit_code == 0, tcc_compile.output
+	assert tcc_compile.output.contains('tcc.exe'), tcc_compile.output
+	assert tcc_compile.output.contains('-fwrapv'), tcc_compile.output
+
+	cg_output := os.join_path(root, 'signed_overflow_cg')
+	cg_compile := cmdexec.run(v3_bin, ['-nocache', '-no-memory-limit', '-prod', '-showcc', '-cg',
+		'-o', cg_output, source])
+	assert cg_compile.exit_code == 0, cg_compile.output
+	assert cg_compile.output.contains('-Wl,-export_dynamic'), cg_compile.output
+
+	g_output := os.join_path(root, 'signed_overflow_g')
+	g_compile := cmdexec.run(v3_bin, ['-nocache', '-no-memory-limit', '-prod', '-showcc', '-g',
+		'-o', g_output, source])
+	assert g_compile.exit_code == 0, g_compile.output
+	assert !g_compile.output.contains('-Wl,-export_dynamic'), g_compile.output
+}
+
 fn test_driver_requests_macos_compatibility_for_inline_assembly() {
 	$if amd64 || arm64 {
 		root := os.join_path(os.vtmp_dir(), 'v3_driver_inline_asm_fallback_${os.getpid()}')

--- a/vlib/v3/tests/driver_cli_test.v
+++ b/vlib/v3/tests/driver_cli_test.v
@@ -434,15 +434,19 @@ fn test_driver_resolves_boolean_d_and_documented_pseudos() {
 const enabled = \$d('feature', false)
 const column = @COLUMN
 const project_hash = @VMODHASH
+const legacy_root_matches = @VROOT == @VEXEROOT
 const column_condition = \$if @COLUMN != '' { true } \$else { false }
 const hash_condition = \$if @VMODHASH == '0123456' { true } \$else { false }
+const legacy_root_condition = \$if @VROOT == @VEXEROOT { true } \$else { false }
 
 fn main() {
 	println(enabled)
 	println(column)
 	println(project_hash)
+	println(legacy_root_matches)
 	println(column_condition)
 	println(hash_condition)
+	println(legacy_root_condition)
 }
 ")!
 	for i, define_args in [
@@ -456,7 +460,7 @@ fn main() {
 		assert compile.exit_code == 0, compile.output
 		run := cmdexec.run(output, [])
 		assert run.exit_code == 0, run.output
-		assert run.output == 'true\n16\n0123456\ntrue\ntrue\n', run.output
+		assert run.output == 'true\n16\n0123456\ntrue\ntrue\ntrue\ntrue\n', run.output
 	}
 	os.write_file(os.join_path(git_refs, 'main'), 'abcdef0123456789abcdef0123456789abcdef01\n')!
 	updated_output := os.join_path(root, 'comptime_values_updated_hash')
@@ -465,7 +469,54 @@ fn main() {
 	assert updated_compile.exit_code == 0, updated_compile.output
 	updated_run := cmdexec.run(updated_output, [])
 	assert updated_run.exit_code == 0, updated_run.output
-	assert updated_run.output == 'true\n16\nabcdef0\ntrue\nfalse\n', updated_run.output
+	assert updated_run.output == 'true\n16\nabcdef0\ntrue\ntrue\nfalse\ntrue\n', updated_run.output
+
+	invalid_source := os.join_path(project, 'invalid_define.v')
+	os.write_file(invalid_source, "module main
+
+const value = \$d('feature', 1)
+
+fn main() {
+	println(value)
+}
+")!
+	assert_driver_cli_failure(v3_bin, ['-d', 'feature', '-silent', '-no-parallel', invalid_source],
+		'i64 literal expected, found "true"')
+}
+
+fn test_delegated_driver_preserves_invoking_vroot() {
+	root := os.join_path(os.vtmp_dir(), 'v3_driver_invoking_vroot_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	v3_bin := build_driver_cli_v3(root)
+	other_checkout := os.join_path(root, 'other_checkout')
+	os.mkdir_all(os.join_path(other_checkout, 'vlib', 'builtin')) or { panic(err) }
+	source := os.join_path(other_checkout, 'main.v')
+	os.write_file(source, 'module main
+
+fn main() {
+	println(@VEXEROOT)
+	println(@VROOT)
+	println(\$if @VROOT == @VEXEROOT { true } \$else { false })
+}
+')!
+	output := os.join_path(root, 'invoking_vroot')
+	mut environment := os.environ()
+	environment['VEXE'] = @VEXE
+	environment['V_MACOS_V3_CALLER_VEXE'] = ''
+	environment['V_MACOS_V3_CALLER_VEXE_PRESENT'] = '0'
+	environment['V_MACOS_V3_CALLER_VCHILD'] = ''
+	environment['V_MACOS_V3_CALLER_VCHILD_PRESENT'] = '0'
+	compile := run_driver_with_environment(v3_bin, ['-nocache', '-silent', '-no-parallel', '-o',
+		output, source], environment)
+	assert compile.exit_code == 0, compile.output
+	run := cmdexec.run(output, [])
+	assert run.exit_code == 0, run.output
+	invoking_root := os.real_path(os.dir(@VEXE))
+	assert run.output == '${invoking_root}\n${invoking_root}\ntrue\n', run.output
 }
 
 fn test_driver_run_preserves_stdin() {

--- a/vlib/v3/tests/driver_cli_test.v
+++ b/vlib/v3/tests/driver_cli_test.v
@@ -793,6 +793,35 @@ fn test_driver_accepts_dispatcher_arguments_and_runs_vsh_files() {
 	assert kept_files.len == 1, kept_files.str()
 	assert os.file_size(kept_files[0]) > 0
 	assert os.file_name(kept_files[0]).starts_with('implicit_build.')
+	keep_c_module_dir := os.join_path(root, 'keepcmod')
+	os.mkdir_all(keep_c_module_dir)!
+	os.write_file(os.join_path(keep_c_module_dir, 'keepcmod.v'), "module keepcmod
+
+pub fn message() string {
+	return 'cached module code retained'
+}
+")!
+	keep_c_module_program := os.join_path(root, 'keepc_modules.v')
+	keep_c_module_binary := keep_c_module_program.all_before_last('.v')
+	os.write_file(keep_c_module_program, 'import keepcmod
+
+fn main() {
+	println(keepcmod.message())
+}
+')!
+	keep_c_environment['V3CACHE'] = os.join_path(root, 'keepc_cache')
+	keep_c_module_build := run_driver_with_environment(v3_bin, ['-silent', '-no-parallel', '-keepc',
+		keep_c_module_program], keep_c_environment)
+	assert keep_c_module_build.exit_code == 0, keep_c_module_build.output
+	keep_c_module_run := cmdexec.run(keep_c_module_binary, [])
+	assert keep_c_module_run.exit_code == 0, keep_c_module_run.output
+	assert keep_c_module_run.output == 'cached module code retained\n', keep_c_module_run.output
+	kept_module_files :=
+		kept_c_files(keep_c_dir).filter(os.file_name(it).starts_with('keepc_modules.'))
+	assert kept_module_files.len == 1, kept_module_files.str()
+	kept_module_source := os.read_file(kept_module_files[0])!
+	assert kept_module_source.contains('keepcmod__message'), kept_module_source
+	assert kept_module_source.contains('cached module code retained'), kept_module_source
 	run_program := os.join_path(root, 'implicit_run.v')
 	run_binary := run_program.all_before_last('.v')
 	os.write_file(run_program, "println('ran once')")!

--- a/vlib/v3/tests/driver_cli_test.v
+++ b/vlib/v3/tests/driver_cli_test.v
@@ -458,6 +458,14 @@ fn main() {
 		assert run.exit_code == 0, run.output
 		assert run.output == 'true\n16\n0123456\ntrue\ntrue\n', run.output
 	}
+	os.write_file(os.join_path(git_refs, 'main'), 'abcdef0123456789abcdef0123456789abcdef01\n')!
+	updated_output := os.join_path(root, 'comptime_values_updated_hash')
+	updated_compile := cmdexec.run(v3_bin, ['-d', 'feature', '-silent', '-no-parallel', '-o',
+		updated_output, source])
+	assert updated_compile.exit_code == 0, updated_compile.output
+	updated_run := cmdexec.run(updated_output, [])
+	assert updated_run.exit_code == 0, updated_run.output
+	assert updated_run.output == 'true\n16\nabcdef0\ntrue\nfalse\n', updated_run.output
 }
 
 fn test_driver_run_preserves_stdin() {

--- a/vlib/v3/tests/driver_cli_test.v
+++ b/vlib/v3/tests/driver_cli_test.v
@@ -414,6 +414,52 @@ fn main() {
 	assert set_run.output == 'compile:caller-vexe|caller-vchild\nruntime:caller-vexe|caller-vchild\nprivate:|<unset>|<unset>\n', set_run.output
 }
 
+fn test_driver_resolves_boolean_d_and_documented_pseudos() {
+	root := os.join_path(os.vtmp_dir(), 'v3_driver_comptime_values_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	v3_bin := build_driver_cli_v3(root)
+	project := os.join_path(root, 'project')
+	git_refs := os.join_path(project, '.git', 'refs', 'heads')
+	os.mkdir_all(git_refs) or { panic(err) }
+	os.write_file(os.join_path(project, 'v.mod'), "Module { name: 'driver_comptime_values' }\n")!
+	os.write_file(os.join_path(project, '.git', 'HEAD'), 'ref: refs/heads/main\n')!
+	os.write_file(os.join_path(git_refs, 'main'), '0123456789abcdef0123456789abcdef01234567\n')!
+	source := os.join_path(project, 'main.v')
+	os.write_file(source, "module main
+
+const enabled = \$d('feature', false)
+const column = @COLUMN
+const project_hash = @VMODHASH
+const column_condition = \$if @COLUMN != '' { true } \$else { false }
+const hash_condition = \$if @VMODHASH == '0123456' { true } \$else { false }
+
+fn main() {
+	println(enabled)
+	println(column)
+	println(project_hash)
+	println(column_condition)
+	println(hash_condition)
+}
+")!
+	for i, define_args in [
+		['-d', 'feature'],
+		['-dfeature'],
+	] {
+		output := os.join_path(root, 'comptime_values_${i}')
+		mut args := define_args.clone()
+		args << ['-silent', '-no-parallel', '-o', output, source]
+		compile := cmdexec.run(v3_bin, args)
+		assert compile.exit_code == 0, compile.output
+		run := cmdexec.run(output, [])
+		assert run.exit_code == 0, run.output
+		assert run.output == 'true\n16\n0123456\ntrue\ntrue\n', run.output
+	}
+}
+
 fn test_driver_run_preserves_stdin() {
 	root := os.join_path(os.vtmp_dir(), 'v3_driver_stdin_${os.getpid()}')
 	os.rmdir_all(root) or {}

--- a/vlib/v3/tests/driver_cli_test.v
+++ b/vlib/v3/tests/driver_cli_test.v
@@ -361,6 +361,59 @@ pub fn values() []string {
 	}
 }
 
+fn test_driver_preserves_macos_launcher_caller_environment() {
+	root := os.join_path(os.vtmp_dir(), 'v3_driver_caller_environment_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	v3_bin := build_driver_cli_v3(root)
+	source := os.join_path(root, 'caller_environment.v')
+	os.write_file(source, "import os
+
+const compile_vexe = \$env('VEXE')
+const compile_vchild = \$env('VCHILD')
+const compile_private = \$env('V_MACOS_V3_CALLER_VEXE')
+
+fn env_value(name string) string {
+	return os.getenv_opt(name) or { '<unset>' }
+}
+
+fn main() {
+	println('compile:' + compile_vexe + '|' + compile_vchild)
+	println('runtime:' + env_value('VEXE') + '|' + env_value('VCHILD'))
+	println('private:' + compile_private + '|' + env_value('V_MACOS_V3_CALLER_VEXE') + '|' +
+		env_value('V_MACOS_V3_CALLER_VCHILD'))
+}
+")!
+	cache_dir := os.join_path(root, 'cache')
+	mut unset_environment := os.environ()
+	unset_environment['VEXE'] = @VEXE
+	unset_environment['VCHILD'] = 'true'
+	unset_environment['V_MACOS_V3_CALLER_VEXE'] = ''
+	unset_environment['V_MACOS_V3_CALLER_VEXE_PRESENT'] = '0'
+	unset_environment['V_MACOS_V3_CALLER_VCHILD'] = ''
+	unset_environment['V_MACOS_V3_CALLER_VCHILD_PRESENT'] = '0'
+	unset_environment['V3CACHE'] = cache_dir
+	unset_output := os.join_path(root, 'caller_unset')
+	unset_run := run_driver_with_environment(v3_bin, ['-silent', '-no-parallel', '-no-memory-limit',
+		'-o', unset_output, 'run', source], unset_environment)
+	assert unset_run.exit_code == 0, unset_run.output
+	assert unset_run.output == 'compile:|\nruntime:<unset>|<unset>\nprivate:|<unset>|<unset>\n', unset_run.output
+
+	mut set_environment := unset_environment.clone()
+	set_environment['V_MACOS_V3_CALLER_VEXE'] = 'caller-vexe'
+	set_environment['V_MACOS_V3_CALLER_VEXE_PRESENT'] = '1'
+	set_environment['V_MACOS_V3_CALLER_VCHILD'] = 'caller-vchild'
+	set_environment['V_MACOS_V3_CALLER_VCHILD_PRESENT'] = '1'
+	set_output := os.join_path(root, 'caller_set')
+	set_run := run_driver_with_environment(v3_bin, ['-silent', '-no-parallel', '-no-memory-limit',
+		'-o', set_output, 'run', source], set_environment)
+	assert set_run.exit_code == 0, set_run.output
+	assert set_run.output == 'compile:caller-vexe|caller-vchild\nruntime:caller-vexe|caller-vchild\nprivate:|<unset>|<unset>\n', set_run.output
+}
+
 fn test_driver_run_preserves_stdin() {
 	root := os.join_path(os.vtmp_dir(), 'v3_driver_stdin_${os.getpid()}')
 	os.rmdir_all(root) or {}

--- a/vlib/v3/tests/driver_cli_test.v
+++ b/vlib/v3/tests/driver_cli_test.v
@@ -225,6 +225,50 @@ fn main() {
 	}
 }
 
+fn test_driver_cg_selects_debug_module_files() {
+	root := os.join_path(os.vtmp_dir(), 'v3_driver_cg_debug_files_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	v3_bin := build_driver_cli_v3(root)
+	project := os.join_path(root, 'project')
+	variant_dir := os.join_path(project, 'variant')
+	os.mkdir_all(variant_dir) or { panic(err) }
+	os.write_file(os.join_path(project, 'v.mod'), "Module {
+	name: 'debug_file_selection'
+}
+")!
+	os.write_file(os.join_path(project, 'main.v'), 'module main
+
+import variant
+
+fn main() {
+	println(variant.selected())
+}
+')!
+	os.write_file(os.join_path(variant_dir, 'variant_d_debug.v'), "module variant
+
+pub fn selected() string {
+	return 'debug'
+}
+")!
+	os.write_file(os.join_path(variant_dir, 'variant_notd_debug.v'), "module variant
+
+pub fn selected() string {
+	return 'release'
+}
+")!
+	output := os.join_path(root, 'debug_file_selection')
+	compile := cmdexec.run(v3_bin, ['-silent', '-no-parallel', '-no-memory-limit', '-cg', '-o',
+		output, project])
+	assert compile.exit_code == 0, compile.output
+	run := cmdexec.run(output, [])
+	assert run.exit_code == 0, run.output
+	assert run.output == 'debug\n', run.output
+}
+
 fn test_driver_run_preserves_stdin() {
 	root := os.join_path(os.vtmp_dir(), 'v3_driver_stdin_${os.getpid()}')
 	os.rmdir_all(root) or {}

--- a/vlib/v3/tests/driver_cli_test.v
+++ b/vlib/v3/tests/driver_cli_test.v
@@ -927,6 +927,20 @@ println(os.args[1..].join('|'))
 	warm_cache_run := cmdexec.run(v3_bin, ['-silent', '-no-parallel', source, 'warm'])
 	assert warm_cache_run.exit_code == 0, warm_cache_run.output
 	assert warm_cache_run.output == 'false\ncached module\nwarm\n', warm_cache_run.output
+	compat_source := os.join_path(root, 'compat_script_binary.v')
+	os.write_file(compat_source, "fn main() {
+	println('compatibility binary')
+}
+")!
+	compat_build := cmdexec.run(@VEXE, ['-old-compiler', '-o', script_binary, compat_source])
+	assert compat_build.exit_code == 0, compat_build.output
+	compat_run := cmdexec.run(script_binary, [])
+	assert compat_run.exit_code == 0, compat_run.output
+	assert compat_run.output == 'compatibility binary\n', compat_run.output
+	rebound_v3_run := cmdexec.run(v3_bin,
+		['-silent', '-no-parallel', source, 'after-compatibility'])
+	assert rebound_v3_run.exit_code == 0, rebound_v3_run.output
+	assert rebound_v3_run.output == 'false\ncached module\nafter-compatibility\n', rebound_v3_run.output
 	cache_stamp := os.file_last_mod_unix(script_binary) + 3600
 	os.utime(script_binary, cache_stamp, cache_stamp)!
 	cached_run := cmdexec.run(v3_bin, ['-silent', '-no-parallel', source, 'cached'])

--- a/vlib/v3/tests/driver_cli_test.v
+++ b/vlib/v3/tests/driver_cli_test.v
@@ -1,4 +1,5 @@
 import os
+import time
 import v3.cmdexec
 import v3.pref
 
@@ -229,6 +230,54 @@ fn test_driver_accepts_dispatcher_arguments_and_runs_vsh_files() {
 	assert implicit_run.output == 'ran once\n', implicit_run.output
 	assert !os.exists(run_binary)
 	assert !os.exists(run_binary + '.c')
+	$if !windows {
+		interrupted_program := os.join_path(root, 'interrupted_run.v')
+		interrupted_binary := interrupted_program.all_before_last('.v')
+		interrupted_marker := os.join_path(root, 'interrupted_run_started')
+		os.write_file(interrupted_program, "import os
+
+fn main() {
+	os.write_file('${interrupted_marker}', 'started') or { exit(2) }
+	for {}
+}
+")!
+		mut interrupted_run := os.new_process(v3_bin)
+		interrupted_run.use_pgroup = true
+		interrupted_run.set_args(['-silent', '-no-parallel', 'run', interrupted_program])
+		interrupted_run.run()
+		mut interrupted_started := false
+		for _ in 0 .. 600 {
+			if os.exists(interrupted_marker) {
+				interrupted_started = true
+				break
+			}
+			if !interrupted_run.is_alive() {
+				break
+			}
+			time.sleep(100 * time.millisecond)
+		}
+		if !interrupted_started {
+			if interrupted_run.is_alive() {
+				interrupted_run.signal_pgkill()
+			}
+			interrupted_run.wait()
+			run_error := interrupted_run.err
+			interrupted_run.close()
+			assert false, 'interrupted run did not start: ${run_error}'
+		}
+		interrupt := os.execute('kill -INT -${interrupted_run.pid}')
+		if interrupt.exit_code != 0 {
+			interrupted_run.signal_pgkill()
+			interrupted_run.wait()
+			interrupted_run.close()
+			assert false, interrupt.output
+		}
+		interrupted_run.wait()
+		interrupted_exit_code := interrupted_run.code
+		interrupted_run.close()
+		assert interrupted_exit_code != 0
+		assert !os.exists(interrupted_binary)
+	}
 	debug_define_program := os.join_path(root, 'debug_define.v')
 	os.write_file(debug_define_program, '@[if debug]
 fn enabled_by_define() {

--- a/vlib/v3/tests/driver_cli_test.v
+++ b/vlib/v3/tests/driver_cli_test.v
@@ -489,6 +489,7 @@ fn test_driver_preserves_macos_launcher_caller_environment() {
 const compile_vexe = \$env('VEXE')
 const compile_vchild = \$env('VCHILD')
 const compile_private = \$env('V_MACOS_V3_CALLER_VEXE')
+const compile_c_error_dir = \$env('V_MACOS_V3_C_ERROR_DIR')
 
 fn env_value(name string) string {
 	return os.getenv_opt(name) or { '<unset>' }
@@ -499,6 +500,7 @@ fn main() {
 	println('runtime:' + env_value('VEXE') + '|' + env_value('VCHILD'))
 	println('private:' + compile_private + '|' + env_value('V_MACOS_V3_CALLER_VEXE') + '|' +
 		env_value('V_MACOS_V3_CALLER_VCHILD'))
+	println('c-error-dir:' + compile_c_error_dir + '|' + env_value('V_MACOS_V3_C_ERROR_DIR'))
 }
 ")!
 	cache_dir := os.join_path(root, 'cache')
@@ -509,12 +511,13 @@ fn main() {
 	unset_environment['V_MACOS_V3_CALLER_VEXE_PRESENT'] = '0'
 	unset_environment['V_MACOS_V3_CALLER_VCHILD'] = ''
 	unset_environment['V_MACOS_V3_CALLER_VCHILD_PRESENT'] = '0'
+	unset_environment['V_MACOS_V3_C_ERROR_DIR'] = os.join_path(root, 'private-c-error')
 	unset_environment['V3CACHE'] = cache_dir
 	unset_output := os.join_path(root, 'caller_unset')
 	unset_run := run_driver_with_environment(v3_bin, ['-silent', '-no-parallel', '-no-memory-limit',
 		'-o', unset_output, 'run', source], unset_environment)
 	assert unset_run.exit_code == 0, unset_run.output
-	assert unset_run.output == 'compile:|\nruntime:<unset>|<unset>\nprivate:|<unset>|<unset>\n', unset_run.output
+	assert unset_run.output == 'compile:|\nruntime:<unset>|<unset>\nprivate:|<unset>|<unset>\nc-error-dir:|<unset>\n', unset_run.output
 
 	mut set_environment := unset_environment.clone()
 	set_environment['V_MACOS_V3_CALLER_VEXE'] = 'caller-vexe'
@@ -525,7 +528,7 @@ fn main() {
 	set_run := run_driver_with_environment(v3_bin, ['-silent', '-no-parallel', '-no-memory-limit',
 		'-o', set_output, 'run', source], set_environment)
 	assert set_run.exit_code == 0, set_run.output
-	assert set_run.output == 'compile:caller-vexe|caller-vchild\nruntime:caller-vexe|caller-vchild\nprivate:|<unset>|<unset>\n', set_run.output
+	assert set_run.output == 'compile:caller-vexe|caller-vchild\nruntime:caller-vexe|caller-vchild\nprivate:|<unset>|<unset>\nc-error-dir:|<unset>\n', set_run.output
 }
 
 fn test_driver_resolves_boolean_d_and_documented_pseudos() {

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -1591,6 +1591,72 @@ fn main() {
 	assert !stdout.contains('C compilation failed:'), 'stdout:\n${stdout}\nstderr:\n${stderr}'
 }
 
+fn test_module_cache_restart_preserves_macos_fallback_transport() {
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_module_cache_restart_fallback_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	write_module_cache_file(root, 'wrapper/wrapper.v', 'module wrapper
+
+pub fn value() int {
+	return 41
+}
+')
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'module main
+
+import wrapper
+
+fn main() {
+	println(wrapper.value())
+}
+')
+	cache_dir := os.join_path(root, 'cache')
+	first_output := os.join_path(root, 'first')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, first_output)
+
+	// Adding a C flag changes the cached compile signature and restarts V3 after parsing.
+	write_module_cache_file(root, 'main.v', "module main
+
+#flag -DV3_CACHE_RESTART_FALLBACK_PROBE
+
+import os
+import wrapper
+
+fn main() {
+	mut marker := os.open_append(os.args[1]) or { panic(err) }
+	marker.writeln('run') or { panic(err) }
+	marker.close()
+	println(wrapper.value())
+	exit(23)
+}
+")
+	fallback_file := os.join_path(root, 'fallback')
+	report_dir := os.join_path(root, 'c_error')
+	side_effect_file := os.join_path(root, 'side_effects')
+	mut environment := os.environ()
+	environment['V3CACHE'] = cache_dir
+	environment['V_MACOS_V3_FALLBACK_FILE'] = fallback_file
+	environment['V_MACOS_V3_C_ERROR_DIR'] = report_dir
+	mut process := os.new_process(v3_bin)
+	process.set_args(['-silent', '-no-memory-limit', 'run', main_file, side_effect_file])
+	process.set_environment(environment)
+	process.set_redirect_stdio()
+	process.run()
+	process.wait()
+	output := process.stdout_slurp() + process.stderr_slurp()
+	exit_code := process.code
+	process.close()
+	assert exit_code == 23, output
+	assert output == '41\n', output
+	assert os.read_lines(side_effect_file)! == ['run']
+	assert !os.exists(fallback_file), 'cache restart left a stale fallback marker'
+	assert !os.exists(report_dir), 'cache restart exposed or staged a C error report'
+}
+
 fn test_cached_objects_receive_forced_include_flags() {
 	v3_bin := build_module_cache_v3()
 	root := os.join_path(os.temp_dir(), 'v3_module_cache_forced_include_${os.getpid()}')

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -14,7 +14,7 @@ fn build_module_cache_v3() string {
 		return v3_bin
 	}
 	build :=
-		os.execute('${os.quoted_path(@VEXE)} -gc none -path "${module_cache_vlib_dir}|@vlib|@vmodules" -o ${os.quoted_path(v3_bin)} ${os.quoted_path(module_cache_v3_src)}')
+		os.execute('${os.quoted_path(@VEXE)} -gc none -prealloc -path "${module_cache_vlib_dir}|@vlib|@vmodules" -o ${os.quoted_path(v3_bin)} ${os.quoted_path(module_cache_v3_src)}')
 	assert build.exit_code == 0, build.output
 	return v3_bin
 }
@@ -48,6 +48,13 @@ fn compile_module_cache_project(v3_bin string, cache_dir string, main_file strin
 	result :=
 		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -o ${os.quoted_path(output)} ${os.quoted_path(main_file)}')
 	assert result.exit_code == 0, result.output
+}
+
+fn run_cached_module_cache_project(v3_bin string, cache_dir string, main_file string) string {
+	result :=
+		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -silent -no-memory-limit run ${os.quoted_path(main_file)}')
+	assert result.exit_code == 0, result.output
+	return result.output.trim_space()
 }
 
 fn run_module_cache_binary(path string) string {
@@ -5630,12 +5637,8 @@ fn main() {
 }
 ')
 	cache_dir := os.join_path(root, 'cache')
-	first_output := os.join_path(root, 'first')
-	compile_module_cache_project(v3_bin, cache_dir, main_file, first_output)
-	assert run_module_cache_binary(first_output) == '1'
-	baseline_output := os.join_path(root, 'baseline')
-	compile_module_cache_project(v3_bin, cache_dir, main_file, baseline_output)
-	assert run_module_cache_binary(baseline_output) == '1'
+	assert run_cached_module_cache_project(v3_bin, cache_dir, main_file) == '1'
+	assert run_cached_module_cache_project(v3_bin, cache_dir, main_file) == '1'
 
 	write_module_cache_file(root, 'archive/value.c', 'int cached_archive_value(void) {
 	return 2;
@@ -5646,11 +5649,7 @@ fn main() {
 	assert second_cc.exit_code == 0, second_cc.output
 	second_ar := os.execute('ar rcs ${os.quoted_path(library)} ${os.quoted_path(library_object)}')
 	assert second_ar.exit_code == 0, second_ar.output
-	changed_output := os.join_path(root, 'changed')
-	changed :=
-		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -o ${os.quoted_path(changed_output)} ${os.quoted_path(main_file)}')
-	assert changed.exit_code == 0, changed.output
-	assert run_module_cache_binary(changed_output) == '2'
+	assert run_cached_module_cache_project(v3_bin, cache_dir, main_file) == '2'
 }
 
 fn test_cached_dev_dylib_invalidates_for_force_loaded_static_archive_change() {
@@ -5698,12 +5697,8 @@ fn main() {
 }
 ')
 	cache_dir := os.join_path(root, 'cache')
-	first_output := os.join_path(root, 'first')
-	compile_module_cache_project(v3_bin, cache_dir, main_file, first_output)
-	assert run_module_cache_binary(first_output) == '3'
-	baseline_output := os.join_path(root, 'baseline')
-	compile_module_cache_project(v3_bin, cache_dir, main_file, baseline_output)
-	assert run_module_cache_binary(baseline_output) == '3'
+	assert run_cached_module_cache_project(v3_bin, cache_dir, main_file) == '3'
+	assert run_cached_module_cache_project(v3_bin, cache_dir, main_file) == '3'
 
 	write_module_cache_file(root, 'archive/value.c', 'int force_loaded_archive_value(void) {
 	return 4;
@@ -5714,14 +5709,10 @@ fn main() {
 	assert second_cc.exit_code == 0, second_cc.output
 	second_ar := os.execute('ar rcs ${os.quoted_path(library)} ${os.quoted_path(library_object)}')
 	assert second_ar.exit_code == 0, second_ar.output
-	changed_output := os.join_path(root, 'changed')
-	changed :=
-		os.execute('V3CACHE=${os.quoted_path(cache_dir)} ${os.quoted_path(v3_bin)} -o ${os.quoted_path(changed_output)} ${os.quoted_path(main_file)}')
-	assert changed.exit_code == 0, changed.output
-	assert run_module_cache_binary(changed_output) == '4'
+	assert run_cached_module_cache_project(v3_bin, cache_dir, main_file) == '4'
 }
 
-fn test_cached_dev_dylib_preserves_split_weak_library_flag() {
+fn test_standalone_build_preserves_split_weak_library_flag() {
 	$if !macos {
 		return
 	}
@@ -5764,10 +5755,7 @@ fn main() {
 	output := os.join_path(root, 'output')
 	compile_module_cache_project(v3_bin, cache_dir, main_file, output)
 	assert run_module_cache_binary(output) == '42'
-	mut cached_dylibs :=
-		os.walk_ext(cache_dir, '.dylib').filter(os.file_name(it).starts_with('dev_modules_'))
-	assert cached_dylibs.len == 1, cached_dylibs.str()
-	inspection := os.execute('otool -l ${os.quoted_path(cached_dylibs[0])}')
+	inspection := os.execute('otool -l ${os.quoted_path(output)}')
 	assert inspection.exit_code == 0, inspection.output
 	assert inspection.output.contains('cmd LC_LOAD_WEAK_DYLIB'), inspection.output
 	assert inspection.output.contains(library), inspection.output

--- a/vlib/v3/tests/pseudo_vars_codegen_test.v
+++ b/vlib/v3/tests/pseudo_vars_codegen_test.v
@@ -3,6 +3,7 @@ import os
 const vexe = @VEXE
 const tests_dir = os.dir(@FILE)
 const v3_dir = os.dir(tests_dir)
+const vlib_dir = os.dir(v3_dir)
 const v3_src = os.join_path(v3_dir, 'v3.v')
 
 // test_at_mod_codegen validates that v3 lowers @MOD to the current module name.
@@ -27,17 +28,19 @@ fn test_at_mod_codegen() {
 
 fn test_at_file_line_codegen_uses_source_line() {
 	v3_bin := os.join_path(os.temp_dir(), 'v3_file_line_codegen_test')
-	build := os.execute('${vexe} -gc none -o ${v3_bin} ${v3_src}')
+	build :=
+		os.execute('${vexe} -gc none -prealloc -path "${vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${v3_src}')
 	assert build.exit_code == 0, build.output
 
 	main_src := os.join_path(os.temp_dir(), 'v3_file_line_main.v')
 	main_bin := os.join_path(os.temp_dir(), 'v3_file_line_main')
 	os.write_file(main_src,
-		"fn main() {\n\tgot, expected := @FILE_LINE, @FILE + ':' + @LINE.str()\n\tassert got == expected\n\tassert !got.ends_with(':0')\n}\n")!
-	main_result := os.execute('${v3_bin} ${main_src} -o ${main_bin}')
+		"fn main() {\n\tgot := @FILE_LINE\n\texpected := 'v3_file_line_main.v:' + @LINE.str()\n\tprintln(got)\n\tprintln(expected)\n}\n")!
+	main_result := os.execute('${v3_bin} -nocache -o ${main_bin} ${main_src}')
 	assert main_result.exit_code == 0, main_result.output
 	run := os.execute(main_bin)
 	assert run.exit_code == 0, run.output
+	assert run.output == 'v3_file_line_main.v:2\nv3_file_line_main.v:3\n', run.output
 }
 
 fn test_quoted_comptime_pseudo_vars_are_not_expanded() {

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -166,18 +166,25 @@ fn tcc_atomic_arg(prefs &pref.Preferences, tcc_path string, tcc_includes string)
 	if atomic_s.len == 0 {
 		return ''
 	}
+	wrapv_flag := c_wrapv_flag(prefs.normalized_target_os())
 	cache_dir := os.join_path(os.vtmp_dir(), 'v3_thirdparty_objs')
 	signature := modulecache.file_signature(atomic_s)
 	if signature.len == 0 {
 		return atomic_s
 	}
-	object_path := os.join_path(cache_dir, 'atomic_${naming.sanitize(signature)}.o')
+	wrapv_suffix := if wrapv_flag.len > 0 { '_wrapv' } else { '' }
+	object_path := os.join_path(cache_dir, 'atomic_${naming.sanitize(signature)}${wrapv_suffix}.o')
 	if os.is_file(object_path) {
 		return object_path
 	}
 	os.mkdir_all(cache_dir) or { return atomic_s }
 	build_path := '${object_path}.tmp.${os.getpid()}'
-	result := cmdexec.run(tcc_path, ['-std=gnu11', tcc_includes, '-c', atomic_s, '-o', build_path])
+	mut args := ['-std=gnu11', tcc_includes]
+	if wrapv_flag.len > 0 {
+		args << wrapv_flag
+	}
+	args << ['-c', atomic_s, '-o', build_path]
+	result := cmdexec.run(tcc_path, args)
 	if result.exit_code != 0 || !os.is_file(build_path) {
 		os.rm(build_path) or {}
 		return atomic_s
@@ -339,7 +346,7 @@ fn prepare_c_flags_for_link(flags []string, c99 bool, pic_flag string, target_ar
 fn c_link_plan_path(cache_dir string, flags []string, c99 bool, pic_flag string, target_args []string, target pref.Target, compiler string, mut stats CObjectCacheStats) string {
 	compiler_path, compiler_version := c_object_compiler_identity(compiler, mut stats)
 	mut hash := u64(1469598103934665603)
-	for identity in ['v3-c-link-plan-v1', os.getwd(), flags.join('\x00'),
+	for identity in ['v3-c-link-plan-v2', os.getwd(), flags.join('\x00'),
 		c99.str(), pic_flag, target_args.join('\x00'), compiler_path, compiler_version, target.os,
 		target.arch, target.abi, target.endian, target.pointer_bits.str(), target.object_format] {
 		hash = c_hash_bytes(hash, identity.bytes())
@@ -1103,6 +1110,10 @@ fn compile_cached_c_source_object(obj_path string, source_file string, source_la
 	if pic_flag.len > 0 {
 		args << pic_flag
 	}
+	wrapv_flag := c_wrapv_flag(target.os)
+	if wrapv_flag.len > 0 {
+		args << wrapv_flag
+	}
 	args << '-w'
 	args << support_flags
 	if language.len > 0 {
@@ -1387,6 +1398,14 @@ fn c_flag_is_c_source_file(flag string) bool {
 
 fn c_standard_flag(c99 bool) string {
 	return if c99 { '-std=c99' } else { '-std=gnu11' }
+}
+
+fn c_wrapv_flag(target_os string) string {
+	return if target_os in ['macos', 'linux', 'openbsd', 'freebsd', 'windows'] {
+		'-fwrapv'
+	} else {
+		''
+	}
 }
 
 fn shared_pic_flag(is_shared bool, target_os string) string {
@@ -3556,6 +3575,7 @@ fn main() {
 	mut keep_c := false
 	mut skip_running := false
 	mut is_debug := false
+	mut is_c_debug := false
 	mut c99 := false
 	mut thread_stack_size := 0
 	mut thread_stack_size_set := false
@@ -3686,6 +3706,9 @@ fn main() {
 			i += 2
 		} else if args[i] in ['-g', '-cg'] {
 			is_debug = true
+			if args[i] == '-cg' {
+				is_c_debug = true
+			}
 			user_c_flags << '-g'
 			i++
 		} else if args[i] == '-autofree' {
@@ -3990,6 +4013,7 @@ fn main() {
 		'target_arch=${prefs.normalized_target_arch()}',
 		'prod=${is_prod}',
 		'debug=${is_debug}',
+		'c_debug=${is_c_debug}',
 		'shared=${is_shared}',
 		'selfhost=${is_selfhost}',
 		'c99=${c99}',
@@ -5283,6 +5307,10 @@ fn main() {
 		if prefs.normalized_target_os() == 'macos' {
 			warn_args << ['-Wno-incompatible-function-pointer-types', '-Wno-typedef-redefinition']
 		}
+		wrapv_flag := c_wrapv_flag(prefs.normalized_target_os())
+		if wrapv_flag.len > 0 {
+			warn_args << wrapv_flag
+		}
 		needs_objective_c := c_flags_need_objective_c(generated_c_flags)
 		resolved_c_flags := prepare_c_flags_for_link(generated_c_flags, prefs.c99, pic_flag,
 			target_args, prefs.target, c_compiler, cc_dir, mut c_object_cache_stats) or {
@@ -5539,7 +5567,8 @@ fn main() {
 		mut tried_tcc := false
 		mut tcc_cache_hit := false
 		mut used_tcc := false
-		if cached_dev_dylib.len > 0 && tcc_main_file.len > 0 && !link_uses_non_c_language {
+		if cached_dev_dylib.len > 0 && tcc_main_file.len > 0 && !link_uses_non_c_language
+			&& !is_c_debug {
 			tried_tcc = true
 			tcc_dir := os.join_path_single(os.join_path_single(prefs.vroot, 'thirdparty'), 'tcc')
 			tcc_path := os.join_path_single(tcc_dir, 'tcc.exe')
@@ -5548,6 +5577,9 @@ fn main() {
 			tcc_lib := '-L${tcc_lib_dir}'
 			mut tcc_args := [c_standard, tcc_includes, tcc_lib, '-w',
 				'-Werror=implicit-function-declaration']
+			if wrapv_flag.len > 0 {
+				tcc_args << wrapv_flag
+			}
 			tcc_args << tcc_cached_main_flags(resolved_c_flags)
 			tcc_args << ['-o', 'out', os.base(tcc_main_file)]
 			atomic_s := tcc_atomic_arg(prefs, tcc_path, tcc_includes)
@@ -5594,7 +5626,7 @@ fn main() {
 		// undeclared-function diagnostics remain enforced.
 		if !tried_tcc && !is_prod && !needs_objective_c && !link_uses_non_c_language
 			&& target_args.len == 0 && (!c_compiler_explicit || explicit_tcc)
-			&& !cache_state.manager.enabled {
+			&& !cache_state.manager.enabled && !is_c_debug {
 			tried_tcc = true
 			tcc_dir := os.join_path_single(os.join_path_single(prefs.vroot, 'thirdparty'), 'tcc')
 			bundled_tcc_path := os.join_path_single(tcc_dir, 'tcc.exe')
@@ -5658,6 +5690,9 @@ fn main() {
 			cc_args << '-Wno-int-conversion'
 			if prefs.normalized_target_os() == 'macos' && !is_shared {
 				cc_args << '-Wl,-stack_size,0x4000000'
+			}
+			if is_c_debug && prefs.normalized_target_os() == 'macos' && !is_shared {
+				cc_args << '-Wl,-export_dynamic'
 			}
 			if is_shared {
 				cc_args << '-shared'

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -60,6 +60,7 @@ const macos_v3_fallback_file_env = 'V_MACOS_V3_FALLBACK_FILE'
 const macos_v3_c_error_dir_env = 'V_MACOS_V3_C_ERROR_DIR'
 const macos_v3_vhash_env = 'V_MACOS_V3_VHASH'
 const macos_v3_vcurrent_hash_env = 'V_MACOS_V3_VCURRENT_HASH'
+const macos_v3_compat_c99_flag = '-macos-v3-compat-c99'
 const macos_v3_inline_asm_diagnostic = 'inline assembly is not supported by the selected V3 backend'
 const macos_v3_inline_asm_fallback = 'inline_asm'
 const macos_v3_compiler_error_fallback = 'compiler_error'
@@ -3718,9 +3719,9 @@ fn main() {
 			// of the generics machinery) is pure overhead when building it.
 			building_v = true
 			i++
-		} else if args[i] == '-c99' || args[i] == '--c99' {
+		} else if args[i] in ['-c99', '--c99', macos_v3_compat_c99_flag] {
 			c99 = true
-			if 'c99' !in user_defines {
+			if args[i] != macos_v3_compat_c99_flag && 'c99' !in user_defines {
 				user_defines << 'c99'
 			}
 			i++

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -1668,18 +1668,26 @@ fn v3_crun_cache_matches(bin_file string, build_identity string) bool {
 	if build_identity.len == 0 {
 		return false
 	}
+	binary_signature := modulecache.file_signature(bin_file)
+	if binary_signature.len == 0 {
+		return false
+	}
 	marker := os.read_file(v3_crun_cache_marker_path(bin_file)) or { return false }
-	return marker == build_identity
+	return marker == '${build_identity}\n${binary_signature}'
 }
 
 fn write_v3_crun_cache_marker(bin_file string, build_identity string) ! {
 	if build_identity.len == 0 {
 		return
 	}
+	binary_signature := modulecache.file_signature(bin_file)
+	if binary_signature.len == 0 {
+		return
+	}
 	marker := v3_crun_cache_marker_path(bin_file)
 	os.mkdir_all(os.dir(marker), mode: 0o700)!
 	staged := '${marker}.stage.${os.getpid()}.${rand.ulid()}'
-	os.write_file(staged, build_identity)!
+	os.write_file(staged, '${build_identity}\n${binary_signature}')!
 	os.mv(staged, marker) or {
 		os.rm(staged) or {}
 		return err

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -57,6 +57,8 @@ $if !skip_wasm ? {
 
 const cache_bundle_import_file_name = '.v3_cache_bundle_imports.vh'
 const macos_v3_fallback_file_env = 'V_MACOS_V3_FALLBACK_FILE'
+const macos_v3_vhash_env = 'V_MACOS_V3_VHASH'
+const macos_v3_vcurrent_hash_env = 'V_MACOS_V3_VCURRENT_HASH'
 const macos_v3_inline_asm_diagnostic = 'inline assembly is not supported by the selected V3 backend'
 const macos_v3_inline_asm_fallback = 'inline_asm'
 const scoped_transform_signature_headroom = 2048
@@ -1427,6 +1429,10 @@ fn run_binary(bin_file string, args []string) int {
 	run_path := executable_path_for_run(bin_file)
 	mut process := os.new_process(run_path)
 	process.set_args(args)
+	mut environment := os.environ()
+	environment.delete(macos_v3_vhash_env)
+	environment.delete(macos_v3_vcurrent_hash_env)
+	process.set_environment(environment)
 	// `v3 run` is interactive: leave all three standard streams inherited so
 	// prompts are visible immediately and the program can read the caller's stdin.
 	// Ignore SIGINT and SIGQUIT while waiting so an interrupted child does not
@@ -3157,6 +3163,46 @@ fn default_cc_identity() string {
 	return '${cc_path}\t${metadata}\t${version.exit_code}\t${version.output.replace('\n', ' ')}'
 }
 
+fn effective_c_compiler_name(compiler string, target pref.Target) string {
+	compiler_path := os.find_abs_path_of_executable(compiler) or { compiler }
+	name := os.file_name(os.real_path(compiler_path)).to_lower_ascii()
+	if name.contains('tcc') || name.contains('tinyc') {
+		return 'tinyc'
+	}
+	if name.contains('clang') {
+		return 'clang'
+	}
+	if name.contains('gcc') {
+		return 'gcc'
+	}
+	if name.contains('mingw') {
+		return 'mingw'
+	}
+	if name in ['cl', 'cl.exe'] || name.contains('msvc') {
+		return 'msvc'
+	}
+	if name.contains('++') {
+		return 'cplusplus'
+	}
+	version := cmdexec.run(compiler_path, ['--version']).output.to_lower_ascii()
+	if version.contains('tiny c compiler') || version.contains('tcc version') {
+		return 'tinyc'
+	}
+	if version.contains('clang') {
+		return 'clang'
+	}
+	if version.contains('gcc') || version.contains('free software foundation') {
+		return 'gcc'
+	}
+	if version.contains('mingw') {
+		return 'mingw'
+	}
+	if version.contains('microsoft') && version.contains('c/c++') {
+		return 'msvc'
+	}
+	return if target.os in ['macos', 'ios'] { 'clang' } else { 'gcc' }
+}
+
 fn v3_cache_compiler_signature(vroot string) string {
 	dir := os.join_path(vroot, 'vlib', 'v3')
 	if !os.is_dir(dir) {
@@ -3882,10 +3928,23 @@ fn main() {
 		target.default_thread_stack_size()
 	}
 	prefs.backend = backend
+	prefs.ccompiler = if backend == 'arm64' {
+		'tinyc'
+	} else {
+		effective_c_compiler_name(c_compiler, target)
+	}
 	prefs.c99 = c99
 	prefs.user_defines = user_defines
 	prefs.compile_values = compile_values.clone()
 	prefs.vroot = resolve_vroot_for_input(prefs.vroot, input_file)
+	prefs.vhash = os.getenv(macos_v3_vhash_env)
+	if prefs.vhash == '' {
+		prefs.vhash = @VHASH
+	}
+	prefs.vcurrent_hash = os.getenv(macos_v3_vcurrent_hash_env)
+	if prefs.vcurrent_hash == '' {
+		prefs.vcurrent_hash = @VCURRENTHASH
+	}
 	prefs.selfhost = is_selfhost
 	prefs.building_v = building_v
 	prefs.is_prod = is_prod
@@ -3899,6 +3958,7 @@ fn main() {
 	cache_salt := [
 		'compiler=${v3_cache_compiler_signature(prefs.vroot)}',
 		'cc=${cc_identity}',
+		'ccompiler=${prefs.ccompiler}',
 		'vexe=${prefs.vexe}',
 		'backend=${backend}',
 		'target=${prefs.normalized_target_os()}',
@@ -3913,7 +3973,8 @@ fn main() {
 		'test=${is_test_command || is_v3_test_file(input_file, backend, target)}',
 		'defines=${prefs.user_defines.join(',')}',
 	].join('\n')
-	build_pseudo_values := [prefs.build_date, prefs.build_time, prefs.build_timestamp].join('\n')
+	build_pseudo_values := [prefs.build_date, prefs.build_time, prefs.build_timestamp, prefs.vhash,
+		prefs.vcurrent_hash].join('\n')
 	cache_manager := modulecache.new_manager(prefs.vroot, cache_salt, cache_enabled,
 		build_pseudo_values)
 	force_cache_source := os.getenv('V3_CACHE_FORCE_SOURCE') == '1'

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -897,7 +897,7 @@ fn v3_program_prefix_source_identity(prefix_source string, cached_objects []stri
 	return hash.hex()
 }
 
-fn compile_v3_dev_dylib(prefix_object string, cached_objects []string, resolved_c_flags []string, manager &modulecache.Manager, target_args []string, target pref.Target, c_compiler string, build_dir string, mut stats CObjectCacheStats) !string {
+fn compile_v3_dev_dylib(prefix_object string, cached_objects []string, resolved_c_flags []string, manager &modulecache.Manager, target_args []string, target pref.Target, c_compiler string, build_dir string, show_c_command bool, mut stats CObjectCacheStats) !string {
 	link_flags := c_dylib_link_flags(resolved_c_flags)
 	mut objects := [prefix_object]
 	objects << cached_objects
@@ -962,7 +962,9 @@ fn compile_v3_dev_dylib(prefix_object string, cached_objects []string, resolved_
 	response := args.map(c_response_file_arg(it)).join('\n')
 	os.write_file(response_path, response)!
 	response_arg := '@${response_path}'
-	println('  > ${cmdexec.display(c_compiler, [response_arg])} (${objects.len} cached objects)')
+	if show_c_command {
+		println('  > ${cmdexec.display(c_compiler, [response_arg])} (${objects.len} cached objects)')
+	}
 	result := cmdexec.run(c_compiler, [response_arg])
 	if result.exit_code != 0 {
 		return error('failed to build cached development dylib:\n${result.output}')
@@ -1612,6 +1614,7 @@ fn cli_usage() string {
 		'  -prod -c99 -shared -strict  C build modes\n' +
 		'  -v                           verbose stage profiling\n' +
 		'  -silent                      suppress benchmark output\n' +
+		'  -showcc                      print C compiler commands\n' +
 		'  -no-memory-limit             disable the 2 GiB memory safety limit\n' +
 		'  -d <name>                    compile-time define'
 }
@@ -3473,6 +3476,7 @@ fn main() {
 	mut ownership_mode := false
 	mut verbose := false
 	mut silent := false
+	mut show_cc := false
 	mut keep_c := false
 	mut skip_running := false
 	mut is_debug := false
@@ -3619,6 +3623,9 @@ fn main() {
 		} else if args[i] == '-silent' {
 			silent = true
 			i++
+		} else if args[i] == '-showcc' {
+			show_cc = true
+			i++
 		} else if args[i] == '-checker-fixture' {
 			is_checker_fixture = true
 			i++
@@ -3628,10 +3635,9 @@ fn main() {
 		} else if args[i] == '-skip-running' {
 			skip_running = true
 			i++
-		} else if args[i] in ['-stats', '-show-timings', '-showcc', '-w', '-no-retry-compilation',
-			'-usecache'] {
-			// v3 already reports phase metrics, prints the C command, suppresses C
-			// warnings, leaves explicit-output tests unrun, and caches modules by default.
+		} else if args[i] in ['-stats', '-show-timings', '-w', '-no-retry-compilation', '-usecache'] {
+			// v3 already reports phase metrics, suppresses C warnings, leaves
+			// explicit-output tests unrun, and caches modules by default.
 			// Accept the corresponding V flags for compatibility.
 			i++
 		} else if args[i] == '-no-prealloc' || args[i] == '--no-prealloc' {
@@ -5384,7 +5390,7 @@ fn main() {
 				}
 				cached_dev_dylib = compile_v3_dev_dylib(prefix_object, prepared_cache.objects,
 					resolved_c_flags, &cache_state.manager, target_args, prefs.target, c_compiler,
-					cc_dir, mut c_object_cache_stats) or {
+					cc_dir, !silent || show_cc, mut c_object_cache_stats) or {
 					eprintln(err.msg())
 					cleanup_c_build_dir(cc_dir)
 					exit(1)
@@ -5456,7 +5462,7 @@ fn main() {
 				tcc_cache_hit = os.is_file(cc_out)
 				used_tcc = tcc_cache_hit
 			}
-			if !silent {
+			if !silent || show_cc {
 				println('  > ${cmdexec.display(tcc_path, tcc_args)}${if tcc_cache_hit {
 					' (cached)'
 				} else {
@@ -5511,7 +5517,7 @@ fn main() {
 			}
 			tcc_args << resolved_c_flags
 			tcc_args << '-lm'
-			if !silent {
+			if !silent || show_cc {
 				println('  > ${cmdexec.display(tcc_path, tcc_args)}')
 			}
 			result = cmdexec.run_in(tcc_path, tcc_args, cc_dir)
@@ -5565,7 +5571,7 @@ fn main() {
 			}
 			cc_args << resolved_c_flags
 			cc_args << '-lm'
-			if !silent {
+			if !silent || show_cc {
 				println('  > ${cmdexec.display(c_compiler, cc_args)}')
 			}
 			result = cmdexec.run_in(c_compiler, cc_args, cc_dir)

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -56,6 +56,9 @@ $if !skip_wasm ? {
 }
 
 const cache_bundle_import_file_name = '.v3_cache_bundle_imports.vh'
+const macos_v3_fallback_file_env = 'V_MACOS_V3_FALLBACK_FILE'
+const macos_v3_inline_asm_diagnostic = 'inline assembly is not supported by the selected V3 backend'
+const macos_v3_inline_asm_fallback = 'inline_asm'
 const scoped_transform_signature_headroom = 2048
 const v3_vvmrc_file_name = '.vvmrc'
 const v3_vvmrc_skip_env = 'V_SKIP_VVMRC'
@@ -3442,6 +3445,15 @@ fn record_compile_value(mut values map[string]string, define string) {
 	values[name] = if define.contains('=') { define.all_after_first('=') } else { 'true' }
 }
 
+fn request_macos_v3_compatibility_fallback(diagnostics []parser.Diagnostic) bool {
+	fallback_file := os.getenv(macos_v3_fallback_file_env)
+	if fallback_file == '' || !diagnostics.any(it.message == macos_v3_inline_asm_diagnostic) {
+		return false
+	}
+	os.write_file(fallback_file, macos_v3_inline_asm_fallback) or { return false }
+	return true
+}
+
 // main runs the v3 entry point.
 fn main() {
 	args := os.args[1..]
@@ -4029,6 +4041,9 @@ fn main() {
 		i64(0)
 	}
 	if p.diagnostics.len > 0 {
+		if request_macos_v3_compatibility_fallback(p.diagnostics) {
+			exit(1)
+		}
 		for diagnostic in p.diagnostics {
 			if file := a.source_files[diagnostic.pos.id] {
 				eprintln(v3errors.formatted_source_error('error:', diagnostic.message, file,
@@ -4039,6 +4054,7 @@ fn main() {
 		}
 		exit(1)
 	}
+	os.unsetenv(macos_v3_fallback_file_env)
 	// Parsing workers canonicalize source-backed node text before their buffers
 	// are released. Metadata keys are finalized here before semantic phases begin.
 	p.release_source_storage()

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -1415,14 +1415,38 @@ fn run_test_binary(bin_file string) int {
 	return run_binary(bin_file, []string{})
 }
 
+fn ignore_run_signal(_ os.Signal) {
+}
+
 fn run_binary(bin_file string, args []string) int {
 	run_path := executable_path_for_run(bin_file)
 	mut process := os.new_process(run_path)
 	process.set_args(args)
 	// `v3 run` is interactive: leave all three standard streams inherited so
 	// prompts are visible immediately and the program can read the caller's stdin.
-	process.run()
+	// Ignore SIGINT and SIGQUIT while waiting so an interrupted child does not
+	// terminate V3 before it can remove the implicit run executable.
+	prev_int_handler := os.signal_opt(.int, ignore_run_signal) or {
+		eprintln('v3: could not set SIGINT handler: ${err}')
+		return 1
+	}
+	mut prev_quit_handler := os.SignalHandler(ignore_run_signal)
+	$if !windows {
+		prev_quit_handler = os.signal_opt(.quit, ignore_run_signal) or {
+			os.signal_opt(.int, prev_int_handler) or {}
+			eprintln('v3: could not set SIGQUIT handler: ${err}')
+			return 1
+		}
+	}
 	process.wait()
+	os.signal_opt(.int, prev_int_handler) or {
+		eprintln('v3: could not restore SIGINT handler: ${err}')
+	}
+	$if !windows {
+		os.signal_opt(.quit, prev_quit_handler) or {
+			eprintln('v3: could not restore SIGQUIT handler: ${err}')
+		}
+	}
 	exit_code := if process.code >= 0 { process.code } else { 1 }
 	process.close()
 	return exit_code

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -4073,7 +4073,10 @@ fn main() {
 	prefs.verbose = verbose
 	prefs.supports_inline_asm = is_checker_fixture
 	host_target := pref.host_target()
-	cache_enabled := backend == 'c' && !c_only && !no_cache && !c_compiler_explicit
+	// `-keepc` promises a complete generated C translation unit. The module cache
+	// splits imported implementations into separate objects, so its main source
+	// alone cannot reproduce the build.
+	cache_enabled := backend == 'c' && !c_only && !no_cache && !keep_c && !c_compiler_explicit
 		&& target.os == host_target.os && target.arch == host_target.arch
 	cc_identity := if cache_enabled { default_cc_identity() } else { '' }
 	cache_salt := [

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -72,6 +72,8 @@ const scoped_transform_signature_headroom = 2048
 const v3_vvmrc_file_name = '.vvmrc'
 const v3_vvmrc_skip_env = 'V_SKIP_VVMRC'
 const v3_vvmrc_stop_paths = ['.git', '.hg', '.svn', '.v.mod.stop']
+const v3_crun_build_identity_env = 'V3_CRUN_BUILD_IDENTITY'
+const v3_internal_restart_env = 'V3_INTERNAL_RESTART'
 
 struct V3ModuleCacheState {
 	manager             modulecache.Manager
@@ -1655,6 +1657,107 @@ fn keep_c_output_file(bin_file string) string {
 		base = 'vtmp'
 	}
 	return os.real_path(os.join_path_single(os.vtmp_dir(), '${base}.${rand.ulid()}.tmp.c'))
+}
+
+fn v3_crun_cache_marker_path(bin_file string) string {
+	key := c_hash_bytes(u64(1469598103934665603), os.abs_path(bin_file).bytes()).hex()
+	return os.join_path(os.vtmp_dir(), 'v3_crun_cache', key)
+}
+
+fn v3_crun_cache_matches(bin_file string, build_identity string) bool {
+	if build_identity.len == 0 {
+		return false
+	}
+	marker := os.read_file(v3_crun_cache_marker_path(bin_file)) or { return false }
+	return marker == build_identity
+}
+
+fn write_v3_crun_cache_marker(bin_file string, build_identity string) ! {
+	if build_identity.len == 0 {
+		return
+	}
+	marker := v3_crun_cache_marker_path(bin_file)
+	os.mkdir_all(os.dir(marker), mode: 0o700)!
+	staged := '${marker}.stage.${os.getpid()}.${rand.ulid()}'
+	os.write_file(staged, build_identity)!
+	os.mv(staged, marker) or {
+		os.rm(staged) or {}
+		return err
+	}
+}
+
+fn v3_crun_build_identity(state &V3ModuleCacheState, prefs &pref.Preferences, user_files []string, user_c_flags []string, is_strict bool, enable_globals bool) string {
+	mut source_paths := map[string]bool{}
+	for file in user_files {
+		source_paths[os.real_path(file)] = true
+	}
+	for files in state.module_sources.values() {
+		for file in files {
+			source_paths[os.real_path(file)] = true
+		}
+	}
+	mut sources := source_paths.keys()
+	sources.sort()
+	source_signature := modulecache.cached_source_signature(state.manager.dir, 'crun', sources)
+	if source_signature.len == 0 {
+		return ''
+	}
+	uses_build_time := modulecache.source_files_use_build_time_pseudo(sources)
+	mut hash := u64(1469598103934665603)
+	for value in [
+		'v3-crun-cache-v1',
+		state.manager.salt,
+		is_strict.str(),
+		enable_globals.str(),
+		user_c_flags.join('\x00'),
+		source_signature,
+		prefs.vhash,
+		prefs.vcurrent_hash,
+		if uses_build_time {
+			prefs.build_date
+		} else {
+			''
+		},
+		if uses_build_time {
+			prefs.build_time
+		} else {
+			''
+		},
+		if uses_build_time {
+			prefs.build_timestamp
+		} else {
+			''
+		},
+	] {
+		hash = c_hash_bytes(hash, value.bytes())
+		hash = c_hash_bytes(hash, [u8(0xff)])
+	}
+	mut external_paths := map[string]bool{}
+	for paths in state.module_external_inputs.values() {
+		for path in paths {
+			external_paths[os.real_path(path)] = true
+		}
+	}
+	for paths in state.module_native_roots.values() {
+		for path in paths {
+			external_paths[os.real_path(path)] = true
+		}
+	}
+	for path in state.external_resolution_dirs {
+		external_paths[os.real_path(path)] = true
+	}
+	for path in state.external_missing_paths {
+		external_paths[os.real_path(path)] = true
+	}
+	mut paths := external_paths.keys()
+	paths.sort()
+	for path in paths {
+		hash = c_hash_bytes(hash, path.bytes())
+		hash = c_hash_bytes(hash, [u8(0)])
+		hash = c_hash_bytes(hash, modulecache.file_metadata_signature(path).bytes())
+		hash = c_hash_bytes(hash, [u8(0xff)])
+	}
+	return hash.hex()
 }
 
 fn cli_usage() string {
@@ -3658,6 +3761,7 @@ fn main() {
 	mut compile_values := map[string]string{}
 	mut user_c_flags := []string{}
 	mut should_run := false
+	mut is_direct_vsh := false
 	mut is_test_command := false
 	mut is_checker_fixture := false
 	mut run_args := []string{}
@@ -3844,6 +3948,7 @@ fn main() {
 			}
 			input_file = args[i]
 			if input_file.ends_with('.vsh') {
+				is_direct_vsh = !should_run
 				should_run = true
 			}
 			i++
@@ -3978,7 +4083,8 @@ fn main() {
 		output_file = bin_file + '.c'
 	}
 	binary_existed_before := os.exists(bin_file)
-	remove_binary_after_run := should_run && !explicit_output && !keep_c && !binary_existed_before
+	remove_binary_after_run := should_run && !is_direct_vsh && !explicit_output && !keep_c
+		&& !binary_existed_before
 
 	// Decide which backend modules to compile into the output. By default only the C
 	// backend is built; the arm64/wasm/eval backends (and the whole SSA pipeline that the
@@ -4299,6 +4405,34 @@ fn main() {
 	b.metric('AST children after parse', a.children.len, 'edges')
 	b.metric('canonical AST texts', a.text_count(), 'texts')
 	b.metric('persistent worker threads', a.worker_count(), 'threads')
+
+	mut crun_build_identity := ''
+	if is_direct_vsh && should_run && !explicit_output {
+		carried_identity := os.getenv(v3_crun_build_identity_env)
+		if os.getenv(v3_internal_restart_env) == '1' && carried_identity.len > 0 {
+			crun_build_identity = carried_identity
+		} else {
+			mut crun_c_flags := user_c_flags.clone()
+			crun_c_flags << cgen.cache_directive_flags(a, prefs.vroot, prefs.target,
+				prefs.compile_values)
+			_ = prepare_v3_cache_external_inputs(mut cache_state, a, prefs, crun_c_flags)
+			crun_build_identity = v3_crun_build_identity(&cache_state, prefs, user_files,
+				crun_c_flags, is_strict, enable_globals_compat)
+			if crun_build_identity.len > 0 {
+				os.setenv(v3_crun_build_identity_env, crun_build_identity, true)
+			}
+		}
+		if os.is_file(bin_file) && v3_crun_cache_matches(bin_file, crun_build_identity) {
+			clear_macos_v3_compiler_error_fallback(macos_v3_fallback_file)
+			run_result := run_binary(bin_file, run_args)
+			if run_result != 0 {
+				exit(run_result)
+			}
+			b.step('run (cached)')
+			b.print_report()
+			return
+		}
+	}
 
 	// An exact whole-program C plan hit already certifies the current user sources,
 	// cached module interfaces, compiler configuration, target, and native inputs.
@@ -5899,6 +6033,9 @@ fn main() {
 		})
 		clear_macos_v3_compiler_error_fallback(macos_v3_fallback_file)
 		if should_run {
+			if is_direct_vsh && !explicit_output {
+				write_v3_crun_cache_marker(bin_file, crun_build_identity) or {}
+			}
 			run_result := run_binary(bin_file, run_args)
 			if remove_binary_after_run {
 				os.rm(bin_file) or {}
@@ -6662,6 +6799,7 @@ fn restart_v3_with_args(extra_args []string) {
 	executable := os.executable()
 	mut args := extra_args.clone()
 	args << os.args[1..]
+	os.setenv(v3_internal_restart_env, '1', true)
 	$if js {
 		mut command := [os.quoted_path(executable)]
 		for arg in args {

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -1613,6 +1613,24 @@ fn default_bin_file_for_input(input_file string) string {
 	return input_file
 }
 
+fn keep_c_output_file(bin_file string) string {
+	name := os.file_name(os.real_path(bin_file))
+	mut sanitized := strings.new_builder(name.len)
+	for ch in name {
+		if ch >= 128 || (ch >= `0` && ch <= `9`) || (ch >= `A` && ch <= `Z`)
+			|| (ch >= `a` && ch <= `z`) || ch in [`-`, `.`, `_`] {
+			sanitized.write_u8(ch)
+		} else {
+			sanitized.write_u8(`_`)
+		}
+	}
+	mut base := sanitized.str()
+	if base in ['', '.', '..'] {
+		base = 'vtmp'
+	}
+	return os.real_path(os.join_path_single(os.vtmp_dir(), '${base}.${rand.ulid()}.tmp.c'))
+}
+
 fn cli_usage() string {
 	return 'usage: v3 [run|test] <file.v|directory> [options]\n' +
 		'  -o <output>                 output binary or C file\n' +
@@ -5485,14 +5503,16 @@ fn main() {
 		}
 		b.metric('generated C size', os.file_size(published_c_source), 'bytes')
 		if keep_c {
-			published_c := '${output_file}.tmp.${os.getpid()}.${rand.ulid()}'
-			os.cp(published_c_source, published_c) or {
-				eprintln('failed to stage generated C output ${output_file}: ${err}')
+			keep_c_file := keep_c_output_file(bin_file)
+			staged_c := '${keep_c_file}.stage.${os.getpid()}.${rand.ulid()}'
+			os.cp(published_c_source, staged_c) or {
+				eprintln('failed to stage generated C output ${keep_c_file}: ${err}')
 				cleanup_c_build_dir(cc_dir)
 				exit(1)
 			}
-			os.mv(published_c, output_file) or {
-				eprintln('failed to publish generated C output ${output_file}: ${err}')
+			os.mv(staged_c, keep_c_file) or {
+				os.rm(staged_c) or {}
+				eprintln('failed to retain generated C output ${keep_c_file}: ${err}')
 				cleanup_c_build_dir(cc_dir)
 				exit(1)
 			}

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -4241,8 +4241,6 @@ fn main() {
 		}
 		exit(1)
 	}
-	os.unsetenv(macos_v3_fallback_file_env)
-	os.unsetenv(macos_v3_c_error_dir_env)
 	// Parsing workers canonicalize source-backed node text before their buffers
 	// are released. Metadata keys are finalized here before semantic phases begin.
 	p.release_source_storage()

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -3449,6 +3449,7 @@ fn main() {
 	mut ownership_mode := false
 	mut verbose := false
 	mut silent := false
+	mut keep_c := false
 	mut is_debug := false
 	mut c99 := false
 	mut thread_stack_size := 0
@@ -3595,11 +3596,14 @@ fn main() {
 		} else if args[i] == '-checker-fixture' {
 			is_checker_fixture = true
 			i++
-		} else if args[i] in ['-stats', '-show-timings', '-showcc', '-keepc', '-w',
-			'-no-retry-compilation', '-skip-running', '-usecache'] {
-			// v3 already reports phase metrics, prints the C command, retains generated C,
-			// suppresses C warnings, leaves explicit-output tests unrun, and caches modules
-			// by default. Accept the corresponding V flags for compatibility.
+		} else if args[i] == '-keepc' {
+			keep_c = true
+			i++
+		} else if args[i] in ['-stats', '-show-timings', '-showcc', '-w', '-no-retry-compilation',
+			'-skip-running', '-usecache'] {
+			// v3 already reports phase metrics, prints the C command, suppresses C
+			// warnings, leaves explicit-output tests unrun, and caches modules by default.
+			// Accept the corresponding V flags for compatibility.
 			i++
 		} else if args[i] == '-no-prealloc' || args[i] == '--no-prealloc' {
 			no_prealloc = true
@@ -3761,6 +3765,7 @@ fn main() {
 		}
 		output_file = bin_file + '.c'
 	}
+	binary_existed_before := os.exists(bin_file)
 
 	// Decide which backend modules to compile into the output. By default only the C
 	// backend is built; the arm64/wasm/eval backends (and the whole SSA pipeline that the
@@ -5362,16 +5367,18 @@ fn main() {
 			b.step('C dylib cache')
 		}
 		b.metric('generated C size', os.file_size(published_c_source), 'bytes')
-		published_c := '${output_file}.tmp.${os.getpid()}.${rand.ulid()}'
-		os.cp(published_c_source, published_c) or {
-			eprintln('failed to stage generated C output ${output_file}: ${err}')
-			cleanup_c_build_dir(cc_dir)
-			exit(1)
-		}
-		os.mv(published_c, output_file) or {
-			eprintln('failed to publish generated C output ${output_file}: ${err}')
-			cleanup_c_build_dir(cc_dir)
-			exit(1)
+		if keep_c {
+			published_c := '${output_file}.tmp.${os.getpid()}.${rand.ulid()}'
+			os.cp(published_c_source, published_c) or {
+				eprintln('failed to stage generated C output ${output_file}: ${err}')
+				cleanup_c_build_dir(cc_dir)
+				exit(1)
+			}
+			os.mv(published_c, output_file) or {
+				eprintln('failed to publish generated C output ${output_file}: ${err}')
+				cleanup_c_build_dir(cc_dir)
+				exit(1)
+			}
 		}
 		// Compile inside a per-output build dir, using constant relative source/output basenames,
 		// then move the result to bin_file. On macOS arm64 tcc bakes the -o basename into the
@@ -5565,6 +5572,9 @@ fn main() {
 		})
 		if should_run {
 			run_result := run_binary(bin_file, run_args)
+			if !explicit_output && !keep_c && !binary_existed_before {
+				os.rm(bin_file) or {}
+			}
 			if run_result != 0 {
 				exit(run_result)
 			}

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -1429,7 +1429,7 @@ fn run_binary(bin_file string, args []string) int {
 	run_path := executable_path_for_run(bin_file)
 	mut process := os.new_process(run_path)
 	process.set_args(args)
-	mut environment := os.environ()
+	mut environment := pref.macos_v3_caller_environment()
 	environment.delete(macos_v3_vhash_env)
 	environment.delete(macos_v3_vcurrent_hash_env)
 	process.set_environment(environment)
@@ -3987,6 +3987,7 @@ fn main() {
 		'selfhost=${is_selfhost}',
 		'c99=${c99}',
 		'thread_stack_size=${prefs.thread_stack_size}',
+		'macos_v3_caller_environment=${pref.has_macos_v3_caller_environment()}',
 		'ownership=${ownership_mode}',
 		'test=${is_test_command || is_v3_test_file(input_file, backend, target)}',
 		'defines=${prefs.user_defines.join(',')}',
@@ -5168,6 +5169,7 @@ fn main() {
 			g.set_prealloc('prealloc' in prefs.user_defines)
 			g.set_skip_generics(skip_transform_generics)
 			g.set_compiler_vexe(prefs.vexe)
+			g.set_compiler_vexe_env_setup(!pref.has_macos_v3_caller_environment())
 			g.set_target(prefs.target)
 			g.set_thread_stack_size(prefs.thread_stack_size)
 			g.set_compile_values(prefs.compile_values)
@@ -5204,6 +5206,7 @@ fn main() {
 			g.set_prealloc('prealloc' in prefs.user_defines)
 			g.set_skip_generics(skip_transform_generics)
 			g.set_compiler_vexe(prefs.vexe)
+			g.set_compiler_vexe_env_setup(!pref.has_macos_v3_caller_environment())
 			g.set_target(prefs.target)
 			g.set_thread_stack_size(prefs.thread_stack_size)
 			g.set_compile_values(prefs.compile_values)

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -3450,6 +3450,7 @@ fn main() {
 	mut verbose := false
 	mut silent := false
 	mut keep_c := false
+	mut skip_running := false
 	mut is_debug := false
 	mut c99 := false
 	mut thread_stack_size := 0
@@ -3487,6 +3488,7 @@ fn main() {
 			should_run = true
 			i++
 		} else if args[i] == 'build' && input_file.len == 0 && !should_run {
+			skip_running = true
 			i++
 		} else if args[i] == 'test' && input_file.len == 0 && !should_run {
 			is_test_command = true
@@ -3599,8 +3601,11 @@ fn main() {
 		} else if args[i] == '-keepc' {
 			keep_c = true
 			i++
+		} else if args[i] == '-skip-running' {
+			skip_running = true
+			i++
 		} else if args[i] in ['-stats', '-show-timings', '-showcc', '-w', '-no-retry-compilation',
-			'-skip-running', '-usecache'] {
+			'-usecache'] {
 			// v3 already reports phase metrics, prints the C command, suppresses C
 			// warnings, leaves explicit-output tests unrun, and caches modules by default.
 			// Accept the corresponding V flags for compatibility.
@@ -3642,6 +3647,7 @@ fn main() {
 			i++
 		}
 	}
+	should_run = should_run && !skip_running
 	mut current_no_parallel := no_parallel
 	mut current_parallel_transform := parallel_transform
 	if current_no_parallel {

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -3882,6 +3882,7 @@ fn main() {
 		output_file = bin_file + '.c'
 	}
 	binary_existed_before := os.exists(bin_file)
+	remove_binary_after_run := should_run && !explicit_output && !keep_c && !binary_existed_before
 
 	// Decide which backend modules to compile into the output. By default only the C
 	// backend is built; the arm64/wasm/eval backends (and the whole SSA pipeline that the
@@ -5116,8 +5117,8 @@ fn main() {
 	} else {
 		// C backend (default)
 		c_standard := c_standard_flag(prefs.c99)
-		use_cached_dev_dylib := cache_state.manager.enabled && !is_prod && !is_shared
-			&& !is_selfhost && prefs.normalized_target_os() == 'macos'
+		use_cached_dev_dylib := cache_state.manager.enabled && remove_binary_after_run && !is_prod
+			&& !is_shared && !is_selfhost && prefs.normalized_target_os() == 'macos'
 		mut cc_dir := ''
 		mut cc_src := output_file
 		mut cc_out := ''
@@ -5718,7 +5719,7 @@ fn main() {
 		})
 		if should_run {
 			run_result := run_binary(bin_file, run_args)
-			if !explicit_output && !keep_c && !binary_existed_before {
+			if remove_binary_after_run {
 				os.rm(bin_file) or {}
 			}
 			if run_result != 0 {

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -57,10 +57,15 @@ $if !skip_wasm ? {
 
 const cache_bundle_import_file_name = '.v3_cache_bundle_imports.vh'
 const macos_v3_fallback_file_env = 'V_MACOS_V3_FALLBACK_FILE'
+const macos_v3_c_error_dir_env = 'V_MACOS_V3_C_ERROR_DIR'
 const macos_v3_vhash_env = 'V_MACOS_V3_VHASH'
 const macos_v3_vcurrent_hash_env = 'V_MACOS_V3_VCURRENT_HASH'
 const macos_v3_inline_asm_diagnostic = 'inline assembly is not supported by the selected V3 backend'
 const macos_v3_inline_asm_fallback = 'inline_asm'
+const macos_v3_c_error_fallback = 'c_compilation_error'
+const macos_v3_c_error_compiler_file = 'compiler'
+const macos_v3_c_error_output_file = 'output'
+const macos_v3_c_error_source_name_file = 'source_name'
 const scoped_transform_signature_headroom = 2048
 const v3_vvmrc_file_name = '.vvmrc'
 const v3_vvmrc_skip_env = 'V_SKIP_VVMRC'
@@ -3528,13 +3533,60 @@ fn record_compile_value(mut values map[string]string, define string) {
 	values[name] = if define.contains('=') { define.all_after_first('=') } else { 'true' }
 }
 
-fn request_macos_v3_compatibility_fallback(diagnostics []parser.Diagnostic) bool {
-	fallback_file := os.getenv(macos_v3_fallback_file_env)
+fn request_macos_v3_compatibility_fallback(diagnostics []parser.Diagnostic, fallback_file string) bool {
 	if fallback_file == '' || !diagnostics.any(it.message == macos_v3_inline_asm_diagnostic) {
 		return false
 	}
 	os.write_file(fallback_file, macos_v3_inline_asm_fallback) or { return false }
 	return true
+}
+
+fn request_macos_v3_c_error_fallback(fallback_file string, report_dir string, ccompiler string, c_output string, c_source string) bool {
+	if fallback_file == '' || report_dir == '' || !os.is_file(c_source) {
+		return false
+	}
+	os.rmdir_all(report_dir) or {}
+	os.mkdir_all(report_dir) or { return false }
+	source_name := os.base(c_source)
+	report_source := os.join_path(report_dir, source_name)
+	os.cp(c_source, report_source) or {
+		os.rmdir_all(report_dir) or {}
+		return false
+	}
+	os.write_file(os.join_path(report_dir, macos_v3_c_error_compiler_file), ccompiler) or {
+		os.rmdir_all(report_dir) or {}
+		return false
+	}
+	os.write_file(os.join_path(report_dir, macos_v3_c_error_output_file), c_output) or {
+		os.rmdir_all(report_dir) or {}
+		return false
+	}
+	os.write_file(os.join_path(report_dir, macos_v3_c_error_source_name_file), source_name) or {
+		os.rmdir_all(report_dir) or {}
+		return false
+	}
+	os.write_file(fallback_file, macos_v3_c_error_fallback) or {
+		os.rmdir_all(report_dir) or {}
+		return false
+	}
+	return true
+}
+
+fn request_macos_v3_c_error_fallback_from_message(fallback_file string, report_dir string, ccompiler string, message string, c_sources []string) bool {
+	is_c_error := message.starts_with('failed to build C object ')
+		|| message.starts_with('failed to build cached module object ')
+		|| message.starts_with('failed to build cached program prefix:')
+		|| message.starts_with('failed to build cached development dylib:')
+	if !is_c_error {
+		return false
+	}
+	for c_source in c_sources {
+		if os.is_file(c_source) {
+			return request_macos_v3_c_error_fallback(fallback_file, report_dir, ccompiler, message,
+				c_source)
+		}
+	}
+	return false
 }
 
 // main runs the v3 entry point.
@@ -3544,6 +3596,8 @@ fn main() {
 		eprintln(cli_usage())
 		exit(1)
 	}
+	macos_v3_fallback_file := os.getenv(macos_v3_fallback_file_env)
+	macos_v3_c_error_dir := os.getenv(macos_v3_c_error_dir_env)
 
 	mut input_file := ''
 	mut output_file := ''
@@ -4156,7 +4210,7 @@ fn main() {
 		i64(0)
 	}
 	if p.diagnostics.len > 0 {
-		if request_macos_v3_compatibility_fallback(p.diagnostics) {
+		if request_macos_v3_compatibility_fallback(p.diagnostics, macos_v3_fallback_file) {
 			exit(1)
 		}
 		for diagnostic in p.diagnostics {
@@ -4170,6 +4224,7 @@ fn main() {
 		exit(1)
 	}
 	os.unsetenv(macos_v3_fallback_file_env)
+	os.unsetenv(macos_v3_c_error_dir_env)
 	// Parsing workers canonicalize source-backed node text before their buffers
 	// are released. Metadata keys are finalized here before semantic phases begin.
 	p.release_source_storage()
@@ -5314,7 +5369,15 @@ fn main() {
 		needs_objective_c := c_flags_need_objective_c(generated_c_flags)
 		resolved_c_flags := prepare_c_flags_for_link(generated_c_flags, prefs.c99, pic_flag,
 			target_args, prefs.target, c_compiler, cc_dir, mut c_object_cache_stats) or {
-			eprintln(err.msg())
+			message := err.msg()
+			if request_macos_v3_c_error_fallback_from_message(macos_v3_fallback_file,
+				macos_v3_c_error_dir, c_compiler, message, [published_c_source, cache_plan_file,
+				cc_src])
+			{
+				cleanup_c_build_dir(cc_dir)
+				exit(1)
+			}
+			eprintln(message)
 			cleanup_c_build_dir(cc_dir)
 			exit(1)
 		}
@@ -5378,7 +5441,18 @@ fn main() {
 						prepared_cache = prepare_v3_incremental_cached_body(cache_plan_file,
 							incremental_tcc_declarations_path, cached_prefix, compile_signature, mut
 							cache_state) or {
-							eprintln(err.msg())
+							message := err.msg()
+							if request_macos_v3_c_error_fallback_from_message(macos_v3_fallback_file,
+								macos_v3_c_error_dir, c_compiler, message, [
+								cache_plan_file,
+								published_c_source,
+								cc_src,
+							])
+							{
+								cleanup_c_build_dir(cc_dir)
+								exit(1)
+							}
+							eprintln(message)
 							cleanup_c_build_dir(cc_dir)
 							exit(1)
 						}
@@ -5402,7 +5476,18 @@ fn main() {
 						prepared_cache = prepare_v3_cached_generic_body(generated_source,
 							cached_prefix, cached_declarations, cached_body, compile_signature, mut
 							cache_state) or {
-							eprintln(err.msg())
+							message := err.msg()
+							if request_macos_v3_c_error_fallback_from_message(macos_v3_fallback_file,
+								macos_v3_c_error_dir, c_compiler, message, [
+								cache_plan_file,
+								published_c_source,
+								cc_src,
+							])
+							{
+								cleanup_c_build_dir(cc_dir)
+								exit(1)
+							}
+							eprintln(message)
 							cleanup_c_build_dir(cc_dir)
 							exit(1)
 						}
@@ -5411,7 +5496,18 @@ fn main() {
 					prepared_cache = prepare_v3_module_cache(generated_source, &cgen_used_fns,
 						&pre_tc, c_standard, opt_flag, pic_flag, warning_flags, resolved_c_flags,
 						needs_objective_c, interface_impl_signature, mut cache_state) or {
-						eprintln(err.msg())
+						message := err.msg()
+						if request_macos_v3_c_error_fallback_from_message(macos_v3_fallback_file,
+							macos_v3_c_error_dir, c_compiler, message, [
+							cache_plan_file,
+							published_c_source,
+							cc_src,
+						])
+						{
+							cleanup_c_build_dir(cc_dir)
+							exit(1)
+						}
+						eprintln(message)
 						cleanup_c_build_dir(cc_dir)
 						exit(1)
 					}
@@ -5521,14 +5617,36 @@ fn main() {
 					&cache_state.manager, c_standard, opt_flag, pic_flag, warning_flags,
 					resolved_c_flags, needs_objective_c, target_args, prefs.target, c_compiler, mut
 					c_object_cache_stats) or {
-					eprintln(err.msg())
+					message := err.msg()
+					if request_macos_v3_c_error_fallback_from_message(macos_v3_fallback_file,
+						macos_v3_c_error_dir, c_compiler, message, [
+						published_c_source,
+						cache_plan_file,
+						cc_src,
+					])
+					{
+						cleanup_c_build_dir(cc_dir)
+						exit(1)
+					}
+					eprintln(message)
 					cleanup_c_build_dir(cc_dir)
 					exit(1)
 				}
 				cached_dev_dylib = compile_v3_dev_dylib(prefix_object, prepared_cache.objects,
 					resolved_c_flags, &cache_state.manager, target_args, prefs.target, c_compiler,
 					cc_dir, !silent || show_cc, mut c_object_cache_stats) or {
-					eprintln(err.msg())
+					message := err.msg()
+					if request_macos_v3_c_error_fallback_from_message(macos_v3_fallback_file,
+						macos_v3_c_error_dir, c_compiler, message, [
+						published_c_source,
+						cache_plan_file,
+						cc_src,
+					])
+					{
+						cleanup_c_build_dir(cc_dir)
+						exit(1)
+					}
+					eprintln(message)
 					cleanup_c_build_dir(cc_dir)
 					exit(1)
 				}
@@ -5722,6 +5840,12 @@ fn main() {
 			}
 			result = cmdexec.run_in(c_compiler, cc_args, cc_dir)
 			if result.exit_code != 0 {
+				if request_macos_v3_c_error_fallback(macos_v3_fallback_file, macos_v3_c_error_dir,
+					c_compiler, result.output, os.join_path_single(cc_dir, fallback_source))
+				{
+					cleanup_c_build_dir(cc_dir)
+					exit(1)
+				}
 				eprintln('C compilation failed:')
 				eprintln(result.output)
 				cleanup_c_build_dir(cc_dir)

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -1569,6 +1569,9 @@ fn default_bin_file_for_input(input_file string) string {
 	if input_file.ends_with('.vv') {
 		return input_file.all_before_last('.vv')
 	}
+	if input_file.ends_with('.vsh') {
+		return input_file.all_before_last('.vsh')
+	}
 	if input_file.ends_with('.v') {
 		return input_file.all_before_last('.v')
 	}
@@ -3482,6 +3485,8 @@ fn main() {
 		if args[i] == 'run' && input_file.len == 0 && !should_run {
 			should_run = true
 			i++
+		} else if args[i] == 'build' && input_file.len == 0 && !should_run {
+			i++
 		} else if args[i] == 'test' && input_file.len == 0 && !should_run {
 			is_test_command = true
 			i++
@@ -3520,7 +3525,7 @@ fn main() {
 				user_defines << 'c99'
 			}
 			i++
-		} else if args[i] == '-strict' {
+		} else if args[i] in ['-strict', '-cstrict'] {
 			is_strict = true
 			i++
 		} else if args[i] == '-ownership' || args[i] == '--ownership' {
@@ -3591,9 +3596,10 @@ fn main() {
 			is_checker_fixture = true
 			i++
 		} else if args[i] in ['-stats', '-show-timings', '-showcc', '-keepc', '-w',
-			'-no-retry-compilation'] {
+			'-no-retry-compilation', '-skip-running', '-usecache'] {
 			// v3 already reports phase metrics, prints the C command, retains generated C,
-			// and suppresses C warnings. Accept the corresponding V flags for compatibility.
+			// suppresses C warnings, leaves explicit-output tests unrun, and caches modules
+			// by default. Accept the corresponding V flags for compatibility.
 			i++
 		} else if args[i] == '-no-prealloc' || args[i] == '--no-prealloc' {
 			no_prealloc = true
@@ -3626,6 +3632,9 @@ fn main() {
 				exit(1)
 			}
 			input_file = args[i]
+			if input_file.ends_with('.vsh') {
+				should_run = true
+			}
 			i++
 		}
 	}

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -3954,7 +3954,13 @@ fn main() {
 	prefs.c99 = c99
 	prefs.user_defines = user_defines
 	prefs.compile_values = compile_values.clone()
-	prefs.vroot = resolve_vroot_for_input(prefs.vroot, input_file)
+	prefs.vroot = if pref.has_macos_v3_caller_environment() && prefs.vexe.len > 0 {
+		// The macOS dispatcher sets VEXE to the invoking compiler. Preserve that
+		// checkout instead of selecting another V checkout around the input.
+		os.real_path(os.dir(prefs.vexe))
+	} else {
+		resolve_vroot_for_input(prefs.vroot, input_file)
+	}
 	prefs.vhash = os.getenv(macos_v3_vhash_env)
 	if prefs.vhash == '' {
 		prefs.vhash = @VHASH

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -3700,6 +3700,10 @@ fn main() {
 		eprintln('no input file')
 		exit(1)
 	}
+	if is_debug && 'debug' !in user_defines {
+		user_defines << 'debug'
+		record_compile_value(mut compile_values, 'debug')
+	}
 	if is_test_command && fixturetest.is_diagnostic_fixture_dir(input_file) {
 		exit(fixturetest.run(os.executable(), input_file, args))
 	}

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -62,6 +62,7 @@ const macos_v3_vhash_env = 'V_MACOS_V3_VHASH'
 const macos_v3_vcurrent_hash_env = 'V_MACOS_V3_VCURRENT_HASH'
 const macos_v3_inline_asm_diagnostic = 'inline assembly is not supported by the selected V3 backend'
 const macos_v3_inline_asm_fallback = 'inline_asm'
+const macos_v3_compiler_error_fallback = 'compiler_error'
 const macos_v3_c_error_fallback = 'c_compilation_error'
 const macos_v3_c_error_compiler_file = 'compiler'
 const macos_v3_c_error_output_file = 'output'
@@ -3533,6 +3534,18 @@ fn record_compile_value(mut values map[string]string, define string) {
 	values[name] = if define.contains('=') { define.all_after_first('=') } else { 'true' }
 }
 
+fn stage_macos_v3_compiler_error_fallback(fallback_file string) {
+	if fallback_file != '' {
+		os.write_file(fallback_file, macos_v3_compiler_error_fallback) or {}
+	}
+}
+
+fn clear_macos_v3_compiler_error_fallback(fallback_file string) {
+	if fallback_file != '' {
+		os.rm(fallback_file) or {}
+	}
+}
+
 fn request_macos_v3_compatibility_fallback(diagnostics []parser.Diagnostic, fallback_file string) bool {
 	if fallback_file == '' || !diagnostics.any(it.message == macos_v3_inline_asm_diagnostic) {
 		return false
@@ -3598,6 +3611,11 @@ fn main() {
 	}
 	macos_v3_fallback_file := os.getenv(macos_v3_fallback_file_env)
 	macos_v3_c_error_dir := os.getenv(macos_v3_c_error_dir_env)
+	// A delegated V3 process owns the fallback marker until it has successfully
+	// produced its output. Specialized failures overwrite it below. Successful
+	// run/test programs clear it before launch, so their exit status is never
+	// mistaken for a compiler failure by the macOS driver.
+	stage_macos_v3_compiler_error_fallback(macos_v3_fallback_file)
 
 	mut input_file := ''
 	mut output_file := ''
@@ -5341,6 +5359,7 @@ fn main() {
 		if c_only {
 			b.metric('generated C size', os.file_size(cc_src), 'bytes')
 			b.print_report()
+			clear_macos_v3_compiler_error_fallback(macos_v3_fallback_file)
 			return
 		}
 
@@ -5876,6 +5895,7 @@ fn main() {
 		} else {
 			'cc'
 		})
+		clear_macos_v3_compiler_error_fallback(macos_v3_fallback_file)
 		if should_run {
 			run_result := run_binary(bin_file, run_args)
 			if remove_binary_after_run {
@@ -5893,6 +5913,7 @@ fn main() {
 			b.step('test')
 		}
 	}
+	clear_macos_v3_compiler_error_fallback(macos_v3_fallback_file)
 
 	worker_stats := a.worker_stats()
 	b.metric('worker phase callbacks', i64(worker_stats.tasks_run), 'tasks')


### PR DESCRIPTION
## Summary

- add `-old-compiler` as an explicit macOS escape hatch to the established `vlib/v` compiler
- when delegated V3 C compilation fails, retry in-process through the established compiler; if that retry succeeds, submit the staged V3 generated-C diagnostics through the existing bugs.vlang.io reporter with a leading `V3` build-options tag
- dispatch supported no-GC native macOS C source builds from the `v` CLI to a cached compiler built from `vlib/v3/v3.v`, clearing inherited `VFLAGS` and `VOSARGS` while bootstrapping that compiler
- retain the established compiler for default-GC builds, valued `-d name=value` defines, explicit C compiler selections, explicit `-silent` compile defines, explicit `-no-retry-compilation` retry control, named `-d`-prefixed compatibility options, coverage instrumentation, environment-provided `CFLAGS`/`LDFLAGS`, object-only `.o` output, V-source-mapped `-g`, all shared-library builds, tests, tools, self-hosted temporary compilers, cross-compilation, established architectures not modeled by V3, the legacy `-arch x86` amd64 alias, directory/legacy `.vv`/non-V inputs, symlink-resolved sources, directory-valued or dash-prefixed `-o`, generated-C stdout output, V warning suppression, source help flags, unsupported CLI options, sources needing compatible safe default-output naming, and V3 modes that are not ready yet; leave non-macOS platforms unchanged
- propagate V3's effective default C compiler into compiler `$if` conditions and `@CCOMPILER`, including imported modules and cache identity
- derive `@PLATFORM` and its compile-time condition value from the normalized selected target architecture, including cross-architecture macOS builds
- expand `@COLUMN` and project Git-backed `@VMODHASH` values in normal expressions and compile-time conditions, preserve basename-plus-line `@FILE_LINE` semantics in expressions, conditions, attributes, and cached declarations, and include each project hash in cached source signatures and validation
- forward the driver's `@VHASH` and `@VCURRENTHASH` into delegated V3 parsing, preserve them across cache restarts, include them in build-pseudo source signatures, and keep the private transport variables out of run children
- let V3 request a silent compatibility fallback after recursive parsing when source or imported modules require nonempty inline assembly, while keeping normal compiler/program stdio inherited and removing the private signal before successful run children
- keep implicit generated C private, write exact C output only for explicit `-o file.c`, retain `-keepc` output as a sanitized unique `*.tmp.c` under the V temp directory, and remove newly created implicit run executables after normal completion or SIGINT/SIGQUIT interruption
- route direct `.vsh` scripts while keeping explicit `crun` on the compatibility path, and honor `-skip-running`, `build`, and preference-derived `VNORUN` as compile-only modes
- resolve and type-check primitive `-d` values in V3 `$d()` expressions, reject values incompatible with the fallback literal, preserve boolean defines' conditional-attribute behavior without changing `$if debug` semantics, and add the effective `debug` define before V3 module discovery for `-g`/`-cg` file selection
- track `-showcc` separately from V3 benchmark verbosity so delegated invocations print C commands without enabling timing or memory reports
- preserve caller-visible `VEXE` and `VCHILD` values across delegated compile-time `$env`, module-cache validation, generated startup, and `run` environments while keeping launcher-only transport values private
- preserve the invoking compiler's V root when compiling sources inside another checkout, and expand deprecated `@VROOT` consistently with `@VEXEROOT` in normal expressions and compile-time conditions
- accept `-no-memory-limit` and `--no-memory-limit` in the outer preference parser so both documented V3 opt-outs reach delegated builds
- reserve the macOS cached development dylib for implicit run executables that V3 removes; link ordinary builds, explicit run outputs, `-keepc` runs, and pre-existing run targets standalone so persistent outputs survive cache cleanup
- apply `-fwrapv` throughout V3 C compilation with cache invalidation, and preserve macOS `-cg` symbolic backtraces by using the system linker with `-Wl,-export_dynamic` while keeping plain `-g` distinct
- document the macOS default and add routing/driver regressions

## Testing

- `./vnew cmd/v/macos_v3_test.v` (including an end-to-end fake-V3 C failure that retries and produces a runnable old-compiler output)
- `./vnew vlib/v/pref/pref_test.v`
- `./vnew vlib/v/builder/c_error_report_test.v`
- `./vnew -run-only test_driver_requests_macos_compatibility_for_c_compilation_errors test vlib/v3/tests/driver_cli_test.v`
- `./v -g -keepc -o ./vnew cmd/v`
- `./vnew -silent cmd/v/macos_v3_test.v` (supported and unsupported established architecture aliases covered)
- `./vnew -silent vlib/v/pref/pref_test.v`
- `./vnew -silent vlib/v3/pref/target_test.v`
- `./vnew test -run-only test_driver_cflags_include_dir_is_visible_to_header_inliner vlib/v3/tests/driver_cli_test.v` (1 passed)
- `./vnew test -run-only test_driver_platform_pseudo_uses_selected_target_arch vlib/v3/tests/driver_cli_test.v` (1 passed)
- `./vnew -silent vlib/v3/modulecache/modulecache_test.v`
- `./vnew test -run-only test_driver_preserves_macos_launcher_caller_environment vlib/v3/tests/driver_cli_test.v` (1 passed; unset and custom caller values through the same enabled cache)
- `./vnew test -run-only test_compiler_vexe_env_uses_running_executable vlib/v3/tests/post_merge_review_fixes_test.v` (1 passed; direct V3 behavior unchanged)
- `./vnew test -run-only test_driver_accepts_dispatcher_arguments_and_runs_vsh_files vlib/v3/tests/driver_cli_test.v` (1 passed)
- `./vnew test -run-only test_driver_requests_macos_compatibility_for_inline_assembly vlib/v3/tests/driver_cli_test.v` (1 passed)
- `./vnew test -run-only test_driver_cg_selects_debug_module_files vlib/v3/tests/driver_cli_test.v` (1 passed)
- `./vnew test -run-only test_driver_propagates_default_compiler_and_hash_pseudos vlib/v3/tests/driver_cli_test.v` (1 passed; two enabled-cache hash populations plus delegated run environment isolation)
- `./vnew -silent -run-only test_driver_resolves_boolean_d_and_documented_pseudos test vlib/v3/tests/driver_cli_test.v` (1 passed; spaced/compact defines, primitive-type rejection, normal/conditional pseudos, and enabled-cache invalidation after a HEAD-only change)
- `./vnew -silent -run-only test_delegated_driver_preserves_invoking_vroot test vlib/v3/tests/driver_cli_test.v` (1 passed; a source inside a second checkout retained the invoking root for imports, `@VEXEROOT`, and `@VROOT`)
- `./vnew -silent test vlib/v3/parser/` (3 passed)
- focused `@FILE_LINE` direct-codegen, compile-time condition/match/attribute, and module-cache rewrite tests (all passed)
- focused V3 cache-linking regressions for persistent output after cache deletion, standalone Objective-C and weak-library linkage, ephemeral archive invalidation, and run cleanup (all passed)
- top-level macOS dispatch smoke: `V3CACHE=<isolated> ./vnew -gc none file.v`, delete the cache, then launch the compiled binary (passed)
- `./vnew -silent -run-only test_driver_macos_wrapv_and_cg_link_flags vlib/v3/tests/driver_cli_test.v` (1 passed; optimized overflow semantics, system/TinyCC `-fwrapv`, macOS `-cg` export, and plain `-g` distinction)
- `./vnew -silent -run-only test_driver_cg_selects_debug_module_files vlib/v3/tests/driver_cli_test.v` (1 passed)
- `./vnew -silent vlib/v/compiler_errors_test.v` (1601 passed, 1 skipped)
- top-level delegated `-cg` command containing both `-fwrapv` and `-Wl,-export_dynamic`, with optimized signed overflow producing the wrapped result
- actual macOS V3 dispatch smoke tests for the default `cc` selecting the same `clang` branch and `@CCOMPILER` as the established compiler, identical full `@VHASH` and short `@VCURRENTHASH`, an adjacent hand-written C file surviving `-keepc` with exactly one retained temp C file, an x86_64 Mach-O reporting and selecting `amd64`, a fresh isolated-cache bootstrap driven by parent `VOSARGS`, normal `run`, caller-visible `VEXE`/`VCHILD` parity for unset and custom environments, SIGINT-interrupted `run`, direct `.vsh`, generated-C/run-artifact cleanup, `-skip-running script.vsh`, `build script.vsh`, `VNORUN=1` compile-only behavior, compiling `ci/macos_ci.vsh`, both top-level memory-limit opt-out spellings reaching V3, spaced and compact boolean `$d()` overrides, `@COLUMN`, and Git-backed `@VMODHASH`, standalone `-showcc` emitting only the C command without benchmark output, and `-cg` remaining delegated
- compatibility fallback smoke tests for valued `-d port=2` preserving `$d('port', 1)`, a non-V `-prealloc run` preserving its input checksum, the legacy `-arch x86` selecting amd64 while `x86_64` remains V3-eligible, `rv32` C output remaining on compatibility and defining `__V_rv32`, explicit `-cc clang` preserving `$if clang`, nonempty ARM64 inline assembly compiling and running, explicit `-silent`, explicit `-no-retry-compilation`, named `-div-by-zero-is-zero`, relocatable `.o` output, applied `CFLAGS`/`LDFLAGS`, V-source-mapped `-g`, ordinary shared-library output preserving the established hidden-visibility path, shared `run` with the established diagnostic, `VCOVDIR` metadata/runtime counters, dash-prefixed `-o -foo`, default GC, symlinked source output placement, generated-C stdout with `-o -`, unused-import warning suppression with `-w`, source `-h`, `-path`, the `-output` alias, directory-valued `-o`, and safe `foo.c.v` output naming; complementary checks confirm boolean compact `-dname` and `-cg` remain V3-eligible
- Linux `cmd/v` cross-build
- `./vnew check-md vlib/v3/README.md`
- full `ci/macos_ci.vsh all` task set in an isolated worktree before the review follow-ups: all task bodies passed except `vlib/v/util/version/version_test.v`, which requires a normal `.git/HEAD` rather than a worktree `.git` pointer; that exact test passes in the normal checkout. The self-test aggregate was 3151 passed, 285 skipped, and the two example passes each built 258 with 18 skipped plus 4 hot-reload examples.



