### PR TITLE
v3: ownership fixes

### DIFF
--- a/vlib/v3/gen/c/array.v
+++ b/vlib/v3/gen/c/array.v
@@ -529,17 +529,24 @@ fn (mut g FlatGen) gen_slice_expr(node flat.Node, base_id flat.NodeId, base_type
 fn (mut g FlatGen) gen_array_method_call(node flat.Node, fn_node &flat.Node, arr types.Array) {
 	base_id := g.a.child(fn_node, 0)
 	mut elem_type := arr.elem_type
-	receiver_type := types.unwrap_pointer(g.usable_expr_type(base_id))
+	base_expr_type := g.usable_expr_type(base_id)
+	receiver_type0 := if g.a.nodes[int(base_id)].kind == .call {
+		declared := g.declared_call_return_type(base_id)
+		if declared !is types.Unknown && declared !is types.Void {
+			declared
+		} else {
+			base_expr_type
+		}
+	} else {
+		base_expr_type
+	}
+	receiver_type := types.unwrap_pointer(receiver_type0)
 	if receiver_arr := array_like_type(receiver_type) {
 		elem_type = receiver_arr.elem_type
 	}
 	c_elem := g.value_c_type(elem_type)
 	base_node := g.a.nodes[int(base_id)]
-	is_ptr := if base_node.kind == .ident {
-		g.usable_expr_type(base_id) is types.Pointer
-	} else {
-		false
-	}
+	is_ptr := receiver_type0 is types.Pointer
 	dot := if is_ptr { '->' } else { '.' }
 	match fn_node.value {
 		'clone' {
@@ -1743,6 +1750,9 @@ fn (mut g FlatGen) gen_index_assign(node flat.Node) {
 		if base_type is types.Pointer {
 			ptr_type := base_type
 			mut expected_type := ptr_type.base_type
+			base_node := g.a.node(base_id)
+			explicit_mut_pointer_param := base_node.kind == .ident
+				&& g.current_param_is_mut_pointer(base_node.value)
 			if fixed := array_fixed_type(ptr_type.base_type) {
 				g.write('(*')
 				g.gen_expr(base_id)
@@ -1750,6 +1760,10 @@ fn (mut g FlatGen) gen_index_assign(node flat.Node) {
 				expected_type = fixed.elem_type
 			} else if ptr_type.base_type is types.Void {
 				g.write('((u8*)')
+				g.gen_expr(base_id)
+				g.write(')')
+			} else if explicit_mut_pointer_param {
+				g.write('(*')
 				g.gen_expr(base_id)
 				g.write(')')
 			} else {

--- a/vlib/v3/gen/c/array.v
+++ b/vlib/v3/gen/c/array.v
@@ -1764,7 +1764,7 @@ fn (mut g FlatGen) gen_index_assign(node flat.Node) {
 				g.write(')')
 			} else if explicit_mut_pointer_param {
 				g.write('(*')
-				g.gen_expr(base_id)
+				g.gen_mut_pointer_slot_expr(base_id)
 				g.write(')')
 			} else {
 				g.write('(')

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -12,6 +12,7 @@ import v3.types
 import v3.util
 
 const spread_index_expected_type_marker = '__v3_spread_index_expected_type'
+const source_mut_pointer_deref_marker = '__v3_source_mut_pointer_deref'
 const c_inline_header_size_limit = 262_144
 const v1_c_headers_source = $embed_file('../../../v/gen/c/cheaders.v').to_string()
 const c_objective_c_bridge_qualifiers = ['__bridge', '__bridge_retained', '__bridge_transfer']
@@ -9436,6 +9437,44 @@ fn (mut g FlatGen) expr_to_string_with_expected_type(id flat.NodeId, expected ty
 	return result
 }
 
+fn (mut g FlatGen) gen_mut_pointer_slot_expr(id flat.NodeId) {
+	node := g.a.nodes[int(id)]
+	if node.kind == .ident && g.current_param_is_mut_pointer(node.value) {
+		g.write(g.local_decl_cname(node.value))
+		return
+	}
+	g.gen_expr(id)
+}
+
+fn (g &FlatGen) source_mut_pointer_param_deref_type(id flat.NodeId) ?types.Type {
+	if int(id) < 0 || int(id) >= g.a.nodes.len {
+		return none
+	}
+	node := g.a.node(id)
+	if node.kind in [.expr_stmt, .paren] && node.children_count > 0 {
+		return g.source_mut_pointer_param_deref_type(g.a.child(node, 0))
+	}
+	if node.kind == .block && node.children_count > 0 {
+		return g.source_mut_pointer_param_deref_type(g.a.child(node, node.children_count - 1))
+	}
+	if node.kind == .prefix && node.op == .mul && node.value.len == 0 && node.children_count > 0 {
+		return g.source_mut_pointer_param_deref_type(g.a.child(node, 0))
+	}
+	if node.kind != .prefix || node.op != .mul || node.value != source_mut_pointer_deref_marker
+		|| node.children_count == 0 {
+		return none
+	}
+	child := g.a.child_node(node, 0)
+	if child.kind != .ident || !g.current_param_is_mut_pointer(child.value) {
+		return none
+	}
+	slot_type := g.current_param_type(child.value) or { return none }
+	if slot_type is types.Pointer && slot_type.base_type is types.Pointer {
+		return slot_type.base_type.base_type
+	}
+	return none
+}
+
 fn (mut g FlatGen) default_value_to_string(typ types.Type) string {
 	orig := g.sb
 	orig_line_start := g.line_start
@@ -9628,7 +9667,11 @@ fn (mut g FlatGen) gen_cast_from_mut_param_address(id flat.NodeId, ct string) bo
 		return false
 	}
 	g.write('(${ct})(')
-	g.gen_expr(child_id)
+	if g.current_param_is_mut_pointer(child.value) {
+		g.gen_mut_pointer_slot_expr(child_id)
+	} else {
+		g.gen_expr(child_id)
+	}
 	g.write(')')
 	return true
 }
@@ -9833,7 +9876,11 @@ fn (mut g FlatGen) gen_current_mut_param_value_read(id flat.NodeId, expected typ
 		return false
 	}
 	g.write('*')
-	g.gen_expr(id)
+	if g.current_param_is_mut_pointer(node.value) {
+		g.gen_mut_pointer_slot_expr(id)
+	} else {
+		g.gen_expr(id)
+	}
 	return true
 }
 
@@ -9916,6 +9963,9 @@ fn (mut g FlatGen) gen_expr_with_expected_type(id flat.NodeId, expected types.Ty
 		}
 	}
 	mut actual := if has_known_actual { known_actual } else { g.usable_expr_type(id) }
+	if deref_type := g.source_mut_pointer_param_deref_type(id) {
+		actual = deref_type
+	}
 	if node.kind == .ident {
 		if local_type := g.local_ident_type(node.value) {
 			actual = local_type
@@ -10949,16 +10999,26 @@ fn (mut g FlatGen) gen_pointer_pointer_struct_selector(base_id flat.NodeId, base
 		return false
 	}
 	struct_name := (struct_type as types.Struct).name
+	base := g.a.nodes[int(base_id)]
+	base_is_mut_pointer_param := base.kind == .ident && g.current_param_is_mut_pointer(base.value)
 
 	if _ := g.struct_field_type(struct_name, field) {
 		g.write('(*(')
-		g.gen_expr(base_id)
+		if base_is_mut_pointer_param {
+			g.gen_mut_pointer_slot_expr(base_id)
+		} else {
+			g.gen_expr(base_id)
+		}
 		g.write('))->${g.cname(field)}')
 		return true
 	}
 	if embedded_path := g.embedded_field_path_for_promoted_selector(inner_base, field) {
 		g.write('(*(')
-		g.gen_expr(base_id)
+		if base_is_mut_pointer_param {
+			g.gen_mut_pointer_slot_expr(base_id)
+		} else {
+			g.gen_expr(base_id)
+		}
 		g.write('))')
 		for embedded in embedded_path {
 			g.write('->${g.cname(embedded.name)}')
@@ -12817,6 +12877,15 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 			}
 		}
 		.ident {
+			if g.current_param_is_mut_pointer(node.value) {
+				// A `mut p &T` parameter is stored as a `T**` slot; its value in an
+				// expression is the `&T` pointer `*p`. Slot/lvalue consumers emit the
+				// raw parameter name through gen_mut_pointer_slot_expr instead.
+				g.write('(*')
+				g.gen_mut_pointer_slot_expr(id)
+				g.write(')')
+				return
+			}
 			if c_fn_name := g.test_user_main_fn_value_c_name(id, node) {
 				g.write(c_fn_name)
 				return
@@ -13106,6 +13175,11 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 		.prefix {
 			child_id := g.a.child(node, 0)
 			child := g.a.nodes[int(child_id)]
+			if node.op == .mul && node.value.len == 0
+				&& g.source_mut_pointer_param_deref_type(child_id) != none {
+				g.gen_expr(child_id)
+				return
+			}
 			if node.value == 'shared' {
 				g.gen_expr(child_id)
 				return
@@ -13131,6 +13205,18 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 				return
 			}
 			if node.op == .mul && child.kind == .ident {
+				if g.current_param_is_mut_pointer(child.value) {
+					// A source `*item` must dereference both the `T**` ABI slot and its
+					// semantic `&T` value. Synthetic dereferences only read the slot.
+					g.write('(*')
+					if g.source_mut_pointer_param_deref_type(id) != none {
+						g.gen_expr(child_id)
+					} else {
+						g.gen_mut_pointer_slot_expr(child_id)
+					}
+					g.write(')')
+					return
+				}
 				if typ := g.current_param_type(child.value) {
 					if typ !is types.Pointer {
 						g.gen_expr(child_id)
@@ -13350,7 +13436,11 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 			}
 			if child.kind == .ident && g.current_param_is_mut(child.value) {
 				g.write('(*')
-				g.gen_expr(child_id)
+				if g.current_param_is_mut_pointer(child.value) {
+					g.gen_mut_pointer_slot_expr(child_id)
+				} else {
+					g.gen_expr(child_id)
+				}
 				g.write(')')
 			} else {
 				g.gen_expr(child_id)
@@ -13375,7 +13465,11 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 					return
 				}
 			}
-			base_type0 := g.usable_expr_type(base_id)
+			mut base_type0 := g.usable_expr_type(base_id)
+			base_is_source_mut_pointer_deref := g.source_mut_pointer_param_deref_type(base_id) != none
+			if deref_type := g.source_mut_pointer_param_deref_type(base_id) {
+				base_type0 = deref_type
+			}
 			base_type_clean := types.unwrap_pointer(base_type0)
 			if base_type0 is types.Channel && node.value in ['closed', 'len', 'cap'] {
 				if node.value == 'closed' {
@@ -13686,7 +13780,7 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 					g.write(')')
 				}
 				mut is_ptr := false
-				mut local_type_known := false
+				mut local_type_known := base_is_source_mut_pointer_deref
 				if base.kind == .ident {
 					if typ := g.tc.cur_scope.lookup(base.value) {
 						local_type_known = true

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -398,6 +398,7 @@ mut:
 	cur_param_types              map[string]types.Type
 	cur_concrete_optional_params map[string]bool
 	cur_mut_params               map[string]bool
+	cur_mut_pointer_params       map[string]bool
 	cur_mut_param_owners         map[string]types.ScopeBindingOwner
 	cur_fn_ret                   types.Type = types.Type(types.void_)
 	cur_fn_ret_is_optional       bool
@@ -1016,6 +1017,7 @@ pub fn FlatGen.new() FlatGen {
 		cur_param_types:                 map[string]types.Type{}
 		cur_concrete_optional_params:    map[string]bool{}
 		cur_mut_params:                  map[string]bool{}
+		cur_mut_pointer_params:          map[string]bool{}
 		cur_mut_param_owners:            map[string]types.ScopeBindingOwner{}
 		active_locks:                    []ActiveLock{}
 		conditional_branch_scopes:       []&types.Scope{}
@@ -2102,6 +2104,7 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	g.cur_param_types.clear()
 	g.cur_concrete_optional_params.clear()
 	g.cur_mut_params.clear()
+	g.cur_mut_pointer_params.clear()
 	g.cur_mut_param_owners.clear()
 	g.active_locks = []ActiveLock{}
 	g.loop_depth = 0

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -362,6 +362,7 @@ mut:
 	cur_param_types              map[string]types.Type
 	cur_concrete_optional_params map[string]bool
 	cur_mut_params               map[string]bool
+	cur_mut_pointer_params       map[string]bool
 	cur_mut_param_owners         map[string]types.ScopeBindingOwner
 	cur_fn_ret                   types.Type = types.Type(types.void_)
 	cur_fn_ret_is_optional       bool
@@ -958,6 +959,7 @@ pub fn FlatGen.new() FlatGen {
 		cur_param_types:                 map[string]types.Type{}
 		cur_concrete_optional_params:    map[string]bool{}
 		cur_mut_params:                  map[string]bool{}
+		cur_mut_pointer_params:          map[string]bool{}
 		cur_mut_param_owners:            map[string]types.ScopeBindingOwner{}
 		active_locks:                    []ActiveLock{}
 		conditional_branch_scopes:       []&types.Scope{}
@@ -2042,6 +2044,7 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	g.cur_param_types.clear()
 	g.cur_concrete_optional_params.clear()
 	g.cur_mut_params.clear()
+	g.cur_mut_pointer_params.clear()
 	g.cur_mut_param_owners.clear()
 	g.active_locks = []ActiveLock{}
 	g.loop_depth = 0

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -1441,6 +1441,23 @@ fn (g &FlatGen) selector_base_is_value(name string) bool {
 	return false
 }
 
+fn (g &FlatGen) selector_base_is_local_value(name string) bool {
+	if name.len == 0 {
+		return false
+	}
+	if g.tc != unsafe { nil } && g.tc.cur_scope != unsafe { nil } {
+		if typ := g.tc.cur_scope.lookup(name) {
+			if typ !is types.Void {
+				return true
+			}
+		}
+	}
+	if _ := g.current_param_type(name) {
+		return true
+	}
+	return false
+}
+
 fn (g &FlatGen) has_import_alias(alias string) bool {
 	if _ := g.import_alias_module(alias) {
 		return true
@@ -4144,6 +4161,7 @@ fn (mut g FlatGen) gen_fn_in_module(node_id flat.NodeId, node flat.Node, module_
 	g.cur_param_types.clear()
 	g.cur_concrete_optional_params.clear()
 	g.cur_mut_params.clear()
+	g.cur_mut_pointer_params.clear()
 	g.cur_mut_param_owners.clear()
 	typed_params := g.fn_node_param_types(node, module_name)
 	concrete_optional_params := g.is_specialized_generic_fn_node(node)
@@ -4178,6 +4196,9 @@ fn (mut g FlatGen) gen_fn_in_module(node_id flat.NodeId, node flat.Node, module_
 				}
 				if p.is_mut {
 					g.cur_mut_params[p.value] = true
+					if p.op == .amp {
+						g.cur_mut_pointer_params[p.value] = true
+					}
 					g.cur_mut_param_owners[p.value] = owner
 				}
 				if concrete_optional_params && type_is_optional_result(param_type) {
@@ -4433,12 +4454,14 @@ fn (mut g FlatGen) gen_top_level_main(stmts []TopLevelStmt) {
 	mut old_param_types := g.cur_param_types.move()
 	mut old_concrete_optional_params := g.cur_concrete_optional_params.move()
 	mut old_mut_params := g.cur_mut_params.move()
+	mut old_mut_pointer_params := g.cur_mut_pointer_params.move()
 	mut old_mut_param_owners := g.cur_mut_param_owners.move()
 	g.cur_param_names = []string{}
 	g.cur_param_type_values = []types.Type{}
 	g.cur_param_types = map[string]types.Type{}
 	g.cur_concrete_optional_params = map[string]bool{}
 	g.cur_mut_params = map[string]bool{}
+	g.cur_mut_pointer_params = map[string]bool{}
 	g.cur_mut_param_owners = map[string]types.ScopeBindingOwner{}
 	g.prepare_function_defers(prelude_scan.defer_ids)
 	g.goto_label_c_names.clear()
@@ -4476,6 +4499,7 @@ fn (mut g FlatGen) gen_top_level_main(stmts []TopLevelStmt) {
 	g.cur_param_types = old_param_types.move()
 	g.cur_concrete_optional_params = old_concrete_optional_params.move()
 	g.cur_mut_params = old_mut_params.move()
+	g.cur_mut_pointer_params = old_mut_pointer_params.move()
 	g.cur_mut_param_owners = old_mut_param_owners.move()
 	g.cur_fn_name = old_fn_name
 	g.loop_depth = 0
@@ -9781,6 +9805,10 @@ fn (g &FlatGen) current_param_is_mut(name string) bool {
 	return g.tc.cur_scope.nearest_binding_owned_by(name, owner)
 }
 
+fn (g &FlatGen) current_param_is_mut_pointer(name string) bool {
+	return g.current_param_is_mut(name) && (g.cur_mut_pointer_params[name] or { false })
+}
+
 fn (g &FlatGen) current_mut_param_binding_is_shadowed(name string) bool {
 	if g.cur_mut_params.len == 0 {
 		return false
@@ -10828,12 +10856,18 @@ fn (mut g FlatGen) gen_optional_arg_with_abi(arg_id flat.NodeId, expected types.
 		return true
 	}
 	arg_node := g.a.nodes[int(arg_id)]
+	// The checker can contextually type a plain call as `?T` when it is used
+	// where an option is expected. The callee's declared return type remains
+	// authoritative: only treat a call as an already materialized option when
+	// that function actually returns one.
+	plain_call_in_optional_context := arg_node.kind == .call
+		&& !g.expr_really_returns_optional(arg_id)
 	if concrete_abi && arg_node.kind == .none_expr {
 		ct := g.concrete_optional_type_name(expected)
 		g.write('(${ct}){.ok = false}')
 		return true
 	}
-	if arg_node.typ.len > 0 {
+	if arg_node.typ.len > 0 && !plain_call_in_optional_context {
 		raw_arg_type := g.parse_node_type(&arg_node)
 		if raw_arg_type is types.OptionType || raw_arg_type is types.ResultType {
 			if concrete_abi {
@@ -10862,7 +10896,8 @@ fn (mut g FlatGen) gen_optional_arg_with_abi(arg_id flat.NodeId, expected types.
 	}
 	arg_type := g.usable_expr_type(arg_id)
 	arg_optional_type := optional_result_unalias_type(arg_type)
-	if arg_optional_type is types.OptionType || arg_optional_type is types.ResultType {
+	if !plain_call_in_optional_context
+		&& (arg_optional_type is types.OptionType || arg_optional_type is types.ResultType) {
 		if concrete_abi {
 			g.gen_concrete_optional_arg_from_optional_expr(arg_id, arg_optional_type, expected,
 				base_type)
@@ -12285,15 +12320,20 @@ fn (g &FlatGen) target_module_call_name(target string, node flat.Node) ?string {
 	if base.len == 0 || method.len == 0 {
 		return none
 	}
-	if typ := g.tc.cur_scope.lookup(base) {
-		if typ !is types.Void {
-			return none
+	arg_start := g.target_module_call_arg_start(target, node)
+	// A transformed module selector carries its namespace ident as a synthetic
+	// first argument. That syntactic marker remains authoritative when a global
+	// constant happens to share the module alias; the argument is discarded below.
+	if arg_start != 2 {
+		if typ := g.tc.cur_scope.lookup(base) {
+			if typ !is types.Void {
+				return none
+			}
 		}
 	}
 	static_name := '${base}.${method}'
 	if static_name in g.tc.fn_param_types || static_name in g.tc.fn_ret_types
 		|| static_name in g.tc.fn_generic_params {
-		arg_start := g.target_module_call_arg_start(target, node)
 		params := g.tc.fn_param_types[static_name] or {
 			if static_name in g.tc.fn_ret_types && node.children_count == arg_start {
 				return static_name
@@ -12315,7 +12355,6 @@ fn (g &FlatGen) target_module_call_name(target string, node flat.Node) ?string {
 		return none
 	}
 	call_name := '${mod_name}.${method}'
-	arg_start := g.target_module_call_arg_start(target, node)
 	params := g.tc.fn_param_types[call_name] or {
 		if call_name in g.tc.fn_ret_types && node.children_count == arg_start {
 			return call_name
@@ -12334,8 +12373,12 @@ fn (g &FlatGen) target_module_call_arg_start(target string, node flat.Node) int 
 	}
 	base := target.all_before_last('.')
 	first_arg := g.a.child_node(&node, 1)
-	if first_arg.kind == .ident
-		&& (first_arg.value == base || base.ends_with('.${first_arg.value}')) {
+	// Constant resolution can qualify the synthetic module-base argument when the
+	// imported module exports a same-named constant (`flags` -> `flags.flags`). It
+	// is still the namespace marker inserted while lowering the selector.
+	qualified_same_name := '${base}.${base.all_after_last('.')}'
+	if first_arg.kind == .ident && (first_arg.value == base || base.ends_with('.${first_arg.value}')
+		|| first_arg.value == qualified_same_name) {
 		return 2
 	}
 	return 1
@@ -12518,6 +12561,15 @@ fn (mut g FlatGen) gen_call_args(fn_name string, node flat.Node, start int) {
 			break
 		}
 		if g.gen_array_equality_literal_arg([fn_name, callee_name], arg_idx, arg_id, arg_node) {
+			continue
+		}
+		// A source `mut p &T` parameter is stored as a `T**` pointer slot.
+		// An ordinary (non-`mut`) argument reads its `&T` value from that slot;
+		// forwarding `mut p` is handled below and passes the slot itself.
+		if arg_node.kind == .ident && !arg_node.is_mut
+			&& g.current_param_is_mut_pointer(arg_node.value) {
+			g.write('*')
+			g.gen_expr(arg_id)
 			continue
 		}
 		if !is_c_call && arg_idx == 0 && start == 1 && arg_node.kind == .ident
@@ -12873,7 +12925,15 @@ fn (g &FlatGen) call_callee_is_module_selector(node flat.Node) bool {
 		return false
 	}
 	base := g.a.child_node(callee, 0)
-	if base.kind != .ident || g.selector_base_is_value(base.value) {
+	if base.kind != .ident {
+		return false
+	}
+	if source_file := g.a.source_files[callee.pos.id] {
+		if _ := g.tc.file_imports[source_file.name + '\n' + base.value] {
+			return !g.selector_base_is_local_value(base.value)
+		}
+	}
+	if g.selector_base_is_value(base.value) {
 		return false
 	}
 	return g.selector_base_module(base.value) != none
@@ -13625,7 +13685,8 @@ fn (mut g FlatGen) gen_mut_pointer_slot_arg(arg_id flat.NodeId, arg_node flat.No
 	// by the callee, so emitting the lowered dereference would lose one level.
 	if arg_node.kind == .prefix && arg_node.op == .mul && arg_node.children_count == 1 {
 		child := g.a.child_node(&arg_node, 0)
-		if child.kind == .ident && g.current_param_is_mut(child.value) {
+		if child.kind == .ident && g.current_param_is_mut(child.value)
+			&& !g.current_param_is_mut_pointer(child.value) {
 			param_type := g.current_param_type(child.value) or { types.Type(types.void_) }
 			if g.tc.c_type(param_type) == g.tc.c_type(expected) {
 				g.write(g.cname(child.value))
@@ -15610,23 +15671,32 @@ fn (mut g FlatGen) write_fn_node_params(node flat.Node) {
 		}
 		effective_pt := g.fn_node_effective_param_type(p, raw_pt)
 		param_idx++
-		if concrete_optional_params && type_is_optional_result(effective_pt) && p.value.len > 0 {
+		// `mut p &T` mutates the pointer slot itself. Its semantic parameter is
+		// `&T`, while the C ABI receives the caller's slot as `T**`.
+		abi_pt := if p.is_mut && p.op == .amp && effective_pt is types.Pointer {
+			types.Type(types.Pointer{
+				base_type: effective_pt
+			})
+		} else {
+			effective_pt
+		}
+		if concrete_optional_params && type_is_optional_result(abi_pt) && p.value.len > 0 {
 			g.cur_concrete_optional_params[p.value] = true
 		}
 		ct := if shared_ct := g.shared_param_c_type(p.typ) {
 			shared_ct
 		} else if concrete_optional_params
-			&& (effective_pt is types.OptionType || effective_pt is types.ResultType) {
-			g.concrete_optional_type_name(effective_pt)
-		} else if effective_pt is types.Pointer && (effective_pt.base_type is types.OptionType
-			|| effective_pt.base_type is types.ResultType) {
-			g.optional_type_name(effective_pt)
-		} else if effective_pt is types.ArrayFixed {
-			'${g.fixed_array_elem_c_type(effective_pt.elem_type)}*'
-		} else if effective_pt is types.OptionType || effective_pt is types.ResultType {
-			g.optional_type_name(effective_pt)
+			&& (abi_pt is types.OptionType || abi_pt is types.ResultType) {
+			g.concrete_optional_type_name(abi_pt)
+		} else if abi_pt is types.Pointer
+			&& (abi_pt.base_type is types.OptionType || abi_pt.base_type is types.ResultType) {
+			g.optional_type_name(abi_pt)
+		} else if abi_pt is types.ArrayFixed {
+			'${g.fixed_array_elem_c_type(abi_pt.elem_type)}*'
+		} else if abi_pt is types.OptionType || abi_pt is types.ResultType {
+			g.optional_type_name(abi_pt)
 		} else {
-			g.tc.c_type(effective_pt)
+			g.tc.c_type(abi_pt)
 		}
 		if ct.starts_with('fn_ptr:') {
 			g.write(g.resolve_fn_ptr_type(ct))

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -5525,12 +5525,10 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 			}
 		}
 	}
-	drop_target_name := if resolved_target_name.len > 0 {
-		resolved_target_name
-	} else {
-		target_name
-	}
-	if node.children_count == 2 && g.ownership_drop_intrinsic_name(drop_target_name) {
+	// Ownership lowering appends its calls after checking, so they have no source position.
+	is_ownership_drop := (!node.pos.is_valid() && ownership_synthetic_drop_name(fn_name))
+		|| (resolved_target_name.len > 0 && g.ownership_drop_intrinsic_name(resolved_target_name))
+	if node.children_count == 2 && is_ownership_drop {
 		arg_id := g.a.child(&node, 1)
 		arg_type := g.usable_expr_type(arg_id)
 		g.writeln('({')
@@ -7063,21 +7061,23 @@ fn (g &FlatGen) expr_is_non_string_scalar_value(id flat.NodeId) bool {
 		|| clean is types.ISize || clean is types.USize || clean is types.Enum
 }
 
+fn ownership_synthetic_drop_name(name string) bool {
+	return name == 'drop_owned' || name.starts_with('drop_owned_T_')
+		|| name == 'drop_owned_v3_interface' || name.starts_with('drop_owned_v3_interface_T_')
+}
+
 fn (g &FlatGen) ownership_drop_intrinsic_name(name string) bool {
 	if name in ['builtin.drop_owned', 'builtin__drop_owned']
-		|| name.starts_with('builtin.drop_owned_T_') || name.starts_with('builtin__drop_owned_T_') {
-		return true
-	}
-	if name in ['drop_owned_v3_interface', 'builtin.drop_owned_v3_interface', 'builtin__drop_owned_v3_interface']
-		|| name.starts_with('drop_owned_v3_interface_T_')
+		|| name.starts_with('builtin.drop_owned_T_') || name.starts_with('builtin__drop_owned_T_')
+		|| name in ['builtin.drop_owned_v3_interface', 'builtin__drop_owned_v3_interface']
 		|| name.starts_with('builtin.drop_owned_v3_interface_T_')
 		|| name.starts_with('builtin__drop_owned_v3_interface_T_') {
 		return true
 	}
-	if name != 'drop_owned' && !name.starts_with('drop_owned_T_') {
+	if !ownership_synthetic_drop_name(name) {
 		return false
 	}
-	module_name := g.tc.fn_type_modules['drop_owned'] or { return false }
+	module_name := g.tc.fn_type_modules[name] or { return false }
 	return module_name == 'builtin'
 }
 
@@ -7281,7 +7281,11 @@ fn (mut g FlatGen) gen_current_mut_param_method_receiver(base_id flat.NodeId, wa
 	if base.kind != .ident || !g.current_param_is_mut(base.value) {
 		return false
 	}
-	g.write(g.cname(base.value))
+	if g.current_param_is_mut_pointer(base.value) {
+		g.gen_expr(base_id)
+	} else {
+		g.write(g.cname(base.value))
+	}
 	return true
 }
 
@@ -12563,15 +12567,6 @@ fn (mut g FlatGen) gen_call_args(fn_name string, node flat.Node, start int) {
 		if g.gen_array_equality_literal_arg([fn_name, callee_name], arg_idx, arg_id, arg_node) {
 			continue
 		}
-		// A source `mut p &T` parameter is stored as a `T**` pointer slot.
-		// An ordinary (non-`mut`) argument reads its `&T` value from that slot;
-		// forwarding `mut p` is handled below and passes the slot itself.
-		if arg_node.kind == .ident && !arg_node.is_mut
-			&& g.current_param_is_mut_pointer(arg_node.value) {
-			g.write('*')
-			g.gen_expr(arg_id)
-			continue
-		}
 		if !is_c_call && arg_idx == 0 && start == 1 && arg_node.kind == .ident
 			&& (g.mut_receiver_arg_wants_addr(fn_name, arg_id)
 			|| (!callee_is_module_selector && g.mut_receiver_arg_wants_addr(callee_name, arg_id))) {
@@ -15671,32 +15666,23 @@ fn (mut g FlatGen) write_fn_node_params(node flat.Node) {
 		}
 		effective_pt := g.fn_node_effective_param_type(p, raw_pt)
 		param_idx++
-		// `mut p &T` mutates the pointer slot itself. Its semantic parameter is
-		// `&T`, while the C ABI receives the caller's slot as `T**`.
-		abi_pt := if p.is_mut && p.op == .amp && effective_pt is types.Pointer {
-			types.Type(types.Pointer{
-				base_type: effective_pt
-			})
-		} else {
-			effective_pt
-		}
-		if concrete_optional_params && type_is_optional_result(abi_pt) && p.value.len > 0 {
+		if concrete_optional_params && type_is_optional_result(effective_pt) && p.value.len > 0 {
 			g.cur_concrete_optional_params[p.value] = true
 		}
 		ct := if shared_ct := g.shared_param_c_type(p.typ) {
 			shared_ct
 		} else if concrete_optional_params
-			&& (abi_pt is types.OptionType || abi_pt is types.ResultType) {
-			g.concrete_optional_type_name(abi_pt)
-		} else if abi_pt is types.Pointer
-			&& (abi_pt.base_type is types.OptionType || abi_pt.base_type is types.ResultType) {
-			g.optional_type_name(abi_pt)
-		} else if abi_pt is types.ArrayFixed {
-			'${g.fixed_array_elem_c_type(abi_pt.elem_type)}*'
-		} else if abi_pt is types.OptionType || abi_pt is types.ResultType {
-			g.optional_type_name(abi_pt)
+			&& (effective_pt is types.OptionType || effective_pt is types.ResultType) {
+			g.concrete_optional_type_name(effective_pt)
+		} else if effective_pt is types.Pointer && (effective_pt.base_type is types.OptionType
+			|| effective_pt.base_type is types.ResultType) {
+			g.optional_type_name(effective_pt)
+		} else if effective_pt is types.ArrayFixed {
+			'${g.fixed_array_elem_c_type(effective_pt.elem_type)}*'
+		} else if effective_pt is types.OptionType || effective_pt is types.ResultType {
+			g.optional_type_name(effective_pt)
 		} else {
-			g.tc.c_type(abi_pt)
+			g.tc.c_type(effective_pt)
 		}
 		if ct.starts_with('fn_ptr:') {
 			g.write(g.resolve_fn_ptr_type(ct))

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -1438,6 +1438,23 @@ fn (g &FlatGen) selector_base_is_value(name string) bool {
 	return false
 }
 
+fn (g &FlatGen) selector_base_is_local_value(name string) bool {
+	if name.len == 0 {
+		return false
+	}
+	if g.tc != unsafe { nil } && g.tc.cur_scope != unsafe { nil } {
+		if typ := g.tc.cur_scope.lookup(name) {
+			if typ !is types.Void {
+				return true
+			}
+		}
+	}
+	if _ := g.current_param_type(name) {
+		return true
+	}
+	return false
+}
+
 fn (g &FlatGen) has_import_alias(alias string) bool {
 	if _ := g.import_alias_module(alias) {
 		return true
@@ -4139,6 +4156,7 @@ fn (mut g FlatGen) gen_fn_in_module(node_id flat.NodeId, node flat.Node, module_
 	g.cur_param_types.clear()
 	g.cur_concrete_optional_params.clear()
 	g.cur_mut_params.clear()
+	g.cur_mut_pointer_params.clear()
 	g.cur_mut_param_owners.clear()
 	typed_params := g.fn_node_param_types(node, module_name)
 	concrete_optional_params := g.is_specialized_generic_fn_node(node)
@@ -4173,6 +4191,9 @@ fn (mut g FlatGen) gen_fn_in_module(node_id flat.NodeId, node flat.Node, module_
 				}
 				if p.is_mut {
 					g.cur_mut_params[p.value] = true
+					if p.op == .amp {
+						g.cur_mut_pointer_params[p.value] = true
+					}
 					g.cur_mut_param_owners[p.value] = owner
 				}
 				if concrete_optional_params && type_is_optional_result(param_type) {
@@ -4427,12 +4448,14 @@ fn (mut g FlatGen) gen_top_level_main(stmts []TopLevelStmt) {
 	mut old_param_types := g.cur_param_types.move()
 	mut old_concrete_optional_params := g.cur_concrete_optional_params.move()
 	mut old_mut_params := g.cur_mut_params.move()
+	mut old_mut_pointer_params := g.cur_mut_pointer_params.move()
 	mut old_mut_param_owners := g.cur_mut_param_owners.move()
 	g.cur_param_names = []string{}
 	g.cur_param_type_values = []types.Type{}
 	g.cur_param_types = map[string]types.Type{}
 	g.cur_concrete_optional_params = map[string]bool{}
 	g.cur_mut_params = map[string]bool{}
+	g.cur_mut_pointer_params = map[string]bool{}
 	g.cur_mut_param_owners = map[string]types.ScopeBindingOwner{}
 	g.prepare_function_defers(prelude_scan.defer_ids)
 	g.goto_label_c_names.clear()
@@ -4470,6 +4493,7 @@ fn (mut g FlatGen) gen_top_level_main(stmts []TopLevelStmt) {
 	g.cur_param_types = old_param_types.move()
 	g.cur_concrete_optional_params = old_concrete_optional_params.move()
 	g.cur_mut_params = old_mut_params.move()
+	g.cur_mut_pointer_params = old_mut_pointer_params.move()
 	g.cur_mut_param_owners = old_mut_param_owners.move()
 	g.cur_fn_name = old_fn_name
 	g.loop_depth = 0
@@ -9733,6 +9757,10 @@ fn (g &FlatGen) current_param_is_mut(name string) bool {
 	return g.tc.cur_scope.nearest_binding_owned_by(name, owner)
 }
 
+fn (g &FlatGen) current_param_is_mut_pointer(name string) bool {
+	return g.current_param_is_mut(name) && (g.cur_mut_pointer_params[name] or { false })
+}
+
 fn (g &FlatGen) current_mut_param_binding_is_shadowed(name string) bool {
 	if g.cur_mut_params.len == 0 {
 		return false
@@ -10757,12 +10785,18 @@ fn (mut g FlatGen) gen_optional_arg_with_abi(arg_id flat.NodeId, expected types.
 		return true
 	}
 	arg_node := g.a.nodes[int(arg_id)]
+	// The checker can contextually type a plain call as `?T` when it is used
+	// where an option is expected. The callee's declared return type remains
+	// authoritative: only treat a call as an already materialized option when
+	// that function actually returns one.
+	plain_call_in_optional_context := arg_node.kind == .call
+		&& !g.expr_really_returns_optional(arg_id)
 	if concrete_abi && arg_node.kind == .none_expr {
 		ct := g.concrete_optional_type_name(expected)
 		g.write('(${ct}){.ok = false}')
 		return true
 	}
-	if arg_node.typ.len > 0 {
+	if arg_node.typ.len > 0 && !plain_call_in_optional_context {
 		raw_arg_type := g.tc.parse_type(arg_node.typ)
 		if raw_arg_type is types.OptionType || raw_arg_type is types.ResultType {
 			if concrete_abi {
@@ -10791,7 +10825,8 @@ fn (mut g FlatGen) gen_optional_arg_with_abi(arg_id flat.NodeId, expected types.
 	}
 	arg_type := g.usable_expr_type(arg_id)
 	arg_optional_type := optional_result_unalias_type(arg_type)
-	if arg_optional_type is types.OptionType || arg_optional_type is types.ResultType {
+	if !plain_call_in_optional_context
+		&& (arg_optional_type is types.OptionType || arg_optional_type is types.ResultType) {
 		if concrete_abi {
 			g.gen_concrete_optional_arg_from_optional_expr(arg_id, arg_optional_type, expected,
 				base_type)
@@ -12214,15 +12249,20 @@ fn (g &FlatGen) target_module_call_name(target string, node flat.Node) ?string {
 	if base.len == 0 || method.len == 0 {
 		return none
 	}
-	if typ := g.tc.cur_scope.lookup(base) {
-		if typ !is types.Void {
-			return none
+	arg_start := g.target_module_call_arg_start(target, node)
+	// A transformed module selector carries its namespace ident as a synthetic
+	// first argument. That syntactic marker remains authoritative when a global
+	// constant happens to share the module alias; the argument is discarded below.
+	if arg_start != 2 {
+		if typ := g.tc.cur_scope.lookup(base) {
+			if typ !is types.Void {
+				return none
+			}
 		}
 	}
 	static_name := '${base}.${method}'
 	if static_name in g.tc.fn_param_types || static_name in g.tc.fn_ret_types
 		|| static_name in g.tc.fn_generic_params {
-		arg_start := g.target_module_call_arg_start(target, node)
 		params := g.tc.fn_param_types[static_name] or {
 			if static_name in g.tc.fn_ret_types && node.children_count == arg_start {
 				return static_name
@@ -12244,7 +12284,6 @@ fn (g &FlatGen) target_module_call_name(target string, node flat.Node) ?string {
 		return none
 	}
 	call_name := '${mod_name}.${method}'
-	arg_start := g.target_module_call_arg_start(target, node)
 	params := g.tc.fn_param_types[call_name] or {
 		if call_name in g.tc.fn_ret_types && node.children_count == arg_start {
 			return call_name
@@ -12263,8 +12302,12 @@ fn (g &FlatGen) target_module_call_arg_start(target string, node flat.Node) int 
 	}
 	base := target.all_before_last('.')
 	first_arg := g.a.child_node(&node, 1)
-	if first_arg.kind == .ident
-		&& (first_arg.value == base || base.ends_with('.${first_arg.value}')) {
+	// Constant resolution can qualify the synthetic module-base argument when the
+	// imported module exports a same-named constant (`flags` -> `flags.flags`). It
+	// is still the namespace marker inserted while lowering the selector.
+	qualified_same_name := '${base}.${base.all_after_last('.')}'
+	if first_arg.kind == .ident && (first_arg.value == base || base.ends_with('.${first_arg.value}')
+		|| first_arg.value == qualified_same_name) {
 		return 2
 	}
 	return 1
@@ -12447,6 +12490,15 @@ fn (mut g FlatGen) gen_call_args(fn_name string, node flat.Node, start int) {
 			break
 		}
 		if g.gen_array_equality_literal_arg([fn_name, callee_name], arg_idx, arg_id, arg_node) {
+			continue
+		}
+		// A source `mut p &T` parameter is stored as a `T**` pointer slot.
+		// An ordinary (non-`mut`) argument reads its `&T` value from that slot;
+		// forwarding `mut p` is handled below and passes the slot itself.
+		if arg_node.kind == .ident && !arg_node.is_mut
+			&& g.current_param_is_mut_pointer(arg_node.value) {
+			g.write('*')
+			g.gen_expr(arg_id)
 			continue
 		}
 		if !is_c_call && arg_idx == 0 && start == 1 && arg_node.kind == .ident
@@ -12802,7 +12854,15 @@ fn (g &FlatGen) call_callee_is_module_selector(node flat.Node) bool {
 		return false
 	}
 	base := g.a.child_node(callee, 0)
-	if base.kind != .ident || g.selector_base_is_value(base.value) {
+	if base.kind != .ident {
+		return false
+	}
+	if source_file := g.a.source_files[callee.pos.id] {
+		if _ := g.tc.file_imports[source_file.name + '\n' + base.value] {
+			return !g.selector_base_is_local_value(base.value)
+		}
+	}
+	if g.selector_base_is_value(base.value) {
 		return false
 	}
 	return g.selector_base_module(base.value) != none
@@ -13548,7 +13608,8 @@ fn (mut g FlatGen) gen_mut_pointer_slot_arg(arg_id flat.NodeId, arg_node flat.No
 	// by the callee, so emitting the lowered dereference would lose one level.
 	if arg_node.kind == .prefix && arg_node.op == .mul && arg_node.children_count == 1 {
 		child := g.a.child_node(&arg_node, 0)
-		if child.kind == .ident && g.current_param_is_mut(child.value) {
+		if child.kind == .ident && g.current_param_is_mut(child.value)
+			&& !g.current_param_is_mut_pointer(child.value) {
 			param_type := g.current_param_type(child.value) or { types.Type(types.void_) }
 			if g.tc.c_type(param_type) == g.tc.c_type(expected) {
 				g.write(g.cname(child.value))
@@ -15513,23 +15574,32 @@ fn (mut g FlatGen) write_fn_node_params(node flat.Node) {
 		}
 		effective_pt := g.fn_node_effective_param_type(p, raw_pt)
 		param_idx++
-		if concrete_optional_params && type_is_optional_result(effective_pt) && p.value.len > 0 {
+		// `mut p &T` mutates the pointer slot itself. Its semantic parameter is
+		// `&T`, while the C ABI receives the caller's slot as `T**`.
+		abi_pt := if p.is_mut && p.op == .amp && effective_pt is types.Pointer {
+			types.Type(types.Pointer{
+				base_type: effective_pt
+			})
+		} else {
+			effective_pt
+		}
+		if concrete_optional_params && type_is_optional_result(abi_pt) && p.value.len > 0 {
 			g.cur_concrete_optional_params[p.value] = true
 		}
 		ct := if shared_ct := g.shared_param_c_type(p.typ) {
 			shared_ct
 		} else if concrete_optional_params
-			&& (effective_pt is types.OptionType || effective_pt is types.ResultType) {
-			g.concrete_optional_type_name(effective_pt)
-		} else if effective_pt is types.Pointer && (effective_pt.base_type is types.OptionType
-			|| effective_pt.base_type is types.ResultType) {
-			g.optional_type_name(effective_pt)
-		} else if effective_pt is types.ArrayFixed {
-			'${g.fixed_array_elem_c_type(effective_pt.elem_type)}*'
-		} else if effective_pt is types.OptionType || effective_pt is types.ResultType {
-			g.optional_type_name(effective_pt)
+			&& (abi_pt is types.OptionType || abi_pt is types.ResultType) {
+			g.concrete_optional_type_name(abi_pt)
+		} else if abi_pt is types.Pointer
+			&& (abi_pt.base_type is types.OptionType || abi_pt.base_type is types.ResultType) {
+			g.optional_type_name(abi_pt)
+		} else if abi_pt is types.ArrayFixed {
+			'${g.fixed_array_elem_c_type(abi_pt.elem_type)}*'
+		} else if abi_pt is types.OptionType || abi_pt is types.ResultType {
+			g.optional_type_name(abi_pt)
 		} else {
-			g.tc.c_type(effective_pt)
+			g.tc.c_type(abi_pt)
 		}
 		if ct.starts_with('fn_ptr:') {
 			g.write(g.resolve_fn_ptr_type(ct))

--- a/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
@@ -1682,6 +1682,11 @@ fn (g &FlatGen) new_parallel_worker_config(worker_id int, result_only bool) &Fla
 		} else {
 			g.cur_mut_params.clone()
 		}
+		cur_mut_pointer_params:         if result_only {
+			g.cur_mut_pointer_params
+		} else {
+			g.cur_mut_pointer_params.clone()
+		}
 		cur_mut_param_owners:           if result_only {
 			g.cur_mut_param_owners
 		} else {

--- a/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
@@ -1870,6 +1870,11 @@ fn (g &FlatGen) new_parallel_worker_config(worker_id int, result_only bool) &Fla
 		} else {
 			g.cur_mut_params.clone()
 		}
+		cur_mut_pointer_params:         if result_only {
+			g.cur_mut_pointer_params
+		} else {
+			g.cur_mut_pointer_params.clone()
+		}
 		cur_mut_param_owners:           if result_only {
 			g.cur_mut_param_owners
 		} else {

--- a/vlib/v3/gen/c/interface.v
+++ b/vlib/v3/gen/c/interface.v
@@ -1199,7 +1199,13 @@ fn (mut g FlatGen) gen_interface_value_expr(id flat.NodeId, expected types.Type)
 	mut actual := g.interface_source_type(id)
 	if node.kind == .ident {
 		if param_type := g.current_param_type(node.value) {
-			actual = param_type
+			// A `mut p &T` parameter uses `&&T` storage, but reading `p` yields
+			// the semantic `&T` value that is being boxed into the interface.
+			actual = if g.current_param_is_mut_pointer(node.value) && param_type is types.Pointer {
+				param_type.base_type
+			} else {
+				param_type
+			}
 		}
 	}
 	actual_clean := if actual is types.Pointer { actual.base_type } else { actual }
@@ -1360,7 +1366,13 @@ fn (g &FlatGen) interface_init_typ_id(node flat.Node) ?int {
 	for i in 0 .. node.children_count {
 		field := g.a.child_node(&node, i)
 		if field.kind == .field_init && field.value == '_object' && field.children_count > 0 {
-			obj_type := g.tc.resolve_type(g.a.child(field, 0))
+			obj_id := g.a.child(field, 0)
+			obj_node := g.a.node(obj_id)
+			mut obj_type := g.tc.resolve_type(obj_id)
+			if obj_node.kind == .ident && g.current_param_is_mut_pointer(obj_node.value)
+				&& obj_type is types.Pointer {
+				obj_type = obj_type.base_type
+			}
 			concrete := types.unwrap_pointer(obj_type)
 			id := g.iface_type_id_for_concrete(iface, concrete)
 			if id != 0 {

--- a/vlib/v3/gen/c/stmt.v
+++ b/vlib/v3/gen/c/stmt.v
@@ -43,10 +43,17 @@ fn gen_expr_lvalue(mut g FlatGen, id flat.NodeId) {
 		if base.kind == .prefix && base.op == .mul && base.children_count > 0 {
 			child_id := g.a.child(&base, 0)
 			child := g.a.nodes[int(child_id)]
-			child_type := g.usable_expr_type(child_id)
-			if child.kind == .ident && child_type is types.Pointer
-				&& g.current_param_is_mut(child.value) {
-				g.gen_expr(child_id)
+			if child.kind == .ident && g.current_param_is_mut(child.value) {
+				// A source `mut p &T` parameter has pointer-slot ABI (`T**`),
+				// while a plain `mut value T` parameter has `T*` ABI.
+				// The transformed lvalue base is `*p` in both cases.
+				if g.current_param_is_mut_pointer(child.value) {
+					g.write('(*')
+					g.gen_expr(child_id)
+					g.write(')')
+				} else {
+					g.gen_expr(child_id)
+				}
 				g.write('[')
 				g.gen_expr(g.a.child(&node, 1))
 				g.write(']')
@@ -1033,6 +1040,11 @@ fn (mut g FlatGen) gen_ownership_recursive_drop_helper_forward_decls() {
 	if g.recursive_drop_helpers.len == 0 {
 		return
 	}
+	// Recursive drop helpers are emitted before const definitions and their
+	// generated Result/Option cleanup guards reference the process-wide IError
+	// sentinels. Declare those globals before the helper bodies.
+	g.writeln('extern IError builtin__none__;')
+	g.writeln('extern IError builtin__error_sentinel;')
 	mut keys := g.recursive_drop_helpers.keys()
 	keys.sort()
 	for key in keys {
@@ -2868,7 +2880,12 @@ fn (mut g FlatGen) gen_node(id flat.NodeId) {
 			// NOTE: match_stmt is intentionally absent — the transformer lowers every
 			// match into an if/else-if chain (see transform.lower_match_stmts), so the
 			// backend never sees one. Match lowering lives in the transformer, not here.
-			eprintln('gen_node: unsupported node kind: ${node.kind}')
+			source_name := if source_file := g.a.source_files[node.pos.id] {
+				source_file.name
+			} else {
+				''
+			}
+			eprintln('gen_node: unsupported node kind: ${node.kind}; fn=${g.cur_fn_name}; source=${source_name}:${node.pos.offset}; value=${node.value}; typ=${node.typ}; op=${node.op}; children=${node.children_count}')
 		}
 	}
 }
@@ -4232,14 +4249,8 @@ fn (g &FlatGen) expr_really_returns_optional(id flat.NodeId) bool {
 		return type_is_optional_result(typ)
 	}
 	if node.kind == .call {
-		typ := g.usable_expr_type(id)
-		if typ !is types.Unknown && typ !is types.Void {
-			return type_is_optional_result(typ)
-		}
-		if fname := g.tc.resolved_call_name(id) {
-			ret_type := g.tc.fn_ret_types[fname] or { return false }
-			return ret_type is types.OptionType || ret_type is types.ResultType
-		}
+		ret_type := g.declared_call_return_type(id)
+		return ret_type is types.OptionType || ret_type is types.ResultType
 	}
 	return type_is_optional_result(g.usable_expr_type(id))
 }

--- a/vlib/v3/gen/c/stmt.v
+++ b/vlib/v3/gen/c/stmt.v
@@ -31,6 +31,10 @@ fn gen_map_index_lvalue(mut g FlatGen, node flat.Node, base_id flat.NodeId, map_
 // gen_expr_lvalue emits expr lvalue output for c.
 fn gen_expr_lvalue(mut g FlatGen, id flat.NodeId) {
 	node := g.a.nodes[int(id)]
+	if node.kind == .ident && g.current_param_is_mut_pointer(node.value) {
+		g.gen_mut_pointer_slot_expr(id)
+		return
+	}
 	if node.kind == .index {
 		base_id := g.a.child(&node, 0)
 		base_type := g.usable_expr_type(base_id)
@@ -49,7 +53,7 @@ fn gen_expr_lvalue(mut g FlatGen, id flat.NodeId) {
 				// The transformed lvalue base is `*p` in both cases.
 				if g.current_param_is_mut_pointer(child.value) {
 					g.write('(*')
-					g.gen_expr(child_id)
+					g.gen_mut_pointer_slot_expr(child_id)
 					g.write(')')
 				} else {
 					g.gen_expr(child_id)
@@ -804,15 +808,32 @@ fn (mut g FlatGen) gen_loop_iteration_ownership_drops() {
 fn (mut g FlatGen) gen_ownership_drops(entries []types.OwnershipDropEntry) {
 	for entry in entries {
 		cname := g.cname(entry.name)
+		typ := g.tc.parse_type(entry.type_name)
+		mut expr := cname
+		mut free_pointer_storage := false
+		if local_ct := g.local_storage_c_type(entry.name) {
+			expected_ct := g.tc.c_type(typ)
+			local_depth := cgen_c_type_pointer_depth(local_ct)
+			expected_depth := cgen_c_type_pointer_depth(expected_ct)
+			if local_depth > expected_depth {
+				for _ in 0 .. local_depth - expected_depth {
+					expr = '*(${expr})'
+				}
+				free_pointer_storage = true
+			}
+		}
 		if entry.optional_wrapper {
-			g.writeln('if (${cname}.ok) {')
+			g.writeln('if ((${expr}).ok) {')
 			g.indent++
-			g.gen_ownership_drop_value(g.tc.parse_type(entry.type_name), '${cname}.value', 0)
+			g.gen_ownership_drop_value(typ, '(${expr}).value', 0)
 			g.indent--
 			g.writeln('}')
-			continue
+		} else {
+			g.gen_ownership_drop_value(typ, expr, 0)
 		}
-		g.gen_ownership_drop_value(g.tc.parse_type(entry.type_name), cname, 0)
+		if free_pointer_storage {
+			g.writeln('free(${cname});')
+		}
 	}
 }
 
@@ -847,8 +868,9 @@ fn (mut g FlatGen) precompute_ownership_recursive_drop_helpers() {
 	mut struct_names := drop_struct_names.keys()
 	struct_names.sort()
 	for name in struct_names {
+		parsed := g.tc.parse_type(name)
 		if name.starts_with('C.') || name in g.tc.unions || g.is_generic_struct(name)
-			|| g.skip_builtin_struct(name)
+			|| g.type_contains_generic_placeholder(parsed) || g.skip_builtin_struct(name)
 			|| g.resolve_method_name(name, g.ownership_destructor_method_name()).len > 0 {
 			continue
 		}
@@ -3203,6 +3225,9 @@ fn (mut g FlatGen) pointer_value_return_expr_string(ret_id flat.NodeId, expected
 
 fn (mut g FlatGen) write_pointer_value_return_expr(ret_id flat.NodeId, expected types.Type) bool {
 	source_id := g.pointer_value_return_source_id(ret_id)
+	if g.source_mut_pointer_param_deref_type(source_id) != none {
+		return false
+	}
 	actual := g.usable_expr_type(source_id)
 	expected0 := if expected is types.Alias { expected.base_type } else { expected }
 	if expected0 is types.Pointer {
@@ -4056,6 +4081,12 @@ fn (g &FlatGen) declared_call_return_type(call_id flat.NodeId) types.Type {
 			return ret
 		}
 	} else if fn_node.kind == .ident {
+		// A local or parameter fn value takes precedence over same-named declarations.
+		if local_type := g.local_ident_type(fn_node.value) {
+			if local_fn := fn_type_from(local_type) {
+				return local_fn.return_type
+			}
+		}
 		if ret := g.module_c_fn_return_type(fn_node.value) {
 			return ret
 		}

--- a/vlib/v3/gen/c/stmt.v
+++ b/vlib/v3/gen/c/stmt.v
@@ -43,10 +43,17 @@ fn gen_expr_lvalue(mut g FlatGen, id flat.NodeId) {
 		if base.kind == .prefix && base.op == .mul && base.children_count > 0 {
 			child_id := g.a.child(&base, 0)
 			child := g.a.nodes[int(child_id)]
-			child_type := g.usable_expr_type(child_id)
-			if child.kind == .ident && child_type is types.Pointer
-				&& g.current_param_is_mut(child.value) {
-				g.gen_expr(child_id)
+			if child.kind == .ident && g.current_param_is_mut(child.value) {
+				// A source `mut p &T` parameter has pointer-slot ABI (`T**`),
+				// while a plain `mut value T` parameter has `T*` ABI.
+				// The transformed lvalue base is `*p` in both cases.
+				if g.current_param_is_mut_pointer(child.value) {
+					g.write('(*')
+					g.gen_expr(child_id)
+					g.write(')')
+				} else {
+					g.gen_expr(child_id)
+				}
 				g.write('[')
 				g.gen_expr(g.a.child(&node, 1))
 				g.write(']')
@@ -1033,6 +1040,11 @@ fn (mut g FlatGen) gen_ownership_recursive_drop_helper_forward_decls() {
 	if g.recursive_drop_helpers.len == 0 {
 		return
 	}
+	// Recursive drop helpers are emitted before const definitions and their
+	// generated Result/Option cleanup guards reference the process-wide IError
+	// sentinels. Declare those globals before the helper bodies.
+	g.writeln('extern IError builtin__none__;')
+	g.writeln('extern IError builtin__error_sentinel;')
 	mut keys := g.recursive_drop_helpers.keys()
 	keys.sort()
 	for key in keys {
@@ -2863,7 +2875,12 @@ fn (mut g FlatGen) gen_node(id flat.NodeId) {
 			// NOTE: match_stmt is intentionally absent — the transformer lowers every
 			// match into an if/else-if chain (see transform.lower_match_stmts), so the
 			// backend never sees one. Match lowering lives in the transformer, not here.
-			eprintln('gen_node: unsupported node kind: ${node.kind}')
+			source_name := if source_file := g.a.source_files[node.pos.id] {
+				source_file.name
+			} else {
+				''
+			}
+			eprintln('gen_node: unsupported node kind: ${node.kind}; fn=${g.cur_fn_name}; source=${source_name}:${node.pos.offset}; value=${node.value}; typ=${node.typ}; op=${node.op}; children=${node.children_count}')
 		}
 	}
 }
@@ -4215,10 +4232,8 @@ fn (g &FlatGen) expr_really_returns_optional(id flat.NodeId) bool {
 		return type_is_optional_result(typ)
 	}
 	if node.kind == .call {
-		if fname := g.tc.resolved_call_name(id) {
-			ret_type := g.tc.fn_ret_types[fname] or { return false }
-			return ret_type is types.OptionType || ret_type is types.ResultType
-		}
+		ret_type := g.declared_call_return_type(id)
+		return ret_type is types.OptionType || ret_type is types.ResultType
 	}
 	return type_is_optional_result(g.usable_expr_type(id))
 }

--- a/vlib/v3/gen/c/struct.v
+++ b/vlib/v3/gen/c/struct.v
@@ -407,7 +407,11 @@ fn (mut g FlatGen) gen_struct_init(id flat.NodeId) {
 		|| init_type is types.ResultType
 	has_expected_optional := g.expected_expr_type is types.OptionType
 		|| g.expected_expr_type is types.ResultType || g.expected_expr_is_optional_struct()
-	if is_optional_init && name == 'Optional'
+	// Lowered optional literals can retain their concrete V spelling (`?IError`)
+	// instead of the legacy synthetic `Optional` name. The wrapper ABI still comes
+	// from the expected option/result type; otherwise trimming the `?` above emits
+	// the payload C type and attempts to initialize an interface with option fields.
+	if is_optional_init
 		&& (g.expected_expr_type is types.OptionType || g.expected_expr_type is types.ResultType) {
 		name = g.optional_type_name(g.expected_expr_type)
 	} else if init_value == 'Optional' && g.expected_expr_is_optional_struct() {

--- a/vlib/v3/markused/markused.v
+++ b/vlib/v3/markused/markused.v
@@ -377,6 +377,14 @@ fn mark_used_with_test_files(a &flat.FlatAst, tc &types.TypeChecker, test_files 
 	reachable_modules := markused_reachable_modules(a, tc)
 	queue << 'main'
 	used['main'] = true
+	$if ownership ? {
+		// Ownership cleanup and clone lowering emits direct C references to these
+		// process-wide IError sentinels. They have no source-AST reference for the
+		// ordinary markused traversal to discover, so root their const declarations.
+		for seed in ['builtin.none__', 'builtin.error_sentinel'] {
+			enqueue(seed, mut used, mut queue)
+		}
+	}
 	enqueue_main_module_roots(fn_decls, mut used, mut queue)
 	enqueue_auto_roots(a, fn_decls, reachable_modules, mut used, mut queue)
 	for root in marked_roots {

--- a/vlib/v3/tests/borrowed_array_clone_codegen_test.v
+++ b/vlib/v3/tests/borrowed_array_clone_codegen_test.v
@@ -1,0 +1,21 @@
+import os
+
+const borrowed_array_clone_vexe = @VEXE
+const borrowed_array_clone_tests_dir = os.dir(@FILE)
+const borrowed_array_clone_v3_dir = os.dir(borrowed_array_clone_tests_dir)
+const borrowed_array_clone_vlib_dir = os.dir(borrowed_array_clone_v3_dir)
+const borrowed_array_clone_v3_src = os.join_path(borrowed_array_clone_v3_dir, 'v3.v')
+
+fn test_clone_of_array_returned_by_borrow_does_not_address_pointer_rvalue() {
+	v3_bin := os.join_path(os.temp_dir(), 'v3_borrowed_array_clone_test')
+	build :=
+		os.execute('${borrowed_array_clone_vexe} -gc none -d ownership -path "${borrowed_array_clone_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${borrowed_array_clone_v3_src}')
+	assert build.exit_code == 0, build.output
+
+	source := os.join_path(os.temp_dir(), 'v3_borrowed_array_clone_input.v')
+	os.write_file(source,
+		"import sync.arc\n\nstruct Holder {\n\tvalues []string\n}\n\nfn (holder &^a Holder) get[^a]() &^a []string {\n\treturn &holder.values\n}\n\nfn main() {\n\tholder := Holder{values: ['one', 'two']}\n\tcloned := holder.get().clone()\n\tassert cloned == ['one', 'two']\n\towner := arc.new(['three', 'four'])\n\tshared_clone := owner.get().clone()\n\tassert shared_clone == ['three', 'four']\n\tprintln('ok')\n}\n")!
+	out := os.execute('${v3_bin} -ownership -d ownership -no-parallel run ${source}')
+	assert out.exit_code == 0, out.output
+	assert out.output.contains('\nok\n'), out.output
+}

--- a/vlib/v3/tests/contextual_optional_codegen_test.v
+++ b/vlib/v3/tests/contextual_optional_codegen_test.v
@@ -1,0 +1,21 @@
+import os
+
+const contextual_optional_vexe = @VEXE
+const contextual_optional_tests_dir = os.dir(@FILE)
+const contextual_optional_v3_dir = os.dir(contextual_optional_tests_dir)
+const contextual_optional_vlib_dir = os.dir(contextual_optional_v3_dir)
+const contextual_optional_v3_src = os.join_path(contextual_optional_v3_dir, 'v3.v')
+
+fn test_contextual_optional_wraps_plain_call_and_if_once() {
+	v3_bin := os.join_path(os.temp_dir(), 'v3_contextual_optional_test')
+	build :=
+		os.execute('${contextual_optional_vexe} -gc none -d ownership -path "${contextual_optional_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${contextual_optional_v3_src}')
+	assert build.exit_code == 0, build.output
+
+	source := os.join_path(os.temp_dir(), 'v3_contextual_optional_input.v')
+	os.write_file(source,
+		"enum Mode {\n\tshort\n\tlong\n}\n\nstruct Bytes {\n\tvalue ?[]u8\n}\n\nstruct Args {\nmut:\n\tmode ?Mode\n}\n\nfn default_bytes() Bytes {\n\treturn Bytes{\n\t\tvalue: '--'.bytes()\n\t}\n}\n\nfn fail() ! {\n\treturn error('saved')\n}\n\nfn main() {\n\tbytes := default_bytes().value?\n\tassert bytes == [u8(`-`), `-`]\n\tmut args := Args{}\n\targs.mode = if bytes.len == 2 { .short } else { .long }\n\tassert args.mode? == .short\n\tmut saved := ?IError(none)\n\tfail() or { saved = err }\n\tassert (saved or { panic('missing error') }).msg() == 'saved'\n\tprintln('ok')\n}\n")!
+	out := os.execute('${v3_bin} -ownership -d ownership -no-parallel run ${source}')
+	assert out.exit_code == 0, out.output
+	assert out.output.contains('\nok\n'), out.output
+}

--- a/vlib/v3/tests/default_sum_clone_codegen_test.v
+++ b/vlib/v3/tests/default_sum_clone_codegen_test.v
@@ -1,0 +1,119 @@
+import os
+
+const sum_clone_vexe = @VEXE
+const sum_clone_tests_dir = os.dir(@FILE)
+const sum_clone_v3_dir = os.dir(sum_clone_tests_dir)
+const sum_clone_vlib_dir = os.dir(sum_clone_v3_dir)
+const sum_clone_v3_src = os.join_path(sum_clone_v3_dir, 'v3.v')
+
+fn test_compiler_default_clone_rebuilds_sum_payload() {
+	pid := os.getpid()
+	v3_bin := os.join_path(os.temp_dir(), 'v3_sum_clone_${pid}')
+	source := os.join_path(os.temp_dir(), 'v3_sum_clone_input_${pid}.v')
+	output := os.join_path(os.temp_dir(), 'v3_sum_clone_program_${pid}')
+	defer {
+		os.rm(v3_bin) or {}
+		os.rm(source) or {}
+		os.rm(output) or {}
+		os.rm(output + '.c') or {}
+	}
+	build :=
+		os.execute('${sum_clone_vexe} -gc none -d ownership -path "${sum_clone_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${sum_clone_v3_src}')
+	assert build.exit_code == 0, build.output
+	os.write_file(source, "struct Payload implements IClone {
+mut:
+\tvalues []string
+}
+
+struct Empty implements IClone {}
+
+type Choice = Empty | Payload
+
+struct Owner implements IClone {
+mut:
+\tchoice Choice
+}
+
+struct OptionalOwner implements IClone {
+mut:
+\tpayload ?Payload
+}
+
+struct Recursive implements IClone {
+mut:
+\tchildren     []Recursive
+\talternatives [][]Recursive
+}
+
+fn count_last_alternative(node Recursive) int {
+\tmut count := 0
+\tfor child in node.alternatives.last() {
+\t\tcount += 1 + count_last_alternative(child)
+\t}
+\treturn count
+}
+
+fn main() {
+\tmut original := Owner{
+\t\tchoice: Payload{
+\t\t\tvalues: ['first']
+\t\t}
+\t}
+\tcloned := original.clone()
+\tif mut original.choice is Payload {
+\t\toriginal.choice.values << 'second'
+\t}
+\tif cloned.choice is Payload {
+\t\tassert cloned.choice.values == ['first']
+\t} else {
+\t\tassert false
+\t}
+\tmut optional_original := OptionalOwner{
+\t\tpayload: Payload{
+\t\t\tvalues: ['optional']
+\t\t}
+\t}
+\toptional_cloned := optional_original.clone()
+\tif mut payload := optional_original.payload {
+\t\tpayload.values << 'changed'
+\t}
+\tif payload := optional_cloned.payload {
+\t\tassert payload.values == ['optional']
+\t} else {
+\t\tassert false
+\t}
+\tmut payloads := [Payload{
+\t\tvalues: ['only']
+\t}]
+\tpayloads.last().values << 'next'
+\tassert payloads[0].values == ['only', 'next']
+\tnested := [[Payload{
+\t\tvalues: ['nested']
+\t}]]
+\ttail := nested.last()
+\tassert tail[0].values == ['nested']
+\tmut seen := 0
+\tfor payload in nested.last() {
+\t\tassert payload.values == ['nested']
+\t\tseen++
+\t}
+\tassert seen == 1
+\tleaf := Recursive{
+\t\talternatives: [[]]
+\t}
+\troot := Recursive{
+\t\talternatives: [[leaf]]
+\t}
+\tassert count_last_alternative(root) == 1
+\tprintln('ok')
+}
+") or {
+		panic(err)
+	}
+	compile :=
+		os.execute('${v3_bin} -ownership -d ownership -nocache -no-parallel -o ${output} ${source}')
+	assert compile.exit_code == 0, compile.output
+	run := os.execute(output)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == 'ok', run.output
+}

--- a/vlib/v3/tests/fn_value_decl_type_test.v
+++ b/vlib/v3/tests/fn_value_decl_type_test.v
@@ -343,6 +343,35 @@ println(use(actual))
 }
 "
 
+const local_fn_value_optional_call_shadow_src = 'fn f() ?int {
+	return 99
+}
+
+fn take(value ?int) int {
+	return value or { -1 }
+}
+
+fn main() {
+	f := fn () int {
+		return 7
+	}
+	println(int_str(take(f())))
+}
+'
+
+const drop_owned_callback_shadow_src = 'fn record(value int) {
+	println(int_str(value))
+}
+
+fn invoke(drop_owned fn (int), value int) {
+	drop_owned(value)
+}
+
+fn main() {
+	invoke(record, 7)
+}
+'
+
 const local_fn_value_ident_shadow_fn_src = 'fn foo(i int) int {
 	return i + 100
 }
@@ -627,4 +656,19 @@ fn test_local_fn_literal_decl_generates_fn_pointer_locals() {
 	assert imported_c.contains('f = worker__dec'), imported_c
 	assert imported_c.contains(' loader = worker__read_ok'), imported_c
 	assert imported_c.contains('loader = worker__read_other'), imported_c
+}
+
+fn test_shadowed_fn_value_calls_use_bound_callable_types() {
+	v3_bin := build_v3()
+	assert run_good(v3_bin, 'fn_value_optional_call_shadow',
+		local_fn_value_optional_call_shadow_src) == '7'
+	assert run_good(v3_bin, 'drop_owned_callback_shadow', drop_owned_callback_shadow_src) == '7'
+
+	optional_c := gen_c(v3_bin, 'fn_value_optional_call_shadow_c',
+		local_fn_value_optional_call_shadow_src)
+	assert optional_c.contains('take((Optional){.ok = true, .value = f()})'), optional_c
+	assert !optional_c.contains('take(f())'), optional_c
+
+	drop_owned_c := gen_c(v3_bin, 'drop_owned_callback_shadow_c', drop_owned_callback_shadow_src)
+	assert drop_owned_c.contains('drop_owned(value);'), drop_owned_c
 }

--- a/vlib/v3/tests/generic_const_return_global_codegen_test.v
+++ b/vlib/v3/tests/generic_const_return_global_codegen_test.v
@@ -1,0 +1,21 @@
+import os
+
+const generic_const_global_vexe = @VEXE
+const generic_const_global_tests_dir = os.dir(@FILE)
+const generic_const_global_v3_dir = os.dir(generic_const_global_tests_dir)
+const generic_const_global_vlib_dir = os.dir(generic_const_global_v3_dir)
+const generic_const_global_v3_src = os.join_path(generic_const_global_v3_dir, 'v3.v')
+
+fn test_inferred_generic_const_return_has_concrete_global_type() {
+	v3_bin := os.join_path(os.temp_dir(), 'v3_generic_const_global_test')
+	build :=
+		os.execute('${generic_const_global_vexe} -gc none -path "${generic_const_global_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${generic_const_global_v3_src}')
+	assert build.exit_code == 0, build.output
+
+	source := os.join_path(os.temp_dir(), 'v3_generic_const_global_input.v')
+	os.write_file(source,
+		"import sync.stdatomic\n\nconst flag = stdatomic.new_atomic(false)\nconst number = stdatomic.new_atomic(7)\n\nfn main() {\n\tassert !flag.load()\n\tassert number.load() == 7\n\tprintln('ok')\n}\n")!
+	out := os.execute('${v3_bin} -no-parallel run ${source}')
+	assert out.exit_code == 0, out.output
+	assert out.output.contains('\nok\n'), out.output
+}

--- a/vlib/v3/tests/generic_cross_module_arg_codegen_test.v
+++ b/vlib/v3/tests/generic_cross_module_arg_codegen_test.v
@@ -159,6 +159,15 @@ fn test_interface_generated_generic_method_body_preserves_cross_module_arg_type(
 	assert out == '31'
 }
 
+fn test_generic_receiver_boxes_lifetime_struct_for_interface_dispatch() {
+	v3_bin := generic_cross_build_v3()
+	out := generic_cross_run_project(v3_bin, 'generic_receiver_lifetime_interface_dispatch', {
+		'sink/sink.v': "module sink\n\npub interface Sink {\nmut:\n\tbegin() !bool\n\tmatched[^b](event &Event[^b]) !bool\n}\n\npub struct Event[^b] {\npub:\n\ttext &^b string\n}\n\npub struct Box[^p, ^s, W] {\n\tpath &^p string\n\ttag &^s int\n\tvalue W\nmut:\n\tcount int\n}\n\npub fn (mut b Box[^p, ^s, W]) begin[^p, ^s]() !bool {\n\tb.count++\n\treturn true\n}\n\npub fn (mut b Box[^p, ^s, W]) matched[^b, ^p, ^s](event &Event[^b]) !bool {\n\tb.count += event.text.len\n\treturn true\n}\n\npub fn use_sink(mut value Sink) !int {\n\tif !value.begin()! {\n\t\treturn 0\n\t}\n\ttext := 'ok'\n\tevent := Event{\n\t\ttext: &text\n\t}\n\tif !value.matched(&event)! {\n\t\treturn 0\n\t}\n\treturn 43\n}\n\npub struct Driver[W] {\npub:\n\tvalue W\n}\n\npub fn (mut driver Driver[W]) run[^p, ^s](path &^p string, tag &^s int) !int {\n\tmut boxed := Box[^p, ^s, W]{\n\t\tpath: path\n\t\ttag: tag\n\t\tvalue: driver.value\n\t}\n\treturn use_sink(&boxed)\n}\n"
+		'main.v':      "module main\n\nimport sink\n\nstruct Local {}\n\nfn main() {\n\tpath := 'x'\n\ttag := 1\n\tmut driver := sink.Driver[Local]{\n\t\tvalue: Local{}\n\t}\n\tprintln(int_str(driver.run(&path, &tag) or { 0 }))\n}\n"
+	})
+	assert out == '43'
+}
+
 fn test_generated_generic_body_late_transforms_lifetime_helper() {
 	v3_bin := generic_cross_build_v3()
 	out := generic_cross_run_project(v3_bin, 'generic_interface_late_lifetime_helper', {

--- a/vlib/v3/tests/generic_heap_pointer_escape_test.v
+++ b/vlib/v3/tests/generic_heap_pointer_escape_test.v
@@ -1,0 +1,21 @@
+import os
+
+const generic_heap_vexe = @VEXE
+const generic_heap_tests_dir = os.dir(@FILE)
+const generic_heap_v3_dir = os.dir(generic_heap_tests_dir)
+const generic_heap_vlib_dir = os.dir(generic_heap_v3_dir)
+const generic_heap_v3_src = os.join_path(generic_heap_v3_dir, 'v3.v')
+
+fn test_generic_heap_pointer_can_be_stored_safely() {
+	v3_bin := os.join_path(os.temp_dir(), 'v3_generic_heap_pointer_test')
+	build :=
+		os.execute('${generic_heap_vexe} -gc none -path "${generic_heap_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${generic_heap_v3_src}')
+	assert build.exit_code == 0, build.output
+
+	source := os.join_path(os.temp_dir(), 'v3_generic_heap_pointer_input.v')
+	os.write_file(source,
+		"@[heap]\nstruct Cell[T] {\n\tvalue T\n}\n\nstruct Holder[T] {\n\tcell &Cell[T]\n}\n\nfn hold[T](cell &Cell[T]) int {\n\tholder := Holder[T]{\n\t\tcell: cell\n\t}\n\treturn holder.cell.value\n}\n\nfn main() {\n\tcell := &Cell[int]{\n\t\tvalue: 41\n\t}\n\tassert hold[int](cell) == 41\n\tprintln('ok')\n}\n")!
+	out := os.execute('${v3_bin} -no-parallel run ${source}')
+	assert out.exit_code == 0, out.output
+	assert out.output.contains('\nok\n'), out.output
+}

--- a/vlib/v3/tests/generic_ownership_implicit_coercion_codegen_test.v
+++ b/vlib/v3/tests/generic_ownership_implicit_coercion_codegen_test.v
@@ -1,0 +1,82 @@
+import os
+
+const generic_coercion_vexe = @VEXE
+const generic_coercion_tests_dir = os.dir(@FILE)
+const generic_coercion_v3_dir = os.dir(generic_coercion_tests_dir)
+const generic_coercion_vlib_dir = os.dir(generic_coercion_v3_dir)
+const generic_coercion_v3_src = os.join_path(generic_coercion_v3_dir, 'v3.v')
+
+fn test_generic_ownership_implicit_reference_coercions() {
+	pid := os.getpid()
+	v3_bin := os.join_path(os.temp_dir(), 'v3_generic_coercion_${pid}')
+	source := os.join_path(os.temp_dir(), 'v3_generic_coercion_input_${pid}.v')
+	output := os.join_path(os.temp_dir(), 'v3_generic_coercion_program_${pid}')
+	defer {
+		os.rm(v3_bin) or {}
+		os.rm(source) or {}
+		os.rm(output) or {}
+		os.rm(output + '.c') or {}
+	}
+	build :=
+		os.execute('${generic_coercion_vexe} -gc none -d ownership -path "${generic_coercion_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${generic_coercion_v3_src}')
+	assert build.exit_code == 0, build.output
+	os.write_file(source, "interface Matcher {
+\tfind() int
+}
+
+struct MatcherRef {}
+
+fn (MatcherRef) find() int {
+\treturn 1
+}
+
+struct Searcher {}
+
+struct Path {
+\tvalue string
+}
+
+fn (mut searcher Searcher) search(matcher &Matcher, path &Path) int {
+\treturn matcher.find() + path.value.len
+}
+
+struct ColorSpec {
+\tvalue int
+}
+
+struct Colors {
+\tmatched ColorSpec
+}
+
+fn (colors &Colors) matched() &ColorSpec {
+\treturn &colors.matched
+}
+
+fn set_color(spec ColorSpec) int {
+\treturn spec.value
+}
+
+fn run[T](mut path Path, colors &Colors) int {
+\tmut searcher := Searcher{}
+\tmatcher := MatcherRef{}
+\treturn searcher.search(matcher, &path) + set_color(colors.matched())
+}
+
+fn main() {
+\tmut path := Path{value: 'abc'}
+\tcolors := Colors{
+\t\tmatched: ColorSpec{value: 2}
+\t}
+\tassert run[int](mut path, &colors) == 6
+\tprintln('ok')
+}
+") or {
+		panic(err)
+	}
+	compile :=
+		os.execute('${v3_bin} -ownership -d ownership -nocache -no-parallel -o ${output} ${source}')
+	assert compile.exit_code == 0, compile.output
+	run := os.execute(output)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == 'ok', run.output
+}

--- a/vlib/v3/tests/generic_return_only_monomorph_codegen_test.v
+++ b/vlib/v3/tests/generic_return_only_monomorph_codegen_test.v
@@ -1,0 +1,53 @@
+import os
+
+const return_only_generic_vexe = @VEXE
+const return_only_generic_tests_dir = os.dir(@FILE)
+const return_only_generic_v3_dir = os.dir(return_only_generic_tests_dir)
+const return_only_generic_vlib_dir = os.dir(return_only_generic_v3_dir)
+const return_only_generic_v3_src = os.join_path(return_only_generic_v3_dir, 'v3.v')
+
+fn test_return_only_generic_specializations_emit_bodies() {
+	pid := os.getpid()
+	v3_bin := os.join_path(os.temp_dir(), 'v3_return_only_generic_${pid}')
+	source := os.join_path(os.temp_dir(), 'v3_return_only_generic_input_${pid}.v')
+	output := os.join_path(os.temp_dir(), 'v3_return_only_generic_program_${pid}')
+	defer {
+		os.rm(v3_bin) or {}
+		os.rm(source) or {}
+		os.rm(output) or {}
+		os.rm(output + '.c') or {}
+	}
+	build :=
+		os.execute('${return_only_generic_vexe} -gc none -d ownership -path "${return_only_generic_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${return_only_generic_v3_src}')
+	assert build.exit_code == 0, build.output
+	os.write_file(source, "fn make_default[T]() T {
+	return T{}
+}
+
+fn err[T](message string) !T {
+	return error(message)
+}
+
+fn parse_result_special[T](text string) !T {
+	if text.len == 0 {
+		return err[T]('empty')
+	}
+	return make_default[T]()
+}
+
+fn main() {
+	flag := make_default[bool]()
+	assert !flag
+	value := parse_result_special[int]('') or { 7 }
+	assert value == 7
+	println('ok')
+}
+") or {
+		panic(err)
+	}
+	compile := os.execute('${v3_bin} -ownership -d ownership -no-parallel -o ${output} ${source}')
+	assert compile.exit_code == 0, compile.output
+	run := os.execute(output)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == 'ok', run.output
+}

--- a/vlib/v3/tests/import_alias_constant_collision_codegen_test.v
+++ b/vlib/v3/tests/import_alias_constant_collision_codegen_test.v
@@ -1,0 +1,25 @@
+import os
+
+const import_alias_collision_vexe = @VEXE
+const import_alias_collision_tests_dir = os.dir(@FILE)
+const import_alias_collision_v3_dir = os.dir(import_alias_collision_tests_dir)
+const import_alias_collision_vlib_dir = os.dir(import_alias_collision_v3_dir)
+const import_alias_collision_v3_src = os.join_path(import_alias_collision_v3_dir, 'v3.v')
+
+fn test_import_alias_wins_over_same_named_exported_constant_in_call_selector() {
+	v3_bin := os.join_path(os.temp_dir(), 'v3_import_alias_collision_test')
+	build :=
+		os.execute('${import_alias_collision_vexe} -gc none -path "${import_alias_collision_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${import_alias_collision_v3_src}')
+	assert build.exit_code == 0, build.output
+
+	root := os.join_path(os.temp_dir(), 'v3_import_alias_collision_input')
+	mod_dir := os.join_path(root, 'registry')
+	os.mkdir_all(mod_dir)!
+	os.write_file(os.join_path(mod_dir, 'registry.v'),
+		'module registry\n\npub const registry = [1, 2]\n\npub fn value() int {\n\treturn registry.len\n}\n')!
+	os.write_file(os.join_path(root, 'main.v'),
+		"module main\n\nimport registry\n\nfn main() {\n\tassert registry.value() == 2\n\tprintln('ok')\n}\n")!
+	out := os.execute('cd "${root}" && ${v3_bin} -no-parallel run main.v')
+	assert out.exit_code == 0, out.output
+	assert out.output.contains('\nok\n'), out.output
+}

--- a/vlib/v3/tests/interface_pointer_forward_codegen_test.v
+++ b/vlib/v3/tests/interface_pointer_forward_codegen_test.v
@@ -1,0 +1,79 @@
+import os
+
+const interface_pointer_forward_vexe = @VEXE
+const interface_pointer_forward_tests_dir = os.dir(@FILE)
+const interface_pointer_forward_v3_dir = os.dir(interface_pointer_forward_tests_dir)
+const interface_pointer_forward_vlib_dir = os.dir(interface_pointer_forward_v3_dir)
+const interface_pointer_forward_v3_src = os.join_path(interface_pointer_forward_v3_dir, 'v3.v')
+
+fn test_concrete_pointer_forwarded_to_interface_pointer_is_boxed_once() {
+	pid := os.getpid()
+	v3_bin := os.join_path(os.temp_dir(), 'v3_interface_pointer_forward_${pid}')
+	project := os.join_path(os.temp_dir(), 'v3_interface_pointer_forward_project_${pid}')
+	output := os.join_path(os.temp_dir(), 'v3_interface_pointer_forward_program_${pid}')
+	defer {
+		os.rm(v3_bin) or {}
+		os.rmdir_all(project) or {}
+		os.rm(output) or {}
+		os.rm(output + '.c') or {}
+	}
+	build :=
+		os.execute('${interface_pointer_forward_vexe} -gc none -d ownership -path "${interface_pointer_forward_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${interface_pointer_forward_v3_src}')
+	assert build.exit_code == 0, build.output
+	os.rmdir_all(project) or {}
+	os.mkdir_all(os.join_path(project, 'matcher')) or { panic(err) }
+	os.mkdir_all(os.join_path(project, 'printer')) or { panic(err) }
+	os.write_file(os.join_path(project, 'v.mod'), "Module { name: 'interface_pointer_forward' }\n") or {
+		panic(err)
+	}
+	os.write_file(os.join_path(project, 'matcher', 'matcher.v'), 'module matcher
+
+pub interface Finder {
+	find_at(n int) !int
+}
+
+pub fn find_iter_at(finder &Finder, n int, found fn (int) bool) ! {
+	value := finder.find_at(n)!
+	_ = found(value)
+}
+') or {
+		panic(err)
+	}
+	os.write_file(os.join_path(project, 'printer', 'printer.v'), 'module printer
+
+import matcher
+
+pub struct Concrete {}
+
+fn (c &Concrete) find_at(n int) !int {
+	return n + 1
+}
+
+pub fn forward(finder &Concrete, n int) !int {
+	matcher.find_iter_at(finder, n, fn (value int) bool {
+		return value > 0
+	})!
+	return 42
+}
+') or {
+		panic(err)
+	}
+	os.write_file(os.join_path(project, 'main.v'), "module main
+
+import printer
+
+fn main() {
+	finder := &printer.Concrete{}
+	assert printer.forward(finder, 41) or { 0 } == 42
+	println('ok')
+}
+") or {
+		panic(err)
+	}
+	compile := os.execute('${v3_bin} -ownership -d ownership -nocache -no-parallel -o ${output} ${os.join_path(project,
+		'main.v')}')
+	assert compile.exit_code == 0, compile.output
+	run := os.execute(output)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == 'ok', run.output
+}

--- a/vlib/v3/tests/mut_param_reassign_codegen_test.v
+++ b/vlib/v3/tests/mut_param_reassign_codegen_test.v
@@ -27,6 +27,19 @@ fn mut_param_reassign_run_good(v3_bin string, name string, source string) string
 	return run.output.trim_space()
 }
 
+fn mut_param_reassign_run_good_with_c(v3_bin string, name string, source string) (string, string) {
+	src := os.join_path(os.temp_dir(), 'v3_${name}_${os.getpid()}.v')
+	os.write_file(src, source) or { panic(err) }
+	bin := os.join_path(os.temp_dir(), 'v3_${name}_${os.getpid()}')
+	compile := os.execute('${v3_bin} ${src} -b c -keepc -o ${bin}')
+	assert compile.exit_code == 0, compile.output
+	assert !compile.output.contains('C compilation failed'), compile.output
+	run := os.execute(bin)
+	assert run.exit_code == 0, run.output
+	c_source := os.read_file('${bin}.c') or { panic(err) }
+	return run.output.trim_space(), c_source
+}
+
 fn mut_param_reassign_run_bad(v3_bin string, name string, source string, expected string) {
 	src := os.join_path(os.temp_dir(), 'v3_${name}_${os.getpid()}.v')
 	os.write_file(src, source) or { panic(err) }
@@ -366,6 +379,89 @@ fn main() {
 }
 ',
 		'expected `&&Item`')
+}
+
+fn test_mut_pointer_param_signature_and_expression_conversions() {
+	v3_bin := mut_param_reassign_build_v3()
+	out, c_source := mut_param_reassign_run_good_with_c(v3_bin,
+		'mut_pointer_param_signature_and_expression_conversions', 'interface Reader {
+	read() int
+}
+
+struct Item {
+	value int
+}
+
+fn (item &Item) read() int {
+	return item.value
+}
+
+fn consume_reader(reader Reader) int {
+	return reader.read()
+}
+
+fn consume_pointer(item &Item) int {
+	return item.value
+}
+
+fn consume_optional(item ?&Item) int {
+	if value := item {
+		return value.value
+	}
+	return 0
+}
+
+fn read_field(mut item &Item) int {
+	return item.value
+}
+
+fn read_deref(mut item &Item) int {
+	return (*item).value
+}
+
+fn copy_deref(mut item &Item) Item {
+	return *item
+}
+
+fn assign_deref(mut item &Item) Item {
+	mut copied_value := Item{}
+	copied_value = *item
+	return copied_value
+}
+
+fn increment_deref(mut value &int) int {
+	(*value)++
+	return *value
+}
+
+fn read_method(mut item &Item) int {
+	return item.read()
+}
+
+fn forward(mut item &Item) int {
+	copied := copy_deref(mut item)
+	assigned := assign_deref(mut item)
+	mut number_value := 5
+	mut number := &number_value
+	incremented := increment_deref(mut number)
+	return read_field(mut item) + read_deref(mut item) + read_method(mut item) + consume_reader(item) + consume_pointer(item) + consume_optional(item) + copied.value + assigned.value + incremented
+}
+
+fn main() {
+	mut value := Item{
+		value: 7
+	}
+	mut item := &value
+	println(int_str(forward(mut item)))
+}
+')
+	assert out == '62'
+	assert c_source.contains('int read_field(Item** item) {'), 'missing Item** signature'
+	assert !c_source.contains('int read_field(Item*** item) {'), 'found over-indirected Item*** signature'
+	assert c_source.contains('return ((*item))->value;'), 'missing single slot dereference'
+	assert c_source.contains('return (*(*item));'), 'missing source dereference after slot dereference'
+	assert c_source.contains('copied_value = (*(*item));'), 'missing standalone assignment dereference'
+	assert c_source.contains('((*(*value)))++;'), 'missing standalone postfix dereference'
 }
 
 fn test_mut_param_reassign_keeps_invalid_assignments_rejected() {

--- a/vlib/v3/tests/mut_param_return_reassign_codegen_test.v
+++ b/vlib/v3/tests/mut_param_return_reassign_codegen_test.v
@@ -1,0 +1,62 @@
+import os
+
+const mut_param_return_reassign_vexe = @VEXE
+const mut_param_return_reassign_tests_dir = os.dir(@FILE)
+const mut_param_return_reassign_v3_dir = os.dir(mut_param_return_reassign_tests_dir)
+const mut_param_return_reassign_vlib_dir = os.dir(mut_param_return_reassign_v3_dir)
+const mut_param_return_reassign_v3_src = os.join_path(mut_param_return_reassign_v3_dir, 'v3.v')
+
+fn test_reassign_from_mut_parameter_return_does_not_drop_aliased_storage() {
+	pid := os.getpid()
+	v3_bin := os.join_path(os.temp_dir(), 'v3_mut_param_return_reassign_${pid}')
+	source := os.join_path(os.temp_dir(), 'v3_mut_param_return_reassign_input_${pid}.v')
+	output := os.join_path(os.temp_dir(), 'v3_mut_param_return_reassign_program_${pid}')
+	defer {
+		os.rm(v3_bin) or {}
+		os.rm(source) or {}
+		os.rm(output) or {}
+		os.rm(output + '.c') or {}
+	}
+	build :=
+		os.execute('${mut_param_return_reassign_vexe} -gc none -d ownership -path "${mut_param_return_reassign_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${mut_param_return_reassign_v3_src}')
+	assert build.exit_code == 0, build.output
+	os.write_file(source, "struct Owned implements IClone {
+mut:
+	values []int
+}
+
+struct Extender {}
+
+struct Parser {
+	extender Extender
+}
+
+fn (extender Extender) extend(mut value Owned, mut other Owned) Owned {
+	_ = extender
+	_ = other
+	value.values << 2
+	return value
+}
+
+fn main() {
+	mut value := Owned{
+		values: [1]
+	}
+	mut other := Owned{}
+	parser := Parser{}
+	value = parser.extender.extend(mut value, mut other)
+	assert value.values == [1, 2]
+	println('ok')
+}
+") or {
+		panic(err)
+	}
+	compile :=
+		os.execute('${v3_bin} -ownership -d ownership -nocache -no-parallel ${source} -b c -keepc -o ${output}')
+	assert compile.exit_code == 0, compile.output
+	c_source := os.read_file(output + '.c') or { panic(err) }
+	assert !c_source.contains('main__Owned __drop_assign'), c_source
+	run := os.execute(output)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == 'ok', run.output
+}

--- a/vlib/v3/tests/mutable_array_field_index_move_codegen_test.v
+++ b/vlib/v3/tests/mutable_array_field_index_move_codegen_test.v
@@ -1,0 +1,59 @@
+import os
+
+const mutable_index_move_vexe = @VEXE
+const mutable_index_move_tests_dir = os.dir(@FILE)
+const mutable_index_move_v3_dir = os.dir(mutable_index_move_tests_dir)
+const mutable_index_move_vlib_dir = os.dir(mutable_index_move_v3_dir)
+const mutable_index_move_v3_src = os.join_path(mutable_index_move_v3_dir, 'v3.v')
+
+fn test_mutable_array_field_index_move_clears_source_slot() {
+	pid := os.getpid()
+	v3_bin := os.join_path(os.temp_dir(), 'v3_mutable_index_move_${pid}')
+	source := os.join_path(os.temp_dir(), 'v3_mutable_index_move_input_${pid}.v')
+	output := os.join_path(os.temp_dir(), 'v3_mutable_index_move_program_${pid}')
+	defer {
+		os.rm(v3_bin) or {}
+		os.rm(source) or {}
+		os.rm(output) or {}
+		os.rm(output + '.c') or {}
+	}
+	build :=
+		os.execute('${mutable_index_move_vexe} -gc none -d ownership -path "${mutable_index_move_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${mutable_index_move_v3_src}')
+	assert build.exit_code == 0, build.output
+	os.write_file(source, "struct Item {
+\tpath string
+}
+
+struct Queue {
+mut:
+\titems []Item
+\tnext int
+}
+
+fn (mut queue Queue) pop() Item {
+\titem := queue.items[queue.next]
+\tqueue.next++
+\treturn item
+}
+
+fn main() {
+\tmut queue := Queue{
+\t\titems: [Item{
+\t\t\tpath: 'owned path'.to_owned()
+\t\t}]
+\t}
+\titem := queue.pop()
+\tassert item.path == 'owned path'
+\tassert queue.items[0].path == ''
+\tprintln('ok')
+}
+") or {
+		panic(err)
+	}
+	compile :=
+		os.execute('${v3_bin} -ownership -d ownership -nocache -no-parallel -o ${output} ${source}')
+	assert compile.exit_code == 0, compile.output
+	run := os.execute(output)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == 'ok', run.output
+}

--- a/vlib/v3/tests/nested_default_clone_codegen_test.v
+++ b/vlib/v3/tests/nested_default_clone_codegen_test.v
@@ -1,0 +1,21 @@
+import os
+
+const nested_clone_vexe = @VEXE
+const nested_clone_tests_dir = os.dir(@FILE)
+const nested_clone_v3_dir = os.dir(nested_clone_tests_dir)
+const nested_clone_vlib_dir = os.dir(nested_clone_v3_dir)
+const nested_clone_v3_src = os.join_path(nested_clone_v3_dir, 'v3.v')
+
+fn test_nested_marker_only_iclone_uses_structural_clone() {
+	v3_bin := os.join_path(os.temp_dir(), 'v3_nested_default_clone_test')
+	build :=
+		os.execute('${nested_clone_vexe} -gc none -d ownership -path "${nested_clone_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${nested_clone_v3_src}')
+	assert build.exit_code == 0, build.output
+
+	source := os.join_path(os.temp_dir(), 'v3_nested_default_clone_input.v')
+	os.write_file(source,
+		"interface Drop {\nmut:\n\tdrop()\n}\n\nstruct Inner implements IClone {\n\ttext string\n}\n\nstruct Outer implements IClone {\n\tinner Inner\n}\n\nstruct DropClone implements IClone, Drop {\nmut:\n\ttext string\n}\n\nstruct Token implements IClone {\nmut:\n\tpatterns []Tokens\n}\n\nstruct Tokens implements IClone {\nmut:\n\ttokens []Token\n}\n\nfn (mut value DropClone) drop() {\n\tunsafe { value.text.free() }\n\tvalue.text = ''\n}\n\nfn (value &DropClone) clone() DropClone {\n\treturn DropClone{\n\t\ttext: value.text.clone()\n\t}\n}\n\nfn (mut tokens Tokens) push(token Token) {\n\ttokens.tokens << token\n}\n\nfn clone_in_specialization[T](_ T, original Outer) Outer {\n\treturn original.clone()\n}\n\nfn main() {\n\toriginal := Outer{\n\t\tinner: Inner{\n\t\t\ttext: 'kept'\n\t\t}\n\t}\n\tcloned := clone_in_specialization(1, original)\n\tassert cloned.inner.text == 'kept'\n\towned := DropClone{\n\t\ttext: 'dropped safely'\n\t}\n\towned_clone := owned.clone()\n\tassert owned_clone.text == 'dropped safely'\n\tmut recursive := Tokens{\n\t\ttokens: [Token{\n\t\t\tpatterns: [Tokens{\n\t\t\t\ttokens: [Token{}]\n\t\t\t}]\n\t\t}]\n\t}\n\trecursive_clone := recursive.clone()\n\trecursive.tokens[0].patterns[0].push(Token{})\n\tassert recursive.tokens[0].patterns[0].tokens.len == 2\n\tassert recursive_clone.tokens[0].patterns[0].tokens.len == 1\n\tmut appended := Tokens{}\n\tappended.push(recursive.tokens[0])\n\trecursive.tokens[0].patterns[0].push(Token{})\n\tassert recursive.tokens[0].patterns[0].tokens.len == 3\n\tassert appended.tokens[0].patterns[0].tokens.len == 2\n\tprintln('ok')\n}\n")!
+	out := os.execute('${v3_bin} -ownership -d ownership -nocache -no-parallel run ${source}')
+	assert out.exit_code == 0, out.output
+	assert out.output.contains('\nok\n'), out.output
+}

--- a/vlib/v3/tests/nested_struct_optional_default_codegen_test.v
+++ b/vlib/v3/tests/nested_struct_optional_default_codegen_test.v
@@ -1,0 +1,21 @@
+import os
+
+const nested_optional_default_vexe = @VEXE
+const nested_optional_default_tests_dir = os.dir(@FILE)
+const nested_optional_default_v3_dir = os.dir(nested_optional_default_tests_dir)
+const nested_optional_default_vlib_dir = os.dir(nested_optional_default_v3_dir)
+const nested_optional_default_v3_src = os.join_path(nested_optional_default_v3_dir, 'v3.v')
+
+fn test_nested_struct_array_default_keeps_optional_wrapper() {
+	v3_bin := os.join_path(os.temp_dir(), 'v3_nested_optional_default_test')
+	build :=
+		os.execute('${nested_optional_default_vexe} -gc none -path "${nested_optional_default_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${nested_optional_default_v3_src}')
+	assert build.exit_code == 0, build.output
+
+	source := os.join_path(os.temp_dir(), 'v3_nested_optional_default_input.v')
+	os.write_file(source,
+		"enum PayloadKind {\n\tother\n}\n\nstruct Payload {\n\tkind PayloadKind = .other\n\ttext string\n\titems []int\n\tnested []Payload\n}\n\nstruct Middle {\n\tpayload ?Payload\n}\n\nstruct Outer {\n\tmiddle Middle\n}\n\nfn main() {\n\tvalues := []Outer{len: 2}\n\tassert values[0].middle.payload == none\n\tassert values[1].middle.payload == none\n\treserved := []Outer{cap: 2}\n\tassert reserved.len == 0\n\tassert reserved.cap >= 2\n\tprintln('ok')\n}\n")!
+	out := os.execute('${v3_bin} -no-parallel run ${source}')
+	assert out.exit_code == 0, out.output
+	assert out.output.contains('\nok\n'), out.output
+}

--- a/vlib/v3/tests/optional_borrow_field_codegen_test.v
+++ b/vlib/v3/tests/optional_borrow_field_codegen_test.v
@@ -1,0 +1,44 @@
+import os
+
+fn test_optional_field_payload_can_be_borrowed() {
+	vexe := @VEXE
+	v3_dir := os.dir(os.dir(@FILE))
+	vlib_dir := os.dir(v3_dir)
+	v3_src := os.join_path(v3_dir, 'v3.v')
+	v3_bin := os.join_path(os.temp_dir(), 'v3_optional_borrow_field_compiler')
+	src := os.join_path(os.temp_dir(), 'v3_optional_borrow_field_input.v')
+	out := os.join_path(os.temp_dir(), 'v3_optional_borrow_field_program')
+	defer {
+		os.rm(v3_bin) or {}
+		os.rm(src) or {}
+		os.rm(out) or {}
+		os.rm(out + '.c') or {}
+	}
+	build :=
+		os.execute('${vexe} -gc none -path "${vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${v3_src}')
+	assert build.exit_code == 0, build.output
+	os.write_file(src, "struct Holder {
+	value ?string
+}
+
+fn (holder &^a Holder) value_ref[^a]() ?&^a string {
+	if holder.value != none {
+		return unsafe { &holder.value? }
+	}
+	return none
+}
+
+fn main() {
+	holder := Holder{
+		value: 'borrowed'
+	}
+	assert *(holder.value_ref() or { panic('missing value') }) == 'borrowed'
+}
+") or {
+		panic(err)
+	}
+	compile := os.execute('${v3_bin} -b c -o ${out} ${src}')
+	assert compile.exit_code == 0, compile.output
+	run := os.execute(out)
+	assert run.exit_code == 0, run.output
+}

--- a/vlib/v3/tests/optional_guard_move_codegen_test.v
+++ b/vlib/v3/tests/optional_guard_move_codegen_test.v
@@ -1,0 +1,109 @@
+import os
+
+const optional_guard_move_vexe = @VEXE
+const optional_guard_move_tests_dir = os.dir(@FILE)
+const optional_guard_move_v3_dir = os.dir(optional_guard_move_tests_dir)
+const optional_guard_move_vlib_dir = os.dir(optional_guard_move_v3_dir)
+const optional_guard_move_v3_src = os.join_path(optional_guard_move_v3_dir, 'v3.v')
+
+fn test_optional_guard_clears_only_moved_source_wrapper() {
+	pid := os.getpid()
+	v3_bin := os.join_path(os.temp_dir(), 'v3_optional_guard_move_${pid}')
+	source := os.join_path(os.temp_dir(), 'v3_optional_guard_move_input_${pid}.v')
+	output := os.join_path(os.temp_dir(), 'v3_optional_guard_move_program_${pid}')
+	defer {
+		os.rm(v3_bin) or {}
+		os.rm(source) or {}
+		os.rm(output) or {}
+		os.rm(output + '.c') or {}
+	}
+	build :=
+		os.execute('${optional_guard_move_vexe} -gc none -d ownership -path "${optional_guard_move_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${optional_guard_move_v3_src}')
+	assert build.exit_code == 0, build.output
+	os.write_file(source, "interface Drop {
+mut:
+\tdrop()
+}
+
+struct Holder implements Drop {
+mut:
+\tvalue ?[]u8
+}
+
+struct GenericHolder[T] {
+mut:
+\tvalue ?T
+}
+
+struct Cursor {
+mut:
+\tcalls int
+}
+
+fn (mut c Cursor) next() int {
+\tindex := c.calls
+\tc.calls++
+\treturn index
+}
+
+fn (mut h Holder) drop() {
+\t_ = h
+}
+
+fn (h &Holder) borrowed_len() int {
+\tif bytes := h.value {
+\t\treturn bytes.len
+\t}
+\treturn 0
+}
+
+fn (mut h Holder) clear() {
+\tif bytes := h.value {
+\t\tunsafe { bytes.free() }
+\t\th.value = none
+\t}
+}
+
+@[manualfree]
+fn (mut h GenericHolder[T]) clear[T]() {
+\tif bytes := h.value {
+\t\tunsafe { bytes.free() }
+\t\th.value = none
+\t}
+}
+
+fn main() {
+\tmut holder := Holder{
+\t\tvalue: [u8(1), 2]
+\t}
+\tassert holder.borrowed_len() == 2
+\tassert holder.value != none
+\tholder.clear()
+\tassert holder.value == none
+\tmut generic_holder := GenericHolder[[]u8]{
+\t\tvalue: [u8(3), 4]
+\t}
+\tgeneric_holder.clear()
+\tassert generic_holder.value == none
+\tmut holders := [Holder{
+\t\tvalue: [u8(5), 6]
+\t}, Holder{
+\t\tvalue: [u8(7), 8]
+\t}]
+\tmut cursor := Cursor{}
+\tif bytes := holders[cursor.next()].value {
+\t\tassert bytes == [u8(5), 6]
+\t}
+\tassert cursor.calls == 1
+\tprintln('ok')
+}
+") or {
+		panic(err)
+	}
+	compile :=
+		os.execute('${v3_bin} -ownership -d ownership -nocache -no-parallel -o ${output} ${source}')
+	assert compile.exit_code == 0, compile.output
+	run := os.execute(output)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == 'ok', run.output
+}

--- a/vlib/v3/tests/owned_array_mutation_codegen_test.v
+++ b/vlib/v3/tests/owned_array_mutation_codegen_test.v
@@ -1,0 +1,21 @@
+import os
+
+const owned_array_mutation_vexe = @VEXE
+const owned_array_mutation_tests_dir = os.dir(@FILE)
+const owned_array_mutation_v3_dir = os.dir(owned_array_mutation_tests_dir)
+const owned_array_mutation_vlib_dir = os.dir(owned_array_mutation_v3_dir)
+const owned_array_mutation_v3_src = os.join_path(owned_array_mutation_v3_dir, 'v3.v')
+
+fn test_owned_array_mutations_keep_generated_drop_loops_well_formed() {
+	v3_bin := os.join_path(os.temp_dir(), 'v3_owned_array_mutation_test')
+	build :=
+		os.execute('${owned_array_mutation_vexe} -gc none -d ownership -path "${owned_array_mutation_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${owned_array_mutation_v3_src}')
+	assert build.exit_code == 0, build.output
+
+	source := os.join_path(os.temp_dir(), 'v3_owned_array_mutation_input.v')
+	os.write_file(source,
+		"fn main() {\n\tmut values := ['a', 'b', 'c']\n\tvalues.delete(1)\n\tassert values == ['a', 'c']\n\tvalues.clear()\n\tassert values.len == 0\n\tvalues = ['last']\n\tvalues.free()\n\tassert values.len == 0\n\tmut nested := [['owned']]\n\tnested.pop()\n\tassert nested.len == 0\n\tprintln('ok')\n}\n")!
+	out := os.execute('${v3_bin} -ownership -d ownership -no-parallel run ${source}')
+	assert out.exit_code == 0, out.output
+	assert out.output.contains('\nok\n'), out.output
+}

--- a/vlib/v3/tests/owned_map_delete_codegen_test.v
+++ b/vlib/v3/tests/owned_map_delete_codegen_test.v
@@ -1,0 +1,21 @@
+import os
+
+const owned_map_delete_vexe = @VEXE
+const owned_map_delete_tests_dir = os.dir(@FILE)
+const owned_map_delete_v3_dir = os.dir(owned_map_delete_tests_dir)
+const owned_map_delete_vlib_dir = os.dir(owned_map_delete_v3_dir)
+const owned_map_delete_v3_src = os.join_path(owned_map_delete_v3_dir, 'v3.v')
+
+fn test_owned_map_delete_snapshots_and_drops_the_stored_value() {
+	v3_bin := os.join_path(os.temp_dir(), 'v3_owned_map_delete_test')
+	build :=
+		os.execute('${owned_map_delete_vexe} -gc none -d ownership -path "${owned_map_delete_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${owned_map_delete_v3_src}')
+	assert build.exit_code == 0, build.output
+
+	source := os.join_path(os.temp_dir(), 'v3_owned_map_delete_input.v')
+	os.write_file(source,
+		"fn main() {\n\tmut values := map[string][]string{}\n\tvalues['letters'] = ['a', 'b']\n\tvalues.delete('letters')\n\tassert values.len == 0\n\tprintln('ok')\n}\n")!
+	out := os.execute('${v3_bin} -ownership -d ownership -no-parallel run ${source}')
+	assert out.exit_code == 0, out.output
+	assert out.output.contains('\nok\n'), out.output
+}

--- a/vlib/v3/tests/ownership/ownership_test.v
+++ b/vlib/v3/tests/ownership/ownership_test.v
@@ -311,6 +311,31 @@ fn main() {
 	')
 	assert ok_iclone_default_clone.exit_code == 0, ok_iclone_default_clone.output
 
+	fail_iclone_drop_temporary := run_ownership_check(v3_bin, 'iclone_drop_temporary', '
+interface Drop {
+mut:
+	drop()
+}
+
+struct Resource implements IClone, Drop {
+	id int
+}
+
+fn make_resource() Resource {
+	return Resource{id: 7}
+}
+
+fn (mut resource Resource) drop() {
+	println(resource.id)
+}
+
+fn main() {
+	_ := make_resource().clone()
+}
+	')
+	assert fail_iclone_drop_temporary.exit_code != 0
+	assert fail_iclone_drop_temporary.output.contains('cannot generate default clone for `Resource`: `Resource` requires ownership destruction but has no `clone()` method'), fail_iclone_drop_temporary.output
+
 	ok_iclone_if_expr_clone := run_ownership_check(v3_bin, 'iclone_if_expr_clone', '
 struct Resource implements IClone {
 	id int

--- a/vlib/v3/tests/ownership_optional_array_overwrite_codegen_test.v
+++ b/vlib/v3/tests/ownership_optional_array_overwrite_codegen_test.v
@@ -1,0 +1,21 @@
+import os
+
+const optional_array_overwrite_vexe = @VEXE
+const optional_array_overwrite_tests_dir = os.dir(@FILE)
+const optional_array_overwrite_v3_dir = os.dir(optional_array_overwrite_tests_dir)
+const optional_array_overwrite_vlib_dir = os.dir(optional_array_overwrite_v3_dir)
+const optional_array_overwrite_v3_src = os.join_path(optional_array_overwrite_v3_dir, 'v3.v')
+
+fn test_owned_optional_array_overwrite_wraps_cloned_payload() {
+	v3_bin := os.join_path(os.temp_dir(), 'v3_optional_array_overwrite_test')
+	build :=
+		os.execute('${optional_array_overwrite_vexe} -gc none -d ownership -path "${optional_array_overwrite_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${optional_array_overwrite_v3_src}')
+	assert build.exit_code == 0, build.output
+
+	source := os.join_path(os.temp_dir(), 'v3_optional_array_overwrite_input.v')
+	os.write_file(source,
+		"struct Holder {\nmut:\n\tvalue ?[]u8\n\tseparator_value ?[]u8\n}\n\nfn (mut holder Holder) set(value ?[]u8) {\n\tif bytes := value {\n\t\tholder.value = bytes.clone()\n\t} else {\n\t\tholder.value = none\n\t}\n}\n\nfn (mut holder Holder) separator(separator ?[]u8) {\n\tif sep := separator {\n\t\tholder.separator_value = sep.clone()\n\t} else {\n\t\tholder.separator_value = none\n\t}\n}\n\nfn main() {\n\tmut holder := Holder{}\n\tholder.set([u8(4), 2])\n\tassert holder.value? == [u8(4), 2]\n\tholder.separator([u8(5), 3])\n\tassert holder.separator_value? == [u8(5), 3]\n\tprintln('ok')\n}\n")!
+	out := os.execute('${v3_bin} -ownership -d ownership -no-parallel run ${source}')
+	assert out.exit_code == 0, out.output
+	assert out.output.contains('\nok\n'), out.output
+}

--- a/vlib/v3/tests/ownership_optional_copy_codegen_test.v
+++ b/vlib/v3/tests/ownership_optional_copy_codegen_test.v
@@ -1,0 +1,23 @@
+import os
+
+const ownership_optional_copy_vexe = @VEXE
+const ownership_optional_copy_tests_dir = os.dir(@FILE)
+const ownership_optional_copy_v3_dir = os.dir(ownership_optional_copy_tests_dir)
+const ownership_optional_copy_vlib_dir = os.dir(ownership_optional_copy_v3_dir)
+const ownership_optional_copy_v3_src = os.join_path(ownership_optional_copy_v3_dir, 'v3.v')
+
+fn test_copyable_optional_can_be_read_and_assigned_repeatedly() {
+	v3_bin := os.join_path(os.temp_dir(), 'v3_ownership_optional_copy_test')
+	build :=
+		os.execute('${ownership_optional_copy_vexe} -gc none -d ownership -path "${ownership_optional_copy_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${ownership_optional_copy_v3_src}')
+	assert build.exit_code == 0, build.output
+
+	source := os.join_path(os.temp_dir(), 'v3_ownership_optional_copy_input.v')
+	os.write_file(source,
+		"struct Cursor {\nmut:\n\tprevious ?rune\n}\n\nfn (mut cursor Cursor) replace(value ?rune) ?rune {\n\told := cursor.previous\n\tcursor.previous = value\n\treturn old\n}\n\nfn main() {\n\tmut cursor := Cursor{previous: rune(`a`)}\n\tfirst := cursor.previous\n\tassert first? == `a`\n\tassert cursor.previous? == `a`\n\tassert cursor.replace(rune(`b`))? == `a`\n\tassert cursor.previous? == `b`\n\tprintln('ok')\n}\n") or {
+		panic(err)
+	}
+	out := os.execute('${v3_bin} -ownership -d ownership -no-parallel run ${source}')
+	assert out.exit_code == 0, out.output
+	assert out.output.contains('\nok\n'), out.output
+}

--- a/vlib/v3/tests/ownership_result_sentinel_codegen_test.v
+++ b/vlib/v3/tests/ownership_result_sentinel_codegen_test.v
@@ -1,0 +1,21 @@
+import os
+
+const sentinel_vexe = @VEXE
+const sentinel_tests_dir = os.dir(@FILE)
+const sentinel_v3_dir = os.dir(sentinel_tests_dir)
+const sentinel_vlib_dir = os.dir(sentinel_v3_dir)
+const sentinel_v3_src = os.join_path(sentinel_v3_dir, 'v3.v')
+
+fn test_ownership_generated_result_cleanup_roots_ierror_sentinels() {
+	v3_bin := os.join_path(os.temp_dir(), 'v3_ownership_sentinel_test')
+	build :=
+		os.execute('${sentinel_vexe} -gc none -d ownership -path "${sentinel_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${sentinel_v3_src}')
+	assert build.exit_code == 0, build.output
+
+	source := os.join_path(os.temp_dir(), 'v3_ownership_sentinel_input.v')
+	os.write_file(source,
+		"struct Node {\n\tvalue ?string\n\tchildren []Node\n}\n\nfn main() {\n\tnode := Node{\n\t\tvalue: 'kept'\n\t\tchildren: []Node{}\n\t}\n\tassert node.value or { '' } == 'kept'\n\tprintln('ok')\n}\n")!
+	out := os.execute('${v3_bin} -ownership -d ownership -no-parallel run ${source}')
+	assert out.exit_code == 0, out.output
+	assert out.output.contains('\nok\n'), out.output
+}

--- a/vlib/v3/tests/review_transform_regressions_test.v
+++ b/vlib/v3/tests/review_transform_regressions_test.v
@@ -5455,3 +5455,69 @@ fn main() {
 ')
 	assert out == '2\n1'
 }
+
+fn test_last_lvalue_stabilizes_side_effecting_receiver() {
+	v3_bin := build_v3_review_transform()
+	out := run_good(v3_bin, 'last_lvalue_side_effecting_receiver', '__global calls int
+
+fn next() int {
+	index := calls
+	calls++
+	return index
+}
+
+fn main() {
+	mut arrays := [[[1, 2]], [[3, 4]]]
+	arrays[next()].last() << 9
+	println(int_str(calls))
+	println(arrays[0])
+	println(arrays[1])
+}
+')
+	assert out == '1\n[[1, 2, 9]]\n[[3, 4]]'
+}
+
+fn test_shadowed_allocation_helper_fn_values_preserve_address_escapes() {
+	v3_bin := build_v3_review_transform()
+	c_source := gen_c_from_source(v3_bin, 'shadowed_allocation_helper_fn_value_escape', 'fn pass(p &int) &int {
+	return p
+}
+
+fn make_memdup() &int {
+	local := 41
+	memdup := pass
+	return memdup(&local)
+}
+
+fn make_memdup_noscan() &int {
+	local := 42
+	memdup_noscan := pass
+	return memdup_noscan(&local)
+}
+
+fn make_aligned_memdup() &int {
+	local := 43
+	v3_aligned_memdup := pass
+	return v3_aligned_memdup(&local)
+}
+
+fn make_builtin_memdup() &int {
+	local := 44
+	return unsafe { &int(memdup(&local, sizeof(int))) }
+}
+
+fn main() {
+	println(unsafe { *make_memdup() })
+	println(unsafe { *make_memdup_noscan() })
+	println(unsafe { *make_aligned_memdup() })
+	println(unsafe { *make_builtin_memdup() })
+}
+')
+	for fn_name in ['make_memdup', 'make_memdup_noscan', 'make_aligned_memdup'] {
+		body := c_fn_body(c_source, 'int* ${fn_name}(void) {')
+		assert body.contains('int* local ='), body
+	}
+	builtin_body := c_fn_body(c_source, 'int* make_builtin_memdup(void) {')
+	assert builtin_body.contains('int local = 44;'), builtin_body
+	assert builtin_body.contains('memdup(&local, sizeof(int))'), builtin_body
+}

--- a/vlib/v3/transform/array.v
+++ b/vlib/v3/transform/array.v
@@ -283,27 +283,34 @@ fn (mut t Transformer) make_array_clone_call(base_id flat.NodeId, base_type stri
 		&& !base_type.starts_with('&') && !t.expr_can_take_address(base_id)
 		&& t.tc.ownership_type_requires_destruction(t.tc.parse_type(clean_type))
 	mut receiver := t.transform_expr(base_id)
+	transformed_receiver_type := t.node_type(receiver)
+	effective_base_type := if transformed_receiver_type.starts_with('&')
+		&& t.normalize_type_alias(transformed_receiver_type[1..]) == clean_type {
+		transformed_receiver_type
+	} else {
+		base_type
+	}
 	if clean_type.starts_with('[]') && !isnil(t.tc) {
 		elem_type := t.tc.parse_type(clean_type[2..])
 		if !t.tc.ownership_type_requires_destruction(elem_type) {
 			if source_is_owned_temporary {
 				return t.make_array_clone_from_owned_temporary(receiver, clean_type)
 			}
-			return t.make_array_clone_value(receiver, base_type)
+			return t.make_array_clone_value(receiver, effective_base_type)
 		}
 		// The checker rejects this call. Do not lower it to the unsafe raw clone while
 		// processing the invalid program.
 		if _ := t.tc.ownership_default_clone_missing_method(elem_type) {
 			return receiver
 		}
-		if base_type.starts_with('&') {
+		if effective_base_type.starts_with('&') {
 			receiver = t.make_prefix(.mul, receiver)
 			t.set_node_typ(int(receiver), clean_type)
 		}
 		return t.make_compiler_default_array_clone_value(receiver, clean_type,
 			source_is_owned_temporary)
 	}
-	return t.make_array_clone_value(receiver, base_type)
+	return t.make_array_clone_value(receiver, effective_base_type)
 }
 
 // make_array_clone_from_owned_temporary saves a non-addressable source until its backing
@@ -401,10 +408,12 @@ fn (mut t Transformer) lower_array_init_to_runtime(id flat.NodeId, node flat.Nod
 	mut cap_expr := t.make_int_literal(0)
 	mut init_expr := flat.empty_node
 	mut init_expr_id := flat.empty_node
+	mut has_len := false
 	for i in 0 .. node.children_count {
 		child := t.a.child_node(&node, i)
 		if child.kind == .field_init && child.children_count > 0 {
 			if child.value == 'len' {
+				has_len = true
 				val := t.transform_expr(t.a.child(child, 0))
 				len_expr = val
 			} else if child.value == 'cap' {
@@ -416,7 +425,10 @@ fn (mut t Transformer) lower_array_init_to_runtime(id flat.NodeId, node flat.Nod
 		}
 	}
 	new_call := t.make_array_new_call(elem_type, len_expr, cap_expr)
-	if node.children_count == 0 {
+	// Capacity reserves storage but creates no elements. In particular, do not
+	// synthesize a default-value fill loop merely because `{cap: n}` has a field
+	// child: its runtime length is zero and no element initializer is needed.
+	if node.children_count == 0 || !has_len {
 		return new_call
 	}
 	if int(init_expr_id) < 0 {

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -1792,7 +1792,17 @@ fn (t &Transformer) is_import_alias_ident(id flat.NodeId) bool {
 		return false
 	}
 	node := t.a.nodes[int(id)]
-	if node.kind != .ident || node.value !in t.tc.imports {
+	if node.kind != .ident {
+		return false
+	}
+	// A module may export a constant with the same short name as the import
+	// alias (`import core.flags`, where that module also exports `flags`). In a
+	// selector callee such as `flags.parse()`, the file import remains the
+	// syntactic namespace unless a local value shadows it.
+	if _ := t.tc.file_imports[file_import_key(t.cur_file, node.value)] {
+		return t.raw_var_type(node.value).len == 0
+	}
+	if node.value !in t.tc.imports {
 		return false
 	}
 	// A local or receiver can shadow an import alias. Generic clones may no longer
@@ -7676,7 +7686,8 @@ fn (mut t Transformer) try_lower_struct_clone_method_call(_call_id flat.NodeId, 
 		}
 	}
 	// A user-defined clone() would have been lowered already; only supply the default clone.
-	if t.resolve_receiver_method_name(base_id, 'clone').len > 0 {
+	if t.tc.ownership_type_has_clone_method(t.tc.parse_type(base_type))
+		&& t.resolve_receiver_method_name(base_id, 'clone').len > 0 {
 		return none
 	}
 	// The checker reports the concrete ownership-bearing field that has no safe clone.
@@ -7749,7 +7760,7 @@ fn (mut t Transformer) make_compiler_default_clone_value(source flat.NodeId, typ
 		return t.make_compiler_default_map_clone_value(source, clean,
 			!t.expr_can_take_address(source))
 	}
-	if allow_method {
+	if allow_method && !isnil(t.tc) && t.tc.ownership_type_has_clone_method(t.tc.parse_type(clean)) {
 		if !isnil(t.tc) && clean.contains('[') && clean.ends_with(']') {
 			if _ := t.tc.resolve_generic_struct_method(clean, 'clone') {
 				call := t.make_method_call(source, 'clone', []flat.NodeId{})
@@ -10962,6 +10973,14 @@ fn (mut t Transformer) try_lower_receiver_method_call(id flat.NodeId, node flat.
 			return none
 		}
 		if t.receiver_method_has_generic_template(base_type, method) {
+			return none
+		}
+		// A marker-only `IClone` receiver has no declared method for generic
+		// validation to resolve. Its call is lowered structurally by
+		// try_lower_struct_clone_method_call immediately after this helper.
+		if method == 'clone' && !isnil(t.tc)
+			&& t.tc.named_type_implements_marker(base_type, 'IClone')
+			&& !t.tc.ownership_type_has_clone_method(t.tc.parse_type(base_type)) {
 			return none
 		}
 		base_name := if base_node.kind == .ident && base_node.value.len > 0 {

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -7674,7 +7674,15 @@ fn (mut t Transformer) try_lower_struct_clone_method_call(_call_id flat.NodeId, 
 		|| t.is_fixed_array_type(base_type) {
 		return none
 	}
-	if isnil(t.tc) || !t.tc.named_type_implements_marker(base_type, 'IClone') {
+	parsed_base_type := if isnil(t.tc) {
+		types.Type(types.Unknown{})
+	} else {
+		t.tc.parse_type(base_type)
+	}
+	is_default_sum_clone := t.is_sum_type_name(base_type) && !isnil(t.tc)
+		&& t.tc.ownership_default_clone_missing_method(parsed_base_type) == none
+	if isnil(t.tc) || (!t.tc.named_type_implements_marker(base_type, 'IClone')
+		&& !is_default_sum_clone) {
 		return none
 	}
 	// A concrete generic receiver can have a handwritten clone() on its open
@@ -7693,7 +7701,7 @@ fn (mut t Transformer) try_lower_struct_clone_method_call(_call_id flat.NodeId, 
 	// The checker reports the concrete ownership-bearing field that has no safe clone.
 	// Do not turn the rejected default clone into a shallow aggregate copy while
 	// transforming the invalid program.
-	if _ := t.tc.ownership_default_clone_missing_method(t.tc.parse_type(base_type)) {
+	if _ := t.tc.ownership_default_clone_missing_method(parsed_base_type) {
 		return t.make_empty()
 	}
 	mut receiver := t.transform_expr(base_id)
@@ -7716,20 +7724,25 @@ fn (mut t Transformer) make_compiler_default_clone_value(source flat.NodeId, typ
 	if clean.starts_with('?') || clean.starts_with('!') {
 		inner := t.optional_base_type(t.qualify_optional_type(clean))
 		inner_needs_work := t.compiler_default_clone_type_needs_work(inner)
-		tmp_name := t.new_temp('derived_clone_opt')
-		t.pending_stmts << t.make_decl_assign_typed(tmp_name, source, clean)
-		tmp := t.make_ident(tmp_name)
-		mut body := []flat.NodeId{}
-		if inner_needs_work {
-			source_value := t.make_selector(tmp, 'value', inner)
-			pending_start := t.pending_stmts.len
-			cloned_value := t.make_compiler_default_clone_value(source_value, inner, true)
-			body = t.pending_stmts[pending_start..].clone()
-			t.pending_stmts = t.pending_stmts[..pending_start].clone()
-			body << t.make_assign(t.make_selector(t.make_ident(tmp_name), 'value', inner),
-				cloned_value)
+		source_is_owned_temporary := !t.expr_can_take_address(source)
+		stable_source := t.stable_transformed_expr_for_reuse(source, clean,
+			'derived_clone_opt_source')
+		out_name := t.new_temp('derived_clone_opt')
+		t.pending_stmts << t.make_decl_assign_typed(out_name, t.make_optional_none(clean), clean)
+		pending_start := t.pending_stmts.len
+		cloned_value := if inner_needs_work {
+			t.make_compiler_default_clone_value(t.make_selector(stable_source, 'value', inner),
+				inner, true)
+		} else if inner.len > 0 && inner != 'void' {
+			t.make_selector(stable_source, 'value', inner)
+		} else {
+			t.make_empty()
 		}
-		source_err := t.make_selector(t.make_ident(tmp_name), 'err', 'IError')
+		mut body := t.pending_stmts[pending_start..].clone()
+		t.pending_stmts = t.pending_stmts[..pending_start].clone()
+		body << t.make_assign_without_ownership_drop(t.make_ident(out_name), t.make_optional_some(cloned_value,
+			clean))
+		source_err := t.make_selector(stable_source, 'err', 'IError')
 		t.mark_fn_used('string__clone')
 		if !isnil(t.tc) {
 			for concrete in t.tc.ierror_impl_names() {
@@ -7739,11 +7752,15 @@ fn (mut t Transformer) make_compiler_default_clone_value(source flat.NodeId, typ
 			}
 		}
 		cloned_err := t.make_call_typed('__v3_clone_owned_ierror', arr1(source_err), 'IError')
-		else_branch := t.make_block(arr1(t.make_assign(t.make_selector(t.make_ident(tmp_name),
-			'err', 'IError'), cloned_err)))
-		t.pending_stmts << t.make_if(t.make_selector(tmp, 'ok', 'bool'), t.make_block(body),
-			else_branch)
-		return t.make_ident(tmp_name)
+		else_branch := t.make_block(arr1(t.make_assign_without_ownership_drop(t.make_ident(out_name), t.make_optional_none_with_err(clean,
+			cloned_err))))
+		t.pending_stmts << t.make_if(t.make_selector(stable_source, 'ok', 'bool'),
+			t.make_block(body), else_branch)
+		if source_is_owned_temporary {
+			t.pending_stmts << t.make_expr_stmt(t.make_call_typed('drop_owned',
+				arr1(stable_source), 'void'))
+		}
+		return t.make_ident(out_name)
 	}
 	if clean == 'string' {
 		t.mark_fn_used('string__clone')
@@ -7784,6 +7801,16 @@ fn (mut t Transformer) make_compiler_default_clone_value(source flat.NodeId, typ
 		&& t.tc.ownership_default_clone_missing_method(t.tc.parse_type(clean)) != none) {
 		return source
 	}
+	if clean in t.default_clone_expansion_stack {
+		return t.request_default_clone_helper(source, clean)
+	}
+	t.default_clone_expansion_stack << clean
+	defer {
+		t.default_clone_expansion_stack.delete_last()
+	}
+	if t.is_sum_type_name(clean) {
+		return t.make_compiler_default_sum_clone_value(source, clean)
+	}
 	info := t.lookup_struct_info(clean) or { return source }
 	mut owning_fields := []FieldInfo{}
 	for field in info.fields {
@@ -7812,10 +7839,186 @@ fn (mut t Transformer) make_compiler_default_clone_value(source flat.NodeId, typ
 			t.pending_stmts << t.make_expr_stmt(drop_call)
 			cloned_field = t.make_ident(cloned_name)
 		}
-		t.pending_stmts << t.make_assign(t.make_selector(t.make_ident(tmp_name), field.name,
-			field_type), cloned_field)
+		t.pending_stmts << t.make_assign_without_ownership_drop(t.make_selector(t.make_ident(tmp_name),
+			field.name, field_type), cloned_field)
 	}
 	return t.make_ident(tmp_name)
+}
+
+// make_compiler_default_sum_clone_value rebuilds the active variant so its boxed
+// payload is independent from the source sum value.
+fn (mut t Transformer) make_compiler_default_sum_clone_value(source flat.NodeId, sum_type string) flat.NodeId {
+	resolved_sum := t.resolve_sum_name(sum_type)
+	variants := t.sum_types[resolved_sum] or { return source }
+	if variants.len == 0 {
+		return source
+	}
+	source_is_owned_temporary := !t.expr_can_take_address(source)
+	stable_source := t.stable_transformed_expr_for_reuse(source, sum_type,
+		'derived_clone_sum_source')
+	out_name := t.new_temp('derived_clone_sum')
+	t.pending_stmts << t.make_decl_assign_typed(out_name, stable_source, sum_type)
+	for variant in variants {
+		qvariant := t.resolve_variant(resolved_sum, variant)
+		if qvariant.len == 0 {
+			continue
+		}
+		use_ptr := t.variant_references_sum(qvariant, resolved_sum)
+			&& !t.sum_variant_is_direct_pointer(qvariant)
+		field_type := if use_ptr { '&${qvariant}' } else { qvariant }
+		mut payload :=
+			t.make_selector_op(stable_source, t.sum_field_name(qvariant), field_type, .dot)
+		if use_ptr {
+			payload = t.make_prefix(.mul, payload)
+			t.set_node_typ(int(payload), qvariant)
+		}
+		pending_start := t.pending_stmts.len
+		cloned_payload := t.make_compiler_default_clone_value(payload, qvariant, true)
+		mut body := t.pending_stmts[pending_start..].clone()
+		t.pending_stmts = t.pending_stmts[..pending_start].clone()
+		wrapped := t.make_sum_literal(resolved_sum, qvariant, cloned_payload)
+		body << t.make_assign_without_ownership_drop(t.make_ident(out_name), wrapped)
+		cond := t.make_sum_is_check(stable_source, sum_type, resolved_sum, qvariant)
+		t.pending_stmts << t.make_if(cond, t.make_block(body), t.make_empty())
+	}
+	if source_is_owned_temporary {
+		t.pending_stmts << t.make_expr_stmt(t.make_call_typed('drop_owned', arr1(stable_source),
+			'void'))
+	}
+	result := t.make_ident(out_name)
+	t.set_node_typ(int(result), sum_type)
+	return result
+}
+
+fn default_clone_helper_name(typ string) string {
+	return '__v3_default_clone_${c_name(typ)}'
+}
+
+fn (mut t Transformer) request_default_clone_helper(source flat.NodeId, typ string) flat.NodeId {
+	helper := default_clone_helper_name(typ)
+	if typ !in t.default_clone_types {
+		t.default_clone_types[typ] = DefaultCloneRequest{
+			module: t.cur_module
+			file:   t.cur_file
+		}
+	}
+	t.mark_fn_used_name(helper)
+	address := t.runtime_addr(source, typ)
+	argument := t.make_cast('voidptr', address, 'voidptr')
+	return t.make_call_typed(helper, arr1(argument), typ)
+}
+
+// synthesize_default_clone_helpers drains recursive compiler-provided IClone
+// requests after worker results have been merged. Building a helper can expose
+// another recursive aggregate, so requests are processed as a worklist.
+fn (mut t Transformer) synthesize_default_clone_helpers() []string {
+	old_module := t.cur_module
+	old_file := t.cur_file
+	old_tc_module := if isnil(t.tc) { '' } else { t.tc.cur_module }
+	old_tc_file := if isnil(t.tc) { '' } else { t.tc.cur_file }
+	was_log_active := t.used_fns_log_active
+	log_start := t.used_fns_log.len
+	t.used_fns_log_active = true
+	for {
+		mut pending := []string{}
+		for name, _ in t.default_clone_types {
+			if name in t.default_clone_synthesized {
+				continue
+			}
+			if default_clone_helper_name(name) in t.fn_ret_types {
+				t.default_clone_synthesized[name] = true
+				continue
+			}
+			pending << name
+		}
+		if pending.len == 0 {
+			break
+		}
+		pending.sort()
+		for name in pending {
+			t.default_clone_synthesized[name] = true
+			req := t.default_clone_types[name] or { DefaultCloneRequest{} }
+			t.cur_module = req.module
+			t.cur_file = req.file
+			if !isnil(t.tc) {
+				t.tc.cur_module = req.module
+				t.tc.cur_file = req.file
+			}
+			t.build_default_clone_helper_fn(name)
+		}
+	}
+	mut new_names := []string{}
+	mut seen := map[string]bool{}
+	for i in log_start .. t.used_fns_log.len {
+		name := t.used_fns_log[i]
+		if name.len > 0 && !seen[name] {
+			seen[name] = true
+			new_names << name
+		}
+	}
+	if !was_log_active {
+		t.used_fns_log_active = false
+		t.used_fns_log = t.used_fns_log[..log_start].clone()
+	}
+	t.cur_module = old_module
+	t.cur_file = old_file
+	if !isnil(t.tc) {
+		t.tc.cur_module = old_tc_module
+		t.tc.cur_file = old_tc_file
+	}
+	return new_names
+}
+
+fn (mut t Transformer) build_default_clone_helper_fn(typ string) {
+	helper := default_clone_helper_name(typ)
+	saved_pending := t.pending_stmts
+	saved_vars := t.var_types.clone()
+	saved_fn_name := t.cur_fn_name
+	saved_ret_type := t.cur_fn_ret_type
+	saved_expansion_stack := t.default_clone_expansion_stack.clone()
+	t.pending_stmts = []flat.NodeId{}
+	t.reset_var_types()
+	t.default_clone_expansion_stack = []string{}
+	t.cur_fn_name = helper
+	t.cur_fn_ret_type = typ
+	param_name := '__default_clone_source'
+	param := t.a.add_node(flat.Node{
+		kind:  .param
+		value: param_name
+		typ:   'voidptr'
+	})
+	t.set_var_type(param_name, 'voidptr')
+	typed_pointer := t.make_cast('&${typ}', t.make_ident(param_name), '&${typ}')
+	source := t.make_prefix(.mul, typed_pointer)
+	t.set_node_typ(int(source), typ)
+	cloned := t.make_compiler_default_clone_value(source, typ, false)
+	mut body := t.pending_stmts.clone()
+	body << t.make_return(cloned, typ)
+	t.pending_stmts = saved_pending
+	t.restore_var_types(saved_vars)
+	t.default_clone_expansion_stack = saved_expansion_stack
+	t.cur_fn_name = saved_fn_name
+	t.cur_fn_ret_type = saved_ret_type
+	t.add_generated_fn_decl_context('main')
+	start := t.a.children.len
+	t.a.children << param
+	t.a.children << body
+	fn_decl := t.a.add_node(flat.Node{
+		kind:           .fn_decl
+		value:          helper
+		typ:            typ
+		children_start: i32(start)
+		children_count: flat.child_count(1 + body.len)
+	})
+	t.ensure_node_context_map_capacity()
+	t.mark_node_context(fn_decl, 'main', t.cur_file)
+	t.fn_ret_types[helper] = typ
+	t.mark_fn_used_name(helper)
+	if !isnil(t.tc) {
+		t.tc.fn_ret_types[helper] = t.tc.parse_type(typ)
+		t.tc.fn_param_types[helper] = [t.tc.parse_type('voidptr')]
+		t.tc.fn_variadic[helper] = false
+	}
 }
 
 // make_compiler_default_array_clone_value clones the array storage and then replaces
@@ -7844,8 +8047,8 @@ fn (mut t Transformer) make_compiler_default_array_clone_value(source flat.NodeI
 	cloned_elem := t.make_compiler_default_clone_value(source_elem, elem_type, true)
 	mut body := t.pending_stmts[pending_start..].clone()
 	t.pending_stmts = t.pending_stmts[..pending_start].clone()
-	body << t.make_assign(t.make_index(t.make_ident(out_name), t.make_ident(idx_name), elem_type),
-		cloned_elem)
+	body << t.make_assign_without_ownership_drop(t.make_index(t.make_ident(out_name),
+		t.make_ident(idx_name), elem_type), cloned_elem)
 	t.pending_stmts << t.make_for_stmt(init, cond, post, body, flat.Node{
 		skip_ownership_drops: true
 	})
@@ -7882,8 +8085,8 @@ fn (mut t Transformer) make_compiler_default_fixed_array_clone_value(source flat
 	cloned_elem := t.make_compiler_default_clone_value(source_elem, elem_type, true)
 	mut body := t.pending_stmts[pending_start..].clone()
 	t.pending_stmts = t.pending_stmts[..pending_start].clone()
-	body << t.make_assign(t.make_index(t.make_ident(out_name), t.make_ident(idx_name), elem_type),
-		cloned_elem)
+	body << t.make_assign_without_ownership_drop(t.make_index(t.make_ident(out_name),
+		t.make_ident(idx_name), elem_type), cloned_elem)
 	t.pending_stmts << t.make_for_stmt(init, cond, post, body, flat.Node{
 		skip_ownership_drops: true
 	})
@@ -11379,6 +11582,12 @@ fn (mut t Transformer) resolved_receiver_arg_compatible(arg_id flat.NodeId, actu
 	if expected.starts_with('&') && actual == expected[1..] {
 		return true
 	}
+	// V also permits the inverse value coercion. This covers a borrowed value
+	// passed to a by-value parameter and `&param` inside a specialized function
+	// where a source `mut T` parameter already has `&T` storage after lowering.
+	if actual.starts_with('&') && actual[1..] == expected {
+		return true
+	}
 	if expected == '&void'
 		&& (actual.starts_with('&') || actual in ['voidptr', 'byteptr', 'charptr', 'nil']) {
 		return true
@@ -11424,9 +11633,13 @@ fn (mut t Transformer) resolved_receiver_arg_compatible(arg_id flat.NodeId, actu
 	if t.is_sum_type_name(actual) && t.sum_target_accepts_variant_type(actual, expected) {
 		return true
 	}
-	if !isnil(t.tc) && expected in t.tc.interface_names
-		&& t.tc.type_text_implements_interface(actual, expected) {
-		return true
+	if !isnil(t.tc) {
+		expected_interface := t.trim_all_pointer_type(expected)
+		actual_interface := t.trim_all_pointer_type(actual)
+		if expected_interface in t.tc.interface_names
+			&& t.tc.type_text_implements_interface(actual_interface, expected_interface) {
+			return true
+		}
 	}
 	// Generic applications may differ only in module qualification of their
 	// type arguments (`json2.Node[ValueInfo]` vs `json2.Node[json2.ValueInfo]`).

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -1780,7 +1780,17 @@ fn (t &Transformer) is_import_alias_ident(id flat.NodeId) bool {
 		return false
 	}
 	node := t.a.nodes[int(id)]
-	if node.kind != .ident || node.value !in t.tc.imports {
+	if node.kind != .ident {
+		return false
+	}
+	// A module may export a constant with the same short name as the import
+	// alias (`import core.flags`, where that module also exports `flags`). In a
+	// selector callee such as `flags.parse()`, the file import remains the
+	// syntactic namespace unless a local value shadows it.
+	if _ := t.tc.file_imports[file_import_key(t.cur_file, node.value)] {
+		return t.raw_var_type(node.value).len == 0
+	}
+	if node.value !in t.tc.imports {
 		return false
 	}
 	// A local or receiver can shadow an import alias. Generic clones may no longer
@@ -7614,7 +7624,8 @@ fn (mut t Transformer) try_lower_struct_clone_method_call(_call_id flat.NodeId, 
 		}
 	}
 	// A user-defined clone() would have been lowered already; only supply the default clone.
-	if t.resolve_receiver_method_name(base_id, 'clone').len > 0 {
+	if t.tc.ownership_type_has_clone_method(t.tc.parse_type(base_type))
+		&& t.resolve_receiver_method_name(base_id, 'clone').len > 0 {
 		return none
 	}
 	// The checker reports the concrete ownership-bearing field that has no safe clone.
@@ -7687,7 +7698,7 @@ fn (mut t Transformer) make_compiler_default_clone_value(source flat.NodeId, typ
 		return t.make_compiler_default_map_clone_value(source, clean,
 			!t.expr_can_take_address(source))
 	}
-	if allow_method {
+	if allow_method && !isnil(t.tc) && t.tc.ownership_type_has_clone_method(t.tc.parse_type(clean)) {
 		if !isnil(t.tc) && clean.contains('[') && clean.ends_with(']') {
 			if _ := t.tc.resolve_generic_struct_method(clean, 'clone') {
 				call := t.make_method_call(source, 'clone', []flat.NodeId{})
@@ -10903,6 +10914,14 @@ fn (mut t Transformer) try_lower_receiver_method_call(id flat.NodeId, node flat.
 			return none
 		}
 		if t.receiver_method_has_generic_template(base_type, method) {
+			return none
+		}
+		// A marker-only `IClone` receiver has no declared method for generic
+		// validation to resolve. Its call is lowered structurally by
+		// try_lower_struct_clone_method_call immediately after this helper.
+		if method == 'clone' && !isnil(t.tc)
+			&& t.tc.named_type_implements_marker(base_type, 'IClone')
+			&& !t.tc.ownership_type_has_clone_method(t.tc.parse_type(base_type)) {
 			return none
 		}
 		base_name := if base_node.kind == .ident && base_node.value.len > 0 {

--- a/vlib/v3/transform/for.v
+++ b/vlib/v3/transform/for.v
@@ -936,6 +936,24 @@ fn (mut t Transformer) lower_indexed_for_in(id flat.NodeId, node flat.Node, key_
 	direct_map_index_container := node.op == .amp && container_node.kind == .index
 	mut container := if direct_map_index_container {
 		container_id
+	} else if t.expr_can_take_address(container_id) {
+		mut lvalue := t.transform_lvalue(container_id)
+		if !t.is_stable_expr_for_reuse(lvalue) {
+			lvalue_type := if t.node_type(lvalue).len > 0 && t.node_type(lvalue) != 'unknown' {
+				t.node_type(lvalue)
+			} else if source_container_type.len > 0 && source_container_type != 'unknown' {
+				source_container_type
+			} else {
+				iter_type
+			}
+			lvalue_ptr := t.make_prefix(.amp, lvalue)
+			t.set_node_typ(int(lvalue_ptr), '&${lvalue_type}')
+			stable_ptr := t.stable_transformed_expr_for_reuse(lvalue_ptr, '&${lvalue_type}',
+				'for_container')
+			lvalue = t.make_prefix(.mul, stable_ptr)
+			t.set_node_typ(int(lvalue), lvalue_type)
+		}
+		lvalue
 	} else {
 		t.stable_expr_for_reuse(container_id)
 	}

--- a/vlib/v3/transform/if.v
+++ b/vlib/v3/transform/if.v
@@ -49,7 +49,16 @@ fn (mut t Transformer) try_expand_if_guard(_id flat.NodeId, node flat.Node) ?[]f
 	rhs_type = t.qualify_optional_type(rhs_type)
 	value_type := t.optional_base_type(rhs_type)
 	tmp_name := t.new_temp('if_guard')
-	rhs_expr := t.transform_expr(rhs_id)
+	mut rhs_expr := flat.empty_node
+	mut source_clear := flat.empty_node
+	if !isnil(t.tc) && t.tc.ownership_guard_read_moves_value(rhs_id)
+		&& t.expr_can_take_address(rhs_id) {
+		source := t.stabilize_transformed_lvalue_for_reuse(t.transform_lvalue(rhs_id))
+		rhs_expr = source
+		source_clear = t.make_assign_without_ownership_drop(source, t.make_optional_none(rhs_type))
+	} else {
+		rhs_expr = t.transform_expr(rhs_id)
+	}
 	if !t.is_optional_type_name(t.node_type(rhs_expr)) {
 		t.set_node_typ(int(rhs_expr), rhs_type)
 	}
@@ -110,11 +119,14 @@ fn (mut t Transformer) try_expand_if_guard(_id flat.NodeId, node flat.Node) ?[]f
 		else_node := t.a.nodes[int(else_id)]
 		else_block = t.transform_if_guard_else_block(else_id, else_node, tmp_name)
 	}
-	mut expanded := []flat.NodeId{cap: prelude.len + 2}
+	mut expanded := []flat.NodeId{cap: prelude.len + 3}
 	for stmt in prelude {
 		expanded << stmt
 	}
 	expanded << tmp_decl
+	if source_clear != flat.empty_node {
+		expanded << source_clear
+	}
 	expanded << t.make_if(ok_cond, then_block, else_block)
 	return expanded
 }

--- a/vlib/v3/transform/interface.v
+++ b/vlib/v3/transform/interface.v
@@ -37,7 +37,7 @@ fn (mut t Transformer) heap_copy_interface_expr(expr flat.NodeId, iface_name str
 	t.pending_stmts << t.make_decl_assign_typed(tmp_name, expr, iface_name)
 	addr := t.make_prefix(.amp, t.make_ident(tmp_name))
 	size := t.make_sizeof_type(iface_name)
-	dup := t.make_call_typed('memdup', arr2(addr, size), 'voidptr')
+	dup := t.make_non_aliasing_allocation_call('memdup', arr2(addr, size), 'voidptr')
 	cast := t.make_cast(target_type, dup, target_type)
 	t.set_node_typ(int(cast), target_type)
 	return cast
@@ -759,7 +759,7 @@ fn (mut t Transformer) make_interface_literal_from_expr(id flat.NodeId, iface_na
 	} else {
 		addr := t.make_prefix(.amp, source)
 		size := t.make_sizeof_type(concrete_type)
-		dup := t.make_call_typed('memdup', arr2(addr, size), 'voidptr')
+		dup := t.make_non_aliasing_allocation_call('memdup', arr2(addr, size), 'voidptr')
 		if t.interface_box_object_cast_needs_raw_call(concrete_type) {
 			t.set_node_typ(int(dup), '&${concrete_type}')
 			dup

--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -165,6 +165,7 @@ fn (mut t Transformer) monomorphize_pass() []string {
 	mut changed := true
 	mut scan_start := 0
 	mut generic_fn_value_scan_start := 0
+	mut interface_box_scan_start := 0
 	mut used_fns_at_scan := t.used_fn_count()
 	mut generic_struct_specs := if t.generic_materialization_ready {
 		t.generic_struct_specs_cache.clone()
@@ -409,6 +410,17 @@ fn (mut t Transformer) monomorphize_pass() []string {
 		t.generic_sum_specs_cache = generic_sum_specs.clone()
 		t.generic_materialization_scan_from = node_count
 		t.generic_materialization_ready = true
+		// Generic specialization can turn an unresolved interface conversion such as
+		// `Sink[W] -> Interface` into a concrete boxed type. Include those newly
+		// materialized boxes before deciding which interface methods need bodies.
+		if interface_box_scan_start < node_count {
+			was_frozen := t.interface_boxed_types_frozen
+			t.interface_boxed_types_frozen = false
+			t.collect_interface_boxed_types_range(interface_box_scan_start, node_count)
+			t.interface_boxed_types_frozen = was_frozen
+			t.refresh_interface_impl_indexes_for_boxed_types()
+			interface_box_scan_start = node_count
+		}
 		// Specialize methods of instantiated generic structs that are never reached
 		// through an explicit call node — notably operator overloads (`a + b`), which
 		// are infix expressions lowered to method calls only later in the pipeline.
@@ -3428,6 +3440,25 @@ fn (mut t Transformer) emit_generic_fn_specialization(decl GenericFnDecl, args [
 	clone_id := t.clone_generic_fn_node(decl.node, concrete_args)
 	t.cur_fn_ret_type = old_clone_ret_type
 	t.cloning_generic_fn_depth--
+	// Declaration attributes are indexed by the parsed declaration node. A
+	// specialization is appended later and therefore has no entry in that map.
+	// Preserve the transform-relevant `manualfree` bit on the cloned function so
+	// ownership lowering does not inject frees into an explicitly manual body.
+	if !isnil(t.tc) && t.tc.declaration_has_attribute(decl.id, 'manualfree') {
+		cloned_fn := t.a.nodes[int(clone_id)]
+		t.set_node(int(clone_id), flat.Node{
+			kind:                 cloned_fn.kind
+			op:                   cloned_fn.op
+			pos:                  cloned_fn.pos
+			value:                cloned_fn.value
+			typ:                  cloned_fn.typ
+			payload:              cloned_fn.payload
+			children_start:       cloned_fn.children_start
+			children_count:       cloned_fn.children_count
+			is_mut:               cloned_fn.is_mut
+			skip_ownership_drops: true
+		})
+	}
 	t.a.specialized_fn_nodes[int(clone_id)] = true
 	t.a.specialized_fn_modules[int(clone_id)] = decl.module
 	t.a.specialized_fn_files[int(clone_id)] = decl.file
@@ -5504,6 +5535,22 @@ fn (mut t Transformer) cached_generic_call_specialization(id flat.NodeId, node f
 		if callee.kind == .ident && t.generic_callee_is_specialization(callee.value) {
 			decl_key := t.generic_call_decl_key(id, node, module_name, decls) or { return none }
 			decl := decls[decl_key] or { return none }
+			// The checker and the earlier transform register a concrete signature
+			// before the monomorphization Transformer exists. A specialized callee
+			// therefore does not prove that its body was emitted. Recover its exact
+			// arguments (including return-type-only generics with no value argument)
+			// and queue the missing body before applying the usual stale-callee checks.
+			exact_args := t.exact_generic_specialization_args_from_callee(callee.value) or {
+				t.specialized_plain_generic_call_args(node, decl, module_name) or { []string{} }
+			}
+			if exact_args.len > 0 && !t.generic_args_have_placeholders(exact_args)
+				&& !t.generic_specialization_registered(decl, exact_args) {
+				t.generic_call_spec_cache[idx] = GenericCallSpec{
+					decl_key: decl_key
+					args:     exact_args
+				}
+				return decl_key, exact_args
+			}
 			if raw := t.infer_generic_call_args_from_raw_node_types(decl, node) {
 				resolved_raw := t.resolved_live_generic_call_args(raw, module_name, decl.module)
 				if exact := t.exact_generic_specialization_args_from_callee(callee.value) {
@@ -10106,6 +10153,11 @@ fn (mut t Transformer) generic_decl_has_method_level_params(decl GenericFnDecl) 
 		}
 	}
 	for param in all_params {
+		// Lifetimes do not change the emitted runtime signature. A method-level
+		// lifetime can therefore share the receiver's concrete type specialization.
+		if param.starts_with('^') {
+			continue
+		}
 		if param !in receiver_params {
 			return true
 		}

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -10067,7 +10067,14 @@ fn (mut t Transformer) transform_assign_stmt(id flat.NodeId, node flat.Node) []f
 		&& node.children_count == 2 && !isnil(t.tc) {
 		lhs_id := t.a.child(&node, 0)
 		rhs_id := t.a.child(&node, 1)
-		mut lhs_type_name := t.lvalue_type(t.a.child(&node, 0))
+		lhs_node := t.a.nodes[int(lhs_id)]
+		// Whole-variable assignment overwrites the variable's storage type, even
+		// when an active optional smartcast makes the expression read as its payload.
+		mut lhs_type_name := if lhs_node.kind == .ident {
+			t.var_type(lhs_node.value)
+		} else {
+			t.lvalue_type(t.a.child(&node, 0))
+		}
 		if lhs_type_name.len == 0 {
 			lhs_type_name = t.lvalue_type(new_children[0])
 		}
@@ -10087,7 +10094,33 @@ fn (mut t Transformer) transform_assign_stmt(id flat.NodeId, node flat.Node) []f
 			t.drain_pending(mut result)
 			tmp_name := t.new_temp('drop_assign')
 			tmp_type := lhs_type.name()
-			result << t.make_decl_assign_typed(tmp_name, new_children[1], tmp_type)
+			mut tmp_value := new_children[1]
+			// A clone call can retain the assignment's optional expected type on its
+			// transformed call node even though the lowered call still returns the
+			// payload. The overwrite temporary must therefore wrap a non-optional
+			// source explicitly before it is declared as the optional LHS type.
+			if t.is_optional_type_name(tmp_type) {
+				source_type := t.original_expr_type(rhs_id)
+				payload_type := t.optional_base_type(t.qualify_optional_type(tmp_type))
+				value_node := t.a.nodes[int(tmp_value)]
+				value_is_wrapper := value_node.kind == .struct_init && t.is_optional_type_name(if value_node.value.len > 0 {
+					value_node.value
+				} else {
+					value_node.typ
+				})
+				transformed_type := if value_node.kind == .ident {
+					t.var_type(value_node.value)
+				} else {
+					''
+				}
+				value_is_optional := t.is_optional_type_name(transformed_type)
+				if !value_is_wrapper && !value_is_optional && !t.is_optional_type_name(source_type)
+					&& t.normalize_type_alias(source_type) == t.normalize_type_alias(payload_type) {
+					t.set_node_typ(int(tmp_value), payload_type)
+					tmp_value = t.make_optional_some(tmp_value, tmp_type)
+				}
+			}
+			result << t.make_decl_assign_typed(tmp_name, tmp_value, tmp_type)
 			lvalue := t.stabilize_transformed_lvalue_for_reuse(new_children[0])
 			t.drain_pending(mut result)
 			drop_call := t.make_call_typed('drop_owned', arr1(lvalue), 'void')
@@ -11194,6 +11227,15 @@ fn (t &Transformer) pointer_value_assign_rhs_matches(lhs_value_type_raw string, 
 
 // transform_expr_for_type transforms transform expr for type data for transform.
 fn (t &Transformer) optional_conversion_source_type(id flat.NodeId) string {
+	if int(id) >= 0 && int(id) < t.a.nodes.len {
+		node := t.a.nodes[int(id)]
+		if node.kind == .ident {
+			local_type := t.var_type(node.value)
+			if local_type.len > 0 && local_type != 'unknown' {
+				return local_type
+			}
+		}
+	}
 	mut source_type := t.node_type(id)
 	original_source_type := t.original_expr_type(id)
 	if t.is_optional_type_name(source_type) && !t.is_optional_type_name(original_source_type)

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -10599,7 +10599,14 @@ fn (mut t Transformer) transform_assign_stmt(id flat.NodeId, node flat.Node) []f
 		&& node.children_count == 2 && !isnil(t.tc) {
 		lhs_id := t.a.child(&node, 0)
 		rhs_id := t.a.child(&node, 1)
-		mut lhs_type_name := t.lvalue_type(t.a.child(&node, 0))
+		lhs_node := t.a.nodes[int(lhs_id)]
+		// Whole-variable assignment overwrites the variable's storage type, even
+		// when an active optional smartcast makes the expression read as its payload.
+		mut lhs_type_name := if lhs_node.kind == .ident {
+			t.var_type(lhs_node.value)
+		} else {
+			t.lvalue_type(t.a.child(&node, 0))
+		}
 		if lhs_type_name.len == 0 {
 			lhs_type_name = t.lvalue_type(new_children[0])
 		}
@@ -10619,7 +10626,33 @@ fn (mut t Transformer) transform_assign_stmt(id flat.NodeId, node flat.Node) []f
 			t.drain_pending(mut result)
 			tmp_name := t.new_temp('drop_assign')
 			tmp_type := lhs_type.name()
-			result << t.make_decl_assign_typed(tmp_name, new_children[1], tmp_type)
+			mut tmp_value := new_children[1]
+			// A clone call can retain the assignment's optional expected type on its
+			// transformed call node even though the lowered call still returns the
+			// payload. The overwrite temporary must therefore wrap a non-optional
+			// source explicitly before it is declared as the optional LHS type.
+			if t.is_optional_type_name(tmp_type) {
+				source_type := t.original_expr_type(rhs_id)
+				payload_type := t.optional_base_type(t.qualify_optional_type(tmp_type))
+				value_node := t.a.nodes[int(tmp_value)]
+				value_is_wrapper := value_node.kind == .struct_init && t.is_optional_type_name(if value_node.value.len > 0 {
+					value_node.value
+				} else {
+					value_node.typ
+				})
+				transformed_type := if value_node.kind == .ident {
+					t.var_type(value_node.value)
+				} else {
+					''
+				}
+				value_is_optional := t.is_optional_type_name(transformed_type)
+				if !value_is_wrapper && !value_is_optional && !t.is_optional_type_name(source_type)
+					&& t.normalize_type_alias(source_type) == t.normalize_type_alias(payload_type) {
+					t.set_node_typ(int(tmp_value), payload_type)
+					tmp_value = t.make_optional_some(tmp_value, tmp_type)
+				}
+			}
+			result << t.make_decl_assign_typed(tmp_name, tmp_value, tmp_type)
 			lvalue := t.stabilize_transformed_lvalue_for_reuse(new_children[0])
 			t.drain_pending(mut result)
 			drop_call := t.make_call_typed('drop_owned', arr1(lvalue), 'void')
@@ -11755,6 +11788,15 @@ fn (t &Transformer) pointer_value_assign_rhs_matches(lhs_value_type_raw string, 
 
 // transform_expr_for_type transforms transform expr for type data for transform.
 fn (t &Transformer) optional_conversion_source_type(id flat.NodeId) string {
+	if int(id) >= 0 && int(id) < t.a.nodes.len {
+		node := t.a.nodes[int(id)]
+		if node.kind == .ident {
+			local_type := t.var_type(node.value)
+			if local_type.len > 0 && local_type != 'unknown' {
+				return local_type
+			}
+		}
+	}
 	mut source_type := t.node_type(id)
 	original_source_type := t.original_expr_type(id)
 	if t.is_optional_type_name(source_type) && !t.is_optional_type_name(original_source_type)

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -75,6 +75,9 @@ const prefix_scope_drops_block_value = '__v3_prefix_scope_drops'
 
 const generated_variant_access_marker = '__v3_generated_variant_access'
 const optional_wrapper_access_marker = '__v3_optional_wrapper_access'
+const non_aliasing_allocation_call_marker = '__v3_non_aliasing_allocation_call'
+const source_deref_marker = '__v3_source_deref'
+const source_mut_pointer_deref_marker = '__v3_source_mut_pointer_deref'
 
 // SumEqRequest records where a sum type's equality helper was first requested,
 // so the helper body is built under that module/file resolution context. The
@@ -93,6 +96,15 @@ struct AutoStrRequest {
 	module        string
 	file          string
 	helper_module string
+}
+
+// DefaultCloneRequest records the source resolution context for a recursive
+// compiler-provided IClone helper. The helper is emitted after parallel body
+// transformation so mutually recursive aggregate layouts do not recurse in the
+// transformer itself.
+struct DefaultCloneRequest {
+	module string
+	file   string
 }
 
 // MonomorphCacheSpec identifies one concrete generic function body. Dependency
@@ -254,20 +266,23 @@ mut:
 	// module/file context of the requesting call site (type resolution inside
 	// the helper body needs that context). The helpers are synthesized
 	// serially after the (possibly parallel) transform completes.
-	sum_eq_types                 map[string]SumEqRequest
-	sum_eq_synthesized           map[string]bool
-	sum_eq_helper_module         string
-	auto_str_types               map[string]AutoStrRequest
-	auto_str_synthesized         map[string]bool
-	auto_str_helper_module       string
-	auto_str_synthesis_type      string
-	interface_boxed_types        map[string]bool
-	interface_boxed_types_done   bool
-	interface_boxed_types_frozen bool
-	interface_impl_indexes       map[string]&types.InterfaceImplIndex
-	interface_impl_spec_count    int
-	ierror_none_type_id          int
-	interface_var_concrete_types map[string]string
+	sum_eq_types                  map[string]SumEqRequest
+	sum_eq_synthesized            map[string]bool
+	sum_eq_helper_module          string
+	auto_str_types                map[string]AutoStrRequest
+	auto_str_synthesized          map[string]bool
+	auto_str_helper_module        string
+	auto_str_synthesis_type       string
+	default_clone_types           map[string]DefaultCloneRequest
+	default_clone_synthesized     map[string]bool
+	default_clone_expansion_stack []string
+	interface_boxed_types         map[string]bool
+	interface_boxed_types_done    bool
+	interface_boxed_types_frozen  bool
+	interface_impl_indexes        map[string]&types.InterfaceImplIndex
+	interface_impl_spec_count     int
+	ierror_none_type_id           int
+	interface_var_concrete_types  map[string]string
 	// used_struct_operator_fns holds the callee names of direct calls seen during
 	// monomorphize. Infix operators on generic instances are lowered to direct calls
 	// (`Vec_int__plus(a, b)`) before this pass, so an operator overload is specialized for
@@ -889,12 +904,14 @@ pub fn transform_selected_functions(mut a flat.FlatAst, tc &types.TypeChecker, s
 		t.transform_fn_body(i)
 	}
 	t.apply_ignored_comptime_for_nodes()
+	t.run_default_clone_synthesis_rounds(base_node_count)
 	t.run_sum_eq_synthesis_rounds(base_node_count)
 	t.apply_ignored_comptime_for_nodes()
 	mut synthesized_helpers := []string{}
 	for idx in base_node_count .. t.a.nodes.len {
 		node := t.a.nodes[idx]
-		if node.kind == .fn_decl && node.value.starts_with('__v3_sum_eq_') {
+		if node.kind == .fn_decl && (node.value.starts_with('__v3_sum_eq_')
+			|| node.value.starts_with('__v3_default_clone_')) {
 			synthesized_helpers << node.value
 		}
 	}
@@ -973,6 +990,7 @@ fn transform_with_used_opt_config_scoped_workers_checked_impl(mut a flat.FlatAst
 	t.timing_profile('  [ttime] late bodies        ${f64(impl_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 	impl_sw.restart()
 	t.run_auto_str_synthesis_rounds(base_node_count)
+	t.run_default_clone_synthesis_rounds(base_node_count)
 	t.run_sum_eq_synthesis_rounds(base_node_count)
 	t.apply_ignored_comptime_for_nodes()
 	t.retain_current_worker_scope_all()
@@ -1161,6 +1179,16 @@ fn transform_stage_scope_resume(scope voidptr, state voidptr) {
 fn (mut t Transformer) run_sum_eq_synthesis_rounds(node_limit int) {
 	for _ in 0 .. 16 {
 		new_names := t.synthesize_sum_eq_helpers()
+		if new_names.len == 0 {
+			return
+		}
+		t.transform_late_used_fn_bodies(new_names, node_limit)
+	}
+}
+
+fn (mut t Transformer) run_default_clone_synthesis_rounds(node_limit int) {
+	for _ in 0 .. 16 {
+		new_names := t.synthesize_default_clone_helpers()
 		if new_names.len == 0 {
 			return
 		}
@@ -1359,6 +1387,7 @@ pub fn monomorphize_with_used_checked_config_scoped_cached(mut a flat.FlatAst, t
 	t.monomorph_profile('mono wrapper late matches: ${time.ticks() - debug_started} ms')
 	t.materialize_generic_structs(true)
 	t.monomorph_profile('mono wrapper structs: ${time.ticks() - debug_started} ms')
+	t.run_default_clone_synthesis_rounds(base_node_count)
 	t.run_sum_eq_synthesis_rounds(base_node_count)
 	t.monomorph_profile('mono wrapper sums: ${time.ticks() - debug_started} ms')
 	t.apply_ignored_comptime_for_nodes()
@@ -3499,6 +3528,7 @@ fn (t &Transformer) fork_worker_config(ast &flat.FlatAst, wtc &types.TypeChecker
 	w.interface_boxed_types_done = true
 	w.interface_boxed_types_frozen = t.interface_boxed_types_frozen
 	w.sum_eq_helper_module = ''
+	w.default_clone_expansion_stack = []string{}
 	w.generic_receiver_methods_by_name = map[string][]string{}
 	w.used_fns_log = []string{}
 	w.used_fns_log_active = false
@@ -3704,6 +3734,8 @@ fn (t &Transformer) fork_program_view(ast &flat.FlatAst, wtc &types.TypeChecker,
 		auto_str_synthesized:               t.auto_str_synthesized.clone()
 		auto_str_helper_module:             t.auto_str_helper_module
 		auto_str_synthesis_type:            t.auto_str_synthesis_type
+		default_clone_types:                t.default_clone_types.clone()
+		default_clone_synthesized:          t.default_clone_synthesized.clone()
 		used_fns:                           used_fns.clone()
 		mut_param_values:                   map[string]bool{}
 		pointer_value_lvalues:              map[string]bool{}
@@ -3802,6 +3834,18 @@ fn (mut t Transformer) merge_worker_used_fns(w &Transformer) {
 			}
 		}
 	}
+	for name, req in w.default_clone_types {
+		if name !in t.default_clone_types {
+			if scoped {
+				t.default_clone_types[name.clone()] = DefaultCloneRequest{
+					module: req.module.clone()
+					file:   req.file.clone()
+				}
+			} else {
+				t.default_clone_types[name] = req
+			}
+		}
+	}
 }
 
 fn (mut t Transformer) clone_sum_eq_types_owned() {
@@ -3826,6 +3870,17 @@ fn (mut t Transformer) clone_auto_str_types_owned() {
 		}
 	}
 	t.auto_str_types = cloned.move()
+}
+
+fn (mut t Transformer) clone_default_clone_types_owned() {
+	mut cloned := map[string]DefaultCloneRequest{}
+	for name, req in t.default_clone_types {
+		cloned[name.clone()] = DefaultCloneRequest{
+			module: req.module.clone()
+			file:   req.file.clone()
+		}
+	}
+	t.default_clone_types = cloned.move()
 }
 
 @[inline]
@@ -5401,9 +5456,25 @@ fn (mut t Transformer) make_memdup_call_for_type(addr flat.NodeId, type_name str
 		} else {
 			t.make_call_typed('__alignof__', arr1(t.make_ident(type_name)), 'usize')
 		}
-		return t.make_call_typed('v3_aligned_memdup', arr3(addr, size, align_arg), 'voidptr')
+		return t.make_non_aliasing_allocation_call('v3_aligned_memdup',
+			arr3(addr, size, align_arg), 'voidptr')
 	}
-	return t.make_call_typed('memdup', arr2(addr, size), 'voidptr')
+	return t.make_non_aliasing_allocation_call('memdup', arr2(addr, size), 'voidptr')
+}
+
+fn (mut t Transformer) make_non_aliasing_allocation_call(name string, args []flat.NodeId, typ string) flat.NodeId {
+	start := t.a.children.len
+	t.a.children << t.make_ident(name)
+	for arg in args {
+		t.a.children << arg
+	}
+	return t.a.add_node(flat.Node{
+		kind:           .call
+		children_start: start
+		children_count: flat.child_count(1 + args.len)
+		value:          non_aliasing_allocation_call_marker
+		typ:            typ
+	})
 }
 
 // heapable_value_type reports whether a local of this declared type can be moved to the heap
@@ -7607,6 +7678,11 @@ fn (t &Transformer) escape_aggregate_address_sources(id flat.NodeId, amp_sources
 			return [receiver]
 		}
 		.call {
+			if t.escape_call_is_allocation_helper(id, node) {
+				// These allocation helpers copy from the address argument; the returned
+				// pointer cannot alias the source stack local.
+				return []string{}
+			}
 			mut sources := []string{}
 			// The callee selector is consumed by the call; only argument addresses
 			// can flow through a returned pointer value.
@@ -7637,6 +7713,25 @@ fn (t &Transformer) escape_aggregate_address_sources(id flat.NodeId, amp_sources
 	}
 
 	return []string{}
+}
+
+fn (t &Transformer) escape_call_is_allocation_helper(id flat.NodeId, node flat.Node) bool {
+	if node.children_count == 0 || isnil(t.tc) {
+		return false
+	}
+	callee_id := t.a.child(&node, 0)
+	callee := t.a.nodes[int(callee_id)]
+	if callee.kind != .ident {
+		return false
+	}
+	if node.value == non_aliasing_allocation_call_marker
+		&& callee.value in ['memdup', 'memdup_noscan', 'v3_aligned_memdup'] {
+		return true
+	}
+	if callee.value in ['memdup', 'memdup_noscan'] {
+		return t.tc.resolved_call_is_builtin(id, callee.value)
+	}
+	return false
 }
 
 fn (mut t Transformer) scan_for_in_escape_pass(node flat.Node, mut amp_ptrs map[string]bool, mut amp_sources map[string][]string, mut ptr_aliases map[string]string, mut method_value_receivers map[string]string, mut closure_capture_aliases map[string][]string, mut interface_boxes map[string]bool, mut returned map[string]bool, mut local_stack_names map[string]bool, mut local_stack_added []string, can_clear_interface_boxes bool) {
@@ -7980,7 +8075,11 @@ fn (mut t Transformer) transform_fn_body(fn_idx int) {
 	} else {
 		t.fn_decl_has_unresolved_generics(fn_node, t.cur_module)
 	}
-	t.cur_fn_manualfree = t.tc.declaration_has_attribute(flat.NodeId(fn_idx), 'manualfree')
+	// Generic specializations carry a template's `manualfree` attribute in the
+	// function node because the checker's declaration-attribute index only
+	// contains parsed declarations.
+	t.cur_fn_manualfree = fn_node.skip_ownership_drops
+		|| t.tc.declaration_has_attribute(flat.NodeId(fn_idx), 'manualfree')
 	param_count := t.fn_body_param_count(fn_node)
 	param_types := t.fn_body_param_types(fn_node, param_count)
 	t.cur_fn_ret_type = t.fn_body_return_type(fn_node)
@@ -8122,14 +8221,15 @@ fn (mut t Transformer) transform_fn_body(fn_idx int) {
 		start := t.a.children.len
 		t.a.children << new_children
 		t.set_node(fn_idx, flat.Node{
-			kind:           .fn_decl
-			op:             fn_node.op
-			children_start: start
-			children_count: flat.child_count(new_children.len)
-			pos:            fn_node.pos
-			value:          fn_node.value
-			typ:            fn_node.typ
-			payload:        fn_node.payload
+			kind:                 .fn_decl
+			op:                   fn_node.op
+			children_start:       start
+			children_count:       flat.child_count(new_children.len)
+			pos:                  fn_node.pos
+			value:                fn_node.value
+			typ:                  fn_node.typ
+			payload:              fn_node.payload
+			skip_ownership_drops: fn_node.skip_ownership_drops
 		})
 	}
 	t.smartcast_stack.clear()
@@ -9667,6 +9767,35 @@ pub fn (mut t Transformer) transform_lvalue(id flat.NodeId) flat.NodeId {
 				typ:            node.typ
 			})
 		}
+		.call {
+			if node.children_count > 0 {
+				callee := t.a.child_node(&node, 0)
+				if callee.kind == .selector && callee.value in ['first', 'last']
+					&& callee.children_count > 0 {
+					base_id := t.a.child(callee, 0)
+					base_type := t.normalize_type_alias(t.lvalue_type(base_id))
+					clean_base_type := base_type.trim_left('&')
+					if clean_base_type.starts_with('[]') {
+						mut base := t.transform_lvalue(base_id)
+						if base_type.starts_with('&') {
+							base = t.make_prefix(.mul, base)
+							t.set_node_typ(int(base), clean_base_type)
+						}
+						if callee.value == 'last' {
+							base = t.stabilize_transformed_lvalue_for_reuse(base)
+						}
+						index := if callee.value == 'first' {
+							t.make_int_literal(0)
+						} else {
+							t.make_infix(.minus, t.make_selector(base, 'len', 'int'),
+								t.make_int_literal(1))
+						}
+						return t.make_index(base, index, clean_base_type[2..])
+					}
+				}
+			}
+			return t.transform_expr(id)
+		}
 		else {
 			return t.transform_expr(id)
 		}
@@ -10596,7 +10725,7 @@ fn (mut t Transformer) transform_assign_stmt(id flat.NodeId, node flat.Node) []f
 		t.update_option_assignment_smartcast(t.a.child(&node, 0), t.a.child(&node, 1))
 	}
 	if node.kind in [.assign, .selector_assign, .index_assign] && node.op == .assign
-		&& node.children_count == 2 && !isnil(t.tc) {
+		&& !node.skip_ownership_drops && node.children_count == 2 && !isnil(t.tc) {
 		lhs_id := t.a.child(&node, 0)
 		rhs_id := t.a.child(&node, 1)
 		lhs_node := t.a.nodes[int(lhs_id)]
@@ -10709,13 +10838,14 @@ fn (mut t Transformer) transform_assign_stmt(id flat.NodeId, node flat.Node) []f
 			t.a.children << nc
 		}
 		new_id = t.a.add_node(flat.Node{
-			kind:           node.kind
-			op:             node.op
-			children_start: start
-			children_count: node.children_count
-			pos:            node.pos
-			value:          node.value
-			typ:            node.typ
+			kind:                 node.kind
+			op:                   node.op
+			children_start:       start
+			children_count:       node.children_count
+			pos:                  node.pos
+			value:                node.value
+			typ:                  node.typ
+			skip_ownership_drops: node.skip_ownership_drops
 		})
 	}
 	if node.kind == .assign && node.op == .left_shift_assign {
@@ -12553,7 +12683,7 @@ fn (mut t Transformer) make_ierror_none() flat.NodeId {
 	none_value := t.make_struct_init('None__')
 	addr := t.make_prefix(.amp, none_value)
 	size := t.make_sizeof_type('None__')
-	dup := t.make_call_typed('memdup', arr2(addr, size), 'voidptr')
+	dup := t.make_non_aliasing_allocation_call('memdup', arr2(addr, size), 'voidptr')
 	object := t.make_cast('&None__', dup, '&None__')
 	type_id := t.ierror_none_type_id
 	fields := [
@@ -12667,7 +12797,7 @@ fn (t &Transformer) array_accessor_call_can_take_address(node flat.Node) bool {
 		base_type = t.original_expr_type(base_id)
 	}
 	clean := t.normalize_type_alias(base_type.trim_left('&'))
-	return clean.starts_with('[]')
+	return clean.starts_with('[]') && t.expr_can_take_address(base_id)
 }
 
 fn (t &Transformer) selector_is_enum_value(id flat.NodeId) bool {
@@ -17870,6 +18000,11 @@ fn (mut t Transformer) transform_prefix_expr(id flat.NodeId, node flat.Node) fla
 		if child.kind == .ident && t.pointer_value_rvalues[child.value] {
 			value := t.transform_expr_preserving_pointer_value(child_id)
 			result := t.make_prefix(.mul, value)
+			if node.pos.end > node.pos.offset {
+				// Cgen must distinguish this source dereference from the synthetic
+				// dereference that reads a mutable parameter's pointer slot.
+				t.a.nodes[int(result)].value = source_mut_pointer_deref_marker
+			}
 			value_type := t.node_type(value)
 			if value_type.starts_with('&') {
 				t.set_node_typ(int(result), value_type[1..])
@@ -18164,7 +18299,11 @@ fn (mut t Transformer) transform_prefix_expr(id flat.NodeId, node flat.Node) fla
 		children_start: start
 		children_count: node.children_count
 		pos:            node.pos
-		value:          node.value
+		value:          if node.op == .mul && node.pos.end > node.pos.offset {
+			source_deref_marker
+		} else {
+			node.value
+		}
 		typ:            node.typ
 	})
 	if node.children_count == 1 {
@@ -20089,6 +20228,29 @@ pub fn (mut t Transformer) make_expr_stmt(expr flat.NodeId) flat.NodeId {
 // make_assign builds make assign data for transform.
 pub fn (mut t Transformer) make_assign(lhs flat.NodeId, rhs flat.NodeId) flat.NodeId {
 	return t.make_assign_op(lhs, rhs, .assign)
+}
+
+// make_assign_without_ownership_drop overwrites storage whose previous value has already
+// transferred ownership, or a non-owning shallow template used to build an independent clone.
+fn (mut t Transformer) make_assign_without_ownership_drop(lhs flat.NodeId, rhs flat.NodeId) flat.NodeId {
+	start := t.a.children.len
+	t.a.children << lhs
+	t.a.children << rhs
+	lhs_kind := t.a.nodes[int(lhs)].kind
+	kind := if lhs_kind == .index {
+		flat.NodeKind.index_assign
+	} else if lhs_kind == .selector {
+		flat.NodeKind.selector_assign
+	} else {
+		flat.NodeKind.assign
+	}
+	return t.a.add_node(flat.Node{
+		kind:                 kind
+		op:                   .assign
+		children_start:       start
+		children_count:       2
+		skip_ownership_drops: true
+	})
 }
 
 // make_assign_op builds make assign op data for transform.

--- a/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
@@ -1597,6 +1597,14 @@ fn (mut t Transformer) absorb_scoped_batch(batch &Transformer, scope voidptr, ne
 			}
 		}
 	}
+	for name, req in batch.default_clone_types {
+		if name !in t.default_clone_types {
+			t.default_clone_types[t.promote_scoped_result_text(name)] = DefaultCloneRequest{
+				module: t.promote_scoped_result_text(req.module)
+				file:   t.promote_scoped_result_text(req.file)
+			}
+		}
+	}
 	for message in batch.monomorph_errors {
 		t.monomorph_errors << t.promote_scoped_result_text(message)
 	}
@@ -2206,6 +2214,7 @@ fn (mut t Transformer) run_parallel_transform_shared(items []FnWorkItem, base_no
 		if t.retain_worker_results {
 			t.clone_sum_eq_types_owned()
 			t.clone_auto_str_types_owned()
+			t.clone_default_clone_types_owned()
 		}
 		t.base_write_intercept = false
 		t.defer_oor_writes = false

--- a/vlib/v3/types/annotation_stack_test.v
+++ b/vlib/v3/types/annotation_stack_test.v
@@ -1,0 +1,63 @@
+module types
+
+import v3.flat
+
+fn test_annotation_walk_handles_deep_single_child_ast_iteratively() {
+	mut a := flat.FlatAst.new()
+	mut current := a.add_node(flat.Node{
+		kind:  .int_literal
+		value: '1'
+	})
+	for _ in 0 .. 20_000 {
+		children_start := a.begin_children()
+		a.add_child(current)
+		current = a.add_node(flat.Node{
+			kind:           .paren
+			children_start: children_start
+			children_count: 1
+		})
+	}
+
+	mut tc := TypeChecker.new(&a)
+	tc.extend_node_caches(a.nodes.len)
+	mut memo := &BodyResolveMemo{}
+	memo.begin(0, a.nodes.len - 1)
+	for i in 0 .. a.nodes.len {
+		memo.types[i] = Type(int_)
+		memo.filled[i] = 1
+	}
+	tc.body_resolve_memo = memo
+	tc.annotate_node(current)
+	assert true
+}
+
+fn test_annotation_walk_preserves_pending_siblings_after_call() {
+	mut a := flat.FlatAst.new()
+	first := a.add_node(flat.Node{
+		kind: .call
+	})
+	sibling := a.add_node(flat.Node{
+		kind: .paren
+	})
+	children_start := a.begin_children()
+	a.add_child(first)
+	a.add_child(sibling)
+	root := a.add_node(flat.Node{
+		kind:           .infix
+		op:             .plus
+		children_start: children_start
+		children_count: 2
+	})
+
+	mut tc := TypeChecker.new(&a)
+	tc.extend_node_caches(a.nodes.len)
+	mut memo := &BodyResolveMemo{}
+	memo.begin(0, a.nodes.len - 1)
+	for i in 0 .. a.nodes.len {
+		memo.types[i] = Type(int_)
+		memo.filled[i] = 1
+	}
+	tc.body_resolve_memo = memo
+	tc.annotate_node(root)
+	assert tc.expr_type_set[int(sibling)]
+}

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -4123,6 +4123,18 @@ fn (mut tc TypeChecker) invalidate_const_initializer_type(expr_id flat.NodeId) {
 }
 
 fn (mut tc TypeChecker) refine_const_initializer_type(expr_id flat.NodeId, typ Type) Type {
+	if int(expr_id) >= 0 && int(expr_id) < tc.a.nodes.len {
+		expr := tc.a.nodes[int(expr_id)]
+		if expr.kind == .call {
+			if info0 := tc.resolve_call_info(expr_id, expr) {
+				info := tc.specialized_plain_generic_call_info(expr, info0)
+				if info.return_type !is Unknown && info.return_type !is Void
+					&& !generic_semantic_type_has_placeholder(info.return_type) {
+					return info.return_type
+				}
+			}
+		}
+	}
 	if typ is Array && typ.elem_type is Unknown && int(expr_id) >= 0
 		&& int(expr_id) < tc.a.nodes.len {
 		expr := tc.a.nodes[int(expr_id)]
@@ -6405,7 +6417,7 @@ pub fn (mut tc TypeChecker) check_main_module_requirement(is_shared bool) {
 	if tc.valid_diagnostic_fast {
 		return
 	}
-	if is_shared || (tc.checker_fixture_mode && tc.errors.len > 0) {
+	if is_shared || tc.has_c_test_harness_main() || (tc.checker_fixture_mode && tc.errors.len > 0) {
 		return
 	}
 	for file, _ in tc.diagnostic_files {
@@ -6492,127 +6504,132 @@ fn checker_qualified_fn_name(mod string, name string) string {
 
 // annotate_node supports annotate node handling for TypeChecker.
 fn (mut tc TypeChecker) annotate_node(id flat.NodeId) {
-	if int(id) < 0 {
-		return
-	}
-	node := tc.a.nodes[int(id)]
-	match node.kind {
-		.decl_assign {
-			lhs_count := tc.multi_assign_lhs_count(node)
-			rhs_count := tc.multi_assign_rhs_count(node)
-			if rhs_count == 1 && lhs_count > 1 {
-				tc.annotate_multi_return_decl_assign(node)
+	mut pending := [id]
+	for pending.len > 0 {
+		current_id := pending.pop()
+		if int(current_id) < 0 {
+			return
+		}
+		node := tc.a.nodes[int(current_id)]
+		match node.kind {
+			.decl_assign {
+				lhs_count := tc.multi_assign_lhs_count(node)
+				rhs_count := tc.multi_assign_rhs_count(node)
+				if rhs_count == 1 && lhs_count > 1 {
+					tc.annotate_multi_return_decl_assign(node)
+					return
+				}
+				pair_count := if lhs_count < rhs_count { lhs_count } else { rhs_count }
+				for pair_idx in 0 .. pair_count {
+					lhs_id := tc.multi_assign_lhs_id(node, pair_idx)
+					rhs_id := tc.multi_assign_rhs_id(node, pair_idx)
+					tc.annotate_node(rhs_id)
+					lhs := tc.a.nodes[int(lhs_id)]
+					if lhs.kind == .ident && lhs.value.len > 0 {
+						mut typ := Type(void_)
+						if node.children_count == 2 && node.typ.len > 0 {
+							typ = tc.parse_type(node.typ)
+							tc.annotate_expected_expr(rhs_id, typ)
+						} else {
+							typ = tc.resolve_type(rhs_id)
+						}
+						if typ !is MultiReturn && typ !is Void {
+							owner := tc.cur_scope.insert_with_owner(lhs.value, typ)
+							if owner.storage_key().len > 0
+								&& decl_assign_is_shared_marker(node.value) {
+								tc.mark_shared_binding_owner(lhs.value, owner)
+							}
+							tc.remember_expr_type(lhs_id, typ)
+						}
+					}
+				}
 				return
 			}
-			pair_count := if lhs_count < rhs_count { lhs_count } else { rhs_count }
-			for pair_idx in 0 .. pair_count {
-				lhs_id := tc.multi_assign_lhs_id(node, pair_idx)
-				rhs_id := tc.multi_assign_rhs_id(node, pair_idx)
-				tc.annotate_node(rhs_id)
-				lhs := tc.a.nodes[int(lhs_id)]
-				if lhs.kind == .ident && lhs.value.len > 0 {
-					mut typ := Type(void_)
-					if node.children_count == 2 && node.typ.len > 0 {
-						typ = tc.parse_type(node.typ)
-						tc.annotate_expected_expr(rhs_id, typ)
-					} else {
-						typ = tc.resolve_type(rhs_id)
-					}
-					if typ !is MultiReturn && typ !is Void {
-						owner := tc.cur_scope.insert_with_owner(lhs.value, typ)
-						if owner.storage_key().len > 0 && decl_assign_is_shared_marker(node.value) {
-							tc.mark_shared_binding_owner(lhs.value, owner)
-						}
-						tc.remember_expr_type(lhs_id, typ)
+			.for_in_stmt {
+				tc.annotate_for_in(current_id, node)
+				return
+			}
+			.comptime_for {
+				return
+			}
+			.fn_literal {
+				tc.annotate_fn_literal(node)
+				return
+			}
+			.selector {
+				if node.children_count > 0 {
+					base_id := tc.a.child(&node, 0)
+					base_type := tc.resolve_type(base_id)
+					if type_contains_unknown(base_type)
+						|| ((base_type is OptionType || base_type is ResultType)
+						&& node.value !in ['ok', 'value', 'err'])
+						|| (tc.fn_context.generic_params.len > 0 && (base_type is OptionType
+						|| base_type is ResultType)) {
+						tc.annotate_node(base_id)
+						return
 					}
 				}
 			}
-			return
-		}
-		.for_in_stmt {
-			tc.annotate_for_in(id, node)
-			return
-		}
-		.comptime_for {
-			return
-		}
-		.fn_literal {
-			tc.annotate_fn_literal(node)
-			return
-		}
-		.selector {
-			if node.children_count > 0 {
-				base_id := tc.a.child(&node, 0)
-				base_type := tc.resolve_type(base_id)
-				if type_contains_unknown(base_type)
-					|| ((base_type is OptionType || base_type is ResultType)
-					&& node.value !in ['ok', 'value', 'err'])
-					|| (tc.fn_context.generic_params.len > 0 && (base_type is OptionType
-					|| base_type is ResultType)) {
-					tc.annotate_node(base_id)
+			.assign, .selector_assign, .index_assign {
+				if node.children_count > 0
+					&& tc.annotation_storage_path_has_unknown(tc.a.child(&node, 0)) {
+					for i in 0 .. node.children_count {
+						tc.annotate_node(tc.a.child(&node, i))
+					}
+					return
+				}
+				tc.annotate_assign_expected_exprs(node)
+			}
+			.struct_init {
+				tc.annotate_struct_init_expected_exprs(node)
+			}
+			.call {
+				if tc.fn_context.generic_params.len > 0 {
+					dsl_name := tc.unresolved_array_dsl_call_name(node)
+					if dsl_name.len > 0 {
+						tc.push_array_dsl_scope(node, dsl_name)
+					}
+					for i in 0 .. node.children_count {
+						tc.annotate_node(tc.a.child(&node, i))
+					}
+					tc.annotate_call_expected_exprs(current_id, node)
+					if info := tc.resolve_call_info(current_id, node) {
+						tc.remember_expr_type(current_id, info.return_type)
+					}
+					if dsl_name.len > 0 {
+						tc.pop_scope()
+					}
+					return
+				}
+				tc.annotate_call_expected_exprs(current_id, node)
+				// The call annotation above records a more precise return type for
+				// contextual builtins such as `map.move()`. Avoid replacing it with
+				// the parser's broad `map`/`array` placeholder below.
+				for i in 0 .. node.children_count {
+					tc.annotate_node(tc.a.child(&node, i))
+				}
+				return
+			}
+			.index {
+				if generic_fn_type := tc.explicit_generic_fn_value_type(node) {
+					tc.remember_expr_type(current_id, generic_fn_type)
+					return
+				}
+				if node.children_count > 0
+					&& type_contains_unknown(tc.resolve_type(tc.a.child(&node, 0))) {
+					for i in 0 .. node.children_count {
+						tc.annotate_node(tc.a.child(&node, i))
+					}
 					return
 				}
 			}
+			else {}
 		}
-		.assign, .selector_assign, .index_assign {
-			if node.children_count > 0
-				&& tc.annotation_storage_path_has_unknown(tc.a.child(&node, 0)) {
-				for i in 0 .. node.children_count {
-					tc.annotate_node(tc.a.child(&node, i))
-				}
-				return
-			}
-			tc.annotate_assign_expected_exprs(node)
-		}
-		.struct_init {
-			tc.annotate_struct_init_expected_exprs(node)
-		}
-		.call {
-			if tc.fn_context.generic_params.len > 0 {
-				dsl_name := tc.unresolved_array_dsl_call_name(node)
-				if dsl_name.len > 0 {
-					tc.push_array_dsl_scope(node, dsl_name)
-				}
-				for i in 0 .. node.children_count {
-					tc.annotate_node(tc.a.child(&node, i))
-				}
-				tc.annotate_call_expected_exprs(id, node)
-				if info := tc.resolve_call_info(id, node) {
-					tc.remember_expr_type(id, info.return_type)
-				}
-				if dsl_name.len > 0 {
-					tc.pop_scope()
-				}
-				return
-			}
-			tc.annotate_call_expected_exprs(id, node)
-			// The call annotation above records a more precise return type for
-			// contextual builtins such as `map.move()`. Avoid replacing it with
-			// the parser's broad `map`/`array` placeholder below.
-			for i in 0 .. node.children_count {
-				tc.annotate_node(tc.a.child(&node, i))
-			}
-			return
-		}
-		.index {
-			if generic_fn_type := tc.explicit_generic_fn_value_type(node) {
-				tc.remember_expr_type(id, generic_fn_type)
-				return
-			}
-			if node.children_count > 0
-				&& type_contains_unknown(tc.resolve_type(tc.a.child(&node, 0))) {
-				for i in 0 .. node.children_count {
-					tc.annotate_node(tc.a.child(&node, i))
-				}
-				return
-			}
-		}
-		else {}
-	}
 
-	tc.remember_expr_type(id, tc.resolve_type(id))
-	for i in 0 .. node.children_count {
-		tc.annotate_node(tc.a.child(&node, i))
+		tc.remember_expr_type(current_id, tc.resolve_type(current_id))
+		for i := node.children_count - 1; i >= 0; i-- {
+			pending << tc.a.child(&node, i)
+		}
 	}
 }
 
@@ -13610,7 +13627,7 @@ pub fn (tc &TypeChecker) struct_module_for_type(name string) string {
 
 fn (tc &TypeChecker) type_has_declaration_attribute(typ Type, name string) bool {
 	clean := unalias_type(unwrap_pointer(typ))
-	type_name := clean.name()
+	type_name := strip_generic_args_name(clean.name())
 	if type_name.len == 0 {
 		return false
 	}

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -3860,6 +3860,18 @@ fn (mut tc TypeChecker) invalidate_const_initializer_type(expr_id flat.NodeId) {
 }
 
 fn (mut tc TypeChecker) refine_const_initializer_type(expr_id flat.NodeId, typ Type) Type {
+	if int(expr_id) >= 0 && int(expr_id) < tc.a.nodes.len {
+		expr := tc.a.nodes[int(expr_id)]
+		if expr.kind == .call {
+			if info0 := tc.resolve_call_info(expr_id, expr) {
+				info := tc.specialized_plain_generic_call_info(expr, info0)
+				if info.return_type !is Unknown && info.return_type !is Void
+					&& !generic_semantic_type_has_placeholder(info.return_type) {
+					return info.return_type
+				}
+			}
+		}
+	}
 	if typ is Array && typ.elem_type is Unknown && int(expr_id) >= 0
 		&& int(expr_id) < tc.a.nodes.len {
 		expr := tc.a.nodes[int(expr_id)]
@@ -5962,7 +5974,7 @@ fn (tc &TypeChecker) declaration_contains_error(node flat.Node) bool {
 // check_main_module_requirement rejects ordinary programs that contain no
 // selected source file in the `main` module.
 pub fn (mut tc TypeChecker) check_main_module_requirement(is_shared bool) {
-	if is_shared || (tc.checker_fixture_mode && tc.errors.len > 0) {
+	if is_shared || tc.has_c_test_harness_main() || (tc.checker_fixture_mode && tc.errors.len > 0) {
 		return
 	}
 	for file, _ in tc.diagnostic_files {
@@ -6049,127 +6061,132 @@ fn checker_qualified_fn_name(mod string, name string) string {
 
 // annotate_node supports annotate node handling for TypeChecker.
 fn (mut tc TypeChecker) annotate_node(id flat.NodeId) {
-	if int(id) < 0 {
-		return
-	}
-	node := tc.a.nodes[int(id)]
-	match node.kind {
-		.decl_assign {
-			lhs_count := tc.multi_assign_lhs_count(node)
-			rhs_count := tc.multi_assign_rhs_count(node)
-			if rhs_count == 1 && lhs_count > 1 {
-				tc.annotate_multi_return_decl_assign(node)
+	mut pending := [id]
+	for pending.len > 0 {
+		current_id := pending.pop()
+		if int(current_id) < 0 {
+			return
+		}
+		node := tc.a.nodes[int(current_id)]
+		match node.kind {
+			.decl_assign {
+				lhs_count := tc.multi_assign_lhs_count(node)
+				rhs_count := tc.multi_assign_rhs_count(node)
+				if rhs_count == 1 && lhs_count > 1 {
+					tc.annotate_multi_return_decl_assign(node)
+					return
+				}
+				pair_count := if lhs_count < rhs_count { lhs_count } else { rhs_count }
+				for pair_idx in 0 .. pair_count {
+					lhs_id := tc.multi_assign_lhs_id(node, pair_idx)
+					rhs_id := tc.multi_assign_rhs_id(node, pair_idx)
+					tc.annotate_node(rhs_id)
+					lhs := tc.a.nodes[int(lhs_id)]
+					if lhs.kind == .ident && lhs.value.len > 0 {
+						mut typ := Type(void_)
+						if node.children_count == 2 && node.typ.len > 0 {
+							typ = tc.parse_type(node.typ)
+							tc.annotate_expected_expr(rhs_id, typ)
+						} else {
+							typ = tc.resolve_type(rhs_id)
+						}
+						if typ !is MultiReturn && typ !is Void {
+							owner := tc.cur_scope.insert_with_owner(lhs.value, typ)
+							if owner.storage_key().len > 0
+								&& decl_assign_is_shared_marker(node.value) {
+								tc.mark_shared_binding_owner(lhs.value, owner)
+							}
+							tc.remember_expr_type(lhs_id, typ)
+						}
+					}
+				}
 				return
 			}
-			pair_count := if lhs_count < rhs_count { lhs_count } else { rhs_count }
-			for pair_idx in 0 .. pair_count {
-				lhs_id := tc.multi_assign_lhs_id(node, pair_idx)
-				rhs_id := tc.multi_assign_rhs_id(node, pair_idx)
-				tc.annotate_node(rhs_id)
-				lhs := tc.a.nodes[int(lhs_id)]
-				if lhs.kind == .ident && lhs.value.len > 0 {
-					mut typ := Type(void_)
-					if node.children_count == 2 && node.typ.len > 0 {
-						typ = tc.parse_type(node.typ)
-						tc.annotate_expected_expr(rhs_id, typ)
-					} else {
-						typ = tc.resolve_type(rhs_id)
-					}
-					if typ !is MultiReturn && typ !is Void {
-						owner := tc.cur_scope.insert_with_owner(lhs.value, typ)
-						if owner.storage_key().len > 0 && decl_assign_is_shared_marker(node.value) {
-							tc.mark_shared_binding_owner(lhs.value, owner)
-						}
-						tc.remember_expr_type(lhs_id, typ)
+			.for_in_stmt {
+				tc.annotate_for_in(current_id, node)
+				return
+			}
+			.comptime_for {
+				return
+			}
+			.fn_literal {
+				tc.annotate_fn_literal(node)
+				return
+			}
+			.selector {
+				if node.children_count > 0 {
+					base_id := tc.a.child(&node, 0)
+					base_type := tc.resolve_type(base_id)
+					if type_contains_unknown(base_type)
+						|| ((base_type is OptionType || base_type is ResultType)
+						&& node.value !in ['ok', 'value', 'err'])
+						|| (tc.fn_context.generic_params.len > 0 && (base_type is OptionType
+						|| base_type is ResultType)) {
+						tc.annotate_node(base_id)
+						return
 					}
 				}
 			}
-			return
-		}
-		.for_in_stmt {
-			tc.annotate_for_in(id, node)
-			return
-		}
-		.comptime_for {
-			return
-		}
-		.fn_literal {
-			tc.annotate_fn_literal(node)
-			return
-		}
-		.selector {
-			if node.children_count > 0 {
-				base_id := tc.a.child(&node, 0)
-				base_type := tc.resolve_type(base_id)
-				if type_contains_unknown(base_type)
-					|| ((base_type is OptionType || base_type is ResultType)
-					&& node.value !in ['ok', 'value', 'err'])
-					|| (tc.fn_context.generic_params.len > 0 && (base_type is OptionType
-					|| base_type is ResultType)) {
-					tc.annotate_node(base_id)
+			.assign, .selector_assign, .index_assign {
+				if node.children_count > 0
+					&& tc.annotation_storage_path_has_unknown(tc.a.child(&node, 0)) {
+					for i in 0 .. node.children_count {
+						tc.annotate_node(tc.a.child(&node, i))
+					}
+					return
+				}
+				tc.annotate_assign_expected_exprs(node)
+			}
+			.struct_init {
+				tc.annotate_struct_init_expected_exprs(node)
+			}
+			.call {
+				if tc.fn_context.generic_params.len > 0 {
+					dsl_name := tc.unresolved_array_dsl_call_name(node)
+					if dsl_name.len > 0 {
+						tc.push_array_dsl_scope(node, dsl_name)
+					}
+					for i in 0 .. node.children_count {
+						tc.annotate_node(tc.a.child(&node, i))
+					}
+					tc.annotate_call_expected_exprs(current_id, node)
+					if info := tc.resolve_call_info(current_id, node) {
+						tc.remember_expr_type(current_id, info.return_type)
+					}
+					if dsl_name.len > 0 {
+						tc.pop_scope()
+					}
+					return
+				}
+				tc.annotate_call_expected_exprs(current_id, node)
+				// The call annotation above records a more precise return type for
+				// contextual builtins such as `map.move()`. Avoid replacing it with
+				// the parser's broad `map`/`array` placeholder below.
+				for i in 0 .. node.children_count {
+					tc.annotate_node(tc.a.child(&node, i))
+				}
+				return
+			}
+			.index {
+				if generic_fn_type := tc.explicit_generic_fn_value_type(node) {
+					tc.remember_expr_type(current_id, generic_fn_type)
+					return
+				}
+				if node.children_count > 0
+					&& type_contains_unknown(tc.resolve_type(tc.a.child(&node, 0))) {
+					for i in 0 .. node.children_count {
+						tc.annotate_node(tc.a.child(&node, i))
+					}
 					return
 				}
 			}
+			else {}
 		}
-		.assign, .selector_assign, .index_assign {
-			if node.children_count > 0
-				&& tc.annotation_storage_path_has_unknown(tc.a.child(&node, 0)) {
-				for i in 0 .. node.children_count {
-					tc.annotate_node(tc.a.child(&node, i))
-				}
-				return
-			}
-			tc.annotate_assign_expected_exprs(node)
-		}
-		.struct_init {
-			tc.annotate_struct_init_expected_exprs(node)
-		}
-		.call {
-			if tc.fn_context.generic_params.len > 0 {
-				dsl_name := tc.unresolved_array_dsl_call_name(node)
-				if dsl_name.len > 0 {
-					tc.push_array_dsl_scope(node, dsl_name)
-				}
-				for i in 0 .. node.children_count {
-					tc.annotate_node(tc.a.child(&node, i))
-				}
-				tc.annotate_call_expected_exprs(id, node)
-				if info := tc.resolve_call_info(id, node) {
-					tc.remember_expr_type(id, info.return_type)
-				}
-				if dsl_name.len > 0 {
-					tc.pop_scope()
-				}
-				return
-			}
-			tc.annotate_call_expected_exprs(id, node)
-			// The call annotation above records a more precise return type for
-			// contextual builtins such as `map.move()`. Avoid replacing it with
-			// the parser's broad `map`/`array` placeholder below.
-			for i in 0 .. node.children_count {
-				tc.annotate_node(tc.a.child(&node, i))
-			}
-			return
-		}
-		.index {
-			if generic_fn_type := tc.explicit_generic_fn_value_type(node) {
-				tc.remember_expr_type(id, generic_fn_type)
-				return
-			}
-			if node.children_count > 0
-				&& type_contains_unknown(tc.resolve_type(tc.a.child(&node, 0))) {
-				for i in 0 .. node.children_count {
-					tc.annotate_node(tc.a.child(&node, i))
-				}
-				return
-			}
-		}
-		else {}
-	}
 
-	tc.remember_expr_type(id, tc.resolve_type(id))
-	for i in 0 .. node.children_count {
-		tc.annotate_node(tc.a.child(&node, i))
+		tc.remember_expr_type(current_id, tc.resolve_type(current_id))
+		for i := node.children_count - 1; i >= 0; i-- {
+			pending << tc.a.child(&node, i)
+		}
 	}
 }
 
@@ -13060,7 +13077,7 @@ pub fn (tc &TypeChecker) struct_module_for_type(name string) string {
 
 fn (tc &TypeChecker) type_has_declaration_attribute(typ Type, name string) bool {
 	clean := unalias_type(unwrap_pointer(typ))
-	type_name := clean.name()
+	type_name := strip_generic_args_name(clean.name())
 	if type_name.len == 0 {
 		return false
 	}

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -6508,7 +6508,7 @@ fn (mut tc TypeChecker) annotate_node(id flat.NodeId) {
 	for pending.len > 0 {
 		current_id := pending.pop()
 		if int(current_id) < 0 {
-			return
+			continue
 		}
 		node := tc.a.nodes[int(current_id)]
 		match node.kind {
@@ -6517,7 +6517,7 @@ fn (mut tc TypeChecker) annotate_node(id flat.NodeId) {
 				rhs_count := tc.multi_assign_rhs_count(node)
 				if rhs_count == 1 && lhs_count > 1 {
 					tc.annotate_multi_return_decl_assign(node)
-					return
+					continue
 				}
 				pair_count := if lhs_count < rhs_count { lhs_count } else { rhs_count }
 				for pair_idx in 0 .. pair_count {
@@ -6543,18 +6543,18 @@ fn (mut tc TypeChecker) annotate_node(id flat.NodeId) {
 						}
 					}
 				}
-				return
+				continue
 			}
 			.for_in_stmt {
 				tc.annotate_for_in(current_id, node)
-				return
+				continue
 			}
 			.comptime_for {
-				return
+				continue
 			}
 			.fn_literal {
 				tc.annotate_fn_literal(node)
-				return
+				continue
 			}
 			.selector {
 				if node.children_count > 0 {
@@ -6566,7 +6566,7 @@ fn (mut tc TypeChecker) annotate_node(id flat.NodeId) {
 						|| (tc.fn_context.generic_params.len > 0 && (base_type is OptionType
 						|| base_type is ResultType)) {
 						tc.annotate_node(base_id)
-						return
+						continue
 					}
 				}
 			}
@@ -6576,7 +6576,7 @@ fn (mut tc TypeChecker) annotate_node(id flat.NodeId) {
 					for i in 0 .. node.children_count {
 						tc.annotate_node(tc.a.child(&node, i))
 					}
-					return
+					continue
 				}
 				tc.annotate_assign_expected_exprs(node)
 			}
@@ -6599,7 +6599,7 @@ fn (mut tc TypeChecker) annotate_node(id flat.NodeId) {
 					if dsl_name.len > 0 {
 						tc.pop_scope()
 					}
-					return
+					continue
 				}
 				tc.annotate_call_expected_exprs(current_id, node)
 				// The call annotation above records a more precise return type for
@@ -6608,19 +6608,19 @@ fn (mut tc TypeChecker) annotate_node(id flat.NodeId) {
 				for i in 0 .. node.children_count {
 					tc.annotate_node(tc.a.child(&node, i))
 				}
-				return
+				continue
 			}
 			.index {
 				if generic_fn_type := tc.explicit_generic_fn_value_type(node) {
 					tc.remember_expr_type(current_id, generic_fn_type)
-					return
+					continue
 				}
 				if node.children_count > 0
 					&& type_contains_unknown(tc.resolve_type(tc.a.child(&node, 0))) {
 					for i in 0 .. node.children_count {
 						tc.annotate_node(tc.a.child(&node, i))
 					}
-					return
+					continue
 				}
 			}
 			else {}
@@ -7543,6 +7543,15 @@ fn (tc &TypeChecker) cached_resolved_call(id flat.NodeId) ?string {
 // resolved_call_name returns the checker-resolved function name for a call node.
 pub fn (tc &TypeChecker) resolved_call_name(id flat.NodeId) ?string {
 	return tc.cached_resolved_call(id)
+}
+
+// resolved_call_is_builtin reports whether `id` resolved to the named builtin function.
+pub fn (tc &TypeChecker) resolved_call_is_builtin(id flat.NodeId, name string) bool {
+	resolved := tc.cached_resolved_call(id) or { return false }
+	if resolved != name && resolved != 'builtin.${name}' {
+		return false
+	}
+	return tc.fn_type_modules[resolved] or { '' } == 'builtin'
 }
 
 // reset_resolved_calls_for_reannotation discards pre-transform call-name

--- a/vlib/v3/types/checker_comptime.v
+++ b/vlib/v3/types/checker_comptime.v
@@ -8657,7 +8657,18 @@ fn (tc &TypeChecker) or_block_call_display_name(call &flat.Node) string {
 
 fn (mut tc TypeChecker) check_option_propagation(id flat.NodeId, source_id flat.NodeId) {
 	source := tc.a.node(source_id)
-	source_type := tc.resolve_type(source_id)
+	mut source_type := tc.resolve_type(source_id)
+	// A preceding `field != none` guard smartcasts a selector to its payload,
+	// but `&field?` still needs the declared Option type so it can address the
+	// payload storage itself. Preserve the declared type for propagation while
+	// retaining the smartcast for ordinary selector use.
+	if source.kind == .selector {
+		if declared := tc.selector_declared_value_type(*source) {
+			if declared is OptionType {
+				source_type = declared
+			}
+		}
+	}
 	clean_source_type := unalias_type(source_type)
 	clean_return_type := unalias_type(tc.fn_context.return_type)
 	is_channel_send := int(id) == tc.channel_send_or_expr_id

--- a/vlib/v3/types/checker_comptime.v
+++ b/vlib/v3/types/checker_comptime.v
@@ -8653,7 +8653,18 @@ fn (tc &TypeChecker) or_block_call_display_name(call &flat.Node) string {
 
 fn (mut tc TypeChecker) check_option_propagation(id flat.NodeId, source_id flat.NodeId) {
 	source := tc.a.node(source_id)
-	source_type := tc.resolve_type(source_id)
+	mut source_type := tc.resolve_type(source_id)
+	// A preceding `field != none` guard smartcasts a selector to its payload,
+	// but `&field?` still needs the declared Option type so it can address the
+	// payload storage itself. Preserve the declared type for propagation while
+	// retaining the smartcast for ordinary selector use.
+	if source.kind == .selector {
+		if declared := tc.selector_declared_value_type(*source) {
+			if declared is OptionType {
+				source_type = declared
+			}
+		}
+	}
 	clean_source_type := unalias_type(source_type)
 	clean_return_type := unalias_type(tc.fn_context.return_type)
 	is_channel_send := int(id) == tc.channel_send_or_expr_id

--- a/vlib/v3/types/checker_comptime.v
+++ b/vlib/v3/types/checker_comptime.v
@@ -14851,15 +14851,15 @@ fn (tc &TypeChecker) multi_expr_branch_tail_type_groups(branch_id flat.NodeId, c
 	if groups := tc.tuple_tail_value_groups(branch_id, count, explicit_comma_tail) {
 		mut result := [][]Type{cap: groups.len}
 		for group in groups {
-			mut types := []Type{cap: group.len}
+			mut tail_types := []Type{cap: group.len}
 			for value_id in group {
 				typ := tc.expr_type(value_id) or { tc.resolve_type(value_id) }
 				if !type_has_runtime_value(typ) {
 					return none
 				}
-				types << typ
+				tail_types << typ
 			}
-			result << types
+			result << tail_types
 		}
 		return result
 	}

--- a/vlib/v3/types/checker_ownership_d_ownership.v
+++ b/vlib/v3/types/checker_ownership_d_ownership.v
@@ -1260,8 +1260,11 @@ fn (tc &TypeChecker) ownership_type_requires_destruction_inner(typ Type, depth i
 		return false
 	}
 	match typ {
-		String, Array, Map, Interface, OptionType, ResultType, SumType {
+		String, Array, Map, Interface, ResultType, SumType {
 			return true
+		}
+		OptionType {
+			return tc.ownership_type_requires_destruction_inner(typ.base_type, depth + 1, mut seen)
 		}
 		Alias {
 			return tc.ownership_type_requires_destruction_inner(typ.base_type, depth + 1, mut seen)
@@ -1332,9 +1335,6 @@ fn (tc &TypeChecker) ownership_default_clone_missing_method_inner(typ Type, mut 
 			if tc.ownership_type_has_clone_method(typ) {
 				return none
 			}
-			if tc.ownership_type_has_explicit_drop(name) {
-				return name
-			}
 			if !tc.autofree_mode && !tc.named_type_implements_marker(name, 'IClone') {
 				return name
 			}
@@ -1382,22 +1382,6 @@ fn (tc &TypeChecker) ownership_default_clone_missing_ierror_method() ?string {
 		}
 	}
 	return none
-}
-
-fn (tc &TypeChecker) ownership_type_has_clone_method(typ Type) bool {
-	name := resolve_type_name_for_method(typ)
-	if name.len == 0 {
-		return false
-	}
-	if _ := tc.resolve_generic_struct_method(name, 'clone') {
-		return true
-	}
-	for method_name in receiver_method_name_candidates(typ, 'clone', tc.cur_module) {
-		if method_name in tc.fn_ret_types {
-			return true
-		}
-	}
-	return false
 }
 
 fn (tc &TypeChecker) ownership_ierror_has_compatible_clone_method(typ Type) bool {
@@ -10780,7 +10764,7 @@ fn (tc &TypeChecker) ownership_type_is_owned(typ Type) bool {
 		return tc.ownership_type_is_owned(typ.base_type)
 	}
 	if typ is OptionType {
-		return true
+		return tc.ownership_type_is_owned(typ.base_type)
 	}
 	if typ is ResultType {
 		return true

--- a/vlib/v3/types/checker_ownership_d_ownership.v
+++ b/vlib/v3/types/checker_ownership_d_ownership.v
@@ -224,6 +224,7 @@ mut:
 	pending_loop_label               string
 	deferred_aggregate_consumption   map[int]int
 	index_move_reads                 map[int]bool
+	guard_move_reads                 map[int]bool
 	scope_frames                     []OwnershipScopeFrame
 	suppressed_checks                int
 	path_active                      bool
@@ -308,6 +309,7 @@ fn new_ownership_state() &OwnershipState {
 		pending_loop_label:               ''
 		deferred_aggregate_consumption:   map[int]int{}
 		index_move_reads:                 map[int]bool{}
+		guard_move_reads:                 map[int]bool{}
 		scope_frames:                     []OwnershipScopeFrame{}
 		suppressed_checks:                0
 		path_active:                      true
@@ -414,6 +416,7 @@ fn ownership_clone_state_for_parallel(src &OwnershipState) &OwnershipState {
 		pending_loop_label:               ''
 		deferred_aggregate_consumption:   map[int]int{}
 		index_move_reads:                 map[int]bool{}
+		guard_move_reads:                 map[int]bool{}
 		scope_frames:                     []OwnershipScopeFrame{}
 		suppressed_checks:                0
 		path_active:                      true
@@ -500,13 +503,26 @@ fn ownership_merge_return_descs(mut dst map[string][]OwnershipReturnDescendant, 
 
 fn ownership_return_param_desc_in(values []OwnershipReturnParamDescendant, needle OwnershipReturnParamDescendant) bool {
 	for value in values {
-		if value.param_idx == needle.param_idx && value.slot_idx == needle.slot_idx
-			&& value.source_suffix == needle.source_suffix
-			&& value.target_suffix == needle.target_suffix {
+		if ownership_return_param_desc_subsumes(value, needle) {
 			return true
 		}
 	}
 	return false
+}
+
+// A shallower alias path is a conservative representation of any alias below
+// it. This also makes the return-alias fixed point converge for recursive call
+// graphs instead of growing paths such as `.next.next...` without bound.
+fn ownership_return_param_desc_subsumes(existing OwnershipReturnParamDescendant, candidate OwnershipReturnParamDescendant) bool {
+	return existing.param_idx == candidate.param_idx && existing.slot_idx == candidate.slot_idx
+		&& ownership_storage_suffix_contains(existing.source_suffix, candidate.source_suffix)
+		&& ownership_storage_suffix_contains(existing.target_suffix, candidate.target_suffix)
+}
+
+fn ownership_storage_suffix_contains(parent string, child string) bool {
+	return parent == child
+		|| (parent.len == 0 && child.len > 0 && child[0] in [`.`, `[`])
+		|| ownership_storage_key_is_descendant(child, parent)
 }
 
 fn ownership_merge_return_param_descs(mut dst map[string][]OwnershipReturnParamDescendant, src map[string][]OwnershipReturnParamDescendant) {
@@ -646,6 +662,11 @@ fn (mut tc TypeChecker) ownership_merge_parallel_check_worker(w &TypeChecker) {
 	for id, moved in src.index_move_reads {
 		if moved {
 			dst.index_move_reads[id] = true
+		}
+	}
+	for id, moved in src.guard_move_reads {
+		if moved {
+			dst.guard_move_reads[id] = true
 		}
 	}
 }
@@ -1342,6 +1363,9 @@ fn (tc &TypeChecker) ownership_default_clone_missing_method_inner(typ Type, mut 
 			if tc.ownership_type_has_clone_method(typ) {
 				return none
 			}
+			if tc.ownership_type_has_explicit_drop(name) {
+				return name
+			}
 			if !tc.autofree_mode && !tc.named_type_implements_marker(name, 'IClone') {
 				return name
 			}
@@ -1363,7 +1387,23 @@ fn (tc &TypeChecker) ownership_default_clone_missing_method_inner(typ Type, mut 
 			if tc.ownership_type_has_clone_method(typ) {
 				return none
 			}
-			return typ.name
+			name := typ.name
+			if seen[name] {
+				return none
+			}
+			seen[name] = true
+			base := tc.sum_base_name(name)
+			for variant in tc.sum_types[base] or { return name } {
+				concrete := tc.concrete_sum_variant_name(name, variant)
+				variant_type := tc.parse_type(concrete)
+				if !tc.ownership_type_requires_destruction(variant_type) {
+					continue
+				}
+				if bad := tc.ownership_default_clone_missing_method_inner(variant_type, mut seen) {
+					return bad
+				}
+			}
+			return none
 		}
 		Interface {
 			return typ.name
@@ -1648,15 +1688,24 @@ fn (mut tc TypeChecker) ownership_note_binding(name string, typ Type, pos flat.N
 	source_id := tc.ownership_guard_source_for_binding(pos, name)
 	source_name := tc.ownership_expr_ident_name(source_id)
 	source_participates := source_name.len > 0 && tc.ownership_storage_participates(source_name)
-	if tc.ownership_type_is_owned(typ) || source_participates {
+	mutable_owned_source := source_name.len > 0 && tc.expr_root_is_mutable_lvalue(source_id)
+		&& tc.ownership_type_requires_destruction(typ)
+	if tc.ownership_type_is_owned(typ) || source_participates || mutable_owned_source {
+		mut moved_source := false
 		if source_name.len > 0 {
 			tc.ownership_reject_global_move(source_name, pos, name, false)
 			if source_name in st.owned_vars {
-				tc.ownership_move_var(source_name, name, pos, false, '', true)
+				moved_source = tc.ownership_move_var_result(source_name, name, pos, false, '', true)
 			} else {
-				_ := tc.ownership_move_overlapping_dynamic_storage(source_name, name, pos, false,
-					'', true)
+				moved_source = tc.ownership_move_overlapping_dynamic_storage(source_name, name,
+					pos, false, '', true).len > 0
 			}
+		}
+		if !source_participates && mutable_owned_source {
+			moved_source = true
+		}
+		if moved_source && tc.valid_node_id(source_id) {
+			st.guard_move_reads[int(source_id)] = true
 		}
 		tc.ownership_mark_owned(name, typ, pos)
 		return
@@ -3389,18 +3438,18 @@ fn (mut tc TypeChecker) ownership_add_fn_return_param_descendant(fn_name string,
 	mut descs := st.ownership_fn_return_param_descs[fn_name] or {
 		[]OwnershipReturnParamDescendant{}
 	}
-	for desc in descs {
-		if desc.param_idx == param_idx && desc.slot_idx == slot_idx
-			&& desc.source_suffix == source_suffix && desc.target_suffix == target_suffix {
-			return
-		}
-	}
-	descs << OwnershipReturnParamDescendant{
+	candidate := OwnershipReturnParamDescendant{
 		param_idx:     param_idx
 		slot_idx:      slot_idx
 		source_suffix: source_suffix
 		target_suffix: target_suffix
 	}
+	for desc in descs {
+		if ownership_return_param_desc_subsumes(desc, candidate) {
+			return
+		}
+	}
+	descs << candidate
 	st.ownership_fn_return_param_descs[fn_name] = descs
 }
 
@@ -6610,6 +6659,11 @@ fn (mut tc TypeChecker) ownership_assign_to_name(lhs_name string, rhs_id flat.No
 			return
 		}
 		rhs_type := tc.resolve_type(rhs_id)
+		if tc.ownership_expr_is_mutable_index_move(rhs_id, rhs_type) {
+			tc.ownership_mark_index_move_read(rhs_name, assign_id)
+			tc.ownership_mark_owned(lhs_name, rhs_type, assign_id)
+			return
+		}
 		rhs_owned := tc.ownership_type_is_owned(rhs_type)
 		if rhs_owned || lhs_owned {
 			source_type := if rhs_owned { rhs_type } else { lhs_type }
@@ -6628,6 +6682,23 @@ fn (mut tc TypeChecker) ownership_assign_to_name(lhs_name string, rhs_id flat.No
 		st.owned_vars.delete(lhs_name)
 		st.owned_var_types.delete(lhs_name)
 	}
+}
+
+fn (tc &TypeChecker) ownership_expr_is_mutable_index_move(id flat.NodeId, typ Type) bool {
+	if !tc.valid_node_id(id) || !tc.ownership_type_requires_destruction(typ)
+		|| !tc.expr_root_is_mutable_lvalue(id) || !tc.ownership_expr_ident_name(id).contains('.') {
+		return false
+	}
+	mut source_id := id
+	for tc.valid_node_id(source_id) {
+		node := tc.a.nodes[int(source_id)]
+		if node.kind in [.paren, .expr_stmt, .cast_expr] && node.children_count > 0 {
+			source_id = tc.a.child(&node, 0)
+			continue
+		}
+		return node.kind == .index && node.value != 'range'
+	}
+	return false
 }
 
 fn (mut tc TypeChecker) ownership_assign_shadowing_same_name(lhs_name string, rhs_id flat.NodeId, lhs_type Type, assign_id flat.NodeId) bool {
@@ -10208,7 +10279,8 @@ fn (tc &TypeChecker) ownership_expr_moves_named_storage(source_id flat.NodeId, t
 	if has_receiver && fn_node.kind == .selector && fn_node.children_count > 0 {
 		receiver_id := tc.a.child(fn_node, 0)
 		receiver_type := if params.len > 0 { params[0] } else { Type(void_) }
-		if receiver_type !is Pointer && !tc.ownership_method_keeps_receiver(fn_node.value)
+		if (receiver_type !is Pointer || tc.ownership_call_returns_param(call_name, 0))
+			&& !tc.ownership_method_keeps_receiver(fn_node.value)
 			&& !tc.ownership_array_builtin_keeps_receiver(receiver_id, fn_node.value)
 			&& !tc.ownership_string_builtin_keeps_receiver(receiver_id, fn_node.value)
 			&& tc.ownership_expr_moves_named_storage(receiver_id, target) {
@@ -10218,7 +10290,8 @@ fn (tc &TypeChecker) ownership_expr_moves_named_storage(source_id flat.NodeId, t
 	for i in 1 .. node.children_count {
 		arg_id := tc.call_arg_value(tc.a.child(&node, i))
 		param_idx := if has_receiver { i } else { i - 1 }
-		if param_idx >= 0 && param_idx < params.len && params[param_idx] is Pointer {
+		if param_idx >= 0 && param_idx < params.len && params[param_idx] is Pointer
+			&& !tc.ownership_call_returns_param(call_name, param_idx) {
 			continue
 		}
 		if tc.ownership_expr_moves_named_storage(arg_id, target) {
@@ -10226,6 +10299,14 @@ fn (tc &TypeChecker) ownership_expr_moves_named_storage(source_id flat.NodeId, t
 		}
 	}
 	return false
+}
+
+fn (tc &TypeChecker) ownership_call_returns_param(fn_name string, param_idx int) bool {
+	if fn_name.len == 0 || param_idx < 0 || tc.ownership == unsafe { nil } {
+		return false
+	}
+	params := tc.ownership.ownership_fn_returns_param[fn_name] or { return false }
+	return param_idx in params
 }
 
 fn (tc &TypeChecker) ownership_call_has_receiver(node flat.Node, fn_node flat.Node, params []Type) bool {
@@ -10447,6 +10528,13 @@ fn (mut tc TypeChecker) ownership_mark_index_move_read_in(id flat.NodeId, name s
 // materializing the moved value.
 pub fn (tc &TypeChecker) ownership_index_read_moves_value(id flat.NodeId) bool {
 	return int(id) >= 0 && tc.ownership != unsafe { nil } && tc.ownership.index_move_reads[int(id)]
+}
+
+// ownership_guard_read_moves_value reports whether an optional/result guard binding
+// consumed the addressable wrapper at `id`. The transformer clears that source after
+// materializing the moved wrapper so its storage cannot destroy the payload again.
+pub fn (tc &TypeChecker) ownership_guard_read_moves_value(id flat.NodeId) bool {
+	return int(id) >= 0 && tc.ownership != unsafe { nil } && tc.ownership.guard_move_reads[int(id)]
 }
 
 fn (mut tc TypeChecker) ownership_owned_dynamic_overlap_names(source_name string) []string {

--- a/vlib/v3/types/checker_ownership_d_ownership.v
+++ b/vlib/v3/types/checker_ownership_d_ownership.v
@@ -1267,8 +1267,11 @@ fn (tc &TypeChecker) ownership_type_requires_destruction_inner(typ Type, depth i
 		return false
 	}
 	match typ {
-		String, Array, Map, Interface, OptionType, ResultType, SumType {
+		String, Array, Map, Interface, ResultType, SumType {
 			return true
+		}
+		OptionType {
+			return tc.ownership_type_requires_destruction_inner(typ.base_type, depth + 1, mut seen)
 		}
 		Alias {
 			return tc.ownership_type_requires_destruction_inner(typ.base_type, depth + 1, mut seen)
@@ -1339,9 +1342,6 @@ fn (tc &TypeChecker) ownership_default_clone_missing_method_inner(typ Type, mut 
 			if tc.ownership_type_has_clone_method(typ) {
 				return none
 			}
-			if tc.ownership_type_has_explicit_drop(name) {
-				return name
-			}
 			if !tc.autofree_mode && !tc.named_type_implements_marker(name, 'IClone') {
 				return name
 			}
@@ -1389,22 +1389,6 @@ fn (tc &TypeChecker) ownership_default_clone_missing_ierror_method() ?string {
 		}
 	}
 	return none
-}
-
-fn (tc &TypeChecker) ownership_type_has_clone_method(typ Type) bool {
-	name := resolve_type_name_for_method(typ)
-	if name.len == 0 {
-		return false
-	}
-	if _ := tc.resolve_generic_struct_method(name, 'clone') {
-		return true
-	}
-	for method_name in receiver_method_name_candidates(typ, 'clone', tc.cur_module) {
-		if method_name in tc.fn_ret_types {
-			return true
-		}
-	}
-	return false
 }
 
 fn (tc &TypeChecker) ownership_ierror_has_compatible_clone_method(typ Type) bool {
@@ -10810,7 +10794,7 @@ fn (tc &TypeChecker) ownership_type_is_owned(typ Type) bool {
 		return tc.ownership_type_is_owned(typ.base_type)
 	}
 	if typ is OptionType {
-		return true
+		return tc.ownership_type_is_owned(typ.base_type)
 	}
 	if typ is ResultType {
 		return true

--- a/vlib/v3/types/checker_ownership_notd_ownership.v
+++ b/vlib/v3/types/checker_ownership_notd_ownership.v
@@ -67,6 +67,10 @@ pub fn (tc &TypeChecker) ownership_index_read_moves_value(_ flat.NodeId) bool {
 	return false
 }
 
+pub fn (tc &TypeChecker) ownership_guard_read_moves_value(_ flat.NodeId) bool {
+	return false
+}
+
 pub fn (tc &TypeChecker) ownership_fn_value_returns_owned(_ flat.NodeId, _ string, _ string) bool {
 	return false
 }

--- a/vlib/v3/types/checker_tail.v
+++ b/vlib/v3/types/checker_tail.v
@@ -8253,8 +8253,12 @@ fn (tc &TypeChecker) expr_can_take_address(id flat.NodeId) bool {
 			return tc.expr_can_take_address(tc.a.child(&node, 0))
 		}
 		.or_expr {
-			return node.value == '?' && node.children_count > 0
-				&& tc.expr_can_take_address(tc.a.child(&node, 0))
+			// Optional/result propagation retains the source lvalue's storage.
+			// In particular, `&holder.field?` addresses the unwrapped payload.
+			if node.value !in ['?', '!'] || node.children_count == 0 {
+				return false
+			}
+			return tc.expr_can_take_address(tc.a.child(&node, 0))
 		}
 		else {
 			return false

--- a/vlib/v3/types/checker_tail.v
+++ b/vlib/v3/types/checker_tail.v
@@ -8342,8 +8342,12 @@ fn (tc &TypeChecker) expr_can_take_address(id flat.NodeId) bool {
 			return tc.expr_can_take_address(tc.a.child(&node, 0))
 		}
 		.or_expr {
-			return node.value == '?' && node.children_count > 0
-				&& tc.expr_can_take_address(tc.a.child(&node, 0))
+			// Optional/result propagation retains the source lvalue's storage.
+			// In particular, `&holder.field?` addresses the unwrapped payload.
+			if node.value !in ['?', '!'] || node.children_count == 0 {
+				return false
+			}
+			return tc.expr_can_take_address(tc.a.child(&node, 0))
 		}
 		else {
 			return false

--- a/vlib/v3/types/checker_tail.v
+++ b/vlib/v3/types/checker_tail.v
@@ -15591,7 +15591,7 @@ fn (tc &TypeChecker) branch_explicit_comma_tail_types(id flat.NodeId) ?[]Type {
 	}
 	node := tc.a.node(id)
 	if node.kind == .block && node.value == 'comma_exprs' {
-		mut types := []Type{cap: node.children_count}
+		mut tail_types := []Type{cap: node.children_count}
 		for i in 0 .. node.children_count {
 			stmt_id := tc.a.child(node, i)
 			if !tc.valid_node_id(stmt_id) {
@@ -15606,9 +15606,9 @@ fn (tc &TypeChecker) branch_explicit_comma_tail_types(id flat.NodeId) ?[]Type {
 			if typ is Unknown || !type_has_runtime_value(typ) {
 				return none
 			}
-			types << typ
+			tail_types << typ
 		}
-		return if types.len > 1 { types } else { none }
+		return if tail_types.len > 1 { tail_types } else { none }
 	}
 	if node.kind !in [.block, .match_branch] || node.children_count == 0 {
 		return none

--- a/vlib/v3/types/checker_tail_stmt.v
+++ b/vlib/v3/types/checker_tail_stmt.v
@@ -16732,6 +16732,25 @@ fn resolve_type_name_for_method(t Type) string {
 	return ''
 }
 
+// ownership_type_has_clone_method reports whether typ declares a handwritten clone method.
+// It is kept in the always-built checker surface because ownership transform support is
+// compiled into the V executable even when the executable itself is built without ownership.
+pub fn (tc &TypeChecker) ownership_type_has_clone_method(typ Type) bool {
+	name := resolve_type_name_for_method(typ)
+	if name.len == 0 {
+		return false
+	}
+	if _ := tc.resolve_generic_struct_method(name, 'clone') {
+		return true
+	}
+	for method_name in receiver_method_name_candidates(typ, 'clone', tc.cur_module) {
+		if method_name in tc.fn_ret_types {
+			return true
+		}
+	}
+	return false
+}
+
 fn receiver_type_name_variant(t Type, fixed_array_prefix bool, shorten_modules bool) string {
 	if t is Alias {
 		return receiver_leaf_type_name(t.name, shorten_modules)

--- a/vlib/v3/types/checker_tail_stmt.v
+++ b/vlib/v3/types/checker_tail_stmt.v
@@ -16318,6 +16318,25 @@ fn resolve_type_name_for_method(t Type) string {
 	return ''
 }
 
+// ownership_type_has_clone_method reports whether typ declares a handwritten clone method.
+// It is kept in the always-built checker surface because ownership transform support is
+// compiled into the V executable even when the executable itself is built without ownership.
+pub fn (tc &TypeChecker) ownership_type_has_clone_method(typ Type) bool {
+	name := resolve_type_name_for_method(typ)
+	if name.len == 0 {
+		return false
+	}
+	if _ := tc.resolve_generic_struct_method(name, 'clone') {
+		return true
+	}
+	for method_name in receiver_method_name_candidates(typ, 'clone', tc.cur_module) {
+		if method_name in tc.fn_ret_types {
+			return true
+		}
+	}
+	return false
+}
+
 fn receiver_type_name_variant(t Type, fixed_array_prefix bool, shorten_modules bool) string {
 	if t is Alias {
 		return receiver_leaf_type_name(t.name, shorten_modules)


### PR DESCRIPTION
Fixes to the V3 compiler's ownership system.

- Add `ownership_type_has_clone_method` to the always-built checker surface, detecting types that declare a handwritten `clone` method (including generic-struct methods). Ownership transform support is compiled into `v` even when `v` itself is built without ownership, so this lookup cannot live behind `$if ownership`.
- Distinguish marker-only `IClone` receivers (no declared `clone` method) from types that provide a real `clone`, so generic clone lowering selects the correct path.
- Track mut-pointer parameters in the flat C codegen (`cur_mut_pointer_params`, `current_param_is_mut_pointer`, `selector_base_is_local_value`) so explicitly pointer-typed `mut x &T` parameters retain pointer semantics instead of being treated as value `mut` params.
- Owned array/map clone and move lowering fixes.
