### PR TITLE
net.http: add server-side HTTP/2 response trailers

### DIFF
--- a/vlib/net/http/h2_server.v
+++ b/vlib/net/http/h2_server.v
@@ -936,11 +936,62 @@ fn (mut c H2ServerConn) send_response(stream_id u32, resp Response, mut handler 
 	}
 	body := resp.body.bytes()
 	has_body := body.len > 0
+	trailer_fields := c.h2_outbound_trailer_fields(resp.trailers)
+	has_trailers := trailer_fields.len > 0
+
+	if !has_body && has_trailers {
+		// Trailers-Only: no body separates the response from the trailers, so
+		// both go in one HEADERS block (RFC 9113 §8.1 permits a single HEADERS
+		// frame to carry response and trailer fields together when there is no
+		// DATA in between). This is also the common gRPC "fails immediately"
+		// shape and saves a frame over always splitting.
+		fields << trailer_fields
+		block := c.encoder.encode(fields)
+		c.send_header_block(stream_id, block, true)!
+		return
+	}
+
 	block := c.encoder.encode(fields)
 	c.send_header_block(stream_id, block, !has_body)!
 	if has_body {
-		c.send_body(stream_id, body, mut handler)!
+		c.send_body(stream_id, body, !has_trailers, mut handler)!
 	}
+	// send_body may return early (stream_id no longer in c.streams) if the peer
+	// RST_STREAM'd this stream while we were blocked on flow control. Do not
+	// encode or send trailers in that case: the stream is already torn down on
+	// both ends, and encoding a block that is never transmitted would still
+	// mutate c.encoder's dynamic table, desyncing it from the client's decoder
+	// for every later response on this connection.
+	if has_trailers && stream_id in c.streams {
+		trailer_block := c.encoder.encode(trailer_fields)
+		c.send_header_block(stream_id, trailer_block, true)!
+	}
+}
+
+// h2_outbound_trailer_fields converts handler-authored trailers into wire
+// fields, applying the same RFC 9113 §8.2.2 hop-by-hop filter as the main
+// response headers plus a pseudo-header guard — trailers (like headers) must
+// never carry a pseudo-header field (§8.1) — and the same §8.2.1 forbidden-
+// octet check applied to every inbound field elsewhere in this file
+// (h2_request_field_error, finalize_trailers): a handler-supplied value is
+// wire-bound data too, and Header.add_custom only validates the field NAME,
+// not the value, so nothing upstream of this already rejects an embedded
+// NUL/CR/LF.
+fn (c &H2ServerConn) h2_outbound_trailer_fields(trailers Header) []H2HeaderField {
+	mut fields := []H2HeaderField{}
+	for key in trailers.keys() {
+		lkey := key.to_lower()
+		if lkey.starts_with(':') || lkey in h2_conn_specific_headers {
+			continue
+		}
+		for val in trailers.custom_values(key) {
+			if h2_field_value_has_forbidden_octet(val) {
+				continue
+			}
+			fields << H2HeaderField{lkey, val}
+		}
+	}
+	return fields
 }
 
 fn (mut c H2ServerConn) send_header_block(stream_id u32, block []u8, end_stream bool) ! {
@@ -975,7 +1026,7 @@ fn (mut c H2ServerConn) send_header_block(stream_id u32, block []u8, end_stream 
 	}
 }
 
-fn (mut c H2ServerConn) send_body(stream_id u32, body []u8, mut handler Handler) ! {
+fn (mut c H2ServerConn) send_body(stream_id u32, body []u8, close_stream bool, mut handler Handler) ! {
 	max := int(c.peer.max_frame_size)
 	mut off := 0
 	for off < body.len {
@@ -1009,7 +1060,7 @@ fn (mut c H2ServerConn) send_body(stream_id u32, body []u8, mut handler Handler)
 		c.send_frame(H2DataFrame{
 			stream_id:  stream_id
 			data:       body[off..next]
-			end_stream: next == body.len
+			end_stream: next == body.len && close_stream
 		})!
 		c.send_window -= i64(chunk)
 		if mut s := c.streams[stream_id] {

--- a/vlib/net/http/h2_server_test.v
+++ b/vlib/net/http/h2_server_test.v
@@ -903,6 +903,15 @@ fn (mut h HugeBodyTrailerHandler) handle(req Request) Response {
 // encoder's dynamic table, desyncing it from the client's decoder for every
 // later response on the connection. A second, independent Trailers-Only
 // exchange on the SAME connection afterward proves the encoder stayed in sync.
+//
+// The 100-byte body / 10-byte initial window are chosen so the window is
+// exhausted by the very first DATA frame (10 < h2_default_max_frame_size, so
+// the first chunk is capped at exactly the 10-byte window, not split
+// further); send_body then blocks on its very next iteration and
+// pump_for_window reads the already-buffered RST_STREAM immediately. The
+// test does not depend on how many chunks the remaining 90 bytes would take —
+// only on window << body size, guaranteeing at least one block-and-check
+// cycle happens strictly before the body could complete.
 fn test_h2_server_skips_trailers_after_stream_reset_during_body() {
 	mut client_end, mut server_end := new_pipe()
 	mut handler_iface := Handler(HugeBodyTrailerHandler{

--- a/vlib/net/http/h2_server_test.v
+++ b/vlib/net/http/h2_server_test.v
@@ -654,6 +654,341 @@ fn test_h2_server_accepts_post_with_trailers() {
 	assert status == 200, 'trailers POST should succeed, got status ${status}'
 }
 
+struct BodyTrailerHandler {
+	body string
+}
+
+fn (mut h BodyTrailerHandler) handle(req Request) Response {
+	mut trailers := new_header()
+	trailers.add_custom('grpc-status', '0') or {}
+	trailers.add_custom('grpc-message', 'ok') or {}
+	return Response{
+		status_code: 200
+		body:        h.body
+		trailers:    trailers
+	}
+}
+
+fn test_h2_server_sends_trailers_after_body() {
+	mut client_end, mut server_end := new_pipe()
+	mut handler_iface := Handler(BodyTrailerHandler{
+		body: 'hello'
+	})
+	spawn fn [mut server_end, mut handler_iface] () {
+		mut transport := H2Transport(server_end)
+		serve_h2_conn(mut transport, mut handler_iface) or {}
+	}()
+
+	mut conn := new_h2_conn(client_end)
+	resp := conn.do(H2ClientRequest{ authority: 'h.example' }) or {
+		assert false, 'client do() failed: ${err}'
+		return
+	}
+	assert resp.status == 200
+	assert resp.body.bytestr() == 'hello'
+	assert resp.headers.any(it.name == 'grpc-status' && it.value == '0')
+	assert resp.headers.any(it.name == 'grpc-message' && it.value == 'ok')
+}
+
+// test_h2_server_sends_trailers_as_separate_headers_block drives the raw wire
+// protocol (rather than the high-level client) to verify the actual frame
+// sequence: the DATA frames carrying the body must NOT set END_STREAM when
+// trailers follow, and the trailers must arrive as a second HEADERS block
+// (not merged into the first) that alone carries END_STREAM.
+fn test_h2_server_sends_trailers_as_separate_headers_block() {
+	mut client_end, mut server_end := new_pipe()
+	mut handler_iface := Handler(BodyTrailerHandler{
+		body: 'x'.repeat(20)
+	})
+	spawn fn [mut server_end, mut handler_iface] () {
+		mut transport := H2Transport(server_end)
+		serve_h2_conn(mut transport, mut handler_iface) or {}
+	}()
+
+	mut enc := H2HpackEncoder{}
+	block := enc.encode([
+		H2HeaderField{':method', 'GET'},
+		H2HeaderField{':scheme', 'https'},
+		H2HeaderField{':authority', 'h.example'},
+		H2HeaderField{':path', '/stream'},
+	])
+	mut out := []u8{}
+	out << h2_client_preface.bytes()
+	out << H2Frame(H2SettingsFrame{}).encode()
+	out << H2Frame(H2HeadersFrame{
+		stream_id:   1
+		fragment:    block
+		end_headers: true
+		end_stream:  true
+	}).encode()
+	client_end.write(out) or {
+		assert false, 'client write failed: ${err}'
+		return
+	}
+
+	mut fr := FrameReader{
+		end: client_end
+	}
+	mut dec := H2HpackDecoder{}
+	mut data_end_stream_seen := false
+	mut headers_frame_count := 0
+	mut trailer_fields := []H2HeaderField{}
+	mut got_end := false
+	for !got_end {
+		f := fr.next() or {
+			assert false, 'frame read failed: ${err}'
+			return
+		}
+		match f {
+			H2HeadersFrame {
+				headers_frame_count++
+				decoded := dec.decode(f.fragment) or { []H2HeaderField{} }
+				if headers_frame_count == 2 {
+					trailer_fields = decoded.clone()
+				}
+				if f.end_stream {
+					got_end = true
+				}
+			}
+			H2DataFrame {
+				if f.end_stream {
+					data_end_stream_seen = true
+				}
+			}
+			else {}
+		}
+	}
+	assert headers_frame_count == 2, 'expected response HEADERS + trailer HEADERS, got ${headers_frame_count}'
+	assert !data_end_stream_seen, 'DATA frame must not carry END_STREAM when trailers follow'
+	assert trailer_fields.any(it.name == 'grpc-status' && it.value == '0')
+	assert !trailer_fields.any(it.name == ':status'), 'trailer block must not repeat :status'
+}
+
+struct TrailersOnlyHandler {}
+
+fn (mut h TrailersOnlyHandler) handle(req Request) Response {
+	mut trailers := new_header()
+	trailers.add_custom('grpc-status', '5') or {}
+	trailers.add_custom('grpc-message', 'not found') or {}
+	return Response{
+		status_code: 200
+		trailers:    trailers
+	}
+}
+
+// test_h2_server_trailers_only_response_is_single_frame covers the empty-body
+// case: response and trailer fields must be folded into ONE HEADERS frame
+// (RFC 9113 §8.1 allows this when no DATA separates them) rather than always
+// splitting into two frames with nothing in between.
+fn test_h2_server_trailers_only_response_is_single_frame() {
+	mut client_end, mut server_end := new_pipe()
+	mut handler_iface := Handler(TrailersOnlyHandler{})
+	spawn fn [mut server_end, mut handler_iface] () {
+		mut transport := H2Transport(server_end)
+		serve_h2_conn(mut transport, mut handler_iface) or {}
+	}()
+
+	mut enc := H2HpackEncoder{}
+	block := enc.encode([
+		H2HeaderField{':method', 'GET'},
+		H2HeaderField{':scheme', 'https'},
+		H2HeaderField{':authority', 'h.example'},
+		H2HeaderField{':path', '/fail'},
+	])
+	mut out := []u8{}
+	out << h2_client_preface.bytes()
+	out << H2Frame(H2SettingsFrame{}).encode()
+	out << H2Frame(H2HeadersFrame{
+		stream_id:   1
+		fragment:    block
+		end_headers: true
+		end_stream:  true
+	}).encode()
+	client_end.write(out) or {
+		assert false, 'client write failed: ${err}'
+		return
+	}
+
+	mut fr := FrameReader{
+		end: client_end
+	}
+	mut dec := H2HpackDecoder{}
+	mut headers_frame_count := 0
+	mut fields := []H2HeaderField{}
+	mut got_end := false
+	for !got_end {
+		f := fr.next() or {
+			assert false, 'frame read failed: ${err}'
+			return
+		}
+		match f {
+			H2HeadersFrame {
+				headers_frame_count++
+				fields = dec.decode(f.fragment) or { []H2HeaderField{} }
+				if f.end_stream {
+					got_end = true
+				}
+			}
+			H2DataFrame {
+				assert false, 'unexpected DATA frame in a Trailers-Only response'
+			}
+			else {}
+		}
+	}
+	assert headers_frame_count == 1, 'Trailers-Only response must be a single HEADERS frame, got ${headers_frame_count}'
+	assert fields.any(it.name == ':status' && it.value == '200')
+	assert fields.any(it.name == 'grpc-status' && it.value == '5')
+	assert fields.any(it.name == 'grpc-message' && it.value == 'not found')
+}
+
+struct FilteredTrailerHandler {}
+
+fn (mut h FilteredTrailerHandler) handle(req Request) Response {
+	mut trailers := new_header()
+	trailers.add_custom('grpc-status', '0') or {}
+	trailers.add_custom('connection', 'close') or {}
+	return Response{
+		status_code: 200
+		trailers:    trailers
+	}
+}
+
+// test_h2_server_drops_connection_specific_outbound_trailer_fields checks the
+// same RFC 9113 §8.2.2 hop-by-hop filter applied to normal response headers
+// also applies to handler-authored trailers.
+fn test_h2_server_drops_connection_specific_outbound_trailer_fields() {
+	mut client_end, mut server_end := new_pipe()
+	mut handler_iface := Handler(FilteredTrailerHandler{})
+	spawn fn [mut server_end, mut handler_iface] () {
+		mut transport := H2Transport(server_end)
+		serve_h2_conn(mut transport, mut handler_iface) or {}
+	}()
+
+	mut conn := new_h2_conn(client_end)
+	resp := conn.do(H2ClientRequest{ authority: 'h.example' }) or {
+		assert false, 'client do() failed: ${err}'
+		return
+	}
+	assert resp.status == 200
+	assert resp.headers.any(it.name == 'grpc-status' && it.value == '0')
+	assert !resp.headers.any(it.name == 'connection')
+}
+
+struct HugeBodyTrailerHandler {
+	size int
+}
+
+fn (mut h HugeBodyTrailerHandler) handle(req Request) Response {
+	mut trailers := new_header()
+	if req.url == '/verify' {
+		trailers.add_custom('grpc-status', '9') or {}
+		return Response{
+			status_code: 200
+			trailers:    trailers
+		}
+	}
+	trailers.add_custom('grpc-status', '0') or {}
+	return Response{
+		status_code: 200
+		body:        'x'.repeat(h.size)
+		trailers:    trailers
+	}
+}
+
+// test_h2_server_skips_trailers_after_stream_reset_during_body covers the case
+// where the peer RST_STREAMs a response while send_body is blocked on flow
+// control: send_response must not encode or send a trailer HEADERS block for a
+// stream that no longer exists — sending a frame on a torn-down stream aside,
+// encoding a block that is never transmitted would still mutate the HPACK
+// encoder's dynamic table, desyncing it from the client's decoder for every
+// later response on the connection. A second, independent Trailers-Only
+// exchange on the SAME connection afterward proves the encoder stayed in sync.
+fn test_h2_server_skips_trailers_after_stream_reset_during_body() {
+	mut client_end, mut server_end := new_pipe()
+	mut handler_iface := Handler(HugeBodyTrailerHandler{
+		size: 100
+	})
+	spawn fn [mut server_end, mut handler_iface] () {
+		mut transport := H2Transport(server_end)
+		serve_h2_conn(mut transport, mut handler_iface) or {}
+	}()
+
+	mut enc := H2HpackEncoder{}
+	req1 := enc.encode([
+		H2HeaderField{':method', 'GET'},
+		H2HeaderField{':scheme', 'https'},
+		H2HeaderField{':authority', 'h.example'},
+		H2HeaderField{':path', '/big'},
+	])
+	req2 := enc.encode([
+		H2HeaderField{':method', 'GET'},
+		H2HeaderField{':scheme', 'https'},
+		H2HeaderField{':authority', 'h.example'},
+		H2HeaderField{':path', '/verify'},
+	])
+	mut out := []u8{}
+	out << h2_client_preface.bytes()
+	out << H2Frame(H2SettingsFrame{
+		settings: [H2Setting{h2_settings_initial_window_size, 10}]
+	}).encode()
+	out << H2Frame(H2HeadersFrame{
+		stream_id:   1
+		fragment:    req1
+		end_headers: true
+		end_stream:  true
+	}).encode()
+	// The server can send only 10 bytes of the 100-byte body before blocking on
+	// flow control; reset the stream instead of granting more window.
+	out << H2Frame(H2RstStreamFrame{
+		stream_id:  1
+		error_code: 8 // CANCEL
+	}).encode()
+	// A second, independent request on the same connection — Trailers-Only, so
+	// it does not depend on flow control at all.
+	out << H2Frame(H2HeadersFrame{
+		stream_id:   3
+		fragment:    req2
+		end_headers: true
+		end_stream:  true
+	}).encode()
+	client_end.write(out) or {
+		assert false, 'client write failed: ${err}'
+		return
+	}
+
+	mut fr := FrameReader{
+		end: client_end
+	}
+	mut dec := H2HpackDecoder{}
+	mut stream1_headers_frames := 0
+	mut verify_fields := []H2HeaderField{}
+	mut got_verify := false
+	for !got_verify {
+		f := fr.next() or {
+			assert false, 'frame read failed: ${err}'
+			return
+		}
+		match f {
+			H2HeadersFrame {
+				decoded := dec.decode(f.fragment) or {
+					assert false, 'HPACK decode failed (encoder desynced): ${err}'
+					return
+				}
+				if f.stream_id == 1 {
+					stream1_headers_frames++
+				} else if f.stream_id == 3 {
+					verify_fields = decoded.clone()
+					got_verify = true
+				}
+			}
+			else {}
+		}
+	}
+	assert stream1_headers_frames == 1, 'expected only the initial response HEADERS on stream 1, got ${stream1_headers_frames} (a 2nd would be an illegal post-reset trailer block)'
+	assert verify_fields.any(it.name == ':status' && it.value == '200')
+	assert verify_fields.any(it.name == 'grpc-status' && it.value == '9')
+}
+
 // drive_until_goaway_or_close writes `out`, then reads frames until it sees a
 // GOAWAY (returns its error code) or the connection closes (returns -1). A
 // RST_STREAM on any stream is a wrong-scope answer for a connection error and

--- a/vlib/net/http/response.v
+++ b/vlib/net/http/response.v
@@ -13,8 +13,14 @@ import strings
 // Response represents the result of the request
 pub struct Response {
 pub mut:
-	body         string
-	header       Header
+	body   string
+	header Header
+	// trailers are emitted as a trailing HEADERS block by the HTTP/2 server
+	// path (net.http.h2_server.v) after the body, e.g. for `grpc-status`.
+	// Ignored by the HTTP/1.1 write path — H1 has no wire mechanism for this
+	// enabled here (chunked-encoding trailers are a separate, unimplemented
+	// feature), so fields set here simply do not appear on an H1 response.
+	trailers     Header
 	status_code  int
 	status_msg   string
 	http_version string

--- a/vlib/net/http/server.v
+++ b/vlib/net/http/server.v
@@ -52,7 +52,7 @@ pub mut:
 	cert                   string
 	cert_key               string
 	in_memory_verification bool
-	enable_http2           bool // opt in to HTTP/2 on the TLS listener: advertises ALPN `h2, http/1.1`. Clients that select `h2` are served by the HTTP/2 driver; clients that select `http/1.1` (or send no ALPN) keep the existing HTTP/1.1 path.
+	enable_http2           bool // opt in to HTTP/2. On the TLS listener, advertises ALPN `h2, http/1.1`; clients that select `h2` are served by the HTTP/2 driver, others keep the existing HTTP/1.1 path. On the plain listener, opts into prior-knowledge cleartext h2c (RFC 9113 §3.4): a connection whose first bytes are the HTTP/2 client preface is served by the HTTP/2 driver, others are parsed as HTTP/1.1 as before. A `Server` only ever runs one listener (see listen_and_serve), so one flag unambiguously covers both.
 
 	on_running fn (mut s Server) = unsafe { nil } // Blocking cb. If set, ran by the web server on transitions to its .running state.
 	on_stopped fn (mut s Server) = unsafe { nil } // Blocking cb. If set, ran by the web server on transitions to its .stopped state.
@@ -99,7 +99,7 @@ pub fn (mut s Server) listen_and_serve() {
 	// Create workers
 	mut ws := []thread{cap: s.worker_num}
 	for wid in 0 .. s.worker_num {
-		ws << new_handler_worker(wid, ch, s.handler, s.max_keep_alive_requests)
+		ws << new_handler_worker(wid, ch, s.handler, s.max_keep_alive_requests, s.enable_http2)
 	}
 
 	if s.show_startup_message {
@@ -187,16 +187,18 @@ struct HandlerWorker {
 	id                      int
 	ch                      chan &net.TcpConn
 	max_keep_alive_requests int
+	enable_http2            bool
 pub mut:
 	handler Handler
 }
 
-fn new_handler_worker(wid int, ch chan &net.TcpConn, handler Handler, max_keep_alive_requests int) thread {
+fn new_handler_worker(wid int, ch chan &net.TcpConn, handler Handler, max_keep_alive_requests int, enable_http2 bool) thread {
 	mut w := &HandlerWorker{
 		id:                      wid
 		ch:                      ch
 		handler:                 handler
 		max_keep_alive_requests: max_keep_alive_requests
+		enable_http2:            enable_http2
 	}
 	return spawn w.process_requests()
 }
@@ -223,6 +225,10 @@ fn (mut w HandlerWorker) handle_conn(mut conn net.TcpConn) {
 		unsafe {
 			reader.free()
 		}
+	}
+
+	if w.enable_http2 && try_serve_h2c(mut reader, mut conn, mut w.handler) {
+		return
 	}
 
 	mut request_count := 0

--- a/vlib/net/http/server_h2c.v
+++ b/vlib/net/http/server_h2c.v
@@ -1,0 +1,55 @@
+// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Use of this source code is governed by an MIT license
+// that can be found in the LICENSE file.
+module http
+
+import io
+import net
+
+// h2c_preface_prefix is the leading bytes of the HTTP/2 client connection
+// preface (h2_client_preface, h2_conn.v). RFC 9113 §3.4 chose "PRI" as the
+// pseudo-method specifically because it is not a registered HTTP/1.1 method,
+// so a plain-TCP listener can dispatch on it unambiguously before parsing
+// anything as HTTP/1.1. This is the only h2c bootstrap mechanism implemented:
+// the HTTP/1.1 `Upgrade: h2c` mechanism (RFC 7540 §3.2) was dropped entirely
+// from RFC 9113 and is not supported here.
+const h2c_preface_prefix = h2_client_preface[..4]
+
+// H2cTransport adapts a buffered HTTP/1.1 connection reader to the
+// H2Transport interface for prior-knowledge cleartext HTTP/2 (RFC 9113 §3.4).
+// Reads MUST go through `reader`, never `conn` directly: peek() may already
+// have pulled more than the peeked bytes into the reader's internal buffer,
+// and reading from `conn` directly would silently lose them.
+struct H2cTransport {
+mut:
+	reader &io.BufferedReader
+	conn   &net.TcpConn
+}
+
+fn (mut t H2cTransport) read(mut buf []u8) !int {
+	return t.reader.read(mut buf)
+}
+
+fn (mut t H2cTransport) write(buf []u8) !int {
+	return t.conn.write(buf)
+}
+
+// try_serve_h2c peeks the first bytes of a fresh connection; if they match the
+// start of the HTTP/2 client preface, the connection is handed off to the
+// HTTP/2 server driver for prior-knowledge h2c (RFC 9113 §3.4) and this
+// returns true. Returns false — a no-op, since peek() never consumes bytes —
+// when the connection should be parsed as HTTP/1.1 instead, including when
+// the peek itself fails (e.g. the client connected and sent nothing yet): the
+// existing HTTP/1.1 path already handles that case the same way it always has.
+fn try_serve_h2c(mut reader io.BufferedReader, mut conn net.TcpConn, mut handler Handler) bool {
+	peeked := reader.peek(h2c_preface_prefix.len) or { return false }
+	if peeked.bytestr() != h2c_preface_prefix {
+		return false
+	}
+	mut transport := H2Transport(H2cTransport{
+		reader: reader
+		conn:   conn
+	})
+	serve_h2_conn(mut transport, mut handler) or {}
+	return true
+}

--- a/vlib/net/http/server_h2c_test.v
+++ b/vlib/net/http/server_h2c_test.v
@@ -1,0 +1,176 @@
+// End-to-end test for prior-knowledge cleartext HTTP/2 (RFC 9113 §3.4) on the
+// plain (non-TLS) http.Server listener: a real TCP socket, driven with raw h2
+// frames on one connection and a plain HTTP/1.1 request on another, against
+// the same `enable_http2: true` server.
+module http
+
+import net
+import time
+
+const h2c_atimeout = 500 * time.millisecond
+
+struct H2cEchoHandler {}
+
+fn (mut h H2cEchoHandler) handle(req Request) Response {
+	mut resp_header := new_header()
+	resp_header.add_custom('content-type', 'text/plain') or {}
+	return Response{
+		status_code: 200
+		header:      resp_header
+		body:        'h2c: ${req.method} ${req.url}'
+	}
+}
+
+// server_h2c_frame_reader reads HTTP/2 frames one at a time off a real TCP
+// connection, buffering any leftover bytes between frames. Same shape as
+// h2_server_test.v's FrameReader, backed by net.TcpConn instead of the
+// hermetic in-memory PipeEnd.
+struct ServerH2cFrameReader {
+mut:
+	conn &net.TcpConn
+	buf  []u8
+}
+
+fn (mut r ServerH2cFrameReader) next() !H2Frame {
+	for {
+		if r.buf.len >= h2_frame_header_len {
+			hdr := h2_parse_frame_header(r.buf)!
+			total := h2_frame_header_len + int(hdr.length)
+			if r.buf.len >= total {
+				f := h2_parse_frame(hdr, r.buf[h2_frame_header_len..total])!
+				r.buf = r.buf[total..].clone()
+				return f
+			}
+		}
+		mut tmp := []u8{len: 4096}
+		n := r.conn.read(mut tmp)!
+		r.buf << tmp[..n]
+	}
+	return error('unreachable')
+}
+
+// test_server_h2c_prior_knowledge drives a raw HTTP/2 client preface at a
+// plain `enable_http2: true` listener and confirms it is served by the h2
+// driver (try_serve_h2c in server_h2c.v), with no TLS involved at all.
+fn test_server_h2c_prior_knowledge() {
+	mut server := &Server{
+		accept_timeout:       h2c_atimeout
+		handler:              H2cEchoHandler{}
+		addr:                 ''
+		show_startup_message: false
+		enable_http2:         true
+	}
+	t := spawn server.listen_and_serve()
+	server.wait_till_running() or {
+		assert false, 'server did not start: ${err}'
+		return
+	}
+	defer {
+		server.close()
+		t.wait()
+	}
+
+	mut conn := net.dial_tcp(server.addr)!
+	defer {
+		conn.close() or {}
+	}
+	conn.set_read_timeout(5 * time.second)
+	conn.set_write_timeout(5 * time.second)
+
+	mut enc := H2HpackEncoder{}
+	block := enc.encode([
+		H2HeaderField{':method', 'GET'},
+		H2HeaderField{':scheme', 'http'},
+		H2HeaderField{':authority', server.addr},
+		H2HeaderField{':path', '/h2c'},
+	])
+	mut out := []u8{}
+	out << h2_client_preface.bytes()
+	out << H2Frame(H2SettingsFrame{}).encode()
+	out << H2Frame(H2HeadersFrame{
+		stream_id:   1
+		fragment:    block
+		end_headers: true
+		end_stream:  true
+	}).encode()
+	conn.write(out)!
+
+	mut fr := ServerH2cFrameReader{
+		conn: conn
+	}
+	mut dec := H2HpackDecoder{}
+	mut status := 0
+	mut body := []u8{}
+	mut got_end := false
+	for !got_end {
+		f := fr.next() or {
+			assert false, 'frame read failed: ${err}'
+			return
+		}
+		match f {
+			H2HeadersFrame {
+				for hf in dec.decode(f.fragment) or { []H2HeaderField{} } {
+					if hf.name == ':status' {
+						status = hf.value.int()
+					}
+				}
+				if f.end_stream {
+					got_end = true
+				}
+			}
+			H2DataFrame {
+				body << f.data
+				if f.end_stream {
+					got_end = true
+				}
+			}
+			else {}
+		}
+	}
+	assert status == 200
+	assert body.bytestr() == 'h2c: GET /h2c'
+}
+
+// test_server_h2c_does_not_break_http1 confirms enabling h2c on the plain
+// listener does not disturb ordinary HTTP/1.1 traffic on the same listener —
+// try_serve_h2c must be a true no-op (peek only, nothing consumed) whenever
+// the connection is not an h2 preface.
+fn test_server_h2c_does_not_break_http1() {
+	mut server := &Server{
+		accept_timeout:       h2c_atimeout
+		handler:              H2cEchoHandler{}
+		addr:                 ''
+		show_startup_message: false
+		enable_http2:         true
+	}
+	t := spawn server.listen_and_serve()
+	server.wait_till_running() or {
+		assert false, 'server did not start: ${err}'
+		return
+	}
+	defer {
+		server.close()
+		t.wait()
+	}
+
+	mut conn := net.dial_tcp(server.addr)!
+	defer {
+		conn.close() or {}
+	}
+	conn.set_read_timeout(5 * time.second)
+	conn.set_write_timeout(5 * time.second)
+
+	conn.write('GET /plain HTTP/1.1\r\nHost: ${server.addr}\r\nConnection: close\r\n\r\n'.bytes())!
+	mut resp := []u8{}
+	mut tmp := []u8{len: 4096}
+	for {
+		n := conn.read(mut tmp) or { break }
+		if n <= 0 {
+			break
+		}
+		resp << tmp[..n]
+	}
+	text := resp.bytestr()
+	assert text.starts_with('HTTP/1.1 200')
+	assert text.contains('h2c: GET /plain')
+}


### PR DESCRIPTION
## Summary

This PR ended up shipping two related changes together (branching mistake on my part — the second was meant to be #28067, a separate PR — see note at the bottom):

**1. Server-side HTTP/2 response trailers** (`response.v`, `h2_server.v`, `h2_server_test.v`)
- `http.Response` gains a `trailers Header` field; the HTTP/2 server emits it as a trailing HEADERS block after the body, or folds it into the single response HEADERS when the body is empty (RFC 9113 §8.1's Trailers-Only shape — also the common gRPC "fails immediately" case).
- Outbound trailer fields go through the same RFC 9113 §8.2.2 hop-by-hop / pseudo-header / forbidden-octet filtering already applied to inbound fields elsewhere in this file.
- `HTTP/1.1` write path leaves `trailers` untouched (documented as HTTP/2-only; H1 chunked-trailer emission is a separate, unimplemented feature).
- Closes the last gap for a conformant gRPC server on V's `net.http` h2 stack: a successful gRPC response must carry `grpc-status`/`grpc-message` in HTTP/2 trailers, and the server previously had no send path for them — it could only receive/validate them.

**2. Prior-knowledge cleartext HTTP/2 (h2c) on the plain listener** (`server.v`, `server_h2c.v`, `server_h2c_test.v`)
- `Server.enable_http2` now also opts the plain (non-TLS) listener into h2c per RFC 9113 §3.4: a connection whose first bytes are the HTTP/2 client preface is served by the existing h2 driver; everything else is parsed as HTTP/1.1 unchanged.
- Detection uses `io.BufferedReader.peek()`, which never consumes bytes on a miss.
- Only prior-knowledge h2c is implemented — RFC 9113 dropped the old HTTP/1.1 `Upgrade: h2c` mechanism entirely, and this matches what real gRPC clients use for cleartext.

Related to vlang/v#28063 and we-be/grpc.v#4.

## Test plan
- [x] `./vnew -silent test vlib/net/http/h2_server_test.v` — trailers tests: trailers-after-body, the Trailers-Only single-frame optimization, hop-by-hop field filtering, and a regression test for a stream reset mid-body
- [x] `./vnew -silent test vlib/net/http/server_h2c_test.v` — h2c tests: a real TCP connection driven with raw h2 frames against a plain `enable_http2: true` listener, and a regression check that ordinary HTTP/1.1 traffic on the same listener is untouched
- [x] `./vnew -silent test vlib/net/http/` — full package suite green (27 passed, 2 pre-existing skips, 0 failures)
- [x] `./vnew fmt -w` on all touched files

## Note on #28067

#28067 was meant to carry the h2c change as its own PR, and was opened, reviewed, and fixed independently. It ended up redundant with what's here purely due to a branching mistake on my end (the h2c commit never got removed from this branch's history after being copied over to #28067's branch) — not a duplicate submission. #28067 does contain two small review-prompted fixes not present in this PR's version of the h2c code (debug-only error logging to match the TLS/ALPN listener's existing pattern, and a doc-comment clarification); those are minor and can be picked up separately if wanted.

🧙 Built with [WOZCODE](https://wozcode.com)
