### PR TITLE
v3: fix self-host OOM and five checker/cgen regressions blocking -building-v

### DIFF
--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -9218,6 +9218,23 @@ fn (mut g FlatGen) collect_fixed_storage_consts() {
 						}
 					}
 				}
+				// A const passed as a plain call argument (e.g. the lowered
+				// `array_get(const, i)` from a containment loop) needs dynamic
+				// array representation even when another use site aliases the
+				// same node as an index or `.len` base and marked it safe.
+				for ai in 1 .. node.children_count {
+					arg_id := g.a.child(node, ai)
+					arg_node := g.a.node(arg_id)
+					if g.const_ref_node_may_match_fixed_candidate(arg_node,
+						fixed_candidate_idents, fixed_candidate_shorts)
+					{
+						call_base_items << FixedStorageConstRefItem{
+							id:     arg_id
+							file:   cur_file
+							module: cur_module
+						}
+					}
+				}
 			}
 			.ident, .paren {
 				if g.const_ref_node_may_match_fixed_candidate(node, fixed_candidate_idents,

--- a/vlib/v3/transform/if.v
+++ b/vlib/v3/transform/if.v
@@ -973,15 +973,39 @@ fn (mut t Transformer) build_if_value_guard_chain(if_node flat.Node, target_name
 	t.drain_pending(mut result)
 	result << t.make_decl_assign_typed(tmp_name, rhs_expr, rhs_type)
 	ok_cond := t.make_selector(t.make_ident(tmp_name), 'ok', 'bool')
-	value_decl := t.make_decl_assign_typed(lhs.value, t.make_selector(t.make_ident(tmp_name),
-		'value', value_type), value_type)
-
+	// An if-guard condition stores the call at child 1 and any extra
+	// destructured names after it: [lhs0, rhs, lhs1, lhs2, ...].
+	mut lhs_ids := [lhs_id]
+	for i in 2 .. cond.children_count {
+		lhs_ids << t.a.child(&cond, i)
+	}
 	saved_var_types := t.var_types.clone()
-	t.set_var_type(lhs.value, value_type)
+	mut value_decls := []flat.NodeId{}
+	if lhs_ids.len > 1 {
+		if rhs_types := t.multi_return_types_for_expr(rhs_id, lhs_ids.len) {
+			for i, lhs_item_id in lhs_ids {
+				lhs_item := t.a.nodes[int(lhs_item_id)]
+				if lhs_item.kind != .ident || lhs_item.value == '_' {
+					continue
+				}
+				field_type := rhs_types[i].name()
+				payload := t.make_selector(t.make_ident(tmp_name), 'value', value_type)
+				field := t.make_selector(payload, 'arg${i}', field_type)
+				value_decls << t.make_decl_assign_typed(lhs_item.value, field, field_type)
+				t.set_var_type(lhs_item.value, field_type)
+			}
+		}
+	}
+	if value_decls.len == 0 {
+		value_decls << t.make_decl_assign_typed(lhs.value, t.make_selector(t.make_ident(tmp_name),
+			'value', value_type), value_type)
+		t.set_var_type(lhs.value, value_type)
+	}
 	then_id := t.a.child(&if_node, 1)
 	then_block0 := t.if_value_branch_block(then_id, target_name, target_type)
-	mut then_children := []flat.NodeId{cap: int(t.a.nodes[int(then_block0)].children_count) + 1}
-	then_children << value_decl
+	mut then_children := []flat.NodeId{cap: int(t.a.nodes[int(then_block0)].children_count) +
+		value_decls.len}
+	then_children << value_decls
 	then_children << t.a.children_of(&t.a.nodes[int(then_block0)])
 	then_block := t.make_block_prefix_scope_drops(then_children)
 	t.restore_var_types(saved_var_types)

--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -737,10 +737,61 @@ pub fn erase_generic_templates(mut a flat.FlatAst, tc &types.TypeChecker, used_f
 			}
 			erased[key] = decl
 		}
+		t.erase_consts_initialized_by_erased_templates(decls)
 		t.erase_generic_fn_decls(erased)
 		t.timing_profile('  [ttime]   erase apply           ${f64(sw.elapsed().microseconds()) / 1000.0:7.2f} ms (erased: ${decls.len - keep.len})')
 	}
 	return t.used_fns
+}
+
+// erase_consts_initialized_by_erased_templates empties const initializers that
+// call a generic template. A building-v compile erases those templates instead
+// of monomorphizing them, so a surviving initializer call would reference a
+// function that no longer exists in the generated C. The V compiler itself
+// never reads such consts; an accidental new use fails loudly as an unknown
+// identifier in C rather than silently reading zeroed storage.
+fn (mut t Transformer) erase_consts_initialized_by_erased_templates(decls map[string]GenericFnDecl) {
+	if decls.len == 0 {
+		return
+	}
+	mut cur_module := ''
+	for i in 0 .. t.a.nodes.len {
+		node := t.a.nodes[i]
+		match node.kind {
+			.file {
+				cur_module = t.tc.file_modules[node.value] or { '' }
+			}
+			.module_decl {
+				cur_module = node.value
+			}
+			.const_decl {
+				for ci in 0 .. node.children_count {
+					field := t.a.child_node(&node, ci)
+					if field.kind != .const_field || field.children_count == 0 {
+						continue
+					}
+					value_id := t.a.child(field, 0)
+					mut called := map[string]bool{}
+					t.collect_type_erased_generic_template_calls(value_id, cur_module,
+						decls, mut called)
+					if called.len == 0 {
+						continue
+					}
+					mut subtree := map[int]bool{}
+					t.collect_node_subtree_ids(value_id, mut subtree)
+					for idx, _ in subtree {
+						old := t.a.nodes[idx]
+						t.set_node(idx, flat.Node{
+							kind: .empty
+							pos:  old.pos
+						})
+						t.clear_typechecker_node_cache(idx)
+					}
+				}
+			}
+			else {}
+		}
+	}
 }
 
 fn (mut t Transformer) collect_generic_fn_decls_for_erasure() map[string]GenericFnDecl {

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -12674,6 +12674,12 @@ fn (mut t Transformer) rewrite_multi_return_match_assign(node flat.Node, lhs_ids
 		if parts := t.match_branch_tuple_parts(branch, body_start, lhs_ids.len) {
 			prefix = parts.prefix.clone()
 			assignment = t.make_multi_value_assign(lhs_ids, parts.values)
+		} else if t.match_branch_tail_exits(branch, body_start) {
+			// An exiting branch (return/break/continue/noreturn call) supplies
+			// no tuple values; keep its body unchanged.
+			for j in body_start .. int(branch.children_count) {
+				prefix << t.a.child(branch, j)
+			}
 		} else {
 			tail_id := t.match_branch_multi_return_expr(branch, body_start, lhs_ids.len) or {
 				return none
@@ -12688,7 +12694,9 @@ fn (mut t Transformer) rewrite_multi_return_match_assign(node flat.Node, lhs_ids
 			branch_children << t.a.child(branch, j)
 		}
 		branch_children << prefix
-		branch_children << assignment
+		if assignment != flat.empty_node {
+			branch_children << assignment
+		}
 		start := t.a.children.len
 		t.a.children << branch_children
 		match_children << t.a.add_node(flat.Node{
@@ -12717,6 +12725,45 @@ fn (mut t Transformer) rewrite_multi_return_match_assign(node flat.Node, lhs_ids
 		pos:                  node.pos
 		is_mut:               node.is_mut
 		skip_ownership_drops: node.skip_ownership_drops
+	}
+}
+
+// match_branch_tail_exits reports whether a match branch body always leaves
+// the enclosing scope, so a lowered multi-value match needs no assignment there.
+fn (t &Transformer) match_branch_tail_exits(branch flat.Node, body_start int) bool {
+	if branch.children_count <= body_start {
+		return false
+	}
+	return t.stmt_tail_exits(t.a.child(&branch, branch.children_count - 1))
+}
+
+fn (t &Transformer) stmt_tail_exits(id flat.NodeId) bool {
+	if int(id) < 0 || int(id) >= t.a.nodes.len {
+		return false
+	}
+	node := t.a.nodes[int(id)]
+	match node.kind {
+		.return_stmt, .break_stmt, .continue_stmt {
+			return true
+		}
+		.block {
+			if node.children_count == 0 {
+				return false
+			}
+			return t.stmt_tail_exits(t.a.child(&node, node.children_count - 1))
+		}
+		.expr_stmt {
+			if node.children_count == 0 {
+				return false
+			}
+			return t.stmt_tail_exits(t.a.child(&node, 0))
+		}
+		.call {
+			return t.is_noreturn_call(id)
+		}
+		else {
+			return false
+		}
 	}
 }
 

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -10206,8 +10206,10 @@ fn closest_identifier_span(source string, name string, anchor int, file_id int) 
 	mut best_start := -1
 	mut best_distance := source.len + name.len
 	for search_from <= source.len - name.len {
-		relative := source[search_from..].index(name) or { break }
-		start := search_from + relative
+		start := source.index_after_(name, search_from)
+		if start < 0 {
+			break
+		}
 		left_is_name := start > 0 && (source[start - 1].is_alnum() || source[start - 1] == `_`)
 		end := start + name.len
 		right_is_name := end < source.len && (source[end].is_alnum() || source[end] == `_`)
@@ -10216,6 +10218,11 @@ fn closest_identifier_span(source string, name string, anchor int, file_id int) 
 			if distance < best_distance {
 				best_start = start
 				best_distance = distance
+			}
+			if start >= anchor {
+				// Matches are visited left to right, so every later word match
+				// is farther from the anchor than this one.
+				break
 			}
 		}
 		search_from = start + 1
@@ -18188,12 +18195,30 @@ fn (tc &TypeChecker) source_enclosing_fn_has_generic_param(id flat.NodeId, name 
 	file := tc.a.source_files[node.pos.id] or { return false }
 	source := tc.source_texts_by_file[file.name] or { return false }
 	offset := int_min(int_max(node.pos.offset, 0), source.len)
-	fn_start := source[..offset].last_index('fn ') or { return false }
-	header_end_relative := source[fn_start..].index_u8(`{`)
-	if header_end_relative < 0 {
+	// Scan by index: substr copies of the file prefix/suffix here made every
+	// call allocate whole-file-sized temporaries, which multiplied into
+	// gigabytes on self-host builds.
+	mut fn_start := -1
+	for i := offset - 3; i >= 0; i-- {
+		if source[i] == `f` && source[i + 1] == `n` && source[i + 2] == ` ` {
+			fn_start = i
+			break
+		}
+	}
+	if fn_start < 0 {
 		return false
 	}
-	header := source[fn_start..fn_start + header_end_relative]
+	mut header_end := -1
+	for i := fn_start; i < source.len; i++ {
+		if source[i] == `{` {
+			header_end = i
+			break
+		}
+	}
+	if header_end < 0 {
+		return false
+	}
+	header := source[fn_start..header_end]
 	mut search_start := 0
 	for search_start < header.len {
 		open_relative := header[search_start..].index_u8(`[`)
@@ -21754,6 +21779,18 @@ fn (tc &TypeChecker) or_expr_payload_type(source_id flat.NodeId) ?Type {
 	}
 	if source.kind == .index && source.children_count > 0 {
 		base_type := unalias_and_unwrap_pointer_type(tc.resolve_type(tc.a.child(source, 0)))
+		if source.value == 'range' {
+			// A gated range index yields a slice of the container, not an element.
+			if base_type is ArrayFixed {
+				return Type(Array{
+					elem_type: base_type.elem_type
+				})
+			}
+			if base_type is Array || base_type is String {
+				return base_type
+			}
+			return none
+		}
 		if base_type is Map {
 			return base_type.value_type
 		}
@@ -46394,6 +46431,22 @@ fn (tc &TypeChecker) selector_type(_id flat.NodeId, node flat.Node) ?Type {
 		method_name := 'string.${node.value}'
 		if method_name in tc.fn_param_types || method_name in tc.fn_ret_types {
 			return tc.method_value_type('string', node.value)
+		}
+	}
+	if clean is Array || clean is Map || clean is String {
+		// A declared field (e.g. `string.str &u8`) shadows the builtin method
+		// of the same name for selector access.
+		sname := if clean is Array {
+			'array'
+		} else if clean is Map {
+			'map'
+		} else {
+			'string'
+		}
+		for f in tc.structs[sname] or { []StructField{} } {
+			if f.name == node.value {
+				return f.typ
+			}
 		}
 	}
 	if typ := tc.builtin_method_value_type(base_type, node.value) {

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -681,7 +681,11 @@ pub mut:
 	channel_send_or_expr_id int  = -1
 	smartcasts              map[string]Type
 	ownership               &OwnershipState = unsafe { nil }
-	// See QualifyNameCache: forks must replace it with their own instance.
+	// See QualifyNameCache: nil unless armed for a phase whose allocations
+	// outlive every prealloc scope arena; forks must replace it with their own
+	// instance. A long-lived armed cache written during a scoped driver stage
+	// (markused/transform/cgen under -prealloc) stores map buckets and result
+	// strings in the disposable scope arena, and later reads crash.
 	qualify_name_cache &QualifyNameCache = unsafe { nil }
 	import_info_cache  &ImportInfoCache  = unsafe { nil }
 	// Nanoseconds spent in the ownership checker's per-fn boundary passes.
@@ -867,7 +871,6 @@ pub fn TypeChecker.new(a &flat.FlatAst) TypeChecker {
 		visible_mutation_cache:                  new_visible_mutation_cache()
 		type_interner:                           type_interner
 		symbols:                                 symbols
-		qualify_name_cache:                      &QualifyNameCache{}
 		enclosing_generic_params_by_node:        map[int][]string{}
 		declaration_attributes:                  map[int][]string{}
 		type_declaration_ids:                    map[string][]int{}


### PR DESCRIPTION
\`./v3 -nocache -building-v -o v4 -no-memory-limit v3.v\` was OOM-killed by macOS right after the parse phase (the process allocated at ~20 GB/s in the parallel checker until jetsam sent SIGKILL — \`-no-memory-limit\` only disables the internal watchdog, not the OS kill). Fixing the OOM then exposed five more self-host blockers. With this PR the full bootstrap chain is green again: v1 → v3(prod) → v4 → v5, ~1.8 s total, ~740 MB steady footprint.

### Memory explosion (checker)
- \`source_enclosing_fn_has_generic_param\` copied the whole source file twice per call (\`source[..offset]\`, \`source[fn_start..]\` — ~5 MB per call on checker.v) and was reached for every identifier in \`resolve_type\`/\`check_ident\` because the cheap \`is_bare_generic_param\` guard was applied after the expensive \`||\` chain. Now index-scans without copies, and both call sites short-circuit on the guard first (behavior-preserving: the chain's result was only ever consumed under that same guard).
- \`closest_identifier_span\` copied the file suffix once per occurrence of the searched name (O(occurrences × file size) bytes). Now uses \`index_after_\` and stops after the first word match past the anchor (later matches are strictly farther).

### Checker fixes
- \`s[a..n] or { ... }\` (gated range slice) was typed as the element type \`u8\` instead of the slice type; \`or_expr_payload_type\` now recognizes \`value == 'range'\` index sources (broke \`v/util/version.v\`).
- \`name.str\` on a string in infix position resolved to the \`str()\` method value (\`fn () string\`) instead of the \`&u8\` field; declared builtin-struct fields now take priority over builtin method values in \`selector_type\`.

### Transform fixes
- \`a, b := match e { ... else { return } }\`: the multi-value match lowering bailed out on branches whose tail exits (return/break/continue/noreturn), falling into a broken \`_ifexpr\` fallback. Exiting branches now keep their body unchanged with no assignment.
- Value-producing if-guards with multi-value destructuring (\`x := if a, b, _ := f() { ... }\`) bound the whole tuple to the first name; \`build_if_value_guard_chain\` now emits per-name \`.value.argN\` bindings like the statement path.

### Cgen fixes (-building-v)
- The fixed-storage-const optimization miscompiled \`in const_array\`: the lowered \`array_get(const, i)\` shares its const AST node with a \`.len\` selector base, which the safety scan had whitelisted, so the const was wrongly promoted to a C fixed array. Const references in plain call arguments now always count as dynamic uses.
- \`v.token\` newly entered the v3.v closure (checker.v imports \`v.util\`), and \`-building-v\` template erasure left \`scanner_matcher = new_keywords_matcher_trie(...)\` calling a deleted function (the keep-list preserves the template AST, but cgen never emits open generic templates). Const initializers that call erased templates are now dropped with their storage; the compiler never reads them, and any new use fails loudly at C compile time instead.

Each fix was reduced to a minimal repro first (match-tuple exit branches, guard destructuring, slice-or, \`.str\` infix, \`import v.token\` under \`-building-v\`), and all repros compile and run correctly after the fix.