### PR TITLE
v3: keep scoped macOS transforms parallel

### DIFF
--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -4455,11 +4455,13 @@ pub fn run(args []string) {
 		}
 		exit(1)
 	}
-	// Parallel transform is disabled for larger embedded imports to stay below
-	// 2 GiB. Cgen workers reconcile their local string IDs during the ordered
-	// merge, so embedded generation remains deterministic in parallel.
+	// Parallel transform is disabled for larger embedded imports when worker
+	// scratch allocations live for the whole compilation. Scoped preallocation
+	// releases that scratch after each stage, so it can retain parallel transform
+	// without the former memory growth. Cgen workers reconcile their local string
+	// IDs during the ordered merge, so embedded generation remains deterministic.
 	if !current_no_parallel && os.getenv(v3_embedded_env) == '1' {
-		if a.nodes.len >= embedded_parallel_transform_node_limit {
+		if !scope_prealloc_transform && a.nodes.len >= embedded_parallel_transform_node_limit {
 			current_parallel_transform = false
 		}
 	}


### PR DESCRIPTION
## Summary

- keep large embedded macOS V3 transforms parallel when scoped preallocation contains worker scratch memory
- preserve the existing serial cutoff for ordinary no-GC compiler builds
- update the guard comment to describe the scoped allocation behavior

## Performance

Measured with an unoptimized Office C generation on macOS:

```text
time v -o new.c cmd/excel
before: 2.82-3.00s
 after: 2.63-2.76s
```

The final exact run was 2.48s. Peak footprint remained bounded at about 3.4 GB with scoped preallocation, compared with about 6.7 GB for the non-scoped compiler build.

## Validation

- `./vnew -silent test vlib/v3/driver/implicit_import_test.v`
- generated Office C twice and verified byte-identical output
- `git diff --check`

The compiler used for these measurements was built with `-prod -prealloc`; no garbage collector is used.