### PR TITLE
cgen: support tcc prealloc self-builds on macOS

### DIFF
--- a/vlib/builtin/prealloc_atomics.h
+++ b/vlib/builtin/prealloc_atomics.h
@@ -22,18 +22,40 @@ static inline long long v_prealloc_atomic_add_i64(long long *ptr, long long delt
 static inline long long v_prealloc_atomic_load_i64(long long *ptr) {
 	return _InterlockedCompareExchange64((volatile long long*)ptr, 0, 0);
 }
-#else
+#elif defined(__TINYC__)
+// TinyCC does not implement the legacy __sync_* family. Its __atomic_* builtins
+// lower to fixed-width helpers provided by libtcc1.a.
 static inline int v_prealloc_atomic_add_i32(int *ptr, int delta) {
-	return __sync_add_and_fetch(ptr, delta);
+	return __atomic_add_fetch(ptr, delta, 5);
 }
 static inline int v_prealloc_atomic_load_i32(int *ptr) {
-	return __sync_add_and_fetch(ptr, 0);
+	return __atomic_add_fetch(ptr, 0, 5);
 }
+static inline long long v_prealloc_atomic_add_i64(long long *ptr, long long delta) {
+	return __atomic_add_fetch(ptr, delta, 5);
+}
+static inline long long v_prealloc_atomic_load_i64(long long *ptr) {
+	return __atomic_add_fetch(ptr, 0, 5);
+}
+static inline int v_prealloc_atomic_store_i32(int *ptr, int val) {
+	return (int)__atomic_exchange_4((unsigned int*)ptr, (unsigned int)val, 5);
+}
+static inline int v_prealloc_atomic_cas_i32(int *ptr, int expected, int desired) {
+	unsigned int e = (unsigned int)expected;
+	return __atomic_compare_exchange_4((unsigned int*)ptr, &e, (unsigned int)desired, 5, 5);
+}
+#else
 static inline int v_prealloc_atomic_store_i32(int *ptr, int val) {
 	return __sync_lock_test_and_set(ptr, val);
 }
 static inline int v_prealloc_atomic_cas_i32(int *ptr, int expected, int desired) {
 	return __sync_bool_compare_and_swap(ptr, expected, desired);
+}
+static inline int v_prealloc_atomic_add_i32(int *ptr, int delta) {
+	return __sync_add_and_fetch(ptr, delta);
+}
+static inline int v_prealloc_atomic_load_i32(int *ptr) {
+	return __sync_add_and_fetch(ptr, 0);
 }
 static inline long long v_prealloc_atomic_add_i64(long long *ptr, long long delta) {
 	return __sync_add_and_fetch(ptr, delta);

--- a/vlib/v/gen/c/consts_and_globals.v
+++ b/vlib/v/gen/c/consts_and_globals.v
@@ -607,7 +607,8 @@ fn (mut g Gen) global_decl(node ast.GlobalDecl) {
 			// (a store to a `_Thread_local` variable segfaults), so there we emulate
 			// per-thread storage with a pthread key. The generated C is compiled by
 			// either tcc or the fallback system compiler, so both variants must exist.
-			g.write_prealloc_tls_global(mut def_builder, styp, final_c_name)
+			linkage := '${extern}${field_visibility_kw}'
+			g.write_prealloc_tls_global(mut def_builder, linkage, styp, final_c_name)
 			g.global_const_defs[name] = GlobalConstDef{
 				mod: node.mod
 				def: def_builder.str()
@@ -696,7 +697,8 @@ fn (mut g Gen) global_decl(node ast.GlobalDecl) {
 // thread-local storage (a store to a `_Thread_local` variable segfaults), so there the
 // same identifier is redirected to per-thread storage held in a pthread key. Both variants
 // are emitted because the same generated C can be compiled by TCC or the system compiler.
-fn (mut g Gen) write_prealloc_tls_global(mut def_builder strings.Builder, styp string, cname string) {
+fn (mut g Gen) write_prealloc_tls_global(mut def_builder strings.Builder, linkage string, styp string,
+	cname string) {
 	def_builder.writeln('#if defined(__TINYC__) && defined(__APPLE__)')
 	def_builder.writeln('#include <pthread.h>')
 	def_builder.writeln('static pthread_key_t v_prealloc_tls_key;')
@@ -714,7 +716,7 @@ fn (mut g Gen) write_prealloc_tls_global(mut def_builder strings.Builder, styp s
 	def_builder.writeln('}')
 	def_builder.writeln('#define ${cname} (*(${styp} *)v_prealloc_tls_slot())')
 	def_builder.writeln('#else')
-	def_builder.writeln('_Thread_local ${styp} ${cname}; // global 6')
+	def_builder.writeln('${linkage}_Thread_local ${styp} ${cname}; // global 6')
 	def_builder.writeln('#endif')
 }
 

--- a/vlib/v/gen/c/consts_and_globals.v
+++ b/vlib/v/gen/c/consts_and_globals.v
@@ -601,13 +601,21 @@ fn (mut g Gen) global_decl(node ast.GlobalDecl) {
 			}
 			continue
 		}
-		if field.is_extern {
-			tls_kw := if field.name == 'g_memory_block' && g.pref.prealloc {
-				'_Thread_local '
-			} else {
-				''
+		if field.name == 'g_memory_block' && g.pref.prealloc {
+			// The prealloc arena root is thread-local, so each thread bump-allocates
+			// from its own chunk. TinyCC on macOS has no working thread-local storage
+			// (a store to a `_Thread_local` variable segfaults), so there we emulate
+			// per-thread storage with a pthread key. The generated C is compiled by
+			// either tcc or the fallback system compiler, so both variants must exist.
+			g.write_prealloc_tls_global(mut def_builder, styp, final_c_name)
+			g.global_const_defs[name] = GlobalConstDef{
+				mod: node.mod
+				def: def_builder.str()
 			}
-			def_builder.writeln('${extern}${tls_kw}${field_visibility_kw}${qualifiers}${styp} ${attributes}${final_c_name}; // global 2')
+			continue
+		}
+		if field.is_extern {
+			def_builder.writeln('${extern}${field_visibility_kw}${qualifiers}${styp} ${attributes}${final_c_name}; // global 2')
 			g.global_const_defs[name] = GlobalConstDef{
 				mod:   node.mod
 				def:   def_builder.str()
@@ -617,12 +625,7 @@ fn (mut g Gen) global_decl(node ast.GlobalDecl) {
 		}
 		mut needs_ending_semicolon := false
 		if field.language != .c || field.has_expr {
-			tls_kw := if field.name == 'g_memory_block' && g.pref.prealloc {
-				'_Thread_local '
-			} else {
-				''
-			}
-			def_builder.write_string('${extern}${tls_kw}${field_visibility_kw}${qualifiers}${styp} ${attributes}${final_c_name}')
+			def_builder.write_string('${extern}${field_visibility_kw}${qualifiers}${styp} ${attributes}${final_c_name}')
 			needs_ending_semicolon = true
 		}
 		if field.has_expr || cinit {
@@ -685,6 +688,34 @@ fn (mut g Gen) global_decl(node ast.GlobalDecl) {
 			dep_names: g.table.dependent_names_in_expr(field.expr)
 		}
 	}
+}
+
+// write_prealloc_tls_global emits the definition of the thread-local prealloc arena
+// root (`g_memory_block`). Regular C compilers back it with a `_Thread_local` variable
+// so each thread bump-allocates from its own arena. TinyCC on macOS has no working
+// thread-local storage (a store to a `_Thread_local` variable segfaults), so there the
+// same identifier is redirected to per-thread storage held in a pthread key. Both variants
+// are emitted because the same generated C can be compiled by TCC or the system compiler.
+fn (mut g Gen) write_prealloc_tls_global(mut def_builder strings.Builder, styp string, cname string) {
+	def_builder.writeln('#if defined(__TINYC__) && defined(__APPLE__)')
+	def_builder.writeln('#include <pthread.h>')
+	def_builder.writeln('static pthread_key_t v_prealloc_tls_key;')
+	def_builder.writeln('static pthread_once_t v_prealloc_tls_once = PTHREAD_ONCE_INIT;')
+	def_builder.writeln('static void v_prealloc_tls_slot_free(void *slot) { free(slot); }')
+	def_builder.writeln('static void v_prealloc_tls_key_init(void) { pthread_key_create(&v_prealloc_tls_key, v_prealloc_tls_slot_free); }')
+	def_builder.writeln('static inline void **v_prealloc_tls_slot(void) {')
+	def_builder.writeln('\tpthread_once(&v_prealloc_tls_once, v_prealloc_tls_key_init);')
+	def_builder.writeln('\tvoid **slot = (void **)pthread_getspecific(v_prealloc_tls_key);')
+	def_builder.writeln('\tif (slot == ((void *)0)) {')
+	def_builder.writeln('\t\tslot = (void **)calloc(1, sizeof(void *));')
+	def_builder.writeln('\t\tpthread_setspecific(v_prealloc_tls_key, slot);')
+	def_builder.writeln('\t}')
+	def_builder.writeln('\treturn slot;')
+	def_builder.writeln('}')
+	def_builder.writeln('#define ${cname} (*(${styp} *)v_prealloc_tls_slot())')
+	def_builder.writeln('#else')
+	def_builder.writeln('_Thread_local ${styp} ${cname}; // global 6')
+	def_builder.writeln('#endif')
 }
 
 fn (mut g Gen) sort_globals_consts() {

--- a/vlib/v/gen/c/link_generated_c_files_test.v
+++ b/vlib/v/gen/c/link_generated_c_files_test.v
@@ -42,9 +42,11 @@ int main(void) {
 	return 0;
 }
 ')!
+	// Each preallocated object must keep builtin globals object-local, including
+	// the thread-local g_memory_block arena root.
 	for cmd in [
-		'${test_vexe} -cc ${cc} -gc none -no-skip-unused -is_o -o ${os.quoted_path(a_c)} ${os.quoted_path(a_v)}',
-		'${test_vexe} -cc ${cc} -gc none -no-skip-unused -is_o -o ${os.quoted_path(b_c)} ${os.quoted_path(b_v)}',
+		'${test_vexe} -message-limit 199 -cc ${cc} -gc none -prealloc -no-skip-unused -is_o -o ${os.quoted_path(a_c)} ${os.quoted_path(a_v)}',
+		'${test_vexe} -message-limit 199 -cc ${cc} -gc none -prealloc -no-skip-unused -is_o -o ${os.quoted_path(b_c)} ${os.quoted_path(b_v)}',
 		'${cc} -o ${os.quoted_path(prog)} ${os.quoted_path(a_c)} ${os.quoted_path(b_c)} ${os.quoted_path(host_c)} -lm',
 	] {
 		res := os.execute(cmd)

--- a/vlib/v/gen/c/prealloc_tcc_macos_test.v
+++ b/vlib/v/gen/c/prealloc_tcc_macos_test.v
@@ -1,0 +1,48 @@
+// vtest build: macos && arm64
+import os
+
+fn test_prealloc_uses_tcc_without_native_tls() {
+	test_dir := os.join_path(os.vtmp_dir(), 'prealloc_tcc_macos_test_${os.getpid()}')
+	os.mkdir_all(test_dir)!
+	defer {
+		os.rmdir_all(test_dir) or {}
+	}
+	tcc := os.join_path(@VEXEROOT, 'thirdparty', 'tcc', 'tcc.exe')
+	assert os.is_executable(tcc), 'missing bundled TinyCC: ${tcc}'
+	source_path := os.join_path(test_dir, 'prealloc_threads.v')
+	executable_path := os.join_path(test_dir, 'prealloc_threads')
+	os.write_file(source_path, 'fn worker(id int) int {
+	mut values := []int{len: 4096}
+	for i in 0 .. values.len {
+		values[i] = id
+	}
+	return values[0] + values[values.len - 1]
+}
+
+fn main() {
+	mut workers := []thread int{}
+	for id in 1 .. 5 {
+		workers << spawn worker(id)
+	}
+	mut sum := 0
+	for handle in workers {
+		sum += handle.wait()
+	}
+	println(sum)
+}
+')!
+	old_vflags := os.getenv_opt('VFLAGS')
+	os.unsetenv('VFLAGS')
+	defer {
+		if vflags := old_vflags {
+			os.setenv('VFLAGS', vflags, true)
+		}
+	}
+	// A non-default message limit keeps this regression on the V1 C generator used by cmd/v.
+	compile_cmd := '${os.quoted_path(@VEXE)} -message-limit 199 -cc ${os.quoted_path(tcc)} -gc none -prealloc -no-retry-compilation -nocache -o ${os.quoted_path(executable_path)} ${os.quoted_path(source_path)}'
+	compile_result := os.execute(compile_cmd)
+	assert compile_result.exit_code == 0, '${compile_cmd}\n${compile_result.output}'
+	run_result := os.execute(os.quoted_path(executable_path))
+	assert run_result.exit_code == 0, run_result.output
+	assert run_result.output.trim_space() == '20', run_result.output
+}


### PR DESCRIPTION
## Summary

- emulate the prealloc arena TLS slot with a pthread key when generated C is compiled by TinyCC on macOS
- route prealloc atomics through the fixed-width helpers available in TinyCC while preserving the existing GCC/Clang/MSVC paths
- add an Apple Silicon regression test that builds and runs a threaded prealloc program with TCC and compilation retry disabled

This keeps the default Apple Silicon `v self` path on TCC instead of falling back to the system compiler.

Fixes #28023

## Validation

- `./vnew vlib/v/gen/c/prealloc_tcc_macos_test.v`
- `./vnew -message-limit 199 -cc tcc -gc none -prealloc -no-retry-compilation vlib/builtin/prealloc_scope_ownership_test.v`
- `./vnew self -showcc -no-retry-compilation -o /private/tmp/v-self-28023-fixed` (confirmed bundled `thirdparty/tcc/tcc.exe`)
- `VFLAGS='-message-limit 199' ./vnew -silent vlib/v/compiler_errors_test.v` (1617 passed, 1 skipped)
- `./vnew -silent vlib/v/gen/c/coutput_test.v` in a clean worktree (all 105 output and 141 generated-C fixtures passed or were platform-skipped)
- `VFLAGS='-message-limit 199' ./vnew -silent test vlib/v/` reached 2086/2353 before the temporary volume ran out of space; failures seen before exhaustion were unrelated existing parallel-CC/debugger/V3 expectation failures