### PR TITLE
parser, v3: show where the conflicting signature is defined in C fn redeclaration errors

### DIFF
--- a/vlib/v/checker/c_fn_redeclaration_test.v
+++ b/vlib/v/checker/c_fn_redeclaration_test.v
@@ -26,8 +26,12 @@ fn test_conflicting_c_fn_redeclarations_across_modules_are_reported_at_declarati
 	}
 	result := os.execute('${c_fn_redeclaration_vexe} -check ${os.quoted_path(root)}')
 	assert result.exit_code != 0, result.output
-	assert result.output.contains('moda/moda.v:3:') || result.output.contains('modb/modb.v:3:')
 	assert result.output.contains('C function `C.getpid` was already declared with a different signature')
+	// the error points at the conflicting declaration and references where the other
+	// signature was defined, so both module locations appear in the output
+	assert result.output.contains('moda/moda.v:3:'), result.output
+	assert result.output.contains('modb/modb.v:3:'), result.output
+	assert result.output.contains('in module `moda`') || result.output.contains('in module `modb`'), result.output
 	assert !result.output.contains('cannot use `u64` as `int`'), result.output
 }
 

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -1125,7 +1125,10 @@ run them via `v file.v` instead',
 				&& new_fn.mod != 'builtin' {
 				should_register = false
 				if !p.table.c_fn_declarations_are_compatible(&existing, &new_fn) {
-					p.error_with_pos_no_advance('C function `${name}` was already declared with a different signature',
+					existing_line := existing.name_pos.line_nr + 1
+					existing_col := existing.name_pos.col + 1
+					existing_pos := '${existing.file}:${existing_line}:${existing_col}'
+					p.error_with_pos_no_advance('C function `${name}` was already declared with a different signature in module `${existing.mod}` at ${existing_pos}',
 						name_pos)
 				}
 			}

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -1125,9 +1125,10 @@ run them via `v file.v` instead',
 				&& new_fn.mod != 'builtin' {
 				should_register = false
 				if !p.table.c_fn_declarations_are_compatible(&existing, &new_fn) {
+					existing_path := util.path_styled_for_error_messages(existing.file)
 					existing_line := existing.name_pos.line_nr + 1
 					existing_col := existing.name_pos.col + 1
-					existing_pos := '${existing.file}:${existing_line}:${existing_col}'
+					existing_pos := '${existing_path}:${existing_line}:${existing_col}'
 					p.error_with_pos_no_advance('C function `${name}` was already declared with a different signature in module `${existing.mod}` at ${existing_pos}',
 						name_pos)
 				}

--- a/vlib/v3/tests/c_fn_redeclaration_and_empty_struct_test.v
+++ b/vlib/v3/tests/c_fn_redeclaration_and_empty_struct_test.v
@@ -49,6 +49,8 @@ fn test_v3_c_fn_redeclarations_and_empty_struct_defaults() {
 	assert result.exit_code != 0, result.output
 	assert result.output.contains('C function `C.getpid` was already declared with a different signature'), result.output
 	assert result.output.contains('C function `C.variadic_probe` was already declared with a different signature'), result.output
+	// the error references where the other signature was defined
+	assert result.output.contains('in module `moda`') || result.output.contains('in module `modb`'), result.output
 
 	assert !result.output.contains('C compilation failed'), result.output
 

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -3174,6 +3174,7 @@ struct CFnDeclSignature {
 fn (mut tc TypeChecker) check_c_fn_redeclarations(a &flat.FlatAst) {
 	mut signatures := map[string]CFnDeclSignature{}
 	mut modules := map[string]string{}
+	mut positions := map[string]string{}
 	tc.cur_module = ''
 	tc.cur_file = ''
 	for node_idx in tc.top_level_idx {
@@ -3210,15 +3211,19 @@ fn (mut tc TypeChecker) check_c_fn_redeclarations(a &flat.FlatAst) {
 					if existing_module == 'builtin' || existing_module == tc.cur_module {
 						signatures[name] = signature
 						modules[name] = tc.cur_module
+						positions[name] = tc.node_position_string(flat.NodeId(node_idx))
 					} else if tc.cur_module != 'builtin'
 						&& !c_fn_decl_signatures_compatible(existing, signature) {
+						existing_pos := positions[name] or { '' }
+						location := if existing_pos.len > 0 { ' at ${existing_pos}' } else { '' }
 						tc.record_error_unfiltered(.duplicate_decl,
-							'C function `${name}` was already declared with a different signature',
+							'C function `${name}` was already declared with a different signature in module `${existing_module}`${location}',
 							flat.NodeId(node_idx))
 					}
 				} else {
 					signatures[name] = signature
 					modules[name] = tc.cur_module
+					positions[name] = tc.node_position_string(flat.NodeId(node_idx))
 				}
 			}
 			else {}


### PR DESCRIPTION
## Motivation

When a `C.` function is declared with incompatible signatures in two different modules, the compiler reports:

```
/root/v/vlib/os/os.c.v:29:6: error: C function `C.open` was already declared with a different signature
```

The error only points at the *second* declaration, leaving no hint about *where the conflicting signature* was defined. That makes these conflicts (often between two third-party modules) hard to track down.

## Change

Both the mainline compiler (`vlib/v`) and `vlib/v3` now include the module and location of the previously-seen declaration:

**Before**
```
modb/modb.v:3:6: error: C function `C.getpid` was already declared with a different signature
```

**After**
```
modb/modb.v:3:6: error: C function `C.getpid` was already declared with a different signature in module `moda` at moda/moda.v:3:6
```

- `vlib/v/parser/fn.v`: the existing `ast.Fn` already carries `file`/`name_pos`/`mod`, so the location is built from those.
- `vlib/v3/types/checker.v`: `check_c_fn_redeclarations` now tracks the position string of the declaration whose signature is stored, and references it when reporting the conflict.

## Tests

Extended the existing redeclaration tests in both `vlib/v/checker/c_fn_redeclaration_test.v` and `vlib/v3/tests/c_fn_redeclaration_and_empty_struct_test.v` to assert the referenced location/module now appears in the output. Both pass.