### PR TITLE
v3: add profiling and ownership compatibility fixes

### DIFF
--- a/cmd/v/macos_v3_test.v
+++ b/cmd/v/macos_v3_test.v
@@ -971,11 +971,12 @@ fn test_ownership_delegation_is_platform_scoped_and_honors_old_compiler() {
 	assert !ownership_delegation_is_requested(true, false, true, 'macos')
 }
 
-fn test_ownership_forwarding_adds_the_compile_time_define_once() {
+fn test_ownership_forwarding_keeps_internal_define_out_of_target_args() {
 	prefs := &pref.Preferences{}
 	forwarded := v3_ownership_forwarded_args(prefs, ['-ownership', 'main.v'])
 	assert '-ownership' !in forwarded
-	assert v3_args_have_ownership_define(forwarded)
+	assert 'ownership' !in forwarded
+	assert !forwarded.any(it in ['-d=ownership', '-downership'])
 	explicit := v3_ownership_forwarded_args(prefs, ['-ownership', '-d', 'ownership', 'main.v'])
 	assert explicit.count(it == 'ownership') == 1
 }
@@ -993,7 +994,8 @@ fn test_macos_v3_ownership_forwarding_is_quiet_and_normalizes_x86() {
 			'x86', 'main.v'])
 		assert macos_v3_internal_quiet_flag in forwarded
 		assert '-ownership' !in forwarded
-		assert v3_args_have_ownership_define(forwarded)
+		assert 'ownership' !in forwarded
+		assert !forwarded.any(it in ['-d=ownership', '-downership'])
 		assert forwarded.count(it == 'amd64') == 2
 		assert 'x86' !in forwarded
 
@@ -1004,6 +1006,57 @@ fn test_macos_v3_ownership_forwarding_is_quiet_and_normalizes_x86() {
 			assert macos_v3_internal_quiet_flag !in explicit
 		}
 	}
+}
+
+fn test_ownership_delegation_does_not_define_target_ownership() {
+	root := os.join_path(os.real_path(os.vtmp_dir()), 'v3_ownership_target_define_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	source := os.join_path(root, 'main.v')
+	output := os.join_path(root, 'main')
+	module_dir := os.join_path(root, 'marker')
+	os.mkdir_all(module_dir) or { panic(err) }
+	os.write_file(os.join_path(module_dir, 'marker.v'), 'module marker
+
+pub fn value() string {
+	return "ok"
+}
+')!
+	os.write_file(os.join_path(module_dir, 'marker_d_ownership.v'), 'module marker
+
+$compile_error("ownership-suffixed target file was included")
+')!
+	os.write_file(source, r'
+import marker
+
+$if ownership ? {
+	$compile_error("ownership define leaked into target")
+}
+
+fn main() {
+	println(marker.value())
+}
+')!
+	mut environment := os.environ()
+	environment['VFLAGS'] = ''
+	environment['VOSARGS'] = ''
+	mut process := os.new_process(@VEXE)
+	process.set_args(['-ownership', '-gc', 'none', '-o', output, source])
+	process.set_environment(environment)
+	process.set_redirect_stdio()
+	process.run()
+	process.wait()
+	compiler_output := process.stdout_slurp() + process.stderr_slurp()
+	exit_code := process.code
+	process.close()
+	assert exit_code == 0, compiler_output
+	assert os.is_executable(output)
+	run := os.execute(os.quoted_path(output))
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == 'ok'
 }
 
 fn test_autofree_unsupported_modes_stay_on_the_standard_compiler() {

--- a/cmd/v/macos_v3_test.v
+++ b/cmd/v/macos_v3_test.v
@@ -66,10 +66,10 @@ fn test_macos_v3_relevant_command_selects_user_compilation_and_tests() {
 		assert !is_macos_v3_relevant_command('main.v', prefs)
 		prefs.is_liveshared = false
 		prefs.is_prof = true
-		assert !is_macos_v3_relevant_command('main.v', prefs)
+		assert is_macos_v3_relevant_command('main.v', prefs)
 		prefs.is_prof = false
 		prefs.profile_fns = ['main__work']
-		assert !is_macos_v3_relevant_command('main.v', prefs)
+		assert is_macos_v3_relevant_command('main.v', prefs)
 		prefs.profile_fns.clear()
 		prefs.use_os_system_to_run = true
 		assert !is_macos_v3_relevant_command('run', prefs)
@@ -273,7 +273,7 @@ fn test_remaining_unsupported_autofree_modes_require_standard_compiler() {
 	}
 }
 
-fn test_selective_profile_autofree_requires_standard_compiler() {
+fn test_selective_profile_autofree_uses_v3_compiler() {
 	$if macos {
 		prefs, _ := pref.parse_args_and_show_errors([], [
 			'',
@@ -283,7 +283,7 @@ fn test_selective_profile_autofree_requires_standard_compiler() {
 			'main.v',
 		], false)
 		assert prefs.profile_fns == ['main__work']
-		assert autofree_requires_standard_compiler(prefs)
+		assert !autofree_requires_standard_compiler(prefs)
 	}
 }
 
@@ -971,6 +971,15 @@ fn test_ownership_delegation_is_platform_scoped_and_honors_old_compiler() {
 	assert !ownership_delegation_is_requested(true, false, true, 'macos')
 }
 
+fn test_ownership_forwarding_adds_the_compile_time_define_once() {
+	prefs := &pref.Preferences{}
+	forwarded := v3_ownership_forwarded_args(prefs, ['-ownership', 'main.v'])
+	assert '-ownership' !in forwarded
+	assert v3_args_have_ownership_define(forwarded)
+	explicit := v3_ownership_forwarded_args(prefs, ['-ownership', '-d', 'ownership', 'main.v'])
+	assert explicit.count(it == 'ownership') == 1
+}
+
 fn test_macos_v3_ownership_forwarding_is_quiet_and_normalizes_x86() {
 	$if macos {
 		prefs, _ := pref.parse_args_and_show_errors([], [
@@ -984,6 +993,7 @@ fn test_macos_v3_ownership_forwarding_is_quiet_and_normalizes_x86() {
 			'x86', 'main.v'])
 		assert macos_v3_internal_quiet_flag in forwarded
 		assert '-ownership' !in forwarded
+		assert v3_args_have_ownership_define(forwarded)
 		assert forwarded.count(it == 'amd64') == 2
 		assert 'x86' !in forwarded
 

--- a/cmd/v/v.v
+++ b/cmd/v/v.v
@@ -250,27 +250,11 @@ fn autofree_args_require_standard_compiler(args []string, command string) bool {
 }
 
 fn v3_ownership_forwarded_args(prefs &pref.Preferences, merged_args []string) []string {
-	mut ownership_args := merged_args.filter(it != '-ownership')
-	if !v3_args_have_ownership_define(ownership_args) {
-		ownership_args.prepend('ownership')
-		ownership_args.prepend('-d')
-	}
+	ownership_args := merged_args.filter(it != '-ownership')
 	$if macos {
 		return macos_v3_forwarded_args(prefs, ownership_args)
 	}
 	return ownership_args
-}
-
-fn v3_args_have_ownership_define(args []string) bool {
-	for i, arg in args {
-		if arg in ['-d=ownership', '-downership'] {
-			return true
-		}
-		if arg == '-d' && i + 1 < args.len && args[i + 1] == 'ownership' {
-			return true
-		}
-	}
-	return false
 }
 
 fn autofree_requires_standard_compiler(prefs &pref.Preferences) bool {

--- a/cmd/v/v.v
+++ b/cmd/v/v.v
@@ -250,11 +250,27 @@ fn autofree_args_require_standard_compiler(args []string, command string) bool {
 }
 
 fn v3_ownership_forwarded_args(prefs &pref.Preferences, merged_args []string) []string {
-	ownership_args := merged_args.filter(it != '-ownership')
+	mut ownership_args := merged_args.filter(it != '-ownership')
+	if !v3_args_have_ownership_define(ownership_args) {
+		ownership_args.prepend('ownership')
+		ownership_args.prepend('-d')
+	}
 	$if macos {
 		return macos_v3_forwarded_args(prefs, ownership_args)
 	}
 	return ownership_args
+}
+
+fn v3_args_have_ownership_define(args []string) bool {
+	for i, arg in args {
+		if arg in ['-d=ownership', '-downership'] {
+			return true
+		}
+		if arg == '-d' && i + 1 < args.len && args[i + 1] == 'ownership' {
+			return true
+		}
+	}
+	return false
 }
 
 fn autofree_requires_standard_compiler(prefs &pref.Preferences) bool {
@@ -278,9 +294,8 @@ fn v3_has_v1_only_preferences(prefs &pref.Preferences) bool {
 		return true
 	}
 	return prefs.sanitize || prefs.is_livemain || prefs.is_liveshared
-		|| prefs.is_prof || prefs.profile_fns.len > 0 || prefs.output_cross_c
-		|| prefs.experimental || prefs.use_os_system_to_run || prefs.is_apk
-		|| prefs.json_errors || prefs.no_preludes || prefs.is_quiet
+		|| prefs.output_cross_c || prefs.experimental || prefs.use_os_system_to_run
+		|| prefs.is_apk || prefs.json_errors || prefs.no_preludes || prefs.is_quiet
 		|| prefs.skip_warnings || prefs.skip_notes || prefs.fatal_errors
 		|| prefs.print_watched_files || prefs.dump_modules.len > 0
 		|| prefs.dump_files.len > 0 || prefs.dump_defines.len > 0

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -6165,10 +6165,22 @@ before using the shader in your code.
 
 ### Profiling
 
-V has good support for profiling your programs: `v -profile profile.txt run file.v`
-That will produce a profile.txt file, which you can then analyze.
+V has good support for profiling your programs: `v -profile profile.txt run file.v`.
+That will produce a `profile.txt` file when the program exits, which you can then
+analyze. If the output file is omitted, as in `v -profile run file.v`, the report
+is written to standard output. `-prof` is an alias for `-profile`.
 
-The generated profile.txt file will have lines with 4 columns:
+The V3 compiler supports profiling with its C backend. Other V3 backends reject
+`-profile`. V3 also supports these V1-compatible selection options:
+
+- `-profile-fns name1,name2` profiles only the named functions and functions
+  called from them. Use the function names shown in profile output, such as
+  `main__work`.
+- `-profile-no-inline` omits functions marked `@[inline]` from the report.
+- `-d no_profile_startup` excludes calls made during module initialization.
+
+Use the selection options together with `-profile`. The generated profile file
+has lines with 5 columns:
 
 1. How many times a function was called.
 2. How much time in total a function took (in ms).
@@ -6177,8 +6189,8 @@ The generated profile.txt file will have lines with 4 columns:
 4. How much time on average, a call to a function took (in ns).
 5. The name of the v function.
 
-You can sort on column 3 (average time per function) using:
-`sort -n -k3 profile.txt|tail`
+You can sort on column 3 (exclusive time per function) using:
+`sort -n -k3 profile.txt | tail`
 
 You can also use stopwatches to measure just portions of your code explicitly:
 

--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -1270,9 +1270,14 @@ pub fn (a &array) free() {
 	$if prealloc {
 		return
 	}
-	// if a.is_slice {
-	// return
-	// }
+	// A slice is a borrowed view into another array's buffer; its `.data` points
+	// into (not at the start of) that buffer. Freeing it resolves back to the
+	// owner's block (via `.data - .offset`) and frees live memory out from under
+	// the owner. Harmless with the default allocator (the block is still mapped),
+	// but a use-after-free that guard-malloc/ASAN flag. Only the owner frees.
+	if a.flags.has(.is_slice) {
+		return
+	}
 	if a.flags.has(.nofree) {
 		return
 	}

--- a/vlib/v/slow_tests/profile/profile_test.v
+++ b/vlib/v/slow_tests/profile/profile_test.v
@@ -56,7 +56,9 @@ fn test_v_profile_works_when_interrupted() {
 	assert p.status == .closed
 	eprintln('> reading profile_content from ${program_profile} ...')
 	profile_content := os.read_file(program_profile)!
-	assert profile_content.contains('str_intp')
+	// V1 routes this fixed-width interpolation through `str_intp`, while V3
+	// lowers it to `int.str` plus its generated zero-padding helper.
+	assert profile_content.contains('str_intp') || profile_content.contains('int__str')
 	assert profile_content.contains('println')
 	assert profile_content.contains('time__sleep')
 	assert profile_content.contains('main__main')

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -2199,6 +2199,9 @@ fn cli_usage() string {
 		'  -v                           verbose stage profiling\n' +
 		'  -silent                      suppress benchmark output\n' +
 		'  -showcc                      print C compiler commands\n' +
+		'  -profile [file]              write V1-compatible function profile data\n' +
+		'  -profile-fns <names>         profile only named functions and their callees\n' +
+		'  -profile-no-inline           omit @[inline] functions from the profile\n' +
 		'  -no-memory-limit             disable the 2.25 GiB memory safety limit\n' +
 		'  -d <name>                    compile-time define'
 }
@@ -5835,7 +5838,7 @@ fn v3_driver_option_requires_value(option string) bool {
 	return option in ['-o', '-output', '-b', '-backend', '-os', '-arch', '-compile-backend',
 		'--compile-backend', '-d', '-define', '-gc', '-cc', '-thread-stack-size', '-path', '-cov',
 		'-coverage', '-file-list', '-message-limit', '-printfn', '-generate-c-project',
-		'-test-runner', '-run-only']
+		'-test-runner', '-run-only', '-profile-fns']
 }
 
 fn v3_driver_option_consumes_value(option string) bool {
@@ -5848,6 +5851,41 @@ fn apply_v3_diagnostic_color_option(option string) {
 
 fn apply_v3_default_diagnostic_color() {
 	ansi.set_colors_enabled(ansi.stderr_supports_escape_sequences())
+}
+
+fn v3_has_following_positional_arg(args []string, start int) bool {
+	for idx := start; idx < args.len; idx++ {
+		if !args[idx].starts_with('-') {
+			return true
+		}
+	}
+	return false
+}
+
+// Keep the optional `-profile [file]` argument compatible with V1: a lone
+// source path remains the compiler input, while an earlier non-source path is
+// consumed as the profile output when another positional argument follows it.
+fn v3_profile_optional_arg_value(args []string, idx int, command_seen bool) (string, bool) {
+	next := args[idx + 1] or { return '-', false }
+	if next == '-' {
+		return next, true
+	}
+	if next.starts_with('-') {
+		return '-', false
+	}
+	if !command_seen && (next in ['run', 'build', 'test', 'doc'] || next.ends_with('.v')
+		|| next.ends_with('.vsh') || os.is_dir(next)
+		|| !v3_has_following_positional_arg(args, idx + 2)) {
+		return '-', false
+	}
+	return next, true
+}
+
+fn add_v3_profile_used_fns(mut used_fns map[string]bool) {
+	for name in ['time.vpc_now', 'time.vpc_now_darwin', 'v.profile.state', 'v.profile.on',
+		'profile.state', 'profile.on'] {
+		used_fns[name] = true
+	}
 }
 
 // run executes the V3 compiler driver with `args`.
@@ -5971,6 +6009,11 @@ pub fn run(args []string) {
 	mut run_args := []string{}
 	mut run_only := v3_environment_run_only()
 	mut print_fn_names := []string{}
+	mut is_prof := false
+	mut profile_file := ''
+	mut profile_no_inline := false
+	mut profile_fns := []string{}
+	mut command_seen := false
 	environment_c_flags := parse_v3_environment_flags('CFLAGS')
 	environment_ld_flags := parse_v3_environment_flags('LDFLAGS')
 	if environment_c_flags.len > 0 || environment_ld_flags.len > 0 {
@@ -6002,12 +6045,15 @@ pub fn run(args []string) {
 		}
 		if args[i] == 'run' && input_file.len == 0 && !should_run {
 			should_run = true
+			command_seen = true
 			i++
 		} else if args[i] == 'build' && input_file.len == 0 && !should_run {
 			skip_running = true
+			command_seen = true
 			i++
 		} else if args[i] == 'test' && input_file.len == 0 && !should_run {
 			is_test_command = true
+			command_seen = true
 			i++
 		} else if args[i] in ['-o', '-output'] && i + 1 < args.len {
 			output_file = args[i + 1]
@@ -6154,6 +6200,26 @@ pub fn run(args []string) {
 			print_fn_names << args[i + 1].split(',')
 			no_cache = true
 			i += 2
+		} else if args[i] in ['-prof', '-profile'] {
+			parsed_profile_file, profile_file_consumed := v3_profile_optional_arg_value(args, i,
+				command_seen)
+			profile_file = parsed_profile_file
+			is_prof = true
+			no_cache = true
+			if 'profile' !in user_defines {
+				user_defines << 'profile'
+			}
+			i += if profile_file_consumed { 2 } else { 1 }
+		} else if args[i] == '-profile-fns' && i + 1 < args.len {
+			for fn_name in args[i + 1].split(',') {
+				if fn_name.len > 0 {
+					profile_fns << fn_name
+				}
+			}
+			i += 2
+		} else if args[i] == '-profile-no-inline' {
+			profile_no_inline = true
+			i++
 		} else if args[i] == '-path' && i + 1 < args.len {
 			module_search_path_spec = args[i + 1]
 			i += 2
@@ -6342,6 +6408,10 @@ pub fn run(args []string) {
 		// `-no-bounds-checking`, matching the established parser contract.
 		user_defines = user_defines.filter(it.all_before('=').trim_space() != 'no_bounds_checking')
 	}
+	if is_prof && backend != 'c' {
+		eprintln('option `-profile` is only supported by the C backend')
+		exit(1)
+	}
 	should_run = should_run && !skip_running
 	if is_o && (backend != 'c' || !explicit_output || (!output_file.ends_with('.c')
 		&& !output_file.ends_with('.o'))) {
@@ -6356,6 +6426,12 @@ pub fn run(args []string) {
 		no_cache = true
 	}
 	mut current_no_parallel := no_parallel
+	if is_prof {
+		// Profile counters are assigned in function emission order and accumulated
+		// in one generator, just as they are in V1.
+		current_no_parallel = true
+		no_cache = true
+	}
 	if coverage_dir.len > 0 {
 		current_no_parallel = true
 		no_cache = true
@@ -6701,8 +6777,8 @@ pub fn run(args []string) {
 		eprintln('v.pref.lookup_path: ${os.join_path(prefs.vroot, 'vlib')}')
 	}
 	prefs.supports_inline_asm = is_checker_fixture
-	minimal_literal_output := input_uses_minimal_literal_output_builtin(input_file, prefs,
-		is_test_command, is_checker_fixture)
+	minimal_literal_output := !is_prof
+		&& input_uses_minimal_literal_output_builtin(input_file, prefs, is_test_command, is_checker_fixture)
 	host_target := pref.host_target()
 	// `-keepc` and explicit `-b c` promise a complete generated C translation unit.
 	// The module cache splits imported implementations into separate objects, so its main source
@@ -6875,6 +6951,9 @@ pub fn run(args []string) {
 			eprintln('${listed_path} does not exist')
 			exit(1)
 		}
+	}
+	if is_prof {
+		user_files << os.join_path(prefs.vroot, 'vlib', 'v', 'preludes', 'profiled_program.v')
 	}
 	prefs.is_test = user_files.any(is_v3_test_file(it, backend, prefs.target))
 	parse_files_dispatch_profiled(mut p, user_files, !current_no_parallel, mut parse_timing)
@@ -7566,6 +7645,9 @@ pub fn run(args []string) {
 		} else {
 			used_fns, uses_generics = markused.mark_used_with_generic_usage(a, markused_tc)
 		}
+		if is_prof {
+			add_v3_profile_used_fns(mut used_fns)
+		}
 		program_used_fns = clone_string_bool_map(used_fns)
 		if cache_state.manager.enabled && !generic_cache_hit {
 			if building_v {
@@ -7937,6 +8019,9 @@ pub fn run(args []string) {
 				incremental_changed_names[name] = true
 			}
 		}
+		if is_prof {
+			add_v3_profile_used_fns(mut used_fns)
+		}
 		if !building_v && !uses_generics && transformed_used_fns_need_monomorphize(used_fns) {
 			uses_generics = true
 			skip_transform_generics = false
@@ -8143,6 +8228,9 @@ pub fn run(args []string) {
 			exit(1)
 		}
 	}
+	if is_prof {
+		add_v3_profile_used_fns(mut used_fns)
+	}
 	pre_tc.clear_c_type_cache()
 	mut mono_tail_sw := time.new_stopwatch()
 	// Transform and monomorphization can synthesize or rewrite payload text.
@@ -8320,6 +8408,7 @@ pub fn run(args []string) {
 			g.set_show_test_summary(is_test_command)
 			g.set_test_run_only(run_only)
 			g.set_print_fn_names(print_fn_names)
+			g.set_profile(profile_file, profile_no_inline, profile_fns)
 			g.set_shared(prefs.is_shared)
 			g.set_object_file_mode(is_o)
 			g.set_suppress_main('no_main' in prefs.user_defines)
@@ -8370,6 +8459,7 @@ pub fn run(args []string) {
 			g.set_show_test_summary(is_test_command)
 			g.set_test_run_only(run_only)
 			g.set_print_fn_names(print_fn_names)
+			g.set_profile(profile_file, profile_no_inline, profile_fns)
 			g.set_shared(prefs.is_shared)
 			g.set_object_file_mode(is_o)
 			g.set_suppress_main('no_main' in prefs.user_defines)

--- a/vlib/v3/gen/c/array.v
+++ b/vlib/v3/gen/c/array.v
@@ -546,7 +546,11 @@ fn (mut g FlatGen) gen_array_method_call(node flat.Node, fn_node &flat.Node, arr
 	}
 	c_elem := g.value_c_type(elem_type)
 	base_node := g.a.nodes[int(base_id)]
-	is_ptr := receiver_type0 is types.Pointer
+	// A receiver already yields a pointer (e.g. `arc.Arc[[]T].get()` returns
+	// `&[]T`) for any expression kind, not just idents. Detect it uniformly so
+	// `clone` does not take the address of a pointer rvalue (`array__clone(&p)`)
+	// and element accessors dereference correctly.
+	is_ptr := g.usable_expr_type(base_id) is types.Pointer
 	dot := if is_ptr { '->' } else { '.' }
 	match fn_node.value {
 		'clone' {

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -240,6 +240,12 @@ mut:
 	test_run_only                  []string
 	assert_expr_overrides          map[int]string
 	print_fn_names                 []string
+	profile_file                   string
+	profile_no_inline              bool
+	profile_fns                    []string
+	profile_counters               []ProfileCounterMeta
+	profile_fn_active              bool
+	profile_fn_restore_enabled     bool
 	is_prod                        bool
 	check_overflow                 bool
 	ignore_overflow                bool
@@ -924,6 +930,7 @@ pub fn FlatGen.new() FlatGen {
 		fn_seg_chunk_indexes:            []int{}
 		parallel_chunk_wrapper_defs:     []ParallelChunkWrapperDefs{}
 		test_files:                      map[string]bool{}
+		profile_counters:                []ProfileCounterMeta{}
 		coverage_files:                  map[string]&CoverageInfo{}
 		cache_program_files:             map[string]bool{}
 		incremental_fn_names:            map[string]bool{}
@@ -1138,6 +1145,13 @@ pub fn (mut g FlatGen) set_test_run_only(patterns []string) {
 // set_print_fn_names selects generated C functions to print to stdout.
 pub fn (mut g FlatGen) set_print_fn_names(names []string) {
 	g.print_fn_names = names.clone()
+}
+
+// set_profile configures V1-compatible per-function runtime profiling.
+pub fn (mut g FlatGen) set_profile(file string, no_inline bool, fn_names []string) {
+	g.profile_file = file
+	g.profile_no_inline = no_inline
+	g.profile_fns = fn_names.clone()
 }
 
 // set_shared configures shared-library entry point generation.
@@ -2105,6 +2119,11 @@ fn (g &FlatGen) cleanup_scoped_output_files(stream_path string, fn_stream_path s
 
 // gen_with_used_options emits with used options output for c.
 pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[string]bool, tc &types.TypeChecker, no_parallel bool) string {
+	effective_no_parallel := no_parallel || g.profile_file.len > 0
+	if g.profile_file.len > 0 {
+		// Counter metadata and numbering are accumulated by one serial generator.
+		g.scope_parallel_workers = false
+	}
 	g.a = a
 	// Mark-used is immutable during cgen. Sharing this potentially very large
 	// post-monomorph map matches the worker path and avoids a full-program clone
@@ -2127,6 +2146,9 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	g.parallel_support_ready = false
 	g.coverage_files.clear()
 	g.coverage_counter_count = 0
+	g.profile_counters = []ProfileCounterMeta{}
+	g.profile_fn_active = false
+	g.profile_fn_restore_enabled = false
 	g.str_lits = []string{}
 	g.str_lits_shared = false
 	g.defers = []flat.NodeId{}
@@ -2356,14 +2378,14 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 		g.precompute_embedded_fields()
 		g.timing_profile('  [ttime]   cg preseeds      ${f64(cgsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 		cgsw.restart()
-		parallel_prep_done := g.run_pre_dispatch_parallel(no_parallel)
+		parallel_prep_done := g.run_pre_dispatch_parallel(effective_no_parallel)
 		g.timing_profile('  [ttime]   cg predispatch   ${f64(cgsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 		cgsw.restart()
 		if !parallel_prep_done {
 			g.collect_fixed_storage_consts(false)
 			g.precompute_param_type_index()
 			g.precompute_concrete_optional_abi_fns()
-			if no_parallel {
+			if effective_no_parallel {
 				g.prepare_serial_fn_tables()
 			}
 		}
@@ -2399,8 +2421,8 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	}
 	g.precompute_ownership_recursive_drop_helpers()
 	g.precompute_fixed_array_map_key_types()
-	defer_parallel_support := g.scope_parallel_workers && !no_parallel && !g.program_body_only
-		&& g.incremental_fn_names.len == 0
+	defer_parallel_support := g.scope_parallel_workers && !effective_no_parallel
+		&& !g.program_body_only && g.incremental_fn_names.len == 0
 	mut const_code := if g.program_body_only || defer_parallel_support {
 		''
 	} else {
@@ -2412,7 +2434,7 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	orig_line_start := g.line_start
 	g.sb = strings.new_builder(4096)
 	g.line_start = true
-	g.gen_fns_dispatch(no_parallel)
+	g.gen_fns_dispatch(effective_no_parallel)
 	g.writeln('// THE END.')
 	g.timing_profile('  [ttime] cg fns dispatch    ${f64(cgsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 	cgsw.restart()
@@ -2488,6 +2510,9 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	// Leave headroom for the small body-dependent supplement emitted below.
 	g.sb.ensure_cap(known_output_len + 1_048_576) // 1 MiB
 	g.c99_feature_test_macros()
+	if g.profile_file.len > 0 {
+		g.writeln('#define _VPROFILE (1)')
+	}
 	g.thread_stack_size_definition()
 	g.emit_preinclude_directives()
 	g.emit_preserved_c_directives()
@@ -2516,6 +2541,7 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	g.builtin_abi_decls()
 	g.test_failure_helpers()
 	g.global_decls()
+	g.gen_profile_support()
 	g.emit_coverage_support()
 	// Objective-C implementation files commonly use complete V structs in their
 	// function signatures and bodies. Their framework imports are lifted above
@@ -10297,12 +10323,21 @@ fn (mut g FlatGen) gen_expr_with_expected_type(id flat.NodeId, expected types.Ty
 			return
 		}
 	}
+	mut pointer_actual := actual
+	if node.kind == .call && actual !is types.Pointer {
+		declared := g.declared_call_return_type(id)
+		if declared is types.Pointer {
+			pointer_actual = declared
+		}
+	}
 	if !expected_is_shared_alias && expected !is types.Pointer && expected !is types.Void
-		&& expected !is types.OptionType && expected !is types.ResultType && actual is types.Pointer
-		&& (g.type_names_match(actual.base_type, expected)
-		|| g.type_names_match(actual.base_type, semantic_expected)) && !(node.kind == .ident
-		&& g.local_storage_is_shared(node.value)) && !(node.kind == .char_literal
-		&& node.value.starts_with('c:')) {
+		&& expected !is types.OptionType && expected !is types.ResultType
+		&& pointer_actual is types.Pointer
+		&& (g.type_names_match(pointer_actual.base_type, expected)
+		|| g.type_names_match(pointer_actual.base_type, semantic_expected)
+		|| g.value_c_type(pointer_actual.base_type) == g.value_c_type(semantic_expected))
+		&& !(node.kind == .ident && g.local_storage_is_shared(node.value))
+		&& !(node.kind == .char_literal && node.value.starts_with('c:')) {
 		needs_paren := node.kind !in [.ident, .selector, .call, .index]
 		g.write('*')
 		if needs_paren {
@@ -16759,6 +16794,7 @@ fn (mut g FlatGen) headerless_platform_constants() {
 }
 
 fn (mut g FlatGen) headerless_signal_constants() {
+	g.writeln('#define SIGINT 2')
 	g.writeln('#define SIGKILL 9')
 	g.writeln('#define SIGTERM 15')
 	g.writeln('#define SIGPIPE 13')
@@ -19851,10 +19887,20 @@ fn (mut g FlatGen) emit_const(name string, val_id flat.NodeId) {
 		g.tc.cur_module = old_module
 		return
 	}
-	v_type := if val_node.kind == .offsetof_expr {
+	mut v_type := if val_node.kind == .offsetof_expr {
 		types.Type(types.usize_)
 	} else {
 		g.const_storage_type_for_value(name, val_id, g.tc.resolve_type(val_id))
+	}
+	// A const initialised by a generic call (e.g. `stdatomic.new_atomic(0)`)
+	// keeps the generic return type `&AtomicVal[T]`. The initializer is already
+	// monomorphized, so recover the concrete storage type from it to avoid
+	// emitting an undeclared `AtomicVal_T`.
+	if g.type_contains_generic_placeholder(v_type) {
+		concrete := g.usable_expr_type(val_id)
+		if !g.type_contains_generic_placeholder(concrete) {
+			v_type = concrete
+		}
 	}
 	mut ct := if v_type is types.OptionType || v_type is types.ResultType {
 		g.optional_type_name(v_type)

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -557,6 +557,11 @@ fn (mut g FlatGen) gen_no_main_runtime_init_caller() {
 	g.writeln('static void _vno_main_init_caller(void) {')
 	g.writeln('\tif (_v3_no_main_initialized) { return; }')
 	g.writeln('\t_v3_no_main_initialized = true;')
+	if g.has_builtins {
+		g.writeln('\tg_main_argc = 0;')
+		g.writeln('\tg_main_argv = NULL;')
+	}
+	g.gen_profile_startup_enable()
 	if g.runtime_init_is_needed() {
 		g.writeln('\t_vinit();')
 	}
@@ -4312,10 +4317,12 @@ fn (mut g FlatGen) gen_fn_in_module(node_id flat.NodeId, node flat.Node, module_
 		}
 		g.gen_compiler_vexe_env_setup()
 		g.gen_coverage_registration()
+		g.gen_profile_startup_enable()
 		if g.const_runtime_inits.len > 0 || g.runtime_inits.len > 0 || g.module_init_fns.len > 0
 			|| g.global_inits.len > 0 {
 			g.writeln('\t_vinit();')
 		}
+		g.gen_profile_registration()
 		g.gen_executable_cleanup_registration()
 	} else {
 		ret_type := g.fn_node_return_type(node, module_name)
@@ -4343,6 +4350,8 @@ fn (mut g FlatGen) gen_fn_in_module(node_id flat.NodeId, node flat.Node, module_
 		g.writeln('_vno_main_init_caller();')
 	}
 	g.gen_function_defer_prelude()
+	g.gen_profile_fn_begin(generated_fn_name, module_name, node.value, g.tc.declaration_has_attribute(node_id,
+		'inline'))
 
 	for i in 0 .. node.children_count {
 		id := g.a.child(&node, i)
@@ -4353,6 +4362,7 @@ fn (mut g FlatGen) gen_fn_in_module(node_id flat.NodeId, node flat.Node, module_
 		}
 	}
 	g.gen_all_defers()
+	g.gen_profile_fn_exit()
 	g.gen_ownership_drops(g.tc.ownership_drop_entries_at_fn_exit(qualify_name_in_module(module_name,
 		node.value)))
 	if is_entry_main {
@@ -4572,6 +4582,7 @@ fn (mut g FlatGen) gen_top_level_main(stmts []TopLevelStmt) {
 	}
 	g.gen_compiler_vexe_env_setup()
 	g.gen_coverage_registration()
+	g.gen_profile_startup_enable()
 	if g.needs_no_main_runtime_init_caller() {
 		// Exported callbacks can be invoked without main. Share their guarded
 		// initializer so main and callback startup cannot initialize twice.
@@ -4582,14 +4593,17 @@ fn (mut g FlatGen) gen_top_level_main(stmts []TopLevelStmt) {
 		}
 		g.gen_executable_cleanup_registration()
 	}
+	g.gen_profile_registration()
 	g.indent++
 	g.gen_function_defer_prelude()
+	g.gen_profile_fn_begin('main', 'main', 'main', false)
 	for stmt in stmts {
 		g.tc.cur_file = stmt.file
 		g.tc.cur_module = stmt.module
 		g.gen_top_level_main_stmt(stmt.id)
 	}
 	g.gen_all_defers()
+	g.gen_profile_fn_exit()
 	g.writeln('return 0;')
 	g.indent--
 	g.writeln('}')
@@ -4663,10 +4677,12 @@ fn (mut g FlatGen) gen_test_main() {
 	}
 	g.gen_compiler_vexe_env_setup()
 	g.gen_coverage_registration()
+	g.gen_profile_startup_enable()
 	if g.const_runtime_inits.len > 0 || g.runtime_inits.len > 0 || g.module_init_fns.len > 0
 		|| g.global_inits.len > 0 {
 		g.writeln('\t_vinit();')
 	}
+	g.gen_profile_registration()
 	g.gen_executable_cleanup_registration()
 	g.indent++
 	if g.show_test_stats && tests.len > 0 {
@@ -5631,8 +5647,12 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 			}
 		}
 	}
-	// Ownership lowering appends its calls after checking, so they have no source position.
+	// Ownership lowering appends calls after checking, while a generic builtin
+	// drop specialized inside another module can retain its original source
+	// position. Recognize both forms by their resolved/synthetic names.
 	is_ownership_drop := (!node.pos.is_valid() && ownership_synthetic_drop_name(fn_name))
+		|| g.ownership_drop_intrinsic_name(fn_name)
+		|| (target_name.len > 0 && g.ownership_drop_intrinsic_name(target_name))
 		|| (resolved_target_name.len > 0 && g.ownership_drop_intrinsic_name(resolved_target_name))
 	if node.children_count == 2 && is_ownership_drop {
 		arg_id := g.a.child(&node, 1)
@@ -7192,8 +7212,30 @@ fn (g &FlatGen) ownership_drop_intrinsic_name(name string) bool {
 	if !ownership_synthetic_drop_name(name) {
 		return false
 	}
-	module_name := g.tc.fn_type_modules[name] or { return false }
-	return module_name == 'builtin'
+	if module_name := g.tc.fn_type_modules[name] {
+		return module_name == 'builtin'
+	}
+	// A generic builtin drop can be specialized while transforming another
+	// module (for example `sync.arc.Arc[[]string].drop`). Its concrete name is
+	// synthesized after signature collection, so only the generic declaration
+	// is present in `fn_type_modules`.
+	base_name := if name.starts_with('drop_owned_v3_interface_T_') {
+		'drop_owned_v3_interface'
+	} else if name.starts_with('drop_owned_T_') {
+		'drop_owned'
+	} else {
+		name
+	}
+	for candidate in [base_name, 'builtin.${base_name}', 'builtin__${base_name}'] {
+		if module_name := g.tc.fn_type_modules[candidate] {
+			if module_name == 'builtin' {
+				return true
+			}
+		}
+	}
+	// Unqualified `drop_owned_T_*` names are reserved for these generated
+	// specializations. User functions resolve with their module prefix.
+	return name.starts_with('drop_owned_T_') || name.starts_with('drop_owned_v3_interface_T_')
 }
 
 fn (mut g FlatGen) gen_fixed_array_get_call(node flat.Node, fn_name string, target_name string) bool {
@@ -7676,16 +7718,23 @@ fn (mut g FlatGen) gen_interface_method_call(node flat.Node, fn_node flat.Node, 
 		return false
 	}
 	iface := clean as types.Interface
-	if g.is_ierror_type_name(iface.name) {
+	mut iface_name := iface.name
+	base_name, _, is_generic_iface := g.shared_generic_app_parts(iface_name)
+	if is_generic_iface {
+		// A specialized generic interface dispatches through the base
+		// interface's runtime box and method table.
+		iface_name = base_name
+	}
+	if g.is_ierror_type_name(iface_name) {
 		return false
 	}
-	if iface.name !in g.interfaces {
+	if iface_name !in g.interfaces {
 		return false
 	}
 	if _ := g.field_type(base_type, fn_node.value) {
 		return false
 	}
-	method_name := '${iface.name}.${fn_node.value}'
+	method_name := '${iface_name}.${fn_node.value}'
 	param_types := g.interface_method_param_types(method_name) or { []types.Type{} }
 	base_id := g.a.child(fn_node, 0)
 	g.write(g.cname(method_name))
@@ -9770,10 +9819,19 @@ fn (mut g FlatGen) precompute_concrete_optional_abi_fns() {
 			continue
 		}
 		params := g.fn_node_param_types_or_decl(node, cur_module)
-		if !params_have_optional_result(params) {
+		ret_type := g.fn_node_return_type(node, cur_module)
+		if !params_have_optional_result(params) && !type_is_optional_result(ret_type) {
 			continue
 		}
 		g.register_concrete_optional_abi_fn(cur_module, node.value)
+		for param in params {
+			if type_is_optional_result(param) {
+				g.concrete_optional_type_name(param)
+			}
+		}
+		if type_is_optional_result(ret_type) {
+			g.concrete_optional_type_name(ret_type)
+		}
 	}
 }
 

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -565,6 +565,7 @@ fn (mut g FlatGen) gen_no_main_runtime_init_caller() {
 	if g.runtime_init_is_needed() {
 		g.writeln('\t_vinit();')
 	}
+	g.gen_profile_registration()
 	if !g.is_shared {
 		g.gen_executable_cleanup_registration()
 	}
@@ -4583,7 +4584,8 @@ fn (mut g FlatGen) gen_top_level_main(stmts []TopLevelStmt) {
 	g.gen_compiler_vexe_env_setup()
 	g.gen_coverage_registration()
 	g.gen_profile_startup_enable()
-	if g.needs_no_main_runtime_init_caller() {
+	needs_no_main_runtime_init_caller := g.needs_no_main_runtime_init_caller()
+	if needs_no_main_runtime_init_caller {
 		// Exported callbacks can be invoked without main. Share their guarded
 		// initializer so main and callback startup cannot initialize twice.
 		g.writeln('\t_vno_main_init_caller();')
@@ -4593,7 +4595,9 @@ fn (mut g FlatGen) gen_top_level_main(stmts []TopLevelStmt) {
 		}
 		g.gen_executable_cleanup_registration()
 	}
-	g.gen_profile_registration()
+	if !needs_no_main_runtime_init_caller {
+		g.gen_profile_registration()
+	}
 	g.indent++
 	g.gen_function_defer_prelude()
 	g.gen_profile_fn_begin('main', 'main', 'main', false)

--- a/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
@@ -870,6 +870,9 @@ fn clone_embedded_fields_by_type(values map[string][]types.StructField) map[stri
 }
 
 fn (mut g FlatGen) publish_fixed_storage_scan(mut fs_worker FlatGen) {
+	for opt_name, val_type in fs_worker.needed_optional_types {
+		g.needed_optional_types[opt_name.clone()] = val_type.clone()
+	}
 	if fs_worker.worker_scope == unsafe { nil } {
 		g.fixed_storage_consts = fs_worker.fixed_storage_consts.clone()
 		g.param_types_by_short = fs_worker.param_types_by_short.move()

--- a/vlib/v3/gen/c/interface.v
+++ b/vlib/v3/gen/c/interface.v
@@ -229,11 +229,13 @@ fn (g &FlatGen) interface_arg_conversion_expr(name string, source_type types.Typ
 }
 
 fn (g &FlatGen) interface_method_signature_key(iface_name string, method string) ?string {
-	key := '${iface_name}.${method}'
+	base, _, is_generic := g.shared_generic_app_parts(iface_name)
+	metadata_name := if is_generic { base } else { iface_name }
+	key := '${metadata_name}.${method}'
 	if key in g.tc.fn_ret_types || key in g.tc.fn_param_types {
 		return key
 	}
-	for embed in g.tc.interface_embeds[iface_name] or { []string{} } {
+	for embed in g.tc.interface_embeds[metadata_name] or { []string{} } {
 		if found := g.interface_method_signature_key(embed, method) {
 			return found
 		}
@@ -665,7 +667,10 @@ fn (mut g FlatGen) collect_interface_impls() {
 
 fn (g &FlatGen) interface_dispatch_return_type(decl_key string, concrete_key string) types.Type {
 	decl_type := g.tc.fn_ret_types[decl_key] or { types.Type(types.void_) }
-	if !g.type_contains_generic_placeholder(decl_type) || concrete_key.len == 0 {
+	wrapped_base := interface_dispatch_wrapped_base_type(decl_type) or { types.Type(types.void_) }
+	needs_concrete := g.type_contains_generic_placeholder(decl_type)
+		|| wrapped_base is types.Unknown || wrapped_base is types.Void
+	if !needs_concrete || concrete_key.len == 0 {
 		return decl_type
 	}
 	return g.tc.fn_ret_types[concrete_key] or { decl_type }
@@ -679,14 +684,22 @@ fn (g &FlatGen) interface_dispatch_param_types(decl_key string, concrete_key str
 		[]types.Type{}
 	}
 	mut decl_has_generic := false
-	for param in decl_params {
+	mut generic_params_use_pointer_abi := true
+	for i, param in decl_params {
 		if g.type_contains_generic_placeholder(param) {
 			decl_has_generic = true
-			break
+			// A generic interface has one runtime box for every specialization.
+			// Generic parameters passed through pointers therefore need one stable
+			// erased ABI instead of inheriting the first discovered implementer's
+			// concrete pointer type. `void *` is lossless for every such parameter;
+			// by-value generic parameters still require a concrete ABI below.
+			if i > 0 && param !is types.Pointer {
+				generic_params_use_pointer_abi = false
+			}
 		}
 	}
-	if concrete_params.len > 0
-		&& (decl_has_generic || decl_params.len == 0 || decl_params.len != concrete_params.len) {
+	if concrete_params.len > 0 && ((decl_has_generic && !generic_params_use_pointer_abi)
+		|| decl_params.len == 0 || decl_params.len != concrete_params.len) {
 		return concrete_params
 	}
 	return decl_params
@@ -1416,20 +1429,10 @@ fn (g &FlatGen) interface_object_expr_is_boxed(id flat.NodeId) bool {
 // implementation, passing `_object` as the receiver. Interfaces with no known
 // implementers (and the special builtin `IError`) fall back to a panic stub.
 fn (mut g FlatGen) interface_method_stubs() {
-	mut wrote_prototype := false
-	for iface_name, methods in g.interfaces {
-		cn := g.cname(iface_name)
-		for method in methods {
-			if !g.should_emit_interface_dispatch(iface_name, method) {
-				continue
-			}
-			g.writeln('${g.interface_dispatch_signature(iface_name, cn, method)};')
-			wrote_prototype = true
-		}
-	}
-	if wrote_prototype {
-		g.writeln('')
-	}
+	// `interface_method_forward_decls` has already declared every dispatch stub.
+	// Recomputing the declarations here can observe a different current-module
+	// context after `_vinit` generation and give a generic interface placeholder a
+	// different C signature from its specialized forward declaration.
 	for iface_name, methods in g.interfaces {
 		cn := g.cname(iface_name)
 		for method in methods {
@@ -1724,9 +1727,13 @@ fn (mut g FlatGen) gen_interface_dispatch_with_fallback(iface_name string, cn st
 				call += ')'
 				if ret_ct == 'void' {
 					g.writeln('${call}; return;')
+				} else if g.gen_interface_dispatch_optional_abi_return(call, ret_type, g.tc.fn_ret_types[decl] or {
+					ret_type
+				}, decl)
+				{
 				} else if g.gen_interface_dispatch_wrapped_return(call, ret_type, g.tc.fn_ret_types[decl] or {
 					ret_type
-				})
+				}, decl)
 				{
 				} else {
 					g.writeln('return ${call};')
@@ -1782,9 +1789,13 @@ fn (mut g FlatGen) gen_interface_dispatch_with_fallback(iface_name string, cn st
 			call += ')'
 			if ret_ct == 'void' {
 				g.writeln('${call}; return;')
+			} else if g.gen_interface_dispatch_optional_abi_return(call, ret_type, g.tc.fn_ret_types[method_key] or {
+				ret_type
+			}, method_key)
+			{
 			} else if g.gen_interface_dispatch_wrapped_return(call, ret_type, g.tc.fn_ret_types[method_key] or {
 				ret_type
-			})
+			}, method_key)
 			{
 			} else {
 				g.writeln('return ${call};')
@@ -1804,9 +1815,42 @@ fn (mut g FlatGen) gen_interface_dispatch_with_fallback(iface_name string, cn st
 	g.writeln('}')
 }
 
+// gen_interface_dispatch_optional_abi_return adapts specialized generic methods
+// whose option/result C ABI differs from the interface dispatch ABI.
+fn (mut g FlatGen) gen_interface_dispatch_optional_abi_return(call string, expected types.Type, actual types.Type, actual_key string) bool {
+	expected_wrapped := optional_result_unalias_type(expected)
+	actual_wrapped := optional_result_unalias_type(actual)
+	if (expected_wrapped is types.OptionType) != (actual_wrapped is types.OptionType)
+		|| (expected_wrapped is types.ResultType) != (actual_wrapped is types.ResultType) {
+		return false
+	}
+	expected_base := interface_dispatch_wrapped_base_type(expected) or { return false }
+	actual_base := interface_dispatch_wrapped_base_type(actual) or { return false }
+	if expected_base is types.Void || expected_base is types.Unknown || actual_base is types.Void
+		|| actual_base is types.Unknown {
+		return false
+	}
+	if !g.type_names_match(actual_base, expected_base)
+		&& g.value_c_type(actual_base) != g.value_c_type(expected_base) {
+		return false
+	}
+	expected_ct := g.fn_return_type_name_for_context(expected, false)
+	actual_ct := g.fn_return_type_name_for_context(actual,
+		g.call_uses_concrete_optional_params(actual_key))
+	if actual_ct == expected_ct {
+		return false
+	}
+	result := g.interface_tmp('iface_abi_result')
+	g.writeln('{')
+	g.writeln('\t\t\t${actual_ct} ${result} = ${call};')
+	g.writeln('\t\t\treturn (${expected_ct}){ .ok = ${result}.ok, .err = ${result}.err, .value = ${result}.value };')
+	g.writeln('\t\t}')
+	return true
+}
+
 // gen_interface_dispatch_wrapped_return adapts an option/result whose successful
 // concrete payload implements the interface returned by the dispatch signature.
-fn (mut g FlatGen) gen_interface_dispatch_wrapped_return(call string, expected types.Type, actual types.Type) bool {
+fn (mut g FlatGen) gen_interface_dispatch_wrapped_return(call string, expected types.Type, actual types.Type, actual_key string) bool {
 	if !g.interface_dispatch_wrapped_return_can_adapt(expected, actual) {
 		return false
 	}
@@ -1826,8 +1870,9 @@ fn (mut g FlatGen) gen_interface_dispatch_wrapped_return(call string, expected t
 	if type_id == 0 {
 		return false
 	}
-	actual_ct := g.fn_return_type_name(actual)
-	expected_ct := g.fn_return_type_name(expected)
+	actual_ct := g.fn_return_type_name_for_context(actual,
+		g.call_uses_concrete_optional_params(actual_key))
+	expected_ct := g.fn_return_type_name_for_context(expected, false)
 	iface_ct := g.tc.c_type(expected_iface_type)
 	concrete_ct := g.tc.c_type(actual_value)
 	result := g.interface_tmp('iface_result')
@@ -1886,6 +1931,9 @@ fn interface_dispatch_wrapped_base_type(typ types.Type) ?types.Type {
 }
 
 fn (mut g FlatGen) interface_dispatch_param_c_type(typ types.Type) string {
+	if typ is types.Pointer && g.type_contains_generic_placeholder(typ) {
+		return 'void*'
+	}
 	mut ct := if typ is types.OptionType || typ is types.ResultType {
 		g.optional_type_name(typ)
 	} else {

--- a/vlib/v3/gen/c/interface.v
+++ b/vlib/v3/gen/c/interface.v
@@ -1815,6 +1815,21 @@ fn (mut g FlatGen) gen_interface_dispatch_with_fallback(iface_name string, cn st
 	g.writeln('}')
 }
 
+// gen_interface_dispatch_optional_abi_value_return emits the adapted wrapper return
+// after a specialized generic method and its interface dispatch use different C ABIs.
+fn (mut g FlatGen) gen_interface_dispatch_optional_abi_value_return(expected_ct string, result string, expected_base types.Type) {
+	if _ := array_fixed_type(expected_base) {
+		out := g.interface_tmp('iface_abi_result_out')
+		g.writeln('\t\t\t${expected_ct} ${out} = { .ok = ${result}.ok, .err = ${result}.err };')
+		g.writeln('\t\t\tif (${result}.ok) {')
+		g.writeln('\t\t\t\tmemcpy(${out}.value, ${result}.value, sizeof(${out}.value));')
+		g.writeln('\t\t\t}')
+		g.writeln('\t\t\treturn ${out};')
+	} else {
+		g.writeln('\t\t\treturn (${expected_ct}){ .ok = ${result}.ok, .err = ${result}.err, .value = ${result}.value };')
+	}
+}
+
 // gen_interface_dispatch_optional_abi_return adapts specialized generic methods
 // whose option/result C ABI differs from the interface dispatch ABI.
 fn (mut g FlatGen) gen_interface_dispatch_optional_abi_return(call string, expected types.Type, actual types.Type, actual_key string) bool {
@@ -1843,7 +1858,7 @@ fn (mut g FlatGen) gen_interface_dispatch_optional_abi_return(call string, expec
 	result := g.interface_tmp('iface_abi_result')
 	g.writeln('{')
 	g.writeln('\t\t\t${actual_ct} ${result} = ${call};')
-	g.writeln('\t\t\treturn (${expected_ct}){ .ok = ${result}.ok, .err = ${result}.err, .value = ${result}.value };')
+	g.gen_interface_dispatch_optional_abi_value_return(expected_ct, result, expected_base)
 	g.writeln('\t\t}')
 	return true
 }

--- a/vlib/v3/gen/c/profile.v
+++ b/vlib/v3/gen/c/profile.v
@@ -1,0 +1,190 @@
+module c
+
+struct ProfileCounterMeta {
+	fn_name      string
+	counter_name string
+	calls_name   string
+}
+
+fn (g &FlatGen) profile_enabled_c_name() string {
+	for name, _ in g.global_types {
+		if name == 'v__profile_enabled' || name.ends_with('.v__profile_enabled') {
+			return g.global_c_name(name)
+		}
+	}
+	return g.cname('profile.v__profile_enabled')
+}
+
+fn (g &FlatGen) profile_timer_c_name() string {
+	return if g.target.os == 'macos' { 'time__vpc_now_darwin' } else { 'time__vpc_now' }
+}
+
+fn (g &FlatGen) profile_v1_fn_name(module_name string, fn_name string) string {
+	module_cname := if module_name.len == 0 || module_name == 'main' {
+		'main'
+	} else {
+		g.cname(module_name)
+	}
+	mut short_name := fn_name
+	if module_name.len > 0 && short_name.starts_with('${module_name}.') {
+		short_name = short_name[module_name.len + 1..]
+	}
+	return '${module_cname}__${g.cname(short_name.replace('.', '_'))}'
+}
+
+fn (mut g FlatGen) gen_profile_fn_begin(cfn_name string, module_name string, fn_name string, is_inline bool) {
+	g.profile_fn_active = false
+	g.profile_fn_restore_enabled = false
+	if g.profile_file.len == 0 || (g.profile_no_inline && is_inline)
+		|| fn_name.starts_with('time.vpc_now') || fn_name.starts_with('v.profile.')
+		|| fn_name.starts_with('profile.') || cfn_name.starts_with('time__vpc_now')
+		|| cfn_name.starts_with('profile__') || cfn_name.starts_with('v__profile__') {
+		return
+	}
+	// Prefix the counter names with a unique per-function index. Without it the derived
+	// names collide: a function `…__lower`'s call counter is `vpc_…__lower_calls` (u64),
+	// which is identical to a function `…__lower_calls`'s time accumulator `vpc_…__lower_calls`
+	// (double) — a "redefinition with a different type" C error. The same holds for the
+	// `_only_current` suffix. The index makes every base name unambiguous.
+	counter_name := 'vpc_${g.profile_counters.len}_${cfn_name}'
+	calls_name := '${counter_name}_calls'
+	profile_fn_name := g.profile_v1_fn_name(module_name, fn_name)
+	g.profile_fn_active = true
+	g.profile_fn_restore_enabled = g.profile_fns.len > 0 && profile_fn_name in g.profile_fns
+	profile_enabled := g.profile_enabled_c_name()
+	if g.profile_fn_restore_enabled {
+		g.writeln('bool _prev_v__profile_enabled = ${profile_enabled};')
+		g.writeln('${profile_enabled} = true;')
+	}
+	g.writeln('double _PROF_FN_START = ${g.profile_timer_c_name()}();')
+	g.writeln('double _PROF_PREV_MEASURED_TIME = prof_measured_time;')
+	g.writeln('if (${profile_enabled}) { ${calls_name}++; } // ${profile_fn_name}')
+	g.profile_counters << ProfileCounterMeta{
+		fn_name:      profile_fn_name
+		counter_name: counter_name
+		calls_name:   calls_name
+	}
+}
+
+fn (mut g FlatGen) gen_profile_fn_exit() {
+	if !g.profile_fn_active {
+		return
+	}
+	pc := g.profile_counters.last()
+	profile_enabled := g.profile_enabled_c_name()
+	g.writeln('if (${profile_enabled}) {')
+	g.indent++
+	g.writeln('double _PROF_ELAPSED = ${g.profile_timer_c_name()}() - _PROF_FN_START;')
+	g.writeln('${pc.counter_name} += _PROF_ELAPSED;')
+	g.writeln('${pc.counter_name}_only_current += _PROF_ELAPSED - (prof_measured_time - _PROF_PREV_MEASURED_TIME);')
+	g.writeln('prof_measured_time = _PROF_PREV_MEASURED_TIME + _PROF_ELAPSED;')
+	g.indent--
+	g.writeln('}')
+	if g.profile_fn_restore_enabled {
+		g.writeln('${profile_enabled} = _prev_v__profile_enabled;')
+	}
+}
+
+fn (mut g FlatGen) gen_profile_registration() {
+	if g.profile_file.len == 0 {
+		return
+	}
+	g.writeln('\tv_signal_with_handler_cast(SIGINT, vprint_profile_stats_on_signal);')
+	g.writeln('\tv_signal_with_handler_cast(SIGTERM, vprint_profile_stats_on_signal);')
+	g.writeln('\tatexit(vprint_profile_stats);')
+	if 'no_profile_startup' in g.compile_values || g.profile_fns.len > 0 {
+		g.writeln('\tvreset_profile_stats();')
+	}
+	if g.profile_fns.len > 0 {
+		// v__profile_enabled will be set true *inside* the fns in g.profile_fns:
+		g.writeln('\t${g.profile_enabled_c_name()} = false;')
+	}
+}
+
+fn (mut g FlatGen) gen_profile_startup_enable() {
+	if g.profile_file.len > 0 {
+		g.writeln('\t${g.profile_enabled_c_name()} = true;')
+	}
+}
+
+fn (mut g FlatGen) gen_profile_support() {
+	if g.profile_file.len == 0 {
+		return
+	}
+	// The profiling timer is forced into the used-function set even when user
+	// code does not import `time`. Keep its platform C function declarations
+	// available in that minimal program too. The V-generated Mach struct already
+	// exists here, so including the system header would redefine it.
+	if g.target.os == 'macos' {
+		g.writeln('extern u64 mach_absolute_time(void);')
+		g.writeln('extern int mach_timebase_info(mach_timebase_info_data_t*);')
+	}
+	g.writeln('// V profile counters:')
+	for pc in g.profile_counters {
+		g.writeln('double ${pc.counter_name} = 0.0; double ${pc.counter_name}_only_current = 0.0; u64 ${pc.calls_name} = 0;')
+	}
+	g.writeln('// V profile thread local:')
+	g.writeln('#if defined(__TINYC__)')
+	g.writeln('/* TinyCC on Darwin does not implement working TLS; profiling is already documented as not thread safe. */')
+	g.writeln('#elif defined(__cplusplus) && __cplusplus >= 201103L')
+	g.writeln('#define PROF_THREAD_LOCAL thread_local')
+	g.writeln('#elif defined(__GNUC__) && __GNUC__ < 5')
+	g.writeln('#define PROF_THREAD_LOCAL __thread')
+	g.writeln('#elif defined(_MSC_VER)')
+	g.writeln('#define PROF_THREAD_LOCAL __declspec(thread)')
+	g.writeln('#elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L && !defined(__STDC_NO_THREADS__)')
+	g.writeln('#define PROF_THREAD_LOCAL _Thread_local')
+	g.writeln('#endif')
+	g.writeln('#ifndef PROF_THREAD_LOCAL')
+	g.writeln('#if defined(__GNUC__) && !defined(__TINYC__)')
+	g.writeln('#define PROF_THREAD_LOCAL __thread')
+	g.writeln('#endif')
+	g.writeln('#endif')
+	g.writeln('#ifdef PROF_THREAD_LOCAL')
+	g.writeln('static PROF_THREAD_LOCAL double prof_measured_time = 0.0;')
+	g.writeln('#else')
+	g.writeln('double prof_measured_time = 0.0; // multithreaded: wrong values for func times without its children')
+	g.writeln('#endif')
+	g.writeln('void vprint_profile_stats(void) {')
+	g.indent++
+	g.writeln('double f = 1.0;')
+	if g.target.os == 'windows' {
+		// QueryPerformanceCounter() / QueryPerformanceFrequency()
+		// https://learn.microsoft.com/en-us/windows/win32/sysinfo/acquiring-high-resolution-time-stamps
+		g.writeln('u64 freq_time = 0;')
+		g.writeln('QueryPerformanceFrequency((void*)(&freq_time));')
+		g.writeln('f = (double)1000000000.0 / (double)freq_time;')
+	}
+	fstring := '"%14llu %14.3fms %14.3fms %14.0fns %s \\n"'
+	if g.profile_file == '-' {
+		for pc in g.profile_counters {
+			g.writeln('if (${pc.calls_name}) printf(${fstring}, ${pc.calls_name}, (${pc.counter_name} * f) / 1000000.0, (${pc.counter_name}_only_current * f) / 1000000.0, (${pc.counter_name} * f) / ${pc.calls_name}, "${c_escape(pc.fn_name)}");')
+		}
+	} else {
+		g.writeln('FILE* fp;')
+		g.writeln('fp = fopen("${c_escape(g.profile_file)}", "w+");')
+		for pc in g.profile_counters {
+			g.writeln('if (${pc.calls_name}) fprintf(fp, ${fstring}, ${pc.calls_name}, (${pc.counter_name} * f) / 1000000.0, (${pc.counter_name}_only_current * f) / 1000000.0, (${pc.counter_name} * f) / ${pc.calls_name}, "${c_escape(pc.fn_name)}");')
+		}
+		g.writeln('fclose(fp);')
+	}
+	g.indent--
+	g.writeln('}')
+	g.writeln('')
+	g.writeln('void vreset_profile_stats(void) {')
+	g.indent++
+	for pc in g.profile_counters {
+		g.writeln('${pc.calls_name} = 0;')
+		g.writeln('${pc.counter_name} = 0.0;')
+	}
+	g.indent--
+	g.writeln('}')
+	g.writeln('')
+	g.writeln('void vprint_profile_stats_on_signal(int sig) {')
+	g.indent++
+	g.writeln('(void)sig;')
+	g.writeln('exit(130);')
+	g.indent--
+	g.writeln('}')
+	g.writeln('')
+}

--- a/vlib/v3/gen/c/profile.v
+++ b/vlib/v3/gen/c/profile.v
@@ -6,37 +6,42 @@ struct ProfileCounterMeta {
 	calls_name   string
 }
 
-fn (g &FlatGen) profile_enabled_c_name() string {
-	for name, _ in g.global_types {
-		if name == 'v__profile_enabled' || name.ends_with('.v__profile_enabled') {
-			return g.global_c_name(name)
-		}
+// The loader uses the declared short name until a user `profile` module makes
+// the canonical `v.profile` name necessary to keep the two modules distinct.
+fn (g &FlatGen) profile_runtime_module_name() string {
+	if 'v.profile.v__profile_enabled' in g.global_types {
+		return 'v.profile'
 	}
-	return g.cname('profile.v__profile_enabled')
+	return 'profile'
+}
+
+fn (g &FlatGen) profile_enabled_c_name() string {
+	return g.global_c_name('${g.profile_runtime_module_name()}.v__profile_enabled')
 }
 
 fn (g &FlatGen) profile_timer_c_name() string {
 	return if g.target.os == 'macos' { 'time__vpc_now_darwin' } else { 'time__vpc_now' }
 }
 
-fn (g &FlatGen) profile_v1_fn_name(module_name string, fn_name string) string {
-	module_cname := if module_name.len == 0 || module_name == 'main' {
-		'main'
-	} else {
-		g.cname(module_name)
+fn profile_v1_fn_name(cfn_name string, module_name string, fn_name string) string {
+	if cfn_name == 'main' && fn_name == 'main' && module_name in ['', 'main'] {
+		return 'main__main'
 	}
-	mut short_name := fn_name
-	if module_name.len > 0 && short_name.starts_with('${module_name}.') {
-		short_name = short_name[module_name.len + 1..]
+	if module_name in ['', 'main'] && !cfn_name.starts_with('main__') {
+		return 'main__${cfn_name}'
 	}
-	return '${module_cname}__${g.cname(short_name.replace('.', '_'))}'
+	if module_name == 'builtin' && !cfn_name.starts_with('builtin__') {
+		return 'builtin__${cfn_name}'
+	}
+	return cfn_name
 }
 
 fn (mut g FlatGen) gen_profile_fn_begin(cfn_name string, module_name string, fn_name string, is_inline bool) {
 	g.profile_fn_active = false
 	g.profile_fn_restore_enabled = false
 	if g.profile_file.len == 0 || (g.profile_no_inline && is_inline)
-		|| module_name == 'v.profile' || fn_name.starts_with('time.vpc_now')
+		|| module_name == g.profile_runtime_module_name()
+		|| fn_name.starts_with('time.vpc_now')
 		|| cfn_name.starts_with('time__vpc_now') {
 		return
 	}
@@ -47,7 +52,7 @@ fn (mut g FlatGen) gen_profile_fn_begin(cfn_name string, module_name string, fn_
 	// `_only_current` suffix. The index makes every base name unambiguous.
 	counter_name := 'vpc_${g.profile_counters.len}_${cfn_name}'
 	calls_name := '${counter_name}_calls'
-	profile_fn_name := g.profile_v1_fn_name(module_name, fn_name)
+	profile_fn_name := profile_v1_fn_name(cfn_name, module_name, fn_name)
 	g.profile_fn_active = true
 	g.profile_fn_restore_enabled = g.profile_fns.len > 0 && profile_fn_name in g.profile_fns
 	profile_enabled := g.profile_enabled_c_name()

--- a/vlib/v3/gen/c/profile.v
+++ b/vlib/v3/gen/c/profile.v
@@ -176,6 +176,7 @@ fn (mut g FlatGen) gen_profile_support() {
 	for pc in g.profile_counters {
 		g.writeln('${pc.calls_name} = 0;')
 		g.writeln('${pc.counter_name} = 0.0;')
+		g.writeln('${pc.counter_name}_only_current = 0.0;')
 	}
 	g.indent--
 	g.writeln('}')

--- a/vlib/v3/gen/c/profile.v
+++ b/vlib/v3/gen/c/profile.v
@@ -167,6 +167,7 @@ fn (mut g FlatGen) gen_profile_support() {
 	} else {
 		g.writeln('FILE* fp;')
 		g.writeln('fp = fopen("${c_escape(g.profile_file)}", "w+");')
+		g.writeln('if (fp == NULL) { return; }')
 		for pc in g.profile_counters {
 			g.writeln('if (${pc.calls_name}) fprintf(fp, ${fstring}, ${pc.calls_name}, (${pc.counter_name} * f) / 1000000.0, (${pc.counter_name}_only_current * f) / 1000000.0, (${pc.counter_name} * f) / ${pc.calls_name}, "${c_escape(pc.fn_name)}");')
 		}

--- a/vlib/v3/gen/c/profile.v
+++ b/vlib/v3/gen/c/profile.v
@@ -36,9 +36,8 @@ fn (mut g FlatGen) gen_profile_fn_begin(cfn_name string, module_name string, fn_
 	g.profile_fn_active = false
 	g.profile_fn_restore_enabled = false
 	if g.profile_file.len == 0 || (g.profile_no_inline && is_inline)
-		|| fn_name.starts_with('time.vpc_now') || fn_name.starts_with('v.profile.')
-		|| fn_name.starts_with('profile.') || cfn_name.starts_with('time__vpc_now')
-		|| cfn_name.starts_with('profile__') || cfn_name.starts_with('v__profile__') {
+		|| module_name == 'v.profile' || fn_name.starts_with('time.vpc_now')
+		|| cfn_name.starts_with('time__vpc_now') {
 		return
 	}
 	// Prefix the counter names with a unique per-function index. Without it the derived

--- a/vlib/v3/gen/c/stmt.v
+++ b/vlib/v3/gen/c/stmt.v
@@ -3784,8 +3784,20 @@ fn (mut g FlatGen) gen_heap_local_address_expr(ret_id flat.NodeId, expected type
 	return false
 }
 
-// optional_forward_return_abi_expr converts a directly forwarded option/result
-// when a specialized generic callee and its caller use different C wrapper names.
+// optional_forward_return_abi_wrap_expr converts a directly forwarded option/result
+// after a specialized generic callee and its caller resolve to different C wrapper names.
+fn (mut g FlatGen) optional_forward_return_abi_wrap_expr(source_ct string, expected_ct string, base types.Type, expr string) string {
+	tmp := g.tmp_name()
+	if _ := array_fixed_type(base) {
+		out := g.tmp_name()
+		return '({ ${source_ct} ${tmp} = ${expr}; ${expected_ct} ${out} = { .ok = ${tmp}.ok, .err = ${tmp}.err }; if (${tmp}.ok) { memcpy(${out}.value, ${tmp}.value, sizeof(${out}.value)); } ${out}; })'
+	}
+	value := if base is types.Void { '' } else { ', .value = ${tmp}.value' }
+	return '({ ${source_ct} ${tmp} = ${expr}; (${expected_ct}){ .ok = ${tmp}.ok, .err = ${tmp}.err${value} }; })'
+}
+
+// optional_forward_return_abi_expr resolves the source and destination ABI wrappers
+// for a directly forwarded option/result expression.
 fn (mut g FlatGen) optional_forward_return_abi_expr(ret_id flat.NodeId, expected_ct string) ?string {
 	mut source_type := g.usable_expr_type(ret_id)
 	declared := g.declared_call_return_type(ret_id)
@@ -3807,10 +3819,8 @@ fn (mut g FlatGen) optional_forward_return_abi_expr(ret_id flat.NodeId, expected
 	} else {
 		return none
 	}
-	tmp := g.tmp_name()
-	value := if base is types.Void { '' } else { ', .value = ${tmp}.value' }
 	expr := g.expr_to_string(ret_id)
-	return '({ ${source_ct} ${tmp} = ${expr}; (${expected_ct}){ .ok = ${tmp}.ok, .err = ${tmp}.err${value} }; })'
+	return g.optional_forward_return_abi_wrap_expr(source_ct, expected_ct, base, expr)
 }
 
 fn optional_error_payload_return_expr(value_expr string, base_ct string, opt_ct string) ?string {

--- a/vlib/v3/gen/c/stmt.v
+++ b/vlib/v3/gen/c/stmt.v
@@ -649,6 +649,7 @@ fn (mut g FlatGen) gen_return_cleanup() {
 	g.gen_return_loop_control_copybacks()
 	if g.active_locks.len == 0 {
 		g.gen_all_defers()
+		g.gen_profile_fn_exit()
 		g.gen_current_return_ownership_drops()
 		return
 	}
@@ -660,6 +661,7 @@ fn (mut g FlatGen) gen_return_cleanup() {
 		i--
 	}
 	g.gen_all_defers_range(0, defer_end)
+	g.gen_profile_fn_exit()
 	g.gen_current_return_ownership_drops()
 }
 
@@ -864,6 +866,31 @@ fn (g &FlatGen) ownership_recursive_drop_helper_name(type_name string) string {
 	return '__v3_ownership_drop_${g.cname(type_name)}'
 }
 
+// ownership_recursive_drop_helper_types collapses the logical ownership type
+// keys that share one emitted C struct. In particular, lifetime arguments are
+// erased from C generic names, so two lifetime instantiations can require the
+// same helper symbol. Prefer the spelling for which the checker has the most
+// complete field information when choosing the helper body.
+fn (g &FlatGen) ownership_recursive_drop_helper_types() map[string]string {
+	mut representatives := map[string]string{}
+	mut keys := g.recursive_drop_helpers.keys()
+	keys.sort()
+	for key in keys {
+		type_name := g.recursive_drop_helpers[key]
+		helper_name := g.ownership_recursive_drop_helper_name(type_name)
+		if current := representatives[helper_name] {
+			current_fields := g.tc.struct_fields_for_type(current).len
+			candidate_fields := g.tc.struct_fields_for_type(type_name).len
+			if candidate_fields > current_fields {
+				representatives[helper_name] = type_name
+			}
+			continue
+		}
+		representatives[helper_name] = type_name
+	}
+	return representatives
+}
+
 fn (mut g FlatGen) precompute_ownership_recursive_drop_helpers() {
 	g.recursive_drop_helpers.clear()
 	$if !ownership ? {
@@ -879,8 +906,13 @@ fn (mut g FlatGen) precompute_ownership_recursive_drop_helpers() {
 	struct_names.sort()
 	for name in struct_names {
 		parsed := g.tc.parse_type(name)
+		// An unmonomorphized generic template (e.g. `Printer[W]`) must not get a
+		// drop helper: only its concrete instantiations (`Printer[cli.Buffer]`)
+		// have emitted C types. `is_generic_struct` only matches the base decl
+		// name, so also reject names whose generic args still hold a placeholder.
 		if name.starts_with('C.') || name in g.tc.unions || g.is_generic_struct(name)
-			|| g.type_contains_generic_placeholder(parsed) || g.skip_builtin_struct(name)
+			|| g.type_contains_generic_placeholder(parsed)
+			|| g.type_name_contains_generic_placeholder(name) || g.skip_builtin_struct(name)
 			|| g.resolve_method_name(name, g.ownership_destructor_method_name()).len > 0 {
 			continue
 		}
@@ -1077,11 +1109,11 @@ fn (mut g FlatGen) gen_ownership_recursive_drop_helper_forward_decls() {
 	// sentinels. Declare those globals before the helper bodies.
 	g.writeln('extern IError builtin__none__;')
 	g.writeln('extern IError builtin__error_sentinel;')
-	mut keys := g.recursive_drop_helpers.keys()
-	keys.sort()
-	for key in keys {
-		type_name := g.recursive_drop_helpers[key]
-		helper_name := g.ownership_recursive_drop_helper_name(type_name)
+	representatives := g.ownership_recursive_drop_helper_types()
+	mut helper_names := representatives.keys()
+	helper_names.sort()
+	for helper_name in helper_names {
+		type_name := representatives[helper_name]
 		g.writeln('static void ${helper_name}(${g.struct_cname(type_name)}* _value);')
 	}
 	g.writeln('')
@@ -1093,13 +1125,13 @@ fn (mut g FlatGen) gen_ownership_recursive_drop_helpers() {
 	}
 	old_module := g.tc.cur_module
 	old_file := g.tc.cur_file
-	mut keys := g.recursive_drop_helpers.keys()
-	keys.sort()
-	for key in keys {
-		type_name := g.recursive_drop_helpers[key]
+	representatives := g.ownership_recursive_drop_helper_types()
+	mut helper_names := representatives.keys()
+	helper_names.sort()
+	for helper_name in helper_names {
+		type_name := representatives[helper_name]
 		g.tc.cur_module = g.tc.struct_modules[type_name] or { old_module }
 		g.tc.cur_file = g.tc.struct_files[type_name] or { old_file }
-		helper_name := g.ownership_recursive_drop_helper_name(type_name)
 		g.writeln('static void ${helper_name}(${g.struct_cname(type_name)}* _value) {')
 		g.indent++
 		mut expanding := map[string]bool{}
@@ -2478,7 +2510,8 @@ fn (mut g FlatGen) gen_node(id flat.NodeId) {
 				g.expected_enum = g.cur_fn_ret.name
 			}
 			has_return_cleanup := g.has_pending_defers() || g.active_locks.len > 0
-				|| g.cur_return_drops.len > 0 || g.loop_control_copybacks.len > 0
+				|| g.profile_fn_active || g.cur_return_drops.len > 0
+				|| g.loop_control_copybacks.len > 0
 			if node.children_count > 0 && has_return_cleanup {
 				g.gen_return_with_defers(node)
 				g.expected_enum = ''
@@ -2517,7 +2550,11 @@ fn (mut g FlatGen) gen_node(id flat.NodeId) {
 					if return_node_is_direct_optional_forward(node.value)
 						&& g.expr_really_returns_optional(ret_id) {
 						g.write('return ')
-						g.gen_expr(ret_id)
+						if converted := g.optional_forward_return_abi_expr(ret_id, ct) {
+							g.write(converted)
+						} else {
+							g.gen_expr(ret_id)
+						}
 						g.writeln(';')
 						return
 					}
@@ -3747,6 +3784,35 @@ fn (mut g FlatGen) gen_heap_local_address_expr(ret_id flat.NodeId, expected type
 	return false
 }
 
+// optional_forward_return_abi_expr converts a directly forwarded option/result
+// when a specialized generic callee and its caller use different C wrapper names.
+fn (mut g FlatGen) optional_forward_return_abi_expr(ret_id flat.NodeId, expected_ct string) ?string {
+	mut source_type := g.usable_expr_type(ret_id)
+	declared := g.declared_call_return_type(ret_id)
+	if type_is_optional_result(declared) {
+		source_type = declared
+	}
+	if !type_is_optional_result(source_type) {
+		return none
+	}
+	source_ct := g.optional_type_name_for_expr(ret_id, source_type)
+	if source_ct == expected_ct {
+		return none
+	}
+	clean_type := optional_result_unalias_type(source_type)
+	base := if clean_type is types.OptionType {
+		clean_type.base_type
+	} else if clean_type is types.ResultType {
+		clean_type.base_type
+	} else {
+		return none
+	}
+	tmp := g.tmp_name()
+	value := if base is types.Void { '' } else { ', .value = ${tmp}.value' }
+	expr := g.expr_to_string(ret_id)
+	return '({ ${source_ct} ${tmp} = ${expr}; (${expected_ct}){ .ok = ${tmp}.ok, .err = ${tmp}.err${value} }; })'
+}
+
 fn optional_error_payload_return_expr(value_expr string, base_ct string, opt_ct string) ?string {
 	_ = base_ct
 	marker := '){.ok = false, .err = '
@@ -3773,6 +3839,9 @@ fn (mut g FlatGen) return_expr_string(node flat.Node, ret_id flat.NodeId, ret_no
 		base := g.cur_fn_ret_base
 		if return_node_is_direct_optional_forward(node.value)
 			&& g.expr_really_returns_optional(ret_id) {
+			if converted := g.optional_forward_return_abi_expr(ret_id, ct) {
+				return converted
+			}
 			return g.expr_to_string(ret_id)
 		}
 		if err_id := g.optional_error_payload_err_expr(ret_id) {
@@ -4175,7 +4244,7 @@ fn (g &FlatGen) selector_call_return_type(fn_node flat.Node) ?types.Type {
 	}
 	clean_type := types.unwrap_pointer(base_type)
 	if fn_node.value == 'clone' && (clean_type is types.Array || clean_type is types.Map) {
-		return base_type
+		return clean_type
 	}
 	mut receiver_name := clean_type.name()
 	if clean_type is types.Struct {
@@ -4299,8 +4368,23 @@ fn (g &FlatGen) expr_really_returns_optional(id flat.NodeId) bool {
 		return type_is_optional_result(typ)
 	}
 	if node.kind == .call {
-		ret_type := g.declared_call_return_type(id)
-		return ret_type is types.OptionType || ret_type is types.ResultType
+		typ := g.usable_expr_type(id)
+		if typ !is types.Unknown && typ !is types.Void {
+			// The successful payload type annotates a propagated `call()!`.
+			// Keep consulting the declared callee return in that case so a
+			// compatible Result return is forwarded instead of wrapped twice.
+			if type_is_optional_result(typ) {
+				return true
+			}
+		}
+		declared := g.declared_call_return_type(id)
+		if declared is types.OptionType || declared is types.ResultType {
+			return true
+		}
+		if fname := g.tc.resolved_call_name(id) {
+			ret_type := g.tc.fn_ret_types[fname] or { return false }
+			return ret_type is types.OptionType || ret_type is types.ResultType
+		}
 	}
 	return type_is_optional_result(g.usable_expr_type(id))
 }

--- a/vlib/v3/gen/c/stmt_test.v
+++ b/vlib/v3/gen/c/stmt_test.v
@@ -57,6 +57,20 @@ fn test_primitive_fixed_array_zero_initializer_is_compact() {
 	assert dynamic_init.count('array_new(') == 2
 }
 
+fn test_ownership_recursive_drop_helpers_deduplicate_emitted_c_symbol() {
+	mut a := flat.FlatAst.new()
+	mut tc := types.TypeChecker.new(&a)
+	mut g := FlatGen.new()
+	g.a = &a
+	g.tc = &tc
+	// Distinct logical ownership keys can refer to the same runtime struct after
+	// lifetime erasure. Only one C helper definition may be emitted for it.
+	g.recursive_drop_helpers['struct:pkg.Sink[^p,^s,Writer]'] = 'pkg.Sink[Writer]'
+	g.recursive_drop_helpers['struct:pkg.Sink[^s,^s,Writer]'] = 'pkg.Sink[Writer]'
+	g.gen_ownership_recursive_drop_helpers()
+	assert g.sb.str().count('static void __v3_ownership_drop_pkg__Sink_Writer(') == 1
+}
+
 fn test_usable_resolved_sum_type_requires_exact_qualified_name() {
 	mut a := flat.FlatAst.new()
 	mut tc := types.TypeChecker.new(&a)

--- a/vlib/v3/gen/c/stmt_test.v
+++ b/vlib/v3/gen/c/stmt_test.v
@@ -57,6 +57,27 @@ fn test_primitive_fixed_array_zero_initializer_is_compact() {
 	assert dynamic_init.count('array_new(') == 2
 }
 
+fn test_fixed_array_optional_abi_conversions_use_memcpy() {
+	fixed := types.Type(types.ArrayFixed{
+		elem_type: types.Type(types.int_)
+		len:       2
+	})
+	mut forward_gen := FlatGen.new()
+	forward := forward_gen.optional_forward_return_abi_wrap_expr('Optional_source',
+		'Optional_destination', fixed, 'source()')
+	assert forward.contains('if (_t1.ok) { memcpy(_t2.value, _t1.value, sizeof(_t2.value)); }'), forward
+	assert !forward.contains('.value = _t1.value'), forward
+
+	mut interface_gen := FlatGen.new()
+	interface_gen.gen_interface_dispatch_optional_abi_value_return('Optional_destination',
+		'_iface_result', fixed)
+	interface_output := interface_gen.sb.str()
+	assert interface_output.contains('if (_iface_result.ok) {'), interface_output
+	copy_statement := 'memcpy(_iface_abi_result_out_0.value, _iface_result.value, sizeof(_iface_abi_result_out_0.value));'
+	assert interface_output.contains(copy_statement), interface_output
+	assert !interface_output.contains('.value = _iface_result.value'), interface_output
+}
+
 fn test_ownership_recursive_drop_helpers_deduplicate_emitted_c_symbol() {
 	mut a := flat.FlatAst.new()
 	mut tc := types.TypeChecker.new(&a)

--- a/vlib/v3/markused/markused.v
+++ b/vlib/v3/markused/markused.v
@@ -452,13 +452,11 @@ fn mark_used_with_test_files(a &flat.FlatAst, tc &types.TypeChecker, test_files 
 		}
 		queue << 'array.delete_last'
 		used['array.delete_last'] = true
-		ownership_drop_value_types := tc.ownership_drop_value_type_names()
-		if ownership_drop_value_types.len > 0 {
-			// Ownership cleanup is synthesized after markused. Its recursive array/map
-			// destructors therefore have no AST call sites for the collector to follow.
-			for helper in ['array.free', 'array__free', 'map.free', 'map__free'] {
-				enqueue(helper, mut used, mut queue)
-			}
+		// Ownership cleanup is synthesized after markused. Its array/map destructors
+		// therefore have no AST call sites for the collector to follow. This also
+		// applies to drop-before-reassignment, which is not part of the exit snapshots.
+		for helper in ['array.free', 'array__free', 'map.free', 'map__free'] {
+			enqueue(helper, mut used, mut queue)
 		}
 		for type_name in tc.ownership_drop_type_names() {
 			method := if tc.autofree_mode { '${type_name}.free' } else { '${type_name}.drop' }

--- a/vlib/v3/modulecache/modulecache.v
+++ b/vlib/v3/modulecache/modulecache.v
@@ -6087,8 +6087,10 @@ fn interface_field_text(a &flat.FlatAst, field &flat.Node) string {
 			mut param_type := param.typ
 			if param.is_mut {
 				prefix = 'mut '
-				if param.op == .amp && !param_type.starts_with('&') {
-					param_type = '&${param_type}'
+				if param.op == .amp {
+					if !param_type.starts_with('&') {
+						param_type = '&${param_type}'
+					}
 				} else if param_type.starts_with('&') {
 					param_type = param_type[1..].trim_space()
 				}

--- a/vlib/v3/modulecache/modulecache.v
+++ b/vlib/v3/modulecache/modulecache.v
@@ -6056,35 +6056,52 @@ fn interface_text(a &flat.FlatAst, node flat.Node, source_is_public bool) string
 	mut out := strings.new_builder(128)
 	visibility := if source_is_public { 'pub ' } else { '' }
 	out.writeln('${visibility}interface ${node.value}${generic_suffix(node.generic_params())} {')
+	mut has_mut_fields := false
 	for i in 0 .. node.children_count {
 		field := a.child_node(&node, i)
-		if field.op == .dot {
-			mut params := []string{}
-			for pi in 0 .. field.children_count {
-				param := a.child_node(field, pi)
-				mut param_type := param.typ
-				mut prefix := ''
-				if param.is_mut && param.op == .amp {
-					prefix = 'mut '
-					if !param_type.starts_with('&') {
-						param_type = '&${param_type}'
-					}
-				} else if param_type.starts_with('&') && param.is_mut {
-					prefix = 'mut '
-					param_type = param_type[1..].trim_space()
-				}
-				params << '${prefix}arg${pi} ${param_type}'
-			}
-			ret := if field.typ.len > 0 { ' ${field.typ}' } else { '' }
-			out.writeln('\t${field.value}(${params.join(', ')})${ret}')
-		} else if field.typ.len > 0 {
-			out.writeln('\t${field.value} ${field.typ}')
+		if !field.is_mut {
+			out.writeln(interface_field_text(a, field))
 		} else {
-			out.writeln('\t${field.value}')
+			has_mut_fields = true
+		}
+	}
+	if has_mut_fields {
+		out.writeln('mut:')
+		for i in 0 .. node.children_count {
+			field := a.child_node(&node, i)
+			if field.is_mut {
+				out.writeln(interface_field_text(a, field))
+			}
 		}
 	}
 	out.write_string('}')
 	return out.str()
+}
+
+fn interface_field_text(a &flat.FlatAst, field &flat.Node) string {
+	if field.op == .dot {
+		mut params := []string{}
+		for pi in 0 .. field.children_count {
+			param := a.child_node(field, pi)
+			mut prefix := ''
+			mut param_type := param.typ
+			if param.is_mut {
+				prefix = 'mut '
+				if param.op == .amp && !param_type.starts_with('&') {
+					param_type = '&${param_type}'
+				} else if param_type.starts_with('&') {
+					param_type = param_type[1..].trim_space()
+				}
+			}
+			params << '${prefix}arg${pi} ${param_type}'
+		}
+		ret := if field.typ.len > 0 { ' ${field.typ}' } else { '' }
+		return '\t${field.value}(${params.join(', ')})${ret}'
+	}
+	if field.typ.len > 0 {
+		return '\t${field.value} ${field.typ}'
+	}
+	return '\t${field.value}'
 }
 
 fn expr_text(a &flat.FlatAst, id flat.NodeId) string {

--- a/vlib/v3/tests/default_clone_codegen_test.v
+++ b/vlib/v3/tests/default_clone_codegen_test.v
@@ -45,3 +45,45 @@ fn main() {
 	run := os.execute(out)
 	assert run.exit_code == 0, run.output
 }
+
+// A compiler-provided IClone `clone()` (Rust `#[derive(Clone)]`) has no entry
+// in the fn tables. Inside a generic function body, generic specialization must
+// not diagnose `x.clone()` on such a struct as an unknown function.
+fn test_compiler_default_clone_inside_generic_fn() {
+	pid := os.getpid()
+	v3_bin := os.join_path(os.temp_dir(), 'v3_generic_clone_${pid}')
+	src := os.join_path(os.temp_dir(), 'v3_generic_clone_${pid}.v')
+	out := os.join_path(os.temp_dir(), 'v3_generic_clone_program_${pid}')
+	defer {
+		os.rm(v3_bin) or {}
+		os.rm(src) or {}
+		os.rm(out) or {}
+		os.rm(out + '.c') or {}
+	}
+	build :=
+		os.execute('${default_clone_vexe} -gc none -d ownership -path "${default_clone_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${default_clone_v3_src}')
+	assert build.exit_code == 0, build.output
+	os.write_file(src, 'module main
+
+struct Cfg implements IClone {
+	value int
+}
+
+// `.clone()` is called on a concrete IClone receiver inside a generic fn body.
+fn copy_in_generic[T](c &Cfg, x T) Cfg {
+	return c.clone()
+}
+
+fn main() {
+	c := Cfg{value: 7}
+	d := copy_in_generic[int](&c, 0)
+	assert d.value == 7
+}
+') or {
+		panic(err)
+	}
+	compile := os.execute('${v3_bin} ${src} -d ownership -b c -o ${out}')
+	assert compile.exit_code == 0, compile.output
+	run := os.execute(out)
+	assert run.exit_code == 0, run.output
+}

--- a/vlib/v3/tests/driver_cli_test.v
+++ b/vlib/v3/tests/driver_cli_test.v
@@ -34,6 +34,118 @@ fn assert_driver_cli_failure(v3_bin string, args []string, message string) {
 	assert result.output.contains(message), result.output
 }
 
+fn v3_profile_counter(profile_output string, fn_name string) int {
+	for line in profile_output.split_into_lines() {
+		fields := line.fields()
+		if fields.len > 0 && fields.last() == fn_name {
+			return fields[0].int()
+		}
+	}
+	return -1
+}
+
+fn test_driver_v1_compatible_profile_options() {
+	root := os.join_path(os.vtmp_dir(), 'v3_driver_profile_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	v3_bin := build_driver_cli_v3(root)
+
+	api_source := os.join_path(root, 'profile_api.v')
+	os.write_file(api_source, 'module main
+
+import v.profile
+
+fn abc() {
+	println("abc")
+}
+
+fn main() {
+	profile.on(false)
+	abc()
+	profile.on(true)
+	abc()
+}
+')!
+	api_binary := os.join_path(root, 'profile_api')
+	api_profile := os.join_path(root, 'profile_api.txt')
+	api_compile := cmdexec.run(v3_bin, ['-silent', '-profile', api_profile, '-o', api_binary,
+		api_source])
+	assert api_compile.exit_code == 0, api_compile.output
+	api_run := cmdexec.run(api_binary, [])
+	assert api_run.exit_code == 0, api_run.output
+	api_output := os.read_file(api_profile)!
+	assert v3_profile_counter(api_output, 'builtin__builtin_init') == 1, api_output
+	assert v3_profile_counter(api_output, 'main__main') == 1, api_output
+	assert v3_profile_counter(api_output, 'main__abc') == 1, api_output
+
+	// With no output path, the following source remains the compiler input and
+	// the V1 `-prof` alias writes its report to stdout.
+	stdout_binary := os.join_path(root, 'profile_stdout')
+	stdout_compile := cmdexec.run(v3_bin, ['-silent', '-prof', '-o', stdout_binary, api_source])
+	assert stdout_compile.exit_code == 0, stdout_compile.output
+	stdout_run := cmdexec.run(stdout_binary, [])
+	assert stdout_run.exit_code == 0, stdout_run.output
+	assert v3_profile_counter(stdout_run.output, 'main__main') == 1, stdout_run.output
+	assert v3_profile_counter(stdout_run.output, 'main__abc') == 1, stdout_run.output
+
+	reset_binary := os.join_path(root, 'profile_reset')
+	reset_profile := os.join_path(root, 'profile_reset.txt')
+	reset_compile := cmdexec.run(v3_bin, ['-silent', '-d', 'no_profile_startup', '-profile',
+		reset_profile, '-o', reset_binary, api_source])
+	assert reset_compile.exit_code == 0, reset_compile.output
+	reset_run := cmdexec.run(reset_binary, [])
+	assert reset_run.exit_code == 0, reset_run.output
+	reset_output := os.read_file(reset_profile)!
+	assert v3_profile_counter(reset_output, 'builtin__builtin_init') == -1, reset_output
+	assert v3_profile_counter(reset_output, 'main__main') == 1, reset_output
+	assert v3_profile_counter(reset_output, 'main__abc') == 1, reset_output
+
+	selective_source := os.join_path(root, 'profile_selective.v')
+	os.write_file(selective_source, 'module main
+
+@[inline]
+fn inline_fn() {
+	println("inline")
+}
+
+fn leaf() {
+	println("leaf")
+}
+
+fn selected() {
+	leaf()
+	leaf()
+	inline_fn()
+}
+
+fn ignored() {
+	leaf()
+}
+
+fn main() {
+	ignored()
+	selected()
+}
+')!
+	selective_binary := os.join_path(root, 'profile_selective')
+	selective_profile := os.join_path(root, 'profile_selective.txt')
+	selective_compile := cmdexec.run(v3_bin, ['-silent', '-profile-fns', 'main__selected',
+		'-profile-no-inline', '-profile', selective_profile, '-o', selective_binary, selective_source])
+	assert selective_compile.exit_code == 0, selective_compile.output
+	selective_run := cmdexec.run(selective_binary, [])
+	assert selective_run.exit_code == 0, selective_run.output
+	selective_output := os.read_file(selective_profile)!
+	assert v3_profile_counter(selective_output, 'main__main') == -1, selective_output
+	assert v3_profile_counter(selective_output, 'main__ignored') == -1, selective_output
+	assert v3_profile_counter(selective_output, 'main__selected') == 1, selective_output
+	assert v3_profile_counter(selective_output, 'main__leaf') == 2, selective_output
+	assert v3_profile_counter(selective_output, 'main__inline_fn') == -1, selective_output
+	assert v3_profile_counter(selective_output, 'builtin__println') == 3, selective_output
+}
+
 fn test_driver_only_monomorphizes_when_generics_are_used() {
 	root := os.join_path(os.vtmp_dir(), 'v3_driver_generics_${os.getpid()}')
 	os.rmdir_all(root) or {}

--- a/vlib/v3/tests/driver_cli_test.v
+++ b/vlib/v3/tests/driver_cli_test.v
@@ -54,9 +54,12 @@ fn test_driver_v1_compatible_profile_options() {
 	v3_bin := build_driver_cli_v3(root)
 
 	api_source := os.join_path(root, 'profile_api.v')
-	os.write_file(api_source, 'module main
+	os.write_file(api_source, '@[has_globals]
+module main
 
 import v.profile
+
+__global v__profile_enabled = false
 
 fn abc() {
 	println("abc")
@@ -109,6 +112,50 @@ fn main() {
 	assert user_profile_run.output.trim_space() == '42', user_profile_run.output
 	user_profile_output := os.read_file(user_profile_output_path)!
 	assert v3_profile_counter(user_profile_output, 'profile__answer') == 1, user_profile_output
+
+	operator_profile_source := os.join_path(root, 'operator_profile.v')
+	os.write_file(operator_profile_source, 'module main
+
+struct Number {
+	value int
+}
+
+fn (left Number) plus(right Number) Number {
+	return Number{
+		value: left.value + right.value + 1
+	}
+}
+
+fn (left Number) + (right Number) Number {
+	return Number{
+		value: left.value + right.value
+	}
+}
+
+fn main() {
+	left := Number{
+		value: 20
+	}
+	right := Number{
+		value: 22
+	}
+	println(left.plus(right).value)
+	println((left + right).value)
+}
+')!
+	operator_profile_binary := os.join_path(root, 'operator_profile')
+	operator_profile_output_path := os.join_path(root, 'operator_profile.txt')
+	operator_profile_compile := cmdexec.run(v3_bin, ['-silent', '-profile-fns',
+		'main__Number__plus__operator', '-profile', operator_profile_output_path, '-o',
+		operator_profile_binary, operator_profile_source])
+	assert operator_profile_compile.exit_code == 0, operator_profile_compile.output
+	operator_profile_run := cmdexec.run(operator_profile_binary, [])
+	assert operator_profile_run.exit_code == 0, operator_profile_run.output
+	assert operator_profile_run.output.trim_space() == '43\n42', operator_profile_run.output
+	operator_profile_output := os.read_file(operator_profile_output_path)!
+	assert v3_profile_counter(operator_profile_output, 'main__Number__plus__operator') == 1, operator_profile_output
+
+	assert v3_profile_counter(operator_profile_output, 'main__Number__plus') == -1, operator_profile_output
 
 	// With no output path, the following source remains the compiler input and
 	// the V1 `-prof` alias writes its report to stdout.

--- a/vlib/v3/tests/driver_cli_test.v
+++ b/vlib/v3/tests/driver_cli_test.v
@@ -85,6 +85,15 @@ fn main() {
 	assert v3_profile_counter(api_output, 'main__abc') == 1, api_output
 	assert v3_profile_counter(api_output, 'v__profile__on') == -1, api_output
 
+	missing_profile := os.join_path(root, 'missing', 'profile.txt')
+	missing_profile_binary := os.join_path(root, 'missing_profile')
+	missing_profile_compile := cmdexec.run(v3_bin, ['-silent', '-profile', missing_profile, '-o',
+		missing_profile_binary, api_source])
+	assert missing_profile_compile.exit_code == 0, missing_profile_compile.output
+	missing_profile_run := cmdexec.run(missing_profile_binary, [])
+	assert missing_profile_run.exit_code == 0, missing_profile_run.output
+	assert !os.exists(missing_profile)
+
 	user_profile_module := os.join_path(root, 'profile')
 	os.mkdir_all(user_profile_module)!
 	os.write_file(os.join_path(user_profile_module, 'profile.v'), 'module profile

--- a/vlib/v3/tests/driver_cli_test.v
+++ b/vlib/v3/tests/driver_cli_test.v
@@ -103,6 +103,63 @@ fn main() {
 	assert v3_profile_counter(reset_output, 'main__main') == 1, reset_output
 	assert v3_profile_counter(reset_output, 'main__abc') == 1, reset_output
 
+	reset_c := os.join_path(root, 'profile_reset.c')
+	reset_c_compile := cmdexec.run(v3_bin, ['-silent', '-d', 'no_profile_startup', '-profile',
+		reset_profile, '-o', reset_c, api_source])
+	assert reset_c_compile.exit_code == 0, reset_c_compile.output
+	reset_c_source := os.read_file(reset_c)!
+	reset_body := reset_c_source.all_after('void vreset_profile_stats(void) {').all_before('\n}')
+	assert reset_body.contains('_only_current = 0.0;'), reset_body
+
+	no_main_source := os.join_path(root, 'profile_no_main.v')
+	os.write_file(no_main_source, "@[export: 'profiled_answer']
+pub fn profiled_answer() int {
+	return 42
+}
+")!
+	no_main_c := os.join_path(root, 'profile_no_main.c')
+	no_main_profile := os.join_path(root, 'profile_no_main.txt')
+	no_main_compile := cmdexec.run(v3_bin, ['-silent', '-d', 'no_main', '-profile', no_main_profile,
+		'-o', no_main_c, no_main_source])
+	assert no_main_compile.exit_code == 0, no_main_compile.output
+	no_main_c_source := os.read_file(no_main_c)!
+	no_main_init_body :=
+		no_main_c_source.all_after('static void _vno_main_init_caller(void) {').all_before('\n}')
+	assert no_main_init_body.contains('atexit(vprint_profile_stats);'), no_main_init_body
+	$if !windows {
+		no_main_host_source := os.join_path(root, 'profile_no_main_host.c')
+		os.write_file(no_main_host_source, 'extern int profiled_answer(void);
+int main(void) {
+	return profiled_answer() == 42 ? 0 : 1;
+}
+')!
+		no_main_host := os.join_path(root, 'profile_no_main_host')
+		cc := os.getenv_opt('CC') or { 'cc' }
+		no_main_host_compile := cmdexec.run(cc, ['-std=gnu11', '-w', no_main_c, no_main_host_source,
+			'-lpthread', '-lm', '-o', no_main_host])
+		assert no_main_host_compile.exit_code == 0, no_main_host_compile.output
+		no_main_host_run := cmdexec.run(no_main_host, [])
+		assert no_main_host_run.exit_code == 0, no_main_host_run.output
+		no_main_output := os.read_file(no_main_profile)!
+		assert v3_profile_counter(no_main_output, 'main__profiled_answer') == 1, no_main_output
+	}
+	shared_c := os.join_path(root, 'profile_shared.c')
+	shared_profile := os.join_path(root, 'profile_shared.txt')
+	shared_compile := cmdexec.run(v3_bin, ['-silent', '-shared', '-profile', shared_profile, '-o',
+		shared_c, no_main_source])
+	assert shared_compile.exit_code == 0, shared_compile.output
+	shared_c_source := os.read_file(shared_c)!
+	shared_init_body :=
+		shared_c_source.all_after('static void _vno_main_init_caller(void) {').all_before('\n}')
+	assert shared_init_body.contains('atexit(vprint_profile_stats);'), shared_init_body
+
+	synthetic_main_c := os.join_path(root, 'profile_synthetic_main.c')
+	synthetic_main_compile := cmdexec.run(v3_bin, ['-silent', '-profile', no_main_profile, '-o',
+		synthetic_main_c, no_main_source])
+	assert synthetic_main_compile.exit_code == 0, synthetic_main_compile.output
+	synthetic_main_c_source := os.read_file(synthetic_main_c)!
+	assert synthetic_main_c_source.count('atexit(vprint_profile_stats);') == 1, synthetic_main_c_source
+
 	selective_source := os.join_path(root, 'profile_selective.v')
 	os.write_file(selective_source, 'module main
 

--- a/vlib/v3/tests/driver_cli_test.v
+++ b/vlib/v3/tests/driver_cli_test.v
@@ -80,6 +80,35 @@ fn main() {
 	assert v3_profile_counter(api_output, 'builtin__builtin_init') == 1, api_output
 	assert v3_profile_counter(api_output, 'main__main') == 1, api_output
 	assert v3_profile_counter(api_output, 'main__abc') == 1, api_output
+	assert v3_profile_counter(api_output, 'v__profile__on') == -1, api_output
+
+	user_profile_module := os.join_path(root, 'profile')
+	os.mkdir_all(user_profile_module)!
+	os.write_file(os.join_path(user_profile_module, 'profile.v'), 'module profile
+
+pub fn answer() int {
+	return 42
+}
+')!
+	user_profile_source := os.join_path(root, 'user_profile.v')
+	os.write_file(user_profile_source, 'module main
+
+import profile
+
+fn main() {
+	println(profile.answer())
+}
+')!
+	user_profile_binary := os.join_path(root, 'user_profile')
+	user_profile_output_path := os.join_path(root, 'user_profile.txt')
+	user_profile_compile := cmdexec.run(v3_bin, ['-silent', '-profile', user_profile_output_path,
+		'-o', user_profile_binary, user_profile_source])
+	assert user_profile_compile.exit_code == 0, user_profile_compile.output
+	user_profile_run := cmdexec.run(user_profile_binary, [])
+	assert user_profile_run.exit_code == 0, user_profile_run.output
+	assert user_profile_run.output.trim_space() == '42', user_profile_run.output
+	user_profile_output := os.read_file(user_profile_output_path)!
+	assert v3_profile_counter(user_profile_output, 'profile__answer') == 1, user_profile_output
 
 	// With no output path, the following source remains the compiler input and
 	// the V1 `-prof` alias writes its report to stdout.

--- a/vlib/v3/tests/generic_const_global_type_codegen_test.v
+++ b/vlib/v3/tests/generic_const_global_type_codegen_test.v
@@ -1,0 +1,48 @@
+import os
+
+const gcg_vexe = @VEXE
+const gcg_tests_dir = os.dir(@FILE)
+const gcg_v3_dir = os.dir(gcg_tests_dir)
+const gcg_vlib_dir = os.dir(gcg_v3_dir)
+const gcg_v3_src = os.join_path(gcg_v3_dir, 'v3.v')
+
+// A `const` whose initializer is a generic call (`stdatomic.new_atomic(0)`)
+// keeps the generic return type `&AtomicVal[T]`. The backing global variable
+// must be declared with the concrete monomorphized type recovered from the
+// (already specialized) initializer, not the undeclared `AtomicVal_T`.
+fn test_generic_const_global_uses_concrete_storage_type() {
+	pid := os.getpid()
+	v3_bin := os.join_path(os.temp_dir(), 'v3_generic_const_${pid}')
+	src := os.join_path(os.temp_dir(), 'v3_generic_const_${pid}.v')
+	out := os.join_path(os.temp_dir(), 'v3_generic_const_program_${pid}')
+	defer {
+		os.rm(v3_bin) or {}
+		os.rm(src) or {}
+		os.rm(out) or {}
+		os.rm(out + '.c') or {}
+	}
+	build :=
+		os.execute('${gcg_vexe} -gc none -d ownership -path "${gcg_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${gcg_v3_src}')
+	assert build.exit_code == 0, build.output
+	os.write_file(src, 'module main
+
+import sync.stdatomic
+
+const g_state = stdatomic.new_atomic(0)
+
+fn g_state_ref() &stdatomic.AtomicVal[int] {
+	return g_state
+}
+
+fn main() {
+	g_state_ref().store(7)
+	assert g_state_ref().load() == 7
+}
+') or {
+		panic(err)
+	}
+	compile := os.execute('${v3_bin} ${src} -d ownership -b c -o ${out}')
+	assert compile.exit_code == 0, compile.output
+	run := os.execute(out)
+	assert run.exit_code == 0, run.output
+}

--- a/vlib/v3/tests/large_match_reannotation_codegen_test.v
+++ b/vlib/v3/tests/large_match_reannotation_codegen_test.v
@@ -1,0 +1,51 @@
+import os
+
+const lmr_vexe = @VEXE
+const lmr_tests_dir = os.dir(@FILE)
+const lmr_v3_dir = os.dir(lmr_tests_dir)
+const lmr_vlib_dir = os.dir(lmr_v3_dir)
+const lmr_v3_src = os.join_path(lmr_v3_dir, 'v3.v')
+
+// Match lowering produces an else-if chain. Post-transform type reannotation
+// must walk very large generated tables without overflowing the native stack.
+fn test_large_match_reannotation_does_not_overflow() {
+	pid := os.getpid()
+	v3_bin := os.join_path(os.temp_dir(), 'v3_large_match_reannotation_${pid}')
+	src := os.join_path(os.temp_dir(), 'v3_large_match_reannotation_${pid}.v')
+	out := os.join_path(os.temp_dir(), 'v3_large_match_reannotation_program_${pid}')
+	defer {
+		os.rm(v3_bin) or {}
+		os.rm(src) or {}
+		os.rm(out) or {}
+		os.rm(out + '.c') or {}
+	}
+	build :=
+		os.execute('${lmr_vexe} -gc none -d ownership -path "${lmr_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${lmr_v3_src}')
+	assert build.exit_code == 0, build.output
+	mut branches := []string{cap: 1800}
+	for i in 0 .. 1800 {
+		branches << "\t\t'key_${i}' { return ${i} }"
+	}
+	source := 'module main
+
+fn identity[T](value T) T {
+\treturn value
+}
+
+fn classify(value string) int {
+\tmatch value {
+${branches.join('\n')}
+\t\telse { return -1 }
+\t}
+}
+
+fn main() {
+\tassert classify(identity[string]("key_1799")) == 1799
+}
+'
+	os.write_file(src, source) or { panic(err) }
+	compile := os.execute('${v3_bin} ${src} -d ownership -b c -o ${out}')
+	assert compile.exit_code == 0, compile.output
+	run := os.execute(out)
+	assert run.exit_code == 0, run.output
+}

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -3895,7 +3895,7 @@ fn main() {
 	assert changed_module_cache_objects(first_hashes, module_cache_object_hashes(cache_dir)).len == 0
 }
 
-fn test_cached_header_preserves_mutable_interface_parameter() {
+fn test_cached_header_preserves_mutable_interface_method_and_parameter() {
 	v3_bin := build_module_cache_v3()
 	root := os.join_path(os.temp_dir(), 'v3_module_cache_interface_mut_${os.getpid()}')
 	os.rmdir_all(root) or {}
@@ -3905,8 +3905,13 @@ fn test_cached_header_preserves_mutable_interface_parameter() {
 	}
 	write_module_cache_file(root, 'contract/contract.v', 'module contract
 
-pub interface Sink {
-	fill(mut values []int)
+pub interface Writer {
+mut:
+	write(mut bytes []u8) !int
+}
+
+pub fn fill(mut writer Writer, mut bytes []u8) !int {
+	return writer.write(mut bytes)!
 }
 ')
 	main_file := os.join_path(root, 'main.v')
@@ -3914,35 +3919,33 @@ pub interface Sink {
 
 import contract
 
-struct Writer {}
+struct Device {}
 
-fn (writer Writer) fill(mut values []int) {
-	_ = writer
-	values << 43
-}
-
-fn apply(sink contract.Sink, mut values []int) {
-	sink.fill(mut values)
+fn (mut device Device) write(mut bytes []u8) !int {
+	_ = device
+	bytes[0] = 7
+	return 1
 }
 
 fn main() {
-	mut values := []int{}
-	apply(Writer{}, mut values)
-	println(values[0])
+	mut writer := contract.Writer(Device{})
+	mut bytes := [u8(0)]
+	contract.fill(mut writer, mut bytes) or { panic(err) }
+	println(bytes[0])
 }
 ')
 	cache_dir := os.join_path(root, 'cache')
 	first_output := os.join_path(root, 'first')
 	compile_module_cache_project(v3_bin, cache_dir, main_file, first_output)
-	assert run_module_cache_binary(first_output) == '43'
+	assert run_module_cache_binary(first_output) == '7'
 	header_path := module_cache_artifact(cache_dir, 'contract_', '.vh')
 	assert header_path.len > 0
 	header := os.read_file(header_path) or { panic(err) }
-	assert header.contains('fill(mut arg0 []int)'), header
+	assert header.contains('mut:\n\twrite(mut arg0 []u8) !int'), header
 
 	second_output := os.join_path(root, 'second')
 	compile_module_cache_project(v3_bin, cache_dir, main_file, second_output)
-	assert run_module_cache_binary(second_output) == '43'
+	assert run_module_cache_binary(second_output) == '7'
 }
 
 fn test_cached_interface_implementer_with_embedded_body_has_forward_declaration() {

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -3908,10 +3908,13 @@ fn test_cached_header_preserves_mutable_interface_method_and_parameter() {
 pub interface Writer {
 mut:
 	write(mut bytes []u8) !int
+	write_byte(mut byte &u8) !int
 }
 
 pub fn fill(mut writer Writer, mut bytes []u8) !int {
-	return writer.write(mut bytes)!
+	writer.write(mut bytes)!
+	mut byte := unsafe { &bytes[0] }
+	return writer.write_byte(mut byte)!
 }
 ')
 	main_file := os.join_path(root, 'main.v')
@@ -3924,6 +3927,12 @@ struct Device {}
 fn (mut device Device) write(mut bytes []u8) !int {
 	_ = device
 	bytes[0] = 7
+	return 1
+}
+
+fn (mut device Device) write_byte(mut byte &u8) !int {
+	_ = device
+	_ = byte
 	return 1
 }
 
@@ -3942,6 +3951,7 @@ fn main() {
 	assert header_path.len > 0
 	header := os.read_file(header_path) or { panic(err) }
 	assert header.contains('mut:\n\twrite(mut arg0 []u8) !int'), header
+	assert header.contains('\twrite_byte(mut arg0 &u8) !int'), header
 
 	second_output := os.join_path(root, 'second')
 	compile_module_cache_project(v3_bin, cache_dir, main_file, second_output)

--- a/vlib/v3/tests/optional_field_runtime_default_codegen_test.v
+++ b/vlib/v3/tests/optional_field_runtime_default_codegen_test.v
@@ -1,0 +1,70 @@
+import os
+
+const opt_default_vexe = @VEXE
+const opt_default_tests_dir = os.dir(@FILE)
+const opt_default_v3_dir = os.dir(opt_default_tests_dir)
+const opt_default_vlib_dir = os.dir(opt_default_v3_dir)
+const opt_default_v3_src = os.join_path(opt_default_v3_dir, 'v3.v')
+
+// An `?T` field (T in another module) must not be expanded into a runtime
+// default of its base struct when generating the default element of a
+// `[]Outer{cap: n}` array. Cross-module `normalize_type_alias` used to strip
+// the `?`, emitting `(Optional_ig__IErr){<IErr fields>}` — invalid C, since the
+// optional wrapper has fields `ok`/`err`/`value`, not the base struct's fields.
+fn test_optional_field_runtime_default_is_none_cross_module() {
+	pid := os.getpid()
+	root := os.join_path(os.temp_dir(), 'v3_opt_default_${pid}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(os.join_path(root, 'ig')) or { panic(err) }
+	v3_bin := os.join_path(root, 'v3_opt_default_driver')
+	out := os.join_path(root, 'program')
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	build :=
+		os.execute('${opt_default_vexe} -gc none -d ownership -path "${opt_default_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${opt_default_v3_src}')
+	assert build.exit_code == 0, build.output
+
+	os.write_file(os.join_path(root, 'v.mod'), "Module { name: 'v3optdefault' }\n") or {
+		panic(err)
+	}
+	os.write_file(os.join_path(root, 'ig', 'ig.v'), 'module ig
+
+pub struct IErr implements IClone {
+pub mut:
+	message string
+	nested  []IErr
+}
+') or {
+		panic(err)
+	}
+	os.write_file(os.join_path(root, 'main.v'), 'module main
+import ig
+
+struct Mid implements IClone {
+pub mut:
+	err  ?ig.IErr
+	name string
+}
+
+struct Outer implements IClone {
+pub mut:
+	mid Mid
+}
+
+fn build(n int) []Outer {
+	return []Outer{cap: n}
+}
+
+fn main() {
+	assert build(3).len == 0
+}
+') or {
+		panic(err)
+	}
+
+	compile := os.execute('${v3_bin} ${os.join_path(root, 'main.v')} -d ownership -b c -o ${out}')
+	assert compile.exit_code == 0, compile.output
+	run := os.execute(out)
+	assert run.exit_code == 0, run.output
+}

--- a/vlib/v3/tests/ownership/ownership_test.v
+++ b/vlib/v3/tests/ownership/ownership_test.v
@@ -81,6 +81,20 @@ fn main() {}
 	assert ok.exit_code == 0, ok.output
 }
 
+fn test_non_mut_reference_parameter_accepts_literal_temporary() {
+	v3_bin := ownership_build_v3()
+	result := run_ownership_check(v3_bin, 'borrow_literal_temporary', '
+fn borrowed_len(value &string) int {
+	return value.len
+}
+
+fn main() {
+	assert borrowed_len("literal") == 7
+}
+')
+	assert result.exit_code == 0, result.output
+}
+
 fn test_ownership_move_on_assign_and_clone_escape() {
 	v3_bin := ownership_build_v3()
 	fail := run_ownership_check(v3_bin, 'move_assign', "
@@ -2714,6 +2728,31 @@ fn main() {
 ')
 	assert fail_map_dynamic_index_read.exit_code != 0
 	assert fail_map_dynamic_index_read.output.contains('use of moved value: `m[k]`'), fail_map_dynamic_index_read.output
+}
+
+fn test_ownership_array_alias_builtin_method_keeps_receiver() {
+	v3_bin := ownership_build_v3()
+	ok := run_ownership_check(v3_bin, 'array_alias_insert_keeps_receiver', '
+type Strings = []string
+
+struct State {
+mut:
+	values map[string]string
+}
+
+fn (mut state State) reset() {
+	state.values = map[string]string{}
+}
+
+fn main() {
+	mut values := Strings{}
+	values.insert(0, "item".to_owned())
+	println(values.len)
+	mut state := State{}
+	state.reset()
+}
+')
+	assert ok.exit_code == 0, ok.output
 }
 
 fn test_ownership_aggregate_borrows_block_overlapping_reassignment() {

--- a/vlib/v3/tests/ownership/ownership_test.v
+++ b/vlib/v3/tests/ownership/ownership_test.v
@@ -3031,6 +3031,59 @@ fn main() {
 
 fn test_ownership_branch_moves_are_isolated_between_siblings() {
 	v3_bin := ownership_build_v3()
+	distinct_field_moves := run_ownership_check(v3_bin, 'branch_distinct_field_moves', '
+interface Drop {
+mut:
+	drop()
+}
+
+struct Resource implements Drop {
+	id int
+}
+
+fn (mut resource Resource) drop() {
+	println(resource.id)
+}
+
+struct Pair {
+	left  Resource
+	right Resource
+}
+
+fn consume(resource Resource) {
+	_ = resource.id
+}
+
+fn run(cond bool, base int) {
+	value := Pair{
+		left: Resource{
+			id: base
+		}
+		right: Resource{
+			id: base + 1
+		}
+	}
+	if cond {
+		consume(value.left)
+	} else {
+		consume(value.right)
+	}
+}
+
+fn main() {
+	run(true, 1)
+	run(false, 3)
+}
+')
+	assert distinct_field_moves.exit_code == 0, distinct_field_moves.output
+	distinct_field_binary := os.join_path(os.temp_dir(),
+		'v3_ownership_branch_distinct_field_moves_${os.getpid()}', 'out')
+	distinct_field_run := os.execute(distinct_field_binary)
+	assert distinct_field_run.exit_code == 0, distinct_field_run.output
+	dropped_ids := distinct_field_run.output.fields()
+	assert '2' in dropped_ids, distinct_field_run.output
+	assert '3' in dropped_ids, distinct_field_run.output
+
 	ok_sibling := run_ownership_check(v3_bin, 'branch_sibling_isolation', "
 fn main() {
 	cond := true

--- a/vlib/v3/tests/ownership_clone_codegen_fixes_test.v
+++ b/vlib/v3/tests/ownership_clone_codegen_fixes_test.v
@@ -1,0 +1,531 @@
+import os
+
+const occf_vexe = @VEXE
+const occf_tests_dir = os.dir(@FILE)
+const occf_v3_dir = os.dir(occf_tests_dir)
+const occf_vlib_dir = os.dir(occf_v3_dir)
+const occf_v3_src = os.join_path(occf_v3_dir, 'v3.v')
+
+fn occf_build_v3(tag string) string {
+	pid := os.getpid()
+	v3_bin := os.join_path(os.temp_dir(), 'v3_${tag}_${pid}')
+	build :=
+		os.execute('${occf_vexe} -gc none -d ownership -path "${occf_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${occf_v3_src}')
+	assert build.exit_code == 0, build.output
+	return v3_bin
+}
+
+fn occf_compile_and_run(v3_bin string, tag string, source string) {
+	pid := os.getpid()
+	src := os.join_path(os.temp_dir(), 'v3_${tag}_${pid}.v')
+	out := os.join_path(os.temp_dir(), 'v3_${tag}_prog_${pid}')
+	defer {
+		os.rm(src) or {}
+		os.rm(out) or {}
+		os.rm(out + '.c') or {}
+	}
+	os.write_file(src, source) or { panic(err) }
+	compile := os.execute('${v3_bin} ${src} -d ownership -b c -o ${out}')
+	assert compile.exit_code == 0, compile.output
+	run := os.execute(out)
+	assert run.exit_code == 0, run.output
+}
+
+// Reassigning an `?string` field via the drop-before-assign lowering must keep
+// the optional storage type; the temp used to hold the (auto-wrapped) value must
+// be `Optional_string`, not the unwrapped `string` smartcast.
+fn test_optional_drop_before_assign_keeps_optional_temp() {
+	v3_bin := occf_build_v3('opt_drop_assign')
+	defer {
+		os.rm(v3_bin) or {}
+	}
+	occf_compile_and_run(v3_bin, 'opt_drop_assign', 'module main
+
+fn f(input ?string) ?string {
+	mut preprocessor := ?string(none)
+	if value := input {
+		preprocessor = value.clone()
+	}
+	return preprocessor
+}
+
+fn main() {
+	assert (f("hello") or { "none" }) == "hello"
+}
+')
+}
+
+// The final synthetic store in drop-before-assign lowering may be visited by
+// transform again. It must not destroy the same old field value a second time.
+fn test_owned_field_assignment_drops_replaced_value_once() {
+	v3_bin := occf_build_v3('field_assign_one_drop')
+	defer {
+		os.rm(v3_bin) or {}
+	}
+	occf_compile_and_run(v3_bin, 'field_assign_one_drop', 'module main
+
+struct Owned implements Drop {
+	drops &int
+}
+
+fn (mut value Owned) drop() {
+	unsafe {
+		*value.drops += 1
+	}
+}
+
+struct Holder {
+mut:
+	value Owned
+}
+
+fn main() {
+	mut drops := 0
+	mut holder := Holder{
+		value: Owned{
+			drops: &drops
+		}
+	}
+	holder.value = Owned{
+		drops: &drops
+	}
+	assert drops == 1
+}
+')
+}
+
+// `.clone()` on an array reached through a method that already returns a pointer
+// (`arc.Arc[[]T].get()` returns `&[]T`) must not take the address again.
+fn test_array_clone_on_pointer_returning_receiver() {
+	v3_bin := occf_build_v3('arc_get_clone')
+	defer {
+		os.rm(v3_bin) or {}
+	}
+	occf_compile_and_run(v3_bin, 'arc_get_clone', 'module main
+
+import sync.arc
+
+fn f() []string {
+	a := arc.new(["x", "y"])
+	return a.get().clone()
+}
+
+fn length(values []string) int {
+	return values.len
+}
+
+fn main() {
+	assert f().len == 2
+	a := arc.new(["x", "y"])
+	assert length(a.get()) == 2
+}
+')
+}
+
+// A concrete generic-interface application uses the base interface's runtime
+// box while retaining its specialized method parameter types.
+fn test_generic_interface_parameter_uses_base_runtime_box() {
+	v3_bin := occf_build_v3('generic_interface_parameter')
+	defer {
+		os.rm(v3_bin) or {}
+	}
+	occf_compile_and_run(v3_bin, 'generic_interface_parameter', 'module main
+
+interface CaptureFinder[T] {
+	captures_at(mut caps T) bool
+}
+
+struct Captures {
+mut:
+	count int
+}
+
+struct Matcher {}
+
+fn (m Matcher) captures_at(mut caps Captures) bool {
+	_ = m
+	caps.count++
+	return true
+}
+
+fn captures[T](matcher &CaptureFinder[T], mut caps T) bool {
+	return matcher.captures_at(mut caps)
+}
+
+fn main() {
+	matcher := Matcher{}
+	mut caps := Captures{}
+	assert captures(matcher, mut caps)
+	assert caps.count == 1
+}
+')
+}
+
+// `Drop` does not prevent Rust from deriving `Clone`. An ownership type that
+// explicitly implements both markers can use the compiler's structural clone
+// as long as each ownership-bearing field is itself cloneable.
+fn test_default_clone_is_available_for_drop_type() {
+	v3_bin := occf_build_v3('clone_drop_type')
+	defer {
+		os.rm(v3_bin) or {}
+	}
+	occf_compile_and_run(v3_bin, 'clone_drop_type', 'module main
+
+struct Owned implements IClone, Drop {
+mut:
+	value string
+}
+
+fn (mut x Owned) drop() {
+	x.value = ""
+}
+
+fn main() {
+	first := Owned{
+		value: "hello".to_owned()
+	}
+	second := first.clone()
+	assert first.value == "hello"
+	assert second.value == "hello"
+}
+')
+}
+
+// Array iteration binds elements by value. Ownership-bearing elements must be
+// structurally cloned before the loop body so dropping a binding cannot free
+// storage still owned by the source array.
+fn test_array_for_in_clones_ownership_bearing_elements() {
+	v3_bin := occf_build_v3('array_for_in_clone')
+	defer {
+		os.rm(v3_bin) or {}
+	}
+	occf_compile_and_run(v3_bin, 'array_for_in_clone', 'module main
+
+struct Record implements IClone {
+	name string
+	arg  ?string
+}
+
+fn main() {
+	records := [Record{
+		name: "after-context".to_owned()
+		arg:  "5".to_owned()
+	}]
+	for record in records {
+		assert record.name == "after-context"
+		assert record.arg or { "" } == "5"
+	}
+	assert records[0].name == "after-context"
+	assert records[0].arg or { "" } == "5"
+}
+')
+}
+
+// Captured function literals retain their declared parameter types during checking, so
+// generic builtin methods can validate them against the specialized element
+// type instead of falling back to `fn (voidptr, voidptr)`.
+fn test_captured_sort_compare_keeps_parameter_types() {
+	v3_bin := occf_build_v3('captured_sort_compare')
+	defer {
+		os.rm(v3_bin) or {}
+	}
+	occf_compile_and_run(v3_bin, 'captured_sort_compare', 'module main
+
+struct Item {
+	value int
+}
+
+fn main() {
+	reverse := true
+	mut items := [Item{value: 1}, Item{value: 2}]
+	items.sort_with_compare(fn [reverse] (a &Item, b &Item) int {
+		if reverse {
+			return b.value - a.value
+		}
+		return a.value - b.value
+	})
+	assert items[0].value == 2
+}
+')
+}
+
+// Generic specialization keeps the checker's implicit reference conversion
+// when a concrete value is passed to a borrowed interface parameter.
+fn test_generic_method_accepts_value_for_borrowed_interface_parameter() {
+	v3_bin := occf_build_v3('generic_borrowed_interface_arg')
+	defer {
+		os.rm(v3_bin) or {}
+	}
+	occf_compile_and_run(v3_bin, 'generic_borrowed_interface_arg', 'module main
+
+interface Reader {
+	value() int
+}
+
+struct Borrowed[^a] {
+	value &^a int
+}
+
+fn Borrowed.new[^a](value &^a int) Borrowed[^a] {
+	return Borrowed[^a]{
+		value: value
+	}
+}
+
+fn (borrowed Borrowed[^a]) value[^a]() int {
+	return *borrowed.value
+}
+
+struct Searcher {}
+
+fn (searcher Searcher) search[^a](reader &^a Reader) int {
+	_ = searcher
+	return reader.value()
+}
+
+struct Worker[T] {
+	value    T
+	searcher Searcher
+}
+
+fn (worker Worker[T]) run(value &int) int {
+	borrowed := Borrowed.new(value)
+	return worker.searcher.search(borrowed)
+}
+
+fn main() {
+	n := 42
+	worker := Worker[int]{
+		value: 1
+		searcher: Searcher{}
+	}
+	assert worker.run(&n) == 42
+}
+')
+}
+
+// Consuming an aggregate call argument moves its base and owned descendants as
+// one value instead of treating the descendant metadata as a second use.
+fn test_call_consumes_owned_aggregate_and_descendants_once() {
+	v3_bin := occf_build_v3('call_owned_aggregate')
+	defer {
+		os.rm(v3_bin) or {}
+	}
+	occf_compile_and_run(v3_bin, 'call_owned_aggregate', 'module main
+
+struct Owned implements Drop {
+mut:
+	value string
+}
+
+fn (mut value Owned) drop() {
+	value.value = ""
+}
+
+struct Wrapper[T] {
+	value T
+}
+
+fn wrap[T](value T) Wrapper[T] {
+	return Wrapper[T]{
+		value: value
+	}
+}
+
+fn consume[T](first Owned, second Wrapper[T]) int {
+	return first.value.len + second.value.value.len
+}
+
+fn main() {
+	first := Owned{
+		value: "a".to_owned()
+	}
+	second := Owned{
+		value: "b".to_owned()
+	}
+	assert consume(first, wrap(second)) == 2
+}
+')
+}
+
+// Reannotation rebuilds local scopes after generic specialization. Mutable
+// declarations must keep their mutability there so chained generic receiver
+// calls are not diagnosed as calls on immutable values.
+fn test_chained_generic_mut_receiver_keeps_mutable_local() {
+	v3_bin := occf_build_v3('generic_mut_receiver')
+	defer {
+		os.rm(v3_bin) or {}
+	}
+	occf_compile_and_run(v3_bin, 'generic_mut_receiver', 'module main
+
+struct Inner[T] {
+mut:
+	value T
+}
+
+fn (mut inner Inner[T]) get_mut() &T {
+	return &inner.value
+}
+
+struct Outer[T] {
+mut:
+	inner Inner[T]
+}
+
+fn (mut outer Outer[T]) inner_mut() &Inner[T] {
+	return &outer.inner
+}
+
+fn main() {
+	mut outer := Outer[int]{
+		inner: Inner[int]{
+			value: 42
+		}
+	}
+	value := outer.inner_mut().get_mut()
+	assert *value == 42
+}
+')
+}
+
+// Moving a destructible aggregate leaves its source storage uninitialized.
+// A later assignment must initialize that storage directly instead of dropping
+// the old bits, which now belong to the move destination. The same rule applies
+// when the move destination is an optional.
+fn test_moved_aggregate_reassignment_skips_stale_drop() {
+	v3_bin := occf_build_v3('moved_reassign')
+	defer {
+		os.rm(v3_bin) or {}
+	}
+	occf_compile_and_run(v3_bin, 'moved_reassign', 'module main
+
+struct Owned implements Drop {
+mut:
+	value string
+	drops &int
+}
+
+struct BorrowedAggregate {
+	tag   rune
+	value string
+}
+
+struct WrappedOwned {
+	value Owned
+}
+
+fn (mut value Owned) drop() {
+	unsafe {
+		*value.drops += 1
+	}
+	value.value = ""
+}
+
+fn direct_move(drops &int) {
+	mut current := Owned{
+		value: "old".to_owned()
+		drops: drops
+	}
+	saved := current
+	current = Owned{
+		value: "new".to_owned()
+		drops: drops
+	}
+	unsafe {
+		assert *drops == 0
+	}
+	assert saved.value == "old"
+	assert current.value == "new"
+}
+
+fn optional_move(drops &int) {
+	mut current := Owned{
+		value: "old".to_owned()
+		drops: drops
+	}
+	mut previous := ?Owned(none)
+	previous = ?Owned(current)
+	current = Owned{
+		value: "new".to_owned()
+		drops: drops
+	}
+	unsafe {
+		assert *drops == 0
+	}
+	if saved := previous {
+		assert saved.value == "old"
+	}
+	assert current.value == "new"
+}
+
+fn nested_array_append_move(drops &int) {
+	mut outer := [][]Owned{}
+	mut inner := [Owned{
+		value: "nested".to_owned()
+		drops: drops
+	}]
+	outer << inner
+	inner = []Owned{}
+	unsafe {
+		assert *drops == 0
+	}
+	assert outer[0][0].value == "nested"
+}
+
+fn parse_number(text string) !u64 {
+	if text == "" {
+		return error("empty")
+	}
+	return text.u64()
+}
+
+fn scalar_result_is_copy(text string) {
+	n := parse_number(text) or { 0 }
+	copy := n
+	assert n == copy
+}
+
+fn borrowed_scalar_field_is_copy(value &BorrowedAggregate) string {
+	return unsafe { u8(value.tag).ascii_str() }
+}
+
+fn wrap_owned(value Owned) WrappedOwned {
+	return WrappedOwned{
+		value: value
+	}
+}
+
+fn consume_wrapped(value WrappedOwned) bool {
+	return value.value.value == "nested call"
+}
+
+fn nested_call_moves_source_once(drops &int) {
+	value := Owned{
+		value: "nested call".to_owned()
+		drops: drops
+	}
+	assert consume_wrapped(wrap_owned(value))
+}
+
+fn main() {
+	mut direct_drops := 0
+	direct_move(&direct_drops)
+	assert direct_drops == 2
+	mut optional_drops := 0
+	optional_move(&optional_drops)
+	assert optional_drops == 2
+	mut nested_drops := 0
+	nested_array_append_move(&nested_drops)
+	assert nested_drops == 1
+	scalar_result_is_copy("17")
+	borrowed := BorrowedAggregate{
+		tag: `A`
+		value: "owned".to_owned()
+	}
+	assert borrowed_scalar_field_is_copy(&borrowed) == "A"
+	mut nested_call_drops := 0
+	nested_call_moves_source_once(&nested_call_drops)
+	assert nested_call_drops == 1
+}
+')
+}

--- a/vlib/v3/tests/ownership_self_reassign_call_codegen_test.v
+++ b/vlib/v3/tests/ownership_self_reassign_call_codegen_test.v
@@ -1,0 +1,121 @@
+import os
+
+// Regression test for the `x = f(mut x)` use-after-free.
+//
+// When a call takes `x` by mutable reference, mutates its owned (heap) storage
+// in place, and returns (a copy of) `x`, the assignment `x = f(mut x)` must NOT
+// drop `x` before the assignment: the returned value aliases `x`'s heap buffer,
+// so dropping first frees storage the result still points at. This reproduced as
+// corrupted array contents (e.g. `2043 0 3 4` instead of `1 2 3 4`) and, in the
+// ripgrep port's literal extractor (`seq = ex.cross(seq, ...)`), as a crash.
+
+const vexe = @VEXE
+const tests_dir = os.dir(@FILE)
+const v3_dir = os.dir(tests_dir)
+const vlib_dir = os.dir(v3_dir)
+const v3_src = os.join_path(v3_dir, 'v3.v')
+
+fn self_reassign_build_v3() string {
+	v3_bin := os.join_path(os.temp_dir(), 'v3_self_reassign_call_codegen_test_${os.getpid()}')
+	os.rm(v3_bin) or {}
+	build :=
+		os.execute('${vexe} -gc none -path "${vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${v3_src}')
+	assert build.exit_code == 0, build.output
+	return v3_bin
+}
+
+fn self_reassign_run_good(v3_bin string, name string, source string) string {
+	src := os.join_path(os.temp_dir(), 'v3_${name}_${os.getpid()}.v')
+	os.write_file(src, source) or { panic(err) }
+	bin := os.join_path(os.temp_dir(), 'v3_${name}_${os.getpid()}')
+	compile := os.execute('${v3_bin} ${src} -b c -o ${bin}')
+	assert compile.exit_code == 0, compile.output
+	assert !compile.output.contains('C compilation failed'), compile.output
+	run := os.execute(bin)
+	assert run.exit_code == 0, run.output
+	return run.output.trim_space()
+}
+
+// `acc = combine(mut acc, mut other)` where `combine` returns its mutated-by-ref
+// first argument. The heap array field must survive intact.
+fn test_self_reassign_via_mut_ref_call_preserves_owned_field() {
+	v3_bin := self_reassign_build_v3()
+	out := self_reassign_run_good(v3_bin, 'self_reassign_bag', 'struct Bag implements IClone {
+mut:
+	items []int
+}
+
+fn (b &Bag) clone() Bag {
+	return Bag{ items: b.items.clone() }
+}
+
+fn combine(mut a Bag, mut b Bag) Bag {
+	for x in b.items {
+		a.items << x
+	}
+	return a
+}
+
+fn main() {
+	mut acc := Bag{ items: [1, 2] }
+	mut other := Bag{ items: [3, 4] }
+	acc = combine(mut acc, mut other)
+	assert acc.items.len == 4
+	assert acc.items[0] == 1
+	assert acc.items[1] == 2
+	assert acc.items[2] == 3
+	assert acc.items[3] == 4
+	println("ok")
+}
+')
+	assert out == 'ok'
+}
+
+// Nested-owned variant closer to the extractor: a struct holds an array of
+// structs that each own a `[]u8`. `seq = grow(mut seq, ...)` must not free the
+// inner buffers early.
+fn test_self_reassign_preserves_nested_owned_arrays() {
+	v3_bin := self_reassign_build_v3()
+	out := self_reassign_run_good(v3_bin, 'self_reassign_nested', 'struct Lit implements IClone {
+mut:
+	bytes []u8
+}
+
+fn (l &Lit) clone() Lit {
+	return Lit{ bytes: l.bytes.clone() }
+}
+
+struct Seq implements IClone {
+mut:
+	lits []Lit
+}
+
+fn (s &Seq) clone() Seq {
+	mut out := []Lit{cap: s.lits.len}
+	for l in s.lits {
+		out << l.clone()
+	}
+	return Seq{ lits: out }
+}
+
+fn grow(mut s Seq, b u8) Seq {
+	mut fresh := []u8{}
+	fresh << b
+	s.lits << Lit{ bytes: fresh }
+	return s
+}
+
+fn main() {
+	mut seq := Seq{ lits: [] }
+	seq = grow(mut seq, `a`)
+	seq = grow(mut seq, `b`)
+	seq = grow(mut seq, `c`)
+	assert seq.lits.len == 3
+	assert seq.lits[0].bytes[0] == `a`
+	assert seq.lits[1].bytes[0] == `b`
+	assert seq.lits[2].bytes[0] == `c`
+	println("ok")
+}
+')
+	assert out == 'ok'
+}

--- a/vlib/v3/tests/review_transform_regressions_test.v
+++ b/vlib/v3/tests/review_transform_regressions_test.v
@@ -3429,6 +3429,100 @@ fn test_generic_interface_method_body_marks_log_debug_dispatch() {
 	assert out == 'ok'
 }
 
+fn test_generic_interface_mut_pointer_parameter_uses_erased_dispatch_abi() {
+	v3_bin := build_v3_review_transform_ownership()
+	out := run_good_with_flags(v3_bin, 'generic_interface_mut_pointer_dispatch', '-ownership', 'interface Writer[T] {
+	write(mut value T) !bool
+}
+
+struct Text {
+mut:
+	value string
+}
+
+struct Count {
+	padding [7]u8
+mut:
+	value int
+}
+
+struct TextWriter {}
+struct CountWriter {}
+
+fn (_ TextWriter) write(mut value Text) !bool {
+	value.value = "done"
+	return true
+}
+
+fn (_ CountWriter) write(mut value Count) !bool {
+	value.value = 42
+	return true
+}
+
+fn apply[T](writer &Writer[T], mut value T) !bool {
+	return writer.write(mut value)
+}
+
+fn main() {
+	mut text := Text{
+		value: "before"
+	}
+	mut count := Count{
+		value: 1
+	}
+	assert apply(TextWriter{}, mut text)!
+	assert apply(CountWriter{}, mut count)!
+	println(text.value + ":" + int_str(count.value))
+}
+')
+	assert out == 'done:42'
+}
+
+fn test_generic_interface_implementer_result_uses_dispatch_abi() {
+	v3_bin := build_v3_review_transform_ownership()
+	out := run_good_with_flags(v3_bin, 'generic_interface_implementer_result_dispatch',
+		'-ownership', 'interface Writer {
+mut:
+	write(buf []u8) !int
+}
+
+struct Buffer {}
+
+fn (mut b Buffer) write(buf []u8) !int {
+	_ = b
+	return buf.len
+}
+
+struct CounterWriter[W] {
+mut:
+	inner W
+}
+
+fn (mut w CounterWriter[W]) write(buf []u8) !int {
+	$if W is Writer {
+		return w.inner.write(buf)
+	} $else {
+		return error("not a writer")
+	}
+}
+
+fn write_len(mut writer Writer) !int {
+	return writer.write([u8(1), 2, 3])
+}
+
+fn main() {
+	mut plain := Buffer{}
+	assert write_len(mut plain)! == 3
+	mut counter := CounterWriter[Buffer]{
+		inner: Buffer{}
+	}
+	assert write_len(mut counter)! == 3
+	println("ok")
+}
+')
+	assert out == 'ok'
+}
+
 fn test_materialized_generic_interface_implementer_has_runtime_type_name() {
 	v3_bin := build_v3_review_transform()
 	out := run_good(v3_bin, 'generic_body_materialized_interface_implementer', 'interface Any {

--- a/vlib/v3/transform/array.v
+++ b/vlib/v3/transform/array.v
@@ -481,7 +481,14 @@ fn (mut t Transformer) lower_array_init_to_runtime(id flat.NodeId, node flat.Nod
 	}
 	assign := t.make_assign(elem_lhs, assign_value)
 	loop_body << assign
-	t.pending_stmts << t.make_for_stmt(init_idx, cond, post, loop_body, node)
+	// This synthetic default-fill loop carries no user code and owns nothing, so
+	// it must not consume an ownership-drop loop-iteration slot. The checker only
+	// indexed the source-level loops; if this transform-inserted loop claimed a
+	// slot, the following real loop's per-iteration drops would be emitted here
+	// (referencing a variable not in scope) and dropped from their real loop.
+	for_id := t.make_for_stmt(init_idx, cond, post, loop_body, node)
+	t.a.nodes[int(for_id)].skip_ownership_drops = true
+	t.pending_stmts << for_id
 	result := t.make_ident(tmp_name)
 	t.set_node_typ(int(result), '[]${elem_type}')
 	return result
@@ -525,7 +532,19 @@ fn (mut t Transformer) make_struct_runtime_default_value_guarded(struct_type str
 			if field.typ.len > 0 { field.typ } else { field.raw_typ }
 		}
 		clean_type := t.normalize_type_alias(field_type)
+		// An `?T`/`!T` field with no explicit default is `none`/the zero value,
+		// which the zeroed array element already provides. Never expand it into a
+		// runtime default of its base struct: cross-module `normalize_type_alias`
+		// can strip the `?`/`!`, which would otherwise emit the base struct's
+		// fields into the optional wrapper (`(Optional_T){<T fields>}`).
+		raw_field_type := if field.raw_typ.len > 0 { field.raw_typ } else { field.typ }
+		field_is_optional := field_type.starts_with('?') || field_type.starts_with('!')
+			|| raw_field_type.starts_with('?') || raw_field_type.starts_with('!')
+			|| clean_type.starts_with('?') || clean_type.starts_with('!')
 		mut value := flat.empty_node
+		if field_is_optional && int(field.default_expr) < 0 {
+			continue
+		}
 		if int(field.default_expr) >= 0 {
 			default_node := t.a.nodes[int(field.default_expr)]
 			enum_field_type := t.enum_type_name_for_expected(field_type, info.module)
@@ -1490,6 +1509,14 @@ fn (mut t Transformer) try_lower_optional_array_append_stmt(_node flat.Node, lhs
 
 fn (mut t Transformer) clone_borrowed_array_append_value(source_id flat.NodeId, value flat.NodeId, elem_type string) flat.NodeId {
 	if isnil(t.tc) || !t.expr_can_take_address(source_id) {
+		return value
+	}
+	// Ownership mode transfers an addressable by-value RHS into the appended
+	// element. The non-ownership lowering clones it to preserve ordinary V
+	// value semantics, but doing that here would leave the moved source owning
+	// the same nested storage and make its later reinitialization free the
+	// destination's data.
+	if t.tc.ownership_expr_moves_storage(source_id, source_id) {
 		return value
 	}
 	if !t.compiler_default_clone_type_needs_work(elem_type) {

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -7868,7 +7868,7 @@ fn (mut t Transformer) make_compiler_default_clone_value(source flat.NodeId, typ
 			t.pending_stmts << t.make_expr_stmt(drop_call)
 			cloned_field = t.make_ident(cloned_name)
 		}
-		t.pending_stmts << t.make_assign_without_ownership_drop(t.make_selector(t.make_ident(tmp_name),
+		t.pending_stmts << t.make_assign_after_owned_drop(t.make_selector(t.make_ident(tmp_name),
 			field.name, field_type), cloned_field)
 	}
 	return t.make_ident(tmp_name)

--- a/vlib/v3/transform/for.v
+++ b/vlib/v3/transform/for.v
@@ -577,6 +577,15 @@ fn (mut t Transformer) rebuild_for_in_stmt(_id flat.NodeId, node flat.Node) []fl
 			value_name := if int(key_id) >= 0 { t.a.nodes[int(key_id)].value } else { '' }
 			binding_clones << t.make_for_in_binding_clone(value_name, value_type)
 		}
+	} else if iter_type.starts_with('[]') || t.is_fixed_array_type(iter_type) {
+		value_name := if has_index {
+			if int(val_id) >= 0 { t.a.nodes[int(val_id)].value } else { '' }
+		} else {
+			if int(key_id) >= 0 { t.a.nodes[int(key_id)].value } else { '' }
+		}
+		elem_type := t.infer_for_in_elem_type(iter_type, node)
+		value_type := if node.op == .amp { '&${elem_type}' } else { elem_type }
+		binding_clones << t.make_for_in_binding_clone(value_name, value_type)
 	}
 
 	mut ids := []flat.NodeId{}

--- a/vlib/v3/transform/map.v
+++ b/vlib/v3/transform/map.v
@@ -1211,7 +1211,7 @@ fn (mut t Transformer) try_lower_map_index_selector_assign(node flat.Node) ?[]fl
 	rhs_name := t.new_temp('map_field_value')
 	result << t.make_decl_assign_typed(rhs_name, rhs, field_type)
 	t.append_owned_lvalue_drop_before_assign_if(field, field_type, current_existed, mut result)
-	result << t.make_assign(field, t.make_ident(rhs_name))
+	result << t.make_assign_after_owned_drop(field, t.make_ident(rhs_name))
 	result << t.make_map_set_stmt(map_expr, info.base_type, key_name, current_name)
 	t.append_owned_map_set_key_cleanup(key_name, cleanup_key, existing_key_name, mut result)
 	return result

--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -1430,6 +1430,21 @@ fn (t &Transformer) interface_boxed_type_marked(iface_name string, concrete_type
 			return true
 		}
 	}
+	// A concrete instantiation (`Foo[int]`) is boxed if its generic form was
+	// boxed: the box scan only sees the generic-form argument and records the
+	// base name `Foo` (see mark_interface_boxed_type), because the concrete
+	// instantiations are materialised after the scan has frozen.
+	if bracket := concrete_type.index('[') {
+		base := concrete_type[..bracket].trim_space()
+		if base.len > 0 {
+			for iface in iface_names {
+				if t.interface_boxed_types[interface_boxed_type_key(iface, base)]
+					|| t.interface_boxed_types[interface_boxed_type_key(iface, c_name(base))] {
+					return true
+				}
+			}
+		}
+	}
 	for candidate in [concrete_type, t.tc.qualify_name(concrete_type)] {
 		target := t.tc.type_aliases[candidate] or { continue }
 		for iface in iface_names {
@@ -2226,6 +2241,19 @@ fn (mut t Transformer) mark_interface_boxed_type(iface_name string, concrete_typ
 	for iface in iface_names {
 		t.interface_boxed_types[interface_boxed_type_key(iface, concrete_type)] = true
 		t.interface_boxed_types[interface_boxed_type_key(iface, c_name(concrete_type))] = true
+		// Also record the generic base name (`Foo` for `Foo[T]`). The box scan
+		// runs once and then freezes, so it sees only the generic-form box (a
+		// `Foo[W]` argument passed to an interface parameter); the concrete
+		// instantiations (`Foo[int]`) are created later and cannot be marked.
+		// Recording the base lets `interface_boxed_type_marked` recognise any of
+		// those instantiations as boxed.
+		if bracket := concrete_type.index('[') {
+			base := concrete_type[..bracket].trim_space()
+			if base.len > 0 {
+				t.interface_boxed_types[interface_boxed_type_key(iface, base)] = true
+				t.interface_boxed_types[interface_boxed_type_key(iface, c_name(base))] = true
+			}
+		}
 	}
 }
 

--- a/vlib/v3/transform/return.v
+++ b/vlib/v3/transform/return.v
@@ -366,8 +366,14 @@ fn (t &Transformer) return_expr_is_optional_result(id flat.NodeId) bool {
 			return t.is_optional_type_name(smartcast_ret)
 		}
 		if typ := t.tc.expr_type(id) {
-			if typ is types.OptionType || typ is types.ResultType {
-				return true
+			if typ !is types.Unknown && typ !is types.Void {
+				// A propagated `call()!` is annotated with its successful payload
+				// type. In a compatible `return` position it can still forward the
+				// callee's complete Result directly, so a non-wrapper expression
+				// annotation must not hide the declared call return below.
+				if typ is types.OptionType || typ is types.ResultType {
+					return true
+				}
 			}
 		}
 		if name := t.tc.resolved_call_name(id) {

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -10797,7 +10797,13 @@ fn (mut t Transformer) transform_assign_stmt(id flat.NodeId, node flat.Node) []f
 			}
 		}
 	}
+	// Capture the lvalue's declared storage type before the optional-assign
+	// smartcast unwraps it (`?string` -> `string`), so the drop-before-assign
+	// temp below keeps the optional storage type the assigned value is wrapped
+	// to, instead of a `string` temp initialised with an `Optional_string`.
+	mut pre_smartcast_lhs_type := ''
 	if node.kind == .assign && node.op == .assign && node.children_count == 2 {
+		pre_smartcast_lhs_type = t.lvalue_type(t.a.child(&node, 0))
 		t.update_option_assignment_smartcast(t.a.child(&node, 0), t.a.child(&node, 1))
 	}
 	if node.kind in [.assign, .selector_assign, .index_assign] && node.op == .assign
@@ -10807,10 +10813,13 @@ fn (mut t Transformer) transform_assign_stmt(id flat.NodeId, node flat.Node) []f
 		lhs_node := t.a.nodes[int(lhs_id)]
 		// Whole-variable assignment overwrites the variable's storage type, even
 		// when an active optional smartcast makes the expression read as its payload.
-		mut lhs_type_name := if lhs_node.kind == .ident {
-			t.var_type(lhs_node.value)
-		} else {
-			t.lvalue_type(t.a.child(&node, 0))
+		mut lhs_type_name := pre_smartcast_lhs_type
+		if lhs_type_name.len == 0 {
+			lhs_type_name = if lhs_node.kind == .ident {
+				t.var_type(lhs_node.value)
+			} else {
+				t.lvalue_type(t.a.child(&node, 0))
+			}
 		}
 		if lhs_type_name.len == 0 {
 			lhs_type_name = t.lvalue_type(new_children[0])
@@ -10826,6 +10835,7 @@ fn (mut t Transformer) transform_assign_stmt(id flat.NodeId, node flat.Node) []f
 			&& node.kind in [.selector_assign, .index_assign]
 		if !t.cur_fn_manualfree && !autofree_aggregate_lvalue
 			&& t.tc.ownership_type_requires_destruction(lhs_type)
+			&& !t.tc.ownership_assignment_reinitializes_moved_value(id)
 			&& !t.tc.ownership_expr_moves_storage(rhs_id, lhs_id) {
 			mut result := []flat.NodeId{}
 			t.drain_pending(mut result)
@@ -10862,7 +10872,7 @@ fn (mut t Transformer) transform_assign_stmt(id flat.NodeId, node flat.Node) []f
 			t.drain_pending(mut result)
 			drop_call := t.make_call_typed('drop_owned', arr1(lvalue), 'void')
 			result << t.make_expr_stmt(drop_call)
-			result << t.make_assign(lvalue, t.make_ident(tmp_name))
+			result << t.make_assign_after_owned_drop(lvalue, t.make_ident(tmp_name))
 			t.invalidate_smartcast_for_lvalue(t.a.child(&node, 0))
 			return result
 		}
@@ -11274,7 +11284,7 @@ fn (mut t Transformer) try_lower_optional_selector_lvalue_assign(node flat.Node)
 			stable_lhs := t.stabilize_transformed_lvalue_for_reuse(lowered_lhs)
 			t.drain_pending(mut result)
 			t.append_owned_lvalue_drop_before_assign(stable_lhs, lhs_type, mut result)
-			result << t.make_assign(stable_lhs, t.make_ident(rhs_name))
+			result << t.make_assign_after_owned_drop(stable_lhs, t.make_ident(rhs_name))
 			return result
 		}
 	}
@@ -13720,7 +13730,7 @@ fn (mut t Transformer) try_expand_multi_return_assign(node flat.Node) ?[]flat.No
 				t.drain_pending(mut result)
 				t.append_owned_lvalue_drop_before_assign(lvalue, field_type_name, mut result)
 			}
-			result << t.make_assign(lvalue, field)
+			result << t.make_assign_after_owned_drop(lvalue, field)
 		}
 		return result
 	}
@@ -13814,7 +13824,7 @@ fn (mut t Transformer) try_expand_plain_multi_assign(node flat.Node) ?[]flat.Nod
 			t.drain_pending(mut result)
 			t.append_owned_lvalue_drop_before_assign(lvalue, lhs_type, mut result)
 		}
-		result << t.make_assign(lvalue, t.make_ident(tmp_names[i]))
+		result << t.make_assign_after_owned_drop(lvalue, t.make_ident(tmp_names[i]))
 	}
 	return result
 }
@@ -14504,7 +14514,7 @@ fn (mut t Transformer) multi_if_multi_return_assign_block(block_id flat.NodeId, 
 			t.drain_pending(mut stmts)
 			t.append_owned_lvalue_drop_before_assign(lvalue, field_type, mut stmts)
 		}
-		stmts << t.make_assign(lvalue, field)
+		stmts << t.make_assign_after_owned_drop(lvalue, field)
 	}
 	return t.make_block(stmts)
 }
@@ -14569,7 +14579,7 @@ fn (mut t Transformer) multi_if_assign_stmts(parts TupleBlockParts, lhs_ids []fl
 			t.drain_pending(mut stmts)
 			t.append_owned_lvalue_drop_before_assign(lvalue, lhs_type, mut stmts)
 		}
-		stmts << t.make_assign(lvalue, t.make_ident(tmp_name))
+		stmts << t.make_assign_after_owned_drop(lvalue, t.make_ident(tmp_name))
 	}
 	return stmts
 }
@@ -20334,6 +20344,15 @@ fn (mut t Transformer) make_assign_without_ownership_drop(lhs flat.NodeId, rhs f
 		children_count:       2
 		skip_ownership_drops: true
 	})
+}
+
+// make_assign_after_owned_drop builds the final store for a lowering that has
+// already destroyed the previous lvalue. Transform may revisit synthetic
+// nodes, so mark this assignment to prevent a second drop-before-assign pass.
+fn (mut t Transformer) make_assign_after_owned_drop(lhs flat.NodeId, rhs flat.NodeId) flat.NodeId {
+	id := t.make_assign(lhs, rhs)
+	t.a.nodes[int(id)].skip_ownership_drops = true
+	return id
 }
 
 // make_assign_op builds make assign op data for transform.

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -6580,6 +6580,9 @@ fn (mut tc TypeChecker) annotate_node(id flat.NodeId) {
 						}
 						if typ !is MultiReturn && typ !is Void {
 							owner := tc.cur_scope.insert_with_owner(lhs.value, typ)
+							if lhs.value != '_' && tc.decl_lhs_is_mut(node, lhs_id) {
+								tc.fn_context.mut_local_owners[lhs.value] = owner
+							}
 							if owner.storage_key().len > 0
 								&& decl_assign_is_shared_marker(node.value) {
 								tc.mark_shared_binding_owner(lhs.value, owner)
@@ -6714,6 +6717,11 @@ fn (mut tc TypeChecker) annotate_multi_return_decl_assign(node flat.Node) {
 			continue
 		}
 		tc.cur_scope.insert(lhs.value, item_types[i])
+		if tc.decl_lhs_is_mut(node, lhs_id) {
+			if owner := tc.cur_scope.lookup_owner(lhs.value) {
+				tc.fn_context.mut_local_owners[lhs.value] = owner
+			}
+		}
 		tc.remember_expr_type(lhs_id, item_types[i])
 	}
 }

--- a/vlib/v3/types/checker_ownership_d_ownership.v
+++ b/vlib/v3/types/checker_ownership_d_ownership.v
@@ -6393,8 +6393,8 @@ fn (mut tc TypeChecker) ownership_check_expr(id flat.NodeId) {
 	if moved := tc.ownership_moved_conflict(name) {
 		// Call arguments are context-checked and can subsequently be resolved
 		// again by the enclosing call. If this identifier is still inside the
-		// exact call node that recorded its move, this is the same AST use being
-		// revisited, not a second source-level use.
+		// exact enclosing expression that recorded its move, this is the same AST
+		// use being revisited, not a second source-level use.
 		if tc.ownership_move_site_contains(moved.info.move_pos, id) {
 			return
 		}
@@ -8855,7 +8855,7 @@ fn (mut tc TypeChecker) ownership_after_call(id flat.NodeId, node flat.Node, inf
 		if borrow_name.len > 0 {
 			if moved := tc.ownership_moved_conflict(borrow_name) {
 				if moved.name == borrow_name && moved.info.moved_to == call_name
-					&& moved.info.move_pos == id {
+					&& moved.info.move_pos == arg_id {
 					continue
 				}
 				tc.ownership_report_moved(moved.name, moved.info, arg_id)
@@ -8868,7 +8868,7 @@ fn (mut tc TypeChecker) ownership_after_call(id flat.NodeId, node flat.Node, inf
 			call_borrows << borrow_name
 			continue
 		}
-		method_value := tc.ownership_consume_method_value_receiver(arg_id, call_name, id)
+		method_value := tc.ownership_consume_method_value_receiver(arg_id, call_name, arg_id)
 		if method_value.consumed {
 			if method_value.borrow_name.len > 0 {
 				call_borrows << method_value.borrow_name
@@ -8878,22 +8878,22 @@ fn (mut tc TypeChecker) ownership_after_call(id flat.NodeId, node flat.Node, inf
 		arg_name := tc.ownership_expr_ident_name(arg_id)
 		if arg_name.len == 0 {
 			if expected !is Void && expected !is Pointer {
-				if tc.ownership_consume_array_element_method_result(arg_id, call_name, id) {
+				if tc.ownership_consume_array_element_method_result(arg_id, call_name, arg_id) {
 					continue
 				}
 				if tc.ownership_consume_conditional_call_arg(call_name, target_param_idx,
-					target_suffix, arg_id, expected, id)
+					target_suffix, arg_id, expected, arg_id)
 				{
 					continue
 				}
 				tc.ownership_mark_fn_param_aggregate_literal_descendants(call_name,
-					target_param_idx, target_suffix, arg_id, id)
+					target_param_idx, target_suffix, arg_id, arg_id)
 			}
 			continue
 		}
 		if moved := tc.ownership_moved_conflict(arg_name) {
 			if moved.name == arg_name && moved.info.moved_to == call_name
-				&& moved.info.move_pos == id {
+				&& moved.info.move_pos == arg_id {
 				continue
 			}
 			tc.ownership_report_moved(moved.name, moved.info, arg_id)
@@ -8905,11 +8905,11 @@ fn (mut tc TypeChecker) ownership_after_call(id flat.NodeId, node flat.Node, inf
 		// `string`; passing `borrowed.tag` when it is an enum is a plain copy).
 		if _ := tc.ownership_borrowed_alias_source(arg_name, false) {
 			if tc.ownership_type_requires_destruction(tc.resolve_type(arg_id)) {
-				tc.ownership_reject_global_move(arg_name, id, call_name, true)
+				tc.ownership_reject_global_move(arg_name, arg_id, call_name, true)
 				continue
 			}
 		} else {
-			tc.ownership_reject_global_move(arg_name, id, call_name, true)
+			tc.ownership_reject_global_move(arg_name, arg_id, call_name, true)
 		}
 		mut moved_base := false
 		if arg_name in st.owned_vars {
@@ -8919,7 +8919,7 @@ fn (mut tc TypeChecker) ownership_after_call(id flat.NodeId, node flat.Node, inf
 			// to move them a second time.
 			descendants := tc.ownership_owned_descendant_names(arg_name)
 			type_name := tc.ownership_type_name_for_var(arg_name)
-			if tc.ownership_move_var_result(arg_name, call_name, id, true, call_name, true) {
+			if tc.ownership_move_var_result(arg_name, call_name, arg_id, true, call_name, true) {
 				moved_base = true
 				if variadic_elem_idx >= 0 {
 					tc.ownership_add_fn_param_descendant(call_name, target_param_idx,
@@ -8940,8 +8940,8 @@ fn (mut tc TypeChecker) ownership_after_call(id flat.NodeId, node flat.Node, inf
 				}
 			}
 		} else {
-			moved_types := tc.ownership_move_overlapping_dynamic_storage(arg_name, call_name, id,
-				true, call_name, true)
+			moved_types := tc.ownership_move_overlapping_dynamic_storage(arg_name, call_name,
+				arg_id, true, call_name, true)
 			if moved_types.len > 0 {
 				if variadic_elem_idx >= 0 {
 					tc.ownership_add_fn_param_descendant(call_name, target_param_idx,
@@ -8954,7 +8954,7 @@ fn (mut tc TypeChecker) ownership_after_call(id flat.NodeId, node flat.Node, inf
 		}
 		if expected !is Void && expected !is Pointer && !moved_base {
 			tc.ownership_transfer_owned_descendants_to_param_with_suffix(arg_name, call_name,
-				target_param_idx, target_suffix, id)
+				target_param_idx, target_suffix, arg_id)
 		}
 	}
 	for name in call_borrows {

--- a/vlib/v3/types/checker_ownership_d_ownership.v
+++ b/vlib/v3/types/checker_ownership_d_ownership.v
@@ -6177,14 +6177,8 @@ fn (mut tc TypeChecker) ownership_merge_branch_moved(group OwnershipBranchGroup)
 	for name, _ in group.base.owned_vars {
 		mut moved_on_every_path := true
 		for branch in group.branches {
-			mut moved_on_path := false
-			for moved_name, _ in branch.moved_vars {
-				if ownership_storage_keys_overlap(name, moved_name) {
-					moved_on_path = true
-					break
-				}
-			}
-			if !moved_on_path {
+			// Different overlapping descendants can remain owned on different paths.
+			if name !in branch.moved_vars {
 				moved_on_every_path = false
 				break
 			}

--- a/vlib/v3/types/checker_ownership_d_ownership.v
+++ b/vlib/v3/types/checker_ownership_d_ownership.v
@@ -225,6 +225,7 @@ mut:
 	deferred_aggregate_consumption   map[int]int
 	index_move_reads                 map[int]bool
 	guard_move_reads                 map[int]bool
+	skip_drop_before_assign          map[int]bool
 	scope_frames                     []OwnershipScopeFrame
 	suppressed_checks                int
 	path_active                      bool
@@ -310,6 +311,7 @@ fn new_ownership_state() &OwnershipState {
 		deferred_aggregate_consumption:   map[int]int{}
 		index_move_reads:                 map[int]bool{}
 		guard_move_reads:                 map[int]bool{}
+		skip_drop_before_assign:          map[int]bool{}
 		scope_frames:                     []OwnershipScopeFrame{}
 		suppressed_checks:                0
 		path_active:                      true
@@ -417,6 +419,7 @@ fn ownership_clone_state_for_parallel(src &OwnershipState) &OwnershipState {
 		deferred_aggregate_consumption:   map[int]int{}
 		index_move_reads:                 map[int]bool{}
 		guard_move_reads:                 map[int]bool{}
+		skip_drop_before_assign:          map[int]bool{}
 		scope_frames:                     []OwnershipScopeFrame{}
 		suppressed_checks:                0
 		path_active:                      true
@@ -669,6 +672,11 @@ fn (mut tc TypeChecker) ownership_merge_parallel_check_worker(w &TypeChecker) {
 			dst.guard_move_reads[id] = true
 		}
 	}
+	for id, skip in src.skip_drop_before_assign {
+		if skip {
+			dst.skip_drop_before_assign[id] = true
+		}
+	}
 }
 
 fn (mut tc TypeChecker) ownership_state() &OwnershipState {
@@ -751,6 +759,16 @@ fn (mut tc TypeChecker) ownership_check_node_with_aggregate_consumption_mode(exp
 		return
 	}
 	tc.check_node(expr_id)
+}
+
+fn (mut tc TypeChecker) ownership_check_node_with_expected_context_and_aggregate_consumption_mode(expr_id flat.NodeId, expected Type, should_defer bool) {
+	if should_defer {
+		tc.ownership_begin_defer_aggregate_consumption(expr_id)
+		tc.check_node_with_expected_context(expr_id, expected)
+		tc.ownership_end_defer_aggregate_consumption(expr_id)
+		return
+	}
+	tc.check_node_with_expected_context(expr_id, expected)
 }
 
 fn (mut tc TypeChecker) ownership_should_defer_call_arg_aggregate_consumption(node flat.Node, info CallInfo, child_idx int) bool {
@@ -1362,9 +1380,6 @@ fn (tc &TypeChecker) ownership_default_clone_missing_method_inner(typ Type, mut 
 			name := typ.name
 			if tc.ownership_type_has_clone_method(typ) {
 				return none
-			}
-			if tc.ownership_type_has_explicit_drop(name) {
-				return name
 			}
 			if !tc.autofree_mode && !tc.named_type_implements_marker(name, 'IClone') {
 				return name
@@ -4238,6 +4253,7 @@ fn (mut tc TypeChecker) ownership_prescan_call_for_owned_calls(id flat.NodeId, n
 			}
 			if recv_owned && info.params[0] !is Pointer
 				&& !tc.ownership_method_keeps_receiver(fn_node.value)
+				&& !tc.ownership_array_builtin_keeps_receiver(recv_id, fn_node.value)
 				&& !tc.ownership_string_builtin_keeps_receiver(recv_id, fn_node.value) {
 				if info.name.len > 0 {
 					tc.ownership_state().ownership_fn_params['${info.name}__param_0'] = true
@@ -4247,6 +4263,7 @@ fn (mut tc TypeChecker) ownership_prescan_call_for_owned_calls(id flat.NodeId, n
 			recv_name := tc.ownership_expr_ident_name(recv_id)
 			if recv_name.len > 0 && info.params[0] !is Pointer
 				&& !tc.ownership_method_keeps_receiver(fn_node.value)
+				&& !tc.ownership_array_builtin_keeps_receiver(recv_id, fn_node.value)
 				&& !tc.ownership_string_builtin_keeps_receiver(recv_id, fn_node.value) {
 				tc.ownership_prescan_transfer_owned_descendants_to_param(recv_name, info.name, 0, mut
 					owned_locals, local_types)
@@ -6153,6 +6170,39 @@ fn (mut tc TypeChecker) ownership_merge_branch_moved(group OwnershipBranchGroup)
 			}
 		}
 	}
+	if group.branches.len == 0 {
+		return
+	}
+	mut definitely_moved := []string{}
+	for name, _ in group.base.owned_vars {
+		mut moved_on_every_path := true
+		for branch in group.branches {
+			mut moved_on_path := false
+			for moved_name, _ in branch.moved_vars {
+				if ownership_storage_keys_overlap(name, moved_name) {
+					moved_on_path = true
+					break
+				}
+			}
+			if !moved_on_path {
+				moved_on_every_path = false
+				break
+			}
+		}
+		if moved_on_every_path {
+			definitely_moved << name
+		}
+	}
+	for name in definitely_moved {
+		st.owned_vars.delete(name)
+		st.owned_var_types.delete(name)
+		for owned_name in st.owned_vars.keys() {
+			if ownership_storage_keys_overlap(name, owned_name) {
+				st.owned_vars.delete(owned_name)
+				st.owned_var_types.delete(owned_name)
+			}
+		}
+	}
 }
 
 fn (mut tc TypeChecker) ownership_merge_branch_borrows(group OwnershipBranchGroup) {
@@ -6341,8 +6391,36 @@ fn (mut tc TypeChecker) ownership_check_expr(id flat.NodeId) {
 		return
 	}
 	if moved := tc.ownership_moved_conflict(name) {
+		// Call arguments are context-checked and can subsequently be resolved
+		// again by the enclosing call. If this identifier is still inside the
+		// exact call node that recorded its move, this is the same AST use being
+		// revisited, not a second source-level use.
+		if tc.ownership_move_site_contains(moved.info.move_pos, id) {
+			return
+		}
 		tc.ownership_report_moved(moved.name, moved.info, id)
 	}
+}
+
+fn (tc &TypeChecker) ownership_move_site_contains(move_pos flat.NodeId, id flat.NodeId) bool {
+	if move_pos == id || !tc.valid_node_id(move_pos) || !tc.valid_node_id(id) {
+		return false
+	}
+	return tc.ownership_node_contains(move_pos, id, 0)
+}
+
+fn (tc &TypeChecker) ownership_node_contains(root flat.NodeId, target flat.NodeId, depth int) bool {
+	if depth > 128 || !tc.valid_node_id(root) {
+		return false
+	}
+	node := tc.a.nodes[int(root)]
+	for i in 0 .. node.children_count {
+		child := tc.a.child(&node, i)
+		if child == target || tc.ownership_node_contains(child, target, depth + 1) {
+			return true
+		}
+	}
+	return false
 }
 
 fn (mut tc TypeChecker) ownership_after_decl_assign(lhs_id flat.NodeId, rhs_id flat.NodeId, lhs_type Type, assign_id flat.NodeId) {
@@ -6474,6 +6552,14 @@ fn (mut tc TypeChecker) ownership_after_assign(lhs_id flat.NodeId, rhs_id flat.N
 			tc.ownership_consume_expr(rhs_id, 'blank identifier', assign_id)
 		}
 		return
+	}
+	// Reinitializing a fully moved local must not destroy its old bits: that
+	// storage now belongs to the move destination. Record the assignment for
+	// lowering before `ownership_assign_to_name` installs the new value.
+	if !tc.ownership_storage_participates(lhs_name) {
+		if _ := tc.ownership_moved_conflict(lhs_name) {
+			tc.ownership_state().skip_drop_before_assign[int(assign_id)] = true
+		}
 	}
 	tc.ownership_check_reassign(lhs_name, assign_id)
 	tc.ownership_assign_to_name(lhs_name, rhs_id, tc.ownership_assignment_type(lhs_type, rhs_type),
@@ -6627,7 +6713,11 @@ fn (mut tc TypeChecker) ownership_assign_to_name(lhs_name string, rhs_id flat.No
 	array_literal_owned := tc.ownership_mark_array_literal_elements(lhs_name, rhs_id, assign_id)
 	array_init_owned := tc.ownership_mark_array_init_elements(lhs_name, rhs_id, assign_id)
 	map_literal_owned := tc.ownership_mark_map_literal_entries(lhs_name, rhs_id, assign_id)
-	if array_literal_owned || array_init_owned || map_literal_owned {
+	rhs_node := tc.a.nodes[int(tc.ownership_unwrap_expr(rhs_id))]
+	aggregate_literal_owned :=
+		rhs_node.kind in [.array_literal, .array_init, .map_init, .struct_init, .assoc]
+		&& tc.ownership_type_requires_destruction(lhs_type)
+	if array_literal_owned || array_init_owned || map_literal_owned || aggregate_literal_owned {
 		tc.ownership_mark_owned(lhs_name, tc.resolve_type(rhs_id), assign_id)
 		return
 	}
@@ -6645,13 +6735,23 @@ fn (mut tc TypeChecker) ownership_assign_to_name(lhs_name string, rhs_id flat.No
 	lhs_owned := tc.ownership_type_is_owned(lhs_type)
 	if rhs_name.len > 0 {
 		tc.ownership_reject_global_move(rhs_name, assign_id, lhs_name, false)
-		tc.ownership_transfer_owned_descendants(rhs_name, lhs_name, assign_id)
 		if rhs_name in st.owned_vars {
-			tc.ownership_move_var(rhs_name, lhs_name, assign_id, false, '', true)
-			tc.ownership_mark_owned(lhs_name, tc.ownership_type_for_var(rhs_name, lhs_type),
-				assign_id)
+			descendants := tc.ownership_owned_descendant_names(rhs_name)
+			source_type := tc.ownership_type_for_var(rhs_name, lhs_type)
+			if tc.ownership_move_var_result(rhs_name, lhs_name, assign_id, false, '', true) {
+				tc.ownership_mark_owned(lhs_name, source_type, assign_id)
+				for source_name in descendants {
+					suffix := source_name[rhs_name.len..]
+					tc.ownership_mark_owned_name(lhs_name + suffix,
+						tc.ownership_type_name_for_var(source_name), assign_id)
+					st.owned_vars.delete(source_name)
+					st.owned_var_types.delete(source_name)
+					st.moved_vars.delete(source_name)
+				}
+			}
 			return
 		}
+		tc.ownership_transfer_owned_descendants(rhs_name, lhs_name, assign_id)
 		moved_types := tc.ownership_move_overlapping_dynamic_storage(rhs_name, lhs_name, assign_id,
 			false, '', true)
 		if moved_types.len > 0 {
@@ -7154,7 +7254,12 @@ fn (mut tc TypeChecker) ownership_mark_array_append_expr(array_id flat.NodeId, e
 		return
 	}
 	tc.ownership_check_reassign(array_name, pos)
-	if unwrap_pointer(tc.resolve_type(elem_id)) is Array {
+	rhs_type := unwrap_pointer(tc.resolve_type(elem_id))
+	elem_type := tc.ownership_array_append_elem_type(array_id, elem_id)
+	// `[]T << []T` appends many `T` values, while `[][]T << []T` appends one
+	// array value. Distinguish those cases before deciding whether to transfer
+	// the RHS array itself or its elements.
+	if rhs_type is Array && !semantic_types_equal(rhs_type, elem_type) {
 		tc.ownership_mark_array_append_array(array_name, elem_id, pos)
 		return
 	}
@@ -7836,6 +7941,12 @@ fn (mut tc TypeChecker) ownership_mark_storage_from_expr_with_mode(target_name s
 	if tc.ownership_mark_aggregate_literal_storage(target_name, id, pos, clear_unowned) {
 		return true
 	}
+	node := tc.a.nodes[int(id)]
+	if node.kind in [.array_literal, .array_init, .map_init, .struct_init, .assoc]
+		&& tc.ownership_type_requires_destruction(target_type) {
+		tc.ownership_mark_owned(target_name, target_type, pos)
+		return true
+	}
 	borrow_name := tc.ownership_borrowed_name(id)
 	if borrow_name.len > 0 {
 		mut st := tc.ownership_state()
@@ -7854,9 +7965,20 @@ fn (mut tc TypeChecker) ownership_mark_storage_from_expr_with_mode(target_name s
 	}
 	if source_name.len > 0 && source_name in tc.ownership_state().owned_vars {
 		tc.ownership_reject_global_move(source_name, pos, target_name, false)
-		tc.ownership_move_var(source_name, target_name, pos, false, '', true)
-		tc.ownership_mark_owned(target_name, tc.ownership_type_for_var(source_name, target_type),
-			pos)
+		descendants := tc.ownership_owned_descendant_names(source_name)
+		source_type := tc.ownership_type_for_var(source_name, target_type)
+		if tc.ownership_move_var_result(source_name, target_name, pos, false, '', true) {
+			tc.ownership_mark_owned(target_name, source_type, pos)
+			mut st := tc.ownership_state()
+			for descendant in descendants {
+				suffix := descendant[source_name.len..]
+				type_name := tc.ownership_type_name_for_var(descendant)
+				tc.ownership_mark_owned_name(target_name + suffix, type_name, pos)
+				st.owned_vars.delete(descendant)
+				st.owned_var_types.delete(descendant)
+				st.moved_vars.delete(descendant)
+			}
+		}
 		return true
 	}
 	if source_name.len > 0 {
@@ -8019,6 +8141,13 @@ fn (mut tc TypeChecker) ownership_collect_conditional_result(lhs_name string, if
 
 fn (mut tc TypeChecker) ownership_collect_expr_result(lhs_name string, expr_id flat.NodeId, lhs_type Type, pos flat.NodeId, mut moved_sources []OwnershipConditionalMoveSource) bool {
 	if !tc.valid_node_id(expr_id) {
+		return false
+	}
+	// Only propagate ownership from a branch when the conditional expression's
+	// final type can itself own storage. In particular, `result_call() or { 0 }`
+	// has a plain scalar result even though the call's intermediate `!T` value
+	// requires destruction.
+	if !tc.ownership_type_requires_destruction(lhs_type) {
 		return false
 	}
 	id := tc.ownership_unwrap_expr(expr_id)
@@ -8664,14 +8793,28 @@ fn (mut tc TypeChecker) ownership_after_call(id flat.NodeId, node flat.Node, inf
 							0))
 						call_borrows << recv_name
 					}
-				} else {
+				} else if tc.ownership_type_requires_destruction(tc.resolve_type(recv_id)) {
 					if recv_name.len > 0 {
 						tc.ownership_reject_global_move(recv_name, id, call_name, true)
 						if recv_name in st.owned_vars {
-							tc.ownership_move_var(recv_name, call_name, id, true, call_name, true)
+							descendants := tc.ownership_owned_descendant_names(recv_name)
+							if tc.ownership_move_var_result(recv_name, call_name, id, true,
+								call_name, true)
+							{
+								st.ownership_fn_params['${call_name}__param_0'] = true
+								for source_name in descendants {
+									suffix := source_name[recv_name.len..]
+									tc.ownership_add_fn_param_descendant(call_name, 0, suffix,
+										tc.ownership_type_name_for_var(source_name))
+									st.owned_vars.delete(source_name)
+									st.owned_var_types.delete(source_name)
+									st.moved_vars.delete(source_name)
+								}
+							}
+						} else {
+							tc.ownership_transfer_owned_descendants_to_param(recv_name, call_name,
+								0, id)
 						}
-						tc.ownership_transfer_owned_descendants_to_param(recv_name, call_name, 0,
-							id)
 					} else {
 						_ := tc.ownership_consume_conditional_call_arg(call_name, 0, '', recv_id,
 							info.params[0], id)
@@ -8711,6 +8854,10 @@ fn (mut tc TypeChecker) ownership_after_call(id flat.NodeId, node flat.Node, inf
 		}
 		if borrow_name.len > 0 {
 			if moved := tc.ownership_moved_conflict(borrow_name) {
+				if moved.name == borrow_name && moved.info.moved_to == call_name
+					&& moved.info.move_pos == id {
+					continue
+				}
 				tc.ownership_report_moved(moved.name, moved.info, arg_id)
 				continue
 			}
@@ -8745,23 +8892,52 @@ fn (mut tc TypeChecker) ownership_after_call(id flat.NodeId, node flat.Node, inf
 			continue
 		}
 		if moved := tc.ownership_moved_conflict(arg_name) {
+			if moved.name == arg_name && moved.info.moved_to == call_name
+				&& moved.info.move_pos == id {
+				continue
+			}
 			tc.ownership_report_moved(moved.name, moved.info, arg_id)
 			continue
 		}
+		// Reading a Copy field through a borrowed aggregate does not move from the
+		// borrow. Only ownership-bearing arguments need the borrowed-alias move
+		// rejection below (for example, passing `borrowed.value` when it is a
+		// `string`; passing `borrowed.tag` when it is an enum is a plain copy).
 		if _ := tc.ownership_borrowed_alias_source(arg_name, false) {
+			if tc.ownership_type_requires_destruction(tc.resolve_type(arg_id)) {
+				tc.ownership_reject_global_move(arg_name, id, call_name, true)
+				continue
+			}
+		} else {
 			tc.ownership_reject_global_move(arg_name, id, call_name, true)
-			continue
 		}
-		tc.ownership_reject_global_move(arg_name, id, call_name, true)
+		mut moved_base := false
 		if arg_name in st.owned_vars {
+			// The aggregate and its ownership-bearing fields describe one value.
+			// Move the base once, retain descendant metadata for return-from-param
+			// analysis, and clear the overlapping source entries without attempting
+			// to move them a second time.
+			descendants := tc.ownership_owned_descendant_names(arg_name)
 			type_name := tc.ownership_type_name_for_var(arg_name)
-			tc.ownership_move_var(arg_name, call_name, id, true, call_name, true)
-			if variadic_elem_idx >= 0 {
-				tc.ownership_add_fn_param_descendant(call_name, target_param_idx, target_suffix,
-					type_name)
-			} else {
-				key := '${call_name}__param_${param_idx}'
-				st.ownership_fn_params[key] = true
+			if tc.ownership_move_var_result(arg_name, call_name, id, true, call_name, true) {
+				moved_base = true
+				if variadic_elem_idx >= 0 {
+					tc.ownership_add_fn_param_descendant(call_name, target_param_idx,
+						target_suffix, type_name)
+				} else {
+					key := '${call_name}__param_${param_idx}'
+					st.ownership_fn_params[key] = true
+				}
+				for source_name in descendants {
+					suffix := source_name[arg_name.len..]
+					target_name := target_suffix + suffix
+					descendant_type_name := tc.ownership_type_name_for_var(source_name)
+					tc.ownership_add_fn_param_descendant(call_name, target_param_idx, target_name,
+						descendant_type_name)
+					st.owned_vars.delete(source_name)
+					st.owned_var_types.delete(source_name)
+					st.moved_vars.delete(source_name)
+				}
 			}
 		} else {
 			moved_types := tc.ownership_move_overlapping_dynamic_storage(arg_name, call_name, id,
@@ -8776,7 +8952,7 @@ fn (mut tc TypeChecker) ownership_after_call(id flat.NodeId, node flat.Node, inf
 				}
 			}
 		}
-		if expected !is Void && expected !is Pointer {
+		if expected !is Void && expected !is Pointer && !moved_base {
 			tc.ownership_transfer_owned_descendants_to_param_with_suffix(arg_name, call_name,
 				target_param_idx, target_suffix, id)
 		}
@@ -10545,6 +10721,14 @@ pub fn (tc &TypeChecker) ownership_guard_read_moves_value(id flat.NodeId) bool {
 	return int(id) >= 0 && tc.ownership != unsafe { nil } && tc.ownership.guard_move_reads[int(id)]
 }
 
+// ownership_assignment_reinitializes_moved_value reports whether the assignment
+// writes a fresh value into storage whose previous value has already been moved.
+// The transformer uses this to avoid dropping storage now owned by the move target.
+pub fn (tc &TypeChecker) ownership_assignment_reinitializes_moved_value(id flat.NodeId) bool {
+	return int(id) >= 0 && tc.ownership != unsafe { nil }
+		&& tc.ownership.skip_drop_before_assign[int(id)]
+}
+
 fn (mut tc TypeChecker) ownership_owned_dynamic_overlap_names(source_name string) []string {
 	if source_name.len == 0 {
 		return []string{}
@@ -10895,6 +11079,9 @@ fn (tc &TypeChecker) ownership_type_is_owned(typ Type) bool {
 		return tc.ownership_type_is_owned(typ.base_type)
 	}
 	if typ is OptionType {
+		// An optional whose payload is a Copy (non-owned) type is itself Copy,
+		// mirroring Rust (`Option<char>`/`Option<i32>` are Copy). Only optionals
+		// of owned payloads (e.g. `?string`, `?[]u8`) require move tracking.
 		return tc.ownership_type_is_owned(typ.base_type)
 	}
 	if typ is ResultType {
@@ -10913,6 +11100,8 @@ fn (tc &TypeChecker) ownership_type_is_owned(typ Type) bool {
 		if tc.ownership_type_name_has_drop(typ.name) {
 			return true
 		}
+		mut seen := map[string]bool{}
+		return tc.ownership_type_requires_destruction_inner(typ, 0, mut seen)
 	}
 	return false
 }
@@ -11136,7 +11325,7 @@ fn (tc &TypeChecker) ownership_method_keeps_receiver(method_name string) bool {
 }
 
 fn (tc &TypeChecker) ownership_array_builtin_keeps_receiver(recv_id flat.NodeId, method_name string) bool {
-	if unwrap_pointer(tc.resolve_type(recv_id)) !is Array {
+	if unalias_type(unwrap_pointer(tc.resolve_type(recv_id))) !is Array {
 		return false
 	}
 	return tc.ownership_fn_declared_in_builtin('array.${method_name}')

--- a/vlib/v3/types/checker_ownership_notd_ownership.v
+++ b/vlib/v3/types/checker_ownership_notd_ownership.v
@@ -71,6 +71,10 @@ pub fn (tc &TypeChecker) ownership_guard_read_moves_value(_ flat.NodeId) bool {
 	return false
 }
 
+pub fn (tc &TypeChecker) ownership_assignment_reinitializes_moved_value(_ flat.NodeId) bool {
+	return false
+}
+
 pub fn (tc &TypeChecker) ownership_fn_value_returns_owned(_ flat.NodeId, _ string, _ string) bool {
 	return false
 }

--- a/vlib/v3/types/checker_tail.v
+++ b/vlib/v3/types/checker_tail.v
@@ -10506,12 +10506,20 @@ fn (mut tc TypeChecker) check_call_arg_types(id flat.NodeId, node flat.Node, inf
 				&& check_node.typ.len == 0 && array_like_elem_type(expected_for_check) != none {
 				tc.register_synth_type(check_arg_id, expected_for_check)
 			}
-			tc.check_node_with_expected_context(check_arg_id, expected_for_check)
+			$if ownership ? {
+				tc.ownership_check_node_with_expected_context_and_aggregate_consumption_mode(check_arg_id,
+					expected_for_check, tc.ownership_should_defer_call_arg_aggregate_consumption(node,
+					info, i))
+			} $else {
+				tc.check_node_with_expected_context(check_arg_id, expected_for_check)
+			}
 			checked_with_context = true
 		}
 		$if ownership ? {
-			tc.ownership_check_node_with_aggregate_consumption_mode(check_arg_id, tc.ownership_should_defer_call_arg_aggregate_consumption(node,
-				info, i))
+			if !checked_with_context {
+				tc.ownership_check_node_with_aggregate_consumption_mode(check_arg_id, tc.ownership_should_defer_call_arg_aggregate_consumption(node,
+					info, i))
+			}
 		} $else {
 			if !checked_with_context {
 				tc.check_node(check_arg_id)
@@ -11005,7 +11013,15 @@ fn (mut tc TypeChecker) check_call_arg_types(id flat.NodeId, node flat.Node, inf
 				continue
 			}
 		}
-		tc.check_node_with_expected_context(arg_id, expected)
+		if !checked_with_context {
+			$if ownership ? {
+				tc.ownership_check_node_with_expected_context_and_aggregate_consumption_mode(arg_id,
+					expected, tc.ownership_should_defer_call_arg_aggregate_consumption(node, info,
+					i))
+			} $else {
+				tc.check_node_with_expected_context(arg_id, expected)
+			}
+		}
 		mut actual := Type(void_)
 		if has_dsl_scope {
 			actual = tc.resolve_expr(arg_id, expected)
@@ -11083,7 +11099,8 @@ fn (mut tc TypeChecker) check_call_arg_types(id flat.NodeId, node flat.Node, inf
 				arg_id, tc.call_argument_diagnostic_pos(arg_id))
 			continue
 		}
-		if expected is Pointer && !is_channel_builtin_method_call_name(info.name, 'try_push')
+		if expected is Pointer && param_is_mut
+			&& !is_channel_builtin_method_call_name(info.name, 'try_push')
 			&& tc.a.node(arg_id).kind in [.int_literal, .float_literal, .bool_literal, .char_literal, .string_literal, .string_interp] {
 			mut reference_name := call_argument_type_name(expected)
 			if !info.has_receiver {
@@ -13041,8 +13058,23 @@ fn (mut tc TypeChecker) specialized_plain_generic_call_info(node flat.Node, info
 
 fn (mut tc TypeChecker) resolve_generic_call_arg_type(id flat.NodeId) Type {
 	mut typ := tc.resolve_type(id)
+	node := tc.a.node(id)
+	if node.kind == .call {
+		// A cached generic call type can still be open (`Summary[W]`) when an
+		// enclosing generic call asks for its argument type before the nested call
+		// itself is checked. Specialize the nested signature from its own arguments
+		// first so the enclosing call sees the concrete return application.
+		if info0 := tc.resolve_call_info(id, node) {
+			if tc.call_generic_params(info0.name).len > 0 {
+				info := tc.specialized_plain_generic_call_info(node, info0)
+				if info.return_type !is Void && info.return_type !is Unknown {
+					typ = info.return_type
+					tc.remember_expr_type(id, typ)
+				}
+			}
+		}
+	}
 	if type_contains_unknown(typ) {
-		node := tc.a.node(id)
 		if node.kind == .call && node.children_count >= 2 {
 			callee := tc.a.child_node(node, 0)
 			if callee.kind == .selector && callee.value == 'map' {
@@ -14364,7 +14396,8 @@ fn (tc &TypeChecker) expr_can_be_implicit_ref_arg(expr_id flat.NodeId) bool {
 	}
 	// V materializes non-addressable value expressions into stable temporaries
 	// when they are passed to non-mut reference parameters.
-	return node.kind in [.struct_init, .call, .or_expr, .cast_expr, .if_expr, .match_stmt]
+	return node.kind in [.struct_init, .call, .or_expr, .cast_expr, .if_expr, .match_stmt,
+		.int_literal, .float_literal, .bool_literal, .char_literal, .string_literal, .string_interp]
 }
 
 fn type_pointer_depth_and_base(typ Type) (int, Type) {

--- a/vlib/v3/types/checker_tail_stmt.v
+++ b/vlib/v3/types/checker_tail_stmt.v
@@ -15914,8 +15914,13 @@ fn (tc &TypeChecker) lambda_expr_type(node flat.Node) Type {
 	mut params_mut := []bool{}
 	if node.children_count > 0 {
 		for i in 0 .. node.children_count - 1 {
-			params << unknown_type('lambda parameter')
-			params_mut << tc.a.child_node(&node, i).is_mut
+			param := tc.a.child_node(&node, i)
+			if param.typ.len > 0 {
+				params << tc.parse_type(normalize_fn_type_param_text(param.typ))
+			} else {
+				params << unknown_type('lambda parameter')
+			}
+			params_mut << param.is_mut
 		}
 	}
 	ret_type := if node.children_count > 0 {
@@ -16219,6 +16224,13 @@ fn (tc &TypeChecker) c_type_uncached(t Type) string {
 		return tc.c_struct_type_name(t.name)
 	}
 	if t is Interface {
+		base, _, is_generic := generic_type_application_parts(t.name)
+		if is_generic {
+			// Generic interface applications all use the base interface's runtime
+			// box. Their type arguments specialize method signatures, but do not
+			// introduce a distinct C struct.
+			return naming.c_name(base)
+		}
 		return naming.c_name(t.name)
 	}
 	if t is Enum {


### PR DESCRIPTION
## Summary

- add V1-compatible `-profile`/`-prof`, `-profile-fns`, and `-profile-no-inline` support to the V3 C backend
- forward ownership/profile options through the `v` dispatcher and fix the V3 ownership, generic, interface, and module-cache lowering issues exposed by compiling `ripgrep_v`
- add focused V3 regression coverage for profiling, ownership cloning/drop behavior, optional defaults, generic globals, interface ABIs, and transformed calls

## Validation

- rebuilt the compiler with `/Users/alex/code/v/v -g -keepc -o ./vnew cmd/v`
- passed the V profile slow tests, V3 driver profile tests, and macOS V3 profile tests
- passed all new standalone V3 regression suites, including the 11-case ownership clone/codegen matrix
- built the full `ripgrep_v` project with `-prod -ownership -profile`; the benchmark workload produced 3,912 lines with byte-identical sorted output to installed Rust `rg`, and emitted an 844-line profile
- ran `./vnew -silent test vlib/v/`: 2,213 passed, 115 failed, 35 skipped (the known current V3 baseline; failures include unsupported legacy fixtures and memory-limit cases)
- ran `vlib/v/compiler_errors_test.v`: 1,610 passed, 8 failed, 1 skipped (known baseline)
- ran `vlib/v/gen/c/coutput_test.v`: existing autofree/old-compiler baseline failures remain
