### PR TITLE
docs: fix example code not printing properly

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -540,7 +540,7 @@ fn foo() (int, int) {
 
 fn main() {
 	c, _ := foo()
-	print(c)
+	println(c)
 	// no warning about unused variable returned by foo.
 }
 ```


### PR DESCRIPTION
This code example:

`fn foo() (int, int) {`
`    return 2, 3`
`}`

`fn main() {`
`    c, _ := foo()`
`    print(c)`
`    // no warning about unused variable returned by foo.`
`}`

is supposed to print out the second returned variable from `foo()`, which is 3.

The issue is that it uses `print()` instead of `println()` to do so, resulting in nothing being printed to output, because a new line has not been started.
There are multiple ways to start a new line for this context, `println()` is easiest.