### PR TITLE
compiler: fix five recent issues in v and v3

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -506,8 +506,20 @@ fn (t &Table) fn_type_components_are_compatible(left_type Type, right_type Type,
 	return false
 }
 
+fn (t &Table) method_types_are_equal(left Type, right Type) bool {
+	if left == right {
+		return true
+	}
+	unaliased_left := t.fully_unaliased_type(left)
+	unaliased_right := t.fully_unaliased_type(right)
+	if unaliased_left.has_option_or_result() || unaliased_right.has_option_or_result() {
+		return false
+	}
+	return unaliased_left == unaliased_right
+}
+
 pub fn (t &Table) is_same_method(f &Fn, func &Fn) string {
-	mut same_return_type := f.return_type == func.return_type
+	mut same_return_type := t.method_types_are_equal(f.return_type, func.return_type)
 	if !same_return_type {
 		f_return_type := t.fully_unaliased_type(f.return_type)
 		func_return_type := t.fully_unaliased_type(func.return_type)
@@ -534,7 +546,7 @@ pub fn (t &Table) is_same_method(f &Fn, func &Fn) string {
 	for i in 0 .. f.params.len {
 		// don't check receiver for `.typ`
 		has_unexpected_type := i > 0
-			&& t.unaliased_type(f.params[i].typ) != t.unaliased_type(func.params[i].typ)
+			&& !t.method_types_are_equal(f.params[i].typ, func.params[i].typ)
 		// temporary hack for JS ifaces
 		lsym := t.sym(f.params[i].typ)
 		rsym := t.sym(func.params[i].typ)

--- a/vlib/v/checker/tests/match_undefined_sumtype_variant_err.out
+++ b/vlib/v/checker/tests/match_undefined_sumtype_variant_err.out
@@ -1,0 +1,8 @@
+vlib/v/checker/tests/match_undefined_sumtype_variant_err.vv:6:3: error: `Value` has no variant `Nil`.
+2 possibilities: `int`, `string`.
+    4 |     value := Value(1)
+    5 |     println(match value {
+    6 |         Nil { 'nil' }
+      |         ~~~
+    7 |         else { 'other' }
+    8 |     })

--- a/vlib/v/checker/tests/match_undefined_sumtype_variant_err.vv
+++ b/vlib/v/checker/tests/match_undefined_sumtype_variant_err.vv
@@ -1,0 +1,9 @@
+type Value = int | string
+
+fn main() {
+	value := Value(1)
+	println(match value {
+		Nil { 'nil' }
+		else { 'other' }
+	})
+}

--- a/vlib/v/gen/c/consts_and_globals.v
+++ b/vlib/v/gen/c/consts_and_globals.v
@@ -638,9 +638,11 @@ fn (mut g Gen) global_decl(node ast.GlobalDecl) {
 			}
 			if g.pref.translated {
 				def_builder.write_string(' = ${g.expr_string(field.expr)}')
-			} else if (field.expr.is_literal() && should_init) || cinit
+			} else if !should_init && !cinit {
+				// Cached modules provide the definition and initialization.
+			} else if field.expr.is_literal() || cinit
 				|| (field.expr is ast.ArrayInit && field.expr.is_fixed)
-				|| (is_simple_unsafe_expr && should_init) {
+				|| is_simple_unsafe_expr {
 				// Simple literals can be initialized right away in global scope in C.
 				// e.g. `int myglobal = 10;`
 				def_builder.write_string(' = ${g.expr_string(field.expr)}')

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1319,16 +1319,10 @@ fn (mut g Gen) gen_fn_decl(node &ast.FnDecl, skip bool) {
 				}
 			}
 			mut method_name := c_name(call_fn.name)
-			if call_fn.name.contains('_') {
-				parts := call_fn.name.split('_')
-				if parts.len >= 2 {
-					receiver_type_name := parts[0]
-					if resolved_sym := g.table.find_sym(receiver_type_name) {
-						if resolved_sym.is_builtin() {
-							method_name = 'builtin__${method_name}'
-						}
-					}
-				}
+			trace_receiver_name := call_fn.name.all_before('_')
+			if call_fn.func.is_method
+				&& g.receiver_type_is_builtin(call_fn.func.receiver_type, trace_receiver_name) {
+				method_name = 'builtin__${method_name}'
 			}
 			if call_fn.return_type == 0 || call_fn.return_type == ast.void_type {
 				if add_trace_hook {
@@ -4888,10 +4882,9 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 	} else {
 		name = util.no_dots('${receiver_type_name}_${method_name}')
 	}
-	if resolved_sym := g.table.find_sym(receiver_type_name) {
-		if resolved_sym.is_builtin() && !receiver_type_name.starts_with('_') {
-			name = 'builtin__${name}'
-		}
+	if g.receiver_type_is_builtin(unwrapped_rec_type, receiver_type_name)
+		&& !receiver_type_name.starts_with('_') {
+		name = 'builtin__${name}'
 	} else if receiver_type_name in ['int_literal', 'float_literal', 'vint_t'] {
 		name = 'builtin__${name}'
 	}
@@ -5678,6 +5671,16 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 		// it's non-option fixed array, requires accessing .ret_arr member to get the array
 		g.write('.ret_arr')
 	}
+}
+
+// receiver_type_is_builtin follows type indexes only, so parallel cgen does not
+// read the type-name map while another checker shard may still be extending it.
+fn (g &Gen) receiver_type_is_builtin(typ ast.Type, receiver_name string) bool {
+	sym := g.table.sym(typ)
+	if sym.is_builtin() {
+		return true
+	}
+	return receiver_name in ['array', 'map', 'chan', 'thread']
 }
 
 fn (mut g Gen) fn_call(node ast.CallExpr) {

--- a/vlib/v/gen/c/link_generated_c_files_test.v
+++ b/vlib/v/gen/c/link_generated_c_files_test.v
@@ -120,3 +120,28 @@ fn test_parallel_cc_usecache_interface_index_definition_stays_out_of_header() {
 	assert !header.contains('const u32 _IError_None___index = _IError_None___index_enum;')
 	assert out0.contains('const u32 _IError_None___index = _IError_None___index_enum;'), out0
 }
+
+fn test_parallel_cgen_builtin_method_prefix_uses_receiver_type_index() {
+	tmp_dir := os.join_path(os.vtmp_dir(), 'parallel_cgen_builtin_receiver_${os.getpid()}')
+	os.mkdir_all(tmp_dir)!
+	defer {
+		os.rmdir_all(tmp_dir) or {}
+	}
+	source_path := os.join_path(tmp_dir, 'main.v')
+	os.write_file(source_path,
+		'fn main() {\n\tmut values := []int{}\n\tunsafe { values.free() }\n}\n')!
+	mut prefs, _ := pref.parse_args_and_show_errors([], [
+		'',
+		'-parallel-cc',
+		source_path,
+	], false)
+	mut b := builder.new_builder(prefs)
+	mut files := b.get_builtin_files()
+	files << b.get_user_files()
+	b.set_module_lookup_paths()
+	b.front_and_middle_stages(files)!
+	result := c.gen(b.parsed_files, mut b.table, b.pref)
+	generated := result.res_builder.bytestr()
+	assert generated.contains('builtin__array_free(&values);'), generated
+	assert !generated.contains('\n\tarray_free(&values);'), generated
+}

--- a/vlib/v/gen/wasm/gen.v
+++ b/vlib/v/gen/wasm/gen.v
@@ -18,11 +18,12 @@ pub struct Gen {
 	pref     &pref.Preferences = unsafe { nil } // Preferences shared from V struct
 	files    []&ast.File
 mut:
-	file_path string // current ast.File path
-	warnings  []errors.Warning
-	errors    []errors.Error
-	table     &ast.Table = unsafe { nil }
-	enum_vals map[string]Enum
+	file_path   string // current ast.File path
+	current_pos token.Pos
+	warnings    []errors.Warning
+	errors      []errors.Error
+	table       &ast.Table = unsafe { nil }
+	enum_vals   map[string]Enum
 
 	mod                    wasm.Module
 	pool                   serialise.Pool
@@ -192,6 +193,7 @@ pub fn (mut g Gen) fn_external_import(node ast.FnDecl) {
 }
 
 pub fn (mut g Gen) fn_decl(node ast.FnDecl) {
+	g.current_pos = node.pos
 	if node.language in [.js, .wasm] {
 		g.fn_external_import(node)
 		return
@@ -1059,6 +1061,7 @@ pub fn (mut g Gen) store_field(typ ast.Type, ftyp ast.Type, name string) {
 }
 
 pub fn (mut g Gen) expr(node ast.Expr, expected ast.Type) {
+	g.current_pos = node.pos()
 	match node {
 		ast.ParExpr, ast.UnsafeExpr {
 			g.expr(node.expr, expected)
@@ -1095,7 +1098,7 @@ pub fn (mut g Gen) expr(node ast.Expr, expected ast.Type) {
 			} else {
 				match ts.info {
 					ast.Array {
-						g.w_error('wasm backend does not support dynamic arrays')
+						g.v_error('the wasm backend does not support dynamic arrays yet', node.pos)
 					}
 					ast.ArrayFixed {
 						typ = ts.info.elem_type

--- a/vlib/v/gen/wasm/ops.v
+++ b/vlib/v/gen/wasm/ops.v
@@ -85,7 +85,8 @@ pub fn (mut g Gen) get_wasm_type(typ_ ast.Type) wasm.ValType {
 		else {}
 	}
 
-	g.w_error("get_wasm_type: unreachable type '${*g.table.sym(typ)}' ${ts.info}")
+	g.v_error('the wasm backend does not support type `${g.table.type_to_str(typ)}` yet',
+		g.current_pos)
 }
 
 pub fn (mut g Gen) infix_param_type(typ ast.Type, op token.Kind) {
@@ -94,8 +95,8 @@ pub fn (mut g Gen) infix_param_type(typ ast.Type, op token.Kind) {
 			g.handle_string_operation(op)
 		}
 		else {
-			eprintln(*g.table.sym(typ))
-			panic('unimplemented infix operation for type')
+			g.v_error('the wasm backend does not support `${op}` for type `${g.table.type_to_str(typ)}` yet',
+				g.current_pos)
 		}
 	}
 }

--- a/vlib/v/gen/wasm/tests/scalar_option_result_error_test.v
+++ b/vlib/v/gen/wasm/tests/scalar_option_result_error_test.v
@@ -30,3 +30,22 @@ fn test_scalar_result_return_errors_cleanly() {
 	assert res.output.contains('result types are not implemented'), res.output
 	assert !res.output.contains('get_wasm_type: unreachable'), 'leaked the internal ICE: ${res.output}'
 }
+
+fn test_dynamic_map_errors_cleanly() {
+	res := compile_wasm('fn main() {\n\tmut values := map[string]int{}\n\tvalues["one"] = 1\n}\n',
+		'dynamic_map')
+	assert res.exit_code != 0, 'expected a compile error, got: ${res.output}'
+	assert res.output.contains('dynamic_map.v:1:1:'), res.output
+	assert res.output.contains('the wasm backend does not support type `map[string]int` yet'), res.output
+
+	assert !res.output.contains('get_wasm_type: unreachable'), 'leaked the internal ICE: ${res.output}'
+}
+
+fn test_struct_infix_errors_cleanly() {
+	res := compile_wasm('struct Item {\n\tx int\n}\n\nfn main() {\n\tprintln(Item{} == Item{})\n}\n',
+		'struct_infix')
+	assert res.exit_code != 0, 'expected a compile error, got: ${res.output}'
+	assert res.output.contains('the wasm backend does not support `==` for type `Item` yet'), res.output
+
+	assert !res.output.contains('unimplemented infix operation'), 'leaked the internal panic: ${res.output}'
+}

--- a/vlib/v/tests/interfaces/interface_method_with_params_implemented_with_type_aliased_params_test.v
+++ b/vlib/v/tests/interfaces/interface_method_with_params_implemented_with_type_aliased_params_test.v
@@ -16,6 +16,7 @@ struct Param2 {
 
 type AliasParam1 = Param1
 type AliasParam2 = Param2
+type ChainedAliasParam1 = AliasParam1
 
 interface MyInterface {
 	method1(p1 Param1, p2 Param2) f32
@@ -43,10 +44,28 @@ fn (i ImplWithAliasedParams) method1(p1 AliasParam1, p2 AliasParam2) f32 {
 	return i.v + p1.x + p2.y
 }
 
+interface ReturnsParam {
+	value() Param1
+}
+
+struct ReturnsAlias {}
+
+fn (r ReturnsAlias) value() ChainedAliasParam1 {
+	_ = r
+	return ChainedAliasParam1{
+		x: 42
+	}
+}
+
 fn test_interface_method_can_be_called_with_aliased_type_values() {
 	isdirect := MyInterface(ImplDirect{1000})
 	isalias := MyInterface(ImplWithAliasedParams{2000})
 
 	assert isdirect.method1(AliasParam1{123}, AliasParam2{1.1}) == 1124.1
 	assert isalias.method1(AliasParam1{456}, AliasParam2{2.2}) == 2458.2
+}
+
+fn test_interface_method_can_return_a_chained_alias() {
+	implementation := ReturnsParam(ReturnsAlias{})
+	assert implementation.value().x == 42
 }

--- a/vlib/v/tests/usecache_interface_index_symbol_test.v
+++ b/vlib/v/tests/usecache_interface_index_symbol_test.v
@@ -42,6 +42,24 @@ fn test_usecache_interface_index_is_real_symbol() {
 	assert res2.output.contains('enum { _IError_None___index =')
 }
 
+fn test_usecache_builtin_fixed_array_globals_are_extern_only() {
+	tmp_dir := os.join_path(os.vtmp_dir(), 'v_issue_27592')
+	os.mkdir_all(tmp_dir) or { panic(err) }
+	defer {
+		os.rmdir_all(tmp_dir) or {}
+	}
+	source_path := os.join_path(tmp_dir, 'issue_27592.v')
+	os.write_file(source_path, "fn main() {\n\tprintln('hello world')\n}\n") or { panic(err) }
+
+	res := os.execute('${os.quoted_path(vexe)} -usecache -o - ${os.quoted_path(source_path)}')
+	assert res.exit_code == 0, res.output
+	assert res.output.contains('extern Array_fixed_int_64 g_autostr_type_stack;'), res.output
+	assert res.output.contains('extern Array_fixed_voidptr_64 g_autostr_addr_stack;'), res.output
+	assert !res.output.contains('extern Array_fixed_int_64 g_autostr_type_stack = {0};'), res.output
+	assert !res.output.contains('g_autostr_type_stack = {0}; // global 3'), res.output
+	assert !res.output.contains('g_autostr_addr_stack = {0}; // global 3'), res.output
+}
+
 fn test_usecache_shared_interface_lock_uses_enum_index_in_case_labels() {
 	tmp_dir := os.join_path(os.vtmp_dir(), 'v_issue_27330_shared')
 	os.mkdir_all(tmp_dir) or { panic(err) }

--- a/vlib/v3/tests/interface_return_alias_compatibility_test.v
+++ b/vlib/v3/tests/interface_return_alias_compatibility_test.v
@@ -1,0 +1,46 @@
+import os
+
+const interface_return_vexe = @VEXE
+const interface_return_tests_dir = os.dir(@FILE)
+const interface_return_v3_dir = os.dir(interface_return_tests_dir)
+const interface_return_v3_src = os.join_path(interface_return_v3_dir, 'v3.v')
+const interface_return_v3_bin = os.join_path(os.temp_dir(),
+	'v3_interface_return_alias_${os.getpid()}')
+
+fn build_interface_return_v3() string {
+	if os.is_executable(interface_return_v3_bin) {
+		return interface_return_v3_bin
+	}
+	build :=
+		os.execute('${os.quoted_path(interface_return_vexe)} -gc none -o ${os.quoted_path(interface_return_v3_bin)} ${os.quoted_path(interface_return_v3_src)}')
+	assert build.exit_code == 0, build.output
+	return interface_return_v3_bin
+}
+
+fn compile_interface_return(v3_bin string, name string, source string) os.Result {
+	source_path := os.join_path(os.temp_dir(), 'v3_interface_return_${name}_${os.getpid()}.v')
+	output_path := os.join_path(os.temp_dir(), 'v3_interface_return_${name}_${os.getpid()}')
+	os.write_file(source_path, source) or { panic(err) }
+	return os.execute('${os.quoted_path(v3_bin)} -nocache -b c -o ${os.quoted_path(output_path)} ${os.quoted_path(source_path)}')
+}
+
+fn test_interface_method_return_only_accepts_alias_equivalence() {
+	v3_bin := build_interface_return_v3()
+	alias_compile := compile_interface_return(v3_bin, 'chained_alias',
+		'type Value = int\n\ntype ChainedValue = Value\n\ninterface Provider {\n\tvalue() int\n}\n\nstruct AliasedValue {}\n\nfn (a AliasedValue) value() ChainedValue {\n\treturn 42\n}\n\nfn main() {\n\tprovider := Provider(AliasedValue{})\n\tprintln(provider.value())\n}\n')
+	assert alias_compile.exit_code == 0, alias_compile.output
+	alias_bin := os.join_path(os.temp_dir(), 'v3_interface_return_chained_alias_${os.getpid()}')
+	alias_run := os.execute(os.quoted_path(alias_bin))
+	assert alias_run.exit_code == 0, alias_run.output
+	assert alias_run.output.trim_space() == '42', alias_run.output
+
+	int_compile := compile_interface_return(v3_bin, 'integer_conversion',
+		'interface Provider {\n\tvalue() int\n}\n\nstruct WideValue {}\n\nfn (w WideValue) value() i64 {\n\treturn 42\n}\n\nfn main() {\n\t_ := Provider(WideValue{})\n}\n')
+	assert int_compile.exit_code != 0, int_compile.output
+	assert int_compile.output.contains('expected return type `int`'), int_compile.output
+
+	float_compile := compile_interface_return(v3_bin, 'float_conversion',
+		'interface Provider {\n\tvalue() f32\n}\n\nstruct WideValue {}\n\nfn (w WideValue) value() f64 {\n\treturn 42.0\n}\n\nfn main() {\n\t_ := Provider(WideValue{})\n}\n')
+	assert float_compile.exit_code != 0, float_compile.output
+	assert float_compile.output.contains('expected return type `f32`'), float_compile.output
+}

--- a/vlib/v3/tests/match_and_wasm_diagnostics_test.v
+++ b/vlib/v3/tests/match_and_wasm_diagnostics_test.v
@@ -1,0 +1,47 @@
+import os
+
+const diagnostic_vexe = @VEXE
+const diagnostic_tests_dir = os.dir(@FILE)
+const diagnostic_v3_dir = os.dir(diagnostic_tests_dir)
+const diagnostic_v3_src = os.join_path(diagnostic_v3_dir, 'v3.v')
+const diagnostic_v3_bin = os.join_path(os.temp_dir(),
+	'v3_match_and_wasm_diagnostics_${os.getpid()}')
+
+fn build_diagnostic_v3() string {
+	if os.is_executable(diagnostic_v3_bin) {
+		return diagnostic_v3_bin
+	}
+	build :=
+		os.execute('${os.quoted_path(diagnostic_vexe)} -gc none -o ${os.quoted_path(diagnostic_v3_bin)} ${os.quoted_path(diagnostic_v3_src)}')
+	assert build.exit_code == 0, build.output
+	return diagnostic_v3_bin
+}
+
+fn test_undefined_sumtype_match_variant_stops_before_codegen() {
+	v3_bin := build_diagnostic_v3()
+	source_path := os.join_path(os.temp_dir(), 'v3_undefined_sumtype_variant_${os.getpid()}.v')
+	output_path := os.join_path(os.temp_dir(), 'v3_undefined_sumtype_variant_${os.getpid()}')
+	os.write_file(source_path,
+		"type Value = int | string\n\nfn main() {\n\tvalue := Value(1)\n\tprintln(match value {\n\t\tNil { 'nil' }\n\t\telse { 'other' }\n\t})\n}\n")!
+	result :=
+		os.execute('${os.quoted_path(v3_bin)} -nocache -b c -o ${os.quoted_path(output_path)} ${os.quoted_path(source_path)}')
+	assert result.exit_code != 0, result.output
+	assert result.output.contains('`Value` has no variant `Nil`'), result.output
+	assert !result.output.contains('C compilation failed'), result.output
+	assert !result.output.contains('redict__Nil_str'), result.output
+}
+
+fn test_wasm_unsupported_aggregate_reports_source_error() {
+	v3_bin := build_diagnostic_v3()
+	source_path := os.join_path(os.temp_dir(), 'v3_wasm_dynamic_map_${os.getpid()}.v')
+	output_path := os.join_path(os.temp_dir(), 'v3_wasm_dynamic_map_${os.getpid()}.wasm')
+	os.write_file(source_path,
+		'fn main() {\n\tmut values := map[string]int{}\n\tvalues["one"] = 1\n}\n')!
+	result :=
+		os.execute('${os.quoted_path(v3_bin)} -b wasm -o ${os.quoted_path(output_path)} ${os.quoted_path(source_path)}')
+	assert result.exit_code != 0, result.output
+	assert result.output.contains('v3_wasm_dynamic_map_${os.getpid()}.v:1:4:'), result.output
+	assert result.output.contains('the V3 wasm backend does not support type `map[string]int` yet'), result.output
+
+	assert !result.output.contains('panic:'), result.output
+}

--- a/vlib/v3/tests/struct_init_alias_authority_codegen_test.v
+++ b/vlib/v3/tests/struct_init_alias_authority_codegen_test.v
@@ -20,8 +20,12 @@ fn struct_alias_write_project() string {
 	os.rmdir_all(root) or {}
 	gg_dir := os.join_path(root, 'gg')
 	sgl_dir := os.join_path(root, 'sgl_like')
+	common_dir := os.join_path(root, 'common')
+	data_dir := os.join_path(root, 'data')
 	os.mkdir_all(gg_dir) or { panic(err) }
 	os.mkdir_all(sgl_dir) or { panic(err) }
+	os.mkdir_all(common_dir) or { panic(err) }
+	os.mkdir_all(data_dir) or { panic(err) }
 	os.write_file(os.join_path(root, 'v.mod'), 'Module {
 	name: "v3_struct_alias_fixture"
 }
@@ -80,8 +84,58 @@ pub fn context_score() int {
 ') or {
 		panic(err)
 	}
+	os.write_file(os.join_path(common_dir, 'common.v'), 'module common
+
+pub struct ID {
+pub:
+	value int
+}
+
+pub interface Translation {
+	locale_id() ID
+}
+') or {
+		panic(err)
+	}
+	os.write_file(os.join_path(data_dir, 'data.v'), 'module data
+
+import common
+
+pub type ID = common.ID
+
+fn check_translation_locale_ids(translations []common.Translation) ! {
+	for translation in translations {
+		if translation.locale_id().value < 0 {
+			return error("invalid locale")
+		}
+	}
+}
+
+pub struct CategoryTranslationParams {
+pub:
+	locale_id ID
+}
+
+fn (p CategoryTranslationParams) locale_id() ID {
+	return p.locale_id
+}
+
+pub struct CategoryCreateParams {
+pub:
+	translations ?[]CategoryTranslationParams
+}
+
+pub fn (p CategoryCreateParams) check() ! {
+	if translations := p.translations {
+		check_translation_locale_ids(translations)!
+	}
+}
+') or {
+		panic(err)
+	}
 	os.write_file(os.join_path(root, 'main.v'), 'module main
 
+import data
 import sgl_like
 
 struct Context {
@@ -90,6 +144,15 @@ struct Context {
 }
 
 fn main() {
+	data.CategoryCreateParams{
+		translations: [
+			data.CategoryTranslationParams{
+				locale_id: data.ID{
+					value: 1
+				}
+			},
+		]
+	}.check()!
 	println(int_str(sgl_like.context_score()))
 }
 ') or {

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -50930,7 +50930,7 @@ fn (tc &TypeChecker) method_signature_compatible(actual_key string, expected_key
 	}
 	actual_ret := tc.fn_ret_types[actual_key] or { Type(void_) }
 	expected_ret := tc.fn_ret_types[expected_key] or { Type(void_) }
-	return tc.method_param_signature_compatible(actual_ret, expected_ret)
+	return method_return_signature_compatible(actual_ret, expected_ret)
 }
 
 fn (tc &TypeChecker) method_call_info_signature_compatible(actual CallInfo, expected_key string) bool {
@@ -50944,7 +50944,11 @@ fn (tc &TypeChecker) method_call_info_signature_compatible(actual CallInfo, expe
 		}
 	}
 	expected_ret := tc.fn_ret_types[expected_key] or { Type(void_) }
-	return tc.method_param_signature_compatible(actual.return_type, expected_ret)
+	return method_return_signature_compatible(actual.return_type, expected_ret)
+}
+
+fn method_return_signature_compatible(actual Type, expected Type) bool {
+	return fn_return_canonical_type_name(actual) == fn_return_canonical_type_name(expected)
 }
 
 fn (tc &TypeChecker) method_param_signature_compatible(actual Type, expected Type) bool {

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -44373,6 +44373,10 @@ fn (tc &TypeChecker) distinct_alias_primitive_mismatch(actual Type, expected Typ
 
 fn (tc &TypeChecker) generic_struct_field_unknown_type_message(struct_name string) ?string {
 	decl := tc.source_struct_decl_for_name(struct_name) or { return none }
+	base_name, _, is_generic := generic_type_application_parts(struct_name)
+	lookup_name := if is_generic { base_name } else { struct_name }
+	decl_file := tc.struct_files[lookup_name] or { tc.cur_file }
+	decl_module := tc.struct_modules[lookup_name] or { tc.cur_module }
 	for i in 0 .. decl.children_count {
 		field_id := tc.a.child(&decl, i)
 		field := tc.a.node(field_id)
@@ -44385,39 +44389,55 @@ fn (tc &TypeChecker) generic_struct_field_unknown_type_message(struct_name strin
 				return diagnostic.msg
 			}
 		}
-		if unknown_name := tc.first_unknown_type_name(field.typ) {
+		if unknown_name := tc.first_unknown_type_name_in_scope(field.typ, decl_file, decl_module) {
 			return tc.unknown_type_message(unknown_name, field_id)
 		}
 	}
 	return none
 }
 
-fn (tc &TypeChecker) first_unknown_type_name(raw string) ?string {
+fn (tc &TypeChecker) first_unknown_type_name_in_scope(raw string, file string, mod_name string) ?string {
 	clean := trimmed_space(raw)
 	if clean.len == 0 {
 		return none
 	}
 	for prefix in ['?', '!', '&', '[]', 'shared ', 'mut '] {
 		if clean.starts_with(prefix) {
-			return tc.first_unknown_type_name(clean[prefix.len..])
+			return tc.first_unknown_type_name_in_scope(clean[prefix.len..], file, mod_name)
 		}
 	}
 	base, args, is_generic := generic_type_application_parts(clean)
 	if is_generic {
-		if should_check_named_type(base) && !tc.type_name_known(base) {
+		if should_check_named_type(base) && !tc.type_name_known_in_scope(base, file, mod_name) {
 			return base
 		}
 		for arg in args {
-			if unknown := tc.first_unknown_type_name(arg) {
+			if unknown := tc.first_unknown_type_name_in_scope(arg, file, mod_name) {
 				return unknown
 			}
 		}
 		return none
 	}
-	if should_check_named_type(clean) && !tc.type_name_known(clean) {
+	if should_check_named_type(clean) && !tc.type_name_known_in_scope(clean, file, mod_name) {
 		return clean
 	}
 	return none
+}
+
+fn (tc &TypeChecker) type_name_known_in_scope(name string, file string, mod_name string) bool {
+	if is_builtin_type_name(name) || name == 'unknown' || name.starts_with('C.') {
+		return true
+	}
+	if name.contains('.') {
+		return tc.type_symbol_known(tc.resolve_imported_type_text_in_file(name, file))
+	}
+	if mod_name !in ['', 'main', 'builtin'] && tc.type_symbol_known('${mod_name}.${name}') {
+		return true
+	}
+	if resolved := tc.resolve_selective_import_type_symbol_in_file(name, file) {
+		return tc.type_symbol_known(resolved)
+	}
+	return tc.type_symbol_known(name)
 }
 
 fn struct_field_has_attr(field flat.Node, name string) bool {
@@ -50910,7 +50930,7 @@ fn (tc &TypeChecker) method_signature_compatible(actual_key string, expected_key
 	}
 	actual_ret := tc.fn_ret_types[actual_key] or { Type(void_) }
 	expected_ret := tc.fn_ret_types[expected_key] or { Type(void_) }
-	return actual_ret.name() == expected_ret.name()
+	return tc.method_param_signature_compatible(actual_ret, expected_ret)
 }
 
 fn (tc &TypeChecker) method_call_info_signature_compatible(actual CallInfo, expected_key string) bool {
@@ -50924,7 +50944,7 @@ fn (tc &TypeChecker) method_call_info_signature_compatible(actual CallInfo, expe
 		}
 	}
 	expected_ret := tc.fn_ret_types[expected_key] or { Type(void_) }
-	return actual.return_type.name() == expected_ret.name()
+	return tc.method_param_signature_compatible(actual.return_type, expected_ret)
 }
 
 fn (tc &TypeChecker) method_param_signature_compatible(actual Type, expected Type) bool {

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -6869,10 +6869,15 @@ fn unsupported_backend_error(a &flat.FlatAst, tc &types.TypeChecker, used_fns ma
 		if !transformed_fn_is_used(node.value, module_name, used_fns) {
 			continue
 		}
+		root_file := a.specialized_fn_files[idx] or { cur_file }
 		root_ids << flat.NodeId(idx)
 		root_modules << module_name
-		root_files << (a.specialized_fn_files[idx] or { cur_file })
-		if msg := unsupported_backend_node_error(a, flat.NodeId(idx), backend, mut visited) {
+		root_files << root_file
+		diagnose_aggregates := tc.diagnostic_files.len == 0 || root_file in tc.diagnostic_files
+		fallback_location := backend_node_location(a, node)
+		if msg := unsupported_backend_node_error(a, tc, flat.NodeId(idx), backend,
+			diagnose_aggregates, fallback_location, mut visited)
+		{
 			return msg
 		}
 	}
@@ -6901,7 +6906,12 @@ fn unsupported_backend_error(a &flat.FlatAst, tc &types.TypeChecker, used_fns ma
 				root_ids << a.child(field, 0)
 				root_modules << cur_module
 				root_files << cur_file
-				if msg := unsupported_backend_node_error(a, a.child(field, 0), backend, mut visited) {
+				diagnose_aggregates := tc.diagnostic_files.len == 0
+					|| cur_file in tc.diagnostic_files
+				fallback_location := backend_node_location(a, *field)
+				if msg := unsupported_backend_node_error(a, tc, a.child(field, 0), backend,
+					diagnose_aggregates, fallback_location, mut visited)
+				{
 					return msg
 				}
 			}
@@ -6915,27 +6925,66 @@ fn unsupported_backend_error(a &flat.FlatAst, tc &types.TypeChecker, used_fns ma
 				root_ids << expr_id
 				root_modules << cur_module
 				root_files << cur_file
-				if msg := unsupported_backend_node_error(a, expr_id, backend, mut visited) {
+				diagnose_aggregates := tc.diagnostic_files.len == 0
+					|| cur_file in tc.diagnostic_files
+				fallback_location := backend_node_location(a, *field)
+				if msg := unsupported_backend_node_error(a, tc, expr_id, backend,
+					diagnose_aggregates, fallback_location, mut visited)
+				{
 					return msg
 				}
 			}
 		}
 	}
 	for expr_id in markused.reachable_const_exprs(a, tc, root_ids, root_modules, root_files) {
-		if msg := unsupported_backend_node_error(a, expr_id, backend, mut visited) {
+		mut diagnose_aggregates := false
+		if source_file := a.source_files[a.node(expr_id).pos.id] {
+			diagnose_aggregates = tc.diagnostic_files.len == 0
+				|| source_file.name in tc.diagnostic_files
+		}
+		fallback_location := backend_node_location(a, *a.node(expr_id))
+		if msg := unsupported_backend_node_error(a, tc, expr_id, backend, diagnose_aggregates,
+			fallback_location, mut visited)
+		{
 			return msg
 		}
 	}
 	return none
 }
 
-fn unsupported_backend_node_error(a &flat.FlatAst, id flat.NodeId, backend string, mut visited []bool) ?string {
+fn backend_node_location(a &flat.FlatAst, node flat.Node) string {
+	if source_pos := a.source_position(node.pos) {
+		return '${source_pos}: '
+	}
+	return ''
+}
+
+fn unsupported_backend_node_error(a &flat.FlatAst, tc &types.TypeChecker, id flat.NodeId, backend string, diagnose_aggregates bool, fallback_location string, mut visited []bool) ?string {
 	idx := int(id)
 	if idx < 0 || idx >= a.nodes.len || visited[idx] {
 		return none
 	}
 	visited[idx] = true
 	node := a.nodes[idx]
+	if backend == 'wasm' && diagnose_aggregates {
+		mut unsupported_type := ''
+		if node.kind in [.array_literal, .array_init, .map_init, .struct_init] {
+			unsupported_type = tc.resolve_type(id).name()
+		} else if node.kind == .call && node.children_count > 0 {
+			callee := a.child_node(&node, 0)
+			if callee.kind == .ident && callee.value == 'new_map' {
+				unsupported_type = tc.resolve_type(id).name()
+			}
+		}
+		if unsupported_type.len > 0 {
+			location := if source_pos := a.source_position(node.pos) {
+				'${source_pos}: '
+			} else {
+				fallback_location
+			}
+			return '${location}error: the V3 wasm backend does not support type `${unsupported_type}` yet'
+		}
+	}
 	op := match node.op {
 		.power { '**' }
 		.power_assign { '**=' }
@@ -6945,7 +6994,7 @@ fn unsupported_backend_node_error(a &flat.FlatAst, id flat.NodeId, backend strin
 		location := if source_pos := a.source_position(node.pos) {
 			'${source_pos}: '
 		} else {
-			''
+			fallback_location
 		}
 		return '${location}error: operator `${op}` is not supported by the V3 ${backend} backend'
 	}
@@ -6953,12 +7002,14 @@ fn unsupported_backend_node_error(a &flat.FlatAst, id flat.NodeId, backend strin
 		location := if source_pos := a.source_position(node.pos) {
 			'${source_pos}: '
 		} else {
-			''
+			fallback_location
 		}
 		return '${location}error: `$res()` is not supported by the V3 ${backend} backend'
 	}
 	for i in 0 .. node.children_count {
-		if msg := unsupported_backend_node_error(a, a.child(&node, i), backend, mut visited) {
+		if msg := unsupported_backend_node_error(a, tc, a.child(&node, i), backend,
+			diagnose_aggregates, fallback_location, mut visited)
+		{
 			return msg
 		}
 	}


### PR DESCRIPTION
## Summary

- make interface method signatures compare full alias chains in both compilers while preserving nominal option/result aliases, and resolve V3 generic struct fields in their declaring module
- remove parallel C generation reads from the mutable type-name map and emit cached fixed-array globals as declarations only
- replace unsupported wasm-type panics with source-located diagnostics in V and V3, and keep undefined match variants from reaching C generation

## Tests

- `./vnew -silent vlib/v/compiler_errors_test.v`
- `./vnew -silent test vlib/v/checker/`
- `./vnew -silent vlib/v/slow_tests/inout/compiler_test.v`
- `./vnew -silent vlib/v/gen/c/coutput_test.v`
- focused parallel-cgen, usecache, V1 wasm, V3 wasm, and V3 alias-authority tests
- clang `-usecache` hello-world reproduction
- `./vnew -silent test vlib/v/`: 2314 passed, 24 skipped; the corrected wasm assertion passes separately, while three unrelated local failures remain in Expect debugger startup, ANSI-normalized builder output, and VLS JSON coloring

Fixes #27749
Fixes #27725
Fixes #27592
Fixes #27451
Fixes #26972