### PR TITLE
HTTP/3 (QUIC) foundation: Phase 10 (HTTP/3 framing, RFC 9114)

### DIFF
--- a/vlib/net/quic/PROGRESS.md
+++ b/vlib/net/quic/PROGRESS.md
@@ -914,15 +914,79 @@ to a later phase — `stateless_reset.v`/`pmtu.v` both say so independently):
 `QuicConn` holds exactly one local `scid` and tracks the peer's current
 `dcid`, no active CID set, no NEW_CONNECTION_ID/RETIRE_CONNECTION_ID.
 
-## Phases 10-14 (NOT STARTED)
+## Phase 10: HTTP/3 framing (RFC 9114) — CODE COMPLETE, not yet wired to conn.v
+
+Full section-by-section requirements matrix built BEFORE writing any code
+(`.claude/skills/code-review/quic_conformance_matrix.md`, "HTTP/3 framing
+layer" section) — the direct structural response to Phase 9's own
+postmortem ("build the RFC checklist before/during implementation, not
+reactively"). See that section for the complete requirement-by-requirement
+breakdown; summary here.
+
+New files, all in `vlib/net/quic/`:
+
+- [x] `h3_reserved.v` — the single 0x1f*N+0x21 grease-codepoint formula
+      shared identically across frame types (§7.2.8), stream types
+      (§6.2.3), SETTINGS identifiers (§7.2.4.1), and error codes (§8.1) —
+      confirmed byte-for-byte identical wording in all 4 RFC citations
+      before writing one shared helper instead of four copies.
+- [x] `h3_error.v` — `H3ErrorCode` enum, all 17 values (§8.1/Table 4).
+- [x] `h3_stream_type.v` — unidirectional Stream Type header (§6.2/6.2.1/
+      6.2.2/6.2.3): control (0x00), push (0x01 + push ID), reserved,
+      unknown. Incremental (returns `none`, not an error, on a short
+      buffer — RFC places no requirement on how header bytes are split
+      across QUIC STREAM frames).
+- [x] `h3_frame.v` — frame Type/Length envelope (§7.1) + all 7 defined
+      frame types' payloads (DATA/HEADERS/CANCEL_PUSH/SETTINGS/
+      PUSH_PROMISE/GOAWAY/MAX_PUSH_ID, §7.2.1-7.2.7) + the 4 H2-carryover
+      reserved frame types (§7.2.8/Table 2) rejected outright as
+      H3_FRAME_UNEXPECTED, distinct from grease/genuinely-unknown types
+      (§9), which are preserved as `H3RawFrame` and never rejected.
+      `H3FrameDecoder` is the incremental/resumable reader this phase's
+      whole scope centers on — buffers partial bytes across `push()`
+      calls, only ever returns a frame once its FULL declared Length is
+      available. SETTINGS payload parsing rejects duplicate identifiers
+      (a MAY in §7.2.4, chosen to enforce — documented as a choice, not
+      claimed as a literal MUST) and the 5 reserved HTTP/2-carryover
+      setting identifiers (§7.2.4.1/Table 3), while correctly NOT
+      rejecting QPACK's own 0x01/0x07 (RFC 9204, not reserved by 9114
+      itself) so Phase 11 can add them as recognized without touching
+      this reserved set.
+- [x] `h3_message_state.v` — the one piece of §4's message-framing rules
+      that needs only a stream's ROLE, not request/response context:
+      Table 1's per-role frame-type legality (`is_h3_frame_valid_on_stream`)
+      and the control-stream SETTINGS-must-be-first-and-only-once
+      discipline (`H3ControlStreamState`).
+- [x] Tests: one `_test.v` per file, covering round-trips, every reserved/
+      grease/unknown-type boundary, incremental byte-by-byte feeding,
+      truncated/trailing-byte rejection, and a self-caught integer-overflow
+      hardening case (`int(length)` on an attacker-controlled u64 up to
+      2^62-1 could truncate/wrap before ever reaching a real bounds check
+      — fixed and regression-tested before the first real compile, not
+      found by an external round).
+
+**Explicitly deferred to Phase 12** (needs request/response objects, a
+real connection stream registry, or cross-frame state this framing-only
+phase doesn't have — every instance is a matrix row marked `⏳ Phase 12`,
+not a silent gap): §4.1's HEADERS→DATA*→trailer-HEADERS message-content
+sequencing within one request/response; single-request-per-stream
+enforcement; CONNECT's distinct framing; PUSH_PROMISE/CANCEL_PUSH/
+MAX_PUSH_ID cross-frame state (max advertised push ID, push IDs already
+seen); control-stream uniqueness/closure enforcement; unidirectional
+unknown-stream-type abort/discard action; remapping an unrecognized
+received error code to H3_NO_ERROR. **N/A for this v1 client role**
+(confirmed by re-reading which endpoint the requirement binds, not
+assumed): MAX_PUSH_ID's must-not-decrease check (binds a server receiving
+it from a client); a server receiving a client-initiated push stream.
+
+## Phases 11-14 (NOT STARTED)
 
 See the tracking issue for full detail on each. In order:
 
-10. HTTP/3 framing (RFC 9114) — incremental/resumable parsing (structurally
-    different from HTTP/2's single-shot framing).
 11. QPACK (RFC 9204) — absolute indexing, encoder/decoder streams, blocked-
     stream handling. Not HPACK — don't reuse `h2_hpack_static.v`.
-12. HTTP/3 client wiring into `Request`/`Response`/`Transport`.
+12. HTTP/3 client wiring into `Request`/`Response`/`Transport` — also where
+    Phase 10's deferred-state items above actually get wired up.
 13. Server support — explicitly out of committed scope, but Phases 1-9 are
     designed to need no rework for it (`role` field already present).
 14. 0-RTT — explicitly out of committed scope.

--- a/vlib/net/quic/h3_error.v
+++ b/vlib/net/quic/h3_error.v
@@ -1,0 +1,34 @@
+module quic
+
+// H3ErrorCode is the RFC 9114 §8.1 "HTTP/3 Error Codes" registry, used as
+// the QUIC application-protocol error code when abruptly terminating an
+// HTTP/3 stream, aborting a stream read, or closing an HTTP/3 connection.
+// Exact wire values transcribed directly from §8.1 / Table 4 (§11.2.3),
+// not recalled -- every value here was read from the fetched RFC text at
+// `.claude/skills/code-review/rfc-texts/rfc9114.txt`.
+pub enum H3ErrorCode {
+	no_error               = 0x0100
+	general_protocol_error = 0x0101
+	internal_error         = 0x0102
+	stream_creation_error  = 0x0103
+	closed_critical_stream = 0x0104
+	frame_unexpected       = 0x0105
+	frame_error            = 0x0106
+	excessive_load         = 0x0107
+	id_error               = 0x0108
+	settings_error         = 0x0109
+	missing_settings       = 0x010a
+	request_rejected       = 0x010b
+	request_cancelled      = 0x010c
+	request_incomplete     = 0x010d
+	message_error          = 0x010e
+	connect_error          = 0x010f
+	version_fallback       = 0x0110
+}
+
+// code returns the wire value of e as a u64, ready to carry as a QUIC
+// application-protocol error code (RFC 9000 §20.2) in a CONNECTION_CLOSE
+// or RESET_STREAM/STOP_SENDING frame.
+pub fn (e H3ErrorCode) code() u64 {
+	return u64(e)
+}

--- a/vlib/net/quic/h3_frame.v
+++ b/vlib/net/quic/h3_frame.v
@@ -1,0 +1,470 @@
+module quic
+
+// HTTP/3 framing layer (RFC 9114 §7). Unlike QUIC's own frames (frame.v),
+// which are parsed once from an already-fully-buffered, already-decrypted
+// packet payload, HTTP/3 frames ride inside QUIC STREAM frame byte streams
+// and "can span multiple [QUIC] packets" (§7, explicitly called out). This
+// file is split into three layers to match that:
+//   1. the wire-format frame Type/Length header (§7.1) plus per-frame-type
+//      payload structs and their encode/decode (§7.2.1-7.2.8);
+//   2. `H3FrameDecoder`, a small stateful incremental reader that buffers
+//      partial bytes across calls and only ever hands back a frame once its
+//      FULL declared Length is available -- callers (Phase 12) feed it
+//      arbitrarily-sized chunks as they arrive from `StreamReassembler`'s
+//      already-in-order byte stream (no offset-based reordering is needed
+//      here, unlike stream_reassembly.v/crypto_stream.v, since QUIC's own
+//      stream layer already guarantees in-order delivery by the time bytes
+//      reach this layer).
+//
+// Scope note (mirrors this module's existing role-scoping, e.g. ecn.v/
+// stateless_reset.v): only DATA, HEADERS, CANCEL_PUSH, SETTINGS, GOAWAY,
+// and MAX_PUSH_ID get an ENCODER, since those are the only frame types a
+// v1 client role ever originates (§7.2.5: "A client MUST NOT send a
+// PUSH_PROMISE frame" -- omitted here by not providing an encoder for it,
+// rather than a runtime check with no reachable caller to exercise it).
+// Every frame type still gets a DECODER, since a client must be able to
+// recognize (and, at the Phase 12 wiring layer, correctly reject) any
+// frame type table 1 permits on a given stream, regardless of who
+// legitimately originates it.
+
+// --- Frame type registry (RFC 9114 §11.2.1, Table 2) ---
+
+pub const h3_frame_data = u64(0x00)
+pub const h3_frame_headers = u64(0x01)
+pub const h3_frame_cancel_push = u64(0x03)
+pub const h3_frame_settings = u64(0x04)
+pub const h3_frame_push_promise = u64(0x05)
+pub const h3_frame_goaway = u64(0x07)
+pub const h3_frame_max_push_id = u64(0x0d)
+
+// h3_reserved_h2_carryover_frame_types are frame type codepoints HTTP/2
+// used with no HTTP/3 equivalent (§7.2.8/§11.2.1 Table 2: PRIORITY=0x02,
+// PING=0x06, WINDOW_UPDATE=0x08, CONTINUATION=0x09). These are NOT part of
+// the shared 0x1f*N+0x21 grease sequence -- they MUST NOT be sent, and
+// receipt MUST be treated as a connection error of type H3_FRAME_UNEXPECTED
+// (distinct from an ordinary unrecognized/grease type, which must be
+// silently ignored).
+const h3_reserved_h2_carryover_frame_types = [u64(0x02), u64(0x06), u64(0x08), u64(0x09)]
+
+fn is_h3_reserved_h2_carryover_frame_type(frame_type u64) bool {
+	return frame_type in h3_reserved_h2_carryover_frame_types
+}
+
+// --- Per-frame-type payload structs (RFC 9114 §7.2.1-7.2.8) ---
+
+// DataFrame carries content bytes (§7.2.1). Opaque to this layer -- no
+// interpretation of the bytes happens here.
+pub struct DataFrame {
+pub:
+	data []u8
+}
+
+// HeadersFrame carries a QPACK-encoded field section (§7.2.2). QPACK
+// decoding is Phase 11's responsibility; this layer only extracts the
+// still-encoded bytes.
+pub struct HeadersFrame {
+pub:
+	encoded_field_section []u8
+}
+
+// CancelPushFrame identifies a server push to cancel by push ID (§7.2.3).
+pub struct CancelPushFrame {
+pub:
+	push_id u64
+}
+
+// H3Setting is one (identifier, value) pair from a SETTINGS frame's
+// payload (§7.2.4, Figure 7's inner "Setting" struct).
+pub struct H3Setting {
+pub:
+	identifier u64
+	value      u64
+}
+
+// SettingsFrame carries zero or more configuration parameters (§7.2.4).
+// `settings` includes every syntactically valid pair the payload
+// contained, INCLUDING grease and other unrecognized identifiers --
+// deciding what to actually apply is a Phase 12 concern once real
+// connection state exists to apply settings to (see decode_h3_frame_payload
+// doc comment for what IS rejected outright at parse time).
+pub struct SettingsFrame {
+pub:
+	settings []H3Setting
+}
+
+// PushPromiseFrame carries a promised request's push ID and QPACK-encoded
+// header section (§7.2.5). A v1 client role only ever DECODES this (see
+// this file's module-level scope note); no encoder is provided.
+pub struct PushPromiseFrame {
+pub:
+	push_id               u64
+	encoded_field_section []u8
+}
+
+// GoawayFrame carries a single generic id whose meaning depends on
+// direction: a client-initiated bidirectional QUIC stream ID when sent
+// server-to-client, or a push ID when sent client-to-server (§7.2.6).
+// Distinguishing the two, and validating a received stream-ID-flavored
+// GOAWAY, needs connection role context this layer doesn't have -- see
+// `goaway_id_is_valid_client_initiated_bidi_stream_id` for the one piece
+// of that validation that IS pure/role-independent.
+pub struct GoawayFrame {
+pub:
+	id u64
+}
+
+// goaway_id_is_valid_client_initiated_bidi_stream_id reports whether id is
+// legal as the stream-ID-flavored form of a GOAWAY frame (server-to-client
+// direction): RFC 9000 §2.1 encodes a client-initiated bidirectional
+// stream ID as id%4==0. RFC 9114 §7.2.6: "A client MUST treat receipt of a
+// GOAWAY frame containing a stream ID of any other type as a connection
+// error of type H3_ID_ERROR." This is a pure, role-independent predicate;
+// the actual connection-error action belongs to Phase 12's wiring, once a
+// real connection can be role-aware about which GOAWAY variant it expects.
+pub fn goaway_id_is_valid_client_initiated_bidi_stream_id(id u64) bool {
+	return id % 4 == 0
+}
+
+// MaxPushIdFrame sets the maximum push ID a server may use (§7.2.7). A v1
+// client role only ever ENCODES this; decoding exists only so a client can
+// recognize (and, at Phase 12, reject per §7.2.7 "A client MUST treat the
+// receipt of a MAX_PUSH_ID frame as a connection error of type
+// H3_FRAME_UNEXPECTED") a server that incorrectly sends one.
+pub struct MaxPushIdFrame {
+pub:
+	push_id u64
+}
+
+// H3RawFrame preserves any frame this layer does not assign a dedicated
+// struct to: BOTH the reserved-for-grease codepoints (§7.2.8, MUST be
+// ignored) and any genuinely unrecognized extension frame type (§9, MUST
+// also be ignored, per "Implementations MUST ignore unknown or unsupported
+// values in all extensible protocol elements" -- read directly from §9,
+// not assumed by analogy with HTTP/2). H2-carryover reserved types
+// (`h3_reserved_h2_carryover_frame_types`) are NOT represented this way --
+// decoding one of those returns an error instead, since §7.2.8 requires a
+// connection error on receipt, not silent tolerance.
+pub struct H3RawFrame {
+pub:
+	frame_type u64
+	payload    []u8
+}
+
+// H3Frame is any decoded HTTP/3 frame.
+pub type H3Frame = CancelPushFrame
+	| DataFrame
+	| GoawayFrame
+	| H3RawFrame
+	| HeadersFrame
+	| MaxPushIdFrame
+	| PushPromiseFrame
+	| SettingsFrame
+
+// --- Per-type payload decode (RFC 9114 §7.2.1-7.2.8) ---
+
+// decode_h3_frame_payload decodes `payload` (already known to be exactly
+// `frame_type`'s declared Length, per §7.1/§10.8 -- callers such as
+// H3FrameDecoder are responsible for that slicing) into a concrete H3Frame.
+// Returns an error, carrying an H3ErrorCode via `error_with_code`, for:
+//   - an H2-carryover reserved frame type (§7.2.8) -- H3_FRAME_UNEXPECTED;
+//   - a SETTINGS frame whose payload is not an exact sequence of
+//     (identifier, value) varint pairs (§7.1's generic "terminates before
+//     the end of the identified fields" rule) -- H3_FRAME_ERROR;
+//   - a SETTINGS frame containing a duplicate identifier -- H3_SETTINGS_ERROR.
+//     RFC 9114 §7.2.4 states this as a MAY ("A receiver MAY treat the
+//     presence of duplicate setting identifiers as a connection error"),
+//     not a MUST; this implementation chooses to enforce it, matching the
+//     RFC's own stated rationale elsewhere in the document for preferring
+//     strict validation over permissiveness (§4.1.2: "deliberately strict
+//     because being permissive can expose implementations to [...]
+//     vulnerabilities"). Documented here as a deliberate implementation
+//     choice, not presented as a literal MUST;
+//   - a SETTINGS frame containing one of the 5 reserved HTTP/2-carryover
+//     setting identifiers (§7.2.4.1/§11.2.2 Table 3: 0x00, 0x02, 0x03,
+//     0x04, 0x05) -- H3_SETTINGS_ERROR.
+// Every other frame type's payload is a fixed small number of varints
+// (CANCEL_PUSH/GOAWAY/MAX_PUSH_ID: one; PUSH_PROMISE: one varint + the
+// remaining bytes) -- trailing or missing bytes there are likewise
+// H3_FRAME_ERROR per §7.1's generic rule.
+pub fn decode_h3_frame_payload(frame_type u64, payload []u8) !H3Frame {
+	if is_h3_reserved_h2_carryover_frame_type(frame_type) {
+		return error_with_code('h3: frame type 0x${frame_type.hex()} is reserved (HTTP/2 carryover) and MUST NOT be sent',
+			int(H3ErrorCode.frame_unexpected))
+	}
+	match frame_type {
+		h3_frame_data {
+			return DataFrame{
+				data: payload.clone()
+			}
+		}
+		h3_frame_headers {
+			return HeadersFrame{
+				encoded_field_section: payload.clone()
+			}
+		}
+		h3_frame_cancel_push {
+			push_id, n := decode_varint(payload) or {
+				return error_with_code('h3: CANCEL_PUSH frame payload does not contain a valid push ID: ${err.msg()}',
+					int(H3ErrorCode.frame_error))
+			}
+			if n != payload.len {
+				return error_with_code('h3: CANCEL_PUSH frame payload has ${payload.len - n} trailing byte(s) after its push ID',
+					int(H3ErrorCode.frame_error))
+			}
+			return CancelPushFrame{
+				push_id: push_id
+			}
+		}
+		h3_frame_settings {
+			return decode_h3_settings_payload(payload)!
+		}
+		h3_frame_push_promise {
+			push_id, n := decode_varint(payload) or {
+				return error_with_code('h3: PUSH_PROMISE frame payload does not contain a valid push ID: ${err.msg()}',
+					int(H3ErrorCode.frame_error))
+			}
+			return PushPromiseFrame{
+				push_id:               push_id
+				encoded_field_section: payload[n..].clone()
+			}
+		}
+		h3_frame_goaway {
+			id, n := decode_varint(payload) or {
+				return error_with_code('h3: GOAWAY frame payload does not contain a valid stream/push ID: ${err.msg()}',
+					int(H3ErrorCode.frame_error))
+			}
+			if n != payload.len {
+				return error_with_code('h3: GOAWAY frame payload has ${payload.len - n} trailing byte(s) after its ID',
+					int(H3ErrorCode.frame_error))
+			}
+			return GoawayFrame{
+				id: id
+			}
+		}
+		h3_frame_max_push_id {
+			push_id, n := decode_varint(payload) or {
+				return error_with_code('h3: MAX_PUSH_ID frame payload does not contain a valid push ID: ${err.msg()}',
+					int(H3ErrorCode.frame_error))
+			}
+			if n != payload.len {
+				return error_with_code('h3: MAX_PUSH_ID frame payload has ${payload.len - n} trailing byte(s) after its push ID',
+					int(H3ErrorCode.frame_error))
+			}
+			return MaxPushIdFrame{
+				push_id: push_id
+			}
+		}
+		else {
+			return H3RawFrame{
+				frame_type: frame_type
+				payload:    payload.clone()
+			}
+		}
+	}
+}
+
+// h3_settings_reserved_h2_carryover_ids are the 5 setting identifiers
+// HTTP/2 defined with no HTTP/3 equivalent (§7.2.4.1/§11.2.2 Table 3).
+// NOTE: 0x01 and 0x07 are QPACK's SETTINGS_QPACK_MAX_TABLE_CAPACITY /
+// SETTINGS_QPACK_BLOCKED_STREAMS (RFC 9204, not RFC 9114 itself) -- they
+// are deliberately absent from both this reserved list AND from any
+// "known" list in this Phase 10 file; Phase 11 will add them as
+// recognized identifiers without needing to touch this reserved set.
+const h3_settings_reserved_h2_carryover_ids = [u64(0x00), u64(0x02), u64(0x03), u64(0x04), u64(0x05)]
+
+fn is_h3_settings_reserved_h2_carryover_id(id u64) bool {
+	return id in h3_settings_reserved_h2_carryover_ids
+}
+
+// decode_h3_settings_payload decodes a SETTINGS frame's payload (§7.2.4)
+// into its (identifier, value) pairs, enforcing the checks documented on
+// decode_h3_frame_payload.
+fn decode_h3_settings_payload(payload []u8) !SettingsFrame {
+	mut settings := []H3Setting{}
+	mut seen_ids := map[u64]bool{}
+	mut offset := 0
+	for offset < payload.len {
+		identifier, id_len := decode_varint(payload[offset..]) or {
+			return error_with_code('h3: SETTINGS frame payload has a truncated setting identifier at offset ${offset}: ${err.msg()}',
+				int(H3ErrorCode.frame_error))
+		}
+		value, value_len := decode_varint(payload[offset + id_len..]) or {
+			return error_with_code('h3: SETTINGS frame payload has a truncated setting value at offset ${
+				offset + id_len}: ${err.msg()}', int(H3ErrorCode.frame_error))
+		}
+		if is_h3_settings_reserved_h2_carryover_id(identifier) {
+			return error_with_code('h3: SETTINGS frame contains reserved (HTTP/2 carryover) identifier 0x${identifier.hex()}',
+				int(H3ErrorCode.settings_error))
+		}
+		if seen_ids[identifier] {
+			return error_with_code('h3: SETTINGS frame contains duplicate identifier 0x${identifier.hex()}',
+				int(H3ErrorCode.settings_error))
+		}
+		seen_ids[identifier] = true
+		settings << H3Setting{
+			identifier: identifier
+			value:      value
+		}
+		offset += id_len + value_len
+	}
+	return SettingsFrame{
+		settings: settings
+	}
+}
+
+// --- Encode (RFC 9114 §7.1 envelope + §7.2.1-7.2.7 payloads) ---
+//
+// See this file's module-level scope note for why PUSH_PROMISE has no
+// encoder.
+
+// encode_h3_frame_envelope wraps `payload` with its Type/Length header
+// (§7.1, Figure 3). `frame_type` MUST NOT be one of
+// `h3_reserved_h2_carryover_frame_types` -- callers constructing a frame
+// this layer's own encoders produce never pass one of those, so this is
+// checked defensively rather than reachable in normal use.
+fn encode_h3_frame_envelope(frame_type u64, payload []u8) ![]u8 {
+	if is_h3_reserved_h2_carryover_frame_type(frame_type) {
+		return error('h3: internal error: refusing to encode reserved frame type 0x${frame_type.hex()}')
+	}
+	mut out := encode_varint(frame_type)!
+	out << encode_varint(u64(payload.len))!
+	out << payload
+	return out
+}
+
+// encode_data_frame encodes a DATA frame (§7.2.1).
+pub fn encode_data_frame(data []u8) ![]u8 {
+	return encode_h3_frame_envelope(h3_frame_data, data)
+}
+
+// encode_headers_frame encodes a HEADERS frame (§7.2.2) around an
+// already-QPACK-encoded field section (QPACK encoding is Phase 11's
+// responsibility, not this function's).
+pub fn encode_headers_frame(encoded_field_section []u8) ![]u8 {
+	return encode_h3_frame_envelope(h3_frame_headers, encoded_field_section)
+}
+
+// encode_cancel_push_frame encodes a CANCEL_PUSH frame (§7.2.3).
+pub fn encode_cancel_push_frame(push_id u64) ![]u8 {
+	payload := encode_varint(push_id)!
+	return encode_h3_frame_envelope(h3_frame_cancel_push, payload)
+}
+
+// encode_settings_frame encodes a SETTINGS frame (§7.2.4) from an ordered
+// list of settings. Does not itself enforce the duplicate-identifier or
+// reserved-identifier rules decode_h3_settings_payload checks on receipt --
+// a sender controls its own output and is trusted not to construct an
+// invalid frame; validating here too would only be useful for catching an
+// internal bug, not a wire-format concern.
+pub fn encode_settings_frame(settings []H3Setting) ![]u8 {
+	mut payload := []u8{}
+	for s in settings {
+		payload << encode_varint(s.identifier)!
+		payload << encode_varint(s.value)!
+	}
+	return encode_h3_frame_envelope(h3_frame_settings, payload)
+}
+
+// encode_goaway_frame encodes a GOAWAY frame (§7.2.6). See GoawayFrame's
+// doc comment for the direction-dependent meaning of `id`.
+pub fn encode_goaway_frame(id u64) ![]u8 {
+	payload := encode_varint(id)!
+	return encode_h3_frame_envelope(h3_frame_goaway, payload)
+}
+
+// encode_max_push_id_frame encodes a MAX_PUSH_ID frame (§7.2.7).
+pub fn encode_max_push_id_frame(push_id u64) ![]u8 {
+	payload := encode_varint(push_id)!
+	return encode_h3_frame_envelope(h3_frame_max_push_id, payload)
+}
+
+// --- Incremental/resumable decoding (module-level doc comment) ---
+
+// H3FrameDecodeResult is the result of one H3FrameDecoder.next() call.
+// `has_frame` is false whenever `buf`'s buffered bytes do not yet contain a
+// complete frame -- NOT an error condition, since RFC 9114 explicitly
+// allows a frame's Type/Length/Payload to be split arbitrarily across QUIC
+// STREAM frames (§7, "unlike QUIC frames, HTTP/3 frames can span multiple
+// packets"). `frame`/`consumed` are meaningless when `has_frame` is false
+// (defaults to a zero-value H3RawFrame / 0).
+pub struct H3FrameDecodeResult {
+pub:
+	has_frame bool
+	frame     H3Frame = H3RawFrame{}
+	consumed  int
+}
+
+// H3FrameDecoder incrementally decodes a sequence of HTTP/3 frames from an
+// already-in-order byte stream (e.g. the output of a QUIC
+// `StreamReassembler.data()`/read cursor). Bytes are pushed as they
+// arrive; complete frames are popped one at a time via `next()`.
+@[heap]
+pub struct H3FrameDecoder {
+mut:
+	pending []u8
+}
+
+// new_h3_frame_decoder allocates an empty incremental frame decoder.
+pub fn new_h3_frame_decoder() &H3FrameDecoder {
+	return &H3FrameDecoder{}
+}
+
+// push appends newly-received stream bytes to the decoder's internal
+// buffer. Bytes already fully consumed by a prior `next()` call are never
+// re-examined; `push` never itself parses anything.
+pub fn (mut d H3FrameDecoder) push(data []u8) {
+	d.pending << data
+}
+
+// next attempts to decode one complete frame from the front of the
+// currently-buffered bytes. Returns `has_frame: false` (not an error) if
+// the buffered bytes do not yet contain a full frame; the caller should
+// call `push` again once more data has arrived and retry. On success, the
+// decoded frame's bytes are removed from the internal buffer, so a
+// subsequent `next()` call continues from wherever this one left off.
+// Returns an error for a genuine protocol violation (see
+// decode_h3_frame_payload's doc comment) -- the offending bytes are left
+// in the buffer (not consumed) when this happens, so calling `next()`
+// again is harmless and simply reproduces the same error (decoding is a
+// pure function of the buffered bytes). That said, per RFC 9114 §8, any
+// such error is a CONNECTION error: the caller's real obligation is to
+// close the whole HTTP/3 connection, not to keep feeding this decoder.
+pub fn (mut d H3FrameDecoder) next() !H3FrameDecodeResult {
+	frame_type, type_len := decode_varint(d.pending) or { return H3FrameDecodeResult{} }
+	length, length_len := decode_varint(d.pending[type_len..]) or { return H3FrameDecodeResult{} }
+	header_len := type_len + length_len
+	// `length` is attacker-controlled and can legally be up to 2^62-1
+	// (RFC 9000 §16's varint range) -- e.g. a genuinely huge DATA frame
+	// declared before its bytes have actually arrived. Do the "do we have
+	// enough bytes YET" comparison entirely in u64 space; only convert to
+	// `int` once total is proven <= d.pending.len, which is itself a real,
+	// physically-bounded int already. Casting `length` to `int` BEFORE
+	// this comparison would silently truncate/wrap on any value above
+	// ~2^31, making total wrong (possibly negative) and either falsely
+	// reporting "frame ready" on too few bytes or panicking on a negative
+	// slice bound.
+	total_u64 := u64(header_len) + length
+	if total_u64 > u64(d.pending.len) {
+		return H3FrameDecodeResult{}
+	}
+	total := int(total_u64)
+	payload := d.pending[header_len..total]
+	frame := decode_h3_frame_payload(frame_type, payload)!
+	d.pending.delete_many(0, total)
+	return H3FrameDecodeResult{
+		has_frame: true
+		frame:     frame
+		consumed:  total
+	}
+}
+
+// pending_len returns how many not-yet-decoded bytes are currently
+// buffered -- useful for a caller wanting to bound how much unconsumed
+// data it will let a peer accumulate before a complete frame arrives
+// (mirrors crypto_stream.v's max_crypto_stream_buffered_bytes rationale;
+// no such cap is enforced BY this file itself -- see the "Known design
+// notes" row this phase's matrix section adds on why DATA frames in
+// particular must stay uncapped here).
+pub fn (d &H3FrameDecoder) pending_len() int {
+	return d.pending.len
+}

--- a/vlib/net/quic/h3_frame_test.v
+++ b/vlib/net/quic/h3_frame_test.v
@@ -1,3 +1,4 @@
+// vtest build: present_openssl?
 module quic
 
 fn test_data_frame_roundtrip() {

--- a/vlib/net/quic/h3_frame_test.v
+++ b/vlib/net/quic/h3_frame_test.v
@@ -1,0 +1,376 @@
+module quic
+
+fn test_data_frame_roundtrip() {
+	encoded := encode_data_frame([u8(1), 2, 3, 4, 5])!
+	frame := decode_h3_frame_payload(h3_frame_data, encoded[2..])!
+	match frame {
+		DataFrame {
+			assert frame.data == [u8(1), 2, 3, 4, 5]
+		}
+		else {
+			assert false, 'expected DataFrame'
+		}
+	}
+	assert encoded[0] == u8(h3_frame_data)
+	assert encoded[1] == u8(5) // length, 1-byte varint
+}
+
+fn test_headers_frame_roundtrip() {
+	blob := [u8(0xaa), 0xbb, 0xcc]
+	encoded := encode_headers_frame(blob)!
+	frame := decode_h3_frame_payload(h3_frame_headers, encoded[2..])!
+	match frame {
+		HeadersFrame {
+			assert frame.encoded_field_section == blob
+		}
+		else {
+			assert false, 'expected HeadersFrame'
+		}
+	}
+}
+
+fn test_cancel_push_frame_roundtrip() {
+	encoded := encode_cancel_push_frame(42)!
+	frame := decode_h3_frame_payload(h3_frame_cancel_push, encoded[2..])!
+	match frame {
+		CancelPushFrame {
+			assert frame.push_id == 42
+		}
+		else {
+			assert false, 'expected CancelPushFrame'
+		}
+	}
+}
+
+fn test_cancel_push_frame_rejects_trailing_bytes() {
+	mut payload := encode_varint(42)!
+	payload << u8(0xff) // one stray trailing byte
+	if _ := decode_h3_frame_payload(h3_frame_cancel_push, payload) {
+		assert false, 'expected an error for trailing bytes'
+	} else {
+		assert err.code() == int(H3ErrorCode.frame_error)
+	}
+}
+
+fn test_goaway_frame_roundtrip() {
+	encoded := encode_goaway_frame(1234)!
+	frame := decode_h3_frame_payload(h3_frame_goaway, encoded[2..])!
+	match frame {
+		GoawayFrame {
+			assert frame.id == 1234
+		}
+		else {
+			assert false, 'expected GoawayFrame'
+		}
+	}
+}
+
+fn test_goaway_id_is_valid_client_initiated_bidi_stream_id() {
+	assert goaway_id_is_valid_client_initiated_bidi_stream_id(0)
+	assert goaway_id_is_valid_client_initiated_bidi_stream_id(4)
+	assert goaway_id_is_valid_client_initiated_bidi_stream_id(8)
+	// 1: client unidirectional; 2: server-initiated bidi; 3: server
+	// unidirectional -- none of these are legal in a server-to-client
+	// GOAWAY's stream-ID variant.
+	assert !goaway_id_is_valid_client_initiated_bidi_stream_id(1)
+	assert !goaway_id_is_valid_client_initiated_bidi_stream_id(2)
+	assert !goaway_id_is_valid_client_initiated_bidi_stream_id(3)
+	assert !goaway_id_is_valid_client_initiated_bidi_stream_id(5)
+	assert !goaway_id_is_valid_client_initiated_bidi_stream_id(6)
+	assert !goaway_id_is_valid_client_initiated_bidi_stream_id(7)
+}
+
+fn test_max_push_id_frame_roundtrip() {
+	encoded := encode_max_push_id_frame(99)!
+	frame := decode_h3_frame_payload(h3_frame_max_push_id, encoded[2..])!
+	match frame {
+		MaxPushIdFrame {
+			assert frame.push_id == 99
+		}
+		else {
+			assert false, 'expected MaxPushIdFrame'
+		}
+	}
+}
+
+fn test_push_promise_frame_decode_only() {
+	// No encoder exists (v1 client role never sends PUSH_PROMISE, §7.2.5) --
+	// build the payload by hand to exercise the decode path a client still
+	// needs when RECEIVING one from a server.
+	mut payload := encode_varint(77)! // push id
+	payload << [u8(0xde), 0xad, 0xbe, 0xef] // opaque encoded field section
+	frame := decode_h3_frame_payload(h3_frame_push_promise, payload)!
+	match frame {
+		PushPromiseFrame {
+			assert frame.push_id == 77
+			assert frame.encoded_field_section == [u8(0xde), 0xad, 0xbe, 0xef]
+		}
+		else {
+			assert false, 'expected PushPromiseFrame'
+		}
+	}
+}
+
+fn test_settings_frame_roundtrip_and_preserves_order() {
+	settings := [
+		H3Setting{
+			identifier: 0x06
+			value:      16384
+		},
+		H3Setting{
+			identifier: 0x21 // grease -- must round-trip, not be dropped
+			value:      0
+		},
+	]
+	encoded := encode_settings_frame(settings)!
+	frame := decode_h3_frame_payload(h3_frame_settings, encoded[2..])!
+	match frame {
+		SettingsFrame {
+			assert frame.settings.len == 2
+			assert frame.settings[0].identifier == 0x06
+			assert frame.settings[0].value == 16384
+			assert frame.settings[1].identifier == 0x21
+		}
+		else {
+			assert false, 'expected SettingsFrame'
+		}
+	}
+}
+
+fn test_settings_frame_rejects_duplicate_identifier() {
+	mut payload := encode_varint(0x06)!
+	payload << encode_varint(100)!
+	payload << encode_varint(0x06)! // same identifier again
+	payload << encode_varint(200)!
+	if _ := decode_h3_frame_payload(h3_frame_settings, payload) {
+		assert false, 'expected an error for a duplicate identifier'
+	} else {
+		assert err.code() == int(H3ErrorCode.settings_error)
+	}
+}
+
+fn test_settings_frame_rejects_reserved_h2_carryover_identifiers() {
+	reserved_ids := [u64(0x00), 0x02, 0x03, 0x04, 0x05]
+	for id in reserved_ids {
+		mut payload := encode_varint(id)!
+		payload << encode_varint(1)!
+		if _ := decode_h3_frame_payload(h3_frame_settings, payload) {
+			assert false, 'expected an error for reserved identifier 0x${id.hex()}'
+		} else {
+			assert err.code() == int(H3ErrorCode.settings_error)
+		}
+	}
+}
+
+fn test_settings_frame_accepts_unknown_non_reserved_identifier() {
+	// 0x01/0x07 are QPACK's own identifiers (RFC 9204), not reserved by
+	// RFC 9114 -- must be accepted (ignored, not rejected) at this layer.
+	mut payload := encode_varint(0x01)!
+	payload << encode_varint(4096)!
+	frame := decode_h3_frame_payload(h3_frame_settings, payload)!
+	match frame {
+		SettingsFrame {
+			assert frame.settings.len == 1
+			assert frame.settings[0].identifier == 0x01
+		}
+		else {
+			assert false, 'expected SettingsFrame'
+		}
+	}
+}
+
+fn test_settings_frame_rejects_truncated_payload() {
+	mut payload := encode_varint(0x06)!
+	// value varint omitted entirely
+	if _ := decode_h3_frame_payload(h3_frame_settings, payload) {
+		assert false, 'expected an error for a truncated SETTINGS payload'
+	} else {
+		assert err.code() == int(H3ErrorCode.frame_error)
+	}
+}
+
+fn test_settings_frame_empty_payload_is_valid() {
+	// §7.2.4: "zero or more parameters" -- an empty SETTINGS frame is legal.
+	frame := decode_h3_frame_payload(h3_frame_settings, [])!
+	match frame {
+		SettingsFrame {
+			assert frame.settings.len == 0
+		}
+		else {
+			assert false, 'expected SettingsFrame'
+		}
+	}
+}
+
+fn test_decode_rejects_reserved_h2_carryover_frame_types() {
+	reserved := [u64(0x02), 0x06, 0x08, 0x09]
+	for t in reserved {
+		if _ := decode_h3_frame_payload(t, []) {
+			assert false, 'expected an error for reserved frame type 0x${t.hex()}'
+		} else {
+			assert err.code() == int(H3ErrorCode.frame_unexpected)
+		}
+	}
+}
+
+fn test_decode_grease_frame_type_is_ignored_not_rejected() {
+	frame := decode_h3_frame_payload(0x21, [u8(1), 2, 3])!
+	match frame {
+		H3RawFrame {
+			assert frame.frame_type == 0x21
+			assert frame.payload == [u8(1), 2, 3]
+		}
+		else {
+			assert false, 'expected H3RawFrame'
+		}
+	}
+}
+
+fn test_decode_genuinely_unknown_frame_type_is_ignored_not_rejected() {
+	// 0x0a/0x0b/0x0c sit in the gap between the H2-carryover reserved set
+	// and MAX_PUSH_ID (0x0d) -- not defined, not grease, not H2-reserved.
+	frame := decode_h3_frame_payload(0x0a, [u8(9), 9])!
+	match frame {
+		H3RawFrame {
+			assert frame.frame_type == 0x0a
+			assert frame.payload == [u8(9), 9]
+		}
+		else {
+			assert false, 'expected H3RawFrame'
+		}
+	}
+}
+
+fn test_encode_h3_frame_envelope_refuses_reserved_frame_type() {
+	if _ := encode_h3_frame_envelope(0x06, []) {
+		assert false, 'expected an error encoding a reserved frame type'
+	}
+}
+
+fn test_encode_h3_frame_envelope_length_prefix_matches_payload() {
+	payload := []u8{len: 100, init: u8(0x42)}
+	encoded := encode_h3_frame_envelope(h3_frame_data, payload)!
+	length, n := decode_varint(encoded[1..])!
+	assert length == 100
+	assert encoded.len == 1 + n + 100
+}
+
+// --- H3FrameDecoder: incremental / resumable parsing ---
+
+fn test_h3_frame_decoder_returns_no_frame_on_empty_buffer() {
+	mut d := new_h3_frame_decoder()
+	result := d.next()!
+	assert result.has_frame == false
+}
+
+fn test_h3_frame_decoder_waits_for_full_frame_byte_by_byte() {
+	full := encode_data_frame([u8(1), 2, 3, 4, 5])!
+	mut d := new_h3_frame_decoder()
+	for i := 0; i < full.len - 1; i++ {
+		d.push([full[i]])
+		result := d.next()!
+		assert result.has_frame == false, 'expected no frame with ${i + 1}/${full.len} bytes fed'
+	}
+	d.push([full[full.len - 1]])
+	result := d.next()!
+	assert result.has_frame
+	assert result.consumed == full.len
+	match result.frame {
+		DataFrame {
+			assert result.frame.data == [u8(1), 2, 3, 4, 5]
+		}
+		else {
+			assert false, 'expected DataFrame'
+		}
+	}
+}
+
+fn test_h3_frame_decoder_handles_multiple_frames_in_one_push() {
+	mut combined := encode_data_frame([u8(1)])!
+	combined << encode_cancel_push_frame(5)!
+	combined << encode_max_push_id_frame(9)!
+
+	mut d := new_h3_frame_decoder()
+	d.push(combined)
+
+	r1 := d.next()!
+	assert r1.has_frame
+	match r1.frame {
+		DataFrame { assert r1.frame.data == [u8(1)] }
+		else { assert false, 'expected DataFrame first' }
+	}
+
+	r2 := d.next()!
+	assert r2.has_frame
+	match r2.frame {
+		CancelPushFrame { assert r2.frame.push_id == 5 }
+		else { assert false, 'expected CancelPushFrame second' }
+	}
+
+	r3 := d.next()!
+	assert r3.has_frame
+	match r3.frame {
+		MaxPushIdFrame { assert r3.frame.push_id == 9 }
+		else { assert false, 'expected MaxPushIdFrame third' }
+	}
+
+	r4 := d.next()!
+	assert r4.has_frame == false
+	assert d.pending_len() == 0
+}
+
+fn test_h3_frame_decoder_huge_declared_length_with_insufficient_bytes_does_not_panic() {
+	// Regression test for the u64-vs-int overflow this file's own review
+	// caught before first compile: a declared Length near the varint max
+	// (2^62-1) with only a few real bytes buffered must report "not ready
+	// yet", never panic or misreport readiness via a truncated `int` cast.
+	mut buf := encode_varint(h3_frame_data)! // frame type
+	buf << encode_varint(max_varint)! // Length = 2^62-1
+	buf << [u8(1), 2, 3] // far short of that many payload bytes
+
+	mut d := new_h3_frame_decoder()
+	d.push(buf)
+	result := d.next()!
+	assert result.has_frame == false
+	assert d.pending_len() == buf.len
+}
+
+fn test_h3_frame_decoder_returns_error_for_reserved_frame_type_and_stops_consuming() {
+	mut buf := encode_varint(u64(0x06))! // reserved (PING carryover)
+	buf << encode_varint(u64(0))! // zero-length payload
+	mut d := new_h3_frame_decoder()
+	d.push(buf)
+	if _ := d.next() {
+		assert false, 'expected an error for a reserved frame type'
+	} else {
+		assert err.code() == int(H3ErrorCode.frame_unexpected)
+	}
+}
+
+fn test_h3_frame_decoder_settings_split_across_pushes_mid_payload() {
+	full := encode_settings_frame([
+		H3Setting{
+			identifier: 0x06
+			value:      42
+		},
+	])!
+	mut d := new_h3_frame_decoder()
+	// Feed the envelope (type+length) but stop partway through the payload.
+	split_point := full.len - 1
+	d.push(full[..split_point])
+	mid_result := d.next()!
+	assert mid_result.has_frame == false
+
+	d.push(full[split_point..])
+	final_result := d.next()!
+	assert final_result.has_frame
+	match final_result.frame {
+		SettingsFrame {
+			assert final_result.frame.settings.len == 1
+			assert final_result.frame.settings[0].value == 42
+		}
+		else {
+			assert false, 'expected SettingsFrame'
+		}
+	}
+}

--- a/vlib/net/quic/h3_message_state.v
+++ b/vlib/net/quic/h3_message_state.v
@@ -1,0 +1,107 @@
+module quic
+
+// Per-stream frame-legality rules from RFC 9114 §7 (Table 1) and the
+// control-stream discipline in §6.2.1/§7.2.4. These are genuinely part of
+// "the HTTP framing layer" (Table 1 lives inside §7's own text, not §4's
+// message-semantics chapter) and need only a stream's ROLE, not full
+// request/response context -- unlike the rest of §4.1's message framing
+// (HEADERS -> zero-or-more DATA -> optional trailing HEADERS ordering
+// WITHIN one request/response, single-request-per-stream enforcement,
+// CONNECT's different framing), which needs request/response semantic
+// state this phase deliberately does not model. That remainder is Phase
+// 12's responsibility once real request/response objects exist to hold
+// it -- left as an explicit, documented gap here rather than silently
+// unimplemented, per this module's own established practice (see e.g.
+// conn.v's RFC 9002 §6.4 bytes-in-flight note in
+// quic_conformance_matrix.md).
+
+// H3StreamRole is which of HTTP/3's three stream purposes (Table 1's three
+// columns) a stream is currently playing. Determining a stream's role in
+// the first place (reading its unidirectional Stream Type header via
+// h3_stream_type.v, or recognizing it as a client-initiated bidirectional
+// QUIC stream) is a Phase 12 wiring concern; this file only needs to be
+// TOLD the role once known.
+pub enum H3StreamRole {
+	control
+	request
+	push
+}
+
+// is_h3_frame_valid_on_stream reports whether `frame`'s type is permitted
+// on a stream playing `role`, per RFC 9114 §7 Table 1. H3RawFrame (both
+// grease, §7.2.8, and genuinely unrecognized extension types, §9) is valid
+// everywhere: Table 1's own "Reserved" row is Yes/Yes/Yes, and §9 states
+// implementations "MUST ignore unknown or unsupported values in all
+// extensible protocol elements" -- read directly from §9's text, not
+// assumed by analogy with the grease case alone.
+//
+// This function does NOT enforce the SETTINGS-must-be-first-and-only-once
+// rule (that needs per-stream sequencing state across multiple frames, not
+// just this one frame's type) -- see H3ControlStreamState for that.
+pub fn is_h3_frame_valid_on_stream(frame H3Frame, role H3StreamRole) bool {
+	return match frame {
+		DataFrame, HeadersFrame {
+			role == .request || role == .push
+		}
+		CancelPushFrame, SettingsFrame, GoawayFrame, MaxPushIdFrame {
+			role == .control
+		}
+		PushPromiseFrame {
+			role == .request
+		}
+		H3RawFrame {
+			true
+		}
+	}
+}
+
+// H3ControlStreamState tracks the one piece of control-stream discipline
+// that depends on frame ORDER rather than just frame type: SETTINGS "MUST
+// be sent as the first frame of each control stream... and MUST NOT be
+// sent subsequently" (§6.2.1/§7.2.4). One instance is owned per control
+// stream a connection has (its own outgoing one, and the peer's incoming
+// one); frames arriving on a DIFFERENT stream never touch this type at
+// all (is_h3_frame_valid_on_stream already rejects a SETTINGS frame
+// received on a non-control stream independently of this state).
+pub struct H3ControlStreamState {
+mut:
+	seen_first_frame bool
+}
+
+// new_h3_control_stream_state returns a fresh tracker for a control stream
+// that has not yet received (or sent) any frames.
+pub fn new_h3_control_stream_state() H3ControlStreamState {
+	return H3ControlStreamState{}
+}
+
+// note_frame must be called, in stream order, for every frame decoded on
+// this control stream -- BEFORE the caller acts on the frame's contents.
+// Returns an error, carrying an H3ErrorCode via `error_with_code`, when:
+//   - this is the first frame on the stream and it is not SETTINGS
+//     (§6.2.1: "If the first frame of the control stream is any other
+//     frame type, this MUST be treated as a connection error of type
+//     H3_MISSING_SETTINGS"). A grease/unknown H3RawFrame as the first
+//     frame also triggers this -- §9: "where a known frame type is
+//     required to be in a specific location... an unknown frame type does
+//     not satisfy that requirement and SHOULD be treated as an error";
+//   - this is a SECOND (or later) SETTINGS frame on the same stream
+//     (§7.2.4: "it MUST NOT be sent subsequently... the endpoint MUST
+//     respond with a connection error of type H3_FRAME_UNEXPECTED").
+pub fn (mut s H3ControlStreamState) note_frame(frame H3Frame) ! {
+	is_settings := match frame {
+		SettingsFrame { true }
+		else { false }
+	}
+	if !s.seen_first_frame {
+		s.seen_first_frame = true
+		if !is_settings {
+			return error_with_code("h3: control stream's first frame was not SETTINGS",
+				int(H3ErrorCode.missing_settings))
+		}
+		return
+	}
+	if is_settings {
+		return error_with_code('h3: received a second SETTINGS frame on a control stream',
+			int(H3ErrorCode.frame_unexpected))
+	}
+}

--- a/vlib/net/quic/h3_message_state_test.v
+++ b/vlib/net/quic/h3_message_state_test.v
@@ -1,3 +1,4 @@
+// vtest build: present_openssl?
 module quic
 
 fn test_is_h3_frame_valid_on_stream_table1_data_and_headers() {

--- a/vlib/net/quic/h3_message_state_test.v
+++ b/vlib/net/quic/h3_message_state_test.v
@@ -1,0 +1,92 @@
+module quic
+
+fn test_is_h3_frame_valid_on_stream_table1_data_and_headers() {
+	data := H3Frame(DataFrame{})
+	headers := H3Frame(HeadersFrame{})
+	assert !is_h3_frame_valid_on_stream(data, .control)
+	assert is_h3_frame_valid_on_stream(data, .request)
+	assert is_h3_frame_valid_on_stream(data, .push)
+	assert !is_h3_frame_valid_on_stream(headers, .control)
+	assert is_h3_frame_valid_on_stream(headers, .request)
+	assert is_h3_frame_valid_on_stream(headers, .push)
+}
+
+fn test_is_h3_frame_valid_on_stream_table1_control_only_frames() {
+	control_only := [
+		H3Frame(CancelPushFrame{}),
+		H3Frame(SettingsFrame{}),
+		H3Frame(GoawayFrame{}),
+		H3Frame(MaxPushIdFrame{}),
+	]
+	for f in control_only {
+		assert is_h3_frame_valid_on_stream(f, .control)
+		assert !is_h3_frame_valid_on_stream(f, .request)
+		assert !is_h3_frame_valid_on_stream(f, .push)
+	}
+}
+
+fn test_is_h3_frame_valid_on_stream_table1_push_promise() {
+	pp := H3Frame(PushPromiseFrame{})
+	assert !is_h3_frame_valid_on_stream(pp, .control)
+	assert is_h3_frame_valid_on_stream(pp, .request)
+	assert !is_h3_frame_valid_on_stream(pp, .push)
+}
+
+fn test_is_h3_frame_valid_on_stream_reserved_row_is_universal() {
+	raw := H3Frame(H3RawFrame{
+		frame_type: 0x21
+	})
+	assert is_h3_frame_valid_on_stream(raw, .control)
+	assert is_h3_frame_valid_on_stream(raw, .request)
+	assert is_h3_frame_valid_on_stream(raw, .push)
+}
+
+fn test_h3_control_stream_state_accepts_settings_first() {
+	mut s := new_h3_control_stream_state()
+	s.note_frame(H3Frame(SettingsFrame{}))!
+	// A subsequent non-SETTINGS frame is fine.
+	s.note_frame(H3Frame(GoawayFrame{}))!
+}
+
+fn test_h3_control_stream_state_rejects_non_settings_first_frame() {
+	mut s := new_h3_control_stream_state()
+	if _ := s.note_frame(H3Frame(GoawayFrame{})) {
+		assert false, 'expected an error when the first frame is not SETTINGS'
+	} else {
+		assert err.code() == int(H3ErrorCode.missing_settings)
+	}
+}
+
+fn test_h3_control_stream_state_rejects_grease_as_first_frame() {
+	mut s := new_h3_control_stream_state()
+	raw := H3Frame(H3RawFrame{
+		frame_type: 0x21
+	})
+	if _ := s.note_frame(raw) {
+		assert false, 'expected an error when the first frame is grease, not SETTINGS'
+	} else {
+		assert err.code() == int(H3ErrorCode.missing_settings)
+	}
+}
+
+fn test_h3_control_stream_state_rejects_second_settings_frame() {
+	mut s := new_h3_control_stream_state()
+	s.note_frame(H3Frame(SettingsFrame{}))!
+	if _ := s.note_frame(H3Frame(SettingsFrame{})) {
+		assert false, 'expected an error for a second SETTINGS frame'
+	} else {
+		assert err.code() == int(H3ErrorCode.frame_unexpected)
+	}
+}
+
+fn test_h3_control_stream_state_rejects_second_settings_frame_after_other_frames() {
+	mut s := new_h3_control_stream_state()
+	s.note_frame(H3Frame(SettingsFrame{}))!
+	s.note_frame(H3Frame(GoawayFrame{}))!
+	s.note_frame(H3Frame(CancelPushFrame{}))!
+	if _ := s.note_frame(H3Frame(SettingsFrame{})) {
+		assert false, 'expected an error for a second SETTINGS frame after other traffic'
+	} else {
+		assert err.code() == int(H3ErrorCode.frame_unexpected)
+	}
+}

--- a/vlib/net/quic/h3_reserved.v
+++ b/vlib/net/quic/h3_reserved.v
@@ -1,0 +1,28 @@
+module quic
+
+// HTTP/3 (RFC 9114) reserves one identical "grease" codepoint pattern across
+// FOUR independent numeric spaces -- frame types (§7.2.8), unidirectional
+// stream types (§6.2.3), SETTINGS identifiers (§7.2.4.1), and error codes
+// (§8.1) -- specifically so that a well-behaved implementation is forced to
+// exercise its own "ignore what I don't understand" code path. All four
+// citations use byte-for-byte identical wording ("0x1f * N + 0x21 for
+// non-negative integer values of N ... 0x21, 0x40, ..., through
+// 0x3ffffffffffffffe"), confirmed by reading each of §6.2.3/§7.2.4.1/
+// §7.2.8/§8.1 directly rather than assuming they match. One shared helper
+// avoids reimplementing (and risking a transcription slip in) the same
+// formula four times.
+
+// is_h3_reserved_codepoint reports whether v is one of the reserved "grease"
+// values 0x1f*N+0x21 (N = 0, 1, 2, ...) shared by the frame type, stream
+// type, SETTINGS identifier, and error code numeric spaces. These values
+// MUST NOT be assigned meaning by any implementation and MUST NOT be
+// treated as a protocol violation on receipt -- callers use this to route
+// an otherwise-unrecognized codepoint to "ignore silently" rather than
+// "reject as unknown/invalid".
+pub fn is_h3_reserved_codepoint(v u64) bool {
+	if v < 0x21 {
+		return false
+	}
+	remainder := (v - 0x21) % 0x1f
+	return remainder == 0
+}

--- a/vlib/net/quic/h3_reserved_test.v
+++ b/vlib/net/quic/h3_reserved_test.v
@@ -1,3 +1,4 @@
+// vtest build: present_openssl?
 module quic
 
 fn test_is_h3_reserved_codepoint_matches_known_grease_values() {

--- a/vlib/net/quic/h3_reserved_test.v
+++ b/vlib/net/quic/h3_reserved_test.v
@@ -1,0 +1,42 @@
+module quic
+
+fn test_is_h3_reserved_codepoint_matches_known_grease_values() {
+	// RFC 9114 §6.2.3/§7.2.4.1/§7.2.8/§8.1 give the same first few terms
+	// explicitly: 0x21, 0x40, ... through 0x3ffffffffffffffe.
+	assert is_h3_reserved_codepoint(0x21)
+	assert is_h3_reserved_codepoint(0x40)
+	assert is_h3_reserved_codepoint(0x5f)
+	assert is_h3_reserved_codepoint(0x7e)
+	assert is_h3_reserved_codepoint(0x3ffffffffffffffe)
+}
+
+fn test_is_h3_reserved_codepoint_rejects_adjacent_non_grease_values() {
+	// Boundary values immediately next to grease values must NOT match --
+	// this is exactly the off-by-one a modular-arithmetic slip would produce.
+	assert !is_h3_reserved_codepoint(0x20)
+	assert !is_h3_reserved_codepoint(0x22)
+	assert !is_h3_reserved_codepoint(0x3f)
+	assert !is_h3_reserved_codepoint(0x41)
+	assert !is_h3_reserved_codepoint(0x5e)
+	assert !is_h3_reserved_codepoint(0x60)
+}
+
+fn test_is_h3_reserved_codepoint_rejects_defined_values() {
+	// None of the values this phase actually assigns meaning to may ever
+	// collide with the grease sequence -- spot-check the ones in scope.
+	assert !is_h3_reserved_codepoint(0x00) // DATA / control stream type
+	assert !is_h3_reserved_codepoint(0x01) // HEADERS / push stream type
+	assert !is_h3_reserved_codepoint(0x03) // CANCEL_PUSH
+	assert !is_h3_reserved_codepoint(0x04) // SETTINGS
+	assert !is_h3_reserved_codepoint(0x06) // MAX_FIELD_SECTION_SIZE setting
+	assert !is_h3_reserved_codepoint(0x07) // GOAWAY
+	assert !is_h3_reserved_codepoint(0x0d) // MAX_PUSH_ID
+	assert !is_h3_reserved_codepoint(0x0100) // H3_NO_ERROR
+	assert !is_h3_reserved_codepoint(0x0110) // H3_VERSION_FALLBACK
+}
+
+fn test_is_h3_reserved_codepoint_rejects_values_below_first_grease_term() {
+	assert !is_h3_reserved_codepoint(0)
+	assert !is_h3_reserved_codepoint(1)
+	assert !is_h3_reserved_codepoint(0x1f)
+}

--- a/vlib/net/quic/h3_stream_type.v
+++ b/vlib/net/quic/h3_stream_type.v
@@ -1,0 +1,109 @@
+module quic
+
+// RFC 9114 §6.2 — Unidirectional Streams. The purpose of a unidirectional
+// QUIC stream is indicated by a Stream Type varint sent as the first bytes
+// on that stream ("Unidirectional Stream Header", Figure 1); the format of
+// everything after it depends on that type. This file only decodes the
+// header itself -- the two stream types HTTP/3 defines here (control,
+// §6.2.1; push, §6.2.2) carry HTTP/3 frames or push-stream data
+// respectively after their header, which is a Phase 12 wiring concern once
+// a real QuicConn stream registry exists to dispatch into.
+
+// h3_control_stream_type is the Stream Type value that marks a control
+// stream (RFC 9114 §6.2.1).
+pub const h3_control_stream_type = u64(0x00)
+
+// h3_push_stream_type is the Stream Type value that marks a push stream
+// (RFC 9114 §6.2.2); it is immediately followed by the push ID it fulfills.
+pub const h3_push_stream_type = u64(0x01)
+
+// H3UnidirectionalStreamKind classifies a decoded Stream Type value.
+// `reserved` and `unknown` are deliberately distinct even though RFC 9114
+// treats both as "ignore, do not error" (§6.2/§6.2.3): `reserved` values
+// exist SPECIFICALLY to be grease, while `unknown` covers a value this
+// implementation genuinely does not recognize (e.g. a future extension's
+// QPACK-encoder/-decoder stream types, defined by RFC 9204 rather than
+// RFC 9114 itself, or any other extension) -- keeping them apart lets a
+// caller log/count them differently without treating either as an error.
+pub enum H3UnidirectionalStreamKind {
+	control
+	push
+	reserved
+	unknown
+}
+
+// H3UnidirectionalStreamHeader is the decoded result of the first bytes of
+// a unidirectional QUIC stream. `push_id` is only ever set when
+// `kind == .push` (RFC 9114 §6.2.2, Figure 2). `consumed` is the number of
+// bytes of the input buffer the header occupied, so the caller can advance
+// past it to whatever HTTP/3 frames or push-stream data follows.
+pub struct H3UnidirectionalStreamHeader {
+pub:
+	kind     H3UnidirectionalStreamKind
+	raw_type u64
+	push_id  ?u64
+	consumed int
+}
+
+// classify_h3_unidirectional_stream_type maps a raw Stream Type varint
+// value to its H3UnidirectionalStreamKind per RFC 9114 §6.2/§6.2.1/§6.2.2/
+// §6.2.3. Exported separately from the header parser so callers (and
+// tests) can classify a value without needing a full byte buffer.
+pub fn classify_h3_unidirectional_stream_type(raw_type u64) H3UnidirectionalStreamKind {
+	if raw_type == h3_control_stream_type {
+		return .control
+	}
+	if raw_type == h3_push_stream_type {
+		return .push
+	}
+	if is_h3_reserved_codepoint(raw_type) {
+		return .reserved
+	}
+	return .unknown
+}
+
+// parse_h3_unidirectional_stream_header attempts to decode the Stream Type
+// (and, for a push stream, the Push ID that immediately follows it -- RFC
+// 9114 §6.2.2 Figure 2) from the start of `buf`. Returns `none`, not an
+// error, when `buf` does not yet hold enough bytes to complete the header:
+// RFC 9114 places no requirement on how these header bytes are split across
+// QUIC STREAM frames, so a caller reading a fresh unidirectional stream
+// incrementally must be able to retry once more data has arrived rather
+// than treat a short read as a protocol violation (mirrors this file's
+// h3_frame.v incremental frame decoder). On success, the returned header's
+// `consumed` field is the number of bytes it occupied at the START of `buf`.
+pub fn parse_h3_unidirectional_stream_header(buf []u8) ?H3UnidirectionalStreamHeader {
+	raw_type, type_len := decode_varint(buf) or { return none }
+	kind := classify_h3_unidirectional_stream_type(raw_type)
+	if kind == .push {
+		push_id, id_len := decode_varint(buf[type_len..]) or { return none }
+		return H3UnidirectionalStreamHeader{
+			kind:     .push
+			raw_type: raw_type
+			push_id:  push_id
+			consumed: type_len + id_len
+		}
+	}
+	return H3UnidirectionalStreamHeader{
+		kind:     kind
+		raw_type: raw_type
+		push_id:  none
+		consumed: type_len
+	}
+}
+
+// encode_h3_control_stream_header returns the single-varint header a
+// control stream must send as its first bytes (RFC 9114 §6.2.1).
+pub fn encode_h3_control_stream_header() ![]u8 {
+	return encode_varint(h3_control_stream_type)
+}
+
+// encode_h3_push_stream_header returns the Stream Type + Push ID header a
+// push stream must send as its first bytes (RFC 9114 §6.2.2, Figure 2).
+// `push_id` must already satisfy RFC 9000 §16's varint range (2^62-1);
+// encode_varint enforces that and returns an error otherwise.
+pub fn encode_h3_push_stream_header(push_id u64) ![]u8 {
+	mut out := encode_varint(h3_push_stream_type)!
+	out << encode_varint(push_id)!
+	return out
+}

--- a/vlib/net/quic/h3_stream_type_test.v
+++ b/vlib/net/quic/h3_stream_type_test.v
@@ -1,3 +1,4 @@
+// vtest build: present_openssl?
 module quic
 
 fn test_classify_h3_unidirectional_stream_type_known_kinds() {

--- a/vlib/net/quic/h3_stream_type_test.v
+++ b/vlib/net/quic/h3_stream_type_test.v
@@ -1,0 +1,100 @@
+module quic
+
+fn test_classify_h3_unidirectional_stream_type_known_kinds() {
+	assert classify_h3_unidirectional_stream_type(0x00) == .control
+	assert classify_h3_unidirectional_stream_type(0x01) == .push
+	assert classify_h3_unidirectional_stream_type(0x21) == .reserved
+	assert classify_h3_unidirectional_stream_type(0x40) == .reserved
+	// 0x02/0x03 are QPACK's encoder/decoder stream types (RFC 9204) --
+	// unrecognized here since QPACK is Phase 11, but MUST NOT be grease.
+	assert classify_h3_unidirectional_stream_type(0x02) == .unknown
+	assert classify_h3_unidirectional_stream_type(0x03) == .unknown
+	assert classify_h3_unidirectional_stream_type(0xff) == .unknown
+}
+
+fn test_parse_h3_unidirectional_stream_header_control() {
+	buf := [u8(0x00)]
+	header := parse_h3_unidirectional_stream_header(buf) or { panic('expected a decoded header') }
+	assert header.kind == .control
+	assert header.raw_type == 0x00
+	assert header.push_id == none
+	assert header.consumed == 1
+}
+
+fn test_parse_h3_unidirectional_stream_header_push() {
+	encoded := encode_h3_push_stream_header(12345)!
+	header := parse_h3_unidirectional_stream_header(encoded) or {
+		panic('expected a decoded header')
+	}
+	assert header.kind == .push
+	assert header.raw_type == 0x01
+	assert header.push_id? == u64(12345)
+	assert header.consumed == encoded.len
+}
+
+fn test_parse_h3_unidirectional_stream_header_push_id_at_varint_max() {
+	encoded := encode_h3_push_stream_header(max_varint)!
+	header := parse_h3_unidirectional_stream_header(encoded) or {
+		panic('expected a decoded header')
+	}
+	assert header.push_id? == max_varint
+	assert header.consumed == encoded.len
+}
+
+fn test_parse_h3_unidirectional_stream_header_reserved() {
+	buf := [u8(0x21)]
+	header := parse_h3_unidirectional_stream_header(buf) or { panic('expected a decoded header') }
+	assert header.kind == .reserved
+}
+
+// h3_header_is_none is a small test helper: true iff parsing buf returns
+// `none` (not a decoded header) -- V's Option type has no direct `== none`
+// comparison on a plain variable, so this wraps the idiomatic if-unwrap.
+fn h3_header_is_none(buf []u8) bool {
+	if _ := parse_h3_unidirectional_stream_header(buf) {
+		return false
+	}
+	return true
+}
+
+fn test_parse_h3_unidirectional_stream_header_returns_none_on_empty_buffer() {
+	buf := []u8{}
+	assert h3_header_is_none(buf)
+}
+
+fn test_parse_h3_unidirectional_stream_header_returns_none_on_partial_type_varint() {
+	// 0xC0-prefixed first byte declares an 8-byte varint -- one byte alone
+	// is not enough, and this must be "wait for more", not an error.
+	buf := [u8(0xC0)]
+	assert h3_header_is_none(buf)
+}
+
+fn test_parse_h3_unidirectional_stream_header_returns_none_on_partial_push_id() {
+	// Stream Type byte (push, 1 byte) present, but the Push ID varint's
+	// declared length exceeds what's buffered so far.
+	mut buf := [u8(h3_push_stream_type)]
+	buf << u8(0x40) // 2-byte varint prefix, second byte missing
+	assert h3_header_is_none(buf)
+}
+
+fn test_parse_h3_unidirectional_stream_header_incremental_feed_byte_by_byte() {
+	full := encode_h3_push_stream_header(999)!
+	for n in 1 .. full.len {
+		partial := full[..n]
+		assert h3_header_is_none(partial), 'expected none with only ${n}/${full.len} bytes buffered'
+	}
+	header := parse_h3_unidirectional_stream_header(full) or {
+		panic('expected success with the full buffer')
+	}
+	assert header.push_id? == u64(999)
+	assert header.consumed == full.len
+}
+
+fn test_encode_h3_control_stream_header_roundtrip() {
+	encoded := encode_h3_control_stream_header()!
+	header := parse_h3_unidirectional_stream_header(encoded) or {
+		panic('expected a decoded header')
+	}
+	assert header.kind == .control
+	assert header.consumed == encoded.len
+}


### PR DESCRIPTION
## Summary

Phase 10 of the HTTP/3/QUIC implementation (tracking issue #27675): the HTTP/3
framing layer (RFC 9114 §6.2, §7, §8.1, §9, §10.8). All prior phases (0-9) are
merged to master; this branches directly off master, no stacking needed.

Unlike QUIC's own frames (parsed once from an already-fully-buffered,
already-decrypted packet payload), HTTP/3 frames ride inside QUIC STREAM byte
streams and "can span multiple packets" (§7) — this phase's whole scope
centers on `H3FrameDecoder`, an incremental/resumable reader, not a
single-shot parser.

New files (`vlib/net/quic/`), each with a paired `_test.v`:
- `h3_reserved.v` — the shared `0x1f*N+0x21` grease-codepoint formula, used
  identically across frame types, stream types, SETTINGS identifiers, and
  error codes (verified byte-for-byte identical wording in all four RFC
  citations before writing one shared helper instead of four copies).
- `h3_error.v` — `H3ErrorCode`, all 17 values (§8.1/Table 4).
- `h3_stream_type.v` — the unidirectional Stream Type header (§6.2/6.2.1/
  6.2.2/6.2.3): control, push (+ push ID), reserved, unknown. Incremental —
  returns `none`, not an error, on a short buffer.
- `h3_frame.v` — the frame Type/Length envelope (§7.1) + all 7 defined frame
  types' payloads (§7.2.1-7.2.7) + the 4 HTTP/2-carryover reserved frame
  types (§7.2.8, rejected outright as a connection error) vs. grease/
  genuinely-unknown types (§9, preserved and silently ignored, never
  rejected). SETTINGS payload parsing rejects duplicate identifiers and the
  5 reserved HTTP/2-carryover identifiers, while correctly NOT rejecting
  QPACK's own identifiers (RFC 9204, not reserved by 9114 itself) so Phase 11
  can add them without touching this reserved set.
- `h3_message_state.v` — the one piece of §4's message-framing rules that
  needs only a stream's ROLE, not full request/response context: Table 1's
  per-role frame-type legality, and the control-stream
  SETTINGS-must-be-first-and-only-once discipline.

A full requirements matrix (`.claude/skills/code-review/
quic_conformance_matrix.md`, "HTTP/3 framing layer" section) was built
**before** writing any code, listing every requirement in the sections
audited — including explicit N/A-by-role rows (this is a v1 client-only
implementation) and rows deliberately deferred to Phase 12 (cross-frame
state — advertised max push ID, push IDs already seen, control-stream
uniqueness — needs a real connection/request registry this framing-only
phase doesn't have). Nothing is a silent gap.

Self-review caught and fixed a real bug before the first compile: a
declared frame Length is an attacker-controlled u64 up to 2^62-1; casting it
straight to `int` before checking how many bytes were actually buffered
could truncate/wrap on a 32-bit `int`. Fixed by doing the readiness
comparison entirely in u64 space. Regression test:
`test_h3_frame_decoder_huge_declared_length_with_insufficient_bytes_does_not_panic`.

## Test plan

- [x] `./vnew fmt -w` on all touched files
- [x] Full `net.quic` suite green (41/41)
- [x] Full `/vreview` pass (clean beyond the overflow fix and one doc-comment
      correction, both applied during authoring, before this push)
- [x] RFC 9114 conformance matrix built and cross-checked against every row
      before considering the phase complete

🧙 Built with [WOZCODE](https://wozcode.com)