### PR TITLE
compiler: fix five recent option, result, and TCC regressions

### DIFF
--- a/vlib/v/builder/cc_test.v
+++ b/vlib/v/builder/cc_test.v
@@ -587,6 +587,33 @@ fn test_shared_tcc_compile_args_skip_bt25_after_late_compiler_resolution() {
 	assert !builder.get_compile_args().contains('-bt25')
 }
 
+fn test_macos_arm64_tcc_compile_args_skip_bt25() {
+	mut builder := new_test_builder([
+		'-os',
+		'macos',
+		'-arch',
+		'arm64',
+		'-cc',
+		'tcc',
+		hello_world_example(),
+	])
+	assert 'no_backtrace' in builder.pref.compile_defines_all
+	assert !builder.get_compile_args().contains('-bt25')
+}
+
+fn test_macos_amd64_tcc_compile_args_keep_bt25() {
+	mut builder := new_test_builder([
+		'-os',
+		'macos',
+		'-arch',
+		'amd64',
+		'-cc',
+		'tcc',
+		hello_world_example(),
+	])
+	assert builder.get_compile_args().contains('-bt25')
+}
+
 fn test_shared_build_module_keeps_shared_linker_flag() {
 	mut builder := new_test_builder(['-shared', hello_world_example()])
 	builder.pref.build_mode = .build_module

--- a/vlib/v/checker/return.v
+++ b/vlib/v/checker/return.v
@@ -272,9 +272,25 @@ fn (mut c Checker) return_stmt(mut node ast.Return) {
 				if c.pref.skip_unused && got_types[i].has_flag(.generic) {
 					c.table.used_features.comptime_syms[got_type] = true
 				}
-				if exp_type_sym.kind == .interface
+				expected_is_interface := exp_type_sym.kind == .interface
 					|| (exp_type_sym.kind == .generic_inst && exp_type_sym.info is ast.GenericInst
-					&& c.table.type_symbols[exp_type_sym.info.parent_idx].kind == .interface) {
+					&& c.table.type_symbols[exp_type_sym.info.parent_idx].kind == .interface)
+				// A custom IError is a valid error return even when the Result payload is an
+				// interface. Recognize it before checking against that payload interface.
+				if expected_fn_return_type_has_result && expected_is_interface
+					&& got_type_sym.kind == .struct
+					&& c.table.does_type_implement_interface(got_type, ast.error_type) {
+					node.exprs[expr_idxs[i]] = ast.CastExpr{
+						expr:      exprv
+						typname:   'IError'
+						typ:       ast.error_type
+						expr_type: got_type
+						pos:       node.pos
+					}
+					node.types[expr_idxs[i]] = ast.error_type
+					continue
+				}
+				if expected_is_interface {
 					if c.type_implements(got_type, exp_type, node.pos) {
 						if !got_type.is_any_kind_of_pointer() && got_type_sym.kind != .interface
 							&& !c.inside_unsafe {

--- a/vlib/v/checker/return.v
+++ b/vlib/v/checker/return.v
@@ -275,22 +275,33 @@ fn (mut c Checker) return_stmt(mut node ast.Return) {
 				expected_is_interface := exp_type_sym.kind == .interface
 					|| (exp_type_sym.kind == .generic_inst && exp_type_sym.info is ast.GenericInst
 					&& c.table.type_symbols[exp_type_sym.info.parent_idx].kind == .interface)
-				// A custom IError is a valid error return even when the Result payload is an
-				// interface. Recognize it before checking against that payload interface.
-				if expected_fn_return_type_has_result && expected_is_interface
-					&& got_type_sym.kind == .struct
-					&& c.table.does_type_implement_interface(got_type, ast.error_type) {
-					node.exprs[expr_idxs[i]] = ast.CastExpr{
-						expr:      exprv
-						typname:   'IError'
-						typ:       ast.error_type
-						expr_type: got_type
-						pos:       node.pos
-					}
-					node.types[expr_idxs[i]] = ast.error_type
-					continue
-				}
 				if expected_is_interface {
+					if exp_type_sym.kind == .generic_inst {
+						c.table.generic_insts_to_concrete()
+					}
+					payload_implements := c.table.does_type_implement_interface(got_type, exp_type)
+					if payload_implements {
+						if c.type_implements(got_type, exp_type, node.pos)
+							&& !got_type.is_any_kind_of_pointer() && got_type_sym.kind != .interface
+							&& !c.inside_unsafe {
+							c.mark_as_referenced(mut &node.exprs[expr_idxs[i]], true)
+						}
+						continue
+					}
+					// A custom IError is a valid error return when it does not implement the
+					// Result payload interface.
+					if expected_fn_return_type_has_result && got_type_sym.kind == .struct
+						&& c.table.does_type_implement_interface(got_type, ast.error_type) {
+						node.exprs[expr_idxs[i]] = ast.CastExpr{
+							expr:      exprv
+							typname:   'IError'
+							typ:       ast.error_type
+							expr_type: got_type
+							pos:       node.pos
+						}
+						node.types[expr_idxs[i]] = ast.error_type
+						continue
+					}
 					if c.type_implements(got_type, exp_type, node.pos) {
 						if !got_type.is_any_kind_of_pointer() && got_type_sym.kind != .interface
 							&& !c.inside_unsafe {

--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -1571,6 +1571,10 @@ fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 					g.expr(val)
 					g.writeln(', sizeof(${g.styp(var_type)}));')
 				}
+			} else if is_fixed_array_var && var_type.has_flag(.option) {
+				g.expr(left)
+				g.write(' = ')
+				g.expr_with_opt(val, val_type, var_type)
 			} else {
 				arr_typ := styp.trim('*')
 				old_is_assign_lhs := g.is_assign_lhs

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -4320,7 +4320,16 @@ fn (mut g Gen) stmts_with_tmp_var(stmts []ast.Stmt, tmp_var string) bool {
 						g.write('${tmp_var} = ')
 					}
 				}
-				g.stmt(stmt)
+				if stmt is ast.ExprStmt {
+					// This final expression supplies the enclosing if/match temporary even when
+					// its AST node was not marked as an expression. Keep propagated call results
+					// alive so nested match branches emit the unwrapped value after their prelude.
+					mut value_stmt := stmt
+					value_stmt.is_expr = true
+					g.stmt(value_stmt)
+				} else {
+					g.stmt(stmt)
+				}
 				// Reset outer_tmp_var after processing
 				if is_if_expr_with_tmp {
 					g.outer_tmp_var = ''

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -1705,9 +1705,13 @@ fn (mut p Parser) fn_params() ([]ast.Param, bool, bool, bool) {
 				}
 			}
 			if is_variadic {
-				// derive flags, however nr_muls only needs to be set on the array elem type, so clear it on the arg type
+				// Preserve the flags used by variadic lowering, but keep optional/result function
+				// wrappers on the array element rather than on the variadic array itself.
 				typ =
 					ast.new_type(p.table.find_or_register_array(typ)).derive(typ).set_nr_muls(0).set_flag(.variadic)
+				if p.table.final_sym(orig_typ).kind == .function {
+					typ = typ.clear_flags(.option, .result, .option_mut_param_t)
+				}
 			}
 			for i, para_name in param_names {
 				alanguage := p.table.sym(typ).language

--- a/vlib/v/pref/default.v
+++ b/vlib/v/pref/default.v
@@ -226,9 +226,11 @@ pub fn (mut p Preferences) defines_map_unique_keys() string {
 	return skeys.join(',')
 }
 
-fn (mut p Preferences) disable_tcc_shared_backtraces() {
-	if p.is_shared && p.ccompiler_type == .tinyc && 'no_backtrace' !in p.compile_defines_all {
-		// TCC shared libraries should not depend on TCC's backtrace runtime symbols.
+fn (mut p Preferences) disable_unsupported_tcc_backtraces() {
+	if p.ccompiler_type == .tinyc && (p.is_shared || (p.os == .macos && p.arch == .arm64))
+		&& 'no_backtrace' !in p.compile_defines_all {
+		// TCC shared libraries should not depend on TCC's backtrace runtime symbols. TCC's
+		// backtrace initializer also crashes in dyld on macOS arm64 due to unaligned access.
 		p.parse_define('no_backtrace')
 	}
 }
@@ -420,7 +422,7 @@ fn is_v_compiler_target(npath string) bool {
 // defaults after the effective C compiler has been resolved.
 pub fn (mut p Preferences) normalize_gc_defaults_for_resolved_ccompiler() {
 	p.prefer_openssl_for_bsd_tinyc()
-	p.disable_tcc_shared_backtraces()
+	p.disable_unsupported_tcc_backtraces()
 	if p.prealloc {
 		p.gc_mode = .no_gc
 		p.clear_gc_options()

--- a/vlib/v/pref/pref_test.v
+++ b/vlib/v/pref/pref_test.v
@@ -747,11 +747,27 @@ fn test_tcc_shared_builds_disable_backtraces() {
 	assert 'no_backtrace' in shared_prefs.compile_defines_all
 
 	mut regular_prefs := &pref.Preferences{
-		path:      'main.v'
-		ccompiler: 'tinyc'
+		path:                  'main.v'
+		os:                    .linux
+		arch:                  .amd64
+		ccompiler:             'tinyc'
+		ccompiler_set_by_flag: true
 	}
 	regular_prefs.fill_with_defaults()
 	assert 'no_backtrace' !in regular_prefs.compile_defines_all
+}
+
+fn test_macos_arm64_tcc_builds_disable_backtraces() {
+	mut prefs := &pref.Preferences{
+		path:                  'main.v'
+		os:                    .macos
+		arch:                  .arm64
+		ccompiler:             'tinyc'
+		ccompiler_set_by_flag: true
+	}
+	prefs.fill_with_defaults()
+	assert 'no_backtrace' in prefs.compile_defines_all
+	assert prefs.build_options.contains('-d no_backtrace')
 }
 
 fn test_bsd_tinyc_defaults_to_openssl() {

--- a/vlib/v/tests/assign/assign_option_of_fixed_array_test.v
+++ b/vlib/v/tests/assign/assign_option_of_fixed_array_test.v
@@ -6,3 +6,22 @@ fn test_assign_option_of_fixed_array() {
 	println(addr)
 	assert '${addr}' == 'Option(Addr([1, 2, 3, 4]))'
 }
+
+fn make_fixed_array() [2][3]u8 {
+	return [[u8(1), 2, 3]!, [u8(4), 5, 6]!]!
+}
+
+struct FixedArrayOptions {
+mut:
+	one_dimensional ?[4]u8
+	two_dimensional ?[2][3]u8
+}
+
+fn test_assign_fixed_array_values_to_option_fields() {
+	mut options := FixedArrayOptions{}
+	value := [u8(7), 8, 9, 10]!
+	options.one_dimensional = value
+	options.two_dimensional = make_fixed_array()
+	assert options.one_dimensional? == [u8(7), 8, 9, 10]!
+	assert options.two_dimensional? == [[u8(1), 2, 3]!, [u8(4), 5, 6]!]!
+}

--- a/vlib/v/tests/conditions/ifs/if_expr_match_result_propagation_issue_27988_test.v
+++ b/vlib/v/tests/conditions/ifs/if_expr_match_result_propagation_issue_27988_test.v
@@ -1,0 +1,31 @@
+struct First {}
+
+struct Second {}
+
+type Node = First | Second
+
+fn lower_first(_ First) !int {
+	return 1
+}
+
+fn lower_second(_ Second) !int {
+	return 2
+}
+
+fn select_value(node ?Node) !int {
+	result := if value := node {
+		match value {
+			First { lower_first(value)! }
+			Second { lower_second(value)! }
+		}
+	} else {
+		0
+	}
+	return result
+}
+
+fn test_result_propagation_in_match_nested_in_if_expression() {
+	assert select_value(First{})! == 1
+	assert select_value(Second{})! == 2
+	assert select_value(none)! == 0
+}

--- a/vlib/v/tests/fns/variadic_optional_fn_type_issue_28017_test.v
+++ b/vlib/v/tests/fns/variadic_optional_fn_type_issue_28017_test.v
@@ -1,0 +1,13 @@
+type Job = fn ()
+
+fn compact(values []?Job) int {
+	return values.len
+}
+
+fn combine(values ...?Job) int {
+	return compact(values)
+}
+
+fn test_variadic_optional_fn_is_an_array_of_options() {
+	assert combine() == 0
+}

--- a/vlib/v/tests/interfaces/result_error_return_from_option_interface_or_block_issue_28015_test.v
+++ b/vlib/v/tests/interfaces/result_error_return_from_option_interface_or_block_issue_28015_test.v
@@ -1,0 +1,39 @@
+struct ReproError {
+	message string
+}
+
+fn (err ReproError) msg() string {
+	return err.message
+}
+
+fn (err ReproError) code() int {
+	return 0
+}
+
+interface Something {
+	create() !
+}
+
+struct App {
+mut:
+	something ?&Something
+}
+
+fn (mut app App) get_something() !&Something {
+	mut something := app.something or {
+		return ReproError{
+			message: 'no instance of something'
+		}
+	}
+
+	return something
+}
+
+fn test_result_error_can_be_returned_from_option_interface_or_block() {
+	mut app := App{}
+	app.get_something() or {
+		assert err.msg() == 'no instance of something'
+		return
+	}
+	assert false
+}

--- a/vlib/v/tests/interfaces/result_error_return_from_option_interface_or_block_issue_28015_test.v
+++ b/vlib/v/tests/interfaces/result_error_return_from_option_interface_or_block_issue_28015_test.v
@@ -14,6 +14,10 @@ interface Something {
 	create() !
 }
 
+interface MessagePayload {
+	msg() string
+}
+
 struct App {
 mut:
 	something ?&Something
@@ -29,6 +33,18 @@ fn (mut app App) get_something() !&Something {
 	return something
 }
 
+fn ierror_payload() !IError {
+	return ReproError{
+		message: 'ierror payload'
+	}
+}
+
+fn message_payload() !MessagePayload {
+	return ReproError{
+		message: 'message payload'
+	}
+}
+
 fn test_result_error_can_be_returned_from_option_interface_or_block() {
 	mut app := App{}
 	app.get_something() or {
@@ -36,4 +52,18 @@ fn test_result_error_can_be_returned_from_option_interface_or_block() {
 		return
 	}
 	assert false
+}
+
+fn test_result_interface_payload_is_checked_before_ierror_boxing() {
+	ierror_value := ierror_payload() or {
+		assert false, 'IError payload was returned as an error: ${err}'
+		return
+	}
+	assert ierror_value.msg() == 'ierror payload'
+
+	message_value := message_payload() or {
+		assert false, 'interface payload was returned as an error: ${err}'
+		return
+	}
+	assert message_value.msg() == 'message payload'
 }

--- a/vlib/v3/driver/c_compiler_flags_test.v
+++ b/vlib/v3/driver/c_compiler_flags_test.v
@@ -1,0 +1,17 @@
+module driver
+
+fn test_v3_tcc_backtrace_enabled() {
+	assert !v3_tcc_backtrace_enabled('macos', 'arm64', false)
+	assert v3_tcc_backtrace_enabled('macos', 'amd64', false)
+	assert v3_tcc_backtrace_enabled('linux', 'arm64', false)
+	assert !v3_tcc_backtrace_enabled('linux', 'arm64', true)
+}
+
+fn test_v3_explicit_tcc_flag_plan_skips_backtrace_on_macos_arm64() {
+	plan := v3_c_compiler_flag_plan(V3CCompilerFlagOptions{
+		explicit_tcc: true
+		target_os:    'macos'
+		target_arch:  'arm64'
+	})
+	assert '-bt25' !in plan.before_inputs
+}

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -1727,6 +1727,7 @@ struct V3CCompilerFlagOptions {
 	warn_args            []string
 	vroot                string
 	target_os            string
+	target_arch          string
 	pic_flag             string
 	is_prod              bool
 	no_prod_options      bool
@@ -1774,6 +1775,10 @@ fn v3_c_source_mode_flags(objective_c bool) []string {
 	return []string{}
 }
 
+fn v3_tcc_backtrace_enabled(target_os string, target_arch string, is_shared bool) bool {
+	return !is_shared && !(target_os == 'macos' && target_arch == 'arm64')
+}
+
 fn v3_c_compiler_flag_plan(options V3CCompilerFlagOptions) V3CCompilerFlagPlan {
 	mut before_inputs := options.environment_c_flags.clone()
 	before_inputs << options.target_args
@@ -1790,7 +1795,7 @@ fn v3_c_compiler_flag_plan(options V3CCompilerFlagOptions) V3CCompilerFlagPlan {
 		tcc_lib_dir := os.join_path(options.vroot, 'thirdparty', 'tcc', 'lib')
 		tcc_includes = '-I${os.join_path_single(tcc_lib_dir, 'include')}'
 		before_inputs << [tcc_includes, '-L${tcc_lib_dir}']
-		if !options.is_shared {
+		if v3_tcc_backtrace_enabled(options.target_os, options.target_arch, options.is_shared) {
 			before_inputs << '-bt25'
 		}
 	}
@@ -8434,6 +8439,7 @@ pub fn run(args []string) {
 			warn_args:            warn_args
 			vroot:                prefs.vroot
 			target_os:            prefs.normalized_target_os()
+			target_arch:          prefs.normalized_target_arch()
 			pic_flag:             pic_flag
 			is_prod:              is_prod
 			no_prod_options:      no_prod_options
@@ -8944,7 +8950,9 @@ pub fn run(args []string) {
 			tcc_lib := '-L${tcc_lib_dir}'
 			mut tcc_args := [c_standard, tcc_includes, tcc_lib, '-w',
 				'-Werror=implicit-function-declaration']
-			if !is_shared {
+			if v3_tcc_backtrace_enabled(prefs.normalized_target_os(),
+				prefs.normalized_target_arch(), is_shared)
+			{
 				tcc_args << '-bt25'
 			}
 			if wrapv_flag.len > 0 {
@@ -9023,7 +9031,9 @@ pub fn run(args []string) {
 				tcc_args << pic_flag
 			}
 			tcc_args << [tcc_includes, tcc_lib]
-			if !is_shared {
+			if v3_tcc_backtrace_enabled(prefs.normalized_target_os(),
+				prefs.normalized_target_arch(), is_shared)
+			{
 				tcc_args << '-bt25'
 			}
 			tcc_args << warn_args

--- a/vlib/v3/tests/optional_fixed_array_assign_codegen_test.v
+++ b/vlib/v3/tests/optional_fixed_array_assign_codegen_test.v
@@ -1,0 +1,45 @@
+import os
+
+const vexe = @VEXE
+const tests_dir = os.dir(@FILE)
+const v3_dir = os.dir(tests_dir)
+const vlib_dir = os.dir(v3_dir)
+const v3_src = os.join_path(v3_dir, 'v3.v')
+
+fn test_assign_fixed_array_call_to_option_field() {
+	pid := os.getpid()
+	v3_bin := os.join_path(os.temp_dir(), 'v3_optional_fixed_array_assign_test_${pid}')
+	build :=
+		os.execute('${vexe} -gc none -path "${vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${v3_src}')
+	assert build.exit_code == 0, build.output
+
+	src := os.join_path(os.temp_dir(), 'v3_optional_fixed_array_assign_input_${pid}.v')
+	os.write_file(src, 'struct Foo {
+mut:
+	data ?[2][3]u8
+}
+
+fn make() [2][3]u8 {
+	return [[u8(1), 2, 3]!, [u8(4), 5, 6]!]!
+}
+
+fn main() {
+	mut foo := Foo{}
+	foo.data = make()
+	data := foo.data or { panic("missing fixed array") }
+	assert data == [[u8(1), 2, 3]!, [u8(4), 5, 6]!]!
+}
+')!
+
+	bin := os.join_path(os.temp_dir(), 'v3_optional_fixed_array_assign_input_${pid}')
+	compile := os.execute('${v3_bin} ${src} -b c -o ${bin}')
+	assert compile.exit_code == 0, compile.output
+	assert !compile.output.contains('C compilation failed'), compile.output
+
+	c_code := os.read_file(bin + '.c')!
+	assert c_code.contains('foo.data = ({ Optional_'), c_code
+	assert c_code.contains('memcpy(') && c_code.contains('.value, (make()).ret_arr'), c_code
+
+	run := os.execute(bin)
+	assert run.exit_code == 0, run.output
+}

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -11997,7 +11997,7 @@ fn (mut t Transformer) transform_expr_for_type(id flat.NodeId, target_type strin
 		flat.Node{}
 	}
 	if int(expr) >= 0 && source_node.kind == .call && source_node.typ.contains('[')
-		&& target_type.len > 0 {
+		&& target_type.len > 0 && !t.is_optional_type_name(target_type) {
 		t.set_node_typ(int(expr), target_type)
 	}
 	return t.coerce_transformed_expr_to_type(expr, id, target_type)


### PR DESCRIPTION
## Summary

- fix V1 and V3 assignments of fixed-array call results to optional fixed-array fields
- disable TCC's broken backtrace initializer on macOS arm64 while retaining it on supported targets
- keep optional/result wrappers on variadic function elements instead of marking the variadic array optional
- recognize custom `IError` values before checking a Result value against its interface payload
- preserve propagated call values in match expressions nested inside if-expression temporaries

Closes #28047
Closes #28025
Closes #28017
Closes #28015
Closes #27988

## Testing

- `VFLAGS=-old-compiler ./vnew -old-compiler -silent vlib/v/compiler_errors_test.v` (1618 passed, 1 skipped)
- `VFLAGS=-old-compiler ./vnew -old-compiler -silent test vlib/v/parser/` (8 passed, 1 skipped)
- `VFLAGS=-old-compiler ./vnew -old-compiler -silent test vlib/v/checker/` (4 passed)
- `./vnew -silent vlib/v/gen/c/coutput_test.v` (229 checks passed, 17 skipped)
- `./vnew -silent test vlib/v3/driver/` (4 passed)
- `./vnew -silent test vlib/v3/transform/` (6 passed)
- focused V1/V3 regression, preference, builder, and macOS TCC preallocation tests
- broad V1 `vlib/v/tests/` run: 2191 passed and 16 skipped; it found an optional-scalar variadic regression that was fixed and reverified, while four VLS tests remained environment-blocked because they invoke an unavailable system `v`
