### PR TITLE
v3: fix for-in-by-ref copies and @[heap] struct allocation

### DIFF
--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -3920,6 +3920,18 @@ fn (mut t Transformer) stringify_expr(expr_id flat.NodeId) flat.NodeId {
 	if raw_alias_type.len > 0 {
 		typ = raw_alias_type
 	}
+	// `transform_expr` above already auto-dereferenced a `pointer_value_rvalues`
+	// ident (mutable for-in bindings, `@[heap]`-promoted locals, ...) to its value,
+	// but `typ` was resolved independently and still carries the storage `&T`.
+	// Strip it so `wrap_string_conversion` sees a type matching what `expr` (now a
+	// plain value read) actually evaluates to, instead of treating it as a
+	// genuine nilable pointer.
+	if int(expr_id) >= 0 && typ.starts_with('&') {
+		raw_node := t.a.nodes[int(expr_id)]
+		if raw_node.kind == .ident && t.pointer_value_rvalues[raw_node.value] {
+			typ = typ[1..]
+		}
+	}
 	return t.wrap_string_conversion(expr, typ)
 }
 

--- a/vlib/v3/transform/for.v
+++ b/vlib/v3/transform/for.v
@@ -931,6 +931,11 @@ fn (mut t Transformer) lower_indexed_for_in(id flat.NodeId, node flat.Node, key_
 	} else {
 		iter_type
 	}
+	// `for x in &arr` requests by-reference elements via a `&` on the container
+	// expression itself, distinct from `node.op == .amp` (`for mut x in arr`). A
+	// `mut` parameter is stored as a pointer by the C ABI even without an explicit
+	// `&`, so only a genuine address-of/reference expression counts here.
+	container_is_explicit_reference := container_node.kind == .prefix && container_node.op == .amp
 	source_is_owned_temporary := !source_container_type.starts_with('&')
 		&& !t.expr_can_take_address(container_id)
 	direct_map_index_container := node.op == .amp && container_node.kind == .index
@@ -990,7 +995,8 @@ fn (mut t Transformer) lower_indexed_for_in(id flat.NodeId, node flat.Node, key_
 		elem_name = val.value
 	}
 	t.set_var_type(idx_name, 'int')
-	elem_is_mut := node.op == .amp && actual_iter_type != 'string'
+	elem_is_mut := (node.op == .amp || container_is_explicit_reference)
+		&& actual_iter_type != 'string'
 	elem_needs_ref := elem_is_mut
 	elem_var_type := if elem_needs_ref { '&${elem_type}' } else { elem_type }
 	t.set_var_type(elem_name, elem_var_type)

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -5279,6 +5279,14 @@ fn (t &Transformer) string_interp_needs_value_read(name string, typ string) bool
 	if t.mut_param_values[name] {
 		return true
 	}
+	// A name whose own tracked type is already `&T` is genuinely pointer-backed
+	// storage (mutable for-in bindings, `@[heap]`-promoted locals, ...). Those
+	// still read as a plain value everywhere else via `pointer_value_rvalues`
+	// (see e.g. `heap_escaping_source_decl`); string conversion must match, or a
+	// heap-promoted local prints as a nil-checked pointer instead of its value.
+	if t.pointer_value_rvalues[name] {
+		return true
+	}
 	source_type := t.var_type(name)
 	if source_type.len == 0 || source_type.starts_with('&') {
 		return false
@@ -5413,6 +5421,16 @@ fn (t &Transformer) heapable_value_type(typ string) bool {
 	return typ.len > 0 && !typ.starts_with('&') && !typ.starts_with('[]')
 		&& !typ.starts_with('map[') && !typ.starts_with('?') && !typ.starts_with('!')
 		&& !typ.starts_with('[') && typ != 'unknown' && typ != 'void'
+}
+
+// heap_attr_struct_type reports whether `typ` is a plain (non-pointer) struct type
+// declared `@[heap]`. Such structs must always be heap-allocated at construction, not
+// only when escape analysis detects an address later leaving the stack frame.
+fn (t &Transformer) heap_attr_struct_type(typ string) bool {
+	if isnil(t.tc) || !t.heapable_value_type(typ) {
+		return false
+	}
+	return t.tc.type_has_declaration_attribute(t.tc.parse_type(typ), 'heap')
 }
 
 fn (mut t Transformer) collect_exclusive_closure_return_fns() {
@@ -12956,6 +12974,13 @@ fn (mut t Transformer) transform_decl_assign_stmt(id flat.NodeId, node flat.Node
 		}
 		if src.kind == .ident && src.value in t.escaping_amp_sources
 			&& src.value !in t.heaped_amp_locals && t.heapable_value_type(inferred_typ) {
+			return t.heap_escaping_source_decl(node, src.value, inferred_typ)
+		}
+		// A struct declared `@[heap]` is always heap-allocated at its own declaration,
+		// regardless of whether its address is later taken (`@[heap]` is an unconditional
+		// promise, not an escape-analysis trigger).
+		if src.kind == .ident && src.value !in t.heaped_amp_locals
+			&& t.heap_attr_struct_type(inferred_typ) {
 			return t.heap_escaping_source_decl(node, src.value, inferred_typ)
 		}
 	}

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -13608,7 +13608,7 @@ pub fn (tc &TypeChecker) struct_module_for_type(name string) string {
 	return ''
 }
 
-fn (tc &TypeChecker) type_has_declaration_attribute(typ Type, name string) bool {
+pub fn (tc &TypeChecker) type_has_declaration_attribute(typ Type, name string) bool {
 	clean := unalias_type(unwrap_pointer(typ))
 	type_name := clean.name()
 	if type_name.len == 0 {


### PR DESCRIPTION
## Summary

Fixes two related bugs in the `v3` compiler pipeline (the default on macOS for `v run`/`v build`) reported in #28084:

- **`for i in &arr` copied elements by value instead of by reference.** The for-in node's `.amp` op is only set for `for mut i in arr`, unrelated to a `&` on the container expression. The transformer stripped the container's own leading `&` off its type without tracking that fact anywhere downstream, so `lower_indexed_for_in` always bound the element by value regardless of the explicit `&`. Now tracked directly from the container's AST shape (a genuine `.prefix .amp` container expression), independent of `node.op`.

- **`@[heap]`-tagged structs were never actually heap-allocated for plain `t := Test{}` declarations** — only `&Test{}` worked. The type checker already treats `@[heap]` as an unconditional heap-allocation promise for borrow-safety checks (see `checker.v`/`checker_tail.v`), but nothing in transform/codegen enforced it, so the promise was unsound. This hooks the existing escape-analysis heap-promotion machinery (`heap_escaping_source_decl`, already used for locals whose address is later found to escape) so `@[heap]` structs get the same treatment *unconditionally* at declaration, including a real deep copy (not a pointer alias) on `y := t`, matching classic V's value-copy-with-heap-storage semantics exactly.

Fixing the second bug surfaced a real latent codegen bug: `stringify_expr`/`string_interp_needs_value_read` assumed any local whose tracked type is `&T` is a genuine nilable pointer, and produced invalid C (a pointer/value type mismatch) for the new heap-promoted case — `println(t)` for a `@[heap]` struct. Fixed alongside.

## Test plan

- Both fixes verified against the exact repro in #28084, and cross-checked output/generated-C against the classic (`-old-compiler`) backend for parity across: methods (value + pointer receiver), by-value function args, `mut` params, struct auto-str/`println`, return-value capture, nested scopes, per-iteration loop locals, self-referential structs, arrays/maps of heap structs — all byte-identical to classic V.
- Ran the full `vlib/v3/tests/` suite (206 files) before and after: the 30 failures seen post-patch are pre-existing (28 fail identically on the unpatched baseline) or environmental flakiness under 10-way parallel test execution (2 tests flip pass/fail across repeated runs on *both* the baseline and patched binaries) — no reproducible new regressions.
- `./vnew fmt -diff` clean on all touched files.

Fixes #28084

🤖 Generated with [Claude Code](https://claude.com/claude-code)