### PR TITLE
v3: improve large project compilation performance

### DIFF
--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -5222,7 +5222,7 @@ pub fn run(args []string) {
 			exit(1)
 		}
 		if !incremental_cache_hit {
-			pre_tc.freeze_interface_impl_names()
+			pre_tc.freeze_pre_transform_interface_impl_names()
 		}
 		b.metric('AST nodes after transform', a.nodes.len, 'nodes')
 		b.metric('AST children after transform', a.children.len, 'edges')
@@ -5725,6 +5725,15 @@ pub fn run(args []string) {
 		}
 		b.step('C object cache')
 		link_uses_non_c_language := c_link_flags_use_non_c_language(resolved_c_flags)
+		mut tcc_link_has_incompatible_objects := false
+		if prefs.normalized_target_os() == 'macos' {
+			for flag in resolved_c_flags {
+				if c_flag_is_object_file(flag.trim_space()) {
+					tcc_link_has_incompatible_objects = true
+					break
+				}
+			}
+		}
 		link_c_standard := if link_uses_non_c_language {
 			''
 		} else {
@@ -6083,10 +6092,13 @@ pub fn run(args []string) {
 		// Cached module objects can make tcc accept an unresolved call in the
 		// program translation unit and emit a broken executable. Compile and link
 		// the much smaller cached main unit with the system C compiler so the same
-		// undeclared-function diagnostics remain enforced.
+		// undeclared-function diagnostics remain enforced. Bundled tcc also cannot
+		// link the Mach-O objects supplied by macOS system and third-party modules;
+		// avoid compiling the whole translation unit once before that guaranteed
+		// link failure.
 		if !tried_tcc && !is_prod && !needs_objective_c && !link_uses_non_c_language
-			&& target_args.len == 0 && (!c_compiler_explicit || explicit_tcc)
-			&& !cache_state.manager.enabled && !is_c_debug {
+			&& !tcc_link_has_incompatible_objects && target_args.len == 0
+			&& (!c_compiler_explicit || explicit_tcc) && !cache_state.manager.enabled && !is_c_debug {
 			tried_tcc = true
 			tcc_dir := os.join_path_single(os.join_path_single(prefs.vroot, 'thirdparty'), 'tcc')
 			bundled_tcc_path := os.join_path_single(tcc_dir, 'tcc.exe')

--- a/vlib/v3/gen/c/array.v
+++ b/vlib/v3/gen/c/array.v
@@ -442,7 +442,14 @@ fn (mut g FlatGen) gen_slice_expr(node flat.Node, base_id flat.NodeId, base_type
 	} else if is_fixed_array {
 		c_elem := g.fixed_array_elem_c_type(fixed.elem_type)
 		mut data_str := if fixed_is_ptr { '(*${base_str})' } else { base_str }
-		literal := g.fixed_array_compound_literal_expr(base_id, fixed)
+		base_node := g.a.nodes[int(base_id)]
+		local_fixed_array := base_node.kind == .ident
+			&& g.const_ref_name_from_node(base_node).len == 0
+		literal := if local_fixed_array {
+			''
+		} else {
+			g.fixed_array_compound_literal_expr(base_id, fixed)
+		}
 		if trimmed_space(literal).len > 0 {
 			data_str = literal
 		}

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -149,6 +149,7 @@ mut:
 	global_init_order              []string               // qualified global names, in declaration order
 	enum_backing_infos             map[string]EnumBackingInfo
 	iface_impls                    map[string][]string // interface name -> implementing concrete type names
+	interface_dispatch_required    map[string]bool     // source/lowered concrete method names required by emitted interface dispatch
 	iface_type_ids                 map[string]int      // "${iface}::${concrete}" -> 1-based type id
 	interface_boxed_types          map[string]bool
 	interface_boxed_types_done     bool
@@ -179,6 +180,7 @@ mut:
 	inlined_c_declared_fns         map[string]bool
 	inlined_c_static_fns           map[string]bool
 	cache_omitted_c_fns            map[string]bool
+	preserved_header_files_seen    map[string]bool
 	initial_c_flags                []string
 	c_flags                        []string
 	use_system_stdint              bool
@@ -277,54 +279,59 @@ mut:
 	// in_return is true only while generating a `return` statement's value, so a bare
 	// generic literal (`return Box{...}`) may adopt `cur_fn_ret`'s concrete instance —
 	// but a literal in a local decl / argument elsewhere in the body does not.
-	in_return                      bool
-	cur_return_node_id             int = -1
-	ownership_return_index         int
-	ownership_seen_return_sources  map[string]bool
-	ownership_propagation_index    int
-	ownership_loop_control_index   int
-	ownership_loop_iteration_index int
-	ownership_scope_index          int
-	cur_return_drops               []types.OwnershipDropEntry
-	pending_return_scope_drops     []types.OwnershipDropEntry
-	expected_expr_type             types.Type = types.Type(types.void_)
-	expected_enum                  string
-	known_expr_type_id             int        = -1
-	known_expr_type                types.Type = types.Type(types.void_)
-	needed_optional_types          map[string]string
-	emitted_optional_types         map[string]bool
-	emitted_fns                    map[string]bool
-	array_method_cache             map[string]string
-	param_types_cache              map[string][]types.Type // (name|fallback) -> resolved param types
-	interface_receiver_cache       &StringLookupCache        = unsafe { nil }
-	normalize_call_cache           &StringLookupCache        = unsafe { nil }
-	import_alias_cache             &ContextStringLookupCache = unsafe { nil }
-	enum_selector_cache            &ContextStringLookupCache = unsafe { nil }
-	enum_method_cache              &ContextStringLookupCache = unsafe { nil }
-	qualified_enum_method_cache    &ContextStringLookupCache = unsafe { nil }
-	embedded_fields_by_type        map[string][]types.StructField // type name -> its embedded fields (usually empty)
-	param_types_by_short           map[string][]types.Type        // method short-name suffix -> param types (fallback index)
-	generic_method_candidates      map[string][]GenericMethodCandidate
-	spawn_wrapper_names            map[string]string
-	spawn_wrapper_defs             []string
-	spawn_wrapper_defs_seen        map[string]bool
-	callback_wrapper_names         map[string]string
-	callback_wrapper_defs          []string
-	callback_wrapper_defs_seen     map[string]bool
-	parallel_used                  bool
-	c_name_cache                   &CNameCache = unsafe { nil }
-	emitted_fn_ptr_typedefs        map[string]bool
-	c_extern_refs                  map[string]bool
-	c_extern_refs_ready            bool
-	parallel_prepared              bool
-	scoped_fn_items_scope          voidptr
-	scoped_fn_output_path          string
-	scoped_fn_output_paths         []string
-	const_short_index              &ConstShortIndex = unsafe { nil }
-	mut_recv_facts                 &FnNameFactCache = unsafe { nil }
-	generic_app_cache              &GenericAppCache = unsafe { nil }
-	want_parallel_prep             bool
-	want_parallel_c_extern_prep    bool
+	in_return                       bool
+	cur_return_node_id              int = -1
+	ownership_return_index          int
+	ownership_seen_return_sources   map[string]bool
+	ownership_propagation_index     int
+	ownership_loop_control_index    int
+	ownership_loop_iteration_index  int
+	ownership_scope_index           int
+	cur_return_drops                []types.OwnershipDropEntry
+	pending_return_scope_drops      []types.OwnershipDropEntry
+	expected_expr_type              types.Type = types.Type(types.void_)
+	expected_enum                   string
+	known_expr_type_id              int        = -1
+	known_expr_type                 types.Type = types.Type(types.void_)
+	needed_optional_types           map[string]string
+	emitted_optional_types          map[string]bool
+	emitted_fns                     map[string]bool
+	array_method_cache              map[string]string
+	param_types_cache               map[string][]types.Type // (name|fallback) -> resolved param types
+	interface_receiver_cache        &StringLookupCache        = unsafe { nil }
+	normalize_call_cache            &StringLookupCache        = unsafe { nil }
+	flattened_generic_name_cache    &StringLookupCache        = unsafe { nil }
+	generic_struct_context_ct_cache &StringLookupCache        = unsafe { nil }
+	struct_cname_cache              &StringLookupCache        = unsafe { nil }
+	unique_struct_ct_cache          &StringLookupCache        = unsafe { nil }
+	alias_method_cache              &StringLookupCache        = unsafe { nil }
+	import_alias_cache              &ContextStringLookupCache = unsafe { nil }
+	enum_selector_cache             &ContextStringLookupCache = unsafe { nil }
+	enum_method_cache               &ContextStringLookupCache = unsafe { nil }
+	qualified_enum_method_cache     &ContextStringLookupCache = unsafe { nil }
+	embedded_fields_by_type         map[string][]types.StructField // type name -> its embedded fields (usually empty)
+	param_types_by_short            map[string][]types.Type        // method short-name suffix -> param types (fallback index)
+	generic_method_candidates       map[string][]GenericMethodCandidate
+	spawn_wrapper_names             map[string]string
+	spawn_wrapper_defs              []string
+	spawn_wrapper_defs_seen         map[string]bool
+	callback_wrapper_names          map[string]string
+	callback_wrapper_defs           []string
+	callback_wrapper_defs_seen      map[string]bool
+	parallel_used                   bool
+	c_name_cache                    &CNameCache = unsafe { nil }
+	emitted_fn_ptr_typedefs         map[string]bool
+	c_extern_refs                   map[string]bool
+	c_extern_refs_ready             bool
+	parallel_prepared               bool
+	scoped_fn_items_scope           voidptr
+	scoped_fn_output_path           string
+	scoped_fn_output_paths          []string
+	const_short_index               &ConstShortIndex = unsafe { nil }
+	mut_recv_facts                  &FnNameFactCache = unsafe { nil }
+	generic_app_cache               &GenericAppCache = unsafe { nil }
+	want_parallel_prep              bool
+	want_parallel_c_extern_prep     bool
 	// Set while selected items' C-extern refs still have to be collected: the
 	// fused prep walk defers them to the parallel exact-cost pass, which falls
 	// back to a serial top-up when it cannot run.
@@ -380,6 +387,12 @@ struct CInlineHeader {
 	preserved_directives []string
 	preserved_c_fns      []string
 	preserved_c_structs  []string
+	preserved_headers    []CPreservedHeader
+}
+
+struct CPreservedHeader {
+	include_arg string
+	source_file string
 }
 
 // was_parallel reports whether the last fn codegen actually ran across threads.
@@ -710,146 +723,153 @@ fn (g &FlatGen) local_storage_is_pointer(name string) bool {
 // new creates a FlatGen value for c.
 pub fn FlatGen.new() FlatGen {
 	return FlatGen{
-		sb:                             strings.new_builder(4096)
-		fn_gen_items:                   []FlatFnGenItem{}
-		top_level_node_ids:             []int{}
-		fn_segs:                        []string{}
-		fn_seg_chunk_indexes:           []int{}
-		parallel_chunk_wrapper_defs:    []ParallelChunkWrapperDefs{}
-		test_files:                     map[string]bool{}
-		cache_program_files:            map[string]bool{}
-		incremental_fn_names:           map[string]bool{}
-		str_lit_ids:                    map[string]int{}
-		global_types:                   map[string]types.Type{}
-		global_raw_type_texts:          map[string]string{}
-		enum_vals:                      map[string]int{}
-		enum_value_exprs:               map[string]string{}
-		interfaces:                     map[string][]string{}
-		const_vals:                     map[string]flat.NodeId{}
-		const_modules:                  map[string]string{}
-		const_files:                    map[string]string{}
-		const_init_order:               []string{}
-		fixed_storage_consts:           map[string]bool{}
-		global_modules:                 map[string]string{}
-		global_files:                   map[string]string{}
-		global_inits:                   map[string]flat.NodeId{}
-		global_init_order:              []string{}
-		enum_backing_infos:             map[string]EnumBackingInfo{}
-		iface_impls:                    map[string][]string{}
-		iface_type_ids:                 map[string]int{}
-		interface_boxed_types:          map[string]bool{}
-		ierror_method_emit_names:       map[string]bool{}
-		ierror_stack_pointer_aliases:   []map[string]bool{}
-		ierror_owned_pointer_by_owner:  map[string]bool{}
-		recursive_drop_helpers:         map[string]string{}
-		local_pointer_storage_by_owner: map[string]bool{}
-		local_c_type_by_owner:          map[string]string{}
-		local_mutable_by_owner:         map[string]bool{}
-		local_pointer_alias_by_owner:   map[string]string{}
-		local_pointer_alias_mut_param:  map[string]bool{}
-		local_raw_type_by_owner:        map[string]string{}
-		local_shared_storage_by_owner:  map[string]bool{}
-		local_fn_value_c_name_by_owner: map[string]string{}
-		shadowed_global_locals:         map[string]bool{}
-		sum_name_lookup:                map[string]string{}
-		module_init_fns:                []string{}
-		module_init_fn_modules:         map[string]string{}
-		module_imports:                 map[string][]string{}
-		c_directives:                   []CDirective{}
-		early_c_source_directives:      map[string]bool{}
-		native_source_contexts:         map[string][]NativeSourceContextDirective{}
-		objective_cpp_source_requests:  []ObjectiveCppSourceRequest{}
-		inlined_c_structs:              map[string]bool{}
-		inlined_c_fns:                  map[string]bool{}
-		inlined_c_declared_fns:         map[string]bool{}
-		inlined_c_static_fns:           map[string]bool{}
-		cache_omitted_c_fns:            map[string]bool{}
-		inlined_c_typedef_names:        map[string]bool{}
-		initial_c_flags:                []string{}
-		c_flags:                        []string{}
-		libc_compat_fns:                map[string]bool{}
-		modules:                        map[string]string{}
-		fn_ptr_types:                   map[string]string{}
-		used_fn_ptr_types:              map[string]bool{}
-		multi_return_types:             []types.Type{}
-		multi_return_type_names:        map[string]bool{}
-		fixed_array_ret_wrappers:       map[string]bool{}
-		emitted_fixed_array_typedefs:   map[string]bool{}
-		concrete_optional_abi_fns:      map[string]bool{}
-		fixed_array_typedefs_needed:    map[string]FixedArrayTypedefInfo{}
-		fn_decl_param_types:            map[string][]types.Type{}
-		fn_decl_variadic:               map[string]bool{}
-		fn_decl_variadic_short_counts:  map[string]int{}
-		fn_decl_shared_params:          map[string][]bool{}
-		fn_shared_params_resolved:      map[string][]bool{}
-		fn_decl_mut_receivers:          map[string]bool{}
-		fn_decl_ret_types:              map[string]types.Type{}
-		fn_decl_nodes_by_name:          map[string]flat.NodeId{}
-		fn_decl_nodes_by_short:         map[string]flat.NodeId{}
-		fn_decl_nodes_by_module_short:  map[string]flat.NodeId{}
-		non_generic_fn_names_by_module: map[string]bool{}
-		generic_fn_keys_by_short:       map[string][]string{}
-		generic_fn_keys_by_cname:       map[string][]string{}
-		generic_fn_key_ordinal:         map[string]int{}
-		struct_decl_infos:              map[string]StructDeclInfo{}
-		struct_decl_short_infos:        map[string]StructDeclInfo{}
-		decl_attrs:                     map[int][]string{}
-		shared_type_names:              map[string]SharedTypeInfo{}
-		shared_alias_pointer_shorts:    map[string]string{}
-		default_value_stack:            map[string]bool{}
-		cur_param_names:                []string{}
-		cur_param_type_values:          []types.Type{}
-		cur_param_types:                map[string]types.Type{}
-		cur_concrete_optional_params:   map[string]bool{}
-		cur_mut_params:                 map[string]bool{}
-		cur_mut_param_owners:           map[string]types.ScopeBindingOwner{}
-		active_locks:                   []ActiveLock{}
-		conditional_branch_scopes:      []&types.Scope{}
-		conditional_branch_depths:      []int{}
-		loop_label_depths:              map[string]int{}
-		loop_control_copybacks:         []LoopControlCopyback{}
-		map_loop_copyback_guards:       []MapLoopCopybackGuard{}
-		goto_label_lock_scopes:         map[string][]int{}
-		ownership_seen_return_sources:  map[string]bool{}
-		needed_optional_types:          map[string]string{}
-		emitted_optional_types:         map[string]bool{}
-		emitted_fns:                    map[string]bool{}
-		array_method_cache:             map[string]string{}
-		param_types_cache:              map[string][]types.Type{}
-		interface_receiver_cache:       &StringLookupCache{}
-		normalize_call_cache:           &StringLookupCache{}
-		import_alias_cache:             &ContextStringLookupCache{}
-		enum_selector_cache:            &ContextStringLookupCache{}
-		enum_method_cache:              &ContextStringLookupCache{}
-		qualified_enum_method_cache:    &ContextStringLookupCache{}
-		embedded_fields_by_type:        map[string][]types.StructField{}
-		param_types_by_short:           map[string][]types.Type{}
-		generic_method_candidates:      map[string][]GenericMethodCandidate{}
-		spawn_wrapper_names:            map[string]string{}
-		spawn_wrapper_defs:             []string{}
-		spawn_wrapper_defs_seen:        map[string]bool{}
-		callback_wrapper_names:         map[string]string{}
-		callback_wrapper_defs:          []string{}
-		callback_wrapper_defs_seen:     map[string]bool{}
-		c_name_cache:                   &CNameCache{}
-		const_short_index:              &ConstShortIndex{}
-		mut_recv_facts:                 &FnNameFactCache{}
-		generic_app_cache:              &GenericAppCache{}
-		cached_support_identifiers:     map[string]bool{}
-		str_lits:                       []string{}
-		defers:                         []flat.NodeId{}
-		fn_defers:                      []flat.NodeId{}
-		fn_defer_counts:                map[int]string{}
-		defer_capture_names:            []string{}
-		defer_capture_types:            map[string]types.Type{}
-		const_runtime_inits:            []string{}
-		const_runtime_init_modules:     []string{}
-		runtime_inits:                  []string{}
-		runtime_init_modules:           []string{}
-		compiler_vroot:                 ''
-		compiler_vexe:                  ''
-		target:                         pref.host_target()
-		line_start:                     true
+		sb:                              strings.new_builder(4096)
+		fn_gen_items:                    []FlatFnGenItem{}
+		top_level_node_ids:              []int{}
+		fn_segs:                         []string{}
+		fn_seg_chunk_indexes:            []int{}
+		parallel_chunk_wrapper_defs:     []ParallelChunkWrapperDefs{}
+		test_files:                      map[string]bool{}
+		cache_program_files:             map[string]bool{}
+		incremental_fn_names:            map[string]bool{}
+		str_lit_ids:                     map[string]int{}
+		global_types:                    map[string]types.Type{}
+		global_raw_type_texts:           map[string]string{}
+		enum_vals:                       map[string]int{}
+		enum_value_exprs:                map[string]string{}
+		interfaces:                      map[string][]string{}
+		const_vals:                      map[string]flat.NodeId{}
+		const_modules:                   map[string]string{}
+		const_files:                     map[string]string{}
+		const_init_order:                []string{}
+		fixed_storage_consts:            map[string]bool{}
+		global_modules:                  map[string]string{}
+		global_files:                    map[string]string{}
+		global_inits:                    map[string]flat.NodeId{}
+		global_init_order:               []string{}
+		enum_backing_infos:              map[string]EnumBackingInfo{}
+		iface_impls:                     map[string][]string{}
+		interface_dispatch_required:     map[string]bool{}
+		iface_type_ids:                  map[string]int{}
+		interface_boxed_types:           map[string]bool{}
+		ierror_method_emit_names:        map[string]bool{}
+		ierror_stack_pointer_aliases:    []map[string]bool{}
+		ierror_owned_pointer_by_owner:   map[string]bool{}
+		recursive_drop_helpers:          map[string]string{}
+		local_pointer_storage_by_owner:  map[string]bool{}
+		local_c_type_by_owner:           map[string]string{}
+		local_mutable_by_owner:          map[string]bool{}
+		local_pointer_alias_by_owner:    map[string]string{}
+		local_pointer_alias_mut_param:   map[string]bool{}
+		local_raw_type_by_owner:         map[string]string{}
+		local_shared_storage_by_owner:   map[string]bool{}
+		local_fn_value_c_name_by_owner:  map[string]string{}
+		shadowed_global_locals:          map[string]bool{}
+		sum_name_lookup:                 map[string]string{}
+		module_init_fns:                 []string{}
+		module_init_fn_modules:          map[string]string{}
+		module_imports:                  map[string][]string{}
+		c_directives:                    []CDirective{}
+		early_c_source_directives:       map[string]bool{}
+		native_source_contexts:          map[string][]NativeSourceContextDirective{}
+		objective_cpp_source_requests:   []ObjectiveCppSourceRequest{}
+		inlined_c_structs:               map[string]bool{}
+		inlined_c_fns:                   map[string]bool{}
+		inlined_c_declared_fns:          map[string]bool{}
+		inlined_c_static_fns:            map[string]bool{}
+		cache_omitted_c_fns:             map[string]bool{}
+		preserved_header_files_seen:     map[string]bool{}
+		inlined_c_typedef_names:         map[string]bool{}
+		initial_c_flags:                 []string{}
+		c_flags:                         []string{}
+		libc_compat_fns:                 map[string]bool{}
+		modules:                         map[string]string{}
+		fn_ptr_types:                    map[string]string{}
+		used_fn_ptr_types:               map[string]bool{}
+		multi_return_types:              []types.Type{}
+		multi_return_type_names:         map[string]bool{}
+		fixed_array_ret_wrappers:        map[string]bool{}
+		emitted_fixed_array_typedefs:    map[string]bool{}
+		concrete_optional_abi_fns:       map[string]bool{}
+		fixed_array_typedefs_needed:     map[string]FixedArrayTypedefInfo{}
+		fn_decl_param_types:             map[string][]types.Type{}
+		fn_decl_variadic:                map[string]bool{}
+		fn_decl_variadic_short_counts:   map[string]int{}
+		fn_decl_shared_params:           map[string][]bool{}
+		fn_shared_params_resolved:       map[string][]bool{}
+		fn_decl_mut_receivers:           map[string]bool{}
+		fn_decl_ret_types:               map[string]types.Type{}
+		fn_decl_nodes_by_name:           map[string]flat.NodeId{}
+		fn_decl_nodes_by_short:          map[string]flat.NodeId{}
+		fn_decl_nodes_by_module_short:   map[string]flat.NodeId{}
+		non_generic_fn_names_by_module:  map[string]bool{}
+		generic_fn_keys_by_short:        map[string][]string{}
+		generic_fn_keys_by_cname:        map[string][]string{}
+		generic_fn_key_ordinal:          map[string]int{}
+		struct_decl_infos:               map[string]StructDeclInfo{}
+		struct_decl_short_infos:         map[string]StructDeclInfo{}
+		decl_attrs:                      map[int][]string{}
+		shared_type_names:               map[string]SharedTypeInfo{}
+		shared_alias_pointer_shorts:     map[string]string{}
+		default_value_stack:             map[string]bool{}
+		cur_param_names:                 []string{}
+		cur_param_type_values:           []types.Type{}
+		cur_param_types:                 map[string]types.Type{}
+		cur_concrete_optional_params:    map[string]bool{}
+		cur_mut_params:                  map[string]bool{}
+		cur_mut_param_owners:            map[string]types.ScopeBindingOwner{}
+		active_locks:                    []ActiveLock{}
+		conditional_branch_scopes:       []&types.Scope{}
+		conditional_branch_depths:       []int{}
+		loop_label_depths:               map[string]int{}
+		loop_control_copybacks:          []LoopControlCopyback{}
+		map_loop_copyback_guards:        []MapLoopCopybackGuard{}
+		goto_label_lock_scopes:          map[string][]int{}
+		ownership_seen_return_sources:   map[string]bool{}
+		needed_optional_types:           map[string]string{}
+		emitted_optional_types:          map[string]bool{}
+		emitted_fns:                     map[string]bool{}
+		array_method_cache:              map[string]string{}
+		param_types_cache:               map[string][]types.Type{}
+		interface_receiver_cache:        &StringLookupCache{}
+		normalize_call_cache:            &StringLookupCache{}
+		flattened_generic_name_cache:    &StringLookupCache{}
+		generic_struct_context_ct_cache: &StringLookupCache{}
+		struct_cname_cache:              &StringLookupCache{}
+		unique_struct_ct_cache:          &StringLookupCache{}
+		alias_method_cache:              &StringLookupCache{}
+		import_alias_cache:              &ContextStringLookupCache{}
+		enum_selector_cache:             &ContextStringLookupCache{}
+		enum_method_cache:               &ContextStringLookupCache{}
+		qualified_enum_method_cache:     &ContextStringLookupCache{}
+		embedded_fields_by_type:         map[string][]types.StructField{}
+		param_types_by_short:            map[string][]types.Type{}
+		generic_method_candidates:       map[string][]GenericMethodCandidate{}
+		spawn_wrapper_names:             map[string]string{}
+		spawn_wrapper_defs:              []string{}
+		spawn_wrapper_defs_seen:         map[string]bool{}
+		callback_wrapper_names:          map[string]string{}
+		callback_wrapper_defs:           []string{}
+		callback_wrapper_defs_seen:      map[string]bool{}
+		c_name_cache:                    &CNameCache{}
+		const_short_index:               &ConstShortIndex{}
+		mut_recv_facts:                  &FnNameFactCache{}
+		generic_app_cache:               &GenericAppCache{}
+		cached_support_identifiers:      map[string]bool{}
+		str_lits:                        []string{}
+		defers:                          []flat.NodeId{}
+		fn_defers:                       []flat.NodeId{}
+		fn_defer_counts:                 map[int]string{}
+		defer_capture_names:             []string{}
+		defer_capture_types:             map[string]types.Type{}
+		const_runtime_inits:             []string{}
+		const_runtime_init_modules:      []string{}
+		runtime_inits:                   []string{}
+		runtime_init_modules:            []string{}
+		compiler_vroot:                  ''
+		compiler_vexe:                   ''
+		target:                          pref.host_target()
+		line_start:                      true
 	}
 }
 
@@ -1648,6 +1668,7 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	g.global_init_order = []string{}
 	g.enum_backing_infos.clear()
 	g.iface_impls.clear()
+	g.interface_dispatch_required.clear()
 	g.iface_type_ids.clear()
 	g.ierror_method_emit_names.clear()
 	g.ierror_stack_pointer_aliases = []map[string]bool{}
@@ -1676,6 +1697,7 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	g.inlined_c_declared_fns.clear()
 	g.inlined_c_static_fns.clear()
 	g.cache_omitted_c_fns.clear()
+	g.preserved_header_files_seen.clear()
 	g.inlined_c_typedef_names.clear()
 	g.c_flags = []string{}
 	g.use_system_stdint = false
@@ -1735,6 +1757,11 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	g.param_types_cache.clear()
 	g.interface_receiver_cache = &StringLookupCache{}
 	g.normalize_call_cache = &StringLookupCache{}
+	g.flattened_generic_name_cache = &StringLookupCache{}
+	g.generic_struct_context_ct_cache = &StringLookupCache{}
+	g.struct_cname_cache = &StringLookupCache{}
+	g.unique_struct_ct_cache = &StringLookupCache{}
+	g.alias_method_cache = &StringLookupCache{}
 	g.import_alias_cache = &ContextStringLookupCache{}
 	g.enum_selector_cache = &ContextStringLookupCache{}
 	g.enum_method_cache = &ContextStringLookupCache{}
@@ -1794,11 +1821,13 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 		g.precompute_param_type_index()
 		g.precompute_sum_name_lookup()
 		g.collect_interface_impls()
+		g.precompute_required_interface_dispatch_methods()
 	} else {
 		// Function-item selection can run during pre-dispatch preparation. Populate
 		// interface implementers first so that late-lowered dispatch targets are not
 		// pruned before their concrete method bodies are emitted.
 		g.collect_interface_impls()
+		g.precompute_required_interface_dispatch_methods()
 		g.timing_profile('  [ttime]   cg iface impls   ${f64(cgsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 		cgsw.restart()
 		// Struct field defaults are emitted from their declarations when an otherwise
@@ -3025,6 +3054,10 @@ fn (mut g FlatGen) collect_c_directive(module_name string, node flat.Node, sourc
 			g.collect_inlined_c_declared_fns(header_text)
 			g.collect_preserved_c_fns(header.preserved_c_fns)
 			g.collect_preserved_c_structs(header.preserved_c_structs)
+			for preserved_header in header.preserved_headers {
+				g.collect_preserved_header_tree(preserved_header.include_arg,
+					preserved_header.source_file, include_dirs)
+			}
 			for directive in header.preserved_directives {
 				g.add_c_directive(module_name, directive, before_import)
 			}
@@ -3056,12 +3089,11 @@ fn (mut g FlatGen) collect_c_directive(module_name string, node flat.Node, sourc
 }
 
 fn (mut g FlatGen) collect_preserved_header_tree(include_arg string, source_file string, include_dirs []string) bool {
-	mut seen := map[string]bool{}
 	for path in c_include_file_paths(include_arg, g.compiler_vroot, source_file, include_dirs) {
 		mut tree_size := CHeaderTreeSize{}
 		if os.is_file(path)
 			&& c_header_tree_exceeds_inline_limit(path, g.compiler_vroot, include_dirs, mut tree_size) {
-			g.collect_preserved_header_file(path, include_dirs, mut seen)
+			g.collect_preserved_header_file(path, include_dirs)
 			return true
 		}
 	}
@@ -3096,12 +3128,12 @@ fn c_header_tree_exceeds_inline_limit(path string, vroot string, include_dirs []
 	return false
 }
 
-fn (mut g FlatGen) collect_preserved_header_file(path string, include_dirs []string, mut seen map[string]bool) {
+fn (mut g FlatGen) collect_preserved_header_file(path string, include_dirs []string) {
 	real_path := os.real_path(path)
-	if real_path.len == 0 || seen[real_path] {
+	if real_path.len == 0 || g.preserved_header_files_seen[real_path] {
 		return
 	}
-	seen[real_path] = true
+	g.preserved_header_files_seen[real_path] = true
 	text := os.read_file(real_path) or { return }
 	g.collect_inlined_c_structs(text)
 	g.collect_inlined_c_fns(text)
@@ -3118,7 +3150,7 @@ fn (mut g FlatGen) collect_preserved_header_file(path string, include_dirs []str
 		for nested_path in c_include_file_paths(include_arg, g.compiler_vroot, real_path,
 			include_dirs) {
 			if os.is_file(nested_path) {
-				g.collect_preserved_header_file(nested_path, include_dirs, mut seen)
+				g.collect_preserved_header_file(nested_path, include_dirs)
 				found = true
 				break
 			}
@@ -3151,6 +3183,7 @@ fn c_inline_header_text(include_arg string, vroot string, source_file string, in
 				preserved_directives: header.preserved_directives
 				preserved_c_fns:      header.preserved_c_fns
 				preserved_c_structs:  header.preserved_c_structs
+				preserved_headers:    header.preserved_headers
 			}
 		}
 		unsafe { output.free() }
@@ -3185,6 +3218,7 @@ fn c_inline_header_file_text(text string, vroot string, source_file string, incl
 	mut preserved_directives := []string{}
 	mut preserved_c_fns := []string{}
 	mut preserved_c_structs := []string{}
+	mut preserved_headers := []CPreservedHeader{}
 	mut include_context := []string{}
 	mut include_prefix := []string{}
 	mut in_block_comment := false
@@ -3200,6 +3234,26 @@ fn c_inline_header_file_text(text string, vroot string, source_file string, incl
 			nested_conditional := conditional
 				|| !c_include_context_is_guard_only(include_context, guard_name)
 			mut inlined := false
+			if trimmed_space(include_arg).starts_with('<') {
+				for path in c_include_file_paths(include_arg, vroot, source_file, include_dirs) {
+					mut tree_size := CHeaderTreeSize{}
+					if os.is_file(path)
+						&& c_header_tree_exceeds_inline_limit(path, vroot, include_dirs, mut tree_size) {
+						output.writeln('#include ${include_arg}')
+						preserved_headers << CPreservedHeader{
+							include_arg: include_arg
+							source_file: source_file
+						}
+						preserved_c_fns << c_preserved_system_include_declared_fns(include_arg)
+						preserved_c_structs << c_preserved_system_include_struct_names(include_arg)
+						inlined = true
+						break
+					}
+				}
+			}
+			if inlined {
+				continue
+			}
 			for path in c_include_file_paths(include_arg, vroot, source_file, include_dirs) {
 				if nested := c_inline_header_file(path, vroot, include_dirs, nested_conditional,
 					use_system_stdint, mut seen, mut inlining, mut output)
@@ -3210,6 +3264,7 @@ fn c_inline_header_file_text(text string, vroot string, source_file string, incl
 					}
 					preserved_c_fns << nested.preserved_c_fns
 					preserved_c_structs << nested.preserved_c_structs
+					preserved_headers << nested.preserved_headers
 					inlined = true
 					break
 				}
@@ -3235,6 +3290,7 @@ fn c_inline_header_file_text(text string, vroot string, source_file string, incl
 		preserved_directives: preserved_directives
 		preserved_c_fns:      preserved_c_fns
 		preserved_c_structs:  preserved_c_structs
+		preserved_headers:    preserved_headers
 	}
 }
 
@@ -16835,6 +16891,10 @@ fn (mut g FlatGen) write_fixed_array_value_initializer_from_text(mut builder str
 }
 
 fn (mut g FlatGen) write_empty_fixed_array_initializer(mut builder strings.Builder, fixed types.ArrayFixed) {
+	if fixed_array_empty_initializer_is_zero(fixed) {
+		builder.write_string('{0}')
+		return
+	}
 	len_text := trimmed_space(g.fixed_array_len_value(fixed))
 	if !cgen_decimal_text(len_text) {
 		builder.write_string('{0}')
@@ -16853,6 +16913,14 @@ fn (mut g FlatGen) write_empty_fixed_array_initializer(mut builder strings.Build
 		}
 	}
 	builder.write_u8(`}`)
+}
+
+fn fixed_array_empty_initializer_is_zero(fixed types.ArrayFixed) bool {
+	elem_type := default_init_unalias_type(fixed.elem_type)
+	if elem_type is types.ArrayFixed {
+		return fixed_array_empty_initializer_is_zero(elem_type)
+	}
+	return elem_type !is types.Array && elem_type !is types.Struct && elem_type !is types.Map
 }
 
 fn (mut g FlatGen) write_fixed_array_default_elem_initializer(mut builder strings.Builder, elem_type types.Type) {

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -6575,7 +6575,7 @@ fn (g &FlatGen) c_style_mut_receiver_arg_wants_addr(fn_name string, arg_id flat.
 		return false
 	}
 	receiver_ct := g.tc.c_type(types.unwrap_pointer(arg_type))
-	short_receiver := flattened_generic_struct_c_type_short_name(receiver_ct)
+	short_receiver := g.flattened_generic_struct_c_type_short_name(receiver_ct)
 	if short_receiver.len == 0 || !fn_name.contains(short_receiver) {
 		return false
 	}
@@ -12615,6 +12615,16 @@ fn (g &FlatGen) find_prim_method(method string) string {
 
 // find_alias_method converts find alias method data for c.
 fn (g &FlatGen) find_alias_method(target string, method string) ?string {
+	cache_key := '${target}\n${method}'
+	mut cache := g.alias_method_cache
+	if !isnil(cache) {
+		if cached := cache.entries[cache_key] {
+			if cached.len > 0 {
+				return cached
+			}
+			return none
+		}
+	}
 	mut fallback := ''
 	for alias, alias_target in g.tc.type_aliases {
 		if alias_target != target {
@@ -12625,12 +12635,18 @@ fn (g &FlatGen) find_alias_method(target string, method string) ?string {
 			if alias.contains('.') {
 				short_method := '${alias.all_after_last('.')}.${method}'
 				if short_method in g.tc.fn_param_types {
+					if !isnil(cache) {
+						cache.entries[cache_key] = alias_method
+					}
 					return alias_method
 				}
 			}
 			continue
 		}
 		if alias.contains('.') {
+			if !isnil(cache) {
+				cache.entries[cache_key] = alias_method
+			}
 			return alias_method
 		}
 		if fallback.len == 0 {
@@ -12638,7 +12654,13 @@ fn (g &FlatGen) find_alias_method(target string, method string) ?string {
 		}
 	}
 	if fallback.len > 0 {
+		if !isnil(cache) {
+			cache.entries[cache_key] = fallback
+		}
 		return fallback
+	}
+	if !isnil(cache) {
+		cache.entries[cache_key] = ''
 	}
 	return none
 }

--- a/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
@@ -1562,6 +1562,7 @@ fn (g &FlatGen) new_parallel_worker_config(worker_id int, result_only bool) &Fla
 		global_init_order:              g.global_init_order
 		enum_backing_infos:             g.enum_backing_infos
 		iface_impls:                    g.iface_impls
+		interface_dispatch_required:    g.interface_dispatch_required
 		iface_type_ids:                 g.iface_type_ids
 		interface_boxed_types:          g.interface_boxed_types
 		interface_boxed_types_done:     g.interface_boxed_types_done
@@ -1578,6 +1579,7 @@ fn (g &FlatGen) new_parallel_worker_config(worker_id int, result_only bool) &Fla
 		module_init_fns:                g.module_init_fns
 		module_init_fn_modules:         g.module_init_fn_modules
 		module_imports:                 g.module_imports
+		preserved_header_files_seen:    g.preserved_header_files_seen
 		libc_compat_fns:                g.libc_compat_fns.clone()
 		tc:                             if result_only {
 			unsafe { g.tc }
@@ -1672,37 +1674,42 @@ fn (g &FlatGen) new_parallel_worker_config(worker_id int, result_only bool) &Fla
 		}
 		// Function selection is complete before workers are created; body
 		// generation only reads this set.
-		emitted_fns:                 g.emitted_fns
-		array_method_cache:          if result_only {
+		emitted_fns:                     g.emitted_fns
+		array_method_cache:              if result_only {
 			g.array_method_cache
 		} else {
 			g.array_method_cache.clone()
 		}
-		param_types_cache:           if result_only {
+		param_types_cache:               if result_only {
 			g.param_types_cache
 		} else {
 			g.param_types_cache.clone()
 		}
-		interface_receiver_cache:    &StringLookupCache{}
-		normalize_call_cache:        &StringLookupCache{}
-		import_alias_cache:          &ContextStringLookupCache{}
-		enum_selector_cache:         &ContextStringLookupCache{}
-		enum_method_cache:           &ContextStringLookupCache{}
-		qualified_enum_method_cache: &ContextStringLookupCache{}
-		struct_decl_pref_cache:      &StructDeclPrefCache{}
-		embedded_fields_by_type:     g.embedded_fields_by_type
-		param_types_by_short:        g.param_types_by_short
-		generic_method_candidates:   g.generic_method_candidates
-		spawn_wrapper_names:         g.spawn_wrapper_names.clone()
-		spawn_wrapper_defs:          g.spawn_wrapper_defs.clone()
-		spawn_wrapper_defs_seen:     g.spawn_wrapper_defs_seen.clone()
-		callback_wrapper_names:      g.callback_wrapper_names.clone()
-		callback_wrapper_defs:       g.callback_wrapper_defs.clone()
-		callback_wrapper_defs_seen:  g.callback_wrapper_defs_seen.clone()
-		c_extern_refs:               g.c_extern_refs.clone()
-		c_extern_refs_ready:         g.c_extern_refs_ready
-		scope_parallel_workers:      g.scope_parallel_workers
-		c_name_cache:                &CNameCache{
+		interface_receiver_cache:        &StringLookupCache{}
+		normalize_call_cache:            &StringLookupCache{}
+		flattened_generic_name_cache:    &StringLookupCache{}
+		generic_struct_context_ct_cache: &StringLookupCache{}
+		struct_cname_cache:              &StringLookupCache{}
+		unique_struct_ct_cache:          &StringLookupCache{}
+		alias_method_cache:              &StringLookupCache{}
+		import_alias_cache:              &ContextStringLookupCache{}
+		enum_selector_cache:             &ContextStringLookupCache{}
+		enum_method_cache:               &ContextStringLookupCache{}
+		qualified_enum_method_cache:     &ContextStringLookupCache{}
+		struct_decl_pref_cache:          &StructDeclPrefCache{}
+		embedded_fields_by_type:         g.embedded_fields_by_type
+		param_types_by_short:            g.param_types_by_short
+		generic_method_candidates:       g.generic_method_candidates
+		spawn_wrapper_names:             g.spawn_wrapper_names.clone()
+		spawn_wrapper_defs:              g.spawn_wrapper_defs.clone()
+		spawn_wrapper_defs_seen:         g.spawn_wrapper_defs_seen.clone()
+		callback_wrapper_names:          g.callback_wrapper_names.clone()
+		callback_wrapper_defs:           g.callback_wrapper_defs.clone()
+		callback_wrapper_defs_seen:      g.callback_wrapper_defs_seen.clone()
+		c_extern_refs:                   g.c_extern_refs.clone()
+		c_extern_refs_ready:             g.c_extern_refs_ready
+		scope_parallel_workers:          g.scope_parallel_workers
+		c_name_cache:                    &CNameCache{
 			base: if !isnil(g.c_name_cache.base) { g.c_name_cache.base } else { g.c_name_cache }
 		}
 		// The const short-name index is read-only after its first build (the

--- a/vlib/v3/gen/c/interface.v
+++ b/vlib/v3/gen/c/interface.v
@@ -270,27 +270,33 @@ fn (g &FlatGen) interface_dispatch_target_is_emitted(concrete_key string) bool {
 }
 
 fn (g &FlatGen) interface_dispatch_method_is_required(concrete_key string) bool {
-	if !concrete_key.contains('.') {
-		return false
-	}
-	method := concrete_key.all_after_last('.')
-	concrete_c_name := g.cname(concrete_key)
+	return concrete_key in g.interface_dispatch_required
+}
+
+fn (mut g FlatGen) precompute_required_interface_dispatch_methods() {
+	g.interface_dispatch_required.clear()
 	for iface_name, impls in g.iface_impls {
-		if !g.should_emit_interface_dispatch(iface_name, method) {
-			continue
-		}
-		for concrete in impls {
-			concrete_method := '${concrete}.${method}'
-			if concrete_method == concrete_key || g.cname(concrete_method) == concrete_c_name {
-				return g.interface_dispatch_target_decl_is_used(concrete_method)
+		methods := g.interfaces[iface_name] or { g.tc.interface_abstract_method_names(iface_name) }
+		for method in methods {
+			if !g.should_emit_interface_dispatch(iface_name, method) {
+				continue
 			}
-			expected := g.tc.concrete_method_signature_key(concrete, method) or { concrete_method }
-			if expected == concrete_key || g.cname(expected) == concrete_c_name {
-				return g.interface_dispatch_target_decl_is_used(expected)
+			for concrete in impls {
+				concrete_method := '${concrete}.${method}'
+				if g.interface_dispatch_target_decl_is_used(concrete_method) {
+					g.interface_dispatch_required[concrete_method] = true
+					g.interface_dispatch_required[g.cname(concrete_method)] = true
+				}
+				expected := g.tc.concrete_method_signature_key(concrete, method) or {
+					concrete_method
+				}
+				if g.interface_dispatch_target_decl_is_used(expected) {
+					g.interface_dispatch_required[expected] = true
+					g.interface_dispatch_required[g.cname(expected)] = true
+				}
 			}
 		}
 	}
-	return false
 }
 
 fn (g &FlatGen) interface_dispatch_target_decl_is_used(name string) bool {

--- a/vlib/v3/gen/c/source_directive_test.v
+++ b/vlib/v3/gen/c/source_directive_test.v
@@ -1,5 +1,6 @@
 module c
 
+import os
 import v3.flat
 import v3.pref
 import v3.types
@@ -32,6 +33,52 @@ fn test_multiline_inlined_c_function_definition_is_collected() {
 
 	assert 'qrcodegen_encodeText' in g.inlined_c_fns
 	assert 'declared_with_anon_param' !in g.inlined_c_fns
+}
+
+fn test_preserved_header_trees_scan_shared_files_once() {
+	root := os.join_path(os.vtmp_dir(), 'v3_preserved_headers_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	shared_header := os.join_path(root, 'shared.h')
+	first := os.join_path(root, 'first.h')
+	second := os.join_path(root, 'second.h')
+	os.write_file(shared_header, 'int shared_header_fn(void);\n')!
+	os.write_file(first, '#include "shared.h"\n')!
+	os.write_file(second, '#include "shared.h"\n')!
+
+	mut g := FlatGen.new()
+	g.collect_preserved_header_file(first, [root])
+	g.collect_preserved_header_file(second, [root])
+
+	assert 'shared_header_fn' in g.inlined_c_declared_fns
+	assert g.preserved_header_files_seen.len == 3
+}
+
+fn test_large_nested_angle_header_stays_an_include() {
+	root := os.join_path(os.vtmp_dir(), 'v3_nested_large_header_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	large_header := os.join_path(root, 'large.h')
+	wrapper_header := os.join_path(root, 'wrapper.h')
+	os.write_file(large_header, '#ifndef LARGE_H\n#define LARGE_H\n' + ' '.repeat(263_000) +
+		'\nint large_header_fn(void);\n#endif\n')!
+	os.write_file(wrapper_header, '#include <large.h>\nint wrapper_header_fn(void);\n')!
+
+	header := c_inline_header_text('"${wrapper_header}"', '', wrapper_header, [root], false) or {
+		panic('failed to inline wrapper header')
+	}
+
+	assert header.text.contains('#include <large.h>')
+	assert !header.text.contains('int large_header_fn(void);')
+	assert header.text.contains('int wrapper_header_fn(void);')
+	assert header.preserved_headers.len == 1
+	assert header.preserved_headers[0].include_arg == '<large.h>'
 }
 
 fn test_cache_tracks_omitted_native_function_definitions() {

--- a/vlib/v3/gen/c/stmt_test.v
+++ b/vlib/v3/gen/c/stmt_test.v
@@ -25,6 +25,38 @@ fn stmt_test_prefix(mut a flat.FlatAst, op flat.Op, child flat.NodeId) flat.Node
 	})
 }
 
+fn test_primitive_fixed_array_zero_initializer_is_compact() {
+	mut a := flat.FlatAst.new()
+	mut tc := types.TypeChecker.new(&a)
+	mut g := FlatGen.new()
+	g.a = &a
+	g.tc = &tc
+
+	large := types.ArrayFixed{
+		elem_type: types.Type(types.u8_)
+		len:       65536
+	}
+	assert g.empty_fixed_array_initializer_string(large) == '{0}'
+
+	nested := types.ArrayFixed{
+		elem_type: types.Type(types.ArrayFixed{
+			elem_type: types.Type(types.i32_)
+			len:       32
+		})
+		len:       32
+	}
+	assert g.empty_fixed_array_initializer_string(nested) == '{0}'
+
+	dynamic_arrays := types.ArrayFixed{
+		elem_type: types.Type(types.Array{
+			elem_type: types.Type(types.int_)
+		})
+		len:       2
+	}
+	dynamic_init := g.empty_fixed_array_initializer_string(dynamic_arrays)
+	assert dynamic_init.count('array_new(') == 2
+}
+
 fn test_fixed_array_address_to_byte_pointer_decl_uses_data_pointer() {
 	mut a := flat.FlatAst.new()
 	mut tc := types.TypeChecker.new(&a)

--- a/vlib/v3/gen/c/struct.v
+++ b/vlib/v3/gen/c/struct.v
@@ -389,7 +389,7 @@ fn (mut g FlatGen) gen_struct_init(id flat.NodeId) {
 		expected_ct := g.value_c_type(expected_init_type)
 		if g.generic_struct_init_context_matches(init_value, expected_name)
 			|| (init_value.contains('_')
-			&& flattened_generic_struct_c_type_short_name(expected_ct) == init_value) {
+			&& g.flattened_generic_struct_c_type_short_name(expected_ct) == init_value) {
 			// The same semantic nested generic can be materialized once with a
 			// qualified inner argument and once with its in-module shorthand. Emit
 			// the instance required by the call/field context and use its fields.
@@ -651,6 +651,15 @@ fn (g &FlatGen) unique_qualified_struct_c_type(short_ct string) ?string {
 		|| short_ct.starts_with('union ') {
 		return none
 	}
+	if !isnil(g.unique_struct_ct_cache) {
+		mut cache := g.unique_struct_ct_cache
+		if cached := cache.entries[short_ct] {
+			if cached.len == 0 {
+				return none
+			}
+			return cached
+		}
+	}
 	mut matches := []string{}
 	for type_name, _ in g.tc.structs {
 		candidate_ct := g.struct_cname(type_name)
@@ -662,7 +671,15 @@ fn (g &FlatGen) unique_qualified_struct_c_type(short_ct string) ?string {
 		}
 	}
 	if matches.len == 1 && matches[0] != short_ct {
+		if !isnil(g.unique_struct_ct_cache) {
+			mut cache := g.unique_struct_ct_cache
+			cache.entries[short_ct] = matches[0]
+		}
 		return matches[0]
+	}
+	if !isnil(g.unique_struct_ct_cache) {
+		mut cache := g.unique_struct_ct_cache
+		cache.entries[short_ct] = ''
 	}
 	return none
 }
@@ -3247,7 +3264,7 @@ fn (g &FlatGen) generic_struct_init_instance_ct_for_node(node flat.Node) ?string
 			if name.contains('[') {
 				if ct := g.concrete_generic_struct_init_ct(name) {
 					if name.all_before('[').all_after_last('.') == node.value.all_after_last('.')
-						|| flattened_generic_struct_c_type_short_name(ct) == node.value {
+						|| g.flattened_generic_struct_c_type_short_name(ct) == node.value {
 						return ct
 					}
 				}
@@ -3497,20 +3514,27 @@ fn (g &FlatGen) generic_struct_init_app_ct_from_context(type_name string) ?strin
 		}
 		if generic_receiver_type_suffixes(candidate_args) == arg_suffix {
 			context_ct := g.tc.c_type(candidate_type)
+			if !isnil(g.generic_struct_context_ct_cache) {
+				if cached := g.generic_struct_context_ct_cache.entries[context_ct] {
+					return cached
+				}
+			}
 			mut matches := []string{}
 			for _, info in g.struct_decl_infos {
 				candidate_ct := g.struct_cname(info.full_name)
 				if candidate_ct == context_ct
-					|| flattened_generic_struct_c_type_short_name(candidate_ct) == context_ct {
+					|| g.flattened_generic_struct_c_type_short_name(candidate_ct) == context_ct {
 					if candidate_ct !in matches {
 						matches << candidate_ct
 					}
 				}
 			}
-			if matches.len == 1 {
-				return matches[0]
+			result := if matches.len == 1 { matches[0] } else { context_ct }
+			if !isnil(g.generic_struct_context_ct_cache) {
+				mut cache := g.generic_struct_context_ct_cache
+				cache.entries[context_ct] = result
 			}
-			return context_ct
+			return result
 		}
 	}
 	return none
@@ -3531,7 +3555,7 @@ fn (g &FlatGen) flattened_generic_struct_init_ct_from_context(type_name string) 
 			continue
 		}
 		ct := g.tc.c_type(base)
-		if flattened_generic_struct_c_type_short_name(ct) == clean {
+		if g.flattened_generic_struct_c_type_short_name(ct) == clean {
 			return ct
 		}
 	}
@@ -3553,7 +3577,7 @@ fn (g &FlatGen) flattened_generic_struct_init_ct(type_name string) ?string {
 		ct := g.tc.c_type(g.tc.parse_type(struct_name))
 		candidates := [
 			'${short_base}_${generic_receiver_type_suffixes(args)}',
-			flattened_generic_struct_c_type_short_name(ct),
+			g.flattened_generic_struct_c_type_short_name(ct),
 		]
 		if clean !in candidates {
 			continue
@@ -3588,7 +3612,12 @@ fn (g &FlatGen) same_module_flattened_generic_struct_ct(clean string) ?string {
 	return '${g.cname(g.tc.cur_module)}__${g.cname(base)}_${g.cname(g.tc.cur_module)}__${suffix}'
 }
 
-fn flattened_generic_struct_c_type_short_name(ct string) string {
+fn (g &FlatGen) flattened_generic_struct_c_type_short_name(ct string) string {
+	if !isnil(g.flattened_generic_name_cache) {
+		if cached := g.flattened_generic_name_cache.entries[ct] {
+			return cached
+		}
+	}
 	clean := trimmed_space(ct)
 	if clean.len == 0 {
 		return clean
@@ -3608,7 +3637,12 @@ fn flattened_generic_struct_c_type_short_name(ct string) string {
 		out << clean[i]
 		i++
 	}
-	return out.bytestr()
+	result := out.bytestr()
+	if !isnil(g.flattened_generic_name_cache) {
+		mut cache := g.flattened_generic_name_cache
+		cache.entries[ct] = result
+	}
+	return result
 }
 
 // find_struct_decl resolves find struct decl information for c.
@@ -4674,9 +4708,19 @@ fn c_struct_needs_typedef(name string) bool {
 }
 
 fn (g &FlatGen) struct_cname(name string) string {
-	return g.tc.c_type(types.Type(types.Struct{
+	if !isnil(g.struct_cname_cache) {
+		if cached := g.struct_cname_cache.entries[name] {
+			return cached
+		}
+	}
+	result := g.tc.c_type(types.Type(types.Struct{
 		name: name
 	}))
+	if !isnil(g.struct_cname_cache) {
+		mut cache := g.struct_cname_cache
+		cache.entries[name] = result
+	}
+	return result
 }
 
 fn (g &FlatGen) struct_decl_head(name string) string {

--- a/vlib/v3/markused/markused.v
+++ b/vlib/v3/markused/markused.v
@@ -772,21 +772,27 @@ fn enqueue_used_interface_dispatch_implementers(tc &types.TypeChecker, mut used 
 		if methods.len == 0 {
 			continue
 		}
-		impls := if markused_is_ierror_interface_name(iface_name) {
-			tc.ierror_impl_names()
-		} else {
-			tc.interface_impl_names(iface_name)
-		}
-		if impls.len == 0 {
-			continue
-		}
+		mut used_methods := []string{cap: methods.len}
 		for method in methods {
 			dispatch_key := '${iface_name}.${method}'
 			dispatch_c_key := markused_c_name(dispatch_key)
 			short_dispatch_key := '${iface_name.all_after_last('.')}.${method}'
-			if dispatch_key !in used && dispatch_c_key !in used && short_dispatch_key !in used {
-				continue
+			if dispatch_key in used || dispatch_c_key in used || short_dispatch_key in used {
+				used_methods << method
 			}
+		}
+		if used_methods.len == 0 {
+			continue
+		}
+		impls := if markused_is_ierror_interface_name(iface_name) {
+			tc.ierror_impl_names()
+		} else {
+			markused_interface_impl_names(iface_name, tc)
+		}
+		if impls.len == 0 {
+			continue
+		}
+		for method in used_methods {
 			for impl in impls {
 				for alias in interface_implementer_method_aliases(impl, method, tc) {
 					if enqueue(alias, mut used, mut queue) {
@@ -799,6 +805,12 @@ fn enqueue_used_interface_dispatch_implementers(tc &types.TypeChecker, mut used 
 		}
 	}
 	return added
+}
+
+fn markused_interface_impl_names(iface_name string, tc &types.TypeChecker) []string {
+	return tc.pre_transform_interface_impl_names(iface_name) or {
+		tc.interface_impl_names(iface_name)
+	}
 }
 
 fn interface_implementer_method_aliases(impl string, method string, tc &types.TypeChecker) []string {
@@ -844,7 +856,7 @@ fn ensure_iface_impls(recv string, cur_module string, tc &types.TypeChecker, mut
 	} else {
 		// Structs plus alias implementers, from the same list cgen assigns
 		// dispatch ids over.
-		impls = tc.interface_impl_names(iface_name)
+		impls = markused_interface_impl_names(iface_name, tc)
 	}
 	iface_impls[recv] = impls
 	if iface_name != recv {
@@ -2437,7 +2449,7 @@ fn markused_type_equality_uses_ierror_uncached(typ types.Type, tc &types.TypeChe
 			if markused_is_ierror_interface_name(typ.name) {
 				return true
 			}
-			for concrete in tc.interface_impl_names(typ.name) {
+			for concrete in markused_interface_impl_names(typ.name, tc) {
 				if markused_type_equality_uses_ierror(tc.parse_type(concrete), tc, mut cache) {
 					return true
 				}
@@ -2551,7 +2563,7 @@ fn markused_type_stringifies_channel_uncached(typ types.Type, cur_module string,
 			if 'str' in tc.interface_abstract_method_names(typ.name) {
 				return false
 			}
-			for concrete in tc.interface_impl_names(typ.name) {
+			for concrete in markused_interface_impl_names(typ.name, tc) {
 				if markused_type_stringifies_channel(tc.parse_type(concrete), cur_module, tc, mut
 					cache)
 				{
@@ -2739,7 +2751,7 @@ fn enqueue_stringified_custom_str_method(expr_id flat.NodeId, cur_module string,
 
 fn enqueue_interface_str_methods(iface_name string, tc &types.TypeChecker, mut used map[string]bool, mut queue []string) {
 	enqueue('${iface_name}.str', mut used, mut queue)
-	for impl in tc.interface_impl_names(iface_name) {
+	for impl in markused_interface_impl_names(iface_name, tc) {
 		method := '${impl}.str'
 		enqueue(method, mut used, mut queue)
 		lowered := markused_c_name(method)
@@ -2836,7 +2848,7 @@ fn enqueue_implicit_interface_str_dispatch_helpers(iface_name string, tc &types.
 		return
 	}
 	enqueue('string__plus', mut used, mut queue)
-	for impl in tc.interface_impl_names(iface_name) {
+	for impl in markused_interface_impl_names(iface_name, tc) {
 		if !tc.type_has_implicit_str_method(impl) {
 			continue
 		}

--- a/vlib/v3/tests/driver_cli_test.v
+++ b/vlib/v3/tests/driver_cli_test.v
@@ -382,6 +382,28 @@ fn main() {
 	c99_run := cmdexec.run(c99_output, [])
 	assert c99_run.exit_code == 0, c99_run.output
 	assert c99_run.output == '99\n', c99_run.output
+
+	native_object := os.join_path(root, 'compat_c99.o')
+	native_object_compile := cmdexec.run('cc',
+		['-std=c99', '-c', c99_c_source, '-o', native_object])
+	assert native_object_compile.exit_code == 0, native_object_compile.output
+	object_source := os.join_path(root, 'compat_object.v')
+	os.write_file(object_source, '#flag @DIR/compat_c99.o
+
+fn C.v3_compat_c99_probe() int
+
+fn main() {
+	println(C.v3_compat_c99_probe())
+}
+')!
+	object_output := os.join_path(root, 'compat_object')
+	object_compile := cmdexec.run(v3_bin, ['-nocache', '-no-memory-limit', '-showcc', '-o',
+		object_output, object_source])
+	assert object_compile.exit_code == 0, object_compile.output
+	assert !object_compile.output.contains('tcc.exe'), object_compile.output
+	object_run := cmdexec.run(object_output, [])
+	assert object_run.exit_code == 0, object_run.output
+	assert object_run.output == '99\n', object_run.output
 }
 
 fn test_driver_requests_macos_compatibility_for_inline_assembly() {

--- a/vlib/v3/tests/fixed_array_slice_test.v
+++ b/vlib/v3/tests/fixed_array_slice_test.v
@@ -33,4 +33,10 @@ fn main() {
 	run := os.execute(bin)
 	assert run.exit_code == 0, run.output
 	assert run.output.count('eval') == 1, run.output
+
+	c_file := os.join_path(os.temp_dir(), 'v3_fixed_slice.c')
+	generate_c := os.execute('${v3_bin} -o ${c_file} ${src_file}')
+	assert generate_c.exit_code == 0, generate_c.output
+	generated_c := os.read_file(c_file) or { panic(err) }
+	assert !generated_c.contains('(int[3]){a[0], a[1], a[2]}'), generated_c
 }

--- a/vlib/v3/transform/comptime.v
+++ b/vlib/v3/transform/comptime.v
@@ -381,10 +381,7 @@ fn (mut t Transformer) expand_comptime_for(id flat.NodeId, node flat.Node) []fla
 			return []flat.NodeId{}
 		}
 		// One block per iteration so per-field temps get their own scope.
-		block := t.make_block(cloned)
-		for s in t.transform_stmt(block) {
-			out << s
-		}
+		out << t.make_block(t.transform_stmts(cloned))
 	}
 	return out
 }
@@ -396,10 +393,7 @@ fn (mut t Transformer) expand_comptime_for_attributes(var_name string, source st
 		for sid in body_stmts {
 			cloned << t.clone_attribute_subst(sid, var_name, attr)
 		}
-		block := t.make_block(cloned)
-		for stmt in t.transform_stmt(block) {
-			out << stmt
-		}
+		out << t.make_block(t.transform_stmts(cloned))
 	}
 	return out
 }
@@ -715,7 +709,7 @@ fn (mut t Transformer) clone_attribute_subst_children_with_value(node flat.Node,
 	for child in children {
 		t.a.children << child
 	}
-	return t.a.add_node(flat.Node{
+	result := t.a.add_node(flat.Node{
 		kind:           node.kind
 		op:             node.op
 		pos:            node.pos
@@ -726,6 +720,13 @@ fn (mut t Transformer) clone_attribute_subst_children_with_value(node flat.Node,
 		children_start: start
 		children_count: flat.child_count(children.len)
 	})
+	if t.specialization_node_start >= 0 && node.kind == .decl_assign && children.len >= 2 {
+		lhs := t.a.nodes[int(children[0])]
+		if lhs.kind == .ident && lhs.value.len > 0 {
+			t.specialization_decl_nodes_by_name[lhs.value] << int(result)
+		}
+	}
+	return result
 }
 
 fn (mut t Transformer) make_attribute_literal(attr AttributeMeta) flat.NodeId {
@@ -759,10 +760,7 @@ fn (mut t Transformer) expand_comptime_for_params(var_name string, fn_name strin
 				cloned << cid
 			}
 		}
-		block := t.make_block(cloned)
-		for stmt in t.transform_stmt(block) {
-			out << stmt
-		}
+		out << t.make_block(t.transform_stmts(cloned))
 	}
 	return out
 }
@@ -1037,10 +1035,7 @@ fn (mut t Transformer) expand_comptime_for_methods(var_name string, base_type st
 				cloned << cid
 			}
 		}
-		block := t.make_block(cloned)
-		for stmt in t.transform_stmt(block) {
-			out << stmt
-		}
+		out << t.make_block(t.transform_stmts(cloned))
 	}
 	return out
 }
@@ -1532,10 +1527,7 @@ fn (mut t Transformer) expand_comptime_for_values(var_name string, base_type str
 				cloned << cid
 			}
 		}
-		block := t.make_block(cloned)
-		for s in t.transform_stmt(block) {
-			out << s
-		}
+		out << t.make_block(t.transform_stmts(cloned))
 	}
 	return out
 }
@@ -1552,10 +1544,7 @@ fn (mut t Transformer) expand_comptime_for_variants(var_name string, base_type s
 				cloned << cid
 			}
 		}
-		block := t.make_block(cloned)
-		for s in t.transform_stmt(block) {
-			out << s
-		}
+		out << t.make_block(t.transform_stmts(cloned))
 	}
 	return out
 }
@@ -2339,7 +2328,7 @@ fn (mut t Transformer) clone_variant_subst_with_smartcast(id flat.NodeId, var_na
 			typ = local_type
 		}
 	}
-	if node.kind == .decl_assign && children.len >= 2 {
+	if t.specialization_node_start >= 0 && node.kind == .decl_assign && children.len >= 2 {
 		rhs := t.a.nodes[int(children[1])]
 		rhs_typ := if rhs.kind == .ident && smartcast_name.len > 0 && rhs.value == smartcast_name
 			&& rhs.typ.len > 0 {
@@ -3508,7 +3497,7 @@ fn (mut t Transformer) clone_field_subst_children_with_value(node flat.Node, var
 	for c in children {
 		t.a.children << c
 	}
-	return t.a.add_node(flat.Node{
+	result := t.a.add_node(flat.Node{
 		kind:           node.kind
 		op:             node.op
 		pos:            node.pos
@@ -3518,6 +3507,13 @@ fn (mut t Transformer) clone_field_subst_children_with_value(node flat.Node, var
 		children_start: start
 		children_count: flat.child_count(children.len)
 	})
+	if t.specialization_node_start >= 0 && node.kind == .decl_assign && children.len >= 2 {
+		lhs := t.a.nodes[int(children[0])]
+		if lhs.kind == .ident && lhs.value.len > 0 {
+			t.specialization_decl_nodes_by_name[lhs.value] << int(result)
+		}
+	}
+	return result
 }
 
 fn (mut t Transformer) comptime_field_type_accessor(id flat.NodeId, var_name string, fm FieldMeta) ?string {

--- a/vlib/v3/transform/expr.v
+++ b/vlib/v3/transform/expr.v
@@ -3491,15 +3491,36 @@ fn (t &Transformer) enum_type_name_for_expected(expected_enum string, owner_mod 
 			return qname
 		}
 	}
+	cache_key := '${owner_mod}\n${t.cur_module}\n${clean}'
+	if !isnil(t.enum_expected_cache) {
+		if cached := t.enum_expected_cache.entries[cache_key] {
+			return cached
+		}
+		if t.enum_expected_cache.misses[cache_key] {
+			return ''
+		}
+	}
 	mut found := ''
 	for enum_name, _ in t.enum_types {
 		if enum_name.all_after_last('.') != clean {
 			continue
 		}
 		if found.len > 0 && found != enum_name {
+			if !isnil(t.enum_expected_cache) {
+				mut cache := t.enum_expected_cache
+				cache.misses[cache_key] = true
+			}
 			return ''
 		}
 		found = enum_name
+	}
+	if !isnil(t.enum_expected_cache) {
+		mut cache := t.enum_expected_cache
+		if found.len > 0 {
+			cache.entries[cache_key] = found
+		} else {
+			cache.misses[cache_key] = true
+		}
 	}
 	return found
 }

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -5762,11 +5762,7 @@ fn (t &Transformer) normalize_runtime_array_stringify_type(typ string) string {
 }
 
 fn (mut t Transformer) mark_interface_method_implementers_used(iface_name string, method string) {
-	impls := if t.is_builtin_ierror_interface_name(iface_name) {
-		t.tc.ierror_impl_names()
-	} else {
-		t.tc.interface_impl_names(iface_name)
-	}
+	impls := t.interface_impl_index_for_transform(iface_name).names
 	for concrete in impls {
 		if t.has_used_fn_filter() && !t.interface_boxed_type_used(iface_name, concrete) {
 			continue
@@ -5785,11 +5781,7 @@ fn (t &Transformer) interface_method_implementer_names(iface_name string, method
 	if isnil(t.tc) {
 		return []string{}
 	}
-	impls := if t.is_builtin_ierror_interface_name(iface_name) {
-		t.tc.ierror_impl_names()
-	} else {
-		t.tc.interface_impl_names(iface_name)
-	}
+	impls := t.interface_impl_index_for_transform(iface_name).names
 	mut names := []string{cap: impls.len * 2}
 	for concrete in impls {
 		concrete_method := '${concrete}.${method}'

--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -622,25 +622,26 @@ fn (t &Transformer) sorted_monomorph_cache_specs() []MonomorphCacheSpec {
 }
 
 fn (mut t Transformer) drain_pending_generic_fn_specs(mut emitted map[string]bool, mut generated []string) bool {
-	if t.pending_generic_fn_specs.len == 0 {
-		return false
-	}
-	specs := t.pending_generic_fn_specs
-	t.pending_generic_fn_specs = []PendingGenericFnSpec{}
 	// Keep specialization emission serial. The dynamic parallel work queues can
 	// strand a callback after nested requests are redistributed, and reserving a
 	// private append region per worker costs far more memory than this pass needs.
-	for spec in specs {
-		if spec.key in t.generic_fn_spec_nodes {
+	mut changed := false
+	for t.pending_generic_fn_specs.len > 0 {
+		specs := t.pending_generic_fn_specs
+		t.pending_generic_fn_specs = []PendingGenericFnSpec{}
+		for spec in specs {
+			if spec.key in t.generic_fn_spec_nodes {
+				t.pending_generic_fn_spec_keys.delete(spec.key)
+				continue
+			}
+			clone_id := t.emit_generic_fn_specialization(spec.decl, spec.args)
+			generated << t.generated_fn_used_names(spec.decl, clone_id, spec.args)
+			emitted[generic_fn_spec_key(spec.decl.key, spec.args)] = true
 			t.pending_generic_fn_spec_keys.delete(spec.key)
-			continue
+			changed = true
 		}
-		clone_id := t.emit_generic_fn_specialization(spec.decl, spec.args)
-		generated << t.generated_fn_used_names(spec.decl, clone_id, spec.args)
-		emitted[generic_fn_spec_key(spec.decl.key, spec.args)] = true
-		t.pending_generic_fn_spec_keys.delete(spec.key)
 	}
-	return true
+	return changed
 }
 
 fn (mut t Transformer) collect_generic_call_sites_after_type_refresh(generic_struct_specs map[string]string, decls map[string]GenericFnDecl, ignored_nodes []bool, candidate_ids []int, mut emitted map[string]bool, mut recorded_call_sites map[int]bool) []GenericCallSite {
@@ -2429,16 +2430,50 @@ fn (mut t Transformer) collect_generic_struct_specs_range(decls map[string]Gener
 	t.ensure_node_module_map()
 	safe_start := if start < 0 { 0 } else { start }
 	safe_end := if end > t.a.nodes.len { t.a.nodes.len } else { end }
+	mut type_context_module := ''
+	mut type_context_file := ''
+	mut seen_context_types := map[string]bool{}
 	for node_idx in safe_start .. safe_end {
 		node := t.a.nodes[node_idx]
+		type_has_bracket := node.typ.contains('[')
+		type_has_flat := !type_has_bracket && node.typ.contains('_')
+		mut may_contain_spec := type_has_bracket || type_has_flat
+		if !may_contain_spec {
+			may_contain_spec = match node.kind {
+				.sql_expr {
+					true
+				}
+				.struct_init, .array_init, .cast_expr, .as_expr, .sizeof_expr, .typeof_expr,
+				.is_expr {
+					node.value.contains('[') || node.value.contains('_')
+						|| node.generic_params().len > 0
+				}
+				else {
+					false
+				}
+			}
+		}
+		if !may_contain_spec {
+			continue
+		}
 		node_module := t.node_module_or(node_idx, '')
 		node_file := t.node_file_or(node_idx, '')
-		t.collect_generic_struct_specs_from_node(node, node_module, node_file, decls, mut specs)
+		if node_module != type_context_module || node_file != type_context_file {
+			type_context_module = node_module
+			type_context_file = node_file
+			seen_context_types.clear()
+		}
+		scan_node_type := node.typ.len > 0 && node.typ !in seen_context_types
+		if scan_node_type {
+			seen_context_types[node.typ] = true
+		}
+		t.collect_generic_struct_specs_from_node(node, node_module, node_file, scan_node_type,
+			decls, mut specs)
 	}
 }
 
-fn (mut t Transformer) collect_generic_struct_specs_from_node(node flat.Node, module_name string, file_name string, decls map[string]GenericStructDecl, mut specs map[string]string) {
-	if node.typ.len > 0 {
+fn (mut t Transformer) collect_generic_struct_specs_from_node(node flat.Node, module_name string, file_name string, scan_node_type bool, decls map[string]GenericStructDecl, mut specs map[string]string) {
+	if scan_node_type {
 		t.collect_generic_struct_spec_from_type(node.typ, module_name, file_name, decls, mut specs)
 	}
 	match node.kind {
@@ -2526,6 +2561,9 @@ fn (mut t Transformer) collect_generic_struct_specs_from_sql_expr(value string, 
 }
 
 fn (mut t Transformer) collect_generic_struct_spec_from_type(typ string, module_name string, file_name string, decls map[string]GenericStructDecl, mut specs map[string]string) {
+	if typ.len == 0 || (!typ.contains('[') && !typ.contains('_')) {
+		return
+	}
 	clean := typ.trim_space()
 	if clean.len == 0 {
 		return
@@ -2579,6 +2617,11 @@ fn (mut t Transformer) collect_generic_struct_spec_from_type(typ string, module_
 		return
 	}
 	if !clean.contains('[') {
+		// A flattened concrete generic name always includes the separator before
+		// its type suffix. Ordinary scalar and qualified names cannot be specs.
+		if !clean.contains('_') {
+			return
+		}
 		args := t.recorded_generic_specialization_args(clean) or { return }
 		spec_base := t.generic_struct_spec_base_from_flattened_type(clean, args, module_name,
 			file_name, decls) or { return }
@@ -2698,6 +2741,9 @@ fn (mut t Transformer) collect_generic_sum_specs_from_node(node flat.Node, modul
 }
 
 fn (mut t Transformer) collect_generic_sum_spec_from_type(typ string, module_name string, file_name string, decls map[string]GenericSumDecl, mut specs map[string]GenericSpecContext) {
+	if typ.len == 0 || !typ.contains('[') {
+		return
+	}
 	clean := typ.trim_space()
 	if clean.len == 0 {
 		return
@@ -2742,6 +2788,9 @@ fn (mut t Transformer) collect_generic_sum_spec_from_type(typ string, module_nam
 			t.collect_generic_sum_spec_from_type(clean[bracket_end + 1..], module_name, file_name,
 				decls, mut specs)
 		}
+		return
+	}
+	if !clean.contains('[') {
 		return
 	}
 	base, args, ok := generic_app_parts(clean)
@@ -3155,11 +3204,17 @@ fn (t &Transformer) node_module_or(idx int, fallback string) string {
 }
 
 fn (mut t Transformer) mark_node_context(id flat.NodeId, module_name string, file_name string) {
-	mut stack := [id]
-	for stack.len > 0 {
-		cur := stack.pop()
+	t.node_context_stack.clear()
+	t.node_context_stack << id
+	for t.node_context_stack.len > 0 {
+		cur := t.node_context_stack.pop()
 		idx := int(cur)
 		if idx < 0 || idx >= t.a.nodes.len {
+			continue
+		}
+		if idx < t.node_module_map_cache.len && idx < t.node_file_map_cache.len
+			&& t.node_module_map_cache[idx] == module_name
+			&& t.node_file_map_cache[idx] == file_name {
 			continue
 		}
 		if idx < t.node_module_map_cache.len {
@@ -3178,7 +3233,7 @@ fn (mut t Transformer) mark_node_context(id flat.NodeId, module_name string, fil
 			// The child range is checked above; avoid per-child bounds checks while mapping modules.
 			child_id := unsafe { t.a.children[i] }
 			if int(child_id) >= 0 {
-				stack << child_id
+				t.node_context_stack << child_id
 			}
 		}
 	}
@@ -3231,8 +3286,11 @@ fn (mut t Transformer) emit_generic_fn_specialization(decl GenericFnDecl, args [
 		return flat.empty_node
 	}
 	t.generic_fn_specs_in_progress[spec_key] = true
+	old_specialization_node_start := t.specialization_node_start
+	t.specialization_node_start = t.a.nodes.len
 	defer {
 		t.generic_fn_specs_in_progress.delete(spec_key)
+		t.specialization_node_start = old_specialization_node_start
 	}
 	old_module := t.cur_module
 	old_file := t.cur_file
@@ -3539,8 +3597,10 @@ fn (mut t Transformer) collect_generated_fn_body_call_names(id flat.NodeId, mut 
 				}
 			}
 		}
-	} else if fn_value_name := t.generated_fn_value_name_for_used(id, node) {
-		t.push_generated_used_name(fn_value_name, mut names, mut seen)
+	} else if node.kind in [.ident, .selector, .cast_expr, .paren, .expr_stmt] {
+		if fn_value_name := t.generated_fn_value_name_for_used(id, node) {
+			t.push_generated_used_name(fn_value_name, mut names, mut seen)
+		}
 	}
 	for i in 0 .. node.children_count {
 		t.collect_generated_fn_body_call_names(t.a.child(&node, i), mut names, mut seen)
@@ -6712,12 +6772,17 @@ fn (t &Transformer) current_specialization_has_generic_arg(arg string) bool {
 	return false
 }
 
-fn (t &Transformer) specialization_main_type_closure(args []string) map[string]bool {
+fn (mut t Transformer) specialization_main_type_closure(args []string) map[string]bool {
+	key := args.join('\x1f')
+	if key in t.specialization_main_type_closures {
+		return t.specialization_main_type_closures[key]
+	}
 	mut types_in_scope := map[string]bool{}
 	mut seen := map[string]bool{}
 	for arg in args {
 		t.collect_specialization_main_types(arg, mut types_in_scope, mut seen)
 	}
+	t.specialization_main_type_closures[key] = types_in_scope.clone()
 	return types_in_scope
 }
 
@@ -7469,17 +7534,33 @@ fn (t &Transformer) local_decl_type_before(name string, before flat.NodeId) ?str
 	if name.len == 0 || int(before) <= 0 {
 		return none
 	}
-	mut best := ''
 	limit := int(before)
+	if t.specialization_node_start >= 0 {
+		candidates := t.specialization_decl_nodes_by_name[name]
+		for ci := candidates.len - 1; ci >= 0; ci-- {
+			idx := candidates[ci]
+			if idx < t.specialization_node_start {
+				break
+			}
+			if idx >= limit {
+				continue
+			}
+			if typ := t.local_decl_type_at(name, idx) {
+				return typ
+			}
+		}
+		if better := t.local_decl_type_before_by_pos(name, before, t.specialization_node_start, '') {
+			return better
+		}
+		return none
+	}
 	mut start := 0
 	for i := limit - 1; i >= 0; i-- {
-		if t.a.nodes[i].kind in [.fn_decl, .fn_literal, .lambda_expr] {
+		node := t.a.nodes[i]
+		if node.kind in [.fn_decl, .fn_literal, .lambda_expr] {
 			start = i
 			break
 		}
-	}
-	for i in start .. limit {
-		node := t.a.nodes[i]
 		if node.kind != .decl_assign || node.children_count < 2 {
 			continue
 		}
@@ -7491,31 +7572,51 @@ fn (t &Transformer) local_decl_type_before(name string, before flat.NodeId) ?str
 		if lhs.kind != .ident || lhs.value != name {
 			continue
 		}
-		for candidate in [t.refined_node_types[int(lhs_id)] or { '' }, t.refined_node_types[i] or {
-			''
-		},
-			lhs.typ, node.typ] {
-			typ := if t.generic_type_text_contains_alias(candidate, t.cur_module) {
-				candidate
-			} else {
-				t.normalize_type_alias(candidate)
-			}
-			if typ.len > 0 && !t.generic_arg_is_unresolved(typ) && decl_type_is_usable(typ) {
-				best = typ
-			}
+		if typ := t.local_decl_type_at(name, i) {
+			return typ
 		}
-		if best.len == 0 {
-			rhs_id := t.a.child(&node, 1)
-			rhs_typ := t.node_type(rhs_id)
-			if rhs_typ.len > 0 && !t.generic_arg_is_unresolved(rhs_typ)
-				&& decl_type_is_usable(rhs_typ) {
-				best = rhs_typ
-			}
+	}
+	if better := t.local_decl_type_before_by_pos(name, before, start, '') {
+		return better
+	}
+	return none
+}
+
+fn (t &Transformer) local_decl_type_at(name string, idx int) ?string {
+	if idx < 0 || idx >= t.a.nodes.len {
+		return none
+	}
+	node := t.a.nodes[idx]
+	if node.kind != .decl_assign || node.children_count < 2 {
+		return none
+	}
+	lhs_id := t.a.child(&node, 0)
+	if int(lhs_id) < 0 || int(lhs_id) >= t.a.nodes.len {
+		return none
+	}
+	lhs := t.a.nodes[int(lhs_id)]
+	if lhs.kind != .ident || lhs.value != name {
+		return none
+	}
+	mut best := ''
+	for candidate in [t.refined_node_types[int(lhs_id)] or { '' }, t.refined_node_types[idx] or {
+		''
+	},
+		lhs.typ, node.typ] {
+		typ := if t.generic_type_text_contains_alias(candidate, t.cur_module) {
+			candidate
+		} else {
+			t.normalize_type_alias(candidate)
+		}
+		if typ.len > 0 && !t.generic_arg_is_unresolved(typ) && decl_type_is_usable(typ) {
+			best = typ
 		}
 	}
 	if best.len == 0 {
-		if better := t.local_decl_type_before_by_pos(name, before, start, best) {
-			best = better
+		rhs_id := t.a.child(&node, 1)
+		rhs_typ := t.node_type(rhs_id)
+		if rhs_typ.len > 0 && !t.generic_arg_is_unresolved(rhs_typ) && decl_type_is_usable(rhs_typ) {
+			best = rhs_typ
 		}
 	}
 	if best.len == 0 {
@@ -8402,6 +8503,12 @@ fn (mut t Transformer) clone_generic_node_from(node flat.Node, args []string, is
 		value:          cloned_value
 		is_mut:         node.is_mut
 	})
+	if t.specialization_node_start >= 0 && node.kind == .decl_assign && children.len >= 2 {
+		lhs := t.a.nodes[int(children[0])]
+		if lhs.kind == .ident && lhs.value.len > 0 {
+			t.specialization_decl_nodes_by_name[lhs.value] << int(clone_id)
+		}
+	}
 	if node.kind == .param && cloned_value.len > 0 && cloned_typ.len > 0 {
 		mut scoped_param_type := cloned_typ
 		if node.is_mut && node.op != .amp && scoped_param_type.starts_with('&') {
@@ -11280,14 +11387,25 @@ fn (t &Transformer) recorded_generic_specialization_args(typ string) ?[]string {
 	if clean.len == 0 {
 		return none
 	}
-	candidates := generic_specialization_lookup_candidates(clean)
-	for candidate in candidates {
-		if args := t.generic_specialization_args[candidate] {
+	if args := t.recorded_generic_specialization_args_exact(clean) {
+		return args
+	}
+	clean_cname := c_name(clean)
+	if clean_cname != clean {
+		if args := t.recorded_generic_specialization_args_exact(clean_cname) {
 			return args
 		}
-		if !isnil(t.generic_specialization_args_parent) {
-			parent := unsafe { *t.generic_specialization_args_parent }
-			if args := parent[candidate] {
+	}
+	if clean.contains('__') {
+		dotted := clean.replace('__', '.')
+		if dotted != clean && dotted != clean_cname {
+			if args := t.recorded_generic_specialization_args_exact(dotted) {
+				return args
+			}
+		}
+		dotted_cname := c_name(dotted)
+		if dotted_cname != clean && dotted_cname != clean_cname && dotted_cname != dotted {
+			if args := t.recorded_generic_specialization_args_exact(dotted_cname) {
 				return args
 			}
 		}
@@ -11295,24 +11413,17 @@ fn (t &Transformer) recorded_generic_specialization_args(typ string) ?[]string {
 	return none
 }
 
-fn generic_specialization_lookup_candidates(typ string) []string {
-	mut candidates := []string{}
-	add_generic_specialization_lookup_candidate(mut candidates, typ)
-	add_generic_specialization_lookup_candidate(mut candidates, c_name(typ))
-	if typ.contains('__') {
-		dotted := typ.replace('__', '.')
-		add_generic_specialization_lookup_candidate(mut candidates, dotted)
-		add_generic_specialization_lookup_candidate(mut candidates, c_name(dotted))
+fn (t &Transformer) recorded_generic_specialization_args_exact(name string) ?[]string {
+	if args := t.generic_specialization_args[name] {
+		return args
 	}
-	return candidates
-}
-
-fn add_generic_specialization_lookup_candidate(mut candidates []string, candidate string) {
-	clean := candidate.trim_space()
-	if clean.len == 0 || clean in candidates {
-		return
+	if !isnil(t.generic_specialization_args_parent) {
+		parent := unsafe { *t.generic_specialization_args_parent }
+		if args := parent[name] {
+			return args
+		}
 	}
-	candidates << clean
+	return none
 }
 
 fn generic_param_index(name string) int {

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -188,6 +188,7 @@ mut:
 	resolved_call_return_cache      &ResolvedCallReturnCache = unsafe { nil }
 	variant_match_cache             &VariantMatchCache       = unsafe { nil }
 	interface_type_cache            &ContextLookupCache      = unsafe { nil }
+	enum_expected_cache             &LookupCache             = unsafe { nil }
 	type_alias_name_cache           &ContextBoolLookupCache  = unsafe { nil }
 	interface_box_param_cache       &BoolLookupCache         = unsafe { nil }
 	alias_receiver_method_cache     &LookupCache             = unsafe { nil }
@@ -253,7 +254,8 @@ mut:
 	ignored_comptime_log_active bool
 	// cloning_generic_fn_depth > 0 while a generic specialization is cloned with a live,
 	// seeded parameter scope. Ident inference should use that scope rather than scan annotations.
-	cloning_generic_fn_depth int
+	cloning_generic_fn_depth  int
+	specialization_node_start int = -1
 	// escaping_amp_ptrs holds the names of pointer locals `p` declared as `p := &v`
 	// (v a value local) whose pointer escapes the function (is returned or retained
 	// in nonlocal storage). V semantics auto-heap such a `v`; v3 otherwise takes the
@@ -298,12 +300,15 @@ mut:
 	mut_fixed_array_capture_sources    map[string]bool
 	active_specialization_args         []string
 	active_specialization_main_types   map[string]bool
+	specialization_main_type_closures  map[string]map[string]bool
 	generic_specialization_args        map[string][]string
 	generic_specialization_args_parent &map[string][]string = unsafe { nil }
 	generic_fn_specs_in_progress       map[string]bool
 	generic_fn_spec_nodes              map[string]flat.NodeId
 	monomorph_cache_specs              map[string]MonomorphCacheSpec
 	generic_clone_children             []flat.NodeId
+	node_context_stack                 []flat.NodeId
+	specialization_decl_nodes_by_name  map[string][]int
 	defer_nested_generic_emissions     bool
 	parallel_monomorphize              bool
 	parallel_monomorph_worker          bool
@@ -1142,71 +1147,72 @@ fn new_transformer(mut a flat.FlatAst, tc &types.TypeChecker, used_fns map[strin
 // only the frozen program indexes they are allowed to share.
 fn new_transformer_view(a &flat.FlatAst, tc &types.TypeChecker, used_fns map[string]bool) Transformer {
 	return Transformer{
-		a:                                a
-		tc:                               unsafe { tc }
-		has_spawn_expr:                   tc.threads_condition_value()
-		refined_node_types:               map[int]string{}
-		fn_value_locals:                  map[string]string{}
-		mut_param_values:                 map[string]bool{}
-		fixed_array_param_values:         map[string]bool{}
-		mut_value_ident_nodes:            map[int]bool{}
-		pointer_value_lvalues:            map[string]bool{}
-		pointer_value_rvalues:            map[string]bool{}
-		addr_lvalue_pointer_locals:       map[string]bool{}
-		orm_initialized_fields:           map[string][]string{}
-		sql_query_data_aliases:           map[string][]string{}
-		bound_method_arrays:              map[string]BoundMethodArrayInfo{}
-		comptime_field_metas_cache:       map[string][]FieldMeta{}
-		const_array_fixed_storage_cache:  map[string]i8{}
-		invalidated_smartcasts:           map[string]bool{}
-		escaping_amp_ptrs:                map[string]bool{}
-		escaping_amp_sources:             map[string]bool{}
-		heaped_amp_locals:                map[string]bool{}
-		escaping_interface_box_locals:    map[string]bool{}
-		local_closure_cleanup_decls:      map[int]string{}
-		local_closure_cleanup_values:     map[int]string{}
-		local_closure_cleanup_assigns:    map[int]string{}
-		local_closure_field_cleanups:     map[int]bool{}
-		exclusive_closure_return_fns:     map[string]bool{}
-		mut_fixed_array_capture_sources:  map[string]bool{}
-		generic_specialization_args:      map[string][]string{}
-		generic_fn_specs_in_progress:     map[string]bool{}
-		generic_fn_spec_nodes:            map[string]flat.NodeId{}
-		monomorph_cache_specs:            map[string]MonomorphCacheSpec{}
-		pending_generic_fn_spec_keys:     map[string]bool{}
-		generic_receiver_methods_by_name: map[string][]string{}
-		generic_call_spec_cache:          map[int]GenericCallSpec{}
-		generic_call_spec_misses:         map[int]bool{}
-		monomorph_error_seen:             map[string]bool{}
-		call_param_types_decl_cache:      map[int][]types.Type{}
-		call_param_types_decl_misses:     map[string]bool{}
-		call_param_types_decl_index:      map[string]FnParamDeclRef{}
-		enum_backing_types:               map[string]string{}
-		sum_variant_names:                map[string]bool{}
-		receiver_method_suffix_index:     map[string]string{}
-		variadic_suffix_index:            map[string]i8{}
-		used_fns:                         used_fns.clone()
-		comptime_reflected_params:        map[string][]ParamMeta{}
-		interface_boxed_types:            map[string]bool{}
-		interface_impl_indexes:           map[string]&types.InterfaceImplIndex{}
-		interface_var_concrete_types:     map[string]string{}
-		interface_box_param_cache:        &BoolLookupCache{
+		a:                                 a
+		tc:                                unsafe { tc }
+		has_spawn_expr:                    tc.threads_condition_value()
+		refined_node_types:                map[int]string{}
+		fn_value_locals:                   map[string]string{}
+		mut_param_values:                  map[string]bool{}
+		fixed_array_param_values:          map[string]bool{}
+		mut_value_ident_nodes:             map[int]bool{}
+		pointer_value_lvalues:             map[string]bool{}
+		pointer_value_rvalues:             map[string]bool{}
+		addr_lvalue_pointer_locals:        map[string]bool{}
+		orm_initialized_fields:            map[string][]string{}
+		sql_query_data_aliases:            map[string][]string{}
+		bound_method_arrays:               map[string]BoundMethodArrayInfo{}
+		comptime_field_metas_cache:        map[string][]FieldMeta{}
+		const_array_fixed_storage_cache:   map[string]i8{}
+		invalidated_smartcasts:            map[string]bool{}
+		escaping_amp_ptrs:                 map[string]bool{}
+		escaping_amp_sources:              map[string]bool{}
+		heaped_amp_locals:                 map[string]bool{}
+		escaping_interface_box_locals:     map[string]bool{}
+		local_closure_cleanup_decls:       map[int]string{}
+		local_closure_cleanup_values:      map[int]string{}
+		local_closure_cleanup_assigns:     map[int]string{}
+		local_closure_field_cleanups:      map[int]bool{}
+		exclusive_closure_return_fns:      map[string]bool{}
+		mut_fixed_array_capture_sources:   map[string]bool{}
+		generic_specialization_args:       map[string][]string{}
+		generic_fn_specs_in_progress:      map[string]bool{}
+		generic_fn_spec_nodes:             map[string]flat.NodeId{}
+		monomorph_cache_specs:             map[string]MonomorphCacheSpec{}
+		specialization_decl_nodes_by_name: map[string][]int{}
+		pending_generic_fn_spec_keys:      map[string]bool{}
+		generic_receiver_methods_by_name:  map[string][]string{}
+		generic_call_spec_cache:           map[int]GenericCallSpec{}
+		generic_call_spec_misses:          map[int]bool{}
+		monomorph_error_seen:              map[string]bool{}
+		call_param_types_decl_cache:       map[int][]types.Type{}
+		call_param_types_decl_misses:      map[string]bool{}
+		call_param_types_decl_index:       map[string]FnParamDeclRef{}
+		enum_backing_types:                map[string]string{}
+		sum_variant_names:                 map[string]bool{}
+		receiver_method_suffix_index:      map[string]string{}
+		variadic_suffix_index:             map[string]i8{}
+		used_fns:                          used_fns.clone()
+		comptime_reflected_params:         map[string][]ParamMeta{}
+		interface_boxed_types:             map[string]bool{}
+		interface_impl_indexes:            map[string]&types.InterfaceImplIndex{}
+		interface_var_concrete_types:      map[string]string{}
+		interface_box_param_cache:         &BoolLookupCache{
 			entries: map[string]i8{}
 		}
-		alias_receiver_method_cache:      &LookupCache{
+		alias_receiver_method_cache:       &LookupCache{
 			entries: map[string]string{}
 			misses:  map[string]bool{}
 		}
-		call_variadic_cache:              &BoolLookupCache{
+		call_variadic_cache:               &BoolLookupCache{
 			entries: map[string]i8{}
 		}
-		str_alias_cache:                  &LookupCache{
+		str_alias_cache:                   &LookupCache{
 			entries: map[string]string{}
 			misses:  map[string]bool{}
 		}
-		var_type_indices:                 map[string]int{}
-		scoped_owned_base_nodes:          map[int]bool{}
-		scoped_promoted_texts:            map[string]string{}
+		var_type_indices:                  map[string]int{}
+		scoped_owned_base_nodes:           map[int]bool{}
+		scoped_promoted_texts:             map[string]string{}
 	}
 }
 
@@ -1346,6 +1352,10 @@ fn (mut t Transformer) prepare() {
 	t.resolved_call_return_cache = &ResolvedCallReturnCache{}
 	t.variant_match_cache = &VariantMatchCache{}
 	t.interface_type_cache = &ContextLookupCache{
+		entries: map[string]string{}
+		misses:  map[string]bool{}
+	}
+	t.enum_expected_cache = &LookupCache{
 		entries: map[string]string{}
 		misses:  map[string]bool{}
 	}
@@ -3013,6 +3023,10 @@ fn (t &Transformer) fork_worker_config(ast &flat.FlatAst, wtc &types.TypeChecker
 		entries: map[string]string{}
 		misses:  map[string]bool{}
 	}
+	w.enum_expected_cache = &LookupCache{
+		entries: map[string]string{}
+		misses:  map[string]bool{}
+	}
 	w.type_alias_name_cache = &ContextBoolLookupCache{
 		entries: map[string]i8{}
 	}
@@ -3127,6 +3141,10 @@ fn (t &Transformer) fork_scan_worker(wtc &types.TypeChecker) &Transformer {
 	w.resolved_call_return_cache = &ResolvedCallReturnCache{}
 	w.variant_match_cache = &VariantMatchCache{}
 	w.interface_type_cache = &ContextLookupCache{
+		entries: map[string]string{}
+		misses:  map[string]bool{}
+	}
+	w.enum_expected_cache = &LookupCache{
 		entries: map[string]string{}
 		misses:  map[string]bool{}
 	}
@@ -3278,6 +3296,7 @@ fn (t &Transformer) fork_program_view(ast &flat.FlatAst, wtc &types.TypeChecker,
 		mut_fixed_array_capture_sources:    map[string]bool{}
 		generic_fn_specs_in_progress:       map[string]bool{}
 		generic_fn_spec_nodes:              map[string]flat.NodeId{}
+		specialization_decl_nodes_by_name:  map[string][]int{}
 		pending_generic_fn_spec_keys:       map[string]bool{}
 		generic_receiver_methods_by_name:   map[string][]string{}
 		generic_call_spec_cache:            map[int]GenericCallSpec{}

--- a/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
@@ -652,7 +652,7 @@ $if !windows {
 			for i in spec_nodes_start .. w.a.nodes.len {
 				node := w.a.nodes[i]
 				w.collect_generic_struct_specs_from_node(node, spec.decl.module, spec.decl.file,
-					a.struct_decls, mut struct_specs)
+					true, a.struct_decls, mut struct_specs)
 				w.collect_generic_sum_specs_from_node(node, spec.decl.module, spec.decl.file,
 					a.sum_decls, mut sum_specs)
 			}

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -592,6 +592,7 @@ pub mut:
 	interface_abstract_methods            map[string][]string // iface -> abstract (declared) method names
 	interface_impl_name_snapshots         map[string][]string
 	interface_impl_candidates_at_snapshot map[string]bool
+	interface_impl_candidates_at_index    map[string]bool
 	interface_method_names_index          map[string][]string
 	interface_abstract_index              map[string][]string
 	interface_field_list_index            map[string][]StructField
@@ -853,6 +854,7 @@ pub fn TypeChecker.new(a &flat.FlatAst) TypeChecker {
 		interface_abstract_methods:            map[string][]string{}
 		interface_impl_name_snapshots:         map[string][]string{}
 		interface_impl_candidates_at_snapshot: map[string]bool{}
+		interface_impl_candidates_at_index:    map[string]bool{}
 		interface_method_names_index:          map[string][]string{}
 		interface_abstract_index:              map[string][]string{}
 		interface_field_list_index:            map[string][]StructField{}
@@ -993,6 +995,7 @@ fn (tc &TypeChecker) fork_program_view(ast &flat.FlatAst, direct_dependencies_by
 		interface_fields:                   tc.interface_fields
 		interface_embeds:                   tc.interface_embeds
 		interface_abstract_methods:         tc.interface_abstract_methods
+		interface_impl_candidates_at_index: tc.interface_impl_candidates_at_index
 		interface_method_names_index:       tc.interface_method_names_index
 		interface_abstract_index:           tc.interface_abstract_index
 		interface_field_list_index:         tc.interface_field_list_index

--- a/vlib/v3/types/checker_comptime.v
+++ b/vlib/v3/types/checker_comptime.v
@@ -6662,6 +6662,22 @@ fn (tc &TypeChecker) array_append_is_standalone_statement(id flat.NodeId) bool {
 	if tc.is_statement_node(id) {
 		return true
 	}
+	// Source ASTs already have a direct-parent index. Nearly every `<<` expression
+	// wrapped by an expr_stmt can be answered from it, without walking the entire
+	// program once per append. Keep the scan below as a fallback for shared or
+	// transform-created nodes after the index is no longer authoritative.
+	if tc.direct_parent_index_trusted {
+		idx := int(id)
+		if idx >= 0 && idx < tc.direct_parent_ids.len {
+			parent_id := tc.direct_parent_ids[idx]
+			if tc.valid_node_id(parent_id) {
+				parent := tc.a.node(parent_id)
+				return parent.kind == .expr_stmt && parent.children_count == 1
+					&& tc.a.child(parent, 0) == id && tc.is_statement_node(parent_id)
+			}
+		}
+		return false
+	}
 	for index, candidate in tc.a.nodes {
 		if candidate.kind == .expr_stmt && candidate.children_count == 1
 			&& tc.a.child(&candidate, 0) == id {

--- a/vlib/v3/types/checker_tail_stmt.v
+++ b/vlib/v3/types/checker_tail_stmt.v
@@ -8421,6 +8421,13 @@ pub fn (tc &TypeChecker) interface_impl_names(iface_name string) []string {
 	return impls
 }
 
+// pre_transform_interface_impl_names returns the immutable implementer snapshot
+// prepared after semantic checking and before generic monomorphization.
+pub fn (tc &TypeChecker) pre_transform_interface_impl_names(iface_name string) ?[]string {
+	index := tc.interface_impl_indexes[iface_name] or { return none }
+	return index.names
+}
+
 // interface_type_ids returns the `_typ` dispatch IDs for an interface, preserving
 // any snapshot IDs emitted before late generic implementers were discovered.
 pub fn (tc &TypeChecker) interface_type_ids(iface_name string) map[string]int {
@@ -8444,6 +8451,24 @@ pub fn (mut tc TypeChecker) freeze_interface_impl_names() {
 	// Earlier transform queries may have cached an implementer list before all
 	// lowered method signatures were available. Cgen must rebuild from the frozen
 	// snapshot so its dispatch table uses the same IDs as transformed interface boxes.
+	tc.clear_interface_impl_cache()
+}
+
+// freeze_pre_transform_interface_impl_names freezes the immutable implementer
+// indexes prepared before transform. Transform does not add declarations; later
+// generic implementers remain discoverable because the matching candidate set is
+// frozen with the indexes.
+pub fn (mut tc TypeChecker) freeze_pre_transform_interface_impl_names() {
+	mut snapshots := map[string][]string{}
+	for iface_name in tc.interface_names.keys() {
+		if index := tc.interface_impl_indexes[iface_name] {
+			snapshots[iface_name] = index.names.clone()
+		} else {
+			snapshots[iface_name] = tc.interface_impl_names_uncached(iface_name)
+		}
+	}
+	tc.interface_impl_name_snapshots = snapshots.move()
+	tc.interface_impl_candidates_at_snapshot = tc.interface_impl_candidates_at_index.clone()
 	tc.clear_interface_impl_cache()
 }
 
@@ -9480,6 +9505,7 @@ pub fn (mut tc TypeChecker) prepare_interface_requirement_indexes() {
 pub fn (mut tc TypeChecker) prepare_interface_query_indexes() {
 	tc.prepare_interface_requirement_indexes()
 	tc.interface_impl_indexes = map[string]&InterfaceImplIndex{}
+	tc.interface_impl_candidates_at_index = tc.interface_impl_candidate_names()
 	for iface_name in tc.interface_names.keys() {
 		impls := if is_builtin_ierror_name(iface_name) {
 			tc.ierror_impl_names()

--- a/vlib/v3/types/interface_impl_test.v
+++ b/vlib/v3/types/interface_impl_test.v
@@ -39,8 +39,12 @@ fn test_prepared_interface_indexes_do_not_stale_late_implementers() {
 	mut tc := TypeChecker.new(&a)
 	tc.interface_names['Any'] = true
 	tc.prepare_interface_query_indexes()
+	pre_transform := tc.pre_transform_interface_impl_names('Any') or {
+		panic('missing prepared interface implementer index')
+	}
 	tc.structs['LateType'] = []StructField{}
-	tc.freeze_interface_impl_names()
+	tc.freeze_pre_transform_interface_impl_names()
+	assert 'LateType' !in pre_transform
 	assert 'LateType' in tc.interface_impl_names('Any')
 }
 


### PR DESCRIPTION
## Summary

- reduce repeated whole-AST work in V3 checking, transformation, mark-used analysis, and C generation
- add reusable indexes and per-worker caches for interface implementers, generic specializations, enum/type lookups, fixed-array storage, and cleanup decisions
- keep parallel compiler stages deterministic while preserving pre-transform interface IDs
- add regression coverage for the driver CLI, interface snapshots, fixed arrays, source directives, and generated statements

## Why

Large projects such as Office exposed repeated scans and serialized work that made V3 compilation slower than the old compiler when both ran without a persistent module cache. This change moves repeated queries onto prepared indexes/caches and keeps independent compiler stages parallel.

The branch was rebased onto `master` after the checker split; checker-specific changes now live in `checker.v`, `checker_comptime.v`, and `checker_tail_stmt.v` according to their responsibilities.

## Impact

V3 should spend less time in semantic checking, generic monomorphization, mark-used analysis, and C generation on large programs, without requiring a warm external cache. The added tests protect output correctness and deterministic interface dispatch metadata.

## Validation

- `./v -g -keepc -o ./vnew cmd/v`
- `./vnew -silent test vlib/v3/types/` (6/6 passed)
- `./vnew -silent test vlib/v3/transform/` (6/6 passed)
- `./vnew -silent vlib/v3/types/interface_impl_test.v`
- `./vnew -silent vlib/v3/tests/fixed_array_slice_test.v`
- `./vnew -silent vlib/v3/gen/c/source_directive_test.v`
- `./vnew -silent vlib/v3/gen/c/stmt_test.v`

A broader experimental `vlib/v3/tests/` run was stopped at the author's request after encountering unrelated existing fixture/semantic failures.