### PR TITLE
checker: fix option-wrapped function alias returns

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -524,13 +524,17 @@ fn (t &Table) method_fn_return_types_are_compatible(left Type, right Type) bool 
 	if unaliased_left.nr_muls() != unaliased_right.nr_muls() {
 		return false
 	}
-	if (unaliased_left.has_option_or_result() || unaliased_right.has_option_or_result())
-		&& unaliased_left.flags() != unaliased_right.flags() {
+	has_wrapper := unaliased_left.has_option_or_result() || unaliased_right.has_option_or_result()
+	if has_wrapper && unaliased_left.flags() != unaliased_right.flags() {
 		return false
 	}
 	left_sym := t.sym(unaliased_left)
 	right_sym := t.sym(unaliased_right)
 	if left_sym.info is FnType && right_sym.info is FnType {
+		if has_wrapper
+			&& t.fn_type_signature(left_sym.info.func) != t.fn_type_signature(right_sym.info.func) {
+			return false
+		}
 		return t.fn_types_are_compatible(left_sym.info.func, right_sym.info.func, 0)
 	}
 	return false

--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -518,20 +518,28 @@ fn (t &Table) method_types_are_equal(left Type, right Type) bool {
 	return unaliased_left == unaliased_right
 }
 
+fn (t &Table) method_fn_return_types_are_compatible(left Type, right Type) bool {
+	unaliased_left := t.fully_unaliased_type(left)
+	unaliased_right := t.fully_unaliased_type(right)
+	if unaliased_left.nr_muls() != unaliased_right.nr_muls() {
+		return false
+	}
+	if (unaliased_left.has_option_or_result() || unaliased_right.has_option_or_result())
+		&& unaliased_left.flags() != unaliased_right.flags() {
+		return false
+	}
+	left_sym := t.sym(unaliased_left)
+	right_sym := t.sym(unaliased_right)
+	if left_sym.info is FnType && right_sym.info is FnType {
+		return t.fn_types_are_compatible(left_sym.info.func, right_sym.info.func, 0)
+	}
+	return false
+}
+
 pub fn (t &Table) is_same_method(f &Fn, func &Fn) string {
 	mut same_return_type := t.method_types_are_equal(f.return_type, func.return_type)
 	if !same_return_type {
-		f_return_type := t.fully_unaliased_type(f.return_type)
-		func_return_type := t.fully_unaliased_type(func.return_type)
-		if !f_return_type.has_option_or_result() && !func_return_type.has_option_or_result()
-			&& f_return_type.nr_muls() == func_return_type.nr_muls() {
-			f_return_sym := t.sym(f_return_type)
-			func_return_sym := t.sym(func_return_type)
-			if f_return_sym.info is FnType && func_return_sym.info is FnType {
-				same_return_type = t.fn_types_are_compatible(f_return_sym.info.func,
-					func_return_sym.info.func, 0)
-			}
-		}
+		same_return_type = t.method_fn_return_types_are_compatible(f.return_type, func.return_type)
 	}
 	if !same_return_type {
 		s := t.type_to_str(f.return_type)

--- a/vlib/v/checker/tests/interface_method_option_fn_component_alias_mismatch_err.out
+++ b/vlib/v/checker/tests/interface_method_option_fn_component_alias_mismatch_err.out
@@ -1,0 +1,16 @@
+vlib/v/checker/tests/interface_method_option_fn_component_alias_mismatch_err.vv:20:10: error: `OptionalPlainCalc` incorrectly implements method `get_operation` of interface `OptionalAliasedCalculator`: expected return type `?fn (MyInt, MyInt) MyInt`
+   18 |
+   19 | fn main() {
+   20 |     calc := OptionalAliasedCalculator(OptionalPlainCalc{})
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   21 |     operation := calc.get_operation() or { panic('missing operation') }
+   22 |     assert operation(2, 3) == 5
+Details: main.OptionalAliasedCalculator has `fn get_operation(x main.OptionalAliasedCalculator) ?fn (main.MyInt, main.MyInt) main.MyInt`
+         main.OptionalPlainCalc has `fn get_operation(_ main.OptionalPlainCalc) ?fn (int, int) int`
+vlib/v/checker/tests/interface_method_option_fn_component_alias_mismatch_err.vv:20:10: error: `OptionalPlainCalc` does not implement interface `OptionalAliasedCalculator`, cannot cast `OptionalPlainCalc` to interface `OptionalAliasedCalculator`
+   18 |
+   19 | fn main() {
+   20 |     calc := OptionalAliasedCalculator(OptionalPlainCalc{})
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   21 |     operation := calc.get_operation() or { panic('missing operation') }
+   22 |     assert operation(2, 3) == 5

--- a/vlib/v/checker/tests/interface_method_option_fn_component_alias_mismatch_err.vv
+++ b/vlib/v/checker/tests/interface_method_option_fn_component_alias_mismatch_err.vv
@@ -1,0 +1,23 @@
+type MyInt = int
+
+type MathOp = fn (int, int) int
+
+type AliasedMathOp = fn (MyInt, MyInt) MyInt
+
+interface OptionalAliasedCalculator {
+	get_operation() ?AliasedMathOp
+}
+
+struct OptionalPlainCalc {}
+
+fn (_ OptionalPlainCalc) get_operation() ?MathOp {
+	return fn (a int, b int) int {
+		return a + b
+	}
+}
+
+fn main() {
+	calc := OptionalAliasedCalculator(OptionalPlainCalc{})
+	operation := calc.get_operation() or { panic('missing operation') }
+	assert operation(2, 3) == 5
+}

--- a/vlib/v/tests/interfaces/interface_method_fn_type_alias_return_test.v
+++ b/vlib/v/tests/interfaces/interface_method_fn_type_alias_return_test.v
@@ -28,6 +28,10 @@ interface FactoryCalculator {
 	get_factory() MathFactory
 }
 
+interface OptionalCalculator {
+	get_operation() ?MathOp
+}
+
 struct SimpleCalc {}
 
 fn (s SimpleCalc) get_operation() MathOp {
@@ -75,6 +79,15 @@ fn (c CdeclFactoryCalc) get_factory() CdeclMathFactory {
 	}
 }
 
+struct OptionalSimpleCalc {}
+
+fn (c OptionalSimpleCalc) get_operation() ?MathOp {
+	_ = c
+	return fn (a int, b int) int {
+		return a + b
+	}
+}
+
 fn test_interface_method_fn_type_alias_return() {
 	calc := Calculator(SimpleCalc{})
 	operation := calc.get_operation()
@@ -102,4 +115,10 @@ fn test_interface_method_nested_fn_type_alias_omitted_callconv_matches_cdecl() {
 	factory := calc.get_factory()
 	operation := factory()
 	assert operation(12, 3) == 4
+}
+
+fn test_interface_method_option_fn_type_alias_return() {
+	calc := OptionalCalculator(OptionalSimpleCalc{})
+	operation := calc.get_operation() or { panic('missing operation') }
+	assert operation(2, 3) == 5
 }

--- a/vlib/v/tests/interfaces/interface_method_fn_type_alias_return_test.v
+++ b/vlib/v/tests/interfaces/interface_method_fn_type_alias_return_test.v
@@ -1,5 +1,7 @@
 type MathOp = fn (int, int) int
 
+type EquivalentMathOp = fn (int, int) int
+
 type MyInt = int
 
 type AliasedMathOp = fn (MyInt, MyInt) MyInt
@@ -81,7 +83,7 @@ fn (c CdeclFactoryCalc) get_factory() CdeclMathFactory {
 
 struct OptionalSimpleCalc {}
 
-fn (c OptionalSimpleCalc) get_operation() ?MathOp {
+fn (c OptionalSimpleCalc) get_operation() ?EquivalentMathOp {
 	_ = c
 	return fn (a int, b int) int {
 		return a + b

--- a/vlib/v3/tests/interface_return_alias_compatibility_test.v
+++ b/vlib/v3/tests/interface_return_alias_compatibility_test.v
@@ -34,6 +34,21 @@ fn test_interface_method_return_only_accepts_alias_equivalence() {
 	assert alias_run.exit_code == 0, alias_run.output
 	assert alias_run.output.trim_space() == '42', alias_run.output
 
+	wrapped_fn_compile := compile_interface_return(v3_bin, 'wrapped_fn_alias',
+		'type MathOp = fn (int, int) int\n\ninterface Calculator {\n\tget_operation() ?MathOp\n}\n\nstruct SimpleCalc {}\n\nfn (s SimpleCalc) get_operation() ?MathOp {\n\treturn fn (a int, b int) int {\n\t\treturn a + b\n\t}\n}\n\nfn main() {\n\tcalc := Calculator(SimpleCalc{})\n\toperation := calc.get_operation() or { panic("missing operation") }\n\tprintln(operation(2, 3))\n}\n')
+	assert wrapped_fn_compile.exit_code == 0, wrapped_fn_compile.output
+	wrapped_fn_bin := os.join_path(os.temp_dir(),
+		'v3_interface_return_wrapped_fn_alias_${os.getpid()}')
+	wrapped_fn_run := os.execute(os.quoted_path(wrapped_fn_bin))
+	assert wrapped_fn_run.exit_code == 0, wrapped_fn_run.output
+	assert wrapped_fn_run.output.trim_space() == '5', wrapped_fn_run.output
+
+	wrapped_component_alias_compile := compile_interface_return(v3_bin,
+		'wrapped_fn_component_alias',
+		'type MyInt = int\n\ntype MathOp = fn (int, int) int\n\ntype AliasedMathOp = fn (MyInt, MyInt) MyInt\n\ninterface Calculator {\n\tget_operation() ?AliasedMathOp\n}\n\nstruct SimpleCalc {}\n\nfn (s SimpleCalc) get_operation() ?MathOp {\n\treturn fn (a int, b int) int {\n\t\treturn a + b\n\t}\n}\n\nfn main() {\n\t_ := Calculator(SimpleCalc{})\n}\n')
+	assert wrapped_component_alias_compile.exit_code != 0, wrapped_component_alias_compile.output
+	assert wrapped_component_alias_compile.output.contains('expected return type `?AliasedMathOp`'), wrapped_component_alias_compile.output
+
 	int_compile := compile_interface_return(v3_bin, 'integer_conversion',
 		'interface Provider {\n\tvalue() int\n}\n\nstruct WideValue {}\n\nfn (w WideValue) value() i64 {\n\treturn 42\n}\n\nfn main() {\n\t_ := Provider(WideValue{})\n}\n')
 	assert int_compile.exit_code != 0, int_compile.output

--- a/vlib/v3/tests/interface_return_alias_compatibility_test.v
+++ b/vlib/v3/tests/interface_return_alias_compatibility_test.v
@@ -35,7 +35,7 @@ fn test_interface_method_return_only_accepts_alias_equivalence() {
 	assert alias_run.output.trim_space() == '42', alias_run.output
 
 	wrapped_fn_compile := compile_interface_return(v3_bin, 'wrapped_fn_alias',
-		'type MathOp = fn (int, int) int\n\ninterface Calculator {\n\tget_operation() ?MathOp\n}\n\nstruct SimpleCalc {}\n\nfn (s SimpleCalc) get_operation() ?MathOp {\n\treturn fn (a int, b int) int {\n\t\treturn a + b\n\t}\n}\n\nfn main() {\n\tcalc := Calculator(SimpleCalc{})\n\toperation := calc.get_operation() or { panic("missing operation") }\n\tprintln(operation(2, 3))\n}\n')
+		'type MathOp = fn (int, int) int\n\ntype EquivalentMathOp = fn (int, int) int\n\ninterface Calculator {\n\tget_operation() ?MathOp\n}\n\nstruct SimpleCalc {}\n\nfn (s SimpleCalc) get_operation() ?EquivalentMathOp {\n\treturn fn (a int, b int) int {\n\t\treturn a + b\n\t}\n}\n\nfn main() {\n\tcalc := Calculator(SimpleCalc{})\n\toperation := calc.get_operation() or { panic("missing operation") }\n\tprintln(operation(2, 3))\n}\n')
 	assert wrapped_fn_compile.exit_code == 0, wrapped_fn_compile.output
 	wrapped_fn_bin := os.join_path(os.temp_dir(),
 		'v3_interface_return_wrapped_fn_alias_${os.getpid()}')

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -8767,6 +8767,9 @@ fn (mut t Transformer) transform_return_child(child_id flat.NodeId, child_index 
 		if t.is_error_call(child) {
 			return t.transform_expr(return_child_id)
 		}
+		if child.kind in [.lambda_expr, .fn_literal] {
+			return t.transform_expr_for_type(return_child_id, target_type)
+		}
 		if child.kind == .or_expr {
 			return t.transform_expr_for_type(return_child_id, target_type)
 		}

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -50948,7 +50948,29 @@ fn (tc &TypeChecker) method_call_info_signature_compatible(actual CallInfo, expe
 }
 
 fn method_return_signature_compatible(actual Type, expected Type) bool {
-	return fn_return_canonical_type_name(actual) == fn_return_canonical_type_name(expected)
+	if fn_return_canonical_type_name(actual) == fn_return_canonical_type_name(expected) {
+		return true
+	}
+	actual_unaliased := unalias_type(actual)
+	expected_unaliased := unalias_type(expected)
+	if actual_unaliased is OptionType && expected_unaliased is OptionType {
+		return method_wrapped_fn_return_signature_compatible(actual_unaliased.base_type,
+			expected_unaliased.base_type)
+	}
+	if actual_unaliased is ResultType && expected_unaliased is ResultType {
+		return method_wrapped_fn_return_signature_compatible(actual_unaliased.base_type,
+			expected_unaliased.base_type)
+	}
+	return false
+}
+
+fn method_wrapped_fn_return_signature_compatible(actual Type, expected Type) bool {
+	actual_unaliased := unalias_type(actual)
+	expected_unaliased := unalias_type(expected)
+	if actual_unaliased is FnType && expected_unaliased is FnType {
+		return Type(actual_unaliased).name() == Type(expected_unaliased).name()
+	}
+	return false
 }
 
 fn (tc &TypeChecker) method_param_signature_compatible(actual Type, expected Type) bool {


### PR DESCRIPTION
## Summary
- compare separately materialized function alias return types under matching Option/Result wrappers
- keep wrapped compatibility limited to identical function signatures so V1 C wrapper structs stay ABI-compatible
- cover V3 wrapped-return matching and preserve function-literal payloads in valid optional alias returns

## Tests
- `./vnew vlib/v/tests/interfaces/interface_method_fn_type_alias_return_test.v`
- `./vnew -silent test vlib/v/tests/interfaces/`
- `./vnew -silent test vlib/v/checker/`
- `./vnew -silent vlib/v/compiler_errors_test.v`
- `./vnew vlib/v3/tests/interface_return_alias_compatibility_test.v`
- `./vnew -silent test vlib/v3/transform/`
- generated V3 C compiled with Clang using `-Werror=incompatible-function-pointer-types` and ran successfully
- `./vnew -silent test vlib/v/` (stopped at 1735/2342; two pre-existing environment-sensitive failures observed)

Fixes #27965