### PR TITLE
fix(parser): avoid panic after asm lock prefix

### DIFF
--- a/vlib/v/parser/asm.v
+++ b/vlib/v/parser/asm.v
@@ -90,7 +90,8 @@ fn (mut p Parser) asm_stmt(is_top_level bool) ast.AsmStmt {
 			if p.tok.kind == .key_lock && arch in [.i386, .amd64] {
 				p.next()
 
-				has_suffix := p.tok.lit[p.tok.lit.len - 1] in [`b`, `w`, `l`, `q`]
+				has_suffix := p.tok.lit.len > 0
+					&& p.tok.lit[p.tok.lit.len - 1] in [`b`, `w`, `l`, `q`]
 				if !(p.tok.lit in allowed_lock_prefix_ins
 					|| (has_suffix && p.tok.lit[0..p.tok.lit.len - 1] in allowed_lock_prefix_ins)) {
 					p.error('The lock prefix cannot be used on this instruction')

--- a/vlib/v/parser/tests/asm_lock_missing_instruction.out
+++ b/vlib/v/parser/tests/asm_lock_missing_instruction.out
@@ -1,0 +1,3 @@
+vlib/v/parser/tests/asm_lock_missing_instruction.vv:4:1: error: The lock prefix cannot be used on this instruction
+    2 |     asm amd64 {
+    3 |         lock

--- a/vlib/v/parser/tests/asm_lock_missing_instruction.vv
+++ b/vlib/v/parser/tests/asm_lock_missing_instruction.vv
@@ -1,0 +1,3 @@
+fn main() {
+	asm amd64 {
+		lock


### PR DESCRIPTION
## Summary

- prevent the parser from indexing an empty token after an x86 `lock` prefix
- add a parser-error regression fixture for a truncated inline-assembly block

## Root cause

After parsing `lock`, the parser advances to EOF for truncated input and indexed the empty token literal to check an instruction suffix. This crashed the compiler instead of reporting a syntax error.

## Validation

- `./vnew -silent vlib/v/compiler_errors_test.v`
- `./vnew -silent test vlib/v/parser/`
- `./vnew -silent test vlib/encoding/base58/`
- `./vnew -silent test vlib/encoding/binary/`
