### PR TITLE
v3: forward ownership define to target builds

### DIFF
--- a/cmd/v/macos_v3_test.v
+++ b/cmd/v/macos_v3_test.v
@@ -978,6 +978,10 @@ fn test_ownership_forwarding_adds_the_compile_time_define_once() {
 	assert v3_args_have_ownership_define(forwarded)
 	explicit := v3_ownership_forwarded_args(prefs, ['-ownership', '-d', 'ownership', 'main.v'])
 	assert explicit.count(it == 'ownership') == 1
+	invalid_compact := v3_ownership_forwarded_args(prefs, ['-ownership', '-d=ownership', 'main.v'])
+	assert '-d=ownership' in invalid_compact
+	assert invalid_compact.count(it == '-d') == 1
+	assert invalid_compact.count(it == 'ownership') == 1
 }
 
 fn test_macos_v3_ownership_forwarding_is_quiet_and_normalizes_x86() {
@@ -1040,7 +1044,7 @@ fn main() {
 	environment['VFLAGS'] = ''
 	environment['VOSARGS'] = ''
 	mut process := os.new_process(@VEXE)
-	process.set_args(['-ownership', '-gc', 'none', '-o', output, source])
+	process.set_args(['-ownership', '-d=ownership', '-gc', 'none', '-o', output, source])
 	process.set_environment(environment)
 	process.set_redirect_stdio()
 	process.run()

--- a/cmd/v/macos_v3_test.v
+++ b/cmd/v/macos_v3_test.v
@@ -971,12 +971,11 @@ fn test_ownership_delegation_is_platform_scoped_and_honors_old_compiler() {
 	assert !ownership_delegation_is_requested(true, false, true, 'macos')
 }
 
-fn test_ownership_forwarding_keeps_internal_define_out_of_target_args() {
+fn test_ownership_forwarding_adds_the_compile_time_define_once() {
 	prefs := &pref.Preferences{}
 	forwarded := v3_ownership_forwarded_args(prefs, ['-ownership', 'main.v'])
 	assert '-ownership' !in forwarded
-	assert 'ownership' !in forwarded
-	assert !forwarded.any(it in ['-d=ownership', '-downership'])
+	assert v3_args_have_ownership_define(forwarded)
 	explicit := v3_ownership_forwarded_args(prefs, ['-ownership', '-d', 'ownership', 'main.v'])
 	assert explicit.count(it == 'ownership') == 1
 }
@@ -994,8 +993,7 @@ fn test_macos_v3_ownership_forwarding_is_quiet_and_normalizes_x86() {
 			'x86', 'main.v'])
 		assert macos_v3_internal_quiet_flag in forwarded
 		assert '-ownership' !in forwarded
-		assert 'ownership' !in forwarded
-		assert !forwarded.any(it in ['-d=ownership', '-downership'])
+		assert v3_args_have_ownership_define(forwarded)
 		assert forwarded.count(it == 'amd64') == 2
 		assert 'x86' !in forwarded
 
@@ -1008,7 +1006,7 @@ fn test_macos_v3_ownership_forwarding_is_quiet_and_normalizes_x86() {
 	}
 }
 
-fn test_ownership_delegation_does_not_define_target_ownership() {
+fn test_ownership_delegation_defines_target_ownership() {
 	root := os.join_path(os.real_path(os.vtmp_dir()), 'v3_ownership_target_define_${os.getpid()}')
 	os.rmdir_all(root) or {}
 	os.mkdir_all(root) or { panic(err) }
@@ -1020,20 +1018,18 @@ fn test_ownership_delegation_does_not_define_target_ownership() {
 	module_dir := os.join_path(root, 'marker')
 	os.mkdir_all(module_dir) or { panic(err) }
 	os.write_file(os.join_path(module_dir, 'marker.v'), 'module marker
-
-pub fn value() string {
-	return "ok"
-}
 ')!
 	os.write_file(os.join_path(module_dir, 'marker_d_ownership.v'), 'module marker
 
-$compile_error("ownership-suffixed target file was included")
+pub fn value() string {
+	return "ownership"
+}
 ')!
 	os.write_file(source, r'
 import marker
 
-$if ownership ? {
-	$compile_error("ownership define leaked into target")
+$if !ownership ? {
+	$compile_error("ownership define was not forwarded to target")
 }
 
 fn main() {
@@ -1056,7 +1052,7 @@ fn main() {
 	assert os.is_executable(output)
 	run := os.execute(os.quoted_path(output))
 	assert run.exit_code == 0, run.output
-	assert run.output.trim_space() == 'ok'
+	assert run.output.trim_space() == 'ownership'
 }
 
 fn test_autofree_unsupported_modes_stay_on_the_standard_compiler() {

--- a/cmd/v/v.v
+++ b/cmd/v/v.v
@@ -263,7 +263,7 @@ fn v3_ownership_forwarded_args(prefs &pref.Preferences, merged_args []string) []
 
 fn v3_args_have_ownership_define(args []string) bool {
 	for i, arg in args {
-		if arg in ['-d=ownership', '-downership'] {
+		if arg == '-downership' {
 			return true
 		}
 		if arg == '-d' && i + 1 < args.len && args[i + 1] == 'ownership' {

--- a/cmd/v/v.v
+++ b/cmd/v/v.v
@@ -250,11 +250,27 @@ fn autofree_args_require_standard_compiler(args []string, command string) bool {
 }
 
 fn v3_ownership_forwarded_args(prefs &pref.Preferences, merged_args []string) []string {
-	ownership_args := merged_args.filter(it != '-ownership')
+	mut ownership_args := merged_args.filter(it != '-ownership')
+	if !v3_args_have_ownership_define(ownership_args) {
+		ownership_args.prepend('ownership')
+		ownership_args.prepend('-d')
+	}
 	$if macos {
 		return macos_v3_forwarded_args(prefs, ownership_args)
 	}
 	return ownership_args
+}
+
+fn v3_args_have_ownership_define(args []string) bool {
+	for i, arg in args {
+		if arg in ['-d=ownership', '-downership'] {
+			return true
+		}
+		if arg == '-d' && i + 1 < args.len && args[i + 1] == 'ownership' {
+			return true
+		}
+	}
+	return false
 }
 
 fn autofree_requires_standard_compiler(prefs &pref.Preferences) bool {

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -7173,6 +7173,9 @@ V can bring in values at compile time from `-d ident=value` flag defines, passed
 the command line to the compiler. You can also pass `-d ident`, which will have the
 same meaning as passing `-d ident=true`.
 
+The `-ownership` compiler mode supplies `ownership` as a target-visible custom option.
+This enables `$if ownership ? {}` branches and includes `*_d_ownership.v` files.
+
 To get the value in your code, use: `$d('ident', default)`, where `default`
 can be `false` for booleans, `0` or `123` for i64 numbers, `0.0` or `113.0`
 for f64 numbers, `'a string'` for strings.

--- a/doc/ownership.md
+++ b/doc/ownership.md
@@ -20,6 +20,10 @@ Compile with ownership checking:
 v -ownership -o out main.v
 ```
 
+Ownership mode defines the target-visible custom option `ownership`. Code can use
+`$if ownership ? {}` to select ownership-specific branches, and files named
+`*_d_ownership.v` are included in ownership builds.
+
 ## Creating owned values
 
 Call `.to_owned()` on a string to create an owned copy. Only strings created with
@@ -209,6 +213,9 @@ compile-time defines so there is no ownership-checking overhead in the normal co
 ```
 v -ownership file.v        # check and compile
 ```
+
+The main V driver forwards `-d ownership` to the ownership-enabled compiler. This both
+enables the target compile-time checks described above and selects ownership-specific files.
 
 To build the ownership-enabled compiler manually:
 

--- a/vlib/v3/README.md
+++ b/vlib/v3/README.md
@@ -316,7 +316,8 @@ for generated programs, which support `-gc none` only.
 The standard v3 executable is built without `-d ownership`, so the ownership checker and its
 analysis stages are compiled out. It rejects both `-ownership` and `-d ownership`; the main V
 driver builds a separate ownership-enabled v3 executable only for an explicit `v -ownership`
-invocation.
+invocation. Target compilations receive both `-ownership` and `-d ownership`, so the custom
+`ownership` option is visible in target `$if` blocks and selects target `*_d_ownership.v` files.
 
 The table uses the first v3-generated C stage, `./v3 -o v4 v3.v`. The plain
 bootstrap includes thread support. v3 self-hosts parallel-capable successors by

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -6119,9 +6119,9 @@ pub fn run(args []string) {
 			i++
 		} else if args[i] == '-ownership' || args[i] == '--ownership' {
 			// The ownership checker itself is compiled into v3 via `-d ownership`.
-			// The runtime `-ownership` flag should only load the builtin ownership
-			// overlays; it must not expose `ownership` to target `$if` blocks or target
-			// `_d_ownership.v` files.
+			// The main V launcher pairs this flag with a target `-d ownership`, which
+			// intentionally exposes `ownership` to target `$if` blocks and selects target
+			// `_d_ownership.v` files. This flag enables the ownership analysis itself.
 			ownership_mode = true
 			i++
 		} else if args[i] == '-no-parallel' || args[i] == '--no-parallel' {


### PR DESCRIPTION
## Summary

- forward the ownership compile-time define to V3 ownership/autofree target builds
- recognize the documented -d ownership pair and valid -downership compact form without treating malformed -d=ownership as active
- cover target $if ownership checks and _d_ownership.v selection, including the malformed compact-flag regression
- document the target-visible ownership contract in the ownership guide, compiler docs, and V3 maintainer docs

## Testing

- PASS: ./v -g -keepc -o ./vnew cmd/v
- PASS: focused ownership forwarding and end-to-end delegation tests in cmd/v/macos_v3_test.v
- PASS: VFLAGS=-old-compiler ./vnew -old-compiler -silent vlib/v/compiler_errors_test.v (1618 passed, 1 skipped)
- PASS: ./vnew check-md for doc/ownership.md, doc/docs.md, and vlib/v3/README.md
- PASS: ./vnew fmt -w for all touched V files
- PASS: git diff --check
- PARTIAL: VFLAGS=-old-compiler ./vnew -old-compiler -silent test vlib/v/ (2333 passed, 28 skipped; the unrelated inout compiler snapshot and C output snapshot runners failed)

The full macOS V3 test file also requires an iPhone SDK that is unavailable in this environment; the three changed tests were run directly and passed.