### PR TITLE
v3: speed up parallel self-host frontend

### DIFF
--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -7530,13 +7530,17 @@ pub fn run(args []string) {
 		// Checking and inactive-comptime pruning can add or detach nodes. Rebuild the
 		// parent index once here so markused type queries do not fall back to a full
 		// arena scan for every generated selector base.
-		pre_tc.refresh_direct_parent_index(a)
+		if !building_v || !pre_tc.reuse_direct_parent_index_for_unchanged_ast(a) {
+			pre_tc.refresh_direct_parent_index(a)
+		}
 		mut markused_scope := unsafe { nil }
 		mut markused_tc := &pre_tc
 		if scope_prealloc_markused && !generic_cache_hit {
 			markused_scope = prealloc_scope_begin_for_v3()
 			markused_tc = pre_tc.fork_for_parallel_transform(a)
+			markused_tc.share_direct_dependencies_from(&pre_tc)
 			markused_tc.enable_scoped_parallel_workers()
+			markused_tc.verbose = prefs.verbose
 		}
 		if no_skip_unused {
 			used_fns, uses_generics = markused.mark_all_used_with_generic_usage(a, markused_tc,
@@ -7560,7 +7564,7 @@ pub fn run(args []string) {
 		} else if is_checker_fixture {
 			used_fns, uses_generics = markused.mark_used_with_generic_usage_full_runtime(a,
 				markused_tc)
-		} else if building_v {
+		} else if building_v && current_parallel_transform {
 			used_fns = markused.mark_used_without_generic_detection(a, markused_tc)
 			uses_generics = false
 		} else {
@@ -7568,7 +7572,7 @@ pub fn run(args []string) {
 		}
 		program_used_fns = clone_string_bool_map(used_fns)
 		if cache_state.manager.enabled && !generic_cache_hit {
-			if building_v {
+			if building_v && current_parallel_transform {
 				used_fns = markused.mark_used_for_cache_without_generic_detection(a, markused_tc,
 					test_files, cache_state.source_body_modules)
 			} else {
@@ -7702,9 +7706,9 @@ pub fn run(args []string) {
 			parse_cache_enabled := pre_tc.type_cache_parse_enabled()
 			mut post_sw := time.new_stopwatch()
 			prealloc_scope_leave_for_v3(transform_scope)
-			retain_transform_scope := building_v && backend == 'c' && !cache_state.manager.enabled
-				&& retained_transform_regions.len == 0
-				&& os.getenv('V3_RETAIN_TRANSFORM_SCOPE') == '1'
+			retain_transform_scope := building_v && current_parallel_transform && backend == 'c'
+				&& !cache_state.manager.enabled && retained_transform_regions.len == 0
+				&& os.getenv('V3_NO_RETAIN_TRANSFORM_SCOPE') == ''
 			if retain_transform_scope {
 				// Cgen is the only remaining semantic consumer in this no-cache self-host
 				// path. Keep the typed transform arena alive through it instead of cloning
@@ -12806,7 +12810,11 @@ fn resolve_imports(mut a flat.FlatAst, mut p parser.Parser, prefs &pref.Preferen
 			if mod_dir_exists {
 				mod_files := pref.get_v_files_from_dir_for_target(mod_dir, prefs.user_defines,
 					prefs.target)
-				if !import_uses_explicit_module_alias(prefs, mod_name, importing_file, project_root) {
+				// -building-v compiles the trusted compiler tree and already skips other
+				// validity-only diagnostics. Avoid reading every imported source once here
+				// just before the parser reads the same files.
+				if !prefs.building_v
+					&& !import_uses_explicit_module_alias(prefs, mod_name, importing_file, project_root) {
 					expected_module := mod_name.all_after_last('.')
 					for imported_file in mod_files {
 						declared := declared_module_in_file(imported_file)

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -330,6 +330,7 @@ mut:
 	multi_return_type_names        map[string]bool
 	multi_return_types_ready       bool
 	decl_types_ready               bool
+	optional_types_ready           bool
 	fixed_array_ret_wrappers       map[string]bool // bare fixed-array c_type name -> has a return wrapper struct
 	emitted_fixed_array_typedefs   map[string]bool // bare fixed-array typedefs already written (shared across passes)
 	concrete_optional_abi_fns      map[string]bool // emitted fn names whose option/result params use Optional_T ABI
@@ -2203,6 +2204,7 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	g.multi_return_type_names.clear()
 	g.multi_return_types_ready = false
 	g.decl_types_ready = false
+	g.optional_types_ready = false
 	g.fixed_array_ret_wrappers.clear()
 	g.emitted_fixed_array_typedefs.clear()
 	g.concrete_optional_abi_fns.clear()
@@ -11272,6 +11274,15 @@ fn (mut g FlatGen) gen_sum_shared_field_selector(base_id flat.NodeId, base_type0
 	return true
 }
 
+fn (g &FlatGen) pointer_pointer_selector_base_type(base &flat.Node, fallback types.Type) types.Type {
+	if base.kind == .ident {
+		if local_type := g.local_ident_type(base.value) {
+			return local_type
+		}
+	}
+	return fallback
+}
+
 fn (mut g FlatGen) gen_sum_type_tag_selector(base_id flat.NodeId, base_type0 types.Type, op flat.Op) bool {
 	sum_name := g.sum_type_name_for_type(base_type0) or { return false }
 	sum_ct := g.tc.c_type(g.interface_concrete_type(sum_name))
@@ -11910,6 +11921,8 @@ struct FixedStorageNodeScanArgs {
 	g                      &FlatGen
 	start                  int
 	end                    int
+	file                   string
+	module                 string
 	fixed_candidate_idents map[string]bool
 	fixed_candidate_shorts map[string]bool
 	ident_filter           &FixedStorageCandidateNameFilter
@@ -12028,8 +12041,8 @@ fn fixed_storage_node_scan_thread(arg voidptr) voidptr {
 }
 
 fn (g &FlatGen) scan_fixed_storage_node_range(mut scan FixedStorageNodeScanArgs) {
-	mut cur_module := 'main'
-	mut cur_file := ''
+	mut cur_module := scan.module
+	mut cur_file := scan.file
 	for idx := scan.start; idx < scan.end; idx++ {
 		node := unsafe { &g.a.nodes[idx] }
 		kind_id := int(node.kind)
@@ -12145,21 +12158,14 @@ fn (g &FlatGen) scan_fixed_storage_node_range(mut scan FixedStorageNodeScanArgs)
 	}
 }
 
-fn (g &FlatGen) fixed_storage_node_scan_split() int {
-	target := g.a.nodes.len / 2
-	mut split := 0
-	mut best_distance := g.a.nodes.len
-	for idx in g.top_level_nodes() {
-		if idx <= 0 || idx >= g.a.nodes.len || g.a.nodes[idx].kind != .file {
-			continue
-		}
-		distance := if idx > target { idx - target } else { target - idx }
-		if distance < best_distance {
-			split = idx
-			best_distance = distance
-		}
+fn (g &FlatGen) fixed_storage_node_scan_bounds(max_jobs int) []int {
+	mut bounds := []int{cap: max_jobs + 1}
+	bounds << 0
+	for job in 1 .. max_jobs {
+		bounds << g.a.nodes.len * job / max_jobs
 	}
-	return split
+	bounds << g.a.nodes.len
+	return bounds
 }
 
 fn (mut g FlatGen) collect_fixed_storage_consts(allow_parallel bool) {
@@ -12198,40 +12204,43 @@ fn (mut g FlatGen) collect_fixed_storage_consts(allow_parallel bool) {
 	fixed_candidate_short_filter := fixed_storage_candidate_name_filter(fixed_candidate_shorts)
 	g.timing_profile('  [ttime]         fs setup     ${f64(fssw.elapsed().microseconds()) / 1000.0:7.2f} ms (candidates: ${fixed_storage_candidates.len})')
 	fssw.restart()
-	split := if allow_parallel && os.getenv('V3_NO_PAR_FIXED_STORAGE_SCAN') == '' {
-		g.fixed_storage_node_scan_split()
-	} else {
-		0
+	mut scan_jobs := if !isnil(g.a.worker_pool) { g.a.worker_pool.size() + 1 } else { 2 }
+	if scan_jobs > 8 {
+		scan_jobs = 8
 	}
-	mut scans := [
-		FixedStorageNodeScanArgs{
+	bounds := if allow_parallel && os.getenv('V3_NO_PAR_FIXED_STORAGE_SCAN') == '' {
+		g.fixed_storage_node_scan_bounds(scan_jobs)
+	} else {
+		[0, g.a.nodes.len]
+	}
+	mut scans := []FixedStorageNodeScanArgs{cap: bounds.len - 1}
+	for i in 0 .. bounds.len - 1 {
+		start := bounds[i]
+		mut scan_file := ''
+		if start < g.a.nodes.len {
+			if source_file := g.a.source_files[g.a.nodes[start].pos.id] {
+				scan_file = source_file.name
+			}
+		}
+		scans << FixedStorageNodeScanArgs{
 			g:                      g
-			start:                  0
-			end:                    if split > 0 { split } else { g.a.nodes.len }
+			start:                  start
+			end:                    bounds[i + 1]
+			file:                   scan_file
+			module:                 g.tc.file_modules[scan_file] or { 'main' }
 			fixed_candidate_idents: fixed_candidate_idents
 			fixed_candidate_shorts: fixed_candidate_shorts
 			ident_filter:           &fixed_candidate_ident_filter
 			short_filter:           &fixed_candidate_short_filter
 			fixed_safe_refs:        map[int]bool{}
-		},
-		FixedStorageNodeScanArgs{
-			g:                      g
-			start:                  split
-			end:                    g.a.nodes.len
-			fixed_candidate_idents: fixed_candidate_idents
-			fixed_candidate_shorts: fixed_candidate_shorts
-			ident_filter:           &fixed_candidate_ident_filter
-			short_filter:           &fixed_candidate_short_filter
-			fixed_safe_refs:        map[int]bool{}
-		},
-	]
-	if split > 0 {
-		second_scan_thread := spawn fixed_storage_node_scan_thread(unsafe { voidptr(&scans[1]) })
-		g.scan_fixed_storage_node_range(mut scans[0])
-		_ = second_scan_thread.wait()
-	} else {
-		g.scan_fixed_storage_node_range(mut scans[0])
+		}
 	}
+	mut scan_threads := []thread voidptr{cap: scans.len - 1}
+	for scan_idx in 1 .. scans.len {
+		scan_threads << spawn fixed_storage_node_scan_thread(unsafe { voidptr(&scans[scan_idx]) })
+	}
+	g.scan_fixed_storage_node_range(mut scans[0])
+	scan_threads.wait()
 	for scan in scans {
 		address_items << scan.address_items
 		ref_items << scan.ref_items
@@ -13854,11 +13863,8 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 				// handled
 			} else if g.gen_sum_shared_field_selector(base_id, base_type0, node.value) {
 				// handled
-			} else if g.gen_pointer_pointer_struct_selector(base_id, if base.kind == .ident {
-				g.local_ident_type(base.value) or { base_type0 }
-			} else {
-				base_type0
-			}, node.value)
+			} else if g.gen_pointer_pointer_struct_selector(base_id, g.pointer_pointer_selector_base_type(&base,
+				base_type0), node.value)
 			{
 				// handled
 			} else if base.kind == .call && base.children_count == 2

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -5633,6 +5633,7 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 	}
 	// Ownership lowering appends its calls after checking, so they have no source position.
 	is_ownership_drop := (!node.pos.is_valid() && ownership_synthetic_drop_name(fn_name))
+		|| (g.tc.cur_module == 'builtin' && ownership_synthetic_drop_name(fn_name))
 		|| (resolved_target_name.len > 0 && g.ownership_drop_intrinsic_name(resolved_target_name))
 	if node.children_count == 2 && is_ownership_drop {
 		arg_id := g.a.child(&node, 1)
@@ -14135,8 +14136,10 @@ fn (mut g FlatGen) forward_decls() {
 		g.writeln('')
 		return
 	}
-	for start := 0; start < items.len; start += 256 {
-		end := if start + 256 < items.len { start + 256 } else { items.len }
+	// Compiler-sized output is still only a few hundred KiB per 1024-item
+	// batch. Amortize checker forks and map snapshots across that larger unit.
+	for start := 0; start < items.len; start += 1024 {
+		end := if start + 1024 < items.len { start + 1024 } else { items.len }
 		// Map lookups below can return batch-owned string values. Do not retain them after the
 		// scratch arena is freed; duplicate compatible C prototypes across batches are harmless.
 		forwarded_exports.clear()

--- a/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
@@ -9,7 +9,7 @@ import v3.gen.c.naming
 import v3.types
 import v3.workers
 
-const max_flat_cgen_jobs = 10
+const max_flat_cgen_jobs = 17
 const min_flat_cgen_parallel_items = 128
 // Bound each worker's retained scratch while generating compiler-sized ASTs.
 const scoped_cgen_worker_batches = 32
@@ -130,9 +130,9 @@ $if !windows {
 		defer {
 			w.timing_profile('  [ttime]     cg typedecls   ${f64(tdsw.elapsed().microseconds()) / 1000.0:7.2f} ms (task)')
 		}
-		// This force-sync task uses the master generator without entering a
-		// prealloc worker arena. Keep context caches disabled here; body workers
-		// own arena-local caches and account for nearly all lookup traffic.
+		// This task uses the master generator from a pool thread. Keep caches
+		// disabled because their entries would otherwise borrow that thread's
+		// disposable arena.
 		w.import_alias_cache = unsafe { nil }
 		w.enum_selector_cache = unsafe { nil }
 		w.enum_method_cache = unsafe { nil }
@@ -148,10 +148,10 @@ $if !windows {
 		tdpsw.restart()
 		w.gen_type_declaration_block()
 		w.timing_profile('  [ttime]       td typedecl  ${f64(tdpsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
-		tdpsw.restart()
 		w.parallel_type_decls = w.sb.str()
 		unsafe { w.sb.free() }
 		w.sb = strings.new_builder(4096)
+		tdpsw.restart()
 		w.forward_decls()
 		w.timing_profile('  [ttime]       td fwd decls ${f64(tdpsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 		w.parallel_forward_decls = w.sb.str()
@@ -176,6 +176,33 @@ $if !windows {
 		fssw.restart()
 		w.precompute_concrete_optional_abi_fns()
 		w.timing_profile('  [ttime]       fs opt abi    ${f64(fssw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+		w.worker_scope = scope
+		cgen_worker_scope_leave(scope)
+		return unsafe { nil }
+	}
+
+	// fixed_array_support_thread moves the independent whole-AST fixed-array
+	// discovery out of the serial type-declaration task.
+	fn fixed_array_support_thread(arg voidptr) voidptr {
+		mut w := unsafe { &FlatGen(arg) }
+		fsw := time.new_stopwatch()
+		scope := cgen_worker_scope_begin(w.scope_parallel_workers)
+		_ = w.collect_fixed_array_typedefs_needed()
+		w.timing_profile('  [ttime]       fs fixed types ${f64(fsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+		w.worker_scope = scope
+		cgen_worker_scope_leave(scope)
+		return unsafe { nil }
+	}
+
+	// optional_support_thread fuses the declaration-signature, multi-return and
+	// unresolved-call optional scans on a helper while the other predispatch
+	// workers traverse the same immutable AST.
+	fn optional_support_thread(arg voidptr) voidptr {
+		mut w := unsafe { &FlatGen(arg) }
+		osw := time.new_stopwatch()
+		scope := cgen_worker_scope_begin(w.scope_parallel_workers)
+		w.collect_optional_typedefs()
+		w.timing_profile('  [ttime]       fs opt types   ${f64(osw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 		w.worker_scope = scope
 		cgen_worker_scope_leave(scope)
 		return unsafe { nil }
@@ -881,6 +908,28 @@ fn (mut g FlatGen) publish_fixed_storage_scan(mut fs_worker FlatGen) {
 	g.concrete_optional_abi_fns = fs_worker.concrete_optional_abi_fns.clone()
 	cgen_worker_scope_free(fs_worker.worker_scope)
 	fs_worker.worker_scope = unsafe { nil }
+}
+
+fn (mut g FlatGen) publish_fixed_array_support(mut worker FlatGen) {
+	g.fixed_array_typedefs_needed = worker.fixed_array_typedefs_needed.move()
+	g.fixed_array_typedefs_ready = worker.fixed_array_typedefs_ready
+	if worker.worker_scope != unsafe { nil } {
+		g.parallel_worker_scopes << worker.worker_scope
+		worker.worker_scope = unsafe { nil }
+	}
+}
+
+fn (mut g FlatGen) publish_optional_support(mut worker FlatGen) {
+	g.needed_optional_types = worker.needed_optional_types.move()
+	g.optional_types_ready = worker.optional_types_ready
+	g.multi_return_types = worker.multi_return_types
+	g.multi_return_type_names = worker.multi_return_type_names.move()
+	g.multi_return_types_ready = worker.multi_return_types_ready
+	g.decl_types_ready = worker.decl_types_ready
+	if worker.worker_scope != unsafe { nil } {
+		g.parallel_worker_scopes << worker.worker_scope
+		worker.worker_scope = unsafe { nil }
+	}
 }
 
 // gen_fns_dispatch emits fns dispatch output for c.
@@ -1894,6 +1943,7 @@ fn (g &FlatGen) new_parallel_worker_config(worker_id int, result_only bool) &Fla
 		expected_expr_type:             g.expected_expr_type
 		expected_enum:                  g.expected_enum
 		needed_optional_types:          g.needed_optional_types.clone()
+		optional_types_ready:           g.optional_types_ready
 		emitted_optional_types:         if result_only {
 			g.emitted_optional_types
 		} else {
@@ -2378,6 +2428,10 @@ fn (mut g FlatGen) run_pre_dispatch_parallel(no_parallel bool) bool {
 		}
 		mut fs_worker := g.new_parallel_worker(0)
 		fs_worker.tc.verbose = g.tc.verbose
+		mut fixed_array_worker := g.new_parallel_worker(1)
+		fixed_array_worker.tc.verbose = g.tc.verbose
+		mut optional_worker := g.new_parallel_worker(2)
+		optional_worker.tc.verbose = g.tc.verbose
 		fail := os.getenv('V3_TEST_PTHREAD_CREATE_FAIL')
 		if fail.len > 0 {
 			g.a.worker_pool.run([
@@ -2385,6 +2439,16 @@ fn (mut g FlatGen) run_pre_dispatch_parallel(no_parallel bool) bool {
 					run:        fixed_storage_scan_thread
 					arg:        voidptr(fs_worker)
 					force_sync: fail == 'cgen:all' || fail == 'cgen:pre:all' || fail == 'cgen:pre:0'
+				},
+				workers.Task{
+					run:        fixed_array_support_thread
+					arg:        voidptr(fixed_array_worker)
+					force_sync: fail == 'cgen:all' || fail == 'cgen:pre:all'
+				},
+				workers.Task{
+					run:        optional_support_thread
+					arg:        voidptr(optional_worker)
+					force_sync: fail == 'cgen:all' || fail == 'cgen:pre:all'
 				},
 				workers.Task{
 					run:        pre_dispatch_master_thread
@@ -2399,6 +2463,8 @@ fn (mut g FlatGen) run_pre_dispatch_parallel(no_parallel bool) bool {
 			// fixed-storage scan finishes on a helper thread.
 			mut psw := time.new_stopwatch()
 			fixed_storage_thread := spawn fixed_storage_scan_thread(voidptr(fs_worker))
+			fixed_array_thread := spawn fixed_array_support_thread(voidptr(fixed_array_worker))
+			optional_thread := spawn optional_support_thread(voidptr(optional_worker))
 			g.prepare_pre_dispatch_master()
 			g.timing_profile('  [ttime]     cg prep master ${f64(psw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 			psw.restart()
@@ -2406,9 +2472,13 @@ fn (mut g FlatGen) run_pre_dispatch_parallel(no_parallel bool) bool {
 			g.timing_profile('  [ttime]     cg cost refine ${f64(psw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 			psw.restart()
 			_ = fixed_storage_thread.wait()
+			_ = fixed_array_thread.wait()
+			_ = optional_thread.wait()
 			g.timing_profile('  [ttime]     cg fs wait     ${f64(psw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 		}
 		g.publish_fixed_storage_scan(mut fs_worker)
+		g.publish_fixed_array_support(mut fixed_array_worker)
+		g.publish_optional_support(mut optional_worker)
 		if g.parallel_prepared && !g.prep_externs_pending {
 			// Item-body and top-level C-extern refs are fully collected (fused
 			// prep + exact-cost pass or its serial fallback); the pre-dispatch

--- a/vlib/v3/gen/c/types.v
+++ b/vlib/v3/gen/c/types.v
@@ -388,6 +388,9 @@ fn (mut g FlatGen) optional_typedefs() {
 }
 
 fn (mut g FlatGen) collect_optional_typedefs() {
+	if g.optional_types_ready {
+		return
+	}
 	g.collect_declaration_signature_types()
 	// Calls without a resolved expression type are the only optional-type source
 	// not covered by the shared declaration-signature scan.
@@ -407,6 +410,7 @@ fn (mut g FlatGen) collect_optional_typedefs() {
 			g.collect_optional_typedef_type(g.parse_node_type(&node))
 		}
 	}
+	g.optional_types_ready = true
 }
 
 fn cgen_type_text_is_complete(text string) bool {

--- a/vlib/v3/markused/markused.v
+++ b/vlib/v3/markused/markused.v
@@ -194,6 +194,14 @@ fn mark_used_with_test_files(a &flat.FlatAst, tc &types.TypeChecker, test_files 
 	mut const_decls := map[string]ConstDeclInfo{}
 	mut fn_name_suffixes := map[string]bool{}
 	mut const_name_suffixes := map[string]bool{}
+	// The checker already knows the declaration cardinalities. Reserve once here
+	// instead of repeatedly growing the alias-heavy reachability indexes.
+	fn_decls.reserve(u32(tc.fn_ret_types.len))
+	fn_decl_lists.reserve(u32(tc.fn_ret_types.len))
+	struct_decls.reserve(u32(tc.structs.len * 2))
+	const_decls.reserve(u32(tc.const_types.len))
+	fn_name_suffixes.reserve(u32(tc.fn_ret_types.len))
+	const_name_suffixes.reserve(u32(tc.const_types.len))
 	mut generic_type_bases := map[string]bool{}
 	if detect_reachable_generics {
 		for node in a.nodes {
@@ -205,12 +213,14 @@ fn mark_used_with_test_files(a &flat.FlatAst, tc &types.TypeChecker, test_files 
 
 	// Reverse index: short name (after last '.') -> list of full qualified names
 	mut suffix_map := map[string][]string{}
+	suffix_map.reserve(u32(tc.fn_ret_types.len / 2))
 
 	// Every fn_decl/c_fn_decl node (and its module), in AST order: the worklist
 	// for the parallel body-call precollection below.
 	mut body_ids := []int{cap: 8192}
 	mut body_modules := []string{cap: 8192}
 	mut body_import_contexts := []int{cap: 8192}
+	collect_body_metadata := detect_reachable_generics || all_functions
 	mut cache_roots := []string{}
 	mut c_interface_roots := []string{}
 	mut marked_roots := []string{}
@@ -287,9 +297,11 @@ fn mark_used_with_test_files(a &flat.FlatAst, tc &types.TypeChecker, test_files 
 			fn_decl_import_context := import_context_by_file[fn_decl_file] or {
 				decl_import_context
 			}
-			body_ids << node_idx
-			body_modules << fn_decl_module
-			body_import_contexts << fn_decl_import_context
+			if collect_body_metadata {
+				body_ids << node_idx
+				body_modules << fn_decl_module
+				body_import_contexts << fn_decl_import_context
+			}
 			has_dot := node.value.index_u8(`.`) >= 0
 			can_suffix_match := !markused_fn_decl_is_generic_template(node, a)
 			if trace_markused {
@@ -373,7 +385,8 @@ fn mark_used_with_test_files(a &flat.FlatAst, tc &types.TypeChecker, test_files 
 
 	// BFS from main
 	mut used := map[string]bool{}
-	mut queue := []string{}
+	used.reserve(u32(fn_decls.len))
+	mut queue := []string{cap: fn_decls.len}
 	reachable_modules := markused_reachable_modules(a, tc)
 	queue << 'main'
 	used['main'] = true
@@ -416,8 +429,10 @@ fn mark_used_with_test_files(a &flat.FlatAst, tc &types.TypeChecker, test_files 
 		for seed in ['c.FlatGen.gen_fn_items_scoped_batches',
 			'markused.CallCollector.collect_bodies_scoped_batches',
 			'parser.Parser.precollect_parallel_comptime_consts',
-			'types.TypeChecker.check_scoped_batches', 'sync.Semaphore.timed_wait',
-			'sync.Semaphore.destroy'] {
+			'types.TypeChecker.check_scoped_batches', 'driver.compare_print_notices',
+			'pref.detect_vroot', 'pref.detect_vexe', 'types.compare_type_errors',
+			'types.compare_type_notices', 'types.TypeChecker.result_return_uses_multi_tail',
+			'sync.Semaphore.timed_wait', 'sync.Semaphore.destroy'] {
 			queue << seed
 			used[seed] = true
 		}
@@ -551,7 +566,7 @@ fn mark_used_with_test_files(a &flat.FlatAst, tc &types.TypeChecker, test_files 
 	}
 	mut body_index := map[int]int{}
 	mut body_results := []BodyCalls{}
-	if body_ids.len >= min_eager_markused_bodies {
+	if detect_reachable_generics && body_ids.len >= min_eager_markused_bodies {
 		for i, id in body_ids {
 			body_index[id] = i
 		}
@@ -680,20 +695,22 @@ fn mark_used_with_test_files(a &flat.FlatAst, tc &types.TypeChecker, test_files 
 			for dependency in tc.direct_dependency_ids(node_key) {
 				calls << tc.symbol_name(dependency)
 			}
-			if body_i := body_index[node_key] {
-				body := body_results[body_i]
-				calls << body.calls
-				initializer_refs << body.refs
-				uses_generics = uses_generics || body.uses_generics
-			} else {
-				// Not part of the precollected decl set (should not happen; the BFS
-				// resolves names through the same decl scan) — collect inline.
-				node := a.node(fn_info.node_id)
-				body := collector.collect_body(node, fn_info.module,
-					collector.imports(fn_info.import_context))
-				calls << body.calls
-				initializer_refs << body.refs
-				uses_generics = uses_generics || body.uses_generics
+			if detect_reachable_generics {
+				if body_i := body_index[node_key] {
+					body := body_results[body_i]
+					calls << body.calls
+					initializer_refs << body.refs
+					uses_generics = uses_generics || body.uses_generics
+				} else {
+					// Not part of the precollected decl set (should not happen; the BFS
+					// resolves names through the same decl scan) — collect inline.
+					node := a.node(fn_info.node_id)
+					body := collector.collect_body(node, fn_info.module,
+						collector.imports(fn_info.import_context))
+					calls << body.calls
+					initializer_refs << body.refs
+					uses_generics = uses_generics || body.uses_generics
+				}
 			}
 			call_epoch++
 			mut unique_call_count := 0

--- a/vlib/v3/markused/markused_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/markused/markused_parallel_notd_v3_no_parallel.v
@@ -11,7 +11,7 @@ import runtime
 import v3.flat
 import v3.workers
 
-const max_markused_jobs = 10
+const max_markused_jobs = 17
 const min_markused_parallel_bodies = 512
 const scoped_markused_chunk_oversubscribe = 2
 const scoped_markused_worker_batches = 4

--- a/vlib/v3/parser/parser_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/parser/parser_parallel_notd_v3_no_parallel.v
@@ -19,8 +19,8 @@ import v3.workers
 
 const min_parallel_parse_files = 4
 const min_parallel_parse_bytes = 131072
-const max_parallel_parse_jobs = 10
-const max_parallel_parse_chunks = 32
+const max_parallel_parse_jobs = 17
+const max_parallel_parse_chunks = 48
 const parallel_parse_chunks_per_job = 2
 const comptime_const_prepass_alias_prefix = '\x00v3-comptime-alias:'
 

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -3255,12 +3255,19 @@ fn (mut t Transformer) transform_serial_then_collect_pure(literal_decls []int) [
 				// folds into this item's cost so its region is sized to fit. The
 				// estimate is 0 for every type v3 self-host interpolates, so its work
 				// items and node numbering are untouched.
-				if sc_profile {
-					scsw.restart()
-				}
-				str_est := t.fn_span_interp_estimate(range_lo, i)
-				if sc_profile {
-					est_ms += f64(scsw.elapsed().microseconds()) / 1000.0
+				str_est := if t.building_v && t.parallel_enabled {
+					// The compiler's interpolated types are all bounded primitives and
+					// metadata names; none can trigger aggregate auto-str expansion.
+					0
+				} else {
+					if sc_profile {
+						scsw.restart()
+					}
+					estimate := t.fn_span_interp_estimate(range_lo, i)
+					if sc_profile {
+						est_ms += f64(scsw.elapsed().microseconds()) / 1000.0
+					}
+					estimate
 				}
 				if str_est > deferred_str_expansion_threshold {
 					t.deferred_str_items << FnWorkItem{

--- a/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
@@ -18,8 +18,8 @@ const max_parallel_transform_jobs = 7
 // Shared-base (clone-free) transform: workers share the master arrays and
 // append into pre-partitioned capacity regions, so extra threads cost no
 // clone memory; cap by core count only.
-const max_shared_transform_jobs = 10
-const max_parallel_monomorph_jobs = 10
+const max_shared_transform_jobs = 17
+const max_parallel_monomorph_jobs = 17
 // Recycle scratch arenas throughout large self-hosting transforms.
 const scoped_transform_worker_batches = 16
 const scoped_transform_master_batches = 16

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -1695,6 +1695,16 @@ pub fn (mut tc TypeChecker) refresh_direct_parent_index(a &flat.FlatAst) {
 	tc.build_direct_parent_index(a)
 }
 
+// reuse_direct_parent_index_for_unchanged_ast restores the parsed-tree index's trusted
+// status when an internal valid-build path has not structurally rewritten the AST.
+pub fn (mut tc TypeChecker) reuse_direct_parent_index_for_unchanged_ast(a &flat.FlatAst) bool {
+	if tc.direct_parent_ids.len != a.nodes.len || tc.value_used_nodes.len != a.nodes.len {
+		return false
+	}
+	tc.direct_parent_index_trusted = true
+	return true
+}
+
 // invalidate_direct_parent_index makes generated-node lookups validate parent metadata.
 pub fn (mut tc TypeChecker) invalidate_direct_parent_index() {
 	tc.direct_parent_index_trusted = false
@@ -7735,6 +7745,14 @@ pub fn (tc &TypeChecker) direct_dependencies(fn_node_id int) []string {
 		names << tc.symbol_name(id)
 	}
 	return names
+}
+
+// share_direct_dependencies_from reuses the immutable post-check dependency graph in a
+// synchronous compiler stage view. Parallel checker/transform workers must keep their
+// private dependency maps so resolution writes cannot race.
+pub fn (mut tc TypeChecker) share_direct_dependencies_from(source &TypeChecker) {
+	tc.direct_dependencies_by_fn = source.direct_dependencies_by_fn.clone()
+	tc.symbols = source.symbols
 }
 
 fn (mut tc TypeChecker) record_direct_dependency(id SymbolId) {

--- a/vlib/v3/types/checker_parallel.v
+++ b/vlib/v3/types/checker_parallel.v
@@ -11,7 +11,7 @@ const min_parallel_check_items = 256
 const max_parallel_check_jobs = 26
 // Scoped workers use bounded arena batches, so let self-host checks occupy all
 // of the worker pool's cores without retaining one large arena per core.
-const max_scoped_check_jobs = 10
+const max_scoped_check_jobs = 17
 // The historical 96-batch limit remains the low-memory fallback. Prealloc
 // self-host checks default to one twelfth as many batches below, amortizing
 // checker fork/promotion setup while keeping each worker's scratch bounded.
@@ -24,9 +24,9 @@ const scoped_check_serial_batches = 64
 // (Re-verified 2026-08: oversubscribe=4 costs ~25ms here — the extra per-chunk
 // fork/promote overhead outweighs the straggler absorption.)
 const check_chunk_oversubscribe = 1
-// Extra share of the total work (in percent of an even bucket) pre-assigned to
-// the master's bucket; see split_check_items.
-const check_master_bias_pct = i64(0)
+// The caller also runs the top-level signature pass while workers check bodies.
+// Give its body bucket one fifth less work so it does not become the pool tail.
+const check_master_bias_pct = i64(-20)
 
 struct CheckWorkItem {
 	fn_idx   int
@@ -1249,10 +1249,8 @@ fn split_check_items(items []CheckWorkItem, n int) [][]CheckWorkItem {
 	mut buckets := [][]CheckWorkItem{len: n, init: []CheckWorkItem{}}
 	mut loads := []i64{len: n}
 	if n > 1 && check_master_bias_pct != 0 {
-		// Historical bias: bucket 0 once finished early on this split. Measured
-		// 2026-07-25 the master chunk was instead the pool tail by ~30% (its
-		// span cost undercounts the dense builtin bodies), so the bias is off;
-		// the knob stays for machines where the old premise holds.
+		// A negative bias preloads bucket 0, causing the greedy splitter to assign
+		// it less body work than the helpers.
 		mut total := i64(0)
 		for it in items {
 			total += i64(it.cost) + 1

--- a/vlib/v3/types/checker_parallel_test.v
+++ b/vlib/v3/types/checker_parallel_test.v
@@ -58,6 +58,9 @@ fn test_parallel_checker_dependencies_are_private_and_merged() {
 	mut transform_worker := tc.fork_for_parallel_transform(&a)
 	assert isnil(transform_worker.visible_mutation_cache)
 	assert transform_worker.direct_dependencies_by_fn.len == 0
+	transform_worker.share_direct_dependencies_from(&tc)
+	assert transform_worker.direct_dependencies_by_fn[10] == [master_dependency, worker_dependency]
+	assert transform_worker.symbol_name(master_dependency) == 'main.master_dependency'
 	transform_worker.free_parallel_transform_caches()
 }
 
@@ -83,6 +86,9 @@ fn test_direct_parent_index_preserves_first_parent_and_falls_back_for_new_nodes(
 	tc.build_direct_parent_index(&a)
 	assert tc.direct_parent_id(child) == first_parent
 	assert tc.direct_parent_id(first_parent) == flat.empty_node
+	tc.invalidate_direct_parent_index()
+	assert tc.reuse_direct_parent_index_for_unchanged_ast(&a)
+	assert tc.direct_parent_id(child) == first_parent
 
 	appended_child := a.add_val(.ident, 'appended')
 	appended_children := a.begin_children()
@@ -92,6 +98,7 @@ fn test_direct_parent_index_preserves_first_parent_and_falls_back_for_new_nodes(
 		children_start: appended_children
 		children_count: 1
 	})
+	assert !tc.reuse_direct_parent_index_for_unchanged_ast(&a)
 	assert tc.direct_parent_id(appended_child) == appended_parent
 }
 


### PR DESCRIPTION
## Summary

- use up to 17 jobs across v3 parsing, scoped checking, markused, shared transform, monomorphization, and C generation
- avoid redundant building-v import reads, markused body scans, transform arena promotion, and string-expansion estimation
- overlap fixed-array, optional/multi-return, and fixed-storage C support discovery with predispatch work
- reuse immutable checker dependency metadata and improve checker load balancing
- preserve serial fallbacks and bootstrap compatibility

## Performance

Benchmark workflow from vlib/v3:

    ../../v -gc none -prealloc -prod -o v3 v3.v
    ./v3 -nocache -building-v -o v4 v3.v

The frontend excluding tcc went from approximately 644 ms to a final five-run median of 499.16 ms on an 18-core Apple machine. A lower-background-load sample measured 487.66-492.55 ms for four consecutive warm runs.

The main reductions are in import resolution, checker, markused, transform, and C generation. Markused is approximately 40-42 ms after pre-sizing its declaration indexes, down from roughly 85 ms at baseline.

## Testing

- exact bootstrap and self-host workflow above
- ./vnew -gc none -prealloc -check vlib/v3/v3.v
- ./vnew -silent test vlib/v3/tests/parallel_cgen_test.v
- ./vnew -silent test vlib/v3/tests/markused_test.v
- ./vnew -silent test vlib/v3/types/checker_parallel_test.v
- serial no-parallel directory self-host reproduction
- no-parallel user parallel-define reproduction
- formatting and git diff --check