### PR TITLE
sync.stdatomic: fix tcc builds when tcc has no stdatomic.h

### DIFF
--- a/vlib/sync/stdatomic/1.declarations.c.v
+++ b/vlib/sync/stdatomic/1.declarations.c.v
@@ -19,7 +19,7 @@ $if windows {
 		#insert "@VEXEROOT/vlib/sync/stdatomic/tcc_compat_freebsd_amd64_fence_pre.h"
 	}
 	$if tinyc {
-		#include <stdatomic.h>
+		#insert "@VEXEROOT/vlib/sync/stdatomic/tcc_compat_restore.h"
 		$if linux {
 			#insert "@VEXEROOT/vlib/sync/stdatomic/tcc_compat_linux_fence.h"
 		}

--- a/vlib/sync/stdatomic/tcc_compat_restore.h
+++ b/vlib/sync/stdatomic/tcc_compat_restore.h
@@ -1,0 +1,51 @@
+#ifndef V_TCC_STDATOMIC_COMPAT_RESTORED
+#define V_TCC_STDATOMIC_COMPAT_RESTORED
+
+/*
+ * The cleanup header above hides V's compatibility helpers again, so the
+ * standard API has to come back for user and third party headers.
+ *
+ * TCC ships its own self contained <stdatomic.h> since 0.9.28, so prefer that
+ * one when it is there. Older TCCs have no such header and would silently pick
+ * up GCC's, which is written against __ATOMIC_* builtins that TCC does not
+ * provide - either the include is not found at all, or it fails later with
+ * '__ATOMIC_RELAXED' undeclared. In that case restore the few names V itself
+ * relies on from the bundled compat header instead.
+ */
+#if defined(__has_include)
+#if __has_include(<stdatomic.h>)
+#define V_TCC_STDATOMIC_SYSTEM_HEADER 1
+#endif
+#endif
+
+#ifdef V_TCC_STDATOMIC_SYSTEM_HEADER
+
+#include <stdatomic.h>
+
+#else
+
+#define _Atomic volatile
+
+typedef int memory_order;
+
+#define memory_order_relaxed 0
+#define memory_order_consume 1
+#define memory_order_acquire 2
+#define memory_order_release 3
+#define memory_order_acq_rel 4
+#define memory_order_seq_cst 5
+
+/* The alias pass renamed the fence declarations of the compat header, so the
+ * plain names have to be reintroduced. TinyCC relies on its runtime atomics
+ * support here, same as the compat header does. */
+extern void __atomic_thread_fence(memory_order order);
+
+#if defined(__APPLE__)
+extern void atomic_thread_fence(memory_order order);
+#else
+#define atomic_thread_fence(order) __atomic_thread_fence(order)
+#endif
+
+#endif
+
+#endif


### PR DESCRIPTION
Fixes #28026.

`1.declarations.c.v` unconditionally includes the real `<stdatomic.h>` for tcc builds, right after the bundled compat header has gone out of its way to avoid it. That include was added in #27740 to bring the standard API back for user and third-party headers, and it works fine with the tcc V bundles (0.9.28rc), because that one ships its own self contained `stdatomic.h`. It falls apart on anything older - tcc 0.9.27 has no such header, so the include either fails outright:

```
builder error: 'stdatomic.h' not found
```

or, on a system where tcc does end up finding GCC's copy, dies a bit later on `'__ATOMIC_RELAXED' undeclared`, since GCC's header is written against builtins tcc does not provide.

Because `v run` silently retries with cc, none of this is visible unless you pass `-no-retry-compilation`. Anyone importing `sync.stdatomic` just quietly loses tcc as a backend.

So instead of including the header blindly, check for it first and fall back to the compat header's own definitions when it is not there. The `#include <stdatomic.h>` moves into a new `tcc_compat_restore.h`, guarded by `__has_include`. When tcc has the header nothing changes at all - same include, same order, same behaviour as today. When it does not, the fallback restores the handful of names the cleanup header stripped and that V itself needs: `_Atomic`, `memory_order`, the `memory_order_*` constants and the thread fence declarations, mirroring what `thirdparty/stdatomic/nix/atomic.h` already does for tcc.

Older tccs without `__has_include` support take the fallback branch too, which is the right answer for them anyway.

### Testing

Reproduced by removing `stdatomic.h` from the bundled tcc's include dir, which puts it in the same state as a 0.9.27 install. On master that gives the exact error from the issue; with this patch:

- `v -cc tcc -no-retry-compilation run` on the issue's repro - fails on master, prints `1` with the patch
- `v -cc tcc -no-retry-compilation test vlib/sync/` with the header removed - passes
- `v -cc tcc -no-retry-compilation test vlib/sync/` with the header in place - passes, unchanged
- `v -cc gcc test vlib/sync/stdatomic/` - passes
- `v -cc tcc -no-retry-compilation -o v cmd/v` - builds

One note on the no-header case: `stdatomic_include_after_compat_nix_test.v` still fails there, but that is by design - the test itself does `#include <stdatomic.h>`, so it cannot pass on a compiler that has no such header. CI uses the bundled tcc, so it is unaffected.
