### PR TITLE
cgen: keep comptime regions intact in parallel C shards

### DIFF
--- a/vlib/v/builder/cbuilder/parallel_cc.v
+++ b/vlib/v/builder/cbuilder/parallel_cc.v
@@ -54,6 +54,14 @@ fn parallel_cc(mut b builder.Builder, result c.GenOutput) ! {
 	c_files := int_max(1, util.nr_jobs)
 	eprintln('> c_files: ${c_files} | util.nr_jobs: ${util.nr_jobs}')
 
+	// `-no-builtin` can leave only functions inside a comptime region, so cgen has no safe
+	// function split positions. Offset 0 keeps all generated output together in out_x.c.
+	fn_start_positions := if result.out_fn_start_pos.len == 0 {
+		[0]
+	} else {
+		result.out_fn_start_pos
+	}
+
 	// Write generated stuff in `g.out` before and after the `out_fn_start_pos` locations,
 	// like the `int main()` to "out_0.c" and "out_x.c"
 
@@ -61,14 +69,14 @@ fn parallel_cc(mut b builder.Builder, result c.GenOutput) ! {
 	os.write_file('${tmp_dir}/out.h', result.header) or { panic(err) }
 
 	// out_0.c
-	out0 := '//out0\n' + result.out_str[..result.out_fn_start_pos[0]]
+	out0 := '//out0\n' + result.out_str[..fn_start_positions[0]]
 	os.write_file('${tmp_dir}/out_0.c', '#include "out.h"\n' + out0 + '\n//X:\n' + result.out0_str) or {
 		panic(err)
 	}
 
 	// out_x.c
 	os.write_file('${tmp_dir}/out_x.c', '#include "out.h"\n\n' + result.extern_str + '\n' +
-		result.out_str[result.out_fn_start_pos.last()..]) or { panic(err) }
+		result.out_str[fn_start_positions.last()..]) or { panic(err) }
 
 	mut prev_fn_pos := 0
 	mut out_files := []os.File{len: c_files}
@@ -84,9 +92,9 @@ fn parallel_cc(mut b builder.Builder, result c.GenOutput) ! {
 		out_files[i].writeln(result.extern_str) or { panic(err) }
 	}
 
-	for i, fn_pos in result.out_fn_start_pos {
+	for i, fn_pos in fn_start_positions {
 		if prev_fn_pos >= result.out_str.len || fn_pos >= result.out_str.len || prev_fn_pos > fn_pos {
-			eprintln('> EXITING i=${i} out of ${result.out_fn_start_pos.len} prev_pos=${prev_fn_pos} fn_pos=${fn_pos}')
+			eprintln('> EXITING i=${i} out of ${fn_start_positions.len} prev_pos=${prev_fn_pos} fn_pos=${fn_pos}')
 			break
 		}
 		if i == 0 {

--- a/vlib/v/builder/parallel_cc_failure_test.v
+++ b/vlib/v/builder/parallel_cc_failure_test.v
@@ -51,6 +51,18 @@ fn run_parallel_cc_failure_case(case_name string, files map[string]string) os.Re
 	return run_parallel_cc_case(case_name, files)
 }
 
+fn run_parallel_cc_comptime_case(case_name string, source string, nr_jobs int) os.Result {
+	return run_parallel_cc_case_with_args(case_name, [
+		'-parallel-cc',
+		'run',
+		'main.v',
+	], {
+		'main.v': source
+	}, {
+		'VJOBS': nr_jobs.str()
+	})
+}
+
 fn test_parallel_cc_fails_when_c_compilation_fails() {
 	res := run_parallel_cc_failure_case('compile_fail', {
 		'main.v': 'module main
@@ -87,6 +99,73 @@ fn test_parallel_cc_succeeds_with_array_sort_compare_helper() {
 		println(xs)
 	}
 	'
+	})
+	assert res.exit_code == 0, res.output
+}
+
+fn test_parallel_cc_keeps_top_level_comptime_if_else_together() {
+	source := 'module main
+
+$if true {
+	@[markused]
+	fn parallel_cc_comptime_selected() int {
+		return 42
+	}
+} $else {
+	fn parallel_cc_comptime_inactive() int {
+		return -1
+	}
+}
+
+fn main() {
+	println("parallel-cc-comptime-if: " + parallel_cc_comptime_selected().str())
+}
+'
+	for nr_jobs in [2, 3] {
+		res := run_parallel_cc_comptime_case('top_level_comptime_if_else_${nr_jobs}', source,
+			nr_jobs)
+		assert res.exit_code == 0, res.output
+		assert res.output.contains('parallel-cc-comptime-if: 42'), res.output
+	}
+}
+
+fn test_parallel_cc_keeps_final_top_level_comptime_if_together() {
+	res := run_parallel_cc_comptime_case('final_top_level_comptime_if', 'module main
+
+fn main() {
+	println("parallel-cc-final-comptime: " + parallel_cc_final_comptime_fn().str())
+}
+
+$if true {
+	@[markused]
+	fn parallel_cc_final_comptime_fn() int {
+		return 42
+	}
+}
+', 2)
+	assert res.exit_code == 0, res.output
+	assert res.output.contains('parallel-cc-final-comptime: 42'), res.output
+}
+
+fn test_parallel_cc_handles_only_conditional_functions_without_builtin() {
+	res := run_parallel_cc_case_with_args('only_conditional_functions_without_builtin', [
+		'-no-builtin',
+		'-gc',
+		'none',
+		'-no-skip-unused',
+		'-parallel-cc',
+		'run',
+		'main.v',
+	], {
+		'main.v': '$if usemain1 ? {
+	fn main() {}
+} $else {
+	fn main() {}
+}
+'
+	}, {
+		'VJOBS':                         '2'
+		'V_C_ERROR_BUG_REPORT_DISABLED': '1'
 	})
 	assert res.exit_code == 0, res.output
 }

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -955,7 +955,8 @@ fn (mut g Gen) fn_decl(node ast.FnDecl) {
 			// g.write('static ')
 			// g.definitions.write_string('static ')
 		}
-		if !node.is_anon {
+		// Keep a top-level `$if` region in one C file so its preprocessor directives stay balanced.
+		if !node.is_anon && !g.comptime.inside_comptime_if {
 			g.out_fn_start_pos << g.out.len
 		}
 	}


### PR DESCRIPTION
## Summary

Validate the focused macOS `-parallel-cc` follow-up after vlang/v#27975.

## Change

- Keep functions emitted inside a top-level comptime condition in one generated C shard, preserving balanced preprocessor directives.
- Add regression coverage for `$if/$else`, 2/3 workers, and a conditional region at the end of the source.

## Local validation

- Regression reproduced before the fix with unmatched `#if/#else/#endif` diagnostics.
- Targeted parallel-cc regression test passes.
- Compiler error suite: 1613 passed, 5 skipped.
- CGen output suite passes.
- Linux `cmd/v` self-compilation with `-parallel-cc`: 22 C commands, zero failures.