### PR TITLE
Fix -usecache producing broken binaries in v1

### DIFF
--- a/vlib/v/builder/builder.v
+++ b/vlib/v/builder/builder.v
@@ -1,6 +1,7 @@
 module builder
 
 import os
+import time
 import v.token
 import v.pref
 import v.errors
@@ -31,20 +32,22 @@ pub:
 	compiled_dir string // contains os.real_path() of the dir of the final file being compiled, or the dir itself when doing `v .`
 	module_path  string
 pub mut:
-	checker             &checker.Checker         = unsafe { nil }
-	transformer         &transformer.Transformer = unsafe { nil }
-	comptime            &comptime.Comptime       = unsafe { nil }
-	generics            &generics.Generics       = unsafe { nil }
-	out_name_c          string
-	out_name_js         string
-	stats_lines         int // size of backend generated source code in lines
-	stats_bytes         int // size of backend generated source code in bytes
-	nr_errors           int // accumulated error count of scanner, parser, checker, and builder
-	nr_warnings         int // accumulated warning count of scanner, parser, checker, and builder
-	nr_notices          int // accumulated notice count of scanner, parser, checker, and builder
-	pref                &pref.Preferences = unsafe { nil }
-	module_search_paths []string
-	parsed_files        []&ast.File
+	checker              &checker.Checker         = unsafe { nil }
+	transformer          &transformer.Transformer = unsafe { nil }
+	comptime             &comptime.Comptime       = unsafe { nil }
+	generics             &generics.Generics       = unsafe { nil }
+	out_name_c           string
+	out_name_js          string
+	stats_lines          int // size of backend generated source code in lines
+	stats_bytes          int // size of backend generated source code in bytes
+	stats_cc_micros      i64 // time in the C compiler, for -stats
+	stats_modules_micros i64 // time in `v build-module` children, for -stats
+	nr_errors            int // accumulated error count of scanner, parser, checker, and builder
+	nr_warnings          int // accumulated warning count of scanner, parser, checker, and builder
+	nr_notices           int // accumulated notice count of scanner, parser, checker, and builder
+	pref                 &pref.Preferences = unsafe { nil }
+	module_search_paths  []string
+	parsed_files         []&ast.File
 	//$if windows {
 	cached_msvc MsvcResult
 	//}
@@ -1296,6 +1299,15 @@ fn (b &Builder) print_frontend_builder_errors() {
 			}
 		}
 	}
+}
+
+// execute_cc runs a C compiler command, accumulating how long it took, so that
+// `-stats` can report it apart from the V frontend.
+pub fn (mut b Builder) execute_cc(cmd string) os.Result {
+	sw := time.new_stopwatch()
+	res := os.execute(cmd)
+	b.stats_cc_micros += sw.elapsed().microseconds()
+	return res
 }
 
 @[noreturn]

--- a/vlib/v/builder/cbuilder/parallel_cc.v
+++ b/vlib/v/builder/cbuilder/parallel_cc.v
@@ -49,6 +49,8 @@ fn parallel_cc(mut b builder.Builder, result c.GenOutput) ! {
 	tmp_dir := os.vtmp_dir()
 	sw_total := time.new_stopwatch()
 	defer {
+		// charge this phase (cc + link across processes) to the C compiler for -stats
+		b.stats_cc_micros += sw_total.elapsed().microseconds()
 		eprint_time(sw_total, @METHOD)
 	}
 	c_files := int_max(1, util.nr_jobs)

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -1247,7 +1247,12 @@ fn (mut v Builder) setup_ccompiler_options(ccompiler string) {
 
 	legacy_cflags, ordered_link_flags, pkgconfig_pthread :=
 		v.split_ordered_pkgconfig_link_flags(cflags)
-	defines, others, libs := legacy_cflags.defines_others_libs()
+	defines, mut others, libs := legacy_cflags.defines_others_libs()
+	if v.pref.build_mode == .build_module {
+		// `cc -c -o x.o` takes a single input. Only build-module can drop these: the
+		// program build that links its object compiles them itself.
+		others = others.filter(!cflag.is_c_source_operand(it))
+	}
 	ccoptions.pre_args << defines
 	ccoptions.pre_args << others
 	ccoptions.linker_flags << libs
@@ -2319,10 +2324,8 @@ fn (mut b Builder) cc_linux_cross() {
 	mut other_flags := []string{cap: others.len}
 	mut extra_sources := []string{}
 	for opt in others {
-		unq := opt.trim('"').trim("'")
-		ext := os.file_ext(unq).to_lower()
-		if ext in ['.c', '.cpp', '.cc', '.cxx', '.s'] && os.is_file(unq) {
-			extra_sources << unq
+		if cflag.is_c_source_operand(opt) {
+			extra_sources << opt.trim('"').trim("'")
 		} else {
 			other_flags << opt
 		}

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -1985,7 +1985,7 @@ pub fn (mut v Builder) cc() {
 		// Run
 		ccompiler_label := 'C ${os.file_name(ccompiler):3}'
 		util.timing_start(ccompiler_label)
-		res := os.execute(cmd)
+		res := v.execute_cc(cmd)
 		util.timing_measure(ccompiler_label)
 		if v.pref.show_c_output {
 			v.show_c_compiler_output(ccompiler, res)
@@ -2352,7 +2352,7 @@ fn (mut b Builder) cc_linux_cross() {
 		if b.pref.show_cc {
 			println(src_cmd)
 		}
-		src_res := os.execute(src_cmd)
+		src_res := b.execute_cc(src_cmd)
 		if src_res.exit_code != 0 {
 			println('Cross compilation for Linux failed (extra source ${src}).')
 			verror(src_res.output)
@@ -2375,7 +2375,7 @@ fn (mut b Builder) cc_linux_cross() {
 	if b.pref.show_cc {
 		println(cc_cmd)
 	}
-	cc_res := os.execute(cc_cmd)
+	cc_res := b.execute_cc(cc_cmd)
 	if cc_res.exit_code != 0 {
 		println('Cross compilation for Linux failed (first step, cc). Make sure you have clang installed.')
 		verror(cc_res.output)
@@ -2813,7 +2813,7 @@ fn (mut v Builder) build_thirdparty_obj_file(mod string, path string, moduleflag
 	if trace_thirdparty_obj_files {
 		println('>>> build_thirdparty_obj_files cmd: ${cmd}')
 	}
-	res := os.execute(cmd)
+	res := v.execute_cc(cmd)
 	os.chdir(current_folder) or {}
 	if res.exit_code != 0 {
 		eprintln('> Failed build_thirdparty_obj_file cmd')

--- a/vlib/v/builder/cc_test.v
+++ b/vlib/v/builder/cc_test.v
@@ -3,6 +3,7 @@ module builder
 import os
 import time
 import v.pref
+import v.vcache
 
 fn test_ccompiler_is_available_with_existing_absolute_path() {
 	assert ccompiler_is_available(@VEXE)
@@ -944,6 +945,27 @@ fn test_thirdparty_deps_mtime_includes_module_include_headers() {
 	assert deps == config_mtime, 'thirdparty_deps_mtime must fold in include/ headers; got ${deps}, want ${config_mtime}'
 	// Memoized per module root: a second call returns the same value.
 	assert b.thirdparty_deps_mtime(source) == config_mtime
+}
+
+fn test_forget_source_hashes_makes_the_next_run_reinvalidate() {
+	test_root := os.join_path(os.vtmp_dir(), 'v_forget_hashes_${os.getpid()}')
+	os.rmdir_all(test_root) or {}
+	os.mkdir_all(test_root) or { panic(err) }
+	defer {
+		os.rmdir_all(test_root) or {}
+	}
+	sample := os.join_path(test_root, 'sample.v')
+	os.write_file(sample, 'module sample\n') or { panic(err) }
+	files := [sample]
+
+	mut cm := vcache.new_cache_manager(files)
+	cm.save('.hashes', 'all_files', 'deadbeef ${sample}\n') or { panic(err) }
+	assert cm.load('.hashes', 'all_files') or { '' } != ''
+
+	forget_source_hashes(files)
+
+	mut cm2 := vcache.new_cache_manager(files)
+	assert cm2.load('.hashes', 'all_files') or { 'missing' } == ''
 }
 
 fn prepare_test_ccompiler_alias(test_root string, compiler_name string, version_output string) string {

--- a/vlib/v/builder/msvc_windows.v
+++ b/vlib/v/builder/msvc_windows.v
@@ -418,7 +418,7 @@ pub fn (mut v Builder) cc_msvc() {
 		verror('cannot build with msvc on ${os.user_os()}')
 	}
 	util.timing_start('C msvc')
-	res := os.execute(cmd)
+	res := v.execute_cc(cmd)
 	if res.exit_code != 0 {
 		eprintln('================== ${c_compilation_error_title} (from msvc): ==============')
 		eprintln(res.output)
@@ -514,7 +514,7 @@ fn (mut v Builder) build_thirdparty_obj_file_with_msvc(mod string, path string, 
 	mut res := os.Result{}
 	mut i := 0
 	for i = 0; i < thirdparty_obj_build_max_retries; i++ {
-		res = os.execute(cmd)
+		res = v.execute_cc(cmd)
 		if res.exit_code == 0 {
 			break
 		}

--- a/vlib/v/builder/rebuilding.v
+++ b/vlib/v/builder/rebuilding.v
@@ -213,7 +213,10 @@ fn (mut b Builder) v_build_module(vexe string, imp_path string) (string, int) {
 		eprintln('> Builder.v_build_module: ${rebuild_cmd}')
 	}
 	// eprintln('> Builder.v_build_module: ${rebuild_cmd}')
-	return rebuild_cmd, os.system(rebuild_cmd)
+	sw := time.new_stopwatch()
+	code := os.system(rebuild_cmd)
+	b.stats_modules_micros += sw.elapsed().microseconds()
+	return rebuild_cmd, code
 }
 
 fn usecache_module_error(what string, code int, vroot string, cmd string) string {
@@ -415,10 +418,25 @@ pub fn (mut b Builder) rebuild(backend_cb FnBackend) {
 		sbytes = util.bold('${sbytes:10s}')
 		println('generated  target  code size: ${slines} lines, ${sbytes} bytes')
 		//
-		vlines_per_second := int(1_000_000.0 * f64(all_v_source_lines) / f64(compilation_time_micros))
+		// so the vlines/s figure below is about V, not the C compiler
+		mut frontend_time_micros := compilation_time_micros - b.stats_cc_micros -
+			b.stats_modules_micros
+		if frontend_time_micros < 1 {
+			frontend_time_micros = 1
+		}
+		sfrontend_time_ms := util.bold('${f64(frontend_time_micros) / 1000.0:6.3f}')
+		mut timing_parts := ['${sfrontend_time_ms} ms V frontend']
+		if b.stats_cc_micros > 0 {
+			timing_parts << '${util.bold('${f64(b.stats_cc_micros) / 1000.0:6.3f}')} ms ${b.pref.ccompiler}'
+		}
+		if b.stats_modules_micros > 0 {
+			timing_parts << '${util.bold('${f64(b.stats_modules_micros) / 1000.0:6.3f}')} ms cached module builds'
+		}
+		vlines_per_second := int(1_000_000.0 * f64(all_v_source_lines) / f64(frontend_time_micros))
 		svlines_per_second := util.bold(vlines_per_second.str())
 		used_cgen_threads := if b.pref.no_parallel { 1 } else { runtime.nr_jobs() }
-		println('compilation took: ${scompilation_time_ms} ms, compilation speed: ${svlines_per_second} vlines/s, cgen threads: ${used_cgen_threads}')
+		println('compilation took: ${scompilation_time_ms} ms (${timing_parts.join(', ')})')
+		println('V frontend speed: ${svlines_per_second} vlines/s, cgen threads: ${used_cgen_threads}')
 	}
 }
 

--- a/vlib/v/builder/rebuilding.v
+++ b/vlib/v/builder/rebuilding.v
@@ -34,9 +34,21 @@ pub fn (mut b Builder) rebuild_modules() {
 	if invalidations.len > 0 {
 		vexe := pref.vexe_path()
 		for imp in invalidations {
-			b.v_build_module(vexe, imp)
+			rebuild_cmd, rebuild_code := b.v_build_module(vexe, imp)
+			if rebuild_code != 0 {
+				// find_invalidated_modules_by_files already saved the new hashes; drop
+				// them, or the next run skips the rebuild and links the stale object.
+				forget_source_hashes(all_files)
+				verror(usecache_module_error('Could not rebuild the changed module `${imp}` for `-usecache`.',
+					rebuild_code, os.dir(vexe), rebuild_cmd))
+			}
 		}
 	}
+}
+
+fn forget_source_hashes(all_files []string) {
+	mut cm := vcache.new_cache_manager(all_files)
+	cm.save('.hashes', 'all_files', '') or {}
 }
 
 pub fn (mut b Builder) find_invalidated_modules_by_files(all_files []string) []string {
@@ -185,7 +197,7 @@ pub fn (mut b Builder) find_invalidated_modules_by_files(all_files []string) []s
 	return invalidations
 }
 
-fn (mut b Builder) v_build_module(vexe string, imp_path string) {
+fn (mut b Builder) v_build_module(vexe string, imp_path string) (string, int) {
 	pwd := os.getwd()
 	defer {
 		os.chdir(pwd) or {}
@@ -201,7 +213,17 @@ fn (mut b Builder) v_build_module(vexe string, imp_path string) {
 		eprintln('> Builder.v_build_module: ${rebuild_cmd}')
 	}
 	// eprintln('> Builder.v_build_module: ${rebuild_cmd}')
-	os.system(rebuild_cmd)
+	return rebuild_cmd, os.system(rebuild_cmd)
+}
+
+fn usecache_module_error(what string, code int, vroot string, cmd string) string {
+	mut res := '\n==================\n${what}'
+	res += if code != 0 {
+		'\n`v build-module` exited with code ${code}; its errors are printed above.'
+	} else {
+		'\n`v build-module` reported success, so this is a V bug. Please report it at https://github.com/vlang/v/issues/new/choose .'
+	}
+	return res + '\nTo reproduce just that step, run this in ${os.quoted_path(vroot)}:\n\t${cmd}'
 }
 
 fn (mut b Builder) rebuild_cached_module(vexe string, imp_path string) string {
@@ -209,9 +231,10 @@ fn (mut b Builder) rebuild_cached_module(vexe string, imp_path string) string {
 		if b.pref.is_verbose {
 			println('Cached ${imp_path} .o file not found... Building .o file for ${imp_path}')
 		}
-		b.v_build_module(vexe, imp_path)
+		rebuild_cmd, rebuild_code := b.v_build_module(vexe, imp_path)
 		rebuilt_o := b.pref.cache_manager.mod_exists(imp_path, '.o', imp_path) or {
-			panic('could not rebuild cache module for ${imp_path}, error: ${err.msg()}')
+			verror(usecache_module_error('Could not build module `${imp_path}` for `-usecache`: no cached object file was produced.',
+				rebuild_code, os.dir(vexe), rebuild_cmd))
 		}
 		return rebuilt_o
 	}

--- a/vlib/v/cflag/cflags.v
+++ b/vlib/v/cflag/cflags.v
@@ -194,6 +194,13 @@ fn split_bare_windows_import_libs(value string) []string {
 	return parts
 }
 
+// is_c_source_operand reports whether opt is a bare source file, added with
+// `#flag /path/to/file.c`, and so cannot go into a `-c` compilation with one `-o`.
+pub fn is_c_source_operand(opt string) bool {
+	unq := opt.trim('"').trim("'")
+	return os.file_ext(unq).to_lower() in ['.c', '.cpp', '.cc', '.cxx', '.s'] && os.is_file(unq)
+}
+
 fn is_bare_windows_import_lib(value string) bool {
 	lib := value.trim_space()
 	return lib.len > '.lib'.len && lib.to_lower().ends_with('.lib') && !lib.contains('/')

--- a/vlib/v/cflag/cflags_test.v
+++ b/vlib/v/cflag/cflags_test.v
@@ -47,3 +47,34 @@ fn test_windows_import_lib_link_args_preserves_quoted_paths_and_converts_mixed_c
 	}.windows_import_lib_link_args()
 	assert args == ['"${direct_path}"', '-lVersion', '-lAdvapi32']
 }
+
+fn test_is_c_source_operand_recognizes_existing_translation_units() {
+	test_root := os.join_path(os.vtmp_dir(), 'v_cflag_source_operands')
+	os.mkdir_all(test_root) or { panic(err) }
+	defer {
+		os.rmdir_all(test_root) or {}
+	}
+	for name in ['first.c', 'second.CPP', 'third.cc', 'fourth.cxx', 'fifth.S'] {
+		path := os.join_path(test_root, name)
+		os.write_file(path, '') or { panic(err) }
+		assert is_c_source_operand(path)
+		assert is_c_source_operand('"${path}"')
+		assert is_c_source_operand("'${path}'")
+	}
+}
+
+fn test_is_c_source_operand_ignores_everything_that_is_not_a_source_file() {
+	test_root := os.join_path(os.vtmp_dir(), 'v_cflag_non_source_operands')
+	os.mkdir_all(test_root) or { panic(err) }
+	defer {
+		os.rmdir_all(test_root) or {}
+	}
+	for name in ['header.h', 'prebuilt.o', 'prebuilt.a'] {
+		path := os.join_path(test_root, name)
+		os.write_file(path, '') or { panic(err) }
+		assert !is_c_source_operand(path)
+	}
+	assert !is_c_source_operand('-DFOO=1')
+	assert !is_c_source_operand('-Wall')
+	assert !is_c_source_operand(os.join_path(test_root, 'not_written_out.c'))
+}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -1551,31 +1551,35 @@ pub fn (mut g Gen) write_typeof_functions() {
 				g.writeln('\tif (sidx == _${sym.cname}_${sub_sym.cname}_index) return "${util.strip_main_name(sub_sym.name)}";')
 			}
 			g.writeln2('\treturn "unknown ${util.strip_main_name(sym.name)}";', '}')
-			// Avoid duplicate symbol '_v_typeof_interface_idx_IError' when using -usecache
-			if g.pref.build_mode != .build_module {
-				interface_idx_static_prefix := if g.pref.is_o { 'static ' } else { '' }
-				g.definitions.writeln('${interface_idx_static_prefix}u32 v_typeof_interface_idx_${sym.cname}(u32 sidx);')
-				g.writeln2('',
-					'${interface_idx_static_prefix}u32 v_typeof_interface_idx_${sym.cname}(u32 sidx) {')
-				if g.pref.parallel_cc && interface_idx_static_prefix == '' {
-					g.extern_out.writeln('extern u32 v_typeof_interface_idx_${sym.cname}(u32 sidx);')
-				}
-				for t in impl_types {
-					sub_sym := g.table.sym(ast.mktyp(t))
-					if sub_sym.kind == .interface {
-						continue
-					}
-					if sub_sym.info is ast.Struct && sub_sym.info.is_unresolved_generic() {
-						continue
-					}
-					if g.pref.skip_unused && sub_sym.kind == .struct
-						&& sub_sym.idx !in g.table.used_features.used_syms {
-						continue
-					}
-					g.writeln('\tif (sidx == _${sym.cname}_${sub_sym.cname}_index) return ${u32(t.set_nr_muls(0))};')
-				}
-				g.writeln2('\treturn ${u32(ityp)};', '}')
+			// Avoid duplicate symbol '_v_typeof_interface_idx_IError' when using -usecache;
+			// build-module needs its own static copy, since it calls this too.
+			interface_idx_static_prefix := if g.pref.is_o || g.pref.build_mode == .build_module {
+				'static '
+			} else {
+				''
 			}
+			g.definitions.writeln('${interface_idx_static_prefix}u32 v_typeof_interface_idx_${sym.cname}(u32 sidx);')
+			g.writeln2('',
+				'${interface_idx_static_prefix}u32 v_typeof_interface_idx_${sym.cname}(u32 sidx) {')
+			if g.pref.parallel_cc && interface_idx_static_prefix == '' {
+				g.extern_out.writeln('extern u32 v_typeof_interface_idx_${sym.cname}(u32 sidx);')
+			}
+			for t in impl_types {
+				sub_sym := g.table.sym(ast.mktyp(t))
+				if sub_sym.kind == .interface {
+					continue
+				}
+				if sub_sym.info is ast.Struct && sub_sym.info.is_unresolved_generic() {
+					continue
+				}
+				if g.pref.skip_unused && sub_sym.kind == .struct
+					&& sub_sym.idx !in g.table.used_features.used_syms {
+					continue
+				}
+				// a build-module object has its own type table, so resolve the index at link time
+				g.writeln('\tif (sidx == _${sym.cname}_${sub_sym.cname}_index) return ${g.type_sidx(t.set_nr_muls(0))};')
+			}
+			g.writeln2('\treturn ${g.type_sidx(ityp)};', '}')
 		}
 	}
 	g.writeln2('// << typeof() support for sum types', '')
@@ -5093,8 +5097,8 @@ fn (mut g Gen) write_sumtype_casting_fn(fun SumtypeCastingFn) {
 	mut variant_name := g.get_sumtype_variant_name(got, got_sym)
 	if got_sym.kind == .alias && got_sym.info is ast.Alias
 		&& g.table.unaliased_type(got).idx() == exp.idx() {
-		g.definitions.writeln('${exp_cname} ${fun.fn_name}(${got_cname}* x, bool is_mut);')
-		sb.writeln('${exp_cname} ${fun.fn_name}(${got_cname}* x, bool is_mut) {')
+		g.definitions.writeln('${g.static_non_parallel}${exp_cname} ${fun.fn_name}(${got_cname}* x, bool is_mut);')
+		sb.writeln('${g.static_non_parallel}${exp_cname} ${fun.fn_name}(${got_cname}* x, bool is_mut) {')
 		sb.writeln('\treturn *(${exp_cname}*)x;')
 		sb.writeln('}\n')
 		g.auto_fn_definitions << sb.str()
@@ -5121,8 +5125,8 @@ fn (mut g Gen) write_sumtype_casting_fn(fun SumtypeCastingFn) {
 		got_cname = g.styp(got)
 		// g.definitions.writeln('${g.static_modifier} inline ${exp_cname} ${fun.fn_name}(${got_cname}* x);')
 		// sb.writeln('${g.static_modifier} inline ${exp_cname} ${fun.fn_name}(${got_cname}* x) {')
-		g.definitions.writeln('${exp_cname} ${fun.fn_name}(${got_cname}* x, bool is_mut);')
-		sb.writeln('${exp_cname} ${fun.fn_name}(${got_cname}* x, bool is_mut) {')
+		g.definitions.writeln('${g.static_non_parallel}${exp_cname} ${fun.fn_name}(${got_cname}* x, bool is_mut);')
+		sb.writeln('${g.static_non_parallel}${exp_cname} ${fun.fn_name}(${got_cname}* x, bool is_mut) {')
 		sb.writeln('\t${got_cname}* ptr = x;')
 		sb.writeln('\tif (!is_mut) { ptr = builtin__memdup(x, sizeof(${got_cname})); }')
 	}

--- a/vlib/v/gen/c/consts_and_globals.v
+++ b/vlib/v/gen/c/consts_and_globals.v
@@ -18,6 +18,14 @@ struct GlobalConstDef {
 	is_precomputed bool     // can be declared as a const in C: primitive, and a simple definition
 }
 
+// Under -usecache only the program runs `_vinit`, so it defines the consts, and the cached objects declare them.
+fn (g &Gen) const_visibility_kw(inited_later bool) string {
+	if inited_later && g.pref.build_mode == .build_module {
+		return 'extern '
+	}
+	return if g.pref.use_cache { '' } else { g.static_non_parallel }
+}
+
 fn (mut g Gen) const_decl(node ast.ConstDecl) {
 	g.inside_const = true
 	defer {
@@ -56,7 +64,7 @@ fn (mut g Gen) const_decl(node ast.ConstDecl) {
 					// eprintln('> const_name: ${const_name} | name: ${name} | styp: ${styp} | val: ${val}')
 					g.global_const_defs[name] = GlobalConstDef{
 						mod:       field.mod
-						def:       '${g.static_non_parallel}${styp} ${const_name} = ${val}; // fixed array const'
+						def:       '${g.const_visibility_kw(false)}${styp} ${const_name} = ${val}; // fixed array const'
 						dep_names: g.table.dependent_names_in_expr(field_expr)
 					}
 				} else if field.expr.is_fixed && !field.expr.has_index
@@ -74,7 +82,7 @@ fn (mut g Gen) const_decl(node ast.ConstDecl) {
 				typ := if field.expr.language == .c { 'char*' } else { 'string' }
 				g.global_const_defs[name] = GlobalConstDef{
 					mod:   field.mod
-					def:   '${g.static_non_parallel}${typ} ${const_name}; // a string literal, inited later'
+					def:   '${g.const_visibility_kw(true)}${typ} ${const_name}; // a string literal, inited later'
 					init:  '\t${const_name} = ${val};'
 					order: -1
 				}
@@ -126,7 +134,7 @@ fn (mut g Gen) const_decl(node ast.ConstDecl) {
 							val := g.expr_string(field.expr.expr)
 							g.global_const_defs[name] = GlobalConstDef{
 								mod:       field.mod
-								def:       '${g.static_non_parallel}${styp} ${const_name} = ${val}; // fixed array const'
+								def:       '${g.const_visibility_kw(false)}${styp} ${const_name} = ${val}; // fixed array const'
 								dep_names: g.table.dependent_names_in_expr(field_expr)
 							}
 							continue
@@ -251,7 +259,7 @@ fn (mut g Gen) const_decl_precomputed(mod string, name string, cname string, fie
 			}
 			g.global_const_defs[util.no_dots(field_name)] = GlobalConstDef{
 				mod:   mod
-				def:   '${g.static_non_parallel}${styp} ${cname}; // str inited later'
+				def:   '${g.const_visibility_kw(true)}${styp} ${cname}; // str inited later'
 				init:  '\t${cname} = ${init};'
 				order: -1
 			}
@@ -353,7 +361,7 @@ fn (mut g Gen) const_decl_init_later(mod string, name string, cname string, expr
 	if surround_cbr {
 		init.writeln('}')
 	}
-	mut def := '${g.static_non_parallel}${styp} ${cname}'
+	mut def := '${g.const_visibility_kw(true)}${styp} ${cname}'
 	if g.pref.parallel_cc {
 		// So that the const is usable in other files
 		// def = 'extern ${def}'
@@ -415,7 +423,7 @@ fn (mut g Gen) const_decl_init_later_msvc_string_fixed_array(mod string, name st
 			init.writeln(g.expr_string_surround('\t${cname}[${i}] = ', elem_expr, ';'))
 		}
 	}
-	mut def := '${g.static_non_parallel}${styp} ${cname}'
+	mut def := '${g.const_visibility_kw(true)}${styp} ${cname}'
 	g.global_const_defs[util.no_dots(name)] = GlobalConstDef{
 		mod:       mod
 		def:       '${def}; // inited later'
@@ -522,8 +530,8 @@ fn (mut g Gen) global_decl(node ast.GlobalDecl) {
 		g.inside_cinit = false
 		g.inside_global_decl = false
 	}
-	should_init := (!g.pref.use_cache && g.pref.build_mode != .build_module)
-		|| (g.pref.build_mode == .build_module && g.module_built == node.mod)
+	// The cached object owns the definition (#27592), but only the program has `_vinit`.
+	should_init := g.pref.build_mode != .build_module || g.module_built == node.mod
 	mut attributes := ''
 	first_field := node.fields[0]
 	if first_field.is_weak {
@@ -625,6 +633,8 @@ fn (mut g Gen) global_decl(node ast.GlobalDecl) {
 			continue
 		}
 		mut needs_ending_semicolon := false
+		// an inline `= value` on an extern declaration would define it a second time
+		is_extern_decl := field_visibility_kw == 'extern '
 		if field.language != .c || field.has_expr {
 			def_builder.write_string('${extern}${field_visibility_kw}${qualifiers}${styp} ${attributes}${final_c_name}')
 			needs_ending_semicolon = true
@@ -647,9 +657,11 @@ fn (mut g Gen) global_decl(node ast.GlobalDecl) {
 			} else if field.expr.is_literal() || cinit
 				|| (field.expr is ast.ArrayInit && field.expr.is_fixed)
 				|| is_simple_unsafe_expr {
-				// Simple literals can be initialized right away in global scope in C.
-				// e.g. `int myglobal = 10;`
-				def_builder.write_string(' = ${g.expr_string(field.expr)}')
+				if !is_extern_decl {
+					// Simple literals can be initialized right away in global scope in C.
+					// e.g. `int myglobal = 10;`
+					def_builder.write_string(' = ${g.expr_string(field.expr)}')
+				}
 			} else {
 				// More complex expressions need to be moved to `_vinit()`
 				// e.g. `__global ( mygblobal = 'hello ' + world' )`
@@ -663,7 +675,9 @@ fn (mut g Gen) global_decl(node ast.GlobalDecl) {
 			// don't zero globals from C code
 			g.type_default_vars.clear()
 			default_initializer := g.type_default(field.typ)
-			if default_initializer == '{0}' && should_init {
+			if is_extern_decl {
+				// zeroed by the definition in the cached module object
+			} else if default_initializer == '{0}' && should_init {
 				def_builder.write_string(' = {0}')
 			} else if default_initializer == '{E_STRUCT}' && should_init {
 				init = '\tmemcpy(${final_c_name}, (${styp}){${default_initializer}}, sizeof(${styp})); // global 4'

--- a/vlib/v/gen/c/embed.v
+++ b/vlib/v/gen/c/embed.v
@@ -88,7 +88,8 @@ fn (mut g Gen) gen_embedded_metadata() {
 	if g.pref.parallel_cc {
 		g.extern_out.writeln('extern v__embed_file__EmbedFileData _v_embed_file_metadata(u64 ef_hash);')
 	}
-	g.embedded_data.writeln('v__embed_file__EmbedFileData _v_embed_file_metadata(u64 ef_hash) {')
+	// emitted per translation unit, so it must not collide between cached objects
+	g.embedded_data.writeln('${g.static_non_parallel}v__embed_file__EmbedFileData _v_embed_file_metadata(u64 ef_hash) {')
 	g.embedded_data.writeln('\tv__embed_file__EmbedFileData res;')
 	g.embedded_data.writeln('\tmemset(&res, 0, sizeof(res));')
 	g.embedded_data.writeln('\tswitch(ef_hash) {')

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1433,8 +1433,11 @@ fn (mut g Gen) gen_fn_decl(node &ast.FnDecl, skip bool) {
 		}
 	}
 	arg_str := g.out.after(arg_start_pos)
-	if node.no_body || ((g.pref.use_cache && g.pref.build_mode != .build_module) && node.is_builtin
-		&& !g.pref.is_test) || skip {
+	// closure/overflow are is_builtin but also bundled, and build-module skips
+	// bundled modules, so their bodies are not in builtin.o
+	body_is_in_builtin_o := node.is_builtin && !util.should_bundle_module(node.mod)
+	if node.no_body || ((g.pref.use_cache && g.pref.build_mode != .build_module)
+		&& body_is_in_builtin_o && !g.pref.is_test) || skip {
 		// Just a function header. Builtin function bodies are defined in builtin.o
 		g.definitions.writeln(');') // NO BODY')
 		if g.inside_c_extern {

--- a/vlib/v/gen/c/testdata/check_combination_of_alias_and_sumtype.c.must_have
+++ b/vlib/v/gen/c/testdata/check_combination_of_alias_and_sumtype.c.must_have
@@ -1,1 +1,2 @@
+static main__Opt_T_main__ParseRes main__None_T_main__ParseRes_to_sumtype_main__Opt_T_main__ParseRes(main__None_T_main__ParseRes* x, bool is_mut) {
 // THE END.

--- a/vlib/v/gen/c/testdata/embed_issue_12035.c.must_have
+++ b/vlib/v/gen/c/testdata/embed_issue_12035.c.must_have
@@ -1,3 +1,3 @@
 static const v__embed_file__EmbedFileIndexEntry _v_embed_file_index[2];
 static const v__embed_file__EmbedFileIndexEntry _v_embed_file_index[2] = {
-v__embed_file__EmbedFileData _v_embed_file_metadata(u64 ef_hash) {
+static v__embed_file__EmbedFileData _v_embed_file_metadata(u64 ef_hash) {

--- a/vlib/v/markused/markused.v
+++ b/vlib/v/markused/markused.v
@@ -282,6 +282,14 @@ pub fn mark_used(mut table ast.Table, mut pref_ pref.Preferences, ast_files []&a
 
 	if pref_.use_cache {
 		walker.mark_by_sym_name('IError')
+		// A `build-module` object is compiled without -skip-unused, so it contains
+		// every fn of its module. Treat those as roots, so the consts, globals and
+		// types they reference survive here, where they are defined.
+		for fkey, func in all_fns {
+			if func.mod != 'main' && !util.should_bundle_module(func.mod) {
+				all_fn_root_names << fkey
+			}
+		}
 	}
 
 	walker.mark_root_fns(all_fn_root_names)

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -714,9 +714,11 @@ pub fn parse_args_and_show_errors(known_external_commands []string, args []strin
 				eprintln_cond(show_output && !res.is_quiet,
 					'`--enable-globals` flag is deprecated, please use `-enable-globals` instead')
 				res.enable_globals = true
+				res.build_options << '-enable-globals'
 			}
 			'-enable-globals' {
 				res.enable_globals = true
+				res.build_options << arg // the -usecache `v build-module` child needs it too
 			}
 			'--disable-explicit-mutability', '-disable-explicit-mutability' {
 				res.disable_explicit_mutability = true

--- a/vlib/v/pref/pref_test.v
+++ b/vlib/v/pref/pref_test.v
@@ -814,3 +814,14 @@ fn test_wayland_only_linux_session_surfaces_a_v_error_for_gg() {
 	assert output.contains('Wayland-only Linux session without `-d sokol_wayland`')
 	assert !output.contains('C error. This should never happen.')
 }
+
+fn test_enable_globals_is_forwarded_to_cached_module_builds() {
+	target := os.join_path(vroot, 'examples', 'hello_world.v')
+	for flag in ['-enable-globals', '--enable-globals'] {
+		prefs, command := pref.parse_args_and_show_errors([], [flag, target], false)
+		assert command == target
+		assert prefs.enable_globals
+		// the `-usecache` `v build-module` child is started from build_options
+		assert '-enable-globals' in prefs.build_options
+	}
+}

--- a/vlib/v/tests/usecache_c_interop_test.v
+++ b/vlib/v/tests/usecache_c_interop_test.v
@@ -1,0 +1,192 @@
+// vtest build: !windows
+// Regression test for -usecache: two C sources in one module, an interface
+// crossed by is/as, a __global with an initializer, and integer formatting.
+import os
+
+const vexe = @VEXE
+
+fn testsuite_begin() {
+	os.setenv('VCOLORS', 'never', true)
+}
+
+struct UsecacheProject {
+	root      string
+	cache_dir string
+	vtmp_dir  string
+}
+
+fn new_usecache_project(name string) !UsecacheProject {
+	root := os.join_path(os.vtmp_dir(), '${name}_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	p := UsecacheProject{
+		root:      root
+		cache_dir: os.join_path(root, '.cache')
+		vtmp_dir:  os.join_path(root, '.vtmp')
+	}
+	os.mkdir_all(p.cache_dir)!
+	os.mkdir_all(p.vtmp_dir)!
+	return p
+}
+
+fn (p &UsecacheProject) write(relpath string, content string) ! {
+	full := os.join_path(p.root, relpath)
+	os.mkdir_all(os.dir(full))!
+	os.write_file(full, content)!
+}
+
+// build_and_run compiles the project with -usecache into its own private cache,
+// then runs the result and returns its trimmed output.
+fn (p &UsecacheProject) build_and_run() !string {
+	// keep this build's cache out of the user's, so a stale entry cannot decide it
+	old_vcache := os.getenv_opt('VCACHE') or { '' }
+	old_vtmp := os.getenv_opt('VTMP') or { '' }
+	old_report := os.getenv_opt('V_C_ERROR_BUG_REPORT_DISABLED') or { '' }
+	os.setenv('VCACHE', p.cache_dir, true)
+	os.setenv('VTMP', p.vtmp_dir, true)
+	// A C error here is a V bug to fix locally, not something to upload.
+	os.setenv('V_C_ERROR_BUG_REPORT_DISABLED', '1', true)
+	defer {
+		restore_env('VCACHE', old_vcache)
+		restore_env('VTMP', old_vtmp)
+		restore_env('V_C_ERROR_BUG_REPORT_DISABLED', old_report)
+	}
+	exe := os.join_path(p.root, 'app')
+	mut build := os.new_process(vexe)
+	build.set_work_folder(p.root)
+	// -old-compiler keeps this aimed at the V1 `-usecache` implementation; on macOS
+	// the default compiler is V3, which ignores -usecache and caches modules itself.
+	build.set_args(['-old-compiler', '-usecache', '-enable-globals', '-o', exe, '.'])
+	build.set_redirect_stdio()
+	build.wait()
+	build_out := build.stdout_slurp() + build.stderr_slurp()
+	build_code := build.code
+	build.close()
+	if build_code != 0 {
+		return error('building with -usecache failed:\n${build_out}')
+	}
+	res := os.execute(os.quoted_path(exe))
+	if res.exit_code != 0 {
+		return error('the -usecache binary failed at runtime (exit ${res.exit_code}):\n${res.output}')
+	}
+	return res.output.trim_space()
+}
+
+fn restore_env(name string, old_value string) {
+	if old_value.len == 0 {
+		os.unsetenv(name)
+	} else {
+		os.setenv(name, old_value, true)
+	}
+}
+
+fn test_usecache_project_with_c_interop_interfaces_and_globals() {
+	p := new_usecache_project('v_usecache_c_interop')!
+	defer {
+		os.rmdir_all(p.root) or {}
+	}
+	p.write('v.mod', "Module {\n\tname: 'ucinterop'\n}\n")!
+
+	// a module binding two separate C source files
+	p.write('cbits/first.c', 'int uc_first(void) { return 7; }\n')!
+	p.write('cbits/second.c', 'int uc_second(void) { return 35; }\n')!
+	p.write('cbits/cbits.c.v', 'module cbits
+
+#flag @VMODROOT/cbits/first.c
+#flag @VMODROOT/cbits/second.c
+
+fn C.uc_first() int
+fn C.uc_second() int
+
+pub fn first() int {
+	return C.uc_first()
+}
+
+pub fn second() int {
+	return C.uc_second()
+}
+')!
+
+	// an interface crossed by a cached module: as_size reaches
+	// v_typeof_interface_idx_*, is_large the interface index symbols
+	p.write('shapes/shapes.v', 'module shapes
+
+pub interface Sized {
+	size() int
+}
+
+pub struct Small {}
+
+pub fn (s Small) size() int {
+	return 1
+}
+
+pub struct Large {}
+
+pub fn (l Large) size() int {
+	return 100
+}
+
+pub fn pick(large bool) Sized {
+	if large {
+		return Large{}
+	}
+	return Small{}
+}
+
+pub fn as_size(s Sized) int {
+	l := s as Large
+	return l.size()
+}
+
+pub fn is_large(s Sized) bool {
+	return s is Large
+}
+')!
+
+	// a global with an initializer: only the program emits the `_vinit` that assigns it
+	p.write('registry/registry.v', 'module registry
+
+__global uc_counter = new_counter()
+
+pub struct Counter {
+pub mut:
+	n int
+}
+
+fn new_counter() &Counter {
+	return &Counter{
+		n: 42
+	}
+}
+
+pub fn value() int {
+	return uc_counter.n
+}
+')!
+
+	p.write('main.v', "module main
+
+import cbits
+import shapes
+import registry
+
+fn main() {
+	// integer formatting reads builtin's `digit_pairs` const
+	println(cbits.first() + cbits.second())
+	println(shapes.pick(false).size() + shapes.pick(true).size())
+	println(shapes.as_size(shapes.pick(true)))
+	println(shapes.is_large(shapes.pick(true)))
+	println(registry.value())
+}
+")!
+
+	output := p.build_and_run()!
+	lines := output.split_into_lines().map(it.trim_space())
+	assert lines.len == 5, output
+	assert lines[0] == '42', output
+	assert lines[1] == '101', output
+	assert lines[2] == '100', output
+	assert lines[3] == 'true', output
+	assert lines[4] == '42', output
+	assert os.walk_ext(p.cache_dir, '.o').len > 0, 'no module objects were cached'
+}


### PR DESCRIPTION
This fixes the behavior of `-usecache` in the V1 compiler.

The flag reuses module objects compiled earlier, but the program and those objects disagreed about which one defines a symbol. Values filled in at startup were declared everywhere and defined nowhere, so printing a number crashed, and some generated helpers were defined twice. Modules that pull in C files with `#flag` could not be built at all, and a failed module build neither reported which module failed nor stopped the stale object from being linked. A second commit splits the `-stats` timing into the V part and the C compiler part.

Programs that use C interop, interfaces and globals now build and run with `-usecache`, including V itself, so repeated builds and `v test` can reuse the cached objects instead of recompiling the dependency tree each time.
