### PR TITLE
vdoc, missdoc, cgen, doc: fix packaging/tooling issues (#28115, #28114, #28108)

### DIFF
--- a/cmd/tools/vdoc/main.v
+++ b/cmd/tools/vdoc/main.v
@@ -116,6 +116,7 @@ fn parse_arguments(args []string) Config {
 			}
 			'-theme-dir' {
 				cfg.theme_dir = cmdline.option(current_args, '-theme-dir', default_theme)
+				i++
 			}
 			'-l' {
 				cfg.show_loc = true

--- a/cmd/v/v.v
+++ b/cmd/v/v.v
@@ -115,14 +115,14 @@ fn main() {
 			if os.is_atty(0) == 0 {
 				mut args_and_flags := util.join_env_vflags_and_os_args()[1..].clone()
 				args_and_flags << ['run', '-']
-				pref.parse_args_and_show_errors(external_tools, args_and_flags, true)
+				pref.parse_args_for_launcher(external_tools, args_and_flags, true)
 			}
 		}
 		util.launch_tool(false, 'vrepl', os.args[1..])
 		return
 	}
 	mut args_and_flags := util.join_env_vflags_and_os_args()[1..]
-	prefs, command := pref.parse_args_and_show_errors(external_tools, args_and_flags, true)
+	prefs, command := pref.parse_args_for_launcher(external_tools, args_and_flags, true)
 	maybe_delegate_to_vvmrc(command, prefs)
 	maybe_delegate_to_ownership(command, prefs, args_and_flags)
 	macos_v3_c_error_report := maybe_delegate_to_macos_v3(command, prefs)

--- a/doc/packaging_v_for_distributions.md
+++ b/doc/packaging_v_for_distributions.md
@@ -106,7 +106,7 @@ echo "Alternatively, if you do want a more recent V version, just clone V from s
 echo "then follow the instructions here: https://github.com/vlang/v#installing-v-from-source')" >> cmd/tools/vself.v
 
 v -prod -o v cmd/v                            ## build V itself with -prod
-./v -prod build-tools                         ## build all tools with -prod too
+./v build-tools                               ## build all tools (NB: do *not* pass -prod here; some large tools, like c_builder.v, can exhaust memory during the -prod LTO C compile)
 touch ./cmd/tools/.disable_autorecompilation  ## tell V to not try to recompile any tool anymore
 
 ### Cleanup folders that would not be needed inside a package,

--- a/vlib/v/gen/c/cheaders.v
+++ b/vlib/v/gen/c/cheaders.v
@@ -554,6 +554,17 @@ typedef struct _IO_FILE FILE;
 extern FILE* stdin;
 extern FILE* stdout;
 extern FILE* stderr;
+#if defined(__GLIBC__) || defined(__GNU_LIBRARY__)
+// On glibc, the stdio limit macros (L_tmpnam, FILENAME_MAX, TMP_MAX, ...) are
+// only defined while stdio.h itself is being processed. V declares the stdio
+// functions manually and does not include stdio.h here, so a later include of
+// it from a module header (sqlite3.h, gc.h, ...) can be entered with those
+// macros no longer defined, which breaks the glibc tmpnam prototype (an error
+// about L_tmpnam being undeclared, see vlang/v#28108). Pull stdio.h in up front
+// here, so those macros are defined; the manual prototypes below still
+// redeclare the stdio functions compatibly.
+#include <stdio.h>
+#endif
 	#endif
 typedef __builtin_va_list va_list;
 #ifndef va_start

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -423,6 +423,19 @@ fn optional_arg_value(args []string, idx int, command string, known_external_com
 }
 
 pub fn parse_args_and_show_errors(known_external_commands []string, args []string, show_output bool) (&Preferences, string) {
+	return parse_args_impl(known_external_commands, args, show_output, false)
+}
+
+// parse_args_for_launcher works like parse_args_and_show_errors, but once a known external command
+// (tool) is recognized, every argument after it is left for that tool, instead of being interpreted
+// as a V compiler option here. It is meant for the top level `v` launcher in cmd/v, which forwards
+// the original os.args on to the tool verbatim. Do NOT use it when you actually need the V
+// preferences that follow the command name, for example `v fmt -translated file.v`; see vlang/v#28114.
+pub fn parse_args_for_launcher(known_external_commands []string, args []string, show_output bool) (&Preferences, string) {
+	return parse_args_impl(known_external_commands, args, show_output, true)
+}
+
+fn parse_args_impl(known_external_commands []string, args []string, show_output bool, pass_external_command_args bool) (&Preferences, string) {
 	mut res := &Preferences{}
 	detect_musl(mut res)
 	$if x64 {
@@ -445,6 +458,13 @@ pub fn parse_args_and_show_errors(known_external_commands []string, args []strin
 	mut build_vsh_source := false
 	for i := 0; i < args.len; i++ {
 		arg := args[i]
+		if pass_external_command_args && command_idx < i && command in known_external_commands {
+			// The command is a known external tool, e.g. `missdoc` in `v missdoc -e main`.
+			// Everything after it belongs to that tool, so do not interpret flags like `-e`
+			// as V compiler options here; the launcher (cmd/v) forwards the original os.args
+			// on to the tool verbatim.
+			continue
+		}
 		if inline_icon_path := inline_icon_option_value(arg) {
 			set_icon_path(mut res, inline_icon_path, arg.all_before('='))
 			continue

--- a/vlib/v/pref/pref_test.v
+++ b/vlib/v/pref/pref_test.v
@@ -136,6 +136,33 @@ fn test_profile_flag_still_accepts_explicit_output_file() {
 	assert prefs.profile_file == 'profile.txt'
 }
 
+fn test_launcher_leaves_flags_after_a_known_external_command_for_the_tool() {
+	// Regression test for https://github.com/vlang/v/issues/28114 :
+	// `v missdoc -e main` must not treat `-e` as V's own eval-argument flag.
+	// In launcher mode, everything after a known external command belongs to that tool.
+	prefs, command := pref.parse_args_for_launcher(['missdoc'], ['missdoc', '-r', '-e', 'main',
+		'.'], false)
+	assert command == 'missdoc'
+	assert !prefs.is_eval_argument
+	assert prefs.eval_argument == ''
+}
+
+fn test_non_launcher_parse_keeps_v_flags_after_the_command() {
+	// vfmt and similar tools recognize their own command name (`fmt`), but still rely on the
+	// general V preference flags that follow it. The default parser (non-launcher mode) must
+	// keep interpreting them, so passthrough stays scoped to the `v` launcher; see the review of
+	// vlang/v#28114.
+	translated, cmd1 := pref.parse_args_and_show_errors(['fmt'],
+		['fmt', '-translated', 'generated.v'], false)
+	assert cmd1 == 'fmt'
+	assert translated.translated
+
+	crossos, cmd2 := pref.parse_args_and_show_errors(['fmt'], ['fmt', '-os', 'linux', 'source.v'],
+		false)
+	assert cmd2 == 'fmt'
+	assert crossos.os == .linux
+}
+
 fn new_wasm_preferences() pref.Preferences {
 	return pref.Preferences{
 		backend: .wasm


### PR DESCRIPTION
Fixes three separately reported issues.

### `v doc -theme-dir <dir>` order-dependent (fixes #28115)
The `-theme-dir` case in `cmd/tools/vdoc/main.v` did not advance the argument index past its value, so the directory name was consumed as the input path/symbol filter. `v doc -f html -theme-dir theme main.v -o out` therefore failed with *"No valid V files were found"*, while the same options in a different order worked. Added the missing `i++`.

### `v missdoc -e 'x'` silently ignored (fixes #28114)
`v missdoc -e main` ignored the exclude pattern, while `v missdoc --exclude main` worked. The cause was **not** in `missdoc` or the `flag` module (both handle `-e` correctly) — V's own argument parser interpreted the `-e` *after* the `missdoc` command as its eval-argument flag (`v -e 'code'`) and rewrote the whole invocation into a temp-`.vsh` run before the tool ever saw it.

Fix: once a known external command has been recognized, stop interpreting the following arguments as V compiler flags — the external tool owns its argument space, and `launch_tool` already forwards the original `os.args` verbatim. Added a regression test in `vlib/v/pref/pref_test.v`.

### `vbug-report.v` fails to compile on glibc: `'L_tmpnam' undeclared` (fixes #28108)
Since 0.5.2, V declares the stdio functions manually and no longer includes `<stdio.h>` in its C prelude. On glibc, the stdio limit macros (`L_tmpnam`, `FILENAME_MAX`, `TMP_MAX`, …) are only defined *while `<stdio.h>` is being processed*. When a module header (`sqlite3.h`, `gc.h`, …) later pulls `<stdio.h>` in, it can be entered with those macros no longer defined, breaking glibc's own `tmpnam` prototype:

```
/usr/include/stdio.h:205:27: error: 'L_tmpnam' undeclared here (not in a function)
```

0.5.1 built fine because it always included `<stdio.h>`. This restores that include on the glibc/GNU-libc path only, up front, while keeping the manual prototypes (which redeclare the stdio functions compatibly — exactly as already happens today when a module header includes `<stdio.h>`). Other platforms are unaffected.

### `v -prod build-tools` runs out of memory (addresses #28108)
`build-tools` forwards its leading flags to every tool compile, so `-prod` triggers a per-tool LTO C compile that exhausts memory on the largest generated tools (e.g. `c_builder.v`). Updated `doc/packaging_v_for_distributions.md` to build the tools without `-prod`, matching what downstream packagers already do.

### Verification
- `#28115`: both argument orders now generate docs correctly.
- `#28114`: `-e main` now excludes and `--exclude` still works; `vlib/v/pref` tests pass.
- `#28108` (glibc): the generated Linux C now `#include`s `<stdio.h>` on glibc; the `L_tmpnam` prototype has its macro defined. Manual-decls / shadowed-C-fn tests pass and the macOS build is unchanged (the new include is a no-op off glibc). **The glibc compile itself is left for Linux CI to confirm.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)