### PR TITLE
checker: fix wrapped fn aliases in multiple returns

### DIFF
--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -533,7 +533,10 @@ fn (t &Table) method_types_are_equal(left Type, right Type) bool {
 	return unaliased_left == unaliased_right
 }
 
-fn (t &Table) method_fn_return_types_are_compatible(left Type, right Type) bool {
+fn (t &Table) method_return_types_are_compatible(left Type, right Type) bool {
+	if t.method_types_are_equal(left, right) {
+		return true
+	}
 	unaliased_left := t.fully_unaliased_type(left)
 	unaliased_right := t.fully_unaliased_type(right)
 	if unaliased_left.nr_muls() != unaliased_right.nr_muls() {
@@ -552,15 +555,22 @@ fn (t &Table) method_fn_return_types_are_compatible(left Type, right Type) bool 
 		}
 		return t.fn_types_are_compatible(left_sym.info.func, right_sym.info.func, 0)
 	}
+	if left_sym.info is MultiReturn && right_sym.info is MultiReturn {
+		if left_sym.info.types.len != right_sym.info.types.len {
+			return false
+		}
+		for i, typ in left_sym.info.types {
+			if !t.method_return_types_are_compatible(typ, right_sym.info.types[i]) {
+				return false
+			}
+		}
+		return true
+	}
 	return false
 }
 
 pub fn (t &Table) is_same_method(f &Fn, func &Fn) string {
-	mut same_return_type := t.method_types_are_equal(f.return_type, func.return_type)
-	if !same_return_type {
-		same_return_type = t.method_fn_return_types_are_compatible(f.return_type, func.return_type)
-	}
-	if !same_return_type {
+	if !t.method_return_types_are_compatible(f.return_type, func.return_type) {
 		s := t.type_to_str(f.return_type)
 		return 'expected return type `${s}`'
 	}

--- a/vlib/v/tests/interfaces/interface_method_multi_return_option_fn_alias_test.v
+++ b/vlib/v/tests/interfaces/interface_method_multi_return_option_fn_alias_test.v
@@ -1,0 +1,18 @@
+type Msg = string
+
+type Cmd = fn () ?Msg
+
+interface Model {
+	update(msg Msg) (Model, ?Cmd)
+}
+
+struct ExampleModel {}
+
+fn (_ ExampleModel) update(msg Msg) (Model, ?Cmd) {
+	_ = msg
+	panic('not implemented')
+}
+
+fn test_interface_method_multi_return_option_fn_alias() {
+	_ := Model(ExampleModel{})
+}


### PR DESCRIPTION
Fixes #27976.

## What changed

- compare interface method multiple-return signatures component by component
- reuse the existing strict wrapped function-alias compatibility rules for each component
- add a regression test for an optional function alias inside a multiple return

## Root cause

The checker only applied wrapped function-alias compatibility when the complete method return type was a function. A `MultiReturn` symbol stopped that comparison before it reached the optional function component, so identical signatures were rejected.

## Impact

Concrete methods whose multiple-return signatures exactly match an interface now satisfy that interface when a component is an optional function type alias. Existing incompatible wrapped-alias cases remain rejected.

## Checks

- `VFLAGS='-gc none' ./vnew -gc none -silent vlib/v/compiler_errors_test.v` (1604 passed, 1 skipped)
- `VFLAGS='-old-compiler -gc none' ./vnew -old-compiler -gc none -silent test vlib/v/tests/interfaces/` (101 passed)
- `VFLAGS='-old-compiler -gc none' ./vnew -old-compiler -gc none -silent test vlib/v/ast/` (5 passed)
- `VFLAGS='-old-compiler -gc none' ./vnew -old-compiler -gc none -silent test vlib/v/checker/` (3 passed)

A full `vlib/v/` run was also started, but the isolated worktree does not contain the ignored bundled `thirdparty/tcc` GC runtime, so GC-specific tests failed on missing `libgc.dylib` before the run completed.