### PR TITLE
v3: avoid repeated linear AST and signature scans

### DIFF
--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -5091,7 +5091,7 @@ fn promote_scoped_signatures(mut tc types.TypeChecker, original_names map[string
 		tc.specialized_generic_fns.delete(name)
 		owned_name := name.clone()
 		tc.fn_ret_types[owned_name] = ret
-		tc.fn_param_types[owned_name] = params
+		tc.register_generated_fn_param_types(owned_name, params)
 		tc.fn_variadic[owned_name] = variadic
 		if specialized {
 			tc.specialized_generic_fns[owned_name] = true
@@ -5101,6 +5101,8 @@ fn promote_scoped_signatures(mut tc types.TypeChecker, original_names map[string
 	// string-key text or nested type metadata is allocated in the disposable
 	// stage arena. Rebuild all signature ownership before releasing that arena.
 	tc.rebuild_scoped_transform_signature_maps()
+	// Re-own suffix keys/values after the scoped signatures above are promoted.
+	tc.rebuild_fn_param_suffix_index()
 }
 
 // default_cc_identity returns a precise identity for the resolved default `cc`.
@@ -8035,7 +8037,7 @@ pub fn run(args []string) {
 		} else {
 			b.step_parallel('transform', transform_was_parallel)
 		}
-		pre_tc.invalidate_direct_parent_index()
+		pre_tc.refresh_rewritten_parent_index(a)
 		if transform_errors.len > 0 {
 			eprintln('type checker found ${transform_errors.len} error(s):')
 			for message in transform_errors {

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -8181,6 +8181,7 @@ pub fn run(args []string) {
 			}
 			promote_scoped_checker_node_caches(mut pre_tc, a, monomorph_scope, base_monomorph_nodes)
 			pre_tc.rebuild_scoped_transform_signature_maps()
+			pre_tc.rebuild_fn_param_suffix_index()
 			pre_tc.promote_scoped_transform_interners(0, 0, monomorph_scope)
 			promote_scoped_type_metadata(mut pre_tc)
 			pre_tc.errors = clone_type_errors(pre_tc.errors)

--- a/vlib/v3/transform/expr.v
+++ b/vlib/v3/transform/expr.v
@@ -2922,7 +2922,7 @@ fn (mut t Transformer) register_sum_eq_helper_signature(helper string, clean_sum
 		ret := t.tc.parse_type('bool')
 		params := [t.tc.parse_type(clean_sum), t.tc.parse_type(clean_sum)]
 		t.tc.fn_ret_types[helper] = ret
-		t.tc.fn_param_types[helper] = params.clone()
+		t.tc.register_generated_fn_param_types(helper, params.clone())
 		t.tc.fn_variadic[helper] = false
 	}
 }

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -4931,8 +4931,8 @@ fn (mut t Transformer) build_auto_str_helper_fn(aggregate string) {
 		t.tc.ensure_private_transform_signatures()
 		t.tc.fn_ret_types[helper] = t.tc.parse_type('string')
 		t.tc.fn_ret_types[helper_key] = t.tc.parse_type('string')
-		t.tc.fn_param_types[helper] = [t.tc.parse_type(aggregate)]
-		t.tc.fn_param_types[helper_key] = [t.tc.parse_type(aggregate)]
+		t.tc.register_generated_fn_param_types(helper, [t.tc.parse_type(aggregate)])
+		t.tc.register_generated_fn_param_types(helper_key, [t.tc.parse_type(aggregate)])
 		t.tc.fn_variadic[helper] = false
 		t.tc.fn_variadic[helper_key] = false
 	}
@@ -8045,7 +8045,7 @@ fn (mut t Transformer) build_default_clone_helper_fn(typ string) {
 	t.mark_fn_used_name(helper)
 	if !isnil(t.tc) {
 		t.tc.fn_ret_types[helper] = t.tc.parse_type(typ)
-		t.tc.fn_param_types[helper] = [t.tc.parse_type('voidptr')]
+		t.tc.register_generated_fn_param_types(helper, [t.tc.parse_type('voidptr')])
 		t.tc.fn_variadic[helper] = false
 	}
 }
@@ -9856,13 +9856,13 @@ fn (mut t Transformer) lift_fn_literal(_id flat.NodeId, node flat.Node) flat.Nod
 		t.tc.ensure_private_transform_signatures()
 		ret := t.tc.parse_type(ret_type)
 		t.tc.fn_ret_types[name] = ret
-		t.tc.fn_param_types[name] = param_types.clone()
+		t.tc.register_generated_fn_param_types(name, param_types.clone())
 		t.tc.fn_variadic[name] = false
 		t.add_receiver_method_suffix_index(name)
 		if t.cur_module.len > 0 && t.cur_module != 'main' && t.cur_module != 'builtin' {
 			qname := '${t.cur_module}.${name}'
 			t.tc.fn_ret_types[qname] = ret
-			t.tc.fn_param_types[qname] = param_types.clone()
+			t.tc.register_generated_fn_param_types(qname, param_types.clone())
 			t.tc.fn_variadic[qname] = false
 			t.add_receiver_method_suffix_index(qname)
 		}

--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -4098,7 +4098,7 @@ fn (mut t Transformer) register_specialized_fn_signature_value(decl GenericFnDec
 		t.record_generic_specialization_args_for_names(names, args)
 		for name in names {
 			t.tc.fn_ret_types[name] = ret
-			t.tc.fn_param_types[name] = params.clone()
+			t.tc.register_generated_fn_param_types(name, params.clone())
 			t.tc.fn_variadic[name] = variadic
 			t.tc.fn_type_modules[name] = decl.module
 			t.tc.fn_type_files[name] = decl.file
@@ -5445,6 +5445,9 @@ fn (mut t Transformer) erase_generic_fn_decls(decls map[string]GenericFnDecl) {
 			})
 			t.clear_typechecker_node_cache(idx)
 		}
+	}
+	if !isnil(t.tc) && decls.len > 0 {
+		t.tc.rebuild_fn_param_suffix_index()
 	}
 }
 

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -3910,7 +3910,7 @@ fn (mut t Transformer) merge_worker_signatures(w &Transformer) {
 		owned_name := name.clone()
 		master_tc.fn_ret_types[owned_name] = types.clone_owned_type(ret)
 		if params := w.tc.fn_param_types[name] {
-			master_tc.fn_param_types[owned_name] = types.clone_owned_types(params)
+			master_tc.register_generated_fn_param_types(owned_name, types.clone_owned_types(params))
 		}
 		master_tc.fn_variadic[owned_name] = w.tc.fn_variadic[name]
 		if w.tc.specialized_generic_fns[name] {

--- a/vlib/v3/transform/transform_parallel_test.v
+++ b/vlib/v3/transform/transform_parallel_test.v
@@ -70,6 +70,31 @@ fn test_merge_worker_shifts_private_specialization_metadata() {
 	assert master.a.specialized_fn_files[int(base_id)] == 'base.v'
 }
 
+fn test_merge_worker_signatures_updates_checker_method_suffix_index() {
+	mut a := flat.FlatAst.new()
+	mut tc := types.TypeChecker.new(&a)
+	mut master := new_transformer(mut a, &tc, map[string]bool{})
+
+	worker_ast := master.clone_ast_base(master.a.nodes.len, master.a.children.len)
+	mut worker_tc := tc.fork_for_parallel_transform(worker_ast)
+	worker_tc.ensure_private_transform_signatures()
+	worker_tc.fn_ret_types['widgets.Box.open'] = types.Type(types.bool_)
+	params := [types.Type(types.int_)]
+	worker_tc.register_generated_fn_param_types('widgets.Box.open', params)
+	worker := master.fork_worker(worker_ast, worker_tc)
+
+	assert 'widgets.Box.open' !in master.tc.fn_ret_types
+	assert 'widgets.Box.open' !in master.tc.fn_param_types
+	assert 'Box.open' !in master.tc.receiver_method_suffix_index
+	assert worker.tc.receiver_method_suffix_index['Box.open'] == 'widgets.Box.open'
+	master.merge_worker_signatures(worker)
+
+	assert master.tc.fn_param_types_for_name('widgets.Box.open') == params
+	assert master.tc.receiver_method_suffix_index['Box.open'] == 'widgets.Box.open'
+	assert master.tc.fn_param_types_for_name('Box.open') == params
+	assert master.tc.fn_param_types_for_name('open') == params
+}
+
 fn test_transform_ast_clone_preserves_template_metadata() {
 	mut a := flat.FlatAst.new()
 	a.template_call_sites[7] = token.new_pos(3, 11)

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -1415,6 +1415,7 @@ pub fn (mut tc TypeChecker) ensure_private_transform_signatures() {
 	if tc.transform_signature_maps_shared {
 		tc.fn_ret_types = tc.fn_ret_types.clone()
 		tc.fn_param_types = tc.fn_param_types.clone()
+		tc.receiver_method_suffix_index = tc.receiver_method_suffix_index.clone()
 		tc.fn_variadic = tc.fn_variadic.clone()
 		tc.specialized_generic_fns = tc.specialized_generic_fns.clone()
 		tc.fn_type_modules = tc.fn_type_modules.clone()

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -6151,7 +6151,9 @@ pub fn (mut tc TypeChecker) register_generated_fn_param_types(name string, param
 // rebuild_fn_param_suffix_index refreshes the suffix index after a batch
 // replaces or removes synthesized signatures.
 pub fn (mut tc TypeChecker) rebuild_fn_param_suffix_index() {
-	tc.receiver_method_suffix_index.clear()
+	// Allocate a new map so callers rebuilding after a disposable prealloc
+	// scope do not retain its keys, values, or backing storage.
+	tc.receiver_method_suffix_index = map[string]string{}
 	tc.receiver_method_suffix_index.reserve(u32(tc.fn_param_types.len * 3))
 	for name, _ in tc.fn_param_types {
 		tc.add_receiver_method_suffix_index(name)

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -902,6 +902,7 @@ mut:
 	// checker workers. Transformed or appended nodes use the scan fallback in
 	// direct_parent_id.
 	direct_parent_ids           []flat.NodeId
+	rewritten_parent_ids        []flat.NodeId
 	value_used_nodes            []bool
 	direct_parent_index_trusted bool
 	has_goto_nodes              bool
@@ -1246,6 +1247,7 @@ fn (tc &TypeChecker) fork_program_view(ast &flat.FlatAst, direct_dependencies_by
 		top_level_idx:                      tc.top_level_idx
 		top_level_idx_nodes_len:            tc.top_level_idx_nodes_len
 		direct_parent_ids:                  tc.direct_parent_ids
+		rewritten_parent_ids:               tc.rewritten_parent_ids
 		value_used_nodes:                   tc.value_used_nodes
 		direct_parent_index_trusted:        tc.direct_parent_index_trusted
 		has_goto_nodes:                     tc.has_goto_nodes
@@ -1621,6 +1623,7 @@ fn (mut tc TypeChecker) reset_node_caches(n int) {
 
 fn (mut tc TypeChecker) init_direct_parent_index(a &flat.FlatAst) {
 	tc.direct_parent_ids = []flat.NodeId{len: a.nodes.len, init: flat.empty_node}
+	tc.rewritten_parent_ids = []flat.NodeId{}
 	tc.value_used_nodes = []bool{len: a.nodes.len}
 	tc.declaration_attributes = map[int][]string{}
 	tc.insert_include_dirs_by_file = map[string][]string{}
@@ -1707,6 +1710,28 @@ pub fn (mut tc TypeChecker) reuse_direct_parent_index_for_unchanged_ast(a &flat.
 
 // invalidate_direct_parent_index makes generated-node lookups validate parent metadata.
 pub fn (mut tc TypeChecker) invalidate_direct_parent_index() {
+	tc.direct_parent_index_trusted = false
+}
+
+// refresh_rewritten_parent_index rebuilds the node-parent edges after transform
+// without resetting declaration metadata collected during semantic checking.
+// Rewritten trees can contain hundreds of thousands of new nodes; leaving those
+// nodes outside direct_parent_ids makes every parent query scan the whole AST.
+pub fn (mut tc TypeChecker) refresh_rewritten_parent_index(a &flat.FlatAst) {
+	// Lexical smartcasts deliberately apply only to parsed source nodes, so keep
+	// direct_parent_ids at its original length and index appended nodes separately.
+	tc.rewritten_parent_ids = []flat.NodeId{len: a.nodes.len, init: flat.empty_node}
+	for parent_idx, node in a.nodes {
+		for child_idx in 0 .. node.children_count {
+			idx := int(a.child(&node, child_idx))
+			if idx >= tc.direct_parent_ids.len && idx < tc.rewritten_parent_ids.len
+				&& tc.rewritten_parent_ids[idx] == flat.empty_node {
+				tc.rewritten_parent_ids[idx] = flat.NodeId(parent_idx)
+			}
+		}
+	}
+	// Keep validation enabled because transformed trees may intentionally share
+	// a node or rewrite an edge after this index is built.
 	tc.direct_parent_index_trusted = false
 }
 
@@ -6115,6 +6140,23 @@ fn (mut tc TypeChecker) register_fn_ancillary_owned(name string, shared_params [
 	tc.add_receiver_method_suffix_index(name)
 }
 
+// register_generated_fn_param_types records a synthesized function signature
+// and keeps the receiver/method suffix index complete for post-check phases.
+pub fn (mut tc TypeChecker) register_generated_fn_param_types(name string, params []Type) {
+	tc.fn_param_types[name] = params
+	tc.add_receiver_method_suffix_index(name)
+}
+
+// rebuild_fn_param_suffix_index refreshes the suffix index after a batch
+// replaces or removes synthesized signatures.
+pub fn (mut tc TypeChecker) rebuild_fn_param_suffix_index() {
+	tc.receiver_method_suffix_index.clear()
+	tc.receiver_method_suffix_index.reserve(u32(tc.fn_param_types.len * 3))
+	for name, _ in tc.fn_param_types {
+		tc.add_receiver_method_suffix_index(name)
+	}
+}
+
 fn (mut tc TypeChecker) register_fn_ret_type_text(name string, text string) {
 	if tc.defer_fn_ancillary {
 		tc.fn_ret_text_registrations << FnTextRegistration{
@@ -7652,6 +7694,13 @@ pub fn (tc &TypeChecker) fn_param_types_for_name(name string) []Type {
 		if params := tc.fn_param_types[indexed] {
 			return params
 		}
+	}
+	// add_receiver_method_suffix_index records every source declaration, while
+	// register_generated_fn_param_types records post-check synthesized functions.
+	// A missing key is therefore a definitive miss. Keep the scan only behind the
+	// existing compatibility switch for diagnosing index construction issues.
+	if tc.method_suffix_prescreen {
+		return []Type{}
 	}
 	mut found := []Type{}
 	mut matches := 0

--- a/vlib/v3/types/checker_comptime.v
+++ b/vlib/v3/types/checker_comptime.v
@@ -9421,7 +9421,9 @@ fn (tc &TypeChecker) direct_parent_id(id flat.NodeId) flat.NodeId {
 				}
 			}
 		}
-		return flat.empty_node
+		// A later rewrite may replace the first recorded edge while another
+		// parent still references this shared generated node. Fall through to
+		// the arena scan when the indexed edge is stale.
 	}
 	for parent_idx, candidate in tc.a.nodes {
 		for i in 0 .. candidate.children_count {

--- a/vlib/v3/types/checker_comptime.v
+++ b/vlib/v3/types/checker_comptime.v
@@ -9411,6 +9411,18 @@ fn (tc &TypeChecker) direct_parent_id(id flat.NodeId) flat.NodeId {
 		// entire arena for every type query makes parallel transform quadratic.
 		return flat.empty_node
 	}
+	if idx >= 0 && idx < tc.rewritten_parent_ids.len {
+		parent_id := tc.rewritten_parent_ids[idx]
+		if parent_id != flat.empty_node {
+			parent := tc.a.node(parent_id)
+			for i in 0 .. parent.children_count {
+				if tc.a.child(parent, i) == id {
+					return parent_id
+				}
+			}
+		}
+		return flat.empty_node
+	}
 	for parent_idx, candidate in tc.a.nodes {
 		for i in 0 .. candidate.children_count {
 			if tc.a.child(&candidate, i) == id {

--- a/vlib/v3/types/checker_ownership_d_ownership.v
+++ b/vlib/v3/types/checker_ownership_d_ownership.v
@@ -7862,6 +7862,11 @@ fn ownership_assoc_base_descendant_overridden(source_prefix string, source_name 
 
 fn (tc &TypeChecker) ownership_struct_decl_node(struct_name string) ?flat.Node {
 	target := generic_base_name(struct_name)
+	if decl := tc.source_struct_decl_for_name(target) {
+		return decl
+	}
+	// Keep the historical spelling fallback for synthesized declarations that
+	// were appended after the immutable source declaration index was built.
 	mut cur_module := ''
 	for i in tc.top_level_idx {
 		node := tc.a.nodes[i]

--- a/vlib/v3/types/checker_parallel_test.v
+++ b/vlib/v3/types/checker_parallel_test.v
@@ -100,6 +100,31 @@ fn test_direct_parent_index_preserves_first_parent_and_falls_back_for_new_nodes(
 	})
 	assert !tc.reuse_direct_parent_index_for_unchanged_ast(&a)
 	assert tc.direct_parent_id(appended_child) == appended_parent
+
+	tc.refresh_rewritten_parent_index(&a)
+	assert tc.direct_parent_ids.len < a.nodes.len
+	assert tc.rewritten_parent_ids.len == a.nodes.len
+	assert !tc.direct_parent_index_trusted
+	assert tc.direct_parent_id(child) == first_parent
+	assert tc.direct_parent_id(appended_child) == appended_parent
+}
+
+fn test_generated_fn_params_update_method_suffix_index() {
+	a := flat.FlatAst.new()
+	mut tc := TypeChecker.new(&a)
+	params := [Type(int_)]
+	tc.register_generated_fn_param_types('widgets.Box.open', params)
+
+	assert tc.fn_param_types_for_name('Box.open') == params
+	assert tc.fn_param_types_for_name('open') == params
+
+	tc.register_generated_fn_param_types('other.Door.open', [Type(string_)])
+	assert tc.fn_param_types_for_name('open').len == 0
+	assert tc.fn_param_types_for_name('Box.open') == params
+
+	tc.fn_param_types.delete('other.Door.open')
+	tc.rebuild_fn_param_suffix_index()
+	assert tc.fn_param_types_for_name('open') == params
 }
 
 fn test_enclosing_generic_param_uses_the_owning_top_level_declaration() {

--- a/vlib/v3/types/checker_parallel_test.v
+++ b/vlib/v3/types/checker_parallel_test.v
@@ -109,6 +109,35 @@ fn test_direct_parent_index_preserves_first_parent_and_falls_back_for_new_nodes(
 	assert tc.direct_parent_id(appended_child) == appended_parent
 }
 
+fn test_rewritten_parent_index_falls_back_from_a_stale_shared_edge() {
+	mut a := flat.FlatAst.new()
+	mut tc := TypeChecker.new(&a)
+	tc.build_direct_parent_index(&a)
+
+	shared_child := a.add_val(.ident, 'shared')
+	replacement := a.add_val(.ident, 'replacement')
+	first_children := a.begin_children()
+	a.add_child(shared_child)
+	first_parent := a.add_node(flat.Node{
+		kind:           .paren
+		children_start: first_children
+		children_count: 1
+	})
+	second_children := a.begin_children()
+	a.add_child(shared_child)
+	second_parent := a.add_node(flat.Node{
+		kind:           .expr_stmt
+		children_start: second_children
+		children_count: 1
+	})
+
+	tc.refresh_rewritten_parent_index(&a)
+	assert tc.direct_parent_id(shared_child) == first_parent
+
+	a.children[first_children] = replacement
+	assert tc.direct_parent_id(shared_child) == second_parent
+}
+
 fn test_generated_fn_params_update_method_suffix_index() {
 	a := flat.FlatAst.new()
 	mut tc := TypeChecker.new(&a)

--- a/vlib/v3/types/checker_scoped_transform_test.v
+++ b/vlib/v3/types/checker_scoped_transform_test.v
@@ -101,21 +101,24 @@ fn signature_map_storage_owned_by_scope(scope voidptr, layout &SignatureMapLayou
 	}
 }
 
-fn test_rebuild_scoped_transform_signature_maps_after_growth() {
+fn test_rebuild_scoped_transform_signatures_and_suffix_index_after_growth() {
 	$if prealloc {
 		a := flat.FlatAst.new()
 		mut tc := TypeChecker.new(&a)
 		scope := unsafe { prealloc_scope_begin() }
+		// Model a transform that leaves enough scoped map capacity for the
+		// subsequent suffix rebuild to reuse unless it explicitly replaces the map.
+		tc.receiver_method_suffix_index.reserve(65536)
 		for i in 0 .. 4096 {
-			name := 'generated_signature_${i}'
+			name := 'generated.Box_${i}.open'
 			tc.fn_ret_types[name] = Type(Struct{
 				name: 'GeneratedResult_${i}'
 			})
-			tc.fn_param_types[name] = [
+			tc.register_generated_fn_param_types(name, [
 				Type(Struct{
 					name: 'GeneratedParam_${i}'
 				}),
-			]
+			])
 			tc.fn_variadic[name] = false
 			tc.specialized_generic_fns[name] = true
 		}
@@ -123,25 +126,30 @@ fn test_rebuild_scoped_transform_signature_maps_after_growth() {
 		params_scoped := unsafe { &SignatureMapLayoutForTest(&tc.fn_param_types) }
 		variadic_scoped := unsafe { &SignatureMapLayoutForTest(&tc.fn_variadic) }
 		specialized_scoped := unsafe { &SignatureMapLayoutForTest(&tc.specialized_generic_fns) }
+		suffix_scoped := unsafe { &SignatureMapLayoutForTest(&tc.receiver_method_suffix_index) }
 		assert signature_map_storage_owned_by_scope(scope, ret_scoped)
 		assert signature_map_storage_owned_by_scope(scope, params_scoped)
 		assert signature_map_storage_owned_by_scope(scope, variadic_scoped)
 		assert signature_map_storage_owned_by_scope(scope, specialized_scoped)
+		assert signature_map_storage_owned_by_scope(scope, suffix_scoped)
 
 		unsafe { prealloc_scope_leave(scope) }
 		tc.rebuild_scoped_transform_signature_maps()
+		tc.rebuild_fn_param_suffix_index()
 		ret_rebuilt := unsafe { &SignatureMapLayoutForTest(&tc.fn_ret_types) }
 		params_rebuilt := unsafe { &SignatureMapLayoutForTest(&tc.fn_param_types) }
 		variadic_rebuilt := unsafe { &SignatureMapLayoutForTest(&tc.fn_variadic) }
 		specialized_rebuilt := unsafe { &SignatureMapLayoutForTest(&tc.specialized_generic_fns) }
+		suffix_rebuilt := unsafe { &SignatureMapLayoutForTest(&tc.receiver_method_suffix_index) }
 		assert !signature_map_storage_owned_by_scope(scope, ret_rebuilt)
 		assert !signature_map_storage_owned_by_scope(scope, params_rebuilt)
 		assert !signature_map_storage_owned_by_scope(scope, variadic_rebuilt)
 		assert !signature_map_storage_owned_by_scope(scope, specialized_rebuilt)
+		assert !signature_map_storage_owned_by_scope(scope, suffix_rebuilt)
 		unsafe { prealloc_scope_free_after(scope) }
 
 		for idx in [0, 2048, 4095] {
-			name := 'generated_signature_${idx}'
+			name := 'generated.Box_${idx}.open'
 			ret := tc.fn_ret_types[name] or { Type(void_) }
 			assert ret is Struct
 			assert ret.name == 'GeneratedResult_${idx}'
@@ -150,6 +158,11 @@ fn test_rebuild_scoped_transform_signature_maps_after_growth() {
 			param := params[0]
 			assert param is Struct
 			assert param.name == 'GeneratedParam_${idx}'
+			suffix_params := tc.fn_param_types_for_name('Box_${idx}.open')
+			assert suffix_params.len == 1
+			suffix_param := suffix_params[0]
+			assert suffix_param is Struct
+			assert suffix_param.name == 'GeneratedParam_${idx}'
 			assert !tc.fn_variadic[name]
 			assert tc.specialized_generic_fns[name]
 		}


### PR DESCRIPTION
## What this changes

This removes three linear-scan hot paths found while profiling a full ownership
build of ripgrep.v:

- index parent edges for transform-appended nodes instead of scanning the full
  AST on every generated-node parent lookup;
- keep the method-suffix index authoritative when transform and
  monomorphization add, remove, or merge synthesized function signatures;
- use the existing source declaration index before the ownership checker falls
  back to scanning struct declarations.

The parsed-source parent index remains separate so lexical smartcast behavior is
unchanged. Rewritten parent edges are validated before use, and stale generated
edges fall back to the arena scan so shared nodes can resolve a surviving parent.
Synthesized declarations retain their historical scan fallback. Parallel checker
forks detach the method-suffix index with their other signature tables, and the
serial master merge registers each worker-generated parameter signature in that
index. Scoped monomorphization rebuilds that index in the parent arena before
freeing its disposable preallocation arena.

## Performance

Measured on an Apple M5 Max running macOS 26.5. Both compilers were built with
prod, gc none, and ownership support. Every ripgrep.v build used ownership,
nocache, and an empty output path.

| ripgrep.v build | master 702dbc602 | this PR 7092e5c1a |
| --- | ---: | ---: |
| Debug/default, wall time | 6.12 s | 1.85 s |
| Production, wall time | 16.57 s | 13.41 s |
| Production V3 frontend, excluding external C compiler | 4.21 s | 1.58 s |

The production frontend is 2.67x faster (62.5% less time). The largest stage
changes were:

| Stage | master | this PR |
| --- | ---: | ---: |
| Check | 1,056.48 ms | 445.50 ms |
| Annotate types | 1,252.01 ms | 268.31 ms |
| Monomorphize | 1,400.29 ms | 391.22 ms |

The workload parses 268 files and 98,614 lines, including ripgrep.v and imported
V library modules.

## Validation

- ./vnew -old-compiler -silent test vlib/v3/transform/ (7/7 passed)
- ./vnew -old-compiler -silent test vlib/v3/types/ (9/9 passed)
- prealloc scoped-signature ownership regression passed
- prealloc generic-interface specialization compiled and ran successfully
- production V3 built with -prod -gc none -d ownership
- that V3 compiled ripgrep.v with -nocache -d ownership -ownership -prod
- the resulting ripgrep 15.1.0 executable ran successfully
- v fmt -verify on all changed V files
- git diff --check
