### PR TITLE
Fix 3 recent issues: vfmt mut-ref params (#28070), spawn option args (#28079), root-folder submodule module name (#28074)

### DIFF
--- a/vlib/v/ast/str.v
+++ b/vlib/v/ast/str.v
@@ -229,11 +229,20 @@ fn (t &Table) stringify_fn_after_name(node &FnDecl, mut f strings.Builder, cur_m
 		} else {
 			mut s := t.type_to_str(param_typ.clear_flag(.shared_f))
 			if param.is_mut {
-				if s.starts_with('&') && ((!param_sym.is_number() && param_sym.kind != .bool)
+				// The parser lowers `mut` params by adding one level of indirection
+				// (`mut x T` => `&T`). vfmt must strip only that parser-added `&`, not a
+				// `&` the user wrote explicitly (`mut x &T`). `orig_typ` is the type as
+				// written, before mut lowering, so a larger `nr_muls` on the lowered type
+				// means the parser added the `&` that we are allowed to drop.
+				parser_added_ref := param.orig_typ == 0
+					|| param_typ.nr_muls() > param.orig_typ.nr_muls()
+				if s.starts_with('&') && parser_added_ref
+					&& ((!param_sym.is_number() && param_sym.kind != .bool)
 					|| node.language != .v
 					|| (param_typ.is_ptr() && param_sym.kind == .struct)) {
 					s = s[1..]
-				} else if param_typ.is_ptr() && param_sym.kind == .struct && !s.contains('[') {
+				} else if parser_added_ref && param_typ.is_ptr() && param_sym.kind == .struct
+					&& !s.contains('[') {
 					s = t.type_to_str(param_typ.clear_flag(.shared_f).deref())
 				}
 			}

--- a/vlib/v/ast/stringify_mut_ref_param_test.v
+++ b/vlib/v/ast/stringify_mut_ref_param_test.v
@@ -1,0 +1,37 @@
+module ast
+
+// Regression test for https://github.com/vlang/v/issues/28070
+// vfmt used to drop the explicit `&` from a `mut x &T` parameter when `T` was an
+// unregistered (placeholder, non-struct) type, e.g. when `T` is declared in
+// another file of the same module and vfmt parses a single file in isolation.
+// The parser only auto-adds a `&` to `mut` params when the base type is a
+// registered struct, so `stringify_fn_decl` must strip a leading `&` only when
+// the lowered type actually has more indirection than `orig_typ` (the type as
+// the user wrote it).
+fn test_stringify_fn_decl_keeps_explicit_ref_on_mut_placeholder_param() {
+	mut t := new_table()
+	foo_idx := t.register_sym(TypeSymbol{
+		kind:  .placeholder
+		name:  'Foo'
+		cname: 'Foo'
+		mod:   'main'
+	})
+	// `&Foo`, exactly as written in `fn f(mut p &Foo)`. `orig_typ` keeps the same
+	// number of `&`, so mut lowering added nothing that vfmt may strip.
+	foo_ref := new_type(foo_idx).set_nr_muls(1)
+	decl := FnDecl{
+		name:        'f'
+		mod:         'main'
+		return_type: void_type
+		params:      [
+			Param{
+				name:     'p'
+				is_mut:   true
+				typ:      foo_ref
+				orig_typ: foo_ref
+			},
+		]
+	}
+	s := t.stringify_fn_decl(&decl, 'main', map[string]string{}, false)
+	assert s == 'fn f(mut p &Foo)', 'vfmt dropped the explicit `&`: got `${s}`'
+}

--- a/vlib/v/fmt/tests/mut_ref_param_unregistered_type_keep.vv
+++ b/vlib/v/fmt/tests/mut_ref_param_unregistered_type_keep.vv
@@ -1,0 +1,3 @@
+fn with_unregistered_ref(mut p &Foo) {
+	println(p.x)
+}

--- a/vlib/v/gen/c/spawn_and_go.v
+++ b/vlib/v/gen/c/spawn_and_go.v
@@ -155,14 +155,26 @@ fn (mut g Gen) spawn_and_go_expr(node ast.SpawnExpr, mode SpawnGoMode) {
 	for i, arg in expr.args {
 		arg_field := '${arg_tmp_var}${dot}arg${i + 1}'
 		arg_type := g.unwrap_generic(g.recheck_concrete_type(arg.typ))
-		if !arg_type.is_ptr() && !arg_type.has_option_or_result()
+		expected_type := if i < expr.expected_arg_types.len {
+			g.unwrap_generic(expr.expected_arg_types[i])
+		} else {
+			arg_type
+		}
+		// e.g. `spawn obj.f(none)` (or `spawn obj.f(v)`) where `f` takes an `?T`
+		// parameter: the argument must be wrapped into the option type of the
+		// parameter, otherwise the packed thread argument keeps the bare `none`/value
+		// type and the generated C fails to compile (see issue #28079).
+		coerce_to_option := expected_type.has_flag(.option) && !arg_type.has_flag(.option)
+		if !coerce_to_option && !arg_type.is_ptr() && !arg_type.has_option_or_result()
 			&& g.table.final_sym(arg_type).kind == .array_fixed {
 			g.write('memcpy(${arg_field}, ')
 			g.expr(arg.expr)
 			g.writeln(', sizeof(${arg_field}));')
 		} else {
 			g.write('${arg_field} = ')
-			if arg_type.has_option_or_result() {
+			if coerce_to_option {
+				g.expr_with_opt(arg.expr, arg_type, expected_type)
+			} else if arg_type.has_option_or_result() {
 				old_inside_opt_or_res := g.inside_opt_or_res
 				g.inside_opt_or_res = true
 				g.expr(arg.expr)
@@ -386,8 +398,18 @@ fn (mut g Gen) spawn_and_go_expr(node ast.SpawnExpr, mode SpawnGoMode) {
 					arg_sym.info.func.params.map(it.typ), 'arg${i + 1}')
 				g.type_definitions.writeln('\t' + sig + ';')
 			} else {
-				g.mark_spawn_arg_option_or_result_type(arg_typ)
-				styp := g.styp(arg_typ)
+				// Keep the wrapper field type in sync with the coercion done when
+				// packing the argument: an `?T` parameter given a bare `none`/value
+				// must be stored as the option type, not as `none` (see #28079).
+				mut field_typ := arg_typ
+				if i < expr.expected_arg_types.len {
+					expected_typ := g.unwrap_generic(expr.expected_arg_types[i])
+					if expected_typ.has_flag(.option) && !arg_typ.has_flag(.option) {
+						field_typ = expected_typ
+					}
+				}
+				g.mark_spawn_arg_option_or_result_type(field_typ)
+				styp := g.styp(field_typ)
 				g.type_definitions.writeln('\t${styp} arg${i + 1};')
 			}
 		}

--- a/vlib/v/tests/local_submodule_in_project_root_codegen_test.v
+++ b/vlib/v/tests/local_submodule_in_project_root_codegen_test.v
@@ -1,0 +1,56 @@
+// Regression test for https://github.com/vlang/v/issues/28074
+// A project with a `v.mod` at its root can keep submodule source files directly
+// in that root folder (e.g. `calculator.v` declaring `module calculator`).
+// The module name of such a file used to be mis-qualified as `.` (because the
+// file path resolves to `<root>/.`). When the file also produced parser codegen
+// (any enum does), the generated `module <name>` line was emitted with an empty
+// name, so the generated code failed to parse with:
+//   `error: unexpected token `@`, expecting name`
+import os
+
+@[markused]
+const turn_off_vcolors = os.setenv('VCOLORS', 'never', true)
+
+const vexe = @VEXE
+
+fn project_path() string {
+	return os.join_path(os.real_path(os.vtmp_dir()), 'issue_28074_root_submodule')
+}
+
+fn write_project() {
+	basepath := project_path()
+	os.rmdir_all(basepath) or {}
+	os.mkdir_all(basepath) or { panic(err) }
+	os.write_file(os.join_path(basepath, 'v.mod'), "Module {\n\tname: 'issue_28074'\n\tversion: '0.0.1'\n}\n") or {
+		panic(err)
+	}
+	os.write_file(os.join_path(basepath, 'main.v'),
+		['module main', '', 'import calculator', '', 'fn main() {', '\tprintln(calculator.evaluate(calculator.Op.add))', '}'].join('\n') +
+		'\n') or { panic(err) }
+	// A submodule file living directly in the project root, that also declares an
+	// enum, so the parser generates helper code (which triggered the bug).
+	os.write_file(os.join_path(basepath, 'calculator.v'),
+		['module calculator', '', 'pub enum Op {', '\tadd', '\tsub', '}', '', 'pub fn evaluate(op Op) int {', '\treturn if op == .add { 1 } else { -1 }', '}'].join('\n') +
+		'\n') or { panic(err) }
+}
+
+fn compile_project(target string) os.Result {
+	basepath := project_path()
+	write_project()
+	out_name := os.join_path(os.vtmp_dir(), 'issue_28074_out')
+	old_wd := os.getwd()
+	os.chdir(basepath) or { panic(err) }
+	defer {
+		os.chdir(old_wd) or {}
+		os.rmdir_all(basepath) or {}
+		os.rm(out_name) or {}
+	}
+	// `-old-compiler` forces the compatibility compiler (the default on non-macOS,
+	// a fallback on macOS) where the mis-qualification happened.
+	return os.execute('${os.quoted_path(vexe)} -old-compiler -o ${os.quoted_path(out_name)} ${os.quoted_path(target)}')
+}
+
+fn test_root_submodule_with_enum_compiles_from_project_dir() {
+	res := compile_project('.')
+	assert res.exit_code == 0, res.output
+}

--- a/vlib/v/tests/spawn_call_with_option_arg_test.v
+++ b/vlib/v/tests/spawn_call_with_option_arg_test.v
@@ -1,0 +1,46 @@
+// Regression test for https://github.com/vlang/v/issues/28079
+// `spawn obj.method(none)` / `spawn obj.method(value)` where the method takes an
+// `?T` parameter used to generate a thread-argument wrapper whose field was typed
+// `none` instead of the option type, producing invalid C that failed to compile.
+
+struct StartParams {
+	x int
+}
+
+struct App {
+	name string
+}
+
+fn (a &App) run(params ?StartParams) int {
+	if p := params {
+		return p.x
+	}
+	return -1
+}
+
+fn test_spawn_method_with_none_option_arg() {
+	a := &App{
+		name: 'app'
+	}
+	t := spawn a.run(none)
+	assert t.wait() == -1
+}
+
+fn test_spawn_method_with_value_option_arg() {
+	a := &App{
+		name: 'app'
+	}
+	t := spawn a.run(StartParams{ x: 42 })
+	assert t.wait() == 42
+}
+
+fn plain(params ?StartParams) int {
+	return if p := params { p.x } else { -7 }
+}
+
+fn test_spawn_plain_fn_with_option_arg() {
+	t1 := spawn plain(none)
+	assert t1.wait() == -7
+	t2 := spawn plain(StartParams{ x: 5 })
+	assert t2.wait() == 5
+}

--- a/vlib/v/util/module.v
+++ b/vlib/v/util/module.v
@@ -334,7 +334,16 @@ fn mod_path_to_full_name_with_options(pref_ &pref.Preferences, mod string, path 
 		rel_mod_path := path.replace(abs_pref_path.all_before_last(os.path_separator) +
 			os.path_separator, '')
 		if rel_mod_path != path {
-			return normalize_base_url_mod_name(rel_mod_path.replace(os.path_separator, '.'), path)
+			mod_full_name := normalize_base_url_mod_name(rel_mod_path.replace(os.path_separator,
+				'.'), path)
+			// A file that sits directly in the project root maps to `path` ending in
+			// `/.`, so `rel_mod_path` becomes `.` and yields an empty/dotted module
+			// name. That is not a valid qualified name (it later produces `module `
+			// with no name for parser codegen, see issue #28074), so fall through to
+			// the caller's fallback, which keeps the declared module name.
+			if !module_name_has_empty_part(mod_full_name) {
+				return mod_full_name
+			}
 		}
 	}
 	return error('module not found')

--- a/vlib/v3/tests/root_submodule_enum_codegen_test.v
+++ b/vlib/v3/tests/root_submodule_enum_codegen_test.v
@@ -1,0 +1,63 @@
+// Guard test for the v3 (new) compiler, mirroring the vlib/v regression for
+// https://github.com/vlang/v/issues/28074 . A project with a `v.mod` at its
+// root may keep submodule source files directly in that root folder (e.g.
+// `calculator.v` declaring `module calculator`). Such a submodule that also
+// declares an enum used to make the old compiler emit `module ` with no name
+// for parser codegen. v3 resolves module names differently and already handles
+// this correctly; this test locks that behavior in.
+import os
+
+const root_submodule_tests_dir = os.dir(@FILE)
+const root_submodule_v3_dir = os.dir(root_submodule_tests_dir)
+const root_submodule_vlib_dir = os.dir(root_submodule_v3_dir)
+const root_submodule_v3_src = os.join_path(root_submodule_v3_dir, 'v3.v')
+
+fn v3_bin_path() string {
+	return os.join_path(os.temp_dir(), 'v3_root_submodule_test_${os.getpid()}')
+}
+
+fn build_v3() string {
+	v3_bin := v3_bin_path()
+	if os.is_file(v3_bin) {
+		return v3_bin
+	}
+	build :=
+		os.execute('${os.quoted_path(@VEXE)} -gc none -prealloc -path "${root_submodule_vlib_dir}|@vlib|@vmodules" -o ${os.quoted_path(v3_bin)} ${os.quoted_path(root_submodule_v3_src)}')
+	assert build.exit_code == 0, build.output
+	return v3_bin
+}
+
+fn testsuite_end() {
+	os.rm(v3_bin_path()) or {}
+}
+
+fn test_v3_compiles_root_submodule_with_enum() {
+	v3_bin := build_v3()
+	project := os.join_path(os.vtmp_dir(), 'v3_issue_28074_${os.getpid()}')
+	os.rmdir_all(project) or {}
+	os.mkdir_all(project) or { panic(err) }
+	out := os.join_path(os.vtmp_dir(), 'v3_issue_28074_out_${os.getpid()}')
+	defer {
+		os.rmdir_all(project) or {}
+		os.rm(out) or {}
+	}
+	os.write_file(os.join_path(project, 'v.mod'), "Module {\n\tname: 'issue_28074'\n}\n") or {
+		panic(err)
+	}
+	os.write_file(os.join_path(project, 'main.v'),
+		['module main', '', 'import calculator', '', 'fn main() {', '\tprintln(calculator.evaluate(calculator.Op.add))', '}'].join('\n') +
+		'\n') or { panic(err) }
+	os.write_file(os.join_path(project, 'calculator.v'),
+		['module calculator', '', 'pub enum Op {', '\tadd', '\tsub', '}', '', 'pub fn evaluate(op Op) int {', '\treturn if op == .add { 1 } else { -1 }', '}'].join('\n') +
+		'\n') or { panic(err) }
+	old_wd := os.getwd()
+	os.chdir(project) or { panic(err) }
+	defer {
+		os.chdir(old_wd) or {}
+	}
+	compile := os.execute('${os.quoted_path(v3_bin)} -o ${os.quoted_path(out)} .')
+	assert compile.exit_code == 0, compile.output
+	run := os.execute(os.quoted_path(out))
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == '1', run.output
+}


### PR DESCRIPTION
Fixes three recently-opened issues that had no existing PR. Each fix comes with a regression test that fails on `master` and passes here.

### `vfmt`: keep explicit `&` on `mut x &T` params — fixes #28070
The parser only auto-adds a `&` to a `mut` parameter when its base type is a registered struct. For a placeholder/non-struct type (e.g. a type declared in another file, when vfmt formats a single file in isolation) it does not — so `stringify_fn_after_name` must not strip a `&` the user wrote explicitly. We now strip the leading `&` only when the lowered `typ` has more indirection than `orig_typ` (the type as written), i.e. only the `&` the parser actually added.

- `vlib/v/ast/str.v`
- tests: `vlib/v/ast/stringify_mut_ref_param_test.v`, `vlib/v/fmt/tests/mut_ref_param_unregistered_type_keep.vv`

### cgen: wrap option args when packing `spawn`/`go` thread arguments — fixes #28079
`spawn obj.method(none)` (or `spawn obj.method(value)`) where `method` takes an `?T` parameter produced a thread-argument wrapper whose field was typed with the bare argument type (`none`) instead of the parameter's option type, and packed the raw value into it — so the generated C failed to compile with *passing 'none' to parameter of incompatible type '_option_..._'*. The argument is now coerced with `expr_with_opt` and the wrapper field is declared with the expected option type, matching ordinary calls.

- `vlib/v/gen/c/spawn_and_go.v`
- test: `vlib/v/tests/spawn_call_with_option_arg_test.v`

### parser: fix module name mis-qualified as `.` for a submodule in the project root — fixes #28074
When a project with a `v.mod` keeps submodule source files directly in the root folder, the file path resolves to `<root>/.`, so `mod_path_to_full_name` derived the module name from the relative path `.` and returned `.`. That empty/dotted name later produced a `module ` line with no name for parser codegen (any enum triggers codegen), so the generated code failed to parse with *unexpected token `@`, expecting name*. We now reject a qualified name with an empty part (consistent with the sibling branches), so the caller falls back to the declared module name.

- `vlib/v/util/module.v`
- test: `vlib/v/tests/local_submodule_in_project_root_codegen_test.v`

### v3
The #28074 mis-qualification is specific to the old compiler; v3 already compiles the same co-located-submodule-with-enum project correctly. Added `vlib/v3/tests/root_submodule_enum_codegen_test.v` to lock that behavior in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)