### PR TITLE
net.quic: fix stale Phase 2 status labels in PROGRESS.md

### DIFF
--- a/vlib/net/quic/PROGRESS.md
+++ b/vlib/net/quic/PROGRESS.md
@@ -57,7 +57,7 @@ checklist for exact status. Every checked item has passing tests under
       being rejected) and a minor OpenSSL leak in
       `PublicKey.from_uncompressed_bytes`. Both have regression tests.
 
-## Phase 2 — QUIC-scoped TLS 1.3 handshake + key schedule (NOT STARTED)
+## Phase 2 — QUIC-scoped TLS 1.3 handshake + key schedule (done)
 
 The largest, highest-risk phase. Sub-phases, in build order:
 
@@ -102,9 +102,9 @@ The largest, highest-risk phase. Sub-phases, in build order:
       message bytes, no record-layer framing (RFC 8446 §4.4.1 / RFC 9001
       §4), both extracted from the raw RFC text programmatically, not
       hand-transcribed.
-- **2c — Messages + state machine** (`tls13_messages.v`, `tls13_handshake.v`):
+- [x] **2c — Messages + state machine** (`tls13_messages.v`, `tls13_handshake.v`):
   ClientHello…Finished, the `quic_transport_parameters` extension (0x39),
-  client state machine. In progress — sub-items:
+  client state machine. Sub-items:
   - [x] Generic handshake message framing (`HandshakeType` enum — the real
         RFC 8446 §B.3 v1.3 set only, TLS-1.2-era RESERVED values correctly
         rejected, not silently accepted as unused variants —


### PR DESCRIPTION
## Summary

Small docs-only fix, spotted while bringing PR #27885 (Phase 8) up to
date. `vlib/net/quic/PROGRESS.md`'s Phase 2 section header still said
`(NOT STARTED)`, and its 2c sub-phase said `In progress` — but every
sub-item under both is already checked `[x]`, and Phases 3-8 (which
structurally depend on 2c's client state machine being complete) are all
merged and marked `(done)`. These two labels were simply never updated
when 2c's last item finished; no code changed here, just the stale
status text.

## Test plan

- [x] `./vnew check-md vlib/net/quic/PROGRESS.md` — 0 warnings, 0 errors.
- [x] Manually confirmed every sub-item under Phase 2 (2a, 2b, and all
      of 2c's sub-bullets) is checked `[x]` before flipping the header.

🧙 Built with [WOZCODE](https://wozcode.com)