### PR TITLE
db.pg: expose PostgreSQL result field metadata

### DIFF
--- a/vlib/db/pg/README.md
+++ b/vlib/db/pg/README.md
@@ -188,6 +188,28 @@ defer { conn.close() or {} }
 rows := conn.exec('select 1')!
 ```
 
+## Result Column Metadata
+
+Queries made with `exec_result()`, `exec_param_many_result()`, or
+`exec_prepared_result()` return a `pg.Result` whose `fields` array contains the
+libpq metadata for each result column:
+
+```v oksyntax
+import db.pg
+
+fn show_columns(conn &pg.Conn) ! {
+	result := conn.exec_result('select 1::int4 as id, 3.14::numeric(10, 2) as amount')!
+	for field in result.fields {
+		println('${field.name}: oid=${field.type_oid}, modifier=${field.type_modifier}')
+	}
+}
+```
+
+Each `pg.Field` preserves the type OID, type modifier, fixed size, result format,
+source table OID, and source table column number reported by libpq. Type OIDs for
+user-defined types are database-specific. PostgreSQL can resolve a type OID and
+modifier to its display name with `pg_catalog.format_type(oid, modifier)`.
+
 ## Using Parameterized Queries
 
 Parameterized queries (exec_param, etc.) in V require the use of the following syntax: ($n).

--- a/vlib/db/pg/pg.c.v
+++ b/vlib/db/pg/pg.c.v
@@ -110,11 +110,24 @@ pub mut:
 	vals []string
 }
 
+// Field contains the metadata that libpq reports for a result column.
+pub struct Field {
+pub:
+	name          string
+	type_oid      u32
+	type_modifier int
+	size          int
+	format        int
+	table_oid     u32
+	table_column  int
+}
+
 pub struct Result {
 pub:
-	cols  map[string]int
-	names []string
-	rows  []Row
+	cols   map[string]int
+	names  []string
+	rows   []Row
+	fields []Field
 }
 
 // SslMode controls PostgreSQL SSL/TLS negotiation through libpq's `sslmode`
@@ -229,6 +242,18 @@ fn C.PQntuples(const_res &C.PGresult) i32
 fn C.PQnfields(const_res &C.PGresult) i32
 
 fn C.PQfname(const_res &C.PGresult, i32) &char
+
+fn C.PQftype(const_res &C.PGresult, i32) u32
+
+fn C.PQfmod(const_res &C.PGresult, i32) i32
+
+fn C.PQfsize(const_res &C.PGresult, i32) i32
+
+fn C.PQfformat(const_res &C.PGresult, i32) i32
+
+fn C.PQftable(const_res &C.PGresult, i32) u32
+
+fn C.PQftablecol(const_res &C.PGresult, i32) i32
 
 // Params:
 // const Oid *paramTypes
@@ -490,10 +515,20 @@ fn res_to_result(res voidptr) Result {
 
 	mut cols := map[string]int{}
 	mut names := []string{}
+	mut fields := []Field{cap: nr_cols}
 	for j in 0 .. nr_cols {
 		field_name := unsafe { cstring_to_vstring(C.PQfname(res, j)) }
 		cols[field_name] = j
 		names << field_name
+		fields << Field{
+			name:          field_name
+			type_oid:      C.PQftype(res, j)
+			type_modifier: C.PQfmod(res, j)
+			size:          C.PQfsize(res, j)
+			format:        C.PQfformat(res, j)
+			table_oid:     C.PQftable(res, j)
+			table_column:  C.PQftablecol(res, j)
+		}
 	}
 	mut rows := []Row{}
 	for i in 0 .. nr_rows {
@@ -510,7 +545,12 @@ fn res_to_result(res voidptr) Result {
 	}
 
 	C.PQclear(res)
-	return Result{cols, names, rows}
+	return Result{
+		cols:   cols
+		names:  names
+		rows:   rows
+		fields: fields
+	}
 }
 
 // close releases this conn back to its pool. Safe to call more than once:

--- a/vlib/db/pg/pg_result_test.v
+++ b/vlib/db/pg/pg_result_test.v
@@ -81,4 +81,118 @@ fn test_empty_result_set_returns_col_names() {
 		'id': 0
 	}
 	assert result.rows.len == 0
+	assert result.fields == [
+		pg.Field{
+			name:          'id'
+			type_oid:      23
+			type_modifier: -1
+			size:          4
+			format:        0
+			table_oid:     0
+			table_column:  0
+		},
+	]
+}
+
+fn test_mixed_result_field_metadata() {
+	$if !network ? {
+		eprintln('> Skipping test ${@FN}, since `-d network` is not passed.')
+		eprintln('> This test requires a working postgres server running on localhost.')
+		return
+	}
+
+	mut db := pg.connect(pg.Config{ user: 'postgres', password: '12345678', dbname: 'postgres' })!
+	defer {
+		db.close() or {}
+	}
+
+	result := db.exec_result("SELECT
+		1::int4 AS int4_value,
+		2::int8 AS int8_value,
+		3.14::numeric(10, 2) AS numeric_value,
+		true::boolean AS bool_value,
+		now()::timestamptz AS timestamptz_value,
+		'hello'::text AS text_value,
+		'{}'::jsonb AS jsonb_value,
+		'fixed'::varchar(32) AS varchar_value")!
+
+	assert result.fields.map(it.name) == [
+		'int4_value',
+		'int8_value',
+		'numeric_value',
+		'bool_value',
+		'timestamptz_value',
+		'text_value',
+		'jsonb_value',
+		'varchar_value',
+	]
+	assert result.fields.map(it.type_oid) == [u32(23), 20, 1700, 16, 1184, 25, 3802, 1043]
+	assert result.fields.map(it.type_modifier) == [-1, -1, 655366, -1, -1, -1, -1, 36]
+	assert result.fields.map(it.size) == [4, 8, -1, 1, 8, -1, -1, -1]
+	assert result.fields.all(it.format == 0)
+	assert result.fields.all(it.table_oid == 0)
+	assert result.fields.all(it.table_column == 0)
+	assert result.rows.len == 1
+	assert result.rows[0].val(0) == '1'
+	assert result.rows[0].val(1) == '2'
+	assert result.rows[0].val(2) == '3.14'
+	assert result.rows[0].val(3) == 't'
+	assert result.rows[0].val(5) == 'hello'
+	assert result.rows[0].val(6) == '{}'
+	assert result.rows[0].val(7) == 'fixed'
+}
+
+fn assert_parameterized_result_fields(result pg.Result) {
+	assert result.fields.map(it.name) == ['id', 'label']
+	assert result.fields.map(it.type_oid) == [u32(23), 1043]
+	assert result.fields.map(it.type_modifier) == [-1, 16]
+	assert result.rows.len == 1
+	assert result.rows[0].val(0) == '7'
+	assert result.rows[0].val(1) == 'hello'
+}
+
+fn test_parameterized_result_field_metadata() {
+	$if !network ? {
+		eprintln('> Skipping test ${@FN}, since `-d network` is not passed.')
+		eprintln('> This test requires a working postgres server running on localhost.')
+		return
+	}
+
+	mut db := pg.connect(pg.Config{ user: 'postgres', password: '12345678', dbname: 'postgres' })!
+	defer {
+		db.close() or {}
+	}
+	query := 'SELECT $1::int4 AS id, $2::varchar(12) AS label'
+	params := ['7', 'hello']
+
+	param_result := db.exec_param_many_result(query, params)!
+	assert_parameterized_result_fields(param_result)
+
+	db.prepare('pg_field_metadata_stmt', query, params.len)!
+	prepared_result := db.exec_prepared_result('pg_field_metadata_stmt', params)!
+	assert_parameterized_result_fields(prepared_result)
+}
+
+fn test_result_field_table_origin() {
+	$if !network ? {
+		eprintln('> Skipping test ${@FN}, since `-d network` is not passed.')
+		eprintln('> This test requires a working postgres server running on localhost.')
+		return
+	}
+
+	mut db := pg.connect(pg.Config{ user: 'postgres', password: '12345678', dbname: 'postgres' })!
+	defer {
+		db.close() or {}
+	}
+	db.exec('CREATE TEMP TABLE pg_field_metadata_test (id int4, name varchar(20))')!
+	result := db.exec_result('SELECT id, name FROM pg_field_metadata_test WHERE false')!
+	assert result.rows.len == 0
+	assert result.fields.len == 2
+	assert result.fields[0].table_oid != 0
+	assert result.fields[0].table_oid == result.fields[1].table_oid
+	assert result.fields[0].table_column == 1
+	assert result.fields[1].table_column == 2
+	assert result.fields[0].type_oid == 23
+	assert result.fields[1].type_oid == 1043
+	assert result.fields[1].type_modifier == 24
 }


### PR DESCRIPTION
## Summary

- expose libpq column metadata through `pg.Result.fields`
- preserve type OID, type modifier, size, format, and source table information before `PQclear()`
- document the new result metadata API
- cover direct, parameterized, prepared, empty-result, mixed-type, and table-origin queries

## Why

`pg.Result` previously retained only column names and rows. Column type information from libpq was
discarded when the underlying `PGresult` was cleared, forcing callers to treat every result column as
text.

## Validation

- `./vnew fmt -w vlib/db/pg/pg_result_test.v`
- `git diff --check`
- `./vnew -d network -silent vlib/db/pg/pg_result_test.v`
- `./vnew -silent test vlib/db/pg/` (2 passed, 4 network-gated files skipped)
- `./vnew -d network -silent test vlib/db/pg/` (5 passed; existing
  `test_listen_notify` failed because the received channel was empty)
