### PR TITLE
builtin: use the paired libgc.dylib for macOS amd64 + tinyc, not libgc.a

### DIFF
--- a/.github/workflows/update_tccbin.yml
+++ b/.github/workflows/update_tccbin.yml
@@ -698,13 +698,18 @@ jobs:
             exit 1
           fi
 
-      # Deliverable A (this PR) does not include the V selector change
-      # (deliverable C, vlib/builtin/builtin_d_gcboehm.c.v) - it merges
-      # separately, only after this pair is published and vlang/tccbin's
-      # gate is confirmed green under it. To actually exercise the
-      # dylib pairing here, apply that selector collapse to an entirely
-      # separate, freshly-cloned vlang/v workspace, in memory only -
-      # never written back to this checkout, never committed anywhere.
+      # Build ./v in an entirely separate, freshly-cloned workspace so the
+      # smoke test below runs a real V against the staged bundle.
+      #
+      # This step used to patch vlib/builtin/builtin_d_gcboehm.c.v in memory
+      # to make macOS amd64 select libgc.dylib, because the selector still
+      # chose the static libgc.a and the smoke test would otherwise not have
+      # exercised the dylib pairing at all. That patch is gone: the selector
+      # itself now links the dylib on both macOS arches, so this clone needs
+      # no modification to test the right thing. (Leaving the patch in place
+      # would in fact have broken this job outright - it asserted its search
+      # text occurred exactly once, and that text no longer exists.)
+      #
       # This clone's own thirdparty/tcc has nothing to do with the
       # bundle staged above (a brand new clone doesn't have one yet),
       # so letting `make`'s default target bootstrap it normally here
@@ -732,30 +737,6 @@ jobs:
           rm -rf /tmp/v-bootstrap-workspace
           git clone --quiet "https://github.com/${{ github.repository }}" /tmp/v-bootstrap-workspace
           git -C /tmp/v-bootstrap-workspace checkout --quiet "${{ github.sha }}"
-
-          python3 - <<'PYEOF'
-          path = "/tmp/v-bootstrap-workspace/vlib/builtin/builtin_d_gcboehm.c.v"
-          with open(path, "r", encoding="utf-8", newline="") as f:
-              content = f.read()
-          old = ('\t\t\t\t\t\t$if arm64 {\n'
-                 '\t\t\t\t\t\t\t// tcc on macOS arm64 can leave the bundled GC archive symbols unresolved.\n'
-                 '\t\t\t\t\t\t\t#flag @VEXEROOT/thirdparty/tcc/lib/libgc.dylib\n'
-                 '\t\t\t\t\t\t\t#flag -Wl,-rpath,"@VEXEROOT/thirdparty/tcc/lib"\n'
-                 '\t\t\t\t\t\t} $else {\n'
-                 '\t\t\t\t\t\t\t// macOS amd64 tccbin only ships libgc.a (no .dylib).\n'
-                 '\t\t\t\t\t\t\t#flag @VEXEROOT/thirdparty/tcc/lib/libgc.a\n'
-                 '\t\t\t\t\t\t}\n')
-          new = ('\t\t\t\t\t\t// SMOKE-TEST-ONLY PATCH (thirdparty-macos-amd64_bdwgc_validate.sh\n'
-                 '\t\t\t\t\t\t// caller) - never committed. Deliverable C applies this for real.\n'
-                 '\t\t\t\t\t\t#flag @VEXEROOT/thirdparty/tcc/lib/libgc.dylib\n'
-                 '\t\t\t\t\t\t#flag -Wl,-rpath,"@VEXEROOT/thirdparty/tcc/lib"\n')
-          count = content.count(old)
-          assert count == 1, f"expected exactly 1 occurrence of the selector block to patch, found {count}"
-          content = content.replace(old, new)
-          with open(path, "w", encoding="utf-8", newline="") as f:
-              f.write(content)
-          print("smoke-test-only selector patch applied in isolated workspace")
-          PYEOF
 
           (cd /tmp/v-bootstrap-workspace && make -j4)
 

--- a/vlib/builtin/builtin_d_gcboehm.c.v
+++ b/vlib/builtin/builtin_d_gcboehm.c.v
@@ -74,14 +74,15 @@ $if dynamic_boehm ? {
 			$if !use_bundled_libgc ? {
 				$if macos {
 					$if tinyc {
-						$if arm64 {
-							// tcc on macOS arm64 can leave the bundled GC archive symbols unresolved.
-							#flag @VEXEROOT/thirdparty/tcc/lib/libgc.dylib
-							#flag -Wl,-rpath,"@VEXEROOT/thirdparty/tcc/lib"
-						} $else {
-							// macOS amd64 tccbin only ships libgc.a (no .dylib).
-							#flag @VEXEROOT/thirdparty/tcc/lib/libgc.a
-						}
+						// tcc cannot reliably link the bundled *static* GC archive on
+						// either macOS arch: its Mach-O archive reader leaves the GC
+						// symbols unresolved against an archive built by a modern
+						// toolchain, even though `nm -g` shows them defined. arm64 has
+						// always used the dynamic library for that reason; amd64 now
+						// does too, because tccbin ships a libgc.dylib rebuilt in
+						// lockstep with each tcc.exe for it as of vlang/v#27982.
+						#flag @VEXEROOT/thirdparty/tcc/lib/libgc.dylib
+						#flag -Wl,-rpath,"@VEXEROOT/thirdparty/tcc/lib"
 					} $else {
 						#flag -L@VEXEROOT/thirdparty/tcc/lib
 						#flag -lgc

--- a/vlib/v/builder/gc_flags_test.v
+++ b/vlib/v/builder/gc_flags_test.v
@@ -29,9 +29,17 @@ fn test_macos_tcc_boehm_uses_bundled_libgc() {
 	defer {
 		os.rm(exe_path) or {}
 	}
-	assert res.exit_code == 0
-	// macOS amd64 tccbin only ships libgc.a (no .dylib).
-	assert res.output.contains('thirdparty/tcc/lib/libgc.a')
+	assert res.exit_code == 0, res.output
+	normalized := res.output.replace('\\', '/')
+	// tcc cannot reliably link the bundled static archive on macOS, so both
+	// arches link the paired libgc.dylib with an rpath instead. tccbin ships
+	// one for amd64 as of vlang/v#27982; arm64 already did.
+	assert normalized.contains('thirdparty/tcc/lib/libgc.dylib'), res.output
+	assert normalized.contains('-rpath'), res.output
+	// The static archive must be gone from the link line entirely - this is
+	// what actually proves the selector collapsed, rather than the dylib
+	// merely being present alongside it.
+	assert !normalized.contains('thirdparty/tcc/lib/libgc.a'), res.output
 	assert !res.output.contains(' -lgc')
 }
 


### PR DESCRIPTION
## Summary

Deliverable **C** of the macOS-amd64 libgc pairing plan, and the last piece of it.

`tcc` cannot reliably link the bundled **static** GC archive on macOS: its Mach-O archive reader leaves the GC symbols unresolved against an archive produced by a modern toolchain, even though `nm -g` shows them defined. arm64 has linked the dynamic library with an rpath for exactly that reason since [vlang/tccbin#70](https://github.com/vlang/tccbin/pull/70). amd64 kept selecting `libgc.a` only because tccbin shipped no `.dylib` for it - which is what #27982 fixed, rebuilding `libgc.dylib` in lockstep with every `tcc.exe` rebuild.

```diff
-						$if arm64 {
-							#flag @VEXEROOT/thirdparty/tcc/lib/libgc.dylib
-							#flag -Wl,-rpath,"@VEXEROOT/thirdparty/tcc/lib"
-						} $else {
-							// macOS amd64 tccbin only ships libgc.a (no .dylib).
-							#flag @VEXEROOT/thirdparty/tcc/lib/libgc.a
-						}
+						#flag @VEXEROOT/thirdparty/tcc/lib/libgc.dylib
+						#flag -Wl,-rpath,"@VEXEROOT/thirdparty/tcc/lib"
```

## Why it's safe to land now

This was deliberately held back until the dylib was actually distributed - pointing the selector at a file that isn't in the bundle would break every macOS amd64 `-cc tcc -gc boehm` build. Both preconditions are now met:

- **Published**: `vlang/tccbin` `thirdparty-macos-amd64` is at [`da8ac5a4`](https://github.com/vlang/tccbin/commit/da8ac5a4369accc67c485191d02535d77718a1c8), which ships `lib/libgc.dylib` as a genuine symlink (git mode `120000`) to `libgc.1.dylib`, alongside `libgc.a`.
- **Gate green**: [vlang/tccbin#83](https://github.com/vlang/tccbin/pull/83)'s converted must-pass gate is green on that exact commit ([run 30692570864](https://github.com/vlang/tccbin/actions/runs/30692570864)).

## Two things that would otherwise have broken

Both found by searching for anything depending on the old behaviour, rather than only changing the selector:

**`vlib/v/builder/gc_flags_test.v`** asserted `libgc.a` is on the link line, and its guards (`$if !macos { return }` / `$if arm64 { return }`) mean it runs on *exactly* the platform this changes. It now asserts the dylib and rpath are present **and that no `libgc.a` token remains** - the absence is what actually proves the selector collapsed, rather than the dylib merely appearing alongside it.

**`.github/workflows/update_tccbin.yml`** patched this very selector block in memory, so the macos-amd64 smoke test could exercise the dylib pairing before this change existed. That patch is now both redundant and *fatal*: it asserted its search text occurred exactly once, and that text no longer exists, so the job would fail outright on its next run. Removed. The smoke test's own expectations (`libgc.dylib` present, no `libgc.a` token - already written that way) are unchanged and are now satisfied by the real selector rather than a simulated one, which is strictly better fidelity.

Deliberately left alone after checking: `vlib/v/tests/gnu_make_tcc_fallback_test.v`'s `libgc.a` assertion is inside a `$if !linux { return }` test; `vlib/v/ast/cflags_test.v` uses the path only as a flag-parsing string fixture; the FreeBSD/OpenBSD/Windows/Linux `libgc.a` selections are untouched.

## What CI here can and cannot prove

Worth stating plainly so a green tick isn't over-read: **vlang/v CI has no macOS amd64 job that runs the self-test suite.** `macos_ci.yml` (which runs `self_tests`) is `macos-14` only, i.e. arm64; `macos-15-intel` appears solely in `release_ci.yml`, `vup_works.yml` and `update_tccbin.yml`. Since `test_macos_tcc_boehm_uses_bundled_libgc()` returns early under `$if arm64`, the test updated here will **skip in every CI job** - it is a guard for developers on Intel Macs, not a gate that runs on this PR.

So CI here proves no regression elsewhere (arm64 macOS, formatting, the YAML lint, every other platform), but it does not exercise the changed path.

What does exercise it is #27982's smoke test on a real `macos-15-intel` runner: real V, real `tcc.exe`, real `libgc.dylib`, asserting the staged compiler was the one invoked, exactly one `libgc.dylib` token, exactly one matching `-rpath`, and no `libgc.a` token anywhere on the link line. That test ran against a selector patched in memory to do precisely what this PR now does for real - so the link path in this PR is already validated end-to-end; this PR is what makes it the committed default.

## Test plan

- [x] `v fmt -verify` clean on both changed `.v` files.
- [x] `v vet` clean on both changed `.v` files.
- [x] `update_tccbin.yml` parses, and passes the repo's Prettier lint (`npx prettier@3.9.6 --check **.yml` from the repo root - the same invocation `workflow_lint.yml` runs).
- [x] Swept the tree for other assertions/docs depending on macOS amd64 selecting `libgc.a`; the two that did are updated above, the rest verified out of scope.
- [ ] `gc_flags_test.v` on a macOS amd64 runner - this is the direct end-to-end check, and it now requires the published bundle, which is exactly the precondition verified above.

The dylib link path itself was already validated end-to-end on `macos-15-intel` during #27982: real V + real `tcc.exe` + real `libgc.dylib`, asserting the staged compiler ran, `-rpath` was present, and `libgc.a` never appeared on the link line.

