### PR TITLE
v3: cache native modules in large macOS builds

### DIFF
--- a/vlib/v3/driver/cache_prune_test.v
+++ b/vlib/v3/driver/cache_prune_test.v
@@ -157,6 +157,16 @@ fn test_cache_c_flags_without_forced_inputs_drops_forced_files() {
 	assert filtered == ['-DFEATURE=1', '-I/tmp/inc', '-DOTHER']
 }
 
+fn test_cache_probe_language_unions_input_and_flag_languages() {
+	assert cache_probe_language('c', []string{}) == 'c'
+	assert cache_probe_language('objective-c', []string{}) == 'objective-c'
+	assert cache_probe_language('c++', []string{}) == 'c++'
+	assert cache_probe_language('objective-c++', []string{}) == 'objective-c++'
+	// A C++ input plus a command-line Objective-C request needs both macros.
+	assert cache_probe_language('c++', ['-fobjc-arc']) == 'objective-c++'
+	assert cache_probe_language('c', ['-x', 'objective-c']) == 'objective-c'
+}
+
 fn test_c_source_file_scope_identifiers_excludes_function_bodies_and_directives() {
 	identifiers := c_source_file_scope_identifiers('#define SYSTEM_HELPER() ignored_helper()
 #define LOCAL_FN(name) static int name(void)
@@ -234,9 +244,35 @@ fn test_cache_c_source_definitely_active_code_uses_target_predefined_macros() {
 fn test_cache_compiler_macro_probe_uses_implicit_objective_c_language() {
 	$if macos {
 		macros, complete := cache_c_compiler_predefined_macros([]string{}, 'cc',
-			pref.host_target(), true)
+			pref.host_target(), 'objective-c')
 		assert complete
 		assert '__OBJC__' in macros
+		// An Objective-C++ input defines both __OBJC__ and __cplusplus; the probe must
+		// carry __cplusplus so branches guarded by it are not discarded.
+		objc_cpp_macros, objc_cpp_complete := cache_c_compiler_predefined_macros([]string{},
+			'cc', pref.host_target(), 'objective-c++')
+		assert objc_cpp_complete
+		assert '__OBJC__' in objc_cpp_macros
+		assert '__cplusplus' in objc_cpp_macros
+	}
+}
+
+fn test_cache_compiler_macro_probe_excludes_forced_headers() {
+	$if macos {
+		dir := os.join_path(os.vtmp_dir(), 'v3_probe_forced_header_${os.getpid()}')
+		os.rmdir_all(dir) or {}
+		os.mkdir_all(dir) or { panic(err) }
+		defer {
+			os.rmdir_all(dir) or {}
+		}
+		forced := os.join_path(dir, 'forced.h')
+		os.write_file(forced, '#define V3_FORCED_PROBE_MACRO 1\n') or { panic(err) }
+		macros, complete := cache_c_compiler_predefined_macros(['-include', forced], 'cc',
+			pref.host_target(), 'c')
+		assert complete
+		// The forced header runs before the empty probe input, so its macros must not
+		// be reported as part of the predefined baseline the input scanner starts from.
+		assert 'V3_FORCED_PROBE_MACRO' !in macros
 	}
 }
 

--- a/vlib/v3/driver/cache_prune_test.v
+++ b/vlib/v3/driver/cache_prune_test.v
@@ -128,6 +128,15 @@ fn test_cache_c_source_definitely_active_code_uses_target_predefined_macros() {
 	assert !disabled.contains('apple_api')
 }
 
+fn test_cache_compiler_macro_probe_uses_implicit_objective_c_language() {
+	$if macos {
+		macros, complete := cache_c_compiler_predefined_macros([]string{}, 'cc',
+			pref.host_target(), true)
+		assert complete
+		assert '__OBJC__' in macros
+	}
+}
+
 fn test_cache_c_source_definitely_active_code_evaluates_compound_known_guards() {
 	source := '#if FOO && BAR\nstatic int compound_api(void) { return 1; }\n#else\nint fallback_api(void) { return 2; }\n#endif\n'
 	mut enabled_macros := cache_local_c_flag_macros(['-DFOO=1', '-DBAR=1'])

--- a/vlib/v3/driver/cache_prune_test.v
+++ b/vlib/v3/driver/cache_prune_test.v
@@ -40,6 +40,35 @@ fn test_c_source_references_identifiers_ignores_comments_strings_and_longer_name
 		identifiers)
 }
 
+fn test_cache_native_public_include_strips_conventional_implementation_macros() {
+	include := cache_native_public_include('/tmp/native.h', [
+		'#define FEATURE 1',
+		'#define FONTSTASH_IMPLEMENTATION',
+		'#define SOKOL_FONTSTASH_IMPL',
+	], map[string]bool{})
+	assert include.contains('#define FEATURE 1')
+	assert include.contains('#undef FONTSTASH_IMPLEMENTATION')
+	assert include.contains('#undef SOKOL_FONTSTASH_IMPL')
+	assert include.contains('#undef SOKOL_IMPL')
+	assert !include.contains('#define FONTSTASH_IMPLEMENTATION')
+	assert !include.contains('#define SOKOL_FONTSTASH_IMPL')
+}
+
+fn test_c_source_file_scope_identifiers_excludes_function_bodies_and_directives() {
+	identifiers := c_source_file_scope_identifiers('#define SYSTEM_HELPER() ignored_helper()
+#define LOCAL_FN(name) static int name(void)
+LOCAL_FN(macro_helper) {
+	return system_helper();
+}
+static int local_state;
+')
+	assert identifiers['LOCAL_FN']
+	assert identifiers['macro_helper']
+	assert identifiers['local_state']
+	assert !identifiers['ignored_helper']
+	assert !identifiers['system_helper']
+}
+
 fn test_v_c_identifiers_accepts_spaced_and_commented_selectors() {
 	assert v_c_identifiers('C /* selector */ . helper()\nC\n.\nother()\nC // line comment\n. line_helper()') == [
 		'helper',

--- a/vlib/v3/driver/cache_prune_test.v
+++ b/vlib/v3/driver/cache_prune_test.v
@@ -54,6 +54,31 @@ fn test_cache_native_public_include_strips_conventional_implementation_macros() 
 	assert !include.contains('#define SOKOL_FONTSTASH_IMPL')
 }
 
+fn test_cache_native_public_include_detects_external_function_implementation_macro() {
+	dir := os.join_path(os.vtmp_dir(), 'v3_external_implementation_macro_${os.getpid()}')
+	os.rmdir_all(dir) or {}
+	os.mkdir_all(dir) or { panic(err) }
+	defer {
+		os.rmdir_all(dir) or {}
+	}
+	header := os.join_path(dir, 'native.h')
+	os.write_file(header, 'typedef struct { int value; } V3LibType;
+#ifdef LIB_IMPL
+int v3_lib_value(void) { return 42; }
+#endif
+')!
+	real_header := os.real_path(header)
+	implementation_macros := cache_native_implementation_context_macros(real_header, [
+		'#define LIB_IMPL',
+	], {
+		real_header: true
+	}, []string{}, 'cc', pref.host_target())
+	assert implementation_macros['LIB_IMPL']
+	include := cache_native_public_include(real_header, ['#define LIB_IMPL'], implementation_macros)
+	assert include.contains('#undef LIB_IMPL')
+	assert !include.contains('#define LIB_IMPL')
+}
+
 fn test_c_source_file_scope_identifiers_excludes_function_bodies_and_directives() {
 	identifiers := c_source_file_scope_identifiers('#define SYSTEM_HELPER() ignored_helper()
 #define LOCAL_FN(name) static int name(void)

--- a/vlib/v3/driver/cache_prune_test.v
+++ b/vlib/v3/driver/cache_prune_test.v
@@ -50,8 +50,14 @@ fn test_cache_native_public_include_strips_conventional_implementation_macros() 
 	assert include.contains('#undef FONTSTASH_IMPLEMENTATION')
 	assert include.contains('#undef SOKOL_FONTSTASH_IMPL')
 	assert include.contains('#undef SOKOL_IMPL')
-	assert !include.contains('#define FONTSTASH_IMPLEMENTATION')
-	assert !include.contains('#define SOKOL_FONTSTASH_IMPL')
+	include_pos := include.index('#include') or { -1 }
+	assert include_pos >= 0
+	// The switches are undefined while the header expands, then restored after it
+	// so later native directives in the same unit see the original macro state.
+	assert (include.index('#undef FONTSTASH_IMPLEMENTATION') or { -1 }) < include_pos
+	assert (include.index('#undef SOKOL_FONTSTASH_IMPL') or { -1 }) < include_pos
+	assert (include.last_index('#define FONTSTASH_IMPLEMENTATION') or { -1 }) > include_pos
+	assert (include.last_index('#define SOKOL_FONTSTASH_IMPL') or { -1 }) > include_pos
 }
 
 fn test_cache_native_public_include_detects_external_function_implementation_macro() {
@@ -76,7 +82,79 @@ int v3_lib_value(void) { return 42; }
 	assert implementation_macros['LIB_IMPL']
 	include := cache_native_public_include(real_header, ['#define LIB_IMPL'], implementation_macros)
 	assert include.contains('#undef LIB_IMPL')
-	assert !include.contains('#define LIB_IMPL')
+	include_pos := include.index('#include') or { -1 }
+	assert include_pos >= 0
+	assert (include.index('#undef LIB_IMPL') or { -1 }) < include_pos
+	// The implementation switch is restored after the header expands.
+	assert (include.last_index('#define LIB_IMPL') or { -1 }) > include_pos
+	// A gated external definition is stripped, so splitting the root is safe.
+	assert !cache_native_public_include_replays_external_definition(real_header, ['#define LIB_IMPL'],
+		implementation_macros, []string{}, 'cc', pref.host_target())
+}
+
+fn test_cache_native_public_include_replays_unconditional_external_definition() {
+	dir := os.join_path(os.vtmp_dir(), 'v3_unconditional_external_definition_${os.getpid()}')
+	os.rmdir_all(dir) or {}
+	os.mkdir_all(dir) or { panic(err) }
+	defer {
+		os.rmdir_all(dir) or {}
+	}
+	header := os.join_path(dir, 'native.h')
+	os.write_file(header, 'typedef struct { int value; } V3LibType;
+int v3_unconditional_helper(void) { return 7; }
+')!
+	real_header := os.real_path(header)
+	// No context define gates the definition, so the declaration-only replay would
+	// still emit v3_unconditional_helper and duplicate the owner symbol.
+	assert cache_native_public_include_replays_external_definition(real_header, []string{},
+		map[string]bool{}, []string{}, 'cc', pref.host_target())
+}
+
+fn test_cache_native_public_include_keeps_static_definition_private() {
+	dir := os.join_path(os.vtmp_dir(), 'v3_static_definition_private_${os.getpid()}')
+	os.rmdir_all(dir) or {}
+	os.mkdir_all(dir) or { panic(err) }
+	defer {
+		os.rmdir_all(dir) or {}
+	}
+	header := os.join_path(dir, 'native.h')
+	os.write_file(header, 'typedef struct { int value; } V3LibType;
+static int v3_private_helper(void) { return 7; }
+')!
+	real_header := os.real_path(header)
+	// A static definition has internal linkage, so replaying it in several units
+	// cannot collide; splitting stays safe.
+	assert !cache_native_public_include_replays_external_definition(real_header, []string{},
+		map[string]bool{}, []string{}, 'cc', pref.host_target())
+}
+
+fn test_cache_native_public_include_sees_through_static_storage_macros() {
+	dir := os.join_path(os.vtmp_dir(), 'v3_macro_static_definition_${os.getpid()}')
+	os.rmdir_all(dir) or {}
+	os.mkdir_all(dir) or { panic(err) }
+	defer {
+		os.rmdir_all(dir) or {}
+	}
+	header := os.join_path(dir, 'native.h')
+	os.write_file(header, '#define V3_LOCAL static inline
+typedef struct { int value; } V3MacroStaticType;
+V3_LOCAL V3MacroStaticType v3_macro_static_make(void) {
+	V3MacroStaticType r = {41};
+	return r;
+}
+')!
+	real_header := os.real_path(header)
+	// The storage class is hidden behind V3_LOCAL, as builtin closure headers do
+	// with V_CLOSURE_STATIC_INLINE. Preprocessing expands it to `static inline`, so
+	// the helper recognizes the internal linkage and keeps splitting enabled.
+	assert !cache_native_public_include_replays_external_definition(real_header, []string{},
+		map[string]bool{}, []string{}, 'cc', pref.host_target())
+}
+
+fn test_cache_c_flags_without_forced_inputs_drops_forced_files() {
+	filtered := cache_c_flags_without_forced_inputs(['-DFEATURE=1', '-include', '/tmp/forced.h',
+		'-I/tmp/inc', '-imacros', '/tmp/macros.h', '-DOTHER'])
+	assert filtered == ['-DFEATURE=1', '-I/tmp/inc', '-DOTHER']
 }
 
 fn test_c_source_file_scope_identifiers_excludes_function_bodies_and_directives() {
@@ -274,3 +352,4 @@ fn test_prune_cached_native_function_prototypes_resolves_cache_guards() {
 	assert pruned.contains('int library_api(void);')
 	assert !pruned.contains('V3CACHE_PROGRAM_UNIT')
 }
+

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -87,6 +87,8 @@ mut:
 	module_dependencies       map[string][]string
 	module_external_inputs    map[string][]string
 	module_native_roots       map[string][]string
+	native_root_contexts      map[string][]string
+	native_root_owners        map[string]string
 	external_input_signatures map[string]string
 	external_resolution_dirs  []string
 	external_missing_paths    []string
@@ -2366,12 +2368,18 @@ fn v3_cgen_cache_input(state &V3ModuleCacheState, user_files []string, user_c_fl
 		}
 	}
 	if state.external_inputs_ready {
-		dependencies['external-state:manifest'] = 'v3-external-inputs-2'
+		dependencies['external-state:manifest'] = 'v3-external-inputs-4'
 		mut root_modules := state.module_native_roots.keys()
 		root_modules.sort()
 		for module_name in root_modules {
 			for index, path in state.module_native_roots[module_name] {
 				dependencies['external-root:${module_name}:${index}'] = '${path}\t${modulecache.file_metadata_signature(path)}'
+				dependencies['external-context:${module_name}:${index}'] = (state.native_root_contexts[path] or {
+					[]string{}
+				}).join('\x1e')
+				dependencies['external-root-owner:${module_name}:${index}'] = state.native_root_owners[os.real_path(path)] or {
+					''
+				}
 			}
 		}
 		mut owner_modules := state.native_source_modules.keys()
@@ -2413,11 +2421,15 @@ fn prepare_v3_cache_external_inputs(mut state V3ModuleCacheState, a &flat.FlatAs
 		cache_input_modules[module_name] = true
 	}
 	cache_input_modules['main'] = true
-	external_inputs, native_source_roots, unscoped_inputs, resolution_dirs, missing_resolution_paths, has_untracked_c_include := cgen.cache_external_input_files_with_resolved_flags(a,
+	compiler_macros, compiler_macro_environment_complete := cache_c_compiler_predefined_macros(user_c_flags,
+		prefs.ccompiler, prefs.target)
+	external_inputs, native_source_roots, native_root_contexts, unscoped_inputs, static_storage_inputs, resolution_dirs, missing_resolution_paths, has_untracked_c_include := cgen.cache_external_input_files_with_resolved_flags(a,
 		prefs.vroot, cache_input_modules, user_c_flags, prefs.target,
-		module_cache_source_path_set(user_files))
+		module_cache_source_path_set(user_files), compiler_macros,
+		compiler_macro_environment_complete)
 	state.module_external_inputs = external_inputs.clone()
 	state.module_native_roots = native_source_roots.clone()
+	state.native_root_contexts = native_root_contexts.clone()
 	state.external_input_signatures = map[string]string{}
 	cache_dir := os.abs_path(state.manager.dir)
 	real_cache_dir := os.real_path(state.manager.dir)
@@ -2426,8 +2438,23 @@ fn prepare_v3_cache_external_inputs(mut state V3ModuleCacheState, a &flat.FlatAs
 	state.external_missing_paths = missing_resolution_paths.filter(
 		!v3_path_is_within(it, cache_dir) && !v3_path_is_within(it, real_cache_dir))
 	native_source_modules, can_scope_static_inputs := cache_external_input_owner_modules(state, a,
-		unscoped_inputs, user_files)
+		unscoped_inputs, static_storage_inputs, user_files, user_c_flags, prefs.ccompiler,
+		prefs.target)
 	state.native_source_modules = native_source_modules.clone()
+	state.native_root_owners = map[string]string{}
+	for raw_module_name, roots in state.module_native_roots {
+		module_name := if raw_module_name == 'main' {
+			'main'
+		} else {
+			cache_state_module_name(state, raw_module_name) or { continue }
+		}
+		if !state.native_source_modules[module_name] {
+			continue
+		}
+		for root in roots {
+			state.native_root_owners[os.real_path(root)] = module_name
+		}
+	}
 	can_extract_native_types := prepare_v3_cache_native_type_declarations(mut state, user_c_flags,
 		prefs.ccompiler, prefs.target)
 	state.external_inputs_ready = true
@@ -2442,6 +2469,44 @@ fn prepare_v3_cache_external_inputs(mut state V3ModuleCacheState, a &flat.FlatAs
 	return !has_untracked_c_include && can_scope_static_inputs && can_extract_native_types
 }
 
+fn cache_c_compiler_predefined_macros(flags []string, ccompiler string, target pref.Target) (map[string]string, bool) {
+	path := os.join_path(os.vtmp_dir(), 'v3_compiler_macros_${tempname.unique_token()}.c')
+	defer {
+		os.rm(path) or {}
+	}
+	os.write_file(path, '') or { return map[string]string{}, false }
+	mut args := c_compiler_target_args(target, false) or { return map[string]string{}, false }
+	args << c_object_compile_flags(flags)
+	args << ['-dM', '-E', '-x', if c_flags_need_objective_c(flags) { 'objective-c' } else { 'c' },
+		path]
+	result := cmdexec.run(ccompiler, args)
+	if result.exit_code != 0 {
+		if os.getenv('V3_CACHE_TRACE') != '' {
+			eprintln('  V3 module cache compiler macro probe failed: compiler=${ccompiler}')
+		}
+		return map[string]string{}, false
+	}
+	mut macros := map[string]string{}
+	for line in result.output.split_into_lines() {
+		if !line.starts_with('#define ') {
+			continue
+		}
+		rest := line['#define '.len..]
+		mut end := 0
+		for end < rest.len && (rest[end].is_alnum() || rest[end] == `_`) {
+			end++
+		}
+		if end == 0 {
+			continue
+		}
+		name := rest[..end]
+		// Function-like macros are still definitely defined, but their expansion
+		// cannot be used as a literal include target.
+		macros[name] = rest[end..].trim_space()
+	}
+	return macros, true
+}
+
 fn cached_native_sources_require_monolithic_cgen(state &V3ModuleCacheState, a &flat.FlatAst, user_files []string) bool {
 	if state.native_source_modules.len == 0 {
 		return false
@@ -2452,7 +2517,9 @@ fn cached_native_sources_require_monolithic_cgen(state &V3ModuleCacheState, a &f
 		} else {
 			cache_state_module_name(state, raw_module_name) or { continue }
 		}
-		if !state.native_source_modules[module_name] {
+		// Main native sources remain in the program translation unit, so their
+		// private type declarations never need to cross a cached-object boundary.
+		if module_name == 'main' || !state.native_source_modules[module_name] {
 			continue
 		}
 		for path in paths {
@@ -2463,7 +2530,7 @@ fn cached_native_sources_require_monolithic_cgen(state &V3ModuleCacheState, a &f
 			if modulecache.c_source_declares_types(source) {
 				type_identifiers := modulecache.c_source_type_identifiers(source)
 				if cache_external_identifiers_are_private_to_module(a, state, raw_module_name,
-					type_identifiers, user_files)
+					type_identifiers, user_files, '')
 				{
 					continue
 				}
@@ -2499,21 +2566,81 @@ fn prepare_v3_cache_native_type_declarations(mut state V3ModuleCacheState, c_fla
 		if !state.native_source_modules[module_name] {
 			continue
 		}
+		// Main native sources stay in the program translation unit. Only imported
+		// native sources need declarations extracted after they move to a module object.
+		if module_name == 'main' {
+			mut declared_functions := map[string]bool{}
+			for root in roots {
+				source := os.read_file(root) or { continue }
+				for name, declared in modulecache.c_source_function_identifiers(source) {
+					if declared {
+						declared_functions[name] = true
+					}
+				}
+			}
+			if declared_functions.len > 0 {
+				state.native_declared_functions[module_name] = declared_functions.clone()
+			}
+			continue
+		}
 		mut declared_functions := state.native_declared_functions[module_name].clone()
+		mut roots_with_function_declarations := map[string]bool{}
 		mut declaration_macros := cache_local_c_compiler_macros(c_flags, ccompiler, target)
 		mut declaration_active_paths := map[string]bool{}
+		mut declarations_complete_for_module := true
 		for root in roots {
+			cache_apply_native_root_context(state.native_root_contexts[os.real_path(root)] or {
+				[]string{}
+			}, mut declaration_macros)
 			active_source, declarations_complete := cache_c_source_definitely_active_code_for_path_with_status(root,
 				allowed_paths, mut declaration_active_paths, mut declaration_macros, false)
 			if !declarations_complete {
 				if os.getenv('V3_CACHE_TRACE') != '' {
 					eprintln('  V3 module cache unresolved native declaration guard: module=${module_name} path=${root}')
 				}
-				return false
+				declarations_complete_for_module = false
+				break
 			}
-			for name, declared in modulecache.c_source_function_identifiers(active_source) {
+			root_functions := modulecache.c_source_function_identifiers(active_source)
+			for name, declared in root_functions {
 				if declared {
 					declared_functions[name] = true
+					roots_with_function_declarations[os.real_path(root)] = true
+				}
+			}
+		}
+		if !declarations_complete_for_module {
+			if roots.any(c_flag_is_c_source_file(it)) {
+				return false
+			}
+			mut recovered_functions := map[string]bool{}
+			for root in roots {
+				real_root := os.real_path(root)
+				source := os.read_file(real_root) or { continue }
+				file_scope_identifiers := c_source_file_scope_identifiers(source)
+				preprocessed := cache_preprocessed_native_input(real_root, state.native_root_contexts[real_root] or {
+					[]string{}
+				}, c_flags, ccompiler, target) or { continue }
+				functions, _ := modulecache.c_source_function_identifiers_with_status(preprocessed)
+				for name, present in functions {
+					if present && file_scope_identifiers[name] {
+						recovered_functions[name] = true
+					}
+				}
+			}
+			if recovered_functions.len > 0 {
+				for name, present in recovered_functions {
+					if present {
+						declared_functions[name] = true
+					}
+				}
+				if os.getenv('V3_CACHE_TRACE') != '' {
+					eprintln('  V3 module cache recovered guarded native function prototypes: module=${module_name} functions=${recovered_functions.len}')
+				}
+			} else {
+				declared_functions.clear()
+				if os.getenv('V3_CACHE_TRACE') != '' {
+					eprintln('  V3 module cache keeping guarded native function prototypes: module=${module_name}')
 				}
 			}
 		}
@@ -2521,22 +2648,205 @@ fn prepare_v3_cache_native_type_declarations(mut state V3ModuleCacheState, c_fla
 			state.native_declared_functions[module_name] = declared_functions.clone()
 		}
 		mut include_macros := cache_local_c_compiler_macros(c_flags, ccompiler, target)
+		mut types_complete_for_module := true
 		for root in roots {
 			real_root := os.real_path(root)
+			cache_apply_native_root_context(state.native_root_contexts[real_root] or { []string{} }, mut
+				include_macros)
 			declarations, complete := cache_native_type_declarations_for_path(real_root,
 				allowed_paths, mut include_macros)
 			if !complete {
 				if os.getenv('V3_CACHE_TRACE') != '' {
 					eprintln('  V3 module cache unresolved native type include: module=${module_name} path=${real_root}')
 				}
-				return false
+				types_complete_for_module = false
+				break
 			}
 			if declarations.len > 0 {
-				state.native_type_declarations[real_root] = declarations
+				if roots_with_function_declarations[real_root]
+					&& !c_flag_is_c_source_file(real_root) {
+					context := state.native_root_contexts[real_root] or { []string{} }
+					implementation_macros := cache_native_implementation_context_macros(real_root,
+						context, allowed_paths, c_flags, ccompiler, target)
+					state.native_type_declarations[real_root] = cache_native_public_include(real_root,
+						context, implementation_macros)
+				} else {
+					state.native_type_declarations[real_root] = declarations
+				}
+			}
+		}
+		if !types_complete_for_module {
+			if roots.any(c_flag_is_c_source_file(it)) {
+				return false
+			}
+			if consumer_module := cache_native_type_consumer_module(state, module_name, roots) {
+				for root in roots {
+					real_root := os.real_path(root)
+					context := state.native_root_contexts[real_root] or { []string{} }
+					state.native_root_owners[real_root] = consumer_module
+					// Other cache objects still need the header's public ABI. Reinclude it
+					// without the implementation context; the consumer object receives the
+					// original context and full implementation in source order.
+					implementation_macros := cache_native_implementation_context_macros(real_root,
+						context, allowed_paths, c_flags, ccompiler, target)
+					state.native_type_declarations[real_root] = cache_native_public_include(real_root,
+						context, implementation_macros)
+				}
+				if os.getenv('V3_CACHE_TRACE') != '' {
+					eprintln('  V3 module cache grouped native type owner: module=${module_name} consumer=${consumer_module}')
+				}
+				continue
+			}
+			for root in roots {
+				real_root := os.real_path(root)
+				context := state.native_root_contexts[real_root] or { []string{} }
+				implementation_macros := cache_native_implementation_context_macros(real_root,
+					context, allowed_paths, c_flags, ccompiler, target)
+				state.native_type_declarations[real_root] = cache_native_public_include(real_root,
+					context, implementation_macros)
+			}
+			if os.getenv('V3_CACHE_TRACE') != '' {
+				eprintln('  V3 module cache exposing unresolved native headers as public ABI: module=${module_name}')
 			}
 		}
 	}
 	return true
+}
+
+fn cache_native_type_consumer_module(state &V3ModuleCacheState, owner_module string, roots []string) ?string {
+	mut type_identifiers := map[string]bool{}
+	for root in roots {
+		source := os.read_file(root) or { continue }
+		for identifier, present in modulecache.c_source_type_identifiers(source) {
+			if present {
+				type_identifiers[identifier] = true
+			}
+		}
+	}
+	if type_identifiers.len == 0 {
+		return none
+	}
+	mut consumer := ''
+	for raw_module_name, paths in state.module_external_inputs {
+		candidate := if raw_module_name == 'main' {
+			'main'
+		} else {
+			cache_state_module_name(state, raw_module_name) or { continue }
+		}
+		if candidate == owner_module || candidate == 'main'
+			|| !state.native_source_modules[candidate]
+			|| owner_module !in cache_dependency_modules(state, [candidate]) {
+			continue
+		}
+		mut references_type := false
+		for path in paths {
+			source := os.read_file(path) or { continue }
+			if c_source_references_identifiers(source, type_identifiers) {
+				references_type = true
+				break
+			}
+		}
+		if !references_type {
+			continue
+		}
+		if consumer.len > 0 && consumer != candidate {
+			return none
+		}
+		consumer = candidate
+	}
+	if consumer.len == 0 {
+		return none
+	}
+	return consumer
+}
+
+fn cache_apply_native_root_context(directives []string, mut macros map[string]V3CacheLocalCMacro) {
+	for line in directives {
+		directive, arg := cache_local_c_directive(line)
+		if directive in ['define', 'undef'] {
+			cache_record_local_c_include_macro(directive, arg, false, mut macros)
+		}
+	}
+}
+
+fn cache_native_public_include(path string, context []string, implementation_macros map[string]bool) string {
+	mut out := strings.new_builder(context.len * 24 + path.len + 16)
+	// Sokol's umbrella implementation switch enables every component header. A
+	// prior owning include may leave it defined even when this header's own
+	// context is declaration-only.
+	out.writeln('#undef SOKOL_IMPL')
+	for line in context {
+		directive, arg := cache_local_c_directive(line)
+		if directive == 'undef' {
+			out.writeln(line)
+			continue
+		}
+		if directive != 'define' {
+			continue
+		}
+		name := cache_local_c_define_name(arg)
+		if implementation_macros[name] || cache_native_implementation_macro(name) {
+			out.writeln('#undef ${name}')
+		} else {
+			out.writeln(line)
+		}
+	}
+	out.writeln('#include "${c_include_path(path)}"')
+	return out.str()
+}
+
+fn cache_native_implementation_macro(name string) bool {
+	return name.ends_with('_IMPLEMENTATION')
+		|| (name.starts_with('SOKOL') && name.ends_with('_IMPL'))
+}
+
+fn cache_native_implementation_context_macros(path string, context []string, allowed_paths map[string]bool, c_flags []string, ccompiler string, target pref.Target) map[string]bool {
+	mut implementation_macros := map[string]bool{}
+	mut full_macros := cache_local_c_compiler_macros(c_flags, ccompiler, target)
+	cache_apply_native_root_context(context, mut full_macros)
+	mut full_active_paths := map[string]bool{}
+	full_source, _ := cache_c_source_definitely_active_code_for_path_with_status(path,
+		allowed_paths, mut full_active_paths, mut full_macros, false)
+	full_identifiers := cache_native_static_identifiers(full_source)
+	if full_identifiers.len == 0 {
+		return implementation_macros
+	}
+	for omitted_line in context {
+		directive, arg := cache_local_c_directive(omitted_line)
+		if directive != 'define' {
+			continue
+		}
+		name := cache_local_c_define_name(arg)
+		if name.len == 0 {
+			continue
+		}
+		mut candidate_macros := cache_local_c_compiler_macros(c_flags, ccompiler, target)
+		for line in context {
+			if line == omitted_line {
+				continue
+			}
+			cache_apply_native_root_context([line], mut candidate_macros)
+		}
+		mut candidate_active_paths := map[string]bool{}
+		candidate_source, _ := cache_c_source_definitely_active_code_for_path_with_status(path,
+			allowed_paths, mut candidate_active_paths, mut candidate_macros, false)
+		candidate_identifiers := cache_native_static_identifiers(candidate_source)
+		if full_identifiers.keys().any(!candidate_identifiers[it]) {
+			implementation_macros[name] = true
+		}
+	}
+	return implementation_macros
+}
+
+fn cache_native_static_identifiers(source string) map[string]bool {
+	mut identifiers, _ := modulecache.c_source_static_function_identifiers_with_status(source)
+	variables, _ := modulecache.c_source_static_variable_identifiers(source)
+	for identifier, present in variables {
+		if present {
+			identifiers[identifier] = true
+		}
+	}
+	return identifiers
 }
 
 fn cache_native_type_declarations_for_path(path string, allowed_paths map[string]bool, mut include_macros map[string]V3CacheLocalCMacro) (string, bool) {
@@ -2637,7 +2947,9 @@ fn cache_native_type_declarations_for_path_rec(path string, allowed_paths map[st
 			out.writeln(line)
 			continue
 		}
-		if include_path := cache_local_c_include_path(line, real_path, include_macros) {
+		if include_path := cache_local_c_include_path(line, real_path, allowed_paths,
+			include_macros)
+		{
 			real_include := os.real_path(include_path)
 			if allowed_paths[real_include] {
 				out.write_string(cache_native_type_declarations_for_path_rec(real_include,
@@ -2656,7 +2968,7 @@ fn cache_native_type_declarations_for_path_rec(path string, allowed_paths map[st
 	return result
 }
 
-fn cache_local_c_include_path(line string, source_path string, include_macros map[string]V3CacheLocalCMacro) ?string {
+fn cache_local_c_include_path(line string, source_path string, allowed_paths map[string]bool, include_macros map[string]V3CacheLocalCMacro) ?string {
 	directive, raw_arg := cache_local_c_directive(line)
 	if directive !in ['include', 'import'] {
 		return none
@@ -2665,7 +2977,7 @@ fn cache_local_c_include_path(line string, source_path string, include_macros ma
 	if arg.len == 0 {
 		return none
 	}
-	if arg[0] != `"` {
+	if arg[0] !in [`"`, `<`] {
 		fields := arg.fields()
 		if fields.len != 1 {
 			return none
@@ -2676,7 +2988,31 @@ fn cache_local_c_include_path(line string, source_path string, include_macros ma
 		}
 		arg = macro.literal
 	}
-	if arg.len < 3 || arg[0] != `"` {
+	if arg.len < 3 {
+		return none
+	}
+	if arg[0] == `<` {
+		close := arg[1..].index_u8(`>`)
+		if close < 1 {
+			return none
+		}
+		raw_path := arg[1..close + 1]
+		mut resolved := ''
+		for path, allowed in allowed_paths {
+			if allowed && (path == raw_path || path.ends_with('/' + raw_path)
+				|| path.ends_with('\\' + raw_path)) {
+				if resolved.len > 0 && resolved != path {
+					return none
+				}
+				resolved = path
+			}
+		}
+		if resolved.len > 0 {
+			return resolved
+		}
+		return none
+	}
+	if arg[0] != `"` {
 		return none
 	}
 	close := arg[1..].index_u8(`"`)
@@ -2942,7 +3278,8 @@ fn cache_local_c_compiler_macros(flags []string, ccompiler string, target pref.T
 }
 
 fn cache_local_c_is_literal_include_value(value string) bool {
-	return value.len >= 3 && value[0] == `"` && value[1..].index_u8(`"`) >= 1
+	return value.len >= 3 && ((value[0] == `"` && value[1..].index_u8(`"`) >= 1)
+		|| (value[0] == `<` && value[1..].index_u8(`>`) >= 1))
 }
 
 fn cache_local_c_integer_condition(raw string) int {
@@ -3514,7 +3851,7 @@ fn cache_c_source_definitely_active_code_rec(source string, source_path string, 
 		}
 		ambiguous := ambient_ambiguous || conditionals.any(it.ambiguous)
 		if source_path.len > 0 && directive in ['include', 'import'] {
-			if include_path := cache_local_c_include_path(line, source_path, macros) {
+			if include_path := cache_local_c_include_path(line, source_path, allowed_paths, macros) {
 				real_include := os.real_path(include_path)
 				if allowed_paths[real_include] {
 					include_scan := cache_c_source_active_code_scan_for_path(real_include,
@@ -3583,8 +3920,9 @@ fn v3_external_cache_path(key string, prefix string) ?V3ExternalCachePath {
 
 fn restore_v3_cache_external_inputs(mut state V3ModuleCacheState, user_files []string, user_c_flags []string, ccompiler string, target pref.Target, incremental_declaration_signature string) bool {
 	base_input := v3_cgen_cache_input(state, user_files, user_c_flags)
-	prefixes := ['external:', 'external-meta:', 'external-root:', 'external-owner:', 'external-dir:',
-		'external-missing:', 'external-state:']
+	prefixes := ['external:', 'external-meta:', 'external-root:', 'external-root-owner:',
+		'external-context:', 'external-owner:', 'external-dir:', 'external-missing:',
+		'external-state:']
 	mut restored := map[string]string{}
 	if exact := state.manager.cached_cgen_dependency_inputs(base_input.source_files,
 		base_input.generation_signature, base_input.dependency_inputs, prefixes)
@@ -3598,7 +3936,7 @@ fn restore_v3_cache_external_inputs(mut state V3ModuleCacheState, user_files []s
 			incremental_declaration_signature, base_input.generation_signature,
 			base_input.dependency_inputs, prefixes) or { return false }
 	}
-	if restored['external-state:manifest'] or { '' } != 'v3-external-inputs-2' {
+	if restored['external-state:manifest'] or { '' } != 'v3-external-inputs-4' {
 		return false
 	}
 	mut external_inputs := map[string][]string{}
@@ -3624,6 +3962,9 @@ fn restore_v3_cache_external_inputs(mut state V3ModuleCacheState, user_files []s
 	}
 	mut root_records := []V3ExternalNativeRoot{}
 	for key, value in restored {
+		if key.starts_with('external-root-owner:') {
+			continue
+		}
 		input := v3_external_cache_path(key, 'external-root:') or { continue }
 		if input.path.len == 0 || input.path.bytes().any(!it.is_digit()) {
 			return false
@@ -3659,6 +4000,47 @@ fn restore_v3_cache_external_inputs(mut state V3ModuleCacheState, user_files []s
 		}
 		roots << record.path
 		native_roots[record.module_name] = roots
+	}
+	mut native_root_contexts := map[string][]string{}
+	for key, value in restored {
+		input := v3_external_cache_path(key, 'external-context:') or { continue }
+		if input.path.len == 0 || input.path.bytes().any(!it.is_digit()) {
+			return false
+		}
+		index := input.path.int()
+		roots := native_roots[input.module_name] or { return false }
+		if index < 0 || index >= roots.len {
+			return false
+		}
+		native_root_contexts[roots[index]] = if value.len == 0 {
+			[]string{}
+		} else {
+			value.split('\x1e')
+		}
+	}
+	mut native_root_owners := map[string]string{}
+	mut restored_root_owners := map[string]bool{}
+	for key, owner in restored {
+		input := v3_external_cache_path(key, 'external-root-owner:') or { continue }
+		if input.path.len == 0 || input.path.bytes().any(!it.is_digit()) {
+			return false
+		}
+		index := input.path.int()
+		roots := native_roots[input.module_name] or { return false }
+		if index < 0 || index >= roots.len {
+			return false
+		}
+		restored_root_owners['${input.module_name}:${index}'] = true
+		if owner.len > 0 {
+			native_root_owners[os.real_path(roots[index])] = owner
+		}
+	}
+	for module_name, roots in native_roots {
+		for index, _ in roots {
+			if !restored_root_owners['${module_name}:${index}'] {
+				return false
+			}
+		}
 	}
 	mut native_source_modules := map[string]bool{}
 	for key, value in restored {
@@ -3701,6 +4083,8 @@ fn restore_v3_cache_external_inputs(mut state V3ModuleCacheState, user_files []s
 	state.module_external_inputs = external_inputs.clone()
 	state.external_input_signatures = external_signatures.clone()
 	state.module_native_roots = native_roots.clone()
+	state.native_root_contexts = native_root_contexts.clone()
+	state.native_root_owners = native_root_owners.clone()
 	state.native_source_modules = native_source_modules.clone()
 	if !prepare_v3_cache_native_type_declarations(mut state, user_c_flags, ccompiler, target) {
 		return false
@@ -6869,6 +7253,8 @@ pub fn run(args []string) {
 		module_dependencies:       map[string][]string{}
 		module_external_inputs:    map[string][]string{}
 		module_native_roots:       map[string][]string{}
+		native_root_contexts:      map[string][]string{}
+		native_root_owners:        map[string]string{}
 		external_input_signatures: map[string]string{}
 		dependency_metadata:       map[string]string{}
 		parsed_from_source:        map[string]bool{}
@@ -8472,6 +8858,7 @@ pub fn run(args []string) {
 			g.set_coverage(coverage_dir, args.join(' '))
 			g.set_compile_values(prefs.compile_values)
 			g.set_cache_split(cache_state.manager.enabled)
+			g.set_cache_native_input_paths(cache_scoped_native_input_paths(cache_state))
 			g.set_program_body_only(generic_cache_hit)
 			g.set_cache_program_files(user_files)
 			g.set_incremental_fn_names(incremental_changed_names)
@@ -8523,6 +8910,7 @@ pub fn run(args []string) {
 			g.set_coverage(coverage_dir, args.join(' '))
 			g.set_compile_values(prefs.compile_values)
 			g.set_cache_split(cache_state.manager.enabled)
+			g.set_cache_native_input_paths(cache_scoped_native_input_paths(cache_state))
 			g.set_program_body_only(generic_cache_hit)
 			g.set_cache_program_files(user_files)
 			g.set_incremental_fn_names(incremental_changed_names)
@@ -10047,7 +10435,22 @@ fn cache_object_paths(object_paths map[string]string) []string {
 
 fn prune_cached_native_function_prototypes(source string, state &V3ModuleCacheState, module_names []string) string {
 	mut declared_functions := map[string]bool{}
+	mut selected_modules := map[string]bool{}
 	for module_name in module_names {
+		selected_modules[module_name] = true
+	}
+	mut declaration_modules := selected_modules.clone()
+	for raw_module_name, roots in state.module_native_roots {
+		module_name := if raw_module_name == 'main' {
+			'main'
+		} else {
+			cache_state_module_name(state, raw_module_name) or { continue }
+		}
+		if roots.any(selected_modules[state.native_root_owners[os.real_path(it)] or { module_name }]) {
+			declaration_modules[module_name] = true
+		}
+	}
+	for module_name in declaration_modules.keys() {
 		for name, declared in state.native_declared_functions[module_name] {
 			if declared {
 				declared_functions[name] = true
@@ -10140,6 +10543,30 @@ fn cache_source_without_cached_native_inputs(source string, state &V3ModuleCache
 	return out.str()
 }
 
+fn cache_scoped_native_input_paths(state &V3ModuleCacheState) []string {
+	mut seen := map[string]bool{}
+	mut paths := []string{}
+	for raw_module_name, roots in state.module_native_roots {
+		module_name := if raw_module_name == 'main' {
+			'main'
+		} else {
+			cache_state_module_name(state, raw_module_name) or { continue }
+		}
+		if !state.native_source_modules[module_name] {
+			continue
+		}
+		for root in roots {
+			real_path := os.real_path(root)
+			if !seen[real_path] {
+				seen[real_path] = true
+				paths << real_path
+			}
+		}
+	}
+	paths.sort()
+	return paths
+}
+
 struct V3CachedNativeSource {
 	source             string
 	remaining_includes string
@@ -10172,7 +10599,8 @@ fn cache_source_with_cached_native_inputs(source string, state &V3ModuleCacheSta
 			include_line := '#include "${clean}"'
 			all_include_lines[include_line] = true
 			include_paths[include_line] = os.real_path(root)
-			if selected[module_name] && !selected_include_lines[include_line] {
+			owner_module := state.native_root_owners[os.real_path(root)] or { module_name }
+			if selected[owner_module] && !selected_include_lines[include_line] {
 				selected_include_lines[include_line] = true
 				selected_order << include_line
 			}
@@ -10191,6 +10619,10 @@ fn cache_source_with_cached_native_inputs(source string, state &V3ModuleCacheSta
 			// The compiler-only macro suppresses fallback declarations, but must not
 			// leak into native source that did not see it in the uncached unit.
 			out.writeln('#undef V3CACHE_PROGRAM_UNIT')
+			path := include_paths[clean] or { '' }
+			for directive in state.native_root_contexts[path] or { []string{} } {
+				out.writeln(directive)
+			}
 			out.writeln(line)
 			out.writeln('#define V3CACHE_PROGRAM_UNIT 1')
 			found[clean] = true
@@ -10206,6 +10638,10 @@ fn cache_source_with_cached_native_inputs(source string, state &V3ModuleCacheSta
 	mut remaining := strings.new_builder(selected_order.len * 96)
 	for include_line in selected_order {
 		if !found[include_line] {
+			path := include_paths[include_line] or { '' }
+			for directive in state.native_root_contexts[path] or { []string{} } {
+				remaining.writeln(directive)
+			}
 			remaining.writeln(include_line)
 		}
 	}
@@ -10461,17 +10897,12 @@ fn restart_v3_with_args(extra_args []string) {
 	}
 }
 
-fn cache_external_input_owner_modules(state &V3ModuleCacheState, a &flat.FlatAst, unscoped_inputs map[string][]string, user_files []string) (map[string]bool, bool) {
+fn cache_external_input_owner_modules(state &V3ModuleCacheState, a &flat.FlatAst, unscoped_inputs map[string][]string, static_inputs map[string][]string, user_files []string, c_flags []string, ccompiler string, target pref.Target) (map[string]bool, bool) {
 	mut modules := map[string]bool{}
-	mut static_inputs := map[string][]string{}
 	mut static_input_owners := map[string][]string{}
 	for raw_module_name, paths in unscoped_inputs {
 		for path in paths {
-			source := os.read_file(path) or { continue }
-			if modulecache.c_source_has_static_storage(source) {
-				mut module_inputs := static_inputs[raw_module_name]
-				module_inputs << path
-				static_inputs[raw_module_name] = module_inputs
+			if path in (static_inputs[raw_module_name] or { []string{} }) {
 				mut owners := static_input_owners[path]
 				if raw_module_name !in owners {
 					owners << raw_module_name
@@ -10483,15 +10914,32 @@ fn cache_external_input_owner_modules(state &V3ModuleCacheState, a &flat.FlatAst
 	for raw_module_name, _ in state.module_external_inputs {
 		roots := state.module_native_roots[raw_module_name] or { []string{} }
 		has_static_storage := (static_inputs[raw_module_name] or { []string{} }).len > 0
-		has_source_root := roots.any(c_flag_is_c_source_file(it))
-		if !has_source_root && !has_static_storage {
-			continue
+		if has_static_storage {
+			if raw_module_name == 'main' {
+				if roots.len > 0 {
+					modules['main'] = true
+				}
+			} else {
+				for path in static_inputs[raw_module_name] {
+					owners := static_input_owners[path] or { []string{} }
+					if owners.len != 1 {
+						if os.getenv('V3_CACHE_TRACE') != '' {
+							eprintln('  V3 module cache multiply-owned static input: module=${raw_module_name} owners=${owners} path=${path}')
+						}
+						return modules, false
+					}
+					if !cache_static_input_is_private_to_module(a, state, raw_module_name, path,
+						user_files, c_flags, ccompiler, target) {
+						if os.getenv('V3_CACHE_TRACE') != '' {
+							eprintln('  V3 module cache shared static input: module=${raw_module_name} path=${path}')
+						}
+						return modules, false
+					}
+				}
+			}
 		}
 		if roots.len == 0 {
-			if os.getenv('V3_CACHE_TRACE') != '' {
-				eprintln('  V3 module cache static input without native source root: module=${raw_module_name}')
-			}
-			return modules, false
+			continue
 		}
 		for root in roots {
 			if !c_flag_is_c_source_file(root) && root !in (unscoped_inputs[raw_module_name] or {
@@ -10501,17 +10949,6 @@ fn cache_external_input_owner_modules(state &V3ModuleCacheState, a &flat.FlatAst
 					eprintln('  V3 module cache unsupported native source root: module=${raw_module_name} path=${root}')
 				}
 				return modules, false
-			}
-		}
-		if has_static_storage {
-			for path in static_inputs[raw_module_name] {
-				if (static_input_owners[path] or { []string{} }).len != 1
-					|| !cache_static_input_is_private_to_module(a, state, raw_module_name, path, user_files) {
-					if os.getenv('V3_CACHE_TRACE') != '' {
-						eprintln('  V3 module cache shared static input: module=${raw_module_name} path=${path}')
-					}
-					return modules, false
-				}
 			}
 		}
 		if raw_module_name == 'main' {
@@ -10524,28 +10961,77 @@ fn cache_external_input_owner_modules(state &V3ModuleCacheState, a &flat.FlatAst
 	return modules, true
 }
 
-fn cache_static_input_is_private_to_module(a &flat.FlatAst, state &V3ModuleCacheState, raw_module_name string, path string, user_files []string) bool {
+fn cache_static_input_is_private_to_module(a &flat.FlatAst, state &V3ModuleCacheState, raw_module_name string, path string, user_files []string, c_flags []string, ccompiler string, target pref.Target) bool {
 	source := os.read_file(path) or { return false }
-	mut header_identifiers, function_identifiers_complete :=
-		modulecache.c_source_function_identifiers_with_status(source)
-	if !function_identifiers_complete {
-		return false
-	}
-	static_identifiers, static_identifiers_complete :=
+	file_scope_identifiers := c_source_file_scope_identifiers(source)
+	mut header_identifiers, mut function_identifiers_complete :=
+		modulecache.c_source_static_function_identifiers_with_status(source)
+	mut static_identifiers, mut static_identifiers_complete :=
 		modulecache.c_source_static_variable_identifiers(source)
-	if !static_identifiers_complete {
-		return false
+	if !function_identifiers_complete || !static_identifiers_complete {
+		preprocessed := cache_preprocessed_native_input(path, state.native_root_contexts[os.real_path(path)] or {
+			[]string{}
+		}, c_flags, ccompiler, target) or { return false }
+		header_identifiers, function_identifiers_complete =
+			modulecache.c_source_static_function_identifiers_with_status(preprocessed)
+		static_identifiers, static_identifiers_complete =
+			modulecache.c_source_static_variable_identifiers(preprocessed)
+		if !function_identifiers_complete {
+			if os.getenv('V3_CACHE_TRACE') != '' {
+				eprintln('  V3 module cache incomplete preprocessed static identifier scan: functions=${function_identifiers_complete} variables=${static_identifiers_complete} path=${path}')
+			}
+			return false
+		}
+		for identifier in header_identifiers.keys() {
+			if !file_scope_identifiers[identifier] {
+				header_identifiers.delete(identifier)
+			}
+		}
+		for identifier in static_identifiers.keys() {
+			if !source.contains(identifier) {
+				static_identifiers.delete(identifier)
+			}
+		}
 	}
 	for identifier, present in static_identifiers {
 		if present {
 			header_identifiers[identifier] = true
 		}
 	}
+	if header_identifiers.len == 0 && os.getenv('V3_CACHE_TRACE') != '' {
+		eprintln('  V3 module cache static input has no recoverable identifiers: path=${path}')
+	}
 	return cache_external_identifiers_are_private_to_module(a, state, raw_module_name,
-		header_identifiers, user_files)
+		header_identifiers, user_files, os.real_path(path))
 }
 
-fn cache_external_identifiers_are_private_to_module(a &flat.FlatAst, state &V3ModuleCacheState, raw_module_name string, identifiers map[string]bool, user_files []string) bool {
+fn cache_preprocessed_native_input(path string, context []string, c_flags []string, ccompiler string, target pref.Target) ?string {
+	wrapper := os.join_path(os.vtmp_dir(), 'v3_native_scan_${tempname.unique_token()}.c')
+	defer {
+		os.rm(wrapper) or {}
+	}
+	mut source := strings.new_builder(context.len * 48 + path.len + 32)
+	for directive in context {
+		source.writeln(directive)
+	}
+	source.writeln('#include "${c_include_path(os.real_path(path))}"')
+	os.write_file(wrapper, source.str()) or { return none }
+	unsafe { source.free() }
+	mut args := c_compiler_target_args(target, false) or { return none }
+	args << c_object_compile_flags(c_flags)
+	args << ['-E', '-P', '-x', if c_flags_need_objective_c(c_flags) { 'objective-c' } else { 'c' },
+		wrapper]
+	result := cmdexec.run(ccompiler, args)
+	if result.exit_code != 0 {
+		if os.getenv('V3_CACHE_TRACE') != '' {
+			eprintln('  V3 module cache native privacy preprocessing failed: path=${path}')
+		}
+		return none
+	}
+	return result.output
+}
+
+fn cache_external_identifiers_are_private_to_module(a &flat.FlatAst, state &V3ModuleCacheState, raw_module_name string, identifiers map[string]bool, user_files []string, ignored_external_path string) bool {
 	if identifiers.len == 0 {
 		return false
 	}
@@ -10577,8 +11063,14 @@ fn cache_external_identifiers_are_private_to_module(a &flat.FlatAst, state &V3Mo
 			continue
 		}
 		for path in paths {
+			if ignored_external_path.len > 0 && os.real_path(path) == ignored_external_path {
+				continue
+			}
 			source := os.read_file(path) or { continue }
-			if c_source_references_identifiers(source, exposed_identifiers) {
+			if identifier := c_source_referenced_identifier(source, exposed_identifiers) {
+				if os.getenv('V3_CACHE_TRACE') != '' {
+					eprintln('  V3 module cache static identifier referenced by sibling C input: owner=${owner_module} sibling=${sibling_module} path=${path} identifier=${identifier}')
+				}
 				return false
 			}
 		}
@@ -10590,6 +11082,9 @@ fn cache_external_identifiers_are_private_to_module(a &flat.FlatAst, state &V3Mo
 			file_source := os.read_file(real_path) or { continue }
 			for identifier in v_c_identifiers(file_source) {
 				if exposed_identifiers[identifier] {
+					if os.getenv('V3_CACHE_TRACE') != '' {
+						eprintln('  V3 module cache static identifier referenced by main V input: owner=${owner_module} path=${path} identifier=${identifier}')
+					}
 					return false
 				}
 			}
@@ -10606,6 +11101,9 @@ fn cache_external_identifiers_are_private_to_module(a &flat.FlatAst, state &V3Mo
 			file_source := os.read_file(real_path) or { continue }
 			for identifier in v_c_identifiers(file_source) {
 				if exposed_identifiers[identifier] {
+					if os.getenv('V3_CACHE_TRACE') != '' {
+						eprintln('  V3 module cache static identifier referenced by sibling V input: owner=${owner_module} sibling=${canonical_module} path=${path} identifier=${identifier}')
+					}
 					return false
 				}
 			}
@@ -10642,6 +11140,9 @@ fn cache_external_identifiers_are_private_to_module(a &flat.FlatAst, state &V3Mo
 		file_source := os.read_file(real_path) or { continue }
 		for identifier in v_c_identifiers(file_source) {
 			if exposed_identifiers[identifier] {
+				if os.getenv('V3_CACHE_TRACE') != '' {
+					eprintln('  V3 module cache static identifier referenced by parsed sibling V input: owner=${owner_module} sibling=${canonical_module} path=${real_path} identifier=${identifier}')
+				}
 				return false
 			}
 		}
@@ -10650,6 +11151,98 @@ fn cache_external_identifiers_are_private_to_module(a &flat.FlatAst, state &V3Mo
 }
 
 fn c_source_references_identifiers(source string, identifiers map[string]bool) bool {
+	if _ := c_source_referenced_identifier(source, identifiers) {
+		return true
+	}
+	return false
+}
+
+fn c_source_file_scope_identifiers(source string) map[string]bool {
+	mut identifiers := map[string]bool{}
+	mut brace_depth := 0
+	mut line_start := 0
+	mut i := 0
+	for i < source.len {
+		if source[i] == `\n` {
+			i++
+			line_start = i
+			continue
+		}
+		if source[i] == `#` && source[line_start..i].trim_space().len == 0 {
+			for i < source.len {
+				newline := source.index_after('\n', i) or { return identifiers }
+				mut end := newline - 1
+				for end > i && source[end - 1] in [` `, `\t`, `\r`] {
+					end--
+				}
+				i = newline
+				line_start = i
+				if end == 0 || source[end - 1] != `\\` {
+					break
+				}
+			}
+			continue
+		}
+		if i + 1 < source.len && source[i] == `/` && source[i + 1] == `/` {
+			i += 2
+			for i < source.len && source[i] != `\n` {
+				i++
+			}
+			continue
+		}
+		if i + 1 < source.len && source[i] == `/` && source[i + 1] == `*` {
+			i += 2
+			for i + 1 < source.len && !(source[i] == `*` && source[i + 1] == `/`) {
+				if source[i] == `\n` {
+					line_start = i + 1
+				}
+				i++
+			}
+			i = int_min(i + 2, source.len)
+			continue
+		}
+		if source[i] in [`"`, `'`] {
+			quote := source[i]
+			i++
+			for i < source.len {
+				if source[i] == `\\` && i + 1 < source.len {
+					i += 2
+					continue
+				}
+				i++
+				if source[i - 1] == quote {
+					break
+				}
+			}
+			continue
+		}
+		if source[i] == `{` {
+			brace_depth++
+			i++
+			continue
+		}
+		if source[i] == `}` {
+			brace_depth = int_max(brace_depth - 1, 0)
+			i++
+			continue
+		}
+		if !source[i].is_letter() && source[i] != `_` {
+			i++
+			continue
+		}
+		start := i
+		i++
+		for i < source.len && (source[i].is_alnum() || source[i] == `_`) {
+			i++
+		}
+		if brace_depth == 0 && (start == 0 || source[start - 1] != `@`) {
+			identifiers[source[start..i]] = true
+		}
+	}
+	return identifiers
+}
+
+fn c_source_referenced_identifier(source string, identifiers map[string]bool) ?string {
 	mut i := 0
 	for i < source.len {
 		if source[i] in [`"`, `'`] {
@@ -10691,11 +11284,12 @@ fn c_source_references_identifiers(source string, identifiers map[string]bool) b
 		for i < source.len && (source[i].is_alnum() || source[i] == `_`) {
 			i++
 		}
-		if identifiers[source[start..i]] {
-			return true
+		identifier := source[start..i]
+		if identifiers[identifier] {
+			return identifier
 		}
 	}
-	return false
+	return none
 }
 
 fn v_c_identifiers(source string) []string {

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -2421,10 +2421,10 @@ fn prepare_v3_cache_external_inputs(mut state V3ModuleCacheState, a &flat.FlatAs
 		cache_input_modules[module_name] = true
 	}
 	cache_input_modules['main'] = true
-	native_inputs_need_objective_c := cgen.cache_native_inputs_need_objective_c(a, prefs.vroot,
-		user_c_flags, prefs.c99, prefs.target)
+	native_inputs_language := cgen.cache_native_inputs_language(a, prefs.vroot, user_c_flags,
+		prefs.c99, prefs.target)
 	compiler_macros, compiler_macro_environment_complete := cache_c_compiler_predefined_macros(user_c_flags,
-		prefs.ccompiler, prefs.target, native_inputs_need_objective_c)
+		prefs.ccompiler, prefs.target, native_inputs_language)
 	external_inputs, native_source_roots, native_root_contexts, unscoped_inputs, static_storage_inputs, resolution_dirs, missing_resolution_paths, has_untracked_c_include := cgen.cache_external_input_files_with_resolved_flags(a,
 		prefs.vroot, cache_input_modules, user_c_flags, prefs.target,
 		module_cache_source_path_set(user_files), compiler_macros,
@@ -2471,7 +2471,7 @@ fn prepare_v3_cache_external_inputs(mut state V3ModuleCacheState, a &flat.FlatAs
 	return !has_untracked_c_include && can_scope_static_inputs && can_extract_native_types
 }
 
-fn cache_c_compiler_predefined_macros(flags []string, ccompiler string, target pref.Target, native_inputs_need_objective_c bool) (map[string]string, bool) {
+fn cache_c_compiler_predefined_macros(flags []string, ccompiler string, target pref.Target, native_inputs_language string) (map[string]string, bool) {
 	path := os.join_path(os.vtmp_dir(), 'v3_compiler_macros_${tempname.unique_token()}.c')
 	defer {
 		os.rm(path) or {}
@@ -2479,11 +2479,7 @@ fn cache_c_compiler_predefined_macros(flags []string, ccompiler string, target p
 	os.write_file(path, '') or { return map[string]string{}, false }
 	mut args := c_compiler_target_args(target, false) or { return map[string]string{}, false }
 	args << c_object_compile_flags(cache_c_flags_without_forced_inputs(flags))
-	args << ['-dM', '-E', '-x', if native_inputs_need_objective_c || c_flags_need_objective_c(flags) {
-		'objective-c'
-	} else {
-		'c'
-	}, path]
+	args << ['-dM', '-E', '-x', cache_probe_language(native_inputs_language, flags), path]
 	result := cmdexec.run(ccompiler, args)
 	if result.exit_code != 0 {
 		if os.getenv('V3_CACHE_TRACE') != '' {
@@ -2532,6 +2528,27 @@ fn cache_c_flags_without_forced_inputs(flags []string) []string {
 		i++
 	}
 	return out
+}
+
+// cache_probe_language combines the richest language the native inputs require
+// with any Objective-C request from the command-line flags, so the `-dM` probe
+// captures every language macro the real build defines.
+fn cache_probe_language(native_inputs_language string, flags []string) string {
+	mut need_objc := native_inputs_language in ['objective-c', 'objective-c++']
+	need_cpp := native_inputs_language in ['c++', 'objective-c++']
+	if c_flags_need_objective_c(flags) {
+		need_objc = true
+	}
+	if need_objc && need_cpp {
+		return 'objective-c++'
+	}
+	if need_cpp {
+		return 'c++'
+	}
+	if need_objc {
+		return 'objective-c'
+	}
+	return 'c'
 }
 
 fn cached_native_sources_require_monolithic_cgen(state &V3ModuleCacheState, a &flat.FlatAst, user_files []string) bool {
@@ -11115,12 +11132,11 @@ fn cache_preprocessed_native_input(path string, context []string, c_flags []stri
 	unsafe { source.free() }
 	mut args := c_compiler_target_args(target, false) or { return none }
 	args << c_object_compile_flags(c_flags)
-	args << ['-E', '-P', '-x', if c_flags_need_objective_c(c_flags)
-		|| cgen.cache_native_input_path_needs_objective_c(path, c_flags, false, target) {
-		'objective-c'
-	} else {
-		'c'
-	}, wrapper]
+	mut language := cgen.cache_native_input_language(path, c_flags, false, target)
+	if c_flags_need_objective_c(c_flags) && language !in ['objective-c', 'objective-c++'] {
+		language = if language == 'c++' { 'objective-c++' } else { 'objective-c' }
+	}
+	args << ['-E', '-P', '-x', language, wrapper]
 	result := cmdexec.run(ccompiler, args)
 	if result.exit_code != 0 {
 		if os.getenv('V3_CACHE_TRACE') != '' {

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -2478,7 +2478,7 @@ fn cache_c_compiler_predefined_macros(flags []string, ccompiler string, target p
 	}
 	os.write_file(path, '') or { return map[string]string{}, false }
 	mut args := c_compiler_target_args(target, false) or { return map[string]string{}, false }
-	args << c_object_compile_flags(flags)
+	args << c_object_compile_flags(cache_c_flags_without_forced_inputs(flags))
 	args << ['-dM', '-E', '-x', if native_inputs_need_objective_c || c_flags_need_objective_c(flags) {
 		'objective-c'
 	} else {
@@ -2510,6 +2510,28 @@ fn cache_c_compiler_predefined_macros(flags []string, ccompiler string, target p
 		macros[name] = rest[end..].trim_space()
 	}
 	return macros, true
+}
+
+// cache_c_flags_without_forced_inputs drops `-include`/`-imacros` and their file
+// operands. The predefined-macro probe compiles an empty translation unit to
+// capture only the compiler/target/`-D` baseline, but forced-input files execute
+// before that empty input, so leaving them in would report their macros as
+// predefined. The dependency scanner would then start with those macros already
+// defined and skip includes guarded by `#if !defined(X)`, dropping the nested
+// files from the cache dependency set and serving stale output after they change.
+fn cache_c_flags_without_forced_inputs(flags []string) []string {
+	mut out := []string{cap: flags.len}
+	mut i := 0
+	for i < flags.len {
+		if flags[i].trim_space() in ['-include', '-imacros'] {
+			// Skip the option together with its file operand.
+			i += 2
+			continue
+		}
+		out << flags[i]
+		i++
+	}
+	return out
 }
 
 fn cached_native_sources_require_monolithic_cgen(state &V3ModuleCacheState, a &flat.FlatAst, user_files []string) bool {
@@ -2673,6 +2695,19 @@ fn prepare_v3_cache_native_type_declarations(mut state V3ModuleCacheState, c_fla
 					context := state.native_root_contexts[real_root] or { []string{} }
 					implementation_macros := cache_native_implementation_context_macros(real_root,
 						context, allowed_paths, c_flags, ccompiler, target)
+					// The public replay only strips implementation code that its
+					// undefined macros gate. If a file-scope external definition would
+					// survive, the owner object (full include) and the program unit's
+					// public replay both define the symbol, so the warm cached link
+					// fails with a duplicate symbol. Fail closed instead of splitting.
+					if cache_native_public_include_replays_external_definition(real_root,
+						context, implementation_macros, c_flags, ccompiler, target)
+					{
+						if os.getenv('V3_CACHE_TRACE') != '' {
+							eprintln('  V3 module cache ungated native definition: module=${module_name} path=${real_root}')
+						}
+						return false
+					}
 					state.native_type_declarations[real_root] = cache_native_public_include(real_root,
 						context, implementation_macros)
 				} else {
@@ -2780,6 +2815,7 @@ fn cache_native_public_include(path string, context []string, implementation_mac
 	// prior owning include may leave it defined even when this header's own
 	// context is declaration-only.
 	out.writeln('#undef SOKOL_IMPL')
+	mut restored := []string{}
 	for line in context {
 		directive, arg := cache_local_c_directive(line)
 		if directive == 'undef' {
@@ -2792,17 +2828,68 @@ fn cache_native_public_include(path string, context []string, implementation_mac
 		name := cache_local_c_define_name(arg)
 		if implementation_macros[name] || cache_native_implementation_macro(name) {
 			out.writeln('#undef ${name}')
+			restored << line
 		} else {
 			out.writeln(line)
 		}
 	}
 	out.writeln('#include "${c_include_path(path)}"')
+	// The implementation switches are only suppressed while the header expands, so
+	// its definitions stay in the owner object. Restore each define afterwards so a
+	// later native directive in the same translation unit (for example a
+	// declaration-only header guarded by the same macro) observes the macro state
+	// the uncached unit left behind instead of the temporary undefined state.
+	for line in restored {
+		out.writeln(line)
+	}
 	return out.str()
 }
 
 fn cache_native_implementation_macro(name string) bool {
 	return name.ends_with('_IMPLEMENTATION')
 		|| (name.starts_with('SOKOL') && name.ends_with('_IMPL'))
+}
+
+// cache_native_public_include_replays_external_definition reports whether the
+// declaration-only replay produced by cache_native_public_include would still
+// compile a file-scope external-linkage function definition. Such a symbol would
+// be emitted both in the owner module object (full include) and in every
+// non-owner public replay, so the caller must fail closed rather than split the
+// root. The header is preprocessed with the same macro state the replay
+// establishes (every implementation switch and the Sokol umbrella undefined, all
+// other context defines kept) so storage-class macros such as a `static inline`
+// hidden behind a macro are expanded before linkage is classified; a textual scan
+// cannot see through them and would misread internal-linkage helpers as external.
+// Results are limited to identifiers the header itself declares so definitions
+// pulled in from system headers are ignored. Any failure to verify is unsafe.
+fn cache_native_public_include_replays_external_definition(path string, context []string, implementation_macros map[string]bool, c_flags []string, ccompiler string, target pref.Target) bool {
+	mut replay_context := ['#undef SOKOL_IMPL']
+	for line in context {
+		directive, arg := cache_local_c_directive(line)
+		if directive == 'define' {
+			name := cache_local_c_define_name(arg)
+			if implementation_macros[name] || cache_native_implementation_macro(name) {
+				replay_context << '#undef ${name}'
+				continue
+			}
+		}
+		replay_context << line
+	}
+	preprocessed := cache_preprocessed_native_input(path, replay_context, c_flags, ccompiler,
+		target) or { return true }
+	source := os.read_file(os.real_path(path)) or { return true }
+	file_scope := c_source_file_scope_identifiers(source)
+	all_functions, functions_complete := modulecache.c_source_function_identifiers_with_status(preprocessed)
+	static_functions, static_complete := modulecache.c_source_static_function_identifiers_with_status(preprocessed)
+	if !functions_complete || !static_complete {
+		return true
+	}
+	for name, present in all_functions {
+		if present && !static_functions[name] && file_scope[name] {
+			return true
+		}
+	}
+	return false
 }
 
 fn cache_native_implementation_context_macros(path string, context []string, allowed_paths map[string]bool, c_flags []string, ccompiler string, target pref.Target) map[string]bool {

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -2812,7 +2812,7 @@ fn cache_native_implementation_context_macros(path string, context []string, all
 	mut full_active_paths := map[string]bool{}
 	full_source, _ := cache_c_source_definitely_active_code_for_path_with_status(path,
 		allowed_paths, mut full_active_paths, mut full_macros, false)
-	full_identifiers := cache_native_static_identifiers(full_source)
+	full_identifiers := cache_native_implementation_identifiers(full_source)
 	if full_identifiers.len == 0 {
 		return implementation_macros
 	}
@@ -2835,7 +2835,7 @@ fn cache_native_implementation_context_macros(path string, context []string, all
 		mut candidate_active_paths := map[string]bool{}
 		candidate_source, _ := cache_c_source_definitely_active_code_for_path_with_status(path,
 			allowed_paths, mut candidate_active_paths, mut candidate_macros, false)
-		candidate_identifiers := cache_native_static_identifiers(candidate_source)
+		candidate_identifiers := cache_native_implementation_identifiers(candidate_source)
 		if full_identifiers.keys().any(!candidate_identifiers[it]) {
 			implementation_macros[name] = true
 		}
@@ -2843,8 +2843,8 @@ fn cache_native_implementation_context_macros(path string, context []string, all
 	return implementation_macros
 }
 
-fn cache_native_static_identifiers(source string) map[string]bool {
-	mut identifiers, _ := modulecache.c_source_static_function_identifiers_with_status(source)
+fn cache_native_implementation_identifiers(source string) map[string]bool {
+	mut identifiers, _ := modulecache.c_source_function_identifiers_with_status(source)
 	variables, _ := modulecache.c_source_static_variable_identifiers(source)
 	for identifier, present in variables {
 		if present {

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -2421,8 +2421,10 @@ fn prepare_v3_cache_external_inputs(mut state V3ModuleCacheState, a &flat.FlatAs
 		cache_input_modules[module_name] = true
 	}
 	cache_input_modules['main'] = true
+	native_inputs_need_objective_c := cgen.cache_native_inputs_need_objective_c(a, prefs.vroot,
+		user_c_flags, prefs.c99, prefs.target)
 	compiler_macros, compiler_macro_environment_complete := cache_c_compiler_predefined_macros(user_c_flags,
-		prefs.ccompiler, prefs.target)
+		prefs.ccompiler, prefs.target, native_inputs_need_objective_c)
 	external_inputs, native_source_roots, native_root_contexts, unscoped_inputs, static_storage_inputs, resolution_dirs, missing_resolution_paths, has_untracked_c_include := cgen.cache_external_input_files_with_resolved_flags(a,
 		prefs.vroot, cache_input_modules, user_c_flags, prefs.target,
 		module_cache_source_path_set(user_files), compiler_macros,
@@ -2469,7 +2471,7 @@ fn prepare_v3_cache_external_inputs(mut state V3ModuleCacheState, a &flat.FlatAs
 	return !has_untracked_c_include && can_scope_static_inputs && can_extract_native_types
 }
 
-fn cache_c_compiler_predefined_macros(flags []string, ccompiler string, target pref.Target) (map[string]string, bool) {
+fn cache_c_compiler_predefined_macros(flags []string, ccompiler string, target pref.Target, native_inputs_need_objective_c bool) (map[string]string, bool) {
 	path := os.join_path(os.vtmp_dir(), 'v3_compiler_macros_${tempname.unique_token()}.c')
 	defer {
 		os.rm(path) or {}
@@ -2477,8 +2479,11 @@ fn cache_c_compiler_predefined_macros(flags []string, ccompiler string, target p
 	os.write_file(path, '') or { return map[string]string{}, false }
 	mut args := c_compiler_target_args(target, false) or { return map[string]string{}, false }
 	args << c_object_compile_flags(flags)
-	args << ['-dM', '-E', '-x', if c_flags_need_objective_c(flags) { 'objective-c' } else { 'c' },
-		path]
+	args << ['-dM', '-E', '-x', if native_inputs_need_objective_c || c_flags_need_objective_c(flags) {
+		'objective-c'
+	} else {
+		'c'
+	}, path]
 	result := cmdexec.run(ccompiler, args)
 	if result.exit_code != 0 {
 		if os.getenv('V3_CACHE_TRACE') != '' {
@@ -10972,11 +10977,15 @@ fn cache_static_input_is_private_to_module(a &flat.FlatAst, state &V3ModuleCache
 		preprocessed := cache_preprocessed_native_input(path, state.native_root_contexts[os.real_path(path)] or {
 			[]string{}
 		}, c_flags, ccompiler, target) or { return false }
-		header_identifiers, function_identifiers_complete =
-			modulecache.c_source_static_function_identifiers_with_status(preprocessed)
-		static_identifiers, static_identifiers_complete =
-			modulecache.c_source_static_variable_identifiers(preprocessed)
 		if !function_identifiers_complete {
+			header_identifiers, function_identifiers_complete =
+				modulecache.c_source_static_function_identifiers_with_status(preprocessed)
+		}
+		if !static_identifiers_complete {
+			static_identifiers, static_identifiers_complete =
+				modulecache.c_source_static_variable_identifiers(preprocessed)
+		}
+		if !function_identifiers_complete || !static_identifiers_complete {
 			if os.getenv('V3_CACHE_TRACE') != '' {
 				eprintln('  V3 module cache incomplete preprocessed static identifier scan: functions=${function_identifiers_complete} variables=${static_identifiers_complete} path=${path}')
 			}
@@ -10988,7 +10997,7 @@ fn cache_static_input_is_private_to_module(a &flat.FlatAst, state &V3ModuleCache
 			}
 		}
 		for identifier in static_identifiers.keys() {
-			if !source.contains(identifier) {
+			if !file_scope_identifiers[identifier] {
 				static_identifiers.delete(identifier)
 			}
 		}
@@ -11019,8 +11028,12 @@ fn cache_preprocessed_native_input(path string, context []string, c_flags []stri
 	unsafe { source.free() }
 	mut args := c_compiler_target_args(target, false) or { return none }
 	args << c_object_compile_flags(c_flags)
-	args << ['-E', '-P', '-x', if c_flags_need_objective_c(c_flags) { 'objective-c' } else { 'c' },
-		wrapper]
+	args << ['-E', '-P', '-x', if c_flags_need_objective_c(c_flags)
+		|| cgen.cache_native_input_path_needs_objective_c(path, c_flags, false, target) {
+		'objective-c'
+	} else {
+		'c'
+	}, wrapper]
 	result := cmdexec.run(ccompiler, args)
 	if result.exit_code != 0 {
 		if os.getenv('V3_CACHE_TRACE') != '' {

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -1405,13 +1405,12 @@ pub fn cache_external_input_files_with_resolved_flags(a &flat.FlatAst, vroot str
 				}
 				is_source_input := c_include_arg_is_source_file(include_arg)
 				if is_source_input || node.value == 'insert' {
-					mut roots := native_source_roots[owner_module]
 					real_path := os.real_path(path)
-					if real_path !in roots {
-						roots << real_path
+					if !c_add_cache_native_source_root(mut native_source_roots, mut
+						native_root_contexts, owner_module, real_path,
+						context_directives[owner_module]) {
+						has_untracked_include = true
 					}
-					native_source_roots[owner_module] = roots
-					native_root_contexts[real_path] = context_directives[owner_module].clone()
 				}
 				mut active_paths := map[string]bool{}
 				mut files := []string{}
@@ -1436,13 +1435,12 @@ pub fn cache_external_input_files_with_resolved_flags(a &flat.FlatAst, vroot str
 				}
 				if !is_source_input && include_arg.trim_space().starts_with('"')
 					&& files.any(active_static_storage_paths[owner_module + '\x00' + os.real_path(it)]) {
-					mut roots := native_source_roots[owner_module]
 					real_path := os.real_path(path)
-					if real_path !in roots {
-						roots << real_path
-						native_source_roots[owner_module] = roots
+					if !c_add_cache_native_source_root(mut native_source_roots, mut
+						native_root_contexts, owner_module, real_path,
+						context_directives[owner_module]) {
+						has_untracked_include = true
 					}
-					native_root_contexts[real_path] = context_directives[owner_module].clone()
 				}
 				break
 			}
@@ -1478,6 +1476,73 @@ pub fn cache_external_input_files_with_resolved_flags(a &flat.FlatAst, vroot str
 	mut sorted_missing_resolution_paths := missing_resolution_paths.keys()
 	sorted_missing_resolution_paths.sort()
 	return inputs, native_source_roots, native_root_contexts, unscoped_inputs, static_storage_inputs, sorted_resolution_dirs, sorted_missing_resolution_paths, has_untracked_include
+}
+
+fn c_add_cache_native_source_root(mut native_source_roots map[string][]string, mut native_root_contexts map[string][]string, owner_module string, real_path string, context []string) bool {
+	mut roots := native_source_roots[owner_module]
+	if real_path !in roots {
+		roots << real_path
+		native_source_roots[owner_module] = roots
+	}
+	if real_path in native_root_contexts {
+		if native_root_contexts[real_path] != context {
+			if os.getenv('V3_CACHE_TRACE') != '' {
+				eprintln('  V3 module cache incompatible native root contexts: module=${owner_module} path=${real_path}')
+			}
+			return false
+		}
+		return true
+	}
+	native_root_contexts[real_path] = context.clone()
+	return true
+}
+
+// cache_native_inputs_need_objective_c reports whether cgen will implicitly
+// compile the generated translation unit as Objective-C because of a source
+// directive rather than an explicit compiler flag.
+pub fn cache_native_inputs_need_objective_c(a &flat.FlatAst, vroot string, c_flags []string, c99_mode bool, target pref.Target) bool {
+	include_dirs := c_flag_include_dirs(c_flags)
+	mut cur_file := ''
+	for node in a.nodes {
+		if node.kind == .file {
+			cur_file = node.value
+			continue
+		}
+		if node.kind != .directive || node.value !in ['include', 'insert'] || node.typ.len == 0 {
+			continue
+		}
+		include_arg := c_include_arg_for_target(node.typ, vroot, cur_file, target)
+		if include_arg.len == 0 || c_include_arg_is_builtin_abi_helper(include_arg, vroot) {
+			continue
+		}
+		if c_include_arg_is_source_file(include_arg) {
+			for path in c_include_file_paths(include_arg, vroot, cur_file, include_dirs) {
+				if cache_native_input_path_needs_objective_c(path, c_flags, c99_mode, target) {
+					return true
+				}
+			}
+			continue
+		}
+		if header := c_inline_header_text(include_arg, vroot, cur_file, include_dirs, false) {
+			if c_header_text_needs_objective_c_for_target(header.text, c_flags, c99_mode, target) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// cache_native_input_path_needs_objective_c reports whether a native input
+// must use the Objective-C preprocessor language selected by cgen.
+pub fn cache_native_input_path_needs_objective_c(path string, c_flags []string, c99_mode bool, target pref.Target) bool {
+	if !os.is_file(path) {
+		return false
+	}
+	if path.ends_with('.m') {
+		return true
+	}
+	text := os.read_file(path) or { return false }
+	return c_header_text_needs_objective_c_for_target(text, c_flags, c99_mode, target)
 }
 
 // cache_c_flag_input_files returns forced include/macro files whose contents

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -517,6 +517,7 @@ mut:
 	struct_decl_pref_cache     &StructDeclPrefCache = unsafe { nil }
 	unused_param_seen          &UnusedParamSeen     = unsafe { nil }
 	cache_split                bool
+	cache_native_input_paths   map[string]bool
 	program_body_only          bool
 	cached_support_identifiers map[string]bool
 	// Set when the target is built with -prealloc / -d prealloc: the bump
@@ -1204,6 +1205,15 @@ pub fn (mut g FlatGen) set_cache_split(enabled bool) {
 	g.cache_split = enabled
 }
 
+// set_cache_native_input_paths assigns native headers and sources to their owning
+// cached module object instead of the shared generated declaration prefix.
+pub fn (mut g FlatGen) set_cache_native_input_paths(paths []string) {
+	g.cache_native_input_paths = map[string]bool{}
+	for path in paths {
+		g.cache_native_input_paths[os.real_path(path)] = true
+	}
+}
+
 // set_program_body_only omits the reusable declaration/type prefix. It is used
 // when that prefix has already been validated and loaded from the module cache.
 pub fn (mut g FlatGen) set_program_body_only(enabled bool) {
@@ -1302,8 +1312,8 @@ pub fn cache_external_input_files(a &flat.FlatAst, vroot string, source_modules 
 		}
 	}
 	c_flags << initial_c_flags
-	inputs, native_source_roots, _, _, _, has_untracked_include := cache_external_input_files_with_resolved_flags(a,
-		vroot, source_modules, c_flags, target, map[string]bool{})
+	inputs, native_source_roots, _, _, _, _, _, has_untracked_include := cache_external_input_files_with_resolved_flags(a,
+		vroot, source_modules, c_flags, target, map[string]bool{}, map[string]string{}, false)
 	return inputs, native_source_roots, has_untracked_include
 }
 
@@ -1314,10 +1324,10 @@ pub fn cache_external_input_files(a &flat.FlatAst, vroot string, source_modules 
 // directory whose contents can change path resolution; missing_resolution_paths
 // are the first nonexistent path components searched. Directives from program_files
 // belong to the program translation unit even when a library test declares that module.
-pub fn cache_external_input_files_with_resolved_flags(a &flat.FlatAst, vroot string, source_modules map[string]bool, c_flags []string, target pref.Target, program_files map[string]bool) (map[string][]string, map[string][]string, map[string][]string, []string, []string, bool) {
+pub fn cache_external_input_files_with_resolved_flags(a &flat.FlatAst, vroot string, source_modules map[string]bool, c_flags []string, target pref.Target, program_files map[string]bool, compiler_macros map[string]string, compiler_macro_environment_complete bool) (map[string][]string, map[string][]string, map[string][]string, map[string][]string, map[string][]string, []string, []string, bool) {
 	include_dirs := c_flag_include_dirs(c_flags)
-	flag_inputs, flags_have_untracked_include, mut include_macros, mut dynamic_include_macros, mut resolution_dirs, mut missing_resolution_paths :=
-		cache_c_flag_input_files_with_status(c_flags)
+	flag_inputs, flags_have_untracked_include, mut include_macros, mut dynamic_include_macros, mut resolution_dirs, mut missing_resolution_paths := cache_c_flag_input_files_with_status(c_flags,
+		compiler_macros, compiler_macro_environment_complete)
 	mut collect_modules := map[string]bool{}
 	for module_name, enabled in source_modules {
 		if enabled {
@@ -1330,13 +1340,17 @@ pub fn cache_external_input_files_with_resolved_flags(a &flat.FlatAst, vroot str
 	}
 	mut inputs := map[string][]string{}
 	mut native_source_roots := map[string][]string{}
+	mut native_root_contexts := map[string][]string{}
 	mut unscoped_inputs := map[string][]string{}
+	mut static_storage_inputs := map[string][]string{}
 	mut has_untracked_include := false
 	mut collected_paths := map[string]bool{}
 	mut ambiguous_collected_paths := map[string]bool{}
+	mut active_static_storage_paths := map[string]bool{}
 	mut cur_module := ''
 	mut cur_file := ''
 	mut cur_file_is_program := false
+	mut context_directives := map[string][]string{}
 	for node in a.nodes {
 		if node.kind == .file {
 			cur_file = node.value
@@ -1356,6 +1370,15 @@ pub fn cache_external_input_files_with_resolved_flags(a &flat.FlatAst, vroot str
 			'main'
 		}
 		if !collect_modules[owner_module] {
+			continue
+		}
+		if node.kind == .directive && node.value in ['define', 'undef'] {
+			directive := c_preprocessor_directive_line(node.value, node.typ)
+			c_record_include_macro_definition(directive, false, mut include_macros, mut
+				dynamic_include_macros)
+			mut module_context := context_directives[owner_module]
+			module_context << directive
+			context_directives[owner_module] = module_context
 			continue
 		}
 		if node.kind == .directive
@@ -1383,15 +1406,20 @@ pub fn cache_external_input_files_with_resolved_flags(a &flat.FlatAst, vroot str
 				is_source_input := c_include_arg_is_source_file(include_arg)
 				if is_source_input || node.value == 'insert' {
 					mut roots := native_source_roots[owner_module]
-					roots << os.real_path(path)
+					real_path := os.real_path(path)
+					if real_path !in roots {
+						roots << real_path
+					}
 					native_source_roots[owner_module] = roots
+					native_root_contexts[real_path] = context_directives[owner_module].clone()
 				}
 				mut active_paths := map[string]bool{}
 				mut files := []string{}
 				if c_collect_external_input_tree(path, vroot, include_dirs, mut active_paths, mut
 					collected_paths, mut ambiguous_collected_paths, mut files, mut include_macros, mut
-					dynamic_include_macros, mut resolution_dirs, mut missing_resolution_paths,
-					owner_module, false)
+					dynamic_include_macros, mut resolution_dirs, mut missing_resolution_paths, mut
+					active_static_storage_paths, owner_module, false,
+					compiler_macro_environment_complete)
 				{
 					has_untracked_include = true
 				}
@@ -1399,7 +1427,22 @@ pub fn cache_external_input_files_with_resolved_flags(a &flat.FlatAst, vroot str
 					c_add_cache_external_input(mut inputs, owner_module, file)
 					if is_source_input || include_arg.trim_space().starts_with('"') {
 						c_add_cache_external_input(mut unscoped_inputs, owner_module, file)
+						collection_key := owner_module + '\x00' + os.real_path(file)
+						if active_static_storage_paths[collection_key] {
+							c_add_cache_external_input(mut static_storage_inputs, owner_module,
+								file)
+						}
 					}
+				}
+				if !is_source_input && include_arg.trim_space().starts_with('"')
+					&& files.any(active_static_storage_paths[owner_module + '\x00' + os.real_path(it)]) {
+					mut roots := native_source_roots[owner_module]
+					real_path := os.real_path(path)
+					if real_path !in roots {
+						roots << real_path
+						native_source_roots[owner_module] = roots
+					}
+					native_root_contexts[real_path] = context_directives[owner_module].clone()
 				}
 				break
 			}
@@ -1425,21 +1468,26 @@ pub fn cache_external_input_files_with_resolved_flags(a &flat.FlatAst, vroot str
 		sorted.sort()
 		unscoped_inputs[module_name] = sorted
 	}
+	for module_name, paths in static_storage_inputs {
+		mut sorted := paths.clone()
+		sorted.sort()
+		static_storage_inputs[module_name] = sorted
+	}
 	mut sorted_resolution_dirs := resolution_dirs.keys()
 	sorted_resolution_dirs.sort()
 	mut sorted_missing_resolution_paths := missing_resolution_paths.keys()
 	sorted_missing_resolution_paths.sort()
-	return inputs, native_source_roots, unscoped_inputs, sorted_resolution_dirs, sorted_missing_resolution_paths, has_untracked_include
+	return inputs, native_source_roots, native_root_contexts, unscoped_inputs, static_storage_inputs, sorted_resolution_dirs, sorted_missing_resolution_paths, has_untracked_include
 }
 
 // cache_c_flag_input_files returns forced include/macro files whose contents
 // affect every cached object compiled with the supplied C flags.
 pub fn cache_c_flag_input_files(flags []string) []string {
-	files, _, _, _, _, _ := cache_c_flag_input_files_with_status(flags)
+	files, _, _, _, _, _ := cache_c_flag_input_files_with_status(flags, map[string]string{}, false)
 	return files
 }
 
-fn cache_c_flag_input_files_with_status(flags []string) ([]string, bool, map[string][]string, map[string]bool, map[string]bool, map[string]bool) {
+fn cache_c_flag_input_files_with_status(flags []string, compiler_macros map[string]string, compiler_macro_environment_complete bool) ([]string, bool, map[string][]string, map[string]bool, map[string]bool, map[string]bool) {
 	include_dirs := c_flag_include_dirs(flags)
 	mut active_paths := map[string]bool{}
 	mut collected_paths := map[string]bool{}
@@ -1447,8 +1495,10 @@ fn cache_c_flag_input_files_with_status(flags []string) ([]string, bool, map[str
 	mut files := []string{}
 	mut resolution_dirs := map[string]bool{}
 	mut missing_resolution_paths := map[string]bool{}
+	mut active_static_storage_paths := map[string]bool{}
 	mut has_untracked_include := false
-	mut include_macros, mut dynamic_include_macros := c_flag_include_macro_definitions(flags)
+	mut include_macros, mut dynamic_include_macros := c_flag_include_macro_definitions(flags,
+		compiler_macros)
 	for forced_input in c_forced_include_inputs(flags) {
 		for path in c_include_file_paths('"${forced_input}"', '', '', include_dirs) {
 			c_record_cache_resolution_path(path, mut resolution_dirs, mut missing_resolution_paths)
@@ -1457,8 +1507,9 @@ fn cache_c_flag_input_files_with_status(flags []string) ([]string, bool, map[str
 			}
 			if c_collect_external_input_tree(path, '', include_dirs, mut active_paths, mut
 				collected_paths, mut ambiguous_collected_paths, mut files, mut include_macros, mut
-				dynamic_include_macros, mut resolution_dirs, mut missing_resolution_paths,
-				'__v3_c_flags__', false)
+				dynamic_include_macros, mut resolution_dirs, mut missing_resolution_paths, mut
+				active_static_storage_paths, '__v3_c_flags__', false,
+				compiler_macro_environment_complete)
 			{
 				has_untracked_include = true
 			}
@@ -1517,7 +1568,7 @@ mut:
 	ambiguous bool
 }
 
-fn c_collect_external_input_tree(path string, vroot string, include_dirs []string, mut active_paths map[string]bool, mut collected_paths map[string]bool, mut ambiguous_collected_paths map[string]bool, mut files []string, mut include_macros map[string][]string, mut dynamic_include_macros map[string]bool, mut resolution_dirs map[string]bool, mut missing_resolution_paths map[string]bool, collection_scope string, ambient_ambiguous bool) bool {
+fn c_collect_external_input_tree(path string, vroot string, include_dirs []string, mut active_paths map[string]bool, mut collected_paths map[string]bool, mut ambiguous_collected_paths map[string]bool, mut files []string, mut include_macros map[string][]string, mut dynamic_include_macros map[string]bool, mut resolution_dirs map[string]bool, mut missing_resolution_paths map[string]bool, mut active_static_storage_paths map[string]bool, collection_scope string, ambient_ambiguous bool, compiler_macro_environment_complete bool) bool {
 	if path.len == 0 || !os.is_file(path) {
 		return false
 	}
@@ -1526,6 +1577,7 @@ fn c_collect_external_input_tree(path string, vroot string, include_dirs []strin
 		return false
 	}
 	collection_key := collection_scope + '\x00' + real_path
+	first_collection := !collected_paths[collection_key]
 	mut text := ''
 	if collected_paths[collection_key] {
 		text = os.read_file(real_path) or { return true }
@@ -1551,7 +1603,7 @@ fn c_collect_external_input_tree(path string, vroot string, include_dirs []strin
 	defer {
 		active_paths.delete(real_path)
 	}
-	if !collected_paths[collection_key] {
+	if first_collection {
 		collected_paths[collection_key] = true
 		if ambient_ambiguous {
 			ambiguous_collected_paths[collection_key] = true
@@ -1561,7 +1613,19 @@ fn c_collect_external_input_tree(path string, vroot string, include_dirs []strin
 	if text.len == 0 {
 		text = os.read_file(real_path) or { return false }
 	}
+	if first_collection {
+		if guard := c_whole_file_guard_macro(text) {
+			if guard.len > 0 && guard in include_macros {
+				// Macro state can arrive from the same guarded system header scanned
+				// for another cache unit. Its companion macros are unit-local, so make
+				// the first traversal in this scope collect the complete guarded body.
+				include_macros.delete(guard)
+				dynamic_include_macros.delete(guard)
+			}
+		}
+	}
 	mut has_untracked_include := false
+	mut possible_source := strings.new_builder(text.len)
 	mut in_block_comment := false
 	mut conditionals := []CCacheConditional{}
 	for line in text.split_into_lines() {
@@ -1571,7 +1635,8 @@ fn c_collect_external_input_tree(path string, vroot string, include_dirs []strin
 		if directive_name in ['if', 'ifdef', 'ifndef'] {
 			parent_inactive := conditionals.any(it.inactive)
 			parent_ambiguous := conditionals.any(it.ambiguous)
-			condition := c_cache_known_condition(clean, include_macros, dynamic_include_macros)
+			condition := c_cache_known_condition(clean, include_macros, dynamic_include_macros,
+				compiler_macro_environment_complete)
 			conditionals << CCacheConditional{
 				parent_inactive: parent_inactive
 				condition:       condition
@@ -1589,7 +1654,7 @@ fn c_collect_external_input_tree(path string, vroot string, include_dirs []strin
 				conditional.inactive = true
 			} else {
 				next_condition := c_cache_known_condition(clean, include_macros,
-					dynamic_include_macros)
+					dynamic_include_macros, compiler_macro_environment_complete)
 				conditional.condition = next_condition
 				conditional.ambiguous = conditional.ambiguous || next_condition == 0
 				conditional.inactive = conditional.parent_inactive || conditional.condition < 0
@@ -1606,6 +1671,7 @@ fn c_collect_external_input_tree(path string, vroot string, include_dirs []strin
 		if conditionals.any(it.inactive) {
 			continue
 		}
+		possible_source.writeln(line)
 		if directive_name !in ['include', 'import'] {
 			c_record_include_macro_definition(clean, ambient_ambiguous
 				|| conditionals.any(it.ambiguous), mut include_macros, mut dynamic_include_macros)
@@ -1623,8 +1689,16 @@ fn c_collect_external_input_tree(path string, vroot string, include_dirs []strin
 			}
 			include_args = include_macros[macro_name].clone()
 			if include_args.len == 0 {
+				literal_values := c_literal_include_macro_values(files, macro_name)
+				if literal_values.len == 1 {
+					include_args = literal_values.clone()
+					include_macros[macro_name] = include_args.clone()
+					dynamic_include_macros.delete(macro_name)
+				}
+			}
+			if include_args.len == 0 {
 				if os.getenv('V3_CACHE_TRACE') != '' {
-					eprintln('  V3 module cache unresolved nested include: file=${real_path} include=${macro_name}')
+					eprintln('  V3 module cache unresolved nested include: file=${real_path} include=${macro_name} known=${macro_name in include_macros} dynamic=${macro_name in dynamic_include_macros}')
 				}
 				has_untracked_include = true
 				continue
@@ -1641,7 +1715,8 @@ fn c_collect_external_input_tree(path string, vroot string, include_dirs []strin
 				if c_collect_external_input_tree(nested_path, vroot, include_dirs, mut
 					active_paths, mut collected_paths, mut ambiguous_collected_paths, mut files, mut
 					include_macros, mut dynamic_include_macros, mut resolution_dirs, mut
-					missing_resolution_paths, collection_scope, nested_ambiguous)
+					missing_resolution_paths, mut active_static_storage_paths, collection_scope,
+					nested_ambiguous, compiler_macro_environment_complete)
 				{
 					has_untracked_include = true
 				}
@@ -1649,7 +1724,42 @@ fn c_collect_external_input_tree(path string, vroot string, include_dirs []strin
 			}
 		}
 	}
+	possible_text := possible_source.str()
+	if modulecache.c_source_has_static_storage(possible_text) {
+		active_static_storage_paths[collection_key] = true
+		if os.getenv('V3_CACHE_TRACE') != '' {
+			eprintln('  V3 module cache active static C input: module=${collection_scope} path=${real_path}')
+		}
+	}
+	unsafe { possible_source.free() }
 	return has_untracked_include
+}
+
+fn c_literal_include_macro_values(paths []string, macro_name string) []string {
+	mut values := []string{}
+	for path in paths {
+		text := os.read_file(path) or { continue }
+		mut in_block_comment := false
+		for line in text.split_into_lines() {
+			clean, next_in_block_comment := c_preprocessor_directive_scan_line(line,
+				in_block_comment)
+			in_block_comment = next_in_block_comment
+			if c_directive_name(clean) != 'define' {
+				continue
+			}
+			definition := c_directive_arg(clean)
+			fields := definition.fields()
+			if fields.len == 0 || fields[0] != macro_name {
+				continue
+			}
+			value := definition[macro_name.len..].trim_space()
+			if c_include_arg_is_literal(value) && value !in values {
+				values << value
+			}
+		}
+	}
+	values.sort()
+	return values
 }
 
 // c_whole_file_guard_macro returns the include guard that gates a whole-file
@@ -1733,46 +1843,71 @@ fn c_whole_file_guard_name(directive string) string {
 }
 
 // A false dynamic_include_macros value marks a macro whose defined state is ambiguous.
-fn c_cache_known_condition(directive string, include_macros map[string][]string, dynamic_include_macros map[string]bool) int {
+fn c_cache_known_condition(directive string, include_macros map[string][]string, dynamic_include_macros map[string]bool, compiler_macro_environment_complete bool) int {
 	name := c_directive_name(directive)
-	mut expression := c_directive_arg(directive).trim_space()
-	mut invert := name == 'ifndef'
+	expression := c_directive_arg(directive).trim_space()
 	if name in ['ifdef', 'ifndef'] {
-		if expression !in include_macros && !dynamic_include_macros[expression] {
-			// Compiler-provided macros are not present in the scanned definitions.
-			return 0
-		}
-		return if invert { -1 } else { 1 }
+		return c_cache_macro_condition(expression, name == 'ifndef', include_macros,
+			dynamic_include_macros, compiler_macro_environment_complete)
 	}
-	if name == 'elif' {
-		expression = expression.trim_space()
+	return c_cache_known_expression(expression, include_macros, dynamic_include_macros,
+		compiler_macro_environment_complete)
+}
+
+fn c_cache_known_expression(raw_expression string, include_macros map[string][]string, dynamic_include_macros map[string]bool, compiler_macro_environment_complete bool) int {
+	expression := c_header_condition_without_outer_parens(raw_expression.trim_space())
+	or_parts := c_header_condition_top_level_parts(expression, '||')
+	if or_parts.len > 1 {
+		mut all_false := true
+		for part in or_parts {
+			condition := c_cache_known_expression(part, include_macros, dynamic_include_macros,
+				compiler_macro_environment_complete)
+			if condition > 0 {
+				return 1
+			}
+			all_false = all_false && condition < 0
+		}
+		return if all_false { -1 } else { 0 }
+	}
+	and_parts := c_header_condition_top_level_parts(expression, '&&')
+	if and_parts.len > 1 {
+		mut all_true := true
+		for part in and_parts {
+			condition := c_cache_known_expression(part, include_macros, dynamic_include_macros,
+				compiler_macro_environment_complete)
+			if condition < 0 {
+				return -1
+			}
+			all_true = all_true && condition > 0
+		}
+		return if all_true { 1 } else { 0 }
 	}
 	if expression.starts_with('!') {
-		invert = !invert
-		expression = expression[1..].trim_space()
+		condition := c_cache_known_expression(expression[1..], include_macros,
+			dynamic_include_macros, compiler_macro_environment_complete)
+		return if condition == 0 { 0 } else { -condition }
 	}
-	if !expression.starts_with('defined') {
+	if macro_name := c_header_defined_macro_name(expression) {
+		return c_cache_macro_condition(macro_name, false, include_macros, dynamic_include_macros,
+			compiler_macro_environment_complete)
+	}
+	if expression == '0' {
+		return -1
+	}
+	if expression == '1' {
+		return 1
+	}
+	return 0
+}
+
+fn c_cache_macro_condition(macro_name string, invert bool, include_macros map[string][]string, dynamic_include_macros map[string]bool, compiler_macro_environment_complete bool) int {
+	if macro_name in dynamic_include_macros && !dynamic_include_macros[macro_name] {
 		return 0
 	}
-	expression = expression['defined'.len..].trim_space()
-	mut macro_name := ''
-	if expression.starts_with('(') {
-		close := expression.index_u8(`)`)
-		if close <= 1 || expression[close + 1..].trim_space().len > 0 {
-			return 0
+	if macro_name !in include_macros && macro_name !in dynamic_include_macros {
+		if compiler_macro_environment_complete {
+			return if invert { 1 } else { -1 }
 		}
-		macro_name = expression[1..close].trim_space()
-	} else {
-		fields := expression.fields()
-		if fields.len != 1 {
-			return 0
-		}
-		macro_name = fields[0]
-	}
-	if macro_name.len == 0 {
-		return 0
-	}
-	if macro_name !in include_macros && !dynamic_include_macros[macro_name] {
 		// Preserve both branches when the compiler may provide this macro.
 		return 0
 	}
@@ -1807,9 +1942,12 @@ fn c_record_cache_resolution_path(path string, mut resolution_dirs map[string]bo
 	}
 }
 
-fn c_flag_include_macro_definitions(flags []string) (map[string][]string, map[string]bool) {
+fn c_flag_include_macro_definitions(flags []string, compiler_macros map[string]string) (map[string][]string, map[string]bool) {
 	mut include_macros := map[string][]string{}
 	mut dynamic_include_macros := map[string]bool{}
+	for name, value in compiler_macros {
+		c_record_include_macro_value(name, value, mut include_macros, mut dynamic_include_macros)
+	}
 	mut i := 0
 	for i < flags.len {
 		clean := flags[i].trim_space()
@@ -1879,6 +2017,13 @@ fn c_record_include_macro_value(name string, value string, mut include_macros ma
 		return
 	}
 	if !c_include_arg_is_literal(value) {
+		is_alias := !value[0].is_digit() && value.bytes().all(it.is_alnum() || it == `_`)
+		if is_alias && value in include_macros && value !in dynamic_include_macros
+			&& include_macros[value].len > 0 {
+			dynamic_include_macros.delete(name)
+			include_macros[name] = include_macros[value].clone()
+			return
+		}
 		include_macros.delete(name)
 		dynamic_include_macros[name] = true
 		return
@@ -3956,8 +4101,17 @@ fn (mut g FlatGen) collect_c_directive(module_name string, node flat.Node, sourc
 		{
 			header_text := header.text
 			late_source := c_include_is_late_source(include_arg)
-			scoped_static_insert := g.cache_split && node.value == 'insert'
-				&& modulecache.c_source_has_static_storage(header_text)
+			mut scoped_native_header_path := ''
+			if g.cache_split {
+				for path in c_include_file_paths(include_arg, g.compiler_vroot, source_file,
+					include_dirs) {
+					real_path := os.real_path(path)
+					if g.cache_native_input_paths[real_path] {
+						scoped_native_header_path = real_path
+						break
+					}
+				}
+			}
 			if c_header_text_needs_objective_c_for_target(header_text, g.c_flags, g.c99_mode, g.target)
 				&& 'objective-c' !in g.c_flags {
 				g.c_flags << ['-x', 'objective-c', '-x', 'none']
@@ -3987,17 +4141,11 @@ fn (mut g FlatGen) collect_c_directive(module_name string, node flat.Node, sourc
 					g.add_c_directive(module_name, system_includes, before_import)
 				}
 			}
-			if header_text.len > 0 && !scoped_static_insert {
+			if header_text.len > 0 && scoped_native_header_path.len == 0 {
 				g.add_c_directive_at(module_name, header_text, before_import, late_source)
-			} else if scoped_static_insert {
-				for path in c_include_file_paths(include_arg, g.compiler_vroot, source_file,
-					include_dirs) {
-					if os.is_file(path) {
-						g.add_c_directive(module_name,
-							c_native_source_context_include(os.real_path(path)), before_import)
-						break
-					}
-				}
+			} else if scoped_native_header_path.len > 0 {
+				g.add_c_directive(module_name,
+					c_native_source_context_include(scoped_native_header_path), before_import)
 			}
 		} else if c_should_preserve_uninlined_include(include_arg) || (g.cache_split
 			&& include_arg in ['<mach/mach.h>', '<mach/task.h>', '<mach/mach_time.h>']) {
@@ -4349,32 +4497,73 @@ fn c_inline_header_tree_uses_inttypes(path string, vroot string, include_dirs []
 
 fn c_preprocessor_directive_scan_line(line string, in_block_comment bool) (string, bool) {
 	mut in_comment := in_block_comment
+	mut directive := strings.new_builder(line.len)
+	mut directive_started := false
+	mut directive_possible := true
+	mut quote := u8(0)
+	mut escaped := false
 	mut i := 0
 	for i < line.len {
 		if in_comment {
-			end_rel := line[i..].index('*/') or { return '', true }
+			end_rel := line[i..].index('*/') or {
+				unsafe { directive.free() }
+				return '', true
+			}
 			i += end_rel + 2
 			in_comment = false
 			continue
 		}
+		if quote != 0 {
+			if directive_started {
+				directive.write_u8(line[i])
+			}
+			if escaped {
+				escaped = false
+			} else if line[i] == `\\` {
+				escaped = true
+			} else if line[i] == quote {
+				quote = 0
+			}
+			i++
+			continue
+		}
 		if i + 1 < line.len && line[i] == `/` && line[i + 1] == `*` {
 			in_comment = true
+			if directive_started {
+				directive.write_u8(` `)
+			}
 			i += 2
 			continue
 		}
 		if i + 1 < line.len && line[i] == `/` && line[i + 1] == `/` {
-			return '', in_comment
+			break
 		}
-		if line[i].is_space() {
+		if !directive_started && directive_possible && line[i].is_space() {
 			i++
 			continue
 		}
-		if line[i] == `#` {
-			return trimmed_space(line[i..]), in_comment
+		if !directive_started {
+			if !directive_possible || line[i] != `#` {
+				// Continue scanning ordinary source so a trailing block comment is
+				// carried into the next line, where `#` is still comment text.
+				directive_possible = false
+				if line[i] in [`'`, `"`] {
+					quote = line[i]
+				}
+				i++
+				continue
+			}
+			directive_started = true
 		}
-		return '', in_comment
+		directive.write_u8(line[i])
+		if line[i] in [`'`, `"`] {
+			quote = line[i]
+		}
+		i++
 	}
-	return '', in_comment
+	result := if directive_started { directive.str().trim_space() } else { '' }
+	unsafe { directive.free() }
+	return result, in_comment
 }
 
 // c_header_guard_name returns the macro of a classic `#ifndef X` / `#define X`

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -1351,11 +1351,14 @@ pub fn cache_external_input_files_with_resolved_flags(a &flat.FlatAst, vroot str
 	mut cur_file := ''
 	mut cur_file_is_program := false
 	mut context_directives := map[string][]string{}
+	mut conditional_context_mutations := map[string]bool{}
+	mut conditional_depth := 0
 	for node in a.nodes {
 		if node.kind == .file {
 			cur_file = node.value
 			cur_file_is_program = program_files[cur_file] || program_files[os.real_path(cur_file)]
 			cur_module = ''
+			conditional_depth = 0
 			continue
 		}
 		if node.kind == .module_decl {
@@ -1372,13 +1375,24 @@ pub fn cache_external_input_files_with_resolved_flags(a &flat.FlatAst, vroot str
 		if !collect_modules[owner_module] {
 			continue
 		}
+		if node.kind == .directive {
+			if node.value in ['if', 'ifdef', 'ifndef'] {
+				conditional_depth++
+			} else if node.value == 'endif' && conditional_depth > 0 {
+				conditional_depth--
+			}
+		}
 		if node.kind == .directive && node.value in ['define', 'undef'] {
 			directive := c_preprocessor_directive_line(node.value, node.typ)
-			c_record_include_macro_definition(directive, false, mut include_macros, mut
+			is_conditional := conditional_depth > 0
+			c_record_include_macro_definition(directive, is_conditional, mut include_macros, mut
 				dynamic_include_macros)
 			mut module_context := context_directives[owner_module]
 			module_context << directive
 			context_directives[owner_module] = module_context
+			if is_conditional {
+				conditional_context_mutations[owner_module] = true
+			}
 			continue
 		}
 		if node.kind == .directive
@@ -1408,7 +1422,8 @@ pub fn cache_external_input_files_with_resolved_flags(a &flat.FlatAst, vroot str
 					real_path := os.real_path(path)
 					if !c_add_cache_native_source_root(mut native_source_roots, mut
 						native_root_contexts, owner_module, real_path,
-						context_directives[owner_module]) {
+						context_directives[owner_module],
+						!conditional_context_mutations[owner_module]) {
 						has_untracked_include = true
 					}
 				}
@@ -1438,7 +1453,8 @@ pub fn cache_external_input_files_with_resolved_flags(a &flat.FlatAst, vroot str
 					real_path := os.real_path(path)
 					if !c_add_cache_native_source_root(mut native_source_roots, mut
 						native_root_contexts, owner_module, real_path,
-						context_directives[owner_module]) {
+						context_directives[owner_module],
+						!conditional_context_mutations[owner_module]) {
 						has_untracked_include = true
 					}
 				}
@@ -1478,7 +1494,7 @@ pub fn cache_external_input_files_with_resolved_flags(a &flat.FlatAst, vroot str
 	return inputs, native_source_roots, native_root_contexts, unscoped_inputs, static_storage_inputs, sorted_resolution_dirs, sorted_missing_resolution_paths, has_untracked_include
 }
 
-fn c_add_cache_native_source_root(mut native_source_roots map[string][]string, mut native_root_contexts map[string][]string, owner_module string, real_path string, context []string) bool {
+fn c_add_cache_native_source_root(mut native_source_roots map[string][]string, mut native_root_contexts map[string][]string, owner_module string, real_path string, context []string, context_is_replayable bool) bool {
 	mut roots := native_source_roots[owner_module]
 	if real_path !in roots {
 		roots << real_path
@@ -1491,9 +1507,15 @@ fn c_add_cache_native_source_root(mut native_source_roots map[string][]string, m
 			}
 			return false
 		}
-		return true
+	} else {
+		native_root_contexts[real_path] = context.clone()
 	}
-	native_root_contexts[real_path] = context.clone()
+	if !context_is_replayable {
+		if os.getenv('V3_CACHE_TRACE') != '' {
+			eprintln('  V3 module cache conditional native root context: module=${owner_module} path=${real_path}')
+		}
+		return false
+	}
 	return true
 }
 

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -1411,6 +1411,8 @@ pub fn cache_external_input_files_with_resolved_flags(a &flat.FlatAst, vroot str
 				has_untracked_include = true
 				continue
 			}
+			context_is_replayable := conditional_depth == 0
+				&& !conditional_context_mutations[owner_module]
 			for path in c_include_file_paths(include_arg, vroot, cur_file, include_dirs) {
 				c_record_cache_resolution_path(path, mut resolution_dirs, mut
 					missing_resolution_paths)
@@ -1422,8 +1424,7 @@ pub fn cache_external_input_files_with_resolved_flags(a &flat.FlatAst, vroot str
 					real_path := os.real_path(path)
 					if !c_add_cache_native_source_root(mut native_source_roots, mut
 						native_root_contexts, owner_module, real_path,
-						context_directives[owner_module],
-						!conditional_context_mutations[owner_module]) {
+						context_directives[owner_module], context_is_replayable) {
 						has_untracked_include = true
 					}
 				}
@@ -1453,8 +1454,7 @@ pub fn cache_external_input_files_with_resolved_flags(a &flat.FlatAst, vroot str
 					real_path := os.real_path(path)
 					if !c_add_cache_native_source_root(mut native_source_roots, mut
 						native_root_contexts, owner_module, real_path,
-						context_directives[owner_module],
-						!conditional_context_mutations[owner_module]) {
+						context_directives[owner_module], context_is_replayable) {
 						has_untracked_include = true
 					}
 				}

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -1567,6 +1567,89 @@ pub fn cache_native_input_path_needs_objective_c(path string, c_flags []string, 
 	return c_header_text_needs_objective_c_for_target(text, c_flags, c99_mode, target)
 }
 
+// cache_native_input_language reports the exact preprocessor language cgen
+// selects for a native input. The dependency probe and privacy preprocessing must
+// use it so they observe the same predefined macros as the real build; an `.mm`
+// source, for example, is Objective-C++ and defines both `__OBJC__` and
+// `__cplusplus`, so probing it as plain C or Objective-C omits `__cplusplus` and
+// wrongly discards branches guarded by it.
+pub fn cache_native_input_language(path string, c_flags []string, c99_mode bool, target pref.Target) string {
+	if path.ends_with('.mm') {
+		return 'objective-c++'
+	}
+	if path.ends_with('.m') {
+		return 'objective-c'
+	}
+	if path.ends_with('.cc') || path.ends_with('.cpp') {
+		return 'c++'
+	}
+	if cache_native_input_path_needs_objective_c(path, c_flags, c99_mode, target) {
+		return 'objective-c'
+	}
+	return 'c'
+}
+
+// cache_native_inputs_language reports the richest preprocessor language any
+// native input requires. The shared compiler-macro probe uses it so it never omits
+// a language macro (`__OBJC__`, `__cplusplus`) that an input's active branches
+// depend on.
+pub fn cache_native_inputs_language(a &flat.FlatAst, vroot string, c_flags []string, c99_mode bool, target pref.Target) string {
+	include_dirs := c_flag_include_dirs(c_flags)
+	mut need_objc := false
+	mut need_cpp := false
+	mut cur_file := ''
+	for node in a.nodes {
+		if node.kind == .file {
+			cur_file = node.value
+			continue
+		}
+		if node.kind != .directive || node.value !in ['include', 'insert'] || node.typ.len == 0 {
+			continue
+		}
+		include_arg := c_include_arg_for_target(node.typ, vroot, cur_file, target)
+		if include_arg.len == 0 || c_include_arg_is_builtin_abi_helper(include_arg, vroot) {
+			continue
+		}
+		if c_include_arg_is_source_file(include_arg) {
+			for path in c_include_file_paths(include_arg, vroot, cur_file, include_dirs) {
+				match cache_native_input_language(path, c_flags, c99_mode, target) {
+					'objective-c++' {
+						need_objc = true
+						need_cpp = true
+					}
+					'objective-c' {
+						need_objc = true
+					}
+					'c++' {
+						need_cpp = true
+					}
+					else {}
+				}
+			}
+			continue
+		}
+		if header := c_inline_header_text(include_arg, vroot, cur_file, include_dirs, false) {
+			if c_header_text_needs_objective_c_for_target(header.text, c_flags, c99_mode, target) {
+				need_objc = true
+			}
+		}
+	}
+	return c_native_language_from_features(need_objc, need_cpp)
+}
+
+fn c_native_language_from_features(need_objc bool, need_cpp bool) string {
+	if need_objc && need_cpp {
+		return 'objective-c++'
+	}
+	if need_cpp {
+		return 'c++'
+	}
+	if need_objc {
+		return 'objective-c'
+	}
+	return 'c'
+}
+
 // cache_c_flag_input_files returns forced include/macro files whose contents
 // affect every cached object compiled with the supplied C flags.
 pub fn cache_c_flag_input_files(flags []string) []string {
@@ -1767,7 +1850,12 @@ fn c_collect_external_input_tree(path string, vroot string, include_dirs []strin
 		mut include_args := [c_include_arg(c_directive_arg(clean), vroot, real_path)]
 		if !c_include_arg_is_literal(include_args[0]) {
 			macro_name := include_args[0].trim_space()
-			if dynamic_include_macros[macro_name] {
+			// A `true` value marks a nonliteral dynamic definition; a `false` value
+			// marks an ambiguous mutation. Both make the include target unknowable, so
+			// membership alone is untracked. Falling through on a `false` entry would let
+			// literal recovery adopt a stale textual literal that the real preprocessor
+			// never selects.
+			if macro_name in dynamic_include_macros {
 				if os.getenv('V3_CACHE_TRACE') != '' {
 					eprintln('  V3 module cache dynamic nested include: file=${real_path} include=${macro_name}')
 				}

--- a/vlib/v3/gen/c/source_directive_test.v
+++ b/vlib/v3/gen/c/source_directive_test.v
@@ -66,10 +66,11 @@ fn collect_external_input_tree_status(root string, entry string, ambient_ambiguo
 	mut dynamic_include_macros := map[string]bool{}
 	mut resolution_dirs := map[string]bool{}
 	mut missing_resolution_paths := map[string]bool{}
+	mut active_static_storage_paths := map[string]bool{}
 	untracked := c_collect_external_input_tree(entry, '', [root], mut active_paths, mut
 		collected_paths, mut ambiguous_collected_paths, mut files, mut include_macros, mut
-		dynamic_include_macros, mut resolution_dirs, mut missing_resolution_paths, 'main',
-		ambient_ambiguous)
+		dynamic_include_macros, mut resolution_dirs, mut missing_resolution_paths, mut
+		active_static_storage_paths, 'main', ambient_ambiguous, false)
 	return untracked, files
 }
 
@@ -390,4 +391,22 @@ fn test_builtin_abi_compat_macros_precede_late_c_source() {
 
 	assert alias_pos >= 0
 	assert source_pos > alias_pos
+}
+
+fn test_preprocessor_scan_tracks_comments_after_source_code() {
+	first, in_comment := c_preprocessor_directive_scan_line('int value; /* comment starts', false)
+	assert first == ''
+	assert in_comment
+	commented, still_in_comment := c_preprocessor_directive_scan_line('  #define HIDDEN 1',
+		in_comment)
+	assert commented == ''
+	assert still_in_comment
+	visible, comment_ended := c_preprocessor_directive_scan_line('*/ #define VISIBLE "//" // tail',
+		still_in_comment)
+	assert visible == '#define VISIBLE "//"'
+	assert !comment_ended
+	trailing, _ := c_preprocessor_directive_scan_line('#if defined(ENABLED) // explanation', false)
+	assert trailing == '#if defined(ENABLED)'
+	not_a_directive, _ := c_preprocessor_directive_scan_line('int other; #define LATE 1', false)
+	assert not_a_directive == ''
 }

--- a/vlib/v3/gen/c/target_test.v
+++ b/vlib/v3/gen/c/target_test.v
@@ -734,6 +734,37 @@ fn test_cache_input_scan_tracks_native_header_macro_context() {
 	assert static_inputs['sample'] == [os.real_path(header)]
 }
 
+fn test_cache_input_scan_rejects_conditional_native_root_context() {
+	dir := os.join_path(os.vtmp_dir(), 'v3_conditional_native_header_context_${os.getpid()}')
+	os.rmdir_all(dir) or {}
+	os.mkdir_all(dir) or { panic(err) }
+	defer {
+		os.rmdir_all(dir) or {}
+	}
+	header := os.join_path(dir, 'implementation.h')
+	os.write_file(header, '#ifdef V3_HEADER_IMPLEMENTATION\nstatic int v3_header_state;\n#endif\n')!
+	source := os.join_path(dir, 'sample.v')
+	os.write_file(source, 'module sample
+#if 0
+#define V3_HEADER_IMPLEMENTATION
+#endif
+#insert "implementation.h"
+')!
+	mut prefs := pref.new_preferences()
+	prefs.target = pref.host_target()
+	mut p := parser.Parser.new(prefs)
+	a := p.parse_file(source)
+	_, native_roots, native_contexts, _, _, _, _, has_untracked := cache_external_input_files_with_resolved_flags(a,
+		'', {
+		'sample': true
+	}, [], prefs.target, map[string]bool{}, map[string]string{}, true)
+	assert has_untracked
+	assert native_roots['sample'] == [os.real_path(header)]
+	assert native_contexts[os.real_path(header)] == [
+		'#define V3_HEADER_IMPLEMENTATION',
+	]
+}
+
 fn test_cache_input_scan_rejects_repeated_native_root_with_different_context() {
 	dir := os.join_path(os.vtmp_dir(), 'v3_native_header_context_conflict_${os.getpid()}')
 	os.rmdir_all(dir) or {}

--- a/vlib/v3/gen/c/target_test.v
+++ b/vlib/v3/gen/c/target_test.v
@@ -588,7 +588,34 @@ fn test_cache_input_scan_rejects_dynamic_include_macros() {
 	assert has_untracked
 }
 
-fn test_cache_input_scan_rejects_unresolved_include_macros() {
+fn test_cache_input_scan_resolves_defined_include_macro_aliases() {
+	dir := os.join_path(os.vtmp_dir(), 'v3_alias_macro_cache_inputs_${os.getpid()}')
+	os.rmdir_all(dir) or {}
+	os.mkdir_all(dir) or { panic(err) }
+	defer {
+		os.rmdir_all(dir) or {}
+	}
+	outer_header := os.join_path(dir, 'outer.h')
+	nested_header := os.join_path(dir, 'nested.h')
+	os.write_file(outer_header, '#define V3_SELECTED_HEADER "nested.h"
+#define V3_NESTED_HEADER V3_SELECTED_HEADER
+#include V3_NESTED_HEADER
+')!
+	os.write_file(nested_header, '#define NESTED_VALUE 1\n')!
+	source := os.join_path(dir, 'sample.v')
+	os.write_file(source, 'module sample\n#include "outer.h"\n')!
+	mut prefs := pref.new_preferences()
+	prefs.target = pref.host_target()
+	mut p := parser.Parser.new(prefs)
+	a := p.parse_file(source)
+	inputs, _, has_untracked := cache_external_input_files(a, '', {
+		'sample': true
+	}, [], prefs.target)
+	assert !has_untracked
+	assert os.real_path(nested_header) in inputs['sample']
+}
+
+fn test_cache_input_scan_tracks_source_defined_include_macros() {
 	dir := os.join_path(os.vtmp_dir(), 'v3_unresolved_macro_cache_inputs_${os.getpid()}')
 	os.rmdir_all(dir) or {}
 	os.mkdir_all(dir) or { panic(err) }
@@ -611,8 +638,100 @@ fn test_cache_input_scan_rejects_unresolved_include_macros() {
 	inputs, _, has_untracked := cache_external_input_files(a, '', {
 		'sample': true
 	}, [], prefs.target)
-	assert has_untracked
-	assert inputs['sample'] == [os.real_path(outer_header)]
+	assert !has_untracked
+	mut expected := [os.real_path(outer_header), os.real_path(nested_header)]
+	expected.sort()
+	assert inputs['sample'] == expected
+}
+
+fn test_cache_input_scan_uses_complete_compiler_macro_environment() {
+	dir := os.join_path(os.vtmp_dir(), 'v3_compiler_macro_cache_inputs_${os.getpid()}')
+	os.rmdir_all(dir) or {}
+	os.mkdir_all(dir) or { panic(err) }
+	defer {
+		os.rmdir_all(dir) or {}
+	}
+	outer_header := os.join_path(dir, 'outer.h')
+	default_header := os.join_path(dir, 'default.h')
+	override_header := os.join_path(dir, 'override.h')
+	os.write_file(outer_header,
+		'#if defined(V3_FORCE_DEFAULT) || !defined(V3_SELECTED_HEADER)\n#define V3_SELECTED_HEADER "default.h"\n#endif\n#include V3_SELECTED_HEADER\n')!
+	os.write_file(default_header, '#define V3_DEFAULT_VALUE 1\n')!
+	os.write_file(override_header, '#define V3_OVERRIDE_VALUE 1\n')!
+	source := os.join_path(dir, 'sample.v')
+	os.write_file(source, 'module sample\n#include "outer.h"\n')!
+	mut prefs := pref.new_preferences()
+	prefs.target = pref.host_target()
+	mut p := parser.Parser.new(prefs)
+	a := p.parse_file(source)
+	default_inputs, _, _, _, _, _, _, default_untracked := cache_external_input_files_with_resolved_flags(a,
+		'', {
+		'sample': true
+	}, [], prefs.target, map[string]bool{}, map[string]string{}, true)
+	assert !default_untracked
+	assert os.real_path(default_header) in default_inputs['sample']
+	override_inputs, _, _, _, _, _, _, override_untracked := cache_external_input_files_with_resolved_flags(a,
+		'', {
+		'sample': true
+	}, [], prefs.target, map[string]bool{}, {
+		'V3_SELECTED_HEADER': '"override.h"'
+	}, true)
+	assert !override_untracked
+	assert os.real_path(override_header) in override_inputs['sample']
+	assert os.real_path(default_header) !in override_inputs['sample']
+}
+
+fn test_cache_input_scan_ignores_directives_in_trailing_block_comments() {
+	dir := os.join_path(os.vtmp_dir(), 'v3_commented_macro_cache_inputs_${os.getpid()}')
+	os.rmdir_all(dir) or {}
+	os.mkdir_all(dir) or { panic(err) }
+	defer {
+		os.rmdir_all(dir) or {}
+	}
+	header := os.join_path(dir, 'api.h')
+	os.write_file(header,
+		'int declaration; /* documentation starts here\n#define V3_COMMENTED_IMPLEMENTATION\n*/\n#ifdef V3_COMMENTED_IMPLEMENTATION\nstatic int inactive_state;\n#endif\n')!
+	source := os.join_path(dir, 'sample.v')
+	os.write_file(source, 'module sample\n#include "api.h"\n')!
+	mut prefs := pref.new_preferences()
+	prefs.target = pref.host_target()
+	mut p := parser.Parser.new(prefs)
+	a := p.parse_file(source)
+	inputs, _, _, _, static_inputs, _, _, has_untracked := cache_external_input_files_with_resolved_flags(a,
+		'', {
+		'sample': true
+	}, [], prefs.target, map[string]bool{}, map[string]string{}, true)
+	assert !has_untracked
+	assert inputs['sample'] == [os.real_path(header)]
+	assert static_inputs['sample'].len == 0
+}
+
+fn test_cache_input_scan_tracks_native_header_macro_context() {
+	dir := os.join_path(os.vtmp_dir(), 'v3_native_header_context_${os.getpid()}')
+	os.rmdir_all(dir) or {}
+	os.mkdir_all(dir) or { panic(err) }
+	defer {
+		os.rmdir_all(dir) or {}
+	}
+	header := os.join_path(dir, 'implementation.h')
+	os.write_file(header, '#ifdef V3_HEADER_IMPLEMENTATION\nstatic int v3_header_state;\n#endif\n')!
+	source := os.join_path(dir, 'sample.v')
+	os.write_file(source,
+		'module sample\n#define V3_HEADER_IMPLEMENTATION\n#include "implementation.h"\n')!
+	mut prefs := pref.new_preferences()
+	prefs.target = pref.host_target()
+	mut p := parser.Parser.new(prefs)
+	a := p.parse_file(source)
+	_, native_roots, native_contexts, _, static_inputs, _, _, has_untracked := cache_external_input_files_with_resolved_flags(a,
+		'', {
+		'sample': true
+	}, [], prefs.target, map[string]bool{}, map[string]string{}, true)
+	assert !has_untracked
+	assert native_roots['sample'] == [os.real_path(header)]
+	assert native_contexts[os.real_path(header)] == [
+		'#define V3_HEADER_IMPLEMENTATION',
+	]
+	assert static_inputs['sample'] == [os.real_path(header)]
 }
 
 fn test_cache_input_scan_bounds_repeated_header_trees() {
@@ -642,7 +761,7 @@ fn test_cache_input_scan_bounds_repeated_header_trees() {
 	inputs, _, has_untracked := cache_external_input_files(a, '', {
 		'sample': true
 	}, [], prefs.target)
-	assert has_untracked
+	assert !has_untracked
 	mut expected := [os.real_path(left_header), os.real_path(right_header),
 		os.real_path(common_header)]
 	expected.sort()
@@ -672,26 +791,30 @@ fn test_cache_input_scan_tracks_native_source_roots_for_privacy_checks() {
 	prefs.target = pref.host_target()
 	mut p := parser.Parser.new(prefs)
 	a := p.parse_file(source)
-	inputs, native_roots, unscoped_inputs, _, _, has_untracked := cache_external_input_files_with_resolved_flags(a,
+	inputs, native_roots, _, unscoped_inputs, static_inputs, _, _, has_untracked := cache_external_input_files_with_resolved_flags(a,
 		'', {
 		'sample': true
-	}, [], prefs.target, map[string]bool{})
+	}, [], prefs.target, map[string]bool{}, map[string]string{}, false)
 	assert !has_untracked
 	mut expected_inputs := [os.real_path(root_source), os.real_path(nested_source),
 		os.real_path(direct_header), os.real_path(nested_header)]
 	expected_inputs.sort()
 	assert inputs['sample'] == expected_inputs
-	assert native_roots['sample'] == [os.real_path(root_source)]
+	assert native_roots['sample'] == [os.real_path(root_source),
+		os.real_path(direct_header)]
 	assert unscoped_inputs['sample'] == expected_inputs
-	program_inputs, program_roots, program_unscoped, _, _, program_has_untracked := cache_external_input_files_with_resolved_flags(a,
+	assert static_inputs['sample'] == [os.real_path(nested_source),
+		os.real_path(nested_header)]
+	program_inputs, program_roots, _, program_unscoped, _, _, _, program_has_untracked := cache_external_input_files_with_resolved_flags(a,
 		'', {
 		'sample': true
 	}, [], prefs.target, {
 		os.real_path(source): true
-	})
+	}, map[string]string{}, false)
 	assert !program_has_untracked
 	assert program_inputs['main'] == expected_inputs
-	assert program_roots['main'] == [os.real_path(root_source)]
+	assert program_roots['main'] == [os.real_path(root_source),
+		os.real_path(direct_header)]
 	assert program_unscoped['main'] == expected_inputs
 	assert 'sample' !in program_inputs
 }

--- a/vlib/v3/gen/c/target_test.v
+++ b/vlib/v3/gen/c/target_test.v
@@ -765,6 +765,34 @@ fn test_cache_input_scan_rejects_conditional_native_root_context() {
 	]
 }
 
+fn test_cache_input_scan_rejects_conditionally_included_native_root() {
+	dir := os.join_path(os.vtmp_dir(), 'v3_conditionally_included_native_root_${os.getpid()}')
+	os.rmdir_all(dir) or {}
+	os.mkdir_all(dir) or { panic(err) }
+	defer {
+		os.rmdir_all(dir) or {}
+	}
+	header := os.join_path(dir, 'implementation.h')
+	os.write_file(header, 'int v3_conditional_native_root(void) { return 1; }\n')!
+	source := os.join_path(dir, 'sample.v')
+	os.write_file(source, 'module sample
+#if 0
+#insert "implementation.h"
+#endif
+')!
+	mut prefs := pref.new_preferences()
+	prefs.target = pref.host_target()
+	mut p := parser.Parser.new(prefs)
+	a := p.parse_file(source)
+	_, native_roots, native_contexts, _, _, _, _, has_untracked := cache_external_input_files_with_resolved_flags(a,
+		'', {
+		'sample': true
+	}, [], prefs.target, map[string]bool{}, map[string]string{}, true)
+	assert has_untracked
+	assert native_roots['sample'] == [os.real_path(header)]
+	assert native_contexts[os.real_path(header)].len == 0
+}
+
 fn test_cache_input_scan_rejects_repeated_native_root_with_different_context() {
 	dir := os.join_path(os.vtmp_dir(), 'v3_native_header_context_conflict_${os.getpid()}')
 	os.rmdir_all(dir) or {}

--- a/vlib/v3/gen/c/target_test.v
+++ b/vlib/v3/gen/c/target_test.v
@@ -857,6 +857,71 @@ fn test_cache_native_input_language_detects_implicit_objective_c() {
 	}
 }
 
+fn test_cache_native_input_language_reports_source_language() {
+	dir := os.join_path(os.vtmp_dir(), 'v3_native_language_${os.getpid()}')
+	os.rmdir_all(dir) or {}
+	os.mkdir_all(dir) or { panic(err) }
+	defer {
+		os.rmdir_all(dir) or {}
+	}
+	mut prefs := pref.new_preferences()
+	prefs.target = pref.host_target()
+	objc_cpp_source := os.join_path(dir, 'impl.mm')
+	objc_source := os.join_path(dir, 'impl.m')
+	cpp_source := os.join_path(dir, 'impl.cpp')
+	objc_header := os.join_path(dir, 'objc.h')
+	plain_header := os.join_path(dir, 'plain.h')
+	os.write_file(objc_cpp_source, 'int impl(void) { return 1; }\n')!
+	os.write_file(objc_source, 'int impl(void) { return 1; }\n')!
+	os.write_file(cpp_source, 'int impl(void) { return 1; }\n')!
+	os.write_file(objc_header, '@interface V3CacheLang\n@end\n')!
+	os.write_file(plain_header, 'int plain(void);\n')!
+	assert cache_native_input_language(objc_cpp_source, []string{}, false, prefs.target) == 'objective-c++'
+	assert cache_native_input_language(objc_source, []string{}, false, prefs.target) == 'objective-c'
+	assert cache_native_input_language(cpp_source, []string{}, false, prefs.target) == 'c++'
+	assert cache_native_input_language(objc_header, []string{}, false, prefs.target) == 'objective-c'
+	assert cache_native_input_language(plain_header, []string{}, false, prefs.target) == 'c'
+	// An .mm source is Objective-C++, so the shared probe language must carry both
+	// __OBJC__ and __cplusplus rather than a plain Objective-C choice.
+	mm_program := os.join_path(dir, 'mm_program.v')
+	os.write_file(mm_program, 'module sample\n#include "impl.mm"\n')!
+	mut p := parser.Parser.new(prefs)
+	a := p.parse_file(mm_program)
+	assert cache_native_inputs_language(a, '', []string{}, false, prefs.target) == 'objective-c++'
+}
+
+fn test_cache_input_scan_rejects_ambiguous_include_macro_literal() {
+	dir := os.join_path(os.vtmp_dir(), 'v3_ambiguous_include_macro_${os.getpid()}')
+	os.rmdir_all(dir) or {}
+	os.mkdir_all(dir) or { panic(err) }
+	defer {
+		os.rmdir_all(dir) or {}
+	}
+	outer_header := os.join_path(dir, 'outer.h')
+	os.write_file(outer_header, '#define SELECTED_HEADER "default.h"
+#if FOO == 1
+#undef SELECTED_HEADER
+#define SELECTED_HEADER OVERRIDE_HEADER
+#endif
+#include SELECTED_HEADER
+')!
+	os.write_file(os.join_path(dir, 'default.h'), '#define DEFAULT_VALUE 1\n')!
+	os.write_file(os.join_path(dir, 'override.h'), '#define OVERRIDE_VALUE 1\n')!
+	source := os.join_path(dir, 'sample.v')
+	os.write_file(source, 'module sample\n#include "outer.h"\n')!
+	mut prefs := pref.new_preferences()
+	prefs.target = pref.host_target()
+	mut p := parser.Parser.new(prefs)
+	a := p.parse_file(source)
+	// `FOO == 1` is not evaluable, so the SELECTED_HEADER mutation is ambiguous. The
+	// real preprocessor selects override.h; the scanner must not adopt the stale
+	// "default.h" literal and call the plan cacheable.
+	_, _, has_untracked := cache_external_input_files(a, '', {
+		'sample': true
+	}, ['-DFOO=1', '-DOVERRIDE_HEADER="override.h"'], prefs.target)
+	assert has_untracked
+}
+
 fn test_cache_input_scan_bounds_repeated_header_trees() {
 	dir := os.join_path(os.vtmp_dir(), 'v3_repeated_header_cache_inputs_${os.getpid()}')
 	os.rmdir_all(dir) or {}

--- a/vlib/v3/gen/c/target_test.v
+++ b/vlib/v3/gen/c/target_test.v
@@ -734,6 +734,70 @@ fn test_cache_input_scan_tracks_native_header_macro_context() {
 	assert static_inputs['sample'] == [os.real_path(header)]
 }
 
+fn test_cache_input_scan_rejects_repeated_native_root_with_different_context() {
+	dir := os.join_path(os.vtmp_dir(), 'v3_native_header_context_conflict_${os.getpid()}')
+	os.rmdir_all(dir) or {}
+	os.mkdir_all(dir) or { panic(err) }
+	defer {
+		os.rmdir_all(dir) or {}
+	}
+	header := os.join_path(dir, 'implementation.h')
+	os.write_file(header, '#ifdef V3_HEADER_IMPLEMENTATION\nstatic int v3_header_state;\n#endif\n')!
+	source := os.join_path(dir, 'sample.v')
+	os.write_file(source, 'module sample
+#define V3_HEADER_IMPLEMENTATION
+#insert "implementation.h"
+#undef V3_HEADER_IMPLEMENTATION
+#insert "implementation.h"
+')!
+	mut prefs := pref.new_preferences()
+	prefs.target = pref.host_target()
+	mut p := parser.Parser.new(prefs)
+	a := p.parse_file(source)
+	_, native_roots, native_contexts, _, _, _, _, has_untracked := cache_external_input_files_with_resolved_flags(a,
+		'', {
+		'sample': true
+	}, [], prefs.target, map[string]bool{}, map[string]string{}, true)
+	assert has_untracked
+	assert native_roots['sample'] == [os.real_path(header)]
+	assert native_contexts[os.real_path(header)] == [
+		'#define V3_HEADER_IMPLEMENTATION',
+	]
+}
+
+fn test_cache_native_input_language_detects_implicit_objective_c() {
+	dir := os.join_path(os.vtmp_dir(), 'v3_native_objective_c_${os.getpid()}')
+	os.rmdir_all(dir) or {}
+	os.mkdir_all(dir) or { panic(err) }
+	defer {
+		os.rmdir_all(dir) or {}
+	}
+	objective_c_source := os.join_path(dir, 'implementation.m')
+	objective_c_header := os.join_path(dir, 'implementation.h')
+	plain_header := os.join_path(dir, 'plain.h')
+	os.write_file(objective_c_source, 'int implementation(void) { return 1; }\n')!
+	os.write_file(objective_c_header, '@interface V3CacheImplementation\n@end\n')!
+	os.write_file(plain_header, 'int plain_declaration(void);\n')!
+	mut prefs := pref.new_preferences()
+	prefs.target = pref.host_target()
+	assert cache_native_input_path_needs_objective_c(objective_c_source, []string{}, false,
+		prefs.target)
+	assert cache_native_input_path_needs_objective_c(objective_c_header, []string{}, false,
+		prefs.target)
+	assert !cache_native_input_path_needs_objective_c(plain_header, []string{}, false, prefs.target)
+	for include, expected in {
+		'"implementation.m"': true
+		'"implementation.h"': true
+		'"plain.h"':          false
+	} {
+		source := os.join_path(dir, 'sample_${expected}_${include.len}.v')
+		os.write_file(source, 'module sample\n#include ${include}\n')!
+		mut p := parser.Parser.new(prefs)
+		a := p.parse_file(source)
+		assert cache_native_inputs_need_objective_c(a, '', []string{}, false, prefs.target) == expected
+	}
+}
+
 fn test_cache_input_scan_bounds_repeated_header_trees() {
 	dir := os.join_path(os.vtmp_dir(), 'v3_repeated_header_cache_inputs_${os.getpid()}')
 	os.rmdir_all(dir) or {}

--- a/vlib/v3/modulecache/modulecache.v
+++ b/vlib/v3/modulecache/modulecache.v
@@ -11,7 +11,7 @@ import v3.util
 pub const builtin_bundle_imports = ['strconv', 'strings', 'hash', 'math.bits']
 pub const builtin_bundle_modules = ['builtin', 'strconv', 'strings', 'hash', 'bits', 'math.bits']
 
-const cache_format = 'v3-module-cache-48'
+const cache_format = 'v3-module-cache-51'
 const c_body_begin = '/* V3CACHE_BODY_BEGIN */'
 const c_body_end = '/* V3CACHE_BODY_END */'
 const c_module_prefix = '/* V3CACHE_MODULE '
@@ -1116,13 +1116,18 @@ pub fn (m &Manager) cached_cgen_dependency_inputs(source_files []string, generat
 // declaration-stable program snapshot after the main source bodies change.
 pub fn (m &Manager) cached_incremental_dependency_inputs(source_files []string, declaration_signature string, generation_signature string, fixed_dependencies map[string]string, restored_prefixes []string) ?map[string]string {
 	if !m.enabled || source_files.len == 0 || declaration_signature.len == 0 {
+		trace_dependency_restore_miss('incremental cache is unavailable')
 		return none
 	}
 	entry := m.incremental_program_entry(source_files)
 	if !os.is_file(entry.stamp) {
+		trace_dependency_restore_miss('incremental stamp is missing')
 		return none
 	}
-	stamp := os.read_file(entry.stamp) or { return none }
+	stamp := os.read_file(entry.stamp) or {
+		trace_dependency_restore_miss('incremental stamp cannot be read')
+		return none
+	}
 	expected_head := entry_stamp(m.salt, declaration_signature) +
 		'generation=${hash_text('incremental-v5\n${generation_signature}')}\n'
 	return cached_dependency_inputs_from_stamp(stamp, expected_head, fixed_dependencies,
@@ -1131,40 +1136,55 @@ pub fn (m &Manager) cached_incremental_dependency_inputs(source_files []string, 
 
 fn cached_dependency_inputs_from_stamp(stamp string, expected_head string, fixed_dependencies map[string]string, restored_prefixes []string) ?map[string]string {
 	if !stamp.starts_with(expected_head) {
+		trace_dependency_restore_miss('stamp header changed')
 		return none
 	}
 	mut restored := map[string]string{}
 	mut fixed_seen := map[string]bool{}
 	for line in stamp[expected_head.len..].split_into_lines() {
 		if !line.starts_with('dependency=') {
+			trace_dependency_restore_miss('malformed dependency line')
 			return none
 		}
 		value := line['dependency='.len..]
 		tab := value.index_u8(`\t`)
-		if tab <= 0 || tab + 1 >= value.len {
+		if tab <= 0 {
+			trace_dependency_restore_miss('malformed dependency value')
 			return none
 		}
 		key := value[..tab]
 		signature := value[tab + 1..]
 		if key in restored || fixed_seen[key] {
+			trace_dependency_restore_miss('duplicate dependency ${key}')
 			return none
 		}
 		if expected := fixed_dependencies[key] {
 			if expected != signature {
+				trace_dependency_restore_miss('fixed dependency changed: ${key}')
 				return none
 			}
 			fixed_seen[key] = true
 			continue
 		}
 		if !restored_prefixes.any(key.starts_with(it)) {
+			trace_dependency_restore_miss('unexpected dependency: ${key}')
 			return none
 		}
 		restored[key] = signature
 	}
 	if fixed_seen.len != fixed_dependencies.len {
+		mut missing := fixed_dependencies.keys().filter(it !in fixed_seen)
+		missing.sort()
+		trace_dependency_restore_miss('missing fixed dependencies: ${missing.join(', ')}')
 		return none
 	}
 	return restored
+}
+
+fn trace_dependency_restore_miss(reason string) {
+	if os.getenv('V3_CACHE_TRACE') != '' {
+		eprintln('  V3 cache dependency restore miss: ${reason}')
+	}
 }
 
 // valid_generic_program reports whether cached dependency specializations match
@@ -1231,6 +1251,7 @@ pub fn (m &Manager) write_generic_program(source_files []string, semantic_signat
 // compiler configuration, dependencies, and native inputs are unchanged.
 pub fn (m &Manager) valid_incremental_program(source_files []string, declaration_signature string, generation_signature string, dependency_inputs map[string]string) ?IncrementalProgramEntry {
 	if !m.enabled || source_files.len == 0 || declaration_signature.len == 0 {
+		trace_incremental_cache_miss('cache is unavailable')
 		return none
 	}
 	entry := m.incremental_program_entry(source_files)
@@ -1238,16 +1259,21 @@ pub fn (m &Manager) valid_incremental_program(source_files []string, declaration
 		|| !os.is_file(entry.specs) || !os.is_file(entry.prefix) || !os.is_file(entry.declarations)
 		|| !os.is_file(entry.tcc_declarations) || !os.is_file(entry.objects)
 		|| !os.is_file(entry.metadata) || !os.is_file(entry.stamp) {
+		trace_incremental_cache_miss('one or more payloads are missing')
 		return none
 	}
-	objects := os.read_lines(entry.objects) or { return none }
+	objects := os.read_lines(entry.objects) or {
+		trace_incremental_cache_miss('cached object list cannot be read')
+		return none
+	}
 	if objects.len == 0 || objects.any(it.len == 0 || !os.is_file(it)) {
-		if os.getenv('V3_CACHE_TRACE') != '' {
-			eprintln('  V3 incremental cache miss: cached module object is missing')
-		}
+		trace_incremental_cache_miss('cached module object is missing')
 		return none
 	}
-	stamp := os.read_file(entry.stamp) or { return none }
+	stamp := os.read_file(entry.stamp) or {
+		trace_incremental_cache_miss('stamp cannot be read')
+		return none
+	}
 	expected := cgen_entry_stamp(m.salt, declaration_signature, dependency_inputs,
 		'incremental-v5\n${generation_signature}')
 	if stamp != expected {
@@ -1266,6 +1292,12 @@ pub fn (m &Manager) valid_incremental_program(source_files []string, declaration
 		return none
 	}
 	return entry
+}
+
+fn trace_incremental_cache_miss(reason string) {
+	if os.getenv('V3_CACHE_TRACE') != '' {
+		eprintln('  V3 incremental cache miss: ${reason}')
+	}
 }
 
 // write_incremental_program atomically publishes a function-level program
@@ -2068,7 +2100,8 @@ fn c_native_localize_function_definitions(source string) string {
 				head :=
 					trim_leading_c_comments(declaration[..current_line_start + first_open].trim_space())
 				if c_static_declaration_head_is_function(head)
-					&& !c_declaration_head_keeps_definition(head) {
+					&& !c_declaration_head_keeps_definition(head)
+					&& !c_declaration_head_has_api_decl_macro(head) {
 					indent_len := declaration.len - declaration.trim_left(' \t').len
 					out.write_string('${declaration[..indent_len]}static ${declaration[indent_len..]}')
 				} else {
@@ -2094,6 +2127,16 @@ fn c_native_localize_function_definitions(source string) string {
 	return out.str()
 }
 
+fn c_declaration_head_has_api_decl_macro(head string) bool {
+	for field in head.fields() {
+		name := field.trim('()*')
+		if name.ends_with('_API_DECL') {
+			return true
+		}
+	}
+	return false
+}
+
 // c_source_has_static_storage reports whether a local C input would give cached
 // translation units separate copies of static storage.
 pub fn c_source_has_static_storage(source string) bool {
@@ -2117,6 +2160,16 @@ pub fn c_source_function_identifiers(source string) map[string]bool {
 // c_source_function_identifiers_with_status returns file-scope C function names
 // and whether every function declaration could be classified.
 pub fn c_source_function_identifiers_with_status(source string) (map[string]bool, bool) {
+	return c_source_function_identifiers_mode(source, false)
+}
+
+// c_source_static_function_identifiers_with_status returns file-scope static C function
+// names and whether every potentially static function declaration could be classified.
+pub fn c_source_static_function_identifiers_with_status(source string) (map[string]bool, bool) {
+	return c_source_function_identifiers_mode(source, true)
+}
+
+fn c_source_function_identifiers_mode(source string, static_only bool) (map[string]bool, bool) {
 	mut identifiers := map[string]bool{}
 	mut parameter_macros := map[string]bool{}
 	mut complete := true
@@ -2144,11 +2197,14 @@ pub fn c_source_function_identifiers_with_status(source string) (map[string]bool
 				if identifier := c_function_declaration_identifier_with_parameter_macros(head,
 					parameter_macros)
 				{
-					identifiers[identifier] = true
-					if c_function_declaration_identifier_is_ambiguous(head, identifier) {
+					is_ambiguous := c_function_declaration_identifier_is_ambiguous(head, identifier)
+					if !static_only || c_has_static_storage_class(head) {
+						identifiers[identifier] = true
+					}
+					if is_ambiguous {
 						complete = false
 					}
-				} else {
+				} else if !static_only || c_has_static_storage_class(head) {
 					complete = false
 				}
 			}
@@ -2671,9 +2727,27 @@ pub fn c_source_static_variable_identifiers(source string) (map[string]bool, boo
 	mut item_has_brace := false
 	mut item_is_function := false
 	mut in_block_comment := false
+	mut in_preprocessor_directive := false
+	mut in_objc_declaration := false
 	for raw_line in source.split_into_lines() {
 		trimmed := raw_line.trim_space()
-		if brace_depth == 0 && pending.len == 0 && trimmed.starts_with('#') {
+		if in_preprocessor_directive || trimmed.starts_with('#') {
+			in_preprocessor_directive = raw_line.trim_right(' \t\r').ends_with('\\')
+			continue
+		}
+		if in_objc_declaration {
+			if trimmed.starts_with('@end') {
+				in_objc_declaration = false
+			}
+			continue
+		}
+		if trimmed.starts_with('@interface')
+			|| trimmed.starts_with('@implementation')
+			|| (trimmed.starts_with('@protocol') && !trimmed.ends_with(';')) {
+			in_objc_declaration = true
+			continue
+		}
+		if trimmed.starts_with('@') {
 			continue
 		}
 		if brace_depth == 0 || !item_is_function {
@@ -5601,6 +5675,12 @@ fn cached_split_flag_tokens(value string) ([]string, bool) {
 }
 
 fn cached_resolve_relative_flag_path_token(token string, base_dir string) string {
+	// Keep path-selection expressions intact. They are evaluated by the flag parser
+	// when the cached header is read; prefixing them with the original source
+	// directory changes both their meaning and the program cache key.
+	if token.contains(r'$when_first_existing') || token.contains(r'$first_existing') {
+		return token
+	}
 	for prefix in ['-I', '-L'] {
 		if token.starts_with(prefix) && token.len > prefix.len {
 			path := token[prefix.len..]

--- a/vlib/v3/modulecache/modulecache.v
+++ b/vlib/v3/modulecache/modulecache.v
@@ -2747,7 +2747,7 @@ pub fn c_source_static_variable_identifiers(source string) (map[string]bool, boo
 			in_objc_declaration = true
 			continue
 		}
-		if trimmed.starts_with('@') {
+		if brace_depth == 0 && trimmed.starts_with('@') {
 			continue
 		}
 		if brace_depth == 0 || !item_is_function {
@@ -2756,7 +2756,7 @@ pub fn c_source_static_variable_identifiers(source string) (map[string]bool, boo
 		delta, _, next_comment, last_code, first_open := c_line_braces(raw_line, in_block_comment)
 		in_block_comment = next_comment
 		if brace_depth == 0 && first_open >= 0 {
-			declaration := pending.str()
+			declaration := pending.after(0)
 			current_line_start := declaration.len - raw_line.len - 1
 			head :=
 				trim_leading_c_comments(declaration[..current_line_start + first_open].trim_space())
@@ -2771,6 +2771,38 @@ pub fn c_source_static_variable_identifiers(source string) (map[string]bool, boo
 				item_has_brace = false
 				item_is_function = false
 			}
+			continue
+		}
+		if brace_depth == 0 && item_has_brace && last_code == `}` {
+			declaration := pending.after(0)
+			if block := c_extern_c_block(declaration) {
+				nested_identifiers, nested_complete :=
+					c_source_static_variable_identifiers(block.inner)
+				for identifier, present in nested_identifiers {
+					if present {
+						identifiers[identifier] = true
+					}
+				}
+				complete = complete && nested_complete
+				pending.clear()
+				item_has_brace = false
+				continue
+			}
+			clean_declaration := trim_leading_c_comments(declaration.trim_space())
+			brace := clean_declaration.index_u8(`{`)
+			if brace >= 0 && !c_has_static_storage_class(clean_declaration[..brace]) {
+				pending.clear()
+				item_has_brace = false
+				continue
+			}
+			if os.getenv('V3_CACHE_TRACE') != '' {
+				trace_declaration := declaration.trim_space().replace('\n', ' ')
+				eprintln('  V3 module cache incomplete static braced item: ${trace_declaration[..int_min(trace_declaration.len,
+					400)]}')
+			}
+			complete = false
+			pending.clear()
+			item_has_brace = false
 			continue
 		}
 		if brace_depth > 0 || last_code != `;` {
@@ -2788,6 +2820,10 @@ pub fn c_source_static_variable_identifiers(source string) (map[string]bool, boo
 		} else if c_declaration_item_has_static_storage(declaration, item_has_brace) {
 			declaration_identifiers := c_static_variable_declaration_identifiers(declaration)
 			if declaration_identifiers.len == 0 {
+				if os.getenv('V3_CACHE_TRACE') != '' {
+					eprintln('  V3 module cache incomplete static variable declaration: ${declaration.trim_space().replace('\n',
+						' ')}')
+				}
 				complete = false
 			}
 			for identifier in declaration_identifiers {
@@ -2803,7 +2839,8 @@ pub fn c_source_static_variable_identifiers(source string) (map[string]bool, boo
 }
 
 fn c_static_variable_declaration_identifiers(declaration string) []string {
-	clean := trim_leading_c_comments(declaration.trim_space()).trim_right(';').trim_space()
+	mut clean := trim_leading_c_comments(declaration.trim_space()).trim_right(';').trim_space()
+	clean = c_declarator_without_leading_attributes(clean) or { return [] }
 	if clean.len == 0 {
 		return []
 	}
@@ -3645,6 +3682,12 @@ fn c_declaration_item_has_static_storage(item string, has_brace bool) bool {
 	}
 	if !has_brace {
 		mut declaration_head := clean.trim_right(';').trim_space()
+		if c_function_declaration_identifier(declaration_head) != none {
+			return false
+		}
+		declaration_head = c_declarator_without_leading_attributes(declaration_head) or {
+			return true
+		}
 		for suffix in ['__attribute__', '__declspec', '__asm__', '__asm', 'asm'] {
 			if pos := c_declaration_annotation_index(declaration_head, suffix) {
 				declaration_head = declaration_head[..pos].trim_space()

--- a/vlib/v3/modulecache/modulecache.v
+++ b/vlib/v3/modulecache/modulecache.v
@@ -3222,6 +3222,9 @@ fn c_declaration_header_mode(prefix string, types_only bool) (string, bool, bool
 	mut preprocessor_in_item := false
 	mut in_extern_c_block := false
 	type_declaration_macros := c_type_declaration_macro_names(prefix)
+	static_storage_macros := c_sources_macro_identifiers_referencing([prefix], {
+		'static': true
+	})
 	lines := prefix.split_into_lines()
 	for line_idx, raw_line in lines {
 		line := raw_line + '\n'
@@ -3335,9 +3338,11 @@ fn c_declaration_header_mode(prefix string, types_only bool) (string, bool, bool
 			continue
 		}
 		declaration := item.str()
+		macro_name := c_declaration_macro_invocation_name(declaration, has_brace) or { '' }
+		storage_macro_name := c_static_storage_macro_invocation_name(declaration, has_brace)
 		has_static_storage = has_static_storage
 			|| c_declaration_item_has_static_storage(declaration, has_brace)
-		macro_name := c_declaration_macro_invocation_name(declaration, has_brace) or { '' }
+			|| static_storage_macros[storage_macro_name]
 		item_declares_type := c_declaration_item_declares_type(declaration, has_brace)
 			|| type_declaration_macros[macro_name]
 		if types_only && macro_name.len > 0 && !item_declares_type {
@@ -3356,9 +3361,11 @@ fn c_declaration_header_mode(prefix string, types_only bool) (string, bool, bool
 	}
 	if item.len > 0 {
 		declaration := item.str()
+		macro_name := c_declaration_macro_invocation_name(declaration, has_brace) or { '' }
+		storage_macro_name := c_static_storage_macro_invocation_name(declaration, has_brace)
 		has_static_storage = has_static_storage
 			|| c_declaration_item_has_static_storage(declaration, has_brace)
-		macro_name := c_declaration_macro_invocation_name(declaration, has_brace) or { '' }
+			|| static_storage_macros[storage_macro_name]
 		item_declares_type := c_declaration_item_declares_type(declaration, has_brace)
 			|| type_declaration_macros[macro_name]
 		if types_only && macro_name.len > 0 && !item_declares_type {
@@ -3572,6 +3579,17 @@ fn c_declaration_macro_invocation_name(item string, has_brace bool) ?string {
 		return none
 	}
 	return name
+}
+
+fn c_static_storage_macro_invocation_name(item string, has_brace bool) string {
+	if !has_brace {
+		return c_declaration_macro_invocation_name(item, false) or { '' }
+	}
+	brace := item.index_u8(`{`)
+	if brace < 0 {
+		return ''
+	}
+	return c_declaration_macro_invocation_name(item[..brace], false) or { '' }
 }
 
 fn c_function_block_closes_at_line_start(line string) bool {

--- a/vlib/v3/modulecache/modulecache_test.v
+++ b/vlib/v3/modulecache/modulecache_test.v
@@ -2,6 +2,30 @@ module modulecache
 
 import os
 
+fn test_cached_relative_flag_paths_preserve_path_selection_expressions() {
+	base_dir := os.join_path(os.vtmp_dir(), 'v3_modulecache_flags')
+	value := r"darwin -I$when_first_existing('/opt/local/include','/opt/homebrew/include') -L$first_existing('/opt/local/lib','/opt/homebrew/lib')"
+	assert cached_resolve_relative_flag_paths(value, os.join_path(base_dir, 'source.v')) == value
+}
+
+fn test_cached_dependency_inputs_restore_empty_variable_value() {
+	expected_head := 'format=test\n'
+	stamp := expected_head + 'dependency=fixed\tvalue\n' + 'dependency=external-root-owner:c:0\t\n'
+	restored := cached_dependency_inputs_from_stamp(stamp, expected_head, {
+		'fixed': 'value'
+	}, ['external-root-owner:']) or { panic('expected cache dependency restore') }
+	assert 'external-root-owner:c:0' in restored
+	assert restored['external-root-owner:c:0'] == ''
+}
+
+fn test_native_declaration_api_macro_definition_is_not_localized() {
+	source := '#ifdef LIB_IMPL\nLIB_API_DECL void exported(void) {\n}\n#else\nLIB_API_DECL void exported(void);\n#endif\nint helper(void) {\n\treturn 1;\n}\n'
+	declarations := c_native_declaration_directives(source)
+	assert declarations.contains('LIB_API_DECL void exported(void) {')
+	assert !declarations.contains('static LIB_API_DECL void exported(void) {')
+	assert declarations.contains('static int helper(void) {')
+}
+
 fn test_cached_file_line_uses_source_file_name() {
 	source := 'return [@FILE, @FILE_LINE, @LINE]'
 	source_file := os.join_path(os.vtmp_dir(), 'nested', 'origin.v')
@@ -102,12 +126,42 @@ fn test_static_variable_identifiers_ignore_asm_labels() {
 	assert !function_identifiers['helper_alias']
 }
 
+fn test_static_variable_identifiers_ignore_preprocessor_directives() {
+	identifiers, complete := c_source_static_variable_identifiers('/* declaration guard */
+#if defined(ENABLE_STATE) \\
+	&& !defined(DISABLE_STATE)
+static int state;
+#endif
+')
+	assert complete
+	assert identifiers.keys() == ['state']
+}
+
+fn test_static_variable_identifiers_ignore_objc_declarations() {
+	identifiers, complete := c_source_static_variable_identifiers('@interface CacheDelegate : NSObject
+- (void)finish:(int)value;
+@end
+@protocol ForwardDeclaration;
+static int state;
+')
+	assert complete
+	assert identifiers.keys() == ['state']
+}
+
 fn test_function_identifiers_keep_name_before_suffix_macro() {
 	identifiers, complete :=
 		c_source_function_identifiers_with_status('#define API_SUFFIX(tag)\nstatic int api(void) API_SUFFIX(tag) {\n\treturn 1;\n}\n')
 	assert complete
 	assert identifiers['api']
 	assert !identifiers['API_SUFFIX']
+}
+
+fn test_static_function_identifiers_exclude_exported_functions() {
+	identifiers, complete :=
+		c_source_static_function_identifiers_with_status('static int local_helper(void) { return 1; }\nint exported_helper(void) { return local_helper(); }\n')
+	assert complete
+	assert identifiers['local_helper']
+	assert !identifiers['exported_helper']
 }
 
 fn test_function_identifiers_keep_name_after_return_type_macro() {

--- a/vlib/v3/modulecache/modulecache_test.v
+++ b/vlib/v3/modulecache/modulecache_test.v
@@ -126,6 +126,14 @@ fn test_static_variable_identifiers_ignore_asm_labels() {
 	assert !function_identifiers['helper_alias']
 }
 
+fn test_static_variable_identifiers_classify_attributes() {
+	identifiers, complete := c_source_static_variable_identifiers('__attribute__((availability(macos,introduced=14.0))) static const unsigned long DynamicStride = 42;
+static inline __attribute__((__always_inline__)) __attribute__((__overloadable__)) int simd_any(int value);
+')
+	assert complete
+	assert identifiers.keys() == ['DynamicStride']
+}
+
 fn test_static_variable_identifiers_ignore_preprocessor_directives() {
 	identifiers, complete := c_source_static_variable_identifiers('/* declaration guard */
 #if defined(ENABLE_STATE) \\
@@ -143,6 +151,42 @@ fn test_static_variable_identifiers_ignore_objc_declarations() {
 @end
 @protocol ForwardDeclaration;
 static int state;
+')
+	assert complete
+	assert identifiers.keys() == ['state']
+}
+
+fn test_static_variable_identifiers_track_objc_function_braces() {
+	identifiers, complete := c_source_static_variable_identifiers('static void helper(void) {
+	@autoreleasepool {
+		static int local_state;
+		if (local_state) {
+			local_state++;
+		}
+	}
+}
+static int file_state;
+')
+	assert complete
+	assert identifiers.keys() == ['file_state']
+}
+
+fn test_static_variable_identifiers_keep_anonymous_aggregate_declarator() {
+	identifiers, complete := c_source_static_variable_identifiers('static struct {
+	const char *str;
+	int code;
+} keymap[] = {
+	{"Enter", 1},
+};
+')
+	assert complete
+	assert identifiers.keys() == ['keymap']
+}
+
+fn test_static_variable_identifiers_scan_extern_c_block() {
+	identifiers, complete := c_source_static_variable_identifiers('extern "C" {
+static int state;
+}
 ')
 	assert complete
 	assert identifiers.keys() == ['state']

--- a/vlib/v3/modulecache/modulecache_test.v
+++ b/vlib/v3/modulecache/modulecache_test.v
@@ -126,6 +126,13 @@ fn test_static_variable_identifiers_ignore_asm_labels() {
 	assert !function_identifiers['helper_alias']
 }
 
+fn test_static_storage_detects_macro_generated_declarations() {
+	assert c_source_has_static_storage('#define DECL(name) static int name;\nDECL(shared_state)\n')
+	assert c_source_has_static_storage('#define STORAGE static\n#define DECL(name) STORAGE int name;\nDECL(shared_state)\n')
+	assert c_source_has_static_storage('#define LOCAL_FN(name) static int name(void)\nLOCAL_FN(helper) { return 1; }\n')
+	assert !c_source_has_static_storage('#define DECL(name) int name;\nDECL(shared_state)\n')
+}
+
 fn test_static_variable_identifiers_classify_attributes() {
 	identifiers, complete := c_source_static_variable_identifiers('__attribute__((availability(macos,introduced=14.0))) static const unsigned long DynamicStride = 42;
 static inline __attribute__((__always_inline__)) __attribute__((__overloadable__)) int simd_any(int value);

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -1607,6 +1607,53 @@ fn main() {
 	assert module_cache_artifact(cache_dir, 'owner_', '.o').len > 0
 }
 
+fn test_unconditional_native_definition_disables_module_cache_split() {
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(),
+		'v3_module_cache_unconditional_native_definition_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	write_module_cache_file(root, 'owner/native.h', 'typedef struct { int value; } V3LibType;
+int v3_unconditional_value(void) { return 42; }
+')
+	write_module_cache_file(root, 'owner/owner.v', 'module owner
+
+#insert "@DIR/native.h"
+
+fn C.v3_unconditional_value() int
+
+pub fn value() int {
+	return C.v3_unconditional_value()
+}
+')
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'module main
+
+import owner
+
+fn main() {
+	println(owner.value())
+}
+')
+	cache_dir := os.join_path(root, 'cache')
+	first_output := os.join_path(root, 'first')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, first_output)
+	assert run_module_cache_binary(first_output) == '42'
+	// The warm rebuild links the cached objects. If the header were split, its
+	// public replay in the program unit and the full include in the owner object
+	// would both define v3_unconditional_value, failing the link with a duplicate
+	// symbol. Failing closed keeps the build monolithic and correct.
+	second_output := os.join_path(root, 'second')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, second_output)
+	assert run_module_cache_binary(second_output) == '42'
+	// The header defines an external symbol with no implementation switch to gate
+	// it, so the cache falls back to a monolithic build instead of splitting it.
+	assert module_cache_artifact(cache_dir, 'owner_', '.o').len == 0
+}
+
 fn test_static_helper_exposed_by_owner_macro_disables_module_cache_split() {
 	v3_bin := build_module_cache_v3()
 	root := os.join_path(os.temp_dir(), 'v3_module_cache_owner_macro_static_helper_${os.getpid()}')
@@ -7761,3 +7808,4 @@ fn main() {
 	assert reordered.exit_code == 0, reordered.output
 	assert run_module_cache_binary(reordered_output) == '1'
 }
+

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -1654,6 +1654,55 @@ fn main() {
 	assert module_cache_artifact(cache_dir, 'owner_', '.o').len == 0
 }
 
+fn test_flag_defined_native_implementation_disables_module_cache_split() {
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(),
+		'v3_module_cache_flag_defined_native_implementation_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	write_module_cache_file(root, 'owner/native.h', 'typedef struct { int value; } LibType;
+#ifdef LIB_IMPL
+int lib_value(void) { return 42; }
+#endif
+')
+	write_module_cache_file(root, 'owner/owner.v', 'module owner
+
+#flag -DLIB_IMPL
+#insert "@DIR/native.h"
+
+fn C.lib_value() int
+
+pub fn value() int {
+	return C.lib_value()
+}
+')
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'module main
+
+import owner
+
+fn main() {
+	println(owner.value())
+}
+')
+	cache_dir := os.join_path(root, 'cache')
+	first_output := os.join_path(root, 'first')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, first_output)
+	assert run_module_cache_binary(first_output) == '42'
+	// LIB_IMPL is supplied on the command line, so the implementation is active but
+	// no context define gates it and the name is not a conventional switch. The
+	// public replay cannot disable it, so splitting would define lib_value in both
+	// the owner object and the program unit's replay. The warm rebuild links the
+	// cached objects, so a duplicate would only surface there.
+	second_output := os.join_path(root, 'second')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, second_output)
+	assert run_module_cache_binary(second_output) == '42'
+	assert module_cache_artifact(cache_dir, 'owner_', '.o').len == 0
+}
+
 fn test_static_helper_exposed_by_owner_macro_disables_module_cache_split() {
 	v3_bin := build_module_cache_v3()
 	root := os.join_path(os.temp_dir(), 'v3_module_cache_owner_macro_static_helper_${os.getpid()}')

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -1479,9 +1479,8 @@ fn test_macro_declared_static_helper_used_by_sibling_disables_module_cache_split
 		os.rmdir_all(root) or {}
 	}
 	write_module_cache_file(root, 'owner/native.h', '#define V3_LOCAL_FN(name) static int name(void)
-static int v3_unrelated_macro_state;
 V3_LOCAL_FN(v3_macro_helper) {
-	return 42 + v3_unrelated_macro_state;
+	return 42;
 }
 ')
 	write_module_cache_file(root, 'owner/owner.v', 'module owner
@@ -1515,6 +1514,97 @@ fn main() {
 	compile_module_cache_project(v3_bin, cache_dir, main_file, output)
 	assert run_module_cache_binary(output) == '42'
 	assert module_cache_artifact(cache_dir, 'owner_', '.o').len == 0
+}
+
+fn test_macro_declared_static_variable_used_by_sibling_disables_module_cache_split() {
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_module_cache_macro_static_variable_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	write_module_cache_file(root, 'owner/native.h', '#define V3_LOCAL_STATE(name) static int name = 41;
+V3_LOCAL_STATE(v3_macro_state)
+')
+	write_module_cache_file(root, 'owner/owner.v', 'module owner
+
+#insert "@DIR/native.h"
+
+pub fn marker() {}
+')
+	write_module_cache_file(root, 'sibling/native.h', 'static int v3_read_macro_state(void) {
+	return v3_macro_state + 1;
+}
+')
+	write_module_cache_file(root, 'sibling/sibling.v', 'module sibling
+
+import owner
+
+#insert "@DIR/native.h"
+
+fn C.v3_read_macro_state() int
+
+pub fn value() int {
+	owner.marker()
+	return C.v3_read_macro_state()
+}
+')
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'module main
+
+import sibling
+
+fn main() {
+	println(sibling.value())
+}
+')
+	cache_dir := os.join_path(root, 'cache')
+	output := os.join_path(root, 'program')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, output)
+	assert run_module_cache_binary(output) == '42'
+	assert module_cache_artifact(cache_dir, 'owner_', '.o').len == 0
+}
+
+fn test_nonconventional_native_implementation_macro_is_not_replayed_publicly() {
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(),
+		'v3_module_cache_external_implementation_macro_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	write_module_cache_file(root, 'owner/native.h', 'typedef struct { int value; } V3LibType;
+#ifdef LIB_IMPL
+int v3_lib_value(void) { return 42; }
+#endif
+')
+	write_module_cache_file(root, 'owner/owner.v', 'module owner
+
+#define LIB_IMPL
+#insert "@DIR/native.h"
+
+fn C.v3_lib_value() int
+
+pub fn value() int {
+	return C.v3_lib_value()
+}
+')
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'module main
+
+import owner
+
+fn main() {
+	println(owner.value())
+}
+')
+	cache_dir := os.join_path(root, 'cache')
+	output := os.join_path(root, 'program')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, output)
+	assert run_module_cache_binary(output) == '42'
+	assert module_cache_artifact(cache_dir, 'owner_', '.o').len > 0
 }
 
 fn test_static_helper_exposed_by_owner_macro_disables_module_cache_split() {

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -1096,6 +1096,11 @@ fn test_module_cache_static_inline_attributes_are_not_storage() {
 		modulecache.c_source_function_identifiers('static __attribute__((noinline)) int cached_helper(void) {\n\treturn 1;\n}\n')
 	assert function_identifiers['cached_helper']
 	assert !function_identifiers['__attribute__']
+	static_function_identifiers, static_functions_complete :=
+		modulecache.c_source_static_function_identifiers_with_status('static int local_helper(void) { return 1; }\nint exported_helper(void) { return local_helper(); }\n')
+	assert static_functions_complete
+	assert static_function_identifiers['local_helper']
+	assert !static_function_identifiers['exported_helper']
 	macro_function_identifiers, macro_functions_complete :=
 		modulecache.c_source_function_identifiers_with_status('#define LOCAL_FN(name) static int name(void)\nstatic int state;\nLOCAL_FN(helper) {\n\treturn state;\n}\n')
 	assert macro_function_identifiers['LOCAL_FN']
@@ -1272,6 +1277,54 @@ fn main() {
 	compile_module_cache_project(v3_bin, cache_dir, main_file, output)
 	assert run_module_cache_binary(output) == '83'
 	assert module_cache_artifact(cache_dir, 'native_', '.o').len == 0
+}
+
+fn test_private_static_storage_header_uses_module_cache_split() {
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_module_cache_private_static_header_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	write_module_cache_file(root, 'native/state.h', '#ifndef V3_PRIVATE_STATIC_HEADER_STATE_H
+#define V3_PRIVATE_STATIC_HEADER_STATE_H
+
+static int v3_private_static_header_state = 40;
+
+static __attribute__((noinline)) int v3_private_static_header_next(void) {
+	return ++v3_private_static_header_state;
+}
+
+#endif
+')
+	write_module_cache_file(root, 'native/native.v', 'module native
+
+#include "@DIR/state.h"
+
+fn C.v3_private_static_header_next() int
+
+pub fn next() int {
+	return C.v3_private_static_header_next()
+}
+')
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'module main
+
+import native
+
+fn main() {
+	println(native.next() + native.next())
+}
+')
+	cache_dir := os.join_path(root, 'cache')
+	first_output := os.join_path(root, 'first')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, first_output)
+	assert run_module_cache_binary(first_output) == '83'
+	assert module_cache_artifact(cache_dir, 'native_', '.o').len > 0
+	second_output := os.join_path(root, 'second')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, second_output)
+	assert run_module_cache_binary(second_output) == '83'
 }
 
 fn test_static_storage_variable_used_by_sibling_disables_module_cache_split() {
@@ -6682,6 +6735,82 @@ fn main() {
 	assert run_module_cache_binary(first_output) == '42'
 	assert module_cache_artifact(cache_dir, 'owner_', '.o').len > 0
 	assert module_cache_artifact(cache_dir, 'caller_', '.o').len > 0
+
+	second_output := os.join_path(root, 'second')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, second_output)
+	assert run_module_cache_binary(second_output) == '42'
+}
+
+fn test_cached_private_native_type_groups_dependency_roots() {
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_cached_grouped_native_type_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	dep_path := os.join_path(root, 'owner', 'dep.h').replace('\\', '/')
+	write_module_cache_file(root, 'owner/owner.v', 'module owner
+
+#define V3_GROUPED_DEP "${dep_path}"
+#define V3_GROUPED_DEP_ALIAS V3_GROUPED_DEP
+#define V3_GROUPED_OWNER_IMPL
+#insert "@DIR/native.h"
+
+pub fn marker() {}
+')
+	write_module_cache_file(root, 'owner/dep.h',
+		'/* resolved recursively by the C preprocessor */\n')
+	write_module_cache_file(root, 'owner/native.h', '#include V3_GROUPED_DEP_ALIAS
+
+typedef struct V3GroupedPrivate V3GroupedPrivate;
+
+#ifdef V3_GROUPED_OWNER_IMPL
+struct V3GroupedPrivate {
+	int value;
+};
+static int v3_grouped_owner_state = 1;
+int v3_grouped_owner_value(void) {
+	return v3_grouped_owner_state;
+}
+#endif
+')
+	write_module_cache_file(root, 'consumer/consumer.v', 'module consumer
+
+import owner
+
+#define V3_GROUPED_CONSUMER_IMPL
+#insert "@DIR/native.h"
+
+fn C.v3_grouped_consumer_value() int
+
+pub fn value() int {
+	owner.marker()
+	return C.v3_grouped_consumer_value()
+}
+')
+	write_module_cache_file(root, 'consumer/native.h', '#ifdef V3_GROUPED_CONSUMER_IMPL
+static int v3_grouped_consumer_value(void) {
+	V3GroupedPrivate value = {41};
+	return value.value + v3_grouped_owner_value();
+}
+#endif
+')
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'module main
+
+import consumer
+
+fn main() {
+	println(consumer.value())
+}
+')
+	cache_dir := os.join_path(root, 'cache')
+	first_output := os.join_path(root, 'first')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, first_output)
+	assert run_module_cache_binary(first_output) == '42'
+	assert module_cache_artifact(cache_dir, 'consumer_', '.o').len > 0
+	assert module_cache_artifact(cache_dir, 'owner_', '.o').len > 0
 
 	second_output := os.join_path(root, 'second')
 	compile_module_cache_project(v3_bin, cache_dir, main_file, second_output)

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -1374,6 +1374,102 @@ fn main() {
 	assert module_cache_artifact(cache_dir, 'owner_', '.o').len == 0
 }
 
+fn test_incomplete_static_variable_scan_disables_module_cache_split() {
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_module_cache_incomplete_static_variable_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	write_module_cache_file(root, 'owner/state.h', 'static int v3_recognized_static_state;
+static int __attribute__((unused)) v3_unclassified_static_state;
+')
+	write_module_cache_file(root, 'owner/owner.v', 'module owner
+
+#insert "@DIR/state.h"
+
+pub fn marker() {}
+')
+	write_module_cache_file(root, 'sibling/sibling.v', 'module sibling
+
+import owner
+
+__global C.v3_unclassified_static_state int
+
+pub fn value() int {
+	owner.marker()
+	return C.v3_unclassified_static_state
+}
+')
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'module main
+
+import sibling
+
+fn main() {
+	println(sibling.value())
+}
+')
+	cache_dir := os.join_path(root, 'cache')
+	output := os.join_path(root, 'program')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, output)
+	assert run_module_cache_binary(output) == '0'
+	assert module_cache_artifact(cache_dir, 'owner_', '.o').len == 0
+}
+
+fn test_objective_c_native_source_uses_objective_c_macros_for_cache_dependencies() {
+	$if !macos {
+		return
+	}
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_module_cache_objective_c_macros_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	value_header := os.join_path(root, 'owner/value.h')
+	write_module_cache_file(root, 'owner/value.h', '#define V3_OBJC_CACHE_VALUE 41\n')
+	write_module_cache_file(root, 'owner/implementation.m', '#ifdef __OBJC__
+#include "value.h"
+#endif
+
+int v3_objc_cache_value(void) {
+	return V3_OBJC_CACHE_VALUE;
+}
+')
+	write_module_cache_file(root, 'owner/owner.v', 'module owner
+
+#include "@DIR/implementation.m"
+
+fn C.v3_objc_cache_value() int
+
+pub fn value() int {
+	return C.v3_objc_cache_value()
+}
+')
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'module main
+
+import owner
+
+fn main() {
+	println(owner.value())
+}
+')
+	cache_dir := os.join_path(root, 'cache')
+	first_output := os.join_path(root, 'first')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, first_output)
+	assert run_module_cache_binary(first_output) == '41'
+	assert module_cache_artifact(cache_dir, 'owner_', '.o').len > 0
+
+	os.write_file(value_header, '#define V3_OBJC_CACHE_VALUE 42\n')!
+	second_output := os.join_path(root, 'second')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, second_output)
+	assert run_module_cache_binary(second_output) == '42'
+}
+
 fn test_macro_declared_static_helper_used_by_sibling_disables_module_cache_split() {
 	v3_bin := build_module_cache_v3()
 	root := os.join_path(os.temp_dir(), 'v3_module_cache_macro_static_helper_${os.getpid()}')

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -31,6 +31,12 @@ const deferred_str_expansion_threshold = 0
 // serial deferred path in case the transform expands it inline.
 const unresolved_interp_expansion_estimate = 1000
 
+// recursive_pointer_str_expansion_threshold bounds an indirect recursive pointer
+// expansion before it is rendered as circular. Small recursive structs retain the
+// normal auto-str depth, while large object graphs avoid generating every branch
+// before the repeated type is reached.
+const recursive_pointer_str_expansion_threshold = 512
+
 // resolve_call_name resolves the function name from a .call node.
 // child[0] is the function expression: .ident for plain calls, .selector for method calls.
 fn (t &Transformer) resolve_call_name(node flat.Node) string {
@@ -5043,7 +5049,7 @@ fn (mut t Transformer) lower_ref_value_str(expr flat.NodeId, typ string, nil_tex
 	t.pending_stmts << t.make_decl_assign_typed(ptr_name, expr, typ)
 	t.set_var_type(ptr_name, typ)
 	t.pending_stmts << t.make_decl_assign_typed(res_name, t.make_string_literal(nil_text), 'string')
-	if t.ref_value_str_is_direct_circular(elem_type) {
+	if t.ref_value_str_reaches_large_circular_graph(elem_type) {
 		then_body := t.make_block(arr1(t.make_assign(t.make_ident(res_name),
 			t.make_string_literal('&<circular>'))))
 		cond := t.make_infix(.ne, t.make_ident(ptr_name), t.a.add(.nil_literal))
@@ -5075,12 +5081,16 @@ fn (mut t Transformer) lower_ref_value_str(expr flat.NodeId, typ string, nil_tex
 	return t.make_ident(res_name)
 }
 
-fn (t &Transformer) ref_value_str_is_direct_circular(elem_type string) bool {
+fn (mut t Transformer) ref_value_str_reaches_large_circular_graph(elem_type string) bool {
 	if t.stringify_stack.len == 0 {
 		return false
 	}
 	aggregate := t.stringify_aggregate_type_name(elem_type) or { return false }
-	if !t.stringify_types_match(aggregate, t.stringify_stack.last()) {
+	if t.stringify_expansion_estimate(aggregate) <= recursive_pointer_str_expansion_threshold {
+		return false
+	}
+	mut seen := map[string]bool{}
+	if !t.stringify_type_reaches_stack(aggregate, mut seen) {
 		return false
 	}
 	return !t.struct_autostr_allows_recurse(aggregate)

--- a/vlib/v3/transform/fn_test.v
+++ b/vlib/v3/transform/fn_test.v
@@ -76,6 +76,64 @@ fn test_auto_str_helper_call_uses_type_owner_module() {
 	assert t.auto_str_types['v.token.Pos'].helper_module == 'token'
 }
 
+fn test_large_recursive_pointer_auto_str_stops_before_expanding_back_edge() {
+	mut a := flat.FlatAst.new()
+	mut tc := types.TypeChecker.new(&a)
+	mut t := new_transformer(mut a, &tc, map[string]bool{})
+	mut large_fields := []FieldInfo{cap: 65}
+	for i in 0 .. 64 {
+		large_fields << FieldInfo{
+			name: 'value_${i}'
+			typ:  'int'
+		}
+	}
+	large_fields << FieldInfo{
+		name:    'root'
+		typ:     '&Root'
+		raw_typ: '&Root'
+	}
+	t.structs['Root'] = StructInfo{
+		name:   'Root'
+		fields: [
+			FieldInfo{
+				name:    'large'
+				typ:     '&Large'
+				raw_typ: '&Large'
+			},
+		]
+	}
+	t.structs['Large'] = StructInfo{
+		name:   'Large'
+		fields: large_fields
+	}
+	t.structs['Small'] = StructInfo{
+		name:   'Small'
+		fields: [
+			FieldInfo{
+				name:    'root'
+				typ:     '&SmallRoot'
+				raw_typ: '&SmallRoot'
+			},
+		]
+	}
+	t.structs['SmallRoot'] = StructInfo{
+		name:   'SmallRoot'
+		fields: [
+			FieldInfo{
+				name:    'small'
+				typ:     '&Small'
+				raw_typ: '&Small'
+			},
+		]
+	}
+	t.stringify_stack << 'Root'
+
+	assert t.ref_value_str_reaches_large_circular_graph('Large')
+	t.stringify_stack.clear()
+	t.stringify_stack << 'SmallRoot'
+	assert !t.ref_value_str_reaches_large_circular_graph('Small')
+}
+
 fn test_if_type_merge_ignores_unresolved_branch_fallbacks() {
 	t := Transformer{}
 	assert t.merge_if_expr_types('unknown', 'int') == 'int'


### PR DESCRIPTION
## Summary

- track compiler macros, include-site context, recursive native inputs, and static-storage headers in the V3 module cache
- compile Cocoa, Sokol, fontstash, and other native implementation roots into their owning module objects while preserving public declarations
- restore native root ownership/context and path-selection flags on the first warm build
- keep genuinely ambiguous include macros uncacheable while accepting a single recovered literal such as FreeType's header aliases
- bound recursive auto-string lowering for very large indirect type graphs

## Volt benchmark

The V3 compiler was built with:

```sh
./vnew -prod -gc none -prealloc -path 'vlib|@vlib|@vmodules' \
  -o /tmp/v3-volt-pr/v3prod vlib/v3/v3.v
```

Volt itself was compiled without `-prod`, using a fresh `V3CACHE`:

| stage | cold | warm |
| --- | ---: | ---: |
| wall time | 34.67s | 2.63s |
| check | 239.38ms | 0.08ms cached |
| transform | 606.06ms | cached |
| annotate types | 150.36ms | cached |
| monomorphize | 679.13ms | 12.10ms cached |
| cgen | 1.11s | 0.48ms cached |
| C module plan | 24.98s | 1.18ms cached |
| final clang/link | 1.83s | 1.75s |

The warm link consumes cached module objects for UI and other imports. It had no module-cache fallback, dependency-restore miss, incremental-cache miss, or module-object miss.

## Tests

- `./vnew -silent test vlib/v3/driver/ vlib/v3/modulecache/modulecache_test.v vlib/v3/gen/c/target_test.v vlib/v3/gen/c/source_directive_test.v vlib/v3/transform/fn_test.v` (10 passed)
- `./vnew -silent test -run-only test_private_static_storage_header_uses_module_cache_split vlib/v3/tests/module_cache_test.v`
- `./vnew -silent test -run-only test_cached_private_native_type_groups_dependency_roots vlib/v3/tests/module_cache_test.v`
- production V3 build plus cold/warm Volt compilation without target `-prod`
