### PR TITLE
veb, fasthttp: bind to the configured host instead of the wildcard address

### DIFF
--- a/vlib/fasthttp/fasthttp.v
+++ b/vlib/fasthttp/fasthttp.v
@@ -163,13 +163,66 @@ fn (mut resp HttpResponse) take_request_arena() voidptr {
 	return request_arena
 }
 
+// resolve_bind_addr computes the socket address a fasthttp listener binds to.
+//
+// An empty `host` keeps the historical wildcard bind — 0.0.0.0 for .ip and the
+// dual-stack :: for .ip6 — so existing servers are unaffected. A non-empty
+// `host` is resolved (numeric IPv4/IPv6 literals and host names, via
+// getaddrinfo) and bound explicitly; that is what makes `host: '127.0.0.1'`
+// reachable only on loopback instead of on every interface.
+//
+// The resolved address's family can differ from the requested `family` (e.g. an
+// IPv4 literal while `family` is still the default .ip6), so callers must create
+// the listening socket with `addr.family()`, not the originally requested one.
+fn resolve_bind_addr(host string, family net.AddrFamily, port int) !net.Addr {
+	if host == '' {
+		if family == .ip6 {
+			return net.new_ip6(u16(port), [u8(0), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]!)
+		}
+		return net.new_ip(u16(port), [u8(0), 0, 0, 0]!)
+	}
+	// A bare IPv6 literal must be bracketed so split_address keeps the whole
+	// address instead of treating the last group as a port.
+	saddr := if host.contains(':') && !host.starts_with('[') {
+		'[${host}]:${port}'
+	} else {
+		'${host}:${port}'
+	}
+	// Prefer the requested family, but fall back to any family, so an IPv4/IPv6
+	// literal that does not match the default family still binds as intended.
+	if addrs := net.resolve_addrs(saddr, family, .tcp) {
+		if addrs.len > 0 {
+			return addrs[0]
+		}
+	}
+	addrs := net.resolve_addrs(saddr, .unspec, .tcp) or {
+		return error('could not resolve listen host `${host}`: ${err}')
+	}
+	if addrs.len == 0 {
+		return error('could not resolve listen host `${host}`')
+	}
+	return addrs[0]
+}
+
+// listen_host_display renders the configured host for the "listening on ..."
+// startup line; an empty host is shown as the wildcard 0.0.0.0.
+fn listen_host_display(host string) string {
+	return if host == '' { '0.0.0.0' } else { host }
+}
+
 // ServerConfig bundles the parameters needed to start a fasthttp server.
 pub struct ServerConfig {
 pub:
-	family                  net.AddrFamily = .ip6
-	port                    int            = 3000
-	max_request_buffer_size int            = 8192
-	timeout_in_seconds      int            = 30
+	family net.AddrFamily = .ip6
+	// host is the interface address the listening socket binds to. Empty (the
+	// default) keeps the historical wildcard bind — 0.0.0.0 for .ip and the
+	// dual-stack :: for .ip6 — reachable on every interface. Set it to a
+	// numeric address or host name (e.g. '127.0.0.1') to bind only that
+	// interface. See resolve_bind_addr for the resolution rules.
+	host                    string
+	port                    int = 3000
+	max_request_buffer_size int = 8192
+	timeout_in_seconds      int = 30
 	// handler is the classic contract: it builds and returns a full HttpResponse.
 	// Set exactly ONE of `handler` or `append_handler`.
 	handler   fn (HttpRequest) !HttpResponse = unsafe { nil }

--- a/vlib/fasthttp/fasthttp.v
+++ b/vlib/fasthttp/fasthttp.v
@@ -205,9 +205,20 @@ fn resolve_bind_addr(host string, family net.AddrFamily, port int) !net.Addr {
 }
 
 // listen_host_display renders the configured host for the "listening on ..."
-// startup line; an empty host is shown as the wildcard 0.0.0.0.
-fn listen_host_display(host string) string {
-	return if host == '' { '0.0.0.0' } else { host }
+// startup line as a URL host component. An empty host shows the wildcard the
+// socket actually binds (:: for .ip6, 0.0.0.0 for .ip), and any IPv6 literal is
+// bracketed so the resulting URL is valid (e.g. `http://[::1]:3000/`).
+fn listen_host_display(host string, family net.AddrFamily) string {
+	display_host := if host == '' {
+		if family == .ip6 { '::' } else { '0.0.0.0' }
+	} else {
+		host
+	}
+	return if display_host.contains(':') && !display_host.starts_with('[') {
+		'[${display_host}]'
+	} else {
+		display_host
+	}
 }
 
 // ServerConfig bundles the parameters needed to start a fasthttp server.

--- a/vlib/fasthttp/fasthttp_bind_addr_test.v
+++ b/vlib/fasthttp/fasthttp_bind_addr_test.v
@@ -1,0 +1,58 @@
+module fasthttp
+
+// An empty host must keep the historical wildcard bind, so existing servers
+// that never set a host stay reachable on every interface.
+fn test_empty_host_binds_wildcard() {
+	a6 := resolve_bind_addr('', .ip6, 8081) or {
+		assert false, 'ip6 wildcard failed: ${err}'
+		return
+	}
+	assert a6.family() == .ip6
+	assert a6.str() == '[::]:8081'
+
+	a4 := resolve_bind_addr('', .ip, 8082) or {
+		assert false, 'ip wildcard failed: ${err}'
+		return
+	}
+	assert a4.family() == .ip
+	assert a4.str() == '0.0.0.0:8082'
+}
+
+// An IPv4 literal must bind that address only, even with the default
+// family: .ip6 (the exact configuration from vlang/v issue #28119).
+fn test_ipv4_literal_overrides_default_ip6_family() {
+	a := resolve_bind_addr('127.0.0.1', .ip6, 8083) or {
+		assert false, 'ipv4 literal failed: ${err}'
+		return
+	}
+	assert a.family() == .ip
+	assert a.str() == '127.0.0.1:8083'
+	assert a.port()! == 8083
+}
+
+fn test_ipv4_literal_with_matching_family() {
+	a := resolve_bind_addr('127.0.0.1', .ip, 8084) or {
+		assert false, 'ipv4 literal failed: ${err}'
+		return
+	}
+	assert a.family() == .ip
+	assert a.str() == '127.0.0.1:8084'
+}
+
+// A bare IPv6 literal must be bracketed internally so the whole address is
+// kept and it binds loopback IPv6 only.
+fn test_ipv6_literal_binds_that_address() {
+	a := resolve_bind_addr('::1', .ip6, 8085) or {
+		assert false, 'ipv6 literal failed: ${err}'
+		return
+	}
+	assert a.family() == .ip6
+	assert a.str() == '[::1]:8085'
+	assert a.port()! == 8085
+}
+
+fn test_unresolvable_host_errors() {
+	if _ := resolve_bind_addr('definitely.not.a.real.host.invalid', .ip, 8086) {
+		assert false, 'expected an error for an unresolvable host'
+	}
+}

--- a/vlib/fasthttp/fasthttp_bind_addr_test.v
+++ b/vlib/fasthttp/fasthttp_bind_addr_test.v
@@ -56,3 +56,42 @@ fn test_unresolvable_host_errors() {
 		assert false, 'expected an error for an unresolvable host'
 	}
 }
+
+// The startup "listening on ..." host must be a valid URL host component: the
+// wildcard reflects the family that is actually bound, and IPv6 literals are
+// bracketed.
+fn test_listen_host_display() {
+	assert listen_host_display('', .ip) == '0.0.0.0'
+	assert listen_host_display('', .ip6) == '[::]'
+	assert listen_host_display('127.0.0.1', .ip) == '127.0.0.1'
+	assert listen_host_display('localhost', .ip6) == 'localhost'
+	assert listen_host_display('::1', .ip6) == '[::1]'
+	assert listen_host_display('[::1]', .ip6) == '[::1]'
+}
+
+fn unresolvable_host_handler(_ HttpRequest) !HttpResponse {
+	return HttpResponse{
+		content: 'HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n'.bytes()
+	}
+}
+
+// run() must surface a bind-address resolution failure as an error instead of
+// returning successfully with no listener (regression guard for the Linux path,
+// which previously converted the failure to a bare success return).
+fn test_run_errors_on_unresolvable_host() {
+	mut server := new_server(ServerConfig{
+		family:  .ip
+		host:    'definitely.not.a.real.host.invalid'
+		port:    0
+		handler: unresolvable_host_handler
+	}) or {
+		assert false, 'new_server failed: ${err}'
+		return
+	}
+	server.run() or {
+		// Expected: resolution fails before any listener/worker is created.
+		assert err.msg().len > 0
+		return
+	}
+	assert false, 'run() should have returned an error for an unresolvable host'
+}

--- a/vlib/fasthttp/fasthttp_bsd.c.v
+++ b/vlib/fasthttp/fasthttp_bsd.c.v
@@ -165,6 +165,7 @@ fn (mut c Conn) free_request_arena() {
 pub struct Server {
 pub mut:
 	family                  net.AddrFamily = .ip6
+	host                    string
 	port                    int
 	max_request_buffer_size int = 8192
 	timeout_in_seconds      int = 30
@@ -195,6 +196,7 @@ pub fn new_server(config ServerConfig) !&Server {
 	}
 	mut server := &Server{
 		family:                  config.family
+		host:                    config.host
 		port:                    config.port
 		max_request_buffer_size: config.max_request_buffer_size
 		timeout_in_seconds:      config.timeout_in_seconds
@@ -678,7 +680,11 @@ fn (mut s Server) close_pollers() {
 }
 
 fn create_server_socket(server Server) !int {
-	socket_fd := C.socket(i32(server.family), i32(net.SocketType.tcp), 0)
+	// Resolve the bind address first: the socket family must match the address
+	// family, and a configured host may resolve to a different family than
+	// server.family (e.g. an IPv4 host with the default family: .ip6).
+	addr := resolve_bind_addr(server.host, server.family, server.port)!
+	socket_fd := C.socket(i32(addr.family()), i32(net.SocketType.tcp), 0)
 	if socket_fd < 0 {
 		C.perror(c'socket')
 		return error('socket creation failed')
@@ -689,11 +695,6 @@ fn create_server_socket(server Server) !int {
 		C.perror(c'setsockopt SO_REUSEADDR failed')
 		C.close(socket_fd)
 		return error('setsockopt SO_REUSEADDR failed')
-	}
-	addr := if server.family == .ip6 {
-		net.new_ip6(u16(server.port), [u8(0), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]!)
-	} else {
-		net.new_ip(u16(server.port), [u8(0), 0, 0, 0]!)
 	}
 	alen := addr.len()
 
@@ -839,7 +840,7 @@ pub fn (mut s Server) run() ! {
 	}
 
 	s.mark_running()
-	println('listening on http://0.0.0.0:${s.port}/')
+	println('listening on http://${listen_host_display(s.host)}:${s.port}/')
 
 	for i in 0 .. bsd_thread_pool_size {
 		s.threads[i].wait()

--- a/vlib/fasthttp/fasthttp_bsd.c.v
+++ b/vlib/fasthttp/fasthttp_bsd.c.v
@@ -840,7 +840,7 @@ pub fn (mut s Server) run() ! {
 	}
 
 	s.mark_running()
-	println('listening on http://${listen_host_display(s.host)}:${s.port}/')
+	println('listening on http://${listen_host_display(s.host, s.family)}:${s.port}/')
 
 	for i in 0 .. bsd_thread_pool_size {
 		s.threads[i].wait()

--- a/vlib/fasthttp/fasthttp_bsd_host_bind_test.c.v
+++ b/vlib/fasthttp/fasthttp_bsd_host_bind_test.c.v
@@ -1,0 +1,61 @@
+// vtest build: macos || freebsd || openbsd || netbsd || dragonfly
+module fasthttp
+
+import net
+import net.http
+import time
+
+const host_bind_port = 13037
+
+// Regression test for vlang/v issue #28119: a server configured with
+// host: '127.0.0.1' must bind loopback only, even when family stays at the
+// default .ip6. Previously host was ignored and the socket bound the wildcard
+// address, leaving an "only local" service reachable on every interface.
+fn test_host_binds_loopback_only() {
+	mut server := new_server(ServerConfig{
+		family:                  .ip6 // deliberately the default; host must still win
+		host:                    '127.0.0.1'
+		port:                    host_bind_port
+		timeout_in_seconds:      2
+		max_request_buffer_size: 8192
+		handler:                 host_bind_handler
+	}) or {
+		assert false, 'Failed to create server: ${err}'
+		return
+	}
+	handle := server.handle()
+	spawn server.run()
+	handle.wait_till_running(max_retries: 1000, retry_period_ms: 10) or {
+		assert false, 'server did not start: ${err}'
+		return
+	}
+	defer {
+		handle.shutdown(timeout: 5 * time.second) or {}
+	}
+
+	// The actual bound address of the listening socket must be loopback IPv4,
+	// not the 0.0.0.0 / :: wildcard.
+	bound := net.addr_from_socket_handle(server.socket_fd)
+	assert bound.family() == .ip
+	assert bound.str() == '127.0.0.1:${host_bind_port}'
+
+	// And it must still serve requests on that address.
+	resp := http.fetch(
+		method:                   .get
+		url:                      'http://127.0.0.1:${host_bind_port}/'
+		read_timeout:             2 * time.second
+		write_timeout:            2 * time.second
+		disable_connection_reuse: true
+	) or {
+		assert false, 'loopback request failed: ${err}'
+		return
+	}
+	assert resp.status_code == 200
+	assert resp.body == 'ok'
+}
+
+fn host_bind_handler(req HttpRequest) !HttpResponse {
+	return HttpResponse{
+		content: 'HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok'.bytes()
+	}
+}

--- a/vlib/fasthttp/fasthttp_linux.v
+++ b/vlib/fasthttp/fasthttp_linux.v
@@ -25,9 +25,10 @@ const max_pending_write = 8 * 1024 * 1024
 pub struct Server {
 pub:
 	family                  net.AddrFamily = .ip6
-	port                    int            = 3000
-	max_request_buffer_size int            = 8192
-	timeout_in_seconds      int            = 30
+	host                    string
+	port                    int = 3000
+	max_request_buffer_size int = 8192
+	timeout_in_seconds      int = 30
 	user_data               voidptr
 mut:
 	listen_fds      []int                          = []int{len: max_thread_pool_size, cap: max_thread_pool_size, init: -1}
@@ -57,6 +58,7 @@ pub fn new_server(config ServerConfig) !&Server {
 	}
 	mut server := &Server{
 		family:                  config.family
+		host:                    config.host
 		port:                    config.port
 		max_request_buffer_size: config.max_request_buffer_size
 		timeout_in_seconds:      config.timeout_in_seconds
@@ -147,8 +149,15 @@ fn close_socket(fd int) bool {
 }
 
 fn create_server_socket(server &Server) int {
+	// Resolve the bind address first: the socket family must match the address
+	// family, and a configured host may resolve to a different family than
+	// server.family (e.g. an IPv4 host with the default family: .ip6).
+	addr := resolve_bind_addr(server.host, server.family, server.port) or {
+		eprintln('fasthttp: ${err}')
+		return -1
+	}
 	// Create a socket with non-blocking mode
-	server_fd := C.socket(i32(server.family), i32(net.SocketType.tcp), 0)
+	server_fd := C.socket(i32(addr.family()), i32(net.SocketType.tcp), 0)
 	if server_fd < 0 {
 		eprintln(@LOCATION)
 		C.perror(c'Socket creation failed')
@@ -172,11 +181,6 @@ fn create_server_socket(server &Server) int {
 		return -1
 	}
 
-	addr := if server.family == .ip6 {
-		net.new_ip6(u16(server.port), [u8(0), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]!)
-	} else {
-		net.new_ip(u16(server.port), [u8(0), 0, 0, 0]!)
-	}
 	alen := addr.len()
 	if C.bind(server_fd, voidptr(&addr), alen) < 0 {
 		eprintln(@LOCATION)
@@ -1050,7 +1054,7 @@ pub fn (mut server Server) run() ! {
 	}
 
 	server.mark_running()
-	println('listening on http://0.0.0.0:${server.port}/')
+	println('listening on http://${listen_host_display(server.host)}:${server.port}/')
 	// Main thread waits for workers; accepts are handled in worker epoll loops
 	for i in 0 .. max_thread_pool_size {
 		server.threads[i].wait()

--- a/vlib/fasthttp/fasthttp_linux.v
+++ b/vlib/fasthttp/fasthttp_linux.v
@@ -148,20 +148,18 @@ fn close_socket(fd int) bool {
 	return true
 }
 
-fn create_server_socket(server &Server) int {
-	// Resolve the bind address first: the socket family must match the address
-	// family, and a configured host may resolve to a different family than
-	// server.family (e.g. an IPv4 host with the default family: .ip6).
-	addr := resolve_bind_addr(server.host, server.family, server.port) or {
-		eprintln('fasthttp: ${err}')
-		return -1
-	}
-	// Create a socket with non-blocking mode
+// create_server_socket binds one worker's listening socket to the already
+// resolved `addr` (see resolve_bind_addr). It returns an error rather than -1 so
+// startup failures propagate out of run() instead of being silently swallowed.
+fn create_server_socket(addr net.Addr) !int {
+	// Create a socket with non-blocking mode. The socket family must match the
+	// resolved address family, which may differ from the configured family (e.g.
+	// an IPv4 host with the default family: .ip6).
 	server_fd := C.socket(i32(addr.family()), i32(net.SocketType.tcp), 0)
 	if server_fd < 0 {
 		eprintln(@LOCATION)
 		C.perror(c'Socket creation failed')
-		return -1
+		return error('socket creation failed')
 	}
 
 	set_blocking(server_fd, false)
@@ -172,13 +170,13 @@ fn create_server_socket(server &Server) int {
 		eprintln(@LOCATION)
 		C.perror(c'setsockopt SO_REUSEADDR failed')
 		close_socket(server_fd)
-		return -1
+		return error('setsockopt SO_REUSEADDR failed')
 	}
 	if C.setsockopt(server_fd, C.SOL_SOCKET, C.SO_REUSEPORT, &opt, sizeof(opt)) < 0 {
 		eprintln(@LOCATION)
 		C.perror(c'setsockopt SO_REUSEPORT failed')
 		close_socket(server_fd)
-		return -1
+		return error('setsockopt SO_REUSEPORT failed')
 	}
 
 	alen := addr.len()
@@ -186,13 +184,13 @@ fn create_server_socket(server &Server) int {
 		eprintln(@LOCATION)
 		C.perror(c'Bind failed')
 		close_socket(server_fd)
-		return -1
+		return error('socket bind failed')
 	}
 	if C.listen(server_fd, max_connection_size) < 0 {
 		eprintln(@LOCATION)
 		C.perror(c'Listen failed')
 		close_socket(server_fd)
-		return -1
+		return error('socket listen failed')
 	}
 	return server_fd
 }
@@ -1030,31 +1028,33 @@ pub fn (mut server Server) run() ! {
 		eprintln('Windows is not supported yet')
 		return
 	}
+	// Resolve the bind address once, up front: each worker binds its own
+	// SO_REUSEPORT socket, so resolving per-worker could round-robin a hostname
+	// onto different addresses. Doing it here also lets an invalid/unresolvable
+	// host fail run() instead of silently leaving the server with no listener.
+	addr := resolve_bind_addr(server.host, server.family, server.port)!
 	for i := 0; i < max_thread_pool_size; i++ {
-		server.listen_fds[i] = create_server_socket(server)
-		if server.listen_fds[i] < 0 {
-			return
-		}
+		server.listen_fds[i] = create_server_socket(addr)!
 
 		server.epoll_fds[i] = C.epoll_create1(0)
 		if server.epoll_fds[i] < 0 {
 			C.perror(c'epoll_create1 failed')
 			close_socket(server.listen_fds[i])
-			return
+			return error('epoll_create1 failed')
 		}
 
 		// Register the listening socket with each worker epoll for distributed accepts (edge-triggered)
 		if add_fd_to_epoll(server.epoll_fds[i], server.listen_fds[i], u32(C.EPOLLIN | C.EPOLLET)) == -1 {
 			close_socket(server.listen_fds[i])
 			close_socket(server.epoll_fds[i])
-			return
+			return error('failed to register listener with epoll')
 		}
 
 		server.threads[i] = spawn process_events(server, server.epoll_fds[i], server.listen_fds[i])
 	}
 
 	server.mark_running()
-	println('listening on http://${listen_host_display(server.host)}:${server.port}/')
+	println('listening on http://${listen_host_display(server.host, server.family)}:${server.port}/')
 	// Main thread waits for workers; accepts are handled in worker epoll loops
 	for i in 0 .. max_thread_pool_size {
 		server.threads[i].wait()

--- a/vlib/fasthttp/fasthttp_windows.v
+++ b/vlib/fasthttp/fasthttp_windows.v
@@ -59,9 +59,10 @@ mut:
 pub struct Server {
 pub:
 	family                  net.AddrFamily = .ip6
-	port                    int            = 3000
-	max_request_buffer_size int            = 8192
-	timeout_in_seconds      int            = 30
+	host                    string
+	port                    int = 3000
+	max_request_buffer_size int = 8192
+	timeout_in_seconds      int = 30
 	user_data               voidptr
 mut:
 	listen_fd       C.SOCKET = iocp_invalid_socket
@@ -92,6 +93,7 @@ pub fn new_server(config ServerConfig) !&Server {
 	}
 	mut server := &Server{
 		family:                  config.family
+		host:                    config.host
 		port:                    config.port
 		max_request_buffer_size: config.max_request_buffer_size
 		timeout_in_seconds:      config.timeout_in_seconds
@@ -146,7 +148,11 @@ fn wsa_error_message(label string) string {
 }
 
 fn create_server_socket(server &Server) !C.SOCKET {
-	server_fd := C.WSASocketW(i32(server.family), i32(net.SocketType.tcp), 0, unsafe { nil }, 0,
+	// Resolve the bind address first: the socket family must match the address
+	// family, and a configured host may resolve to a different family than
+	// server.family (e.g. an IPv4 host with the default family: .ip6).
+	addr := resolve_bind_addr(server.host, server.family, server.port)!
+	server_fd := C.WSASocketW(i32(addr.family()), i32(net.SocketType.tcp), 0, unsafe { nil }, 0,
 		u32(C.WSA_FLAG_OVERLAPPED))
 	if server_fd == iocp_invalid_socket {
 		return error(wsa_error_message('WSASocketW'))
@@ -157,17 +163,12 @@ fn create_server_socket(server &Server) !C.SOCKET {
 		close_socket(server_fd)
 		return error(wsa_error_message('setsockopt SO_REUSEADDR'))
 	}
-	if server.family == .ip6 {
+	if addr.family() == .ip6 {
 		ipv6_only := 0
 		C.v_fasthttp_setsockopt(server_fd, C.IPPROTO_IPV6, C.IPV6_V6ONLY, voidptr(&ipv6_only),
 			sizeof(ipv6_only))
 	}
 
-	addr := if server.family == .ip6 {
-		net.new_ip6(u16(server.port), [u8(0), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]!)
-	} else {
-		net.new_ip(u16(server.port), [u8(0), 0, 0, 0]!)
-	}
 	if C.v_fasthttp_bind(server_fd, voidptr(&addr), int(addr.len())) < 0 {
 		close_socket(server_fd)
 		return error(wsa_error_message('bind'))
@@ -822,7 +823,7 @@ pub fn (mut server Server) run() ! {
 	server.threads[max_thread_pool_size] = spawn accept_loop(server)
 
 	server.mark_running()
-	println('listening on http://0.0.0.0:${server.port}/')
+	println('listening on http://${listen_host_display(server.host)}:${server.port}/')
 
 	for i in 0 .. max_thread_pool_size + 1 {
 		server.threads[i].wait()

--- a/vlib/fasthttp/fasthttp_windows.v
+++ b/vlib/fasthttp/fasthttp_windows.v
@@ -823,7 +823,7 @@ pub fn (mut server Server) run() ! {
 	server.threads[max_thread_pool_size] = spawn accept_loop(server)
 
 	server.mark_running()
-	println('listening on http://${listen_host_display(server.host)}:${server.port}/')
+	println('listening on http://${listen_host_display(server.host, server.family)}:${server.port}/')
 
 	for i in 0 .. max_thread_pool_size + 1 {
 		server.threads[i].wait()

--- a/vlib/veb/veb.v
+++ b/vlib/veb/veb.v
@@ -103,6 +103,10 @@ fn startup_host(params RunParams) string {
 	if params.host == '' {
 		return 'localhost'
 	}
+	// Bracket a bare IPv6 literal so the startup URL is valid (e.g. `[::1]`).
+	if params.host.contains(':') && !params.host.starts_with('[') {
+		return '[${params.host}]'
+	}
 	return params.host
 }
 

--- a/vlib/veb/veb_fasthttp.v
+++ b/vlib/veb/veb_fasthttp.v
@@ -97,6 +97,7 @@ pub fn run_new[A, X](mut global_app A, params RunParams) ! {
 	// Configure and run the fasthttp server
 	mut server := fasthttp.new_server(fasthttp.ServerConfig{
 		family:                  params.family
+		host:                    params.host
 		port:                    params.port
 		append_handler:          parallel_append_handler[A, X]
 		max_request_buffer_size: params.max_request_buffer_size


### PR DESCRIPTION
## Fixes #28119

`veb.run_at` / `veb.run` accept a `host:` parameter and the startup log prints it
(e.g. `Running multi-threaded app on http://127.0.0.1:5599/`), but the parallel
**fasthttp** backend ignored it: `create_server_socket` always bound the wildcard
address (`0.0.0.0` / `::`). A service configured with `host: '127.0.0.1'` was still
reachable on every network interface — a security-relevant footgun for admin/debug
services meant to stay loopback-only behind a reverse proxy.

### Root cause
- `fasthttp.ServerConfig` had no `host` field, and `veb`'s fasthttp backend never
  passed `params.host` down.
- `create_server_socket` (BSD/kqueue, Linux/epoll, Windows/IOCP) hardcoded the
  wildcard bind address.
- The backend even printed `listening on http://0.0.0.0:${port}/`, which could
  disagree with veb's own startup line and hide the misconfiguration.

### Fix
- Add a `host` field to `fasthttp.ServerConfig` and to the per-platform `Server`
  structs; wire `params.host` through from `veb.run_new`.
- Add a shared `resolve_bind_addr(host, family, port)` helper:
  - empty `host` → historical wildcard bind (`0.0.0.0` for `.ip`, dual-stack `::`
    for `.ip6`), so **existing servers are unaffected**;
  - non-empty `host` → resolved via `net.resolve_addrs`/getaddrinfo (numeric
    IPv4/IPv6 literals and host names) and bound explicitly.
- The **resolved address's family wins**, so `host: '127.0.0.1'` binds loopback
  IPv4 even with the default `family: .ip6` (the exact config in the issue). All
  three backends now create the listening socket with `addr.family()`.
- The `listening on …` startup line reflects the configured host.

### Verification
Repro from the issue (`host: '127.0.0.1'`, default `family: .ip6`):

Before → `TCP *:5599 (LISTEN)` (all interfaces, IPv6 dual-stack).
After:
```
$ lsof -nP -iTCP:15701 -sTCP:LISTEN
COMMAND   PID USER   FD   TYPE ... NODE NAME
srv     56340 alex    3u  IPv4 ... TCP 127.0.0.1:15701 (LISTEN)
```
The default (no `host`) path still binds the wildcard `*:port`, unchanged.

### Tests
- `fasthttp_bind_addr_test.v` (cross-platform): unit tests for `resolve_bind_addr`
  — wildcard for empty host, IPv4 literal overriding the default `.ip6` family,
  matching-family, IPv6 literal, and unresolvable-host error.
- `fasthttp_bsd_host_bind_test.c.v` (kqueue): end-to-end — a server with
  `host: '127.0.0.1'` and default `family: .ip6` binds loopback-only (verified via
  `getsockname`) and still serves requests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)