### PR TITLE
vself: do not default to tcc on macOS arm64 when it would just fail

### DIFF
--- a/cmd/tools/vself.v
+++ b/cmd/tools/vself.v
@@ -32,10 +32,14 @@ fn main() {
 		// compiling by default, i.e. `v self`:
 		uos := os.user_os()
 		uname := os.uname()
-		if uos == 'macos' && uname.machine == 'arm64' {
+		if uos == 'macos' && uname.machine == 'arm64' && gc_mode_from_args(args) !in ['', 'none'] {
 			// Apple silicon, like m1, m2 etc
 			// Use tcc by default for V, since tinycc is much faster and also
-			// it already supports compiling many programs like V itself, that do not depend on inlined objective-C code
+			// it already supports compiling many programs like V itself, that do not depend on inlined objective-C code.
+			// Note: a plain `v self` (no explicit -gc) forces Preferences.prealloc on
+			// for macOS builds of V itself, which declares its allocator state
+			// `_Thread_local` - a keyword the bundled tcc cannot parse. Only default
+			// to tcc here when an explicit non-`none` `-gc` rules that out.
 			args << '-cc tcc'
 		} else if uos == 'linux' && uname.machine in ['arm64', 'aarch64'] {
 			// Bundled TCC can hang while bootstrapping V on Linux ARM64, so
@@ -131,6 +135,20 @@ fn has_gc_arg(args []string) bool {
 		}
 	}
 	return false
+}
+
+// gc_mode_from_args returns the value of an explicit `-gc <mode>` or `-gc=<mode>`
+// flag in args, or '' when no `-gc` flag is present.
+fn gc_mode_from_args(args []string) string {
+	for i, arg in args {
+		if arg == '-gc' {
+			return if i + 1 < args.len { args[i + 1] } else { '' }
+		}
+		if arg.starts_with('-gc=') {
+			return arg.all_after('-gc=')
+		}
+	}
+	return ''
 }
 
 fn has_profile_cflag(args []string) bool {


### PR DESCRIPTION
## Summary
- A plain `v self` on Apple Silicon macOS always fails to compile with the bundled `tcc` and silently falls back to `cc`, as reported in #28023.
- Root cause: `Preferences.fill_with_defaults()` forces `-prealloc` on for macOS builds of V itself when no real GC is selected (exactly what `v self`'s implicit `-gc none` does). `-prealloc` declares its allocator global `g_memory_block` as `_Thread_local`, a C11 keyword the bundled tcc does not implement.
- The builder's own `try_to_use_tcc_by_default()` already avoids defaulting to tcc when `-prealloc` is set, but `cmd/tools/vself.v` bypasses that guard by unconditionally injecting an explicit `-cc tcc` for Apple Silicon before the guard ever runs.
- Fix: only add `-cc tcc` in `vself.v` when the caller explicitly requested a real GC via `-gc` (the one case where `-prealloc` isn't forced and tcc remains compatible). Plain `v self` (and `v self -gc none`) now goes straight to `cc` with no failing attempt; `v self -gc boehm` still gets the fast tcc path.

## Test plan
- [x] Reproduced the failure on macOS/arm64 (`v self` → `warning: tcc compilation failed, falling back to cc`), traced it to the `_Thread_local g_memory_block` declaration via `-keepc`.
- [x] Verified `v self`, `v self -gc none`, and `v self -gc boehm` all build cleanly after the fix, with correct compiler selection in each case.
- [x] `v test vlib/v/builder/cc_tcc_retry_test.v` passes.
- [x] `v fmt -verify cmd/tools/vself.v` passes.

Fixes #28023

🤖 Generated with [Claude Code](https://claude.com/claude-code)