### PR TITLE
net.quic: reject duplicate ALPN protocol names in ClientHello

### DIFF
--- a/vlib/net/quic/tls13_client_hello.v
+++ b/vlib/net/quic/tls13_client_hello.v
@@ -227,16 +227,28 @@ fn encode_quic_transport_parameters_extension(params QuicTransportParameters) ![
 // followed by its bytes. `protocols` must be non-empty (RFC 7301 §3.1:
 // "the list of protocols MUST NOT be empty") and each entry must fit in a
 // single byte length (RFC 7301 §3.1's own <1..255> bound on ProtocolName).
+// Duplicate entries are rejected too -- RFC 7301 itself has no uniqueness
+// requirement (checked directly, Codex P2 on vlang/v#27680
+// pullrequestreview-4822597219, correctly refuted as an RFC violation), but
+// a maintainer requested it anyway as hygiene: a duplicate wastes bytes on
+// the wire for no negotiation benefit (the server picks at most one match
+// regardless of how many times it appears), so it's rejected here as a
+// caller-input-validation choice, not a protocol-conformance one.
 fn encode_alpn_extension(protocols []string) ![]u8 {
 	if protocols.len == 0 {
 		return error('quic: ALPN protocol list must not be empty')
 	}
 	mut list := []u8{}
+	mut seen := map[string]bool{}
 	for p in protocols {
 		name_bytes := p.bytes()
 		if name_bytes.len == 0 || name_bytes.len > 0xff {
 			return error('quic: ALPN protocol name length ${name_bytes.len} out of range (1..255)')
 		}
+		if p in seen {
+			return error('quic: ALPN protocol list contains duplicate entry "${p}"')
+		}
+		seen[p] = true
 		list << u8(name_bytes.len)
 		list << name_bytes
 	}

--- a/vlib/net/quic/tls13_client_hello_test.v
+++ b/vlib/net/quic/tls13_client_hello_test.v
@@ -160,6 +160,46 @@ fn test_build_client_hello_rejects_empty_alpn_protocols() {
 	assert false, 'expected an error for an empty ALPN protocol list'
 }
 
+// test_build_client_hello_rejects_duplicate_alpn_protocols: RFC 7301 itself
+// has no uniqueness requirement for ProtocolNameList entries (checked
+// directly against §3.1's text, Codex P2 on vlang/v#27680
+// pullrequestreview-4822597219, correctly refuted as an RFC violation at the
+// time), but a maintainer requested rejecting duplicates anyway as hygiene
+// (discussion_r3690498809): a repeated entry wastes wire bytes for no
+// negotiation benefit, since the server can select at most one match no
+// matter how many times it appears.
+fn test_build_client_hello_rejects_duplicate_alpn_protocols() {
+	build_client_hello(ClientHelloParams{
+		random:               []u8{len: 32}
+		server_name:          'example.com'
+		ecdhe_public_key:     []u8{len: 65, init: 0x04}
+		alpn_protocols:       ['h3', 'h3']
+		transport_parameters: QuicTransportParameters{
+			initial_source_connection_id: [u8(1), 2, 3, 4]
+		}
+	}) or {
+		assert err.msg().contains('duplicate')
+		return
+	}
+	assert false, 'expected an error for a duplicate ALPN protocol entry'
+}
+
+// test_build_client_hello_accepts_distinct_alpn_protocols is the sibling
+// positive case: multiple DISTINCT protocol names must still succeed
+// unaffected by the duplicate check above.
+fn test_build_client_hello_accepts_distinct_alpn_protocols() {
+	client_hello := build_client_hello(ClientHelloParams{
+		random:               []u8{len: 32}
+		server_name:          'example.com'
+		ecdhe_public_key:     []u8{len: 65, init: 0x04}
+		alpn_protocols:       ['h3', 'http/1.1']
+		transport_parameters: QuicTransportParameters{
+			initial_source_connection_id: [u8(1), 2, 3, 4]
+		}
+	})!
+	assert client_hello.len > 0
+}
+
 // test_build_client_hello_rejects_missing_initial_source_connection_id is a
 // regression test for a gap this session's QUIC conformance-matrix audit
 // found (not a Codex report): build_client_hello validated that four


### PR DESCRIPTION
## Summary

Small follow-up to #27680: `encode_alpn_extension` now rejects a duplicate
protocol name in the caller-supplied ALPN list.

RFC 7301 §3.1 has no uniqueness requirement for `ProtocolNameList` entries —
a Codex finding on #27680 claimed this as an RFC violation
(pullrequestreview-4822597219), and that specific citation was correctly
refuted at the time (fetched §3.1 directly: it forbids empty/truncated
strings, nothing about uniqueness). @JalonSolov followed up on that thread
agreeing with the RFC read but asking for the check anyway as hygiene: a
duplicate entry wastes wire bytes for no negotiation benefit, since a server
selects at most one match no matter how many times a name appears
(discussion: https://github.com/vlang/v/pull/27680#discussion_r3690498809).

This is caller-input validation, not a protocol-conformance fix — the only
caller (`build_client_hello`) already propagates any of this function's
failures uniformly, and a stricter local check can't create an RFC
conformance regression since duplicate-free output is a strict subset of
what RFC 7301 already permits.

## Test plan

- [x] New test: `test_build_client_hello_rejects_duplicate_alpn_protocols`
- [x] New sibling test: `test_build_client_hello_accepts_distinct_alpn_protocols`
      (confirms the check doesn't affect a normal multi-protocol list)
- [x] `vlib/net/quic/` full suite green (13/13)
- [x] `./vnew fmt -w` on both touched files

🧙 Built with [WOZCODE](https://wozcode.com)