### PR TITLE
v3: fix cmd/v self-host compilation

### DIFF
--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -18526,7 +18526,10 @@ fn (mut g FlatGen) json_number_token_helpers() {
 }
 
 fn (mut g FlatGen) filelock_compat_decls() {
-	if !g.libc_compat_fns['filelock'] {
+	if !g.libc_compat_fns['filelock'] && !g.used_fn_contains('C.v_filelock_lock')
+		&& !g.used_fn_contains('C.v_filelock_unlock')
+		&& !g.used_fn_contains_in_module('FileLock.lock_fd', 'filelock')
+		&& !g.used_fn_contains_in_module('FileLock.close_lock', 'filelock') {
 		return
 	}
 	g.writeln('#ifndef V_OS_FILELOCK_HELPERS_H')

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -18528,6 +18528,7 @@ fn (mut g FlatGen) json_number_token_helpers() {
 fn (mut g FlatGen) filelock_compat_decls() {
 	if !g.libc_compat_fns['filelock'] && !g.used_fn_contains('C.v_filelock_lock')
 		&& !g.used_fn_contains('C.v_filelock_unlock')
+		&& !g.used_fn_contains_in_module('FileLock.lock_handle', 'filelock')
 		&& !g.used_fn_contains_in_module('FileLock.lock_fd', 'filelock')
 		&& !g.used_fn_contains_in_module('FileLock.close_lock', 'filelock') {
 		return

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -1399,7 +1399,9 @@ fn (mut g FlatGen) preseed_libc_compat_fns() {
 		g.libc_compat_fns['gettid'] = true
 	}
 	if refs['C.v_filelock_lock'] || refs['C.v_filelock_unlock'] || refs['v_filelock_lock']
-		|| refs['v_filelock_unlock'] || g.used_fn_contains_in_module('FileLock.lock_fd', 'filelock')
+		|| refs['v_filelock_unlock']
+		|| g.used_fn_contains_in_module('FileLock.lock_handle', 'filelock')
+		|| g.used_fn_contains_in_module('FileLock.lock_fd', 'filelock')
 		|| g.used_fn_contains_in_module('FileLock.close_lock', 'filelock') {
 		g.libc_compat_fns['filelock'] = true
 	}

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -1399,7 +1399,8 @@ fn (mut g FlatGen) preseed_libc_compat_fns() {
 		g.libc_compat_fns['gettid'] = true
 	}
 	if refs['C.v_filelock_lock'] || refs['C.v_filelock_unlock'] || refs['v_filelock_lock']
-		|| refs['v_filelock_unlock'] {
+		|| refs['v_filelock_unlock'] || g.used_fn_contains_in_module('FileLock.lock_fd', 'filelock')
+		|| g.used_fn_contains_in_module('FileLock.close_lock', 'filelock') {
 		g.libc_compat_fns['filelock'] = true
 	}
 }
@@ -14541,6 +14542,14 @@ fn (mut g FlatGen) collect_c_extern_ref_from_node(node &flat.Node) {
 }
 
 fn (g &FlatGen) collect_c_extern_ref_from_node_into(node &flat.Node, mut refs map[string]bool) {
+	if node.kind == .ident
+		&& (node.value.starts_with('C.') || node.value in ['v_filelock_lock', 'v_filelock_unlock']) {
+		raw_name := if node.value.starts_with('C.') { node.value } else { 'C.${node.value}' }
+		raw_cfn := g.cname(raw_name)
+		refs[raw_name] = true
+		refs[raw_cfn] = true
+		refs[c_winapi_wide_export_name(raw_cfn)] = true
+	}
 	if node.kind == .selector && node.children_count > 0 && node.value.len > 0 {
 		base_id := g.a.child(node, 0)
 		if int(base_id) >= 0 {

--- a/vlib/v3/gen/c/parallel_worker_test.v
+++ b/vlib/v3/gen/c/parallel_worker_test.v
@@ -54,6 +54,24 @@ fn test_scoped_parallel_worker_reuses_preselected_functions_and_c_extern_refs() 
 	assert w.c_extern_refs_ready
 }
 
+fn test_windows_filelock_method_preseeds_parallel_compat_helpers() {
+	mut g, _ := parallel_worker_test_gen(true)
+	mut used := {
+		'filelock.FileLock.lock_handle': true
+	}
+	g.used_fns = &used
+	// Isolate used-function reachability from the later function-body reference scan.
+	g.c_extern_refs_ready = true
+	g.preseed_libc_compat_fns()
+	assert g.libc_compat_fns['filelock']
+
+	g.libc_compat_fns.delete('filelock')
+	g.filelock_compat_decls()
+	c_code := g.sb.str()
+	assert c_code.contains('static inline int v_filelock_lock(HANDLE handle'), c_code
+	assert c_code.contains('static inline int v_filelock_unlock(HANDLE handle'), c_code
+}
+
 fn test_parallel_tail_worker_preserves_runtime_init_module_order() {
 	mut g, _ := parallel_worker_test_gen(true)
 	g.const_runtime_inits = ['\tmoda__runtime_const = moda__make_const();']

--- a/vlib/v3/markused/markused.v
+++ b/vlib/v3/markused/markused.v
@@ -479,9 +479,10 @@ fn mark_used_with_test_files(a &flat.FlatAst, tc &types.TypeChecker, test_files 
 			'markused.CallCollector.collect_bodies_scoped_batches',
 			'parser.Parser.precollect_parallel_comptime_consts',
 			'types.TypeChecker.check_scoped_batches', 'driver.compare_print_notices',
-			'pref.detect_vroot', 'pref.detect_vexe', 'types.compare_type_errors',
-			'types.compare_type_notices', 'types.TypeChecker.result_return_uses_multi_tail',
-			'sync.Semaphore.timed_wait', 'sync.Semaphore.destroy'] {
+			'pref.detect_vroot', 'pref.detect_vexe', 'v3.pref.detect_vroot', 'v3.pref.detect_vexe',
+			'types.compare_type_errors', 'types.compare_type_notices',
+			'types.TypeChecker.result_return_uses_multi_tail', 'sync.Semaphore.timed_wait',
+			'sync.Semaphore.destroy'] {
 			queue << seed
 			used[seed] = true
 		}

--- a/vlib/v3/tests/filelock_c_helpers_codegen_test.v
+++ b/vlib/v3/tests/filelock_c_helpers_codegen_test.v
@@ -10,7 +10,7 @@ fn filelock_helpers_build_v3() string {
 	v3_bin := os.join_path(os.temp_dir(), 'v3_filelock_helpers_test_${os.getpid()}')
 	os.rm(v3_bin) or {}
 	build :=
-		os.execute('${filelock_helpers_vexe} -gc none -path "${filelock_helpers_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${filelock_helpers_v3_src}')
+		os.execute('${filelock_helpers_vexe} -gc none -d parallel -path "${filelock_helpers_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${filelock_helpers_v3_src}')
 	assert build.exit_code == 0, build.output
 	return v3_bin
 }
@@ -56,4 +56,33 @@ fn main() {
 	run := os.execute(bin)
 	assert run.exit_code == 0, run.output
 	assert run.output.trim_space() == '47'
+
+	method_src := os.join_path(os.temp_dir(), 'v3_filelock_helpers_method_input_${os.getpid()}.v')
+	os.write_file(method_src, 'module main
+
+import os.filelock
+
+fn use(mut file_lock filelock.FileLock) bool {
+	if file_lock.try_acquire() {
+		return file_lock.release()
+	}
+	return false
+}
+
+fn main() {
+	mut file_lock := filelock.new("v3_filelock_helpers_method_input.lock")
+	println(use(mut file_lock))
+}
+	') or {
+		panic(err)
+	}
+	method_bin := os.join_path(os.temp_dir(), 'v3_filelock_helpers_method_input_${os.getpid()}')
+	os.rm(method_bin) or {}
+	os.rm(method_bin + '.c') or {}
+	method_compile := os.execute('${v3_bin} ${method_src} -b c -o ${method_bin}')
+	assert method_compile.exit_code == 0, method_compile.output
+	assert !method_compile.output.contains('C compilation failed'), method_compile.output
+	method_c_code := os.read_file(method_bin + '.c') or { panic(err) }
+	assert method_c_code.contains('\nstatic inline int v_filelock_lock('), method_c_code
+	assert method_c_code.contains('\nstatic inline int v_filelock_unlock('), method_c_code
 }

--- a/vlib/v3/tests/markused_test.v
+++ b/vlib/v3/tests/markused_test.v
@@ -134,6 +134,8 @@ println(message())
 	assert used['strconv.format_uint']
 	assert used['array.delete_last']
 	assert used['i64.str']
+	assert used['v3.pref.detect_vroot']
+	assert used['v3.pref.detect_vexe']
 }
 
 fn test_cached_trivial_output_keeps_cached_runtime_helper_seeds() {

--- a/vlib/v3/tests/review_transform_regressions_test.v
+++ b/vlib/v3/tests/review_transform_regressions_test.v
@@ -116,6 +116,33 @@ fn main() {
 	assert out == 'true'
 }
 
+fn test_sum_equality_uses_canonical_struct_field_types() {
+	v3_bin := build_v3_review_transform()
+	out := run_good_with_flags(v3_bin, 'sum_equality_canonical_struct_field_types', '-building-v', 'import v.token
+
+struct Box {
+	pos token.Pos
+}
+
+type Value = Box | int
+
+fn main() {
+	left := Value(Box{
+		pos: token.Pos{
+			line_nr: 1
+		}
+	})
+	right := Value(Box{
+		pos: token.Pos{
+			line_nr: 1
+		}
+	})
+	println(left == right)
+}
+')
+	assert out == 'true'
+}
+
 fn test_map_interface_equality_keeps_typed_map_get() {
 	v3_bin := build_v3_review_transform()
 	out := run_good(v3_bin, 'map_interface_equality_typed_get', 'interface Value {
@@ -330,6 +357,10 @@ fn write_project_file(root string, rel string, src string) {
 }
 
 fn run_good_project(v3_bin string, name string, files map[string]string, input string) string {
+	return run_good_project_with_flags(v3_bin, name, '', files, input)
+}
+
+fn run_good_project_with_flags(v3_bin string, name string, flags string, files map[string]string, input string) string {
 	root := os.join_path(os.temp_dir(), 'v3_${name}_project')
 	if os.exists(root) {
 		os.rmdir_all(root) or { panic(err) }
@@ -340,7 +371,7 @@ fn run_good_project(v3_bin string, name string, files map[string]string, input s
 	}
 	input_path := if input.len == 0 { root } else { os.join_path(root, input) }
 	good_bin := os.join_path(os.temp_dir(), 'v3_${name}')
-	compile := os.execute('${v3_bin} ${input_path} -b c -o ${good_bin}')
+	compile := os.execute('${v3_bin} ${flags} ${input_path} -b c -o ${good_bin}')
 	assert compile.exit_code == 0, '${name}: compile failed\n${compile.output}'
 	assert !compile.output.contains('C compilation failed'), '${name}: C compilation failed\n${compile.output}'
 	run := os.execute(good_bin)
@@ -792,6 +823,17 @@ fn test_imported_module_generic_function_value_prefers_local_declaration() {
 		'main.v': 'module main\n\nimport a\n\nfn pick[T](value T) T {\n\treturn value + 100\n}\n\nfn main() {\n\timported := a.make_picker()\n\tlocal := pick[int]\n\tprintln(int_str(imported(1)))\n\tprintln(int_str(local(1)))\n}\n'
 	}, 'main.v')
 	assert out == '2\n101'
+}
+
+fn test_building_v_function_values_keep_plain_and_module_helpers() {
+	v3_bin := build_v3_review_transform()
+	out := run_good_project_with_flags(v3_bin, 'building_v_function_value_reachability',
+		'-building-v', {
+		'v.mod':           "Module { name: 'building_v_function_value_reachability' }\n"
+		'worker/worker.v': 'module worker\n\nfn local_helper() int {\n\treturn 19\n}\n\nfn apply(callback fn () int) int {\n\treturn callback()\n}\n\npub fn local_value() int {\n\treturn apply(local_helper)\n}\n\npub fn selected_helper() int {\n\treturn 23\n}\n'
+		'main.v':          'module main\n\nimport worker\n\nfn apply(callback fn () int) int {\n\treturn callback()\n}\n\nfn main() {\n\tprintln(worker.local_value() + apply(worker.selected_helper))\n}\n'
+	}, 'main.v')
+	assert out == '42'
 }
 
 fn test_imported_selector_generic_function_value_is_specialized() {
@@ -5671,6 +5713,42 @@ fn main() {
 }
 ')
 	assert out == 'integer'
+}
+
+fn test_nested_match_smartcast_declaration_uses_nearest_variant() {
+	v3_bin := build_v3_review_transform()
+	out := run_good_with_flags(v3_bin, 'nested_match_smartcast_nearest_variant', '-building-v', 'struct Assoc {
+	exprs []Expr
+}
+
+struct Empty {}
+struct Other {}
+
+type Expr = Assoc | Empty
+type Node = Expr | Other
+
+fn child_count(node Node) int {
+	if node is Expr {
+		match node {
+			Assoc {
+				assoc := node
+				return assoc.exprs.len
+			}
+			Empty {
+				return 0
+			}
+		}
+	}
+	return 0
+}
+
+fn main() {
+	println(child_count(Expr(Assoc{
+		exprs: [Expr(Empty{})]
+	})))
+}
+')
+	assert out == '1'
 }
 
 fn test_building_v_keeps_valid_match_and_filtered_array_expression_types() {

--- a/vlib/v3/transform/expr.v
+++ b/vlib/v3/transform/expr.v
@@ -3208,7 +3208,9 @@ fn (mut t Transformer) make_struct_field_eq_expr_with_seen(lhs flat.NodeId, rhs 
 	next_seen << struct_type
 	mut eq := flat.empty_node
 	for field in info.fields {
-		field_type := if field.typ.len > 0 { field.typ } else { field.raw_typ }
+		field_type := t.lookup_struct_field_type(struct_type, field.name) or {
+			if field.typ.len > 0 { field.typ } else { field.raw_typ }
+		}
 		lhs_field := t.make_selector(lhs, field.name, field_type)
 		rhs_field := t.make_selector(rhs, field.name, field_type)
 		field_eq := if t.membership_type_is_pointer(field_type) {

--- a/vlib/v3/types/checker_tail_stmt.v
+++ b/vlib/v3/types/checker_tail_stmt.v
@@ -5674,6 +5674,7 @@ fn (mut tc TypeChecker) check_selector(id flat.NodeId, node flat.Node) {
 			}
 			if key := tc.selector_fn_value_key(node) {
 				if typ := tc.fn_type_from_key(key) {
+					tc.remember_resolved_fn_value(id, key)
 					tc.register_synth_type(id, typ)
 					return
 				}
@@ -5703,6 +5704,7 @@ fn (mut tc TypeChecker) check_selector(id flat.NodeId, node flat.Node) {
 		}
 		if key := tc.selector_fn_value_key(node) {
 			if typ := tc.fn_type_from_key(key) {
+				tc.remember_resolved_fn_value(id, key)
 				tc.register_synth_type(id, typ)
 			}
 		}
@@ -6939,6 +6941,7 @@ fn (mut tc TypeChecker) check_valid_selector(id flat.NodeId, node flat.Node) {
 		}
 		if key := tc.selector_fn_value_key(node) {
 			if typ := tc.fn_type_from_key(key) {
+				tc.remember_resolved_fn_value(id, key)
 				tc.register_synth_type(id, typ)
 				return
 			}
@@ -7398,6 +7401,9 @@ fn (mut tc TypeChecker) check_ident(id flat.NodeId, node flat.Node) {
 		}
 	}
 	if typ := tc.fn_value_type(node.value) {
+		if key := tc.ident_fn_value_key(node.value) {
+			tc.remember_resolved_fn_value(id, key)
+		}
 		tc.register_synth_type(id, typ)
 		return
 	}
@@ -12255,13 +12261,15 @@ fn (tc &TypeChecker) match_type_pattern(node &flat.Node) ?string {
 			return node.typ
 		}
 		if node.value.len > 0 && node.pos.offset > 0 {
-			file := tc.a.source_files[node.pos.id] or { return none }
-			source := tc.source_texts_by_file[file.name] or { return none }
-			if node.pos.offset < source.len && source[node.pos.offset] in [`?`, `!`] {
-				return source[node.pos.offset..node.pos.offset + 1] + node.value
-			}
-			if node.pos.offset <= source.len && source[node.pos.offset - 1] in [`?`, `!`] {
-				return source[node.pos.offset - 1..node.pos.offset] + node.value
+			if file := tc.a.source_files[node.pos.id] {
+				if source := tc.source_texts_by_file[file.name] {
+					if node.pos.offset < source.len && source[node.pos.offset] in [`?`, `!`] {
+						return source[node.pos.offset..node.pos.offset + 1] + node.value
+					}
+					if node.pos.offset <= source.len && source[node.pos.offset - 1] in [`?`, `!`] {
+						return source[node.pos.offset - 1..node.pos.offset] + node.value
+					}
+				}
 			}
 		}
 		if node.value.starts_with('fn(') || node.value.starts_with('fn (') {
@@ -12416,19 +12424,42 @@ fn (tc &TypeChecker) smartcast_type(id flat.NodeId) ?Type {
 	return result
 }
 
-fn (tc &TypeChecker) lexical_smartcast_type(id flat.NodeId, key string) ?Type {
-	if typ := tc.lexical_if_smartcast_type(id, key) {
-		return typ
-	}
-	if typ := tc.lexical_for_smartcast_type(id, key) {
-		return typ
-	}
-	return tc.lexical_match_smartcast_type_with_key(id, key)
+struct LexicalSmartcastCandidate {
+	typ   Type
+	depth int
 }
 
-fn (tc &TypeChecker) lexical_for_smartcast_type(id flat.NodeId, key string) ?Type {
+fn (tc &TypeChecker) lexical_smartcast_type(id flat.NodeId, key string) ?Type {
+	mut best := LexicalSmartcastCandidate{
+		depth: max_int
+	}
+	mut found := false
+	if candidate := tc.lexical_if_smartcast_candidate(id, key) {
+		best = candidate
+		found = true
+	}
+	if candidate := tc.lexical_for_smartcast_candidate(id, key) {
+		if !found || candidate.depth < best.depth {
+			best = candidate
+			found = true
+		}
+	}
+	if candidate := tc.lexical_match_smartcast_candidate(id, key) {
+		if !found || candidate.depth < best.depth {
+			best = candidate
+			found = true
+		}
+	}
+	if found {
+		return best.typ
+	}
+	return none
+}
+
+fn (tc &TypeChecker) lexical_for_smartcast_candidate(id flat.NodeId, key string) ?LexicalSmartcastCandidate {
 	mut current := id
 	mut parent_id := tc.direct_parent_id(current)
+	mut depth := 1
 	for tc.valid_node_id(parent_id) {
 		parent := tc.a.node(parent_id)
 		if parent.kind == .for_stmt && parent.children_count > 3 {
@@ -12447,7 +12478,10 @@ fn (tc &TypeChecker) lexical_for_smartcast_type(id flat.NodeId, key string) ?Typ
 			if body_index >= 3 && !tc.for_body_writes_key_before(parent, body_index, current, key) {
 				for binding in tc.extract_smartcasts(tc.a.child(parent, 1)) {
 					if binding.name == key {
-						return binding.typ
+						return LexicalSmartcastCandidate{
+							typ:   binding.typ
+							depth: depth
+						}
 					}
 				}
 			}
@@ -12457,6 +12491,7 @@ fn (tc &TypeChecker) lexical_for_smartcast_type(id flat.NodeId, key string) ?Typ
 		}
 		current = parent_id
 		parent_id = tc.direct_parent_id(current)
+		depth++
 	}
 	return none
 }
@@ -12621,13 +12656,14 @@ fn (tc &TypeChecker) subtree_assigns_key(root flat.NodeId, key string) bool {
 	return false
 }
 
-fn (tc &TypeChecker) lexical_if_smartcast_type(id flat.NodeId, key string) ?Type {
+fn (tc &TypeChecker) lexical_if_smartcast_candidate(id flat.NodeId, key string) ?LexicalSmartcastCandidate {
 	idx := int(id)
 	if idx < 0 || idx >= tc.direct_parent_ids.len {
 		return none
 	}
 	mut current := id
 	mut parent_id := tc.direct_parent_id(current)
+	mut depth := 1
 	for tc.valid_node_id(parent_id) {
 		parent := tc.a.node(parent_id)
 		if parent.kind == .if_expr && parent.children_count >= 2 {
@@ -12647,7 +12683,10 @@ fn (tc &TypeChecker) lexical_if_smartcast_type(id flat.NodeId, key string) ?Type
 				}
 				for binding in bindings {
 					if binding.name == key {
-						return binding.typ
+						return LexicalSmartcastCandidate{
+							typ:   binding.typ
+							depth: depth
+						}
 					}
 				}
 			}
@@ -12657,15 +12696,19 @@ fn (tc &TypeChecker) lexical_if_smartcast_type(id flat.NodeId, key string) ?Type
 		}
 		current = parent_id
 		parent_id = tc.direct_parent_id(current)
+		depth++
 	}
 	return none
 }
 
 fn (tc &TypeChecker) lexical_match_smartcast_type(id flat.NodeId) ?Type {
-	return tc.lexical_match_smartcast_type_with_key(id, tc.expr_key(id))
+	if candidate := tc.lexical_match_smartcast_candidate(id, tc.expr_key(id)) {
+		return candidate.typ
+	}
+	return none
 }
 
-fn (tc &TypeChecker) lexical_match_smartcast_type_with_key(id flat.NodeId, key string) ?Type {
+fn (tc &TypeChecker) lexical_match_smartcast_candidate(id flat.NodeId, key string) ?LexicalSmartcastCandidate {
 	idx := int(id)
 	if idx < 0 || idx >= tc.direct_parent_ids.len {
 		return none
@@ -12675,7 +12718,9 @@ fn (tc &TypeChecker) lexical_match_smartcast_type_with_key(id flat.NodeId, key s
 	}
 	mut current := id
 	mut branch_id := flat.NodeId(-1)
+	mut depth := 0
 	for _ in 0 .. 64 {
+		depth++
 		parent_id := tc.direct_parent_id(current)
 		if !tc.valid_node_id(parent_id) {
 			return none
@@ -12702,10 +12747,18 @@ fn (tc &TypeChecker) lexical_match_smartcast_type_with_key(id flat.NodeId, key s
 				tc.resolve_ierror_match_pattern(pattern) or { return none }
 			} else if subject_type is Interface {
 				tc.resolve_interface_match_pattern(pattern) or { return none }
+			} else if short_type_name(subject_type.name()) == short_type_name(pattern) {
+				// During the branch check, the dynamic smartcast already exposes the
+				// matched variant. Keep recognizing the lexical match so declarations
+				// inside nested sum matches infer that concrete variant.
+				subject_type.name()
 			} else {
 				return none
 			}
-			return tc.parse_type(name)
+			return LexicalSmartcastCandidate{
+				typ:   tc.parse_type(name)
+				depth: depth
+			}
 		} else if parent.kind in [.fn_decl, .fn_literal, .lambda_expr] {
 			return none
 		}


### PR DESCRIPTION
## Summary

- use canonical checker field types when synthesizing struct equality
- choose the nearest lexical smartcast in nested control flow
- retain plain and module-qualified function values as reachability dependencies
- root v3 preference helpers and emit file-lock compatibility declarations before parallel C generation
- add focused regressions for each self-host failure class

## Validation

- optimized v3 builds successfully with `-prod -prealloc -d parallel`
- optimized v3 compiles `cmd/v` with `-prod -gc none -cc clang`
- the generated compiler reports `V 0.5.2 5ad2d1f`
- the generated compiler compiles and runs `examples/hello_world.v`
- focused review-transform regressions pass
- `vlib/v3/tests/filelock_c_helpers_codegen_test.v` passes
- focused markused regression passes
- `VJOBS=1 ./vnew -silent test vlib/v3/types/`: 9/9 pass

## Broader test status

`./vnew -silent vlib/v/compiler_errors_test.v` has existing late module-fixture mismatches in this checkout. The bootstrap `./v` reproduces the same eight expectation failures. A full `VJOBS=1 ./vnew -silent test vlib/v/` run was stopped after v3 compilations exceeded the existing 2304 MiB memory limit.