### PR TITLE
cmd/v: fix macos_v3_test.v compile error on non-macOS platforms

### DIFF
--- a/cmd/v/macos_v3_test.v
+++ b/cmd/v/macos_v3_test.v
@@ -949,9 +949,11 @@ fn test_autofree_non_direct_commands_stay_on_the_standard_command_path() {
 	}
 	assert !is_ownership_relevant_command('run', prefs)
 	assert !is_ownership_relevant_command('test', prefs)
-	prefs.autofree = true
-	assert !is_macos_v3_relevant_command('run', prefs)
-	prefs.autofree = false
+	$if macos {
+		prefs.autofree = true
+		assert !is_macos_v3_relevant_command('run', prefs)
+		prefs.autofree = false
+	}
 	prefs.is_run = false
 	assert is_ownership_relevant_command('app.v', prefs)
 }


### PR DESCRIPTION
## Problem

`cmd/v/macos_v3_test.v:953` calls the darwin-only helper `is_macos_v3_relevant_command` **outside** a `$if macos {}` guard:

```v
prefs.autofree = true
assert !is_macos_v3_relevant_command('run', prefs)
prefs.autofree = false
```

`is_macos_v3_relevant_command` is defined in `cmd/v/macos_v3_darwin.c.v` (compiled on darwin only). Every other call site in this test guards it with `$if macos`; this one is a leftover from the rename to `is_ownership_relevant_command` in #28007. On Linux/Windows the symbol is undefined, so the test fails to compile:

```
cmd/v/macos_v3_test.v:953:10: error: unknown function: is_macos_v3_relevant_command
```

This broke **Tools CI** (and other test workflows) on every non-macOS platform (12 failed jobs).

## Fix

Wrap the darwin-specific assertion and its autofree setup in `$if macos {}`, matching the pattern already used throughout the file (e.g. line 493).

## Verification

- macOS: `v -silent cmd/v/macos_v3_test.v` passes (exit 0).
- Non-macOS: cross-compiling the test to a Linux target (`v -os linux -o out.c cmd/v/macos_v3_test.v`) now passes the checker — no `unknown function` error.