### PR TITLE
v3: reduce parallel self-host frontend to 400ms

### DIFF
--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -12711,11 +12711,12 @@ struct EagerSelfhostImport {
 }
 
 struct EagerSelfhostModule {
-	path  string
-	dir   string
-	files []string
-mut:
+	path     string
+	dir      string
+	files    []string
 	identity string
+mut:
+	import_paths []string
 }
 
 struct EagerSelfhostScanArgs {
@@ -12730,8 +12731,10 @@ struct EagerSelfhostResolveArgs {
 	importing_file string
 	project_root   string
 mut:
-	dir   string
-	files []string
+	dir      string
+	real_dir string
+	files    []string
+	identity string
 }
 
 fn eager_selfhost_scan_thread(arg voidptr) voidptr {
@@ -12750,8 +12753,13 @@ fn eager_selfhost_resolve_thread(arg voidptr) voidptr {
 	result.dir = resolve_project_or_pref_module_path(prefs, result.path, result.importing_file,
 		result.project_root, mut local_cache)
 	if result.dir.len > 0 && os.is_dir(result.dir) {
+		result.real_dir = os.real_path(result.dir)
 		result.files = pref.get_v_files_from_dir_for_target(result.dir, prefs.user_defines,
 			prefs.target)
+		if result.files.len > 0 {
+			result.identity = import_module_identity_with_path_cache(prefs, result.path,
+				result.importing_file, result.project_root, result.dir, mut local_cache)
+		}
 	}
 	return unsafe { nil }
 }
@@ -12995,7 +13003,7 @@ fn discover_eager_selfhost_modules(a &flat.FlatAst, prefs &pref.Preferences, fir
 		}
 	}
 	mut modules := []EagerSelfhostModule{cap: 64}
-	mut paths_by_suffix := map[string][]string{}
+	mut module_by_real_dir := map[string]int{}
 	mut qi := 0
 	for qi < pending.len {
 		wave_end := pending.len
@@ -13023,14 +13031,18 @@ fn discover_eager_selfhost_modules(a &flat.FlatAst, prefs &pref.Preferences, fir
 			}
 			module_path_cache['${importing_dir}\n${import_req.path}'] = result.dir
 			parsed_modules[import_req.path] = true
-			modules << EagerSelfhostModule{
-				path:  import_req.path
-				dir:   result.dir
-				files: result.files
+			if result.real_dir in module_by_real_dir {
+				module_idx := module_by_real_dir[result.real_dir]
+				modules[module_idx].import_paths << import_req.path
+				continue
 			}
-			suffix := import_req.path.all_after_last('.')
-			if import_req.path !in paths_by_suffix[suffix] {
-				paths_by_suffix[suffix] << import_req.path
+			module_by_real_dir[result.real_dir] = modules.len
+			modules << EagerSelfhostModule{
+				path:         import_req.path
+				dir:          result.dir
+				files:        result.files
+				identity:     result.identity
+				import_paths: [import_req.path]
 			}
 			wave_files << result.files
 		}
@@ -13043,12 +13055,6 @@ fn discover_eager_selfhost_modules(a &flat.FlatAst, prefs &pref.Preferences, fir
 				}
 			}
 		}
-	}
-	for i in 0 .. modules.len {
-		path := modules[i].path
-		suffix := path.all_after_last('.')
-		collides := path.contains('.') && paths_by_suffix[suffix].len > 1
-		modules[i].identity = if collides { path } else { suffix }
 	}
 	return modules
 }
@@ -13114,10 +13120,16 @@ fn resolve_imports(mut a flat.FlatAst, mut p parser.Parser, prefs &pref.Preferen
 		mut eager_canons := []string{}
 		for module_info in modules {
 			identity := module_info.identity
-			parsed_module_identities[module_info.path] = identity
+			for import_path in module_info.import_paths {
+				parsed_module_identities[import_path] = identity
+			}
 			parsed_modules[identity] = true
 			parsed_identity_dirs[identity] = module_info.dir
-			cache_state.module_import_paths[identity] = module_info.path
+			cache_state.module_import_paths[identity] = if identity in module_info.import_paths {
+				identity
+			} else {
+				module_info.path
+			}
 			cache_state.module_sources[identity] = module_info.files
 			cache_state.parsed_from_source[identity] = true
 			cache_state.source_body_modules[identity] = true

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -13028,11 +13028,9 @@ fn discover_eager_selfhost_modules(a &flat.FlatAst, prefs &pref.Preferences, fir
 				dir:   result.dir
 				files: result.files
 			}
-			if import_req.path.contains('.') {
-				suffix := import_req.path.all_after_last('.')
-				if import_req.path !in paths_by_suffix[suffix] {
-					paths_by_suffix[suffix] << import_req.path
-				}
+			suffix := import_req.path.all_after_last('.')
+			if import_req.path !in paths_by_suffix[suffix] {
+				paths_by_suffix[suffix] << import_req.path
 			}
 			wave_files << result.files
 		}

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -12713,9 +12713,10 @@ struct EagerSelfhostImport {
 struct EagerSelfhostModule {
 	path     string
 	dir      string
+	real_dir string
 	files    []string
-	identity string
 mut:
+	identity     string
 	import_paths []string
 }
 
@@ -13040,6 +13041,7 @@ fn discover_eager_selfhost_modules(a &flat.FlatAst, prefs &pref.Preferences, fir
 			modules << EagerSelfhostModule{
 				path:         import_req.path
 				dir:          result.dir
+				real_dir:     result.real_dir
 				files:        result.files
 				identity:     result.identity
 				import_paths: [import_req.path]
@@ -13055,6 +13057,19 @@ fn discover_eager_selfhost_modules(a &flat.FlatAst, prefs &pref.Preferences, fir
 				}
 			}
 		}
+	}
+	// Alias-aware resolution is local to each request. Reconcile its short
+	// identities in discovery order so distinct directories with the same module
+	// suffix receive the same qualification as the authoritative resolver.
+	mut identity_dirs := map[string]string{}
+	for i in 0 .. modules.len {
+		identity := modules[i].identity
+		if owner_dir := identity_dirs[identity] {
+			if owner_dir != modules[i].real_dir {
+				modules[i].identity = modules[i].path
+			}
+		}
+		identity_dirs[modules[i].identity] = modules[i].real_dir
 	}
 	return modules
 }

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -7387,7 +7387,10 @@ pub fn run(args []string) {
 	pre_tc.notes_are_errors = notes_are_errors
 	pre_tc.is_prod = prefs.is_prod
 	pre_tc.building_v_fast = building_v && os.getenv('V3_NO_BUILDING_V_FAST_CHECK') == ''
-	pre_tc.valid_diagnostic_fast = building_v && os.getenv('V3_NO_VALID_DIAGNOSTIC_FAST') == ''
+	// Missing imports are rare error paths and need the authoritative serial
+	// diagnostic pass, even for an otherwise-fast parallel self-host build.
+	pre_tc.valid_diagnostic_fast = building_v && a.missing_imports.len == 0
+		&& os.getenv('V3_NO_VALID_DIAGNOSTIC_FAST') == ''
 	pre_tc.valid_resolution_fast = building_v && os.getenv('V3_NO_VALID_RESOLUTION_FAST') == ''
 	pre_tc.suppress_dump_output = 'nop_dump' in prefs.user_defines
 	mut used_fns := map[string]bool{}
@@ -7401,7 +7404,7 @@ pub fn run(args []string) {
 	mut trivial_literal_output := false
 	if !cgen_cache_hit {
 		pre_tc.verbose = prefs.verbose
-		if scope_prealloc_check {
+		if scope_prealloc_check && a.missing_imports.len == 0 {
 			pre_tc.enable_scoped_parallel_workers()
 		}
 		pre_tc.reject_unsupported_generics = is_selfhost
@@ -7463,7 +7466,8 @@ pub fn run(args []string) {
 		} else if incremental_cache_hit {
 			pre_tc.check_semantics_selected(incremental_changed_names)
 		} else {
-			check_was_parallel = pre_tc.check_semantics_opt(!current_no_parallel)
+			check_was_parallel = pre_tc.check_semantics_opt(!current_no_parallel
+				&& a.missing_imports.len == 0)
 		}
 		mut prepared_markused := prepared_markused_thread.wait()
 		ckpre_sw.restart()
@@ -12876,6 +12880,9 @@ fn source_imports_fast_parallel(a &flat.FlatAst, files []string) [][]string {
 // avoids three parse/merge barriers while preserving the ordinary resolver as
 // the source of truth for the resulting AST.
 fn discover_eager_selfhost_modules(a &flat.FlatAst, prefs &pref.Preferences, first_file string, project_root string, mut parsed_modules map[string]bool, mut module_path_cache map[string]string) []EagerSelfhostModule {
+	// Traversal attempts are separate from successfully parsed modules. An
+	// unresolved eager probe must remain visible to the authoritative resolver.
+	mut visited_modules := parsed_modules.clone()
 	mut pending := []EagerSelfhostImport{cap: 128}
 	mut cur_file := first_file
 	for node in a.nodes {
@@ -12897,10 +12904,10 @@ fn discover_eager_selfhost_modules(a &flat.FlatAst, prefs &pref.Preferences, fir
 		for qi < wave_end {
 			import_req := pending[qi]
 			qi++
-			if import_req.path in parsed_modules {
+			if import_req.path in visited_modules {
 				continue
 			}
-			parsed_modules[import_req.path] = true
+			visited_modules[import_req.path] = true
 			wave_requests << import_req
 		}
 		wave_results := resolve_eager_selfhost_wave(a, prefs, wave_requests, project_root)
@@ -12912,10 +12919,11 @@ fn discover_eager_selfhost_modules(a &flat.FlatAst, prefs &pref.Preferences, fir
 			} else {
 				''
 			}
-			module_path_cache['${importing_dir}\n${import_req.path}'] = result.dir
 			if result.files.len == 0 {
 				continue
 			}
+			module_path_cache['${importing_dir}\n${import_req.path}'] = result.dir
+			parsed_modules[import_req.path] = true
 			modules << EagerSelfhostModule{
 				path:  import_req.path
 				dir:   result.dir
@@ -13255,7 +13263,13 @@ fn resolve_imports(mut a flat.FlatAst, mut p parser.Parser, prefs &pref.Preferen
 			cache_module := if module_identity.len > 0 { module_identity } else { mod_name }
 			record_cache_module_dependency(mut cache_state, cur_module, cache_module)
 			mod_dir_exists := mod_dir.len > 0 && os.is_dir(mod_dir)
-			if !mod_dir_exists && !is_bundle_warmup_import {
+			mod_files := if mod_dir_exists {
+				pref.get_v_files_from_dir_for_target(mod_dir, prefs.user_defines, prefs.target)
+			} else {
+				[]string{}
+			}
+			module_resolved := mod_dir_exists && mod_files.len > 0
+			if !module_resolved && !is_bundle_warmup_import {
 				a.missing_imports[node_idx] = mod_name
 				unresolved_modules[mod_name] = true
 			}
@@ -13274,9 +13288,7 @@ fn resolve_imports(mut a flat.FlatAst, mut p parser.Parser, prefs &pref.Preferen
 				mod_name
 			}
 
-			if mod_dir_exists {
-				mod_files := pref.get_v_files_from_dir_for_target(mod_dir, prefs.user_defines,
-					prefs.target)
+			if module_resolved {
 				// -building-v compiles the trusted compiler tree and already skips other
 				// validity-only diagnostics. Avoid reading every imported source once here
 				// just before the parser reads the same files.

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -12743,17 +12743,12 @@ fn eager_selfhost_scan_thread(arg voidptr) voidptr {
 fn eager_selfhost_resolve_thread(arg voidptr) voidptr {
 	mut result := unsafe { &EagerSelfhostResolveArgs(arg) }
 	prefs := unsafe { &pref.Preferences(result.prefs) }
-	// `-building-v` imports compiler/stdlib modules from vlib. Probe that direct
-	// path before the general project/module search, which otherwise repeats
-	// parent-directory and v.mod discovery for every BFS wave.
-	vlib_dir := prefs.get_vlib_module_path(result.path)
-	if os.is_dir(vlib_dir) {
-		result.dir = vlib_dir
-	} else {
-		mut local_cache := map[string]string{}
-		result.dir = resolve_project_or_pref_module_path(prefs, result.path, result.importing_file,
-			result.project_root, mut local_cache)
-	}
+	// Preserve the authoritative resolver's local/project/global precedence.
+	// Every wave contains each import path once, and the chosen result is cached
+	// for the authoritative pass by discover_eager_selfhost_modules.
+	mut local_cache := map[string]string{}
+	result.dir = resolve_project_or_pref_module_path(prefs, result.path, result.importing_file,
+		result.project_root, mut local_cache)
 	if result.dir.len > 0 && os.is_dir(result.dir) {
 		result.files = pref.get_v_files_from_dir_for_target(result.dir, prefs.user_defines,
 			prefs.target)
@@ -12791,46 +12786,103 @@ fn resolve_eager_selfhost_wave(a &flat.FlatAst, prefs &pref.Preferences, request
 // without constructing tokens. It is used only to assemble the trusted
 // -building-v parse batch; the real parser remains authoritative immediately
 // afterwards.
+@[direct_array_access]
 fn source_imports_fast(path string) []string {
 	source := os.read_file(path) or { return []string{} }
 	mut imports := []string{cap: 16}
-	mut line_start := 0
-	mut in_block_comment := false
-	for line_start < source.len {
-		mut line_end := line_start
-		for line_end < source.len && source[line_end] != `\n` {
-			line_end++
-		}
-		mut i := line_start
-		for i < line_end {
-			if in_block_comment {
-				if i + 1 < line_end && source[i] == `*` && source[i + 1] == `/` {
-					in_block_comment = false
+	mut i := 0
+	mut at_line_head := true
+	mut block_comment_depth := 0
+	mut quote := u8(0)
+	mut raw_string := false
+	for i < source.len {
+		if quote != 0 {
+			for i < source.len {
+				c := source[i]
+				if !raw_string && c == `\\` && i + 1 < source.len {
 					i += 2
 					continue
 				}
 				i++
-				continue
+				if c == quote {
+					quote = 0
+					raw_string = false
+					at_line_head = false
+					break
+				}
+				if c == `\n` {
+					at_line_head = true
+				}
 			}
-			if source[i] in [` `, `\t`, `\r`] {
+			continue
+		}
+		if block_comment_depth > 0 {
+			for i < source.len {
+				c := source[i]
+				if i + 1 < source.len && c == `/` && source[i + 1] == `*` {
+					block_comment_depth++
+					i += 2
+					continue
+				}
+				if i + 1 < source.len && c == `*` && source[i + 1] == `/` {
+					block_comment_depth--
+					i += 2
+					if block_comment_depth == 0 {
+						break
+					}
+					continue
+				}
+				if c == `\n` {
+					at_line_head = true
+				}
+				i++
+			}
+			continue
+		}
+		for i < source.len {
+			c := source[i]
+			if c == `\n` {
+				at_line_head = true
 				i++
 				continue
 			}
-			if i + 1 < line_end && source[i] == `/` && source[i + 1] == `*` {
-				in_block_comment = true
-				i += 2
+			if i + 1 < source.len && c == `/` && source[i + 1] == `/` {
+				for i < source.len && source[i] != `\n` {
+					i++
+				}
 				continue
 			}
-			if i + 1 < line_end && source[i] == `/` && source[i + 1] == `/` {
+			if i + 1 < source.len && c == `/` && source[i + 1] == `*` {
+				block_comment_depth = 1
+				i += 2
 				break
 			}
-			if i + 7 <= line_end && source[i..i + 6] == 'import' && source[i + 6] in [` `, `\t`] {
+			if c == `r` && i + 1 < source.len && source[i + 1] in [`'`, `"`] {
+				quote = source[i + 1]
+				raw_string = true
+				at_line_head = false
+				i += 2
+				break
+			}
+			if c in [`'`, `"`, `\``] {
+				quote = c
+				raw_string = false
+				at_line_head = false
+				i++
+				break
+			}
+			if at_line_head && c in [` `, `\t`, `\r`] {
+				i++
+				continue
+			}
+			if at_line_head && i + 7 <= source.len && source[i..i + 6] == 'import'
+				&& source[i + 6] in [` `, `\t`] {
 				i += 7
-				for i < line_end && source[i] in [` `, `\t`] {
+				for i < source.len && source[i] in [` `, `\t`] {
 					i++
 				}
 				start := i
-				for i < line_end && ((source[i] >= `a` && source[i] <= `z`)
+				for i < source.len && ((source[i] >= `a` && source[i] <= `z`)
 					|| (source[i] >= `A` && source[i] <= `Z`)
 					|| (source[i] >= `0` && source[i] <= `9`)
 					|| source[i] in [`_`, `.`]) {
@@ -12839,10 +12891,12 @@ fn source_imports_fast(path string) []string {
 				if i > start {
 					imports << source[start..i]
 				}
+				at_line_head = false
+				continue
 			}
-			break
+			at_line_head = false
+			i++
 		}
-		line_start = line_end + 1
 	}
 	return imports
 }
@@ -13707,36 +13761,10 @@ fn resolve_project_or_pref_module_path_cached(prefs &pref.Preferences, mod_name 
 
 fn resolve_project_or_pref_module_path(prefs &pref.Preferences, mod_name string, importing_file string, project_root string, mut cache map[string]string) string {
 	mod_path := mod_name.replace('.', os.path_separator)
-	if importing_file.len > 0 {
-		importer_dir := os.dir(importing_file)
-		if alias_path := pref.resolve_module_alias_path(importer_dir, mod_name) {
-			return alias_path
-		}
-		local_modules_root := os.join_path_single(importer_dir, 'modules')
-		if alias_path := pref.resolve_module_alias_path(local_modules_root, mod_name) {
-			return alias_path
-		}
-		local_modules_path := os.join_path_single(local_modules_root, mod_path)
-		if module_path_has_v_sources(local_modules_path) {
-			return local_modules_path
-		}
-	}
-	if project_root.len > 0 {
-		if alias_path := pref.resolve_module_alias_path(project_root, mod_name) {
-			return alias_path
-		}
-		project_path := os.join_path_single(project_root, mod_path)
-		if module_path_has_v_sources(project_path) {
-			return project_path
-		}
-	}
-	// Preserve the existing resolver priority: explicit local `modules/` and
-	// project-root modules precede a module beside the importing file.
-	if importing_file.len > 0 {
-		relative_path := os.join_path_single(os.dir(importing_file), mod_path)
-		if module_path_has_v_sources(relative_path) {
-			return relative_path
-		}
+	local_path := resolve_local_or_project_module_path(mod_name, mod_path, importing_file,
+		project_root)
+	if local_path.len > 0 {
+		return local_path
 	}
 	// vlib and the global module directory do not depend on the importing file.
 	// Resolve them once per import name instead of repeating the same alias probes
@@ -13755,6 +13783,51 @@ fn resolve_project_or_pref_module_path(prefs &pref.Preferences, mod_name string,
 		}
 	}
 	return prefs.get_module_path(mod_name, importing_file)
+}
+
+fn resolve_local_or_project_module_path(mod_name string, mod_path string, importing_file string, project_root string) string {
+	top_name := mod_name.all_before('.')
+	if importing_file.len > 0 {
+		importer_dir := os.dir(importing_file)
+		if alias_path := resolve_local_module_alias_path(importer_dir, top_name, mod_name) {
+			return alias_path
+		}
+		local_modules_root := os.join_path_single(importer_dir, 'modules')
+		if alias_path := resolve_local_module_alias_path(local_modules_root, top_name, mod_name) {
+			return alias_path
+		}
+		local_modules_path := os.join_path_single(local_modules_root, mod_path)
+		if module_path_has_v_sources(local_modules_path) {
+			return local_modules_path
+		}
+	}
+	if project_root.len > 0 {
+		if alias_path := resolve_local_module_alias_path(project_root, top_name, mod_name) {
+			return alias_path
+		}
+		project_path := os.join_path_single(project_root, mod_path)
+		if module_path_has_v_sources(project_path) {
+			return project_path
+		}
+	}
+	// Preserve the existing resolver priority: explicit local `modules/` and
+	// project-root modules precede a module beside the importing file.
+	if importing_file.len > 0 {
+		relative_path := os.join_path_single(os.dir(importing_file), mod_path)
+		if module_path_has_v_sources(relative_path) {
+			return relative_path
+		}
+	}
+	return ''
+}
+
+fn resolve_local_module_alias_path(root string, top_name string, mod_name string) ?string {
+	// An alias for `a.b` can only exist below root/a. Avoid probing every
+	// possible alias.v prefix for the overwhelmingly common missing local root.
+	if !os.is_dir(os.join_path_single(root, top_name)) {
+		return none
+	}
+	return pref.resolve_module_alias_path(root, mod_name)
 }
 
 fn import_uses_explicit_module_alias(prefs &pref.Preferences, mod_name string, importing_file string, project_root string) bool {

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -21,6 +21,7 @@ import v3.tempname
 import v3.token as v3token
 import v3.transform
 import v3.types
+import v3.workers
 import v.vmod
 
 $if !skip_eval ? {
@@ -7396,6 +7397,7 @@ pub fn run(args []string) {
 	mut skip_transform_generics := true
 	mut transform_texts_canonical := cgen_cache_hit
 	mut retained_transform_scope := unsafe { nil }
+	mut retained_transform_prepare_scope := unsafe { nil }
 	mut trivial_literal_output := false
 	if !cgen_cache_hit {
 		pre_tc.verbose = prefs.verbose
@@ -7446,6 +7448,14 @@ pub fn run(args []string) {
 		if verbose {
 			eprintln('  [ttime]   ck iface idx     ${f64(cvsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 		}
+		// The parallel checker deliberately leaves one logical core outside its
+		// worker pool. Use it to build the immutable markused declaration indexes.
+		prepare_markused_overlap := building_v && current_parallel_transform
+			&& scope_prealloc_markused && !incremental_cache_hit && !generic_cache_hit
+			&& !cache_state.manager.enabled && test_files.len == 0 && !is_checker_fixture
+			&& !trivial_literal_output && !input_file.ends_with('.vsh') && !no_skip_unused
+		prepared_markused_thread := spawn markused.prepare_markused_declarations(a, &pre_tc,
+			prepare_markused_overlap)
 		mut check_was_parallel := false
 		if trivial_literal_output && !incremental_cache_hit {
 			used_fns = markused.mark_used_without_generic_detection(a, &pre_tc)
@@ -7455,6 +7465,7 @@ pub fn run(args []string) {
 		} else {
 			check_was_parallel = pre_tc.check_semantics_opt(!current_no_parallel)
 		}
+		mut prepared_markused := prepared_markused_thread.wait()
 		ckpre_sw.restart()
 		pre_tc.check_main_module_requirement(is_shared || test_files.len > 0
 			|| a.export_fn_names.len > 0)
@@ -7605,6 +7616,14 @@ pub fn run(args []string) {
 			}
 		}
 		_ = pre_tc.ierror_impl_names()
+		// Self-host markused is dominated by serial reachability/index work. Build
+		// transform's read-only indexes beside it so the otherwise-idle cores do
+		// useful work without delaying either stage's mutable AST operations.
+		prepare_transform_overlap := building_v && current_parallel_transform
+			&& scope_prealloc_transform && !incremental_cache_hit && !generic_cache_hit
+			&& !cache_state.manager.enabled
+		prepared_transform_thread := spawn transform.prepare_selfhost_transform(a, &pre_tc,
+			prepare_transform_overlap)
 
 		// Mark used functions (dead-code elimination). This is done before transform
 		// so the transformer can skip function bodies that the C backend will prune.
@@ -7646,7 +7665,12 @@ pub fn run(args []string) {
 			used_fns, uses_generics = markused.mark_used_with_generic_usage_full_runtime(a,
 				markused_tc)
 		} else if building_v && current_parallel_transform {
-			used_fns = markused.mark_used_without_generic_detection(a, markused_tc)
+			if prepare_markused_overlap {
+				used_fns = markused.mark_used_without_generic_detection_prepared(a, markused_tc, mut
+					prepared_markused)
+			} else {
+				used_fns = markused.mark_used_without_generic_detection(a, markused_tc)
+			}
 			uses_generics = false
 		} else {
 			used_fns, uses_generics = markused.mark_used_with_generic_usage(a, markused_tc)
@@ -7654,7 +7678,12 @@ pub fn run(args []string) {
 		if is_prof {
 			add_v3_profile_used_fns(mut used_fns)
 		}
-		program_used_fns = clone_string_bool_map(used_fns)
+		// The separate program reachability snapshot is consumed only by the
+		// module/generic cache publishers. A -nocache self-host can skip cloning
+		// ~10k entries twice around the disposable markused arena.
+		if cache_state.manager.enabled {
+			program_used_fns = clone_string_bool_map(used_fns)
+		}
 		if cache_state.manager.enabled && !generic_cache_hit {
 			if building_v && current_parallel_transform {
 				used_fns = markused.mark_used_for_cache_without_generic_detection(a, markused_tc,
@@ -7668,10 +7697,16 @@ pub fn run(args []string) {
 		}
 		if scope_prealloc_markused && !generic_cache_hit {
 			prealloc_scope_leave_for_v3(markused_scope)
-			program_used_fns = clone_string_bool_map(program_used_fns)
 			used_fns = clone_string_bool_map(used_fns)
+			if cache_state.manager.enabled {
+				program_used_fns = clone_string_bool_map(program_used_fns)
+			}
 			prealloc_scope_free_for_v3(markused_scope)
 		}
+		if prepare_markused_overlap {
+			prepared_markused.release()
+		}
+		mut prepared_transform := prepared_transform_thread.wait()
 		b.step('markused')
 		b.metric('reachable symbols', used_fns.len, 'symbols')
 		mut tfpre_sw := time.new_stopwatch()
@@ -7729,7 +7764,7 @@ pub fn run(args []string) {
 		if incremental_cache_hit {
 			skip_transform_generics = true
 		}
-		mut transform_used_fns := clone_string_bool_map(used_fns)
+		mut transform_used_fns := map[string]bool{}
 		if incremental_cache_hit {
 			transform_used_fns = clone_string_bool_map(incremental_changed_names)
 			// `main` activates the transformer's used-function filter. If another
@@ -7784,9 +7819,16 @@ pub fn run(args []string) {
 			transform_scope := prealloc_scope_begin_for_v3()
 			mut scoped_owned_base_nodes := []int{}
 			mut retained_transform_regions := []transform.ScopedTransformRegion{}
-			transform_used_fns, transform_was_parallel, transform_errors, scoped_owned_base_nodes, retained_transform_regions = transform.transform_with_used_opt_config_scoped_workers_checked_owned(mut a,
-				&pre_tc, transform_used_fns, current_parallel_transform, skip_transform_generics,
-				true, building_v || trivial_literal_output, transform_scope)
+			if prepare_transform_overlap {
+				transform_used_fns, transform_was_parallel, transform_errors, scoped_owned_base_nodes, retained_transform_regions = transform.transform_prepared_selfhost_owned(mut prepared_transform, mut
+					a, &pre_tc, used_fns, transform_scope)
+				retained_transform_prepare_scope = prepared_transform.take_scope()
+			} else {
+				transform_used_fns, transform_was_parallel, transform_errors, scoped_owned_base_nodes, retained_transform_regions = transform.transform_with_used_opt_config_scoped_workers_checked_owned(mut a,
+					&pre_tc, used_fns, current_parallel_transform, skip_transform_generics, true,
+
+					building_v || trivial_literal_output, transform_scope)
+			}
 			parse_cache_enabled := pre_tc.type_cache_parse_enabled()
 			mut post_sw := time.new_stopwatch()
 			prealloc_scope_leave_for_v3(transform_scope)
@@ -8011,8 +8053,9 @@ pub fn run(args []string) {
 			}
 		} else {
 			transform_used_fns, transform_was_parallel, transform_errors = transform.transform_with_used_opt_config_scoped_workers_checked(mut a,
-				&pre_tc, transform_used_fns, current_parallel_transform, skip_transform_generics,
-				false, building_v || trivial_literal_output)
+				&pre_tc, used_fns, current_parallel_transform, skip_transform_generics, false,
+
+				building_v || trivial_literal_output)
 		}
 		if !incremental_cache_hit {
 			used_fns = transform_used_fns.move()
@@ -9370,6 +9413,10 @@ Please install the corresponding development package/libraries and make sure the
 	if retained_transform_scope != unsafe { nil } {
 		prealloc_scope_free_for_v3(retained_transform_scope)
 		retained_transform_scope = unsafe { nil }
+	}
+	if retained_transform_prepare_scope != unsafe { nil } {
+		prealloc_scope_free_for_v3(retained_transform_prepare_scope)
+		retained_transform_prepare_scope = unsafe { nil }
 	}
 	if show_test_stats {
 		println('checker summary: 0 V errors, ${checker_warning_count} V warnings, ${checker_notice_count} V notices')
@@ -12649,6 +12696,258 @@ fn file_index_usable_for_imports(a &flat.FlatAst) bool {
 		&& os.getenv('V3_NO_FILE_IDX') == '' && os.getenv('V3_NO_IMPORT_IDX') == ''
 }
 
+struct ImportCollisionSeed {
+	path           string
+	importing_file string
+}
+
+struct EagerSelfhostImport {
+	path           string
+	importing_file string
+}
+
+struct EagerSelfhostModule {
+	path  string
+	dir   string
+	files []string
+mut:
+	identity string
+}
+
+struct EagerSelfhostScanArgs {
+	path string
+mut:
+	imports []string
+}
+
+struct EagerSelfhostResolveArgs {
+	prefs          voidptr
+	path           string
+	importing_file string
+	project_root   string
+mut:
+	dir   string
+	files []string
+}
+
+fn eager_selfhost_scan_thread(arg voidptr) voidptr {
+	mut scan := unsafe { &EagerSelfhostScanArgs(arg) }
+	scan.imports = source_imports_fast(scan.path)
+	return unsafe { nil }
+}
+
+fn eager_selfhost_resolve_thread(arg voidptr) voidptr {
+	mut result := unsafe { &EagerSelfhostResolveArgs(arg) }
+	prefs := unsafe { &pref.Preferences(result.prefs) }
+	// `-building-v` imports compiler/stdlib modules from vlib. Probe that direct
+	// path before the general project/module search, which otherwise repeats
+	// parent-directory and v.mod discovery for every BFS wave.
+	vlib_dir := prefs.get_vlib_module_path(result.path)
+	if os.is_dir(vlib_dir) {
+		result.dir = vlib_dir
+	} else {
+		mut local_cache := map[string]string{}
+		result.dir = resolve_project_or_pref_module_path(prefs, result.path, result.importing_file,
+			result.project_root, mut local_cache)
+	}
+	if result.dir.len > 0 && os.is_dir(result.dir) {
+		result.files = pref.get_v_files_from_dir_for_target(result.dir, prefs.user_defines,
+			prefs.target)
+	}
+	return unsafe { nil }
+}
+
+fn resolve_eager_selfhost_wave(a &flat.FlatAst, prefs &pref.Preferences, requests []EagerSelfhostImport, project_root string) []EagerSelfhostResolveArgs {
+	mut results := []EagerSelfhostResolveArgs{cap: requests.len}
+	mut tasks := []workers.Task{cap: requests.len}
+	for i, import_req in requests {
+		results << EagerSelfhostResolveArgs{
+			prefs:          voidptr(prefs)
+			path:           import_req.path
+			importing_file: import_req.importing_file
+			project_root:   project_root
+		}
+		tasks << workers.Task{
+			run:        eager_selfhost_resolve_thread
+			arg:        unsafe { voidptr(&results[i]) }
+			force_sync: i == 0
+		}
+	}
+	if isnil(a.worker_pool) || a.worker_pool.size() == 0 {
+		for i in 0 .. results.len {
+			eager_selfhost_resolve_thread(unsafe { voidptr(&results[i]) })
+		}
+	} else {
+		a.worker_pool.run(tasks)
+	}
+	return results
+}
+
+// source_imports_fast extracts the compiler tree's one-line import declarations
+// without constructing tokens. It is used only to assemble the trusted
+// -building-v parse batch; the real parser remains authoritative immediately
+// afterwards.
+fn source_imports_fast(path string) []string {
+	source := os.read_file(path) or { return []string{} }
+	mut imports := []string{cap: 16}
+	mut line_start := 0
+	mut in_block_comment := false
+	for line_start < source.len {
+		mut line_end := line_start
+		for line_end < source.len && source[line_end] != `\n` {
+			line_end++
+		}
+		mut i := line_start
+		for i < line_end {
+			if in_block_comment {
+				if i + 1 < line_end && source[i] == `*` && source[i + 1] == `/` {
+					in_block_comment = false
+					i += 2
+					continue
+				}
+				i++
+				continue
+			}
+			if source[i] in [` `, `\t`, `\r`] {
+				i++
+				continue
+			}
+			if i + 1 < line_end && source[i] == `/` && source[i + 1] == `*` {
+				in_block_comment = true
+				i += 2
+				continue
+			}
+			if i + 1 < line_end && source[i] == `/` && source[i + 1] == `/` {
+				break
+			}
+			if i + 7 <= line_end && source[i..i + 6] == 'import' && source[i + 6] in [` `, `\t`] {
+				i += 7
+				for i < line_end && source[i] in [` `, `\t`] {
+					i++
+				}
+				start := i
+				for i < line_end && ((source[i] >= `a` && source[i] <= `z`)
+					|| (source[i] >= `A` && source[i] <= `Z`)
+					|| (source[i] >= `0` && source[i] <= `9`)
+					|| source[i] in [`_`, `.`]) {
+					i++
+				}
+				if i > start {
+					imports << source[start..i]
+				}
+			}
+			break
+		}
+		line_start = line_end + 1
+	}
+	return imports
+}
+
+fn source_imports_fast_parallel(a &flat.FlatAst, files []string) [][]string {
+	if files.len < 2 || isnil(a.worker_pool) || a.worker_pool.size() == 0 {
+		mut imports := [][]string{cap: files.len}
+		for file in files {
+			imports << source_imports_fast(file)
+		}
+		return imports
+	}
+	mut scans := []EagerSelfhostScanArgs{cap: files.len}
+	mut tasks := []workers.Task{cap: files.len}
+	for i, file in files {
+		scans << EagerSelfhostScanArgs{
+			path: file
+		}
+		tasks << workers.Task{
+			run:        eager_selfhost_scan_thread
+			arg:        unsafe { voidptr(&scans[i]) }
+			force_sync: i == 0
+		}
+	}
+	a.worker_pool.run(tasks)
+	mut imports := [][]string{cap: files.len}
+	for scan in scans {
+		imports << scan.imports
+	}
+	return imports
+}
+
+// discover_eager_selfhost_modules resolves the complete trusted compiler import
+// graph with a byte-level import scan. Parsing the resulting files in one batch
+// avoids three parse/merge barriers while preserving the ordinary resolver as
+// the source of truth for the resulting AST.
+fn discover_eager_selfhost_modules(a &flat.FlatAst, prefs &pref.Preferences, first_file string, project_root string, mut parsed_modules map[string]bool, mut module_path_cache map[string]string) []EagerSelfhostModule {
+	mut pending := []EagerSelfhostImport{cap: 128}
+	mut cur_file := first_file
+	for node in a.nodes {
+		if node.kind == .file && node.value.len > 0 {
+			cur_file = node.value
+		} else if node.kind == .import_decl && node.value.len > 0 {
+			pending << EagerSelfhostImport{
+				path:           node.value
+				importing_file: cur_file
+			}
+		}
+	}
+	mut modules := []EagerSelfhostModule{cap: 64}
+	mut paths_by_suffix := map[string][]string{}
+	mut qi := 0
+	for qi < pending.len {
+		wave_end := pending.len
+		mut wave_requests := []EagerSelfhostImport{}
+		for qi < wave_end {
+			import_req := pending[qi]
+			qi++
+			if import_req.path in parsed_modules {
+				continue
+			}
+			parsed_modules[import_req.path] = true
+			wave_requests << import_req
+		}
+		wave_results := resolve_eager_selfhost_wave(a, prefs, wave_requests, project_root)
+		mut wave_files := []string{}
+		for i, result in wave_results {
+			import_req := wave_requests[i]
+			importing_dir := if import_req.importing_file.len > 0 {
+				os.dir(import_req.importing_file)
+			} else {
+				''
+			}
+			module_path_cache['${importing_dir}\n${import_req.path}'] = result.dir
+			if result.files.len == 0 {
+				continue
+			}
+			modules << EagerSelfhostModule{
+				path:  import_req.path
+				dir:   result.dir
+				files: result.files
+			}
+			if import_req.path.contains('.') {
+				suffix := import_req.path.all_after_last('.')
+				if import_req.path !in paths_by_suffix[suffix] {
+					paths_by_suffix[suffix] << import_req.path
+				}
+			}
+			wave_files << result.files
+		}
+		wave_imports := source_imports_fast_parallel(a, wave_files)
+		for i, file in wave_files {
+			for imported in wave_imports[i] {
+				pending << EagerSelfhostImport{
+					path:           imported
+					importing_file: file
+				}
+			}
+		}
+	}
+	for i in 0 .. modules.len {
+		path := modules[i].path
+		suffix := path.all_after_last('.')
+		collides := path.contains('.') && paths_by_suffix[suffix].len > 1
+		modules[i].identity = if collides { path } else { suffix }
+	}
+	return modules
+}
+
 fn resolve_imports(mut a flat.FlatAst, mut p parser.Parser, prefs &pref.Preferences, initial_files []string, allow_parallel bool, skip_closure_runtime bool, mut cache_state V3ModuleCacheState, mut parse_timing V3ParseTiming) bool {
 	mut parsed_modules := map[string]bool{}
 	parsed_modules['builtin'] = true
@@ -12690,6 +12989,8 @@ fn resolve_imports(mut a flat.FlatAst, mut p parser.Parser, prefs &pref.Preferen
 	mut forced_full_module_paths := map[string]bool{}
 	mut module_path_cache := map[string]string{}
 	mut module_identity_cache := map[string]string{}
+	mut first_collision_seed_by_short := map[string]ImportCollisionSeed{}
+	mut resolved_collision_seeds := map[string]bool{}
 	mut unresolved_modules := map[string]bool{}
 	mut cached_header_source_contexts := map[string]string{}
 	bundle_import_file := cache_bundle_import_file(prefs.get_vlib_module_path('builtin'))
@@ -12699,8 +13000,46 @@ fn resolve_imports(mut a flat.FlatAst, mut p parser.Parser, prefs &pref.Preferen
 			cached_header_source_contexts[builtin_header] = builtin_sources[0]
 		}
 	}
-
 	mut was_parallel := false
+	if prefs.building_v && allow_parallel && !cache_state.manager.enabled
+		&& os.getenv('V3_NO_EAGER_SELFHOST_IMPORTS') == '' {
+		modules := discover_eager_selfhost_modules(a, prefs, first_file, project_root, mut
+			parsed_modules, mut module_path_cache)
+		mut eager_files := []string{}
+		mut eager_canons := []string{}
+		for module_info in modules {
+			identity := module_info.identity
+			parsed_module_identities[module_info.path] = identity
+			parsed_modules[identity] = true
+			parsed_identity_dirs[identity] = module_info.dir
+			cache_state.module_import_paths[identity] = module_info.path
+			cache_state.module_sources[identity] = module_info.files
+			cache_state.parsed_from_source[identity] = true
+			cache_state.source_body_modules[identity] = true
+			for file in module_info.files {
+				eager_files << file
+				eager_canons << if identity == module_info.path { identity } else { '' }
+			}
+		}
+		if eager_files.len > 0 {
+			starts, eager_parallel := parse_files_dispatch_profiled(mut p, eager_files,
+				allow_parallel, mut parse_timing)
+			was_parallel = was_parallel || eager_parallel
+			end_node := a.nodes.len
+			for i, canon in eager_canons {
+				if canon.len == 0 {
+					continue
+				}
+				file_end := if i + 1 < starts.len { starts[i + 1] } else { end_node }
+				canonicalize_imported_module_name(mut a, starts[i], file_end, canon)
+			}
+			// Imported code can be the first user of embed/channel/closure syntax.
+			// Seed those compiler-provided modules before the authoritative resolver
+			// scans the now-complete AST.
+			seed_implicit_imports(mut a, skip_closure_runtime)
+		}
+	}
+
 	mut cur_file := first_file
 	mut cur_module := 'main'
 	mut node_idx := 0
@@ -12767,21 +13106,53 @@ fn resolve_imports(mut a flat.FlatAst, mut p parser.Parser, prefs &pref.Preferen
 			}
 			scan_path := scan_node.value
 			scan_importing_file := if scan_file.len > 0 { scan_file } else { first_file }
-			scan_dir := resolve_project_or_pref_module_path_cached(prefs, scan_path,
-				scan_importing_file, project_root, mut module_path_cache)
-			scan_identity := import_module_identity_cached(prefs, scan_path, scan_importing_file,
-				project_root, scan_dir, mut module_path_cache, mut module_identity_cache)
-			if owner_path := identity_source_paths[scan_identity] {
-				owner_dir := identity_source_dirs[scan_identity] or { '' }
-				if owner_path != scan_path && owner_dir.len > 0 && scan_dir.len > 0
-					&& os.is_dir(owner_dir) && os.is_dir(scan_dir)
-					&& os.real_path(owner_dir) != os.real_path(scan_dir) {
-					forced_full_module_paths[owner_path] = true
-					forced_full_module_paths[scan_path] = true
+			mut collision_seeds := [
+				ImportCollisionSeed{
+					path:           scan_path
+					importing_file: scan_importing_file
+				},
+			]
+			if prefs.building_v {
+				// Compiler-tree modules declare their path suffix as the module name.
+				// A unique suffix cannot collide, so defer filesystem/identity work
+				// until a second distinct dotted path with that suffix appears.
+				short := scan_path.all_after_last('.')
+				if first := first_collision_seed_by_short[short] {
+					if first.path == scan_path {
+						continue
+					}
+					first_key := '${first.importing_file}\x00${first.path}'
+					if !resolved_collision_seeds[first_key] {
+						collision_seeds.prepend(first)
+					}
+				} else {
+					first_collision_seed_by_short[short] = collision_seeds[0]
+					continue
 				}
-			} else {
-				identity_source_paths[scan_identity] = scan_path
-				identity_source_dirs[scan_identity] = scan_dir
+			}
+			for seed in collision_seeds {
+				seed_key := '${seed.importing_file}\x00${seed.path}'
+				if resolved_collision_seeds[seed_key] {
+					continue
+				}
+				resolved_collision_seeds[seed_key] = true
+				scan_dir := resolve_project_or_pref_module_path_cached(prefs, seed.path,
+					seed.importing_file, project_root, mut module_path_cache)
+				scan_identity := import_module_identity_cached(prefs, seed.path,
+					seed.importing_file, project_root, scan_dir, mut module_path_cache, mut
+					module_identity_cache)
+				if owner_path := identity_source_paths[scan_identity] {
+					owner_dir := identity_source_dirs[scan_identity] or { '' }
+					if owner_path != seed.path && owner_dir.len > 0 && scan_dir.len > 0
+						&& os.is_dir(owner_dir) && os.is_dir(scan_dir)
+						&& os.real_path(owner_dir) != os.real_path(scan_dir) {
+						forced_full_module_paths[owner_path] = true
+						forced_full_module_paths[seed.path] = true
+					}
+				} else {
+					identity_source_paths[scan_identity] = seed.path
+					identity_source_dirs[scan_identity] = scan_dir
+				}
 			}
 		}
 		ri_collision_ns += time.sys_mono_now() - ri_t0

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -12793,20 +12793,39 @@ fn source_imports_fast(path string) []string {
 	mut i := 0
 	mut at_line_head := true
 	mut block_comment_depth := 0
-	mut quote := u8(0)
-	mut raw_string := false
+	// Context 0 is root code. Strings and their `${...}` code regions are
+	// pushed in alternating slots, so same-quoted strings inside interpolation
+	// cannot accidentally close the outer string.
+	mut context_kinds := [64]u8{}
+	mut context_quotes := [64]u8{}
+	mut context_raw := [64]bool{}
+	mut interpolation_brace_depths := [64]int{}
+	mut context_top := 0
 	for i < source.len {
-		if quote != 0 {
+		if context_kinds[context_top] == 1 {
+			quote := context_quotes[context_top]
+			raw_string := context_raw[context_top]
 			for i < source.len {
 				c := source[i]
 				if !raw_string && c == `\\` && i + 1 < source.len {
 					i += 2
 					continue
 				}
+				if !raw_string && quote != `\`` && c == `$` && i + 1 < source.len
+					&& source[i + 1] == `{` {
+					if context_top + 1 >= context_kinds.len {
+						return imports
+					}
+					context_top++
+					context_kinds[context_top] = 0
+					interpolation_brace_depths[context_top] = 1
+					at_line_head = false
+					i += 2
+					break
+				}
 				i++
 				if c == quote {
-					quote = 0
-					raw_string = false
+					context_top--
 					at_line_head = false
 					break
 				}
@@ -12858,25 +12877,51 @@ fn source_imports_fast(path string) []string {
 				break
 			}
 			if c == `r` && i + 1 < source.len && source[i + 1] in [`'`, `"`] {
-				quote = source[i + 1]
-				raw_string = true
+				if context_top + 1 >= context_kinds.len {
+					return imports
+				}
+				context_top++
+				context_kinds[context_top] = 1
+				context_quotes[context_top] = source[i + 1]
+				context_raw[context_top] = true
 				at_line_head = false
 				i += 2
 				break
 			}
 			if c in [`'`, `"`, `\``] {
-				quote = c
-				raw_string = false
+				if context_top + 1 >= context_kinds.len {
+					return imports
+				}
+				context_top++
+				context_kinds[context_top] = 1
+				context_quotes[context_top] = c
+				context_raw[context_top] = false
 				at_line_head = false
 				i++
 				break
+			}
+			if context_top > 0 && c == `{` {
+				interpolation_brace_depths[context_top]++
+				at_line_head = false
+				i++
+				continue
+			}
+			if context_top > 0 && c == `}` {
+				interpolation_brace_depths[context_top]--
+				at_line_head = false
+				i++
+				if interpolation_brace_depths[context_top] == 0 {
+					context_top--
+					break
+				}
+				continue
 			}
 			if at_line_head && c in [` `, `\t`, `\r`] {
 				i++
 				continue
 			}
-			if at_line_head && i + 7 <= source.len && source[i..i + 6] == 'import'
-				&& source[i + 6] in [` `, `\t`] {
+			if context_top == 0 && at_line_head && i + 7 <= source.len
+				&& source[i..i + 6] == 'import' && source[i + 6] in [` `, `\t`] {
 				i += 7
 				for i < source.len && source[i] in [` `, `\t`] {
 					i++

--- a/vlib/v3/driver/eager_import_scan_test.v
+++ b/vlib/v3/driver/eager_import_scan_test.v
@@ -1,0 +1,28 @@
+module driver
+
+import os
+
+fn test_source_imports_fast_tracks_nested_interpolation_strings() {
+	path := os.join_path(os.temp_dir(), 'v3_eager_import_scan_${os.getpid()}.v')
+	defer {
+		os.rm(path) or {}
+	}
+	dollar := '$'
+	source := 'module scan_fixture
+
+import real_module
+
+fn interpolate(value string) string {
+	return value
+}
+
+const text = \'before ${dollar}{interpolate(\'it\\\'s\')}
+import fake_module
+after\'
+'
+	expected_interpolation := dollar + "{interpolate('it\\'s')}"
+	assert source.contains(expected_interpolation)
+	os.write_file(path, source) or { panic(err) }
+
+	assert source_imports_fast(path) == ['real_module']
+}

--- a/vlib/v3/flat/flat.v
+++ b/vlib/v3/flat/flat.v
@@ -348,6 +348,15 @@ pub fn (mut a FlatAst) intern_text(value string) (TextId, string) {
 	return id, a.text_values.last()
 }
 
+// intern_texts_from replays the source AST's compact text table into a.
+// The source table is already ordered by first occurrence, so this preserves
+// deterministic text identities while avoiding a second walk over every node.
+pub fn (mut a FlatAst) intern_texts_from(source &FlatAst) {
+	for value in source.text_values {
+		a.intern_text(value)
+	}
+}
+
 // reserve_transform_texts keeps canonical text-table backing in the
 // compilation arena before a disposable transform scope starts.
 pub fn (mut a FlatAst) reserve_transform_texts(headroom int) {

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -204,7 +204,7 @@ fn (mut g FlatGen) preseed_type_first_seen(typ &types.Type) bool {
 	words := unsafe { &u64(voidptr(typ)) }
 	w0 := unsafe { words[0] }
 	w1 := unsafe { words[1] }
-	slot := int(((w0 >> 4) ^ w1) & 4095)
+	slot := int((w0 >> 4 ^ w1) & 4095)
 	if cache.seen[slot] && cache.w0[slot] == w0 && cache.w1[slot] == w1 {
 		return false
 	}
@@ -231,7 +231,12 @@ mut:
 	parallel_chunk_wrapper_defs    []ParallelChunkWrapperDefs
 	parallel_chunk_wrapper_capture int = -1
 	parallel_type_decls            string
+	parallel_global_decls          string
 	parallel_forward_decls         string
+	parallel_support_decls         string
+	parallel_enum_str_defs         string
+	parallel_interface_stubs       string
+	parallel_init_defs             string
 	parallel_const_code            string
 	parallel_support_ready         bool
 	test_files                     map[string]bool
@@ -526,6 +531,21 @@ mut:
 struct FixedArrayTypedefInfo {
 	arr    types.ArrayFixed
 	module string
+}
+
+struct FixedArrayTypeSeen {
+mut:
+	w0      [4096]u64
+	w1      [4096]u64
+	modules [4096]string
+	seen    [4096]bool
+}
+
+struct FixedArrayTextSeen {
+mut:
+	ptrs    [4096]voidptr
+	lens    [4096]int
+	modules [4096]string
 }
 
 struct CDirective {
@@ -2142,7 +2162,12 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	g.parallel_chunk_wrapper_defs = []ParallelChunkWrapperDefs{}
 	g.parallel_chunk_wrapper_capture = -1
 	g.parallel_type_decls = ''
+	g.parallel_global_decls = ''
 	g.parallel_forward_decls = ''
+	g.parallel_support_decls = ''
+	g.parallel_enum_str_defs = ''
+	g.parallel_interface_stubs = ''
+	g.parallel_init_defs = ''
 	g.parallel_const_code = ''
 	g.parallel_support_ready = false
 	g.coverage_files.clear()
@@ -2344,6 +2369,7 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	g.preintern_json_encode_strings()
 	g.timing_profile('  [ttime] cg collect_info    ${f64(cgsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 	cgsw.restart()
+	mut parallel_support_precomputed := false
 	if g.incremental_fn_names.len > 0 {
 		// Cached declarations already contain whole-program typedefs, wrappers,
 		// interface tables and shared-parameter metadata. A body-only update only
@@ -2359,10 +2385,28 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 		// Function-item selection can run during pre-dispatch preparation. Populate
 		// interface implementers first so that late-lowered dispatch targets are not
 		// pruned before their concrete method bodies are emitted.
-		g.collect_interface_impls()
-		g.precompute_required_interface_dispatch_methods()
-		g.timing_profile('  [ttime]   cg iface impls   ${f64(cgsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
-		cgsw.restart()
+		mut parallel_iface_scan := false
+		mut iface_worker := &FlatGen{}
+		mut iface_threads := []thread voidptr{cap: 1}
+		$if !v3_no_parallel ? {
+			parallel_iface_scan = g.scope_parallel_workers && !effective_no_parallel
+		}
+		if parallel_iface_scan {
+			$if !v3_no_parallel ? {
+				iface_worker = g.new_parallel_worker(4)
+				iface_worker.interface_boxed_types = map[string]bool{}
+				iface_worker.interface_boxed_types_done = false
+				iface_worker.iface_impls = map[string][]string{}
+				iface_worker.iface_type_ids = map[string]int{}
+				iface_worker.ierror_method_emit_names = map[string]bool{}
+				iface_threads << spawn interface_impl_scan_thread(voidptr(iface_worker))
+			}
+		} else {
+			g.collect_interface_impls()
+			g.precompute_required_interface_dispatch_methods()
+			g.timing_profile('  [ttime]   cg iface impls   ${f64(cgsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+			cgsw.restart()
+		}
 		// Struct field defaults are emitted from their declarations when an otherwise
 		// unrelated function initializes the struct. Parallel function pre-scanning only
 		// visits that function body, so seed literals from defaults before workers fork.
@@ -2380,6 +2424,15 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 		g.precompute_embedded_fields()
 		g.timing_profile('  [ttime]   cg preseeds      ${f64(cgsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 		cgsw.restart()
+		if parallel_iface_scan {
+			$if !v3_no_parallel ? {
+				_ = iface_threads[0].wait()
+				g.publish_interface_impl_scan(mut iface_worker)
+				g.precompute_required_interface_dispatch_methods()
+				g.timing_profile('  [ttime]   cg iface wait    ${f64(cgsw.elapsed().microseconds()) / 1000.0:7.2f} ms (overlapped)')
+				cgsw.restart()
+			}
+		}
 		parallel_prep_done := g.run_pre_dispatch_parallel(effective_no_parallel)
 		g.timing_profile('  [ttime]   cg predispatch   ${f64(cgsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 		cgsw.restart()
@@ -2391,17 +2444,11 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 				g.prepare_serial_fn_tables()
 			}
 		}
-		g.collect_shared_type_names()
-		g.precompute_sum_name_lookup()
-		if !g.skip_generics {
-			g.precompute_generic_method_candidate_index()
-		}
-		g.timing_profile('  [ttime]     wr shared+sum  ${f64(cgsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
-		cgsw.restart()
-		// Decide fixed-array return wrappers before generating function bodies, so
-		// signatures, returns and call sites all agree on the wrapped types.
-		g.populate_fixed_array_ret_wrappers()
-		g.timing_profile('  [ttime]     wr fixed ret   ${f64(cgsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+		// The fixed-array return scan only reads completed declaration tables. Run
+		// it beside the independent shared/sum indexes on the parallel self-host
+		// path; both must finish before any function body is generated.
+		parallel_support_precomputed =
+			g.prepare_shared_sum_and_fixed_array_ret_wrappers(parallel_prep_done)
 		cgsw.restart()
 		// Seed declaration-owned function-pointer types before parallel type
 		// generation starts. The pre-dispatch item walk adds body-local types
@@ -2421,8 +2468,10 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 		g.timing_profile('  [ttime]   cg wrappers      ${f64(cgsw.elapsed().microseconds()) / 1000.0:7.2f} ms (sig+extern)')
 		cgsw.restart()
 	}
-	g.precompute_ownership_recursive_drop_helpers()
-	g.precompute_fixed_array_map_key_types()
+	if !parallel_support_precomputed {
+		g.precompute_ownership_recursive_drop_helpers()
+		g.precompute_fixed_array_map_key_types()
+	}
 	defer_parallel_support := g.scope_parallel_workers && !effective_no_parallel
 		&& !g.program_body_only && g.incremental_fn_names.len == 0
 	mut const_code := if g.program_body_only || defer_parallel_support {
@@ -2505,26 +2554,16 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 		}
 		return result
 	}
-	mut known_output_len := g.sb.len + fn_code.len + const_code.len + g.parallel_type_decls.len
+	mut known_output_len := g.sb.len + fn_code.len + const_code.len + g.parallel_type_decls.len +
+		g.parallel_global_decls.len + g.parallel_support_decls.len + g.parallel_enum_str_defs.len +
+		g.parallel_interface_stubs.len + g.parallel_init_defs.len
 	for segment in g.fn_segs {
 		known_output_len += segment.len
 	}
 	// Leave headroom for the small body-dependent supplement emitted below.
 	g.sb.ensure_cap(known_output_len + 1_048_576) // 1 MiB
-	g.c99_feature_test_macros()
-	if g.profile_file.len > 0 {
-		g.writeln('#define _VPROFILE (1)')
-	}
-	g.thread_stack_size_definition()
-	g.emit_preinclude_directives()
-	g.emit_preserved_c_directives()
-	g.preamble()
-	if g.cache_split {
-		g.writeln('/* V3CACHE_NATIVE_DIRECTIVES_BEGIN */')
-	}
-	g.emit_c_directives(false)
-	if g.cache_split {
-		g.writeln('/* V3CACHE_NATIVE_DIRECTIVES_END */')
+	if g.parallel_type_decls.len == 0 {
+		g.gen_translation_unit_prefix()
 	}
 	g.write_type_declaration_block()
 	if g.cache_split {
@@ -2535,26 +2574,12 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 		g.writeln('/* V3CACHE_SOURCE_DIRECTIVES_END */')
 	}
 	g.c_extern_forward_decls()
-	if g.object_file_mode {
-		g.writeln('#if defined(__clang__)')
-		g.writeln('#pragma clang attribute push(__attribute__((internal_linkage)), apply_to = any(function, variable(is_global)))')
-		g.writeln('#endif')
-	}
-	g.builtin_abi_decls()
-	g.test_failure_helpers()
-	g.global_decls()
-	g.gen_profile_support()
-	g.emit_coverage_support()
-	// Objective-C implementation files commonly use complete V structs in their
-	// function signatures and bodies. Their framework imports are lifted above
-	// the headerless preamble, but the implementation itself belongs after the V
-	// type declarations.
-	if g.cache_split {
-		g.writeln('/* V3CACHE_LATE_DIRECTIVES_BEGIN */')
-	}
-	g.emit_c_directives(true)
-	if g.cache_split {
-		g.writeln('/* V3CACHE_LATE_DIRECTIVES_END */')
+	if g.parallel_global_decls.len > 0 {
+		g.sb.write_string(g.parallel_global_decls)
+		unsafe { g.parallel_global_decls.free() }
+		g.parallel_global_decls = ''
+	} else {
+		g.gen_global_declaration_block()
 	}
 	if g.parallel_forward_decls.len > 0 {
 		g.sb.write_string(g.parallel_forward_decls)
@@ -2563,25 +2588,35 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	} else {
 		g.forward_decls()
 	}
-	g.fixed_array_map_key_forward_decls()
-	g.fixed_array_map_key_definitions()
-	g.gen_ownership_recursive_drop_helpers()
-	g.release_scoped_fn_items()
-	g.cached_header_forward_decls()
-	g.interface_method_forward_decls()
-	g.shared_dup_fns()
-	if !g.skip_enum_autostr {
-		g.enum_str_forward_decls()
+	if g.parallel_support_decls.len > 0 {
+		g.sb.write_string(g.parallel_support_decls)
+		unsafe { g.parallel_support_decls.free() }
+		g.parallel_support_decls = ''
+	} else {
+		g.gen_pre_body_support_declarations()
 	}
+	g.release_scoped_fn_items()
 	g.callback_wrapper_decls()
 	g.spawn_wrapper_decls()
 	g.register_interface_strings()
 	g.string_literals()
 	if !g.cache_split {
-		g.interface_method_stubs()
+		if g.parallel_interface_stubs.len > 0 {
+			g.sb.write_string(g.parallel_interface_stubs)
+			unsafe { g.parallel_interface_stubs.free() }
+			g.parallel_interface_stubs = ''
+		} else {
+			g.interface_method_stubs()
+		}
 	}
 	if !g.skip_enum_autostr {
-		g.enum_str_defs()
+		if g.parallel_enum_str_defs.len > 0 {
+			g.sb.write_string(g.parallel_enum_str_defs)
+			unsafe { g.parallel_enum_str_defs.free() }
+			g.parallel_enum_str_defs = ''
+		} else {
+			g.enum_str_defs()
+		}
 	}
 	g.sb.write_string(const_code)
 	// The final builder now owns a copy of the const code.
@@ -2594,8 +2629,14 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 		// every edited translation unit.
 		g.writeln('/* V3CACHE_MODULE __v3_program_support */')
 	}
-	g.gen_vinit()
-	g.gen_vcleanup()
+	if g.parallel_init_defs.len > 0 {
+		g.sb.write_string(g.parallel_init_defs)
+		unsafe { g.parallel_init_defs.free() }
+		g.parallel_init_defs = ''
+	} else {
+		g.gen_vinit()
+		g.gen_vcleanup()
+	}
 	if g.cache_split {
 		g.interface_method_stubs()
 	}
@@ -2677,6 +2718,60 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	// Keep only the returned C string, not the builder's copied backing array.
 	unsafe { g.sb.free() }
 	return result
+}
+
+fn (mut g FlatGen) gen_pre_body_support_declarations() {
+	g.fixed_array_map_key_forward_decls()
+	g.fixed_array_map_key_definitions()
+	g.gen_ownership_recursive_drop_helpers()
+	g.cached_header_forward_decls()
+	g.interface_method_forward_decls()
+	g.shared_dup_fns()
+	if !g.skip_enum_autostr {
+		g.enum_str_forward_decls()
+	}
+}
+
+fn (mut g FlatGen) gen_translation_unit_prefix() {
+	g.c99_feature_test_macros()
+	if g.profile_file.len > 0 {
+		g.writeln('#define _VPROFILE (1)')
+	}
+	g.thread_stack_size_definition()
+	g.emit_preinclude_directives()
+	g.emit_preserved_c_directives()
+	g.preamble()
+	if g.cache_split {
+		g.writeln('/* V3CACHE_NATIVE_DIRECTIVES_BEGIN */')
+	}
+	g.emit_c_directives(false)
+	if g.cache_split {
+		g.writeln('/* V3CACHE_NATIVE_DIRECTIVES_END */')
+	}
+}
+
+fn (mut g FlatGen) gen_global_declaration_block() {
+	if g.object_file_mode {
+		g.writeln('#if defined(__clang__)')
+		g.writeln('#pragma clang attribute push(__attribute__((internal_linkage)), apply_to = any(function, variable(is_global)))')
+		g.writeln('#endif')
+	}
+	g.builtin_abi_decls()
+	g.test_failure_helpers()
+	g.global_decls()
+	g.gen_profile_support()
+	g.emit_coverage_support()
+	// Objective-C implementation files commonly use complete V structs in their
+	// function signatures and bodies. Their framework imports are lifted above
+	// the headerless preamble, but the implementation itself belongs after the V
+	// type declarations.
+	if g.cache_split {
+		g.writeln('/* V3CACHE_LATE_DIRECTIVES_BEGIN */')
+	}
+	g.emit_c_directives(true)
+	if g.cache_split {
+		g.writeln('/* V3CACHE_LATE_DIRECTIVES_END */')
+	}
 }
 
 // gen_type_declaration_block emits the declaration block whose inputs are
@@ -2994,6 +3089,18 @@ mut:
 	first_param_is_mut bool
 }
 
+struct FnSignatureRegistration {
+	module_key    string
+	short_name    string
+	aliases       [6]string
+	alias_count   u8
+	ptypes        []types.Type
+	shared_params []bool
+	is_variadic   bool
+	is_mut        bool
+	return_type   types.Type
+}
+
 fn (g &FlatGen) new_collect_gen_info_view() FlatGen {
 	mut view := *g
 	view.tc = g.clone_parallel_type_checker()
@@ -3140,6 +3247,9 @@ fn (mut g FlatGen) collect_gen_info() {
 	mut preferred_shared_fn_file_ranks := map[string]int{}
 	mut preferred_shared_fn_node_indexes := map[string]int{}
 	mut preferred_shared_fn_params := map[string][]bool{}
+	mut fn_signature_registrations := []FnSignatureRegistration{cap: 16_384}
+	defer_fn_signature_registrations := g.scope_parallel_workers && g.skip_generics
+		&& g.incremental_fn_names.len == 0 && par_cgen_prep_enabled()
 	top_level_nodes := g.top_level_nodes()
 	fn_preps := g.collect_gen_info_fn_preps(top_level_nodes)
 	for top_level_pos, node_idx in top_level_nodes {
@@ -3220,8 +3330,14 @@ fn (mut g FlatGen) collect_gen_info() {
 			if profile {
 				ci_ret_ns += time.sys_mono_now() - ci_r0
 			}
-			g.register_fn_decl_signature_type(node.value, full_name, ptypes, shared_params,
-				decl_is_variadic, first_param_is_mut, return_type)
+			if defer_fn_signature_registrations {
+				fn_signature_registrations << g.prepare_fn_signature_registration(node.value,
+					full_name, ptypes, shared_params, decl_is_variadic, first_param_is_mut,
+					return_type)
+			} else {
+				g.register_fn_decl_signature_type(node.value, full_name, ptypes, shared_params,
+					decl_is_variadic, first_param_is_mut, return_type)
+			}
 			if profile {
 				ci_reg_ns += time.sys_mono_now() - ci_r0
 			}
@@ -3404,6 +3520,9 @@ fn (mut g FlatGen) collect_gen_info() {
 			continue
 		}
 	}
+	if defer_fn_signature_registrations {
+		g.apply_fn_signature_registrations(fn_signature_registrations)
+	}
 	if g.has_shared_params {
 		for full_name, flags in preferred_shared_fn_params {
 			g.fn_decl_shared_params[full_name] = flags
@@ -3450,21 +3569,13 @@ fn (mut g FlatGen) collect_gen_info() {
 }
 
 @[direct_array_access]
-fn (mut g FlatGen) reserve_collect_gen_info_maps() {
-	mut fn_count := 0
-	mut struct_count := 0
-	mut global_count := 0
-	mut const_count := 0
-	mut enum_field_count := 0
-	mut interface_count := 0
-	mut import_count := 0
+fn (mut g FlatGen) scan_collect_gen_info_serial() CollectGenInfoScanCounts {
+	mut counts := CollectGenInfoScanCounts{}
 	incremental := g.incremental_fn_names.len > 0
 	g.ast_string_literals = []string{cap: 4096}
+	g.top_level_node_ids = []int{cap: 4096}
 	for node_idx, node in g.a.nodes {
 		if node.kind == .string_literal {
-			// The parallel pre-dispatch pass needs these in exact AST order.
-			// Retain the small value list while this unavoidable sizing scan is
-			// hot, avoiding another pass over the multi-million-node AST.
 			g.ast_string_literals << node.value
 		}
 		if node.kind in [.file, .module_decl, .fn_decl, .c_fn_decl, .struct_decl, .type_decl,
@@ -3474,30 +3585,55 @@ fn (mut g FlatGen) reserve_collect_gen_info_maps() {
 		match node.kind {
 			.fn_decl {
 				if !incremental || g.incremental_fn_names[node.value] {
-					fn_count++
+					counts.fn_count++
 				}
 			}
 			.struct_decl {
-				struct_count++
+				counts.struct_count++
 			}
 			.global_decl {
-				global_count += int(node.children_count)
+				counts.global_count += int(node.children_count)
 			}
 			.const_decl {
-				const_count += int(node.children_count)
+				counts.const_count += int(node.children_count)
 			}
 			.enum_decl {
-				enum_field_count += int(node.children_count)
+				counts.enum_field_count += int(node.children_count)
 			}
 			.interface_decl {
-				interface_count++
+				counts.interface_count++
 			}
 			.import_decl {
-				import_count++
+				counts.import_count++
 			}
 			else {}
 		}
 	}
+	return counts
+}
+
+struct CollectGenInfoScanCounts {
+mut:
+	fn_count         int
+	struct_count     int
+	global_count     int
+	const_count      int
+	enum_field_count int
+	interface_count  int
+	import_count     int
+}
+
+@[direct_array_access]
+fn (mut g FlatGen) reserve_collect_gen_info_maps() {
+	counts := g.scan_collect_gen_info()
+	mut fn_count := counts.fn_count
+	struct_count := counts.struct_count
+	global_count := counts.global_count
+	const_count := counts.const_count
+	enum_field_count := counts.enum_field_count
+	interface_count := counts.interface_count
+	import_count := counts.import_count
+	incremental := g.incremental_fn_names.len > 0
 	g.ast_string_literals_ready = true
 	if incremental && fn_count < g.incremental_fn_names.len {
 		fn_count = g.incremental_fn_names.len
@@ -9198,68 +9334,136 @@ fn (mut g FlatGen) register_fn_decl_signature(name string, full_name string, pty
 }
 
 fn (mut g FlatGen) register_fn_decl_signature_type(name string, full_name string, ptypes []types.Type, shared_params []bool, is_variadic bool, is_mut bool, rt types.Type) {
-	module_key := fn_decl_module_key(g.tc.cur_module, name)
-	g.fn_decl_param_types[module_key] = ptypes
-	g.fn_decl_ret_types[module_key] = rt
-	if is_variadic {
-		g.fn_decl_variadic[module_key] = true
-	}
-	short_name := c_short_name_view(name)
-	g.fn_decl_variadic_short_counts[short_name] = g.fn_decl_variadic_short_counts[short_name] + 1
+	registration := g.prepare_fn_signature_registration(name, full_name, ptypes, shared_params,
+		is_variadic, is_mut, rt)
+	g.apply_fn_signature_registration_group(registration, 0)
+	g.apply_fn_signature_registration_group(registration, 1)
+	g.apply_fn_signature_registration_group(registration, 2)
+	g.apply_fn_signature_registration_group(registration, 3)
+}
+
+fn (mut g FlatGen) prepare_fn_signature_registration(name string, full_name string, ptypes []types.Type, shared_params []bool, is_variadic bool, is_mut bool, rt types.Type) FnSignatureRegistration {
 	for flag in shared_params {
 		if flag {
 			g.has_shared_params = true
 			break
 		}
 	}
+	mut aliases := [6]string{}
+	mut alias_count := 0
 	if !g.dedup_fn_decl_aliases {
-		g.register_fn_decl_signature_alias(name, ptypes, shared_params, is_variadic, is_mut, rt)
+		aliases[alias_count] = name
+		alias_count++
 		cname := g.cname(name)
-		g.register_fn_decl_signature_alias(cname, ptypes, shared_params, is_variadic, is_mut, rt)
+		aliases[alias_count] = cname
+		alias_count++
 		if g.tc.cur_module.len > 0 && g.tc.cur_module != 'main' && g.tc.cur_module != 'builtin' {
 			dotted_name := '${g.tc.cur_module}.${name}'
-			g.register_fn_decl_signature_alias(dotted_name, ptypes, shared_params, is_variadic,
-				is_mut, rt)
+			aliases[alias_count] = dotted_name
+			alias_count++
 			cdotted_name := g.cname(dotted_name)
-			g.register_fn_decl_signature_alias(cdotted_name, ptypes, shared_params, is_variadic,
-				is_mut, rt)
+			aliases[alias_count] = cdotted_name
+			alias_count++
 		}
-		g.register_fn_decl_signature_alias(full_name, ptypes, shared_params, is_variadic, is_mut,
-			rt)
+		aliases[alias_count] = full_name
+		alias_count++
 		cfull_name := g.cname(full_name)
-		g.register_fn_decl_signature_alias(cfull_name, ptypes, shared_params, is_variadic, is_mut,
-			rt)
-		return
-	}
-	g.register_fn_decl_signature_alias(name, ptypes, shared_params, is_variadic, is_mut, rt)
-	cname := g.cname(name)
-	if cname != name {
-		g.register_fn_decl_signature_alias(cname, ptypes, shared_params, is_variadic, is_mut, rt)
-	}
-	mut dotted_name := ''
-	mut cdotted_name := ''
-	if g.tc.cur_module.len > 0 && g.tc.cur_module != 'main' && g.tc.cur_module != 'builtin' {
-		dotted_name = '${g.tc.cur_module}.${name}'
-		if dotted_name != name && dotted_name != cname {
-			g.register_fn_decl_signature_alias(dotted_name, ptypes, shared_params, is_variadic,
-				is_mut, rt)
+		aliases[alias_count] = cfull_name
+		alias_count++
+	} else {
+		aliases[alias_count] = name
+		alias_count++
+		cname := g.cname(name)
+		if cname != name {
+			aliases[alias_count] = cname
+			alias_count++
 		}
-		cdotted_name = g.cname(dotted_name)
-		if cdotted_name != name && cdotted_name != cname && cdotted_name != dotted_name {
-			g.register_fn_decl_signature_alias(cdotted_name, ptypes, shared_params, is_variadic,
-				is_mut, rt)
+		mut dotted_name := ''
+		mut cdotted_name := ''
+		if g.tc.cur_module.len > 0 && g.tc.cur_module != 'main' && g.tc.cur_module != 'builtin' {
+			dotted_name = '${g.tc.cur_module}.${name}'
+			if dotted_name != name && dotted_name != cname {
+				aliases[alias_count] = dotted_name
+				alias_count++
+			}
+			cdotted_name = g.cname(dotted_name)
+			if cdotted_name != name && cdotted_name != cname && cdotted_name != dotted_name {
+				aliases[alias_count] = cdotted_name
+				alias_count++
+			}
+		}
+		if full_name != name && full_name != cname && full_name != dotted_name
+			&& full_name != cdotted_name {
+			aliases[alias_count] = full_name
+			alias_count++
+		}
+		cfull_name := g.cname(full_name)
+		if cfull_name != name && cfull_name != cname && cfull_name != dotted_name
+			&& cfull_name != cdotted_name && cfull_name != full_name {
+			aliases[alias_count] = cfull_name
+			alias_count++
 		}
 	}
-	if full_name != name && full_name != cname && full_name != dotted_name
-		&& full_name != cdotted_name {
-		g.register_fn_decl_signature_alias(full_name, ptypes, shared_params, is_variadic, is_mut,
-			rt)
+	return FnSignatureRegistration{
+		module_key:    fn_decl_module_key(g.tc.cur_module, name)
+		short_name:    c_short_name_view(name)
+		aliases:       aliases
+		alias_count:   u8(alias_count)
+		ptypes:        ptypes
+		shared_params: shared_params
+		is_variadic:   is_variadic
+		is_mut:        is_mut
+		return_type:   rt
 	}
-	cfull_name := g.cname(full_name)
-	if cfull_name != name && cfull_name != cname && cfull_name != dotted_name
-		&& cfull_name != cdotted_name && cfull_name != full_name {
-		g.register_fn_decl_signature_alias(cfull_name, ptypes, shared_params, is_variadic, is_mut,
-			rt)
+}
+
+fn (mut g FlatGen) apply_fn_signature_registration_group(registration FnSignatureRegistration, group int) {
+	match group {
+		0 {
+			g.fn_decl_param_types[registration.module_key] = registration.ptypes
+			if registration.is_variadic {
+				g.fn_decl_variadic[registration.module_key] = true
+			}
+			g.fn_decl_variadic_short_counts[registration.short_name] =
+				g.fn_decl_variadic_short_counts[registration.short_name] + 1
+			for alias_idx in 0 .. registration.alias_count {
+				alias := registration.aliases[alias_idx]
+				if alias !in g.fn_decl_param_types {
+					g.fn_decl_param_types[alias] = registration.ptypes
+					if registration.is_variadic {
+						g.fn_decl_variadic[alias] = true
+					}
+				}
+			}
+		}
+		1 {
+			g.fn_decl_ret_types[registration.module_key] = registration.return_type
+			for alias_idx in 0 .. registration.alias_count {
+				alias := registration.aliases[alias_idx]
+				if alias !in g.fn_decl_ret_types {
+					g.fn_decl_ret_types[alias] = registration.return_type
+				}
+			}
+		}
+		2 {
+			if registration.shared_params.len > 0 {
+				for alias_idx in 0 .. registration.alias_count {
+					alias := registration.aliases[alias_idx]
+					if alias !in g.fn_decl_shared_params {
+						g.fn_decl_shared_params[alias] = registration.shared_params
+					}
+				}
+			}
+		}
+		3 {
+			if registration.is_mut {
+				for alias_idx in 0 .. registration.alias_count {
+					alias := registration.aliases[alias_idx]
+					g.fn_decl_mut_receivers[alias] = true
+				}
+			}
+		}
+		else {}
 	}
 }
 
@@ -18343,41 +18547,57 @@ fn (mut g FlatGen) collect_fixed_array_typedefs_needed() map[string]FixedArrayTy
 		return g.fixed_array_typedefs_needed
 	}
 	mut needed := map[string]FixedArrayTypedefInfo{}
+	mut type_seen := &FixedArrayTypeSeen{}
+	mut text_seen := &FixedArrayTextSeen{}
 	old_module := g.tc.cur_module
 	old_file := g.tc.cur_file
 	for name, ret_type in g.tc.fn_ret_types {
 		g.tc.cur_module = module_from_qualified_name(name)
-		g.collect_fixed_array_typedef(ret_type, g.tc.cur_module, mut needed)
+		if fixed_array_type_first_seen(ret_type, g.tc.cur_module, mut type_seen) {
+			g.collect_fixed_array_typedef(ret_type, g.tc.cur_module, mut needed)
+		}
 	}
 	for name, param_types in g.tc.fn_param_types {
 		g.tc.cur_module = module_from_qualified_name(name)
 		for param_type in param_types {
-			g.collect_fixed_array_typedef(param_type, g.tc.cur_module, mut needed)
+			if fixed_array_type_first_seen(param_type, g.tc.cur_module, mut type_seen) {
+				g.collect_fixed_array_typedef(param_type, g.tc.cur_module, mut needed)
+			}
 		}
 	}
 	for name, fields in g.tc.structs {
 		g.tc.cur_module = g.fixed_array_typedef_type_module(name, old_module)
 		for field in fields {
-			g.collect_fixed_array_typedef(field.typ, g.tc.cur_module, mut needed)
+			if fixed_array_type_first_seen(field.typ, g.tc.cur_module, mut type_seen) {
+				g.collect_fixed_array_typedef(field.typ, g.tc.cur_module, mut needed)
+			}
 		}
 	}
 	for name, fields in g.tc.interface_fields {
 		g.tc.cur_module = module_from_qualified_name(name)
 		for field in fields {
-			g.collect_fixed_array_typedef(field.typ, g.tc.cur_module, mut needed)
+			if fixed_array_type_first_seen(field.typ, g.tc.cur_module, mut type_seen) {
+				g.collect_fixed_array_typedef(field.typ, g.tc.cur_module, mut needed)
+			}
 		}
 	}
 	for name, typ in g.global_types {
 		g.tc.cur_module = g.global_modules[name] or { old_module }
-		g.collect_fixed_array_typedef(typ, g.tc.cur_module, mut needed)
+		if fixed_array_type_first_seen(typ, g.tc.cur_module, mut type_seen) {
+			g.collect_fixed_array_typedef(typ, g.tc.cur_module, mut needed)
+		}
 	}
 	for _, typ in g.tc.c_globals {
 		g.tc.cur_module = old_module
-		g.collect_fixed_array_typedef(typ, g.tc.cur_module, mut needed)
+		if fixed_array_type_first_seen(typ, g.tc.cur_module, mut type_seen) {
+			g.collect_fixed_array_typedef(typ, g.tc.cur_module, mut needed)
+		}
 	}
 	for name, typ in g.tc.const_types {
 		g.tc.cur_module = g.const_modules[name] or { old_module }
-		g.collect_fixed_array_typedef(typ, g.tc.cur_module, mut needed)
+		if fixed_array_type_first_seen(typ, g.tc.cur_module, mut type_seen) {
+			g.collect_fixed_array_typedef(typ, g.tc.cur_module, mut needed)
+		}
 	}
 	mut cur_file := old_file
 	mut cur_module := old_module
@@ -18400,12 +18620,16 @@ fn (mut g FlatGen) collect_fixed_array_typedefs_needed() map[string]FixedArrayTy
 		g.tc.cur_module = cur_module
 		// Struct-init node types use scratch text while fields are transformed; the
 		// declared struct metadata above is the authoritative fixed-array source.
-		if node.kind != .struct_init {
+		if node.kind != .struct_init && fixed_array_type_text_may_need_typedef(node.typ)
+			&& fixed_array_text_first_seen(node.typ, cur_module, mut text_seen) {
 			g.collect_fixed_array_typedef_text(node.typ, cur_module, mut needed)
 		}
 		match node.kind {
 			.array_init, .array_literal, .cast_expr, .sizeof_expr, .typeof_expr {
-				g.collect_fixed_array_typedef_text(node.value, cur_module, mut needed)
+				if fixed_array_type_text_may_need_typedef(node.value)
+					&& fixed_array_text_first_seen(node.value, cur_module, mut text_seen) {
+					g.collect_fixed_array_typedef_text(node.value, cur_module, mut needed)
+				}
 			}
 			else {}
 		}
@@ -18415,6 +18639,39 @@ fn (mut g FlatGen) collect_fixed_array_typedefs_needed() map[string]FixedArrayTy
 	g.fixed_array_typedefs_needed = needed.move()
 	g.fixed_array_typedefs_ready = true
 	return g.fixed_array_typedefs_needed
+}
+
+@[inline]
+fn fixed_array_type_first_seen(typ &types.Type, module_name string, mut seen FixedArrayTypeSeen) bool {
+	words := unsafe { &u64(voidptr(typ)) }
+	w0 := unsafe { words[0] }
+	w1 := unsafe { words[1] }
+	slot := int((w0 >> 4 ^ w1 ^ u64(module_name.len)) & 4095)
+	if seen.seen[slot] && seen.w0[slot] == w0 && seen.w1[slot] == w1
+		&& seen.modules[slot] == module_name {
+		return false
+	}
+	seen.w0[slot] = w0
+	seen.w1[slot] = w1
+	seen.modules[slot] = module_name
+	seen.seen[slot] = true
+	return true
+}
+
+@[inline]
+fn fixed_array_text_first_seen(text string, module_name string, mut seen FixedArrayTextSeen) bool {
+	if text.len == 0 {
+		return false
+	}
+	ptr := voidptr(text.str)
+	slot := int((u64(ptr) >> 4 ^ u64(text.len) ^ u64(module_name.len)) & 4095)
+	if seen.ptrs[slot] == ptr && seen.lens[slot] == text.len && seen.modules[slot] == module_name {
+		return false
+	}
+	seen.ptrs[slot] = ptr
+	seen.lens[slot] = text.len
+	seen.modules[slot] = module_name
+	return true
 }
 
 fn (mut g FlatGen) fixed_array_typedefs() {

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -125,92 +125,37 @@ fn (mut g FlatGen) ensure_fn_gen_items() []FlatFnGenItem {
 
 // collect_fn_gen_items updates collect fn gen items state for c.
 fn (mut g FlatGen) collect_fn_gen_items() []FlatFnGenItem {
-	mut candidates := []FlatFnGenCandidate{}
 	direct_array_access_fns := g.direct_array_access_fns()
 	ignore_overflow_fns := g.function_attribute_fns('ignore_overflow')
+	program_modules := g.cache_program_module_names()
+	// Defer cost/prep until after preferred-file and emission filtering. When
+	// the parallel path asks for prep, that walk also collects C-extern refs.
+	prep := g.want_parallel_prep
+	mut candidates := if prep && g.scope_parallel_workers && par_cgen_prep_enabled() {
+		g.collect_fn_gen_candidates_parallel(direct_array_access_fns, ignore_overflow_fns,
+			program_modules)
+	} else {
+		nodes := g.top_level_nodes()
+		g.collect_fn_gen_candidates_range(nodes, 0, nodes.len, '', '', direct_array_access_fns,
+			ignore_overflow_fns, program_modules)
+	}
 	mut preferred_fns := map[string]int{}
 	mut ranks := map[string]int{}
 	mut program_specializations := map[string]bool{}
 	mut preferred_program_specializations := map[string]bool{}
-	program_modules := g.cache_program_module_names()
-	mut cur_module := ''
-	mut cur_file := ''
-	// Defer cost/prep until after preferred-file and emission filtering. When
-	// the parallel path asks for prep, that walk also collects C-extern refs.
-	prep := g.want_parallel_prep
-	for i in g.top_level_nodes() {
-		node := g.a.nodes[i]
-		kind_id := node_kind_id(node)
-		if kind_id == 77 {
-			cur_file = node.value
-			g.tc.cur_file = cur_file
-			cur_module = ''
-			g.tc.cur_module = cur_module
-			continue
+	for candidate in candidates {
+		if candidate.item.is_program_specialization {
+			program_specializations[candidate.preferred_name] = true
 		}
-		if kind_id == 73 {
-			cur_module = node.value
-			g.tc.cur_file = cur_file
-			g.tc.cur_module = cur_module
-			continue
-		}
-
-		if kind_id == 61 {
-			is_specialization := g.a.specialized_fn_nodes[i]
-			item_module := g.a.specialized_fn_modules[i] or { cur_module }
-			item_file := g.a.specialized_fn_files[i] or {
-				if is_specialization {
-					g.tc.fn_type_files[node.value] or { cur_file }
-				} else {
-					cur_file
-				}
-			}
-			if g.program_body_only && !is_specialization && !g.cache_program_files[item_file]
-				&& item_module !in ['', 'main'] {
-				continue
-			}
-			if g.incremental_fn_names.len > 0 {
-				qname := if item_module in ['', 'main', 'builtin'] {
-					node.value
-				} else {
-					'${item_module}.${node.value}'
-				}
-				if !g.incremental_fn_names[qname] && !g.incremental_fn_names[node.value] {
-					continue
-				}
-			}
-			qfn := g.qualified_fn_name_in_module_c(item_module, node.value)
-			is_program_specialization := g.is_program_specialization_fn_node_with_qfn(node, i, qfn)
-			if !g.should_emit_fn_node_in_module_known(node, item_module, item_file, qfn,
-				is_program_specialization) {
-				continue
-			}
-			preferred_name := g.fn_c_name_in_module(item_module, node.value)
-			if is_program_specialization {
-				program_specializations[preferred_name] = true
-			}
-			rank := c_backend_fn_file_rank(item_file)
-			preferred_is_program_specialization := program_specializations[preferred_name]
-			if preferred_name !in preferred_fns || rank > ranks[preferred_name]
-				|| (rank == ranks[preferred_name] && preferred_is_program_specialization
-				&& !preferred_program_specializations[preferred_name]) {
-				preferred_fns[preferred_name] = i
-				ranks[preferred_name] = rank
-				preferred_program_specializations[preferred_name] = preferred_is_program_specialization
-			}
-			candidates << FlatFnGenCandidate{
-				preferred_name: preferred_name
-				item:           FlatFnGenItem{
-					node_id:             flat.NodeId(i)
-					file:                item_file
-					module:              item_module
-					c_name:              preferred_name
-					is_program:          g.cache_program_files[item_file]
-						|| program_modules[item_module]
-					direct_array_access: direct_array_access_fns.contains(i, node)
-					ignore_overflow:     ignore_overflow_fns.contains(i, node)
-				}
-			}
+		rank := c_backend_fn_file_rank(candidate.item.file)
+		preferred_is_program_specialization := program_specializations[candidate.preferred_name]
+		if candidate.preferred_name !in preferred_fns
+			|| rank > ranks[candidate.preferred_name]
+			|| (rank == ranks[candidate.preferred_name] && preferred_is_program_specialization
+			&& !preferred_program_specializations[candidate.preferred_name]) {
+			preferred_fns[candidate.preferred_name] = int(candidate.item.node_id)
+			ranks[candidate.preferred_name] = rank
+			preferred_program_specializations[candidate.preferred_name] = preferred_is_program_specialization
 		}
 	}
 	mut items := []FlatFnGenItem{cap: candidates.len}
@@ -271,6 +216,78 @@ fn (mut g FlatGen) collect_fn_gen_items() []FlatFnGenItem {
 	}
 	items.sort(a.c_name < b.c_name)
 	return items
+}
+
+fn (mut g FlatGen) collect_fn_gen_candidates_range(nodes []int, start int, end int, first_file string, first_module string, direct_array_access_fns DirectArrayAccessFns, ignore_overflow_fns DirectArrayAccessFns, program_modules map[string]bool) []FlatFnGenCandidate {
+	mut candidates := []FlatFnGenCandidate{cap: end - start}
+	mut cur_module := first_module
+	mut cur_file := first_file
+	for pos in start .. end {
+		i := nodes[pos]
+		node := g.a.nodes[i]
+		kind_id := node_kind_id(node)
+		if kind_id == 77 {
+			cur_file = node.value
+			g.tc.cur_file = cur_file
+			cur_module = ''
+			g.tc.cur_module = cur_module
+			continue
+		}
+		if kind_id == 73 {
+			cur_module = node.value
+			g.tc.cur_file = cur_file
+			g.tc.cur_module = cur_module
+			continue
+		}
+		if kind_id != 61 {
+			continue
+		}
+		is_specialization := g.a.specialized_fn_nodes[i]
+		item_module := g.a.specialized_fn_modules[i] or { cur_module }
+		item_file := g.a.specialized_fn_files[i] or {
+			if is_specialization {
+				g.tc.fn_type_files[node.value] or { cur_file }
+			} else {
+				cur_file
+			}
+		}
+		if g.program_body_only && !is_specialization && !g.cache_program_files[item_file]
+			&& item_module !in ['', 'main'] {
+			continue
+		}
+		if g.incremental_fn_names.len > 0 {
+			qname := if item_module in ['', 'main', 'builtin'] {
+				node.value
+			} else {
+				'${item_module}.${node.value}'
+			}
+			if !g.incremental_fn_names[qname] && !g.incremental_fn_names[node.value] {
+				continue
+			}
+		}
+		qfn := g.qualified_fn_name_in_module_c(item_module, node.value)
+		is_program_specialization := g.is_program_specialization_fn_node_with_qfn(node, i, qfn)
+		if !g.should_emit_fn_node_in_module_known(node, item_module, item_file, qfn,
+			is_program_specialization) {
+			continue
+		}
+		preferred_name := g.fn_c_name_in_module(item_module, node.value)
+		candidates << FlatFnGenCandidate{
+			preferred_name: preferred_name
+			item:           FlatFnGenItem{
+				node_id:                   flat.NodeId(i)
+				file:                      item_file
+				module:                    item_module
+				c_name:                    preferred_name
+				is_program_specialization: is_program_specialization
+				is_program:                g.cache_program_files[item_file]
+					|| program_modules[item_module]
+				direct_array_access:       direct_array_access_fns.contains(i, node)
+				ignore_overflow:           ignore_overflow_fns.contains(i, node)
+			}
+		}
+	}
+	return candidates
 }
 
 fn (g &FlatGen) cache_program_module_names() map[string]bool {

--- a/vlib/v3/gen/c/fn_parallel_d_v3_no_parallel.v
+++ b/vlib/v3/gen/c/fn_parallel_d_v3_no_parallel.v
@@ -1,6 +1,7 @@
 module c
 
 import v3.flat
+import time
 
 fn (mut g FlatGen) refine_fn_item_costs(_ bool, _ bool) {}
 
@@ -8,8 +9,40 @@ fn par_cgen_prep_enabled() bool {
 	return false
 }
 
+fn (mut g FlatGen) scan_collect_gen_info() CollectGenInfoScanCounts {
+	return g.scan_collect_gen_info_serial()
+}
+
+fn (mut g FlatGen) apply_fn_signature_registrations(registrations []FnSignatureRegistration) {
+	for group in 0 .. 4 {
+		for registration in registrations {
+			g.apply_fn_signature_registration_group(registration, group)
+		}
+	}
+}
+
+fn (mut g FlatGen) prepare_shared_sum_and_fixed_array_ret_wrappers(_ bool) bool {
+	mut sw := time.new_stopwatch()
+	g.collect_shared_type_names()
+	g.precompute_sum_name_lookup()
+	if !g.skip_generics {
+		g.precompute_generic_method_candidate_index()
+	}
+	g.timing_profile('  [ttime]     wr shared+sum  ${f64(sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+	sw.restart()
+	g.populate_fixed_array_ret_wrappers()
+	g.timing_profile('  [ttime]     wr fixed ret   ${f64(sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+	return false
+}
+
 fn (mut g FlatGen) collect_gen_info_fn_preps(_ []int) []CollectGenFnPrep {
 	return []CollectGenFnPrep{}
+}
+
+fn (mut g FlatGen) collect_fn_gen_candidates_parallel(direct_array_access_fns DirectArrayAccessFns, ignore_overflow_fns DirectArrayAccessFns, program_modules map[string]bool) []FlatFnGenCandidate {
+	nodes := g.top_level_nodes()
+	return g.collect_fn_gen_candidates_range(nodes, 0, nodes.len, '', '', direct_array_access_fns,
+		ignore_overflow_fns, program_modules)
 }
 
 // gen_fns_dispatch emits all functions serially when v3 is built with the

--- a/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
@@ -9,7 +9,8 @@ import v3.gen.c.naming
 import v3.types
 import v3.workers
 
-const max_flat_cgen_jobs = 17
+const max_flat_cgen_jobs = 18
+const max_flat_cgen_select_jobs = 15
 const min_flat_cgen_parallel_items = 128
 // Bound each worker's retained scratch while generating compiler-sized ASTs.
 const scoped_cgen_worker_batches = 32
@@ -55,6 +56,61 @@ $if !windows {
 		module_name  string
 	}
 
+	struct CollectGenInfoScanArgs {
+		g     voidptr // read-only &FlatGen master
+		start int
+		end   int
+	mut:
+		counts         CollectGenInfoScanCounts
+		top_level_pos  int
+		string_pos     int
+		top_levels_ptr voidptr
+		strings_ptr    voidptr
+	}
+
+	struct FnSignatureRegistrationArgs {
+		g                 voidptr
+		registrations_ptr voidptr
+		group             int
+	}
+
+	fn fn_signature_registration_thread(arg voidptr) voidptr {
+		a := unsafe { &FnSignatureRegistrationArgs(arg) }
+		mut g := unsafe { &FlatGen(a.g) }
+		registrations := unsafe { &[]FnSignatureRegistration(a.registrations_ptr) }
+		for registration in registrations {
+			g.apply_fn_signature_registration_group(registration, a.group)
+		}
+		return unsafe { nil }
+	}
+
+	struct FlatCgenSelectArgs {
+		g                       voidptr
+		nodes_ptr               voidptr
+		start                   int
+		end                     int
+		file                    string
+		module_name             string
+		direct_array_access_fns DirectArrayAccessFns
+		ignore_overflow_fns     DirectArrayAccessFns
+		program_modules         map[string]bool
+	mut:
+		candidates []FlatFnGenCandidate
+		scope      voidptr
+	}
+
+	fn flat_cgen_select_thread(arg voidptr) voidptr {
+		mut a := unsafe { &FlatCgenSelectArgs(arg) }
+		a.scope = cgen_worker_scope_begin(true)
+		master := unsafe { &FlatGen(a.g) }
+		mut view := master.new_collect_gen_info_view()
+		nodes := unsafe { &[]int(a.nodes_ptr) }
+		a.candidates = view.collect_fn_gen_candidates_range(*nodes, a.start, a.end, a.file,
+			a.module_name, a.direct_array_access_fns, a.ignore_overflow_fns, a.program_modules)
+		cgen_worker_scope_leave(a.scope)
+		return unsafe { nil }
+	}
+
 	fn collect_gen_info_fn_prep_thread(arg voidptr) voidptr {
 		a := unsafe { &CollectGenInfoFnPrepArgs(arg) }
 		master := unsafe { &FlatGen(a.g) }
@@ -78,6 +134,77 @@ $if !windows {
 				unsafe {
 					preps[pos] = view.compute_collect_gen_fn_prep(node, cur_module, cur_file)
 				}
+			}
+		}
+		return unsafe { nil }
+	}
+
+	@[direct_array_access]
+	fn collect_gen_info_scan_count_thread(arg voidptr) voidptr {
+		mut a := unsafe { &CollectGenInfoScanArgs(arg) }
+		g := unsafe { &FlatGen(a.g) }
+		incremental := g.incremental_fn_names.len > 0
+		for node_idx in a.start .. a.end {
+			node := g.a.nodes[node_idx]
+			if node.kind == .string_literal {
+				a.string_pos++
+			}
+			if node.kind in [.file, .module_decl, .fn_decl, .c_fn_decl, .struct_decl, .type_decl,
+				.global_decl, .const_decl, .enum_decl, .interface_decl, .import_decl, .directive] {
+				a.top_level_pos++
+			}
+			match node.kind {
+				.fn_decl {
+					if !incremental || g.incremental_fn_names[node.value] {
+						a.counts.fn_count++
+					}
+				}
+				.struct_decl {
+					a.counts.struct_count++
+				}
+				.global_decl {
+					a.counts.global_count += int(node.children_count)
+				}
+				.const_decl {
+					a.counts.const_count += int(node.children_count)
+				}
+				.enum_decl {
+					a.counts.enum_field_count += int(node.children_count)
+				}
+				.interface_decl {
+					a.counts.interface_count++
+				}
+				.import_decl {
+					a.counts.import_count++
+				}
+				else {}
+			}
+		}
+		return unsafe { nil }
+	}
+
+	@[direct_array_access]
+	fn collect_gen_info_scan_fill_thread(arg voidptr) voidptr {
+		mut a := unsafe { &CollectGenInfoScanArgs(arg) }
+		g := unsafe { &FlatGen(a.g) }
+		mut top_levels := unsafe { &[]int(a.top_levels_ptr) }
+		mut literals := unsafe { &[]string(a.strings_ptr) }
+		mut top_level_pos := a.top_level_pos
+		mut string_pos := a.string_pos
+		for node_idx in a.start .. a.end {
+			node := g.a.nodes[node_idx]
+			if node.kind == .string_literal {
+				unsafe {
+					literals[string_pos] = node.value
+				}
+				string_pos++
+			}
+			if node.kind in [.file, .module_decl, .fn_decl, .c_fn_decl, .struct_decl, .type_decl,
+				.global_decl, .const_decl, .enum_decl, .interface_decl, .import_decl, .directive] {
+				unsafe {
+					top_levels[top_level_pos] = node_idx
+				}
+				top_level_pos++
 			}
 		}
 		return unsafe { nil }
@@ -146,17 +273,61 @@ $if !windows {
 		w.parallel_const_code = w.precompute_consts()
 		w.timing_profile('  [ttime]       td consts    ${f64(tdpsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 		tdpsw.restart()
+		w.gen_translation_unit_prefix()
 		w.gen_type_declaration_block()
-		w.timing_profile('  [ttime]       td typedecl  ${f64(tdpsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+		w.timing_profile('  [ttime]       td prefix+type ${f64(tdpsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 		w.parallel_type_decls = w.sb.str()
 		unsafe { w.sb.free() }
 		w.sb = strings.new_builder(4096)
+		tdpsw.restart()
+		w.gen_global_declaration_block()
+		w.parallel_global_decls = w.sb.str()
+		unsafe { w.sb.free() }
+		w.sb = strings.new_builder(4096)
+		w.timing_profile('  [ttime]       td globals    ${f64(tdpsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 		tdpsw.restart()
 		w.forward_decls()
 		w.timing_profile('  [ttime]       td fwd decls ${f64(tdpsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 		w.parallel_forward_decls = w.sb.str()
 		unsafe { w.sb.free() }
 		w.sb = strings.new_builder(4096)
+		tdpsw.restart()
+		w.gen_pre_body_support_declarations()
+		w.parallel_support_decls = w.sb.str()
+		unsafe { w.sb.free() }
+		w.sb = strings.new_builder(4096)
+		w.timing_profile('  [ttime]       td support   ${f64(tdpsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+		tdpsw.restart()
+		if !w.skip_enum_autostr {
+			w.enum_str_defs()
+			w.parallel_enum_str_defs = w.sb.str()
+			unsafe { w.sb.free() }
+			w.sb = strings.new_builder(4096)
+		}
+		w.timing_profile('  [ttime]       td enum str  ${f64(tdpsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+		tdpsw.restart()
+		// Tail generation uses a full private worker. The master generator is also
+		// the declaration task, while body lanes concurrently read its frozen
+		// tables; running these emitters on the master would mutate shared name and
+		// type caches. The private worker keeps those writes isolated while its
+		// already-complete const/global metadata is read-only.
+		mut tail := w.new_parallel_worker(max_flat_cgen_jobs + 1)
+		if !w.cache_split {
+			tail.interface_method_stubs()
+			w.parallel_interface_stubs = tail.sb.str()
+			unsafe { tail.sb.free() }
+			tail.sb = strings.new_builder(4096)
+		}
+		w.timing_profile('  [ttime]       td iface defs ${f64(tdpsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+		tdpsw.restart()
+		if w.print_fn_names.len == 0 {
+			tail.gen_vinit()
+			tail.gen_vcleanup()
+			w.parallel_init_defs = tail.sb.str()
+			unsafe { tail.sb.free() }
+			tail.sb = strings.new_builder(0)
+		}
+		w.timing_profile('  [ttime]       td init defs  ${f64(tdpsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 		w.parallel_support_ready = true
 		return unsafe { nil }
 	}
@@ -208,6 +379,36 @@ $if !windows {
 		return unsafe { nil }
 	}
 
+	// interface_impl_scan_thread builds the structural-interface dispatch tables
+	// while the master pre-seeds independent declaration metadata.
+	fn interface_impl_scan_thread(arg voidptr) voidptr {
+		mut w := unsafe { &FlatGen(arg) }
+		scope := cgen_worker_scope_begin(w.scope_parallel_workers)
+		w.collect_interface_impls()
+		w.worker_scope = scope
+		cgen_worker_scope_leave(scope)
+		return arg
+	}
+
+	fn fixed_array_ret_wrappers_thread(arg voidptr) voidptr {
+		mut w := unsafe { &FlatGen(arg) }
+		scope := cgen_worker_scope_begin(w.scope_parallel_workers)
+		w.populate_fixed_array_ret_wrappers()
+		w.worker_scope = scope
+		cgen_worker_scope_leave(scope)
+		return unsafe { nil }
+	}
+
+	fn cgen_support_precompute_thread(arg voidptr) voidptr {
+		mut w := unsafe { &FlatGen(arg) }
+		scope := cgen_worker_scope_begin(w.scope_parallel_workers)
+		w.precompute_ownership_recursive_drop_helpers()
+		w.precompute_fixed_array_map_key_types()
+		w.worker_scope = scope
+		cgen_worker_scope_leave(scope)
+		return unsafe { nil }
+	}
+
 	fn pre_dispatch_master_thread(arg voidptr) voidptr {
 		mut g := unsafe { &FlatGen(arg) }
 		g.prepare_pre_dispatch_master()
@@ -243,6 +444,243 @@ $if !windows {
 		chunks := unsafe { &[][]FlatFnGenItem(a.work_chunks_ptr) }
 		w.gen_fn_chunks_scoped_dynamic(*chunks, a.chunk_queue, a.reserve_cost)
 		return unsafe { nil }
+	}
+}
+
+fn (mut g FlatGen) collect_fn_gen_candidates_parallel(direct_array_access_fns DirectArrayAccessFns, ignore_overflow_fns DirectArrayAccessFns, program_modules map[string]bool) []FlatFnGenCandidate {
+	$if windows {
+		nodes := g.top_level_nodes()
+		return g.collect_fn_gen_candidates_range(nodes, 0, nodes.len, '', '',
+			direct_array_access_fns, ignore_overflow_fns, program_modules)
+	} $else {
+		nodes := g.top_level_nodes()
+		if isnil(g.a.worker_pool) || g.a.worker_pool.size() == 0 || nodes.len < 2048 {
+			return g.collect_fn_gen_candidates_range(nodes, 0, nodes.len, '', '',
+				direct_array_access_fns, ignore_overflow_fns, program_modules)
+		}
+		mut n_jobs := g.a.worker_pool.size() + 1
+		if n_jobs > max_flat_cgen_select_jobs {
+			n_jobs = max_flat_cgen_select_jobs
+		}
+		if n_jobs > nodes.len {
+			n_jobs = nodes.len
+		}
+		mut files := []string{len: n_jobs}
+		mut modules := []string{len: n_jobs}
+		mut boundary := 0
+		mut cur_file := ''
+		mut cur_module := ''
+		for pos in 0 .. nodes.len {
+			for boundary < n_jobs && pos == nodes.len * boundary / n_jobs {
+				files[boundary] = cur_file
+				modules[boundary] = cur_module
+				boundary++
+			}
+			node := g.a.nodes[nodes[pos]]
+			if node.kind == .file {
+				cur_file = node.value
+				cur_module = ''
+			} else if node.kind == .module_decl {
+				cur_module = node.value
+			}
+		}
+		mut args := []FlatCgenSelectArgs{cap: n_jobs}
+		for job in 0 .. n_jobs {
+			args << FlatCgenSelectArgs{
+				g:                       voidptr(g)
+				nodes_ptr:               unsafe { voidptr(&nodes) }
+				start:                   nodes.len * job / n_jobs
+				end:                     nodes.len * (job + 1) / n_jobs
+				file:                    files[job]
+				module_name:             modules[job]
+				direct_array_access_fns: direct_array_access_fns
+				ignore_overflow_fns:     ignore_overflow_fns
+				program_modules:         program_modules
+				candidates:              []FlatFnGenCandidate{}
+				scope:                   unsafe { nil }
+			}
+		}
+		mut tasks := []workers.Task{cap: n_jobs}
+		for job in 0 .. n_jobs {
+			tasks << workers.Task{
+				run:        flat_cgen_select_thread
+				arg:        unsafe { voidptr(&args[job]) }
+				force_sync: job == 0
+			}
+		}
+		g.a.worker_pool.run(tasks)
+		mut candidates := []FlatFnGenCandidate{}
+		for arg in args {
+			candidates << arg.candidates
+			if arg.scope != unsafe { nil } {
+				g.parallel_worker_scopes << arg.scope
+			}
+		}
+		return candidates
+	}
+}
+
+// scan_collect_gen_info partitions the read-only whole-AST sizing scan across
+// the persistent pool. A count pass computes exact output offsets, then a fill
+// pass writes disjoint ranges while preserving AST order.
+fn (mut g FlatGen) scan_collect_gen_info() CollectGenInfoScanCounts {
+	$if windows {
+		return g.scan_collect_gen_info_serial()
+	} $else {
+		if isnil(g.a.worker_pool) || g.a.worker_pool.size() == 0 || g.a.nodes.len < 65_536
+			|| os.getenv('V3_NO_PAR_CGEN_INFO_SCAN') != '' {
+			return g.scan_collect_gen_info_serial()
+		}
+		mut n_jobs := g.a.worker_pool.size() + 1
+		if n_jobs > max_flat_cgen_jobs {
+			n_jobs = max_flat_cgen_jobs
+		}
+		mut args := []CollectGenInfoScanArgs{cap: n_jobs}
+		mut tasks := []workers.Task{cap: n_jobs}
+		for job in 0 .. n_jobs {
+			args << CollectGenInfoScanArgs{
+				g:     voidptr(g)
+				start: g.a.nodes.len * job / n_jobs
+				end:   g.a.nodes.len * (job + 1) / n_jobs
+			}
+		}
+		for job in 0 .. n_jobs {
+			tasks << workers.Task{
+				run:        collect_gen_info_scan_count_thread
+				arg:        unsafe { voidptr(&args[job]) }
+				force_sync: job == 0
+			}
+		}
+		g.a.worker_pool.run(tasks)
+		mut counts := CollectGenInfoScanCounts{}
+		mut top_level_count := 0
+		mut string_count := 0
+		for mut arg in args {
+			counts.fn_count += arg.counts.fn_count
+			counts.struct_count += arg.counts.struct_count
+			counts.global_count += arg.counts.global_count
+			counts.const_count += arg.counts.const_count
+			counts.enum_field_count += arg.counts.enum_field_count
+			counts.interface_count += arg.counts.interface_count
+			counts.import_count += arg.counts.import_count
+			counted_top_levels := arg.top_level_pos
+			counted_strings := arg.string_pos
+			arg.top_level_pos = top_level_count
+			arg.string_pos = string_count
+			top_level_count += counted_top_levels
+			string_count += counted_strings
+		}
+		g.top_level_node_ids = []int{len: top_level_count}
+		g.ast_string_literals = []string{len: string_count}
+		for mut arg in args {
+			arg.top_levels_ptr = unsafe { voidptr(&g.top_level_node_ids) }
+			arg.strings_ptr = unsafe { voidptr(&g.ast_string_literals) }
+		}
+		tasks.clear()
+		for job in 0 .. n_jobs {
+			tasks << workers.Task{
+				run:        collect_gen_info_scan_fill_thread
+				arg:        unsafe { voidptr(&args[job]) }
+				force_sync: job == 0
+			}
+		}
+		g.a.worker_pool.run(tasks)
+		return counts
+	}
+}
+
+fn (mut g FlatGen) apply_fn_signature_registrations(registrations []FnSignatureRegistration) {
+	$if windows {
+		for group in 0 .. 4 {
+			for registration in registrations {
+				g.apply_fn_signature_registration_group(registration, group)
+			}
+		}
+	} $else {
+		if registrations.len < 128 || isnil(g.a.worker_pool) || g.a.worker_pool.size() < 4
+			|| os.getenv('V3_NO_PAR_CGEN_SIG_REG') != '' {
+			for group in 0 .. 4 {
+				for registration in registrations {
+					g.apply_fn_signature_registration_group(registration, group)
+				}
+			}
+			return
+		}
+		mut args := []FnSignatureRegistrationArgs{cap: 4}
+		mut tasks := []workers.Task{cap: 4}
+		for group in 0 .. 4 {
+			args << FnSignatureRegistrationArgs{
+				g:                 voidptr(g)
+				registrations_ptr: unsafe { voidptr(&registrations) }
+				group:             group
+			}
+		}
+		for group in 0 .. 4 {
+			tasks << workers.Task{
+				run:        fn_signature_registration_thread
+				arg:        unsafe { voidptr(&args[group]) }
+				force_sync: group == 0
+			}
+		}
+		g.a.worker_pool.run(tasks)
+	}
+}
+
+fn (mut g FlatGen) prepare_shared_sum_and_fixed_array_ret_wrappers(parallel bool) bool {
+	mut sw := time.new_stopwatch()
+	$if windows {
+		g.collect_shared_type_names()
+		g.precompute_sum_name_lookup()
+		if !g.skip_generics {
+			g.precompute_generic_method_candidate_index()
+		}
+		g.timing_profile('  [ttime]     wr shared+sum  ${f64(sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+		sw.restart()
+		g.populate_fixed_array_ret_wrappers()
+		g.timing_profile('  [ttime]     wr fixed ret   ${f64(sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+		return false
+	} $else {
+		if !parallel || os.getenv('V3_NO_PAR_FIXED_RET') != '' {
+			g.collect_shared_type_names()
+			g.precompute_sum_name_lookup()
+			if !g.skip_generics {
+				g.precompute_generic_method_candidate_index()
+			}
+			g.timing_profile('  [ttime]     wr shared+sum  ${f64(sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+			sw.restart()
+			g.populate_fixed_array_ret_wrappers()
+			g.timing_profile('  [ttime]     wr fixed ret   ${f64(sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+			return false
+		}
+		mut worker := g.new_parallel_worker(3)
+		worker.fixed_array_ret_wrappers = map[string]bool{}
+		mut support_worker := g.new_parallel_worker(5)
+		support_worker.recursive_drop_helpers = map[string]string{}
+		support_worker.fixed_array_map_key_types = map[string]types.ArrayFixed{}
+		wrapper_thread := spawn fixed_array_ret_wrappers_thread(voidptr(worker))
+		support_thread := spawn cgen_support_precompute_thread(voidptr(support_worker))
+		g.collect_shared_type_names()
+		g.precompute_sum_name_lookup()
+		if !g.skip_generics {
+			g.precompute_generic_method_candidate_index()
+		}
+		g.timing_profile('  [ttime]     wr shared+sum  ${f64(sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+		sw.restart()
+		_ = wrapper_thread.wait()
+		_ = support_thread.wait()
+		g.fixed_array_ret_wrappers = worker.fixed_array_ret_wrappers.move()
+		g.recursive_drop_helpers = support_worker.recursive_drop_helpers.move()
+		g.fixed_array_map_key_types = support_worker.fixed_array_map_key_types.move()
+		if worker.worker_scope != unsafe { nil } {
+			g.parallel_worker_scopes << worker.worker_scope
+			worker.worker_scope = unsafe { nil }
+		}
+		if support_worker.worker_scope != unsafe { nil } {
+			g.parallel_worker_scopes << support_worker.worker_scope
+			support_worker.worker_scope = unsafe { nil }
+		}
+		g.timing_profile('  [ttime]     wr fixed ret   ${f64(sw.elapsed().microseconds()) / 1000.0:7.2f} ms (overlapped)')
+		return true
 	}
 }
 
@@ -870,14 +1308,6 @@ fn (mut g FlatGen) gen_fn_items_scoped_master_batches(items []FlatFnGenItem) {
 	}
 }
 
-fn clone_param_types_by_short(values map[string][]types.Type) map[string][]types.Type {
-	mut cloned := map[string][]types.Type{}
-	for name, params in values {
-		cloned[name.clone()] = types.clone_owned_types(params)
-	}
-	return cloned
-}
-
 fn clone_embedded_fields_by_type(values map[string][]types.StructField) map[string][]types.StructField {
 	mut cloned := map[string][]types.StructField{}
 	for name, fields in values {
@@ -900,17 +1330,16 @@ fn (mut g FlatGen) publish_fixed_storage_scan(mut fs_worker FlatGen) {
 	for opt_name, val_type in fs_worker.needed_optional_types {
 		g.needed_optional_types[opt_name.clone()] = val_type.clone()
 	}
-	if fs_worker.worker_scope == unsafe { nil } {
-		g.fixed_storage_consts = fs_worker.fixed_storage_consts.clone()
-		g.param_types_by_short = fs_worker.param_types_by_short.move()
-		g.concrete_optional_abi_fns = fs_worker.concrete_optional_abi_fns.move()
-		return
+	g.fixed_storage_consts = fs_worker.fixed_storage_consts.move()
+	g.param_types_by_short = fs_worker.param_types_by_short.move()
+	g.concrete_optional_abi_fns = fs_worker.concrete_optional_abi_fns.move()
+	if fs_worker.worker_scope != unsafe { nil } {
+		// These tables stay live through function emission. Retaining the small
+		// helper arena is cheaper than deep-cloning their type/string payloads and
+		// matches the optional/fixed-array support publishers below.
+		g.parallel_worker_scopes << fs_worker.worker_scope
+		fs_worker.worker_scope = unsafe { nil }
 	}
-	g.fixed_storage_consts = fs_worker.fixed_storage_consts.clone()
-	g.param_types_by_short = clone_param_types_by_short(fs_worker.param_types_by_short)
-	g.concrete_optional_abi_fns = fs_worker.concrete_optional_abi_fns.clone()
-	cgen_worker_scope_free(fs_worker.worker_scope)
-	fs_worker.worker_scope = unsafe { nil }
 }
 
 fn (mut g FlatGen) publish_fixed_array_support(mut worker FlatGen) {
@@ -929,6 +1358,18 @@ fn (mut g FlatGen) publish_optional_support(mut worker FlatGen) {
 	g.multi_return_type_names = worker.multi_return_type_names.move()
 	g.multi_return_types_ready = worker.multi_return_types_ready
 	g.decl_types_ready = worker.decl_types_ready
+	if worker.worker_scope != unsafe { nil } {
+		g.parallel_worker_scopes << worker.worker_scope
+		worker.worker_scope = unsafe { nil }
+	}
+}
+
+fn (mut g FlatGen) publish_interface_impl_scan(mut worker FlatGen) {
+	g.interface_boxed_types = worker.interface_boxed_types.move()
+	g.interface_boxed_types_done = worker.interface_boxed_types_done
+	g.iface_impls = worker.iface_impls.move()
+	g.iface_type_ids = worker.iface_type_ids.move()
+	g.ierror_method_emit_names = worker.ierror_method_emit_names.move()
 	if worker.worker_scope != unsafe { nil } {
 		g.parallel_worker_scopes << worker.worker_scope
 		worker.worker_scope = unsafe { nil }
@@ -1646,7 +2087,7 @@ fn preseed_type_words(typ &types.Type) (u64, u64, int) {
 	words := unsafe { &u64(voidptr(typ)) }
 	w0 := unsafe { words[0] }
 	w1 := unsafe { words[1] }
-	return w0, w1, int(((w0 >> 4) ^ w1) & 4095)
+	return w0, w1, int((w0 >> 4 ^ w1) & 4095)
 }
 
 // par_cgen_prep_enabled gates the parallel fused item prep, so a single binary

--- a/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
@@ -311,7 +311,7 @@ $if !windows {
 		// tables; running these emitters on the master would mutate shared name and
 		// type caches. The private worker keeps those writes isolated while its
 		// already-complete const/global metadata is read-only.
-		mut tail := w.new_parallel_worker(max_flat_cgen_jobs + 1)
+		mut tail := w.new_parallel_tail_worker(max_flat_cgen_jobs + 1)
 		if !w.cache_split {
 			tail.interface_method_stubs()
 			w.parallel_interface_stubs = tail.sb.str()
@@ -2207,6 +2207,15 @@ fn (mut g FlatGen) preseed_parallel_fn_ptr_type(typ types.Type) {
 // worker and, under -gc none, never freed.
 fn (g &FlatGen) new_parallel_worker(worker_id int) &FlatGen {
 	return g.new_parallel_worker_config(worker_id, false)
+}
+
+fn (g &FlatGen) new_parallel_tail_worker(worker_id int) &FlatGen {
+	mut w := g.new_parallel_worker(worker_id)
+	// gen_vinit pairs each initializer with its owning module. These arrays are
+	// declaration-task output and remain read-only while the tail is generated.
+	w.const_runtime_init_modules = g.const_runtime_init_modules.clone()
+	w.runtime_init_modules = g.runtime_init_modules.clone()
+	return w
 }
 
 // new_parallel_dispatch_worker selects the lightweight accumulator only when

--- a/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
@@ -2211,6 +2211,7 @@ fn (g &FlatGen) new_parallel_worker(worker_id int) &FlatGen {
 
 fn (g &FlatGen) new_parallel_tail_worker(worker_id int) &FlatGen {
 	mut w := g.new_parallel_worker(worker_id)
+	w.is_shared = g.is_shared
 	// gen_vinit pairs each initializer with its owning module. These arrays are
 	// declaration-task output and remain read-only while the tail is generated.
 	w.const_runtime_init_modules = g.const_runtime_init_modules.clone()

--- a/vlib/v3/gen/c/parallel_worker_test.v
+++ b/vlib/v3/gen/c/parallel_worker_test.v
@@ -54,6 +54,26 @@ fn test_scoped_parallel_worker_reuses_preselected_functions_and_c_extern_refs() 
 	assert w.c_extern_refs_ready
 }
 
+fn test_parallel_tail_worker_preserves_runtime_init_module_order() {
+	mut g, _ := parallel_worker_test_gen(true)
+	g.const_runtime_inits = ['\tmoda__runtime_const = moda__make_const();']
+	g.const_runtime_init_modules = ['moda']
+	g.runtime_inits = ['\tmoda__runtime_global = moda__make_global();']
+	g.runtime_init_modules = ['moda']
+	g.module_init_fns = ['moda__init']
+	g.module_init_fn_modules['moda__init'] = 'moda'
+
+	mut tail := g.new_parallel_tail_worker(max_flat_cgen_jobs + 1)
+	tail.gen_vinit()
+	output := tail.sb.str()
+	const_pos := output.index('moda__runtime_const = moda__make_const();') or { -1 }
+	global_pos := output.index('moda__runtime_global = moda__make_global();') or { -1 }
+	init_pos := output.index('moda__init();') or { -1 }
+	assert const_pos >= 0
+	assert global_pos > const_pos
+	assert init_pos > global_pos
+}
+
 fn test_parallel_checker_clone_preserves_sparse_transform_caches() {
 	g, mut tc := parallel_worker_test_gen(false)
 	tc.a.nodes = [flat.Node{

--- a/vlib/v3/gen/c/parallel_worker_test.v
+++ b/vlib/v3/gen/c/parallel_worker_test.v
@@ -74,6 +74,18 @@ fn test_parallel_tail_worker_preserves_runtime_init_module_order() {
 	assert init_pos > global_pos
 }
 
+fn test_parallel_tail_worker_preserves_shared_cleanup_mode() {
+	mut g, _ := parallel_worker_test_gen(true)
+	g.is_shared = true
+	assert g.module_cleanup_fns.len == 0
+
+	mut tail := g.new_parallel_tail_worker(max_flat_cgen_jobs + 1)
+	tail.gen_vcleanup()
+	output := tail.sb.str()
+	assert tail.is_shared
+	assert output.contains('void _vcleanup(void) {')
+}
+
 fn test_parallel_checker_clone_preserves_sparse_transform_caches() {
 	g, mut tc := parallel_worker_test_gen(false)
 	tc.a.nodes = [flat.Node{

--- a/vlib/v3/gen/c/types.v
+++ b/vlib/v3/gen/c/types.v
@@ -471,12 +471,16 @@ fn (mut g FlatGen) collect_declaration_signature_types() {
 				concrete_optional)
 		}
 	}
+	mut seen := &PreseedTypeSeen{}
 	for name, ret in g.tc.fn_ret_types {
 		// Generic template signatures keep unspecialized placeholder types
 		// (`!&Tls[T]`); their typedefs would reference C types that are never
 		// emitted. Specializations register concrete signatures under their
 		// own suffixed names.
 		if name in g.tc.fn_generic_params {
+			continue
+		}
+		if !cgen_type_first_seen(ret, mut seen) {
 			continue
 		}
 		g.collect_declaration_signature_type(ret)
@@ -486,33 +490,67 @@ fn (mut g FlatGen) collect_declaration_signature_types() {
 			continue
 		}
 		for param in params {
+			if !cgen_type_first_seen(param, mut seen) {
+				continue
+			}
 			g.collect_declaration_signature_type(param)
 		}
 	}
 	for _, fields in g.tc.structs {
 		for field in fields {
+			if !cgen_type_first_seen(field.typ, mut seen) {
+				continue
+			}
 			g.collect_declaration_signature_type(field.typ)
 		}
 	}
 	for _, fields in g.tc.interface_fields {
 		for field in fields {
+			if !cgen_type_first_seen(field.typ, mut seen) {
+				continue
+			}
 			g.collect_declaration_signature_type(field.typ)
 		}
 	}
 	for _, typ in g.tc.c_globals {
+		if !cgen_type_first_seen(typ, mut seen) {
+			continue
+		}
 		g.collect_declaration_signature_type(typ)
 	}
 	for _, typ in g.tc.const_types {
+		if !cgen_type_first_seen(typ, mut seen) {
+			continue
+		}
 		g.collect_declaration_signature_type(typ)
 	}
 	for idx, is_set in g.tc.expr_type_set {
 		if !is_set || idx >= g.tc.expr_type_values.len {
 			continue
 		}
-		g.collect_declaration_signature_type(g.tc.expr_type_values[idx])
+		typ := g.tc.expr_type_values[idx]
+		if !cgen_type_first_seen(typ, mut seen) {
+			continue
+		}
+		g.collect_declaration_signature_type(typ)
 	}
 	g.decl_types_ready = true
 	g.multi_return_types_ready = true
+}
+
+@[inline]
+fn cgen_type_first_seen(typ &types.Type, mut seen PreseedTypeSeen) bool {
+	words := unsafe { &u64(voidptr(typ)) }
+	w0 := unsafe { words[0] }
+	w1 := unsafe { words[1] }
+	slot := int((w0 >> 4 ^ w1) & 4095)
+	if seen.seen[slot] && seen.w0[slot] == w0 && seen.w1[slot] == w1 {
+		return false
+	}
+	seen.w0[slot] = w0
+	seen.w1[slot] = w1
+	seen.seen[slot] = true
+	return true
 }
 
 fn (mut g FlatGen) collect_declaration_signature_type(t types.Type) {

--- a/vlib/v3/markused/markused.v
+++ b/vlib/v3/markused/markused.v
@@ -186,14 +186,14 @@ fn mark_used_with_test_files(a &flat.FlatAst, tc &types.TypeChecker, test_files 
 	detect_reachable_generics := detect_generics && !trivial_literal_output
 	use_prepared := !isnil(prepared) && prepared.ready && !detect_reachable_generics && !cache_mode
 		&& !all_functions
-	// The runtime-helper detection scan only reads the AST and (forked) checker
-	// caches, so it runs on its own thread under the decl scan + precollect and
-	// its enqueue requests are replayed in scan order at the seeds step below.
+	// Runtime-helper detection reads completed semantic types. Start it here,
+	// after checking, and overlap it with the declaration scan + precollect.
+	// Its enqueue requests are replayed in scan order at the seeds step below.
 	mut rt_scan := &RtHelpersScanArgs{
 		a:  a
-		tc: if use_prepared { tc } else { tc.fork_for_parallel_transform(a) }
+		tc: tc.fork_for_parallel_transform(a)
 	}
-	rt_scan_parallel := !use_prepared && par_markused_seeds_enabled() && !trivial_literal_output
+	rt_scan_parallel := par_markused_seeds_enabled() && !trivial_literal_output
 	rt_scan.enabled = rt_scan_parallel
 	mut rt_scan_threads := []thread{cap: 1}
 	if rt_scan_parallel {
@@ -625,18 +625,7 @@ fn mark_used_with_test_files(a &flat.FlatAst, tc &types.TypeChecker, test_files 
 		mu_sw.restart()
 	}
 	has_entry_main := markused_has_entry_main_indexed(a, tc)
-	if use_prepared {
-		for name in prepared.runtime_helper_roots {
-			enqueue(name, mut used, mut queue)
-		}
-	} else if rt_scan_parallel {
-		rt_scan_threads[0].wait()
-		for name in rt_scan.queue {
-			// Clone into the master arena: the scan scope is freed right below.
-			enqueue(name.clone(), mut used, mut queue)
-		}
-		markused_worker_scope_free(rt_scan.scope)
-	} else if !trivial_literal_output {
+	if !rt_scan_parallel && !trivial_literal_output {
 		enqueue_detected_runtime_helpers(a, tc, mut used, mut queue)
 	}
 	needs_closure_runtime := if use_prepared && prepared.needs_closure_runtime {
@@ -700,7 +689,21 @@ fn mark_used_with_test_files(a &flat.FlatAst, tc &types.TypeChecker, test_files 
 		mu_sw.restart()
 	}
 	mut qi := 0
-	for qi < queue.len {
+	mut runtime_helpers_pending := rt_scan_parallel
+	for qi < queue.len || runtime_helpers_pending {
+		if qi >= queue.len {
+			// Runtime-helper scanning starts only after semantic checking. Let the
+			// ordinary reachability roots keep the caller busy while it runs, then
+			// append its roots before allowing the fixed-point queue to finish.
+			rt_scan_threads[0].wait()
+			for helper_name in rt_scan.queue {
+				// Clone into the master arena: the scan scope is freed right below.
+				enqueue(helper_name.clone(), mut used, mut queue)
+			}
+			markused_worker_scope_free(rt_scan.scope)
+			runtime_helpers_pending = false
+			continue
+		}
 		name := queue[qi]
 		qi++
 		prev_len := queue.len
@@ -1737,7 +1740,6 @@ mut:
 	import_contexts       []map[string]string
 	marked_roots          []string
 	c_interface_roots     []string
-	runtime_helper_roots  []string
 	auto_roots            []string
 	needs_closure_runtime bool
 	scope                 voidptr
@@ -1920,10 +1922,6 @@ fn build_prepared_markused_declarations(a &flat.FlatAst, tc &types.TypeChecker) 
 			}
 		}
 	}
-	runtime_tc := tc.fork_for_parallel_transform(a)
-	mut runtime_used := map[string]bool{}
-	enqueue_detected_runtime_helpers(a, runtime_tc, mut runtime_used, mut
-		result.runtime_helper_roots)
 	reachable_modules := markused_reachable_modules(a, tc)
 	mut auto_used := map[string]bool{}
 	enqueue_auto_roots(a, result.fn_decls, reachable_modules, mut auto_used, mut result.auto_roots)

--- a/vlib/v3/markused/markused.v
+++ b/vlib/v3/markused/markused.v
@@ -13,7 +13,7 @@ const min_eager_markused_bodies = 4096
 // mark_used updates mark used state for markused.
 pub fn mark_used(a &flat.FlatAst, tc &types.TypeChecker) map[string]bool {
 	used, _ := mark_used_with_test_files(a, tc, map[string]bool{}, map[string]bool{}, false, true,
-		false, true)
+		false, true, unsafe { nil })
 	return used
 }
 
@@ -26,21 +26,29 @@ pub fn mark_used_for_tests(a &flat.FlatAst, tc &types.TypeChecker, test_files []
 // function, struct, or sum type and therefore requires monomorphization.
 pub fn mark_used_with_generic_usage(a &flat.FlatAst, tc &types.TypeChecker) (map[string]bool, bool) {
 	return mark_used_with_test_files(a, tc, map[string]bool{}, map[string]bool{}, false, true,
-		false, true)
+		false, true, unsafe { nil })
 }
 
 // mark_used_with_generic_usage_full_runtime disables the literal-output shortcut so
 // compatibility fixtures retain helpers referenced by the complete builtin runtime.
 pub fn mark_used_with_generic_usage_full_runtime(a &flat.FlatAst, tc &types.TypeChecker) (map[string]bool, bool) {
 	return mark_used_with_test_files(a, tc, map[string]bool{}, map[string]bool{}, false, true,
-		false, false)
+		false, false, unsafe { nil })
 }
 
 // mark_used_without_generic_detection is the self-host variant for inputs whose caller
 // already guarantees that monomorphization is unnecessary.
 pub fn mark_used_without_generic_detection(a &flat.FlatAst, tc &types.TypeChecker) map[string]bool {
 	used, _ := mark_used_with_test_files(a, tc, map[string]bool{}, map[string]bool{}, false, false,
-		false, true)
+		false, true, unsafe { nil })
+	return used
+}
+
+// mark_used_without_generic_detection_prepared consumes declaration indexes
+// built concurrently with checking for the no-generic self-host path.
+pub fn mark_used_without_generic_detection_prepared(a &flat.FlatAst, tc &types.TypeChecker, mut prepared PreparedMarkusedDecls) map[string]bool {
+	used, _ := mark_used_with_test_files(a, tc, map[string]bool{}, map[string]bool{}, false, false,
+		false, true, prepared)
 	return used
 }
 
@@ -51,7 +59,8 @@ pub fn mark_used_for_tests_with_generic_usage(a &flat.FlatAst, tc &types.TypeChe
 	for file in test_files {
 		file_map[file] = true
 	}
-	return mark_used_with_test_files(a, tc, file_map, map[string]bool{}, false, true, false, true)
+	return mark_used_with_test_files(a, tc, file_map, map[string]bool{}, false, true, false, true,
+		unsafe { nil })
 }
 
 // mark_all_used_with_generic_usage roots every concrete function while preserving
@@ -61,7 +70,8 @@ pub fn mark_all_used_with_generic_usage(a &flat.FlatAst, tc &types.TypeChecker, 
 	for file in test_files {
 		file_map[file] = true
 	}
-	return mark_used_with_test_files(a, tc, file_map, map[string]bool{}, false, true, true, true)
+	return mark_used_with_test_files(a, tc, file_map, map[string]bool{}, false, true, true, true,
+		unsafe { nil })
 }
 
 // mark_used_for_cache roots every concrete function in modules being built for the object cache.
@@ -77,7 +87,8 @@ pub fn mark_used_for_cache_with_generic_usage(a &flat.FlatAst, tc &types.TypeChe
 	for file in test_files {
 		file_map[file] = true
 	}
-	return mark_used_with_test_files(a, tc, file_map, source_modules, true, true, false, true)
+	return mark_used_with_test_files(a, tc, file_map, source_modules, true, true, false, true,
+		unsafe { nil })
 }
 
 // mark_used_for_cache_without_generic_detection is the self-host cache variant for inputs
@@ -87,7 +98,8 @@ pub fn mark_used_for_cache_without_generic_detection(a &flat.FlatAst, tc &types.
 	for file in test_files {
 		file_map[file] = true
 	}
-	used, _ := mark_used_with_test_files(a, tc, file_map, source_modules, true, false, false, true)
+	used, _ := mark_used_with_test_files(a, tc, file_map, source_modules, true, false, false, true,
+		unsafe { nil })
 	return used
 }
 
@@ -164,7 +176,7 @@ pub fn reachable_const_exprs(a &flat.FlatAst, tc &types.TypeChecker, root_ids []
 }
 
 @[direct_array_access]
-fn mark_used_with_test_files(a &flat.FlatAst, tc &types.TypeChecker, test_files map[string]bool, cache_modules map[string]bool, cache_mode bool, detect_generics bool, all_functions bool, allow_trivial_literal_output bool) (map[string]bool, bool) {
+fn mark_used_with_test_files(a &flat.FlatAst, tc &types.TypeChecker, test_files map[string]bool, cache_modules map[string]bool, cache_mode bool, detect_generics bool, all_functions bool, allow_trivial_literal_output bool, prepared &PreparedMarkusedDecls) (map[string]bool, bool) {
 	mut mu_sw := time.new_stopwatch()
 	trivial_literal_output := allow_trivial_literal_output && !cache_mode && cache_modules.len == 0
 		&& test_files.len == 0 && is_trivial_literal_output_program(a, tc.diagnostic_files)
@@ -172,16 +184,21 @@ fn mark_used_with_test_files(a &flat.FlatAst, tc &types.TypeChecker, test_files 
 	// can instantiate a generic. Skip generic indexes and per-node generic checks,
 	// just as the known non-generic self-host path does.
 	detect_reachable_generics := detect_generics && !trivial_literal_output
+	use_prepared := !isnil(prepared) && prepared.ready && !detect_reachable_generics && !cache_mode
+		&& !all_functions
 	// The runtime-helper detection scan only reads the AST and (forked) checker
 	// caches, so it runs on its own thread under the decl scan + precollect and
 	// its enqueue requests are replayed in scan order at the seeds step below.
 	mut rt_scan := &RtHelpersScanArgs{
 		a:  a
-		tc: tc.fork_for_parallel_transform(a)
+		tc: if use_prepared { tc } else { tc.fork_for_parallel_transform(a) }
 	}
-	rt_scan_parallel := par_markused_seeds_enabled() && !trivial_literal_output
+	rt_scan_parallel := !use_prepared && par_markused_seeds_enabled() && !trivial_literal_output
 	rt_scan.enabled = rt_scan_parallel
-	rt_scan_thread := spawn markused_rt_helpers_thread(mut rt_scan)
+	mut rt_scan_threads := []thread{cap: 1}
+	if rt_scan_parallel {
+		rt_scan_threads << spawn markused_rt_helpers_thread(mut rt_scan)
+	}
 	mut cur_module := ''
 	mut cur_file := ''
 	mut import_contexts := []map[string]string{cap: 256}
@@ -196,12 +213,14 @@ fn mark_used_with_test_files(a &flat.FlatAst, tc &types.TypeChecker, test_files 
 	mut const_name_suffixes := map[string]bool{}
 	// The checker already knows the declaration cardinalities. Reserve once here
 	// instead of repeatedly growing the alias-heavy reachability indexes.
-	fn_decls.reserve(u32(tc.fn_ret_types.len))
-	fn_decl_lists.reserve(u32(tc.fn_ret_types.len))
-	struct_decls.reserve(u32(tc.structs.len * 2))
-	const_decls.reserve(u32(tc.const_types.len))
-	fn_name_suffixes.reserve(u32(tc.fn_ret_types.len))
-	const_name_suffixes.reserve(u32(tc.const_types.len))
+	if !use_prepared {
+		fn_decls.reserve(u32(tc.fn_ret_types.len))
+		fn_decl_lists.reserve(u32(tc.fn_ret_types.len))
+		struct_decls.reserve(u32(tc.structs.len * 2))
+		const_decls.reserve(u32(tc.const_types.len))
+		fn_name_suffixes.reserve(u32(tc.fn_ret_types.len))
+		const_name_suffixes.reserve(u32(tc.const_types.len))
+	}
 	mut generic_type_bases := map[string]bool{}
 	if detect_reachable_generics {
 		for node in a.nodes {
@@ -213,7 +232,9 @@ fn mark_used_with_test_files(a &flat.FlatAst, tc &types.TypeChecker, test_files 
 
 	// Reverse index: short name (after last '.') -> list of full qualified names
 	mut suffix_map := map[string][]string{}
-	suffix_map.reserve(u32(tc.fn_ret_types.len / 2))
+	if !use_prepared {
+		suffix_map.reserve(u32(tc.fn_ret_types.len / 2))
+	}
 
 	// Every fn_decl/c_fn_decl node (and its module), in AST order: the worklist
 	// for the parallel body-call precollection below.
@@ -224,160 +245,178 @@ fn mark_used_with_test_files(a &flat.FlatAst, tc &types.TypeChecker, test_files 
 	mut cache_roots := []string{}
 	mut c_interface_roots := []string{}
 	mut marked_roots := []string{}
+	if use_prepared {
+		// These indexes remain owned by the retained helper arena until the
+		// prepared wrapper clones the result and releases that arena.
+		unsafe {
+			fn_decls = prepared.fn_decls
+			fn_decl_lists = prepared.fn_decl_lists
+			struct_decls = prepared.struct_decls
+			const_decls = prepared.const_decls
+			fn_name_suffixes = prepared.fn_name_suffixes
+			const_name_suffixes = prepared.const_name_suffixes
+			suffix_map = prepared.suffix_map
+			import_contexts = prepared.import_contexts
+			marked_roots = prepared.marked_roots
+			c_interface_roots = prepared.c_interface_roots
+		}
+	}
 
 	mut fn_count := 0
 	mut fn_with_dot := 0
 	mut contains2_total := 0
-	for node_idx in tc.top_level_idx {
-		node := a.nodes[node_idx]
-		if node.kind == .file {
-			cur_file = node.value
-			cur_module = ''
-			import_contexts << markused_top_level_file_imports(a, node)
-			cur_import_context = import_contexts.len - 1
-			import_context_by_file[cur_file] = cur_import_context
-			continue
-		}
-		if node.kind == .module_decl {
-			cur_module = node.value
-			continue
-		}
-		if node.kind == .import_decl {
-			if cur_import_context >= 0 && cur_import_context < import_contexts.len {
-				import_contexts[cur_import_context][node.typ] = node.value
+	if !use_prepared {
+		for node_idx in tc.top_level_idx {
+			node := a.nodes[node_idx]
+			if node.kind == .file {
+				cur_file = node.value
+				cur_module = ''
+				import_contexts << markused_top_level_file_imports(a, node)
+				cur_import_context = import_contexts.len - 1
+				import_context_by_file[cur_file] = cur_import_context
+				continue
 			}
-			continue
-		}
-		decl_file := if source_file := a.source_files[node.pos.id] {
-			source_file.name
-		} else {
-			cur_file
-		}
-		decl_module := tc.file_modules[decl_file] or { cur_module }
-		decl_import_context := import_context_by_file[decl_file] or { cur_import_context }
-		if node.kind == .struct_decl {
-			full_name := qualify_fn(decl_module, node.value)
-			info := StructDeclInfo{
-				node_id:        flat.NodeId(node_idx)
-				module:         decl_module
-				import_context: decl_import_context
+			if node.kind == .module_decl {
+				cur_module = node.value
+				continue
 			}
-			struct_decls[full_name] = info
-			if node.value !in struct_decls {
-				struct_decls[node.value] = info
-			}
-			continue
-		}
-		if node.kind == .const_decl || node.kind == .global_decl {
-			for i in 0 .. node.children_count {
-				field_id := a.child(&node, i)
-				field := a.node(field_id)
-				if field.kind != .const_field || field.children_count == 0 {
-					continue
+			if node.kind == .import_decl {
+				if cur_import_context >= 0 && cur_import_context < import_contexts.len {
+					import_contexts[cur_import_context][node.typ] = node.value
 				}
-				info := ConstDeclInfo{
-					expr_id:        a.child(field, 0)
+				continue
+			}
+			decl_file := if source_file := a.source_files[node.pos.id] {
+				source_file.name
+			} else {
+				cur_file
+			}
+			decl_module := tc.file_modules[decl_file] or { cur_module }
+			decl_import_context := import_context_by_file[decl_file] or { cur_import_context }
+			if node.kind == .struct_decl {
+				full_name := qualify_fn(decl_module, node.value)
+				info := StructDeclInfo{
+					node_id:        flat.NodeId(node_idx)
 					module:         decl_module
 					import_context: decl_import_context
 				}
-				const_decls[field.value] = info
-				add_candidate_suffix(mut const_name_suffixes, field.value)
-				full_name := qualify_fn(decl_module, field.value)
-				if full_name != field.value {
-					const_decls[full_name] = info
-					add_candidate_suffix(mut const_name_suffixes, full_name)
+				struct_decls[full_name] = info
+				if node.value !in struct_decls {
+					struct_decls[node.value] = info
 				}
+				continue
 			}
-			continue
-		}
-		if node.kind == .fn_decl || node.kind == .c_fn_decl {
-			decl_qname := qualify_fn(decl_module, node.value)
-			fn_decl_file := tc.fn_type_files[decl_qname] or { decl_file }
-			fn_decl_module := tc.fn_type_modules[decl_qname] or { decl_module }
-			fn_decl_import_context := import_context_by_file[fn_decl_file] or {
-				decl_import_context
-			}
-			if collect_body_metadata {
-				body_ids << node_idx
-				body_modules << fn_decl_module
-				body_import_contexts << fn_decl_import_context
-			}
-			has_dot := node.value.index_u8(`.`) >= 0
-			can_suffix_match := !markused_fn_decl_is_generic_template(node, a)
-			if trace_markused {
-				fn_count++
-				if has_dot {
-					fn_with_dot++
-					if fn_with_dot <= 5 {
-						eprintln('  fn with dot: "${node.value}"')
+			if node.kind == .const_decl || node.kind == .global_decl {
+				for i in 0 .. node.children_count {
+					field_id := a.child(&node, i)
+					field := a.node(field_id)
+					if field.kind != .const_field || field.children_count == 0 {
+						continue
+					}
+					info := ConstDeclInfo{
+						expr_id:        a.child(field, 0)
+						module:         decl_module
+						import_context: decl_import_context
+					}
+					const_decls[field.value] = info
+					add_candidate_suffix(mut const_name_suffixes, field.value)
+					full_name := qualify_fn(decl_module, field.value)
+					if full_name != field.value {
+						const_decls[full_name] = info
+						add_candidate_suffix(mut const_name_suffixes, full_name)
 					}
 				}
+				continue
 			}
-			info := FnDeclInfo{
-				node_id:        flat.NodeId(node_idx)
-				module:         fn_decl_module
-				import_context: fn_decl_import_context
-			}
-			add_fn_decl_info(mut fn_decls, mut fn_decl_lists, node.value, info)
-			if can_suffix_match {
-				add_candidate_suffix(mut fn_name_suffixes, node.value)
-			}
-			lowered_name := markused_c_name(node.value)
-			if lowered_name != node.value {
-				add_fn_decl_info(mut fn_decls, mut fn_decl_lists, lowered_name, info)
-				if can_suffix_match {
-					add_candidate_suffix(mut fn_name_suffixes, lowered_name)
+			if node.kind == .fn_decl || node.kind == .c_fn_decl {
+				decl_qname := qualify_fn(decl_module, node.value)
+				fn_decl_file := tc.fn_type_files[decl_qname] or { decl_file }
+				fn_decl_module := tc.fn_type_modules[decl_qname] or { decl_module }
+				fn_decl_import_context := import_context_by_file[fn_decl_file] or {
+					decl_import_context
 				}
-			}
-			qname := qualify_fn(fn_decl_module, node.value)
-			if markused_fn_has_attribute(a, node_idx, 'markused') {
-				marked_roots << qname
-			}
-			// Cached headers retain bodies only when the warm pass must recreate
-			// generated specializations or closure support symbols. Root those bodies
-			// even though their ordinary caller can live entirely in another cached
-			// object and therefore be invisible to the program AST.
-			cached_header_body := fn_decl_file.ends_with('.vh') && !node.is_mut
-			if cache_mode && node.kind == .fn_decl && node.generic_params().len == 0
-				&& (cache_modules[fn_decl_module] || cached_header_body) {
-				cache_roots << qname
-			}
-			if qname != node.value {
-				add_fn_decl_info(mut fn_decls, mut fn_decl_lists, qname, info)
-				if can_suffix_match {
-					add_candidate_suffix(mut fn_name_suffixes, qname)
+				if collect_body_metadata {
+					body_ids << node_idx
+					body_modules << fn_decl_module
+					body_import_contexts << fn_decl_import_context
 				}
-				lowered_qname := markused_c_name(qname)
-				if lowered_qname != qname {
-					add_fn_decl_info(mut fn_decls, mut fn_decl_lists, lowered_qname, info)
-					if can_suffix_match {
-						add_candidate_suffix(mut fn_name_suffixes, lowered_qname)
-					}
-				}
-			}
-			// Build suffix_map entries
-			if has_dot && can_suffix_match {
+				has_dot := node.value.index_u8(`.`) >= 0
+				can_suffix_match := !markused_fn_decl_is_generic_template(node, a)
 				if trace_markused {
-					contains2_total++
+					fn_count++
+					if has_dot {
+						fn_with_dot++
+						if fn_with_dot <= 5 {
+							eprintln('  fn with dot: "${node.value}"')
+						}
+					}
 				}
-				short := node.value.all_after_last('.')
-				add_suffix_candidate(mut suffix_map, short, node.value)
+				info := FnDeclInfo{
+					node_id:        flat.NodeId(node_idx)
+					module:         fn_decl_module
+					import_context: fn_decl_import_context
+				}
+				add_fn_decl_info(mut fn_decls, mut fn_decl_lists, node.value, info)
+				if can_suffix_match {
+					add_candidate_suffix(mut fn_name_suffixes, node.value)
+				}
+				lowered_name := markused_c_name(node.value)
+				if lowered_name != node.value {
+					add_fn_decl_info(mut fn_decls, mut fn_decl_lists, lowered_name, info)
+					if can_suffix_match {
+						add_candidate_suffix(mut fn_name_suffixes, lowered_name)
+					}
+				}
+				qname := qualify_fn(fn_decl_module, node.value)
+				if markused_fn_has_attribute(a, node_idx, 'markused') {
+					marked_roots << qname
+				}
+				// Cached headers retain bodies only when the warm pass must recreate
+				// generated specializations or closure support symbols. Root those bodies
+				// even though their ordinary caller can live entirely in another cached
+				// object and therefore be invisible to the program AST.
+				cached_header_body := fn_decl_file.ends_with('.vh') && !node.is_mut
+				if cache_mode && node.kind == .fn_decl && node.generic_params().len == 0
+					&& (cache_modules[fn_decl_module] || cached_header_body) {
+					cache_roots << qname
+				}
 				if qname != node.value {
+					add_fn_decl_info(mut fn_decls, mut fn_decl_lists, qname, info)
+					if can_suffix_match {
+						add_candidate_suffix(mut fn_name_suffixes, qname)
+					}
+					lowered_qname := markused_c_name(qname)
+					if lowered_qname != qname {
+						add_fn_decl_info(mut fn_decls, mut fn_decl_lists, lowered_qname, info)
+						if can_suffix_match {
+							add_candidate_suffix(mut fn_name_suffixes, lowered_qname)
+						}
+					}
+				}
+				// Build suffix_map entries
+				if has_dot && can_suffix_match {
+					if trace_markused {
+						contains2_total++
+					}
+					short := node.value.all_after_last('.')
+					add_suffix_candidate(mut suffix_map, short, node.value)
+					if qname != node.value {
+						add_suffix_candidate(mut suffix_map, short, qname)
+					}
+				}
+				if qname != node.value && qname.index_u8(`.`) >= 0 && can_suffix_match {
+					short := qname.all_after_last('.')
 					add_suffix_candidate(mut suffix_map, short, qname)
 				}
-			}
-			if qname != node.value && qname.index_u8(`.`) >= 0 && can_suffix_match {
-				short := qname.all_after_last('.')
-				add_suffix_candidate(mut suffix_map, short, qname)
-			}
-			if fn_decl_module == 'c' && fn_decl_file.ends_with('/gen/c/interface.v') {
-				c_interface_roots << node.value
-				if qname != node.value {
-					c_interface_roots << qname
-				}
-				lowered_qname := markused_c_name(qname)
-				if lowered_qname != qname {
-					c_interface_roots << lowered_qname
+				if fn_decl_module == 'c' && fn_decl_file.ends_with('/gen/c/interface.v') {
+					c_interface_roots << node.value
+					if qname != node.value {
+						c_interface_roots << qname
+					}
+					lowered_qname := markused_c_name(qname)
+					if lowered_qname != qname {
+						c_interface_roots << lowered_qname
+					}
 				}
 			}
 		}
@@ -387,7 +426,11 @@ fn mark_used_with_test_files(a &flat.FlatAst, tc &types.TypeChecker, test_files 
 	mut used := map[string]bool{}
 	used.reserve(u32(fn_decls.len))
 	mut queue := []string{cap: fn_decls.len}
-	reachable_modules := markused_reachable_modules(a, tc)
+	reachable_modules := if use_prepared {
+		map[string]bool{}
+	} else {
+		markused_reachable_modules(a, tc)
+	}
 	queue << 'main'
 	used['main'] = true
 	$if ownership ? {
@@ -399,7 +442,13 @@ fn mark_used_with_test_files(a &flat.FlatAst, tc &types.TypeChecker, test_files 
 		}
 	}
 	enqueue_main_module_roots(fn_decls, mut used, mut queue)
-	enqueue_auto_roots(a, fn_decls, reachable_modules, mut used, mut queue)
+	if use_prepared {
+		for root in prepared.auto_roots {
+			enqueue(root, mut used, mut queue)
+		}
+	} else {
+		enqueue_auto_roots(a, fn_decls, reachable_modules, mut used, mut queue)
+	}
 	enqueue_implicit_global_container_roots(a, tc, fn_decls, mut used, mut queue)
 	for root in marked_roots {
 		enqueue(root, mut used, mut queue)
@@ -576,8 +625,12 @@ fn mark_used_with_test_files(a &flat.FlatAst, tc &types.TypeChecker, test_files 
 		mu_sw.restart()
 	}
 	has_entry_main := markused_has_entry_main_indexed(a, tc)
-	if rt_scan_parallel {
-		rt_scan_thread.wait()
+	if use_prepared {
+		for name in prepared.runtime_helper_roots {
+			enqueue(name, mut used, mut queue)
+		}
+	} else if rt_scan_parallel {
+		rt_scan_threads[0].wait()
 		for name in rt_scan.queue {
 			// Clone into the master arena: the scan scope is freed right below.
 			enqueue(name.clone(), mut used, mut queue)
@@ -586,7 +639,12 @@ fn mark_used_with_test_files(a &flat.FlatAst, tc &types.TypeChecker, test_files 
 	} else if !trivial_literal_output {
 		enqueue_detected_runtime_helpers(a, tc, mut used, mut queue)
 	}
-	if !trivial_literal_output && markused_program_needs_closure_runtime(a, tc) {
+	needs_closure_runtime := if use_prepared && prepared.needs_closure_runtime {
+		true
+	} else {
+		markused_program_needs_closure_runtime(a, tc)
+	}
+	if !trivial_literal_output && needs_closure_runtime {
 		enqueue('closure.closure_create_with_data', mut used, mut queue)
 		enqueue('closure.closure_try_destroy', mut used, mut queue)
 	}
@@ -613,8 +671,11 @@ fn mark_used_with_test_files(a &flat.FlatAst, tc &types.TypeChecker, test_files 
 	// without this they would be pruned and produce undefined-symbol errors.
 	mut iface_impls := map[string][]string{}
 	mut checked_iface_impls := map[string]bool{}
+	iface_impls.reserve(u32(tc.interface_names.len * 2 + 16))
+	checked_iface_impls.reserve(u32(tc.interface_names.len * 2 + 16))
 	mut processed_nodes := []bool{len: a.nodes.len}
 	mut processed_initializer_refs := map[string]bool{}
+	processed_initializer_refs.reserve(u32(const_decls.len + 16))
 	mut calls := []string{cap: 128}
 	mut initializer_calls := []string{cap: 32}
 	mut initializer_refs := []string{cap: 32}
@@ -632,6 +693,8 @@ fn mark_used_with_test_files(a &flat.FlatAst, tc &types.TypeChecker, test_files 
 	// skipping a repeat performs no fewer markings.
 	mut safe_alias_done := map[string]bool{}
 	mut iface_tail_done := map[string]bool{}
+	safe_alias_done.reserve(u32(fn_decls.len))
+	iface_tail_done.reserve(u32(fn_decls.len))
 	if tc.verbose {
 		eprintln('  [ttime] mu seeds           ${f64(mu_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 		mu_sw.restart()
@@ -641,7 +704,7 @@ fn mark_used_with_test_files(a &flat.FlatAst, tc &types.TypeChecker, test_files 
 		name := queue[qi]
 		qi++
 		prev_len := queue.len
-		fn_infos := fn_decl_infos_for_queue_name(name, fn_decl_lists, a)
+		fn_infos := fn_decl_infos_for_queue_name(name, fn_decl_lists, a, detect_reachable_generics)
 		if fn_infos.len == 0 {
 			not_in_cg++
 			if trace_markused && qi <= 10 {
@@ -691,7 +754,7 @@ fn mark_used_with_test_files(a &flat.FlatAst, tc &types.TypeChecker, test_files 
 			// The body collector below remains responsible for implicit helpers
 			// introduced by lowering and for unresolved compatibility fallbacks.
 			for dependency in tc.direct_dependency_ids(node_key) {
-				calls << tc.symbol_name(dependency)
+				calls << tc.frozen_symbol_name(dependency)
 			}
 			if detect_reachable_generics {
 				if body_i := body_index[node_key] {
@@ -710,15 +773,21 @@ fn mark_used_with_test_files(a &flat.FlatAst, tc &types.TypeChecker, test_files 
 					uses_generics = uses_generics || body.uses_generics
 				}
 			}
-			call_epoch++
-			mut unique_call_count := 0
-			for call in calls {
-				if call_seen_epoch[call] == call_epoch {
-					continue
+			mut unique_call_count := calls.len
+			if detect_reachable_generics {
+				// The body collector can add compatibility fallbacks beside checker
+				// edges. Self-host uses only the checker's already-deduplicated symbol
+				// ids, so it can skip this per-callee hash pass entirely.
+				call_epoch++
+				unique_call_count = 0
+				for call in calls {
+					if call_seen_epoch[call] == call_epoch {
+						continue
+					}
+					call_seen_epoch[call] = call_epoch
+					calls[unique_call_count] = call
+					unique_call_count++
 				}
-				call_seen_epoch[call] = call_epoch
-				calls[unique_call_count] = call
-				unique_call_count++
 			}
 			for initializer_ref in initializer_refs {
 				enqueue_initializer_ref_calls(a, collector, fn_decls, initializer_ref, mut
@@ -1066,8 +1135,11 @@ fn add_fn_decl_info(mut fn_decls map[string]FnDeclInfo, mut fn_decl_lists map[st
 	fn_decl_lists[name] = infos
 }
 
-fn fn_decl_infos_for_queue_name(name string, fn_decl_lists map[string][]FnDeclInfo, a &flat.FlatAst) []FnDeclInfo {
+fn fn_decl_infos_for_queue_name(name string, fn_decl_lists map[string][]FnDeclInfo, a &flat.FlatAst, allow_generic_specialization bool) []FnDeclInfo {
 	infos := fn_decl_lists[name] or {
+		if !allow_generic_specialization {
+			return []FnDeclInfo{}
+		}
 		return fn_decl_infos_for_generic_specialization_name(name, fn_decl_lists, a)
 	}
 	if infos.len <= 1 {
@@ -1649,6 +1721,225 @@ struct ConstDeclInfo {
 	import_context int
 }
 
+// PreparedMarkusedDecls owns the declaration indexes that can be built from
+// the immutable post-collect AST while semantic body checking uses the other
+// cores.
+@[heap]
+pub struct PreparedMarkusedDecls {
+mut:
+	fn_decls              map[string]FnDeclInfo
+	fn_decl_lists         map[string][]FnDeclInfo
+	struct_decls          map[string]StructDeclInfo
+	const_decls           map[string]ConstDeclInfo
+	fn_name_suffixes      map[string]bool
+	const_name_suffixes   map[string]bool
+	suffix_map            map[string][]string
+	import_contexts       []map[string]string
+	marked_roots          []string
+	c_interface_roots     []string
+	runtime_helper_roots  []string
+	auto_roots            []string
+	needs_closure_runtime bool
+	scope                 voidptr
+	ready                 bool
+}
+
+// prepare_markused_declarations builds self-host declaration indexes on a
+// helper-local arena. It intentionally performs no semantic/body queries.
+pub fn prepare_markused_declarations(a &flat.FlatAst, tc &types.TypeChecker, enabled bool) &PreparedMarkusedDecls {
+	mut prepared := &PreparedMarkusedDecls{}
+	if !enabled {
+		return prepared
+	}
+	scope := markused_worker_scope_begin(true)
+	prepared = build_prepared_markused_declarations(a, tc)
+	prepared.scope = scope
+	prepared.ready = true
+	markused_worker_scope_leave(scope)
+	return prepared
+}
+
+// release frees the helper-local preparation arena after the caller has
+// published the used-name map into its compilation arena.
+pub fn (mut prepared PreparedMarkusedDecls) release() {
+	scope := prepared.scope
+	prepared.scope = unsafe { nil }
+	prepared.ready = false
+	if scope != unsafe { nil } {
+		// `prepared` itself belongs to this arena, so the final write must happen
+		// before releasing it.
+		markused_worker_scope_free(scope)
+	}
+}
+
+fn build_prepared_markused_declarations(a &flat.FlatAst, tc &types.TypeChecker) &PreparedMarkusedDecls {
+	mut result := &PreparedMarkusedDecls{
+		fn_decls:            map[string]FnDeclInfo{}
+		fn_decl_lists:       map[string][]FnDeclInfo{}
+		struct_decls:        map[string]StructDeclInfo{}
+		const_decls:         map[string]ConstDeclInfo{}
+		fn_name_suffixes:    map[string]bool{}
+		const_name_suffixes: map[string]bool{}
+		suffix_map:          map[string][]string{}
+		import_contexts:     []map[string]string{cap: 256}
+	}
+	result.import_contexts << map[string]string{}
+	result.fn_decls.reserve(u32(tc.fn_ret_types.len))
+	result.fn_decl_lists.reserve(u32(tc.fn_ret_types.len))
+	result.struct_decls.reserve(u32(tc.structs.len * 2))
+	result.const_decls.reserve(u32(tc.const_types.len))
+	result.fn_name_suffixes.reserve(u32(tc.fn_ret_types.len))
+	result.const_name_suffixes.reserve(u32(tc.const_types.len))
+	result.suffix_map.reserve(u32(tc.fn_ret_types.len / 2))
+	mut import_context_by_file := map[string]int{}
+	mut cur_file := ''
+	mut cur_module := ''
+	mut cur_import_context := 0
+	for node_idx in tc.top_level_idx {
+		node := a.nodes[node_idx]
+		if node.kind == .file {
+			cur_file = node.value
+			cur_module = ''
+			result.import_contexts << markused_top_level_file_imports(a, node)
+			cur_import_context = result.import_contexts.len - 1
+			import_context_by_file[cur_file] = cur_import_context
+			continue
+		}
+		if node.kind == .module_decl {
+			cur_module = node.value
+			continue
+		}
+		if node.kind == .import_decl {
+			if cur_import_context >= 0 && cur_import_context < result.import_contexts.len {
+				result.import_contexts[cur_import_context][node.typ] = node.value
+			}
+			continue
+		}
+		decl_file := if source_file := a.source_files[node.pos.id] {
+			source_file.name
+		} else {
+			cur_file
+		}
+		decl_module := tc.file_modules[decl_file] or { cur_module }
+		decl_import_context := import_context_by_file[decl_file] or { cur_import_context }
+		if node.kind == .struct_decl {
+			full_name := qualify_fn(decl_module, node.value)
+			info := StructDeclInfo{
+				node_id:        flat.NodeId(node_idx)
+				module:         decl_module
+				import_context: decl_import_context
+			}
+			result.struct_decls[full_name] = info
+			if node.value !in result.struct_decls {
+				result.struct_decls[node.value] = info
+			}
+			continue
+		}
+		if node.kind == .const_decl || node.kind == .global_decl {
+			for i in 0 .. node.children_count {
+				field_id := a.child(&node, i)
+				field := a.node(field_id)
+				if field.kind != .const_field || field.children_count == 0 {
+					continue
+				}
+				info := ConstDeclInfo{
+					expr_id:        a.child(field, 0)
+					module:         decl_module
+					import_context: decl_import_context
+				}
+				result.const_decls[field.value] = info
+				add_candidate_suffix(mut result.const_name_suffixes, field.value)
+				full_name := qualify_fn(decl_module, field.value)
+				if full_name != field.value {
+					result.const_decls[full_name] = info
+					add_candidate_suffix(mut result.const_name_suffixes, full_name)
+				}
+			}
+			continue
+		}
+		if node.kind != .fn_decl && node.kind != .c_fn_decl {
+			continue
+		}
+		decl_qname := qualify_fn(decl_module, node.value)
+		fn_decl_file := tc.fn_type_files[decl_qname] or { decl_file }
+		fn_decl_module := tc.fn_type_modules[decl_qname] or { decl_module }
+		fn_decl_import_context := import_context_by_file[fn_decl_file] or { decl_import_context }
+		has_dot := node.value.index_u8(`.`) >= 0
+		can_suffix_match := !markused_fn_decl_is_generic_template(node, a)
+		info := FnDeclInfo{
+			node_id:        flat.NodeId(node_idx)
+			module:         fn_decl_module
+			import_context: fn_decl_import_context
+		}
+		add_fn_decl_info(mut result.fn_decls, mut result.fn_decl_lists, node.value, info)
+		if can_suffix_match {
+			add_candidate_suffix(mut result.fn_name_suffixes, node.value)
+		}
+		lowered_name := markused_c_name(node.value)
+		if lowered_name != node.value {
+			add_fn_decl_info(mut result.fn_decls, mut result.fn_decl_lists, lowered_name, info)
+			if can_suffix_match {
+				add_candidate_suffix(mut result.fn_name_suffixes, lowered_name)
+			}
+		}
+		qname := qualify_fn(fn_decl_module, node.value)
+		if markused_fn_has_attribute(a, node_idx, 'markused') {
+			result.marked_roots << qname
+		}
+		if qname != node.value {
+			add_fn_decl_info(mut result.fn_decls, mut result.fn_decl_lists, qname, info)
+			if can_suffix_match {
+				add_candidate_suffix(mut result.fn_name_suffixes, qname)
+			}
+			lowered_qname := markused_c_name(qname)
+			if lowered_qname != qname {
+				add_fn_decl_info(mut result.fn_decls, mut result.fn_decl_lists, lowered_qname, info)
+				if can_suffix_match {
+					add_candidate_suffix(mut result.fn_name_suffixes, lowered_qname)
+				}
+			}
+		}
+		if has_dot && can_suffix_match {
+			short := node.value.all_after_last('.')
+			add_suffix_candidate(mut result.suffix_map, short, node.value)
+			if qname != node.value {
+				add_suffix_candidate(mut result.suffix_map, short, qname)
+			}
+		}
+		if qname != node.value && qname.index_u8(`.`) >= 0 && can_suffix_match {
+			add_suffix_candidate(mut result.suffix_map, qname.all_after_last('.'), qname)
+		}
+		if fn_decl_module == 'c' && fn_decl_file.ends_with('/gen/c/interface.v') {
+			result.c_interface_roots << node.value
+			if qname != node.value {
+				result.c_interface_roots << qname
+			}
+			lowered_qname := markused_c_name(qname)
+			if lowered_qname != qname {
+				result.c_interface_roots << lowered_qname
+			}
+		}
+	}
+	runtime_tc := tc.fork_for_parallel_transform(a)
+	mut runtime_used := map[string]bool{}
+	enqueue_detected_runtime_helpers(a, runtime_tc, mut runtime_used, mut
+		result.runtime_helper_roots)
+	reachable_modules := markused_reachable_modules(a, tc)
+	mut auto_used := map[string]bool{}
+	enqueue_auto_roots(a, result.fn_decls, reachable_modules, mut auto_used, mut result.auto_roots)
+	result.needs_closure_runtime = markused_syntax_needs_closure_runtime(a)
+	return result
+}
+
+fn markused_syntax_needs_closure_runtime(a &flat.FlatAst) bool {
+	for idx, node in a.nodes {
+		if node.kind == .fn_literal || (idx >= a.user_code_start && node.kind == .lambda_expr) {
+			return true
+		}
+	}
+	return false
+}
+
 // CallCollector represents call collector data used by markused.
 struct CallCollector {
 	a               &flat.FlatAst      = unsafe { nil }
@@ -1797,6 +2088,11 @@ fn enqueue_export_roots(a &flat.FlatAst, tc &types.TypeChecker, mut used map[str
 }
 
 fn enqueue_veb_handler_roots(a &flat.FlatAst, tc &types.TypeChecker, mut used map[string]bool, mut queue []string) {
+	// Most programs, including compiler self-hosts, do not import veb. Avoid
+	// parsing every function return type when its Result type is absent.
+	if !markused_type_name_known_in_module(tc, 'veb', 'Result') {
+		return
+	}
 	mut cur_module := ''
 	for node_idx in tc.top_level_idx {
 		node := a.nodes[node_idx]

--- a/vlib/v3/parser/parser_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/parser/parser_parallel_notd_v3_no_parallel.v
@@ -19,7 +19,7 @@ import v3.workers
 
 const min_parallel_parse_files = 4
 const min_parallel_parse_bytes = 131072
-const max_parallel_parse_jobs = 17
+const max_parallel_parse_jobs = 18
 const max_parallel_parse_chunks = 48
 const parallel_parse_chunks_per_job = 2
 const comptime_const_prepass_alias_prefix = '\x00v3-comptime-alias:'
@@ -1068,6 +1068,17 @@ fn (mut p Parser) merge_parsed_workers_parallel(mut parser_workers []&Parser, mu
 	for ci in 0 .. thread_count {
 		node_offsets[ci + 1] = node_offsets[ci] + parser_workers[ci].a.nodes.len
 		child_offsets[ci + 1] = child_offsets[ci] + parser_workers[ci].a.children.len
+	}
+	// Each worker has already interned its node payloads in source order. Merge
+	// those unique tables once, in chunk order, so the copy threads can rebind
+	// every payload without leaving a serial per-node miss pass behind.
+	mut text_headroom := 0
+	for worker in parser_workers {
+		text_headroom += worker.a.text_count()
+	}
+	p.a.reserve_transform_texts(text_headroom)
+	for worker in parser_workers {
+		p.a.intern_texts_from(worker.a)
 	}
 	unsafe {
 		p.a.nodes.grow_len(node_offsets[thread_count] - base_nodes)

--- a/vlib/v3/tests/markused_test.v
+++ b/vlib/v3/tests/markused_test.v
@@ -396,6 +396,38 @@ fn main() {
 	assert used['new_map']
 }
 
+// test_prepared_markused_scans_runtime_helpers_after_semantic_check validates
+// that declaration preparation never captures incomplete semantic results.
+fn test_prepared_markused_scans_runtime_helpers_after_semantic_check() {
+	src := os.join_path(os.temp_dir(), 'v3_markused_prepared_runtime_helpers.v')
+	os.write_file(src, '
+fn maybe_map() ?map[string]int {
+	return none
+}
+
+fn main() {
+	m := maybe_map() or { return }
+	_ := m
+}
+') or {
+		panic(err)
+	}
+	prefs := pref.new_preferences()
+	mut p := parser.Parser.new(prefs)
+	mut a := p.parse_file(src)
+	mut tc := types.TypeChecker.new(a)
+	tc.enable_globals = true
+	tc.collect(a)
+	tc.diagnostic_files[src] = true
+	prepared_thread := spawn markused.prepare_markused_declarations(a, &tc, true)
+	tc.check_semantics()
+	assert tc.errors.len == 0, tc.errors.str()
+	mut prepared := prepared_thread.wait()
+	used := markused.mark_used_without_generic_detection_prepared(a, &tc, mut prepared)
+	prepared.release()
+	assert used['new_map']
+}
+
 fn test_self_typed_default_collects_explicit_initializer_calls() {
 	used := mark_used_source('self_typed_default_explicit_call', '
 interface Value {}

--- a/vlib/v3/tests/missing_import_diagnostics_test.v
+++ b/vlib/v3/tests/missing_import_diagnostics_test.v
@@ -134,4 +134,56 @@ fn main() {
 	string_run := os.execute(output)
 	assert string_run.exit_code == 0, string_run.output
 	assert string_run.output.trim_space() == 'before\nimport eager_string_literal_trap\nafter', string_run.output
+
+	collision_root := os.join_path(root, 'suffix_collision')
+	plain_bar_dir := os.join_path(collision_root, 'bar')
+	dotted_bar_dir := os.join_path(collision_root, 'foo', 'bar')
+	user_dir := os.join_path(collision_root, 'user')
+	os.mkdir_all(plain_bar_dir) or { panic(err) }
+	os.mkdir_all(dotted_bar_dir) or { panic(err) }
+	os.mkdir_all(user_dir) or { panic(err) }
+	os.write_file(os.join_path(plain_bar_dir, 'bar.v'), "module bar
+
+pub fn value() string {
+	return 'plain bar'
+}
+") or {
+		panic(err)
+	}
+	os.write_file(os.join_path(dotted_bar_dir, 'bar.v'), "module bar
+
+pub fn value() string {
+	return 'dotted bar'
+}
+") or {
+		panic(err)
+	}
+	os.write_file(os.join_path(user_dir, 'user.v'), 'module user
+
+import foo.bar
+
+pub fn value() string {
+	return bar.value()
+}
+') or {
+		panic(err)
+	}
+	os.write_file(os.join_path(collision_root, 'main.v'), 'module main
+
+import bar
+import user
+
+fn main() {
+	println(bar.value())
+	println(user.value())
+}
+') or {
+		panic(err)
+	}
+	collision_build :=
+		os.execute('${v3_bin} -nocache -building-v -o ${output} ${collision_root}/main.v')
+	assert collision_build.exit_code == 0, collision_build.output
+	collision_run := os.execute(output)
+	assert collision_run.exit_code == 0, collision_run.output
+	assert collision_run.output.trim_space() == 'plain bar\ndotted bar', collision_run.output
 }

--- a/vlib/v3/tests/missing_import_diagnostics_test.v
+++ b/vlib/v3/tests/missing_import_diagnostics_test.v
@@ -22,9 +22,15 @@ fn test_each_unresolved_module_import_is_reported() {
 
 	os.mkdir_all(root) or { panic(err) }
 	module_name := 'definitely_missing_v3_review_module'
+	empty_module_name := 'empty_target_v3_review_module'
+	empty_module_dir := os.join_path(root, 'modules', empty_module_name)
+	os.mkdir_all(empty_module_dir) or { panic(err) }
+	os.write_file(os.join_path(empty_module_dir, 'only_d_v3_review_never.v'),
+		'module ${empty_module_name}\n') or { panic(err) }
 	os.write_file(os.join_path(root, 'main.v'), 'module main
 
 import ${module_name}
+import ${empty_module_name}
 
 fn main() {}
 ') or {
@@ -33,16 +39,21 @@ fn main() {}
 	os.write_file(os.join_path(root, 'second.v'), 'module main
 
 import ${module_name}
+import ${empty_module_name}
 
 fn helper() {}
 ') or {
 		panic(err)
 	}
 
-	result := os.execute('${v3_bin} -nocache -no-parallel -o ${output} ${root}')
-	assert result.exit_code != 0, result.output
-	message := 'cannot import module "${module_name}" (not found)'
-	assert result.output.count(message) == 2, result.output
-	assert result.output.contains('main.v'), result.output
-	assert result.output.contains('second.v'), result.output
+	for flags in ['-no-parallel', '-building-v'] {
+		result := os.execute('${v3_bin} -nocache ${flags} -o ${output} ${root}')
+		assert result.exit_code != 0, result.output
+		for unresolved in [module_name, empty_module_name] {
+			message := 'cannot import module "${unresolved}" (not found)'
+			assert result.output.count(message) == 2, result.output
+		}
+		assert result.output.contains('main.v'), result.output
+		assert result.output.contains('second.v'), result.output
+	}
 }

--- a/vlib/v3/tests/missing_import_diagnostics_test.v
+++ b/vlib/v3/tests/missing_import_diagnostics_test.v
@@ -235,4 +235,67 @@ fn main() {
 	alias_run := os.execute(output)
 	assert alias_run.exit_code == 0, alias_run.output
 	assert alias_run.output.trim_space() == '42', alias_run.output
+
+	dotted_root := os.join_path(root, 'dotted_suffix_collision')
+	a_bar_dir := os.join_path(dotted_root, 'a', 'bar')
+	b_bar_dir := os.join_path(dotted_root, 'b', 'bar')
+	left_dir := os.join_path(dotted_root, 'left')
+	right_dir := os.join_path(dotted_root, 'right')
+	os.mkdir_all(a_bar_dir) or { panic(err) }
+	os.mkdir_all(b_bar_dir) or { panic(err) }
+	os.mkdir_all(left_dir) or { panic(err) }
+	os.mkdir_all(right_dir) or { panic(err) }
+	os.write_file(os.join_path(a_bar_dir, 'bar.v'), "module bar
+
+pub fn value() string {
+	return 'a.bar'
+}
+") or {
+		panic(err)
+	}
+	os.write_file(os.join_path(b_bar_dir, 'bar.v'), "module bar
+
+pub fn value() string {
+	return 'b.bar'
+}
+") or {
+		panic(err)
+	}
+	os.write_file(os.join_path(left_dir, 'left.v'), 'module left
+
+import a.bar
+
+pub fn value() string {
+	return bar.value()
+}
+') or {
+		panic(err)
+	}
+	os.write_file(os.join_path(right_dir, 'right.v'), 'module right
+
+import b.bar
+
+pub fn value() string {
+	return bar.value()
+}
+') or {
+		panic(err)
+	}
+	os.write_file(os.join_path(dotted_root, 'main.v'), 'module main
+
+import left
+import right
+
+fn main() {
+	println(left.value())
+	println(right.value())
+}
+') or {
+		panic(err)
+	}
+	dotted_build := os.execute('${v3_bin} -nocache -building-v -o ${output} ${dotted_root}/main.v')
+	assert dotted_build.exit_code == 0, dotted_build.output
+	dotted_run := os.execute(output)
+	assert dotted_run.exit_code == 0, dotted_run.output
+	assert dotted_run.output.trim_space() == 'a.bar\nb.bar', dotted_run.output
 }

--- a/vlib/v3/tests/missing_import_diagnostics_test.v
+++ b/vlib/v3/tests/missing_import_diagnostics_test.v
@@ -186,4 +186,53 @@ fn main() {
 	collision_run := os.execute(output)
 	assert collision_run.exit_code == 0, collision_run.output
 	assert collision_run.output.trim_space() == 'plain bar\ndotted bar', collision_run.output
+
+	alias_root := os.join_path(root, 'module_alias')
+	legacy_dir := os.join_path(alias_root, 'modules', 'legacy')
+	canonical_dir := os.join_path(alias_root, 'modules', 'canonical')
+	os.mkdir_all(legacy_dir) or { panic(err) }
+	os.mkdir_all(canonical_dir) or { panic(err) }
+	os.write_file(os.join_path(alias_root, 'v.mod'), "Module {
+	name: 'eager_alias_identity'
+}
+") or {
+		panic(err)
+	}
+	os.write_file(os.join_path(legacy_dir, 'alias.v'),
+		"@[alias: '@VMODROOT/modules/canonical'] module legacy\n") or { panic(err) }
+	os.write_file(os.join_path(canonical_dir, 'canonical.v'), 'module canonical
+
+pub struct Value {
+pub:
+	n int
+}
+
+pub fn make() Value {
+	return Value{
+		n: 42
+	}
+}
+
+pub fn read(value Value) int {
+	return value.n
+}
+') or {
+		panic(err)
+	}
+	os.write_file(os.join_path(alias_root, 'main.v'), 'module main
+
+import legacy
+import canonical
+
+fn main() {
+	println(canonical.read(legacy.make()))
+}
+') or {
+		panic(err)
+	}
+	alias_build := os.execute('${v3_bin} -nocache -building-v -o ${output} ${alias_root}/main.v')
+	assert alias_build.exit_code == 0, alias_build.output
+	alias_run := os.execute(output)
+	assert alias_run.exit_code == 0, alias_run.output
+	assert alias_run.output.trim_space() == '42', alias_run.output
 }

--- a/vlib/v3/tests/missing_import_diagnostics_test.v
+++ b/vlib/v3/tests/missing_import_diagnostics_test.v
@@ -57,3 +57,81 @@ fn helper() {}
 		assert result.output.contains('second.v'), result.output
 	}
 }
+
+fn test_eager_import_resolution_matches_authoritative_resolution() {
+	v3_bin := os.join_path(os.temp_dir(), 'v3_eager_import_resolution_${os.getpid()}')
+	root := os.join_path(os.temp_dir(), 'v3_eager_import_project_${os.getpid()}')
+	output := os.join_path(os.temp_dir(), 'v3_eager_import_output_${os.getpid()}')
+	defer {
+		os.rm(v3_bin) or {}
+		os.rmdir_all(root) or {}
+		os.rm(output) or {}
+		os.rm(output + '.c') or {}
+	}
+	build :=
+		os.execute('${missing_import_vexe} -gc none -path "${missing_import_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${missing_import_v3_src}')
+	assert build.exit_code == 0, build.output
+
+	precedence_root := os.join_path(root, 'precedence')
+	local_arrays_dir := os.join_path(precedence_root, 'modules', 'arrays')
+	os.mkdir_all(local_arrays_dir) or { panic(err) }
+	os.write_file(os.join_path(local_arrays_dir, 'arrays.v'), "module arrays
+
+pub fn eager_local_marker() string {
+	return 'local arrays'
+}
+") or {
+		panic(err)
+	}
+	os.write_file(os.join_path(precedence_root, 'main.v'), 'module main
+
+import arrays
+
+fn main() {
+	println(arrays.eager_local_marker())
+}
+') or {
+		panic(err)
+	}
+	precedence_build :=
+		os.execute('${v3_bin} -nocache -building-v -o ${output} ${precedence_root}/main.v')
+	assert precedence_build.exit_code == 0, precedence_build.output
+	precedence_run := os.execute(output)
+	assert precedence_run.exit_code == 0, precedence_run.output
+	assert precedence_run.output.trim_space() == 'local arrays', precedence_run.output
+
+	string_root := os.join_path(root, 'string_literal')
+	bridge_dir := os.join_path(string_root, 'modules', 'eager_string_bridge')
+	trap_dir := os.join_path(string_root, 'modules', 'eager_string_literal_trap')
+	os.mkdir_all(bridge_dir) or { panic(err) }
+	os.mkdir_all(trap_dir) or { panic(err) }
+	os.write_file(os.join_path(bridge_dir, 'bridge.v'), "module eager_string_bridge
+
+pub const text = 'before
+import eager_string_literal_trap
+after'
+") or {
+		panic(err)
+	}
+	os.write_file(os.join_path(trap_dir, 'trap.v'), 'module eager_string_literal_trap
+
+this source must never be parsed
+') or {
+		panic(err)
+	}
+	os.write_file(os.join_path(string_root, 'main.v'), 'module main
+
+import eager_string_bridge
+
+fn main() {
+	println(eager_string_bridge.text)
+}
+') or {
+		panic(err)
+	}
+	string_build := os.execute('${v3_bin} -nocache -building-v -o ${output} ${string_root}/main.v')
+	assert string_build.exit_code == 0, string_build.output
+	string_run := os.execute(output)
+	assert string_run.exit_code == 0, string_run.output
+	assert string_run.output.trim_space() == 'before\nimport eager_string_literal_trap\nafter', string_run.output
+}

--- a/vlib/v3/tests/parallel_cgen_test.v
+++ b/vlib/v3/tests/parallel_cgen_test.v
@@ -77,14 +77,29 @@ fn write_parallel_module_init_project(name string) string {
 
 	os.write_file(os.join_path(project_dir, 'moda', 'moda.v'), 'module moda
 
-__global x int
+const runtime_const = make_const()
+
+__global (
+	runtime_global = make_global()
+	seen_const int
+	seen_global int
+)
+
+fn make_const() int {
+	return 5
+}
+
+fn make_global() int {
+	return 7
+}
 
 fn init() {
-	x = 7
+	seen_const = runtime_const
+	seen_global = runtime_global
 }
 
 pub fn value() int {
-	return x
+	return seen_const + seen_global
 }
 ') or {
 		panic(err)
@@ -413,6 +428,14 @@ fn test_prealloc_keeps_parallel_transform_enabled() {
 	assert compile.exit_code == 0, compile.output
 	assert compile.output.contains('transform (parallel)'), compile.output
 	assert compile.output.contains('cgen (parallel)'), compile.output
+	c_code := os.read_file(c_out) or { panic(err) }
+	vinit := c_code.all_after('void _vinit() {')
+	const_init := vinit.index('moda__runtime_const =') or { -1 }
+	global_init := vinit.index('moda__runtime_global =') or { -1 }
+	module_init := vinit.index('moda__init();') or { -1 }
+	assert const_init >= 0
+	assert global_init > const_init
+	assert module_init > global_init
 }
 
 fn test_parallel_transform_generates_v3_c_with_vjobs_4_and_12() {

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -389,6 +389,8 @@ mut:
 	parallel_monomorph_scan_start      int
 	parallel_monomorph_scan_end        int
 	fn_scan_costs                      []int
+	literal_fn_decls                   []int
+	literal_fn_decls_ready             bool
 	parallel_monomorph_struct_specs    map[string]string
 	parallel_monomorph_sum_specs       map[string]GenericSpecContext
 	generic_call_spec_cache            map[int]GenericCallSpec
@@ -826,6 +828,67 @@ pub:
 
 // --- entry point ---
 
+// PreparedSelfhostTransform owns the read-only transformer indexes built while
+// markused walks the same checked AST on the driver thread.
+@[heap]
+pub struct PreparedSelfhostTransform {
+mut:
+	transformer Transformer
+	scope       voidptr
+	ready       bool
+}
+
+// take_scope transfers ownership of the preparation arena to the driver. The
+// arena can back lowered AST text, so it must remain alive through codegen.
+pub fn (mut prepared PreparedSelfhostTransform) take_scope() voidptr {
+	scope := prepared.scope
+	prepared.scope = unsafe { nil }
+	return scope
+}
+
+// prepare_selfhost_transform builds the immutable transform indexes on a
+// helper-local arena. The caller keeps the returned value alive until
+// transform_prepared_selfhost_owned consumes it.
+pub fn prepare_selfhost_transform(a &flat.FlatAst, tc &types.TypeChecker, enabled bool) &PreparedSelfhostTransform {
+	mut prepared := &PreparedSelfhostTransform{}
+	if !enabled {
+		return prepared
+	}
+	scope := transform_worker_scope_begin(true)
+	prep_tc := tc.fork_for_parallel_transform(a)
+	mut t := new_transformer_view(a, prep_tc, map[string]bool{})
+	configure_transformer(mut t, true, true, true, true, false, unsafe { nil })
+	t.prepare_with_pre_scans()
+	// This whole-AST scan is independent of reachability and otherwise leaves
+	// the persistent worker pool idle at the start of transform.
+	t.collect_exclusive_closure_return_fns()
+	prepared = &PreparedSelfhostTransform{
+		transformer: t
+		scope:       scope
+		ready:       true
+	}
+	transform_worker_scope_leave(scope)
+	return prepared
+}
+
+// transform_prepared_selfhost_owned completes a self-host transform whose
+// immutable indexes were prepared concurrently with markused.
+pub fn transform_prepared_selfhost_owned(mut prepared PreparedSelfhostTransform, mut a flat.FlatAst, tc &types.TypeChecker, used_fns map[string]bool, stage_scope voidptr) (map[string]bool, bool, []string, []int, []ScopedTransformRegion) {
+	if !prepared.ready {
+		return transform_with_used_opt_config_scoped_workers_checked_impl(mut a, tc, used_fns,
+			true, true, true, true, true, stage_scope)
+	}
+	mut t := &prepared.transformer
+	t.a = unsafe { &a }
+	t.tc = unsafe { tc }
+	t.used_fns = used_fns.clone()
+	configure_transformer(mut t, true, true, true, true, true, stage_scope)
+	augmented, was_parallel, errors, owned_base_nodes, retained_regions := transform_after_prepare(mut t, mut
+		a, used_fns, true, true)
+	prepared.ready = false
+	return augmented, was_parallel, errors, owned_base_nodes, retained_regions
+}
+
 // transform supports transform handling for transform.
 pub fn transform(mut a flat.FlatAst, tc &types.TypeChecker) {
 	transform_with_used(mut a, tc, map[string]bool{})
@@ -932,6 +995,14 @@ pub fn transform_selected_functions(mut a flat.FlatAst, tc &types.TypeChecker, s
 fn transform_with_used_opt_config_scoped_workers_checked_impl(mut a flat.FlatAst, tc &types.TypeChecker, used_fns map[string]bool, want_parallel bool, skip_generics bool, scope_parallel_workers bool, building_v bool, retain_worker_results bool, stage_scope voidptr) (map[string]bool, bool, []string, []int, []ScopedTransformRegion) {
 	mut impl_sw := time.new_stopwatch()
 	mut t := new_transformer(mut a, tc, used_fns)
+	configure_transformer(mut t, want_parallel, skip_generics, scope_parallel_workers, building_v,
+		retain_worker_results, stage_scope)
+	t.prepare_with_pre_scans()
+	t.timing_profile('  [ttime] new+prepare        ${f64(impl_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+	return transform_after_prepare(mut t, mut a, used_fns, want_parallel, skip_generics)
+}
+
+fn configure_transformer(mut t Transformer, want_parallel bool, skip_generics bool, scope_parallel_workers bool, building_v bool, retain_worker_results bool, stage_scope voidptr) {
 	t.skip_generics = skip_generics
 	t.building_v = building_v
 	t.memo_node_types = building_v && os.getenv('V3_NO_NODE_TYPE_MEMO') == ''
@@ -966,9 +1037,10 @@ fn transform_with_used_opt_config_scoped_workers_checked_impl(mut a flat.FlatAst
 	if scope_parallel_workers {
 		t.scoped_base_nodes = t.a.nodes.len
 	}
-	t.prepare_with_pre_scans()
-	t.timing_profile('  [ttime] new+prepare        ${f64(impl_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
-	impl_sw.restart()
+}
+
+fn transform_after_prepare(mut t Transformer, mut a flat.FlatAst, used_fns map[string]bool, want_parallel bool, skip_generics bool) (map[string]bool, bool, []string, []int, []ScopedTransformRegion) {
+	mut impl_sw := time.new_stopwatch()
 	t.cache_comptime_param_reflection_metadata()
 	if want_parallel {
 		reserve_parallel_transform_ast(mut a, skip_generics)
@@ -976,7 +1048,7 @@ fn transform_with_used_opt_config_scoped_workers_checked_impl(mut a flat.FlatAst
 	t.timing_profile('  [ttime] reflect+reserve    ${f64(impl_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 	impl_sw.restart()
 	base_node_count := t.a.nodes.len
-	if scope_parallel_workers {
+	if t.scope_parallel_workers {
 		t.scoped_base_nodes = base_node_count
 	}
 	t.transformed_fns = []bool{len: t.a.nodes.len}
@@ -989,7 +1061,7 @@ fn transform_with_used_opt_config_scoped_workers_checked_impl(mut a flat.FlatAst
 	// non-generic programs too: a call on a narrowed sum-type variant can become a
 	// concrete primitive method only after transform.
 	mut late_names := newly_used_fn_names(used_fns, t.used_fns)
-	if !building_v {
+	if !t.building_v {
 		// Interface implementers can become reachable while their interface calls
 		// are transformed. Include them in the type-aware call scan so dependencies
 		// from their already-transformed bodies are queued too.
@@ -3207,7 +3279,11 @@ fn (mut t Transformer) transform_all_dispatch(want_parallel bool) bool {
 	// contains a function literal (the only construct that lifts new top-level
 	// declarations and mutates the shared TypeChecker). Collect the remaining,
 	// closure-free functions as parallelizable work items.
-	literal_decls := t.collect_literal_fn_decls(t.a.nodes.len)
+	literal_decls := if t.literal_fn_decls_ready {
+		t.literal_fn_decls
+	} else {
+		t.collect_literal_fn_decls(t.a.nodes.len)
+	}
 	t.timing_profile('  [ttime] literal_decls      ${f64(ttsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 	ttsw.restart()
 	pure_items := t.transform_serial_then_collect_pure(literal_decls)
@@ -4642,7 +4718,17 @@ fn (mut t Transformer) transform_late_used_fn_bodies(names []string, node_limit 
 	mut candidates := []LateFnCandidate{}
 	mut scan_file := ''
 	mut scan_module := ''
-	for i in 0 .. limit {
+	late_scan_ids := if t.building_v && t.tc.top_level_idx.len > 0 {
+		t.tc.top_level_idx
+	} else {
+		[]int{}
+	}
+	scan_count := if late_scan_ids.len > 0 { late_scan_ids.len } else { limit }
+	for scan_pos in 0 .. scan_count {
+		i := if late_scan_ids.len > 0 { late_scan_ids[scan_pos] } else { scan_pos }
+		if i < 0 || i >= limit {
+			continue
+		}
 		node := t.a.nodes[i]
 		kind_id := node_kind_id(node)
 		if kind_id == 77 {
@@ -5675,8 +5761,36 @@ fn (mut t Transformer) collect_exclusive_closure_return_fns() {
 		t.cur_module = old_module
 	}
 	mut module_name := ''
+	mut literal_pending := false
+	mut span_cost := 0
+	t.literal_fn_decls = []int{cap: 64}
+	t.fn_scan_costs = []int{len: t.a.nodes.len}
 	for idx in 0 .. t.a.nodes.len {
 		node := t.a.nodes[idx]
+		span_cost += match node.kind {
+			.call, .struct_init { 8 }
+			.selector { 6 }
+			.assign, .decl_assign, .selector_assign, .index_assign { 5 }
+			.array_literal, .array_init, .map_init, .fn_literal, .lambda_expr, .string_interp { 4 }
+			.index, .if_expr, .match_stmt, .for_stmt, .for_in_stmt, .select_stmt { 3 }
+			.infix, .cast_expr, .as_expr, .or_expr, .return_stmt { 2 }
+			else { 1 }
+		}
+		if node.kind in [.fn_literal, .lambda_expr] {
+			literal_pending = true
+		} else if node.kind == .fn_decl {
+			if literal_pending {
+				t.literal_fn_decls << idx
+			}
+			literal_pending = false
+			t.fn_scan_costs[idx] = span_cost
+		} else if node.kind in [.const_decl, .global_decl] {
+			literal_pending = false
+		}
+		if node.kind in [.file, .module_decl, .struct_decl, .type_decl, .interface_decl, .enum_decl,
+			.import_decl, .const_decl, .global_decl, .fn_decl, .c_fn_decl] {
+			span_cost = 0
+		}
 		if node.kind == .module_decl {
 			module_name = node.value
 			t.cur_module = module_name
@@ -5698,6 +5812,7 @@ fn (mut t Transformer) collect_exclusive_closure_return_fns() {
 			t.exclusive_closure_return_fns['${module_name}.${node.value}'] = true
 		}
 	}
+	t.literal_fn_decls_ready = true
 }
 
 fn (t &Transformer) fn_decl_returns_fn_pointer(node flat.Node, module_name string) bool {

--- a/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
@@ -18,8 +18,13 @@ const max_parallel_transform_jobs = 7
 // Shared-base (clone-free) transform: workers share the master arrays and
 // append into pre-partitioned capacity regions, so extra threads cost no
 // clone memory; cap by core count only.
-const max_shared_transform_jobs = 17
-const max_parallel_monomorph_jobs = 17
+const max_shared_transform_jobs = 18
+// Shared regions are cheap views over the same AST. Keep two chunks per lane so
+// the persistent queue can absorb heterogeneous-core and scheduler stragglers;
+// the caller consumes two synchronous chunks while each pool worker consumes
+// two queued chunks.
+const shared_transform_chunks_per_job = 2
+const max_parallel_monomorph_jobs = 18
 // Recycle scratch arenas throughout large self-hosting transforms.
 const scoped_transform_worker_batches = 16
 const scoped_transform_master_batches = 16
@@ -2158,9 +2163,20 @@ fn (mut t Transformer) run_parallel_transform_shared(items []FnWorkItem, base_no
 	} $else {
 		mut ttsw := time.new_stopwatch()
 		t.tc.freeze_type_cache_for_forks()
-		mut chunks := split_work_items_ex(items, n_jobs, false)
+		mut chunk_target := n_jobs * shared_transform_chunks_per_job
+		if chunk_target > items.len {
+			chunk_target = items.len
+		}
+		mut chunks := split_work_items_ex(items, chunk_target, false)
 		chunk_count := chunks.len
 		thread_count := chunk_count - 1
+		// Pool.run queues asynchronous work before running synchronous tasks. Give
+		// the caller the same number of chunks as every persistent worker so its
+		// core remains useful across both scheduling waves.
+		mut sync_chunk_count := chunk_count - (n_jobs - 1) * shared_transform_chunks_per_job
+		if sync_chunk_count < 1 {
+			sync_chunk_count = 1
+		}
 		// Partition the reserved capacity into per-chunk append regions,
 		// proportional to chunk cost (the caller reserved ~2x the expected
 		// total growth for this pool).
@@ -2237,7 +2253,8 @@ fn (mut t Transformer) run_parallel_transform_shared(items []FnWorkItem, base_no
 			tasks << workers.Task{
 				run:        shared_chunk_thread
 				arg:        unsafe { voidptr(&args[ci]) }
-				force_sync: ci == 0 || fail == 'transform:all' || fail == 'transform:${helper_idx}'
+				force_sync: ci < sync_chunk_count || fail == 'transform:all'
+					|| fail == 'transform:${helper_idx}'
 			}
 		}
 		transform_worker_scope_leave(setup_scope)

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -904,6 +904,7 @@ mut:
 	direct_parent_ids           []flat.NodeId
 	rewritten_parent_ids        []flat.NodeId
 	value_used_nodes            []bool
+	fn_check_costs              []int
 	direct_parent_index_trusted bool
 	has_goto_nodes              bool
 	// Immutable declaration indexes shared by checker workers.
@@ -1626,6 +1627,7 @@ fn (mut tc TypeChecker) init_direct_parent_index(a &flat.FlatAst) {
 	tc.direct_parent_ids = []flat.NodeId{len: a.nodes.len, init: flat.empty_node}
 	tc.rewritten_parent_ids = []flat.NodeId{}
 	tc.value_used_nodes = []bool{len: a.nodes.len}
+	tc.fn_check_costs = if tc.building_v_fast { []int{len: a.nodes.len} } else { []int{} }
 	tc.declaration_attributes = map[int][]string{}
 	tc.insert_include_dirs_by_file = map[string][]string{}
 	tc.translated_files = map[string]bool{}
@@ -1635,7 +1637,9 @@ fn (mut tc TypeChecker) init_direct_parent_index(a &flat.FlatAst) {
 }
 
 fn (mut tc TypeChecker) fill_direct_parent_edges(a &flat.FlatAst) {
+	mut fn_cost := 0
 	for parent_idx, node in a.nodes {
+		fn_cost += 1 + int(node.children_count) * 2
 		if node.kind == .goto_stmt {
 			tc.has_goto_nodes = true
 		}
@@ -1650,6 +1654,13 @@ fn (mut tc TypeChecker) fill_direct_parent_edges(a &flat.FlatAst) {
 				&& tc.direct_parent_ids[idx] == flat.empty_node {
 				tc.direct_parent_ids[idx] = flat.NodeId(parent_idx)
 			}
+		}
+		if node.kind == .fn_decl && parent_idx < tc.fn_check_costs.len {
+			tc.fn_check_costs[parent_idx] = fn_cost
+		}
+		if node.kind in [.file, .module_decl, .struct_decl, .type_decl, .interface_decl, .enum_decl,
+			.import_decl, .const_decl, .global_decl, .fn_decl, .c_fn_decl] {
+			fn_cost = 0
 		}
 	}
 }
@@ -3013,9 +3024,11 @@ fn (mut tc TypeChecker) register_declaration_visibility(node flat.Node) {
 // and the full-scan fallback in collect()).
 fn (mut tc TypeChecker) collect_after_index(a &flat.FlatAst) {
 	mut ck_c_sw := time.new_stopwatch()
-	tc.build_enclosing_generic_param_index(a)
-	tc.build_type_declaration_index(a)
-	tc.build_fn_declaration_indexes(a)
+	if !tc.prepare_collect_declaration_indexes_parallel(a) {
+		tc.build_enclosing_generic_param_index(a)
+		tc.build_type_declaration_index(a)
+		tc.build_fn_declaration_indexes(a)
+	}
 	if !tc.valid_diagnostic_fast {
 		tc.index_multiple_module_import_lines(a)
 	}
@@ -7852,6 +7865,17 @@ fn (tc &TypeChecker) intern_symbol(name string) (SymbolId, string) {
 	return symbols.intern(name)
 }
 
+// intern_scoped_symbol bypasses the pointer-identity hot cache when promoting
+// names from a worker arena. Those addresses can be reused after each scoped
+// batch, so retaining them in the cache could alias a later, different name.
+fn (tc &TypeChecker) intern_scoped_symbol(name string) (SymbolId, string) {
+	if isnil(tc.symbols) {
+		return SymbolId(0), name
+	}
+	mut symbols := unsafe { tc.symbols }
+	return symbols.intern(name)
+}
+
 // symbol_name resolves a checker symbol identity to its canonical name.
 pub fn (tc &TypeChecker) symbol_name(id SymbolId) string {
 	if isnil(tc.symbols) {
@@ -7859,6 +7883,21 @@ pub fn (tc &TypeChecker) symbol_name(id SymbolId) string {
 	}
 	mut symbols := unsafe { tc.symbols }
 	return symbols.name(id)
+}
+
+// frozen_symbol_name resolves an id after semantic checking has frozen the
+// compilation's symbol table. Post-check reachability runs concurrently only
+// with read-only transform preparation, so it does not need the interner lock.
+pub fn (tc &TypeChecker) frozen_symbol_name(id SymbolId) string {
+	if isnil(tc.symbols) {
+		return ''
+	}
+	symbols := unsafe { tc.symbols }
+	index := int(id) - 1
+	if index < 0 || index >= symbols.names.len {
+		return ''
+	}
+	return symbols.names[index]
 }
 
 // canonical_symbol returns the compilation-owned canonical spelling of name.

--- a/vlib/v3/types/checker_parallel.v
+++ b/vlib/v3/types/checker_parallel.v
@@ -21,7 +21,7 @@ const scoped_check_worker_batches = 96
 const scoped_check_serial_batches = 64
 // Keep one scheduled chunk per scoped worker. Finer arena batches within each
 // chunk release transient checker allocations without retaining extra shards.
-// (Re-verified 2026-08: oversubscribe=4 costs ~25ms here — the extra per-chunk
+// (Re-verified 2026-08: oversubscribe=2 costs ~3-5ms here — the extra per-chunk
 // fork/promote overhead outweighs the straggler absorption.)
 const check_chunk_oversubscribe = 1
 // The caller also runs the top-level signature pass while workers check bodies.
@@ -50,6 +50,12 @@ struct CollectIndexPrepArgs {
 	n    int
 }
 
+struct CollectDeclarationIndexArgs {
+	tc   voidptr
+	a    &flat.FlatAst
+	kind u8 // 0 = generic params, 1 = type declarations, 2 = function declarations
+}
+
 fn collect_index_prep_thread(arg voidptr) voidptr {
 	a := unsafe { &CollectIndexPrepArgs(arg) }
 	mut tc := unsafe { &TypeChecker(a.tc) }
@@ -66,6 +72,17 @@ fn collect_index_prep_thread(arg voidptr) voidptr {
 		else {
 			tc.reset_node_caches(a.n)
 		}
+	}
+	return unsafe { nil }
+}
+
+fn collect_declaration_index_thread(arg voidptr) voidptr {
+	a := unsafe { &CollectDeclarationIndexArgs(arg) }
+	mut tc := unsafe { &TypeChecker(a.tc) }
+	match a.kind {
+		0 { tc.build_enclosing_generic_param_index(a.a) }
+		1 { tc.build_type_declaration_index(a.a) }
+		else { tc.build_fn_declaration_indexes(a.a) }
 	}
 	return unsafe { nil }
 }
@@ -108,6 +125,49 @@ fn (mut tc TypeChecker) prepare_collect_index_parallel(a &flat.FlatAst) bool {
 	])
 	tc.collect_direct_parent_metadata(a)
 	tc.direct_parent_index_trusted = true
+	return true
+}
+
+// prepare_collect_declaration_indexes_parallel builds the three independent
+// read-only-AST declaration indexes on separate persistent lanes.
+fn (mut tc TypeChecker) prepare_collect_declaration_indexes_parallel(a &flat.FlatAst) bool {
+	if !tc.building_v_fast || !tc.scope_parallel_check_workers
+		|| os.getenv('V3_NO_PAR_CHECK_DECL_INDEXES') != '' || isnil(a.worker_pool)
+		|| a.worker_pool.size() < 2 || tc.top_level_idx.len < 2048 {
+		return false
+	}
+	mut args := [
+		CollectDeclarationIndexArgs{
+			tc:   voidptr(tc)
+			a:    a
+			kind: 0
+		},
+		CollectDeclarationIndexArgs{
+			tc:   voidptr(tc)
+			a:    a
+			kind: 1
+		},
+		CollectDeclarationIndexArgs{
+			tc:   voidptr(tc)
+			a:    a
+			kind: 2
+		},
+	]
+	a.worker_pool.run([
+		workers.Task{
+			run: collect_declaration_index_thread
+			arg: unsafe { voidptr(&args[0]) }
+		},
+		workers.Task{
+			run: collect_declaration_index_thread
+			arg: unsafe { voidptr(&args[1]) }
+		},
+		workers.Task{
+			run:        collect_declaration_index_thread
+			arg:        unsafe { voidptr(&args[2]) }
+			force_sync: true
+		},
+	])
 	return true
 }
 
@@ -842,7 +902,12 @@ fn (mut tc TypeChecker) collect_parallel_check_items() []CheckWorkItem {
 				tc.enter_module(node.value)
 			}
 			.fn_decl {
-				cost := i - prev_tl
+				span := i - prev_tl
+				cost := if i < tc.fn_check_costs.len && tc.fn_check_costs[i] > 0 {
+					tc.fn_check_costs[i]
+				} else {
+					span
+				}
 				items << CheckWorkItem{
 					fn_idx:   i
 					range_lo: prev_tl + 1
@@ -2687,6 +2752,19 @@ fn (mut tc TypeChecker) merge_parallel_check_worker(w &TypeChecker) {
 }
 
 fn (mut tc TypeChecker) merge_parallel_check_worker_scoped(w &TypeChecker, scoped bool) {
+	// Scoped checkers use a private symbol interner. Translate each distinct
+	// spelling once per worker, then replay dependency edges with O(1) ids; the
+	// old per-edge name+intern path repeated the same locked hash probes across
+	// thousands of call sites.
+	mut symbol_remap := []SymbolId{}
+	if scoped && !isnil(w.symbols) {
+		worker_symbols := unsafe { w.symbols }
+		symbol_remap = []SymbolId{len: worker_symbols.names.len + 1}
+		for index, name in worker_symbols.names {
+			id, _ := tc.intern_scoped_symbol(name)
+			symbol_remap[index + 1] = id
+		}
+	}
 	for err in w.errors {
 		tc.errors << if scoped { clone_parallel_type_error(err) } else { err }
 	}
@@ -2734,11 +2812,36 @@ fn (mut tc TypeChecker) merge_parallel_check_worker_scoped(w &TypeChecker, scope
 		tc.expr_type_set[idx] = true
 	}
 	for fn_idx, dependencies in w.direct_dependencies_by_fn {
+		if fn_idx !in tc.direct_dependencies_by_fn {
+			if scoped {
+				mut owned := []SymbolId{cap: dependencies.len}
+				for dependency in dependencies {
+					dependency_index := int(dependency)
+					if dependency_index > 0 && dependency_index < symbol_remap.len {
+						owned << symbol_remap[dependency_index]
+					} else {
+						id, _ := tc.intern_scoped_symbol(w.symbol_name(dependency))
+						owned << id
+					}
+				}
+				if owned.len > 0 {
+					tc.direct_dependencies_by_fn[fn_idx] = owned
+				}
+			} else if dependencies.len > 0 {
+				tc.direct_dependencies_by_fn[fn_idx] = dependencies
+			}
+			continue
+		}
 		mut merged := tc.direct_dependencies_by_fn[fn_idx] or { []SymbolId{} }
 		for dependency in dependencies {
 			owned_dependency := if scoped {
-				id, _ := tc.intern_symbol(w.symbol_name(dependency))
-				id
+				dependency_index := int(dependency)
+				if dependency_index > 0 && dependency_index < symbol_remap.len {
+					symbol_remap[dependency_index]
+				} else {
+					id, _ := tc.intern_scoped_symbol(w.symbol_name(dependency))
+					id
+				}
 			} else {
 				dependency
 			}


### PR DESCRIPTION
## Summary

- keep the V3 self-host frontend busy across all 18 execution lanes (17 persistent workers plus the caller)
- overlap checker declaration indexing, markused preparation, parser interning, and transform planning with independent work
- split transform work into finer waves and move safe cgen preparation, declarations, interface stubs, and init generation off the serial tail
- avoid redundant whole-AST scans, clones, deduplication, and cgen support precomputation in the no-cache self-host path

## Benchmark

From `vlib/v3`:

```sh
../../v -gc none -prealloc -prod -o v3 v3.v
./v3 -nocache -building-v -o v4 v3.v
```

Frontend time excludes the reported `tcc` stage.

| Revision | Frontend |
| --- | ---: |
| master baseline | 498.76 ms |
| this branch, 7-run warm median | 399.26 ms |
| this branch, best | 397.04 ms |

Five of seven final warm runs were below 400 ms. The compiler reports 17 persistent worker threads; the caller participates as the 18th execution lane.

## Validation

- `./vnew -silent vlib/v3/tests/parallel_determinism_test.v`
- `./vnew -silent vlib/v3/tests/parallel_cgen_test.v`
- `./vnew -silent vlib/v3/tests/parallel_parser_test.v`
- `./vnew -silent vlib/v3/types/checker_parallel_test.v`
- `./vnew -silent vlib/v3/transform/transform_parallel_test.v`
- `./vnew -silent vlib/v3/markused/custom_str_test.v`
- `./vnew -silent vlib/v3/gen/c/parallel_worker_test.v`
- `./vnew -gc none -d v3_no_parallel -o /tmp/v3_no_parallel_final vlib/v3/v3.v`
- `./vnew -silent vlib/v/gen/c/coutput_test.v` (106 output fixtures and 141 C pattern files)
- `./vnew -silent vlib/v/compiler_errors_test.v` remains baseline-red in existing V1 module-diagnostic fixtures: 1610 passed, 8 failed, 1 skipped; `./v` reproduces the same fixture area with 1611 passed, 7 failed, 1 skipped
