### PR TITLE
v3: keep refined C extern redeclarations in the signature tables

### DIFF
--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -5127,10 +5127,19 @@ fn (mut tc TypeChecker) register_fn_signature(name string, ret_type Type, params
 
 // register_fn_name_alias updates register fn name alias state for types.
 fn (mut tc TypeChecker) register_fn_name_alias(name string, ret_type Type, params []Type, shared_params []bool, is_variadic bool, implicit_veb_ctx bool) {
-	if owner_module := tc.fn_type_modules[name] {
-		if owner_module != tc.cur_module && tc.cur_module !in ['', 'main', 'builtin']
-			&& !name.starts_with('${tc.cur_module}.') {
-			return
+	// C externs live in one global namespace and modules routinely redeclare
+	// them with refined types (builtin: `C.pthread_join(thread voidptr, ...)`,
+	// v3.workers: `C.pthread_join(thread C.pthread_t, ...)`). The
+	// first-registration guard below must not drop those refinements: cgen's
+	// module-blind parameter lookup would then see `voidptr` and take the
+	// address of struct-typed handles (gen-2 compilers panicked with
+	// `failed to join compiler worker 0`).
+	if !name.starts_with('C.') {
+		if owner_module := tc.fn_type_modules[name] {
+			if owner_module != tc.cur_module && tc.cur_module !in ['', 'main', 'builtin']
+				&& !name.starts_with('${tc.cur_module}.') {
+				return
+			}
 		}
 	}
 	tc.fn_ret_types[name] = ret_type

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -5151,8 +5151,15 @@ fn (mut tc TypeChecker) register_fn_name_alias(name string, ret_type Type, param
 		tc.fn_shared_params.delete(name)
 	}
 	if tc.cur_file.len > 0 {
-		tc.fn_type_files[name] = tc.cur_file
-		tc.fn_type_modules[name] = tc.cur_module
+		// A refined C-extern redeclaration updates the signature tables above
+		// but must not steal ownership: is_builtin_unsafe_c_call keys the
+		// unsafe-block requirement for the C.m*/C.s* memory externs off the
+		// builtin owner, so a module redeclaring C.malloc (json does) would
+		// otherwise suppress that diagnostic program-wide.
+		if !name.starts_with('C.') || name !in tc.fn_type_modules {
+			tc.fn_type_files[name] = tc.cur_file
+			tc.fn_type_modules[name] = tc.cur_module
+		}
 	}
 	tc.fn_variadic[name] = is_variadic
 	if implicit_veb_ctx || tc.fn_implicit_veb_ctx.len > 0 {


### PR DESCRIPTION
Fixes the second-generation bootstrap regression introduced by \`579ec07454\` (bisected: \`73fa3211d6\` good → \`579ec07454\` bad, also reported on #27974): v4 (built with \`-building-v\`) and v5 panic with \`V panic: failed to join compiler worker 0\` in the \`close_workers\` defer after every otherwise-successful compile.

**Root cause.** \`579ec07454\` added a first-registration-wins guard to \`register_fn_name_alias\` so cross-module V-name collisions cannot clobber signatures. C externs live in one global namespace, though, and modules routinely redeclare them with refined types: builtin declares \`fn C.pthread_join(thread voidptr, retval voidptr)\` while \`v3.workers\` refines it to \`(thread C.pthread_t, retval voidptr)\`. The guard silently dropped the refinement from the global \`fn_param_types\` table. The checker's own call path is module-aware (\`c_fn_module_param_types\`) and unaffected — but cgen's \`param_types_for\` reads the module-blind global table, saw \`voidptr\`, and \`voidptr_value_arg_needs_address\` then emitted \`pthread_join(&thread_id, …)\` instead of \`pthread_join(thread_id, …)\`, passing the address of the stack slot rather than the handle. It compiles silently (the emitted prototype is \`pthread_join(void*, …)\`) and only fails at join time.

**Fix.** Exempt \`C.\`-prefixed names from the guard, restoring last-write-wins for extern redeclarations (the pre-\`579ec07454\` behavior). The guard's protection for V functions is unchanged.

**Validation.**
- Minimal repro (module declaring \`C.pthread_join(thread C.pthread_t, …)\` + for-in over \`[]C.pthread_t\`): bad compiler emits \`&thread_id\`, fixed compiler emits \`thread_id\`.
- Full bootstrap: v1 → v3(prod) → v4 → v5 all exit 0, zero join panics (both v4-compiling-small-programs and v4-compiling-v3.v).
- \`checker_parallel_test\`, \`format_test\`, \`fixturetest_test\` pass; \`markused_test\` and \`post_merge_review_fixes_test\` fail identically on pristine master (pre-existing, not from this change).