### PR TITLE
Fix 3 recent issues: veb host controller (#28019), v new/init hang (#28061), v up libgc dependency (#27148)

### DIFF
--- a/cmd/tools/diagnostic_tools_no_libgc_test.v
+++ b/cmd/tools/diagnostic_tools_no_libgc_test.v
@@ -1,0 +1,31 @@
+// Regression test for https://github.com/vlang/v/issues/27148
+// The diagnostic tools (vself, vup, vdoctor, vsymlink) are compiled with `-g` so
+// their crash backtraces have .v line numbers. On macOS the default GC (boehm)
+// made them link `@rpath/libgc.dylib`; if that dylib could not be found, the
+// tool failed to even start with a dynamic loader error. They are now compiled
+// with `-gc none` as well, so they carry no such runtime dependency.
+import os
+
+fn test_vdoctor_has_no_libgc_dependency() {
+	$if !macos {
+		// The dynamic-loader failure and the `otool -L` check are macOS specific.
+		return
+	}
+	otool := os.find_abs_path_of_executable('otool') or {
+		eprintln('skipping test, `otool` is not available')
+		return
+	}
+	vexe := @VEXE
+	// `v doctor` builds the vdoctor tool through `util.launch_tool` (the code path
+	// that received the `-gc none` fix) and then runs it.
+	res := os.execute('${os.quoted_path(vexe)} doctor')
+	assert res.exit_code == 0, res.output
+	vdoctor_exe := os.join_path(os.dir(vexe), 'cmd', 'tools', 'vdoctor')
+	if !os.exists(vdoctor_exe) {
+		eprintln('skipping test, `${vdoctor_exe}` was not produced')
+		return
+	}
+	libs := os.execute('${os.quoted_path(otool)} -L ${os.quoted_path(vdoctor_exe)}')
+	assert libs.exit_code == 0, libs.output
+	assert !libs.output.contains('libgc'), 'vdoctor must not depend on libgc:\n${libs.output}'
+}

--- a/cmd/tools/vcreate/vcreate.v
+++ b/cmd/tools/vcreate/vcreate.v
@@ -66,8 +66,11 @@ fn main() {
 				description: [
 					'Creates a new V project in a directory with the specified project name.',
 					'',
-					'A setup prompt is started to create a `v.mod` file with the projects metadata.',
-					'The <project_name> argument can be omitted and entered in the prompts dialog.',
+					'When run in a terminal, a setup prompt is started to create a `v.mod` file with',
+					'the projects metadata; the <project_name> argument can then be omitted and',
+					'entered in the prompts dialog. When stdin is not a terminal (piped/redirected,',
+					'e.g. in CI) the prompts are skipped, defaults are used, and <project_name> is',
+					'required.',
 					'If git is installed, `git init` will be performed during the setup.',
 				].join_lines()
 				parent:      &Command{
@@ -84,6 +87,7 @@ fn main() {
 					'Sets up a V project within the current directory.',
 					'',
 					"If no `v.mod` exists, a setup prompt is started to create one with the project's metadata.",
+					'The prompts run only when stdin is a terminal; otherwise the defaults are used.',
 					'If no `.v` file exists, a project template is generated. If the current directory is not a',
 					'git project and git is installed, `git init` will be performed during the setup.',
 				].join_lines()

--- a/cmd/tools/vcreate/vcreate.v
+++ b/cmd/tools/vcreate/vcreate.v
@@ -148,12 +148,23 @@ fn init_project(cmd Command) ! {
 	c.create_git_repo('.')
 }
 
+// prompt_input asks for a line of input, but only when stdin is a terminal.
+// When it is not (piped input, CI, some IDE terminals), the interactive prompt
+// would block forever waiting for input that never arrives, making
+// `v new`/`v init` appear to hang, so return `default` instead. See #28061.
+fn prompt_input(prompt string, default string) string {
+	if os.is_atty(0) == 0 {
+		return default
+	}
+	return os.input(prompt)
+}
+
 fn (mut c Create) prompt(args []string) {
 	if c.name == '' {
-		c.name = check_name(args[0] or { os.input('Input your project name: ') })
+		c.name = check_name(args[0] or { prompt_input('Input your project name: ', '') })
 		if c.name == '' {
 			eprintln('')
-			cerror('project name cannot be empty')
+			cerror('project name cannot be empty; pass it on the command line, e.g. `v new my_project`')
 			exit(1)
 		}
 		if c.name.contains('-') {
@@ -167,14 +178,14 @@ fn (mut c Create) prompt(args []string) {
 			exit(3)
 		}
 	}
-	c.description = os.input('Input your project description: ')
+	c.description = prompt_input('Input your project description: ', '')
 	default_version := '0.0.0'
-	c.version = os.input('Input your project version: (${default_version}) ')
+	c.version = prompt_input('Input your project version: (${default_version}) ', default_version)
 	if c.version == '' {
 		c.version = default_version
 	}
 	default_license := 'MIT'
-	c.license = os.input('Input your project license: (${default_license}) ')
+	c.license = prompt_input('Input your project license: (${default_license}) ', default_license)
 	if c.license == '' {
 		c.license = default_license
 	}

--- a/cmd/tools/vcreate/vcreate_noninteractive_test.v
+++ b/cmd/tools/vcreate/vcreate_noninteractive_test.v
@@ -1,0 +1,35 @@
+// vtest build: !windows
+// Regression test for https://github.com/vlang/v/issues/28061
+// `v new <name>` / `v init` used to block on interactive prompts even when stdin
+// is not a terminal, so piping/redirecting stdin made them appear to hang. They
+// must instead fall back to defaults for the metadata prompts.
+import os
+import v.vmod
+
+const vexe = @VEXE
+
+fn test_new_non_interactive_uses_defaults() {
+	tdir := os.join_path(os.vtmp_dir(), 'vcreate_noninteractive_${os.getpid()}')
+	os.rmdir_all(tdir) or {}
+	os.mkdir_all(tdir) or { panic(err) }
+	defer {
+		os.rmdir_all(tdir) or {}
+	}
+	old_wd := os.getwd()
+	os.chdir(tdir) or { panic(err) }
+	defer {
+		os.chdir(old_wd) or {}
+	}
+	name := 'my_ni_project'
+	// `< /dev/null` guarantees a non-terminal stdin that returns EOF immediately.
+	res := os.execute('${os.quoted_path(vexe)} new ${name} < /dev/null')
+	assert res.exit_code == 0, res.output
+	mod := vmod.from_file(os.join_path(tdir, name, 'v.mod')) or {
+		assert false, err.str()
+		return
+	}
+	assert mod.name == name
+	assert mod.description == ''
+	assert mod.version == '0.0.0'
+	assert mod.license == 'MIT'
+}

--- a/cmd/tools/vup.v
+++ b/cmd/tools/vup.v
@@ -129,7 +129,10 @@ fn (app App) recompile_vup() bool {
 		eprintln('> Skipping recompiling vup.v, `${vexe_path}` is missing.')
 		return false
 	}
-	vup_result := os.execute('${os.quoted_path(vexe_path)} -g cmd/tools/vup.v')
+	// `-gc none` matches how `util.launch_tool` builds vup, so this self-rebuild
+	// after a successful update does not overwrite the GC-free executable with a
+	// libgc-linked one (which could fail to start in the dynamic loader). See #27148.
+	vup_result := os.execute('${os.quoted_path(vexe_path)} -g -gc none cmd/tools/vup.v')
 	if vup_result.exit_code != 0 {
 		eprintln('> Failed recompiling vup.v .')
 		eprintln(vup_result.output)

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -86,6 +86,12 @@ by using any of the following commands in a terminal:
 
 The `v new --web` template uses `veb`, V's web framework.
 
+When run in a terminal, `v new` and `v init` interactively prompt for the project's
+description, version and license. When stdin is *not* a terminal (for example when the
+input is piped or redirected, as in CI), the prompts are skipped and the defaults are
+used instead of blocking on input; in that case the project name must be passed as an
+argument, e.g. `v new abc`.
+
 ## Table of Contents
 
 <table>
@@ -6322,6 +6328,9 @@ Package are up to date.
    Initialising ...
    Complete!
    ```
+
+   The prompts above appear only when running in a terminal; with a non-terminal
+   stdin the defaults are used instead (see [Getting started](#getting-started)).
 
    Example `v.mod`:
    ```v ignore

--- a/vlib/v/tests/local_submodule_in_project_root_codegen_test.v
+++ b/vlib/v/tests/local_submodule_in_project_root_codegen_test.v
@@ -21,9 +21,8 @@ fn write_project() {
 	basepath := project_path()
 	os.rmdir_all(basepath) or {}
 	os.mkdir_all(basepath) or { panic(err) }
-	os.write_file(os.join_path(basepath, 'v.mod'), "Module {\n\tname: 'issue_28074'\n\tversion: '0.0.1'\n}\n") or {
-		panic(err)
-	}
+	os.write_file(os.join_path(basepath, 'v.mod'),
+		"Module {\n\tname: 'issue_28074'\n\tversion: '0.0.1'\n}\n") or { panic(err) }
 	os.write_file(os.join_path(basepath, 'main.v'),
 		['module main', '', 'import calculator', '', 'fn main() {', '\tprintln(calculator.evaluate(calculator.Op.add))', '}'].join('\n') +
 		'\n') or { panic(err) }

--- a/vlib/v/util/module.v
+++ b/vlib/v/util/module.v
@@ -334,8 +334,8 @@ fn mod_path_to_full_name_with_options(pref_ &pref.Preferences, mod string, path 
 		rel_mod_path := path.replace(abs_pref_path.all_before_last(os.path_separator) +
 			os.path_separator, '')
 		if rel_mod_path != path {
-			mod_full_name := normalize_base_url_mod_name(rel_mod_path.replace(os.path_separator,
-				'.'), path)
+			mod_full_name :=
+				normalize_base_url_mod_name(rel_mod_path.replace(os.path_separator, '.'), path)
 			// A file that sits directly in the project root maps to `path` ending in
 			// `/.`, so `rel_mod_path` becomes `.` and yields an empty/dotted module
 			// name. That is not a valid qualified name (it later produces `module `

--- a/vlib/v/util/util.v
+++ b/vlib/v/util/util.v
@@ -195,7 +195,11 @@ pub fn launch_tool(is_verbose bool, tool_name string, args []string) {
 			// it is better to always compile them with -g, so that in
 			// case these tools do crash/panic, their backtraces will have
 			// .v line numbers, to ease diagnostic in #bugs and issues.
-			compilation_command += ' -g '
+			// `-gc none` also keeps these small, short-lived tools from gaining a
+			// runtime dependency on `libgc.dylib`/`libgc.so`, which can be missing or
+			// unfound (e.g. a vroot path with spaces) and then make the tool fail to
+			// even start with a dynamic loader error. See #27148.
+			compilation_command += ' -g -gc none '
 		}
 		if tool_name == 'vfmt' {
 			compilation_command += ' -d vfmt '

--- a/vlib/veb/README.md
+++ b/vlib/veb/README.md
@@ -1094,7 +1094,7 @@ pub fn (app &Example) index(mut ctx Context) veb.Result {
 mut example_app := &Example{}
 // set the controllers hostname to 'example.com' and handle all routes starting with '/',
 // we handle requests with any route to 'example.com'
-app.register_controller[Example, Context]('example.com', '/', mut example_app)!
+app.register_host_controller[Example, Context]('example.com', '/', mut example_app)!
 ```
 
 ## Context Methods

--- a/vlib/veb/controller.v
+++ b/vlib/veb/controller.v
@@ -72,8 +72,8 @@ pub fn (mut c Controller) register_host_controller[A, X](host string, path strin
 }
 
 // controller_host generates a controller which only handles incoming requests from the `host` domain
-pub fn controller_host[A, X](host string, path string, mut global_app A) &ControllerPath {
-	mut ctrl := controller[A, X](path, mut global_app)
+pub fn controller_host[A, X](host string, path string, mut global_app A) !&ControllerPath {
+	mut ctrl := controller[A, X](path, mut global_app)!
 	ctrl.host = host
 	return ctrl
 }

--- a/vlib/veb/tests/register_host_controller_test.v
+++ b/vlib/veb/tests/register_host_controller_test.v
@@ -1,0 +1,33 @@
+// Regression test for https://github.com/vlang/v/issues/28019
+// The veb README documented host-scoped controllers via
+// `register_controller('host', '/', mut app)`, but that method only takes
+// `(path, mut app)`. The correct API is `register_host_controller`. This test
+// locks that method's signature/behavior in.
+import veb
+
+pub struct Context {
+	veb.Context
+}
+
+pub struct HostApp {}
+
+pub fn (app &HostApp) index(mut ctx Context) veb.Result {
+	return ctx.text('host app')
+}
+
+pub struct RootApp {
+	veb.Controller
+}
+
+pub fn (app &RootApp) index(mut ctx Context) veb.Result {
+	return ctx.text('root app')
+}
+
+fn test_register_host_controller_registers_with_host() {
+	mut host_app := &HostApp{}
+	mut app := &RootApp{}
+	app.register_host_controller[HostApp, Context]('example.com', '/', mut host_app)!
+	assert app.controllers.len == 1
+	assert app.controllers[0].host == 'example.com'
+	assert app.controllers[0].path == '/'
+}


### PR DESCRIPTION
Three recently-opened issues with no existing PR. Each has a regression test that fails on `master` and passes here.

### veb: `register_host_controller` did not compile — fixes #28019
`controller_host[A, X]` called `controller[A, X](...)` (which returns `!&ControllerPath`) without handling the `Result`, so `register_host_controller` failed to compile whenever it was instantiated:

```
error: unexpected `!`, the function `veb.controller_host` does not return a Result
```

It's now `!&ControllerPath` and propagates the error. The veb README also documented this as a 3-argument `register_controller('host', '/', mut app)` call, but that method only takes `(path, mut app)`; corrected to `register_host_controller`. Added `vlib/veb/tests/register_host_controller_test.v`.

### vcreate: `v new` / `v init` hang on non-terminal stdin — fixes #28061
The setup prompts called `os.input` unconditionally, so with a non-terminal stdin (piped input, CI, some IDE terminals) they blocked forever waiting for input that never arrives — appearing to hang. Now they prompt only when stdin is a TTY and fall back to defaults otherwise (requiring the project name on the command line). Added `cmd/tools/vcreate/vcreate_noninteractive_test.v`.

### tools: `v up` fails to start due to missing libgc.dylib — fixes #27148
`vself`/`vup`/`vdoctor`/`vsymlink` are compiled with `-g`; on macOS the default boehm GC made them link `@rpath/libgc.dylib`, so they failed to even start with a dynamic loader error when that dylib was missing/unfound (e.g. a vroot path with spaces). These short-lived tools don't need a GC, so they are now compiled with `-gc none` too and carry no libgc dependency (verified with `otool -L`). Added `cmd/tools/diagnostic_tools_no_libgc_test.v`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)