### PR TITLE
v3 cgen: resolve function parameters in interface dispatch

### DIFF
--- a/vlib/v3/gen/c/interface.v
+++ b/vlib/v3/gen/c/interface.v
@@ -1468,12 +1468,7 @@ fn (mut g FlatGen) interface_method_forward_decls() {
 			sig_params := g.interface_dispatch_param_types(decl_key, sig_key)
 			g.write('${g.fn_return_type_name(ret_type)} ${cn}__${method}(${cn}* i')
 			for pi := 1; pi < sig_params.len; pi++ {
-				pt := sig_params[pi]
-				pct := if pt is types.OptionType || pt is types.ResultType {
-					g.optional_type_name(pt)
-				} else {
-					g.tc.c_type(pt)
-				}
+				pct := g.interface_dispatch_param_c_type(sig_params[pi])
 				g.write(', ${pct} _a${pi - 1}')
 			}
 			g.writeln(');')
@@ -1562,12 +1557,7 @@ fn (mut g FlatGen) interface_dispatch_signature(iface_name string, cn string, me
 	sig_params := g.interface_dispatch_param_types(decl_key, sig_key)
 	mut sig := '${ret_ct} ${cn}__${method}(${cn}* i'
 	for pi := 1; pi < sig_params.len; pi++ {
-		pt := sig_params[pi]
-		pct := if pt is types.OptionType || pt is types.ResultType {
-			g.optional_type_name(pt)
-		} else {
-			g.tc.c_type(pt)
-		}
+		pct := g.interface_dispatch_param_c_type(sig_params[pi])
 		sig += ', ${pct} _a${pi - 1}'
 	}
 	sig += ')'
@@ -1659,12 +1649,7 @@ fn (mut g FlatGen) gen_interface_dispatch_with_fallback(iface_name string, cn st
 	mut arg_names := []string{}
 	g.write('${ret_ct} ${cn}__${method}(${cn}* i')
 	for pi := 1; pi < sig_params.len; pi++ {
-		pt := sig_params[pi]
-		pct := if pt is types.OptionType || pt is types.ResultType {
-			g.optional_type_name(pt)
-		} else {
-			g.tc.c_type(pt)
-		}
+		pct := g.interface_dispatch_param_c_type(sig_params[pi])
 		an := '_a${pi - 1}'
 		arg_names << an
 		g.write(', ${pct} ${an}')
@@ -1886,6 +1871,18 @@ fn interface_dispatch_wrapped_base_type(typ types.Type) ?types.Type {
 			return none
 		}
 	}
+}
+
+fn (mut g FlatGen) interface_dispatch_param_c_type(typ types.Type) string {
+	mut ct := if typ is types.OptionType || typ is types.ResultType {
+		g.optional_type_name(typ)
+	} else {
+		g.tc.c_type(typ)
+	}
+	if ct.starts_with('fn_ptr:') {
+		ct = g.resolve_fn_ptr_type(ct)
+	}
+	return ct
 }
 
 fn (mut g FlatGen) interface_boxed_type_marked_for_dispatch(iface_name string, concrete string) bool {

--- a/vlib/v3/tests/interface_fn_parameter_test.v
+++ b/vlib/v3/tests/interface_fn_parameter_test.v
@@ -1,0 +1,50 @@
+import os
+
+const interface_fn_tests_dir = os.dir(@FILE)
+const interface_fn_v3_dir = os.dir(interface_fn_tests_dir)
+const interface_fn_vlib_dir = os.dir(interface_fn_v3_dir)
+const interface_fn_v3_src = os.join_path(interface_fn_v3_dir, 'v3.v')
+const interface_fn_v3_bin = os.join_path(os.temp_dir(), 'v3_interface_fn_${os.getpid()}')
+
+fn build_interface_fn_v3() string {
+	if os.is_executable(interface_fn_v3_bin) {
+		return interface_fn_v3_bin
+	}
+	build :=
+		os.execute('${os.quoted_path(@VEXE)} -gc none -path "${interface_fn_vlib_dir}|@vlib|@vmodules" -o ${os.quoted_path(interface_fn_v3_bin)} ${os.quoted_path(interface_fn_v3_src)}')
+	assert build.exit_code == 0, build.output
+	return interface_fn_v3_bin
+}
+
+fn write_interface_fn_project() string {
+	root := os.join_path(os.temp_dir(), 'v3_interface_fn_project_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(os.join_path(root, 'core')) or { panic(err) }
+	os.write_file(os.join_path(root, 'core', 'core.v'),
+		'module core\n\npub interface EventData {}\n\npub interface Connector {\n\tconnect(handler fn (EventData))\n}\n\npub fn use_connector(connector Connector) {\n\tconnector.connect(fn (event EventData) {})\n}\n') or {
+		panic(err)
+	}
+	os.write_file(os.join_path(root, 'main.v'),
+		'module main\n\nimport core\n\nstruct App {}\n\nfn (app App) connect(handler fn (core.EventData)) {}\n\nfn main() {\n\tcore.use_connector(App{})\n\tprint("ok")\n}\n') or {
+		panic(err)
+	}
+	return root
+}
+
+// https://github.com/vlang/v/issues/28042
+fn test_interface_method_fn_parameter_uses_c_typedef() {
+	v3_bin := build_interface_fn_v3()
+	root := write_interface_fn_project()
+	defer {
+		os.rm(v3_bin) or {}
+		os.rmdir_all(root) or {}
+	}
+	output := os.join_path(root, 'interface_fn_parameter')
+	compile := os.execute('${os.quoted_path(v3_bin)} -nocache -b c -o ${os.quoted_path(output)} ${os.quoted_path(os.join_path(root,
+		'main.v'))}')
+	assert compile.exit_code == 0, compile.output
+	assert !compile.output.contains('C compilation failed'), compile.output
+	run := os.execute(os.quoted_path(output))
+	assert run.exit_code == 0, run.output
+	assert run.output == 'ok'
+}


### PR DESCRIPTION
## Summary

- resolve function-typed interface method parameters to generated C typedefs
- use the same ABI rendering for dispatcher forward declarations, signatures, and definitions
- add a cross-module V3 regression test

## Issue status

- V3 fix: #28042
- Already works in V3 without changes: #28029, #28030, #28036
- Not a V3 compiler issue: #28033 (`veb`/`fasthttp` runtime SIGPIPE handling)

## Tests

- `./vnew -silent vlib/v3/tests/interface_fn_parameter_test.v`
- `./vnew -silent vlib/v3/gen/c/interface_test.v`
- `./vnew fmt -verify vlib/v3/gen/c/interface.v vlib/v3/tests/interface_fn_parameter_test.v`
- `git diff --check origin/master...HEAD`

## Notes

- No broad test suites were run.
- `./v -g -keepc -o ./vnew cmd/v` remains blocked by an unrelated pre-existing V1 bootstrap code generation failure at `vlib/v/ast/cflags.v:95`.
- This PR changes only V3; it does not change compatibility-compiler behavior.