### PR TITLE
v3: reduce Cgen RSS after parallel stages

### DIFF
--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -7640,7 +7640,7 @@ pub fn run(args []string) {
 			prealloc_scope_leave_for_v3(transform_scope)
 			retain_transform_scope := building_v && backend == 'c' && !cache_state.manager.enabled
 				&& retained_transform_regions.len == 0
-				&& os.getenv('V3_NO_RETAIN_TRANSFORM_SCOPE') == ''
+				&& os.getenv('V3_RETAIN_TRANSFORM_SCOPE') == '1'
 			if retain_transform_scope {
 				// Cgen is the only remaining semantic consumer in this no-cache self-host
 				// path. Keep the typed transform arena alive through it instead of cloning
@@ -8350,6 +8350,7 @@ pub fn run(args []string) {
 				exit(1)
 			}
 		}
+		a.close_workers()
 		if cgen_cache_hit {
 			b.step('cgen (cached)')
 		} else if incremental_cache_hit {

--- a/vlib/v3/workers/worker_pool_nix.c.v
+++ b/vlib/v3/workers/worker_pool_nix.c.v
@@ -89,6 +89,7 @@ mut:
 	fallback_task_count    u64
 	launch_attempt_count   u64
 	launch_failure_count   u64
+	launched_thread_count  u64
 	queue_wait_ns          u64
 	worker_run_ns          u64
 	started_at_ns          u64
@@ -151,6 +152,7 @@ pub fn new(size int) &Pool {
 			pool.launch_failure_count++
 		}
 	}
+	pool.launched_thread_count = u64(pool.threads.len)
 	return pool
 }
 
@@ -231,7 +233,7 @@ pub fn (p &Pool) tasks_run() u64 {
 pub fn (p &Pool) stats() Stats {
 	now := time.sys_mono_now()
 	elapsed_ns := if now >= p.started_at_ns { now - p.started_at_ns } else { 0 }
-	capacity_ns := elapsed_ns * u64(p.threads.len)
+	capacity_ns := elapsed_ns * p.launched_thread_count
 	utilization_ppm := if capacity_ns > 0 {
 		p.worker_run_ns * 1_000_000 / capacity_ns
 	} else {

--- a/vlib/v3/workers/worker_pool_test.v
+++ b/vlib/v3/workers/worker_pool_test.v
@@ -80,6 +80,9 @@ fn test_pool_runs_persistent_batches_and_sync_fallbacks() {
 		assert stats.worker_run_ns > 0
 	}
 	pool.close()
+	$if !windows {
+		assert pool.stats().utilization_ppm > 0
+	}
 }
 
 fn test_pool_falls_back_for_every_failed_launch_index() {


### PR DESCRIPTION
## What changed

- promote and release the scoped transform arena by default for no-cache self-host C builds
- close the persistent compiler worker pool immediately after its final Cgen work
- retain the launched worker count so utilization metrics remain meaningful after pool teardown
- cover statistics queried after pool closure

The former behavior kept transform scratch, worker root arenas, recycled scoped blocks, and touched worker stacks resident until the entire compiler process exited. None of that state is needed after C generation.

The old transform-arena retention remains available as an explicit diagnostic/performance experiment with `V3_RETAIN_TRANSFORM_SCOPE=1`.

## Impact

For the no-cache V3 self-host benchmark on macOS arm64:

```text
before: cgen (parallel)  224.32 ms  1350 MB RSS
 after: cgen (parallel)  247.41 ms   869 MB RSS
```

This reduces reported Cgen RSS by 481 MB (35.6%). The complete benchmark remained approximately 1.10 seconds, and two independent C-only generations with a fixed `SOURCE_DATE_EPOCH` were byte-identical.

## Validation

- `./vnew -silent test vlib/v3/workers/`
- `./vnew -silent test vlib/v3/driver/`
- `../../v -gc none -prealloc -prod -o v3 v3.v && ./v3 -nocache -building-v -o v4 v3.v`
- deterministic two-pass C output comparison with `SOURCE_DATE_EPOCH=1700000000`

A full V3 suite run was intentionally skipped. Rebuilding the debug `vnew` compiler was attempted but encountered an unrelated existing V1 C-generation failure in `vlib/v/ast/cflags.v`; the existing working `vnew` was used for the focused tests.