### PR TITLE
builtin: preserve prealloc recycling on fresh workers

### DIFF
--- a/vlib/builtin/prealloc.c.v
+++ b/vlib/builtin/prealloc.c.v
@@ -494,6 +494,41 @@ fn vmemory_block_free_chain(first &VMemoryBlock) {
 	}
 }
 
+@[unsafe]
+fn prealloc_recycle_cache_free(cache &VPreallocBlockCache) {
+	if cache == unsafe { nil } {
+		return
+	}
+	$if !windows && !freestanding && !vinix {
+		unsafe {
+			for i in 0 .. cache.count {
+				C.munmap(cache.starts[i], usize(cache.sizes[i]))
+			}
+		}
+	}
+	unsafe {
+		C.free(cache)
+	}
+}
+
+// prealloc_thread_cleanup releases the current thread's arena and recycle
+// cache. Generated wrappers call it after void-returning spawned work.
+@[unsafe]
+pub fn prealloc_thread_cleanup() {
+	unsafe {
+		mut cache := &VPreallocBlockCache(nil)
+		if g_memory_block != nil {
+			cache = g_memory_block.recycle_cache
+		}
+		for g_memory_block != nil {
+			block := g_memory_block
+			g_memory_block = g_memory_block.previous
+			vmemory_block_free(block)
+		}
+		prealloc_recycle_cache_free(cache)
+	}
+}
+
 /////////////////////////////////////////////////
 
 @[unsafe]
@@ -577,11 +612,7 @@ fn prealloc_vcleanup() {
 		}
 	}
 	unsafe {
-		for g_memory_block != 0 {
-			tmp := g_memory_block
-			g_memory_block = g_memory_block.previous
-			vmemory_block_free(tmp)
-		}
+		prealloc_thread_cleanup()
 	}
 }
 

--- a/vlib/builtin/prealloc.c.v
+++ b/vlib/builtin/prealloc.c.v
@@ -339,6 +339,23 @@ fn vmemory_block_new_sized(prev &VMemoryBlock, at_least isize, align isize, min_
 	return v
 }
 
+@[inline; unsafe]
+fn vmemory_block_current_or_new() &VMemoryBlock {
+	unsafe {
+		// The current block is thread-local. Fresh workers need a base arena
+		// even when their first operation is a scoped allocation, so scope
+		// blocks have a per-thread recycle cache after the scope is detached.
+		mut mb := g_memory_block
+		if _unlikely_(mb == nil) {
+			mb = vmemory_block_new(nil, isize(prealloc_block_size), 0)
+			mb.recycle_cache = &VPreallocBlockCache(C.calloc(1, sizeof(VPreallocBlockCache)))
+			vmemory_abort_on_nil(mb.recycle_cache, sizeof(VPreallocBlockCache))
+			g_memory_block = mb
+		}
+		return mb
+	}
+}
+
 @[unsafe]
 fn vmemory_block_malloc(n isize, align isize) &u8 {
 	unsafe {
@@ -346,16 +363,7 @@ fn vmemory_block_malloc(n isize, align isize) &u8 {
 		// which block is current, and the bump updates go through the block
 		// itself. Thread-local access can be a library call (cc -O0 TLS,
 		// pthread-key emulation), so the fast path must not repeat it.
-		mut mb := g_memory_block
-		if _unlikely_(mb == nil) {
-			// Lazy per-thread initialization: when g_memory_block is
-			// thread-local, new threads start with a null pointer and need
-			// their own arena.
-			mb = vmemory_block_new(nil, isize(prealloc_block_size), 0)
-			mb.recycle_cache = &VPreallocBlockCache(C.calloc(1, sizeof(VPreallocBlockCache)))
-			vmemory_abort_on_nil(mb.recycle_cache, sizeof(VPreallocBlockCache))
-			g_memory_block = mb
-		}
+		mut mb := vmemory_block_current_or_new()
 		$if prealloc_trace_malloc ? {
 			C.fprintf(C.stderr, c'vmemory_block_malloc g_memory_block.id: %d, n: %lld align: %d\n',
 				mb.id, n, align)
@@ -587,7 +595,7 @@ pub fn prealloc_scope_begin() voidptr {
 	unsafe {
 		scope := &VPreallocScope(C.calloc(1, sizeof(VPreallocScope)))
 		vmemory_abort_on_nil(scope, sizeof(VPreallocScope))
-		scope.previous = g_memory_block
+		scope.previous = vmemory_block_current_or_new()
 		scope.first = vmemory_block_new_sized(scope.previous, isize(prealloc_scope_block_size), 0,
 			isize(prealloc_scope_block_size))
 		scope.first.is_scope = true

--- a/vlib/builtin/prealloc_scope_ownership_test.v
+++ b/vlib/builtin/prealloc_scope_ownership_test.v
@@ -49,6 +49,10 @@ fn recycle_scopes_on_worker(worker_id int) int {
 				return -1
 			}
 		}
+		unsafe { prealloc_thread_cleanup() }
+		if unsafe { g_memory_block != nil } {
+			return -1
+		}
 	}
 	return worker_id
 }

--- a/vlib/builtin/prealloc_scope_ownership_test.v
+++ b/vlib/builtin/prealloc_scope_ownership_test.v
@@ -42,6 +42,9 @@ fn recycle_scopes_on_worker(worker_id int) int {
 			checksum := int(data[0]) + int(data[data.len - 1])
 			unsafe { prealloc_scope_leave(scope) }
 			unsafe { prealloc_scope_free_after(scope) }
+			if unsafe { g_memory_block == nil } {
+				return -1
+			}
 			if checksum != worker_id + int(u8(iteration)) {
 				return -1
 			}

--- a/vlib/sync/waitgroup_nix.c.v
+++ b/vlib/sync/waitgroup_nix.c.v
@@ -11,6 +11,7 @@ fn waitgroup_thread_entry(args_ptr voidptr) voidptr {
 		defer {
 			unsafe {
 				prealloc_scope_end(scope)
+				prealloc_thread_cleanup()
 			}
 		}
 	}

--- a/vlib/sync/waitgroup_windows.c.v
+++ b/vlib/sync/waitgroup_windows.c.v
@@ -11,6 +11,7 @@ fn waitgroup_thread_entry(args_ptr voidptr) u32 {
 		defer {
 			unsafe {
 				prealloc_scope_end(scope)
+				prealloc_thread_cleanup()
 			}
 		}
 	}

--- a/vlib/time/timer_nix.c.v
+++ b/vlib/time/timer_nix.c.v
@@ -11,6 +11,7 @@ fn timer_thread_entry(args_ptr voidptr) voidptr {
 		defer {
 			unsafe {
 				prealloc_scope_end(scope)
+				prealloc_thread_cleanup()
 			}
 		}
 	}

--- a/vlib/time/timer_windows.c.v
+++ b/vlib/time/timer_windows.c.v
@@ -11,6 +11,7 @@ fn timer_thread_entry(args_ptr voidptr) u32 {
 		defer {
 			unsafe {
 				prealloc_scope_end(scope)
+				prealloc_thread_cleanup()
 			}
 		}
 	}

--- a/vlib/v/gen/c/spawn_and_go.v
+++ b/vlib/v/gen/c/spawn_and_go.v
@@ -524,6 +524,9 @@ fn (mut g Gen) spawn_and_go_expr(node ast.SpawnExpr, mode SpawnGoMode) {
 				g.gowrappers.writeln('\tbuiltin___v_free(arg);')
 			}
 		}
+		if is_spawn && g.pref.prealloc && wrapper_return_type == ast.void_type {
+			g.gowrappers.writeln('\tbuiltin__prealloc_thread_cleanup();')
+		}
 		if g.pref.os != .windows && wrapper_return_type != ast.void_type {
 			g.gowrappers.writeln('\treturn ret_ptr;')
 		} else {

--- a/vlib/v/gen/c/thread_bool_wait_codegen_test.v
+++ b/vlib/v/gen/c/thread_bool_wait_codegen_test.v
@@ -44,6 +44,8 @@ fn test_prealloc_spawn_args_use_c_malloc() {
 	assert res.output.contains('builtin__prealloc_scope_end(thread_prealloc_scope);'), res.output
 	assert res.output.contains('builtin__prealloc_scope_release(arg->prealloc_scope);'), res.output
 	assert res.output.contains('free(arg);'), res.output
+	assert res.output.contains('builtin__prealloc_thread_cleanup();'), res.output
+	assert res.output.contains('builtin__prealloc_scope_release(arg->prealloc_scope);\n\tfree(arg);\n\tbuiltin__prealloc_thread_cleanup();'), res.output
 	assert !res.output.contains('builtin___v_malloc(sizeof(thread_arg_main__worker))'), res.output
 	assert res.output.contains('malloc(sizeof(int))'), res.output
 	assert res.output.contains('free(ret_ptr);'), res.output

--- a/vlib/v3/workers/worker_pool_nix.c.v
+++ b/vlib/v3/workers/worker_pool_nix.c.v
@@ -112,6 +112,11 @@ fn pool_worker(arg voidptr) voidptr {
 			worker_run_ns: if finished_at >= started_at { finished_at - started_at } else { 0 }
 		}
 	}
+	$if prealloc {
+		unsafe {
+			prealloc_thread_cleanup()
+		}
+	}
 	return unsafe { nil }
 }
 

--- a/vlib/v3/workers/worker_pool_test.v
+++ b/vlib/v3/workers/worker_pool_test.v
@@ -8,6 +8,14 @@ mut:
 }
 
 fn pool_test_task(arg voidptr) voidptr {
+	$if prealloc {
+		scope := unsafe { prealloc_scope_begin() }
+		defer {
+			unsafe {
+				prealloc_scope_end(scope)
+			}
+		}
+	}
 	mut a := unsafe { &PoolTestArg(arg) }
 	a.value++
 	return unsafe { nil }


### PR DESCRIPTION
Follow-up to #27943 and the [original review feedback](https://github.com/vlang/v/pull/27943#discussion_r3651981109).

A fresh spawned worker can enter `prealloc_scope_begin()` before making a normal prealloc allocation. In that case its thread-local `g_memory_block` is null, so the scope inherits no recycle cache and every detached scope is unmapped instead of recycled.

Factor lazy per-thread base-arena initialization into a shared helper and use it from both normal allocation and scope creation. Long-lived workers can therefore recycle mappings across repeated scopes. At the known thread-lifetime boundaries, void-returning `spawn` wrappers, detached wait-group and timer workers, and persistent V3 POSIX pool workers now drain the recycle cache and arena chain. Short-lived or closed workers therefore do not leave their 16 MiB base arena or cached mappings unreachable.

Validation:

- bootstrapped a temporary compiler from current master
- `./vreview -prealloc test vlib/builtin/prealloc_scope_ownership_test.v`
- `./vreview test vlib/v/gen/c/thread_bool_wait_codegen_test.v`
- `./vreview -prealloc test vlib/sync/waitgroup_test.v`
- `./vreview -prealloc test vlib/v/tests/concurrency/thread_array_test.v`
- `./vreview -silent vlib/v/compiler_errors_test.v` (1604 passed, 1 skipped)
- `./vreview -silent vlib/v/gen/c/coutput_test.v` (all output and must-have fixtures passed)
- `./vreview -silent test vlib/v/` (2318 passed, 24 skipped)
- `./v -o ./vnew cmd/v`
- `./vnew -prealloc test vlib/time/timer_test.v`
- `./vnew -prealloc -silent test vlib/time/` (19 passed)
- `./vnew test vlib/v3/workers/worker_pool_test.v`
- `./vnew -prealloc test vlib/v3/workers/worker_pool_test.v`
- `./vnew test -run-only test_prealloc_keeps_parallel_transform_enabled vlib/v3/tests/parallel_cgen_test.v`
- formatting and `git diff --check`

The full `parallel_cgen_test.v` currently reaches an unrelated non-prealloc fixture failure after its generated program succeeds: it then expects `/tmp/v3_parallel_user_main_test_file_out.c`, which was not emitted. The isolated parallel prealloc test passes.

`test-all` was not run.