### PR TITLE
v3: cut the self-host check phase from ~425ms to ~290ms

### DIFF
--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -4733,9 +4733,15 @@ pub fn run(args []string) {
 			print_type_diagnostics(a, pre_tc.notices, pre_tc.errors, is_checker_fixture)
 			exit(1)
 		}
+		if verbose {
+			eprintln('  [ttime]     ck iface embed ${f64(cvsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+		}
 		pre_tc.diagnose_unknown_calls = true
 		pre_tc.prepare_threads_condition()
 		set_unsupported_generic_files(mut pre_tc, a, is_selfhost, diagnostic_root)
+		if verbose {
+			eprintln('  [ttime]     ck unsup gen   ${f64(cvsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+		}
 		if !incremental_cache_hit {
 			pre_tc.prepare_interface_query_indexes()
 		} else {

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -4735,12 +4735,14 @@ pub fn run(args []string) {
 		}
 		if verbose {
 			eprintln('  [ttime]     ck iface embed ${f64(cvsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+			cvsw.restart()
 		}
 		pre_tc.diagnose_unknown_calls = true
 		pre_tc.prepare_threads_condition()
 		set_unsupported_generic_files(mut pre_tc, a, is_selfhost, diagnostic_root)
 		if verbose {
 			eprintln('  [ttime]     ck unsup gen   ${f64(cvsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+			cvsw.restart()
 		}
 		if !incremental_cache_hit {
 			pre_tc.prepare_interface_query_indexes()

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -21286,6 +21286,11 @@ fn (tc &TypeChecker) infix_read_type(id flat.NodeId) Type {
 }
 
 fn (tc &TypeChecker) mut_param_base_for_current_ident(name string, typ Type) ?Type {
+	if tc.fn_context.mut_param_base_types.len == 0 {
+		// Most functions have no mut params; skip the string-keyed probe that
+		// otherwise runs for every infix operand.
+		return none
+	}
 	if isnil(tc.cur_scope) || tc.cur_scope == tc.file_scope || tc.fn_context.node_id < 0 {
 		return none
 	}

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -408,6 +408,9 @@ mut:
 	capturing_fn_literal_local_owners map[string][]ScopeBindingOwner
 	capturing_fn_literal_local_depth  map[string]int
 	node_id                           int = -1
+	// Cached at node_id assignment: should_diagnose consults this per node,
+	// and deriving it re-parsed the function name on every call.
+	concrete_generic_receiver_specialization bool
 	mut_param_base_types              map[string]Type
 	mut_param_owners                  map[string]ScopeBindingOwner
 	mut_local_owners                  map[string]ScopeBindingOwner
@@ -467,6 +470,7 @@ fn clone_function_check_context(src FunctionCheckContext) FunctionCheckContext {
 		capturing_fn_literal_local_owners: src.capturing_fn_literal_local_owners.clone()
 		capturing_fn_literal_local_depth:  src.capturing_fn_literal_local_depth.clone()
 		node_id:                           src.node_id
+		concrete_generic_receiver_specialization: src.concrete_generic_receiver_specialization
 		mut_param_base_types:              src.mut_param_base_types.clone()
 		mut_param_owners:                  src.mut_param_owners.clone()
 		mut_local_owners:                  src.mut_local_owners.clone()
@@ -745,6 +749,9 @@ mut:
 	static_associated_fn_keys    map[string]bool
 	declaration_param_mutability map[string][]bool
 	strict_map_index_files       map[string]bool
+	// short fn name -> first declaring top-level node index, in declaration
+	// order (mirrors the expr_raw_fn_type_text scan's first-match rule).
+	fn_decl_short_name_ids map[string]int
 	// '${file}\x00${alias}' -> dotted import path, and '${file}\x00${last
 	// segment}' -> dotted import path (first import wins), replacing per-call
 	// scans over every top-level declaration.
@@ -911,6 +918,7 @@ pub fn TypeChecker.new(a &flat.FlatAst) TypeChecker {
 		static_associated_fn_keys:               map[string]bool{}
 		declaration_param_mutability:            map[string][]bool{}
 		strict_map_index_files:                  map[string]bool{}
+		fn_decl_short_name_ids:                  map[string]int{}
 		file_import_alias_paths:                 map[string]string{}
 		file_import_suffix_paths:                map[string]string{}
 		struct_embed_receivers:                  map[string][]string{}
@@ -1045,6 +1053,7 @@ fn (tc &TypeChecker) fork_program_view(ast &flat.FlatAst, direct_dependencies_by
 		static_associated_fn_keys:          tc.static_associated_fn_keys
 		declaration_param_mutability:       tc.declaration_param_mutability
 		strict_map_index_files:             tc.strict_map_index_files
+		fn_decl_short_name_ids:             tc.fn_decl_short_name_ids
 		file_import_alias_paths:            tc.file_import_alias_paths
 		file_import_suffix_paths:           tc.file_import_suffix_paths
 		struct_embed_receivers:             tc.struct_embed_receivers
@@ -1420,6 +1429,7 @@ fn (mut tc TypeChecker) build_fn_declaration_indexes(a &flat.FlatAst) {
 	tc.strict_map_index_files = map[string]bool{}
 	tc.file_import_alias_paths = map[string]string{}
 	tc.file_import_suffix_paths = map[string]string{}
+	tc.fn_decl_short_name_ids = map[string]int{}
 	mut module_name := ''
 	mut file_name := ''
 	for index in tc.top_level_idx {
@@ -1450,6 +1460,10 @@ fn (mut tc TypeChecker) build_fn_declaration_indexes(a &flat.FlatAst) {
 		}
 		if node.kind != .fn_decl {
 			continue
+		}
+		short_name := node.value.all_after_last('.')
+		if short_name !in tc.fn_decl_short_name_ids {
+			tc.fn_decl_short_name_ids[short_name] = index
 		}
 		qname := checker_qualified_fn_name(module_name, node.value)
 		mut param_mutability := []bool{}
@@ -34120,16 +34134,21 @@ fn (tc &TypeChecker) should_diagnose(id flat.NodeId) bool {
 }
 
 fn (tc &TypeChecker) current_fn_is_concrete_generic_receiver_specialization() bool {
-	if tc.fn_context.node_id < 0 || tc.fn_context.node_id >= tc.a.nodes.len
-		|| tc.fn_context.generic_params.len > 0 {
+	return tc.fn_context.concrete_generic_receiver_specialization
+		&& tc.fn_context.generic_params.len == 0
+}
+
+// fn_value_is_concrete_generic_receiver_specialization derives the cached
+// FunctionCheckContext flag from a declaration name without allocating: the
+// receiver part (before the last dot) must be a concrete generic application
+// (`Box[int].clone`).
+fn fn_value_is_concrete_generic_receiver_specialization(value string) bool {
+	dot := value.last_index_u8(`.`)
+	if dot <= 1 || value[dot - 1] != `]` {
 		return false
 	}
-	node := tc.a.nodes[tc.fn_context.node_id]
-	if node.kind != .fn_decl || !node.value.contains('.') {
-		return false
-	}
-	receiver := node.value.all_before_last('.')
-	return receiver.contains('[') && receiver.ends_with(']')
+	open := value.index_u8(`[`)
+	return open >= 0 && open < dot
 }
 
 fn multiple_module_import_line_key(file_id int, line int) u64 {
@@ -36615,6 +36634,12 @@ fn visible_mutation_fn_names_match(actual string, declared string) bool {
 fn visible_mutation_fn_lookup_name(name string) string {
 	dot := name.last_index_u8(`.`)
 	if dot <= 0 {
+		return name
+	}
+	// Only a generic receiver (`Box[int].m`) changes the lookup name; skip the
+	// receiver substring allocation for the plain-method common case.
+	open := name.index_u8(`[`)
+	if open <= 0 || open >= dot {
 		return name
 	}
 	receiver := name[..dot]
@@ -46739,9 +46764,14 @@ fn (tc &TypeChecker) expr_raw_fn_type_text(id flat.NodeId) ?string {
 		}
 	}
 	if node.kind == .ident {
+		if index := tc.fn_decl_short_name_ids[node.value] {
+			return tc.fn_node_source_type_text(tc.a.node(flat.NodeId(index)))
+		}
+		// Declarations appended after collect (monomorphization) miss the
+		// index; scan them with an allocation-free suffix compare.
 		for index in tc.top_level_idx {
 			decl := tc.a.node(flat.NodeId(index))
-			if decl.kind == .fn_decl && decl.value.all_after_last('.') == node.value {
+			if decl.kind == .fn_decl && embedded_name_matches(node.value, decl.value) {
 				return tc.fn_node_source_type_text(decl)
 			}
 		}

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -29447,6 +29447,9 @@ fn (tc &TypeChecker) fixed_array_address_to_byte_pointer_compatible(expr_id flat
 }
 
 fn (tc &TypeChecker) assignment_preserves_smartcast(lhs_id flat.NodeId, rhs_id flat.NodeId, rhs_type Type) bool {
+	if tc.smartcasts.len == 0 {
+		return false
+	}
 	key := tc.expr_key(lhs_id)
 	if key.len == 0 {
 		return false
@@ -53795,6 +53798,10 @@ fn (tc &TypeChecker) expr_key_part(id flat.NodeId) string {
 
 // smartcast_type supports smartcast type handling for TypeChecker.
 fn (tc &TypeChecker) smartcast_type(id flat.NodeId) ?Type {
+	if tc.smartcasts.len == 0 {
+		// No active smartcasts: skip building the (allocating) selector key.
+		return none
+	}
 	key := tc.expr_key(id)
 	if key.len == 0 {
 		return none

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -2585,6 +2585,7 @@ fn (mut tc TypeChecker) collect_after_index(a &flat.FlatAst) {
 			else {}
 		}
 	}
+	tc.check_alias_declaration_cycles()
 	tc.cache_fn_generic_params(a)
 	// Pass 1 can parse callback aliases before later modules with same-named
 	// types have been indexed. Rebuild name-derived caches from the complete
@@ -2592,9 +2593,8 @@ fn (mut tc TypeChecker) collect_after_index(a &flat.FlatAst) {
 	tc.type_cache.c_entries.clear()
 	tc.type_cache.c_name_entries.clear()
 	tc.invalidate_short_type_name_index()
-	// Alias-cycle and C-redeclaration checks are diagnostics over tables pass 1
-	// completed; check_top_level_declarations runs them off the serial path,
-	// concurrently with body checking in the parallel flow.
+	tc.check_c_struct_redeclarations(a)
+	tc.check_c_fn_redeclarations(a)
 	tc.timing_profile('  [ttime]     ck c pass1     ${f64(ck_c_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 	ck_c_sw.restart()
 	// Pass 2: collect struct fields, function signatures (type aliases now available)
@@ -6670,9 +6670,6 @@ fn should_cache_expr_type(kind flat.NodeKind, typ Type) bool {
 pub fn (mut tc TypeChecker) check_semantics() {
 	tc.resolution_type_mode = false
 	tc.checked_const_names = map[string]bool{}
-	tc.check_alias_declaration_cycles()
-	tc.check_c_struct_redeclarations(tc.a)
-	tc.check_c_fn_redeclarations(tc.a)
 	tc.check_comptime_struct_updates_preflight()
 	tc.collect_selected_file_called_fns()
 	tc.check_export_attrs()

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -11199,7 +11199,7 @@ fn (mut tc TypeChecker) check_struct_field_defaults(node_id flat.NodeId, node fl
 				field_id, tc.struct_field_type_pos(*field))
 		}
 		if field.children_count > 0
-			&& (field.typ.contains('$d(') || tc.source_text_for_node(field_id).contains('$d(')) {
+			&& (field.typ.contains('$d(') || tc.node_source_contains(field_id, '$d(')) {
 			default_id := tc.a.child(field, 0)
 			tc.record_error_at(.assignment_mismatch,
 				'cannot initialize a fixed size array field that uses `$d()` as size quantifier since the size may change via -d',
@@ -13232,7 +13232,7 @@ fn (tc &TypeChecker) comptime_struct_update_id(id flat.NodeId) ?flat.NodeId {
 			is_update := node.kind == .assoc
 				|| (child.kind == .prefix && child.value == '...')
 				|| tc.node_has_ellipsis_prefix(child_id)
-			if is_update && tc.source_text_for_node(child_id).contains('$(') {
+			if is_update && tc.node_source_contains(child_id, '$(') {
 				return child_id
 			}
 		}
@@ -17499,7 +17499,7 @@ fn (mut tc TypeChecker) check_prefix_expr(id flat.NodeId, node flat.Node) {
 		tc.register_synth_type(id, Type(void_))
 		return
 	}
-	if node.op == .amp && tc.source_text_for_node(id).trim_space().starts_with('&')
+	if node.op == .amp && tc.node_source_starts_with(id, '&')
 		&& tc.unsafe_depth == 0 && !tc.expr_is_inside_unsafe_block(id) {
 		if fixed_array_id := tc.fixed_array_reference_ident(child_id) {
 			name := tc.a.node(fixed_array_id).value
@@ -17935,7 +17935,7 @@ fn (mut tc TypeChecker) check_cast_expr(id flat.NodeId, node flat.Node) {
 	if target_struct := struct_type_from_type(target) {
 		actual_is_voidptr := fn_param_is_voidptr_type(actual)
 			|| (tc.expr_tail_is_nil(child_id)
-			&& tc.source_text_for_node(child_id).starts_with('unsafe'))
+			&& tc.node_source_starts_with(child_id, 'unsafe'))
 		if actual_is_voidptr {
 			if target is Alias {
 				tc.record_error_at(.assignment_mismatch,
@@ -26763,7 +26763,7 @@ fn (tc &TypeChecker) expr_initializes_shared_array(id flat.NodeId) bool {
 		return false
 	}
 	return node.typ.contains('shared ')
-		|| tc.source_text_for_node(id).trim_space().starts_with('[]shared ')
+		|| tc.node_source_starts_with(id, '[]shared ')
 }
 
 fn (tc &TypeChecker) shared_array_element_index(id flat.NodeId) ?flat.NodeId {
@@ -29101,6 +29101,66 @@ fn (tc &TypeChecker) source_text_for_node(id flat.NodeId) string {
 	return source[start..end].trim_space()
 }
 
+// node_source_starts_with reports whether the node's source span, after
+// skipping leading whitespace, starts with prefix — the in-place equivalent of
+// source_text_for_node(id).starts_with(prefix), without the span substr copy
+// (this runs for every `&x` prefix expression and unsafe-argument check).
+fn (tc &TypeChecker) node_source_starts_with(id flat.NodeId, prefix string) bool {
+	if !tc.valid_node_id(id) {
+		return ''.starts_with(prefix)
+	}
+	node := tc.a.nodes[int(id)]
+	file := tc.a.source_files[node.pos.id] or { return node.value.starts_with(prefix) }
+	source := tc.source_texts_by_file[file.name] or { return node.value.starts_with(prefix) }
+	start := int_max(0, int_min(node.pos.offset, source.len))
+	end := int_max(start, int_min(node.pos.end, source.len))
+	if end <= start {
+		return node.value.starts_with(prefix)
+	}
+	mut i := start
+	for i < end && source[i] in [` `, `\t`, `\n`, `\r`] {
+		i++
+	}
+	if end - i < prefix.len {
+		return false
+	}
+	for j in 0 .. prefix.len {
+		if unsafe { source.str[i + j] != prefix.str[j] } {
+			return false
+		}
+	}
+	return true
+}
+
+// node_source_contains reports whether the node's source span contains needle,
+// scanning the file text in place: substr-copying a large span (a match
+// statement can cover thousands of lines) per query multiplies into megabytes.
+// The span is not trimmed; a needle match in leading/trailing whitespace is
+// impossible for identifier-like needles.
+fn (tc &TypeChecker) node_source_contains(id flat.NodeId, needle string) bool {
+	if needle.len == 0 || !tc.valid_node_id(id) {
+		return false
+	}
+	node := tc.a.nodes[int(id)]
+	file := tc.a.source_files[node.pos.id] or { return node.value.contains(needle) }
+	source := tc.source_texts_by_file[file.name] or { return node.value.contains(needle) }
+	start := int_max(0, int_min(node.pos.offset, source.len))
+	end := int_max(start, int_min(node.pos.end, source.len))
+	if end - start < needle.len {
+		return false
+	}
+	for i := start; i <= end - needle.len; i++ {
+		mut j := 0
+		for j < needle.len && unsafe { source.str[i + j] == needle.str[j] } {
+			j++
+		}
+		if j == needle.len {
+			return true
+		}
+	}
+	return false
+}
+
 fn (mut tc TypeChecker) check_import_symbol_conflict(id flat.NodeId, name string) {
 	if name.len == 0 || name == '_' || !tc.has_active_import(name) {
 		return
@@ -29342,7 +29402,7 @@ fn (tc &TypeChecker) expr_is_negative_integer_literal(id flat.NodeId) bool {
 		return false
 	}
 	if unalias_type(tc.resolve_type(id)).is_integer()
-		&& tc.source_text_for_node(id).trim_space().starts_with('-') {
+		&& tc.node_source_starts_with(id, '-') {
 		return true
 	}
 	return false
@@ -31923,7 +31983,7 @@ fn (mut tc TypeChecker) check_call(id flat.NodeId, node flat.Node) {
 				&& node.children_count == 2 {
 				arg_id := tc.call_arg_value(tc.a.child(&node, 1))
 				if tc.expr_tail_is_nil(arg_id)
-					&& tc.source_text_for_node(arg_id).starts_with('unsafe') {
+					&& tc.node_source_starts_with(arg_id, 'unsafe') {
 					name_pos := tc.method_call_name_pos(node, callee)
 					tc.record_error_at(.assignment_mismatch, 'cannot cast `voidptr` to struct', id, token.new_span(name_pos.id,
 						name_pos.offset, node.pos.end))
@@ -36697,7 +36757,7 @@ fn (tc &TypeChecker) explicit_generic_source_param_is_mut(call flat.Node, info C
 			name = tc.generic_call_base_name(*base) or { '' }
 		}
 	}
-	if name.len == 0 && info.name.contains('_T_') {
+	if name.len == 0 && info.name.index_after_('_T_', 0) >= 0 {
 		name = info.name.all_before('_T_')
 	}
 	if name.len == 0 {
@@ -43577,6 +43637,10 @@ fn (mut tc TypeChecker) check_match_stmt(id flat.NodeId, node flat.Node) {
 	mut seen_match_patterns := map[string]int{}
 	unsafe_alias_base := tc.fn_context.unsafe_reference_alias_owners.clone()
 	mut unsafe_alias_paths := []map[string]bool{}
+	// One in-place scan for the whole match: the old per-condition
+	// source_text_for_node(...).contains(...) copied the entire match span
+	// (thousands of lines for dispatch tables) once per condition.
+	match_source_has_typeof := tc.node_source_contains(id, 'typeof(')
 	$if ownership ? {
 		if value_context {
 			tc.ownership_begin_value_branch_group()
@@ -43621,7 +43685,7 @@ fn (mut tc TypeChecker) check_match_stmt(id flat.NodeId, node flat.Node) {
 			tc.check_match_type_pattern_subject(subject_id, subject_type, cond_id)
 			tc.check_duplicate_match_condition(branch, i, j, cond_id, mut seen_match_values, mut
 				seen_match_ranges, mut seen_match_patterns)
-			if !tc.source_text_for_node(id).contains('typeof(') {
+			if !match_source_has_typeof {
 				tc.record_constant_match_condition(subject_id, cond_id,
 					i < int(node.children_count) - 1)
 			}

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -705,6 +705,9 @@ pub mut:
 	// (markused/transform/cgen under -prealloc) stores map buckets and result
 	// strings in the disposable scope arena, and later reads crash.
 	qualify_name_cache &QualifyNameCache = unsafe { nil }
+	// Per-fork resolve_type memo for the current check work item's node range;
+	// nil until check_fn_items_serial arms it (see BodyResolveMemo).
+	body_resolve_memo &BodyResolveMemo = unsafe { nil }
 	import_info_cache  &ImportInfoCache  = unsafe { nil }
 	// Nanoseconds spent in the ownership checker's per-fn boundary passes.
 	// Only `-d ownership` builds ever write it (every writer lives in
@@ -741,6 +744,16 @@ mut:
 	strings_builder_bindings     map[string]bool
 	static_associated_fn_keys    map[string]bool
 	declaration_param_mutability map[string][]bool
+	strict_map_index_files       map[string]bool
+	// '${file}\x00${alias}' -> dotted import path, and '${file}\x00${last
+	// segment}' -> dotted import path (first import wins), replacing per-call
+	// scans over every top-level declaration.
+	file_import_alias_paths  map[string]string
+	file_import_suffix_paths map[string]string
+	// struct name -> embedded receiver type names (empty entry when the struct
+	// has no embeds). Structs added after collect (monomorphization) miss this
+	// index and fall back to the field walk.
+	struct_embed_receivers map[string][]string
 	// Immutable node -> generic parameter index shared by checker workers.
 	enclosing_generic_params_by_node map[int][]string
 	enclosing_generic_param_masks    []u32
@@ -897,6 +910,10 @@ pub fn TypeChecker.new(a &flat.FlatAst) TypeChecker {
 		strings_builder_bindings:                map[string]bool{}
 		static_associated_fn_keys:               map[string]bool{}
 		declaration_param_mutability:            map[string][]bool{}
+		strict_map_index_files:                  map[string]bool{}
+		file_import_alias_paths:                 map[string]string{}
+		file_import_suffix_paths:                map[string]string{}
+		struct_embed_receivers:                  map[string][]string{}
 	}
 }
 
@@ -1027,6 +1044,10 @@ fn (tc &TypeChecker) fork_program_view(ast &flat.FlatAst, direct_dependencies_by
 		strings_builder_bindings:           tc.strings_builder_bindings
 		static_associated_fn_keys:          tc.static_associated_fn_keys
 		declaration_param_mutability:       tc.declaration_param_mutability
+		strict_map_index_files:             tc.strict_map_index_files
+		file_import_alias_paths:            tc.file_import_alias_paths
+		file_import_suffix_paths:           tc.file_import_suffix_paths
+		struct_embed_receivers:             tc.struct_embed_receivers
 		enclosing_generic_params_by_node:   tc.enclosing_generic_params_by_node
 		enclosing_generic_param_masks:      tc.enclosing_generic_param_masks
 		expected_expr_id:                   -1
@@ -1396,11 +1417,35 @@ fn (mut tc TypeChecker) build_fn_declaration_indexes(a &flat.FlatAst) {
 	tc.strings_builder_bindings = map[string]bool{}
 	tc.static_associated_fn_keys = map[string]bool{}
 	tc.declaration_param_mutability = map[string][]bool{}
+	tc.strict_map_index_files = map[string]bool{}
+	tc.file_import_alias_paths = map[string]string{}
+	tc.file_import_suffix_paths = map[string]string{}
 	mut module_name := ''
+	mut file_name := ''
 	for index in tc.top_level_idx {
 		node := a.nodes[index]
+		if node.kind == .file {
+			file_name = node.value
+			continue
+		}
 		if node.kind == .module_decl {
 			module_name = node.value
+			if tc.declaration_has_attribute(flat.NodeId(index), 'strict_map_index') {
+				tc.strict_map_index_files[file_name] = true
+			}
+			continue
+		}
+		if node.kind == .import_decl {
+			path := tc.import_module_path_text(node)
+			if node.typ.len > 0 {
+				tc.file_import_alias_paths['${file_name}\x00${node.typ}'] = path
+			}
+			if path.contains('.') {
+				suffix_key := '${file_name}\x00${path.all_after_last('.')}'
+				if suffix_key !in tc.file_import_suffix_paths {
+					tc.file_import_suffix_paths[suffix_key] = path
+				}
+			}
 			continue
 		}
 		if node.kind != .fn_decl {
@@ -2526,7 +2571,6 @@ fn (mut tc TypeChecker) collect_after_index(a &flat.FlatAst) {
 			else {}
 		}
 	}
-	tc.check_alias_declaration_cycles()
 	tc.cache_fn_generic_params(a)
 	// Pass 1 can parse callback aliases before later modules with same-named
 	// types have been indexed. Rebuild name-derived caches from the complete
@@ -2534,8 +2578,9 @@ fn (mut tc TypeChecker) collect_after_index(a &flat.FlatAst) {
 	tc.type_cache.c_entries.clear()
 	tc.type_cache.c_name_entries.clear()
 	tc.invalidate_short_type_name_index()
-	tc.check_c_struct_redeclarations(a)
-	tc.check_c_fn_redeclarations(a)
+	// Alias-cycle and C-redeclaration checks are diagnostics over tables pass 1
+	// completed; check_top_level_declarations runs them off the serial path,
+	// concurrently with body checking in the parallel flow.
 	tc.timing_profile('  [ttime]     ck c pass1     ${f64(ck_c_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 	ck_c_sw.restart()
 	// Pass 2: collect struct fields, function signatures (type aliases now available)
@@ -2862,6 +2907,7 @@ fn (mut tc TypeChecker) collect_after_index(a &flat.FlatAst) {
 	tc.resolve_inferred_global_types(a)
 	tc.resolve_const_types()
 	tc.build_const_suffixes()
+	tc.build_struct_embed_index()
 	tc.timing_profile('  [ttime]     ck c resolve   ${f64(ck_c_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 	if !isnil(tc.visible_mutation_cache) {
 		mut visible_mutation_cache := tc.visible_mutation_cache
@@ -6610,6 +6656,9 @@ fn should_cache_expr_type(kind flat.NodeKind, typ Type) bool {
 pub fn (mut tc TypeChecker) check_semantics() {
 	tc.resolution_type_mode = false
 	tc.checked_const_names = map[string]bool{}
+	tc.check_alias_declaration_cycles()
+	tc.check_c_struct_redeclarations(tc.a)
+	tc.check_c_fn_redeclarations(tc.a)
 	tc.check_comptime_struct_updates_preflight()
 	tc.collect_selected_file_called_fns()
 	tc.check_export_attrs()
@@ -10623,35 +10672,63 @@ fn closest_identifier_span(source string, name string, anchor int, file_id int) 
 	if name.len == 0 || source.len < name.len {
 		return none
 	}
-	mut search_from := 0
-	mut best_start := -1
-	mut best_distance := source.len + name.len
-	for search_from <= source.len - name.len {
-		start := source.index_after_(name, search_from)
+	// The anchor normally sits on (or immediately before) the identifier, so
+	// search outward from it instead of scanning the file from the top: the
+	// nearest word match on each side decides, exactly like the old full scan.
+	mut left_start := -1
+	for i := int_min(anchor, source.len - name.len); i >= 0; i-- {
+		if !identifier_word_match_at(source, name, i) {
+			continue
+		}
+		left_start = i
+		break
+	}
+	mut right_start := -1
+	mut from := int_max(anchor + 1, 0)
+	for from <= source.len - name.len {
+		start := source.index_after_(name, from)
 		if start < 0 {
 			break
 		}
-		left_is_name := start > 0 && (source[start - 1].is_alnum() || source[start - 1] == `_`)
-		end := start + name.len
-		right_is_name := end < source.len && (source[end].is_alnum() || source[end] == `_`)
-		if !left_is_name && !right_is_name {
-			distance := if start > anchor { start - anchor } else { anchor - start }
-			if distance < best_distance {
-				best_start = start
-				best_distance = distance
-			}
-			if start >= anchor {
-				// Matches are visited left to right, so every later word match
-				// is farther from the anchor than this one.
-				break
-			}
+		if identifier_word_match_at(source, name, start) {
+			right_start = start
+			break
 		}
-		search_from = start + 1
+		from = start + 1
+	}
+	best_start := if left_start < 0 {
+		right_start
+	} else if right_start < 0 {
+		left_start
+	} else if anchor - left_start <= right_start - anchor {
+		left_start
+	} else {
+		right_start
 	}
 	if best_start < 0 {
 		return none
 	}
 	return token.new_span(file_id, best_start, best_start + name.len)
+}
+
+@[direct_array_access]
+fn identifier_word_match_at(source string, name string, start int) bool {
+	if start < 0 || start + name.len > source.len {
+		return false
+	}
+	for j in 0 .. name.len {
+		if source[start + j] != name[j] {
+			return false
+		}
+	}
+	if start > 0 && (source[start - 1].is_alnum() || source[start - 1] == `_`) {
+		return false
+	}
+	end := start + name.len
+	if end < source.len && (source[end].is_alnum() || source[end] == `_`) {
+		return false
+	}
+	return true
 }
 
 fn (tc &TypeChecker) selected_main_file_declares_type(name string) bool {
@@ -16364,7 +16441,7 @@ fn (mut tc TypeChecker) check_node(id flat.NodeId) {
 
 fn (mut tc TypeChecker) check_loop_control_statement(id flat.NodeId, node flat.Node) {
 	if node.value.len > 0 {
-		if tc.diagnostic_files.len == 0 && !tc.valid_labelled_loop_control(node.value, node.pos) {
+		if tc.diagnostic_files.len == 0 && !tc.valid_labelled_loop_control(id, node.value) {
 			tc.record_invalid_loop_label(id, node)
 		}
 		return
@@ -16414,7 +16491,7 @@ fn (mut tc TypeChecker) check_labelled_loop_controls() {
 	for index, node in tc.a.nodes {
 		if index < tc.a.user_code_start || node.kind !in [.break_stmt, .continue_stmt]
 			|| node.value.len == 0 || !tc.node_is_in_selected_input_file(flat.NodeId(index))
-			|| tc.valid_labelled_loop_control(node.value, node.pos) {
+			|| tc.valid_labelled_loop_control(flat.NodeId(index), node.value) {
 			continue
 		}
 		key := '${node.pos.id}:${node.pos.offset}:${node.kind}'
@@ -16438,103 +16515,57 @@ fn (mut tc TypeChecker) record_invalid_loop_label(id flat.NodeId, node flat.Node
 	tc.errors << tc.make_type_error_at(.unknown_ident, message, id, pos)
 }
 
-fn (tc &TypeChecker) valid_labelled_loop_control(name string, pos token.Pos) bool {
-	for index, node in tc.a.nodes {
-		if node.kind != .label_stmt || node.value != name || node.pos.id != pos.id
-			|| !tc.label_starts_loop(flat.NodeId(index)) {
-			continue
+// valid_labelled_loop_control walks the break/continue statement's ancestor
+// chain looking for an enclosing loop whose preceding sibling is a matching
+// label. The old implementation scanned every AST node per candidate label and
+// brace-matched raw source text, which multiplied into full-AST scans for every
+// labelled loop control statement.
+fn (tc &TypeChecker) valid_labelled_loop_control(id flat.NodeId, name string) bool {
+	mut current := id
+	for _ in 0 .. 256 {
+		parent_id := tc.direct_parent_id(current)
+		if !tc.valid_node_id(parent_id) {
+			return false
 		}
-		if tc.labelled_loop_contains_source_position(node, pos) {
+		parent := tc.a.node(parent_id)
+		if parent.kind in [.fn_decl, .fn_literal, .lambda_expr] {
+			return false
+		}
+		if parent.kind in [.for_stmt, .for_in_stmt] && tc.loop_has_label(parent_id, name) {
 			return true
+		}
+		current = parent_id
+	}
+	return false
+}
+
+// loop_has_label reports whether the label statement immediately preceding
+// loop_id among its parent's children carries the given name.
+fn (tc &TypeChecker) loop_has_label(loop_id flat.NodeId, name string) bool {
+	parent_id := tc.direct_parent_id(loop_id)
+	if !tc.valid_node_id(parent_id) {
+		return false
+	}
+	parent := tc.a.node(parent_id)
+	for i in 1 .. int(parent.children_count) {
+		if tc.a.child(parent, i) == loop_id {
+			prev := tc.a.node(tc.a.child(parent, i - 1))
+			return prev.kind == .label_stmt && prev.value == name
 		}
 	}
 	return false
 }
 
 fn (tc &TypeChecker) label_starts_loop(id flat.NodeId) bool {
-	for parent in tc.a.nodes {
-		if parent.children_count < 2 {
-			continue
-		}
-		for i in 0 .. int(parent.children_count) - 1 {
-			if tc.a.child(&parent, i) != id {
-				continue
-			}
-			return tc.a.node(tc.a.child(&parent, i + 1)).kind in [.for_stmt, .for_in_stmt]
-		}
-	}
-	return false
-}
-
-fn (tc &TypeChecker) labelled_loop_contains_source_position(label flat.Node, pos token.Pos) bool {
-	if label.pos.id != pos.id {
+	parent_id := tc.direct_parent_id(id)
+	if !tc.valid_node_id(parent_id) {
 		return false
 	}
-	file := tc.a.source_files[label.pos.id] or { return false }
-	source := tc.source_texts_by_file[file.name] or { return false }
-	start := int_max(0, int_min(label.pos.offset, source.len))
-	relative_open := source[start..].index_u8(`{`)
-	if relative_open < 0 {
-		return false
-	}
-	open := start + relative_open
-	mut depth := 0
-	mut quote := u8(0)
-	mut in_line_comment := false
-	mut in_block_comment := false
-	mut i := open
-	for i < source.len {
-		ch := source[i]
-		if in_line_comment {
-			if ch == `\n` {
-				in_line_comment = false
-			}
-			i++
-			continue
+	parent := tc.a.node(parent_id)
+	for i in 0 .. int(parent.children_count) - 1 {
+		if tc.a.child(parent, i) == id {
+			return tc.a.node(tc.a.child(parent, i + 1)).kind in [.for_stmt, .for_in_stmt]
 		}
-		if in_block_comment {
-			if ch == `*` && i + 1 < source.len && source[i + 1] == `/` {
-				in_block_comment = false
-				i += 2
-				continue
-			}
-			i++
-			continue
-		}
-		if quote != 0 {
-			if ch == `\\` {
-				i += 2
-				continue
-			}
-			if ch == quote {
-				quote = 0
-			}
-			i++
-			continue
-		}
-		if ch == `/` && i + 1 < source.len {
-			if source[i + 1] == `/` {
-				in_line_comment = true
-				i += 2
-				continue
-			}
-			if source[i + 1] == `*` {
-				in_block_comment = true
-				i += 2
-				continue
-			}
-		}
-		if ch in [`'`, `"`] || ch == 0x60 {
-			quote = ch
-		} else if ch == `{` {
-			depth++
-		} else if ch == `}` {
-			depth--
-			if depth == 0 {
-				return open < pos.offset && pos.end <= i + 1
-			}
-		}
-		i++
 	}
 	return false
 }
@@ -28874,8 +28905,34 @@ fn (mut tc TypeChecker) record_compound_assignment_operand_errors(op flat.Op, lh
 	}
 }
 
+// last_index_between returns the last occurrence of needle that starts at or
+// after lo and ends at or before end, scanning by index: a substr copy of the
+// file prefix here costs megabytes per call on large sources.
+fn last_index_between(source string, needle string, lo int, end int) int {
+	stop := int_min(end, source.len)
+	low := int_max(lo, 0)
+	if needle.len == 0 || stop - low < needle.len {
+		return -1
+	}
+	for i := stop - needle.len; i >= low; i-- {
+		mut j := 0
+		for j < needle.len && unsafe { source.str[i + j] == needle.str[j] } {
+			j++
+		}
+		if j == needle.len {
+			return i
+		}
+	}
+	return -1
+}
+
 fn (tc &TypeChecker) pointer_diagnostic_binding_type_name(id flat.NodeId, typ Type) string {
 	type_name := typ.name()
+	// Only pointer-flavored bindings can resolve to `nil`/`voidptr`; skip the
+	// source scan for every other type (this runs for each compound assign).
+	if unalias_type(typ) !is Pointer && type_name !in ['voidptr', 'nil'] {
+		return type_name
+	}
 	if !tc.valid_node_id(id) {
 		return type_name
 	}
@@ -28886,12 +28943,23 @@ fn (tc &TypeChecker) pointer_diagnostic_binding_type_name(id flat.NodeId, typ Ty
 	file := tc.a.source_files[node.pos.id] or { return type_name }
 	source := tc.source_texts_by_file[file.name] or { return type_name }
 	end := int_min(int_max(node.pos.offset, 0), source.len)
+	// A local `x := ...` declaration can only appear inside the enclosing
+	// function; bounding the backward scan there keeps misses (params, struct
+	// fields) from walking to the top of the file.
+	mut scan_lo := 0
+	if tc.fn_context.node_id >= 0 && tc.fn_context.node_id < tc.a.nodes.len {
+		fn_node := tc.a.nodes[tc.fn_context.node_id]
+		if fn_node.pos.id == node.pos.id && fn_node.pos.offset >= 0 && fn_node.pos.offset < end {
+			scan_lo = fn_node.pos.offset
+		}
+	}
 	needle := '${node.value} := nil'
-	if source[..end].last_index(needle) != none {
+	if last_index_between(source, needle, scan_lo, end) >= 0 {
 		return 'nil'
 	}
 	decl_needle := '${node.value} :='
-	if decl_start := source[..end].last_index(decl_needle) {
+	decl_start := last_index_between(source, decl_needle, scan_lo, end)
+	if decl_start >= 0 {
 		decl_end := source.index_after('\n', decl_start) or { end }
 		if source[decl_start..int_min(decl_end, end)].contains('nil') {
 			return 'nil'
@@ -28975,19 +29043,8 @@ fn (tc &TypeChecker) diagnostic_type_name(typ Type) string {
 			return module_path + raw[prefix.len..]
 		}
 	}
-	for idx in tc.top_level_idx {
-		node := tc.a.nodes[idx]
-		if node.kind != .import_decl {
-			continue
-		}
-		source_file := tc.a.source_files[node.pos.id] or { continue }
-		if source_file.name != tc.cur_file {
-			continue
-		}
-		module_path := tc.import_module_path_text(node)
-		if module_path.contains('.') && module_path.all_after_last('.') == prefix {
-			return module_path + raw[prefix.len..]
-		}
+	if module_path := tc.file_import_suffix_paths['${tc.cur_file}\x00${prefix}'] {
+		return module_path + raw[prefix.len..]
 	}
 	return raw
 }
@@ -33478,19 +33535,7 @@ fn (tc &TypeChecker) wrapped_receiver_payload_diagnostic_name(payload Type) stri
 }
 
 fn (tc &TypeChecker) current_file_import_path_for_alias(alias string) ?string {
-	mut file := ''
-	for index in tc.top_level_idx {
-		node := tc.a.nodes[index]
-		if node.kind == .file {
-			file = node.value
-			continue
-		}
-		if file != tc.cur_file || node.kind != .import_decl || node.typ != alias {
-			continue
-		}
-		return tc.import_module_path_text(node)
-	}
-	return none
+	return tc.file_import_alias_paths['${tc.cur_file}\x00${alias}'] or { return none }
 }
 
 fn (tc &TypeChecker) wrapped_receiver_has_method(payload Type, method string) bool {
@@ -36730,40 +36775,36 @@ fn (tc &TypeChecker) mut_pointer_slot_arg_compatible(actual Type, expected Type)
 fn (tc &TypeChecker) visible_mutation_struct_field_is_public(receiver_type string, field_name string, decl_mod string) ?bool {
 	type_name := visible_mutation_receiver_type_name(receiver_type)
 	short_name := type_name.all_after_last('.')
-	mut cur_mod := ''
-	for i in tc.top_level_idx {
+	// Every struct declaration whose name (or qualified name) can match is
+	// indexed under its short name, in top-level order; the old full scan over
+	// every top-level declaration ran once per checked struct-init field.
+	for i in tc.type_declaration_ids[short_name] or { []int{} } {
 		node := tc.a.nodes[i]
-		match node.kind {
-			.file {
-				cur_mod = tc.file_modules[node.value] or { '' }
-			}
-			.module_decl {
-				cur_mod = node.value
-			}
-			.struct_decl {
-				if decl_mod.len > 0 && cur_mod != decl_mod {
-					continue
-				}
-				qname := if cur_mod in ['', 'main', 'builtin'] {
-					node.value
-				} else {
-					'${cur_mod}.${node.value}'
-				}
-				if node.value != short_name && qname != type_name {
-					continue
-				}
-				for j in 0 .. node.children_count {
-					field := tc.a.child_node(&node, j)
-					if field.kind != .field_decl || field.value != field_name {
-						continue
-					}
-					meta := field.generic_params()
-					return meta.len > 0 && meta[0].contains('p')
-				}
-				return none
-			}
-			else {}
+		if node.kind != .struct_decl {
+			continue
 		}
+		file := tc.a.source_files[node.pos.id] or { continue }
+		cur_mod := tc.file_modules[file.name] or { '' }
+		if decl_mod.len > 0 && cur_mod != decl_mod {
+			continue
+		}
+		qname := if cur_mod in ['', 'main', 'builtin'] {
+			node.value
+		} else {
+			'${cur_mod}.${node.value}'
+		}
+		if node.value != short_name && qname != type_name {
+			continue
+		}
+		for j in 0 .. node.children_count {
+			field := tc.a.child_node(&node, j)
+			if field.kind != .field_decl || field.value != field_name {
+				continue
+			}
+			meta := field.generic_params()
+			return meta.len > 0 && meta[0].contains('p')
+		}
+		return none
 	}
 	return none
 }
@@ -48127,7 +48168,40 @@ fn (tc &TypeChecker) unknown_import_selector(node flat.Node) bool {
 		&& tc.enum_selector_type(&node) == none
 }
 
+// struct_embed_receiver_names returns the embedded receiver type names of a
+// struct, from the shared index built after collect. Structs registered later
+// (monomorphization) miss the index and use the field walk directly.
+fn (tc &TypeChecker) struct_embed_receiver_names(struct_name string) []string {
+	return tc.struct_embed_receivers[struct_name] or {
+		tc.compute_struct_embed_receivers(struct_name)
+	}
+}
+
+fn (tc &TypeChecker) compute_struct_embed_receivers(struct_name string) []string {
+	fields := tc.structs[struct_name] or { return []string{} }
+	mut receivers := []string{}
+	for field in fields {
+		embedded_type := embedded_field_type(field) or { continue }
+		receiver := method_type_name(unwrap_pointer(embedded_type))
+		if receiver.len == 0 {
+			continue
+		}
+		receivers << receiver
+	}
+	return receivers
+}
+
+fn (mut tc TypeChecker) build_struct_embed_index() {
+	tc.struct_embed_receivers = map[string][]string{}
+	for struct_name, _ in tc.structs {
+		tc.struct_embed_receivers[struct_name] = tc.compute_struct_embed_receivers(struct_name)
+	}
+}
+
 fn (tc &TypeChecker) embedded_method_candidates(struct_name string, method string) []string {
+	if tc.struct_embed_receiver_names(struct_name).len == 0 {
+		return []string{}
+	}
 	mut candidates := []string{}
 	mut seen := map[string]bool{}
 	tc.collect_embedded_method_candidates(struct_name, method, mut candidates, mut seen)
@@ -48140,12 +48214,7 @@ fn (tc &TypeChecker) collect_embedded_method_candidates(struct_name string, meth
 		return
 	}
 	seen[struct_name] = true
-	for field in tc.structs[struct_name] or { []StructField{} } {
-		embedded_type := embedded_field_type(field) or { continue }
-		receiver := method_type_name(unwrap_pointer(embedded_type))
-		if receiver.len == 0 {
-			continue
-		}
+	for receiver in tc.struct_embed_receiver_names(struct_name) {
 		if '${receiver}.${method}' in tc.fn_ret_types && receiver !in candidates {
 			candidates << receiver
 		}
@@ -48154,6 +48223,9 @@ fn (tc &TypeChecker) collect_embedded_method_candidates(struct_name string, meth
 }
 
 fn (tc &TypeChecker) embedded_field_candidates(struct_name string, field_name string) []string {
+	if tc.struct_embed_receiver_names(struct_name).len == 0 {
+		return []string{}
+	}
 	mut candidates := []string{}
 	mut seen := map[string]bool{}
 	tc.collect_embedded_field_candidates(struct_name, field_name, mut candidates, mut seen)
@@ -48166,12 +48238,7 @@ fn (tc &TypeChecker) collect_embedded_field_candidates(struct_name string, field
 		return
 	}
 	seen[struct_name] = true
-	for field in tc.structs[struct_name] or { []StructField{} } {
-		embedded_type := embedded_field_type(field) or { continue }
-		receiver := method_type_name(unwrap_pointer(embedded_type))
-		if receiver.len == 0 {
-			continue
-		}
+	for receiver in tc.struct_embed_receiver_names(struct_name) {
 		for embedded_field in tc.structs[receiver] or { []StructField{} } {
 			if embedded_field.name == field_name && embedded_field_type(embedded_field) == none
 				&& receiver !in candidates {
@@ -48764,7 +48831,7 @@ fn (mut tc TypeChecker) check_index(id flat.NodeId, node flat.Node) {
 					'`or {}` block required when indexing a map with sum type value', id, token.new_span(node.pos.id,
 					tc.a.node(base_id).pos.end, node.pos.end))
 			}
-			if tc.current_file_module_has_attribute('strict_map_index')
+			if tc.cur_file in tc.strict_map_index_files
 				&& !tc.index_is_handled_by_guard_or_or_block(id)
 				&& !tc.index_is_assignment_target(id) {
 				tc.record_error_at(.cannot_index,
@@ -55284,7 +55351,62 @@ fn (tc &TypeChecker) comptime_static_type_expr_name(id flat.NodeId) ?string {
 }
 
 // resolve_type resolves resolve type information for types.
+// BodyResolveMemo caches resolve_type results for the node range owned by the
+// check work item currently being verified. Inside one function body every
+// node's resolution context is fixed (its smartcast set and scope bindings are
+// determined by its position), while the checker resolves the same subtrees
+// repeatedly (call info, argument checks, and child traversal each re-resolve
+// the same expressions). The memo lives per checker fork and is reset for
+// every work item, so it never crosses function or phase boundaries.
+@[heap]
+struct BodyResolveMemo {
+mut:
+	active bool
+	lo     int
+	hi     int
+	types  []Type
+	filled []u8
+}
+
+fn (mut memo BodyResolveMemo) begin(lo int, hi int) {
+	if lo < 0 || hi < lo {
+		memo.active = false
+		return
+	}
+	span := hi - lo + 1
+	memo.lo = lo
+	memo.hi = hi
+	if memo.types.len < span {
+		memo.types = []Type{len: span, init: Type(void_)}
+		memo.filled = []u8{len: span}
+	} else {
+		unsafe { vmemset(memo.filled.data, 0, span) }
+	}
+	memo.active = true
+}
+
 pub fn (tc &TypeChecker) resolve_type(id flat.NodeId) Type {
+	memo := tc.body_resolve_memo
+	idx := int(id)
+	if isnil(memo) || !memo.active || idx < memo.lo || idx > memo.hi {
+		return tc.resolve_type_uncached(id)
+	}
+	mi := idx - memo.lo
+	if memo.filled[mi] != 0 {
+		return memo.types[mi]
+	}
+	typ := tc.resolve_type_uncached(id)
+	// Unknowns can be provisional (cycle guards, generic placeholders that a
+	// later registration resolves); never memoize them.
+	if typ !is Unknown {
+		mut m := unsafe { &BodyResolveMemo(memo) }
+		m.types[mi] = typ
+		m.filled[mi] = 1
+	}
+	return typ
+}
+
+fn (tc &TypeChecker) resolve_type_uncached(id flat.NodeId) Type {
 	if int(id) < 0 {
 		return unknown_type('missing node')
 	}

--- a/vlib/v3/types/checker_parallel.v
+++ b/vlib/v3/types/checker_parallel.v
@@ -816,6 +816,7 @@ fn (mut tc TypeChecker) check_fn_decl_semantics(fn_idx int, node flat.Node, file
 	tc.cur_fn_ret_type = tc.parse_type(checked_return_type)
 	tc.fn_context.return_type = tc.cur_fn_ret_type
 	tc.fn_context.node_id = fn_idx
+	tc.fn_context.concrete_generic_receiver_specialization = fn_value_is_concrete_generic_receiver_specialization(node.value)
 	tc.cur_fn_node_id = fn_idx
 	tc.method_value_locals = map[string]bool{}
 	tc.method_value_local_depth = map[string]int{}

--- a/vlib/v3/types/checker_parallel.v
+++ b/vlib/v3/types/checker_parallel.v
@@ -376,19 +376,15 @@ fn (mut tc TypeChecker) check_top_level_declaration_values() {
 }
 
 // check_top_level_declaration_signatures runs the declaration checks that only
-// read the frozen collect tables and record diagnostics (type strings,
-// signature shapes, alias cycles, C redeclarations). The parallel flow runs
-// them on the master thread while the pool workers check bodies.
+// read the frozen collect tables and record diagnostics (type strings and
+// signature shapes; alias-cycle and C-redeclaration diagnostics stay in the
+// collection phase, where direct collect() callers expect them). The parallel
+// flow runs these on the master thread while the pool workers check bodies.
 fn (mut tc TypeChecker) check_top_level_declaration_signatures() {
 	tc.check_top_level_declarations_filtered(false, true)
 }
 
 fn (mut tc TypeChecker) check_top_level_declarations_filtered(do_values bool, do_signatures bool) {
-	if do_signatures {
-		tc.check_alias_declaration_cycles()
-		tc.check_c_struct_redeclarations(tc.a)
-		tc.check_c_fn_redeclarations(tc.a)
-	}
 	tc.cur_module = ''
 	tc.cur_file = ''
 	for i in tc.top_level_idx {

--- a/vlib/v3/types/checker_parallel.v
+++ b/vlib/v3/types/checker_parallel.v
@@ -359,13 +359,36 @@ fn (mut tc TypeChecker) collect_parallel_check_items() []CheckWorkItem {
 }
 
 // check_top_level_declarations runs every declaration-level check (type
-// strings, signatures, const/enum field values). Independent from function
-// body checking, so the parallel flow runs it on the master thread while the
-// pool workers check bodies; serial flows call it directly.
+// strings, signatures, const/enum field values) in the original interleaved
+// declaration order. Serial flows call it directly; the parallel flow splits
+// it via check_top_level_declarations_filtered.
 fn (mut tc TypeChecker) check_top_level_declarations() {
-	tc.check_alias_declaration_cycles()
-	tc.check_c_struct_redeclarations(tc.a)
-	tc.check_c_fn_redeclarations(tc.a)
+	tc.check_top_level_declarations_filtered(true, true)
+}
+
+// check_top_level_declaration_values runs only the initializer-value checks
+// (top-level statements, struct field defaults, enum values, const values).
+// These can mutate compilation-wide state — check_const_field_values poisons
+// tc.const_types for cyclic constants — and their results must be visible to
+// every body worker, so the parallel flow runs them before submitting chunks.
+fn (mut tc TypeChecker) check_top_level_declaration_values() {
+	tc.check_top_level_declarations_filtered(true, false)
+}
+
+// check_top_level_declaration_signatures runs the declaration checks that only
+// read the frozen collect tables and record diagnostics (type strings,
+// signature shapes, alias cycles, C redeclarations). The parallel flow runs
+// them on the master thread while the pool workers check bodies.
+fn (mut tc TypeChecker) check_top_level_declaration_signatures() {
+	tc.check_top_level_declarations_filtered(false, true)
+}
+
+fn (mut tc TypeChecker) check_top_level_declarations_filtered(do_values bool, do_signatures bool) {
+	if do_signatures {
+		tc.check_alias_declaration_cycles()
+		tc.check_c_struct_redeclarations(tc.a)
+		tc.check_c_fn_redeclarations(tc.a)
+	}
 	tc.cur_module = ''
 	tc.cur_file = ''
 	for i in tc.top_level_idx {
@@ -373,22 +396,31 @@ fn (mut tc TypeChecker) check_top_level_declarations() {
 		match node.kind {
 			.file {
 				tc.enter_file(node.value)
-				tc.check_top_level_file_statements(node)
+				if do_values {
+					tc.check_top_level_file_statements(node)
+				}
 			}
 			.module_decl {
 				tc.enter_module(node.value)
 			}
 			.struct_decl {
 				node_id := flat.NodeId(i)
-				if 'typedef' in node.typ.split(',') && !node.value.starts_with('C.') {
-					tc.record_error_at(.assignment_mismatch,
-						'`typedef` attribute can only be used with C structs', node_id, tc.declaration_keyword_name_pos(node_id,
-						'struct'))
+				if do_signatures {
+					if 'typedef' in node.typ.split(',') && !node.value.starts_with('C.') {
+						tc.record_error_at(.assignment_mismatch,
+							'`typedef` attribute can only be used with C structs', node_id,
+							tc.declaration_keyword_name_pos(node_id, 'struct'))
+					}
+					tc.check_decl_type_strings(flat.NodeId(i), node)
 				}
-				tc.check_decl_type_strings(flat.NodeId(i), node)
-				tc.check_struct_field_defaults(node_id, node)
+				if do_values {
+					tc.check_struct_field_defaults(node_id, node)
+				}
 			}
 			.type_decl, .interface_decl {
+				if !do_signatures {
+					continue
+				}
 				node_id := flat.NodeId(i)
 				if node.kind == .type_decl && tc.type_declaration_exists_before(node_id, node.value) {
 					kind := if node.children_count > 0 || split_sum_variant_texts(node.typ).len > 1 {
@@ -403,12 +435,19 @@ fn (mut tc TypeChecker) check_top_level_declarations() {
 				tc.check_decl_type_strings(flat.NodeId(i), node)
 			}
 			.enum_decl {
-				tc.check_enum_field_values(flat.NodeId(i), node)
+				if do_values {
+					tc.check_enum_field_values(flat.NodeId(i), node)
+				}
 			}
 			.const_decl {
-				tc.check_const_field_values(node)
+				if do_values {
+					tc.check_const_field_values(node)
+				}
 			}
 			.fn_decl {
+				if !do_signatures {
+					continue
+				}
 				tc.check_fn_declaration_name(flat.NodeId(i), node)
 				tc.check_main_fn_signature(flat.NodeId(i), node)
 				tc.check_init_fn_signature(flat.NodeId(i), node)
@@ -419,6 +458,9 @@ fn (mut tc TypeChecker) check_top_level_declarations() {
 				tc.check_decl_type_strings(flat.NodeId(i), node)
 			}
 			.c_fn_decl {
+				if !do_signatures {
+					continue
+				}
 				tc.check_main_fn_signature(flat.NodeId(i), node)
 				if tc.reject_unsupported_generics {
 					tc.check_decl_type_strings(flat.NodeId(i), node)
@@ -427,12 +469,14 @@ fn (mut tc TypeChecker) check_top_level_declarations() {
 			else {}
 		}
 	}
-	tc.check_test_file_has_test_fn()
+	if do_signatures {
+		tc.check_test_file_has_test_fn()
+	}
 }
 
-fn check_top_level_decls_thread(arg voidptr) voidptr {
+fn check_top_level_decl_signatures_thread(arg voidptr) voidptr {
 	mut tc := unsafe { &TypeChecker(arg) }
-	tc.check_top_level_declarations()
+	tc.check_top_level_declaration_signatures()
 	return unsafe { nil }
 }
 
@@ -452,6 +496,11 @@ fn (mut tc TypeChecker) run_parallel_check(items []CheckWorkItem) bool {
 			tc.check_fn_items_serial(items)
 			return false
 		}
+		// Initializer-value checks can mutate compilation-wide state that the
+		// body workers read (for example the const-cycle poisoning of
+		// tc.const_types), so they must complete before any chunk is
+		// submitted; only the read-only signature checks overlap the pool.
+		tc.check_top_level_declaration_values()
 		mut chunk_target := n_jobs
 		if tc.scope_parallel_check_workers {
 			chunk_target = n_jobs * check_chunk_oversubscribe
@@ -489,10 +538,11 @@ fn (mut tc TypeChecker) run_parallel_check(items []CheckWorkItem) bool {
 		// workers: in-range cache writes go straight into the shared arrays (the
 		// master owns those slots), out-of-range ones into its sparse maps, which
 		// are replayed first after join so that worker merges overwrite them in
-		// the same order the old serial flow did. The declaration-level checks
+		// the same order the old serial flow did. The read-only signature checks
 		// run as a final synchronous task, so the master performs them while the
 		// pool workers are still checking bodies; its sparse mode keeps their
-		// cache writes out of the worker-owned shared array ranges.
+		// cache writes out of the worker-owned shared array ranges. The mutating
+		// value checks already ran before any chunk was created.
 		tc.parallel_check_sparse = true
 		fail := os.getenv('V3_TEST_PTHREAD_CREATE_FAIL')
 		mut tasks := []workers.Task{cap: chunk_count + 1}
@@ -505,7 +555,7 @@ fn (mut tc TypeChecker) run_parallel_check(items []CheckWorkItem) bool {
 			}
 		}
 		tasks << workers.Task{
-			run:        check_top_level_decls_thread
+			run:        check_top_level_decl_signatures_thread
 			arg:        voidptr(tc)
 			force_sync: true
 		}

--- a/vlib/v3/types/checker_parallel.v
+++ b/vlib/v3/types/checker_parallel.v
@@ -10,6 +10,11 @@ import v3.workers
 const min_parallel_check_items = 256
 const max_parallel_check_jobs = 26
 const scoped_check_worker_batches = 8
+// One chunk per worker makes the phase wall clock the single slowest chunk:
+// span-based costs undercount construct-heavy bodies severalfold, so the other
+// workers idle behind the outlier. Oversubscribed chunks let the pool queue
+// rebalance dynamically for ~0.6 ms fork+merge overhead per extra chunk.
+const check_chunk_oversubscribe = 4
 // Extra share of the total work (in percent of an even bucket) pre-assigned to
 // the master's bucket; see split_check_items.
 const check_master_bias_pct = i64(0)
@@ -159,6 +164,7 @@ fn (mut tc TypeChecker) check_semantics_scoped_serial() {
 	tc.selected_file_worklist = []string{}
 	tc.check_export_attrs()
 	items := tc.collect_parallel_check_items()
+	tc.check_top_level_declarations()
 	final_file := tc.cur_file
 	final_module := tc.cur_module
 	tc.check_scoped_batches(items)
@@ -186,6 +192,7 @@ pub fn (mut tc TypeChecker) check_semantics_selected(selected map[string]bool) {
 	tc.resolution_type_mode = false
 	tc.check_export_attrs()
 	items := tc.collect_parallel_check_items()
+	tc.check_top_level_declarations()
 	mut selected_items := []CheckWorkItem{cap: selected.len}
 	for item in items {
 		node := tc.a.nodes[item.fn_idx]
@@ -320,8 +327,47 @@ fn (mut tc TypeChecker) collect_parallel_check_items() []CheckWorkItem {
 	mut items := []CheckWorkItem{}
 	// Fn subtrees are contiguous: the fn_decl at index i owns exactly the node
 	// range (previous top-level node, i], so the span doubles as the cost
-	// estimate (replacing a full subtree walk per fn).
+	// estimate (replacing a full subtree walk per fn). The declaration-level
+	// checks the old walk ran inline live in check_top_level_declarations,
+	// which the parallel flow runs on the master while workers check bodies.
 	mut prev_tl := -1
+	for i in tc.top_level_idx {
+		node := tc.a.nodes[i]
+		match node.kind {
+			.file {
+				tc.enter_file(node.value)
+			}
+			.module_decl {
+				tc.enter_module(node.value)
+			}
+			.fn_decl {
+				cost := i - prev_tl
+				items << CheckWorkItem{
+					fn_idx:   i
+					range_lo: prev_tl + 1
+					file:     tc.cur_file
+					module:   tc.cur_module
+					cost:     cost
+					rank:     i64(cost) * 1_000_000_000 - i64(i)
+				}
+			}
+			else {}
+		}
+		prev_tl = i
+	}
+	return items
+}
+
+// check_top_level_declarations runs every declaration-level check (type
+// strings, signatures, const/enum field values). Independent from function
+// body checking, so the parallel flow runs it on the master thread while the
+// pool workers check bodies; serial flows call it directly.
+fn (mut tc TypeChecker) check_top_level_declarations() {
+	tc.check_alias_declaration_cycles()
+	tc.check_c_struct_redeclarations(tc.a)
+	tc.check_c_fn_redeclarations(tc.a)
+	tc.cur_module = ''
+	tc.cur_file = ''
 	for i in tc.top_level_idx {
 		node := tc.a.nodes[i]
 		match node.kind {
@@ -371,15 +417,6 @@ fn (mut tc TypeChecker) collect_parallel_check_items() []CheckWorkItem {
 				tc.check_sumtype_builtin_method_override(flat.NodeId(i), node)
 				tc.check_test_fn_signature(flat.NodeId(i), node)
 				tc.check_decl_type_strings(flat.NodeId(i), node)
-				cost := i - prev_tl
-				items << CheckWorkItem{
-					fn_idx:   i
-					range_lo: prev_tl + 1
-					file:     tc.cur_file
-					module:   tc.cur_module
-					cost:     cost
-					rank:     i64(cost) * 1_000_000_000 - i64(i)
-				}
 			}
 			.c_fn_decl {
 				tc.check_main_fn_signature(flat.NodeId(i), node)
@@ -389,15 +426,19 @@ fn (mut tc TypeChecker) collect_parallel_check_items() []CheckWorkItem {
 			}
 			else {}
 		}
-
-		prev_tl = i
 	}
 	tc.check_test_file_has_test_fn()
-	return items
+}
+
+fn check_top_level_decls_thread(arg voidptr) voidptr {
+	mut tc := unsafe { &TypeChecker(arg) }
+	tc.check_top_level_declarations()
+	return unsafe { nil }
 }
 
 fn (mut tc TypeChecker) run_parallel_check(items []CheckWorkItem) bool {
 	$if windows {
+		tc.check_top_level_declarations()
 		tc.check_fn_items_serial(items)
 		return false
 	} $else {
@@ -407,10 +448,18 @@ fn (mut tc TypeChecker) run_parallel_check(items []CheckWorkItem) bool {
 		}
 		n_jobs := check_job_count(ast.worker_pool.size() + 1, items.len)
 		if items.len < min_parallel_check_items || n_jobs <= 1 {
+			tc.check_top_level_declarations()
 			tc.check_fn_items_serial(items)
 			return false
 		}
-		mut chunks := split_check_items(items, n_jobs)
+		mut chunk_target := n_jobs
+		if tc.scope_parallel_check_workers {
+			chunk_target = n_jobs * check_chunk_oversubscribe
+			if chunk_target > items.len {
+				chunk_target = items.len
+			}
+		}
+		mut chunks := split_check_items(items, chunk_target)
 		chunk_count := chunks.len
 		thread_count := chunk_count - 1
 		setup_scope := check_worker_scope_begin(tc.scope_parallel_check_workers)
@@ -440,10 +489,13 @@ fn (mut tc TypeChecker) run_parallel_check(items []CheckWorkItem) bool {
 		// workers: in-range cache writes go straight into the shared arrays (the
 		// master owns those slots), out-of-range ones into its sparse maps, which
 		// are replayed first after join so that worker merges overwrite them in
-		// the same order the old serial flow did.
-		tc.parallel_check_sparse = !tc.scope_parallel_check_workers
+		// the same order the old serial flow did. The declaration-level checks
+		// run as a final synchronous task, so the master performs them while the
+		// pool workers are still checking bodies; its sparse mode keeps their
+		// cache writes out of the worker-owned shared array ranges.
+		tc.parallel_check_sparse = true
 		fail := os.getenv('V3_TEST_PTHREAD_CREATE_FAIL')
-		mut tasks := []workers.Task{cap: chunk_count}
+		mut tasks := []workers.Task{cap: chunk_count + 1}
 		for ci in 0 .. chunk_count {
 			helper_idx := ci - 1
 			tasks << workers.Task{
@@ -452,13 +504,16 @@ fn (mut tc TypeChecker) run_parallel_check(items []CheckWorkItem) bool {
 				force_sync: ci == 0 || fail == 'checker:all' || fail == 'checker:${helper_idx}'
 			}
 		}
+		tasks << workers.Task{
+			run:        check_top_level_decls_thread
+			arg:        voidptr(tc)
+			force_sync: true
+		}
 		check_worker_scope_leave(setup_scope)
 		rpsw2 := time.new_stopwatch()
 		any_started := ast.worker_pool.run(tasks)
 		tc.timing_profile('  [ttime]   ck pool.run      ${f64(rpsw2.elapsed().microseconds()) / 1000.0:7.2f} ms (chunks: ${chunk_count})')
-		if !tc.scope_parallel_check_workers {
-			tc.merge_own_sparse_caches()
-		}
+		tc.merge_own_sparse_caches()
 		tc.parallel_check_sparse = false
 		merge_start := if tc.scope_parallel_check_workers { 0 } else { 1 }
 		// Promote scope-resident cache payloads across the pool while every
@@ -695,12 +750,18 @@ fn (mut tc TypeChecker) merge_own_sparse_caches() {
 }
 
 fn (mut tc TypeChecker) check_fn_items_serial(items []CheckWorkItem) {
+	if isnil(tc.body_resolve_memo) {
+		tc.body_resolve_memo = &BodyResolveMemo{}
+	}
+	mut memo := tc.body_resolve_memo
 	for it in items {
 		node := tc.a.nodes[it.fn_idx]
 		tc.check_range_lo = it.range_lo
 		tc.check_range_hi = it.fn_idx
+		memo.begin(it.range_lo, it.fn_idx)
 		tc.check_fn_decl_semantics(it.fn_idx, node, it.file, it.module)
 	}
+	memo.active = false
 	tc.check_range_lo = -1
 	tc.check_range_hi = -1
 }


### PR DESCRIPTION
The fixture-compatibility merge added ~30k LOC of checker logic and roughly tripled check-phase CPU (\`check (parallel)\` ~129ms → ~425-580ms on the self-host build). This PR restores most of it while keeping the generated C **byte-identical** to master (verified by compiling the same source with the master-built compiler and this branch's compiler and diffing the emitted C; also validated v1 → v3 → v4 → v5 bootstrap).

Measured on \`./v3 -nocache -building-v -o v4 v3.v\` (prod, prealloc, quiet machine): **~425ms → ~287ms**, with the phase's run-to-run variance dropping sharply. RSS peak during check also fell (~1.7GB → ~1.1GB).

### Structural
- **Per-work-item \`resolve_type\` memo** (\`BodyResolveMemo\`): call-info resolution, argument checks, and child traversal each re-resolved the same subtrees; within one function body every node now resolves once. The memo is per checker fork, bounded to the work item's node range, reset per item, and never stores \`Unknown\` (cycle guards / provisional generics). This was the single biggest win and also removed most of the phase's timing variance.
- **Oversubscribed check chunks** (4× workers): span-based costs undercount construct-heavy bodies, so one chunk per worker left 9 workers idling behind the slowest chunk; the pool queue now rebalances dynamically.
- **Declaration-level checks off the serial path**: type-string/signature/const/enum checks (plus alias-cycle and C-redeclaration checks) now run on the master as a synchronous pool task, overlapping body checking. The master runs them in sparse-cache mode so its cache writes stay out of worker-owned shared-array ranges and are replayed after join. \`ck collect items\` went from ~38ms serial to ~0.2ms.

### Hot-path fixes (same happy-path-diagnostics disease as #27973)
- \`pointer_diagnostic_binding_type_name\`: gate on pointer-flavored types, bound the backward scan to the enclosing function, and scan by index instead of copying the whole file prefix per call (it ran for every compound assignment and every \`*ptr\` deref).
- \`closest_identifier_span\`: search outward from the anchor (the identifier is normally at it) instead of scanning the file from the top.
- \`valid_labelled_loop_control\`/\`label_starts_loop\`: ancestor walk over the direct-parent index instead of full-AST scans plus source brace matching per labelled break/continue.

### New shared collect-time indexes replacing per-call linear scans
- import alias/suffix path index (\`current_file_import_path_for_alias\`, \`diagnostic_type_name\` fallback — both were O(top-level decls) per namespace selector)
- struct embed receiver index (\`embedded_method_candidates\`/\`embedded_field_candidates\` walked every field of every struct per method lookup; no-embed structs now early-out)
- \`strict_map_index\` file set (was an O(top-level) scan per unguarded map index)
- \`visible_mutation_struct_field_is_public\` now resolves through \`type_declaration_ids\` instead of scanning every top-level declaration per struct-init field

Remaining to get under 200ms (follow-up): the serial \`ck collect\` pass2 (~34ms of signature/field type-text parsing) could pre-warm the parse cache in parallel, and the worker profile is now dominated by diffuse small-string interpolation keys and map traffic rather than any single function.