### PR TITLE
v3: optimize monomorphization for large programs

### DIFF
--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -8150,8 +8150,8 @@ pub fn run(args []string) {
 			base_specialized_fns := a.specialized_fn_nodes.len
 			monomorph_scope := prealloc_scope_begin_for_v3()
 			monomorph_used_fns, monomorph_errors, generated_monomorph_specs = transform.monomorphize_with_used_checked_config_scoped_cached(mut a,
-				&pre_tc, monomorph_input_used, should_parallel_monomorphize()
-				&& cache_state.parsed_from_source.len == 0, monomorph_scope, cached_monomorph_specs)
+				&pre_tc, monomorph_input_used, should_parallel_monomorphize(), monomorph_scope,
+				cached_monomorph_specs)
 			parse_cache_enabled := pre_tc.type_cache_parse_enabled()
 			prealloc_scope_leave_for_v3(monomorph_scope)
 			// Specialization can rewrite payload text on pre-existing nodes as
@@ -8191,8 +8191,11 @@ pub fn run(args []string) {
 		} else {
 			monomorph_used_fns, monomorph_errors, generated_monomorph_specs = transform.monomorphize_with_used_checked_config_scoped_cached(mut a,
 				&pre_tc, monomorph_input_used, should_parallel_monomorphize()
-				&& cache_state.parsed_from_source.len == 0, unsafe { nil }, cached_monomorph_specs)
+				&& !incremental_cache_hit, unsafe { nil }, cached_monomorph_specs)
 		}
+		// Monomorphization publishes every synthesized or rewritten AST string
+		// after its final worker merge, including the serial/no-worker path.
+		transform_texts_canonical = true
 		if incremental_cache_hit {
 			incremental_stage_used_fns = monomorph_used_fns.move()
 			for idx in incremental_monomorph_node_start .. a.nodes.len {

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -16282,6 +16282,8 @@ fn (mut g FlatGen) headerless_libc_preamble() {
 	g.headerless_darwin_task_info_struct()
 	g.writeln('#ifdef __APPLE__')
 	g.writeln('typedef struct mach_timebase_info_data_t { u32 numer; u32 denom; } mach_timebase_info_data_t;')
+	g.writeln('u64 mach_absolute_time(void);')
+	g.writeln('int mach_timebase_info(mach_timebase_info_data_t*);')
 	g.writeln('#endif')
 	g.headerless_utsname_struct()
 	g.headerless_stat_struct()

--- a/vlib/v3/gen/c/interface.v
+++ b/vlib/v3/gen/c/interface.v
@@ -2361,7 +2361,9 @@ fn (mut g FlatGen) interface_struct_str_expr(struct_name string, expr string, mu
 	}
 	tmp := g.interface_tmp('iface_str_struct')
 	out := g.interface_tmp('iface_str_out')
-	ct := g.cname(struct_name)
+	ct := g.tc.c_type(types.Type(types.Struct{
+		name: struct_name
+	}))
 	mut body := '${ct} ${tmp} = ${expr}; string ${out} = ${g.interface_str_lit('${display_name}{\n')};'
 	for field in fields {
 		field_expr := '${tmp}.${c_field_name(field.name)}'

--- a/vlib/v3/gen/c/types.v
+++ b/vlib/v3/gen/c/types.v
@@ -446,6 +446,31 @@ fn (mut g FlatGen) collect_declaration_signature_types() {
 	if g.decl_types_ready {
 		return
 	}
+	// Parallel monomorph workers can append concrete declarations before their
+	// checker signature maps are merged. Read declaration nodes directly too, so
+	// an option/result used only by a worker specialization still gets a typedef.
+	for idx, node in g.a.nodes {
+		if node.kind != .fn_decl {
+			continue
+		}
+		concrete_optional := g.a.specialized_fn_nodes[idx]
+			|| g.name_uses_specialized_generic_abi(node.value)
+		if !concrete_optional {
+			continue
+		}
+		if node.typ.len > 0 {
+			g.collect_declaration_signature_type_for_context(g.tc.parse_type(node.typ),
+				concrete_optional)
+		}
+		for i in 0 .. node.children_count {
+			param := g.a.child_node(&node, i)
+			if param.kind != .param {
+				break
+			}
+			g.collect_declaration_signature_type_for_context(g.tc.parse_type(param.typ),
+				concrete_optional)
+		}
+	}
 	for name, ret in g.tc.fn_ret_types {
 		// Generic template signatures keep unspecialized placeholder types
 		// (`!&Tls[T]`); their typedefs would reference C types that are never
@@ -491,6 +516,10 @@ fn (mut g FlatGen) collect_declaration_signature_types() {
 }
 
 fn (mut g FlatGen) collect_declaration_signature_type(t types.Type) {
+	g.collect_declaration_signature_type_for_context(t, false)
+}
+
+fn (mut g FlatGen) collect_declaration_signature_type_for_context(t types.Type, concrete_optional bool) {
 	// Erased-template signatures keep their placeholder spellings in the
 	// checker tables even when the program itself uses no generics
 	// (skip_generics); force the placeholder check so an unused template's
@@ -502,7 +531,7 @@ fn (mut g FlatGen) collect_declaration_signature_type(t types.Type) {
 	if skip {
 		return
 	}
-	g.collect_concrete_optional_typedef_type(t)
+	g.collect_concrete_optional_typedef_type_for_context(t, concrete_optional)
 	g.collect_known_concrete_multi_return_type(t)
 }
 
@@ -514,43 +543,55 @@ fn (mut g FlatGen) collect_optional_typedef_type(t types.Type) {
 }
 
 fn (mut g FlatGen) collect_concrete_optional_typedef_type(t types.Type) {
+	g.collect_concrete_optional_typedef_type_for_context(t, false)
+}
+
+fn (mut g FlatGen) collect_concrete_optional_typedef_type_for_context(t types.Type, concrete_optional bool) {
 	match t {
 		types.OptionType {
-			g.optional_type_name(t)
-			g.collect_concrete_optional_typedef_type(t.base_type)
+			if concrete_optional {
+				g.concrete_optional_type_name(t)
+			} else {
+				g.optional_type_name(t)
+			}
+			g.collect_concrete_optional_typedef_type_for_context(t.base_type, concrete_optional)
 		}
 		types.ResultType {
-			g.optional_type_name(t)
-			g.collect_concrete_optional_typedef_type(t.base_type)
+			if concrete_optional {
+				g.concrete_optional_type_name(t)
+			} else {
+				g.optional_type_name(t)
+			}
+			g.collect_concrete_optional_typedef_type_for_context(t.base_type, concrete_optional)
 		}
 		types.Array {
-			g.collect_concrete_optional_typedef_type(t.elem_type)
+			g.collect_concrete_optional_typedef_type_for_context(t.elem_type, concrete_optional)
 		}
 		types.ArrayFixed {
-			g.collect_concrete_optional_typedef_type(t.elem_type)
+			g.collect_concrete_optional_typedef_type_for_context(t.elem_type, concrete_optional)
 		}
 		types.Channel {
-			g.collect_concrete_optional_typedef_type(t.elem_type)
+			g.collect_concrete_optional_typedef_type_for_context(t.elem_type, concrete_optional)
 		}
 		types.Map {
-			g.collect_concrete_optional_typedef_type(t.key_type)
-			g.collect_concrete_optional_typedef_type(t.value_type)
+			g.collect_concrete_optional_typedef_type_for_context(t.key_type, concrete_optional)
+			g.collect_concrete_optional_typedef_type_for_context(t.value_type, concrete_optional)
 		}
 		types.Pointer {
-			g.collect_concrete_optional_typedef_type(t.base_type)
+			g.collect_concrete_optional_typedef_type_for_context(t.base_type, concrete_optional)
 		}
 		types.FnType {
 			for param in t.params {
-				g.collect_concrete_optional_typedef_type(param)
+				g.collect_concrete_optional_typedef_type_for_context(param, concrete_optional)
 			}
-			g.collect_concrete_optional_typedef_type(t.return_type)
+			g.collect_concrete_optional_typedef_type_for_context(t.return_type, concrete_optional)
 		}
 		types.Alias {
-			g.collect_concrete_optional_typedef_type(t.base_type)
+			g.collect_concrete_optional_typedef_type_for_context(t.base_type, concrete_optional)
 		}
 		types.MultiReturn {
 			for typ in t.types {
-				g.collect_concrete_optional_typedef_type(typ)
+				g.collect_concrete_optional_typedef_type_for_context(typ, concrete_optional)
 			}
 		}
 		else {}

--- a/vlib/v3/gen/c/types_test.v
+++ b/vlib/v3/gen/c/types_test.v
@@ -49,6 +49,40 @@ fn test_optional_payload_qualifies_concrete_generic_struct() {
 	})) == 'Array'
 }
 
+fn test_declaration_signature_scan_ignores_unscoped_regular_fn_nodes() {
+	mut ast := flat.FlatAst.new()
+	ast.add_node(flat.Node{
+		kind:  .fn_decl
+		value: 'load'
+		typ:   '!Image'
+	})
+	mut tc := types.TypeChecker.new(&ast)
+	tc.cur_module = 'json2'
+	mut g := FlatGen.new()
+	g.a = &ast
+	g.tc = &tc
+
+	g.collect_declaration_signature_types()
+	assert 'Optional_json2__Image' !in g.needed_optional_types
+}
+
+fn test_declaration_signature_scan_collects_specialized_fn_nodes() {
+	mut ast := flat.FlatAst.new()
+	fn_id := ast.add_node(flat.Node{
+		kind:  .fn_decl
+		value: 'decode_T_Data'
+		typ:   '!Data'
+	})
+	ast.specialized_fn_nodes[int(fn_id)] = true
+	mut tc := types.TypeChecker.new(&ast)
+	mut g := FlatGen.new()
+	g.a = &ast
+	g.tc = &tc
+
+	g.collect_declaration_signature_types()
+	assert 'Optional_Data' in g.needed_optional_types
+}
+
 fn test_optional_value_info_preserves_pointer_payload_abi() {
 	mut ast := &flat.FlatAst{}
 	mut tc := types.TypeChecker.new(ast)

--- a/vlib/v3/tests/params_struct_codegen_test.v
+++ b/vlib/v3/tests/params_struct_codegen_test.v
@@ -64,6 +64,41 @@ fn test_interface_field_in_params_struct_codegen() {
 	assert out == '8'
 }
 
+fn test_interface_array_field_in_params_struct_uses_expected_element_type() {
+	v3_bin := build_v3()
+	source := 'interface Widget {
+	kind() string
+}
+
+struct TextBox {}
+struct Label {}
+struct Button {}
+
+fn (TextBox) kind() string { return "textbox" }
+fn (Label) kind() string { return "label" }
+fn (Button) kind() string { return "button" }
+
+@[params]
+struct RowConfig {
+	children []Widget
+}
+
+fn row(config RowConfig) string {
+	mut kinds := []string{}
+	for child in config.children {
+		kinds << child.kind()
+	}
+	return kinds.join(",")
+}
+
+fn main() {
+	println(row(children: [TextBox{}, Label{}, Button{}]))
+}
+'
+	out := run_good(v3_bin, 'params_interface_array_field_input', source)
+	assert out == 'textbox,label,button'
+}
+
 fn test_fixed_array_field_struct_init_codegen() {
 	v3_bin := build_v3()
 	source := "struct Item {\n\tx int\n}\n\nstruct Header {\nmut:\n\tdata [2]Item\n\tcur_pos int\n}\n\nstruct Uniforms {\n\tlights [2][4]f32\n}\n\nfn row() [4]f32 {\n\treturn [f32(1.1), 1.2, 1.3, 1.4]!\n}\n\nfn main() {\n\tmut h := Header{}\n\th.data[0] = Item{x: 4}\n\th.data[1] = Item{x: 9}\n\th.cur_pos = 2\n\tcombined := Header{\n\t\tdata: h.data\n\t\tcur_pos: h.cur_pos\n\t}\n\tprintln('\${combined.cur_pos}|\${combined.data[0].x}|\${combined.data[1].x}')\n\tmixed := Uniforms{\n\t\tlights: [\n\t\t\trow(),\n\t\t\t[f32(2.1), 2.2]!,\n\t\t]!\n\t}\n\tassert mixed.lights[0][0] == f32(1.1)\n\tassert mixed.lights[1][0] == f32(2.1)\n\tassert mixed.lights[1][1] == f32(2.2)\n\tassert mixed.lights[1][2] == 0\n\tassert mixed.lights[1][3] == 0\n}\n"

--- a/vlib/v3/tests/post_merge_review_fixes_test.v
+++ b/vlib/v3/tests/post_merge_review_fixes_test.v
@@ -6007,6 +6007,53 @@ fn test_imported_private_free_function_is_rejected() {
 	}, ['main.v'], 'function `other.hidden` is private')
 }
 
+fn test_private_declarations_in_main_module_accept_empty_module_alias() {
+	v3_bin := build_v3()
+	out := run_good_project(v3_bin, 'review_main_module_private_alias', {
+		'v.mod':  "Module { name: 'review_main_module_private_alias' }\n"
+		'app.v':  'module main
+
+struct App {
+	value int
+}
+
+fn (app App) hidden() int {
+	return app.value
+}
+'
+		'main.v': 'module main
+
+fn main() {
+	app := App{
+		value: 7
+	}
+	println(app.hidden())
+}
+'
+	}, '')
+	assert out == '7'
+}
+
+fn test_map_index_value_can_be_implicit_non_mut_reference_argument() {
+	v3_bin := build_v3()
+	out := run_good(v3_bin, 'review_map_index_implicit_ref_arg', 'struct Image {
+	value int
+}
+
+fn draw(image &Image) int {
+	return image.value
+}
+
+fn main() {
+	images := {
+		"avatar": Image{value: 9}
+	}
+	println(draw(images["avatar"]))
+}
+')
+	assert out == '9'
+}
+
 fn test_cross_module_mut_receiver_checks_visible_mutation() {
 	v3_bin := build_v3()
 	run_bad_project(v3_bin, 'review_cross_module_public_mut_receiver', {

--- a/vlib/v3/tests/review_transform_regressions_test.v
+++ b/vlib/v3/tests/review_transform_regressions_test.v
@@ -414,6 +414,41 @@ fn main() {
 }'
 }
 
+fn test_recursive_interface_auto_str_uses_helper() {
+	v3_bin := build_v3_review_transform()
+	out := run_good(v3_bin, 'recursive_interface_auto_str', "interface Entry {
+	name() string
+}
+
+struct Leaf {
+	value int
+}
+
+fn (Leaf) name() string {
+	return 'leaf'
+}
+
+struct Branch {
+	child Entry
+}
+
+fn (Branch) name() string {
+	return 'branch'
+}
+
+fn main() {
+	value := Entry(Branch{
+		child: Entry(Leaf{
+			value: 42
+		})
+	})
+	println(value)
+}
+")
+	assert out.contains('child: Entry(Leaf{'), out
+	assert out.contains('value: 42'), out
+}
+
 fn test_auto_str_preserves_distinct_sum_beyond_inline_depth() {
 	v3_bin := build_v3_review_transform()
 	out := run_good(v3_bin, 'auto_str_distinct_sum_depth', 'struct Leaf {
@@ -3892,6 +3927,22 @@ fn test_parallel_monomorphization_grows_uneven_worker_regions() {
 	assert out == '40'
 }
 
+fn test_parallel_monomorphization_expands_single_seed() {
+	$if windows {
+		return
+	}
+	v3_bin := build_v3_review_transform()
+	mut declarations := []string{cap: 40}
+	mut calls := []string{cap: 40}
+	for i in 0 .. 40 {
+		declarations << 'struct MonoSeed${i} {}'
+		calls << '\ttotal += inner(MonoSeed${i}{})'
+	}
+	src := '${declarations.join('\n')}\n\nfn inner[T](value T) int {\n\t_ = value\n\treturn 1\n}\n\nfn seed[T]() int {\n\t_ = T{}\n\tmut total := 0\n${calls.join('\n')}\n\treturn total\n}\n\nfn main() {\n\tprintln(seed[MonoSeed0]())\n}\n'
+	out := run_good_with_env(v3_bin, 'parallel_monomorph_single_seed', 'VJOBS=4', src)
+	assert out == '40'
+}
+
 fn test_parallel_monomorphization_registers_worker_fixed_array_signatures() {
 	$if windows {
 		return
@@ -4825,6 +4876,17 @@ fn test_parallel_json2_specializations_emit_registered_bodies() {
 	assert out == '42'
 }
 
+fn test_parallel_json2_exact_callee_does_not_rebind_main_type_to_imported_homonym() {
+	v3_bin := build_v3_review_transform()
+	c_source := gen_c_from_project(v3_bin, 'parallel_json2_exact_callee_homonym', {
+		'v.mod':             "Module { name: 'parallel_json2_exact_callee_homonym' }\n"
+		'discord/discord.v': 'module discord\n\npub struct Discord {\npub:\n\tname string\n}\n'
+		'main.v':            'module main\n\nimport discord\nimport x.json2\n\nstruct Discord {\n\tvalue int\n}\n\nfn main() {\n\t_ = json2.encode(discord.Discord{})\n\tvalue := json2.decode[Discord](r\'{"value":42}\')!\n\tprintln(value.value)\n}\n'
+	}, 'main.v')
+	assert c_source.contains('decode_struct_key_T_Discord(')
+	assert !c_source.contains('decode_struct_key_T_discord__Discord(')
+}
+
 fn test_module_local_const_array_struct_types_do_not_use_previous_module() {
 	v3_bin := build_v3_review_transform()
 	out := run_good(v3_bin, 'module_local_const_array_struct_types', 'import encoding.utf8
@@ -5217,6 +5279,32 @@ fn main() {
 }
 ')
 	assert out == '[2, 3]'
+}
+
+fn test_for_in_sum_array_smartcast_indexes_variant_payload() {
+	v3_bin := build_v3_review_transform()
+	out := run_good(v3_bin, 'for_in_sum_array_smartcast', 'type Size = []f64 | f64
+
+fn values(size Size) []f32 {
+	mut result := []f32{}
+	match size {
+		[]f64 {
+			for _, value in size {
+				result << f32(value)
+			}
+		}
+		f64 {
+			result << f32(size)
+		}
+	}
+	return result
+}
+
+fn main() {
+	println(values(Size([1.5, 2.5])))
+}
+')
+	assert out == '[1.5, 2.5]'
 }
 
 fn test_autofree_array_map_preserves_v1_sum_value_copy_compatibility() {

--- a/vlib/v3/transform/comptime.v
+++ b/vlib/v3/transform/comptime.v
@@ -2331,7 +2331,7 @@ fn (t &Transformer) comptime_option_unwrapped_local_type(name string, call flat.
 	return none
 }
 
-fn (t &Transformer) comptime_reflected_for_in_local_type(name string, fm FieldMeta) ?string {
+fn (mut t Transformer) comptime_reflected_for_in_local_type(name string, fm FieldMeta) ?string {
 	if name.len == 0 {
 		return none
 	}
@@ -2339,35 +2339,61 @@ fn (t &Transformer) comptime_reflected_for_in_local_type(name string, fm FieldMe
 	if !iter_type.starts_with('map[') && !iter_type.starts_with('[]') {
 		return none
 	}
+	t.prepare_comptime_reflected_for_roles()
+	role := t.comptime_reflected_for_roles[name] or { return none }
+	if iter_type.starts_with('map[') {
+		if role in [u8(1), 3] {
+			return t.map_key_type(iter_type)
+		}
+		return t.map_value_type(iter_type)
+	}
+	if role == 1 {
+		return 'int'
+	}
+	return iter_type[2..]
+}
+
+// prepare_comptime_reflected_for_roles indexes the first reflected-field loop role for each
+// local name. Generic JSON decoders query this while cloning every reflected field; rescanning
+// the complete, growing AST for each query made monomorphization quadratic on large programs.
+fn (mut t Transformer) prepare_comptime_reflected_for_roles() {
+	if t.comptime_reflected_for_ready {
+		return
+	}
+	t.comptime_reflected_for_ready = true
+	mut reflected_locals := map[string]bool{}
+	for node in t.a.nodes {
+		if node.kind != .decl_assign || node.children_count < 2 {
+			continue
+		}
+		lhs := t.a.child_node(&node, 0)
+		if lhs.kind == .ident && lhs.value.len > 0
+			&& t.subtree_has_comptime_field_selector(t.a.child(&node, 1)) {
+			reflected_locals[lhs.value] = true
+		}
+	}
+	mut roles := map[string]u8{}
 	for node in t.a.nodes {
 		if node.kind != .for_in_stmt || node.children_count < 3 {
 			continue
 		}
-		key := t.a.child_node(&node, 0)
-		value := t.a.child_node(&node, 1)
 		container_id := t.a.child(&node, 2)
-		if !t.comptime_for_container_uses_reflected_field(container_id) {
+		container := t.a.nodes[int(container_id)]
+		if !t.subtree_has_comptime_field_selector(container_id) && !(container.kind == .ident
+			&& reflected_locals[container.value]) {
 			continue
 		}
+		key := t.a.child_node(&node, 0)
+		value := t.a.child_node(&node, 1)
 		has_index := value.kind == .ident && value.value.len > 0
-		if iter_type.starts_with('map[') {
-			if key.kind == .ident && key.value == name {
-				return t.map_key_type(iter_type)
-			}
-			if value.kind == .ident && value.value == name {
-				return t.map_value_type(iter_type)
-			}
-		} else {
-			elem_type := iter_type[2..]
-			if has_index && key.kind == .ident && key.value == name {
-				return 'int'
-			}
-			if (has_index && value.value == name) || (!has_index && key.value == name) {
-				return elem_type
-			}
+		if key.kind == .ident && key.value.len > 0 && key.value !in roles {
+			roles[key.value] = if has_index { u8(1) } else { u8(3) }
+		}
+		if has_index && value.value !in roles {
+			roles[value.value] = 2
 		}
 	}
-	return none
+	t.comptime_reflected_for_roles = roles.move()
 }
 
 fn (t &Transformer) comptime_for_container_uses_reflected_field(container_id flat.NodeId) bool {

--- a/vlib/v3/transform/expr.v
+++ b/vlib/v3/transform/expr.v
@@ -2924,6 +2924,7 @@ fn (mut t Transformer) register_sum_eq_helper_signature(helper string, clean_sum
 		t.tc.fn_ret_types[helper] = ret
 		t.tc.fn_param_types[helper] = params.clone()
 		t.tc.fn_variadic[helper] = false
+		t.tc_signature_names_log << helper
 	}
 }
 

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -4585,6 +4585,15 @@ fn (mut t Transformer) lower_interface_auto_str(expr flat.NodeId, iface_name str
 }
 
 fn (mut t Transformer) lower_interface_auto_str_with_nil(expr flat.NodeId, iface_name string, allow_nil bool) flat.NodeId {
+	if t.stringify_stack_count(iface_name) > 0
+		|| (t.stringify_stack.len >= t.stringify_depth_cap
+		&& !t.stringify_types_match(t.auto_str_synthesis_type, iface_name)) {
+		return t.request_auto_str_helper(expr, iface_name)
+	}
+	t.stringify_stack << iface_name
+	defer {
+		t.stringify_stack.delete_last()
+	}
 	display_name := iface_name.all_after_last('.')
 	if isnil(t.tc) {
 		return t.make_string_literal('${display_name}{}')
@@ -4892,7 +4901,9 @@ fn (mut t Transformer) build_auto_str_helper_fn(aggregate string) {
 	t.set_var_type(param_name, aggregate)
 	value := t.make_ident(param_name)
 	t.set_node_typ(int(value), aggregate)
-	result := if aggregate in t.sum_types {
+	result := if t.is_interface_type(aggregate) {
+		t.lower_interface_auto_str(value, aggregate)
+	} else if aggregate in t.sum_types {
 		t.lower_sum_str(value, aggregate)
 	} else {
 		t.lower_struct_str(value, aggregate) or {
@@ -4935,6 +4946,10 @@ fn (mut t Transformer) build_auto_str_helper_fn(aggregate string) {
 		t.tc.fn_param_types[helper_key] = [t.tc.parse_type(aggregate)]
 		t.tc.fn_variadic[helper] = false
 		t.tc.fn_variadic[helper_key] = false
+		t.tc_signature_names_log << helper
+		if helper_key != helper {
+			t.tc_signature_names_log << helper_key
+		}
 	}
 }
 
@@ -5467,15 +5482,32 @@ fn (t &Transformer) stringify_type_at_circular_limit(typ string) bool {
 	return t.stringify_stack_count(aggregate) >= limit
 }
 
-fn (t &Transformer) struct_autostr_allows_recurse(struct_type string) bool {
-	decl_name := generic_base_name_text(struct_type)
+fn (mut t Transformer) rebuild_struct_autostr_recurse_index() {
+	mut allow_nodes := map[int]bool{}
+	for node in t.a.nodes {
+		if node.kind != .directive || !node.value.starts_with('@attributes:') {
+			continue
+		}
+		mut allows_recurse := false
+		for attr in node.generic_params() {
+			clean := attr.trim_space()
+			if clean.starts_with('autostr') && clean.contains('allowrecurse') {
+				allows_recurse = true
+				break
+			}
+		}
+		if allows_recurse {
+			allow_nodes[node.value['@attributes:'.len..].int()] = true
+		}
+	}
+	mut recurse_types := map[string]bool{}
 	mut cur_module := ''
 	for idx, node in t.a.nodes {
 		if node.kind == .module_decl {
 			cur_module = node.value
 			continue
 		}
-		if node.kind != .struct_decl {
+		if node.kind != .struct_decl || !allow_nodes[idx] {
 			continue
 		}
 		qualified := if cur_module.len > 0 && cur_module !in ['main', 'builtin'] {
@@ -5483,19 +5515,16 @@ fn (t &Transformer) struct_autostr_allows_recurse(struct_type string) bool {
 		} else {
 			node.value
 		}
-		if decl_name != node.value && decl_name != qualified
-			&& decl_name.all_after_last('.') != node.value {
-			continue
-		}
-		for attr in t.comptime_node_raw_attributes(idx) {
-			clean := attr.trim_space()
-			if clean.starts_with('autostr') && clean.contains('allowrecurse') {
-				return true
-			}
-		}
-		return false
+		recurse_types[node.value] = true
+		recurse_types[qualified] = true
 	}
-	return false
+	t.struct_autostr_recurse_types = recurse_types.move()
+}
+
+fn (t &Transformer) struct_autostr_allows_recurse(struct_type string) bool {
+	decl_name := generic_base_name_text(struct_type)
+	return t.struct_autostr_recurse_types[decl_name]
+		|| t.struct_autostr_recurse_types[decl_name.all_after_last('.')]
 }
 
 fn struct_string_display_name(typ string) string {
@@ -8041,12 +8070,13 @@ fn (mut t Transformer) build_default_clone_helper_fn(typ string) {
 	})
 	t.ensure_node_context_map_capacity()
 	t.mark_node_context(fn_decl, 'main', t.cur_file)
-	t.fn_ret_types[helper] = typ
+	t.set_fn_ret_type(helper, typ)
 	t.mark_fn_used_name(helper)
 	if !isnil(t.tc) {
 		t.tc.fn_ret_types[helper] = t.tc.parse_type(typ)
 		t.tc.fn_param_types[helper] = [t.tc.parse_type('voidptr')]
 		t.tc.fn_variadic[helper] = false
+		t.tc_signature_names_log << helper
 	}
 }
 
@@ -9859,12 +9889,14 @@ fn (mut t Transformer) lift_fn_literal(_id flat.NodeId, node flat.Node) flat.Nod
 		t.tc.fn_param_types[name] = param_types.clone()
 		t.tc.fn_variadic[name] = false
 		t.add_receiver_method_suffix_index(name)
+		t.tc_signature_names_log << name
 		if t.cur_module.len > 0 && t.cur_module != 'main' && t.cur_module != 'builtin' {
 			qname := '${t.cur_module}.${name}'
 			t.tc.fn_ret_types[qname] = ret
 			t.tc.fn_param_types[qname] = param_types.clone()
 			t.tc.fn_variadic[qname] = false
 			t.add_receiver_method_suffix_index(qname)
+			t.tc_signature_names_log << qname
 		}
 	}
 	// Fn literals are materialized after markused has already walked the parsed

--- a/vlib/v3/transform/for.v
+++ b/vlib/v3/transform/for.v
@@ -949,6 +949,11 @@ fn (mut t Transformer) lower_indexed_for_in(id flat.NodeId, node flat.Node, key_
 	direct_map_index_container := node.op == .amp && container_node.kind == .index
 	mut container := if direct_map_index_container {
 		container_id
+	} else if t.expr_has_smartcast(container_id) {
+		// The checker-facing iterator type is already the narrowed collection, but
+		// taking the original expression as an lvalue would bypass the active sum
+		// smartcast and make cgen index the sum wrapper itself.
+		t.transform_expr(container_id)
 	} else if t.expr_can_take_address(container_id) {
 		mut lvalue := t.transform_lvalue(container_id)
 		if !t.is_stable_expr_for_reuse(lvalue) {

--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -146,6 +146,15 @@ fn (mut t Transformer) monomorphize_pass() []string {
 	if decls.len == 0 {
 		return []string{}
 	}
+	methods_by_receiver := generic_struct_methods_by_receiver(decls)
+	mut method_level_params := map[string]bool{}
+	for _, methods in methods_by_receiver {
+		for decl in methods {
+			method_level_params[decl.key] = t.generic_decl_has_method_level_params(decl)
+		}
+	}
+	interfaces_by_method := t.generic_struct_interfaces_by_method()
+	mut interface_impl_cache := map[string]bool{}
 	// Generic cloning is recursive. Reuse one stack-shaped child-id buffer instead
 	// of allocating a temporary array for every cloned AST node.
 	t.generic_clone_children.ensure_cap(t.a.nodes.len)
@@ -165,7 +174,7 @@ fn (mut t Transformer) monomorphize_pass() []string {
 	mut changed := true
 	mut scan_start := 0
 	mut generic_fn_value_scan_start := 0
-	mut interface_box_scan_start := 0
+	mut interface_box_scan_start := t.a.nodes.len
 	mut used_fns_at_scan := t.used_fn_count()
 	mut generic_struct_specs := if t.generic_materialization_ready {
 		t.generic_struct_specs_cache.clone()
@@ -180,6 +189,9 @@ fn (mut t Transformer) monomorphize_pass() []string {
 	mut generic_struct_specs_scan_start := t.a.nodes.len
 	mut lowered_operator_uses := t.lowered_generic_struct_operator_uses_for_specs(generic_struct_specs,
 		decls)
+	if t.parallel_monomorphize {
+		t.prepare_parallel_monomorph_scan(0, t.a.nodes.len)
+	}
 	t.monomorph_profile('mono driver setup: ${time.ticks() - debug_started} ms')
 	t.in_monomorphize_scan = true
 	defer {
@@ -346,6 +358,9 @@ fn (mut t Transformer) monomorphize_pass() []string {
 					if t.node_file_or(i, '').len == 0 {
 						continue
 					}
+					if !t.call_name_can_target_generic(node) {
+						continue
+					}
 					if t.call_is_recorded_struct_operator(node)
 						|| t.record_lowered_generic_struct_operator_call(node, lowered_operator_uses) {
 						continue
@@ -413,24 +428,35 @@ fn (mut t Transformer) monomorphize_pass() []string {
 		// Generic specialization can turn an unresolved interface conversion such as
 		// `Sink[W] -> Interface` into a concrete boxed type. Include those newly
 		// materialized boxes before deciding which interface methods need bodies.
+		box_refresh_started := time.ticks()
 		if interface_box_scan_start < node_count {
 			was_frozen := t.interface_boxed_types_frozen
 			t.interface_boxed_types_frozen = false
 			t.collect_interface_boxed_types_range(interface_box_scan_start, node_count)
 			t.interface_boxed_types_frozen = was_frozen
-			t.refresh_interface_impl_indexes_for_boxed_types()
+			t.monomorph_profile('mono round ${debug_round} box scan: ${time.ticks() - box_refresh_started} ms (${t.interface_boxed_types.len} keys)')
 			interface_box_scan_start = node_count
 		}
+		box_index_started := time.ticks()
+		t.refresh_interface_impl_indexes_for_boxed_types()
+		t.monomorph_profile('mono round ${debug_round} box index: ${time.ticks() - box_index_started} ms')
+		t.monomorph_profile('mono round ${debug_round} boxes: ${time.ticks() - box_refresh_started} ms')
 		// Specialize methods of instantiated generic structs that are never reached
 		// through an explicit call node — notably operator overloads (`a + b`), which
 		// are infix expressions lowered to method calls only later in the pipeline.
-		if t.specialize_generic_struct_methods(generic_struct_specs, decls, mut emitted) {
+		method_started := time.ticks()
+		if t.specialize_generic_struct_methods(generic_struct_specs, decls, methods_by_receiver,
+			method_level_params, interfaces_by_method, mut interface_impl_cache, mut emitted)
+		{
 			changed = true
 		}
-		t.monomorph_profile('mono round ${debug_round} methods: ${time.ticks() - debug_round_started} ms')
-		if t.drain_pending_generic_fn_specs(mut emitted, mut generated) {
+		t.monomorph_profile('mono round ${debug_round} methods: ${time.ticks() - method_started} ms')
+		if t.drain_pending_generic_fn_specs(struct_decls, sum_decls, mut emitted, mut generated) {
 			changed = true
 		}
+		// Every specialization scans its own appended range while it is transformed,
+		// including on parallel workers; do not rescan those nodes next round.
+		interface_box_scan_start = t.a.nodes.len
 		t.monomorph_profile('mono round ${debug_round} drain: ${time.ticks() - debug_round_started} ms')
 	}
 	t.monomorph_profile('mono driver rounds: ${time.ticks() - debug_started} ms')
@@ -449,7 +475,8 @@ fn (mut t Transformer) monomorphize_pass() []string {
 		extra_call_sites := t.collect_generic_call_sites_after_type_refresh(generic_struct_specs,
 			decls, ignored_nodes, missed_call_sites, mut emitted, mut recorded_call_sites)
 		if extra_call_sites.len > 0 {
-			for t.drain_pending_generic_fn_specs(mut emitted, mut generated) {
+			for t.drain_pending_generic_fn_specs(struct_decls, sum_decls, mut emitted, mut
+				generated) {
 			}
 			t.rewrite_generic_call_sites(decls, extra_call_sites)
 			t.refresh_decl_assign_types_after_generic_rewrite()
@@ -664,19 +691,25 @@ fn (t &Transformer) sorted_monomorph_cache_specs() []MonomorphCacheSpec {
 	return specs
 }
 
-fn (mut t Transformer) drain_pending_generic_fn_specs(mut emitted map[string]bool, mut generated []string) bool {
-	// Keep specialization emission serial. The dynamic parallel work queues can
-	// strand a callback after nested requests are redistributed, and reserving a
-	// private append region per worker costs far more memory than this pass needs.
+fn (mut t Transformer) drain_pending_generic_fn_specs(struct_decls map[string]GenericStructDecl, sum_decls map[string]GenericSumDecl, mut emitted map[string]bool, mut generated []string) bool {
 	mut changed := false
 	for t.pending_generic_fn_specs.len > 0 {
 		specs := t.pending_generic_fn_specs
 		t.pending_generic_fn_specs = []PendingGenericFnSpec{}
+		mut pending := []PendingGenericFnSpec{cap: specs.len}
 		for spec in specs {
 			if spec.key in t.generic_fn_spec_nodes {
 				t.pending_generic_fn_spec_keys.delete(spec.key)
 				continue
 			}
+			pending << spec
+		}
+		if t.parallel_monomorphize
+			&& t.run_parallel_monomorphize_specs(pending, struct_decls, sum_decls, mut emitted, mut generated) {
+			changed = true
+			continue
+		}
+		for spec in pending {
 			clone_id := t.emit_generic_fn_specialization(spec.decl, spec.args)
 			generated << t.generated_fn_used_names(spec.decl, clone_id, spec.args)
 			emitted[generic_fn_spec_key(spec.decl.key, spec.args)] = true
@@ -1144,20 +1177,79 @@ fn (mut t Transformer) record_index_operator_fn_name(node flat.Node, method stri
 // `vec__Vec4_f32__one`, ...). It only handles methods whose generic parameters are
 // exactly the struct's parameters (no extra method-level `[U]`); those are left to
 // the call-driven path. Returns whether any new specialization was emitted.
-fn (mut t Transformer) specialize_generic_struct_methods(specs map[string]string, decls map[string]GenericFnDecl, mut emitted map[string]bool) bool {
+fn generic_struct_methods_by_receiver(decls map[string]GenericFnDecl) map[string][]GenericFnDecl {
+	mut methods_by_receiver := map[string][]GenericFnDecl{}
+	for decl_key, decl in decls {
+		if !decl_key.contains('.') {
+			continue
+		}
+		receiver := decl_key.all_before_last('.')
+		mut methods := methods_by_receiver[receiver] or { []GenericFnDecl{} }
+		methods << decl
+		methods_by_receiver[receiver] = methods
+	}
+	return methods_by_receiver
+}
+
+fn (t &Transformer) generic_struct_interfaces_by_method() map[string][]string {
+	mut interfaces_by_method := map[string][]string{}
+	if isnil(t.tc) {
+		return interfaces_by_method
+	}
+	for iface_name, _ in t.tc.interface_names {
+		for method in t.tc.interface_abstract_method_names(iface_name) {
+			mut interfaces := interfaces_by_method[method] or { []string{} }
+			interfaces << iface_name
+			interfaces_by_method[method] = interfaces
+		}
+	}
+	return interfaces_by_method
+}
+
+fn (t &Transformer) used_generic_method_names() map[string]bool {
+	mut methods := map[string]bool{}
+	for name, used in t.used_fns {
+		if !used || name.len == 0 {
+			continue
+		}
+		if name.contains('.') {
+			methods[name.all_after_last('.')] = true
+		}
+		if name.contains('__') {
+			methods[name.all_after_last('__')] = true
+		}
+	}
+	return methods
+}
+
+fn (mut t Transformer) specialize_generic_struct_methods(specs map[string]string, decls map[string]GenericFnDecl, methods_by_receiver map[string][]GenericFnDecl, method_level_params map[string]bool, interfaces_by_method map[string][]string, mut interface_impl_cache map[string]bool, mut emitted map[string]bool) bool {
 	if !t.needs_generic_struct_method_specialization(decls) {
 		return false
 	}
+	used_method_names := t.used_generic_method_names()
 	mut any := false
 	for spec, base in specs {
 		_, args, ok := generic_app_parts(spec)
 		if !ok || args.len == 0 {
 			continue
 		}
+		methods := methods_by_receiver[base] or { continue }
 		fixture_expand_regular_methods := t.fixture_should_expand_regular_generic_methods(args)
 			&& t.generic_struct_spec_has_emitted_method(base, args, decls, emitted)
-		for decl_key, decl in decls {
-			if !decl_key.contains('.') || decl_key.all_before_last('.') != base {
+		concrete_args := t.canonical_generic_specialization_args(args)
+		for decl in methods {
+			decl_key := decl.key
+			if method_level_params[decl_key] {
+				// Method has its own generic parameters beyond the struct's; leave it
+				// to the call-driven specialization which can infer them.
+				continue
+			}
+			spec_key := generic_fn_spec_key(decl_key, concrete_args)
+			if emitted[spec_key] {
+				continue
+			}
+			if t.generic_specialization_registered(decl, concrete_args) {
+				emitted[spec_key] = true
 				continue
 			}
 			// Only operator overloads need struct-instantiation-driven specialization:
@@ -1175,8 +1267,10 @@ fn (mut t Transformer) specialize_generic_struct_methods(specs map[string]string
 				if !t.generic_struct_operator_call_seen(c_name('${spec}.${method}')) {
 					continue
 				}
+			} else if !fixture_expand_regular_methods && !used_method_names[method] {
+				continue
 			} else if !fixture_expand_regular_methods
-				&& !t.generic_struct_method_needed_for_interface(spec, method) {
+				&& !t.generic_struct_method_needed_for_interface(spec, method, interfaces_by_method, mut interface_impl_cache) {
 				mvkey := '${spec}.${method}'
 				if !t.generic_struct_method_used_for_spec(spec, decl, args, method) {
 					if isnil(t.tc) || mvkey !in t.tc.generic_method_value_info {
@@ -1191,20 +1285,6 @@ fn (mut t Transformer) specialize_generic_struct_methods(specs map[string]string
 						continue
 					}
 				}
-			}
-			if t.generic_decl_has_method_level_params(decl) {
-				// Method has its own generic parameters beyond the struct's; leave it
-				// to the call-driven specialization which can infer them.
-				continue
-			}
-			concrete_args := t.canonical_generic_specialization_args(args)
-			spec_key := generic_fn_spec_key(decl_key, concrete_args)
-			if emitted[spec_key] {
-				continue
-			}
-			if t.generic_specialization_registered(decl, concrete_args) {
-				emitted[spec_key] = true
-				continue
 			}
 			t.request_generic_fn_specialization(decl, concrete_args)
 			emitted[spec_key] = true
@@ -1252,10 +1332,15 @@ fn (t &Transformer) generic_struct_spec_has_emitted_method(base string, args []s
 }
 
 fn (t &Transformer) generic_struct_method_used_for_spec(spec string, decl GenericFnDecl, args []string, method string) bool {
-	mut aliases := ['${spec}.${method}']
-	if !generic_method_c_name_can_collide_with_operator(method) {
-		aliases << c_name('${spec}.${method}')
+	direct := '${spec}.${method}'
+	if t.used_fn_contains_name(direct) {
+		return true
 	}
+	direct_c := c_name(direct)
+	if !generic_method_c_name_can_collide_with_operator(method) && t.used_fn_contains_name(direct_c) {
+		return true
+	}
+	mut aliases := []string{}
 	for alias in specialized_generic_fn_signature_aliases(decl, args) {
 		if !generic_method_c_name_can_collide_with_operator(method) || alias.ends_with('.${method}') {
 			aliases << alias
@@ -1339,22 +1424,27 @@ fn (t &Transformer) needs_generic_struct_method_specialization(decls map[string]
 	return false
 }
 
-fn (mut t Transformer) generic_struct_method_needed_for_interface(spec string, method string) bool {
+fn (mut t Transformer) generic_struct_method_needed_for_interface(spec string, method string, interfaces_by_method map[string][]string, mut interface_impl_cache map[string]bool) bool {
 	if isnil(t.tc) || spec.len == 0 || method.len == 0 {
 		return false
 	}
-	for iface_name, _ in t.tc.interface_names {
-		if method !in t.tc.interface_abstract_method_names(iface_name) {
+	for iface_name in interfaces_by_method[method] or { return false } {
+		if t.has_used_fn_filter() && (!t.interface_dispatch_method_used(iface_name, method)
+			|| !t.interface_boxed_type_used(iface_name, spec)) {
 			continue
 		}
-		if !t.tc.named_type_implements_interface(spec, iface_name) {
+		cache_key := '${iface_name}\n${spec}'
+		does_implement := if cached := interface_impl_cache[cache_key] {
+			cached
+		} else {
+			value := t.tc.named_type_implements_interface(spec, iface_name)
+			interface_impl_cache[cache_key] = value
+			value
+		}
+		if !does_implement {
 			continue
 		}
-		if !t.has_used_fn_filter()
-			|| (t.interface_dispatch_method_used(iface_name, method)
-			&& t.interface_boxed_type_used(iface_name, spec)) {
-			return true
-		}
+		return true
 	}
 	return false
 }
@@ -1541,6 +1631,25 @@ fn (mut t Transformer) collect_interface_boxed_types_range(start int, end int) {
 			continue
 		}
 		t.collect_interface_boxed_value(flat.NodeId(idx), t.tc.parse_type(node.value))
+		iface_name := t.interface_literal_name(node.value) or { continue }
+		for i in 0 .. node.children_count {
+			field := t.a.child_node(&node, i)
+			if field.kind != .field_init || field.value != '_object' {
+				continue
+			}
+			concrete_type := if field.typ.starts_with('&') { field.typ[1..] } else { field.typ }
+			t.mark_interface_boxed_type(iface_name, concrete_type)
+		}
+	}
+}
+
+fn (mut t Transformer) collect_lowered_interface_boxed_types_range(start int, end int) {
+	limit := if end < t.a.nodes.len { end } else { t.a.nodes.len }
+	for idx in start .. limit {
+		node := t.a.nodes[idx]
+		if node.kind != .struct_init {
+			continue
+		}
 		iface_name := t.interface_literal_name(node.value) or { continue }
 		for i in 0 .. node.children_count {
 			field := t.a.child_node(&node, i)
@@ -2316,8 +2425,8 @@ fn (mut t Transformer) materialize_generic_struct_specs(specs map[string]string,
 		t.materialize_generic_struct_spec(spec, decl)
 	}
 	started := time.ticks()
-	t.tc.clear_interface_impl_cache()
 	if specs.len > t.interface_impl_spec_count {
+		t.tc.clear_interface_impl_cache()
 		t.refresh_interface_impl_indexes_for_generic_specs(specs)
 		t.interface_impl_spec_count = specs.len
 	}
@@ -3390,7 +3499,8 @@ fn (mut t Transformer) emit_generic_fn_specialization(decl GenericFnDecl, args [
 	}
 	t.generic_fn_specs_in_progress[spec_key] = true
 	old_specialization_node_start := t.specialization_node_start
-	t.specialization_node_start = t.a.nodes.len
+	specialization_nodes_start := t.a.nodes.len
+	t.specialization_node_start = specialization_nodes_start
 	defer {
 		t.generic_fn_specs_in_progress.delete(spec_key)
 		t.specialization_node_start = old_specialization_node_start
@@ -3510,6 +3620,10 @@ fn (mut t Transformer) emit_generic_fn_specialization(decl GenericFnDecl, args [
 	}
 	t.transform_specialized_fn_body(clone_id, decl.module, decl.file, generic_params,
 		concrete_args, decl.node.value, validate_return)
+	was_boxed_types_frozen := t.interface_boxed_types_frozen
+	t.interface_boxed_types_frozen = false
+	t.collect_lowered_interface_boxed_types_range(specialization_nodes_start, t.a.nodes.len)
+	t.interface_boxed_types_frozen = was_boxed_types_frozen
 	t.mut_param_values = old_clone_mut_param_values.clone()
 	if check_fixture_semantics && t.tc.errors.len == concrete_error_count {
 		t.tc.check_concrete_fn_semantics(int(clone_id), decl.file, decl.module)
@@ -4104,6 +4218,7 @@ fn (mut t Transformer) register_specialized_fn_signature_value(decl GenericFnDec
 			t.tc.fn_type_files[name] = decl.file
 			t.add_receiver_method_suffix_index(name)
 			t.tc.specialized_generic_fns[name] = true
+			t.tc_signature_names_log << name
 		}
 		t.tc.cur_module = old_tc_module
 		t.tc.cur_file = old_tc_file
@@ -4675,6 +4790,7 @@ fn (mut t Transformer) cached_generic_fn_decls() map[string]GenericFnDecl {
 		if !t.generic_fn_decls_ready {
 			t.generic_fn_decls_cache = map[string]GenericFnDecl{}
 			t.generic_receiver_methods_by_name = map[string][]string{}
+			t.generic_fn_call_names = map[string]bool{}
 			t.generic_fn_decls_ready = true
 		}
 		return t.generic_fn_decls_cache
@@ -4689,14 +4805,41 @@ fn (mut t Transformer) cached_generic_fn_decls() map[string]GenericFnDecl {
 
 fn (mut t Transformer) build_generic_receiver_method_index() {
 	mut by_name := map[string][]string{}
+	mut call_names := map[string]bool{}
 	for key, decl in t.generic_fn_decls_cache {
 		if !t.generic_decl_is_receiver_method(decl.node) {
+			for name in [key, decl.node.value, key.all_after_last('.'),
+				decl.node.value.all_after_last('.')] {
+				if name.len > 0 {
+					call_names[name] = true
+				}
+			}
 			continue
 		}
 		method := key.all_after_last('.')
 		by_name[method] << key
+		call_names[method] = true
 	}
 	t.generic_receiver_methods_by_name = by_name.move()
+	t.generic_fn_call_names = call_names.move()
+}
+
+// call_name_can_target_generic is an allocation-free superset filter for the
+// monomorph scan. Most calls in a large program cannot name any generic
+// declaration; rejecting them before module/type inference avoids doing the
+// expensive resolution path for every ordinary call node.
+fn (t &Transformer) call_name_can_target_generic(node flat.Node) bool {
+	if node.children_count == 0 {
+		return false
+	}
+	mut callee := t.a.nodes[int(t.a.child(&node, 0))]
+	if callee.kind == .index && callee.children_count > 0 && callee.value != 'range' {
+		callee = t.a.nodes[int(t.a.child(&callee, 0))]
+	}
+	if callee.kind !in [.ident, .selector] || callee.value.len == 0 {
+		return false
+	}
+	return t.generic_fn_call_names[callee.value] || t.generic_callee_is_specialization(callee.value)
 }
 
 fn (mut t Transformer) infer_generic_call_args_from_params(decl GenericFnDecl, call_id flat.NodeId, node flat.Node, call_module string) ?[]string {
@@ -5503,6 +5646,26 @@ fn (mut t Transformer) cached_generic_call_specialization(id flat.NodeId, node f
 	// newer and more precise (notably for module-qualified homonyms), so only
 	// replace it when the current argument nodes confirm the cached arguments.
 	if spec := t.generic_call_spec_cache[idx] {
+		if node.children_count > 0 && !isnil(t.tc) {
+			callee := t.a.child_node(&node, 0)
+			if callee.kind == .ident && t.generic_callee_is_specialization(callee.value) {
+				decl := decls[spec.decl_key] or { return none }
+				if exact := t.exact_generic_specialization_args_from_callee(callee.value) {
+					if generic_type_args_equal(spec.args, exact) {
+						ret_type := t.specialized_fn_return_type_text(decl, exact)
+						if ret_type.len > 0 && !t.generic_arg_is_unresolved(ret_type)
+							&& node.typ != ret_type {
+							t.set_node_typ(idx, ret_type)
+							t.clear_typechecker_node_cache(idx)
+						}
+						if t.generic_specialization_progress_key(decl, exact) !in t.generic_fn_spec_nodes {
+							return spec.decl_key, exact
+						}
+						return none
+					}
+				}
+			}
+		}
 		// Explicit source arguments and the alias marker retained in `node.value`
 		// are more precise than a later inference pass over an alias-erased ABI
 		// argument. Preserve that identity for reflected `T.typ` specializations.
@@ -5615,6 +5778,13 @@ fn (mut t Transformer) cached_generic_call_specialization(id flat.NodeId, node f
 				}
 				return decl_key, exact_args
 			}
+			// Worker-local inference caches are intentionally not merged. Once an exact
+			// generated callee has a body, its encoded semantic arguments remain
+			// authoritative during the following global scan; re-inferring from bare ABI
+			// argument types can bind a main-module type to an imported homonym.
+			if exact_args.len > 0 && !t.generic_args_have_placeholders(exact_args) {
+				return none
+			}
 			if node.value.len > 0 {
 				if explicit := t.explicit_generic_call_args(node, module_name) {
 					if scoped := t.infer_generic_call_args_with_explicit(decl, id, node,
@@ -5710,6 +5880,18 @@ fn (mut t Transformer) missing_specialized_plain_generic_call(node flat.Node, mo
 	callee := t.a.child_node(&node, 0)
 	if callee.kind != .ident || !t.generic_callee_is_specialization(callee.value) {
 		return none
+	}
+	if exact := t.exact_generic_specialization_args_from_callee(callee.value) {
+		decl_key := t.generic_call_decl_key(flat.empty_node, node, module_name, decls) or {
+			return none
+		}
+		decl := decls[decl_key] or { return none }
+		if exact.len > 0 && !t.generic_args_have_placeholders(exact) {
+			if t.generic_specialization_registered(decl, exact) {
+				return none
+			}
+			return decl_key, exact
+		}
 	}
 	spec := t.specialized_plain_generic_call_specialization(node, module_name, decls) or {
 		return none
@@ -11979,6 +12161,7 @@ fn (mut t Transformer) record_generic_specialization_args_in_module(base string,
 	for key in keys {
 		if key.len > 0 && !t.has_recorded_generic_specialization_args(key) {
 			t.generic_specialization_args[key] = recorded_args.clone()
+			t.generic_specialization_args_log << key
 		}
 	}
 }
@@ -11991,6 +12174,7 @@ fn (mut t Transformer) record_generic_specialization_args_for_names(names []stri
 	for name in names {
 		if name.len > 0 && !t.has_recorded_generic_specialization_args(name) {
 			t.generic_specialization_args[name] = recorded_args.clone()
+			t.generic_specialization_args_log << name
 		}
 	}
 }

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -164,6 +164,8 @@ mut:
 	sum_variant_fields            map[string]string
 	qualified_types               map[string]string
 	fn_ret_types                  map[string]string
+	fn_ret_types_log              []string
+	tc_signature_names_log        []string
 	multi_return_fn_ret_types     map[string]types.Type
 	receiver_method_suffix_index  map[string]string
 	declared_fn_name_counts       map[string]u8
@@ -252,6 +254,8 @@ mut:
 	local_decl_nodes_by_name        map[string][]int
 	struct_field_decl_metas_cache   map[string]map[string]FieldDeclMeta
 	comptime_field_metas_cache      map[string][]FieldMeta
+	comptime_reflected_for_roles    map[string]u8
+	comptime_reflected_for_ready    bool
 	call_param_types_decl_cache     map[int][]types.Type
 	call_param_types_decl_misses    map[string]bool
 	call_param_types_decl_index     map[string]FnParamDeclRef
@@ -266,23 +270,24 @@ mut:
 	// module/file context of the requesting call site (type resolution inside
 	// the helper body needs that context). The helpers are synthesized
 	// serially after the (possibly parallel) transform completes.
-	sum_eq_types                  map[string]SumEqRequest
-	sum_eq_synthesized            map[string]bool
-	sum_eq_helper_module          string
-	auto_str_types                map[string]AutoStrRequest
-	auto_str_synthesized          map[string]bool
-	auto_str_helper_module        string
-	auto_str_synthesis_type       string
-	default_clone_types           map[string]DefaultCloneRequest
-	default_clone_synthesized     map[string]bool
-	default_clone_expansion_stack []string
-	interface_boxed_types         map[string]bool
-	interface_boxed_types_done    bool
-	interface_boxed_types_frozen  bool
-	interface_impl_indexes        map[string]&types.InterfaceImplIndex
-	interface_impl_spec_count     int
-	ierror_none_type_id           int
-	interface_var_concrete_types  map[string]string
+	sum_eq_types                   map[string]SumEqRequest
+	sum_eq_synthesized             map[string]bool
+	sum_eq_helper_module           string
+	auto_str_types                 map[string]AutoStrRequest
+	auto_str_synthesized           map[string]bool
+	auto_str_helper_module         string
+	auto_str_synthesis_type        string
+	default_clone_types            map[string]DefaultCloneRequest
+	default_clone_synthesized      map[string]bool
+	default_clone_expansion_stack  []string
+	interface_boxed_types          map[string]bool
+	interface_boxed_impl_processed map[string]bool
+	interface_boxed_types_done     bool
+	interface_boxed_types_frozen   bool
+	interface_impl_indexes         map[string]&types.InterfaceImplIndex
+	interface_impl_spec_count      int
+	ierror_none_type_id            int
+	interface_var_concrete_types   map[string]string
 	// used_struct_operator_fns holds the callee names of direct calls seen during
 	// monomorphize. Infix operators on generic instances are lowered to direct calls
 	// (`Vec_int__plus(a, b)`) before this pass, so an operator overload is specialized for
@@ -358,6 +363,7 @@ mut:
 	active_specialization_main_types   map[string]bool
 	specialization_main_type_closures  map[string]map[string]bool
 	generic_specialization_args        map[string][]string
+	generic_specialization_args_log    []string
 	generic_specialization_args_parent &map[string][]string = unsafe { nil }
 	generic_fn_specs_in_progress       map[string]bool
 	generic_fn_spec_nodes              map[string]flat.NodeId
@@ -373,6 +379,7 @@ mut:
 	pending_generic_fn_spec_keys       map[string]bool
 	generic_fn_decls_cache             map[string]GenericFnDecl
 	generic_receiver_methods_by_name   map[string][]string
+	generic_fn_call_names              map[string]bool
 	generic_fn_decls_ready             bool
 	generic_struct_specs_cache         map[string]string
 	generic_sum_specs_cache            map[string]GenericSpecContext
@@ -388,6 +395,7 @@ mut:
 	generic_call_spec_misses           map[int]bool
 	stringify_stack                    []string
 	stringify_depth_cap                int = max_stringify_nesting_depth
+	struct_autostr_recurse_types       map[string]bool
 	str_expansion_memo                 map[string]int
 	deferred_str_items                 []FnWorkItem
 	deferred_str_count                 int
@@ -463,6 +471,7 @@ mut:
 	retained_worker_regions     []ScopedTransformRegion
 	stage_scope                 voidptr
 	scoped_monomorphize         bool
+	monomorph_worker_scopes     []voidptr
 	signature_maps_shared       bool
 	signature_maps_changed      bool
 }
@@ -1355,6 +1364,14 @@ pub fn monomorphize_with_used_checked_config_scoped_cached(mut a flat.FlatAst, t
 		t.scope_parallel_workers = true
 	}
 	t.prepare()
+	// Interface conversions are explicit struct-init nodes after transform. Scan
+	// only that lowered form here; the semantic source scan already ran in the
+	// preceding transform and would be far more expensive on the enlarged AST.
+	t.interface_boxed_types_done = true
+	t.interface_boxed_types_frozen = false
+	t.collect_lowered_interface_boxed_types_range(0, t.a.nodes.len)
+	t.interface_boxed_types_frozen = true
+	t.refresh_interface_impl_indexes_for_boxed_types()
 	t.seed_cached_monomorph_specs(cached_specs)
 	t.monomorph_profile('mono wrapper prepare: ${time.ticks() - debug_started} ms')
 	base_node_count := t.a.nodes.len
@@ -1394,14 +1411,37 @@ pub fn monomorphize_with_used_checked_config_scoped_cached(mut a flat.FlatAst, t
 	t.monomorph_profile('mono wrapper sums: ${time.ticks() - debug_started} ms')
 	t.apply_ignored_comptime_for_nodes()
 	t.monomorph_profile('mono wrapper ignored: ${time.ticks() - debug_started} ms')
+	final_specs := t.sorted_monomorph_cache_specs()
 	if stage_scope != unsafe { nil } {
 		parent_state := transform_stage_scope_suspend(stage_scope)
-		for idx in 0 .. t.a.nodes.len {
-			t.clone_scoped_worker_node(idx, stage_scope)
-		}
+		// Rebuild the canonical table outside the disposable monomorph arena, then
+		// publish all worker-owned node strings while their arenas are still live.
+		t.a.promote_transform_texts_from(0, stage_scope)
+		t.monomorph_profile('mono wrapper text table: ${time.ticks() - debug_started} ms')
+		t.release_monomorph_worker_scopes()
 		transform_stage_scope_resume(stage_scope, parent_state)
+	} else {
+		t.release_monomorph_worker_scopes()
 	}
-	return t.used_fns, t.monomorph_errors, t.sorted_monomorph_cache_specs()
+	return t.used_fns, t.monomorph_errors, final_specs
+}
+
+fn (mut t Transformer) release_monomorph_worker_scopes() {
+	started := time.ticks()
+	// This is also the final monomorph text-publication barrier when no helper
+	// scope was retained. Keep it unconditional so the driver does not need a
+	// second full-AST canonicalization pass after this function returns.
+	t.a.intern_node_texts_from(0)
+	t.monomorph_profile('mono wrapper intern: ${time.ticks() - started} ms')
+	if !free_worker_scopes_parallel(t.a, t.monomorph_worker_scopes) {
+		for scope in t.monomorph_worker_scopes {
+			if scope != unsafe { nil } {
+				transform_worker_scope_free(scope)
+			}
+		}
+	}
+	t.monomorph_worker_scopes = []voidptr{}
+	t.monomorph_profile('mono wrapper release: ${time.ticks() - started} ms')
 }
 
 // register_cached_monomorph_signatures installs persistent concrete signatures
@@ -1441,6 +1481,7 @@ fn new_transformer_view(a &flat.FlatAst, tc &types.TypeChecker, used_fns map[str
 		sql_query_data_aliases:            map[string][]string{}
 		bound_method_arrays:               map[string]BoundMethodArrayInfo{}
 		comptime_field_metas_cache:        map[string][]FieldMeta{}
+		comptime_reflected_for_roles:      map[string]u8{}
 		const_array_fixed_storage_cache:   map[string]i8{}
 		invalidated_smartcasts:            map[string]bool{}
 		escaping_amp_ptrs:                 map[string]bool{}
@@ -1474,6 +1515,7 @@ fn new_transformer_view(a &flat.FlatAst, tc &types.TypeChecker, used_fns map[str
 		used_fns:                          used_fns.clone()
 		comptime_reflected_params:         map[string][]ParamMeta{}
 		interface_boxed_types:             map[string]bool{}
+		interface_boxed_impl_processed:    map[string]bool{}
 		interface_impl_indexes:            map[string]&types.InterfaceImplIndex{}
 		interface_var_concrete_types:      map[string]string{}
 		interface_box_param_cache:         &BoolLookupCache{
@@ -1595,6 +1637,7 @@ fn (mut t Transformer) prepare() {
 	}
 	mut psw := time.new_stopwatch()
 	t.collect_types()
+	t.rebuild_struct_autostr_recurse_index()
 	if !t.defer_pre_scan_indexes {
 		t.build_source_parent_index()
 	}
@@ -1734,37 +1777,65 @@ fn (mut t Transformer) refresh_interface_impl_indexes_for_boxed_types() {
 		return
 	}
 	mut boxed_types := map[string][]string{}
+	mut boxed_seen := map[string]bool{}
+	mut iface_names_cache := map[string]string{}
 	mut runtime_type_names := []string{}
 	for key, _ in t.interface_boxed_types {
-		parts := key.split('\n')
-		if parts.len != 2 || t.generic_arg_is_unresolved(parts[1]) {
+		if t.interface_boxed_impl_processed[key] {
 			continue
 		}
-		iface := t.resolve_interface_type_name(parts[0])
+		separator := key.index_u8(`\n`)
+		if separator <= 0 || separator + 1 >= key.len {
+			continue
+		}
+		raw_iface := key[..separator]
+		raw_concrete := key[separator + 1..]
+		if t.generic_arg_is_unresolved(raw_concrete)
+			|| !t.interface_boxed_impl_name_is_direct(raw_concrete) {
+			continue
+		}
+		t.interface_boxed_impl_processed[key] = true
+		iface := if cached := iface_names_cache[raw_iface] {
+			cached
+		} else {
+			resolved := t.resolve_interface_type_name(raw_iface)
+			iface_names_cache[raw_iface] = resolved
+			resolved
+		}
 		if iface.len == 0 {
 			continue
 		}
-		concrete := t.interface_concrete_impl_name(parts[1]) or { continue }
-		mut concrete_types := boxed_types[iface] or { []string{} }
-		if concrete !in concrete_types {
-			concrete_types << concrete
-			boxed_types[iface] = concrete_types
-			runtime_type_names << concrete
+		concrete := t.interface_concrete_impl_name(raw_concrete) or { continue }
+		seen_key := '${iface}\n${concrete}'
+		if boxed_seen[seen_key] {
+			continue
 		}
+		boxed_seen[seen_key] = true
+		mut concrete_types := boxed_types[iface] or { []string{} }
+		concrete_types << concrete
+		boxed_types[iface] = concrete_types
+		runtime_type_names << concrete
+	}
+	if boxed_types.len == 0 {
+		return
 	}
 	types.extend_stable_type_indexes_ref(mut t.runtime_type_indexes, &runtime_type_names)
 	mut refreshed := t.interface_impl_indexes.clone()
-	mut iface_names := t.interface_impl_indexes.keys()
+	mut iface_names := boxed_types.keys()
 	iface_names.sort()
 	for iface_name in iface_names {
 		old_index := t.interface_impl_indexes[iface_name] or { continue }
 		mut impls := old_index.names.clone()
-		resolved_iface := t.resolve_interface_type_name(iface_name)
-		mut concrete_types := boxed_types[resolved_iface] or { []string{} }
+		mut seen := map[string]bool{}
+		for name in impls {
+			seen[name] = true
+		}
+		mut concrete_types := boxed_types[iface_name] or { []string{} }
 		concrete_types.sort()
 		for concrete in concrete_types {
-			if concrete !in impls {
+			if !seen[concrete] {
 				impls << concrete
+				seen[concrete] = true
 			}
 		}
 		if impls.len == old_index.names.len {
@@ -1776,6 +1847,25 @@ fn (mut t Transformer) refresh_interface_impl_indexes_for_boxed_types() {
 		}
 	}
 	t.interface_impl_indexes = refreshed.move()
+}
+
+fn (t &Transformer) interface_boxed_impl_name_is_direct(name string) bool {
+	if name.len == 0 {
+		return false
+	}
+	if name.starts_with('fn(') || name.starts_with('fn ') || name.starts_with('[]')
+		|| name.starts_with('map[') || name.starts_with('builtin.') {
+		return true
+	}
+	if name in ['bool', 'int', 'i8', 'i16', 'i32', 'i64', 'isize', 'usize', 'u8', 'byte', 'u16',
+		'u32', 'u64', 'f32', 'f64', 'string', 'char', 'rune'] {
+		return true
+	}
+	if name in t.tc.structs || name in t.tc.type_aliases {
+		return true
+	}
+	base, _, is_generic_app := generic_app_parts(name)
+	return is_generic_app && (base in t.tc.structs || base in t.tc.type_aliases)
 }
 
 fn (t &Transformer) interface_impl_index_for_transform(iface_name string) &types.InterfaceImplIndex {
@@ -2167,6 +2257,7 @@ fn (mut t Transformer) ensure_private_signature_maps() {
 fn (mut t Transformer) set_fn_ret_type(name string, typ string) {
 	t.ensure_private_signature_maps()
 	t.fn_ret_types[name] = typ
+	t.fn_ret_types_log << name
 }
 
 fn (mut t Transformer) set_receiver_method_suffix_index(key string, name string) {
@@ -3721,6 +3812,8 @@ fn (t &Transformer) fork_program_view(ast &flat.FlatAst, wtc &types.TypeChecker,
 		local_decl_nodes_by_name:        t.local_decl_nodes_by_name
 		struct_field_decl_metas_cache:   t.struct_field_decl_metas_cache
 		comptime_field_metas_cache:      map[string][]FieldMeta{}
+		comptime_reflected_for_roles:    t.comptime_reflected_for_roles
+		comptime_reflected_for_ready:    t.comptime_reflected_for_ready
 		call_param_types_decl_cache:     t.call_param_types_decl_cache
 		call_param_types_decl_misses:    t.call_param_types_decl_misses.clone()
 		call_param_types_decl_index:     t.call_param_types_decl_index
@@ -3791,6 +3884,7 @@ fn (t &Transformer) fork_program_view(ast &flat.FlatAst, wtc &types.TypeChecker,
 		building_v:                         t.building_v
 		memo_node_types:                    t.memo_node_types
 		stringify_depth_cap:                t.stringify_depth_cap
+		struct_autostr_recurse_types:       t.struct_autostr_recurse_types
 		has_spawn_expr:                     t.has_spawn_expr
 		base_write_intercept:               t.base_write_intercept
 		defer_oor_writes:                   t.defer_oor_writes
@@ -3886,7 +3980,8 @@ fn (mut t Transformer) merge_worker_signatures(w &Transformer) {
 	if w.signature_maps_changed {
 		t.ensure_private_signature_maps()
 	}
-	for name, ret in w.fn_ret_types {
+	for name in w.fn_ret_types_log {
+		ret := w.fn_ret_types[name] or { continue }
 		if name !in t.fn_ret_types {
 			owned_name := name.clone()
 			t.fn_ret_types[owned_name] = ret.clone()
@@ -3903,7 +3998,10 @@ fn (mut t Transformer) merge_worker_signatures(w &Transformer) {
 	// uniquely-owned master checker.
 	mut master_tc := unsafe { &types.TypeChecker(voidptr(t.tc)) }
 	master_tc.ensure_private_transform_signatures()
-	for name, ret in w.tc.fn_ret_types {
+	mut tc_signature_names := w.tc_signature_names_log.clone()
+	tc_signature_names << w.fn_ret_types_log
+	for name in tc_signature_names {
+		ret := w.tc.fn_ret_types[name] or { continue }
 		if name in master_tc.fn_ret_types {
 			continue
 		}
@@ -4244,7 +4342,10 @@ fn (mut t Transformer) merge_worker(w &Transformer, items []FnWorkItem, base_nod
 		}
 	}
 	for idx, typ in w.refined_node_types {
-		shifted := if idx >= base_nodes { idx + int(node_shift) } else { idx }
+		if idx < base_nodes {
+			continue
+		}
+		shifted := idx + int(node_shift)
 		owned_typ := if w.worker_scope != unsafe { nil } { typ.clone() } else { typ }
 		t.record_refined_node_type(shifted, owned_typ)
 	}

--- a/vlib/v3/transform/transform_parallel_d_v3_no_parallel.v
+++ b/vlib/v3/transform/transform_parallel_d_v3_no_parallel.v
@@ -11,6 +11,10 @@ fn scan_top_level_kind_flags_parallel(_ &flat.FlatAst, _ int, mut _ []u8, _ bool
 	return false
 }
 
+fn (mut _ Transformer) prepare_parallel_monomorph_scan(_ int, _ int) bool {
+	return false
+}
+
 // collect_interface_boxed_types_parallel keeps the interface scan serial when
 // v3 is built with the internal `v3_no_parallel` define.
 fn (mut t Transformer) collect_interface_boxed_types_parallel() bool {
@@ -39,6 +43,10 @@ pub fn promote_scoped_checker_node_caches_parallel(mut _ types.TypeChecker, _ &f
 }
 
 pub fn scan_scoped_text_flags_parallel(_ &flat.FlatAst, _ voidptr, mut _ []u8) bool {
+	return false
+}
+
+fn free_worker_scopes_parallel(_ &flat.FlatAst, _ []voidptr) bool {
 	return false
 }
 

--- a/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
@@ -149,6 +149,12 @@ struct ScopedTextScanArgs {
 	flags voidptr // &u8 base of the per-node flag array
 }
 
+struct WorkerScopeFreeArgs {
+	scopes []voidptr
+	start  int
+	end    int
+}
+
 // node_has_scoped_text reports whether any text payload of `node` lives in
 // `scope`'s arena, i.e. whether canonicalization/promotion would rewrite it.
 @[inline]
@@ -519,6 +525,14 @@ struct CheckerCachePromoteArgs {
 }
 
 $if !windows {
+	fn worker_scope_free_thread(arg voidptr) voidptr {
+		a := unsafe { &WorkerScopeFreeArgs(arg) }
+		for i in a.start .. a.end {
+			transform_worker_scope_free(a.scopes[i])
+		}
+		return unsafe { nil }
+	}
+
 	// checker_cache_promote_thread publishes scope-owned resolved-call /
 	// fn-value strings and clones generated-range expression types for this
 	// worker's id range. Slot writes are range-disjoint; clones allocate in the
@@ -545,6 +559,50 @@ $if !windows {
 			}
 		}
 		return unsafe { nil }
+	}
+}
+
+// free_worker_scopes_parallel releases independent retained worker arenas on
+// the shared pool. Returns false when a serial release is cheaper or required.
+fn free_worker_scopes_parallel(a &flat.FlatAst, scopes []voidptr) bool {
+	$if windows {
+		return false
+	} $else {
+		if isnil(a.worker_pool) || scopes.len < 4 {
+			return false
+		}
+		n_jobs := if scopes.len < a.worker_pool.size() + 1 {
+			scopes.len
+		} else {
+			a.worker_pool.size() + 1
+		}
+		chunk := (scopes.len + n_jobs - 1) / n_jobs
+		mut args := []WorkerScopeFreeArgs{cap: n_jobs}
+		for ji in 0 .. n_jobs {
+			start := ji * chunk
+			mut end := start + chunk
+			if end > scopes.len {
+				end = scopes.len
+			}
+			if start >= end {
+				break
+			}
+			args << WorkerScopeFreeArgs{
+				scopes: scopes
+				start:  start
+				end:    end
+			}
+		}
+		mut tasks := []workers.Task{cap: args.len}
+		for ji in 0 .. args.len {
+			tasks << workers.Task{
+				run:        worker_scope_free_thread
+				arg:        unsafe { voidptr(&args[ji]) }
+				force_sync: ji == 0
+			}
+		}
+		a.worker_pool.run(tasks)
+		return true
 	}
 }
 
@@ -651,23 +709,45 @@ struct MonomorphChunkArgs {
 mut:
 	roots         []flat.NodeId
 	emitted_specs []PendingGenericFnSpec
+	generated     []string
 	scan_nodes    []int
 	struct_specs  map[string]string
 	sum_specs     map[string]GenericSpecContext
 	scope         voidptr
 }
 
+struct MonomorphScanArgs {
+	a     &flat.FlatAst = unsafe { nil }
+	start int
+	end   int
+mut:
+	nodes []int
+}
+
 @[heap]
 struct MonomorphClaimState {
 mut:
-	mu        &sync.Mutex = unsafe { nil }
-	cond      &sync.Cond  = unsafe { nil }
-	claimed   map[string]bool
-	queues    [][]PendingGenericFnSpec
-	remaining int
+	mu          &sync.Mutex = unsafe { nil }
+	cond        &sync.Cond  = unsafe { nil }
+	claimed     map[string]bool
+	queues      [][]PendingGenericFnSpec
+	queue_costs []i64
+	remaining   int
 }
 
 $if !windows {
+	fn monomorph_scan_thread(arg voidptr) voidptr {
+		mut scan := unsafe { &MonomorphScanArgs(arg) }
+		mut nodes := []int{cap: (scan.end - scan.start) / 16}
+		for i in scan.start .. scan.end {
+			if scan.a.nodes[i].kind in [.call, .index, .index_assign] {
+				nodes << i
+			}
+		}
+		scan.nodes = unsafe { nodes }
+		return unsafe { nil }
+	}
+
 	fn monomorph_chunk_thread(arg voidptr) voidptr {
 		mut a := unsafe { &MonomorphChunkArgs(arg) }
 		mut w := unsafe { &Transformer(a.worker) }
@@ -685,26 +765,38 @@ $if !windows {
 		generated_start := w.a.nodes.len
 		mut roots := []flat.NodeId{cap: 64}
 		mut emitted_specs := []PendingGenericFnSpec{cap: 64}
+		mut generated := []string{}
 		mut struct_specs := map[string]string{}
 		mut sum_specs := map[string]GenericSpecContext{}
 		mut private_region := false
 		mut claims := a.claims
 		for {
 			claims.mu.lock()
-			for claims.queues[a.worker_idx].len == 0 && claims.remaining > 0 {
+			mut queue_idx := 0
+			for claims.remaining > 0 {
+				mut heaviest := i64(0)
+				for idx, cost in claims.queue_costs {
+					if cost > heaviest {
+						heaviest = cost
+						queue_idx = idx
+					}
+				}
+				if heaviest > 0 && claims.queues[queue_idx].len > 0 {
+					break
+				}
 				claims.cond.wait()
 			}
 			if claims.remaining == 0 {
 				claims.mu.unlock()
 				break
 			}
-			if claims.queues[a.worker_idx].len == 0 {
-				// A condition variable may wake spuriously. Recheck the queue while
-				// holding the mutex instead of popping an empty worker queue.
+			if claims.queues[queue_idx].len == 0 {
+				// A condition variable may wake spuriously. Recheck all queues.
 				claims.mu.unlock()
 				continue
 			}
-			spec := claims.queues[a.worker_idx].pop()
+			spec := claims.queues[queue_idx].pop()
+			claims.queue_costs[queue_idx] -= i64(w.generic_decl_source_cost(spec.decl))
 			claims.mu.unlock()
 			if !w.generic_specialization_registered(spec.decl, spec.args) {
 				value := specialized_generic_fn_value(spec.decl.node.value, spec.args)
@@ -717,7 +809,7 @@ $if !windows {
 			}
 			spec_nodes_start := w.a.nodes.len
 			root := w.emit_generic_fn_specialization(spec.decl, spec.args)
-			w.generated_fn_used_names(spec.decl, root, spec.args)
+			generated << w.generated_fn_used_names(spec.decl, root, spec.args)
 			for i in spec_nodes_start .. w.a.nodes.len {
 				node := w.a.nodes[i]
 				w.collect_generic_struct_specs_from_node(node, spec.decl.module, spec.decl.file,
@@ -735,6 +827,7 @@ $if !windows {
 					claims.claimed[request.key] = true
 					target := monomorph_spec_worker(request.key, claims.queues.len)
 					claims.queues[target] << request
+					claims.queue_costs[target] += i64(w.generic_decl_source_cost(request.decl))
 					claims.remaining++
 				} else {
 					w.pending_generic_fn_spec_keys.delete(request.key)
@@ -756,6 +849,7 @@ $if !windows {
 		}
 		a.roots = roots
 		a.emitted_specs = emitted_specs
+		a.generated = generated
 		a.scan_nodes = scan_nodes.clone()
 		a.struct_specs = struct_specs.move()
 		a.sum_specs = sum_specs.move()
@@ -793,17 +887,71 @@ $if !windows {
 	}
 }
 
-fn (mut t Transformer) run_parallel_monomorphize_specs(specs []PendingGenericFnSpec, struct_decls map[string]GenericStructDecl, sum_decls map[string]GenericSumDecl, mut emitted map[string]bool) bool {
+fn (mut t Transformer) prepare_parallel_monomorph_scan(start int, end int) bool {
 	$if windows {
 		return false
 	} $else {
-		if specs.len < 2 {
+		if isnil(t.a.worker_pool) || end - start < 65536 {
+			return false
+		}
+		n_jobs := t.a.worker_pool.size() + 1
+		chunk := (end - start + n_jobs - 1) / n_jobs
+		mut args := []MonomorphScanArgs{cap: n_jobs}
+		for ji in 0 .. n_jobs {
+			chunk_start := start + ji * chunk
+			chunk_end := int_min(chunk_start + chunk, end)
+			if chunk_start >= chunk_end {
+				break
+			}
+			args << MonomorphScanArgs{
+				a:     t.a
+				start: chunk_start
+				end:   chunk_end
+			}
+		}
+		mut tasks := []workers.Task{cap: args.len}
+		for ji in 0 .. args.len {
+			tasks << workers.Task{
+				run:        monomorph_scan_thread
+				arg:        unsafe { voidptr(&args[ji]) }
+				force_sync: ji == 0
+			}
+		}
+		t.a.worker_pool.run(tasks)
+		mut count := 0
+		for arg in args {
+			count += arg.nodes.len
+		}
+		mut nodes := []int{cap: count}
+		for arg in args {
+			nodes << arg.nodes
+		}
+		t.parallel_monomorph_scan_nodes = unsafe { nodes }
+		t.parallel_monomorph_scan_start = start
+		t.parallel_monomorph_scan_end = end
+		return true
+	}
+}
+
+fn (mut t Transformer) run_parallel_monomorphize_specs(specs []PendingGenericFnSpec, struct_decls map[string]GenericStructDecl, sum_decls map[string]GenericSumDecl, mut emitted map[string]bool, mut generated []string) bool {
+	$if windows {
+		return false
+	} $else {
+		if specs.len == 0 {
 			return false
 		}
 		if isnil(t.a.worker_pool) {
 			t.a.worker_pool = workers.new(runtime.nr_jobs() - 1)
 		}
-		n_jobs := monomorph_job_count(t.a.worker_pool.size() + 1, specs.len)
+		available_jobs := t.a.worker_pool.size() + 1
+		// Forked checkers carry substantial semantic indexes. Small programs do not have
+		// enough specialization work to repay a full machine-sized set of those clones.
+		job_limit := if t.a.nodes.len < 200_000 {
+			int_min(available_jobs, 4)
+		} else {
+			available_jobs
+		}
+		n_jobs := monomorph_job_count(job_limit, specs.len)
 		if n_jobs <= 1 {
 			return false
 		}
@@ -847,20 +995,27 @@ fn (mut t Transformer) run_parallel_monomorphize_specs(specs []PendingGenericFnS
 		// not been warmed by the earlier function-body transform. Build it before
 		// the forks; lazy initialization from several workers corrupts the map.
 		t.prepare_parallel_call_param_types()
+		// Reflected generic JSON bodies query loop-variable roles while every
+		// specialization is cloned. Build the immutable source-template index once
+		// on the master instead of making every worker scan the multi-million-node
+		// AST independently on its first reflected field.
+		t.prepare_comptime_reflected_for_roles()
 		t.tc.freeze_type_cache_for_forks()
 		setup_scope := transform_worker_scope_begin(t.scope_parallel_workers)
 		decls := t.cached_generic_fn_decls()
 		mut claims := &MonomorphClaimState{
-			mu:        sync.new_mutex()
-			claimed:   map[string]bool{}
-			queues:    [][]PendingGenericFnSpec{len: n_jobs}
-			remaining: specs.len
+			mu:          sync.new_mutex()
+			claimed:     map[string]bool{}
+			queues:      [][]PendingGenericFnSpec{len: n_jobs}
+			queue_costs: []i64{len: n_jobs}
+			remaining:   specs.len
 		}
 		claims.cond = sync.new_cond(claims.mu)
 		for spec in specs {
 			claims.claimed[spec.key] = true
 			target := monomorph_spec_worker(spec.key, n_jobs)
 			claims.queues[target] << spec
+			claims.queue_costs[target] += i64(t.generic_decl_source_cost(spec.decl))
 		}
 		mut args := []MonomorphChunkArgs{len: n_jobs}
 		args[0] = MonomorphChunkArgs{
@@ -1009,10 +1164,13 @@ fn (mut t Transformer) run_parallel_monomorphize_specs(specs []PendingGenericFnS
 				node_shift = t.a.nodes.len - node_starts[ci]
 				t.merge_worker_used_fns(w)
 				t.merge_worker(w, []FnWorkItem{}, node_starts[ci], child_starts[ci], false)
-				for name, receiver in w.receiver_method_suffix_index {
-					t.receiver_method_suffix_index[name.clone()] = receiver.clone()
+				for key, boxed in w.interface_boxed_types {
+					if boxed && key !in t.interface_boxed_types {
+						t.interface_boxed_types[key.clone()] = true
+					}
 				}
-				for name, spec_args in w.generic_specialization_args {
+				for name in w.generic_specialization_args_log {
+					spec_args := w.generic_specialization_args[name] or { continue }
 					if name !in t.generic_specialization_args {
 						t.generic_specialization_args[name.clone()] = spec_args.clone()
 					}
@@ -1047,10 +1205,10 @@ fn (mut t Transformer) run_parallel_monomorphize_specs(specs []PendingGenericFnS
 				emitted[generic_fn_spec_key(spec.decl.key, spec.args)] = true
 				t.pending_generic_fn_spec_keys.delete(spec.key)
 			}
+			for name in args[ci].generated {
+				generated << name.clone()
+			}
 			if ci > 0 {
-				for name, ret in w.fn_ret_types {
-					t.fn_ret_types[name.clone()] = ret.clone()
-				}
 				for pending in w.pending_generic_fn_specs {
 					mut owned_args := []string{cap: pending.args.len}
 					for item in pending.args {
@@ -1061,21 +1219,9 @@ fn (mut t Transformer) run_parallel_monomorphize_specs(specs []PendingGenericFnS
 			}
 			t.monomorph_profile('mono merged worker ${ci}: ${time.ticks() - debug_started} ms')
 		}
-		// Nested specialization requests can be transferred between workers.
-		// A node emitted by one worker can therefore retain arguments allocated
-		// by another. Publish merged node payloads through the parent text table
-		// against every worker arena before releasing any of them.
-		for ci in 1 .. n_jobs {
-			if args[ci].scope == unsafe { nil } {
-				continue
-			}
-			for idx in 0 .. t.a.nodes.len {
-				t.clone_scoped_worker_node(idx, args[ci].scope)
-			}
-		}
 		for ci in 1 .. n_jobs {
 			if args[ci].scope != unsafe { nil } {
-				transform_worker_scope_free(args[ci].scope)
+				t.monomorph_worker_scopes << args[ci].scope
 			}
 		}
 		t.parallel_monomorph_worker = false
@@ -1097,10 +1243,7 @@ fn (mut t Transformer) run_parallel_monomorphize_specs(specs []PendingGenericFnS
 			}
 		}
 		t.parallel_monomorph_sum_specs = owned_sum_specs.move()
-		for idx in 0 .. t.a.nodes.len {
-			t.clone_scoped_worker_node(idx, setup_scope)
-		}
-		transform_worker_scope_free(setup_scope)
+		t.monomorph_worker_scopes << setup_scope
 		t.monomorph_profile('mono merge: ${time.ticks() - debug_started} ms')
 		return any_started
 	}
@@ -1171,7 +1314,8 @@ fn (mut t Transformer) run_scoped_monomorphize_specs(specs []PendingGenericFnSpe
 		node_shift := t.a.nodes.len - base_nodes
 		t.merge_worker_used_fns(w)
 		t.merge_worker(w, []FnWorkItem{}, base_nodes, base_children, false)
-		for name, spec_args in w.generic_specialization_args {
+		for name in w.generic_specialization_args_log {
+			spec_args := w.generic_specialization_args[name] or { continue }
 			if name !in t.generic_specialization_args {
 				t.generic_specialization_args[name.clone()] = spec_args.clone()
 			}
@@ -1233,9 +1377,6 @@ fn monomorph_job_count(n_runtime_jobs int, n_specs int) int {
 	mut n := n_runtime_jobs
 	if n > max_parallel_monomorph_jobs {
 		n = max_parallel_monomorph_jobs
-	}
-	if n > n_specs {
-		n = n_specs
 	}
 	return n
 }

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -5101,7 +5101,8 @@ fn (tc &TypeChecker) private_declaration(name string) ?DeclarationVisibility {
 	}
 	for candidate in candidates {
 		visibility := tc.declaration_visibility[candidate] or { continue }
-		if !visibility.is_pub && visibility.module_name != tc.cur_module {
+		same_main_module := visibility.module_name in ['', 'main'] && tc.cur_module in ['', 'main']
+		if !visibility.is_pub && visibility.module_name != tc.cur_module && !same_main_module {
 			return visibility
 		}
 		return none

--- a/vlib/v3/types/checker_tail.v
+++ b/vlib/v3/types/checker_tail.v
@@ -10411,16 +10411,27 @@ fn (mut tc TypeChecker) check_call_arg_types(id flat.NodeId, node flat.Node, inf
 		raw_arg := tc.a.child_node(&node, i)
 		if raw_arg.kind == .field_init {
 			$if ownership ? {
-				tc.ownership_check_node_with_deferred_aggregate_consumption(arg_id)
+				if expected := tc.params_field_expected_type(raw_arg.value, info) {
+					tc.ownership_check_node_with_expected_context_and_aggregate_consumption_mode(arg_id,
+						expected, true)
+				} else {
+					tc.ownership_check_node_with_deferred_aggregate_consumption(arg_id)
+				}
 			} $else {
-				tc.check_node(arg_id)
+				if expected := tc.params_field_expected_type(raw_arg.value, info) {
+					tc.check_node_with_expected_context(arg_id, expected)
+				} else {
+					tc.check_node(arg_id)
+				}
 			}
 			if tc.unsafe_depth == 0 {
 				if owner := tc.params_field_owner(raw_arg.value, info) {
 					if !is_anonymous_struct_name(owner) {
 						owner_base := strip_generic_args_name(owner)
 						decl_mod := tc.struct_modules[owner_base] or { '' }
-						if decl_mod.len > 0 && decl_mod != tc.cur_module {
+						same_main_module := decl_mod in ['', 'main']
+							&& tc.cur_module in ['', 'main']
+						if decl_mod.len > 0 && decl_mod != tc.cur_module && !same_main_module {
 							is_public := tc.visible_mutation_struct_field_is_public(owner,
 								raw_arg.value, decl_mod) or { true }
 							if !is_public {
@@ -14396,7 +14407,7 @@ fn (tc &TypeChecker) expr_can_be_implicit_ref_arg(expr_id flat.NodeId) bool {
 	}
 	// V materializes non-addressable value expressions into stable temporaries
 	// when they are passed to non-mut reference parameters.
-	return node.kind in [.struct_init, .call, .or_expr, .cast_expr, .if_expr, .match_stmt,
+	return node.kind in [.struct_init, .call, .or_expr, .cast_expr, .if_expr, .match_stmt, .index,
 		.int_literal, .float_literal, .bool_literal, .char_literal, .string_literal, .string_interp]
 }
 

--- a/vlib/v3/types/checker_tail_stmt.v
+++ b/vlib/v3/types/checker_tail_stmt.v
@@ -3647,7 +3647,8 @@ fn (mut tc TypeChecker) check_struct_init(id flat.NodeId, node flat.Node) {
 					&& tc.resolve_selective_import_type_symbol(init_type_text) == none {
 					owner_base := strip_generic_args_name(init_name)
 					decl_mod := tc.struct_modules[owner_base] or { '' }
-					if decl_mod.len > 0 && decl_mod != tc.cur_module
+					same_main_module := decl_mod in ['', 'main'] && tc.cur_module in ['', 'main']
+					if decl_mod.len > 0 && decl_mod != tc.cur_module && !same_main_module
 						&& !is_anonymous_struct_name(init_name) {
 						is_public := tc.visible_mutation_struct_field_is_public(init_name,
 							field.value, decl_mod) or { true }


### PR DESCRIPTION
## Summary

- make generic specialization emission parallel and balance nested work between workers
- precompute reflected-field loop metadata and avoid repeated whole-AST generic scans
- reduce interface/cache refreshes, worker-arena promotion, and redundant text canonicalization
- stop recursive interface auto-string lowering by routing cycles through generated helpers
- preserve exact generic specialization identities across worker merges
- fix related sum smartcast and concrete optional/interface C ABI regressions found while compiling Volt

## Performance

Measured while compiling /Users/alex/code/volt with a V3 compiler built using -prod:

- monomorphize: about 39-40 s before, 759.32 ms after
- V3 C generation: 562.41 ms
- V3 frontend through C output: 7.69 s, versus 24.49 s with V1
- complete native compile and link succeeds in 29.59 s

A V -profile run identified generic specialization draining, reflected comptime loops, and repeated FlatAst child lookups as the dominant old hotspots.

## Tests

- full native Volt compile and link with the production V3 compiler
- ./vnew -silent test vlib/v3/transform/ — 7/7 passed
- focused V3 recursive auto-string, generic interface, parallel monomorphization, JSON homonym, params-struct, and sum-smartcast regressions
- ./vnew -silent vlib/v3/gen/c/types_test.v — passed
- ./vnew -silent vlib/v/gen/c/coutput_test.v — passed, 230 matched and 17 platform-skipped
- formatting verification and git diff --check — passed

The broader compiler error runner remains non-green on 10 module fixtures in this worktree, and the full V3 Cgen directory retains the cache-input assertion in target_test.v. The directly affected tests above pass.