### PR TITLE
ci: pair macOS-amd64 tcc.exe rebuilds with a freshly-rebuilt, dynamically-linked libgc

### DIFF
--- a/.github/workflows/update_tccbin.yml
+++ b/.github/workflows/update_tccbin.yml
@@ -299,7 +299,31 @@ jobs:
           set -euo pipefail
           cd thirdparty/tcc
           libgc_dylib_target=$(readlink lib/libgc.dylib)
-          git add lib/libgc.a "lib/libgc.dylib" "lib/$libgc_dylib_target" lib/libgc_build_*.txt bundle_checksums.txt build_macosx_deployment_target.txt build_toolchain_identity.txt
+          # -A (not a hardcoded file list) against these exact globs:
+          # if bdwgc's SONAME bumped this run (e.g. libgc.1.dylib ->
+          # libgc.2.dylib), the old versioned file was already removed
+          # from disk by thirdparty-macos-amd64_bdwgc.sh's own cleanup
+          # step, but a plain `git add <new-file-list>` never mentions
+          # the old path, so its deletion would never get staged - the
+          # stale file would keep reappearing from history on every
+          # future checkout. `git add -A -- <pathspec>` stages adds AND
+          # deletions matching the glob, so whatever SONAME disappeared
+          # this run is captured without needing to know its name.
+          #
+          # Deliberately only libgc*.dylib/libgc*.a here, NOT libgc.la/
+          # libgc.lai (which thirdparty-macos-amd64_bdwgc.sh's own
+          # cleanup line also removes defensively, but rsyncs only from
+          # bdwgc/.libs/ - libtool's .la/.lai wrapper files live one
+          # level up and are never actually staged into lib/ in the
+          # first place). `git add -A -- <pathspecs>` fails its ENTIRE
+          # invocation (stages nothing, not even the globs that do
+          # match) if even one pathspec matches zero files either
+          # on disk or in the index - confirmed by testing. A glob for
+          # a file that plausibly never exists here would turn this
+          # into a hard failure on every single normal run, not just a
+          # SONAME bump.
+          git add -A -- 'lib/libgc*.dylib' 'lib/libgc*.a' lib/libgc_build_*.txt bundle_checksums.txt build_macosx_deployment_target.txt build_toolchain_identity.txt
+          git status --porcelain
           git commit -m "pair libgc rebuild (bdwgc $LIBGC_COMMIT) with this tcc.exe rebuild"
         env:
           LIBGC_COMMIT: ${{ steps.bdwgc.outputs.libgc_hash }}
@@ -339,6 +363,20 @@ jobs:
       # so letting `make`'s default target bootstrap it normally here
       # is safe - unlike running `make` against the staged checkout
       # itself, which would `git clean -xf` away everything just built.
+      #
+      # Plain `make -j4`, deliberately NOT `make local=1`: both vc/ and
+      # thirdparty/tcc are gitignored, so this fresh `git clone` starts
+      # with neither. `local=1` makes the `latest_vc`/`latest_tcc`
+      # targets skip their own git-clone bootstrap entirely (see
+      # GNUmakefile's `ifndef local` branches) on the assumption that
+      # vc/v.c already exists from an earlier step in the same
+      # job - true in bootstrapping_ci.yml, which runs a plain `make`
+      # first, but not true here. `make local=1` here would fail
+      # outright with no vc/v.c to bootstrap v1 from. `latest_tcc`
+      # cloning its own stock thirdparty/tcc under plain `make` is
+      # harmless: the next step wholesale-replaces it with the staged,
+      # fresh-checkout-validated bundle only after this `make` already
+      # finished building ./v.
       - name: Build V from source in an isolated workspace
         if: matrix.id == 'macos-amd64' && steps.rebuild.outputs.skip != 'true'
         shell: bash
@@ -372,7 +410,7 @@ jobs:
           print("smoke-test-only selector patch applied in isolated workspace")
           PYEOF
 
-          (cd /tmp/v-bootstrap-workspace && make local=1 -j4)
+          (cd /tmp/v-bootstrap-workspace && make -j4)
 
       - name: Real V + tcc + boehm compile-and-execute smoke test
         if: matrix.id == 'macos-amd64' && steps.rebuild.outputs.skip != 'true'
@@ -463,8 +501,23 @@ jobs:
           name: tccbin-${{ matrix.id }}
           path: thirdparty/tcc
 
+      # macos-amd64 additionally requires an explicit unlock: vlang/tccbin's
+      # thirdparty-macos-amd64 build-and-test.yml currently hard-fails if the
+      # checked-in package unexpectedly starts passing (today it's supposed
+      # to still be broken) - that gate must flip to "must pass" (deliverable
+      # B) BEFORE a working pair is ever pushed here, or the very next green
+      # publish breaks that CI for the opposite reason. PUBLISH alone isn't
+      # a safe gate for this platform: it's true unconditionally on every
+      # monthly schedule run, and also on any manual dispatch with
+      # publish=true, regardless of whether B has landed yet. Repo variable
+      # MACOS_AMD64_LIBGC_PUBLISH_UNLOCKED defaults to unset (falsy), so
+      # this stays closed until a maintainer sets it to 'true' after
+      # confirming B is live and green - see the "Sequence" section of the
+      # PR description.
       - name: Push tccbin branch
-        if: steps.rebuild.outputs.skip != 'true' && env.PUBLISH == 'true'
+        if: >-
+          steps.rebuild.outputs.skip != 'true' && env.PUBLISH == 'true' &&
+          (matrix.id != 'macos-amd64' || vars.MACOS_AMD64_LIBGC_PUBLISH_UNLOCKED == 'true')
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/update_tccbin.yml
+++ b/.github/workflows/update_tccbin.yml
@@ -143,9 +143,10 @@ jobs:
             fi
             sleep "$((attempt * 5))"
           done
+          git -C /tmp/libatomic_ops-ref checkout --quiet master
           libatomic_ops_hash="$(git -C /tmp/libatomic_ops-ref rev-parse HEAD)"
           echo "libatomic_ops_hash=$libatomic_ops_hash" >> "$GITHUB_OUTPUT"
-          echo "libatomic_ops default branch resolves to $libatomic_ops_hash"
+          echo "libatomic_ops master resolves to $libatomic_ops_hash"
 
       - name: Clone tccbin branch
         id: tccbin
@@ -266,6 +267,7 @@ jobs:
           CC: clang
           TCC_FOLDER: thirdparty/tcc
           LIBGC_COMMIT: ${{ steps.bdwgc.outputs.libgc_hash }}
+          LIBATOMIC_OPS_COMMIT: ${{ steps.bdwgc.outputs.libatomic_ops_hash }}
           RECIPE_VERSION: ${{ env.MACOS_AMD64_RECIPE_VERSION }}
         run: bash thirdparty/build_scripts/thirdparty-macos-amd64_bdwgc.sh
 
@@ -281,7 +283,13 @@ jobs:
           set -euo pipefail
           cd thirdparty/tcc
           libgc_dylib_target=$(readlink lib/libgc.dylib)
-          shasum -a 256 tcc.exe "lib/$libgc_dylib_target" lib/libgc.a lib/libtcc.a lib/libtcc1.a > bundle_checksums.txt
+          # lib/libgc.dylib is a symlink - shasum follows it and hashes
+          # the same content as lib/$libgc_dylib_target, but recording
+          # it under this name too matters: it's the exact path V's
+          # #flag @VEXEROOT/thirdparty/tcc/lib/libgc.dylib references,
+          # so a consumer verifying the bundle checks the path that
+          # actually gets used, not just its resolved target.
+          shasum -a 256 tcc.exe lib/libgc.dylib "lib/$libgc_dylib_target" lib/libgc.a lib/libtcc.a lib/libtcc1.a > bundle_checksums.txt
           cat bundle_checksums.txt
 
       - name: Commit paired libgc rebuild

--- a/.github/workflows/update_tccbin.yml
+++ b/.github/workflows/update_tccbin.yml
@@ -7,6 +7,10 @@ on:
         description: 'TinyCC ref, branch, or commit to build'
         required: false
         default: mob
+      libgc_commit:
+        description: 'bdwgc (Boehm GC) ref, branch, or commit to build - macOS amd64 only for now'
+        required: false
+        default: master
       publish:
         description: 'Push the rebuilt bundle to vlang/tccbin'
         type: boolean
@@ -49,9 +53,21 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       TCC_COMMIT: ${{ github.event.inputs.tcc_commit || 'mob' }}
+      LIBGC_COMMIT: ${{ github.event.inputs.libgc_commit || 'master' }}
       TCCBIN_REPO: vlang/tccbin
       PUBLISH: ${{ github.event_name == 'schedule' || github.event.inputs.publish == 'true' }}
       FORCE_REBUILD: ${{ github.event.inputs.force_rebuild == 'true' }}
+      ## Bump whenever the macos-amd64 paired-rebuild recipe (this
+      ## workflow's macos-amd64-scoped steps, or the _bdwgc*.sh scripts
+      ## they call) changes materially, independent of any upstream
+      ## SHA - lets "Check whether rebuild is needed" force a rebuild on
+      ## a recipe change alone.
+      MACOS_AMD64_RECIPE_VERSION: "1"
+      ## Single source of truth for both halves of the macos-amd64
+      ## pair - passed explicitly to both scripts below rather than
+      ## relying on their own internal defaults, so this check step
+      ## and the actual build can never independently drift.
+      MACOSX_DEPLOYMENT_TARGET: "10.13"
     steps:
       - uses: actions/checkout@v7
 
@@ -62,6 +78,13 @@ jobs:
       - name: Install macOS build dependencies
         if: runner.os == 'macOS'
         run: brew install make
+
+      - name: Install macOS build dependencies (bdwgc rebuild)
+        if: matrix.id == 'macos-amd64'
+        ## automake/libtool are needed by bdwgc's autogen.sh (aclocal,
+        ## libtoolize) - exact match to vlang/tccbin's own already-
+        ## proven CI step for this same rebuild.
+        run: brew install make automake libtool
 
       - name: Resolve TinyCC source hash
         id: tinycc
@@ -82,6 +105,47 @@ jobs:
           hash="$(git -C /tmp/tinycc-ref rev-parse HEAD)"
           echo "hash=$hash" >> "$GITHUB_OUTPUT"
           echo "TinyCC $TCC_COMMIT resolves to $hash"
+
+      # Resolved once, here, and passed through explicitly as
+      # LIBGC_COMMIT into thirdparty-macos-amd64_bdwgc.sh below (which
+      # checks out this exact SHA, not a re-fetched floating ref) - so
+      # the rebuild-decision fingerprint and the actual build can never
+      # silently drift apart if LIBGC_COMMIT/libatomic_ops's default
+      # branch moves between resolving and building.
+      - name: Resolve bdwgc/libatomic_ops source hashes
+        if: matrix.id == 'macos-amd64'
+        id: bdwgc
+        shell: bash
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            if git clone --quiet https://github.com/ivmai/bdwgc /tmp/bdwgc-ref; then
+              break
+            fi
+            rm -rf /tmp/bdwgc-ref
+            if [ "$attempt" -eq 3 ]; then
+              exit 1
+            fi
+            sleep "$((attempt * 5))"
+          done
+          git -C /tmp/bdwgc-ref checkout --quiet "$LIBGC_COMMIT"
+          libgc_hash="$(git -C /tmp/bdwgc-ref rev-parse HEAD)"
+          echo "libgc_hash=$libgc_hash" >> "$GITHUB_OUTPUT"
+          echo "bdwgc $LIBGC_COMMIT resolves to $libgc_hash"
+
+          for attempt in 1 2 3; do
+            if git clone --quiet https://github.com/bdwgc/libatomic_ops /tmp/libatomic_ops-ref; then
+              break
+            fi
+            rm -rf /tmp/libatomic_ops-ref
+            if [ "$attempt" -eq 3 ]; then
+              exit 1
+            fi
+            sleep "$((attempt * 5))"
+          done
+          libatomic_ops_hash="$(git -C /tmp/libatomic_ops-ref rev-parse HEAD)"
+          echo "libatomic_ops_hash=$libatomic_ops_hash" >> "$GITHUB_OUTPUT"
+          echo "libatomic_ops default branch resolves to $libatomic_ops_hash"
 
       - name: Clone tccbin branch
         id: tccbin
@@ -108,11 +172,52 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          skip=false
           if [ "$FORCE_REBUILD" != 'true' ] \
             && [ -f thirdparty/tcc/build_source_hash.txt ] \
             && [ "$(cat thirdparty/tcc/build_source_hash.txt)" = "${{ steps.tinycc.outputs.hash }}" ]; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
+            skip=true
             echo "tccbin/${{ matrix.branch }} already has TinyCC ${{ steps.tinycc.outputs.hash }}"
+          fi
+
+          # macos-amd64 ships a PAIR (tcc.exe + libgc) - a TinyCC-only
+          # hash match isn't enough to skip, since libgc has its own
+          # independent upstream (bdwgc/libatomic_ops), its own pinned
+          # deployment target, and its own recipe. Fingerprint the whole
+          # pair; skip only when every part of it, and the required
+          # output files, are already exactly what a rebuild would
+          # produce.
+          if [ "${{ matrix.id }}" = 'macos-amd64' ] && [ "$skip" = 'true' ]; then
+            reason=""
+            if [ ! -f thirdparty/tcc/lib/libgc_build_source_hash.txt ] \
+              || [ "$(cat thirdparty/tcc/lib/libgc_build_source_hash.txt)" != "${{ steps.bdwgc.outputs.libgc_hash }}" ]; then
+              reason="bdwgc hash mismatch or missing"
+            elif [ ! -f thirdparty/tcc/lib/libgc_build_libatomic_ops_source_hash.txt ] \
+              || [ "$(cat thirdparty/tcc/lib/libgc_build_libatomic_ops_source_hash.txt)" != "${{ steps.bdwgc.outputs.libatomic_ops_hash }}" ]; then
+              reason="libatomic_ops hash mismatch or missing"
+            elif [ ! -f thirdparty/tcc/build_macosx_deployment_target.txt ] \
+              || [ "$(cat thirdparty/tcc/build_macosx_deployment_target.txt)" != "$MACOSX_DEPLOYMENT_TARGET" ]; then
+              reason="deployment target mismatch or missing"
+            elif [ ! -f thirdparty/tcc/build_toolchain_identity.txt ] \
+              || [ "$(cat thirdparty/tcc/build_toolchain_identity.txt)" != "$(clang --version)" ]; then
+              reason="toolchain identity mismatch or missing"
+            elif [ ! -f thirdparty/tcc/lib/libgc_build_recipe_version.txt ] \
+              || [ "$(cat thirdparty/tcc/lib/libgc_build_recipe_version.txt)" != "$MACOS_AMD64_RECIPE_VERSION" ]; then
+              reason="recipe version mismatch or missing"
+            elif [ ! -L thirdparty/tcc/lib/libgc.dylib ] \
+              || [ ! -f "thirdparty/tcc/lib/$(readlink thirdparty/tcc/lib/libgc.dylib)" ]; then
+              reason="libgc.dylib missing or not a valid symlink"
+            elif [ ! -f thirdparty/tcc/bundle_checksums.txt ]; then
+              reason="bundle_checksums.txt missing"
+            fi
+            if [ -n "$reason" ]; then
+              echo "macos-amd64 pair fingerprint mismatch ($reason) - forcing rebuild despite TinyCC hash match"
+              skip=false
+            fi
+          fi
+
+          if [ "$skip" = 'true' ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
@@ -145,6 +250,192 @@ jobs:
           EOF
           thirdparty/tcc/tcc.exe /tmp/tcc-stdatomic-smoke.c -o /tmp/tcc-stdatomic-smoke
           /tmp/tcc-stdatomic-smoke
+
+      # macos-amd64 only, from here through the tar upload: rebuild
+      # libgc.dylib in step with this same tcc.exe (the checked-in
+      # libgc.a has been silently preserved untouched across every
+      # prior rebuild, which is the root cause of the pair's
+      # conformance failure this whole change addresses), validate the
+      # pair, commit it separately from the tcc.exe commit above, then
+      # re-validate against a genuinely independent fresh checkout
+      # before ever considering it safe to upload/publish.
+      - name: Build paired libgc (macOS amd64)
+        if: matrix.id == 'macos-amd64' && steps.rebuild.outputs.skip != 'true'
+        shell: bash
+        env:
+          CC: clang
+          TCC_FOLDER: thirdparty/tcc
+          LIBGC_COMMIT: ${{ steps.bdwgc.outputs.libgc_hash }}
+          RECIPE_VERSION: ${{ env.MACOS_AMD64_RECIPE_VERSION }}
+        run: bash thirdparty/build_scripts/thirdparty-macos-amd64_bdwgc.sh
+
+      - name: Validate staged tcc.exe + libgc pairing (build directory)
+        if: matrix.id == 'macos-amd64' && steps.rebuild.outputs.skip != 'true'
+        shell: bash
+        run: bash thirdparty/build_scripts/thirdparty-macos-amd64_bdwgc_validate.sh thirdparty/tcc
+
+      - name: Record bundle checksums
+        if: matrix.id == 'macos-amd64' && steps.rebuild.outputs.skip != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd thirdparty/tcc
+          libgc_dylib_target=$(readlink lib/libgc.dylib)
+          shasum -a 256 tcc.exe "lib/$libgc_dylib_target" lib/libgc.a lib/libtcc.a lib/libtcc1.a > bundle_checksums.txt
+          cat bundle_checksums.txt
+
+      - name: Commit paired libgc rebuild
+        if: matrix.id == 'macos-amd64' && steps.rebuild.outputs.skip != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd thirdparty/tcc
+          libgc_dylib_target=$(readlink lib/libgc.dylib)
+          git add lib/libgc.a "lib/libgc.dylib" "lib/$libgc_dylib_target" lib/libgc_build_*.txt bundle_checksums.txt build_macosx_deployment_target.txt build_toolchain_identity.txt
+          git commit -m "pair libgc rebuild (bdwgc $LIBGC_COMMIT) with this tcc.exe rebuild"
+        env:
+          LIBGC_COMMIT: ${{ steps.bdwgc.outputs.libgc_hash }}
+
+      - name: Clone a fresh, independent checkout of the new commit
+        if: matrix.id == 'macos-amd64' && steps.rebuild.outputs.skip != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -rf /tmp/tccbin-fresh-checkout
+          # Clone from the LOCAL thirdparty/tcc, not GitHub - these
+          # commits haven't been pushed yet, and the whole point is to
+          # verify exactly what's about to be pushed, not what's
+          # already public.
+          git clone --quiet thirdparty/tcc /tmp/tccbin-fresh-checkout
+          if [ -n "$(git -C /tmp/tccbin-fresh-checkout status --porcelain)" ]; then
+            echo "::error::fresh checkout of the new commit is not clean - something is untracked or modified that shouldn't be:"
+            git -C /tmp/tccbin-fresh-checkout status
+            exit 1
+          fi
+          echo "fresh checkout is clean at $(git -C /tmp/tccbin-fresh-checkout rev-parse HEAD)"
+
+      - name: Re-validate against the fresh, independent checkout
+        if: matrix.id == 'macos-amd64' && steps.rebuild.outputs.skip != 'true'
+        shell: bash
+        run: bash thirdparty/build_scripts/thirdparty-macos-amd64_bdwgc_validate.sh /tmp/tccbin-fresh-checkout
+
+      # Deliverable A (this PR) does not include the V selector change
+      # (deliverable C, vlib/builtin/builtin_d_gcboehm.c.v) - it merges
+      # separately, only after this pair is published and vlang/tccbin's
+      # gate is confirmed green under it. To actually exercise the
+      # dylib pairing here, apply that selector collapse to an entirely
+      # separate, freshly-cloned vlang/v workspace, in memory only -
+      # never written back to this checkout, never committed anywhere.
+      # This clone's own thirdparty/tcc has nothing to do with the
+      # bundle staged above (a brand new clone doesn't have one yet),
+      # so letting `make`'s default target bootstrap it normally here
+      # is safe - unlike running `make` against the staged checkout
+      # itself, which would `git clean -xf` away everything just built.
+      - name: Build V from source in an isolated workspace
+        if: matrix.id == 'macos-amd64' && steps.rebuild.outputs.skip != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -rf /tmp/v-bootstrap-workspace
+          git clone --quiet "https://github.com/${{ github.repository }}" /tmp/v-bootstrap-workspace
+          git -C /tmp/v-bootstrap-workspace checkout --quiet "${{ github.sha }}"
+
+          python3 - <<'PYEOF'
+          path = "/tmp/v-bootstrap-workspace/vlib/builtin/builtin_d_gcboehm.c.v"
+          with open(path, "r", encoding="utf-8", newline="") as f:
+              content = f.read()
+          old = ('\t\t\t\t\t\t$if arm64 {\n'
+                 '\t\t\t\t\t\t\t// tcc on macOS arm64 can leave the bundled GC archive symbols unresolved.\n'
+                 '\t\t\t\t\t\t\t#flag @VEXEROOT/thirdparty/tcc/lib/libgc.dylib\n'
+                 '\t\t\t\t\t\t\t#flag -Wl,-rpath,"@VEXEROOT/thirdparty/tcc/lib"\n'
+                 '\t\t\t\t\t\t} $else {\n'
+                 '\t\t\t\t\t\t\t// macOS amd64 tccbin only ships libgc.a (no .dylib).\n'
+                 '\t\t\t\t\t\t\t#flag @VEXEROOT/thirdparty/tcc/lib/libgc.a\n'
+                 '\t\t\t\t\t\t}\n')
+          new = ('\t\t\t\t\t\t// SMOKE-TEST-ONLY PATCH (thirdparty-macos-amd64_bdwgc_validate.sh\n'
+                 '\t\t\t\t\t\t// caller) - never committed. Deliverable C applies this for real.\n'
+                 '\t\t\t\t\t\t#flag @VEXEROOT/thirdparty/tcc/lib/libgc.dylib\n'
+                 '\t\t\t\t\t\t#flag -Wl,-rpath,"@VEXEROOT/thirdparty/tcc/lib"\n')
+          count = content.count(old)
+          assert count == 1, f"expected exactly 1 occurrence of the selector block to patch, found {count}"
+          content = content.replace(old, new)
+          with open(path, "w", encoding="utf-8", newline="") as f:
+              f.write(content)
+          print("smoke-test-only selector patch applied in isolated workspace")
+          PYEOF
+
+          (cd /tmp/v-bootstrap-workspace && make local=1 -j4)
+
+      - name: Real V + tcc + boehm compile-and-execute smoke test
+        if: matrix.id == 'macos-amd64' && steps.rebuild.outputs.skip != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Point the isolated-workspace V's @VEXEROOT/thirdparty/tcc
+          # resolution at the exact, fresh-checkout-validated staged
+          # bundle - copied in only now, after `make` already built
+          # ./v using its own unrelated bootstrap, never before.
+          rm -rf /tmp/v-bootstrap-workspace/thirdparty/tcc
+          cp -a /tmp/tccbin-fresh-checkout /tmp/v-bootstrap-workspace/thirdparty/tcc
+
+          cat > /tmp/tcc_boehm_gc_smoke.v <<'EOF'
+          module main
+
+          fn main() {
+              mut arrs := [][]int{}
+              for i in 0 .. 20000 {
+                  arrs << [i, i * 2, i * 3]
+              }
+              gc_collect()
+              mut sum := i64(0)
+              for a in arrs {
+                  sum += a[0]
+              }
+              println('sum=${sum}')
+              if sum != i64(20000) * 19999 / 2 {
+                  eprintln('mismatch: got ${sum}')
+                  exit(1)
+              }
+          }
+          EOF
+
+          showcc_output=$(/tmp/v-bootstrap-workspace/v -cc tcc -gc boehm -showcc -o /tmp/tcc_boehm_gc_smoke /tmp/tcc_boehm_gc_smoke.v 2>&1)
+          echo "$showcc_output"
+          /tmp/tcc_boehm_gc_smoke
+
+          # @VEXEROOT resolves relative to the isolated workspace (where
+          # ./v itself lives and runs from), NOT this job's own working
+          # directory - the staged bundle only got copied into the
+          # isolated workspace's thirdparty/tcc, so that's the path a
+          # correct run must actually reference.
+          expected_tcc="/tmp/v-bootstrap-workspace/thirdparty/tcc/tcc.exe"
+          case "$showcc_output" in
+            *"$expected_tcc"*) echo "confirmed: used the staged tcc.exe at $expected_tcc" ;;
+            *) echo "::error::-showcc output does not reference the staged tcc.exe ($expected_tcc) - the smoke test may have compiled with a different compiler entirely."; exit 1 ;;
+          esac
+          case "$showcc_output" in
+            *"libgc.dylib"*) ;;
+            *) echo "::error::-showcc output does not mention libgc.dylib - the smoke test did not actually link against the dylib."; exit 1 ;;
+          esac
+          case "$showcc_output" in
+            *"-rpath"*) ;;
+            *) echo "::error::-showcc output does not include an -rpath flag - the dylib would not be locatable at runtime outside this exact CI job."; exit 1 ;;
+          esac
+          case "$showcc_output" in
+            *"libgc.a"*) echo "::error::-showcc output mentions libgc.a - the smoke test linked the static archive, not the dylib, contradicting the whole point of this validation."; exit 1 ;;
+            *) echo "confirmed: libgc.a does not appear in the link line" ;;
+          esac
+
+      - name: Upload tar archive (macOS amd64, preserves symlinks and executable bits)
+        if: matrix.id == 'macos-amd64' && steps.rebuild.outputs.skip != 'true'
+        shell: bash
+        run: tar -czf /tmp/tccbin-macos-amd64.tar.gz -C /tmp/tccbin-fresh-checkout .
+      - name: Upload tar archive artifact (macOS amd64)
+        if: matrix.id == 'macos-amd64' && steps.rebuild.outputs.skip != 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: tccbin-macos-amd64-tar
+          path: /tmp/tccbin-macos-amd64.tar.gz
 
       - name: Verify tccbin workflows were preserved
         if: steps.rebuild.outputs.skip != 'true'

--- a/thirdparty/build_scripts/thirdparty-macos-amd64_bdwgc.sh
+++ b/thirdparty/build_scripts/thirdparty-macos-amd64_bdwgc.sh
@@ -26,6 +26,12 @@ export TCC_FOLDER="${TCC_FOLDER:-thirdparty/tcc}"
 ## in between). The `master` default here exists only for local/manual
 ## invocation outside that workflow.
 export LIBGC_COMMIT="${LIBGC_COMMIT:-master}"
+## Same reasoning as LIBGC_COMMIT above: pass the already-resolved
+## libatomic_ops SHA through explicitly and check it out, rather than
+## just cloning its default branch and recording whatever HEAD happens
+## to land - otherwise the resolved hash the caller fingerprinted and
+## the commit actually built could silently disagree.
+export LIBATOMIC_OPS_COMMIT="${LIBATOMIC_OPS_COMMIT:-master}"
 ## Neither half of the tcc.exe/libgc pair pins a deployment target
 ## today, so a rebuilt binary silently inherits the CI runner's own
 ## macOS floor. Pin one explicitly here; thirdparty-macos-amd64_tcc.sh
@@ -42,6 +48,7 @@ mkdir -p $TCC_FOLDER/lib/
 echo "                      CC: $CC"
 echo "              TCC_FOLDER: $TCC_FOLDER"
 echo "            LIBGC_COMMIT: $LIBGC_COMMIT"
+echo "   LIBATOMIC_OPS_COMMIT: $LIBATOMIC_OPS_COMMIT"
 echo "MACOSX_DEPLOYMENT_TARGET: $MACOSX_DEPLOYMENT_TARGET"
 echo "          RECIPE_VERSION: $RECIPE_VERSION"
 echo ===============================================================
@@ -63,11 +70,13 @@ cd bdwgc/
 git checkout $LIBGC_COMMIT
 export LIBGC_COMMIT_FULL_HASH=$(git rev-parse HEAD)
 
-## libatomic_ops is cloned from its moving default branch and gets
-## compiled into the resulting archive/dylib - record its resolved
-## commit too, so the pair's provenance covers everything that was
-## actually linked in, not just bdwgc's own commit.
+## Check out the explicitly-resolved commit, same as LIBGC_COMMIT
+## above - previously this cloned the default branch and recorded
+## whatever HEAD it happened to land on, which could silently disagree
+## with whatever hash the caller's rebuild-fingerprint check resolved
+## and recorded moments earlier.
 git clone https://github.com/bdwgc/libatomic_ops
+git -C libatomic_ops checkout $LIBATOMIC_OPS_COMMIT
 export LIBATOMIC_OPS_COMMIT_FULL_HASH=$(git -C libatomic_ops rev-parse HEAD)
 
 ./autogen.sh

--- a/thirdparty/build_scripts/thirdparty-macos-amd64_bdwgc.sh
+++ b/thirdparty/build_scripts/thirdparty-macos-amd64_bdwgc.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+
+set -e
+
+if ! test -f vlib/v/compiler_errors_test.v; then
+  echo "this script should be run in V's main repo folder!"
+  exit 1
+fi
+
+## ensure all output is in English, independent from the current user's local:
+export LANG=C
+
+export CURRENT_SCRIPT_PATH=$(realpath "$0")
+
+## CC defaults to clang here (not arm64_bdwgc.sh's gcc default) - this
+## matches the exact toolchain vlang/tccbin#74 already proved works for
+## a real, CI-validated macOS-amd64 libgc rebuild; not a guess.
+export CC="${CC:-clang}"
+export TCC_FOLDER="${TCC_FOLDER:-thirdparty/tcc}"
+## Callers should pass an already-resolved commit SHA here, not a
+## floating ref - the caller (update_tccbin.yml) resolves bdwgc's
+## commit once, before deciding whether a rebuild is even needed, and
+## must pass that exact resolved SHA through so the build can't
+## silently drift from what the skip-check just fingerprinted (a
+## `master` re-resolved independently at build time could have moved
+## in between). The `master` default here exists only for local/manual
+## invocation outside that workflow.
+export LIBGC_COMMIT="${LIBGC_COMMIT:-master}"
+## Neither half of the tcc.exe/libgc pair pins a deployment target
+## today, so a rebuilt binary silently inherits the CI runner's own
+## macOS floor. Pin one explicitly here; thirdparty-macos-amd64_tcc.sh
+## pins the same default for the tcc.exe half of the pair.
+export MACOSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET:-10.13}"
+## Bump this whenever this script's (or its validate-script sibling's)
+## own logic materially changes, independent of any upstream SHA - lets
+## the caller's rebuild-fingerprint check force a rebuild on a recipe
+## change alone, e.g. a fixed configure flag, even when bdwgc/
+## libatomic_ops/TinyCC haven't moved.
+export RECIPE_VERSION="${RECIPE_VERSION:-1}"
+mkdir -p $TCC_FOLDER/lib/
+
+echo "                      CC: $CC"
+echo "              TCC_FOLDER: $TCC_FOLDER"
+echo "            LIBGC_COMMIT: $LIBGC_COMMIT"
+echo "MACOSX_DEPLOYMENT_TARGET: $MACOSX_DEPLOYMENT_TARGET"
+echo "          RECIPE_VERSION: $RECIPE_VERSION"
+echo ===============================================================
+
+## A prior rebuild's libgc-family files (any SONAME, any extension)
+## must not linger alongside a freshly-built set - if libtool ever
+## bumps the SONAME (e.g. libgc.1.dylib -> libgc.2.dylib), an orphaned
+## old-versioned file left in place would be dead weight at best and a
+## confusing double-provider at worst. Clear the whole family before
+## staging the new build's output below.
+rm -f $TCC_FOLDER/lib/libgc*.dylib $TCC_FOLDER/lib/libgc*.a $TCC_FOLDER/lib/libgc.la $TCC_FOLDER/lib/libgc.lai
+
+rm -rf bdwgc/
+
+pushd .
+git clone https://github.com/ivmai/bdwgc
+cd bdwgc/
+
+git checkout $LIBGC_COMMIT
+export LIBGC_COMMIT_FULL_HASH=$(git rev-parse HEAD)
+
+## libatomic_ops is cloned from its moving default branch and gets
+## compiled into the resulting archive/dylib - record its resolved
+## commit too, so the pair's provenance covers everything that was
+## actually linked in, not just bdwgc's own commit.
+git clone https://github.com/bdwgc/libatomic_ops
+export LIBATOMIC_OPS_COMMIT_FULL_HASH=$(git -C libatomic_ops rev-parse HEAD)
+
+./autogen.sh
+
+export CONFIGURE_CMD="MACOSX_DEPLOYMENT_TARGET=\"$MACOSX_DEPLOYMENT_TARGET\" CC=\"$CC\" CFLAGS=\"-Os -mtune=generic -fPIC\" LDFLAGS=\"-Os -fPIC\" ./configure --disable-dependency-tracking --disable-docs --enable-static=yes --enable-shared=yes --enable-single-obj-compilation --enable-gc-debug --enable-thread-local-alloc --enable-large-config --enable-cplusplus --with-libatomic-ops=check --enable-sigrt-signals"
+
+MACOSX_DEPLOYMENT_TARGET=$MACOSX_DEPLOYMENT_TARGET CC=$CC CFLAGS="-Os -mtune=generic -fPIC" LDFLAGS="-Os -fPIC" ./configure \
+	--disable-dependency-tracking \
+	--disable-docs \
+	--enable-static=yes \
+	--enable-shared=yes \
+	--enable-single-obj-compilation \
+	--enable-gc-debug \
+	--enable-thread-local-alloc \
+	--enable-large-config \
+	--enable-cplusplus \
+	--with-libatomic-ops=check \
+	--enable-sigrt-signals
+
+make
+
+cd .libs/
+for dname in *.dylib; do
+   echo "Post processing ${dname} ..."
+   install_name_tool -id "@rpath/${dname}" "$dname"
+   otool -D "$dname"
+done
+
+popd
+
+################################################################################################
+date                                   > $TCC_FOLDER/lib/libgc_build_on_date.txt
+echo $LIBGC_COMMIT_FULL_HASH           > $TCC_FOLDER/lib/libgc_build_source_hash.txt
+echo $LIBATOMIC_OPS_COMMIT_FULL_HASH   > $TCC_FOLDER/lib/libgc_build_libatomic_ops_source_hash.txt
+uname -a                               > $TCC_FOLDER/lib/libgc_build_machine_uname.txt
+echo $RECIPE_VERSION                   > $TCC_FOLDER/lib/libgc_build_recipe_version.txt
+{
+  echo "$0"
+  echo "$CONFIGURE_CMD"
+}                                      > $TCC_FOLDER/lib/libgc_build_cmd.txt
+
+rsync -a bdwgc/.libs/                   $TCC_FOLDER/lib/
+ls -lad $TCC_FOLDER/lib/*
+
+## Verify libgc.dylib actually landed as a real symlink to a versioned
+## file, not a plain/dereferenced copy - confirmed via the GitHub API
+## that the existing macOS-arm64 bundle's committed libgc.dylib is a
+## plain file, not a symlink, i.e. this exact failure mode has already
+## happened once, silently. Don't just `test -L`; resolve and print the
+## actual target, and independently re-check the install name
+## `install_name_tool -id` set above rather than trusting it ran.
+if [ ! -L "$TCC_FOLDER/lib/libgc.dylib" ]; then
+  echo "::error::$TCC_FOLDER/lib/libgc.dylib is not a symlink after staging - expected a symlink to a versioned file (e.g. libgc.1.dylib), got a plain file or nothing. This would silently ship a dereferenced copy instead of the real libtool-managed layout."
+  exit 1
+fi
+libgc_dylib_target=$(readlink "$TCC_FOLDER/lib/libgc.dylib")
+if [ ! -f "$TCC_FOLDER/lib/$libgc_dylib_target" ]; then
+  echo "::error::$TCC_FOLDER/lib/libgc.dylib points at '$libgc_dylib_target', but that file does not exist alongside it - the symlink target was not staged."
+  exit 1
+fi
+echo "libgc.dylib -> $libgc_dylib_target (confirmed present)"
+libgc_install_name=$(otool -D "$TCC_FOLDER/lib/$libgc_dylib_target" | tail -n 1)
+case "$libgc_install_name" in
+  @rpath/*)
+    echo "install name of $libgc_dylib_target: $libgc_install_name (rpath-relative, as expected)" ;;
+  *)
+    echo "::error::install name of $libgc_dylib_target is '$libgc_install_name', not an @rpath/-relative path - install_name_tool -id did not take effect as expected."
+    exit 1 ;;
+esac
+
+echo "Done compiling libgc, at commit $LIBGC_COMMIT, full hash: $LIBGC_COMMIT_FULL_HASH. Static: $TCC_FOLDER/lib/libgc.a, dynamic: $TCC_FOLDER/lib/libgc.dylib -> $libgc_dylib_target"

--- a/thirdparty/build_scripts/thirdparty-macos-amd64_bdwgc_validate.sh
+++ b/thirdparty/build_scripts/thirdparty-macos-amd64_bdwgc_validate.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+# Usage: thirdparty-macos-amd64_bdwgc_validate.sh <TCC_FOLDER>
+#
+# Validates a staged tcc.exe + libgc.{a,dylib} pair in place, using
+# thirdparty/tccbin_tests/run.sh (present in the same vlang/v checkout
+# this script lives in). Ports the hardened checks already proven in
+# vlang/tccbin's thirdparty-macos-amd64 build-and-test.yml (PR #74),
+# with two deliberate departures called out below rather than copied
+# blind:
+#
+#   - The GC-linked flag set here also includes -DGC_THREADS=1 and
+#     -DTHREAD_LOCAL_ALLOC=1, which tccbin's own existing CI omits but
+#     vlib/builtin/builtin_d_gcboehm.c.v applies unconditionally
+#     (lines 3-21) before ever reaching the macOS-specific block. A
+#     validation that doesn't pass these flags isn't actually testing
+#     what V will use.
+#   - The static-lane summary matcher is adapted, not copied verbatim:
+#     tccbin's pinned run.sh (checked out at a fixed vlang/v commit
+#     that predates vlang/v#27935's stderr-capture fix) only ever
+#     prints a bare "FAIL name (compile error)"; the current run.sh in
+#     this checkout prints "FAIL name (compile error: <detail>)". The
+#     direct per-test symbol/error-text checks (is_known_gc_init) stay
+#     the authority either way; only the loose aggregate-shape match
+#     was adjusted to tolerate the added detail.
+#
+# Exits 0 only if the dylib lane, the no-GC fallback lane, and the
+# static lane's signature match (or the static lane unexpectedly fully
+# passes - also fine, just logged) all hold. Any other shape exits 1.
+set -euo pipefail
+
+TCC_FOLDER="${1:?usage: $0 <TCC_FOLDER>}"
+
+echo "== independently re-verifying the dylib itself (build script's own check is not trusted blindly) =="
+if [ ! -L "$TCC_FOLDER/lib/libgc.dylib" ]; then
+  echo "::error::$TCC_FOLDER/lib/libgc.dylib is not a symlink - expected a symlink to a versioned file (e.g. libgc.1.dylib)."
+  exit 1
+fi
+libgc_dylib_target=$(readlink "$TCC_FOLDER/lib/libgc.dylib")
+if [ ! -f "$TCC_FOLDER/lib/$libgc_dylib_target" ]; then
+  echo "::error::$TCC_FOLDER/lib/libgc.dylib points at '$libgc_dylib_target', which does not exist alongside it."
+  exit 1
+fi
+libgc_install_name=$(otool -D "$TCC_FOLDER/lib/$libgc_dylib_target" | tail -n 1)
+case "$libgc_install_name" in
+  @rpath/*) echo "libgc.dylib -> $libgc_dylib_target, install name $libgc_install_name (both confirmed)" ;;
+  *) echo "::error::install name of $libgc_dylib_target is '$libgc_install_name', not @rpath/-relative."; exit 1 ;;
+esac
+
+echo "== validating the static libgc.a archive directly (ported verbatim from vlang/tccbin PR #74) =="
+# If the rebuild produced a structurally valid but empty or incomplete
+# libgc.a (a real, different regression from a broken bdwgc build),
+# the static lane's probes below would still show only "unresolved
+# reference to '_GC_init'" text - the exact same shape as tcc's own
+# known archive-parsing limitation. Validate the archive directly via
+# ar/nm before treating any link failure against it as the known,
+# harmless tcc limitation.
+if ! ar t "$TCC_FOLDER/lib/libgc.a" >/dev/null 2>&1; then
+  echo "::error::$TCC_FOLDER/lib/libgc.a is not a well-formed archive (ar t failed) - a real regression in the bdwgc build, not the known tcc archive-parsing limitation."
+  exit 1
+fi
+# `grep -q` stops reading as soon as it finds a match, which can make
+# `nm` receive SIGPIPE while still writing the rest of a large
+# archive's symbol list - under `set -e -o pipefail`, that SIGPIPE-
+# killed `nm` makes the whole pipeline report failure even though grep
+# itself found the match. Capture the full output first, grep the
+# captured text without -q.
+rebuilt_gc_symbols=$(nm -g "$TCC_FOLDER/lib/libgc.a" 2>&1) || true
+rebuilt_gc_init_defined=$(printf '%s\n' "$rebuilt_gc_symbols" | grep -E '(^| )[Tt] _?GC_init$') || true
+if [ -z "$rebuilt_gc_init_defined" ]; then
+  echo "::error::$TCC_FOLDER/lib/libgc.a does not define GC_init - a real regression (missing/incomplete symbols), not the known tcc archive-parsing limitation."
+  exit 1
+fi
+
+# Full flag set V actually uses (builtin_d_gcboehm.c.v lines 3-21, 74-90
+# combined) - not just the subset tccbin's own CI currently tests.
+GC_CFLAGS=(-DGC_THREADS=1 -DTHREAD_LOCAL_ALLOC=1 -DGC_BUILTIN_ATOMIC=1 -DMPROTECT_VDB=1)
+
+echo "== dylib lane (blocking) =="
+# run.sh/libgc/include are resolved relative to the vlang/v checkout
+# root (this script is invoked with cwd at that root, matching every
+# other build_scripts/*.sh convention), not relative to $TCC_FOLDER.
+run_sh="thirdparty/tccbin_tests/run.sh"
+chmod +x "$run_sh"
+"$run_sh" "$TCC_FOLDER/tcc.exe" macos -- \
+    "${GC_CFLAGS[@]}" \
+    -I thirdparty/libgc/include \
+    "$PWD/$TCC_FOLDER/lib/libgc.dylib" \
+    -Wl,-rpath,"$PWD/$TCC_FOLDER/lib" \
+    -ldl -lpthread
+
+echo "== no-GC fallback lane (ported verbatim) =="
+"$TCC_FOLDER/tcc.exe" thirdparty/tccbin_tests/shared/crash.c -o /tmp/crash_nogc_validate.exe
+if [ ! -x /tmp/crash_nogc_validate.exe ]; then
+  echo "::error::expected tcc to produce a runnable /tmp/crash_nogc_validate.exe, but it's missing or not executable."
+  exit 1
+fi
+set +e
+/tmp/crash_nogc_validate.exe
+nogc_code=$?
+set -e
+if [ "$nogc_code" -ne 139 ]; then
+  echo "::error::expected exit 139 (killed by SIGSEGV) from an unguarded null-pointer dereference, got $nogc_code"
+  exit 1
+fi
+cat > /tmp/nogc_trivial_validate.c <<'TRIVIALEOF'
+int main(void) { return 0; }
+TRIVIALEOF
+"$TCC_FOLDER/tcc.exe" /tmp/nogc_trivial_validate.c -o /tmp/nogc_trivial_validate.exe
+if [ ! -x /tmp/nogc_trivial_validate.exe ]; then
+  echo "::error::expected tcc to produce a runnable trivial no-GC binary, but it's missing or not executable."
+  exit 1
+fi
+set +e
+/tmp/nogc_trivial_validate.exe
+trivial_code=$?
+set -e
+if [ "$trivial_code" -ne 0 ]; then
+  echo "::error::expected the trivial no-GC program to exit 0, got $trivial_code."
+  exit 1
+fi
+echo "no-GC fallback lane passed (crash.c SIGSEGV as expected, trivial program exits 0)"
+
+echo "== static libgc.a lane (signature-checked XFAIL only, never blocking) =="
+set +e
+static_output=$("$run_sh" "$TCC_FOLDER/tcc.exe" macos -- \
+    "${GC_CFLAGS[@]}" \
+    -I thirdparty/libgc/include \
+    "$TCC_FOLDER/lib/libgc.a" \
+    -ldl -lpthread 2>&1)
+static_code=$?
+set -e
+echo "$static_output"
+
+if [ "$static_code" -eq 0 ]; then
+  echo "Static libgc.a linking now succeeds on macOS amd64 - not treated as a failure here (this validator's job is to confirm the pair works; if static linking has genuinely started working, that's good news, not a regression). Flag this for a human to consider folding the static lane back into a single blocking lane."
+else
+  # Direct per-test probes, ported verbatim - these, not the aggregate
+  # summary line, are the actual authority on whether this is the known
+  # archive-parsing limitation.
+  set +e
+  direct_err_gc_alloc=$("$TCC_FOLDER/tcc.exe" thirdparty/tccbin_tests/shared/gc_alloc.c \
+      "${GC_CFLAGS[@]}" \
+      -I thirdparty/libgc/include \
+      "$TCC_FOLDER/lib/libgc.a" \
+      -ldl -lpthread \
+      -o /tmp/gc_alloc_xfail_validate 2>&1)
+  direct_code_gc_alloc=$?
+  direct_err_hello=$("$TCC_FOLDER/tcc.exe" thirdparty/tccbin_tests/shared/hello.c \
+      "${GC_CFLAGS[@]}" \
+      -I thirdparty/libgc/include \
+      "$TCC_FOLDER/lib/libgc.a" \
+      -ldl -lpthread \
+      -o /tmp/hello_xfail_validate 2>&1)
+  direct_code_hello=$?
+  set -e
+
+  is_known_gc_init() {
+    # $1 = captured stderr text, $2 = the probe's own exit code.
+    if [ "$2" -eq 0 ] || [ "$2" -gt 128 ]; then
+      return 1
+    fi
+    case "$1" in
+      *"unresolved reference to '_GC_init'"*|*"unresolved reference to 'GC_init'"*) ;;
+      *) return 1 ;;
+    esac
+    other=$(printf '%s\n' "$1" | grep -E '^tcc: error:' | grep -v -E "unresolved reference to '_?GC_[A-Za-z0-9_]+'")
+    [ -z "$other" ]
+  }
+
+  # Adapted from tccbin's `*"PASS crash"*"FAIL gc_alloc (compile error)"*"FAIL hello (compile error)"*`:
+  # the current run.sh appends detail after "(compile error: ...)", so
+  # an exact trailing-paren match would never fire. Match only the
+  # stable prefix of each line; the direct checks above remain the
+  # actual authority regardless of what the aggregate shape says.
+  case "$static_output" in
+    *"PASS crash"*"FAIL gc_alloc"*"FAIL hello"*)
+      if is_known_gc_init "$direct_err_gc_alloc" "$direct_code_gc_alloc" && is_known_gc_init "$direct_err_hello" "$direct_code_hello"; then
+        echo "known XFAIL: static libgc.a still can't link gc_alloc.c/hello.c (unresolved GC_init, the known tcc archive-parsing bug), as expected - not blocking"
+      else
+        echo "::error::static lane failed with the known aggregate shape, but at least one of gc_alloc.c/hello.c's direct compile errors does NOT mention an unresolved GC_init reference (or exited abnormally) - this looks like a different, unexpected regression:"
+        echo "gc_alloc.c: exit=$direct_code_gc_alloc: $direct_err_gc_alloc"
+        echo "hello.c: exit=$direct_code_hello: $direct_err_hello"
+        exit 1
+      fi
+      ;;
+    *)
+      echo "::error::static libgc.a lane failed, but NOT with the known/expected shape (PASS crash, FAIL gc_alloc/hello) - this looks like a different, unexpected problem, not the known XFAIL."
+      exit 1
+      ;;
+  esac
+fi
+
+echo "All gates passed: dylib lane blocking-green, no-GC fallback green, static lane is either green or the known signature-checked XFAIL."

--- a/thirdparty/build_scripts/thirdparty-macos-amd64_bdwgc_validate.sh
+++ b/thirdparty/build_scripts/thirdparty-macos-amd64_bdwgc_validate.sh
@@ -30,6 +30,19 @@ set -euo pipefail
 
 TCC_FOLDER="${1:?usage: $0 <TCC_FOLDER>}"
 
+# TCC_FOLDER is passed both as a relative path (the in-tree build
+# directory, "thirdparty/tcc") and as an already-absolute path (the
+# fresh-checkout clone under /tmp) by the two call sites in
+# update_tccbin.yml - blindly prefixing $PWD onto it (as an earlier
+# version of this script did) is only correct for the relative case;
+# for the absolute case "$PWD/$TCC_FOLDER" collapses the leading slash
+# into "$PWD/tmp/..." instead of "/tmp/...", pointing the dylib/rpath
+# args below at a path that doesn't exist.
+case "$TCC_FOLDER" in
+  /*) TCC_FOLDER_ABS="$TCC_FOLDER" ;;
+  *) TCC_FOLDER_ABS="$PWD/$TCC_FOLDER" ;;
+esac
+
 echo "== independently re-verifying the dylib itself (build script's own check is not trusted blindly) =="
 if [ ! -L "$TCC_FOLDER/lib/libgc.dylib" ]; then
   echo "::error::$TCC_FOLDER/lib/libgc.dylib is not a symlink - expected a symlink to a versioned file (e.g. libgc.1.dylib)."
@@ -84,8 +97,8 @@ chmod +x "$run_sh"
 "$run_sh" "$TCC_FOLDER/tcc.exe" macos -- \
     "${GC_CFLAGS[@]}" \
     -I thirdparty/libgc/include \
-    "$PWD/$TCC_FOLDER/lib/libgc.dylib" \
-    -Wl,-rpath,"$PWD/$TCC_FOLDER/lib" \
+    "$TCC_FOLDER_ABS/lib/libgc.dylib" \
+    -Wl,-rpath,"$TCC_FOLDER_ABS/lib" \
     -ldl -lpthread
 
 echo "== no-GC fallback lane (ported verbatim) =="

--- a/thirdparty/build_scripts/thirdparty-macos-amd64_tcc.sh
+++ b/thirdparty/build_scripts/thirdparty-macos-amd64_tcc.sh
@@ -30,18 +30,26 @@ if ! test -f vlib/v/compiler_errors_test.v; then
   exit 1
 fi
 
-export CFLAGS='-O3'
 export CURRENT_SCRIPT_PATH=$(realpath "$0")
 
 export TCC_COMMIT="${TCC_COMMIT:-mob}"
 export TCC_FOLDER="${TCC_FOLDER:-thirdparty/tcc.$TCC_COMMIT}"
 export TCC_REPO="${TCC_REPO:-https://repo.or.cz/tinycc.git}"
 export CC="${CC:-clang}"
+## Neither half of the tcc.exe/libgc pair pinned a deployment target
+## before this - without one, a rebuilt tcc.exe silently inherits the
+## CI runner's own macOS floor. Pin the same default here as
+## thirdparty-macos-amd64_bdwgc.sh uses for the GC half of the pair,
+## and fold it into CFLAGS explicitly - tcc's own build (unlike
+## bdwgc's autotools one) doesn't necessarily honor the bare env var.
+export MACOSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET:-10.13}"
+export CFLAGS="-O3 -mmacosx-version-min=$MACOSX_DEPLOYMENT_TARGET"
 
-echo " BUILD_CMD: \`$BUILD_CMD\`"
-echo "        CC: $CC"
-echo "TCC_COMMIT: $TCC_COMMIT"
-echo "TCC_FOLDER: \`$TCC_FOLDER\`"
+echo "                      BUILD_CMD: \`$BUILD_CMD\`"
+echo "                             CC: $CC"
+echo "                     TCC_COMMIT: $TCC_COMMIT"
+echo "                     TCC_FOLDER: \`$TCC_FOLDER\`"
+echo "       MACOSX_DEPLOYMENT_TARGET: $MACOSX_DEPLOYMENT_TARGET"
 echo ===============================================================
 
 rm -rf tinycc/
@@ -102,6 +110,8 @@ date                                                > $TCC_FOLDER/build_on_date.
 echo $TCC_COMMIT_FULL_HASH                          > $TCC_FOLDER/build_source_hash.txt
 $TCC_FOLDER/tcc.exe --version                       > $TCC_FOLDER/build_version.txt
 uname -a                                            > $TCC_FOLDER/build_machine_uname.txt
+echo $MACOSX_DEPLOYMENT_TARGET                      > $TCC_FOLDER/build_macosx_deployment_target.txt
+$CC --version                                       > $TCC_FOLDER/build_toolchain_identity.txt
 
 ## needed for Big Sur
 ln -s /System/DriverKit/usr/lib/libSystem.dylib $TCC_FOLDER/lib/libc.dylib


### PR DESCRIPTION
## Problem

`thirdparty-macos-amd64_tcc.sh` only ever rebuilds `tcc.exe` - it explicitly preserves whatever `lib/libgc*` was already committed, unchanged, on every automated `update_tccbin.yml` run. This produced a genuinely broken pair (`vlang/tccbin` commit `d712d0f`: new `tcc.exe`, old never-rebuilt `libgc.a`), which `vlang/tccbin`'s CI correctly rejects - **that check must stay blocking; this PR fixes the producer, not the check.**

A freshly-rebuilt **static** `libgc.a` alone would not fix this either: `vlang/tccbin` PR #74 already proved tcc can't reliably link a modern-toolchain-built static archive on macOS-amd64 (`GC_init` well-defined, archive well-formed, tcc still reports it unresolved) - the same limitation macOS-arm64 already solved via `libgc.dylib` + rpath.

## What this PR does

- Adds `thirdparty-macos-amd64_bdwgc.sh`, mirroring the established arm64 pattern, with amd64-specific corrections grounded in PR #74's already-proven recipe (`CC=clang`, pinned `MACOSX_DEPLOYMENT_TARGET`, stale-artifact cleanup before staging, and explicit `readlink`/`otool` re-verification that `libgc.dylib` actually landed as a real symlink - confirmed via the GitHub API that the *existing* arm64 bundle's `libgc.dylib` is committed as a plain file, not a symlink, i.e. this exact failure mode has already happened once, silently).
- Pins the deployment target on the `tcc.exe` half of the pair too, and records a toolchain-identity provenance file - neither half pinned this before.
- Adds `thirdparty-macos-amd64_bdwgc_validate.sh`, porting the hardened dylib-blocking / no-GC-fallback / static-signature-XFAIL checks already proven in `vlang/tccbin`'s `build-and-test.yml`, corrected to use V's actual full flag set (`GC_THREADS`, `THREAD_LOCAL_ALLOC`, not just the subset tccbin's own CI currently tests) and adapted to the current `run.sh` output format.
- Expands `update_tccbin.yml`'s rebuild-skip decision, for macos-amd64 only, to fingerprint the whole pair (TinyCC + bdwgc + libatomic_ops SHAs, deployment target, toolchain identity, a bumpable recipe version, required-file presence) rather than TinyCC alone.
- After staging and committing the pair, clones that exact new commit into a genuinely independent, fresh checkout and re-validates against it - the check that actually catches "file exists in the build directory but was never `git add`ed" (the same class of gap that produced arm64's non-symlinked `libgc.dylib`).
- Builds V itself in a separate, freshly-cloned workspace for a real compile-and-execute smoke test (`-cc tcc -gc boehm`) against the staged bundle. Deliberately never runs `make` against the staged checkout itself: `GNUmakefile`'s default target depends on `latest_tcc`, which runs `git clean -xf && git pull --rebase` inside `thirdparty/tcc` unless invoked with `local=1` - this would silently destroy the staged, uncommitted GC files before they're ever validated or committed.
- Uploads the bundle as a tar (preserves symlinks/executable bits, unlike `actions/upload-artifact` on a raw directory) alongside the existing raw-directory upload.

## What this PR deliberately does NOT do

Does **not** include the `vlib/builtin/builtin_d_gcboehm.c.v` selector change (amd64 still selects `libgc.a` there). That's a separate, later PR, held back until this pair is actually published and `vlang/tccbin`'s checked-in-package gate (itself needing a coordinated follow-up: it currently hard-fails if that package unexpectedly starts passing, since today it's supposed to still be broken) is confirmed green under it. The smoke test above applies the selector collapse as an in-memory-only patch to the isolated workspace, never written back to this checkout or committed anywhere, specifically so this PR can validate the real end-to-end path without prematurely shipping the selector change.

Not touched: macOS-arm64 has the identical latent gap (its `update_tccbin.yml` entry also never rebuilds GC) but is out of scope here. `linux-amd64`'s `_tcc.sh` has the same preserve-libgc pattern but wasn't reported broken. No credential/push-repair changes.

## Verification plan

This needs to run on a real `macos-15-intel` GitHub Actions runner to validate - I can't do that from here. Suggested path:
```
gh workflow run update_tccbin.yml --ref <this-branch-once-its-a-real-vlang/v-ref> -f publish=false -f force_rebuild=true -f tcc_commit=mob -f libgc_commit=master
```
`force_rebuild=true` is deliberate here, not just a default: the current `thirdparty-macos-amd64` tree has none of the new fingerprint files (`libgc_build_source_hash.txt`, etc.) this PR's expanded rebuild-skip check compares against, so relying on that check alone for the very first run against this new logic is untested territory - force it explicitly instead.

`workflow_dispatch --ref` needs a real ref in `vlang/v` itself (a fork branch won't resolve) - happy to have this validated on a test branch, or if a maintainer wants to dispatch it directly, I'll iterate on any failures.

Once this is merged and validated, the plan is: land the `vlang/tccbin` gate-conversion follow-up → publish the fix with `force_rebuild=true` → confirm `vlang/tccbin` CI is green → only then open the selector-change PR.
