### PR TITLE
arrays: add merge_desc for descending sorted arrays

### DIFF
--- a/vlib/arrays/arrays.v
+++ b/vlib/arrays/arrays.v
@@ -85,9 +85,41 @@ pub fn merge[T](a []T, b []T) []T {
 	mut ia := 0
 	mut ib := 0
 	mut j := 0
-	// TODO: efficient approach to merge_desc where: a[ia] >= b[ib]
 	for ia < a.len && ib < b.len {
 		if a[ia] <= b[ib] {
+			m[j] = a[ia]
+			ia++
+		} else {
+			m[j] = b[ib]
+			ib++
+		}
+		j++
+	}
+	// a leftovers
+	for ia < a.len {
+		m[j] = a[ia]
+		ia++
+		j++
+	}
+	// b leftovers
+	for ib < b.len {
+		m[j] = b[ib]
+		ib++
+		j++
+	}
+	return m
+}
+
+// merge_desc merges two sorted arrays (descending) and maintains sorted order.
+// Example: arrays.merge_desc([7, 5, 3, 1], [8, 6, 4, 2]) // => [8, 7, 6, 5, 4, 3, 2, 1]
+@[direct_array_access]
+pub fn merge_desc[T](a []T, b []T) []T {
+	mut m := []T{len: a.len + b.len}
+	mut ia := 0
+	mut ib := 0
+	mut j := 0
+	for ia < a.len && ib < b.len {
+		if a[ia] >= b[ib] {
 			m[j] = a[ia]
 			ia++
 		} else {

--- a/vlib/arrays/arrays_test.v
+++ b/vlib/arrays/arrays_test.v
@@ -71,6 +71,17 @@ fn test_merge() {
 	assert merge[int](d, b) == b
 }
 
+fn test_merge_desc() {
+	a := [7, 5, 5, 3, 1]
+	b := [8, 6, 5, 4, 2]
+	c := []int{}
+	d := []int{}
+	assert merge_desc[int](a, b) == [8, 7, 6, 5, 5, 5, 4, 3, 2, 1]
+	assert merge_desc[int](c, d) == []
+	assert merge_desc[int](a, c) == a
+	assert merge_desc[int](d, b) == b
+}
+
 fn test_append() {
 	a := [1, 3, 5, 5, 7]
 	b := [2, 4, 4, 5, 6, 8]


### PR DESCRIPTION
# What does this PR do?

Add arrays.merge_desc, which merges two descending-sorted arrays while
preserving their order.

# Tests

All tests passed.