### PR TITLE
net.http: add prior-knowledge cleartext HTTP/2 (h2c) to the plain listener

### DIFF
--- a/vlib/net/http/server.v
+++ b/vlib/net/http/server.v
@@ -52,7 +52,7 @@ pub mut:
 	cert                   string
 	cert_key               string
 	in_memory_verification bool
-	enable_http2           bool // opt in to HTTP/2 on the TLS listener: advertises ALPN `h2, http/1.1`. Clients that select `h2` are served by the HTTP/2 driver; clients that select `http/1.1` (or send no ALPN) keep the existing HTTP/1.1 path.
+	enable_http2           bool // opt in to HTTP/2. On the TLS listener, advertises ALPN `h2, http/1.1`; clients that select `h2` are served by the HTTP/2 driver, others keep the existing HTTP/1.1 path. On the plain listener, opts into prior-knowledge cleartext h2c (RFC 9113 §3.4): a connection whose first bytes are the HTTP/2 client preface is served by the HTTP/2 driver, others are parsed as HTTP/1.1 as before. A `Server` only ever runs one listener (see listen_and_serve), so one flag unambiguously covers both.
 
 	on_running fn (mut s Server) = unsafe { nil } // Blocking cb. If set, ran by the web server on transitions to its .running state.
 	on_stopped fn (mut s Server) = unsafe { nil } // Blocking cb. If set, ran by the web server on transitions to its .stopped state.
@@ -99,7 +99,7 @@ pub fn (mut s Server) listen_and_serve() {
 	// Create workers
 	mut ws := []thread{cap: s.worker_num}
 	for wid in 0 .. s.worker_num {
-		ws << new_handler_worker(wid, ch, s.handler, s.max_keep_alive_requests)
+		ws << new_handler_worker(wid, ch, s.handler, s.max_keep_alive_requests, s.enable_http2)
 	}
 
 	if s.show_startup_message {
@@ -187,16 +187,18 @@ struct HandlerWorker {
 	id                      int
 	ch                      chan &net.TcpConn
 	max_keep_alive_requests int
+	enable_http2            bool
 pub mut:
 	handler Handler
 }
 
-fn new_handler_worker(wid int, ch chan &net.TcpConn, handler Handler, max_keep_alive_requests int) thread {
+fn new_handler_worker(wid int, ch chan &net.TcpConn, handler Handler, max_keep_alive_requests int, enable_http2 bool) thread {
 	mut w := &HandlerWorker{
 		id:                      wid
 		ch:                      ch
 		handler:                 handler
 		max_keep_alive_requests: max_keep_alive_requests
+		enable_http2:            enable_http2
 	}
 	return spawn w.process_requests()
 }
@@ -223,6 +225,10 @@ fn (mut w HandlerWorker) handle_conn(mut conn net.TcpConn) {
 		unsafe {
 			reader.free()
 		}
+	}
+
+	if w.enable_http2 && try_serve_h2c(mut reader, mut conn, mut w.handler) {
+		return
 	}
 
 	mut request_count := 0

--- a/vlib/net/http/server_h2c.v
+++ b/vlib/net/http/server_h2c.v
@@ -1,0 +1,55 @@
+// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Use of this source code is governed by an MIT license
+// that can be found in the LICENSE file.
+module http
+
+import io
+import net
+
+// h2c_preface_prefix is the leading bytes of the HTTP/2 client connection
+// preface (h2_client_preface, h2_conn.v). RFC 9113 §3.4 chose "PRI" as the
+// pseudo-method specifically because it is not a registered HTTP/1.1 method,
+// so a plain-TCP listener can dispatch on it unambiguously before parsing
+// anything as HTTP/1.1. This is the only h2c bootstrap mechanism implemented:
+// the HTTP/1.1 `Upgrade: h2c` mechanism (RFC 7540 §3.2) was dropped entirely
+// from RFC 9113 and is not supported here.
+const h2c_preface_prefix = h2_client_preface[..4]
+
+// H2cTransport adapts a buffered HTTP/1.1 connection reader to the
+// H2Transport interface for prior-knowledge cleartext HTTP/2 (RFC 9113 §3.4).
+// Reads MUST go through `reader`, never `conn` directly: peek() may already
+// have pulled more than the peeked bytes into the reader's internal buffer,
+// and reading from `conn` directly would silently lose them.
+struct H2cTransport {
+mut:
+	reader &io.BufferedReader
+	conn   &net.TcpConn
+}
+
+fn (mut t H2cTransport) read(mut buf []u8) !int {
+	return t.reader.read(mut buf)
+}
+
+fn (mut t H2cTransport) write(buf []u8) !int {
+	return t.conn.write(buf)
+}
+
+// try_serve_h2c peeks the first bytes of a fresh connection; if they match the
+// start of the HTTP/2 client preface, the connection is handed off to the
+// HTTP/2 server driver for prior-knowledge h2c (RFC 9113 §3.4) and this
+// returns true. Returns false — a no-op, since peek() never consumes bytes —
+// when the connection should be parsed as HTTP/1.1 instead, including when
+// the peek itself fails (e.g. the client connected and sent nothing yet): the
+// existing HTTP/1.1 path already handles that case the same way it always has.
+fn try_serve_h2c(mut reader io.BufferedReader, mut conn net.TcpConn, mut handler Handler) bool {
+	peeked := reader.peek(h2c_preface_prefix.len) or { return false }
+	if peeked.bytestr() != h2c_preface_prefix {
+		return false
+	}
+	mut transport := H2Transport(H2cTransport{
+		reader: reader
+		conn:   conn
+	})
+	serve_h2_conn(mut transport, mut handler) or {}
+	return true
+}

--- a/vlib/net/http/server_h2c.v
+++ b/vlib/net/http/server_h2c.v
@@ -7,12 +7,12 @@ import io
 import net
 
 // h2c_preface_prefix is the leading bytes of the HTTP/2 client connection
-// preface (h2_client_preface, h2_conn.v). RFC 9113 §3.4 chose "PRI" as the
-// pseudo-method specifically because it is not a registered HTTP/1.1 method,
-// so a plain-TCP listener can dispatch on it unambiguously before parsing
-// anything as HTTP/1.1. This is the only h2c bootstrap mechanism implemented:
-// the HTTP/1.1 `Upgrade: h2c` mechanism (RFC 7540 §3.2) was dropped entirely
-// from RFC 9113 and is not supported here.
+// preface (h2_client_preface, h2_conn.v) — the literal string "PRI ". RFC
+// 9113 §3.4 chose "PRI" as the pseudo-method specifically because it is not a
+// registered HTTP/1.1 method, so a plain-TCP listener can dispatch on it
+// unambiguously before parsing anything as HTTP/1.1. This is the only h2c
+// bootstrap mechanism implemented: the HTTP/1.1 `Upgrade: h2c` mechanism (RFC
+// 7540 §3.2) was dropped entirely from RFC 9113 and is not supported here.
 const h2c_preface_prefix = h2_client_preface[..4]
 
 // H2cTransport adapts a buffered HTTP/1.1 connection reader to the
@@ -50,6 +50,10 @@ fn try_serve_h2c(mut reader io.BufferedReader, mut conn net.TcpConn, mut handler
 		reader: reader
 		conn:   conn
 	})
-	serve_h2_conn(mut transport, mut handler) or {}
+	serve_h2_conn(mut transport, mut handler) or {
+		$if debug {
+			eprintln('h2c server error: ${err}')
+		}
+	}
 	return true
 }

--- a/vlib/net/http/server_h2c_test.v
+++ b/vlib/net/http/server_h2c_test.v
@@ -1,0 +1,176 @@
+// End-to-end test for prior-knowledge cleartext HTTP/2 (RFC 9113 §3.4) on the
+// plain (non-TLS) http.Server listener: a real TCP socket, driven with raw h2
+// frames on one connection and a plain HTTP/1.1 request on another, against
+// the same `enable_http2: true` server.
+module http
+
+import net
+import time
+
+const h2c_atimeout = 500 * time.millisecond
+
+struct H2cEchoHandler {}
+
+fn (mut h H2cEchoHandler) handle(req Request) Response {
+	mut resp_header := new_header()
+	resp_header.add_custom('content-type', 'text/plain') or {}
+	return Response{
+		status_code: 200
+		header:      resp_header
+		body:        'h2c: ${req.method} ${req.url}'
+	}
+}
+
+// server_h2c_frame_reader reads HTTP/2 frames one at a time off a real TCP
+// connection, buffering any leftover bytes between frames. Same shape as
+// h2_server_test.v's FrameReader, backed by net.TcpConn instead of the
+// hermetic in-memory PipeEnd.
+struct ServerH2cFrameReader {
+mut:
+	conn &net.TcpConn
+	buf  []u8
+}
+
+fn (mut r ServerH2cFrameReader) next() !H2Frame {
+	for {
+		if r.buf.len >= h2_frame_header_len {
+			hdr := h2_parse_frame_header(r.buf)!
+			total := h2_frame_header_len + int(hdr.length)
+			if r.buf.len >= total {
+				f := h2_parse_frame(hdr, r.buf[h2_frame_header_len..total])!
+				r.buf = r.buf[total..].clone()
+				return f
+			}
+		}
+		mut tmp := []u8{len: 4096}
+		n := r.conn.read(mut tmp)!
+		r.buf << tmp[..n]
+	}
+	return error('unreachable')
+}
+
+// test_server_h2c_prior_knowledge drives a raw HTTP/2 client preface at a
+// plain `enable_http2: true` listener and confirms it is served by the h2
+// driver (try_serve_h2c in server_h2c.v), with no TLS involved at all.
+fn test_server_h2c_prior_knowledge() {
+	mut server := &Server{
+		accept_timeout:       h2c_atimeout
+		handler:              H2cEchoHandler{}
+		addr:                 ''
+		show_startup_message: false
+		enable_http2:         true
+	}
+	t := spawn server.listen_and_serve()
+	server.wait_till_running() or {
+		assert false, 'server did not start: ${err}'
+		return
+	}
+	defer {
+		server.close()
+		t.wait()
+	}
+
+	mut conn := net.dial_tcp(server.addr)!
+	defer {
+		conn.close() or {}
+	}
+	conn.set_read_timeout(5 * time.second)
+	conn.set_write_timeout(5 * time.second)
+
+	mut enc := H2HpackEncoder{}
+	block := enc.encode([
+		H2HeaderField{':method', 'GET'},
+		H2HeaderField{':scheme', 'http'},
+		H2HeaderField{':authority', server.addr},
+		H2HeaderField{':path', '/h2c'},
+	])
+	mut out := []u8{}
+	out << h2_client_preface.bytes()
+	out << H2Frame(H2SettingsFrame{}).encode()
+	out << H2Frame(H2HeadersFrame{
+		stream_id:   1
+		fragment:    block
+		end_headers: true
+		end_stream:  true
+	}).encode()
+	conn.write(out)!
+
+	mut fr := ServerH2cFrameReader{
+		conn: conn
+	}
+	mut dec := H2HpackDecoder{}
+	mut status := 0
+	mut body := []u8{}
+	mut got_end := false
+	for !got_end {
+		f := fr.next() or {
+			assert false, 'frame read failed: ${err}'
+			return
+		}
+		match f {
+			H2HeadersFrame {
+				for hf in dec.decode(f.fragment) or { []H2HeaderField{} } {
+					if hf.name == ':status' {
+						status = hf.value.int()
+					}
+				}
+				if f.end_stream {
+					got_end = true
+				}
+			}
+			H2DataFrame {
+				body << f.data
+				if f.end_stream {
+					got_end = true
+				}
+			}
+			else {}
+		}
+	}
+	assert status == 200
+	assert body.bytestr() == 'h2c: GET /h2c'
+}
+
+// test_server_h2c_does_not_break_http1 confirms enabling h2c on the plain
+// listener does not disturb ordinary HTTP/1.1 traffic on the same listener —
+// try_serve_h2c must be a true no-op (peek only, nothing consumed) whenever
+// the connection is not an h2 preface.
+fn test_server_h2c_does_not_break_http1() {
+	mut server := &Server{
+		accept_timeout:       h2c_atimeout
+		handler:              H2cEchoHandler{}
+		addr:                 ''
+		show_startup_message: false
+		enable_http2:         true
+	}
+	t := spawn server.listen_and_serve()
+	server.wait_till_running() or {
+		assert false, 'server did not start: ${err}'
+		return
+	}
+	defer {
+		server.close()
+		t.wait()
+	}
+
+	mut conn := net.dial_tcp(server.addr)!
+	defer {
+		conn.close() or {}
+	}
+	conn.set_read_timeout(5 * time.second)
+	conn.set_write_timeout(5 * time.second)
+
+	conn.write('GET /plain HTTP/1.1\r\nHost: ${server.addr}\r\nConnection: close\r\n\r\n'.bytes())!
+	mut resp := []u8{}
+	mut tmp := []u8{len: 4096}
+	for {
+		n := conn.read(mut tmp) or { break }
+		if n <= 0 {
+			break
+		}
+		resp << tmp[..n]
+	}
+	text := resp.bytestr()
+	assert text.starts_with('HTTP/1.1 200')
+	assert text.contains('h2c: GET /plain')
+}


### PR DESCRIPTION
## Summary
- `Server.enable_http2` now also opts the **plain (non-TLS) listener** into prior-knowledge cleartext HTTP/2 (h2c, RFC 9113 §3.4): a connection whose first bytes are the HTTP/2 client preface is handed off to the existing h2 server driver; everything else is parsed as HTTP/1.1 exactly as before.
- Detection uses `io.BufferedReader.peek()`, which never consumes bytes on a miss — the HTTP/1.1 path is unaffected byte-for-byte when the peek doesn't match.
- Only **prior-knowledge** h2c is implemented. RFC 9113 dropped the old HTTP/1.1 `Upgrade: h2c` mechanism (RFC 7540 §3.2) entirely — it's not supported here, matching the spec and matching what real gRPC clients use for cleartext (e.g. `grpc.Dial` with insecure credentials).
- New `H2cTransport` adapts the buffered connection reader to the existing `H2Transport` interface, so this plugs into the unmodified h2 driver with zero changes to `h2_server.v`.

This is a standalone follow-up to #28066 (server-side response trailers) — same motivation, independent change. Together they're the two items originally scoped in #28063.

Related to vlang/v#28063 and we-be/grpc.v#4 (native gRPC server tracking issue).

## Test plan
- [x] `./vnew -silent test vlib/net/http/server_h2c_test.v` — new end-to-end tests: a real TCP connection driven with raw h2 frames against a plain `enable_http2: true` listener, and a regression check that ordinary HTTP/1.1 traffic on the same listener is untouched
- [x] `./vnew -silent test vlib/net/http/` — full package suite green (27 passed, 2 pre-existing skips, 0 failures), run in complete isolation from #28066 (this branch has exactly one commit ahead of `upstream/master`)
- [x] `./vnew fmt -w` on all touched/new files

🧙 Built with [WOZCODE](https://wozcode.com)