### PR TITLE
HTTP/3 (QUIC) foundation: Phase 9 (QuicConn top-level struct and event loop)

### DIFF
--- a/vlib/net/quic/PROGRESS.md
+++ b/vlib/net/quic/PROGRESS.md
@@ -864,14 +864,14 @@ The largest, highest-risk phase. Sub-phases, in build order:
       one-sided and both-sided paths and confirms a large-but-finite,
       strictly positive `Duration` comes back.
 
-## Phase 9 — QuicConn top-level struct and event loop (IN PROGRESS)
+## Phase 9 — QuicConn top-level struct and event loop
 
 No prior phase composes any two of the pieces built so far — every phase
 built independently unit-tested state and deferred wiring to "a future
 QuicConn." `vlib/net/quic/conn.v` is that wiring. Sub-phased like Phase 2,
 landing as one PR:
 
-- [ ] **9a — Connection establishment** (`conn.v`): `dial()` picks
+- [x] **9a — Connection establishment** (`conn.v`): `dial()` picks
       `scid`/`original_dcid`, derives Initial secrets, builds ClientHello.
       `poll()`/`process_timeouts()` handle Retry/VN detection (RFC 9000
       §17.2.5.2's at-most-one-Retry + VN/Retry anti-spoof state, both
@@ -882,7 +882,7 @@ landing as one PR:
       `CryptoStreamReassembler`, ACK generation/processing for
       Initial/Handshake tied into `loss_detection.v`, idle timeout, and key
       discard on handshake confirmation (RFC 9001 §4.9).
-- [ ] **9b — Steady state**: 1-RTT packet processing (STREAM/ACK/
+- [x] **9b — Steady state**: 1-RTT packet processing (STREAM/ACK/
       CONNECTION_CLOSE dispatch into `QuicStreamSet` + flow control both
       directions), `open_stream`/`write_stream`/`read_stream`, full
       loss-detection↔congestion-control wiring for 1-RTT sends,
@@ -890,10 +890,24 @@ landing as one PR:
       current limit, stateless-reset detection on decrypt failure, ECN
       count recording, graceful/immediate close, 1-RTT key update rotation
       (`app_read_keys`/`app_write_keys`).
-- [ ] Tests: `conn_test.v`, hand-built ServerHello→Finished fixtures
+- [x] Tests: `conn_test.v`, hand-built ServerHello→Finished fixtures
       (reusing Phase 2's RFC 8448/quiche vectors, no live server) driving
       `dial()`+`poll()` to `handshake_confirmed`; STREAM data round-trip
       through `poll()`; CONNECTION_CLOSE handling; key update.
+- [x] `/vreview` found and fixed two real bugs, both reproduced with a
+      failing test before the fix landed (Phase R): (1) `write_stream`/
+      `read_stream` never called `ensure_stream_windows` for a stream that
+      only exists because RFC 9000 §2.1 auto-created it as a lower-numbered
+      sibling of a peer-referenced higher stream ID — such a stream had no
+      flow-control window, so a local write to it queued forever with no
+      error, never reaching the wire; (2) `handle_peer_connection_close`
+      and the stateless-reset branch of `note_one_rtt_processing_failed`
+      transitioned to `.draining` without setting `closing_deadline` (RFC
+      9000 §10.2.2 requires the draining period to be bounded, same as
+      closing) — a peer-initiated close, the most common real-world close
+      path, left the connection draining forever instead of eventually
+      reaching `.closed`. Fixed with a shared `enter_draining(now)` helper
+      mirroring `close_with_error`'s existing deadline formula.
 
 Connection ID rotation/migration is explicitly OUT of scope (not deferred
 to a later phase — `stateless_reset.v`/`pmtu.v` both say so independently):

--- a/vlib/net/quic/PROGRESS.md
+++ b/vlib/net/quic/PROGRESS.md
@@ -864,12 +864,46 @@ The largest, highest-risk phase. Sub-phases, in build order:
       one-sided and both-sided paths and confirms a large-but-finite,
       strictly positive `Duration` comes back.
 
-## Phases 9-14 (NOT STARTED)
+## Phase 9 — QuicConn top-level struct and event loop (IN PROGRESS)
+
+No prior phase composes any two of the pieces built so far — every phase
+built independently unit-tested state and deferred wiring to "a future
+QuicConn." `vlib/net/quic/conn.v` is that wiring. Sub-phased like Phase 2,
+landing as one PR:
+
+- [ ] **9a — Connection establishment** (`conn.v`): `dial()` picks
+      `scid`/`original_dcid`, derives Initial secrets, builds ClientHello.
+      `poll()`/`process_timeouts()` handle Retry/VN detection (RFC 9000
+      §17.2.5.2's at-most-one-Retry + VN/Retry anti-spoof state, both
+      explicitly documented in `retry.v`/`version_negotiation.v` as this
+      phase's job), Initial/Handshake packet demux→unprotect→frame-parse,
+      driving `Tls13ClientHandshake` through to `process_finished`, key
+      derivation/promotion per level, CRYPTO-frame reassembly via
+      `CryptoStreamReassembler`, ACK generation/processing for
+      Initial/Handshake tied into `loss_detection.v`, idle timeout, and key
+      discard on handshake confirmation (RFC 9001 §4.9).
+- [ ] **9b — Steady state**: 1-RTT packet processing (STREAM/ACK/
+      CONNECTION_CLOSE dispatch into `QuicStreamSet` + flow control both
+      directions), `open_stream`/`write_stream`/`read_stream`, full
+      loss-detection↔congestion-control wiring for 1-RTT sends,
+      MAX_STREAMS enforcement on locally-opened streams against the peer's
+      current limit, stateless-reset detection on decrypt failure, ECN
+      count recording, graceful/immediate close, 1-RTT key update rotation
+      (`app_read_keys`/`app_write_keys`).
+- [ ] Tests: `conn_test.v`, hand-built ServerHello→Finished fixtures
+      (reusing Phase 2's RFC 8448/quiche vectors, no live server) driving
+      `dial()`+`poll()` to `handshake_confirmed`; STREAM data round-trip
+      through `poll()`; CONNECTION_CLOSE handling; key update.
+
+Connection ID rotation/migration is explicitly OUT of scope (not deferred
+to a later phase — `stateless_reset.v`/`pmtu.v` both say so independently):
+`QuicConn` holds exactly one local `scid` and tracks the peer's current
+`dcid`, no active CID set, no NEW_CONNECTION_ID/RETIRE_CONNECTION_ID.
+
+## Phases 10-14 (NOT STARTED)
 
 See the tracking issue for full detail on each. In order:
 
-9. `QuicConn` — top-level struct, `poll()`/`process_timeouts()` event-loop
-   contract.
 10. HTTP/3 framing (RFC 9114) — incremental/resumable parsing (structurally
     different from HTTP/2's single-shot framing).
 11. QPACK (RFC 9204) — absolute indexing, encoder/decoder streams, blocked-

--- a/vlib/net/quic/conn.v
+++ b/vlib/net/quic/conn.v
@@ -1,0 +1,1486 @@
+module quic
+
+import time
+import rand
+
+// RFC 9000/9001 — QuicConn is the top-level connection struct wiring
+// together every independently-built piece from Phases 0-8: packet/header
+// protection, the TLS 1.3 handshake, packet number spaces, CRYPTO stream
+// reassembly, loss detection, NewReno congestion control, and
+// connection-lifecycle bookkeeping (idle timeout, CONNECTION_CLOSE,
+// stateless reset, ECN). No prior file composes any two of these; this file
+// is that composition.
+//
+// Phase 9a scope: connection establishment only, through the real RFC 9001
+// §4.1.2 "confirmed" checkpoint (not merely "complete" -- see
+// handshake_confirm.v). Steady-state 1-RTT application data (STREAM frames,
+// flow control, open/write/read_stream) is Phase 9b's job; this file
+// accepts those frame types on the wire without erroring (they are legal at
+// this packet-number space, RFC 9000 §12.4) but does not yet act on them.
+//
+// Single-threaded, caller-driven event loop (the tracking issue's own
+// wording: "mirroring how quiche/ngtcp2 expose themselves as libraries"):
+// this struct owns state, the caller owns actual socket I/O and calls
+// poll()/process_timeouts() to advance it. Nothing happens off the
+// caller's own call stack -- no locks, no background threads.
+//
+// Connection ID rotation/migration is explicitly out of v1 scope (not
+// deferred -- stateless_reset.v/pmtu.v both already say so independently):
+// exactly one local `scid` and one tracked peer `dcid`, no active CID set,
+// no NEW_CONNECTION_ID/RETIRE_CONNECTION_ID.
+
+// local_cid_len is this client's own chosen connection-ID length -- within
+// RFC 9000 §17.2's 20-byte v1 limit, matching common real-world practice
+// (quiche and others typically use 8).
+const local_cid_len = 8
+
+// aead_tag_len is AES-128-GCM's fixed authentication tag length (RFC 9001
+// §5.3), confirmed against initial_exchange_test.v's own literal use in the
+// same padding-size calculation this file's build_initial_packet mirrors.
+const aead_tag_len = 16
+
+// quic_error_protocol_violation is RFC 9000 §20.1's PROTOCOL_VIOLATION --
+// the fallback CONNECTION_CLOSE error code for an internal failure that
+// carries no more specific QUIC error code of its own (see close_with_error).
+const quic_error_protocol_violation = u64(0x0a)
+
+// default_max_ack_delay is RFC 9000 §18.2's stated default for the
+// max_ack_delay transport parameter, used until the peer's own value (if
+// any) is known.
+const default_max_ack_delay_ms = u64(25)
+
+pub enum ConnectionState {
+	handshaking
+	established
+	closing
+	draining
+	closed
+}
+
+// QuicDatagram is one UDP datagram this connection needs the caller to
+// actually write to the socket.
+pub struct QuicDatagram {
+pub:
+	bytes []u8
+}
+
+pub enum QuicEventKind {
+	handshake_confirmed
+	connection_closed
+}
+
+// QuicEvent reports one thing that happened during a poll()/
+// process_timeouts() call. `error_code`/`reason` are set only for
+// connection_closed.
+pub struct QuicEvent {
+pub:
+	kind       QuicEventKind
+	error_code ?u64
+	reason     string
+}
+
+// PollResult reports everything one poll()/process_timeouts() call
+// produced: events, datagrams the caller must now send, and when to next
+// call process_timeouts() if nothing else arrives first (none means no
+// timer is currently armed).
+pub struct PollResult {
+pub mut:
+	events       []QuicEvent
+	outgoing     []QuicDatagram
+	next_timeout ?u64
+}
+
+// DialParams is everything dial() needs beyond what it decides for itself
+// (connection IDs, ClientHello random). `transport_parameters` is this
+// client's own OFFERED set; dial() overrides its
+// initial_source_connection_id with the freshly-picked scid regardless of
+// what the caller set there.
+pub struct DialParams {
+pub:
+	server_name          string
+	ca_bundle_pem        string
+	alpn_protocols       []string
+	transport_parameters QuicTransportParameters
+}
+
+@[heap]
+pub struct QuicConn {
+mut:
+	role  QuicRole
+	state ConnectionState
+
+	original_dcid                 []u8
+	dcid                          []u8
+	scid                          []u8
+	peer_scid                     []u8
+	token                         []u8
+	retry_accepted                bool
+	processed_first_server_packet bool
+	retry_scid                    ?[]u8
+
+	handshake            &Tls13ClientHandshake
+	handshake_completion &HandshakeCompletionState
+	pn_spaces            &QuicPacketNumberSpaces
+
+	initial_keys_client      QuicPacketProtectionKeys
+	initial_keys_server      QuicPacketProtectionKeys
+	initial_keys_discarded   bool
+	handshake_keys_client    ?QuicPacketProtectionKeys
+	handshake_keys_server    ?QuicPacketProtectionKeys
+	handshake_keys_discarded bool
+	app_write_keys           ?QuicPacketProtectionKeys
+	app_read_keys            ?&KeyUpdateState
+
+	initial_crypto               &CryptoStreamReassembler
+	initial_crypto_consumed      u64
+	handshake_crypto             &CryptoStreamReassembler
+	handshake_crypto_consumed    u64
+	handshake_crypto_send_offset u64
+
+	client_hello             []u8
+	pending_initial_crypto   ?[]u8
+	pending_handshake_crypto ?[]u8
+
+	loss_detection     &QuicLossDetectionTimer
+	congestion_control NewRenoCongestionControl
+
+	own_max_idle_timeout_ms u64
+	idle_timeout            IdleTimeoutState
+	connection_close        ConnectionCloseTracker
+	stateless_reset         StatelessResetTracker
+	ecn                     EcnState
+
+	initial_received_pns   map[u64]bool
+	handshake_received_pns map[u64]bool
+	app_received_pns       map[u64]bool
+
+	connection_start u64
+
+	// -- Phase 9b: steady-state 1-RTT state ---------------------------------
+	own_transport_parameters QuicTransportParameters
+
+	streams              &QuicStreamSet
+	stream_send_windows  map[u64]&FlowControlWindow
+	stream_recv_windows  map[u64]&ReceiveWindow
+	pending_stream_write map[u64]PendingStreamWrite
+	pending_stream_reset map[u64]u64 // stream_id -> error_code, queued RESET_STREAM frames
+	conn_bytes_read      u64
+
+	conn_send_window FlowControlWindow
+	conn_recv_window ReceiveWindow
+
+	// local_max_streams_* are the FIXED caps this endpoint advertised to the
+	// peer (via own_transport_parameters) for how many streams the peer may
+	// open to us -- v1 simplification: never dynamically raised with a
+	// follow-up MAX_STREAMS frame of our own (documented follow-up, not a
+	// Phase 9b blocker). peer_max_streams_* are the CURRENT caps the peer
+	// has told us (initial transport parameter, then raised by any
+	// MAX_STREAMS frames received) for how many streams we may open to it.
+	local_max_streams_bidi u64
+	local_max_streams_uni  u64
+	peer_max_streams_bidi  u64
+	peer_max_streams_uni   u64
+	// last value we've already told the peer we're blocked at, per
+	// direction -- avoids re-sending a redundant STREAMS_BLOCKED for the
+	// same still-unraised limit on every subsequent open_stream() call.
+	streams_blocked_sent_bidi ?u64
+	streams_blocked_sent_uni  ?u64
+	pending_streams_blocked   []StreamDirection
+
+	pending_close      ?PendingClose
+	sent_close_payload ?[]u8
+	closing_deadline   ?u64
+}
+
+// PendingStreamWrite accumulates data queued via write_stream() awaiting
+// the next drain_outgoing() call -- fin OR-latches (once true, a later
+// write_stream(..., fin: false) call never un-sets it; RFC 9000 §3.1 has no
+// "un-FIN" operation).
+struct PendingStreamWrite {
+mut:
+	data []u8
+	fin  bool
+}
+
+// PendingClose is set by the public close() API and drained by the next
+// poll()/process_timeouts() call (which has the `now`/PollResult context
+// close() itself deliberately doesn't take -- matching the "nothing
+// happens off the caller's own call stack" rule the rest of this file
+// follows).
+struct PendingClose {
+	error_code           u64
+	reason               string
+	is_application_error bool
+}
+
+// state reports which of RFC 9000's connection lifecycle states this
+// connection is currently in.
+pub fn (c &QuicConn) state() ConnectionState {
+	return c.state
+}
+
+// role reports which side of the connection this endpoint is. v1 is always
+// .client (see stream.v's QuicRole doc comment).
+pub fn (c &QuicConn) role() QuicRole {
+	return c.role
+}
+
+// -------------------------------------------------------------------------
+// Streams and application data (Phase 9b)
+// -------------------------------------------------------------------------
+
+// ensure_stream_windows lazily creates `id`'s per-stream flow-control
+// windows the first time this connection sees it -- from either side (a
+// local open_stream() call, or the first STREAM/RESET_STREAM/etc. frame
+// naming a peer-opened stream). Both directions' windows are always
+// created regardless of which half `id`'s category actually has (matches
+// new_quic_stream's own "populate exactly the halves this endpoint has"
+// pattern being a SEPARATE, QuicStream-level concern -- an unused window
+// here just never gets touched, which is cheaper than threading the
+// has_send/has_recv distinction through every call site).
+fn (mut c QuicConn) ensure_stream_windows(id StreamId) {
+	if id.value !in c.stream_send_windows {
+		limit := initial_send_limit_for_stream(id, c.role, c.handshake.peer_transport_parameters)
+		mut w := new_flow_control_window(limit)
+		c.stream_send_windows[id.value] = &w
+	}
+	if id.value !in c.stream_recv_windows {
+		limit := initial_receive_limit_for_stream(id, c.role, c.own_transport_parameters)
+		mut w := new_receive_window(limit)
+		c.stream_recv_windows[id.value] = &w
+	}
+}
+
+// open_stream opens a new LOCALLY-initiated stream (bidirectional if `bidi`,
+// else unidirectional), enforcing RFC 9000 §4.6's peer-imposed MAX_STREAMS
+// limit -- QuicStreamSet.open_local_stream itself does NOT check this (see
+// its own doc comment), so this is where that check belongs. Queues a
+// STREAMS_BLOCKED frame (once per still-unraised limit value, not on every
+// call) when blocked, per RFC 9000 §19.14.
+pub fn (mut c QuicConn) open_stream(bidi bool) !u64 {
+	direction := if bidi { StreamDirection.bidirectional } else { StreamDirection.unidirectional }
+	opened_count := if bidi { c.streams.next_local_bidi } else { c.streams.next_local_uni }
+	limit := if bidi { c.peer_max_streams_bidi } else { c.peer_max_streams_uni }
+	if opened_count >= limit {
+		already_reported := if bidi {
+			c.streams_blocked_sent_bidi
+		} else {
+			c.streams_blocked_sent_uni
+		}
+		mut should_report := true
+		if v := already_reported {
+			should_report = v != limit
+		}
+		if should_report {
+			c.pending_streams_blocked << direction
+			if bidi {
+				c.streams_blocked_sent_bidi = limit
+			} else {
+				c.streams_blocked_sent_uni = limit
+			}
+		}
+		return error('quic: STREAM_LIMIT: peer allows only ${limit} ${direction} stream(s), already opened ${opened_count}')
+	}
+	stream := c.streams.open_local_stream(direction)
+	c.ensure_stream_windows(stream.id)
+	return stream.id.value
+}
+
+// write_stream queues `data` (and, if `fin`, the end of the stream) to send
+// on `stream_id`. Nothing is actually sent until the next poll()/
+// process_timeouts() call drains it -- matching this file's own "nothing
+// happens off the caller's own call stack" invariant. Actual flow-control
+// admission (both this stream's own send window and the connection-level
+// one) is checked at DRAIN time, not here, since the available budget can
+// change between queuing and draining (a MAX_DATA/MAX_STREAM_DATA frame
+// might arrive first).
+pub fn (mut c QuicConn) write_stream(stream_id u64, data []u8, fin bool) ! {
+	stream := c.streams.get(stream_id) or { return error('quic: unknown stream ${stream_id}') }
+	if !stream.has_send() {
+		return error('quic: stream ${stream_id} has no send side')
+	}
+	if stream.send.state == .data_sent || stream.send.state == .reset_sent
+		|| stream.send.state == .reset_recvd || stream.send.state == .data_recvd {
+		return error('quic: stream ${stream_id} send side already closed (state ${stream.send.state})')
+	}
+	// A stream can exist in c.streams without flow-control windows yet: RFC
+	// 9000 §2.1 requires get_or_create to auto-create every LOWER-numbered
+	// same-category stream when the peer references a higher one directly,
+	// and only the explicitly-named frame.stream_id gets its windows
+	// created at that point (handle_stream_frame/handle_reset_stream_frame).
+	// Without this call, drain_pending_stream_writes' window lookup for
+	// such a sibling would never succeed, and the write would be queued
+	// forever with no error (found via /vreview -- see
+	// test_write_stream_on_auto_created_sibling_stream_is_not_stuck).
+	c.ensure_stream_windows(StreamId{
+		value: stream_id
+	})
+	mut pending := c.pending_stream_write[stream_id] or { PendingStreamWrite{} }
+	pending.data << data
+	pending.fin = pending.fin || fin
+	c.pending_stream_write[stream_id] = pending
+}
+
+// read_stream returns and consumes whatever new bytes have arrived on
+// `stream_id` since the last read_stream() call (an empty slice if
+// nothing new has arrived). Advances the stream's own read-side
+// flow-control marker AND the connection-level one -- see
+// should_advertise_more's own doc comment for why both must move together.
+pub fn (mut c QuicConn) read_stream(stream_id u64) ![]u8 {
+	mut stream := c.streams.get(stream_id) or { return error('quic: unknown stream ${stream_id}') }
+	if !stream.has_recv() {
+		return error('quic: stream ${stream_id} has no receive side')
+	}
+	// See write_stream's identical call for why this is needed even for an
+	// already-existing stream (an auto-created sibling may have no windows
+	// yet).
+	c.ensure_stream_windows(StreamId{
+		value: stream_id
+	})
+	data := stream.recv.reassembler.data().clone()
+	if data.len == 0 {
+		return data
+	}
+	new_base := stream.recv.reassembler.consumed_len()
+	stream.recv.reassembler.discard(new_base)!
+	if mut w := c.stream_recv_windows[stream_id] {
+		w.note_read(new_base)
+	}
+	c.conn_bytes_read += u64(data.len)
+	c.conn_recv_window.note_read(c.conn_bytes_read)
+	return data
+}
+
+// close requests a graceful, application-initiated shutdown. Like
+// write_stream, nothing happens synchronously -- the CONNECTION_CLOSE
+// frame is built and sent on the next poll()/process_timeouts() call. A
+// no-op once already closing/draining/closed.
+pub fn (mut c QuicConn) close(error_code u64, reason string) {
+	if c.state == .closing || c.state == .draining || c.state == .closed {
+		return
+	}
+	c.pending_close = PendingClose{
+		error_code:           error_code
+		reason:               reason
+		is_application_error: true
+	}
+}
+
+// dial starts a new client connection attempt: picks this endpoint's own
+// connection IDs, derives Initial secrets, builds the ClientHello, and
+// returns the connection object plus the first outgoing datagram (a padded
+// Initial packet) the caller must send.
+pub fn dial(params DialParams, now u64) !(&QuicConn, QuicDatagram) {
+	original_dcid := rand.bytes(local_cid_len) or {
+		return error('quic: failed to generate initial destination connection ID: ${err.msg()}')
+	}
+	scid := rand.bytes(local_cid_len) or {
+		return error('quic: failed to generate source connection ID: ${err.msg()}')
+	}
+	client_random := rand.bytes(32) or {
+		return error('quic: failed to generate ClientHello random: ${err.msg()}')
+	}
+
+	mut own_params := params.transport_parameters
+	own_params.initial_source_connection_id = scid.clone()
+
+	handshake, client_hello := Tls13ClientHandshake.start(ClientHandshakeParams{
+		random:               client_random
+		server_name:          params.server_name
+		transport_parameters: own_params
+		ca_bundle_pem:        params.ca_bundle_pem
+		alpn_protocols:       params.alpn_protocols
+	})!
+
+	initial_secrets := derive_initial_secrets(original_dcid)!
+	initial_keys_client := derive_packet_protection_keys(initial_secrets.client)!
+	initial_keys_server := derive_packet_protection_keys(initial_secrets.server)!
+
+	own_max_idle_timeout_ms := own_params.max_idle_timeout or { u64(0) }
+
+	mut c := &QuicConn{
+		role:                     .client
+		state:                    .handshaking
+		original_dcid:            original_dcid
+		dcid:                     original_dcid.clone()
+		scid:                     scid
+		peer_scid:                []u8{}
+		token:                    []u8{}
+		handshake:                handshake
+		handshake_completion:     new_handshake_completion_state()
+		pn_spaces:                new_packet_number_spaces()
+		initial_keys_client:      initial_keys_client
+		initial_keys_server:      initial_keys_server
+		initial_crypto:           new_crypto_stream_reassembler()
+		handshake_crypto:         new_crypto_stream_reassembler()
+		client_hello:             client_hello
+		loss_detection:           new_quic_loss_detection_timer()
+		congestion_control:       new_newreno_congestion_control()
+		own_max_idle_timeout_ms:  own_max_idle_timeout_ms
+		stateless_reset:          new_stateless_reset_tracker()
+		connection_start:         now
+		own_transport_parameters: own_params
+		streams:                  new_quic_stream_set(.client)
+		conn_send_window:         new_flow_control_window(0)
+		conn_recv_window:         new_receive_window(own_params.initial_max_data or { u64(0) })
+		local_max_streams_bidi:   own_params.initial_max_streams_bidi or { u64(0) }
+		local_max_streams_uni:    own_params.initial_max_streams_uni or { u64(0) }
+	}
+
+	crypto_frame := encode_crypto_frame(0, client_hello)!
+	datagram := c.build_initial_packet(crypto_frame, true, now)!
+	return c, datagram
+}
+
+// poll feeds one incoming UDP datagram (or none, to just drain queued
+// outgoing data and check timers) and returns what happened. A protocol
+// error while processing `incoming` closes the connection (transitions to
+// .closing, queues a best-effort CONNECTION_CLOSE datagram, and reports a
+// connection_closed event) rather than propagating as a Result error --
+// callers see connection failures as ordinary events, matching how a
+// caller-driven library is expected to behave, not as exceptions.
+pub fn (mut c QuicConn) poll(incoming ?[]u8, now u64) !PollResult {
+	mut result := PollResult{}
+	if c.state == .closed {
+		return result
+	}
+	if data := incoming {
+		c.process_datagram(data, now, mut result) or {
+			code := if err.code() != 0 { u64(err.code()) } else { quic_error_protocol_violation }
+			c.close_with_error(code, err.msg(), false, now, mut result)
+		}
+	}
+	c.drain_pending_close(now, mut result)
+	if c.state == .handshaking || c.state == .established {
+		c.drain_outgoing(now, mut result)!
+	}
+	result.next_timeout = c.compute_next_timeout()
+	return result
+}
+
+// drain_pending_close actions a close() call queued since the last poll()/
+// process_timeouts() -- see close()'s own doc comment for why the actual
+// send is deferred to here rather than happening synchronously. A no-op if
+// no close is pending, or if this connection has already started closing/
+// draining/closed by some other path in the meantime (e.g. a protocol
+// violation detected while processing this same call's incoming data).
+fn (mut c QuicConn) drain_pending_close(now u64, mut result PollResult) {
+	pc := c.pending_close or { return }
+	c.pending_close = none
+	if c.state == .closing || c.state == .draining || c.state == .closed {
+		return
+	}
+	c.close_with_error(pc.error_code, pc.reason, pc.is_application_error, now, mut result)
+}
+
+// process_timeouts is called when a previously-returned next_timeout
+// deadline elapses with no new incoming data. Checks idle timeout first
+// (a genuinely idle connection has nothing left to time-out into), then
+// drives RFC 9002's loss-detection/PTO timer.
+pub fn (mut c QuicConn) process_timeouts(now u64) !PollResult {
+	mut result := PollResult{}
+	if c.state == .closed {
+		return result
+	}
+	if deadline := c.idle_timeout_deadline() {
+		if now >= deadline {
+			c.state = .closed
+			result.events << QuicEvent{
+				kind:   .connection_closed
+				reason: 'idle timeout'
+			}
+			return result
+		}
+	}
+	if c.state == .closing || c.state == .draining {
+		if deadline := c.closing_deadline {
+			if now >= deadline {
+				c.state = .closed
+				result.events << QuicEvent{
+					kind:   .connection_closed
+					reason: 'closing/draining period elapsed'
+				}
+				return result
+			}
+		}
+	}
+	c.drain_pending_close(now, mut result)
+
+	if c.state == .handshaking || c.state == .established {
+		handshake_confirmed := c.handshake_completion.is_confirmed()
+		max_ack_delay := c.effective_max_ack_delay()
+		timeout_result := c.loss_detection.on_loss_detection_timeout(now, handshake_confirmed,
+			max_ack_delay)
+		if timeout_result.pto_fired {
+			c.send_pto_probe(timeout_result.pto_space, now, mut result) or {
+				code := if err.code() != 0 { u64(err.code()) } else { quic_error_protocol_violation }
+				c.close_with_error(code, err.msg(), false, now, mut result)
+			}
+		} else if timeout_result.lost.len > 0 {
+			c.congestion_control.on_packets_lost(timeout_result.lost, false, now)
+		}
+
+		if c.state == .handshaking || c.state == .established {
+			c.drain_outgoing(now, mut result)!
+		}
+	}
+	result.next_timeout = c.compute_next_timeout()
+	return result
+}
+
+// -------------------------------------------------------------------------
+// Incoming datagram processing
+// -------------------------------------------------------------------------
+
+fn (mut c QuicConn) process_datagram(datagram []u8, now u64, mut result PollResult) ! {
+	if c.state == .draining {
+		return
+	}
+	packets := split_coalesced_datagram(datagram) or { return }
+	for p in packets {
+		c.process_one_packet(p, now, mut result)!
+	}
+	// RFC 9000 §10.2.1: while closing, at most one CONNECTION_CLOSE
+	// retransmission per received packet (note_packet_received_while_closing
+	// itself enforces the rate limit). Checked AFTER normal processing above
+	// (not instead of it) so a peer CONNECTION_CLOSE arriving here still
+	// correctly flips c.state to .draining via handle_peer_connection_close
+	// first -- in which case this check's own `c.state == .closing` test is
+	// already false, correctly skipping the retransmit per §10.2.2's silence
+	// requirement.
+	if c.state == .closing && c.connection_close.note_packet_received_while_closing() {
+		if frame := c.sent_close_payload {
+			retransmit := c.build_best_effort_close_packet(frame, now) or { return }
+			result.outgoing << retransmit
+		}
+	}
+}
+
+fn (mut c QuicConn) process_one_packet(p CoalescedPacket, now u64, mut result PollResult) ! {
+	if p.form == .short {
+		c.process_one_rtt_packet(p.bytes, now, mut result)!
+		return
+	}
+	if p.bytes.len < 5 {
+		return
+	}
+	version := (u32(p.bytes[1]) << 24) | (u32(p.bytes[2]) << 16) | (u32(p.bytes[3]) << 8) | u32(p.bytes[4])
+	if version == 0 {
+		c.process_version_negotiation(p.bytes)!
+		return
+	}
+	header, offset := parse_long_header(p.bytes) or { return }
+	match header.typ {
+		.retry {
+			c.process_retry(p.bytes)!
+		}
+		.initial {
+			c.process_initial_or_handshake(.initial, p.bytes, header, offset, now, mut result)!
+		}
+		.handshake {
+			c.process_initial_or_handshake(.handshake, p.bytes, header, offset, now, mut result)!
+		}
+		.zero_rtt {
+			// v1 never offers 0-RTT and derives no keys to decrypt one --
+			// nothing to do with it (RFC 9000 doesn't require a client to
+			// react to an unexpected 0-RTT packet in any particular way).
+		}
+	}
+}
+
+fn (mut c QuicConn) process_version_negotiation(raw []u8) ! {
+	vn := parse_version_negotiation(raw) or { return }
+	handle_version_negotiation(vn, c.original_dcid, c.scid, c.processed_first_server_packet)!
+}
+
+fn (mut c QuicConn) process_retry(raw []u8) ! {
+	accepted := verify_retry_integrity_tag(c.original_dcid, raw, c.processed_first_server_packet)!
+	if !accepted {
+		return
+	}
+	retry := parse_retry_packet(raw, c.original_dcid, c.scid)!
+
+	c.retry_accepted = true
+	c.processed_first_server_packet = true
+	c.retry_scid = retry.scid.clone()
+	c.dcid = retry.scid.clone()
+	c.peer_scid = retry.scid.clone()
+	c.token = retry.retry_token.clone()
+
+	// RFC 9001 §5.2: Initial secrets change to key off the new DCID. The
+	// ClientHello must be resent under the new keys, restarting Initial-space
+	// packet numbers and loss-detection tracking cleanly against them.
+	new_secrets := derive_initial_secrets(c.dcid)!
+	c.initial_keys_client = derive_packet_protection_keys(new_secrets.client)!
+	c.initial_keys_server = derive_packet_protection_keys(new_secrets.server)!
+	c.pn_spaces.initial = PacketNumberSpaceState{}
+	c.loss_detection.initial = LossDetectionSpaceState{}
+	c.initial_received_pns = map[u64]bool{}
+	c.pending_initial_crypto = c.client_hello
+}
+
+fn (mut c QuicConn) process_initial_or_handshake(space QuicPacketNumberSpace, raw []u8, header QuicLongHeader, offset int, now u64, mut result PollResult) ! {
+	keys := if space == .initial {
+		c.initial_keys_server
+	} else {
+		c.handshake_keys_server or { return }
+	}
+	mut packet := raw.clone()
+	largest_pn := if space == .initial {
+		c.pn_spaces.initial.largest_received
+	} else {
+		c.pn_spaces.handshake.largest_received
+	}
+	unprotected := unprotect_packet(mut packet, offset, .long, keys, largest_pn) or { return }
+
+	c.processed_first_server_packet = true
+	if c.peer_scid.len == 0 {
+		// RFC 9000 §7.2: upon first receiving a packet from the server, the
+		// client MUST use its Source Connection ID as the Destination
+		// Connection ID for subsequent packets. Done only after a
+		// successfully authenticated packet -- never from a spoofed one.
+		c.peer_scid = header.scid.clone()
+		c.dcid = header.scid.clone()
+	}
+
+	if space == .initial {
+		c.pn_spaces.initial.note_received(unprotected.packet_number)
+		c.initial_received_pns[unprotected.packet_number] = true
+	} else {
+		c.pn_spaces.handshake.note_received(unprotected.packet_number)
+		c.handshake_received_pns[unprotected.packet_number] = true
+	}
+
+	frames := parse_frames(unprotected.payload)!
+	for frame in frames {
+		c.dispatch_pre_confirm_frame(space, frame, now, mut result)!
+	}
+}
+
+// note_one_rtt_processing_failed is called from EVERY failure point in
+// process_one_rtt_packet below (header parse, header-protection removal,
+// packet-number decode, key resolution, AEAD decrypt) -- RFC 9000
+// §10.3.1's stateless-reset check MUST only run as a last-resort fallback
+// AFTER normal processing has already failed, never as a first-choice
+// interpretation, and any of these steps failing means normal processing
+// genuinely failed. Checking on every failure point (rather than only the
+// single "final" one) is harmless: is_stateless_reset is a cheap
+// constant-time compare against 16 trailing bytes, and `raw` -- the
+// ORIGINAL, unmutated datagram -- is what a real stateless reset's
+// trailing bytes would appear in regardless of which step first noticed
+// something was wrong.
+fn (mut c QuicConn) note_one_rtt_processing_failed(raw []u8, now u64, mut result PollResult) {
+	if c.state == .draining {
+		return
+	}
+	if c.stateless_reset.is_stateless_reset(c.peer_scid, raw) {
+		c.enter_draining(now)
+		result.events << QuicEvent{
+			kind:   .connection_closed
+			reason: 'stateless reset received'
+		}
+	}
+}
+
+fn (mut c QuicConn) process_one_rtt_packet(raw []u8, now u64, mut result PollResult) ! {
+	mut read_keys := c.app_read_keys or {
+		c.note_one_rtt_processing_failed(raw, now, mut result)
+		return
+	}
+
+	dcid_len := c.scid.len
+	_, offset := parse_short_header(raw, dcid_len) or {
+		c.note_one_rtt_processing_failed(raw, now, mut result)
+		return
+	}
+	mut packet := raw.clone()
+	// The header-protection key never changes across a key update within
+	// one encryption level (RFC 9001 §6, see
+	// derive_updated_packet_protection_keys' own doc comment) -- read it
+	// once from current_keys regardless of which generation's AEAD keys
+	// this packet's key phase bit (unknown until AFTER this call) will
+	// turn out to need.
+	hp_key := read_keys.current_keys.hp
+	pn_length := unprotect_header(mut packet, offset, hp_key, .short) or {
+		c.note_one_rtt_processing_failed(raw, now, mut result)
+		return
+	}
+	if offset + pn_length > packet.len {
+		c.note_one_rtt_processing_failed(raw, now, mut result)
+		return
+	}
+	mut truncated := u64(0)
+	for i in 0 .. pn_length {
+		truncated = (truncated << 8) | u64(packet[offset + i])
+	}
+	full_pn := decode_packet_number(truncated, pn_length,
+		c.pn_spaces.application_data.largest_received) or {
+		c.note_one_rtt_processing_failed(raw, now, mut result)
+		return
+	}
+	packet_phase := packet[0] & 0x04 != 0
+	resolution := read_keys.resolve_read_keys(packet_phase, full_pn) or {
+		c.note_one_rtt_processing_failed(raw, now, mut result)
+		return
+	}
+	header := packet[..offset + pn_length].clone()
+	// unsafe, not .clone(): mirrors unprotect_packet's own identical slice
+	// in packet_protection.v -- read-only pass into decrypt_packet_payload,
+	// no mutation of `packet` happens after this point.
+	ciphertext := unsafe { packet[offset + pn_length..] }
+	payload := decrypt_packet_payload(resolution.keys, full_pn, header, ciphertext) or {
+		c.note_one_rtt_processing_failed(raw, now, mut result)
+		return
+	}
+	read_keys.note_successful_decrypt(resolution, full_pn)!
+
+	c.processed_first_server_packet = true
+	c.pn_spaces.application_data.note_received(full_pn)
+	c.app_received_pns[full_pn] = true
+
+	frames := parse_frames(payload)!
+	for frame in frames {
+		c.dispatch_one_rtt_frame(frame, now, mut result)!
+	}
+}
+
+// -------------------------------------------------------------------------
+// Frame dispatch
+// -------------------------------------------------------------------------
+
+fn (mut c QuicConn) dispatch_pre_confirm_frame(space QuicPacketNumberSpace, frame QuicFrame, now u64, mut result PollResult) ! {
+	match frame {
+		PaddingFrame {}
+		PingFrame {}
+		AckFrame {
+			c.handle_ack_frame(space, frame, now)
+		}
+		CryptoFrame {
+			c.handle_crypto_frame(space, frame)!
+		}
+		ConnectionCloseFrame {
+			c.handle_peer_connection_close(frame, now, mut result)
+		}
+		else {
+			// STREAM/RESET_STREAM/MAX_DATA/HANDSHAKE_DONE/etc: none of
+			// these are legal in the Initial or Handshake packet number
+			// space (RFC 9000 §12.4, Table 3) -- a real MUST-violation,
+			// not merely something this file doesn't act on yet (contrast
+			// with dispatch_one_rtt_frame's own else arm below).
+			return error('quic: frame type not legal in ${space} space (RFC 9000 §12.4 PROTOCOL_VIOLATION)')
+		}
+	}
+}
+
+fn (mut c QuicConn) dispatch_one_rtt_frame(frame QuicFrame, now u64, mut result PollResult) ! {
+	match frame {
+		PaddingFrame {}
+		PingFrame {}
+		AckFrame {
+			c.handle_ack_frame(.application_data, frame, now)
+		}
+		ConnectionCloseFrame {
+			c.handle_peer_connection_close(frame, now, mut result)
+		}
+		HandshakeDoneFrame {
+			c.handshake_completion.mark_handshake_done_received()
+			if c.handshake_completion.is_confirmed() {
+				c.on_handshake_confirmed(mut result)
+			}
+		}
+		CryptoFrame {
+			// Post-handshake CRYPTO (NewSessionTicket, post-handshake
+			// auth) is out of v1 scope -- Tls13ClientHandshake has no
+			// handler for it. Legal on the wire, silently not acted upon.
+		}
+		StreamFrame {
+			c.handle_stream_frame(frame)!
+		}
+		ResetStreamFrame {
+			c.handle_reset_stream_frame(frame)!
+		}
+		StopSendingFrame {
+			c.handle_stop_sending_frame(frame)
+		}
+		MaxDataFrame {
+			c.conn_send_window.raise_limit(frame.maximum_data)
+		}
+		MaxStreamDataFrame {
+			if mut w := c.stream_send_windows[frame.stream_id] {
+				w.raise_limit(frame.maximum_stream_data)
+			}
+		}
+		MaxStreamsFrame {
+			if frame.direction == .bidirectional {
+				if frame.maximum_streams > c.peer_max_streams_bidi {
+					c.peer_max_streams_bidi = frame.maximum_streams
+				}
+			} else {
+				if frame.maximum_streams > c.peer_max_streams_uni {
+					c.peer_max_streams_uni = frame.maximum_streams
+				}
+			}
+		}
+		else {
+			// DATA_BLOCKED/STREAM_DATA_BLOCKED/STREAMS_BLOCKED: purely
+			// informational hints (RFC 9000 §19.12-§19.14 impose no MUST
+			// response) -- legal on the wire, accepted, not acted upon.
+		}
+	}
+}
+
+fn (mut c QuicConn) handle_stream_frame(frame StreamFrame) ! {
+	id := StreamId{
+		value: frame.stream_id
+	}
+	max_streams := if id.direction() == .unidirectional {
+		c.local_max_streams_uni
+	} else {
+		c.local_max_streams_bidi
+	}
+	mut stream := c.streams.get_or_create(frame.stream_id, max_streams)!
+	if !stream.has_recv() {
+		return error('quic: STREAM_STATE_ERROR: received STREAM frame for send-only stream ${frame.stream_id}')
+	}
+	c.ensure_stream_windows(id)
+
+	frame_end := frame.offset + u64(frame.data.len)
+	mut recv_window := c.stream_recv_windows[frame.stream_id] or {
+		panic('unreachable: ensure_stream_windows just created it')
+	}
+	prev_high := recv_window.received
+	recv_window.note_received(frame_end)!
+	delta := recv_window.received - prev_high
+	if delta > 0 {
+		c.conn_recv_window.note_received(c.conn_recv_window.received + delta)!
+	}
+
+	stream.recv.note_data(frame.offset, frame.data)!
+	if frame.fin {
+		stream.recv.note_size_known(frame_end)!
+	}
+}
+
+fn (mut c QuicConn) handle_reset_stream_frame(frame ResetStreamFrame) ! {
+	id := StreamId{
+		value: frame.stream_id
+	}
+	max_streams := if id.direction() == .unidirectional {
+		c.local_max_streams_uni
+	} else {
+		c.local_max_streams_bidi
+	}
+	mut stream := c.streams.get_or_create(frame.stream_id, max_streams)!
+	if !stream.has_recv() {
+		return error('quic: STREAM_STATE_ERROR: received RESET_STREAM for send-only stream ${frame.stream_id}')
+	}
+	c.ensure_stream_windows(id)
+
+	mut recv_window := c.stream_recv_windows[frame.stream_id] or {
+		panic('unreachable: ensure_stream_windows just created it')
+	}
+	prev_high := recv_window.received
+	recv_window.note_received(frame.final_size)!
+	delta := recv_window.received - prev_high
+	if delta > 0 {
+		c.conn_recv_window.note_received(c.conn_recv_window.received + delta)!
+	}
+
+	stream.recv.mark_reset_recvd(frame.error_code, frame.final_size)!
+}
+
+// handle_stop_sending_frame reacts to a peer's STOP_SENDING (RFC 9000
+// §19.16) by immediately resetting our own send side with the SAME error
+// code, per §3.5's SHOULD -- queued for the next drain_outgoing() call to
+// actually send the RESET_STREAM, matching write_stream's own deferred-send
+// pattern. Silently ignored for an unknown stream (nothing to stop) or one
+// whose send side is already closed (mark_reset_sent is itself a safe
+// no-op there, but there is also nothing new to queue).
+fn (mut c QuicConn) handle_stop_sending_frame(frame StopSendingFrame) {
+	mut stream := c.streams.get(frame.stream_id) or { return }
+	if !stream.has_send() {
+		return
+	}
+	if stream.send.state == .data_recvd || stream.send.state == .reset_recvd
+		|| stream.send.state == .reset_sent {
+		return
+	}
+	stream.send.mark_reset_sent(frame.error_code)
+	c.pending_stream_reset[frame.stream_id] = frame.error_code
+}
+
+fn (mut c QuicConn) handle_ack_frame(space QuicPacketNumberSpace, frame AckFrame, now u64) {
+	handshake_confirmed := c.handshake_completion.is_confirmed()
+	max_ack_delay := c.effective_max_ack_delay()
+	result := c.loss_detection.on_ack_received(space, frame, default_ack_delay_exponent,
+		max_ack_delay, handshake_confirmed, now)
+	c.congestion_control.on_packets_acked(result.newly_acked)
+	if result.lost.len > 0 {
+		c.congestion_control.on_packets_lost(result.lost, result.persistent_congestion, now)
+	}
+	if counts := frame.ecn_counts {
+		c.ecn.note_ack_ecn_counts(counts)
+	}
+}
+
+fn (mut c QuicConn) handle_crypto_frame(space QuicPacketNumberSpace, frame CryptoFrame) ! {
+	if space == .initial {
+		c.initial_crypto.add(frame.offset, frame.data)!
+		c.pump_handshake_messages(.initial)!
+	} else {
+		c.handshake_crypto.add(frame.offset, frame.data)!
+		c.pump_handshake_messages(.handshake)!
+	}
+}
+
+fn (mut c QuicConn) handle_peer_connection_close(frame ConnectionCloseFrame, now u64, mut result PollResult) {
+	c.enter_draining(now)
+	result.events << QuicEvent{
+		kind:       .connection_closed
+		error_code: frame.error_code
+		reason:     frame.reason
+	}
+}
+
+// -------------------------------------------------------------------------
+// TLS handshake message pump
+// -------------------------------------------------------------------------
+
+fn (mut c QuicConn) pump_handshake_messages(space QuicPacketNumberSpace) ! {
+	data := if space == .initial { c.initial_crypto.data() } else { c.handshake_crypto.data() }
+	mut cursor := if space == .initial {
+		c.initial_crypto_consumed
+	} else {
+		c.handshake_crypto_consumed
+	}
+	for cursor < u64(data.len) {
+		remaining := data[cursor..]
+		if remaining.len < 4 {
+			break
+		}
+		length := int((u32(remaining[1]) << 16) | (u32(remaining[2]) << 8) | u32(remaining[3]))
+		total := 4 + length
+		if remaining.len < total {
+			break
+		}
+		msg, n := parse_handshake_message(remaining)!
+		framed := remaining[..n].clone()
+		c.dispatch_handshake_message(msg, framed)!
+		cursor += u64(n)
+	}
+	if space == .initial {
+		c.initial_crypto_consumed = cursor
+	} else {
+		c.handshake_crypto_consumed = cursor
+	}
+}
+
+fn (mut c QuicConn) dispatch_handshake_message(msg HandshakeMessage, framed []u8) ! {
+	state := c.handshake.state()
+	match state {
+		.wait_server_hello {
+			hs := c.handshake.process_server_hello(msg, framed)!
+			c.handshake_keys_client = derive_packet_protection_keys(hs.client_secret)!
+			c.handshake_keys_server = derive_packet_protection_keys(hs.server_secret)!
+		}
+		.wait_encrypted_extensions {
+			c.handshake.process_encrypted_extensions(msg, framed, c.peer_scid, c.original_dcid,
+				c.retry_scid)!
+			peer_params := c.handshake.peer_transport_parameters
+			c.conn_send_window.raise_limit(peer_params.initial_max_data or { u64(0) })
+			c.peer_max_streams_bidi = peer_params.initial_max_streams_bidi or { u64(0) }
+			c.peer_max_streams_uni = peer_params.initial_max_streams_uni or { u64(0) }
+			if token := peer_params.stateless_reset_token {
+				c.stateless_reset.record_token(c.peer_scid, token)!
+			}
+		}
+		.wait_certificate {
+			c.handshake.process_certificate_or_request(msg, framed)!
+		}
+		.wait_certificate_verify {
+			c.handshake.process_certificate_verify(msg, framed)!
+		}
+		.wait_finished {
+			client_finished, app_secrets := c.handshake.process_finished(msg, framed)!
+			c.app_write_keys = derive_packet_protection_keys(app_secrets.client_secret)!
+			c.app_read_keys = new_key_update_state(app_secrets.server_secret)!
+			c.handshake_completion.mark_peer_finished_verified()
+			c.pending_handshake_crypto = client_finished
+		}
+		.connected {
+			return error('quic: unexpected handshake message after the handshake completed')
+		}
+	}
+}
+
+fn (mut c QuicConn) on_handshake_confirmed(mut result PollResult) {
+	c.state = .established
+	result.events << QuicEvent{
+		kind: .handshake_confirmed
+	}
+	if !c.handshake_keys_discarded {
+		c.discard_handshake_keys()
+	}
+}
+
+// -------------------------------------------------------------------------
+// Key discard (RFC 9001 §4.9)
+// -------------------------------------------------------------------------
+
+// discard_initial_keys implements RFC 9001 §4.9.1. v1 scope simplification:
+// only clears this connection's own per-space bookkeeping; the precise RFC
+// 9002 §6.4 interaction with bytes_in_flight/congestion accounting for
+// packets that were still outstanding in the discarded space is not
+// separately modeled (a documented follow-up, not a Phase 9a blocker --
+// affects retransmission-timing precision, not handshake correctness).
+fn (mut c QuicConn) discard_initial_keys() {
+	c.initial_keys_discarded = true
+	c.pn_spaces.initial = PacketNumberSpaceState{}
+	c.loss_detection.initial = LossDetectionSpaceState{}
+	c.initial_received_pns = map[u64]bool{}
+	c.pending_initial_crypto = none
+}
+
+// discard_handshake_keys implements RFC 9001 §4.9.2 -- same v1 scope note
+// as discard_initial_keys above.
+fn (mut c QuicConn) discard_handshake_keys() {
+	c.handshake_keys_discarded = true
+	c.pn_spaces.handshake = PacketNumberSpaceState{}
+	c.loss_detection.handshake = LossDetectionSpaceState{}
+	c.handshake_received_pns = map[u64]bool{}
+	c.pending_handshake_crypto = none
+}
+
+// -------------------------------------------------------------------------
+// Outgoing packet construction
+// -------------------------------------------------------------------------
+
+fn (mut c QuicConn) drain_outgoing(now u64, mut result PollResult) ! {
+	if data := c.pending_initial_crypto {
+		crypto_frame := encode_crypto_frame(0, data)!
+		datagram := c.build_initial_packet(crypto_frame, true, now)!
+		result.outgoing << datagram
+		c.pending_initial_crypto = none
+	}
+	if !c.initial_keys_discarded && c.initial_received_pns.len > 0 {
+		ack_frame := c.build_ack_frame_for(.initial)!
+		datagram := c.build_initial_packet(ack_frame, false, now)!
+		result.outgoing << datagram
+		c.initial_received_pns = map[u64]bool{}
+	}
+
+	if data := c.pending_handshake_crypto {
+		crypto_frame := encode_crypto_frame(c.handshake_crypto_send_offset, data)!
+		c.handshake_crypto_send_offset += u64(data.len)
+		datagram := c.build_handshake_packet(crypto_frame, true, now)!
+		result.outgoing << datagram
+		c.pending_handshake_crypto = none
+		c.handshake_completion.mark_own_finished_sent()
+	}
+	if hs_keys := c.handshake_keys_client {
+		_ := hs_keys
+		if !c.handshake_keys_discarded && c.handshake_received_pns.len > 0 {
+			ack_frame := c.build_ack_frame_for(.handshake)!
+			datagram := c.build_handshake_packet(ack_frame, false, now)!
+			result.outgoing << datagram
+			c.handshake_received_pns = map[u64]bool{}
+		}
+	}
+
+	if _ := c.app_write_keys {
+		if c.app_received_pns.len > 0 {
+			ack_frame := c.build_ack_frame_for(.application_data)!
+			datagram := c.build_one_rtt_packet(ack_frame, false, now)!
+			result.outgoing << datagram
+			c.app_received_pns = map[u64]bool{}
+		}
+		c.drain_pending_stream_writes(now, mut result)!
+		c.drain_pending_stream_resets(now, mut result)!
+		c.drain_pending_streams_blocked(now, mut result)!
+		c.drain_flow_control_raises(now, mut result)!
+	}
+}
+
+// drain_pending_stream_writes sends whatever write_stream() has queued that
+// currently fits within BOTH this stream's own send window and the
+// connection-level one -- v1 simplification: a queued write that does NOT
+// fully fit is left queued whole rather than partially sent (no splitting
+// at an arbitrary flow-control boundary), retried on a later drain once
+// more budget exists (a MAX_DATA/MAX_STREAM_DATA raise from the peer).
+// Documented follow-up, not a Phase 9b blocker -- bandwidth efficiency, not
+// correctness.
+fn (mut c QuicConn) drain_pending_stream_writes(now u64, mut result PollResult) ! {
+	for stream_id, pending in c.pending_stream_write {
+		if pending.data.len == 0 && !pending.fin {
+			continue
+		}
+		mut send_window := c.stream_send_windows[stream_id] or { continue }
+		needed := u64(pending.data.len)
+		if needed > send_window.available() || needed > c.conn_send_window.available() {
+			continue
+		}
+		mut stream := c.streams.get(stream_id) or { continue }
+		offset := stream.send.offset
+		stream_frame := encode_stream_frame(stream_id, offset, pending.data, pending.fin, true)!
+		datagram := c.build_one_rtt_packet(stream_frame, true, now)!
+		result.outgoing << datagram
+		send_window.consume(needed)!
+		c.conn_send_window.consume(needed)!
+		stream.send.mark_data_queued()
+		stream.send.offset = offset + needed
+		if pending.fin {
+			stream.send.mark_fin_sent(stream.send.offset)
+		}
+		c.pending_stream_write.delete(stream_id)
+	}
+}
+
+// drain_pending_stream_resets sends a RESET_STREAM for every stream
+// handle_stop_sending_frame queued (peer-requested) -- an application-
+// initiated reset would go through the same queue once a public
+// reset_stream() API exists (not yet added; out of Phase 9b's stated scope,
+// which names open_stream/write_stream/read_stream/close specifically).
+fn (mut c QuicConn) drain_pending_stream_resets(now u64, mut result PollResult) ! {
+	for stream_id, error_code in c.pending_stream_reset {
+		stream := c.streams.get(stream_id) or { continue }
+		reset_frame := encode_reset_stream_frame(stream_id, error_code, stream.send.offset)!
+		datagram := c.build_one_rtt_packet(reset_frame, true, now)!
+		result.outgoing << datagram
+		c.pending_stream_reset.delete(stream_id)
+	}
+}
+
+// drain_pending_streams_blocked sends the STREAMS_BLOCKED frames
+// open_stream() queued when it was rejected by the peer's current limit.
+fn (mut c QuicConn) drain_pending_streams_blocked(now u64, mut result PollResult) ! {
+	for direction in c.pending_streams_blocked {
+		limit := if direction == .bidirectional {
+			c.peer_max_streams_bidi
+		} else {
+			c.peer_max_streams_uni
+		}
+		blocked_frame := encode_streams_blocked_frame(direction, limit)!
+		datagram := c.build_one_rtt_packet(blocked_frame, true, now)!
+		result.outgoing << datagram
+	}
+	c.pending_streams_blocked = []StreamDirection{}
+}
+
+// drain_flow_control_raises sends MAX_DATA/MAX_STREAM_DATA once this
+// connection's own receive windows (connection-level, then every known
+// stream's) cross their auto-tuning threshold -- see ReceiveWindow.
+// should_advertise_more's own doc comment for the heuristic.
+fn (mut c QuicConn) drain_flow_control_raises(now u64, mut result PollResult) ! {
+	if c.conn_recv_window.should_advertise_more() {
+		new_limit := c.conn_recv_window.next_advertised_limit()
+		max_data_frame := encode_max_data_frame(new_limit)!
+		datagram := c.build_one_rtt_packet(max_data_frame, true, now)!
+		result.outgoing << datagram
+		c.conn_recv_window.mark_advertised(new_limit)
+	}
+	for stream_id, mut recv_window in c.stream_recv_windows {
+		if recv_window.should_advertise_more() {
+			new_limit := recv_window.next_advertised_limit()
+			msd_frame := encode_max_stream_data_frame(stream_id, new_limit)!
+			datagram := c.build_one_rtt_packet(msd_frame, true, now)!
+			result.outgoing << datagram
+			recv_window.mark_advertised(new_limit)
+		}
+	}
+}
+
+fn (mut c QuicConn) build_ack_frame_for(space QuicPacketNumberSpace) ![]u8 {
+	pns := match space {
+		.initial { c.initial_received_pns.keys() }
+		.handshake { c.handshake_received_pns.keys() }
+		.application_data { c.app_received_pns.keys() }
+	}
+	ranges := ranges_from_received_pns(pns)
+	return encode_ack_frame(ranges, 0, none)
+}
+
+// ranges_from_received_pns builds RFC 9000 §19.3.1-shaped, largest-first,
+// non-overlapping ACK ranges from an unordered set of received packet
+// numbers.
+fn ranges_from_received_pns(pns []u64) []AckRange {
+	if pns.len == 0 {
+		return []AckRange{}
+	}
+	mut sorted := pns.clone()
+	sorted.sort()
+	mut ranges := []AckRange{}
+	mut i := sorted.len - 1
+	for i >= 0 {
+		largest := sorted[i]
+		mut smallest := sorted[i]
+		for i > 0 && sorted[i - 1] == smallest - 1 {
+			i--
+			smallest = sorted[i]
+		}
+		ranges << AckRange{
+			smallest: smallest
+			largest:  largest
+		}
+		i--
+	}
+	return ranges
+}
+
+// build_initial_packet builds one Initial-space packet, always padded to
+// RFC 9000 §14.1's 1200-byte floor (pad_initial_payload). Every Initial
+// packet this client sends is therefore always "in flight" for RFC 9002
+// purposes (ack-eliciting OR contains PADDING), regardless of whether
+// `is_ack_eliciting` itself is true.
+fn (mut c QuicConn) build_initial_packet(payload []u8, is_ack_eliciting bool, now u64) !QuicDatagram {
+	pn := c.pn_spaces.initial.next_packet_number()!
+	pn_bytes, pn_length := encode_packet_number(pn, c.pn_spaces.initial.largest_acked_by_peer)!
+
+	h_probe := QuicLongHeader{
+		typ:     .initial
+		version: quic_v1
+		dcid:    c.dcid
+		scid:    c.scid
+		token:   c.token
+		length:  u64(pn_length) + u64(payload.len) + aead_tag_len
+	}
+	header_probe := encode_long_header(h_probe, 0, u8(pn_length - 1))!
+	padded_payload := pad_initial_payload(payload, header_probe.len + pn_length, aead_tag_len)
+
+	h := QuicLongHeader{
+		typ:     .initial
+		version: quic_v1
+		dcid:    c.dcid
+		scid:    c.scid
+		token:   c.token
+		length:  u64(pn_length) + u64(padded_payload.len) + aead_tag_len
+	}
+	mut header := encode_long_header(h, 0, u8(pn_length - 1))!
+	header << pn_bytes
+
+	protected :=
+		protect_packet(header, .long, pn, pn_length, padded_payload, c.initial_keys_client)!
+
+	c.loss_detection.on_packet_sent(.initial, pn, u64(protected.len), is_ack_eliciting, true, now)
+	c.congestion_control.on_packet_sent_cc(u64(protected.len))
+	c.idle_timeout.note_packet_sent(now)
+	return QuicDatagram{
+		bytes: protected
+	}
+}
+
+fn (mut c QuicConn) build_handshake_packet(payload []u8, is_ack_eliciting bool, now u64) !QuicDatagram {
+	keys := c.handshake_keys_client or {
+		return error('quic: internal error: no Handshake write keys available yet')
+	}
+
+	pn := c.pn_spaces.handshake.next_packet_number()!
+	pn_bytes, pn_length := encode_packet_number(pn, c.pn_spaces.handshake.largest_acked_by_peer)!
+
+	h := QuicLongHeader{
+		typ:     .handshake
+		version: quic_v1
+		dcid:    c.dcid
+		scid:    c.scid
+		token:   []u8{}
+		length:  u64(pn_length) + u64(payload.len) + aead_tag_len
+	}
+	mut header := encode_long_header(h, 0, u8(pn_length - 1))!
+	header << pn_bytes
+
+	protected := protect_packet(header, .long, pn, pn_length, payload, keys)!
+
+	in_flight := is_ack_eliciting
+	c.loss_detection.on_packet_sent(.handshake, pn, u64(protected.len), is_ack_eliciting,
+		in_flight, now)
+	if in_flight {
+		c.congestion_control.on_packet_sent_cc(u64(protected.len))
+	}
+	c.idle_timeout.note_packet_sent(now)
+
+	// RFC 9001 §4.9.1: discard Initial keys once the first Handshake-space
+	// packet has been sent.
+	c.handshake_completion.mark_sent_first_handshake_packet()
+	if c.handshake_completion.should_discard_initial_keys() && !c.initial_keys_discarded {
+		c.discard_initial_keys()
+	}
+	return QuicDatagram{
+		bytes: protected
+	}
+}
+
+fn (mut c QuicConn) build_one_rtt_packet(payload []u8, is_ack_eliciting bool, now u64) !QuicDatagram {
+	write_keys := c.app_write_keys or {
+		return error('quic: internal error: no 1-RTT write keys available yet')
+	}
+
+	pn := c.pn_spaces.application_data.next_packet_number()!
+	pn_bytes, pn_length := encode_packet_number(pn,
+		c.pn_spaces.application_data.largest_acked_by_peer)!
+
+	// key_phase is always false: v1 never client-initiates a key update
+	// (key_update.v's own documented scope), so this endpoint's own write
+	// phase never advances past the first generation.
+	header_prefix := encode_short_header(c.dcid, false, 0, false, u8(pn_length - 1))!
+	mut header := header_prefix.clone()
+	header << pn_bytes
+
+	protected := protect_packet(header, .short, pn, pn_length, payload, write_keys)!
+
+	in_flight := is_ack_eliciting
+	c.loss_detection.on_packet_sent(.application_data, pn, u64(protected.len), is_ack_eliciting,
+		in_flight, now)
+	if in_flight {
+		c.congestion_control.on_packet_sent_cc(u64(protected.len))
+	}
+	c.idle_timeout.note_packet_sent(now)
+	return QuicDatagram{
+		bytes: protected
+	}
+}
+
+// send_pto_probe sends a minimal, always-legal RFC 9002 §6.2 PTO probe
+// (a PING frame) in the space the timer identified. v1 scope
+// simplification: always probes with PING rather than retransmitting
+// specific unacked data -- correct (RFC 9002 explicitly permits this) but
+// not the most bandwidth-efficient choice; a real send/retransmission
+// buffer is a documented follow-up, not a Phase 9a blocker.
+fn (mut c QuicConn) send_pto_probe(space QuicPacketNumberSpace, now u64, mut result PollResult) ! {
+	ping := encode_varint(frame_type_ping)!
+	match space {
+		.initial {
+			if c.initial_keys_discarded {
+				return
+			}
+			datagram := c.build_initial_packet(ping, true, now)!
+			result.outgoing << datagram
+		}
+		.handshake {
+			if c.handshake_keys_discarded {
+				return
+			}
+			_ := c.handshake_keys_client or { return }
+			datagram := c.build_handshake_packet(ping, true, now)!
+			result.outgoing << datagram
+		}
+		.application_data {
+			_ := c.app_write_keys or { return }
+			datagram := c.build_one_rtt_packet(ping, true, now)!
+			result.outgoing << datagram
+		}
+	}
+}
+
+// closing_or_draining_deadline computes the RFC 9000 §10.2 closing/draining
+// period end (recommended 3x PTO, the same bound for both states) from
+// `now`. Shared by close_with_error (.closing) and enter_draining
+// (.draining) so both states are bounded identically -- see enter_draining's
+// own doc comment for why a missing deadline here is a real, not
+// theoretical, bug.
+fn (c &QuicConn) closing_or_draining_deadline(now u64) u64 {
+	return now + 3 * u64(c.loss_detection.rtt.pto_period().milliseconds())
+}
+
+// enter_draining transitions to RFC 9000 §10.2.2's draining state -- used
+// both when the peer sends CONNECTION_CLOSE (handle_peer_connection_close)
+// and when a stateless reset is detected (note_one_rtt_processing_failed).
+// Setting closing_deadline here is required, not optional: process_timeouts'
+// own draining-timeout check is gated on it being Some, so a connection
+// that enters draining without it would sit there forever, never reaching
+// .closed -- found via /vreview (this is the MORE common real-world close
+// path than our own close_with_error, yet was the one missing the bound).
+fn (mut c QuicConn) enter_draining(now u64) {
+	c.connection_close.enter_draining()
+	c.state = .draining
+	c.closing_deadline = c.closing_or_draining_deadline(now)
+}
+
+// close_with_error transitions to .closing and sends a best-effort
+// CONNECTION_CLOSE using whichever packet protection keys are currently
+// available, most-advanced first (RFC 9000 §10.2.3). Never itself returns
+// an error -- a failure to even build/send the close packet still leaves
+// the connection correctly marked closing and the event reported; the peer
+// simply won't receive an explicit notification (it will eventually reach
+// the same conclusion via its own idle timeout).
+fn (mut c QuicConn) close_with_error(error_code u64, reason string, is_application_error bool, now u64, mut result PollResult) {
+	c.connection_close.enter_closing()
+	c.state = .closing
+	c.closing_deadline = c.closing_or_draining_deadline(now)
+	frame := encode_connection_close_frame(is_application_error, error_code, 0, reason) or {
+		result.events << QuicEvent{
+			kind:       .connection_closed
+			error_code: error_code
+			reason:     reason
+		}
+		return
+	}
+	datagram := c.build_best_effort_close_packet(frame, now) or {
+		result.events << QuicEvent{
+			kind:       .connection_closed
+			error_code: error_code
+			reason:     reason
+		}
+		return
+	}
+	c.sent_close_payload = frame
+	result.outgoing << datagram
+	result.events << QuicEvent{
+		kind:       .connection_closed
+		error_code: error_code
+		reason:     reason
+	}
+}
+
+fn (mut c QuicConn) build_best_effort_close_packet(frame []u8, now u64) !QuicDatagram {
+	if _ := c.app_write_keys {
+		return c.build_one_rtt_packet(frame, false, now)
+	}
+	if !c.handshake_keys_discarded {
+		if _ := c.handshake_keys_client {
+			return c.build_handshake_packet(frame, false, now)
+		}
+	}
+	if !c.initial_keys_discarded {
+		return c.build_initial_packet(frame, false, now)
+	}
+	return error('quic: no packet protection keys available to send CONNECTION_CLOSE')
+}
+
+// -------------------------------------------------------------------------
+// Timers
+// -------------------------------------------------------------------------
+
+fn (c &QuicConn) effective_max_ack_delay() time.Duration {
+	if !c.handshake_completion.is_complete() {
+		return time.Duration(0)
+	}
+	v := c.handshake.peer_transport_parameters.max_ack_delay or { default_max_ack_delay_ms }
+	return time.Duration(i64(v) * i64(time.millisecond))
+}
+
+fn (c &QuicConn) idle_timeout_deadline() ?u64 {
+	peer_max := c.handshake.peer_transport_parameters.max_idle_timeout or { u64(0) }
+	timeout := effective_idle_timeout(c.own_max_idle_timeout_ms, peer_max) or { return none }
+	baseline := c.idle_timeout.last_reset or { c.connection_start }
+	return baseline + u64(timeout)
+}
+
+fn (mut c QuicConn) compute_next_timeout() ?u64 {
+	handshake_confirmed := c.handshake_completion.is_confirmed()
+	max_ack_delay := c.effective_max_ack_delay()
+	mut deadline := ?u64(none)
+	if t, _ := c.loss_detection.next_timeout(handshake_confirmed, max_ack_delay,
+		c.congestion_control.bytes_in_flight)
+	{
+		deadline = t
+	}
+	if idle_deadline := c.idle_timeout_deadline() {
+		if d := deadline {
+			if idle_deadline < d {
+				deadline = idle_deadline
+			}
+		} else {
+			deadline = idle_deadline
+		}
+	}
+	return deadline
+}

--- a/vlib/net/quic/conn.v
+++ b/vlib/net/quic/conn.v
@@ -1482,5 +1482,21 @@ fn (mut c QuicConn) compute_next_timeout() ?u64 {
 			deadline = idle_deadline
 		}
 	}
+	// closing_deadline (set by close_with_error/enter_draining) is the
+	// caller's only signal to call process_timeouts() again once in
+	// .closing/.draining -- without merging it in here, a connection with
+	// no active idle timeout and nothing in flight would return `none` and
+	// the caller would never learn it needs to retire the connection to
+	// .closed (RFC 9000 §10.2.2). Found via a maintainer "Local AI Review"
+	// on PR #28083 -- see test_compute_next_timeout_includes_closing_deadline.
+	if closing_deadline := c.closing_deadline {
+		if d := deadline {
+			if closing_deadline < d {
+				deadline = closing_deadline
+			}
+		} else {
+			deadline = closing_deadline
+		}
+	}
 	return deadline
 }

--- a/vlib/net/quic/conn.v
+++ b/vlib/net/quic/conn.v
@@ -131,6 +131,18 @@ mut:
 	app_write_keys           ?QuicPacketProtectionKeys
 	app_read_keys            ?&KeyUpdateState
 
+	// app_write_secret/app_write_generation track this endpoint's OWN 1-RTT
+	// send-key generation, independently of app_read_keys' read-side
+	// generation chain (RFC 9001 §6.1: "each side's traffic secret chain
+	// advances on its own schedule" -- key_update.v's own doc comment says
+	// the same). RFC 9001 §6.2 requires this side's SEND keys to catch up
+	// to whatever generation the PEER has advanced to (see
+	// sync_write_keys_to_peer_update) -- the key phase bit sent on the wire
+	// is this generation's parity (odd generation -> phase 1), matching RFC
+	// 9001 §6's "toggled to signal each subsequent key update".
+	app_write_secret     []u8
+	app_write_generation int
+
 	initial_crypto               &CryptoStreamReassembler
 	initial_crypto_consumed      u64
 	handshake_crypto             &CryptoStreamReassembler
@@ -153,6 +165,16 @@ mut:
 	initial_received_pns   map[u64]bool
 	handshake_received_pns map[u64]bool
 	app_received_pns       map[u64]bool
+
+	// *_ack_eliciting_pending track whether ANY frame in the packets
+	// currently accumulated in the sibling *_received_pns map above was
+	// ack-eliciting (RFC 9000 §13.2.1: all frames except ACK, PADDING, and
+	// CONNECTION_CLOSE). drain_outgoing's auto-ACK gates on this, not just
+	// on *_received_pns being non-empty -- see frame_is_ack_eliciting's own
+	// doc comment for why the two must be tracked separately.
+	initial_ack_eliciting_pending   bool
+	handshake_ack_eliciting_pending bool
+	app_ack_eliciting_pending       bool
 
 	connection_start u64
 
@@ -685,15 +707,29 @@ fn (mut c QuicConn) process_initial_or_handshake(space QuicPacketNumberSpace, ra
 		c.dcid = header.scid.clone()
 	}
 
+	frames := parse_frames(unprotected.payload)!
+	// RFC 9000 §13.2.1: whether THIS packet is ack-eliciting is determined
+	// by its frames, before any of them are dispatched (dispatch can itself
+	// close/transition the connection, but the ack-eliciting-ness of the
+	// packet that arrived is independent of that).
+	mut ack_eliciting := false
+	for frame in frames {
+		if frame_is_ack_eliciting(frame) {
+			ack_eliciting = true
+			break
+		}
+	}
+
 	if space == .initial {
 		c.pn_spaces.initial.note_received(unprotected.packet_number)
 		c.initial_received_pns[unprotected.packet_number] = true
+		c.initial_ack_eliciting_pending = c.initial_ack_eliciting_pending || ack_eliciting
 	} else {
 		c.pn_spaces.handshake.note_received(unprotected.packet_number)
 		c.handshake_received_pns[unprotected.packet_number] = true
+		c.handshake_ack_eliciting_pending = c.handshake_ack_eliciting_pending || ack_eliciting
 	}
 
-	frames := parse_frames(unprotected.payload)!
 	for frame in frames {
 		c.dispatch_pre_confirm_frame(space, frame, now, mut result)!
 	}
@@ -790,6 +826,11 @@ fn (mut c QuicConn) process_one_rtt_packet(raw []u8, now u64, mut result PollRes
 		return
 	}
 	read_keys.note_successful_decrypt(resolution, full_pn)!
+	// RFC 9001 §6.2: "Sending keys MUST be updated before sending an
+	// acknowledgment for the packet that was received with updated keys."
+	// Called here, before this same poll() call's drain_outgoing can send
+	// anything (including the auto-ACK for the packet just processed).
+	c.sync_write_keys_to_peer_update()!
 
 	c.processed_first_server_packet = true
 	// RFC 9000 §10.1: receiving and successfully processing ANY packet
@@ -800,14 +841,76 @@ fn (mut c QuicConn) process_one_rtt_packet(raw []u8, now u64, mut result PollRes
 	c.app_received_pns[full_pn] = true
 
 	frames := parse_frames(payload)!
+	// RFC 9000 §13.2.1: see frame_is_ack_eliciting's own doc comment and
+	// process_initial_or_handshake's identical block for the full
+	// rationale -- this packet must only ARM the auto-ACK if at least one
+	// of its frames is ack-eliciting.
+	for frame in frames {
+		if frame_is_ack_eliciting(frame) {
+			c.app_ack_eliciting_pending = true
+			break
+		}
+	}
 	for frame in frames {
 		c.dispatch_one_rtt_frame(frame, now, mut result)!
+	}
+}
+
+// sync_write_keys_to_peer_update advances this endpoint's OWN 1-RTT send
+// keys to match however many key updates the peer has initiated so far
+// (RFC 9001 §6.2): "If a packet is successfully processed using the next
+// key and IV, then the peer has initiated a key update. The endpoint MUST
+// update its send keys to the corresponding key phase in response... By
+// acknowledging the packet that triggered the key update in a packet
+// protected with the updated keys, the endpoint signals that the key
+// update is complete." The read and write traffic-secret chains advance
+// independently (§6.1; key_update.v's own doc comment says the same), so
+// this steps app_write_secret/app_write_generation forward one generation
+// at a time -- using the identical derive_updated_secret/
+// derive_updated_packet_protection_keys primitives KeyUpdateState uses for
+// the read side, since both chains use the same derivation, just seeded
+// from a different starting secret. A no-op once caught up (the common
+// case: every call after the first packet in a phase). This project's own
+// scope note ("client-initiated key rotation deferred past v1") is about
+// this endpoint choosing to START a new update on its own, which stays
+// unimplemented -- RESPONDING to a peer's update is not optional and is
+// exactly what this function does.
+fn (mut c QuicConn) sync_write_keys_to_peer_update() ! {
+	read_keys := c.app_read_keys or { return }
+	target_generation := read_keys.generation()
+	for c.app_write_generation < target_generation {
+		current_write_keys := c.app_write_keys or {
+			return error('quic: internal error: no 1-RTT write keys available to advance for key update')
+		}
+
+		next_secret := derive_updated_secret(c.app_write_secret)!
+		next_keys := derive_updated_packet_protection_keys(next_secret, current_write_keys.hp)!
+		c.app_write_secret = next_secret
+		c.app_write_keys = next_keys
+		c.app_write_generation++
 	}
 }
 
 // -------------------------------------------------------------------------
 // Frame dispatch
 // -------------------------------------------------------------------------
+
+// frame_is_ack_eliciting reports whether `frame` is one of the frame types
+// RFC 9000 §13.2.1 requires be acknowledged: "all frames other than ACK,
+// PADDING, and CONNECTION_CLOSE are ack-eliciting." This is distinct from
+// (and NOT interchangeable with) the *_received_pns bookkeeping used to
+// build ACK RANGES -- every successfully-processed packet's number belongs
+// in an ACK once one is sent, ack-eliciting or not, but whether a packet
+// being non-ack-eliciting-only should by ITSELF trigger sending an ACK at
+// all is a separate question: §13.2.1 is explicit that "an endpoint MUST
+// NOT send a non-ack-eliciting packet in response to a non-ack-eliciting
+// packet ... this avoids an infinite feedback loop of acknowledgments."
+fn frame_is_ack_eliciting(frame QuicFrame) bool {
+	return match frame {
+		AckFrame, PaddingFrame, ConnectionCloseFrame { false }
+		else { true }
+	}
+}
 
 fn (mut c QuicConn) dispatch_pre_confirm_frame(space QuicPacketNumberSpace, frame QuicFrame, now u64, mut result PollResult) ! {
 	match frame {
@@ -984,7 +1087,16 @@ fn (mut c QuicConn) handle_stop_sending_frame(frame StopSendingFrame) {
 fn (mut c QuicConn) handle_ack_frame(space QuicPacketNumberSpace, frame AckFrame, now u64) {
 	handshake_confirmed := c.handshake_completion.is_confirmed()
 	max_ack_delay := c.effective_max_ack_delay()
-	result := c.loss_detection.on_ack_received(space, frame, default_ack_delay_exponent,
+	// on_ack_received's own doc comment: "ack_delay_exponent is the PEER's
+	// own ack_delay_exponent transport parameter" -- this ACK frame's raw
+	// ack_delay field was encoded by the peer using ITS advertised value
+	// (RFC 9000 §18.2), not ours, and not the RFC's own default-if-absent
+	// value unconditionally.
+	peer_ack_delay_exponent := c.handshake.peer_transport_parameters.ack_delay_exponent or {
+		default_ack_delay_exponent
+	}
+
+	result := c.loss_detection.on_ack_received(space, frame, peer_ack_delay_exponent,
 		max_ack_delay, handshake_confirmed, now)
 	c.congestion_control.on_packets_acked(result.newly_acked)
 	if result.lost.len > 0 {
@@ -1075,6 +1187,8 @@ fn (mut c QuicConn) dispatch_handshake_message(msg HandshakeMessage, framed []u8
 		.wait_finished {
 			client_finished, app_secrets := c.handshake.process_finished(msg, framed)!
 			c.app_write_keys = derive_packet_protection_keys(app_secrets.client_secret)!
+			c.app_write_secret = app_secrets.client_secret.clone()
+			c.app_write_generation = 0
 			c.app_read_keys = new_key_update_state(app_secrets.server_secret)!
 			c.handshake_completion.mark_peer_finished_verified()
 			c.pending_handshake_crypto = client_finished
@@ -1110,6 +1224,7 @@ fn (mut c QuicConn) discard_initial_keys() {
 	c.pn_spaces.initial = PacketNumberSpaceState{}
 	c.loss_detection.initial = LossDetectionSpaceState{}
 	c.initial_received_pns = map[u64]bool{}
+	c.initial_ack_eliciting_pending = false
 	c.pending_initial_crypto = none
 }
 
@@ -1120,6 +1235,7 @@ fn (mut c QuicConn) discard_handshake_keys() {
 	c.pn_spaces.handshake = PacketNumberSpaceState{}
 	c.loss_detection.handshake = LossDetectionSpaceState{}
 	c.handshake_received_pns = map[u64]bool{}
+	c.handshake_ack_eliciting_pending = false
 	c.pending_handshake_crypto = none
 }
 
@@ -1134,11 +1250,19 @@ fn (mut c QuicConn) drain_outgoing(now u64, mut result PollResult) ! {
 		result.outgoing << datagram
 		c.pending_initial_crypto = none
 	}
-	if !c.initial_keys_discarded && c.initial_received_pns.len > 0 {
+	// RFC 9000 §13.2.1: gated on *_ack_eliciting_pending, not just
+	// *_received_pns.len > 0 -- see frame_is_ack_eliciting's own doc
+	// comment. A packet whose only frames were ACK/PADDING/CONNECTION_CLOSE
+	// must not itself trigger sending this ACK-only (non-ack-eliciting)
+	// reply; its packet number stays in *_received_pns to be included
+	// once an ack-eliciting packet DOES trigger one.
+	if !c.initial_keys_discarded && c.initial_received_pns.len > 0
+		&& c.initial_ack_eliciting_pending {
 		ack_frame := c.build_ack_frame_for(.initial)!
 		datagram := c.build_initial_packet(ack_frame, false, now)!
 		result.outgoing << datagram
 		c.initial_received_pns = map[u64]bool{}
+		c.initial_ack_eliciting_pending = false
 	}
 
 	if data := c.pending_handshake_crypto {
@@ -1151,20 +1275,23 @@ fn (mut c QuicConn) drain_outgoing(now u64, mut result PollResult) ! {
 	}
 	if hs_keys := c.handshake_keys_client {
 		_ := hs_keys
-		if !c.handshake_keys_discarded && c.handshake_received_pns.len > 0 {
+		if !c.handshake_keys_discarded && c.handshake_received_pns.len > 0
+			&& c.handshake_ack_eliciting_pending {
 			ack_frame := c.build_ack_frame_for(.handshake)!
 			datagram := c.build_handshake_packet(ack_frame, false, now)!
 			result.outgoing << datagram
 			c.handshake_received_pns = map[u64]bool{}
+			c.handshake_ack_eliciting_pending = false
 		}
 	}
 
 	if _ := c.app_write_keys {
-		if c.app_received_pns.len > 0 {
+		if c.app_received_pns.len > 0 && c.app_ack_eliciting_pending {
 			ack_frame := c.build_ack_frame_for(.application_data)!
 			datagram := c.build_one_rtt_packet(ack_frame, false, now)!
 			result.outgoing << datagram
 			c.app_received_pns = map[u64]bool{}
+			c.app_ack_eliciting_pending = false
 		}
 		c.drain_pending_stream_writes(now, mut result)!
 		c.drain_pending_stream_resets(now, mut result)!
@@ -1389,10 +1516,14 @@ fn (mut c QuicConn) build_one_rtt_packet(payload []u8, is_ack_eliciting bool, no
 	pn_bytes, pn_length := encode_packet_number(pn,
 		c.pn_spaces.application_data.largest_acked_by_peer)!
 
-	// key_phase is always false: v1 never client-initiates a key update
-	// (key_update.v's own documented scope), so this endpoint's own write
-	// phase never advances past the first generation.
-	header_prefix := encode_short_header(c.dcid, false, 0, false, u8(pn_length - 1))!
+	// key_phase reflects app_write_generation's parity -- generation 0 is
+	// phase false (RFC 9000 §17.3.1's own initial value), toggling each
+	// time sync_write_keys_to_peer_update advances a generation (RFC 9001
+	// §6.2). This endpoint never INITIATES its own key update (v1 scope,
+	// key_update.v's own doc comment) but MUST follow a peer-initiated one,
+	// which is exactly what app_write_generation tracks.
+	key_phase := c.app_write_generation % 2 == 1
+	header_prefix := encode_short_header(c.dcid, false, 0, key_phase, u8(pn_length - 1))!
 	mut header := header_prefix.clone()
 	header << pn_bytes
 

--- a/vlib/net/quic/conn.v
+++ b/vlib/net/quic/conn.v
@@ -634,6 +634,10 @@ fn (mut c QuicConn) process_initial_or_handshake(space QuicPacketNumberSpace, ra
 	unprotected := unprotect_packet(mut packet, offset, .long, keys, largest_pn) or { return }
 
 	c.processed_first_server_packet = true
+	// RFC 9000 §10.1: receiving and successfully processing ANY packet
+	// restarts the idle timer, not just an ack-eliciting one -- see
+	// idle_timeout.v's own doc comment.
+	c.idle_timeout.note_packet_received(now)
 	if c.peer_scid.len == 0 {
 		// RFC 9000 §7.2: upon first receiving a packet from the server, the
 		// client MUST use its Source Connection ID as the Destination
@@ -735,6 +739,10 @@ fn (mut c QuicConn) process_one_rtt_packet(raw []u8, now u64, mut result PollRes
 	read_keys.note_successful_decrypt(resolution, full_pn)!
 
 	c.processed_first_server_packet = true
+	// RFC 9000 §10.1: receiving and successfully processing ANY packet
+	// restarts the idle timer, not just an ack-eliciting one -- see
+	// idle_timeout.v's own doc comment.
+	c.idle_timeout.note_packet_received(now)
 	c.pn_spaces.application_data.note_received(full_pn)
 	c.app_received_pns[full_pn] = true
 
@@ -783,6 +791,17 @@ fn (mut c QuicConn) dispatch_one_rtt_frame(frame QuicFrame, now u64, mut result 
 			c.handle_peer_connection_close(frame, now, mut result)
 		}
 		HandshakeDoneFrame {
+			// RFC 9000 §19.20: "A HANDSHAKE_DONE frame can only be sent by
+			// the server... A server MUST treat receipt of a
+			// HANDSHAKE_DONE frame as a connection error of type
+			// PROTOCOL_VIOLATION." Currently unreachable in real use (v1
+			// only ever constructs clients, role is always .client) but
+			// kept so this dispatch code needs no rework when server
+			// support (Phase 13) lands -- see
+			// test_handshake_done_rejected_when_role_is_server.
+			if c.role == .server {
+				return error('quic: PROTOCOL_VIOLATION: server received HANDSHAKE_DONE (RFC 9000 §19.20)')
+			}
 			c.handshake_completion.mark_handshake_done_received()
 			if c.handshake_completion.is_confirmed() {
 				c.on_handshake_confirmed(mut result)
@@ -1375,9 +1394,19 @@ fn (mut c QuicConn) send_pto_probe(space QuicPacketNumberSpace, now u64, mut res
 // `now`. Shared by close_with_error (.closing) and enter_draining
 // (.draining) so both states are bounded identically -- see enter_draining's
 // own doc comment for why a missing deadline here is a real, not
-// theoretical, bug.
+// theoretical, bug. `now` is a `time.sys_mono_now()`-sourced nanosecond
+// instant throughout this module (see IdleTimeoutState.last_reset's own
+// doc comment, and loss_detection_test.v's own RTT-sample assertions, e.g.
+// `ld.rtt.latest_rtt == 1000 * time.nanosecond`) -- `pto_period()` is
+// ALREADY a real, nanosecond-scale `time.Duration`, so it must be added
+// directly, never routed through `.milliseconds()` first (that would
+// shrink it to a tiny millisecond COUNT before adding it to a
+// nanosecond-scale `now`, landing the deadline almost immediately instead
+// of ~3xPTO out). Found self-inflicted while re-verifying a maintainer
+// "Local AI Review" idle-timeout finding on PR #28083 surfaced the exact
+// same mistake freshly introduced in idle_timeout_deadline().
 fn (c &QuicConn) closing_or_draining_deadline(now u64) u64 {
-	return now + 3 * u64(c.loss_detection.rtt.pto_period().milliseconds())
+	return now + 3 * u64(c.loss_detection.rtt.pto_period())
 }
 
 // enter_draining transitions to RFC 9000 §10.2.2's draining state -- used
@@ -1457,6 +1486,20 @@ fn (c &QuicConn) effective_max_ack_delay() time.Duration {
 	return time.Duration(i64(v) * i64(time.millisecond))
 }
 
+// idle_timeout_deadline computes the absolute `now`-scale time (a
+// `time.sys_mono_now()`-sourced nanosecond instant throughout this module
+// -- see IdleTimeoutState.last_reset's own doc comment) at which RFC 9000
+// §10.1's idle timeout elapses. `effective_idle_timeout` already returns a
+// real, nanosecond-scale `time.Duration` (correctly converted from the
+// millisecond WIRE value via `clamped_ms_to_duration`) -- add it to
+// `baseline` directly, never through `.milliseconds()` first, which would
+// shrink it to a tiny millisecond COUNT before adding it to a
+// nanosecond-scale baseline, making the deadline arrive almost immediately
+// instead of the real configured timeout. (A prior version of this
+// function briefly "fixed" this into the wrong shape while investigating a
+// maintainer "Local AI Review" finding on PR #28083 -- the ORIGINAL bare
+// `u64(timeout)` was correct all along; the real, adjacent bug was in
+// `closing_or_draining_deadline`, which had the identical mistake.)
 fn (c &QuicConn) idle_timeout_deadline() ?u64 {
 	peer_max := c.handshake.peer_transport_parameters.max_idle_timeout or { u64(0) }
 	timeout := effective_idle_timeout(c.own_max_idle_timeout_ms, peer_max) or { return none }

--- a/vlib/net/quic/conn.v
+++ b/vlib/net/quic/conn.v
@@ -620,6 +620,44 @@ fn (mut c QuicConn) process_retry(raw []u8) ! {
 }
 
 fn (mut c QuicConn) process_initial_or_handshake(space QuicPacketNumberSpace, raw []u8, header QuicLongHeader, offset int, now u64, mut result PollResult) ! {
+	// RFC 9001 §4.9: once this space's keys are discarded, packets received
+	// in it MUST be discarded too -- the key material itself is NOT cleared
+	// by discard_initial_keys/discard_handshake_keys (see their own doc
+	// comments), so this check is the only thing preventing a stale,
+	// replayed, or attacker-injected packet from still being decrypted and
+	// processed after the RFC-required discard point.
+	if (space == .initial && c.initial_keys_discarded)
+		|| (space == .handshake && c.handshake_keys_discarded) {
+		return
+	}
+	// RFC 9000 §7.2: a packet not addressed to this connection's own SCID
+	// must be silently dropped. Initial keys are publicly derivable (RFC
+	// 9001 §5.2, from the DCID alone), so without this check an off-path
+	// attacker who observes the client's chosen DCID could forge a
+	// well-encrypted Initial packet with an ARBITRARY destination CID and
+	// have it accepted as if it were a legitimate reply, redirecting the
+	// client's subsequent packets.
+	if header.dcid != c.scid {
+		return
+	}
+	// RFC 9000 §7.2 (verbatim): "Once a client has received a valid Initial
+	// packet from the server, it MUST discard any subsequent packet it
+	// receives on that connection with a different Source Connection ID."
+	// Concretely exploitable for Initial packets specifically: Initial keys
+	// are derived from the DCID alone (RFC 9001 §5.2), with no dependency
+	// on the real server's identity, so an attacker who observes the
+	// client's chosen DCID can forge a second, well-encrypted Initial
+	// packet claiming an arbitrary source CID and have its frames (e.g.
+	// injected CRYPTO data) processed as if from the already-established
+	// peer. Checked here (before this connection's own peer_scid is ever
+	// latched below) so it applies uniformly to both spaces, matching the
+	// RFC's own unscoped "any subsequent packet... on that connection"
+	// wording, even though Handshake-space forgery isn't practically
+	// exploitable the same way (those keys derive from the real ECDHE
+	// shared secret).
+	if c.peer_scid.len != 0 && header.scid != c.peer_scid {
+		return
+	}
 	keys := if space == .initial {
 		c.initial_keys_server
 	} else {
@@ -693,7 +731,22 @@ fn (mut c QuicConn) process_one_rtt_packet(raw []u8, now u64, mut result PollRes
 	}
 
 	dcid_len := c.scid.len
-	_, offset := parse_short_header(raw, dcid_len) or {
+	short_header, offset := parse_short_header(raw, dcid_len) or {
+		c.note_one_rtt_processing_failed(raw, now, mut result)
+		return
+	}
+	// RFC 9000 §7.2: a packet not addressed to this connection's own SCID
+	// must be silently dropped -- see process_initial_or_handshake's
+	// identical check for the full rationale. Routed through
+	// note_one_rtt_processing_failed (not a bare return) rather than
+	// dropped outright: a genuine stateless reset (RFC 9000 §10.3) is
+	// deliberately shaped like an ordinary short-header packet with
+	// unpredictable bytes where a real DCID would be, so it will almost
+	// always fail this exact check -- the stateless-reset comparison
+	// (against the packet's own trailing bytes, independent of anything
+	// parsed here) MUST still get a chance to run for a DCID mismatch, not
+	// be short-circuited before it ever fires.
+	if short_header.dcid != c.scid {
 		c.note_one_rtt_processing_failed(raw, now, mut result)
 		return
 	}
@@ -1417,10 +1470,24 @@ fn (c &QuicConn) closing_or_draining_deadline(now u64) u64 {
 // that enters draining without it would sit there forever, never reaching
 // .closed -- found via /vreview (this is the MORE common real-world close
 // path than our own close_with_error, yet was the one missing the bound).
+//
+// If closing_deadline is ALREADY set (this connection was already .closing
+// -- e.g. it sent its own CONNECTION_CLOSE and is now receiving the peer's
+// in reply, a real and reachable path since process_datagram only
+// special-cases .draining, not .closing, before dispatching frames), it
+// MUST NOT be recomputed from the current `now`: RFC 9000 §10.2.2 "the
+// endpoint uses the same end time but ceases transmission of any packets."
+// Recomputing here would extend the period every time a further packet
+// happened to arrive while closing, rather than preserving the original
+// bound. Self-found while auditing this function for the conformance
+// matrix's new §10.2 section; test:
+// test_closing_deadline_not_extended_by_peer_close_while_already_closing.
 fn (mut c QuicConn) enter_draining(now u64) {
 	c.connection_close.enter_draining()
 	c.state = .draining
-	c.closing_deadline = c.closing_or_draining_deadline(now)
+	if c.closing_deadline == none {
+		c.closing_deadline = c.closing_or_draining_deadline(now)
+	}
 }
 
 // close_with_error transitions to .closing and sends a best-effort
@@ -1434,7 +1501,24 @@ fn (mut c QuicConn) close_with_error(error_code u64, reason string, is_applicati
 	c.connection_close.enter_closing()
 	c.state = .closing
 	c.closing_deadline = c.closing_or_draining_deadline(now)
-	frame := encode_connection_close_frame(is_application_error, error_code, 0, reason) or {
+	// RFC 9000 §10.2.3: a CONNECTION_CLOSE of application-error type (0x1d)
+	// MUST be replaced by the transport-error type (0x1c), with the Reason
+	// Phrase field cleared, when sent in an Initial or Handshake packet --
+	// those levels aren't backed by the fully-authenticated 1-RTT keys yet,
+	// so an application-supplied reason string could leak application state
+	// to an observer before the peer is confirmed. build_best_effort_close_packet
+	// picks 1-RTT only when app_write_keys is available; every other branch
+	// falls back to Handshake or Initial, so that's the exact condition to
+	// mirror here, decided BEFORE encoding rather than after (the encoded
+	// frame is also what gets replayed verbatim on every §10.2.1 closing-state
+	// retransmission, so getting this right once here is sufficient).
+	mut wire_is_application_error := is_application_error
+	mut wire_reason := reason
+	if c.app_write_keys == none {
+		wire_is_application_error = false
+		wire_reason = ''
+	}
+	frame := encode_connection_close_frame(wire_is_application_error, error_code, 0, wire_reason) or {
 		result.events << QuicEvent{
 			kind:       .connection_closed
 			error_code: error_code

--- a/vlib/net/quic/conn_test.v
+++ b/vlib/net/quic/conn_test.v
@@ -609,6 +609,84 @@ fn test_close_sends_connection_close_and_transitions_to_closing() {
 	assert found_close
 }
 
+// test_close_before_one_rtt_keys_downgrades_to_transport_connection_close
+// covers RFC 9000 §10.2.3: a CONNECTION_CLOSE of application-error type
+// (0x1d) MUST be replaced by the transport-error type (0x1c) -- with the
+// Reason Phrase field cleared -- when it has to be sent in an Initial or
+// Handshake packet, since those levels aren't fully authenticated/protected
+// yet and could expose application state to an observer. close() always
+// marks its request as application-level (is_application_error: true,
+// carrying the caller's real reason string) with no way for the caller to
+// know which packet level will actually carry it -- reproduced here by
+// calling close() in the window between EncryptedExtensions and Finished,
+// where only Handshake keys are available (app_write_keys is still none).
+fn test_close_before_one_rtt_keys_downgrades_to_transport_connection_close() {
+	mut now := u64(1000)
+	mut c, initial_dg := dial(DialParams{
+		server_name:          'example.com'
+		ca_bundle_pem:        conn_test_cert_pem
+		alpn_protocols:       ['h3']
+		transport_parameters: QuicTransportParameters{}
+	}, now)!
+	defer {
+		c.handshake.free()
+	}
+	assert initial_dg.bytes.len >= min_initial_datagram_size
+
+	server_initial_scid := [u8(0xaa), 0xbb, 0xcc, 0xdd]
+
+	server_pub, server_priv := ecdsa.generate_key(nid: .prime256v1)!
+	defer {
+		server_pub.free()
+		unsafe { server_priv.free() }
+	}
+	server_ecdhe_public_bytes := server_pub.uncompressed_bytes()!
+	server_random := []u8{len: 32, init: 0x22}
+	client_key_exchange := conn_test_extract_client_hello_key_exchange(c.client_hello)!
+	client_pub := ecdsa.PublicKey.from_uncompressed_bytes(client_key_exchange, nid: .prime256v1)!
+	defer {
+		client_pub.free()
+	}
+	server_shared_secret := server_priv.derive_shared_secret(client_pub)!
+	server_hello_framed := conn_test_build_fake_server_hello(server_random,
+		server_ecdhe_public_bytes)!
+
+	sh_payload := encode_crypto_frame(0, server_hello_framed)!
+	sh_datagram := build_fake_long_header_packet(.initial, c.scid, server_initial_scid, 0,
+		sh_payload, c.initial_keys_server)!
+	result1 := c.poll(sh_datagram.bytes, now)!
+	assert result1.events.len == 0
+	now += 10
+
+	hs_keys_server := c.handshake_keys_server or { panic('unreachable: just asserted != none') }
+	mut ee_params := QuicTransportParameters{}
+	ee_params.initial_source_connection_id = server_initial_scid
+	ee_params.original_destination_connection_id = c.original_dcid
+	ee_framed := conn_test_build_fake_encrypted_extensions(ee_params)!
+	ee_payload := encode_crypto_frame(0, ee_framed)!
+	ee_datagram := build_fake_long_header_packet(.handshake, c.scid, server_initial_scid, 0,
+		ee_payload, hs_keys_server)!
+	result2 := c.poll(ee_datagram.bytes, now)!
+	assert result2.events.len == 0
+	assert c.handshake.state() == .wait_certificate
+	assert c.app_write_keys == none // still pre-1-RTT -- the window this bug lives in
+	now += 10
+
+	c.close(99, 'application-level reason that must not leak')
+	poll_result := c.poll(none, now)!
+	assert c.state() == .closing
+	assert poll_result.outgoing.len > 0
+
+	sent := c.sent_close_payload or {
+		panic('unreachable: close_with_error always sets this on success')
+	}
+
+	frame, _ := parse_frame(sent)!
+	close_frame := frame as ConnectionCloseFrame
+	assert !close_frame.is_application_error
+	assert close_frame.reason == ''
+}
+
 // test_peer_connection_close_enters_draining covers the receive side of
 // RFC 9000 §10.2.2: a CONNECTION_CLOSE from the peer transitions this
 // connection straight to .draining (never .closing -- draining requires no
@@ -649,6 +727,56 @@ fn test_peer_connection_close_enters_draining() {
 	timeout_result := c.process_timeouts(far_future)!
 	assert c.state() == .closed
 	assert timeout_result.events.any(it.kind == .connection_closed)
+}
+
+// test_closing_deadline_not_extended_by_peer_close_while_already_closing
+// covers RFC 9000 §10.2.2's "same end time" rule: "An endpoint MAY enter
+// the draining state from the closing state if it receives a
+// CONNECTION_CLOSE frame... the endpoint uses the same end time but
+// ceases transmission." enter_draining unconditionally recomputed
+// closing_deadline from the `now` at the moment of the closing->draining
+// transition -- if that transition happens meaningfully later than the
+// original close_with_error call (this endpoint sent its own close, THEN
+// received the peer's close some time afterward, while still within the
+// original closing period), the recomputed deadline is now+3xPTO from the
+// LATER time, extending the period instead of preserving it. Self-found
+// while auditing §10.2 for the conformance matrix -- process_datagram only
+// special-cases .draining (not .closing) before dispatching frames, so a
+// peer CONNECTION_CLOSE arriving while already .closing is a real,
+// reachable path, not a theoretical one.
+fn test_closing_deadline_not_extended_by_peer_close_while_already_closing() {
+	mut c, _, now0 :=
+		drive_to_established(generous_transport_params(), generous_transport_params())!
+	defer {
+		c.handshake.free()
+	}
+
+	c.close(1, 'bye')
+	result1 := c.poll(none, now0)!
+	assert c.state() == .closing
+	assert result1.outgoing.len > 0
+	original_deadline := c.closing_deadline or {
+		panic('unreachable: close_with_error always sets this')
+	}
+
+	// Advance `now` by a small amount, still well within the original
+	// closing period (3x PTO, at minimum hundreds of ms with default
+	// smoothed_rtt) -- large enough to prove recomputation would actually
+	// change the deadline, small enough the ORIGINAL deadline hasn't
+	// elapsed yet.
+	now1 := now0 + 50_000_000 // 50ms, nanosecond-scale per this module's convention
+	read_keys := c.app_read_keys or { panic('unreachable: established asserts this') }
+	server_app_keys := read_keys.current_keys
+	cc_frame := encode_connection_close_frame(false, 7, 0, 'server done too')!
+	incoming := build_fake_one_rtt_packet(c.scid, 1, cc_frame, server_app_keys)!
+	c.poll(incoming.bytes, now1)!
+	assert c.state() == .draining
+
+	preserved_deadline := c.closing_deadline or {
+		panic('unreachable: enter_draining always sets this')
+	}
+
+	assert preserved_deadline == original_deadline
 }
 
 // test_idle_timeout_mechanism_fires_after_configured_window is a sanity
@@ -759,6 +887,222 @@ fn test_handshake_done_rejected_when_role_is_server() {
 		return
 	}
 	assert false, 'expected dispatch_one_rtt_frame to reject HANDSHAKE_DONE when role is server'
+}
+
+// test_discarded_initial_keys_reject_further_packets is a regression test
+// for a reviewer finding on PR #28083: process_initial_or_handshake used
+// c.initial_keys_server/c.handshake_keys_server to decrypt without checking
+// c.initial_keys_discarded/c.handshake_keys_discarded first. discard_initial_
+// keys/discard_handshake_keys (RFC 9001 §4.9) only reset per-space
+// bookkeeping -- they never clear the key material itself -- so a stale,
+// replayed, or attacker-injected packet in a discarded space was still
+// successfully decrypted and its frames dispatched after the RFC-required
+// discard point. RFC 9001 §4.9: "once an endpoint has discarded its
+// Initial/Handshake keys, it MUST discard all packets it receives in that
+// space." Observable via c.initial_received_pns staying empty: discard
+// resets it to a fresh map, and only a successfully-processed packet in
+// that space would repopulate it.
+fn test_discarded_initial_keys_reject_further_packets() {
+	mut c, server_initial_scid, mut now := drive_to_established(generous_transport_params(),
+		generous_transport_params())!
+	defer {
+		c.handshake.free()
+	}
+	assert c.initial_keys_discarded
+
+	// A bare PING frame (RFC 9000 §19.2, legal in the Initial space, always
+	// a harmless no-op) so the ONLY thing that can explain a difference in
+	// c.initial_received_pns is whether the discard check runs -- a CRYPTO
+	// frame with arbitrary content would ALSO get rejected by the TLS layer
+	// post-handshake for an unrelated reason (unexpected message), giving a
+	// false pass/fail signal.
+	// RFC 9001 §5.4.2: header protection sampling needs at least 4 bytes of
+	// packet number plus a 16-byte sample after it -- a bare 1-byte PING
+	// frame's resulting packet is a few bytes too short, so pad with
+	// PADDING frames (0x00, RFC 9000 §19.1 -- legal anywhere).
+	mut ping_payload := [u8(frame_type_ping)]
+	ping_payload << [u8(0), 0, 0, 0]
+	stale_datagram := build_fake_long_header_packet(.initial, c.scid, server_initial_scid, 5,
+		ping_payload, c.initial_keys_server)!
+	result := c.poll(stale_datagram.bytes, now)!
+	assert result.events.len == 0
+	assert c.initial_received_pns.len == 0
+}
+
+// test_discarded_handshake_keys_reject_further_packets is the Handshake-space
+// sibling of test_discarded_initial_keys_reject_further_packets above -- same
+// finding, same RFC 9001 §4.9 requirement, same gap in
+// process_initial_or_handshake's .handshake branch.
+fn test_discarded_handshake_keys_reject_further_packets() {
+	mut c, server_initial_scid, mut now := drive_to_established(generous_transport_params(),
+		generous_transport_params())!
+	defer {
+		c.handshake.free()
+	}
+	assert c.handshake_keys_discarded
+	hs_keys_server := c.handshake_keys_server or {
+		panic('unreachable: discard does not clear this')
+	}
+
+	// RFC 9001 §5.4.2: header protection sampling needs at least 4 bytes of
+	// packet number plus a 16-byte sample after it -- a bare 1-byte PING
+	// frame's resulting packet is a few bytes too short, so pad with
+	// PADDING frames (0x00, RFC 9000 §19.1 -- legal anywhere).
+	mut ping_payload := [u8(frame_type_ping)]
+	ping_payload << [u8(0), 0, 0, 0]
+	stale_datagram := build_fake_long_header_packet(.handshake, c.scid, server_initial_scid, 5,
+		ping_payload, hs_keys_server)!
+	result := c.poll(stale_datagram.bytes, now)!
+	assert result.events.len == 0
+	assert c.handshake_received_pns.len == 0
+}
+
+// test_wrong_destination_cid_rejected_on_long_header is a regression test for
+// a reviewer finding on PR #28083: process_initial_or_handshake accepts any
+// authenticated server packet and updates c.dcid/c.peer_scid from its source
+// CID without ever checking header.dcid == c.scid. Initial keys are publicly
+// derivable (RFC 9001 §5.2, from the DCID alone), so an off-path attacker
+// who observes (or guesses) the client's chosen DCID can forge a
+// well-encrypted Initial packet addressed with an ARBITRARY (wrong)
+// destination CID and have it accepted as if it were a legitimate reply,
+// letting it redirect the client's subsequent packets to a CID of the
+// attacker's choosing. Fed as the very FIRST incoming packet (mirroring
+// drive_to_established's own first step) so a pre-fix acceptance is
+// observable via c.peer_scid/c.dcid changing from empty.
+fn test_wrong_destination_cid_rejected_on_long_header() {
+	mut c, initial_dg := dial(DialParams{
+		server_name:          'example.com'
+		ca_bundle_pem:        conn_test_cert_pem
+		alpn_protocols:       ['h3']
+		transport_parameters: QuicTransportParameters{}
+	}, u64(0))!
+	defer {
+		c.handshake.free()
+	}
+	assert initial_dg.bytes.len >= min_initial_datagram_size
+	assert c.peer_scid.len == 0
+
+	// A bare PING frame (harmless no-op) rather than a CRYPTO frame with
+	// arbitrary content -- garbage handshake-message bytes would ALSO get
+	// rejected by the TLS layer as an unexpected/malformed message,
+	// producing a false pass/fail signal unrelated to the DCID check.
+	wrong_dcid := [u8(0xde), 0xad, 0xbe, 0xef]
+	attacker_scid := [u8(0x99), 0x99, 0x99, 0x99]
+	mut forged_payload := [u8(frame_type_ping)]
+	forged_payload << [u8(0), 0, 0, 0]
+	forged_datagram := build_fake_long_header_packet(.initial, wrong_dcid, attacker_scid, 0,
+		forged_payload, c.initial_keys_server)!
+	result := c.poll(forged_datagram.bytes, u64(10))!
+	assert result.events.len == 0
+	assert c.peer_scid.len == 0
+	assert c.handshake.state() == .wait_server_hello
+}
+
+// test_wrong_destination_cid_rejected_on_short_header is the 1-RTT sibling of
+// test_wrong_destination_cid_rejected_on_long_header above -- same finding,
+// same missing check, in process_one_rtt_packet's use of parse_short_header's
+// discarded header return value (previously `_, offset := ...`).
+fn test_wrong_destination_cid_rejected_on_short_header() {
+	mut c, server_initial_scid, mut now := drive_to_established(generous_transport_params(),
+		generous_transport_params())!
+	defer {
+		c.handshake.free()
+	}
+
+	read_keys := c.app_read_keys or { panic('unreachable: established asserts this') }
+	server_app_keys := read_keys.current_keys
+	// Short headers don't self-describe their DCID length (the receiver
+	// supplies it from its own connection state, c.scid.len) -- unlike the
+	// long-header test above, this MUST be the same length as c.scid or
+	// the parse itself is corrupted (a length mismatch, not a content
+	// mismatch), which would fail for an unrelated reason.
+	wrong_dcid := []u8{len: c.scid.len, init: 0xde}
+	stream_frame := encode_stream_frame(1, 0, 'forged'.bytes(), false, false)!
+	forged_datagram := build_fake_one_rtt_packet(wrong_dcid, 0, stream_frame, server_app_keys)!
+	result := c.poll(forged_datagram.bytes, now)!
+	assert result.events.len == 0
+	assert c.streams.len() == 0
+}
+
+// test_wrong_source_cid_rejected_after_peer_scid_established is a regression
+// test SELF-FOUND while auditing RFC 9000 §7.2/§17.2.2.1 to build a proper
+// conn.v conformance-matrix section (in direct response to a maintainer
+// reviewer's separate DCID/discarded-key findings on PR #28083, plus the
+// user's explicit feedback that /vreview kept missing this class of gap).
+// RFC 9000 §7.2 (verbatim): "Once a client has received a valid Initial
+// packet from the server, it MUST discard any subsequent packet it
+// receives on that connection with a different Source Connection ID."
+// process_initial_or_handshake only ever WRITES c.peer_scid on the first
+// packet (`if c.peer_scid.len == 0 {...}`) -- it never checks a LATER
+// packet's header.scid against the already-established c.peer_scid. Unlike
+// the destination-CID finding, this is concretely exploitable: Initial
+// packet protection keys are derived from the DCID ALONE (RFC 9001 §5.2),
+// with no dependency on the real server's identity, so an attacker who
+// observes the client's chosen DCID can forge a second, well-encrypted
+// Initial packet claiming an ARBITRARY source CID and have its frames
+// (e.g. injected CRYPTO data) processed as if from the already-established
+// peer. (Handshake-space packets are NOT exploitable the same way --
+// Handshake keys derive from the real ECDHE shared secret -- but the fix
+// still covers both spaces uniformly, matching the RFC's own unscoped
+// "any subsequent packet... on that connection" wording and this file's
+// established practice of implementing the full MUST rather than only the
+// practically-exploitable subset.)
+fn test_wrong_source_cid_rejected_after_peer_scid_established() {
+	mut c, initial_dg := dial(DialParams{
+		server_name:          'example.com'
+		ca_bundle_pem:        conn_test_cert_pem
+		alpn_protocols:       ['h3']
+		transport_parameters: QuicTransportParameters{}
+	}, u64(0))!
+	defer {
+		c.handshake.free()
+	}
+	assert initial_dg.bytes.len >= min_initial_datagram_size
+
+	real_server_scid := [u8(0xaa), 0xbb, 0xcc, 0xdd]
+	server_pub, server_priv := ecdsa.generate_key(nid: .prime256v1)!
+	defer {
+		server_pub.free()
+		unsafe { server_priv.free() }
+	}
+	server_ecdhe_public_bytes := server_pub.uncompressed_bytes()!
+	server_random := []u8{len: 32, init: 0x22}
+	client_key_exchange := conn_test_extract_client_hello_key_exchange(c.client_hello)!
+	client_pub := ecdsa.PublicKey.from_uncompressed_bytes(client_key_exchange, nid: .prime256v1)!
+	defer {
+		client_pub.free()
+	}
+	_ := server_priv.derive_shared_secret(client_pub)!
+	server_hello_framed := conn_test_build_fake_server_hello(server_random,
+		server_ecdhe_public_bytes)!
+	sh_payload := encode_crypto_frame(0, server_hello_framed)!
+	sh_datagram := build_fake_long_header_packet(.initial, c.scid, real_server_scid, 0, sh_payload,
+		c.initial_keys_server)!
+	result1 := c.poll(sh_datagram.bytes, u64(10))!
+	assert result1.events.len == 0
+	assert c.peer_scid == real_server_scid
+	assert !c.initial_keys_discarded
+
+	// Forged SECOND Initial packet: correct dcid (=c.scid, so it passes the
+	// separate destination-CID check), but a DIFFERENT scid than the one
+	// just established above.
+	forged_scid := [u8(0x99), 0x99, 0x99, 0x99]
+	mut forged_payload := [u8(frame_type_ping)]
+	forged_payload << [u8(0), 0, 0, 0]
+	forged_datagram := build_fake_long_header_packet(.initial, c.scid, forged_scid, 1,
+		forged_payload, c.initial_keys_server)!
+	result2 := c.poll(forged_datagram.bytes, u64(20))!
+	assert result2.events.len == 0
+	assert c.peer_scid == real_server_scid
+	// initial_received_pns itself is drained (reset to empty) by
+	// drain_outgoing's own ACK-building logic on every poll() call, so it
+	// can't distinguish "nothing new arrived" from "something arrived and
+	// got ACKed" across two separate poll() calls -- pn_spaces.initial's
+	// own largest_received is the stable, persistent signal: it stays at 0
+	// (the first legit packet) if the forged pn=1 packet was correctly
+	// rejected, or advances to 1 if it was wrongly processed.
+	largest_received := c.pn_spaces.initial.largest_received or { u64(999) }
+	assert largest_received == 0
 }
 
 // test_compute_next_timeout_includes_closing_deadline is a regression test

--- a/vlib/net/quic/conn_test.v
+++ b/vlib/net/quic/conn_test.v
@@ -640,11 +640,125 @@ fn test_peer_connection_close_enters_draining() {
 	// RFC 9000 §10.2.2: draining MUST be bounded (same period as closing,
 	// recommended 3x PTO) -- a peer-initiated close is the MOST common
 	// real-world close path, so process_timeouts() must eventually retire
-	// this connection to .closed, not leave it draining forever.
-	far_future := now + 1000 * 1000
+	// this connection to .closed, not leave it draining forever. `now`
+	// throughout this module is a time.sys_mono_now()-sourced nanosecond
+	// instant (see IdleTimeoutState.last_reset's own doc comment), so
+	// "far future" must be nanosecond-scale too -- 10 real seconds safely
+	// exceeds even a first-sample PTO (default smoothed_rtt=333ms) x3.
+	far_future := now + 10_000_000_000
 	timeout_result := c.process_timeouts(far_future)!
 	assert c.state() == .closed
 	assert timeout_result.events.any(it.kind == .connection_closed)
+}
+
+// test_idle_timeout_mechanism_fires_after_configured_window is a sanity
+// regression test for the idle-timeout mechanism itself, written while
+// verifying a maintainer "Local AI Review" finding on PR #28083
+// (2026-08-14). It also caught a genuine self-inflicted bug: an earlier
+// attempt at this fix "corrected" idle_timeout_deadline() to route its
+// already-real, nanosecond-scale `time.Duration` through `.milliseconds()`
+// before combining with `now` -- but `now` is nanosecond-scale throughout
+// this module (time.sys_mono_now()-sourced; see loss_detection_test.v's
+// own RTT-sample assertions, e.g. `ld.rtt.latest_rtt == 1000 *
+// time.nanosecond`, for independent confirmation), so that "fix" shrank the
+// real timeout to a tiny millisecond COUNT and made the deadline arrive
+// almost immediately instead of after the configured window. The ORIGINAL
+// code (a bare `u64(timeout)`, no conversion) was correct all along; this
+// test's own first draft (using tiny `now` deltas modeled on the wrong,
+// millisecond assumption) could not have caught that mistake either, since
+// small deltas pass trivially regardless of which formula is used.
+fn test_idle_timeout_mechanism_fires_after_configured_window() {
+	mut own_params := generous_transport_params()
+	own_params.max_idle_timeout = 5000 // milliseconds, per RFC 9000 §18.2's wire format
+	mut peer_params := generous_transport_params()
+	peer_params.max_idle_timeout = 5000
+	mut c, _, mut now := drive_to_established(own_params, peer_params)!
+	defer {
+		c.handshake.free()
+	}
+
+	// Genuinely idle (nothing received or sent since establishment) and
+	// well past the real 5-second (5_000_000_000ns) window -- must close.
+	now += 6_000_000_000
+	final_result := c.process_timeouts(now)!
+	assert c.state() == .closed
+	assert final_result.events.any(it.kind == .connection_closed)
+}
+
+// test_process_one_rtt_packet_resets_idle_timer_on_receive is a regression
+// test for a maintainer "Local AI Review" finding on PR #28083 (2026-08-14,
+// a different LLM than the closing_deadline round): conn.v never called
+// IdleTimeoutState.note_packet_received at all -- only note_packet_sent was
+// wired in (build_initial_packet/build_handshake_packet/
+// build_one_rtt_packet). An otherwise active connection that only RECEIVES
+// data (never itself initiates a send) would incorrectly idle-timeout at
+// the original deadline. Verifying this surfaced a second, deeper bug:
+// note_packet_received itself had RFC 9000 §10.1's rule backwards --
+// gating the RECEIVE-side restart on ack-eliciting, when the RFC's
+// ack-eliciting condition applies only to the SEND side; receive restarts
+// unconditionally on ANY successfully processed packet (fixed in
+// idle_timeout.v, which also dropped the now-unnecessary is_ack_eliciting
+// parameter).
+//
+// White-box (same-module), calling process_one_rtt_packet directly rather
+// than through poll(): this module's own drain_outgoing unconditionally
+// ACKs every received 1-RTT packet in the SAME poll() call
+// (`app_received_pns.len > 0` gates an outgoing ACK with no ack-eliciting
+// check), and building that ACK packet calls note_packet_sent -- so a
+// poll()-driven test can never isolate "receive alone resets the timer"
+// from "the auto-generated ACK response resets it," the same masking shape
+// already seen once this session (a stale PTO masking the closing_deadline
+// gap). Calling process_one_rtt_packet directly, before drain_outgoing ever
+// runs, is the only way to observe the receive-side effect in isolation.
+fn test_process_one_rtt_packet_resets_idle_timer_on_receive() {
+	mut c, _, mut now := drive_to_established(generous_transport_params(),
+		generous_transport_params())!
+	defer {
+		c.handshake.free()
+	}
+
+	read_keys := c.app_read_keys or { panic('unreachable: established asserts this') }
+	server_app_keys := read_keys.current_keys
+	stream_frame := encode_stream_frame(1, 0, 'keepalive'.bytes(), false, false)!
+	incoming := build_fake_one_rtt_packet(c.scid, 0, stream_frame, server_app_keys)!
+
+	now += 4000
+	mut result := PollResult{}
+	c.process_one_rtt_packet(incoming.bytes, now, mut result)!
+	last_reset := c.idle_timeout.last_reset or { u64(0) }
+	assert last_reset == now
+}
+
+// test_handshake_done_rejected_when_role_is_server is a regression test for
+// a maintainer "Local AI Review" finding on PR #28083 (2026-08-14): RFC
+// 9000 §19.20 -- "A HANDSHAKE_DONE frame can only be sent by the server...
+// A server MUST treat receipt of a HANDSHAKE_DONE frame as a connection
+// error of type PROTOCOL_VIOLATION" -- was never checked;
+// dispatch_one_rtt_frame's HandshakeDoneFrame arm unconditionally advanced
+// handshake state regardless of role.
+//
+// White-box (same-module), forcing `c.role = .server`: this codebase only
+// ever constructs clients in v1 (dial() hardcodes role: .client, no server
+// constructor exists), so this exact path is currently unreachable through
+// any real call path -- forcing the role is the only way to exercise it.
+// Still worth fixing now rather than deferring to Phase 13: stream.v's own
+// QuicRole doc comment and PROGRESS.md both state the role field exists
+// specifically so Phases 1-9's dispatch code needs no rework when server
+// support lands, and this is a one-line, zero-risk guard matching an
+// explicit RFC MUST.
+fn test_handshake_done_rejected_when_role_is_server() {
+	mut c, _, now := drive_to_established(generous_transport_params(), generous_transport_params())!
+	defer {
+		c.handshake.free()
+	}
+	c.role = .server
+
+	mut result := PollResult{}
+	c.dispatch_one_rtt_frame(HandshakeDoneFrame{}, now, mut result) or {
+		assert err.msg().contains('PROTOCOL_VIOLATION')
+		return
+	}
+	assert false, 'expected dispatch_one_rtt_frame to reject HANDSHAKE_DONE when role is server'
 }
 
 // test_compute_next_timeout_includes_closing_deadline is a regression test

--- a/vlib/net/quic/conn_test.v
+++ b/vlib/net/quic/conn_test.v
@@ -5,6 +5,7 @@ import crypto.ecdsa
 import crypto.sha256
 import encoding.base64
 import net.mbedtls
+import time
 
 // Duplicated locally (rather than referenced from any other _test.v file)
 // deliberately, per this module's own established convention -- each
@@ -248,9 +249,9 @@ fn build_fake_long_header_packet(typ LongPacketType, dcid []u8, scid []u8, pn u6
 
 // build_fake_one_rtt_packet mirrors build_fake_long_header_packet for a
 // fake server's short-header (1-RTT) datagram.
-fn build_fake_one_rtt_packet(dcid []u8, pn u64, payload []u8, keys QuicPacketProtectionKeys) !QuicDatagram {
+fn build_fake_one_rtt_packet(dcid []u8, pn u64, payload []u8, keys QuicPacketProtectionKeys, key_phase bool) !QuicDatagram {
 	pn_length := 2
-	header_prefix := encode_short_header(dcid, false, 0, false, u8(pn_length - 1))!
+	header_prefix := encode_short_header(dcid, false, 0, key_phase, u8(pn_length - 1))!
 	mut header := header_prefix.clone()
 	header << [u8(pn >> 8), u8(pn)]
 	protected := protect_packet(header, .short, pn, pn_length, payload, keys)!
@@ -260,14 +261,16 @@ fn build_fake_one_rtt_packet(dcid []u8, pn u64, payload []u8, keys QuicPacketPro
 }
 
 // conn_test_decrypt_one_rtt decrypts and frame-parses a 1-RTT datagram
-// USING A SINGLE, KNOWN (non-rotating) generation of keys -- suitable for
-// tests inspecting what the CLIENT itself just sent (c.app_write_keys never
-// rotates, matching key_update.v's own documented v1 scope: client-initiated
-// rotation is out of scope, and app_write_keys is a plain, non-KeyUpdateState
-// field for exactly that reason). NOT a substitute for conn.v's own
-// process_one_rtt_packet (which must handle key-phase resolution via
-// KeyUpdateState); this is a test-only, single-generation-only decrypt used
-// purely to verify what conn.v's outgoing path built.
+// USING A SINGLE, KNOWN generation of keys passed by the caller -- suitable
+// for tests inspecting what the CLIENT itself just sent. c.app_write_keys
+// DOES advance generations now (RFC 9001 §6.2: this endpoint follows a
+// peer-initiated key update, via sync_write_keys_to_peer_update), so a
+// caller testing anything AFTER a key-update exchange must pass the
+// CURRENT c.app_write_keys at the point of decryption, not an earlier
+// snapshot. NOT a substitute for conn.v's own process_one_rtt_packet
+// (which must handle key-phase resolution via KeyUpdateState); this is a
+// test-only, single-generation-only decrypt used purely to verify what
+// conn.v's outgoing path built.
 fn conn_test_decrypt_one_rtt(datagram []u8, dcid_len int, keys QuicPacketProtectionKeys) ![]QuicFrame {
 	mut packet := datagram.clone()
 	_, offset := parse_short_header(datagram, dcid_len)!
@@ -404,7 +407,8 @@ fn drive_to_established(own_params QuicTransportParameters, peer_params QuicTran
 	// anywhere, silently ignored).
 	mut hs_done_payload := [u8(frame_type_handshake_done)]
 	hs_done_payload << [u8(0), 0, 0, 0]
-	hs_done_datagram := build_fake_one_rtt_packet(c.scid, 0, hs_done_payload, server_app_keys)!
+	hs_done_datagram := build_fake_one_rtt_packet(c.scid, 0, hs_done_payload, server_app_keys,
+		false)!
 	result4 := c.poll(hs_done_datagram.bytes, now)!
 	assert result4.events.any(it.kind == .handshake_confirmed)
 	assert c.state() == .established
@@ -522,7 +526,7 @@ fn test_stream_write_read_round_trip_over_fake_transport() {
 	read_keys := c.app_read_keys or { panic('unreachable: established asserts this') }
 	server_app_keys := read_keys.current_keys
 	reply_frame := encode_stream_frame(stream_id, 0, 'hello from server'.bytes(), true, true)!
-	reply_datagram := build_fake_one_rtt_packet(c.scid, 0, reply_frame, server_app_keys)!
+	reply_datagram := build_fake_one_rtt_packet(c.scid, 0, reply_frame, server_app_keys, false)!
 	result2 := c.poll(reply_datagram.bytes, now)!
 	assert result2.events.len == 0
 
@@ -569,7 +573,7 @@ fn test_open_stream_respects_peer_max_streams_and_streams_blocked() {
 	read_keys := c.app_read_keys or { panic('unreachable: established asserts this') }
 	server_app_keys := read_keys.current_keys
 	max_streams_frame := encode_max_streams_frame(.bidirectional, 5)!
-	incoming := build_fake_one_rtt_packet(c.scid, 0, max_streams_frame, server_app_keys)!
+	incoming := build_fake_one_rtt_packet(c.scid, 0, max_streams_frame, server_app_keys, false)!
 	result2 := c.poll(incoming.bytes, now)!
 	assert result2.events.len == 0
 
@@ -687,6 +691,162 @@ fn test_close_before_one_rtt_keys_downgrades_to_transport_connection_close() {
 	assert close_frame.reason == ''
 }
 
+// test_non_ack_eliciting_packet_does_not_elicit_an_ack covers RFC 9000
+// §13.2.1: "An endpoint MUST NOT send a non-ack-eliciting packet in
+// response to a non-ack-eliciting packet, even if there are packet gaps
+// that precede the received packet. This avoids an infinite feedback loop
+// of acknowledgments, which could prevent the connection from ever
+// becoming idle." process_one_rtt_packet/process_initial_or_handshake add
+// EVERY successfully-processed packet's number to the space's
+// `_received_pns` map regardless of whether any of its frames were
+// ack-eliciting, and drain_outgoing unconditionally sends an ACK-only
+// packet (itself non-ack-eliciting) whenever that map is non-empty -- so a
+// peer's own ACK-only packet (ACK is explicitly non-ack-eliciting, RFC
+// 9000 Table 3) triggers an ACK-only reply, which is exactly the
+// "non-ack-eliciting in response to non-ack-eliciting" case the RFC
+// prohibits.
+fn test_non_ack_eliciting_packet_does_not_elicit_an_ack() {
+	mut c, _, now := drive_to_established(generous_transport_params(), generous_transport_params())!
+	defer {
+		c.handshake.free()
+	}
+
+	read_keys := c.app_read_keys or { panic('unreachable: established asserts this') }
+	server_app_keys := read_keys.current_keys
+	ack_only_payload := encode_ack_frame([AckRange{
+		smallest: 0
+		largest:  0
+	}], 0, none)!
+	incoming := build_fake_one_rtt_packet(c.scid, 0, ack_only_payload, server_app_keys, false)!
+	result := c.poll(incoming.bytes, now)!
+	assert result.outgoing.len == 0
+}
+
+// test_handle_ack_frame_uses_peer_advertised_ack_delay_exponent covers RFC
+// 9002's on_ack_received contract (its own doc comment: "ack_delay_exponent
+// is the PEER's own ack_delay_exponent transport parameter") -- conn.v's
+// handle_ack_frame passed the bare frame.v default_ack_delay_exponent
+// constant (3) instead of c.handshake.peer_transport_parameters.
+// ack_delay_exponent, so any peer advertising a non-default value (legal up
+// to 20 per RFC 9000 §18.2) had every one of its ACK Delay fields
+// misinterpreted, corrupting the smoothed_rtt/rttvar the PTO timer is built
+// from. Verified by comparing the actual post-second-sample smoothed_rtt
+// against the value the CORRECT exponent (12, set on this test's own peer
+// transport parameters) predicts -- a wrong exponent (the buggy default, 3)
+// predicts a measurably different value (raw wire ack_delay=5 scales to
+// ~20.48ms under exponent 12 vs ~0.04ms under exponent 3, a >2ms difference
+// in the resulting smoothed_rtt, easily distinguishable from floating-point-
+// style rounding noise).
+fn test_handle_ack_frame_uses_peer_advertised_ack_delay_exponent() {
+	mut peer_params := generous_transport_params()
+	peer_params.ack_delay_exponent = 12
+	mut c, _, now := drive_to_established(generous_transport_params(), peer_params)!
+	defer {
+		c.handshake.free()
+	}
+
+	// First RTT sample -- seeds has_sample; RttEstimator.update's
+	// first-sample path ignores ack_delay entirely regardless of exponent,
+	// so this step is identical either way.
+	c.loss_detection.on_packet_sent(.application_data, 100, 50, true, true, now)
+	first_ack := AckFrame{
+		largest_acknowledged: 100
+		ack_delay:            0
+		ranges:               [AckRange{
+			smallest: 100
+			largest:  100
+		}]
+	}
+	c.handle_ack_frame(.application_data, first_ack, now + 10_000_000)
+	assert c.loss_detection.rtt.smoothed_rtt == time.Duration(10_000_000)
+
+	// Second sample: raw wire ack_delay=5. min_rtt stays 10ms (130ms isn't
+	// smaller). adjusted_rtt = latest_rtt(130ms) - effective_ack_delay,
+	// where effective_ack_delay = scaled_ack_delay_micros(5, exponent) in
+	// nanoseconds, clamped to max_ack_delay (25ms default, not reached by
+	// either candidate exponent here).
+	c.loss_detection.on_packet_sent(.application_data, 101, 50, true, true, now + 20_000_000)
+	second_ack := AckFrame{
+		largest_acknowledged: 101
+		ack_delay:            5
+		ranges:               [AckRange{
+			smallest: 101
+			largest:  101
+		}]
+	}
+	c.handle_ack_frame(.application_data, second_ack, now + 20_000_000 + 130_000_000)
+
+	// scaled_ack_delay_micros(5, 12) == 5 << 12 == 20480 us == 20_480_000 ns
+	adjusted_rtt_correct := time.Duration(130_000_000 - 20_480_000)
+	expected_smoothed_rtt := (time.Duration(10_000_000) * 7 + adjusted_rtt_correct) / 8
+	assert c.loss_detection.rtt.smoothed_rtt == expected_smoothed_rtt
+
+	// scaled_ack_delay_micros(5, 3) (the buggy always-default value) ==
+	// 5 << 3 == 40 us == 40_000 ns -- confirm the actual result does NOT
+	// match what the bug would have produced, not just that it matches the
+	// correct value (guards against both computations coincidentally
+	// landing on the same number).
+	adjusted_rtt_wrong_default := time.Duration(130_000_000 - 40_000)
+	smoothed_rtt_if_bug_present := (time.Duration(10_000_000) * 7 + adjusted_rtt_wrong_default) / 8
+	assert c.loss_detection.rtt.smoothed_rtt != smoothed_rtt_if_bug_present
+}
+
+// test_client_follows_server_initiated_key_update covers RFC 9001 §6.2:
+// "If a packet is successfully processed using the next key and IV, then
+// the peer has initiated a key update. The endpoint MUST update its send
+// keys to the corresponding key phase in response... Sending keys MUST be
+// updated before sending an acknowledgment for the packet that was
+// received with updated keys." key_update.v's KeyUpdateState only ever
+// tracked the READ direction; c.app_write_keys was set once at handshake
+// completion and never advanced, so this client's own sends -- including
+// the ACK for the very packet that triggers a server-initiated update --
+// stayed on generation 0 forever, which RFC 9001 §6.2's last paragraph
+// permits the SERVER to treat as a fatal KEY_UPDATE_ERROR.
+fn test_client_follows_server_initiated_key_update() {
+	mut c, server_initial_scid, now := drive_to_established(generous_transport_params(),
+		generous_transport_params())!
+	defer {
+		c.handshake.free()
+	}
+
+	read_keys := c.app_read_keys or { panic('unreachable: established asserts this') }
+	server_gen0_secret := read_keys.current_secret
+	server_gen0_hp := read_keys.current_keys.hp
+
+	// Simulate the SERVER initiating a key update: derive its next-generation
+	// secret/keys via RFC 9001 §6.1's own derivation and send a packet using
+	// them with the toggled Key Phase bit.
+	server_gen1_secret := derive_updated_secret(server_gen0_secret)!
+	server_gen1_keys := derive_updated_packet_protection_keys(server_gen1_secret, server_gen0_hp)!
+
+	mut ping_payload := [u8(frame_type_ping)]
+	ping_payload << [u8(0), 0, 0, 0]
+	incoming := build_fake_one_rtt_packet(c.scid, 0, ping_payload, server_gen1_keys, true)!
+	result := c.poll(incoming.bytes, now)!
+	assert result.events.len == 0
+
+	// RFC 9001 §6.2: the client's OWN send generation MUST have followed.
+	assert c.app_write_generation == 1
+
+	// The auto-ACK drain_outgoing queues for this ack-eliciting PING (same
+	// poll() call) MUST be protected with the NEW (generation-1) write
+	// keys -- exactly the "sending keys MUST be updated before sending an
+	// acknowledgment" requirement. Decrypting it with the stale
+	// generation-0 keys, or the correct generation-1 keys fetched fresh
+	// from c.app_write_keys, distinguishes the two.
+	assert result.outgoing.len > 0
+	write_keys := c.app_write_keys or { panic('unreachable: established asserts this') }
+	frames := conn_test_decrypt_one_rtt(result.outgoing[0].bytes, server_initial_scid.len,
+		write_keys)!
+	mut found_ack := false
+	for f in frames {
+		if f is AckFrame {
+			found_ack = true
+		}
+	}
+	assert found_ack
+}
+
 // test_peer_connection_close_enters_draining covers the receive side of
 // RFC 9000 §10.2.2: a CONNECTION_CLOSE from the peer transitions this
 // connection straight to .draining (never .closing -- draining requires no
@@ -700,7 +860,7 @@ fn test_peer_connection_close_enters_draining() {
 	read_keys := c.app_read_keys or { panic('unreachable: established asserts this') }
 	server_app_keys := read_keys.current_keys
 	cc_frame := encode_connection_close_frame(false, 7, 0, 'server done')!
-	incoming := build_fake_one_rtt_packet(c.scid, 0, cc_frame, server_app_keys)!
+	incoming := build_fake_one_rtt_packet(c.scid, 0, cc_frame, server_app_keys, false)!
 	result := c.poll(incoming.bytes, now)!
 	assert c.state() == .draining
 	assert result.events.any(it.kind == .connection_closed)
@@ -768,7 +928,7 @@ fn test_closing_deadline_not_extended_by_peer_close_while_already_closing() {
 	read_keys := c.app_read_keys or { panic('unreachable: established asserts this') }
 	server_app_keys := read_keys.current_keys
 	cc_frame := encode_connection_close_frame(false, 7, 0, 'server done too')!
-	incoming := build_fake_one_rtt_packet(c.scid, 1, cc_frame, server_app_keys)!
+	incoming := build_fake_one_rtt_packet(c.scid, 1, cc_frame, server_app_keys, false)!
 	c.poll(incoming.bytes, now1)!
 	assert c.state() == .draining
 
@@ -848,7 +1008,7 @@ fn test_process_one_rtt_packet_resets_idle_timer_on_receive() {
 	read_keys := c.app_read_keys or { panic('unreachable: established asserts this') }
 	server_app_keys := read_keys.current_keys
 	stream_frame := encode_stream_frame(1, 0, 'keepalive'.bytes(), false, false)!
-	incoming := build_fake_one_rtt_packet(c.scid, 0, stream_frame, server_app_keys)!
+	incoming := build_fake_one_rtt_packet(c.scid, 0, stream_frame, server_app_keys, false)!
 
 	now += 4000
 	mut result := PollResult{}
@@ -1018,7 +1178,8 @@ fn test_wrong_destination_cid_rejected_on_short_header() {
 	// mismatch), which would fail for an unrelated reason.
 	wrong_dcid := []u8{len: c.scid.len, init: 0xde}
 	stream_frame := encode_stream_frame(1, 0, 'forged'.bytes(), false, false)!
-	forged_datagram := build_fake_one_rtt_packet(wrong_dcid, 0, stream_frame, server_app_keys)!
+	forged_datagram := build_fake_one_rtt_packet(wrong_dcid, 0, stream_frame, server_app_keys,
+		false)!
 	result := c.poll(forged_datagram.bytes, now)!
 	assert result.events.len == 0
 	assert c.streams.len() == 0
@@ -1163,7 +1324,7 @@ fn test_write_stream_on_auto_created_sibling_stream_is_not_stuck() {
 	read_keys := c.app_read_keys or { panic('unreachable: established asserts this') }
 	server_app_keys := read_keys.current_keys
 	stream_frame := encode_stream_frame(9, 0, 'from server on stream 9'.bytes(), true, true)!
-	incoming := build_fake_one_rtt_packet(c.scid, 0, stream_frame, server_app_keys)!
+	incoming := build_fake_one_rtt_packet(c.scid, 0, stream_frame, server_app_keys, false)!
 	result1 := c.poll(incoming.bytes, now)!
 	assert result1.events.len == 0
 	now += 10

--- a/vlib/net/quic/conn_test.v
+++ b/vlib/net/quic/conn_test.v
@@ -627,6 +627,16 @@ fn test_peer_connection_close_enters_draining() {
 	assert c.state() == .draining
 	assert result.events.any(it.kind == .connection_closed)
 
+	// Maintainer "Local AI Review" finding (2026-08-14): closing_deadline
+	// being set (previous assertion block, enter_draining) is not enough on
+	// its own -- compute_next_timeout() must also surface it, or a
+	// caller-driven event loop with no other active timer (no idle timeout
+	// configured here, no loss-detection PTO armed after a clean reply)
+	// never learns it needs to call process_timeouts() again, and the
+	// connection would sit in .draining forever despite the deadline being
+	// correctly recorded.
+	assert result.next_timeout != none
+
 	// RFC 9000 §10.2.2: draining MUST be bounded (same period as closing,
 	// recommended 3x PTO) -- a peer-initiated close is the MOST common
 	// real-world close path, so process_timeouts() must eventually retire
@@ -635,6 +645,39 @@ fn test_peer_connection_close_enters_draining() {
 	timeout_result := c.process_timeouts(far_future)!
 	assert c.state() == .closed
 	assert timeout_result.events.any(it.kind == .connection_closed)
+}
+
+// test_compute_next_timeout_includes_closing_deadline is a regression test
+// for a maintainer "Local AI Review" finding on PR #28083 (2026-08-14):
+// closing_deadline being set (by enter_draining/close_with_error) is not
+// enough on its own -- compute_next_timeout() must also surface it in its
+// merged deadline, or a caller-driven event loop with no other active timer
+// (no idle timeout configured, nothing currently in flight) never learns it
+// needs to call process_timeouts() again, leaving the connection stuck in
+// .closing/.draining forever despite the deadline being correctly recorded.
+// Same-module (white-box) test, deliberately isolating this from
+// loss-detection/idle-timeout noise: a fixture driven through the full
+// fake-transport flow always has SOME packet outstanding (the fixture never
+// constructs ACK frames back to the client), which happens to keep a PTO
+// timer armed and masks this exact gap -- force `bytes_in_flight` to 0 to
+// reproduce the precise "nothing else armed" scenario the finding
+// describes.
+fn test_compute_next_timeout_includes_closing_deadline() {
+	mut c, _ := dial(DialParams{
+		server_name:          'example.com'
+		ca_bundle_pem:        conn_test_cert_pem
+		alpn_protocols:       ['h3']
+		transport_parameters: QuicTransportParameters{}
+	}, u64(0))!
+	defer {
+		c.handshake.free()
+	}
+	c.congestion_control.bytes_in_flight = 0
+	assert c.idle_timeout_deadline() == none
+	assert c.compute_next_timeout() == none
+
+	c.enter_draining(u64(500))
+	assert c.compute_next_timeout() != none
 }
 
 // test_write_stream_on_auto_created_sibling_stream_is_not_stuck is a

--- a/vlib/net/quic/conn_test.v
+++ b/vlib/net/quic/conn_test.v
@@ -1,0 +1,690 @@
+// vtest build: present_openssl?
+module quic
+
+import crypto.ecdsa
+import crypto.sha256
+import encoding.base64
+import net.mbedtls
+
+// Duplicated locally (rather than referenced from any other _test.v file)
+// deliberately, per this module's own established convention -- each
+// _test.v file is its own independent compilation unit (confirmed the hard
+// way: a first draft of this file tried to call tls13_handshake_test.v's
+// helpers directly and failed with "unknown function" -- test files do NOT
+// share symbols with each other, only with the module's non-test .v
+// files). Same real self-signed test cert + matching RSA private key used
+// throughout this module's test suite -- see tls13_certificate_chain_test.v
+// and tls13_handshake_test.v's own identical notes for provenance.
+const conn_test_cert_pem = '-----BEGIN CERTIFICATE-----\nMIIEOTCCAyECFG64Q2g46jZb3kRbDOJWX/BwjSp6MA0GCSqGSIb3DQEBCwUAMEUx\nCzAJBgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJbnRl\ncm5ldCBXaWRnaXRzIFB0eSBMdGQwIBcNMjMwODAyMTcyOTQyWhgPMjA1MDEyMTcx\nNzI5NDJaMGsxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRQwEgYD\nVQQHDAtMb3MgQW5nZWxlczEdMBsGA1UECgwUQ2F0YWx5c3QgRGV2ZWxvcG1lbnQx\nEjAQBgNVBAMMCWxvY2FsaG9zdDCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoC\nggIBALqAI4fqUi+QBVWcsXglouLdOML5+w0+1hSR1KdO0Q5XPdQAs/yYWJ+KUkDw\nG++rfy9DUPq7FNRBVurXQkcAtn6gXdllGUSjwUiDo/N4mMOyS/2sufBuaeww7jVi\nrppH+zwP1tUnjRd6khl6bi1Ian9VSzr3Iy9CkXIg1GU4CPXkOydLeoQfepXxWoK1\nOUNwT3VKC/stAfY3j/NIIeiJYkyuRGFCkxn/BUjN+AsXiTugRcYKEFHdIPkOuCXp\nYbhf+lLsczpxCs3rdZG9b/N6mEDCzXTmeHkmsjdPTf+1k5DZZvKzVBBrgdxCgBb7\n5RwjF5v9WmnIc33wWgfJC6FaUzj9NYxYUbPHD+jTz0rJB/jj4u/xJlM/e5NRmXdW\n70pOMKXtWjRSolLOFIPKLY1qs3KMTAZxKKWPDDF7WlMJxMRt7nnnks5yw43Nog4C\njDLk1ZgETnPpLgo3jbmJdIv+OHKTJrBlVvDq7VTyixCoS5G8KoOmyQJhaXG6NwE2\niVhH5JIKgzgCfetfDsnjxqJ/qtrFXPa8FF2TsomD0NK/GZmIcs+9OeVB75Jn5uhF\nfLHScpiTbuu5w3P/LI/MqihLRB6RRNnRzPH8fIg5bYC9b770ta/8GcFRuYE8t+UR\nGtqXJoIKixbDlqV54kal8FQzYzhETf9+NM6Kb/lKEfG/pslvAgMBAAEwDQYJKoZI\nhvcNAQELBQADggEBALI3uNiNO0QE1brA3QYFK+d9ZroB72NrJ0UNkzYHDg2Fc6xg\n4aVVfaxY08+TmKc0JlMOW+pUxeCW/+UBSngdQiR9EE9xm0k0XIrAsy9RXxRvEtPu\nM1VI2h7ayp1Y2BrnQinevTSgtqLRyS1VbOFRl1FiyVvinw2I0KsDdAMNevAPXcOa\nQ8pUgUq6f56DkhocQaj+hxD/uV8HryNxuoSXnPhvfTN3z4YRGzsaWevJ9EYJliOM\n+XugcqfFJ+W7/QCEcAHCL+Bw6OydG5NFORr3p57PXjjcL/uKmxPBrWg2Bz6uT4uR\nMhj0zttiFHLAt9jGfyk6W57UNUja1e1ggftJJhs=\n-----END CERTIFICATE-----\n'
+
+const conn_test_key_pem = '-----BEGIN RSA PRIVATE KEY-----\nMIIJKQIBAAKCAgEAuoAjh+pSL5AFVZyxeCWi4t04wvn7DT7WFJHUp07RDlc91ACz\n/JhYn4pSQPAb76t/L0NQ+rsU1EFW6tdCRwC2fqBd2WUZRKPBSIOj83iYw7JL/ay5\n8G5p7DDuNWKumkf7PA/W1SeNF3qSGXpuLUhqf1VLOvcjL0KRciDUZTgI9eQ7J0t6\nhB96lfFagrU5Q3BPdUoL+y0B9jeP80gh6IliTK5EYUKTGf8FSM34CxeJO6BFxgoQ\nUd0g+Q64JelhuF/6UuxzOnEKzet1kb1v83qYQMLNdOZ4eSayN09N/7WTkNlm8rNU\nEGuB3EKAFvvlHCMXm/1aachzffBaB8kLoVpTOP01jFhRs8cP6NPPSskH+OPi7/Em\nUz97k1GZd1bvSk4wpe1aNFKiUs4Ug8otjWqzcoxMBnEopY8MMXtaUwnExG3ueeeS\nznLDjc2iDgKMMuTVmAROc+kuCjeNuYl0i/44cpMmsGVW8OrtVPKLEKhLkbwqg6bJ\nAmFpcbo3ATaJWEfkkgqDOAJ9618OyePGon+q2sVc9rwUXZOyiYPQ0r8ZmYhyz705\n5UHvkmfm6EV8sdJymJNu67nDc/8sj8yqKEtEHpFE2dHM8fx8iDltgL1vvvS1r/wZ\nwVG5gTy35REa2pcmggqLFsOWpXniRqXwVDNjOERN/340zopv+UoR8b+myW8CAwEA\nAQKCAgEAkcoffF0JOBMOiHlAJhrNtSiX+ZruzNDlCxlgshUjyWEbfQG7sWbqSHUZ\njZflTrqyZqDpyca7Jp2ZM2Vocxa0klIMayfj08trCaOWY3pPeROE4d3HUJMPjEpH\nvEXTFdnVJIOBPgl3+vWfBfm17QIh9j4X3BVbVNNl3WCaiDGAl699Kl+Pe38cFeCh\nD3JZPEWsZ5SlvwjU8sNGbThjAWN8C1NjMuCXG4hGej5Ae3M/nPPR91jgnw4Me4Ut\nIL3K3RVyGqaqAPJjLsu0kWQUArJAGMfvUkXjwVklkaUV5SHtJBs+pdTXjyprTmJR\nvSXWWON5zkAEEJNY7QcZaeKYi96PFLUFI+ciEdnXn74CfSKhgZCBo+OyFZjDWW5R\nNmgAbZTN2RW0z+V54Lg36JfJrmiGs8TN06KwNjFo+iOJCdQnoUSIhTlmMfVbXPah\ntRfQvwqtfqVS9W/jkiGq9yDDqyXx093R/QTM/XqDlWJ2iOJFppOJefGFCWF6Fwll\nVT9povTAGQmXFiAxwFZxWtbFa0i8fP5QG80X6l/gRklSd6ZXAVvcLkaFGqxunDAe\nrYC2jBwHWRpVmbxw880SWRzlAsJXc7M8PQnBTlyX1mFZNnwAJgqplz0BQHQhQh4V\nqNfisUm9smtda+Hr9GBBUxs09ulery3I0lQjsArVxPqPVgUbFPECggEBANqLA5fH\n2LupOBoFH/fK5jixyGdSB8eJvU+XuS8RBBexnzTQApmDHiU7Axa/cKvxAfUgwBpU\n6OIsL6Lq6wowVInBgo7GraACwspGMIP8Z7+A8qDgSWIcpXP21Ny2RW+nukdH8ZnV\nTFtiFxLYU9GRfzSUcqvE0miKfMGP/S9Cqbew00K6CQ2xurLTR2AchfUQZJJIg7eF\nRBoftthXLQ+s1JoiLJX2gqCliFy32RMAUP+pKvKVJmVQh8bxEkoEzTV2eY7eTxsH\nJDH5hD66EZ5bW/nVAMruJ3iKjy3WvjDbnddNAz9IFKrd1RMP9dgSEKuSv/HhqwPe\n1q9Wm6LWZo8BlYcCggEBANp3M14QMcMxRlZE0TiSopi1CaE8OG0C9apToS1dol2s\n4lCsWHVPIC516LMPGU0bmCdtwJey1mgXQEKVxCWHkVhhoCKT/tN53o5qkptrhrXL\npbqmRfoMXI7LwJU+Vqi5fwSPGrSR/IzHwCUL7pHTbYN7wT5rr2rcC84XYSX31TFm\nNfMnbDuUk33ycAo07Vqts5A5FN+xViEUMFSDmfA2XmOAV77awz0l/3n3qOg9lQYe\nU4Av2nT19lGELirLInkB1ndLirWAcLaCBXKOLW4bzpNm9Bt8aiziVzcUzlJlLa+1\nnb/7//xzKi0eM/BhyJfhsmOz5B8AQ6Ca/keDk8M7JtkCggEARl8DDinE6VCpBv/l\ndlX4YgMlQ9fPN3pr4ig58iTpi3Ofj1L3s1TcLSLecMG+Vy9o8PTVxuTWhJWz1SMO\nAh7j6ePM1Yq2N9MLxDRrxOROyASOnCz8lEIjKL8vdc6fdz+sJO3OpzleuAJS6beM\n7euK6XRvpE3hbtZBK9bgsQonOkYPEOp0pds4AgM0dYdZvzrDF7OP7lVUQ5E4wFr5\n4JVHdEZS0wsoru/+g9STaqHscxaXBLvwPCl9Pxs7R2haZ7+5jr6Y/FwFVK5C3ivu\nJm7GpCDpe27KeO8tAZancXYWUlCzHfpo5Ug/Jz85a5UNlyHO+uUuuzVTLeyWew3M\nwnnBGwKCAQEAqGTBP3wUH3TX1p9s9cJxemvxZEra44woeIXF8wX9pV8hgzWVabb4\nA1f3ai31Pq5KdfnvPf8nrUxex/RRIOyCaDG4EW8qOS/zEKutHgef6nly4ZBQ2BC3\nN4pug5ttiNiSw5za5NyyYoGF5ghweA8UlwjJR6gRqri6kL0MsQt7VXyHkUmN787y\ncV5yZiut2PuTMVQOdu5miVDagAqAmdwOnXvMJtzRKU0kw4rWs0zklbbCfkhkh0sf\n9m2AeJPjmoqEGags3wKF3ugR8t8MvZbJgG0XNCiOXtKIj3iGIJTExm+jjNxd0OWk\nWOqy9lMpH4lky91ZtVuqxR0za0RMnWv24QKCAQBe8l0w9AYVNGDLv1jyPcbsncty\nNYI81yqe2mL+TC00sMCeil7C7WCP7kRklY01rH5q5gJ9Q1UV+bOj2fQdXDmQ5Bgo\n41jseh44gkbuXAeWcSDrDkJCrfvlNqFobTmUb8cdb9aQlHYfOJ31367LJspiw2SY\nmCbnLQ5sMnyBiMkcn0GfBV6IAkZVN73DPa8a1m/0Qrrv1GmBJFVbuZd9d/hAWpHa\nekhXPq0Sta+RNDfBR3aI5lAmVA17qRGiubQYJ+Ldq0aRJ40fGE51ctoSU/5RMcmh\n6+Qro+jSC94L46xMFp+1J5atgB1p/jVzTT/Ws7SLyotYUSL8zU7tcLiycQXs\n-----END RSA PRIVATE KEY-----\n'
+
+fn conn_test_pem_to_der(pem string) []u8 {
+	body :=
+		pem.replace('-----BEGIN CERTIFICATE-----', '').replace('-----END CERTIFICATE-----', '').replace('\n', '').trim_space()
+	return base64.decode(body)
+}
+
+// conn_test_sign_certificate_verify signs `signed_content` with the test RSA
+// private key using real RSA-PSS/SHA-256 -- see tls13_handshake_test.v's
+// fake_server_sign_certificate_verify (duplicated, not shared -- see this
+// file's top-of-file note) for the full rationale.
+fn conn_test_sign_certificate_verify(signed_content []u8) ![]u8 {
+	hash := sha256.sum256(signed_content)
+
+	mut ctr_drbg := C.mbedtls_ctr_drbg_context{}
+	mut entropy := C.mbedtls_entropy_context{}
+	C.mbedtls_ctr_drbg_init(&ctr_drbg)
+	C.mbedtls_entropy_init(&entropy)
+	defer {
+		C.mbedtls_ctr_drbg_free(&ctr_drbg)
+		C.mbedtls_entropy_free(&entropy)
+	}
+	seed_ret := C.mbedtls_ctr_drbg_seed(&ctr_drbg, C.mbedtls_entropy_func, &entropy, 0, 0)
+	if seed_ret != 0 {
+		return error('test: failed to seed RNG, mbedtls ret: ${seed_ret}')
+	}
+
+	mut pk := C.mbedtls_pk_context{}
+	C.mbedtls_pk_init(&pk)
+	defer {
+		C.mbedtls_pk_free(&pk)
+	}
+	unsafe {
+		parse_ret := C.mbedtls_pk_parse_key(&pk, conn_test_key_pem.str, conn_test_key_pem.len + 1,
+			0, 0, C.mbedtls_ctr_drbg_random, &ctr_drbg)
+		if parse_ret != 0 {
+			return error('test: failed to parse RSA private key, mbedtls ret: ${parse_ret}')
+		}
+	}
+	// pk_type 6 = MBEDTLS_PK_RSASSA_PSS, md_alg 9 = MBEDTLS_MD_SHA256.
+	mut sig := []u8{len: 600}
+	mut sig_len := usize(0)
+	ret := C.mbedtls_pk_sign_ext(6, &pk, 9, hash.data, usize(hash.len), sig.data, usize(sig.len),
+		&sig_len, C.mbedtls_ctr_drbg_random, &ctr_drbg)
+	if ret != 0 {
+		return error('test: mbedtls_pk_sign_ext failed, mbedtls ret: ${ret}')
+	}
+	return sig[..int(sig_len)].clone()
+}
+
+// conn_test_extract_client_hello_key_exchange hand-parses a built
+// ClientHello far enough to pull out the key_share extension's
+// key_exchange bytes -- see tls13_handshake_test.v's identically-named
+// helper for the full rationale (duplicated, not shared).
+fn conn_test_extract_client_hello_key_exchange(client_hello_framed []u8) ![]u8 {
+	msg, _ := parse_handshake_message(client_hello_framed)!
+	body := msg.body
+	mut cursor := 2 + 32 // legacy_version + random
+	session_id_len := int(body[cursor])
+	cursor += 1 + session_id_len
+	cipher_suites_len := int((u32(body[cursor]) << 8) | u32(body[cursor + 1]))
+	cursor += 2 + cipher_suites_len
+	compression_len := int(body[cursor])
+	cursor += 1 + compression_len
+	extensions_len := int((u32(body[cursor]) << 8) | u32(body[cursor + 1]))
+	cursor += 2
+	extensions := parse_extension_list(body[cursor..cursor + extensions_len])!
+	ks_ext := find_extension(extensions, ext_key_share) or {
+		return error('test: ClientHello missing key_share')
+	}
+	group := u16((u32(ks_ext.data[2]) << 8) | u32(ks_ext.data[3]))
+	if group != named_group_secp256r1 {
+		return error('test: unexpected client key_share group 0x${group:04x}')
+	}
+	key_exchange_len := int((u32(ks_ext.data[4]) << 8) | u32(ks_ext.data[5]))
+	return ks_ext.data[6..6 + key_exchange_len].clone()
+}
+
+// conn_test_build_fake_server_hello builds a real ServerHello (RFC 8446
+// §4.1.3) offering exactly what build_client_hello sent
+// (TLS_AES_128_GCM_SHA256, secp256r1) -- see tls13_handshake_test.v's
+// build_fake_server_hello for the full rationale (duplicated, not shared).
+fn conn_test_build_fake_server_hello(server_random []u8, key_exchange []u8) ![]u8 {
+	mut body := []u8{}
+	body << u8(0x03)
+	body << u8(0x03)
+	body << server_random
+	body << u8(0) // legacy_session_id_echo length = 0
+	body << u8(cipher_suite_tls_aes_128_gcm_sha256 >> 8)
+	body << u8(cipher_suite_tls_aes_128_gcm_sha256)
+	body << u8(0) // legacy_compression_method
+
+	mut sv_data := []u8{}
+	sv_data << u8(tls_version_1_3 >> 8)
+	sv_data << u8(tls_version_1_3)
+	sv_ext := encode_extension(ext_supported_versions, sv_data)!
+
+	mut ks_entry := []u8{}
+	ks_entry << u8(named_group_secp256r1 >> 8)
+	ks_entry << u8(named_group_secp256r1)
+	ks_entry << u8(key_exchange.len >> 8)
+	ks_entry << u8(key_exchange.len)
+	ks_entry << key_exchange
+	ks_ext := encode_extension(ext_key_share, ks_entry)!
+
+	mut extensions := []u8{}
+	extensions << sv_ext
+	extensions << ks_ext
+	body << u8(extensions.len >> 8)
+	body << u8(extensions.len)
+	body << extensions
+
+	return encode_handshake_message(.server_hello, body)!
+}
+
+// conn_test_build_fake_encrypted_extensions builds a real EncryptedExtensions
+// offering ALPN 'h3' and the given transport parameters -- see
+// tls13_handshake_test.v's build_fake_encrypted_extensions_with_alpn for the
+// full rationale (duplicated, not shared; the ALPN-parametrized variant
+// isn't needed here so only the 'h3' shape is kept).
+fn conn_test_build_fake_encrypted_extensions(server_transport_params QuicTransportParameters) ![]u8 {
+	encoded_tp := encode_transport_parameters(server_transport_params)!
+	tp_ext := encode_extension(ext_quic_transport_parameters, encoded_tp)!
+
+	name_bytes := 'h3'.bytes()
+	mut alpn_list := []u8{}
+	alpn_list << u8(name_bytes.len)
+	alpn_list << name_bytes
+	mut alpn_data := []u8{}
+	alpn_data << u8(alpn_list.len >> 8)
+	alpn_data << u8(alpn_list.len)
+	alpn_data << alpn_list
+	alpn_ext := encode_extension(ext_alpn, alpn_data)!
+
+	mut extensions := []u8{}
+	extensions << alpn_ext
+	extensions << tp_ext
+	mut body := []u8{}
+	body << u8(extensions.len >> 8)
+	body << u8(extensions.len)
+	body << extensions
+	return encode_handshake_message(.encrypted_extensions, body)!
+}
+
+// conn_test_build_fake_certificate builds a real Certificate message
+// carrying one DER-encoded certificate with no per-entry extensions -- see
+// tls13_handshake_test.v's build_fake_certificate (duplicated, not shared).
+fn conn_test_build_fake_certificate(cert_der []u8) ![]u8 {
+	mut entry := []u8{}
+	entry << u8(cert_der.len >> 16)
+	entry << u8(cert_der.len >> 8)
+	entry << u8(cert_der.len)
+	entry << cert_der
+	entry << u8(0) // per-CertificateEntry extensions length = 0
+	entry << u8(0)
+
+	mut body := []u8{}
+	body << u8(0) // certificate_request_context length = 0
+	body << u8(entry.len >> 16)
+	body << u8(entry.len >> 8)
+	body << u8(entry.len)
+	body << entry
+	return encode_handshake_message(.certificate, body)!
+}
+
+fn conn_test_build_fake_certificate_verify(algorithm u16, signature []u8) ![]u8 {
+	mut body := []u8{}
+	body << u8(algorithm >> 8)
+	body << u8(algorithm)
+	body << u8(signature.len >> 8)
+	body << u8(signature.len)
+	body << signature
+	return encode_handshake_message(.certificate_verify, body)!
+}
+
+fn conn_test_concat_bytes(a []u8, b []u8) []u8 {
+	mut out := []u8{cap: a.len + b.len}
+	out << a
+	out << b
+	return out
+}
+
+// generous_transport_params is a reusable QuicTransportParameters value
+// with every flow-control/stream-count limit set high enough that Phase 9b
+// stream/flow-control tests aren't ALSO incidentally testing "what happens
+// at limit zero" (drive_to_established's own default -- an empty
+// QuicTransportParameters{} -- deliberately leaves every limit at zero,
+// which is what Phase 9a's own capstone test needed since it never opens a
+// stream at all). Tests that specifically want to probe a limit (e.g.
+// MAX_STREAMS blocking) start from this and override just the one field
+// they care about.
+fn generous_transport_params() QuicTransportParameters {
+	return QuicTransportParameters{
+		initial_max_data:                    1_000_000
+		initial_max_stream_data_bidi_local:  100_000
+		initial_max_stream_data_bidi_remote: 100_000
+		initial_max_stream_data_uni:         100_000
+		initial_max_streams_bidi:            10
+		initial_max_streams_uni:             10
+	}
+}
+
+// build_fake_long_header_packet builds one long-header (Initial/Handshake)
+// datagram as if from a fake server: encodes the header, appends the
+// packet number, and protects it with `keys` (the same-direction keys the
+// client independently derived -- QuicPacketProtectionKeys is a plain AEAD
+// key/iv/hp bundle, not client/server-typed, so the identical struct value
+// works for both the client's decrypt and this fake server's encrypt).
+// No RFC 9000 §14.1 1200-byte padding is applied -- that requirement is on
+// the CLIENT's first flight only (anti-amplification), never the server's.
+fn build_fake_long_header_packet(typ LongPacketType, dcid []u8, scid []u8, pn u64, payload []u8, keys QuicPacketProtectionKeys) !QuicDatagram {
+	pn_length := 2
+	h := QuicLongHeader{
+		typ:     typ
+		version: quic_v1
+		dcid:    dcid
+		scid:    scid
+		token:   []u8{}
+		length:  u64(pn_length) + u64(payload.len) + aead_tag_len
+	}
+	mut header := encode_long_header(h, 0, u8(pn_length - 1))!
+	header << [u8(pn >> 8), u8(pn)]
+	protected := protect_packet(header, .long, pn, pn_length, payload, keys)!
+	return QuicDatagram{
+		bytes: protected
+	}
+}
+
+// build_fake_one_rtt_packet mirrors build_fake_long_header_packet for a
+// fake server's short-header (1-RTT) datagram.
+fn build_fake_one_rtt_packet(dcid []u8, pn u64, payload []u8, keys QuicPacketProtectionKeys) !QuicDatagram {
+	pn_length := 2
+	header_prefix := encode_short_header(dcid, false, 0, false, u8(pn_length - 1))!
+	mut header := header_prefix.clone()
+	header << [u8(pn >> 8), u8(pn)]
+	protected := protect_packet(header, .short, pn, pn_length, payload, keys)!
+	return QuicDatagram{
+		bytes: protected
+	}
+}
+
+// conn_test_decrypt_one_rtt decrypts and frame-parses a 1-RTT datagram
+// USING A SINGLE, KNOWN (non-rotating) generation of keys -- suitable for
+// tests inspecting what the CLIENT itself just sent (c.app_write_keys never
+// rotates, matching key_update.v's own documented v1 scope: client-initiated
+// rotation is out of scope, and app_write_keys is a plain, non-KeyUpdateState
+// field for exactly that reason). NOT a substitute for conn.v's own
+// process_one_rtt_packet (which must handle key-phase resolution via
+// KeyUpdateState); this is a test-only, single-generation-only decrypt used
+// purely to verify what conn.v's outgoing path built.
+fn conn_test_decrypt_one_rtt(datagram []u8, dcid_len int, keys QuicPacketProtectionKeys) ![]QuicFrame {
+	mut packet := datagram.clone()
+	_, offset := parse_short_header(datagram, dcid_len)!
+	pn_length := unprotect_header(mut packet, offset, keys.hp, .short)!
+	mut truncated := u64(0)
+	for i in 0 .. pn_length {
+		truncated = (truncated << 8) | u64(packet[offset + i])
+	}
+	full_pn := decode_packet_number(truncated, pn_length, none)!
+	header := packet[..offset + pn_length].clone()
+	// unsafe, not .clone(): mirrors conn.v's process_one_rtt_packet's own
+	// identical slice -- read-only pass into decrypt_packet_payload, no
+	// mutation of `packet` happens after this point.
+	ciphertext := unsafe { packet[offset + pn_length..] }
+	payload := decrypt_packet_payload(keys, full_pn, header, ciphertext)!
+	return parse_frames(payload)!
+}
+
+// drive_to_established is the shared Phase 9a/9b test fixture: dials a real
+// QuicConn and drives it, against a fake in-memory server, all the way
+// through RFC 9001 §4.1.2's "confirmed" checkpoint -- see
+// test_full_handshake_reaches_confirmed_over_fake_transport's own (fuller)
+// doc comment below for why Certificate/CertificateVerify go through
+// c.handshake's direct API rather than the wire. `own_params`/`peer_params`
+// let callers control flow-control/stream-count limits on either side;
+// drive_to_established forces `peer_params`' two connection-ID identity
+// fields (initial_source_connection_id/original_destination_connection_id)
+// regardless of what the caller passed, since those MUST match this
+// specific handshake's actual IDs or EncryptedExtensions processing itself
+// would (correctly) fail RFC 9000 §7.3's anti-tampering check.
+fn drive_to_established(own_params QuicTransportParameters, peer_params QuicTransportParameters) !(&QuicConn, []u8, u64) {
+	mut now := u64(1000)
+	mut c, initial_dg := dial(DialParams{
+		server_name:          'example.com'
+		ca_bundle_pem:        conn_test_cert_pem
+		alpn_protocols:       ['h3']
+		transport_parameters: own_params
+	}, now)!
+	assert initial_dg.bytes.len >= min_initial_datagram_size
+
+	server_initial_scid := [u8(0xaa), 0xbb, 0xcc, 0xdd]
+
+	// --- Fake server: ECDHE key exchange against the real ClientHello dial() built ---
+	server_pub, server_priv := ecdsa.generate_key(nid: .prime256v1)!
+	defer {
+		server_pub.free()
+		unsafe { server_priv.free() }
+	}
+	server_ecdhe_public_bytes := server_pub.uncompressed_bytes()!
+	server_random := []u8{len: 32, init: 0x22}
+	client_key_exchange := conn_test_extract_client_hello_key_exchange(c.client_hello)!
+	client_pub := ecdsa.PublicKey.from_uncompressed_bytes(client_key_exchange, nid: .prime256v1)!
+	defer {
+		client_pub.free()
+	}
+	server_shared_secret := server_priv.derive_shared_secret(client_pub)!
+	server_hello_framed := conn_test_build_fake_server_hello(server_random,
+		server_ecdhe_public_bytes)!
+
+	early_secret := derive_early_secret()!
+	ch_sh_hash := sha256.sum256(conn_test_concat_bytes(c.client_hello, server_hello_framed))
+	server_handshake_secrets := derive_handshake_secrets(early_secret, server_shared_secret,
+		ch_sh_hash)!
+
+	// --- Deliver ServerHello as a real, protected Initial packet ---
+	sh_payload := encode_crypto_frame(0, server_hello_framed)!
+	sh_datagram := build_fake_long_header_packet(.initial, c.scid, server_initial_scid, 0,
+		sh_payload, c.initial_keys_server)!
+	result1 := c.poll(sh_datagram.bytes, now)!
+	assert result1.events.len == 0
+	assert c.handshake.state() == .wait_encrypted_extensions
+	now += 10
+
+	// --- Deliver EncryptedExtensions as a real, protected Handshake packet ---
+	hs_keys_server := c.handshake_keys_server or { panic('unreachable: just asserted != none') }
+	mut ee_params := peer_params
+	ee_params.initial_source_connection_id = server_initial_scid
+	ee_params.original_destination_connection_id = c.original_dcid
+	ee_framed := conn_test_build_fake_encrypted_extensions(ee_params)!
+	ee_payload := encode_crypto_frame(0, ee_framed)!
+	ee_datagram := build_fake_long_header_packet(.handshake, c.scid, server_initial_scid, 0,
+		ee_payload, hs_keys_server)!
+	result2 := c.poll(ee_datagram.bytes, now)!
+	assert result2.events.len == 0
+	assert c.handshake.state() == .wait_certificate
+	now += 10
+
+	// --- Certificate + CertificateVerify: direct API, not over the wire (see doc comment below) ---
+	server_der := conn_test_pem_to_der(conn_test_cert_pem)
+	cert_framed := conn_test_build_fake_certificate(server_der)!
+	cert_msg, _ := parse_handshake_message(cert_framed)!
+	c.handshake.process_certificate_or_request(cert_msg, cert_framed) or {
+		// Expected: this repo's test cert is self-signed, so trust
+		// validation fails -- matches tls13_handshake_test.v's own
+		// documented, accepted limitation. The transcript is still
+		// correctly updated by this call despite the error.
+	}
+	real_chain := mbedtls.build_certificate_chain([server_der])!
+	unsafe {
+		c.handshake.verified_chain = &VerifiedCertificateChain{
+			chain: real_chain
+		}
+	}
+	c.handshake.certificate_transcript_hash = c.handshake.transcript_hash()
+	c.handshake.state = .wait_certificate_verify
+
+	signed_content := certificate_verify_signed_content(.server,
+		c.handshake.certificate_transcript_hash)
+	sig := conn_test_sign_certificate_verify(signed_content)!
+	cv_framed := conn_test_build_fake_certificate_verify(sig_scheme_rsa_pss_rsae_sha256, sig)!
+	cv_msg, _ := parse_handshake_message(cv_framed)!
+	c.handshake.process_certificate_verify(cv_msg, cv_framed)!
+	assert c.handshake.state() == .wait_finished
+
+	// --- Deliver Finished as a real, protected Handshake packet ---
+	finished_verify_data := compute_finished_verify_data(server_handshake_secrets.server_secret,
+		c.handshake.transcript_hash())!
+	finished_framed := encode_handshake_message(.finished, finished_verify_data)!
+	finished_payload := encode_crypto_frame(u64(ee_framed.len), finished_framed)!
+	finished_datagram := build_fake_long_header_packet(.handshake, c.scid, server_initial_scid, 1,
+		finished_payload, hs_keys_server)!
+	result3 := c.poll(finished_datagram.bytes, now)!
+	assert result3.events.len == 0
+	assert c.handshake.state() == .connected
+	now += 10
+
+	// --- Fake server: deliver HANDSHAKE_DONE over a real 1-RTT packet ---
+	read_keys := c.app_read_keys or { panic('unreachable: just asserted != none') }
+	server_app_keys := read_keys.current_keys
+	// RFC 9001 §5.4.2: header protection sampling needs at least 4 bytes of
+	// packet number plus a 16-byte sample after it -- a bare 1-byte
+	// HANDSHAKE_DONE frame's resulting packet is 1 byte too short for that,
+	// so pad with a few PADDING frames (0x00, RFC 9000 §19.1 -- legal
+	// anywhere, silently ignored).
+	mut hs_done_payload := [u8(frame_type_handshake_done)]
+	hs_done_payload << [u8(0), 0, 0, 0]
+	hs_done_datagram := build_fake_one_rtt_packet(c.scid, 0, hs_done_payload, server_app_keys)!
+	result4 := c.poll(hs_done_datagram.bytes, now)!
+	assert result4.events.any(it.kind == .handshake_confirmed)
+	assert c.state() == .established
+	now += 10
+
+	return c, server_initial_scid, now
+}
+
+// test_dial_produces_a_valid_padded_initial_datagram checks dial()'s own
+// contract in isolation, independent of the much larger fake-transport
+// tests below: a freshly dialed connection is .handshaking, and its first
+// outgoing datagram meets RFC 9000 §14.1's 1200-byte floor (the same
+// property initial_exchange_test.v already proves for build_client_hello +
+// manual packet construction -- this test proves dial()'s OWN composition
+// of that same pipeline produces the same result).
+fn test_dial_produces_a_valid_padded_initial_datagram() {
+	mut c, dg := dial(DialParams{
+		server_name:          'example.com'
+		ca_bundle_pem:        conn_test_cert_pem
+		alpn_protocols:       ['h3']
+		transport_parameters: QuicTransportParameters{}
+	}, u64(0))!
+	defer {
+		c.handshake.free()
+	}
+	assert dg.bytes.len >= min_initial_datagram_size
+	assert c.state() == .handshaking
+	assert c.role() == .client
+}
+
+// test_full_handshake_reaches_confirmed_over_fake_transport is Phase 9a's
+// capstone integration test: drives a REAL QuicConn from dial() through the
+// full RFC 9001 §4.1.2 "confirmed" checkpoint against a fake, in-memory
+// server -- real ECDHE, real QUIC packet protection, real CRYPTO framing,
+// real key derivation/promotion/discard at every level. This is the first
+// test anywhere in the project to exercise conn.v's own composition logic
+// (no prior phase had a QuicConn to test); the underlying TLS message
+// semantics (extension validation, signature verification, transcript
+// hashing) are already exhaustively covered by tls13_handshake_test.v and
+// are NOT re-proven here.
+//
+// Certificate/CertificateVerify are deliberately NOT sent over the fake
+// wire: this repo has no CA-flagged test certificate (documented,
+// long-standing limitation -- see tls13_handshake_test.v's own note), so a
+// real Certificate message routed through conn.v's normal poll() path
+// would fail trust validation and conn.v would (correctly) treat that as a
+// fatal protocol violation, closing the connection. Instead, following
+// tls13_handshake_test.v's OWN established pattern for testing past this
+// gap, Certificate/CertificateVerify are processed by calling
+// c.handshake's methods DIRECTLY (white-box, same-module access -- conn.v
+// itself has no other side effects for these two dispatch arms beyond
+// c.handshake's own state, so nothing about conn.v's own wiring is skipped
+// by this shortcut). ServerHello, EncryptedExtensions, Finished, and
+// HANDSHAKE_DONE all go through the REAL wire path (dial()/poll()), since
+// those four are exactly where conn.v's own key-derivation/promotion/
+// discard and event-reporting logic lives.
+fn test_full_handshake_reaches_confirmed_over_fake_transport() {
+	mut c, _, _ := drive_to_established(QuicTransportParameters{}, QuicTransportParameters{})!
+	defer {
+		c.handshake.free()
+	}
+	assert c.handshake_completion_is_complete()
+	assert c.app_write_keys != none
+	assert c.app_read_keys != none
+	assert c.initial_keys_discarded
+	assert c.handshake_keys_discarded
+}
+
+// handshake_completion_is_complete is a tiny same-module accessor so tests
+// can assert RFC 9001 §4.1.2's "complete" checkpoint without reaching into
+// HandshakeCompletionState's own mut fields directly.
+fn (c &QuicConn) handshake_completion_is_complete() bool {
+	return c.handshake_completion.is_complete()
+}
+
+// -------------------------------------------------------------------------
+// Phase 9b: steady-state 1-RTT tests
+// -------------------------------------------------------------------------
+
+// test_stream_write_read_round_trip_over_fake_transport covers
+// open_stream/write_stream's OUTGOING path (verified by decrypting the
+// datagram conn.v itself built, using the same fake-server technique as
+// drive_to_established) and read_stream's INCOMING path (fed a real,
+// protected STREAM frame from the fake server).
+fn test_stream_write_read_round_trip_over_fake_transport() {
+	mut c, server_initial_scid, mut now := drive_to_established(generous_transport_params(),
+		generous_transport_params())!
+	defer {
+		c.handshake.free()
+	}
+
+	stream_id := c.open_stream(true)!
+	assert stream_id == 0 // first client-initiated bidi stream id, RFC 9000 §2.1
+	c.write_stream(stream_id, 'hello from client'.bytes(), true)!
+	result := c.poll(none, now)!
+	assert result.outgoing.len > 0
+	now += 10
+
+	write_keys := c.app_write_keys or { panic('unreachable: established asserts this') }
+	frames := conn_test_decrypt_one_rtt(result.outgoing[0].bytes, server_initial_scid.len,
+		write_keys)!
+	mut found_stream_frame := false
+	for f in frames {
+		if f is StreamFrame {
+			assert f.stream_id == stream_id
+			assert f.offset == 0
+			assert f.data == 'hello from client'.bytes()
+			assert f.fin
+			found_stream_frame = true
+		}
+	}
+	assert found_stream_frame
+
+	// --- Fake server replies with STREAM data on the same bidi stream ---
+	read_keys := c.app_read_keys or { panic('unreachable: established asserts this') }
+	server_app_keys := read_keys.current_keys
+	reply_frame := encode_stream_frame(stream_id, 0, 'hello from server'.bytes(), true, true)!
+	reply_datagram := build_fake_one_rtt_packet(c.scid, 0, reply_frame, server_app_keys)!
+	result2 := c.poll(reply_datagram.bytes, now)!
+	assert result2.events.len == 0
+
+	got := c.read_stream(stream_id)!
+	assert got == 'hello from server'.bytes()
+	// A second read before any new data arrives returns nothing new.
+	assert c.read_stream(stream_id)!.len == 0
+}
+
+// test_open_stream_respects_peer_max_streams_and_streams_blocked drives
+// open_stream() into RFC 9000 §4.6's peer-imposed limit (advertised as 0
+// bidi streams here), confirms it errors and queues STREAMS_BLOCKED (RFC
+// 9000 §19.14) rather than silently failing, then confirms a MAX_STREAMS
+// frame from the peer unblocks it.
+fn test_open_stream_respects_peer_max_streams_and_streams_blocked() {
+	own_params := generous_transport_params()
+	mut restrictive_peer_params := generous_transport_params()
+	restrictive_peer_params.initial_max_streams_bidi = 0
+	mut c, server_initial_scid, mut now :=
+		drive_to_established(own_params, restrictive_peer_params)!
+	defer {
+		c.handshake.free()
+	}
+
+	c.open_stream(true) or { assert err.msg().contains('STREAM_LIMIT') }
+
+	result := c.poll(none, now)!
+	assert result.outgoing.len > 0
+	now += 10
+	write_keys := c.app_write_keys or { panic('unreachable: established asserts this') }
+	frames := conn_test_decrypt_one_rtt(result.outgoing[0].bytes, server_initial_scid.len,
+		write_keys)!
+	mut found_blocked := false
+	for f in frames {
+		if f is StreamsBlockedFrame {
+			assert f.direction == .bidirectional
+			assert f.maximum_streams == 0
+			found_blocked = true
+		}
+	}
+	assert found_blocked
+
+	// --- Fake server raises the limit via MAX_STREAMS ---
+	read_keys := c.app_read_keys or { panic('unreachable: established asserts this') }
+	server_app_keys := read_keys.current_keys
+	max_streams_frame := encode_max_streams_frame(.bidirectional, 5)!
+	incoming := build_fake_one_rtt_packet(c.scid, 0, max_streams_frame, server_app_keys)!
+	result2 := c.poll(incoming.bytes, now)!
+	assert result2.events.len == 0
+
+	stream_id := c.open_stream(true)!
+	assert stream_id == 0
+}
+
+// test_close_sends_connection_close_and_transitions_to_closing covers the
+// public close() API's deferred-send contract (see close()'s own doc
+// comment): nothing happens until the next poll() call, which then builds
+// and sends a real, protected CONNECTION_CLOSE and transitions to .closing.
+fn test_close_sends_connection_close_and_transitions_to_closing() {
+	mut c, server_initial_scid, now := drive_to_established(generous_transport_params(),
+		generous_transport_params())!
+	defer {
+		c.handshake.free()
+	}
+
+	c.close(42, 'bye')
+	assert c.state() == .established // deferred -- nothing happens synchronously
+	result := c.poll(none, now)!
+	assert c.state() == .closing
+	assert result.outgoing.len > 0
+
+	write_keys := c.app_write_keys or { panic('unreachable: established asserts this') }
+	frames := conn_test_decrypt_one_rtt(result.outgoing[0].bytes, server_initial_scid.len,
+		write_keys)!
+	mut found_close := false
+	for f in frames {
+		if f is ConnectionCloseFrame {
+			assert f.error_code == 42
+			assert f.is_application_error
+			assert f.reason == 'bye'
+			found_close = true
+		}
+	}
+	assert found_close
+}
+
+// test_peer_connection_close_enters_draining covers the receive side of
+// RFC 9000 §10.2.2: a CONNECTION_CLOSE from the peer transitions this
+// connection straight to .draining (never .closing -- draining requires no
+// close of our own to be sent) and reports a connection_closed event.
+fn test_peer_connection_close_enters_draining() {
+	mut c, _, now := drive_to_established(generous_transport_params(), generous_transport_params())!
+	defer {
+		c.handshake.free()
+	}
+
+	read_keys := c.app_read_keys or { panic('unreachable: established asserts this') }
+	server_app_keys := read_keys.current_keys
+	cc_frame := encode_connection_close_frame(false, 7, 0, 'server done')!
+	incoming := build_fake_one_rtt_packet(c.scid, 0, cc_frame, server_app_keys)!
+	result := c.poll(incoming.bytes, now)!
+	assert c.state() == .draining
+	assert result.events.any(it.kind == .connection_closed)
+
+	// RFC 9000 §10.2.2: draining MUST be bounded (same period as closing,
+	// recommended 3x PTO) -- a peer-initiated close is the MOST common
+	// real-world close path, so process_timeouts() must eventually retire
+	// this connection to .closed, not leave it draining forever.
+	far_future := now + 1000 * 1000
+	timeout_result := c.process_timeouts(far_future)!
+	assert c.state() == .closed
+	assert timeout_result.events.any(it.kind == .connection_closed)
+}
+
+// test_write_stream_on_auto_created_sibling_stream_is_not_stuck is a
+// regression test for a bug found during /vreview: QuicStreamSet.
+// get_or_create (stream.v) auto-creates every LOWER-numbered same-category
+// stream when the peer references a higher one directly (RFC 9000 §2.1 --
+// "before a stream is created, all streams of the same type with
+// lower-numbered stream IDs MUST be created"), but handle_stream_frame/
+// handle_reset_stream_frame only called ensure_stream_windows for the named
+// frame.stream_id, never for those auto-created siblings. write_stream() on
+// such a sibling queued data that drain_pending_stream_writes could never
+// send (its `c.stream_send_windows[stream_id] or { continue }` lookup
+// always missed), silently and permanently -- no error, no event, just a
+// write that never reaches the wire.
+fn test_write_stream_on_auto_created_sibling_stream_is_not_stuck() {
+	mut c, server_initial_scid, mut now := drive_to_established(generous_transport_params(),
+		generous_transport_params())!
+	defer {
+		c.handshake.free()
+	}
+
+	// Server-initiated bidi stream ids are 1, 5, 9, ... (base 1, step 4).
+	// Referencing id=9 directly auto-creates siblings 1 and 5 with NO
+	// flow-control windows under the pre-fix code.
+	read_keys := c.app_read_keys or { panic('unreachable: established asserts this') }
+	server_app_keys := read_keys.current_keys
+	stream_frame := encode_stream_frame(9, 0, 'from server on stream 9'.bytes(), true, true)!
+	incoming := build_fake_one_rtt_packet(c.scid, 0, stream_frame, server_app_keys)!
+	result1 := c.poll(incoming.bytes, now)!
+	assert result1.events.len == 0
+	now += 10
+
+	// Stream 1 (an auto-created sibling, never itself named in any frame)
+	// is a real bidi stream from the client's perspective -- writing to it
+	// must eventually reach the wire, not silently vanish.
+	c.write_stream(1, 'sibling data'.bytes(), true)!
+	result2 := c.poll(none, now)!
+	write_keys := c.app_write_keys or { panic('unreachable: established asserts this') }
+	mut found_sibling_stream_frame := false
+	for dg in result2.outgoing {
+		frames := conn_test_decrypt_one_rtt(dg.bytes, server_initial_scid.len, write_keys)!
+		for f in frames {
+			if f is StreamFrame {
+				if f.stream_id == 1 {
+					assert f.data == 'sibling data'.bytes()
+					assert f.fin
+					found_sibling_stream_frame = true
+				}
+			}
+		}
+	}
+	assert found_sibling_stream_frame
+}

--- a/vlib/net/quic/frame.v
+++ b/vlib/net/quic/frame.v
@@ -201,10 +201,21 @@ pub:
 	maximum_streams u64
 }
 
+// HandshakeDoneFrame represents a HANDSHAKE_DONE frame (type 0x1e, RFC 9000
+// §19.20): sent only by a server, only once, to signal handshake
+// confirmation (RFC 9001 §4.1.2) -- carries no fields. A client MUST treat
+// receipt of one as a connection error of type PROTOCOL_VIOLATION (RFC 9000
+// §19.20); parse_frame itself has no connection-role awareness to enforce
+// that, so it is the caller's (Phase 9 QuicConn's) job, same division as
+// every other role-dependent check this module defers (see coalesce.v's
+// analogous note).
+pub struct HandshakeDoneFrame {}
+
 pub type QuicFrame = AckFrame
 	| ConnectionCloseFrame
 	| CryptoFrame
 	| DataBlockedFrame
+	| HandshakeDoneFrame
 	| MaxDataFrame
 	| MaxStreamDataFrame
 	| MaxStreamsFrame
@@ -234,6 +245,7 @@ const frame_type_streams_blocked_bidi = u64(0x16)
 const frame_type_streams_blocked_uni = u64(0x17)
 const frame_type_connection_close_transport = u64(0x1c)
 const frame_type_connection_close_application = u64(0x1d)
+const frame_type_handshake_done = u64(0x1e)
 
 // parse_frame parses exactly one frame from the start of `buf`, returning
 // the frame and the number of bytes consumed. A run of consecutive PADDING
@@ -306,6 +318,10 @@ pub fn parse_frame(buf []u8) !(QuicFrame, int) {
 		|| typ == frame_type_connection_close_application {
 		return parse_connection_close_frame(buf, typ_len,
 			typ == frame_type_connection_close_application)
+	}
+
+	if typ == frame_type_handshake_done {
+		return QuicFrame(HandshakeDoneFrame{}), typ_len
 	}
 
 	return error('quic: frame type 0x${typ:02x} is not yet implemented by this module')

--- a/vlib/net/quic/frame_test.v
+++ b/vlib/net/quic/frame_test.v
@@ -27,6 +27,18 @@ fn test_parse_frame_ping() {
 	}
 }
 
+fn test_parse_frame_handshake_done() {
+	buf := [u8(0x1e)]
+	frame, n := parse_frame(buf)!
+	assert n == 1
+	match frame {
+		HandshakeDoneFrame {}
+		else {
+			assert false, 'expected a HandshakeDoneFrame'
+		}
+	}
+}
+
 fn test_parse_frame_crypto_round_trip() {
 	data := [u8(0xde), 0xad, 0xbe, 0xef, 0x01, 0x02, 0x03]
 	encoded := encode_crypto_frame(1234, data)!
@@ -247,12 +259,14 @@ fn test_scaled_ack_delay_micros_saturates_at_exponent_ge_64() {
 }
 
 fn test_parse_frame_rejects_unimplemented_frame_type() {
-	// 0x1e (HANDSHAKE_DONE) is a real, valid QUIC frame type this module
-	// simply doesn't implement yet (Phase 8/9) -- must be a clear "not
-	// implemented" error, not a wire-format error or a panic. (0x08, used
-	// here before Phase 6 implemented STREAM frames, would no longer
+	// 0x18 (NEW_CONNECTION_ID) is a real, valid QUIC frame type this module
+	// simply doesn't implement yet -- connection ID rotation/migration is
+	// explicitly out of v1 scope (see stateless_reset.v's own doc comment)
+	// -- must be a clear "not implemented" error, not a wire-format error
+	// or a panic. (0x08 STREAM and 0x1e HANDSHAKE_DONE, both used here
+	// before their respective phases implemented them, would no longer
 	// demonstrate this.)
-	parse_frame([u8(0x1e)]) or {
+	parse_frame([u8(0x18)]) or {
 		assert err.msg().contains('not yet implemented')
 		return
 	}

--- a/vlib/net/quic/header.v
+++ b/vlib/net/quic/header.v
@@ -346,6 +346,43 @@ pub fn parse_short_header(buf []u8, dcid_len int) !(QuicShortHeader, int) {
 	}, 1 + dcid_len
 }
 
+// encode_short_header serializes a short header's unprotected portion (RFC
+// 9000 §17.3.1), everything up to (but not including) the packet number
+// field -- the caller appends the packet-number bytes separately and
+// applies header protection afterward, exactly mirroring
+// encode_long_header's own two-step convention (see its doc comment for why
+// the packet-number length must be decided before this is called). Unlike
+// a long header, there is no DCID length prefix on the wire (see
+// QuicShortHeader's own doc comment) -- `dcid` is written verbatim.
+pub fn encode_short_header(dcid []u8, spin_bit bool, reserved_bits u8, key_phase bool, pn_length_bits u8) ![]u8 {
+	if reserved_bits > 0x3 {
+		return error('reserved_bits must fit in 2 bits')
+	}
+	if pn_length_bits > 0x3 {
+		return error('pn_length_bits must fit in 2 bits')
+	}
+	if dcid.len > quic_v1_max_cid_len {
+		return error('QUIC v1 connection IDs must not exceed ${quic_v1_max_cid_len} bytes')
+	}
+	// RFC 9000 §17.3.1 first-byte layout (MSB to LSB): Header Form(1)=0,
+	// Fixed Bit(1)=1, Spin Bit(1), Reserved(2), Key Phase(1), Packet Number
+	// Length(2) -- matching header_protection.v's protected_bits_mask/
+	// reserved_bits_mask bit positions for the short-header form exactly.
+	mut first_byte := u8(0x40)
+	if spin_bit {
+		first_byte |= 0x20
+	}
+	first_byte |= reserved_bits << 3
+	if key_phase {
+		first_byte |= 0x04
+	}
+	first_byte |= pn_length_bits
+	mut out := []u8{cap: 1 + dcid.len}
+	out << first_byte
+	out << dcid
+	return out
+}
+
 // QuicVersionNegotiation represents a parsed Version Negotiation packet (RFC
 // 9000 §17.2.1) — distinguished by `version == 0`, and structurally distinct
 // from every other long-header packet: no packet number, no Length field, no

--- a/vlib/net/quic/header_test.v
+++ b/vlib/net/quic/header_test.v
@@ -278,6 +278,34 @@ fn test_short_header_round_trip_and_zero_length_dcid() {
 	assert parsed2.dcid == dcid
 }
 
+fn test_encode_short_header_round_trips_through_parse() {
+	dcid := [u8(0xDE), 0xAD, 0xBE, 0xEF]
+	encoded := encode_short_header(dcid, true, 0, true, 0x3)!
+	assert encoded.len == 1 + dcid.len
+	// Protected low bits (reserved+key_phase+pn_length) are checked directly
+	// here rather than round-tripped through parse_short_header, since that
+	// function assumes header protection has already been removed and would
+	// reject these reserved bits as nonzero.
+	assert encoded[0] & 0x40 != 0 // Fixed Bit always set
+	assert encoded[0] & 0x20 != 0 // spin_bit
+	assert encoded[0] & 0x04 != 0 // key_phase
+	assert encoded[0] & 0x03 == 0x3 // pn_length_bits
+	assert encoded[1..] == dcid
+
+	encoded_off := encode_short_header(dcid, false, 0, false, 0)!
+	assert encoded_off[0] & 0x20 == 0
+	assert encoded_off[0] & 0x04 == 0
+	assert encoded_off[0] & 0x03 == 0
+}
+
+fn test_encode_short_header_rejects_out_of_range_fields() {
+	encode_short_header([]u8{}, false, 0x4, false, 0) or {
+		assert err.msg().contains('reserved_bits')
+		return
+	}
+	assert false, 'expected out-of-range reserved_bits to be rejected'
+}
+
 // test_short_header_rejects_negative_dcid_len is a regression test for a
 // Codex finding (vlang/v#27680 pullrequestreview-4806500473): a negative
 // `dcid_len` (e.g. from unvalidated connection state) made

--- a/vlib/net/quic/idle_timeout.v
+++ b/vlib/net/quic/idle_timeout.v
@@ -49,11 +49,18 @@ pub fn effective_idle_timeout(local_max_idle_timeout_ms u64, peer_max_idle_timeo
 }
 
 // IdleTimeoutState tracks when the idle timer last restarted -- RFC 9000
-// §10.1's deliberately ASYMMETRIC reset rule, not "any packet either
-// direction": an ack-eliciting packet RECEIVED restarts it, but a
-// non-ack-eliciting receive (e.g. an ACK-only packet) does NOT; any
-// packet SENT restarts it regardless of whether that packet itself was
-// ack-eliciting.
+// §10.1: "An endpoint restarts its idle timer when a packet from its peer
+// is received and processed successfully" (RECEIVE side: unconditional,
+// any packet) "[An endpoint] also restarts its idle timer when sending an
+// ack-eliciting packet if no other ack-eliciting packets have been sent
+// since last receiving and processing a packet" (SEND side: only
+// ack-eliciting matters there, though restarting on every send, as this
+// type does, is a superset -- more lenient, never less, so it still
+// satisfies the MUST). The ack-eliciting condition in the RFC text is
+// SEND-only; an earlier version of this type had it backwards, gating the
+// RECEIVE side on ack-eliciting instead and never restarting on a
+// non-ack-eliciting receive (e.g. a lone ACK frame) -- found via a
+// maintainer "Local AI Review" on PR #28083.
 pub struct IdleTimeoutState {
 pub mut:
 	last_reset ?u64 // time.sys_mono_now()-sourced instant
@@ -69,14 +76,12 @@ pub fn (mut s IdleTimeoutState) note_packet_sent(now u64) {
 	s.last_reset = now
 }
 
-// note_packet_received restarts the idle timer ONLY for an ack-eliciting
-// packet -- a non-ack-eliciting receive (e.g. a lone ACK frame) must NOT
-// restart it, otherwise two idle peers exchanging nothing but ACKs of
-// each other's ACKs could keep the connection alive forever.
-pub fn (mut s IdleTimeoutState) note_packet_received(is_ack_eliciting bool, now u64) {
-	if is_ack_eliciting {
-		s.last_reset = now
-	}
+// note_packet_received restarts the idle timer -- ANY successfully
+// processed received packet qualifies, per RFC 9000 §10.1 (see this
+// type's own doc comment); there is no ack-eliciting condition on the
+// receive side.
+pub fn (mut s IdleTimeoutState) note_packet_received(now u64) {
+	s.last_reset = now
 }
 
 // is_idle reports whether `timeout` has elapsed since the timer was last

--- a/vlib/net/quic/idle_timeout_test.v
+++ b/vlib/net/quic/idle_timeout_test.v
@@ -60,12 +60,12 @@ fn test_idle_timeout_state_reset_asymmetry() {
 	assert !s.is_idle(timeout, ms500, 0)
 	assert s.is_idle(timeout, ms1500, 0)
 
-	// A non-ack-eliciting receive does NOT restart the timer.
-	s.note_packet_received(false, ms1400)
-	assert s.is_idle(timeout, ms1500, 0) // still measured from connection_start=0
-
-	// An ack-eliciting receive DOES restart the timer.
-	s.note_packet_received(true, ms1400)
+	// RFC 9000 §10.1: "An endpoint restarts its idle timer when a packet
+	// from its peer is received and processed successfully" -- ANY
+	// received packet, not just an ack-eliciting one (the ack-eliciting
+	// condition in the RFC text applies only to the SEND side, in the
+	// very next sentence).
+	s.note_packet_received(ms1400)
 	assert !s.is_idle(timeout, ms1500, 0) // now measured from ms1400
 	assert s.is_idle(timeout, ms2500, 0)
 

--- a/vlib/net/quic/key_update.v
+++ b/vlib/net/quic/key_update.v
@@ -133,6 +133,18 @@ pub fn (s &KeyUpdateState) current_phase_bit() bool {
 	return s.current_phase
 }
 
+// generation reports the ABSOLUTE key generation this side has committed
+// on the READ direction (see KeyResolution.generation's own doc comment
+// for why this is tracked as an absolute counter rather than the
+// period-2 phase bit). Used by the WRITE side (conn.v's
+// sync_write_keys_to_peer_update, RFC 9001 §6.2) to know how many
+// peer-initiated updates this connection's own send keys still need to
+// catch up to -- the read and write generation chains are independent
+// (§6.1), so the write side cannot derive this from its own state alone.
+pub fn (s &KeyUpdateState) generation() int {
+	return s.current_generation
+}
+
 // resolve_read_keys decides which keys to TRY decrypting an incoming
 // 1-RTT packet with, given its key phase bit (already revealed by header
 // protection removal) and its reconstructed packet number. Per RFC 9001


### PR DESCRIPTION
## Summary

Phase 9 of HTTP/3/QUIC support (#27675), continuing from the Phase 8 work in
#27885 (connection lifecycle) — idle timeout, connection close, stateless
reset, and ECN bookkeeping are all wired directly into the connection driver
this phase adds.

**Update:** #27885 has merged. This branch has been rebased cleanly onto
`master` (`git rebase --onto upstream/master <old-base> HEAD`, no
conflicts) and no longer carries any of its commits.

9a and 9b are both implemented, formatted, passing the full `net.quic` suite
(37/37), and have been through a full `/vreview` pass (see Test plan below).

See [`vlib/net/quic/PROGRESS.md`](https://github.com/quaesitor-scientiam/v/blob/http3-quic-quicconn/vlib/net/quic/PROGRESS.md)
for the exact phase-by-phase checklist.

## Scope

Unlike every prior phase, Phase 9 had no detailed design written down
before starting — every earlier phase's `PROGRESS.md` entry cites specific
RFC sections and prior art; Phase 9's was one line. `QuicConn`
(`vlib/net/quic/conn.v`, new file) is the top-level struct that wires
together everything Phases 0-8 built as independent, unit-tested pieces —
no existing file composes any two of them yet, by design (each phase's own
doc comments defer that wiring to "a future `QuicConn`").

Design recovered from the tracking issue's own wording (struct name, file
name, the `poll()`/`process_timeouts()` event-loop contract, the `role`
field, "single-threaded caller-driven... mirroring how quiche/ngtcp2
expose themselves as libraries") plus ~15 scattered "deferred to Phase 9"
doc comments across the existing 31 files that name exactly which piece of
connection-level state (`scids`, current/original DCID tracking, "at most
one Retry accepted," MAX_STREAMS enforcement, transport-parameter default
application, etc.) belongs here.

Sub-phased like Phase 2, landing as one PR:

- **9a — Connection establishment**: `dial()`, Retry/VN handling,
  Initial/Handshake packet processing, driving the TLS handshake state
  machine to `handshake_confirmed`, key derivation/discard, CRYPTO
  reassembly, ACK generation tied into loss detection, idle timeout.
- **9b — Steady state**: 1-RTT packet processing (STREAM/RESET_STREAM/
  STOP_SENDING/MAX_DATA/MAX_STREAM_DATA/MAX_STREAMS dispatch),
  `open_stream`/`write_stream`/`read_stream`/`close` application API,
  connection- and stream-level flow control, stateless-reset detection,
  ECN recording, graceful/immediate close with RFC 9000 §10.2
  closing/draining retransmission + timeout.

Connection ID rotation/migration stays explicitly out of scope for v1 (not
deferred — several existing files independently document this), matching
0-RTT (a separate, later phase). Client-initiated 1-RTT key update
rotation is also out of v1 scope — an existing decision from Phase 8's own
`key_update.v` (only responding to a peer-initiated update is implemented),
not something Phase 9 needed to add.

`/vreview` found and fixed two bugs before the final commit, both
reproduced with a failing test first:

- `write_stream`/`read_stream` never called `ensure_stream_windows` for a
  stream that only exists because RFC 9000 §2.1 auto-created it as a
  lower-numbered sibling of a peer-referenced higher stream ID — such a
  stream had no flow-control window, so a local write to it queued forever
  with no error, never reaching the wire.
- `handle_peer_connection_close` and the stateless-reset branch of
  `note_one_rtt_processing_failed` transitioned to `.draining` without
  setting `closing_deadline` (RFC 9000 §10.2.2 requires the draining
  period to be bounded, same as closing) — a peer-initiated close, the
  most common real-world close path, left the connection draining forever
  instead of eventually reaching `.closed`. Fixed with a shared
  `enter_draining(now)` helper mirroring `close_with_error`'s existing
  deadline formula.

## Test plan

- [x] 9a: hand-built ServerHello→Finished fixtures (reusing Phase 2's RFC
      8448/quiche vectors — no live server) driving `dial()` + `poll()` to
      `handshake_confirmed`; key transitions/discards verified at each
      level.
- [x] 9b: STREAM data round-trip through `poll()`/`open_stream`/
      `write_stream`/`read_stream`; MAX_STREAMS blocking + STREAMS_BLOCKED
      + unblock; application-initiated `close()`; peer-initiated
      CONNECTION_CLOSE → draining (including the RFC 9000 §10.2.2 bounded-
      draining regression test).
- [x] All new/modified code passing under `./vnew test vlib/net/quic/`
      (37/37).
- [x] `./vnew fmt -w` applied to all touched `.v` files.
- [x] Full `/vreview` A-G pass before commit — found and fixed the two
      bugs described above.

🧙 Built with [WOZCODE](https://wozcode.com)
