### PR TITLE
tools: make git_argv.sh argv validation locale independent

### DIFF
--- a/cmd/tools/git_argv.sh
+++ b/cmd/tools/git_argv.sh
@@ -7,6 +7,9 @@ declare -a git_cmd=()
 parse_git_argv() {
 	local git_argv_spec="${GIT:-git}"
 	git_cmd=()
+	# Bracket ranges are collation dependent, so keep the check on the C locale.
+	# Under tr_TR.UTF-8 for example, [A-Za-z] does not even match plain `git`.
+	local LC_ALL=C
 	# GIT is a space-delimited argv prefix. Use a wrapper without spaces when
 	# one argument itself would otherwise need shell quoting.
 	if [[ ! "$git_argv_spec" =~ ^[-A-Za-z0-9_./:=+@%,\ ]+$ ]]; then


### PR DESCRIPTION
`make` fails to bootstrap on a machine with a Turkish locale:

```
$ make
git is required to download ./vc/v.c. Install git or provide the file manually.
make: *** [GNUmakefile:445: vc/.git/config] Error 1
```

git is installed and on PATH. The real cause is the argv validation in `cmd/tools/git_argv.sh`:

```sh
if [[ ! "$git_argv_spec" =~ ^[-A-Za-z0-9_./:=+@%,\ ]+$ ]]; then
```

Bracket ranges inside a regex are matched by collation order, not by code point, so `[A-Za-z]` means whatever the current locale says lies between A and z. Under `tr_TR.UTF-8` that does not include the letters in the default value `git`:

```
$ LANG=tr_TR.UTF-8 bash -c '[[ "git" =~ ^[-A-Za-z0-9_./:=+@%,\ ]+$ ]] && echo MATCH || echo NOMATCH'
NOMATCH
$ LC_ALL=C bash -c '[[ "git" =~ ^[-A-Za-z0-9_./:=+@%,\ ]+$ ]] && echo MATCH || echo NOMATCH'
MATCH
```

So `git_argv.sh check` returns 2 with "the Git command contains unsupported characters", the GNUmakefile reads that as git being unavailable, and the build stops before it ever gets to `vc/v.c`. Anyone on a locale whose collation puts ASCII letters outside that range hits it, and the error message points in completely the wrong direction.

Fix is to pin the locale for that one comparison with `local LC_ALL=C`. It is scoped to the function, so nothing else in the script or in the callers changes locale, and the accepted character set stays exactly what it was.

### Testing

- `bash cmd/tools/git_argv.sh check` under `tr_TR.UTF-8` - fails on master, passes with this patch
- `make` under `tr_TR.UTF-8` - stops at the git check on master, builds fine with this patch
- rejection still works: `GIT='git;rm -rf /' bash cmd/tools/git_argv.sh check` exits 2
- argv prefixes still work: `GIT='git -c core.autocrlf=false' bash cmd/tools/git_argv.sh check` passes
- `v test vlib/v/tests/gnu_make_tcc_fallback_test.v` - passes
