### PR TITLE
v3: reduce self-host pipeline latency

### DIFF
--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -1,6 +1,7 @@
 module driver
 
 import os
+import runtime
 import strconv
 import strings
 import time
@@ -48,6 +49,21 @@ const macos_v3_c_error_fallback = 'c_compilation_error'
 const macos_v3_c_error_compiler_file = 'compiler'
 const macos_v3_c_error_output_file = 'output'
 const macos_v3_c_error_source_name_file = 'source_name'
+
+fn configure_selfhost_parallelism(building_v bool) {
+	if !building_v || os.getenv('VJOBS') != '' || os.getenv('V3_NO_SELFHOST_JOB_OVERCOMMIT') != '' {
+		return
+	}
+	jobs := runtime.nr_jobs()
+	if jobs < 2 || jobs >= 12 {
+		return
+	}
+	overcommitted := int_min(12, jobs + jobs / 2)
+	if overcommitted > jobs {
+		os.setenv('VJOBS', overcommitted.str(), true)
+	}
+}
+
 const embedded_parallel_transform_node_limit = 10_000_000
 const scoped_transform_signature_headroom = 2048
 const v3_vvmrc_file_name = '.vvmrc'
@@ -3741,7 +3757,7 @@ fn cache_v3_type_diagnostics(a &flat.FlatAst, diagnostics []types.TypeError) []V
 			node:            int(diagnostic.node)
 			offset:          diagnostic.pos.offset
 			end:             diagnostic.pos.end
-			reported_column: diagnostic.pos.reported_column
+			reported_column: diagnostic.pos.reported_column()
 			details:         clone_string_list(diagnostic.details)
 		}
 	}
@@ -3777,12 +3793,7 @@ fn restore_v3_type_diagnostics(mut a flat.FlatAst, diagnostics []V3CachedTypeDia
 			kind:     .unknown_ident
 			node:     flat.NodeId(diagnostic.node)
 			file:     diagnostic.file.clone()
-			pos:      v3token.Pos{
-				id:              file_id
-				offset:          diagnostic.offset
-				end:             diagnostic.end
-				reported_column: diagnostic.reported_column
-			}
+			pos:      v3token.new_span(file_id, diagnostic.offset, diagnostic.end).with_reported_column(diagnostic.reported_column)
 			details:  clone_string_list(diagnostic.details)
 			severity: diagnostic.severity.clone()
 		}
@@ -4719,6 +4730,9 @@ fn canonicalize_scoped_node_cached(mut ast flat.FlatAst, idx int, scope voidptr,
 	if node.typ.len > 0 && scoped_value_owned(scope, node.typ.str) {
 		node.typ = ast.intern_text_ptr_cached(node.typ, mut cache_ptrs, mut cache_vals)
 	}
+	if node.type_text_id() == 0 && node.typ.len > 0 {
+		node.set_type_text_id(ast.type_text_id(node.typ))
+	}
 	old_params := node.generic_params()
 	if old_params.len == 0 {
 		return
@@ -4757,6 +4771,9 @@ fn canonicalize_scoped_node(mut ast flat.FlatAst, idx int, scope voidptr) {
 	}
 	if node.typ.len > 0 && scoped_value_owned(scope, node.typ.str) {
 		_, node.typ = ast.intern_text(node.typ)
+	}
+	if node.type_text_id() == 0 && node.typ.len > 0 {
+		node.set_type_text_id(ast.type_text_id(node.typ))
 	}
 	old_params := node.generic_params()
 	if old_params.len == 0 {
@@ -6315,6 +6332,7 @@ pub fn run(args []string) {
 		eprintln("builder error: ${input_file} doesn't exist")
 		exit(1)
 	}
+	configure_selfhost_parallelism(building_v)
 	if generate_c_project.len > 0 {
 		if backend != 'c' {
 			eprintln('`-generate-c-project` is currently supported only for the C backend')
@@ -7222,6 +7240,9 @@ pub fn run(args []string) {
 	pre_tc.warns_are_errors = effective_warns_are_errors
 	pre_tc.notes_are_errors = notes_are_errors
 	pre_tc.is_prod = prefs.is_prod
+	pre_tc.building_v_fast = building_v && os.getenv('V3_NO_BUILDING_V_FAST_CHECK') == ''
+	pre_tc.valid_diagnostic_fast = building_v && os.getenv('V3_NO_VALID_DIAGNOSTIC_FAST') == ''
+	pre_tc.valid_resolution_fast = building_v && os.getenv('V3_NO_VALID_RESOLUTION_FAST') == ''
 	pre_tc.suppress_dump_output = 'nop_dump' in prefs.user_defines
 	mut used_fns := map[string]bool{}
 	mut program_used_fns := map[string]bool{}
@@ -7229,6 +7250,7 @@ pub fn run(args []string) {
 	mut uses_generics := false
 	mut skip_transform_generics := true
 	mut transform_texts_canonical := cgen_cache_hit
+	mut retained_transform_scope := unsafe { nil }
 	mut trivial_literal_output := false
 	if !cgen_cache_hit {
 		pre_tc.verbose = prefs.verbose
@@ -7236,9 +7258,13 @@ pub fn run(args []string) {
 			pre_tc.enable_scoped_parallel_workers()
 		}
 		pre_tc.reject_unsupported_generics = is_selfhost
+		mut ckpre_sw := time.new_stopwatch()
 		set_diagnostic_files(mut pre_tc, user_files)
 		trivial_literal_output = test_files.len == 0 && !is_checker_fixture
 			&& markused.is_trivial_literal_output_program(a, pre_tc.diagnostic_files)
+		if verbose {
+			eprintln('  [ttime]   ck trivial gate  ${f64(ckpre_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+		}
 		mut cvsw := time.new_stopwatch()
 		pre_tc.collect(a)
 		if translated_mode {
@@ -7284,8 +7310,12 @@ pub fn run(args []string) {
 		} else {
 			check_was_parallel = pre_tc.check_semantics_opt(!current_no_parallel)
 		}
+		ckpre_sw.restart()
 		pre_tc.check_main_module_requirement(is_shared || test_files.len > 0
 			|| a.export_fn_names.len > 0)
+		if verbose {
+			eprintln('  [ttime]   ck main req      ${f64(ckpre_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+		}
 		if is_repl {
 			pre_tc.notices.clear()
 		}
@@ -7492,8 +7522,13 @@ pub fn run(args []string) {
 		}
 		b.step('markused')
 		b.metric('reachable symbols', used_fns.len, 'symbols')
-		if !is_repl {
+		mut tfpre_sw := time.new_stopwatch()
+		if !is_repl && !pre_tc.valid_diagnostic_fast {
 			pre_tc.diagnose_unused_private_declarations(used_fns)
+		}
+		if verbose {
+			eprintln('  [ttime] tf diag unused     ${f64(tfpre_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+			tfpre_sw.restart()
 		}
 		if pre_tc.notices.len > 0 {
 			checker_sql_warnings_only := is_checker_fixture && ast_contains_sql_expr(a)
@@ -7521,6 +7556,12 @@ pub fn run(args []string) {
 			}
 		}
 
+		// Checking is complete: from here on, resolve_type may serve unmodified
+		// source nodes straight from the checker's dense per-node cache
+		// (transform invalidates every id it rewrites).
+		if os.getenv('V3_NO_TRUST_CHECKED_TYPES').len == 0 {
+			pre_tc.trust_checked_expr_types = true
+		}
 		// Transform (match lowering, string/in lowering, etc.). Threaded transform is enabled
 		// by default for compatible builds, and `-no-parallel` disables both threaded transform
 		// and cgen.
@@ -7549,6 +7590,11 @@ pub fn run(args []string) {
 				&pre_tc, incremental_changed_names)
 			transform_texts_canonical = true
 		} else if scope_prealloc_transform {
+			if verbose {
+				eprintln('  [ttime] tf pre misc        ${f64(tfpre_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+				eprintln('  [leakcheck] pre-reserve: nodes ${a.nodes.len}/${a.nodes.cap} children ${a.children.len}/${a.children.cap} cache_mode ${cache_state.manager.enabled} skipgen ${skip_transform_generics}')
+				tfpre_sw.restart()
+			}
 			// Keep the large escaping AST/cache slabs in the compilation arena, while
 			// transformer indexes and per-body temporary state use a stage arena.
 			if cache_state.manager.enabled {
@@ -7556,11 +7602,21 @@ pub fn run(args []string) {
 			} else {
 				transform.reserve_parallel_transform_ast(mut a, skip_transform_generics)
 			}
+			if verbose {
+				eprintln('  [leakcheck] post-reserve: nodes ${a.nodes.len}/${a.nodes.cap} children ${a.children.len}/${a.children.cap}')
+				eprintln('  [ttime] tf reserve         ${f64(tfpre_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+				tfpre_sw.restart()
+			}
 			pre_tc.begin_sparse_transform_node_caches(a.nodes.len)
 			pre_tc.reserve_scoped_transform_metadata(scoped_transform_signature_headroom)
+			if verbose {
+				eprintln('  [ttime] tf sparse+meta     ${f64(tfpre_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+				tfpre_sw.restart()
+			}
 			base_transform_nodes := a.nodes.len
 			reserved_nodes_cap := a.nodes.cap
 			reserved_children_cap := a.children.cap
+			pre_scope_children_data := unsafe { a.children.data }
 			base_specialized_fns := a.specialized_fn_nodes.len
 			base_type_count := pre_tc.type_count()
 			base_symbol_count := pre_tc.symbol_count()
@@ -7568,6 +7624,10 @@ pub fn run(args []string) {
 			mut original_signature_names := map[string]bool{}
 			for name, _ in pre_tc.fn_ret_types {
 				original_signature_names[name] = true
+			}
+			if verbose {
+				eprintln('  [ttime] tf signames        ${f64(tfpre_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+				tfpre_sw.restart()
 			}
 			transform_scope := prealloc_scope_begin_for_v3()
 			mut scoped_owned_base_nodes := []int{}
@@ -7578,151 +7638,222 @@ pub fn run(args []string) {
 			parse_cache_enabled := pre_tc.type_cache_parse_enabled()
 			mut post_sw := time.new_stopwatch()
 			prealloc_scope_leave_for_v3(transform_scope)
-			retained_transform_regions = clone_scoped_transform_regions(retained_transform_regions)
-			pre_tc.promote_scoped_transform_interners(base_type_count, base_symbol_count,
-				transform_scope)
-			if verbose {
-				eprintln('  [ttime] promote interners  ${f64(post_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
-				post_sw.restart()
-			}
-			if a.nodes.cap == reserved_nodes_cap && a.children.cap == reserved_children_cap
-				&& !scoped_value_owned(transform_scope, a.nodes.data)
-				&& !scoped_value_owned(transform_scope, a.children.data) {
-				a.promote_transform_texts_from(base_text_count, transform_scope)
+			retain_transform_scope := building_v && backend == 'c' && !cache_state.manager.enabled
+				&& retained_transform_regions.len == 0
+				&& os.getenv('V3_NO_RETAIN_TRANSFORM_SCOPE') == ''
+			if retain_transform_scope {
+				// Cgen is the only remaining semantic consumer in this no-cache self-host
+				// path. Keep the typed transform arena alive through it instead of cloning
+				// the AST/checker payloads into the parent and immediately rebuilding the
+				// same type caches in the backend.
+				retained_transform_scope = transform_scope
+				transform_texts_canonical = true
+			} else {
+				retained_transform_regions =
+					clone_scoped_transform_regions(retained_transform_regions)
+				pre_tc.promote_scoped_transform_interners(base_type_count, base_symbol_count,
+					transform_scope)
 				if verbose {
-					eprintln('  [ttime] promote texts      ${f64(post_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+					eprintln('  [ttime] promote interners  ${f64(post_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 					post_sw.restart()
 				}
-				// Lowering can rewrite arbitrary pre-existing nodes, including type text
-				// on otherwise non-generic expressions. Publish every scope-owned
-				// text before releasing the outer arena. Without retained regions
-				// one fused pool pass (ownership check + table-hit reuse + clone)
-				// replaces the serial canonicalize + promote walks.
-				mut fused_text_promote := false
-				if retained_transform_regions.len == 0
-					&& os.getenv('V3_NO_FUSED_TEXT_PROMOTE') == '' {
-					fused_text_promote = transform.promote_scoped_texts_parallel(mut a,
-						transform_scope)
-					if fused_text_promote {
-						transform_texts_canonical = true
-					}
-				}
-				if verbose {
-					eprintln('  [ttime] canon nodes        ${f64(post_sw.elapsed().microseconds()) / 1000.0:7.2f} ms (n: ${a.nodes.len}, fused: ${fused_text_promote})')
-					post_sw.restart()
-				}
-				if !fused_text_promote {
-					mut scoped_text_flags := []u8{len: a.nodes.len}
-					if transform.scan_scoped_text_flags_parallel(a, transform_scope, mut
-						scoped_text_flags)
-					{
-						mut canon_cache_ptrs := unsafe { []voidptr{len: 4096} }
-						mut canon_cache_vals := []string{len: 4096}
-						for idx, flag in scoped_text_flags {
-							if flag != 0 {
-								canonicalize_scoped_node_cached(mut a, idx, transform_scope, mut
-									canon_cache_ptrs, mut canon_cache_vals)
+				if a.nodes.cap == reserved_nodes_cap && a.children.cap == reserved_children_cap
+					&& !scoped_value_owned(transform_scope, a.nodes.data)
+					&& !scoped_value_owned(transform_scope, a.children.data) {
+					a.promote_transform_texts_from(base_text_count, transform_scope)
+					if verbose {
+						mut dirty_texts := 0
+						for tv in a.text_values {
+							if tv.len > 0 && scoped_value_owned(transform_scope, tv.str) {
+								dirty_texts++
 							}
 						}
-					} else {
-						scoped_text_flags = []u8{}
-						for idx in 0 .. a.nodes.len {
-							canonicalize_scoped_node(mut a, idx, transform_scope)
+						eprintln('  [leakcheck] text table dirty ${dirty_texts} / ${a.text_values.len} (base_text_count ${base_text_count}, regions ${retained_transform_regions.len})')
+						eprintln('  [ttime] promote texts      ${f64(post_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+						post_sw.restart()
+					}
+					// Lowering can rewrite arbitrary pre-existing nodes, including type text
+					// on otherwise non-generic expressions. Publish every scope-owned
+					// text before releasing the outer arena. Without retained regions
+					// one fused pool pass (ownership check + table-hit reuse + clone)
+					// replaces the serial canonicalize + promote walks.
+					mut fused_text_promote := false
+					if retained_transform_regions.len == 0
+						&& os.getenv('V3_NO_FUSED_TEXT_PROMOTE') == '' {
+						fused_text_promote = transform.promote_scoped_texts_parallel(mut a,
+							transform_scope)
+						if fused_text_promote {
+							transform_texts_canonical = true
 						}
 					}
-					if retained_transform_regions.len > 0 {
-						outer_new_end := retained_transform_regions[0].new_start
-						promote_scoped_ast_nodes_flagged(mut a, base_transform_nodes,
-							outer_new_end, scoped_owned_base_nodes, transform_scope,
+					if verbose {
+						eprintln('  [ttime] canon nodes        ${f64(post_sw.elapsed().microseconds()) / 1000.0:7.2f} ms (n: ${a.nodes.len}, fused: ${fused_text_promote})')
+						post_sw.restart()
+					}
+					if !fused_text_promote {
+						mut scoped_text_flags := []u8{len: a.nodes.len}
+						if transform.scan_scoped_text_flags_parallel(a, transform_scope, mut
 							scoped_text_flags)
-						// Late lowering can rewrite nodes that live in a retained worker region
-						// while allocating their replacement text in the outer transform arena.
-						// Publish those strings before releasing that arena; the worker-owned
-						// fields in the same regions are canonicalized below from their own scope.
-						for region in retained_transform_regions {
-							canonicalize_scoped_transform_region_from_scope(mut a, region,
-								transform_scope)
+						{
+							mut canon_cache_ptrs := unsafe { []voidptr{len: 4096} }
+							mut canon_cache_vals := []string{len: 4096}
+							for idx, flag in scoped_text_flags {
+								if flag != 0 {
+									canonicalize_scoped_node_cached(mut a, idx, transform_scope, mut
+										canon_cache_ptrs, mut canon_cache_vals)
+								}
+							}
+						} else {
+							scoped_text_flags = []u8{}
+							for idx in 0 .. a.nodes.len {
+								canonicalize_scoped_node(mut a, idx, transform_scope)
+							}
 						}
-						last_worker_end := retained_transform_regions.last().new_end
-						promote_scoped_ast_nodes_flagged(mut a, last_worker_end, a.nodes.len,
-							[]int{}, transform_scope, scoped_text_flags)
-					} else {
-						// Workers report every rewritten base node. Publish those and the
-						// appended range without rebuilding the text table for the source AST.
-						promote_scoped_ast_nodes_flagged(mut a, base_transform_nodes, a.nodes.len,
-							scoped_owned_base_nodes, transform_scope, scoped_text_flags)
-						transform_texts_canonical = true
+						if retained_transform_regions.len > 0 {
+							outer_new_end := retained_transform_regions[0].new_start
+							promote_scoped_ast_nodes_flagged(mut a, base_transform_nodes,
+								outer_new_end, scoped_owned_base_nodes, transform_scope,
+								scoped_text_flags)
+							// Late lowering can rewrite nodes that live in a retained worker region
+							// while allocating their replacement text in the outer transform arena.
+							// Publish those strings before releasing that arena; the worker-owned
+							// fields in the same regions are canonicalized below from their own scope.
+							for region in retained_transform_regions {
+								canonicalize_scoped_transform_region_from_scope(mut a, region,
+									transform_scope)
+							}
+							last_worker_end := retained_transform_regions.last().new_end
+							promote_scoped_ast_nodes_flagged(mut a, last_worker_end, a.nodes.len,
+								[]int{}, transform_scope, scoped_text_flags)
+						} else {
+							// Workers report every rewritten base node. Publish those and the
+							// appended range without rebuilding the text table for the source AST.
+							promote_scoped_ast_nodes_flagged(mut a, base_transform_nodes,
+								a.nodes.len, scoped_owned_base_nodes, transform_scope,
+								scoped_text_flags)
+							transform_texts_canonical = true
+						}
 					}
-				}
-			} else {
-				clone_flat_ast_storage(mut a)
-				pre_tc.rebind_ast(a)
-			}
-			if a.specialized_fn_nodes.len != base_specialized_fns {
-				a.specialized_fn_nodes = a.specialized_fn_nodes.clone()
-				a.specialized_fn_modules = clone_int_string_map(a.specialized_fn_modules)
-				a.specialized_fn_files = clone_int_string_map(a.specialized_fn_files)
-			}
-			if verbose {
-				eprintln('  [ttime] promote ast nodes  ${f64(post_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
-				post_sw.restart()
-			}
-			promote_scoped_checker_node_caches(mut pre_tc, a, transform_scope, base_transform_nodes)
-			if verbose {
-				eprintln('  [ttime]   pc node caches   ${f64(post_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
-				post_sw.restart()
-			}
-			promote_scoped_signatures(mut pre_tc, original_signature_names)
-			if verbose {
-				eprintln('  [ttime]   pc signatures    ${f64(post_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
-				post_sw.restart()
-			}
-			promote_scoped_type_metadata(mut pre_tc)
-			// Transform type lookups can canonicalize alias keys/targets while the
-			// disposable arena is active. Re-own the table before releasing that arena;
-			// interface snapshotting below iterates every alias, including otherwise
-			// unreachable callback aliases.
-			pre_tc.type_aliases = clone_string_string_map(pre_tc.type_aliases)
-			transform_used_fns = clone_string_bool_map(transform_used_fns)
-			transform_errors = clone_string_list(transform_errors)
-			pre_tc.set_fresh_type_cache(parse_cache_enabled)
-			prealloc_scope_free_for_v3(transform_scope)
-			if verbose {
-				eprintln('  [ttime] promote checker    ${f64(post_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
-				post_sw.restart()
-			}
-			if retained_transform_regions.len > 0 {
-				if p.parsed_v_header_files > 0 {
-					// Header-only warm builds are small enough that transform may not
-					// force the pre-reserved flat arrays to grow. Publish their backing
-					// once in the compilation arena before releasing retained helper
-					// arenas; individual node text is promoted below.
+				} else {
+					if verbose {
+						eprintln('  [leakcheck] canon SKIPPED: nodes cap ${a.nodes.cap} vs ${reserved_nodes_cap} children cap ${a.children.cap} vs ${reserved_children_cap} nodes.len ${a.nodes.len} owned n ${scoped_value_owned(transform_scope,
+							a.nodes.data)} c ${scoped_value_owned(transform_scope, a.children.data)}')
+						eprintln('  [leakcheck] children.data pre ${u64(pre_scope_children_data)} now ${u64(unsafe { a.children.data })} moved ${pre_scope_children_data != unsafe { a.children.data }}')
+					}
+					// The flat arrays escaped into the stage arena, so their backing is
+					// cloned below — but each node's value/typ/params strings can live in
+					// that arena too. Publish them through the canonical text table first;
+					// skipping this dangled every transform-written node text whenever the
+					// pre-reserved capacity was outgrown.
+					a.promote_transform_texts_from(base_text_count, transform_scope)
+					for idx in 0 .. a.nodes.len {
+						canonicalize_scoped_node(mut a, idx, transform_scope)
+					}
 					clone_flat_ast_storage(mut a)
 					pre_tc.rebind_ast(a)
 				}
-				for region in retained_transform_regions {
-					if skip_transform_generics {
-						canonicalize_scoped_transform_region(mut a, region)
-					} else {
-						// Bounded generic batches can publish rewrites to any source node
-						// through this result arena, so verify every flat payload before
-						// releasing it.
-						for idx in 0 .. a.nodes.len {
-							canonicalize_scoped_node(mut a, idx, region.scope)
+				if a.specialized_fn_nodes.len != base_specialized_fns {
+					a.specialized_fn_nodes = a.specialized_fn_nodes.clone()
+					a.specialized_fn_modules = clone_int_string_map(a.specialized_fn_modules)
+					a.specialized_fn_files = clone_int_string_map(a.specialized_fn_files)
+				}
+				if verbose {
+					eprintln('  [ttime] promote ast nodes  ${f64(post_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+					post_sw.restart()
+				}
+				promote_scoped_checker_node_caches(mut pre_tc, a, transform_scope,
+					base_transform_nodes)
+				if verbose {
+					eprintln('  [ttime]   pc node caches   ${f64(post_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+					post_sw.restart()
+				}
+				promote_scoped_signatures(mut pre_tc, original_signature_names)
+				if verbose {
+					eprintln('  [ttime]   pc signatures    ${f64(post_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+					post_sw.restart()
+				}
+				promote_scoped_type_metadata(mut pre_tc)
+				// Transform type lookups can canonicalize alias keys/targets while the
+				// disposable arena is active. Re-own the table before releasing that arena;
+				// interface snapshotting below iterates every alias, including otherwise
+				// unreachable callback aliases.
+				pre_tc.type_aliases = clone_string_string_map(pre_tc.type_aliases)
+				transform_used_fns = clone_string_bool_map(transform_used_fns)
+				transform_errors = clone_string_list(transform_errors)
+				pre_tc.set_fresh_type_cache(parse_cache_enabled)
+				if verbose {
+					mut leaked_rc := 0
+					mut leaked_fv := 0
+					mut leaked_nv := 0
+					mut leaked_nt := 0
+					mut first_leak := -1
+					for idx in 0 .. pre_tc.resolved_call_names.len {
+						if idx < pre_tc.resolved_call_set.len && pre_tc.resolved_call_set[idx] {
+							name := pre_tc.resolved_call_names[idx]
+							if name.len > 0 && scoped_value_owned(transform_scope, name.str) {
+								leaked_rc++
+								if first_leak < 0 {
+									first_leak = idx
+								}
+							}
+						}
+						if idx < pre_tc.resolved_fn_value_set.len
+							&& pre_tc.resolved_fn_value_set[idx] {
+							name := pre_tc.resolved_fn_value_names[idx]
+							if name.len > 0 && scoped_value_owned(transform_scope, name.str) {
+								leaked_fv++
+							}
 						}
 					}
-					if scoped_value_owned(region.scope, a.nodes.data)
-						|| scoped_value_owned(region.scope, a.children.data) {
-						a = clone_flat_ast_after_transform(a)
+					for idx in 0 .. a.nodes.len {
+						node := a.nodes[idx]
+						if node.value.len > 0 && scoped_value_owned(transform_scope, node.value.str) {
+							leaked_nv++
+						}
+						if node.typ.len > 0 && scoped_value_owned(transform_scope, node.typ.str) {
+							leaked_nt++
+						}
+					}
+					eprintln('  [leakcheck] tf scope: rc ${leaked_rc} fv ${leaked_fv} node.value ${leaked_nv} node.typ ${leaked_nt} first_rc ${first_leak}')
+				}
+				prealloc_scope_free_for_v3(transform_scope)
+				if verbose {
+					eprintln('  [ttime] promote checker    ${f64(post_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+					post_sw.restart()
+				}
+				if retained_transform_regions.len > 0 {
+					if p.parsed_v_header_files > 0 {
+						// Header-only warm builds are small enough that transform may not
+						// force the pre-reserved flat arrays to grow. Publish their backing
+						// once in the compilation arena before releasing retained helper
+						// arenas; individual node text is promoted below.
+						clone_flat_ast_storage(mut a)
 						pre_tc.rebind_ast(a)
 					}
-					prealloc_scope_free_for_v3(region.scope)
+					for region in retained_transform_regions {
+						if skip_transform_generics {
+							canonicalize_scoped_transform_region(mut a, region)
+						} else {
+							// Bounded generic batches can publish rewrites to any source node
+							// through this result arena, so verify every flat payload before
+							// releasing it.
+							for idx in 0 .. a.nodes.len {
+								canonicalize_scoped_node(mut a, idx, region.scope)
+							}
+						}
+						if scoped_value_owned(region.scope, a.nodes.data)
+							|| scoped_value_owned(region.scope, a.children.data) {
+							a = clone_flat_ast_after_transform(a)
+							pre_tc.rebind_ast(a)
+						}
+						prealloc_scope_free_for_v3(region.scope)
+					}
+					transform_texts_canonical = true
 				}
-				transform_texts_canonical = true
+				// Type-resolution views can grow their by-file map while the transform arena
+				// is active. Recreate it in the compilation arena before later phases use it.
+				pre_tc.reset_resolution_type_view_cache()
 			}
-			// Type-resolution views can grow their by-file map while the transform arena
-			// is active. Recreate it in the compilation arena before later phases use it.
-			pre_tc.reset_resolution_type_view_cache()
 			if verbose {
 				eprintln('  [ttime] regions+views      ${f64(post_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 			}
@@ -9063,6 +9194,10 @@ Please install the corresponding development package/libraries and make sure the
 		'objects')
 	b.metric('C object publish races', c_object_cache_stats.publish_races, 'objects')
 	b.metric('C object input-snapshot races', c_object_cache_stats.input_snapshot_races, 'objects')
+	if retained_transform_scope != unsafe { nil } {
+		prealloc_scope_free_for_v3(retained_transform_scope)
+		retained_transform_scope = unsafe { nil }
+	}
 	if show_test_stats {
 		println('checker summary: 0 V errors, ${checker_warning_count} V warnings, ${checker_notice_count} V notices')
 	}

--- a/vlib/v3/errors/format.v
+++ b/vlib/v3/errors/format.v
@@ -76,8 +76,8 @@ pub fn formatted_source_error(kind string, message string, file &token.File, pos
 	position := file.position(pos)
 	path := relative_error_path(file.name)
 	mut result := strings.new_builder(message.len + 256)
-	reported_column := if pos.reported_column > 0 {
-		pos.reported_column
+	reported_column := if pos.reported_column() > 0 {
+		pos.reported_column()
 	} else {
 		position.column
 	}

--- a/vlib/v3/flat/flat.v
+++ b/vlib/v3/flat/flat.v
@@ -179,17 +179,30 @@ pub fn node_payload(generic_params []string) &NodePayload {
 // Node represents node data used by flat.
 pub struct Node {
 pub mut:
-	value          string
-	typ            string
-	payload        &NodePayload = unsafe { nil }
-	children_start i32
-	is_mut         bool
-pub:
+	value                string
+	typ                  string
+	payload              &NodePayload = unsafe { nil }
+	children_start       i32
+	is_mut               bool
 	kind                 NodeKind
 	op                   Op
 	skip_ownership_drops bool
 	children_count       i32
 	pos                  token.Pos
+}
+
+// type_text_id returns the compact canonical identity carried in this node's
+// otherwise-unused source-position metadata.
+@[inline]
+pub fn (n &Node) type_text_id() u16 {
+	return n.pos.type_text_id()
+}
+
+// set_type_text_id updates the compact type identity without disturbing a
+// diagnostic reported-column override.
+@[inline]
+pub fn (mut n Node) set_type_text_id(id u16) {
+	n.pos = n.pos.with_type_text_id(id)
 }
 
 // generic_params returns this node's uncommon generic/attribute metadata.
@@ -396,6 +409,34 @@ pub fn (a &FlatAst) text_count() int {
 	return a.text_values.len
 }
 
+// type_text_id returns the compact canonical identity for value, or 0 when it
+// has not been interned or the compilation's text table exceeds u16 range.
+pub fn (a &FlatAst) type_text_id(value string) u16 {
+	if value.len == 0 {
+		return 0
+	}
+	if id := a.text_ids[value] {
+		if id <= 65535 {
+			return u16(id)
+		}
+	}
+	return 0
+}
+
+// node_type_text_id preserves an already-matching identity without a map
+// lookup. A changed or newly synthesized spelling is assigned during the
+// ordered canonicalization pass after worker merge.
+@[inline]
+pub fn (a &FlatAst) node_type_text_id(value string, current u16) u16 {
+	if current != 0 {
+		canonical := a.text(TextId(current))
+		if canonical.len == value.len && canonical.str == value.str {
+			return current
+		}
+	}
+	return 0
+}
+
 // intern_node_texts_from canonicalizes managed payloads in nodes[start..].
 // This runs serially after parse/transform worker merges, so the text table
 // itself requires no synchronization and cannot retain worker-arena storage.
@@ -417,8 +458,12 @@ pub fn (mut a FlatAst) intern_node_texts_range(start int, end int) {
 	// Nothing is freed during this pass, so pointer keys stay valid.
 	mut cache_ptrs := unsafe { []voidptr{len: 4096} }
 	mut cache_vals := []string{len: 4096}
+	mut type_cache_ptrs := unsafe { []voidptr{len: 4096} }
+	mut type_cache_vals := []string{len: 4096}
+	mut type_cache_ids := []u16{len: 4096}
 	for idx in first .. end {
-		a.intern_node_texts_one(idx, mut cache_ptrs, mut cache_vals)
+		a.intern_node_texts_one(idx, mut cache_ptrs, mut cache_vals, mut type_cache_ptrs, mut
+			type_cache_vals, mut type_cache_ids)
 	}
 }
 
@@ -432,15 +477,22 @@ pub fn (mut a FlatAst) intern_node_texts_at(indexes []int) {
 	}
 	mut cache_ptrs := unsafe { []voidptr{len: 4096} }
 	mut cache_vals := []string{len: 4096}
+	mut type_cache_ptrs := unsafe { []voidptr{len: 4096} }
+	mut type_cache_vals := []string{len: 4096}
+	mut type_cache_ids := []u16{len: 4096}
 	for idx in indexes {
-		a.intern_node_texts_one(idx, mut cache_ptrs, mut cache_vals)
+		a.intern_node_texts_one(idx, mut cache_ptrs, mut cache_vals, mut type_cache_ptrs, mut
+			type_cache_vals, mut type_cache_ids)
 	}
 }
 
-fn (mut a FlatAst) intern_node_texts_one(idx int, mut cache_ptrs []voidptr, mut cache_vals []string) {
+fn (mut a FlatAst) intern_node_texts_one(idx int, mut cache_ptrs []voidptr, mut cache_vals []string, mut type_cache_ptrs []voidptr, mut type_cache_vals []string, mut type_cache_ids []u16) {
 	a.nodes[idx].value = a.intern_text_ptr_cached(a.nodes[idx].value, mut cache_ptrs, mut
 		cache_vals)
-	a.nodes[idx].typ = a.intern_text_ptr_cached(a.nodes[idx].typ, mut cache_ptrs, mut cache_vals)
+	type_id, canonical_type := a.intern_type_text_ptr_cached(a.nodes[idx].typ, mut type_cache_ptrs, mut
+		type_cache_vals, mut type_cache_ids)
+	a.nodes[idx].typ = canonical_type
+	a.nodes[idx].set_type_text_id(type_id)
 	params := a.nodes[idx].generic_params()
 	if params.len > 0 {
 		// Always rebuild the payload: the params array itself may live in a
@@ -451,6 +503,25 @@ fn (mut a FlatAst) intern_node_texts_one(idx int, mut cache_ptrs []voidptr, mut 
 		}
 		a.nodes[idx].set_generic_params(canonical_params)
 	}
+}
+
+// intern_type_text_ptr_cached canonicalizes a node type spelling and returns
+// its compact identity. Programs with more than 65535 texts use 0 and retain
+// the existing string-keyed fallback.
+pub fn (mut a FlatAst) intern_type_text_ptr_cached(value string, mut cache_ptrs []voidptr, mut cache_vals []string, mut cache_ids []u16) (u16, string) {
+	if value.len == 0 {
+		return 0, ''
+	}
+	slot := int((u64(voidptr(value.str)) >> 4) & 4095)
+	if cache_ptrs[slot] == voidptr(value.str) && cache_vals[slot].len == value.len {
+		return cache_ids[slot], cache_vals[slot]
+	}
+	id, canonical := a.intern_text(value)
+	compact_id := if id <= 65535 { u16(id) } else { u16(0) }
+	cache_ptrs[slot] = voidptr(value.str)
+	cache_vals[slot] = canonical
+	cache_ids[slot] = compact_id
+	return compact_id, canonical
 }
 
 // probe_text_ptr_cached is the read-only twin of intern_text_ptr_cached: it
@@ -472,6 +543,27 @@ pub fn (a &FlatAst) probe_text_ptr_cached(value string, mut cache_ptrs []voidptr
 		return canonical, true
 	}
 	return value, false
+}
+
+// probe_type_text_ptr_cached is the compact-id form used while parallel parse
+// workers probe the frozen master text table.
+pub fn (a &FlatAst) probe_type_text_ptr_cached(value string, mut cache_ptrs []voidptr, mut cache_vals []string, mut cache_ids []u16) (u16, string, bool) {
+	if value.len == 0 {
+		return 0, '', true
+	}
+	slot := int((u64(voidptr(value.str)) >> 4) & 4095)
+	if cache_ptrs[slot] == voidptr(value.str) && cache_vals[slot].len == value.len {
+		return cache_ids[slot], cache_vals[slot], true
+	}
+	if id := a.text_ids[value] {
+		canonical := a.text_values[int(id) - 1]
+		compact_id := if id <= 65535 { u16(id) } else { u16(0) }
+		cache_ptrs[slot] = voidptr(value.str)
+		cache_vals[slot] = canonical
+		cache_ids[slot] = compact_id
+		return compact_id, canonical, true
+	}
+	return 0, value, false
 }
 
 pub fn (mut a FlatAst) intern_text_ptr_cached(value string, mut cache_ptrs []voidptr, mut cache_vals []string) string {
@@ -596,7 +688,7 @@ pub fn (n Node) with_pos(pos token.Pos) Node {
 		value:                n.value
 		typ:                  n.typ
 		payload:              n.payload
-		pos:                  pos
+		pos:                  pos.with_type_text_id(n.type_text_id())
 		children_start:       n.children_start
 		children_count:       n.children_count
 		kind:                 n.kind
@@ -629,7 +721,9 @@ pub fn (n Node) clone_owned() Node {
 // add_node updates add node state for FlatAst.
 pub fn (mut a FlatAst) add_node(node Node) NodeId {
 	id := NodeId(a.nodes.len)
-	a.nodes << node
+	mut stored := node
+	stored.set_type_text_id(a.node_type_text_id(stored.typ, stored.type_text_id()))
+	a.nodes << stored
 	return id
 }
 

--- a/vlib/v3/gen/c/array.v
+++ b/vlib/v3/gen/c/array.v
@@ -149,7 +149,7 @@ fn (mut g FlatGen) gen_array_equality_literal_arg(names []string, arg_idx int, a
 		g.gen_array_literal_value(node, arr.elem_type)
 		return true
 	}
-	if arr := array_like_type(g.tc.parse_type(node.typ)) {
+	if arr := array_like_type(g.parse_node_type(&node)) {
 		g.gen_array_literal_value(node, arr.elem_type)
 		return true
 	}
@@ -296,7 +296,7 @@ fn (mut g FlatGen) gen_fixed_array_data_arg(id flat.NodeId, arr types.ArrayFixed
 			return
 		}
 	}
-	annotated_is_fixed := node.typ.len > 0 && array_fixed_type(g.tc.parse_type(node.typ)) != none
+	annotated_is_fixed := node.typ.len > 0 && array_fixed_type(g.parse_node_type(&node)) != none
 	if !annotated_is_fixed
 		&& fixed_array_option_payload_type(types.unwrap_pointer(g.usable_expr_type(id))) != none {
 		g.gen_expr(id)
@@ -774,7 +774,7 @@ fn (mut g FlatGen) to_fixed_size_call_fixed_type(id flat.NodeId) ?types.ArrayFix
 		return none
 	}
 	if node.typ.len > 0 {
-		if fixed := array_fixed_type(g.tc.parse_type(node.typ)) {
+		if fixed := array_fixed_type(g.parse_node_type(&node)) {
 			return fixed
 		}
 	}

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -2190,6 +2190,7 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 		// interface IDs too: newly boxed values must match the cached dispatch tables.
 		g.precompute_embedded_fields()
 		g.precompute_param_type_index()
+		g.precompute_shared_param_index()
 		g.precompute_sum_name_lookup()
 		g.collect_interface_impls()
 		g.precompute_required_interface_dispatch_methods()

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -160,6 +160,41 @@ mut:
 	verdicts   [4096]bool
 }
 
+@[heap]
+struct UsableExprTypeMemo {
+mut:
+	active     bool
+	generation u32
+	ids        []int
+	gens       []u32
+	values     []types.Type
+}
+
+fn (mut g FlatGen) begin_usable_expr_type_memo() {
+	if !g.memo_usable_expr_types {
+		return
+	}
+	if isnil(g.usable_expr_type_memo) {
+		g.usable_expr_type_memo = &UsableExprTypeMemo{
+			ids:    []int{len: 16384, init: -1}
+			gens:   []u32{len: 16384}
+			values: unsafe { []types.Type{len: 16384} }
+		}
+	}
+	mut memo := g.usable_expr_type_memo
+	memo.generation++
+	if memo.generation == 0 {
+		memo.generation = 1
+	}
+	memo.active = true
+}
+
+fn (mut g FlatGen) end_usable_expr_type_memo() {
+	if !isnil(g.usable_expr_type_memo) {
+		g.usable_expr_type_memo.active = false
+	}
+}
+
 fn (mut g FlatGen) preseed_type_first_seen(typ &types.Type) bool {
 	mut cache := g.preseed_type_seen
 	if isnil(cache) {
@@ -400,6 +435,13 @@ mut:
 	expected_enum                   string
 	known_expr_type_id              int        = -1
 	known_expr_type                 types.Type = types.Type(types.void_)
+	memo_usable_expr_types          bool
+	cache_struct_fields             bool
+	dedup_fn_decl_aliases           bool
+	prefix_param_scan               bool
+	lean_parallel_worker_init       bool
+	lazy_param_abi_merge            bool
+	usable_expr_type_memo           &UsableExprTypeMemo = unsafe { nil }
 	needed_optional_types           map[string]string
 	emitted_optional_types          map[string]bool
 	emitted_fns                     map[string]bool
@@ -434,8 +476,12 @@ mut:
 	scoped_fn_items_scope           voidptr
 	scoped_fn_output_path           string
 	scoped_fn_output_paths          []string
-	const_short_index               &ConstShortIndex = unsafe { nil }
-	mut_recv_facts                  &FnNameFactCache = unsafe { nil }
+	const_short_index               &ConstShortIndex      = unsafe { nil }
+	mut_recv_facts                  &FnNameFactCache      = unsafe { nil }
+	local_typedef_shadow_facts      &FnNameFactCache      = unsafe { nil }
+	local_global_shadow_facts       &ContextNameFactCache = unsafe { nil }
+	local_global_suffix_names       map[string]bool
+	local_global_suffix_names_ready bool
 	generic_app_cache               &GenericAppCache = unsafe { nil }
 	want_parallel_prep              bool
 	want_parallel_c_extern_prep     bool
@@ -512,6 +558,11 @@ fn (g &FlatGen) timing_profile(message string) {
 	if !isnil(g.tc) && g.tc.verbose {
 		eprintln(message)
 	}
+}
+
+@[inline]
+fn (g &FlatGen) parse_node_type(node &flat.Node) types.Type {
+	return g.tc.parse_type_ref(node.typ, node.type_text_id())
 }
 
 pub fn (g &FlatGen) c_flags() []string {
@@ -639,7 +690,7 @@ fn (g &FlatGen) ierror_pointer_alias_scope_index(name string) ?int {
 	}
 	mut scope := g.tc.cur_scope
 	mut idx := g.ierror_stack_pointer_aliases.len - 1
-	for scope != unsafe { nil } && scope != g.tc.file_scope && idx >= 0 {
+	for scope != unsafe { nil } && voidptr(scope) != voidptr(g.tc.file_scope) && idx >= 0 {
 		for existing in scope.names {
 			if existing == name {
 				return idx
@@ -856,6 +907,12 @@ fn (g &FlatGen) local_storage_is_pointer(name string) bool {
 // new creates a FlatGen value for c.
 pub fn FlatGen.new() FlatGen {
 	return FlatGen{
+		memo_usable_expr_types:          os.getenv('V3_NO_CGEN_EXPR_TYPE_MEMO') == ''
+		cache_struct_fields:             os.getenv('V3_NO_CGEN_STRUCT_FIELDS_CACHE') == ''
+		dedup_fn_decl_aliases:           os.getenv('V3_NO_DEDUP_FN_DECL_ALIASES') == ''
+		prefix_param_scan:               os.getenv('V3_NO_PREFIX_PARAM_SCAN') == ''
+		lean_parallel_worker_init:       os.getenv('V3_NO_LEAN_CGEN_WORKER_INIT') == ''
+		lazy_param_abi_merge:            os.getenv('V3_NO_LAZY_PARAM_ABI_MERGE') == ''
 		sb:                              strings.new_builder(4096)
 		fn_gen_items:                    []FlatFnGenItem{}
 		top_level_node_ids:              []int{}
@@ -999,6 +1056,8 @@ pub fn FlatGen.new() FlatGen {
 		c_name_cache:                    &CNameCache{}
 		const_short_index:               &ConstShortIndex{}
 		mut_recv_facts:                  &FnNameFactCache{}
+		local_global_shadow_facts:       &ContextNameFactCache{}
+		local_global_suffix_names:       map[string]bool{}
 		generic_app_cache:               &GenericAppCache{}
 		cached_support_identifiers:      map[string]bool{}
 		str_lits:                        []string{}
@@ -2093,6 +2152,9 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	g.scoped_fn_output_paths = []string{}
 	g.const_short_index = &ConstShortIndex{}
 	g.mut_recv_facts = &FnNameFactCache{}
+	g.local_global_shadow_facts = &ContextNameFactCache{}
+	g.local_global_suffix_names.clear()
+	g.local_global_suffix_names_ready = false
 	g.generic_app_cache = &GenericAppCache{}
 	g.want_parallel_prep = false
 	g.want_parallel_c_extern_prep = false
@@ -2104,6 +2166,7 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	}
 	mut cgsw := time.new_stopwatch()
 	g.tc.precompute_source_error_embed_index()
+	g.timing_profile('  [ttime]   ci embed idx     ${f64(cgsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 	if g.skip_generics {
 		// The declared-type tables are static for the whole generic-free cgen
 		// phase, so qualify_name is memoizable per (module, file) context.
@@ -2116,6 +2179,7 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	g.has_builtins = g.tc.has_builtins
 	g.precompute_shared_alias_pointer_shorts()
 	g.collect_gen_info()
+	g.precompute_local_global_suffix_names()
 	g.preintern_json_encode_strings()
 	g.timing_profile('  [ttime] cg collect_info    ${f64(cgsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 	cgsw.restart()
@@ -2158,7 +2222,7 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 		g.timing_profile('  [ttime]   cg predispatch   ${f64(cgsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 		cgsw.restart()
 		if !parallel_prep_done {
-			g.collect_fixed_storage_consts()
+			g.collect_fixed_storage_consts(false)
 			g.precompute_param_type_index()
 			g.precompute_concrete_optional_abi_fns()
 			if no_parallel {
@@ -2374,6 +2438,24 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	if !g.cache_split && !g.object_file_mode && g.output_path.len > 0
 		&& g.postinclude_directives.len == 0 && (g.fn_segs.len > 0 || fn_code.len > 0) {
 		mut prefix := unsafe { g.sb.reuse_as_plain_u8_array() }
+		$if !windows {
+			if os.getenv('V3_NO_MMAP_CGEN_OUTPUT') == '' {
+				write_c_output_mapped(g.output_path, prefix, g.fn_segs, fn_code) or {
+					g.output_error = err.msg()
+				}
+				unsafe { prefix.free() }
+				for segment in g.fn_segs {
+					unsafe { segment.free() }
+				}
+				g.fn_segs = []string{}
+				if fn_code.len > 0 {
+					unsafe { fn_code.free() }
+				}
+				g.sb = strings.new_builder(4096)
+				g.timing_profile('  [ttime] cg write out       ${f64(cgsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+				return ''
+			}
+		}
 		os.write_file_array(g.output_path, prefix) or { g.output_error = err.msg() }
 		unsafe { prefix.free() }
 		g.sb = strings.new_builder(4096)
@@ -2732,16 +2814,149 @@ mut:
 	texts  map[string]bool
 }
 
+// CollectGenFnPrep carries the context-dependent, table-write-free portion of
+// one function declaration's collect_gen_info work. Parallel workers compute
+// these values; the master still replays all registrations in source order.
+struct CollectGenFnPrep {
+mut:
+	prepared           bool
+	ptypes             []types.Type
+	shared_params      []bool
+	fn_ptr_ctypes      []string
+	return_type        types.Type = types.Type(types.void_)
+	decl_is_variadic   bool
+	first_param_is_mut bool
+}
+
+fn (g &FlatGen) new_collect_gen_info_view() FlatGen {
+	mut view := *g
+	view.tc = g.clone_parallel_type_checker()
+	view.c_name_cache = &CNameCache{}
+	view.param_types_cache = map[string][]types.Type{}
+	view.interface_receiver_cache = &StringLookupCache{}
+	view.normalize_call_cache = &StringLookupCache{}
+	view.flattened_generic_name_cache = &StringLookupCache{}
+	view.generic_struct_context_ct_cache = &StringLookupCache{}
+	view.struct_cname_cache = &StringLookupCache{}
+	view.unique_struct_ct_cache = &StringLookupCache{}
+	view.alias_method_cache = &StringLookupCache{}
+	view.import_alias_cache = &ContextStringLookupCache{}
+	view.enum_selector_cache = &ContextStringLookupCache{}
+	view.enum_method_cache = &ContextStringLookupCache{}
+	view.qualified_enum_method_cache = &ContextStringLookupCache{}
+	view.mut_recv_facts = &FnNameFactCache{}
+	view.local_global_shadow_facts = &ContextNameFactCache{}
+	view.generic_app_cache = &GenericAppCache{}
+	return view
+}
+
+fn (mut g FlatGen) compute_collect_gen_fn_prep(node flat.Node, module_name string, file string) CollectGenFnPrep {
+	g.tc.cur_file = file
+	g.tc.cur_module = module_name
+	typed_params := g.fn_node_param_types(node, module_name)
+	param_cap := if node.children_count < 64 { int(node.children_count) } else { 64 }
+	mut ptypes := []types.Type{cap: param_cap}
+	mut shared_params := []bool{}
+	mut fn_ptr_ctypes := []string{}
+	mut decl_is_variadic := false
+	mut first_param_is_mut := false
+	mut seen_param := false
+	mut param_idx := 0
+	for i in 0 .. node.children_count {
+		child := g.a.child_node(&node, i)
+		if node_kind_id(child) != 75 {
+			if g.prefix_param_scan {
+				break
+			}
+			continue
+		}
+		if child.typ.starts_with('...') {
+			decl_is_variadic = true
+		}
+		raw_pt := if param_idx < typed_params.len {
+			typed_params[param_idx]
+		} else {
+			g.tc.parse_resolution_type(child.typ)
+		}
+		mut pt := raw_pt
+		if shared_alias_ptr := g.cached_shared_alias_pointer_type_from_text(child.typ) {
+			pt = shared_alias_ptr
+		} else if raw_pt is types.Pointer && param_idx < typed_params.len {
+			typed_pt := typed_params[param_idx]
+			if child.is_mut && child.op == .amp && typed_pt is types.Pointer
+				&& typed_pt.base_type is types.Pointer {
+				pt = typed_pt
+			} else if typed_pt is types.Pointer && raw_pt.base_type is types.FnType
+				&& typed_pt.base_type is types.FnType {
+				// Specialized `mut T` parameters keep a pointer-to-function type in
+				// the flat declaration. The registered signature retains the concrete
+				// module identity when same-named callback parameter types coexist.
+				pt = typed_pt
+			}
+		} else if raw_pt !is types.Pointer && param_idx < typed_params.len {
+			pt = typed_params[param_idx]
+		}
+		if child.is_mut && child.op == .amp {
+			pt = g.explicit_mut_pointer_param_type(child, pt)
+		}
+		mut is_shared_param := false
+		if child.typ.len > 0 && child.typ[0] in [`s`, ` `, `\t`, `\n`, `\r`] {
+			if _ := shared_inner_type_text(child.typ) {
+				is_shared_param = true
+			}
+		}
+		if is_shared_param {
+			for shared_params.len <= param_idx {
+				shared_params << false
+			}
+			shared_params[param_idx] = true
+		} else if shared_params.len > 0 {
+			shared_params << false
+		}
+		param_idx++
+		if !seen_param {
+			first_param_is_mut = child.is_mut || raw_pt is types.Pointer || pt is types.Pointer
+				|| child.typ.starts_with('&') || child.typ.starts_with('mut ')
+			seen_param = true
+		}
+		ptypes << pt
+		if pt is types.FnType {
+			fn_ptr_ctypes << g.tc.c_type(pt)
+		}
+	}
+	ptypes = g.fn_param_types_with_implicit_veb_ctx(node, ptypes)
+	if shared_params.len > 0 {
+		shared_params = g.fn_shared_params_with_implicit_veb_ctx(node, shared_params)
+	}
+	return CollectGenFnPrep{
+		prepared:           true
+		ptypes:             ptypes
+		shared_params:      shared_params
+		fn_ptr_ctypes:      fn_ptr_ctypes
+		return_type:        g.fn_node_return_type(node, module_name)
+		decl_is_variadic:   decl_is_variadic
+		first_param_is_mut: first_param_is_mut
+	}
+}
+
 @[direct_array_access]
 fn (mut g FlatGen) collect_gen_info() {
+	profile := !isnil(g.tc) && g.tc.verbose
+	mut presw := time.new_stopwatch()
 	g.unused_param_seen = &UnusedParamSeen{}
 	g.reserve_collect_gen_info_maps()
+	if profile {
+		g.timing_profile('  [ttime]   ci reserve maps  ${f64(presw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+		presw.restart()
+	}
 	if g.incremental_fn_names.len == 0 {
 		g.collect_c_flags_from_directives()
 	}
 	g.c_flags << g.initial_c_flags
 	g.use_system_stdint = g.translation_unit_uses_inttypes()
-	profile := !isnil(g.tc) && g.tc.verbose
+	if profile {
+		g.timing_profile('  [ttime]   ci flags+stdint  ${f64(presw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+	}
 	cisw := time.new_stopwatch()
 	mut ci_fn_ns := u64(0)
 	mut ci_reg_ns := u64(0)
@@ -2758,7 +2973,9 @@ fn (mut g FlatGen) collect_gen_info() {
 	mut preferred_shared_fn_file_ranks := map[string]int{}
 	mut preferred_shared_fn_node_indexes := map[string]int{}
 	mut preferred_shared_fn_params := map[string][]bool{}
-	for node_idx in g.top_level_nodes() {
+	top_level_nodes := g.top_level_nodes()
+	fn_preps := g.collect_gen_info_fn_preps(top_level_nodes)
+	for top_level_pos, node_idx in top_level_nodes {
 		node := g.a.nodes[node_idx]
 		kind_id := node_kind_id(node)
 		if node.kind == .directive && node.value.starts_with('@attributes:') {
@@ -2797,82 +3014,22 @@ fn (mut g FlatGen) collect_gen_info() {
 			}
 			g.register_fn_decl_node(node.value, cur_module, flat.NodeId(node_idx))
 			ci_p0 := if profile { time.sys_mono_now() } else { u64(0) }
-			typed_params := g.fn_node_param_types(node, cur_module)
-			param_cap := if node.children_count < 64 { int(node.children_count) } else { 64 }
-			mut ptypes := []types.Type{cap: param_cap}
-			mut shared_params := []bool{}
-			mut decl_is_variadic := false
-			mut first_param_is_mut := false
-			mut seen_param := false
-			mut param_idx := 0
+			prep := if top_level_pos < fn_preps.len && fn_preps[top_level_pos].prepared {
+				fn_preps[top_level_pos]
+			} else {
+				g.compute_collect_gen_fn_prep(node, cur_module, cur_file)
+			}
+			ptypes := prep.ptypes
+			shared_params := prep.shared_params
+			decl_is_variadic := prep.decl_is_variadic
+			first_param_is_mut := prep.first_param_is_mut
 			g.tc.cur_file = cur_file
 			g.tc.cur_module = cur_module
-			for i in 0 .. node.children_count {
-				child := g.a.child_node(&node, i)
-				if node_kind_id(child) == 75 {
-					if child.typ.starts_with('...') {
-						decl_is_variadic = true
-					}
-					raw_pt := if param_idx < typed_params.len {
-						typed_params[param_idx]
-					} else {
-						g.tc.parse_resolution_type(child.typ)
-					}
-					mut pt := raw_pt
-					if shared_alias_ptr := g.cached_shared_alias_pointer_type_from_text(child.typ) {
-						pt = shared_alias_ptr
-					} else if raw_pt is types.Pointer && param_idx < typed_params.len {
-						typed_pt := typed_params[param_idx]
-						if child.is_mut && child.op == .amp && typed_pt is types.Pointer
-							&& typed_pt.base_type is types.Pointer {
-							pt = typed_pt
-						} else if typed_pt is types.Pointer && raw_pt.base_type is types.FnType
-							&& typed_pt.base_type is types.FnType {
-							// Specialized `mut T` parameters keep a pointer-to-function type in
-							// the flat declaration. The registered signature retains the concrete
-							// module identity when same-named callback parameter types coexist.
-							pt = typed_pt
-						}
-					} else if raw_pt !is types.Pointer && param_idx < typed_params.len {
-						pt = typed_params[param_idx]
-					}
-					if child.is_mut && child.op == .amp {
-						pt = g.explicit_mut_pointer_param_type(child, pt)
-					}
-					mut is_shared_param := false
-					if child.typ.len > 0 && child.typ[0] in [`s`, ` `, `\t`, `\n`, `\r`] {
-						if _ := shared_inner_type_text(child.typ) {
-							is_shared_param = true
-						}
-					}
-					if is_shared_param {
-						for shared_params.len <= param_idx {
-							shared_params << false
-						}
-						shared_params[param_idx] = true
-					} else if shared_params.len > 0 {
-						shared_params << false
-					}
-					param_idx++
-					if !seen_param {
-						first_param_is_mut = child.is_mut || raw_pt is types.Pointer
-							|| pt is types.Pointer || child.typ.starts_with('&')
-							|| child.typ.starts_with('mut ')
-						seen_param = true
-					}
-					ptypes << pt
-					if pt is types.FnType {
-						ct := g.tc.c_type(pt)
-						g.resolve_fn_ptr_type(ct)
-					}
-				}
+			for ct in prep.fn_ptr_ctypes {
+				g.resolve_fn_ptr_type(ct)
 			}
 			if profile {
 				ci_ptypes_ns += time.sys_mono_now() - ci_p0
-			}
-			ptypes = g.fn_param_types_with_implicit_veb_ctx(node, ptypes)
-			if shared_params.len > 0 {
-				shared_params = g.fn_shared_params_with_implicit_veb_ctx(node, shared_params)
 			}
 			if shared_params.len > 0 {
 				file_rank := c_backend_fn_file_rank(cur_file)
@@ -2892,7 +3049,7 @@ fn (mut g FlatGen) collect_gen_info() {
 				nonshared_fn_node_indexes << node_idx
 			}
 			ci_r0 := if profile { time.sys_mono_now() } else { u64(0) }
-			return_type := g.fn_node_return_type(node, cur_module)
+			return_type := prep.return_type
 			if profile {
 				ci_ret_ns += time.sys_mono_now() - ci_r0
 			}
@@ -3241,7 +3398,13 @@ fn (mut g FlatGen) preseed_unused_fn_ptr_param_types(node flat.Node, module_name
 		mut all_seen := true
 		for i in 0 .. node.children_count {
 			child := g.a.child_node(&node, i)
-			if node_kind_id(child) == 75 && child.typ !in seen.texts {
+			if node_kind_id(child) != 75 {
+				if g.prefix_param_scan {
+					break
+				}
+				continue
+			}
+			if child.typ !in seen.texts {
 				all_seen = false
 				break
 			}
@@ -3257,6 +3420,9 @@ fn (mut g FlatGen) preseed_unused_fn_ptr_param_types(node flat.Node, module_name
 	for i in 0 .. node.children_count {
 		child := g.a.child_node(&node, i)
 		if node_kind_id(child) != 75 {
+			if g.prefix_param_scan {
+				break
+			}
 			continue
 		}
 		if !isnil(g.unused_param_seen) {
@@ -3265,7 +3431,7 @@ fn (mut g FlatGen) preseed_unused_fn_ptr_param_types(node flat.Node, module_name
 		raw_type := if param_idx < typed_params.len {
 			typed_params[param_idx]
 		} else {
-			g.tc.parse_type(child.typ)
+			g.parse_node_type(child)
 		}
 		param_idx++
 		param_type := cgen_unalias_type(raw_type)
@@ -8814,20 +8980,55 @@ fn (mut g FlatGen) register_fn_decl_signature_type(name string, full_name string
 			break
 		}
 	}
+	if !g.dedup_fn_decl_aliases {
+		g.register_fn_decl_signature_alias(name, ptypes, shared_params, is_variadic, is_mut, rt)
+		cname := g.cname(name)
+		g.register_fn_decl_signature_alias(cname, ptypes, shared_params, is_variadic, is_mut, rt)
+		if g.tc.cur_module.len > 0 && g.tc.cur_module != 'main' && g.tc.cur_module != 'builtin' {
+			dotted_name := '${g.tc.cur_module}.${name}'
+			g.register_fn_decl_signature_alias(dotted_name, ptypes, shared_params, is_variadic,
+				is_mut, rt)
+			cdotted_name := g.cname(dotted_name)
+			g.register_fn_decl_signature_alias(cdotted_name, ptypes, shared_params, is_variadic,
+				is_mut, rt)
+		}
+		g.register_fn_decl_signature_alias(full_name, ptypes, shared_params, is_variadic, is_mut,
+			rt)
+		cfull_name := g.cname(full_name)
+		g.register_fn_decl_signature_alias(cfull_name, ptypes, shared_params, is_variadic, is_mut,
+			rt)
+		return
+	}
 	g.register_fn_decl_signature_alias(name, ptypes, shared_params, is_variadic, is_mut, rt)
 	cname := g.cname(name)
-	g.register_fn_decl_signature_alias(cname, ptypes, shared_params, is_variadic, is_mut, rt)
-	if g.tc.cur_module.len > 0 && g.tc.cur_module != 'main' && g.tc.cur_module != 'builtin' {
-		dotted_name := '${g.tc.cur_module}.${name}'
-		g.register_fn_decl_signature_alias(dotted_name, ptypes, shared_params, is_variadic, is_mut,
-			rt)
-		cdotted_name := g.cname(dotted_name)
-		g.register_fn_decl_signature_alias(cdotted_name, ptypes, shared_params, is_variadic,
-			is_mut, rt)
+	if cname != name {
+		g.register_fn_decl_signature_alias(cname, ptypes, shared_params, is_variadic, is_mut, rt)
 	}
-	g.register_fn_decl_signature_alias(full_name, ptypes, shared_params, is_variadic, is_mut, rt)
+	mut dotted_name := ''
+	mut cdotted_name := ''
+	if g.tc.cur_module.len > 0 && g.tc.cur_module != 'main' && g.tc.cur_module != 'builtin' {
+		dotted_name = '${g.tc.cur_module}.${name}'
+		if dotted_name != name && dotted_name != cname {
+			g.register_fn_decl_signature_alias(dotted_name, ptypes, shared_params, is_variadic,
+				is_mut, rt)
+		}
+		cdotted_name = g.cname(dotted_name)
+		if cdotted_name != name && cdotted_name != cname && cdotted_name != dotted_name {
+			g.register_fn_decl_signature_alias(cdotted_name, ptypes, shared_params, is_variadic,
+				is_mut, rt)
+		}
+	}
+	if full_name != name && full_name != cname && full_name != dotted_name
+		&& full_name != cdotted_name {
+		g.register_fn_decl_signature_alias(full_name, ptypes, shared_params, is_variadic, is_mut,
+			rt)
+	}
 	cfull_name := g.cname(full_name)
-	g.register_fn_decl_signature_alias(cfull_name, ptypes, shared_params, is_variadic, is_mut, rt)
+	if cfull_name != name && cfull_name != cname && cfull_name != dotted_name
+		&& cfull_name != cdotted_name && cfull_name != full_name {
+		g.register_fn_decl_signature_alias(cfull_name, ptypes, shared_params, is_variadic, is_mut,
+			rt)
+	}
 }
 
 fn (mut g FlatGen) register_fn_decl_node(name string, module_name string, id flat.NodeId) {
@@ -9649,6 +9850,7 @@ fn mut_optional_param_value_types_match(param_type types.Type, expected types.Ty
 }
 
 // gen_expr_with_expected_type emits expr with expected type output for c.
+@[direct_array_access]
 fn (mut g FlatGen) gen_expr_with_expected_type(id flat.NodeId, expected types.Type) {
 	has_known_actual := g.known_expr_type_id == int(id)
 	known_actual := g.known_expr_type
@@ -9662,7 +9864,7 @@ fn (mut g FlatGen) gen_expr_with_expected_type(id flat.NodeId, expected types.Ty
 	if expected is types.Enum {
 		g.expected_enum = expected.name
 	}
-	node := g.a.nodes[int(id)]
+	node := unsafe { &g.a.nodes[int(id)] }
 	expected_is_ierror := if node.kind == .none_expr || node.kind == .call {
 		g.is_ierror_type_name(semantic_expected.name())
 	} else {
@@ -9682,7 +9884,7 @@ fn (mut g FlatGen) gen_expr_with_expected_type(id flat.NodeId, expected types.Ty
 	}
 	if node.kind == .dump_expr {
 		if node.children_count > 0 {
-			g.gen_expr_with_expected_type(g.a.child(&node, 0), expected)
+			g.gen_expr_with_expected_type(g.a.child(node, 0), expected)
 		} else {
 			g.write('0')
 		}
@@ -9702,7 +9904,7 @@ fn (mut g FlatGen) gen_expr_with_expected_type(id flat.NodeId, expected types.Ty
 		return
 	}
 	if semantic_expected is types.MultiReturn && node.kind == .block {
-		if g.gen_multi_return_block_expr(&node, semantic_expected) {
+		if g.gen_multi_return_block_expr(node, semantic_expected) {
 			g.expected_expr_type = old_expected
 			g.expected_enum = old_expected_enum
 			return
@@ -9761,13 +9963,13 @@ fn (mut g FlatGen) gen_expr_with_expected_type(id flat.NodeId, expected types.Ty
 	}
 	if node.kind == .cast_expr && node.children_count > 0 {
 		if _ := g.shared_alias_pointer_type_from_text(node.value) {
-			g.gen_expr_with_expected_type(g.a.child(&node, 0), expected)
+			g.gen_expr_with_expected_type(g.a.child(node, 0), expected)
 			g.expected_expr_type = old_expected
 			g.expected_enum = old_expected_enum
 			return
 		}
 		if g.cast_alias_matches_expected_storage(node.value, expected) {
-			g.gen_expr_with_expected_type(g.a.child(&node, 0), expected)
+			g.gen_expr_with_expected_type(g.a.child(node, 0), expected)
 			g.expected_expr_type = old_expected
 			g.expected_enum = old_expected_enum
 			return
@@ -9816,7 +10018,7 @@ fn (mut g FlatGen) gen_expr_with_expected_type(id flat.NodeId, expected types.Ty
 			return
 		}
 		if node.kind == .postfix && node.op == .not && node.children_count == 1 {
-			child_id := g.a.child(&node, 0)
+			child_id := g.a.child(node, 0)
 			child := g.a.nodes[int(child_id)]
 			if child.kind == .array_literal {
 				g.gen_fixed_array_literal_value(child, fixed)
@@ -9895,7 +10097,7 @@ fn (mut g FlatGen) gen_expr_with_expected_type(id flat.NodeId, expected types.Ty
 	if node.kind == .prefix && node.op in [.minus, .plus] && node.children_count > 0
 		&& clean_expected is types.Primitive && clean_expected.props.has(.float)
 		&& clean_expected.size == 32 {
-		child_id := g.a.child(&node, 0)
+		child_id := g.a.child(node, 0)
 		child := g.a.nodes[int(child_id)]
 		if child.kind == .float_literal {
 			g.write(g.op_str(node.op))
@@ -10540,7 +10742,7 @@ fn (g &FlatGen) selector_declared_type(id flat.NodeId) ?types.Type {
 	mut resolved_base_type := g.selector_base_expr_type(base_id)
 	base_node := g.a.nodes[int(base_id)]
 	if base_node.typ.len > 0 {
-		annotated_base_type := g.tc.parse_type(base_node.typ)
+		annotated_base_type := g.parse_node_type(&base_node)
 		if annotated_base_type !is types.Unknown && annotated_base_type !is types.Void
 			&& !g.type_contains_generic_placeholder(annotated_base_type)
 			&& (resolved_base_type is types.Unknown
@@ -11047,7 +11249,7 @@ fn sizeof_selector_target(base string, fields []string) string {
 
 fn (g &FlatGen) cur_scope_has_local_name(name string) bool {
 	mut scope := g.tc.cur_scope
-	for scope != unsafe { nil } && scope != g.tc.file_scope {
+	for scope != unsafe { nil } && voidptr(scope) != voidptr(g.tc.file_scope) {
 		$if !ownership ? {
 			if name in scope.name_indexes {
 				return true
@@ -11093,7 +11295,7 @@ fn (mut g FlatGen) optional_none_type(id flat.NodeId) types.Type {
 	if int(id) >= 0 && int(id) < g.a.nodes.len {
 		node := g.a.nodes[int(id)]
 		if node.typ.starts_with('?') || node.typ.starts_with('!') {
-			return g.tc.parse_type(node.typ)
+			return g.parse_node_type(&node)
 		}
 	}
 	if typ := g.tc.expr_type(id) {
@@ -11415,6 +11617,22 @@ mut:
 	lengths_by_initial [256]u64
 }
 
+struct FixedStorageNodeScanArgs {
+	g                      &FlatGen
+	start                  int
+	end                    int
+	fixed_candidate_idents map[string]bool
+	fixed_candidate_shorts map[string]bool
+	ident_filter           &FixedStorageCandidateNameFilter
+	short_filter           &FixedStorageCandidateNameFilter
+mut:
+	address_items    []FixedStorageConstRefItem
+	ref_items        []FixedStorageConstRefItem
+	call_base_items  []FixedStorageConstRefItem
+	index_base_items []FixedStorageConstRefItem
+	fixed_safe_refs  map[int]bool
+}
+
 @[direct_array_access]
 fn fixed_storage_candidate_name_filter(names map[string]bool) FixedStorageCandidateNameFilter {
 	mut filter := FixedStorageCandidateNameFilter{}
@@ -11514,67 +11732,35 @@ fn (mut g FlatGen) const_address_can_force_fixed_storage(const_name string) bool
 	return const_type !is types.Array && const_type !is types.Unknown && const_type !is types.Void
 }
 
-fn (mut g FlatGen) collect_fixed_storage_consts() {
-	// Cached module headers deliberately materialize inferred array constants as
-	// dynamic arrays. Keep cached objects on the same ABI: promoting one of those
-	// constants to a C fixed array would make warm users read an Array header as
-	// element storage.
-	if g.cache_split {
-		return
-	}
-	old_module := g.tc.cur_module
-	old_file := g.tc.cur_file
+fn fixed_storage_node_scan_thread(arg voidptr) voidptr {
+	mut scan := unsafe { &FixedStorageNodeScanArgs(arg) }
+	scan.g.scan_fixed_storage_node_range(mut scan)
+	return unsafe { nil }
+}
+
+fn (g &FlatGen) scan_fixed_storage_node_range(mut scan FixedStorageNodeScanArgs) {
 	mut cur_module := 'main'
 	mut cur_file := ''
-	mut fixed_storage_candidates := map[string]bool{}
-	mut fixed_candidate_refs := map[string]bool{}
-	mut fixed_candidate_shorts := map[string]bool{}
-	mut dynamic_uses := map[string]bool{}
-	mut indexed_candidates := map[string]bool{}
-	mut fixed_safe_refs := map[int]bool{}
-	mut fixed_storage_cache := map[string]bool{}
-	mut primary_name_cache := map[string]string{}
-	g.collect_fixed_storage_const_candidates(mut fixed_storage_candidates, mut
-		fixed_candidate_refs, mut fixed_candidate_shorts, mut fixed_storage_cache, mut
-		primary_name_cache)
-	unique_const_ref_names := g.build_unique_const_ref_names()
-	mut const_ref_name_cache := map[string]string{}
-	mut ref_items := []FixedStorageConstRefItem{}
-	mut call_base_items := []FixedStorageConstRefItem{}
-	mut index_base_items := []FixedStorageConstRefItem{}
-	mut fixed_candidate_idents := fixed_candidate_refs.clone()
-	for short_name, _ in fixed_candidate_shorts {
-		fixed_candidate_idents[short_name] = true
-	}
-	fixed_candidate_ident_filter := fixed_storage_candidate_name_filter(fixed_candidate_idents)
-	fixed_candidate_short_filter := fixed_storage_candidate_name_filter(fixed_candidate_shorts)
-	for idx := 0; idx < g.a.nodes.len; idx++ {
+	for idx := scan.start; idx < scan.end; idx++ {
 		node := unsafe { &g.a.nodes[idx] }
 		kind_id := int(node.kind)
 		if kind_id == 77 {
 			cur_file = node.value
 			cur_module = 'main'
-			g.tc.cur_file = cur_file
-			g.tc.cur_module = cur_module
 			continue
 		}
 		if kind_id == 73 {
 			cur_module = node.value
-			g.tc.cur_file = cur_file
-			g.tc.cur_module = cur_module
 			continue
 		}
 		match node.kind {
 			.prefix {
-				if node.op != .amp || node.children_count == 0 {
-					continue
-				}
-				child := g.a.child_node(node, 0)
-				const_name := g.const_ref_name_from_node_cached_for_collect(child,
-					unique_const_ref_names, mut const_ref_name_cache)
-				if const_name.len > 0 && g.const_address_can_force_fixed_storage(const_name) {
-					primary := g.const_primary_name_cached(const_name, mut primary_name_cache)
-					g.fixed_storage_consts[primary] = true
+				if node.op == .amp && node.children_count > 0 {
+					scan.address_items << FixedStorageConstRefItem{
+						id:     g.a.child(node, 0)
+						file:   cur_file
+						module: cur_module
+					}
 				}
 			}
 			.index {
@@ -11583,12 +11769,12 @@ fn (mut g FlatGen) collect_fixed_storage_consts() {
 				}
 				base_id := g.a.child(node, 0)
 				base_node := g.a.node(base_id)
-				if g.const_ref_node_may_match_fixed_candidate(base_node, fixed_candidate_idents,
-					fixed_candidate_shorts, &fixed_candidate_ident_filter,
-					&fixed_candidate_short_filter)
+				if g.const_ref_node_may_match_fixed_candidate(base_node,
+					scan.fixed_candidate_idents, scan.fixed_candidate_shorts, scan.ident_filter,
+					scan.short_filter)
 				{
-					g.mark_const_ref_descendants(mut fixed_safe_refs, base_id)
-					index_base_items << FixedStorageConstRefItem{
+					g.mark_const_ref_descendants(mut scan.fixed_safe_refs, base_id)
+					scan.index_base_items << FixedStorageConstRefItem{
 						id:     base_id
 						file:   cur_file
 						module: cur_module
@@ -11600,17 +11786,16 @@ fn (mut g FlatGen) collect_fixed_storage_consts() {
 					base_id := g.a.child(node, 0)
 					base_node := g.a.node(base_id)
 					if g.const_ref_node_may_match_fixed_candidate(base_node,
-						fixed_candidate_idents, fixed_candidate_shorts,
-						&fixed_candidate_ident_filter, &fixed_candidate_short_filter)
+						scan.fixed_candidate_idents, scan.fixed_candidate_shorts,
+						scan.ident_filter, scan.short_filter)
 					{
-						g.mark_const_ref_descendants(mut fixed_safe_refs, base_id)
+						g.mark_const_ref_descendants(mut scan.fixed_safe_refs, base_id)
 					}
 				}
-				if g.const_ref_node_may_match_fixed_candidate(node, fixed_candidate_idents,
-					fixed_candidate_shorts, &fixed_candidate_ident_filter,
-					&fixed_candidate_short_filter)
+				if g.const_ref_node_may_match_fixed_candidate(node, scan.fixed_candidate_idents,
+					scan.fixed_candidate_shorts, scan.ident_filter, scan.short_filter)
 				{
-					ref_items << FixedStorageConstRefItem{
+					scan.ref_items << FixedStorageConstRefItem{
 						id:     flat.NodeId(idx)
 						file:   cur_file
 						module: cur_module
@@ -11626,10 +11811,10 @@ fn (mut g FlatGen) collect_fixed_storage_consts() {
 					base_id := g.a.child(fn_node, 0)
 					base_node := g.a.node(base_id)
 					if g.const_ref_node_may_match_fixed_candidate(base_node,
-						fixed_candidate_idents, fixed_candidate_shorts,
-						&fixed_candidate_ident_filter, &fixed_candidate_short_filter)
+						scan.fixed_candidate_idents, scan.fixed_candidate_shorts,
+						scan.ident_filter, scan.short_filter)
 					{
-						call_base_items << FixedStorageConstRefItem{
+						scan.call_base_items << FixedStorageConstRefItem{
 							id:     base_id
 							file:   cur_file
 							module: cur_module
@@ -11643,11 +11828,11 @@ fn (mut g FlatGen) collect_fixed_storage_consts() {
 				for ai in 1 .. node.children_count {
 					arg_id := g.a.child(node, ai)
 					arg_node := g.a.node(arg_id)
-					if g.const_ref_node_may_match_fixed_candidate(arg_node, fixed_candidate_idents,
-						fixed_candidate_shorts, &fixed_candidate_ident_filter,
-						&fixed_candidate_short_filter)
+					if g.const_ref_node_may_match_fixed_candidate(arg_node,
+						scan.fixed_candidate_idents, scan.fixed_candidate_shorts,
+						scan.ident_filter, scan.short_filter)
 					{
-						call_base_items << FixedStorageConstRefItem{
+						scan.call_base_items << FixedStorageConstRefItem{
 							id:     arg_id
 							file:   cur_file
 							module: cur_module
@@ -11656,11 +11841,10 @@ fn (mut g FlatGen) collect_fixed_storage_consts() {
 				}
 			}
 			.ident, .paren {
-				if g.const_ref_node_may_match_fixed_candidate(node, fixed_candidate_idents,
-					fixed_candidate_shorts, &fixed_candidate_ident_filter,
-					&fixed_candidate_short_filter)
+				if g.const_ref_node_may_match_fixed_candidate(node, scan.fixed_candidate_idents,
+					scan.fixed_candidate_shorts, scan.ident_filter, scan.short_filter)
 				{
-					ref_items << FixedStorageConstRefItem{
+					scan.ref_items << FixedStorageConstRefItem{
 						id:     flat.NodeId(idx)
 						file:   cur_file
 						module: cur_module
@@ -11668,6 +11852,119 @@ fn (mut g FlatGen) collect_fixed_storage_consts() {
 				}
 			}
 			else {}
+		}
+	}
+}
+
+fn (g &FlatGen) fixed_storage_node_scan_split() int {
+	target := g.a.nodes.len / 2
+	mut split := 0
+	mut best_distance := g.a.nodes.len
+	for idx in g.top_level_nodes() {
+		if idx <= 0 || idx >= g.a.nodes.len || g.a.nodes[idx].kind != .file {
+			continue
+		}
+		distance := if idx > target { idx - target } else { target - idx }
+		if distance < best_distance {
+			split = idx
+			best_distance = distance
+		}
+	}
+	return split
+}
+
+fn (mut g FlatGen) collect_fixed_storage_consts(allow_parallel bool) {
+	// Cached module headers deliberately materialize inferred array constants as
+	// dynamic arrays. Keep cached objects on the same ABI: promoting one of those
+	// constants to a C fixed array would make warm users read an Array header as
+	// element storage.
+	if g.cache_split {
+		return
+	}
+	mut fssw := time.new_stopwatch()
+	old_module := g.tc.cur_module
+	old_file := g.tc.cur_file
+	mut fixed_storage_candidates := map[string]bool{}
+	mut fixed_candidate_refs := map[string]bool{}
+	mut fixed_candidate_shorts := map[string]bool{}
+	mut dynamic_uses := map[string]bool{}
+	mut indexed_candidates := map[string]bool{}
+	mut fixed_safe_refs := map[int]bool{}
+	mut fixed_storage_cache := map[string]bool{}
+	mut primary_name_cache := map[string]string{}
+	g.collect_fixed_storage_const_candidates(mut fixed_storage_candidates, mut
+		fixed_candidate_refs, mut fixed_candidate_shorts, mut fixed_storage_cache, mut
+		primary_name_cache)
+	unique_const_ref_names := g.build_unique_const_ref_names()
+	mut const_ref_name_cache := map[string]string{}
+	mut address_items := []FixedStorageConstRefItem{}
+	mut ref_items := []FixedStorageConstRefItem{}
+	mut call_base_items := []FixedStorageConstRefItem{}
+	mut index_base_items := []FixedStorageConstRefItem{}
+	mut fixed_candidate_idents := fixed_candidate_refs.clone()
+	for short_name, _ in fixed_candidate_shorts {
+		fixed_candidate_idents[short_name] = true
+	}
+	fixed_candidate_ident_filter := fixed_storage_candidate_name_filter(fixed_candidate_idents)
+	fixed_candidate_short_filter := fixed_storage_candidate_name_filter(fixed_candidate_shorts)
+	g.timing_profile('  [ttime]         fs setup     ${f64(fssw.elapsed().microseconds()) / 1000.0:7.2f} ms (candidates: ${fixed_storage_candidates.len})')
+	fssw.restart()
+	split := if allow_parallel && os.getenv('V3_NO_PAR_FIXED_STORAGE_SCAN') == '' {
+		g.fixed_storage_node_scan_split()
+	} else {
+		0
+	}
+	mut scans := [
+		FixedStorageNodeScanArgs{
+			g:                      g
+			start:                  0
+			end:                    if split > 0 { split } else { g.a.nodes.len }
+			fixed_candidate_idents: fixed_candidate_idents
+			fixed_candidate_shorts: fixed_candidate_shorts
+			ident_filter:           &fixed_candidate_ident_filter
+			short_filter:           &fixed_candidate_short_filter
+			fixed_safe_refs:        map[int]bool{}
+		},
+		FixedStorageNodeScanArgs{
+			g:                      g
+			start:                  split
+			end:                    g.a.nodes.len
+			fixed_candidate_idents: fixed_candidate_idents
+			fixed_candidate_shorts: fixed_candidate_shorts
+			ident_filter:           &fixed_candidate_ident_filter
+			short_filter:           &fixed_candidate_short_filter
+			fixed_safe_refs:        map[int]bool{}
+		},
+	]
+	if split > 0 {
+		second_scan_thread := spawn fixed_storage_node_scan_thread(unsafe { voidptr(&scans[1]) })
+		g.scan_fixed_storage_node_range(mut scans[0])
+		_ = second_scan_thread.wait()
+	} else {
+		g.scan_fixed_storage_node_range(mut scans[0])
+	}
+	for scan in scans {
+		address_items << scan.address_items
+		ref_items << scan.ref_items
+		call_base_items << scan.call_base_items
+		index_base_items << scan.index_base_items
+		for id, safe in scan.fixed_safe_refs {
+			if safe {
+				fixed_safe_refs[id] = true
+			}
+		}
+	}
+	g.timing_profile('  [ttime]         fs node scan ${f64(fssw.elapsed().microseconds()) / 1000.0:7.2f} ms (refs: ${ref_items.len}, calls: ${call_base_items.len}, indexes: ${index_base_items.len})')
+	fssw.restart()
+	for item in address_items {
+		g.tc.cur_file = item.file
+		g.tc.cur_module = item.module
+		child := g.a.nodes[int(item.id)]
+		const_name := g.const_ref_name_from_node_cached_for_collect(child, unique_const_ref_names, mut
+			const_ref_name_cache)
+		if const_name.len > 0 && g.const_address_can_force_fixed_storage(const_name) {
+			primary := g.const_primary_name_cached(const_name, mut primary_name_cache)
+			g.fixed_storage_consts[primary] = true
 		}
 	}
 	if fixed_storage_candidates.len == 0 {
@@ -11717,11 +12014,12 @@ fn (mut g FlatGen) collect_fixed_storage_consts() {
 		}
 		g.fixed_storage_consts[const_name] = true
 	}
+	g.timing_profile('  [ttime]         fs replay    ${f64(fssw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 	g.tc.cur_module = old_module
 	g.tc.cur_file = old_file
 }
 
-fn (mut g FlatGen) mark_const_ref_descendants(mut ids map[int]bool, id flat.NodeId) {
+fn (g &FlatGen) mark_const_ref_descendants(mut ids map[int]bool, id flat.NodeId) {
 	if int(id) < 0 || int(id) >= g.a.nodes.len {
 		return
 	}
@@ -12397,7 +12695,7 @@ fn (g &FlatGen) infix_channel_type(id flat.NodeId, fallback types.Type) types.Ty
 	if int(id) >= 0 && int(id) < g.a.nodes.len {
 		node := g.a.nodes[int(id)]
 		if node.typ.len > 0 {
-			annotated := concrete_receiver_type(g.tc.parse_type(node.typ))
+			annotated := concrete_receiver_type(g.parse_node_type(&node))
 			if annotated is types.Channel {
 				return annotated
 			}
@@ -12417,7 +12715,7 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 		g.write(replacement)
 		return
 	}
-	node := g.a.nodes[int(id)]
+	node := unsafe { &g.a.nodes[int(id)] }
 	match node.kind {
 		.int_literal {
 			v := node.value.replace('_', '')
@@ -12490,7 +12788,7 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 		}
 		.dump_expr {
 			if node.children_count > 0 {
-				g.gen_expr(g.a.child(&node, 0))
+				g.gen_expr(g.a.child(node, 0))
 			} else {
 				g.write('0')
 			}
@@ -12646,8 +12944,8 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 				g.gen_assoc_infix_chain(node)
 				return
 			}
-			lhs_id := g.a.child(&node, 0)
-			rhs_id := g.a.child(&node, 1)
+			lhs_id := g.a.child(node, 0)
+			rhs_id := g.a.child(node, 1)
 			old_expected_enum := g.expected_enum
 			lhs_type := g.usable_expr_type(lhs_id)
 			rhs_type := g.usable_expr_type(rhs_id)
@@ -12664,7 +12962,7 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 			}
 			// An int-literal shift by >= 31 would be performed at C `int` width
 			// and wrap (`u64(1 << 40)`); widen the lhs so the shift is 64-bit.
-			if node.op == .left_shift && g.shift_needs_64bit_widening(&node) {
+			if node.op == .left_shift && g.shift_needs_64bit_widening(node) {
 				g.write('((u64)(')
 				g.gen_expr(lhs_id)
 				g.write(') << (')
@@ -12801,7 +13099,7 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 			g.expected_enum = old_expected_enum
 		}
 		.prefix {
-			child_id := g.a.child(&node, 0)
+			child_id := g.a.child(node, 0)
 			child := g.a.nodes[int(child_id)]
 			if node.value == 'shared' {
 				g.gen_expr(child_id)
@@ -12872,7 +13170,7 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 			} else if node.op == .amp && g.gen_current_mut_param_address(id) {
 				return
 			} else if node.op == .amp && node.typ.len > 0
-				&& g.gen_sum_pointer_value_expr(id, g.tc.parse_type(node.typ)) {
+				&& g.gen_sum_pointer_value_expr(id, g.parse_node_type(node)) {
 				return
 			} else if node.op == .amp && child.kind == .struct_init {
 				g.gen_heap_struct_init(child)
@@ -12956,8 +13254,8 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 			// fixed-array membership, and `!in` negation are lowered by the
 			// transformer (transform.transform_in_expr). Map membership stays as an
 			// in_expr so each backend can lower it directly.
-			lhs_id := g.a.child(&node, 0)
-			rhs_id := g.a.child(&node, 1)
+			lhs_id := g.a.child(node, 0)
+			rhs_id := g.a.child(node, 1)
 			rhs := g.a.nodes[int(rhs_id)]
 			rhs_type := g.usable_expr_type(rhs_id)
 			clean_rhs := types.unwrap_pointer(rhs_type)
@@ -13034,7 +13332,7 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 			}
 		}
 		.postfix {
-			child_id := g.a.child(&node, 0)
+			child_id := g.a.child(node, 0)
 			child := g.a.nodes[int(child_id)]
 			if node.op in [.inc, .dec] {
 				if atomic_type := g.atomic_selector_type(child_id) {
@@ -13056,11 +13354,11 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 		}
 		.paren {
 			g.write('(')
-			g.gen_expr(g.a.child(&node, 0))
+			g.gen_expr(g.a.child(node, 0))
 			g.write(')')
 		}
 		.selector {
-			base_id := g.a.child(&node, 0)
+			base_id := g.a.child(node, 0)
 			base := g.a.nodes[int(base_id)]
 			if base.kind == .typeof_expr {
 				if node.value == 'name' {
@@ -13438,7 +13736,7 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 			if g.gen_explicit_generic_callee_index(node) {
 				return
 			}
-			base_id := g.a.child(&node, 0)
+			base_id := g.a.child(node, 0)
 			mut base_type := g.usable_expr_type(base_id)
 			if storage_type := g.const_storage_type_from_node(g.a.nodes[int(base_id)]) {
 				base_type = storage_type
@@ -13453,7 +13751,7 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 				g.write('(*(${c_val}*)map__get(&')
 				g.gen_expr(base_id)
 				g.write(', &(${c_key}[]){')
-				g.gen_expr(g.a.child(&node, 1))
+				g.gen_expr(g.a.child(node, 1))
 				g.write('}, ')
 				g.gen_default_value_addr_for_type(base_type.value_type)
 				g.write('))')
@@ -13464,7 +13762,7 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 				if fixed_lit := g.fixed_array_literal_index_type(base_id, node) {
 					g.gen_expr_with_expected_type(base_id, types.Type(fixed_lit))
 					g.write('[')
-					g.gen_expr(g.a.child(&node, 1))
+					g.gen_expr(g.a.child(node, 1))
 					g.write(']')
 					return
 				}
@@ -13495,16 +13793,16 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 						}
 					}
 					g.write('[')
-					g.gen_expr(g.a.child(&node, 1))
+					g.gen_expr(g.a.child(node, 1))
 					g.write(']')
 				} else {
 					is_array_index, is_ptr, arr_type := array_index_info(index_base_type)
 					if is_array_index {
-						if g.gen_shared_array_index_value_expr(base_id, g.a.child(&node, 1)) {
+						if g.gen_shared_array_index_value_expr(base_id, g.a.child(node, 1)) {
 							return
 						}
 						index_type := if node.typ.starts_with('?') || node.typ.starts_with('!') {
-							g.tc.parse_type(node.typ)
+							g.parse_node_type(node)
 						} else {
 							g.array_index_type_for_expected_arg(arr_type.elem_type, node)
 						}
@@ -13514,7 +13812,7 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 							g.gen_expr(base_id)
 							g.write(if is_ptr { ')->data' } else { ').data' })
 							g.write(') + (')
-							g.gen_expr(g.a.child(&node, 1))
+							g.gen_expr(g.a.child(node, 1))
 							g.write(')))')
 							return
 						}
@@ -13526,7 +13824,7 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 						}
 						g.gen_expr(base_id)
 						g.write(', ')
-						g.gen_expr(g.a.child(&node, 1))
+						g.gen_expr(g.a.child(node, 1))
 						g.write('))')
 					} else {
 						is_runtime_array, runtime_is_ptr :=
@@ -13542,7 +13840,7 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 							mut index_type := g.usable_expr_type(id)
 							if index_type is types.Unknown || index_type is types.Void {
 								if node.typ.len > 0 && node.typ != 'unknown' {
-									index_type = g.tc.parse_type(node.typ)
+									index_type = g.parse_node_type(node)
 								}
 							}
 							index_type = g.array_index_type_for_expected_arg(index_type, node)
@@ -13553,7 +13851,7 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 							}
 							g.gen_expr(base_id)
 							g.write(', ')
-							g.gen_expr(g.a.child(&node, 1))
+							g.gen_expr(g.a.child(node, 1))
 							g.write('))')
 						} else if base_type is types.String {
 							// Parenthesize the base: a smartcast sum variant yields a deref
@@ -13562,7 +13860,7 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 							g.write('(')
 							g.gen_expr(base_id)
 							g.write(').str[')
-							g.gen_expr(g.a.child(&node, 1))
+							g.gen_expr(g.a.child(node, 1))
 							g.write(']')
 						} else if base_type is types.Pointer {
 							ptr_type := base_type
@@ -13570,19 +13868,19 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 								g.write('((u8*)')
 								g.gen_expr(base_id)
 								g.write(')[')
-								g.gen_expr(g.a.child(&node, 1))
+								g.gen_expr(g.a.child(node, 1))
 								g.write(']')
 							} else {
 								g.write('(')
 								g.gen_expr(base_id)
 								g.write(')[')
-								g.gen_expr(g.a.child(&node, 1))
+								g.gen_expr(g.a.child(node, 1))
 								g.write(']')
 							}
 						} else {
 							g.gen_expr(base_id)
 							g.write('[')
-							g.gen_expr(g.a.child(&node, 1))
+							g.gen_expr(g.a.child(node, 1))
 							g.write(']')
 						}
 					}
@@ -13617,9 +13915,9 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 			if ct.starts_with('fn_ptr:') {
 				ct = g.resolve_fn_ptr_type(ct)
 			}
-			cast_arg := g.a.child_node(&node, 0)
+			cast_arg := g.a.child_node(node, 0)
 			if shared_alias_ptr := g.shared_alias_pointer_type_from_text(node.value) {
-				g.gen_expr_with_expected_type(g.a.child(&node, 0), shared_alias_ptr)
+				g.gen_expr_with_expected_type(g.a.child(node, 0), shared_alias_ptr)
 				return
 			}
 			if cast_arg.kind == .nil_literal && target_type !is types.Pointer {
@@ -13627,30 +13925,30 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 				return
 			}
 			if semantic_target is types.Interface {
-				if !g.gen_interface_value_expr(g.a.child(&node, 0), semantic_target) {
-					g.gen_expr(g.a.child(&node, 0))
+				if !g.gen_interface_value_expr(g.a.child(node, 0), semantic_target) {
+					g.gen_expr(g.a.child(node, 0))
 				}
 			} else if semantic_target is types.SumType {
-				g.gen_sum_cast_expr(semantic_target, g.a.child(&node, 0))
+				g.gen_sum_cast_expr(semantic_target, g.a.child(node, 0))
 			} else if semantic_target is types.OptionType || semantic_target is types.ResultType {
-				g.gen_optional_arg(g.a.child(&node, 0), semantic_target)
+				g.gen_optional_arg(g.a.child(node, 0), semantic_target)
 			} else if target_type is types.Pointer
-				&& g.gen_sum_pointer_cast_expr(g.a.child(&node, 0), target_type, ct) {
+				&& g.gen_sum_pointer_cast_expr(g.a.child(node, 0), target_type, ct) {
 				return
 			} else if target_type is types.Pointer
-				&& g.gen_sum_variant_pointer_cast(g.a.child(&node, 0), target_type, ct) {
+				&& g.gen_sum_variant_pointer_cast(g.a.child(node, 0), target_type, ct) {
 				return
 			} else if target_type is types.Pointer
-				&& g.gen_pointer_cast_fixed_array_literal(g.a.child(&node, 0), target_type, ct) {
+				&& g.gen_pointer_cast_fixed_array_literal(g.a.child(node, 0), target_type, ct) {
 				return
 			} else if target_type is types.Pointer
-				&& g.gen_pointer_cast_from_array_ref(g.a.child(&node, 0), target_type, ct) {
+				&& g.gen_pointer_cast_from_array_ref(g.a.child(node, 0), target_type, ct) {
 				return
 			} else if target_type is types.Pointer
-				&& g.gen_pointer_cast_from_map_value_address(g.a.child(&node, 0), target_type) {
+				&& g.gen_pointer_cast_from_map_value_address(g.a.child(node, 0), target_type) {
 				return
 			} else if ct == 'map*' {
-				child_id := g.a.child(&node, 0)
+				child_id := g.a.child(node, 0)
 				child_node := g.a.nodes[int(child_id)]
 				if child_node.kind == .call && child_node.children_count > 0 {
 					callee := g.a.child_node(&child_node, 0)
@@ -13677,23 +13975,23 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 				}
 				return
 			} else if target_type is types.Pointer
-				&& g.gen_cast_from_mut_param_address(g.a.child(&node, 0), ct) {
+				&& g.gen_cast_from_mut_param_address(g.a.child(node, 0), ct) {
 				return
 			} else if target_type is types.Pointer
-				&& g.gen_cast_from_mut_pointer_param_value(g.a.child(&node, 0), ct) {
+				&& g.gen_cast_from_mut_pointer_param_value(g.a.child(node, 0), ct) {
 				return
 			} else if fixed := array_fixed_type(target_type) {
-				literal := g.fixed_array_compound_literal_expr(g.a.child(&node, 0), fixed)
+				literal := g.fixed_array_compound_literal_expr(g.a.child(node, 0), fixed)
 				if trimmed_space(literal).len > 0 {
 					g.write(literal)
 				} else {
 					g.write('(${ct})(')
-					g.gen_expr(g.a.child(&node, 0))
+					g.gen_expr(g.a.child(node, 0))
 					g.write(')')
 				}
 			} else {
 				g.write('(${ct})(')
-				g.gen_expr(g.a.child(&node, 0))
+				g.gen_expr(g.a.child(node, 0))
 				g.write(')')
 			}
 		}
@@ -13713,7 +14011,7 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 				if i > 0 {
 					g.write(', ')
 				}
-				g.gen_expr(g.a.child(&node, i))
+				g.gen_expr(g.a.child(node, i))
 			}
 			g.write('}')
 		}
@@ -13735,9 +14033,9 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 			if node.children_count > 1 {
 				g.write('({')
 				for bi in 0 .. node.children_count - 1 {
-					g.gen_node(g.a.child(&node, bi))
+					g.gen_node(g.a.child(node, bi))
 				}
-				last_id := g.a.child(&node, node.children_count - 1)
+				last_id := g.a.child(node, node.children_count - 1)
 				last := g.a.nodes[int(last_id)]
 				if last.kind == .expr_stmt {
 					g.gen_expr(g.a.child(&last, 0))
@@ -13751,7 +14049,7 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 				}
 				g.write(';})')
 			} else if node.children_count > 0 {
-				last_id := g.a.child(&node, 0)
+				last_id := g.a.child(node, 0)
 				last := g.a.nodes[int(last_id)]
 				if last.kind == .expr_stmt {
 					g.gen_expr(g.a.child(&last, 0))
@@ -13761,7 +14059,7 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 			}
 		}
 		.is_expr {
-			expr_id := g.a.child(&node, 0)
+			expr_id := g.a.child(node, 0)
 			expr_type := g.tc.resolve_type(expr_id)
 			clean := cgen_unalias_unwrap_all_pointers(expr_type)
 			expr_node := g.a.nodes[int(expr_id)]
@@ -13826,7 +14124,7 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 			}
 		}
 		.as_expr {
-			expr_id := g.a.child(&node, 0)
+			expr_id := g.a.child(node, 0)
 			expr_type0 := g.usable_expr_type(expr_id)
 			expr_type := if expr_type0 is types.Unknown || expr_type0 is types.Void {
 				g.tc.resolve_type(expr_id)
@@ -14851,7 +15149,7 @@ fn (g &FlatGen) fixed_array_literal_index_type(base_id flat.NodeId, node flat.No
 	} else if base.kind != .array_literal {
 		return none
 	}
-	mut elem_type := g.tc.parse_type(node.typ)
+	mut elem_type := g.parse_node_type(&node)
 	if elem_type is types.Void && literal.children_count > 0 {
 		elem_type = g.usable_expr_type(g.a.child(&literal, 0))
 	}
@@ -18802,7 +19100,13 @@ fn (g &FlatGen) const_collect_deps_inner(val_id flat.NodeId, mut deps []string, 
 			mut fn_shadowed := shadowed.clone()
 			for i in 0 .. node.children_count {
 				child := g.a.child_node(&node, i)
-				if child.kind == .param && child.value.len > 0 {
+				if child.kind != .param {
+					if g.prefix_param_scan {
+						break
+					}
+					continue
+				}
+				if child.value.len > 0 {
 					fn_shadowed[child.value] = true
 				}
 			}
@@ -20095,6 +20399,7 @@ fn (g &FlatGen) shift_count_const_value(id flat.NodeId, seen []string) ?int {
 // gen_prefix_op_operand writes a prefix operator and its operand, adding
 // parentheses when the operand is a binary expression: `!(a && b)` — without
 // them the `!` would bind to the first operand only.
+@[direct_array_access]
 fn (mut g FlatGen) gen_prefix_op_operand(op flat.Op, child_id flat.NodeId) {
 	g.write(g.op_str(op))
 	child := g.a.nodes[int(child_id)]

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -236,7 +236,10 @@ fn (mut g FlatGen) collect_fn_gen_items() []FlatFnGenItem {
 		}
 		g.emitted_fns[qfn] = true
 		cost := if par_prep {
-			0
+			// The parallel exact-cost pass overwrites this value before cgen
+			// dispatch. Retain the O(1) source-span estimate meanwhile so that
+			// pass can split its own uneven function bodies by work, not count.
+			flat_fn_gen_item_cost(g.a, item.node_id)
 		} else if prep {
 			if item.file != g.tc.cur_file || item.module != g.tc.cur_module {
 				prep_type_text_cache.clear()
@@ -4096,6 +4099,7 @@ fn (g &FlatGen) print_fn_selector_matches(c_name string, module_name string, sou
 fn (mut g FlatGen) gen_fn_in_module(node_id flat.NodeId, node flat.Node, module_name string, skip_prelude_scan bool) {
 	g.tc.cur_module = module_name
 	g.cur_fn_name = node.value
+	g.begin_usable_expr_type_memo()
 	g.known_expr_type_id = -1
 	g.ownership_return_index = 0
 	g.ownership_seen_return_sources.clear()
@@ -4251,6 +4255,7 @@ fn (mut g FlatGen) gen_fn_in_module(node_id flat.NodeId, node flat.Node, module_
 	g.loop_depth = 0
 	g.pending_loop_label = ''
 	g.pop_scope()
+	g.end_usable_expr_type_memo()
 }
 
 fn (mut g FlatGen) gen_export_wrapper_for_fn(node flat.Node, module_name string) {
@@ -4696,7 +4701,7 @@ fn (g &FlatGen) test_harness_fns() ([]TestHarnessFn, TestHarnessHooks) {
 							node_id:      child_id
 							name:         child.value
 							c_name:       cname
-							ret:          g.tc.parse_type(child.typ)
+							ret:          g.parse_node_type(&child)
 							file:         file_node.value
 							failure_line: g.test_fn_failure_line(child_id)
 						}
@@ -4808,23 +4813,27 @@ fn (g &FlatGen) is_supported_test_fn_decl(node flat.Node) bool {
 	if g.test_fn_param_count(node) != 0 {
 		return false
 	}
-	return test_harness_fn_return_supported(g.tc.parse_type(node.typ))
+	return test_harness_fn_return_supported(g.parse_node_type(&node))
 }
 
 fn (g &FlatGen) is_supported_test_hook_decl(node flat.Node) bool {
 	if node.generic_params().len > 0 {
 		return false
 	}
-	return g.test_fn_param_count(node) == 0 && g.tc.parse_type(node.typ) is types.Void
+	return g.test_fn_param_count(node) == 0 && g.parse_node_type(&node) is types.Void
 }
 
 fn (g &FlatGen) test_fn_param_count(node flat.Node) int {
 	mut count := 0
 	for i in 0 .. node.children_count {
 		child := g.a.child_node(&node, i)
-		if child.kind == .param {
-			count++
+		if child.kind != .param {
+			if g.prefix_param_scan {
+				break
+			}
+			continue
 		}
+		count++
 	}
 	return count
 }
@@ -5372,6 +5381,7 @@ fn (mut g FlatGen) gen_traced_call(id flat.NodeId, trace_name string) bool {
 }
 
 // gen_call emits call output for c.
+@[direct_array_access]
 fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 	mut fn_node := g.a.child_node(&node, 0)
 	target_name := g.call_target_name(g.a.child(&node, 0))
@@ -5845,7 +5855,7 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 		'new_map' {
 			if g.is_runtime_new_map_call(node) {
 				if node.typ.starts_with('map[') {
-					map_type := g.tc.parse_type(node.typ)
+					map_type := g.parse_node_type(&node)
 					if map_type is types.Map {
 						g.write_new_map(map_type.key_type, map_type.value_type)
 						return
@@ -7340,14 +7350,16 @@ fn (mut g FlatGen) mut_receiver_arg_wants_addr(fn_name string, arg_id flat.NodeI
 // signature tables, and asked once per call site — memoized.
 fn (mut g FlatGen) fn_first_param_is_mut_receiver(fn_name string) bool {
 	if !isnil(g.mut_recv_facts) {
-		if cached := g.mut_recv_facts.entries[fn_name] {
+		mut cache := g.mut_recv_facts
+		cached := cache.get(fn_name)
+		if cached != 0 {
 			return cached > 0
 		}
 	}
 	result := g.fn_first_param_is_mut_receiver_uncached(fn_name)
 	if !isnil(g.mut_recv_facts) {
 		mut cache := g.mut_recv_facts
-		cache.entries[fn_name] = if result { i8(1) } else { i8(-1) }
+		cache.put(fn_name, if result { i8(1) } else { i8(-1) })
 	}
 	return result
 }
@@ -9024,7 +9036,7 @@ fn (g &FlatGen) call_default_return_type(id flat.NodeId) types.Type {
 	if int(id) >= 0 && int(id) < g.a.nodes.len {
 		node := g.a.nodes[int(id)]
 		if node.typ.len > 0 && node.typ != 'unknown' {
-			typ := g.tc.parse_type(node.typ)
+			typ := g.parse_node_type(&node)
 			if typ !is types.Unknown && typ !is types.Void {
 				return typ
 			}
@@ -9035,7 +9047,7 @@ fn (g &FlatGen) call_default_return_type(id flat.NodeId) types.Type {
 
 fn (g &FlatGen) json_decode_result_type_for_call(node flat.Node) ?types.Type {
 	if node.typ.len > 0 {
-		ret_type := g.tc.parse_type(node.typ)
+		ret_type := g.parse_node_type(&node)
 		if ret_type is types.ResultType {
 			return ret_type
 		}
@@ -9378,7 +9390,8 @@ fn (g &FlatGen) interface_receiver_name(typ types.Type) string {
 		name = base
 	}
 	if !isnil(g.interface_receiver_cache) {
-		if cached := g.interface_receiver_cache.entries[name] {
+		mut cache := g.interface_receiver_cache
+		if cached := cache.get(name) {
 			return cached
 		}
 	}
@@ -9393,7 +9406,7 @@ fn (g &FlatGen) interface_receiver_name(typ types.Type) string {
 	}
 	if !isnil(g.interface_receiver_cache) {
 		mut cache := g.interface_receiver_cache
-		cache.entries[name] = result
+		cache.put(name, result)
 	}
 	return result
 }
@@ -9621,9 +9634,13 @@ fn (mut g FlatGen) fn_node_param_types_or_decl(node flat.Node, module_name strin
 	mut result := []types.Type{}
 	for i in 0 .. node.children_count {
 		child := g.a.child_node(&node, i)
-		if child.kind == .param {
-			result << g.tc.parse_resolution_type(child.typ)
+		if child.kind != .param {
+			if g.prefix_param_scan {
+				break
+			}
+			continue
 		}
+		result << g.tc.parse_resolution_type(child.typ)
 	}
 	return result
 }
@@ -9893,14 +9910,15 @@ fn resolved_call_matches_target(resolved string, target string) bool {
 fn (g &FlatGen) normalize_call_key(name string) string {
 	cache_key := '${g.tc.cur_module}\x01${g.tc.cur_file}\x01${name}'
 	if !isnil(g.normalize_call_cache) {
-		if cached := g.normalize_call_cache.entries[cache_key] {
+		mut cache := g.normalize_call_cache
+		if cached := cache.get(cache_key) {
 			return cached
 		}
 	}
 	result := g.normalize_call_key_uncached(name)
 	if !isnil(g.normalize_call_cache) {
 		mut cache := g.normalize_call_cache
-		cache.entries[cache_key] = result
+		cache.put(cache_key, result)
 	}
 	return result
 }
@@ -10091,7 +10109,7 @@ fn (mut g FlatGen) param_types_for_uncached(name string, fallback string) []type
 	if name.contains('__') {
 		exact_decl_types := g.fn_decl_param_types[name] or { []types.Type{} }
 		if params := g.tc.fn_param_types[name] {
-			return merge_decl_pointer_param_abi(params, exact_decl_types)
+			return g.merge_decl_pointer_param_abi(params, exact_decl_types)
 		}
 		if exact_decl_types.len > 0 {
 			return exact_decl_types
@@ -10100,7 +10118,7 @@ fn (mut g FlatGen) param_types_for_uncached(name string, fallback string) []type
 		dotted_decl_types := g.param_types_from_decl(dotted_name, dotted_name)
 		for candidate in [dotted_name, dotted_name.all_after_last('.')] {
 			if params := g.tc.fn_param_types[candidate] {
-				return merge_decl_pointer_param_abi(params, dotted_decl_types)
+				return g.merge_decl_pointer_param_abi(params, dotted_decl_types)
 			}
 		}
 		if dotted_decl_types.len > 0 {
@@ -10110,12 +10128,12 @@ fn (mut g FlatGen) param_types_for_uncached(name string, fallback string) []type
 	decl_types := g.param_types_from_decl(name, fallback)
 	for candidate in [name, fallback] {
 		if params := g.tc.fn_param_types[candidate] {
-			return merge_decl_pointer_param_abi(params, decl_types)
+			return g.merge_decl_pointer_param_abi(params, decl_types)
 		}
 		if candidate.starts_with('main.') {
 			short_name := candidate.all_after_last('.')
 			if params := g.tc.fn_param_types[short_name] {
-				return merge_decl_pointer_param_abi(params, decl_types)
+				return g.merge_decl_pointer_param_abi(params, decl_types)
 			}
 		}
 	}
@@ -10125,7 +10143,7 @@ fn (mut g FlatGen) param_types_for_uncached(name string, fallback string) []type
 	if name.contains('__') {
 		short_name := name.all_after_last('__')
 		if params := g.param_types_by_short[short_name] {
-			return merge_decl_pointer_param_abi(params, decl_types)
+			return g.merge_decl_pointer_param_abi(params, decl_types)
 		}
 	}
 	if generic_params := g.generic_receiver_method_param_types(name) {
@@ -10146,25 +10164,47 @@ fn (mut g FlatGen) param_types_for_uncached(name string, fallback string) []type
 	return []types.Type{}
 }
 
-fn merge_decl_pointer_param_abi(params []types.Type, decl_types []types.Type) []types.Type {
+fn (g &FlatGen) merge_decl_pointer_param_abi(params []types.Type, decl_types []types.Type) []types.Type {
 	if params.len == 0 {
 		return params
 	}
 	if params.len != decl_types.len {
 		return if decl_types.len > params.len { decl_types } else { params }
 	}
-	mut merged := params.clone()
-	mut changed := false
+	if !g.lazy_param_abi_merge {
+		mut merged := params.clone()
+		mut changed := false
+		for i, decl_type in decl_types {
+			if decl_type is types.Unknown || decl_type is types.Void {
+				continue
+			}
+			if decl_type.name() != merged[i].name() {
+				merged[i] = decl_type
+				changed = true
+			}
+		}
+		return if changed { merged } else { params }
+	}
 	for i, decl_type in decl_types {
 		if decl_type is types.Unknown || decl_type is types.Void {
 			continue
 		}
-		if decl_type.name() != merged[i].name() {
+		if decl_type.name() != params[i].name() {
+			mut merged := params.clone()
 			merged[i] = decl_type
-			changed = true
+			for j := i + 1; j < decl_types.len; j++ {
+				later := decl_types[j]
+				if later is types.Unknown || later is types.Void {
+					continue
+				}
+				if later.name() != merged[j].name() {
+					merged[j] = later
+				}
+			}
+			return merged
 		}
 	}
-	return if changed { merged } else { params }
+	return params
 }
 
 fn (g &FlatGen) generic_receiver_method_param_types(name string) ?[]types.Type {
@@ -10797,7 +10837,7 @@ fn (mut g FlatGen) gen_optional_arg_with_abi(arg_id flat.NodeId, expected types.
 		return true
 	}
 	if arg_node.typ.len > 0 {
-		raw_arg_type := g.tc.parse_type(arg_node.typ)
+		raw_arg_type := g.parse_node_type(&arg_node)
 		if raw_arg_type is types.OptionType || raw_arg_type is types.ResultType {
 			if concrete_abi {
 				g.gen_concrete_optional_arg_from_optional_expr(arg_id, raw_arg_type, expected,
@@ -11990,7 +12030,7 @@ fn (g &FlatGen) fn_value_call_param_types(callee_id flat.NodeId) ?[]types.Type {
 		}
 	}
 	if node.typ.len > 0 {
-		if ft := fn_type_from(g.tc.parse_type(node.typ)) {
+		if ft := fn_type_from(g.parse_node_type(&node)) {
 			return ft.params.clone()
 		}
 	}
@@ -12022,7 +12062,7 @@ fn (mut g FlatGen) guarded_anon_self_call(node flat.Node) ?GuardedAnonSelfCall {
 	}
 	callee_type := g.local_ident_type(callee_node.value) or {
 		if callee_node.typ.len > 0 {
-			g.tc.parse_type(callee_node.typ)
+			g.parse_node_type(&callee_node)
 		} else {
 			g.tc.resolve_type(callee_id)
 		}
@@ -13012,6 +13052,7 @@ fn type_is_void_pointer(typ types.Type) bool {
 	return false
 }
 
+@[direct_array_access]
 fn (mut g FlatGen) gen_transformed_method_ident_call(id flat.NodeId, node flat.Node, fn_node flat.Node) bool {
 	if fn_node.kind != .ident || node.children_count < 2 || !fn_node.value.contains('.') {
 		return false
@@ -13481,7 +13522,13 @@ fn is_generic_type(typ string) bool {
 fn (g &FlatGen) has_generic_params(node flat.Node) bool {
 	for i in 0 .. node.children_count {
 		child := g.a.child_node(&node, i)
-		if child.kind == .param && is_generic_type(child.typ) {
+		if child.kind != .param {
+			if g.prefix_param_scan {
+				break
+			}
+			continue
+		}
+		if is_generic_type(child.typ) {
 			return true
 		}
 	}
@@ -13724,7 +13771,7 @@ fn (g &FlatGen) find_alias_method(target string, method string) ?string {
 	cache_key := '${target}\n${method}'
 	mut cache := g.alias_method_cache
 	if !isnil(cache) {
-		if cached := cache.entries[cache_key] {
+		if cached := cache.get(cache_key) {
 			if cached.len > 0 {
 				return cached
 			}
@@ -13742,7 +13789,7 @@ fn (g &FlatGen) find_alias_method(target string, method string) ?string {
 				short_method := '${alias.all_after_last('.')}.${method}'
 				if short_method in g.tc.fn_param_types {
 					if !isnil(cache) {
-						cache.entries[cache_key] = alias_method
+						cache.put(cache_key, alias_method)
 					}
 					return alias_method
 				}
@@ -13751,7 +13798,7 @@ fn (g &FlatGen) find_alias_method(target string, method string) ?string {
 		}
 		if alias.contains('.') {
 			if !isnil(cache) {
-				cache.entries[cache_key] = alias_method
+				cache.put(cache_key, alias_method)
 			}
 			return alias_method
 		}
@@ -13761,12 +13808,12 @@ fn (g &FlatGen) find_alias_method(target string, method string) ?string {
 	}
 	if fallback.len > 0 {
 		if !isnil(cache) {
-			cache.entries[cache_key] = fallback
+			cache.put(cache_key, fallback)
 		}
 		return fallback
 	}
 	if !isnil(cache) {
-		cache.entries[cache_key] = ''
+		cache.put(cache_key, '')
 	}
 	return none
 }
@@ -14211,7 +14258,7 @@ fn (mut g FlatGen) preseed_c_extern_fn_ptr_types_with_filter(referenced map[stri
 		if !g.should_emit_c_extern_decl(cfn) {
 			continue
 		}
-		ret_type := g.tc.parse_type(node.typ)
+		ret_type := g.parse_node_type(&node)
 		g.preseed_fn_ptr_type(ret_type)
 		for j in 0 .. node.children_count {
 			param_id := g.a.child(&node, j)
@@ -14737,7 +14784,7 @@ const c_static_helper_symbols = {
 
 fn (mut g FlatGen) c_extern_decl_line(node flat.Node, cfn string) string {
 	mut sb := strings.new_builder(96)
-	ret_type := g.tc.parse_type(node.typ)
+	ret_type := g.parse_node_type(&node)
 	sb.write_string(g.fn_return_type_name(ret_type))
 	sb.write_string(' ')
 	call_conv := c_extern_calling_convention(cfn)
@@ -15054,20 +15101,23 @@ fn (g &FlatGen) fn_param_is_shared(fn_name string, idx int) bool {
 	if flags := g.fn_shared_params_resolved[fn_name] {
 		return idx < flags.len && flags[idx]
 	}
-	candidates := [
-		fn_name,
-		g.cname(fn_name),
-		fn_name.all_after_last('.'),
-		g.cname(fn_name.all_after_last('.')),
-	]
-	for candidate in candidates {
-		flags := g.fn_decl_shared_params[candidate] or {
-			g.tc.fn_shared_params[candidate] or { continue }
+	cname := g.cname(fn_name)
+	if cname != fn_name {
+		if flags := g.fn_shared_params_resolved[cname] {
+			return idx < flags.len && flags[idx]
 		}
-		// The first present entry is authoritative: an exact-name (possibly
-		// all-false) entry must stop the short-name fallback from matching an
-		// unrelated declaration.
-		return idx < flags.len && flags[idx]
+	}
+	short_name := fn_name.all_after_last('.')
+	if short_name != fn_name {
+		if flags := g.fn_shared_params_resolved[short_name] {
+			return idx < flags.len && flags[idx]
+		}
+	}
+	short_cname := g.cname(short_name)
+	if short_cname != short_name && short_cname != fn_name && short_cname != cname {
+		if flags := g.fn_shared_params_resolved[short_cname] {
+			return idx < flags.len && flags[idx]
+		}
 	}
 	return false
 }
@@ -15079,21 +15129,9 @@ fn (g &FlatGen) fn_param_shared_exact(fn_name string, idx int) ?bool {
 	if flags := g.fn_shared_params_resolved[fn_name] {
 		return idx < flags.len && flags[idx]
 	}
-	if flags := g.fn_decl_shared_params[fn_name] {
-		return idx < flags.len && flags[idx]
-	}
-	if flags := g.tc.fn_shared_params[fn_name] {
-		return idx < flags.len && flags[idx]
-	}
 	cname := g.cname(fn_name)
 	if cname != fn_name {
 		if flags := g.fn_shared_params_resolved[cname] {
-			return idx < flags.len && flags[idx]
-		}
-		if flags := g.fn_decl_shared_params[cname] {
-			return idx < flags.len && flags[idx]
-		}
-		if flags := g.tc.fn_shared_params[cname] {
 			return idx < flags.len && flags[idx]
 		}
 	}
@@ -15105,8 +15143,30 @@ fn (g &FlatGen) fn_param_is_shared_for_call(idx int, name1 string, name2 string,
 		return false
 	}
 	mut found_exact := false
-	for name in [name1, name2, name3, name4] {
-		if flag := g.fn_param_shared_exact(name, idx) {
+	if flag := g.fn_param_shared_exact(name1, idx) {
+		found_exact = true
+		if flag {
+			return true
+		}
+	}
+	if name2 != name1 {
+		if flag := g.fn_param_shared_exact(name2, idx) {
+			found_exact = true
+			if flag {
+				return true
+			}
+		}
+	}
+	if name3 != name1 && name3 != name2 {
+		if flag := g.fn_param_shared_exact(name3, idx) {
+			found_exact = true
+			if flag {
+				return true
+			}
+		}
+	}
+	if name4 != name1 && name4 != name2 && name4 != name3 {
+		if flag := g.fn_param_shared_exact(name4, idx) {
 			found_exact = true
 			if flag {
 				return true
@@ -15121,8 +15181,11 @@ fn (g &FlatGen) fn_param_is_shared_for_call(idx int, name1 string, name2 string,
 }
 
 fn (mut g FlatGen) precompute_shared_param_index() {
-	if !g.has_shared_params {
+	if !g.has_shared_params && g.tc.fn_shared_params.len == 0 {
 		return
+	}
+	for name, flags in g.tc.fn_shared_params {
+		g.fn_shared_params_resolved[name] = flags.clone()
 	}
 	for name, flags in g.fn_decl_shared_params {
 		// The name's own entry is authoritative (mirrors fn_param_is_shared's
@@ -15202,7 +15265,7 @@ fn (mut g FlatGen) fn_returns_veb_result(node flat.Node) bool {
 	if node.typ == 'veb.Result' {
 		return true
 	}
-	ret := g.tc.parse_type(node.typ)
+	ret := g.parse_node_type(&node)
 	return ret.name() == 'veb.Result'
 }
 
@@ -15351,9 +15414,13 @@ fn (mut g FlatGen) fn_node_param_types(node flat.Node, module_name string) []typ
 	}
 	mut explicit_params := 0
 	for i in 0 .. node.children_count {
-		if g.a.child_node(&node, i).kind == .param {
-			explicit_params++
+		if g.a.child_node(&node, i).kind != .param {
+			if g.prefix_param_scan {
+				break
+			}
+			continue
 		}
+		explicit_params++
 	}
 	// The module-scoped key first: a method name (`Recv.method`) is dotted but
 	// not module-qualified, and two modules declaring the same receiver/method

--- a/vlib/v3/gen/c/fn_parallel_d_v3_no_parallel.v
+++ b/vlib/v3/gen/c/fn_parallel_d_v3_no_parallel.v
@@ -8,6 +8,10 @@ fn par_cgen_prep_enabled() bool {
 	return false
 }
 
+fn (mut g FlatGen) collect_gen_info_fn_preps(_ []int) []CollectGenFnPrep {
+	return []CollectGenFnPrep{}
+}
+
 // gen_fns_dispatch emits all functions serially when v3 is built with the
 // internal `v3_no_parallel` define.
 fn (mut g FlatGen) gen_fns_dispatch(_ bool) {

--- a/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
@@ -13,7 +13,7 @@ const max_flat_cgen_jobs = 10
 const min_flat_cgen_parallel_items = 128
 // Bound each worker's retained scratch while generating compiler-sized ASTs.
 const scoped_cgen_worker_batches = 32
-const flat_cgen_chunks_per_job = 24
+const flat_cgen_chunks_per_job = 12
 
 $if !windows {
 	// FlatCgenChunkArgs represents flat cgen chunk args data used by c.
@@ -35,10 +35,52 @@ $if !windows {
 	}
 
 	struct FlatCgenDynamicArgs {
-		worker          voidptr
+		dispatcher      voidptr
+		worker_id       int
 		work_chunks_ptr voidptr
 		chunk_queue     chan int
 		reserve_cost    i64
+	mut:
+		worker      voidptr
+		setup_scope voidptr
+	}
+
+	struct CollectGenInfoFnPrepArgs {
+		g            voidptr // read-only &FlatGen master
+		node_ids_ptr voidptr // &[]int
+		preps_ptr    voidptr // &[]CollectGenFnPrep; shards fill disjoint positions
+		start        int
+		end          int
+		file         string
+		module_name  string
+	}
+
+	fn collect_gen_info_fn_prep_thread(arg voidptr) voidptr {
+		a := unsafe { &CollectGenInfoFnPrepArgs(arg) }
+		master := unsafe { &FlatGen(a.g) }
+		mut view := master.new_collect_gen_info_view()
+		view.tc.cur_file = a.file
+		view.tc.cur_module = a.module_name
+		node_ids := unsafe { &[]int(a.node_ids_ptr) }
+		mut preps := unsafe { &[]CollectGenFnPrep(a.preps_ptr) }
+		mut cur_file := a.file
+		mut cur_module := a.module_name
+		for pos in a.start .. a.end {
+			node_idx := unsafe { node_ids[pos] }
+			node := view.a.nodes[node_idx]
+			if node.kind == .file {
+				cur_file = node.value
+				cur_module = 'main'
+			} else if node.kind == .module_decl {
+				cur_module = node.value
+			} else if node.kind == .fn_decl && (!view.has_used_fn_filter()
+				|| view.used_fn_contains_in_module(node.value, cur_module)) {
+				unsafe {
+					preps[pos] = view.compute_collect_gen_fn_prep(node, cur_module, cur_file)
+				}
+			}
+		}
+		return unsafe { nil }
 	}
 
 	fn flat_cgen_cost_thread(arg voidptr) voidptr {
@@ -84,6 +126,10 @@ $if !windows {
 
 	fn parallel_type_decls_thread(arg voidptr) voidptr {
 		mut w := unsafe { &FlatGen(arg) }
+		tdsw := time.new_stopwatch()
+		defer {
+			w.timing_profile('  [ttime]     cg typedecls   ${f64(tdsw.elapsed().microseconds()) / 1000.0:7.2f} ms (task)')
+		}
 		// This force-sync task uses the master generator without entering a
 		// prealloc worker arena. Keep context caches disabled here; body workers
 		// own arena-local caches and account for nearly all lookup traffic.
@@ -91,15 +137,23 @@ $if !windows {
 		w.enum_selector_cache = unsafe { nil }
 		w.enum_method_cache = unsafe { nil }
 		w.qualified_enum_method_cache = unsafe { nil }
+		w.local_typedef_shadow_facts = unsafe { nil }
+		w.local_global_shadow_facts = unsafe { nil }
 		// Self-host declaration output is several MiB. Reserve it once instead of
 		// repeatedly copying a geometrically growing builder.
 		w.sb.ensure_cap(4 * 1024 * 1024)
+		mut tdpsw := time.new_stopwatch()
 		w.parallel_const_code = w.precompute_consts()
+		w.timing_profile('  [ttime]       td consts    ${f64(tdpsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+		tdpsw.restart()
 		w.gen_type_declaration_block()
+		w.timing_profile('  [ttime]       td typedecl  ${f64(tdpsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+		tdpsw.restart()
 		w.parallel_type_decls = w.sb.str()
 		unsafe { w.sb.free() }
 		w.sb = strings.new_builder(4096)
 		w.forward_decls()
+		w.timing_profile('  [ttime]       td fwd decls ${f64(tdpsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 		w.parallel_forward_decls = w.sb.str()
 		unsafe { w.sb.free() }
 		w.sb = strings.new_builder(4096)
@@ -112,14 +166,18 @@ $if !windows {
 	// fn work items and pre-seeds the parallel tables.
 	fn fixed_storage_scan_thread(arg voidptr) voidptr {
 		mut w := unsafe { &FlatGen(arg) }
-		fssw := time.new_stopwatch()
+		mut fssw := time.new_stopwatch()
 		scope := cgen_worker_scope_begin(w.scope_parallel_workers)
-		w.collect_fixed_storage_consts()
+		w.collect_fixed_storage_consts(true)
+		w.timing_profile('  [ttime]       fs consts     ${f64(fssw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+		fssw.restart()
 		w.precompute_param_type_index()
+		w.timing_profile('  [ttime]       fs param idx  ${f64(fssw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+		fssw.restart()
 		w.precompute_concrete_optional_abi_fns()
+		w.timing_profile('  [ttime]       fs opt abi    ${f64(fssw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 		w.worker_scope = scope
 		cgen_worker_scope_leave(scope)
-		w.timing_profile('  [ttime]     cg fs scan     ${f64(fssw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 		return unsafe { nil }
 	}
 
@@ -147,11 +205,82 @@ $if !windows {
 	}
 
 	fn flat_cgen_dynamic_thread(arg voidptr) voidptr {
-		a := unsafe { &FlatCgenDynamicArgs(arg) }
+		mut a := unsafe { &FlatCgenDynamicArgs(arg) }
+		if isnil(a.worker) {
+			dispatcher := unsafe { &FlatGen(a.dispatcher) }
+			a.setup_scope = cgen_worker_scope_begin(dispatcher.scope_parallel_workers)
+			a.worker = voidptr(dispatcher.new_parallel_dispatch_worker(a.worker_id))
+			cgen_worker_scope_leave(a.setup_scope)
+		}
 		mut w := unsafe { &FlatGen(a.worker) }
 		chunks := unsafe { &[][]FlatFnGenItem(a.work_chunks_ptr) }
 		w.gen_fn_chunks_scoped_dynamic(*chunks, a.chunk_queue, a.reserve_cost)
 		return unsafe { nil }
+	}
+}
+
+// collect_gen_info_fn_preps resolves used function signatures on the persistent
+// worker pool. Registration stays serial in collect_gen_info, preserving all
+// source-order and duplicate-declaration semantics.
+fn (mut g FlatGen) collect_gen_info_fn_preps(node_ids []int) []CollectGenFnPrep {
+	$if windows {
+		return []CollectGenFnPrep{}
+	} $else {
+		if isnil(g.a.worker_pool) || g.a.worker_pool.size() == 0 || node_ids.len < 2048
+			|| os.getenv('V3_NO_PAR_CGEN_INFO_FNS') != '' {
+			return []CollectGenFnPrep{}
+		}
+		mut n_jobs := g.a.worker_pool.size() + 1
+		if n_jobs > max_flat_cgen_jobs {
+			n_jobs = max_flat_cgen_jobs
+		}
+		mut preps := []CollectGenFnPrep{len: node_ids.len}
+		mut context_files := []string{len: n_jobs}
+		mut context_modules := []string{len: n_jobs}
+		mut cur_file := ''
+		mut cur_module := 'main'
+		mut boundary := 0
+		for pos in 0 .. node_ids.len {
+			for boundary < n_jobs && pos == node_ids.len * boundary / n_jobs {
+				context_files[boundary] = cur_file
+				context_modules[boundary] = cur_module
+				boundary++
+			}
+			node := g.a.nodes[node_ids[pos]]
+			if node.kind == .file {
+				cur_file = node.value
+				cur_module = 'main'
+			} else if node.kind == .module_decl {
+				cur_module = node.value
+			}
+		}
+		for boundary < n_jobs {
+			context_files[boundary] = cur_file
+			context_modules[boundary] = cur_module
+			boundary++
+		}
+		mut args := []CollectGenInfoFnPrepArgs{cap: n_jobs}
+		mut tasks := []workers.Task{cap: n_jobs}
+		for job in 0 .. n_jobs {
+			args << CollectGenInfoFnPrepArgs{
+				g:            voidptr(g)
+				node_ids_ptr: unsafe { voidptr(&node_ids) }
+				preps_ptr:    unsafe { voidptr(&preps) }
+				start:        node_ids.len * job / n_jobs
+				end:          node_ids.len * (job + 1) / n_jobs
+				file:         context_files[job]
+				module_name:  context_modules[job]
+			}
+		}
+		for job in 0 .. n_jobs {
+			tasks << workers.Task{
+				run:        collect_gen_info_fn_prep_thread
+				arg:        unsafe { voidptr(&args[job]) }
+				force_sync: job == 0
+			}
+		}
+		g.a.worker_pool.run(tasks)
+		return preps
 	}
 }
 
@@ -221,14 +350,35 @@ fn (mut g FlatGen) refine_fn_item_costs(no_parallel bool, reserve_worker bool) {
 		}
 		mut args := []FlatCgenCostArgs{cap: n_jobs}
 		mut tasks := []workers.Task{cap: n_jobs}
+		mut boundaries := []int{len: n_jobs + 1, init: g.fn_gen_items.len}
+		boundaries[0] = 0
+		if os.getenv('V3_NO_CGEN_COST_BALANCE') == '' {
+			mut total_cost := i64(g.fn_gen_items.len)
+			for item in g.fn_gen_items {
+				total_cost += i64(item.cost)
+			}
+			mut consumed_cost := i64(0)
+			mut pos := 0
+			for job in 1 .. n_jobs {
+				target_cost := total_cost * i64(job) / i64(n_jobs)
+				max_pos := g.fn_gen_items.len - (n_jobs - job)
+				for pos < max_pos && (consumed_cost < target_cost || pos == boundaries[job - 1]) {
+					consumed_cost += i64(g.fn_gen_items[pos].cost) + 1
+					pos++
+				}
+				boundaries[job] = pos
+			}
+		} else {
+			for job in 1 .. n_jobs {
+				boundaries[job] = g.fn_gen_items.len * job / n_jobs
+			}
+		}
 		for job in 0 .. n_jobs {
-			start := g.fn_gen_items.len * job / n_jobs
-			end := g.fn_gen_items.len * (job + 1) / n_jobs
 			args << FlatCgenCostArgs{
 				a:         unsafe { g.a }
 				items_ptr: unsafe { voidptr(&g.fn_gen_items) }
-				start:     start
-				end:       end
+				start:     boundaries[job]
+				end:       boundaries[job + 1]
 				g:         prep_g
 			}
 		}
@@ -318,8 +468,10 @@ fn (mut g FlatGen) prepare_pre_dispatch_master() {
 	if g.scope_parallel_workers {
 		mut pmsw := time.new_stopwatch()
 		selection_scope := cgen_worker_scope_begin(true)
+		retain_selection := os.getenv('V3_NO_RETAIN_CGEN_PREP_SCOPE') == ''
 		master_tc := g.tc
 		g.tc = g.clone_parallel_type_checker()
+		g.tc.verbose = master_tc.verbose
 		g.timing_profile('  [ttime]       pm clone tc  ${f64(pmsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 		pmsw.restart()
 		// Fuse body-local function-pointer discovery into the item cost walk so
@@ -339,36 +491,46 @@ fn (mut g FlatGen) prepare_pre_dispatch_master() {
 		g.register_interface_strings()
 		g.tc = master_tc
 		cgen_worker_scope_leave(selection_scope)
-		items_scope := cgen_worker_scope_begin(true)
-		mut owned_items := []FlatFnGenItem{cap: items.len}
-		for item in items {
-			owned_items << FlatFnGenItem{
-				node_id:                   item.node_id
-				file:                      item.file
-				module:                    item.module
-				c_name:                    item.c_name.clone()
-				cost:                      item.cost
-				is_program_specialization: item.is_program_specialization
-				direct_array_access:       item.direct_array_access
-				ignore_overflow:           item.ignore_overflow
+		if retain_selection {
+			// The selected items and predispatch tables are immutable from here on.
+			// Keep their arena through final output so they can move straight into
+			// cgen instead of cloning every item, string table, and lookup map only
+			// to free the originals immediately afterward.
+			g.parallel_worker_scopes << selection_scope
+			g.timing_profile('  [ttime]       pm retain out ${f64(pmsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+			n_items = items.len
+		} else {
+			items_scope := cgen_worker_scope_begin(true)
+			mut owned_items := []FlatFnGenItem{cap: items.len}
+			for item in items {
+				owned_items << FlatFnGenItem{
+					node_id:                   item.node_id
+					file:                      item.file
+					module:                    item.module
+					c_name:                    item.c_name.clone()
+					cost:                      item.cost
+					is_program_specialization: item.is_program_specialization
+					direct_array_access:       item.direct_array_access
+					ignore_overflow:           item.ignore_overflow
+				}
 			}
+			g.fn_gen_items = owned_items
+			g.emitted_fns = clone_cgen_string_bool_map(g.emitted_fns)
+			cgen_worker_scope_leave(items_scope)
+			g.scoped_fn_items_scope = items_scope
+			// These tables remain live after release_scoped_fn_items, so promote them
+			// into the enclosing cgen arena rather than the retained item arena.
+			g.str_lits = clone_cgen_string_list(g.str_lits)
+			g.str_lit_ids = clone_cgen_string_int_map(g.str_lit_ids)
+			g.fn_ptr_types = clone_cgen_string_map(g.fn_ptr_types)
+			g.used_fn_ptr_types = clone_cgen_string_bool_map(g.used_fn_ptr_types)
+			g.c_extern_refs = clone_cgen_string_bool_map(g.c_extern_refs)
+			g.c_name_cache = clone_c_name_cache(g.c_name_cache)
+			g.generic_app_cache = clone_generic_app_cache(g.generic_app_cache)
+			cgen_worker_scope_free(selection_scope)
+			n_items = g.fn_gen_items.len
+			g.timing_profile('  [ttime]       pm clone out ${f64(pmsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 		}
-		g.fn_gen_items = owned_items
-		g.emitted_fns = clone_cgen_string_bool_map(g.emitted_fns)
-		cgen_worker_scope_leave(items_scope)
-		g.scoped_fn_items_scope = items_scope
-		// These tables remain live after release_scoped_fn_items, so promote them
-		// into the enclosing cgen arena rather than the retained item arena.
-		g.str_lits = clone_cgen_string_list(g.str_lits)
-		g.str_lit_ids = clone_cgen_string_int_map(g.str_lit_ids)
-		g.fn_ptr_types = clone_cgen_string_map(g.fn_ptr_types)
-		g.used_fn_ptr_types = clone_cgen_string_bool_map(g.used_fn_ptr_types)
-		g.c_extern_refs = clone_cgen_string_bool_map(g.c_extern_refs)
-		g.c_name_cache = clone_c_name_cache(g.c_name_cache)
-		g.generic_app_cache = clone_generic_app_cache(g.generic_app_cache)
-		cgen_worker_scope_free(selection_scope)
-		n_items = g.fn_gen_items.len
-		g.timing_profile('  [ttime]       pm clone out ${f64(pmsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 	} else {
 		g.want_parallel_prep = true
 		n_items = g.ensure_fn_gen_items().len
@@ -604,15 +766,29 @@ fn (mut g FlatGen) gen_fn_chunks_scoped_dynamic(
 	chunks [][]FlatFnGenItem,
 	chunk_queue chan int,
 	_reserve_cost i64) {
+	wsw := time.new_stopwatch()
+	mut n_chunks := 0
 	result_scope := cgen_worker_scope_begin(true)
+	// Chunks assigned to one dispatcher run sequentially. Keep the dense
+	// generation-tagged expression-type memo in the result arena so each scratch
+	// chunk does not allocate and zero another 192 KiB table.
+	reuse_expr_type_memo := os.getenv('V3_NO_REUSE_CGEN_EXPR_TYPE_MEMO') == ''
+	if reuse_expr_type_memo {
+		g.begin_usable_expr_type_memo()
+		g.end_usable_expr_type_memo()
+	}
 	for {
 		chunk_idx := <-chunk_queue or { break }
+		n_chunks++
 		mut chunk_cost := i64(chunks[chunk_idx].len)
 		for item in chunks[chunk_idx] {
 			chunk_cost += item.cost
 		}
 		scratch_scope := cgen_worker_scope_begin(true)
 		mut batch := g.new_parallel_worker(chunk_idx)
+		if reuse_expr_type_memo {
+			batch.usable_expr_type_memo = g.usable_expr_type_memo
+		}
 		batch.sb = strings.new_builder(int(chunk_cost * 5) + 65_536)
 		batch.parallel_chunk_wrapper_defs << ParallelChunkWrapperDefs{
 			chunk_idx: chunk_idx
@@ -628,6 +804,7 @@ fn (mut g FlatGen) gen_fn_chunks_scoped_dynamic(
 		}
 		cgen_worker_scope_free(scratch_scope)
 	}
+	g.timing_profile('  [ttime]     cg wkr busy    ${f64(wsw.elapsed().microseconds()) / 1000.0:7.2f} ms (chunks: ${n_chunks})')
 	g.worker_scope = result_scope
 	cgen_worker_scope_leave(result_scope)
 }
@@ -758,6 +935,7 @@ fn (mut g FlatGen) gen_fns_dispatch(no_parallel bool) {
 		// transform phases) as the shared read-only base for every worker's
 		// fresh cache; the master's own memoization writes go to a private
 		// overlay for the duration of the region.
+		mut stsw := time.new_stopwatch()
 		g.tc.freeze_type_cache_for_forks()
 		g.freeze_parallel_lookup_caches()
 		if !g.parallel_prepared {
@@ -770,19 +948,26 @@ fn (mut g FlatGen) gen_fns_dispatch(no_parallel bool) {
 		}
 		mut chunk_items := split_flat_cgen_items(items, chunk_jobs)
 		chunk_count := chunk_items.len
+		g.timing_profile('  [ttime]   cg freeze+split  ${f64(stsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+		stsw.restart()
 		if parallel_type_decls {
 			fail := os.getenv('V3_TEST_PTHREAD_CREATE_FAIL')
 			static_dispatch := fail.len > 0
+			lazy_worker_setup := !static_dispatch && os.getenv('V3_NO_PAR_CGEN_WORKER_SETUP') == ''
 			worker_count := if static_dispatch { chunk_count } else { n_jobs }
-			mut cgen_workers := []voidptr{cap: worker_count}
+			mut cgen_workers := []voidptr{len: worker_count, init: unsafe { nil }}
+			mut worker_setup_scopes := []voidptr{len: worker_count, init: unsafe { nil }}
 			mut ordered_chunk_outputs := []string{}
 			mut ordered_wrapper_defs := []ParallelChunkWrapperDefs{}
-			worker_setup_scope := cgen_worker_scope_begin(true)
-			for ci := 0; ci < worker_count; ci++ {
-				mut w := g.new_parallel_dispatch_worker(ci)
-				cgen_workers << voidptr(w)
+			mut worker_setup_scope := unsafe { nil }
+			if !lazy_worker_setup {
+				worker_setup_scope = cgen_worker_scope_begin(true)
+				for ci := 0; ci < worker_count; ci++ {
+					cgen_workers[ci] = voidptr(g.new_parallel_dispatch_worker(ci))
+				}
+				cgen_worker_scope_leave(worker_setup_scope)
 			}
-			cgen_worker_scope_leave(worker_setup_scope)
+			g.timing_profile('  [ttime]   cg wkr setup     ${f64(stsw.elapsed().microseconds()) / 1000.0:7.2f} ms (workers: ${worker_count})')
 			if static_dispatch {
 				mut args := []FlatCgenChunkArgs{cap: chunk_count}
 				mut tasks := []workers.Task{cap: chunk_count + 1}
@@ -829,6 +1014,8 @@ fn (mut g FlatGen) gen_fns_dispatch(no_parallel bool) {
 				}
 				for ci in 0 .. worker_count {
 					args << FlatCgenDynamicArgs{
+						dispatcher:      voidptr(g)
+						worker_id:       ci
 						worker:          cgen_workers[ci]
 						work_chunks_ptr: unsafe { voidptr(&chunk_items) }
 						chunk_queue:     chunk_queue
@@ -841,13 +1028,19 @@ fn (mut g FlatGen) gen_fns_dispatch(no_parallel bool) {
 					}
 				}
 				g.parallel_used = g.a.worker_pool.run(tasks)
+				if lazy_worker_setup {
+					for ci in 0 .. worker_count {
+						cgen_workers[ci] = args[ci].worker
+						worker_setup_scopes[ci] = args[ci].setup_scope
+					}
+				}
 				g.timing_profile('  [ttime]   cg pool.run      ${f64(dsw.elapsed().microseconds()) / 1000.0:7.2f} ms (chunks: ${chunk_count}, workers: ${worker_count})')
 			}
 			// The declaration thread disables the master's caches while body
 			// workers use their private copies. Restore them for synthetic output.
 			mut msw := time.new_stopwatch()
 			g.reset_context_lookup_caches()
-			for worker_ptr in cgen_workers {
+			for ci, worker_ptr in cgen_workers {
 				mut w := unsafe { &FlatGen(worker_ptr) }
 				if ordered_chunk_outputs.len > 0 {
 					g.merge_parallel_worker_ordered(w, mut ordered_chunk_outputs, mut
@@ -855,9 +1048,9 @@ fn (mut g FlatGen) gen_fns_dispatch(no_parallel bool) {
 				} else {
 					g.merge_parallel_worker(w)
 				}
-				if w.worker_scope != unsafe { nil } {
-					cgen_worker_scope_free(w.worker_scope)
-					w.worker_scope = unsafe { nil }
+				g.finish_parallel_worker_scope(mut w)
+				if worker_setup_scopes[ci] != unsafe { nil } {
+					cgen_worker_scope_free(worker_setup_scopes[ci])
 				}
 			}
 			g.replay_ordered_parallel_wrapper_defs(ordered_wrapper_defs)
@@ -867,7 +1060,9 @@ fn (mut g FlatGen) gen_fns_dispatch(no_parallel bool) {
 					g.fn_segs << output
 				}
 			}
-			cgen_worker_scope_free(worker_setup_scope)
+			if worker_setup_scope != unsafe { nil } {
+				cgen_worker_scope_free(worker_setup_scope)
+			}
 			g.tc.unfreeze_type_cache_after_forks()
 			g.gen_synthetic_main_after_fns()
 			synthetic_output := g.sb.str()
@@ -928,10 +1123,7 @@ fn (mut g FlatGen) gen_fns_dispatch(no_parallel bool) {
 		for ci := 0; ci < thread_count; ci++ {
 			mut w := unsafe { &FlatGen(cgen_workers[ci]) }
 			g.merge_parallel_worker(w)
-			if w.worker_scope != unsafe { nil } {
-				cgen_worker_scope_free(w.worker_scope)
-				w.worker_scope = unsafe { nil }
-			}
+			g.finish_parallel_worker_scope(mut w)
 		}
 		cgen_worker_scope_free(worker_setup_scope)
 		g.tc.unfreeze_type_cache_after_forks()
@@ -1110,7 +1302,7 @@ fn (mut g FlatGen) fn_item_cost_and_prep(node_id flat.NodeId, mut stack []flat.N
 		// fallback, see refine_fn_item_costs). Keep this walk preseed-only.
 		if node.typ.len > 0
 			&& g.should_preseed_parallel_type_text_ptr_cached(node.typ, mut type_text_cache) {
-			g.preseed_parallel_fn_ptr_type(g.tc.parse_type(node.typ))
+			g.preseed_parallel_fn_ptr_type(g.parse_node_type(node))
 		}
 		if expr_type := g.parallel_cached_expr_type(current_id, node) {
 			// Checker-cached expression types repeat the same ~1K canonical
@@ -1203,7 +1395,7 @@ fn (mut g FlatGen) prepare_parallel_node(id flat.NodeId, mut stack []flat.NodeId
 		g.collect_c_extern_ref_from_node(node)
 		if node.typ.len > 0
 			&& g.should_preseed_parallel_type_text_cached(node.typ, mut type_text_cache) {
-			g.preseed_parallel_fn_ptr_type(g.tc.parse_type(node.typ))
+			g.preseed_parallel_fn_ptr_type(g.parse_node_type(node))
 		}
 		if expr_type := g.parallel_cached_expr_type(current_id, node) {
 			g.preseed_parallel_fn_ptr_type(expr_type)
@@ -1538,7 +1730,7 @@ fn (g &FlatGen) new_parallel_result_worker(worker_id int) &FlatGen {
 }
 
 fn (g &FlatGen) new_parallel_worker_config(worker_id int, result_only bool) &FlatGen {
-	return &FlatGen{
+	mut w := &FlatGen{
 		sb:                             strings.new_builder(if result_only { 0 } else { 64_000 })
 		a:                              unsafe { g.a }
 		used_fns:                       g.used_fns
@@ -1589,14 +1781,7 @@ fn (g &FlatGen) new_parallel_worker_config(worker_id int, result_only bool) &Fla
 		interface_boxed_types:          g.interface_boxed_types
 		interface_boxed_types_done:     g.interface_boxed_types_done
 		ierror_method_emit_names:       g.ierror_method_emit_names
-		ierror_stack_pointer_aliases:   []map[string]bool{}
-		ierror_owned_pointer_by_owner:  map[string]bool{}
 		recursive_drop_helpers:         g.recursive_drop_helpers
-		local_pointer_storage_by_owner: map[string]bool{}
-		local_c_type_by_owner:          map[string]string{}
-		local_raw_type_by_owner:        map[string]string{}
-		local_shared_storage_by_owner:  map[string]bool{}
-		local_fn_value_c_name_by_owner: map[string]string{}
 		sum_name_lookup:                g.sum_name_lookup
 		module_init_fns:                g.module_init_fns
 		module_init_fn_modules:         g.module_init_fn_modules
@@ -1642,7 +1827,6 @@ fn (g &FlatGen) new_parallel_worker_config(worker_id int, result_only bool) &Fla
 		decl_attrs:                     g.decl_attrs
 		shared_type_names:              g.shared_type_names
 		shared_alias_pointer_shorts:    g.shared_alias_pointer_shorts
-		default_value_stack:            map[string]bool{}
 		const_runtime_inits:            if result_only {
 			g.const_runtime_inits
 		} else {
@@ -1690,10 +1874,12 @@ fn (g &FlatGen) new_parallel_worker_config(worker_id int, result_only bool) &Fla
 		cur_fn_ret:                     g.cur_fn_ret
 		cur_fn_ret_is_optional:         g.cur_fn_ret_is_optional
 		cur_fn_ret_base:                g.cur_fn_ret_base
-		loop_label_depths:              map[string]int{}
-		loop_defer_starts:              []int{}
-		loop_label_defer_starts:        map[string]int{}
-		goto_label_c_names:             map[string]string{}
+		memo_usable_expr_types:         g.memo_usable_expr_types
+		cache_struct_fields:            g.cache_struct_fields
+		dedup_fn_decl_aliases:          g.dedup_fn_decl_aliases
+		prefix_param_scan:              g.prefix_param_scan
+		lean_parallel_worker_init:      g.lean_parallel_worker_init
+		lazy_param_abi_merge:           g.lazy_param_abi_merge
 		expected_expr_type:             g.expected_expr_type
 		expected_enum:                  g.expected_enum
 		needed_optional_types:          g.needed_optional_types.clone()
@@ -1745,9 +1931,13 @@ fn (g &FlatGen) new_parallel_worker_config(worker_id int, result_only bool) &Fla
 		// The const short-name index is read-only after its first build (the
 		// master queries it during the const precompute, before the forks);
 		// sharing it avoids a rebuild per worker.
-		const_short_index: g.const_short_index
-		mut_recv_facts:    &FnNameFactCache{}
-		generic_app_cache: &GenericAppCache{
+		const_short_index:               g.const_short_index
+		mut_recv_facts:                  &FnNameFactCache{}
+		local_typedef_shadow_facts:      &FnNameFactCache{}
+		local_global_shadow_facts:       &ContextNameFactCache{}
+		local_global_suffix_names:       g.local_global_suffix_names
+		local_global_suffix_names_ready: g.local_global_suffix_names_ready
+		generic_app_cache:               &GenericAppCache{
 			base: if !isnil(g.generic_app_cache.base) {
 				g.generic_app_cache.base
 			} else {
@@ -1755,6 +1945,21 @@ fn (g &FlatGen) new_parallel_worker_config(worker_id int, result_only bool) &Fla
 			}
 		}
 	}
+	if !g.lean_parallel_worker_init {
+		w.ierror_stack_pointer_aliases = []map[string]bool{}
+		w.ierror_owned_pointer_by_owner = map[string]bool{}
+		w.local_pointer_storage_by_owner = map[string]bool{}
+		w.local_c_type_by_owner = map[string]string{}
+		w.local_raw_type_by_owner = map[string]string{}
+		w.local_shared_storage_by_owner = map[string]bool{}
+		w.local_fn_value_c_name_by_owner = map[string]string{}
+		w.default_value_stack = map[string]bool{}
+		w.loop_label_depths = map[string]int{}
+		w.loop_defer_starts = []int{}
+		w.loop_label_defer_starts = map[string]int{}
+		w.goto_label_c_names = map[string]string{}
+	}
+	return w
 }
 
 fn (g &FlatGen) clone_parallel_type_checker_legacy() &types.TypeChecker {
@@ -1763,6 +1968,10 @@ fn (g &FlatGen) clone_parallel_type_checker_legacy() &types.TypeChecker {
 	fs := types.new_scope(g.tc.file_scope)
 	mut wtc := &types.TypeChecker{
 		a:                                     unsafe { g.tc.a }
+		fast_parse_recent:                     g.tc.fast_parse_recent
+		fast_type_text_refs:                   g.tc.fast_type_text_refs
+		fast_c_type_recent:                    g.tc.fast_c_type_recent
+		memo_call_info:                        g.tc.memo_call_info
 		fn_ret_types:                          g.tc.fn_ret_types
 		fn_param_types:                        g.tc.fn_param_types
 		c_fn_module_ret_types:                 g.tc.c_fn_module_ret_types
@@ -1816,6 +2025,7 @@ fn (g &FlatGen) clone_parallel_type_checker_legacy() &types.TypeChecker {
 		scope_pool:                            []&types.Scope{}
 		has_builtins:                          g.tc.has_builtins
 		resolution_type_mode:                  g.tc.resolution_type_mode
+		trust_checked_expr_types:              g.tc.trust_checked_expr_types
 		cur_module:                            g.tc.cur_module
 		cur_file:                              g.tc.cur_file
 		errors:                                g.tc.errors.clone()
@@ -1968,6 +2178,8 @@ fn (mut g FlatGen) merge_parallel_worker_into(w &FlatGen, mut ordered []string, 
 		g.output_error = w.output_error.clone()
 	}
 	string_id_remap := g.publish_worker_string_literals(w)
+	borrow_worker_segments := os.getenv('V3_NO_RETAIN_CGEN_RESULT_SCOPES') == ''
+		&& w.worker_scope != unsafe { nil } && !g.cache_split && string_id_remap.len == 0
 	user_c_symbols := if string_id_remap.len > 0 {
 		g.cache_user_c_string_symbols()
 	} else {
@@ -1996,6 +2208,11 @@ fn (mut g FlatGen) merge_parallel_worker_into(w &FlatGen, mut ordered []string, 
 			ww.rewrite_cache_string_symbols(segment)
 		} else if string_id_remap.len > 0 {
 			remap_scoped_worker_string_symbols(segment, string_id_remap, user_c_symbols)
+		} else if borrow_worker_segments {
+			// The immutable segment already lives in this worker's retained result
+			// arena. Its lifetime now extends through final file output, so moving
+			// the string view avoids cloning the complete generated function body.
+			segment
 		} else {
 			segment.clone()
 		}
@@ -2107,6 +2324,21 @@ fn (mut g FlatGen) merge_parallel_worker_into(w &FlatGen, mut ordered []string, 
 	}
 }
 
+// finish_parallel_worker_scope either releases a joined result arena
+// immediately (oracle fallback) or retains it until FlatGen has written every
+// borrowed function segment.
+fn (mut g FlatGen) finish_parallel_worker_scope(mut w FlatGen) {
+	if w.worker_scope == unsafe { nil } {
+		return
+	}
+	if os.getenv('V3_NO_RETAIN_CGEN_RESULT_SCOPES') == '' {
+		g.parallel_worker_scopes << w.worker_scope
+	} else {
+		cgen_worker_scope_free(w.worker_scope)
+	}
+	w.worker_scope = unsafe { nil }
+}
+
 fn (mut g FlatGen) replay_ordered_parallel_wrapper_defs(wrapper_defs []ParallelChunkWrapperDefs) {
 	for wrappers in wrapper_defs {
 		for def in wrappers.spawn {
@@ -2134,6 +2366,7 @@ fn (mut g FlatGen) run_pre_dispatch_parallel(no_parallel bool) bool {
 			g.a.worker_pool = workers.new(runtime.nr_jobs() - 1)
 		}
 		mut fs_worker := g.new_parallel_worker(0)
+		fs_worker.tc.verbose = g.tc.verbose
 		fail := os.getenv('V3_TEST_PTHREAD_CREATE_FAIL')
 		if fail.len > 0 {
 			g.a.worker_pool.run([

--- a/vlib/v3/gen/c/for.v
+++ b/vlib/v3/gen/c/for.v
@@ -123,6 +123,7 @@ fn (mut g FlatGen) gen_loop_continue_label(label string) {
 }
 
 // gen_for emits for output for c.
+@[direct_array_access]
 fn (mut g FlatGen) gen_for(node flat.Node) {
 	g.push_scope()
 	defer_start := g.defers.len
@@ -540,7 +541,7 @@ fn (mut g FlatGen) gen_for_in(node flat.Node) {
 
 fn (g &FlatGen) for_in_container_type(node flat.Node, container_id flat.NodeId) types.Type {
 	if node.typ.starts_with('map[') {
-		typ := g.tc.parse_type(node.typ)
+		typ := g.parse_node_type(&node)
 		if typ is types.Map {
 			return typ
 		}
@@ -567,7 +568,7 @@ fn (mut g FlatGen) gen_range_for_in(node flat.Node, key_id flat.NodeId, low_id f
 		return
 	}
 	key_name := if key.value == '_' {
-		'__discard_${int(key_id)}'
+		g.discard_name(key_id)
 	} else {
 		g.c_loop_local_name(key.value)
 	}

--- a/vlib/v3/gen/c/if.v
+++ b/vlib/v3/gen/c/if.v
@@ -9,6 +9,7 @@ struct MultiReturnTailParts {
 }
 
 // gen_if emits if output for c.
+@[direct_array_access]
 fn (mut g FlatGen) gen_if(node flat.Node) {
 	// Iterate the `else if` chain rather than recursing through gen_if/gen_if_else for
 	// each link. A lowered match can produce hundreds of chained `if_expr` nodes (one
@@ -710,7 +711,7 @@ fn (mut g FlatGen) seed_scope_from_decl(node flat.Node) {
 	// disagree for lowered temps (`__or_val := <zero []Val>` resolving to the
 	// element sum type) and would poison every later use of the binding.
 	if node.typ.len > 0 {
-		typ := g.tc.parse_type(node.typ)
+		typ := g.parse_node_type(&node)
 		if !decl_annotation_is_unusable(typ, node.typ) {
 			g.tc.cur_scope.insert(lhs.value, typ)
 			return
@@ -769,7 +770,7 @@ fn (mut g FlatGen) if_expr_type(node &flat.Node) types.Type {
 // gen_if_expr_stmt emits if expr stmt output for c.
 fn (mut g FlatGen) gen_if_expr_stmt(node flat.Node) {
 	ret_type := if node.typ.len > 0 {
-		g.tc.parse_type(node.typ)
+		g.parse_node_type(&node)
 	} else if g.expected_expr_type !is types.Void {
 		g.expected_expr_type
 	} else {

--- a/vlib/v3/gen/c/interface_test.v
+++ b/vlib/v3/gen/c/interface_test.v
@@ -75,3 +75,54 @@ fn main() {
 	assert c_source.contains('selected_speaker'), c_source
 	assert !c_source.contains('._typ = 0'), c_source
 }
+
+fn test_incremental_cgen_populates_shared_parameter_index() {
+	source_path := os.join_path(os.temp_dir(), 'v3_incremental_cgen_shared_params.v')
+	os.write_file(source_path, 'module main
+
+struct State {
+	value int
+}
+
+fn read(shared state State) int {
+	rlock state {
+		return state.value
+	}
+}
+
+fn selected_read(shared state State) int {
+	return read(shared state)
+}
+
+fn main() {
+	shared state := State{}
+	println(selected_read(shared state))
+}
+') or {
+		panic(err)
+	}
+	defer {
+		os.rm(source_path) or {}
+	}
+	prefs := pref.new_preferences()
+	mut p := parser.Parser.new(prefs)
+	mut a := p.parse_file(source_path)
+	mut tc := types.TypeChecker.new(a)
+	tc.collect(a)
+	tc.diagnose_unknown_calls = true
+	tc.diagnostic_files[source_path] = true
+	tc.check_semantics()
+	assert tc.errors.len == 0, tc.errors.str()
+	transform.transform(mut a, &tc)
+	tc.annotate_types()
+	used_fns := markused.mark_used(a, tc)
+	mut g := FlatGen.new()
+	g.set_cache_split(true)
+	g.set_program_body_only(true)
+	g.set_incremental_fn_names({
+		'selected_read': true
+	})
+	c_source := g.gen_with_used_options(a, used_fns, &tc, true)
+	assert g.fn_param_is_shared('read', 0)
+	assert c_source.contains('selected_read'), c_source
+}

--- a/vlib/v3/gen/c/names.v
+++ b/vlib/v3/gen/c/names.v
@@ -15,10 +15,44 @@ fn c_name(name string) string {
 @[heap]
 struct CNameCache {
 mut:
-	entries    map[string]string
-	base       &CNameCache = unsafe { nil }
-	last_name  string
-	last_value string
+	entries          map[string]string
+	base             &CNameCache = unsafe { nil }
+	last_name        string
+	last_value       string
+	recent_ptrs      [1024]voidptr
+	recent_lens      [1024]u16
+	recent_values    [1024]string
+	recent_populated [1024]bool
+}
+
+@[inline]
+fn c_name_recent_slot(name string) int {
+	return int(((u64(voidptr(name.str)) >> 4) ^ u64(name.len)) & 1023)
+}
+
+@[inline]
+fn (c &CNameCache) recent(name string) ?string {
+	if name.len > 65535 {
+		return none
+	}
+	slot := c_name_recent_slot(name)
+	if c.recent_populated[slot] && c.recent_ptrs[slot] == voidptr(name.str)
+		&& c.recent_lens[slot] == u16(name.len) {
+		return c.recent_values[slot]
+	}
+	return none
+}
+
+@[inline]
+fn (mut c CNameCache) remember(name string, value string) {
+	if name.len > 65535 {
+		return
+	}
+	slot := c_name_recent_slot(name)
+	c.recent_ptrs[slot] = voidptr(name.str)
+	c.recent_lens[slot] = u16(name.len)
+	c.recent_values[slot] = value
+	c.recent_populated[slot] = true
 }
 
 // ConstShortIndex maps a const short name to its unique primary const name
@@ -36,7 +70,75 @@ mut:
 @[heap]
 struct FnNameFactCache {
 mut:
-	entries map[string]i8
+	entries    map[string]i8
+	last_name  string
+	last_value i8
+}
+
+@[heap]
+struct ContextNameFactCache {
+mut:
+	file       string = '\x00'
+	module     string
+	entries    map[string]i8
+	last_name  string
+	last_value i8
+}
+
+@[inline]
+fn (mut c FnNameFactCache) get(name string) i8 {
+	if c.last_value != 0 && c.last_name.len == name.len
+		&& (unsafe { c.last_name.str == name.str } || c.last_name == name) {
+		return c.last_value
+	}
+	if cached := c.entries[name] {
+		c.last_name = name
+		c.last_value = cached
+		return cached
+	}
+	return 0
+}
+
+@[inline]
+fn (mut c FnNameFactCache) put(name string, value i8) {
+	c.entries[name] = value
+	c.last_name = name
+	c.last_value = value
+}
+
+@[inline]
+fn (mut c ContextNameFactCache) get(name string) i8 {
+	if c.last_value != 0 && c.last_name.len == name.len
+		&& (unsafe { c.last_name.str == name.str } || c.last_name == name) {
+		return c.last_value
+	}
+	if cached := c.entries[name] {
+		c.last_name = name
+		c.last_value = cached
+		return cached
+	}
+	return 0
+}
+
+@[inline]
+fn (mut c ContextNameFactCache) put(name string, value i8) {
+	c.entries[name] = value
+	c.last_name = name
+	c.last_value = value
+}
+
+@[inline]
+fn (mut c ContextNameFactCache) select_context(file string, module_name string) {
+	if c.file.len == file.len && c.module.len == module_name.len && unsafe {
+		c.file.str == file.str && c.module.str == module_name.str
+	} {
+		return
+	}
+	c.file = file
+	c.module = module_name
+	c.entries = map[string]i8{}
+	c.last_name = ''
+	c.last_value = 0
 }
 
 // StringLookupCache memoizes context-qualified string lookups whose empty
@@ -45,7 +147,33 @@ mut:
 @[heap]
 struct StringLookupCache {
 mut:
-	entries map[string]string
+	entries    map[string]string
+	last_name  string
+	last_value string
+	last_valid bool
+}
+
+@[inline]
+fn (mut c StringLookupCache) get(name string) ?string {
+	if c.last_valid && c.last_name.len == name.len
+		&& (unsafe { c.last_name.str == name.str } || c.last_name == name) {
+		return c.last_value
+	}
+	if cached := c.entries[name] {
+		c.last_name = name
+		c.last_value = cached
+		c.last_valid = true
+		return cached
+	}
+	return none
+}
+
+@[inline]
+fn (mut c StringLookupCache) put(name string, value string) {
+	c.entries[name] = value
+	c.last_name = name
+	c.last_value = value
+	c.last_valid = true
 }
 
 // ContextStringLookupCache memoizes string lookups whose answers depend on the
@@ -65,7 +193,9 @@ mut:
 
 @[inline]
 fn (mut c ContextStringLookupCache) select_context(file string, module_name string) {
-	if c.file == file && c.module == module_name {
+	if c.file.len == file.len && c.module.len == module_name.len && unsafe {
+		c.file.str == file.str && c.module.str == module_name.str
+	} {
 		return
 	}
 	c.file = file
@@ -94,15 +224,28 @@ fn (g &FlatGen) cname(name string) string {
 		&& (unsafe { cache.last_name.str == name.str } || cache.last_name == name) {
 		return cache.last_value
 	}
-	if cached := cache.entries[name] {
+	if cached := cache.recent(name) {
 		cache.last_name = name
 		cache.last_value = cached
 		return cached
 	}
+	if cached := cache.entries[name] {
+		cache.last_name = name
+		cache.last_value = cached
+		cache.remember(name, cached)
+		return cached
+	}
 	if !isnil(cache.base) {
+		if cached := cache.base.recent(name) {
+			cache.last_name = name
+			cache.last_value = cached
+			cache.remember(name, cached)
+			return cached
+		}
 		if cached := cache.base.entries[name] {
 			cache.last_name = name
 			cache.last_value = cached
+			cache.remember(name, cached)
 			return cached
 		}
 	}
@@ -110,6 +253,7 @@ fn (g &FlatGen) cname(name string) string {
 	cache.entries[name] = result
 	cache.last_name = name
 	cache.last_value = result
+	cache.remember(name, result)
 	return result
 }
 

--- a/vlib/v3/gen/c/output_nix.c.v
+++ b/vlib/v3/gen/c/output_nix.c.v
@@ -5,26 +5,56 @@ import os
 #include <sys/mman.h>
 #include <unistd.h>
 
+fn write_c_output_sequential(mut file os.File, prefix []u8, segments []string, tail string) ! {
+	if prefix.len > 0 {
+		unsafe { file.write_full_buffer(prefix.data, usize(prefix.len))! }
+	}
+	for segment in segments {
+		if segment.len > 0 {
+			file.write_string(segment)!
+		}
+	}
+	if tail.len > 0 {
+		file.write_string(tail)!
+	}
+}
+
 fn write_c_output_mapped(path string, prefix []u8, segments []string, tail string) ! {
 	mut total := prefix.len + tail.len
 	for segment in segments {
 		total += segment.len
 	}
-	mut file := os.open_file(path, 'w+b')!
+	mut file := os.open_file(path, 'w+b') or {
+		mut sequential_file := os.open_file(path, 'wb')!
+		write_c_output_sequential(mut sequential_file, prefix, segments, tail) or {
+			sequential_file.close()
+			return err
+		}
+		sequential_file.close()
+		return
+	}
 	if total == 0 {
 		file.close()
 		return
 	}
 	if C.ftruncate(file.fd, u64(total)) != 0 {
+		write_c_output_sequential(mut file, prefix, segments, tail) or {
+			file.close()
+			return err
+		}
 		file.close()
-		return error('ftruncate failed (errno ${C.errno})')
+		return
 	}
 	mapped := unsafe {
 		C.mmap(nil, usize(total), C.PROT_READ | C.PROT_WRITE, C.MAP_SHARED, file.fd, 0)
 	}
 	if mapped == C.MAP_FAILED {
+		write_c_output_sequential(mut file, prefix, segments, tail) or {
+			file.close()
+			return err
+		}
 		file.close()
-		return error('mmap failed (errno ${C.errno})')
+		return
 	}
 	mut offset := 0
 	unsafe {

--- a/vlib/v3/gen/c/output_nix.c.v
+++ b/vlib/v3/gen/c/output_nix.c.v
@@ -1,0 +1,50 @@
+module c
+
+import os
+
+#include <sys/mman.h>
+#include <unistd.h>
+
+fn write_c_output_mapped(path string, prefix []u8, segments []string, tail string) ! {
+	mut total := prefix.len + tail.len
+	for segment in segments {
+		total += segment.len
+	}
+	mut file := os.open_file(path, 'w+b')!
+	if total == 0 {
+		file.close()
+		return
+	}
+	if C.ftruncate(file.fd, u64(total)) != 0 {
+		file.close()
+		return error('ftruncate failed (errno ${C.errno})')
+	}
+	mapped := unsafe {
+		C.mmap(nil, usize(total), C.PROT_READ | C.PROT_WRITE, C.MAP_SHARED, file.fd, 0)
+	}
+	if mapped == C.MAP_FAILED {
+		file.close()
+		return error('mmap failed (errno ${C.errno})')
+	}
+	mut offset := 0
+	unsafe {
+		if prefix.len > 0 {
+			vmemcpy(&u8(mapped) + offset, prefix.data, prefix.len)
+			offset += prefix.len
+		}
+		for segment in segments {
+			if segment.len > 0 {
+				vmemcpy(&u8(mapped) + offset, segment.str, segment.len)
+				offset += segment.len
+			}
+		}
+		if tail.len > 0 {
+			vmemcpy(&u8(mapped) + offset, tail.str, tail.len)
+		}
+	}
+	// Keep the shared mapping alive for the short remaining lifetime of the
+	// compiler process. The generated file is coherent as soon as the stores
+	// above complete; unmapping it here can synchronously reclaim thousands of
+	// dirty VM pages before the C compiler has even opened the file.
+	file.close()
+}

--- a/vlib/v3/gen/c/stmt.v
+++ b/vlib/v3/gen/c/stmt.v
@@ -1553,7 +1553,7 @@ fn (mut g FlatGen) gen_lock_body_stmt(node flat.Node) {
 
 fn (g &FlatGen) lock_expr_result_type(node flat.Node) types.Type {
 	if node.typ.len > 0 {
-		typ := g.tc.parse_type(node.typ)
+		typ := g.parse_node_type(&node)
 		if typ !is types.Unknown && typ !is types.Void {
 			return typ
 		}
@@ -3003,7 +3003,7 @@ fn (g &FlatGen) debugger_scope_vars() []DebuggerScopeVar {
 	mut result := []DebuggerScopeVar{}
 	mut seen := map[string]bool{}
 	mut scope := g.tc.cur_scope
-	for scope != unsafe { nil } && scope != g.tc.file_scope {
+	for scope != unsafe { nil } && voidptr(scope) != voidptr(g.tc.file_scope) {
 		for i := scope.names.len - 1; i >= 0; i-- {
 			name := scope.names[i]
 			if name.len == 0 || name == '_' || name.starts_with('__') || seen[name] {
@@ -3632,7 +3632,7 @@ fn (g &FlatGen) selector_address_crosses_pointer(id flat.NodeId) bool {
 		base := g.a.nodes[int(base_id)]
 		mut base_type := g.usable_expr_type(base_id)
 		if base_type is types.Unknown || base_type is types.Void {
-			base_type = g.tc.parse_type(base.typ)
+			base_type = g.parse_node_type(&base)
 		}
 		if cgen_unalias_type(base_type) is types.Pointer {
 			return true
@@ -3956,7 +3956,7 @@ fn (g &FlatGen) local_fn_call_return_type(call_id flat.NodeId, call_node flat.No
 	// on the call node. The checker resolution still names the open template,
 	// so prefer the rewritten annotation over that stale `!T`/`?T` signature.
 	if call_node.typ.len > 0 {
-		node_type = g.tc.parse_type(call_node.typ)
+		node_type = g.parse_node_type(&call_node)
 		if node_type is types.OptionType || node_type is types.ResultType {
 			return node_type
 		}
@@ -4399,7 +4399,7 @@ fn (g &FlatGen) generated_variant_access_type(id flat.NodeId) ?types.Type {
 		for i, param in params {
 			if param == '__v3_generated_variant_access' && i + 1 < params.len {
 				if node.typ.starts_with('&') {
-					return g.tc.parse_type(node.typ)
+					return g.parse_node_type(&node)
 				}
 				return g.tc.parse_type(params[i + 1])
 			}
@@ -4449,6 +4449,25 @@ fn (mut g FlatGen) gen_generated_variant_access_selector(node flat.Node, base_id
 }
 
 fn (g &FlatGen) usable_expr_type(id flat.NodeId) types.Type {
+	idx := int(id)
+	if idx >= 0 && !isnil(g.usable_expr_type_memo) {
+		mut memo := g.usable_expr_type_memo
+		if memo.active {
+			slot := idx & 16383
+			if memo.gens[slot] == memo.generation && memo.ids[slot] == idx {
+				return memo.values[slot]
+			}
+			result := g.usable_expr_type_uncached(id)
+			memo.ids[slot] = idx
+			memo.gens[slot] = memo.generation
+			memo.values[slot] = result
+			return result
+		}
+	}
+	return g.usable_expr_type_uncached(id)
+}
+
+fn (g &FlatGen) usable_expr_type_uncached(id flat.NodeId) types.Type {
 	if int(id) >= 0 && int(id) < g.a.nodes.len {
 		node := g.a.nodes[int(id)]
 		if node.kind in [.string_literal, .string_interp] {
@@ -4599,7 +4618,7 @@ fn (g &FlatGen) usable_expr_type(id flat.NodeId) types.Type {
 				}
 			}
 			if node.typ.len > 0 {
-				node_type := g.tc.parse_type(node.typ)
+				node_type := g.parse_node_type(&node)
 				if !decl_annotation_is_unusable(node_type, node.typ) {
 					if node_type is types.Pointer && node_type.base_type is types.Char
 						&& fn_node.kind == .ident {
@@ -4610,13 +4629,6 @@ fn (g &FlatGen) usable_expr_type(id flat.NodeId) types.Type {
 						}
 					}
 					return node_type
-				}
-			}
-			if node.typ.len > 0 && node.typ !in ['int', 'array', 'map', 'unknown'] {
-				typ := g.tc.parse_type(node.typ)
-				if !decl_annotation_is_unusable(typ, node.typ) && typ !is types.Unknown
-					&& typ !is types.Void {
-					return typ
 				}
 			}
 			if map_return_type := g.array_map_call_return_type(node, fn_node) {
@@ -4942,6 +4954,7 @@ fn (mut g FlatGen) static_local_initializer_needs_runtime(id flat.NodeId) bool {
 }
 
 // gen_decl_assign emits decl assign output for c.
+@[direct_array_access]
 fn (mut g FlatGen) gen_decl_assign(node flat.Node) {
 	old_decl_is_mut := g.current_decl_is_mut
 	g.current_decl_is_mut = node.is_mut
@@ -5065,7 +5078,7 @@ fn (mut g FlatGen) gen_decl_assign(node flat.Node) {
 		if rhs.kind == .array_literal {
 			mut rhs_v_type := g.tc.resolve_type(rhs_id)
 			if rhs.typ.len > 0 {
-				annotated_type := g.tc.parse_type(rhs.typ)
+				annotated_type := g.parse_node_type(&rhs)
 				if !(rhs.children_count == 0 && annotated_type is types.ArrayFixed
 					&& rhs_v_type is types.Array) {
 					rhs_v_type = annotated_type
@@ -5080,7 +5093,7 @@ fn (mut g FlatGen) gen_decl_assign(node flat.Node) {
 				}
 			}
 			if lhs.typ.len > 0 {
-				lhs_decl_type := g.tc.parse_type(lhs.typ)
+				lhs_decl_type := g.parse_node_type(&lhs)
 				if _ := array_like_type(lhs_decl_type) {
 					rhs_v_type = lhs_decl_type
 				} else if _ := array_fixed_type(lhs_decl_type) {
@@ -5144,7 +5157,7 @@ fn (mut g FlatGen) gen_decl_assign(node flat.Node) {
 				}
 			}
 			if lhs.typ.len > 0 {
-				lhs_decl_type := g.tc.parse_type(lhs.typ)
+				lhs_decl_type := g.parse_node_type(&lhs)
 				if arr := array_like_type(lhs_decl_type) {
 					resolved_init_type = lhs_decl_type
 					init_type = arr.elem_type
@@ -5819,7 +5832,7 @@ fn (g &FlatGen) decl_rhs_fallback_type(rhs_id flat.NodeId, rhs flat.Node) types.
 		return alias_type
 	}
 	if rhs.typ.len > 0 {
-		rhs_type := g.tc.parse_type(rhs.typ)
+		rhs_type := g.parse_node_type(&rhs)
 		if !decl_annotation_is_unusable(rhs_type, rhs.typ) {
 			return rhs_type
 		}
@@ -6332,6 +6345,7 @@ fn (mut g FlatGen) gen_fixed_array_address_to_byte_pointer_assign(lhs_id flat.No
 }
 
 // gen_assign emits assign output for c.
+@[direct_array_access]
 fn (mut g FlatGen) gen_assign(node flat.Node) {
 	if node.children_count >= 3 {
 		rhs_id := g.a.child(&node, 1)
@@ -6734,7 +6748,7 @@ fn (mut g FlatGen) gen_decl_lhs(id flat.NodeId) {
 	node := g.a.nodes[int(id)]
 	if node.kind == .ident {
 		if node.value == '_' {
-			g.write('__discard_${int(id)}')
+			g.write(g.discard_name(id))
 			return
 		}
 		g.write(g.local_decl_cname(node.value))
@@ -6748,11 +6762,18 @@ fn (mut g FlatGen) decl_lhs_str(id flat.NodeId) string {
 	node := g.a.nodes[int(id)]
 	if node.kind == .ident {
 		if node.value == '_' {
-			return '__discard_${int(id)}'
+			return g.discard_name(id)
 		}
 		return g.local_decl_cname(node.value)
 	}
 	return g.expr_to_string(id)
+}
+
+// discard_name derives ignored-local names from their source span. NodeIds for
+// generated AST nodes depend on parallel append-region sizes and are not stable.
+fn (g &FlatGen) discard_name(id flat.NodeId) string {
+	pos := g.a.nodes[int(id)].pos
+	return '__discard_${pos.id}_${pos.offset}_${pos.end}'
 }
 
 fn (g &FlatGen) local_cname(name string) string {
@@ -6774,20 +6795,60 @@ fn (g &FlatGen) local_decl_cname(name string) string {
 }
 
 fn (g &FlatGen) local_name_needs_global_suffix(name string) bool {
-	if 'C.${name}' in g.tc.c_globals {
-		return true
+	if g.local_global_suffix_names_ready {
+		return name in g.local_global_suffix_names
 	}
-	if _ := g.global_type_for_ident(name) {
-		module_name := g.global_modules[name] or { g.tc.cur_module }
-		return module_name.len == 0 || module_name in ['main', 'builtin']
+	mut cache := g.local_global_shadow_facts
+	if !isnil(cache) {
+		cache.select_context(g.tc.cur_file, g.tc.cur_module)
+		cached := cache.get(name)
+		if cached != 0 {
+			return cached > 0
+		}
 	}
-	return false
+	mut result := 'C.${name}' in g.tc.c_globals
+	if !result {
+		if _ := g.global_type_for_ident(name) {
+			module_name := g.global_modules[name] or { g.tc.cur_module }
+			result = module_name.len == 0 || module_name in ['main', 'builtin']
+		}
+	}
+	if !isnil(cache) {
+		cache.put(name, if result { i8(1) } else { i8(-1) })
+	}
+	return result
+}
+
+fn (mut g FlatGen) precompute_local_global_suffix_names() {
+	for name, _ in g.tc.c_globals {
+		if name.starts_with('C.') && name.len > 2 {
+			g.local_global_suffix_names[name[2..]] = true
+		}
+	}
+	for name, module_name in g.global_modules {
+		if module_name.len == 0 || module_name in ['main', 'builtin'] {
+			g.local_global_suffix_names[name] = true
+		}
+	}
+	g.local_global_suffix_names_ready = true
 }
 
 fn (g &FlatGen) local_name_shadows_c_typedef(name string) bool {
+	if !isnil(g.local_typedef_shadow_facts) {
+		mut cache := g.local_typedef_shadow_facts
+		cached := cache.get(name)
+		if cached != 0 {
+			return cached > 0
+		}
+	}
 	cname := g.cname(name)
-	return cname in g.inlined_c_typedef_names || cname in g.tc.c_typedef_structs
+	result := cname in g.inlined_c_typedef_names || cname in g.tc.c_typedef_structs
 		|| 'C.${cname}' in g.tc.c_typedef_structs
+	if !isnil(g.local_typedef_shadow_facts) {
+		mut cache := g.local_typedef_shadow_facts
+		cache.put(name, if result { i8(1) } else { i8(-1) })
+	}
+	return result
 }
 
 fn local_name_shadows_c_runtime(name string) bool {
@@ -7243,7 +7304,7 @@ fn (g &FlatGen) or_expr_source_type(expr_id flat.NodeId, expr_node flat.Node) ty
 			return thread_ret
 		}
 		if expr_node.typ.len > 0 {
-			node_type := g.tc.parse_type(expr_node.typ)
+			node_type := g.parse_node_type(&expr_node)
 			if node_type is types.OptionType || node_type is types.ResultType {
 				return node_type
 			}

--- a/vlib/v3/gen/c/struct.v
+++ b/vlib/v3/gen/c/struct.v
@@ -402,7 +402,7 @@ fn (mut g FlatGen) gen_struct_init(id flat.NodeId) {
 		}
 	}
 	init_type := g.tc.parse_type(init_value)
-	node_type := g.tc.parse_type(node.typ)
+	node_type := g.parse_node_type(&node)
 	is_optional_init := init_value == 'Optional' || init_type is types.OptionType
 		|| init_type is types.ResultType
 	has_expected_optional := g.expected_expr_type is types.OptionType
@@ -659,7 +659,7 @@ fn (g &FlatGen) unique_qualified_struct_c_type(short_ct string) ?string {
 	}
 	if !isnil(g.unique_struct_ct_cache) {
 		mut cache := g.unique_struct_ct_cache
-		if cached := cache.entries[short_ct] {
+		if cached := cache.get(short_ct) {
 			if cached.len == 0 {
 				return none
 			}
@@ -679,13 +679,13 @@ fn (g &FlatGen) unique_qualified_struct_c_type(short_ct string) ?string {
 	if matches.len == 1 && matches[0] != short_ct {
 		if !isnil(g.unique_struct_ct_cache) {
 			mut cache := g.unique_struct_ct_cache
-			cache.entries[short_ct] = matches[0]
+			cache.put(short_ct, matches[0])
 		}
 		return matches[0]
 	}
 	if !isnil(g.unique_struct_ct_cache) {
 		mut cache := g.unique_struct_ct_cache
-		cache.entries[short_ct] = ''
+		cache.put(short_ct, '')
 	}
 	return none
 }
@@ -3285,7 +3285,7 @@ fn (g &FlatGen) generic_struct_init_instance_ct_for_node(node flat.Node) ?string
 		return none
 	}
 	if node.typ.len > 0 {
-		candidate := g.tc.parse_type(node.typ)
+		candidate := g.parse_node_type(&node)
 		base := default_init_unalias_type(types.unwrap_all_pointers(candidate))
 		if base !is types.Array && base !is types.ArrayFixed {
 			name := base.name()
@@ -3307,7 +3307,7 @@ fn (g &FlatGen) generic_struct_init_instance_ct_for_node(node flat.Node) ?string
 
 fn (g &FlatGen) generic_struct_init_instance_name_for_node(node flat.Node) ?string {
 	if node.typ.len > 0 {
-		candidate := g.tc.parse_type(node.typ)
+		candidate := g.parse_node_type(&node)
 		base := default_init_unalias_type(types.unwrap_all_pointers(candidate))
 		if base !is types.Array && base !is types.ArrayFixed {
 			name := base.name()
@@ -3540,7 +3540,8 @@ fn (g &FlatGen) generic_struct_init_app_ct_from_context(type_name string) ?strin
 		if generic_receiver_type_suffixes(candidate_args) == arg_suffix {
 			context_ct := g.tc.c_type(candidate_type)
 			if !isnil(g.generic_struct_context_ct_cache) {
-				if cached := g.generic_struct_context_ct_cache.entries[context_ct] {
+				mut cache := g.generic_struct_context_ct_cache
+				if cached := cache.get(context_ct) {
 					return cached
 				}
 			}
@@ -3557,7 +3558,7 @@ fn (g &FlatGen) generic_struct_init_app_ct_from_context(type_name string) ?strin
 			result := if matches.len == 1 { matches[0] } else { context_ct }
 			if !isnil(g.generic_struct_context_ct_cache) {
 				mut cache := g.generic_struct_context_ct_cache
-				cache.entries[context_ct] = result
+				cache.put(context_ct, result)
 			}
 			return result
 		}
@@ -3639,7 +3640,8 @@ fn (g &FlatGen) same_module_flattened_generic_struct_ct(clean string) ?string {
 
 fn (g &FlatGen) flattened_generic_struct_c_type_short_name(ct string) string {
 	if !isnil(g.flattened_generic_name_cache) {
-		if cached := g.flattened_generic_name_cache.entries[ct] {
+		mut cache := g.flattened_generic_name_cache
+		if cached := cache.get(ct) {
 			return cached
 		}
 	}
@@ -3665,7 +3667,7 @@ fn (g &FlatGen) flattened_generic_struct_c_type_short_name(ct string) string {
 	result := out.bytestr()
 	if !isnil(g.flattened_generic_name_cache) {
 		mut cache := g.flattened_generic_name_cache
-		cache.entries[ct] = result
+		cache.put(ct, result)
 	}
 	return result
 }
@@ -3691,9 +3693,28 @@ fn (g &FlatGen) find_struct_decl(type_name string) ?StructDeclInfo {
 // a private instance (new_parallel_worker_config).
 struct StructDeclPrefCache {
 mut:
-	module  string
-	entries map[string]StructDeclInfo
-	misses  map[string]bool
+	module           string
+	entries          map[string]StructDeclInfo
+	misses           map[string]bool
+	field_entries    map[string][]types.StructField
+	field_misses     map[string]bool
+	field_last_name  string
+	field_last_value []types.StructField
+	field_last_state i8
+}
+
+fn (mut cache StructDeclPrefCache) select_module(module_name string) {
+	if cache.module == module_name {
+		return
+	}
+	cache.module = module_name
+	cache.entries.clear()
+	cache.misses.clear()
+	cache.field_entries.clear()
+	cache.field_misses.clear()
+	cache.field_last_name = ''
+	cache.field_last_value = []types.StructField{}
+	cache.field_last_state = 0
 }
 
 fn (g &FlatGen) find_struct_decl_preferred(type_name string) ?StructDeclInfo {
@@ -3701,11 +3722,7 @@ fn (g &FlatGen) find_struct_decl_preferred(type_name string) ?StructDeclInfo {
 	if isnil(cache) {
 		return g.find_struct_decl_preferred_uncached(type_name)
 	}
-	if cache.module != g.tc.cur_module {
-		cache.module = g.tc.cur_module
-		cache.entries.clear()
-		cache.misses.clear()
-	}
+	cache.select_module(g.tc.cur_module)
 	if cached := cache.entries[type_name] {
 		return cached
 	}
@@ -3910,6 +3927,46 @@ fn (g &FlatGen) struct_embedded_fields(type_name string) []types.StructField {
 }
 
 fn (g &FlatGen) struct_fields_for_type(type_name string) ?[]types.StructField {
+	mut cache := g.struct_decl_pref_cache
+	if g.cache_struct_fields && !isnil(cache) {
+		cache.select_module(g.tc.cur_module)
+		if cache.field_last_state != 0 && cache.field_last_name.len == type_name.len
+			&& (unsafe { cache.field_last_name.str == type_name.str }
+			|| cache.field_last_name == type_name) {
+			if cache.field_last_state > 0 {
+				return cache.field_last_value
+			}
+			return none
+		}
+		if fields := cache.field_entries[type_name] {
+			cache.field_last_name = type_name
+			cache.field_last_value = fields
+			cache.field_last_state = 1
+			return fields
+		}
+		if cache.field_misses[type_name] {
+			cache.field_last_name = type_name
+			cache.field_last_value = []types.StructField{}
+			cache.field_last_state = -1
+			return none
+		}
+		if fields := g.struct_fields_for_type_uncached(type_name) {
+			cache.field_entries[type_name] = fields
+			cache.field_last_name = type_name
+			cache.field_last_value = fields
+			cache.field_last_state = 1
+			return fields
+		}
+		cache.field_misses[type_name] = true
+		cache.field_last_name = type_name
+		cache.field_last_value = []types.StructField{}
+		cache.field_last_state = -1
+		return none
+	}
+	return g.struct_fields_for_type_uncached(type_name)
+}
+
+fn (g &FlatGen) struct_fields_for_type_uncached(type_name string) ?[]types.StructField {
 	if info := g.find_struct_decl(type_name) {
 		if fields := g.tc.structs[info.full_name] {
 			return fields
@@ -4487,7 +4544,7 @@ fn (mut g FlatGen) gen_map_init(id flat.NodeId, node flat.Node) {
 		}
 	}
 	if node.typ.len > 0 {
-		map_type := g.tc.parse_type(node.typ)
+		map_type := g.parse_node_type(&node)
 		if map_type is types.Map {
 			g.gen_map_init_for_type(node, g.refined_map_init_type(node, map_type))
 			return
@@ -4890,7 +4947,8 @@ fn c_struct_needs_typedef(name string) bool {
 
 fn (g &FlatGen) struct_cname(name string) string {
 	if !isnil(g.struct_cname_cache) {
-		if cached := g.struct_cname_cache.entries[name] {
+		mut cache := g.struct_cname_cache
+		if cached := cache.get(name) {
 			return cached
 		}
 	}
@@ -4899,7 +4957,7 @@ fn (g &FlatGen) struct_cname(name string) string {
 	}))
 	if !isnil(g.struct_cname_cache) {
 		mut cache := g.struct_cname_cache
-		cache.entries[name] = result
+		cache.put(name, result)
 	}
 	return result
 }

--- a/vlib/v3/gen/c/types.v
+++ b/vlib/v3/gen/c/types.v
@@ -400,7 +400,7 @@ fn (mut g FlatGen) collect_optional_typedefs() {
 		}
 		if node.typ.len > 0 && node.typ !in ['int', 'array', 'map', 'unknown']
 			&& cgen_type_text_is_complete(node.typ) {
-			g.collect_optional_typedef_type(g.tc.parse_type(node.typ))
+			g.collect_optional_typedef_type(g.parse_node_type(&node))
 		}
 	}
 }

--- a/vlib/v3/parser/parser_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/parser/parser_parallel_notd_v3_no_parallel.v
@@ -312,7 +312,7 @@ fn remap_worker_pos(pos token.Pos, first_file_id int, next_file_id int, delta in
 	}
 	return token.Pos{
 		...pos
-		id: pos.id + delta
+		id: u16(int(pos.id) + delta)
 	}
 }
 
@@ -971,6 +971,9 @@ fn parse_merge_copy_thread(arg voidptr) voidptr {
 	}
 	mut cache_ptrs := unsafe { []voidptr{len: 4096} }
 	mut cache_vals := []string{len: 4096}
+	mut type_cache_ptrs := unsafe { []voidptr{len: 4096} }
+	mut type_cache_vals := []string{len: 4096}
+	mut type_cache_ids := []u16{len: 4096}
 	for k in 0 .. w.a.nodes.len {
 		mut node := w.a.nodes[k]
 		if node.children_count != 0 {
@@ -988,7 +991,10 @@ fn parse_merge_copy_thread(arg voidptr) voidptr {
 		mut all_hit := true
 		node.value, all_hit = p.a.probe_text_ptr_cached(node.value, mut cache_ptrs, mut cache_vals)
 		mut hit := true
-		node.typ, hit = p.a.probe_text_ptr_cached(node.typ, mut cache_ptrs, mut cache_vals)
+		mut type_id := u16(0)
+		type_id, node.typ, hit = p.a.probe_type_text_ptr_cached(node.typ, mut type_cache_ptrs, mut
+			type_cache_vals, mut type_cache_ids)
+		node.set_type_text_id(type_id)
 		all_hit = all_hit && hit
 		params := node.generic_params()
 		if params.len > 0 {

--- a/vlib/v3/parser/parser_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/parser/parser_parallel_notd_v3_no_parallel.v
@@ -312,7 +312,7 @@ fn remap_worker_pos(pos token.Pos, first_file_id int, next_file_id int, delta in
 	}
 	return token.Pos{
 		...pos
-		id: u16(int(pos.id) + delta)
+		id: pos.id + delta
 	}
 }
 

--- a/vlib/v3/parser/span_test.v
+++ b/vlib/v3/parser/span_test.v
@@ -3,6 +3,7 @@ module parser
 import os
 import v3.flat
 import v3.pref
+import v3.token
 
 // Parses `src` on its own and returns the flat AST plus the exact bytes the
 // parser saw, so a node's [offset, end) span can be checked against the source.
@@ -74,6 +75,24 @@ fn test_supported_unix_comptime_aliases_have_no_diagnostics() {
 	mut p := Parser.new(pref.new_preferences())
 	p.parse_file(path)
 	assert p.diagnostics.len == 0, p.diagnostics.str()
+}
+
+fn test_parser_and_parallel_remap_keep_file_ids_beyond_u16() {
+	path := os.join_path(os.temp_dir(), 'v3_wide_file_id_${os.getpid()}.v')
+	os.write_file(path, 'fn main() {}\n') or { panic(err) }
+	defer {
+		os.rm(path) or {}
+	}
+	wide_file_id := int(max_u16) + 1
+	mut p := Parser.new(pref.new_preferences())
+	p.next_file_id = wide_file_id
+	a := p.parse_file(path)
+	assert wide_file_id in a.source_files
+	assert a.nodes.any(it.pos.id == wide_file_id)
+
+	remapped := remap_worker_pos(token.new_span(wide_file_id, 1, 2), wide_file_id,
+		wide_file_id + 1, 1)
+	assert remapped.id == wide_file_id + 1
 }
 
 fn test_attribute_before_module_preserves_qualified_noreturn_name() {

--- a/vlib/v3/tests/c_output_only_test.v
+++ b/vlib/v3/tests/c_output_only_test.v
@@ -1,15 +1,32 @@
+import io
 import os
 
 const vexe = @VEXE
 const tests_dir = os.dir(@FILE)
 const v3_dir = os.dir(tests_dir)
+const vlib_dir = os.dir(v3_dir)
 const v3_src = os.join_path(v3_dir, 'v3.v')
 const hello_src = os.join_path(tests_dir, 'testdata', 'hello.v')
+
+fn read_c_output_fifo(path string, result chan string) {
+	mut file := os.open(path) or {
+		result <- 'read failed: ${err.msg()}'
+		return
+	}
+	data := io.read_all(reader: file) or {
+		file.close()
+		result <- 'read failed: ${err.msg()}'
+		return
+	}
+	file.close()
+	result <- data.bytestr()
+}
 
 // test_c_output_path_only_writes_c_file validates this v3 regression case.
 fn test_c_output_path_only_writes_c_file() {
 	v3_bin := os.join_path(os.temp_dir(), 'v3_c_output_only_test')
-	build := os.execute('${vexe} -gc none -o ${v3_bin} ${v3_src}')
+	build :=
+		os.execute('${vexe} -old-compiler -gc none -path "${vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${v3_src}')
 	assert build.exit_code == 0, build.output
 
 	c_out := os.join_path(os.temp_dir(), 'v3_output_only.c')
@@ -31,4 +48,22 @@ fn test_c_output_path_only_writes_c_file() {
 	assert !compile.output.contains('  > ')
 	assert !compile.output.contains('tcc.exe')
 	assert !compile.output.contains('cc -std=gnu11')
+
+	$if !windows {
+		fifo_out := os.join_path(os.temp_dir(), 'v3_output_fifo_${os.getpid()}.c')
+		os.rm(fifo_out) or {}
+		defer {
+			os.rm(fifo_out) or {}
+		}
+		mkfifo := os.execute('mkfifo ${os.quoted_path(fifo_out)}')
+		assert mkfifo.exit_code == 0, mkfifo.output
+		fifo_result := chan string{cap: 1}
+		reader := spawn read_c_output_fifo(fifo_out, fifo_result)
+		fifo_compile := os.execute('${v3_bin} -gc none -o ${os.quoted_path(fifo_out)} ${hello_src}')
+		fifo_source := <-fifo_result
+		reader.wait()
+		assert fifo_compile.exit_code == 0, fifo_compile.output
+		assert !fifo_source.starts_with('read failed:'), fifo_source
+		assert fifo_source.contains('int main(int argc, char** argv)'), fifo_source
+	}
 }

--- a/vlib/v3/tests/review_checker_regressions_test.v
+++ b/vlib/v3/tests/review_checker_regressions_test.v
@@ -548,6 +548,22 @@ fn main() {
 		'cannot assign to `value`: expected `?int`, not `?void`')
 }
 
+fn test_assignment_selector_diagnostic_accepts_wide_columns() {
+	v3_bin := build_v3_review_checker()
+	indent := ' '.repeat(32768)
+	run_bad(v3_bin, 'wide_assignment_selector_diagnostic', 'struct Holder {
+	item ?string
+}
+
+fn main() {
+	holder := Holder{}
+	mut value := 0
+${indent}value = holder.item or { "" }
+}
+',
+		'cannot assign to `value`: expected `int`, not `string`')
+}
+
 fn test_optional_address_preserves_wrapper_shape() {
 	v3_bin := build_v3_review_checker()
 	out := run_good(v3_bin, 'optional_address_wrapper_shape', 'fn take_wrapper(value &?int) {

--- a/vlib/v3/token/position.v
+++ b/vlib/v3/token/position.v
@@ -5,7 +5,7 @@ pub struct Pos {
 pub:
 	offset int
 	end    int
-	id     u16
+	id     int
 	meta   u16
 }
 
@@ -13,11 +13,8 @@ const type_text_meta_flag = u16(0x8000)
 
 // new_pos creates a source position from a stable file id and byte offset.
 pub fn new_pos(file_id int, offset int) Pos {
-	if file_id < 0 || file_id > int(max_u16) {
-		panic('V3 source file id exceeds 65535')
-	}
 	return Pos{
-		id:     u16(file_id)
+		id:     file_id
 		offset: offset
 		end:    offset
 	}
@@ -26,11 +23,8 @@ pub fn new_pos(file_id int, offset int) Pos {
 // new_span creates an immutable half-open source span. The offset field is
 // retained as the start for compatibility with existing diagnostic consumers.
 pub fn new_span(file_id int, start int, end int) Pos {
-	if file_id < 0 || file_id > int(max_u16) {
-		panic('V3 source file id exceeds 65535')
-	}
 	return Pos{
-		id:     u16(file_id)
+		id:     file_id
 		offset: start
 		end:    if end < start { start } else { end }
 	}

--- a/vlib/v3/token/position.v
+++ b/vlib/v3/token/position.v
@@ -37,9 +37,11 @@ pub fn new_span(file_id int, start int, end int) Pos {
 }
 
 // with_reported_column overrides the one-based column shown in a diagnostic header.
+// Columns that do not fit in the compact metadata are ignored so diagnostics can
+// fall back to the source position instead of aborting compilation.
 pub fn (p Pos) with_reported_column(column int) Pos {
 	if column < 0 || column >= int(type_text_meta_flag) {
-		panic('V3 reported source column exceeds 32767')
+		return p
 	}
 	return Pos{
 		...p

--- a/vlib/v3/token/position.v
+++ b/vlib/v3/token/position.v
@@ -3,16 +3,21 @@ module token
 // Pos represents pos data used by token.
 pub struct Pos {
 pub:
-	offset          int
-	end             int
-	id              int
-	reported_column int
+	offset int
+	end    int
+	id     u16
+	meta   u16
 }
+
+const type_text_meta_flag = u16(0x8000)
 
 // new_pos creates a source position from a stable file id and byte offset.
 pub fn new_pos(file_id int, offset int) Pos {
+	if file_id < 0 || file_id > int(max_u16) {
+		panic('V3 source file id exceeds 65535')
+	}
 	return Pos{
-		id:     file_id
+		id:     u16(file_id)
 		offset: offset
 		end:    offset
 	}
@@ -21,8 +26,11 @@ pub fn new_pos(file_id int, offset int) Pos {
 // new_span creates an immutable half-open source span. The offset field is
 // retained as the start for compatibility with existing diagnostic consumers.
 pub fn new_span(file_id int, start int, end int) Pos {
+	if file_id < 0 || file_id > int(max_u16) {
+		panic('V3 source file id exceeds 65535')
+	}
 	return Pos{
-		id:     file_id
+		id:     u16(file_id)
 		offset: start
 		end:    if end < start { start } else { end }
 	}
@@ -30,9 +38,41 @@ pub fn new_span(file_id int, start int, end int) Pos {
 
 // with_reported_column overrides the one-based column shown in a diagnostic header.
 pub fn (p Pos) with_reported_column(column int) Pos {
+	if column < 0 || column >= int(type_text_meta_flag) {
+		panic('V3 reported source column exceeds 32767')
+	}
 	return Pos{
 		...p
-		reported_column: column
+		meta: u16(column)
+	}
+}
+
+// reported_column returns the optional diagnostic column override. The high
+// meta bit belongs to Node's canonical type-text id and is invisible to
+// ordinary source-position consumers.
+@[inline]
+pub fn (p Pos) reported_column() int {
+	return if p.meta & type_text_meta_flag == 0 { int(p.meta) } else { 0 }
+}
+
+// type_text_id returns the compact Node annotation identity stored in unused
+// position metadata. Source positions carrying a diagnostic column do not
+// carry a type identity.
+@[inline]
+pub fn (p Pos) type_text_id() u16 {
+	return if p.meta & type_text_meta_flag != 0 { p.meta & ~type_text_meta_flag } else { 0 }
+}
+
+// with_type_text_id stores a compact identity when no diagnostic column is
+// present. Larger ids use the existing string-keyed type cache.
+@[inline]
+pub fn (p Pos) with_type_text_id(id u16) Pos {
+	if p.reported_column() > 0 {
+		return p
+	}
+	return Pos{
+		...p
+		meta: if id > 0 && id < type_text_meta_flag { type_text_meta_flag | id } else { 0 }
 	}
 }
 

--- a/vlib/v3/token/token_test.v
+++ b/vlib/v3/token/token_test.v
@@ -45,6 +45,16 @@ fn test_file_position_resolves_file_local_offsets() {
 	assert f.line(new_pos(1, 9)) == 2
 }
 
+fn test_reported_column_outside_compact_range_is_ignored() {
+	pos := new_span(1, 10, 13)
+	wide := pos.with_reported_column(32768)
+	assert wide == pos
+	assert wide.reported_column() == 0
+
+	typed := pos.with_type_text_id(7)
+	assert typed.with_reported_column(32768) == typed
+}
+
 fn test_keyword_property_does_not_depend_on_enum_ordinals() {
 	assert Token.key_as.is_keyword()
 	assert Token.key_unsafe.is_keyword()

--- a/vlib/v3/token/token_test.v
+++ b/vlib/v3/token/token_test.v
@@ -55,6 +55,14 @@ fn test_reported_column_outside_compact_range_is_ignored() {
 	assert typed.with_reported_column(32768) == typed
 }
 
+fn test_source_file_ids_are_wider_than_u16() {
+	file_id := int(max_u16) + 1
+	pos := new_pos(file_id, 7)
+	span := new_span(file_id, 7, 11)
+	assert pos.id == file_id
+	assert span.id == file_id
+}
+
 fn test_keyword_property_does_not_depend_on_enum_ordinals() {
 	assert Token.key_as.is_keyword()
 	assert Token.key_unsafe.is_keyword()

--- a/vlib/v3/transform/array.v
+++ b/vlib/v3/transform/array.v
@@ -1162,6 +1162,7 @@ fn (mut t Transformer) try_lower_array_append_or_stmt(node flat.Node) ?[]flat.No
 	return none
 }
 
+@[direct_array_access]
 fn (mut t Transformer) try_lower_array_append_stmt(id flat.NodeId) ?[]flat.NodeId {
 	if int(id) < 0 {
 		return none

--- a/vlib/v3/transform/comptime.v
+++ b/vlib/v3/transform/comptime.v
@@ -801,6 +801,9 @@ fn (t &Transformer) comptime_param_metas(fn_name string) []ParamMeta {
 		for i in 0 .. node.children_count {
 			param := t.a.child_node(&node, i)
 			if param.kind != .param {
+				if t.prefix_param_scan {
+					break
+				}
 				continue
 			}
 			if i == 0 && param.op == .dot {
@@ -1149,13 +1152,17 @@ fn (t &Transformer) comptime_method_metas(base_type string) []MethodMeta {
 		mut params := []ParamMeta{}
 		for i in 1 .. node.children_count {
 			param := t.a.child_node(&node, i)
-			if param.kind == .param {
-				params << ParamMeta{
-					name:        param.value
-					typ:         substitute_generic_type_text_with_params(param.typ, generic_args,
-						generic_params)
-					module_name: module_name
+			if param.kind != .param {
+				if t.prefix_param_scan {
+					break
 				}
+				continue
+			}
+			params << ParamMeta{
+				name:        param.value
+				typ:         substitute_generic_type_text_with_params(param.typ, generic_args,
+					generic_params)
+				module_name: module_name
 			}
 		}
 		return_type := substitute_generic_type_text_with_params(if node.typ.len > 0 {
@@ -2180,6 +2187,9 @@ fn (mut t Transformer) comptime_field_call_generic_args(node flat.Node, mut chil
 	for i in 0 .. decl.node.children_count {
 		param := t.a.child_node(&decl.node, i)
 		if param.kind != .param {
+			if t.prefix_param_scan {
+				break
+			}
 			continue
 		}
 		arg_id := if is_receiver && param_idx == 0 {

--- a/vlib/v3/transform/expr.v
+++ b/vlib/v3/transform/expr.v
@@ -1196,7 +1196,7 @@ fn (t &Transformer) raw_checker_node_type(id flat.NodeId) string {
 		return ''
 	}
 	typ := t.tc.expr_type(id) or { t.tc.resolve_type(id) }
-	name := typ.name()
+	name := t.tc.type_name(typ)
 	if name.len == 0 || name == 'void' {
 		return ''
 	}
@@ -1228,12 +1228,15 @@ fn (t &Transformer) is_type_alias_name(name string) bool {
 		if cache.module != t.cur_module {
 			cache.module = t.cur_module
 			cache.entries.clear()
+			cache.last_name = ''
+			cache.last_value = 0
 		}
-		if cached := cache.entries[name] {
+		cached := cache.get(name)
+		if cached != 0 {
 			return cached > 0
 		}
 		result := t.is_type_alias_name_uncached(name)
-		cache.entries[name] = if result { i8(1) } else { i8(-1) }
+		cache.put(name, if result { i8(1) } else { i8(-1) })
 		return result
 	}
 	return t.is_type_alias_name_uncached(name)
@@ -3320,18 +3323,18 @@ fn (t &Transformer) selector_array_elem_type(node flat.Node) string {
 
 // membership_container_type supports membership container type handling for Transformer.
 fn (t &Transformer) membership_container_type(typ string) string {
-	mut clean := t.normalize_type_alias(typ).trim_space()
+	mut clean := trimmed_transform_text(t.normalize_type_alias(typ))
 	for {
 		if clean.starts_with('shared ') {
-			clean = clean[7..].trim_space()
+			clean = trimmed_transform_text(clean[7..])
 			continue
 		}
 		if clean.starts_with('&') {
-			clean = clean[1..].trim_space()
+			clean = trimmed_transform_text(clean[1..])
 			continue
 		}
 		if clean.starts_with('...') {
-			clean = '[]' + clean[3..].trim_space()
+			clean = '[]' + trimmed_transform_text(clean[3..])
 			continue
 		}
 		break
@@ -3340,14 +3343,14 @@ fn (t &Transformer) membership_container_type(typ string) string {
 }
 
 fn (t &Transformer) membership_type_is_pointer(typ string) bool {
-	mut clean := t.normalize_type_alias(typ).trim_space()
+	mut clean := trimmed_transform_text(t.normalize_type_alias(typ))
 	for {
 		if clean.starts_with('shared ') {
-			clean = clean[7..].trim_space()
+			clean = trimmed_transform_text(clean[7..])
 			continue
 		}
 		if clean.starts_with('mut ') {
-			clean = clean[4..].trim_space()
+			clean = trimmed_transform_text(clean[4..])
 			continue
 		}
 		break
@@ -3356,16 +3359,16 @@ fn (t &Transformer) membership_type_is_pointer(typ string) bool {
 }
 
 fn (t &Transformer) equality_type_is_array_pointer(typ string) bool {
-	mut clean := typ.trim_space()
+	mut clean := trimmed_transform_text(typ)
 	for clean.starts_with('shared ') {
-		clean = clean[7..].trim_space()
+		clean = trimmed_transform_text(clean[7..])
 	}
 	if clean.starts_with('mut ') {
 		return false
 	}
-	clean = t.normalize_type_alias(clean).trim_space()
+	clean = trimmed_transform_text(t.normalize_type_alias(clean))
 	for clean.starts_with('shared ') {
-		clean = clean[7..].trim_space()
+		clean = trimmed_transform_text(clean[7..])
 	}
 	if !clean.starts_with('&') {
 		return false
@@ -3382,40 +3385,40 @@ fn (t &Transformer) equality_expr_is_string_pointer(id flat.NodeId, typ string) 
 	if node.kind in [.string_literal, .string_interp] {
 		return false
 	}
-	mut clean := typ.trim_space()
+	mut clean := trimmed_transform_text(typ)
 	for clean.starts_with('shared ') {
-		clean = clean[7..].trim_space()
+		clean = trimmed_transform_text(clean[7..])
 	}
 	if clean.starts_with('mut ') {
 		return false
 	}
-	clean = t.normalize_type_alias(clean).trim_space()
+	clean = trimmed_transform_text(t.normalize_type_alias(clean))
 	for clean.starts_with('shared ') {
-		clean = clean[7..].trim_space()
+		clean = trimmed_transform_text(clean[7..])
 	}
 	return clean == '&string'
 }
 
 fn (t &Transformer) equality_type_is_map_pointer(typ string) bool {
-	mut clean := typ.trim_space()
+	mut clean := trimmed_transform_text(typ)
 	for clean.starts_with('shared ') {
-		clean = clean[7..].trim_space()
+		clean = trimmed_transform_text(clean[7..])
 	}
 	if clean.starts_with('mut ') {
 		return false
 	}
-	clean = t.normalize_type_alias(clean).trim_space()
+	clean = trimmed_transform_text(t.normalize_type_alias(clean))
 	for clean.starts_with('shared ') {
-		clean = clean[7..].trim_space()
+		clean = trimmed_transform_text(clean[7..])
 	}
 	return clean.starts_with('&') && t.clean_map_type(clean).starts_with('map[')
 }
 
 // membership_container_is_pointer_array supports membership_container_is_pointer_array handling.
 fn (t &Transformer) membership_container_is_pointer_array(typ string) bool {
-	mut clean := t.normalize_type_alias(typ).trim_space()
+	mut clean := trimmed_transform_text(t.normalize_type_alias(typ))
 	for clean.starts_with('shared ') {
-		clean = clean[7..].trim_space()
+		clean = trimmed_transform_text(clean[7..])
 	}
 	if !clean.starts_with('&') {
 		return false
@@ -3535,14 +3538,14 @@ fn (mut t Transformer) transform_fixed_array_len(_id flat.NodeId, node flat.Node
 
 // clean_map_type transforms clean map type data for transform.
 fn (t &Transformer) clean_map_type(typ string) string {
-	mut clean := t.normalize_type_alias(typ).trim_space()
+	mut clean := trimmed_transform_text(t.normalize_type_alias(typ))
 	for {
 		if clean.starts_with('shared ') {
-			clean = clean[7..].trim_space()
+			clean = trimmed_transform_text(clean[7..])
 			continue
 		}
 		if clean.starts_with('&') {
-			clean = clean[1..].trim_space()
+			clean = trimmed_transform_text(clean[1..])
 			continue
 		}
 		break

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -97,7 +97,7 @@ fn (t &Transformer) local_fn_decl_return_type(name string) ?string {
 	}
 	if !isnil(t.tc) {
 		if ret := t.tc.fn_ret_types[qname] {
-			return ret.name()
+			return t.semantic_type_name(ret)
 		}
 	}
 	return none
@@ -136,7 +136,7 @@ fn (t &Transformer) fn_value_call_return_type(node flat.Node) ?string {
 	if !isnil(t.tc) {
 		mut callee_type := t.tc.expr_type(callee_id) or { t.tc.resolve_type(callee_id) }
 		if fn_type := fn_type_from_type(callee_type) {
-			return fn_type.return_type.name()
+			return t.semantic_type_name(fn_type.return_type)
 		}
 	}
 	callee_type_name := t.node_type(callee_id)
@@ -639,7 +639,7 @@ fn (t &Transformer) resolve_alias_receiver_method(base_type string, method strin
 		if receiver_name.len == 0 || receiver_name !in t.tc.type_aliases {
 			continue
 		}
-		param_name := params[0].name()
+		param_name := t.semantic_type_name(params[0])
 		if t.alias_receiver_type_matches(clean_base, param_name) {
 			if !isnil(t.alias_receiver_method_cache) {
 				mut cache := t.alias_receiver_method_cache
@@ -750,7 +750,7 @@ fn (t &Transformer) raw_const_type_name_for_expr(id flat.NodeId) ?string {
 	}
 	key := t.const_type_key_in_context(name, t.cur_module, t.cur_file) or { return none }
 	typ := t.tc.const_types[key] or { return none }
-	return typ.name()
+	return t.semantic_type_name(typ)
 }
 
 // resolve_method_receiver_type determines the receiver type for method calls.
@@ -982,6 +982,7 @@ fn transform_type_is_indexable(typ types.Type) bool {
 
 // transform_call_args transforms all children of a call expression.
 // child[0] is the function expression, children[1..n] are arguments.
+@[direct_array_access]
 fn (mut t Transformer) transform_call_args(id flat.NodeId, node flat.Node) flat.NodeId {
 	if node.children_count == 0 {
 		return t.a.add_node(flat.Node{
@@ -1041,7 +1042,7 @@ fn (mut t Transformer) transform_call_args(id flat.NodeId, node flat.Node) flat.
 	mut transformed_callee := t.const_fn_call_target(callee_id) or {
 		if param_offset == 1 && params.len > 0 {
 			if converted_callee := t.transform_method_callee_receiver_for_param(callee_id,
-				params[0].name())
+				t.semantic_type_name(params[0]))
 			{
 				converted_callee
 			} else {
@@ -1156,7 +1157,7 @@ fn (mut t Transformer) transform_call_args(id flat.NodeId, node flat.Node) flat.
 			spread_base := t.stable_expr_for_reuse(spread_id)
 			spread_count := params.len - param_idx
 			for spread_offset in 0 .. spread_count {
-				expected := params[param_idx + spread_offset].name()
+				expected := t.semantic_type_name(params[param_idx + spread_offset])
 				index_arg := t.make_spread_index_for_expected_param(spread_base, spread_offset,
 					expected)
 				new_children << t.transform_call_arg_for_named_param(index_arg, expected, call_name)
@@ -1176,7 +1177,8 @@ fn (mut t Transformer) transform_call_args(id flat.NodeId, node flat.Node) flat.
 					if expected_idx >= params.len {
 						break
 					}
-					field := t.make_selector(value, 'arg${multi_idx}', item_type.name())
+					field := t.make_selector(value, 'arg${multi_idx}',
+						t.semantic_type_name(item_type))
 					new_children << t.transform_call_arg_for_named_param(field,
 						param_type_names[expected_idx], call_name)
 				}
@@ -1195,14 +1197,20 @@ fn (mut t Transformer) transform_call_args(id flat.NodeId, node flat.Node) flat.
 		}
 	}
 	t.append_missing_params_struct_args(mut new_children, params, param_offset)
-	start := t.a.children.len
-	for nc in new_children {
-		t.a.children << nc
-	}
 	mut typ := node.typ
 	concrete_ret := t.concrete_generic_call_return_type(id, node)
 	if concrete_ret.len > 0 {
 		typ = concrete_ret
+	}
+	if t.rewrite_children_in_place(id, new_children) {
+		if typ != t.a.nodes[int(id)].typ {
+			t.set_node_typ(int(id), typ)
+		}
+		return id
+	}
+	start := t.a.children.len
+	for nc in new_children {
+		t.a.children << nc
 	}
 	new_id := t.a.add_node(flat.Node{
 		kind:           .call
@@ -1263,7 +1271,11 @@ fn (mut t Transformer) transform_cgen_json_encode_call(id flat.NodeId, node flat
 fn (t &Transformer) call_param_type_names(params []types.Type) []string {
 	mut names := []string{cap: params.len}
 	for param in params {
-		names << param.name()
+		names << if t.memo_call_param_type_names && !isnil(t.tc) {
+			t.tc.type_name(param)
+		} else {
+			param.name()
+		}
 	}
 	return names
 }
@@ -1272,7 +1284,7 @@ fn (t &Transformer) variadic_interface_single_array_should_box(arg_type string, 
 	if !arg_type.starts_with('[]') {
 		return false
 	}
-	if t.normalize_type_alias(arg_type) == t.normalize_type_alias(types.Type(variadic_type).name()) {
+	if t.normalize_type_alias(arg_type) == t.normalize_type_alias(t.semantic_type_name(variadic_type)) {
 		return false
 	}
 	elem_type := variadic_type.elem_type
@@ -1317,7 +1329,7 @@ fn (mut t Transformer) transform_spread_arg_over_fixed_variadic_tail(arg_node fl
 		return none
 	}
 	spread_id := t.a.child(&arg_node, 0)
-	variadic_array_type := variadic_type.name()
+	variadic_array_type := t.semantic_type_name(variadic_type)
 	spread_type0 := t.node_type(spread_id)
 	spread_type := if spread_type0.len > 0 { spread_type0 } else { variadic_array_type }
 	spread_expr := t.stable_transformed_expr_for_reuse(t.transform_call_arg_for_param(spread_id,
@@ -1325,7 +1337,7 @@ fn (mut t Transformer) transform_spread_arg_over_fixed_variadic_tail(arg_node fl
 	mut args := []flat.NodeId{cap: variadic_idx - param_idx + 1}
 	for fixed_idx in param_idx .. variadic_idx {
 		elem := t.make_index(spread_expr, t.make_int_literal(fixed_idx - param_idx),
-			params[fixed_idx].name())
+			t.semantic_type_name(params[fixed_idx]))
 		args << elem
 	}
 	tail_start := variadic_idx - param_idx
@@ -1355,8 +1367,8 @@ fn (mut t Transformer) transform_variadic_spread_arg_for_param(spread_id flat.No
 		actual := types.unwrap_pointer(t.tc.resolve_type(spread_id))
 		if actual is types.Array {
 			expected := types.Type(variadic_type)
-			actual_elem := t.normalize_type_alias(actual.elem_type.name())
-			expected_elem := t.normalize_type_alias(variadic_type.elem_type.name())
+			actual_elem := t.normalize_type_alias(t.semantic_type_name(actual.elem_type))
+			expected_elem := t.normalize_type_alias(t.semantic_type_name(variadic_type.elem_type))
 			if actual_elem != expected_elem
 				&& t.sum_target_accepts_variant_type(expected_elem, actual_elem) {
 				return t.convert_forwarded_array_to_dynamic(spread_id, actual, actual.elem_type,
@@ -1677,7 +1689,7 @@ fn (t &Transformer) selector_call_name_has_receiver_param(call_name string, meth
 		|| !call_name.ends_with('.${method}') {
 		return false
 	}
-	first_type := t.normalize_type_alias(params[0].name())
+	first_type := t.normalize_type_alias(t.semantic_type_name(params[0]))
 	clean_first := if first_type.starts_with('&') { first_type[1..] } else { first_type }
 	if receiver_param_matches_method_name(clean_first, call_name) {
 		return true
@@ -1790,7 +1802,7 @@ fn (t &Transformer) is_import_alias_ident(id flat.NodeId) bool {
 		return false
 	}
 	if typ := t.tc.expr_type(id) {
-		name := typ.name()
+		name := t.semantic_type_name(typ)
 		if name.len > 0 && name != 'unknown' && name != 'void' {
 			return false
 		}
@@ -1993,6 +2005,9 @@ fn (mut t Transformer) call_param_types_from_decl(call_name string) ?[]types.Typ
 	for i in 0 .. node.children_count {
 		child := t.a.child_node(&node, i)
 		if child.kind != .param {
+			if t.prefix_param_scan {
+				break
+			}
 			continue
 		}
 		mut param_type := t.parse_decl_param_type(child.typ, decl.module, decl.file)
@@ -2021,8 +2036,37 @@ fn (mut t Transformer) ensure_call_param_types_decl_index() {
 		return
 	}
 	t.call_param_types_decl_index.clear()
+	if !isnil(t.tc) && t.tc.top_level_idx.len > 0 {
+		t.call_param_types_decl_index.reserve(u32(t.tc.top_level_idx.len * 3))
+	}
 	mut file_name := ''
 	mut module_name := ''
+	use_top_level_index := !isnil(t.tc) && t.tc.top_level_idx.len > 0
+		&& t.tc.top_level_idx_nodes_len == t.a.nodes.len
+	if use_top_level_index {
+		for i in t.tc.top_level_idx {
+			node := t.a.nodes[i]
+			if node.kind == .file {
+				file_name = node.value
+				module_name = t.tc.file_modules[file_name] or { '' }
+				continue
+			}
+			if node.kind == .module_decl {
+				module_name = node.value
+				continue
+			}
+			if node.kind != .fn_decl {
+				continue
+			}
+			t.add_call_param_types_decl_key(node.value, i, file_name, module_name)
+			qname := transform_qualified_fn_name(module_name, node.value)
+			if qname != node.value {
+				t.add_call_param_types_decl_key(qname, i, file_name, module_name)
+			}
+		}
+		t.call_param_types_index_ready = true
+		return
+	}
 	for i, node in t.a.nodes {
 		if node.kind == .file {
 			file_name = node.value
@@ -2046,17 +2090,29 @@ fn (mut t Transformer) ensure_call_param_types_decl_index() {
 }
 
 fn (mut t Transformer) prepare_parallel_call_param_types() {
+	if t.call_param_types_prepared {
+		return
+	}
 	t.ensure_call_param_types_decl_index()
-	names := t.call_param_types_decl_index.keys()
-	for name in names {
+	mut seen := map[int]bool{}
+	seen.reserve(u32(t.call_param_types_decl_index.len / 2 + 1))
+	for name, decl in t.call_param_types_decl_index {
+		if seen[decl.idx] {
+			continue
+		}
+		seen[decl.idx] = true
 		_ = t.call_param_types_from_decl(name) or { continue }
 	}
+	t.call_param_types_prepared = true
 }
 
 fn (mut t Transformer) add_call_param_types_decl_key(key string, idx int, file string, module_name string) {
 	if key.len == 0 {
 		return
 	}
+	// A later generic specialization can extend the declaration index between
+	// parallel batches. Make the next snapshot include its signature too.
+	t.call_param_types_prepared = false
 	if key !in t.call_param_types_decl_index {
 		t.call_param_types_decl_index[key] = FnParamDeclRef{
 			idx:    idx
@@ -2215,14 +2271,15 @@ fn (t &Transformer) call_is_variadic(call_name string) bool {
 	key := '${t.cur_file}\n${call_name}'
 	if !isnil(t.call_variadic_cache) {
 		mut cache := t.call_variadic_cache
-		if cached := cache.entries[key] {
+		cached := cache.get(key)
+		if cached != 0 {
 			return cached > 0
 		}
 	}
 	result := t.call_is_variadic_uncached(call_name)
 	if !isnil(t.call_variadic_cache) {
 		mut cache := t.call_variadic_cache
-		cache.entries[key] = if result { i8(1) } else { i8(-1) }
+		cache.put(key, if result { i8(1) } else { i8(-1) })
 	}
 	return result
 }
@@ -2280,7 +2337,7 @@ fn (t &Transformer) call_param_type_name(call_name string, idx int) string {
 	if idx >= params.len {
 		return ''
 	}
-	return params[idx].name()
+	return t.semantic_type_name(params[idx])
 }
 
 fn (mut t Transformer) wrap_sum_ref_arg(arg_id flat.NodeId, target_sum string) ?flat.NodeId {
@@ -2447,7 +2504,7 @@ fn (t &Transformer) overloaded_index_result_type(id flat.NodeId) ?string {
 					}
 				}
 				if ret := t.tc.fn_ret_types[method_name] {
-					typ := t.normalize_type_alias(ret.name())
+					typ := t.normalize_type_alias(t.semantic_type_name(ret))
 					if decl_type_is_usable(typ) {
 						return typ
 					}
@@ -2455,7 +2512,7 @@ fn (t &Transformer) overloaded_index_result_type(id flat.NodeId) ?string {
 			}
 			base_type := t.tc.expr_type(base_id) or { t.tc.resolve_type(base_id) }
 			if info := t.tc.index_overload_call_info(base_type, false) {
-				typ := t.normalize_type_alias(info.return_type.name())
+				typ := t.normalize_type_alias(t.semantic_type_name(info.return_type))
 				if decl_type_is_usable(typ) {
 					return typ
 				}
@@ -2517,6 +2574,7 @@ fn pointer_type_depth_and_base(typ string) (int, string) {
 }
 
 // transform_call_arg_for_param transforms transform call arg for param data for transform.
+@[direct_array_access]
 fn (mut t Transformer) transform_call_arg_for_param(arg_id flat.NodeId, param_type string) flat.NodeId {
 	if int(arg_id) < 0 {
 		return arg_id
@@ -2888,7 +2946,7 @@ fn (mut t Transformer) lift_lambda_expr_for_fn_param(_id flat.NodeId, node flat.
 	for i in 0 .. lambda_param_count {
 		param_id := t.a.child(&node, i)
 		param_node := t.a.nodes[int(param_id)]
-		param_type_name := fn_type.params[i].name()
+		param_type_name := t.semantic_type_name(fn_type.params[i])
 		children << t.a.add_node(flat.Node{
 			kind:  .param
 			value: param_node.value
@@ -2897,7 +2955,7 @@ fn (mut t Transformer) lift_lambda_expr_for_fn_param(_id flat.NodeId, node flat.
 		})
 	}
 	for i in lambda_param_count .. fn_type.params.len {
-		param_type_name := fn_type.params[i].name()
+		param_type_name := t.semantic_type_name(fn_type.params[i])
 		children << t.a.add_node(flat.Node{
 			kind:  .param
 			value: '_unused_${i}'
@@ -2905,7 +2963,7 @@ fn (mut t Transformer) lift_lambda_expr_for_fn_param(_id flat.NodeId, node flat.
 			op:    if param_type_name.starts_with('&') { .amp } else { .none }
 		})
 	}
-	ret_type := fn_type.return_type.name()
+	ret_type := t.semantic_type_name(fn_type.return_type)
 	if t.is_optional_type_name(ret_type) && t.optional_base_type(ret_type) == 'void' {
 		body_type := t.qualify_optional_type(t.node_type(body_id))
 		ret_type0 := t.qualify_optional_type(ret_type)
@@ -2967,7 +3025,7 @@ fn (mut t Transformer) lift_fn_literal_for_fn_param(_id flat.NodeId, node flat.N
 	mut children := []flat.NodeId{cap: capture_ids.len + fn_type.params.len + body_ids.len}
 	children << capture_ids
 	for i, param_id in param_ids {
-		param_type_name := fn_type.params[i].name()
+		param_type_name := t.semantic_type_name(fn_type.params[i])
 		param := t.a.nodes[int(param_id)]
 		if param.typ == param_type_name {
 			children << param_id
@@ -2982,7 +3040,7 @@ fn (mut t Transformer) lift_fn_literal_for_fn_param(_id flat.NodeId, node flat.N
 		}
 	}
 	for i in param_ids.len .. fn_type.params.len {
-		param_type_name := fn_type.params[i].name()
+		param_type_name := t.semantic_type_name(fn_type.params[i])
 		children << t.a.add_node(flat.Node{
 			kind:  .param
 			value: '_unused_${i}'
@@ -2998,7 +3056,7 @@ fn (mut t Transformer) lift_fn_literal_for_fn_param(_id flat.NodeId, node flat.N
 	ret_type := if node.typ.len > 0 && node.typ != 'void' {
 		node.typ
 	} else {
-		fn_type.return_type.name()
+		t.semantic_type_name(fn_type.return_type)
 	}
 	fn_id := t.a.add_node(flat.Node{
 		kind:           .fn_literal
@@ -3356,7 +3414,7 @@ fn (mut t Transformer) append_missing_params_struct_args(mut args []flat.NodeId,
 		param_idx = args.len - 1 + param_offset
 	}
 	for param_idx < params.len {
-		param_type := params[param_idx].name()
+		param_type := t.semantic_type_name(params[param_idx])
 		if struct_type := t.params_struct_type_name(param_type) {
 			args << t.zero_value_for_type(struct_type)
 			t.mark_params_struct_default_calls(struct_type)
@@ -3544,11 +3602,11 @@ fn (t &Transformer) selector_const_base_is_value(node flat.Node) bool {
 		return true
 	}
 	if typ := t.tc.expr_type(base_id) {
-		name := typ.name()
+		name := t.semantic_type_name(typ)
 		return name.len > 0 && name !in ['void', 'unknown']
 	}
 	resolved := t.tc.resolve_type(base_id)
-	name := resolved.name()
+	name := t.semantic_type_name(resolved)
 	return name.len > 0 && name !in ['void', 'unknown']
 }
 
@@ -3573,7 +3631,7 @@ fn (t &Transformer) const_expr_for_name_in_context(name string, module_name stri
 
 // pack_variadic_args supports pack variadic args handling for Transformer.
 fn (mut t Transformer) pack_variadic_args(node flat.Node, first_arg int, elem_type types.Type) flat.NodeId {
-	expected_enum := elem_type.name()
+	expected_enum := t.semantic_type_name(elem_type)
 	array_type := '[]${expected_enum}'
 	if named_arg := t.transform_variadic_struct_fields(node, first_arg, elem_type) {
 		if t.in_const_init {
@@ -3634,7 +3692,7 @@ fn (mut t Transformer) append_trailing_args_to_variadic_tail(tail flat.NodeId, n
 		return tail
 	}
 	elem_type := variadic_type.elem_type
-	expected_elem := elem_type.name()
+	expected_elem := t.semantic_type_name(elem_type)
 	array_type := '[]${expected_elem}'
 	tail_value := t.stable_transformed_expr_for_reuse(tail, array_type, 'varargs_tail')
 	tmp_name := t.new_temp('varargs')
@@ -3660,7 +3718,7 @@ fn (mut t Transformer) append_trailing_args_to_variadic_tail(tail flat.NodeId, n
 }
 
 fn (mut t Transformer) append_variadic_arg_push(tmp_name string, arg_id flat.NodeId, elem_type types.Type) {
-	expected_elem := elem_type.name()
+	expected_elem := t.semantic_type_name(elem_type)
 	arg := t.a.nodes[int(arg_id)]
 	value := if specialized := t.specialize_generic_fn_value_arg(arg_id, expected_elem, true) {
 		specialized
@@ -3677,7 +3735,7 @@ fn (mut t Transformer) append_variadic_arg_push(tmp_name string, arg_id flat.Nod
 }
 
 fn (mut t Transformer) append_variadic_value_push(tmp_name string, value flat.NodeId, arg_id flat.NodeId, elem_type types.Type) {
-	expected_elem := elem_type.name()
+	expected_elem := t.semantic_type_name(elem_type)
 	value_name := t.new_temp('vararg')
 	if int(arg_id) >= 0 && variadic_elem_is_voidptr(elem_type) {
 		value_arg := if t.voidptr_variadic_arg_passes_direct(arg_id) {
@@ -3778,8 +3836,8 @@ fn (mut t Transformer) transform_variadic_struct_fields(node flat.Node, field_st
 		kind:           .struct_init
 		children_start: start
 		children_count: flat.child_count(field_ids.len)
-		value:          elem_type.name()
-		typ:            elem_type.name()
+		value:          t.semantic_type_name(elem_type)
+		typ:            t.semantic_type_name(elem_type)
 	})
 	return t.transform_struct_fields(struct_id, t.a.nodes[int(struct_id)])
 }
@@ -4006,13 +4064,13 @@ fn (t &Transformer) reliable_infix_stringify_type(node flat.Node) string {
 fn (t &Transformer) unsigned_shift_type_text(typ string) string {
 	clean := typ.trim_space()
 	if !isnil(t.tc) {
-		resolved := types.unsigned_shift_result_type(t.tc.parse_type(clean)).name()
+		resolved := t.semantic_type_name(types.unsigned_shift_result_type(t.tc.parse_type(clean)))
 		if resolved in ['u8', 'u16', 'u32', 'u64', 'usize'] {
 			return resolved
 		}
 	}
 	if types.is_builtin_type_name(clean) {
-		return types.unsigned_shift_result_type(types.builtin_type_value(clean)).name()
+		return t.semantic_type_name(types.unsigned_shift_result_type(types.builtin_type_value(clean)))
 	}
 	return typ
 }
@@ -4651,7 +4709,7 @@ fn (t &Transformer) str_method_has_pointer_receiver(str_fn string) bool {
 		return false
 	}
 	receiver := params[0]
-	return receiver is types.Pointer || receiver.name().starts_with('&')
+	return receiver is types.Pointer || t.semantic_type_name(receiver).starts_with('&')
 }
 
 fn (t &Transformer) aggregate_str_method_name(aggregate string) ?string {
@@ -5145,7 +5203,7 @@ fn (t &Transformer) fn_stringify_display(typ string) string {
 	if !isnil(t.tc) {
 		parsed := t.tc.parse_type(clean)
 		if parsed is types.Alias && parsed.base_type is types.FnType {
-			return t.fn_stringify_display(types.Type(parsed.base_type).name())
+			return t.fn_stringify_display(t.semantic_type_name(parsed.base_type))
 		}
 	}
 	return typeof_fn_type_display(clean)
@@ -5570,7 +5628,7 @@ fn (mut t Transformer) lower_multi_return_str(expr flat.NodeId, multi types.Mult
 		if i > 0 {
 			result = t.string_plus(result, t.make_string_literal(', '))
 		}
-		item_type := item.name()
+		item_type := t.semantic_type_name(item)
 		mut item_str := t.wrap_string_conversion(t.make_selector(base, 'arg${i}', item_type),
 			item_type)
 		if item is types.String {
@@ -6918,7 +6976,7 @@ fn (mut t Transformer) generic_receiver_str_call(expr flat.NodeId, typ string) ?
 	info := t.tc.resolve_generic_struct_method(clean_typ, 'str') or {
 		t.tc.resolve_generic_sum_method(clean_typ, 'str') or { return none }
 	}
-	if info.return_type.name() != 'string' {
+	if t.semantic_type_name(info.return_type) != 'string' {
 		return none
 	}
 	method_name := '${clean_typ}.str'
@@ -7719,7 +7777,7 @@ fn (mut t Transformer) make_compiler_default_clone_value(source flat.NodeId, typ
 		if method_name.len > 0 {
 			params := t.call_param_types(method_name)
 			mut receiver := source
-			if params.len > 0 && params[0].name().starts_with('&') {
+			if params.len > 0 && t.semantic_type_name(params[0]).starts_with('&') {
 				receiver = t.runtime_addr(source, clean)
 			}
 			t.mark_fn_used_name(method_name)
@@ -7950,12 +8008,8 @@ fn (t &Transformer) compiler_default_clone_type_needs_work(typ string) bool {
 		}
 	}
 	if clean in t.structs || clean in t.sum_types {
-		for name, _ in t.fn_ret_types {
-			if name == '${clean}.clone' {
-				return true
-			}
-		}
-		if !isnil(t.tc) && '${clean}.clone' in t.tc.fn_ret_types {
+		clone_name := '${clean}.clone'
+		if clone_name in t.fn_ret_types || (!isnil(t.tc) && clone_name in t.tc.fn_ret_types) {
 			return true
 		}
 	}
@@ -8786,7 +8840,7 @@ fn (mut t Transformer) validate_cgen_array_method_args(node flat.Node, base_id f
 		if params.len > 0 {
 			param_offset := t.receiver_method_param_offset(base_id, node, params, builtin_method)
 			for i in param_offset .. params.len {
-				expected_types << t.normalize_type_alias(params[i].name())
+				expected_types << t.normalize_type_alias(t.semantic_type_name(params[i]))
 			}
 			has_signature = true
 		}
@@ -9376,7 +9430,7 @@ fn (mut t Transformer) lift_fn_literal(_id flat.NodeId, node flat.Node) flat.Nod
 				}
 				if capture_type.len == 0 && !isnil(t.tc) {
 					if typ := t.tc.expr_type(child_id) {
-						capture_type = typ.name()
+						capture_type = t.semantic_type_name(typ)
 					}
 				}
 				if capture_type.len == 0 || capture_type == 'unknown' {
@@ -10576,6 +10630,7 @@ fn (mut t Transformer) pool_processor_field(base flat.NodeId, base_type string, 
 }
 
 // try_lower_receiver_method_call supports try lower receiver method call handling for Transformer.
+@[direct_array_access]
 fn (mut t Transformer) try_lower_receiver_method_call(id flat.NodeId, node flat.Node) ?flat.NodeId {
 	if node.children_count == 0 {
 		return none
@@ -11002,7 +11057,7 @@ fn (mut t Transformer) validate_resolved_receiver_method_args(node flat.Node, ba
 			trailing_idx--
 			continue
 		}
-		if _ := t.params_struct_type_name(params[trailing_idx].name()) {
+		if _ := t.params_struct_type_name(t.semantic_type_name(params[trailing_idx])) {
 			min_count--
 			trailing_idx--
 			continue
@@ -11023,8 +11078,9 @@ fn (mut t Transformer) validate_resolved_receiver_method_args(node flat.Node, ba
 		param_idx := param_offset + arg_idx
 		mut expected := params[if param_idx < params.len { param_idx } else { params.len - 1 }]
 		if arg_node.kind == .field_init {
-			struct_type := t.params_struct_type_name(expected.name()) or {
-				t.struct_arg_type_name(expected.name()) or { '' }
+			expected_name := t.semantic_type_name(expected)
+			struct_type := t.params_struct_type_name(expected_name) or {
+				t.struct_arg_type_name(expected_name) or { '' }
 			}
 			if struct_type.len == 0
 				|| !t.validate_specialized_struct_field_args(node, child_idx, struct_type) {
@@ -11041,7 +11097,7 @@ fn (mut t Transformer) validate_resolved_receiver_method_args(node flat.Node, ba
 					if arg_node.children_count > 0 {
 						spread_id := t.a.child(&arg_node, 0)
 						actual_name := t.specialized_expr_type_name(spread_id)
-						expected_name := params[params.len - 1].name()
+						expected_name := t.semantic_type_name(params[params.len - 1])
 						if !t.resolved_receiver_arg_compatible(spread_id, actual_name,
 							expected_name) {
 							t.record_monomorph_error('cannot use `${actual_name}` as argument ${
@@ -11057,7 +11113,7 @@ fn (mut t Transformer) validate_resolved_receiver_method_args(node flat.Node, ba
 			}
 		}
 		actual_name := t.specialized_expr_type_name(arg_id)
-		expected_name := expected.name()
+		expected_name := t.semantic_type_name(expected)
 		if t.resolved_receiver_arg_compatible(arg_id, actual_name, expected_name) {
 			child_idx++
 			arg_idx++
@@ -11126,7 +11182,7 @@ fn (mut t Transformer) validate_specialized_fn_field_call(id flat.NodeId, node f
 	for i in 0 .. actual_count {
 		arg_id := t.a.child(&node, i + 1)
 		actual_type := t.specialized_expr_type_name(arg_id)
-		expected_type := fn_type.params[i].name()
+		expected_type := t.semantic_type_name(fn_type.params[i])
 		if t.resolved_receiver_arg_compatible(arg_id, actual_type, expected_type) {
 			continue
 		}
@@ -11136,7 +11192,7 @@ fn (mut t Transformer) validate_specialized_fn_field_call(id flat.NodeId, node f
 		t.record_monomorph_error('cannot use `${actual_type}` as argument ${i + 1} to `${display_name}`; expected `${expected_type}`')
 		valid = false
 	}
-	if !t.validate_specialized_call_result(id, fn_type.return_type.name()) {
+	if !t.validate_specialized_call_result(id, t.semantic_type_name(fn_type.return_type)) {
 		valid = false
 	}
 	return valid
@@ -11636,7 +11692,7 @@ fn (t &Transformer) resolved_call_uses_receiver_type(base_id flat.NodeId, receiv
 	if params.len == 0 {
 		return false
 	}
-	mut param_type := params[0].name()
+	mut param_type := t.semantic_type_name(params[0])
 	if param_type.starts_with('&') {
 		param_type = param_type[1..]
 	}
@@ -11707,7 +11763,7 @@ fn (mut t Transformer) receiver_base_for_resolved_method(base_id flat.NodeId, me
 	if params.len == 0 {
 		return t.transform_expr(base_id)
 	}
-	mut param_type := params[0].name()
+	mut param_type := t.semantic_type_name(params[0])
 	if param_type.starts_with('&') {
 		param_type = param_type[1..]
 	}
@@ -11750,7 +11806,7 @@ fn (mut t Transformer) embedded_receiver_base(base_id flat.NodeId, method_name s
 	if params.len == 0 {
 		return none
 	}
-	mut param_type := params[0].name()
+	mut param_type := t.semantic_type_name(params[0])
 	if param_type.starts_with('&') {
 		param_type = param_type[1..]
 	}
@@ -11855,7 +11911,7 @@ fn (t &Transformer) receiver_method_return_type(method_name string, fallback str
 	if !isnil(t.tc) {
 		if typ := t.tc.fn_ret_types[method_name] {
 			if typ !is types.Unknown && typ !is types.Void {
-				return typ.name()
+				return t.semantic_type_name(typ)
 			}
 		}
 		if ret_text := t.tc.fn_ret_type_texts[method_name] {
@@ -11950,7 +12006,7 @@ fn (t &Transformer) receiver_method_matches_base_type(method_name string, base_i
 	}
 	mut base_type := t.node_type(base_id)
 	if base_type.len == 0 && !isnil(t.tc) {
-		base_type = t.tc.resolve_type(base_id).name()
+		base_type = t.semantic_type_name(t.tc.resolve_type(base_id))
 	}
 	for base_type.starts_with('&') {
 		base_type = base_type[1..]
@@ -12452,7 +12508,7 @@ fn (t &Transformer) receiver_type_text_source_fixed_spelling(type_text string) s
 	if !isnil(t.tc) {
 		parsed := t.tc.parse_type(clean)
 		if parsed is types.ArrayFixed {
-			return types.Type(parsed).name()
+			return t.semantic_type_name(parsed)
 		}
 	}
 	elem, dims := transform_postfix_fixed_array_parts(clean)
@@ -12601,6 +12657,7 @@ fn (mut t Transformer) transform_receiver_method_args(node flat.Node, base_id fl
 
 // transform_receiver_method_args_with_base
 // transforms helper data for transform.
+@[direct_array_access]
 fn (mut t Transformer) transform_receiver_method_args_with_base(node flat.Node, base flat.NodeId, method_name string) []flat.NodeId {
 	mut args := []flat.NodeId{cap: int(node.children_count)}
 	args << base
@@ -12625,7 +12682,11 @@ fn (mut t Transformer) transform_receiver_method_args_with_base(node flat.Node, 
 		param_idx := (args.len - 1) + param_offset
 		arg_id := t.a.child(&node, i)
 		arg_node := t.a.nodes[int(arg_id)]
-		param_type := if param_idx < params.len { params[param_idx].name() } else { '' }
+		param_type := if param_idx < params.len {
+			t.semantic_type_name(params[param_idx])
+		} else {
+			''
+		}
 		if spread_args := t.transform_spread_arg_over_fixed_variadic_tail(arg_node, param_idx,
 			variadic_idx, params)
 		{
@@ -12689,7 +12750,7 @@ fn (mut t Transformer) transform_receiver_method_args_with_base(node flat.Node, 
 			spread_base := t.stable_expr_for_reuse(spread_id)
 			spread_count := params.len - param_idx
 			for spread_offset in 0 .. spread_count {
-				expected := params[param_idx + spread_offset].name()
+				expected := t.semantic_type_name(params[param_idx + spread_offset])
 				index_arg := t.make_spread_index_for_expected_param(spread_base, spread_offset,
 					expected)
 				args << t.transform_call_arg_for_param(index_arg, expected)
@@ -12709,8 +12770,10 @@ fn (mut t Transformer) transform_receiver_method_args_with_base(node flat.Node, 
 					if expected_idx >= params.len {
 						break
 					}
-					field := t.make_selector(value, 'arg${multi_idx}', item_type.name())
-					args << t.transform_call_arg_for_param(field, params[expected_idx].name())
+					field := t.make_selector(value, 'arg${multi_idx}',
+						t.semantic_type_name(item_type))
+					args << t.transform_call_arg_for_param(field,
+						t.semantic_type_name(params[expected_idx]))
 				}
 				i++
 				continue
@@ -12755,7 +12818,7 @@ fn (t &Transformer) receiver_method_param_offset(base_id flat.NodeId, node flat.
 		return 0
 	}
 	base_type := t.node_type(base_id)
-	first_type := t.normalize_type_alias(params[0].name())
+	first_type := t.normalize_type_alias(t.semantic_type_name(params[0]))
 	clean_first := if first_type.starts_with('&') { first_type[1..] } else { first_type }
 	clean_base := if base_type.starts_with('&') { base_type[1..] } else { base_type }
 	if receiver_param_types_match(clean_first, clean_base)
@@ -12963,7 +13026,7 @@ fn (t &Transformer) get_call_return_type(id flat.NodeId, node flat.Node) string 
 						}
 						if !isnil(t.tc) {
 							if ret := t.tc.fn_ret_types[name] {
-								return substitute_generic_type_text(ret.name(), args)
+								return substitute_generic_type_text(t.semantic_type_name(ret), args)
 							}
 						}
 					}
@@ -12983,7 +13046,7 @@ fn (t &Transformer) get_call_return_type(id flat.NodeId, node flat.Node) string 
 						return t.call_return_type_name(ret, node)
 					}
 					if ret := t.tc.fn_ret_types[name] {
-						return t.call_return_type_name(ret.name(), node)
+						return t.call_return_type_name(t.semantic_type_name(ret), node)
 					}
 				}
 			}
@@ -13078,7 +13141,7 @@ fn (t &Transformer) get_call_return_type(id flat.NodeId, node flat.Node) string 
 			clean_base := if base_type.starts_with('&') { base_type[1..] } else { base_type }
 			if clean_base.contains('[') && clean_base.ends_with(']') {
 				if ci := t.tc.resolve_generic_struct_method(clean_base, fn_node.value) {
-					rn := ci.return_type.name()
+					rn := t.semantic_type_name(ci.return_type)
 					if rn.len > 0 && rn != 'void' && rn != 'unknown' {
 						return t.normalize_type_alias(rn)
 					}
@@ -13089,7 +13152,7 @@ fn (t &Transformer) get_call_return_type(id flat.NodeId, node flat.Node) string 
 	if !isnil(t.tc) {
 		if name := t.tc.resolved_call_name(id) {
 			if ret := t.tc.fn_ret_types[name] {
-				return t.call_return_type_name(ret.name(), node)
+				return t.call_return_type_name(t.semantic_type_name(ret), node)
 			}
 		}
 	}
@@ -13102,11 +13165,11 @@ fn (t &Transformer) get_call_return_type(id flat.NodeId, node flat.Node) string 
 			&& !name.contains('.') {
 			qname := '${t.cur_module}.${name}'
 			if ret := t.tc.fn_ret_types[qname] {
-				return t.call_return_type_name(ret.name(), node)
+				return t.call_return_type_name(t.semantic_type_name(ret), node)
 			}
 		}
 		if ret := t.tc.fn_ret_types[name] {
-			return t.call_return_type_name(ret.name(), node)
+			return t.call_return_type_name(t.semantic_type_name(ret), node)
 		}
 	}
 	if t.cur_module.len > 0 && t.cur_module != 'main' && t.cur_module != 'builtin'
@@ -13200,11 +13263,11 @@ fn (t &Transformer) checker_resolved_non_builtin_return_type_uncached(id flat.No
 		if fn_node.kind == .ident && fn_node.value == short_name {
 			qname := '${t.cur_module}.${short_name}'
 			if ret := t.tc.fn_ret_types[qname] {
-				return t.call_return_type_name(ret.name(), node)
+				return t.call_return_type_name(t.semantic_type_name(ret), node)
 			}
 			lowered_qname := c_name(qname)
 			if ret := t.tc.fn_ret_types[lowered_qname] {
-				return t.call_return_type_name(ret.name(), node)
+				return t.call_return_type_name(t.semantic_type_name(ret), node)
 			}
 		}
 	}
@@ -13214,7 +13277,7 @@ fn (t &Transformer) checker_resolved_non_builtin_return_type_uncached(id flat.No
 	decl_module := t.tc.fn_type_modules[name] or { '' }
 	if ret := t.tc.fn_ret_types[name] {
 		if ret !is types.Unknown && ret !is types.Void {
-			return t.call_return_type_name_in_module(ret.name(), node, decl_module)
+			return t.call_return_type_name_in_module(t.semantic_type_name(ret), node, decl_module)
 		}
 	}
 	if ret_text := t.tc.fn_ret_type_texts[name] {
@@ -13224,7 +13287,7 @@ fn (t &Transformer) checker_resolved_non_builtin_return_type_uncached(id flat.No
 	}
 	if typ := t.tc.expr_type(id) {
 		if typ !is types.Unknown && typ !is types.Void {
-			return t.call_return_type_name(typ.name(), node)
+			return t.call_return_type_name(t.semantic_type_name(typ), node)
 		}
 	}
 	return none

--- a/vlib/v3/transform/fn_test.v
+++ b/vlib/v3/transform/fn_test.v
@@ -168,8 +168,10 @@ fn test_parallel_worker_reuses_prebuilt_call_param_decl_index() {
 	mut tc := types.TypeChecker.new(a)
 	mut t := new_transformer(mut a, &tc, map[string]bool{})
 	t.prepare_parallel_call_param_types()
+	assert t.call_param_types_prepared
 	mut worker := t.fork_worker(t.a, t.tc)
 	assert worker.call_param_types_index_ready
+	assert worker.call_param_types_prepared
 	assert worker.call_param_types_decl_index.len == t.call_param_types_decl_index.len
 	assert worker.call_param_types_decl_cache.len == t.call_param_types_decl_cache.len
 	params := worker.call_param_types_from_decl('takes_string') or {
@@ -178,6 +180,9 @@ fn test_parallel_worker_reuses_prebuilt_call_param_decl_index() {
 	}
 	assert params.len == 1
 	assert params[0] is types.String
+	t.add_call_param_types_decl_key('main.takes_string', a.nodes.len - 1, 'signature_index_test.v',
+		'main')
+	assert !t.call_param_types_prepared
 }
 
 fn test_pending_generic_specialization_keys_are_private_initialized_maps() {

--- a/vlib/v3/transform/for.v
+++ b/vlib/v3/transform/for.v
@@ -120,25 +120,27 @@ fn (mut t Transformer) transform_for_body(id flat.NodeId, node flat.Node) []flat
 		loop_cond = t.make_bool_literal(true)
 		loop_body = guarded_body.clone()
 	}
-	// Rebuild the for_stmt with transformed children
-	start := t.a.children.len
-	t.a.children << new_init
-	t.a.children << loop_cond
-	t.a.children << new_post
+	// Rebuild the for_stmt with transformed children.
+	mut new_children := [new_init, loop_cond, new_post]
 	for bid in loop_body {
-		t.a.children << bid
+		new_children << bid
 	}
-	count := t.a.children.len - start
-	new_id := t.a.add_node(flat.Node{
-		kind:                 .for_stmt
-		op:                   node.op
-		children_start:       start
-		children_count:       flat.child_count(count)
-		pos:                  node.pos
-		value:                node.value
-		typ:                  node.typ
-		skip_ownership_drops: node.skip_ownership_drops
-	})
+	new_id := if t.rewrite_children_in_place(id, new_children) {
+		id
+	} else {
+		start := t.a.children.len
+		t.a.children << new_children
+		t.a.add_node(flat.Node{
+			kind:                 .for_stmt
+			op:                   node.op
+			children_start:       start
+			children_count:       flat.child_count(new_children.len)
+			pos:                  node.pos
+			value:                node.value
+			typ:                  node.typ
+			skip_ownership_drops: node.skip_ownership_drops
+		})
+	}
 	if synthetic_continue_label.len > 0 {
 		return [
 			t.a.add_val(.label_stmt, pending_loop_label_marker + synthetic_continue_label),
@@ -309,6 +311,9 @@ fn (mut t Transformer) rewrite_continue_to_for_post_label_in_children(id flat.No
 		children << new_child
 	}
 	if !changed {
+		return id
+	}
+	if t.rewrite_children_in_place(id, children) {
 		return id
 	}
 	start := t.a.children.len
@@ -817,7 +822,11 @@ fn (mut t Transformer) lower_range_for_in(id flat.NodeId, node flat.Node, key_id
 	range_type := t.range_loop_var_type_name(low_id)
 	low := t.stable_expr_for_reuse(low_id)
 	high := t.stable_expr_for_reuse(high_id)
-	loop_name := if key.value == '_' { '__discard_${int(key_id)}' } else { key.value }
+	loop_name := if key.value == '_' {
+		'__discard_${key.pos.id}_${key.pos.offset}_${key.pos.end}'
+	} else {
+		key.value
+	}
 	t.set_var_type(loop_name, range_type)
 	mut prefix := []flat.NodeId{}
 	t.drain_pending(mut prefix)
@@ -898,6 +907,7 @@ fn (mut t Transformer) lower_iterator_for_in(id flat.NodeId, node flat.Node, key
 }
 
 // lower_indexed_for_in builds lower indexed for in data for transform.
+@[direct_array_access]
 fn (mut t Transformer) lower_indexed_for_in(id flat.NodeId, node flat.Node, key_id flat.NodeId, val_id flat.NodeId, container_id flat.NodeId, iter_type string, has_index bool, body_ids []flat.NodeId) []flat.NodeId {
 	if int(key_id) < 0 {
 		return arr1(id)

--- a/vlib/v3/transform/if.v
+++ b/vlib/v3/transform/if.v
@@ -11,6 +11,7 @@ import v3.types
 //   __or_tmp_N := maybe_call()
 //   if !__or_tmp_N.is_error { val := __or_tmp_N.data; body... }
 //
+@[direct_array_access]
 fn (mut t Transformer) try_expand_if_guard(_id flat.NodeId, node flat.Node) ?[]flat.NodeId {
 	if node.kind != .if_expr || node.children_count < 2 {
 		return none
@@ -1439,13 +1440,18 @@ fn (mut t Transformer) transform_if_guard_condition(node flat.Node) flat.NodeId 
 	})
 }
 
+@[direct_array_access]
 fn (mut t Transformer) transform_if_branch_as_block(branch_id flat.NodeId) flat.NodeId {
 	if int(branch_id) < 0 {
 		return t.make_block([]flat.NodeId{})
 	}
 	branch := t.a.nodes[int(branch_id)]
 	if branch.kind == .block {
-		return t.make_block(t.transform_stmts(t.a.children_of(&branch)))
+		children := t.transform_stmts(t.a.children_of(&branch))
+		if t.rewrite_children_in_place(branch_id, children) {
+			return branch_id
+		}
+		return t.make_block(children)
 	}
 	mut stmts := []flat.NodeId{}
 	if t.is_stmt_kind_id(node_kind_id(branch)) {
@@ -1511,21 +1517,25 @@ fn (mut t Transformer) transform_plain_if_branches(id flat.NodeId, node flat.Nod
 		t.smartcast_stack = t.non_invalidated_smartcasts(base_smartcasts)
 	}
 
-	if_start := t.a.children.len
-	t.a.children << new_cond_id
-	t.a.children << new_then_id
 	mut child_count := 2
+	mut new_children := [new_cond_id, new_then_id]
 	if has_else {
-		t.a.children << new_else_id
+		new_children << new_else_id
 		child_count = 3
 	}
-	new_if := t.a.add_node(flat.Node{
-		kind:           .if_expr
-		children_start: if_start
-		children_count: flat.child_count(child_count)
-		typ:            node.typ
-		pos:            node.pos
-	})
+	new_if := if t.rewrite_children_in_place(id, new_children) {
+		id
+	} else {
+		if_start := t.a.children.len
+		t.a.children << new_children
+		t.a.add_node(flat.Node{
+			kind:           .if_expr
+			children_start: if_start
+			children_count: flat.child_count(child_count)
+			typ:            node.typ
+			pos:            node.pos
+		})
+	}
 	for pending in cond_pending {
 		t.pending_stmts << pending
 	}
@@ -1536,6 +1546,7 @@ fn (mut t Transformer) transform_plain_if_branches(id flat.NodeId, node flat.Nod
 // integrates smartcasting. When the condition contains an is_expr, it
 // pushes a smartcast for the then-branch, transforms the body under
 // that context, pops the smartcast, then transforms the else-block.
+@[direct_array_access]
 fn (mut t Transformer) transform_if_branches_with_smartcast(id flat.NodeId, node flat.Node) flat.NodeId {
 	if node.kind != .if_expr || node.children_count < 2 {
 		return id
@@ -1596,21 +1607,25 @@ fn (mut t Transformer) transform_if_branches_with_smartcast(id flat.NodeId, node
 	t.smartcast_stack = t.non_invalidated_smartcasts(then_base_smartcasts)
 
 	// Rebuild the if_expr with (possibly) new children.
-	if_start := t.a.children.len
-	t.a.children << new_cond_id
-	t.a.children << new_then_id
 	mut child_count := 2
+	mut new_children := [new_cond_id, new_then_id]
 	if has_else {
-		t.a.children << new_else_id
+		new_children << new_else_id
 		child_count = 3
 	}
-	new_if := t.a.add_node(flat.Node{
-		kind:           .if_expr
-		children_start: if_start
-		children_count: flat.child_count(child_count)
-		typ:            node.typ
-		pos:            node.pos
-	})
+	new_if := if t.rewrite_children_in_place(id, new_children) {
+		id
+	} else {
+		if_start := t.a.children.len
+		t.a.children << new_children
+		t.a.add_node(flat.Node{
+			kind:           .if_expr
+			children_start: if_start
+			children_count: flat.child_count(child_count)
+			typ:            node.typ
+			pos:            node.pos
+		})
+	}
 	for pending in cond_pending {
 		t.pending_stmts << pending
 	}

--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -613,10 +613,14 @@ fn (mut t Transformer) materialize_monomorph_signature_types(specs []MonomorphCa
 		]
 		for i in 0 .. decl.node.children_count {
 			param := t.a.child_node(&decl.node, i)
-			if param.kind == .param {
-				signature_types << t.specialized_signature_type_text(decl, param.typ, args,
-					generic_params)
+			if param.kind != .param {
+				if t.prefix_param_scan {
+					break
+				}
+				continue
 			}
+			signature_types << t.specialized_signature_type_text(decl, param.typ, args,
+				generic_params)
 		}
 		for typ in signature_types {
 			t.collect_generic_struct_spec_from_type(typ, decl.module, decl.file, struct_decls, mut
@@ -835,7 +839,7 @@ fn (mut t Transformer) collect_generic_fn_decls_for_erasure() map[string]Generic
 	// serial walk. Prescreen-negative fn decls can never need erasure.
 	mut scan_sw := time.new_stopwatch()
 	mut flags := []u8{len: t.a.nodes.len}
-	if scan_top_level_kind_flags_parallel(t.a, 0, mut flags) {
+	if scan_top_level_kind_flags_parallel(t.a, 0, mut flags, t.prefix_param_scan) {
 		t.timing_profile('  [ttime]     collect scan        ${f64(scan_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 		scan_sw.restart()
 		// Word-scan the flag array: flagged nodes are rare, so loading eight
@@ -1001,7 +1005,13 @@ fn (mut t Transformer) generic_fn_decl_needs_erasure_scan(node flat.Node, module
 	}
 	for i in 0 .. node.children_count {
 		child := t.a.child_node(&node, i)
-		if child.kind == .param && t.type_text_has_generic_placeholder(child.typ, module_name) {
+		if child.kind != .param {
+			if t.prefix_param_scan {
+				break
+			}
+			continue
+		}
+		if t.type_text_has_generic_placeholder(child.typ, module_name) {
 			return true
 		}
 	}
@@ -1654,13 +1664,16 @@ fn (mut t Transformer) collect_interface_call_boxes(call_id flat.NodeId, node fl
 fn (mut t Transformer) interface_box_call_param_maybe(param types.Type) bool {
 	key := '${t.cur_module}:${t.tc.type_name(param)}'
 	if !isnil(t.interface_box_param_cache) {
-		if cached := t.interface_box_param_cache.entries[key] {
+		mut cache := t.interface_box_param_cache
+		cached := cache.get(key)
+		if cached != 0 {
 			return cached > 0
 		}
 	}
 	result := t.interface_box_call_param_maybe_uncached(param)
 	if !isnil(t.interface_box_param_cache) {
-		t.interface_box_param_cache.entries[key] = if result { i8(1) } else { i8(-1) }
+		mut cache := t.interface_box_param_cache
+		cache.put(key, if result { i8(1) } else { i8(-1) })
 	}
 	return result
 }
@@ -3378,7 +3391,13 @@ fn (mut t Transformer) emit_generic_fn_specialization(decl GenericFnDecl, args [
 	t.reset_var_types()
 	for i in 0 .. decl.node.children_count {
 		param_child := t.a.child_node(&decl.node, i)
-		if node_kind_id(param_child) != 75 || param_child.value.len == 0 || param_child.typ.len == 0 {
+		if node_kind_id(param_child) != 75 {
+			if t.prefix_param_scan {
+				break
+			}
+			continue
+		}
+		if param_child.value.len == 0 || param_child.typ.len == 0 {
 			continue
 		}
 		mut param_raw := param_child.typ
@@ -3589,7 +3608,13 @@ fn (mut t Transformer) seed_generated_fn_body_context(root flat.NodeId) {
 			continue
 		}
 		child := t.a.nodes[int(child_id)]
-		if node_kind_id(child) != 75 || child.value.len == 0 {
+		if node_kind_id(child) != 75 {
+			if t.prefix_param_scan {
+				break
+			}
+			continue
+		}
+		if child.value.len == 0 {
 			continue
 		}
 		raw_source_typ := if child.typ.starts_with('...') {
@@ -3934,14 +3959,21 @@ fn (mut t Transformer) specialize_cloned_fn_signature(clone_id flat.NodeId, decl
 	clone := t.a.nodes[int(clone_id)]
 	for i in 0 .. clone.children_count {
 		dst_id := t.a.child(&clone, i)
-		if t.a.nodes[int(dst_id)].kind == .param {
-			dst_params << dst_id
+		if t.a.nodes[int(dst_id)].kind != .param {
+			if t.prefix_param_scan {
+				break
+			}
+			continue
 		}
+		dst_params << dst_id
 	}
 	mut param_idx := 0
 	for i in 0 .. decl.node.children_count {
 		src := t.a.child_node(&decl.node, i)
 		if src.kind != .param {
+			if t.prefix_param_scan {
+				break
+			}
 			continue
 		}
 		if param_idx >= dst_params.len {
@@ -3980,6 +4012,9 @@ fn (mut t Transformer) register_specialized_fn_signature_value(decl GenericFnDec
 	for i in 0 .. decl.node.children_count {
 		child := t.a.child_node(&decl.node, i)
 		if child.kind != .param {
+			if t.prefix_param_scan {
+				break
+			}
 			continue
 		}
 		param_type := explicit_mut_pointer_param_type_text(child, t.specialized_signature_type_text(decl,
@@ -4536,6 +4571,9 @@ fn (mut t Transformer) concrete_generic_call_param_types(id flat.NodeId, node fl
 	for i in 0 .. decl.node.children_count {
 		child := t.a.child_node(&decl.node, i)
 		if child.kind != .param {
+			if t.prefix_param_scan {
+				break
+			}
 			continue
 		}
 		param_type := explicit_mut_pointer_param_type_text(child, t.specialized_signature_type_text(decl,
@@ -4614,6 +4652,9 @@ fn (mut t Transformer) infer_generic_call_args_from_params(decl GenericFnDecl, c
 	for i in 0 .. decl.node.children_count {
 		child := t.a.child_node(&decl.node, i)
 		if child.kind != .param {
+			if t.prefix_param_scan {
+				break
+			}
 			continue
 		}
 		is_recv_param := is_receiver && param_idx == 0
@@ -4681,9 +4722,13 @@ fn (t &Transformer) generic_decl_param_count(node flat.Node) int {
 	mut count := 0
 	for i in 0 .. node.children_count {
 		child := t.a.child_node(&node, i)
-		if child.kind == .param {
-			count++
+		if child.kind != .param {
+			if t.prefix_param_scan {
+				break
+			}
+			continue
 		}
+		count++
 	}
 	return count
 }
@@ -4874,6 +4919,9 @@ fn (mut t Transformer) specialized_generic_call_param_type_texts(decl GenericFnD
 	for i in 0 .. decl.node.children_count {
 		child := t.a.child_node(&decl.node, i)
 		if child.kind != .param {
+			if t.prefix_param_scan {
+				break
+			}
 			continue
 		}
 		result << explicit_mut_pointer_param_type_text(child, t.specialized_call_target_type_text(decl,
@@ -4991,9 +5039,13 @@ fn (mut t Transformer) specialize_generic_fn_value_arg(arg_id flat.NodeId, expec
 		mut signature_params := []string{}
 		for i in 0 .. decl.node.children_count {
 			param := t.a.child_node(&decl.node, i)
-			if param.kind == .param {
-				signature_params << param.typ
+			if param.kind != .param {
+				if t.prefix_param_scan {
+					break
+				}
+				continue
 			}
+			signature_params << param.typ
 		}
 		signature := 'fn (${signature_params.join(', ')})${if decl.node.typ.len > 0
 			&& decl.node.typ != 'void' {
@@ -5594,7 +5646,13 @@ fn (mut t Transformer) generic_args_equal_ignoring_mut_storage(decl GenericFnDec
 	mut direct_mut_params := map[string]bool{}
 	for i in 0 .. decl.node.children_count {
 		param := t.a.child_node(&decl.node, i)
-		if param.kind == .param && (param.is_mut || param.typ.starts_with('mut ')) {
+		if param.kind != .param {
+			if t.prefix_param_scan {
+				break
+			}
+			continue
+		}
+		if param.is_mut || param.typ.starts_with('mut ') {
 			generic_name := generic_inference_param_type(param)
 			if is_generic_fn_placeholder_name(generic_name) {
 				direct_mut_params[generic_name] = true
@@ -5639,6 +5697,9 @@ fn (mut t Transformer) infer_generic_call_args_from_raw_node_types(decl GenericF
 	for i in 0 .. decl.node.children_count {
 		param := t.a.child_node(&decl.node, i)
 		if param.kind != .param {
+			if t.prefix_param_scan {
+				break
+			}
 			continue
 		}
 		arg_id := t.generic_call_arg_id_for_param(node, param_idx, is_receiver) or {
@@ -6466,6 +6527,9 @@ fn (t &Transformer) generic_call_arg_count_matches_decl(node flat.Node, decl Gen
 	for i in 0 .. decl.node.children_count {
 		child := t.a.child_node(&decl.node, i)
 		if child.kind != .param {
+			if t.prefix_param_scan {
+				break
+			}
 			continue
 		}
 		param_count++
@@ -6686,6 +6750,9 @@ fn (mut t Transformer) infer_generic_call_args_seeded(decl GenericFnDecl, _id fl
 	for i in 0 .. decl.node.children_count {
 		child := t.a.child_node(&decl.node, i)
 		if child.kind != .param {
+			if t.prefix_param_scan {
+				break
+			}
 			continue
 		}
 		is_recv_param := is_receiver && param_idx == 0
@@ -7245,7 +7312,7 @@ fn (mut t Transformer) build_generic_alias_name_index() {
 }
 
 fn (t &Transformer) generic_arg_is_alias_name(arg string, module_name string) bool {
-	clean := arg.trim_space()
+	clean := trimmed_transform_text(arg)
 	if clean.len == 0 || isnil(t.tc) {
 		return false
 	}
@@ -9321,6 +9388,9 @@ fn (mut t Transformer) retarget_cloned_generic_call(node flat.Node, mut children
 		for i in 0 .. decl.node.children_count {
 			child := t.a.child_node(&decl.node, i)
 			if child.kind != .param {
+				if t.prefix_param_scan {
+					break
+				}
 				continue
 			}
 			arg_pos := param_idx + 1
@@ -9566,6 +9636,9 @@ fn (mut t Transformer) retarget_cloned_implicit_generic_call(clone_id flat.NodeI
 		for i in 0 .. decl.node.children_count {
 			child := t.a.child_node(&decl.node, i)
 			if child.kind != .param {
+				if t.prefix_param_scan {
+					break
+				}
 				continue
 			}
 			clone_arg_id := t.generic_call_arg_id_for_param(clone, param_idx, is_receiver) or {
@@ -9711,7 +9784,11 @@ fn (mut t Transformer) copy_cloned_resolution(src_id flat.NodeId, dst_id flat.No
 
 fn (mut t Transformer) copy_cloned_resolution_forked(src_idx int, dst_idx int) {
 	mut overlay := t.tc.fork_overlay
-	mut call_name := overlay.resolved_call_names[src_idx] or { '' }
+	mut call_name := if src_idx >= overlay.base_node_count {
+		overlay.resolved_call_names[src_idx] or { '' }
+	} else {
+		''
+	}
 	if call_name.len == 0 && src_idx < t.tc.resolved_call_set.len && t.tc.resolved_call_set[src_idx] {
 		call_name = t.tc.resolved_call_names[src_idx]
 	}
@@ -9719,7 +9796,11 @@ fn (mut t Transformer) copy_cloned_resolution_forked(src_idx int, dst_idx int) {
 		&& !t.resolved_call_is_generic_fn(call_name) {
 		overlay.resolved_call_names[dst_idx] = call_name
 	}
-	mut fn_value := overlay.resolved_fn_values[src_idx] or { '' }
+	mut fn_value := if src_idx >= overlay.base_node_count {
+		overlay.resolved_fn_values[src_idx] or { '' }
+	} else {
+		''
+	}
 	if fn_value.len == 0 && src_idx < t.tc.resolved_fn_value_set.len
 		&& t.tc.resolved_fn_value_set[src_idx] {
 		fn_value = t.tc.resolved_fn_value_names[src_idx]
@@ -9793,7 +9874,13 @@ fn (mut t Transformer) fn_decl_has_unresolved_generics(node flat.Node, module_na
 	}
 	for i in 0 .. node.children_count {
 		child := t.a.child_node(&node, i)
-		if child.kind == .param && t.type_text_has_generic_placeholder(child.typ, module_name) {
+		if child.kind != .param {
+			if t.prefix_param_scan {
+				break
+			}
+			continue
+		}
+		if t.type_text_has_generic_placeholder(child.typ, module_name) {
 			return true
 		}
 	}
@@ -10038,9 +10125,13 @@ fn (mut t Transformer) generic_fn_param_names(node flat.Node, module_name string
 	t.collect_generic_param_names_from_type(node.typ, module_name, mut names)
 	for i in 0 .. node.children_count {
 		child := t.a.child_node(&node, i)
-		if child.kind == .param {
-			t.collect_generic_param_names_from_type(child.typ, module_name, mut names)
+		if child.kind != .param {
+			if t.prefix_param_scan {
+				break
+			}
+			continue
 		}
+		t.collect_generic_param_names_from_type(child.typ, module_name, mut names)
 	}
 	return names
 }
@@ -12053,12 +12144,15 @@ fn (t &Transformer) generic_arg_is_unresolved(arg string) bool {
 		if cache.module != t.cur_module {
 			cache.module = t.cur_module
 			cache.entries.clear()
+			cache.last_name = ''
+			cache.last_value = 0
 		}
-		if cached := cache.entries[arg] {
+		cached := cache.get(arg)
+		if cached != 0 {
 			return cached > 0
 		}
 		result := t.generic_arg_is_unresolved_uncached(arg)
-		cache.entries[arg] = if result { i8(1) } else { i8(-1) }
+		cache.put(arg, if result { i8(1) } else { i8(-1) })
 		return result
 	}
 	return t.generic_arg_is_unresolved_uncached(arg)

--- a/vlib/v3/transform/return.v
+++ b/vlib/v3/transform/return.v
@@ -306,7 +306,7 @@ fn (mut t Transformer) try_convert_forwarded_wrapped_multi_return(value_id flat.
 	}
 	mut needs_conversion := false
 	for i, actual_type in actual_types {
-		if actual_type.name() != expected_types[i].name()
+		if t.semantic_type_name(actual_type) != t.semantic_type_name(expected_types[i])
 			&& t.forwarded_slot_conversion_supported(actual_type, expected_types[i]) {
 			needs_conversion = true
 			break
@@ -318,7 +318,7 @@ fn (mut t Transformer) try_convert_forwarded_wrapped_multi_return(value_id flat.
 	pending_start := t.pending_stmts.len
 	mut return_values := []flat.NodeId{cap: expected_types.len}
 	for i, actual_type in actual_types {
-		field := t.make_selector(value_id, 'arg${i}', actual_type.name())
+		field := t.make_selector(value_id, 'arg${i}', t.semantic_type_name(actual_type))
 		return_values << t.transform_forwarded_return_slot(field, actual_type, expected_types[i])
 	}
 	mut then_body := t.pending_stmts[pending_start..].clone()
@@ -336,7 +336,7 @@ fn (t &Transformer) return_expr_is_optional_result(id flat.NodeId) bool {
 	if node.kind == .call && !isnil(t.tc) {
 		if name := t.tc.resolved_call_name(id) {
 			if ret := t.tc.fn_ret_types[name] {
-				return t.is_optional_type_name(ret.name())
+				return t.is_optional_type_name(t.semantic_type_name(ret))
 			}
 		}
 		call_type := t.get_call_return_type(id, node)
@@ -368,7 +368,7 @@ fn (mut t Transformer) try_expand_forwarded_multi_return(source_return_id flat.N
 	actual_types := t.multi_return_types_for_expr(value_id, expected_types.len) or { return none }
 	mut needs_conversion := false
 	for i, actual_type in actual_types {
-		if actual_type.name() != expected_types[i].name()
+		if t.semantic_type_name(actual_type) != t.semantic_type_name(expected_types[i])
 			&& t.forwarded_slot_conversion_supported(actual_type, expected_types[i]) {
 			needs_conversion = true
 			break
@@ -384,7 +384,8 @@ fn (mut t Transformer) try_expand_forwarded_multi_return(source_return_id flat.N
 	result << t.make_decl_assign_typed(tmp_name, value, t.multi_return_type_name(actual_types))
 	mut return_values := []flat.NodeId{cap: expected_types.len}
 	for i, actual_type in actual_types {
-		field := t.make_selector(t.make_ident(tmp_name), 'arg${i}', actual_type.name())
+		field := t.make_selector(t.make_ident(tmp_name), 'arg${i}',
+			t.semantic_type_name(actual_type))
 		return_values << t.transform_forwarded_return_slot(field, actual_type, expected_types[i])
 	}
 	t.drain_pending(mut result)
@@ -399,18 +400,19 @@ fn (mut t Transformer) transform_forwarded_return_slot(value_id flat.NodeId, act
 	actual_base := forwarded_return_unalias_type(actual)
 	expected_base := forwarded_return_unalias_type(expected)
 	if actual_base is types.OptionType && expected_base is types.OptionType
-		&& actual_base.base_type.name() != expected_base.base_type.name() {
+		&& t.semantic_type_name(actual_base.base_type) != t.semantic_type_name(expected_base.base_type) {
 		return t.convert_forwarded_optional_result(value_id, actual, actual_base.base_type,
 			expected, expected_base, expected_base.base_type)
 	}
 	if actual_base is types.ResultType && expected_base is types.ResultType
-		&& actual_base.base_type.name() != expected_base.base_type.name() {
+		&& t.semantic_type_name(actual_base.base_type) != t.semantic_type_name(expected_base.base_type) {
 		return t.convert_forwarded_optional_result(value_id, actual, actual_base.base_type,
 			expected, expected_base, expected_base.base_type)
 	}
 	if expected_base is types.Array {
 		if actual_base is types.Array
-			&& actual_base.elem_type.name() != expected_base.elem_type.name() {
+			&& t.semantic_type_name(actual_base.elem_type) != t.semantic_type_name(expected_base.elem_type)
+			&& !forwarded_array_elems_storage_identical(actual_base.elem_type, expected_base.elem_type) {
 			return t.convert_forwarded_array_to_dynamic(value_id, actual, actual_base.elem_type,
 				expected, expected_base.elem_type, false)
 		}
@@ -420,20 +422,19 @@ fn (mut t Transformer) transform_forwarded_return_slot(value_id flat.NodeId, act
 		}
 	}
 	if actual_base is types.ArrayFixed && expected_base is types.ArrayFixed
-		&& actual_base.elem_type.name() != expected_base.elem_type.name() {
+		&& t.semantic_type_name(actual_base.elem_type) != t.semantic_type_name(expected_base.elem_type) {
 		return t.convert_forwarded_fixed_array(value_id, actual, actual_base, expected,
 			expected_base)
 	}
-	if actual_base is types.Map && expected_base is types.Map
-		&& (actual_base.key_type.name() != expected_base.key_type.name()
-		|| actual_base.value_type.name() != expected_base.value_type.name()) {
+	if actual_base is types.Map && expected_base is types.Map&& (t.semantic_type_name(actual_base.key_type) != t.semantic_type_name(expected_base.key_type)
+		|| t.semantic_type_name(actual_base.value_type) != t.semantic_type_name(expected_base.value_type)) {
 		return t.convert_forwarded_map(value_id, actual, actual_base, expected, expected_base)
 	}
 	if expected_base is types.SumType
-		&& t.sum_target_accepts_variant_type(expected_base.name, actual_base.name()) {
+		&& t.sum_target_accepts_variant_type(expected_base.name, t.semantic_type_name(actual_base)) {
 		return t.wrap_sum_value(value_id, expected_base.name)
 	}
-	return t.transform_expr_for_type(value_id, expected.name())
+	return t.transform_expr_for_type(value_id, t.semantic_type_name(expected))
 }
 
 fn (t &Transformer) forwarded_slot_conversion_supported(actual types.Type, expected types.Type) bool {
@@ -442,18 +443,33 @@ fn (t &Transformer) forwarded_slot_conversion_supported(actual types.Type, expec
 	}
 	actual_base := forwarded_return_unalias_type(actual)
 	expected_base := forwarded_return_unalias_type(expected)
-	if actual_base.name() == expected_base.name() {
+	if t.semantic_type_name(actual_base) == t.semantic_type_name(expected_base) {
+		return false
+	}
+	// Registered aliases can reach this comparison unresolved on one side only
+	// (`[]flat.NodeId` vs `[]int`). Such slots are storage-identical: emitting a
+	// per-element copy here is not just wasted work — the copy loop rebuilds the
+	// array with cap==len, silently discarding reserved capacity (which broke
+	// the self-host transform arena reserves).
+	if t.normalize_type_alias(t.semantic_type_name(actual_base)) == t.normalize_type_alias(t.semantic_type_name(expected_base)) {
 		return false
 	}
 	if actual_base.is_integer() && expected_base.is_integer() {
-		return true
+		// A registered integer alias can appear here unresolved on one side only
+		// (`flat.NodeId` vs `int`) — the parsed primitive keeps the alias
+		// spelling but carries the base storage. Converting such slots is not
+		// just wasted work: the element-copy loop rebuilds arrays with cap==len,
+		// silently discarding reserved capacity. Only genuine width or
+		// signedness changes need the conversion.
+		return !forwarded_integer_storage_matches(actual_base, expected_base)
 	}
 	if expected_base is types.Interface {
 		return true
 	}
 	if expected_base is types.SumType {
-		return t.sum_target_accepts_variant_type(expected_base.name, actual_base.name())
-			|| t.sum_target_accepts_variant_type(expected_base.name, actual.name())
+		return
+			t.sum_target_accepts_variant_type(expected_base.name, t.semantic_type_name(actual_base))
+			|| t.sum_target_accepts_variant_type(expected_base.name, t.semantic_type_name(actual))
 	}
 	if actual_base is types.OptionType && expected_base is types.OptionType {
 		return t.forwarded_slot_conversion_supported(actual_base.base_type, expected_base.base_type)
@@ -507,23 +523,24 @@ fn forwarded_return_type_is_unresolved(typ types.Type) bool {
 }
 
 fn (mut t Transformer) convert_forwarded_optional_result(value_id flat.NodeId, actual_type types.Type, actual_payload types.Type, expected_type types.Type, expected_wrapper types.Type, expected_payload types.Type) flat.NodeId {
-	source := t.stable_transformed_expr_for_reuse(t.transform_expr(value_id), actual_type.name(),
-		'return_optional')
+	source := t.stable_transformed_expr_for_reuse(t.transform_expr(value_id),
+		t.semantic_type_name(actual_type), 'return_optional')
 	result_name := t.new_temp('return_optional')
 	err := t.make_selector(source, 'err', 'IError')
-	initial := t.make_optional_none_with_err(expected_wrapper.name(), err)
-	t.pending_stmts << t.make_decl_assign_typed(result_name, initial, expected_type.name())
+	initial := t.make_optional_none_with_err(t.semantic_type_name(expected_wrapper), err)
+	t.pending_stmts << t.make_decl_assign_typed(result_name, initial,
+		t.semantic_type_name(expected_type))
 	pending_start := t.pending_stmts.len
-	payload := t.make_selector(source, 'value', actual_payload.name())
+	payload := t.make_selector(source, 'value', t.semantic_type_name(actual_payload))
 	converted := t.transform_forwarded_return_slot(payload, actual_payload, expected_payload)
 	mut then_body := t.pending_stmts[pending_start..].clone()
 	t.pending_stmts = t.pending_stmts[..pending_start].clone()
-	wrapped := t.make_optional_some(converted, expected_wrapper.name())
+	wrapped := t.make_optional_some(converted, t.semantic_type_name(expected_wrapper))
 	then_body << t.make_assign(t.make_ident(result_name), wrapped)
 	t.pending_stmts << t.make_if(t.make_selector(source, 'ok', 'bool'), t.make_block(then_body),
 		t.make_empty())
 	result := t.make_ident(result_name)
-	t.set_node_typ(int(result), expected_type.name())
+	t.set_node_typ(int(result), t.semantic_type_name(expected_type))
 	return result
 }
 
@@ -534,36 +551,69 @@ fn forwarded_return_unalias_type(typ types.Type) types.Type {
 	return typ
 }
 
+// forwarded_integer_storage_matches reports whether two integer types share the
+// same C storage (width and signedness), regardless of their spellings.
+fn forwarded_integer_storage_matches(a types.Type, b types.Type) bool {
+	if a.name() == b.name() {
+		return true
+	}
+	if a is types.Primitive && b is types.Primitive {
+		// Unknown widths cannot prove a match; keep the conversion then.
+		if a.size == 0 || b.size == 0 {
+			return false
+		}
+		return a.size == b.size && a.props.has(.unsigned) == b.props.has(.unsigned)
+	}
+	return false
+}
+
+// forwarded_array_elems_storage_identical reports whether two array element
+// types are the same type at the C level even though their spellings differ —
+// a registered alias next to its base type (`flat.NodeId` vs `int`). Emitting
+// an element-copy conversion for such slots is not just wasted work: the copy
+// loop rebuilds the array with cap==len, silently discarding any reserved
+// capacity (which broke the self-host transform arena reserves and, from
+// there, the whole gen-2 bootstrap).
+fn forwarded_array_elems_storage_identical(actual_elem types.Type, expected_elem types.Type) bool {
+	actual_base := forwarded_return_unalias_type(actual_elem)
+	expected_base := forwarded_return_unalias_type(expected_elem)
+	if actual_base.name() == expected_base.name() {
+		return true
+	}
+	return actual_base.is_integer() && expected_base.is_integer()
+		&& forwarded_integer_storage_matches(actual_base, expected_base)
+}
+
 fn (mut t Transformer) convert_forwarded_array_to_dynamic(value_id flat.NodeId, actual_type types.Type, actual_elem types.Type, expected_type types.Type, expected_elem types.Type, actual_is_fixed bool) flat.NodeId {
 	src := t.a.nodes[int(value_id)]
 	pending_start := t.pending_stmts.len
-	base := t.stable_transformed_expr_for_reuse(t.transform_expr(value_id), actual_type.name(),
-		'return_array')
+	base := t.stable_transformed_expr_for_reuse(t.transform_expr(value_id),
+		t.semantic_type_name(actual_type), 'return_array')
 	mut prefix := t.pending_stmts[pending_start..].clone()
 	t.pending_stmts = t.pending_stmts[..pending_start].clone()
 	out_name := t.new_temp('return_array')
 	idx_name := t.new_temp('return_array_idx')
 	len_expr := if actual_is_fixed {
-		t.make_fixed_array_len_expr(forwarded_return_unalias_type(actual_type).name())
+		t.make_fixed_array_len_expr(t.semantic_type_name(forwarded_return_unalias_type(actual_type)))
 	} else {
 		t.make_selector(base, 'len', 'int')
 	}
-	prefix << t.make_decl_assign_typed(out_name, t.make_array_new_call(expected_elem.name(),
-		t.make_int_literal(0), len_expr), expected_type.name())
+	prefix << t.make_decl_assign_typed(out_name, t.make_array_new_call(t.semantic_type_name(expected_elem),
+		t.make_int_literal(0), len_expr), t.semantic_type_name(expected_type))
 	init := t.make_decl_assign_typed(idx_name, t.make_int_literal(0), 'int')
 	cond := t.make_infix(.lt, t.make_ident(idx_name), len_expr)
 	post := t.make_expr_stmt(t.make_postfix(t.make_ident(idx_name), .inc))
 	elem := if actual_is_fixed {
-		t.make_index(base, t.make_ident(idx_name), actual_elem.name())
+		t.make_index(base, t.make_ident(idx_name), t.semantic_type_name(actual_elem))
 	} else {
-		t.array_get_value(base, t.make_ident(idx_name), actual_elem.name())
+		t.array_get_value(base, t.make_ident(idx_name), t.semantic_type_name(actual_elem))
 	}
 	body_pending_start := t.pending_stmts.len
 	converted := t.transform_forwarded_return_slot(elem, actual_elem, expected_elem)
 	mut body := t.pending_stmts[body_pending_start..].clone()
 	t.pending_stmts = t.pending_stmts[..body_pending_start].clone()
 	value_name := t.new_temp('return_array_value')
-	body << t.make_decl_assign_typed(value_name, converted, expected_elem.name())
+	body << t.make_decl_assign_typed(value_name, converted, t.semantic_type_name(expected_elem))
 	body << t.make_expr_stmt(t.make_call_typed('array_push', arr2(t.make_prefix(.amp,
 		t.make_ident(out_name)), t.make_prefix(.amp, t.make_ident(value_name))), 'void'))
 	prefix << t.make_for_stmt(init, cond, post, body, src)
@@ -571,40 +621,40 @@ fn (mut t Transformer) convert_forwarded_array_to_dynamic(value_id flat.NodeId, 
 		t.pending_stmts << stmt
 	}
 	result := t.make_ident(out_name)
-	t.set_node_typ(int(result), expected_type.name())
+	t.set_node_typ(int(result), t.semantic_type_name(expected_type))
 	return result
 }
 
 fn (mut t Transformer) convert_forwarded_fixed_array(value_id flat.NodeId, actual_type types.Type, actual types.ArrayFixed, expected_type types.Type, expected types.ArrayFixed) flat.NodeId {
 	if isnil(t.tc) {
-		return t.transform_expr_for_type(value_id, expected_type.name())
+		return t.transform_expr_for_type(value_id, t.semantic_type_name(expected_type))
 	}
 	len := t.tc.fixed_array_len_value(expected) or {
-		return t.transform_expr_for_type(value_id, expected_type.name())
+		return t.transform_expr_for_type(value_id, t.semantic_type_name(expected_type))
 	}
-	base := t.stable_transformed_expr_for_reuse(t.transform_expr(value_id), actual_type.name(),
-		'return_fixed_array')
+	base := t.stable_transformed_expr_for_reuse(t.transform_expr(value_id),
+		t.semantic_type_name(actual_type), 'return_fixed_array')
 	mut values := []flat.NodeId{cap: len}
 	for i in 0 .. len {
-		elem := t.make_index(base, t.make_int_literal(i), actual.elem_type.name())
+		elem := t.make_index(base, t.make_int_literal(i), t.semantic_type_name(actual.elem_type))
 		values << t.transform_forwarded_return_slot(elem, actual.elem_type, expected.elem_type)
 	}
-	return t.make_array_literal_typed(values, expected_type.name())
+	return t.make_array_literal_typed(values, t.semantic_type_name(expected_type))
 }
 
 fn (mut t Transformer) convert_forwarded_map(value_id flat.NodeId, actual_type types.Type, actual types.Map, expected_type types.Type, expected types.Map) flat.NodeId {
 	src := t.a.nodes[int(value_id)]
 	pending_start := t.pending_stmts.len
-	base := t.stable_transformed_expr_for_reuse(t.transform_expr(value_id), actual_type.name(),
-		'return_map')
+	base := t.stable_transformed_expr_for_reuse(t.transform_expr(value_id),
+		t.semantic_type_name(actual_type), 'return_map')
 	mut prefix := t.pending_stmts[pending_start..].clone()
 	t.pending_stmts = t.pending_stmts[..pending_start].clone()
-	actual_map_type := actual_type.name()
-	expected_map_type := expected_type.name()
-	actual_key_type := actual.key_type.name()
-	expected_key_type := expected.key_type.name()
-	actual_value_type := actual.value_type.name()
-	expected_value_type := expected.value_type.name()
+	actual_map_type := t.semantic_type_name(actual_type)
+	expected_map_type := t.semantic_type_name(expected_type)
+	actual_key_type := t.semantic_type_name(actual.key_type)
+	expected_key_type := t.semantic_type_name(expected.key_type)
+	actual_value_type := t.semantic_type_name(actual.value_type)
+	expected_value_type := t.semantic_type_name(expected.value_type)
 	actual_key_storage := t.map_key_storage_type(actual_key_type)
 	expected_key_storage := t.map_key_storage_type(expected_key_type)
 	out_name := t.new_temp('return_map')
@@ -617,7 +667,7 @@ fn (mut t Transformer) convert_forwarded_map(value_id flat.NodeId, actual_type t
 	value_name := t.new_temp('return_map_value')
 	keys_type := '[]${actual_key_storage}'
 	prefix << t.make_decl_assign_typed(out_name, t.make_new_map_call(expected_map_type),
-		expected_type.name())
+		t.semantic_type_name(expected_type))
 	keys_call := t.make_call_typed('map__keys', arr1(t.runtime_addr(base, actual_map_type)),
 		keys_type)
 	prefix << t.make_decl_assign_typed(keys_name, keys_call, keys_type)
@@ -657,7 +707,7 @@ fn (mut t Transformer) convert_forwarded_map(value_id flat.NodeId, actual_type t
 		t.pending_stmts << stmt
 	}
 	result := t.make_ident(out_name)
-	t.set_node_typ(int(result), expected_type.name())
+	t.set_node_typ(int(result), t.semantic_type_name(expected_type))
 	return result
 }
 

--- a/vlib/v3/transform/struct.v
+++ b/vlib/v3/transform/struct.v
@@ -14,6 +14,9 @@ fn (mut t Transformer) transform_field_init_expr(id flat.NodeId, node flat.Node)
 	} else {
 		t.transform_expr(val_id)
 	}
+	if t.rewrite_one_child_in_place(id, new_val) {
+		return id
+	}
 	start := t.a.children.len
 	t.a.children << new_val
 	return t.a.add_node(flat.Node{
@@ -40,10 +43,10 @@ fn (mut t Transformer) transform_struct_fields(id flat.NodeId, node flat.Node) f
 	}
 	// Build a field name -> type lookup from the struct definition
 	mut field_types := map[string]string{}
-	mut field_order := []string{cap: info.fields.len}
-	for f in info.fields {
-		field_types[f.name] = t.lookup_struct_field_type(node.value, f.name) or { f.typ }
-		field_order << f.name
+	if !t.lean_struct_init_fields {
+		for f in info.fields {
+			field_types[f.name] = t.lookup_struct_field_type(node.value, f.name) or { f.typ }
+		}
 	}
 	mut field_ids := []flat.NodeId{}
 	mut promoted_fields := map[string][]flat.NodeId{}
@@ -58,13 +61,19 @@ fn (mut t Transformer) transform_struct_fields(id flat.NodeId, node flat.Node) f
 			val_node := t.a.nodes[int(val_id)]
 			field_name := if child.value.len > 0 {
 				child.value
-			} else if i < field_order.len {
-				field_order[i]
+			} else if i < info.fields.len {
+				info.fields[i].name
 			} else {
 				''
 			}
 			mut target_field_name := field_name
-			mut field_type := field_types[field_name] or { '' }
+			mut field_type := if t.lean_struct_init_fields {
+				t.lookup_struct_field_type(node.value, field_name) or {
+					struct_info_field_type(info, field_name)
+				}
+			} else {
+				field_types[field_name] or { '' }
+			}
 			mut promoted_key := ''
 			if field_type.len == 0 {
 				// A cross-module embed (`aa.Inner`) is initialized under its
@@ -72,7 +81,11 @@ fn (mut t Transformer) transform_struct_fields(id flat.NodeId, node flat.Node) f
 				for f in info.fields {
 					if f.name.contains('.') && f.name.all_after_last('.') == field_name {
 						target_field_name = f.name
-						field_type = field_types[f.name] or { f.typ }
+						field_type = if t.lean_struct_init_fields {
+							t.lookup_struct_field_type(node.value, f.name) or { f.typ }
+						} else {
+							field_types[f.name] or { f.typ }
+						}
 						break
 					}
 				}
@@ -127,17 +140,22 @@ fn (mut t Transformer) transform_struct_fields(id flat.NodeId, node flat.Node) f
 				new_val = t.make_ident(closure_name)
 				t.set_node_typ(int(new_val), closure_type)
 			}
-			fi_start := t.a.children.len
-			t.a.children << new_val
-			new_field := t.a.add_node(flat.Node{
-				kind:           .field_init
-				op:             child.op
-				children_start: fi_start
-				children_count: 1
-				pos:            child.pos
-				value:          target_field_name
-				typ:            child.typ
-			})
+			new_field := if t.inplace_struct_fields && target_field_name == child.value
+				&& t.rewrite_one_child_in_place(child_id, new_val) {
+				child_id
+			} else {
+				fi_start := t.a.children.len
+				t.a.children << new_val
+				t.a.add_node(flat.Node{
+					kind:           .field_init
+					op:             child.op
+					children_start: fi_start
+					children_count: 1
+					pos:            child.pos
+					value:          target_field_name
+					typ:            child.typ
+				})
+			}
 			if promoted_key.len > 0 {
 				mut promoted := promoted_fields[promoted_key] or { []flat.NodeId{} }
 				promoted << new_field
@@ -162,24 +180,41 @@ fn (mut t Transformer) transform_struct_fields(id flat.NodeId, node flat.Node) f
 		}
 		field_ids << t.make_promoted_struct_field_init(path, promoted)
 	}
-	start := t.a.children.len
-	for fid in field_ids {
-		t.a.children << fid
+	output_typ := if node.typ.len > 0 { node.typ } else { node.value }
+	new_id := if t.inplace_struct_fields && t.rewrite_children_in_place(id, field_ids) {
+		if output_typ != node.typ {
+			t.set_node_typ(int(id), output_typ)
+		}
+		id
+	} else {
+		start := t.a.children.len
+		for fid in field_ids {
+			t.a.children << fid
+		}
+		t.a.add_node(flat.Node{
+			kind:           .struct_init
+			op:             node.op
+			children_start: start
+			children_count: flat.child_count(field_ids.len)
+			pos:            node.pos
+			value:          node.value
+			typ:            output_typ
+		})
 	}
-	new_id := t.a.add_node(flat.Node{
-		kind:           .struct_init
-		op:             node.op
-		children_start: start
-		children_count: flat.child_count(field_ids.len)
-		pos:            node.pos
-		value:          node.value
-		typ:            if node.typ.len > 0 { node.typ } else { node.value }
-	})
 	final_id := t.add_missing_struct_defaults(new_id, t.a.nodes[int(new_id)])
 	for stmt in prelude {
 		t.pending_stmts << stmt
 	}
 	return final_id
+}
+
+fn struct_info_field_type(info StructInfo, name string) string {
+	for field in info.fields {
+		if field.name == name {
+			return field.typ
+		}
+	}
+	return ''
 }
 
 fn promoted_field_path_key(path []FieldInfo) string {
@@ -531,20 +566,32 @@ fn (mut t Transformer) transform_struct_children(id flat.NodeId, node flat.Node)
 		if child.kind == .field_init && child.children_count > 0 {
 			val_id := t.a.child(&child, 0)
 			new_val := t.transform_expr(val_id)
-			fi_start := t.a.children.len
-			t.a.children << new_val
-			field_ids << t.a.add_node(flat.Node{
-				kind:           .field_init
-				op:             child.op
-				children_start: fi_start
-				children_count: 1
-				pos:            child.pos
-				value:          child.value
-				typ:            child.typ
-			})
+			field_ids << if t.inplace_struct_fields
+				&& t.rewrite_one_child_in_place(child_id, new_val) {
+				child_id
+			} else {
+				fi_start := t.a.children.len
+				t.a.children << new_val
+				t.a.add_node(flat.Node{
+					kind:           .field_init
+					op:             child.op
+					children_start: fi_start
+					children_count: 1
+					pos:            child.pos
+					value:          child.value
+					typ:            child.typ
+				})
+			}
 		} else {
 			field_ids << child_id
 		}
+	}
+	if t.inplace_struct_fields && t.rewrite_children_in_place(id, field_ids) {
+		output_typ := if node.typ.len > 0 { node.typ } else { node.value }
+		if output_typ != node.typ {
+			t.set_node_typ(int(id), output_typ)
+		}
+		return id
 	}
 	start := t.a.children.len
 	for fid in field_ids {
@@ -1436,6 +1483,9 @@ fn (mut t Transformer) transform_array_init_expr(id flat.NodeId, node flat.Node)
 		child_id := t.a.child(&node, i)
 		new_children << t.transform_expr(child_id)
 	}
+	if t.rewrite_children_in_place(id, new_children) {
+		return id
+	}
 	start := t.a.children.len
 	for nc in new_children {
 		t.a.children << nc
@@ -1475,6 +1525,9 @@ fn (mut t Transformer) transform_map_init_expr(id flat.NodeId, node flat.Node) f
 	for i in 0 .. node.children_count {
 		child_id := t.a.child(&node, i)
 		new_children << t.transform_expr(child_id)
+	}
+	if t.rewrite_children_in_place(id, new_children) {
+		return id
 	}
 	start := t.a.children.len
 	for nc in new_children {

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -129,6 +129,11 @@ struct LocalClosureDeclCandidate {
 	name      string
 }
 
+struct InplaceChildRewrite {
+	slot  int
+	child flat.NodeId
+}
+
 // Transformer represents transformer data used by transform.
 pub struct Transformer {
 mut:
@@ -154,6 +159,15 @@ mut:
 	const_suffixes                map[string]string
 	source_parent_ids             []int
 	shared_local_decl_names       map[string]bool
+	// const_array_fixed_storage_ready marks the cache below as fully populated
+	// (by the overlapped pre-dispatch scan), making the precompute a no-op.
+	const_array_fixed_storage_ready bool
+	// defer_pre_scan_indexes routes the AST/tc-only index builders in prepare()
+	// to the overlapped pre-scan helper thread (see prepare_with_pre_scans).
+	defer_pre_scan_indexes bool
+	// merge_regions_relocated marks worker regions as already id-relocated in
+	// place (parallel pass), so merge_worker compacts with plain memmoves.
+	merge_regions_relocated bool
 	// const_array_fixed_storage_cache avoids rescanning the complete AST for
 	// repeated uses of the same array constant in one transform worker.
 	const_array_fixed_storage_cache map[string]i8
@@ -230,6 +244,7 @@ mut:
 	call_param_types_decl_misses    map[string]bool
 	call_param_types_decl_index     map[string]FnParamDeclRef
 	call_param_types_index_ready    bool
+	call_param_types_prepared       bool
 	used_fns                        map[string]bool
 	used_fns_parent                 &map[string]bool = unsafe { nil }
 	used_fns_root                   &map[string]bool = unsafe { nil }
@@ -390,24 +405,49 @@ mut:
 	base_write_intercept bool
 	defer_oor_writes     bool
 	shared_base_nodes    int = -1
+	shared_base_children int = -1
 	item_range_lo        int = -1
 	item_range_hi        int = -1
+	memo_node_types      bool
+	node_type_memo       &NodeTypeMemo = unsafe { nil }
 	deferred_base_writes []DeferredBaseWrite
 	// Prealloc self-host builds put helper-thread scratch allocations in
 	// disposable arenas. The worker's surviving AST strings are cloned by the
 	// master before that arena is released.
-	scope_parallel_workers  bool
-	parallel_enabled        bool
-	worker_scope            voidptr
-	scoped_base_nodes       int = -1
-	scoped_owned_base_nodes map[int]bool
-	scoped_owned_base_log   []int
-	scoped_base_log_active  bool
-	scoped_promoted_texts   map[string]string
-	retain_worker_results   bool
-	retained_worker_regions []ScopedTransformRegion
-	stage_scope             voidptr
-	scoped_monomorphize     bool
+	scope_parallel_workers bool
+	parallel_enabled       bool
+	fast_escape_precheck   bool
+	// The skip-generics body pass owns disjoint source-node ranges. Reusing a
+	// source parent when its transformed child count is unchanged avoids
+	// copying that parent and its child span into the append-only AST.
+	inplace_child_rewrites       bool
+	inplace_fn_child_rewrites    bool
+	inplace_assign_rewrites      bool
+	inplace_simple_rewrites      bool
+	inplace_lvalue_rewrites      bool
+	inplace_block_expr_rewrites  bool
+	inplace_decl_assign_rewrites bool
+	inplace_scalar_prefixes      bool
+	lean_struct_init_fields      bool
+	inplace_struct_fields        bool
+	memo_call_param_type_names   bool
+	memo_semantic_type_names     bool
+	prefix_param_scan            bool
+	// Child-only lowering preserves the parent expression's checked semantic
+	// type. Keep that dense sidecar entry so later transform/cgen queries do not
+	// reconstruct the same type from the lowered text tree.
+	preserve_inplace_expr_types bool
+	inplace_child_log           []InplaceChildRewrite
+	worker_scope                voidptr
+	scoped_base_nodes           int = -1
+	scoped_owned_base_nodes     map[int]bool
+	scoped_owned_base_log       []int
+	scoped_base_log_active      bool
+	scoped_promoted_texts       map[string]string
+	retain_worker_results       bool
+	retained_worker_regions     []ScopedTransformRegion
+	stage_scope                 voidptr
+	scoped_monomorphize         bool
 }
 
 // AliasCache memoizes normalize_type_alias results. It lives on the heap so the
@@ -423,12 +463,31 @@ mut:
 	recent_types       [1024]string
 	recent_results     [1024]string
 	recent_generations [1024]u32
+	canonical_types    [1024]string
+	canonical_results  [1024]string
 	entries            map[string]string
 }
 
 @[inline]
 fn alias_cache_slot(typ string) int {
 	return int((u64(voidptr(typ.str)) >> 4 ^ u64(typ.len)) & 1023)
+}
+
+// trimmed_transform_text avoids allocating a substring for the overwhelmingly
+// common case where canonical type text has no surrounding whitespace.
+@[direct_array_access; inline]
+fn trimmed_transform_text(s string) string {
+	if s.len == 0 {
+		return s
+	}
+	first := s[0]
+	last := s[s.len - 1]
+	if first != ` ` && first != `\n` && first != `\t` && first != `\v` && first != `\f`
+		&& first != `\r` && last != ` ` && last != `\n` && last != `\t` && last != `\v`
+		&& last != `\f` && last != `\r` {
+		return s
+	}
+	return s.trim_space()
 }
 
 @[inline]
@@ -493,13 +552,59 @@ mut:
 
 struct BoolLookupCache {
 mut:
-	entries map[string]i8 // 1 = true, -1 = false
+	entries    map[string]i8 // 1 = true, -1 = false
+	last_name  string
+	last_value i8
 }
 
 struct ContextBoolLookupCache {
 mut:
-	module  string
-	entries map[string]i8 // 1 = true, -1 = false
+	module     string
+	entries    map[string]i8 // 1 = true, -1 = false
+	last_name  string
+	last_value i8
+}
+
+@[inline]
+fn (mut c BoolLookupCache) get(name string) i8 {
+	if c.last_value != 0 && c.last_name.len == name.len
+		&& (unsafe { c.last_name.str == name.str } || c.last_name == name) {
+		return c.last_value
+	}
+	if cached := c.entries[name] {
+		c.last_name = name
+		c.last_value = cached
+		return cached
+	}
+	return 0
+}
+
+@[inline]
+fn (mut c BoolLookupCache) put(name string, value i8) {
+	c.entries[name] = value
+	c.last_name = name
+	c.last_value = value
+}
+
+@[inline]
+fn (mut c ContextBoolLookupCache) get(name string) i8 {
+	if c.last_value != 0 && c.last_name.len == name.len
+		&& (unsafe { c.last_name.str == name.str } || c.last_name == name) {
+		return c.last_value
+	}
+	if cached := c.entries[name] {
+		c.last_name = name
+		c.last_value = cached
+		return cached
+	}
+	return 0
+}
+
+@[inline]
+fn (mut c ContextBoolLookupCache) put(name string, value i8) {
+	c.entries[name] = value
+	c.last_name = name
+	c.last_value = value
 }
 
 struct VarTypeIndexCache {
@@ -543,8 +648,31 @@ fn (mut c VarTypeIndexCache) clear() {
 // and cleared on module switch (resolution consults module-qualified names).
 struct GenericUnresolvedCache {
 mut:
-	module  string
-	entries map[string]i8 // 1 = unresolved, -1 = resolved
+	module     string
+	entries    map[string]i8 // 1 = unresolved, -1 = resolved
+	last_name  string
+	last_value i8
+}
+
+@[inline]
+fn (mut c GenericUnresolvedCache) get(name string) i8 {
+	if c.last_value != 0 && c.last_name.len == name.len
+		&& (unsafe { c.last_name.str == name.str } || c.last_name == name) {
+		return c.last_value
+	}
+	if cached := c.entries[name] {
+		c.last_name = name
+		c.last_value = cached
+		return cached
+	}
+	return 0
+}
+
+@[inline]
+fn (mut c GenericUnresolvedCache) put(name string, value i8) {
+	c.entries[name] = value
+	c.last_name = name
+	c.last_value = value
 }
 
 // ReceiverMethodCache memoizes resolve_receiver_method_for_type results. Lives
@@ -778,6 +906,31 @@ fn transform_with_used_opt_config_scoped_workers_checked_impl(mut a flat.FlatAst
 	mut t := new_transformer(mut a, tc, used_fns)
 	t.skip_generics = skip_generics
 	t.building_v = building_v
+	t.memo_node_types = building_v && os.getenv('V3_NO_NODE_TYPE_MEMO') == ''
+	t.fast_escape_precheck = building_v && os.getenv('V3_NO_ESCAPE_PRECHECK') == ''
+	t.inplace_child_rewrites = building_v && os.getenv('V3_NO_INPLACE_TRANSFORM_CHILDREN') == ''
+	t.inplace_fn_child_rewrites = t.inplace_child_rewrites
+		&& os.getenv('V3_NO_INPLACE_TRANSFORM_FN_CHILDREN') == ''
+	t.inplace_assign_rewrites = t.inplace_child_rewrites
+		&& os.getenv('V3_NO_INPLACE_TRANSFORM_ASSIGN_CHILDREN') == ''
+	t.inplace_simple_rewrites = t.inplace_child_rewrites
+		&& os.getenv('V3_NO_INPLACE_TRANSFORM_SIMPLE_CHILDREN') == ''
+	t.inplace_lvalue_rewrites = t.inplace_simple_rewrites
+		&& os.getenv('V3_NO_INPLACE_TRANSFORM_LVALUE_CHILDREN') == ''
+	t.inplace_block_expr_rewrites = t.inplace_simple_rewrites
+		&& os.getenv('V3_NO_INPLACE_TRANSFORM_BLOCK_EXPR_CHILDREN') == ''
+	t.inplace_decl_assign_rewrites = t.inplace_child_rewrites
+		&& os.getenv('V3_NO_INPLACE_TRANSFORM_DECL_ASSIGN_CHILDREN') == ''
+	t.inplace_scalar_prefixes = t.inplace_simple_rewrites
+		&& os.getenv('V3_NO_INPLACE_TRANSFORM_SCALAR_PREFIXES') == ''
+	t.lean_struct_init_fields = building_v && os.getenv('V3_NO_LEAN_TRANSFORM_STRUCT_FIELDS') == ''
+	t.inplace_struct_fields = t.inplace_child_rewrites
+		&& os.getenv('V3_NO_INPLACE_TRANSFORM_STRUCT_FIELDS') == ''
+	t.memo_call_param_type_names = building_v && os.getenv('V3_NO_TRANSFORM_TYPE_NAME_MEMO') == ''
+	t.memo_semantic_type_names = building_v && os.getenv('V3_TRANSFORM_TYPE_NAME_MEMO_ALL') != ''
+	t.prefix_param_scan = building_v && os.getenv('V3_NO_PREFIX_PARAM_SCAN') == ''
+	t.preserve_inplace_expr_types = t.inplace_child_rewrites
+		&& os.getenv('V3_NO_PRESERVE_INPLACE_EXPR_TYPES') == ''
 	t.scope_parallel_workers = scope_parallel_workers
 	t.parallel_enabled = want_parallel
 	t.retain_worker_results = retain_worker_results
@@ -785,7 +938,7 @@ fn transform_with_used_opt_config_scoped_workers_checked_impl(mut a flat.FlatAst
 	if scope_parallel_workers {
 		t.scoped_base_nodes = t.a.nodes.len
 	}
-	t.prepare()
+	t.prepare_with_pre_scans()
 	t.timing_profile('  [ttime] new+prepare        ${f64(impl_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 	impl_sw.restart()
 	t.cache_comptime_param_reflection_metadata()
@@ -826,6 +979,11 @@ fn transform_with_used_opt_config_scoped_workers_checked_impl(mut a flat.FlatAst
 	t.timing_profile('  [ttime] sum_eq+tail        ${f64(impl_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 	mut owned_base_nodes := t.scoped_owned_base_nodes.keys()
 	owned_base_nodes << t.scoped_owned_base_log
+	// The per-item resolve memo was allocated inside this stage's disposable
+	// arena; drop the master checker's pointer before the driver releases it.
+	if !isnil(t.tc) {
+		t.tc.reset_body_resolve_memo()
+	}
 	return t.used_fns, was_parallel, t.monomorph_errors, owned_base_nodes, t.retained_worker_regions
 }
 
@@ -877,18 +1035,78 @@ fn reserve_parallel_transform_ast_with_cache_mode(mut a flat.FlatAst, skip_gener
 		4, 1
 	}
 	nodes_cap := a.nodes.len * nodes_factor_num / nodes_factor_den
-	if nodes_cap > a.nodes.cap {
+	children_cap := a.children.len * children_factor_num / children_factor_den
+	grow_nodes := nodes_cap > a.nodes.cap
+	grow_children := children_cap > a.children.cap
+	// The two grown arrays copy ~150MB of stable payload; shard the copies
+	// across helper threads (the worker pool is idle before dispatch).
+	if grow_nodes && grow_children && a.nodes.len >= 262_144 {
+		old_nodes := a.nodes
+		mut grown_nodes := []flat.Node{cap: nodes_cap}
+		old_children := a.children
+		mut grown_children := []flat.NodeId{cap: children_cap}
+		unsafe {
+			grown_nodes.grow_len(old_nodes.len)
+			grown_children.grow_len(old_children.len)
+		}
+		third := old_nodes.len / 3
+		copies := [
+			TransformByteCopy{
+				dst:   unsafe { voidptr(&grown_children[0]) }
+				src:   unsafe { voidptr(&old_children[0]) }
+				bytes: u64(old_children.len) * u64(old_children.element_size)
+			},
+			TransformByteCopy{
+				dst:   unsafe { voidptr(&grown_nodes[0]) }
+				src:   unsafe { voidptr(&old_nodes[0]) }
+				bytes: u64(third) * u64(old_nodes.element_size)
+			},
+			TransformByteCopy{
+				dst:   unsafe { voidptr(&grown_nodes[third]) }
+				src:   unsafe { voidptr(&old_nodes[third]) }
+				bytes: u64(third) * u64(old_nodes.element_size)
+			},
+		]
+		copy_thread0 := spawn transform_byte_copy_thread(unsafe { voidptr(&copies[0]) })
+		copy_thread1 := spawn transform_byte_copy_thread(unsafe { voidptr(&copies[1]) })
+		copy_thread2 := spawn transform_byte_copy_thread(unsafe { voidptr(&copies[2]) })
+		tail_start := third * 2
+		unsafe {
+			vmemcpy(voidptr(&grown_nodes[tail_start]), voidptr(&old_nodes[tail_start]),
+				isize(u64(old_nodes.len - tail_start) * u64(old_nodes.element_size)))
+		}
+		_ = copy_thread0.wait()
+		_ = copy_thread1.wait()
+		_ = copy_thread2.wait()
+		a.nodes = grown_nodes
+		a.file_node_ids = []int{}
+		a.children = grown_children
+		return
+	}
+	if grow_nodes {
 		old_nodes := a.nodes
 		a.nodes = []flat.Node{cap: nodes_cap}
 		a.file_node_ids = []int{}
 		a.nodes << old_nodes
 	}
-	children_cap := a.children.len * children_factor_num / children_factor_den
-	if children_cap > a.children.cap {
+	if grow_children {
 		old_children := a.children
 		a.children = []flat.NodeId{cap: children_cap}
 		a.children << old_children
 	}
+}
+
+// TransformByteCopy is one shard of a large stable-payload array copy.
+struct TransformByteCopy {
+	dst   voidptr
+	src   voidptr
+	bytes u64
+}
+
+fn transform_byte_copy_thread(arg voidptr) voidptr {
+	c := unsafe { &TransformByteCopy(arg) }
+	unsafe { vmemcpy(c.dst, c.src, isize(c.bytes)) }
+	return unsafe { nil }
 }
 
 // transform_worker_scope_begin starts a helper-local disposable arena in
@@ -1346,19 +1564,29 @@ fn (mut t Transformer) prepare() {
 	}
 	mut psw := time.new_stopwatch()
 	t.collect_types()
-	t.build_source_parent_index()
+	if !t.defer_pre_scan_indexes {
+		t.build_source_parent_index()
+	}
 	t.timing_profile('  [ttime]   prep collect_types ${f64(psw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 	psw.restart()
 	t.rebuild_embedded_fields_index()
 	t.prepare_runtime_type_indexes()
 	t.rebuild_struct_short_name_index()
-	t.collect_multi_return_fn_ret_types()
+	if !t.defer_pre_scan_indexes {
+		t.collect_multi_return_fn_ret_types()
+	}
 	t.collect_const_suffixes()
 	t.timing_profile('  [ttime]   prep small idx     ${f64(psw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 	psw.restart()
+	// Alias normalization consults the type maps populated by collect_types.
+	// Keep it on the owning thread after those maps are complete; unlike the
+	// AST/tc-only indexes, it is not safe to overlap with type-map construction
+	// on a shared Transformer.
 	t.collect_alias_methods()
 	t.rebuild_receiver_method_suffix_index()
-	t.rebuild_variadic_suffix_index()
+	if !t.defer_pre_scan_indexes {
+		t.rebuild_variadic_suffix_index()
+	}
 	t.build_generic_alias_name_index()
 	t.build_type_alias_suffix_index()
 	t.build_struct_field_decl_metas_cache()
@@ -1565,6 +1793,14 @@ fn type_contains_multi_return(typ types.Type) bool {
 	return false
 }
 
+@[inline]
+fn (t &Transformer) semantic_type_name(typ types.Type) string {
+	if t.memo_semantic_type_names && !isnil(t.tc) {
+		return t.tc.type_name(typ)
+	}
+	return typ.name()
+}
+
 const struct_short_name_ambiguous = '__v_struct_short_name_ambiguous__'
 
 fn (mut t Transformer) rebuild_struct_short_name_index() {
@@ -1596,10 +1832,96 @@ fn (t &Transformer) base_write_allowed(idx int) bool {
 }
 
 @[inline]
+fn (mut t Transformer) record_inplace_child_rewrite(slot int, child flat.NodeId) {
+	// Helper chunks append at temporary region offsets. Preserve the source-slot
+	// write so region relocation can shift its generated child id alongside the
+	// append block. The master chunk already appends at the final offset.
+	if !t.defer_oor_writes && slot >= 0 && slot < t.shared_base_children {
+		t.inplace_child_log << InplaceChildRewrite{
+			slot:  slot
+			child: child
+		}
+	}
+}
+
+@[direct_array_access]
+fn (mut t Transformer) rewrite_children_in_place(id flat.NodeId, children []flat.NodeId) bool {
+	idx := int(id)
+	if !t.inplace_child_rewrites || !t.skip_generics || !t.base_write_intercept
+		|| t.smartcast_stack.len > 0 || idx < 0 || idx >= t.a.nodes.len
+		|| !t.base_write_allowed(idx) {
+		return false
+	}
+	node := t.a.nodes[idx]
+	if int(node.children_count) != children.len {
+		return false
+	}
+	for i, child in children {
+		slot := int(node.children_start) + i
+		t.a.children[slot] = child
+		t.record_inplace_child_rewrite(slot, child)
+	}
+	t.invalidate_node_type_memo(idx)
+	if !t.preserve_inplace_expr_types && !isnil(t.tc) {
+		t.tc.invalidate_checked_expr_type(idx)
+	}
+	return true
+}
+
+@[inline]
+fn (mut t Transformer) rewrite_one_child_in_place(id flat.NodeId, child flat.NodeId) bool {
+	idx := int(id)
+	if !t.inplace_child_rewrites || !t.skip_generics || !t.base_write_intercept
+		|| t.smartcast_stack.len > 0 || idx < 0 || idx >= t.a.nodes.len
+		|| !t.base_write_allowed(idx) {
+		return false
+	}
+	node := t.a.nodes[idx]
+	if node.children_count != 1 {
+		return false
+	}
+	t.a.children[node.children_start] = child
+	t.record_inplace_child_rewrite(int(node.children_start), child)
+	t.invalidate_node_type_memo(idx)
+	if !t.preserve_inplace_expr_types && !isnil(t.tc) {
+		t.tc.invalidate_checked_expr_type(idx)
+	}
+	return true
+}
+
+@[inline]
+fn (mut t Transformer) rewrite_two_children_in_place(id flat.NodeId, first flat.NodeId, second flat.NodeId) bool {
+	idx := int(id)
+	if !t.inplace_child_rewrites || !t.skip_generics || !t.base_write_intercept
+		|| t.smartcast_stack.len > 0 || idx < 0 || idx >= t.a.nodes.len
+		|| !t.base_write_allowed(idx) {
+		return false
+	}
+	node := t.a.nodes[idx]
+	if node.children_count != 2 {
+		return false
+	}
+	t.a.children[node.children_start] = first
+	t.a.children[node.children_start + 1] = second
+	t.record_inplace_child_rewrite(int(node.children_start), first)
+	t.record_inplace_child_rewrite(int(node.children_start) + 1, second)
+	t.invalidate_node_type_memo(idx)
+	if !t.preserve_inplace_expr_types && !isnil(t.tc) {
+		t.tc.invalidate_checked_expr_type(idx)
+	}
+	return true
+}
+
+@[inline]
 fn (mut t Transformer) set_node_typ(idx int, typ string) {
 	if t.base_write_allowed(idx) {
+		t.invalidate_node_type_memo(idx)
 		t.a.nodes[idx].typ = typ
+		t.a.nodes[idx].set_type_text_id(0)
 		t.mark_scoped_owned_base_node(idx)
+		if !isnil(t.tc) {
+			t.tc.invalidate_checked_expr_type(idx)
+		}
 		return
 	}
 	if t.defer_oor_writes {
@@ -1614,8 +1936,12 @@ fn (mut t Transformer) set_node_typ(idx int, typ string) {
 @[inline]
 fn (mut t Transformer) set_node_value(idx int, value string) {
 	if t.base_write_allowed(idx) {
+		t.invalidate_node_type_memo(idx)
 		t.a.nodes[idx].value = value
 		t.mark_scoped_owned_base_node(idx)
+		if !isnil(t.tc) {
+			t.tc.invalidate_checked_expr_type(idx)
+		}
 		return
 	}
 	if t.defer_oor_writes {
@@ -1630,8 +1956,14 @@ fn (mut t Transformer) set_node_value(idx int, value string) {
 @[inline]
 fn (mut t Transformer) set_node(idx int, node flat.Node) {
 	if t.base_write_allowed(idx) {
-		t.a.nodes[idx] = node
+		t.invalidate_node_type_memo(idx)
+		mut stored := node
+		stored.set_type_text_id(t.a.node_type_text_id(stored.typ, stored.type_text_id()))
+		t.a.nodes[idx] = stored
 		t.mark_scoped_owned_base_node(idx)
+		if !isnil(t.tc) {
+			t.tc.invalidate_checked_expr_type(idx)
+		}
 		return
 	}
 	if t.defer_oor_writes {
@@ -1676,6 +2008,7 @@ fn (mut t Transformer) apply_ignored_comptime_for_nodes() {
 			continue
 		}
 		old := t.a.nodes[idx]
+		t.invalidate_node_type_memo(idx)
 		t.a.nodes[idx] = flat.Node{
 			kind: .empty
 			pos:  old.pos
@@ -1688,8 +2021,12 @@ fn (mut t Transformer) apply_ignored_comptime_for_nodes() {
 @[inline]
 fn (mut t Transformer) set_node_generic_params(idx int, gparams []string) {
 	if t.base_write_allowed(idx) {
+		t.invalidate_node_type_memo(idx)
 		t.a.nodes[idx].set_generic_params(gparams)
 		t.mark_scoped_owned_base_node(idx)
+		if !isnil(t.tc) {
+			t.tc.invalidate_checked_expr_type(idx)
+		}
 		return
 	}
 	if t.defer_oor_writes {
@@ -1716,13 +2053,28 @@ fn (mut t Transformer) mark_scoped_owned_base_node(idx int) {
 // in original program order once every worker has been joined.
 fn (mut t Transformer) flush_deferred_base_writes() {
 	for w in t.deferred_base_writes {
+		t.invalidate_node_type_memo(w.idx)
 		match w.kind {
-			0 { t.a.nodes[w.idx].typ = w.str }
-			1 { t.a.nodes[w.idx].value = w.str }
-			2 { t.a.nodes[w.idx] = w.node }
-			else { t.a.nodes[w.idx].set_generic_params(w.gparams) }
+			0 {
+				t.a.nodes[w.idx].typ = w.str
+				t.a.nodes[w.idx].set_type_text_id(0)
+			}
+			1 {
+				t.a.nodes[w.idx].value = w.str
+			}
+			2 {
+				mut stored := w.node
+				stored.set_type_text_id(t.a.node_type_text_id(stored.typ, stored.type_text_id()))
+				t.a.nodes[w.idx] = stored
+			}
+			else {
+				t.a.nodes[w.idx].set_generic_params(w.gparams)
+			}
 		}
 		t.mark_scoped_owned_base_node(w.idx)
+		if !isnil(t.tc) {
+			t.tc.invalidate_checked_expr_type(w.idx)
+		}
 	}
 	t.deferred_base_writes = []DeferredBaseWrite{}
 }
@@ -2661,14 +3013,21 @@ struct DeferredBaseWrite {
 // enough work, with closure-free function bodies transformed across threads.
 // Returns whether function bodies were actually transformed in parallel.
 fn (mut t Transformer) transform_all_dispatch(want_parallel bool) bool {
+	mut dpsw := time.new_stopwatch()
 	t.collect_exclusive_closure_return_fns()
+	t.timing_profile('  [ttime]   dsp closure ret  ${f64(dpsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+	dpsw.restart()
 	t.precompute_const_array_fixed_storage()
+	t.timing_profile('  [ttime]   dsp const fixed  ${f64(dpsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+	dpsw.restart()
 	// Every forked worker checker otherwise lazily rebuilds the source-error
 	// embedding index by rescanning all struct declarations; build it once in
 	// the master cache so forks inherit it through the frozen base.
 	if !isnil(t.tc) {
 		t.tc.precompute_source_error_embed_index()
 	}
+	t.timing_profile('  [ttime]   dsp embed idx    ${f64(dpsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+	dpsw.restart()
 	// Collect source-level interface conversions before any worker rewrites its
 	// private AST. Equality and automatic string lowering can then generate the
 	// same bounded tag dispatch independently of worker scheduling.
@@ -2682,6 +3041,7 @@ fn (mut t Transformer) transform_all_dispatch(want_parallel bool) bool {
 		t.collect_interface_boxed_types_dispatch(want_parallel)
 	}
 	t.refresh_interface_impl_indexes_for_boxed_types()
+	t.timing_profile('  [ttime]   dsp boxed+iface  ${f64(dpsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 	if !want_parallel {
 		if t.scope_parallel_workers && t.retain_worker_results {
 			$if !v3_no_parallel ? {
@@ -2787,6 +3147,8 @@ fn (mut t Transformer) transform_serial_then_collect_pure(literal_decls []int) [
 	mut prev_tl_any := -1
 	mut const_ms := f64(0)
 	mut lit_ms := f64(0)
+	mut est_ms := f64(0)
+	sc_profile := !isnil(t.tc) && t.tc.verbose
 	mut scsw := time.new_stopwatch()
 	for i in tl {
 		range_lo := prev_tl_any + 1
@@ -2845,7 +3207,13 @@ fn (mut t Transformer) transform_serial_then_collect_pure(literal_decls []int) [
 				// folds into this item's cost so its region is sized to fit. The
 				// estimate is 0 for every type v3 self-host interpolates, so its work
 				// items and node numbering are untouched.
+				if sc_profile {
+					scsw.restart()
+				}
 				str_est := t.fn_span_interp_estimate(range_lo, i)
+				if sc_profile {
+					est_ms += f64(scsw.elapsed().microseconds()) / 1000.0
+				}
 				if str_est > deferred_str_expansion_threshold {
 					t.deferred_str_items << FnWorkItem{
 						fn_idx:   i
@@ -2878,7 +3246,7 @@ fn (mut t Transformer) transform_serial_then_collect_pure(literal_decls []int) [
 		}
 	}
 	t.fn_scan_costs = []int{}
-	t.timing_profile('  [ttime]   sc consts ${const_ms:.2f} ms, closures ${lit_ms:.2f} ms')
+	t.timing_profile('  [ttime]   sc consts ${const_ms:.2f} ms, closures ${lit_ms:.2f} ms, interp est ${est_ms:.2f} ms')
 	return pure
 }
 
@@ -2941,11 +3309,17 @@ fn (mut t Transformer) collect_literal_fn_decls(limit int) []int {
 // on this Transformer, in order. Used both as the serial fallback and as the
 // per-worker body in the parallel path.
 fn (mut t Transformer) transform_pure_items_serial(items []FnWorkItem) {
+	// NOTE: arming the checker's BodyResolveMemo per item here was measured a
+	// wash (2026-08): transform's tc-level resolve repeats are already absorbed
+	// by trust_checked_expr_types and the transformer's own caches.
 	for it in items {
 		t.cur_file = it.file
 		t.cur_module = it.module
 		t.item_range_lo = it.range_lo
 		t.item_range_hi = it.fn_idx
+		if t.memo_node_types {
+			t.begin_node_type_memo(it.range_lo, it.fn_idx)
+		}
 		$if v3_ttime ? {
 			mut item_sw := time.new_stopwatch()
 			t.transform_fn_body(it.fn_idx)
@@ -2957,6 +3331,7 @@ fn (mut t Transformer) transform_pure_items_serial(items []FnWorkItem) {
 		}
 		t.transform_fn_body(it.fn_idx)
 	}
+	t.end_node_type_memo()
 	t.item_range_lo = -1
 	t.item_range_hi = -1
 }
@@ -3294,6 +3669,7 @@ fn (t &Transformer) fork_program_view(ast &flat.FlatAst, wtc &types.TypeChecker,
 		call_param_types_decl_misses:    t.call_param_types_decl_misses.clone()
 		call_param_types_decl_index:     t.call_param_types_decl_index
 		call_param_types_index_ready:    t.call_param_types_index_ready
+		call_param_types_prepared:       t.call_param_types_prepared
 		comptime_reflected_params:       t.comptime_reflected_params
 		// Function-body lowering records operator helpers as used. Each parallel
 		// worker therefore needs private map storage; sharing this map races on
@@ -3355,13 +3731,30 @@ fn (t &Transformer) fork_program_view(ast &flat.FlatAst, wtc &types.TypeChecker,
 		monomorph_error_seen:               map[string]bool{}
 		skip_generics:                      t.skip_generics
 		building_v:                         t.building_v
+		memo_node_types:                    t.memo_node_types
 		stringify_depth_cap:                t.stringify_depth_cap
 		has_spawn_expr:                     t.has_spawn_expr
 		base_write_intercept:               t.base_write_intercept
 		defer_oor_writes:                   t.defer_oor_writes
 		shared_base_nodes:                  t.shared_base_nodes
+		shared_base_children:               t.shared_base_children
 		scoped_base_nodes:                  t.scoped_base_nodes
 		scope_parallel_workers:             t.scope_parallel_workers
+		fast_escape_precheck:               t.fast_escape_precheck
+		inplace_child_rewrites:             t.inplace_child_rewrites
+		inplace_fn_child_rewrites:          t.inplace_fn_child_rewrites
+		inplace_assign_rewrites:            t.inplace_assign_rewrites
+		inplace_simple_rewrites:            t.inplace_simple_rewrites
+		inplace_lvalue_rewrites:            t.inplace_lvalue_rewrites
+		inplace_block_expr_rewrites:        t.inplace_block_expr_rewrites
+		inplace_decl_assign_rewrites:       t.inplace_decl_assign_rewrites
+		inplace_scalar_prefixes:            t.inplace_scalar_prefixes
+		lean_struct_init_fields:            t.lean_struct_init_fields
+		inplace_struct_fields:              t.inplace_struct_fields
+		memo_call_param_type_names:         t.memo_call_param_type_names
+		memo_semantic_type_names:           t.memo_semantic_type_names
+		prefix_param_scan:                  t.prefix_param_scan
+		preserve_inplace_expr_types:        t.preserve_inplace_expr_types
 		retain_worker_results:              t.retain_worker_results
 		stage_scope:                        t.stage_scope
 		scoped_monomorphize:                t.scoped_monomorphize
@@ -3485,6 +3878,31 @@ fn (mut t Transformer) clone_scoped_worker_node(idx int, scope voidptr) {
 	}
 }
 
+// relocate_region_in_place rewrites one worker region's appended-node child
+// references and children_start offsets to their final merged values, using the
+// same shift arithmetic merge_worker applies during its fused copy+relocate.
+@[direct_array_access]
+fn (mut t Transformer) relocate_region_in_place(node_start int, node_end int, child_start int, child_end int, node_shift i32, child_shift i32) {
+	for k in node_start .. node_end {
+		if t.a.nodes[k].children_start >= child_start {
+			t.a.nodes[k] = t.a.nodes[k].with_shifted_children(child_shift)
+		}
+	}
+	for j in child_start .. child_end {
+		cid := t.a.children[j]
+		if int(cid) >= node_start {
+			t.a.children[j] = flat.NodeId(int(cid) + int(node_shift))
+		}
+	}
+	for rewrite in t.inplace_child_log {
+		t.a.children[rewrite.slot] = if int(rewrite.child) >= node_start {
+			flat.NodeId(int(rewrite.child) + int(node_shift))
+		} else {
+			rewrite.child
+		}
+	}
+}
+
 // merge_worker folds a finished worker's transformed output back into the master
 // AST. The worker created its new nodes/children at indices base_nodes/base_children
 // (matching the master at fork time); here they are appended to the master and every
@@ -3494,6 +3912,15 @@ fn (mut t Transformer) clone_scoped_worker_node(idx int, scope voidptr) {
 fn (mut t Transformer) merge_worker(w &Transformer, items []FnWorkItem, base_nodes int, base_children int, clear_node_caches bool) {
 	node_shift := i32(t.a.nodes.len - base_nodes)
 	child_shift := i32(t.a.children.len - base_children)
+	if !t.merge_regions_relocated {
+		for rewrite in w.inplace_child_log {
+			t.a.children[rewrite.slot] = if int(rewrite.child) >= base_nodes {
+				flat.NodeId(int(rewrite.child) + int(node_shift))
+			} else {
+				rewrite.child
+			}
+		}
+	}
 	// New children: bulk-copy the worker block, then relocate references to
 	// worker-local new nodes in place (a per-element push paid a capacity check
 	// and branch per child id).
@@ -3503,15 +3930,24 @@ fn (mut t Transformer) merge_worker(w &Transformer, items []FnWorkItem, base_nod
 		unsafe {
 			t.a.children.grow_len(new_children)
 		}
-		// Fused copy+relocate: under the shared-base path compaction copies
-		// leftward within one array, so the forward pass reads ahead of its own
-		// writes; one streamed pass replaces the former memmove + fixup pass.
-		for j in 0 .. new_children {
-			cid := w.a.children[base_children + j]
-			t.a.children[old_len + j] = if int(cid) >= base_nodes {
-				flat.NodeId(int(cid) + int(node_shift))
-			} else {
-				cid
+		if t.merge_regions_relocated {
+			// A parallel pass already applied node_shift inside the region;
+			// compaction is a plain leftward move.
+			unsafe {
+				vmemmove(&t.a.children[old_len], &w.a.children[base_children],
+					isize(new_children) * isize(t.a.children.element_size))
+			}
+		} else {
+			// Fused copy+relocate: under the shared-base path compaction copies
+			// leftward within one array, so the forward pass reads ahead of its own
+			// writes; one streamed pass replaces the former memmove + fixup pass.
+			for j in 0 .. new_children {
+				cid := w.a.children[base_children + j]
+				t.a.children[old_len + j] = if int(cid) >= base_nodes {
+					flat.NodeId(int(cid) + int(node_shift))
+				} else {
+					cid
+				}
 			}
 		}
 	}
@@ -3532,18 +3968,26 @@ fn (mut t Transformer) merge_worker(w &Transformer, items []FnWorkItem, base_nod
 		}
 		clone_worker_nodes := w.worker_scope != unsafe { nil } && !t.retain_worker_results
 			&& t.stage_scope == unsafe { nil }
-		// Fused copy+relocate, same leftward-overlap argument as the children
-		// block above.
-		for j in 0 .. new_nodes {
-			node := w.a.nodes[base_nodes + j]
-			k := nodes_old_len + j
-			t.a.nodes[k] = if node.children_start >= base_children {
-				node.with_shifted_children(child_shift)
-			} else {
-				node
+		if t.merge_regions_relocated && !clone_worker_nodes {
+			// A parallel pass already applied child_shift inside the region.
+			unsafe {
+				vmemmove(&t.a.nodes[nodes_old_len], &w.a.nodes[base_nodes],
+					isize(new_nodes) * isize(t.a.nodes.element_size))
 			}
-			if clone_worker_nodes {
-				t.clone_scoped_worker_node(k, w.worker_scope)
+		} else {
+			// Fused copy+relocate, same leftward-overlap argument as the children
+			// block above.
+			for j in 0 .. new_nodes {
+				node := w.a.nodes[base_nodes + j]
+				k := nodes_old_len + j
+				t.a.nodes[k] = if node.children_start >= base_children {
+					node.with_shifted_children(child_shift)
+				} else {
+					node
+				}
+				if clone_worker_nodes {
+					t.clone_scoped_worker_node(k, w.worker_scope)
+				}
 			}
 		}
 	}
@@ -5359,6 +5803,9 @@ fn (mut t Transformer) heap_escaping_source_decl(node flat.Node, var_name string
 // from fields; the source type is checked at rewrite time when `v`'s type is known.
 fn (mut t Transformer) mark_escaping_amp_ptrs(body_ids []flat.NodeId) {
 	t.reset_escaping_amp_state()
+	if t.fast_escape_precheck && !t.escape_scan_may_be_needed(body_ids) {
+		return
+	}
 	mut amp_ptrs := map[string]bool{}
 	mut amp_sources := map[string][]string{} // pointer `p` -> possible source locals `v`
 	mut ptr_aliases := map[string]string{} // copy `q := p` -> aliased pointer `p`
@@ -5434,6 +5881,51 @@ fn (mut t Transformer) mark_escaping_amp_ptrs(body_ids []flat.NodeId) {
 			t.escaping_interface_box_locals[name] = true
 		}
 	}
+}
+
+fn (t &Transformer) escape_scan_may_be_needed(body_ids []flat.NodeId) bool {
+	for id in body_ids {
+		if t.escape_subtree_may_need_scan(id) {
+			return true
+		}
+	}
+	return false
+}
+
+@[direct_array_access]
+fn (t &Transformer) escape_subtree_may_need_scan(id flat.NodeId) bool {
+	idx := int(id)
+	if idx < 0 || idx >= t.a.nodes.len {
+		return false
+	}
+	node := t.a.nodes[idx]
+	if node.kind in [.fn_literal, .lambda_expr, .fn_decl] {
+		return false
+	}
+	if node.kind == .prefix && node.op == .amp {
+		return true
+	}
+	// Passing a value local to a void-pointer parameter implicitly takes its
+	// address. Checked direct calls expose their exact signature here; unresolved
+	// function-value calls stay conservative and use the full escape walk.
+	if node.kind == .call && node.children_count > 1 {
+		if isnil(t.tc) {
+			return true
+		}
+		name := t.tc.resolved_call_name(id) or { return true }
+		params := t.tc.fn_param_types[name] or { return true }
+		for param in params {
+			if escape_type_is_void_pointer(param) {
+				return true
+			}
+		}
+	}
+	for i in 0 .. node.children_count {
+		if t.escape_subtree_may_need_scan(t.a.child(&node, i)) {
+			return true
+		}
+	}
+	return false
 }
 
 @[direct_array_access]
@@ -7506,69 +7998,85 @@ fn (mut t Transformer) transform_fn_body(fn_idx int) {
 			continue
 		}
 		child := t.a.nodes[int(child_id)]
-		if node_kind_id(child) == 75 && child.value.len > 0 {
-			if child.typ.starts_with('...') {
-				t.cur_fn_variadic_param = child.value
+		if node_kind_id(child) != 75 {
+			if t.prefix_param_scan {
+				break
 			}
-			mut raw_source_typ := if child.typ.starts_with('...') {
-				'[]' + child.typ[3..]
-			} else {
-				child.typ
-			}
-			raw_typ := if child.typ.len > 0 {
-				if child.typ.starts_with('...') {
-					'[]' + t.normalize_type_alias(child.typ[3..])
-				} else {
-					t.normalize_type_alias(child.typ)
-				}
-			} else {
-				''
-			}
-			mut typ := if param_idx < param_types.len && param_types[param_idx] !is types.Unknown {
-				t.normalize_type_alias(param_types[param_idx].name())
-			} else if raw_typ.len > 0 {
-				raw_typ
-			} else if param_idx == 0 {
-				t.fn_body_receiver_type(fn_node.value)
-			} else {
-				''
-			}
-			if child.is_mut && child.op == .amp && typ.starts_with('&') {
-				typ = '&${typ}'
-			}
-			if child.is_mut {
-				typ = mut_optional_param_value_type(typ)
-				raw_source_typ = mut_optional_param_value_type(raw_source_typ)
-			}
-			if typ.starts_with('&') && raw_typ.len > 0 && !raw_typ.starts_with('&')
-				&& t.normalize_type_alias(typ[1..]) == raw_typ {
-				typ = raw_typ
-			}
-			if typ.len > 0 {
-				t.set_var_type_with_raw(child.value, typ, raw_source_typ)
-				if t.is_fixed_array_type(typ) {
-					t.fixed_array_param_values[child.value] = true
-				}
-			}
-			if child.is_mut || child.op == .amp || child.typ.starts_with('mut ') {
-				t.mut_param_values[child.value] = true
-				source_mut_params << child.value
-				if child.op == .amp {
-					source_pointer_value_params << child.value
-				}
-			}
-			param_idx++
-		}
-	}
-	mut body_ids := []flat.NodeId{cap: int(fn_node.children_count)}
-	for i in 0 .. fn_node.children_count {
-		child_id := t.a.children[fn_node.children_start + i]
-		if int(child_id) < 0 {
 			continue
 		}
-		child := t.a.nodes[int(child_id)]
-		if node_kind_id(child) != 75 {
-			body_ids << child_id
+		if child.value.len == 0 {
+			continue
+		}
+		if child.typ.starts_with('...') {
+			t.cur_fn_variadic_param = child.value
+		}
+		mut raw_source_typ := if child.typ.starts_with('...') {
+			'[]' + child.typ[3..]
+		} else {
+			child.typ
+		}
+		raw_typ := if child.typ.len > 0 {
+			if child.typ.starts_with('...') {
+				'[]' + t.normalize_type_alias(child.typ[3..])
+			} else {
+				t.normalize_type_alias(child.typ)
+			}
+		} else {
+			''
+		}
+		mut typ := if param_idx < param_types.len && param_types[param_idx] !is types.Unknown {
+			t.normalize_type_alias(param_types[param_idx].name())
+		} else if raw_typ.len > 0 {
+			raw_typ
+		} else if param_idx == 0 {
+			t.fn_body_receiver_type(fn_node.value)
+		} else {
+			''
+		}
+		if child.is_mut && child.op == .amp && typ.starts_with('&') {
+			typ = '&${typ}'
+		}
+		if child.is_mut {
+			typ = mut_optional_param_value_type(typ)
+			raw_source_typ = mut_optional_param_value_type(raw_source_typ)
+		}
+		if typ.starts_with('&') && raw_typ.len > 0 && !raw_typ.starts_with('&')
+			&& t.normalize_type_alias(typ[1..]) == raw_typ {
+			typ = raw_typ
+		}
+		if typ.len > 0 {
+			t.set_var_type_with_raw(child.value, typ, raw_source_typ)
+			if t.is_fixed_array_type(typ) {
+				t.fixed_array_param_values[child.value] = true
+			}
+		}
+		if child.is_mut || child.op == .amp || child.typ.starts_with('mut ') {
+			t.mut_param_values[child.value] = true
+			source_mut_params << child.value
+			if child.op == .amp {
+				source_pointer_value_params << child.value
+			}
+		}
+		param_idx++
+	}
+	mut body_ids := []flat.NodeId{cap: int(fn_node.children_count)}
+	if t.prefix_param_scan {
+		for i in param_count .. fn_node.children_count {
+			child_id := t.a.children[fn_node.children_start + i]
+			if int(child_id) >= 0 {
+				body_ids << child_id
+			}
+		}
+	} else {
+		for i in 0 .. fn_node.children_count {
+			child_id := t.a.children[fn_node.children_start + i]
+			if int(child_id) < 0 {
+				continue
+			}
+			child := t.a.nodes[int(child_id)]
+			if node_kind_id(child) != 75 {
+				body_ids << child_id
+			}
 		}
 	}
 	t.mark_escaping_amp_ptrs(body_ids)
@@ -7584,31 +8092,42 @@ fn (mut t Transformer) transform_fn_body(fn_idx int) {
 	}
 	new_body := t.transform_stmts(body_ids)
 	// Rebuild function children: params then new body
-	start := t.a.children.len
-	for i in 0 .. fn_node.children_count {
-		child_id := t.a.children[fn_node.children_start + i]
-		if int(child_id) < 0 {
-			continue
+	mut new_children := []flat.NodeId{cap: int(fn_node.children_count)}
+	if t.prefix_param_scan {
+		for i in 0 .. param_count {
+			child_id := t.a.children[fn_node.children_start + i]
+			if int(child_id) >= 0 {
+				new_children << child_id
+			}
 		}
-		child := t.a.nodes[int(child_id)]
-		if node_kind_id(child) == 75 {
-			t.a.children << child_id
+	} else {
+		for i in 0 .. fn_node.children_count {
+			child_id := t.a.children[fn_node.children_start + i]
+			if int(child_id) < 0 {
+				continue
+			}
+			child := t.a.nodes[int(child_id)]
+			if node_kind_id(child) == 75 {
+				new_children << child_id
+			}
 		}
 	}
-	for id in new_body {
-		t.a.children << id
+	new_children << new_body
+	if !t.inplace_fn_child_rewrites
+		|| !t.rewrite_children_in_place(flat.NodeId(fn_idx), new_children) {
+		start := t.a.children.len
+		t.a.children << new_children
+		t.set_node(fn_idx, flat.Node{
+			kind:           .fn_decl
+			op:             fn_node.op
+			children_start: start
+			children_count: flat.child_count(new_children.len)
+			pos:            fn_node.pos
+			value:          fn_node.value
+			typ:            fn_node.typ
+			payload:        fn_node.payload
+		})
 	}
-	count := t.a.children.len - start
-	t.set_node(fn_idx, flat.Node{
-		kind:           .fn_decl
-		op:             fn_node.op
-		children_start: start
-		children_count: flat.child_count(count)
-		pos:            fn_node.pos
-		value:          fn_node.value
-		typ:            fn_node.typ
-		payload:        fn_node.payload
-	})
 	t.smartcast_stack.clear()
 	t.invalidated_smartcasts.clear()
 	t.cur_fn_is_generic = old_is_generic
@@ -7692,9 +8211,13 @@ fn (t &Transformer) fn_body_param_count(fn_node flat.Node) int {
 	mut n := 0
 	for i in 0 .. fn_node.children_count {
 		child := t.a.child_node(&fn_node, i)
-		if child.kind == .param {
-			n++
+		if child.kind != .param {
+			if t.prefix_param_scan {
+				break
+			}
+			continue
 		}
+		n++
 	}
 	return n
 }
@@ -7736,6 +8259,7 @@ fn (t &Transformer) fn_return_type_for_name(name string) ?string {
 // --- statement list driver ---
 
 // transform_stmts transforms transform stmts data for transform.
+@[direct_array_access]
 pub fn (mut t Transformer) transform_stmts(ids []flat.NodeId) []flat.NodeId {
 	mut result := []flat.NodeId{cap: ids.len}
 	had_base_smartcasts := t.smartcast_stack.len > 0
@@ -7977,7 +8501,7 @@ pub fn (mut t Transformer) transform_stmt(id flat.NodeId) []flat.NodeId {
 		return t.transform_assert_stmt(id, node)
 	}
 	if kind_id == 56 {
-		return t.transform_select_stmt(node)
+		return t.transform_select_stmt(id, node)
 	}
 	match node.kind {
 		.return_stmt {
@@ -8020,7 +8544,7 @@ pub fn (mut t Transformer) transform_stmt(id flat.NodeId) []flat.NodeId {
 			return t.transform_assert_stmt(id, node)
 		}
 		.select_stmt {
-			return t.transform_select_stmt(node)
+			return t.transform_select_stmt(id, node)
 		}
 		else {
 			return arr1(id)
@@ -8134,7 +8658,7 @@ pub fn (mut t Transformer) transform_expr(id flat.NodeId) flat.NodeId {
 		return t.transform_spawn_expr(id, node)
 	}
 	if kind_id == 56 {
-		return t.transform_select_expr(node)
+		return t.transform_select_expr(id, node)
 	}
 	if node.kind == .string_literal {
 		return t.transform_nested_string_literal_expr(id, node)
@@ -8248,7 +8772,7 @@ pub fn (mut t Transformer) transform_expr(id flat.NodeId) flat.NodeId {
 			return t.transform_spawn_expr(id, node)
 		}
 		.select_stmt {
-			return t.transform_select_expr(node)
+			return t.transform_select_expr(id, node)
 		}
 		.lambda_expr, .range, .select_branch {
 			return t.transform_children_expr(id, node)
@@ -9035,6 +9559,9 @@ pub fn (mut t Transformer) transform_lvalue(id flat.NodeId) flat.NodeId {
 			for i in 1 .. node.children_count {
 				new_children << t.transform_expr(t.a.child(&node, i))
 			}
+			if t.inplace_lvalue_rewrites && t.rewrite_children_in_place(id, new_children) {
+				return id
+			}
 			start := t.a.children.len
 			for child in new_children {
 				t.a.children << child
@@ -9060,6 +9587,9 @@ pub fn (mut t Transformer) transform_lvalue(id flat.NodeId) flat.NodeId {
 			new_children << t.transform_expr(t.a.child(&node, 0))
 			for i in 1 .. node.children_count {
 				new_children << t.transform_expr(t.a.child(&node, i))
+			}
+			if t.inplace_lvalue_rewrites && t.rewrite_children_in_place(id, new_children) {
+				return id
 			}
 			start := t.a.children.len
 			for child in new_children {
@@ -9096,6 +9626,9 @@ pub fn (mut t Transformer) transform_lvalue(id flat.NodeId) flat.NodeId {
 					child = t.make_prefix(.mul, child)
 					t.set_node_typ(int(child), t.var_type(child_node.value)[1..])
 				}
+				if t.inplace_lvalue_rewrites && t.rewrite_one_child_in_place(id, child) {
+					return id
+				}
 				start := t.a.children.len
 				t.a.children << child
 				return t.a.add_node(flat.Node{
@@ -9115,6 +9648,9 @@ pub fn (mut t Transformer) transform_lvalue(id flat.NodeId) flat.NodeId {
 				return id
 			}
 			child := t.transform_lvalue(t.a.child(&node, 0))
+			if t.inplace_lvalue_rewrites && t.rewrite_one_child_in_place(id, child) {
+				return id
+			}
 			start := t.a.children.len
 			t.a.children << child
 			return t.a.add_node(flat.Node{
@@ -9172,6 +9708,9 @@ fn (mut t Transformer) transform_return_stmt(id flat.NodeId, node flat.Node) []f
 		child_id := t.a.child(&node, i)
 		new_children << t.transform_return_child(child_id, i, int(node.children_count))
 	}
+	if t.rewrite_children_in_place(id, new_children) {
+		return t.with_pending_before(id)
+	}
 	start := t.a.children.len
 	for nc in new_children {
 		t.a.children << nc
@@ -9198,6 +9737,7 @@ fn (mut t Transformer) return_values_with_extra(first_id flat.NodeId, extra_ids 
 	return t.return_values_from_ids(ids)
 }
 
+@[direct_array_access]
 fn (mut t Transformer) transform_return_child(child_id flat.NodeId, child_index int, total_children int) flat.NodeId {
 	old_in_return_expr := t.in_return_expr
 	t.in_return_expr = true
@@ -9650,9 +10190,10 @@ fn (mut t Transformer) const_array_literal_requires_fixed_storage(key string) bo
 // once per constant and per worker batch, putting a multi-millisecond lazy
 // initialization cost on otherwise tiny function bodies.
 fn (mut t Transformer) precompute_const_array_fixed_storage() {
-	if isnil(t.tc) {
+	if isnil(t.tc) || t.const_array_fixed_storage_ready {
 		return
 	}
+	t.const_array_fixed_storage_ready = true
 	mut candidate_ids := map[string]int{}
 	mut candidate_names := map[string]bool{}
 	mut candidate_keys := []string{}
@@ -10047,19 +10588,6 @@ fn (mut t Transformer) transform_assign_stmt(id flat.NodeId, node flat.Node) []f
 			}
 		}
 	}
-	start := t.a.children.len
-	for nc in new_children {
-		t.a.children << nc
-	}
-	new_id := t.a.add_node(flat.Node{
-		kind:           node.kind
-		op:             node.op
-		children_start: start
-		children_count: node.children_count
-		pos:            node.pos
-		value:          node.value
-		typ:            node.typ
-	})
 	if node.kind == .assign && node.op == .assign && node.children_count == 2 {
 		t.update_option_assignment_smartcast(t.a.child(&node, 0), t.a.child(&node, 1))
 	}
@@ -10096,9 +10624,6 @@ fn (mut t Transformer) transform_assign_stmt(id flat.NodeId, node flat.Node) []f
 			t.invalidate_smartcast_for_lvalue(t.a.child(&node, 0))
 			return result
 		}
-	}
-	if node.kind == .assign && node.op == .left_shift_assign {
-		t.annotate_left_shift_assign(new_id)
 	}
 	for i := 0; i < int(node.children_count); i += 2 {
 		lhs_id := t.a.child(&node, i)
@@ -10138,9 +10663,32 @@ fn (mut t Transformer) transform_assign_stmt(id flat.NodeId, node flat.Node) []f
 		}
 		return result
 	}
+	preserve_self_capture_source := t.fn_value_self_capture_refresh_source(node)
+	mut new_id := id
+	if !t.inplace_assign_rewrites || preserve_self_capture_source
+		|| !t.rewrite_children_in_place(id, new_children) {
+		start := t.a.children.len
+		for nc in new_children {
+			t.a.children << nc
+		}
+		new_id = t.a.add_node(flat.Node{
+			kind:           node.kind
+			op:             node.op
+			children_start: start
+			children_count: node.children_count
+			pos:            node.pos
+			value:          node.value
+			typ:            node.typ
+		})
+	}
+	if node.kind == .assign && node.op == .left_shift_assign {
+		t.annotate_left_shift_assign(new_id)
+	}
 	mut result := t.with_pending_before(new_id)
-	if post_assign := t.fn_value_self_capture_refresh_stmt(node, new_children) {
-		result << post_assign
+	if preserve_self_capture_source {
+		if post_assign := t.fn_value_self_capture_refresh_stmt(node, new_children) {
+			result << post_assign
+		}
 	}
 	return result
 }
@@ -10224,6 +10772,15 @@ fn (t &Transformer) local_closure_overwrite_name(id flat.NodeId, node flat.Node)
 		return none
 	}
 	return t.local_closure_cleanup_assigns[int(id)] or { none }
+}
+
+fn (t &Transformer) fn_value_self_capture_refresh_source(node flat.Node) bool {
+	if node.op != .assign || node.children_count != 2 {
+		return false
+	}
+	lhs := t.a.child_node(&node, 0)
+	return lhs.kind == .ident && lhs.value.len > 0
+		&& t.fn_literal_captures_name(t.a.child(&node, 1), lhs.value)
 }
 
 fn (mut t Transformer) update_option_assignment_smartcast(lhs_id flat.NodeId, rhs_id flat.NodeId) {
@@ -11211,6 +11768,7 @@ fn (t &Transformer) optional_conversion_source_type(id flat.NodeId) string {
 	return source_type
 }
 
+@[direct_array_access]
 fn (mut t Transformer) transform_expr_for_type(id flat.NodeId, target_type string) flat.NodeId {
 	old_expected_node := t.expected_expr_node
 	old_expected_type := t.expected_expr_type
@@ -11528,7 +12086,8 @@ fn (mut t Transformer) transform_array_value_for_type(id flat.NodeId, target_typ
 		}
 		actual_base := forwarded_return_unalias_type(actual_type)
 		if actual_base is types.Array {
-			if actual_base.elem_type.name() != expected_base.elem_type.name() {
+			if actual_base.elem_type.name() != expected_base.elem_type.name()
+				&& !forwarded_array_elems_storage_identical(actual_base.elem_type, expected_base.elem_type) {
 				return t.convert_forwarded_array_to_dynamic(id, actual_type, actual_base.elem_type,
 					expected_type, expected_base.elem_type, false)
 			}
@@ -12127,9 +12686,15 @@ fn (mut t Transformer) try_lower_string_compound_assign(_id flat.NodeId, node fl
 }
 
 // transform_decl_assign_stmt transforms transform decl assign stmt data for transform.
+@[direct_array_access]
 fn (mut t Transformer) transform_decl_assign_stmt(id flat.NodeId, node flat.Node) []flat.NodeId {
 	if node.children_count == 0 {
 		return arr1(id)
+	}
+	source_rhs_id := if node.children_count == 2 {
+		t.a.child(&node, 1)
+	} else {
+		flat.empty_node
 	}
 	mut has_empty_child := false
 	for i in 0 .. node.children_count {
@@ -12474,30 +13039,39 @@ fn (mut t Transformer) transform_decl_assign_stmt(id flat.NodeId, node flat.Node
 			t.set_node_typ(int(new_children[0]), inferred_typ)
 		}
 	}
-	start := t.a.children.len
-	for nc in new_children {
-		t.a.children << nc
+	output_typ := if inferred_typ.len > 0 { inferred_typ } else { node.typ }
+	mut new_id := id
+	if !t.inplace_decl_assign_rewrites || !t.rewrite_children_in_place(id, new_children) {
+		start := t.a.children.len
+		for nc in new_children {
+			t.a.children << nc
+		}
+		new_id = t.a.add_node(flat.Node{
+			kind:           .decl_assign
+			op:             node.op
+			children_start: start
+			children_count: node.children_count
+			pos:            node.pos
+			value:          node.value
+			typ:            output_typ
+			is_mut:         node.is_mut
+		})
+	} else if output_typ != node.typ {
+		t.set_node_typ(int(id), output_typ)
 	}
-	new_id := t.a.add_node(flat.Node{
-		kind:           .decl_assign
-		op:             node.op
-		children_start: start
-		children_count: node.children_count
-		pos:            node.pos
-		value:          node.value
-		typ:            if inferred_typ.len > 0 { inferred_typ } else { node.typ }
-		is_mut:         node.is_mut
-	})
 	mut result := t.with_pending_before(new_id)
 	if cleanup_name := t.local_closure_cleanup_decls[int(id)] {
 		result << t.make_local_closure_cleanup_defer(cleanup_name)
 	}
 	if node.children_count == 2 {
 		lhs := t.a.child_node(&node, 0)
-		rhs_id := t.a.child(&node, 1)
 		if lhs.kind == .ident && lhs.value.len > 0 {
-			aggregate_type := if inferred_typ.len > 0 { inferred_typ } else { t.node_type(rhs_id) }
-			t.append_local_closure_initializer_cleanups(lhs.value, rhs_id, aggregate_type, mut
+			aggregate_type := if inferred_typ.len > 0 {
+				inferred_typ
+			} else {
+				t.node_type(source_rhs_id)
+			}
+			t.append_local_closure_initializer_cleanups(lhs.value, source_rhs_id, aggregate_type, mut
 				result)
 		}
 	}
@@ -13992,6 +14566,9 @@ fn (mut t Transformer) transform_expr_stmt(id flat.NodeId, node flat.Node) []fla
 	if child.kind == .select_stmt && t.a.node(new_child).kind == .block {
 		return t.with_pending_before(new_child)
 	}
+	if t.rewrite_one_child_in_place(id, new_child) {
+		return t.with_pending_before(id)
+	}
 	start := t.a.children.len
 	t.a.children << new_child
 	new_id := t.a.add_node(flat.Node{
@@ -14224,12 +14801,15 @@ fn (mut t Transformer) transform_for_in_stmt(id flat.NodeId, node flat.Node) []f
 }
 
 // transform_block_stmt transforms transform block stmt data for transform.
-fn (mut t Transformer) transform_block_stmt(_id flat.NodeId, node flat.Node) []flat.NodeId {
+fn (mut t Transformer) transform_block_stmt(id flat.NodeId, node flat.Node) []flat.NodeId {
 	mut child_ids := []flat.NodeId{cap: int(node.children_count)}
 	for i in 0 .. node.children_count {
 		child_ids << t.a.children[node.children_start + i]
 	}
 	new_children := t.transform_stmts(child_ids)
+	if t.rewrite_children_in_place(id, new_children) {
+		return arr1(id)
+	}
 	new_block := t.make_block(new_children)
 	t.set_node_value(int(new_block), node.value)
 	return arr1(new_block)
@@ -14808,7 +15388,11 @@ fn (mut t Transformer) transform_block_expr(id flat.NodeId, node flat.Node) flat
 		child_ids << t.a.children[node.children_start + i]
 	}
 	new_children := t.transform_stmts(child_ids)
-	new_block := t.make_block(new_children)
+	new_block := if t.inplace_block_expr_rewrites && t.rewrite_children_in_place(id, new_children) {
+		id
+	} else {
+		t.make_block(new_children)
+	}
 	t.set_node_value(int(new_block), node.value)
 	mut block_typ := t.checker_expr_type_name(id) or { '' }
 	if !decl_type_is_usable(block_typ) && node.children_count > 0 {
@@ -14889,6 +15473,12 @@ fn (mut t Transformer) transform_lock_node(id flat.NodeId, node flat.Node) flat.
 			t.stmt_value_type(new_body)
 		}
 	}
+	if t.rewrite_children_in_place(id, children) {
+		if lock_typ != node.typ {
+			t.set_node_typ(int(id), lock_typ)
+		}
+		return id
+	}
 	start := t.a.children.len
 	t.a.children << children
 	return t.a.add_node(flat.Node{
@@ -14946,24 +15536,28 @@ fn (mut t Transformer) transform_defer_stmt(id flat.NodeId, node flat.Node) []fl
 	} else {
 		t.make_block(arr1(t.transform_expr(body_id)))
 	}
-	start := t.a.children.len
-	t.a.children << new_body
-	new_id := t.a.add_node(flat.Node{
-		kind:           .defer_stmt
-		children_start: start
-		children_count: 1
-		pos:            node.pos
-		value:          node.value
-		typ:            node.typ
-	})
+	new_id := if t.rewrite_one_child_in_place(id, new_body) {
+		id
+	} else {
+		start := t.a.children.len
+		t.a.children << new_body
+		t.a.add_node(flat.Node{
+			kind:           .defer_stmt
+			children_start: start
+			children_count: 1
+			pos:            node.pos
+			value:          node.value
+			typ:            node.typ
+		})
+	}
 	return arr1(new_id)
 }
 
-fn (mut t Transformer) transform_select_stmt(node flat.Node) []flat.NodeId {
-	return arr1(t.transform_select_expr(node))
+fn (mut t Transformer) transform_select_stmt(id flat.NodeId, node flat.Node) []flat.NodeId {
+	return arr1(t.transform_select_expr(id, node))
 }
 
-fn (mut t Transformer) transform_select_expr(node flat.Node) flat.NodeId {
+fn (mut t Transformer) transform_select_expr(id flat.NodeId, node flat.Node) flat.NodeId {
 	if node.children_count == 1 {
 		branch := t.a.child_node(&node, 0)
 		if branch.kind == .select_branch && branch.value == 'else' {
@@ -15002,10 +15596,11 @@ fn (mut t Transformer) transform_select_expr(node flat.Node) flat.NodeId {
 		t.invalidated_smartcasts = merged_invalidated.move()
 		t.smartcast_stack = t.non_invalidated_smartcasts(base_smartcasts)
 	}
-	start := t.a.children.len
-	for branch in branches {
-		t.a.children << branch
+	if t.rewrite_children_in_place(id, branches) {
+		return id
 	}
+	start := t.a.children.len
+	t.a.children << branches
 	return t.a.add_node(flat.Node{
 		kind:           .select_stmt
 		children_start: start
@@ -15111,6 +15706,9 @@ fn (mut t Transformer) transform_select_branch(id flat.NodeId) flat.NodeId {
 			t.restore_shadowed_smartcast_state(bound_name, saved_smartcasts, saved_invalidated)
 		}
 	}
+	if t.rewrite_children_in_place(id, children) {
+		return id
+	}
 	start := t.a.children.len
 	for child in children {
 		t.a.children << child
@@ -15174,6 +15772,9 @@ fn (mut t Transformer) transform_children_stmt(id flat.NodeId, node flat.Node) [
 			new_children << t.transform_expr(child_id)
 		}
 	}
+	if t.rewrite_children_in_place(id, new_children) {
+		return arr1(id)
+	}
 	start := t.a.children.len
 	for nc in new_children {
 		t.a.children << nc
@@ -15217,6 +15818,9 @@ fn (mut t Transformer) transform_assert_stmt(id flat.NodeId, node flat.Node) []f
 		} else {
 			new_children << t.transform_expr(child_id)
 		}
+	}
+	if t.rewrite_children_in_place(id, new_children) {
+		return arr1(id)
 	}
 	start := t.a.children.len
 	for nc in new_children {
@@ -15271,6 +15875,9 @@ fn (mut t Transformer) transform_children_expr(id flat.NodeId, node flat.Node) f
 		}
 	}
 	if !changed {
+		return id
+	}
+	if t.rewrite_children_in_place(id, new_children) {
 		return id
 	}
 	start := t.a.children.len
@@ -15355,6 +15962,10 @@ fn (mut t Transformer) transform_infix_expr(id flat.NodeId, node flat.Node) flat
 		} else {
 			t.transform_expr(rhs_id)
 		}
+		if t.rewrite_two_children_in_place(id, new_lhs, new_rhs) {
+			t.annotate_left_shift(id)
+			return id
+		}
 		start := t.a.children.len
 		t.a.children << new_lhs
 		t.a.children << new_rhs
@@ -15432,6 +16043,9 @@ fn (mut t Transformer) transform_infix_expr(id flat.NodeId, node flat.Node) flat
 		// never freed, so avoiding them cuts both transform time and peak RAM.
 		return id
 	}
+	if t.rewrite_two_children_in_place(id, new_lhs, new_rhs) {
+		return id
+	}
 	start := t.a.children.len
 	t.a.children << new_lhs
 	t.a.children << new_rhs
@@ -15447,6 +16061,7 @@ fn (mut t Transformer) transform_infix_expr(id flat.NodeId, node flat.Node) flat
 }
 
 // transform_call_expr transforms transform call expr data for transform.
+@[direct_array_access]
 fn (mut t Transformer) transform_call_expr(id flat.NodeId, node flat.Node) flat.NodeId {
 	if node.value.len > 0 && node.value == '__v_compile_warn' {
 		return t.make_empty()
@@ -15923,6 +16538,12 @@ fn (mut t Transformer) transform_index_expr(id flat.NodeId, node flat.Node) flat
 		index_typ = node.value
 	}
 	if !changed {
+		if index_typ.len > 0 {
+			t.set_node_typ(int(id), index_typ)
+		}
+		return t.lower_owned_array_index_move(id, id)
+	}
+	if t.rewrite_children_in_place(id, new_children) {
 		if index_typ.len > 0 {
 			t.set_node_typ(int(id), index_typ)
 		}
@@ -16793,6 +17414,11 @@ fn (mut t Transformer) transform_selector_expr(id flat.NodeId, node flat.Node) f
 		t.set_node_typ(int(id), sel_typ)
 		return id
 	}
+	if sel_op == node.op && selector_generic_params == node.generic_params()
+		&& t.rewrite_children_in_place(id, new_children) {
+		t.set_node_typ(int(id), sel_typ)
+		return id
+	}
 	start := t.a.children.len
 	for nc in new_children {
 		t.a.children << nc
@@ -17478,6 +18104,10 @@ fn (mut t Transformer) transform_prefix_expr(id flat.NodeId, node flat.Node) fla
 		}
 		new_children << new_child
 	}
+	if t.inplace_scalar_prefixes && node.op in [.plus, .minus, .bit_not]
+		&& t.rewrite_children_in_place(id, new_children) {
+		return id
+	}
 	start := t.a.children.len
 	for nc in new_children {
 		t.a.children << nc
@@ -17889,6 +18519,9 @@ fn (mut t Transformer) transform_paren_expr(id flat.NodeId, node flat.Node) flat
 	} else {
 		t.transform_expr(child_id)
 	}
+	if t.rewrite_one_child_in_place(id, new_child) {
+		return id
+	}
 	start := t.a.children.len
 	t.a.children << new_child
 	return t.a.add_node(flat.Node{
@@ -17943,6 +18576,9 @@ fn (mut t Transformer) transform_postfix_expr(id flat.NodeId, node flat.Node) fl
 		t.make_paren(t.make_prefix(.mul, t.make_ident(child.value)))
 	} else {
 		t.transform_expr(child_id)
+	}
+	if t.rewrite_one_child_in_place(id, new_child) {
+		return id
 	}
 	start := t.a.children.len
 	t.a.children << new_child
@@ -18033,6 +18669,9 @@ fn (mut t Transformer) transform_cast_expr(id flat.NodeId, node flat.Node) flat.
 		for i in 0 .. node.children_count {
 			child_id := t.a.child(&node, i)
 			new_children << t.transform_expr_preserving_pointer_value(child_id)
+		}
+		if t.rewrite_children_in_place(id, new_children) {
+			return id
 		}
 		start := t.a.children.len
 		for nc in new_children {
@@ -18151,6 +18790,16 @@ fn (mut t Transformer) transform_cast_expr(id flat.NodeId, node flat.Node) flat.
 			new_children << t.transform_expr(child_id)
 		}
 	}
+	output_typ := if node.typ.len > 0 { t.normalize_type_alias(node.typ) } else { target_type }
+	if t.rewrite_children_in_place(id, new_children) {
+		if target_type != node.value {
+			t.set_node_value(int(id), target_type)
+		}
+		if output_typ != node.typ {
+			t.set_node_typ(int(id), output_typ)
+		}
+		return id
+	}
 	start := t.a.children.len
 	for nc in new_children {
 		t.a.children << nc
@@ -18162,7 +18811,7 @@ fn (mut t Transformer) transform_cast_expr(id flat.NodeId, node flat.Node) flat.
 		children_count: node.children_count
 		pos:            node.pos
 		value:          target_type
-		typ:            if node.typ.len > 0 { t.normalize_type_alias(node.typ) } else { target_type }
+		typ:            output_typ
 	})
 }
 
@@ -18263,6 +18912,9 @@ fn (mut t Transformer) transform_array_literal(id flat.NodeId, node flat.Node) f
 		} else {
 			t.transform_expr(child_id)
 		}
+	}
+	if t.rewrite_children_in_place(id, new_children) {
+		return id
 	}
 	start := t.a.children.len
 	for nc in new_children {
@@ -21270,6 +21922,7 @@ fn (mut t Transformer) lower_one_match(node flat.Node) flat.NodeId {
 }
 
 // build_match_chain builds match chain data for transform.
+@[direct_array_access]
 fn (mut t Transformer) build_match_chain(match_expr_id flat.NodeId, orig_expr_id flat.NodeId, branches []flat.NodeId, idx int) flat.NodeId {
 	if idx >= branches.len {
 		return t.a.add(flat.NodeKind.empty)

--- a/vlib/v3/transform/transform_parallel_d_v3_no_parallel.v
+++ b/vlib/v3/transform/transform_parallel_d_v3_no_parallel.v
@@ -7,7 +7,7 @@ fn scan_literal_decl_flags_parallel(_ &flat.FlatAst, _ int, mut _ []u8) bool {
 	return false
 }
 
-fn scan_top_level_kind_flags_parallel(_ &flat.FlatAst, _ int, mut _ []u8) bool {
+fn scan_top_level_kind_flags_parallel(_ &flat.FlatAst, _ int, mut _ []u8, _ bool) bool {
 	return false
 }
 
@@ -40,4 +40,10 @@ pub fn promote_scoped_checker_node_caches_parallel(mut _ types.TypeChecker, _ &f
 
 pub fn scan_scoped_text_flags_parallel(_ &flat.FlatAst, _ voidptr, mut _ []u8) bool {
 	return false
+}
+
+// prepare_with_pre_scans keeps preparation serial when v3 is built with the
+// internal `v3_no_parallel` define.
+fn (mut t Transformer) prepare_with_pre_scans() {
+	t.prepare()
 }

--- a/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
@@ -21,12 +21,71 @@ const max_parallel_transform_jobs = 7
 const max_shared_transform_jobs = 10
 const max_parallel_monomorph_jobs = 10
 // Recycle scratch arenas throughout large self-hosting transforms.
-const scoped_transform_worker_batches = 32
-const scoped_transform_master_batches = 32
+const scoped_transform_worker_batches = 16
+const scoped_transform_master_batches = 16
 const scoped_transform_max_batch_items = 2048
 const scoped_monomorph_batch_specs = 512
 
 $if !windows {
+	// RegionRelocateArgs is one worker region's in-place id-relocation job: the
+	// shifts are precomputed from the (deterministic) region content lengths, so
+	// disjoint regions relocate concurrently before the serial compaction pass.
+	struct RegionRelocateArgs {
+		worker      voidptr // &Transformer (region view)
+		node_start  int
+		node_end    int
+		child_start int
+		child_end   int
+		node_shift  i32
+		child_shift i32
+	}
+
+	fn region_relocate_thread(arg voidptr) voidptr {
+		a := unsafe { &RegionRelocateArgs(arg) }
+		mut w := unsafe { &Transformer(a.worker) }
+		w.relocate_region_in_place(a.node_start, a.node_end, a.child_start, a.child_end,
+			a.node_shift, a.child_shift)
+		return unsafe { nil }
+	}
+
+	// transform_pre_scan_index_thread builds the AST/tc-only prepare() indexes
+	// (deferred via defer_pre_scan_indexes) on a helper thread, directly on the
+	// master transformer: the fields it writes are untouched by the concurrent
+	// collect_types walk, and the permanent thread arena keeps them alive. Alias
+	// method collection stays on the master because its normalization reads the
+	// type maps collect_types is still populating.
+	fn transform_pre_scan_index_thread(arg voidptr) voidptr {
+		mut t := unsafe { &Transformer(arg) }
+		t.build_source_parent_index()
+		t.collect_multi_return_fn_ret_types()
+		t.rebuild_variadic_suffix_index()
+		return unsafe { nil }
+	}
+
+	// transform_const_fixed_scan_thread classifies array-literal constants on a
+	// helper thread while the master builds its lookup indexes in prepare().
+	// The scan worker only reads the immutable AST and post-check tc tables,
+	// plus its own private const-suffix map, so it never observes the maps the
+	// master is concurrently building.
+	fn transform_const_fixed_scan_thread(arg voidptr) voidptr {
+		mut w := unsafe { &Transformer(arg) }
+		scope := transform_worker_scope_begin(w.scope_parallel_workers)
+		w.collect_const_suffixes()
+		w.precompute_const_array_fixed_storage()
+		w.worker_scope = scope
+		transform_worker_scope_leave(scope)
+		return unsafe { nil }
+	}
+
+	// transform_param_prep_thread snapshots function parameter types while the
+	// master prepares its independent type indexes. The worker owns its checker
+	// caches and publishes only its completed declaration maps after joining.
+	fn transform_param_prep_thread(arg voidptr) voidptr {
+		mut w := unsafe { &Transformer(arg) }
+		w.prepare_parallel_call_param_types()
+		return unsafe { nil }
+	}
+
 	// TransformChunkArgs is the payload handed to each persistent worker.
 	struct TransformChunkArgs {
 		worker    voidptr // &Transformer
@@ -142,11 +201,12 @@ $if !windows {
 
 // TopLevelKindScanArgs is the payload for one top-level-kind flag-scan worker.
 struct TopLevelKindScanArgs {
-	a     &flat.FlatAst = unsafe { nil }
-	start int
-	end   int
-	flags voidptr // &u8 base of the per-node flag array (index 0 == node `base`)
-	base  int
+	a                 &flat.FlatAst = unsafe { nil }
+	start             int
+	end               int
+	flags             voidptr // &u8 base of the per-node flag array (index 0 == node `base`)
+	base              int
+	prefix_param_scan bool
 }
 
 $if !windows {
@@ -214,7 +274,8 @@ $if !windows {
 				unsafe {
 					flags[i - a.base] = 1
 				}
-			} else if node.kind == .fn_decl && fn_decl_generic_candidate_prescreen(a.a, node) {
+			} else if node.kind == .fn_decl
+				&& fn_decl_generic_candidate_prescreen(a.a, node, a.prefix_param_scan) {
 				unsafe {
 					flags[i - a.base] = 1
 				}
@@ -271,7 +332,7 @@ fn scan_literal_decl_flags_parallel(a &flat.FlatAst, limit int, mut flags []u8) 
 // possible placeholder in the signature texts. Fn decls failing it can never
 // need erasure.
 @[inline]
-fn fn_decl_generic_candidate_prescreen(a &flat.FlatAst, node &flat.Node) bool {
+fn fn_decl_generic_candidate_prescreen(a &flat.FlatAst, node &flat.Node, prefix_param_scan bool) bool {
 	if !isnil(node.payload) && node.payload.generic_params.len > 0 {
 		return true
 	}
@@ -280,7 +341,13 @@ fn fn_decl_generic_candidate_prescreen(a &flat.FlatAst, node &flat.Node) bool {
 	}
 	for i in 0 .. node.children_count {
 		child := a.child_node(node, i)
-		if child.kind == .param && generic_placeholder_prescreen(child.typ) {
+		if child.kind != .param {
+			if prefix_param_scan {
+				break
+			}
+			continue
+		}
+		if generic_placeholder_prescreen(child.typ) {
 			return true
 		}
 	}
@@ -291,7 +358,7 @@ fn fn_decl_generic_candidate_prescreen(a &flat.FlatAst, node &flat.Node) bool {
 // [base, base + flags.len)) for file/module/fn-decl nodes, using the shared
 // worker pool. Returns false when no pool is available so the caller can walk
 // the range serially instead.
-fn scan_top_level_kind_flags_parallel(a &flat.FlatAst, base int, mut flags []u8) bool {
+fn scan_top_level_kind_flags_parallel(a &flat.FlatAst, base int, mut flags []u8, prefix_param_scan bool) bool {
 	$if windows {
 		return false
 	} $else {
@@ -312,11 +379,12 @@ fn scan_top_level_kind_flags_parallel(a &flat.FlatAst, base int, mut flags []u8)
 				break
 			}
 			args << TopLevelKindScanArgs{
-				a:     a
-				start: start
-				end:   end
-				flags: flags.data
-				base:  base
+				a:                 a
+				start:             start
+				end:               end
+				flags:             flags.data
+				base:              base
+				prefix_param_scan: prefix_param_scan
 			}
 		}
 		mut tasks := []workers.Task{cap: args.len}
@@ -1434,10 +1502,10 @@ fn (mut t Transformer) promote_scoped_result_text(value string) string {
 	// strings before adding a worker-local entry; generic specialization clones
 	// otherwise retain another copy of almost every source identifier and type.
 	mut canonical := ''
-	if id := t.a.text_ids[value] {
-		canonical = t.a.text_values[int(id) - 1]
-	} else if promoted := t.scoped_promoted_texts[value] {
+	if promoted := t.scoped_promoted_texts[value] {
 		canonical = promoted
+	} else if id := t.a.text_ids[value] {
+		canonical = t.a.text_values[int(id) - 1]
 	} else {
 		canonical = value.clone()
 		t.scoped_promoted_texts[canonical] = canonical
@@ -1454,13 +1522,18 @@ fn (mut t Transformer) promote_scoped_result_text(value string) string {
 // the parent arena. Individual node payloads are promoted by absorb_scoped_batch;
 // this preserves the flat containers themselves before the scratch arena dies.
 fn (mut t Transformer) promote_scoped_ast_storage(scope voidptr) {
-	if transform_scope_owns(scope, t.a.nodes.data) {
+	owns_nodes := transform_scope_owns(scope, t.a.nodes.data)
+	owns_children := transform_scope_owns(scope, t.a.children.data)
+	if !isnil(t.tc) && t.tc.verbose {
+		eprintln('  [leakcheck] pas: nodes ${u64(t.a.nodes.data)}/${t.a.nodes.len}/${t.a.nodes.cap} owned ${owns_nodes} children ${u64(t.a.children.data)}/${t.a.children.len}/${t.a.children.cap} owned ${owns_children}')
+	}
+	if owns_nodes {
 		mut nodes := []flat.Node{cap: t.a.nodes.len + t.a.nodes.len / 4 + 1024}
 		nodes << t.a.nodes
 		t.a.nodes = nodes
 		t.a.file_node_ids = []int{}
 	}
-	if transform_scope_owns(scope, t.a.children.data) {
+	if owns_children {
 		mut children := []flat.NodeId{cap: t.a.children.len + t.a.children.len / 4 + 1024}
 		children << t.a.children
 		t.a.children = children
@@ -1497,6 +1570,7 @@ fn (mut t Transformer) absorb_scoped_batch(batch &Transformer, scope voidptr, ne
 		t.scoped_owned_base_log << idx
 	}
 	t.scoped_owned_base_log << batch.scoped_owned_base_log
+	t.inplace_child_log << batch.inplace_child_log
 	for name in batch.used_fns_log {
 		t.mark_used_fn_key(t.promote_scoped_result_text(name))
 	}
@@ -1564,6 +1638,10 @@ fn (mut t Transformer) absorb_scoped_batch(batch &Transformer, scope voidptr, ne
 // batch prevents caches from retaining pointers into the released arena.
 fn (mut t Transformer) transform_scoped_helper_batches(items []FnWorkItem, max_batches int) {
 	t.retain_current_worker_scope_all()
+	// NOTE (2026-08): a worker-persistent per-file normalize-result base shared
+	// across batches was implemented and measured an exact wash — items are
+	// sorted by fn_idx, so each file's work is contiguous within one worker and
+	// almost never spans batches; there is no cross-batch refill churn to save.
 	mut total_cost := i64(0)
 	for item in items {
 		total_cost += i64(item.cost) + 1
@@ -1952,7 +2030,9 @@ fn (mut t Transformer) run_parallel_transform_shared(items []FnWorkItem, base_no
 		t.base_write_intercept = true
 		t.defer_oor_writes = true
 		t.shared_base_nodes = base_nodes
+		t.shared_base_children = base_children
 		t.node_context_read_only = true
+		t.timing_profile('  [ttime]     ss split+part  ${f64(ttsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 		setup_scope := transform_worker_scope_begin(t.scope_parallel_workers)
 		mut args := []SharedChunkArgs{len: chunk_count}
 		args[0] = SharedChunkArgs{
@@ -1960,16 +2040,21 @@ fn (mut t Transformer) run_parallel_transform_shared(items []FnWorkItem, base_no
 			items_ptr: unsafe { voidptr(&chunks[0]) }
 			is_master: true
 		}
+		mut sfsw := time.new_stopwatch()
 		for ci in 0 .. thread_count {
 			view := shared_region_view(t.a, node_starts[ci + 1], node_starts[ci + 2], child_starts[
 				ci + 1], child_starts[ci + 2])
+			view_ms := f64(sfsw.elapsed().microseconds()) / 1000.0
 			wtc := t.tc.fork_for_parallel_transform(view)
+			tc_ms := f64(sfsw.elapsed().microseconds()) / 1000.0
 			mut ww := t.fork_worker(view, wtc)
 			ww.defer_oor_writes = false
 			args[ci + 1] = SharedChunkArgs{
 				worker:    voidptr(ww)
 				items_ptr: unsafe { voidptr(&chunks[ci + 1]) }
 			}
+			t.timing_profile('  [ttime]     ss fork ${ci} view ${view_ms:.2f} tc ${tc_ms - view_ms:.2f} wk ${f64(sfsw.elapsed().microseconds()) / 1000.0 - tc_ms:.2f} ms')
+			sfsw.restart()
 		}
 		// The master takes region 0, which is [base, node_starts[1]) — exactly
 		// where compaction wants its output, so its appends need no shifting
@@ -2032,6 +2117,43 @@ fn (mut t Transformer) run_parallel_transform_shared(items []FnWorkItem, base_no
 				}
 			}
 		}
+		// Relocate every worker region's appended ids in place first, in
+		// parallel: the shifts derive from the deterministic region content
+		// lengths, so the serial compaction below degrades to plain memmoves.
+		// Only valid when compaction will not re-clone nodes (clone_worker_nodes
+		// in merge_worker re-reads children_start values).
+		if thread_count > 0 && (t.retain_worker_results || t.stage_scope != unsafe { nil })
+			&& os.getenv('V3_NO_MERGE_RELOC').len == 0 {
+			mut running_nodes := t.a.nodes.len
+			mut running_children := t.a.children.len
+			mut reloc_args := []RegionRelocateArgs{cap: thread_count}
+			for ci in 0 .. thread_count {
+				ww := unsafe { &Transformer(args[ci + 1].worker) }
+				ns := node_starts[ci + 1]
+				cs := child_starts[ci + 1]
+				reloc_args << RegionRelocateArgs{
+					worker:      args[ci + 1].worker
+					node_start:  ns
+					node_end:    ww.a.nodes.len
+					child_start: cs
+					child_end:   ww.a.children.len
+					node_shift:  i32(running_nodes - ns)
+					child_shift: i32(running_children - cs)
+				}
+				running_nodes += ww.a.nodes.len - ns
+				running_children += ww.a.children.len - cs
+			}
+			mut reloc_tasks := []workers.Task{cap: thread_count}
+			for i in 0 .. reloc_args.len {
+				reloc_tasks << workers.Task{
+					run:        region_relocate_thread
+					arg:        unsafe { voidptr(&reloc_args[i]) }
+					force_sync: i == 0
+				}
+			}
+			t.a.worker_pool.run(reloc_tasks)
+			t.merge_regions_relocated = true
+		}
 		// Compact each worker region in fixed order (deterministic
 		// node numbering). merge_worker treats the region start exactly like a
 		// clone's base offset; compaction always moves content left, so the
@@ -2041,6 +2163,9 @@ fn (mut t Transformer) run_parallel_transform_shared(items []FnWorkItem, base_no
 		mut mwsw := time.new_stopwatch()
 		for ci in 0 .. thread_count {
 			ww := unsafe { &Transformer(args[ci + 1].worker) }
+			t.timing_profile('  [ttime]     mg region ${ci}: nodes [${node_starts[ci + 1]}, ${ww.a.nodes.len}) cap ${node_starts[
+				ci + 2]} children [${child_starts[ci + 1]}, ${ww.a.children.len}) cap ${child_starts[
+				ci + 2]} dst n ${t.a.nodes.len} c ${t.a.children.len}')
 			mwsw.restart()
 			t.merge_worker_used_fns(ww)
 			merge_used_ms += f64(mwsw.elapsed().microseconds()) / 1000.0
@@ -2072,6 +2197,7 @@ fn (mut t Transformer) run_parallel_transform_shared(items []FnWorkItem, base_no
 				}
 			}
 		}
+		t.merge_regions_relocated = false
 		t.timing_profile('  [ttime]   shared merge     ${f64(ttsw.elapsed().microseconds()) / 1000.0:7.2f} ms (used: ${merge_used_ms:.2f}, core: ${merge_core_ms:.2f})')
 		ttsw.restart()
 		if t.retain_worker_results {
@@ -2081,6 +2207,7 @@ fn (mut t Transformer) run_parallel_transform_shared(items []FnWorkItem, base_no
 		t.base_write_intercept = false
 		t.defer_oor_writes = false
 		t.shared_base_nodes = -1
+		t.shared_base_children = -1
 		t.flush_deferred_base_writes()
 		if t.ignored_comptime_for_log.len > 0 {
 			if t.ignored_comptime_for_nodes.len < t.a.nodes.len {
@@ -2254,4 +2381,76 @@ fn transform_job_count(n_runtime_jobs int, n_items int) int {
 		n = n_items
 	}
 	return n
+}
+
+// prepare_with_pre_scans runs prepare() while the const-array fixed-storage
+// classification (a full post-markused AST pass) proceeds on a helper thread.
+// The scan publishes into the master cache before this function returns, so
+// transform_all_dispatch's precompute call becomes a no-op.
+fn (mut t Transformer) prepare_with_pre_scans() {
+	$if windows {
+		t.prepare()
+		return
+	} $else {
+		if !t.parallel_enabled || !t.skip_generics || !t.scope_parallel_workers || isnil(t.tc) {
+			t.prepare()
+			return
+		}
+		// The scan worker shares only immutable state: the AST (stable while the
+		// master builds its indexes; any reserve/grow runs after this returns)
+		// and the checker's post-check const/import tables. Its suffix map and
+		// result cache are private and cloned out below.
+		mut w := &Transformer{
+			a:                               t.a
+			tc:                              t.tc
+			skip_generics:                   t.skip_generics
+			building_v:                      t.building_v
+			scope_parallel_workers:          t.scope_parallel_workers
+			const_suffixes:                  map[string]string{}
+			const_array_fixed_storage_cache: map[string]i8{}
+		}
+		scan_thread := spawn transform_const_fixed_scan_thread(voidptr(w))
+		// The index builders below only read the AST and post-check tc tables
+		// and write master fields prepare() never touches while they run; their
+		// results are allocated in the helper's permanent thread arena. The
+		// alias-suffix indexes must stay on the master: collect_types consults
+		// them in declaration order.
+		if os.getenv('V3_NO_PAR_TRANSFORM_PARAM_PREP') == '' {
+			param_tc := t.tc.fork_for_parallel_transform(t.a)
+			mut param_w := &Transformer{
+				a:                            t.a
+				tc:                           param_tc
+				prefix_param_scan:            t.prefix_param_scan
+				call_param_types_decl_cache:  map[int][]types.Type{}
+				call_param_types_decl_misses: map[string]bool{}
+				call_param_types_decl_index:  map[string]FnParamDeclRef{}
+			}
+			param_thread := spawn transform_param_prep_thread(voidptr(param_w))
+			t.defer_pre_scan_indexes = true
+			index_thread := spawn transform_pre_scan_index_thread(voidptr(t))
+			t.prepare()
+			_ = param_thread.wait()
+			_ = index_thread.wait()
+			t.call_param_types_decl_cache = param_w.call_param_types_decl_cache.move()
+			t.call_param_types_decl_misses = param_w.call_param_types_decl_misses.move()
+			t.call_param_types_decl_index = param_w.call_param_types_decl_index.move()
+			t.call_param_types_index_ready = param_w.call_param_types_index_ready
+			t.call_param_types_prepared = param_w.call_param_types_prepared
+		} else {
+			t.defer_pre_scan_indexes = true
+			index_thread := spawn transform_pre_scan_index_thread(voidptr(t))
+			t.prepare()
+			_ = index_thread.wait()
+		}
+		_ = scan_thread.wait()
+		t.defer_pre_scan_indexes = false
+		for key, val in w.const_array_fixed_storage_cache {
+			t.const_array_fixed_storage_cache[key.clone()] = val
+		}
+		t.const_array_fixed_storage_ready = true
+		if w.worker_scope != unsafe { nil } {
+			transform_worker_scope_free(w.worker_scope)
+			w.worker_scope = unsafe { nil }
+		}
+	}
 }

--- a/vlib/v3/transform/type_propagation.v
+++ b/vlib/v3/transform/type_propagation.v
@@ -3,6 +3,65 @@ module transform
 import v3.flat
 import v3.types
 
+@[heap]
+struct NodeTypeMemo {
+mut:
+	active bool
+	lo     int
+	hi     int
+	values []string
+	filled []u8
+}
+
+fn (mut t Transformer) begin_node_type_memo(lo int, hi int) {
+	if lo < 0 || hi < lo {
+		t.end_node_type_memo()
+		return
+	}
+	if isnil(t.node_type_memo) {
+		t.node_type_memo = &NodeTypeMemo{}
+	}
+	mut memo := t.node_type_memo
+	n := hi - lo + 1
+	if n > memo.values.cap {
+		memo.values = []string{len: n}
+		memo.filled = []u8{len: n}
+	} else {
+		if n <= memo.values.len {
+			memo.values = memo.values[..n]
+			memo.filled = memo.filled[..n]
+		} else {
+			unsafe {
+				memo.values.grow_len(n)
+				memo.filled.grow_len(n)
+			}
+		}
+		if n > 0 {
+			unsafe { vmemset(&memo.filled[0], 0, n) }
+		}
+	}
+	memo.lo = lo
+	memo.hi = hi
+	memo.active = true
+}
+
+fn (mut t Transformer) end_node_type_memo() {
+	if !isnil(t.node_type_memo) {
+		t.node_type_memo.active = false
+	}
+}
+
+@[inline]
+fn (t &Transformer) invalidate_node_type_memo(idx int) {
+	if isnil(t.node_type_memo) {
+		return
+	}
+	mut memo := t.node_type_memo
+	if memo.active && idx >= memo.lo && idx <= memo.hi {
+		memo.filled[idx - memo.lo] = 0
+	}
+}
+
 // propagate_decl_type infers the declared variable type from a .decl_assign node
 // and registers it in var_types so downstream transforms can resolve it.
 fn (mut t Transformer) propagate_decl_type(node flat.Node) {
@@ -132,12 +191,12 @@ fn (t &Transformer) checker_expr_type_name(id flat.NodeId) ?string {
 		return none
 	}
 	typ := t.tc.expr_type(id) or { t.tc.resolve_type(id) }
-	mut name := typ.name()
+	mut name := t.tc.type_name(typ)
 	if name in t.tc.type_aliases {
 		name = t.normalize_type_alias(name)
 	}
 	if types.type_text_contains_typeof(name) {
-		name = t.tc.resolve_type(id).name()
+		name = t.tc.type_name(t.tc.resolve_type(id))
 		if name in t.tc.type_aliases {
 			name = t.normalize_type_alias(name)
 		}
@@ -298,10 +357,14 @@ fn (t &Transformer) fn_literal_type_text(node flat.Node) string {
 	mut params := []string{}
 	for i in 0 .. node.children_count {
 		child := t.a.child_node(&node, i)
-		if child.kind == .param {
-			raw := if child.typ.len > 0 { child.typ } else { child.value }
-			params << fn_literal_param_type_text(raw)
+		if child.kind != .param {
+			if t.prefix_param_scan {
+				break
+			}
+			continue
 		}
+		raw := if child.typ.len > 0 { child.typ } else { child.value }
+		params << fn_literal_param_type_text(raw)
 	}
 	ret := node.typ.trim_space()
 	if ret.len == 0 || ret == 'void' {
@@ -358,7 +421,7 @@ fn (t &Transformer) concrete_node_type_name(node flat.Node) string {
 }
 
 fn type_text_has_unresolved_generic_placeholder(typ string) bool {
-	clean := typ.trim_space()
+	clean := trimmed_transform_text(typ)
 	if clean.len == 0 {
 		return false
 	}
@@ -1006,13 +1069,17 @@ fn (t &Transformer) normalize_type_alias(typ string) string {
 		return t.normalize_type_alias_uncached(typ)
 	}
 	mut c := t.alias_cache
+	recent_slot := alias_cache_slot(typ)
+	if c.canonical_types[recent_slot].len == typ.len
+		&& unsafe { c.canonical_types[recent_slot].str == typ.str } {
+		return c.canonical_results[recent_slot]
+	}
 	if c.module != t.cur_module || c.file != t.cur_file {
 		c.module = t.cur_module
 		c.file = t.cur_file
 		c.entries.clear()
 		c.clear_recent()
 	}
-	recent_slot := alias_cache_slot(typ)
 	if c.recent_generations[recent_slot] == c.recent_generation
 		&& unsafe { c.recent_types[recent_slot].str == typ.str }
 		&& c.recent_types[recent_slot].len == typ.len {
@@ -1022,10 +1089,52 @@ fn (t &Transformer) normalize_type_alias(typ string) string {
 		c.put_recent(typ, cached)
 		return cached
 	}
+	if fast := t.normalize_dotted_canonical_fast(typ) {
+		c.entries[typ] = fast
+		c.put_recent(typ, fast)
+		c.canonical_types[recent_slot] = typ
+		c.canonical_results[recent_slot] = fast
+		return fast
+	}
 	result := t.normalize_type_alias_uncached(typ)
 	c.entries[typ] = result
 	c.put_recent(typ, result)
 	return result
+}
+
+// normalize_dotted_canonical_fast answers the most common per-file cache miss
+// without the full uncached walk: a plain `module.Type` spelling that is not an
+// alias key and is declared in the authority tables is already canonical (the
+// uncached walk's qualified-name branch returns it before consulting imports,
+// so the answer is file-independent). Any other shape falls through.
+@[direct_array_access; inline]
+fn (t &Transformer) normalize_dotted_canonical_fast(typ string) ?string {
+	mut has_dot := false
+	for i in 0 .. typ.len {
+		c := typ[i]
+		if c == `.` {
+			has_dot = true
+			continue
+		}
+		if (c >= `a` && c <= `z`) || (c >= `A` && c <= `Z`) || (c >= `0` && c <= `9`) || c == `_` {
+			continue
+		}
+		return none
+	}
+	if !has_dot {
+		return none
+	}
+	first := typ[0]
+	if !((first >= `a` && first <= `z`) || (first >= `A` && first <= `Z`) || first == `_`) {
+		return none
+	}
+	if typ in t.tc.type_aliases {
+		return none
+	}
+	if t.type_authority_has(typ) {
+		return typ
+	}
+	return none
 }
 
 // normalize_type_alias_uncached converts normalize type alias uncached data for transform.
@@ -1318,7 +1427,7 @@ fn (t &Transformer) normalize_type_in_module(typ string, mod string) string {
 }
 
 fn (t &Transformer) normalize_type_in_module_uncached(typ string, mod string) string {
-	clean := typ.trim_space()
+	clean := trimmed_transform_text(typ)
 	if clean.len == 0 {
 		return clean
 	}
@@ -1368,7 +1477,7 @@ fn (t &Transformer) normalize_type_in_module_uncached(typ string, mod string) st
 		params, ret := fn_type_text_parts(clean) or { return clean }
 		mut normalized_params := []string{cap: params.len}
 		for param in params {
-			raw_param := param.trim_space()
+			raw_param := trimmed_transform_text(param)
 			payload := generic_fn_type_param_payload(raw_param)
 			param_type := if raw_param.starts_with('mut ') { 'mut ${payload}' } else { payload }
 			normalized_params << t.normalize_type_in_module(param_type, mod)
@@ -1515,6 +1624,25 @@ fn (t &Transformer) index_expr_type(id flat.NodeId, node flat.Node) string {
 // here rather than in the backend.
 @[direct_array_access]
 fn (t &Transformer) node_type(id flat.NodeId) string {
+	idx := int(id)
+	if !isnil(t.node_type_memo) {
+		mut memo := t.node_type_memo
+		if memo.active && idx >= memo.lo && idx <= memo.hi {
+			slot := idx - memo.lo
+			if memo.filled[slot] != 0 {
+				return memo.values[slot]
+			}
+			result := t.node_type_uncached(id)
+			memo.values[slot] = result
+			memo.filled[slot] = 1
+			return result
+		}
+	}
+	return t.node_type_uncached(id)
+}
+
+@[direct_array_access]
+fn (t &Transformer) node_type_uncached(id flat.NodeId) string {
 	if int(id) < 0 {
 		return ''
 	}
@@ -1541,7 +1669,7 @@ fn (t &Transformer) node_type(id flat.NodeId) string {
 		}
 		if types.type_text_contains_typeof(resolved) && !isnil(t.tc) {
 			if typ := t.tc.expr_type(id) {
-				name := t.normalize_type_alias(typ.name())
+				name := t.normalize_type_alias(t.tc.type_name(typ))
 				if decl_type_is_usable(name) {
 					return name
 				}
@@ -1563,7 +1691,7 @@ fn (t &Transformer) node_type(id flat.NodeId) string {
 			return checker_type
 		}
 		if !isnil(t.tc) {
-			checker_resolved := t.tc.resolve_type(id).name()
+			checker_resolved := t.tc.type_name(t.tc.resolve_type(id))
 			if decl_type_is_usable(checker_resolved) && checker_resolved != 'void' {
 				return t.normalize_type_alias(checker_resolved)
 			}

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -362,13 +362,50 @@ mut:
 	parse_key_recent_context [512]u64
 	parse_key_recent_values  [512]u64
 	parse_key_recent_set     [512]bool
+	// Canonical AST type texts repeat by pointer within one checker view. Cache
+	// their parsed values directly so the common hit avoids the generic map
+	// lookup after the existing context check.
+	parse_value_recent_ptrs    [2048]usize
+	parse_value_recent_lens    [2048]int
+	parse_value_recent_context [2048]u64
+	parse_value_recent_values  [2048]Type
+	parse_value_recent_set     [2048]bool
+	// Exact canonical text-id cache used by post-transform consumers. A lazy
+	// 65536-slot table avoids collisions for every compact FlatAst text id.
+	parse_text_id_context []u64
+	parse_text_id_values  []Type
+	parse_text_id_set     []bool
 	// Alias targets can contain callbacks whose signatures mention the alias
 	// itself (for example `type Handlers = map[string]fn (Handlers)`). Keep the
 	// active expansion chain private to each checker/cache so parsing such a
 	// recursive alias terminates without introducing shared parallel state.
-	alias_parse_stack           []string
-	c_entries                   map[TypeId]string
-	c_name_entries              map[string]string
+	alias_parse_stack []string
+	c_entries         map[TypeId]string
+	c_name_entries    map[string]string
+	// Lock-free recent slots for c_type, with the same Type-value/lifetime
+	// invariant as name_recent below.
+	c_recent_w0   [2048]u64
+	c_recent_w1   [2048]u64
+	c_recent_vals [2048]string
+	c_recent_set  [2048]bool
+	// Lock-free recent slots for type_name: keyed by the Type value's raw words
+	// (tag + payload pointer — identical bytes imply the same type), they avoid
+	// the interner's lock round-trips for repeated spellings of shared type
+	// values. Slots never outlive the cache, and every cache dies with (or
+	// before) the arena owning the payloads it saw, so a recycled payload
+	// address can never produce a stale hit.
+	name_recent_w0   [2048]u64
+	name_recent_w1   [2048]u64
+	name_recent_vals [2048]string
+	name_recent_set  [2048]bool
+	// Per-checker symbol probes front the compilation-wide interner. Resolved
+	// names are usually repeated as the same canonical string pointer inside a
+	// worker, so these slots avoid taking the interner mutex on every call.
+	symbol_recent_ptrs          [2048]usize
+	symbol_recent_lens          [2048]int
+	symbol_recent_ids           [2048]SymbolId
+	symbol_recent_vals          [2048]string
+	symbol_recent_set           [2048]bool
 	struct_field_entries        map[string]Type
 	struct_field_misses         map[string]bool
 	struct_field_last_struct    usize
@@ -435,6 +472,10 @@ pub struct TransformForkOverlay {
 pub mut:
 	resolved_call_names map[int]string
 	resolved_fn_values  map[int]string
+	// Transform forks write overlay entries only for nodes appended after the
+	// fork. IDs below this boundary are guaranteed to live in the shared dense
+	// checker arrays, so reads can avoid probing two sparse maps per expression.
+	base_node_count int
 }
 
 // PendingIerrorError is an invalid-ierror-return candidate recorded while the
@@ -596,36 +637,52 @@ mut:
 @[heap]
 pub struct TypeChecker {
 pub mut:
-	a                            &flat.FlatAst = unsafe { nil }
-	compiler_vroot               string
-	verbose                      bool
-	enable_globals               bool
-	fn_ret_types                 map[string]Type
-	fn_param_types               map[string][]Type
-	v_fn_semantic_names          map[string]bool
-	c_fn_module_ret_types        map[string]Type
-	c_fn_module_param_types      map[string][]Type
-	c_fn_module_variadic         map[string]bool
-	fn_shared_params             map[string][]bool
-	mut_receiver_methods         map[string]bool
-	source_no_body_fns           map[string]bool
-	source_no_body_fn_suffixes   map[string]bool
-	unsafe_fns                   map[string]bool
-	unsafe_c_fns                 map[string]bool
-	fn_ret_type_texts            map[string]string   // generic struct method key -> original return type text (e.g. `Box[T].clone` -> `Box[T]`)
-	fn_param_type_texts          map[string][]string // generic struct method key -> original param type texts (receiver first)
-	fn_type_files                map[string]string
-	fn_type_modules              map[string]string
-	fn_generic_params            map[string][]string
-	specialized_generic_fns      map[string]bool
-	fn_variadic                  map[string]bool
-	c_variadic_fns               map[string]bool
-	fn_implicit_veb_ctx          map[string]bool
-	receiver_method_suffix_index map[string]string
-	structs                      map[string][]StructField
-	struct_modules               map[string]string
-	struct_files                 map[string]string
-	soa_structs                  map[string]bool
+	a                              &flat.FlatAst = unsafe { nil }
+	compiler_vroot                 string
+	verbose                        bool
+	raw_type_equality              bool
+	fast_parse_recent              bool
+	fast_type_text_refs            bool
+	fast_c_type_recent             bool
+	memo_call_info                 bool
+	method_suffix_prescreen        bool
+	prefix_param_scan              bool
+	building_v_fast                bool
+	valid_diagnostic_fast          bool
+	valid_resolution_fast          bool
+	defer_fn_ancillary             bool
+	fn_ancillary_registrations     []FnAncillaryRegistration
+	fn_c_variadic_registrations    []FnNamePairRegistration
+	fn_mut_receiver_registrations  []FnNamePairRegistration
+	fn_ret_text_registrations      []FnTextRegistration
+	visible_mutation_registrations []VisibleMutationRegistration
+	enable_globals                 bool
+	fn_ret_types                   map[string]Type
+	fn_param_types                 map[string][]Type
+	v_fn_semantic_names            map[string]bool
+	c_fn_module_ret_types          map[string]Type
+	c_fn_module_param_types        map[string][]Type
+	c_fn_module_variadic           map[string]bool
+	fn_shared_params               map[string][]bool
+	mut_receiver_methods           map[string]bool
+	source_no_body_fns             map[string]bool
+	source_no_body_fn_suffixes     map[string]bool
+	unsafe_fns                     map[string]bool
+	unsafe_c_fns                   map[string]bool
+	fn_ret_type_texts              map[string]string   // generic struct method key -> original return type text (e.g. `Box[T].clone` -> `Box[T]`)
+	fn_param_type_texts            map[string][]string // generic struct method key -> original param type texts (receiver first)
+	fn_type_files                  map[string]string
+	fn_type_modules                map[string]string
+	fn_generic_params              map[string][]string
+	specialized_generic_fns        map[string]bool
+	fn_variadic                    map[string]bool
+	c_variadic_fns                 map[string]bool
+	fn_implicit_veb_ctx            map[string]bool
+	receiver_method_suffix_index   map[string]string
+	structs                        map[string][]StructField
+	struct_modules                 map[string]string
+	struct_files                   map[string]string
+	soa_structs                    map[string]bool
 	// set of `${file}\x01${module}\x01${name}` keys for every source-level
 	// struct/type/interface/enum declaration, built once in `collect`. Replaces
 	// the former full-node scan in `source_declares_type_in_scope`, which was
@@ -811,6 +868,11 @@ pub mut:
 	// and codegen read synthesized generic-specialization type text. Source annotations
 	// must keep normal module scoping and never enable this fallback.
 	resolution_type_mode bool
+	// trust_checked_expr_types serves resolve_type straight from the checker's
+	// dense per-node type cache. Armed by the driver only after checking
+	// completes; transform's node-write helpers invalidate rewritten ids, and
+	// nodes appended after checking fall outside the cache and resolve normally.
+	trust_checked_expr_types bool
 	// fork_overlay is non-nil only on parallel-transform worker forks; see
 	// TransformForkOverlay and fork_for_parallel_transform.
 	fork_overlay &TransformForkOverlay = unsafe { nil }
@@ -884,6 +946,13 @@ pub fn TypeChecker.new(a &flat.FlatAst) TypeChecker {
 	symbols := new_symbol_interner()
 	return TypeChecker{
 		a:                                     a
+		raw_type_equality:                     os.getenv('V3_NO_RAW_TYPE_EQUALITY') == ''
+		fast_parse_recent:                     os.getenv('V3_NO_FAST_PARSE_RECENT') == ''
+		fast_type_text_refs:                   os.getenv('V3_NO_TYPE_TEXT_REFS') == ''
+		fast_c_type_recent:                    os.getenv('V3_NO_FAST_C_TYPE_RECENT') == ''
+		memo_call_info:                        os.getenv('V3_NO_CALL_INFO_MEMO') == ''
+		method_suffix_prescreen:               os.getenv('V3_NO_METHOD_SUFFIX_PRESCREEN') == ''
+		prefix_param_scan:                     os.getenv('V3_NO_PREFIX_PARAM_SCAN') == ''
 		fn_ret_types:                          map[string]Type{}
 		fn_param_types:                        map[string][]Type{}
 		c_fn_module_ret_types:                 map[string]Type{}
@@ -1032,6 +1101,16 @@ fn (tc &TypeChecker) fork_program_view(ast &flat.FlatAst, direct_dependencies_by
 	return TypeChecker{
 		a:                                  ast
 		compiler_vroot:                     tc.compiler_vroot
+		raw_type_equality:                  tc.raw_type_equality
+		fast_parse_recent:                  tc.fast_parse_recent
+		fast_type_text_refs:                tc.fast_type_text_refs
+		fast_c_type_recent:                 tc.fast_c_type_recent
+		memo_call_info:                     tc.memo_call_info
+		method_suffix_prescreen:            tc.method_suffix_prescreen
+		prefix_param_scan:                  tc.prefix_param_scan
+		building_v_fast:                    tc.building_v_fast
+		valid_diagnostic_fast:              tc.valid_diagnostic_fast
+		valid_resolution_fast:              tc.valid_resolution_fast
 		enable_globals:                     tc.enable_globals
 		fn_ret_types:                       tc.fn_ret_types
 		fn_param_types:                     tc.fn_param_types
@@ -1112,6 +1191,7 @@ fn (tc &TypeChecker) fork_program_view(ast &flat.FlatAst, direct_dependencies_by
 		cur_module:                         tc.cur_module
 		cur_file:                           tc.cur_file
 		resolution_type_mode:               tc.resolution_type_mode
+		trust_checked_expr_types:           tc.trust_checked_expr_types
 		errors:                             []TypeError{}
 		notices:                            []TypeError{}
 		resolved_call_names:                tc.resolved_call_names
@@ -1223,6 +1303,10 @@ fn (tc &TypeChecker) fork_type_parse_view(file string, module_name string) TypeC
 	view.cur_file = file
 	view.cur_module = module_name
 	view.type_cache = tc.type_cache
+	// Signature parsing immediately creates an unscoped resolution view. Reuse
+	// this worker's synchronous per-file view cache instead of allocating two
+	// full TypeChecker views for every substituted parameter and return type.
+	view.resolution_type_views = tc.resolution_type_views
 	return view
 }
 
@@ -1271,7 +1355,9 @@ pub fn (tc &TypeChecker) fork_for_parallel_transform(ast &flat.FlatAst) &TypeChe
 	// while other threads read them, so each fork gets a private sparse overlay:
 	// writes go only to the overlay, reads check it before the shared arrays,
 	// and merge_worker replays the entries into the master under shifted ids.
-	forked.fork_overlay = &TransformForkOverlay{}
+	forked.fork_overlay = &TransformForkOverlay{
+		base_node_count: if os.getenv('V3_NO_OVERLAY_RANGE') == '' { ast.nodes.len } else { -1 }
+	}
 	// Transform helpers allocate inside disposable arenas. A shared interner
 	// would let one helper publish map/array storage owned by its arena and leave
 	// other helpers with dangling storage when that arena is released. Each
@@ -1482,7 +1568,7 @@ fn (mut tc TypeChecker) reset_node_caches(n int) {
 	tc.parallel_check_sparse = false
 }
 
-fn (mut tc TypeChecker) build_direct_parent_index(a &flat.FlatAst) {
+fn (mut tc TypeChecker) init_direct_parent_index(a &flat.FlatAst) {
 	tc.direct_parent_ids = []flat.NodeId{len: a.nodes.len, init: flat.empty_node}
 	tc.value_used_nodes = []bool{len: a.nodes.len}
 	tc.declaration_attributes = map[int][]string{}
@@ -1491,16 +1577,36 @@ fn (mut tc TypeChecker) build_direct_parent_index(a &flat.FlatAst) {
 	tc.has_globals_files = map[string]bool{}
 	tc.strings_builder_candidates = []int{cap: 1024}
 	tc.has_goto_nodes = false
+}
+
+fn (mut tc TypeChecker) fill_direct_parent_edges(a &flat.FlatAst) {
 	for parent_idx, node in a.nodes {
 		if node.kind == .goto_stmt {
 			tc.has_goto_nodes = true
-		} else if node.kind == .decl_assign && node.children_count >= 2 {
+		}
+		for child_idx in 0 .. node.children_count {
+			child := a.child(&node, child_idx)
+			idx := int(child)
+			if idx >= 0 && idx < tc.value_used_nodes.len
+				&& node.kind !in [.expr_stmt, .block, .match_branch, .fn_decl, .comptime_for] {
+				tc.value_used_nodes[idx] = true
+			}
+			if idx >= 0 && idx < tc.direct_parent_ids.len
+				&& tc.direct_parent_ids[idx] == flat.empty_node {
+				tc.direct_parent_ids[idx] = flat.NodeId(parent_idx)
+			}
+		}
+	}
+}
+
+fn (mut tc TypeChecker) collect_direct_parent_metadata(a &flat.FlatAst) {
+	for parent_idx, node in a.nodes {
+		if node.kind == .decl_assign && node.children_count >= 2 {
 			lhs := a.child_node(&node, 0)
 			if lhs.kind == .ident && tc.expr_is_strings_new_builder_call(a.child(&node, 1)) {
 				tc.strings_builder_candidates << parent_idx
 			}
-		}
-		if node.kind == .directive {
+		} else if node.kind == .directive {
 			if node.value.starts_with('@attributes:') {
 				decl_id := node.value['@attributes:'.len..].int()
 				if decl_id >= 0 && decl_id < a.nodes.len {
@@ -1523,19 +1629,13 @@ fn (mut tc TypeChecker) build_direct_parent_index(a &flat.FlatAst) {
 				}
 			}
 		}
-		for child_idx in 0 .. node.children_count {
-			child := a.child(&node, child_idx)
-			idx := int(child)
-			if idx >= 0 && idx < tc.value_used_nodes.len
-				&& node.kind !in [.expr_stmt, .block, .match_branch, .fn_decl, .comptime_for] {
-				tc.value_used_nodes[idx] = true
-			}
-			if idx >= 0 && idx < tc.direct_parent_ids.len
-				&& tc.direct_parent_ids[idx] == flat.empty_node {
-				tc.direct_parent_ids[idx] = flat.NodeId(parent_idx)
-			}
-		}
 	}
+}
+
+fn (mut tc TypeChecker) build_direct_parent_index(a &flat.FlatAst) {
+	tc.init_direct_parent_index(a)
+	tc.fill_direct_parent_edges(a)
+	tc.collect_direct_parent_metadata(a)
 	tc.direct_parent_index_trusted = true
 }
 
@@ -1620,9 +1720,13 @@ fn (mut tc TypeChecker) build_fn_declaration_indexes(a &flat.FlatAst) {
 				mut param_mutability := [field.is_mut]
 				for param_index in 0 .. field.children_count {
 					param := a.child_node(field, param_index)
-					if param.kind == .param {
-						param_mutability << param.is_mut
+					if param.kind != .param {
+						if tc.prefix_param_scan {
+							break
+						}
+						continue
 					}
+					param_mutability << param.is_mut
 				}
 				tc.declaration_param_mutability['${iface_name}.${field.value}'] = param_mutability
 			}
@@ -1632,9 +1736,13 @@ fn (mut tc TypeChecker) build_fn_declaration_indexes(a &flat.FlatAst) {
 			mut param_mutability := []bool{}
 			for child_index in 0 .. node.children_count {
 				param := a.child_node(&node, child_index)
-				if param.kind == .param {
-					param_mutability << param.is_mut
+				if param.kind != .param {
+					if tc.prefix_param_scan {
+						break
+					}
+					continue
 				}
+				param_mutability << param.is_mut
 			}
 			c_name := if node.value.starts_with('C.') { node.value } else { 'C.${node.value}' }
 			if c_name !in tc.declaration_param_mutability {
@@ -1653,9 +1761,13 @@ fn (mut tc TypeChecker) build_fn_declaration_indexes(a &flat.FlatAst) {
 		mut param_mutability := []bool{}
 		for child_index in 0 .. node.children_count {
 			param := a.child_node(&node, child_index)
-			if param.kind == .param {
-				param_mutability << param.is_mut
+			if param.kind != .param {
+				if tc.prefix_param_scan {
+					break
+				}
+				continue
 			}
+			param_mutability << param.is_mut
 		}
 		if node.value !in tc.declaration_param_mutability {
 			tc.declaration_param_mutability[node.value] = param_mutability
@@ -1965,7 +2077,8 @@ pub fn (mut tc TypeChecker) pop_scope() {
 		tc.ownership_run_scope_defers()
 		tc.ownership_pop_scope()
 	}
-	if tc.scope_pool_index > 0 && tc.cur_scope == tc.scope_pool[tc.scope_pool_index - 1] {
+	if tc.scope_pool_index > 0
+		&& voidptr(tc.cur_scope) == voidptr(tc.scope_pool[tc.scope_pool_index - 1]) {
 		tc.scope_pool_index--
 	}
 	tc.cur_scope = parent
@@ -2478,6 +2591,7 @@ fn (mut tc TypeChecker) collect_index_child(a &flat.FlatAst, i int, idx_file str
 
 pub fn (mut tc TypeChecker) collect(a &flat.FlatAst) {
 	mut ck_c_sw := time.new_stopwatch()
+	mut ck_part_sw := time.new_stopwatch()
 	tc.a = a
 	tc.visible_mutation_cache = new_visible_mutation_cache()
 	tc.unsafe_c_fns.clear()
@@ -2487,8 +2601,22 @@ pub fn (mut tc TypeChecker) collect(a &flat.FlatAst) {
 	tc.file_scope = new_scope(unsafe { nil })
 	tc.cur_scope = tc.file_scope
 	tc.scope_pool_index = 0
-	tc.reset_node_caches(a.nodes.len)
-	tc.build_direct_parent_index(a)
+	parallel_index_prep := tc.prepare_collect_index_parallel(a)
+	if !parallel_index_prep {
+		tc.reset_node_caches(a.nodes.len)
+		if tc.verbose {
+			tc.timing_profile('  [ttime]       ck idx reset ${f64(ck_part_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+			ck_part_sw.restart()
+		}
+		tc.build_direct_parent_index(a)
+		if tc.verbose {
+			tc.timing_profile('  [ttime]       ck idx parent ${f64(ck_part_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+			ck_part_sw.restart()
+		}
+	} else if tc.verbose {
+		tc.timing_profile('  [ttime]       ck idx parallel ${f64(ck_part_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+		ck_part_sw.restart()
+	}
 	$if ownership ? {
 		tc.ownership_reset()
 	}
@@ -2511,9 +2639,15 @@ pub fn (mut tc TypeChecker) collect(a &flat.FlatAst) {
 	tc.declared_type_scope_keys = map[string]bool{}
 	tc.concrete_type_scope_keys = map[string]bool{}
 	tc.top_level_idx = []int{cap: 65536}
-	tc.prepare_threads_condition()
+	if !parallel_index_prep {
+		tc.prepare_threads_condition()
+	}
 	inactive_comptime_nodes := tc.inactive_top_level_comptime_nodes()
 	tc.inactive_top_level_node_ids.clear()
+	if tc.verbose {
+		tc.timing_profile('  [ttime]       ck idx prep  ${f64(ck_part_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+		ck_part_sw.restart()
+	}
 	if file_index_usable(a) {
 		tc.collect_top_level_idx_fast(a, inactive_comptime_nodes)
 		tc.top_level_idx_nodes_len = a.nodes.len
@@ -2574,6 +2708,44 @@ pub fn (mut tc TypeChecker) collect(a &flat.FlatAst) {
 		}
 	}
 	tc.top_level_idx_nodes_len = a.nodes.len
+	// The collection passes below fill the signature/type tables from empty;
+	// with ~10k declarations each hot map otherwise pays a dozen doubling
+	// rehashes. Reserve once from the now-known top-level count (short-name and
+	// qualified spellings both register, hence the 2x factor).
+	decl_estimate := u32(tc.top_level_idx.len)
+	if decl_estimate > 512 {
+		tc.fn_ret_types.reserve(u32(tc.fn_ret_types.len) + decl_estimate * 2)
+		tc.fn_param_types.reserve(u32(tc.fn_param_types.len) + decl_estimate * 2)
+		tc.fn_variadic.reserve(u32(tc.fn_variadic.len) + decl_estimate * 2)
+		tc.fn_ret_type_texts.reserve(u32(tc.fn_ret_type_texts.len) + decl_estimate * 2)
+		tc.v_fn_semantic_names.reserve(u32(tc.v_fn_semantic_names.len) + decl_estimate * 2)
+		tc.structs.reserve(u32(tc.structs.len) + decl_estimate)
+		tc.struct_modules.reserve(u32(tc.struct_modules.len) + decl_estimate)
+		tc.struct_files.reserve(u32(tc.struct_files.len) + decl_estimate)
+		tc.const_types.reserve(u32(tc.const_types.len) + decl_estimate)
+		tc.const_exprs.reserve(u32(tc.const_exprs.len) + decl_estimate)
+		tc.fn_type_files.reserve(u32(tc.fn_type_files.len) + decl_estimate)
+		tc.fn_type_modules.reserve(u32(tc.fn_type_modules.len) + decl_estimate)
+		if os.getenv('V3_NO_WIDE_COLLECT_RESERVES') == '' {
+			// Pass 1 records one visibility entry per declaration, while pass 2
+			// derives several method-suffix and visible-mutation keys per function.
+			// These maps are populated from separate pool lanes, so reserving here
+			// avoids their otherwise serial rehash ladders without sharing writes.
+			tc.declaration_visibility.reserve(u32(tc.declaration_visibility.len) + decl_estimate * 2)
+			tc.receiver_method_suffix_index.reserve(u32(tc.receiver_method_suffix_index.len) +
+				decl_estimate * 3)
+			if !isnil(tc.visible_mutation_cache) {
+				mut mutation_cache := tc.visible_mutation_cache
+				mutation_cache.decls.reserve(u32(mutation_cache.decls.len) + decl_estimate * 8)
+			}
+			if os.getenv('V3_NO_EXTENDED_COLLECT_RESERVES') == '' {
+				tc.fn_type_files.reserve(u32(tc.fn_type_files.len) + decl_estimate * 3)
+				tc.fn_type_modules.reserve(u32(tc.fn_type_modules.len) + decl_estimate * 3)
+				tc.type_cache.c_name_entries.reserve(u32(tc.type_cache.c_name_entries.len) +
+					decl_estimate * 3)
+			}
+		}
+	}
 	tc.timing_profile('  [ttime]     ck c idx       ${f64(ck_c_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 	tc.collect_after_index(a)
 }
@@ -2757,7 +2929,9 @@ fn (mut tc TypeChecker) collect_after_index(a &flat.FlatAst) {
 	tc.build_enclosing_generic_param_index(a)
 	tc.build_type_declaration_index(a)
 	tc.build_fn_declaration_indexes(a)
-	tc.index_multiple_module_import_lines(a)
+	if !tc.valid_diagnostic_fast {
+		tc.index_multiple_module_import_lines(a)
+	}
 	// Pass 1: collect type-level names (aliases, enums, sum types)
 	for tl_idx in tc.top_level_idx {
 		node := a.nodes[tl_idx]
@@ -2931,8 +3105,31 @@ fn (mut tc TypeChecker) collect_after_index(a &flat.FlatAst) {
 		tc.type_cache.parse_enabled = true
 	}
 	tc.cur_module = ''
-	for tl_idx in tc.top_level_idx {
+	p2_profile := tc.verbose
+	mut p2_fn_ns := u64(0)
+	mut p2_struct_ns := u64(0)
+	mut p2_t0 := u64(0)
+	// The parse-heavy per-declaration computation fans out over the worker
+	// pool; this serial walk then only replays the order-sensitive table
+	// registrations. Empty when the pool is unavailable — then each fn_decl
+	// computes inline exactly as before.
+	pass2_preps := tc.collect_pass2_fn_preps_parallel()
+	fast_pass2_registration := os.getenv('V3_NO_FAST_PASS2_REGISTRATION') == ''
+	parallel_pass2_ancillary := fast_pass2_registration && tc.building_v_fast
+		&& os.getenv('V3_NO_PAR_PASS2_REGISTRATION') == ''
+	if parallel_pass2_ancillary {
+		tc.defer_fn_ancillary = true
+		tc.fn_ancillary_registrations = []FnAncillaryRegistration{cap: tc.top_level_idx.len * 2}
+		tc.fn_c_variadic_registrations = []FnNamePairRegistration{cap: 64}
+		tc.fn_mut_receiver_registrations = []FnNamePairRegistration{cap: tc.top_level_idx.len / 2}
+		tc.fn_ret_text_registrations = []FnTextRegistration{cap: tc.top_level_idx.len * 2}
+		tc.visible_mutation_registrations = []VisibleMutationRegistration{cap: tc.top_level_idx.len}
+	}
+	for pi, tl_idx in tc.top_level_idx {
 		node := a.nodes[tl_idx]
+		if p2_profile {
+			p2_t0 = time.sys_mono_now()
+		}
 		match node.kind {
 			.file {
 				tc.enter_file(node.value)
@@ -2942,6 +3139,20 @@ fn (mut tc TypeChecker) collect_after_index(a &flat.FlatAst) {
 			}
 			.fn_decl {
 				qname := tc.qualify_fn_name(node.value)
+				lowered_qname := if fast_pass2_registration {
+					tc.cached_c_name(qname)
+				} else {
+					''
+				}
+				lowered_source_name := if fast_pass2_registration {
+					if node.value == qname {
+						lowered_qname
+					} else {
+						tc.cached_c_name(node.value)
+					}
+				} else {
+					''
+				}
 				// A parsed source body supersedes a matching declaration imported from
 				// a cached header. Pass 1 sees all bodyless declarations first, so clear
 				// their marker while collecting concrete source signatures in pass 2.
@@ -2953,72 +3164,83 @@ fn (mut tc TypeChecker) collect_after_index(a &flat.FlatAst) {
 				if tc.cur_module in ['', 'main', 'builtin'] {
 					tc.v_fn_semantic_names[node.value] = true
 				}
-				tc.register_visible_mutation_fn_decl(tl_idx, tc.cur_module, qname, node.value)
-				is_open_generic := node.generic_params().len > 0 || node.value.contains('[')
-				ret_type := if is_open_generic {
-					tc.parse_scope_param_type(node.typ)
+				if fast_pass2_registration {
+					tc.register_visible_mutation_fn_decl_with_lowered(tl_idx, tc.cur_module, qname,
+						node.value, lowered_qname, lowered_source_name)
 				} else {
-					tc.parse_resolution_type(node.typ)
+					tc.register_visible_mutation_fn_decl(tl_idx, tc.cur_module, qname, node.value)
 				}
-				mut ptypes := []Type{}
-				mut param_texts := []string{}
-				mut shared_params := []bool{}
-				mut is_variadic := false
-				mut is_c_variadic := false
-				mut has_mut_receiver := false
-				for i in 0 .. node.children_count {
-					child := a.child_node(&node, i)
-					if child.kind == .param {
-						if ptypes.len == 0 && node.value.contains('.') && child.is_mut
-							&& !param_type_text_is_shared(child.typ) {
-							has_mut_receiver = true
-						}
-						param_type := child.typ
-						if param_type.starts_with('...') {
-							is_variadic = true
-							if param_type == '...' {
-								is_c_variadic = true
-							}
-						}
-						raw_parsed_param_type := if is_open_generic {
-							tc.parse_scope_param_type(param_type)
-						} else {
-							tc.parse_resolution_type(param_type)
-						}
-						ptypes << if child.is_mut {
-							mut_param_semantic_type(raw_parsed_param_type)
-						} else {
-							raw_parsed_param_type
-						}
-						param_texts << param_type
-						shared_params << param_type_text_is_shared(child.typ)
+				prep := if pi < pass2_preps.len && pass2_preps[pi].prepared {
+					pass2_preps[pi]
+				} else {
+					tc.compute_pass2_fn_prep(node)
+				}
+				ret_type := prep.ret_type
+				ptypes := prep.ptypes
+				param_texts := prep.param_texts
+				shared_params := prep.shared_params
+				is_variadic := prep.is_variadic
+				is_c_variadic := prep.is_c_variadic
+				has_mut_receiver := prep.has_mut_receiver
+				has_forwardable_ctx := prep.has_forwardable_ctx
+				if fast_pass2_registration {
+					// The signature arrays are immutable after registration. Keep one
+					// master-arena copy shared by the semantic, lowered, legacy, and
+					// builtin aliases instead of cloning it independently for each key.
+					owned_ptypes := ptypes.clone()
+					owned_shared_params := if shared_params.len > 0 {
+						shared_params.clone()
+					} else {
+						shared_params
 					}
-				}
-				has_forwardable_ctx := tc.fn_is_veb_app_handler(node)
-				ptypes = tc.fn_param_types_with_implicit_veb_ctx(node, ptypes)
-				shared_params = tc.fn_shared_params_with_implicit_veb_ctx(node, shared_params)
-				tc.register_fn_signature(qname, ret_type, ptypes, shared_params, is_variadic,
-					has_forwardable_ctx)
-				if is_c_variadic {
-					tc.register_c_variadic_fn(qname)
-				}
-				if has_mut_receiver {
-					tc.register_mut_receiver_method(qname)
-				}
-				tc.fn_ret_type_texts[qname] = node.typ
-				tc.fn_ret_type_texts[tc.cached_c_name(qname)] = node.typ
-				if tc.cur_module in ['', 'main', 'builtin'] && qname != node.value
-					&& node.value !in tc.fn_param_types {
-					tc.register_fn_signature(node.value, ret_type, ptypes, shared_params,
-						is_variadic, has_forwardable_ctx)
+					tc.register_fn_signature_owned(qname, lowered_qname, ret_type, owned_ptypes,
+						owned_shared_params, is_variadic, has_forwardable_ctx)
 					if is_c_variadic {
-						tc.register_c_variadic_fn(node.value)
+						tc.register_c_variadic_fn_with_lowered(qname, lowered_qname)
 					}
 					if has_mut_receiver {
-						tc.register_mut_receiver_method(node.value)
+						tc.register_mut_receiver_method_with_lowered(qname, lowered_qname)
 					}
-					tc.fn_ret_type_texts[node.value] = node.typ
-					tc.fn_ret_type_texts[tc.cached_c_name(node.value)] = node.typ
+					tc.register_fn_ret_type_text(qname, node.typ)
+					tc.register_fn_ret_type_text(lowered_qname, node.typ)
+					if tc.cur_module in ['', 'main', 'builtin'] && qname != node.value
+						&& node.value !in tc.fn_param_types {
+						tc.register_fn_signature_owned(node.value, lowered_source_name, ret_type,
+							owned_ptypes, owned_shared_params, is_variadic, has_forwardable_ctx)
+						if is_c_variadic {
+							tc.register_c_variadic_fn_with_lowered(node.value, lowered_source_name)
+						}
+						if has_mut_receiver {
+							tc.register_mut_receiver_method_with_lowered(node.value,
+								lowered_source_name)
+						}
+						tc.register_fn_ret_type_text(node.value, node.typ)
+						tc.register_fn_ret_type_text(lowered_source_name, node.typ)
+					}
+				} else {
+					tc.register_fn_signature(qname, ret_type, ptypes, shared_params, is_variadic,
+						has_forwardable_ctx)
+					if is_c_variadic {
+						tc.register_c_variadic_fn(qname)
+					}
+					if has_mut_receiver {
+						tc.register_mut_receiver_method(qname)
+					}
+					tc.register_fn_ret_type_text(qname, node.typ)
+					tc.register_fn_ret_type_text(tc.cached_c_name(qname), node.typ)
+					if tc.cur_module in ['', 'main', 'builtin'] && qname != node.value
+						&& node.value !in tc.fn_param_types {
+						tc.register_fn_signature(node.value, ret_type, ptypes, shared_params,
+							is_variadic, has_forwardable_ctx)
+						if is_c_variadic {
+							tc.register_c_variadic_fn(node.value)
+						}
+						if has_mut_receiver {
+							tc.register_mut_receiver_method(node.value)
+						}
+						tc.register_fn_ret_type_text(node.value, node.typ)
+						tc.register_fn_ret_type_text(tc.cached_c_name(node.value), node.typ)
+					}
 				}
 				// A generic struct method (`Box[T].clone`) keeps its original signature
 				// TEXT: the parsed types collapse a non-concrete `Box[T]` to the bare base,
@@ -3128,16 +3350,20 @@ fn (mut tc TypeChecker) collect_after_index(a &flat.FlatAst) {
 				mut is_variadic := false
 				for i in 0 .. node.children_count {
 					child := a.child_node(&node, i)
-					if child.kind == .param {
-						if child.typ.starts_with('...') {
-							is_variadic = true
+					if child.kind != .param {
+						if tc.prefix_param_scan {
+							break
 						}
-						parsed_param_type := tc.parse_type(child.typ)
-						ptypes << if child.is_mut {
-							mut_param_semantic_type(parsed_param_type)
-						} else {
-							parsed_param_type
-						}
+						continue
+					}
+					if child.typ.starts_with('...') {
+						is_variadic = true
+					}
+					parsed_param_type := tc.parse_type(child.typ)
+					ptypes << if child.is_mut {
+						mut_param_semantic_type(parsed_param_type)
+					} else {
+						parsed_param_type
 					}
 				}
 				module_key := c_fn_module_signature_key(tc.cur_module, c_name)
@@ -3191,24 +3417,28 @@ fn (mut tc TypeChecker) collect_after_index(a &flat.FlatAst) {
 						shared_params << false
 						for j in 0 .. f.children_count {
 							child := a.child_node(f, j)
-							if child.kind == .param {
-								if child.typ.starts_with('...') {
-									is_variadic = true
+							if child.kind != .param {
+								if tc.prefix_param_scan {
+									break
 								}
-								parsed_param_type := if iface_generic_params.len > 0 {
-									tc.parse_scope_param_type(child.typ)
-								} else {
-									tc.parse_type(child.typ)
-								}
-								ptypes << if child.is_mut {
-									mut_param_semantic_type(parsed_param_type)
-								} else {
-									parsed_param_type
-								}
-								param_texts << child.typ
-								shared_params << param_type_text_is_shared(child.typ)
-								param_mutability << child.is_mut
+								continue
 							}
+							if child.typ.starts_with('...') {
+								is_variadic = true
+							}
+							parsed_param_type := if iface_generic_params.len > 0 {
+								tc.parse_scope_param_type(child.typ)
+							} else {
+								tc.parse_type(child.typ)
+							}
+							ptypes << if child.is_mut {
+								mut_param_semantic_type(parsed_param_type)
+							} else {
+								parsed_param_type
+							}
+							param_texts << child.typ
+							shared_params << param_type_text_is_shared(child.typ)
+							param_mutability << child.is_mut
 						}
 						tc.register_fn_name_alias(mname, ret_type, ptypes, shared_params,
 							is_variadic, false)
@@ -3217,7 +3447,7 @@ fn (mut tc TypeChecker) collect_after_index(a &flat.FlatAst) {
 							tc.register_mut_receiver_method(mname)
 						}
 						if iface_generic_params.len > 0 {
-							tc.fn_ret_type_texts[mname] = f.typ
+							tc.register_fn_ret_type_text(mname, f.typ)
 							tc.fn_param_type_texts[mname] = [iface_name]
 							tc.fn_param_type_texts[mname] << param_texts
 						}
@@ -3273,8 +3503,23 @@ fn (mut tc TypeChecker) collect_after_index(a &flat.FlatAst) {
 			}
 			else {}
 		}
+		if p2_profile {
+			p2_el := time.sys_mono_now() - p2_t0
+			if node.kind == .fn_decl {
+				p2_fn_ns += p2_el
+			} else if node.kind == .struct_decl {
+				p2_struct_ns += p2_el
+			}
+		}
+	}
+	if parallel_pass2_ancillary {
+		tc.defer_fn_ancillary = false
+		tc.finish_pass2_ancillary_registrations()
 	}
 	tc.collect_deprecated_symbols()
+	if p2_profile {
+		tc.timing_profile('  [ttime]       p2 fns ${f64(p2_fn_ns) / 1000000.0:.2f} ms, structs ${f64(p2_struct_ns) / 1000000.0:.2f} ms')
+	}
 	tc.timing_profile('  [ttime]     ck c pass2     ${f64(ck_c_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 	ck_c_sw.restart()
 	tc.resolve_inferred_global_types(a)
@@ -3542,6 +3787,9 @@ fn (mut tc TypeChecker) check_c_fn_redeclarations(a &flat.FlatAst) {
 				for i in 0 .. node.children_count {
 					child := a.child_node(&node, i)
 					if child.kind != .param {
+						if tc.prefix_param_scan {
+							break
+						}
 						continue
 					}
 					if child.typ.starts_with('...') {
@@ -5618,11 +5866,70 @@ fn (tc &TypeChecker) has_active_import(alias string) bool {
 
 const receiver_method_suffix_ambiguous = '__v_receiver_method_suffix_ambiguous__'
 
+struct FnAncillaryRegistration {
+	name             string
+	ret_type         Type
+	shared_params    []bool
+	is_variadic      bool
+	implicit_veb_ctx bool
+	file             string
+	write_file       bool
+}
+
+struct FnNamePairRegistration {
+	name         string
+	lowered_name string
+}
+
+struct FnTextRegistration {
+	name string
+	text string
+}
+
+struct VisibleMutationRegistration {
+	idx           int
+	module_name   string
+	qname         string
+	source_name   string
+	c_qname       string
+	c_source_name string
+}
+
 fn (mut tc TypeChecker) register_mut_receiver_method(name string) {
-	tc.mut_receiver_methods[name] = true
 	lowered_name := tc.cached_c_name(name)
+	tc.register_mut_receiver_method_with_lowered(name, lowered_name)
+}
+
+fn (mut tc TypeChecker) register_mut_receiver_method_with_lowered(name string, lowered_name string) {
+	if tc.defer_fn_ancillary {
+		tc.fn_mut_receiver_registrations << FnNamePairRegistration{
+			name:         name
+			lowered_name: lowered_name
+		}
+		return
+	}
+	tc.mut_receiver_methods[name] = true
 	if lowered_name != name {
 		tc.mut_receiver_methods[lowered_name] = true
+	}
+}
+
+// register_fn_signature_owned installs aliases that may share immutable
+// master-owned signature arrays. lowered_name must be cached_c_name(name).
+fn (mut tc TypeChecker) register_fn_signature_owned(name string, lowered_name string, ret_type Type, params []Type, shared_params []bool, is_variadic bool, implicit_veb_ctx bool) {
+	tc.register_fn_name_alias_owned(name, ret_type, params, shared_params, is_variadic,
+		implicit_veb_ctx)
+	if lowered_name != name && !(name.starts_with('C.') && lowered_name in tc.v_fn_semantic_names) {
+		tc.register_fn_name_alias_owned(lowered_name, ret_type, params, shared_params, is_variadic,
+			implicit_veb_ctx)
+	}
+	if name.ends_with('.str') {
+		receiver := name.all_before_last('.')
+		legacy_name := '${receiver}_str'
+		if !legacy_name.contains('.') {
+			tc.register_fn_name_alias_owned(legacy_name, ret_type, params, shared_params,
+				is_variadic, implicit_veb_ctx)
+		}
 	}
 }
 
@@ -5646,6 +5953,17 @@ fn (mut tc TypeChecker) register_fn_signature(name string, ret_type Type, params
 
 // register_fn_name_alias updates register fn name alias state for types.
 fn (mut tc TypeChecker) register_fn_name_alias(name string, ret_type Type, params []Type, shared_params []bool, is_variadic bool, implicit_veb_ctx bool) {
+	owned_params := params.clone()
+	owned_shared_params := if shared_params.len > 0 {
+		shared_params.clone()
+	} else {
+		shared_params
+	}
+	tc.register_fn_name_alias_owned(name, ret_type, owned_params, owned_shared_params, is_variadic,
+		implicit_veb_ctx)
+}
+
+fn (mut tc TypeChecker) register_fn_name_alias_owned(name string, ret_type Type, params []Type, shared_params []bool, is_variadic bool, implicit_veb_ctx bool) {
 	// C externs live in one global namespace and modules routinely redeclare
 	// them with refined types (builtin: `C.pthread_join(thread voidptr, ...)`,
 	// v3.workers: `C.pthread_join(thread C.pthread_t, ...)`). The
@@ -5661,14 +5979,8 @@ fn (mut tc TypeChecker) register_fn_name_alias(name string, ret_type Type, param
 			}
 		}
 	}
-	tc.fn_ret_types[name] = ret_type
-	tc.fn_param_types[name] = params.clone()
-	if shared_params.len > 0 {
-		tc.fn_shared_params[name] = shared_params.clone()
-	} else if tc.fn_shared_params.len > 0 {
-		// Deleting from an empty map is a paid no-op on this hot path.
-		tc.fn_shared_params.delete(name)
-	}
+	tc.fn_param_types[name] = params
+	mut write_file := false
 	if tc.cur_file.len > 0 {
 		// A refined C-extern redeclaration updates the signature tables above
 		// but must not steal ownership: is_builtin_unsafe_c_call keys the
@@ -5676,9 +5988,35 @@ fn (mut tc TypeChecker) register_fn_name_alias(name string, ret_type Type, param
 		// builtin owner, so a module redeclaring C.malloc (json does) would
 		// otherwise suppress that diagnostic program-wide.
 		if !name.starts_with('C.') || name !in tc.fn_type_modules || tc.cur_module in ['', 'main'] {
-			tc.fn_type_files[name] = tc.cur_file
+			write_file = true
 			tc.fn_type_modules[name] = tc.cur_module
 		}
+	}
+	if tc.defer_fn_ancillary {
+		tc.fn_ancillary_registrations << FnAncillaryRegistration{
+			name:             name
+			ret_type:         ret_type
+			shared_params:    shared_params
+			is_variadic:      is_variadic
+			implicit_veb_ctx: implicit_veb_ctx
+			file:             tc.cur_file
+			write_file:       write_file
+		}
+	} else {
+		tc.fn_ret_types[name] = ret_type
+		if write_file {
+			tc.fn_type_files[name] = tc.cur_file
+		}
+		tc.register_fn_ancillary_owned(name, shared_params, is_variadic, implicit_veb_ctx)
+	}
+}
+
+fn (mut tc TypeChecker) register_fn_ancillary_owned(name string, shared_params []bool, is_variadic bool, implicit_veb_ctx bool) {
+	if shared_params.len > 0 {
+		tc.fn_shared_params[name] = shared_params
+	} else if tc.fn_shared_params.len > 0 {
+		// Deleting from an empty map is a paid no-op on this hot path.
+		tc.fn_shared_params.delete(name)
 	}
 	tc.fn_variadic[name] = is_variadic
 	if implicit_veb_ctx || tc.fn_implicit_veb_ctx.len > 0 {
@@ -5689,8 +6027,25 @@ fn (mut tc TypeChecker) register_fn_name_alias(name string, ret_type Type, param
 	tc.add_receiver_method_suffix_index(name)
 }
 
+fn (mut tc TypeChecker) register_fn_ret_type_text(name string, text string) {
+	if tc.defer_fn_ancillary {
+		tc.fn_ret_text_registrations << FnTextRegistration{
+			name: name
+			text: text
+		}
+		return
+	}
+	tc.fn_ret_type_texts[name] = text
+}
+
 fn (mut tc TypeChecker) add_receiver_method_suffix_index(name string) {
 	if name.len == 0 {
+		return
+	}
+	// Plain functions and C-lowered aliases cannot form receiver.method keys.
+	// Dotted semantic methods already install both their full and short suffixes,
+	// so indexing these aliases only adds paid map writes.
+	if tc.method_suffix_prescreen && name.index_u8(`.`) < 0 {
 		return
 	}
 	tc.set_receiver_method_suffix_index(name, name)
@@ -5726,8 +6081,22 @@ fn (mut tc TypeChecker) register_c_variadic_fn(name string) {
 	if name.len == 0 {
 		return
 	}
-	tc.c_variadic_fns[name] = true
 	lowered_name := tc.cached_c_name(name)
+	tc.register_c_variadic_fn_with_lowered(name, lowered_name)
+}
+
+fn (mut tc TypeChecker) register_c_variadic_fn_with_lowered(name string, lowered_name string) {
+	if name.len == 0 {
+		return
+	}
+	if tc.defer_fn_ancillary {
+		tc.fn_c_variadic_registrations << FnNamePairRegistration{
+			name:         name
+			lowered_name: lowered_name
+		}
+		return
+	}
+	tc.c_variadic_fns[name] = true
 	if lowered_name != name {
 		tc.c_variadic_fns[lowered_name] = true
 	}
@@ -5870,31 +6239,32 @@ pub fn (mut tc TypeChecker) annotate_types_with_used(used_fns map[string]bool) {
 
 // diagnose_unused_private_declarations records notices for unreachable private
 // functions and constants that are never referenced by any declaration.
+// UnusedDeclCandidate is one private declaration that survived the used-fns
+// filter and now only needs the referenced-name scan to confirm it is unused.
+struct UnusedDeclCandidate {
+	is_fn    bool
+	name     string
+	qname    string
+	file     string
+	node_id  flat.NodeId
+	position token.Pos
+mut:
+	alive bool
+}
+
 pub fn (mut tc TypeChecker) diagnose_unused_private_declarations(used_fns map[string]bool) {
 	if tc.errors.len > 0 || !tc.has_main_module_fn_main() {
 		return
 	}
-	mut referenced_consts := map[string]bool{}
-	mut referenced_fns := map[string]bool{}
-	for node in tc.a.nodes {
-		if node.kind in [.ident, .selector] && node.value.len > 0 {
-			referenced_consts[node.value] = true
-			short_name := short_name_view(node.value)
-			if short_name.len != node.value.len {
-				referenced_consts[short_name] = true
-			}
-		}
-		if node.kind == .call && node.children_count > 0 {
-			callee := tc.a.child_node(&node, 0)
-			if callee.value.len > 0 {
-				referenced_fns[callee.value] = true
-				short_name := short_name_view(callee.value)
-				if short_name.len != callee.value.len {
-					referenced_fns[short_name] = true
-				}
-			}
-		}
-	}
+	// Collect the (few) candidate declarations first, then scan the AST once
+	// probing only against that small candidate set. Building referenced-name
+	// maps over every ident/selector/call in the program did the same work as
+	// this inverted form, but with hundreds of thousands of map inserts.
+	mut candidates := []UnusedDeclCandidate{cap: 64}
+	// Maps a referenced spelling (name or module-qualified name) to the
+	// candidate indexes it keeps alive.
+	mut fn_keys := map[string][]int{}
+	mut const_keys := map[string][]int{}
 	mut module_name := ''
 	for idx in tc.top_level_idx {
 		node := tc.a.nodes[idx]
@@ -5917,12 +6287,21 @@ pub fn (mut tc TypeChecker) diagnose_unused_private_declarations(used_fns map[st
 			}
 			qname := checker_qualified_fn_name(module_name, node.value)
 			cname := tc.cached_c_name(qname)
-			if used_fns[node.value] || used_fns[qname] || used_fns[cname]
-				|| referenced_fns[node.value] || referenced_fns[qname] {
+			if used_fns[node.value] || used_fns[qname] || used_fns[cname] {
 				continue
 			}
-			tc.record_notice_at(.unknown_ident, 'unused function: `${node.value}`',
-				flat.NodeId(idx), tc.node_value_diagnostic_pos(flat.NodeId(idx)))
+			cand_idx := candidates.len
+			candidates << UnusedDeclCandidate{
+				is_fn:   true
+				name:    node.value
+				qname:   qname
+				file:    tc.cur_file
+				node_id: flat.NodeId(idx)
+			}
+			fn_keys[node.value] << cand_idx
+			if qname != node.value {
+				fn_keys[qname] << cand_idx
+			}
 			continue
 		}
 		if node.kind != .const_decl {
@@ -5940,13 +6319,53 @@ pub fn (mut tc TypeChecker) diagnose_unused_private_declarations(used_fns map[st
 			} else {
 				field.value
 			}
-			if referenced_consts[field.value] || referenced_consts[qname] {
-				continue
+			cand_idx := candidates.len
+			candidates << UnusedDeclCandidate{
+				is_fn:    false
+				name:     field.value
+				qname:    qname
+				file:     tc.cur_file
+				node_id:  field_id
+				position: field.pos
 			}
-			tc.record_notice_at(.unknown_ident, 'unused constant: `${field.value}`', field_id,
-				field.pos)
+			const_keys[field.value] << cand_idx
+			if qname != field.value {
+				const_keys[qname] << cand_idx
+			}
 		}
 	}
+	if candidates.len == 0 {
+		return
+	}
+	// A reference through either the full spelling or its short (last-segment)
+	// spelling keeps a candidate alive, mirroring the referenced-name maps the
+	// former form built from both spellings of every reference. The scan only
+	// probes the small candidate-key maps and sets alive flags, so disjoint
+	// node shards can run on the worker pool and OR-merge deterministically.
+	mut alive := []bool{len: candidates.len}
+	tc.scan_unused_candidate_references(fn_keys, const_keys, mut alive)
+	for cand_idx in 0 .. candidates.len {
+		if alive[cand_idx] {
+			candidates[cand_idx].alive = true
+		}
+	}
+	// The diagnostic filter and recorded file both read tc.cur_file; replay each
+	// candidate's file so deferred emission matches the former in-walk emission.
+	walk_end_file := tc.cur_file
+	for cand in candidates {
+		if cand.alive {
+			continue
+		}
+		tc.cur_file = cand.file
+		if cand.is_fn {
+			tc.record_notice_at(.unknown_ident, 'unused function: `${cand.name}`', cand.node_id,
+				tc.node_value_diagnostic_pos(cand.node_id))
+		} else {
+			tc.record_notice_at(.unknown_ident, 'unused constant: `${cand.name}`', cand.node_id,
+				cand.position)
+		}
+	}
+	tc.cur_file = walk_end_file
 }
 
 fn (tc &TypeChecker) declaration_contains_error(node flat.Node) bool {
@@ -5962,6 +6381,9 @@ fn (tc &TypeChecker) declaration_contains_error(node flat.Node) bool {
 // check_main_module_requirement rejects ordinary programs that contain no
 // selected source file in the `main` module.
 pub fn (mut tc TypeChecker) check_main_module_requirement(is_shared bool) {
+	if tc.valid_diagnostic_fast {
+		return
+	}
 	if is_shared || (tc.checker_fixture_mode && tc.errors.len > 0) {
 		return
 	}
@@ -7013,6 +7435,31 @@ fn (tc &TypeChecker) in_check_range(idx int) bool {
 }
 
 // cached_expr_type supports cached expr type handling for TypeChecker.
+// invalidate_checked_expr_type drops the cached checked type for one node the
+// transformer rewrote in place, so a trust_checked_expr_types resolve cannot
+// return the pre-rewrite type (see resolve_type). Rewrites target ids inside
+// the writer's own disjoint region, so the shared dense flag array sees no
+// concurrent writes to the same slot.
+@[direct_array_access; inline]
+pub fn (tc &TypeChecker) invalidate_checked_expr_type(idx int) {
+	if idx >= 0 && idx < tc.expr_type_set.len && tc.expr_type_set[idx] {
+		mut wtc := unsafe { tc }
+		wtc.expr_type_set[idx] = false
+	}
+	// A body-local resolve memo can be active while the transformer rewrites
+	// nodes inside the current work item; its positional entries go stale the
+	// same way the dense cache does.
+	mut memo := tc.body_resolve_memo
+	if !isnil(memo) && memo.active && idx >= memo.lo && idx <= memo.hi {
+		memo.filled[idx - memo.lo] = 0
+		call_slot := idx & 2047
+		if memo.call_generations[call_slot] == memo.call_generation
+			&& memo.call_ids[call_slot] == idx {
+			memo.call_generations[call_slot] = 0
+		}
+	}
+}
+
 @[direct_array_access]
 fn (tc &TypeChecker) cached_expr_type(id flat.NodeId) ?Type {
 	idx := int(id)
@@ -7035,7 +7482,7 @@ fn (tc &TypeChecker) cached_expr_type(id flat.NodeId) ?Type {
 @[direct_array_access]
 fn (tc &TypeChecker) cached_resolved_call(id flat.NodeId) ?string {
 	idx := int(id)
-	if !isnil(tc.fork_overlay) {
+	if !isnil(tc.fork_overlay) && idx >= tc.fork_overlay.base_node_count {
 		if name := tc.fork_overlay.resolved_call_names[idx] {
 			return name
 		}
@@ -7133,7 +7580,7 @@ fn (tc &TypeChecker) name_never_returns(name string) bool {
 @[direct_array_access]
 pub fn (tc &TypeChecker) resolved_fn_value_name(id flat.NodeId) ?string {
 	idx := int(id)
-	if !isnil(tc.fork_overlay) {
+	if !isnil(tc.fork_overlay) && idx >= tc.fork_overlay.base_node_count {
 		if name := tc.fork_overlay.resolved_fn_values[idx] {
 			return name
 		}
@@ -7202,6 +7649,23 @@ fn (mut tc TypeChecker) record_direct_dependency(id SymbolId) {
 fn (tc &TypeChecker) intern_symbol(name string) (SymbolId, string) {
 	if isnil(tc.symbols) {
 		return SymbolId(0), name
+	}
+	mut cache := unsafe { tc.type_cache }
+	if !isnil(cache) {
+		ptr := usize(name.str)
+		slot := int((u64(ptr) >> 4 ^ u64(name.len)) & 2047)
+		if cache.symbol_recent_set[slot] && cache.symbol_recent_ptrs[slot] == ptr
+			&& cache.symbol_recent_lens[slot] == name.len {
+			return cache.symbol_recent_ids[slot], cache.symbol_recent_vals[slot]
+		}
+		mut symbols := unsafe { tc.symbols }
+		id, canonical := symbols.intern(name)
+		cache.symbol_recent_ptrs[slot] = ptr
+		cache.symbol_recent_lens[slot] = name.len
+		cache.symbol_recent_ids[slot] = id
+		cache.symbol_recent_vals[slot] = canonical
+		cache.symbol_recent_set[slot] = true
+		return id, canonical
 	}
 	mut symbols := unsafe { tc.symbols }
 	return symbols.intern(name)
@@ -8015,7 +8479,13 @@ fn (mut tc TypeChecker) check_str_method_signature(id flat.NodeId, node flat.Nod
 	mut explicit_params := 0
 	for i in 0 .. node.children_count {
 		param := tc.a.child_node(&node, i)
-		if param.kind == .param && param.op != .dot {
+		if param.kind != .param {
+			if tc.prefix_param_scan {
+				break
+			}
+			continue
+		}
+		if param.op != .dot {
 			explicit_params++
 		}
 	}
@@ -8039,6 +8509,9 @@ fn (mut tc TypeChecker) check_free_method_signature(id flat.NodeId, node flat.No
 		param_id := tc.a.child(&node, i)
 		param := tc.a.node(param_id)
 		if param.kind != .param {
+			if tc.prefix_param_scan {
+				break
+			}
 			continue
 		}
 		if param.op == .dot {
@@ -8223,9 +8696,13 @@ fn (mut tc TypeChecker) check_main_fn_signature(id flat.NodeId, node flat.Node) 
 		return
 	}
 	for i in 0 .. node.children_count {
-		if tc.a.child_node(&node, i).kind == .param {
+		child := tc.a.child_node(&node, i)
+		if child.kind == .param {
 			tc.record_error_at(.return_mismatch, 'function `main` cannot have arguments', id,
 				tc.fn_header_declaration_pos(id))
+			break
+		}
+		if tc.prefix_param_scan {
 			break
 		}
 	}
@@ -8246,8 +8723,12 @@ fn (mut tc TypeChecker) check_init_fn_signature(id flat.NodeId, node flat.Node) 
 	// An `init()` hook has no parameters. A public API can still use the
 	// ordinary name `init` when it takes arguments (for example `term.ui.init`).
 	for i in 0 .. node.children_count {
-		if tc.a.child_node(&node, i).kind == .param {
+		child := tc.a.child_node(&node, i)
+		if child.kind == .param {
 			return
+		}
+		if tc.prefix_param_scan {
+			break
 		}
 	}
 	pos := tc.fn_header_declaration_pos(id)
@@ -8475,9 +8956,14 @@ fn (mut tc TypeChecker) check_test_fn_signature(id flat.NodeId, node flat.Node) 
 	}
 	mut param_count := 0
 	for i in 0 .. node.children_count {
-		if tc.a.child_node(&node, i).kind == .param {
-			param_count++
+		child := tc.a.child_node(&node, i)
+		if child.kind != .param {
+			if tc.prefix_param_scan {
+				break
+			}
+			continue
 		}
+		param_count++
 	}
 	if param_count != 0 {
 		tc.record_error_at(.call_arg_mismatch,
@@ -8857,7 +9343,13 @@ fn (mut tc TypeChecker) collect_selected_file_fn_body_called_fns(node flat.Node)
 	tc.push_scope()
 	for i in 0 .. node.children_count {
 		child := tc.a.child_node(&node, i)
-		if child.kind == .param && child.value.len > 0 {
+		if child.kind != .param {
+			if tc.prefix_param_scan {
+				break
+			}
+			continue
+		}
+		if child.value.len > 0 {
 			tc.cur_scope.insert(child.value, tc.parse_type(child.typ))
 		}
 	}
@@ -9140,6 +9632,9 @@ fn (tc &TypeChecker) selected_file_receiver_method_name(base_id flat.NodeId, met
 }
 
 fn (mut tc TypeChecker) check_export_attrs() {
+	if tc.valid_diagnostic_fast {
+		return
+	}
 	mut natural_symbols := map[string]string{}
 	synthetic_main_reserved := tc.has_synthetic_c_entry_main()
 	mut cur_module := ''
@@ -9277,7 +9772,13 @@ fn (mut tc TypeChecker) check_export_attrs() {
 				}
 				for pi in 0 .. node.children_count {
 					p := tc.a.child_node(&node, pi)
-					if p.kind == .param && (p.value.len == 0 || p.typ.len == 0) {
+					if p.kind != .param {
+						if tc.prefix_param_scan {
+							break
+						}
+						continue
+					}
+					if p.value.len == 0 || p.typ.len == 0 {
 						tc.record_error_unfiltered(.unsupported_generic,
 							'exported function `${qname}` must name all parameters', flat.NodeId(i))
 					}
@@ -9650,7 +10151,13 @@ fn (tc &TypeChecker) fn_receiver_type_is_context(node flat.Node) bool {
 fn (tc &TypeChecker) fn_has_veb_context_param(node flat.Node) bool {
 	for i in 0 .. node.children_count {
 		p := tc.a.child_node(&node, i)
-		if p.kind == .param && tc.is_veb_context_type(tc.parse_type(p.typ)) {
+		if p.kind != .param {
+			if tc.prefix_param_scan {
+				break
+			}
+			continue
+		}
+		if tc.is_veb_context_type(tc.parse_type(p.typ)) {
 			return true
 		}
 	}
@@ -9686,6 +10193,9 @@ fn (mut tc TypeChecker) check_veb_app_method_params(fn_id flat.NodeId, node flat
 		param_id := tc.a.child(&node, i)
 		param := tc.a.node(param_id)
 		if param.kind != .param {
+			if tc.prefix_param_scan {
+				break
+			}
 			continue
 		}
 		param_type := tc.parse_type(param.typ)
@@ -9746,6 +10256,13 @@ fn (mut tc TypeChecker) check_fn_body(node flat.Node) {
 		child_id := tc.a.child(&node, i)
 		child := tc.a.child_node(&node, i)
 		if child.kind == .param {
+			continue
+		}
+		if tc.valid_diagnostic_fast {
+			tc.check_stmt_node(child_id)
+			tc.fn_context.continue_after_unknown_ident = false
+			tc.apply_post_if_exit_smartcasts(child_id)
+			tc.apply_post_assert_smartcasts(child_id)
 			continue
 		}
 		if child.kind == .label_stmt {
@@ -10041,7 +10558,13 @@ fn (mut tc TypeChecker) check_fn_bare_generic_fntype_params(node flat.Node) {
 	for i in 0 .. node.children_count {
 		child_id := tc.a.child(&node, i)
 		child := tc.a.node(child_id)
-		if child.kind == .param && child.op != .dot {
+		if child.kind != .param {
+			if tc.prefix_param_scan {
+				break
+			}
+			continue
+		}
+		if child.op != .dot {
 			tc.check_bare_generic_fntype_param(child_id, child.typ)
 		}
 	}
@@ -10246,7 +10769,13 @@ fn (mut tc TypeChecker) check_fn_decl_unmentioned_generic_types(node_id flat.Nod
 	for i in 0 .. node.children_count {
 		child_id := tc.a.child(&node, i)
 		child := tc.a.node(child_id)
-		if child.kind != .param || child.typ.len == 0 {
+		if child.kind != .param {
+			if tc.prefix_param_scan {
+				break
+			}
+			continue
+		}
+		if child.typ.len == 0 {
 			continue
 		}
 		for name in tc.unmentioned_generic_names_in_type(child.typ, explicit_params) {

--- a/vlib/v3/types/checker_comptime.v
+++ b/vlib/v3/types/checker_comptime.v
@@ -4470,6 +4470,9 @@ fn (tc &TypeChecker) interface_declaration_diagnostic(iface_name string) (flat.N
 // check_interface_embedding_limits rejects deep interface casts before requirement
 // indexes recursively expand the embedding chain.
 pub fn (mut tc TypeChecker) check_interface_embedding_limits() bool {
+	if tc.valid_diagnostic_fast {
+		return false
+	}
 	mut embedded := map[string]bool{}
 	for _, embeds in tc.interface_embeds {
 		for embed in embeds {
@@ -7846,7 +7849,8 @@ fn (tc &TypeChecker) mut_param_base_for_current_ident(name string, typ Type) ?Ty
 		// otherwise runs for every infix operand.
 		return none
 	}
-	if isnil(tc.cur_scope) || tc.cur_scope == tc.file_scope || tc.fn_context.node_id < 0 {
+	if isnil(tc.cur_scope) || voidptr(tc.cur_scope) == voidptr(tc.file_scope)
+		|| tc.fn_context.node_id < 0 {
 		return none
 	}
 	base := tc.fn_context.mut_param_base_types[name] or { return none }
@@ -12096,6 +12100,7 @@ fn (tc &TypeChecker) lock_keyword_diagnostic_pos(node flat.Node) token.Pos {
 }
 
 // check_for_in_stmt validates check for in stmt state for types.
+@[direct_array_access]
 fn (mut tc TypeChecker) check_for_in_stmt(node flat.Node) {
 	header := node.value.int()
 	if header < 3 || node.children_count < 3 {
@@ -12840,6 +12845,10 @@ fn (mut tc TypeChecker) check_decl_assign(id flat.NodeId, node flat.Node) {
 	if node.children_count == 0 {
 		return
 	}
+	if tc.valid_resolution_fast {
+		tc.check_valid_decl_assign(id, node)
+		return
+	}
 	if tc.check_multi_return_decl_assign(id, node) {
 		return
 	}
@@ -13200,6 +13209,59 @@ fn (mut tc TypeChecker) check_decl_assign(id flat.NodeId, node flat.Node) {
 		tc.track_method_value_local(lhs_id, rhs_id)
 		tc.track_variadic_fn_value_local(lhs_id, rhs_id)
 		tc.track_capturing_fn_literal_local(lhs_id, rhs_id, owner)
+		i += 2
+	}
+}
+
+// check_valid_decl_assign performs only the resolution state updates needed by
+// later expressions and code generation. The building-v input is already known
+// to be valid, so recreating declaration diagnostics here is redundant work.
+fn (mut tc TypeChecker) check_valid_decl_assign(id flat.NodeId, node flat.Node) {
+	if tc.check_multi_return_decl_assign(id, node) {
+		return
+	}
+	if tc.check_multi_value_list_decl_assign(id, node) {
+		return
+	}
+	if tc.check_assignment_marker(id, node) {
+		return
+	}
+	mut i := 0
+	for i + 1 < node.children_count {
+		lhs_id := tc.a.child(&node, i)
+		rhs_id := tc.a.child(&node, i + 1)
+		lhs_node := tc.a.node(lhs_id)
+		if lhs_node.kind != .ident {
+			tc.check_node(rhs_id)
+			i += 2
+			continue
+		}
+		explicit_expected := if node.children_count == 2 && node.typ.len > 0 {
+			tc.parse_type(node.typ)
+		} else {
+			Type(void_)
+		}
+		if explicit_expected is Void {
+			tc.check_node(rhs_id)
+		} else {
+			tc.check_node_with_expected_context(rhs_id, explicit_expected)
+		}
+		mut inferred := tc.decl_assign_inferred_type(rhs_id)
+		if explicit_expected !is Void {
+			inferred = tc.resolve_expr(rhs_id, explicit_expected)
+		}
+		lhs_is_mut := tc.decl_lhs_is_mut(node, lhs_id)
+		owner := tc.insert_decl_lhs(lhs_id, if explicit_expected is Void {
+			inferred
+		} else {
+			explicit_expected
+		}, lhs_is_mut)
+		if owner.storage_key().len > 0 && decl_assign_is_shared_marker(node.value) {
+			tc.mark_shared_binding_owner(lhs_node.value, owner)
+		}
+		if owner.storage_key().len > 0 && tc.expr_initializes_shared_array(rhs_id) {
+			tc.mark_shared_array_binding_owner(lhs_node.value, owner)
+		}
 		i += 2
 	}
 }
@@ -15384,7 +15446,7 @@ fn (mut tc TypeChecker) insert_decl_lhs(lhs_id flat.NodeId, typ Type, is_mut boo
 fn (tc &TypeChecker) visible_mut_param_binding_owns_name(name string) bool {
 	param_owner := tc.fn_context.mut_param_owners[name] or { return false }
 	owner := tc.cur_scope.lookup_owner(name) or { return false }
-	return owner.scope == param_owner.scope && owner.index == param_owner.index
+	return voidptr(owner.scope) == voidptr(param_owner.scope) && owner.index == param_owner.index
 		&& owner.generation == param_owner.generation
 }
 
@@ -15404,6 +15466,10 @@ fn (tc &TypeChecker) visible_local_scope_owns_name(name string) bool {
 // check_assign validates check assign state for types.
 fn (mut tc TypeChecker) check_assign(id flat.NodeId, node flat.Node) {
 	if node.children_count < 2 {
+		return
+	}
+	if tc.valid_resolution_fast {
+		tc.check_valid_assign(id, node)
 		return
 	}
 	if _ := tc.malformed_const_keyword_pos(id) {
@@ -15918,6 +15984,65 @@ fn (mut tc TypeChecker) check_assign(id flat.NodeId, node flat.Node) {
 		_ = ownership_rhs_ids
 		_ = ownership_lhs_types
 		_ = ownership_rhs_types
+	}
+}
+
+// check_valid_assign retains expression typing and smartcast state while
+// omitting assignment diagnostics for the already-validated building-v input.
+fn (mut tc TypeChecker) check_valid_assign(id flat.NodeId, node flat.Node) {
+	if tc.check_assignment_marker(id, node) {
+		return
+	}
+	if tc.check_multi_return_assign(id, node) {
+		return
+	}
+	mut smartcast_write_keys := []string{}
+	mut smartcast_updates := map[string]Type{}
+	mut i := 0
+	for i + 1 < node.children_count {
+		lhs_id := tc.a.child(&node, i)
+		rhs_id := tc.a.child(&node, i + 1)
+		lhs_node := tc.a.node(lhs_id)
+		lhs_type := if node.kind == .index_assign {
+			tc.resolve_index_lvalue_type(lhs_id, node.op)
+		} else {
+			tc.resolve_lvalue_type(lhs_id)
+		}
+		tc.remember_expr_type(lhs_id, lhs_type)
+		expected_type := tc.assignment_expected_type(lhs_id, lhs_type)
+		source_rhs_type := tc.resolve_type(rhs_id)
+		tc.annotate_expected_expr(rhs_id, expected_type)
+		tc.check_node_with_expected_context(rhs_id, expected_type)
+		mut rhs_type := tc.resolve_expr(rhs_id, expected_type)
+		rhs_node := tc.a.node(rhs_id)
+		if rhs_node.kind == .call {
+			if call_info := tc.resolve_call_info(rhs_id, rhs_node) {
+				if call_info.return_type !is Unknown && call_info.return_type !is Void {
+					rhs_type = call_info.return_type
+					tc.remember_expr_type(rhs_id, rhs_type)
+				}
+			}
+		}
+		lhs_key := tc.expr_key(lhs_id)
+		if lhs_key.len > 0 {
+			if !tc.assignment_preserves_smartcast(lhs_id, rhs_id, source_rhs_type) {
+				smartcast_write_keys << lhs_key
+			}
+			if node.op == .assign && lhs_node.kind == .ident {
+				declared := tc.cur_scope.lookup(lhs_node.value) or { Type(void_) }
+				if declared is OptionType
+					&& tc.expr_compatible(rhs_id, source_rhs_type, declared.base_type) {
+					smartcast_updates[lhs_key] = declared.base_type
+				}
+			}
+		}
+		i += 2
+	}
+	for key in smartcast_write_keys {
+		tc.invalidate_smartcasts_for_write_key(key)
+	}
+	for key, typ in smartcast_updates {
+		tc.smartcasts[key] = typ
 	}
 }
 

--- a/vlib/v3/types/checker_parallel.v
+++ b/vlib/v3/types/checker_parallel.v
@@ -12,12 +12,17 @@ const max_parallel_check_jobs = 26
 // Scoped workers use bounded arena batches, so let self-host checks occupy all
 // of the worker pool's cores without retaining one large arena per core.
 const max_scoped_check_jobs = 10
+// The historical 96-batch limit remains the low-memory fallback. Prealloc
+// self-host checks default to one twelfth as many batches below, amortizing
+// checker fork/promotion setup while keeping each worker's scratch bounded.
 const scoped_check_worker_batches = 96
 // A serial checker owns the whole import graph instead of one worker shard, so
 // use finer arena batches to keep compiler-module checks below the memory cap.
 const scoped_check_serial_batches = 64
 // Keep one scheduled chunk per scoped worker. Finer arena batches within each
 // chunk release transient checker allocations without retaining extra shards.
+// (Re-verified 2026-08: oversubscribe=4 costs ~25ms here — the extra per-chunk
+// fork/promote overhead outweighs the straggler absorption.)
 const check_chunk_oversubscribe = 1
 // Extra share of the total work (in percent of an even bucket) pre-assigned to
 // the master's bucket; see split_check_items.
@@ -38,26 +43,430 @@ struct UnusedFnVarCandidate {
 	rhs_id flat.NodeId
 }
 
+struct CollectIndexPrepArgs {
+	tc   voidptr
+	a    &flat.FlatAst
+	kind u8 // 0 = parent edges, 1 = threads condition, 2 = node-cache reset
+	n    int
+}
+
+fn collect_index_prep_thread(arg voidptr) voidptr {
+	a := unsafe { &CollectIndexPrepArgs(arg) }
+	mut tc := unsafe { &TypeChecker(a.tc) }
+	match a.kind {
+		0 {
+			tc.fill_direct_parent_edges(a.a)
+		}
+		1 {
+			scope := check_worker_scope_begin(true)
+			tc.prepare_threads_condition()
+			check_worker_scope_leave(scope)
+			check_worker_scope_free(scope)
+		}
+		else {
+			tc.reset_node_caches(a.n)
+		}
+	}
+	return unsafe { nil }
+}
+
+// prepare_collect_index_parallel overlaps three independent index-front-end
+// tasks. Persistent arrays are initialized and reset on the caller's arena;
+// helper tasks only fill those arrays or return the scalar threads condition.
+fn (mut tc TypeChecker) prepare_collect_index_parallel(a &flat.FlatAst) bool {
+	if !tc.building_v_fast || os.getenv('V3_NO_PAR_CHECK_INDEX_PREP') != '' || isnil(a.worker_pool)
+		|| a.worker_pool.size() < 2 || a.nodes.len < 65536 {
+		return false
+	}
+	tc.init_direct_parent_index(a)
+	mut args := [
+		CollectIndexPrepArgs{
+			tc:   voidptr(tc)
+			a:    a
+			kind: 0
+		},
+		CollectIndexPrepArgs{
+			tc:   voidptr(tc)
+			a:    a
+			kind: 1
+		},
+		CollectIndexPrepArgs{
+			tc:   voidptr(tc)
+			a:    a
+			kind: 2
+			n:    a.nodes.len
+		},
+	]
+	a.worker_pool.run([
+		workers.Task{ run: collect_index_prep_thread, arg: unsafe { voidptr(&args[0]) } },
+		workers.Task{ run: collect_index_prep_thread, arg: unsafe { voidptr(&args[1]) } },
+		workers.Task{
+			run:        collect_index_prep_thread
+			arg:        unsafe { voidptr(&args[2]) }
+			force_sync: true
+		},
+	])
+	tc.collect_direct_parent_metadata(a)
+	tc.direct_parent_index_trusted = true
+	return true
+}
+
+// Pass2FnPrep carries the parse-heavy portion of one fn_decl's pass-2
+// collection (type parsing, param iteration, veb adjustments), computed on the
+// worker pool so the serial pass only replays the order-sensitive table
+// registrations.
+struct Pass2FnPrep {
+mut:
+	prepared            bool
+	ret_type            Type = Type(void_)
+	ptypes              []Type
+	param_texts         []string
+	shared_params       []bool
+	is_variadic         bool
+	is_c_variadic       bool
+	has_mut_receiver    bool
+	has_forwardable_ctx bool
+}
+
+// compute_pass2_fn_prep performs the context-dependent but table-write-free
+// part of pass 2 for one function declaration. Callers must have cur_file /
+// cur_module positioned exactly as the serial pass-2 walk would.
+fn (mut tc TypeChecker) compute_pass2_fn_prep(node flat.Node) Pass2FnPrep {
+	is_open_generic := node.generic_params().len > 0 || node.value.contains('[')
+	ret_type := if is_open_generic {
+		tc.parse_scope_param_type(node.typ)
+	} else {
+		tc.parse_resolution_type(node.typ)
+	}
+	mut ptypes := []Type{}
+	mut param_texts := []string{}
+	mut shared_params := []bool{}
+	mut is_variadic := false
+	mut is_c_variadic := false
+	mut has_mut_receiver := false
+	for i in 0 .. node.children_count {
+		child := tc.a.child_node(&node, i)
+		if child.kind != .param {
+			if tc.prefix_param_scan {
+				break
+			}
+			continue
+		}
+		if ptypes.len == 0 && node.value.contains('.') && child.is_mut
+			&& !param_type_text_is_shared(child.typ) {
+			has_mut_receiver = true
+		}
+		param_type := child.typ
+		if param_type.starts_with('...') {
+			is_variadic = true
+			if param_type == '...' {
+				is_c_variadic = true
+			}
+		}
+		raw_parsed_param_type := if is_open_generic {
+			tc.parse_scope_param_type(param_type)
+		} else {
+			tc.parse_resolution_type(param_type)
+		}
+		ptypes << if child.is_mut {
+			mut_param_semantic_type(raw_parsed_param_type)
+		} else {
+			raw_parsed_param_type
+		}
+		param_texts << param_type
+		shared_params << param_type_text_is_shared(child.typ)
+	}
+	has_forwardable_ctx := tc.fn_is_veb_app_handler(node)
+	ptypes = tc.fn_param_types_with_implicit_veb_ctx(node, ptypes)
+	shared_params = tc.fn_shared_params_with_implicit_veb_ctx(node, shared_params)
+	return Pass2FnPrep{
+		prepared:            true
+		ret_type:            ret_type
+		ptypes:              ptypes
+		param_texts:         param_texts
+		shared_params:       shared_params
+		is_variadic:         is_variadic
+		is_c_variadic:       is_c_variadic
+		has_mut_receiver:    has_mut_receiver
+		has_forwardable_ctx: has_forwardable_ctx
+	}
+}
+
+// collect_pass2_fn_range fills preps for every fn_decl whose top_level_idx
+// position lies in [start, end), tracking file/module context exactly like the
+// serial pass-2 walk — but without enter_file/enter_module, whose
+// file_modules bindings were all established in pass 1 (re-binding here would
+// race the shared map across shards for no state change).
+fn (mut tc TypeChecker) collect_pass2_fn_range(start int, end int, mut preps []Pass2FnPrep) {
+	for pi in start .. end {
+		tl_idx := tc.top_level_idx[pi]
+		node := tc.a.nodes[tl_idx]
+		match node.kind {
+			.file {
+				tc.cur_file = node.value
+				tc.cur_module = tc.file_modules[node.value] or { '' }
+			}
+			.module_decl {
+				tc.cur_module = node.value
+			}
+			.fn_decl {
+				preps[pi] = tc.compute_pass2_fn_prep(node)
+			}
+			else {}
+		}
+	}
+}
+
+// collect_pass2_fn_preps_parallel precomputes every fn_decl's pass-2 parse
+// work over the worker pool. Returns an empty array when the pool cannot be
+// used, in which case pass 2 computes inline as before. Worker forks own
+// private type caches and interners ("TypeIds stay local"), so the produced
+// Type values are plain data and the master's interner keeps its own
+// deterministic id order.
+fn (mut tc TypeChecker) collect_pass2_fn_preps_parallel() []Pass2FnPrep {
+	$if windows {
+		return []Pass2FnPrep{}
+	} $else {
+		n := tc.top_level_idx.len
+		if isnil(tc.a.worker_pool) || tc.a.worker_pool.size() == 0 || n < 2048
+			|| os.getenv('V3_NO_PAR_PASS2') != '' {
+			return []Pass2FnPrep{}
+		}
+		mut n_jobs := tc.a.worker_pool.size() + 1
+		if n_jobs > 10 {
+			n_jobs = 10
+		}
+		mut preps := []Pass2FnPrep{len: n}
+		// One cheap serial walk captures the (file, module) context active at
+		// each shard boundary.
+		mut ctx_files := []string{len: n_jobs}
+		mut ctx_modules := []string{len: n_jobs}
+		mut cur_file := ''
+		mut cur_module := ''
+		mut bi := 0
+		for pi in 0 .. n {
+			for bi < n_jobs && pi == n * bi / n_jobs {
+				ctx_files[bi] = cur_file
+				ctx_modules[bi] = cur_module
+				bi++
+			}
+			node := tc.a.nodes[tc.top_level_idx[pi]]
+			if node.kind == .file {
+				cur_file = node.value
+				cur_module = tc.file_modules[node.value] or { '' }
+			} else if node.kind == .module_decl {
+				cur_module = node.value
+			}
+		}
+		for bi < n_jobs {
+			ctx_files[bi] = cur_file
+			ctx_modules[bi] = cur_module
+			bi++
+		}
+		mut args := []Pass2PrepArgs{cap: n_jobs}
+		for ji in 0 .. n_jobs {
+			args << Pass2PrepArgs{
+				tc:          voidptr(tc)
+				start:       n * ji / n_jobs
+				end:         n * (ji + 1) / n_jobs
+				file:        ctx_files[ji]
+				module_name: ctx_modules[ji]
+				preps:       unsafe { voidptr(&preps) }
+			}
+		}
+		mut tasks := []workers.Task{cap: n_jobs}
+		for ji in 0 .. n_jobs {
+			tasks << workers.Task{
+				run:        pass2_fn_prep_thread
+				arg:        unsafe { voidptr(&args[ji]) }
+				force_sync: ji == 0
+			}
+		}
+		tc.a.worker_pool.run(tasks)
+		return preps
+	}
+}
+
+// finish_pass2_ancillary_registrations replays independent signature tables on
+// separate pool lanes. Each lane preserves source order within its own map, so
+// duplicate declarations retain the serial checker's last-write semantics.
+fn (mut tc TypeChecker) finish_pass2_ancillary_registrations() {
+	if tc.fn_ancillary_registrations.len == 0 {
+		return
+	}
+	$if windows {
+		for group in 0 .. 9 {
+			tc.apply_pass2_ancillary_group(group)
+		}
+	} $else {
+		if isnil(tc.a.worker_pool) || tc.a.worker_pool.size() < 2 {
+			for group in 0 .. 9 {
+				tc.apply_pass2_ancillary_group(group)
+			}
+		} else {
+			mut args := []Pass2AncillaryArgs{cap: 9}
+			mut tasks := []workers.Task{cap: 9}
+			for group in 0 .. 9 {
+				args << Pass2AncillaryArgs{
+					tc:    voidptr(tc)
+					group: group
+				}
+			}
+			for group in 0 .. 9 {
+				tasks << workers.Task{
+					run:        pass2_ancillary_thread
+					arg:        unsafe { voidptr(&args[group]) }
+					force_sync: group == 0
+				}
+			}
+			tc.a.worker_pool.run(tasks)
+		}
+	}
+	tc.fn_ancillary_registrations = []FnAncillaryRegistration{}
+	tc.fn_c_variadic_registrations = []FnNamePairRegistration{}
+	tc.fn_mut_receiver_registrations = []FnNamePairRegistration{}
+	tc.fn_ret_text_registrations = []FnTextRegistration{}
+	tc.visible_mutation_registrations = []VisibleMutationRegistration{}
+}
+
+fn (mut tc TypeChecker) apply_pass2_ancillary_group(group int) {
+	if group < 3 {
+		for registration in tc.fn_ancillary_registrations {
+			match group {
+				0 {
+					if registration.shared_params.len > 0 {
+						tc.fn_shared_params[registration.name] = registration.shared_params
+					} else if tc.fn_shared_params.len > 0 {
+						tc.fn_shared_params.delete(registration.name)
+					}
+				}
+				1 {
+					tc.fn_variadic[registration.name] = registration.is_variadic
+					if registration.implicit_veb_ctx || tc.fn_implicit_veb_ctx.len > 0 {
+						tc.fn_implicit_veb_ctx[registration.name] = registration.implicit_veb_ctx
+					}
+				}
+				else {
+					tc.add_receiver_method_suffix_index(registration.name)
+				}
+			}
+		}
+	}
+	if group == 3 {
+		for registration in tc.fn_c_variadic_registrations {
+			tc.register_c_variadic_fn_with_lowered(registration.name, registration.lowered_name)
+		}
+	} else if group == 4 {
+		for registration in tc.fn_mut_receiver_registrations {
+			tc.register_mut_receiver_method_with_lowered(registration.name,
+				registration.lowered_name)
+		}
+	} else if group == 5 {
+		for registration in tc.fn_ret_text_registrations {
+			tc.fn_ret_type_texts[registration.name] = registration.text
+		}
+	} else if group == 6 {
+		for registration in tc.visible_mutation_registrations {
+			tc.register_visible_mutation_fn_decl_with_lowered(registration.idx,
+				registration.module_name, registration.qname, registration.source_name,
+				registration.c_qname, registration.c_source_name)
+		}
+	} else if group == 7 {
+		for registration in tc.fn_ancillary_registrations {
+			tc.fn_ret_types[registration.name] = registration.ret_type
+		}
+	} else if group == 8 {
+		for registration in tc.fn_ancillary_registrations {
+			if registration.write_file {
+				tc.fn_type_files[registration.name] = registration.file
+			}
+		}
+	}
+}
+
 $if !windows {
+	struct Pass2AncillaryArgs {
+		tc    voidptr
+		group int
+	}
+
+	fn pass2_ancillary_thread(arg voidptr) voidptr {
+		a := unsafe { &Pass2AncillaryArgs(arg) }
+		mut tc := unsafe { &TypeChecker(a.tc) }
+		tc.apply_pass2_ancillary_group(a.group)
+		return unsafe { nil }
+	}
+
+	struct Pass2PrepArgs {
+		tc          voidptr // master &TypeChecker
+		start       int
+		end         int
+		file        string
+		module_name string
+		preps       voidptr // &[]Pass2FnPrep — shards fill disjoint positions
+	}
+
+	fn pass2_fn_prep_thread(arg voidptr) voidptr {
+		a := unsafe { &Pass2PrepArgs(arg) }
+		master := unsafe { &TypeChecker(a.tc) }
+		mut view := master.fork_for_parallel_transform(master.a)
+		view.cur_file = a.file
+		view.cur_module = a.module_name
+		mut preps := unsafe { &[]Pass2FnPrep(a.preps) }
+		view.collect_pass2_fn_range(a.start, a.end, mut *preps)
+		return unsafe { nil }
+	}
+
+	// UnusedAliveScanArgs shards the unused-declaration reference scan: each
+	// task probes its node range against the shared read-only candidate-key
+	// maps and records hits in a private alive array.
+	struct UnusedAliveScanArgs {
+		tc         voidptr // &TypeChecker
+		fn_keys    map[string][]int
+		const_keys map[string][]int
+		start      int
+		end        int
+	mut:
+		alive []bool
+	}
+
+	fn unused_alive_scan_thread(arg voidptr) voidptr {
+		mut a := unsafe { &UnusedAliveScanArgs(arg) }
+		tc := unsafe { &TypeChecker(a.tc) }
+		tc.scan_unused_alive_range(a.fn_keys, a.const_keys, a.start, a.end, mut a.alive)
+		return unsafe { nil }
+	}
+
 	struct CheckChunkArgs {
 		worker        voidptr
 		items_ptr     voidptr
 		scope_enabled bool
+		index         int
 	mut:
 		scope voidptr
 	}
 
 	fn check_chunk_thread(arg voidptr) voidptr {
 		mut a := unsafe { &CheckChunkArgs(arg) }
+		cksw := time.new_stopwatch()
 		a.scope = check_worker_scope_begin(a.scope_enabled)
 		mut w := unsafe { &TypeChecker(a.worker) }
 		items := unsafe { &[]CheckWorkItem(a.items_ptr) }
 		if a.scope_enabled {
-			w.check_scoped_batches(*items, scoped_check_worker_batches)
+			configured_batches := os.getenv('V3_CHECK_WORKER_BATCHES').int()
+			batch_limit := if configured_batches > 0 {
+				configured_batches
+			} else if os.getenv('V3_NO_COARSER_CHECK_BATCHES') != '' {
+				scoped_check_worker_batches
+			} else {
+				scoped_check_worker_batches / 12
+			}
+			w.check_scoped_batches(*items, batch_limit)
 		} else {
 			w.check_fn_items_serial(*items)
 		}
 		check_worker_scope_leave(a.scope)
+		w.timing_profile('  [ttime]     ck chunk ${a.index:2}  ${f64(cksw.elapsed().microseconds()) / 1000.0:7.2f} ms (items: ${items.len})')
 		return unsafe { nil }
 	}
 }
@@ -268,6 +677,94 @@ pub fn (mut tc TypeChecker) check_semantics_reachable(selected map[string]bool) 
 	tc.resolution_type_mode = true
 }
 
+// scan_unused_alive_range probes one node range against the candidate-key maps.
+@[direct_array_access]
+fn (tc &TypeChecker) scan_unused_alive_range(fn_keys map[string][]int, const_keys map[string][]int, start int, end int, mut alive []bool) {
+	for i in start .. end {
+		node := tc.a.nodes[i]
+		if node.kind in [.ident, .selector] && node.value.len > 0 {
+			if hits := const_keys[node.value] {
+				for cand_idx in hits {
+					alive[cand_idx] = true
+				}
+			}
+			short_name := short_name_view(node.value)
+			if short_name.len != node.value.len {
+				if hits := const_keys[short_name] {
+					for cand_idx in hits {
+						alive[cand_idx] = true
+					}
+				}
+			}
+		}
+		if node.kind == .call && node.children_count > 0 {
+			callee := tc.a.child_node(&node, 0)
+			if callee.value.len > 0 {
+				if hits := fn_keys[callee.value] {
+					for cand_idx in hits {
+						alive[cand_idx] = true
+					}
+				}
+				short_name := short_name_view(callee.value)
+				if short_name.len != callee.value.len {
+					if hits := fn_keys[short_name] {
+						for cand_idx in hits {
+							alive[cand_idx] = true
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+// scan_unused_candidate_references dispatches the reference scan over the
+// worker pool when available; hit-flag OR-merging keeps the result identical
+// to the serial scan regardless of shard boundaries.
+fn (mut tc TypeChecker) scan_unused_candidate_references(fn_keys map[string][]int, const_keys map[string][]int, mut alive []bool) {
+	$if windows {
+		tc.scan_unused_alive_range(fn_keys, const_keys, 0, tc.a.nodes.len, mut alive)
+		return
+	} $else {
+		n_nodes := tc.a.nodes.len
+		if isnil(tc.a.worker_pool) || tc.a.worker_pool.size() == 0 || n_nodes < 262_144 {
+			tc.scan_unused_alive_range(fn_keys, const_keys, 0, n_nodes, mut alive)
+			return
+		}
+		mut n_jobs := tc.a.worker_pool.size() + 1
+		if n_jobs > 8 {
+			n_jobs = 8
+		}
+		mut args := []UnusedAliveScanArgs{cap: n_jobs}
+		mut tasks := []workers.Task{cap: n_jobs}
+		for job in 0 .. n_jobs {
+			args << UnusedAliveScanArgs{
+				tc:         voidptr(tc)
+				fn_keys:    fn_keys
+				const_keys: const_keys
+				start:      n_nodes * job / n_jobs
+				end:        n_nodes * (job + 1) / n_jobs
+				alive:      []bool{len: alive.len}
+			}
+		}
+		for job in 0 .. n_jobs {
+			tasks << workers.Task{
+				run:        unused_alive_scan_thread
+				arg:        unsafe { voidptr(&args[job]) }
+				force_sync: job == 0
+			}
+		}
+		tc.a.worker_pool.run(tasks)
+		for arg in args {
+			for cand_idx in 0 .. alive.len {
+				if arg.alive[cand_idx] {
+					alive[cand_idx] = true
+				}
+			}
+		}
+	}
+}
+
 fn (mut tc TypeChecker) check_semantics_parallel() bool {
 	$if windows {
 		tc.check_semantics()
@@ -385,6 +882,9 @@ fn (mut tc TypeChecker) check_top_level_declaration_values() {
 // collection phase, where direct collect() callers expect them). The parallel
 // flow runs these on the master thread while the pool workers check bodies.
 fn (mut tc TypeChecker) check_top_level_declaration_signatures() {
+	if tc.valid_diagnostic_fast {
+		return
+	}
 	tc.check_top_level_declarations_filtered(false, true)
 }
 
@@ -519,7 +1019,8 @@ fn (mut tc TypeChecker) run_parallel_check(items []CheckWorkItem) bool {
 		rpsw := time.new_stopwatch()
 		mut checker_workers := []voidptr{cap: worker_count}
 		for _ in 0 .. worker_count {
-			w := tc.fork_for_parallel_check()
+			mut w := tc.fork_for_parallel_check()
+			w.verbose = tc.verbose
 			checker_workers << voidptr(w)
 		}
 		tc.timing_profile('  [ttime]   ck forks         ${f64(rpsw.elapsed().microseconds()) / 1000.0:7.2f} ms (workers: ${worker_count})')
@@ -535,6 +1036,7 @@ fn (mut tc TypeChecker) run_parallel_check(items []CheckWorkItem) bool {
 				worker:        worker
 				items_ptr:     unsafe { voidptr(&chunks[ci]) }
 				scope_enabled: tc.scope_parallel_check_workers
+				index:         ci
 			}
 		}
 		// The master checks its own chunk under the same range discipline as the
@@ -836,6 +1338,7 @@ pub fn (mut tc TypeChecker) check_concrete_fn_semantics(fn_idx int, file string,
 }
 
 fn (mut tc TypeChecker) check_fn_decl_semantics(fn_idx int, node flat.Node, file string, module_name string) {
+	fast_valid_build := tc.building_v_fast
 	saved_fn_context := tc.fn_context
 	tc.fn_context = new_function_check_context()
 	inferred_generic_params := tc.infer_decl_generic_param_names(node)
@@ -849,7 +1352,7 @@ fn (mut tc TypeChecker) check_fn_decl_semantics(fn_idx int, node flat.Node, file
 	}
 	tc.cur_file = file
 	tc.cur_module = module_name
-	if module_name in ['', 'main'] && !node.value.contains('.') {
+	if !fast_valid_build && module_name in ['', 'main'] && !node.value.contains('.') {
 		if visibility := tc.declaration_visibility['builtin.${node.value}'] {
 			if visibility.is_pub {
 				tc.record_error_at(.duplicate_decl,
@@ -869,7 +1372,9 @@ fn (mut tc TypeChecker) check_fn_decl_semantics(fn_idx int, node flat.Node, file
 	tc.cur_fn_ret_type = tc.parse_type(checked_return_type)
 	tc.fn_context.return_type = tc.cur_fn_ret_type
 	tc.fn_context.node_id = fn_idx
-	tc.index_local_decl_rhs(flat.NodeId(fn_idx))
+	if !fast_valid_build {
+		tc.index_local_decl_rhs(flat.NodeId(fn_idx))
+	}
 	tc.fn_context.concrete_generic_receiver_specialization =
 		fn_value_is_concrete_generic_receiver_specialization(node.value)
 	tc.cur_fn_node_id = fn_idx
@@ -878,66 +1383,71 @@ fn (mut tc TypeChecker) check_fn_decl_semantics(fn_idx int, node flat.Node, file
 	tc.capturing_fn_literal_locals.clear()
 	tc.capturing_fn_literal_local_depth.clear()
 	tc.capturing_fn_literal_return_unsupported.clear()
-	tc.check_fn_receiver_and_operator_return(node, flat.NodeId(fn_idx))
+	if !fast_valid_build {
+		tc.check_fn_receiver_and_operator_return(node, flat.NodeId(fn_idx))
+	}
 	$if ownership ? {
 		tc.ownership_begin_fn(node)
 	}
 	tc.push_scope()
-	if module_name != 'builtin' && node.value.ends_with('.map') && node.children_count > 0 {
+	if !fast_valid_build && module_name != 'builtin' && node.value.ends_with('.map')
+		&& node.children_count > 0 {
 		receiver := tc.a.child_node(&node, 0)
 		if receiver.kind == .param && receiver.typ.trim_left('&').starts_with('[]') {
 			tc.record_error_at(.call_arg_mismatch, 'method overrides built-in array method',
 				flat.NodeId(fn_idx), tc.fn_declaration_diagnostic_pos(node))
 		}
 	}
-	mut parameter_names := map[string]bool{}
 	mut duplicate_parameter_ids := map[int]bool{}
-	for pi in 0 .. node.children_count {
-		param_id := tc.a.child(&node, pi)
-		param := tc.a.node(param_id)
-		if param.kind == .param {
-			if param.value.len > 0 && param.value != '_' {
-				if parameter_names[param.value] {
-					tc.record_error_at(.duplicate_decl,
-						'redefinition of parameter `${param.value}`', param_id,
-						tc.node_value_diagnostic_pos(param_id))
-					duplicate_parameter_ids[int(param_id)] = true
+	if !fast_valid_build {
+		mut parameter_names := map[string]bool{}
+		for pi in 0 .. node.children_count {
+			param_id := tc.a.child(&node, pi)
+			param := tc.a.node(param_id)
+			if param.kind == .param {
+				if param.value.len > 0 && param.value != '_' {
+					if parameter_names[param.value] {
+						tc.record_error_at(.duplicate_decl,
+							'redefinition of parameter `${param.value}`', param_id,
+							tc.node_value_diagnostic_pos(param_id))
+						duplicate_parameter_ids[int(param_id)] = true
+					} else {
+						parameter_names[param.value] = true
+					}
+				}
+				if param.is_mut {
+					implicit_mut_reference := param.op != .amp && param.typ.starts_with('&')
+					diagnostic_type_text := if implicit_mut_reference {
+						param.typ[1..]
+					} else {
+						param.typ
+					}
+					raw_param_type := tc.parse_scope_param_type(diagnostic_type_text)
+					if tc.is_params_struct_type(raw_param_type) {
+						tc.record_error_at(.call_arg_mismatch,
+							'declaring a mutable parameter that accepts a struct with the `@[params]` attribute is not allowed',
+							param_id, tc.type_diagnostic_pos(param_id, diagnostic_type_text))
+					}
+					param_type := unalias_type(raw_param_type)
+					if !is_specialized && !mut_param_type_is_allowed(raw_param_type) {
+						type_name := param_type.name()
+						tc.record_error_at(.call_arg_mismatch,
+							'mutable arguments are only allowed for arrays, interfaces, maps, pointers, structs or their aliases\nreturn values instead: `fn foo(mut n ${type_name}) {` => `fn foo(n ${type_name}) ${type_name} {`',
+							param_id, tc.type_diagnostic_pos(param_id, diagnostic_type_text))
+					}
+				}
+				tc.check_reserved_parameter_name(param_id)
+				if param.op == .dot {
+					tc.check_import_symbol_conflict_at(param_id, param.value, tc.fn_receiver_param_diagnostic_pos(node,
+						param.value))
 				} else {
-					parameter_names[param.value] = true
+					tc.check_import_symbol_conflict(param_id, param.value)
 				}
+				tc.check_module_name_conflict(param_id, param.value)
 			}
-			if param.is_mut {
-				implicit_mut_reference := param.op != .amp && param.typ.starts_with('&')
-				diagnostic_type_text := if implicit_mut_reference {
-					param.typ[1..]
-				} else {
-					param.typ
-				}
-				raw_param_type := tc.parse_scope_param_type(diagnostic_type_text)
-				if tc.is_params_struct_type(raw_param_type) {
-					tc.record_error_at(.call_arg_mismatch,
-						'declaring a mutable parameter that accepts a struct with the `@[params]` attribute is not allowed',
-						param_id, tc.type_diagnostic_pos(param_id, diagnostic_type_text))
-				}
-				param_type := unalias_type(raw_param_type)
-				if !is_specialized && !mut_param_type_is_allowed(raw_param_type) {
-					type_name := param_type.name()
-					tc.record_error_at(.call_arg_mismatch,
-						'mutable arguments are only allowed for arrays, interfaces, maps, pointers, structs or their aliases\nreturn values instead: `fn foo(mut n ${type_name}) {` => `fn foo(n ${type_name}) ${type_name} {`',
-						param_id, tc.type_diagnostic_pos(param_id, diagnostic_type_text))
-				}
-			}
-			tc.check_reserved_parameter_name(param_id)
-			if param.op == .dot {
-				tc.check_import_symbol_conflict_at(param_id, param.value, tc.fn_receiver_param_diagnostic_pos(node,
-					param.value))
-			} else {
-				tc.check_import_symbol_conflict(param_id, param.value)
-			}
-			tc.check_module_name_conflict(param_id, param.value)
 		}
 	}
-	if !node.value.contains('.') && tc.has_active_import(node.value) {
+	if !fast_valid_build && !node.value.contains('.') && tc.has_active_import(node.value) {
 		tc.record_error_at(.duplicate_decl, 'duplicate of an import symbol `${node.value}`',
 			flat.NodeId(fn_idx), tc.fn_declaration_diagnostic_pos(node))
 	}
@@ -950,7 +1460,9 @@ fn (mut tc TypeChecker) check_fn_decl_semantics(fn_idx int, node flat.Node, file
 		tc.insert_fn_param_binding(p)
 	}
 	tc.insert_implicit_veb_ctx(node)
-	tc.check_veb_app_method_params(flat.NodeId(fn_idx), node)
+	if !fast_valid_build {
+		tc.check_veb_app_method_params(flat.NodeId(fn_idx), node)
+	}
 	// Open generic declarations are checked when they are instantiated.  Walking every
 	// template in a selected module diagnoses names that only exist after comptime
 	// expansion (and even dead generic helpers), unlike the reference compiler.
@@ -959,42 +1471,46 @@ fn (mut tc TypeChecker) check_fn_decl_semantics(fn_idx int, node flat.Node, file
 	} else {
 		tc.infer_decl_generic_params(node)
 	}
-	qname := checker_qualified_fn_name(module_name, node.value)
 	signature_has_bare_generic_type := tc.fn_decl_has_bare_generic_signature_type(node)
 	should_check_generic_body := generic_params.len == 0
 	if should_check_generic_body && !signature_has_bare_generic_type {
 		tc.check_fn_body(node)
-		tc.check_recursive_str_calls(flat.NodeId(fn_idx), node)
-	} else if generic_params.len > 0 && node.value.contains('.')
+		if !fast_valid_build {
+			tc.check_recursive_str_calls(flat.NodeId(fn_idx), node)
+		}
+	} else if generic_params.len > 0 && node.value.contains('.') && !fast_valid_build
 		&& tc.should_diagnose(flat.NodeId(fn_idx)) {
 		tc.check_deferred_generic_receiver_comparisons(node)
 	}
-	tc.check_noreturn_fn_semantics(flat.NodeId(fn_idx), node, qname)
-	tc.check_unreachable_after_noreturn_call(node)
-	if !is_specialized {
-		if tc.should_diagnose(flat.NodeId(fn_idx)) {
-			tc.record_unused_fn_vars(node)
-			tc.record_unused_fn_params(node)
-			tc.record_unused_fn_labels(node)
+	if !fast_valid_build {
+		qname := checker_qualified_fn_name(module_name, node.value)
+		tc.check_noreturn_fn_semantics(flat.NodeId(fn_idx), node, qname)
+		tc.check_unreachable_after_noreturn_call(node)
+		if !is_specialized {
+			if tc.should_diagnose(flat.NodeId(fn_idx)) {
+				tc.record_unused_fn_vars(node)
+				tc.record_unused_fn_params(node)
+				tc.record_unused_fn_labels(node)
+			}
+			tc.check_fn_bare_generic_fntype_params(node)
 		}
-		tc.check_fn_bare_generic_fntype_params(node)
+		is_disabled_stub := node.value in tc.a.disabled_fns
+		// A terminal propagation whose payload still contains a generic placeholder
+		// and return control flow guarded by a generic `$if` are lowered against the
+		// concrete specialization. Keep those narrow deferrals without suppressing
+		// ordinary generic fallthrough.
+		has_deferred_generic_return := generic_params.len > 0
+			&& tc.fn_has_deferred_generic_return(node, generic_params)
+		if tc.fn_context.return_type !is Unknown
+			&& !type_allows_implicit_return(tc.fn_context.return_type)
+			&& !tc.fn_body_definitely_returns(node) && !is_disabled_stub
+			&& !has_deferred_generic_return && tc.should_diagnose(flat.NodeId(fn_idx)) {
+			message := 'missing return at end of function `${node.value.all_after_last('.')}`'
+			tc.record_error_at(.return_mismatch, message, flat.NodeId(fn_idx),
+				tc.fn_declaration_diagnostic_pos(node))
+		}
 	}
 	tc.fn_context.node_id = -1
-	is_disabled_stub := node.value in tc.a.disabled_fns
-	// A terminal propagation whose payload still contains a generic placeholder
-	// and return control flow guarded by a generic `$if` are lowered against the
-	// concrete specialization. Keep those narrow deferrals without suppressing
-	// ordinary generic fallthrough.
-	has_deferred_generic_return := generic_params.len > 0
-		&& tc.fn_has_deferred_generic_return(node, generic_params)
-	if tc.fn_context.return_type !is Unknown
-		&& !type_allows_implicit_return(tc.fn_context.return_type)
-		&& !tc.fn_body_definitely_returns(node) && !is_disabled_stub && !has_deferred_generic_return
-		&& tc.should_diagnose(flat.NodeId(fn_idx)) {
-		message := 'missing return at end of function `${node.value.all_after_last('.')}`'
-		tc.record_error_at(.return_mismatch, message, flat.NodeId(fn_idx),
-			tc.fn_declaration_diagnostic_pos(node))
-	}
 	tc.pop_scope()
 	$if ownership ? {
 		tc.ownership_end_fn()

--- a/vlib/v3/types/checker_tail.v
+++ b/vlib/v3/types/checker_tail.v
@@ -1386,14 +1386,14 @@ fn (tc &TypeChecker) mut_param_binding_matches_lvalue(name string) bool {
 	}
 	if param_owner := tc.fn_context.mut_param_owners[name] {
 		if owner := tc.cur_scope.lookup_owner(name) {
-			return owner.scope == param_owner.scope && owner.index == param_owner.index
-				&& owner.generation == param_owner.generation
+			return voidptr(owner.scope) == voidptr(param_owner.scope)
+				&& owner.index == param_owner.index && owner.generation == param_owner.generation
 		}
 	}
 	if local_owner := tc.fn_context.mut_local_owners[name] {
 		if owner := tc.cur_scope.lookup_owner(name) {
-			return owner.scope == local_owner.scope && owner.index == local_owner.index
-				&& owner.generation == local_owner.generation
+			return voidptr(owner.scope) == voidptr(local_owner.scope)
+				&& owner.index == local_owner.index && owner.generation == local_owner.generation
 		}
 	}
 	return false
@@ -1405,7 +1405,7 @@ fn (tc &TypeChecker) mut_value_param_binding_matches_lvalue(name string) bool {
 	}
 	param_owner := tc.fn_context.mut_param_owners[name] or { return false }
 	owner := tc.cur_scope.lookup_owner(name) or { return false }
-	if owner.scope != param_owner.scope || owner.index != param_owner.index
+	if voidptr(owner.scope) != voidptr(param_owner.scope) || owner.index != param_owner.index
 		|| owner.generation != param_owner.generation {
 		return false
 	}
@@ -1586,6 +1586,7 @@ fn (tc &TypeChecker) option_marker_payload_pos(node flat.Node) token.Pos {
 }
 
 // check_return validates check return state for types.
+@[direct_array_access]
 fn (mut tc TypeChecker) check_return(id flat.NodeId, node flat.Node) {
 	// A returned method value escapes the function. Per-instance closure contexts make
 	// value receivers safe, but mutable methods borrowing addressable stack receivers
@@ -3159,10 +3160,55 @@ fn (tc &TypeChecker) expr_has_option_result_handler(id flat.NodeId) bool {
 	return false
 }
 
+fn (mut tc TypeChecker) check_valid_call_preamble(id flat.NodeId, node flat.Node) bool {
+	if node.children_count == 0 {
+		return false
+	}
+	if tc.check_json_magic_call(id, node) {
+		return true
+	}
+	callee_id := tc.a.child(&node, 0)
+	callee := tc.a.node(callee_id)
+	if callee.kind in [.call, .fn_literal, .lambda_expr] {
+		tc.check_node(callee_id)
+	}
+	if callee.kind == .selector && callee.value.starts_with('$') && callee.value.len > 1 {
+		tc.check_dynamic_comptime_method_call(id, node, callee)
+		return true
+	}
+	if callee.kind == .selector && callee.value == '$' {
+		for i in 1 .. node.children_count {
+			tc.check_node(tc.call_arg_value(tc.a.child(&node, i)))
+		}
+		return true
+	}
+	if callee.kind == .selector && callee.children_count > 0 && callee.value == 'sort' {
+		receiver_id := tc.a.child(callee, 0)
+		receiver_type := unalias_and_unwrap_pointer_type(tc.resolve_type(receiver_id))
+		if receiver_type is Array || receiver_type is ArrayFixed {
+			tc.check_array_sort_call(id, node, callee)
+			return true
+		}
+	}
+	if callee.kind == .selector && callee.children_count > 0 {
+		base := tc.a.child_node(callee, 0)
+		if base.kind == .none_expr && callee.value == 'str' {
+			tc.remember_resolved_call(id, 'none.str')
+			tc.register_synth_type(id, Type(string_))
+			return true
+		}
+	}
+	return false
+}
+
 // check_call validates check call state for types.
 @[direct_array_access]
 fn (mut tc TypeChecker) check_call(id flat.NodeId, node flat.Node) {
-	if node.children_count > 0 {
+	if tc.valid_resolution_fast {
+		if tc.check_valid_call_preamble(id, node) {
+			return
+		}
+	} else if node.children_count > 0 {
 		if tc.check_json_magic_call(id, node) {
 			return
 		}
@@ -3741,6 +3787,10 @@ fn (mut tc TypeChecker) check_call(id flat.NodeId, node flat.Node) {
 		}
 		if info.return_type !is Void && info.return_type !is Unknown {
 			tc.remember_expr_type(id, info.return_type)
+		}
+		if tc.valid_resolution_fast {
+			tc.check_valid_call_arg_types(id, node, info)
+			return
 		}
 		if tc.check_call_privacy(id, node, info) {
 			return
@@ -5473,6 +5523,12 @@ fn (tc &TypeChecker) cur_fn_is_generic_template() bool {
 	}
 	for i in 0 .. fn_node.children_count {
 		child := tc.a.child_node(&fn_node, i)
+		if child.kind != .param {
+			if tc.prefix_param_scan {
+				break
+			}
+			continue
+		}
 		if child.kind == .param && child.typ.len > 0
 			&& tc.type_text_has_generic_placeholder(child.typ) {
 			return true
@@ -5875,6 +5931,9 @@ fn (tc &TypeChecker) known_sum_constructor_name(name string) ?string {
 
 // should_diagnose reports whether should diagnose applies in types.
 fn (tc &TypeChecker) should_diagnose(id flat.NodeId) bool {
+	if tc.valid_diagnostic_fast {
+		return false
+	}
 	if int(id) < 0 || int(id) < tc.a.user_code_start {
 		return false
 	}
@@ -6038,7 +6097,37 @@ fn (tc &TypeChecker) imported_fn_key(module_name string, fn_name string) ?string
 }
 
 // resolve_call_info resolves resolve call info information for types.
+@[direct_array_access]
 fn (mut tc TypeChecker) resolve_call_info(id flat.NodeId, node flat.Node) ?CallInfo {
+	idx := int(id)
+	mut memo := tc.body_resolve_memo
+	if tc.memo_call_info && !isnil(memo) && memo.active && idx >= memo.lo && idx <= memo.hi {
+		slot := idx & 2047
+		if memo.call_generations[slot] == memo.call_generation && memo.call_ids[slot] == idx {
+			return memo.call_infos[slot]
+		}
+		info := tc.resolve_call_info_uncached(id, node) or { return none }
+		if info.params_known && !type_contains_unknown(info.return_type) {
+			mut stable := true
+			for param in info.params {
+				if type_contains_unknown(param) {
+					stable = false
+					break
+				}
+			}
+			if stable {
+				memo.call_ids[slot] = idx
+				memo.call_infos[slot] = info
+				memo.call_generations[slot] = memo.call_generation
+			}
+		}
+		return info
+	}
+	return tc.resolve_call_info_uncached(id, node)
+}
+
+@[direct_array_access]
+fn (mut tc TypeChecker) resolve_call_info_uncached(id flat.NodeId, node flat.Node) ?CallInfo {
 	if node.children_count == 0 {
 		return none
 	}
@@ -8566,15 +8655,31 @@ fn (tc &TypeChecker) cache_visible_mutation_fn_decl(key string, decl VisibleMuta
 	}
 }
 
-fn (tc &TypeChecker) register_visible_mutation_fn_decl(idx int, module_name string, qname string, source_name string) {
+fn (mut tc TypeChecker) register_visible_mutation_fn_decl(idx int, module_name string, qname string, source_name string) {
+	c_qname := tc.cached_c_name(qname)
+	c_source_name := tc.cached_c_name(source_name)
+	tc.register_visible_mutation_fn_decl_with_lowered(idx, module_name, qname, source_name,
+		c_qname, c_source_name)
+}
+
+fn (mut tc TypeChecker) register_visible_mutation_fn_decl_with_lowered(idx int, module_name string, qname string, source_name string, c_qname string, c_source_name string) {
+	if tc.defer_fn_ancillary {
+		tc.visible_mutation_registrations << VisibleMutationRegistration{
+			idx:           idx
+			module_name:   module_name
+			qname:         qname
+			source_name:   source_name
+			c_qname:       c_qname
+			c_source_name: c_source_name
+		}
+		return
+	}
 	decl := VisibleMutationFnDecl{
 		idx: idx
 		mod: module_name
 	}
 	normalized_qname := visible_mutation_fn_lookup_name(qname)
 	normalized_source_name := visible_mutation_fn_lookup_name(source_name)
-	c_qname := tc.cached_c_name(qname)
-	c_source_name := tc.cached_c_name(source_name)
 	mut candidates := [normalized_qname, normalized_source_name]
 	// C declarations are referenced semantically through their `C.` name. Their
 	// raw linker symbol can collide with an ordinary V function (for example
@@ -9701,6 +9806,92 @@ fn (tc &TypeChecker) struct_field_has_shared_elements(struct_name string, field_
 }
 
 // check_call_arg_types validates check call arg types state for types.
+@[direct_array_access]
+fn (mut tc TypeChecker) check_valid_call_arg_types(id flat.NodeId, node flat.Node, info CallInfo) {
+	if node.children_count == 0 {
+		return
+	}
+	if tc.check_builtin_map_call_args(id, node, info)
+		|| tc.check_builtin_array_call_args(id, node, info) {
+		return
+	}
+	if info.has_receiver && info.params.len > 0 {
+		mut callee := tc.a.child_node(&node, 0)
+		if callee.kind == .index && callee.children_count > 0 {
+			callee = tc.a.child_node(callee, 0)
+		}
+		if callee.kind == .selector && callee.children_count > 0 {
+			tc.check_node(tc.a.child(callee, 0))
+		}
+	}
+	if !info.params_known {
+		dsl_name := tc.unresolved_array_dsl_call_name(node)
+		if dsl_name.len > 0 {
+			tc.push_array_dsl_scope(node, dsl_name)
+		}
+		for i in 1 .. node.children_count {
+			tc.check_node(tc.call_arg_value(tc.a.child(&node, i)))
+		}
+		if dsl_name.len > 0 {
+			tc.pop_scope()
+		}
+		return
+	}
+	recv_extra := if info.has_receiver { 1 } else { 0 }
+	actual_count := node.children_count - 1 - info.arg_offset + recv_extra
+	ctx_count := if info.has_implicit_veb_ctx { 1 } else { 0 }
+	ctx_omitted := ctx_count > 0 && actual_count < info.params.len
+	mut expanded_arg_offset := 0
+	for i in 1 + info.arg_offset .. node.children_count {
+		raw_arg := tc.a.child_node(&node, i)
+		arg_id := tc.call_arg_value(tc.a.child(&node, i))
+		if raw_arg.kind == .field_init {
+			if expected := tc.params_field_expected_type(raw_arg.value, info) {
+				tc.check_node_with_expected_context(arg_id, expected)
+			} else {
+				tc.check_node(arg_id)
+			}
+			continue
+		}
+		arg_shift := if ctx_omitted { ctx_count } else { 0 }
+		param_idx := i - 1 - info.arg_offset + recv_extra + arg_shift + expanded_arg_offset
+		check_arg_id := tc.spread_arg_value(arg_id) or { arg_id }
+		has_dsl_scope := tc.call_arg_needs_array_dsl_scope(info.name, param_idx)
+		if has_dsl_scope {
+			tc.push_array_dsl_scope(node, info.name)
+		}
+		mut has_expected := param_idx >= 0 && param_idx < info.params.len
+		mut expected := Type(void_)
+		if has_expected {
+			expected = info.params[param_idx]
+		} else if info.is_variadic && info.params.len > 0 {
+			has_expected = true
+			expected = info.params[info.params.len - 1]
+		}
+		if has_expected {
+			if info.is_variadic && expected is Array && tc.spread_arg_value(arg_id) == none {
+				expected = expected.elem_type
+			}
+			check_node := tc.a.node(check_arg_id)
+			if check_node.kind == .array_literal && check_node.children_count == 0
+				&& check_node.typ.len == 0 && array_like_elem_type(expected) != none {
+				tc.register_synth_type(check_arg_id, expected)
+			}
+			tc.check_node_with_expected_context(check_arg_id, expected)
+		} else {
+			tc.check_node(check_arg_id)
+		}
+		if multi := tc.cached_expr_type(check_arg_id) {
+			if !info.is_variadic && multi is MultiReturn {
+				expanded_arg_offset += multi.types.len - 1
+			}
+		}
+		if has_dsl_scope {
+			tc.pop_scope()
+		}
+	}
+}
+
 fn (mut tc TypeChecker) check_call_arg_types(id flat.NodeId, node flat.Node, info0 CallInfo) {
 	info := tc.specialized_plain_generic_call_info(node, info0)
 	if node.children_count == 0 {
@@ -14115,6 +14306,7 @@ fn struct_type_from_type(typ Type) ?Struct {
 	return none
 }
 
+@[direct_array_access]
 fn (tc &TypeChecker) selector_declared_value_type(node flat.Node) ?Type {
 	if node.children_count == 0 {
 		return none
@@ -15075,8 +15267,13 @@ fn (tc &TypeChecker) call_display_name(node flat.Node) string {
 }
 
 // check_if_expr validates check if expr state for types.
+@[direct_array_access]
 fn (mut tc TypeChecker) check_if_expr(id flat.NodeId, node flat.Node) {
 	if node.children_count < 2 {
+		return
+	}
+	if tc.valid_resolution_fast {
+		tc.check_valid_if_expr(id, node)
 		return
 	}
 	value_context := !tc.is_statement_node(id) && tc.expression_node_used_as_value(id)
@@ -15294,6 +15491,70 @@ fn (mut tc TypeChecker) check_if_expr(id flat.NodeId, node flat.Node) {
 				}
 			}
 		}
+	}
+}
+
+// check_valid_if_expr preserves scopes, guard bindings, smartcasts, and branch
+// expression typing without rebuilding diagnostics for the valid self-host input.
+fn (mut tc TypeChecker) check_valid_if_expr(id flat.NodeId, node flat.Node) {
+	value_context := !tc.is_statement_node(id) && tc.expression_node_used_as_value(id)
+	cond_id := tc.a.child(&node, 0)
+	saved_mut_local_owners := tc.fn_context.mut_local_owners.clone()
+	defer {
+		tc.fn_context.mut_local_owners = saved_mut_local_owners.clone()
+	}
+	tc.enable_explicit_mut_smartcasts(cond_id)
+	guard_bindings := tc.check_condition(cond_id)
+	smartcasts := tc.extract_smartcasts(cond_id)
+	had_saved_smartcasts := tc.smartcasts.len > 0
+	saved_smartcasts := if had_saved_smartcasts {
+		clone_smartcasts(tc.smartcasts)
+	} else {
+		tc.smartcasts
+	}
+	for sc in smartcasts {
+		if valid_string_data(sc.name) {
+			tc.smartcasts[sc.name] = sc.typ
+		}
+	}
+	then_id := tc.a.child(&node, 1)
+	tc.push_scope()
+	for binding in guard_bindings {
+		owner := tc.cur_scope.insert_with_owner(binding.name, binding.typ)
+		tc.initialize_unknown_pointer_binding(owner, binding.typ)
+		if binding.is_mut {
+			tc.fn_context.mut_local_owners[binding.name] = owner
+		}
+	}
+	tc.check_branch_node(then_id, value_context)
+	if value_context {
+		tc.branch_tail_type(then_id)
+	}
+	tc.pop_scope()
+	if had_saved_smartcasts {
+		tc.smartcasts = clone_smartcasts(saved_smartcasts)
+	} else {
+		tc.smartcasts.clear()
+	}
+	if node.children_count > 2 {
+		else_id := tc.a.child(&node, 2)
+		for sc in tc.extract_else_branch_smartcasts(cond_id) {
+			if valid_string_data(sc.name) {
+				tc.smartcasts[sc.name] = sc.typ
+			}
+		}
+		if tc.valid_node_id(else_id) && tc.a.node(else_id).kind == .if_expr {
+			tc.fn_context.mut_local_owners = saved_mut_local_owners.clone()
+		}
+		tc.check_branch_node(else_id, value_context)
+		if value_context {
+			tc.branch_tail_type(else_id)
+		}
+	}
+	if had_saved_smartcasts {
+		tc.smartcasts = clone_smartcasts(saved_smartcasts)
+	} else {
+		tc.smartcasts.clear()
 	}
 }
 

--- a/vlib/v3/types/checker_tail_stmt.v
+++ b/vlib/v3/types/checker_tail_stmt.v
@@ -15,7 +15,9 @@ fn (mut tc TypeChecker) check_stmt_node(id flat.NodeId) {
 	}
 	tc.mark_statement_context(id)
 	tc.check_node(id)
-	tc.check_unused_expression_statement(id)
+	if !tc.valid_resolution_fast {
+		tc.check_unused_expression_statement(id)
+	}
 	$if ownership ? {
 		tc.ownership_after_stmt_node(id)
 	}
@@ -96,6 +98,7 @@ fn (tc &TypeChecker) expression_node_used_as_value(id flat.NodeId) bool {
 	return false
 }
 
+@[direct_array_access]
 fn (mut tc TypeChecker) check_statement_sequence(node flat.Node, body_start int, value_tail bool) {
 	had_saved_smartcasts := tc.smartcasts.len > 0
 	saved_smartcasts := if had_saved_smartcasts {
@@ -524,6 +527,7 @@ fn (mut tc TypeChecker) check_must_use_call(id flat.NodeId, node flat.Node) {
 		'return value must be used, ${kind} `${name}` was tagged with `@[must_use]`', id, pos)
 }
 
+@[direct_array_access]
 fn (mut tc TypeChecker) check_branch_node(id flat.NodeId, value_tail bool) {
 	if !tc.valid_node_id(id) {
 		return
@@ -669,6 +673,7 @@ fn (tc &TypeChecker) branch_has_value_tail(id flat.NodeId) bool {
 }
 
 // check_condition validates check condition state for types.
+@[direct_array_access]
 fn (mut tc TypeChecker) check_condition(cond_id flat.NodeId) []LocalBinding {
 	if int(cond_id) < 0 {
 		return []LocalBinding{}
@@ -681,6 +686,18 @@ fn (mut tc TypeChecker) check_condition(cond_id flat.NodeId) []LocalBinding {
 		lhs_id := tc.a.child(&cond, 0)
 		rhs_id := tc.a.child(&cond, 1)
 		mut bindings := tc.check_condition(lhs_id)
+		if tc.valid_resolution_fast {
+			saved_smartcasts := clone_smartcasts(tc.smartcasts)
+			for sc in tc.extract_smartcasts(lhs_id) {
+				if valid_string_data(sc.name) {
+					tc.smartcasts[sc.name] = sc.typ
+				}
+			}
+			bindings << tc.check_condition(rhs_id)
+			tc.smartcasts = clone_smartcasts(saved_smartcasts)
+			tc.check_infix(cond_id, cond)
+			return bindings
+		}
 		unsafe_alias_skipped_rhs := tc.fn_context.unsafe_reference_alias_owners.clone()
 		pointer_alias_skipped_rhs :=
 			clone_pointer_binding_value_keys(tc.fn_context.pointer_binding_value_keys)
@@ -718,6 +735,9 @@ fn (mut tc TypeChecker) check_condition(cond_id flat.NodeId) []LocalBinding {
 // check_bool_condition validates check bool condition state for types.
 fn (mut tc TypeChecker) check_bool_condition(cond_id flat.NodeId) {
 	tc.check_node(cond_id)
+	if tc.valid_resolution_fast {
+		return
+	}
 	cond_type := tc.resolve_type(cond_id)
 	if (cond_type is Unknown && cond_type.reason == 'invalid variable')
 		|| tc.expr_contains_invalid_variable_binding(cond_id) {
@@ -763,6 +783,10 @@ fn (tc &TypeChecker) condition_type_is_bool_like(typ Type) bool {
 }
 
 fn (mut tc TypeChecker) check_for_condition(cond_id flat.NodeId, _node flat.Node) {
+	if tc.valid_resolution_fast {
+		tc.check_node(cond_id)
+		return
+	}
 	condition := tc.a.node(cond_id)
 	if condition.kind == .match_stmt {
 		tc.check_stmt_node(cond_id)
@@ -5485,6 +5509,10 @@ fn (mut tc TypeChecker) check_selector(id flat.NodeId, node flat.Node) {
 	if node.children_count == 0 {
 		return
 	}
+	if tc.valid_resolution_fast {
+		tc.check_valid_selector(id, node)
+		return
+	}
 	if node.value == '$' {
 		tc.check_comptime_field_selector(id, node, '', ComptimeStaticFieldCases{})
 		return
@@ -6819,6 +6847,146 @@ fn (mut tc TypeChecker) check_index(id flat.NodeId, node flat.Node) {
 	tc.register_synth_type(id, tc.resolve_index_type(node))
 }
 
+fn (mut tc TypeChecker) check_valid_selector(id flat.NodeId, node flat.Node) {
+	if node.value == '$' {
+		tc.check_comptime_field_selector(id, node, '', ComptimeStaticFieldCases{})
+		return
+	}
+	if typ := tc.enum_selector_type(&node) {
+		tc.register_synth_type(id, typ)
+		return
+	}
+	base_id := tc.a.child(&node, 0)
+	base := tc.a.nodes[int(base_id)]
+	if base.kind == .selector && base.children_count > 0 {
+		module_node := tc.a.child_node(&base, 0)
+		if module_node.kind == .ident && tc.has_active_import(module_node.value)
+			&& base.value.len > 0 && base.value[0].is_capital() {
+			module_name := tc.resolve_import_alias(module_node.value) or { module_node.value }
+			if resolved_enum_name := tc.resolve_enum_name('${module_name}.${base.value}') {
+				tc.register_synth_type(base_id, Type(Enum{
+					name:    resolved_enum_name
+					is_flag: resolved_enum_name in tc.flag_enums
+				}))
+			}
+		}
+	}
+	if typ := tc.enum_selector_type(&node) {
+		tc.register_synth_type(id, typ)
+		return
+	}
+	if tc.is_namespace_selector(node, base) {
+		module_name := tc.resolve_import_alias(base.value) or { base.value }
+		if base.value == 'C' {
+			qname := 'C.${node.value}'
+			if qname !in tc.c_globals && qname !in tc.const_types && qname !in tc.fn_ret_types
+				&& node.value.len > 0 && node.value[0] >= `a` && node.value[0] <= `z`
+				&& !ascii_name_has_upper(node.value) {
+				if expected := tc.expected_context_for_expr(id) {
+					tc.c_globals[qname] = expected
+					tc.register_synth_type(id, expected)
+				} else {
+					tc.register_synth_type(id, Type(int_))
+				}
+				return
+			}
+			if c_upper_constant_is_pointer(qname) {
+				tc.register_synth_type(id, Type(voidptr_))
+				return
+			}
+		}
+		if key := tc.selector_fn_value_key(node) {
+			if typ := tc.fn_type_from_key(key) {
+				tc.register_synth_type(id, typ)
+				return
+			}
+		}
+		if typ := tc.enum_selector_type(&node) {
+			tc.register_synth_type(id, typ)
+			return
+		}
+		if typ := tc.global_type_for_selector(node) {
+			tc.register_synth_type(id, typ)
+			return
+		}
+		if typ := tc.const_type_for_selector(node) {
+			tc.register_synth_type(id, typ)
+			return
+		}
+		if base.value == 'C' {
+			tc.register_synth_type(id, if c_upper_constant_is_pointer('C.${node.value}') {
+				Type(voidptr_)
+			} else {
+				Type(int_)
+			})
+		}
+		_ = module_name
+		return
+	}
+	tc.check_storage_path_base_node(base_id)
+	mut base_type := tc.smartcast_type(base_id) or { tc.resolve_type(base_id) }
+	if base.kind == .ident {
+		if mut_base := tc.mut_param_base_for_current_ident(base.value, base_type) {
+			base_type = mut_base
+		}
+	}
+	tc.register_synth_type(base_id, base_type)
+	if smart_type := tc.smartcast_type(id) {
+		tc.register_synth_type(id, smart_type)
+		return
+	}
+	tc.record_valid_method_value(id, node, base_type)
+	if typ := tc.selector_type(id, node) {
+		tc.register_synth_type(id, typ)
+	}
+}
+
+fn (mut tc TypeChecker) record_valid_method_value(id flat.NodeId, node flat.Node, base_type Type) {
+	if !tc.expr_is_method_value(id) || tc.ident_is_call_callee_or_generic_base(id)
+		|| tc.fn_context.node_id < 0 {
+		return
+	}
+	clean_recv := unwrap_pointer(base_type)
+	if clean_recv is Struct {
+		if tc.struct_field_type(clean_recv.name, node.value) != none {
+			return
+		}
+		mut mkey := '${clean_recv.name}.${node.value}'
+		mut is_generic_method_value := false
+		if mkey !in tc.fn_param_types {
+			if ci := tc.resolve_generic_struct_method(clean_recv.name, node.value) {
+				tc.generic_method_value_info[mkey] = ci
+				mkey = ci.name
+				is_generic_method_value = true
+			}
+		}
+		if mkey in tc.fn_param_types || is_generic_method_value {
+			tc.method_values_by_fn[tc.fn_context.node_id] << mkey
+			concrete_mkey := '${clean_recv.name}.${node.value}'
+			if concrete_mkey != mkey {
+				tc.method_values_by_fn[tc.fn_context.node_id] << concrete_mkey
+			}
+		}
+		return
+	}
+	if clean_recv is Alias {
+		underlying := unalias_type(clean_recv)
+		has_field := underlying is Struct
+			&& tc.struct_field_type(underlying.name, node.value) != none
+		if !has_field {
+			if mkey := tc.alias_method_value_decl_key(clean_recv, node.value) {
+				tc.method_values_by_fn[tc.fn_context.node_id] << mkey
+			}
+		}
+		return
+	}
+	if clean_recv is Interface && tc.interface_field_type(clean_recv.name, node.value) == none {
+		if _ := tc.interface_receiver_method_call_info(clean_recv.name, node.value) {
+			tc.method_values_by_fn[tc.fn_context.node_id] << '${clean_recv.name}.${node.value}'
+		}
+	}
+}
+
 fn (tc &TypeChecker) map_key_type_compatible(actual Type, expected Type) bool {
 	clean_actual := unalias_type(actual)
 	clean_expected := unalias_type(expected)
@@ -7775,7 +7943,10 @@ fn (mut tc TypeChecker) resolve_expr(id flat.NodeId, expected Type) Type {
 		return actual
 	}
 	if tc.type_compatible(actual, expected) {
-		if actual.name() == expected.name() {
+		actual_w0, actual_w1, _ := type_value_words(&actual)
+		expected_w0, expected_w1, _ := type_value_words(&expected)
+		if (tc.raw_type_equality && actual_w0 == expected_w0 && actual_w1 == expected_w1)
+			|| tc.type_name(actual) == tc.type_name(expected) {
 			tc.register_synth_type(id, expected)
 			return expected
 		}
@@ -8281,10 +8452,25 @@ fn (tc &TypeChecker) enum_selector_type(node &flat.Node) ?Type {
 fn (tc &TypeChecker) type_compatible(actual Type, expected Type) bool {
 	actual_raw := actual
 	expected_raw := expected
-	if actual.name() == expected.name() {
+	// Canonical types dominate this path. Identical Type value bytes mean the
+	// same tag and payload, so avoid both spelling-cache lookups entirely.
+	if tc.raw_type_equality {
+		actual_w0, actual_w1, _ := type_value_words(&actual)
+		expected_w0, expected_w1, _ := type_value_words(&expected)
+		if actual_w0 == expected_w0 && actual_w1 == expected_w1 {
+			return true
+		}
+	}
+	// One memoized spelling per side: the former per-comparison name() calls
+	// composed fresh strings up to eight times per invocation (1.3M+ calls per
+	// self-host build), and equal compound types now compare via the shared
+	// memo instance's pointer fast path.
+	actual_name := tc.type_name(actual)
+	expected_name := tc.type_name(expected)
+	if actual_name == expected_name {
 		return true
 	}
-	if thread_handle_type_names_match(actual.name(), expected.name()) {
+	if thread_handle_type_names_match(actual_name, expected_name) {
 		return true
 	}
 	if fn_param_is_voidptr_type(actual) && fn_param_is_voidptr_type(expected) {
@@ -8302,11 +8488,11 @@ fn (tc &TypeChecker) type_compatible(actual Type, expected Type) bool {
 	if actual is FnType && expected is FnType {
 		return tc.fn_value_signature_compatible(Type(actual), Type(expected))
 	}
-	if (actual.name().contains('[') || expected.name().contains('['))
-		&& tc.generic_type_name_matches(actual.name(), expected.name()) {
+	if (actual_name.contains('[') || expected_name.contains('['))
+		&& tc.generic_type_name_matches(actual_name, expected_name) {
 		return true
 	}
-	if tc.sum_variant_type_for_pattern(expected.name(), actual.name()) != none {
+	if tc.sum_variant_type_for_pattern(expected_name, actual_name) != none {
 		return true
 	}
 	if actual is Alias && expected is Alias {
@@ -8361,10 +8547,9 @@ fn (tc &TypeChecker) type_compatible(actual Type, expected Type) bool {
 		}
 		return tc.type_compatible(actual, expected.base_type)
 	}
-	expected_named_interface := expected.name()
-	if expected_named_interface in tc.interface_names {
+	if expected_name in tc.interface_names {
 		return tc.type_implements_interface(actual, Interface{
-			name: expected_named_interface
+			name: expected_name
 		})
 	}
 	if expected is SumType {
@@ -8578,6 +8763,13 @@ fn (tc &TypeChecker) fn_param_compatible(actual Type, expected Type) bool {
 	if actual is Unknown || expected is Unknown {
 		return false
 	}
+	if tc.raw_type_equality {
+		actual_w0, actual_w1, _ := type_value_words(&actual)
+		expected_w0, expected_w1, _ := type_value_words(&expected)
+		if actual_w0 == expected_w0 && actual_w1 == expected_w1 {
+			return true
+		}
+	}
 	if tc.c_type(actual) == tc.c_type(expected) {
 		return true
 	}
@@ -8585,7 +8777,14 @@ fn (tc &TypeChecker) fn_param_compatible(actual Type, expected Type) bool {
 }
 
 fn (tc &TypeChecker) fn_return_compatible(actual Type, expected Type) bool {
-	if actual.name() == expected.name() {
+	if tc.raw_type_equality {
+		actual_w0, actual_w1, _ := type_value_words(&actual)
+		expected_w0, expected_w1, _ := type_value_words(&expected)
+		if actual_w0 == expected_w0 && actual_w1 == expected_w1 {
+			return true
+		}
+	}
+	if tc.type_name(actual) == tc.type_name(expected) {
 		return true
 	}
 	if tc.c_type(actual) == tc.c_type(expected) && tc.type_compatible(actual, expected) {
@@ -11417,6 +11616,13 @@ fn (tc &TypeChecker) method_call_info_signature_compatible_for_interface(actual 
 }
 
 fn (tc &TypeChecker) method_return_signature_compatible(actual Type, expected Type) bool {
+	if tc.raw_type_equality {
+		actual_w0, actual_w1, _ := type_value_words(&actual)
+		expected_w0, expected_w1, _ := type_value_words(&expected)
+		if actual_w0 == expected_w0 && actual_w1 == expected_w1 {
+			return true
+		}
+	}
 	if fn_return_canonical_type_name(actual) == fn_return_canonical_type_name(expected) {
 		return true
 	}
@@ -11812,7 +12018,7 @@ fn (tc &TypeChecker) bare_variant_name_matches(candidate string, declared string
 // type_matches_sum returns type matches sum data for TypeChecker.
 fn (tc &TypeChecker) type_matches_sum(actual Type, expected Type) bool {
 	if expected is SumType {
-		actual_name := actual.name()
+		actual_name := tc.type_name(actual)
 		if tc.sum_variant_type_for_pattern(expected.name, actual_name) != none {
 			return true
 		}
@@ -11821,7 +12027,7 @@ fn (tc &TypeChecker) type_matches_sum(actual Type, expected Type) bool {
 		for variant in variants {
 			concrete := tc.concrete_sum_variant_name(expected.name, variant)
 			variant_type := tc.parse_type(concrete)
-			if variant_type.name() == expected.name {
+			if tc.type_name(variant_type) == expected.name {
 				continue
 			}
 			if tc.type_compatible(actual, variant_type) {
@@ -12101,6 +12307,7 @@ fn (tc &TypeChecker) expr_key_part(id flat.NodeId) string {
 }
 
 // smartcast_type supports smartcast type handling for TypeChecker.
+@[direct_array_access]
 fn (tc &TypeChecker) smartcast_type(id flat.NodeId) ?Type {
 	idx := int(id)
 	if idx < 0 || idx >= tc.a.nodes.len || tc.a.nodes[idx].kind !in [.ident, .selector, .index] {
@@ -12354,13 +12561,15 @@ pub fn (tc &TypeChecker) parse_type(typ string) Type {
 	// cached until its complete semantic type exists; caching this symbolic
 	// recursive edge would otherwise leave the shallow placeholder as the
 	// permanent result for the alias.
-	if recursive_alias := tc.recursive_alias_reference(typ) {
-		return recursive_alias
+	if !isnil(tc.type_cache) && tc.type_cache.alias_parse_stack.len > 0 {
+		if recursive_alias := tc.recursive_alias_reference(typ) {
+			return recursive_alias
+		}
 	}
 	if tc.type_cache != unsafe { nil } && tc.type_cache.parse_enabled {
 		mut cache := unsafe { tc.type_cache }
-		if cached := parse_type_cache_get(mut cache, tc.cur_file, tc.cur_module, typ,
-			tc.fn_context.generic_params, tc.resolution_type_mode)
+		if cached := parse_type_cache_get_mode(mut cache, tc.cur_file, tc.cur_module, typ,
+			tc.fn_context.generic_params, tc.resolution_type_mode, tc.fast_parse_recent)
 		{
 			cache.parse_hits++
 			return cached
@@ -12374,14 +12583,54 @@ pub fn (tc &TypeChecker) parse_type(typ string) Type {
 		}
 		cache.parse_misses++
 		_, result := tc.intern_type(tc.parse_type_uncached(typ))
-		parse_type_cache_put(mut cache, tc.cur_file, tc.cur_module, typ,
-			tc.fn_context.generic_params, tc.resolution_type_mode, result)
+		if tc.fast_parse_recent {
+			parse_type_cache_put_recent(mut cache, tc.cur_file, tc.cur_module, typ,
+				tc.fn_context.generic_params, tc.resolution_type_mode, result)
+		} else {
+			parse_type_cache_put(mut cache, tc.cur_file, tc.cur_module, typ,
+				tc.fn_context.generic_params, tc.resolution_type_mode, result)
+		}
 		return result
 	}
 	if type_text_contains_typeof(typ) {
 		return tc.parse_type_uncached(typ)
 	}
 	_, result := tc.intern_type(tc.parse_type_uncached(typ))
+	return result
+}
+
+// parse_type_ref resolves a node annotation through its exact canonical text
+// identity. Context remains part of the key because an unqualified spelling
+// can denote different types in different files/modules.
+pub fn (tc &TypeChecker) parse_type_ref(typ string, text_id u16) Type {
+	if text_id == 0 || !tc.fast_type_text_refs || tc.type_cache == unsafe { nil }
+		|| !tc.type_cache.parse_enabled {
+		return tc.parse_type(typ)
+	}
+	// Recursive aliases must observe the active expansion chain before any
+	// memoized value, matching parse_type's ordering.
+	if tc.type_cache.alias_parse_stack.len > 0 {
+		if recursive_alias := tc.recursive_alias_reference(typ) {
+			return recursive_alias
+		}
+	}
+	mut cache := unsafe { tc.type_cache }
+	if cache.parse_text_id_set.len == 0 {
+		cache.parse_text_id_context = []u64{len: 65536}
+		cache.parse_text_id_values = unsafe { []Type{len: 65536} }
+		cache.parse_text_id_set = []bool{len: 65536}
+	}
+	slot := int(text_id)
+	context_hash := parse_type_cache_context_hash(mut cache, tc.cur_file, tc.cur_module,
+		tc.fn_context.generic_params, tc.resolution_type_mode)
+	if cache.parse_text_id_set[slot] && cache.parse_text_id_context[slot] == context_hash {
+		cache.parse_hits++
+		return cache.parse_text_id_values[slot]
+	}
+	result := tc.parse_type(typ)
+	cache.parse_text_id_context[slot] = context_hash
+	cache.parse_text_id_values[slot] = result
+	cache.parse_text_id_set[slot] = true
 	return result
 }
 
@@ -12523,12 +12772,55 @@ pub fn (tc &TypeChecker) type_count() int {
 // type. Hot compiler paths should prefer this to repeated recursive Type.name
 // construction.
 pub fn (tc &TypeChecker) type_name(t Type) string {
+	// Stored-name variants are free; interning them would only add hashing on
+	// top of returning the field.
+	if t is Struct {
+		return t.name
+	}
+	if t is Alias {
+		return t.name
+	}
+	if t is Enum {
+		return t.name
+	}
+	if t is SumType {
+		return t.name
+	}
+	if t is Interface {
+		return t.name
+	}
 	if isnil(tc.type_interner) {
 		return t.name()
+	}
+	mut cache := unsafe { tc.type_cache }
+	if !isnil(cache) {
+		w0, w1, slot := type_value_words(&t)
+		if cache.name_recent_set[slot] && cache.name_recent_w0[slot] == w0
+			&& cache.name_recent_w1[slot] == w1 {
+			return cache.name_recent_vals[slot]
+		}
+		id, _ := tc.intern_type(t)
+		mut interner := unsafe { tc.type_interner }
+		result := interner.name(id)
+		cache.name_recent_w0[slot] = w0
+		cache.name_recent_w1[slot] = w1
+		cache.name_recent_vals[slot] = result
+		cache.name_recent_set[slot] = true
+		return result
 	}
 	id, _ := tc.intern_type(t)
 	mut interner := unsafe { tc.type_interner }
 	return interner.name(id)
+}
+
+// type_value_words exposes a Type value's two raw words for slot hashing:
+// identical bytes always denote the same type (same tag, same payload).
+@[inline]
+fn type_value_words(typ &Type) (u64, u64, int) {
+	words := unsafe { &u64(voidptr(typ)) }
+	w0 := unsafe { words[0] }
+	w1 := unsafe { words[1] }
+	return w0, w1, int(((w0 >> 4) ^ w1) & 2047)
 }
 
 // type_cache_stats returns cache counters accumulated by this checker.
@@ -12677,6 +12969,41 @@ fn parse_type_cache_get(mut cache TypeCache, file string, module_name string, te
 	return none
 }
 
+@[inline]
+fn parse_type_cache_get_mode(mut cache TypeCache, file string, module_name string, text string, generic_params []string, resolution bool, fast_recent bool) ?Type {
+	if fast_recent {
+		return parse_type_cache_get_recent(mut cache, file, module_name, text, generic_params,
+			resolution)
+	}
+	return parse_type_cache_get(mut cache, file, module_name, text, generic_params, resolution)
+}
+
+@[inline]
+fn parse_type_cache_value_recent_slot(text string, context_hash u64) int {
+	return int(((u64(voidptr(text.str)) >> 4) ^ u64(text.len) ^ context_hash) & 2047)
+}
+
+fn parse_type_cache_get_recent(mut cache TypeCache, file string, module_name string, text string, generic_params []string, resolution bool) ?Type {
+	context_hash := parse_type_cache_context_hash(mut cache, file, module_name, generic_params,
+		resolution)
+	text_ptr := usize(voidptr(text.str))
+	slot := parse_type_cache_value_recent_slot(text, context_hash)
+	if cache.parse_value_recent_set[slot] && cache.parse_value_recent_ptrs[slot] == text_ptr
+		&& cache.parse_value_recent_lens[slot] == text.len
+		&& cache.parse_value_recent_context[slot] == context_hash {
+		return cache.parse_value_recent_values[slot]
+	}
+	result := parse_type_cache_get(mut cache, file, module_name, text, generic_params, resolution) or {
+		return none
+	}
+	cache.parse_value_recent_ptrs[slot] = text_ptr
+	cache.parse_value_recent_lens[slot] = text.len
+	cache.parse_value_recent_context[slot] = context_hash
+	cache.parse_value_recent_values[slot] = result
+	cache.parse_value_recent_set[slot] = true
+	return result
+}
+
 fn parse_type_cache_put(mut cache TypeCache, file string, module_name string, text string, generic_params []string, resolution bool, typ Type) {
 	context_hash := parse_type_cache_context_hash(mut cache, file, module_name, generic_params,
 		resolution)
@@ -12722,6 +13049,18 @@ fn parse_type_cache_put(mut cache TypeCache, file string, module_name string, te
 		cache.parse_last_valid = true
 		return
 	}
+}
+
+fn parse_type_cache_put_recent(mut cache TypeCache, file string, module_name string, text string, generic_params []string, resolution bool, typ Type) {
+	parse_type_cache_put(mut cache, file, module_name, text, generic_params, resolution, typ)
+	context_hash := parse_type_cache_context_hash(mut cache, file, module_name, generic_params,
+		resolution)
+	slot := parse_type_cache_value_recent_slot(text, context_hash)
+	cache.parse_value_recent_ptrs[slot] = usize(voidptr(text.str))
+	cache.parse_value_recent_lens[slot] = text.len
+	cache.parse_value_recent_context[slot] = context_hash
+	cache.parse_value_recent_values[slot] = typ
+	cache.parse_value_recent_set[slot] = true
 }
 
 // parse_scope_param_type preserves open generic struct applications for local parameter
@@ -14051,11 +14390,44 @@ fn (tc &TypeChecker) comptime_static_type_expr_name(id flat.NodeId) ?string {
 @[heap]
 struct BodyResolveMemo {
 mut:
-	active bool
-	lo     int
-	hi     int
-	types  []Type
-	filled []u8
+	active           bool
+	lo               int
+	hi               int
+	types            []Type
+	filled           []u8
+	call_generation  u32 = 1
+	call_ids         [2048]int
+	call_generations [2048]u32
+	call_infos       [2048]CallInfo
+}
+
+// arm_body_resolve_memo (re)activates the per-item resolve memo for one work
+// item's node range. The transformer arms it per lowered function exactly like
+// the checker does per checked item; node-write helpers invalidate rewritten
+// slots (see invalidate_checked_expr_type).
+pub fn (tc &TypeChecker) arm_body_resolve_memo(lo int, hi int) {
+	mut wtc := unsafe { tc }
+	if isnil(wtc.body_resolve_memo) {
+		wtc.body_resolve_memo = &BodyResolveMemo{}
+	}
+	wtc.body_resolve_memo.begin(lo, hi)
+}
+
+// disarm_body_resolve_memo deactivates the per-item resolve memo.
+pub fn (tc &TypeChecker) disarm_body_resolve_memo() {
+	if !isnil(tc.body_resolve_memo) {
+		mut memo := tc.body_resolve_memo
+		memo.active = false
+	}
+}
+
+// reset_body_resolve_memo detaches the memo entirely. The transformer arms it
+// inside a disposable stage arena, so the master checker must drop the pointer
+// before that arena is released — later phases would otherwise dereference a
+// freed allocation just to see that the memo is inactive.
+pub fn (tc &TypeChecker) reset_body_resolve_memo() {
+	mut wtc := unsafe { tc }
+	wtc.body_resolve_memo = unsafe { nil }
 }
 
 fn (mut memo BodyResolveMemo) begin(lo int, hi int) {
@@ -14066,6 +14438,7 @@ fn (mut memo BodyResolveMemo) begin(lo int, hi int) {
 	span := hi - lo + 1
 	memo.lo = lo
 	memo.hi = hi
+	memo.call_generation++
 	if memo.types.len < span {
 		memo.types = []Type{len: span, init: Type(void_)}
 		memo.filled = []u8{len: span}
@@ -14077,6 +14450,22 @@ fn (mut memo BodyResolveMemo) begin(lo int, hi int) {
 
 @[direct_array_access]
 pub fn (tc &TypeChecker) resolve_type(id flat.NodeId) Type {
+	if tc.trust_checked_expr_types {
+		// Post-check phases re-resolve mostly unchanged subtrees the checker
+		// already typed. Serve those straight from the dense per-node cache:
+		// dense in-range entries are checker-authored, transform's node-write
+		// helpers invalidate every id they rewrite, and appended nodes lie
+		// beyond the dense range so they resolve normally below. Cached
+		// unknowns stay excluded — a later registration may resolve them.
+		tidx := int(id)
+		if tidx >= 0 && tidx < tc.expr_type_set.len && tc.expr_type_set[tidx]
+			&& (!tc.parallel_check_sparse || tc.in_check_range(tidx)) {
+			typ := tc.expr_type_values[tidx]
+			if !type_contains_unknown(typ) {
+				return typ
+			}
+		}
+	}
 	memo := tc.body_resolve_memo
 	idx := int(id)
 	if isnil(memo) || !memo.active || idx < memo.lo || idx > memo.hi {
@@ -15245,16 +15634,20 @@ fn (tc &TypeChecker) fn_literal_type(node flat.Node) Type {
 	mut params_mut := []bool{}
 	for i in 0 .. node.children_count {
 		child := tc.a.child_node(&node, i)
-		if child.kind == .param {
-			params_mut << child.is_mut
-			parsed := tc.parse_type(normalize_fn_type_param_text(child.typ))
-			if child.value.len == 0 && child.typ.len > 0 && parsed is Unknown {
-				params << Type(Struct{
-					name: child.typ
-				})
-			} else {
-				params << parsed
+		if child.kind != .param {
+			if tc.prefix_param_scan {
+				break
 			}
+			continue
+		}
+		params_mut << child.is_mut
+		parsed := tc.parse_type(normalize_fn_type_param_text(child.typ))
+		if child.value.len == 0 && child.typ.len > 0 && parsed is Unknown {
+			params << Type(Struct{
+				name: child.typ
+			})
+		} else {
+			params << parsed
 		}
 	}
 	return Type(FnType{
@@ -15422,15 +15815,38 @@ pub fn (tc &TypeChecker) c_type(t Type) string {
 	if tc.type_cache == unsafe { nil } || isnil(tc.type_interner) {
 		return tc.c_type_uncached(t)
 	}
-	key, canonical := tc.intern_type(t)
 	mut cache := unsafe { tc.type_cache }
+	mut w0 := u64(0)
+	mut w1 := u64(0)
+	mut slot := 0
+	if tc.fast_c_type_recent {
+		w0, w1, slot = type_value_words(&t)
+		if cache.c_recent_set[slot] && cache.c_recent_w0[slot] == w0
+			&& cache.c_recent_w1[slot] == w1 {
+			cache.c_hits++
+			return cache.c_recent_vals[slot]
+		}
+	}
+	key, canonical := tc.intern_type(t)
 	if cached := cache.c_entries[key] {
 		cache.c_hits++
+		if tc.fast_c_type_recent {
+			cache.c_recent_w0[slot] = w0
+			cache.c_recent_w1[slot] = w1
+			cache.c_recent_vals[slot] = cached
+			cache.c_recent_set[slot] = true
+		}
 		return cached
 	}
 	cache.c_misses++
 	result := tc.c_type_uncached(canonical)
 	cache.c_entries[key] = result
+	if tc.fast_c_type_recent {
+		cache.c_recent_w0[slot] = w0
+		cache.c_recent_w1[slot] = w1
+		cache.c_recent_vals[slot] = result
+		cache.c_recent_set[slot] = true
+	}
 	return result
 }
 

--- a/vlib/v3/types/scope.v
+++ b/vlib/v3/types/scope.v
@@ -1,5 +1,7 @@
 module types
 
+import os
+
 // Scope represents scope data used by types.
 @[heap]
 pub struct Scope {
@@ -13,11 +15,17 @@ pub mut:
 	// the per-level map probe (most lookups walk many levels that do not bind
 	// the name at all). False positives only cost the probe they would have
 	// paid anyway.
-	name_mask       u64
-	generations     []int
-	storage_keys    []string
-	next_generation int
-	lifetime        int
+	name_mask        u64
+	fast_lookup      bool
+	fast_generation  u32
+	fast_name_ptrs   [32]voidptr
+	fast_name_lens   [32]u16
+	fast_indexes     [32]u32
+	fast_generations [32]u32
+	generations      []int
+	storage_keys     []string
+	next_generation  int
+	lifetime         int
 }
 
 pub struct ScopeBindingOwner {
@@ -35,11 +43,46 @@ fn scope_name_bit(name string) u64 {
 	return u64(1) << ((first * 33 + u32(name.len)) & 63)
 }
 
+@[inline]
+fn scope_fast_slot(name string) int {
+	return int(((u64(voidptr(name.str)) >> 4) ^ u64(name.len)) & 31)
+}
+
+@[direct_array_access; inline]
+fn (s &Scope) own_binding_index(name string) ?int {
+	if s.fast_lookup {
+		slot := scope_fast_slot(name)
+		if s.fast_generations[slot] == s.fast_generation
+			&& s.fast_name_ptrs[slot] == voidptr(name.str)
+			&& s.fast_name_lens[slot] == u16(name.len) {
+			return int(s.fast_indexes[slot])
+		}
+	}
+	if i := s.name_indexes[name] {
+		return i
+	}
+	return none
+}
+
+@[direct_array_access; inline]
+fn (mut s Scope) remember_fast_binding(name string, index int) {
+	if !s.fast_lookup || name.len > 65535 {
+		return
+	}
+	slot := scope_fast_slot(name)
+	s.fast_name_ptrs[slot] = voidptr(name.str)
+	s.fast_name_lens[slot] = u16(name.len)
+	s.fast_indexes[slot] = u32(index)
+	s.fast_generations[slot] = s.fast_generation
+}
+
 // new_scope returns a reusable type-checker scope with an optional parent.
 pub fn new_scope(parent &Scope) &Scope {
 	unsafe {
 		return &Scope{
-			parent: parent
+			parent:          parent
+			fast_lookup:     os.getenv('V3_NO_SCOPE_DIRECT') == ''
+			fast_generation: 1
 		}
 	}
 }
@@ -58,6 +101,11 @@ pub fn (mut s Scope) reset(parent &Scope) {
 	// nearest_binding_owned_by) stays exact in every build mode.
 	s.lifetime++
 	s.name_mask = 0
+	s.fast_generation++
+	if s.fast_generation == 0 {
+		s.fast_generations = [32]u32{}
+		s.fast_generation = 1
+	}
 	$if !ownership ? {
 		s.name_indexes.clear()
 	}
@@ -78,7 +126,7 @@ pub fn (s &Scope) lookup(name string) ?Type {
 		mut scope := unsafe { &Scope(s) }
 		for scope != unsafe { nil } {
 			if scope.name_mask & bit != 0 {
-				if i := scope.name_indexes[name] {
+				if i := scope.own_binding_index(name) {
 					return scope.types[i]
 				}
 			}
@@ -111,7 +159,7 @@ pub fn (s &Scope) lookup_owner(name string) ?ScopeBindingOwner {
 				scope = scope.parent
 				continue
 			}
-			if i := scope.name_indexes[name] {
+			if i := scope.own_binding_index(name) {
 				return ScopeBindingOwner{
 					scope:       scope
 					index:       i
@@ -160,8 +208,8 @@ fn scope_binding_storage_key(scope &Scope, lifetime int, index int, generation i
 
 // belongs_to_scope reports whether this binding owner was declared directly in `scope`.
 pub fn (owner ScopeBindingOwner) belongs_to_scope(scope &Scope) bool {
-	return owner.scope != unsafe { nil } && scope != unsafe { nil } && owner.scope == scope
-		&& owner.lifetime == scope.lifetime
+	return owner.scope != unsafe { nil } && scope != unsafe { nil }
+		&& voidptr(owner.scope) == voidptr(scope) && owner.lifetime == scope.lifetime
 }
 
 // belongs_to_scope_chain_until reports whether this binding owner was declared
@@ -176,7 +224,7 @@ pub fn (owner ScopeBindingOwner) belongs_to_scope_chain_until(scope &Scope, stop
 		if owner.belongs_to_scope(cur) {
 			return true
 		}
-		if cur == stop {
+		if voidptr(cur) == voidptr(stop) {
 			return false
 		}
 		cur = cur.parent
@@ -191,18 +239,23 @@ pub fn (s &Scope) nearest_binding_owned_by(name string, owner ScopeBindingOwner)
 		return false
 	}
 	$if !ownership ? {
-		if i := s.name_indexes[name] {
-			return s == owner.scope && s.lifetime == owner.lifetime && i == owner.index
-		}
-		if s.parent != unsafe { nil } {
-			return s.parent.nearest_binding_owned_by(name, owner)
+		bit := scope_name_bit(name)
+		mut scope := unsafe { &Scope(s) }
+		for scope != unsafe { nil } {
+			if scope.name_mask & bit != 0 {
+				if i := scope.own_binding_index(name) {
+					return voidptr(scope) == voidptr(owner.scope)
+						&& scope.lifetime == owner.lifetime && i == owner.index
+				}
+			}
+			scope = scope.parent
 		}
 		return false
 	}
 	for i := s.names.len - 1; i >= 0; i-- {
 		if s.names[i] == name {
-			return s == owner.scope && s.lifetime == owner.lifetime && i == owner.index
-				&& s.generations[i] == owner.generation
+			return voidptr(s) == voidptr(owner.scope) && s.lifetime == owner.lifetime
+				&& i == owner.index && s.generations[i] == owner.generation
 		}
 	}
 	if s.parent != unsafe { nil } {
@@ -222,6 +275,7 @@ pub fn (mut s Scope) insert_with_owner(name string, typ Type) ScopeBindingOwner 
 	$if !ownership ? {
 		if i := s.name_indexes[name] {
 			s.types[i] = typ
+			s.remember_fast_binding(name, i)
 			return ScopeBindingOwner{
 				scope:       s
 				index:       i
@@ -233,8 +287,9 @@ pub fn (mut s Scope) insert_with_owner(name string, typ Type) ScopeBindingOwner 
 		s.names << name
 		s.types << typ
 		s.name_mask |= scope_name_bit(name)
-		s.name_indexes[name] = s.names.len - 1
 		index := s.names.len - 1
+		s.name_indexes[name] = index
+		s.remember_fast_binding(name, index)
 		storage_key := scope_binding_storage_key(s, s.lifetime, index, 0)
 		s.storage_keys << storage_key
 		return ScopeBindingOwner{


### PR DESCRIPTION
## Summary

Reduce the V3 no-cache self-host critical path across checking, transformation, and C generation while preserving deterministic output.

The main changes:

- retain scoped compiler data through its final consumer instead of cloning it between stages
- precompute and share read-only checker/type metadata across bounded parallel workers
- use shared-base transform regions with parallel relocation and compact merging
- overlap independent transform scans, including function parameter signature preparation
- balance C-generation work using refined costs and lazily initialize pooled workers
- retain generated function segments and write the final C file through a mapped output path on Unix
- add targeted caches and fast paths for repeated type, scope, naming, and declaration lookups

The runtime and compile-time no-parallel fallbacks remain available.

## Performance

Measured with the no-cache self-host workflow:

```sh
cd vlib/v3
../../v -gc none -prealloc -prod -o v3 v3.v
./v3 -nocache -building-v -o v4 v3.v
```

- best observed `check + transform + cgen`: **494.41 ms**
- latest same-binary A/B transform median: **170.59 -> 161.34 ms** (`-9.25 ms`)
- applying that isolated saving to the earlier 507.52 ms pipeline median gives approximately **498.3 ms**

Timings remain sensitive to concurrent desktop load, so the A/B comparison uses one binary and interleaved runs.

## Validation

- `./vnew -silent vlib/v/compiler_errors_test.v`: 1617 passed, 1 skipped
- `./vnew -silent vlib/v/gen/c/coutput_test.v`: 97 output fixtures and 132 must-have fixtures passed
- `./vnew -old-compiler -silent test vlib/v3/transform/`: 6 passed
- `./vnew -old-compiler vlib/v3/tests/parallel_determinism_test.v`
- `./vnew -old-compiler vlib/v3/tests/parallel_worker_failure_test.v`
- clean rebased V3 source build and self-host C-emission smoke test
- generated C compared byte-for-byte with the final transform overlap enabled and disabled
- `git diff --check`
