### PR TITLE
v3: speed up self-host compiler stages

### DIFF
--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -28,6 +28,17 @@ const c_common_c_attributes = ['alias', 'aligned', 'always_inline', 'cold', 'con
 const c_has_attribute_predicate = '__has_attribute'
 const c_has_attribute_override_key = '@function:__has_attribute'
 
+// c_short_name_view returns the suffix after the final dot without allocating.
+@[direct_array_access; inline]
+fn c_short_name_view(name string) string {
+	for i := name.len - 1; i >= 0; i-- {
+		if name[i] == `.` {
+			return unsafe { name.substr_unsafe(i + 1, name.len) }
+		}
+	}
+	return name
+}
+
 fn manual_stdlib_c_headers() string {
 	start := v1_c_headers_source.index('// c_headers\n') or { return '' }
 	relative_end := v1_c_headers_source[start..].index('static void v_stable_sort') or { return '' }
@@ -431,10 +442,11 @@ mut:
 	// Set while selected items' C-extern refs still have to be collected: the
 	// fused prep walk defers them to the parallel exact-cost pass, which falls
 	// back to a serial top-up when it cannot run.
-	prep_externs_pending bool
-	prep_costs_pending   bool
-	prep_typ_text_cache  &PrepTypTextCache = unsafe { nil }
-	preseed_type_seen    &PreseedTypeSeen  = unsafe { nil }
+	prep_externs_pending   bool
+	prep_costs_pending     bool
+	prep_typ_text_cache    &PrepTypTextCache = unsafe { nil }
+	prep_alias_short_names map[string]bool
+	preseed_type_seen      &PreseedTypeSeen = unsafe { nil }
 	// Separate seen-cache for the declaration preseed family
 	// (preseed_fn_ptr_type has optional-typedef side effects the body-walk
 	// preseed does not); armed only for the contiguous pre-dispatch preseed
@@ -8794,7 +8806,7 @@ fn (mut g FlatGen) register_fn_decl_signature_type(name string, full_name string
 	if is_variadic {
 		g.fn_decl_variadic[module_key] = true
 	}
-	short_name := name.all_after_last('.')
+	short_name := c_short_name_view(name)
 	g.fn_decl_variadic_short_counts[short_name] = g.fn_decl_variadic_short_counts[short_name] + 1
 	for flag in shared_params {
 		if flag {
@@ -8822,7 +8834,7 @@ fn (mut g FlatGen) register_fn_decl_node(name string, module_name string, id fla
 	if name !in g.fn_decl_nodes_by_name {
 		g.fn_decl_nodes_by_name[name] = id
 	}
-	short := name.all_after_last('.')
+	short := c_short_name_view(name)
 	if short !in g.fn_decl_nodes_by_short {
 		g.fn_decl_nodes_by_short[short] = id
 	}
@@ -11355,12 +11367,21 @@ fn (g &FlatGen) const_ref_name_from_node_cached_for_collect(node flat.Node, uniq
 	return ''
 }
 
+@[direct_array_access]
 fn (g &FlatGen) fixed_storage_candidate_short_name(name string) string {
-	dot := name.last_index_u8(`.`)
-	if dot >= 0 {
-		return unsafe { name.substr_unsafe(dot + 1, name.len) }
+	mut sep := -1
+	mut i := name.len - 1
+	for i >= 0 {
+		if name[i] == `.` {
+			return unsafe { name.substr_unsafe(i + 1, name.len) }
+		}
+		if sep < 0 && i > 0 && name[i] == `_` && name[i - 1] == `_` {
+			sep = i - 1
+			i--
+		}
+		i--
 	}
-	if sep := name.last_index('__') {
+	if sep >= 0 {
 		return unsafe { name.substr_unsafe(sep + 2, name.len) }
 	}
 	return name
@@ -11389,21 +11410,48 @@ fn (mut g FlatGen) collect_fixed_storage_const_candidates(mut candidates map[str
 	}
 }
 
-fn (g &FlatGen) const_ref_node_may_match_fixed_candidate(node &flat.Node, ident_refs map[string]bool, shorts map[string]bool) bool {
+struct FixedStorageCandidateNameFilter {
+mut:
+	lengths_by_initial [256]u64
+}
+
+@[direct_array_access]
+fn fixed_storage_candidate_name_filter(names map[string]bool) FixedStorageCandidateNameFilter {
+	mut filter := FixedStorageCandidateNameFilter{}
+	for name, _ in names {
+		if name.len == 0 {
+			continue
+		}
+		length_bit := if name.len < 63 { name.len } else { 63 }
+		filter.lengths_by_initial[name[0]] |= u64(1) << length_bit
+	}
+	return filter
+}
+
+@[direct_array_access; inline]
+fn (filter &FixedStorageCandidateNameFilter) may_match(name string) bool {
+	if name.len == 0 {
+		return false
+	}
+	length_bit := if name.len < 63 { name.len } else { 63 }
+	return filter.lengths_by_initial[name[0]] & (u64(1) << length_bit) != 0
+}
+
+fn (g &FlatGen) const_ref_node_may_match_fixed_candidate(node &flat.Node, ident_refs map[string]bool, shorts map[string]bool, ident_filter &FixedStorageCandidateNameFilter, short_filter &FixedStorageCandidateNameFilter) bool {
 	if node.kind == .paren {
 		if node.children_count == 0 {
 			return false
 		}
 		return g.const_ref_node_may_match_fixed_candidate(g.a.child_node(node, 0), ident_refs,
-			shorts)
+			shorts, ident_filter, short_filter)
 	}
 	if node.kind == .ident {
-		if node.value in ident_refs {
+		if ident_filter.may_match(node.value) && node.value in ident_refs {
 			return true
 		}
 		short_name := g.fixed_storage_candidate_short_name(node.value)
 		if short_name.len != node.value.len {
-			return short_name in shorts
+			return short_filter.may_match(short_name) && short_name in shorts
 		}
 		return false
 	}
@@ -11411,7 +11459,7 @@ fn (g &FlatGen) const_ref_node_may_match_fixed_candidate(node &flat.Node, ident_
 		if node.children_count == 0 {
 			return false
 		}
-		if node.value !in shorts {
+		if !short_filter.may_match(node.value) || node.value !in shorts {
 			return false
 		}
 		base := g.a.child_node(node, 0)
@@ -11498,6 +11546,8 @@ fn (mut g FlatGen) collect_fixed_storage_consts() {
 	for short_name, _ in fixed_candidate_shorts {
 		fixed_candidate_idents[short_name] = true
 	}
+	fixed_candidate_ident_filter := fixed_storage_candidate_name_filter(fixed_candidate_idents)
+	fixed_candidate_short_filter := fixed_storage_candidate_name_filter(fixed_candidate_shorts)
 	for idx := 0; idx < g.a.nodes.len; idx++ {
 		node := unsafe { &g.a.nodes[idx] }
 		kind_id := int(node.kind)
@@ -11534,7 +11584,8 @@ fn (mut g FlatGen) collect_fixed_storage_consts() {
 				base_id := g.a.child(node, 0)
 				base_node := g.a.node(base_id)
 				if g.const_ref_node_may_match_fixed_candidate(base_node, fixed_candidate_idents,
-					fixed_candidate_shorts)
+					fixed_candidate_shorts, &fixed_candidate_ident_filter,
+					&fixed_candidate_short_filter)
 				{
 					g.mark_const_ref_descendants(mut fixed_safe_refs, base_id)
 					index_base_items << FixedStorageConstRefItem{
@@ -11549,13 +11600,15 @@ fn (mut g FlatGen) collect_fixed_storage_consts() {
 					base_id := g.a.child(node, 0)
 					base_node := g.a.node(base_id)
 					if g.const_ref_node_may_match_fixed_candidate(base_node,
-						fixed_candidate_idents, fixed_candidate_shorts)
+						fixed_candidate_idents, fixed_candidate_shorts,
+						&fixed_candidate_ident_filter, &fixed_candidate_short_filter)
 					{
 						g.mark_const_ref_descendants(mut fixed_safe_refs, base_id)
 					}
 				}
 				if g.const_ref_node_may_match_fixed_candidate(node, fixed_candidate_idents,
-					fixed_candidate_shorts)
+					fixed_candidate_shorts, &fixed_candidate_ident_filter,
+					&fixed_candidate_short_filter)
 				{
 					ref_items << FixedStorageConstRefItem{
 						id:     flat.NodeId(idx)
@@ -11573,7 +11626,8 @@ fn (mut g FlatGen) collect_fixed_storage_consts() {
 					base_id := g.a.child(fn_node, 0)
 					base_node := g.a.node(base_id)
 					if g.const_ref_node_may_match_fixed_candidate(base_node,
-						fixed_candidate_idents, fixed_candidate_shorts)
+						fixed_candidate_idents, fixed_candidate_shorts,
+						&fixed_candidate_ident_filter, &fixed_candidate_short_filter)
 					{
 						call_base_items << FixedStorageConstRefItem{
 							id:     base_id
@@ -11590,7 +11644,8 @@ fn (mut g FlatGen) collect_fixed_storage_consts() {
 					arg_id := g.a.child(node, ai)
 					arg_node := g.a.node(arg_id)
 					if g.const_ref_node_may_match_fixed_candidate(arg_node, fixed_candidate_idents,
-						fixed_candidate_shorts)
+						fixed_candidate_shorts, &fixed_candidate_ident_filter,
+						&fixed_candidate_short_filter)
 					{
 						call_base_items << FixedStorageConstRefItem{
 							id:     arg_id
@@ -11602,7 +11657,8 @@ fn (mut g FlatGen) collect_fixed_storage_consts() {
 			}
 			.ident, .paren {
 				if g.const_ref_node_may_match_fixed_candidate(node, fixed_candidate_idents,
-					fixed_candidate_shorts)
+					fixed_candidate_shorts, &fixed_candidate_ident_filter,
+					&fixed_candidate_short_filter)
 				{
 					ref_items << FixedStorageConstRefItem{
 						id:     flat.NodeId(idx)

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -1133,11 +1133,12 @@ fn (g &FlatGen) enum_method_c_name_in_module_uncached(module_name string, name s
 	} else {
 		name
 	}
-	receiver := qualified.all_before_last('.')
-	method := qualified.all_after_last('.')
-	if receiver.len == 0 || method.len == 0 {
+	dot := qualified.last_index_u8(`.`)
+	if dot <= 0 || dot + 1 >= qualified.len {
 		return none
 	}
+	receiver := unsafe { qualified.substr_unsafe(0, dot) }
+	method := unsafe { qualified.substr_unsafe(dot + 1, qualified.len) }
 	if _ := g.enum_selector_base_name(receiver) {
 		return '${g.cname(receiver)}_${g.cname(method)}'
 	}
@@ -6634,9 +6635,10 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 			// handler's context in that slot so the remaining explicit arguments
 			// still line up with their parameters.
 			expected_non_ctx := if is_method { param_types.len - 1 } else { param_types.len }
-			current_ctx_name := g.cur_veb_ctx_name() or { '' }
-			forward_ctx := param_types.len > 1 && g.is_implicit_veb_ctx_param(param_types[1])
-				&& num_call_args < expected_non_ctx && current_ctx_name.len > 0
+			may_forward_ctx := param_types.len > 1 && num_call_args < expected_non_ctx
+				&& g.is_implicit_veb_ctx_param(param_types[1])
+			mut current_ctx_name := if may_forward_ctx { g.cur_veb_ctx_name() or { '' } } else { '' }
+			forward_ctx := may_forward_ctx && current_ctx_name.len > 0
 			if forward_ctx && is_method {
 				g.write(', ${g.cname(current_ctx_name)}')
 			}
@@ -6960,7 +6962,11 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 					}
 					// The implicit veb `Context` parameter is supplied from the
 					// enclosing handler's context, not a zero/default value.
-					if g.is_implicit_veb_ctx_param(pt) && current_ctx_name.len > 0 {
+					implicit_ctx := g.is_implicit_veb_ctx_param(pt)
+					if implicit_ctx && current_ctx_name.len == 0 {
+						current_ctx_name = g.cur_veb_ctx_name() or { '' }
+					}
+					if implicit_ctx && current_ctx_name.len > 0 {
 						g.write(g.cname(current_ctx_name))
 					} else {
 						g.gen_default_value_for_type(pt)
@@ -9843,8 +9849,8 @@ fn resolved_call_matches_target(resolved string, target string) bool {
 	if resolved == target || c_name(resolved) == target || resolved == c_name(target) {
 		return true
 	}
-	resolved_short := resolved.all_after_last('.')
-	target_short := target.all_after_last('.')
+	resolved_short := c_short_name_view(resolved)
+	target_short := c_short_name_view(target)
 	return resolved_short == target_short || c_name(resolved_short) == target_short
 		|| resolved_short == c_name(target_short)
 }
@@ -13047,9 +13053,10 @@ fn (mut g FlatGen) gen_transformed_method_ident_call(id flat.NodeId, node flat.N
 			g.write('})[0]')
 		}
 	}
-	current_ctx_name := g.cur_veb_ctx_name() or { '' }
-	forward_ctx := params.len > 1 && g.is_implicit_veb_ctx_param(params[1])
-		&& node.children_count - 1 < params.len && current_ctx_name.len > 0
+	may_forward_ctx := params.len > 1 && node.children_count - 1 < params.len
+		&& g.is_implicit_veb_ctx_param(params[1])
+	current_ctx_name := if may_forward_ctx { g.cur_veb_ctx_name() or { '' } } else { '' }
+	forward_ctx := may_forward_ctx && current_ctx_name.len > 0
 	if forward_ctx {
 		g.write(', ${g.cname(current_ctx_name)}')
 	}
@@ -13075,14 +13082,19 @@ fn (mut g FlatGen) gen_ierror_str_arg(fn_name string, callee_name string, arg_id
 	if arg_idx != 0 {
 		return false
 	}
-	arg_type := g.usable_expr_type(arg_id)
-	clean_type := types.unwrap_pointer(arg_type)
-	if !g.is_ierror_type_name(clean_type.name()) {
+	// C-name sanitization cannot turn an unrelated name into `IError__str`.
+	// Reject virtually every call before probing the generator's name cache.
+	if fn_name != 'str' && !fn_name.contains('IError') && !callee_name.contains('IError') {
 		return false
 	}
 	is_ierror_str := g.cname(fn_name) == 'IError__str' || g.cname(callee_name) == 'IError__str'
 		|| fn_name == 'IError.str' || callee_name == 'IError.str'
 	if !is_ierror_str && fn_name != 'str' {
+		return false
+	}
+	arg_type := g.usable_expr_type(arg_id)
+	clean_type := types.unwrap_pointer(arg_type)
+	if !g.is_ierror_type_name(clean_type.name()) {
 		return false
 	}
 	arg_node := g.a.nodes[int(arg_id)]

--- a/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
@@ -13,7 +13,7 @@ const max_flat_cgen_jobs = 10
 const min_flat_cgen_parallel_items = 128
 // Bound each worker's retained scratch while generating compiler-sized ASTs.
 const scoped_cgen_worker_batches = 32
-const flat_cgen_chunks_per_job = 12
+const flat_cgen_chunks_per_job = 24
 
 $if !windows {
 	// FlatCgenChunkArgs represents flat cgen chunk args data used by c.
@@ -212,6 +212,11 @@ fn (mut g FlatGen) refine_fn_item_costs(no_parallel bool, reserve_worker bool) {
 		fused := g.prep_costs_pending
 		mut prep_g := unsafe { nil }
 		if fused {
+			if g.prep_alias_short_names.len == 0 {
+				for name, _ in g.tc.type_aliases {
+					g.prep_alias_short_names[name.all_after_last('.')] = true
+				}
+			}
 			prep_g = voidptr(g)
 		}
 		mut args := []FlatCgenCostArgs{cap: n_jobs}
@@ -1290,7 +1295,7 @@ fn exact_flat_fn_gen_item_cost_and_prep(g &FlatGen, node_id flat.NodeId, item_id
 				}
 			}
 		}
-		if node.typ.len > 0 {
+		if parallel_type_text_may_preseed(g, node.typ) {
 			slot := int((u64(voidptr(node.typ.str)) >> 4) & 4095)
 			if text_cache.gens[slot] != text_cache.generation
 				|| text_cache.ptrs[slot] != voidptr(node.typ.str)
@@ -1325,6 +1330,66 @@ fn exact_flat_fn_gen_item_cost_and_prep(g &FlatGen, node_id flat.NodeId, item_id
 		}
 	}
 	return cost, needs_prelude_scan
+}
+
+// parallel_type_text_may_preseed cheaply rejects builtin/container type text
+// before the exact-cost workers retain it for the ordered alias/fn-type replay.
+// V alias declarations are capitalized; literal callback types are the only
+// lowercase text that can require a function-pointer preseed.
+fn parallel_type_text_may_preseed(g &FlatGen, typ string) bool {
+	if typ.len == 0 {
+		return false
+	}
+	mut start := 0
+	for start < typ.len {
+		for start < typ.len && typ[start] in [` `, `\t`, `\n`, `\r`] {
+			start++
+		}
+		if start + 7 <= typ.len && typ[start] == `s` && typ[start + 1] == `h`
+			&& typ[start + 2] == `a` && typ[start + 3] == `r` && typ[start + 4] == `e`
+			&& typ[start + 5] == `d` && typ[start + 6] == ` ` {
+			start += 7
+			continue
+		}
+		if start + 3 <= typ.len && typ[start] == `.` && typ[start + 1] == `.`
+			&& typ[start + 2] == `.` {
+			start += 3
+			continue
+		}
+		if start + 2 <= typ.len && typ[start] == `[` && typ[start + 1] == `]` {
+			start += 2
+			continue
+		}
+		if start < typ.len && typ[start] in [`&`, `?`, `!`] {
+			start++
+			continue
+		}
+		break
+	}
+	if start >= typ.len {
+		return false
+	}
+	if start + 1 < typ.len && typ[start] == `f` && typ[start + 1] == `n` {
+		return true
+	}
+	mut name_start := start
+	for i := start; i < typ.len; i++ {
+		if typ[i] == `.` {
+			name_start = i + 1
+		}
+	}
+	if name_start >= typ.len || !typ[name_start].is_capital() {
+		return false
+	}
+	mut end := typ.len
+	for end > name_start && typ[end - 1] in [` `, `\t`, `\n`, `\r`] {
+		end--
+	}
+	if end <= name_start {
+		return false
+	}
+	short := unsafe { tos(typ.str + name_start, end - name_start) }
+	return short in g.prep_alias_short_names
 }
 
 @[inline]

--- a/vlib/v3/gen/c/interface.v
+++ b/vlib/v3/gen/c/interface.v
@@ -418,7 +418,7 @@ fn (g &FlatGen) resolve_sum_name(sum_name string) string {
 		return resolved
 	}
 	if sum_name.contains('.') {
-		if resolved := g.sum_name_lookup[sum_name.all_after_last('.')] {
+		if resolved := g.sum_name_lookup[c_short_name_view(sum_name)] {
 			return resolved
 		}
 	}
@@ -429,7 +429,7 @@ fn (mut g FlatGen) precompute_sum_name_lookup() {
 	g.sum_name_lookup = map[string]string{}
 	for name, _ in g.tc.sum_types {
 		g.sum_name_lookup[name] = name
-		short := name.all_after_last('.')
+		short := c_short_name_view(name)
 		if short.len > 0 && short !in g.sum_name_lookup {
 			g.sum_name_lookup[short] = name
 		}

--- a/vlib/v3/markused/markused.v
+++ b/vlib/v3/markused/markused.v
@@ -281,8 +281,9 @@ fn mark_used_with_test_files(a &flat.FlatAst, tc &types.TypeChecker, test_files 
 			continue
 		}
 		if node.kind == .fn_decl || node.kind == .c_fn_decl {
-			fn_decl_file := tc.fn_type_files[node.value] or { decl_file }
-			fn_decl_module := tc.fn_type_modules[node.value] or { decl_module }
+			decl_qname := qualify_fn(decl_module, node.value)
+			fn_decl_file := tc.fn_type_files[decl_qname] or { decl_file }
+			fn_decl_module := tc.fn_type_modules[decl_qname] or { decl_module }
 			fn_decl_import_context := import_context_by_file[fn_decl_file] or {
 				decl_import_context
 			}

--- a/vlib/v3/tests/markused_test.v
+++ b/vlib/v3/tests/markused_test.v
@@ -224,6 +224,43 @@ pub fn make() Box {
 	assert uses_generics
 }
 
+fn test_module_function_owner_uses_qualified_declaration_key() {
+	a, tc := parse_checked_project_in_order('qualified_function_owner', [
+		'main/main.v',
+		'builtin/compat.v',
+		'support/support.v',
+	], [
+		'module main
+
+import support
+
+fn main() {
+	_ := support.decode()
+}
+',
+		'module builtin
+
+fn decode() int {
+	return 0
+}
+',
+		'module support
+
+pub fn decode() int {
+	return helper()
+}
+
+fn helper() int {
+	return 1
+}
+',
+	])
+	used := markused.mark_used_without_generic_detection(a, tc)
+	assert used['support.decode']
+	assert used['support.helper']
+	assert !used['builtin.decode']
+}
+
 // test_eager_markused_import_alias_context_is_file_local covers the eager,
 // parallel-capable body precollection path with the same per-file alias reuse.
 fn test_eager_markused_import_alias_context_is_file_local() {

--- a/vlib/v3/transform/expr.v
+++ b/vlib/v3/transform/expr.v
@@ -3650,7 +3650,7 @@ fn (t &Transformer) enum_type_name_for_expected(expected_enum string, owner_mod 
 	}
 	mut found := ''
 	for enum_name, _ in t.enum_types {
-		if enum_name.all_after_last('.') != clean {
+		if short_name_view(enum_name) != clean {
 			continue
 		}
 		if found.len > 0 && found != enum_name {

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -426,7 +426,7 @@ fn (t &Transformer) resolve_receiver_method_for_type_uncached(receiver_type stri
 			mut matched := ''
 			for sname, _ in t.tc.structs {
 				if !sname.contains('.') || sname.contains('[')
-					|| sname.all_after_last('.') != clean_type {
+					|| short_name_view(sname) != clean_type {
 					continue
 				}
 				qmethod := '${sname}.${method}'
@@ -1542,7 +1542,7 @@ fn (t &Transformer) call_name_for_node(id flat.NodeId, node flat.Node) string {
 			if node.children_count > 0 && t.cur_module.len > 0
 				&& t.cur_module !in ['main', 'builtin'] {
 				fn_node := t.a.child_node(&node, 0)
-				short_name := name.all_after_last('.')
+				short_name := short_name_view(name)
 				if fn_node.kind == .ident && fn_node.value == short_name {
 					qname := '${t.cur_module}.${short_name}'
 					lowered_qname := c_name(qname)
@@ -1686,7 +1686,7 @@ fn (t &Transformer) selector_call_name_has_receiver_param(call_name string, meth
 	clean_receiver := if receiver.starts_with('&') { receiver[1..] } else { receiver }
 	if receiver_param_types_match(clean_first, clean_receiver)
 		|| t.normalize_type_alias(clean_first) == t.normalize_type_alias(clean_receiver)
-		|| clean_first.all_after_last('.') == clean_receiver.all_after_last('.') {
+		|| short_name_view(clean_first) == short_name_view(clean_receiver) {
 		return true
 	}
 	return false
@@ -2839,7 +2839,7 @@ fn (t &Transformer) pointer_global_arg_matches_param(name string, param_type str
 	}
 	param_base := t.normalize_type_alias(param_type[1..])
 	arg_base := t.normalize_type_alias(arg_type[1..])
-	return param_base == arg_base || param_base.all_after_last('.') == arg_base.all_after_last('.')
+	return param_base == arg_base || short_name_view(param_base) == short_name_view(arg_base)
 }
 
 fn (t &Transformer) global_ident_type(name string) ?string {
@@ -4237,7 +4237,7 @@ fn (t &Transformer) enum_autostr_type_name(typ string) string {
 			}
 		}
 	}
-	short_name := qualified.all_after_last('.')
+	short_name := short_name_view(qualified)
 	if qualified !in t.enum_types && short_name in t.enum_types {
 		return short_name
 	}
@@ -4263,7 +4263,7 @@ fn (mut t Transformer) wrap_string_conversion(expr flat.NodeId, typ string) flat
 		clean_typ = clean_typ[7..].trim_space()
 	}
 	if clean_typ.starts_with('builtin.') {
-		clean_typ = clean_typ.all_after_last('.')
+		clean_typ = clean_typ['builtin.'.len..]
 	}
 	if source_typ := t.source_type_name_from_c_name(clean_typ) {
 		return t.wrap_string_conversion(expr, source_typ)
@@ -4314,7 +4314,7 @@ fn (mut t Transformer) wrap_string_conversion(expr flat.NodeId, typ string) flat
 		}
 		if !clean_typ.contains('.') && !local_struct_shadows_alias {
 			for aname, target in t.tc.type_aliases {
-				if aname.all_after_last('.') == clean_typ {
+				if short_name_view(aname) == clean_typ {
 					return t.alias_str_wrap(expr, clean_typ, target, is_ref)
 				}
 			}
@@ -5112,14 +5112,14 @@ fn (mut t Transformer) alias_str_wrap(expr flat.NodeId, alias_name string, base_
 
 fn (t &Transformer) is_fn_stringify_type(typ string) bool {
 	clean := typ.trim_space()
-	short := clean.all_after_last('.')
+	short := short_name_view(clean)
 	return clean.starts_with('fn(') || clean.starts_with('fn (') || clean.starts_with('_fn_ptr_')
 		|| short.starts_with('_fn_ptr_') || t.is_fn_pointer_type_name(clean)
 }
 
 fn (t &Transformer) fn_stringify_display(typ string) string {
 	clean := typ.trim_space()
-	if clean.starts_with('_fn_ptr_') || clean.all_after_last('.').starts_with('_fn_ptr_') {
+	if clean.starts_with('_fn_ptr_') || short_name_view(clean).starts_with('_fn_ptr_') {
 		return 'fn'
 	}
 	if !isnil(t.tc) {
@@ -11519,7 +11519,7 @@ fn (t &Transformer) receiver_method_name_is_open_generic(method_name string) boo
 		}
 	}
 	if method_name.contains('.') {
-		receiver := method_name.all_before_last('.')
+		receiver := owner_name_view(method_name)
 		if collection_receiver := receiver_collection_method_type(receiver) {
 			return t.generic_arg_is_unresolved_collection_type(collection_receiver)
 		}
@@ -11656,7 +11656,7 @@ fn (t &Transformer) resolved_call_uses_receiver_type(base_id flat.NodeId, receiv
 // receiver_base_for_resolved_method
 // supports helper handling in transform.
 fn (mut t Transformer) receiver_base_for_resolved_method(base_id flat.NodeId, method_name string) flat.NodeId {
-	method_receiver := t.trim_pointer_type(method_name.all_before_last('.'))
+	method_receiver := t.trim_pointer_type(owner_name_view(method_name))
 	key := t.expr_key(base_id)
 	for source_type in [t.raw_var_type_for_expr(base_id) or { '' },
 		t.original_expr_type(base_id), t.node_type(base_id)] {
@@ -12741,7 +12741,7 @@ fn (t &Transformer) receiver_method_param_offset(base_id flat.NodeId, node flat.
 	if receiver_param_types_match(clean_first, clean_base)
 		|| receiver_param_matches_method_name(clean_first, method_name)
 		|| t.normalize_type_alias(clean_first) == t.normalize_type_alias(clean_base)
-		|| clean_first.all_after_last('.') == clean_base.all_after_last('.') {
+		|| short_name_view(clean_first) == short_name_view(clean_base) {
 		return 1
 	}
 	if params.len >= int(node.children_count) {
@@ -12771,8 +12771,8 @@ fn receiver_param_matches_method_name(first string, method_name string) bool {
 	if receiver_is_generic {
 		receiver_base = receiver_generic_base
 	}
-	first_short := first_base.all_after_last('.')
-	receiver_short := receiver_base.all_after_last('.')
+	first_short := short_name_view(first_base)
+	receiver_short := short_name_view(receiver_base)
 	return first_base == receiver_base || first_short == receiver_short
 		|| receiver_short.starts_with('${first_short}_')
 		|| c_name(receiver_base).starts_with('${c_name(first_base)}_')

--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -3169,6 +3169,9 @@ fn (mut t Transformer) monomorphize_ignored_nodes(decls map[string]GenericFnDecl
 }
 
 fn (mut t Transformer) ensure_node_module_map() {
+	if t.node_context_read_only {
+		return
+	}
 	if t.node_module_map_nodes == t.a.nodes.len {
 		return
 	}
@@ -3208,6 +3211,9 @@ fn (mut t Transformer) ensure_node_module_map() {
 }
 
 fn (mut t Transformer) ensure_node_context_map_capacity() {
+	if t.node_context_read_only {
+		return
+	}
 	if t.node_module_map_cache.len < t.a.nodes.len {
 		t.node_module_map_cache.ensure_cap(t.a.nodes.cap)
 		t.node_module_map_cache << []string{len: t.a.nodes.len - t.node_module_map_cache.len}
@@ -3239,6 +3245,9 @@ fn (t &Transformer) node_module_or(idx int, fallback string) string {
 }
 
 fn (mut t Transformer) mark_node_context(id flat.NodeId, module_name string, file_name string) {
+	if t.node_context_read_only {
+		return
+	}
 	t.node_context_stack.clear()
 	t.node_context_stack << id
 	for t.node_context_stack.len > 0 {
@@ -7210,25 +7219,6 @@ fn (mut t Transformer) build_generic_alias_name_index() {
 	t.generic_alias_names = names.move()
 }
 
-@[direct_array_access]
-fn (mut t Transformer) build_local_decl_index() {
-	mut decls := map[string][]int{}
-	for idx, node in t.a.nodes {
-		if node.kind != .decl_assign || node.children_count < 2 {
-			continue
-		}
-		lhs_id := t.a.child(&node, 0)
-		if int(lhs_id) < 0 || int(lhs_id) >= t.a.nodes.len {
-			continue
-		}
-		lhs := t.a.nodes[int(lhs_id)]
-		if lhs.kind == .ident && lhs.value.len > 0 {
-			decls[lhs.value] << idx
-		}
-	}
-	t.local_decl_nodes_by_name = decls.move()
-}
-
 fn (t &Transformer) generic_arg_is_alias_name(arg string, module_name string) bool {
 	clean := arg.trim_space()
 	if clean.len == 0 || isnil(t.tc) {
@@ -9789,7 +9779,7 @@ fn (t &Transformer) fn_decl_receiver_is_open_generic(node flat.Node, module_name
 	if !node.value.contains('.') || isnil(t.tc) {
 		return false
 	}
-	receiver := node.value.all_before_last('.')
+	receiver := owner_name_view(node.value)
 	base, args, ok := generic_app_parts(receiver)
 	if !ok || args.len == 0 {
 		return false

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -45,6 +45,27 @@ fn node_kind_id(node flat.Node) int {
 	return int(node.kind)
 }
 
+// short_name_view returns the suffix after the final dot without allocating.
+@[direct_array_access; inline]
+fn short_name_view(name string) string {
+	for i := name.len - 1; i >= 0; i-- {
+		if name[i] == `.` {
+			return unsafe { name.substr_unsafe(i + 1, name.len) }
+		}
+	}
+	return name
+}
+
+@[direct_array_access; inline]
+fn owner_name_view(name string) string {
+	for i := name.len - 1; i >= 0; i-- {
+		if name[i] == `.` {
+			return unsafe { name.substr_unsafe(0, i) }
+		}
+	}
+	return name
+}
+
 // option_unwrap_marker tags a SmartcastContext produced by an `x != none`
 // condition: variant_name holds the option's base type and the access is
 // lowered to the option's `.value` field instead of a sum union field.
@@ -132,6 +153,7 @@ mut:
 	variadic_suffix_index         map[string]i8
 	const_suffixes                map[string]string
 	source_parent_ids             []int
+	shared_local_decl_names       map[string]bool
 	// const_array_fixed_storage_cache avoids rescanning the complete AST for
 	// repeated uses of the same array constant in one transform worker.
 	const_array_fixed_storage_cache map[string]i8
@@ -200,6 +222,7 @@ mut:
 	call_variadic_cache             &BoolLookupCache         = unsafe { nil }
 	str_alias_cache                 &LookupCache             = unsafe { nil }
 	generic_alias_names             map[string]bool
+	type_alias_suffixes             map[string]string
 	local_decl_nodes_by_name        map[string][]int
 	struct_field_decl_metas_cache   map[string]map[string]FieldDeclMeta
 	comptime_field_metas_cache      map[string][]FieldMeta
@@ -341,6 +364,7 @@ mut:
 	node_module_map_cache              []string
 	node_file_map_cache                []string
 	node_module_map_nodes              int = -1
+	node_context_read_only             bool
 	// used_fns_log records names newly inserted into used_fns while the
 	// late-used-fn-bodies pass runs, so that pass can tell "was this name
 	// already used before the current body's transform" without cloning the
@@ -1336,7 +1360,7 @@ fn (mut t Transformer) prepare() {
 	t.rebuild_receiver_method_suffix_index()
 	t.rebuild_variadic_suffix_index()
 	t.build_generic_alias_name_index()
-	t.build_local_decl_index()
+	t.build_type_alias_suffix_index()
 	t.build_struct_field_decl_metas_cache()
 	t.timing_profile('  [ttime]   prep suffix+decl   ${f64(psw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 	psw.restart()
@@ -2638,6 +2662,7 @@ struct DeferredBaseWrite {
 // Returns whether function bodies were actually transformed in parallel.
 fn (mut t Transformer) transform_all_dispatch(want_parallel bool) bool {
 	t.collect_exclusive_closure_return_fns()
+	t.precompute_const_array_fixed_storage()
 	// Every forked worker checker otherwise lazily rebuilds the source-error
 	// embedding index by rescanning all struct declarations; build it once in
 	// the master cache so forks inherit it through the frozen base.
@@ -3064,8 +3089,15 @@ fn (t &Transformer) fork_worker_config(ast &flat.FlatAst, wtc &types.TypeChecker
 	// start. Keep the shared read-only index and signature cache; rebuilding
 	// either would read fn_decl nodes while shared-base workers rewrite them.
 	// Misses stay private because unknown call names can still be queried.
-	w.node_module_map_cache = []string{}
-	w.node_module_map_nodes = -1
+	if t.node_context_read_only {
+		w.node_module_map_cache = t.node_module_map_cache
+		w.node_file_map_cache = t.node_file_map_cache
+		w.node_module_map_nodes = t.node_module_map_nodes
+		w.node_context_read_only = true
+	} else {
+		w.node_module_map_cache = []string{}
+		w.node_module_map_nodes = -1
+	}
 	w.var_types = []VarTypeBinding{}
 	w.var_type_indices = map[string]int{}
 	w.refined_node_types = t.refined_node_types.clone()
@@ -3248,11 +3280,13 @@ fn (t &Transformer) fork_program_view(ast &flat.FlatAst, wtc &types.TypeChecker,
 		variadic_suffix_index:           t.variadic_suffix_index
 		const_suffixes:                  t.const_suffixes
 		source_parent_ids:               t.source_parent_ids
-		const_array_fixed_storage_cache: map[string]i8{}
+		shared_local_decl_names:         t.shared_local_decl_names
+		const_array_fixed_storage_cache: t.const_array_fixed_storage_cache
 		enum_types:                      t.enum_types
 		enum_backing_types:              t.enum_backing_types
 		runtime_type_indexes:            t.runtime_type_indexes
 		generic_alias_names:             t.generic_alias_names
+		type_alias_suffixes:             t.type_alias_suffixes
 		local_decl_nodes_by_name:        t.local_decl_nodes_by_name
 		struct_field_decl_metas_cache:   t.struct_field_decl_metas_cache
 		comptime_field_metas_cache:      map[string][]FieldMeta{}
@@ -3331,6 +3365,7 @@ fn (t &Transformer) fork_program_view(ast &flat.FlatAst, wtc &types.TypeChecker,
 		retain_worker_results:              t.retain_worker_results
 		stage_scope:                        t.stage_scope
 		scoped_monomorphize:                t.scoped_monomorphize
+		node_context_read_only:             t.node_context_read_only
 	}
 }
 
@@ -7703,9 +7738,18 @@ fn (t &Transformer) fn_return_type_for_name(name string) ?string {
 // transform_stmts transforms transform stmts data for transform.
 pub fn (mut t Transformer) transform_stmts(ids []flat.NodeId) []flat.NodeId {
 	mut result := []flat.NodeId{cap: ids.len}
-	base_smartcasts := t.smartcast_stack.clone()
+	had_base_smartcasts := t.smartcast_stack.len > 0
+	base_smartcasts := if had_base_smartcasts {
+		t.smartcast_stack.clone()
+	} else {
+		t.smartcast_stack
+	}
 	defer {
-		t.smartcast_stack = t.non_invalidated_smartcasts(base_smartcasts)
+		if had_base_smartcasts {
+			t.smartcast_stack = t.non_invalidated_smartcasts(base_smartcasts)
+		} else {
+			t.smartcast_stack.clear()
+		}
 	}
 	mut i := 0
 	for i < ids.len {
@@ -9599,6 +9643,144 @@ fn (mut t Transformer) const_array_literal_requires_fixed_storage(key string) bo
 	result := t.const_array_literal_requires_fixed_storage_uncached(key)
 	t.const_array_fixed_storage_cache[key] = if result { i8(1) } else { i8(-1) }
 	return result
+}
+
+// precompute_const_array_fixed_storage classifies every array-literal constant
+// in one AST pass. The parallel transform used to run the complete scan below
+// once per constant and per worker batch, putting a multi-millisecond lazy
+// initialization cost on otherwise tiny function bodies.
+fn (mut t Transformer) precompute_const_array_fixed_storage() {
+	if isnil(t.tc) {
+		return
+	}
+	mut candidate_ids := map[string]int{}
+	mut candidate_names := map[string]bool{}
+	mut candidate_keys := []string{}
+	for key, expr_id in t.tc.const_exprs {
+		if int(expr_id) < 0 || int(expr_id) >= t.a.nodes.len {
+			continue
+		}
+		expr := t.a.nodes[int(expr_id)]
+		if expr.kind != .array_literal || expr.children_count == 0 {
+			continue
+		}
+		candidate_ids[key] = candidate_keys.len
+
+		candidate_names[if key.contains('.') {
+			key.all_after_last('.')
+		} else {
+			key
+		}] = true
+		candidate_keys << key
+	}
+	if candidate_keys.len == 0 {
+		return
+	}
+	mut ref_candidates := []int{len: t.a.nodes.len}
+	mut ref_states := []u8{len: t.a.nodes.len}
+	mut unmatched := []int{len: candidate_keys.len}
+	mut fixed_candidates := []bool{len: candidate_keys.len}
+	mut invalid_candidates := []bool{len: candidate_keys.len}
+	mut cur_module := 'main'
+	mut cur_file := ''
+	for idx, node in t.a.nodes {
+		kind_id := node_kind_id(node)
+		if kind_id == 77 {
+			cur_file = node.value
+			cur_module = 'main'
+			continue
+		}
+		if kind_id == 73 {
+			cur_module = node.value
+			continue
+		}
+		if node.kind == .call && node.children_count > 0 {
+			fn_node := t.a.child_node(&node, 0)
+			if fn_node.kind == .selector && fn_node.children_count > 0 {
+				base_id := t.a.child(fn_node, 0)
+				if candidate := t.const_array_candidate_for_expr(base_id, cur_module, cur_file,
+					candidate_ids, candidate_names)
+				{
+					invalid_candidates[candidate] = true
+				}
+			}
+		}
+		if node.kind in [.ident, .selector, .as_expr, .paren] {
+			if candidate := t.const_array_candidate_for_expr(flat.NodeId(idx), cur_module,
+				cur_file, candidate_ids, candidate_names)
+			{
+				ref_candidates[idx] = candidate + 1
+				if ref_states[idx] != 1 {
+					ref_states[idx] = 2
+					unmatched[candidate]++
+				}
+			}
+		}
+		if node.kind == .selector && node.value == 'len' && node.children_count > 0 {
+			t.mark_const_array_ref_safe(mut ref_candidates, mut ref_states, mut unmatched, t.a.child(&node,
+				0))
+		}
+		if node.kind == .index && node.children_count > 0 {
+			base_id := t.a.child(&node, 0)
+			if candidate := t.const_array_candidate_for_expr(base_id, cur_module, cur_file,
+				candidate_ids, candidate_names)
+			{
+				fixed_candidates[candidate] = true
+			}
+			t.mark_const_array_ref_safe(mut ref_candidates, mut ref_states, mut unmatched, base_id)
+		}
+		if node.kind == .for_in_stmt && node.value.int() == 3 && node.children_count > 2 {
+			container_id := t.a.child(&node, 2)
+			if int(container_id) >= 0 && t.a.nodes[int(container_id)].kind != .range {
+				if candidate := t.const_array_candidate_for_expr(container_id, cur_module,
+					cur_file, candidate_ids, candidate_names)
+				{
+					fixed_candidates[candidate] = true
+				}
+				t.mark_const_array_ref_safe(mut ref_candidates, mut ref_states, mut unmatched,
+					container_id)
+			}
+		}
+	}
+	for idx, key in candidate_keys {
+		result := !invalid_candidates[idx] && fixed_candidates[idx] && unmatched[idx] == 0
+		t.const_array_fixed_storage_cache[key] = if result { i8(1) } else { i8(-1) }
+	}
+}
+
+fn (t &Transformer) const_array_candidate_for_expr(id flat.NodeId, module_name string, file string, candidates map[string]int, candidate_names map[string]bool) ?int {
+	if int(id) < 0 || int(id) >= t.a.nodes.len {
+		return none
+	}
+	node := t.a.nodes[int(id)]
+	if node.kind in [.as_expr, .paren] && node.children_count > 0 {
+		return t.const_array_candidate_for_expr(t.a.child(&node, 0), module_name, file, candidates,
+			candidate_names)
+	}
+	if node.kind !in [.ident, .selector] || !candidate_names[node.value] {
+		return none
+	}
+	name := t.expr_key(id)
+	key := t.const_type_key_in_context(name, module_name, file) or { return none }
+	return candidates[key] or { return none }
+}
+
+fn (t &Transformer) mark_const_array_ref_safe(mut candidates []int, mut states []u8, mut unmatched []int, id flat.NodeId) {
+	idx := int(id)
+	if idx < 0 || idx >= t.a.nodes.len {
+		return
+	}
+	candidate := candidates[idx] - 1
+	if candidate >= 0 {
+		if states[idx] == 2 {
+			unmatched[candidate]--
+		}
+		states[idx] = 1
+	}
+	node := t.a.nodes[idx]
+	if node.kind == .paren && node.children_count > 0 {
+		t.mark_const_array_ref_safe(mut candidates, mut states, mut unmatched, t.a.child(&node, 0))
+	}
 }
 
 fn (t &Transformer) const_array_literal_requires_fixed_storage_uncached(key string) bool {
@@ -13906,6 +14088,12 @@ fn (t &Transformer) local_decl_is_shared_before(name string, before flat.NodeId)
 	if name.len == 0 || int(before) < 0 || int(before) >= t.a.nodes.len {
 		return false
 	}
+	// Prepared transforms index all shared declaration names. Most interpolation
+	// identifiers are ordinary locals, so reject them before reconstructing their
+	// enclosing scope path through the compiler-sized AST.
+	if t.source_parent_ids.len > 0 && !t.shared_local_decl_names[name] {
+		return false
+	}
 	// Follow the mutation's ancestor path and inspect only declarations preceding that
 	// path in each enclosing scope; bindings inside sibling blocks must not leak out.
 	mut path := [int(before)]
@@ -13957,6 +14145,8 @@ fn (t &Transformer) local_decl_is_shared_before(name string, before flat.NodeId)
 
 fn (mut t Transformer) build_source_parent_index() {
 	t.source_parent_ids = []int{len: t.a.nodes.len, init: -1}
+	mut decls := map[string][]int{}
+	mut shared_names := map[string]bool{}
 	for parent_id, node in t.a.nodes {
 		for i in 0 .. node.children_count {
 			child_id := int(t.a.child(&node, i))
@@ -13964,7 +14154,23 @@ fn (mut t Transformer) build_source_parent_index() {
 				t.source_parent_ids[child_id] = parent_id
 			}
 		}
+		if node.kind != .decl_assign || node.children_count < 2 {
+			continue
+		}
+		lhs_id := t.a.child(&node, 0)
+		if int(lhs_id) < 0 || int(lhs_id) >= t.a.nodes.len {
+			continue
+		}
+		lhs := t.a.nodes[int(lhs_id)]
+		if lhs.kind == .ident && lhs.value.len > 0 {
+			decls[lhs.value] << parent_id
+			if node.value == 'shared' || node.value.starts_with('shared:') {
+				shared_names[lhs.value] = true
+			}
+		}
 	}
+	t.local_decl_nodes_by_name = decls.move()
+	t.shared_local_decl_names = shared_names.move()
 }
 
 fn (t &Transformer) source_parent_id(child_id int) int {
@@ -13972,8 +14178,10 @@ fn (t &Transformer) source_parent_id(child_id int) int {
 		return t.source_parent_ids[child_id]
 	}
 	// Hand-built transform tests and nodes synthesized after prepare have no entry
-	// in the immutable source index. Keep their uncommon lookup behavior intact.
-	for parent_id, node in t.a.nodes {
+	// in the immutable source index. Synthesized parent/child nodes are appended
+	// together, so find them from the newest end of the compiler-sized AST.
+	for parent_id := t.a.nodes.len - 1; parent_id >= 0; parent_id-- {
+		node := t.a.nodes[parent_id]
 		for i in 0 .. node.children_count {
 			if int(t.a.child(&node, i)) == child_id && child_id != parent_id {
 				return parent_id
@@ -19910,7 +20118,7 @@ fn (t &Transformer) sum_constructor_call_type(node flat.Node) string {
 	if name.len == 0 {
 		return ''
 	}
-	short_name := name.all_after_last('.')
+	short_name := short_name_view(name)
 	if short_name.len == 0 || short_name[0] < `A` || short_name[0] > `Z` {
 		return ''
 	}

--- a/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
@@ -1952,6 +1952,7 @@ fn (mut t Transformer) run_parallel_transform_shared(items []FnWorkItem, base_no
 		t.base_write_intercept = true
 		t.defer_oor_writes = true
 		t.shared_base_nodes = base_nodes
+		t.node_context_read_only = true
 		setup_scope := transform_worker_scope_begin(t.scope_parallel_workers)
 		mut args := []SharedChunkArgs{len: chunk_count}
 		args[0] = SharedChunkArgs{
@@ -1998,6 +1999,7 @@ fn (mut t Transformer) run_parallel_transform_shared(items []FnWorkItem, base_no
 		t.timing_profile('  [ttime]   shared setup     ${f64(ttsw.elapsed().microseconds()) / 1000.0:7.2f} ms (chunks: ${chunk_count}, jobs: ${n_jobs})')
 		ttsw.restart()
 		any_started := t.a.worker_pool.run(tasks)
+		t.node_context_read_only = false
 		t.timing_profile('  [ttime]   shared pool.run  ${f64(ttsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 		$if v3_ttime ? {
 			for ci, arg in args {
@@ -2045,7 +2047,10 @@ fn (mut t Transformer) run_parallel_transform_shared(items []FnWorkItem, base_no
 			deferred_start := t.deferred_base_writes.len
 			merged_node_start := t.a.nodes.len
 			mwsw.restart()
-			t.merge_worker(ww, chunks[ci + 1], node_starts[ci + 1], child_starts[ci + 1], true)
+			// Compaction appends each worker at the current master end. Sparse cache
+			// entries from the master and earlier workers end before that fresh range,
+			// so clearing every new id would only hash absent keys.
+			t.merge_worker(ww, chunks[ci + 1], node_starts[ci + 1], child_starts[ci + 1], false)
 			merge_core_ms += f64(mwsw.elapsed().microseconds()) / 1000.0
 			if ww.worker_scope != unsafe { nil } && !t.retain_worker_results {
 				t.clone_deferred_worker_writes_from(deferred_start)

--- a/vlib/v3/transform/type_propagation.v
+++ b/vlib/v3/transform/type_propagation.v
@@ -1121,20 +1121,27 @@ fn (t &Transformer) normalize_type_alias_uncached(typ string) string {
 		}
 	}
 	if !typ.contains('.') {
-		mut unique_target := ''
-		for name, target in t.tc.type_aliases {
-			if name == typ || name.ends_with('.${typ}') {
-				if unique_target.len > 0 && unique_target != target {
-					return typ
-				}
-				unique_target = target
+		if unique_target := t.type_alias_suffixes[typ] {
+			if unique_target.len > 0 {
+				return unique_target
 			}
-		}
-		if unique_target.len > 0 {
-			return unique_target
 		}
 	}
 	return typ
+}
+
+fn (mut t Transformer) build_type_alias_suffix_index() {
+	t.type_alias_suffixes = map[string]string{}
+	for name, target in t.tc.type_aliases {
+		short := if name.contains('.') { name.all_after_last('.') } else { name }
+		if existing := t.type_alias_suffixes[short] {
+			if existing != target {
+				t.type_alias_suffixes[short] = ''
+			}
+		} else {
+			t.type_alias_suffixes[short] = target
+		}
+	}
 }
 
 fn (t &Transformer) expand_generic_type_alias(typ string) ?string {

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -9,6 +9,37 @@ import v3.gen.c.naming
 import v3.token
 import v3.util
 
+// short_name_view returns the suffix after the final dot without allocating.
+@[direct_array_access; inline]
+fn short_name_view(name string) string {
+	for i := name.len - 1; i >= 0; i-- {
+		if name[i] == `.` {
+			return unsafe { name.substr_unsafe(i + 1, name.len) }
+		}
+	}
+	return name
+}
+
+@[direct_array_access; inline]
+fn owner_name_view(name string) string {
+	for i := name.len - 1; i >= 0; i-- {
+		if name[i] == `.` {
+			return unsafe { name.substr_unsafe(0, i) }
+		}
+	}
+	return name
+}
+
+@[direct_array_access; inline]
+fn path_leaf_view(path string) string {
+	for i := path.len - 1; i >= 0; i-- {
+		if path[i] == `/` || path[i] == `\\` {
+			return unsafe { path.substr_unsafe(i + 1, path.len) }
+		}
+	}
+	return path
+}
+
 const comptime_field_members = [
 	'name',
 	'is_option',
@@ -335,23 +366,28 @@ mut:
 	// itself (for example `type Handlers = map[string]fn (Handlers)`). Keep the
 	// active expansion chain private to each checker/cache so parsing such a
 	// recursive alias terminates without introducing shared parallel state.
-	alias_parse_stack          []string
-	c_entries                  map[TypeId]string
-	c_name_entries             map[string]string
-	struct_field_entries       map[string]Type
-	struct_field_misses        map[string]bool
-	struct_field_last_struct   usize
-	struct_field_last_field    usize
-	struct_field_last_struct_n int
-	struct_field_last_field_n  int
-	struct_field_last_value    Type = Type(void_)
-	struct_field_last_state    i8
-	ierror_compat_entries      map[string]int
-	interface_impl_entries     map[string][]string
-	source_error_embed_entries map[string]int
-	source_error_embed_indexed bool
-	ierror_impl_names          []string
-	ierror_impl_names_set      bool
+	alias_parse_stack           []string
+	c_entries                   map[TypeId]string
+	c_name_entries              map[string]string
+	struct_field_entries        map[string]Type
+	struct_field_misses         map[string]bool
+	struct_field_last_struct    usize
+	struct_field_last_field     usize
+	struct_field_last_struct_n  int
+	struct_field_last_field_n   int
+	struct_field_last_value     Type = Type(void_)
+	struct_field_last_state     i8
+	struct_field_fn_diagnostics map[string]string
+	sum_variant_pattern_entries map[string]string
+	lexical_smartcast_entries   map[int]Type
+	lexical_smartcast_misses    map[int]bool
+	ierror_compat_entries       map[string]int
+	interface_impl_entries      map[string][]string
+	source_error_embed_entries  map[string]int
+	source_error_embed_indexed  bool
+	source_error_embed_shared   bool
+	ierror_impl_names           []string
+	ierror_impl_names_set       bool
 	// short type name -> unique qualified name ('' = ambiguous); built lazily
 	// by unique_qualified_type_name from the five type-name maps.
 	short_type_name_index       map[string]string
@@ -447,6 +483,7 @@ mut:
 	closure_forbidden_captures               map[string]bool
 	local_decl_rhs_by_name                   map[string][]LocalDeclRhs
 	local_decl_rhs_indexed                   bool
+	has_goto_nodes                           bool
 	closure_scope                            &Scope = unsafe { nil }
 	lambda_no_captures                       bool
 	generic_params                           []string
@@ -456,34 +493,10 @@ mut:
 }
 
 fn new_function_check_context() FunctionCheckContext {
-	return FunctionCheckContext{
-		method_value_locals:                 map[string]bool{}
-		method_value_local_owners:           map[string][]ScopeBindingOwner{}
-		method_value_local_depth:            map[string]int{}
-		method_value_stack_mut_owners:       map[string]bool{}
-		fn_value_variadic_locals:            map[string]bool{}
-		fn_value_variadic_local_owners:      map[string][]ScopeBindingOwner{}
-		fn_value_variadic_local_depth:       map[string]int{}
-		capturing_fn_literal_locals:         map[string]bool{}
-		capturing_fn_literal_local_owners:   map[string][]ScopeBindingOwner{}
-		capturing_fn_literal_local_depth:    map[string]int{}
-		mut_param_base_types:                map[string]Type{}
-		mut_param_owners:                    map[string]ScopeBindingOwner{}
-		mut_local_owners:                    map[string]ScopeBindingOwner{}
-		closure_copy_owners:                 map[string]ScopeBindingOwner{}
-		shared_owners:                       map[string][]ScopeBindingOwner{}
-		shared_array_owners:                 map[string][]ScopeBindingOwner{}
-		locked_shared_names:                 map[string]int{}
-		locked_shared_modes:                 map[string][]u8{}
-		locked_shared_base_names:            map[string]string{}
-		pointer_binding_value_keys:          map[string][]string{}
-		immutable_reference_aliases:         map[string]bool{}
-		unsafe_reference_alias_owners:       map[string]bool{}
-		pointer_alias_goto_states:           map[string][]map[string][]string{}
-		pointer_alias_backward_goto_targets: map[string]bool{}
-		closure_forbidden_captures:          map[string]bool{}
-		local_decl_rhs_by_name:              map[string][]LocalDeclRhs{}
-	}
+	// V maps initialize on first insertion. Most functions use only a small
+	// subset of these ownership/capture maps, so eagerly constructing every map
+	// multiplies allocator work by the number of checked functions.
+	return FunctionCheckContext{}
 }
 
 fn clone_function_check_context(src FunctionCheckContext) FunctionCheckContext {
@@ -520,6 +533,7 @@ fn clone_function_check_context(src FunctionCheckContext) FunctionCheckContext {
 		closure_forbidden_captures:               src.closure_forbidden_captures.clone()
 		local_decl_rhs_by_name:                   src.local_decl_rhs_by_name.clone()
 		local_decl_rhs_indexed:                   src.local_decl_rhs_indexed
+		has_goto_nodes:                           src.has_goto_nodes
 		closure_scope:                            src.closure_scope
 		lambda_no_captures:                       src.lambda_no_captures
 		generic_params:                           src.generic_params.clone()
@@ -718,6 +732,7 @@ pub mut:
 	cur_comptime_variant_loop_vars          []string
 	expr_type_values                        []Type // node_id -> complex/contextual resolved type
 	expr_type_set                           []bool
+	lexical_smartcast_misses                []bool
 	checking_nodes                          []bool
 	parallel_check_sparse                   bool
 	scope_parallel_check_workers            bool
@@ -747,6 +762,8 @@ pub mut:
 	diagnostic_files              map[string]bool
 	multiple_module_import_lines  map[u64]bool
 	source_texts_by_file          map[string]string
+	ct_update_pos                 map[int]token.Pos
+	ct_update_indexed             bool
 	insert_include_dirs_by_file   map[string][]string
 	has_spawn_expr                int = -1
 	inactive_top_level_node_ids   []int
@@ -754,10 +771,9 @@ pub mut:
 	// Names newly inserted into selected_file_called_fns and not yet chased by
 	// the transitive closure in collect_selected_file_called_fns_transitively.
 	selected_file_worklist []string
-	// During the parallel check region the called-fns closure is computed on its
-	// own thread, so `selected_file_called_fns` is not yet available. Sites that
-	// would gate on it park their candidate error here instead; the master
-	// filters the list against the finished set after joining the thread.
+	// During a scoped check, sites that would gate on the called-fns closure park
+	// their candidate error here. Successful builds skip the closure entirely;
+	// the master computes it after checking only when a candidate needs filtering.
 	defer_ierror_gating   bool
 	pending_ierror_errors []PendingIerrorError
 	// Node indices of every top-level declaration node (file markers, module/import
@@ -820,6 +836,7 @@ mut:
 	declaration_attributes       map[int][]string
 	type_declaration_ids         map[string][]int
 	strings_builder_bindings     map[string]bool
+	strings_builder_candidates   []int
 	static_associated_fn_keys    map[string]bool
 	declaration_param_mutability map[string][]bool
 	strict_map_index_files       map[string]bool
@@ -964,6 +981,7 @@ pub fn TypeChecker.new(a &flat.FlatAst) TypeChecker {
 		cur_fn_shared_binding_owners:            map[string]ScopeBindingOwner{}
 		expr_type_values:                        []Type{}
 		expr_type_set:                           []bool{}
+		lexical_smartcast_misses:                []bool{}
 		checking_nodes:                          []bool{}
 		sparse_resolved_call_names:              map[int]string{}
 		sparse_resolved_fn_values:               map[int]string{}
@@ -1106,6 +1124,7 @@ fn (tc &TypeChecker) fork_program_view(ast &flat.FlatAst, direct_dependencies_by
 		cur_comptime_variant_loop_vars:     tc.cur_comptime_variant_loop_vars
 		expr_type_values:                   tc.expr_type_values
 		expr_type_set:                      tc.expr_type_set
+		lexical_smartcast_misses:           tc.lexical_smartcast_misses
 		checking_nodes:                     tc.checking_nodes
 		sparse_resolved_call_names:         map[int]string{}
 		sparse_resolved_fn_values:          map[int]string{}
@@ -1124,6 +1143,8 @@ fn (tc &TypeChecker) fork_program_view(ast &flat.FlatAst, direct_dependencies_by
 		diagnostic_files:                   tc.diagnostic_files
 		multiple_module_import_lines:       tc.multiple_module_import_lines
 		source_texts_by_file:               tc.source_texts_by_file
+		ct_update_pos:                      tc.ct_update_pos
+		ct_update_indexed:                  tc.ct_update_indexed
 		has_spawn_expr:                     tc.has_spawn_expr
 		inactive_top_level_node_ids:        tc.inactive_top_level_node_ids
 		selected_file_called_fns:           tc.selected_file_called_fns
@@ -1456,6 +1477,7 @@ fn (mut tc TypeChecker) reset_node_caches(n int) {
 	// keeps this a plain zeroed allocation.
 	tc.expr_type_values = unsafe { []Type{len: n} }
 	tc.expr_type_set = []bool{len: n}
+	tc.lexical_smartcast_misses = []bool{len: n}
 	tc.checking_nodes = []bool{len: n}
 	tc.parallel_check_sparse = false
 }
@@ -1464,15 +1486,41 @@ fn (mut tc TypeChecker) build_direct_parent_index(a &flat.FlatAst) {
 	tc.direct_parent_ids = []flat.NodeId{len: a.nodes.len, init: flat.empty_node}
 	tc.value_used_nodes = []bool{len: a.nodes.len}
 	tc.declaration_attributes = map[int][]string{}
+	tc.insert_include_dirs_by_file = map[string][]string{}
+	tc.translated_files = map[string]bool{}
+	tc.has_globals_files = map[string]bool{}
+	tc.strings_builder_candidates = []int{cap: 1024}
 	tc.has_goto_nodes = false
 	for parent_idx, node in a.nodes {
 		if node.kind == .goto_stmt {
 			tc.has_goto_nodes = true
+		} else if node.kind == .decl_assign && node.children_count >= 2 {
+			lhs := a.child_node(&node, 0)
+			if lhs.kind == .ident && tc.expr_is_strings_new_builder_call(a.child(&node, 1)) {
+				tc.strings_builder_candidates << parent_idx
+			}
 		}
-		if node.kind == .directive && node.value.starts_with('@attributes:') {
-			decl_id := node.value['@attributes:'.len..].int()
-			if decl_id >= 0 && decl_id < a.nodes.len {
-				tc.declaration_attributes[decl_id] = node.generic_params()
+		if node.kind == .directive {
+			if node.value.starts_with('@attributes:') {
+				decl_id := node.value['@attributes:'.len..].int()
+				if decl_id >= 0 && decl_id < a.nodes.len {
+					tc.declaration_attributes[decl_id] = node.generic_params()
+					decl := a.nodes[decl_id]
+					if decl.kind == .module_decl {
+						if source_file := a.source_files[decl.pos.id] {
+							tc.collect_module_attributes(node, source_file.name)
+						}
+					}
+				}
+			} else if node.value == 'flag' && node.pos.is_valid() {
+				if source_file := a.source_files[node.pos.id] {
+					if raw_dir := checker_flag_include_dir(node.typ) {
+						resolved := tc.resolve_insert_path(raw_dir, source_file.name)
+						if resolved !in tc.insert_include_dirs_by_file[source_file.name] {
+							tc.insert_include_dirs_by_file[source_file.name] << resolved
+						}
+					}
+				}
 			}
 		}
 		for child_idx in 0 .. node.children_count {
@@ -1625,30 +1673,28 @@ fn (mut tc TypeChecker) build_fn_declaration_indexes(a &flat.FlatAst) {
 				tc.static_associated_fn_keys[qname] = is_static
 			}
 		}
-		mut stack := []flat.NodeId{}
-		for child_index in 0 .. node.children_count {
-			child_id := a.child(&node, child_index)
-			if a.node(child_id).kind != .param {
-				stack << child_id
+	}
+	for candidate_idx in tc.strings_builder_candidates {
+		candidate := a.nodes[candidate_idx]
+		lhs := a.child_node(&candidate, 0)
+		mut ancestor := int(tc.direct_parent_ids[candidate_idx])
+		for ancestor >= 0 && ancestor < a.nodes.len {
+			ancestor_node := a.nodes[ancestor]
+			if ancestor_node.kind == .fn_literal {
+				break
 			}
-		}
-		for stack.len > 0 {
-			id := stack.pop()
-			current := a.node(id)
-			if current.kind == .fn_literal {
-				continue
+			if ancestor_node.kind == .fn_decl {
+				tc.strings_builder_bindings[strings_builder_binding_key(ancestor, lhs.value)] = true
+				break
 			}
-			if current.kind == .decl_assign && current.children_count >= 2 {
-				lhs := a.child_node(current, 0)
-				if lhs.kind == .ident && tc.expr_is_strings_new_builder_call(a.child(current, 1)) {
-					tc.strings_builder_bindings[strings_builder_binding_key(index, lhs.value)] = true
-				}
+			next := int(tc.direct_parent_ids[ancestor])
+			if next == ancestor {
+				break
 			}
-			for child_index in 0 .. current.children_count {
-				stack << a.child(current, child_index)
-			}
+			ancestor = next
 		}
 	}
+	tc.strings_builder_candidates = []int{}
 }
 
 // has_fn_decl_short_name reports whether collection indexed a function
@@ -2280,24 +2326,6 @@ fn (mut tc TypeChecker) collect_module_attributes(node flat.Node, file string) {
 	}
 }
 
-fn (mut tc TypeChecker) collect_module_attributes_from_nodes(a &flat.FlatAst) {
-	for node in a.nodes {
-		if node.kind != .directive || !node.value.starts_with('@attributes:') {
-			continue
-		}
-		decl_idx := node.value['@attributes:'.len..].int()
-		if decl_idx < 0 || decl_idx >= a.nodes.len {
-			continue
-		}
-		decl := a.nodes[decl_idx]
-		if decl.kind != .module_decl {
-			continue
-		}
-		file := a.source_files[decl.pos.id] or { continue }
-		tc.collect_module_attributes(node, file.name)
-	}
-}
-
 fn (mut tc TypeChecker) check_insert_directive(id flat.NodeId, node flat.Node, file string, module_name string) {
 	if node.value == 'flag' && node.typ.contains('`') {
 		saved_file := tc.cur_file
@@ -2387,21 +2415,6 @@ fn checker_flag_include_dir(raw string) ?string {
 		}
 	}
 	return none
-}
-
-fn (mut tc TypeChecker) collect_insert_include_dirs(a &flat.FlatAst) {
-	tc.insert_include_dirs_by_file = map[string][]string{}
-	for node in a.nodes {
-		if node.kind != .directive || node.value != 'flag' || !node.pos.is_valid() {
-			continue
-		}
-		source_file := a.source_files[node.pos.id] or { continue }
-		raw_dir := checker_flag_include_dir(node.typ) or { continue }
-		resolved := tc.resolve_insert_path(raw_dir, source_file.name)
-		if resolved !in tc.insert_include_dirs_by_file[source_file.name] {
-			tc.insert_include_dirs_by_file[source_file.name] << resolved
-		}
-	}
 }
 
 fn (mut tc TypeChecker) collect_index_child(a &flat.FlatAst, i int, idx_file string, idx_module string, inactive []bool) string {
@@ -2497,9 +2510,6 @@ pub fn (mut tc TypeChecker) collect(a &flat.FlatAst) {
 	// whole compile.
 	tc.declared_type_scope_keys = map[string]bool{}
 	tc.concrete_type_scope_keys = map[string]bool{}
-	tc.translated_files = map[string]bool{}
-	tc.has_globals_files = map[string]bool{}
-	tc.collect_insert_include_dirs(a)
 	tc.top_level_idx = []int{cap: 65536}
 	tc.prepare_threads_condition()
 	inactive_comptime_nodes := tc.inactive_top_level_comptime_nodes()
@@ -2747,7 +2757,6 @@ fn (mut tc TypeChecker) collect_after_index(a &flat.FlatAst) {
 	tc.build_enclosing_generic_param_index(a)
 	tc.build_type_declaration_index(a)
 	tc.build_fn_declaration_indexes(a)
-	tc.collect_module_attributes_from_nodes(a)
 	tc.index_multiple_module_import_lines(a)
 	// Pass 1: collect type-level names (aliases, enums, sum types)
 	for tl_idx in tc.top_level_idx {
@@ -2998,10 +3007,6 @@ fn (mut tc TypeChecker) collect_after_index(a &flat.FlatAst) {
 				}
 				tc.fn_ret_type_texts[qname] = node.typ
 				tc.fn_ret_type_texts[tc.cached_c_name(qname)] = node.typ
-				for signature_name in [qname, tc.cached_c_name(qname)] {
-					tc.fn_type_files[signature_name] = tc.cur_file
-					tc.fn_type_modules[signature_name] = tc.cur_module
-				}
 				if tc.cur_module in ['', 'main', 'builtin'] && qname != node.value
 					&& node.value !in tc.fn_param_types {
 					tc.register_fn_signature(node.value, ret_type, ptypes, shared_params,
@@ -3014,10 +3019,6 @@ fn (mut tc TypeChecker) collect_after_index(a &flat.FlatAst) {
 					}
 					tc.fn_ret_type_texts[node.value] = node.typ
 					tc.fn_ret_type_texts[tc.cached_c_name(node.value)] = node.typ
-					for signature_name in [node.value, tc.cached_c_name(node.value)] {
-						tc.fn_type_files[signature_name] = tc.cur_file
-						tc.fn_type_modules[signature_name] = tc.cur_module
-					}
 				}
 				// A generic struct method (`Box[T].clone`) keeps its original signature
 				// TEXT: the parsed types collapse a non-concrete `Box[T]` to the bare base,
@@ -5878,13 +5879,19 @@ pub fn (mut tc TypeChecker) diagnose_unused_private_declarations(used_fns map[st
 	for node in tc.a.nodes {
 		if node.kind in [.ident, .selector] && node.value.len > 0 {
 			referenced_consts[node.value] = true
-			referenced_consts[node.value.all_after_last('.')] = true
+			short_name := short_name_view(node.value)
+			if short_name.len != node.value.len {
+				referenced_consts[short_name] = true
+			}
 		}
 		if node.kind == .call && node.children_count > 0 {
 			callee := tc.a.child_node(&node, 0)
 			if callee.value.len > 0 {
 				referenced_fns[callee.value] = true
-				referenced_fns[callee.value.all_after_last('.')] = true
+				short_name := short_name_view(callee.value)
+				if short_name.len != callee.value.len {
+					referenced_fns[short_name] = true
+				}
 			}
 		}
 	}
@@ -5911,8 +5918,7 @@ pub fn (mut tc TypeChecker) diagnose_unused_private_declarations(used_fns map[st
 			qname := checker_qualified_fn_name(module_name, node.value)
 			cname := tc.cached_c_name(qname)
 			if used_fns[node.value] || used_fns[qname] || used_fns[cname]
-				|| referenced_fns[node.value] || referenced_fns[qname]
-				|| referenced_fns[node.value.all_after_last('.')] {
+				|| referenced_fns[node.value] || referenced_fns[qname] {
 				continue
 			}
 			tc.record_notice_at(.unknown_ident, 'unused function: `${node.value}`',
@@ -8293,7 +8299,8 @@ fn (tc &TypeChecker) fn_receiver_source_text_pos(node flat.Node) (string, token.
 	file := tc.a.source_files[node.pos.id] or { return '', node.pos }
 	source := tc.source_texts_by_file[file.name] or { return '', node.pos }
 	name_start := int_min(int_max(node.pos.offset, 0), source.len)
-	line_start := if relative := source[..name_start].last_index('\n') {
+	relative := last_index_between(source, '\n', 0, name_start)
+	line_start := if relative >= 0 {
 		relative + 1
 	} else {
 		0
@@ -9466,7 +9473,7 @@ fn (tc &TypeChecker) is_selected_input_file(file string) bool {
 }
 
 fn is_c_backend_test_file(path string) bool {
-	file := path.all_after_last('/').all_after_last('\\')
+	file := path_leaf_view(path)
 	if file.ends_with('_test.v') || file.ends_with('_test.vv') || file.ends_with('_test.c.v') {
 		return true
 	}
@@ -9481,7 +9488,7 @@ fn is_c_backend_test_file(path string) bool {
 }
 
 fn is_regular_v_test_file(path string) bool {
-	file := path.all_after_last('/').all_after_last('\\')
+	file := path_leaf_view(path)
 	if file.ends_with('_d_test.v') || file.ends_with('_d_test.vv') {
 		return false
 	}
@@ -9714,12 +9721,24 @@ pub fn (tc &TypeChecker) is_veb_context_type(typ Type) bool {
 
 // check_fn_body validates check fn body state for types.
 fn (mut tc TypeChecker) check_fn_body(node flat.Node) {
-	if tc.has_goto_nodes {
+	if tc.fn_context.has_goto_nodes {
 		tc.initialize_pointer_alias_goto_targets()
 	}
-	saved_smartcasts := clone_smartcasts(tc.smartcasts)
+	had_saved_smartcasts := tc.smartcasts.len > 0
+	saved_smartcasts := if had_saved_smartcasts {
+		clone_smartcasts(tc.smartcasts)
+	} else {
+		// The empty map may be reused throughout this function; the deferred clear
+		// below restores the empty outer context without allocating a clone for
+		// every checked function.
+		tc.smartcasts
+	}
 	defer {
-		tc.smartcasts = clone_smartcasts(saved_smartcasts)
+		if had_saved_smartcasts {
+			tc.smartcasts = clone_smartcasts(saved_smartcasts)
+		} else {
+			tc.smartcasts.clear()
+		}
 	}
 	mut sequence_exited := false
 	mut unreachable_id := flat.empty_node
@@ -10682,7 +10701,7 @@ fn (tc &TypeChecker) bare_generic_decl_type_name(type_text string) ?string {
 	if generic_type_application(clean) || !should_check_named_type(clean) {
 		return none
 	}
-	if scope_type_key(tc.cur_file, tc.cur_module, clean.all_after_last('.')) in tc.concrete_type_scope_keys {
+	if scope_type_key(tc.cur_file, tc.cur_module, short_name_view(clean)) in tc.concrete_type_scope_keys {
 		return none
 	}
 	qualified := tc.qualify_name(clean)
@@ -10932,7 +10951,7 @@ fn (tc &TypeChecker) collect_generic_receiver_params(node flat.Node, mut params 
 		receiver_type = receiver_type[7..].trim_space()
 	}
 	receiver_type = receiver_type.trim_left('&')
-	if receiver_type != node.value.all_before_last('.') {
+	if receiver_type != owner_name_view(node.value) {
 		return
 	}
 	receiver_base, receiver_args, is_generic := generic_type_application_parts(receiver_type)
@@ -14401,24 +14420,18 @@ fn (tc &TypeChecker) ellipsis_diagnostic_pos(id flat.NodeId) token.Pos {
 }
 
 fn (tc &TypeChecker) comptime_struct_update_source_pos(node flat.Node) ?token.Pos {
+	if tc.ct_update_indexed {
+		return tc.ct_update_pos[node.pos.id] or { return none }
+	}
 	file := tc.a.source_files[node.pos.id] or { return none }
 	source := tc.source_texts_by_file[file.name] or { return none }
-	mut cursor := 0
-	for cursor + 3 <= source.len {
-		if source[cursor..cursor + 3] == '...' {
-			line_end := source[cursor..].index('\n') or { source.len - cursor }
-			if source[cursor..cursor + line_end].contains('$(') && source[..cursor].contains('$for') {
-				return token.new_span(node.pos.id, cursor, cursor + 3)
-			}
-		}
-		cursor++
-	}
-	return none
+	return comptime_struct_update_pos_in_source(node.pos.id, source)
 }
 
 fn (mut tc TypeChecker) check_comptime_struct_updates_preflight() {
 	message := 'cannot use struct update syntax in compile time expressions'
-	for index, node in tc.a.nodes {
+	tc.ct_update_pos = map[int]token.Pos{}
+	for node in tc.a.nodes {
 		if node.kind != .comptime_for || node.children_count == 0 {
 			continue
 		}
@@ -14428,11 +14441,6 @@ fn (mut tc TypeChecker) check_comptime_struct_updates_preflight() {
 				tc.record_error_at(.assignment_mismatch, message, update_id,
 					tc.ellipsis_diagnostic_pos(update_id))
 			}
-		} else if pos := tc.comptime_struct_update_source_pos(node) {
-			node_id := flat.NodeId(index)
-			if !tc.errors.any(it.msg == message && it.pos == pos) {
-				tc.record_error_at(.assignment_mismatch, message, node_id, pos)
-			}
 		}
 	}
 	for file_id, file in tc.a.source_files {
@@ -14441,21 +14449,22 @@ fn (mut tc TypeChecker) check_comptime_struct_updates_preflight() {
 		}
 		source := tc.source_texts_by_file[file.name] or { continue }
 		pos := comptime_struct_update_pos_in_source(file_id, source) or { continue }
+		tc.ct_update_pos[file_id] = pos
 		if tc.errors.any(it.msg == message && it.pos == pos) {
 			continue
 		}
 		node_id := tc.closest_source_node_id(pos)
 		tc.errors << tc.make_type_error_at(.assignment_mismatch, message, node_id, pos)
 	}
+	tc.ct_update_indexed = true
 }
 
 fn comptime_struct_update_pos_in_source(file_id int, source string) ?token.Pos {
-	mut cursor := 0
+	mut cursor := source.index('$for') or { return none }
 	for cursor + 3 <= source.len {
-		relative := source[cursor..].index('...') or { return none }
-		cursor += relative
-		line_end := source[cursor..].index('\n') or { source.len - cursor }
-		if source[cursor..cursor + line_end].contains('$(') && source[..cursor].contains('$for') {
+		cursor = source.index_after('...', cursor) or { return none }
+		line_end := source.index_after('\n', cursor) or { source.len }
+		if last_index_between(source, '$(', cursor, line_end) >= 0 {
 			return token.new_span(file_id, cursor, cursor + 3)
 		}
 		cursor += 3

--- a/vlib/v3/types/checker_comptime.v
+++ b/vlib/v3/types/checker_comptime.v
@@ -13014,9 +13014,10 @@ fn (mut tc TypeChecker) check_decl_assign(id flat.NodeId, node flat.Node) {
 			i += 2
 			continue
 		}
-		tc.check_const_reference_assignment(lhs_id, rhs_id, true, tc.decl_lhs_is_mut(node, lhs_id))
-		if lhs_node.value != '_' && tc.unsafe_depth == 0 && (tc.decl_lhs_is_mut(node, lhs_id)
-			|| tc.slice_expr_base_is_mutable(rhs_id)) {
+		lhs_is_mut := tc.decl_lhs_is_mut(node, lhs_id)
+		tc.check_const_reference_assignment(lhs_id, rhs_id, true, lhs_is_mut)
+		if lhs_node.value != '_' && tc.unsafe_depth == 0
+			&& (lhs_is_mut || tc.slice_expr_base_is_mutable(rhs_id)) {
 			tc.record_implicit_slice_clone_notice(rhs_id)
 		}
 		if tc.new_error_kind_since(error_count, .unknown_ident) {
@@ -13135,9 +13136,8 @@ fn (mut tc TypeChecker) check_decl_assign(id flat.NodeId, node flat.Node) {
 				'cannot copy map: call `move` or `clone` method (or use a reference)', rhs_id,
 				rhs_node.pos)
 		}
-		if tc.unsafe_depth == 0 && tc.decl_lhs_is_mut(node, lhs_id)
-			&& unalias_type(rhs_type) is Array && rhs_node.kind == .selector
-			&& tc.expr_root_is_mutable_lvalue(rhs_id) {
+		if tc.unsafe_depth == 0 && lhs_is_mut && unalias_type(rhs_type) is Array
+			&& rhs_node.kind == .selector && tc.expr_root_is_mutable_lvalue(rhs_id) {
 			tc.record_error_at(.assignment_mismatch,
 				'use `mut array2 := array1.clone()` instead of `mut array2 := array1` (or use `unsafe`)',
 				id, tc.assignment_operator_pos(node, lhs_id, rhs_id))
@@ -13158,13 +13158,13 @@ fn (mut tc TypeChecker) check_decl_assign(id flat.NodeId, node flat.Node) {
 					'cannot assign `${rhs_type.name()}` to `${expected.name()}`', id)
 			}
 		}
-		owner := tc.insert_decl_lhs(lhs_id, expected, tc.decl_lhs_is_mut(node, lhs_id))
+		owner := tc.insert_decl_lhs(lhs_id, expected, lhs_is_mut)
 		tc.record_pointer_binding_alias(owner, rhs_id, expected)
 		if owner.storage_key().len > 0 && unalias_type(expected) is Map
 			&& tc.expr_is_unsafe_reference_alias(rhs_id) {
 			tc.fn_context.unsafe_reference_alias_owners[owner.storage_key()] = true
 		}
-		if lhs_node.value != '_' && tc.decl_lhs_is_mut(node, lhs_id) {
+		if lhs_node.value != '_' && lhs_is_mut {
 			tc.check_mutable_array_immutable_references(rhs_id)
 			tc.record_mutable_decl_branch_immutable_notices(rhs_id)
 			if immutable_source_id := tc.immutable_reference_source(rhs_id, rhs_type) {
@@ -15345,9 +15345,12 @@ fn (tc &TypeChecker) decl_lhs_is_mut(node flat.Node, lhs_id flat.NodeId) bool {
 		if file := tc.a.source_files[lhs.pos.id] {
 			if source := tc.source_texts_by_file[file.name] {
 				start := int_min(int_max(lhs.pos.offset, 0), source.len)
-				line_start := source[..start].last_index_u8(`\n`)
+				mut line_start := start
+				for line_start > 0 && source[line_start - 1] != `\n` {
+					line_start--
+				}
 				line_end := source.index_after('\n', start) or { source.len }
-				if source[line_start + 1..line_end].contains('mut ${lhs.value} :=') {
+				if last_index_between(source, 'mut ${lhs.value} :=', line_start, line_end) >= 0 {
 					return true
 				}
 			}

--- a/vlib/v3/types/checker_parallel.v
+++ b/vlib/v3/types/checker_parallel.v
@@ -9,9 +9,9 @@ import v3.workers
 
 const min_parallel_check_items = 256
 const max_parallel_check_jobs = 26
-// Scoped workers keep an arena alive for the phase. Limit their count and use
-// many short batches so self-hosting does not retain one large arena per core.
-const max_scoped_check_jobs = 8
+// Scoped workers use bounded arena batches, so let self-host checks occupy all
+// of the worker pool's cores without retaining one large arena per core.
+const max_scoped_check_jobs = 10
 const scoped_check_worker_batches = 96
 // A serial checker owns the whole import graph instead of one worker shard, so
 // use finer arena batches to keep compiler-module checks below the memory cap.
@@ -169,11 +169,6 @@ fn (mut tc TypeChecker) check_semantics_scoped_serial() {
 	tc.check_export_attrs()
 	items := tc.collect_parallel_check_items()
 	tc.check_top_level_declarations()
-	if tc.diagnostic_files.len > 0 {
-		// Open generic bodies are checked only when reachable from the selected input.
-		// Populate the reachability set before the scoped workers inherit it.
-		tc.collect_selected_file_called_fns()
-	}
 	final_file := tc.cur_file
 	final_module := tc.cur_module
 	tc.check_scoped_batches(items, scoped_check_serial_batches)
@@ -295,11 +290,6 @@ fn (mut tc TypeChecker) check_semantics_parallel() bool {
 		cksw.restart()
 		items := tc.collect_parallel_check_items()
 		tc.timing_profile('  [ttime]   ck collect items ${f64(cksw.elapsed().microseconds()) / 1000.0:7.2f} ms (items: ${items.len})')
-		if tc.diagnostic_files.len > 0 {
-			// Open generic bodies are checked only when reachable from the selected input.
-			// Populate the reachability set before the parallel workers inherit it.
-			tc.collect_selected_file_called_fns()
-		}
 		final_file := tc.cur_file
 		final_module := tc.cur_module
 		was_parallel := tc.run_parallel_check(items)
@@ -883,11 +873,11 @@ fn (mut tc TypeChecker) check_fn_decl_semantics(fn_idx int, node flat.Node, file
 	tc.fn_context.concrete_generic_receiver_specialization =
 		fn_value_is_concrete_generic_receiver_specialization(node.value)
 	tc.cur_fn_node_id = fn_idx
-	tc.method_value_locals = map[string]bool{}
-	tc.method_value_local_depth = map[string]int{}
-	tc.capturing_fn_literal_locals = map[string]bool{}
-	tc.capturing_fn_literal_local_depth = map[string]int{}
-	tc.capturing_fn_literal_return_unsupported = map[string]bool{}
+	tc.method_value_locals.clear()
+	tc.method_value_local_depth.clear()
+	tc.capturing_fn_literal_locals.clear()
+	tc.capturing_fn_literal_local_depth.clear()
+	tc.capturing_fn_literal_return_unsupported.clear()
 	tc.check_fn_receiver_and_operator_return(node, flat.NodeId(fn_idx))
 	$if ownership ? {
 		tc.ownership_begin_fn(node)
@@ -1960,6 +1950,7 @@ fn (mut tc TypeChecker) restore_type_cache_base() {
 
 fn (tc &TypeChecker) fork_for_parallel_check() &TypeChecker {
 	mut w := tc.fork_program_view(tc.a, map[int][]SymbolId{})
+	precomputed := tc.precomputed_check_cache()
 	// Parallel checker workers may populate this cache concurrently, so each
 	// worker (and each disposable scoped batch) owns mutable result/miss maps while
 	// sharing the declaration index that collect completed before checking starts.
@@ -2000,22 +1991,55 @@ fn (tc &TypeChecker) fork_for_parallel_check() &TypeChecker {
 	w.type_cache = &TypeCache{
 		// The master's frozen pre-region cache (the overlay's base) is shared
 		// read-only across all forks; each fork writes to its own maps.
-		base:                       if tc.type_cache != unsafe { nil } {
+		base:                        if tc.type_cache != unsafe { nil } {
 			tc.type_cache.base
 		} else {
 			&TypeCache(unsafe { nil })
 		}
-		parse_enabled:              if tc.type_cache != unsafe { nil } {
+		parse_enabled:               if tc.type_cache != unsafe { nil } {
 			tc.type_cache.parse_enabled
 		} else {
 			false
 		}
-		parse_entries:              map[u64]ParseTypeCacheEntry{}
-		c_entries:                  map[TypeId]string{}
-		struct_field_entries:       map[string]Type{}
-		struct_field_misses:        map[string]bool{}
-		ierror_compat_entries:      map[string]int{}
-		source_error_embed_entries: map[string]int{}
+		parse_entries:               map[u64]ParseTypeCacheEntry{}
+		c_entries:                   map[TypeId]string{}
+		struct_field_entries:        map[string]Type{}
+		struct_field_misses:         map[string]bool{}
+		sum_variant_pattern_entries: map[string]string{}
+		lexical_smartcast_entries:   map[int]Type{}
+		lexical_smartcast_misses:    map[int]bool{}
+		short_type_name_index:       if isnil(precomputed)
+			|| !precomputed.short_type_name_index_built {
+			map[string]string{}
+		} else {
+			precomputed.short_type_name_index
+		}
+		short_type_name_index_built: !isnil(precomputed) && precomputed.short_type_name_index_built
+		local_fn_decl_index:         if isnil(precomputed)
+			|| precomputed.local_fn_decl_indexed_len == 0 {
+			map[string]bool{}
+		} else {
+			precomputed.local_fn_decl_index
+		}
+		local_fn_decl_indexed_len:   if isnil(precomputed) {
+			0
+		} else {
+			precomputed.local_fn_decl_indexed_len
+		}
+		local_fn_decl_last_module:   if isnil(precomputed) {
+			''
+		} else {
+			precomputed.local_fn_decl_last_module
+		}
+		ierror_compat_entries:       map[string]int{}
+		source_error_embed_entries:  if isnil(precomputed)
+			|| !precomputed.source_error_embed_indexed {
+			map[string]int{}
+		} else {
+			precomputed.source_error_embed_entries
+		}
+		source_error_embed_indexed:  !isnil(precomputed) && precomputed.source_error_embed_indexed
+		source_error_embed_shared:   !isnil(precomputed) && precomputed.source_error_embed_indexed
 	}
 	if tc.scope_parallel_check_workers {
 		// Shared interner growth from a helper arena would leave compilation-wide
@@ -2026,6 +2050,28 @@ fn (tc &TypeChecker) fork_for_parallel_check() &TypeChecker {
 		w.type_cache.base = unsafe { nil }
 	}
 	return &w
+}
+
+// precomputed_check_cache returns the immutable indexes warmed before the
+// parallel region. Scoped forks can share these maps without also inheriting
+// the large, context-sensitive parse cache.
+fn (tc &TypeChecker) precomputed_check_cache() &TypeCache {
+	if isnil(tc.type_cache) {
+		return unsafe { nil }
+	}
+	if tc.type_cache.source_error_embed_indexed || tc.type_cache.short_type_name_index_built
+		|| tc.type_cache.local_fn_decl_indexed_len > 0 {
+		return tc.type_cache
+	}
+	mut fallback := tc.type_cache.base
+	for !isnil(fallback) {
+		if fallback.source_error_embed_indexed || fallback.short_type_name_index_built
+			|| fallback.local_fn_decl_indexed_len > 0 {
+			return fallback
+		}
+		fallback = fallback.base
+	}
+	return unsafe { nil }
 }
 
 struct CheckCloneChunkArgs {
@@ -2226,7 +2272,9 @@ fn (mut tc TypeChecker) free_parallel_check_worker_cache() {
 			cache.struct_field_misses.free()
 			cache.ierror_compat_entries.free()
 			cache.interface_impl_entries.free()
-			cache.source_error_embed_entries.free()
+			if !cache.source_error_embed_shared {
+				cache.source_error_embed_entries.free()
+			}
 		}
 	}
 }

--- a/vlib/v3/types/checker_tail.v
+++ b/vlib/v3/types/checker_tail.v
@@ -2804,10 +2804,9 @@ fn (tc &TypeChecker) optional_pointer_expr_compatible(expr_id flat.NodeId, actua
 	}
 	if expected_interface := cast_target_interface(expected_ptr.base_type) {
 		interface_actual := if actual_base is Pointer { actual_base.base_type } else { actual_base }
-		if tc.type_implements_interface(interface_actual, expected_interface)
-			|| tc.type_implements_interface(Type(Pointer{
-				base_type: interface_actual
-			}), expected_interface) {
+		if tc.type_implements_interface(interface_actual, expected_interface) || tc.type_implements_interface(Type(Pointer{
+			base_type: interface_actual
+		}), expected_interface) {
 			return true
 		}
 	}
@@ -3277,7 +3276,8 @@ fn (mut tc TypeChecker) check_call(id flat.NodeId, node flat.Node) {
 				}
 			}
 			if !(receiver.kind == .ident && receiver.value == 'C') {
-				receiver_name := resolve_type_name_for_method(unalias_and_unwrap_pointer_type(tc.resolve_type(receiver_id)))
+				receiver_name :=
+					resolve_type_name_for_method(unalias_and_unwrap_pointer_type(tc.resolve_type(receiver_id)))
 				method_name := '${receiver_name}.${callee.value}'
 				if method_name in tc.source_no_body_fns && !tc.v_source_fn_has_body(method_name) {
 					name_pos := tc.method_call_name_pos(node, callee)
@@ -4965,6 +4965,22 @@ fn (mut tc TypeChecker) index_local_decl_rhs(fn_id flat.NodeId) {
 	if !tc.valid_node_id(fn_id) {
 		return
 	}
+	// Normal semantic work items own one contiguous postfix AST range. Stream it
+	// once and inspect only declarations instead of rebuilding a DFS stack and a
+	// visited map for every function.
+	if tc.check_range_lo >= 0 && tc.check_range_hi == int(fn_id) {
+		for idx in tc.check_range_lo .. int(fn_id) {
+			current := tc.a.nodes[idx]
+			if current.kind == .goto_stmt {
+				tc.fn_context.has_goto_nodes = true
+			}
+			if current.kind == .decl_assign
+				&& !tc.local_decl_is_in_nested_function(flat.NodeId(idx), fn_id) {
+				tc.index_local_decl_rhs_node(current)
+			}
+		}
+		return
+	}
 	fn_node := tc.a.node(fn_id)
 	mut stack := []flat.NodeId{}
 	for i in 0 .. fn_node.children_count {
@@ -4981,17 +4997,11 @@ fn (mut tc TypeChecker) index_local_decl_rhs(fn_id flat.NodeId) {
 		}
 		seen[int(current_id)] = true
 		current := tc.a.node(current_id)
+		if current.kind == .goto_stmt {
+			tc.fn_context.has_goto_nodes = true
+		}
 		if current.kind == .decl_assign {
-			for i := 0; i + 1 < int(current.children_count); i += 2 {
-				lhs := tc.a.child_node(current, i)
-				if lhs.kind == .ident && lhs.value.len > 0 {
-					tc.fn_context.local_decl_rhs_by_name[lhs.value] << LocalDeclRhs{
-						rhs:    tc.a.child(current, i + 1)
-						file:   lhs.pos.id
-						offset: lhs.pos.offset
-					}
-				}
-			}
+			tc.index_local_decl_rhs_node(current)
 		}
 		if current.kind in [.fn_literal, .lambda_expr] {
 			continue
@@ -5000,6 +5010,38 @@ fn (mut tc TypeChecker) index_local_decl_rhs(fn_id flat.NodeId) {
 			stack << tc.a.child(current, i)
 		}
 	}
+}
+
+fn (mut tc TypeChecker) index_local_decl_rhs_node(node &flat.Node) {
+	for i := 0; i + 1 < int(node.children_count); i += 2 {
+		lhs := tc.a.child_node(node, i)
+		if lhs.kind == .ident && lhs.value.len > 0 {
+			tc.fn_context.local_decl_rhs_by_name[lhs.value] << LocalDeclRhs{
+				rhs:    tc.a.child(node, i + 1)
+				file:   lhs.pos.id
+				offset: lhs.pos.offset
+			}
+		}
+	}
+}
+
+fn (tc &TypeChecker) local_decl_is_in_nested_function(id flat.NodeId, owner_fn flat.NodeId) bool {
+	mut current := id
+	for _ in 0 .. 128 {
+		parent_id := tc.direct_parent_id(current)
+		if parent_id == owner_fn {
+			return false
+		}
+		if !tc.valid_node_id(parent_id) {
+			return false
+		}
+		parent := tc.a.node(parent_id)
+		if parent.kind in [.fn_literal, .lambda_expr] {
+			return true
+		}
+		current = parent_id
+	}
+	return false
 }
 
 fn (tc &TypeChecker) local_decl_rhs_before(name string, use_id flat.NodeId) ?flat.NodeId {
@@ -7254,7 +7296,7 @@ fn (tc &TypeChecker) current_receiver_param_method_call_info(base_id flat.NodeId
 	if fn_node.kind != .fn_decl || !fn_node.value.contains('.') {
 		return none
 	}
-	receiver_name := fn_node.value.all_before_last('.')
+	receiver_name := owner_name_view(fn_node.value)
 	if receiver_name.len == 0 {
 		return none
 	}
@@ -8487,7 +8529,7 @@ fn visible_mutation_fn_names_match(actual string, declared string) bool {
 	if actual == declared {
 		return true
 	}
-	if actual.all_after_last('.') != declared.all_after_last('.') {
+	if short_name_view(actual) != short_name_view(declared) {
 		return false
 	}
 	actual_receiver := actual.all_before_last('.')
@@ -8887,13 +8929,13 @@ fn (tc &TypeChecker) selector_fn_value_param_is_mut(callee &flat.Node, param_idx
 	if receiver_type !is Struct {
 		return false
 	}
+	field_type := tc.struct_field_type(receiver_type.name(), callee.value) or { return false }
 	if source_type, _ := tc.struct_field_diagnostic_fn_type(receiver_type.name(), callee.value, 0) {
 		modes := fn_diagnostic_parameter_modes(source_type)
 		if param_idx >= 0 && param_idx < modes.len {
 			return modes[param_idx] == 'mut'
 		}
 	}
-	field_type := tc.struct_field_type(receiver_type.name(), callee.value) or { return false }
 	callable_type := match field_type {
 		OptionType { field_type.base_type }
 		ResultType { field_type.base_type }
@@ -10689,18 +10731,9 @@ fn (mut tc TypeChecker) check_call_arg_types(id flat.NodeId, node flat.Node, inf
 				continue
 			}
 		}
-		if call_arg_numeric_type(expected) && call_arg_numeric_type(actual)
-			&& call_argument_type_name(actual) != call_argument_type_name(expected)
-			&& !(call_argument_type_name(actual) in ['int', 'i32']
-			&& call_argument_type_name(expected) in ['int', 'i32'])
-			&& !call_arg_implicit_signed_widening(actual, expected)
-			&& tc.integer_literal_source(arg_id) == none
-			&& tc.a.node(arg_id).kind !in [.float_literal, .char_literal] && !(expected is Alias
-			&& tc.type_compatible(actual, expected.base_type))
-			&& !(actual is Alias && tc.type_compatible(actual.base_type, expected))
-			&& !(unalias_type(actual).is_integer() && unalias_type(expected).is_integer())
-			&& !(unalias_type(actual).is_integer() && unalias_type(expected).is_float())
-			&& (tc.mut_param_expr_base(arg_id, actual) or { actual }).name() != expected.name() {
+		if call_arg_numeric_type(expected) && call_arg_numeric_type(actual) && call_argument_type_name(actual) != call_argument_type_name(expected) && !(call_argument_type_name(actual) in ['int', 'i32'] && call_argument_type_name(expected) in ['int', 'i32']) && !call_arg_implicit_signed_widening(actual, expected) && tc.integer_literal_source(arg_id) == none && tc.a.node(arg_id).kind !in [.float_literal, .char_literal] && !(expected is Alias && tc.type_compatible(actual, expected.base_type)) && !(actual is Alias && tc.type_compatible(actual.base_type, expected)) && !(unalias_type(actual).is_integer() && unalias_type(expected).is_integer()) && !(unalias_type(actual).is_integer() && unalias_type(expected).is_float()) && (tc.mut_param_expr_base(arg_id, actual) or {
+			actual
+		}).name() != expected.name() {
 			if info.name.all_after_last('.') == 'int_str' && unalias_type(actual).is_integer()
 				&& unalias_type(expected).is_integer() {
 				continue
@@ -10749,8 +10782,7 @@ fn (mut tc TypeChecker) check_call_arg_types(id flat.NodeId, node flat.Node, inf
 			&& !tc.call_arg_is_callee_receiver(node, arg_id)
 			&& !tc.call_arg_is_lowered_method_receiver(node, info, param_idx, expected)
 			&& !(arg_node.is_mut && expected is Pointer
-			&& tc.type_compatible(actual, expected.base_type))
-			&& !pointer_value_arg
+			&& tc.type_compatible(actual, expected.base_type)) && !pointer_value_arg
 		pointer_array_mismatch := actual_pointer_depth > 0 && expected_pointer_depth > 0
 			&& unalias_type(actual_pointer_base) is Array
 			&& unalias_type(expected_pointer_base) is Array
@@ -11073,7 +11105,7 @@ fn (tc &TypeChecker) call_arg_is_lowered_method_receiver(node flat.Node, info Ca
 	if receiver_type is Pointer {
 		receiver_type = fn_param_unalias_type(receiver_type.base_type)
 	}
-	owner := info.name.all_before_last('.')
+	owner := owner_name_view(info.name)
 	receiver_name := receiver_type.name()
 	return owner == receiver_name || owner.ends_with('.${receiver_name}')
 		|| receiver_name.ends_with('.${owner}')
@@ -12229,8 +12261,7 @@ fn (tc &TypeChecker) c_fn_value_signature_compatible(actual Type, expected Type)
 	}
 	for i in 0 .. actual_fn.params.len {
 		if !fn_param_modes_compatible(actual_fn, expected_fn, i)
-			|| !tc.fn_param_compatible(fn_compatible_param_type(actual_fn, i),
-			fn_compatible_param_type(expected_fn, i)) {
+			|| !tc.fn_param_compatible(fn_compatible_param_type(actual_fn, i), fn_compatible_param_type(expected_fn, i)) {
 			return false
 		}
 	}
@@ -12398,8 +12429,8 @@ fn (mut tc TypeChecker) call_has_spread_covering_fixed_variadic_args(node flat.N
 
 fn (tc &TypeChecker) spread_elem_compatible(actual Type, expected Type) bool {
 	clean_expected := unalias_type(expected)
-	return tc.receiver_compatible(actual, expected) || tc.type_compatible(actual, expected)
-		|| (clean_expected is SumType
+	return tc.receiver_compatible(actual, expected)
+		|| tc.type_compatible(actual, expected) || (clean_expected is SumType
 		&& tc.direct_sum_assignment_variant_matches(actual, clean_expected))
 }
 
@@ -12943,8 +12974,8 @@ fn (mut tc TypeChecker) infer_generic_fn_type_text_from_type(param_text string, 
 		if i >= actual.params.len {
 			break
 		}
-		tc.infer_generic_type_text_from_type(normalize_fn_type_param_text(part),
-			fn_compatible_param_type(actual, i), generic_params, mut inferred)
+		tc.infer_generic_type_text_from_type(normalize_fn_type_param_text(part), fn_compatible_param_type(actual,
+			i), generic_params, mut inferred)
 	}
 	ret := trimmed_space(param_text[params_end + 1..])
 	if ret.len > 0 {
@@ -13453,8 +13484,7 @@ fn (tc &TypeChecker) enclosing_array_dsl_ident_type(id flat.NodeId, name string)
 			dsl_name := tc.unresolved_array_dsl_call_name(parent)
 			// The DSL binding applies only to call arguments. An `it` used in the
 			// receiver of a nested DSL call still belongs to the enclosing DSL.
-			in_call_argument := parent.children_count > 1
-				&& current != tc.a.child(parent, 0)
+			in_call_argument := parent.children_count > 1 && current != tc.a.child(parent, 0)
 			if dsl_name.len > 0 && in_call_argument {
 				is_sort_ident := is_array_sort_dsl_call_name(dsl_name) && name in ['a', 'b']
 				if (name == 'it' && !is_array_sort_dsl_call_name(dsl_name)) || is_sort_ident {
@@ -14092,13 +14122,17 @@ fn (tc &TypeChecker) selector_declared_value_type(node flat.Node) ?Type {
 	if !valid_string_data(node.value) {
 		return none
 	}
-	if typ := tc.global_type_for_selector(node) {
-		return typ
-	}
-	if typ := tc.const_type_for_selector(node) {
-		return typ
-	}
 	base_id := tc.a.child(&node, 0)
+	base_node := tc.a.node(base_id)
+	base_is_local := base_node.kind == .ident && tc.ident_resolves_to_value(base_node.value)
+	if !base_is_local {
+		if typ := tc.global_type_for_selector(node) {
+			return typ
+		}
+		if typ := tc.const_type_for_selector(node) {
+			return typ
+		}
+	}
 	base_type := tc.selector_fn_base_type(base_id) or { return none }
 	clean := unalias_and_unwrap_pointer_type(base_type)
 	if clean is Struct {
@@ -14819,8 +14853,7 @@ fn fn_param_modes_compatible_at(actual FnType, actual_idx int, expected FnType, 
 	actual_type := fn_compatible_param_type(actual, actual_idx)
 	expected_type := fn_compatible_param_type(expected, expected_idx)
 	if actual_type is Pointer && expected_type is Pointer {
-		if fn_param_unalias_type(actual_type.base_type).name() ==
-			fn_param_unalias_type(expected_type.base_type).name() {
+		if fn_param_unalias_type(actual_type.base_type).name() == fn_param_unalias_type(expected_type.base_type).name() {
 			return true
 		}
 	}
@@ -15075,7 +15108,12 @@ fn (mut tc TypeChecker) check_if_expr(id flat.NodeId, node flat.Node) {
 	then_id := tc.a.child(&node, 1)
 	then_uses_block_scope := guard_bindings.len == 0 && tc.valid_node_id(then_id)
 		&& tc.a.nodes[int(then_id)].kind == .block
-	saved_smartcasts := clone_smartcasts(tc.smartcasts)
+	had_saved_smartcasts := tc.smartcasts.len > 0
+	saved_smartcasts := if had_saved_smartcasts {
+		clone_smartcasts(tc.smartcasts)
+	} else {
+		tc.smartcasts
+	}
 	for sc in smartcasts {
 		if valid_string_data(sc.name) {
 			tc.smartcasts[sc.name] = sc.typ
@@ -15115,7 +15153,11 @@ fn (mut tc TypeChecker) check_if_expr(id flat.NodeId, node flat.Node) {
 	}
 	tc.fn_context.unsafe_reference_alias_owners = unsafe_alias_base.clone()
 	tc.fn_context.pointer_binding_value_keys = clone_pointer_binding_value_keys(pointer_alias_base)
-	tc.smartcasts = clone_smartcasts(saved_smartcasts)
+	if had_saved_smartcasts {
+		tc.smartcasts = clone_smartcasts(saved_smartcasts)
+	} else {
+		tc.smartcasts.clear()
+	}
 	if node.children_count > 2 {
 		else_id := tc.a.child(&node, 2)
 		else_smartcasts := tc.extract_else_branch_smartcasts(cond_id)
@@ -15139,7 +15181,11 @@ fn (mut tc TypeChecker) check_if_expr(id flat.NodeId, node flat.Node) {
 			pointer_alias_paths << clone_pointer_binding_value_keys(tc.fn_context.pointer_binding_value_keys)
 		}
 		if else_smartcasts.len > 0 {
-			tc.smartcasts = clone_smartcasts(saved_smartcasts)
+			if had_saved_smartcasts {
+				tc.smartcasts = clone_smartcasts(saved_smartcasts)
+			} else {
+				tc.smartcasts.clear()
+			}
 		}
 	} else {
 		if !condition_is_true {
@@ -15175,7 +15221,11 @@ fn (mut tc TypeChecker) check_if_expr(id flat.NodeId, node flat.Node) {
 		}
 	}
 	then_type := tc.branch_tail_type(then_id)
-	tc.smartcasts = clone_smartcasts(saved_smartcasts)
+	if had_saved_smartcasts {
+		tc.smartcasts = clone_smartcasts(saved_smartcasts)
+	} else {
+		tc.smartcasts.clear()
+	}
 	mut else_type := Type(void_)
 	if node.children_count > 2 {
 		else_id := tc.a.child(&node, 2)

--- a/vlib/v3/types/checker_tail_stmt.v
+++ b/vlib/v3/types/checker_tail_stmt.v
@@ -97,9 +97,18 @@ fn (tc &TypeChecker) expression_node_used_as_value(id flat.NodeId) bool {
 }
 
 fn (mut tc TypeChecker) check_statement_sequence(node flat.Node, body_start int, value_tail bool) {
-	saved_smartcasts := clone_smartcasts(tc.smartcasts)
+	had_saved_smartcasts := tc.smartcasts.len > 0
+	saved_smartcasts := if had_saved_smartcasts {
+		clone_smartcasts(tc.smartcasts)
+	} else {
+		tc.smartcasts
+	}
 	defer {
-		tc.smartcasts = clone_smartcasts(saved_smartcasts)
+		if had_saved_smartcasts {
+			tc.smartcasts = clone_smartcasts(saved_smartcasts)
+		} else {
+			tc.smartcasts.clear()
+		}
 	}
 	last_idx := int(node.children_count) - 1
 	mut sequence_exited := false
@@ -3097,25 +3106,20 @@ fn (tc &TypeChecker) struct_init_is_interface_return(id flat.NodeId) bool {
 	if unalias_and_unwrap_pointer_type(tc.fn_context.return_type) !is Interface {
 		return false
 	}
-	fn_id := flat.NodeId(tc.fn_context.node_id)
-	if !tc.valid_node_id(fn_id) {
-		return false
-	}
-	fn_node := tc.a.node(fn_id)
-	mut stack := []flat.NodeId{}
-	for i in 0 .. fn_node.children_count {
-		stack << tc.a.child(fn_node, i)
-	}
-	for stack.len > 0 {
-		current_id := stack.pop()
-		current := tc.a.node(current_id)
-		if current.kind == .return_stmt && current.children_count == 1
-			&& tc.node_tree_contains(tc.a.child(current, 0), id, 0) {
-			return true
+	mut current := id
+	for _ in 0 .. 128 {
+		parent_id := tc.direct_parent_id(current)
+		if !tc.valid_node_id(parent_id) {
+			return false
 		}
-		for i in 0 .. current.children_count {
-			stack << tc.a.child(current, i)
+		parent := tc.a.node(parent_id)
+		if parent.kind == .return_stmt {
+			return parent.children_count == 1
 		}
+		if parent.kind in [.fn_decl, .fn_literal, .lambda_expr] {
+			return false
+		}
+		current = parent_id
 	}
 	return false
 }
@@ -4154,6 +4158,31 @@ fn (tc &TypeChecker) source_struct_decl_id_for_name(name string) ?flat.NodeId {
 }
 
 fn (tc &TypeChecker) struct_field_diagnostic_fn_type(struct_name string, field_name string, field_index int) ?(string, string) {
+	key := '${struct_name}\x00${field_name}\x00${field_index}'
+	mut cache := tc.type_cache
+	if !isnil(cache) {
+		if cached := cache.struct_field_fn_diagnostics[key] {
+			separator := cached.index_u8(0)
+			if separator <= 0 {
+				return none
+			}
+			return cached[..separator], cached[separator + 1..]
+		}
+	}
+	expected, alias := tc.struct_field_diagnostic_fn_type_uncached(struct_name, field_name,
+		field_index) or {
+		if !isnil(cache) {
+			cache.struct_field_fn_diagnostics[key] = '\x00'
+		}
+		return none
+	}
+	if !isnil(cache) {
+		cache.struct_field_fn_diagnostics[key] = '${expected}\x00${alias}'
+	}
+	return expected, alias
+}
+
+fn (tc &TypeChecker) struct_field_diagnostic_fn_type_uncached(struct_name string, field_name string, field_index int) ?(string, string) {
 	decl := tc.source_struct_decl_for_name(struct_name) or { return none }
 	base, concrete_args, is_generic := generic_type_application_parts(struct_name)
 	struct_params := if is_generic {
@@ -4195,7 +4224,12 @@ fn (tc &TypeChecker) source_fn_field_type_text(field flat.Node) ?string {
 	source := tc.source_texts_by_file[file.name] or { return none }
 	offset := int_min(int_max(field.pos.offset, 0), source.len)
 	line_start := if offset > 0 {
-		if relative := source[..offset].last_index('\n') { relative + 1 } else { 0 }
+		relative := last_index_between(source, '\n', 0, offset)
+		if relative >= 0 {
+			relative + 1
+		} else {
+			0
+		}
 	} else {
 		0
 	}
@@ -8223,10 +8257,13 @@ fn (tc &TypeChecker) enum_selector_type(node &flat.Node) ?Type {
 	base := tc.a.child_node(node, 0)
 	mut enum_name := ''
 	if base.kind == .ident {
+		if base.value.len == 0 || !base.value[0].is_capital() {
+			return none
+		}
 		enum_name = tc.resolve_enum_name(base.value) or { '' }
 	} else if base.kind == .selector && base.children_count > 0 {
 		inner := tc.a.child_node(base, 0)
-		if inner.kind == .ident {
+		if inner.kind == .ident && base.value.len > 0 && base.value[0].is_capital() {
 			mod_name := tc.resolve_import_alias(inner.value) or { inner.value }
 			enum_name = tc.resolve_enum_name('${mod_name}.${base.value}') or { '' }
 		}
@@ -10828,11 +10865,19 @@ fn (tc &TypeChecker) struct_field_type(struct_name string, field_name string) ?T
 				tc.remember_struct_field_type(struct_name, field_name, typ, true)
 				return typ
 			}
+			if fallback.struct_field_misses[cache_key] {
+				tc.remember_struct_field_type(struct_name, field_name, Type(void_), false)
+				return none
+			}
 			fallback = fallback.base
 		}
 		if typ := tc.type_cache.struct_field_entries[cache_key] {
 			tc.remember_struct_field_type(struct_name, field_name, typ, true)
 			return typ
+		}
+		if tc.type_cache.struct_field_misses[cache_key] {
+			tc.remember_struct_field_type(struct_name, field_name, Type(void_), false)
+			return none
 		}
 	}
 	mut seen := map[string]bool{}
@@ -10843,6 +10888,10 @@ fn (tc &TypeChecker) struct_field_type(struct_name string, field_name string) ?T
 		}
 		tc.remember_struct_field_type(struct_name, field_name, typ, true)
 		return typ
+	}
+	if !isnil(tc.type_cache) {
+		mut cache := tc.type_cache
+		cache.struct_field_misses[cache_key] = true
 	}
 	tc.remember_struct_field_type(struct_name, field_name, Type(void_), false)
 	return none
@@ -10890,8 +10939,16 @@ fn (tc &TypeChecker) struct_field_type_inner(struct_name string, field_name stri
 			return field.typ
 		}
 	}
+	embeds_indexed := lookup_name in tc.struct_embed_receivers
 	for field in fields {
-		mut embedded_type := embedded_field_type(field) or { continue }
+		mut embedded_type := field.typ
+		if embeds_indexed {
+			if !field.is_embed {
+				continue
+			}
+		} else {
+			embedded_type = embedded_field_type(field) or { continue }
+		}
 		embedded_type = if is_generic {
 			tc.substitute_generic_type(embedded_type, generic_args, tc.struct_generic_params[base_name] or {
 				[]string{}
@@ -11781,7 +11838,23 @@ fn (tc &TypeChecker) sum_has_variant(sum_name string, variant_name string) bool 
 }
 
 pub fn (tc &TypeChecker) sum_variant_type_for_pattern(sum_name string, variant_name string) ?string {
-	return tc.sum_variant_type_for_pattern_depth(sum_name, variant_name, 0)
+	if isnil(tc.type_cache) {
+		return tc.sum_variant_type_for_pattern_depth(sum_name, variant_name, 0)
+	}
+	mut cache := tc.type_cache
+	key := '${tc.cur_file}\x01${tc.cur_module}\x01${sum_name}\x01${variant_name}'
+	if cached := cache.sum_variant_pattern_entries[key] {
+		if cached.len == 0 {
+			return none
+		}
+		return cached
+	}
+	result := tc.sum_variant_type_for_pattern_depth(sum_name, variant_name, 0) or {
+		cache.sum_variant_pattern_entries[key] = ''
+		return none
+	}
+	cache.sum_variant_pattern_entries[key] = result
+	return result
 }
 
 fn (tc &TypeChecker) sum_variant_type_for_pattern_depth(sum_name string, variant_name string, depth int) ?string {
@@ -12029,6 +12102,26 @@ fn (tc &TypeChecker) expr_key_part(id flat.NodeId) string {
 
 // smartcast_type supports smartcast type handling for TypeChecker.
 fn (tc &TypeChecker) smartcast_type(id flat.NodeId) ?Type {
+	idx := int(id)
+	if idx < 0 || idx >= tc.a.nodes.len || tc.a.nodes[idx].kind !in [.ident, .selector, .index] {
+		return none
+	}
+	mut cache := tc.type_cache
+	// Most checker contexts have no active dynamic smartcast. Consult the
+	// node-indexed lexical cache first so repeated type queries do not rebuild an
+	// expression key merely to rediscover the same lexical hit or miss.
+	if tc.smartcasts.len == 0 && idx >= 0 && idx < tc.lexical_smartcast_misses.len
+		&& tc.lexical_smartcast_misses[idx] {
+		return none
+	}
+	if tc.smartcasts.len == 0 && idx >= 0 && idx < tc.direct_parent_ids.len && !isnil(cache) {
+		if typ := cache.lexical_smartcast_entries[idx] {
+			return typ
+		}
+		if cache.lexical_smartcast_misses[idx] {
+			return none
+		}
+	}
 	key := tc.expr_key(id)
 	if key.len == 0 {
 		return none
@@ -12043,14 +12136,42 @@ fn (tc &TypeChecker) smartcast_type(id flat.NodeId) ?Type {
 	// are appended after the parent index was built and carry explicit/synthetic
 	// types; walking the full arena to rediscover a parent for each such lookup
 	// makes self-host transformation quadratic.
-	idx := int(id)
 	if idx < 0 || idx >= tc.direct_parent_ids.len {
 		return none
 	}
+	if idx < tc.lexical_smartcast_misses.len && tc.lexical_smartcast_misses[idx] {
+		return none
+	}
+	if !isnil(cache) {
+		if typ := cache.lexical_smartcast_entries[idx] {
+			return typ
+		}
+		if cache.lexical_smartcast_misses[idx] {
+			return none
+		}
+	}
+	result := tc.lexical_smartcast_type(id, key) or {
+		if !tc.resolution_type_mode && idx < tc.lexical_smartcast_misses.len
+			&& (!tc.parallel_check_sparse || (idx >= tc.check_range_lo && idx <= tc.check_range_hi)) {
+			mut writable := unsafe { tc }
+			writable.lexical_smartcast_misses[idx] = true
+		}
+		if !isnil(cache) {
+			cache.lexical_smartcast_misses[idx] = true
+		}
+		return none
+	}
+	if !isnil(cache) {
+		cache.lexical_smartcast_entries[idx] = result
+	}
+	return result
+}
+
+fn (tc &TypeChecker) lexical_smartcast_type(id flat.NodeId, key string) ?Type {
 	if typ := tc.lexical_if_smartcast_type(id, key) {
 		return typ
 	}
-	return tc.lexical_match_smartcast_type(id)
+	return tc.lexical_match_smartcast_type_with_key(id, key)
 }
 
 fn (tc &TypeChecker) lexical_if_smartcast_type(id flat.NodeId, key string) ?Type {
@@ -12094,11 +12215,14 @@ fn (tc &TypeChecker) lexical_if_smartcast_type(id flat.NodeId, key string) ?Type
 }
 
 fn (tc &TypeChecker) lexical_match_smartcast_type(id flat.NodeId) ?Type {
+	return tc.lexical_match_smartcast_type_with_key(id, tc.expr_key(id))
+}
+
+fn (tc &TypeChecker) lexical_match_smartcast_type_with_key(id flat.NodeId, key string) ?Type {
 	idx := int(id)
 	if idx < 0 || idx >= tc.direct_parent_ids.len {
 		return none
 	}
-	key := tc.expr_key(id)
 	if key.len == 0 || !valid_string_data(key) {
 		return none
 	}
@@ -15924,12 +16048,12 @@ fn (tc &TypeChecker) generic_struct_method_base_candidates(base string) []string
 	if base.contains('.') {
 		resolved := tc.resolve_imported_type_text(base)
 		push_receiver_method_candidate(mut candidates, resolved)
-		push_receiver_method_candidate(mut candidates, resolved.all_after_last('.'))
-		push_receiver_method_candidate(mut candidates, base.all_after_last('.'))
+		push_receiver_method_candidate(mut candidates, short_name_view(resolved))
+		push_receiver_method_candidate(mut candidates, short_name_view(base))
 	} else {
 		if resolved := tc.resolve_selective_import_type_symbol(base) {
 			push_receiver_method_candidate(mut candidates, resolved)
-			push_receiver_method_candidate(mut candidates, resolved.all_after_last('.'))
+			push_receiver_method_candidate(mut candidates, short_name_view(resolved))
 		}
 		qualified := tc.qualify_name(base)
 		push_receiver_method_candidate(mut candidates, qualified)


### PR DESCRIPTION
## Summary

- reduce repeated AST scans, string allocations, cache cloning, and redundant map work in V3 checking
- share frozen transform context across workers and merge only fresh worker cache ranges
- batch C generation work and cheaply filter fixed-storage candidates before expensive name lookups
- preserve qualified function ownership during mark-used pruning and add a regression test

## Why

V3 self-host compilation had regressed to roughly 1.99 seconds across check, transform, and C generation. The hot paths repeatedly scanned large AST regions, allocated short/owner name strings, rebuilt worker-local indexes, and merged cache entries that could not overlap.

These changes keep the existing semantics while reusing read-only indexes, reducing allocations under `-prealloc`, and increasing useful work per parallel dispatch.

## Impact

Using:

```sh
cd vlib/v3
../../v -gc none -prealloc -prod -o v3 v3.v
./v3 -nocache -building-v -o v4 v3.v
```

A representative run measured:

- check: 265.81 ms
- transform: 269.65 ms
- cgen: 240.97 ms
- combined: 776.43 ms

After rebasing the work onto merged `master`, three warm runs measured 769.35, 789.25, and 805.96 ms (789.25 ms median). Wall-clock timing is sensitive to concurrent workstation load.

## Validation

- `./vnew -silent vlib/v3/tests/markused_test.v`
- `./vnew -silent vlib/v3/tests/fixed_array_const_materialization_codegen_test.v`
- `./vnew -silent vlib/v3/types/checker_parallel_test.v`
- `./vnew -silent vlib/v3/transform/transform_parallel_test.v`
- `./vnew -silent vlib/v3/tests/parallel_determinism_test.v`
- `git diff --check`

All focused tests pass on the merged `master` base.