### PR TITLE
v3: optimize JSON comptime field expansion

### DIFF
--- a/vlib/v3/transform/comptime.v
+++ b/vlib/v3/transform/comptime.v
@@ -3096,6 +3096,18 @@ fn (mut t Transformer) clone_field_subst_scoped(id flat.NodeId, var_name string,
 	if node.children_count == 0 {
 		return t.a.add_node(node)
 	}
+	// Field attributes are compile-time metadata. Avoid materializing and then
+	// lowering runtime array work for operations whose result is already known
+	// for this unrolled field.
+	if node.kind == .call {
+		if contains := t.comptime_field_attrs_condition(id, var_name, fm) {
+			return t.make_bool_literal(contains)
+		}
+	}
+	if node.kind == .for_in_stmt && node.children_count >= 3 && fm.attrs.len == 0
+		&& t.direct_reflected_field_attrs_selector(t.a.child(&node, 2), var_name) {
+		return none
+	}
 	if node.kind == .match_stmt && node.children_count > 1 {
 		subject := t.a.child_node(&node, 0)
 		if subject.kind == .selector && subject.value == 'typ' && subject.children_count > 0 {
@@ -3271,6 +3283,18 @@ fn (mut t Transformer) clone_field_subst_scoped(id flat.NodeId, var_name string,
 		return t.clone_field_subst_children_with_value(node, var_name, fm, inner_vars, cond)
 	}
 	return t.clone_field_subst_children(node, var_name, fm, inner_vars)
+}
+
+fn (t &Transformer) direct_reflected_field_attrs_selector(id flat.NodeId, var_name string) bool {
+	if int(id) < 0 || int(id) >= t.a.nodes.len {
+		return false
+	}
+	node := t.a.nodes[int(id)]
+	if node.kind != .selector || node.value != 'attrs' || node.children_count == 0 {
+		return false
+	}
+	base := t.a.child_node(&node, 0)
+	return base.kind == .ident && base.value == var_name
 }
 
 fn (mut t Transformer) clone_field_match_branch_body(branch flat.Node, body_start int, var_name string, fm FieldMeta, inner_vars []string) flat.NodeId {

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -6438,6 +6438,14 @@ pub fn (tc &TypeChecker) fn_param_types_for_name(name string) []Type {
 	if name.len == 0 {
 		return []Type{}
 	}
+	if indexed := tc.receiver_method_suffix_index[name] {
+		if indexed == receiver_method_suffix_ambiguous {
+			return []Type{}
+		}
+		if params := tc.fn_param_types[indexed] {
+			return params
+		}
+	}
 	mut found := []Type{}
 	mut matches := 0
 	for candidate, params in tc.fn_param_types {


### PR DESCRIPTION
## Summary
- fold reflected field attribute membership checks while unrolling `$for field in T.fields`
- skip known-empty reflected attribute loops instead of lowering runtime array work
- use the existing function suffix index before scanning all function signatures

## Performance
No-cache Office Excel benchmark (`-no-memory-limit`, generated C output):
- total: 5.02–5.09 s -> 4.53–4.60 s
- monomorphize: 2.73–2.74 s -> 2.36 s
- post-monomorph AST: 1,202,479 -> 1,009,414 nodes
- generated C: 9.57 MB -> 8.01 MB
- peak physical footprint: 2,929 MB -> 2,785–2,788 MB

V1 baseline on the same no-cache workload: 5.88–6.00 s.

## Validation
- rebuilt `./vnew` and standalone V3 compiler
- generated Office Excel C output with both baseline and optimized compilers
- test suite intentionally skipped as requested