### PR TITLE
v3: compile ownership-heavy generic programs in under one second

### DIFF
--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -7769,6 +7769,7 @@ pub fn run(args []string) {
 			skip_transform_generics = true
 		}
 		mut transform_used_fns := map[string]bool{}
+		pre_transform_node_count := a.nodes.len
 		if incremental_cache_hit {
 			transform_used_fns = clone_string_bool_map(incremental_changed_names)
 			// `main` activates the transformer's used-function filter. If another
@@ -8118,12 +8119,11 @@ pub fn run(args []string) {
 				// Generic lowering rewrites and clones call nodes in disposable arenas.
 				// Resolve their final names from the owned transformed AST instead of
 				// retaining pre-transform canonical string views across arena release.
-				pre_tc.reset_resolved_calls_for_reannotation()
-				pre_tc.annotate_types_with_used(if incremental_cache_hit {
+				pre_tc.annotate_types_with_used_missing_calls(if incremental_cache_hit {
 					transform_used_fns
 				} else {
 					used_fns
-				})
+				}, pre_transform_node_count)
 			} else {
 				restore_transformed_fn_value_types(mut pre_tc, a, if incremental_cache_hit {
 					incremental_stage_used_fns

--- a/vlib/v3/gen/c/target_test.v
+++ b/vlib/v3/gen/c/target_test.v
@@ -642,7 +642,7 @@ fn test_cache_input_scan_bounds_repeated_header_trees() {
 	inputs, _, has_untracked := cache_external_input_files(a, '', {
 		'sample': true
 	}, [], prefs.target)
-	assert has_untracked
+	assert !has_untracked
 	mut expected := [os.real_path(left_header), os.real_path(right_header),
 		os.real_path(common_header)]
 	expected.sort()

--- a/vlib/v3/tests/ownership/ownership_test.v
+++ b/vlib/v3/tests/ownership/ownership_test.v
@@ -3055,6 +3055,30 @@ fn main() {
 	assert fail.output.contains('use of moved value: `s`'), fail.output
 }
 
+fn test_ownership_expression_statement_call_seeds_param_fixed_point() {
+	v3_bin := ownership_build_v3()
+	fail := run_ownership_check(v3_bin, 'expression_statement_call_param_fixed_point', "
+fn forward(s string) int {
+	sink(s)
+	println(s)
+	return 0
+}
+
+fn seed() int {
+	forward('owned'.to_owned())
+	return 0
+}
+
+fn sink(s string) {}
+
+fn main() {
+	_ = seed()
+}
+")
+	assert fail.exit_code != 0
+	assert fail.output.contains('use of moved value: `s`'), fail.output
+}
+
 fn test_ownership_branch_moves_are_isolated_between_siblings() {
 	v3_bin := ownership_build_v3()
 	distinct_field_moves := run_ownership_check(v3_bin, 'branch_distinct_field_moves', '

--- a/vlib/v3/tests/ownership/ownership_test.v
+++ b/vlib/v3/tests/ownership/ownership_test.v
@@ -3079,6 +3079,30 @@ fn main() {
 	assert fail.output.contains('use of moved value: `s`'), fail.output
 }
 
+fn test_ownership_assert_call_seeds_param_fixed_point() {
+	v3_bin := ownership_build_v3()
+	fail := run_ownership_check(v3_bin, 'assert_call_param_fixed_point', "
+fn forward(s string) bool {
+	sink(s)
+	println(s)
+	return true
+}
+
+fn seed() int {
+	assert forward('owned'.to_owned())
+	return 0
+}
+
+fn sink(s string) {}
+
+fn main() {
+	_ = seed()
+}
+")
+	assert fail.exit_code != 0
+	assert fail.output.contains('use of moved value: `s`'), fail.output
+}
+
 fn test_ownership_branch_moves_are_isolated_between_siblings() {
 	v3_bin := ownership_build_v3()
 	distinct_field_moves := run_ownership_check(v3_bin, 'branch_distinct_field_moves', '

--- a/vlib/v3/tests/ownership/ownership_test.v
+++ b/vlib/v3/tests/ownership/ownership_test.v
@@ -3029,6 +3029,32 @@ fn main() {
 	assert fail_params_field_borrow_move.output.contains('cannot move `s` because it is borrowed'), fail_params_field_borrow_move.output
 }
 
+fn test_ownership_deferred_call_seeds_param_fixed_point() {
+	v3_bin := ownership_build_v3()
+	fail := run_ownership_check(v3_bin, 'deferred_call_param_fixed_point', "
+fn forward(s string) int {
+	sink(s)
+	println(s)
+	return 0
+}
+
+fn seed() int {
+	defer {
+		forward('owned'.to_owned())
+	}
+	return 0
+}
+
+fn sink(s string) {}
+
+fn main() {
+	_ = seed()
+}
+")
+	assert fail.exit_code != 0
+	assert fail.output.contains('use of moved value: `s`'), fail.output
+}
+
 fn test_ownership_branch_moves_are_isolated_between_siblings() {
 	v3_bin := ownership_build_v3()
 	distinct_field_moves := run_ownership_check(v3_bin, 'branch_distinct_field_moves', '

--- a/vlib/v3/tests/review_transform_regressions_test.v
+++ b/vlib/v3/tests/review_transform_regressions_test.v
@@ -5858,3 +5858,53 @@ fn main() {
 	assert builtin_body.contains('int local = 44;'), builtin_body
 	assert builtin_body.contains('memdup(&local, sizeof(int))'), builtin_body
 }
+
+fn test_parallel_monomorph_workers_use_disjoint_lifted_literal_names() {
+	v3_bin := build_v3_review_transform()
+	out := run_good_with_env(v3_bin, 'parallel_monomorph_literal_names', 'VJOBS=4', 'fn apply[T](value T, callback fn (T) int) int {
+	return callback(value)
+}
+
+fn alpha[T](value T, offset int) int {
+	return apply(value, fn [offset] (_ T) int {
+		return offset
+	})
+}
+
+fn beta[T](value T, label string) int {
+	return apply(value, fn [label] (_ T) int {
+		return label.len
+	})
+}
+
+fn gamma[T](value T, enabled bool) int {
+	return apply(value, fn [enabled] (_ T) int {
+		return if enabled { 1 } else { 0 }
+	})
+}
+
+fn main() {
+	println(alpha(1, 7))
+	println(beta("x", "four"))
+	println(gamma(u64(3), true))
+}
+')
+	assert out == '7\n4\n1'
+}
+
+fn test_parallel_transform_merges_generic_call_metadata() {
+	v3_bin := build_v3_review_transform()
+	mut source := 'fn identity[T](value T) T {\n\treturn value\n}\n\n'
+	mut expected := 0
+	for i in 0 .. 300 {
+		source += 'fn value_${i}() int {\n\treturn identity(${i})\n}\n\n'
+		expected += i
+	}
+	source += 'fn main() {\n\tmut total := 0\n'
+	for i in 0 .. 300 {
+		source += '\ttotal += value_${i}()\n'
+	}
+	source += '\tprintln(total)\n}\n'
+	out := run_good_with_env(v3_bin, 'parallel_transform_generic_calls', 'VJOBS=4', source)
+	assert out == expected.str()
+}

--- a/vlib/v3/transform/expr.v
+++ b/vlib/v3/transform/expr.v
@@ -3693,7 +3693,13 @@ pub fn (mut t Transformer) make_call(fn_name string, args []flat.NodeId) flat.No
 // make_call_typed builds make call typed data for transform.
 pub fn (mut t Transformer) make_call_typed(fn_name string, args []flat.NodeId, typ string) flat.NodeId {
 	fn_ident := t.make_ident(fn_name)
-	return t.make_call_expr_typed(fn_ident, args, typ)
+	call_id := t.make_call_expr_typed(fn_ident, args, typ)
+	// `__v3_` calls are C-generator intrinsics, not declarations in the
+	// semantic function table. Keep them unresolved so Cgen recognizes them.
+	if !fn_name.starts_with('__v3_') {
+		t.set_generated_resolved_call(call_id, fn_name)
+	}
+	return call_id
 }
 
 fn (mut t Transformer) mark_fn_used(fn_name string) {

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -9999,6 +9999,13 @@ fn (t &Transformer) fn_literal_name_exists(name string) bool {
 }
 
 fn (mut t Transformer) add_fn_literal_capture_context(name string, module_name string, capture_names []string, capture_types map[string]string) {
+	if t.struct_maps_shared {
+		t.structs = t.structs.clone()
+		t.struct_maps_shared = false
+	}
+	if !isnil(t.tc) {
+		t.tc.ensure_private_transform_structs()
+	}
 	t.add_generated_fn_decl_context(module_name)
 	mut field_ids := []flat.NodeId{cap: capture_names.len}
 	mut semantic_fields := []types.StructField{cap: capture_names.len}
@@ -10046,6 +10053,7 @@ fn (mut t Transformer) add_fn_literal_capture_context(name string, module_name s
 		fields: transform_fields
 	}
 	t.structs[name] = info
+	t.generated_capture_contexts << name
 	if !isnil(t.tc) {
 		t.tc.structs[name] = semantic_fields
 		t.tc.struct_modules[name] = module_name
@@ -10055,6 +10063,7 @@ fn (mut t Transformer) add_fn_literal_capture_context(name string, module_name s
 	if module_name.len > 0 && module_name !in ['main', 'builtin'] {
 		qualified := '${module_name}.${name}'
 		t.structs[qualified] = info
+		t.generated_capture_contexts << qualified
 		if !isnil(t.tc) {
 			t.tc.structs[qualified] = semantic_fields
 			t.tc.struct_modules[qualified] = module_name

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -166,6 +166,8 @@ mut:
 	fn_ret_types                  map[string]string
 	fn_ret_types_log              []string
 	tc_signature_names_log        []string
+	generated_capture_contexts    []string
+	struct_maps_shared            bool
 	multi_return_fn_ret_types     map[string]types.Type
 	receiver_method_suffix_index  map[string]string
 	declared_fn_name_counts       map[string]u8
@@ -3989,11 +3991,13 @@ fn (t &Transformer) fork_program_view(ast &flat.FlatAst, wtc &types.TypeChecker,
 		node_context_read_only:             t.node_context_read_only
 		signature_maps_shared:              true
 		signature_maps_changed:             false
+		struct_maps_shared:                 true
 	}
 }
 
 fn (mut t Transformer) merge_worker_used_fns(w &Transformer) {
 	t.merge_worker_signatures(w)
+	t.merge_worker_capture_contexts(w)
 	scoped := w.worker_scope != unsafe { nil }
 	for name, used in w.used_fns {
 		if used {
@@ -4047,6 +4051,69 @@ fn (mut t Transformer) merge_worker_used_fns(w &Transformer) {
 	}
 }
 
+fn clone_struct_info_owned(info StructInfo) StructInfo {
+	mut fields := []FieldInfo{cap: info.fields.len}
+	for field in info.fields {
+		fields << FieldInfo{
+			name:         field.name.clone()
+			typ:          field.typ.clone()
+			raw_typ:      field.raw_typ.clone()
+			default_expr: field.default_expr
+			is_embedded:  field.is_embedded
+		}
+	}
+	return StructInfo{
+		name:       info.name.clone()
+		module:     info.module.clone()
+		is_params:  info.is_params
+		is_aligned: info.is_aligned
+		alignment:  info.alignment.clone()
+		fields:     fields
+	}
+}
+
+fn clone_struct_fields_owned(fields []types.StructField) []types.StructField {
+	mut cloned := []types.StructField{cap: fields.len}
+	for field in fields {
+		cloned << types.StructField{
+			name:        field.name.clone()
+			typ:         types.clone_owned_type(field.typ)
+			has_default: field.has_default
+			is_embed:    field.is_embed
+			is_mut:      field.is_mut
+			is_volatile: field.is_volatile
+		}
+	}
+	return cloned
+}
+
+// merge_worker_capture_contexts publishes closure context metadata created by
+// monomorph workers. Their struct maps are private because peers can lift
+// different literals concurrently.
+fn (mut t Transformer) merge_worker_capture_contexts(w &Transformer) {
+	if w.generated_capture_contexts.len == 0 {
+		return
+	}
+	for name in w.generated_capture_contexts {
+		if info := w.structs[name] {
+			t.structs[name.clone()] = clone_struct_info_owned(info)
+		}
+	}
+	if isnil(t.tc) || isnil(w.tc) {
+		return
+	}
+	mut master_tc := unsafe { &types.TypeChecker(voidptr(t.tc)) }
+	for name in w.generated_capture_contexts {
+		if fields := w.tc.structs[name] {
+			owned_name := name.clone()
+			master_tc.structs[owned_name] = clone_struct_fields_owned(fields)
+			master_tc.struct_modules[owned_name] = (w.tc.struct_modules[name] or { '' }).clone()
+			master_tc.struct_files[owned_name] = (w.tc.struct_files[name] or { '' }).clone()
+			master_tc.register_short_type_name(owned_name)
+		}
+	}
+}
+
 // merge_worker_signatures publishes declarations synthesized by a private
 // transform worker before its disposable arena is released.
 fn (mut t Transformer) merge_worker_signatures(w &Transformer) {
@@ -4076,14 +4143,18 @@ fn (mut t Transformer) merge_worker_signatures(w &Transformer) {
 	master_tc.ensure_private_transform_signatures()
 	mut tc_signature_names := w.tc_signature_names_log.clone()
 	tc_signature_names << w.fn_ret_types_log
+	tc_signature_names << w.tc.transform_signature_names_log
 	for name in tc_signature_names {
-		ret := w.tc.fn_ret_types[name] or { continue }
-		if name in master_tc.fn_ret_types {
-			continue
-		}
 		owned_name := name.clone()
-		master_tc.fn_ret_types[owned_name] = types.clone_owned_type(ret)
+		if ret := w.tc.fn_ret_types[name] {
+			if name !in master_tc.fn_ret_types {
+				master_tc.fn_ret_types[owned_name] = types.clone_owned_type(ret)
+			}
+		}
 		if params := w.tc.fn_param_types[name] {
+			if name in master_tc.fn_param_types {
+				continue
+			}
 			master_tc.register_generated_fn_param_types(owned_name, types.clone_owned_types(params))
 		}
 		master_tc.fn_variadic[owned_name] = w.tc.fn_variadic[name]
@@ -4465,6 +4536,20 @@ fn (mut t Transformer) set_resolved_call_entry(idx int, name string) {
 	}
 	t.tc.resolved_call_names[idx] = t.tc.canonical_symbol(name)
 	t.tc.resolved_call_set[idx] = true
+}
+
+// set_generated_resolved_call records the exact target of a call synthesized
+// by the transformer. Parallel workers publish the entry through their private
+// overlay, while serial transforms can update the dense checker cache directly.
+fn (mut t Transformer) set_generated_resolved_call(id flat.NodeId, name string) {
+	if isnil(t.tc) || int(id) < 0 || name.len == 0 {
+		return
+	}
+	if !isnil(t.tc.fork_overlay) {
+		t.tc.fork_overlay.resolved_call_names[int(id)] = name
+		return
+	}
+	t.set_resolved_call_entry(int(id), name)
 }
 
 fn (mut t Transformer) set_resolved_fn_value_entry(idx int, name string) {

--- a/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
@@ -951,10 +951,14 @@ fn (mut t Transformer) run_parallel_monomorphize_specs(specs []PendingGenericFnS
 		available_jobs := t.a.worker_pool.size() + 1
 		// Forked checkers carry substantial semantic indexes. Small programs do not have
 		// enough specialization work to repay a full machine-sized set of those clones.
-		job_limit := if t.a.nodes.len < 200_000 {
+		mut job_limit := if t.a.nodes.len < 1_000_000 {
 			int_min(available_jobs, 4)
 		} else {
 			available_jobs
+		}
+		configured_jobs := os.getenv('V3_MONOMORPH_JOBS').int()
+		if configured_jobs > 0 && configured_jobs < job_limit {
+			job_limit = configured_jobs
 		}
 		n_jobs := monomorph_job_count(job_limit, specs.len)
 		if n_jobs <= 1 {
@@ -995,6 +999,10 @@ fn (mut t Transformer) run_parallel_monomorphize_specs(specs []PendingGenericFnS
 			node_starts[i] = base_nodes + node_pool * i / n_jobs
 			child_starts[i] = base_children + child_pool * i / n_jobs
 		}
+		// Each monomorph worker can lift function literals while specializing its
+		// generic bodies. Give every worker a disjoint deterministic name range;
+		// private checker snapshots cannot see names created concurrently by peers.
+		t.global_temp_counter = node_starts[0]
 
 		// Monomorphization uses a fresh Transformer, so its declaration cache has
 		// not been warmed by the earlier function-body transform. Build it before
@@ -1050,6 +1058,7 @@ fn (mut t Transformer) run_parallel_monomorphize_specs(specs []PendingGenericFnS
 			wtc.fn_type_files = t.tc.fn_type_files.clone()
 			wtc.transform_signature_maps_shared = false
 			mut w := t.fork_worker(view, wtc)
+			w.global_temp_counter = node_starts[ci]
 			w.fn_ret_types = t.fn_ret_types.clone()
 			w.receiver_method_suffix_index = t.receiver_method_suffix_index.clone()
 			w.signature_maps_shared = false
@@ -1231,6 +1240,7 @@ fn (mut t Transformer) run_parallel_monomorphize_specs(specs []PendingGenericFnS
 		}
 		t.parallel_monomorph_worker = false
 		t.generic_signatures_pre_registered = false
+		t.global_temp_counter = node_starts[n_jobs]
 		t.parallel_monomorph_scan_end = t.a.nodes.len
 		t.tc.unfreeze_type_cache_after_forks()
 		t.parallel_monomorph_scan_nodes = t.parallel_monomorph_scan_nodes.clone()
@@ -1382,6 +1392,9 @@ fn monomorph_job_count(n_runtime_jobs int, n_specs int) int {
 	mut n := n_runtime_jobs
 	if n > max_parallel_monomorph_jobs {
 		n = max_parallel_monomorph_jobs
+	}
+	if n > n_specs {
+		n = n_specs
 	}
 	return n
 }
@@ -2007,14 +2020,9 @@ fn (mut t Transformer) run_parallel_transform(items []FnWorkItem, base_nodes int
 		t.transform_pure_items_serial(items)
 		return false
 	} $else {
-		// Generic body lowering can discover and register new specializations. The
-		// signature tables are compilation-wide mutable state, so cloned workers
-		// must not update them concurrently. The dedicated monomorphization stage
-		// has its own synchronized parallel queue; keep this earlier pass serial.
-		if !t.skip_generics {
-			t.transform_pure_items_serial(items)
-			return false
-		}
+		// Generic body lowering can discover signatures, so generic builds use the
+		// cloned-worker path below. Each worker owns its signature maps and the
+		// deterministic merge publishes additions after all body work has joined.
 		if isnil(t.a.worker_pool) {
 			t.a.worker_pool = workers.new(runtime.nr_jobs() - 1)
 		}

--- a/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
@@ -2078,10 +2078,10 @@ fn (mut t Transformer) run_parallel_transform(items []FnWorkItem, base_nodes int
 				items_ptr: unsafe { voidptr(&chunks[ci + 1]) }
 			}
 		}
-		// Helper forks share the current signature-map backing arrays. The master
-		// participates in the transform as chunk 0, so make its next write detach
+		// Helper forks share the current signature and struct-map backing arrays.
+		// The master participates as chunk 0, so make its next metadata write detach
 		// instead of reallocating storage while helpers are reading it.
-		t.mark_parallel_signature_maps_shared()
+		t.mark_parallel_worker_maps_shared()
 		t.temp_counter = 0
 		fail := os.getenv('V3_TEST_PTHREAD_CREATE_FAIL')
 		mut tasks := []workers.Task{cap: chunk_count}
@@ -2105,11 +2105,13 @@ fn (mut t Transformer) run_parallel_transform(items []FnWorkItem, base_nodes int
 	}
 }
 
-fn (mut t Transformer) mark_parallel_signature_maps_shared() {
+fn (mut t Transformer) mark_parallel_worker_maps_shared() {
 	t.signature_maps_shared = true
+	t.struct_maps_shared = true
 	if !isnil(t.tc) {
 		mut master_tc := unsafe { &types.TypeChecker(voidptr(t.tc)) }
 		master_tc.transform_signature_maps_shared = true
+		master_tc.transform_struct_maps_shared = true
 	}
 }
 

--- a/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
@@ -2078,6 +2078,10 @@ fn (mut t Transformer) run_parallel_transform(items []FnWorkItem, base_nodes int
 				items_ptr: unsafe { voidptr(&chunks[ci + 1]) }
 			}
 		}
+		// Helper forks share the current signature-map backing arrays. The master
+		// participates in the transform as chunk 0, so make its next write detach
+		// instead of reallocating storage while helpers are reading it.
+		t.mark_parallel_signature_maps_shared()
 		t.temp_counter = 0
 		fail := os.getenv('V3_TEST_PTHREAD_CREATE_FAIL')
 		mut tasks := []workers.Task{cap: chunk_count}
@@ -2098,6 +2102,14 @@ fn (mut t Transformer) run_parallel_transform(items []FnWorkItem, base_nodes int
 		}
 		t.tc.unfreeze_type_cache_after_forks()
 		return any_started
+	}
+}
+
+fn (mut t Transformer) mark_parallel_signature_maps_shared() {
+	t.signature_maps_shared = true
+	if !isnil(t.tc) {
+		mut master_tc := unsafe { &types.TypeChecker(voidptr(t.tc)) }
+		master_tc.transform_signature_maps_shared = true
 	}
 }
 

--- a/vlib/v3/transform/transform_parallel_test.v
+++ b/vlib/v3/transform/transform_parallel_test.v
@@ -4,6 +4,24 @@ import v3.flat
 import v3.token
 import v3.types
 
+fn test_monomorph_job_count_does_not_start_empty_workers() {
+	$if !v3_no_parallel ? {
+		assert monomorph_job_count(16, 1) == 1
+		assert monomorph_job_count(16, 3) == 3
+		assert monomorph_job_count(2, 8) == 2
+	}
+}
+
+fn test_generated_calls_publish_exact_resolution_except_cgen_intrinsics() {
+	mut a := flat.FlatAst.new()
+	mut tc := types.TypeChecker.new(&a)
+	mut t := new_transformer(mut a, &tc, map[string]bool{})
+	call_id := t.make_call('main.helper', []flat.NodeId{})
+	assert tc.resolved_call_name(call_id)? == 'main.helper'
+	intrinsic_id := t.make_call('__v3_clone_owned_ierror', []flat.NodeId{})
+	assert tc.resolved_call_name(intrinsic_id) == none
+}
+
 fn test_deferred_worker_node_clone_preserves_skip_ownership_drops() {
 	$if !v3_no_parallel ? {
 		mut t := Transformer{

--- a/vlib/v3/transform/transform_parallel_test.v
+++ b/vlib/v3/transform/transform_parallel_test.v
@@ -113,6 +113,31 @@ fn test_merge_worker_signatures_updates_checker_method_suffix_index() {
 	assert master.tc.fn_param_types_for_name('open') == params
 }
 
+fn test_parallel_master_detaches_signature_maps_before_writing() {
+	mut a := flat.FlatAst.new()
+	mut tc := types.TypeChecker.new(&a)
+	mut master := new_transformer(mut a, &tc, map[string]bool{})
+	master.fn_ret_types['main.base'] = 'int'
+	tc.fn_param_types['main.base'] = [types.Type(types.int_)]
+
+	worker_ast := master.clone_ast_base(master.a.nodes.len, master.a.children.len)
+	worker_tc := tc.fork_for_parallel_transform(worker_ast)
+	worker := master.fork_worker(worker_ast, worker_tc)
+	master.mark_parallel_signature_maps_shared()
+
+	master.set_fn_ret_type('main.master_generated', 'bool')
+	mut master_tc := unsafe { &types.TypeChecker(voidptr(master.tc)) }
+	master_tc.ensure_private_transform_signatures()
+	master_tc.register_generated_fn_param_types('main.master_generated', [
+		types.Type(types.bool_),
+	])
+
+	assert master.fn_ret_types['main.master_generated'] == 'bool'
+	assert 'main.master_generated' !in worker.fn_ret_types
+	assert 'main.master_generated' in master.tc.fn_param_types
+	assert 'main.master_generated' !in worker.tc.fn_param_types
+}
+
 fn test_transform_ast_clone_preserves_template_metadata() {
 	mut a := flat.FlatAst.new()
 	a.template_call_sites[7] = token.new_pos(3, 11)

--- a/vlib/v3/transform/transform_parallel_test.v
+++ b/vlib/v3/transform/transform_parallel_test.v
@@ -113,17 +113,21 @@ fn test_merge_worker_signatures_updates_checker_method_suffix_index() {
 	assert master.tc.fn_param_types_for_name('open') == params
 }
 
-fn test_parallel_master_detaches_signature_maps_before_writing() {
+fn test_parallel_master_detaches_metadata_maps_before_writing() {
 	mut a := flat.FlatAst.new()
 	mut tc := types.TypeChecker.new(&a)
 	mut master := new_transformer(mut a, &tc, map[string]bool{})
 	master.fn_ret_types['main.base'] = 'int'
 	tc.fn_param_types['main.base'] = [types.Type(types.int_)]
+	master.structs['main.Base'] = StructInfo{
+		name: 'main.Base'
+	}
+	tc.structs['main.Base'] = []types.StructField{}
 
 	worker_ast := master.clone_ast_base(master.a.nodes.len, master.a.children.len)
 	worker_tc := tc.fork_for_parallel_transform(worker_ast)
 	worker := master.fork_worker(worker_ast, worker_tc)
-	master.mark_parallel_signature_maps_shared()
+	master.mark_parallel_worker_maps_shared()
 
 	master.set_fn_ret_type('main.master_generated', 'bool')
 	mut master_tc := unsafe { &types.TypeChecker(voidptr(master.tc)) }
@@ -136,6 +140,12 @@ fn test_parallel_master_detaches_signature_maps_before_writing() {
 	assert 'main.master_generated' !in worker.fn_ret_types
 	assert 'main.master_generated' in master.tc.fn_param_types
 	assert 'main.master_generated' !in worker.tc.fn_param_types
+
+	master.add_fn_literal_capture_context('CaptureContext', 'main', []string{}, map[string]string{})
+	assert 'CaptureContext' in master.structs
+	assert 'CaptureContext' !in worker.structs
+	assert 'CaptureContext' in master.tc.structs
+	assert 'CaptureContext' !in worker.tc.structs
 }
 
 fn test_transform_ast_clone_preserves_template_metadata() {

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -683,6 +683,8 @@ pub mut:
 	fn_type_modules                  map[string]string
 	transform_signature_maps_shared  bool
 	transform_signature_maps_changed bool
+	transform_signature_names_log    []string
+	transform_struct_maps_shared     bool
 	fn_generic_params                map[string][]string
 	specialized_generic_fns          map[string]bool
 	fn_variadic                      map[string]bool
@@ -852,14 +854,23 @@ pub mut:
 	// `collect`; no later phase of the check step appends declarations. Phases
 	// after the check (transform) may grow the AST: top_level_idx_nodes_len
 	// records the node count the index covers.
-	top_level_idx           []int
-	top_level_idx_nodes_len int
-	expected_expr_id        int  = -1
-	expected_expr_type      Type = Type(void_)
-	cur_fn_ret_type         Type = Type(void_)
-	channel_send_or_expr_id int  = -1
-	smartcasts              map[string]Type
-	ownership               &OwnershipState = unsafe { nil }
+	top_level_idx                 []int
+	top_level_idx_nodes_len       int
+	expected_expr_id              int  = -1
+	expected_expr_type            Type = Type(void_)
+	cur_fn_ret_type               Type = Type(void_)
+	channel_send_or_expr_id       int  = -1
+	smartcasts                    map[string]Type
+	ownership                     &OwnershipState = unsafe { nil }
+	ownership_return_item_by_name map[string]int
+	ownership_return_edges        []u64
+	ownership_return_current_item int = -1
+	ownership_return_record_calls bool
+	ownership_return_item_changed bool
+	ownership_param_item_by_name  map[string]int
+	ownership_param_changed_items []bool
+	ownership_param_current_item  int = -1
+	ownership_param_track_changes bool
 	// See QualifyNameCache: nil unless armed for a phase whose allocations
 	// outlive every prealloc scope arena; forks must replace it with their own
 	// instance. A long-lived armed cache written during a scoped driver stage
@@ -1360,6 +1371,7 @@ pub fn (tc &TypeChecker) fork_for_parallel_transform(ast &flat.FlatAst) &TypeChe
 	// cloning all maps for every scoped batch dominates self-host memory.
 	forked.transform_signature_maps_shared = true
 	forked.transform_signature_maps_changed = false
+	forked.transform_struct_maps_shared = true
 	// Visible-mutation analysis only runs during checking. Do not allocate its
 	// three private maps for the many short-lived transform forks.
 	forked.visible_mutation_cache = unsafe { nil }
@@ -1430,6 +1442,18 @@ pub fn (mut tc TypeChecker) ensure_private_transform_signatures() {
 // added signature state that its parent must merge.
 pub fn (tc &TypeChecker) transform_signatures_changed() bool {
 	return tc.transform_signature_maps_changed
+}
+
+// ensure_private_transform_structs detaches struct metadata before a transform
+// worker publishes a generated capture context into its private result.
+pub fn (mut tc TypeChecker) ensure_private_transform_structs() {
+	if !tc.transform_struct_maps_shared {
+		return
+	}
+	tc.structs = tc.structs.clone()
+	tc.struct_modules = tc.struct_modules.clone()
+	tc.struct_files = tc.struct_files.clone()
+	tc.transform_struct_maps_shared = false
 }
 
 // freeze_type_cache_for_forks freezes this checker's warm type cache as the
@@ -6160,6 +6184,9 @@ fn (mut tc TypeChecker) register_fn_ancillary_owned(name string, shared_params [
 pub fn (mut tc TypeChecker) register_generated_fn_param_types(name string, params []Type) {
 	tc.fn_param_types[name] = params
 	tc.add_receiver_method_suffix_index(name)
+	if tc.transform_signature_maps_changed {
+		tc.transform_signature_names_log << name
+	}
 }
 
 // rebuild_fn_param_suffix_index refreshes the suffix index after a batch
@@ -6361,27 +6388,89 @@ pub fn (mut tc TypeChecker) annotate_types_with_used(used_fns map[string]bool) {
 			if !tc.should_annotate_fn(node, used_fns) {
 				continue
 			}
-			saved_fn_context := tc.fn_context
-			tc.fn_context = new_function_check_context()
-			tc.fn_context.generic_params = tc.infer_decl_generic_param_names(node)
-			tc.fn_context.return_type = tc.parse_type(node.typ)
-			tc.cur_scope = tc.file_scope
-			tc.push_scope()
-			for pi in 0 .. node.children_count {
-				p := tc.a.child_node(&node, pi)
-				tc.insert_fn_param_binding(p)
-			}
-			tc.insert_implicit_veb_ctx(node)
-			for i in 0 .. node.children_count {
-				child := tc.a.child_node(&node, i)
-				if child.kind != .param {
-					tc.annotate_node(tc.a.child(&node, i))
-				}
-			}
-			tc.pop_scope()
-			tc.fn_context = saved_fn_context
+			tc.annotate_fn_node(node)
 		}
 	}
+}
+
+// annotate_types_with_used_missing_calls revisits only reachable functions
+// containing calls whose checked binding was invalidated by lowering, plus
+// functions synthesized after the source AST. Unchanged calls retain the
+// binding recorded by semantic checking and copied by the transformer.
+pub fn (mut tc TypeChecker) annotate_types_with_used_missing_calls(used_fns map[string]bool, source_node_count int) {
+	tc.extend_node_caches(tc.a.nodes.len)
+	tc.cur_module = ''
+	mut pending := []flat.NodeId{cap: 1024}
+	mut candidate_fns := 0
+	mut annotated_fns := 0
+	mut generated_fns := 0
+	for idx, node in tc.a.nodes {
+		if node.kind == .file {
+			tc.enter_file(node.value)
+		} else if node.kind == .module_decl {
+			tc.enter_module(node.value)
+		} else if node.kind == .fn_decl {
+			candidate_fns++
+			if !tc.should_annotate_fn(node, used_fns)
+				|| (idx < source_node_count && !tc.fn_contains_unresolved_call(node, mut pending)) {
+				continue
+			}
+			annotated_fns++
+			if idx >= source_node_count {
+				generated_fns++
+			}
+			tc.annotate_fn_node(node)
+		}
+	}
+	tc.timing_profile('  [ttime]   annotate candidates ${candidate_fns}, selected ${annotated_fns}, generated ${generated_fns}')
+}
+
+fn (tc &TypeChecker) fn_contains_unresolved_call(root flat.Node, mut pending []flat.NodeId) bool {
+	pending.clear()
+	pending.ensure_cap(root.children_count)
+	for i in 0 .. root.children_count {
+		pending << tc.a.child(&root, i)
+	}
+	for pending.len > 0 {
+		id := pending.pop()
+		idx := int(id)
+		if idx < 0 || idx >= tc.a.nodes.len {
+			continue
+		}
+		node := tc.a.nodes[idx]
+		if node.kind == .call && tc.cached_resolved_call(id) == none {
+			return true
+		}
+		for i in 0 .. node.children_count {
+			pending << tc.a.child(&node, i)
+		}
+	}
+	return false
+}
+
+// annotate_fn_node records contextual types for one function body. The caller
+// owns the function's node range, allowing independent bodies to run in
+// parallel without sharing lexical state.
+fn (mut tc TypeChecker) annotate_fn_node(node flat.Node) {
+	saved_fn_context := tc.fn_context
+	tc.fn_context = new_function_check_context()
+	tc.fn_context.generic_params = tc.infer_decl_generic_param_names(node)
+	tc.fn_context.return_type = tc.parse_type(node.typ)
+	tc.cur_scope = tc.file_scope
+	tc.push_scope()
+	for pi in 0 .. node.children_count {
+		p := tc.a.child_node(&node, pi)
+		tc.insert_fn_param_binding(p)
+	}
+	tc.insert_implicit_veb_ctx(node)
+	for i in 0 .. node.children_count {
+		child := tc.a.child_node(&node, i)
+		if child.kind != .param {
+			tc.annotate_node(tc.a.child(&node, i))
+		}
+	}
+	tc.pop_scope()
+	tc.fn_context = saved_fn_context
 }
 
 // diagnose_unused_private_declarations records notices for unreachable private

--- a/vlib/v3/types/checker_ownership_d_ownership.v
+++ b/vlib/v3/types/checker_ownership_d_ownership.v
@@ -2374,11 +2374,30 @@ fn (mut tc TypeChecker) ownership_register_fn_param_mut_alias(name string, param
 }
 
 fn (mut tc TypeChecker) ownership_prescan_fn_returns(items []OwnershipFnScanItem) {
-	mut changed := true
-	for changed {
-		before := tc.ownership_return_prescan_state_count()
-		changed = false
-		for item in items {
+	if items.len == 0 {
+		return
+	}
+	tc.ownership_return_item_by_name = map[string]int{}
+	for item_idx, item in items {
+		tc.ownership_return_item_by_name[item.name] = item_idx
+	}
+	tc.ownership_return_edges = []u64{cap: items.len * 8}
+	tc.ownership_return_record_calls = true
+	mut pending := []bool{len: items.len, init: true}
+	mut rounds := 0
+	for {
+		rounds++
+		mut scanned_items := 0
+		mut changed_items := []int{}
+		for item_idx := items.len - 1; item_idx >= 0; item_idx-- {
+			if !pending[item_idx] {
+				continue
+			}
+			scanned_items++
+			tc.ownership_return_current_item = item_idx
+			tc.ownership_return_item_changed = false
+			item := items[item_idx]
+			item_before := tc.ownership_return_prescan_fn_state_count(item.name)
 			tc.cur_file = item.file
 			tc.cur_module = item.module
 			node := tc.a.nodes[item.idx]
@@ -2386,31 +2405,53 @@ fn (mut tc TypeChecker) ownership_prescan_fn_returns(items []OwnershipFnScanItem
 				continue
 			}
 			tc.ownership_prescan_fn_return_node(item.name, node)
+			if tc.ownership_return_item_changed
+				|| tc.ownership_return_prescan_fn_state_count(item.name) != item_before {
+				changed_items << item_idx
+			}
 		}
-		changed = tc.ownership_return_prescan_state_count() != before
+		tc.timing_profile('  [ttime]   ownership return round ${rounds}: ${scanned_items} scanned, ${changed_items.len} changed')
+		if changed_items.len == 0 {
+			break
+		}
+		pending = []bool{len: items.len}
+		mut queued := 0
+		mut changed_set := []bool{len: items.len}
+		for changed_idx in changed_items {
+			changed_set[changed_idx] = true
+		}
+		for edge in tc.ownership_return_edges {
+			callee_idx := int(edge >> 32)
+			if !changed_set[callee_idx] {
+				continue
+			}
+			caller_idx := int(edge & 0xffff_ffff)
+			if !pending[caller_idx] {
+				pending[caller_idx] = true
+				queued++
+			}
+		}
+		if queued == 0 {
+			break
+		}
 	}
+	tc.ownership_return_record_calls = false
+	tc.ownership_return_current_item = -1
+	tc.ownership_return_item_by_name = map[string]int{}
+	tc.ownership_return_edges = []u64{}
+	tc.timing_profile('  [ttime]   ownership return prescan ${rounds} rounds')
 }
 
-fn (mut tc TypeChecker) ownership_return_prescan_state_count() int {
+fn (mut tc TypeChecker) ownership_return_prescan_fn_state_count(name string) int {
 	st := tc.ownership_state()
-	mut n := st.ownership_fns.len + st.ownership_fn_return_fn_values.len
-	for _, values in st.ownership_fn_returns_param {
-		n += values.len
-	}
-	for _, values in st.ownership_fn_return_params {
-		n += values.len
-	}
-	for _, values in st.ownership_fn_return_slots {
-		n += values.len
-	}
-	for _, values in st.ownership_fn_return_descs {
-		n += values.len
-	}
-	for _, values in st.ownership_fn_return_param_descs {
-		n += values.len
-	}
-	for _, value in st.ownership_fn_return_fn_values {
-		n += value.len
+	mut n := if name in st.ownership_fns { 1 } else { 0 }
+	n += (st.ownership_fn_returns_param[name] or { []int{} }).len
+	n += (st.ownership_fn_return_params[name] or { []OwnershipReturnParamSlot{} }).len
+	n += (st.ownership_fn_return_slots[name] or { []int{} }).len
+	n += (st.ownership_fn_return_descs[name] or { []OwnershipReturnDescendant{} }).len
+	n += (st.ownership_fn_return_param_descs[name] or { []OwnershipReturnParamDescendant{} }).len
+	if value := st.ownership_fn_return_fn_values[name] {
+		n += 1 + value.len
 	}
 	return n
 }
@@ -2457,8 +2498,15 @@ fn (mut tc TypeChecker) ownership_prescan_fn_return_node(fn_name string, fn_node
 
 fn (mut tc TypeChecker) ownership_prescan_returned_fn_literal(fn_name string, id flat.NodeId, node flat.Node) {
 	literal_name := ownership_fn_literal_name(fn_name, id)
+	if tc.ownership_return_record_calls && tc.ownership_return_current_item >= 0 {
+		tc.ownership_return_item_by_name[literal_name] = tc.ownership_return_current_item
+	}
 	tc.ownership_register_fn_literal_signature(literal_name, node)
+	before := tc.ownership_return_prescan_fn_state_count(literal_name)
 	tc.ownership_prescan_fn_return_node(literal_name, node)
+	if tc.ownership_return_prescan_fn_state_count(literal_name) != before {
+		tc.ownership_return_item_changed = true
+	}
 }
 
 fn (tc &TypeChecker) ownership_fn_name(node flat.Node) string {
@@ -3486,26 +3534,109 @@ fn (mut tc TypeChecker) ownership_add_fn_param_descendant(fn_name string, param_
 	}
 	st.ownership_fn_param_descs[fn_name] = descs
 	st.ownership_fn_param_desc_count++
+	tc.ownership_note_fn_param_change(fn_name)
 }
 
 fn (mut tc TypeChecker) ownership_prescan_owned_call_params(items []OwnershipFnScanItem) {
-	if tc.autofree_mode {
+	if tc.autofree_mode || items.len == 0 {
 		return
 	}
-	mut changed := true
-	for changed {
-		st := tc.ownership_state()
-		before_params := st.ownership_fn_params.len
-		before_descs := st.ownership_fn_param_desc_count
-		changed = false
-		for item in items {
+	tc.ownership_param_item_by_name = map[string]int{}
+	for item_idx, item in items {
+		tc.ownership_param_item_by_name[item.name] = item_idx
+	}
+	// Return inference has already walked every non-void body with the same
+	// owned-call scanner. Seed this fixed point with void bodies (which return
+	// inference skips) and non-void bodies whose parameter ownership changed;
+	// rescanning every non-void body duplicated most of the ownership prescan.
+	mut pending := []bool{len: items.len}
+	mut initial_items := 0
+	for item_idx, item in items {
+		node := tc.a.nodes[item.idx]
+		if node.typ.len == 0 || node.typ == 'void'
+			|| tc.ownership_fn_has_owned_param_state(item.name, node) {
+			pending[item_idx] = true
+			initial_items++
+		}
+	}
+	tc.timing_profile('  [ttime]   ownership params initial ${initial_items}/${items.len} functions')
+	mut rounds := 0
+	for {
+		rounds++
+		tc.ownership_param_changed_items = []bool{len: items.len}
+		tc.ownership_param_track_changes = true
+		mut scanned_items := 0
+		for item_idx, item in items {
+			if !pending[item_idx] {
+				continue
+			}
+			scanned_items++
+			tc.ownership_param_current_item = item_idx
 			tc.cur_file = item.file
 			tc.cur_module = item.module
 			tc.ownership_prescan_fn_owned_call_params(item.name, tc.a.nodes[item.idx])
 		}
-		changed = st.ownership_fn_params.len != before_params
-			|| st.ownership_fn_param_desc_count != before_descs
+		tc.ownership_param_track_changes = false
+		mut changed_items := 0
+		for changed in tc.ownership_param_changed_items {
+			if changed {
+				changed_items++
+			}
+		}
+		tc.timing_profile('  [ttime]   ownership params round ${rounds}: ${scanned_items} scanned, ${changed_items} changed')
+		if changed_items == 0 {
+			break
+		}
+		pending = tc.ownership_param_changed_items.clone()
 	}
+	tc.ownership_param_track_changes = false
+	tc.ownership_param_current_item = -1
+	tc.ownership_param_item_by_name = map[string]int{}
+	tc.ownership_param_changed_items = []bool{}
+	tc.timing_profile('  [ttime]   ownership params prescan ${rounds} rounds')
+}
+
+fn (mut tc TypeChecker) ownership_fn_has_owned_param_state(fn_name string, node flat.Node) bool {
+	st := tc.ownership_state()
+	if descs := st.ownership_fn_param_descs[fn_name] {
+		if descs.len > 0 {
+			return true
+		}
+	}
+	mut param_idx := 0
+	for i in 0 .. node.children_count {
+		if tc.a.child_node(&node, i).kind != .param {
+			continue
+		}
+		if '${fn_name}__param_${param_idx}' in st.ownership_fn_params {
+			return true
+		}
+		param_idx++
+	}
+	return false
+}
+
+fn (mut tc TypeChecker) ownership_note_fn_param_change(fn_name string) {
+	if !tc.ownership_param_track_changes || fn_name.len == 0 {
+		return
+	}
+	item_idx := tc.ownership_param_item_by_name[fn_name] or { return }
+	if item_idx >= 0 && item_idx < tc.ownership_param_changed_items.len {
+		tc.ownership_param_changed_items[item_idx] = true
+	}
+}
+
+fn (mut tc TypeChecker) ownership_mark_fn_param_owned(fn_name string, param_idx int) {
+	if fn_name.len == 0 || param_idx < 0 {
+		return
+	}
+	mut st := tc.ownership_state()
+	key := '${fn_name}__param_${param_idx}'
+	if key in st.ownership_fn_params {
+		return
+	}
+	st.ownership_fn_params[key] = true
+	tc.ownership_note_fn_param_change(fn_name)
 }
 
 fn (mut tc TypeChecker) ownership_prescan_fn_owned_call_params(fn_name string, fn_node flat.Node) {
@@ -3558,6 +3689,9 @@ fn (mut tc TypeChecker) ownership_prescan_fn_literal_owned_call_params(id flat.N
 	before := st.ownership_fn_params.len
 	before_descs := tc.ownership_fn_param_desc_count()
 	fn_name := ownership_fn_literal_name(st.cur_fn, id)
+	if tc.ownership_param_track_changes && tc.ownership_param_current_item >= 0 {
+		tc.ownership_param_item_by_name[fn_name] = tc.ownership_param_current_item
+	}
 	tc.ownership_register_fn_literal_signature(fn_name, node)
 	saved_cur_fn := st.cur_fn
 	saved_fn_value_vars := st.ownership_fn_value_vars.clone()
@@ -4255,9 +4389,7 @@ fn (mut tc TypeChecker) ownership_prescan_call_for_owned_calls(id flat.NodeId, n
 				&& !tc.ownership_method_keeps_receiver(fn_node.value)
 				&& !tc.ownership_array_builtin_keeps_receiver(recv_id, fn_node.value)
 				&& !tc.ownership_string_builtin_keeps_receiver(recv_id, fn_node.value) {
-				if info.name.len > 0 {
-					tc.ownership_state().ownership_fn_params['${info.name}__param_0'] = true
-				}
+				tc.ownership_mark_fn_param_owned(info.name, 0)
 				tc.ownership_prescan_consume_local(recv_id, mut owned_locals)
 			}
 			recv_name := tc.ownership_expr_ident_name(recv_id)
@@ -4318,7 +4450,7 @@ fn (mut tc TypeChecker) ownership_prescan_call_for_owned_calls(id flat.NodeId, n
 				tc.ownership_add_fn_param_descendant(info.name, target_param_idx, target_suffix,
 					arg_type.name())
 			} else {
-				tc.ownership_state().ownership_fn_params['${info.name}__param_${param_idx}'] = true
+				tc.ownership_mark_fn_param_owned(info.name, param_idx)
 			}
 		}
 		tc.ownership_prescan_consume_local(arg_id, mut owned_locals)
@@ -4424,18 +4556,25 @@ fn (mut tc TypeChecker) ownership_prescan_call_info(node flat.Node, local_types 
 		.ident {
 			if mapped := tc.ownership_state().ownership_fn_value_vars[fn_node.value] {
 				if info := tc.ownership_fn_literal_call_info(mapped) {
+					tc.ownership_record_return_dependency(info.name)
 					return info
 				}
 				if mapped in tc.fn_ret_types {
-					return tc.call_info(mapped, false)
+					info := tc.call_info(mapped, false)
+					tc.ownership_record_return_dependency(info.name)
+					return info
 				}
 			}
 			qname := tc.qualify_fn_name(fn_node.value)
 			if qname in tc.fn_ret_types {
-				return tc.call_info(qname, false)
+				info := tc.call_info(qname, false)
+				tc.ownership_record_return_dependency(info.name)
+				return info
 			}
 			if fn_node.value in tc.fn_ret_types {
-				return tc.call_info(fn_node.value, false)
+				info := tc.call_info(fn_node.value, false)
+				tc.ownership_record_return_dependency(info.name)
+				return info
 			}
 		}
 		.selector {
@@ -4449,13 +4588,17 @@ fn (mut tc TypeChecker) ownership_prescan_call_info(node flat.Node, local_types 
 			if resolved_mod := tc.resolve_import_alias(base_node.value) {
 				mod_name := '${resolved_mod}.${fn_node.value}'
 				if mod_name in tc.fn_ret_types {
-					return tc.call_info(mod_name, false)
+					info := tc.call_info(mod_name, false)
+					tc.ownership_record_return_dependency(info.name)
+					return info
 				}
 			}
 			if base_node.value == tc.cur_module {
 				mod_name := '${tc.cur_module}.${fn_node.value}'
 				if mod_name in tc.fn_ret_types {
-					return tc.call_info(mod_name, false)
+					info := tc.call_info(mod_name, false)
+					tc.ownership_record_return_dependency(info.name)
+					return info
 				}
 			}
 			qbase := tc.qualify_name(base_node.value)
@@ -4463,7 +4606,9 @@ fn (mut tc TypeChecker) ownership_prescan_call_info(node flat.Node, local_types 
 			if static_name in tc.fn_ret_types && (qbase in tc.structs
 				|| qbase in tc.enum_names || qbase in tc.sum_types
 				|| qbase in tc.interface_names || qbase in tc.type_aliases) {
-				return tc.call_info(static_name, false)
+				info := tc.call_info(static_name, false)
+				tc.ownership_record_return_dependency(info.name)
+				return info
 			}
 			if recv_type := local_types[base_node.value] {
 				for mname in receiver_method_name_candidates(unwrap_pointer(recv_type),
@@ -4474,7 +4619,9 @@ fn (mut tc TypeChecker) ownership_prescan_call_info(node flat.Node, local_types 
 					if !tc.method_can_be_called_on_receiver(recv_type, fn_node.value, mname) {
 						continue
 					}
-					return tc.call_info(mname, true)
+					info := tc.call_info(mname, true)
+					tc.ownership_record_return_dependency(info.name)
+					return info
 				}
 			}
 		}
@@ -4482,6 +4629,18 @@ fn (mut tc TypeChecker) ownership_prescan_call_info(node flat.Node, local_types 
 	}
 
 	return none
+}
+
+fn (mut tc TypeChecker) ownership_record_return_dependency(callee_name string) {
+	if !tc.ownership_return_record_calls || callee_name.len == 0 {
+		return
+	}
+	caller_idx := tc.ownership_return_current_item
+	if caller_idx < 0 {
+		return
+	}
+	callee_idx := tc.ownership_return_item_by_name[callee_name] or { return }
+	tc.ownership_return_edges << (u64(callee_idx) << 32) | u64(caller_idx)
 }
 
 fn (tc &TypeChecker) ownership_call_arg_shift(node flat.Node, info CallInfo) int {
@@ -6883,6 +7042,7 @@ fn (mut tc TypeChecker) ownership_fn_return_fn_value_from_call(id flat.NodeId) ?
 	if call_name.len == 0 {
 		return none
 	}
+	tc.ownership_record_return_dependency(call_name)
 	fn_value := tc.ownership_state().ownership_fn_return_fn_values[call_name] or { return none }
 	if fn_value.len == 0 {
 		return none

--- a/vlib/v3/types/checker_ownership_d_ownership.v
+++ b/vlib/v3/types/checker_ownership_d_ownership.v
@@ -2524,6 +2524,10 @@ fn (mut tc TypeChecker) ownership_prescan_returns_in(fn_name string, id flat.Nod
 	if node.kind == .defer_stmt {
 		return
 	}
+	if node.kind == .call {
+		_ := tc.ownership_prescan_expr_for_owned_calls(id, mut owned_locals, mut local_types)
+		return
+	}
 	if node.kind == .return_stmt {
 		for i in 0 .. node.children_count {
 			expr_id := tc.a.child(&node, i)

--- a/vlib/v3/types/checker_ownership_d_ownership.v
+++ b/vlib/v3/types/checker_ownership_d_ownership.v
@@ -2570,6 +2570,10 @@ fn (mut tc TypeChecker) ownership_prescan_returns_in(fn_name string, id flat.Nod
 		}
 		return
 	}
+	if node.kind == .expr_stmt {
+		_ := tc.ownership_prescan_expr_for_owned_calls(id, mut owned_locals, mut local_types)
+		return
+	}
 	if node.kind == .block {
 		tc.ownership_prescan_returns_in_sequence(fn_name, node, 0, param_names, mut owned_locals, mut
 			local_types)

--- a/vlib/v3/types/checker_ownership_d_ownership.v
+++ b/vlib/v3/types/checker_ownership_d_ownership.v
@@ -3546,14 +3546,15 @@ fn (mut tc TypeChecker) ownership_prescan_owned_call_params(items []OwnershipFnS
 		tc.ownership_param_item_by_name[item.name] = item_idx
 	}
 	// Return inference has already walked every non-void body with the same
-	// owned-call scanner. Seed this fixed point with void bodies (which return
-	// inference skips) and non-void bodies whose parameter ownership changed;
-	// rescanning every non-void body duplicated most of the ownership prescan.
+	// owned-call scanner, except for deferred bodies. Seed this fixed point with
+	// void bodies, bodies containing defers, and non-void bodies whose parameter
+	// ownership changed; rescanning every other non-void body duplicated most of
+	// the ownership prescan.
 	mut pending := []bool{len: items.len}
 	mut initial_items := 0
 	for item_idx, item in items {
 		node := tc.a.nodes[item.idx]
-		if node.typ.len == 0 || node.typ == 'void'
+		if node.typ.len == 0 || node.typ == 'void' || tc.ownership_node_contains_defer(node)
 			|| tc.ownership_fn_has_owned_param_state(item.name, node) {
 			pending[item_idx] = true
 			initial_items++
@@ -3594,6 +3595,16 @@ fn (mut tc TypeChecker) ownership_prescan_owned_call_params(items []OwnershipFnS
 	tc.ownership_param_item_by_name = map[string]int{}
 	tc.ownership_param_changed_items = []bool{}
 	tc.timing_profile('  [ttime]   ownership params prescan ${rounds} rounds')
+}
+
+fn (tc &TypeChecker) ownership_node_contains_defer(node flat.Node) bool {
+	for i in 0 .. node.children_count {
+		child := tc.a.child_node(&node, i)
+		if child.kind == .defer_stmt || tc.ownership_node_contains_defer(child) {
+			return true
+		}
+	}
+	return false
 }
 
 fn (mut tc TypeChecker) ownership_fn_has_owned_param_state(fn_name string, node flat.Node) bool {


### PR DESCRIPTION
## Summary

This reduces a clean V3 ownership build of the 98,614-line ripgrep.v compilation unit from 1,555 ms to 875 ms median on an Apple M5 Max.

- replace whole-program ownership fixed-point rescans with dependency/change worklists
- retain exact bindings for transformer-generated calls and reannotate only functions with missing bindings
- enable isolated parallel body transforms in generic builds and merge generated signatures/capture contexts deterministically
- cap sub-million-node monomorphization batches at four workers, which is faster and uses less memory on this workload
- give monomorph workers disjoint generated-name ranges and preserve their generated method indexes
- include deferred bodies in the ownership parameter seed set so the reduced worklist remains sound
- prescan ownership-relevant calls reached through statement wrappers before pruning the parameter worklist
- detach master signature maps on first write while parallel generic helpers read the shared base
- detach master closure-capture struct maps on first write as well

## Five-run median by stage

| Stage | master | this PR |
| --- | ---: | ---: |
| Parse setup/cache | 2.3 ms | 2.2 ms |
| Parse V in parallel | 21.8 ms | 20.6 ms |
| Resolve imports | 16.3 ms | 15.4 ms |
| Check in parallel | 399.3 ms | 216.5 ms |
| Ownership (inside check) | 22.2 ms | 18.5 ms |
| Mark used | 26.9 ms | 24.6 ms |
| Transform | 214.8 ms | 116.7 ms |
| Annotate types | 258.3 ms | 23.9 ms |
| Monomorphize | 365.9 ms | 219.1 ms |
| Generate C | 154.0 ms | 141.7 ms |
| TCC | 98.1 ms | 93.9 ms |
| Total | 1,555.2 ms | 874.8 ms |

A separate five-run Hyperfine measurement reports 920.5 +/- 4.4 ms; every run was below one second (915.5-924.4 ms). Peak reported memory remains about 3.62 GB, down from about 8.8 GB on master.

Both compilers were production V3 binaries built with `-prod -gc none -prealloc -d ownership`; targets used `-nocache -d ownership -ownership`, VJOBS=16, and the current ripgrep.v tree.

## Validation

- `v test vlib/v3/transform/transform_parallel_test.v`
- `v test vlib/v3/tests/review_transform_regressions_test.v -run-only test_parallel_*`
- focused ownership tests covering order-independent propagation, deferred-call propagation, and owned returns
- full ownership suite compared with pristine master: both pass all but the same four pre-existing assertions
- ripgrep.v compiles, reports ripgrep 15.1.0, and its sorted output is byte-identical to installed Rust ripgrep for explicit-source and default recursive searches
