### PR TITLE
compiler: fix V3 captured callbacks and V1 #insert fallback

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -469,7 +469,7 @@ pub fn gen(files []&ast.File, mut table ast.Table, pref_ &pref.Preferences) GenO
 				if stmt.kind == 'flag' && stmt.main.contains('-l') {
 					global_g.mods_with_c_libs[file.mod.name] = true
 				}
-				if stmt.kind in ['include', 'preinclude'] {
+				if stmt.kind in ['include', 'preinclude', 'insert'] {
 					global_g.mods_with_c_includes[file.mod.name] = true
 				}
 			}

--- a/vlib/v/gen/c/coutput_test.v
+++ b/vlib/v/gen/c/coutput_test.v
@@ -586,7 +586,7 @@ fn test_coverage_output_checks_counter_file_open() {
 	}
 }
 
-fn test_c_fallback_decl_uses_module_wide_c_includes() {
+fn test_c_fallback_decl_uses_module_wide_c_inserts() {
 	os.chdir(vroot) or {}
 	test_source := os.join_path(os.vtmp_dir(), 'coutput_module_c_include')
 	os.rmdir_all(test_source) or {}
@@ -595,13 +595,16 @@ fn test_c_fallback_decl_uses_module_wide_c_includes() {
 		os.rmdir_all(test_source) or {}
 	}
 	header_path := os.join_path(test_source, 'c_header_decl.h')
-	os.write_file(header_path, 'int c_header_decl(const char* input);\n')!
+	os.write_file(header_path,
+		'static int c_header_decl(const char *input) { return input != 0; }\n')!
 	header_include_path := header_path.replace('\\', '/')
 	os.write_file(os.join_path(test_source, 'include.v'), 'module main
 
-#include "${header_include_path}"
+#insert "${header_include_path}"
 ')!
 	os.write_file(os.join_path(test_source, 'decl.v'), "module main
+
+#flag -lm
 
 fn C.c_header_decl(input &char) int
 
@@ -609,10 +612,39 @@ fn main() {
 	C.c_header_decl(c'text')
 }
 ")!
-	cmd := '${os.quoted_path(vexe)} -o - ${os.quoted_path(test_source)}'
+	cmd := '${os.quoted_path(vexe)} -old-compiler -o - ${os.quoted_path(test_source)}'
 	compilation := os.execute(cmd)
 	ensure_compilation_succeeded(compilation, cmd)
+	assert compilation.output.contains('static int c_header_decl(const char *input)')
 	assert !compilation.output.contains('extern int c_header_decl(')
+}
+
+fn test_c_fallback_decl_uses_inserted_header() {
+	os.chdir(vroot) or {}
+	test_source := os.join_path(os.vtmp_dir(), 'coutput_inserted_c_header')
+	os.rmdir_all(test_source) or {}
+	os.mkdir_all(test_source)!
+	defer {
+		os.rmdir_all(test_source) or {}
+	}
+	os.write_file(os.join_path(test_source, 'inserted.h'),
+		'static int inserted_const_decl(const char *input) { return input != 0; }\n')!
+	os.write_file(os.join_path(test_source, 'linked.c'), 'int inserted_link_anchor = 0;\n')!
+	os.write_file(os.join_path(test_source, 'main.v'), 'module main
+
+#flag @DIR/linked.c
+#insert "@DIR/inserted.h"
+
+fn C.inserted_const_decl(input &char) int
+
+fn main() {
+	assert C.inserted_const_decl(c\'text\') == 1
+}
+')!
+	executable := os.join_path(test_source, 'inserted_header_test')
+	cmd := '${os.quoted_path(vexe)} -old-compiler -o ${os.quoted_path(executable)} ${os.quoted_path(test_source)}'
+	compilation := os.execute(cmd)
+	ensure_compilation_succeeded(compilation, cmd)
 }
 
 fn test_c_fallback_decl_uses_c_helper_submodule_includes() {

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -678,7 +678,7 @@ fn file_has_c_includes(file &ast.File) bool {
 		return false
 	}
 	for stmt in file.stmts {
-		if stmt is ast.HashStmt && stmt.kind in ['include', 'preinclude'] {
+		if stmt is ast.HashStmt && stmt.kind in ['include', 'preinclude', 'insert'] {
 			return true
 		}
 	}

--- a/vlib/v3/tests/review_transform_regressions_test.v
+++ b/vlib/v3/tests/review_transform_regressions_test.v
@@ -4775,6 +4775,23 @@ fn test_array_filter_and_map_reuse_capturing_callback_state() {
 	assert out == '[2, 3]\n[11, 22, 33]'
 }
 
+fn test_capturing_callback_variable_keeps_declared_parameters() {
+	v3_bin := build_v3_review_transform()
+	out := run_good(v3_bin, 'capturing_callback_variable_parameters', 'fn report(callback fn (int, string)) {
+	callback(42, "ready")
+}
+
+fn main() {
+	prefix := "progress"
+	callback := fn [prefix] (percent int, stage string) {
+		println("\${prefix}:\${percent}:\${stage}")
+	}
+	report(callback)
+}
+')
+	assert out == 'progress:42:ready'
+}
+
 fn test_array_filter_and_map_hoist_bound_method_callbacks() {
 	v3_bin := build_v3_review_transform()
 	source := '@[heap]

--- a/vlib/v3/types/checker_tail_stmt.v
+++ b/vlib/v3/types/checker_tail_stmt.v
@@ -15632,14 +15632,18 @@ fn (tc &TypeChecker) resolve_type_uncached(id flat.NodeId) Type {
 fn (tc &TypeChecker) fn_literal_type(node flat.Node) Type {
 	mut params := []Type{}
 	mut params_mut := []bool{}
+	mut reached_params := false
 	for i in 0 .. node.children_count {
 		child := tc.a.child_node(&node, i)
 		if child.kind != .param {
-			if tc.prefix_param_scan {
+			// Explicit closure captures are stored before the parameter prefix.
+			// Skip those identifiers, then stop once the function body begins.
+			if tc.prefix_param_scan && (reached_params || child.kind != .ident) {
 				break
 			}
 			continue
 		}
+		reached_params = true
 		params_mut << child.is_mut
 		parsed := tc.parse_type(normalize_fn_type_param_text(child.typ))
 		if child.value.len == 0 && child.typ.len > 0 && parsed is Unknown {


### PR DESCRIPTION
On macOS, this failure was a two-stage compiler cascade:

1. V3 is the default, but its prefix parameter scan treated a leading closure capture as the end of a function literal parameter region. A captured callback such as `fn [state] (int, string)` was therefore typed as `fn ()`, causing V3 to request the compatibility fallback.
2. V1 then mishandled `#insert` in a module that links C libraries. It emitted synthesized `extern` declarations after inserted static definitions, which exposed the reported linkage/qualifier conflicts.

This change fixes both paths:

- V3 now skips explicit capture identifiers before scanning the function literal parameter prefix, with coverage for a captured two-parameter callback stored in a variable.
- V1 now classifies `#insert` like `#include` and `#preinclude` when deciding whether inserted C already supplies declarations, for both same-file and module-wide extern fallback decisions.

V3 already handles the inserted Office VBA header correctly; compiling that focused module directly does not emit conflicting externs.

Focused checks:
- `./vnew -old-compiler test vlib/v3/tests/review_transform_regressions_test.v -run-only test_capturing_callback_variable_keeps_declared_parameters`
- `./vnew -silent vlib/v/gen/c/coutput_test.v`
- `VFLAGS=-old-compiler ./vnew -old-compiler -silent vlib/v/compiler_errors_test.v`
- default macOS V3 Office build completed without a V3-to-V1 retry: `/Users/alex/code/v/vnew -no-memory-limit -o /tmp/office_excel_v3_default cmd/excel`