### PR TITLE
term.ui: fix non-ASCII output on Windows consoles

### DIFF
--- a/vlib/term/ui/ui.c.v
+++ b/vlib/term/ui/ui.c.v
@@ -34,16 +34,33 @@ pub fn (mut ctx Context) write(s string) {
 	unsafe { ctx.print_buf.push_many(s.str, s.len) }
 }
 
-// flush displays the accumulated print buffer to the screen.
+// write_to_stdout writes a string to stdout.
+// On Windows, V's standard output path is used, since it converts UTF-8
+// to UTF-16 for consoles, where the code page may not be UTF-8.
 @[inline]
+fn write_to_stdout(s string) {
+	$if windows {
+		print(s)
+		return
+	}
+	C.write(1, s.str, s.len)
+}
+
+// flush displays the accumulated print buffer to the screen.
+@[inline; manualfree]
 pub fn (mut ctx Context) flush() {
 	// TODO: Diff the previous frame against this one, and only render things that changed?
+	if ctx.print_buf.len == 0 {
+		return
+	}
+	// tos() borrows the print buffer; @[manualfree] stops -autofree
+	// from freeing the borrowed string after flush returns.
 	if !ctx.enable_su {
-		C.write(1, ctx.print_buf.data, ctx.print_buf.len)
+		write_to_stdout(unsafe { tos(ctx.print_buf.data, ctx.print_buf.len) })
 	} else {
-		C.write(1, bsu.str, bsu.len)
-		C.write(1, ctx.print_buf.data, ctx.print_buf.len)
-		C.write(1, esu.str, esu.len)
+		write_to_stdout(bsu)
+		write_to_stdout(unsafe { tos(ctx.print_buf.data, ctx.print_buf.len) })
+		write_to_stdout(esu)
 	}
 	ctx.print_buf.clear()
 }


### PR DESCRIPTION
This fixes garbled non-ASCII output from `term.ui` on Windows consoles
whose output code page is not UTF-8 (e.g. 936/GBK, the default on
Chinese systems): for example, the box-drawing glyph `─` is emitted as
the UTF-8 bytes `E2 94 80` and decoded into unrelated CJK glyphs.

`flush()` writes the print buffer directly via `C.write`, i.e. as raw
UTF-8 bytes, which is only correct when the console output code page
is UTF-8. Previously the builtin set that code page to UTF-8 on
startup; after that was removed (c47b8d18b, fix #15124), term.ui kept
writing raw UTF-8 bytes, which broke on non-UTF-8 consoles. On
Windows, the output now goes through `print()`, which converts UTF-8
to UTF-16 when writing to a console. Other platforms and redirected
output are unchanged.

Verified on Windows with console code page 936, where a box border
drawn by `term.ui` renders as mojibake before the fix and correctly
after it (see screenshots below). `v fmt` is clean and
`v test vlib/term/ui` passes. The console path cannot be exercised in
CI (test stdout is a pipe, not a console), so this fix has no
automated test.

---

**Before**
<img width="979" height="512" alt="before" src="https://github.com/user-attachments/assets/a9867dca-72dc-44c2-914d-2a6f19e1a547" />

**After**
<img width="979" height="512" alt="after" src="https://github.com/user-attachments/assets/a662930c-2a00-45d4-8d06-59daf06d31fc" />
