### PR TITLE
arrays: fixes overlapping slices of arrays used for copy

### DIFF
--- a/vlib/arrays/arrays.v
+++ b/vlib/arrays/arrays.v
@@ -665,6 +665,7 @@ fn swap_nonoverlapping[T](x_ &T, y_ &T, count int) {
 
 // copy copies the `src` array elements to the `dst` array.
 // The number of the elements copied is the minimum of the length of both arrays.
+// The `src` and `dst` arrays may overlap.
 // Returns the number of elements copied.
 pub fn copy[T](mut dst []T, src []T) int {
 	min_len := if dst.len < src.len { dst.len } else { src.len }
@@ -675,8 +676,17 @@ pub fn copy[T](mut dst []T, src []T) int {
 		blen := min_len * isize(sizeof(T))
 		unsafe { vmemmove(&T(dst.data), src.data, blen) }
 	} else {
-		for i in 0 .. min_len {
-			dst[i] = src[i]
+		dst_start := unsafe { usize(dst.data) }
+		src_start := unsafe { usize(src.data) }
+		copy_bytes := usize(min_len) * usize(sizeof(T))
+		if dst_start > src_start && dst_start - src_start < copy_bytes {
+			for i := min_len - 1; i >= 0; i-- {
+				dst[i] = src[i]
+			}
+		} else {
+			for i in 0 .. min_len {
+				dst[i] = src[i]
+			}
 		}
 	}
 	return min_len

--- a/vlib/arrays/arrays_test.v
+++ b/vlib/arrays/arrays_test.v
@@ -404,6 +404,16 @@ fn test_copy() {
 	assert b == [8, 9, 3, 7]
 }
 
+fn test_copy_overlapping_managed_elements() {
+	mut right := ['a', 'b', 'c', 'd']
+	assert copy(mut right[1..], right[..3]) == 3
+	assert right == ['a', 'a', 'b', 'c']
+
+	mut left := ['a', 'b', 'c', 'd']
+	assert copy(mut left[..3], left[1..]) == 3
+	assert left == ['b', 'c', 'd', 'd']
+}
+
 fn test_can_copy_bits() {
 	assert can_copy_bits[u8]()
 	assert can_copy_bits[int]()


### PR DESCRIPTION
# Summary

Fix `arrays.copy` for rightward overlapping slices of arrays for managed elements like strings.

Previously it would overwrite source elements by proceeding left to right:

```v
mut a := ['a', 'b', 'c', 'd'] 
arrays.copy(mut a[1..], a[..3]) // ['a', 'a', 'a', 'a']    
```

# Tests

 - ./vnew vlib/arrays/arrays_test.v