### PR TITLE
ci: preserve tccbin workflows during rebuilds

### DIFF
--- a/.github/workflows/update_tccbin.yml
+++ b/.github/workflows/update_tccbin.yml
@@ -55,6 +55,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      - name: Test tccbin workflow preservation
+        if: matrix.id == 'linux-amd64'
+        run: bash thirdparty/build_scripts/tccbin_workflow_preservation_test.sh
+
       - name: Install macOS build dependencies
         if: runner.os == 'macOS'
         run: brew install make
@@ -80,6 +84,7 @@ jobs:
           echo "TinyCC $TCC_COMMIT resolves to $hash"
 
       - name: Clone tccbin branch
+        id: tccbin
         shell: bash
         env:
           TCCBIN_TOKEN: ${{ secrets.VLANG_BOT_SECRET }}
@@ -87,6 +92,8 @@ jobs:
           set -euo pipefail
           git clone --branch "${{ matrix.branch }}" --depth=1 \
             "https://github.com/${TCCBIN_REPO}.git" thirdparty/tcc
+          echo "base_commit=$(git -C thirdparty/tcc rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "workflow_tree=$(git -C thirdparty/tcc rev-parse HEAD:.github/workflows)" >> "$GITHUB_OUTPUT"
           if [ "$PUBLISH" = 'true' ]; then
             if [ -z "$TCCBIN_TOKEN" ]; then
               echo "::error::VLANG_BOT_SECRET is required to publish to ${TCCBIN_REPO}"
@@ -138,6 +145,17 @@ jobs:
           EOF
           thirdparty/tcc/tcc.exe /tmp/tcc-stdatomic-smoke.c -o /tmp/tcc-stdatomic-smoke
           /tmp/tcc-stdatomic-smoke
+
+      - name: Verify tccbin workflows were preserved
+        if: steps.rebuild.outputs.skip != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -d thirdparty/tcc/.github/workflows
+          test -n "$(find thirdparty/tcc/.github/workflows -type f -print)"
+          test "$(git -C thirdparty/tcc rev-parse HEAD:.github/workflows)" = "${{ steps.tccbin.outputs.workflow_tree }}"
+          git -C thirdparty/tcc diff --exit-code \
+            "${{ steps.tccbin.outputs.base_commit }}" HEAD -- .github/workflows
 
       - name: Upload TCC bundle artifact
         if: steps.rebuild.outputs.skip != 'true'
@@ -218,6 +236,8 @@ jobs:
 
           git clone --branch "${{ matrix.branch }}" --depth=1 \
             "https://github.com/${TCCBIN_REPO}.git" thirdparty/tcc
+          tccbin_base_commit="$(git -C thirdparty/tcc rev-parse HEAD)"
+          tccbin_workflow_tree="$(git -C thirdparty/tcc rev-parse HEAD:.github/workflows)"
           if [ "$PUBLISH" = 'true' ]; then
             if [ -z "$TCCBIN_TOKEN" ]; then
               echo "VLANG_BOT_SECRET is required to publish to ${TCCBIN_REPO}" >&2
@@ -249,6 +269,12 @@ jobs:
           EOF
           thirdparty/tcc/tcc.exe /tmp/tcc-stdatomic-smoke.c -o /tmp/tcc-stdatomic-smoke
           /tmp/tcc-stdatomic-smoke
+
+          test -d thirdparty/tcc/.github/workflows
+          test -n "$(find thirdparty/tcc/.github/workflows -type f -print)"
+          test "$(git -C thirdparty/tcc rev-parse HEAD:.github/workflows)" = "$tccbin_workflow_tree"
+          git -C thirdparty/tcc diff --exit-code \
+            "$tccbin_base_commit" HEAD -- .github/workflows
 
           if [ "$PUBLISH" = 'true' ]; then
             git -C thirdparty/tcc push origin HEAD:${{ matrix.branch }}

--- a/thirdparty/build_scripts/tccbin_workflow_preservation_test.sh
+++ b/thirdparty/build_scripts/tccbin_workflow_preservation_test.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+
+for script in \
+  thirdparty-linux-amd64_tcc.sh \
+  thirdparty-freebsd-amd64_tcc.sh \
+  thirdparty-openbsd-amd64_tcc.sh
+do
+  script_path="$script_dir/$script"
+  test "$(grep -Fc 'rsync -a --delete' "$script_path")" -eq 1
+  grep -Fq -- "rsync -a --delete --exclude='/.github/' tinycc/\$TCC_FOLDER/" "$script_path"
+done
+
+test_root="$(mktemp -d)"
+trap 'rm -rf "$test_root"' EXIT
+
+source_dir="$test_root/tinycc/thirdparty/tcc"
+target_dir="$test_root/thirdparty/tcc"
+mkdir -p "$source_dir" "$target_dir/.github/workflows"
+printf 'fresh\n' > "$source_dir/fresh.txt"
+printf 'obsolete\n' > "$target_dir/obsolete.txt"
+printf 'sentinel:\n  preserved: true\n' > "$test_root/sentinel.yml"
+cp "$test_root/sentinel.yml" "$target_dir/.github/workflows/sentinel.yml"
+
+rsync -a --delete --exclude='/.github/' "$source_dir/" "$target_dir/"
+
+test "$(cat "$target_dir/fresh.txt")" = fresh
+test ! -e "$target_dir/obsolete.txt"
+cmp -s "$test_root/sentinel.yml" "$target_dir/.github/workflows/sentinel.yml"

--- a/thirdparty/build_scripts/thirdparty-freebsd-amd64_tcc.sh
+++ b/thirdparty/build_scripts/thirdparty-freebsd-amd64_tcc.sh
@@ -73,7 +73,7 @@ gmake install
 
 popd
 
-rsync -a --delete tinycc/$TCC_FOLDER/                 $TCC_FOLDER/
+rsync -a --delete --exclude='/.github/' tinycc/$TCC_FOLDER/                 $TCC_FOLDER/
 rsync -a          thirdparty/tcc.original/.git/       $TCC_FOLDER/.git/
 rsync -a          thirdparty/tcc.original/lib/libgc*  $TCC_FOLDER/lib/
 rsync -a          thirdparty/tcc.original/lib/build*  $TCC_FOLDER/lib/

--- a/thirdparty/build_scripts/thirdparty-linux-amd64_tcc.sh
+++ b/thirdparty/build_scripts/thirdparty-linux-amd64_tcc.sh
@@ -74,7 +74,7 @@ make install
 
 popd
 
-rsync -a --delete tinycc/$TCC_FOLDER/                 $TCC_FOLDER/
+rsync -a --delete --exclude='/.github/' tinycc/$TCC_FOLDER/                 $TCC_FOLDER/
 rsync -a          thirdparty/tcc.original/.git/       $TCC_FOLDER/.git/
 rsync -a          thirdparty/tcc.original/lib/libgc*  $TCC_FOLDER/lib/
 rsync -a          thirdparty/tcc.original/lib/build*  $TCC_FOLDER/lib/

--- a/thirdparty/build_scripts/thirdparty-openbsd-amd64_tcc.sh
+++ b/thirdparty/build_scripts/thirdparty-openbsd-amd64_tcc.sh
@@ -70,7 +70,7 @@ gmake install
 
 popd
 
-rsync -a --delete tinycc/$TCC_FOLDER/                 $TCC_FOLDER/
+rsync -a --delete --exclude='/.github/' tinycc/$TCC_FOLDER/                 $TCC_FOLDER/
 rsync -a          thirdparty/tcc.original/.git/       $TCC_FOLDER/.git/
 # rsync -a          thirdparty/tcc.original/lib/libgc*  $TCC_FOLDER/lib/
 # rsync -a          thirdparty/tcc.original/lib/build*  $TCC_FOLDER/lib/


### PR DESCRIPTION
## Summary

Preserve tccbin workflows during Linux, FreeBSD, and OpenBSD rebuilds, and block publication if they are modified or removed.

## Root cause

The rebuild scripts used rsync --delete, which treated the branch-local .github directory as obsolete generated content. On Linux, this deleted the workflow and prevented GitHub from starting CI.

## Validation

A regression test confirms that workflows are preserved while obsolete TCC files are still deleted. macOS, Windows, binaries, and public APIs remain unchanged.