### PR TITLE
cgen: define L_tmpnam on glibc instead of including <stdio.h> (follow-up to #28121)

### DIFF
--- a/vlib/v/gen/c/cheaders.v
+++ b/vlib/v/gen/c/cheaders.v
@@ -555,15 +555,16 @@ extern FILE* stdin;
 extern FILE* stdout;
 extern FILE* stderr;
 #if defined(__GLIBC__) || defined(__GNU_LIBRARY__)
-// On glibc, the stdio limit macros (L_tmpnam, FILENAME_MAX, TMP_MAX, ...) are
-// only defined while stdio.h itself is being processed. V declares the stdio
-// functions manually and does not include stdio.h here, so a later include of
-// it from a module header (sqlite3.h, gc.h, ...) can be entered with those
-// macros no longer defined, which breaks the glibc tmpnam prototype (an error
-// about L_tmpnam being undeclared, see vlang/v#28108). Pull stdio.h in up front
-// here, so those macros are defined; the manual prototypes below still
-// redeclare the stdio functions compatibly.
-#include <stdio.h>
+// V declares the stdio functions manually here, instead of including <stdio.h>.
+// glibc defines L_tmpnam only while <stdio.h> is being processed (it sits behind
+// `#ifdef _STDIO_H` in <bits/stdio_lim.h>), and it is the one stdio limit macro that
+// <stdio.h> itself uses in a prototype: char *tmpnam(char[L_tmpnam]). So a <stdio.h>
+// pulled in later by a module header (sqlite3.h, gc.h, ...) can fail with L_tmpnam
+// being undeclared; see vlang/v#28108. Define it here, to the stable glibc value,
+// without adding an include. A later identical redefinition by glibc is a no-op.
+#ifndef L_tmpnam
+#define L_tmpnam 20
+#endif
 #endif
 	#endif
 typedef __builtin_va_list va_list;

--- a/vlib/v/gen/c/cheaders_manual_stdlib_decls_test.v
+++ b/vlib/v/gen/c/cheaders_manual_stdlib_decls_test.v
@@ -340,3 +340,17 @@ fn test_c_prelude_ctype_decls_do_not_conflict_with_later_ctype_includes() {
 	res := os.execute(cmd)
 	assert res.exit_code == 0, '${cmd}\n${res.output}'
 }
+
+fn test_c_prelude_defines_l_tmpnam_on_glibc_without_including_stdio() {
+	// Regression test for https://github.com/vlang/v/issues/28108 :
+	// V does not #include <stdio.h> in its prelude. glibc only defines L_tmpnam while <stdio.h>
+	// is being processed, and uses it in the `tmpnam` prototype, so a <stdio.h> pulled in later by
+	// a module header (sqlite3.h, gc.h, ...) would fail with `L_tmpnam undeclared`. The prelude
+	// therefore defines L_tmpnam itself, on the glibc path, without adding an include.
+	cmd := '${os.quoted_path(cheaders_manual_stdlib_vexe)} -o - ${os.quoted_path(cheaders_manual_stdlib_varargs_source)}'
+	res := os.execute(cmd)
+	assert res.exit_code == 0, '${cmd}\n${res.output}'
+	generated_c := res.output.replace('\r\n', '\n')
+	assert generated_c.contains('#if defined(__GLIBC__) || defined(__GNU_LIBRARY__)'), generated_c
+	assert generated_c.contains('#ifndef L_tmpnam\n#define L_tmpnam 20\n#endif'), generated_c
+}

--- a/vlib/v3/gen/c/preamble_test.v
+++ b/vlib/v3/gen/c/preamble_test.v
@@ -42,3 +42,12 @@ fn test_headerless_libc_preamble_declares_printf_for_cached_test_harnesses() {
 	c_code := g.sb.str()
 	assert c_code.contains('int printf(const char* format, ...);'), c_code
 }
+
+fn test_manual_stdlib_headers_define_l_tmpnam_for_glibc() {
+	// The v3 backend embeds and reuses the v1 c_headers prelude (see manual_stdlib_c_headers).
+	// Make sure the glibc L_tmpnam define is inherited, so a module header that pulls <stdio.h>
+	// in on glibc still finds L_tmpnam; see https://github.com/vlang/v/issues/28108 .
+	headers := manual_stdlib_c_headers()
+	assert headers.contains('#if defined(__GLIBC__) || defined(__GNU_LIBRARY__)'), headers#[-500..]
+	assert headers.contains('#ifndef L_tmpnam\n#define L_tmpnam 20\n#endif'), headers#[-500..]
+}


### PR DESCRIPTION
Follow-up to #28121, which fixed the glibc `error: 'L_tmpnam' undeclared here` build failure (#28108) by re-adding `#include <stdio.h>` on the glibc prelude path.

V tries to include as few system headers as possible, so this replaces that include with a direct macro definition.

### Why just `L_tmpnam`
V declares the stdio functions manually and does not `#include <stdio.h>`. glibc only defines the stdio limit macros while `<stdio.h>` is being processed (they sit behind `#ifdef _STDIO_H` in `<bits/stdio_lim.h>`), and **`L_tmpnam` is the only one of them that `<stdio.h>` itself uses in a declaration**:

```c
extern char *tmpnam (char[L_tmpnam]) __THROW __wur;
```

`FILENAME_MAX`, `TMP_MAX`, `FOPEN_MAX` are only `#define`s for user code — nothing in the tree or the generated C references them — so `L_tmpnam` is the one that must exist when a `<stdio.h>` gets pulled in later by a module header (`sqlite3.h`, `gc.h`, …).

```c
#if defined(__GLIBC__) || defined(__GNU_LIBRARY__)
#ifndef L_tmpnam
#define L_tmpnam 20
#endif
#endif
```

`20` is a stable glibc constant, and glibc's own definition is `#define L_tmpnam 20` (identical), so if `<stdio.h>` is later processed its redefinition is a no-op — no `-Werror` redefinition diagnostic.

### v3 (new compiler)
Verified the three #28121 issues are not a problem for the v3 backend:
- **glibc L_tmpnam**: v3 reuses this same `c_headers` block via `manual_stdlib_c_headers()` (embeds `cheaders.v`), so it inherits the define on its system-libc path; its headerless path never includes `<stdio.h>` at all (it forward-declares the functions it uses). Added a `preamble_test.v` assertion to lock this in.
- **`v doc -theme-dir` / `v missdoc -e`**: `vdoc` and `missdoc` are shared tools; v3 does not reimplement them.
- **`-e` argument passthrough**: v3 has no argument parser of its own — the launcher handling lives in `pref.parse_args_for_launcher()`, which every backend goes through.

### Tests
- `vlib/v/gen/c/cheaders_manual_stdlib_decls_test.v`: asserts the glibc guard + `L_tmpnam` define are in the prelude.
- `vlib/v3/gen/c/preamble_test.v`: asserts the v3 backend inherits the define.

Both pass locally; the actual glibc compile is exercised by the Linux `tools-linux` job (it builds `vbug-report.v`, the original failing case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)