### PR TITLE
cmd/v: guard macOS V3 helpers with $if macos to fix unused-declaration notices

### DIFF
--- a/cmd/v/macos_v3_args.c.v
+++ b/cmd/v/macos_v3_args.c.v
@@ -1,80 +1,90 @@
 module main
 
-import v.pref
-
-const macos_v3_compat_c99_flag = '-macos-v3-compat-c99'
-const macos_v3_internal_quiet_flag = '-macos-v3-internal-quiet'
-
 // These helpers are shared by the native Darwin dispatcher and the default
-// implementation selected while generating cross-platform VC sources.
-fn macos_v3_has_v1_only_leading_option(args []string, command string) bool {
-	mut i := 0
-	for i < args.len {
-		arg := args[i]
-		if arg == '--' {
-			return false
+// implementation selected while generating cross-platform VC sources, so this
+// file has to stay platform neutral (no `_darwin.c.v` suffix): `v -os cross`
+// keeps *both* sides of a `$if macos {}` and guards them with a C `#if`, so the
+// macOS branch is codegen'ed even when the VC sources are produced on Linux.
+// The top level `$if macos {}` below preserves that, while keeping the helpers
+// out of the checker's unused-declaration scan on non macOS hosts - their only
+// callers are themselves inside `$if macos {}` blocks (see cmd/v/v.v's
+// `autofree_args_require_standard_compiler` and `v3_ownership_forwarded_args`),
+// and the checker does not walk inactive comptime branches.
+$if macos {
+	import v.pref
+
+	const macos_v3_compat_c99_flag = '-macos-v3-compat-c99'
+	const macos_v3_internal_quiet_flag = '-macos-v3-internal-quiet'
+
+	fn macos_v3_has_v1_only_leading_option(args []string, command string) bool {
+		mut i := 0
+		for i < args.len {
+			arg := args[i]
+			if arg == '--' {
+				return false
+			}
+			if arg in ['-message-limit', '-debug', '-debug-tcc', '-wasm-validate', '-wasm-stack-top',
+				'-use-coroutines', '-checker-match-exhaustive-cutoff-limit', '-raw-vsh-tmp-prefix',
+				'-c++', '-check-unused-fn-args', '-subsystem', '-translated-go', '-musl', '-glibc'] {
+				return true
+			}
+			if macos_v3_leading_option_consumes_value(arg) {
+				i += 2
+				continue
+			}
+			if command.len > 0 && arg == command {
+				return false
+			}
+			i++
 		}
-		if arg in ['-message-limit', '-debug', '-debug-tcc', '-wasm-validate', '-wasm-stack-top',
-			'-use-coroutines', '-checker-match-exhaustive-cutoff-limit', '-raw-vsh-tmp-prefix',
-			'-c++', '-check-unused-fn-args', '-subsystem', '-translated-go', '-musl', '-glibc'] {
-			return true
-		}
-		if macos_v3_leading_option_consumes_value(arg) {
-			i += 2
-			continue
-		}
-		if command.len > 0 && arg == command {
-			return false
-		}
-		i++
+		return false
 	}
-	return false
-}
 
-fn macos_v3_leading_option_consumes_value(option string) bool {
-	return option in ['-wasm-stack-top', '-arch', '-assert', '-e', '-subsystem', '-icon', '--icon',
-		'-seticon', '--seticon', '-gc', '-print_autofree_vars_in_fn', '-trace-fns', '-cov',
-		'-coverage', '-profile-fns', '-bug-report-url', '-run-only', '-exclude', '-file-list',
-		'-test-runner', '-dump-c-flags', '-dump-modules', '-dump-files', '-dump-defines',
-		'-generate-c-project', '-macosx-version-min', '-os', '-printfn', '-cflags', '-ldflags',
-		'-d', '-define', '-message-limit', '-thread-stack-size', '-cc', '-c++',
-		'-checker-match-exhaustive-cutoff-limit', '-o', '-output', '-b', '-backend',
-		'-compile-backend', '--compile-backend', '-path', '-bare-builtin-dir', '-custom-prelude',
-		'-raw-vsh-tmp-prefix', '-cmain', '-line-info']
-}
+	fn macos_v3_leading_option_consumes_value(option string) bool {
+		return option in ['-wasm-stack-top', '-arch', '-assert', '-e', '-subsystem', '-icon',
+			'--icon', '-seticon', '--seticon', '-gc', '-print_autofree_vars_in_fn', '-trace-fns',
+			'-cov', '-coverage', '-profile-fns', '-bug-report-url', '-run-only', '-exclude',
+			'-file-list', '-test-runner', '-dump-c-flags', '-dump-modules', '-dump-files',
+			'-dump-defines', '-generate-c-project', '-macosx-version-min', '-os', '-printfn',
+			'-cflags', '-ldflags', '-d', '-define', '-message-limit', '-thread-stack-size', '-cc',
+			'-c++', '-checker-match-exhaustive-cutoff-limit', '-o', '-output', '-b', '-backend',
+			'-compile-backend', '--compile-backend', '-path', '-bare-builtin-dir', '-custom-prelude',
+			'-raw-vsh-tmp-prefix', '-cmain', '-line-info']
+	}
 
-fn macos_v3_forwarded_args(prefs &pref.Preferences, raw_args []string) []string {
-	mut forwarded_args := raw_args.clone()
-	if prefs.enable_globals {
-		for i, arg in forwarded_args {
-			if arg == '--enable-globals' {
-				forwarded_args[i] = '-enable-globals'
+	fn macos_v3_forwarded_args(prefs &pref.Preferences, raw_args []string) []string {
+		mut forwarded_args := raw_args.clone()
+		if prefs.enable_globals {
+			for i, arg in forwarded_args {
+				if arg == '--enable-globals' {
+					forwarded_args[i] = '-enable-globals'
+				}
 			}
 		}
-	}
-	// V1 treats `x86` as an amd64 alias, while V3 reserves it for the 32-bit target.
-	if prefs.arch == .amd64 && '-arch x86' in prefs.build_options {
-		for i in 0 .. forwarded_args.len {
-			if i + 1 < forwarded_args.len && forwarded_args[i] == '-arch'
-				&& forwarded_args[i + 1] == 'x86' {
-				forwarded_args[i + 1] = 'amd64'
+		// V1 treats `x86` as an amd64 alias, while V3 reserves it for the 32-bit target.
+		if prefs.arch == .amd64 && '-arch x86' in prefs.build_options {
+			for i in 0 .. forwarded_args.len {
+				if i + 1 < forwarded_args.len && forwarded_args[i] == '-arch'
+					&& forwarded_args[i + 1] == 'x86' {
+					forwarded_args[i + 1] = 'amd64'
+				}
 			}
 		}
+		if macos_v3_compat_c99_flag !in forwarded_args {
+			forwarded_args.insert(0, macos_v3_compat_c99_flag)
+		}
+		if prefs.skip_running && '-skip-running' !in forwarded_args {
+			forwarded_args.insert(0, '-skip-running')
+		}
+		if !prefs.is_verbose && !prefs.is_stats && !prefs.show_timings
+			&& '-silent' !in forwarded_args && macos_v3_internal_quiet_flag !in forwarded_args {
+			forwarded_args.insert(0, macos_v3_internal_quiet_flag)
+		}
+		// The compatibility fallback must not select a different compiler merely
+		// because a valid V3 build crosses the standalone driver's safety cap.
+		if '-no-memory-limit' !in forwarded_args && '--no-memory-limit' !in forwarded_args {
+			forwarded_args.insert(0, '-no-memory-limit')
+		}
+		return forwarded_args
 	}
-	if macos_v3_compat_c99_flag !in forwarded_args {
-		forwarded_args.insert(0, macos_v3_compat_c99_flag)
-	}
-	if prefs.skip_running && '-skip-running' !in forwarded_args {
-		forwarded_args.insert(0, '-skip-running')
-	}
-	if !prefs.is_verbose && !prefs.is_stats && !prefs.show_timings && '-silent' !in forwarded_args
-		&& macos_v3_internal_quiet_flag !in forwarded_args {
-		forwarded_args.insert(0, macos_v3_internal_quiet_flag)
-	}
-	// The compatibility fallback must not select a different compiler merely
-	// because a valid V3 build crosses the standalone driver's safety cap.
-	if '-no-memory-limit' !in forwarded_args && '--no-memory-limit' !in forwarded_args {
-		forwarded_args.insert(0, '-no-memory-limit')
-	}
-	return forwarded_args
 }

--- a/cmd/v/macos_v3_test.v
+++ b/cmd/v/macos_v3_test.v
@@ -950,7 +950,9 @@ fn test_autofree_non_direct_commands_stay_on_the_standard_command_path() {
 	assert !is_ownership_relevant_command('run', prefs)
 	assert !is_ownership_relevant_command('test', prefs)
 	prefs.autofree = true
-	assert !is_macos_v3_relevant_command('run', prefs)
+	$if macos {
+		assert !is_macos_v3_relevant_command('run', prefs)
+	}
 	prefs.autofree = false
 	prefs.is_run = false
 	assert is_ownership_relevant_command('app.v', prefs)


### PR DESCRIPTION
## Summary
- `cmd/v/macos_v3_args.c.v` keeps its helpers/consts platform-neutral (no `_darwin.c.v` suffix) so `v -os cross` still codegens the macOS branch when producing VC sources on non-macOS hosts, but that left the consts/functions unguarded at file scope, triggering unused-declaration notices on non-macOS hosts since their only callers are themselves macOS-gated (`cmd/v/v.v`'s `autofree_args_require_standard_compiler` / `v3_ownership_forwarded_args`). Wraps the import, consts, and function definitions in a single top-level `$if macos {}` block.
- `cmd/v/macos_v3_test.v` had one call to `is_macos_v3_relevant_command` (defined in the macOS-only `macos_v3_darwin.c.v`) missing the `$if macos` guard every sibling assertion in the file already uses, which failed compilation on non-macOS hosts (`unknown function: is_macos_v3_relevant_command`).

## Test plan
- [x] Native Windows: `v self` clean, no notices
- [x] `-os cross`: exits 0; diffed generated `v.c` against baseline — only change is the three helper definitions gaining a matched `#if defined(__APPLE__)`/`#endif`, call sites unaffected
- [x] `v test cmd/v/` on Windows: 2 passed, 2 total (was 1 passed / 1 failed at HEAD)
- [x] Native Linux (WSL): `v self` clean; `v test cmd/v/macos_v3_test.v cmd/v/vvm_test.v`: 2 passed, 2 total
- [x] `v fmt -w` on both touched files: no changes needed

🧙 Built with [WOZCODE](https://wozcode.com)