### PR TITLE
v3: fix wrapped fn aliases in multiple returns

### DIFF
--- a/vlib/v3/tests/interface_return_alias_compatibility_test.v
+++ b/vlib/v3/tests/interface_return_alias_compatibility_test.v
@@ -43,11 +43,27 @@ fn test_interface_method_return_only_accepts_alias_equivalence() {
 	assert wrapped_fn_run.exit_code == 0, wrapped_fn_run.output
 	assert wrapped_fn_run.output.trim_space() == '5', wrapped_fn_run.output
 
+	multi_return_wrapped_fn_compile := compile_interface_return(v3_bin,
+		'multi_return_wrapped_fn_alias',
+		'type Msg = string\n\ntype Cmd = fn () ?Msg\n\ntype EquivalentCmd = fn () ?Msg\n\ninterface Model {\n\tupdate(msg Msg) (Model, ?Cmd)\n}\n\nstruct ExampleModel {}\n\nfn (_ ExampleModel) update(msg Msg) (Model, ?EquivalentCmd) {\n\t_ = msg\n\tpanic("not implemented")\n}\n\nfn main() {\n\t_ := Model(ExampleModel{})\n\tprintln("ok")\n}\n')
+	assert multi_return_wrapped_fn_compile.exit_code == 0, multi_return_wrapped_fn_compile.output
+	multi_return_wrapped_fn_bin := os.join_path(os.temp_dir(),
+		'v3_interface_return_multi_return_wrapped_fn_alias_${os.getpid()}')
+	multi_return_wrapped_fn_run := os.execute(os.quoted_path(multi_return_wrapped_fn_bin))
+	assert multi_return_wrapped_fn_run.exit_code == 0, multi_return_wrapped_fn_run.output
+	assert multi_return_wrapped_fn_run.output.trim_space() == 'ok', multi_return_wrapped_fn_run.output
+
 	wrapped_component_alias_compile := compile_interface_return(v3_bin,
 		'wrapped_fn_component_alias',
 		'type MyInt = int\n\ntype MathOp = fn (int, int) int\n\ntype AliasedMathOp = fn (MyInt, MyInt) MyInt\n\ninterface Calculator {\n\tget_operation() ?AliasedMathOp\n}\n\nstruct SimpleCalc {}\n\nfn (s SimpleCalc) get_operation() ?MathOp {\n\treturn fn (a int, b int) int {\n\t\treturn a + b\n\t}\n}\n\nfn main() {\n\t_ := Calculator(SimpleCalc{})\n}\n')
 	assert wrapped_component_alias_compile.exit_code != 0, wrapped_component_alias_compile.output
 	assert wrapped_component_alias_compile.output.contains('expected return type `?AliasedMathOp`'), wrapped_component_alias_compile.output
+
+	multi_return_wrapped_component_alias_compile := compile_interface_return(v3_bin,
+		'multi_return_wrapped_fn_component_alias',
+		'type MyInt = int\n\ntype MathOp = fn (int, int) int\n\ntype AliasedMathOp = fn (MyInt, MyInt) MyInt\n\ninterface Calculator {\n\tget_operation() (int, ?AliasedMathOp)\n}\n\nstruct SimpleCalc {}\n\nfn (_ SimpleCalc) get_operation() (int, ?MathOp) {\n\tpanic("not implemented")\n}\n\nfn main() {\n\t_ := Calculator(SimpleCalc{})\n}\n')
+	assert multi_return_wrapped_component_alias_compile.exit_code != 0, multi_return_wrapped_component_alias_compile.output
+	assert multi_return_wrapped_component_alias_compile.output.contains('expected return type `(int, ?AliasedMathOp)`'), multi_return_wrapped_component_alias_compile.output
 
 	int_compile := compile_interface_return(v3_bin, 'integer_conversion',
 		'interface Provider {\n\tvalue() int\n}\n\nstruct WideValue {}\n\nfn (w WideValue) value() i64 {\n\treturn 42\n}\n\nfn main() {\n\t_ := Provider(WideValue{})\n}\n')

--- a/vlib/v3/tests/interface_return_alias_compatibility_test.v
+++ b/vlib/v3/tests/interface_return_alias_compatibility_test.v
@@ -53,6 +53,28 @@ fn test_interface_method_return_only_accepts_alias_equivalence() {
 	assert multi_return_wrapped_fn_run.exit_code == 0, multi_return_wrapped_fn_run.output
 	assert multi_return_wrapped_fn_run.output.trim_space() == 'ok', multi_return_wrapped_fn_run.output
 
+	option_multi_return_wrapped_fn_compile := compile_interface_return(v3_bin,
+		'option_multi_return_wrapped_fn_alias',
+		'type Msg = string\n\ntype Cmd = fn () ?Msg\n\ntype EquivalentCmd = fn () ?Msg\n\ninterface Model {\n\tupdate(msg Msg) ?(Model, ?Cmd)\n}\n\nstruct ExampleModel {}\n\nfn (_ ExampleModel) update(msg Msg) ?(Model, ?EquivalentCmd) {\n\t_ = msg\n\tpanic("not implemented")\n}\n\nfn main() {\n\t_ := Model(ExampleModel{})\n\tprintln("ok")\n}\n')
+	assert option_multi_return_wrapped_fn_compile.exit_code == 0, option_multi_return_wrapped_fn_compile.output
+	option_multi_return_wrapped_fn_bin := os.join_path(os.temp_dir(),
+		'v3_interface_return_option_multi_return_wrapped_fn_alias_${os.getpid()}')
+	option_multi_return_wrapped_fn_run :=
+		os.execute(os.quoted_path(option_multi_return_wrapped_fn_bin))
+	assert option_multi_return_wrapped_fn_run.exit_code == 0, option_multi_return_wrapped_fn_run.output
+	assert option_multi_return_wrapped_fn_run.output.trim_space() == 'ok', option_multi_return_wrapped_fn_run.output
+
+	result_multi_return_wrapped_fn_compile := compile_interface_return(v3_bin,
+		'result_multi_return_wrapped_fn_alias',
+		'type Msg = string\n\ntype Cmd = fn () ?Msg\n\ntype EquivalentCmd = fn () ?Msg\n\ninterface Model {\n\tupdate(msg Msg) !(Model, ?Cmd)\n}\n\nstruct ExampleModel {}\n\nfn (_ ExampleModel) update(msg Msg) !(Model, ?EquivalentCmd) {\n\t_ = msg\n\tpanic("not implemented")\n}\n\nfn main() {\n\t_ := Model(ExampleModel{})\n\tprintln("ok")\n}\n')
+	assert result_multi_return_wrapped_fn_compile.exit_code == 0, result_multi_return_wrapped_fn_compile.output
+	result_multi_return_wrapped_fn_bin := os.join_path(os.temp_dir(),
+		'v3_interface_return_result_multi_return_wrapped_fn_alias_${os.getpid()}')
+	result_multi_return_wrapped_fn_run :=
+		os.execute(os.quoted_path(result_multi_return_wrapped_fn_bin))
+	assert result_multi_return_wrapped_fn_run.exit_code == 0, result_multi_return_wrapped_fn_run.output
+	assert result_multi_return_wrapped_fn_run.output.trim_space() == 'ok', result_multi_return_wrapped_fn_run.output
+
 	wrapped_component_alias_compile := compile_interface_return(v3_bin,
 		'wrapped_fn_component_alias',
 		'type MyInt = int\n\ntype MathOp = fn (int, int) int\n\ntype AliasedMathOp = fn (MyInt, MyInt) MyInt\n\ninterface Calculator {\n\tget_operation() ?AliasedMathOp\n}\n\nstruct SimpleCalc {}\n\nfn (s SimpleCalc) get_operation() ?MathOp {\n\treturn fn (a int, b int) int {\n\t\treturn a + b\n\t}\n}\n\nfn main() {\n\t_ := Calculator(SimpleCalc{})\n}\n')

--- a/vlib/v3/types/checker_tail_stmt.v
+++ b/vlib/v3/types/checker_tail_stmt.v
@@ -10246,19 +10246,22 @@ fn method_return_signature_compatible(actual Type, expected Type) bool {
 		return true
 	}
 	if actual_unaliased is OptionType && expected_unaliased is OptionType {
-		return method_wrapped_fn_return_signature_compatible(actual_unaliased.base_type,
+		return method_wrapped_return_signature_compatible(actual_unaliased.base_type,
 			expected_unaliased.base_type)
 	}
 	if actual_unaliased is ResultType && expected_unaliased is ResultType {
-		return method_wrapped_fn_return_signature_compatible(actual_unaliased.base_type,
+		return method_wrapped_return_signature_compatible(actual_unaliased.base_type,
 			expected_unaliased.base_type)
 	}
 	return false
 }
 
-fn method_wrapped_fn_return_signature_compatible(actual Type, expected Type) bool {
+fn method_wrapped_return_signature_compatible(actual Type, expected Type) bool {
 	actual_unaliased := unalias_type(actual)
 	expected_unaliased := unalias_type(expected)
+	if actual_unaliased is MultiReturn && expected_unaliased is MultiReturn {
+		return method_return_signature_compatible(actual_unaliased, expected_unaliased)
+	}
 	if actual_unaliased is FnType && expected_unaliased is FnType {
 		return Type(actual_unaliased).name() == Type(expected_unaliased).name()
 	}

--- a/vlib/v3/types/checker_tail_stmt.v
+++ b/vlib/v3/types/checker_tail_stmt.v
@@ -10234,6 +10234,17 @@ fn method_return_signature_compatible(actual Type, expected Type) bool {
 	}
 	actual_unaliased := unalias_type(actual)
 	expected_unaliased := unalias_type(expected)
+	if actual_unaliased is MultiReturn && expected_unaliased is MultiReturn {
+		if actual_unaliased.types.len != expected_unaliased.types.len {
+			return false
+		}
+		for i, typ in actual_unaliased.types {
+			if !method_return_signature_compatible(typ, expected_unaliased.types[i]) {
+				return false
+			}
+		}
+		return true
+	}
 	if actual_unaliased is OptionType && expected_unaliased is OptionType {
 		return method_wrapped_fn_return_signature_compatible(actual_unaliased.base_type,
 			expected_unaliased.base_type)


### PR DESCRIPTION
Follow-up to #27977 and #27976.

## What changed

- compare V3 interface method multiple-return signatures component by component
- reuse the existing strict option/result function-alias compatibility rule for each component
- add positive coverage for equivalent optional function aliases inside a multiple return
- add negative coverage proving incompatible nested function-alias payloads remain rejected

## Root cause

V3 only applied wrapped function-alias compatibility to the complete method return type. When the return type was a `MultiReturn`, comparison stopped at the tuple and never reached the optional function component.

## Impact

V3 now matches the legacy checker for interface methods that return multiple values containing equivalent optional function type aliases.

## Checks

- `VFLAGS='-old-compiler -gc none' ./vnew -old-compiler -gc none vlib/v3/tests/interface_return_alias_compatibility_test.v`
- `VFLAGS='-old-compiler -gc none' ./vnew -old-compiler -gc none -silent test vlib/v3/types/` (6 passed)
- `VFLAGS='-old-compiler -gc none' ./vnew -old-compiler -gc none -silent vlib/v/compiler_errors_test.v` (1604 passed, 1 skipped)

The broader `vlib/v3/tests/` run was also started, but current `master` has unrelated failures in existing builtin multi-return, globals, and ARC tests, so it was stopped after those failures were confirmed outside this two-file change.