### PR TITLE
v3: add ORM migrations

### DIFF
--- a/vlib/v3/migrations/README.md
+++ b/vlib/v3/migrations/README.md
@@ -72,7 +72,8 @@ removals must use `remove_index()` or raw SQL.
 MySQL auto-increment columns must be primary keys or unique, MySQL index names must be unqualified
 when adding or removing them, and MySQL foreign keys reject `SET DEFAULT`. Column-level identifiers
 must be unqualified. Generated PostgreSQL and MySQL index and foreign-key names are shortened
-deterministically to their dialect limits; overlong explicit names are rejected.
+deterministically to their dialect limits; overlong explicit names are rejected. Caller-supplied
+table, column, and history-table name components are also checked against those dialect limits.
 PostgreSQL and SQLite table rename targets must also be unqualified; MySQL keeps support for
 qualified table targets. MySQL migrations default to non-transactional execution because MySQL DDL
 implicitly commits, and its history strings use hex literals to avoid SQL-mode-sensitive escaping.

--- a/vlib/v3/migrations/README.md
+++ b/vlib/v3/migrations/README.md
@@ -105,3 +105,6 @@ transactions, including `pg.Tx`, are rejected in every transaction mode so the s
 be released before their work commits. Unqualified PostgreSQL history tables resolve an existing
 persistent relation before falling back to the normal creation schema for inspection, creation,
 and lock namespacing. Temporary relations are ignored unless explicitly qualified in `Config.table`.
+MySQL migrations and inspections also reject connections with active transactions. An unqualified
+MySQL history table is resolved and retained on first use, so later database changes on the same
+connection cannot redirect history operations or lock namespacing.

--- a/vlib/v3/migrations/README.md
+++ b/vlib/v3/migrations/README.md
@@ -57,7 +57,10 @@ foreign keys, and trusted raw SQL via `ctx.execute()`. SQLite cannot directly ch
 add/remove a foreign key on an existing table; those helpers return an error so the migration can
 explicitly rebuild the table. PostgreSQL `change_column` supports type-related fields only and
 rejects explicitly supplied constraint options, including false or empty values, before executing
-SQL; use `ctx.execute()` for explicit constraint DDL. MySQL migrations default to non-transactional
-execution because MySQL DDL implicitly commits. The migrator accepts `orm.TransactionalConnection`
-implementations, and `Config.transaction_mode` can override whether their transaction methods are
-used for DDL.
+SQL; use `ctx.execute()` for explicit constraint DDL. MySQL `change_column` requires all optional
+constraint fields because `MODIFY COLUMN` replaces the complete definition, and MySQL
+auto-increment columns must be primary keys or unique. PostgreSQL and SQLite table rename targets
+must be unqualified; MySQL keeps support for qualified targets. MySQL migrations default to
+non-transactional execution because MySQL DDL implicitly commits. The migrator accepts
+`orm.TransactionalConnection` implementations, and `Config.transaction_mode` can override whether
+their transaction methods are used for DDL.

--- a/vlib/v3/migrations/README.md
+++ b/vlib/v3/migrations/README.md
@@ -105,6 +105,8 @@ transactions, including `pg.Tx`, are rejected in every transaction mode so the s
 be released before their work commits. Unqualified PostgreSQL history tables resolve an existing
 persistent relation before falling back to the normal creation schema for inspection, creation,
 and lock namespacing. Temporary relations are ignored unless explicitly qualified in `Config.table`.
+PostgreSQL transactions opened by callbacks in `never` mode are rolled back and rejected before the
+advisory migration lock is released.
 MySQL migrations and inspections also reject connections with active transactions or disabled
 session autocommit. An unqualified MySQL history table is resolved and retained on first use, so
 later database changes on the same connection cannot redirect history operations or lock

--- a/vlib/v3/migrations/README.md
+++ b/vlib/v3/migrations/README.md
@@ -67,7 +67,8 @@ foreign keys, and trusted raw SQL via `ctx.execute()`. SQLite cannot directly ch
 add/remove a foreign key on an existing table; those helpers return an error so the migration can
 explicitly rebuild the table. SQLite `add_column` also rejects primary-key, unique, and
 auto-increment columns, non-nullable columns without a non-NULL default, and nonconstant defaults
-even when prohibited expressions have SQL comments. Parenthesized literal defaults remain allowed.
+even when prohibited expressions have SQL comments or postfix clauses. Parenthesized literal
+defaults remain allowed.
 SQLite index tables and foreign-key targets must be unqualified; index removal derives the index
 schema from a qualified table or resolves an unqualified table using SQLite lookup order.
 PostgreSQL `change_column` supports type-related fields only and rejects explicitly supplied
@@ -96,5 +97,6 @@ The migrator accepts `orm.TransactionalConnection` implementations, and `Config.
 can override whether per-migration transaction methods are used for DDL. SQLite's immediate lock
 transaction still covers each mutating workflow. Migration names containing NUL bytes are rejected
 before any database access. PostgreSQL migrations reject `orm.DB` decorators without probing their
-transactions; pass a direct session-pinned `pg.Conn`. Transaction-managed modes reject an already
-open transaction, including `pg.Tx`; use `.never` when the caller owns the transaction.
+transactions; pass a direct session-pinned `pg.Conn` without an active transaction. Existing
+transactions, including `pg.Tx`, are rejected in every transaction mode so the session lock cannot
+be released before their work commits.

--- a/vlib/v3/migrations/README.md
+++ b/vlib/v3/migrations/README.md
@@ -65,11 +65,13 @@ constant. SQLite index tables and foreign-key targets must be unqualified. Postg
 options, including false or empty values, before executing SQL; use `ctx.execute()` for explicit
 constraint DDL. PostgreSQL serial columns reject explicit defaults, and index removal derives the
 index schema from a qualified table; PostgreSQL index names are unqualified when adding them.
-Decimal scale requires a positive precision. MySQL `change_column` requires all optional constraint
-fields because `MODIFY COLUMN` replaces the complete definition, and MySQL auto-increment columns
-must be primary keys or unique. MySQL foreign keys reject `SET DEFAULT`. Column-level identifiers
-must be unqualified. PostgreSQL and SQLite table rename targets must also be unqualified; MySQL
-keeps support for qualified table targets. MySQL migrations default to non-transactional execution
-because MySQL DDL implicitly commits. The migrator accepts `orm.TransactionalConnection`
-implementations, and `Config.transaction_mode` can override whether per-migration transaction
-methods are used for DDL. SQLite's immediate lock transaction still covers each mutating workflow.
+SQLite non-integer primary keys are explicitly non-nullable. Decimal scale requires a positive
+precision. MySQL `change_column` requires nullable, default, and auto-increment attributes; omitted
+key options are preserved, additions use `true`, and removals must use `remove_index()` or raw SQL.
+MySQL auto-increment columns must be primary keys or unique, MySQL index names must be unqualified,
+and MySQL foreign keys reject `SET DEFAULT`. Column-level identifiers must be unqualified.
+PostgreSQL and SQLite table rename targets must also be unqualified; MySQL keeps support for
+qualified table targets. MySQL migrations default to non-transactional execution because MySQL DDL
+implicitly commits. The migrator accepts `orm.TransactionalConnection` implementations, and
+`Config.transaction_mode` can override whether per-migration transaction methods are used for DDL.
+SQLite's immediate lock transaction still covers each mutating workflow.

--- a/vlib/v3/migrations/README.md
+++ b/vlib/v3/migrations/README.md
@@ -78,10 +78,11 @@ MySQL auto-increment columns must be primary keys or unique, MySQL index names m
 when adding or removing them, and tables cannot contain more than one auto-increment column. MySQL
 foreign keys reject `SET DEFAULT`. Column-level identifiers must be unqualified. Generated
 PostgreSQL and MySQL index and foreign-key names are shortened deterministically to their dialect
-limits; ambiguous index column boundaries receive deterministic hash suffixes, and overlong
-explicit names are rejected. Caller-supplied table, column, and history-table name components are
-also checked against those dialect limits, and qualified table, history, or index names may contain
-at most two components. SQLite and MySQL reject case-insensitive duplicate table columns.
+limits; ambiguous index column boundaries and generated MySQL foreign-key component boundaries
+receive deterministic hash suffixes, and overlong explicit names are rejected. Caller-supplied
+table, column, and history-table name components are also checked against those dialect limits, and
+qualified table, history, or index names may contain at most two components. SQLite and MySQL reject
+case-insensitive duplicate table columns.
 PostgreSQL and SQLite table rename targets must also be unqualified; MySQL keeps support for
 qualified table targets. MySQL migrations default to non-transactional execution because MySQL DDL
 implicitly commits, and its history strings use hex literals to avoid SQL-mode-sensitive escaping.

--- a/vlib/v3/migrations/README.md
+++ b/vlib/v3/migrations/README.md
@@ -8,7 +8,8 @@ Mutating workflows hold a database-level lock from before the applied-version sn
 callbacks and history updates. PostgreSQL uses an advisory lock, MySQL uses a named lock, and
 SQLite uses an immediate transaction so concurrent runners cannot apply the same migration. MySQL
 lock names use a qualified history table's database, or otherwise the current database, so
-independent databases on one server do not contend.
+independent databases on one server do not contend. PostgreSQL lock keys use the full signed 64-bit
+advisory-lock space.
 
 ```v ignore
 import db.sqlite
@@ -61,12 +62,12 @@ The schema helpers include table and column creation/removal/renaming, indexes, 
 foreign keys, and trusted raw SQL via `ctx.execute()`. SQLite cannot directly change a column or
 add/remove a foreign key on an existing table; those helpers return an error so the migration can
 explicitly rebuild the table. SQLite `add_column` also rejects primary-key, unique, and
-auto-increment columns, non-nullable columns without a non-NULL default, and defaults that are not
-constant even when prohibited expressions have SQL comments. SQLite index tables and foreign-key
-targets must be unqualified; index removal derives the index schema from a qualified table.
-PostgreSQL `change_column` supports type-related fields
-only and rejects explicitly supplied constraint options, including false or empty values, before
-executing SQL; use `ctx.execute()` for explicit constraint DDL. PostgreSQL serial columns reject
+auto-increment columns, non-nullable columns without a non-NULL default, and nonconstant defaults
+even when prohibited expressions have SQL comments. Parenthesized literal defaults remain allowed.
+SQLite index tables and foreign-key targets must be unqualified; index removal derives the index
+schema from a qualified table. PostgreSQL `change_column` supports type-related fields only and
+rejects explicitly supplied constraint options, including false or empty values, before executing
+SQL; use `ctx.execute()` for explicit constraint DDL. PostgreSQL serial columns reject
 explicit defaults, and index removal derives the index schema from a qualified table; PostgreSQL
 index names are unqualified when adding them.
 SQLite non-integer primary keys are explicitly non-nullable. Decimal scale requires a positive
@@ -77,10 +78,10 @@ MySQL auto-increment columns must be primary keys or unique, MySQL index names m
 when adding or removing them, and tables cannot contain more than one auto-increment column. MySQL
 foreign keys reject `SET DEFAULT`. Column-level identifiers must be unqualified. Generated
 PostgreSQL and MySQL index and foreign-key names are shortened deterministically to their dialect
-limits; overlong explicit names are rejected. Caller-supplied table, column, and history-table name
-components are also checked against those dialect limits, and qualified table, history, or index
-names may contain at most two components. SQLite and MySQL reject case-insensitive duplicate table
-columns.
+limits; ambiguous index column boundaries receive deterministic hash suffixes, and overlong
+explicit names are rejected. Caller-supplied table, column, and history-table name components are
+also checked against those dialect limits, and qualified table, history, or index names may contain
+at most two components. SQLite and MySQL reject case-insensitive duplicate table columns.
 PostgreSQL and SQLite table rename targets must also be unqualified; MySQL keeps support for
 qualified table targets. MySQL migrations default to non-transactional execution because MySQL DDL
 implicitly commits, and its history strings use hex literals to avoid SQL-mode-sensitive escaping.

--- a/vlib/v3/migrations/README.md
+++ b/vlib/v3/migrations/README.md
@@ -86,7 +86,8 @@ dialect limits, and qualified table, history, or index names may contain at most
 SQLite and MySQL reject case-insensitive duplicate table columns.
 PostgreSQL and SQLite table rename targets must also be unqualified; MySQL keeps support for
 qualified table targets. MySQL migrations default to non-transactional execution because MySQL DDL
-implicitly commits, and its history strings use hex literals to avoid SQL-mode-sensitive escaping.
+implicitly commits. MySQL history strings use hex literals, while PostgreSQL uses explicit escape
+strings with doubled backslashes, avoiding session-mode-sensitive escaping.
 The migrator accepts `orm.TransactionalConnection` implementations, and `Config.transaction_mode`
 can override whether per-migration transaction methods are used for DDL. SQLite's immediate lock
 transaction still covers each mutating workflow.

--- a/vlib/v3/migrations/README.md
+++ b/vlib/v3/migrations/README.md
@@ -63,11 +63,13 @@ auto-increment columns, non-nullable columns without a non-NULL default, and def
 constant. SQLite index tables and foreign-key targets must be unqualified. PostgreSQL
 `change_column` supports type-related fields only and rejects explicitly supplied constraint
 options, including false or empty values, before executing SQL; use `ctx.execute()` for explicit
-constraint DDL. MySQL `change_column` requires all optional constraint fields because `MODIFY
-COLUMN` replaces the complete definition, and MySQL auto-increment columns must be primary keys or
-unique. Column-level identifiers must be unqualified. PostgreSQL and SQLite table rename targets
-must also be unqualified; MySQL keeps support for qualified table targets. MySQL migrations default
-to non-transactional execution because MySQL DDL implicitly commits. The migrator accepts
+constraint DDL. PostgreSQL serial columns reject explicit defaults, and index removal derives the
+index schema from a qualified table. Decimal scale requires a positive precision. MySQL
+`change_column` requires all optional constraint fields because `MODIFY COLUMN` replaces the
+complete definition, and MySQL auto-increment columns must be primary keys or unique. Column-level
+identifiers must be unqualified. PostgreSQL and SQLite table rename targets must also be
+unqualified; MySQL keeps support for qualified table targets. MySQL migrations default to
+non-transactional execution because MySQL DDL implicitly commits. The migrator accepts
 `orm.TransactionalConnection` implementations, and `Config.transaction_mode` can override whether
 per-migration transaction methods are used for DDL. SQLite's immediate lock transaction still
 covers each mutating workflow.

--- a/vlib/v3/migrations/README.md
+++ b/vlib/v3/migrations/README.md
@@ -56,7 +56,8 @@ The schema helpers include table and column creation/removal/renaming, indexes, 
 foreign keys, and trusted raw SQL via `ctx.execute()`. SQLite cannot directly change a column or
 add/remove a foreign key on an existing table; those helpers return an error so the migration can
 explicitly rebuild the table. PostgreSQL `change_column` supports type-related fields only and
-rejects constraint options before executing SQL; use `ctx.execute()` for explicit constraint DDL.
-MySQL migrations default to non-transactional execution because MySQL DDL implicitly commits. The
-migrator accepts `orm.TransactionalConnection` implementations, and `Config.transaction_mode` can
-override whether their transaction methods are used for DDL.
+rejects explicitly supplied constraint options, including false or empty values, before executing
+SQL; use `ctx.execute()` for explicit constraint DDL. MySQL migrations default to non-transactional
+execution because MySQL DDL implicitly commits. The migrator accepts `orm.TransactionalConnection`
+implementations, and `Config.transaction_mode` can override whether their transaction methods are
+used for DDL.

--- a/vlib/v3/migrations/README.md
+++ b/vlib/v3/migrations/README.md
@@ -69,7 +69,8 @@ explicitly rebuild the table. SQLite `add_column` also rejects primary-key, uniq
 auto-increment columns, non-nullable columns without a non-NULL default, and nonconstant defaults
 even when prohibited expressions have unary signs, SQL comments, or postfix clauses.
 Parenthesized and signed literal defaults remain allowed. Numeric defaults require a mantissa and a
-complete exponent; digit separators require SQLite 3.46.0 or newer.
+complete exponent; digit separators require SQLite 3.46.0 or newer. Constant `CAST` expressions are
+also accepted, while casts of functions, column identifiers, or current-time values remain rejected.
 SQLite index tables and foreign-key targets must be unqualified; index removal derives the index
 schema from a qualified table or resolves an unqualified table using SQLite lookup order. Index
 creation resolves the table and qualifies an unqualified index name with the same schema; an

--- a/vlib/v3/migrations/README.md
+++ b/vlib/v3/migrations/README.md
@@ -96,4 +96,5 @@ The migrator accepts `orm.TransactionalConnection` implementations, and `Config.
 can override whether per-migration transaction methods are used for DDL. SQLite's immediate lock
 transaction still covers each mutating workflow. Migration names containing NUL bytes are rejected
 before any database access. PostgreSQL migrations reject `orm.DB` decorators without probing their
-transactions; pass a direct session-pinned `pg.Conn` or `pg.Tx` instead.
+transactions; pass a direct session-pinned `pg.Conn`. Transaction-managed modes reject an already
+open transaction, including `pg.Tx`; use `.never` when the caller owns the transaction.

--- a/vlib/v3/migrations/README.md
+++ b/vlib/v3/migrations/README.md
@@ -107,8 +107,9 @@ persistent relation before falling back to the normal creation schema for inspec
 and lock namespacing. Temporary relations are ignored unless explicitly qualified in `Config.table`.
 PostgreSQL transactions opened by callbacks in `never` mode are rolled back and rejected before the
 advisory migration lock is released. In transactional modes, callbacks cannot end the
-migrator-owned PostgreSQL transaction before history is written. SQLite callbacks likewise cannot
-end the immediate lock transaction before the history write.
+migrator-owned PostgreSQL transaction before history is written. MySQL `always` mode verifies an
+owned savepoint before writing history. SQLite callbacks likewise cannot end or replace the
+original immediate lock transaction before the history write.
 MySQL migrations and inspections also reject connections with active transactions or disabled
 session autocommit. An unqualified MySQL history table is resolved and retained on first use, so
 later database changes on the same connection cannot redirect history operations or lock

--- a/vlib/v3/migrations/README.md
+++ b/vlib/v3/migrations/README.md
@@ -55,6 +55,8 @@ fn create_users(mut ctx migrations.Context) ! {
 The schema helpers include table and column creation/removal/renaming, indexes, inline or altered
 foreign keys, and trusted raw SQL via `ctx.execute()`. SQLite cannot directly change a column or
 add/remove a foreign key on an existing table; those helpers return an error so the migration can
-explicitly rebuild the table. MySQL migrations default to non-transactional execution because
-MySQL DDL implicitly commits. The migrator accepts `orm.TransactionalConnection` implementations,
-and `Config.transaction_mode` can override whether their transaction methods are used for DDL.
+explicitly rebuild the table. PostgreSQL `change_column` supports type-related fields only and
+rejects constraint options before executing SQL; use `ctx.execute()` for explicit constraint DDL.
+MySQL migrations default to non-transactional execution because MySQL DDL implicitly commits. The
+migrator accepts `orm.TransactionalConnection` implementations, and `Config.transaction_mode` can
+override whether their transaction methods are used for DDL.

--- a/vlib/v3/migrations/README.md
+++ b/vlib/v3/migrations/README.md
@@ -10,7 +10,8 @@ SQLite uses an immediate transaction so concurrent runners cannot apply the same
 lock names use a qualified history table's database, or otherwise the current database, so
 independent databases on one server do not contend, and follow the server's
 `lower_case_table_names` mode. PostgreSQL lock keys use the effective history schema and the full
-signed 64-bit advisory-lock space.
+signed 64-bit advisory-lock space. Locked workflows retain that resolved database or schema for all
+history reads and writes, even when a callback changes the connection namespace.
 
 ```v ignore
 import db.sqlite

--- a/vlib/v3/migrations/README.md
+++ b/vlib/v3/migrations/README.md
@@ -68,7 +68,8 @@ add/remove a foreign key on an existing table; those helpers return an error so 
 explicitly rebuild the table. SQLite `add_column` also rejects primary-key, unique, and
 auto-increment columns, non-nullable columns without a non-NULL default, and nonconstant defaults
 even when prohibited expressions have unary signs, SQL comments, or postfix clauses.
-Parenthesized and signed literal defaults remain allowed.
+Parenthesized and signed literal defaults, including SQLite numeric digit separators, remain
+allowed.
 SQLite index tables and foreign-key targets must be unqualified; index removal derives the index
 schema from a qualified table or resolves an unqualified table using SQLite lookup order. Index
 creation resolves the table and qualifies an unqualified index name with the same schema; an

--- a/vlib/v3/migrations/README.md
+++ b/vlib/v3/migrations/README.md
@@ -1,0 +1,60 @@
+# V3 ORM migrations
+
+`v3.migrations` provides ordered, reversible ORM migrations for the V3 compiler. It records
+applied versions in `schema_migrations`, runs each migration in its own transaction when the
+database supports transactional DDL, and supports migrate, rollback, redo, reset, target-version,
+and status workflows.
+
+```v ignore
+import db.sqlite
+import v3.migrations
+
+fn create_users(mut ctx migrations.Context) ! {
+    ctx.create_table(migrations.Table{
+        name: 'users'
+        columns: [
+            migrations.Column{
+                name: 'email'
+                kind: .varchar
+                nullable: false
+            },
+        ]
+    })!
+}
+
+fn drop_users(mut ctx migrations.Context) ! {
+    ctx.drop_table('users')!
+}
+
+mut db := sqlite.connect('app.db')!
+mut migrator := migrations.new(mut db, [
+    migrations.Migration{
+        version: 20260816143000
+        name: 'create_users'
+        up: create_users
+        down: drop_users
+    },
+], migrations.Config{
+    dialect: .sqlite
+})!
+
+migrator.migrate()!
+```
+
+Migration callbacks receive a context that implements `orm.Connection`. Existing ORM DDL and DML
+can therefore be mixed with migration helpers:
+
+```v ignore
+fn create_users(mut ctx migrations.Context) ! {
+    sql ctx {
+        create table User
+    }!
+}
+```
+
+The schema helpers include table and column creation/removal/renaming, indexes, inline or altered
+foreign keys, and trusted raw SQL via `ctx.execute()`. SQLite cannot directly change a column or
+add/remove a foreign key on an existing table; those helpers return an error so the migration can
+explicitly rebuild the table. MySQL migrations default to non-transactional execution because
+MySQL DDL implicitly commits. The migrator accepts `orm.TransactionalConnection` implementations,
+and `Config.transaction_mode` can override whether their transaction methods are used for DDL.

--- a/vlib/v3/migrations/README.md
+++ b/vlib/v3/migrations/README.md
@@ -8,8 +8,9 @@ Mutating workflows hold a database-level lock from before the applied-version sn
 callbacks and history updates. PostgreSQL uses an advisory lock, MySQL uses a named lock, and
 SQLite uses an immediate transaction so concurrent runners cannot apply the same migration. MySQL
 lock names use a qualified history table's database, or otherwise the current database, so
-independent databases on one server do not contend. PostgreSQL lock keys use the effective history
-schema and the full signed 64-bit advisory-lock space.
+independent databases on one server do not contend, and follow the server's
+`lower_case_table_names` mode. PostgreSQL lock keys use the effective history schema and the full
+signed 64-bit advisory-lock space.
 
 ```v ignore
 import db.sqlite

--- a/vlib/v3/migrations/README.md
+++ b/vlib/v3/migrations/README.md
@@ -68,8 +68,8 @@ add/remove a foreign key on an existing table; those helpers return an error so 
 explicitly rebuild the table. SQLite `add_column` also rejects primary-key, unique, and
 auto-increment columns, non-nullable columns without a non-NULL default, and nonconstant defaults
 even when prohibited expressions have unary signs, SQL comments, or postfix clauses.
-Parenthesized and signed literal defaults, including SQLite numeric digit separators, remain
-allowed. Numeric defaults require a mantissa and a complete exponent.
+Parenthesized and signed literal defaults remain allowed. Numeric defaults require a mantissa and a
+complete exponent; digit separators require SQLite 3.46.0 or newer.
 SQLite index tables and foreign-key targets must be unqualified; index removal derives the index
 schema from a qualified table or resolves an unqualified table using SQLite lookup order. Index
 creation resolves the table and qualifies an unqualified index name with the same schema; an
@@ -112,7 +112,7 @@ history is written. MySQL `always` mode verifies an owned savepoint before writi
 callbacks likewise cannot end or replace the original immediate lock transaction before the history
 write.
 MySQL migrations and inspections also reject connections with active transactions or disabled
-session autocommit. An unqualified MySQL history table is resolved and retained on first use, so
-later database changes on the same connection cannot redirect history operations or lock
-namespacing. Callback-created MySQL transaction state is rolled back and rejected before the named
-migration lock is released.
+session autocommit, using a unique savepoint name for each transaction-state probe. An unqualified
+MySQL history table is resolved and retained on first use, so later database changes on the same
+connection cannot redirect history operations or lock namespacing. Callback-created MySQL
+transaction state is rolled back and rejected before the named migration lock is released.

--- a/vlib/v3/migrations/README.md
+++ b/vlib/v3/migrations/README.md
@@ -101,4 +101,5 @@ transaction still covers each mutating workflow. Migration names containing NUL 
 before any database access. PostgreSQL migrations reject `orm.DB` decorators without probing their
 transactions; pass a direct session-pinned `pg.Conn` without an active transaction. Existing
 transactions, including `pg.Tx`, are rejected in every transaction mode so the session lock cannot
-be released before their work commits.
+be released before their work commits. Unqualified PostgreSQL history tables resolve an existing
+visible relation before falling back to the current schema for creation and lock namespacing.

--- a/vlib/v3/migrations/README.md
+++ b/vlib/v3/migrations/README.md
@@ -11,7 +11,8 @@ lock names use a qualified history table's database, or otherwise the current da
 independent databases on one server do not contend, and follow the server's
 `lower_case_table_names` mode. PostgreSQL lock keys use the effective history schema and the full
 signed 64-bit advisory-lock space. Locked workflows retain that resolved database or schema for all
-history reads and writes, even when a callback changes the connection namespace.
+history reads and writes, even when a callback changes the connection namespace. Unqualified SQLite
+history tables are pinned to `main`, preventing TEMP tables from shadowing persistent history.
 
 ```v ignore
 import db.sqlite
@@ -91,4 +92,5 @@ implicitly commits. MySQL history strings use hex literals, while PostgreSQL use
 strings with doubled backslashes, avoiding session-mode-sensitive escaping.
 The migrator accepts `orm.TransactionalConnection` implementations, and `Config.transaction_mode`
 can override whether per-migration transaction methods are used for DDL. SQLite's immediate lock
-transaction still covers each mutating workflow.
+transaction still covers each mutating workflow. Migration names containing NUL bytes are rejected
+before any database access.

--- a/vlib/v3/migrations/README.md
+++ b/vlib/v3/migrations/README.md
@@ -70,7 +70,9 @@ auto-increment columns, non-nullable columns without a non-NULL default, and non
 even when prohibited expressions have unary signs, SQL comments, or postfix clauses.
 Parenthesized and signed literal defaults remain allowed.
 SQLite index tables and foreign-key targets must be unqualified; index removal derives the index
-schema from a qualified table or resolves an unqualified table using SQLite lookup order.
+schema from a qualified table or resolves an unqualified table using SQLite lookup order. Index
+creation resolves the table and qualifies an unqualified index name with the same schema; an
+explicitly qualified index name selects its attached database.
 PostgreSQL `change_column` supports type-related fields only and rejects explicitly supplied
 constraint options, including false or empty values, before executing SQL; use `ctx.execute()` for
 explicit constraint DDL. PostgreSQL serial columns reject

--- a/vlib/v3/migrations/README.md
+++ b/vlib/v3/migrations/README.md
@@ -59,7 +59,8 @@ The schema helpers include table and column creation/removal/renaming, indexes, 
 foreign keys, and trusted raw SQL via `ctx.execute()`. SQLite cannot directly change a column or
 add/remove a foreign key on an existing table; those helpers return an error so the migration can
 explicitly rebuild the table. SQLite `add_column` also rejects primary-key, unique, and
-auto-increment columns, plus non-nullable columns without a non-NULL default. PostgreSQL
+auto-increment columns, non-nullable columns without a non-NULL default, and defaults that are not
+constant. SQLite index tables and foreign-key targets must be unqualified. PostgreSQL
 `change_column` supports type-related fields only and rejects explicitly supplied constraint
 options, including false or empty values, before executing SQL; use `ctx.execute()` for explicit
 constraint DDL. MySQL `change_column` requires all optional constraint fields because `MODIFY

--- a/vlib/v3/migrations/README.md
+++ b/vlib/v3/migrations/README.md
@@ -61,11 +61,12 @@ foreign keys, and trusted raw SQL via `ctx.execute()`. SQLite cannot directly ch
 add/remove a foreign key on an existing table; those helpers return an error so the migration can
 explicitly rebuild the table. SQLite `add_column` also rejects primary-key, unique, and
 auto-increment columns, non-nullable columns without a non-NULL default, and defaults that are not
-constant. SQLite index tables and foreign-key targets must be unqualified. PostgreSQL
-`change_column` supports type-related fields only and rejects explicitly supplied constraint
-options, including false or empty values, before executing SQL; use `ctx.execute()` for explicit
-constraint DDL. PostgreSQL serial columns reject explicit defaults, and index removal derives the
-index schema from a qualified table; PostgreSQL index names are unqualified when adding them.
+constant. SQLite index tables and foreign-key targets must be unqualified; index removal derives
+the index schema from a qualified table. PostgreSQL `change_column` supports type-related fields
+only and rejects explicitly supplied constraint options, including false or empty values, before
+executing SQL; use `ctx.execute()` for explicit constraint DDL. PostgreSQL serial columns reject
+explicit defaults, and index removal derives the index schema from a qualified table; PostgreSQL
+index names are unqualified when adding them.
 SQLite non-integer primary keys are explicitly non-nullable. Decimal scale requires a positive
 precision. MySQL `change_column` requires nullable, default, and auto-increment attributes; omitted
 key options, including those on auto-increment columns, are preserved, additions use `true`, and
@@ -76,7 +77,7 @@ foreign keys reject `SET DEFAULT`. Column-level identifiers must be unqualified.
 PostgreSQL and MySQL index and foreign-key names are shortened deterministically to their dialect
 limits; overlong explicit names are rejected. Caller-supplied table, column, and history-table name
 components are also checked against those dialect limits, and qualified table or history names may
-contain at most two components.
+contain at most two components. SQLite and MySQL reject case-insensitive duplicate table columns.
 PostgreSQL and SQLite table rename targets must also be unqualified; MySQL keeps support for
 qualified table targets. MySQL migrations default to non-transactional execution because MySQL DDL
 implicitly commits, and its history strings use hex literals to avoid SQL-mode-sensitive escaping.

--- a/vlib/v3/migrations/README.md
+++ b/vlib/v3/migrations/README.md
@@ -71,8 +71,8 @@ key options, including those on auto-increment columns, are preserved, additions
 removals must use `remove_index()` or raw SQL.
 MySQL auto-increment columns must be primary keys or unique, MySQL index names must be unqualified
 when adding or removing them, and MySQL foreign keys reject `SET DEFAULT`. Column-level identifiers
-must be unqualified. Generated PostgreSQL and MySQL index names are deterministically shortened to
-their dialect limits; overlong explicit add-index names are rejected.
+must be unqualified. Generated PostgreSQL and MySQL index and foreign-key names are shortened
+deterministically to their dialect limits; overlong explicit names are rejected.
 PostgreSQL and SQLite table rename targets must also be unqualified; MySQL keeps support for
 qualified table targets. MySQL migrations default to non-transactional execution because MySQL DDL
 implicitly commits, and its history strings use hex literals to avoid SQL-mode-sensitive escaping.

--- a/vlib/v3/migrations/README.md
+++ b/vlib/v3/migrations/README.md
@@ -8,8 +8,8 @@ Mutating workflows hold a database-level lock from before the applied-version sn
 callbacks and history updates. PostgreSQL uses an advisory lock, MySQL uses a named lock, and
 SQLite uses an immediate transaction so concurrent runners cannot apply the same migration. MySQL
 lock names use a qualified history table's database, or otherwise the current database, so
-independent databases on one server do not contend. PostgreSQL lock keys use the full signed 64-bit
-advisory-lock space.
+independent databases on one server do not contend. PostgreSQL lock keys use the effective history
+schema and the full signed 64-bit advisory-lock space.
 
 ```v ignore
 import db.sqlite
@@ -78,11 +78,11 @@ MySQL auto-increment columns must be primary keys or unique, MySQL index names m
 when adding or removing them, and tables cannot contain more than one auto-increment column. MySQL
 foreign keys reject `SET DEFAULT`. Column-level identifiers must be unqualified. Generated
 PostgreSQL and MySQL index and foreign-key names are shortened deterministically to their dialect
-limits; ambiguous index column boundaries and generated MySQL foreign-key component boundaries
-receive deterministic hash suffixes, and overlong explicit names are rejected. Caller-supplied
-table, column, and history-table name components are also checked against those dialect limits, and
-qualified table, history, or index names may contain at most two components. SQLite and MySQL reject
-case-insensitive duplicate table columns.
+limits; ambiguous index component boundaries and generated PostgreSQL and MySQL foreign-key
+identities receive deterministic hash suffixes, and overlong explicit names are rejected.
+Caller-supplied table, column, and history-table name components are also checked against those
+dialect limits, and qualified table, history, or index names may contain at most two components.
+SQLite and MySQL reject case-insensitive duplicate table columns.
 PostgreSQL and SQLite table rename targets must also be unqualified; MySQL keeps support for
 qualified table targets. MySQL migrations default to non-transactional execution because MySQL DDL
 implicitly commits, and its history strings use hex literals to avoid SQL-mode-sensitive escaping.

--- a/vlib/v3/migrations/README.md
+++ b/vlib/v3/migrations/README.md
@@ -87,8 +87,8 @@ MySQL auto-increment columns must be primary keys or unique, MySQL index names m
 when adding or removing them, and tables cannot contain more than one auto-increment column. MySQL
 foreign keys reject `SET DEFAULT`. Column-level identifiers must be unqualified. Generated
 PostgreSQL and MySQL index and foreign-key names are shortened deterministically to their dialect
-limits; ambiguous index component boundaries and generated PostgreSQL and MySQL foreign-key
-identities receive deterministic hash suffixes, and overlong explicit names are rejected.
+limits; every generated index name and every generated PostgreSQL or MySQL foreign-key identity
+receives a deterministic component-aware hash suffix, and overlong explicit names are rejected.
 Caller-supplied table, column, and history-table name components are also checked against those
 dialect limits, and qualified table, history, or index names may contain at most two components.
 SQLite and MySQL reject case-insensitive duplicate table columns.
@@ -108,4 +108,5 @@ and lock namespacing. Temporary relations are ignored unless explicitly qualifie
 MySQL migrations and inspections also reject connections with active transactions or disabled
 session autocommit. An unqualified MySQL history table is resolved and retained on first use, so
 later database changes on the same connection cannot redirect history operations or lock
-namespacing.
+namespacing. Callback-created MySQL transaction state is rolled back and rejected before the named
+migration lock is released.

--- a/vlib/v3/migrations/README.md
+++ b/vlib/v3/migrations/README.md
@@ -106,7 +106,9 @@ be released before their work commits. Unqualified PostgreSQL history tables res
 persistent relation before falling back to the normal creation schema for inspection, creation,
 and lock namespacing. Temporary relations are ignored unless explicitly qualified in `Config.table`.
 PostgreSQL transactions opened by callbacks in `never` mode are rolled back and rejected before the
-advisory migration lock is released.
+advisory migration lock is released. In transactional modes, callbacks cannot end the
+migrator-owned PostgreSQL transaction before history is written. SQLite callbacks likewise cannot
+end the immediate lock transaction before the history write.
 MySQL migrations and inspections also reject connections with active transactions or disabled
 session autocommit. An unqualified MySQL history table is resolved and retained on first use, so
 later database changes on the same connection cannot redirect history operations or lock

--- a/vlib/v3/migrations/README.md
+++ b/vlib/v3/migrations/README.md
@@ -1,9 +1,12 @@
 # V3 ORM migrations
 
 `v3.migrations` provides ordered, reversible ORM migrations for the V3 compiler. It records
-applied versions in `schema_migrations`, runs each migration in its own transaction when the
-database supports transactional DDL, and supports migrate, rollback, redo, reset, target-version,
-and status workflows.
+applied versions in `schema_migrations`, uses transactions when the database supports transactional
+DDL, and supports migrate, rollback, redo, reset, target-version, and status workflows.
+
+Mutating workflows hold a database-level lock from before the applied-version snapshot through all
+callbacks and history updates. PostgreSQL uses an advisory lock, MySQL uses a named lock, and
+SQLite uses an immediate transaction so concurrent runners cannot apply the same migration.
 
 ```v ignore
 import db.sqlite
@@ -55,12 +58,15 @@ fn create_users(mut ctx migrations.Context) ! {
 The schema helpers include table and column creation/removal/renaming, indexes, inline or altered
 foreign keys, and trusted raw SQL via `ctx.execute()`. SQLite cannot directly change a column or
 add/remove a foreign key on an existing table; those helpers return an error so the migration can
-explicitly rebuild the table. PostgreSQL `change_column` supports type-related fields only and
-rejects explicitly supplied constraint options, including false or empty values, before executing
-SQL; use `ctx.execute()` for explicit constraint DDL. MySQL `change_column` requires all optional
-constraint fields because `MODIFY COLUMN` replaces the complete definition, and MySQL
-auto-increment columns must be primary keys or unique. PostgreSQL and SQLite table rename targets
-must be unqualified; MySQL keeps support for qualified targets. MySQL migrations default to
-non-transactional execution because MySQL DDL implicitly commits. The migrator accepts
+explicitly rebuild the table. SQLite `add_column` also rejects primary-key, unique, and
+auto-increment columns, plus non-nullable columns without a non-NULL default. PostgreSQL
+`change_column` supports type-related fields only and rejects explicitly supplied constraint
+options, including false or empty values, before executing SQL; use `ctx.execute()` for explicit
+constraint DDL. MySQL `change_column` requires all optional constraint fields because `MODIFY
+COLUMN` replaces the complete definition, and MySQL auto-increment columns must be primary keys or
+unique. Column-level identifiers must be unqualified. PostgreSQL and SQLite table rename targets
+must also be unqualified; MySQL keeps support for qualified table targets. MySQL migrations default
+to non-transactional execution because MySQL DDL implicitly commits. The migrator accepts
 `orm.TransactionalConnection` implementations, and `Config.transaction_mode` can override whether
-their transaction methods are used for DDL.
+per-migration transaction methods are used for DDL. SQLite's immediate lock transaction still
+covers each mutating workflow.

--- a/vlib/v3/migrations/README.md
+++ b/vlib/v3/migrations/README.md
@@ -67,12 +67,15 @@ constraint DDL. PostgreSQL serial columns reject explicit defaults, and index re
 index schema from a qualified table; PostgreSQL index names are unqualified when adding them.
 SQLite non-integer primary keys are explicitly non-nullable. Decimal scale requires a positive
 precision. MySQL `change_column` requires nullable, default, and auto-increment attributes; omitted
-key options are preserved, additions use `true`, and removals must use `remove_index()` or raw SQL.
+key options, including those on auto-increment columns, are preserved, additions use `true`, and
+removals must use `remove_index()` or raw SQL.
 MySQL auto-increment columns must be primary keys or unique, MySQL index names must be unqualified
 when adding or removing them, and MySQL foreign keys reject `SET DEFAULT`. Column-level identifiers
-must be unqualified.
+must be unqualified. Generated PostgreSQL and MySQL index names are deterministically shortened to
+their dialect limits; overlong explicit add-index names are rejected.
 PostgreSQL and SQLite table rename targets must also be unqualified; MySQL keeps support for
 qualified table targets. MySQL migrations default to non-transactional execution because MySQL DDL
-implicitly commits. The migrator accepts `orm.TransactionalConnection` implementations, and
-`Config.transaction_mode` can override whether per-migration transaction methods are used for DDL.
-SQLite's immediate lock transaction still covers each mutating workflow.
+implicitly commits, and its history strings use hex literals to avoid SQL-mode-sensitive escaping.
+The migrator accepts `orm.TransactionalConnection` implementations, and `Config.transaction_mode`
+can override whether per-migration transaction methods are used for DDL. SQLite's immediate lock
+transaction still covers each mutating workflow.

--- a/vlib/v3/migrations/README.md
+++ b/vlib/v3/migrations/README.md
@@ -100,8 +100,9 @@ implicitly commits. MySQL history strings use hex literals, while PostgreSQL use
 strings with doubled backslashes, avoiding session-mode-sensitive escaping.
 The migrator accepts `orm.TransactionalConnection` implementations, and `Config.transaction_mode`
 can override whether per-migration transaction methods are used for DDL. SQLite's immediate lock
-transaction still covers each mutating workflow. Migration names containing NUL bytes are rejected
-before any database access. PostgreSQL migrations reject `orm.DB` decorators without probing their
+transaction still covers each mutating workflow; failed acquisition and commit paths roll back and
+remove their temporary transaction probes. Migration names containing NUL bytes are rejected before
+any database access. PostgreSQL migrations reject `orm.DB` decorators without probing their
 transactions; pass a direct session-pinned `pg.Conn` without an active transaction. Existing
 transactions, including `pg.Tx`, are rejected in every transaction mode so the session lock cannot
 be released before their work commits. Unqualified PostgreSQL history tables resolve an existing

--- a/vlib/v3/migrations/README.md
+++ b/vlib/v3/migrations/README.md
@@ -64,12 +64,12 @@ constant. SQLite index tables and foreign-key targets must be unqualified. Postg
 `change_column` supports type-related fields only and rejects explicitly supplied constraint
 options, including false or empty values, before executing SQL; use `ctx.execute()` for explicit
 constraint DDL. PostgreSQL serial columns reject explicit defaults, and index removal derives the
-index schema from a qualified table. Decimal scale requires a positive precision. MySQL
-`change_column` requires all optional constraint fields because `MODIFY COLUMN` replaces the
-complete definition, and MySQL auto-increment columns must be primary keys or unique. Column-level
-identifiers must be unqualified. PostgreSQL and SQLite table rename targets must also be
-unqualified; MySQL keeps support for qualified table targets. MySQL migrations default to
-non-transactional execution because MySQL DDL implicitly commits. The migrator accepts
-`orm.TransactionalConnection` implementations, and `Config.transaction_mode` can override whether
-per-migration transaction methods are used for DDL. SQLite's immediate lock transaction still
-covers each mutating workflow.
+index schema from a qualified table; PostgreSQL index names are unqualified when adding them.
+Decimal scale requires a positive precision. MySQL `change_column` requires all optional constraint
+fields because `MODIFY COLUMN` replaces the complete definition, and MySQL auto-increment columns
+must be primary keys or unique. MySQL foreign keys reject `SET DEFAULT`. Column-level identifiers
+must be unqualified. PostgreSQL and SQLite table rename targets must also be unqualified; MySQL
+keeps support for qualified table targets. MySQL migrations default to non-transactional execution
+because MySQL DDL implicitly commits. The migrator accepts `orm.TransactionalConnection`
+implementations, and `Config.transaction_mode` can override whether per-migration transaction
+methods are used for DDL. SQLite's immediate lock transaction still covers each mutating workflow.

--- a/vlib/v3/migrations/README.md
+++ b/vlib/v3/migrations/README.md
@@ -7,7 +7,8 @@ DDL, and supports migrate, rollback, redo, reset, target-version, and status wor
 Mutating workflows hold a database-level lock from before the applied-version snapshot through all
 callbacks and history updates. PostgreSQL uses an advisory lock, MySQL uses a named lock, and
 SQLite uses an immediate transaction so concurrent runners cannot apply the same migration. MySQL
-lock names include the current database so independent databases on one server do not contend.
+lock names use a qualified history table's database, or otherwise the current database, so
+independent databases on one server do not contend.
 
 ```v ignore
 import db.sqlite
@@ -61,8 +62,9 @@ foreign keys, and trusted raw SQL via `ctx.execute()`. SQLite cannot directly ch
 add/remove a foreign key on an existing table; those helpers return an error so the migration can
 explicitly rebuild the table. SQLite `add_column` also rejects primary-key, unique, and
 auto-increment columns, non-nullable columns without a non-NULL default, and defaults that are not
-constant. SQLite index tables and foreign-key targets must be unqualified; index removal derives
-the index schema from a qualified table. PostgreSQL `change_column` supports type-related fields
+constant even when prohibited expressions have SQL comments. SQLite index tables and foreign-key
+targets must be unqualified; index removal derives the index schema from a qualified table.
+PostgreSQL `change_column` supports type-related fields
 only and rejects explicitly supplied constraint options, including false or empty values, before
 executing SQL; use `ctx.execute()` for explicit constraint DDL. PostgreSQL serial columns reject
 explicit defaults, and index removal derives the index schema from a qualified table; PostgreSQL
@@ -76,8 +78,9 @@ when adding or removing them, and tables cannot contain more than one auto-incre
 foreign keys reject `SET DEFAULT`. Column-level identifiers must be unqualified. Generated
 PostgreSQL and MySQL index and foreign-key names are shortened deterministically to their dialect
 limits; overlong explicit names are rejected. Caller-supplied table, column, and history-table name
-components are also checked against those dialect limits, and qualified table or history names may
-contain at most two components. SQLite and MySQL reject case-insensitive duplicate table columns.
+components are also checked against those dialect limits, and qualified table, history, or index
+names may contain at most two components. SQLite and MySQL reject case-insensitive duplicate table
+columns.
 PostgreSQL and SQLite table rename targets must also be unqualified; MySQL keeps support for
 qualified table targets. MySQL migrations default to non-transactional execution because MySQL DDL
 implicitly commits, and its history strings use hex literals to avoid SQL-mode-sensitive escaping.

--- a/vlib/v3/migrations/README.md
+++ b/vlib/v3/migrations/README.md
@@ -69,7 +69,7 @@ explicitly rebuild the table. SQLite `add_column` also rejects primary-key, uniq
 auto-increment columns, non-nullable columns without a non-NULL default, and nonconstant defaults
 even when prohibited expressions have unary signs, SQL comments, or postfix clauses.
 Parenthesized and signed literal defaults, including SQLite numeric digit separators, remain
-allowed.
+allowed. Numeric defaults require a mantissa and a complete exponent.
 SQLite index tables and foreign-key targets must be unqualified; index removal derives the index
 schema from a qualified table or resolves an unqualified table using SQLite lookup order. Index
 creation resolves the table and qualifies an unqualified index name with the same schema; an
@@ -106,10 +106,11 @@ be released before their work commits. Unqualified PostgreSQL history tables res
 persistent relation before falling back to the normal creation schema for inspection, creation,
 and lock namespacing. Temporary relations are ignored unless explicitly qualified in `Config.table`.
 PostgreSQL transactions opened by callbacks in `never` mode are rolled back and rejected before the
-advisory migration lock is released. In transactional modes, callbacks cannot end the
-migrator-owned PostgreSQL transaction before history is written. MySQL `always` mode verifies an
-owned savepoint before writing history. SQLite callbacks likewise cannot end or replace the
-original immediate lock transaction before the history write.
+advisory migration lock is released, including when an aborted transaction makes the history write
+fail. In transactional modes, callbacks cannot end the migrator-owned PostgreSQL transaction before
+history is written. MySQL `always` mode verifies an owned savepoint before writing history. SQLite
+callbacks likewise cannot end or replace the original immediate lock transaction before the history
+write.
 MySQL migrations and inspections also reject connections with active transactions or disabled
 session autocommit. An unqualified MySQL history table is resolved and retained on first use, so
 later database changes on the same connection cannot redirect history operations or lock

--- a/vlib/v3/migrations/README.md
+++ b/vlib/v3/migrations/README.md
@@ -95,5 +95,5 @@ strings with doubled backslashes, avoiding session-mode-sensitive escaping.
 The migrator accepts `orm.TransactionalConnection` implementations, and `Config.transaction_mode`
 can override whether per-migration transaction methods are used for DDL. SQLite's immediate lock
 transaction still covers each mutating workflow. Migration names containing NUL bytes are rejected
-before any database access. PostgreSQL `orm.DB` decorators must wrap a session-pinned transactional
-connection, such as `pg.Conn`; pool-backed wrappers are rejected before advisory-lock acquisition.
+before any database access. PostgreSQL migrations reject `orm.DB` decorators without probing their
+transactions; pass a direct session-pinned `pg.Conn` or `pg.Tx` instead.

--- a/vlib/v3/migrations/README.md
+++ b/vlib/v3/migrations/README.md
@@ -68,8 +68,9 @@ index schema from a qualified table; PostgreSQL index names are unqualified when
 SQLite non-integer primary keys are explicitly non-nullable. Decimal scale requires a positive
 precision. MySQL `change_column` requires nullable, default, and auto-increment attributes; omitted
 key options are preserved, additions use `true`, and removals must use `remove_index()` or raw SQL.
-MySQL auto-increment columns must be primary keys or unique, MySQL index names must be unqualified,
-and MySQL foreign keys reject `SET DEFAULT`. Column-level identifiers must be unqualified.
+MySQL auto-increment columns must be primary keys or unique, MySQL index names must be unqualified
+when adding or removing them, and MySQL foreign keys reject `SET DEFAULT`. Column-level identifiers
+must be unqualified.
 PostgreSQL and SQLite table rename targets must also be unqualified; MySQL keeps support for
 qualified table targets. MySQL migrations default to non-transactional execution because MySQL DDL
 implicitly commits. The migrator accepts `orm.TransactionalConnection` implementations, and

--- a/vlib/v3/migrations/README.md
+++ b/vlib/v3/migrations/README.md
@@ -67,8 +67,8 @@ foreign keys, and trusted raw SQL via `ctx.execute()`. SQLite cannot directly ch
 add/remove a foreign key on an existing table; those helpers return an error so the migration can
 explicitly rebuild the table. SQLite `add_column` also rejects primary-key, unique, and
 auto-increment columns, non-nullable columns without a non-NULL default, and nonconstant defaults
-even when prohibited expressions have SQL comments or postfix clauses. Parenthesized literal
-defaults remain allowed.
+even when prohibited expressions have unary signs, SQL comments, or postfix clauses.
+Parenthesized and signed literal defaults remain allowed.
 SQLite index tables and foreign-key targets must be unqualified; index removal derives the index
 schema from a qualified table or resolves an unqualified table using SQLite lookup order.
 PostgreSQL `change_column` supports type-related fields only and rejects explicitly supplied

--- a/vlib/v3/migrations/README.md
+++ b/vlib/v3/migrations/README.md
@@ -10,9 +10,10 @@ SQLite uses an immediate transaction so concurrent runners cannot apply the same
 lock names use a qualified history table's database, or otherwise the current database, so
 independent databases on one server do not contend, and follow the server's
 `lower_case_table_names` mode. PostgreSQL lock keys use the effective history schema and the full
-signed 64-bit advisory-lock space. Locked workflows retain that resolved database or schema for all
-history reads and writes, even when a callback changes the connection namespace. Unqualified SQLite
-history tables are pinned to `main`, preventing TEMP tables from shadowing persistent history.
+signed 64-bit advisory-lock space. A migrator retains its resolved database or schema across
+workflow calls, so callback namespace changes cannot redirect later locks or history access.
+Unqualified SQLite history tables are pinned to `main`, preventing TEMP tables from shadowing
+persistent history.
 
 ```v ignore
 import db.sqlite
@@ -68,9 +69,10 @@ explicitly rebuild the table. SQLite `add_column` also rejects primary-key, uniq
 auto-increment columns, non-nullable columns without a non-NULL default, and nonconstant defaults
 even when prohibited expressions have SQL comments. Parenthesized literal defaults remain allowed.
 SQLite index tables and foreign-key targets must be unqualified; index removal derives the index
-schema from a qualified table. PostgreSQL `change_column` supports type-related fields only and
-rejects explicitly supplied constraint options, including false or empty values, before executing
-SQL; use `ctx.execute()` for explicit constraint DDL. PostgreSQL serial columns reject
+schema from a qualified table or resolves an unqualified table using SQLite lookup order.
+PostgreSQL `change_column` supports type-related fields only and rejects explicitly supplied
+constraint options, including false or empty values, before executing SQL; use `ctx.execute()` for
+explicit constraint DDL. PostgreSQL serial columns reject
 explicit defaults, and index removal derives the index schema from a qualified table; PostgreSQL
 index names are unqualified when adding them.
 SQLite non-integer primary keys are explicitly non-nullable. Decimal scale requires a positive
@@ -93,4 +95,5 @@ strings with doubled backslashes, avoiding session-mode-sensitive escaping.
 The migrator accepts `orm.TransactionalConnection` implementations, and `Config.transaction_mode`
 can override whether per-migration transaction methods are used for DDL. SQLite's immediate lock
 transaction still covers each mutating workflow. Migration names containing NUL bytes are rejected
-before any database access.
+before any database access. PostgreSQL `orm.DB` decorators must wrap a session-pinned transactional
+connection, such as `pg.Conn`; pool-backed wrappers are rejected before advisory-lock acquisition.

--- a/vlib/v3/migrations/README.md
+++ b/vlib/v3/migrations/README.md
@@ -69,9 +69,9 @@ explicitly rebuild the table. SQLite `add_column` also rejects primary-key, uniq
 auto-increment columns, non-nullable columns without a non-NULL default, and nonconstant defaults
 even when prohibited expressions have unary signs, SQL comments, or postfix clauses.
 Parenthesized and signed literal defaults remain allowed. Numeric defaults require a mantissa and a
-complete exponent; digit separators require SQLite 3.46.0 or newer. Constant `CAST` expressions are
-also accepted, while casts resolving to NULL are rejected for NOT NULL columns. Casts of functions,
-column identifiers, or current-time values remain rejected.
+complete exponent; digit separators require SQLite 3.46.0 or newer. Constant `CAST` expressions,
+including signed casts, are also accepted, while casts resolving to NULL are rejected for NOT NULL
+columns. Casts of functions, column identifiers, or current-time values remain rejected.
 SQLite index tables and foreign-key targets must be unqualified; index removal derives the index
 schema from a qualified table or resolves an unqualified table using SQLite lookup order. Index
 creation resolves the table and qualifies an unqualified index name with the same schema; an

--- a/vlib/v3/migrations/README.md
+++ b/vlib/v3/migrations/README.md
@@ -102,4 +102,5 @@ before any database access. PostgreSQL migrations reject `orm.DB` decorators wit
 transactions; pass a direct session-pinned `pg.Conn` without an active transaction. Existing
 transactions, including `pg.Tx`, are rejected in every transaction mode so the session lock cannot
 be released before their work commits. Unqualified PostgreSQL history tables resolve an existing
-visible relation before falling back to the current schema for creation and lock namespacing.
+persistent relation before falling back to the normal creation schema for inspection, creation,
+and lock namespacing. Temporary relations are ignored unless explicitly qualified in `Config.table`.

--- a/vlib/v3/migrations/README.md
+++ b/vlib/v3/migrations/README.md
@@ -6,7 +6,8 @@ DDL, and supports migrate, rollback, redo, reset, target-version, and status wor
 
 Mutating workflows hold a database-level lock from before the applied-version snapshot through all
 callbacks and history updates. PostgreSQL uses an advisory lock, MySQL uses a named lock, and
-SQLite uses an immediate transaction so concurrent runners cannot apply the same migration.
+SQLite uses an immediate transaction so concurrent runners cannot apply the same migration. MySQL
+lock names include the current database so independent databases on one server do not contend.
 
 ```v ignore
 import db.sqlite
@@ -70,10 +71,12 @@ precision. MySQL `change_column` requires nullable, default, and auto-increment 
 key options, including those on auto-increment columns, are preserved, additions use `true`, and
 removals must use `remove_index()` or raw SQL.
 MySQL auto-increment columns must be primary keys or unique, MySQL index names must be unqualified
-when adding or removing them, and MySQL foreign keys reject `SET DEFAULT`. Column-level identifiers
-must be unqualified. Generated PostgreSQL and MySQL index and foreign-key names are shortened
-deterministically to their dialect limits; overlong explicit names are rejected. Caller-supplied
-table, column, and history-table name components are also checked against those dialect limits.
+when adding or removing them, and tables cannot contain more than one auto-increment column. MySQL
+foreign keys reject `SET DEFAULT`. Column-level identifiers must be unqualified. Generated
+PostgreSQL and MySQL index and foreign-key names are shortened deterministically to their dialect
+limits; overlong explicit names are rejected. Caller-supplied table, column, and history-table name
+components are also checked against those dialect limits, and qualified table or history names may
+contain at most two components.
 PostgreSQL and SQLite table rename targets must also be unqualified; MySQL keeps support for
 qualified table targets. MySQL migrations default to non-transactional execution because MySQL DDL
 implicitly commits, and its history strings use hex literals to avoid SQL-mode-sensitive escaping.

--- a/vlib/v3/migrations/README.md
+++ b/vlib/v3/migrations/README.md
@@ -70,7 +70,8 @@ auto-increment columns, non-nullable columns without a non-NULL default, and non
 even when prohibited expressions have unary signs, SQL comments, or postfix clauses.
 Parenthesized and signed literal defaults remain allowed. Numeric defaults require a mantissa and a
 complete exponent; digit separators require SQLite 3.46.0 or newer. Constant `CAST` expressions are
-also accepted, while casts of functions, column identifiers, or current-time values remain rejected.
+also accepted, while casts resolving to NULL are rejected for NOT NULL columns. Casts of functions,
+column identifiers, or current-time values remain rejected.
 SQLite index tables and foreign-key targets must be unqualified; index removal derives the index
 schema from a qualified table or resolves an unqualified table using SQLite lookup order. Index
 creation resolves the table and qualifies an unqualified index name with the same schema; an

--- a/vlib/v3/migrations/README.md
+++ b/vlib/v3/migrations/README.md
@@ -105,6 +105,7 @@ transactions, including `pg.Tx`, are rejected in every transaction mode so the s
 be released before their work commits. Unqualified PostgreSQL history tables resolve an existing
 persistent relation before falling back to the normal creation schema for inspection, creation,
 and lock namespacing. Temporary relations are ignored unless explicitly qualified in `Config.table`.
-MySQL migrations and inspections also reject connections with active transactions. An unqualified
-MySQL history table is resolved and retained on first use, so later database changes on the same
-connection cannot redirect history operations or lock namespacing.
+MySQL migrations and inspections also reject connections with active transactions or disabled
+session autocommit. An unqualified MySQL history table is resolved and retained on first use, so
+later database changes on the same connection cannot redirect history operations or lock
+namespacing.

--- a/vlib/v3/migrations/migrations.v
+++ b/vlib/v3/migrations/migrations.v
@@ -407,7 +407,7 @@ fn (mut m Migrator) ensure_history_table() ! {
 		}
 		.mysql {
 			if m.mysql_lock_name == '' {
-				m.reject_existing_mysql_transaction()!
+				m.validate_mysql_session()!
 			}
 			m.resolve_mysql_history_database()!
 		}
@@ -449,7 +449,7 @@ fn (mut m Migrator) acquire_migration_lock() ! {
 			m.retain_history_relation(.pg, schema)
 		}
 		.mysql {
-			m.reject_existing_mysql_transaction()!
+			m.validate_mysql_session()!
 			database := m.resolve_mysql_history_database()!
 			case_rows := m.conn.execute('SELECT @@lower_case_table_names;')!
 			lower_case_table_names := mysql_lower_case_table_names(case_rows)!
@@ -506,7 +506,11 @@ fn (mut m Migrator) reject_existing_postgresql_transaction() ! {
 	return error('PostgreSQL migrations require a connection without an already-open transaction; pg.Tx and transactional pg.Conn values are not supported')
 }
 
-fn (mut m Migrator) reject_existing_mysql_transaction() ! {
+fn (mut m Migrator) validate_mysql_session() ! {
+	autocommit_rows := m.conn.execute('SELECT @@autocommit;')!
+	if !mysql_autocommit_enabled(autocommit_rows)! {
+		return error('MySQL migrations require session autocommit to be enabled')
+	}
 	probe := 'v3_migrations_transaction_probe'
 	m.conn.orm_savepoint(probe) or {
 		// MySQL rejects the savepoint outside a transaction, or discards it at
@@ -613,6 +617,17 @@ fn mysql_lower_case_table_names(rows []orm.Row) !int {
 		return error('unsupported MySQL lower_case_table_names value `${rows[0].vals[0]}`')
 	}
 	return value
+}
+
+fn mysql_autocommit_enabled(rows []orm.Row) !bool {
+	if rows.len != 1 || rows[0].vals.len == 0 {
+		return error('could not determine MySQL session autocommit state')
+	}
+	return match rows[0].vals[0].to_lower_ascii() {
+		'1', 'on', 'true' { true }
+		'0', 'off', 'false' { false }
+		else { return error('unsupported MySQL session autocommit value `${rows[0].vals[0]}`') }
+	}
 }
 
 fn postgresql_schema_name(rows []orm.Row) !string {

--- a/vlib/v3/migrations/migrations.v
+++ b/vlib/v3/migrations/migrations.v
@@ -467,19 +467,16 @@ fn (mut m Migrator) acquire_migration_lock() ! {
 }
 
 fn (mut m Migrator) reject_existing_postgresql_transaction() ! {
-	if !m.uses_transactions() {
-		return
-	}
 	probe := 'v3_migrations_transaction_probe'
 	m.conn.orm_savepoint(probe) or {
-		// PostgreSQL rejects SAVEPOINT outside a transaction, which is the expected
-		// state when the migrator owns per-migration transactions.
+		// PostgreSQL rejects SAVEPOINT outside a transaction, which is the required
+		// state before the migrator acquires its session lock.
 		return
 	}
 	m.conn.orm_release_savepoint(probe) or {
 		return error('could not release PostgreSQL transaction ownership probe: ${err.msg()}')
 	}
-	return error('PostgreSQL migrations cannot manage transactions on a connection with an already-open transaction (including pg.Tx); use transaction_mode: .never to preserve the caller-owned transaction')
+	return error('PostgreSQL migrations require a connection without an already-open transaction; pg.Tx and transactional pg.Conn values are not supported')
 }
 
 fn (mut m Migrator) retain_history_relation(dialect Dialect, namespace string) {

--- a/vlib/v3/migrations/migrations.v
+++ b/vlib/v3/migrations/migrations.v
@@ -72,11 +72,12 @@ pub:
 // Migrator applies an ordered set of migrations and records their versions.
 pub struct Migrator {
 mut:
-	conn            orm.TransactionalConnection
-	migrations      []Migration
-	config          Config
-	pg_lock_key     ?i64
-	mysql_lock_name string
+	conn                     orm.TransactionalConnection
+	migrations               []Migration
+	config                   Config
+	pg_lock_key              ?i64
+	mysql_lock_name          string
+	locked_history_table_sql string
 }
 
 // new creates and validates a migrator. It does not access the database until
@@ -288,7 +289,7 @@ fn (mut m Migrator) run_unlocked(operation MigrationOperation, argument i64) ![]
 // applied returns the migrations recorded in the database, oldest first.
 pub fn (mut m Migrator) applied() ![]AppliedMigration {
 	m.ensure_history_table()!
-	table := quote_identifier(m.config.dialect, m.config.table)
+	table := m.history_table_sql()
 	rows := m.conn.execute('SELECT version, name, applied_at FROM ${table} ORDER BY version ASC;')!
 	mut result := []AppliedMigration{cap: rows.len}
 	for row in rows {
@@ -391,14 +392,22 @@ fn (m &Migrator) find_migration(version i64) ?Migration {
 }
 
 fn (mut m Migrator) ensure_history_table() ! {
-	table := quote_identifier(m.config.dialect, m.config.table)
+	table := m.history_table_sql()
 	m.conn.execute('CREATE TABLE IF NOT EXISTS ${table} (version BIGINT PRIMARY KEY, name VARCHAR(255) NOT NULL, applied_at VARCHAR(32) NOT NULL);')!
+}
+
+fn (m &Migrator) history_table_sql() string {
+	if m.locked_history_table_sql != '' {
+		return m.locked_history_table_sql
+	}
+	return quote_identifier(m.config.dialect, m.config.table)
 }
 
 fn (mut m Migrator) acquire_migration_lock() ! {
 	match m.config.dialect {
 		.sqlite {
 			m.conn.execute('BEGIN IMMEDIATE;')!
+			m.locked_history_table_sql = quote_identifier(.sqlite, m.config.table)
 		}
 		.pg {
 			schema := if m.config.table.contains('.') {
@@ -410,6 +419,7 @@ fn (mut m Migrator) acquire_migration_lock() ! {
 			key := postgresql_migration_lock_key(schema, m.config.table)
 			m.conn.execute('SELECT pg_advisory_lock(${key});')!
 			m.pg_lock_key = key
+			m.locked_history_table_sql = qualified_history_table_sql(.pg, schema, m.config.table)
 		}
 		.mysql {
 			database := if m.config.table.contains('.') {
@@ -427,6 +437,8 @@ fn (mut m Migrator) acquire_migration_lock() ! {
 				return error('could not acquire MySQL migration lock `${name}` within ${migration_lock_timeout_seconds} seconds')
 			}
 			m.mysql_lock_name = name
+			m.locked_history_table_sql = qualified_history_table_sql(.mysql, database,
+				m.config.table)
 		}
 	}
 }
@@ -463,6 +475,7 @@ fn (mut m Migrator) release_migration_lock(success bool) ! {
 			m.mysql_lock_name = ''
 		}
 	}
+	m.locked_history_table_sql = ''
 }
 
 fn migration_lock_key(identity string) i64 {
@@ -477,6 +490,12 @@ fn postgresql_migration_lock_key(schema string, table string) i64 {
 	table_name := if table.contains('.') { table.all_after('.') } else { table }
 	identity := '${schema.len}:${schema}:${table_name.len}:${table_name}'
 	return migration_lock_key(identity)
+}
+
+fn qualified_history_table_sql(dialect Dialect, namespace string, table string) string {
+	table_name := if table.contains('.') { table.all_after('.') } else { table }
+	return '${quote_identifier_component(dialect, namespace)}.${quote_identifier_component(dialect,
+		table_name)}'
 }
 
 fn mysql_migration_lock_name(database string, table string, lower_case_table_names int) string {
@@ -589,13 +608,13 @@ fn (mut m Migrator) run_down(migration Migration) ! {
 }
 
 fn (m &Migrator) history_insert_sql(migration Migration, applied_at string) string {
-	table := quote_identifier(m.config.dialect, m.config.table)
+	table := m.history_table_sql()
 	name := string_literal_sql(m.config.dialect, migration.name)
 	timestamp := string_literal_sql(m.config.dialect, applied_at)
 	return 'INSERT INTO ${table} (version, name, applied_at) VALUES (${migration.version}, ${name}, ${timestamp});'
 }
 
 fn (m &Migrator) history_delete_sql(version i64) string {
-	table := quote_identifier(m.config.dialect, m.config.table)
+	table := m.history_table_sql()
 	return 'DELETE FROM ${table} WHERE version = ${version};'
 }

--- a/vlib/v3/migrations/migrations.v
+++ b/vlib/v3/migrations/migrations.v
@@ -75,6 +75,7 @@ mut:
 	conn            orm.TransactionalConnection
 	migrations      []Migration
 	config          Config
+	pg_lock_key     ?i64
 	mysql_lock_name string
 }
 
@@ -395,13 +396,20 @@ fn (mut m Migrator) ensure_history_table() ! {
 }
 
 fn (mut m Migrator) acquire_migration_lock() ! {
-	key := migration_lock_key(m.config.table)
 	match m.config.dialect {
 		.sqlite {
 			m.conn.execute('BEGIN IMMEDIATE;')!
 		}
 		.pg {
+			schema := if m.config.table.contains('.') {
+				m.config.table.all_before('.')
+			} else {
+				schema_rows := m.conn.execute('SELECT current_schema();')!
+				postgresql_schema_name(schema_rows)!
+			}
+			key := postgresql_migration_lock_key(schema, m.config.table)
 			m.conn.execute('SELECT pg_advisory_lock(${key});')!
+			m.pg_lock_key = key
 		}
 		.mysql {
 			database := if m.config.table.contains('.') {
@@ -422,7 +430,6 @@ fn (mut m Migrator) acquire_migration_lock() ! {
 }
 
 fn (mut m Migrator) release_migration_lock(success bool) ! {
-	key := migration_lock_key(m.config.table)
 	match m.config.dialect {
 		.sqlite {
 			if success {
@@ -432,10 +439,15 @@ fn (mut m Migrator) release_migration_lock(success bool) ! {
 			}
 		}
 		.pg {
+			key := m.pg_lock_key or {
+				return error('cannot release PostgreSQL migration lock before it is acquired')
+			}
+
 			rows := m.conn.execute('SELECT pg_advisory_unlock(${key});')!
 			if !migration_lock_result(rows) {
 				return error('could not release PostgreSQL migration lock ${key}')
 			}
+			m.pg_lock_key = none
 		}
 		.mysql {
 			name := m.mysql_lock_name
@@ -451,12 +463,18 @@ fn (mut m Migrator) release_migration_lock(success bool) ! {
 	}
 }
 
-fn migration_lock_key(table string) i64 {
-	hash := fnv1a.sum64_string(table)
+fn migration_lock_key(identity string) i64 {
+	hash := fnv1a.sum64_string(identity)
 	if hash <= u64(max_i64) {
 		return i64(hash)
 	}
 	return -i64(~hash) - 1
+}
+
+fn postgresql_migration_lock_key(schema string, table string) i64 {
+	table_name := if table.contains('.') { table.all_after('.') } else { table }
+	identity := '${schema.len}:${schema}:${table_name.len}:${table_name}'
+	return migration_lock_key(identity)
 }
 
 fn mysql_migration_lock_name(database string, table string) string {
@@ -468,6 +486,13 @@ fn mysql_migration_lock_name(database string, table string) string {
 fn mysql_database_name(rows []orm.Row) !string {
 	if rows.len != 1 || rows[0].vals.len == 0 || rows[0].vals[0] == '' {
 		return error('could not determine current MySQL database for migration lock')
+	}
+	return rows[0].vals[0]
+}
+
+fn postgresql_schema_name(rows []orm.Row) !string {
+	if rows.len != 1 || rows[0].vals.len == 0 || rows[0].vals[0] == '' {
+		return error('could not determine current PostgreSQL schema for migration lock')
 	}
 	return rows[0].vals[0]
 }

--- a/vlib/v3/migrations/migrations.v
+++ b/vlib/v3/migrations/migrations.v
@@ -523,7 +523,9 @@ fn (mut m Migrator) run_down(migration Migration) ! {
 
 fn (m &Migrator) history_insert_sql(migration Migration, applied_at string) string {
 	table := quote_identifier(m.config.dialect, m.config.table)
-	return "INSERT INTO ${table} (version, name, applied_at) VALUES (${migration.version}, '${escape_literal(migration.name)}', '${escape_literal(applied_at)}');"
+	name := string_literal_sql(m.config.dialect, migration.name)
+	timestamp := string_literal_sql(m.config.dialect, applied_at)
+	return 'INSERT INTO ${table} (version, name, applied_at) VALUES (${migration.version}, ${name}, ${timestamp});'
 }
 
 fn (m &Migrator) history_delete_sql(version i64) string {

--- a/vlib/v3/migrations/migrations.v
+++ b/vlib/v3/migrations/migrations.v
@@ -78,6 +78,7 @@ mut:
 	config                     Config
 	pg_lock_key                ?i64
 	mysql_lock_name            string
+	sqlite_lock_active         bool
 	resolved_history_namespace string
 	resolved_history_table_sql string
 }
@@ -432,6 +433,7 @@ fn (mut m Migrator) acquire_migration_lock() ! {
 	match m.config.dialect {
 		.sqlite {
 			m.conn.execute('BEGIN IMMEDIATE;')!
+			m.sqlite_lock_active = true
 			namespace := if m.resolved_history_namespace != '' {
 				m.resolved_history_namespace
 			} else if m.config.table.contains('.') {
@@ -495,12 +497,20 @@ fn (mut m Migrator) resolve_mysql_history_database() !string {
 }
 
 fn (mut m Migrator) reject_existing_postgresql_transaction() ! {
-	token := 'probe_${time.now().unix_nano()}'
-	m.conn.execute(postgresql_transaction_probe_set_query(token))!
-	rows := m.conn.execute(postgresql_transaction_probe_read_query())!
-	if postgresql_transaction_probe_value(rows)! == token {
+	if m.postgresql_transaction_is_active()! {
 		return error('PostgreSQL migrations require a connection without an already-open transaction; pg.Tx and transactional pg.Conn values are not supported')
 	}
+}
+
+fn (mut m Migrator) postgresql_transaction_is_active() !bool {
+	token := new_postgresql_transaction_probe_token()
+	m.conn.execute(postgresql_transaction_probe_set_query(token))!
+	rows := m.conn.execute(postgresql_transaction_probe_read_query())!
+	return postgresql_transaction_probe_value(rows)! == token
+}
+
+fn new_postgresql_transaction_probe_token() string {
+	return 'probe_${time.now().unix_nano()}'
 }
 
 fn postgresql_transaction_probe_set_query(token string) string {
@@ -516,6 +526,19 @@ fn postgresql_transaction_probe_value(rows []orm.Row) !string {
 		return error('could not determine PostgreSQL transaction state')
 	}
 	return rows[0].vals[0]
+}
+
+fn mark_postgresql_owned_transaction(mut ctx Context) !string {
+	token := new_postgresql_transaction_probe_token()
+	ctx.execute(postgresql_transaction_probe_set_query(token))!
+	return token
+}
+
+fn verify_postgresql_owned_transaction(mut ctx Context, token string) ! {
+	rows := ctx.execute(postgresql_transaction_probe_read_query())!
+	if postgresql_transaction_probe_value(rows)! != token {
+		return error('PostgreSQL migration callback ended the migrator-owned transaction before history was recorded')
+	}
 }
 
 fn (mut m Migrator) validate_mysql_session() ! {
@@ -544,11 +567,15 @@ fn (mut m Migrator) retain_history_relation(dialect Dialect, namespace string) {
 fn (mut m Migrator) release_migration_lock(success bool) ! {
 	match m.config.dialect {
 		.sqlite {
+			if !m.sqlite_lock_active {
+				return
+			}
 			if success {
 				m.conn.orm_commit()!
 			} else {
 				m.conn.orm_rollback()!
 			}
+			m.sqlite_lock_active = false
 		}
 		.pg {
 			key := m.pg_lock_key or {
@@ -653,6 +680,39 @@ fn migration_lock_result(rows []orm.Row) bool {
 	return rows.len == 1 && rows[0].vals.len > 0 && rows[0].vals[0] in ['1', 't', 'true']
 }
 
+fn (mut m Migrator) verify_sqlite_lock_transaction() ! {
+	foreign_keys_rows := m.conn.execute('PRAGMA foreign_keys;')!
+	foreign_keys_enabled := sqlite_foreign_keys_enabled(foreign_keys_rows)!
+	toggled_value := if foreign_keys_enabled { 'OFF' } else { 'ON' }
+	m.conn.execute('PRAGMA foreign_keys = ${toggled_value};')!
+	toggled_rows := m.conn.execute('PRAGMA foreign_keys;')!
+	if sqlite_foreign_keys_enabled(toggled_rows)! == foreign_keys_enabled {
+		// SQLite ignores foreign_keys changes inside a transaction. An unchanged
+		// value confirms that the BEGIN IMMEDIATE transaction is still active.
+		return
+	}
+	state_err := 'SQLite migration callback ended the migration lock transaction before history was recorded'
+	restored_value := if foreign_keys_enabled { 'ON' } else { 'OFF' }
+	m.conn.execute('PRAGMA foreign_keys = ${restored_value};')!
+	restored_rows := m.conn.execute('PRAGMA foreign_keys;')!
+	if sqlite_foreign_keys_enabled(restored_rows)! != foreign_keys_enabled {
+		return error('${state_err}; restoring SQLite foreign_keys state failed')
+	}
+	m.sqlite_lock_active = false
+	return error(state_err)
+}
+
+fn sqlite_foreign_keys_enabled(rows []orm.Row) !bool {
+	if rows.len != 1 || rows[0].vals.len == 0 {
+		return error('could not determine SQLite transaction state')
+	}
+	return match rows[0].vals[0] {
+		'0' { false }
+		'1' { true }
+		else { return error('unsupported SQLite foreign_keys value `${rows[0].vals[0]}`') }
+	}
+}
+
 fn (m &Migrator) uses_transactions() bool {
 	return match m.config.transaction_mode {
 		.always { true }
@@ -667,12 +727,31 @@ fn (mut m Migrator) run_up(migration Migration) !AppliedMigration {
 	if m.config.dialect != .sqlite && m.uses_transactions() {
 		mut tx := orm.begin(mut m.conn)!
 		mut ctx := new_context(tx, m.config.dialect)
+		mut postgresql_transaction_token := ''
+		if m.config.dialect == .pg {
+			postgresql_transaction_token = mark_postgresql_owned_transaction(mut ctx) or {
+				probe_err := err
+				tx.rollback() or {
+					return error('could not mark the migrator-owned PostgreSQL transaction: ${probe_err.msg()}; rollback failed: ${err.msg()}')
+				}
+				return error('could not mark the migrator-owned PostgreSQL transaction: ${probe_err.msg()}')
+			}
+		}
 		migration.up(mut ctx) or {
 			migration_err := err
 			tx.rollback() or {
 				return error('migration ${migration.version} `${migration.name}` failed: ${migration_err.msg()}; rollback failed: ${err.msg()}')
 			}
 			return error('migration ${migration.version} `${migration.name}` failed: ${migration_err.msg()}')
+		}
+		if m.config.dialect == .pg {
+			verify_postgresql_owned_transaction(mut ctx, postgresql_transaction_token) or {
+				transaction_err := err
+				tx.rollback() or {
+					return error('${transaction_err.msg()}; rollback failed: ${err.msg()}')
+				}
+				return transaction_err
+			}
 		}
 		ctx.execute(m.history_insert_sql(migration, applied_at)) or {
 			history_err := err
@@ -691,6 +770,9 @@ fn (mut m Migrator) run_up(migration Migration) !AppliedMigration {
 			}
 			return migration_err
 		}
+		if m.config.dialect == .sqlite {
+			m.verify_sqlite_lock_transaction()!
+		}
 		ctx.execute(m.history_insert_sql(migration, applied_at))!
 	}
 	m.validate_session_after_callback()!
@@ -705,12 +787,31 @@ fn (mut m Migrator) run_down(migration Migration) ! {
 	if m.config.dialect != .sqlite && m.uses_transactions() {
 		mut tx := orm.begin(mut m.conn)!
 		mut ctx := new_context(tx, m.config.dialect)
+		mut postgresql_transaction_token := ''
+		if m.config.dialect == .pg {
+			postgresql_transaction_token = mark_postgresql_owned_transaction(mut ctx) or {
+				probe_err := err
+				tx.rollback() or {
+					return error('could not mark the migrator-owned PostgreSQL transaction: ${probe_err.msg()}; transaction rollback failed: ${err.msg()}')
+				}
+				return error('could not mark the migrator-owned PostgreSQL transaction: ${probe_err.msg()}')
+			}
+		}
 		migration.down(mut ctx) or {
 			migration_err := err
 			tx.rollback() or {
 				return error('rollback of migration ${migration.version} `${migration.name}` failed: ${migration_err.msg()}; transaction rollback failed: ${err.msg()}')
 			}
 			return error('rollback of migration ${migration.version} `${migration.name}` failed: ${migration_err.msg()}')
+		}
+		if m.config.dialect == .pg {
+			verify_postgresql_owned_transaction(mut ctx, postgresql_transaction_token) or {
+				transaction_err := err
+				tx.rollback() or {
+					return error('${transaction_err.msg()}; transaction rollback failed: ${err.msg()}')
+				}
+				return transaction_err
+			}
 		}
 		ctx.execute(m.history_delete_sql(migration.version)) or {
 			history_err := err
@@ -728,6 +829,9 @@ fn (mut m Migrator) run_down(migration Migration) ! {
 				return error('${migration_err.msg()}; ${err.msg()}')
 			}
 			return migration_err
+		}
+		if m.config.dialect == .sqlite {
+			m.verify_sqlite_lock_transaction()!
 		}
 		ctx.execute(m.history_delete_sql(migration.version))!
 	}

--- a/vlib/v3/migrations/migrations.v
+++ b/vlib/v3/migrations/migrations.v
@@ -6,6 +6,7 @@ import strconv
 import time
 
 const migration_lock_timeout_seconds = 60
+const postgresql_transaction_probe_setting = 'v3_migrations.transaction_probe'
 
 // MigrationFn changes the schema through a migration Context.
 pub type MigrationFn = fn (mut Context) !
@@ -494,16 +495,27 @@ fn (mut m Migrator) resolve_mysql_history_database() !string {
 }
 
 fn (mut m Migrator) reject_existing_postgresql_transaction() ! {
-	probe := 'v3_migrations_transaction_probe'
-	m.conn.orm_savepoint(probe) or {
-		// PostgreSQL rejects SAVEPOINT outside a transaction, which is the required
-		// state before the migrator acquires its session lock.
-		return
+	token := 'probe_${time.now().unix_nano()}'
+	m.conn.execute(postgresql_transaction_probe_set_query(token))!
+	rows := m.conn.execute(postgresql_transaction_probe_read_query())!
+	if postgresql_transaction_probe_value(rows)! == token {
+		return error('PostgreSQL migrations require a connection without an already-open transaction; pg.Tx and transactional pg.Conn values are not supported')
 	}
-	m.conn.orm_release_savepoint(probe) or {
-		return error('could not release PostgreSQL transaction ownership probe: ${err.msg()}')
+}
+
+fn postgresql_transaction_probe_set_query(token string) string {
+	return "SELECT pg_catalog.set_config('${postgresql_transaction_probe_setting}', '${token}', true);"
+}
+
+fn postgresql_transaction_probe_read_query() string {
+	return "SELECT pg_catalog.current_setting('${postgresql_transaction_probe_setting}', true);"
+}
+
+fn postgresql_transaction_probe_value(rows []orm.Row) !string {
+	if rows.len != 1 || rows[0].vals.len == 0 {
+		return error('could not determine PostgreSQL transaction state')
 	}
-	return error('PostgreSQL migrations require a connection without an already-open transaction; pg.Tx and transactional pg.Conn values are not supported')
+	return rows[0].vals[0]
 }
 
 fn (mut m Migrator) validate_mysql_session() ! {

--- a/vlib/v3/migrations/migrations.v
+++ b/vlib/v3/migrations/migrations.v
@@ -672,8 +672,19 @@ fn (mut m Migrator) run_up(migration Migration) !AppliedMigration {
 		tx.commit()!
 	} else {
 		mut ctx := new_context(m.conn, m.config.dialect)
-		migration.up(mut ctx)!
+		migration.up(mut ctx) or {
+			migration_err := err
+			if m.config.dialect == .mysql {
+				m.validate_mysql_session_after_callback() or {
+					return error('${migration_err.msg()}; ${err.msg()}')
+				}
+			}
+			return migration_err
+		}
 		ctx.execute(m.history_insert_sql(migration, applied_at))!
+	}
+	if m.config.dialect == .mysql {
+		m.validate_mysql_session_after_callback()!
 	}
 	return AppliedMigration{
 		version:    migration.version
@@ -703,8 +714,29 @@ fn (mut m Migrator) run_down(migration Migration) ! {
 		tx.commit()!
 	} else {
 		mut ctx := new_context(m.conn, m.config.dialect)
-		migration.down(mut ctx)!
+		migration.down(mut ctx) or {
+			migration_err := err
+			if m.config.dialect == .mysql {
+				m.validate_mysql_session_after_callback() or {
+					return error('${migration_err.msg()}; ${err.msg()}')
+				}
+			}
+			return migration_err
+		}
 		ctx.execute(m.history_delete_sql(migration.version))!
+	}
+	if m.config.dialect == .mysql {
+		m.validate_mysql_session_after_callback()!
+	}
+}
+
+fn (mut m Migrator) validate_mysql_session_after_callback() ! {
+	m.validate_mysql_session() or {
+		session_err := err
+		m.conn.orm_rollback() or {
+			return error('${session_err.msg()}; rolling back callback-created MySQL transaction state failed: ${err.msg()}')
+		}
+		return error('MySQL migration callback left unsafe session state: ${session_err.msg()}')
 	}
 }
 

--- a/vlib/v3/migrations/migrations.v
+++ b/vlib/v3/migrations/migrations.v
@@ -4,6 +4,8 @@ import orm
 import strconv
 import time
 
+const migration_lock_timeout_seconds = 60
+
 // MigrationFn changes the schema through a migration Context.
 pub type MigrationFn = fn (mut Context) !
 
@@ -47,6 +49,13 @@ pub enum MigrationState {
 	applied
 	pending
 	missing
+}
+
+enum MigrationOperation {
+	migrate_to
+	rollback
+	redo
+	reset
 }
 
 // Status is one row returned by Migrator.status.
@@ -127,6 +136,10 @@ pub fn (mut m Migrator) migrate_to(target_version i64) ![]AppliedMigration {
 	if target_version < 0 {
 		return error('migration target version must not be negative')
 	}
+	return m.run_locked(.migrate_to, target_version)
+}
+
+fn (mut m Migrator) migrate_to_unlocked(target_version i64) ![]AppliedMigration {
 	applied := m.applied()!
 	mut applied_versions := map[i64]bool{}
 	for item in applied {
@@ -167,6 +180,10 @@ pub fn (mut m Migrator) rollback(steps int) ![]AppliedMigration {
 	if steps < 1 {
 		return error('rollback steps must be at least 1')
 	}
+	return m.run_locked(.rollback, i64(steps))
+}
+
+fn (mut m Migrator) rollback_unlocked(steps int) ![]AppliedMigration {
 	mut applied := m.applied()!
 	applied.sort_with_compare(compare_applied_desc)
 	mut reverted := []AppliedMigration{}
@@ -193,7 +210,14 @@ pub fn (mut m Migrator) rollback_last() ![]AppliedMigration {
 
 // redo rolls back the newest `steps` migrations and applies them again.
 pub fn (mut m Migrator) redo(steps int) ![]AppliedMigration {
-	reverted := m.rollback(steps)!
+	if steps < 1 {
+		return error('rollback steps must be at least 1')
+	}
+	return m.run_locked(.redo, i64(steps))
+}
+
+fn (mut m Migrator) redo_unlocked(steps int) ![]AppliedMigration {
+	reverted := m.rollback_unlocked(steps)!
 	if reverted.len == 0 {
 		return []
 	}
@@ -217,11 +241,45 @@ pub fn (mut m Migrator) redo_last() ![]AppliedMigration {
 
 // reset rolls back every applied migration while preserving the history table.
 pub fn (mut m Migrator) reset() ![]AppliedMigration {
+	return m.run_locked(.reset, 0)
+}
+
+fn (mut m Migrator) reset_unlocked() ![]AppliedMigration {
 	applied := m.applied()!
 	if applied.len == 0 {
 		return []
 	}
-	return m.rollback(applied.len)
+	return m.rollback_unlocked(applied.len)
+}
+
+fn (mut m Migrator) run_locked(operation MigrationOperation, argument i64) ![]AppliedMigration {
+	m.acquire_migration_lock()!
+	result := m.run_unlocked(operation, argument) or {
+		operation_err := err
+		m.release_migration_lock(false) or {
+			return error('${operation_err.msg()}; releasing migration lock failed: ${err.msg()}')
+		}
+		return operation_err
+	}
+	m.release_migration_lock(true)!
+	return result
+}
+
+fn (mut m Migrator) run_unlocked(operation MigrationOperation, argument i64) ![]AppliedMigration {
+	match operation {
+		.migrate_to {
+			return m.migrate_to_unlocked(argument)
+		}
+		.rollback {
+			return m.rollback_unlocked(int(argument))
+		}
+		.redo {
+			return m.redo_unlocked(int(argument))
+		}
+		.reset {
+			return m.reset_unlocked()
+		}
+	}
 }
 
 // applied returns the migrations recorded in the database, oldest first.
@@ -334,6 +392,68 @@ fn (mut m Migrator) ensure_history_table() ! {
 	m.conn.execute('CREATE TABLE IF NOT EXISTS ${table} (version BIGINT PRIMARY KEY, name VARCHAR(255) NOT NULL, applied_at VARCHAR(32) NOT NULL);')!
 }
 
+fn (mut m Migrator) acquire_migration_lock() ! {
+	key := migration_lock_key(m.config.table)
+	match m.config.dialect {
+		.sqlite {
+			m.conn.execute('BEGIN IMMEDIATE;')!
+		}
+		.pg {
+			m.conn.execute('SELECT pg_advisory_lock(${key});')!
+		}
+		.mysql {
+			name := migration_lock_name(key)
+			rows :=
+				m.conn.execute("SELECT GET_LOCK('${name}', ${migration_lock_timeout_seconds});")!
+			if !migration_lock_result(rows) {
+				return error('could not acquire MySQL migration lock `${name}` within ${migration_lock_timeout_seconds} seconds')
+			}
+		}
+	}
+}
+
+fn (mut m Migrator) release_migration_lock(success bool) ! {
+	key := migration_lock_key(m.config.table)
+	match m.config.dialect {
+		.sqlite {
+			if success {
+				m.conn.orm_commit()!
+			} else {
+				m.conn.orm_rollback()!
+			}
+		}
+		.pg {
+			rows := m.conn.execute('SELECT pg_advisory_unlock(${key});')!
+			if !migration_lock_result(rows) {
+				return error('could not release PostgreSQL migration lock ${key}')
+			}
+		}
+		.mysql {
+			name := migration_lock_name(key)
+			rows := m.conn.execute("SELECT RELEASE_LOCK('${name}');")!
+			if !migration_lock_result(rows) {
+				return error('could not release MySQL migration lock `${name}`')
+			}
+		}
+	}
+}
+
+fn migration_lock_key(table string) i64 {
+	mut hash := u64(5381)
+	for ch in table.bytes() {
+		hash = ((hash * 33) ^ u64(ch)) & u64(0x7fffffff)
+	}
+	return i64(hash)
+}
+
+fn migration_lock_name(key i64) string {
+	return 'v3_migrations_${key}'
+}
+
+fn migration_lock_result(rows []orm.Row) bool {
+	return rows.len == 1 && rows[0].vals.len > 0 && rows[0].vals[0] in ['1', 't', 'true']
+}
+
 fn (m &Migrator) uses_transactions() bool {
 	return match m.config.transaction_mode {
 		.always { true }
@@ -345,7 +465,7 @@ fn (m &Migrator) uses_transactions() bool {
 fn (mut m Migrator) run_up(migration Migration) !AppliedMigration {
 	m.ensure_history_table()!
 	applied_at := time.utc().format_rfc3339()
-	if m.uses_transactions() {
+	if m.config.dialect != .sqlite && m.uses_transactions() {
 		mut tx := orm.begin(mut m.conn)!
 		mut ctx := new_context(tx, m.config.dialect)
 		migration.up(mut ctx) or {
@@ -376,7 +496,7 @@ fn (mut m Migrator) run_up(migration Migration) !AppliedMigration {
 }
 
 fn (mut m Migrator) run_down(migration Migration) ! {
-	if m.uses_transactions() {
+	if m.config.dialect != .sqlite && m.uses_transactions() {
 		mut tx := orm.begin(mut m.conn)!
 		mut ctx := new_context(tx, m.config.dialect)
 		migration.down(mut ctx) or {

--- a/vlib/v3/migrations/migrations.v
+++ b/vlib/v3/migrations/migrations.v
@@ -435,7 +435,7 @@ fn (mut m Migrator) acquire_migration_lock() ! {
 			} else if m.config.table.contains('.') {
 				m.config.table.all_before('.')
 			} else {
-				schema_rows := m.conn.execute('SELECT current_schema();')!
+				schema_rows := m.conn.execute(postgresql_history_schema_query(m.config.table))!
 				postgresql_schema_name(schema_rows)!
 			}
 			key := postgresql_migration_lock_key(schema, m.config.table)
@@ -535,6 +535,11 @@ fn postgresql_migration_lock_key(schema string, table string) i64 {
 	return migration_lock_key(identity)
 }
 
+fn postgresql_history_schema_query(table string) string {
+	return 'SELECT COALESCE((SELECT n.nspname FROM pg_catalog.pg_class AS c JOIN pg_catalog.pg_namespace AS n ON n.oid = c.relnamespace WHERE c.relname = ${string_literal_sql(.pg,
+		table)} AND pg_catalog.pg_table_is_visible(c.oid) LIMIT 1), pg_catalog.current_schema());'
+}
+
 fn qualified_history_table_sql(dialect Dialect, namespace string, table string) string {
 	table_name := if table.contains('.') { table.all_after('.') } else { table }
 	return '${quote_identifier_component(dialect, namespace)}.${quote_identifier_component(dialect,
@@ -574,7 +579,7 @@ fn mysql_lower_case_table_names(rows []orm.Row) !int {
 
 fn postgresql_schema_name(rows []orm.Row) !string {
 	if rows.len != 1 || rows[0].vals.len == 0 || rows[0].vals[0] == '' {
-		return error('could not determine current PostgreSQL schema for migration lock')
+		return error('could not determine PostgreSQL migration history schema for migration lock')
 	}
 	return rows[0].vals[0]
 }

--- a/vlib/v3/migrations/migrations.v
+++ b/vlib/v3/migrations/migrations.v
@@ -434,9 +434,21 @@ fn (mut m Migrator) acquire_migration_lock() ! {
 	match m.config.dialect {
 		.sqlite {
 			m.prepare_sqlite_transaction_probe()!
-			m.conn.execute('BEGIN IMMEDIATE;')!
+			m.conn.execute('BEGIN IMMEDIATE;') or {
+				lock_err := err
+				m.release_sqlite_migration_lock(false) or {
+					return error('${lock_err.msg()}; cleaning up SQLite lock acquisition state failed: ${err.msg()}')
+				}
+				return lock_err
+			}
 			m.sqlite_lock_active = true
-			m.conn.execute('SAVEPOINT ${m.sqlite_transaction_probe};')!
+			m.conn.execute('SAVEPOINT ${m.sqlite_transaction_probe};') or {
+				lock_err := err
+				m.release_sqlite_migration_lock(false) or {
+					return error('${lock_err.msg()}; cleaning up SQLite lock acquisition state failed: ${err.msg()}')
+				}
+				return lock_err
+			}
 			namespace := if m.resolved_history_namespace != '' {
 				m.resolved_history_namespace
 			} else if m.config.table.contains('.') {
@@ -582,15 +594,7 @@ fn (mut m Migrator) retain_history_relation(dialect Dialect, namespace string) {
 fn (mut m Migrator) release_migration_lock(success bool) ! {
 	match m.config.dialect {
 		.sqlite {
-			if m.sqlite_lock_active {
-				if success {
-					m.conn.orm_commit()!
-				} else {
-					m.conn.orm_rollback()!
-				}
-				m.sqlite_lock_active = false
-			}
-			m.cleanup_sqlite_transaction_probe()!
+			m.release_sqlite_migration_lock(success)!
 		}
 		.pg {
 			key := m.pg_lock_key or {
@@ -614,6 +618,43 @@ fn (mut m Migrator) release_migration_lock(success bool) ! {
 			}
 			m.mysql_lock_name = ''
 		}
+	}
+}
+
+fn (mut m Migrator) release_sqlite_migration_lock(success bool) ! {
+	mut release_error := ''
+	mut transaction_ended := false
+	if m.sqlite_lock_active {
+		if success {
+			m.conn.orm_commit() or {
+				commit_err := err
+				m.conn.orm_rollback() or {
+					release_error = '${commit_err.msg()}; rolling back the failed SQLite lock transaction failed: ${err.msg()}'
+				}
+				if release_error == '' {
+					transaction_ended = true
+					release_error = commit_err.msg()
+				}
+			}
+			if release_error == '' {
+				transaction_ended = true
+			}
+		} else {
+			m.conn.orm_rollback() or { release_error = err.msg() }
+			transaction_ended = release_error == ''
+		}
+		if transaction_ended {
+			m.sqlite_lock_active = false
+		}
+	}
+	m.cleanup_sqlite_transaction_probe() or {
+		if release_error != '' {
+			return error('${release_error}; cleaning up the SQLite transaction probe failed: ${err.msg()}')
+		}
+		return err
+	}
+	if release_error != '' {
+		return error(release_error)
 	}
 }
 

--- a/vlib/v3/migrations/migrations.v
+++ b/vlib/v3/migrations/migrations.v
@@ -460,7 +460,8 @@ fn migration_lock_key(table string) i64 {
 }
 
 fn mysql_migration_lock_name(database string, table string) string {
-	identity := '${database.len}:${database}:${table}'
+	table_name := if table.contains('.') { table.all_after('.') } else { table }
+	identity := '${database.len}:${database}:${table_name.len}:${table_name}'
 	return 'v3_migrations_${fnv1a.sum64_string(identity).hex()}'
 }
 

--- a/vlib/v3/migrations/migrations.v
+++ b/vlib/v3/migrations/migrations.v
@@ -72,20 +72,24 @@ pub:
 // Migrator applies an ordered set of migrations and records their versions.
 pub struct Migrator {
 mut:
-	conn                         orm.TransactionalConnection
-	migrations                   []Migration
-	config                       Config
-	pg_lock_key                  ?i64
-	mysql_lock_name              string
-	resolved_history_namespace   string
-	resolved_history_table_sql   string
-	session_connection_validated bool
+	conn                       orm.TransactionalConnection
+	migrations                 []Migration
+	config                     Config
+	pg_lock_key                ?i64
+	mysql_lock_name            string
+	resolved_history_namespace string
+	resolved_history_table_sql string
 }
 
 // new creates and validates a migrator. It does not access the database until
 // one of the migration or inspection methods is called.
 pub fn new(mut conn orm.TransactionalConnection, registered []Migration, config Config) !Migrator {
 	validate_identifier_for_dialect(config.dialect, config.table, 'migration history table')!
+	if config.dialect == .pg {
+		if mut conn is orm.DB {
+			return error('PostgreSQL migrations require a direct session-pinned connection; orm.DB wrappers cannot be validated without mutating the wrapped connection; pass pg.Conn or pg.Tx directly')
+		}
+	}
 	mut ordered := registered.clone()
 	ordered.sort_with_compare(compare_migrations)
 	mut previous := i64(0)
@@ -412,7 +416,6 @@ fn (m &Migrator) history_table_sql() string {
 }
 
 fn (mut m Migrator) acquire_migration_lock() ! {
-	m.validate_session_connection()!
 	match m.config.dialect {
 		.sqlite {
 			m.conn.execute('BEGIN IMMEDIATE;')!
@@ -468,21 +471,6 @@ fn (mut m Migrator) retain_history_relation(dialect Dialect, namespace string) {
 	}
 	m.resolved_history_namespace = namespace
 	m.resolved_history_table_sql = qualified_history_table_sql(dialect, namespace, m.config.table)
-}
-
-fn (mut m Migrator) validate_session_connection() ! {
-	if m.config.dialect != .pg || m.session_connection_validated {
-		return
-	}
-	if m.conn is orm.DB {
-		m.conn.orm_begin() or {
-			return error('PostgreSQL migrations require a session-pinned connection; orm.DB wrapper validation failed: ${err.msg()}; use pg.DB.conn() or pg.connect_direct()')
-		}
-		m.conn.orm_rollback() or {
-			return error('PostgreSQL migrations could not roll back the session-affinity validation transaction: ${err.msg()}')
-		}
-	}
-	m.session_connection_validated = true
 }
 
 fn (mut m Migrator) release_migration_lock(success bool) ! {

--- a/vlib/v3/migrations/migrations.v
+++ b/vlib/v3/migrations/migrations.v
@@ -1,0 +1,412 @@
+module migrations
+
+import orm
+import strconv
+import time
+
+// MigrationFn changes the schema through a migration Context.
+pub type MigrationFn = fn (mut Context) !
+
+// Migration is one reversible, versioned database schema change.
+//
+// Versions are positive integers. Timestamp-shaped versions such as
+// `20260816143000` make migrations naturally sortable, like Rails migrations.
+pub struct Migration {
+pub:
+	version i64
+	name    string
+	up      MigrationFn @[required]
+	down    MigrationFn @[required]
+}
+
+// TransactionMode controls whether each migration is wrapped in a transaction.
+pub enum TransactionMode {
+	automatic
+	always
+	never
+}
+
+// Config configures a Migrator.
+pub struct Config {
+pub:
+	dialect          Dialect
+	table            string          = 'schema_migrations'
+	transaction_mode TransactionMode = .automatic
+}
+
+// AppliedMigration is a migration recorded in the database history table.
+pub struct AppliedMigration {
+pub:
+	version    i64
+	name       string
+	applied_at string
+}
+
+// MigrationState describes the relationship between code and database history.
+pub enum MigrationState {
+	applied
+	pending
+	missing
+}
+
+// Status is one row returned by Migrator.status.
+// A missing row was applied to the database but is no longer registered in code.
+pub struct Status {
+pub:
+	version    i64
+	name       string
+	state      MigrationState
+	applied_at string
+}
+
+// Migrator applies an ordered set of migrations and records their versions.
+pub struct Migrator {
+mut:
+	conn       orm.TransactionalConnection
+	migrations []Migration
+	config     Config
+}
+
+// new creates and validates a migrator. It does not access the database until
+// one of the migration or inspection methods is called.
+pub fn new(mut conn orm.TransactionalConnection, registered []Migration, config Config) !Migrator {
+	validate_identifier(config.table, 'migration history table')!
+	mut ordered := registered.clone()
+	ordered.sort_with_compare(compare_migrations)
+	mut previous := i64(0)
+	for i, migration in ordered {
+		if migration.version <= 0 {
+			return error('migration `${migration.name}` has invalid version ${migration.version}; versions must be positive')
+		}
+		if migration.name.trim_space() == '' {
+			return error('migration ${migration.version} must have a name')
+		}
+		if migration.name.len > 255 {
+			return error('migration ${migration.version} name must not exceed 255 bytes')
+		}
+		if i > 0 && migration.version == previous {
+			return error('duplicate migration version ${migration.version}')
+		}
+		previous = migration.version
+	}
+	return Migrator{
+		conn:       conn
+		migrations: ordered
+		config:     config
+	}
+}
+
+fn compare_migrations(a &Migration, b &Migration) int {
+	if a.version < b.version {
+		return -1
+	}
+	if a.version > b.version {
+		return 1
+	}
+	return 0
+}
+
+fn compare_applied_desc(a &AppliedMigration, b &AppliedMigration) int {
+	if a.version > b.version {
+		return -1
+	}
+	if a.version < b.version {
+		return 1
+	}
+	return 0
+}
+
+// migrate applies every pending migration in ascending version order.
+pub fn (mut m Migrator) migrate() ![]AppliedMigration {
+	return m.migrate_to(max_i64)
+}
+
+// migrate_to moves the schema to target_version. Pending migrations at or
+// below the target are applied; applied migrations above it are rolled back.
+pub fn (mut m Migrator) migrate_to(target_version i64) ![]AppliedMigration {
+	if target_version < 0 {
+		return error('migration target version must not be negative')
+	}
+	applied := m.applied()!
+	mut applied_versions := map[i64]bool{}
+	for item in applied {
+		applied_versions[item.version] = true
+	}
+	mut changed := []AppliedMigration{}
+	mut descending := applied.clone()
+	descending.sort_with_compare(compare_applied_desc)
+	for item in descending {
+		if item.version > target_version && m.find_migration(item.version) == none {
+			return error('cannot roll back migration ${item.version}: its migration file is missing')
+		}
+	}
+	for item in descending {
+		if item.version <= target_version {
+			continue
+		}
+		migration := m.find_migration(item.version) or {
+			return error('cannot roll back migration ${item.version}: its migration file is missing')
+		}
+		m.run_down(migration)!
+		changed << item
+		applied_versions.delete(item.version)
+	}
+	for migration in m.migrations {
+		if migration.version > target_version || migration.version in applied_versions {
+			continue
+		}
+		item := m.run_up(migration)!
+		changed << item
+		applied_versions[migration.version] = true
+	}
+	return changed
+}
+
+// rollback reverts the newest `steps` applied migrations.
+pub fn (mut m Migrator) rollback(steps int) ![]AppliedMigration {
+	if steps < 1 {
+		return error('rollback steps must be at least 1')
+	}
+	mut applied := m.applied()!
+	applied.sort_with_compare(compare_applied_desc)
+	mut reverted := []AppliedMigration{}
+	limit := if steps < applied.len { steps } else { applied.len }
+	for item in applied[..limit] {
+		if m.find_migration(item.version) == none {
+			return error('cannot roll back migration ${item.version}: its migration file is missing')
+		}
+	}
+	for item in applied[..limit] {
+		migration := m.find_migration(item.version) or {
+			return error('cannot roll back migration ${item.version}: its migration file is missing')
+		}
+		m.run_down(migration)!
+		reverted << item
+	}
+	return reverted
+}
+
+// rollback_last reverts the newest applied migration.
+pub fn (mut m Migrator) rollback_last() ![]AppliedMigration {
+	return m.rollback(1)
+}
+
+// redo rolls back the newest `steps` migrations and applies them again.
+pub fn (mut m Migrator) redo(steps int) ![]AppliedMigration {
+	reverted := m.rollback(steps)!
+	if reverted.len == 0 {
+		return []
+	}
+	mut versions := map[i64]bool{}
+	for item in reverted {
+		versions[item.version] = true
+	}
+	mut reapplied := []AppliedMigration{}
+	for migration in m.migrations {
+		if migration.version in versions {
+			reapplied << m.run_up(migration)!
+		}
+	}
+	return reapplied
+}
+
+// redo_last rolls back and reapplies the newest migration.
+pub fn (mut m Migrator) redo_last() ![]AppliedMigration {
+	return m.redo(1)
+}
+
+// reset rolls back every applied migration while preserving the history table.
+pub fn (mut m Migrator) reset() ![]AppliedMigration {
+	applied := m.applied()!
+	if applied.len == 0 {
+		return []
+	}
+	return m.rollback(applied.len)
+}
+
+// applied returns the migrations recorded in the database, oldest first.
+pub fn (mut m Migrator) applied() ![]AppliedMigration {
+	m.ensure_history_table()!
+	table := quote_identifier(m.config.dialect, m.config.table)
+	rows := m.conn.execute('SELECT version, name, applied_at FROM ${table} ORDER BY version ASC;')!
+	mut result := []AppliedMigration{cap: rows.len}
+	for row in rows {
+		if row.vals.len < 3 {
+			return error('migration history query returned ${row.vals.len} columns; expected 3')
+		}
+		version := strconv.parse_int(row.vals[0], 10, 64) or {
+			return error('migration history contains invalid version `${row.vals[0]}`')
+		}
+		result << AppliedMigration{
+			version:    version
+			name:       row.vals[1]
+			applied_at: row.vals[2]
+		}
+	}
+	return result
+}
+
+// pending returns registered migrations that have not been applied yet.
+pub fn (mut m Migrator) pending() ![]Migration {
+	applied := m.applied()!
+	mut versions := map[i64]bool{}
+	for item in applied {
+		versions[item.version] = true
+	}
+	return m.migrations.filter(it.version !in versions)
+}
+
+// current_version returns the greatest applied version, or zero for an empty schema.
+pub fn (mut m Migrator) current_version() !i64 {
+	applied := m.applied()!
+	mut latest := i64(0)
+	for item in applied {
+		if item.version > latest {
+			latest = item.version
+		}
+	}
+	return latest
+}
+
+// status reports applied and pending migrations, plus applied versions whose
+// migration definitions are missing from the program.
+pub fn (mut m Migrator) status() ![]Status {
+	applied := m.applied()!
+	mut applied_by_version := map[i64]AppliedMigration{}
+	mut known_versions := map[i64]bool{}
+	for item in applied {
+		applied_by_version[item.version] = item
+	}
+	mut result := []Status{cap: applied.len + m.migrations.len}
+	for migration in m.migrations {
+		known_versions[migration.version] = true
+		if migration.version in applied_by_version {
+			item := applied_by_version[migration.version]
+			result << Status{
+				version:    migration.version
+				name:       migration.name
+				state:      .applied
+				applied_at: item.applied_at
+			}
+		} else {
+			result << Status{
+				version: migration.version
+				name:    migration.name
+				state:   .pending
+			}
+		}
+	}
+	for item in applied {
+		if item.version !in known_versions {
+			result << Status{
+				version:    item.version
+				name:       item.name
+				state:      .missing
+				applied_at: item.applied_at
+			}
+		}
+	}
+	result.sort_with_compare(compare_status)
+	return result
+}
+
+fn compare_status(a &Status, b &Status) int {
+	if a.version < b.version {
+		return -1
+	}
+	if a.version > b.version {
+		return 1
+	}
+	return 0
+}
+
+fn (m &Migrator) find_migration(version i64) ?Migration {
+	for migration in m.migrations {
+		if migration.version == version {
+			return migration
+		}
+	}
+	return none
+}
+
+fn (mut m Migrator) ensure_history_table() ! {
+	table := quote_identifier(m.config.dialect, m.config.table)
+	m.conn.execute('CREATE TABLE IF NOT EXISTS ${table} (version BIGINT PRIMARY KEY, name VARCHAR(255) NOT NULL, applied_at VARCHAR(32) NOT NULL);')!
+}
+
+fn (m &Migrator) uses_transactions() bool {
+	return match m.config.transaction_mode {
+		.always { true }
+		.never { false }
+		.automatic { m.config.dialect != .mysql }
+	}
+}
+
+fn (mut m Migrator) run_up(migration Migration) !AppliedMigration {
+	m.ensure_history_table()!
+	applied_at := time.utc().format_rfc3339()
+	if m.uses_transactions() {
+		mut tx := orm.begin(mut m.conn)!
+		mut ctx := new_context(tx, m.config.dialect)
+		migration.up(mut ctx) or {
+			migration_err := err
+			tx.rollback() or {
+				return error('migration ${migration.version} `${migration.name}` failed: ${migration_err.msg()}; rollback failed: ${err.msg()}')
+			}
+			return error('migration ${migration.version} `${migration.name}` failed: ${migration_err.msg()}')
+		}
+		ctx.execute(m.history_insert_sql(migration, applied_at)) or {
+			history_err := err
+			tx.rollback() or {
+				return error('could not record migration ${migration.version}: ${history_err.msg()}; rollback failed: ${err.msg()}')
+			}
+			return error('could not record migration ${migration.version}: ${history_err.msg()}')
+		}
+		tx.commit()!
+	} else {
+		mut ctx := new_context(m.conn, m.config.dialect)
+		migration.up(mut ctx)!
+		ctx.execute(m.history_insert_sql(migration, applied_at))!
+	}
+	return AppliedMigration{
+		version:    migration.version
+		name:       migration.name
+		applied_at: applied_at
+	}
+}
+
+fn (mut m Migrator) run_down(migration Migration) ! {
+	if m.uses_transactions() {
+		mut tx := orm.begin(mut m.conn)!
+		mut ctx := new_context(tx, m.config.dialect)
+		migration.down(mut ctx) or {
+			migration_err := err
+			tx.rollback() or {
+				return error('rollback of migration ${migration.version} `${migration.name}` failed: ${migration_err.msg()}; transaction rollback failed: ${err.msg()}')
+			}
+			return error('rollback of migration ${migration.version} `${migration.name}` failed: ${migration_err.msg()}')
+		}
+		ctx.execute(m.history_delete_sql(migration.version)) or {
+			history_err := err
+			tx.rollback() or {
+				return error('could not remove migration ${migration.version} from history: ${history_err.msg()}; transaction rollback failed: ${err.msg()}')
+			}
+			return error('could not remove migration ${migration.version} from history: ${history_err.msg()}')
+		}
+		tx.commit()!
+	} else {
+		mut ctx := new_context(m.conn, m.config.dialect)
+		migration.down(mut ctx)!
+		ctx.execute(m.history_delete_sql(migration.version))!
+	}
+}
+
+fn (m &Migrator) history_insert_sql(migration Migration, applied_at string) string {
+	table := quote_identifier(m.config.dialect, m.config.table)
+	return "INSERT INTO ${table} (version, name, applied_at) VALUES (${migration.version}, '${escape_literal(migration.name)}', '${escape_literal(applied_at)}');"
+}
+
+fn (m &Migrator) history_delete_sql(version i64) string {
+	table := quote_identifier(m.config.dialect, m.config.table)
+	return 'DELETE FROM ${table} WHERE version = ${version};'
+}

--- a/vlib/v3/migrations/migrations.v
+++ b/vlib/v3/migrations/migrations.v
@@ -830,7 +830,13 @@ fn (mut m Migrator) run_up(migration Migration) !AppliedMigration {
 		if m.config.dialect == .sqlite {
 			m.verify_sqlite_lock_transaction()!
 		}
-		ctx.execute(m.history_insert_sql(migration, applied_at))!
+		ctx.execute(m.history_insert_sql(migration, applied_at)) or {
+			history_err := err
+			m.validate_session_after_callback() or {
+				return error('could not record migration ${migration.version}: ${history_err.msg()}; ${err.msg()}')
+			}
+			return error('could not record migration ${migration.version}: ${history_err.msg()}')
+		}
 	}
 	m.validate_session_after_callback()!
 	return AppliedMigration{
@@ -907,7 +913,13 @@ fn (mut m Migrator) run_down(migration Migration) ! {
 		if m.config.dialect == .sqlite {
 			m.verify_sqlite_lock_transaction()!
 		}
-		ctx.execute(m.history_delete_sql(migration.version))!
+		ctx.execute(m.history_delete_sql(migration.version)) or {
+			history_err := err
+			m.validate_session_after_callback() or {
+				return error('could not remove migration ${migration.version} from history: ${history_err.msg()}; ${err.msg()}')
+			}
+			return error('could not remove migration ${migration.version} from history: ${history_err.msg()}')
+		}
 	}
 	m.validate_session_after_callback()!
 }

--- a/vlib/v3/migrations/migrations.v
+++ b/vlib/v3/migrations/migrations.v
@@ -401,6 +401,9 @@ fn (m &Migrator) find_migration(version i64) ?Migration {
 }
 
 fn (mut m Migrator) ensure_history_table() ! {
+	if m.config.dialect == .pg {
+		m.resolve_postgresql_history_schema()!
+	}
 	table := m.history_table_sql()
 	m.conn.execute('CREATE TABLE IF NOT EXISTS ${table} (version BIGINT PRIMARY KEY, name VARCHAR(255) NOT NULL, applied_at VARCHAR(32) NOT NULL);')!
 }
@@ -430,14 +433,7 @@ fn (mut m Migrator) acquire_migration_lock() ! {
 		}
 		.pg {
 			m.reject_existing_postgresql_transaction()!
-			schema := if m.resolved_history_namespace != '' {
-				m.resolved_history_namespace
-			} else if m.config.table.contains('.') {
-				m.config.table.all_before('.')
-			} else {
-				schema_rows := m.conn.execute(postgresql_history_schema_query(m.config.table))!
-				postgresql_schema_name(schema_rows)!
-			}
+			schema := m.resolve_postgresql_history_schema()!
 			key := postgresql_migration_lock_key(schema, m.config.table)
 			m.conn.execute('SELECT pg_advisory_lock(${key});')!
 			m.pg_lock_key = key
@@ -464,6 +460,20 @@ fn (mut m Migrator) acquire_migration_lock() ! {
 			m.retain_history_relation(.mysql, database)
 		}
 	}
+}
+
+fn (mut m Migrator) resolve_postgresql_history_schema() !string {
+	if m.resolved_history_namespace != '' {
+		return m.resolved_history_namespace
+	}
+	schema := if m.config.table.contains('.') {
+		m.config.table.all_before('.')
+	} else {
+		schema_rows := m.conn.execute(postgresql_history_schema_query(m.config.table))!
+		postgresql_schema_name(schema_rows)!
+	}
+	m.retain_history_relation(.pg, schema)
+	return schema
 }
 
 fn (mut m Migrator) reject_existing_postgresql_transaction() ! {
@@ -536,8 +546,8 @@ fn postgresql_migration_lock_key(schema string, table string) i64 {
 }
 
 fn postgresql_history_schema_query(table string) string {
-	return 'SELECT COALESCE((SELECT n.nspname FROM pg_catalog.pg_class AS c JOIN pg_catalog.pg_namespace AS n ON n.oid = c.relnamespace WHERE c.relname = ${string_literal_sql(.pg,
-		table)} AND pg_catalog.pg_table_is_visible(c.oid) LIMIT 1), pg_catalog.current_schema());'
+	return 'WITH persistent_search_path AS (SELECT n.oid AS namespace_oid, schemas.schema_name, schemas.search_order FROM pg_catalog.unnest(pg_catalog.current_schemas(false)) WITH ORDINALITY AS schemas(schema_name, search_order) JOIN pg_catalog.pg_namespace AS n ON n.nspname = schemas.schema_name WHERE n.oid <> pg_catalog.pg_my_temp_schema()) SELECT COALESCE((SELECT path.schema_name FROM persistent_search_path AS path JOIN pg_catalog.pg_class AS c ON c.relnamespace = path.namespace_oid WHERE c.relname = ${string_literal_sql(.pg,
+		table)} ORDER BY path.search_order LIMIT 1), (SELECT path.schema_name FROM persistent_search_path AS path ORDER BY path.search_order LIMIT 1));'
 }
 
 fn qualified_history_table_sql(dialect Dialect, namespace string, table string) string {

--- a/vlib/v3/migrations/migrations.v
+++ b/vlib/v3/migrations/migrations.v
@@ -674,18 +674,14 @@ fn (mut m Migrator) run_up(migration Migration) !AppliedMigration {
 		mut ctx := new_context(m.conn, m.config.dialect)
 		migration.up(mut ctx) or {
 			migration_err := err
-			if m.config.dialect == .mysql {
-				m.validate_mysql_session_after_callback() or {
-					return error('${migration_err.msg()}; ${err.msg()}')
-				}
+			m.validate_session_after_callback() or {
+				return error('${migration_err.msg()}; ${err.msg()}')
 			}
 			return migration_err
 		}
 		ctx.execute(m.history_insert_sql(migration, applied_at))!
 	}
-	if m.config.dialect == .mysql {
-		m.validate_mysql_session_after_callback()!
-	}
+	m.validate_session_after_callback()!
 	return AppliedMigration{
 		version:    migration.version
 		name:       migration.name
@@ -716,27 +712,37 @@ fn (mut m Migrator) run_down(migration Migration) ! {
 		mut ctx := new_context(m.conn, m.config.dialect)
 		migration.down(mut ctx) or {
 			migration_err := err
-			if m.config.dialect == .mysql {
-				m.validate_mysql_session_after_callback() or {
-					return error('${migration_err.msg()}; ${err.msg()}')
-				}
+			m.validate_session_after_callback() or {
+				return error('${migration_err.msg()}; ${err.msg()}')
 			}
 			return migration_err
 		}
 		ctx.execute(m.history_delete_sql(migration.version))!
 	}
-	if m.config.dialect == .mysql {
-		m.validate_mysql_session_after_callback()!
-	}
+	m.validate_session_after_callback()!
 }
 
-fn (mut m Migrator) validate_mysql_session_after_callback() ! {
-	m.validate_mysql_session() or {
-		session_err := err
-		m.conn.orm_rollback() or {
-			return error('${session_err.msg()}; rolling back callback-created MySQL transaction state failed: ${err.msg()}')
+fn (mut m Migrator) validate_session_after_callback() ! {
+	match m.config.dialect {
+		.sqlite {}
+		.pg {
+			m.reject_existing_postgresql_transaction() or {
+				session_err := err
+				m.conn.orm_rollback() or {
+					return error('${session_err.msg()}; rolling back callback-created PostgreSQL transaction state failed: ${err.msg()}')
+				}
+				return error('PostgreSQL migration callback left unsafe session state: ${session_err.msg()}')
+			}
 		}
-		return error('MySQL migration callback left unsafe session state: ${session_err.msg()}')
+		.mysql {
+			m.validate_mysql_session() or {
+				session_err := err
+				m.conn.orm_rollback() or {
+					return error('${session_err.msg()}; rolling back callback-created MySQL transaction state failed: ${err.msg()}')
+				}
+				return error('MySQL migration callback left unsafe session state: ${session_err.msg()}')
+			}
+		}
 	}
 }
 

--- a/vlib/v3/migrations/migrations.v
+++ b/vlib/v3/migrations/migrations.v
@@ -561,7 +561,7 @@ fn (mut m Migrator) validate_mysql_session() ! {
 	if !mysql_autocommit_enabled(autocommit_rows)! {
 		return error('MySQL migrations require session autocommit to be enabled')
 	}
-	probe := 'v3_migrations_transaction_probe'
+	probe := 'v3_migrations_transaction_probe_${time.now().unix_nano()}'
 	m.conn.orm_savepoint(probe) or {
 		// MySQL rejects the savepoint outside a transaction, or discards it at
 		// the end of the probe statement when autocommit is enabled.

--- a/vlib/v3/migrations/migrations.v
+++ b/vlib/v3/migrations/migrations.v
@@ -418,7 +418,9 @@ fn (mut m Migrator) acquire_migration_lock() ! {
 				database_rows := m.conn.execute('SELECT DATABASE();')!
 				mysql_database_name(database_rows)!
 			}
-			name := mysql_migration_lock_name(database, m.config.table)
+			case_rows := m.conn.execute('SELECT @@lower_case_table_names;')!
+			lower_case_table_names := mysql_lower_case_table_names(case_rows)!
+			name := mysql_migration_lock_name(database, m.config.table, lower_case_table_names)
 			rows :=
 				m.conn.execute("SELECT GET_LOCK('${name}', ${migration_lock_timeout_seconds});")!
 			if !migration_lock_result(rows) {
@@ -477,9 +479,14 @@ fn postgresql_migration_lock_key(schema string, table string) i64 {
 	return migration_lock_key(identity)
 }
 
-fn mysql_migration_lock_name(database string, table string) string {
-	table_name := if table.contains('.') { table.all_after('.') } else { table }
-	identity := '${database.len}:${database}:${table_name.len}:${table_name}'
+fn mysql_migration_lock_name(database string, table string, lower_case_table_names int) string {
+	mut database_name := database
+	mut table_name := if table.contains('.') { table.all_after('.') } else { table }
+	if lower_case_table_names in [1, 2] {
+		database_name = database_name.to_lower_ascii()
+		table_name = table_name.to_lower_ascii()
+	}
+	identity := '${database_name.len}:${database_name}:${table_name.len}:${table_name}'
 	return 'v3_migrations_${fnv1a.sum64_string(identity).hex()}'
 }
 
@@ -488,6 +495,19 @@ fn mysql_database_name(rows []orm.Row) !string {
 		return error('could not determine current MySQL database for migration lock')
 	}
 	return rows[0].vals[0]
+}
+
+fn mysql_lower_case_table_names(rows []orm.Row) !int {
+	if rows.len != 1 || rows[0].vals.len == 0 {
+		return error('could not determine MySQL lower_case_table_names for migration lock')
+	}
+	value := strconv.atoi(rows[0].vals[0]) or {
+		return error('could not determine MySQL lower_case_table_names for migration lock')
+	}
+	if value !in [0, 1, 2] {
+		return error('unsupported MySQL lower_case_table_names value `${rows[0].vals[0]}`')
+	}
+	return value
 }
 
 fn postgresql_schema_name(rows []orm.Row) !string {

--- a/vlib/v3/migrations/migrations.v
+++ b/vlib/v3/migrations/migrations.v
@@ -1,5 +1,6 @@
 module migrations
 
+import hash.fnv1a
 import orm
 import strconv
 import time
@@ -71,9 +72,10 @@ pub:
 // Migrator applies an ordered set of migrations and records their versions.
 pub struct Migrator {
 mut:
-	conn       orm.TransactionalConnection
-	migrations []Migration
-	config     Config
+	conn            orm.TransactionalConnection
+	migrations      []Migration
+	config          Config
+	mysql_lock_name string
 }
 
 // new creates and validates a migrator. It does not access the database until
@@ -402,12 +404,15 @@ fn (mut m Migrator) acquire_migration_lock() ! {
 			m.conn.execute('SELECT pg_advisory_lock(${key});')!
 		}
 		.mysql {
-			name := migration_lock_name(key)
+			database_rows := m.conn.execute('SELECT DATABASE();')!
+			database := mysql_database_name(database_rows)!
+			name := mysql_migration_lock_name(database, m.config.table)
 			rows :=
 				m.conn.execute("SELECT GET_LOCK('${name}', ${migration_lock_timeout_seconds});")!
 			if !migration_lock_result(rows) {
 				return error('could not acquire MySQL migration lock `${name}` within ${migration_lock_timeout_seconds} seconds')
 			}
+			m.mysql_lock_name = name
 		}
 	}
 }
@@ -429,11 +434,15 @@ fn (mut m Migrator) release_migration_lock(success bool) ! {
 			}
 		}
 		.mysql {
-			name := migration_lock_name(key)
+			name := m.mysql_lock_name
+			if name == '' {
+				return error('cannot release MySQL migration lock before it is acquired')
+			}
 			rows := m.conn.execute("SELECT RELEASE_LOCK('${name}');")!
 			if !migration_lock_result(rows) {
 				return error('could not release MySQL migration lock `${name}`')
 			}
+			m.mysql_lock_name = ''
 		}
 	}
 }
@@ -448,6 +457,18 @@ fn migration_lock_key(table string) i64 {
 
 fn migration_lock_name(key i64) string {
 	return 'v3_migrations_${key}'
+}
+
+fn mysql_migration_lock_name(database string, table string) string {
+	identity := '${database.len}:${database}:${table}'
+	return 'v3_migrations_${fnv1a.sum64_string(identity).hex()}'
+}
+
+fn mysql_database_name(rows []orm.Row) !string {
+	if rows.len != 1 || rows[0].vals.len == 0 || rows[0].vals[0] == '' {
+		return error('could not determine current MySQL database for migration lock')
+	}
+	return rows[0].vals[0]
 }
 
 fn migration_lock_result(rows []orm.Row) bool {

--- a/vlib/v3/migrations/migrations.v
+++ b/vlib/v3/migrations/migrations.v
@@ -452,15 +452,11 @@ fn (mut m Migrator) release_migration_lock(success bool) ! {
 }
 
 fn migration_lock_key(table string) i64 {
-	mut hash := u64(5381)
-	for ch in table.bytes() {
-		hash = ((hash * 33) ^ u64(ch)) & u64(0x7fffffff)
+	hash := fnv1a.sum64_string(table)
+	if hash <= u64(max_i64) {
+		return i64(hash)
 	}
-	return i64(hash)
-}
-
-fn migration_lock_name(key i64) string {
-	return 'v3_migrations_${key}'
+	return -i64(~hash) - 1
 }
 
 fn mysql_migration_lock_name(database string, table string) string {

--- a/vlib/v3/migrations/migrations.v
+++ b/vlib/v3/migrations/migrations.v
@@ -404,8 +404,12 @@ fn (mut m Migrator) acquire_migration_lock() ! {
 			m.conn.execute('SELECT pg_advisory_lock(${key});')!
 		}
 		.mysql {
-			database_rows := m.conn.execute('SELECT DATABASE();')!
-			database := mysql_database_name(database_rows)!
+			database := if m.config.table.contains('.') {
+				m.config.table.all_before('.')
+			} else {
+				database_rows := m.conn.execute('SELECT DATABASE();')!
+				mysql_database_name(database_rows)!
+			}
 			name := mysql_migration_lock_name(database, m.config.table)
 			rows :=
 				m.conn.execute("SELECT GET_LOCK('${name}', ${migration_lock_timeout_seconds});")!

--- a/vlib/v3/migrations/migrations.v
+++ b/vlib/v3/migrations/migrations.v
@@ -72,12 +72,14 @@ pub:
 // Migrator applies an ordered set of migrations and records their versions.
 pub struct Migrator {
 mut:
-	conn                     orm.TransactionalConnection
-	migrations               []Migration
-	config                   Config
-	pg_lock_key              ?i64
-	mysql_lock_name          string
-	locked_history_table_sql string
+	conn                         orm.TransactionalConnection
+	migrations                   []Migration
+	config                       Config
+	pg_lock_key                  ?i64
+	mysql_lock_name              string
+	resolved_history_namespace   string
+	resolved_history_table_sql   string
+	session_connection_validated bool
 }
 
 // new creates and validates a migrator. It does not access the database until
@@ -400,8 +402,8 @@ fn (mut m Migrator) ensure_history_table() ! {
 }
 
 fn (m &Migrator) history_table_sql() string {
-	if m.locked_history_table_sql != '' {
-		return m.locked_history_table_sql
+	if m.resolved_history_table_sql != '' {
+		return m.resolved_history_table_sql
 	}
 	if m.config.dialect == .sqlite && !m.config.table.contains('.') {
 		return qualified_history_table_sql(.sqlite, 'main', m.config.table)
@@ -410,19 +412,23 @@ fn (m &Migrator) history_table_sql() string {
 }
 
 fn (mut m Migrator) acquire_migration_lock() ! {
+	m.validate_session_connection()!
 	match m.config.dialect {
 		.sqlite {
 			m.conn.execute('BEGIN IMMEDIATE;')!
-			namespace := if m.config.table.contains('.') {
+			namespace := if m.resolved_history_namespace != '' {
+				m.resolved_history_namespace
+			} else if m.config.table.contains('.') {
 				m.config.table.all_before('.')
 			} else {
 				'main'
 			}
-			m.locked_history_table_sql = qualified_history_table_sql(.sqlite, namespace,
-				m.config.table)
+			m.retain_history_relation(.sqlite, namespace)
 		}
 		.pg {
-			schema := if m.config.table.contains('.') {
+			schema := if m.resolved_history_namespace != '' {
+				m.resolved_history_namespace
+			} else if m.config.table.contains('.') {
 				m.config.table.all_before('.')
 			} else {
 				schema_rows := m.conn.execute('SELECT current_schema();')!
@@ -431,10 +437,12 @@ fn (mut m Migrator) acquire_migration_lock() ! {
 			key := postgresql_migration_lock_key(schema, m.config.table)
 			m.conn.execute('SELECT pg_advisory_lock(${key});')!
 			m.pg_lock_key = key
-			m.locked_history_table_sql = qualified_history_table_sql(.pg, schema, m.config.table)
+			m.retain_history_relation(.pg, schema)
 		}
 		.mysql {
-			database := if m.config.table.contains('.') {
+			database := if m.resolved_history_namespace != '' {
+				m.resolved_history_namespace
+			} else if m.config.table.contains('.') {
 				m.config.table.all_before('.')
 			} else {
 				database_rows := m.conn.execute('SELECT DATABASE();')!
@@ -449,10 +457,32 @@ fn (mut m Migrator) acquire_migration_lock() ! {
 				return error('could not acquire MySQL migration lock `${name}` within ${migration_lock_timeout_seconds} seconds')
 			}
 			m.mysql_lock_name = name
-			m.locked_history_table_sql = qualified_history_table_sql(.mysql, database,
-				m.config.table)
+			m.retain_history_relation(.mysql, database)
 		}
 	}
+}
+
+fn (mut m Migrator) retain_history_relation(dialect Dialect, namespace string) {
+	if m.resolved_history_namespace != '' {
+		return
+	}
+	m.resolved_history_namespace = namespace
+	m.resolved_history_table_sql = qualified_history_table_sql(dialect, namespace, m.config.table)
+}
+
+fn (mut m Migrator) validate_session_connection() ! {
+	if m.config.dialect != .pg || m.session_connection_validated {
+		return
+	}
+	if m.conn is orm.DB {
+		m.conn.orm_begin() or {
+			return error('PostgreSQL migrations require a session-pinned connection; orm.DB wrapper validation failed: ${err.msg()}; use pg.DB.conn() or pg.connect_direct()')
+		}
+		m.conn.orm_rollback() or {
+			return error('PostgreSQL migrations could not roll back the session-affinity validation transaction: ${err.msg()}')
+		}
+	}
+	m.session_connection_validated = true
 }
 
 fn (mut m Migrator) release_migration_lock(success bool) ! {
@@ -487,7 +517,6 @@ fn (mut m Migrator) release_migration_lock(success bool) ! {
 			m.mysql_lock_name = ''
 		}
 	}
-	m.locked_history_table_sql = ''
 }
 
 fn migration_lock_key(identity string) i64 {

--- a/vlib/v3/migrations/migrations.v
+++ b/vlib/v3/migrations/migrations.v
@@ -87,7 +87,7 @@ pub fn new(mut conn orm.TransactionalConnection, registered []Migration, config 
 	validate_identifier_for_dialect(config.dialect, config.table, 'migration history table')!
 	if config.dialect == .pg {
 		if mut conn is orm.DB {
-			return error('PostgreSQL migrations require a direct session-pinned connection; orm.DB wrappers cannot be validated without mutating the wrapped connection; pass pg.Conn or pg.Tx directly')
+			return error('PostgreSQL migrations require a direct session-pinned connection; orm.DB wrappers cannot be validated without mutating the wrapped connection; pass pg.Conn directly')
 		}
 	}
 	mut ordered := registered.clone()
@@ -429,6 +429,7 @@ fn (mut m Migrator) acquire_migration_lock() ! {
 			m.retain_history_relation(.sqlite, namespace)
 		}
 		.pg {
+			m.reject_existing_postgresql_transaction()!
 			schema := if m.resolved_history_namespace != '' {
 				m.resolved_history_namespace
 			} else if m.config.table.contains('.') {
@@ -463,6 +464,22 @@ fn (mut m Migrator) acquire_migration_lock() ! {
 			m.retain_history_relation(.mysql, database)
 		}
 	}
+}
+
+fn (mut m Migrator) reject_existing_postgresql_transaction() ! {
+	if !m.uses_transactions() {
+		return
+	}
+	probe := 'v3_migrations_transaction_probe'
+	m.conn.orm_savepoint(probe) or {
+		// PostgreSQL rejects SAVEPOINT outside a transaction, which is the expected
+		// state when the migrator owns per-migration transactions.
+		return
+	}
+	m.conn.orm_release_savepoint(probe) or {
+		return error('could not release PostgreSQL transaction ownership probe: ${err.msg()}')
+	}
+	return error('PostgreSQL migrations cannot manage transactions on a connection with an already-open transaction (including pg.Tx); use transaction_mode: .never to preserve the caller-owned transaction')
 }
 
 fn (mut m Migrator) retain_history_relation(dialect Dialect, namespace string) {

--- a/vlib/v3/migrations/migrations.v
+++ b/vlib/v3/migrations/migrations.v
@@ -79,6 +79,7 @@ mut:
 	pg_lock_key                ?i64
 	mysql_lock_name            string
 	sqlite_lock_active         bool
+	sqlite_transaction_probe   string
 	resolved_history_namespace string
 	resolved_history_table_sql string
 }
@@ -432,8 +433,10 @@ fn (m &Migrator) history_table_sql() string {
 fn (mut m Migrator) acquire_migration_lock() ! {
 	match m.config.dialect {
 		.sqlite {
+			m.prepare_sqlite_transaction_probe()!
 			m.conn.execute('BEGIN IMMEDIATE;')!
 			m.sqlite_lock_active = true
+			m.conn.execute('SAVEPOINT ${m.sqlite_transaction_probe};')!
 			namespace := if m.resolved_history_namespace != '' {
 				m.resolved_history_namespace
 			} else if m.config.table.contains('.') {
@@ -541,6 +544,18 @@ fn verify_postgresql_owned_transaction(mut ctx Context, token string) ! {
 	}
 }
 
+fn (mut m Migrator) mark_mysql_owned_transaction() !string {
+	savepoint := 'v3_migrations_owned_${time.now().unix_nano()}'
+	m.conn.orm_savepoint(savepoint)!
+	return savepoint
+}
+
+fn (mut m Migrator) verify_mysql_owned_transaction(savepoint string) ! {
+	m.conn.orm_release_savepoint(savepoint) or {
+		return error('MySQL migration callback ended the migrator-owned transaction before history was recorded')
+	}
+}
+
 fn (mut m Migrator) validate_mysql_session() ! {
 	autocommit_rows := m.conn.execute('SELECT @@autocommit;')!
 	if !mysql_autocommit_enabled(autocommit_rows)! {
@@ -567,15 +582,15 @@ fn (mut m Migrator) retain_history_relation(dialect Dialect, namespace string) {
 fn (mut m Migrator) release_migration_lock(success bool) ! {
 	match m.config.dialect {
 		.sqlite {
-			if !m.sqlite_lock_active {
-				return
+			if m.sqlite_lock_active {
+				if success {
+					m.conn.orm_commit()!
+				} else {
+					m.conn.orm_rollback()!
+				}
+				m.sqlite_lock_active = false
 			}
-			if success {
-				m.conn.orm_commit()!
-			} else {
-				m.conn.orm_rollback()!
-			}
-			m.sqlite_lock_active = false
+			m.cleanup_sqlite_transaction_probe()!
 		}
 		.pg {
 			key := m.pg_lock_key or {
@@ -680,36 +695,61 @@ fn migration_lock_result(rows []orm.Row) bool {
 	return rows.len == 1 && rows[0].vals.len > 0 && rows[0].vals[0] in ['1', 't', 'true']
 }
 
+fn (mut m Migrator) prepare_sqlite_transaction_probe() ! {
+	m.sqlite_transaction_probe = 'v3_migrations_transaction_${time.now().unix_nano()}'
+	table := sqlite_transaction_probe_table_sql(m.sqlite_transaction_probe)
+	m.conn.execute('CREATE TEMP TABLE ${table} (marker INTEGER NOT NULL);')!
+}
+
+fn (mut m Migrator) cleanup_sqlite_transaction_probe() ! {
+	if m.sqlite_transaction_probe == '' {
+		return
+	}
+	table := sqlite_transaction_probe_table_sql(m.sqlite_transaction_probe)
+	m.conn.execute('DROP TABLE IF EXISTS ${table};')!
+	m.sqlite_transaction_probe = ''
+}
+
 fn (mut m Migrator) verify_sqlite_lock_transaction() ! {
-	foreign_keys_rows := m.conn.execute('PRAGMA foreign_keys;')!
-	foreign_keys_enabled := sqlite_foreign_keys_enabled(foreign_keys_rows)!
-	toggled_value := if foreign_keys_enabled { 'OFF' } else { 'ON' }
-	m.conn.execute('PRAGMA foreign_keys = ${toggled_value};')!
-	toggled_rows := m.conn.execute('PRAGMA foreign_keys;')!
-	if sqlite_foreign_keys_enabled(toggled_rows)! == foreign_keys_enabled {
-		// SQLite ignores foreign_keys changes inside a transaction. An unchanged
-		// value confirms that the BEGIN IMMEDIATE transaction is still active.
+	if m.sqlite_transaction_probe == '' {
+		return error('cannot verify SQLite migration lock transaction before it is acquired')
+	}
+	table := sqlite_transaction_probe_table_sql(m.sqlite_transaction_probe)
+	check_savepoint := '${m.sqlite_transaction_probe}_check'
+	m.conn.execute('SAVEPOINT ${check_savepoint};')!
+	m.conn.execute('RELEASE SAVEPOINT ${m.sqlite_transaction_probe};') or {
+		return error('SQLite migration callback ended the migration lock transaction before history was recorded')
+	}
+	m.conn.execute('INSERT INTO ${table} (marker) VALUES (1);')!
+	m.conn.execute('ROLLBACK TO SAVEPOINT ${check_savepoint};') or {
+		// Releasing the original savepoint also released the nested check
+		// savepoint, proving that the original lock transaction is still active.
+		m.conn.execute('DELETE FROM ${table};')!
+		m.conn.execute('SAVEPOINT ${m.sqlite_transaction_probe};')!
+		return
+	}
+	rows := m.conn.execute('SELECT COUNT(*) FROM ${table};')!
+	marker_count := sqlite_transaction_probe_count(rows)!
+	m.conn.execute('DELETE FROM ${table};')!
+	m.conn.execute('RELEASE SAVEPOINT ${check_savepoint};') or {}
+	if marker_count == 1 {
+		m.conn.execute('SAVEPOINT ${m.sqlite_transaction_probe};')!
 		return
 	}
 	state_err := 'SQLite migration callback ended the migration lock transaction before history was recorded'
-	restored_value := if foreign_keys_enabled { 'ON' } else { 'OFF' }
-	m.conn.execute('PRAGMA foreign_keys = ${restored_value};')!
-	restored_rows := m.conn.execute('PRAGMA foreign_keys;')!
-	if sqlite_foreign_keys_enabled(restored_rows)! != foreign_keys_enabled {
-		return error('${state_err}; restoring SQLite foreign_keys state failed')
-	}
-	m.sqlite_lock_active = false
 	return error(state_err)
 }
 
-fn sqlite_foreign_keys_enabled(rows []orm.Row) !bool {
+fn sqlite_transaction_probe_table_sql(name string) string {
+	return 'temp.${quote_identifier_component(.sqlite, name)}'
+}
+
+fn sqlite_transaction_probe_count(rows []orm.Row) !int {
 	if rows.len != 1 || rows[0].vals.len == 0 {
 		return error('could not determine SQLite transaction state')
 	}
-	return match rows[0].vals[0] {
-		'0' { false }
-		'1' { true }
-		else { return error('unsupported SQLite foreign_keys value `${rows[0].vals[0]}`') }
+	return strconv.atoi(rows[0].vals[0]) or {
+		return error('could not determine SQLite transaction state')
 	}
 }
 
@@ -728,6 +768,7 @@ fn (mut m Migrator) run_up(migration Migration) !AppliedMigration {
 		mut tx := orm.begin(mut m.conn)!
 		mut ctx := new_context(tx, m.config.dialect)
 		mut postgresql_transaction_token := ''
+		mut mysql_transaction_savepoint := ''
 		if m.config.dialect == .pg {
 			postgresql_transaction_token = mark_postgresql_owned_transaction(mut ctx) or {
 				probe_err := err
@@ -735,6 +776,14 @@ fn (mut m Migrator) run_up(migration Migration) !AppliedMigration {
 					return error('could not mark the migrator-owned PostgreSQL transaction: ${probe_err.msg()}; rollback failed: ${err.msg()}')
 				}
 				return error('could not mark the migrator-owned PostgreSQL transaction: ${probe_err.msg()}')
+			}
+		} else if m.config.dialect == .mysql {
+			mysql_transaction_savepoint = m.mark_mysql_owned_transaction() or {
+				probe_err := err
+				tx.rollback() or {
+					return error('could not mark the migrator-owned MySQL transaction: ${probe_err.msg()}; rollback failed: ${err.msg()}')
+				}
+				return error('could not mark the migrator-owned MySQL transaction: ${probe_err.msg()}')
 			}
 		}
 		migration.up(mut ctx) or {
@@ -746,6 +795,14 @@ fn (mut m Migrator) run_up(migration Migration) !AppliedMigration {
 		}
 		if m.config.dialect == .pg {
 			verify_postgresql_owned_transaction(mut ctx, postgresql_transaction_token) or {
+				transaction_err := err
+				tx.rollback() or {
+					return error('${transaction_err.msg()}; rollback failed: ${err.msg()}')
+				}
+				return transaction_err
+			}
+		} else if m.config.dialect == .mysql {
+			m.verify_mysql_owned_transaction(mysql_transaction_savepoint) or {
 				transaction_err := err
 				tx.rollback() or {
 					return error('${transaction_err.msg()}; rollback failed: ${err.msg()}')
@@ -788,6 +845,7 @@ fn (mut m Migrator) run_down(migration Migration) ! {
 		mut tx := orm.begin(mut m.conn)!
 		mut ctx := new_context(tx, m.config.dialect)
 		mut postgresql_transaction_token := ''
+		mut mysql_transaction_savepoint := ''
 		if m.config.dialect == .pg {
 			postgresql_transaction_token = mark_postgresql_owned_transaction(mut ctx) or {
 				probe_err := err
@@ -795,6 +853,14 @@ fn (mut m Migrator) run_down(migration Migration) ! {
 					return error('could not mark the migrator-owned PostgreSQL transaction: ${probe_err.msg()}; transaction rollback failed: ${err.msg()}')
 				}
 				return error('could not mark the migrator-owned PostgreSQL transaction: ${probe_err.msg()}')
+			}
+		} else if m.config.dialect == .mysql {
+			mysql_transaction_savepoint = m.mark_mysql_owned_transaction() or {
+				probe_err := err
+				tx.rollback() or {
+					return error('could not mark the migrator-owned MySQL transaction: ${probe_err.msg()}; transaction rollback failed: ${err.msg()}')
+				}
+				return error('could not mark the migrator-owned MySQL transaction: ${probe_err.msg()}')
 			}
 		}
 		migration.down(mut ctx) or {
@@ -806,6 +872,14 @@ fn (mut m Migrator) run_down(migration Migration) ! {
 		}
 		if m.config.dialect == .pg {
 			verify_postgresql_owned_transaction(mut ctx, postgresql_transaction_token) or {
+				transaction_err := err
+				tx.rollback() or {
+					return error('${transaction_err.msg()}; transaction rollback failed: ${err.msg()}')
+				}
+				return transaction_err
+			}
+		} else if m.config.dialect == .mysql {
+			m.verify_mysql_owned_transaction(mysql_transaction_savepoint) or {
 				transaction_err := err
 				tx.rollback() or {
 					return error('${transaction_err.msg()}; transaction rollback failed: ${err.msg()}')

--- a/vlib/v3/migrations/migrations.v
+++ b/vlib/v3/migrations/migrations.v
@@ -401,8 +401,17 @@ fn (m &Migrator) find_migration(version i64) ?Migration {
 }
 
 fn (mut m Migrator) ensure_history_table() ! {
-	if m.config.dialect == .pg {
-		m.resolve_postgresql_history_schema()!
+	match m.config.dialect {
+		.pg {
+			m.resolve_postgresql_history_schema()!
+		}
+		.mysql {
+			if m.mysql_lock_name == '' {
+				m.reject_existing_mysql_transaction()!
+			}
+			m.resolve_mysql_history_database()!
+		}
+		.sqlite {}
 	}
 	table := m.history_table_sql()
 	m.conn.execute('CREATE TABLE IF NOT EXISTS ${table} (version BIGINT PRIMARY KEY, name VARCHAR(255) NOT NULL, applied_at VARCHAR(32) NOT NULL);')!
@@ -440,14 +449,8 @@ fn (mut m Migrator) acquire_migration_lock() ! {
 			m.retain_history_relation(.pg, schema)
 		}
 		.mysql {
-			database := if m.resolved_history_namespace != '' {
-				m.resolved_history_namespace
-			} else if m.config.table.contains('.') {
-				m.config.table.all_before('.')
-			} else {
-				database_rows := m.conn.execute('SELECT DATABASE();')!
-				mysql_database_name(database_rows)!
-			}
+			m.reject_existing_mysql_transaction()!
+			database := m.resolve_mysql_history_database()!
 			case_rows := m.conn.execute('SELECT @@lower_case_table_names;')!
 			lower_case_table_names := mysql_lower_case_table_names(case_rows)!
 			name := mysql_migration_lock_name(database, m.config.table, lower_case_table_names)
@@ -476,6 +479,20 @@ fn (mut m Migrator) resolve_postgresql_history_schema() !string {
 	return schema
 }
 
+fn (mut m Migrator) resolve_mysql_history_database() !string {
+	if m.resolved_history_namespace != '' {
+		return m.resolved_history_namespace
+	}
+	database := if m.config.table.contains('.') {
+		m.config.table.all_before('.')
+	} else {
+		database_rows := m.conn.execute('SELECT DATABASE();')!
+		mysql_database_name(database_rows)!
+	}
+	m.retain_history_relation(.mysql, database)
+	return database
+}
+
 fn (mut m Migrator) reject_existing_postgresql_transaction() ! {
 	probe := 'v3_migrations_transaction_probe'
 	m.conn.orm_savepoint(probe) or {
@@ -487,6 +504,17 @@ fn (mut m Migrator) reject_existing_postgresql_transaction() ! {
 		return error('could not release PostgreSQL transaction ownership probe: ${err.msg()}')
 	}
 	return error('PostgreSQL migrations require a connection without an already-open transaction; pg.Tx and transactional pg.Conn values are not supported')
+}
+
+fn (mut m Migrator) reject_existing_mysql_transaction() ! {
+	probe := 'v3_migrations_transaction_probe'
+	m.conn.orm_savepoint(probe) or {
+		// MySQL rejects the savepoint outside a transaction, or discards it at
+		// the end of the probe statement when autocommit is enabled.
+		return
+	}
+	m.conn.orm_release_savepoint(probe) or { return }
+	return error('MySQL migrations require a connection without an already-open transaction')
 }
 
 fn (mut m Migrator) retain_history_relation(dialect Dialect, namespace string) {

--- a/vlib/v3/migrations/migrations.v
+++ b/vlib/v3/migrations/migrations.v
@@ -79,7 +79,7 @@ mut:
 // new creates and validates a migrator. It does not access the database until
 // one of the migration or inspection methods is called.
 pub fn new(mut conn orm.TransactionalConnection, registered []Migration, config Config) !Migrator {
-	validate_identifier(config.table, 'migration history table')!
+	validate_identifier_for_dialect(config.dialect, config.table, 'migration history table')!
 	mut ordered := registered.clone()
 	ordered.sort_with_compare(compare_migrations)
 	mut previous := i64(0)

--- a/vlib/v3/migrations/migrations.v
+++ b/vlib/v3/migrations/migrations.v
@@ -94,6 +94,9 @@ pub fn new(mut conn orm.TransactionalConnection, registered []Migration, config 
 		if migration.name.trim_space() == '' {
 			return error('migration ${migration.version} must have a name')
 		}
+		if migration.name.contains_u8(u8(0)) {
+			return error('migration ${migration.version} name must not contain NUL bytes')
+		}
 		if migration.name.len > 255 {
 			return error('migration ${migration.version} name must not exceed 255 bytes')
 		}
@@ -400,6 +403,9 @@ fn (m &Migrator) history_table_sql() string {
 	if m.locked_history_table_sql != '' {
 		return m.locked_history_table_sql
 	}
+	if m.config.dialect == .sqlite && !m.config.table.contains('.') {
+		return qualified_history_table_sql(.sqlite, 'main', m.config.table)
+	}
 	return quote_identifier(m.config.dialect, m.config.table)
 }
 
@@ -407,7 +413,13 @@ fn (mut m Migrator) acquire_migration_lock() ! {
 	match m.config.dialect {
 		.sqlite {
 			m.conn.execute('BEGIN IMMEDIATE;')!
-			m.locked_history_table_sql = quote_identifier(.sqlite, m.config.table)
+			namespace := if m.config.table.contains('.') {
+				m.config.table.all_before('.')
+			} else {
+				'main'
+			}
+			m.locked_history_table_sql = qualified_history_table_sql(.sqlite, namespace,
+				m.config.table)
 		}
 		.pg {
 			schema := if m.config.table.contains('.') {

--- a/vlib/v3/migrations/migrations_test.v
+++ b/vlib/v3/migrations/migrations_test.v
@@ -52,7 +52,7 @@ fn (mut conn RecordingConnection) execute(query string) ![]orm.Row {
 			vals: [conn.database]
 		}]
 	}
-	if query.starts_with('SELECT COALESCE((SELECT n.nspname FROM pg_catalog.pg_class AS c ') {
+	if query.starts_with('WITH persistent_search_path AS (') {
 		return [
 			orm.Row{
 				vals: [if conn.postgresql_history_schema == '' {
@@ -689,6 +689,58 @@ fn test_postgresql_migration_locks_canonicalize_history_table() {
 	qualified_runner.acquire_migration_lock()!
 	qualified_runner.release_migration_lock(true)!
 	assert qualified_recorder.queries == unqualified_recorder.queries[1..]
+
+	temp_key := postgresql_migration_lock_key('pg_temp', 'schema_migrations')
+	mut temp_recorder := &RecordingConnection{}
+	mut temp_runner := new(mut temp_recorder, []Migration{}, Config{
+		dialect: .pg
+		table:   'pg_temp.schema_migrations'
+	})!
+	temp_runner.acquire_migration_lock()!
+	temp_runner.release_migration_lock(true)!
+	assert temp_recorder.queries == [
+		'SELECT pg_advisory_lock(${temp_key});',
+		'SELECT pg_advisory_unlock(${temp_key});',
+	]
+}
+
+fn test_postgresql_inspection_resolves_and_retains_existing_history_schema() {
+	mut recorder := &RecordingConnection{
+		schema:                    'tenant'
+		postgresql_history_schema: 'public'
+		history_rows:              [
+			orm.Row{
+				vals: ['7', 'already_applied', '2026-08-16T00:00:00Z']
+			},
+		]
+	}
+	mut runner := new(mut recorder, []Migration{}, Config{
+		dialect: .pg
+	})!
+	assert runner.applied()!.map(it.version) == [i64(7)]
+	assert runner.pending()!.len == 0
+	assert runner.current_version()! == 7
+	status := runner.status()!
+	assert status.len == 1
+	assert status[0].state == .missing
+	assert runner.resolved_history_namespace == 'public'
+	assert recorder.queries.filter(it == postgresql_history_schema_query('schema_migrations')).len == 1
+	for query in recorder.queries {
+		if query.starts_with('CREATE TABLE IF NOT EXISTS ')
+			|| query.starts_with('SELECT version, name, applied_at FROM ') {
+			assert query.contains('"public"."schema_migrations"')
+		}
+	}
+	runner.acquire_migration_lock()!
+	runner.release_migration_lock(true)!
+	key := postgresql_migration_lock_key('public', 'schema_migrations')
+	assert recorder.queries#[-2..] == [
+		'SELECT pg_advisory_lock(${key});',
+		'SELECT pg_advisory_unlock(${key});',
+	]
+	query := postgresql_history_schema_query('schema_migrations')
+	assert query.contains('current_schemas(false)')
+	assert query.contains('n.oid <> pg_catalog.pg_my_temp_schema()')
 }
 
 fn test_mysql_history_literals_are_backslash_safe() {

--- a/vlib/v3/migrations/migrations_test.v
+++ b/vlib/v3/migrations/migrations_test.v
@@ -7,11 +7,13 @@ import orm
 @[heap]
 struct RecordingConnection {
 mut:
-	queries                []string
-	database               string = 'test_database'
-	schema                 string = 'public'
-	lower_case_table_names int
-	history_rows           []orm.Row
+	queries                 []string
+	database                string = 'test_database'
+	schema                  string = 'public'
+	lower_case_table_names  int
+	history_rows            []orm.Row
+	in_transaction          bool
+	postgresql_table_schema string = 'public'
 }
 
 fn (mut conn RecordingConnection) select(_ orm.SelectConfig, _ orm.QueryData, _ orm.QueryData) ![][]orm.Primitive {
@@ -53,6 +55,11 @@ fn (mut conn RecordingConnection) execute(query string) ![]orm.Row {
 			vals: [conn.schema]
 		}]
 	}
+	if query.starts_with('SELECT n.nspname FROM pg_catalog.pg_class AS c ') {
+		return [orm.Row{
+			vals: [conn.postgresql_table_schema]
+		}]
+	}
 	if query == 'SELECT @@lower_case_table_names;' {
 		return [orm.Row{
 			vals: [conn.lower_case_table_names.str()]
@@ -69,17 +76,23 @@ fn (mut conn RecordingConnection) execute(query string) ![]orm.Row {
 
 fn (mut conn RecordingConnection) orm_begin() ! {
 	conn.queries << 'ORM BEGIN'
+	conn.in_transaction = true
 }
 
 fn (mut conn RecordingConnection) orm_commit() ! {
 	conn.queries << 'ORM COMMIT'
+	conn.in_transaction = false
 }
 
 fn (mut conn RecordingConnection) orm_rollback() ! {
 	conn.queries << 'ORM ROLLBACK'
+	conn.in_transaction = false
 }
 
 fn (mut conn RecordingConnection) orm_savepoint(name string) ! {
+	if !conn.in_transaction {
+		return error('savepoint requires an active transaction')
+	}
 	conn.queries << 'ORM SAVEPOINT ${name}'
 }
 
@@ -425,8 +438,37 @@ fn test_postgresql_orm_wrapper_is_rejected_without_mutating_its_transaction() {
 	new(mut scoped, []Migration{}, Config{
 		dialect: .pg
 	}) or { error_message = err.msg() }
-	assert error_message == 'PostgreSQL migrations require a direct session-pinned connection; orm.DB wrappers cannot be validated without mutating the wrapped connection; pass pg.Conn or pg.Tx directly'
+	assert error_message == 'PostgreSQL migrations require a direct session-pinned connection; orm.DB wrappers cannot be validated without mutating the wrapped connection; pass pg.Conn directly'
 	assert recorder.queries.len == 0
+}
+
+fn test_postgresql_open_transaction_is_rejected_without_being_finished() {
+	mut recorder := &RecordingConnection{
+		in_transaction: true
+	}
+	mut runner := new(mut recorder, []Migration{}, Config{
+		dialect: .pg
+	})!
+	mut error_message := ''
+	runner.migrate() or { error_message = err.msg() }
+	assert error_message == 'PostgreSQL migrations cannot manage transactions on a connection with an already-open transaction (including pg.Tx); use transaction_mode: .never to preserve the caller-owned transaction'
+	assert recorder.in_transaction
+	assert recorder.queries == [
+		'ORM SAVEPOINT v3_migrations_transaction_probe',
+		'ORM RELEASE SAVEPOINT v3_migrations_transaction_probe',
+	]
+
+	mut externally_managed := &RecordingConnection{
+		in_transaction: true
+	}
+	mut never_runner := new(mut externally_managed, []Migration{}, Config{
+		dialect:          .pg
+		transaction_mode: .never
+	})!
+	assert never_runner.migrate()!.len == 0
+	assert externally_managed.in_transaction
+	assert 'ORM COMMIT' !in externally_managed.queries
+	assert 'ORM ROLLBACK' !in externally_managed.queries
 }
 
 fn test_sqlite_history_table_is_pinned_to_main() {
@@ -920,7 +962,9 @@ fn test_rename_table_rejects_qualified_targets_where_required() {
 }
 
 fn test_postgresql_remove_index_uses_the_table_schema() {
-	mut recorder := &RecordingConnection{}
+	mut recorder := &RecordingConnection{
+		postgresql_table_schema: 'later_schema'
+	}
 	mut ctx := new_context(recorder, .pg)
 	ctx.remove_index('archive.users', 'index_archive_users_on_email')!
 	ctx.remove_index('archive.users', 'reporting.custom_email_index')!
@@ -928,7 +972,8 @@ fn test_postgresql_remove_index_uses_the_table_schema() {
 	assert recorder.queries == [
 		'DROP INDEX "archive"."index_archive_users_on_email";',
 		'DROP INDEX "reporting"."custom_email_index";',
-		'DROP INDEX "index_users_on_email";',
+		"SELECT n.nspname FROM pg_catalog.pg_class AS c JOIN pg_catalog.pg_namespace AS n ON n.oid = c.relnamespace WHERE c.relname = E'users' AND c.relkind IN ('r', 'p', 'v', 'm', 'f') AND pg_catalog.pg_table_is_visible(c.oid) LIMIT 1;",
+		'DROP INDEX "later_schema"."index_users_on_email";',
 	]
 }
 

--- a/vlib/v3/migrations/migrations_test.v
+++ b/vlib/v3/migrations/migrations_test.v
@@ -2,6 +2,36 @@
 module migrations
 
 import db.sqlite
+import orm
+
+@[heap]
+struct RecordingConnection {
+mut:
+	queries []string
+}
+
+fn (mut conn RecordingConnection) select(_ orm.SelectConfig, _ orm.QueryData, _ orm.QueryData) ![][]orm.Primitive {
+	return []
+}
+
+fn (mut conn RecordingConnection) insert(_ orm.Table, _ orm.QueryData) ! {}
+
+fn (mut conn RecordingConnection) update(_ orm.Table, _ orm.QueryData, _ orm.QueryData) ! {}
+
+fn (mut conn RecordingConnection) delete(_ orm.Table, _ orm.QueryData) ! {}
+
+fn (mut conn RecordingConnection) create(_ orm.Table, _ []orm.TableField) ! {}
+
+fn (mut conn RecordingConnection) drop(_ orm.Table) ! {}
+
+fn (mut conn RecordingConnection) last_id() int {
+	return 0
+}
+
+fn (mut conn RecordingConnection) execute(query string) ![]orm.Row {
+	conn.queries << query
+	return []
+}
 
 struct MigrationWidget {
 	id    int @[primary; sql: serial]
@@ -180,6 +210,34 @@ fn test_context_supports_v3_orm_sql_blocks() {
 	assert db.q_int("SELECT count(*) FROM sqlite_master WHERE type = 'table' AND name = 'migrationwidget';")! == 1
 	runner.rollback(1)!
 	assert db.q_int("SELECT count(*) FROM sqlite_master WHERE type = 'table' AND name = 'migrationwidget';")! == 0
+}
+
+fn test_postgresql_change_column_rejects_constraint_options_before_sql() {
+	mut recorder := &RecordingConnection{}
+	mut ctx := new_context(recorder, .pg)
+	ctx.change_column('accounts', Column{
+		name:  'score'
+		kind:  .bigint
+		limit: 64
+	})!
+	assert recorder.queries == [
+		'ALTER TABLE "accounts" ALTER COLUMN "score" TYPE BIGINT;',
+	]
+
+	ctx.change_column('accounts', Column{
+		name:           'score'
+		kind:           .bigint
+		nullable:       false
+		default_sql:    '0'
+		unique:         true
+		primary_key:    true
+		auto_increment: true
+	}) or {
+		assert err.msg() == 'PostgreSQL change_column only supports type, limit, precision, and scale; unsupported options: nullable, default_sql, unique, primary_key, auto_increment; use ctx.execute() for constraint changes'
+		assert recorder.queries.len == 1
+		return
+	}
+	assert false
 }
 
 fn test_validation_and_portable_sql_generation() {

--- a/vlib/v3/migrations/migrations_test.v
+++ b/vlib/v3/migrations/migrations_test.v
@@ -286,6 +286,23 @@ fn test_mutating_runner_holds_dialect_lock_around_callbacks() {
 	}
 }
 
+fn test_mysql_history_literals_are_backslash_safe() {
+	mut recorder := &RecordingConnection{}
+	name := "quote\\'and_trailing\\"
+	migration := Migration{
+		version: 7
+		name:    name
+		up:      record_locked_migration
+		down:    record_locked_migration
+	}
+	runner := new(mut recorder, [migration], Config{
+		dialect: .mysql
+	})!
+	applied_at := '2026-08-16T00:00:00Z'
+	assert runner.history_insert_sql(migration, applied_at) == "INSERT INTO `schema_migrations` (version, name, applied_at) VALUES (7, X'${name.hex()}', X'${applied_at.hex()}');"
+	assert string_literal_sql(.sqlite, "quote'only") == "'quote''only'"
+}
+
 fn test_postgresql_change_column_rejects_constraint_options_before_sql() {
 	mut recorder := &RecordingConnection{}
 	mut ctx := new_context(recorder, .pg)
@@ -366,6 +383,21 @@ fn test_mysql_change_column_requires_complete_definition() {
 	})!
 	assert recorder.queries == [
 		'ALTER TABLE `accounts` MODIFY COLUMN `score` BIGINT NOT NULL DEFAULT 0;',
+	]
+}
+
+fn test_mysql_change_column_preserves_omitted_auto_increment_key() {
+	mut recorder := &RecordingConnection{}
+	mut ctx := new_context(recorder, .mysql)
+	ctx.change_column('accounts', Column{
+		name:           'id'
+		kind:           .bigint
+		nullable:       false
+		default_sql:    ''
+		auto_increment: true
+	})!
+	assert recorder.queries == [
+		'ALTER TABLE `accounts` MODIFY COLUMN `id` BIGINT AUTO_INCREMENT NOT NULL;',
 	]
 }
 
@@ -787,11 +819,46 @@ fn test_validation_and_portable_sql_generation() {
 		assert err.msg() == 'duplicate migration version 7'
 		assert column_type_sql(.pg, Column{ name: 'payload', kind: .jsonb })! == 'JSONB'
 		assert column_type_sql(.mysql, Column{ name: 'amount', kind: .double_precision })! == 'DOUBLE'
-		assert index_name(Index{
+		assert index_name(.sqlite, Index{
 			table:   'accounts'
 			columns: ['email', 'name']
 		})! == 'index_accounts_on_email_and_name'
 		return
 	}
 	assert false
+}
+
+fn test_generated_index_names_respect_dialect_limits() {
+	index := Index{
+		table:   'customer_account_records_archive'
+		columns: ['external_customer_reference', 'external_organization_reference']
+	}
+	raw_name := 'index_customer_account_records_archive_on_external_customer_reference_and_external_organization_reference'
+	mysql_name := index_name(.mysql, index)!
+	postgres_name := index_name(.pg, index)!
+	assert mysql_name.len == 64
+	assert postgres_name.len == 63
+	assert index_name(.sqlite, index)! == raw_name
+	assert index_name(.mysql, index)! == mysql_name
+	mut recorder := &RecordingConnection{}
+	mut ctx := new_context(recorder, .mysql)
+	ctx.add_index(index)!
+	assert recorder.queries == [
+		'CREATE INDEX `${mysql_name}` ON `customer_account_records_archive` (`external_customer_reference`, `external_organization_reference`);',
+	]
+
+	other_mysql_name := index_name(.mysql, Index{
+		table:   index.table
+		columns: ['external_customer_reference', 'external_organization_identifier']
+	})!
+	assert other_mysql_name != mysql_name
+
+	long_explicit_name := 'x'.repeat(65)
+	mut error_message := ''
+	index_name(.mysql, Index{
+		table:   'accounts'
+		columns: ['email']
+		name:    long_explicit_name
+	}) or { error_message = err.msg() }
+	assert error_message == 'MySQL index name `${long_explicit_name}` must not exceed 64 bytes'
 }

--- a/vlib/v3/migrations/migrations_test.v
+++ b/vlib/v3/migrations/migrations_test.v
@@ -1,0 +1,214 @@
+// vtest build: present_sqlite3? && !sanitize-memory-clang
+module migrations
+
+import db.sqlite
+
+struct MigrationWidget {
+	id    int @[primary; sql: serial]
+	label string
+}
+
+fn create_accounts(mut ctx Context) ! {
+	ctx.create_table(Table{
+		name: 'organizations'
+	})!
+	ctx.create_table(Table{
+		name:         'accounts'
+		columns:      [
+			Column{
+				name:     'email'
+				kind:     .varchar
+				nullable: false
+			},
+			Column{
+				name:     'organization_id'
+				kind:     .bigint
+				nullable: false
+			},
+		]
+		foreign_keys: [
+			ForeignKey{
+				from_table: 'accounts'
+				column:     'organization_id'
+				to_table:   'organizations'
+				on_delete:  'cascade'
+			},
+		]
+	})!
+}
+
+fn drop_accounts(mut ctx Context) ! {
+	ctx.drop_table('accounts')!
+	ctx.drop_table('organizations')!
+}
+
+fn add_account_name(mut ctx Context) ! {
+	ctx.add_column('accounts', Column{
+		name:        'name'
+		kind:        .text
+		default_sql: "''"
+		nullable:    false
+	})!
+	ctx.add_index(Index{
+		table:   'accounts'
+		columns: ['name']
+		name:    'index_accounts_on_name'
+	})!
+}
+
+fn remove_account_name(mut ctx Context) ! {
+	ctx.remove_index('accounts', 'index_accounts_on_name')!
+	ctx.remove_column('accounts', 'name')!
+}
+
+fn fail_after_create(mut ctx Context) ! {
+	ctx.create_table(Table{
+		name: 'should_rollback'
+	})!
+	return error('forced migration failure')
+}
+
+fn drop_should_rollback(mut ctx Context) ! {
+	ctx.drop_table('should_rollback')!
+}
+
+fn create_widget_with_orm_dsl(mut ctx Context) ! {
+	sql ctx {
+		create table MigrationWidget
+	}!
+}
+
+fn drop_widget_with_orm_dsl(mut ctx Context) ! {
+	sql ctx {
+		drop table MigrationWidget
+	}!
+}
+
+fn test_migrate_rollback_redo_and_status() {
+	mut db := sqlite.connect(':memory:')!
+	defer {
+		db.close() or {}
+	}
+	mut runner := new(mut db, [
+		Migration{
+			version: 202608160001
+			name:    'create_accounts'
+			up:      create_accounts
+			down:    drop_accounts
+		},
+		Migration{
+			version: 202608160002
+			name:    'add_account_name'
+			up:      add_account_name
+			down:    remove_account_name
+		},
+	], Config{})!
+
+	assert runner.pending()!.map(it.version) == [i64(202608160001), 202608160002]
+	applied := runner.migrate()!
+	assert applied.map(it.name) == ['create_accounts', 'add_account_name']
+	assert runner.current_version()! == 202608160002
+	assert db.q_int("SELECT count(*) FROM pragma_table_info('accounts') WHERE name = 'name';")! == 1
+	assert db.q_int("SELECT count(*) FROM pragma_foreign_key_list('accounts') WHERE `from` = 'organization_id';")! == 1
+	assert db.q_int("SELECT count(*) FROM sqlite_master WHERE type = 'index' AND name = 'index_accounts_on_name';")! == 1
+	assert runner.migrate()!.len == 0
+
+	statuses := runner.status()!
+	assert statuses.len == 2
+	assert statuses.all(it.state == .applied)
+
+	reverted := runner.rollback(1)!
+	assert reverted.map(it.version) == [i64(202608160002)]
+	assert db.q_int("SELECT count(*) FROM pragma_table_info('accounts') WHERE name = 'name';")! == 0
+	assert db.q_int("SELECT count(*) FROM sqlite_master WHERE type = 'index' AND name = 'index_accounts_on_name';")! == 0
+	assert runner.migrate()!.map(it.version) == [i64(202608160002)]
+	assert runner.redo(1)!.map(it.version) == [i64(202608160002)]
+	assert db.q_int("SELECT count(*) FROM pragma_table_info('accounts') WHERE name = 'name';")! == 1
+
+	runner.migrate_to(0)!
+	assert db.q_int("SELECT count(*) FROM sqlite_master WHERE type = 'table' AND name = 'accounts';")! == 0
+	assert runner.current_version()! == 0
+	db.exec("INSERT INTO schema_migrations (version, name, applied_at) VALUES (99, 'missing_file', '2026-08-16T00:00:00.000Z');")!
+	missing := runner.status()!.filter(it.state == .missing)
+	assert missing.len == 1
+	assert missing[0].version == 99
+	runner.rollback_last() or {
+		assert err.msg() == 'cannot roll back migration 99: its migration file is missing'
+		return
+	}
+	assert false
+}
+
+fn test_failed_migration_rolls_back_schema_and_history() {
+	mut db := sqlite.connect(':memory:')!
+	defer {
+		db.close() or {}
+	}
+	mut runner := new(mut db, [
+		Migration{
+			version: 1
+			name:    'fail_after_create'
+			up:      fail_after_create
+			down:    drop_should_rollback
+		},
+	], Config{})!
+
+	runner.migrate() or {
+		assert err.msg().contains('forced migration failure')
+		assert db.q_int("SELECT count(*) FROM sqlite_master WHERE type = 'table' AND name = 'should_rollback';")! == 0
+		assert runner.applied()!.len == 0
+		return
+	}
+	assert false
+}
+
+fn test_context_supports_v3_orm_sql_blocks() {
+	mut db := sqlite.connect(':memory:')!
+	defer {
+		db.close() or {}
+	}
+	mut runner := new(mut db, [
+		Migration{
+			version: 1
+			name:    'create_widget_with_orm_dsl'
+			up:      create_widget_with_orm_dsl
+			down:    drop_widget_with_orm_dsl
+		},
+	], Config{})!
+
+	runner.migrate()!
+	assert db.q_int("SELECT count(*) FROM sqlite_master WHERE type = 'table' AND name = 'migrationwidget';")! == 1
+	runner.rollback(1)!
+	assert db.q_int("SELECT count(*) FROM sqlite_master WHERE type = 'table' AND name = 'migrationwidget';")! == 0
+}
+
+fn test_validation_and_portable_sql_generation() {
+	mut db := sqlite.connect(':memory:')!
+	defer {
+		db.close() or {}
+	}
+	new(mut db, [
+		Migration{
+			version: 7
+			name:    'one'
+			up:      create_accounts
+			down:    drop_accounts
+		},
+		Migration{
+			version: 7
+			name:    'two'
+			up:      create_accounts
+			down:    drop_accounts
+		},
+	], Config{}) or {
+		assert err.msg() == 'duplicate migration version 7'
+		assert column_type_sql(.pg, Column{ name: 'payload', kind: .jsonb })! == 'JSONB'
+		assert column_type_sql(.mysql, Column{ name: 'amount', kind: .double_precision })! == 'DOUBLE'
+		assert index_name(Index{
+			table:   'accounts'
+			columns: ['email', 'name']
+		})! == 'index_accounts_on_email_and_name'
+		return
+	}
+	assert false
+}

--- a/vlib/v3/migrations/migrations_test.v
+++ b/vlib/v3/migrations/migrations_test.v
@@ -435,6 +435,64 @@ fn test_postgresql_remove_index_uses_the_table_schema() {
 	]
 }
 
+fn test_postgresql_add_index_rejects_qualified_names() {
+	mut recorder := &RecordingConnection{}
+	mut ctx := new_context(recorder, .pg)
+	mut error_message := ''
+	ctx.add_index(Index{
+		table:   'reporting.users'
+		columns: ['email']
+		name:    'reporting.users_email_idx'
+	}) or { error_message = err.msg() }
+	assert error_message == 'PostgreSQL add_index name `reporting.users_email_idx` must be unqualified'
+	assert recorder.queries.len == 0
+
+	ctx.add_index(Index{
+		table:   'reporting.users'
+		columns: ['email']
+		name:    'users_email_idx'
+	})!
+	assert recorder.queries == [
+		'CREATE INDEX "users_email_idx" ON "reporting"."users" ("email");',
+	]
+}
+
+fn test_mysql_foreign_keys_reject_set_default_actions() {
+	mut recorder := &RecordingConnection{}
+	mut ctx := new_context(recorder, .mysql)
+	mut error_message := ''
+	ctx.add_foreign_key(ForeignKey{
+		from_table: 'accounts'
+		column:     'organization_id'
+		to_table:   'organizations'
+		on_delete:  'set_default'
+	}) or { error_message = err.msg() }
+	assert error_message == 'MySQL does not support SET DEFAULT for foreign-key actions'
+
+	error_message = ''
+	ctx.create_table(Table{
+		name:         'accounts'
+		id:           false
+		columns:      [
+			Column{
+				name: 'organization_id'
+				kind: .bigint
+			},
+		]
+		foreign_keys: [
+			ForeignKey{
+				from_table: 'accounts'
+				column:     'organization_id'
+				to_table:   'organizations'
+				on_update:  'SET DEFAULT'
+			},
+		]
+	}) or { error_message = err.msg() }
+	assert error_message == 'MySQL does not support SET DEFAULT for foreign-key actions'
+	assert recorder.queries.len == 0
+	assert foreign_key_action(.pg, 'set_default')! == 'SET DEFAULT'
+}
+
 fn test_column_sql_rejects_postgresql_serial_defaults_and_scale_without_precision() {
 	mut recorder := &RecordingConnection{}
 	mut ctx := new_context(recorder, .pg)

--- a/vlib/v3/migrations/migrations_test.v
+++ b/vlib/v3/migrations/migrations_test.v
@@ -7,7 +7,8 @@ import orm
 @[heap]
 struct RecordingConnection {
 mut:
-	queries []string
+	queries  []string
+	database string = 'test_database'
 }
 
 fn (mut conn RecordingConnection) select(_ orm.SelectConfig, _ orm.QueryData, _ orm.QueryData) ![][]orm.Primitive {
@@ -30,6 +31,11 @@ fn (mut conn RecordingConnection) last_id() int {
 
 fn (mut conn RecordingConnection) execute(query string) ![]orm.Row {
 	conn.queries << query
+	if query == 'SELECT DATABASE();' {
+		return [orm.Row{
+			vals: [conn.database]
+		}]
+	}
 	if query.starts_with('SELECT GET_LOCK(') || query.starts_with('SELECT RELEASE_LOCK(')
 		|| query.starts_with('SELECT pg_advisory_unlock(') {
 		return [orm.Row{
@@ -274,8 +280,9 @@ fn test_mutating_runner_holds_dialect_lock_around_callbacks() {
 				assert 'ORM COMMIT' in recorder.queries
 			}
 			.mysql {
-				name := migration_lock_name(key)
-				assert recorder.queries[0] == "SELECT GET_LOCK('${name}', ${migration_lock_timeout_seconds});"
+				name := mysql_migration_lock_name(recorder.database, 'schema_migrations')
+				assert recorder.queries[0] == 'SELECT DATABASE();'
+				assert recorder.queries[1] == "SELECT GET_LOCK('${name}', ${migration_lock_timeout_seconds});"
 				assert recorder.queries.last() == "SELECT RELEASE_LOCK('${name}');"
 				assert 'ORM BEGIN' !in recorder.queries
 			}
@@ -284,6 +291,35 @@ fn test_mutating_runner_holds_dialect_lock_around_callbacks() {
 		assert callback_index > 0
 		assert callback_index < recorder.queries.len - 1
 	}
+}
+
+fn test_mysql_migration_locks_are_namespaced_by_database() {
+	mut first_recorder := &RecordingConnection{
+		database: 'application_one'
+	}
+	mut first_runner := new(mut first_recorder, []Migration{}, Config{
+		dialect: .mysql
+	})!
+	first_runner.acquire_migration_lock()!
+	first_runner.release_migration_lock(true)!
+	first_name := mysql_migration_lock_name('application_one', 'schema_migrations')
+	assert first_recorder.queries == [
+		'SELECT DATABASE();',
+		"SELECT GET_LOCK('${first_name}', ${migration_lock_timeout_seconds});",
+		"SELECT RELEASE_LOCK('${first_name}');",
+	]
+
+	mut second_recorder := &RecordingConnection{
+		database: 'application_two'
+	}
+	mut second_runner := new(mut second_recorder, []Migration{}, Config{
+		dialect: .mysql
+	})!
+	second_runner.acquire_migration_lock()!
+	second_runner.release_migration_lock(true)!
+	second_name := mysql_migration_lock_name('application_two', 'schema_migrations')
+	assert second_name != first_name
+	assert second_recorder.queries[1] == "SELECT GET_LOCK('${second_name}', ${migration_lock_timeout_seconds});"
 }
 
 fn test_mysql_history_literals_are_backslash_safe() {
@@ -436,6 +472,39 @@ fn test_mysql_auto_increment_requires_a_key() {
 	assert recorder.queries == [
 		'ALTER TABLE `accounts` ADD COLUMN `sequence` BIGINT AUTO_INCREMENT UNIQUE;',
 	]
+}
+
+fn test_mysql_create_table_rejects_multiple_auto_increment_columns() {
+	mut recorder := &RecordingConnection{}
+	mut ctx := new_context(recorder, .mysql)
+	mut error_message := ''
+	ctx.create_table(Table{
+		name:    'events'
+		columns: [
+			Column{
+				name:           'sequence'
+				kind:           .bigint
+				auto_increment: true
+				unique:         true
+			},
+		]
+	}) or { error_message = err.msg() }
+	assert error_message == 'MySQL table `events` cannot have more than one auto-increment column'
+	assert recorder.queries.len == 0
+
+	ctx.create_table(Table{
+		name:    'single_sequence'
+		id:      false
+		columns: [
+			Column{
+				name:           'sequence'
+				kind:           .bigint
+				auto_increment: true
+				unique:         true
+			},
+		]
+	})!
+	assert recorder.queries.len == 1
 }
 
 fn test_rename_table_rejects_qualified_targets_where_required() {
@@ -967,5 +1036,27 @@ fn test_caller_supplied_identifiers_respect_dialect_limits() {
 		table:   'app.${mysql_long_name}'
 	}) or { error_message = err.msg() }
 	assert error_message == 'MySQL migration history table name component `${mysql_long_name}` must not exceed 64 bytes'
+	assert history_recorder.queries.len == 0
+
+	error_message = ''
+	mysql_ctx.drop_table('application.archive.users') or { error_message = err.msg() }
+	assert error_message == 'MySQL table name `application.archive.users` must not exceed 2 components'
+	assert mysql_recorder.queries.len == 1
+
+	mut sqlite_recorder := &RecordingConnection{}
+	mut sqlite_ctx := new_context(sqlite_recorder, .sqlite)
+	error_message = ''
+	sqlite_ctx.create_table(Table{
+		name: 'main.application.users'
+	}) or { error_message = err.msg() }
+	assert error_message == 'SQLite table name `main.application.users` must not exceed 2 components'
+	assert sqlite_recorder.queries.len == 0
+
+	error_message = ''
+	new(mut history_recorder, []Migration{}, Config{
+		dialect: .mysql
+		table:   'application.archive.schema_migrations'
+	}) or { error_message = err.msg() }
+	assert error_message == 'MySQL migration history table name `application.archive.schema_migrations` must not exceed 2 components'
 	assert history_recorder.queries.len == 0
 }

--- a/vlib/v3/migrations/migrations_test.v
+++ b/vlib/v3/migrations/migrations_test.v
@@ -1339,6 +1339,32 @@ fn test_sqlite_add_column_accepts_parenthesized_literal_defaults() {
 	assert db.q_string('SELECT collated_label FROM accounts WHERE id = 1;')! == 'collated'
 }
 
+fn test_sqlite_accepts_numeric_literal_digit_separators() {
+	for literal in ['1_000', '(1_000)', '1_2.3_4e5_6', '1e+1_0', '0xCA_FE', '(0xA_B_C)'] {
+		assert sqlite_is_literal_default(literal)
+	}
+	for literal in ['_1000', '1000_', '1__000', '1_.0', '0x_FF', '0xFF_', '0xA__B'] {
+		assert !sqlite_is_literal_default(literal)
+	}
+
+	mut recorder := &RecordingConnection{}
+	mut ctx := new_context(recorder, .sqlite)
+	ctx.add_column('accounts', Column{
+		name:        'population'
+		kind:        .integer
+		default_sql: '(1_000)'
+	})!
+	ctx.add_column('accounts', Column{
+		name:        'mask'
+		kind:        .integer
+		default_sql: '(0xCA_FE)'
+	})!
+	assert recorder.queries == [
+		'ALTER TABLE "accounts" ADD COLUMN "population" INTEGER DEFAULT (1_000);',
+		'ALTER TABLE "accounts" ADD COLUMN "mask" INTEGER DEFAULT (0xCA_FE);',
+	]
+}
+
 fn test_sqlite_requires_unqualified_index_and_foreign_key_tables() {
 	mut recorder := &RecordingConnection{}
 	mut ctx := new_context(recorder, .sqlite)

--- a/vlib/v3/migrations/migrations_test.v
+++ b/vlib/v3/migrations/migrations_test.v
@@ -912,3 +912,60 @@ fn test_generated_foreign_key_names_respect_dialect_limits() {
 	assert error_message == 'MySQL foreign key name `${long_explicit_name}` must not exceed 64 bytes'
 	assert recorder.queries.len == 2
 }
+
+fn test_caller_supplied_identifiers_respect_dialect_limits() {
+	mysql_limit_name := 'm'.repeat(64)
+	mysql_long_name := 'm'.repeat(65)
+	mut mysql_recorder := &RecordingConnection{}
+	mut mysql_ctx := new_context(mysql_recorder, .mysql)
+	mysql_ctx.create_table(Table{
+		name:    mysql_limit_name
+		id:      false
+		columns: [
+			Column{
+				name: mysql_limit_name
+				kind: .text
+			},
+		]
+	})!
+	assert mysql_recorder.queries.len == 1
+
+	mut error_message := ''
+	mysql_ctx.create_table(Table{
+		name: 'app.${mysql_long_name}'
+	}) or { error_message = err.msg() }
+	assert error_message == 'MySQL table name component `${mysql_long_name}` must not exceed 64 bytes'
+	assert mysql_recorder.queries.len == 1
+
+	error_message = ''
+	mysql_ctx.add_column(mysql_limit_name, Column{
+		name: mysql_long_name
+		kind: .text
+	}) or { error_message = err.msg() }
+	assert error_message == 'MySQL column name component `${mysql_long_name}` must not exceed 64 bytes'
+	assert mysql_recorder.queries.len == 1
+
+	postgres_limit_name := 'p'.repeat(63)
+	postgres_long_name := 'p'.repeat(64)
+	mut postgres_recorder := &RecordingConnection{}
+	mut postgres_ctx := new_context(postgres_recorder, .pg)
+	postgres_ctx.drop_table(postgres_limit_name)!
+	error_message = ''
+	postgres_ctx.drop_table(postgres_long_name) or { error_message = err.msg() }
+	assert error_message == 'PostgreSQL table name component `${postgres_long_name}` must not exceed 63 bytes'
+	assert postgres_recorder.queries.len == 1
+
+	mut history_recorder := &RecordingConnection{}
+	runner := new(mut history_recorder, []Migration{}, Config{
+		dialect: .mysql
+		table:   '${mysql_limit_name}.${mysql_limit_name}'
+	})!
+	assert runner.config.table == '${mysql_limit_name}.${mysql_limit_name}'
+	error_message = ''
+	new(mut history_recorder, []Migration{}, Config{
+		dialect: .mysql
+		table:   'app.${mysql_long_name}'
+	}) or { error_message = err.msg() }
+	assert error_message == 'MySQL migration history table name component `${mysql_long_name}` must not exceed 64 bytes'
+	assert history_recorder.queries.len == 0
+}

--- a/vlib/v3/migrations/migrations_test.v
+++ b/vlib/v3/migrations/migrations_test.v
@@ -172,6 +172,17 @@ fn change_connection_namespace(mut ctx Context) ! {
 	}
 }
 
+fn create_sqlite_temp_history_shadow(mut ctx Context) ! {
+	ctx.create_table(Table{
+		name: 'persistent_from_migration'
+	})!
+	ctx.execute('CREATE TEMP TABLE IF NOT EXISTS schema_migrations (version BIGINT PRIMARY KEY, name VARCHAR(255) NOT NULL, applied_at VARCHAR(32) NOT NULL);')!
+}
+
+fn drop_sqlite_temp_history_shadow(mut ctx Context) ! {
+	ctx.drop_table('persistent_from_migration')!
+}
+
 fn create_widget_with_orm_dsl(mut ctx Context) ! {
 	sql ctx {
 		create table MigrationWidget
@@ -383,6 +394,53 @@ fn test_locked_history_table_survives_callback_namespace_changes() {
 		delete_query := down_recorder.queries.filter(it.starts_with('DELETE FROM '))
 		assert delete_query == ['DELETE FROM ${qualified_table} WHERE version = 1;']
 	}
+}
+
+fn test_sqlite_history_table_is_pinned_to_main() {
+	for temp_table_exists in [false, true] {
+		mut db := sqlite.connect(':memory:')!
+		if temp_table_exists {
+			db.exec('CREATE TEMP TABLE schema_migrations (version BIGINT PRIMARY KEY, name VARCHAR(255) NOT NULL, applied_at VARCHAR(32) NOT NULL);')!
+			db.exec("INSERT INTO temp.schema_migrations VALUES (1, 'shadow', '2026-08-16T00:00:00Z');")!
+		}
+		mut runner := new(mut db, [
+			Migration{
+				version: 1
+				name:    'persistent_history'
+				up:      create_sqlite_temp_history_shadow
+				down:    drop_sqlite_temp_history_shadow
+			},
+		], Config{
+			dialect: .sqlite
+		})!
+		assert runner.migrate()!.map(it.version) == [i64(1)]
+		assert runner.applied()!.map(it.name) == ['persistent_history']
+		assert db.q_int("SELECT count(*) FROM main.sqlite_master WHERE type = 'table' AND name = 'persistent_from_migration';")! == 1
+		assert db.q_string('SELECT name FROM main.schema_migrations WHERE version = 1;')! == 'persistent_history'
+		if temp_table_exists {
+			assert db.q_string('SELECT name FROM temp.schema_migrations WHERE version = 1;')! == 'shadow'
+		} else {
+			assert db.q_int('SELECT count(*) FROM temp.schema_migrations;')! == 0
+		}
+		db.close()!
+	}
+}
+
+fn test_migration_names_reject_nul_bytes_before_database_access() {
+	mut recorder := &RecordingConnection{}
+	new(mut recorder, [
+		Migration{
+			version: 1
+			name:    'before\x00after'
+			up:      record_locked_migration
+			down:    record_locked_migration
+		},
+	], Config{}) or {
+		assert err.msg() == 'migration 1 name must not contain NUL bytes'
+		assert recorder.queries.len == 0
+		return
+	}
+	assert false
 }
 
 fn test_mysql_migration_locks_are_namespaced_by_database() {

--- a/vlib/v3/migrations/migrations_test.v
+++ b/vlib/v3/migrations/migrations_test.v
@@ -442,33 +442,24 @@ fn test_postgresql_orm_wrapper_is_rejected_without_mutating_its_transaction() {
 	assert recorder.queries.len == 0
 }
 
-fn test_postgresql_open_transaction_is_rejected_without_being_finished() {
-	mut recorder := &RecordingConnection{
-		in_transaction: true
+fn test_postgresql_open_transaction_is_rejected_in_every_mode_without_being_finished() {
+	for mode in [TransactionMode.automatic, .always, .never] {
+		mut recorder := &RecordingConnection{
+			in_transaction: true
+		}
+		mut runner := new(mut recorder, []Migration{}, Config{
+			dialect:          .pg
+			transaction_mode: mode
+		})!
+		mut error_message := ''
+		runner.migrate() or { error_message = err.msg() }
+		assert error_message == 'PostgreSQL migrations require a connection without an already-open transaction; pg.Tx and transactional pg.Conn values are not supported'
+		assert recorder.in_transaction
+		assert recorder.queries == [
+			'ORM SAVEPOINT v3_migrations_transaction_probe',
+			'ORM RELEASE SAVEPOINT v3_migrations_transaction_probe',
+		]
 	}
-	mut runner := new(mut recorder, []Migration{}, Config{
-		dialect: .pg
-	})!
-	mut error_message := ''
-	runner.migrate() or { error_message = err.msg() }
-	assert error_message == 'PostgreSQL migrations cannot manage transactions on a connection with an already-open transaction (including pg.Tx); use transaction_mode: .never to preserve the caller-owned transaction'
-	assert recorder.in_transaction
-	assert recorder.queries == [
-		'ORM SAVEPOINT v3_migrations_transaction_probe',
-		'ORM RELEASE SAVEPOINT v3_migrations_transaction_probe',
-	]
-
-	mut externally_managed := &RecordingConnection{
-		in_transaction: true
-	}
-	mut never_runner := new(mut externally_managed, []Migration{}, Config{
-		dialect:          .pg
-		transaction_mode: .never
-	})!
-	assert never_runner.migrate()!.len == 0
-	assert externally_managed.in_transaction
-	assert 'ORM COMMIT' !in externally_managed.queries
-	assert 'ORM ROLLBACK' !in externally_managed.queries
 }
 
 fn test_sqlite_history_table_is_pinned_to_main() {
@@ -1167,7 +1158,8 @@ fn test_sqlite_add_column_rejects_unsupported_constraints() {
 	}
 	for default_sql in ['CURRENT_TIME', 'CURRENT_DATE', 'CURRENT_TIMESTAMP', "(datetime('now'))",
 		'CURRENT_TIMESTAMP /* now */', '/* now */ CURRENT_DATE', 'CURRENT_TIME -- now',
-		"(datetime('now')) /* now */"] {
+		"(datetime('now')) /* now */", 'CURRENT_TIMESTAMP COLLATE binary',
+		'CURRENT_DATE\tCOLLATE binary', 'CURRENT_TIME/* now */ COLLATE binary'] {
 		error_message = ''
 		ctx.add_column('accounts', Column{
 			name:        'created_at'

--- a/vlib/v3/migrations/migrations_test.v
+++ b/vlib/v3/migrations/migrations_test.v
@@ -42,6 +42,12 @@ fn (mut conn RecordingConnection) execute(query string) ![]orm.Row {
 	if query == 'USE other_database;' {
 		conn.database = 'other_database'
 	}
+	if query == 'SET autocommit=0;' {
+		conn.autocommit = false
+	}
+	if query == 'START TRANSACTION;' {
+		conn.in_transaction = true
+	}
 	if query == 'SET search_path TO other_schema;' {
 		conn.schema = 'other_schema'
 	}
@@ -240,6 +246,14 @@ fn drop_widget_with_orm_dsl(mut ctx Context) ! {
 
 fn record_locked_migration(mut ctx Context) ! {
 	ctx.execute('migration callback;')!
+}
+
+fn disable_mysql_autocommit(mut ctx Context) ! {
+	ctx.execute('SET autocommit=0;')!
+}
+
+fn start_mysql_transaction(mut ctx Context) ! {
+	ctx.execute('START TRANSACTION;')!
 }
 
 fn test_migrate_rollback_redo_and_status() {
@@ -532,6 +546,59 @@ fn test_mysql_disabled_autocommit_is_rejected_before_locking_or_inspection() {
 		runner.applied() or { error_message = err.msg() }
 		assert error_message == 'MySQL migrations require session autocommit to be enabled'
 		assert recorder.queries == ['SELECT @@autocommit;', 'SELECT @@autocommit;']
+	}
+}
+
+fn test_mysql_callback_session_state_is_rechecked_before_unlocking() {
+	for mode in [TransactionMode.automatic, .never] {
+		mut autocommit_recorder := &RecordingConnection{}
+		mut autocommit_runner := new(mut autocommit_recorder, [
+			Migration{
+				version: 1
+				name:    'disable_autocommit'
+				up:      disable_mysql_autocommit
+				down:    disable_mysql_autocommit
+			},
+		], Config{
+			dialect:          .mysql
+			transaction_mode: mode
+		})!
+		mut error_message := ''
+		autocommit_runner.migrate() or { error_message = err.msg() }
+		assert error_message == 'MySQL migration callback left unsafe session state: MySQL migrations require session autocommit to be enabled'
+		assert !autocommit_recorder.in_transaction
+		assert !autocommit_recorder.autocommit
+		rollback_index := autocommit_recorder.queries.index('ORM ROLLBACK')
+		history_inserts := autocommit_recorder.queries.filter(it.starts_with('INSERT INTO '))
+		assert history_inserts.len == 1
+		assert rollback_index > autocommit_recorder.queries.index('SET autocommit=0;')
+		assert rollback_index > autocommit_recorder.queries.index(history_inserts[0])
+		assert autocommit_recorder.queries.last().starts_with('SELECT RELEASE_LOCK(')
+
+		mut transaction_recorder := &RecordingConnection{}
+		mut transaction_runner := new(mut transaction_recorder, [
+			Migration{
+				version: 1
+				name:    'start_transaction'
+				up:      start_mysql_transaction
+				down:    start_mysql_transaction
+			},
+		], Config{
+			dialect:          .mysql
+			transaction_mode: mode
+		})!
+		error_message = ''
+		transaction_runner.migrate() or { error_message = err.msg() }
+		assert error_message == 'MySQL migration callback left unsafe session state: MySQL migrations require a connection without an already-open transaction'
+		assert !transaction_recorder.in_transaction
+		assert transaction_recorder.autocommit
+		transaction_rollback_index := transaction_recorder.queries.index('ORM ROLLBACK')
+		transaction_history_inserts :=
+			transaction_recorder.queries.filter(it.starts_with('INSERT INTO '))
+		assert transaction_history_inserts.len == 1
+		assert transaction_rollback_index > transaction_recorder.queries.index('START TRANSACTION;')
+		assert transaction_rollback_index > transaction_recorder.queries.index(transaction_history_inserts[0])
+		assert transaction_recorder.queries.last().starts_with('SELECT RELEASE_LOCK(')
 	}
 }
 
@@ -1464,6 +1531,10 @@ fn test_sqlite_requires_unqualified_index_and_foreign_key_tables() {
 	assert recorder.queries.len == 0
 
 	error_message = ''
+	generated_name := index_name(.sqlite, Index{
+		table:   'users'
+		columns: ['email']
+	})!
 	ctx.add_index(Index{
 		table:   'users'
 		columns: ['email']
@@ -1518,7 +1589,7 @@ fn test_sqlite_requires_unqualified_index_and_foreign_key_tables() {
 		'PRAGMA database_list;',
 		'SELECT 1 FROM "temp".sqlite_schema WHERE type = \'table\' AND name = \'users\' COLLATE NOCASE LIMIT 1;',
 		'SELECT 1 FROM "main".sqlite_schema WHERE type = \'table\' AND name = \'users\' COLLATE NOCASE LIMIT 1;',
-		'CREATE INDEX "main"."index_users_on_email" ON "users" ("email");',
+		'CREATE INDEX "main"."${generated_name}" ON "users" ("email");',
 		'CREATE TABLE "main"."children" ("parent_id" BIGINT, CONSTRAINT "fk_main_children_parent_id" FOREIGN KEY ("parent_id") REFERENCES "parents" ("id"));',
 	]
 }
@@ -1643,10 +1714,11 @@ fn test_validation_and_portable_sql_generation() {
 		assert err.msg() == 'duplicate migration version 7'
 		assert column_type_sql(.pg, Column{ name: 'payload', kind: .jsonb })! == 'JSONB'
 		assert column_type_sql(.mysql, Column{ name: 'amount', kind: .double_precision })! == 'DOUBLE'
-		assert index_name(.sqlite, Index{
+		generated_name := index_name(.sqlite, Index{
 			table:   'accounts'
 			columns: ['email', 'name']
-		})! == 'index_accounts_on_email_and_name'
+		})!
+		assert generated_name.starts_with('index_accounts_on_email_and_name_')
 		return
 	}
 	assert false
@@ -1657,7 +1729,9 @@ fn test_generated_index_names_respect_dialect_limits() {
 		table:   'customer_account_records_archive'
 		columns: ['external_customer_reference', 'external_organization_reference']
 	}
-	raw_name := 'index_customer_account_records_archive_on_external_customer_reference_and_external_organization_reference'
+	raw_base := 'index_customer_account_records_archive_on_external_customer_reference_and_external_organization_reference'
+	raw_name := generated_index_name(index)
+	assert raw_name.starts_with('${raw_base}_')
 	mysql_name := index_name(.mysql, index)!
 	postgres_name := index_name(.pg, index)!
 	assert mysql_name.len == 64
@@ -1700,7 +1774,7 @@ fn test_generated_index_names_distinguish_column_boundaries() {
 	composite_name := index_name(.sqlite, composite)!
 	assert single_name != composite_name
 	assert single_name.starts_with('index_users_on_a_and_b_')
-	assert composite_name == 'index_users_on_a_and_b'
+	assert composite_name.starts_with('index_users_on_a_and_b_')
 	case_variant_name := index_name(.mysql, Index{
 		table:   'users'
 		columns: ['a_AnD_b']
@@ -1717,6 +1791,18 @@ fn test_generated_index_names_distinguish_column_boundaries() {
 	for dialect in [Dialect.sqlite, .pg] {
 		assert index_name(dialect, table_boundary)! != index_name(dialect, column_boundary)!
 	}
+	fragment_table_boundary := Index{
+		table:   'a_on'
+		columns: ['b']
+	}
+	fragment_column_boundary := Index{
+		table:   'a'
+		columns: ['on_b']
+	}
+	for dialect in [Dialect.sqlite, .pg] {
+		assert index_name(dialect, fragment_table_boundary)! != index_name(dialect,
+			fragment_column_boundary)!
+	}
 
 	mut db := sqlite.connect(':memory:')!
 	defer {
@@ -1730,7 +1816,11 @@ fn test_generated_index_names_distinguish_column_boundaries() {
 	db.exec('CREATE TABLE a (b_on_c TEXT);')!
 	ctx.add_index(table_boundary)!
 	ctx.add_index(column_boundary)!
-	assert db.q_int("SELECT count(*) FROM sqlite_master WHERE type = 'index';")! == 4
+	db.exec('CREATE TABLE a_on (b TEXT);')!
+	db.exec('ALTER TABLE a ADD COLUMN on_b TEXT;')!
+	ctx.add_index(fragment_table_boundary)!
+	ctx.add_index(fragment_column_boundary)!
+	assert db.q_int("SELECT count(*) FROM sqlite_master WHERE type = 'index';")! == 6
 }
 
 fn test_generated_foreign_key_names_respect_dialect_limits() {

--- a/vlib/v3/migrations/migrations_test.v
+++ b/vlib/v3/migrations/migrations_test.v
@@ -1799,6 +1799,10 @@ fn test_sqlite_add_column_rejects_unsupported_constraints() {
 	invalid_defaults << '((+NULL)) /* absent */ COLLATE binary'
 	invalid_defaults << 'NULL COLLATE binary'
 	invalid_defaults << '+NULL /* absent */ COLLATE binary'
+	invalid_defaults << '(CAST(NULL AS INTEGER))'
+	invalid_defaults << '(CAST((+NULL) AS TEXT))'
+	invalid_defaults << '(CAST(CAST(NULL AS TEXT) AS INTEGER))'
+	invalid_defaults << '(CAST(NULL /* absent */ AS INTEGER)) COLLATE binary'
 	for default_sql in invalid_defaults {
 		error_message = ''
 		ctx.add_column('accounts', Column{
@@ -1853,6 +1857,13 @@ fn test_sqlite_add_column_rejects_unsupported_constraints() {
 		'ALTER TABLE "accounts" ADD COLUMN "parenthesized_1" TEXT DEFAULT (\'x\');',
 		'ALTER TABLE "accounts" ADD COLUMN "parenthesized_2" TEXT DEFAULT (NULL);',
 	]
+	ctx.add_column('accounts', Column{
+		name:        'cast_null_text'
+		kind:        .text
+		nullable:    false
+		default_sql: "(CAST('NULL' AS TEXT))"
+	})!
+	assert recorder.queries.last() == 'ALTER TABLE "accounts" ADD COLUMN "cast_null_text" TEXT NOT NULL DEFAULT (CAST(\'NULL\' AS TEXT));'
 }
 
 fn test_sqlite_add_column_accepts_parenthesized_literal_defaults() {

--- a/vlib/v3/migrations/migrations_test.v
+++ b/vlib/v3/migrations/migrations_test.v
@@ -349,6 +349,26 @@ fn test_mysql_migration_locks_are_namespaced_by_database() {
 	assert qualified_second_recorder.queries == qualified_first_recorder.queries
 }
 
+fn test_postgresql_migration_locks_use_full_64bit_keys() {
+	first_table := 's_d015hmpz1cdl'
+	second_table := 's_syia3wc6g1qq'
+	first_key := migration_lock_key(first_table)
+	second_key := migration_lock_key(second_table)
+	assert first_key != second_key
+
+	mut recorder := &RecordingConnection{}
+	mut runner := new(mut recorder, []Migration{}, Config{
+		dialect: .pg
+		table:   first_table
+	})!
+	runner.acquire_migration_lock()!
+	runner.release_migration_lock(true)!
+	assert recorder.queries == [
+		'SELECT pg_advisory_lock(${first_key});',
+		'SELECT pg_advisory_unlock(${first_key});',
+	]
+}
+
 fn test_mysql_history_literals_are_backslash_safe() {
 	mut recorder := &RecordingConnection{}
 	name := "quote\\'and_trailing\\"
@@ -800,6 +820,7 @@ fn test_sqlite_add_column_rejects_unsupported_constraints() {
 	invalid_defaults << ''
 	invalid_defaults << 'NULL'
 	invalid_defaults << 'NULL /* absent */'
+	invalid_defaults << '(NULL)'
 	for default_sql in invalid_defaults {
 		error_message = ''
 		ctx.add_column('accounts', Column{
@@ -839,6 +860,46 @@ fn test_sqlite_add_column_rejects_unsupported_constraints() {
 		default_sql: "'CURRENT_TIMESTAMP /* literal */'"
 	})!
 	assert recorder.queries[1] == 'ALTER TABLE "accounts" ADD COLUMN "literal_comment" TEXT NOT NULL DEFAULT \'CURRENT_TIMESTAMP /* literal */\';'
+	for i, default_sql in ['(0)', "('x')", '(NULL)'] {
+		ctx.add_column('accounts', Column{
+			name:        'parenthesized_${i}'
+			kind:        .text
+			default_sql: default_sql
+		})!
+	}
+	assert recorder.queries[2..] == [
+		'ALTER TABLE "accounts" ADD COLUMN "parenthesized_0" TEXT DEFAULT (0);',
+		'ALTER TABLE "accounts" ADD COLUMN "parenthesized_1" TEXT DEFAULT (\'x\');',
+		'ALTER TABLE "accounts" ADD COLUMN "parenthesized_2" TEXT DEFAULT (NULL);',
+	]
+}
+
+fn test_sqlite_add_column_accepts_parenthesized_literal_defaults() {
+	mut db := sqlite.connect(':memory:')!
+	defer {
+		db.close() or {}
+	}
+	db.exec('CREATE TABLE accounts (id INTEGER PRIMARY KEY);')!
+	db.exec('INSERT INTO accounts (id) VALUES (1);')!
+	mut ctx := new_context(db, .sqlite)
+	ctx.add_column('accounts', Column{
+		name:        'count'
+		kind:        .integer
+		default_sql: '(0)'
+	})!
+	ctx.add_column('accounts', Column{
+		name:        'label'
+		kind:        .text
+		default_sql: "('x')"
+	})!
+	ctx.add_column('accounts', Column{
+		name:        'optional'
+		kind:        .text
+		default_sql: '(NULL)'
+	})!
+	assert db.q_int('SELECT count FROM accounts WHERE id = 1;')! == 0
+	assert db.q_string('SELECT label FROM accounts WHERE id = 1;')! == 'x'
+	assert db.q_int('SELECT count(*) FROM accounts WHERE optional IS NULL;')! == 1
 }
 
 fn test_sqlite_requires_unqualified_index_and_foreign_key_tables() {
@@ -1050,6 +1111,37 @@ fn test_generated_index_names_respect_dialect_limits() {
 		name:    long_explicit_name
 	}) or { error_message = err.msg() }
 	assert error_message == 'MySQL index name component `${long_explicit_name}` must not exceed 64 bytes'
+}
+
+fn test_generated_index_names_distinguish_column_boundaries() {
+	single_column := Index{
+		table:   'users'
+		columns: ['a_and_b']
+	}
+	composite := Index{
+		table:   'users'
+		columns: ['a', 'b']
+	}
+	single_name := index_name(.sqlite, single_column)!
+	composite_name := index_name(.sqlite, composite)!
+	assert single_name != composite_name
+	assert single_name.starts_with('index_users_on_a_and_b_')
+	assert composite_name == 'index_users_on_a_and_b'
+	case_variant_name := index_name(.mysql, Index{
+		table:   'users'
+		columns: ['a_AnD_b']
+	})!
+	assert case_variant_name != index_name(.mysql, composite)!
+
+	mut db := sqlite.connect(':memory:')!
+	defer {
+		db.close() or {}
+	}
+	db.exec('CREATE TABLE users (a_and_b TEXT, a TEXT, b TEXT);')!
+	mut ctx := new_context(db, .sqlite)
+	ctx.add_index(single_column)!
+	ctx.add_index(composite)!
+	assert db.q_int("SELECT count(*) FROM sqlite_master WHERE type = 'index' AND tbl_name = 'users';")! == 2
 }
 
 fn test_generated_foreign_key_names_respect_dialect_limits() {

--- a/vlib/v3/migrations/migrations_test.v
+++ b/vlib/v3/migrations/migrations_test.v
@@ -7,9 +7,10 @@ import orm
 @[heap]
 struct RecordingConnection {
 mut:
-	queries  []string
-	database string = 'test_database'
-	schema   string = 'public'
+	queries                []string
+	database               string = 'test_database'
+	schema                 string = 'public'
+	lower_case_table_names int
 }
 
 fn (mut conn RecordingConnection) select(_ orm.SelectConfig, _ orm.QueryData, _ orm.QueryData) ![][]orm.Primitive {
@@ -40,6 +41,11 @@ fn (mut conn RecordingConnection) execute(query string) ![]orm.Row {
 	if query == 'SELECT current_schema();' {
 		return [orm.Row{
 			vals: [conn.schema]
+		}]
+	}
+	if query == 'SELECT @@lower_case_table_names;' {
+		return [orm.Row{
+			vals: [conn.lower_case_table_names.str()]
 		}]
 	}
 	if query.starts_with('SELECT GET_LOCK(') || query.starts_with('SELECT RELEASE_LOCK(')
@@ -287,9 +293,11 @@ fn test_mutating_runner_holds_dialect_lock_around_callbacks() {
 				assert 'ORM COMMIT' in recorder.queries
 			}
 			.mysql {
-				name := mysql_migration_lock_name(recorder.database, 'schema_migrations')
+				name := mysql_migration_lock_name(recorder.database, 'schema_migrations',
+					recorder.lower_case_table_names)
 				assert recorder.queries[0] == 'SELECT DATABASE();'
-				assert recorder.queries[1] == "SELECT GET_LOCK('${name}', ${migration_lock_timeout_seconds});"
+				assert recorder.queries[1] == 'SELECT @@lower_case_table_names;'
+				assert recorder.queries[2] == "SELECT GET_LOCK('${name}', ${migration_lock_timeout_seconds});"
 				assert recorder.queries.last() == "SELECT RELEASE_LOCK('${name}');"
 				assert 'ORM BEGIN' !in recorder.queries
 			}
@@ -309,9 +317,10 @@ fn test_mysql_migration_locks_are_namespaced_by_database() {
 	})!
 	first_runner.acquire_migration_lock()!
 	first_runner.release_migration_lock(true)!
-	first_name := mysql_migration_lock_name('application_one', 'schema_migrations')
+	first_name := mysql_migration_lock_name('application_one', 'schema_migrations', 0)
 	assert first_recorder.queries == [
 		'SELECT DATABASE();',
+		'SELECT @@lower_case_table_names;',
 		"SELECT GET_LOCK('${first_name}', ${migration_lock_timeout_seconds});",
 		"SELECT RELEASE_LOCK('${first_name}');",
 	]
@@ -324,13 +333,13 @@ fn test_mysql_migration_locks_are_namespaced_by_database() {
 	})!
 	second_runner.acquire_migration_lock()!
 	second_runner.release_migration_lock(true)!
-	second_name := mysql_migration_lock_name('application_two', 'schema_migrations')
+	second_name := mysql_migration_lock_name('application_two', 'schema_migrations', 0)
 	assert second_name != first_name
-	assert second_recorder.queries[1] == "SELECT GET_LOCK('${second_name}', ${migration_lock_timeout_seconds});"
+	assert second_recorder.queries[2] == "SELECT GET_LOCK('${second_name}', ${migration_lock_timeout_seconds});"
 
 	qualified_table := 'shared.schema_migrations'
-	qualified_name := mysql_migration_lock_name('shared', qualified_table)
-	assert qualified_name == mysql_migration_lock_name('shared', 'schema_migrations')
+	qualified_name := mysql_migration_lock_name('shared', qualified_table, 0)
+	assert qualified_name == mysql_migration_lock_name('shared', 'schema_migrations', 0)
 	mut qualified_first_recorder := &RecordingConnection{
 		database: 'application_one'
 	}
@@ -341,6 +350,7 @@ fn test_mysql_migration_locks_are_namespaced_by_database() {
 	qualified_first_runner.acquire_migration_lock()!
 	qualified_first_runner.release_migration_lock(true)!
 	assert qualified_first_recorder.queries == [
+		'SELECT @@lower_case_table_names;',
 		"SELECT GET_LOCK('${qualified_name}', ${migration_lock_timeout_seconds});",
 		"SELECT RELEASE_LOCK('${qualified_name}');",
 	]
@@ -364,7 +374,43 @@ fn test_mysql_migration_locks_are_namespaced_by_database() {
 	})!
 	unqualified_runner.acquire_migration_lock()!
 	unqualified_runner.release_migration_lock(true)!
-	assert unqualified_recorder.queries[1..] == qualified_first_recorder.queries
+	assert unqualified_recorder.queries[2..] == qualified_first_recorder.queries[1..]
+}
+
+fn test_mysql_migration_locks_follow_lower_case_table_names() {
+	assert mysql_migration_lock_name('app', 'app.schema_migrations', 0) != mysql_migration_lock_name('APP',
+		'APP.Schema_Migrations', 0)
+	for mode in [1, 2] {
+		lower_name := mysql_migration_lock_name('app', 'app.schema_migrations', mode)
+		upper_name := mysql_migration_lock_name('APP', 'APP.Schema_Migrations', mode)
+		assert lower_name == upper_name
+
+		mut lower_recorder := &RecordingConnection{
+			lower_case_table_names: mode
+		}
+		mut lower_runner := new(mut lower_recorder, []Migration{}, Config{
+			dialect: .mysql
+			table:   'app.schema_migrations'
+		})!
+		lower_runner.acquire_migration_lock()!
+		lower_runner.release_migration_lock(true)!
+
+		mut upper_recorder := &RecordingConnection{
+			lower_case_table_names: mode
+		}
+		mut upper_runner := new(mut upper_recorder, []Migration{}, Config{
+			dialect: .mysql
+			table:   'APP.Schema_Migrations'
+		})!
+		upper_runner.acquire_migration_lock()!
+		upper_runner.release_migration_lock(true)!
+		assert upper_recorder.queries == lower_recorder.queries
+		assert lower_recorder.queries == [
+			'SELECT @@lower_case_table_names;',
+			"SELECT GET_LOCK('${lower_name}', ${migration_lock_timeout_seconds});",
+			"SELECT RELEASE_LOCK('${lower_name}');",
+		]
+	}
 }
 
 fn test_postgresql_migration_locks_use_full_64bit_keys() {

--- a/vlib/v3/migrations/migrations_test.v
+++ b/vlib/v3/migrations/migrations_test.v
@@ -481,6 +481,24 @@ fn test_mysql_history_literals_are_backslash_safe() {
 	assert string_literal_sql(.sqlite, "quote'only") == "'quote''only'"
 }
 
+fn test_postgresql_history_literals_are_backslash_mode_independent() {
+	mut recorder := &RecordingConnection{}
+	name := "quote\\'and_trailing\\"
+	migration := Migration{
+		version: 8
+		name:    name
+		up:      record_locked_migration
+		down:    record_locked_migration
+	}
+	runner := new(mut recorder, [migration], Config{
+		dialect: .pg
+	})!
+	applied_at := '2026-08-16T00:00:00Z'
+	escaped_name := escape_postgresql_literal(name)
+	assert escaped_name == "quote\\\\''and_trailing\\\\"
+	assert runner.history_insert_sql(migration, applied_at) == 'INSERT INTO "schema_migrations" (version, name, applied_at) VALUES (8, E\'${escaped_name}\', E\'${applied_at}\');'
+}
+
 fn test_postgresql_change_column_rejects_constraint_options_before_sql() {
 	mut recorder := &RecordingConnection{}
 	mut ctx := new_context(recorder, .pg)

--- a/vlib/v3/migrations/migrations_test.v
+++ b/vlib/v3/migrations/migrations_test.v
@@ -11,6 +11,7 @@ mut:
 	database               string = 'test_database'
 	schema                 string = 'public'
 	lower_case_table_names int
+	history_rows           []orm.Row
 }
 
 fn (mut conn RecordingConnection) select(_ orm.SelectConfig, _ orm.QueryData, _ orm.QueryData) ![][]orm.Primitive {
@@ -33,6 +34,15 @@ fn (mut conn RecordingConnection) last_id() int {
 
 fn (mut conn RecordingConnection) execute(query string) ![]orm.Row {
 	conn.queries << query
+	if query == 'USE other_database;' {
+		conn.database = 'other_database'
+	}
+	if query == 'SET search_path TO other_schema;' {
+		conn.schema = 'other_schema'
+	}
+	if query.starts_with('SELECT version, name, applied_at FROM ') {
+		return conn.history_rows.clone()
+	}
 	if query == 'SELECT DATABASE();' {
 		return [orm.Row{
 			vals: [conn.database]
@@ -148,6 +158,18 @@ fn fail_after_create(mut ctx Context) ! {
 
 fn drop_should_rollback(mut ctx Context) ! {
 	ctx.drop_table('should_rollback')!
+}
+
+fn change_connection_namespace(mut ctx Context) ! {
+	match ctx.dialect {
+		.sqlite {}
+		.pg {
+			ctx.execute('SET search_path TO other_schema;')!
+		}
+		.mysql {
+			ctx.execute('USE other_database;')!
+		}
+	}
 }
 
 fn create_widget_with_orm_dsl(mut ctx Context) ! {
@@ -305,6 +327,61 @@ fn test_mutating_runner_holds_dialect_lock_around_callbacks() {
 		callback_index := recorder.queries.index('migration callback;')
 		assert callback_index > 0
 		assert callback_index < recorder.queries.len - 1
+	}
+}
+
+fn test_locked_history_table_survives_callback_namespace_changes() {
+	for dialect in [Dialect.pg, .mysql] {
+		migration := Migration{
+			version: 1
+			name:    'change_namespace'
+			up:      change_connection_namespace
+			down:    change_connection_namespace
+		}
+		mut up_recorder := &RecordingConnection{
+			database: 'app'
+			schema:   'app'
+		}
+		mut up_runner := new(mut up_recorder, [migration], Config{
+			dialect:          dialect
+			transaction_mode: .never
+		})!
+		up_runner.migrate()!
+		qualified_table := quote_identifier(dialect, 'app.schema_migrations')
+		mut saw_insert := false
+		for query in up_recorder.queries {
+			if query.starts_with('CREATE TABLE IF NOT EXISTS ')
+				|| query.starts_with('SELECT version, name, applied_at FROM ')
+				|| query.starts_with('INSERT INTO ') {
+				assert query.contains(qualified_table)
+			}
+			if query.starts_with('INSERT INTO ') {
+				saw_insert = true
+			}
+		}
+		assert saw_insert
+		if dialect == .pg {
+			assert up_recorder.schema == 'other_schema'
+		} else {
+			assert up_recorder.database == 'other_database'
+		}
+
+		mut down_recorder := &RecordingConnection{
+			database:     'app'
+			schema:       'app'
+			history_rows: [
+				orm.Row{
+					vals: ['1', migration.name, '2026-08-16T00:00:00Z']
+				},
+			]
+		}
+		mut down_runner := new(mut down_recorder, [migration], Config{
+			dialect:          dialect
+			transaction_mode: .never
+		})!
+		down_runner.rollback(1)!
+		delete_query := down_recorder.queries.filter(it.starts_with('DELETE FROM '))
+		assert delete_query == ['DELETE FROM ${qualified_table} WHERE version = 1;']
 	}
 }
 

--- a/vlib/v3/migrations/migrations_test.v
+++ b/vlib/v3/migrations/migrations_test.v
@@ -507,6 +507,63 @@ fn test_mysql_create_table_rejects_multiple_auto_increment_columns() {
 	assert recorder.queries.len == 1
 }
 
+fn test_sqlite_and_mysql_reject_case_insensitive_duplicate_columns() {
+	for dialect in [Dialect.sqlite, .mysql] {
+		mut recorder := &RecordingConnection{}
+		mut ctx := new_context(recorder, dialect)
+		mut error_message := ''
+		ctx.create_table(Table{
+			name:    'records'
+			columns: [
+				Column{
+					name: 'ID'
+					kind: .bigint
+				},
+			]
+		}) or { error_message = err.msg() }
+		assert error_message == 'table `records` has duplicate column `ID`'
+		assert recorder.queries.len == 0
+
+		error_message = ''
+		ctx.create_table(Table{
+			name:    'contacts'
+			id:      false
+			columns: [
+				Column{
+					name: 'email'
+					kind: .text
+				},
+				Column{
+					name: 'Email'
+					kind: .text
+				},
+			]
+		}) or { error_message = err.msg() }
+		assert error_message == 'table `contacts` has duplicate column `Email`'
+		assert recorder.queries.len == 0
+	}
+
+	mut postgres_recorder := &RecordingConnection{}
+	mut postgres_ctx := new_context(postgres_recorder, .pg)
+	postgres_ctx.create_table(Table{
+		name:    'contacts'
+		id:      false
+		columns: [
+			Column{
+				name: 'email'
+				kind: .text
+			},
+			Column{
+				name: 'Email'
+				kind: .text
+			},
+		]
+	})!
+	assert postgres_recorder.queries == [
+		'CREATE TABLE "contacts" ("email" TEXT, "Email" TEXT);',
+	]
+}
+
 fn test_rename_table_rejects_qualified_targets_where_required() {
 	mut pg_recorder := &RecordingConnection{}
 	mut pg_ctx := new_context(pg_recorder, .pg)
@@ -545,6 +602,23 @@ fn test_postgresql_remove_index_uses_the_table_schema() {
 		'DROP INDEX "reporting"."custom_email_index";',
 		'DROP INDEX "index_users_on_email";',
 	]
+}
+
+fn test_sqlite_remove_index_uses_the_table_schema() {
+	mut db := sqlite.connect(':memory:')!
+	defer {
+		db.close() or {}
+	}
+	db.exec("ATTACH DATABASE ':memory:' AS aux;")!
+	db.exec('CREATE TABLE main.users (email TEXT);')!
+	db.exec('CREATE TABLE aux.users (email TEXT);')!
+	db.exec('CREATE INDEX main.same_idx ON users (email);')!
+	db.exec('CREATE INDEX aux.same_idx ON users (email);')!
+
+	mut ctx := new_context(db, .sqlite)
+	ctx.remove_index('aux.users', 'same_idx')!
+	assert db.q_int("SELECT count(*) FROM main.sqlite_master WHERE type = 'index' AND name = 'same_idx';")! == 1
+	assert db.q_int("SELECT count(*) FROM aux.sqlite_master WHERE type = 'index' AND name = 'same_idx';")! == 0
 }
 
 fn test_postgresql_add_index_rejects_qualified_names() {

--- a/vlib/v3/migrations/migrations_test.v
+++ b/vlib/v3/migrations/migrations_test.v
@@ -48,6 +48,9 @@ fn (mut conn RecordingConnection) execute(query string) ![]orm.Row {
 	if query == 'START TRANSACTION;' {
 		conn.in_transaction = true
 	}
+	if query == 'BEGIN;' {
+		conn.in_transaction = true
+	}
 	if query == 'SET search_path TO other_schema;' {
 		conn.schema = 'other_schema'
 	}
@@ -254,6 +257,10 @@ fn disable_mysql_autocommit(mut ctx Context) ! {
 
 fn start_mysql_transaction(mut ctx Context) ! {
 	ctx.execute('START TRANSACTION;')!
+}
+
+fn start_postgresql_transaction(mut ctx Context) ! {
+	ctx.execute('BEGIN;')!
 }
 
 fn test_migrate_rollback_redo_and_status() {
@@ -600,6 +607,53 @@ fn test_mysql_callback_session_state_is_rechecked_before_unlocking() {
 		assert transaction_rollback_index > transaction_recorder.queries.index(transaction_history_inserts[0])
 		assert transaction_recorder.queries.last().starts_with('SELECT RELEASE_LOCK(')
 	}
+}
+
+fn test_postgresql_callback_transactions_are_rolled_back_before_unlocking() {
+	migration := Migration{
+		version: 1
+		name:    'start_transaction'
+		up:      start_postgresql_transaction
+		down:    start_postgresql_transaction
+	}
+	mut up_recorder := &RecordingConnection{}
+	mut up_runner := new(mut up_recorder, [migration], Config{
+		dialect:          .pg
+		transaction_mode: .never
+	})!
+	mut error_message := ''
+	up_runner.migrate() or { error_message = err.msg() }
+	assert error_message == 'PostgreSQL migration callback left unsafe session state: PostgreSQL migrations require a connection without an already-open transaction; pg.Tx and transactional pg.Conn values are not supported'
+	assert !up_recorder.in_transaction
+	up_rollback_index := up_recorder.queries.index('ORM ROLLBACK')
+	history_inserts := up_recorder.queries.filter(it.starts_with('INSERT INTO '))
+	assert history_inserts.len == 1
+	assert up_rollback_index > up_recorder.queries.index('BEGIN;')
+	assert up_rollback_index > up_recorder.queries.index(history_inserts[0])
+	key := postgresql_migration_lock_key('public', 'schema_migrations')
+	assert up_recorder.queries.last() == 'SELECT pg_advisory_unlock(${key});'
+
+	mut down_recorder := &RecordingConnection{
+		history_rows: [
+			orm.Row{
+				vals: ['1', migration.name, '2026-08-16T00:00:00Z']
+			},
+		]
+	}
+	mut down_runner := new(mut down_recorder, [migration], Config{
+		dialect:          .pg
+		transaction_mode: .never
+	})!
+	error_message = ''
+	down_runner.rollback(1) or { error_message = err.msg() }
+	assert error_message == 'PostgreSQL migration callback left unsafe session state: PostgreSQL migrations require a connection without an already-open transaction; pg.Tx and transactional pg.Conn values are not supported'
+	assert !down_recorder.in_transaction
+	down_rollback_index := down_recorder.queries.index('ORM ROLLBACK')
+	history_deletes := down_recorder.queries.filter(it.starts_with('DELETE FROM '))
+	assert history_deletes.len == 1
+	assert down_rollback_index > down_recorder.queries.index('BEGIN;')
+	assert down_rollback_index > down_recorder.queries.index(history_deletes[0])
+	assert down_recorder.queries.last() == 'SELECT pg_advisory_unlock(${key});'
 }
 
 fn test_sqlite_history_table_is_pinned_to_main() {

--- a/vlib/v3/migrations/migrations_test.v
+++ b/vlib/v3/migrations/migrations_test.v
@@ -91,6 +91,30 @@ fn (mut conn RecordingConnection) orm_release_savepoint(name string) ! {
 	conn.queries << 'ORM RELEASE SAVEPOINT ${name}'
 }
 
+struct PoolBackedConnection {}
+
+fn (mut conn PoolBackedConnection) select(_ orm.SelectConfig, _ orm.QueryData, _ orm.QueryData) ![][]orm.Primitive {
+	return []
+}
+
+fn (mut conn PoolBackedConnection) insert(_ orm.Table, _ orm.QueryData) ! {}
+
+fn (mut conn PoolBackedConnection) update(_ orm.Table, _ orm.QueryData, _ orm.QueryData) ! {}
+
+fn (mut conn PoolBackedConnection) delete(_ orm.Table, _ orm.QueryData) ! {}
+
+fn (mut conn PoolBackedConnection) create(_ orm.Table, _ []orm.TableField) ! {}
+
+fn (mut conn PoolBackedConnection) drop(_ orm.Table) ! {}
+
+fn (mut conn PoolBackedConnection) last_id() int {
+	return 0
+}
+
+fn (mut conn PoolBackedConnection) execute(_ string) ![]orm.Row {
+	return error('pool query should not execute')
+}
+
 struct MigrationWidget {
 	id    int @[primary; sql: serial]
 	label string
@@ -358,6 +382,12 @@ fn test_locked_history_table_survives_callback_namespace_changes() {
 			transaction_mode: .never
 		})!
 		up_runner.migrate()!
+		up_recorder.history_rows = [
+			orm.Row{
+				vals: ['1', migration.name, '2026-08-16T00:00:00Z']
+			},
+		]
+		assert up_runner.migrate()!.len == 0
 		qualified_table := quote_identifier(dialect, 'app.schema_migrations')
 		mut saw_insert := false
 		for query in up_recorder.queries {
@@ -371,10 +401,26 @@ fn test_locked_history_table_survives_callback_namespace_changes() {
 			}
 		}
 		assert saw_insert
+		assert up_recorder.queries.filter(it == if dialect == .pg {
+			'SET search_path TO other_schema;'
+		} else {
+			'USE other_database;'
+		}).len == 1
+		lock_query := if dialect == .pg {
+			key := postgresql_migration_lock_key('app', 'schema_migrations')
+			'SELECT pg_advisory_lock(${key});'
+		} else {
+			name := mysql_migration_lock_name('app', 'schema_migrations', 0)
+			"SELECT GET_LOCK('${name}', ${migration_lock_timeout_seconds});"
+		}
+		assert up_recorder.queries.filter(it == lock_query).len == 2
+		assert up_runner.resolved_history_namespace == 'app'
 		if dialect == .pg {
 			assert up_recorder.schema == 'other_schema'
+			assert up_recorder.queries.filter(it == 'SELECT current_schema();').len == 1
 		} else {
 			assert up_recorder.database == 'other_database'
+			assert up_recorder.queries.filter(it == 'SELECT DATABASE();').len == 1
 		}
 
 		mut down_recorder := &RecordingConnection{
@@ -394,6 +440,17 @@ fn test_locked_history_table_survives_callback_namespace_changes() {
 		delete_query := down_recorder.queries.filter(it.starts_with('DELETE FROM '))
 		assert delete_query == ['DELETE FROM ${qualified_table} WHERE version = 1;']
 	}
+}
+
+fn test_postgresql_pool_backed_orm_wrapper_is_rejected_before_locking() {
+	pool := PoolBackedConnection{}
+	mut scoped := orm.new_db(pool, orm.DataScope{})
+	mut runner := new(mut scoped, []Migration{}, Config{
+		dialect: .pg
+	})!
+	mut error_message := ''
+	runner.acquire_migration_lock() or { error_message = err.msg() }
+	assert error_message == 'PostgreSQL migrations require a session-pinned connection; orm.DB wrapper validation failed: orm.DB: underlying connection does not support transactions; use pg.DB.conn() or pg.connect_direct()'
 }
 
 fn test_sqlite_history_table_is_pinned_to_main() {
@@ -912,6 +969,14 @@ fn test_sqlite_remove_index_uses_the_table_schema() {
 
 	mut ctx := new_context(db, .sqlite)
 	ctx.remove_index('aux.users', 'same_idx')!
+	assert db.q_int("SELECT count(*) FROM main.sqlite_master WHERE type = 'index' AND name = 'same_idx';")! == 1
+	assert db.q_int("SELECT count(*) FROM aux.sqlite_master WHERE type = 'index' AND name = 'same_idx';")! == 0
+
+	db.exec('DROP TABLE main.users;')!
+	db.exec('CREATE TABLE main.other (email TEXT);')!
+	db.exec('CREATE INDEX main.same_idx ON other (email);')!
+	db.exec('CREATE INDEX aux.same_idx ON users (email);')!
+	ctx.remove_index('users', 'same_idx')!
 	assert db.q_int("SELECT count(*) FROM main.sqlite_master WHERE type = 'index' AND name = 'same_idx';")! == 1
 	assert db.q_int("SELECT count(*) FROM aux.sqlite_master WHERE type = 'index' AND name = 'same_idx';")! == 0
 }

--- a/vlib/v3/migrations/migrations_test.v
+++ b/vlib/v3/migrations/migrations_test.v
@@ -14,6 +14,7 @@ mut:
 	history_rows              []orm.Row
 	in_transaction            bool
 	autocommit                bool = true
+	foreign_keys              bool
 	postgresql_history_schema string
 	postgresql_table_schema   string = 'public'
 	postgresql_probe_value    string
@@ -49,8 +50,15 @@ fn (mut conn RecordingConnection) execute(query string) ![]orm.Row {
 	if query == 'START TRANSACTION;' {
 		conn.in_transaction = true
 	}
-	if query == 'BEGIN;' {
+	if query in ['BEGIN;', 'BEGIN IMMEDIATE;'] {
+		if conn.in_transaction {
+			return error('cannot start a transaction within a transaction')
+		}
 		conn.in_transaction = true
+	}
+	if query in ['ROLLBACK;', 'COMMIT;'] {
+		conn.in_transaction = false
+		conn.postgresql_probe_value = ''
 	}
 	if query == 'SET search_path TO other_schema;' {
 		conn.schema = 'other_schema'
@@ -119,6 +127,17 @@ fn (mut conn RecordingConnection) execute(query string) ![]orm.Row {
 		return [orm.Row{
 			vals: [if conn.autocommit { '1' } else { '0' }]
 		}]
+	}
+	if query == 'PRAGMA foreign_keys;' {
+		return [orm.Row{
+			vals: [if conn.foreign_keys { '1' } else { '0' }]
+		}]
+	}
+	if query == 'PRAGMA foreign_keys = ON;' && !conn.in_transaction {
+		conn.foreign_keys = true
+	}
+	if query == 'PRAGMA foreign_keys = OFF;' && !conn.in_transaction {
+		conn.foreign_keys = false
 	}
 	if query.starts_with('SELECT GET_LOCK(') || query.starts_with('SELECT RELEASE_LOCK(')
 		|| query.starts_with('SELECT pg_advisory_unlock(') {
@@ -279,6 +298,22 @@ fn start_mysql_transaction(mut ctx Context) ! {
 
 fn start_postgresql_transaction(mut ctx Context) ! {
 	ctx.execute('BEGIN;')!
+}
+
+fn rollback_callback_transaction(mut ctx Context) ! {
+	ctx.execute('ROLLBACK;')!
+}
+
+fn create_sqlite_table_then_rollback(mut ctx Context) ! {
+	ctx.create_table(Table{
+		name: 'rolled_back_callback_table'
+	})!
+	ctx.execute('ROLLBACK;')!
+}
+
+fn drop_sqlite_table_then_rollback(mut ctx Context) ! {
+	ctx.drop_table('rolled_back_callback_table')!
+	ctx.execute('ROLLBACK;')!
 }
 
 fn assert_postgresql_transaction_probe(queries []string) {
@@ -679,6 +714,89 @@ fn test_postgresql_callback_transactions_are_rolled_back_before_unlocking() {
 	assert down_rollback_index > down_recorder.queries.index('BEGIN;')
 	assert down_rollback_index > down_recorder.queries.index(history_deletes[0])
 	assert down_recorder.queries.last() == 'SELECT pg_advisory_unlock(${key});'
+}
+
+fn test_postgresql_owned_transaction_is_verified_before_history_writes() {
+	migration := Migration{
+		version: 1
+		name:    'rollback_transaction'
+		up:      rollback_callback_transaction
+		down:    rollback_callback_transaction
+	}
+	for mode in [TransactionMode.automatic, .always] {
+		mut up_recorder := &RecordingConnection{}
+		mut up_runner := new(mut up_recorder, [migration], Config{
+			dialect:          .pg
+			transaction_mode: mode
+		})!
+		mut error_message := ''
+		up_runner.migrate() or { error_message = err.msg() }
+		assert error_message == 'PostgreSQL migration callback ended the migrator-owned transaction before history was recorded'
+		assert !up_recorder.in_transaction
+		assert up_recorder.queries.filter(it.starts_with('INSERT INTO ')).len == 0
+		callback_index := up_recorder.queries.index('ROLLBACK;')
+		assert callback_index > up_recorder.queries.index('ORM BEGIN')
+		assert postgresql_transaction_probe_read_query() in up_recorder.queries[callback_index + 1..]
+
+		mut down_recorder := &RecordingConnection{
+			history_rows: [
+				orm.Row{
+					vals: ['1', migration.name, '2026-08-16T00:00:00Z']
+				},
+			]
+		}
+		mut down_runner := new(mut down_recorder, [migration], Config{
+			dialect:          .pg
+			transaction_mode: mode
+		})!
+		error_message = ''
+		down_runner.rollback(1) or { error_message = err.msg() }
+		assert error_message == 'PostgreSQL migration callback ended the migrator-owned transaction before history was recorded'
+		assert !down_recorder.in_transaction
+		assert down_recorder.queries.filter(it.starts_with('DELETE FROM ')).len == 0
+	}
+}
+
+fn test_sqlite_callback_cannot_end_lock_transaction_before_history_writes() {
+	mut up_db := sqlite.connect(':memory:')!
+	up_db.exec('CREATE TABLE schema_migrations (version BIGINT PRIMARY KEY, name VARCHAR(255) NOT NULL, applied_at VARCHAR(32) NOT NULL);')!
+	mut up_runner := new(mut up_db, [
+		Migration{
+			version: 1
+			name:    'rollback_transaction'
+			up:      create_sqlite_table_then_rollback
+			down:    drop_sqlite_table_then_rollback
+		},
+	], Config{
+		dialect: .sqlite
+	})!
+	mut error_message := ''
+	up_runner.migrate() or { error_message = err.msg() }
+	assert error_message == 'SQLite migration callback ended the migration lock transaction before history was recorded'
+	assert up_db.q_int("SELECT count(*) FROM sqlite_master WHERE type = 'table' AND name = 'rolled_back_callback_table';")! == 0
+	assert up_db.q_int('SELECT count(*) FROM schema_migrations;')! == 0
+	up_db.close()!
+
+	mut down_db := sqlite.connect(':memory:')!
+	down_db.exec('CREATE TABLE schema_migrations (version BIGINT PRIMARY KEY, name VARCHAR(255) NOT NULL, applied_at VARCHAR(32) NOT NULL);')!
+	down_db.exec('CREATE TABLE rolled_back_callback_table (id INTEGER PRIMARY KEY AUTOINCREMENT);')!
+	down_db.exec("INSERT INTO schema_migrations VALUES (1, 'rollback_transaction', '2026-08-16T00:00:00Z');")!
+	mut down_runner := new(mut down_db, [
+		Migration{
+			version: 1
+			name:    'rollback_transaction'
+			up:      create_sqlite_table_then_rollback
+			down:    drop_sqlite_table_then_rollback
+		},
+	], Config{
+		dialect: .sqlite
+	})!
+	error_message = ''
+	down_runner.rollback(1) or { error_message = err.msg() }
+	assert error_message == 'SQLite migration callback ended the migration lock transaction before history was recorded'
+	assert down_db.q_int("SELECT count(*) FROM sqlite_master WHERE type = 'table' AND name = 'rolled_back_callback_table';")! == 1
+	assert down_db.q_int('SELECT count(*) FROM schema_migrations;')! == 1
+	down_db.close()!
 }
 
 fn test_sqlite_history_table_is_pinned_to_main() {

--- a/vlib/v3/migrations/migrations_test.v
+++ b/vlib/v3/migrations/migrations_test.v
@@ -30,7 +30,37 @@ fn (mut conn RecordingConnection) last_id() int {
 
 fn (mut conn RecordingConnection) execute(query string) ![]orm.Row {
 	conn.queries << query
+	if query.starts_with('SELECT GET_LOCK(') || query.starts_with('SELECT RELEASE_LOCK(')
+		|| query.starts_with('SELECT pg_advisory_unlock(') {
+		return [orm.Row{
+			vals: ['1']
+		}]
+	}
 	return []
+}
+
+fn (mut conn RecordingConnection) orm_begin() ! {
+	conn.queries << 'ORM BEGIN'
+}
+
+fn (mut conn RecordingConnection) orm_commit() ! {
+	conn.queries << 'ORM COMMIT'
+}
+
+fn (mut conn RecordingConnection) orm_rollback() ! {
+	conn.queries << 'ORM ROLLBACK'
+}
+
+fn (mut conn RecordingConnection) orm_savepoint(name string) ! {
+	conn.queries << 'ORM SAVEPOINT ${name}'
+}
+
+fn (mut conn RecordingConnection) orm_rollback_to(name string) ! {
+	conn.queries << 'ORM ROLLBACK TO ${name}'
+}
+
+fn (mut conn RecordingConnection) orm_release_savepoint(name string) ! {
+	conn.queries << 'ORM RELEASE SAVEPOINT ${name}'
 }
 
 struct MigrationWidget {
@@ -112,6 +142,10 @@ fn drop_widget_with_orm_dsl(mut ctx Context) ! {
 	sql ctx {
 		drop table MigrationWidget
 	}!
+}
+
+fn record_locked_migration(mut ctx Context) ! {
+	ctx.execute('migration callback;')!
 }
 
 fn test_migrate_rollback_redo_and_status() {
@@ -210,6 +244,46 @@ fn test_context_supports_v3_orm_sql_blocks() {
 	assert db.q_int("SELECT count(*) FROM sqlite_master WHERE type = 'table' AND name = 'migrationwidget';")! == 1
 	runner.rollback(1)!
 	assert db.q_int("SELECT count(*) FROM sqlite_master WHERE type = 'table' AND name = 'migrationwidget';")! == 0
+}
+
+fn test_mutating_runner_holds_dialect_lock_around_callbacks() {
+	for dialect in [Dialect.sqlite, .pg, .mysql] {
+		mut recorder := &RecordingConnection{}
+		mut runner := new(mut recorder, [
+			Migration{
+				version: 1
+				name:    'locked'
+				up:      record_locked_migration
+				down:    record_locked_migration
+			},
+		], Config{
+			dialect: dialect
+		})!
+		runner.migrate()!
+		key := migration_lock_key('schema_migrations')
+		match dialect {
+			.sqlite {
+				assert recorder.queries[0] == 'BEGIN IMMEDIATE;'
+				assert recorder.queries.last() == 'ORM COMMIT'
+				assert 'ORM BEGIN' !in recorder.queries
+			}
+			.pg {
+				assert recorder.queries[0] == 'SELECT pg_advisory_lock(${key});'
+				assert recorder.queries.last() == 'SELECT pg_advisory_unlock(${key});'
+				assert 'ORM BEGIN' in recorder.queries
+				assert 'ORM COMMIT' in recorder.queries
+			}
+			.mysql {
+				name := migration_lock_name(key)
+				assert recorder.queries[0] == "SELECT GET_LOCK('${name}', ${migration_lock_timeout_seconds});"
+				assert recorder.queries.last() == "SELECT RELEASE_LOCK('${name}');"
+				assert 'ORM BEGIN' !in recorder.queries
+			}
+		}
+		callback_index := recorder.queries.index('migration callback;')
+		assert callback_index > 0
+		assert callback_index < recorder.queries.len - 1
+	}
 }
 
 fn test_postgresql_change_column_rejects_constraint_options_before_sql() {
@@ -346,6 +420,102 @@ fn test_rename_table_rejects_qualified_targets_where_required() {
 	assert mysql_recorder.queries == [
 		'ALTER TABLE `app`.`users` RENAME TO `archive`.`users`;',
 	]
+}
+
+fn test_sqlite_add_column_rejects_unsupported_constraints() {
+	mut recorder := &RecordingConnection{}
+	mut ctx := new_context(recorder, .sqlite)
+	mut error_message := ''
+	ctx.add_column('accounts', Column{
+		name:        'owner_id'
+		kind:        .bigint
+		primary_key: true
+	}) or { error_message = err.msg() }
+	assert error_message == 'SQLite add_column does not support primary-key, unique, or auto-increment columns; rebuild the table in the migration'
+
+	error_message = ''
+	ctx.add_column('accounts', Column{
+		name:   'email'
+		kind:   .text
+		unique: true
+	}) or { error_message = err.msg() }
+	assert error_message == 'SQLite add_column does not support primary-key, unique, or auto-increment columns; rebuild the table in the migration'
+
+	mut invalid_defaults := []?string{}
+	invalid_defaults << none
+	invalid_defaults << ''
+	invalid_defaults << 'NULL'
+	for default_sql in invalid_defaults {
+		error_message = ''
+		ctx.add_column('accounts', Column{
+			name:        'label'
+			kind:        .text
+			nullable:    false
+			default_sql: default_sql
+		}) or { error_message = err.msg() }
+		assert error_message == 'SQLite add_column requires a non-NULL default for a NOT NULL column; rebuild the table in the migration'
+	}
+	assert recorder.queries.len == 0
+
+	ctx.add_column('accounts', Column{
+		name:        'label'
+		kind:        .text
+		nullable:    false
+		default_sql: "''"
+	})!
+	assert recorder.queries == [
+		'ALTER TABLE "accounts" ADD COLUMN "label" TEXT NOT NULL DEFAULT \'\';',
+	]
+}
+
+fn test_sqlite_autoincrement_precedes_other_constraints() {
+	definition := column_sql(.sqlite, Column{
+		name:           'id'
+		kind:           .integer
+		primary_key:    true
+		auto_increment: true
+		unique:         true
+		default_sql:    '5'
+	})!
+	assert definition == '"id" INTEGER PRIMARY KEY AUTOINCREMENT UNIQUE DEFAULT 5'
+	mut db := sqlite.connect(':memory:')!
+	defer {
+		db.close() or {}
+	}
+	db.exec('CREATE TABLE items (${definition});')!
+}
+
+fn test_column_level_identifiers_must_be_unqualified() {
+	mut recorder := &RecordingConnection{}
+	mut ctx := new_context(recorder, .pg)
+	mut error_message := ''
+	ctx.add_column('users', Column{
+		name: 'users.email'
+		kind: .text
+	}) or { error_message = err.msg() }
+	assert error_message == 'column name `users.email` must be unqualified'
+
+	error_message = ''
+	ctx.rename_column('users', 'users.email', 'address') or { error_message = err.msg() }
+	assert error_message == 'column name `users.email` must be unqualified'
+
+	error_message = ''
+	ctx.add_index(Index{
+		table:   'public.users'
+		columns: ['users.email']
+	}) or { error_message = err.msg() }
+	assert error_message == 'column name `users.email` must be unqualified'
+
+	error_message = ''
+	ctx.add_foreign_key(ForeignKey{
+		from_table:  'public.posts'
+		column:      'posts.author_id'
+		to_table:    'public.users'
+		primary_key: 'id'
+		name:        'fk_posts_author'
+	}) or { error_message = err.msg() }
+	assert error_message == 'column name `posts.author_id` must be unqualified'
+	assert recorder.queries.len == 0
 }
 
 fn test_validation_and_portable_sql_generation() {

--- a/vlib/v3/migrations/migrations_test.v
+++ b/vlib/v3/migrations/migrations_test.v
@@ -14,7 +14,9 @@ mut:
 	history_rows              []orm.Row
 	in_transaction            bool
 	autocommit                bool = true
-	foreign_keys              bool
+	savepoints                []string
+	savepoint_probe_rows      map[string]int
+	sqlite_probe_rows         int
 	postgresql_history_schema string
 	postgresql_table_schema   string = 'public'
 	postgresql_probe_value    string
@@ -49,16 +51,43 @@ fn (mut conn RecordingConnection) execute(query string) ![]orm.Row {
 	}
 	if query == 'START TRANSACTION;' {
 		conn.in_transaction = true
+		conn.clear_savepoints()
 	}
 	if query in ['BEGIN;', 'BEGIN IMMEDIATE;'] {
 		if conn.in_transaction {
 			return error('cannot start a transaction within a transaction')
 		}
 		conn.in_transaction = true
+		conn.clear_savepoints()
 	}
 	if query in ['ROLLBACK;', 'COMMIT;'] {
 		conn.in_transaction = false
 		conn.postgresql_probe_value = ''
+		conn.sqlite_probe_rows = 0
+		conn.clear_savepoints()
+	}
+	if query.starts_with('SAVEPOINT ') {
+		if !conn.in_transaction {
+			conn.in_transaction = true
+		}
+		conn.add_savepoint(query.all_after('SAVEPOINT ').all_before(';'))
+	}
+	if query.starts_with('RELEASE SAVEPOINT ') {
+		conn.release_savepoint(query.all_after('RELEASE SAVEPOINT ').all_before(';'))
+	}
+	if query.starts_with('INSERT INTO temp."v3_migrations_transaction_') {
+		conn.sqlite_probe_rows++
+	}
+	if query.starts_with('ROLLBACK TO SAVEPOINT ') {
+		conn.rollback_to_savepoint(query.all_after('ROLLBACK TO SAVEPOINT ').all_before(';'))
+	}
+	if query.starts_with('SELECT COUNT(*) FROM temp."v3_migrations_transaction_') {
+		return [orm.Row{
+			vals: [conn.sqlite_probe_rows.str()]
+		}]
+	}
+	if query.starts_with('DELETE FROM temp."v3_migrations_transaction_') {
+		conn.sqlite_probe_rows = 0
 	}
 	if query == 'SET search_path TO other_schema;' {
 		conn.schema = 'other_schema'
@@ -128,17 +157,6 @@ fn (mut conn RecordingConnection) execute(query string) ![]orm.Row {
 			vals: [if conn.autocommit { '1' } else { '0' }]
 		}]
 	}
-	if query == 'PRAGMA foreign_keys;' {
-		return [orm.Row{
-			vals: [if conn.foreign_keys { '1' } else { '0' }]
-		}]
-	}
-	if query == 'PRAGMA foreign_keys = ON;' && !conn.in_transaction {
-		conn.foreign_keys = true
-	}
-	if query == 'PRAGMA foreign_keys = OFF;' && !conn.in_transaction {
-		conn.foreign_keys = false
-	}
 	if query.starts_with('SELECT GET_LOCK(') || query.starts_with('SELECT RELEASE_LOCK(')
 		|| query.starts_with('SELECT pg_advisory_unlock(') {
 		return [orm.Row{
@@ -157,12 +175,15 @@ fn (mut conn RecordingConnection) orm_commit() ! {
 	conn.queries << 'ORM COMMIT'
 	conn.in_transaction = false
 	conn.postgresql_probe_value = ''
+	conn.clear_savepoints()
 }
 
 fn (mut conn RecordingConnection) orm_rollback() ! {
 	conn.queries << 'ORM ROLLBACK'
 	conn.in_transaction = false
 	conn.postgresql_probe_value = ''
+	conn.sqlite_probe_rows = 0
+	conn.clear_savepoints()
 }
 
 fn (mut conn RecordingConnection) orm_savepoint(name string) ! {
@@ -170,14 +191,56 @@ fn (mut conn RecordingConnection) orm_savepoint(name string) ! {
 		return error('savepoint requires an active transaction')
 	}
 	conn.queries << 'ORM SAVEPOINT ${name}'
+	conn.add_savepoint(name)
 }
 
 fn (mut conn RecordingConnection) orm_rollback_to(name string) ! {
+	if !conn.rollback_to_savepoint(name) {
+		return error('savepoint `${name}` does not exist')
+	}
 	conn.queries << 'ORM ROLLBACK TO ${name}'
 }
 
 fn (mut conn RecordingConnection) orm_release_savepoint(name string) ! {
+	if !conn.release_savepoint(name) {
+		return error('savepoint `${name}` does not exist')
+	}
 	conn.queries << 'ORM RELEASE SAVEPOINT ${name}'
+}
+
+fn (mut conn RecordingConnection) add_savepoint(name string) {
+	conn.savepoints << name
+	conn.savepoint_probe_rows[name] = conn.sqlite_probe_rows
+}
+
+fn (mut conn RecordingConnection) release_savepoint(name string) bool {
+	index := conn.savepoints.index(name)
+	if index < 0 {
+		return false
+	}
+	for savepoint in conn.savepoints[index..] {
+		conn.savepoint_probe_rows.delete(savepoint)
+	}
+	conn.savepoints = conn.savepoints[..index].clone()
+	return true
+}
+
+fn (mut conn RecordingConnection) rollback_to_savepoint(name string) bool {
+	index := conn.savepoints.index(name)
+	if index < 0 {
+		return false
+	}
+	conn.sqlite_probe_rows = conn.savepoint_probe_rows[name]
+	for savepoint in conn.savepoints[index + 1..] {
+		conn.savepoint_probe_rows.delete(savepoint)
+	}
+	conn.savepoints = conn.savepoints[..index + 1].clone()
+	return true
+}
+
+fn (mut conn RecordingConnection) clear_savepoints() {
+	conn.savepoints.clear()
+	conn.savepoint_probe_rows.clear()
 }
 
 struct MigrationWidget {
@@ -316,6 +379,14 @@ fn drop_sqlite_table_then_rollback(mut ctx Context) ! {
 	ctx.execute('ROLLBACK;')!
 }
 
+fn create_sqlite_table_then_replace_transaction(mut ctx Context) ! {
+	ctx.create_table(Table{
+		name: 'replaced_transaction_table'
+	})!
+	ctx.execute('ROLLBACK;')!
+	ctx.execute('BEGIN;')!
+}
+
 fn assert_postgresql_transaction_probe(queries []string) {
 	assert queries.len >= 2
 	assert queries[0].starts_with("SELECT pg_catalog.set_config('${postgresql_transaction_probe_setting}', 'probe_")
@@ -436,9 +507,11 @@ fn test_mutating_runner_holds_dialect_lock_around_callbacks() {
 		runner.migrate()!
 		match dialect {
 			.sqlite {
-				assert recorder.queries[0] == 'BEGIN IMMEDIATE;'
-				assert recorder.queries.last() == 'ORM COMMIT'
+				assert recorder.queries[0].starts_with('CREATE TEMP TABLE temp."v3_migrations_transaction_')
+				assert recorder.queries[1] == 'BEGIN IMMEDIATE;'
+				assert recorder.queries.last().starts_with('DROP TABLE IF EXISTS temp."v3_migrations_transaction_')
 				assert 'ORM BEGIN' !in recorder.queries
+				assert 'ORM COMMIT' in recorder.queries
 			}
 			.pg {
 				key := postgresql_migration_lock_key(recorder.schema, 'schema_migrations')
@@ -757,6 +830,44 @@ fn test_postgresql_owned_transaction_is_verified_before_history_writes() {
 	}
 }
 
+fn test_mysql_owned_transaction_is_verified_before_history_writes() {
+	migration := Migration{
+		version: 1
+		name:    'rollback_transaction'
+		up:      rollback_callback_transaction
+		down:    rollback_callback_transaction
+	}
+	mut up_recorder := &RecordingConnection{}
+	mut up_runner := new(mut up_recorder, [migration], Config{
+		dialect:          .mysql
+		transaction_mode: .always
+	})!
+	mut error_message := ''
+	up_runner.migrate() or { error_message = err.msg() }
+	assert error_message == 'MySQL migration callback ended the migrator-owned transaction before history was recorded'
+	assert !up_recorder.in_transaction
+	assert up_recorder.queries.filter(it.starts_with('INSERT INTO ')).len == 0
+	assert up_recorder.queries.last().starts_with('SELECT RELEASE_LOCK(')
+
+	mut down_recorder := &RecordingConnection{
+		history_rows: [
+			orm.Row{
+				vals: ['1', migration.name, '2026-08-16T00:00:00Z']
+			},
+		]
+	}
+	mut down_runner := new(mut down_recorder, [migration], Config{
+		dialect:          .mysql
+		transaction_mode: .always
+	})!
+	error_message = ''
+	down_runner.rollback(1) or { error_message = err.msg() }
+	assert error_message == 'MySQL migration callback ended the migrator-owned transaction before history was recorded'
+	assert !down_recorder.in_transaction
+	assert down_recorder.queries.filter(it.starts_with('DELETE FROM ')).len == 0
+	assert down_recorder.queries.last().starts_with('SELECT RELEASE_LOCK(')
+}
+
 fn test_sqlite_callback_cannot_end_lock_transaction_before_history_writes() {
 	mut up_db := sqlite.connect(':memory:')!
 	up_db.exec('CREATE TABLE schema_migrations (version BIGINT PRIMARY KEY, name VARCHAR(255) NOT NULL, applied_at VARCHAR(32) NOT NULL);')!
@@ -797,6 +908,30 @@ fn test_sqlite_callback_cannot_end_lock_transaction_before_history_writes() {
 	assert down_db.q_int("SELECT count(*) FROM sqlite_master WHERE type = 'table' AND name = 'rolled_back_callback_table';")! == 1
 	assert down_db.q_int('SELECT count(*) FROM schema_migrations;')! == 1
 	down_db.close()!
+}
+
+fn test_sqlite_callback_cannot_replace_lock_transaction_before_history_write() {
+	mut db := sqlite.connect(':memory:')!
+	defer {
+		db.close() or {}
+	}
+	db.exec('CREATE TABLE schema_migrations (version BIGINT PRIMARY KEY, name VARCHAR(255) NOT NULL, applied_at VARCHAR(32) NOT NULL);')!
+	mut runner := new(mut db, [
+		Migration{
+			version: 1
+			name:    'replace_transaction'
+			up:      create_sqlite_table_then_replace_transaction
+			down:    drop_sqlite_table_then_rollback
+		},
+	], Config{
+		dialect: .sqlite
+	})!
+	mut error_message := ''
+	runner.migrate() or { error_message = err.msg() }
+	assert error_message == 'SQLite migration callback ended the migration lock transaction before history was recorded'
+	assert db.q_int("SELECT count(*) FROM sqlite_master WHERE type = 'table' AND name = 'replaced_transaction_table';")! == 0
+	assert db.q_int('SELECT count(*) FROM schema_migrations;')! == 0
+	assert runner.sqlite_transaction_probe == ''
 }
 
 fn test_sqlite_history_table_is_pinned_to_main() {

--- a/vlib/v3/migrations/migrations_test.v
+++ b/vlib/v3/migrations/migrations_test.v
@@ -22,6 +22,7 @@ mut:
 	postgresql_probe_value    string
 	postgresql_aborted        bool
 	sqlite_table_schema       string = 'main'
+	sqlite_version            string = '3.46.0'
 }
 
 fn (mut conn RecordingConnection) select(_ orm.SelectConfig, _ orm.QueryData, _ orm.QueryData) ![][]orm.Primitive {
@@ -164,6 +165,11 @@ fn (mut conn RecordingConnection) execute(query string) ![]orm.Row {
 	if query == 'SELECT @@autocommit;' {
 		return [orm.Row{
 			vals: [if conn.autocommit { '1' } else { '0' }]
+		}]
+	}
+	if query == 'SELECT sqlite_version();' {
+		return [orm.Row{
+			vals: [conn.sqlite_version]
 		}]
 	}
 	if query.starts_with('SELECT GET_LOCK(') || query.starts_with('SELECT RELEASE_LOCK(')
@@ -650,6 +656,7 @@ fn test_postgresql_open_transaction_is_rejected_in_every_mode_without_being_fini
 	for mode in [TransactionMode.automatic, .always, .never] {
 		mut recorder := &RecordingConnection{
 			in_transaction: true
+			savepoints:     ['v3_migrations_transaction_probe']
 		}
 		mut runner := new(mut recorder, []Migration{}, Config{
 			dialect:          .pg
@@ -678,11 +685,12 @@ fn test_mysql_open_transaction_is_rejected_in_every_mode_without_being_finished(
 		runner.migrate() or { error_message = err.msg() }
 		assert error_message == 'MySQL migrations require a connection without an already-open transaction'
 		assert recorder.in_transaction
-		assert recorder.queries == [
-			'SELECT @@autocommit;',
-			'ORM SAVEPOINT v3_migrations_transaction_probe',
-			'ORM RELEASE SAVEPOINT v3_migrations_transaction_probe',
-		]
+		assert recorder.queries.len == 3
+		assert recorder.queries[0] == 'SELECT @@autocommit;'
+		assert recorder.queries[1].starts_with('ORM SAVEPOINT v3_migrations_transaction_probe_')
+		probe := recorder.queries[1].all_after('ORM SAVEPOINT ')
+		assert probe != 'v3_migrations_transaction_probe'
+		assert recorder.queries[2] == 'ORM RELEASE SAVEPOINT ${probe}'
 	}
 }
 
@@ -1922,6 +1930,7 @@ fn test_sqlite_accepts_numeric_literal_digit_separators() {
 		default_sql: '(0xCA_FE)'
 	})!
 	assert recorder.queries == [
+		'SELECT sqlite_version();',
 		'ALTER TABLE "accounts" ADD COLUMN "population" INTEGER DEFAULT (1_000);',
 		'ALTER TABLE "accounts" ADD COLUMN "mask" INTEGER DEFAULT (0xCA_FE);',
 	]
@@ -1932,7 +1941,20 @@ fn test_sqlite_accepts_numeric_literal_digit_separators() {
 		default_sql: '(e1)'
 	}) or { error_message = err.msg() }
 	assert error_message == 'SQLite add_column does not support nonconstant default `(e1)`; rebuild the table in the migration'
-	assert recorder.queries.len == 2
+	assert recorder.queries.len == 3
+
+	mut old_recorder := &RecordingConnection{
+		sqlite_version: '3.45.1'
+	}
+	mut old_ctx := new_context(old_recorder, .sqlite)
+	error_message = ''
+	old_ctx.add_column('accounts', Column{
+		name:        'population'
+		kind:        .integer
+		default_sql: '(1_000)'
+	}) or { error_message = err.msg() }
+	assert error_message == 'SQLite add_column default `(1_000)` uses numeric digit separators, which require SQLite 3.46.0 or newer'
+	assert old_recorder.queries == ['SELECT sqlite_version();']
 }
 
 fn test_sqlite_requires_unqualified_index_and_foreign_key_tables() {

--- a/vlib/v3/migrations/migrations_test.v
+++ b/vlib/v3/migrations/migrations_test.v
@@ -7,14 +7,15 @@ import orm
 @[heap]
 struct RecordingConnection {
 mut:
-	queries                 []string
-	database                string = 'test_database'
-	schema                  string = 'public'
-	lower_case_table_names  int
-	history_rows            []orm.Row
-	in_transaction          bool
-	postgresql_table_schema string = 'public'
-	sqlite_table_schema     string = 'main'
+	queries                   []string
+	database                  string = 'test_database'
+	schema                    string = 'public'
+	lower_case_table_names    int
+	history_rows              []orm.Row
+	in_transaction            bool
+	postgresql_history_schema string
+	postgresql_table_schema   string = 'public'
+	sqlite_table_schema       string = 'main'
 }
 
 fn (mut conn RecordingConnection) select(_ orm.SelectConfig, _ orm.QueryData, _ orm.QueryData) ![][]orm.Primitive {
@@ -51,10 +52,16 @@ fn (mut conn RecordingConnection) execute(query string) ![]orm.Row {
 			vals: [conn.database]
 		}]
 	}
-	if query == 'SELECT current_schema();' {
-		return [orm.Row{
-			vals: [conn.schema]
-		}]
+	if query.starts_with('SELECT COALESCE((SELECT n.nspname FROM pg_catalog.pg_class AS c ') {
+		return [
+			orm.Row{
+				vals: [if conn.postgresql_history_schema == '' {
+					conn.schema
+				} else {
+					conn.postgresql_history_schema
+				}]
+			},
+		]
 	}
 	if query.starts_with('SELECT n.nspname FROM pg_catalog.pg_class AS c ') {
 		return [orm.Row{
@@ -349,7 +356,7 @@ fn test_mutating_runner_holds_dialect_lock_around_callbacks() {
 			}
 			.pg {
 				key := postgresql_migration_lock_key(recorder.schema, 'schema_migrations')
-				assert recorder.queries[0] == 'SELECT current_schema();'
+				assert recorder.queries[0] == postgresql_history_schema_query('schema_migrations')
 				assert recorder.queries[1] == 'SELECT pg_advisory_lock(${key});'
 				assert recorder.queries.last() == 'SELECT pg_advisory_unlock(${key});'
 				assert 'ORM BEGIN' in recorder.queries
@@ -423,7 +430,7 @@ fn test_locked_history_table_survives_callback_namespace_changes() {
 		assert up_runner.resolved_history_namespace == 'app'
 		if dialect == .pg {
 			assert up_recorder.schema == 'other_schema'
-			assert up_recorder.queries.filter(it == 'SELECT current_schema();').len == 1
+			assert up_recorder.queries.filter(it == postgresql_history_schema_query('schema_migrations')).len == 1
 		} else {
 			assert up_recorder.database == 'other_database'
 			assert up_recorder.queries.filter(it == 'SELECT DATABASE();').len == 1
@@ -646,18 +653,19 @@ fn test_postgresql_migration_locks_use_full_64bit_keys() {
 	runner.acquire_migration_lock()!
 	runner.release_migration_lock(true)!
 	assert recorder.queries == [
-		'SELECT current_schema();',
+		postgresql_history_schema_query(first_table),
 		'SELECT pg_advisory_lock(${first_key});',
 		'SELECT pg_advisory_unlock(${first_key});',
 	]
 }
 
 fn test_postgresql_migration_locks_canonicalize_history_table() {
-	key := postgresql_migration_lock_key('app', 'schema_migrations')
-	assert key == postgresql_migration_lock_key('app', 'app.schema_migrations')
+	key := postgresql_migration_lock_key('public', 'schema_migrations')
+	assert key == postgresql_migration_lock_key('public', 'public.schema_migrations')
 
 	mut unqualified_recorder := &RecordingConnection{
-		schema: 'app'
+		schema:                    'tenant'
+		postgresql_history_schema: 'public'
 	}
 	mut unqualified_runner := new(mut unqualified_recorder, []Migration{}, Config{
 		dialect: .pg
@@ -665,17 +673,18 @@ fn test_postgresql_migration_locks_canonicalize_history_table() {
 	unqualified_runner.acquire_migration_lock()!
 	unqualified_runner.release_migration_lock(true)!
 	assert unqualified_recorder.queries == [
-		'SELECT current_schema();',
+		postgresql_history_schema_query('schema_migrations'),
 		'SELECT pg_advisory_lock(${key});',
 		'SELECT pg_advisory_unlock(${key});',
 	]
+	assert unqualified_runner.resolved_history_namespace == 'public'
 
 	mut qualified_recorder := &RecordingConnection{
 		schema: 'unrelated'
 	}
 	mut qualified_runner := new(mut qualified_recorder, []Migration{}, Config{
 		dialect: .pg
-		table:   'app.schema_migrations'
+		table:   'public.schema_migrations'
 	})!
 	qualified_runner.acquire_migration_lock()!
 	qualified_runner.release_migration_lock(true)!
@@ -1168,6 +1177,8 @@ fn test_sqlite_add_column_rejects_unsupported_constraints() {
 	invalid_defaults << '((+NULL))'
 	invalid_defaults << '(NULL) COLLATE binary'
 	invalid_defaults << '((+NULL)) /* absent */ COLLATE binary'
+	invalid_defaults << 'NULL COLLATE binary'
+	invalid_defaults << '+NULL /* absent */ COLLATE binary'
 	for default_sql in invalid_defaults {
 		error_message = ''
 		ctx.add_column('accounts', Column{

--- a/vlib/v3/migrations/migrations_test.v
+++ b/vlib/v3/migrations/migrations_test.v
@@ -323,6 +323,7 @@ fn test_mysql_migration_locks_are_namespaced_by_database() {
 
 	qualified_table := 'shared.schema_migrations'
 	qualified_name := mysql_migration_lock_name('shared', qualified_table)
+	assert qualified_name == mysql_migration_lock_name('shared', 'schema_migrations')
 	mut qualified_first_recorder := &RecordingConnection{
 		database: 'application_one'
 	}
@@ -347,6 +348,16 @@ fn test_mysql_migration_locks_are_namespaced_by_database() {
 	qualified_second_runner.acquire_migration_lock()!
 	qualified_second_runner.release_migration_lock(true)!
 	assert qualified_second_recorder.queries == qualified_first_recorder.queries
+
+	mut unqualified_recorder := &RecordingConnection{
+		database: 'shared'
+	}
+	mut unqualified_runner := new(mut unqualified_recorder, []Migration{}, Config{
+		dialect: .mysql
+	})!
+	unqualified_runner.acquire_migration_lock()!
+	unqualified_runner.release_migration_lock(true)!
+	assert unqualified_recorder.queries[1..] == qualified_first_recorder.queries
 }
 
 fn test_postgresql_migration_locks_use_full_64bit_keys() {
@@ -1192,6 +1203,31 @@ fn test_generated_foreign_key_names_respect_dialect_limits() {
 	}) or { error_message = err.msg() }
 	assert error_message == 'MySQL foreign key name `${long_explicit_name}` must not exceed 64 bytes'
 	assert recorder.queries.len == 2
+}
+
+fn test_generated_mysql_foreign_key_names_distinguish_component_boundaries() {
+	first := ForeignKey{
+		from_table: 'a_b'
+		column:     'c'
+		to_table:   'parents'
+	}
+	second := ForeignKey{
+		from_table: 'a'
+		column:     'b_c'
+		to_table:   'parents'
+	}
+	first_name := foreign_key_name(.mysql, first)!
+	second_name := foreign_key_name(.mysql, second)!
+	assert first_name.starts_with('fk_a_b_c_')
+	assert second_name.starts_with('fk_a_b_c_')
+	assert first_name != second_name
+
+	mut recorder := &RecordingConnection{}
+	mut ctx := new_context(recorder, .mysql)
+	ctx.add_foreign_key(first)!
+	ctx.add_foreign_key(second)!
+	assert recorder.queries[0].contains('CONSTRAINT `${first_name}` FOREIGN KEY')
+	assert recorder.queries[1].contains('CONSTRAINT `${second_name}` FOREIGN KEY')
 }
 
 fn test_caller_supplied_identifiers_respect_dialect_limits() {

--- a/vlib/v3/migrations/migrations_test.v
+++ b/vlib/v3/migrations/migrations_test.v
@@ -240,6 +240,25 @@ fn test_postgresql_change_column_rejects_constraint_options_before_sql() {
 	assert false
 }
 
+fn test_postgresql_change_column_rejects_explicit_constraint_removals() {
+	mut recorder := &RecordingConnection{}
+	mut ctx := new_context(recorder, .pg)
+	ctx.change_column('accounts', Column{
+		name:           'score'
+		kind:           .bigint
+		nullable:       true
+		default_sql:    ''
+		unique:         false
+		primary_key:    false
+		auto_increment: false
+	}) or {
+		assert err.msg() == 'PostgreSQL change_column only supports type, limit, precision, and scale; unsupported options: nullable, default_sql, unique, primary_key, auto_increment; use ctx.execute() for constraint changes'
+		assert recorder.queries.len == 0
+		return
+	}
+	assert false
+}
+
 fn test_validation_and_portable_sql_generation() {
 	mut db := sqlite.connect(':memory:')!
 	defer {

--- a/vlib/v3/migrations/migrations_test.v
+++ b/vlib/v3/migrations/migrations_test.v
@@ -320,6 +320,33 @@ fn test_mysql_migration_locks_are_namespaced_by_database() {
 	second_name := mysql_migration_lock_name('application_two', 'schema_migrations')
 	assert second_name != first_name
 	assert second_recorder.queries[1] == "SELECT GET_LOCK('${second_name}', ${migration_lock_timeout_seconds});"
+
+	qualified_table := 'shared.schema_migrations'
+	qualified_name := mysql_migration_lock_name('shared', qualified_table)
+	mut qualified_first_recorder := &RecordingConnection{
+		database: 'application_one'
+	}
+	mut qualified_first_runner := new(mut qualified_first_recorder, []Migration{}, Config{
+		dialect: .mysql
+		table:   qualified_table
+	})!
+	qualified_first_runner.acquire_migration_lock()!
+	qualified_first_runner.release_migration_lock(true)!
+	assert qualified_first_recorder.queries == [
+		"SELECT GET_LOCK('${qualified_name}', ${migration_lock_timeout_seconds});",
+		"SELECT RELEASE_LOCK('${qualified_name}');",
+	]
+
+	mut qualified_second_recorder := &RecordingConnection{
+		database: 'application_two'
+	}
+	mut qualified_second_runner := new(mut qualified_second_recorder, []Migration{}, Config{
+		dialect: .mysql
+		table:   qualified_table
+	})!
+	qualified_second_runner.acquire_migration_lock()!
+	qualified_second_runner.release_migration_lock(true)!
+	assert qualified_second_recorder.queries == qualified_first_recorder.queries
 }
 
 fn test_mysql_history_literals_are_backslash_safe() {
@@ -772,6 +799,7 @@ fn test_sqlite_add_column_rejects_unsupported_constraints() {
 	invalid_defaults << none
 	invalid_defaults << ''
 	invalid_defaults << 'NULL'
+	invalid_defaults << 'NULL /* absent */'
 	for default_sql in invalid_defaults {
 		error_message = ''
 		ctx.add_column('accounts', Column{
@@ -782,7 +810,9 @@ fn test_sqlite_add_column_rejects_unsupported_constraints() {
 		}) or { error_message = err.msg() }
 		assert error_message == 'SQLite add_column requires a non-NULL default for a NOT NULL column; rebuild the table in the migration'
 	}
-	for default_sql in ['CURRENT_TIME', 'CURRENT_DATE', 'CURRENT_TIMESTAMP', "(datetime('now'))"] {
+	for default_sql in ['CURRENT_TIME', 'CURRENT_DATE', 'CURRENT_TIMESTAMP', "(datetime('now'))",
+		'CURRENT_TIMESTAMP /* now */', '/* now */ CURRENT_DATE', 'CURRENT_TIME -- now',
+		"(datetime('now')) /* now */"] {
 		error_message = ''
 		ctx.add_column('accounts', Column{
 			name:        'created_at'
@@ -802,6 +832,13 @@ fn test_sqlite_add_column_rejects_unsupported_constraints() {
 	assert recorder.queries == [
 		'ALTER TABLE "accounts" ADD COLUMN "label" TEXT NOT NULL DEFAULT \'\';',
 	]
+	ctx.add_column('accounts', Column{
+		name:        'literal_comment'
+		kind:        .text
+		nullable:    false
+		default_sql: "'CURRENT_TIMESTAMP /* literal */'"
+	})!
+	assert recorder.queries[1] == 'ALTER TABLE "accounts" ADD COLUMN "literal_comment" TEXT NOT NULL DEFAULT \'CURRENT_TIMESTAMP /* literal */\';'
 }
 
 fn test_sqlite_requires_unqualified_index_and_foreign_key_tables() {
@@ -813,6 +850,15 @@ fn test_sqlite_requires_unqualified_index_and_foreign_key_tables() {
 		columns: ['email']
 	}) or { error_message = err.msg() }
 	assert error_message == 'SQLite add_index table `main.users` must be unqualified'
+	assert recorder.queries.len == 0
+
+	error_message = ''
+	ctx.add_index(Index{
+		table:   'users'
+		columns: ['email']
+		name:    'main.aux.users_email_idx'
+	}) or { error_message = err.msg() }
+	assert error_message == 'SQLite index name `main.aux.users_email_idx` must not exceed 2 components'
 	assert recorder.queries.len == 0
 
 	error_message = ''
@@ -1003,7 +1049,7 @@ fn test_generated_index_names_respect_dialect_limits() {
 		columns: ['email']
 		name:    long_explicit_name
 	}) or { error_message = err.msg() }
-	assert error_message == 'MySQL index name `${long_explicit_name}` must not exceed 64 bytes'
+	assert error_message == 'MySQL index name component `${long_explicit_name}` must not exceed 64 bytes'
 }
 
 fn test_generated_foreign_key_names_respect_dialect_limits() {

--- a/vlib/v3/migrations/migrations_test.v
+++ b/vlib/v3/migrations/migrations_test.v
@@ -9,6 +9,7 @@ struct RecordingConnection {
 mut:
 	queries  []string
 	database string = 'test_database'
+	schema   string = 'public'
 }
 
 fn (mut conn RecordingConnection) select(_ orm.SelectConfig, _ orm.QueryData, _ orm.QueryData) ![][]orm.Primitive {
@@ -34,6 +35,11 @@ fn (mut conn RecordingConnection) execute(query string) ![]orm.Row {
 	if query == 'SELECT DATABASE();' {
 		return [orm.Row{
 			vals: [conn.database]
+		}]
+	}
+	if query == 'SELECT current_schema();' {
+		return [orm.Row{
+			vals: [conn.schema]
 		}]
 	}
 	if query.starts_with('SELECT GET_LOCK(') || query.starts_with('SELECT RELEASE_LOCK(')
@@ -266,7 +272,6 @@ fn test_mutating_runner_holds_dialect_lock_around_callbacks() {
 			dialect: dialect
 		})!
 		runner.migrate()!
-		key := migration_lock_key('schema_migrations')
 		match dialect {
 			.sqlite {
 				assert recorder.queries[0] == 'BEGIN IMMEDIATE;'
@@ -274,7 +279,9 @@ fn test_mutating_runner_holds_dialect_lock_around_callbacks() {
 				assert 'ORM BEGIN' !in recorder.queries
 			}
 			.pg {
-				assert recorder.queries[0] == 'SELECT pg_advisory_lock(${key});'
+				key := postgresql_migration_lock_key(recorder.schema, 'schema_migrations')
+				assert recorder.queries[0] == 'SELECT current_schema();'
+				assert recorder.queries[1] == 'SELECT pg_advisory_lock(${key});'
 				assert recorder.queries.last() == 'SELECT pg_advisory_unlock(${key});'
 				assert 'ORM BEGIN' in recorder.queries
 				assert 'ORM COMMIT' in recorder.queries
@@ -363,8 +370,8 @@ fn test_mysql_migration_locks_are_namespaced_by_database() {
 fn test_postgresql_migration_locks_use_full_64bit_keys() {
 	first_table := 's_d015hmpz1cdl'
 	second_table := 's_syia3wc6g1qq'
-	first_key := migration_lock_key(first_table)
-	second_key := migration_lock_key(second_table)
+	first_key := postgresql_migration_lock_key('public', first_table)
+	second_key := postgresql_migration_lock_key('public', second_table)
 	assert first_key != second_key
 
 	mut recorder := &RecordingConnection{}
@@ -375,9 +382,40 @@ fn test_postgresql_migration_locks_use_full_64bit_keys() {
 	runner.acquire_migration_lock()!
 	runner.release_migration_lock(true)!
 	assert recorder.queries == [
+		'SELECT current_schema();',
 		'SELECT pg_advisory_lock(${first_key});',
 		'SELECT pg_advisory_unlock(${first_key});',
 	]
+}
+
+fn test_postgresql_migration_locks_canonicalize_history_table() {
+	key := postgresql_migration_lock_key('app', 'schema_migrations')
+	assert key == postgresql_migration_lock_key('app', 'app.schema_migrations')
+
+	mut unqualified_recorder := &RecordingConnection{
+		schema: 'app'
+	}
+	mut unqualified_runner := new(mut unqualified_recorder, []Migration{}, Config{
+		dialect: .pg
+	})!
+	unqualified_runner.acquire_migration_lock()!
+	unqualified_runner.release_migration_lock(true)!
+	assert unqualified_recorder.queries == [
+		'SELECT current_schema();',
+		'SELECT pg_advisory_lock(${key});',
+		'SELECT pg_advisory_unlock(${key});',
+	]
+
+	mut qualified_recorder := &RecordingConnection{
+		schema: 'unrelated'
+	}
+	mut qualified_runner := new(mut qualified_recorder, []Migration{}, Config{
+		dialect: .pg
+		table:   'app.schema_migrations'
+	})!
+	qualified_runner.acquire_migration_lock()!
+	qualified_runner.release_migration_lock(true)!
+	assert qualified_recorder.queries == unqualified_recorder.queries[1..]
 }
 
 fn test_mysql_history_literals_are_backslash_safe() {
@@ -1143,6 +1181,17 @@ fn test_generated_index_names_distinguish_column_boundaries() {
 		columns: ['a_AnD_b']
 	})!
 	assert case_variant_name != index_name(.mysql, composite)!
+	table_boundary := Index{
+		table:   'a_on_b'
+		columns: ['c']
+	}
+	column_boundary := Index{
+		table:   'a'
+		columns: ['b_on_c']
+	}
+	for dialect in [Dialect.sqlite, .pg] {
+		assert index_name(dialect, table_boundary)! != index_name(dialect, column_boundary)!
+	}
 
 	mut db := sqlite.connect(':memory:')!
 	defer {
@@ -1152,7 +1201,11 @@ fn test_generated_index_names_distinguish_column_boundaries() {
 	mut ctx := new_context(db, .sqlite)
 	ctx.add_index(single_column)!
 	ctx.add_index(composite)!
-	assert db.q_int("SELECT count(*) FROM sqlite_master WHERE type = 'index' AND tbl_name = 'users';")! == 2
+	db.exec('CREATE TABLE a_on_b (c TEXT);')!
+	db.exec('CREATE TABLE a (b_on_c TEXT);')!
+	ctx.add_index(table_boundary)!
+	ctx.add_index(column_boundary)!
+	assert db.q_int("SELECT count(*) FROM sqlite_master WHERE type = 'index';")! == 4
 }
 
 fn test_generated_foreign_key_names_respect_dialect_limits() {
@@ -1228,6 +1281,49 @@ fn test_generated_mysql_foreign_key_names_distinguish_component_boundaries() {
 	ctx.add_foreign_key(second)!
 	assert recorder.queries[0].contains('CONSTRAINT `${first_name}` FOREIGN KEY')
 	assert recorder.queries[1].contains('CONSTRAINT `${second_name}` FOREIGN KEY')
+}
+
+fn test_generated_foreign_key_names_include_targets() {
+	parent_key := ForeignKey{
+		from_table: 'accounts'
+		column:     'owner_id'
+		to_table:   'parents'
+	}
+	other_table := ForeignKey{
+		...parent_key
+		to_table: 'guardians'
+	}
+	other_primary_key := ForeignKey{
+		...parent_key
+		primary_key: 'uuid'
+	}
+	for dialect in [Dialect.pg, .mysql] {
+		parent_name := foreign_key_name(dialect, parent_key)!
+		other_table_name := foreign_key_name(dialect, other_table)!
+		other_primary_key_name := foreign_key_name(dialect, other_primary_key)!
+		assert parent_name != other_table_name
+		assert parent_name != other_primary_key_name
+		assert other_table_name != other_primary_key_name
+
+		mut recorder := &RecordingConnection{}
+		mut ctx := new_context(recorder, dialect)
+		ctx.create_table(Table{
+			name:         'accounts'
+			id:           false
+			columns:      [
+				Column{
+					name: 'owner_id'
+					kind: .bigint
+				},
+			]
+			foreign_keys: [parent_key, other_table, other_primary_key]
+		})!
+		assert recorder.queries[0].contains('CONSTRAINT ${quote_identifier(dialect, parent_name)} FOREIGN KEY')
+		assert recorder.queries[0].contains('CONSTRAINT ${quote_identifier(dialect,
+			other_table_name)} FOREIGN KEY')
+		assert recorder.queries[0].contains('CONSTRAINT ${quote_identifier(dialect,
+			other_primary_key_name)} FOREIGN KEY')
+	}
 }
 
 fn test_caller_supplied_identifiers_respect_dialect_limits() {

--- a/vlib/v3/migrations/migrations_test.v
+++ b/vlib/v3/migrations/migrations_test.v
@@ -1903,8 +1903,25 @@ fn test_sqlite_add_column_accepts_parenthesized_literal_defaults() {
 		kind:        .text
 		default_sql: "('collated') COLLATE binary"
 	})!
+	ctx.add_column('accounts', Column{
+		name:        'cast_count'
+		kind:        .integer
+		default_sql: '(CAST(42 AS INTEGER))'
+	})!
 	assert db.q_int('SELECT collated_count FROM accounts WHERE id = 1;')! == 0
 	assert db.q_string('SELECT collated_label FROM accounts WHERE id = 1;')! == 'collated'
+	assert db.q_int('SELECT cast_count FROM accounts WHERE id = 1;')! == 42
+}
+
+fn test_sqlite_constant_cast_default_classification() {
+	for default_sql in ['(CAST(42 AS INTEGER))', "(CAST('x AS y' AS TEXT))",
+		'(CAST(CAST(42 AS TEXT) AS INTEGER))', '(CAST((+42) AS DECIMAL(10, 2)))'] {
+		assert !sqlite_add_column_default_is_nonconstant(default_sql)
+	}
+	for default_sql in ['(CAST(CURRENT_TIMESTAMP AS TEXT))', "(CAST(datetime('now') AS TEXT))",
+		'(CAST(account_id AS INTEGER))', '(CAST( AS TEXT))'] {
+		assert sqlite_add_column_default_is_nonconstant(default_sql)
+	}
 }
 
 fn test_sqlite_accepts_numeric_literal_digit_separators() {
@@ -1929,10 +1946,16 @@ fn test_sqlite_accepts_numeric_literal_digit_separators() {
 		kind:        .integer
 		default_sql: '(0xCA_FE)'
 	})!
+	ctx.add_column('accounts', Column{
+		name:        'cast_population'
+		kind:        .integer
+		default_sql: '(CAST(1_000 AS INTEGER))'
+	})!
 	assert recorder.queries == [
 		'SELECT sqlite_version();',
 		'ALTER TABLE "accounts" ADD COLUMN "population" INTEGER DEFAULT (1_000);',
 		'ALTER TABLE "accounts" ADD COLUMN "mask" INTEGER DEFAULT (0xCA_FE);',
+		'ALTER TABLE "accounts" ADD COLUMN "cast_population" INTEGER DEFAULT (CAST(1_000 AS INTEGER));',
 	]
 	mut error_message := ''
 	ctx.add_column('accounts', Column{
@@ -1941,7 +1964,7 @@ fn test_sqlite_accepts_numeric_literal_digit_separators() {
 		default_sql: '(e1)'
 	}) or { error_message = err.msg() }
 	assert error_message == 'SQLite add_column does not support nonconstant default `(e1)`; rebuild the table in the migration'
-	assert recorder.queries.len == 3
+	assert recorder.queries.len == 4
 
 	mut old_recorder := &RecordingConnection{
 		sqlite_version: '3.45.1'
@@ -1954,6 +1977,14 @@ fn test_sqlite_accepts_numeric_literal_digit_separators() {
 		default_sql: '(1_000)'
 	}) or { error_message = err.msg() }
 	assert error_message == 'SQLite add_column default `(1_000)` uses numeric digit separators, which require SQLite 3.46.0 or newer'
+	assert old_recorder.queries == ['SELECT sqlite_version();']
+	error_message = ''
+	old_ctx.add_column('accounts', Column{
+		name:        'cast_population'
+		kind:        .integer
+		default_sql: '(CAST(1_000 AS INTEGER))'
+	}) or { error_message = err.msg() }
+	assert error_message == 'SQLite add_column default `(CAST(1_000 AS INTEGER))` uses numeric digit separators, which require SQLite 3.46.0 or newer'
 	assert old_recorder.queries == ['SELECT sqlite_version();']
 }
 

--- a/vlib/v3/migrations/migrations_test.v
+++ b/vlib/v3/migrations/migrations_test.v
@@ -259,6 +259,95 @@ fn test_postgresql_change_column_rejects_explicit_constraint_removals() {
 	assert false
 }
 
+fn test_mysql_change_column_requires_complete_definition() {
+	mut recorder := &RecordingConnection{}
+	mut ctx := new_context(recorder, .mysql)
+	mut error_message := ''
+	ctx.change_column('accounts', Column{
+		name: 'score'
+		kind: .bigint
+	}) or { error_message = err.msg() }
+	assert error_message == 'MySQL change_column requires a complete column definition; missing options: nullable, default_sql, unique, primary_key, auto_increment'
+	assert recorder.queries.len == 0
+
+	ctx.change_column('accounts', Column{
+		name:           'score'
+		kind:           .bigint
+		nullable:       false
+		default_sql:    '0'
+		unique:         false
+		primary_key:    false
+		auto_increment: false
+	})!
+	assert recorder.queries == [
+		'ALTER TABLE `accounts` MODIFY COLUMN `score` BIGINT NOT NULL DEFAULT 0;',
+	]
+}
+
+fn test_mysql_auto_increment_requires_a_key() {
+	mut recorder := &RecordingConnection{}
+	mut ctx := new_context(recorder, .mysql)
+	mut add_error := ''
+	ctx.add_column('accounts', Column{
+		name:           'sequence'
+		kind:           .bigint
+		auto_increment: true
+	}) or { add_error = err.msg() }
+	assert add_error == 'MySQL auto-increment column `sequence` must be a primary key or unique'
+
+	mut create_error := ''
+	ctx.create_table(Table{
+		name:    'events'
+		id:      false
+		columns: [
+			Column{
+				name:           'sequence'
+				kind:           .bigint
+				auto_increment: true
+			},
+		]
+	}) or { create_error = err.msg() }
+	assert create_error == 'MySQL auto-increment column `sequence` must be a primary key or unique'
+	assert recorder.queries.len == 0
+
+	ctx.add_column('accounts', Column{
+		name:           'sequence'
+		kind:           .bigint
+		auto_increment: true
+		unique:         true
+	})!
+	assert recorder.queries == [
+		'ALTER TABLE `accounts` ADD COLUMN `sequence` BIGINT AUTO_INCREMENT UNIQUE;',
+	]
+}
+
+fn test_rename_table_rejects_qualified_targets_where_required() {
+	mut pg_recorder := &RecordingConnection{}
+	mut pg_ctx := new_context(pg_recorder, .pg)
+	mut pg_error := ''
+	pg_ctx.rename_table('public.users', 'public.new_users') or { pg_error = err.msg() }
+	assert pg_error == 'rename_table target `public.new_users` must be unqualified for PostgreSQL and SQLite'
+	assert pg_recorder.queries.len == 0
+	pg_ctx.rename_table('public.users', 'new_users')!
+	assert pg_recorder.queries == [
+		'ALTER TABLE "public"."users" RENAME TO "new_users";',
+	]
+
+	mut sqlite_recorder := &RecordingConnection{}
+	mut sqlite_ctx := new_context(sqlite_recorder, .sqlite)
+	mut sqlite_error := ''
+	sqlite_ctx.rename_table('main.users', 'main.new_users') or { sqlite_error = err.msg() }
+	assert sqlite_error == 'rename_table target `main.new_users` must be unqualified for PostgreSQL and SQLite'
+	assert sqlite_recorder.queries.len == 0
+
+	mut mysql_recorder := &RecordingConnection{}
+	mut mysql_ctx := new_context(mysql_recorder, .mysql)
+	mysql_ctx.rename_table('app.users', 'archive.users')!
+	assert mysql_recorder.queries == [
+		'ALTER TABLE `app`.`users` RENAME TO `archive`.`users`;',
+	]
+}
+
 fn test_validation_and_portable_sql_generation() {
 	mut db := sqlite.connect(':memory:')!
 	defer {

--- a/vlib/v3/migrations/migrations_test.v
+++ b/vlib/v3/migrations/migrations_test.v
@@ -486,6 +486,26 @@ fn test_postgresql_open_transaction_is_rejected_in_every_mode_without_being_fini
 	}
 }
 
+fn test_mysql_open_transaction_is_rejected_in_every_mode_without_being_finished() {
+	for mode in [TransactionMode.automatic, .always, .never] {
+		mut recorder := &RecordingConnection{
+			in_transaction: true
+		}
+		mut runner := new(mut recorder, []Migration{}, Config{
+			dialect:          .mysql
+			transaction_mode: mode
+		})!
+		mut error_message := ''
+		runner.migrate() or { error_message = err.msg() }
+		assert error_message == 'MySQL migrations require a connection without an already-open transaction'
+		assert recorder.in_transaction
+		assert recorder.queries == [
+			'ORM SAVEPOINT v3_migrations_transaction_probe',
+			'ORM RELEASE SAVEPOINT v3_migrations_transaction_probe',
+		]
+	}
+}
+
 fn test_sqlite_history_table_is_pinned_to_main() {
 	for temp_table_exists in [false, true] {
 		mut db := sqlite.connect(':memory:')!
@@ -741,6 +761,41 @@ fn test_postgresql_inspection_resolves_and_retains_existing_history_schema() {
 	query := postgresql_history_schema_query('schema_migrations')
 	assert query.contains('current_schemas(false)')
 	assert query.contains('n.oid <> pg_catalog.pg_my_temp_schema()')
+}
+
+fn test_mysql_inspection_resolves_and_retains_history_database() {
+	mut recorder := &RecordingConnection{
+		database:     'app'
+		history_rows: [
+			orm.Row{
+				vals: ['7', 'already_applied', '2026-08-16T00:00:00Z']
+			},
+		]
+	}
+	mut runner := new(mut recorder, []Migration{}, Config{
+		dialect: .mysql
+	})!
+	assert runner.applied()!.map(it.version) == [i64(7)]
+	assert runner.pending()!.len == 0
+	assert runner.current_version()! == 7
+	status := runner.status()!
+	assert status.len == 1
+	assert status[0].state == .missing
+	assert runner.resolved_history_namespace == 'app'
+	assert recorder.queries.filter(it == 'SELECT DATABASE();').len == 1
+	for query in recorder.queries {
+		if query.starts_with('CREATE TABLE IF NOT EXISTS ')
+			|| query.starts_with('SELECT version, name, applied_at FROM ') {
+			assert query.contains('`app`.`schema_migrations`')
+		}
+	}
+	recorder.execute('USE other_database;')!
+	assert runner.migrate()!.len == 0
+	assert recorder.queries.filter(it == 'SELECT DATABASE();').len == 1
+	name := mysql_migration_lock_name('app', 'schema_migrations', 0)
+	assert "SELECT GET_LOCK('${name}', ${migration_lock_timeout_seconds});" in recorder.queries
+	assert recorder.queries.filter(it.starts_with('CREATE TABLE IF NOT EXISTS ')
+		|| it.starts_with('SELECT version, name, applied_at FROM ')).all(it.contains('`app`.`schema_migrations`'))
 }
 
 fn test_mysql_history_literals_are_backslash_safe() {

--- a/vlib/v3/migrations/migrations_test.v
+++ b/vlib/v3/migrations/migrations_test.v
@@ -14,6 +14,7 @@ mut:
 	history_rows            []orm.Row
 	in_transaction          bool
 	postgresql_table_schema string = 'public'
+	sqlite_table_schema     string = 'main'
 }
 
 fn (mut conn RecordingConnection) select(_ orm.SelectConfig, _ orm.QueryData, _ orm.QueryData) ![][]orm.Primitive {
@@ -58,6 +59,22 @@ fn (mut conn RecordingConnection) execute(query string) ![]orm.Row {
 	if query.starts_with('SELECT n.nspname FROM pg_catalog.pg_class AS c ') {
 		return [orm.Row{
 			vals: [conn.postgresql_table_schema]
+		}]
+	}
+	if query == 'PRAGMA database_list;' {
+		mut rows := [orm.Row{
+			vals: ['0', 'main', '']
+		}]
+		if conn.sqlite_table_schema !in ['temp', 'main'] {
+			rows << orm.Row{
+				vals: ['2', conn.sqlite_table_schema, '']
+			}
+		}
+		return rows
+	}
+	if query.starts_with('SELECT 1 FROM "${conn.sqlite_table_schema}".sqlite_schema ') {
+		return [orm.Row{
+			vals: ['1']
 		}]
 	}
 	if query == 'SELECT @@lower_case_table_names;' {
@@ -1149,6 +1166,8 @@ fn test_sqlite_add_column_rejects_unsupported_constraints() {
 	invalid_defaults << '+NULL'
 	invalid_defaults << '- /* absent */ NULL'
 	invalid_defaults << '((+NULL))'
+	invalid_defaults << '(NULL) COLLATE binary'
+	invalid_defaults << '((+NULL)) /* absent */ COLLATE binary'
 	for default_sql in invalid_defaults {
 		error_message = ''
 		ctx.add_column('accounts', Column{
@@ -1163,7 +1182,8 @@ fn test_sqlite_add_column_rejects_unsupported_constraints() {
 		'CURRENT_TIMESTAMP /* now */', '/* now */ CURRENT_DATE', 'CURRENT_TIME -- now',
 		"(datetime('now')) /* now */", 'CURRENT_TIMESTAMP COLLATE binary',
 		'CURRENT_DATE\tCOLLATE binary', 'CURRENT_TIME/* now */ COLLATE binary', '+CURRENT_TIMESTAMP',
-		'- CURRENT_DATE', '+/* now */ CURRENT_TIME'] {
+		'- CURRENT_DATE', '+/* now */ CURRENT_TIME', '(CURRENT_TIMESTAMP) COLLATE binary',
+		'((+CURRENT_DATE)) /* now */ COLLATE binary'] {
 		error_message = ''
 		ctx.add_column('accounts', Column{
 			name:        'created_at'
@@ -1242,6 +1262,18 @@ fn test_sqlite_add_column_accepts_parenthesized_literal_defaults() {
 	})!
 	assert db.q_int('SELECT signed_count FROM accounts WHERE id = 1;')! == -1
 	assert db.q_string('SELECT signed_label FROM accounts WHERE id = 1;')! == 'signed'
+	ctx.add_column('accounts', Column{
+		name:        'collated_count'
+		kind:        .integer
+		default_sql: '(0) COLLATE binary'
+	})!
+	ctx.add_column('accounts', Column{
+		name:        'collated_label'
+		kind:        .text
+		default_sql: "('collated') COLLATE binary"
+	})!
+	assert db.q_int('SELECT collated_count FROM accounts WHERE id = 1;')! == 0
+	assert db.q_string('SELECT collated_label FROM accounts WHERE id = 1;')! == 'collated'
 }
 
 fn test_sqlite_requires_unqualified_index_and_foreign_key_tables() {
@@ -1307,9 +1339,33 @@ fn test_sqlite_requires_unqualified_index_and_foreign_key_tables() {
 		]
 	})!
 	assert recorder.queries == [
-		'CREATE INDEX "index_users_on_email" ON "users" ("email");',
+		'PRAGMA database_list;',
+		'SELECT 1 FROM "temp".sqlite_schema WHERE type = \'table\' AND name = \'users\' COLLATE NOCASE LIMIT 1;',
+		'SELECT 1 FROM "main".sqlite_schema WHERE type = \'table\' AND name = \'users\' COLLATE NOCASE LIMIT 1;',
+		'CREATE INDEX "main"."index_users_on_email" ON "users" ("email");',
 		'CREATE TABLE "main"."children" ("parent_id" BIGINT, CONSTRAINT "fk_main_children_parent_id" FOREIGN KEY ("parent_id") REFERENCES "parents" ("id"));',
 	]
+}
+
+fn test_sqlite_add_index_uses_the_resolved_table_schema() {
+	mut db := sqlite.connect(':memory:')!
+	defer {
+		db.close() or {}
+	}
+	db.exec("ATTACH DATABASE ':memory:' AS aux;")!
+	db.exec('CREATE TABLE aux.users (email TEXT);')!
+	mut ctx := new_context(db, .sqlite)
+	ctx.add_index(Index{
+		table:   'users'
+		columns: ['email']
+	})!
+	ctx.add_index(Index{
+		table:   'users'
+		columns: ['email']
+		name:    'aux.custom_users_email_idx'
+	})!
+	assert db.q_int("SELECT count(*) FROM main.sqlite_master WHERE type = 'index';")! == 0
+	assert db.q_int("SELECT count(*) FROM aux.sqlite_master WHERE type = 'index';")! == 2
 }
 
 fn test_sqlite_autoincrement_precedes_other_constraints() {

--- a/vlib/v3/migrations/migrations_test.v
+++ b/vlib/v3/migrations/migrations_test.v
@@ -862,3 +862,53 @@ fn test_generated_index_names_respect_dialect_limits() {
 	}) or { error_message = err.msg() }
 	assert error_message == 'MySQL index name `${long_explicit_name}` must not exceed 64 bytes'
 }
+
+fn test_generated_foreign_key_names_respect_dialect_limits() {
+	key := ForeignKey{
+		from_table: 'customer_account_records_archive'
+		column:     'external_organization_reference'
+		to_table:   'organizations'
+	}
+	raw_name := 'fk_customer_account_records_archive_external_organization_reference'
+	mysql_name := foreign_key_name(.mysql, key)!
+	postgres_name := foreign_key_name(.pg, key)!
+	assert mysql_name.len == 64
+	assert postgres_name.len == 63
+	assert foreign_key_name(.sqlite, key)! == raw_name
+	assert foreign_key_name(.mysql, key)! == mysql_name
+
+	other_mysql_name := foreign_key_name(.mysql, ForeignKey{
+		from_table: key.from_table
+		column:     'external_organization_identifier'
+		to_table:   key.to_table
+	})!
+	assert other_mysql_name != mysql_name
+
+	mut recorder := &RecordingConnection{}
+	mut ctx := new_context(recorder, .mysql)
+	ctx.add_foreign_key(key)!
+	ctx.create_table(Table{
+		name:         key.from_table
+		id:           false
+		columns:      [
+			Column{
+				name: key.column
+				kind: .bigint
+			},
+		]
+		foreign_keys: [key]
+	})!
+	assert recorder.queries[0].contains('CONSTRAINT `${mysql_name}` FOREIGN KEY')
+	assert recorder.queries[1].contains('CONSTRAINT `${mysql_name}` FOREIGN KEY')
+
+	long_explicit_name := 'x'.repeat(65)
+	mut error_message := ''
+	ctx.add_foreign_key(ForeignKey{
+		from_table: 'accounts'
+		column:     'organization_id'
+		to_table:   'organizations'
+		name:       long_explicit_name
+	}) or { error_message = err.msg() }
+	assert error_message == 'MySQL foreign key name `${long_explicit_name}` must not exceed 64 bytes'
+	assert recorder.queries.len == 2
+}

--- a/vlib/v3/migrations/migrations_test.v
+++ b/vlib/v3/migrations/migrations_test.v
@@ -468,7 +468,7 @@ fn test_postgresql_add_index_rejects_qualified_names() {
 	]
 }
 
-fn test_mysql_add_index_rejects_qualified_names() {
+fn test_mysql_index_names_must_be_unqualified() {
 	mut recorder := &RecordingConnection{}
 	mut ctx := new_context(recorder, .mysql)
 	mut error_message := ''
@@ -487,6 +487,17 @@ fn test_mysql_add_index_rejects_qualified_names() {
 	})!
 	assert recorder.queries == [
 		'CREATE INDEX `users_email_idx` ON `app`.`users` (`email`);',
+	]
+
+	error_message = ''
+	ctx.remove_index('app.users', 'app.users_email_idx') or { error_message = err.msg() }
+	assert error_message == 'MySQL remove_index name `app.users_email_idx` must be unqualified'
+	assert recorder.queries.len == 1
+
+	ctx.remove_index('app.users', 'users_email_idx')!
+	assert recorder.queries == [
+		'CREATE INDEX `users_email_idx` ON `app`.`users` (`email`);',
+		'DROP INDEX `users_email_idx` ON `app`.`users`;',
 	]
 }
 

--- a/vlib/v3/migrations/migrations_test.v
+++ b/vlib/v3/migrations/migrations_test.v
@@ -16,6 +16,7 @@ mut:
 	autocommit                bool = true
 	postgresql_history_schema string
 	postgresql_table_schema   string = 'public'
+	postgresql_probe_value    string
 	sqlite_table_schema       string = 'main'
 }
 
@@ -53,6 +54,21 @@ fn (mut conn RecordingConnection) execute(query string) ![]orm.Row {
 	}
 	if query == 'SET search_path TO other_schema;' {
 		conn.schema = 'other_schema'
+	}
+	probe_prefix := "SELECT pg_catalog.set_config('${postgresql_transaction_probe_setting}', '"
+	if query.starts_with(probe_prefix) {
+		value := query.all_after(probe_prefix).all_before("', true);")
+		if conn.in_transaction {
+			conn.postgresql_probe_value = value
+		}
+		return [orm.Row{
+			vals: [value]
+		}]
+	}
+	if query == postgresql_transaction_probe_read_query() {
+		return [orm.Row{
+			vals: [conn.postgresql_probe_value]
+		}]
 	}
 	if query.starts_with('SELECT version, name, applied_at FROM ') {
 		return conn.history_rows.clone()
@@ -121,11 +137,13 @@ fn (mut conn RecordingConnection) orm_begin() ! {
 fn (mut conn RecordingConnection) orm_commit() ! {
 	conn.queries << 'ORM COMMIT'
 	conn.in_transaction = false
+	conn.postgresql_probe_value = ''
 }
 
 fn (mut conn RecordingConnection) orm_rollback() ! {
 	conn.queries << 'ORM ROLLBACK'
 	conn.in_transaction = false
+	conn.postgresql_probe_value = ''
 }
 
 fn (mut conn RecordingConnection) orm_savepoint(name string) ! {
@@ -263,6 +281,12 @@ fn start_postgresql_transaction(mut ctx Context) ! {
 	ctx.execute('BEGIN;')!
 }
 
+fn assert_postgresql_transaction_probe(queries []string) {
+	assert queries.len >= 2
+	assert queries[0].starts_with("SELECT pg_catalog.set_config('${postgresql_transaction_probe_setting}', 'probe_")
+	assert queries[1] == postgresql_transaction_probe_read_query()
+}
+
 fn test_migrate_rollback_redo_and_status() {
 	mut db := sqlite.connect(':memory:')!
 	defer {
@@ -383,8 +407,10 @@ fn test_mutating_runner_holds_dialect_lock_around_callbacks() {
 			}
 			.pg {
 				key := postgresql_migration_lock_key(recorder.schema, 'schema_migrations')
-				assert recorder.queries[0] == postgresql_history_schema_query('schema_migrations')
-				assert recorder.queries[1] == 'SELECT pg_advisory_lock(${key});'
+				assert recorder.queries[0].starts_with("SELECT pg_catalog.set_config('${postgresql_transaction_probe_setting}', 'probe_")
+				assert recorder.queries[1] == postgresql_transaction_probe_read_query()
+				assert recorder.queries[2] == postgresql_history_schema_query('schema_migrations')
+				assert recorder.queries[3] == 'SELECT pg_advisory_lock(${key});'
 				assert recorder.queries.last() == 'SELECT pg_advisory_unlock(${key});'
 				assert 'ORM BEGIN' in recorder.queries
 				assert 'ORM COMMIT' in recorder.queries
@@ -507,10 +533,9 @@ fn test_postgresql_open_transaction_is_rejected_in_every_mode_without_being_fini
 		runner.migrate() or { error_message = err.msg() }
 		assert error_message == 'PostgreSQL migrations require a connection without an already-open transaction; pg.Tx and transactional pg.Conn values are not supported'
 		assert recorder.in_transaction
-		assert recorder.queries == [
-			'ORM SAVEPOINT v3_migrations_transaction_probe',
-			'ORM RELEASE SAVEPOINT v3_migrations_transaction_probe',
-		]
+		assert recorder.queries.len == 2
+		assert recorder.queries[0].starts_with("SELECT pg_catalog.set_config('${postgresql_transaction_probe_setting}', 'probe_")
+		assert recorder.queries[1] == postgresql_transaction_probe_read_query()
 	}
 }
 
@@ -825,7 +850,8 @@ fn test_postgresql_migration_locks_use_full_64bit_keys() {
 	})!
 	runner.acquire_migration_lock()!
 	runner.release_migration_lock(true)!
-	assert recorder.queries == [
+	assert_postgresql_transaction_probe(recorder.queries)
+	assert recorder.queries[2..] == [
 		postgresql_history_schema_query(first_table),
 		'SELECT pg_advisory_lock(${first_key});',
 		'SELECT pg_advisory_unlock(${first_key});',
@@ -845,7 +871,8 @@ fn test_postgresql_migration_locks_canonicalize_history_table() {
 	})!
 	unqualified_runner.acquire_migration_lock()!
 	unqualified_runner.release_migration_lock(true)!
-	assert unqualified_recorder.queries == [
+	assert_postgresql_transaction_probe(unqualified_recorder.queries)
+	assert unqualified_recorder.queries[2..] == [
 		postgresql_history_schema_query('schema_migrations'),
 		'SELECT pg_advisory_lock(${key});',
 		'SELECT pg_advisory_unlock(${key});',
@@ -861,7 +888,11 @@ fn test_postgresql_migration_locks_canonicalize_history_table() {
 	})!
 	qualified_runner.acquire_migration_lock()!
 	qualified_runner.release_migration_lock(true)!
-	assert qualified_recorder.queries == unqualified_recorder.queries[1..]
+	assert_postgresql_transaction_probe(qualified_recorder.queries)
+	assert qualified_recorder.queries[2..] == [
+		'SELECT pg_advisory_lock(${key});',
+		'SELECT pg_advisory_unlock(${key});',
+	]
 
 	temp_key := postgresql_migration_lock_key('pg_temp', 'schema_migrations')
 	mut temp_recorder := &RecordingConnection{}
@@ -871,7 +902,8 @@ fn test_postgresql_migration_locks_canonicalize_history_table() {
 	})!
 	temp_runner.acquire_migration_lock()!
 	temp_runner.release_migration_lock(true)!
-	assert temp_recorder.queries == [
+	assert_postgresql_transaction_probe(temp_recorder.queries)
+	assert temp_recorder.queries[2..] == [
 		'SELECT pg_advisory_lock(${temp_key});',
 		'SELECT pg_advisory_unlock(${temp_key});',
 	]

--- a/vlib/v3/migrations/migrations_test.v
+++ b/vlib/v3/migrations/migrations_test.v
@@ -23,6 +23,8 @@ mut:
 	postgresql_aborted        bool
 	sqlite_table_schema       string = 'main'
 	sqlite_version            string = '3.46.0'
+	fail_sqlite_lock          bool
+	fail_sqlite_commit        bool
 }
 
 fn (mut conn RecordingConnection) select(_ orm.SelectConfig, _ orm.QueryData, _ orm.QueryData) ![][]orm.Primitive {
@@ -45,6 +47,9 @@ fn (mut conn RecordingConnection) last_id() int {
 
 fn (mut conn RecordingConnection) execute(query string) ![]orm.Row {
 	conn.queries << query
+	if query == 'BEGIN IMMEDIATE;' && conn.fail_sqlite_lock {
+		return error('database is locked')
+	}
 	if query == 'USE other_database;' {
 		conn.database = 'other_database'
 	}
@@ -189,6 +194,9 @@ fn (mut conn RecordingConnection) orm_begin() ! {
 
 fn (mut conn RecordingConnection) orm_commit() ! {
 	conn.queries << 'ORM COMMIT'
+	if conn.fail_sqlite_commit {
+		return error('FOREIGN KEY constraint failed')
+	}
 	conn.in_transaction = false
 	conn.postgresql_probe_value = ''
 	conn.postgresql_aborted = false
@@ -1006,6 +1014,66 @@ fn test_sqlite_callback_cannot_replace_lock_transaction_before_history_write() {
 	assert error_message == 'SQLite migration callback ended the migration lock transaction before history was recorded'
 	assert db.q_int("SELECT count(*) FROM sqlite_master WHERE type = 'table' AND name = 'replaced_transaction_table';")! == 0
 	assert db.q_int('SELECT count(*) FROM schema_migrations;')! == 0
+	assert runner.sqlite_transaction_probe == ''
+}
+
+fn test_sqlite_failed_lock_acquisition_cleans_up_transaction_probe() {
+	mut recorder := &RecordingConnection{
+		fail_sqlite_lock: true
+	}
+	mut runner := new(mut recorder, []Migration{}, Config{
+		dialect: .sqlite
+	})!
+	mut error_message := ''
+	runner.migrate() or { error_message = err.msg() }
+	assert error_message.contains('database is locked'), error_message
+	assert !runner.sqlite_lock_active
+	assert runner.sqlite_transaction_probe == ''
+	assert recorder.queries.len == 3
+	assert recorder.queries[0].starts_with('CREATE TEMP TABLE temp."v3_migrations_transaction_')
+	assert recorder.queries[1] == 'BEGIN IMMEDIATE;'
+	assert recorder.queries[2].starts_with('DROP TABLE IF EXISTS temp."v3_migrations_transaction_')
+
+	recorder.fail_sqlite_lock = false
+	runner.migrate()!
+	assert runner.sqlite_transaction_probe == ''
+	assert recorder.queries.filter(it.starts_with('CREATE TEMP TABLE temp."v3_migrations_transaction_')).len == 2
+	assert recorder.queries.filter(it.starts_with('DROP TABLE IF EXISTS temp."v3_migrations_transaction_')).len == 2
+}
+
+fn test_sqlite_failed_lock_commit_rolls_back_and_cleans_up_transaction_probe() {
+	mut recorder := &RecordingConnection{
+		fail_sqlite_commit: true
+	}
+	mut runner := new(mut recorder, [
+		Migration{
+			version: 1
+			name:    'deferred_foreign_key_violation'
+			up:      record_locked_migration
+			down:    record_locked_migration
+		},
+	], Config{
+		dialect: .sqlite
+	})!
+	mut error_message := ''
+	runner.migrate() or { error_message = err.msg() }
+	assert error_message.contains('FOREIGN KEY constraint failed'), error_message
+	assert !runner.sqlite_lock_active
+	assert runner.sqlite_transaction_probe == ''
+	assert !recorder.in_transaction
+	commit_index := recorder.queries.index('ORM COMMIT')
+	rollback_index := recorder.queries.index('ORM ROLLBACK')
+	probe_drops :=
+		recorder.queries.filter(it.starts_with('DROP TABLE IF EXISTS temp."v3_migrations_transaction_'))
+	assert probe_drops.len == 1
+	probe_drop_index := recorder.queries.index(probe_drops[0])
+	assert commit_index > recorder.queries.index('migration callback;')
+	assert rollback_index > commit_index
+	assert probe_drop_index > rollback_index
+
+	recorder.fail_sqlite_commit = false
+	runner.migrate()!
+	assert !runner.sqlite_lock_active
 	assert runner.sqlite_transaction_probe == ''
 }
 

--- a/vlib/v3/migrations/migrations_test.v
+++ b/vlib/v3/migrations/migrations_test.v
@@ -455,6 +455,15 @@ fn test_sqlite_add_column_rejects_unsupported_constraints() {
 		}) or { error_message = err.msg() }
 		assert error_message == 'SQLite add_column requires a non-NULL default for a NOT NULL column; rebuild the table in the migration'
 	}
+	for default_sql in ['CURRENT_TIME', 'CURRENT_DATE', 'CURRENT_TIMESTAMP', "(datetime('now'))"] {
+		error_message = ''
+		ctx.add_column('accounts', Column{
+			name:        'created_at'
+			kind:        .timestamp
+			default_sql: default_sql
+		}) or { error_message = err.msg() }
+		assert error_message == 'SQLite add_column does not support nonconstant default `${default_sql}`; rebuild the table in the migration'
+	}
 	assert recorder.queries.len == 0
 
 	ctx.add_column('accounts', Column{
@@ -465,6 +474,65 @@ fn test_sqlite_add_column_rejects_unsupported_constraints() {
 	})!
 	assert recorder.queries == [
 		'ALTER TABLE "accounts" ADD COLUMN "label" TEXT NOT NULL DEFAULT \'\';',
+	]
+}
+
+fn test_sqlite_requires_unqualified_index_and_foreign_key_tables() {
+	mut recorder := &RecordingConnection{}
+	mut ctx := new_context(recorder, .sqlite)
+	mut error_message := ''
+	ctx.add_index(Index{
+		table:   'main.users'
+		columns: ['email']
+	}) or { error_message = err.msg() }
+	assert error_message == 'SQLite add_index table `main.users` must be unqualified'
+	assert recorder.queries.len == 0
+
+	error_message = ''
+	ctx.create_table(Table{
+		name:         'main.children'
+		id:           false
+		columns:      [
+			Column{
+				name: 'parent_id'
+				kind: .bigint
+			},
+		]
+		foreign_keys: [
+			ForeignKey{
+				from_table: 'main.children'
+				column:     'parent_id'
+				to_table:   'main.parents'
+			},
+		]
+	}) or { error_message = err.msg() }
+	assert error_message == 'SQLite foreign-key target table `main.parents` must be unqualified'
+	assert recorder.queries.len == 0
+
+	ctx.add_index(Index{
+		table:   'users'
+		columns: ['email']
+	})!
+	ctx.create_table(Table{
+		name:         'main.children'
+		id:           false
+		columns:      [
+			Column{
+				name: 'parent_id'
+				kind: .bigint
+			},
+		]
+		foreign_keys: [
+			ForeignKey{
+				from_table: 'main.children'
+				column:     'parent_id'
+				to_table:   'parents'
+			},
+		]
+	})!
+	assert recorder.queries == [
+		'CREATE INDEX "index_users_on_email" ON "users" ("email");',
+		'CREATE TABLE "main"."children" ("parent_id" BIGINT, CONSTRAINT "fk_main_children_parent_id" FOREIGN KEY ("parent_id") REFERENCES "parents" ("id"));',
 	]
 }
 

--- a/vlib/v3/migrations/migrations_test.v
+++ b/vlib/v3/migrations/migrations_test.v
@@ -91,30 +91,6 @@ fn (mut conn RecordingConnection) orm_release_savepoint(name string) ! {
 	conn.queries << 'ORM RELEASE SAVEPOINT ${name}'
 }
 
-struct PoolBackedConnection {}
-
-fn (mut conn PoolBackedConnection) select(_ orm.SelectConfig, _ orm.QueryData, _ orm.QueryData) ![][]orm.Primitive {
-	return []
-}
-
-fn (mut conn PoolBackedConnection) insert(_ orm.Table, _ orm.QueryData) ! {}
-
-fn (mut conn PoolBackedConnection) update(_ orm.Table, _ orm.QueryData, _ orm.QueryData) ! {}
-
-fn (mut conn PoolBackedConnection) delete(_ orm.Table, _ orm.QueryData) ! {}
-
-fn (mut conn PoolBackedConnection) create(_ orm.Table, _ []orm.TableField) ! {}
-
-fn (mut conn PoolBackedConnection) drop(_ orm.Table) ! {}
-
-fn (mut conn PoolBackedConnection) last_id() int {
-	return 0
-}
-
-fn (mut conn PoolBackedConnection) execute(_ string) ![]orm.Row {
-	return error('pool query should not execute')
-}
-
 struct MigrationWidget {
 	id    int @[primary; sql: serial]
 	label string
@@ -442,15 +418,15 @@ fn test_locked_history_table_survives_callback_namespace_changes() {
 	}
 }
 
-fn test_postgresql_pool_backed_orm_wrapper_is_rejected_before_locking() {
-	pool := PoolBackedConnection{}
-	mut scoped := orm.new_db(pool, orm.DataScope{})
-	mut runner := new(mut scoped, []Migration{}, Config{
-		dialect: .pg
-	})!
+fn test_postgresql_orm_wrapper_is_rejected_without_mutating_its_transaction() {
+	mut recorder := &RecordingConnection{}
+	mut scoped := orm.new_db(recorder, orm.DataScope{})
 	mut error_message := ''
-	runner.acquire_migration_lock() or { error_message = err.msg() }
-	assert error_message == 'PostgreSQL migrations require a session-pinned connection; orm.DB wrapper validation failed: orm.DB: underlying connection does not support transactions; use pg.DB.conn() or pg.connect_direct()'
+	new(mut scoped, []Migration{}, Config{
+		dialect: .pg
+	}) or { error_message = err.msg() }
+	assert error_message == 'PostgreSQL migrations require a direct session-pinned connection; orm.DB wrappers cannot be validated without mutating the wrapped connection; pass pg.Conn or pg.Tx directly'
+	assert recorder.queries.len == 0
 }
 
 fn test_sqlite_history_table_is_pinned_to_main() {

--- a/vlib/v3/migrations/migrations_test.v
+++ b/vlib/v3/migrations/migrations_test.v
@@ -341,7 +341,20 @@ fn test_mysql_change_column_requires_complete_definition() {
 		name: 'score'
 		kind: .bigint
 	}) or { error_message = err.msg() }
-	assert error_message == 'MySQL change_column requires a complete column definition; missing options: nullable, default_sql, unique, primary_key, auto_increment'
+	assert error_message == 'MySQL change_column requires a complete column definition; missing options: nullable, default_sql, auto_increment'
+	assert recorder.queries.len == 0
+
+	error_message = ''
+	ctx.change_column('accounts', Column{
+		name:           'score'
+		kind:           .bigint
+		nullable:       true
+		default_sql:    ''
+		unique:         false
+		primary_key:    false
+		auto_increment: false
+	}) or { error_message = err.msg() }
+	assert error_message == 'MySQL change_column cannot remove key constraints; unsupported false options: unique, primary_key; use remove_index() or ctx.execute()'
 	assert recorder.queries.len == 0
 
 	ctx.change_column('accounts', Column{
@@ -349,8 +362,6 @@ fn test_mysql_change_column_requires_complete_definition() {
 		kind:           .bigint
 		nullable:       false
 		default_sql:    '0'
-		unique:         false
-		primary_key:    false
 		auto_increment: false
 	})!
 	assert recorder.queries == [
@@ -454,6 +465,28 @@ fn test_postgresql_add_index_rejects_qualified_names() {
 	})!
 	assert recorder.queries == [
 		'CREATE INDEX "users_email_idx" ON "reporting"."users" ("email");',
+	]
+}
+
+fn test_mysql_add_index_rejects_qualified_names() {
+	mut recorder := &RecordingConnection{}
+	mut ctx := new_context(recorder, .mysql)
+	mut error_message := ''
+	ctx.add_index(Index{
+		table:   'app.users'
+		columns: ['email']
+		name:    'app.users_email_idx'
+	}) or { error_message = err.msg() }
+	assert error_message == 'MySQL add_index name `app.users_email_idx` must be unqualified'
+	assert recorder.queries.len == 0
+
+	ctx.add_index(Index{
+		table:   'app.users'
+		columns: ['email']
+		name:    'users_email_idx'
+	})!
+	assert recorder.queries == [
+		'CREATE INDEX `users_email_idx` ON `app`.`users` (`email`);',
 	]
 }
 
@@ -659,6 +692,33 @@ fn test_sqlite_autoincrement_precedes_other_constraints() {
 		db.close() or {}
 	}
 	db.exec('CREATE TABLE items (${definition});')!
+}
+
+fn test_sqlite_non_integer_primary_keys_are_not_null() {
+	text_definition := column_sql(.sqlite, Column{
+		name:        'code'
+		kind:        .text
+		primary_key: true
+	})!
+	assert text_definition == '"code" TEXT PRIMARY KEY NOT NULL'
+	integer_definition := column_sql(.sqlite, Column{
+		name:        'id'
+		kind:        .integer
+		primary_key: true
+	})!
+	assert integer_definition == '"id" INTEGER PRIMARY KEY'
+
+	mut db := sqlite.connect(':memory:')!
+	defer {
+		db.close() or {}
+	}
+	db.exec('CREATE TABLE custom_keys (${text_definition});')!
+	columns := db.exec("PRAGMA table_info('custom_keys');")!
+	assert columns.len == 1
+	assert columns[0].vals[3] == '1'
+	db.exec('INSERT INTO custom_keys (code) VALUES (NULL);')!
+	rows := db.exec('SELECT count(*) FROM custom_keys;')!
+	assert rows[0].vals[0] == '0'
 }
 
 fn test_column_level_identifiers_must_be_unqualified() {

--- a/vlib/v3/migrations/migrations_test.v
+++ b/vlib/v3/migrations/migrations_test.v
@@ -1146,6 +1146,9 @@ fn test_sqlite_add_column_rejects_unsupported_constraints() {
 	invalid_defaults << 'NULL'
 	invalid_defaults << 'NULL /* absent */'
 	invalid_defaults << '(NULL)'
+	invalid_defaults << '+NULL'
+	invalid_defaults << '- /* absent */ NULL'
+	invalid_defaults << '((+NULL))'
 	for default_sql in invalid_defaults {
 		error_message = ''
 		ctx.add_column('accounts', Column{
@@ -1159,7 +1162,8 @@ fn test_sqlite_add_column_rejects_unsupported_constraints() {
 	for default_sql in ['CURRENT_TIME', 'CURRENT_DATE', 'CURRENT_TIMESTAMP', "(datetime('now'))",
 		'CURRENT_TIMESTAMP /* now */', '/* now */ CURRENT_DATE', 'CURRENT_TIME -- now',
 		"(datetime('now')) /* now */", 'CURRENT_TIMESTAMP COLLATE binary',
-		'CURRENT_DATE\tCOLLATE binary', 'CURRENT_TIME/* now */ COLLATE binary'] {
+		'CURRENT_DATE\tCOLLATE binary', 'CURRENT_TIME/* now */ COLLATE binary', '+CURRENT_TIMESTAMP',
+		'- CURRENT_DATE', '+/* now */ CURRENT_TIME'] {
 		error_message = ''
 		ctx.add_column('accounts', Column{
 			name:        'created_at'
@@ -1226,6 +1230,18 @@ fn test_sqlite_add_column_accepts_parenthesized_literal_defaults() {
 	assert db.q_int('SELECT count FROM accounts WHERE id = 1;')! == 0
 	assert db.q_string('SELECT label FROM accounts WHERE id = 1;')! == 'x'
 	assert db.q_int('SELECT count(*) FROM accounts WHERE optional IS NULL;')! == 1
+	ctx.add_column('accounts', Column{
+		name:        'signed_count'
+		kind:        .integer
+		default_sql: '(-1)'
+	})!
+	ctx.add_column('accounts', Column{
+		name:        'signed_label'
+		kind:        .text
+		default_sql: "(+'signed')"
+	})!
+	assert db.q_int('SELECT signed_count FROM accounts WHERE id = 1;')! == -1
+	assert db.q_string('SELECT signed_label FROM accounts WHERE id = 1;')! == 'signed'
 }
 
 fn test_sqlite_requires_unqualified_index_and_foreign_key_tables() {

--- a/vlib/v3/migrations/migrations_test.v
+++ b/vlib/v3/migrations/migrations_test.v
@@ -20,6 +20,7 @@ mut:
 	postgresql_history_schema string
 	postgresql_table_schema   string = 'public'
 	postgresql_probe_value    string
+	postgresql_aborted        bool
 	sqlite_table_schema       string = 'main'
 }
 
@@ -63,8 +64,16 @@ fn (mut conn RecordingConnection) execute(query string) ![]orm.Row {
 	if query in ['ROLLBACK;', 'COMMIT;'] {
 		conn.in_transaction = false
 		conn.postgresql_probe_value = ''
+		conn.postgresql_aborted = false
 		conn.sqlite_probe_rows = 0
 		conn.clear_savepoints()
+	}
+	if query == 'force PostgreSQL statement error;' {
+		conn.postgresql_aborted = true
+		return error('forced PostgreSQL statement error')
+	}
+	if conn.postgresql_aborted {
+		return error('current PostgreSQL transaction is aborted')
 	}
 	if query.starts_with('SAVEPOINT ') {
 		if !conn.in_transaction {
@@ -169,12 +178,14 @@ fn (mut conn RecordingConnection) execute(query string) ![]orm.Row {
 fn (mut conn RecordingConnection) orm_begin() ! {
 	conn.queries << 'ORM BEGIN'
 	conn.in_transaction = true
+	conn.postgresql_aborted = false
 }
 
 fn (mut conn RecordingConnection) orm_commit() ! {
 	conn.queries << 'ORM COMMIT'
 	conn.in_transaction = false
 	conn.postgresql_probe_value = ''
+	conn.postgresql_aborted = false
 	conn.clear_savepoints()
 }
 
@@ -182,6 +193,7 @@ fn (mut conn RecordingConnection) orm_rollback() ! {
 	conn.queries << 'ORM ROLLBACK'
 	conn.in_transaction = false
 	conn.postgresql_probe_value = ''
+	conn.postgresql_aborted = false
 	conn.sqlite_probe_rows = 0
 	conn.clear_savepoints()
 }
@@ -361,6 +373,12 @@ fn start_mysql_transaction(mut ctx Context) ! {
 
 fn start_postgresql_transaction(mut ctx Context) ! {
 	ctx.execute('BEGIN;')!
+}
+
+fn abort_postgresql_transaction_and_catch_error(mut ctx Context) ! {
+	ctx.execute('BEGIN;')!
+	ctx.execute('force PostgreSQL statement error;') or { return }
+	return error('expected the PostgreSQL statement to fail')
 }
 
 fn rollback_callback_transaction(mut ctx Context) ! {
@@ -786,6 +804,55 @@ fn test_postgresql_callback_transactions_are_rolled_back_before_unlocking() {
 	assert history_deletes.len == 1
 	assert down_rollback_index > down_recorder.queries.index('BEGIN;')
 	assert down_rollback_index > down_recorder.queries.index(history_deletes[0])
+	assert down_recorder.queries.last() == 'SELECT pg_advisory_unlock(${key});'
+}
+
+fn test_postgresql_history_write_errors_rollback_callback_transaction_state() {
+	migration := Migration{
+		version: 1
+		name:    'aborted_transaction'
+		up:      abort_postgresql_transaction_and_catch_error
+		down:    abort_postgresql_transaction_and_catch_error
+	}
+	mut up_recorder := &RecordingConnection{}
+	mut up_runner := new(mut up_recorder, [migration], Config{
+		dialect:          .pg
+		transaction_mode: .never
+	})!
+	mut error_message := ''
+	up_runner.migrate() or { error_message = err.msg() }
+	assert error_message.contains('could not record migration 1: current PostgreSQL transaction is aborted')
+	assert !up_recorder.in_transaction
+	assert !up_recorder.postgresql_aborted
+	up_inserts := up_recorder.queries.filter(it.starts_with('INSERT INTO '))
+	assert up_inserts.len == 1
+	up_insert_index := up_recorder.queries.index(up_inserts[0])
+	assert up_insert_index > up_recorder.queries.index('force PostgreSQL statement error;')
+	assert up_recorder.queries.index('ORM ROLLBACK') > up_insert_index
+	key := postgresql_migration_lock_key('public', 'schema_migrations')
+	assert up_recorder.queries.last() == 'SELECT pg_advisory_unlock(${key});'
+
+	mut down_recorder := &RecordingConnection{
+		history_rows: [
+			orm.Row{
+				vals: ['1', migration.name, '2026-08-16T00:00:00Z']
+			},
+		]
+	}
+	mut down_runner := new(mut down_recorder, [migration], Config{
+		dialect:          .pg
+		transaction_mode: .never
+	})!
+	error_message = ''
+	down_runner.rollback(1) or { error_message = err.msg() }
+	assert error_message.contains('could not remove migration 1 from history: current PostgreSQL transaction is aborted')
+	assert !down_recorder.in_transaction
+	assert !down_recorder.postgresql_aborted
+	down_deletes := down_recorder.queries.filter(it.starts_with('DELETE FROM '))
+	assert down_deletes.len == 1
+	down_delete_index := down_recorder.queries.index(down_deletes[0])
+	assert down_delete_index > down_recorder.queries.index('force PostgreSQL statement error;')
+	assert down_recorder.queries.index('ORM ROLLBACK') > down_delete_index
 	assert down_recorder.queries.last() == 'SELECT pg_advisory_unlock(${key});'
 }
 
@@ -1833,10 +1900,12 @@ fn test_sqlite_add_column_accepts_parenthesized_literal_defaults() {
 }
 
 fn test_sqlite_accepts_numeric_literal_digit_separators() {
-	for literal in ['1_000', '(1_000)', '1_2.3_4e5_6', '1e+1_0', '0xCA_FE', '(0xA_B_C)'] {
+	for literal in ['1_000', '(1_000)', '1_2.3_4e5_6', '1e+1_0', '0xCA_FE', '(0xA_B_C)', '.5',
+		'1.', '1e-2'] {
 		assert sqlite_is_literal_default(literal)
 	}
-	for literal in ['_1000', '1000_', '1__000', '1_.0', '0x_FF', '0xFF_', '0xA__B'] {
+	for literal in ['_1000', '1000_', '1__000', '1_.0', '0x_FF', '0xFF_', '0xA__B', 'e1', 'E+1',
+		'.e1', '1e', '1e+', '1.2.3'] {
 		assert !sqlite_is_literal_default(literal)
 	}
 
@@ -1856,6 +1925,14 @@ fn test_sqlite_accepts_numeric_literal_digit_separators() {
 		'ALTER TABLE "accounts" ADD COLUMN "population" INTEGER DEFAULT (1_000);',
 		'ALTER TABLE "accounts" ADD COLUMN "mask" INTEGER DEFAULT (0xCA_FE);',
 	]
+	mut error_message := ''
+	ctx.add_column('accounts', Column{
+		name:        'invalid_exponent'
+		kind:        .real
+		default_sql: '(e1)'
+	}) or { error_message = err.msg() }
+	assert error_message == 'SQLite add_column does not support nonconstant default `(e1)`; rebuild the table in the migration'
+	assert recorder.queries.len == 2
 }
 
 fn test_sqlite_requires_unqualified_index_and_foreign_key_tables() {

--- a/vlib/v3/migrations/migrations_test.v
+++ b/vlib/v3/migrations/migrations_test.v
@@ -13,6 +13,7 @@ mut:
 	lower_case_table_names    int
 	history_rows              []orm.Row
 	in_transaction            bool
+	autocommit                bool = true
 	postgresql_history_schema string
 	postgresql_table_schema   string = 'public'
 	sqlite_table_schema       string = 'main'
@@ -87,6 +88,11 @@ fn (mut conn RecordingConnection) execute(query string) ![]orm.Row {
 	if query == 'SELECT @@lower_case_table_names;' {
 		return [orm.Row{
 			vals: [conn.lower_case_table_names.str()]
+		}]
+	}
+	if query == 'SELECT @@autocommit;' {
+		return [orm.Row{
+			vals: [if conn.autocommit { '1' } else { '0' }]
 		}]
 	}
 	if query.starts_with('SELECT GET_LOCK(') || query.starts_with('SELECT RELEASE_LOCK(')
@@ -365,9 +371,10 @@ fn test_mutating_runner_holds_dialect_lock_around_callbacks() {
 			.mysql {
 				name := mysql_migration_lock_name(recorder.database, 'schema_migrations',
 					recorder.lower_case_table_names)
-				assert recorder.queries[0] == 'SELECT DATABASE();'
-				assert recorder.queries[1] == 'SELECT @@lower_case_table_names;'
-				assert recorder.queries[2] == "SELECT GET_LOCK('${name}', ${migration_lock_timeout_seconds});"
+				assert recorder.queries[0] == 'SELECT @@autocommit;'
+				assert recorder.queries[1] == 'SELECT DATABASE();'
+				assert recorder.queries[2] == 'SELECT @@lower_case_table_names;'
+				assert recorder.queries[3] == "SELECT GET_LOCK('${name}', ${migration_lock_timeout_seconds});"
 				assert recorder.queries.last() == "SELECT RELEASE_LOCK('${name}');"
 				assert 'ORM BEGIN' !in recorder.queries
 			}
@@ -500,9 +507,31 @@ fn test_mysql_open_transaction_is_rejected_in_every_mode_without_being_finished(
 		assert error_message == 'MySQL migrations require a connection without an already-open transaction'
 		assert recorder.in_transaction
 		assert recorder.queries == [
+			'SELECT @@autocommit;',
 			'ORM SAVEPOINT v3_migrations_transaction_probe',
 			'ORM RELEASE SAVEPOINT v3_migrations_transaction_probe',
 		]
+	}
+}
+
+fn test_mysql_disabled_autocommit_is_rejected_before_locking_or_inspection() {
+	for mode in [TransactionMode.automatic, .always, .never] {
+		mut recorder := &RecordingConnection{
+			autocommit: false
+		}
+		mut runner := new(mut recorder, []Migration{}, Config{
+			dialect:          .mysql
+			transaction_mode: mode
+		})!
+		mut error_message := ''
+		runner.migrate() or { error_message = err.msg() }
+		assert error_message == 'MySQL migrations require session autocommit to be enabled'
+		assert recorder.queries == ['SELECT @@autocommit;']
+
+		error_message = ''
+		runner.applied() or { error_message = err.msg() }
+		assert error_message == 'MySQL migrations require session autocommit to be enabled'
+		assert recorder.queries == ['SELECT @@autocommit;', 'SELECT @@autocommit;']
 	}
 }
 
@@ -564,6 +593,7 @@ fn test_mysql_migration_locks_are_namespaced_by_database() {
 	first_runner.release_migration_lock(true)!
 	first_name := mysql_migration_lock_name('application_one', 'schema_migrations', 0)
 	assert first_recorder.queries == [
+		'SELECT @@autocommit;',
 		'SELECT DATABASE();',
 		'SELECT @@lower_case_table_names;',
 		"SELECT GET_LOCK('${first_name}', ${migration_lock_timeout_seconds});",
@@ -580,7 +610,7 @@ fn test_mysql_migration_locks_are_namespaced_by_database() {
 	second_runner.release_migration_lock(true)!
 	second_name := mysql_migration_lock_name('application_two', 'schema_migrations', 0)
 	assert second_name != first_name
-	assert second_recorder.queries[2] == "SELECT GET_LOCK('${second_name}', ${migration_lock_timeout_seconds});"
+	assert second_recorder.queries[3] == "SELECT GET_LOCK('${second_name}', ${migration_lock_timeout_seconds});"
 
 	qualified_table := 'shared.schema_migrations'
 	qualified_name := mysql_migration_lock_name('shared', qualified_table, 0)
@@ -595,6 +625,7 @@ fn test_mysql_migration_locks_are_namespaced_by_database() {
 	qualified_first_runner.acquire_migration_lock()!
 	qualified_first_runner.release_migration_lock(true)!
 	assert qualified_first_recorder.queries == [
+		'SELECT @@autocommit;',
 		'SELECT @@lower_case_table_names;',
 		"SELECT GET_LOCK('${qualified_name}', ${migration_lock_timeout_seconds});",
 		"SELECT RELEASE_LOCK('${qualified_name}');",
@@ -651,6 +682,7 @@ fn test_mysql_migration_locks_follow_lower_case_table_names() {
 		upper_runner.release_migration_lock(true)!
 		assert upper_recorder.queries == lower_recorder.queries
 		assert lower_recorder.queries == [
+			'SELECT @@autocommit;',
 			'SELECT @@lower_case_table_names;',
 			"SELECT GET_LOCK('${lower_name}', ${migration_lock_timeout_seconds});",
 			"SELECT RELEASE_LOCK('${lower_name}');",

--- a/vlib/v3/migrations/migrations_test.v
+++ b/vlib/v3/migrations/migrations_test.v
@@ -422,6 +422,56 @@ fn test_rename_table_rejects_qualified_targets_where_required() {
 	]
 }
 
+fn test_postgresql_remove_index_uses_the_table_schema() {
+	mut recorder := &RecordingConnection{}
+	mut ctx := new_context(recorder, .pg)
+	ctx.remove_index('archive.users', 'index_archive_users_on_email')!
+	ctx.remove_index('archive.users', 'reporting.custom_email_index')!
+	ctx.remove_index('users', 'index_users_on_email')!
+	assert recorder.queries == [
+		'DROP INDEX "archive"."index_archive_users_on_email";',
+		'DROP INDEX "reporting"."custom_email_index";',
+		'DROP INDEX "index_users_on_email";',
+	]
+}
+
+fn test_column_sql_rejects_postgresql_serial_defaults_and_scale_without_precision() {
+	mut recorder := &RecordingConnection{}
+	mut ctx := new_context(recorder, .pg)
+	mut error_message := ''
+	ctx.add_column('accounts', Column{
+		name:           'sequence'
+		kind:           .bigint
+		auto_increment: true
+		default_sql:    '5'
+	}) or { error_message = err.msg() }
+	assert error_message == 'PostgreSQL auto-increment column `sequence` cannot specify default_sql'
+
+	error_message = ''
+	ctx.add_column('accounts', Column{
+		name:      'amount'
+		kind:      .decimal
+		precision: 0
+		scale:     2
+	}) or { error_message = err.msg() }
+	assert error_message == 'decimal scale requires a positive precision'
+	assert recorder.queries.len == 0
+
+	assert column_sql(.pg, Column{
+		name:           'sequence'
+		kind:           .bigint
+		primary_key:    true
+		auto_increment: true
+		default_sql:    ''
+	})! == '"sequence" BIGSERIAL PRIMARY KEY'
+	assert column_type_sql(.mysql, Column{
+		name:      'amount'
+		kind:      .decimal
+		precision: 8
+		scale:     2
+	})! == 'DECIMAL(8, 2)'
+}
+
 fn test_sqlite_add_column_rejects_unsupported_constraints() {
 	mut recorder := &RecordingConnection{}
 	mut ctx := new_context(recorder, .sqlite)

--- a/vlib/v3/migrations/migrations_test.v
+++ b/vlib/v3/migrations/migrations_test.v
@@ -1919,14 +1919,27 @@ fn test_sqlite_add_column_accepts_parenthesized_literal_defaults() {
 		kind:        .integer
 		default_sql: '(CAST(42 AS INTEGER))'
 	})!
+	ctx.add_column('accounts', Column{
+		name:        'signed_cast_count'
+		kind:        .integer
+		default_sql: '(+CAST(42 AS INTEGER))'
+	})!
+	ctx.add_column('accounts', Column{
+		name:        'nested_signed_cast_count'
+		kind:        .integer
+		default_sql: '(CAST(-CAST(42 AS INTEGER) AS INTEGER))'
+	})!
 	assert db.q_int('SELECT collated_count FROM accounts WHERE id = 1;')! == 0
 	assert db.q_string('SELECT collated_label FROM accounts WHERE id = 1;')! == 'collated'
 	assert db.q_int('SELECT cast_count FROM accounts WHERE id = 1;')! == 42
+	assert db.q_int('SELECT signed_cast_count FROM accounts WHERE id = 1;')! == 42
+	assert db.q_int('SELECT nested_signed_cast_count FROM accounts WHERE id = 1;')! == -42
 }
 
 fn test_sqlite_constant_cast_default_classification() {
 	for default_sql in ['(CAST(42 AS INTEGER))', "(CAST('x AS y' AS TEXT))",
-		'(CAST(CAST(42 AS TEXT) AS INTEGER))', '(CAST((+42) AS DECIMAL(10, 2)))'] {
+		'(CAST(CAST(42 AS TEXT) AS INTEGER))', '(CAST((+42) AS DECIMAL(10, 2)))',
+		'(+CAST(42 AS INTEGER))', '(CAST(-CAST(42 AS INTEGER) AS INTEGER))'] {
 		assert !sqlite_add_column_default_is_nonconstant(default_sql)
 	}
 	for default_sql in ['(CAST(CURRENT_TIMESTAMP AS TEXT))', "(CAST(datetime('now') AS TEXT))",

--- a/vlib/v3/migrations/schema.v
+++ b/vlib/v3/migrations/schema.v
@@ -1,5 +1,6 @@
 module migrations
 
+import hash.fnv1a
 import orm
 
 // Dialect selects the SQL emitted by schema helpers.
@@ -212,11 +213,11 @@ pub fn (mut ctx Context) change_column(table string, column Column) ! {
 			if removals.len > 0 {
 				return error('MySQL change_column cannot remove key constraints; unsupported false options: ${removals.join(', ')}; use remove_index() or ctx.execute()')
 			}
-			definition := column_sql(ctx.dialect, column)!
 			missing := mysql_change_column_missing_options(column)
 			if missing.len > 0 {
 				return error('MySQL change_column requires a complete column definition; missing options: ${missing.join(', ')}')
 			}
+			definition := mysql_change_column_sql(column)!
 			ctx.execute('ALTER TABLE ${quote_identifier(ctx.dialect, table)} MODIFY COLUMN ${definition};')!
 		}
 	}
@@ -275,7 +276,7 @@ fn mysql_change_column_unsupported_key_removals(column Column) []string {
 // `index_<table>_on_<columns>` name is used. SQLite tables and PostgreSQL/MySQL
 // index names must be unqualified.
 pub fn (mut ctx Context) add_index(index Index) ! {
-	name := index_name(index)!
+	name := index_name(ctx.dialect, index)!
 	if ctx.dialect == .sqlite && index.table.contains('.') {
 		return error('SQLite add_index table `${index.table}` must be unqualified')
 	}
@@ -410,6 +411,14 @@ fn auto_primary_key_sql(dialect Dialect, name string) string {
 }
 
 fn column_sql(dialect Dialect, column Column) !string {
+	return column_sql_internal(dialect, column, false)
+}
+
+fn mysql_change_column_sql(column Column) !string {
+	return column_sql_internal(.mysql, column, true)
+}
+
+fn column_sql_internal(dialect Dialect, column Column, preserve_omitted_mysql_key bool) !string {
 	validate_unqualified_identifier(column.name, 'column')!
 	if column.limit < 0 {
 		return error('column `${column.name}` limit must not be negative')
@@ -427,7 +436,9 @@ fn column_sql(dialect Dialect, column Column) !string {
 	if dialect == .sqlite && auto_increment && !primary_key {
 		return error('SQLite auto-increment column `${column.name}` must be a primary key')
 	}
-	if dialect == .mysql && auto_increment && !primary_key && !unique {
+	preserves_mysql_key := preserve_omitted_mysql_key && column.primary_key == none
+		&& column.unique == none
+	if dialect == .mysql && auto_increment && !primary_key && !unique && !preserves_mysql_key {
 		return error('MySQL auto-increment column `${column.name}` must be a primary key or unique')
 	}
 	mut sql_type := column_type_sql(dialect, column)!
@@ -599,7 +610,7 @@ fn column_type_sql(dialect Dialect, column Column) !string {
 	}
 }
 
-fn index_name(index Index) !string {
+fn index_name(dialect Dialect, index Index) !string {
 	validate_identifier(index.table, 'table')!
 	if index.columns.len == 0 {
 		return error('index on `${index.table}` must include at least one column')
@@ -607,13 +618,37 @@ fn index_name(index Index) !string {
 	for column in index.columns {
 		validate_unqualified_identifier(column, 'column')!
 	}
-	name := if index.name != '' {
+	mut name := if index.name != '' {
 		index.name
 	} else {
 		'index_${index.table.replace('.', '_')}_on_${index.columns.join('_and_')}'
 	}
 	validate_identifier(name, 'index')!
+	limit := index_name_limit(dialect)
+	if limit > 0 && name.len > limit {
+		if index.name != '' {
+			return error('${dialect_name(dialect)} index name `${name}` must not exceed ${limit} bytes')
+		}
+		hash := fnv1a.sum64_string(name).hex()
+		name = '${name[..limit - hash.len - 1]}_${hash}'
+	}
 	return name
+}
+
+fn index_name_limit(dialect Dialect) int {
+	return match dialect {
+		.sqlite { 0 }
+		.pg { 63 }
+		.mysql { 64 }
+	}
+}
+
+fn dialect_name(dialect Dialect) string {
+	return match dialect {
+		.sqlite { 'SQLite' }
+		.pg { 'PostgreSQL' }
+		.mysql { 'MySQL' }
+	}
 }
 
 fn quoted_columns(dialect Dialect, columns []string) !string {
@@ -704,4 +739,11 @@ fn quote_identifier(dialect Dialect, value string) string {
 
 fn escape_literal(value string) string {
 	return value.replace("'", "''")
+}
+
+fn string_literal_sql(dialect Dialect, value string) string {
+	if dialect == .mysql {
+		return "X'${value.hex()}'"
+	}
+	return "'${escape_literal(value)}'"
 }

--- a/vlib/v3/migrations/schema.v
+++ b/vlib/v3/migrations/schema.v
@@ -2,6 +2,9 @@ module migrations
 
 import hash.fnv1a
 import orm
+import strconv
+
+const sqlite_digit_separator_min_version = 3_046_000
 
 // Dialect selects the SQL emitted by schema helpers.
 pub enum Dialect {
@@ -84,7 +87,8 @@ pub:
 // normal V3 `sql ctx { ... }` ORM statements can be used alongside schema helpers.
 pub struct Context {
 mut:
-	conn orm.Connection
+	conn                   orm.Connection
+	sqlite_runtime_version ?int
 pub:
 	dialect Dialect
 }
@@ -177,7 +181,7 @@ pub fn (mut ctx Context) add_column(table string, column Column) ! {
 	validate_identifier_for_dialect(ctx.dialect, table, 'table')!
 	definition := column_sql(ctx.dialect, column)!
 	if ctx.dialect == .sqlite {
-		validate_sqlite_add_column(column)!
+		validate_sqlite_add_column(mut ctx, column)!
 	}
 	ctx.execute('ALTER TABLE ${quote_identifier(ctx.dialect, table)} ADD COLUMN ${definition};')!
 }
@@ -539,7 +543,7 @@ fn column_sql_internal(dialect Dialect, column Column, preserve_omitted_mysql_ke
 	return parts.join(' ')
 }
 
-fn validate_sqlite_add_column(column Column) ! {
+fn validate_sqlite_add_column(mut ctx Context, column Column) ! {
 	if column_primary_key(column) || column_unique(column) || column_auto_increment(column) {
 		return error('SQLite add_column does not support primary-key, unique, or auto-increment columns; rebuild the table in the migration')
 	}
@@ -547,10 +551,56 @@ fn validate_sqlite_add_column(column Column) ! {
 		if sqlite_add_column_default_is_nonconstant(default_sql) {
 			return error('SQLite add_column does not support nonconstant default `${default_sql}`; rebuild the table in the migration')
 		}
+		if sqlite_numeric_default_uses_digit_separators(default_sql)
+			&& ctx.sqlite_version_number()! < sqlite_digit_separator_min_version {
+			return error('SQLite add_column default `${default_sql}` uses numeric digit separators, which require SQLite 3.46.0 or newer')
+		}
 	}
 	if !column_nullable(column) && !sqlite_has_non_null_default(column) {
 		return error('SQLite add_column requires a non-NULL default for a NOT NULL column; rebuild the table in the migration')
 	}
+}
+
+fn (mut ctx Context) sqlite_version_number() !int {
+	if version := ctx.sqlite_runtime_version {
+		return version
+	}
+	rows := ctx.execute('SELECT sqlite_version();')!
+	version := sqlite_version_number(rows)!
+	ctx.sqlite_runtime_version = version
+	return version
+}
+
+fn sqlite_version_number(rows []orm.Row) !int {
+	if rows.len != 1 || rows[0].vals.len == 0 {
+		return error('could not determine SQLite runtime version')
+	}
+	parts := rows[0].vals[0].split('.')
+	if parts.len != 3 {
+		return error('unsupported SQLite runtime version `${rows[0].vals[0]}`')
+	}
+	major := strconv.atoi(parts[0]) or {
+		return error('unsupported SQLite runtime version `${rows[0].vals[0]}`')
+	}
+	minor := strconv.atoi(parts[1]) or {
+		return error('unsupported SQLite runtime version `${rows[0].vals[0]}`')
+	}
+	patch := strconv.atoi(parts[2]) or {
+		return error('unsupported SQLite runtime version `${rows[0].vals[0]}`')
+	}
+	return major * 1_000_000 + minor * 1_000 + patch
+}
+
+fn sqlite_numeric_default_uses_digit_separators(default_sql string) bool {
+	literal := sqlite_unwrapped_default(sqlite_default_without_comments(default_sql))
+	if !literal.contains('_') {
+		return false
+	}
+	normalized := sqlite_numeric_literal_without_separators(literal) or { return false }
+	if normalized.len > 2 && normalized[0] == `0` && normalized[1] in [u8(`x`), `X`] {
+		return normalized[2..].bytes().all(it.is_hex_digit())
+	}
+	return sqlite_is_decimal_numeric_literal(normalized)
 }
 
 fn sqlite_add_column_default_is_nonconstant(default_sql string) bool {

--- a/vlib/v3/migrations/schema.v
+++ b/vlib/v3/migrations/schema.v
@@ -596,6 +596,9 @@ fn sqlite_numeric_default_uses_digit_separators(default_sql string) bool {
 	if !literal.contains('_') {
 		return false
 	}
+	if cast_expression := sqlite_cast_expression(literal) {
+		return sqlite_numeric_default_uses_digit_separators(cast_expression.value)
+	}
 	normalized := sqlite_numeric_literal_without_separators(literal) or { return false }
 	if normalized.len > 2 && normalized[0] == `0` && normalized[1] in [u8(`x`), `X`] {
 		return normalized[2..].bytes().all(it.is_hex_digit())
@@ -610,9 +613,119 @@ fn sqlite_add_column_default_is_nonconstant(default_sql string) bool {
 		return true
 	}
 	if core := sqlite_parenthesized_default_core(normalized) {
-		return !sqlite_is_literal_default(core)
+		return !sqlite_is_constant_default_expression(core)
 	}
 	return false
+}
+
+struct SqliteCastExpression {
+	value string
+}
+
+fn sqlite_is_constant_default_expression(default_sql string) bool {
+	if sqlite_is_literal_default(default_sql) {
+		return true
+	}
+	cast_expression := sqlite_cast_expression(default_sql) or { return false }
+	return sqlite_is_constant_default_expression(cast_expression.value)
+}
+
+fn sqlite_cast_expression(default_sql string) ?SqliteCastExpression {
+	literal := default_sql.trim_space()
+	if literal.len < 6 || literal[..4].to_upper() != 'CAST' {
+		return none
+	}
+	mut open_parenthesis := 4
+	for open_parenthesis < literal.len && literal[open_parenthesis].is_space() {
+		open_parenthesis++
+	}
+	if open_parenthesis >= literal.len || literal[open_parenthesis] != `(` {
+		return none
+	}
+	close_parenthesis := sqlite_matching_parenthesis(literal, open_parenthesis) or { return none }
+	if literal[close_parenthesis + 1..].trim_space() != '' {
+		return none
+	}
+	inner := literal[open_parenthesis + 1..close_parenthesis]
+	as_index := sqlite_top_level_as_index(inner) or { return none }
+	value := inner[..as_index].trim_space()
+	type_name := inner[as_index + 2..].trim_space()
+	if value == '' || type_name == '' {
+		return none
+	}
+	return SqliteCastExpression{
+		value: value
+	}
+}
+
+fn sqlite_matching_parenthesis(expression string, open_parenthesis int) ?int {
+	mut depth := 0
+	mut quote := u8(0)
+	mut index := open_parenthesis
+	for index < expression.len {
+		character := expression[index]
+		if quote != 0 {
+			if character == quote {
+				if index + 1 < expression.len && expression[index + 1] == quote {
+					index += 2
+					continue
+				}
+				quote = 0
+			}
+			index++
+			continue
+		}
+		if character in [u8(39), 34] {
+			quote = character
+		} else if character == `(` {
+			depth++
+		} else if character == `)` {
+			depth--
+			if depth == 0 {
+				return index
+			}
+		}
+		index++
+	}
+	return none
+}
+
+fn sqlite_top_level_as_index(expression string) ?int {
+	mut depth := 0
+	mut quote := u8(0)
+	mut index := 0
+	for index + 1 < expression.len {
+		character := expression[index]
+		if quote != 0 {
+			if character == quote {
+				if index + 1 < expression.len && expression[index + 1] == quote {
+					index += 2
+					continue
+				}
+				quote = 0
+			}
+			index++
+			continue
+		}
+		if character in [u8(39), 34] {
+			quote = character
+		} else if character == `(` {
+			depth++
+		} else if character == `)` {
+			depth--
+		} else if depth == 0 && character in [u8(`A`), `a`]
+			&& expression[index + 1] in [u8(`S`), `s`]
+			&& (index == 0 || !sqlite_identifier_character(expression[index - 1]))
+			&& (index + 2 == expression.len || !sqlite_identifier_character(expression[index + 2])) {
+			return index
+		}
+		index++
+	}
+	return none
+}
+
+fn sqlite_identifier_character(character u8) bool {
+	return character.is_alnum() || character == `_`
 }
 
 fn sqlite_default_starts_with_current_time_keyword(default_sql string) bool {

--- a/vlib/v3/migrations/schema.v
+++ b/vlib/v3/migrations/schema.v
@@ -107,7 +107,7 @@ pub fn (mut ctx Context) create_table(table Table) ! {
 	mut column_names := map[string]bool{}
 	mut has_primary_key := false
 	if table.id {
-		validate_identifier(table.id_name, 'primary key')!
+		validate_unqualified_identifier(table.id_name, 'primary key')!
 		definitions << auto_primary_key_sql(ctx.dialect, table.id_name)
 		column_names[table.id_name] = true
 		has_primary_key = true
@@ -125,6 +125,7 @@ pub fn (mut ctx Context) create_table(table Table) ! {
 		has_primary_key = has_primary_key || is_primary_key
 	}
 	for key in table.foreign_keys {
+		validate_foreign_key(key)!
 		if key.from_table != table.name {
 			return error('foreign key `${key.name}` must use from_table `${table.name}`')
 		}
@@ -162,13 +163,16 @@ pub fn (mut ctx Context) rename_table(from string, to string) ! {
 pub fn (mut ctx Context) add_column(table string, column Column) ! {
 	validate_identifier(table, 'table')!
 	definition := column_sql(ctx.dialect, column)!
+	if ctx.dialect == .sqlite {
+		validate_sqlite_add_column(column)!
+	}
 	ctx.execute('ALTER TABLE ${quote_identifier(ctx.dialect, table)} ADD COLUMN ${definition};')!
 }
 
 // remove_column removes a column from an existing table.
 pub fn (mut ctx Context) remove_column(table string, column string) ! {
 	validate_identifier(table, 'table')!
-	validate_identifier(column, 'column')!
+	validate_unqualified_identifier(column, 'column')!
 	ctx.execute('ALTER TABLE ${quote_identifier(ctx.dialect, table)} DROP COLUMN ${quote_identifier(ctx.dialect,
 		column)};')!
 }
@@ -176,8 +180,8 @@ pub fn (mut ctx Context) remove_column(table string, column string) ! {
 // rename_column renames a column.
 pub fn (mut ctx Context) rename_column(table string, from string, to string) ! {
 	validate_identifier(table, 'table')!
-	validate_identifier(from, 'column')!
-	validate_identifier(to, 'column')!
+	validate_unqualified_identifier(from, 'column')!
+	validate_unqualified_identifier(to, 'column')!
 	ctx.execute('ALTER TABLE ${quote_identifier(ctx.dialect, table)} RENAME COLUMN ${quote_identifier(ctx.dialect,
 		from)} TO ${quote_identifier(ctx.dialect, to)};')!
 }
@@ -287,7 +291,7 @@ pub fn (mut ctx Context) add_foreign_key(key ForeignKey) ! {
 // remove_foreign_key removes a named foreign-key constraint.
 pub fn (mut ctx Context) remove_foreign_key(table string, name string) ! {
 	validate_identifier(table, 'table')!
-	validate_identifier(name, 'foreign key')!
+	validate_unqualified_identifier(name, 'foreign key')!
 	match ctx.dialect {
 		.sqlite {
 			return error('remove_foreign_key is not directly supported by SQLite; create a replacement table in the migration')
@@ -360,7 +364,7 @@ fn auto_primary_key_sql(dialect Dialect, name string) string {
 }
 
 fn column_sql(dialect Dialect, column Column) !string {
-	validate_identifier(column.name, 'column')!
+	validate_unqualified_identifier(column.name, 'column')!
 	if column.limit < 0 {
 		return error('column `${column.name}` limit must not be negative')
 	}
@@ -392,7 +396,11 @@ fn column_sql(dialect Dialect, column Column) !string {
 	}
 	mut parts := [quote_identifier(dialect, column.name), sql_type]
 	if primary_key {
-		parts << 'PRIMARY KEY'
+		if dialect == .sqlite && auto_increment {
+			parts << 'PRIMARY KEY AUTOINCREMENT'
+		} else {
+			parts << 'PRIMARY KEY'
+		}
 	}
 	if !column_nullable(column) && !primary_key {
 		parts << 'NOT NULL'
@@ -404,10 +412,24 @@ fn column_sql(dialect Dialect, column Column) !string {
 	if default_sql != '' {
 		parts << 'DEFAULT ${default_sql}'
 	}
-	if dialect == .sqlite && auto_increment && primary_key {
-		parts << 'AUTOINCREMENT'
-	}
 	return parts.join(' ')
+}
+
+fn validate_sqlite_add_column(column Column) ! {
+	if column_primary_key(column) || column_unique(column) || column_auto_increment(column) {
+		return error('SQLite add_column does not support primary-key, unique, or auto-increment columns; rebuild the table in the migration')
+	}
+	if !column_nullable(column) && !sqlite_has_non_null_default(column) {
+		return error('SQLite add_column requires a non-NULL default for a NOT NULL column; rebuild the table in the migration')
+	}
+}
+
+fn sqlite_has_non_null_default(column Column) bool {
+	if default_sql := column.default_sql {
+		normalized := default_sql.trim_space().to_upper()
+		return normalized != '' && normalized != 'NULL'
+	}
+	return false
 }
 
 fn column_nullable(column Column) bool {
@@ -519,7 +541,7 @@ fn index_name(index Index) !string {
 		return error('index on `${index.table}` must include at least one column')
 	}
 	for column in index.columns {
-		validate_identifier(column, 'column')!
+		validate_unqualified_identifier(column, 'column')!
 	}
 	name := if index.name != '' {
 		index.name
@@ -536,7 +558,7 @@ fn quoted_columns(dialect Dialect, columns []string) !string {
 	}
 	mut quoted := []string{cap: columns.len}
 	for column in columns {
-		validate_identifier(column, 'column')!
+		validate_unqualified_identifier(column, 'column')!
 		quoted << quote_identifier(dialect, column)
 	}
 	return quoted.join(', ')
@@ -548,13 +570,13 @@ fn foreign_key_name(key ForeignKey) !string {
 	} else {
 		'fk_${key.from_table.replace('.', '_')}_${key.column}'
 	}
-	validate_identifier(name, 'foreign key')!
+	validate_unqualified_identifier(name, 'foreign key')!
 	return name
 }
 
 fn foreign_key_constraint_sql(dialect Dialect, key ForeignKey) !string {
-	name := foreign_key_name(key)!
 	validate_foreign_key(key)!
+	name := foreign_key_name(key)!
 	mut query := 'CONSTRAINT ${quote_identifier(dialect, name)} FOREIGN KEY (${quote_identifier(dialect,
 		key.column)}) REFERENCES ${quote_identifier(dialect, key.to_table)} (${quote_identifier(dialect,
 		key.primary_key)})'
@@ -569,9 +591,9 @@ fn foreign_key_constraint_sql(dialect Dialect, key ForeignKey) !string {
 
 fn validate_foreign_key(key ForeignKey) ! {
 	validate_identifier(key.from_table, 'table')!
-	validate_identifier(key.column, 'column')!
+	validate_unqualified_identifier(key.column, 'column')!
 	validate_identifier(key.to_table, 'table')!
-	validate_identifier(key.primary_key, 'column')!
+	validate_unqualified_identifier(key.primary_key, 'column')!
 }
 
 fn foreign_key_action(action string) !string {
@@ -595,6 +617,13 @@ fn validate_identifier(value string, kind string) ! {
 				return error('invalid ${kind} name `${value}`')
 			}
 		}
+	}
+}
+
+fn validate_unqualified_identifier(value string, kind string) ! {
+	validate_identifier(value, kind)!
+	if value.contains('.') {
+		return error('${kind} name `${value}` must be unqualified')
 	}
 }
 

--- a/vlib/v3/migrations/schema.v
+++ b/vlib/v3/migrations/schema.v
@@ -567,21 +567,24 @@ fn sqlite_add_column_default_is_nonconstant(default_sql string) bool {
 }
 
 fn sqlite_default_starts_with_current_time_keyword(default_sql string) bool {
+	return sqlite_default_first_identifier(default_sql) in ['CURRENT_TIME', 'CURRENT_DATE',
+		'CURRENT_TIMESTAMP']
+}
+
+fn sqlite_default_first_identifier(default_sql string) string {
 	mut token_end := 0
 	for token_end < default_sql.len
 		&& (default_sql[token_end].is_alnum() || default_sql[token_end] == `_`) {
 		token_end++
 	}
-	if token_end == 0 {
-		return false
-	}
-	return default_sql[..token_end] in ['CURRENT_TIME', 'CURRENT_DATE', 'CURRENT_TIMESTAMP']
+	return default_sql[..token_end]
 }
 
 fn sqlite_has_non_null_default(column Column) bool {
 	if default_sql := column.default_sql {
 		normalized := sqlite_default_without_comments(default_sql).trim_space().to_upper()
-		return normalized != '' && sqlite_unwrapped_default(normalized) != 'NULL'
+		return normalized != ''
+			&& sqlite_default_first_identifier(sqlite_unwrapped_default(normalized)) != 'NULL'
 	}
 	return false
 }

--- a/vlib/v3/migrations/schema.v
+++ b/vlib/v3/migrations/schema.v
@@ -551,9 +551,21 @@ fn validate_sqlite_add_column(column Column) ! {
 
 fn sqlite_add_column_default_is_nonconstant(default_sql string) bool {
 	normalized := sqlite_default_without_comments(default_sql).trim_space().to_upper()
-	return normalized in ['CURRENT_TIME', 'CURRENT_DATE', 'CURRENT_TIMESTAMP']
+	return sqlite_default_starts_with_current_time_keyword(normalized)
 		|| (normalized.starts_with('(') && normalized.ends_with(')')
 		&& !sqlite_is_literal_default(normalized))
+}
+
+fn sqlite_default_starts_with_current_time_keyword(default_sql string) bool {
+	mut token_end := 0
+	for token_end < default_sql.len
+		&& (default_sql[token_end].is_alnum() || default_sql[token_end] == `_`) {
+		token_end++
+	}
+	if token_end == 0 {
+		return false
+	}
+	return default_sql[..token_end] in ['CURRENT_TIME', 'CURRENT_DATE', 'CURRENT_TIMESTAMP']
 }
 
 fn sqlite_has_non_null_default(column Column) bool {

--- a/vlib/v3/migrations/schema.v
+++ b/vlib/v3/migrations/schema.v
@@ -320,8 +320,13 @@ pub fn (mut ctx Context) remove_index(table string, name string) ! {
 				table)};')!
 		}
 		.pg {
-			drop_name := schema_qualified_index_name(table, name)
-			ctx.execute('DROP INDEX ${quote_identifier(ctx.dialect, drop_name)};')!
+			drop_name_sql := if name.contains('.') {
+				quote_identifier(.pg, name)
+			} else {
+				schema := ctx.postgresql_table_schema(table)!
+				'${quote_identifier_component(.pg, schema)}.${quote_identifier_component(.pg, name)}'
+			}
+			ctx.execute('DROP INDEX ${drop_name_sql};')!
 		}
 		.sqlite {
 			drop_name := if name.contains('.') {
@@ -333,6 +338,18 @@ pub fn (mut ctx Context) remove_index(table string, name string) ! {
 			ctx.execute('DROP INDEX ${quote_identifier(ctx.dialect, drop_name)};')!
 		}
 	}
+}
+
+fn (mut ctx Context) postgresql_table_schema(table string) !string {
+	if table.contains('.') {
+		return table.all_before('.')
+	}
+	rows := ctx.execute("SELECT n.nspname FROM pg_catalog.pg_class AS c JOIN pg_catalog.pg_namespace AS n ON n.oid = c.relnamespace WHERE c.relname = ${string_literal_sql(.pg,
+		table)} AND c.relkind IN ('r', 'p', 'v', 'm', 'f') AND pg_catalog.pg_table_is_visible(c.oid) LIMIT 1;")!
+	if rows.len != 1 || rows[0].vals.len == 0 || rows[0].vals[0] == '' {
+		return error('PostgreSQL remove_index could not resolve table `${table}` to a schema')
+	}
+	return rows[0].vals[0]
 }
 
 fn (mut ctx Context) sqlite_table_schema(table string) !string {
@@ -358,15 +375,6 @@ fn (mut ctx Context) sqlite_table_schema(table string) !string {
 		}
 	}
 	return error('SQLite remove_index could not resolve table `${table}` to a database')
-}
-
-fn schema_qualified_index_name(table string, name string) string {
-	if name.contains('.') || !table.contains('.') {
-		return name
-	}
-	mut parts := table.split('.')
-	parts[parts.len - 1] = name
-	return parts.join('.')
 }
 
 fn column_name_key(dialect Dialect, name string) string {

--- a/vlib/v3/migrations/schema.v
+++ b/vlib/v3/migrations/schema.v
@@ -631,7 +631,7 @@ fn sqlite_is_constant_default_expression(default_sql string) bool {
 }
 
 fn sqlite_cast_expression(default_sql string) ?SqliteCastExpression {
-	literal := default_sql.trim_space()
+	literal := sqlite_default_without_leading_signs(default_sql)
 	if literal.len < 6 || literal[..4].to_upper() != 'CAST' {
 		return none
 	}

--- a/vlib/v3/migrations/schema.v
+++ b/vlib/v3/migrations/schema.v
@@ -931,9 +931,14 @@ fn escape_literal(value string) string {
 	return value.replace("'", "''")
 }
 
+fn escape_postgresql_literal(value string) string {
+	return value.replace('\\', '\\\\').replace("'", "''")
+}
+
 fn string_literal_sql(dialect Dialect, value string) string {
-	if dialect == .mysql {
-		return "X'${value.hex()}'"
+	return match dialect {
+		.sqlite { "'${escape_literal(value)}'" }
+		.pg { "E'${escape_postgresql_literal(value)}'" }
+		.mysql { "X'${value.hex()}'" }
 	}
-	return "'${escape_literal(value)}'"
 }

--- a/vlib/v3/migrations/schema.v
+++ b/vlib/v3/migrations/schema.v
@@ -147,10 +147,13 @@ pub fn (mut ctx Context) drop_table(name string) ! {
 	ctx.execute('DROP TABLE ${quote_identifier(ctx.dialect, name)};')!
 }
 
-// rename_table renames a table.
+// rename_table renames a table. PostgreSQL and SQLite targets must be unqualified.
 pub fn (mut ctx Context) rename_table(from string, to string) ! {
 	validate_identifier(from, 'table')!
 	validate_identifier(to, 'table')!
+	if ctx.dialect in [.sqlite, .pg] && to.contains('.') {
+		return error('rename_table target `${to}` must be unqualified for PostgreSQL and SQLite')
+	}
 	ctx.execute('ALTER TABLE ${quote_identifier(ctx.dialect, from)} RENAME TO ${quote_identifier(ctx.dialect,
 		to)};')!
 }
@@ -182,6 +185,8 @@ pub fn (mut ctx Context) rename_column(table string, from string, to string) ! {
 // change_column changes a column definition. SQLite requires a table rebuild.
 // PostgreSQL supports type-related fields only and rejects constraint changes
 // before executing SQL; use execute for explicit PostgreSQL constraint DDL.
+// MySQL requires every optional constraint field to be supplied because MODIFY
+// COLUMN replaces the complete column definition.
 pub fn (mut ctx Context) change_column(table string, column Column) ! {
 	validate_identifier(table, 'table')!
 	definition := column_sql(ctx.dialect, column)!
@@ -198,6 +203,10 @@ pub fn (mut ctx Context) change_column(table string, column Column) ! {
 				column.name)} TYPE ${column_type_sql(ctx.dialect, column)!};')!
 		}
 		.mysql {
+			missing := mysql_change_column_missing_options(column)
+			if missing.len > 0 {
+				return error('MySQL change_column requires a complete column definition; missing options: ${missing.join(', ')}')
+			}
 			ctx.execute('ALTER TABLE ${quote_identifier(ctx.dialect, table)} MODIFY COLUMN ${definition};')!
 		}
 	}
@@ -218,6 +227,26 @@ fn pg_change_column_unsupported_options(column Column) []string {
 		options << 'primary_key'
 	}
 	if _ := column.auto_increment {
+		options << 'auto_increment'
+	}
+	return options
+}
+
+fn mysql_change_column_missing_options(column Column) []string {
+	mut options := []string{}
+	if column.nullable == none {
+		options << 'nullable'
+	}
+	if column.default_sql == none {
+		options << 'default_sql'
+	}
+	if column.unique == none {
+		options << 'unique'
+	}
+	if column.primary_key == none {
+		options << 'primary_key'
+	}
+	if column.auto_increment == none {
 		options << 'auto_increment'
 	}
 	return options
@@ -337,11 +366,15 @@ fn column_sql(dialect Dialect, column Column) !string {
 	}
 	auto_increment := column_auto_increment(column)
 	primary_key := column_primary_key(column)
+	unique := column_unique(column)
 	if auto_increment && column.kind !in [.integer, .bigint] {
 		return error('auto-increment column `${column.name}` must be integer or bigint')
 	}
 	if dialect == .sqlite && auto_increment && !primary_key {
 		return error('SQLite auto-increment column `${column.name}` must be a primary key')
+	}
+	if dialect == .mysql && auto_increment && !primary_key && !unique {
+		return error('MySQL auto-increment column `${column.name}` must be a primary key or unique')
 	}
 	mut sql_type := column_type_sql(dialect, column)!
 	if auto_increment {
@@ -364,7 +397,7 @@ fn column_sql(dialect Dialect, column Column) !string {
 	if !column_nullable(column) && !primary_key {
 		parts << 'NOT NULL'
 	}
-	if column_unique(column) {
+	if unique {
 		parts << 'UNIQUE'
 	}
 	default_sql := column_default_sql(column)

--- a/vlib/v3/migrations/schema.v
+++ b/vlib/v3/migrations/schema.v
@@ -760,7 +760,10 @@ fn index_name(dialect Dialect, index Index) !string {
 
 fn generated_index_name(index Index) string {
 	base := 'index_${index.table.replace('.', '_')}_on_${index.columns.join('_and_')}'
-	if index.columns.any(it.to_lower_ascii().contains('_and_')) {
+	encoded_table := index.table.replace('.', '_').to_lower_ascii()
+	if index.table.contains('.') || encoded_table.contains('_on_')
+		|| index.columns.any(it.to_lower_ascii().contains('_and_')
+		|| it.to_lower_ascii().contains('_on_')) {
 		mut identity := '${index.table.len}:${index.table}'
 		for column in index.columns {
 			identity += ':${column.len}:${column}'
@@ -822,8 +825,8 @@ fn foreign_key_name(dialect Dialect, key ForeignKey) !string {
 
 fn generated_foreign_key_name(dialect Dialect, key ForeignKey) string {
 	base := 'fk_${key.from_table.replace('.', '_')}_${key.column}'
-	if dialect == .mysql {
-		identity := '${key.from_table.len}:${key.from_table}:${key.column.len}:${key.column}'
+	if dialect in [.pg, .mysql] {
+		identity := '${key.from_table.len}:${key.from_table}:${key.column.len}:${key.column}:${key.to_table.len}:${key.to_table}:${key.primary_key.len}:${key.primary_key}'
 		return '${base}_${fnv1a.sum64_string(identity).hex()}'
 	}
 	return base

--- a/vlib/v3/migrations/schema.v
+++ b/vlib/v3/migrations/schema.v
@@ -511,17 +511,67 @@ fn validate_sqlite_add_column(column Column) ! {
 }
 
 fn sqlite_add_column_default_is_nonconstant(default_sql string) bool {
-	normalized := default_sql.trim_space().to_upper()
+	normalized := sqlite_default_without_comments(default_sql).trim_space().to_upper()
 	return normalized in ['CURRENT_TIME', 'CURRENT_DATE', 'CURRENT_TIMESTAMP']
 		|| (normalized.starts_with('(') && normalized.ends_with(')'))
 }
 
 fn sqlite_has_non_null_default(column Column) bool {
 	if default_sql := column.default_sql {
-		normalized := default_sql.trim_space().to_upper()
+		normalized := sqlite_default_without_comments(default_sql).trim_space().to_upper()
 		return normalized != '' && normalized != 'NULL'
 	}
 	return false
+}
+
+fn sqlite_default_without_comments(default_sql string) string {
+	mut result := []u8{cap: default_sql.len}
+	mut i := 0
+	mut quote := u8(0)
+	for i < default_sql.len {
+		ch := default_sql[i]
+		if quote != 0 {
+			result << ch
+			if ch == quote {
+				if i + 1 < default_sql.len && default_sql[i + 1] == quote {
+					result << default_sql[i + 1]
+					i += 2
+					continue
+				}
+				quote = 0
+			}
+			i++
+			continue
+		}
+		if ch == 39 || ch == 34 {
+			quote = ch
+			result << ch
+			i++
+			continue
+		}
+		if ch == 47 && i + 1 < default_sql.len && default_sql[i + 1] == 42 {
+			i += 2
+			for i + 1 < default_sql.len && !(default_sql[i] == 42 && default_sql[i + 1] == 47) {
+				i++
+			}
+			if i + 1 < default_sql.len {
+				i += 2
+			}
+			result << u8(32)
+			continue
+		}
+		if ch == 45 && i + 1 < default_sql.len && default_sql[i + 1] == 45 {
+			i += 2
+			for i < default_sql.len && default_sql[i] !in [u8(10), 13] {
+				i++
+			}
+			result << u8(32)
+			continue
+		}
+		result << ch
+		i++
+	}
+	return result.bytestr()
 }
 
 fn column_nullable(column Column) bool {
@@ -643,7 +693,11 @@ fn index_name(dialect Dialect, index Index) !string {
 	} else {
 		'index_${index.table.replace('.', '_')}_on_${index.columns.join('_and_')}'
 	}
-	validate_identifier(name, 'index')!
+	if index.name != '' {
+		validate_identifier_for_dialect(dialect, name, 'index')!
+	} else {
+		validate_identifier(name, 'index')!
+	}
 	return bounded_identifier_name(dialect, name, index.name == '', 'index')
 }
 

--- a/vlib/v3/migrations/schema.v
+++ b/vlib/v3/migrations/schema.v
@@ -2,7 +2,6 @@ module migrations
 
 import hash.fnv1a
 import orm
-import strconv
 
 // Dialect selects the SQL emitted by schema helpers.
 pub enum Dialect {
@@ -613,10 +612,40 @@ fn sqlite_is_literal_default(default_sql string) bool {
 		&& numeric_literal[2..].bytes().all(it.is_hex_digit()) {
 		return true
 	}
-	if _ := strconv.atof64(numeric_literal) {
-		return true
+	return sqlite_is_decimal_numeric_literal(numeric_literal)
+}
+
+fn sqlite_is_decimal_numeric_literal(literal string) bool {
+	mut index := 0
+	mut mantissa_digits := 0
+	for index < literal.len && literal[index].is_digit() {
+		index++
+		mantissa_digits++
 	}
-	return false
+	if index < literal.len && literal[index] == `.` {
+		index++
+		for index < literal.len && literal[index].is_digit() {
+			index++
+			mantissa_digits++
+		}
+	}
+	if mantissa_digits == 0 {
+		return false
+	}
+	if index < literal.len && literal[index] in [u8(`e`), `E`] {
+		index++
+		if index < literal.len && literal[index] in [u8(`+`), `-`] {
+			index++
+		}
+		exponent_start := index
+		for index < literal.len && literal[index].is_digit() {
+			index++
+		}
+		if index == exponent_start {
+			return false
+		}
+	}
+	return index == literal.len
 }
 
 fn sqlite_numeric_literal_without_separators(literal string) ?string {

--- a/vlib/v3/migrations/schema.v
+++ b/vlib/v3/migrations/schema.v
@@ -618,29 +618,33 @@ fn index_name(dialect Dialect, index Index) !string {
 	for column in index.columns {
 		validate_unqualified_identifier(column, 'column')!
 	}
-	mut name := if index.name != '' {
+	name := if index.name != '' {
 		index.name
 	} else {
 		'index_${index.table.replace('.', '_')}_on_${index.columns.join('_and_')}'
 	}
 	validate_identifier(name, 'index')!
-	limit := index_name_limit(dialect)
-	if limit > 0 && name.len > limit {
-		if index.name != '' {
-			return error('${dialect_name(dialect)} index name `${name}` must not exceed ${limit} bytes')
-		}
-		hash := fnv1a.sum64_string(name).hex()
-		name = '${name[..limit - hash.len - 1]}_${hash}'
-	}
-	return name
+	return bounded_identifier_name(dialect, name, index.name == '', 'index')
 }
 
-fn index_name_limit(dialect Dialect) int {
+fn identifier_name_limit(dialect Dialect) int {
 	return match dialect {
 		.sqlite { 0 }
 		.pg { 63 }
 		.mysql { 64 }
 	}
+}
+
+fn bounded_identifier_name(dialect Dialect, name string, generated bool, kind string) !string {
+	limit := identifier_name_limit(dialect)
+	if limit == 0 || name.len <= limit {
+		return name
+	}
+	if !generated {
+		return error('${dialect_name(dialect)} ${kind} name `${name}` must not exceed ${limit} bytes')
+	}
+	hash := fnv1a.sum64_string(name).hex()
+	return '${name[..limit - hash.len - 1]}_${hash}'
 }
 
 fn dialect_name(dialect Dialect) string {
@@ -663,14 +667,14 @@ fn quoted_columns(dialect Dialect, columns []string) !string {
 	return quoted.join(', ')
 }
 
-fn foreign_key_name(key ForeignKey) !string {
+fn foreign_key_name(dialect Dialect, key ForeignKey) !string {
 	name := if key.name != '' {
 		key.name
 	} else {
 		'fk_${key.from_table.replace('.', '_')}_${key.column}'
 	}
 	validate_unqualified_identifier(name, 'foreign key')!
-	return name
+	return bounded_identifier_name(dialect, name, key.name == '', 'foreign key')
 }
 
 fn foreign_key_constraint_sql(dialect Dialect, key ForeignKey) !string {
@@ -678,7 +682,7 @@ fn foreign_key_constraint_sql(dialect Dialect, key ForeignKey) !string {
 	if dialect == .sqlite && key.to_table.contains('.') {
 		return error('SQLite foreign-key target table `${key.to_table}` must be unqualified')
 	}
-	name := foreign_key_name(key)!
+	name := foreign_key_name(dialect, key)!
 	mut query := 'CONSTRAINT ${quote_identifier(dialect, name)} FOREIGN KEY (${quote_identifier(dialect,
 		key.column)}) REFERENCES ${quote_identifier(dialect, key.to_table)} (${quote_identifier(dialect,
 		key.primary_key)})'

--- a/vlib/v3/migrations/schema.v
+++ b/vlib/v3/migrations/schema.v
@@ -2,6 +2,7 @@ module migrations
 
 import hash.fnv1a
 import orm
+import strconv
 
 // Dialect selects the SQL emitted by schema helpers.
 pub enum Dialect {
@@ -513,15 +514,71 @@ fn validate_sqlite_add_column(column Column) ! {
 fn sqlite_add_column_default_is_nonconstant(default_sql string) bool {
 	normalized := sqlite_default_without_comments(default_sql).trim_space().to_upper()
 	return normalized in ['CURRENT_TIME', 'CURRENT_DATE', 'CURRENT_TIMESTAMP']
-		|| (normalized.starts_with('(') && normalized.ends_with(')'))
+		|| (normalized.starts_with('(') && normalized.ends_with(')')
+		&& !sqlite_is_literal_default(normalized))
 }
 
 fn sqlite_has_non_null_default(column Column) bool {
 	if default_sql := column.default_sql {
 		normalized := sqlite_default_without_comments(default_sql).trim_space().to_upper()
-		return normalized != '' && normalized != 'NULL'
+		return normalized != '' && sqlite_unwrapped_default(normalized) != 'NULL'
 	}
 	return false
+}
+
+fn sqlite_is_literal_default(default_sql string) bool {
+	literal := default_sql.trim_space()
+	if literal == '' {
+		return false
+	}
+	upper := literal.to_upper()
+	if upper in ['NULL', 'TRUE', 'FALSE'] {
+		return true
+	}
+	if sqlite_is_single_quoted_literal(literal) {
+		return true
+	}
+	if literal.len > 1 && literal[0] in [u8(`x`), `X`]
+		&& sqlite_is_single_quoted_literal(literal[1..]) {
+		return true
+	}
+	if literal.len > 2 && literal[0] == `0` && literal[1] in [u8(`x`), `X`]
+		&& literal[2..].bytes().all(it.is_hex_digit()) {
+		return true
+	}
+	if _ := strconv.atof64(literal) {
+		return true
+	}
+	if literal.starts_with('(') && literal.ends_with(')') {
+		return sqlite_is_literal_default(literal[1..literal.len - 1])
+	}
+	return false
+}
+
+fn sqlite_is_single_quoted_literal(literal string) bool {
+	if literal.len < 2 || literal[0] != 39 || literal[literal.len - 1] != 39 {
+		return false
+	}
+	mut i := 1
+	for i < literal.len - 1 {
+		if literal[i] == 39 {
+			if i + 1 >= literal.len - 1 || literal[i + 1] != 39 {
+				return false
+			}
+			i += 2
+			continue
+		}
+		i++
+	}
+	return true
+}
+
+fn sqlite_unwrapped_default(default_sql string) string {
+	mut literal := default_sql.trim_space()
+	for literal.len >= 2 && literal.starts_with('(') && literal.ends_with(')') {
+		literal = literal[1..literal.len - 1].trim_space()
+	}
+	return literal
 }
 
 fn sqlite_default_without_comments(default_sql string) string {
@@ -691,7 +748,7 @@ fn index_name(dialect Dialect, index Index) !string {
 	name := if index.name != '' {
 		index.name
 	} else {
-		'index_${index.table.replace('.', '_')}_on_${index.columns.join('_and_')}'
+		generated_index_name(index)
 	}
 	if index.name != '' {
 		validate_identifier_for_dialect(dialect, name, 'index')!
@@ -699,6 +756,18 @@ fn index_name(dialect Dialect, index Index) !string {
 		validate_identifier(name, 'index')!
 	}
 	return bounded_identifier_name(dialect, name, index.name == '', 'index')
+}
+
+fn generated_index_name(index Index) string {
+	base := 'index_${index.table.replace('.', '_')}_on_${index.columns.join('_and_')}'
+	if index.columns.any(it.to_lower_ascii().contains('_and_')) {
+		mut identity := '${index.table.len}:${index.table}'
+		for column in index.columns {
+			identity += ':${column.len}:${column}'
+		}
+		return '${base}_${fnv1a.sum64_string(identity).hex()}'
+	}
+	return base
 }
 
 fn identifier_name_limit(dialect Dialect) int {

--- a/vlib/v3/migrations/schema.v
+++ b/vlib/v3/migrations/schema.v
@@ -550,7 +550,8 @@ fn validate_sqlite_add_column(column Column) ! {
 }
 
 fn sqlite_add_column_default_is_nonconstant(default_sql string) bool {
-	normalized := sqlite_default_without_comments(default_sql).trim_space().to_upper()
+	normalized :=
+		sqlite_default_without_leading_signs(sqlite_default_without_comments(default_sql)).to_upper()
 	return sqlite_default_starts_with_current_time_keyword(normalized)
 		|| (normalized.starts_with('(') && normalized.ends_with(')')
 		&& !sqlite_is_literal_default(normalized))
@@ -577,7 +578,7 @@ fn sqlite_has_non_null_default(column Column) bool {
 }
 
 fn sqlite_is_literal_default(default_sql string) bool {
-	literal := default_sql.trim_space()
+	literal := sqlite_default_without_leading_signs(default_sql)
 	if literal == '' {
 		return false
 	}
@@ -625,8 +626,20 @@ fn sqlite_is_single_quoted_literal(literal string) bool {
 
 fn sqlite_unwrapped_default(default_sql string) string {
 	mut literal := default_sql.trim_space()
-	for literal.len >= 2 && literal.starts_with('(') && literal.ends_with(')') {
-		literal = literal[1..literal.len - 1].trim_space()
+	for {
+		literal = sqlite_default_without_leading_signs(literal)
+		if literal.len < 2 || !literal.starts_with('(') || !literal.ends_with(')') {
+			return literal
+		}
+		literal = literal[1..literal.len - 1]
+	}
+	return literal
+}
+
+fn sqlite_default_without_leading_signs(default_sql string) string {
+	mut literal := default_sql.trim_space()
+	for literal.len > 0 && literal[0] in [u8(`+`), `-`] {
+		literal = literal[1..].trim_space()
 	}
 	return literal
 }

--- a/vlib/v3/migrations/schema.v
+++ b/vlib/v3/migrations/schema.v
@@ -30,6 +30,8 @@ pub enum ColumnType {
 
 // Column describes a column used by create_table, add_column, or change_column.
 // default_sql is inserted verbatim and should contain a trusted SQL expression.
+// Constraint fields are optional so change_column can distinguish omitted
+// options from explicit false or empty values.
 pub struct Column {
 pub:
 	name           string
@@ -37,11 +39,11 @@ pub:
 	limit          int
 	precision      int
 	scale          int
-	nullable       bool = true
-	default_sql    string
-	primary_key    bool
-	auto_increment bool
-	unique         bool
+	nullable       ?bool
+	default_sql    ?string
+	primary_key    ?bool
+	auto_increment ?bool
+	unique         ?bool
 }
 
 // Table describes a table for Context.create_table. An auto-incrementing
@@ -114,12 +116,13 @@ pub fn (mut ctx Context) create_table(table Table) ! {
 		if column.name in column_names {
 			return error('table `${table.name}` has duplicate column `${column.name}`')
 		}
-		if has_primary_key && column.primary_key {
+		is_primary_key := column_primary_key(column)
+		if has_primary_key && is_primary_key {
 			return error('table `${table.name}` cannot have more than one primary key column')
 		}
 		definitions << column_sql(ctx.dialect, column)!
 		column_names[column.name] = true
-		has_primary_key = has_primary_key || column.primary_key
+		has_primary_key = has_primary_key || is_primary_key
 	}
 	for key in table.foreign_keys {
 		if key.from_table != table.name {
@@ -202,19 +205,19 @@ pub fn (mut ctx Context) change_column(table string, column Column) ! {
 
 fn pg_change_column_unsupported_options(column Column) []string {
 	mut options := []string{}
-	if !column.nullable {
+	if _ := column.nullable {
 		options << 'nullable'
 	}
-	if column.default_sql != '' {
+	if _ := column.default_sql {
 		options << 'default_sql'
 	}
-	if column.unique {
+	if _ := column.unique {
 		options << 'unique'
 	}
-	if column.primary_key {
+	if _ := column.primary_key {
 		options << 'primary_key'
 	}
-	if column.auto_increment {
+	if _ := column.auto_increment {
 		options << 'auto_increment'
 	}
 	return options
@@ -332,14 +335,16 @@ fn column_sql(dialect Dialect, column Column) !string {
 	if column.limit < 0 {
 		return error('column `${column.name}` limit must not be negative')
 	}
-	if column.auto_increment && column.kind !in [.integer, .bigint] {
+	auto_increment := column_auto_increment(column)
+	primary_key := column_primary_key(column)
+	if auto_increment && column.kind !in [.integer, .bigint] {
 		return error('auto-increment column `${column.name}` must be integer or bigint')
 	}
-	if dialect == .sqlite && column.auto_increment && !column.primary_key {
+	if dialect == .sqlite && auto_increment && !primary_key {
 		return error('SQLite auto-increment column `${column.name}` must be a primary key')
 	}
 	mut sql_type := column_type_sql(dialect, column)!
-	if column.auto_increment {
+	if auto_increment {
 		sql_type = match dialect {
 			.sqlite {
 				'INTEGER'
@@ -353,22 +358,43 @@ fn column_sql(dialect Dialect, column Column) !string {
 		}
 	}
 	mut parts := [quote_identifier(dialect, column.name), sql_type]
-	if column.primary_key {
+	if primary_key {
 		parts << 'PRIMARY KEY'
 	}
-	if !column.nullable && !column.primary_key {
+	if !column_nullable(column) && !primary_key {
 		parts << 'NOT NULL'
 	}
-	if column.unique {
+	if column_unique(column) {
 		parts << 'UNIQUE'
 	}
-	if column.default_sql != '' {
-		parts << 'DEFAULT ${column.default_sql}'
+	default_sql := column_default_sql(column)
+	if default_sql != '' {
+		parts << 'DEFAULT ${default_sql}'
 	}
-	if dialect == .sqlite && column.auto_increment && column.primary_key {
+	if dialect == .sqlite && auto_increment && primary_key {
 		parts << 'AUTOINCREMENT'
 	}
 	return parts.join(' ')
+}
+
+fn column_nullable(column Column) bool {
+	return column.nullable or { true }
+}
+
+fn column_default_sql(column Column) string {
+	return column.default_sql or { '' }
+}
+
+fn column_primary_key(column Column) bool {
+	return column.primary_key or { false }
+}
+
+fn column_auto_increment(column Column) bool {
+	return column.auto_increment or { false }
+}
+
+fn column_unique(column Column) bool {
+	return column.unique or { false }
 }
 
 fn column_type_sql(dialect Dialect, column Column) !string {

--- a/vlib/v3/migrations/schema.v
+++ b/vlib/v3/migrations/schema.v
@@ -176,8 +176,9 @@ pub fn (mut ctx Context) rename_column(table string, from string, to string) ! {
 		from)} TO ${quote_identifier(ctx.dialect, to)};')!
 }
 
-// change_column changes a column type and constraints. SQLite requires a table
-// rebuild for this operation, so the helper returns an explicit error there.
+// change_column changes a column definition. SQLite requires a table rebuild.
+// PostgreSQL supports type-related fields only and rejects constraint changes
+// before executing SQL; use execute for explicit PostgreSQL constraint DDL.
 pub fn (mut ctx Context) change_column(table string, column Column) ! {
 	validate_identifier(table, 'table')!
 	definition := column_sql(ctx.dialect, column)!
@@ -186,6 +187,10 @@ pub fn (mut ctx Context) change_column(table string, column Column) ! {
 			return error('change_column is not directly supported by SQLite; create a replacement table in the migration')
 		}
 		.pg {
+			unsupported := pg_change_column_unsupported_options(column)
+			if unsupported.len > 0 {
+				return error('PostgreSQL change_column only supports type, limit, precision, and scale; unsupported options: ${unsupported.join(', ')}; use ctx.execute() for constraint changes')
+			}
 			ctx.execute('ALTER TABLE ${quote_identifier(ctx.dialect, table)} ALTER COLUMN ${quote_identifier(ctx.dialect,
 				column.name)} TYPE ${column_type_sql(ctx.dialect, column)!};')!
 		}
@@ -193,6 +198,26 @@ pub fn (mut ctx Context) change_column(table string, column Column) ! {
 			ctx.execute('ALTER TABLE ${quote_identifier(ctx.dialect, table)} MODIFY COLUMN ${definition};')!
 		}
 	}
+}
+
+fn pg_change_column_unsupported_options(column Column) []string {
+	mut options := []string{}
+	if !column.nullable {
+		options << 'nullable'
+	}
+	if column.default_sql != '' {
+		options << 'default_sql'
+	}
+	if column.unique {
+		options << 'unique'
+	}
+	if column.primary_key {
+		options << 'primary_key'
+	}
+	if column.auto_increment {
+		options << 'auto_increment'
+	}
+	return options
 }
 
 // add_index adds an index. When name is empty, a deterministic Rails-style

--- a/vlib/v3/migrations/schema.v
+++ b/vlib/v3/migrations/schema.v
@@ -814,10 +814,19 @@ fn foreign_key_name(dialect Dialect, key ForeignKey) !string {
 	name := if key.name != '' {
 		key.name
 	} else {
-		'fk_${key.from_table.replace('.', '_')}_${key.column}'
+		generated_foreign_key_name(dialect, key)
 	}
 	validate_unqualified_identifier(name, 'foreign key')!
 	return bounded_identifier_name(dialect, name, key.name == '', 'foreign key')
+}
+
+fn generated_foreign_key_name(dialect Dialect, key ForeignKey) string {
+	base := 'fk_${key.from_table.replace('.', '_')}_${key.column}'
+	if dialect == .mysql {
+		identity := '${key.from_table.len}:${key.from_table}:${key.column.len}:${key.column}'
+		return '${base}_${fnv1a.sum64_string(identity).hex()}'
+	}
+	return base
 }
 
 fn foreign_key_constraint_sql(dialect Dialect, key ForeignKey) !string {

--- a/vlib/v3/migrations/schema.v
+++ b/vlib/v3/migrations/schema.v
@@ -605,17 +605,49 @@ fn sqlite_is_literal_default(default_sql string) bool {
 		&& sqlite_is_single_quoted_literal(literal[1..]) {
 		return true
 	}
-	if literal.len > 2 && literal[0] == `0` && literal[1] in [u8(`x`), `X`]
-		&& literal[2..].bytes().all(it.is_hex_digit()) {
-		return true
-	}
-	if _ := strconv.atof64(literal) {
-		return true
-	}
 	if literal.starts_with('(') && literal.ends_with(')') {
 		return sqlite_is_literal_default(literal[1..literal.len - 1])
 	}
+	numeric_literal := sqlite_numeric_literal_without_separators(literal) or { return false }
+	if numeric_literal.len > 2 && numeric_literal[0] == `0` && numeric_literal[1] in [u8(`x`), `X`]
+		&& numeric_literal[2..].bytes().all(it.is_hex_digit()) {
+		return true
+	}
+	if _ := strconv.atof64(numeric_literal) {
+		return true
+	}
 	return false
+}
+
+fn sqlite_numeric_literal_without_separators(literal string) ?string {
+	if !literal.contains('_') {
+		return literal
+	}
+	is_hex := literal.len > 2 && literal[0] == `0` && literal[1] in [u8(`x`), `X`]
+	mut normalized := []u8{cap: literal.len}
+	for i, character in literal {
+		if character != `_` {
+			normalized << character
+			continue
+		}
+		if i == 0 || i == literal.len - 1 {
+			return none
+		}
+		previous_is_digit := if is_hex {
+			literal[i - 1].is_hex_digit()
+		} else {
+			literal[i - 1].is_digit()
+		}
+		next_is_digit := if is_hex {
+			literal[i + 1].is_hex_digit()
+		} else {
+			literal[i + 1].is_digit()
+		}
+		if !previous_is_digit || !next_is_digit {
+			return none
+		}
+	}
+	return normalized.bytestr()
 }
 
 fn sqlite_is_single_quoted_literal(literal string) bool {

--- a/vlib/v3/migrations/schema.v
+++ b/vlib/v3/migrations/schema.v
@@ -292,10 +292,14 @@ pub fn (mut ctx Context) add_index(index Index) ! {
 }
 
 // remove_index removes an index by name. PostgreSQL derives the index schema
-// from a qualified table unless name is already qualified.
+// from a qualified table unless name is already qualified. MySQL index names
+// must be unqualified.
 pub fn (mut ctx Context) remove_index(table string, name string) ! {
 	validate_identifier(table, 'table')!
 	validate_identifier(name, 'index')!
+	if ctx.dialect == .mysql && name.contains('.') {
+		return error('MySQL remove_index name `${name}` must be unqualified')
+	}
 	match ctx.dialect {
 		.mysql {
 			ctx.execute('DROP INDEX ${quote_identifier(ctx.dialect, name)} ON ${quote_identifier(ctx.dialect,

--- a/vlib/v3/migrations/schema.v
+++ b/vlib/v3/migrations/schema.v
@@ -923,8 +923,12 @@ fn validate_unqualified_identifier_for_dialect(dialect Dialect, value string, ki
 }
 
 fn quote_identifier(dialect Dialect, value string) string {
+	return value.split('.').map(quote_identifier_component(dialect, it)).join('.')
+}
+
+fn quote_identifier_component(dialect Dialect, value string) string {
 	quote := if dialect == .mysql { '`' } else { '"' }
-	return value.split('.').map('${quote}${it}${quote}').join('.')
+	return '${quote}${value.replace(quote, quote + quote)}${quote}'
 }
 
 fn escape_literal(value string) string {

--- a/vlib/v3/migrations/schema.v
+++ b/vlib/v3/migrations/schema.v
@@ -189,8 +189,8 @@ pub fn (mut ctx Context) rename_column(table string, from string, to string) ! {
 // change_column changes a column definition. SQLite requires a table rebuild.
 // PostgreSQL supports type-related fields only and rejects constraint changes
 // before executing SQL; use execute for explicit PostgreSQL constraint DDL.
-// MySQL requires every optional constraint field to be supplied because MODIFY
-// COLUMN replaces the complete column definition.
+// MySQL requires nullable, default_sql, and auto_increment to be supplied because
+// MODIFY COLUMN replaces those attributes. Omitted key options are preserved.
 pub fn (mut ctx Context) change_column(table string, column Column) ! {
 	validate_identifier(table, 'table')!
 	match ctx.dialect {
@@ -208,6 +208,10 @@ pub fn (mut ctx Context) change_column(table string, column Column) ! {
 				column.name)} TYPE ${column_type_sql(ctx.dialect, column)!};')!
 		}
 		.mysql {
+			removals := mysql_change_column_unsupported_key_removals(column)
+			if removals.len > 0 {
+				return error('MySQL change_column cannot remove key constraints; unsupported false options: ${removals.join(', ')}; use remove_index() or ctx.execute()')
+			}
 			definition := column_sql(ctx.dialect, column)!
 			missing := mysql_change_column_missing_options(column)
 			if missing.len > 0 {
@@ -246,20 +250,29 @@ fn mysql_change_column_missing_options(column Column) []string {
 	if column.default_sql == none {
 		options << 'default_sql'
 	}
-	if column.unique == none {
-		options << 'unique'
-	}
-	if column.primary_key == none {
-		options << 'primary_key'
-	}
 	if column.auto_increment == none {
 		options << 'auto_increment'
 	}
 	return options
 }
 
+fn mysql_change_column_unsupported_key_removals(column Column) []string {
+	mut options := []string{}
+	if unique := column.unique {
+		if !unique {
+			options << 'unique'
+		}
+	}
+	if primary_key := column.primary_key {
+		if !primary_key {
+			options << 'primary_key'
+		}
+	}
+	return options
+}
+
 // add_index adds an index. When name is empty, a deterministic Rails-style
-// `index_<table>_on_<columns>` name is used. SQLite tables and PostgreSQL
+// `index_<table>_on_<columns>` name is used. SQLite tables and PostgreSQL/MySQL
 // index names must be unqualified.
 pub fn (mut ctx Context) add_index(index Index) ! {
 	name := index_name(index)!
@@ -268,6 +281,9 @@ pub fn (mut ctx Context) add_index(index Index) ! {
 	}
 	if ctx.dialect == .pg && name.contains('.') {
 		return error('PostgreSQL add_index name `${name}` must be unqualified')
+	}
+	if ctx.dialect == .mysql && name.contains('.') {
+		return error('MySQL add_index name `${name}` must be unqualified')
 	}
 	columns := quoted_columns(ctx.dialect, index.columns)!
 	unique := if index.unique { 'UNIQUE ' } else { '' }
@@ -432,7 +448,8 @@ fn column_sql(dialect Dialect, column Column) !string {
 			parts << 'PRIMARY KEY'
 		}
 	}
-	if !column_nullable(column) && !primary_key {
+	if (!column_nullable(column) && !primary_key)
+		|| (dialect == .sqlite && primary_key && sql_type != 'INTEGER') {
 		parts << 'NOT NULL'
 	}
 	if unique {

--- a/vlib/v3/migrations/schema.v
+++ b/vlib/v3/migrations/schema.v
@@ -111,14 +111,15 @@ pub fn (mut ctx Context) create_table(table Table) ! {
 	if table.id {
 		validate_unqualified_identifier_for_dialect(ctx.dialect, table.id_name, 'primary key')!
 		definitions << auto_primary_key_sql(ctx.dialect, table.id_name)
-		column_names[table.id_name] = true
+		column_names[column_name_key(ctx.dialect, table.id_name)] = true
 		has_primary_key = true
 		if ctx.dialect == .mysql {
 			auto_increment_columns = 1
 		}
 	}
 	for column in table.columns {
-		if column.name in column_names {
+		column_key := column_name_key(ctx.dialect, column.name)
+		if column_key in column_names {
 			return error('table `${table.name}` has duplicate column `${column.name}`')
 		}
 		is_primary_key := column_primary_key(column)
@@ -133,7 +134,7 @@ pub fn (mut ctx Context) create_table(table Table) ! {
 			}
 		}
 		definitions << definition
-		column_names[column.name] = true
+		column_names[column_key] = true
 		has_primary_key = has_primary_key || is_primary_key
 	}
 	for key in table.foreign_keys {
@@ -141,7 +142,7 @@ pub fn (mut ctx Context) create_table(table Table) ! {
 		if key.from_table != table.name {
 			return error('foreign key `${key.name}` must use from_table `${table.name}`')
 		}
-		if key.column !in column_names {
+		if column_name_key(ctx.dialect, key.column) !in column_names {
 			return error('foreign key column `${key.column}` does not exist in table `${table.name}`')
 		}
 		definitions << foreign_key_constraint_sql(ctx.dialect, key)!
@@ -303,9 +304,9 @@ pub fn (mut ctx Context) add_index(index Index) ! {
 		index.table)} (${columns});')!
 }
 
-// remove_index removes an index by name. PostgreSQL derives the index schema
-// from a qualified table unless name is already qualified. MySQL index names
-// must be unqualified.
+// remove_index removes an index by name. PostgreSQL and SQLite derive the index
+// schema from a qualified table unless name is already qualified. MySQL index
+// names must be unqualified.
 pub fn (mut ctx Context) remove_index(table string, name string) ! {
 	validate_identifier_for_dialect(ctx.dialect, table, 'table')!
 	validate_identifier_for_dialect(ctx.dialect, name, 'index')!
@@ -318,22 +319,30 @@ pub fn (mut ctx Context) remove_index(table string, name string) ! {
 				table)};')!
 		}
 		.pg {
-			drop_name := postgres_index_drop_name(table, name)
+			drop_name := schema_qualified_index_name(table, name)
 			ctx.execute('DROP INDEX ${quote_identifier(ctx.dialect, drop_name)};')!
 		}
 		.sqlite {
-			ctx.execute('DROP INDEX ${quote_identifier(ctx.dialect, name)};')!
+			drop_name := schema_qualified_index_name(table, name)
+			ctx.execute('DROP INDEX ${quote_identifier(ctx.dialect, drop_name)};')!
 		}
 	}
 }
 
-fn postgres_index_drop_name(table string, name string) string {
+fn schema_qualified_index_name(table string, name string) string {
 	if name.contains('.') || !table.contains('.') {
 		return name
 	}
 	mut parts := table.split('.')
 	parts[parts.len - 1] = name
 	return parts.join('.')
+}
+
+fn column_name_key(dialect Dialect, name string) string {
+	if dialect in [.sqlite, .mysql] {
+		return name.to_lower_ascii()
+	}
+	return name
 }
 
 // add_foreign_key adds a named foreign-key constraint. SQLite cannot add one

--- a/vlib/v3/migrations/schema.v
+++ b/vlib/v3/migrations/schema.v
@@ -324,10 +324,40 @@ pub fn (mut ctx Context) remove_index(table string, name string) ! {
 			ctx.execute('DROP INDEX ${quote_identifier(ctx.dialect, drop_name)};')!
 		}
 		.sqlite {
-			drop_name := schema_qualified_index_name(table, name)
+			drop_name := if name.contains('.') {
+				name
+			} else {
+				schema := ctx.sqlite_table_schema(table)!
+				'${schema}.${name}'
+			}
 			ctx.execute('DROP INDEX ${quote_identifier(ctx.dialect, drop_name)};')!
 		}
 	}
+}
+
+fn (mut ctx Context) sqlite_table_schema(table string) !string {
+	if table.contains('.') {
+		return table.all_before('.')
+	}
+	database_rows := ctx.execute('PRAGMA database_list;')!
+	mut schemas := ['temp', 'main']
+	for row in database_rows {
+		if row.vals.len < 2 {
+			return error('SQLite PRAGMA database_list returned ${row.vals.len} columns; expected at least 2')
+		}
+		schema := row.vals[1]
+		if schema !in schemas {
+			schemas << schema
+		}
+	}
+	for schema in schemas {
+		rows := ctx.execute("SELECT 1 FROM ${quote_identifier_component(.sqlite, schema)}.sqlite_schema WHERE type = 'table' AND name = ${string_literal_sql(.sqlite,
+			table)} COLLATE NOCASE LIMIT 1;")!
+		if rows.len > 0 {
+			return schema
+		}
+	}
+	return error('SQLite remove_index could not resolve table `${table}` to a database')
 }
 
 fn schema_qualified_index_name(table string, name string) string {

--- a/vlib/v3/migrations/schema.v
+++ b/vlib/v3/migrations/schema.v
@@ -107,11 +107,15 @@ pub fn (mut ctx Context) create_table(table Table) ! {
 	mut definitions := []string{}
 	mut column_names := map[string]bool{}
 	mut has_primary_key := false
+	mut auto_increment_columns := 0
 	if table.id {
 		validate_unqualified_identifier_for_dialect(ctx.dialect, table.id_name, 'primary key')!
 		definitions << auto_primary_key_sql(ctx.dialect, table.id_name)
 		column_names[table.id_name] = true
 		has_primary_key = true
+		if ctx.dialect == .mysql {
+			auto_increment_columns = 1
+		}
 	}
 	for column in table.columns {
 		if column.name in column_names {
@@ -121,7 +125,14 @@ pub fn (mut ctx Context) create_table(table Table) ! {
 		if has_primary_key && is_primary_key {
 			return error('table `${table.name}` cannot have more than one primary key column')
 		}
-		definitions << column_sql(ctx.dialect, column)!
+		definition := column_sql(ctx.dialect, column)!
+		if ctx.dialect == .mysql && column_auto_increment(column) {
+			auto_increment_columns++
+			if auto_increment_columns > 1 {
+				return error('MySQL table `${table.name}` cannot have more than one auto-increment column')
+			}
+		}
+		definitions << definition
 		column_names[column.name] = true
 		has_primary_key = has_primary_key || is_primary_key
 	}
@@ -731,14 +742,25 @@ fn validate_identifier(value string, kind string) ! {
 
 fn validate_identifier_for_dialect(dialect Dialect, value string, kind string) ! {
 	validate_identifier(value, kind)!
+	parts := value.split('.')
+	max_components := identifier_max_components(dialect)
+	if parts.len > max_components {
+		return error('${dialect_name(dialect)} ${kind} name `${value}` must not exceed ${max_components} components')
+	}
 	limit := identifier_name_limit(dialect)
 	if limit == 0 {
 		return
 	}
-	for part in value.split('.') {
+	for part in parts {
 		if part.len > limit {
 			return error('${dialect_name(dialect)} ${kind} name component `${part}` must not exceed ${limit} bytes')
 		}
+	}
+}
+
+fn identifier_max_components(dialect Dialect) int {
+	return match dialect {
+		.sqlite, .pg, .mysql { 2 }
 	}
 }
 

--- a/vlib/v3/migrations/schema.v
+++ b/vlib/v3/migrations/schema.v
@@ -259,11 +259,15 @@ fn mysql_change_column_missing_options(column Column) []string {
 }
 
 // add_index adds an index. When name is empty, a deterministic Rails-style
-// `index_<table>_on_<columns>` name is used. SQLite tables must be unqualified.
+// `index_<table>_on_<columns>` name is used. SQLite tables and PostgreSQL
+// index names must be unqualified.
 pub fn (mut ctx Context) add_index(index Index) ! {
 	name := index_name(index)!
 	if ctx.dialect == .sqlite && index.table.contains('.') {
 		return error('SQLite add_index table `${index.table}` must be unqualified')
+	}
+	if ctx.dialect == .pg && name.contains('.') {
+		return error('PostgreSQL add_index name `${name}` must be unqualified')
 	}
 	columns := quoted_columns(ctx.dialect, index.columns)!
 	unique := if index.unique { 'UNIQUE ' } else { '' }
@@ -623,10 +627,10 @@ fn foreign_key_constraint_sql(dialect Dialect, key ForeignKey) !string {
 		key.column)}) REFERENCES ${quote_identifier(dialect, key.to_table)} (${quote_identifier(dialect,
 		key.primary_key)})'
 	if key.on_delete != '' {
-		query += ' ON DELETE ${foreign_key_action(key.on_delete)!}'
+		query += ' ON DELETE ${foreign_key_action(dialect, key.on_delete)!}'
 	}
 	if key.on_update != '' {
-		query += ' ON UPDATE ${foreign_key_action(key.on_update)!}'
+		query += ' ON UPDATE ${foreign_key_action(dialect, key.on_update)!}'
 	}
 	return query
 }
@@ -638,10 +642,13 @@ fn validate_foreign_key(key ForeignKey) ! {
 	validate_unqualified_identifier(key.primary_key, 'column')!
 }
 
-fn foreign_key_action(action string) !string {
+fn foreign_key_action(dialect Dialect, action string) !string {
 	normalized := action.trim_space().to_upper().replace('_', ' ')
 	if normalized !in ['CASCADE', 'RESTRICT', 'NO ACTION', 'SET NULL', 'SET DEFAULT'] {
 		return error('unsupported foreign-key action `${action}`')
+	}
+	if dialect == .mysql && normalized == 'SET DEFAULT' {
+		return error('MySQL does not support SET DEFAULT for foreign-key actions')
 	}
 	return normalized
 }

--- a/vlib/v3/migrations/schema.v
+++ b/vlib/v3/migrations/schema.v
@@ -901,17 +901,11 @@ fn index_name(dialect Dialect, index Index) !string {
 
 fn generated_index_name(index Index) string {
 	base := 'index_${index.table.replace('.', '_')}_on_${index.columns.join('_and_')}'
-	encoded_table := index.table.replace('.', '_').to_lower_ascii()
-	if index.table.contains('.') || encoded_table.contains('_on_')
-		|| index.columns.any(it.to_lower_ascii().contains('_and_')
-		|| it.to_lower_ascii().contains('_on_')) {
-		mut identity := '${index.table.len}:${index.table}'
-		for column in index.columns {
-			identity += ':${column.len}:${column}'
-		}
-		return '${base}_${fnv1a.sum64_string(identity).hex()}'
+	mut identity := '${index.table.len}:${index.table}'
+	for column in index.columns {
+		identity += ':${column.len}:${column}'
 	}
-	return base
+	return '${base}_${fnv1a.sum64_string(identity).hex()}'
 }
 
 fn identifier_name_limit(dialect Dialect) int {

--- a/vlib/v3/migrations/schema.v
+++ b/vlib/v3/migrations/schema.v
@@ -744,11 +744,19 @@ fn sqlite_default_first_identifier(default_sql string) string {
 
 fn sqlite_has_non_null_default(column Column) bool {
 	if default_sql := column.default_sql {
-		normalized := sqlite_default_without_comments(default_sql).trim_space().to_upper()
-		return normalized != ''
-			&& sqlite_default_first_identifier(sqlite_unwrapped_default(normalized)) != 'NULL'
+		normalized := sqlite_default_without_comments(default_sql).trim_space()
+		return normalized != '' && !sqlite_default_resolves_to_null(normalized)
 	}
 	return false
+}
+
+fn sqlite_default_resolves_to_null(default_sql string) bool {
+	literal := sqlite_unwrapped_default(default_sql)
+	if sqlite_default_first_identifier(literal.to_upper()) == 'NULL' {
+		return true
+	}
+	cast_expression := sqlite_cast_expression(literal) or { return false }
+	return sqlite_default_resolves_to_null(cast_expression.value)
 }
 
 fn sqlite_is_literal_default(default_sql string) bool {

--- a/vlib/v3/migrations/schema.v
+++ b/vlib/v3/migrations/schema.v
@@ -193,9 +193,9 @@ pub fn (mut ctx Context) rename_column(table string, from string, to string) ! {
 // COLUMN replaces the complete column definition.
 pub fn (mut ctx Context) change_column(table string, column Column) ! {
 	validate_identifier(table, 'table')!
-	definition := column_sql(ctx.dialect, column)!
 	match ctx.dialect {
 		.sqlite {
+			column_sql(ctx.dialect, column)!
 			return error('change_column is not directly supported by SQLite; create a replacement table in the migration')
 		}
 		.pg {
@@ -203,10 +203,12 @@ pub fn (mut ctx Context) change_column(table string, column Column) ! {
 			if unsupported.len > 0 {
 				return error('PostgreSQL change_column only supports type, limit, precision, and scale; unsupported options: ${unsupported.join(', ')}; use ctx.execute() for constraint changes')
 			}
+			column_sql(ctx.dialect, column)!
 			ctx.execute('ALTER TABLE ${quote_identifier(ctx.dialect, table)} ALTER COLUMN ${quote_identifier(ctx.dialect,
 				column.name)} TYPE ${column_type_sql(ctx.dialect, column)!};')!
 		}
 		.mysql {
+			definition := column_sql(ctx.dialect, column)!
 			missing := mysql_change_column_missing_options(column)
 			if missing.len > 0 {
 				return error('MySQL change_column requires a complete column definition; missing options: ${missing.join(', ')}')
@@ -269,16 +271,33 @@ pub fn (mut ctx Context) add_index(index Index) ! {
 		index.table)} (${columns});')!
 }
 
-// remove_index removes an index by name.
+// remove_index removes an index by name. PostgreSQL derives the index schema
+// from a qualified table unless name is already qualified.
 pub fn (mut ctx Context) remove_index(table string, name string) ! {
 	validate_identifier(table, 'table')!
 	validate_identifier(name, 'index')!
-	if ctx.dialect == .mysql {
-		ctx.execute('DROP INDEX ${quote_identifier(ctx.dialect, name)} ON ${quote_identifier(ctx.dialect,
-			table)};')!
-	} else {
-		ctx.execute('DROP INDEX ${quote_identifier(ctx.dialect, name)};')!
+	match ctx.dialect {
+		.mysql {
+			ctx.execute('DROP INDEX ${quote_identifier(ctx.dialect, name)} ON ${quote_identifier(ctx.dialect,
+				table)};')!
+		}
+		.pg {
+			drop_name := postgres_index_drop_name(table, name)
+			ctx.execute('DROP INDEX ${quote_identifier(ctx.dialect, drop_name)};')!
+		}
+		.sqlite {
+			ctx.execute('DROP INDEX ${quote_identifier(ctx.dialect, name)};')!
+		}
 	}
+}
+
+fn postgres_index_drop_name(table string, name string) string {
+	if name.contains('.') || !table.contains('.') {
+		return name
+	}
+	mut parts := table.split('.')
+	parts[parts.len - 1] = name
+	return parts.join('.')
 }
 
 // add_foreign_key adds a named foreign-key constraint. SQLite cannot add one
@@ -374,8 +393,12 @@ fn column_sql(dialect Dialect, column Column) !string {
 	auto_increment := column_auto_increment(column)
 	primary_key := column_primary_key(column)
 	unique := column_unique(column)
+	default_sql := column_default_sql(column)
 	if auto_increment && column.kind !in [.integer, .bigint] {
 		return error('auto-increment column `${column.name}` must be integer or bigint')
+	}
+	if dialect == .pg && auto_increment && default_sql != '' {
+		return error('PostgreSQL auto-increment column `${column.name}` cannot specify default_sql')
 	}
 	if dialect == .sqlite && auto_increment && !primary_key {
 		return error('SQLite auto-increment column `${column.name}` must be a primary key')
@@ -411,7 +434,6 @@ fn column_sql(dialect Dialect, column Column) !string {
 	if unique {
 		parts << 'UNIQUE'
 	}
-	default_sql := column_default_sql(column)
 	if default_sql != '' {
 		parts << 'DEFAULT ${default_sql}'
 	}
@@ -534,6 +556,9 @@ fn column_type_sql(dialect Dialect, column Column) !string {
 		.decimal {
 			if column.precision < 0 || column.scale < 0 {
 				return error('decimal precision and scale must not be negative')
+			}
+			if column.precision == 0 && column.scale > 0 {
+				return error('decimal scale requires a positive precision')
 			}
 			if column.precision == 0 {
 				'DECIMAL'

--- a/vlib/v3/migrations/schema.v
+++ b/vlib/v3/migrations/schema.v
@@ -300,8 +300,13 @@ pub fn (mut ctx Context) add_index(index Index) ! {
 		return error('MySQL add_index name `${name}` must be unqualified')
 	}
 	columns := quoted_columns(ctx.dialect, index.columns)!
+	mut create_name_sql := quote_identifier(ctx.dialect, name)
+	if ctx.dialect == .sqlite && !name.contains('.') {
+		schema := ctx.sqlite_table_schema(index.table)!
+		create_name_sql = '${quote_identifier_component(.sqlite, schema)}.${quote_identifier_component(.sqlite, name)}'
+	}
 	unique := if index.unique { 'UNIQUE ' } else { '' }
-	ctx.execute('CREATE ${unique}INDEX ${quote_identifier(ctx.dialect, name)} ON ${quote_identifier(ctx.dialect,
+	ctx.execute('CREATE ${unique}INDEX ${create_name_sql} ON ${quote_identifier(ctx.dialect,
 		index.table)} (${columns});')!
 }
 
@@ -552,9 +557,13 @@ fn validate_sqlite_add_column(column Column) ! {
 fn sqlite_add_column_default_is_nonconstant(default_sql string) bool {
 	normalized :=
 		sqlite_default_without_leading_signs(sqlite_default_without_comments(default_sql)).to_upper()
-	return sqlite_default_starts_with_current_time_keyword(normalized)
-		|| (normalized.starts_with('(') && normalized.ends_with(')')
-		&& !sqlite_is_literal_default(normalized))
+	if sqlite_default_starts_with_current_time_keyword(normalized) {
+		return true
+	}
+	if core := sqlite_parenthesized_default_core(normalized) {
+		return !sqlite_is_literal_default(core)
+	}
+	return false
 }
 
 fn sqlite_default_starts_with_current_time_keyword(default_sql string) bool {
@@ -628,12 +637,46 @@ fn sqlite_unwrapped_default(default_sql string) string {
 	mut literal := default_sql.trim_space()
 	for {
 		literal = sqlite_default_without_leading_signs(literal)
-		if literal.len < 2 || !literal.starts_with('(') || !literal.ends_with(')') {
-			return literal
-		}
-		literal = literal[1..literal.len - 1]
+		core := sqlite_parenthesized_default_core(literal) or { return literal }
+		literal = core
 	}
 	return literal
+}
+
+fn sqlite_parenthesized_default_core(default_sql string) ?string {
+	literal := default_sql.trim_space()
+	if literal.len < 2 || literal[0] != `(` {
+		return none
+	}
+	mut depth := 0
+	mut quote := u8(0)
+	mut i := 0
+	for i < literal.len {
+		ch := literal[i]
+		if quote != 0 {
+			if ch == quote {
+				if i + 1 < literal.len && literal[i + 1] == quote {
+					i += 2
+					continue
+				}
+				quote = 0
+			}
+			i++
+			continue
+		}
+		if ch in [u8(39), 34] {
+			quote = ch
+		} else if ch == `(` {
+			depth++
+		} else if ch == `)` {
+			depth--
+			if depth == 0 {
+				return literal[1..i]
+			}
+		}
+		i++
+	}
+	return none
 }
 
 fn sqlite_default_without_leading_signs(default_sql string) string {

--- a/vlib/v3/migrations/schema.v
+++ b/vlib/v3/migrations/schema.v
@@ -1,0 +1,524 @@
+module migrations
+
+import orm
+
+// Dialect selects the SQL emitted by schema helpers.
+pub enum Dialect {
+	sqlite
+	pg
+	mysql
+}
+
+// ColumnType is a portable subset of common SQL column types.
+pub enum ColumnType {
+	boolean
+	integer
+	bigint
+	real
+	double_precision
+	text
+	varchar
+	blob
+	date
+	datetime
+	timestamp
+	json
+	jsonb
+	uuid
+	decimal
+}
+
+// Column describes a column used by create_table, add_column, or change_column.
+// default_sql is inserted verbatim and should contain a trusted SQL expression.
+pub struct Column {
+pub:
+	name           string
+	kind           ColumnType
+	limit          int
+	precision      int
+	scale          int
+	nullable       bool = true
+	default_sql    string
+	primary_key    bool
+	auto_increment bool
+	unique         bool
+}
+
+// Table describes a table for Context.create_table. An auto-incrementing
+// bigint `id` primary key is added unless id is false.
+pub struct Table {
+pub:
+	name          string
+	columns       []Column
+	foreign_keys  []ForeignKey
+	id            bool   = true
+	id_name       string = 'id'
+	if_not_exists bool
+}
+
+// Index describes an index for Context.add_index.
+pub struct Index {
+pub:
+	table   string
+	columns []string
+	name    string
+	unique  bool
+}
+
+// ForeignKey describes a foreign-key constraint.
+pub struct ForeignKey {
+pub:
+	from_table  string
+	column      string
+	to_table    string
+	primary_key string = 'id'
+	name        string
+	on_delete   string
+	on_update   string
+}
+
+// Context is passed to migration callbacks. It implements orm.Connection, so
+// normal V3 `sql ctx { ... }` ORM statements can be used alongside schema helpers.
+pub struct Context {
+mut:
+	conn orm.Connection
+pub:
+	dialect Dialect
+}
+
+fn new_context(conn orm.Connection, dialect Dialect) Context {
+	return Context{
+		conn:    conn
+		dialect: dialect
+	}
+}
+
+// execute runs trusted raw SQL through the migration connection.
+pub fn (mut ctx Context) execute(query string) ![]orm.Row {
+	return ctx.conn.execute(query)
+}
+
+// create_table creates a table from a Rails-style table definition.
+pub fn (mut ctx Context) create_table(table Table) ! {
+	validate_identifier(table.name, 'table')!
+	mut definitions := []string{}
+	mut column_names := map[string]bool{}
+	mut has_primary_key := false
+	if table.id {
+		validate_identifier(table.id_name, 'primary key')!
+		definitions << auto_primary_key_sql(ctx.dialect, table.id_name)
+		column_names[table.id_name] = true
+		has_primary_key = true
+	}
+	for column in table.columns {
+		if column.name in column_names {
+			return error('table `${table.name}` has duplicate column `${column.name}`')
+		}
+		if has_primary_key && column.primary_key {
+			return error('table `${table.name}` cannot have more than one primary key column')
+		}
+		definitions << column_sql(ctx.dialect, column)!
+		column_names[column.name] = true
+		has_primary_key = has_primary_key || column.primary_key
+	}
+	for key in table.foreign_keys {
+		if key.from_table != table.name {
+			return error('foreign key `${key.name}` must use from_table `${table.name}`')
+		}
+		if key.column !in column_names {
+			return error('foreign key column `${key.column}` does not exist in table `${table.name}`')
+		}
+		definitions << foreign_key_constraint_sql(ctx.dialect, key)!
+	}
+	if definitions.len == 0 {
+		return error('table `${table.name}` must have at least one column')
+	}
+	guard := if table.if_not_exists { ' IF NOT EXISTS' } else { '' }
+	name := quote_identifier(ctx.dialect, table.name)
+	ctx.execute('CREATE TABLE${guard} ${name} (${definitions.join(', ')});')!
+}
+
+// drop_table drops a table by name.
+pub fn (mut ctx Context) drop_table(name string) ! {
+	validate_identifier(name, 'table')!
+	ctx.execute('DROP TABLE ${quote_identifier(ctx.dialect, name)};')!
+}
+
+// rename_table renames a table.
+pub fn (mut ctx Context) rename_table(from string, to string) ! {
+	validate_identifier(from, 'table')!
+	validate_identifier(to, 'table')!
+	ctx.execute('ALTER TABLE ${quote_identifier(ctx.dialect, from)} RENAME TO ${quote_identifier(ctx.dialect,
+		to)};')!
+}
+
+// add_column adds a column to an existing table.
+pub fn (mut ctx Context) add_column(table string, column Column) ! {
+	validate_identifier(table, 'table')!
+	definition := column_sql(ctx.dialect, column)!
+	ctx.execute('ALTER TABLE ${quote_identifier(ctx.dialect, table)} ADD COLUMN ${definition};')!
+}
+
+// remove_column removes a column from an existing table.
+pub fn (mut ctx Context) remove_column(table string, column string) ! {
+	validate_identifier(table, 'table')!
+	validate_identifier(column, 'column')!
+	ctx.execute('ALTER TABLE ${quote_identifier(ctx.dialect, table)} DROP COLUMN ${quote_identifier(ctx.dialect,
+		column)};')!
+}
+
+// rename_column renames a column.
+pub fn (mut ctx Context) rename_column(table string, from string, to string) ! {
+	validate_identifier(table, 'table')!
+	validate_identifier(from, 'column')!
+	validate_identifier(to, 'column')!
+	ctx.execute('ALTER TABLE ${quote_identifier(ctx.dialect, table)} RENAME COLUMN ${quote_identifier(ctx.dialect,
+		from)} TO ${quote_identifier(ctx.dialect, to)};')!
+}
+
+// change_column changes a column type and constraints. SQLite requires a table
+// rebuild for this operation, so the helper returns an explicit error there.
+pub fn (mut ctx Context) change_column(table string, column Column) ! {
+	validate_identifier(table, 'table')!
+	definition := column_sql(ctx.dialect, column)!
+	match ctx.dialect {
+		.sqlite {
+			return error('change_column is not directly supported by SQLite; create a replacement table in the migration')
+		}
+		.pg {
+			ctx.execute('ALTER TABLE ${quote_identifier(ctx.dialect, table)} ALTER COLUMN ${quote_identifier(ctx.dialect,
+				column.name)} TYPE ${column_type_sql(ctx.dialect, column)!};')!
+		}
+		.mysql {
+			ctx.execute('ALTER TABLE ${quote_identifier(ctx.dialect, table)} MODIFY COLUMN ${definition};')!
+		}
+	}
+}
+
+// add_index adds an index. When name is empty, a deterministic Rails-style
+// `index_<table>_on_<columns>` name is used.
+pub fn (mut ctx Context) add_index(index Index) ! {
+	name := index_name(index)!
+	columns := quoted_columns(ctx.dialect, index.columns)!
+	unique := if index.unique { 'UNIQUE ' } else { '' }
+	ctx.execute('CREATE ${unique}INDEX ${quote_identifier(ctx.dialect, name)} ON ${quote_identifier(ctx.dialect,
+		index.table)} (${columns});')!
+}
+
+// remove_index removes an index by name.
+pub fn (mut ctx Context) remove_index(table string, name string) ! {
+	validate_identifier(table, 'table')!
+	validate_identifier(name, 'index')!
+	if ctx.dialect == .mysql {
+		ctx.execute('DROP INDEX ${quote_identifier(ctx.dialect, name)} ON ${quote_identifier(ctx.dialect,
+			table)};')!
+	} else {
+		ctx.execute('DROP INDEX ${quote_identifier(ctx.dialect, name)};')!
+	}
+}
+
+// add_foreign_key adds a named foreign-key constraint. SQLite cannot add one
+// to an existing table without rebuilding the table.
+pub fn (mut ctx Context) add_foreign_key(key ForeignKey) ! {
+	if ctx.dialect == .sqlite {
+		return error('add_foreign_key is not directly supported by SQLite; define it while creating a replacement table')
+	}
+	constraint := foreign_key_constraint_sql(ctx.dialect, key)!
+	ctx.execute('ALTER TABLE ${quote_identifier(ctx.dialect, key.from_table)} ADD ${constraint};')!
+}
+
+// remove_foreign_key removes a named foreign-key constraint.
+pub fn (mut ctx Context) remove_foreign_key(table string, name string) ! {
+	validate_identifier(table, 'table')!
+	validate_identifier(name, 'foreign key')!
+	match ctx.dialect {
+		.sqlite {
+			return error('remove_foreign_key is not directly supported by SQLite; create a replacement table in the migration')
+		}
+		.pg {
+			ctx.execute('ALTER TABLE ${quote_identifier(ctx.dialect, table)} DROP CONSTRAINT ${quote_identifier(ctx.dialect,
+				name)};')!
+		}
+		.mysql {
+			ctx.execute('ALTER TABLE ${quote_identifier(ctx.dialect, table)} DROP FOREIGN KEY ${quote_identifier(ctx.dialect,
+				name)};')!
+		}
+	}
+}
+
+// create_orm_table creates the table represented by T through V's ORM metadata.
+pub fn create_orm_table[T](mut ctx Context) ! {
+	mut query := orm.new_query[T](ctx)
+	query.create()!
+}
+
+// drop_orm_table drops the table represented by T through V's ORM metadata.
+pub fn drop_orm_table[T](mut ctx Context) ! {
+	mut query := orm.new_query[T](ctx)
+	query.drop()!
+}
+
+// select forwards ORM queries through the migration connection.
+pub fn (mut ctx Context) select(config orm.SelectConfig, data orm.QueryData, where orm.QueryData) ![][]orm.Primitive {
+	return ctx.conn.select(config, data, where)
+}
+
+// insert forwards ORM inserts through the migration connection.
+pub fn (mut ctx Context) insert(table orm.Table, data orm.QueryData) ! {
+	ctx.conn.insert(table, data)!
+}
+
+// update forwards ORM updates through the migration connection.
+pub fn (mut ctx Context) update(table orm.Table, data orm.QueryData, where orm.QueryData) ! {
+	ctx.conn.update(table, data, where)!
+}
+
+// delete forwards ORM deletes through the migration connection.
+pub fn (mut ctx Context) delete(table orm.Table, where orm.QueryData) ! {
+	ctx.conn.delete(table, where)!
+}
+
+// create forwards ORM table creation through the migration connection.
+pub fn (mut ctx Context) create(table orm.Table, fields []orm.TableField) ! {
+	ctx.conn.create(table, fields)!
+}
+
+// drop forwards ORM table removal through the migration connection.
+pub fn (mut ctx Context) drop(table orm.Table) ! {
+	ctx.conn.drop(table)!
+}
+
+// last_id forwards the last inserted id from the migration connection.
+pub fn (mut ctx Context) last_id() int {
+	return ctx.conn.last_id()
+}
+
+fn auto_primary_key_sql(dialect Dialect, name string) string {
+	quoted := quote_identifier(dialect, name)
+	return match dialect {
+		.sqlite { '${quoted} INTEGER PRIMARY KEY AUTOINCREMENT' }
+		.pg { '${quoted} BIGSERIAL PRIMARY KEY' }
+		.mysql { '${quoted} BIGINT AUTO_INCREMENT PRIMARY KEY' }
+	}
+}
+
+fn column_sql(dialect Dialect, column Column) !string {
+	validate_identifier(column.name, 'column')!
+	if column.limit < 0 {
+		return error('column `${column.name}` limit must not be negative')
+	}
+	if column.auto_increment && column.kind !in [.integer, .bigint] {
+		return error('auto-increment column `${column.name}` must be integer or bigint')
+	}
+	if dialect == .sqlite && column.auto_increment && !column.primary_key {
+		return error('SQLite auto-increment column `${column.name}` must be a primary key')
+	}
+	mut sql_type := column_type_sql(dialect, column)!
+	if column.auto_increment {
+		sql_type = match dialect {
+			.sqlite {
+				'INTEGER'
+			}
+			.pg {
+				if column.kind == .bigint { 'BIGSERIAL' } else { 'SERIAL' }
+			}
+			.mysql {
+				'${sql_type} AUTO_INCREMENT'
+			}
+		}
+	}
+	mut parts := [quote_identifier(dialect, column.name), sql_type]
+	if column.primary_key {
+		parts << 'PRIMARY KEY'
+	}
+	if !column.nullable && !column.primary_key {
+		parts << 'NOT NULL'
+	}
+	if column.unique {
+		parts << 'UNIQUE'
+	}
+	if column.default_sql != '' {
+		parts << 'DEFAULT ${column.default_sql}'
+	}
+	if dialect == .sqlite && column.auto_increment && column.primary_key {
+		parts << 'AUTOINCREMENT'
+	}
+	return parts.join(' ')
+}
+
+fn column_type_sql(dialect Dialect, column Column) !string {
+	return match column.kind {
+		.boolean {
+			'BOOLEAN'
+		}
+		.integer {
+			'INTEGER'
+		}
+		.bigint {
+			'BIGINT'
+		}
+		.real {
+			'REAL'
+		}
+		.double_precision {
+			if dialect == .mysql {
+				'DOUBLE'
+			} else {
+				'DOUBLE PRECISION'
+			}
+		}
+		.text {
+			'TEXT'
+		}
+		.varchar {
+			limit := if column.limit > 0 { column.limit } else { 255 }
+			'VARCHAR(${limit})'
+		}
+		.blob {
+			if dialect == .pg {
+				'BYTEA'
+			} else {
+				'BLOB'
+			}
+		}
+		.date {
+			'DATE'
+		}
+		.datetime {
+			if dialect == .pg {
+				'TIMESTAMP'
+			} else {
+				'DATETIME'
+			}
+		}
+		.timestamp {
+			'TIMESTAMP'
+		}
+		.json {
+			'JSON'
+		}
+		.jsonb {
+			if dialect == .pg {
+				'JSONB'
+			} else {
+				'JSON'
+			}
+		}
+		.uuid {
+			if dialect == .pg {
+				'UUID'
+			} else {
+				'CHAR(36)'
+			}
+		}
+		.decimal {
+			if column.precision < 0 || column.scale < 0 {
+				return error('decimal precision and scale must not be negative')
+			}
+			if column.precision == 0 {
+				'DECIMAL'
+			} else if column.scale == 0 {
+				'DECIMAL(${column.precision})'
+			} else {
+				if column.scale > column.precision {
+					return error('decimal scale must not exceed precision')
+				}
+				'DECIMAL(${column.precision}, ${column.scale})'
+			}
+		}
+	}
+}
+
+fn index_name(index Index) !string {
+	validate_identifier(index.table, 'table')!
+	if index.columns.len == 0 {
+		return error('index on `${index.table}` must include at least one column')
+	}
+	for column in index.columns {
+		validate_identifier(column, 'column')!
+	}
+	name := if index.name != '' {
+		index.name
+	} else {
+		'index_${index.table.replace('.', '_')}_on_${index.columns.join('_and_')}'
+	}
+	validate_identifier(name, 'index')!
+	return name
+}
+
+fn quoted_columns(dialect Dialect, columns []string) !string {
+	if columns.len == 0 {
+		return error('at least one column is required')
+	}
+	mut quoted := []string{cap: columns.len}
+	for column in columns {
+		validate_identifier(column, 'column')!
+		quoted << quote_identifier(dialect, column)
+	}
+	return quoted.join(', ')
+}
+
+fn foreign_key_name(key ForeignKey) !string {
+	name := if key.name != '' {
+		key.name
+	} else {
+		'fk_${key.from_table.replace('.', '_')}_${key.column}'
+	}
+	validate_identifier(name, 'foreign key')!
+	return name
+}
+
+fn foreign_key_constraint_sql(dialect Dialect, key ForeignKey) !string {
+	name := foreign_key_name(key)!
+	validate_foreign_key(key)!
+	mut query := 'CONSTRAINT ${quote_identifier(dialect, name)} FOREIGN KEY (${quote_identifier(dialect,
+		key.column)}) REFERENCES ${quote_identifier(dialect, key.to_table)} (${quote_identifier(dialect,
+		key.primary_key)})'
+	if key.on_delete != '' {
+		query += ' ON DELETE ${foreign_key_action(key.on_delete)!}'
+	}
+	if key.on_update != '' {
+		query += ' ON UPDATE ${foreign_key_action(key.on_update)!}'
+	}
+	return query
+}
+
+fn validate_foreign_key(key ForeignKey) ! {
+	validate_identifier(key.from_table, 'table')!
+	validate_identifier(key.column, 'column')!
+	validate_identifier(key.to_table, 'table')!
+	validate_identifier(key.primary_key, 'column')!
+}
+
+fn foreign_key_action(action string) !string {
+	normalized := action.trim_space().to_upper().replace('_', ' ')
+	if normalized !in ['CASCADE', 'RESTRICT', 'NO ACTION', 'SET NULL', 'SET DEFAULT'] {
+		return error('unsupported foreign-key action `${action}`')
+	}
+	return normalized
+}
+
+fn validate_identifier(value string, kind string) ! {
+	if value == '' {
+		return error('${kind} name must not be empty')
+	}
+	for part in value.split('.') {
+		if part == '' || !(part[0].is_letter() || part[0] == `_`) {
+			return error('invalid ${kind} name `${value}`')
+		}
+		for ch in part[1..] {
+			if !(ch.is_alnum() || ch == `_`) {
+				return error('invalid ${kind} name `${value}`')
+			}
+		}
+	}
+}
+
+fn quote_identifier(dialect Dialect, value string) string {
+	quote := if dialect == .mysql { '`' } else { '"' }
+	return value.split('.').map('${quote}${it}${quote}').join('.')
+}
+
+fn escape_literal(value string) string {
+	return value.replace("'", "''")
+}

--- a/vlib/v3/migrations/schema.v
+++ b/vlib/v3/migrations/schema.v
@@ -257,9 +257,12 @@ fn mysql_change_column_missing_options(column Column) []string {
 }
 
 // add_index adds an index. When name is empty, a deterministic Rails-style
-// `index_<table>_on_<columns>` name is used.
+// `index_<table>_on_<columns>` name is used. SQLite tables must be unqualified.
 pub fn (mut ctx Context) add_index(index Index) ! {
 	name := index_name(index)!
+	if ctx.dialect == .sqlite && index.table.contains('.') {
+		return error('SQLite add_index table `${index.table}` must be unqualified')
+	}
 	columns := quoted_columns(ctx.dialect, index.columns)!
 	unique := if index.unique { 'UNIQUE ' } else { '' }
 	ctx.execute('CREATE ${unique}INDEX ${quote_identifier(ctx.dialect, name)} ON ${quote_identifier(ctx.dialect,
@@ -419,9 +422,20 @@ fn validate_sqlite_add_column(column Column) ! {
 	if column_primary_key(column) || column_unique(column) || column_auto_increment(column) {
 		return error('SQLite add_column does not support primary-key, unique, or auto-increment columns; rebuild the table in the migration')
 	}
+	if default_sql := column.default_sql {
+		if sqlite_add_column_default_is_nonconstant(default_sql) {
+			return error('SQLite add_column does not support nonconstant default `${default_sql}`; rebuild the table in the migration')
+		}
+	}
 	if !column_nullable(column) && !sqlite_has_non_null_default(column) {
 		return error('SQLite add_column requires a non-NULL default for a NOT NULL column; rebuild the table in the migration')
 	}
+}
+
+fn sqlite_add_column_default_is_nonconstant(default_sql string) bool {
+	normalized := default_sql.trim_space().to_upper()
+	return normalized in ['CURRENT_TIME', 'CURRENT_DATE', 'CURRENT_TIMESTAMP']
+		|| (normalized.starts_with('(') && normalized.ends_with(')'))
 }
 
 fn sqlite_has_non_null_default(column Column) bool {
@@ -576,6 +590,9 @@ fn foreign_key_name(key ForeignKey) !string {
 
 fn foreign_key_constraint_sql(dialect Dialect, key ForeignKey) !string {
 	validate_foreign_key(key)!
+	if dialect == .sqlite && key.to_table.contains('.') {
+		return error('SQLite foreign-key target table `${key.to_table}` must be unqualified')
+	}
 	name := foreign_key_name(key)!
 	mut query := 'CONSTRAINT ${quote_identifier(dialect, name)} FOREIGN KEY (${quote_identifier(dialect,
 		key.column)}) REFERENCES ${quote_identifier(dialect, key.to_table)} (${quote_identifier(dialect,

--- a/vlib/v3/migrations/schema.v
+++ b/vlib/v3/migrations/schema.v
@@ -103,12 +103,12 @@ pub fn (mut ctx Context) execute(query string) ![]orm.Row {
 
 // create_table creates a table from a Rails-style table definition.
 pub fn (mut ctx Context) create_table(table Table) ! {
-	validate_identifier(table.name, 'table')!
+	validate_identifier_for_dialect(ctx.dialect, table.name, 'table')!
 	mut definitions := []string{}
 	mut column_names := map[string]bool{}
 	mut has_primary_key := false
 	if table.id {
-		validate_unqualified_identifier(table.id_name, 'primary key')!
+		validate_unqualified_identifier_for_dialect(ctx.dialect, table.id_name, 'primary key')!
 		definitions << auto_primary_key_sql(ctx.dialect, table.id_name)
 		column_names[table.id_name] = true
 		has_primary_key = true
@@ -126,7 +126,7 @@ pub fn (mut ctx Context) create_table(table Table) ! {
 		has_primary_key = has_primary_key || is_primary_key
 	}
 	for key in table.foreign_keys {
-		validate_foreign_key(key)!
+		validate_foreign_key(ctx.dialect, key)!
 		if key.from_table != table.name {
 			return error('foreign key `${key.name}` must use from_table `${table.name}`')
 		}
@@ -145,14 +145,14 @@ pub fn (mut ctx Context) create_table(table Table) ! {
 
 // drop_table drops a table by name.
 pub fn (mut ctx Context) drop_table(name string) ! {
-	validate_identifier(name, 'table')!
+	validate_identifier_for_dialect(ctx.dialect, name, 'table')!
 	ctx.execute('DROP TABLE ${quote_identifier(ctx.dialect, name)};')!
 }
 
 // rename_table renames a table. PostgreSQL and SQLite targets must be unqualified.
 pub fn (mut ctx Context) rename_table(from string, to string) ! {
-	validate_identifier(from, 'table')!
-	validate_identifier(to, 'table')!
+	validate_identifier_for_dialect(ctx.dialect, from, 'table')!
+	validate_identifier_for_dialect(ctx.dialect, to, 'table')!
 	if ctx.dialect in [.sqlite, .pg] && to.contains('.') {
 		return error('rename_table target `${to}` must be unqualified for PostgreSQL and SQLite')
 	}
@@ -162,7 +162,7 @@ pub fn (mut ctx Context) rename_table(from string, to string) ! {
 
 // add_column adds a column to an existing table.
 pub fn (mut ctx Context) add_column(table string, column Column) ! {
-	validate_identifier(table, 'table')!
+	validate_identifier_for_dialect(ctx.dialect, table, 'table')!
 	definition := column_sql(ctx.dialect, column)!
 	if ctx.dialect == .sqlite {
 		validate_sqlite_add_column(column)!
@@ -172,17 +172,17 @@ pub fn (mut ctx Context) add_column(table string, column Column) ! {
 
 // remove_column removes a column from an existing table.
 pub fn (mut ctx Context) remove_column(table string, column string) ! {
-	validate_identifier(table, 'table')!
-	validate_unqualified_identifier(column, 'column')!
+	validate_identifier_for_dialect(ctx.dialect, table, 'table')!
+	validate_unqualified_identifier_for_dialect(ctx.dialect, column, 'column')!
 	ctx.execute('ALTER TABLE ${quote_identifier(ctx.dialect, table)} DROP COLUMN ${quote_identifier(ctx.dialect,
 		column)};')!
 }
 
 // rename_column renames a column.
 pub fn (mut ctx Context) rename_column(table string, from string, to string) ! {
-	validate_identifier(table, 'table')!
-	validate_unqualified_identifier(from, 'column')!
-	validate_unqualified_identifier(to, 'column')!
+	validate_identifier_for_dialect(ctx.dialect, table, 'table')!
+	validate_unqualified_identifier_for_dialect(ctx.dialect, from, 'column')!
+	validate_unqualified_identifier_for_dialect(ctx.dialect, to, 'column')!
 	ctx.execute('ALTER TABLE ${quote_identifier(ctx.dialect, table)} RENAME COLUMN ${quote_identifier(ctx.dialect,
 		from)} TO ${quote_identifier(ctx.dialect, to)};')!
 }
@@ -193,7 +193,7 @@ pub fn (mut ctx Context) rename_column(table string, from string, to string) ! {
 // MySQL requires nullable, default_sql, and auto_increment to be supplied because
 // MODIFY COLUMN replaces those attributes. Omitted key options are preserved.
 pub fn (mut ctx Context) change_column(table string, column Column) ! {
-	validate_identifier(table, 'table')!
+	validate_identifier_for_dialect(ctx.dialect, table, 'table')!
 	match ctx.dialect {
 		.sqlite {
 			column_sql(ctx.dialect, column)!
@@ -296,8 +296,8 @@ pub fn (mut ctx Context) add_index(index Index) ! {
 // from a qualified table unless name is already qualified. MySQL index names
 // must be unqualified.
 pub fn (mut ctx Context) remove_index(table string, name string) ! {
-	validate_identifier(table, 'table')!
-	validate_identifier(name, 'index')!
+	validate_identifier_for_dialect(ctx.dialect, table, 'table')!
+	validate_identifier_for_dialect(ctx.dialect, name, 'index')!
 	if ctx.dialect == .mysql && name.contains('.') {
 		return error('MySQL remove_index name `${name}` must be unqualified')
 	}
@@ -337,8 +337,8 @@ pub fn (mut ctx Context) add_foreign_key(key ForeignKey) ! {
 
 // remove_foreign_key removes a named foreign-key constraint.
 pub fn (mut ctx Context) remove_foreign_key(table string, name string) ! {
-	validate_identifier(table, 'table')!
-	validate_unqualified_identifier(name, 'foreign key')!
+	validate_identifier_for_dialect(ctx.dialect, table, 'table')!
+	validate_unqualified_identifier_for_dialect(ctx.dialect, name, 'foreign key')!
 	match ctx.dialect {
 		.sqlite {
 			return error('remove_foreign_key is not directly supported by SQLite; create a replacement table in the migration')
@@ -419,7 +419,7 @@ fn mysql_change_column_sql(column Column) !string {
 }
 
 fn column_sql_internal(dialect Dialect, column Column, preserve_omitted_mysql_key bool) !string {
-	validate_unqualified_identifier(column.name, 'column')!
+	validate_unqualified_identifier_for_dialect(dialect, column.name, 'column')!
 	if column.limit < 0 {
 		return error('column `${column.name}` limit must not be negative')
 	}
@@ -611,12 +611,12 @@ fn column_type_sql(dialect Dialect, column Column) !string {
 }
 
 fn index_name(dialect Dialect, index Index) !string {
-	validate_identifier(index.table, 'table')!
+	validate_identifier_for_dialect(dialect, index.table, 'table')!
 	if index.columns.len == 0 {
 		return error('index on `${index.table}` must include at least one column')
 	}
 	for column in index.columns {
-		validate_unqualified_identifier(column, 'column')!
+		validate_unqualified_identifier_for_dialect(dialect, column, 'column')!
 	}
 	name := if index.name != '' {
 		index.name
@@ -661,7 +661,7 @@ fn quoted_columns(dialect Dialect, columns []string) !string {
 	}
 	mut quoted := []string{cap: columns.len}
 	for column in columns {
-		validate_unqualified_identifier(column, 'column')!
+		validate_unqualified_identifier_for_dialect(dialect, column, 'column')!
 		quoted << quote_identifier(dialect, column)
 	}
 	return quoted.join(', ')
@@ -678,7 +678,7 @@ fn foreign_key_name(dialect Dialect, key ForeignKey) !string {
 }
 
 fn foreign_key_constraint_sql(dialect Dialect, key ForeignKey) !string {
-	validate_foreign_key(key)!
+	validate_foreign_key(dialect, key)!
 	if dialect == .sqlite && key.to_table.contains('.') {
 		return error('SQLite foreign-key target table `${key.to_table}` must be unqualified')
 	}
@@ -695,11 +695,11 @@ fn foreign_key_constraint_sql(dialect Dialect, key ForeignKey) !string {
 	return query
 }
 
-fn validate_foreign_key(key ForeignKey) ! {
-	validate_identifier(key.from_table, 'table')!
-	validate_unqualified_identifier(key.column, 'column')!
-	validate_identifier(key.to_table, 'table')!
-	validate_unqualified_identifier(key.primary_key, 'column')!
+fn validate_foreign_key(dialect Dialect, key ForeignKey) ! {
+	validate_identifier_for_dialect(dialect, key.from_table, 'table')!
+	validate_unqualified_identifier_for_dialect(dialect, key.column, 'column')!
+	validate_identifier_for_dialect(dialect, key.to_table, 'table')!
+	validate_unqualified_identifier_for_dialect(dialect, key.primary_key, 'column')!
 }
 
 fn foreign_key_action(dialect Dialect, action string) !string {
@@ -729,8 +729,28 @@ fn validate_identifier(value string, kind string) ! {
 	}
 }
 
+fn validate_identifier_for_dialect(dialect Dialect, value string, kind string) ! {
+	validate_identifier(value, kind)!
+	limit := identifier_name_limit(dialect)
+	if limit == 0 {
+		return
+	}
+	for part in value.split('.') {
+		if part.len > limit {
+			return error('${dialect_name(dialect)} ${kind} name component `${part}` must not exceed ${limit} bytes')
+		}
+	}
+}
+
 fn validate_unqualified_identifier(value string, kind string) ! {
 	validate_identifier(value, kind)!
+	if value.contains('.') {
+		return error('${kind} name `${value}` must be unqualified')
+	}
+}
+
+fn validate_unqualified_identifier_for_dialect(dialect Dialect, value string, kind string) ! {
+	validate_identifier_for_dialect(dialect, value, kind)!
 	if value.contains('.') {
 		return error('${kind} name `${value}` must be unqualified')
 	}

--- a/vlib/v3/tests/migrations_public_api_test.v
+++ b/vlib/v3/tests/migrations_public_api_test.v
@@ -1,0 +1,39 @@
+// vtest build: present_sqlite3? && !sanitize-memory-clang
+import db.sqlite
+import v3.migrations
+
+struct MigrationApiUser {
+	id   int @[primary; sql: serial]
+	name string
+}
+
+fn create_migration_api_users(mut ctx migrations.Context) ! {
+	migrations.create_orm_table[MigrationApiUser](mut ctx)!
+}
+
+fn drop_migration_api_users(mut ctx migrations.Context) ! {
+	migrations.drop_orm_table[MigrationApiUser](mut ctx)!
+}
+
+fn test_v3_migrations_public_api_import_and_orm_helpers() {
+	mut db := sqlite.connect(':memory:')!
+	defer {
+		db.close() or {}
+	}
+	mut runner := migrations.new(mut db, [
+		migrations.Migration{
+			version: 202608160100
+			name:    "create_migration_api_users'quoted"
+			up:      create_migration_api_users
+			down:    drop_migration_api_users
+		},
+	], migrations.Config{
+		dialect: .sqlite
+	})!
+
+	runner.migrate()!
+	assert runner.applied()![0].name == "create_migration_api_users'quoted"
+	assert db.q_int("SELECT count(*) FROM sqlite_master WHERE type = 'table' AND name = 'migrationapiuser';")! == 1
+	runner.rollback_last()!
+	assert db.q_int("SELECT count(*) FROM sqlite_master WHERE type = 'table' AND name = 'migrationapiuser';")! == 0
+}


### PR DESCRIPTION
## Summary

- add versioned, reversible ORM migrations under vlib/v3 only
- track applied migrations and support migrate, target-version, rollback, redo, reset, pending, and status workflows
- add Rails-style schema helpers for tables, columns, indexes, and foreign keys
- allow existing V3 sql blocks and typed ORM table helpers inside migration callbacks
- document the public v3.migrations API

## Testing

- rebuilt ./vnew with ./v -g -keepc -o ./vnew cmd/v
- ./vnew -cc clang -g vlib/v3/migrations/migrations_test.v
- ./vnew -cc clang -g vlib/v3/tests/migrations_public_api_test.v
- ./vnew vet vlib/v3/migrations
- ./vnew check-md vlib/v3/migrations/README.md

The normal test dispatcher skipped both SQLite-backed files because its present_sqlite3 capability probe is false in this environment; both pass when compiled and run directly. The existing vlib/v3/tests/orm_join_sql_attr_test.v was also attempted and fails independently on a FirstGenericSqlRow[int] generated-symbol mismatch; it does not import this module.

Not run: test-all.