### PR TITLE
cgen: fix nested result propagation and generic interface defaults

### DIFF
--- a/vlib/v/gen/c/defer.v
+++ b/vlib/v/gen/c/defer.v
@@ -36,8 +36,11 @@ fn (mut g Gen) write_defer_stmts(scope &ast.Scope, lookup bool, pos token.Pos) {
 
 	prev_inside_defer_generation := g.inside_defer_generation
 	g.inside_defer_generation = true
+	prev_skip_stmt_pos := g.skip_stmt_pos
+	g.skip_stmt_pos = false
 	defer {
 		g.inside_defer_generation = prev_inside_defer_generation
+		g.skip_stmt_pos = prev_skip_stmt_pos
 	}
 	g.indent++
 	for i := g.defer_stmts.len - 1; i >= 0; i-- {

--- a/vlib/v/gen/c/if.v
+++ b/vlib/v/gen/c/if.v
@@ -1198,13 +1198,13 @@ fn (mut g Gen) if_expr(node ast.IfExpr) {
 				g.expected_cast_type = resolved_node_typ
 			}
 			// A containing if/match expression can suppress statement positions while
-			// emitting this if as its final expression. Its branches still need their
-			// own positions so option/result propagation stays inside the branch.
+			// emitting this if as its final expression. Its branches and branch defers
+			// still need their own positions so option/result preludes stay in scope.
 			prev_skip_stmt_pos := g.skip_stmt_pos
 			g.skip_stmt_pos = false
 			g.stmts_with_tmp_var(branch.stmts, tmp)
-			g.skip_stmt_pos = prev_skip_stmt_pos
 			g.write_defer_stmts(branch.scope, false, node.pos)
+			g.skip_stmt_pos = prev_skip_stmt_pos
 			g.expected_cast_type = prev_expected_cast_type
 			if !is_else
 				&& (branch.stmts.len > 0 && branch.stmts.last() !in [ast.Return, ast.BranchStmt]) {

--- a/vlib/v/gen/c/if.v
+++ b/vlib/v/gen/c/if.v
@@ -1197,7 +1197,13 @@ fn (mut g Gen) if_expr(node ast.IfExpr) {
 				|| resolved_node_typ.has_flag(.shared_f)) {
 				g.expected_cast_type = resolved_node_typ
 			}
+			// A containing if/match expression can suppress statement positions while
+			// emitting this if as its final expression. Its branches still need their
+			// own positions so option/result propagation stays inside the branch.
+			prev_skip_stmt_pos := g.skip_stmt_pos
+			g.skip_stmt_pos = false
 			g.stmts_with_tmp_var(branch.stmts, tmp)
+			g.skip_stmt_pos = prev_skip_stmt_pos
 			g.write_defer_stmts(branch.scope, false, node.pos)
 			g.expected_cast_type = prev_expected_cast_type
 			if !is_else

--- a/vlib/v/gen/c/struct.v
+++ b/vlib/v/gen/c/struct.v
@@ -770,10 +770,15 @@ fn (mut g Gen) zero_struct_field(field ast.StructField) bool {
 	g.write('.${field_name} = ')
 	if field.has_default_expr {
 		if sym.kind in [.sum_type, .interface] {
-			if field.typ.has_flag(.option) {
-				g.expr_with_opt(field.default_expr, field.default_expr_typ, field.typ)
+			default_expr_typ := if field.default_expr is ast.None {
+				ast.none_type
 			} else {
-				g.expr_with_cast(field.default_expr, field.default_expr_typ, field.typ)
+				field.default_expr_typ
+			}
+			if field.typ.has_flag(.option) {
+				g.expr_with_opt(field.default_expr, default_expr_typ, field.typ)
+			} else {
+				g.expr_with_cast(field.default_expr, default_expr_typ, field.typ)
 			}
 			return true
 		}

--- a/vlib/v/tests/generics/generic_closure_struct_ierror_test.v
+++ b/vlib/v/tests/generics/generic_closure_struct_ierror_test.v
@@ -1,0 +1,33 @@
+struct GenericClosureOutcome[T] {
+	value T
+	err   IError = none
+}
+
+fn generic_closure_retry[T](op fn () GenericClosureOutcome[T]) GenericClosureOutcome[T] {
+	result := op()
+	if result.err is none {
+		return result
+	}
+	return GenericClosureOutcome[T]{
+		value: result.value
+		err:   error('fail: ${result.err.msg()}')
+	}
+}
+
+fn test_generic_closure_returning_struct_with_ierror_field() {
+	mut count := 0
+	operation := fn [mut count] () GenericClosureOutcome[int] {
+		count++
+		if count == 3 {
+			return GenericClosureOutcome[int]{
+				value: 42
+			}
+		}
+		return GenericClosureOutcome[int]{
+			err: error('boom ${count}')
+		}
+	}
+	result := generic_closure_retry(operation)
+	assert result.value == 0
+	assert result.err.msg() == 'fail: boom 1'
+}

--- a/vlib/v/tests/options/optional_binding_match_result_propagation_test.v
+++ b/vlib/v/tests/options/optional_binding_match_result_propagation_test.v
@@ -1,0 +1,25 @@
+fn optional_binding_match_convert(value int) !int {
+	return value
+}
+
+fn optional_binding_match_transform(input ?int, flag bool) !int {
+	return match flag {
+		true {
+			if value := input {
+				normalized := optional_binding_match_convert(value)!
+				normalized
+			} else {
+				0
+			}
+		}
+		false {
+			0
+		}
+	}
+}
+
+fn test_optional_binding_inside_match_with_result_propagation() {
+	assert optional_binding_match_transform(66, true)! == 66
+	assert optional_binding_match_transform(none, true)! == 0
+	assert optional_binding_match_transform(66, false)! == 0
+}

--- a/vlib/v/tests/options/optional_binding_match_result_propagation_test.v
+++ b/vlib/v/tests/options/optional_binding_match_result_propagation_test.v
@@ -23,3 +23,32 @@ fn test_optional_binding_inside_match_with_result_propagation() {
 	assert optional_binding_match_transform(none, true)! == 0
 	assert optional_binding_match_transform(66, false)! == 0
 }
+
+fn match_result_defer_log(mut events []string, label string) !int {
+	events << label
+	return 1
+}
+
+fn optional_binding_match_transform_with_defer(input ?int, flag bool, mut events []string) !int {
+	return match flag {
+		true {
+			if value := input {
+				defer {
+					_ := match_result_defer_log(mut events, 'defer') or { 0 }
+				}
+				match_result_defer_log(mut events, 'value:${value}')!
+			} else {
+				0
+			}
+		}
+		false {
+			0
+		}
+	}
+}
+
+fn test_defer_result_propagation_stays_after_match_branch_value() {
+	mut events := []string{}
+	assert optional_binding_match_transform_with_defer(7, true, mut events)! == 1
+	assert events == ['value:7', 'defer']
+}

--- a/vlib/v3/tests/cgen_optional_match_generic_closure_regression_test.v
+++ b/vlib/v3/tests/cgen_optional_match_generic_closure_regression_test.v
@@ -1,0 +1,97 @@
+import os
+
+const issues_vexe = @VEXE
+const issues_v3_dir = os.dir(os.dir(@FILE))
+const issues_vlib_dir = os.dir(issues_v3_dir)
+const issues_v3_src = os.join_path(issues_v3_dir, 'v3.v')
+
+fn issues_build_v3() string {
+	v3_bin := os.join_path(os.temp_dir(), 'v3_issues_27981_27984_${os.getpid()}')
+	if os.is_executable(v3_bin) {
+		return v3_bin
+	}
+	build :=
+		os.execute('${issues_vexe} -gc none -path "${issues_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${issues_v3_src}')
+	assert build.exit_code == 0, build.output
+	return v3_bin
+}
+
+fn issues_compile_and_run(v3_bin string, name string, source string) string {
+	src := os.join_path(os.temp_dir(), 'v3_${name}_${os.getpid()}.v')
+	bin := os.join_path(os.temp_dir(), 'v3_${name}_${os.getpid()}')
+	os.write_file(src, source) or { panic(err) }
+	compile := os.execute('${v3_bin} -nocache ${src} -b c -o ${bin}')
+	assert compile.exit_code == 0, compile.output
+	run := os.execute(bin)
+	assert run.exit_code == 0, run.output
+	return run.output.trim_space()
+}
+
+fn test_generic_closure_returning_struct_with_ierror_field() {
+	v3_bin := issues_build_v3()
+	output := issues_compile_and_run(v3_bin, 'issue_27984', '
+struct Outcome[T] {
+	value T
+	err   IError = none
+}
+
+fn retry_op[T](op fn () Outcome[T]) Outcome[T] {
+	result := op()
+	if result.err is none {
+		return result
+	}
+	return Outcome[T]{
+		value: result.value
+		err:   error("fail: \${result.err.msg()}")
+	}
+}
+
+fn main() {
+	mut count := 0
+	operation := fn [mut count] () Outcome[int] {
+		count++
+		if count == 3 {
+			return Outcome[int]{
+				value: 42
+			}
+		}
+		return Outcome[int]{
+			err: error("boom \${count}")
+		}
+	}
+	result := retry_op(operation)
+	println("\${result.value},\${result.err.msg()}")
+}
+')
+	assert output == '0,fail: boom 1'
+}
+
+fn test_optional_binding_inside_match_with_result_propagation() {
+	v3_bin := issues_build_v3()
+	output := issues_compile_and_run(v3_bin, 'issue_27981', '
+fn convert(value int) !int {
+	return value
+}
+
+fn transform(input ?int, flag bool) !int {
+	return match flag {
+		true {
+			if value := input {
+				normalized := convert(value)!
+				normalized
+			} else {
+				0
+			}
+		}
+		false {
+			0
+		}
+	}
+}
+
+fn main() {
+	println("\${transform(66, true)!},\${transform(none, true)!},\${transform(66, false)!}")
+}
+')
+	assert output == '66,0,0'
+}


### PR DESCRIPTION
Fixes #27981
Fixes #27984

- keep statement insertion points local to nested if-expression branches so Result propagation remains inside optional guards
- type `none` defaults explicitly when emitting interface fields in instantiated generic structs
- add regression coverage for both the established compiler and v3

Tests:
- `./vnew vlib/v/tests/options/optional_binding_match_result_propagation_test.v`
- `./vnew vlib/v/tests/generics/generic_closure_struct_ierror_test.v`
- `./vnew vlib/v3/tests/cgen_optional_match_generic_closure_regression_test.v`
- `./vnew -silent vlib/v/compiler_errors_test.v` (1612 passed, 1 skipped)
- `./vnew -silent vlib/v/gen/c/coutput_test.v`
- `./vnew -silent test vlib/v/` (2321 passed, 24 skipped)