### PR TITLE
builder: use paired libgc.dylib safely with macOS TinyCC

### DIFF
--- a/.github/workflows/update_tccbin.yml
+++ b/.github/workflows/update_tccbin.yml
@@ -698,13 +698,6 @@ jobs:
             exit 1
           fi
 
-      # Deliverable A (this PR) does not include the V selector change
-      # (deliverable C, vlib/builtin/builtin_d_gcboehm.c.v) - it merges
-      # separately, only after this pair is published and vlang/tccbin's
-      # gate is confirmed green under it. To actually exercise the
-      # dylib pairing here, apply that selector collapse to an entirely
-      # separate, freshly-cloned vlang/v workspace, in memory only -
-      # never written back to this checkout, never committed anywhere.
       # This clone's own thirdparty/tcc has nothing to do with the
       # bundle staged above (a brand new clone doesn't have one yet),
       # so letting `make`'s default target bootstrap it normally here
@@ -732,30 +725,6 @@ jobs:
           rm -rf /tmp/v-bootstrap-workspace
           git clone --quiet "https://github.com/${{ github.repository }}" /tmp/v-bootstrap-workspace
           git -C /tmp/v-bootstrap-workspace checkout --quiet "${{ github.sha }}"
-
-          python3 - <<'PYEOF'
-          path = "/tmp/v-bootstrap-workspace/vlib/builtin/builtin_d_gcboehm.c.v"
-          with open(path, "r", encoding="utf-8", newline="") as f:
-              content = f.read()
-          old = ('\t\t\t\t\t\t$if arm64 {\n'
-                 '\t\t\t\t\t\t\t// tcc on macOS arm64 can leave the bundled GC archive symbols unresolved.\n'
-                 '\t\t\t\t\t\t\t#flag @VEXEROOT/thirdparty/tcc/lib/libgc.dylib\n'
-                 '\t\t\t\t\t\t\t#flag -Wl,-rpath,"@VEXEROOT/thirdparty/tcc/lib"\n'
-                 '\t\t\t\t\t\t} $else {\n'
-                 '\t\t\t\t\t\t\t// macOS amd64 tccbin only ships libgc.a (no .dylib).\n'
-                 '\t\t\t\t\t\t\t#flag @VEXEROOT/thirdparty/tcc/lib/libgc.a\n'
-                 '\t\t\t\t\t\t}\n')
-          new = ('\t\t\t\t\t\t// SMOKE-TEST-ONLY PATCH (thirdparty-macos-amd64_bdwgc_validate.sh\n'
-                 '\t\t\t\t\t\t// caller) - never committed. Deliverable C applies this for real.\n'
-                 '\t\t\t\t\t\t#flag @VEXEROOT/thirdparty/tcc/lib/libgc.dylib\n'
-                 '\t\t\t\t\t\t#flag -Wl,-rpath,"@VEXEROOT/thirdparty/tcc/lib"\n')
-          count = content.count(old)
-          assert count == 1, f"expected exactly 1 occurrence of the selector block to patch, found {count}"
-          content = content.replace(old, new)
-          with open(path, "w", encoding="utf-8", newline="") as f:
-              f.write(content)
-          print("smoke-test-only selector patch applied in isolated workspace")
-          PYEOF
 
           (cd /tmp/v-bootstrap-workspace && make -j4)
 

--- a/README.md
+++ b/README.md
@@ -204,6 +204,13 @@ when no compatible bundled `thirdparty/tcc` binary is available on the host.
 The [Tiny C Compiler (tcc)](https://repo.or.cz/w/tinycc.git) is downloaded for you by `make` if
 there is a compatible version for your system, and installed under the V `thirdparty` directory.
 
+On macOS, `-cc tcc -gc boehm` uses a persistent bundled `libgc.dylib` store when the physical V
+installation path contains a comma. The store is under `$XDG_DATA_HOME/v-tcc-libgc-v1`, or
+`$HOME/.local/share/v-tcc-libgc-v1` when the XDG variable is unset or empty. V creates the fallback
+directories with private permissions. An explicit `XDG_DATA_HOME` must already be absolute,
+user-owned, not group/world-writable, and have a safe, comma-free canonical path. Compiled binaries
+can depend on this store at runtime, so do not delete it while they are in use.
+
 This compiler is very fast, but does almost no optimizations. It is best for development builds.
 
 For production builds (using the `-prod` option to V), it's recommended to use clang, gcc, or

--- a/vlib/builtin/builtin_d_gcboehm.c.v
+++ b/vlib/builtin/builtin_d_gcboehm.c.v
@@ -74,12 +74,12 @@ $if dynamic_boehm ? {
 			$if !use_bundled_libgc ? {
 				$if macos {
 					$if tinyc {
-						$if arm64 {
-							// tcc on macOS arm64 can leave the bundled GC archive symbols unresolved.
+						$if arm64 || amd64 {
+							// tcc can leave bundled static GC archive symbols unresolved on macOS 64-bit.
 							#flag @VEXEROOT/thirdparty/tcc/lib/libgc.dylib
 							#flag -Wl,-rpath,"@VEXEROOT/thirdparty/tcc/lib"
 						} $else {
-							// macOS amd64 tccbin only ships libgc.a (no .dylib).
+							// Retain the bundled static archive fallback on other architectures.
 							#flag @VEXEROOT/thirdparty/tcc/lib/libgc.a
 						}
 					} $else {

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -2638,24 +2638,10 @@ fn sqlite_thirdparty_validation_error(mod string, obj_path string, source_file s
 	return ''
 }
 
-// fixup_tcc_macos_comma_path_flags works around the fact that both tcc and
-// clang split `-Wl,foo,bar` on every comma without an escape mechanism. When
-// V's install path contains a literal comma (used in CI to stress
-// space-paths), the `-Wl,-rpath,"@VEXEROOT/thirdparty/tcc/lib"` flag emitted
-// by builtin_d_gcboehm.c.v under `$if tinyc` expands into a path with a comma
-// and the linker rejects it. The bundled libgc.dylib also gets passed by
-// absolute path; that itself is fine, but the dylib's `LC_ID_DYLIB` is
-// `@rpath/libgc.dylib`, so the linked binary cannot find the library at
-// runtime once we strip the rpath flag.
-//
-// This helper copies the bundled dylib into a non-comma cache directory,
-// updates the copy's install_name to its own absolute path (so the linked
-// binary records that path in `LC_LOAD_DYLIB`), then rewrites the dylib flag
-// in the linker arguments to point at the copy and drops the now-broken rpath
-// flag. The bundled libgc.dylib itself is left untouched, so binaries built
-// before/elsewhere that rely on `@rpath/libgc.dylib` still work. The fixup is
-// applied for any cc, since V may fall back from tcc to clang and reuse the
-// already-emitted flags.
+// fixup_tcc_macos_comma_path_flags moves the exact bundled libgc dylib/rpath
+// pair to a persistent comma-free content store when V's root contains a comma.
+// It is token-driven because a fallback compiler can reuse the already emitted
+// flags. The store keeps the dylib bytes and its @rpath install name unchanged.
 fn (v &Builder) fixup_tcc_macos_comma_path_flags(mut ccoptions CcompilerOptions) {
 	$if !macos {
 		return
@@ -2663,44 +2649,16 @@ fn (v &Builder) fixup_tcc_macos_comma_path_flags(mut ccoptions CcompilerOptions)
 	if v.pref.os != .macos {
 		return
 	}
-	tcc_lib_dir := os.real_path(os.join_path(v.pref.vroot, 'thirdparty', 'tcc', 'lib'))
-	if !tcc_lib_dir.contains(',') {
+	plan := plan_tcc_macos_libgc_store(v.pref.vroot, ccoptions.linker_flags, ccoptions.pre_args) or {
+		verror(err.msg())
+	}
+	if !plan.required {
 		return
 	}
-	src_dylib := os.join_path(tcc_lib_dir, 'libgc.dylib')
-	if !os.exists(src_dylib) {
-		return
-	}
-	cache_dir := os.join_path(os.temp_dir(), 'v_tcc_libgc')
-	if cache_dir.contains(',') {
-		return
-	}
-	if !os.exists(cache_dir) {
-		os.mkdir_all(cache_dir) or { return }
-	}
-	cache_dylib := os.join_path(cache_dir, 'libgc.dylib')
-	src_mtime := os.file_last_mod_unix(src_dylib)
-	if !os.exists(cache_dylib) || os.file_last_mod_unix(cache_dylib) < src_mtime {
-		os.cp(src_dylib, cache_dylib) or { return }
-		idres :=
-			os.execute('install_name_tool -id ${os.quoted_path(cache_dylib)} ${os.quoted_path(cache_dylib)}')
-		if idres.exit_code != 0 {
-			if v.pref.is_verbose {
-				eprintln('install_name_tool -id for ${cache_dylib} failed: ${idres.output.trim_space()}')
-			}
-			return
-		}
-	}
-	cache_dylib_quoted := '"${cache_dylib}"'
-	suffix := os.path_separator + 'tcc' + os.path_separator + 'lib' + os.path_separator +
-		'libgc.dylib'
-	ccoptions.linker_flags = ccoptions.linker_flags.map(if it.ends_with(suffix + '"')
-		&& it.starts_with('"') {
-		cache_dylib_quoted
-	} else {
-		it
-	})
-	ccoptions.pre_args = ccoptions.pre_args.filter(!it.starts_with('-Wl,-rpath,'))
+	linker_flags, pre_args := materialize_and_rewrite_tcc_macos_libgc_flags(plan,
+		ccoptions.linker_flags, ccoptions.pre_args) or { verror(err.msg()) }
+	ccoptions.linker_flags = linker_flags
+	ccoptions.pre_args = pre_args
 }
 
 fn (v &Builder) should_compile_bundled_thirdparty_object_from_source(obj_path string, source_file string, source_kind SourceKind) bool {

--- a/vlib/v/builder/gc_flags_test.v
+++ b/vlib/v/builder/gc_flags_test.v
@@ -14,25 +14,208 @@ fn execute_without_vflags(cmd string) os.Result {
 	return res
 }
 
-fn test_macos_tcc_boehm_uses_bundled_libgc() {
+const showcc_prefix = '> C compiler cmd: '
+
+struct ShowccExpectation {
+	tcc    string
+	dylib  string
+	rpath  string
+	binary string
+}
+
+fn tokenize_showcc_command(command string) ![]string {
+	mut tokens := []string{}
+	mut token := []u8{}
+	mut quote := u8(0)
+	mut started := false
+	mut i := 0
+	for i < command.len {
+		ch := command[i]
+		if quote == 0 && ch in [` `, `\t`, `\r`, `\n`] {
+			if started {
+				tokens << token.bytestr()
+				token = []u8{}
+				started = false
+			}
+			i++
+			continue
+		}
+		if ch in [`'`, `"`] {
+			if quote == 0 {
+				quote = ch
+				started = true
+				i++
+				continue
+			}
+			if quote == ch {
+				quote = 0
+				i++
+				continue
+			}
+		}
+		if ch == `\\` && quote != `'` && i + 1 < command.len {
+			next := command[i + 1]
+			escapable := if quote == `"` {
+				next in [`"`, `\\`]
+			} else {
+				next in [` `, `\t`, `\r`, `\n`, `'`, `"`, `\\`]
+			}
+			if escapable {
+				token << next
+				started = true
+				i += 2
+				continue
+			}
+		}
+		token << ch
+		started = true
+		i++
+	}
+	if quote != 0 {
+		return error('unterminated quote in -showcc command')
+	}
+	if started {
+		tokens << token.bytestr()
+	}
+	return tokens
+}
+
+fn count_showcc_token(tokens []string, expected string) int {
+	mut count := 0
+	for token in tokens {
+		if token == expected {
+			count++
+		}
+	}
+	return count
+}
+
+fn validate_showcc_output(output string, expected ShowccExpectation) ![]string {
+	lines := output.split_into_lines().filter(it.starts_with(showcc_prefix))
+	if lines.len != 1 {
+		return error('expected exactly one -showcc compiler command, found ${lines.len}')
+	}
+	tokens := tokenize_showcc_command(lines[0][showcc_prefix.len..])!
+	if tokens.len == 0 || tokens[0] != expected.tcc || count_showcc_token(tokens, expected.tcc) != 1 {
+		return error('expected exactly one physical TCC token in compiler position')
+	}
+	if count_showcc_token(tokens, expected.dylib) != 1
+		|| count_showcc_token(tokens, expected.rpath) != 1 {
+		return error('expected exactly one physical dylib/rpath token pair')
+	}
+	if count_showcc_token(tokens, '-o') != 1 {
+		return error('expected exactly one -o token')
+	}
+	output_index := tokens.index('-o')
+	if output_index < 0 || output_index + 1 >= tokens.len
+		|| tokens[output_index + 1] != expected.binary {
+		return error('the compiler command does not target the expected binary')
+	}
+	compiler_names := ['cc', 'gcc', 'clang', 'clang++', 'tcc', 'tcc.exe']
+	for i, token in tokens {
+		if token.starts_with('@') {
+			return error('response-file tokens are forbidden')
+		}
+		if token.contains('libgc.a') || token == '-lgc' {
+			return error('static or implicit libgc linkage is forbidden')
+		}
+		if token != '-o' && token.starts_with('-o') {
+			return error('joined output options are forbidden')
+		}
+		if token != expected.tcc
+			&& (token.starts_with(expected.tcc) || (i > 0 && os.file_name(token) in compiler_names)) {
+			return error('fallback, duplicate, or near-match compiler token')
+		}
+		if token != expected.dylib && token.contains('libgc.dylib') {
+			return error('near-match or duplicate dylib token')
+		}
+		if token != expected.rpath && token.starts_with('-Wl,-rpath,') {
+			return error('near-match or duplicate rpath token')
+		}
+	}
+	lower_output := output.to_lower()
+	for marker in ['falling back', 'retrying with', 'fallback compiler', 'backup compiler'] {
+		if lower_output.contains(marker) {
+			return error('compiler fallback marker found in output')
+		}
+	}
+	return tokens
+}
+
+fn showcc_fixture(tokens []string) string {
+	return showcc_prefix + tokens.map(os.quoted_path(it)).join(' ')
+}
+
+fn showcc_tokens_with_extra(tokens []string, index int, extra string) []string {
+	mut result := tokens.clone()
+	result.insert(index, extra)
+	return result
+}
+
+fn assert_showcc_rejected(output string, expected ShowccExpectation) {
+	validate_showcc_output(output, expected) or { return }
+	assert false, 'invalid -showcc fixture was accepted: ${output}'
+}
+
+fn test_macos_tcc_boehm_showcc_parser_fixtures() {
+	expected := ShowccExpectation{
+		tcc:    '/physical/tcc/tcc.exe'
+		dylib:  '/physical/tcc/lib/libgc.dylib'
+		rpath:  '-Wl,-rpath,/physical/tcc/lib'
+		binary: '/tmp/output'
+	}
+	good := [expected.tcc, expected.rpath, expected.dylib, '-o', expected.binary, '/tmp/input.c']
+	validate_showcc_output(showcc_fixture(good), expected) or { assert false, err.msg() }
+	assert_showcc_rejected(showcc_fixture(showcc_tokens_with_extra(good, 1, expected.tcc)),
+		expected)
+	assert_showcc_rejected(showcc_fixture(showcc_tokens_with_extra(good, 1, expected.tcc + '.bad')),
+		expected)
+	assert_showcc_rejected(showcc_fixture(showcc_tokens_with_extra(good, 3, expected.dylib + '.bad')),
+		expected)
+	assert_showcc_rejected(showcc_fixture(showcc_tokens_with_extra(good, 3, expected.dylib)),
+		expected)
+	assert_showcc_rejected(showcc_fixture(showcc_tokens_with_extra(good, 2, expected.rpath + '.bad')),
+		expected)
+	assert_showcc_rejected(showcc_fixture(showcc_tokens_with_extra(good, 2, expected.rpath)),
+		expected)
+	assert_showcc_rejected(showcc_fixture(showcc_tokens_with_extra(good, 3, '@/tmp/evil.rsp')),
+		expected)
+	assert_showcc_rejected(showcc_fixture(showcc_tokens_with_extra(good, 3,
+		'/physical/tcc/lib/libgc.a')), expected)
+	assert_showcc_rejected(showcc_fixture(showcc_tokens_with_extra(good, 3, '-lgc')), expected)
+	assert_showcc_rejected(showcc_fixture(showcc_tokens_with_extra(good, good.len, '/usr/bin/clang')),
+		expected)
+	assert_showcc_rejected(showcc_fixture(good) + '\nfalling back to clang', expected)
+}
+
+fn test_macos_amd64_tcc_boehm_uses_bundled_libgc_dylib() {
 	$if !macos {
 		return
 	}
-	$if arm64 {
-		// TCC on macOS arm64 cannot link the i386/asm path that this test exercises.
+	$if !amd64 {
 		return
 	}
-	exe_path := os.join_path(os.vtmp_dir(), 'builder_gc_flags_test')
+	test_root := os.join_path(os.vtmp_dir(), 'builder_gc_flags_test_${os.getpid()}')
+	os.mkdir_all(test_root) or { panic(err) }
+	physical_test_root := os.real_path(test_root)
+	exe_path := os.join_path(physical_test_root, 'hello_world')
 	source_path := os.join_path(@VEXEROOT, 'examples', 'hello_world.v')
-	cmd := '${os.quoted_path(@VEXE)} -showcc -cc tcc -no-retry-compilation -o ${os.quoted_path(exe_path)} ${os.quoted_path(source_path)}'
+	tcc_root := os.real_path(os.join_path(@VEXEROOT, 'thirdparty', 'tcc'))
+	expected := ShowccExpectation{
+		tcc:    os.join_path(tcc_root, 'tcc.exe')
+		dylib:  os.join_path(tcc_root, 'lib', 'libgc.dylib')
+		rpath:  '-Wl,-rpath,${os.join_path(tcc_root, 'lib')}'
+		binary: exe_path
+	}
+	cmd := '${os.quoted_path(@VEXE)} -cc tcc -gc boehm -showcc -no-retry-compilation -no-rsp -nocache -o ${os.quoted_path(exe_path)} ${os.quoted_path(source_path)}'
 	res := execute_without_vflags(cmd)
 	defer {
-		os.rm(exe_path) or {}
+		os.rmdir_all(test_root) or {}
 	}
-	assert res.exit_code == 0
-	// macOS amd64 tccbin only ships libgc.a (no .dylib).
-	assert res.output.contains('thirdparty/tcc/lib/libgc.a')
-	assert !res.output.contains(' -lgc')
+	assert res.exit_code == 0, res.output
+	validate_showcc_output(res.output, expected) or { assert false, '${err.msg()}\n${res.output}' }
+	run_res := os.execute(os.quoted_path(exe_path))
+	assert run_res.exit_code == 0, run_res.output
 }
 
 fn test_linux_musl_tcc_boehm_uses_system_libgc() {

--- a/vlib/v/builder/tcc_macos_libgc_store.v
+++ b/vlib/v/builder/tcc_macos_libgc_store.v
@@ -1,0 +1,633 @@
+module builder
+
+import crypto.sha256
+import os
+import sync
+
+const tcc_macos_libgc_store_name = 'v-tcc-libgc-v1'
+const tcc_macos_libgc_name = 'libgc.dylib'
+const tcc_macos_libgc_max_size = u64(64 * 1024 * 1024)
+const tcc_macos_libgc_hash_buffer_size = 256 * 1024
+const tcc_macos_libgc_temp_attempts = 32
+const tcc_macos_libgc_data_root_remediation = 'set XDG_DATA_HOME to an absolute, existing, private directory without a comma'
+
+enum TccMacosLibgcArgList {
+	linker_flags
+	pre_args
+}
+
+struct TccMacosLibgcTokenLocation {
+	arg_list TccMacosLibgcArgList
+	index    int = -1
+}
+
+struct TccMacosLibgcPlan {
+	required           bool
+	source_dylib       string
+	source_dylib_token string
+	source_rpath_token string
+	dylib_location     TccMacosLibgcTokenLocation
+	rpath_location     TccMacosLibgcTokenLocation
+}
+
+struct TccMacosLibgcFileHash {
+	sum  string
+	size u64
+}
+
+struct TccMacosLibgcTemporaryObject {
+	directory string
+	path      string
+}
+
+struct TccMacosLibgcPublicationResult {
+	final_dylib string
+	won         bool
+}
+
+fn plan_tcc_macos_libgc_store(vroot string, linker_flags []string, pre_args []string) !TccMacosLibgcPlan {
+	physical_vroot := os.real_path(vroot)
+	if !physical_vroot.contains(',') {
+		return TccMacosLibgcPlan{}
+	}
+	lib_dir := os.join_path(vroot, 'thirdparty', 'tcc', 'lib')
+	source_dylib := os.join_path(lib_dir, tcc_macos_libgc_name)
+	dylib_token := '"${source_dylib}"'
+	rpath_token := '-Wl,-rpath,"${lib_dir}"'
+	mut dylib_locations := []TccMacosLibgcTokenLocation{}
+	mut rpath_locations := []TccMacosLibgcTokenLocation{}
+	mut near_dylibs := 0
+	mut near_rpaths := 0
+	for i, token in linker_flags {
+		if token == dylib_token {
+			dylib_locations << TccMacosLibgcTokenLocation{
+				arg_list: .linker_flags
+				index:    i
+			}
+		} else if token == rpath_token {
+			rpath_locations << TccMacosLibgcTokenLocation{
+				arg_list: .linker_flags
+				index:    i
+			}
+		} else if is_tcc_macos_libgc_dylib_near_match(token, source_dylib) {
+			near_dylibs++
+		} else if is_tcc_macos_libgc_rpath_near_match(token, lib_dir) {
+			near_rpaths++
+		}
+	}
+	for i, token in pre_args {
+		if token == dylib_token {
+			dylib_locations << TccMacosLibgcTokenLocation{
+				arg_list: .pre_args
+				index:    i
+			}
+		} else if token == rpath_token {
+			rpath_locations << TccMacosLibgcTokenLocation{
+				arg_list: .pre_args
+				index:    i
+			}
+		} else if is_tcc_macos_libgc_dylib_near_match(token, source_dylib) {
+			near_dylibs++
+		} else if is_tcc_macos_libgc_rpath_near_match(token, lib_dir) {
+			near_rpaths++
+		}
+	}
+	if near_dylibs > 0 || near_rpaths > 0 {
+		return error('ambiguous macOS bundled libgc flags: found ${near_dylibs} dylib and ${near_rpaths} rpath near-match(es)')
+	}
+	if dylib_locations.len == 0 && rpath_locations.len == 0 {
+		return TccMacosLibgcPlan{}
+	}
+	if dylib_locations.len != 1 || rpath_locations.len != 1 {
+		return error('ambiguous macOS bundled libgc flags: expected one exact dylib/rpath pair, found ${dylib_locations.len}/${rpath_locations.len}')
+	}
+	return TccMacosLibgcPlan{
+		required:           true
+		source_dylib:       source_dylib
+		source_dylib_token: dylib_token
+		source_rpath_token: rpath_token
+		dylib_location:     dylib_locations[0]
+		rpath_location:     rpath_locations[0]
+	}
+}
+
+fn is_tcc_macos_libgc_dylib_near_match(token string, source_dylib string) bool {
+	normalized := token.trim_space().trim('"').trim("'").replace('\\', '/')
+	normalized_source := source_dylib.replace('\\', '/')
+	return normalized.contains(normalized_source)
+		|| normalized.contains('/thirdparty/tcc/lib/${tcc_macos_libgc_name}')
+}
+
+fn is_tcc_macos_libgc_rpath_near_match(token string, source_lib_dir string) bool {
+	trimmed_token := token.trim_space().trim('"')
+	mut rpath_value := ''
+	for prefix in ['-Wl,-rpath,', '-Wl,--rpath,', '-Wl,-rpath=', '-Wl,--rpath='] {
+		if trimmed_token.starts_with(prefix) {
+			rpath_value = trimmed_token[prefix.len..]
+			break
+		}
+	}
+	if rpath_value == '' {
+		return false
+	}
+	normalized := rpath_value.trim_space().trim('"').trim("'").replace('\\', '/')
+	normalized_source := source_lib_dir.replace('\\', '/')
+	bundled_lib_suffix := '/thirdparty/tcc/lib'
+	return normalized.contains(normalized_source) || normalized.ends_with(bundled_lib_suffix)
+		|| normalized.contains(bundled_lib_suffix + '/')
+}
+
+fn rewrite_tcc_macos_libgc_flags(plan TccMacosLibgcPlan, linker_flags []string, pre_args []string, stored_dylib string) !([]string, []string) {
+	if !plan.required {
+		return linker_flags.clone(), pre_args.clone()
+	}
+	if !tcc_macos_libgc_location_is_valid(plan.dylib_location, linker_flags, pre_args)
+		|| !tcc_macos_libgc_location_is_valid(plan.rpath_location, linker_flags, pre_args) {
+		return error('macOS bundled libgc rewrite plan contains an invalid token index')
+	}
+	if tcc_macos_libgc_token_at(plan.dylib_location, linker_flags, pre_args) != plan.source_dylib_token
+		|| tcc_macos_libgc_token_at(plan.rpath_location, linker_flags, pre_args) != plan.source_rpath_token {
+		return error('macOS bundled libgc flags changed after planning')
+	}
+	if !os.is_abs_path(stored_dylib) || os.file_name(stored_dylib) != tcc_macos_libgc_name {
+		return error('macOS bundled libgc store returned an invalid dylib path')
+	}
+	stored_dir := os.dir(stored_dylib)
+	if !tcc_macos_libgc_flag_path_is_safe(stored_dir) {
+		return error('macOS bundled libgc store path cannot be represented safely in a linker rpath')
+	}
+	mut rewritten_linker_flags := linker_flags.clone()
+	mut rewritten_pre_args := pre_args.clone()
+	match plan.dylib_location.arg_list {
+		.linker_flags { rewritten_linker_flags[plan.dylib_location.index] = '"${stored_dylib}"' }
+		.pre_args { rewritten_pre_args[plan.dylib_location.index] = '"${stored_dylib}"' }
+	}
+	match plan.rpath_location.arg_list {
+		.linker_flags {
+			rewritten_linker_flags[plan.rpath_location.index] = '-Wl,-rpath,"${stored_dir}"'
+		}
+		.pre_args {
+			rewritten_pre_args[plan.rpath_location.index] = '-Wl,-rpath,"${stored_dir}"'
+		}
+	}
+	return rewritten_linker_flags, rewritten_pre_args
+}
+
+fn tcc_macos_libgc_location_is_valid(location TccMacosLibgcTokenLocation, linker_flags []string, pre_args []string) bool {
+	if location.index < 0 {
+		return false
+	}
+	return match location.arg_list {
+		.linker_flags { location.index < linker_flags.len }
+		.pre_args { location.index < pre_args.len }
+	}
+}
+
+fn tcc_macos_libgc_token_at(location TccMacosLibgcTokenLocation, linker_flags []string, pre_args []string) string {
+	return match location.arg_list {
+		.linker_flags { linker_flags[location.index] }
+		.pre_args { pre_args[location.index] }
+	}
+}
+
+fn materialize_tcc_macos_libgc(source_dylib string) !string {
+	data_base := resolve_tcc_macos_libgc_data_base(os.getenv('XDG_DATA_HOME'), os.getenv('HOME'))!
+	return materialize_tcc_macos_libgc_at(source_dylib, data_base)
+}
+
+fn materialize_and_rewrite_tcc_macos_libgc_flags(plan TccMacosLibgcPlan, linker_flags []string, pre_args []string) !([]string, []string) {
+	stored_dylib := materialize_tcc_macos_libgc(plan.source_dylib)!
+	return rewrite_tcc_macos_libgc_flags(plan, linker_flags, pre_args, stored_dylib)
+}
+
+fn materialize_and_rewrite_tcc_macos_libgc_flags_at(plan TccMacosLibgcPlan, linker_flags []string, pre_args []string, data_base string) !([]string, []string) {
+	stored_dylib := materialize_tcc_macos_libgc_at(plan.source_dylib, data_base)!
+	return rewrite_tcc_macos_libgc_flags(plan, linker_flags, pre_args, stored_dylib)
+}
+
+fn materialize_tcc_macos_libgc_at(source_dylib string, requested_data_base string) !string {
+	resolved_source := resolve_tcc_macos_libgc_source(source_dylib)!
+	source_hash := hash_tcc_macos_libgc_regular_file(resolved_source)!
+	data_base := resolve_tcc_macos_libgc_data_base(requested_data_base, '')!
+	store_root := os.join_path(data_base, tcc_macos_libgc_store_name)
+	ensure_tcc_macos_libgc_private_directory(store_root)!
+	content_dir := os.join_path(store_root, source_hash.sum)
+	ensure_tcc_macos_libgc_private_directory(content_dir)!
+	final_dylib := os.join_path(content_dir, tcc_macos_libgc_name)
+	_, final_exists := lstat_tcc_macos_libgc_path(final_dylib)!
+	if final_exists {
+		validate_tcc_macos_libgc_store_object(final_dylib, source_hash)!
+		return final_dylib
+	}
+	temporary := copy_tcc_macos_libgc_to_exclusive_temp(resolved_source, content_dir, source_hash)!
+	publication := publish_tcc_macos_libgc_temporary(temporary, final_dylib, source_hash)!
+	return publication.final_dylib
+}
+
+fn resolve_tcc_macos_libgc_data_base(xdg_data_home string, home string) !string {
+	raw_base := if xdg_data_home != '' {
+		xdg_data_home
+	} else {
+		if home == '' {
+			return error(tcc_macos_libgc_data_root_error('XDG_DATA_HOME="" and HOME=""',
+				'no persistent data root is configured'))
+		}
+		os.join_path(home, '.local', 'share')
+	}
+	if !os.is_abs_path(raw_base) {
+		return error(tcc_macos_libgc_data_root_error(raw_base, 'the path is relative'))
+	}
+	_, raw_exists := lstat_tcc_macos_libgc_path(raw_base) or {
+		return error(tcc_macos_libgc_data_root_error(raw_base,
+			'the path cannot be inspected: ${err.msg()}'))
+	}
+	if !raw_exists {
+		return error(tcc_macos_libgc_data_root_error(raw_base, 'the path does not exist'))
+	}
+	canonical_base := os.real_path(raw_base)
+	if !os.is_abs_path(canonical_base) || !tcc_macos_libgc_flag_path_is_safe(canonical_base) {
+		return error(tcc_macos_libgc_data_root_error('${raw_base} (canonical: ${canonical_base})',
+			'the canonical path is not a safe comma-free absolute path'))
+	}
+	canonical_stat, canonical_exists := lstat_tcc_macos_libgc_path(canonical_base) or {
+		return error(tcc_macos_libgc_data_root_error('${raw_base} (canonical: ${canonical_base})',
+			'the canonical path cannot be inspected: ${err.msg()}'))
+	}
+	if !canonical_exists {
+		return error(tcc_macos_libgc_data_root_error(raw_base,
+			'the canonical path cannot be resolved'))
+	}
+	validate_tcc_macos_libgc_data_base_stat(canonical_stat,
+		'${raw_base} (canonical: ${canonical_base})', os.geteuid())!
+	return canonical_base
+}
+
+fn tcc_macos_libgc_data_root_error(rejected string, reason string) string {
+	return 'invalid macOS bundled libgc data root `${rejected}`: ${reason}; remediation: ${tcc_macos_libgc_data_root_remediation}'
+}
+
+fn tcc_macos_libgc_flag_path_is_safe(path string) bool {
+	if path.contains(',') || path.contains('"') || path.contains('\\') || path.contains('`')
+		|| path.contains('$') {
+		return false
+	}
+	for b in path.bytes() {
+		if b < 0x20 || b == 0x7f {
+			return false
+		}
+	}
+	return true
+}
+
+fn validate_tcc_macos_libgc_data_base_stat(stat os.Stat, path string, expected_euid int) ! {
+	if stat.get_filetype() != .directory {
+		return error(tcc_macos_libgc_data_root_error(path, 'the path is not a directory'))
+	}
+	if stat.uid != u32(expected_euid) {
+		return error(tcc_macos_libgc_data_root_error(path,
+			'the directory is not owned by the effective user'))
+	}
+	mode := stat.mode & 0o7777
+	if (mode & 0o700) != 0o700 || (mode & 0o7022) != 0 {
+		return error(tcc_macos_libgc_data_root_error(path,
+			'the directory has unsafe permissions ${mode:o}'))
+	}
+}
+
+fn validate_tcc_macos_libgc_private_directory_stat(stat os.Stat, expected_euid int) ! {
+	if stat.get_filetype() != .directory {
+		return error('macOS bundled libgc store path is not a directory')
+	}
+	if stat.uid != u32(expected_euid) {
+		return error('macOS bundled libgc store directory is not owned by the effective user')
+	}
+	mode := stat.mode & 0o7777
+	if mode != 0o700 {
+		return error('macOS bundled libgc store directory must have mode 0700, got ${mode:o}')
+	}
+}
+
+fn ensure_tcc_macos_libgc_private_directory(path string) ! {
+	stat, exists := lstat_tcc_macos_libgc_path(path)!
+	if exists {
+		validate_tcc_macos_libgc_private_directory_stat(stat, os.geteuid())!
+		return
+	}
+	os.mkdir(path, mode: 0o700) or {
+		concurrent_stat, concurrent_exists := lstat_tcc_macos_libgc_path(path)!
+		if !concurrent_exists {
+			return error('cannot create private macOS bundled libgc store directory ${path}: ${err.msg()}')
+		}
+		validate_tcc_macos_libgc_private_directory_stat(concurrent_stat, os.geteuid())!
+		return
+	}
+	created_stat, created_exists := lstat_tcc_macos_libgc_path(path)!
+	if !created_exists {
+		return error('private macOS bundled libgc store directory disappeared after creation: ${path}')
+	}
+	validate_tcc_macos_libgc_private_directory_stat(created_stat, os.geteuid())!
+}
+
+fn resolve_tcc_macos_libgc_source(source_dylib string) !string {
+	if !os.is_abs_path(source_dylib) {
+		return error('macOS bundled libgc source path must be absolute')
+	}
+	normalized_lib_dir := os.norm_path(os.dir(source_dylib)).replace('\\', '/').trim_right('/')
+	if os.file_name(source_dylib) != tcc_macos_libgc_name
+		|| !normalized_lib_dir.ends_with('/thirdparty/tcc/lib') {
+		return error('macOS bundled libgc source is not the official thirdparty/tcc/lib object')
+	}
+	source_stat, source_exists := lstat_tcc_macos_libgc_path(source_dylib)!
+	if !source_exists {
+		return error('macOS bundled libgc source does not exist: ${source_dylib}')
+	}
+	if source_stat.get_filetype() !in [.regular, .symbolic_link] {
+		return error('macOS bundled libgc source must be a regular file or an internal symlink')
+	}
+	if source_stat.get_filetype() == .symbolic_link {
+		link_target := os.readlink(source_dylib)!
+		if link_target == '' {
+			return error('macOS bundled libgc source symlink has an empty target')
+		}
+	}
+	lexical_lib_dir := os.dir(source_dylib)
+	lexical_vroot := os.dir(os.dir(os.dir(lexical_lib_dir)))
+	canonical_vroot := os.real_path(lexical_vroot)
+	lib_dir := os.real_path(lexical_lib_dir)
+	if !path_is_within_tcc_macos_libgc_dir(lib_dir, canonical_vroot) {
+		return error('macOS bundled libgc source directory resolves outside the canonical VROOT')
+	}
+	resolved_source := os.real_path(source_dylib)
+	if !path_is_within_tcc_macos_libgc_dir(resolved_source, lib_dir) {
+		return error('macOS bundled libgc source symlink resolves outside thirdparty/tcc/lib')
+	}
+	resolved_stat, resolved_exists := lstat_tcc_macos_libgc_path(resolved_source)!
+	if !resolved_exists || resolved_stat.get_filetype() != .regular {
+		return error('macOS bundled libgc source target is not a regular file')
+	}
+	validate_tcc_macos_libgc_bounded_regular_stat(resolved_stat)!
+	return resolved_source
+}
+
+fn path_is_within_tcc_macos_libgc_dir(path string, directory string) bool {
+	if !os.is_abs_path(path) || !os.is_abs_path(directory) {
+		return false
+	}
+	clean_directory := directory.trim_right(os.path_separator)
+	return path.starts_with(clean_directory + os.path_separator)
+}
+
+fn validate_tcc_macos_libgc_bounded_regular_stat(stat os.Stat) ! {
+	if stat.get_filetype() != .regular {
+		return error('macOS bundled libgc object is not a regular file')
+	}
+	if stat.size == 0 || stat.size > tcc_macos_libgc_max_size {
+		return error('macOS bundled libgc object size ${stat.size} is outside the accepted range')
+	}
+}
+
+fn hash_tcc_macos_libgc_regular_file(path string) !TccMacosLibgcFileHash {
+	before, before_exists := lstat_tcc_macos_libgc_path(path)!
+	if !before_exists {
+		return error('macOS bundled libgc object does not exist: ${path}')
+	}
+	validate_tcc_macos_libgc_bounded_regular_stat(before)!
+	mut file := os.open(path)!
+	defer {
+		file.close()
+	}
+	mut digest := sha256.new()
+	mut buffer := []u8{len: tcc_macos_libgc_hash_buffer_size}
+	mut total := u64(0)
+	for {
+		read := file.read(mut buffer) or {
+			if err is os.Eof {
+				break
+			}
+			return error('cannot read macOS bundled libgc object ${path}: ${err.msg()}')
+		}
+		if read <= 0 {
+			break
+		}
+		total += u64(read)
+		if total > tcc_macos_libgc_max_size {
+			return error('macOS bundled libgc object grew beyond the accepted size while hashing')
+		}
+		digest.write(buffer[..read])!
+	}
+	after, after_exists := lstat_tcc_macos_libgc_path(path)!
+	if !after_exists || !same_tcc_macos_libgc_file_snapshot(before, after) || total != before.size {
+		return error('macOS bundled libgc object changed while hashing: ${path}')
+	}
+	return TccMacosLibgcFileHash{
+		sum:  digest.sum([]).hex()
+		size: total
+	}
+}
+
+fn same_tcc_macos_libgc_file_snapshot(first os.Stat, second os.Stat) bool {
+	return first.dev == second.dev && first.inode == second.inode && first.mode == second.mode
+		&& first.uid == second.uid && first.size == second.size && first.mtime == second.mtime
+}
+
+fn validate_tcc_macos_libgc_store_object(path string, expected TccMacosLibgcFileHash) ! {
+	stat, exists := lstat_tcc_macos_libgc_path(path)!
+	if !exists {
+		return error('macOS bundled libgc store object does not exist: ${path}')
+	}
+	validate_tcc_macos_libgc_store_object_stat(stat, os.geteuid())!
+	actual := hash_tcc_macos_libgc_regular_file(path)!
+	if actual.size != expected.size || actual.sum != expected.sum {
+		return error('macOS bundled libgc store object failed its content hash validation')
+	}
+}
+
+fn validate_tcc_macos_libgc_store_object_stat(stat os.Stat, expected_euid int) ! {
+	if stat.get_filetype() != .regular {
+		return error('macOS bundled libgc store object is not a regular file')
+	}
+	if stat.uid != u32(expected_euid) {
+		return error('macOS bundled libgc store object is not owned by the effective user')
+	}
+	mode := stat.mode & 0o7777
+	if mode != 0o700 {
+		return error('macOS bundled libgc store object must have mode 0700, got ${mode:o}')
+	}
+	validate_tcc_macos_libgc_bounded_regular_stat(stat)!
+}
+
+fn tcc_macos_libgc_temp_directory_path(content_dir string, attempt int) string {
+	temp_prefix := '.${tcc_macos_libgc_name}.tmp.${os.getpid()}.${sync.thread_id()}'
+	return os.join_path(content_dir, '${temp_prefix}.${attempt}')
+}
+
+fn create_tcc_macos_libgc_exclusive_temp_directory(content_dir string) !string {
+	for attempt in 0 .. tcc_macos_libgc_temp_attempts {
+		temp_directory := tcc_macos_libgc_temp_directory_path(content_dir, attempt)
+		os.mkdir(temp_directory, mode: 0o700) or {
+			_, collision_exists := lstat_tcc_macos_libgc_path(temp_directory)!
+			if collision_exists {
+				continue
+			}
+			return error('cannot create exclusive macOS bundled libgc temporary directory ${temp_directory}: ${err.msg()}')
+		}
+		created_stat, created_exists := lstat_tcc_macos_libgc_path(temp_directory) or {
+			inspection_error := err.msg()
+			os.rmdir(temp_directory) or {
+				return error('${inspection_error}; cannot clean unvalidated temporary directory ${temp_directory}: ${err.msg()}')
+			}
+			return error(inspection_error)
+		}
+		if !created_exists {
+			return error('exclusive macOS bundled libgc temporary directory disappeared after creation: ${temp_directory}')
+		}
+		validate_tcc_macos_libgc_private_directory_stat(created_stat, os.geteuid()) or {
+			validation_error := err.msg()
+			os.rmdir(temp_directory) or {
+				return error('${validation_error}; cannot clean invalid temporary directory ${temp_directory}: ${err.msg()}')
+			}
+			return error(validation_error)
+		}
+		return temp_directory
+	}
+	return error('cannot create exclusive macOS bundled libgc temporary directory after ${tcc_macos_libgc_temp_attempts} collisions')
+}
+
+fn stream_copy_tcc_macos_libgc(source string, destination string, expected TccMacosLibgcFileHash) ! {
+	if expected.size == 0 || expected.size > tcc_macos_libgc_max_size {
+		return error('macOS bundled libgc copy size ${expected.size} is outside the accepted range')
+	}
+	mut source_file := os.open(source)!
+	defer {
+		source_file.close()
+	}
+	_, destination_exists := lstat_tcc_macos_libgc_path(destination)!
+	if destination_exists {
+		return error('macOS bundled libgc temporary destination already exists: ${destination}')
+	}
+	mut destination_file := os.open_file(destination, 'wb', 0o600)!
+	defer {
+		destination_file.close()
+	}
+	destination_stat, destination_now_exists := lstat_tcc_macos_libgc_path(destination)!
+	if !destination_now_exists || destination_stat.get_filetype() != .regular
+		|| destination_stat.uid != u32(os.geteuid()) {
+		return error('macOS bundled libgc temporary destination is not a regular euid-owned file')
+	}
+	mut buffer := []u8{len: tcc_macos_libgc_hash_buffer_size}
+	mut total := u64(0)
+	for {
+		read := source_file.read(mut buffer) or {
+			if err is os.Eof {
+				break
+			}
+			return error('cannot read macOS bundled libgc source during streaming copy: ${err.msg()}')
+		}
+		if read <= 0 {
+			break
+		}
+		total += u64(read)
+		if total > expected.size || total > tcc_macos_libgc_max_size {
+			return error('macOS bundled libgc source grew beyond the accepted copy size')
+		}
+		mut written := 0
+		for written < read {
+			count := destination_file.write(buffer[written..read]) or {
+				return error('cannot write macOS bundled libgc temporary object: ${err.msg()}')
+			}
+			if count <= 0 {
+				return error('cannot write macOS bundled libgc temporary object: zero-byte write')
+			}
+			written += count
+		}
+	}
+	destination_file.close()
+	source_file.close()
+	if total != expected.size {
+		return error('macOS bundled libgc source changed size during streaming copy: expected ${expected.size}, copied ${total}')
+	}
+}
+
+fn copy_tcc_macos_libgc_to_exclusive_temp(source string, content_dir string, expected TccMacosLibgcFileHash) !TccMacosLibgcTemporaryObject {
+	temp_directory := create_tcc_macos_libgc_exclusive_temp_directory(content_dir)!
+	temporary := TccMacosLibgcTemporaryObject{
+		directory: temp_directory
+		path:      os.join_path(temp_directory, tcc_macos_libgc_name)
+	}
+	stream_copy_tcc_macos_libgc(source, temporary.path, expected) or {
+		return tcc_macos_libgc_temporary_error(temporary,
+			'cannot copy macOS bundled libgc to its exclusive temporary object: ${err.msg()}')
+	}
+	os.chmod(temporary.path, 0o700) or {
+		return tcc_macos_libgc_temporary_error(temporary,
+			'cannot set macOS bundled libgc temporary object mode: ${err.msg()}')
+	}
+	validate_tcc_macos_libgc_store_object(temporary.path, expected) or {
+		return tcc_macos_libgc_temporary_error(temporary,
+			'macOS bundled libgc temporary object failed post-close validation: ${err.msg()}')
+	}
+	return temporary
+}
+
+fn cleanup_tcc_macos_libgc_temporary(temporary TccMacosLibgcTemporaryObject) ! {
+	directory_stat, directory_exists := lstat_tcc_macos_libgc_path(temporary.directory)!
+	if !directory_exists {
+		return error('macOS bundled libgc temporary directory disappeared before cleanup: ${temporary.directory}')
+	}
+	validate_tcc_macos_libgc_private_directory_stat(directory_stat, os.geteuid())!
+	_, file_exists := lstat_tcc_macos_libgc_path(temporary.path)!
+	if file_exists {
+		os.rm(temporary.path) or {
+			return error('cannot remove macOS bundled libgc temporary file ${temporary.path}: ${err.msg()}')
+		}
+	}
+	os.rmdir(temporary.directory) or {
+		return error('cannot remove macOS bundled libgc temporary directory ${temporary.directory}: ${err.msg()}')
+	}
+}
+
+fn tcc_macos_libgc_temporary_error(temporary TccMacosLibgcTemporaryObject, operation_error string) IError {
+	cleanup_tcc_macos_libgc_temporary(temporary) or {
+		return error('${operation_error}; temporary cleanup also failed: ${err.msg()}')
+	}
+	return error(operation_error)
+}
+
+fn publish_tcc_macos_libgc_temporary(temporary TccMacosLibgcTemporaryObject, final_dylib string, expected TccMacosLibgcFileHash) !TccMacosLibgcPublicationResult {
+	validate_tcc_macos_libgc_store_object(temporary.path, expected) or {
+		return tcc_macos_libgc_temporary_error(temporary,
+			'cannot publish invalid macOS bundled libgc temporary object: ${err.msg()}')
+	}
+	mut won := true
+	os.link(temporary.path, final_dylib) or {
+		won = false
+		publication_error := err.msg()
+		validate_tcc_macos_libgc_store_object(final_dylib, expected) or {
+			return tcc_macos_libgc_temporary_error(temporary,
+				'could not publish macOS bundled libgc atomically: ${publication_error}; concurrent object is invalid: ${err.msg()}')
+		}
+	}
+	if won {
+		validate_tcc_macos_libgc_store_object(final_dylib, expected) or {
+			return tcc_macos_libgc_temporary_error(temporary,
+				'published macOS bundled libgc object is invalid: ${err.msg()}')
+		}
+	}
+	cleanup_tcc_macos_libgc_temporary(temporary) or {
+		return error('macOS bundled libgc final object is valid, but temporary cleanup failed: ${err.msg()}')
+	}
+	return TccMacosLibgcPublicationResult{
+		final_dylib: final_dylib
+		won:         won
+	}
+}
+
+fn lstat_tcc_macos_libgc_path(path string) !(os.Stat, bool) {
+	stat := os.lstat(path) or {
+		if err.code() == 2 {
+			return os.Stat{}, false
+		}
+		return error('cannot inspect macOS bundled libgc path ${path}: ${err.msg()}')
+	}
+	return stat, true
+}

--- a/vlib/v/builder/tcc_macos_libgc_store.v
+++ b/vlib/v/builder/tcc_macos_libgc_store.v
@@ -225,15 +225,24 @@ fn materialize_tcc_macos_libgc_at(source_dylib string, requested_data_base strin
 }
 
 fn resolve_tcc_macos_libgc_data_base(xdg_data_home string, home string) !string {
-	raw_base := if xdg_data_home != '' {
-		xdg_data_home
-	} else {
-		if home == '' {
-			return error(tcc_macos_libgc_data_root_error('XDG_DATA_HOME="" and HOME=""',
-				'no persistent data root is configured'))
-		}
-		os.join_path(home, '.local', 'share')
+	if xdg_data_home != '' {
+		return resolve_tcc_macos_libgc_existing_data_base(xdg_data_home)
 	}
+	if home == '' {
+		return error(tcc_macos_libgc_data_root_error('XDG_DATA_HOME="" and HOME=""',
+			'no persistent data root is configured'))
+	}
+	if !os.is_abs_path(home) {
+		return error(tcc_macos_libgc_data_root_error(home, 'the path is relative'))
+	}
+	canonical_home := resolve_tcc_macos_libgc_existing_data_base(home)!
+	local_data := ensure_tcc_macos_libgc_fallback_data_directory(os.join_path(canonical_home,
+		'.local'))!
+	ensure_tcc_macos_libgc_fallback_data_directory(os.join_path(local_data, 'share'))!
+	return resolve_tcc_macos_libgc_existing_data_base(os.join_path(home, '.local', 'share'))
+}
+
+fn resolve_tcc_macos_libgc_existing_data_base(raw_base string) !string {
 	if !os.is_abs_path(raw_base) {
 		return error(tcc_macos_libgc_data_root_error(raw_base, 'the path is relative'))
 	}
@@ -260,6 +269,20 @@ fn resolve_tcc_macos_libgc_data_base(xdg_data_home string, home string) !string 
 	validate_tcc_macos_libgc_data_base_stat(canonical_stat,
 		'${raw_base} (canonical: ${canonical_base})', os.geteuid())!
 	return canonical_base
+}
+
+fn ensure_tcc_macos_libgc_fallback_data_directory(path string) !string {
+	_, exists := lstat_tcc_macos_libgc_path(path)!
+	if !exists {
+		os.mkdir(path, mode: 0o700) or {
+			_, concurrent_exists := lstat_tcc_macos_libgc_path(path)!
+			if !concurrent_exists {
+				return error(tcc_macos_libgc_data_root_error(path,
+					'the default directory cannot be created: ${err.msg()}'))
+			}
+		}
+	}
+	return resolve_tcc_macos_libgc_existing_data_base(path)
 }
 
 fn tcc_macos_libgc_data_root_error(rejected string, reason string) string {

--- a/vlib/v/builder/tcc_macos_libgc_store_test.v
+++ b/vlib/v/builder/tcc_macos_libgc_store_test.v
@@ -83,6 +83,37 @@ fn expect_tcc_macos_libgc_data_base_error(xdg_data_home string, home string, rej
 	assert false, 'expected macOS bundled libgc data root validation to fail'
 }
 
+fn assert_tcc_macos_libgc_private_test_directory(path string) ! {
+	stat := os.lstat(path)!
+	assert stat.get_filetype() == .directory
+	assert stat.uid == u32(os.geteuid())
+	assert stat.mode & 0o7777 == 0o700
+}
+
+fn create_tcc_macos_libgc_test_home(root string, name string) !string {
+	home := os.join_path(root, name)
+	os.mkdir(home, mode: 0o700)!
+	return home
+}
+
+fn expect_tcc_macos_libgc_home_fallback_error(home string, rejected string, expected_reason string, absent_path string) {
+	expect_tcc_macos_libgc_data_base_error('', home, rejected, expected_reason)
+	assert !os.exists(absent_path)
+}
+
+fn restore_tcc_macos_libgc_test_environment(name string, old_value ?string) {
+	if value := old_value {
+		os.setenv(name, value, true)
+	} else {
+		os.unsetenv(name)
+	}
+}
+
+fn resolve_tcc_macos_libgc_home_fallback_concurrently(home string, start chan bool) !string {
+	_ := <-start
+	return resolve_tcc_macos_libgc_data_base('', home)
+}
+
 fn prepare_tcc_macos_libgc_test_content_store(fixture TccMacosLibgcTestFixture) !TccMacosLibgcTestContentStore {
 	resolved_source := resolve_tcc_macos_libgc_source(fixture.libgc.source)!
 	expected := hash_tcc_macos_libgc_regular_file(resolved_source)!
@@ -317,7 +348,7 @@ fn test_tcc_macos_libgc_data_base_resolver_is_fallible_and_absolute() ! {
 		'no persistent data root')
 }
 
-fn test_tcc_macos_libgc_data_base_resolver_uses_home_fallback() ! {
+fn test_tcc_macos_libgc_data_base_resolver_creates_and_materializes_home_fallback() ! {
 	$if windows {
 		return
 	}
@@ -325,10 +356,120 @@ fn test_tcc_macos_libgc_data_base_resolver_uses_home_fallback() ! {
 	defer {
 		os.rmdir_all(fixture.root) or {}
 	}
-	home := os.join_path(fixture.root, 'home')
+	home := create_tcc_macos_libgc_test_home(fixture.root, 'home')!
 	fallback := os.join_path(home, '.local', 'share')
-	os.mkdir_all(fallback, mode: 0o700)!
-	assert resolve_tcc_macos_libgc_data_base('', home)! == os.real_path(fallback)
+	assert !os.exists(os.join_path(home, '.local'))
+	old_xdg_data_home := os.getenv_opt('XDG_DATA_HOME')
+	old_home := os.getenv_opt('HOME')
+	defer {
+		restore_tcc_macos_libgc_test_environment('XDG_DATA_HOME', old_xdg_data_home)
+		restore_tcc_macos_libgc_test_environment('HOME', old_home)
+	}
+	os.setenv('XDG_DATA_HOME', '', true)
+	os.setenv('HOME', home, true)
+	stored := materialize_tcc_macos_libgc(fixture.libgc.source)!
+	resolved := os.real_path(fallback)
+	assert os.dir(os.dir(os.dir(stored))) == resolved
+	assert_tcc_macos_libgc_private_test_directory(os.join_path(home, '.local'))!
+	assert_tcc_macos_libgc_private_test_directory(fallback)!
+	assert stored.starts_with(os.join_path(resolved, tcc_macos_libgc_store_name) + os.path_separator)
+	assert os.read_file(stored)! == os.read_file(fixture.libgc.target)!
+}
+
+fn test_tcc_macos_libgc_data_base_home_fallback_creation_is_idempotent_under_concurrency() ! {
+	$if windows {
+		return
+	}
+	fixture := create_tcc_macos_libgc_test_fixture('home_fallback_concurrent',
+		'home-concurrent-content')!
+	defer {
+		os.rmdir_all(fixture.root) or {}
+	}
+	home := create_tcc_macos_libgc_test_home(fixture.root, 'home')!
+	worker_count := 8
+	start := chan bool{cap: worker_count}
+	mut workers := []thread !string{cap: worker_count}
+	for _ in 0 .. worker_count {
+		workers << spawn resolve_tcc_macos_libgc_home_fallback_concurrently(home, start)
+	}
+	for _ in 0 .. worker_count {
+		start <- true
+	}
+	fallback := os.join_path(home, '.local', 'share')
+	for worker in workers {
+		assert worker.wait()! == os.real_path(fallback)
+	}
+	assert_tcc_macos_libgc_private_test_directory(os.join_path(home, '.local'))!
+	assert_tcc_macos_libgc_private_test_directory(fallback)!
+}
+
+fn test_tcc_macos_libgc_data_base_home_fallback_preserves_private_symlink() ! {
+	$if windows {
+		return
+	}
+	fixture := create_tcc_macos_libgc_test_fixture('home_fallback_symlink', 'home-symlink-content')!
+	defer {
+		os.rmdir_all(fixture.root) or {}
+	}
+	home := create_tcc_macos_libgc_test_home(fixture.root, 'home')!
+	local_target := os.join_path(fixture.root, 'private local data')
+	os.mkdir(local_target, mode: 0o700)!
+	os.symlink(local_target, os.join_path(home, '.local'))!
+	fallback_target := os.join_path(local_target, 'share')
+	assert resolve_tcc_macos_libgc_data_base('', home)! == os.real_path(fallback_target)
+	assert os.is_link(os.join_path(home, '.local'))
+	assert_tcc_macos_libgc_private_test_directory(fallback_target)!
+}
+
+fn test_tcc_macos_libgc_data_base_home_fallback_rejects_unsafe_traversal() ! {
+	$if windows {
+		return
+	}
+	fixture := create_tcc_macos_libgc_test_fixture('home_fallback_unsafe', 'unsafe-content')!
+	defer {
+		os.rmdir_all(fixture.root) or {}
+	}
+	unsafe_home := create_tcc_macos_libgc_test_home(fixture.root, 'unsafe home')!
+	os.chmod(unsafe_home, 0o770)!
+	expect_tcc_macos_libgc_home_fallback_error(unsafe_home, unsafe_home, 'unsafe permissions', os.join_path(unsafe_home,
+		'.local'))
+
+	file_home := create_tcc_macos_libgc_test_home(fixture.root, 'file home')!
+	file_local := os.join_path(file_home, '.local')
+	os.write_file(file_local, 'not-a-directory')!
+	expect_tcc_macos_libgc_home_fallback_error(file_home, file_local, 'not a directory', os.join_path(file_local,
+		'share'))
+
+	writable_home := create_tcc_macos_libgc_test_home(fixture.root, 'writable local home')!
+	writable_local := os.join_path(writable_home, '.local')
+	os.mkdir(writable_local, mode: 0o700)!
+	os.chmod(writable_local, 0o770)!
+	expect_tcc_macos_libgc_home_fallback_error(writable_home, writable_local, 'unsafe permissions', os.join_path(writable_local,
+		'share'))
+
+	unsafe_share_home := create_tcc_macos_libgc_test_home(fixture.root, 'unsafe share home')!
+	unsafe_share_local := os.join_path(unsafe_share_home, '.local')
+	unsafe_share := os.join_path(unsafe_share_local, 'share')
+	os.mkdir(unsafe_share_local, mode: 0o700)!
+	os.mkdir(unsafe_share, mode: 0o700)!
+	os.chmod(unsafe_share, 0o770)!
+	expect_tcc_macos_libgc_home_fallback_error(unsafe_share_home, unsafe_share,
+		'unsafe permissions', os.join_path(unsafe_share, tcc_macos_libgc_store_name))
+
+	unsafe_target_home := create_tcc_macos_libgc_test_home(fixture.root, 'unsafe target home')!
+	unsafe_target := os.join_path(fixture.root, 'unsafe local target')
+	os.mkdir(unsafe_target, mode: 0o700)!
+	os.chmod(unsafe_target, 0o770)!
+	os.symlink(unsafe_target, os.join_path(unsafe_target_home, '.local'))!
+	expect_tcc_macos_libgc_home_fallback_error(unsafe_target_home, unsafe_target,
+		'unsafe permissions', os.join_path(unsafe_target, 'share'))
+
+	comma_target_home := create_tcc_macos_libgc_test_home(fixture.root, 'comma target home')!
+	comma_target := os.join_path(fixture.root, 'private,local target')
+	os.mkdir(comma_target, mode: 0o700)!
+	os.symlink(comma_target, os.join_path(comma_target_home, '.local'))!
+	expect_tcc_macos_libgc_home_fallback_error(comma_target_home, comma_target, 'comma-free', os.join_path(comma_target,
+		'share'))
 }
 
 fn test_tcc_macos_libgc_data_base_resolver_rejects_absence() ! {

--- a/vlib/v/builder/tcc_macos_libgc_store_test.v
+++ b/vlib/v/builder/tcc_macos_libgc_store_test.v
@@ -1,0 +1,944 @@
+module builder
+
+import os
+
+struct TccMacosLibgcTestSource {
+	lib_dir string
+	target  string
+	source  string
+}
+
+struct TccMacosLibgcTestFixture {
+	root      string
+	data_base string
+	libgc     TccMacosLibgcTestSource
+}
+
+struct TccMacosLibgcTestContentStore {
+	resolved_source string
+	expected        TccMacosLibgcFileHash
+	store_root      string
+	content_dir     string
+	final_dylib     string
+}
+
+fn tcc_macos_libgc_test_tokens(vroot string) (string, string) {
+	lib_dir := os.join_path(vroot, 'thirdparty', 'tcc', 'lib')
+	return '"${os.join_path(lib_dir, tcc_macos_libgc_name)}"', '-Wl,-rpath,"${lib_dir}"'
+}
+
+fn expect_tcc_macos_libgc_plan_error(vroot string, linker_flags []string, pre_args []string, expected_fragment string) {
+	plan_tcc_macos_libgc_store(vroot, linker_flags, pre_args) or {
+		assert err.msg().contains(expected_fragment), err.msg()
+		return
+	}
+	assert false, 'expected macOS bundled libgc planning to fail'
+}
+
+fn create_tcc_macos_libgc_test_source(root string, name string, content string) !TccMacosLibgcTestSource {
+	lib_dir := os.join_path(root, '${name} V root, with space', 'thirdparty', 'tcc', 'lib')
+	os.mkdir_all(lib_dir, mode: 0o700)!
+	target := os.join_path(lib_dir, 'libgc.1.dylib')
+	source := os.join_path(lib_dir, tcc_macos_libgc_name)
+	os.write_file(target, content)!
+	os.chmod(target, 0o700)!
+	os.symlink(os.file_name(target), source)!
+	return TccMacosLibgcTestSource{
+		lib_dir: lib_dir
+		target:  target
+		source:  source
+	}
+}
+
+fn create_tcc_macos_libgc_test_fixture(name string, content string) !TccMacosLibgcTestFixture {
+	root := os.join_path(os.vtmp_dir(), 'v_builder_tcc_macos_libgc_${os.getpid()}_${name}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root, mode: 0o700)!
+	data_base := os.join_path(root, 'persistent data root')
+	os.mkdir(data_base, mode: 0o700)!
+	libgc := create_tcc_macos_libgc_test_source(root, 'primary', content)!
+	return TccMacosLibgcTestFixture{
+		root:      root
+		data_base: data_base
+		libgc:     libgc
+	}
+}
+
+fn expect_tcc_macos_libgc_materialize_error(source string, data_base string, expected_fragment string) {
+	materialize_tcc_macos_libgc_at(source, data_base) or {
+		assert err.msg().contains(expected_fragment), err.msg()
+		return
+	}
+	assert false, 'expected macOS bundled libgc materialization to fail'
+}
+
+fn expect_tcc_macos_libgc_data_base_error(xdg_data_home string, home string, rejected string, expected_reason string) {
+	resolve_tcc_macos_libgc_data_base(xdg_data_home, home) or {
+		message := err.msg()
+		assert message.contains(rejected), message
+		assert message.contains(expected_reason), message
+		assert message.contains(tcc_macos_libgc_data_root_remediation), message
+		return
+	}
+	assert false, 'expected macOS bundled libgc data root validation to fail'
+}
+
+fn prepare_tcc_macos_libgc_test_content_store(fixture TccMacosLibgcTestFixture) !TccMacosLibgcTestContentStore {
+	resolved_source := resolve_tcc_macos_libgc_source(fixture.libgc.source)!
+	expected := hash_tcc_macos_libgc_regular_file(resolved_source)!
+	store_root := os.join_path(fixture.data_base, tcc_macos_libgc_store_name)
+	ensure_tcc_macos_libgc_private_directory(store_root)!
+	content_dir := os.join_path(store_root, expected.sum)
+	ensure_tcc_macos_libgc_private_directory(content_dir)!
+	return TccMacosLibgcTestContentStore{
+		resolved_source: resolved_source
+		expected:        expected
+		store_root:      store_root
+		content_dir:     content_dir
+		final_dylib:     os.join_path(content_dir, tcc_macos_libgc_name)
+	}
+}
+
+fn test_tcc_macos_libgc_planner_ignores_absence() {
+	vroot := '/Applications/V, active domain'
+	linker_flags := ['-lm', '"/opt/vendor/libother.dylib"']
+	pre_args := ['-Wl,-rpath,"/opt/vendor/lib"', '-DAPP_FLAG=1']
+	plan := plan_tcc_macos_libgc_store(vroot, linker_flags, pre_args)!
+	assert !plan.required
+	assert linker_flags == ['-lm', '"/opt/vendor/libother.dylib"']
+	assert pre_args == ['-Wl,-rpath,"/opt/vendor/lib"', '-DAPP_FLAG=1']
+}
+
+fn test_tcc_macos_libgc_planner_keeps_exact_pair_without_comma() {
+	vroot := '/Applications/V stable'
+	dylib, rpath := tcc_macos_libgc_test_tokens(vroot)
+	plan := plan_tcc_macos_libgc_store(vroot, [dylib], [rpath])!
+	assert !plan.required
+}
+
+fn test_tcc_macos_libgc_planner_noops_before_rejecting_out_of_scope_flags_without_comma() {
+	vroot := '/Applications/V stable'
+	dylib, rpath := tcc_macos_libgc_test_tokens(vroot)
+	linker_flags := [dylib, dylib, dylib.trim('"'), '"/other/thirdparty/tcc/lib/libgc.dylib"']
+	pre_args := [rpath, rpath, rpath + '-near-match']
+	plan := plan_tcc_macos_libgc_store(vroot, linker_flags, pre_args)!
+	assert !plan.required
+	assert linker_flags == [dylib, dylib, dylib.trim('"'), '"/other/thirdparty/tcc/lib/libgc.dylib"']
+	assert pre_args == [rpath, rpath, rpath + '-near-match']
+}
+
+fn test_tcc_macos_libgc_planner_uses_physical_vroot_for_comma_activation() ! {
+	$if windows {
+		return
+	}
+	root := os.join_path(os.vtmp_dir(),
+		'v_builder_tcc_macos_libgc_${os.getpid()}_physical_activation')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root, mode: 0o700)!
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	physical_without_comma := os.join_path(root, 'physical vroot')
+	os.mkdir(physical_without_comma, mode: 0o700)!
+	lexical_with_comma := os.join_path(root, 'lexical,vroot')
+	os.symlink(physical_without_comma, lexical_with_comma)!
+	no_op_dylib, no_op_rpath := tcc_macos_libgc_test_tokens(lexical_with_comma)
+	no_op_plan := plan_tcc_macos_libgc_store(lexical_with_comma, [no_op_dylib, no_op_dylib,
+		no_op_dylib.trim('"')], [no_op_rpath, no_op_rpath + '-near-match'])!
+	assert !no_op_plan.required
+	physical_with_comma := os.join_path(root, 'physical,vroot')
+	os.mkdir(physical_with_comma, mode: 0o700)!
+	lexical_without_comma := os.join_path(root, 'lexical-vroot')
+	os.symlink(physical_with_comma, lexical_without_comma)!
+	active_dylib, active_rpath := tcc_macos_libgc_test_tokens(lexical_without_comma)
+	active_plan := plan_tcc_macos_libgc_store(lexical_without_comma, [active_dylib], [
+		active_rpath,
+	])!
+	assert active_plan.required
+}
+
+fn test_tcc_macos_libgc_planner_requires_one_complete_pair() {
+	vroot := '/Applications/V, nightly'
+	dylib, rpath := tcc_macos_libgc_test_tokens(vroot)
+	expect_tcc_macos_libgc_plan_error(vroot, [dylib], [], 'expected one exact')
+	expect_tcc_macos_libgc_plan_error(vroot, [], [rpath], 'expected one exact')
+	expect_tcc_macos_libgc_plan_error(vroot, [dylib, dylib], [rpath], 'found 2/1')
+	expect_tcc_macos_libgc_plan_error(vroot, [dylib], [rpath, rpath], 'found 1/2')
+	expect_tcc_macos_libgc_plan_error(vroot, [dylib, rpath], [dylib], 'found 2/1')
+	expect_tcc_macos_libgc_plan_error(vroot, [dylib, rpath], [rpath], 'found 1/2')
+}
+
+fn test_tcc_macos_libgc_planner_rejects_near_matches() {
+	vroot := '/Applications/V, nightly'
+	dylib, rpath := tcc_macos_libgc_test_tokens(vroot)
+	unquoted_dylib := dylib.trim('"')
+	expect_tcc_macos_libgc_plan_error(vroot, [unquoted_dylib], [], 'near-match')
+	expect_tcc_macos_libgc_plan_error(vroot, [dylib + '.backup'], [rpath], 'near-match')
+	expect_tcc_macos_libgc_plan_error(vroot, [dylib], [rpath + '-other'], 'near-match')
+	expect_tcc_macos_libgc_plan_error(vroot, [], ['  ${rpath}  '], 'near-match')
+	expect_tcc_macos_libgc_plan_error(vroot, [], [
+		rpath.replace('-Wl,-rpath,', '-Wl,--rpath='),
+	], 'near-match')
+	expect_tcc_macos_libgc_plan_error(vroot, [dylib, '"/other/thirdparty/tcc/lib/libgc.dylib"'], [
+		rpath,
+	], 'near-match')
+}
+
+fn test_tcc_macos_libgc_rewrite_preserves_third_party_rpaths_byte_for_byte() {
+	vroot := '/Applications/V checkout, nightly build'
+	dylib, rpath := tcc_macos_libgc_test_tokens(vroot)
+	linker_flags := ['-lm', dylib, '"/opt/vendor/libother.dylib"']
+	pre_args := [
+		'-Wl,-rpath,"/opt/vendor/lib"',
+		rpath,
+		'-Wl,-rpath,"@loader_path/../Frameworks"',
+	]
+	plan := plan_tcc_macos_libgc_store(vroot, linker_flags, pre_args)!
+	assert plan.required
+	hash := 'a'.repeat(64)
+	stored_dylib := '/Users/test/Library/Application Support/v-tcc-libgc-v1/${hash}/libgc.dylib'
+	rewritten_linker_flags, rewritten_pre_args := rewrite_tcc_macos_libgc_flags(plan, linker_flags,
+		pre_args, stored_dylib)!
+	assert rewritten_linker_flags == [
+		'-lm',
+		'"${stored_dylib}"',
+		'"/opt/vendor/libother.dylib"',
+	]
+	assert rewritten_pre_args == [
+		'-Wl,-rpath,"/opt/vendor/lib"',
+		'-Wl,-rpath,"${os.dir(stored_dylib)}"',
+		'-Wl,-rpath,"@loader_path/../Frameworks"',
+	]
+	assert linker_flags == ['-lm', dylib, '"/opt/vendor/libother.dylib"']
+	assert pre_args[0] == '-Wl,-rpath,"/opt/vendor/lib"'
+	assert pre_args[2] == '-Wl,-rpath,"@loader_path/../Frameworks"'
+}
+
+fn test_tcc_macos_libgc_rewrite_is_transactional_on_error() {
+	vroot := '/Applications/V checkout, nightly build'
+	dylib, rpath := tcc_macos_libgc_test_tokens(vroot)
+	plan := plan_tcc_macos_libgc_store(vroot, [dylib], [rpath])!
+	linker_flags := ['"tampered-after-plan.dylib"']
+	pre_args := [rpath]
+	original_linker_flags := linker_flags.clone()
+	original_pre_args := pre_args.clone()
+	rewrite_tcc_macos_libgc_flags(plan, linker_flags, pre_args,
+		'/Users/test/data/store/hash/libgc.dylib') or {
+		assert err.msg().contains('changed after planning'), err.msg()
+		assert linker_flags == original_linker_flags
+		assert pre_args == original_pre_args
+		return
+	}
+	assert false, 'expected a stale macOS bundled libgc plan to fail'
+}
+
+fn test_tcc_macos_libgc_materialize_and_rewrite_keeps_inputs_on_materialization_error() ! {
+	$if windows {
+		return
+	}
+	fixture := create_tcc_macos_libgc_test_fixture('transactional_materialize',
+		'transactional-materialize-content')!
+	defer {
+		os.rmdir_all(fixture.root) or {}
+	}
+	vroot := os.dir(os.dir(os.dir(fixture.libgc.lib_dir)))
+	dylib, rpath := tcc_macos_libgc_test_tokens(vroot)
+	linker_flags := ['-lm', dylib, '-lthird_party']
+	pre_args := ['-DTRANSACTIONAL_SENTINEL=1', rpath]
+	original_linker_flags := linker_flags.clone()
+	original_pre_args := pre_args.clone()
+	plan := plan_tcc_macos_libgc_store(vroot, linker_flags, pre_args)!
+	assert plan.required
+	comma_base := os.join_path(fixture.root, 'transactional,persistent-data')
+	os.mkdir(comma_base, mode: 0o700)!
+	materialize_and_rewrite_tcc_macos_libgc_flags_at(plan, linker_flags, pre_args, comma_base) or {
+		assert err.msg().contains(comma_base), err.msg()
+		assert linker_flags == original_linker_flags
+		assert pre_args == original_pre_args
+		assert !os.exists(os.join_path(comma_base, tcc_macos_libgc_store_name))
+		return
+	}
+	assert false, 'expected materialization failure to leave compiler arguments unchanged'
+}
+
+fn test_tcc_macos_libgc_rewrite_supports_ordered_pkgconfig_layout() {
+	vroot := '/Applications/V checkout, ordered pkgconfig'
+	dylib, rpath := tcc_macos_libgc_test_tokens(vroot)
+	linker_flags := [
+		'-Wl,-rpath,"/opt/vendor/lib"',
+		dylib,
+		'-lthird_party',
+		rpath,
+	]
+	pre_args := ['-DORDERED_PKGCONFIG_SENTINEL=1']
+	plan := plan_tcc_macos_libgc_store(vroot, linker_flags, pre_args)!
+	assert plan.required
+	hash := 'c'.repeat(64)
+	stored_dylib := '/Users/test/data/v-tcc-libgc-v1/${hash}/libgc.dylib'
+	rewritten_linker_flags, rewritten_pre_args := rewrite_tcc_macos_libgc_flags(plan, linker_flags,
+		pre_args, stored_dylib)!
+	assert rewritten_linker_flags == [
+		'-Wl,-rpath,"/opt/vendor/lib"',
+		'"${stored_dylib}"',
+		'-lthird_party',
+		'-Wl,-rpath,"${os.dir(stored_dylib)}"',
+	]
+	assert rewritten_pre_args == pre_args
+	assert linker_flags[0] == '-Wl,-rpath,"/opt/vendor/lib"'
+	assert linker_flags[2] == '-lthird_party'
+}
+
+fn test_tcc_macos_libgc_planner_is_architecture_neutral() {
+	vroot := '/Applications/V arm64, nightly'
+	dylib, rpath := tcc_macos_libgc_test_tokens(vroot)
+	linker_flags := ['-arch', 'arm64', dylib]
+	pre_args := ['-DARM64_SENTINEL=1', rpath]
+	plan := plan_tcc_macos_libgc_store(vroot, linker_flags, pre_args)!
+	assert plan.required
+	hash := 'b'.repeat(64)
+	stored_dylib := '/Users/test/data/v-tcc-libgc-v1/${hash}/libgc.dylib'
+	rewritten_linker_flags, rewritten_pre_args := rewrite_tcc_macos_libgc_flags(plan, linker_flags,
+		pre_args, stored_dylib)!
+	assert rewritten_linker_flags[..2] == ['-arch', 'arm64']
+	assert rewritten_pre_args[0] == '-DARM64_SENTINEL=1'
+}
+
+fn test_tcc_macos_libgc_data_base_resolver_is_fallible_and_absolute() ! {
+	$if windows {
+		return
+	}
+	fixture := create_tcc_macos_libgc_test_fixture('data_base', 'resolver-content')!
+	defer {
+		os.rmdir_all(fixture.root) or {}
+	}
+	assert resolve_tcc_macos_libgc_data_base(fixture.data_base, '')! == os.real_path(fixture.data_base)
+	expect_tcc_macos_libgc_data_base_error('relative/data', '', 'relative/data', 'relative')
+	expect_tcc_macos_libgc_data_base_error('', '', 'XDG_DATA_HOME="" and HOME=""',
+		'no persistent data root')
+}
+
+fn test_tcc_macos_libgc_data_base_resolver_uses_home_fallback() ! {
+	$if windows {
+		return
+	}
+	fixture := create_tcc_macos_libgc_test_fixture('home_fallback', 'home-content')!
+	defer {
+		os.rmdir_all(fixture.root) or {}
+	}
+	home := os.join_path(fixture.root, 'home')
+	fallback := os.join_path(home, '.local', 'share')
+	os.mkdir_all(fallback, mode: 0o700)!
+	assert resolve_tcc_macos_libgc_data_base('', home)! == os.real_path(fallback)
+}
+
+fn test_tcc_macos_libgc_data_base_resolver_rejects_absence() ! {
+	$if windows {
+		return
+	}
+	fixture := create_tcc_macos_libgc_test_fixture('missing_data_base', 'missing-base-content')!
+	defer {
+		os.rmdir_all(fixture.root) or {}
+	}
+	missing_base := os.join_path(fixture.root, 'missing persistent data root')
+	expect_tcc_macos_libgc_data_base_error(missing_base, '', missing_base, 'does not exist')
+	assert !os.exists(missing_base)
+}
+
+fn test_tcc_macos_libgc_data_base_accepts_owned_0755() ! {
+	$if windows {
+		return
+	}
+	fixture := create_tcc_macos_libgc_test_fixture('base_0755', 'base-0755-content')!
+	defer {
+		os.rmdir_all(fixture.root) or {}
+	}
+	os.chmod(fixture.data_base, 0o755)!
+	assert resolve_tcc_macos_libgc_data_base(fixture.data_base, '')! == os.real_path(fixture.data_base)
+}
+
+fn test_tcc_macos_libgc_data_base_rejects_unsafe_modes() ! {
+	$if windows {
+		return
+	}
+	fixture := create_tcc_macos_libgc_test_fixture('base_modes', 'base-mode-content')!
+	defer {
+		os.rmdir_all(fixture.root) or {}
+	}
+	os.chmod(fixture.data_base, 0o775)!
+	expect_tcc_macos_libgc_data_base_error(fixture.data_base, '', fixture.data_base,
+		'unsafe permissions')
+	os.chmod(fixture.data_base, 0o1755)!
+	expect_tcc_macos_libgc_data_base_error(fixture.data_base, '', fixture.data_base,
+		'unsafe permissions')
+}
+
+fn test_tcc_macos_libgc_data_base_rejects_non_directory() ! {
+	$if windows {
+		return
+	}
+	fixture := create_tcc_macos_libgc_test_fixture('base_type', 'base-type-content')!
+	defer {
+		os.rmdir_all(fixture.root) or {}
+	}
+	file_base := os.join_path(fixture.root, 'data-root-file')
+	os.write_file(file_base, 'not-a-directory')!
+	expect_tcc_macos_libgc_data_base_error(file_base, '', file_base, 'not a directory')
+}
+
+fn test_tcc_macos_libgc_data_base_owner_validation_is_actionable() ! {
+	$if windows {
+		return
+	}
+	fixture := create_tcc_macos_libgc_test_fixture('base_owner', 'base-owner-content')!
+	defer {
+		os.rmdir_all(fixture.root) or {}
+	}
+	stat := os.lstat(fixture.data_base)!
+	validate_tcc_macos_libgc_data_base_stat(stat, fixture.data_base, os.geteuid() + 1) or {
+		assert err.msg().contains(fixture.data_base), err.msg()
+		assert err.msg().contains('not owned'), err.msg()
+		assert err.msg().contains(tcc_macos_libgc_data_root_remediation), err.msg()
+		return
+	}
+	assert false, 'expected a data root owned by another uid to fail validation'
+}
+
+fn test_tcc_macos_libgc_store_rejects_comma_data_root() ! {
+	$if windows {
+		return
+	}
+	fixture := create_tcc_macos_libgc_test_fixture('comma_root', 'comma-root-content')!
+	defer {
+		os.rmdir_all(fixture.root) or {}
+	}
+	comma_base := os.join_path(fixture.root, 'persistent,data')
+	os.mkdir(comma_base, mode: 0o700)!
+	materialize_tcc_macos_libgc_at(fixture.libgc.source, comma_base) or {
+		message := err.msg()
+		assert message.contains(comma_base), message
+		assert message.contains(tcc_macos_libgc_data_root_remediation), message
+		assert message.contains('comma-free'), message
+		assert !os.exists(os.join_path(comma_base, tcc_macos_libgc_store_name))
+		return
+	}
+	assert false, 'expected a comma data root to fail'
+}
+
+fn test_tcc_macos_libgc_store_rejects_empty_source_without_creating_store() ! {
+	$if windows {
+		return
+	}
+	fixture := create_tcc_macos_libgc_test_fixture('empty_source', '')!
+	defer {
+		os.rmdir_all(fixture.root) or {}
+	}
+	expect_tcc_macos_libgc_materialize_error(fixture.libgc.source, fixture.data_base,
+		'outside the accepted range')
+	assert !os.exists(os.join_path(fixture.data_base, tcc_macos_libgc_store_name))
+}
+
+fn test_tcc_macos_libgc_store_rejects_oversized_sparse_source_without_creating_store() ! {
+	$if windows {
+		return
+	}
+	fixture := create_tcc_macos_libgc_test_fixture('oversized_source', 'seed')!
+	defer {
+		os.rmdir_all(fixture.root) or {}
+	}
+	os.truncate(fixture.libgc.target, tcc_macos_libgc_max_size + 1)!
+	expect_tcc_macos_libgc_materialize_error(fixture.libgc.source, fixture.data_base,
+		'outside the accepted range')
+	assert !os.exists(os.join_path(fixture.data_base, tcc_macos_libgc_store_name))
+}
+
+fn test_tcc_macos_libgc_store_materializes_byte_identical_regular_object() ! {
+	$if windows {
+		return
+	}
+	fixture := create_tcc_macos_libgc_test_fixture('healthy', 'healthy-content-123456')!
+	defer {
+		os.rmdir_all(fixture.root) or {}
+	}
+	source_before := os.read_bytes(fixture.libgc.target)!
+	stored := materialize_tcc_macos_libgc_at(fixture.libgc.source, fixture.data_base)!
+	assert os.read_bytes(stored)! == source_before
+	assert os.read_bytes(fixture.libgc.target)! == source_before
+	stat := os.lstat(stored)!
+	assert stat.get_filetype() == .regular
+	assert stat.get_mode().bitmask() == 0o700
+	assert stat.uid == u32(os.geteuid())
+	assert os.file_name(os.dir(stored)).len == 64
+	assert os.ls(os.dir(stored))! == [tcc_macos_libgc_name]
+}
+
+fn test_tcc_macos_libgc_store_reuses_same_content_key() ! {
+	$if windows {
+		return
+	}
+	fixture := create_tcc_macos_libgc_test_fixture('same_key', 'same-content-key')!
+	defer {
+		os.rmdir_all(fixture.root) or {}
+	}
+	second_source := create_tcc_macos_libgc_test_source(fixture.root, 'secondary',
+		'same-content-key')!
+	os.utime(fixture.libgc.target, i64(1_900_000_000), i64(1_900_000_000))!
+	os.utime(second_source.target, i64(2_000_000_000), i64(2_000_000_000))!
+	assert os.file_last_mod_unix(fixture.libgc.target) != os.file_last_mod_unix(second_source.target)
+	first := materialize_tcc_macos_libgc_at(fixture.libgc.source, fixture.data_base)!
+	second := materialize_tcc_macos_libgc_at(second_source.source, fixture.data_base)!
+	assert first == second
+}
+
+fn test_tcc_macos_libgc_store_keys_bytes_not_mtime() ! {
+	$if windows {
+		return
+	}
+	fixture := create_tcc_macos_libgc_test_fixture('mtime_key', 'content-alpha')!
+	defer {
+		os.rmdir_all(fixture.root) or {}
+	}
+	second_source := create_tcc_macos_libgc_test_source(fixture.root, 'secondary', 'content-bravo')!
+	mtime := i64(2_000_000_000)
+	os.utime(fixture.libgc.target, mtime, mtime)!
+	os.utime(second_source.target, mtime, mtime)!
+	first := materialize_tcc_macos_libgc_at(fixture.libgc.source, fixture.data_base)!
+	second := materialize_tcc_macos_libgc_at(second_source.source, fixture.data_base)!
+	assert os.file_last_mod_unix(fixture.libgc.target) == os.file_last_mod_unix(second_source.target)
+	assert first != second
+}
+
+fn test_tcc_macos_libgc_store_refuses_truncated_final_without_repair() ! {
+	$if windows {
+		return
+	}
+	fixture := create_tcc_macos_libgc_test_fixture('truncated', 'complete-content-for-truncation')!
+	defer {
+		os.rmdir_all(fixture.root) or {}
+	}
+	stored := materialize_tcc_macos_libgc_at(fixture.libgc.source, fixture.data_base)!
+	os.write_file(stored, 'x')!
+	expect_tcc_macos_libgc_materialize_error(fixture.libgc.source, fixture.data_base,
+		'content hash validation')
+	assert os.read_file(stored)! == 'x'
+}
+
+fn test_tcc_macos_libgc_store_refuses_wrong_hash_without_repair() ! {
+	$if windows {
+		return
+	}
+	content := 'equal-length-original-content'
+	fixture := create_tcc_macos_libgc_test_fixture('wrong_hash', content)!
+	defer {
+		os.rmdir_all(fixture.root) or {}
+	}
+	stored := materialize_tcc_macos_libgc_at(fixture.libgc.source, fixture.data_base)!
+	original_mtime := os.file_last_mod_unix(stored)
+	wrong := 'x'.repeat(content.len)
+	os.write_file(stored, wrong)!
+	os.utime(stored, original_mtime, original_mtime)!
+	assert os.file_last_mod_unix(stored) == original_mtime
+	expect_tcc_macos_libgc_materialize_error(fixture.libgc.source, fixture.data_base,
+		'content hash validation')
+	assert os.read_file(stored)! == wrong
+}
+
+fn test_tcc_macos_libgc_store_refuses_symlink_final() ! {
+	$if windows {
+		return
+	}
+	fixture := create_tcc_macos_libgc_test_fixture('symlink_final', 'symlink-final-content')!
+	defer {
+		os.rmdir_all(fixture.root) or {}
+	}
+	stored := materialize_tcc_macos_libgc_at(fixture.libgc.source, fixture.data_base)!
+	os.rm(stored)!
+	os.symlink(fixture.libgc.target, stored)!
+	expect_tcc_macos_libgc_materialize_error(fixture.libgc.source, fixture.data_base,
+		'not a regular file')
+	assert os.lstat(stored)!.get_filetype() == .symbolic_link
+}
+
+fn test_tcc_macos_libgc_store_refuses_wrong_final_mode() ! {
+	$if windows {
+		return
+	}
+	fixture := create_tcc_macos_libgc_test_fixture('wrong_mode', 'wrong-mode-content')!
+	defer {
+		os.rmdir_all(fixture.root) or {}
+	}
+	stored := materialize_tcc_macos_libgc_at(fixture.libgc.source, fixture.data_base)!
+	os.chmod(stored, 0o755)!
+	expect_tcc_macos_libgc_materialize_error(fixture.libgc.source, fixture.data_base, 'mode 0700')
+	assert os.lstat(stored)!.get_mode().bitmask() == 0o755
+}
+
+fn test_tcc_macos_libgc_store_object_owner_validation_fails_closed() ! {
+	$if windows {
+		return
+	}
+	fixture := create_tcc_macos_libgc_test_fixture('wrong_owner', 'wrong-owner-content')!
+	defer {
+		os.rmdir_all(fixture.root) or {}
+	}
+	stored := materialize_tcc_macos_libgc_at(fixture.libgc.source, fixture.data_base)!
+	stat := os.lstat(stored)!
+	validate_tcc_macos_libgc_store_object_stat(stat, os.geteuid() + 1) or {
+		assert err.msg().contains('not owned'), err.msg()
+		return
+	}
+	assert false, 'expected a store object owned by another uid to fail validation'
+}
+
+fn test_tcc_macos_libgc_store_refuses_hostile_leaf() ! {
+	$if windows {
+		return
+	}
+	fixture := create_tcc_macos_libgc_test_fixture('hostile_leaf', 'hostile-leaf-content')!
+	defer {
+		os.rmdir_all(fixture.root) or {}
+	}
+	outside := os.join_path(fixture.root, 'outside store')
+	os.mkdir(outside, mode: 0o700)!
+	store_root := os.join_path(fixture.data_base, tcc_macos_libgc_store_name)
+	os.symlink(outside, store_root)!
+	expect_tcc_macos_libgc_materialize_error(fixture.libgc.source, fixture.data_base,
+		'not a directory')
+	assert os.lstat(store_root)!.get_filetype() == .symbolic_link
+}
+
+fn test_tcc_macos_libgc_store_refuses_leaf_with_wrong_mode() ! {
+	$if windows {
+		return
+	}
+	fixture := create_tcc_macos_libgc_test_fixture('leaf_mode', 'leaf-mode-content')!
+	defer {
+		os.rmdir_all(fixture.root) or {}
+	}
+	store_root := os.join_path(fixture.data_base, tcc_macos_libgc_store_name)
+	os.mkdir(store_root, mode: 0o700)!
+	os.chmod(store_root, 0o755)!
+	expect_tcc_macos_libgc_materialize_error(fixture.libgc.source, fixture.data_base, 'mode 0700')
+}
+
+fn test_tcc_macos_libgc_store_leaf_owner_validation_fails_closed() ! {
+	$if windows {
+		return
+	}
+	fixture := create_tcc_macos_libgc_test_fixture('leaf_owner', 'leaf-owner-content')!
+	defer {
+		os.rmdir_all(fixture.root) or {}
+	}
+	store_root := os.join_path(fixture.data_base, tcc_macos_libgc_store_name)
+	os.mkdir(store_root, mode: 0o700)!
+	stat := os.lstat(store_root)!
+	validate_tcc_macos_libgc_private_directory_stat(stat, os.geteuid() + 1) or {
+		assert err.msg().contains('not owned'), err.msg()
+		return
+	}
+	assert false, 'expected a store leaf owned by another uid to fail validation'
+}
+
+fn test_tcc_macos_libgc_store_refuses_content_directory_symlink() ! {
+	$if windows {
+		return
+	}
+	fixture := create_tcc_macos_libgc_test_fixture('content_symlink', 'content-symlink-content')!
+	defer {
+		os.rmdir_all(fixture.root) or {}
+	}
+	resolved_source := resolve_tcc_macos_libgc_source(fixture.libgc.source)!
+	expected := hash_tcc_macos_libgc_regular_file(resolved_source)!
+	store_root := os.join_path(fixture.data_base, tcc_macos_libgc_store_name)
+	os.mkdir(store_root, mode: 0o700)!
+	outside := os.join_path(fixture.root, 'outside content directory')
+	os.mkdir(outside, mode: 0o700)!
+	content_dir := os.join_path(store_root, expected.sum)
+	os.symlink(outside, content_dir)!
+	expect_tcc_macos_libgc_materialize_error(fixture.libgc.source, fixture.data_base,
+		'not a directory')
+	assert os.lstat(content_dir)!.get_filetype() == .symbolic_link
+	assert os.ls(outside)! == []
+}
+
+fn test_tcc_macos_libgc_store_refuses_content_directory_regular_file() ! {
+	$if windows {
+		return
+	}
+	fixture := create_tcc_macos_libgc_test_fixture('content_file', 'content-file-content')!
+	defer {
+		os.rmdir_all(fixture.root) or {}
+	}
+	resolved_source := resolve_tcc_macos_libgc_source(fixture.libgc.source)!
+	expected := hash_tcc_macos_libgc_regular_file(resolved_source)!
+	store_root := os.join_path(fixture.data_base, tcc_macos_libgc_store_name)
+	os.mkdir(store_root, mode: 0o700)!
+	content_dir := os.join_path(store_root, expected.sum)
+	os.write_file(content_dir, 'hostile-content-directory-file')!
+	expect_tcc_macos_libgc_materialize_error(fixture.libgc.source, fixture.data_base,
+		'not a directory')
+	assert os.read_file(content_dir)! == 'hostile-content-directory-file'
+}
+
+fn test_tcc_macos_libgc_store_refuses_content_directory_with_wrong_mode() ! {
+	$if windows {
+		return
+	}
+	fixture := create_tcc_macos_libgc_test_fixture('content_mode', 'content-mode-content')!
+	defer {
+		os.rmdir_all(fixture.root) or {}
+	}
+	resolved_source := resolve_tcc_macos_libgc_source(fixture.libgc.source)!
+	expected := hash_tcc_macos_libgc_regular_file(resolved_source)!
+	store_root := os.join_path(fixture.data_base, tcc_macos_libgc_store_name)
+	os.mkdir(store_root, mode: 0o700)!
+	content_dir := os.join_path(store_root, expected.sum)
+	os.mkdir(content_dir, mode: 0o700)!
+	os.chmod(content_dir, 0o755)!
+	expect_tcc_macos_libgc_materialize_error(fixture.libgc.source, fixture.data_base, 'mode 0700')
+	assert os.lstat(content_dir)!.get_mode().bitmask() == 0o755
+}
+
+fn test_tcc_macos_libgc_source_symlink_must_remain_internal() ! {
+	$if windows {
+		return
+	}
+	fixture := create_tcc_macos_libgc_test_fixture('external_source', 'internal-content')!
+	defer {
+		os.rmdir_all(fixture.root) or {}
+	}
+	external_target := os.join_path(fixture.root, 'external-libgc.dylib')
+	os.write_file(external_target, 'external-content')!
+	os.chmod(external_target, 0o700)!
+	os.rm(fixture.libgc.source)!
+	os.symlink(external_target, fixture.libgc.source)!
+	expect_tcc_macos_libgc_materialize_error(fixture.libgc.source, fixture.data_base,
+		'resolves outside')
+}
+
+fn test_tcc_macos_libgc_source_accepts_official_internal_symlink() ! {
+	$if windows {
+		return
+	}
+	fixture := create_tcc_macos_libgc_test_fixture('internal_source', 'internal-source-content')!
+	defer {
+		os.rmdir_all(fixture.root) or {}
+	}
+	assert os.lstat(fixture.libgc.source)!.get_filetype() == .symbolic_link
+	assert resolve_tcc_macos_libgc_source(fixture.libgc.source)! == os.real_path(fixture.libgc.target)
+}
+
+fn test_tcc_macos_libgc_source_parent_symlink_must_remain_inside_canonical_vroot() ! {
+	$if windows {
+		return
+	}
+	root := os.join_path(os.vtmp_dir(), 'v_builder_tcc_macos_libgc_${os.getpid()}_external_parent')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root, mode: 0o700)!
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	data_base := os.join_path(root, 'persistent data root')
+	os.mkdir(data_base, mode: 0o700)!
+	lexical_vroot := os.join_path(root, 'symlinked V root, with comma')
+	lexical_tcc_dir := os.join_path(lexical_vroot, 'thirdparty', 'tcc')
+	os.mkdir_all(lexical_tcc_dir, mode: 0o700)!
+	external_lib_dir := os.join_path(root, 'external parent', 'lib')
+	os.mkdir_all(external_lib_dir, mode: 0o700)!
+	external_source := os.join_path(external_lib_dir, tcc_macos_libgc_name)
+	os.write_file(external_source, 'external-parent-content')!
+	os.chmod(external_source, 0o700)!
+	lexical_lib_dir := os.join_path(lexical_tcc_dir, 'lib')
+	os.symlink(external_lib_dir, lexical_lib_dir)!
+	lexical_source := os.join_path(lexical_lib_dir, tcc_macos_libgc_name)
+	dylib, rpath := tcc_macos_libgc_test_tokens(lexical_vroot)
+	linker_flags := [dylib]
+	pre_args := [rpath]
+	plan := plan_tcc_macos_libgc_store(lexical_vroot, linker_flags, pre_args)!
+	assert plan.required
+	assert plan.source_dylib == lexical_source
+	materialize_and_rewrite_tcc_macos_libgc_flags_at(plan, linker_flags, pre_args, data_base) or {
+		assert err.msg().contains('directory resolves outside the canonical VROOT'), err.msg()
+		assert os.lstat(lexical_lib_dir)!.get_filetype() == .symbolic_link
+		assert os.read_file(external_source)! == 'external-parent-content'
+		assert !os.exists(os.join_path(data_base, tcc_macos_libgc_store_name))
+		return
+	}
+	assert false, 'expected an external source parent symlink to fail materialization'
+}
+
+fn test_tcc_macos_libgc_copy_skips_hostile_temp_name_collisions_and_cleans_its_object() ! {
+	$if windows {
+		return
+	}
+	fixture :=
+		create_tcc_macos_libgc_test_fixture('temp_collisions', 'temporary-collision-content')!
+	defer {
+		os.rmdir_all(fixture.root) or {}
+	}
+	store := prepare_tcc_macos_libgc_test_content_store(fixture)!
+	file_collision := tcc_macos_libgc_temp_directory_path(store.content_dir, 0)
+	os.write_file(file_collision, 'preserve-file-collision')!
+	symlink_collision := tcc_macos_libgc_temp_directory_path(store.content_dir, 1)
+	symlink_target := os.join_path(fixture.root, 'preserve symlink target')
+	os.write_file(symlink_target, 'preserve-symlink-target')!
+	os.symlink(symlink_target, symlink_collision)!
+	temporary := copy_tcc_macos_libgc_to_exclusive_temp(store.resolved_source, store.content_dir,
+		store.expected)!
+	assert temporary.directory != file_collision
+	assert temporary.directory != symlink_collision
+	cleanup_tcc_macos_libgc_temporary(temporary)!
+	assert !os.exists(temporary.path)
+	assert !os.exists(temporary.directory)
+	assert os.read_file(file_collision)! == 'preserve-file-collision'
+	assert os.lstat(symlink_collision)!.get_filetype() == .symbolic_link
+	actual_symlink_target := os.readlink(symlink_collision)!
+	assert actual_symlink_target == symlink_target
+}
+
+fn test_tcc_macos_libgc_copy_error_removes_its_temporary_directory() ! {
+	$if windows {
+		return
+	}
+	fixture := create_tcc_macos_libgc_test_fixture('copy_error_cleanup',
+		'copy-error-cleanup-content')!
+	defer {
+		os.rmdir_all(fixture.root) or {}
+	}
+	store := prepare_tcc_macos_libgc_test_content_store(fixture)!
+	short_expected := TccMacosLibgcFileHash{
+		sum:  store.expected.sum
+		size: store.expected.size - 1
+	}
+	copy_tcc_macos_libgc_to_exclusive_temp(store.resolved_source, store.content_dir, short_expected) or {
+		assert err.msg().contains('grew beyond the accepted copy size'), err.msg()
+		assert os.ls(store.content_dir)! == []
+		return
+	}
+	assert false, 'expected bounded streaming copy failure to clean its temporary directory'
+}
+
+fn test_tcc_macos_libgc_post_close_hash_error_removes_its_temporary_directory() ! {
+	$if windows {
+		return
+	}
+	fixture := create_tcc_macos_libgc_test_fixture('post_close_cleanup',
+		'post-close-cleanup-content')!
+	defer {
+		os.rmdir_all(fixture.root) or {}
+	}
+	store := prepare_tcc_macos_libgc_test_content_store(fixture)!
+	wrong_expected := TccMacosLibgcFileHash{
+		sum:  '0'.repeat(64)
+		size: store.expected.size
+	}
+	copy_tcc_macos_libgc_to_exclusive_temp(store.resolved_source, store.content_dir, wrong_expected) or {
+		assert err.msg().contains('post-close validation'), err.msg()
+		assert os.ls(store.content_dir)! == []
+		return
+	}
+	assert false, 'expected post-close hash failure to clean its temporary directory'
+}
+
+fn test_tcc_macos_libgc_cleanup_propagates_rmdir_failure_after_removing_exact_file() ! {
+	$if windows {
+		return
+	}
+	fixture := create_tcc_macos_libgc_test_fixture('cleanup_error', 'cleanup-error-content')!
+	defer {
+		os.rmdir_all(fixture.root) or {}
+	}
+	store := prepare_tcc_macos_libgc_test_content_store(fixture)!
+	temporary := copy_tcc_macos_libgc_to_exclusive_temp(store.resolved_source, store.content_dir,
+		store.expected)!
+	unexpected := os.join_path(temporary.directory, 'unexpected-object')
+	os.write_file(unexpected, 'preserve-unexpected-object')!
+	cleanup_tcc_macos_libgc_temporary(temporary) or {
+		assert err.msg().contains('cannot remove macOS bundled libgc temporary directory'), err.msg()
+		assert !os.exists(temporary.path)
+		assert os.exists(temporary.directory)
+		assert os.read_file(unexpected)! == 'preserve-unexpected-object'
+		return
+	}
+	assert false, 'expected exact cleanup to propagate a non-empty directory failure'
+}
+
+fn test_tcc_macos_libgc_publication_propagates_cleanup_failure_without_removing_unknown_file() ! {
+	$if windows {
+		return
+	}
+	fixture := create_tcc_macos_libgc_test_fixture('publication_cleanup_error',
+		'publication-cleanup-error-content')!
+	defer {
+		os.rmdir_all(fixture.root) or {}
+	}
+	store := prepare_tcc_macos_libgc_test_content_store(fixture)!
+	temporary := copy_tcc_macos_libgc_to_exclusive_temp(store.resolved_source, store.content_dir,
+		store.expected)!
+	unknown := os.join_path(temporary.directory, 'unknown-sentinel')
+	os.write_file(unknown, 'preserve-unknown-sentinel')!
+	publish_tcc_macos_libgc_temporary(temporary, store.final_dylib, store.expected) or {
+		assert err.msg().contains('final object is valid, but temporary cleanup failed'), err.msg()
+		validate_tcc_macos_libgc_store_object(store.final_dylib, store.expected)!
+		assert !os.exists(temporary.path)
+		assert os.exists(temporary.directory)
+		assert os.read_file(unknown)! == 'preserve-unknown-sentinel'
+		return
+	}
+	assert false, 'expected publication to propagate exact cleanup failure'
+}
+
+fn publish_tcc_macos_libgc_concurrently(temporary TccMacosLibgcTemporaryObject, final_dylib string, expected TccMacosLibgcFileHash, start chan bool) !TccMacosLibgcPublicationResult {
+	_ := <-start
+	return publish_tcc_macos_libgc_temporary(temporary, final_dylib, expected)
+}
+
+fn test_tcc_macos_libgc_store_publication_has_one_causal_winner_and_no_temporary() ! {
+	$if windows {
+		return
+	}
+	fixture := create_tcc_macos_libgc_test_fixture('concurrent', 'concurrent-content')!
+	defer {
+		os.rmdir_all(fixture.root) or {}
+	}
+	store := prepare_tcc_macos_libgc_test_content_store(fixture)!
+	worker_count := 8
+	mut temporaries := []TccMacosLibgcTemporaryObject{cap: worker_count}
+	for _ in 0 .. worker_count {
+		temporary := copy_tcc_macos_libgc_to_exclusive_temp(store.resolved_source,
+			store.content_dir, store.expected)!
+		assert os.exists(temporary.directory)
+		assert os.exists(temporary.path)
+		temporaries << temporary
+	}
+	assert !os.exists(store.final_dylib)
+	start := chan bool{cap: worker_count}
+	mut workers := []thread !TccMacosLibgcPublicationResult{cap: worker_count}
+	for temporary in temporaries {
+		workers << spawn publish_tcc_macos_libgc_concurrently(temporary, store.final_dylib,
+			store.expected, start)
+	}
+	for _ in 0 .. worker_count {
+		start <- true
+	}
+	mut results := []TccMacosLibgcPublicationResult{cap: worker_count}
+	for worker in workers {
+		results << worker.wait()!
+	}
+	mut winners := 0
+	for result in results {
+		assert result.final_dylib == store.final_dylib
+		if result.won {
+			winners++
+		}
+	}
+	assert winners == 1
+	assert results.len - winners == worker_count - 1
+	validate_tcc_macos_libgc_store_object(store.final_dylib, store.expected)!
+	mut entries := os.ls(store.content_dir)!
+	entries.sort()
+	assert entries == [tcc_macos_libgc_name]
+	for temporary in temporaries {
+		assert !os.exists(temporary.path)
+		assert !os.exists(temporary.directory)
+	}
+}


### PR DESCRIPTION
## Summary

TinyCC can leave unresolved symbols when linking the bundled static `libgc.a` on 64-bit macOS. The published macOS TinyCC bundle now provides a paired `libgc.dylib`, but paths containing commas also require safe handling because TinyCC interprets them as linker argument separators.

## Changes

- use the paired `libgc.dylib` and its exact rpath with TinyCC on macOS arm64 and amd64
- retain the static `libgc.a` fallback for the other supported architectures
- safely materialize comma-containing libgc paths in a private, content-addressed, atomic store
- preserve unrelated rpaths and harden concurrent and untrusted-filesystem handling
- add selector, architecture, parser, concurrency and security coverage
- remove the obsolete workflow-only selector patch

## Validation

- formatting and vet checks pass
- the targeted selector tests pass
- all 44 comma-path store tests pass
- the five-architecture selection matrix passes
- a native macOS Intel end-to-end smoke passes with TinyCC and Boehm GC
- the resulting binary loads exactly one `@rpath/libgc.dylib`, uses the expected rpath, runs successfully and does not fall back to another compiler