### PR TITLE
all: fix 3 recent issues: Darwin mutexes, pg escaping, comptime or blocks

### DIFF
--- a/vlib/db/pg/README.md
+++ b/vlib/db/pg/README.md
@@ -225,10 +225,13 @@ When an operation cannot use parameters, `escape_literal` returns a complete quo
 literal using libpq's connection-aware escaping:
 
 ```v ignore
-value := db.escape_literal("O'Reilly")!
-row := db.exec_one('INSERT INTO authors (name) VALUES (${value}) RETURNING id')!
+mut conn := db.conn()!
+defer { conn.close() or {} }
+value := conn.escape_literal("O'Reilly")!
+row := conn.exec_one('INSERT INTO authors (name) VALUES (${value}) RETURNING id')!
 ```
 
+Escaping and execution must use the same connection because escaping depends on its settings.
 Prefer parameterized queries whenever possible. Do not add quotes around the returned value.
 
 ## Using LISTEN/NOTIFY

--- a/vlib/db/pg/README.md
+++ b/vlib/db/pg/README.md
@@ -221,6 +221,16 @@ db.exec_param_many('INSERT INTO users (username, password) VALUES ($1, $2)', ['t
 db.exec_param('SELECT * FROM users WHERE username = ($1) limit 1', 'tom')!
 ```
 
+When an operation cannot use parameters, `escape_literal` returns a complete quoted PostgreSQL
+literal using libpq's connection-aware escaping:
+
+```v ignore
+value := db.escape_literal("O'Reilly")!
+row := db.exec_one('INSERT INTO authors (name) VALUES (${value}) RETURNING id')!
+```
+
+Prefer parameterized queries whenever possible. Do not add quotes around the returned value.
+
 ## Using LISTEN/NOTIFY
 
 PostgreSQL's LISTEN/NOTIFY mechanism allows you to build event-driven applications. One

--- a/vlib/db/pg/db.v
+++ b/vlib/db/pg/db.v
@@ -171,6 +171,14 @@ pub fn (mut db DB) q_strings(query string) ![]Row {
 	return db.exec(query)
 }
 
+// escape_literal returns `value` as a quoted PostgreSQL literal using a pooled connection.
+// Prefer parameterized queries when they can express the operation.
+pub fn (mut db DB) escape_literal(value string) !string {
+	mut c := db.pool.acquire()!
+	defer { c.close() or {} }
+	return c.escape_literal(value)
+}
+
 // copy_expert runs a COPY command on a pooled conn.
 pub fn (mut db DB) copy_expert(query string, mut file io.ReaderWriter) !int {
 	mut c := db.pool.acquire()!

--- a/vlib/db/pg/db.v
+++ b/vlib/db/pg/db.v
@@ -171,14 +171,6 @@ pub fn (mut db DB) q_strings(query string) ![]Row {
 	return db.exec(query)
 }
 
-// escape_literal returns `value` as a quoted PostgreSQL literal using a pooled connection.
-// Prefer parameterized queries when they can express the operation.
-pub fn (mut db DB) escape_literal(value string) !string {
-	mut c := db.pool.acquire()!
-	defer { c.close() or {} }
-	return c.escape_literal(value)
-}
-
 // copy_expert runs a COPY command on a pooled conn.
 pub fn (mut db DB) copy_expert(query string, mut file io.ReaderWriter) !int {
 	mut c := db.pool.acquire()!

--- a/vlib/db/pg/pg.c.v
+++ b/vlib/db/pg/pg.c.v
@@ -1027,6 +1027,20 @@ pub fn (c &Conn) unlisten_all() ! {
 	}
 }
 
+// escape_literal returns `value` as a quoted PostgreSQL literal that is safe to interpolate into
+// a query. Prefer parameterized queries when they can express the operation.
+pub fn (c &Conn) escape_literal(value string) !string {
+	c.ensure_active()!
+	escaped := C.PQescapeLiteral(c.conn, &char(value.str), usize(value.len))
+	if escaped == unsafe { nil } {
+		e := unsafe { C.PQerrorMessage(c.conn).vstring() }
+		return error('pg escape_literal error: "${e}"')
+	}
+	result := unsafe { escaped.vstring().clone() }
+	C.PQfreemem(escaped)
+	return result
+}
+
 // notify sends a notification on the specified channel with an optional payload.
 // All connections currently listening on that channel will receive the notification.
 pub fn (c &Conn) notify(channel string, payload string) ! {
@@ -1036,14 +1050,8 @@ pub fn (c &Conn) notify(channel string, payload string) ! {
 	}
 	mut sql_stmt := ''
 	if payload.len > 0 {
-		// Use PQescapeLiteral to safely escape the payload
-		escaped := C.PQescapeLiteral(c.conn, &char(payload.str), usize(payload.len))
-		if escaped == unsafe { nil } {
-			e := unsafe { C.PQerrorMessage(c.conn).vstring() }
-			return error('pg notify error: failed to escape payload: "${e}"')
-		}
-		sql_stmt = unsafe { 'NOTIFY ${channel}, ' + escaped.vstring() + ';' }
-		C.PQfreemem(escaped)
+		escaped := c.escape_literal(payload)!
+		sql_stmt = 'NOTIFY ${channel}, ${escaped};'
 	} else {
 		sql_stmt = 'NOTIFY ${channel};'
 	}

--- a/vlib/db/pg/pg_escape_literal_test.v
+++ b/vlib/db/pg/pg_escape_literal_test.v
@@ -12,9 +12,13 @@ fn test_escape_literal() {
 	defer {
 		db.close() or {}
 	}
+	mut conn := db.conn()!
+	defer {
+		conn.close() or {}
+	}
 
-	escaped := db.escape_literal("O'Reilly")!
+	escaped := conn.escape_literal("O'Reilly")!
 	assert escaped == "'O''Reilly'"
-	rows := db.exec('select ${escaped}')!
+	rows := conn.exec('select ${escaped}')!
 	assert rows[0].val(0) == "O'Reilly"
 }

--- a/vlib/db/pg/pg_escape_literal_test.v
+++ b/vlib/db/pg/pg_escape_literal_test.v
@@ -1,0 +1,20 @@
+module main
+
+import db.pg
+
+fn test_escape_literal() {
+	$if !network ? {
+		eprintln('> Skipping test ${@FN}, since `-d network` is not passed.')
+		eprintln('> This test requires a working postgres server running on localhost.')
+		return
+	}
+	mut db := pg.connect(pg.Config{ user: 'postgres', password: '12345678', dbname: 'postgres' })!
+	defer {
+		db.close() or {}
+	}
+
+	escaped := db.escape_literal("O'Reilly")!
+	assert escaped == "'O''Reilly'"
+	rows := db.exec('select ${escaped}')!
+	assert rows[0].val(0) == "O'Reilly"
+}

--- a/vlib/sync/mutex_zero_value_darwin_test.c.v
+++ b/vlib/sync/mutex_zero_value_darwin_test.c.v
@@ -1,0 +1,14 @@
+import sync
+
+struct MutexHolder {
+mut:
+	mutex sync.Mutex
+}
+
+fn test_zero_value_mutex_is_initialised_on_first_use() {
+	mut holder := &MutexHolder{}
+	assert holder.mutex.try_lock()
+	assert !holder.mutex.try_lock()
+	holder.mutex.unlock()
+	holder.mutex.destroy()
+}

--- a/vlib/sync/sync_darwin.c.v
+++ b/vlib/sync/sync_darwin.c.v
@@ -47,7 +47,8 @@ pub struct C.sem_t {}
 // [init_with=new_mutex] // TODO: implement support for this struct attribute, and disallow Mutex{} from outside the sync.new_mutex() function.
 @[heap]
 pub struct Mutex {
-	mutex C.pthread_mutex_t
+	mutex  C.pthread_mutex_t
+	inited u32
 }
 
 @[heap]
@@ -86,10 +87,22 @@ pub fn new_mutex() &Mutex {
 	return m
 }
 
-// init initialises the mutex. It should be called once before the mutex is used,
-// since it creates the associated resources needed for the mutex to work properly.
+// init initialises the mutex. Calling it on an already initialised mutex has no effect.
 pub fn (mut m Mutex) init() {
-	should_be_zero(C.pthread_mutex_init(&m.mutex, C.NULL))
+	m.lazy_init()
+}
+
+fn (mut m Mutex) lazy_init() {
+	if C.atomic_load_u32(&m.inited) == 2 {
+		return
+	}
+	mut expected := u32(0)
+	if C.atomic_compare_exchange_strong_u32(&m.inited, &expected, 1) {
+		should_be_zero(C.pthread_mutex_init(&m.mutex, C.NULL))
+		C.atomic_store_u32(&m.inited, 2)
+		return
+	}
+	for C.atomic_load_u32(&m.inited) != 2 {}
 }
 
 // new_rwmutex creates a new read/write mutex instance on the heap, and returns a pointer to it.
@@ -126,13 +139,15 @@ fn (mut m RwMutex) lazy_init() {
 // If the mutex was already locked, it will block, till it is unlocked.
 @[inline]
 pub fn (mut m Mutex) lock() {
-	C.pthread_mutex_lock(&m.mutex)
+	m.lazy_init()
+	should_be_zero(C.pthread_mutex_lock(&m.mutex))
 }
 
 // try_lock try to lock the mutex instance and return immediately.
 // If the mutex was already locked, it will return false.
 @[inline]
 pub fn (mut m Mutex) try_lock() bool {
+	m.lazy_init()
 	return C.pthread_mutex_trylock(&m.mutex) == 0
 }
 
@@ -140,13 +155,18 @@ pub fn (mut m Mutex) try_lock() bool {
 // the other threads, that were blocked, because they called lock can continue.
 @[inline]
 pub fn (mut m Mutex) unlock() {
-	C.pthread_mutex_unlock(&m.mutex)
+	should_be_zero(C.pthread_mutex_unlock(&m.mutex))
 }
 
 // destroy frees the resources associated with the mutex instance.
 // Note: the mutex itself is not freed.
 pub fn (mut m Mutex) destroy() {
+	if C.atomic_load_u32(&m.inited) == 0 {
+		return
+	}
+	for C.atomic_load_u32(&m.inited) != 2 {}
 	should_be_zero(C.pthread_mutex_destroy(&m.mutex))
+	C.atomic_store_u32(&m.inited, 0)
 }
 
 // rlock locks the given RwMutex instance for reading.

--- a/vlib/v/tests/options/or_block_comptime_if_issue_28018_test.v
+++ b/vlib/v/tests/options/or_block_comptime_if_issue_28018_test.v
@@ -1,0 +1,21 @@
+fn issue_28018_value(ok bool) !u32 {
+	if ok {
+		return 1
+	}
+	return error('failed')
+}
+
+fn value_with_platform_fallback(ok bool) u32 {
+	value := issue_28018_value(ok) or {
+		$if !windows {
+			panic(err)
+		} $else {
+			u32(0)
+		}
+	}
+	return value
+}
+
+fn test_or_block_with_platform_comptime_if() {
+	assert value_with_platform_fallback(true) == 1
+}

--- a/vlib/v3/v3_test_passes.txt
+++ b/vlib/v3/v3_test_passes.txt
@@ -2462,6 +2462,7 @@ vlib/v/tests/options/option_void_2_test.v
 vlib/v/tests/options/option_void_fn_return_test.v
 vlib/v/tests/options/option_with_error_test.v
 vlib/v/tests/options/or_block_err_var_collision_test.v
+vlib/v/tests/options/or_block_comptime_if_issue_28018_test.v
 vlib/v/tests/options/or_expr_with_comptime_test.v
 vlib/v/tests/options/or_expr_with_multi_stmts_test.v
 vlib/v/tests/options/var_option_arr_test.v


### PR DESCRIPTION
## Summary

- make zero-value `sync.Mutex` fields safe on Darwin with race-safe lazy initialization
- expose PostgreSQL literal escaping through pinned `pg.Conn` values, and reuse it for `NOTIFY` payloads
- add the exact compile-time platform branch/result fallback regression to the shared V1/V3 test corpus

Fixes #28091
Fixes #28035
Fixes #28018

## Tests

- `./vnew -old-compiler vlib/sync/mutex_zero_value_darwin_test.c.v`
- `./vnew vlib/sync/mutex_zero_value_darwin_test.c.v`
- `./vnew -old-compiler vlib/sync/mutex_test.v`
- `./vnew vlib/sync/mutex_test.v`
- `./vnew -old-compiler -d network vlib/db/pg/pg_escape_literal_test.v`
- `./vnew -d network vlib/db/pg/pg_escape_literal_test.v`
- standalone V3 compile and run of `vlib/db/pg/pg_escape_literal_test.v`
- V1 and standalone V3 compile and run of `vlib/v/tests/options/or_block_comptime_if_issue_28018_test.v`
- V1 and standalone V3 Linux C generation for the issue #28018 regression
- `./vnew check-md vlib/db/pg/README.md`

The broader local V3 compiler suites currently hit unrelated failures in existing checker,
codegen, and alias tests; the focused regressions above pass.
