### PR TITLE
term.ui: fix CJK/IME input on Windows (fake control key events, lost console mode flags)

### DIFF
--- a/vlib/term/ui/input_windows.c.v
+++ b/vlib/term/ui/input_windows.c.v
@@ -52,15 +52,13 @@ pub fn init(cfg Config) &Context {
 	}
 
 	// enable extended input flags (see https://stackoverflow.com/a/46802726)
-	// 0x80 == C.ENABLE_EXTENDED_FLAGS
-	if !C.SetConsoleMode(stdin_handle, 0x80) {
-		panic('could not set raw input mode')
-	}
-	mut input_mode := u32(C.ENABLE_WINDOW_INPUT)
+	mut input_mode := u32(C.ENABLE_EXTENDED_FLAGS) | u32(C.ENABLE_WINDOW_INPUT)
 	if ctx.cfg.mouse_enabled {
 		input_mode |= u32(C.ENABLE_MOUSE_INPUT)
 	}
 	// enable window input and optionally mouse input events.
+	// set all flags in a single call, since each SetConsoleMode call replaces
+	// the previous input mode completely, instead of extending it.
 	if !C.SetConsoleMode(stdin_handle, input_mode) {
 		panic('could not set raw input mode')
 	}
@@ -130,6 +128,18 @@ pub fn (mut ctx Context) run() ! {
 	}
 }
 
+// key_code_for_char maps the character of a key event that did not match
+// any of the known virtual key codes to a KeyCode.
+fn key_code_for_char(e C.KEY_EVENT_RECORD) KeyCode {
+	// non-ASCII characters (e.g. from CJK IME input) have no ASCII
+	// representation; mapping their low byte to a KeyCode would
+	// produce fake control keys like .escape
+	if unsafe { e.uChar.UnicodeChar } > 0x7F {
+		return KeyCode.null
+	}
+	return unsafe { KeyCode(e.uChar.AsciiChar) }
+}
+
 fn (mut ctx Context) parse_events() {
 	nr_events := u32(0)
 	if !C.GetNumberOfConsoleInputEvents(ctx.stdin_handle, &nr_events) {
@@ -168,7 +178,7 @@ fn (mut ctx Context) parse_events() {
 					91...93 { KeyCode.null } // special keys
 					96...105 { unsafe { KeyCode(ch - 48) } } // numpad numbers
 					112...135 { unsafe { KeyCode(ch + 178) } } // f1 - f24
-					else { unsafe { KeyCode(ascii) } }
+					else { key_code_for_char(e) }
 				}
 
 				mut modifiers := unsafe { Modifiers(0) }

--- a/vlib/term/ui/input_windows_test.v
+++ b/vlib/term/ui/input_windows_test.v
@@ -1,0 +1,23 @@
+module ui
+
+fn key_event_with_char(c rune) C.KEY_EVENT_RECORD {
+	mut e := C.KEY_EVENT_RECORD{}
+	unsafe {
+		e.uChar.UnicodeChar = c
+	}
+	return e
+}
+
+fn test_key_code_for_char_maps_ascii_characters() {
+	assert key_code_for_char(key_event_with_char(`a`)) == .a
+	assert key_code_for_char(key_event_with_char(rune(0x1B))) == .escape
+}
+
+fn test_key_code_for_char_ignores_non_ascii_characters() {
+	// characters with a 0x1B low byte, like `创` (U+521B) and `唛` (U+551B),
+	// previously produced fake .escape key events
+	assert key_code_for_char(key_event_with_char(rune(0x521B))) == .null
+	assert key_code_for_char(key_event_with_char(rune(0x551B))) == .null
+	// `é` (U+00E9) previously mapped to an invalid KeyCode value
+	assert key_code_for_char(key_event_with_char(rune(0xE9))) == .null
+}


### PR DESCRIPTION
This fixes two related bugs in `term.ui` on Windows that made
CJK (Chinese/Japanese/Korean) input via an IME (input method editor)
unusable:

1. In `init()`, the second `SetConsoleMode` call completely replaced the
   mode set by the first one, so `ENABLE_EXTENDED_FLAGS` (0x80) was lost
   immediately after being set. `SetConsoleMode` replaces the whole input
   mode instead of extending it, so all flags are now set in a single
   call. The `0x80` literal was replaced with the equivalent
   `C.ENABLE_EXTENDED_FLAGS` constant, matching the other flags in the
   same expression (which also made the comment explaining the magic
   number unnecessary).

2. In `parse_events()`, the fallback branch of the key code match mapped
   the low byte of the character (`uChar.AsciiChar`) to a `KeyCode`. For
   non-ASCII characters (e.g. from CJK IME input), this produced bogus
   `KeyCode` values, including fake control key events: for example `创`
   (U+521B) or `唛` (U+551B) have a low byte of `0x1B`, so typing them
   generated a spurious `.escape` key_down event. Such characters now
   report `KeyCode.null`, while the character itself is still delivered
   correctly through the `utf8` field. ASCII input is unaffected.

Tested on Windows 10 (22H2) with a Chinese IME, using a small `term.ui`
echo program: IME composition works, and characters with a `0x1B` low
byte like `创` (U+521B) now produce `code=null` events instead of fake
`.escape` events, which previously made TUI applications quit.
`v fmt -verify` passes and `v test vlib/term/ui` is green, including a
new `input_windows_test.v` that covers the `KeyCode` mapping fix.
