### PR TITLE
v3: fix assert truncating a negated wide integer literal to 32 bits

### DIFF
--- a/vlib/v3/gen/c/stmt.v
+++ b/vlib/v3/gen/c/stmt.v
@@ -2943,7 +2943,9 @@ fn (mut g FlatGen) gen_assert_capture_numeric_operands(condition_id flat.NodeId)
 	for operand_index in 0 .. 2 {
 		operand_id := g.a.child(condition, operand_index)
 		node := g.a.node(operand_id)
-		if node.kind in [.int_literal, .float_literal, .char_literal] || g.arg_is_const_ident(node) {
+		// exempt operands whose value a capture temp would truncate: constant
+		// numeric literals/exprs (ours) and const identifiers (upstream)
+		if g.is_constant_numeric_literal(operand_id) || g.arg_is_const_ident(node) {
 			continue
 		}
 		operand_type := g.usable_expr_type(operand_id)
@@ -2965,13 +2967,36 @@ fn (mut g FlatGen) gen_assert_capture_numeric_operands(condition_id flat.NodeId)
 	return captured_ids
 }
 
-fn (mut g FlatGen) gen_assert_numeric_value(prefix string, id flat.NodeId) {
+// A signed literal parses as a prefix over the literal; capturing it would type
+// it as the default `int` and truncate anything wider than 32 bits.
+fn (g &FlatGen) is_constant_numeric_literal(id flat.NodeId) bool {
 	node := g.a.node(id)
+	if node.kind in [.int_literal, .float_literal, .char_literal] {
+		return true
+	}
+	if node.children_count == 0 {
+		return false
+	}
+	return match node.kind {
+		.paren {
+			g.is_constant_numeric_literal(g.a.child(node, 0))
+		}
+		.prefix {
+			node.op in [.plus, .minus, .bit_not]
+				&& g.is_constant_numeric_literal(g.a.child(node, 0))
+		}
+		else {
+			false
+		}
+	}
+}
+
+fn (mut g FlatGen) gen_assert_numeric_value(prefix string, id flat.NodeId) {
 	label := g.assert_source_text(id)
 	if label.len == 0 {
 		return
 	}
-	if node.kind in [.int_literal, .float_literal, .char_literal] {
+	if g.is_constant_numeric_literal(id) {
 		g.writeln('v3_eprint_lit("${c_escape(prefix)}: ${c_escape(label)}\\n");')
 		return
 	}

--- a/vlib/v3/gen/c/stmt.v
+++ b/vlib/v3/gen/c/stmt.v
@@ -2967,8 +2967,9 @@ fn (mut g FlatGen) gen_assert_capture_numeric_operands(condition_id flat.NodeId)
 	return captured_ids
 }
 
-// A signed literal parses as a prefix over the literal; capturing it would type
-// it as the default `int` and truncate anything wider than 32 bits.
+// Capture eligibility: these are side-effect free, so skipping the temp is safe.
+// A signed literal parses as a prefix over the literal, and capturing it would
+// type it as the default `int` and truncate anything wider than 32 bits.
 fn (g &FlatGen) is_constant_numeric_literal(id flat.NodeId) bool {
 	node := g.a.node(id)
 	if node.kind in [.int_literal, .float_literal, .char_literal] {
@@ -2991,12 +2992,27 @@ fn (g &FlatGen) is_constant_numeric_literal(id flat.NodeId) bool {
 	}
 }
 
+// Display suppression: narrower than capture eligibility, because the label only
+// spells out the value for a bare or sign-prefixed literal. `~5` and `-(-1)`
+// still need evaluating.
+fn (g &FlatGen) is_signed_numeric_literal(id flat.NodeId) bool {
+	node := g.a.node(id)
+	if node.kind in [.int_literal, .float_literal, .char_literal] {
+		return true
+	}
+	if node.kind != .prefix || node.op !in [.plus, .minus] || node.children_count == 0 {
+		return false
+	}
+	operand := g.a.node(g.a.child(node, 0))
+	return operand.kind in [.int_literal, .float_literal, .char_literal]
+}
+
 fn (mut g FlatGen) gen_assert_numeric_value(prefix string, id flat.NodeId) {
 	label := g.assert_source_text(id)
 	if label.len == 0 {
 		return
 	}
-	if g.is_constant_numeric_literal(id) {
+	if g.is_signed_numeric_literal(id) {
 		g.writeln('v3_eprint_lit("${c_escape(prefix)}: ${c_escape(label)}\\n");')
 		return
 	}

--- a/vlib/v3/gen/c/stmt.v
+++ b/vlib/v3/gen/c/stmt.v
@@ -2942,8 +2942,7 @@ fn (mut g FlatGen) gen_assert_capture_numeric_operands(condition_id flat.NodeId)
 	mut captured_ids := []int{cap: 2}
 	for operand_index in 0 .. 2 {
 		operand_id := g.a.child(condition, operand_index)
-		node := g.a.node(operand_id)
-		if node.kind in [.int_literal, .float_literal, .char_literal] {
+		if g.is_constant_numeric_literal(operand_id) {
 			continue
 		}
 		typ := g.value_unalias_type(g.tc.resolve_type(operand_id))
@@ -2964,13 +2963,36 @@ fn (mut g FlatGen) gen_assert_capture_numeric_operands(condition_id flat.NodeId)
 	return captured_ids
 }
 
-fn (mut g FlatGen) gen_assert_numeric_value(prefix string, id flat.NodeId) {
+// A signed literal parses as a prefix over the literal; capturing it would type
+// it as the default `int` and truncate anything wider than 32 bits.
+fn (g &FlatGen) is_constant_numeric_literal(id flat.NodeId) bool {
 	node := g.a.node(id)
+	if node.kind in [.int_literal, .float_literal, .char_literal] {
+		return true
+	}
+	if node.children_count == 0 {
+		return false
+	}
+	return match node.kind {
+		.paren {
+			g.is_constant_numeric_literal(g.a.child(node, 0))
+		}
+		.prefix {
+			node.op in [.plus, .minus, .bit_not]
+				&& g.is_constant_numeric_literal(g.a.child(node, 0))
+		}
+		else {
+			false
+		}
+	}
+}
+
+fn (mut g FlatGen) gen_assert_numeric_value(prefix string, id flat.NodeId) {
 	label := g.assert_source_text(id)
 	if label.len == 0 {
 		return
 	}
-	if node.kind in [.int_literal, .float_literal, .char_literal] {
+	if g.is_constant_numeric_literal(id) {
 		g.writeln('v3_eprint_lit("${c_escape(prefix)}: ${c_escape(label)}\\n");')
 		return
 	}

--- a/vlib/v3/gen/c/stmt.v
+++ b/vlib/v3/gen/c/stmt.v
@@ -2945,7 +2945,7 @@ fn (mut g FlatGen) gen_assert_capture_numeric_operands(condition_id flat.NodeId)
 		node := g.a.node(operand_id)
 		// exempt operands whose value a capture temp would truncate: constant
 		// numeric literals/exprs (ours) and const identifiers (upstream)
-		if g.is_constant_numeric_literal(operand_id) || g.arg_is_const_ident(node) {
+		if g.is_constant_numeric_expr(operand_id) || g.arg_is_const_ident(node) {
 			continue
 		}
 		operand_type := g.usable_expr_type(operand_id)
@@ -2967,10 +2967,8 @@ fn (mut g FlatGen) gen_assert_capture_numeric_operands(condition_id flat.NodeId)
 	return captured_ids
 }
 
-// Capture eligibility: these are side-effect free, so skipping the temp is safe.
-// A signed literal parses as a prefix over the literal, and capturing it would
-// type it as the default `int` and truncate anything wider than 32 bits.
-fn (g &FlatGen) is_constant_numeric_literal(id flat.NodeId) bool {
+// side-effect free; a capture temp would type the constant as `int` and truncate wider values
+fn (g &FlatGen) is_constant_numeric_expr(id flat.NodeId) bool {
 	node := g.a.node(id)
 	if node.kind in [.int_literal, .float_literal, .char_literal] {
 		return true
@@ -2980,11 +2978,14 @@ fn (g &FlatGen) is_constant_numeric_literal(id flat.NodeId) bool {
 	}
 	return match node.kind {
 		.paren {
-			g.is_constant_numeric_literal(g.a.child(node, 0))
+			g.is_constant_numeric_expr(g.a.child(node, 0))
 		}
 		.prefix {
-			node.op in [.plus, .minus, .bit_not]
-				&& g.is_constant_numeric_literal(g.a.child(node, 0))
+			node.op in [.plus, .minus, .bit_not] && g.is_constant_numeric_expr(g.a.child(node, 0))
+		}
+		.infix {
+			node.children_count == 2 && g.is_constant_numeric_expr(g.a.child(node, 0))
+				&& g.is_constant_numeric_expr(g.a.child(node, 1))
 		}
 		else {
 			false
@@ -2992,9 +2993,7 @@ fn (g &FlatGen) is_constant_numeric_literal(id flat.NodeId) bool {
 	}
 }
 
-// Display suppression: narrower than capture eligibility, because the label only
-// spells out the value for a bare or sign-prefixed literal. `~5` and `-(-1)`
-// still need evaluating.
+// display only: `~5` and `-(-1)` still need evaluating, so this stays narrower than capture
 fn (g &FlatGen) is_signed_numeric_literal(id flat.NodeId) bool {
 	node := g.a.node(id)
 	if node.kind in [.int_literal, .float_literal, .char_literal] {

--- a/vlib/v3/tests/assert_negated_literal_codegen_test.v
+++ b/vlib/v3/tests/assert_negated_literal_codegen_test.v
@@ -5,8 +5,7 @@ const tests_dir = os.dir(@FILE)
 const v3_dir = os.dir(tests_dir)
 const v3_src = os.join_path(v3_dir, 'v3.v')
 
-// A signed literal missed assert's literal exemption and was captured as the
-// default `int`, truncating the comparison itself, not just the failure message.
+// a signed wide literal captured as the default `int` truncated the assert comparison itself
 fn test_assert_negated_wide_literal_is_not_captured_as_int() {
 	v3_bin := os.join_path(os.temp_dir(), 'v3_assert_negated_literal_codegen_test')
 	build := os.execute('${vexe} -gc none -o ${v3_bin} ${v3_src}')
@@ -15,16 +14,17 @@ fn test_assert_negated_wide_literal_is_not_captured_as_int() {
 	src := os.join_path(os.temp_dir(), 'v3_assert_negated_literal_input.v')
 	out_c := os.join_path(os.temp_dir(), 'v3_assert_negated_literal_input.c')
 	os.write_file(src,
-		'fn get() i64 {\n\treturn i64(-123456789012345)\n}\n\nfn main() {\n\tassert get() == -123456789012345\n}\n')!
+		'fn get() i64 {\n\treturn i64(-123456789012345)\n}\n\nfn main() {\n\tassert get() == -123456789012345\n\tassert get() == 5 * -24691357802469\n}\n')!
 	result := os.execute('${v3_bin} ${src} -o ${out_c}')
 	assert result.exit_code == 0, result.output
 
-	// the emitted failure detail repeats the assert source, so only the generated
-	// condition proves the literal is compared inline rather than through a temp
+	// the failure detail repeats the assert source, so only the condition line is proof
 	lines := os.read_file(out_c)!.split_into_lines()
 	conditions := lines.filter(
-		it.trim_space().starts_with('if (!(') && it.contains('123456789012345'))
-	assert conditions.len == 1, 'expected one assert condition holding the literal, got ${conditions.len}'
+		it.trim_space().starts_with('if (!(') && (it.contains('123456789012345') || it.contains('24691357802469')))
+	assert conditions.len == 2, 'expected two assert conditions holding the constants, got ${conditions.len}'
 	assert conditions[0].contains('== -123456789012345'), 'literal not compared inline: ${conditions[0]}'
-	assert !lines.any(it.trim_space().starts_with('int _t') && it.contains('123456789012345')), 'wide literal initialized into an int temp'
+	assert conditions[1].contains('== (5 * -24691357802469)'), 'constant expr not compared inline: ${conditions[1]}'
+	assert !lines.any(it.trim_space().starts_with('int _t')
+		&& (it.contains('123456789012345') || it.contains('24691357802469'))), 'wide constant initialized into an int temp'
 }

--- a/vlib/v3/tests/assert_negated_literal_codegen_test.v
+++ b/vlib/v3/tests/assert_negated_literal_codegen_test.v
@@ -1,0 +1,25 @@
+import os
+
+const vexe = @VEXE
+const tests_dir = os.dir(@FILE)
+const v3_dir = os.dir(tests_dir)
+const v3_src = os.join_path(v3_dir, 'v3.v')
+
+// A signed literal missed assert's literal exemption and was captured as the
+// default `int`, truncating the comparison itself, not just the failure message.
+fn test_assert_negated_wide_literal_is_not_captured_as_int() {
+	v3_bin := os.join_path(os.temp_dir(), 'v3_assert_negated_literal_codegen_test')
+	build := os.execute('${vexe} -gc none -o ${v3_bin} ${v3_src}')
+	assert build.exit_code == 0, build.output
+
+	src := os.join_path(os.temp_dir(), 'v3_assert_negated_literal_input.v')
+	out_c := os.join_path(os.temp_dir(), 'v3_assert_negated_literal_input.c')
+	os.write_file(src,
+		'fn get() i64 {\n\treturn i64(-123456789012345)\n}\n\nfn main() {\n\tassert get() == -123456789012345\n}\n')!
+	result := os.execute('${v3_bin} ${src} -o ${out_c}')
+	assert result.exit_code == 0, result.output
+
+	code := os.read_file(out_c)!
+	assert !code.contains('(int)(-123456789012345)'), 'assert captured the 64-bit literal into a 32-bit temp'
+	assert code.contains('== -123456789012345'), 'expected the literal to be compared inline'
+}

--- a/vlib/v3/tests/assert_negated_literal_codegen_test.v
+++ b/vlib/v3/tests/assert_negated_literal_codegen_test.v
@@ -19,7 +19,12 @@ fn test_assert_negated_wide_literal_is_not_captured_as_int() {
 	result := os.execute('${v3_bin} ${src} -o ${out_c}')
 	assert result.exit_code == 0, result.output
 
-	code := os.read_file(out_c)!
-	assert !code.contains('(int)(-123456789012345)'), 'assert captured the 64-bit literal into a 32-bit temp'
-	assert code.contains('== -123456789012345'), 'expected the literal to be compared inline'
+	// the emitted failure detail repeats the assert source, so only the generated
+	// condition proves the literal is compared inline rather than through a temp
+	lines := os.read_file(out_c)!.split_into_lines()
+	conditions := lines.filter(
+		it.trim_space().starts_with('if (!(') && it.contains('123456789012345'))
+	assert conditions.len == 1, 'expected one assert condition holding the literal, got ${conditions.len}'
+	assert conditions[0].contains('== -123456789012345'), 'literal not compared inline: ${conditions[0]}'
+	assert !lines.any(it.trim_space().starts_with('int _t') && it.contains('123456789012345')), 'wide literal initialized into an int temp'
 }


### PR DESCRIPTION
Fixes #28050.

`assert` captures numeric operands into temps for its failure diagnostic, exempting literals. A signed literal parses as a `.prefix` over the literal, so it missed the exemption, resolved to the default `int`, and truncated:

```c
i64 _t1 = (i64)(get_plain());
int _t2 = (int)(-123456789012345);   // 2045911175
if (!(_t1 == _t2)) {
```

The comparison reads the temp, so the assert **evaluated** wrong, not just reported wrong. Only macOS delegates to v3 by default, which is why it looked platform-specific; driving v3 directly on Linux reproduces it.

**Fix:** exempt side-effect-free constant operands from capture: literals, sign/`~` prefixes, parens, and constant infix — `-9223372036854775807 - 1` (`math_test.v:1145`) is an infix, so a literal-only exemption missed it. The classic backend never captures these shapes (`assert_subexpression_to_ctemp` allowlists only side-effecting exprs), so this restores parity: assert evaluates constants exactly like a plain `if`. Non-constant operands still capture, preserving single evaluation of side effects.

**Diagnostics:** per review, display suppression is a separate, narrower predicate — only a bare or sign-prefixed literal drops its `= value` (the label already spells it out). `~5`, `-(-1)`, `(5)`, `2 * 3` keep their evaluated output; captured-then-truncated constants previously printed the truncated value and now print the true one.

**Affected in vlib today:** `time_test.v:505,512,518`, `enum_explicit_size_big_and_small_test.v:78-80`, `math_test.v:1145`.

**Tests:** `vlib/v3/tests/assert_negated_literal_codegen_test.v` inspects the emitted `if (!(` conditions for a negated literal and a constant product; each fails without its part of the fix. It asserts on emitted C rather than running a binary — v3's prelude omits `<stdlib.h>` and gcc 16 rejects the resulting implicit `qsort`, which also fails `assert_stderr_shadow_codegen_test.v` on master. The three `v3_assert_*` inout fixtures emit byte-identical C with and without this patch.
