### PR TITLE
orm: strip module prefix from query table names so it matches `create table` (fixes #28106, #28107)

### DIFF
--- a/vlib/orm/orm_func.v
+++ b/vlib/orm/orm_func.v
@@ -786,6 +786,11 @@ fn table_from_struct[T](meta []TableField) Table {
 		}
 	}
 	if !has_custom_table_name {
+		// Strip the module prefix, e.g. `models.SendSMSRequest` -> `SendSMSRequest`, so the table
+		// name matches the one the compiler generates for `sql db { create table ... }` (which uses
+		// util.strip_mod_name). Otherwise inserts/selects would target `models.sendsmsrequest`, while
+		// the table was created as `sendsmsrequest` (see vlang/v#28106, vlang/v#28107).
+		table_name = table_name.all_after_last('.')
 		// Keep default ORM table names aligned with unquoted SQL identifiers across DB drivers.
 		table_name = table_name.to_lower()
 	}

--- a/vlib/orm/orm_module_table_prefix/models/models.v
+++ b/vlib/orm/orm_module_table_prefix/models/models.v
@@ -1,0 +1,9 @@
+module models
+
+pub struct SendSMSRequest {
+pub mut:
+	id     int @[primary; sql: serial]
+	msisdn string
+	msg    string
+	sender string
+}

--- a/vlib/orm/orm_module_table_prefix/orm_module_table_prefix_test.v
+++ b/vlib/orm/orm_module_table_prefix/orm_module_table_prefix_test.v
@@ -1,0 +1,36 @@
+import db.sqlite
+import orm
+import models
+
+// Regression test for https://github.com/vlang/v/issues/28106 and
+// https://github.com/vlang/v/issues/28107 : an ORM struct defined in a module must resolve to the
+// same table name for `create table` (the compiler path) and for the runtime query builder used by
+// inserts/selects. Previously the query builder kept the module prefix (`models.sendsmsrequest`),
+// while `create table` stripped it (`sendsmsrequest`), so inserts failed with a missing relation.
+fn test_module_prefixed_struct_table_name_is_consistent() {
+	mut db := sqlite.connect(':memory:')!
+	defer {
+		db.close() or {}
+	}
+
+	// created as `sendsmsrequest` - the compiler strips the `models.` module prefix
+	sql db {
+		create table models.SendSMSRequest
+	}!
+
+	// the runtime query-builder path from the bug report - it must target the same table
+	first := models.SendSMSRequest{
+		msisdn: '123456'
+		msg:    'Test'
+		sender: 'sender'
+	}
+	mut qb := orm.new_query[models.SendSMSRequest](db)
+	qb.insert(first)!
+
+	rows := sql db {
+		select from models.SendSMSRequest
+	}!
+	assert rows.len == 1
+	assert rows[0].msisdn == '123456'
+	assert rows[0].sender == 'sender'
+}


### PR DESCRIPTION
Fixes #28106 and #28107 (duplicate reports).

### The bug
When an ORM struct is defined in a module, `create table` and the runtime query builder disagree on the table name:

- `sql db { create table models.SendSMSRequest }` creates **`sendsmsrequest`** — the compiler strips the module prefix via `util.strip_mod_name`.
- `orm.new_query[models.SendSMSRequest](db).insert(...)` targets **`models.sendsmsrequest`** — the runtime kept the module prefix, only lowercasing `T.name`.

So inserts/selects fail with `relation "models.sendsmsrequest" does not exist` on PostgreSQL (`no such table: models.sendsmsrequest` on sqlite). Keeping the `.` is also wrong for SQL, where `models.sendsmsrequest` reads as *schema.table*.

### The fix
`vlib/orm/orm_func.v` — in `table_from_struct[T]`, strip the module prefix (`all_after_last('.')`) before lowercasing, so the runtime table name matches what the compiler emits for `create table`:

```v
if !has_custom_table_name {
    table_name = table_name.all_after_last('.')  // models.SendSMSRequest -> SendSMSRequest
    table_name = table_name.to_lower()
}
```

`@[table: '...']` custom names are untouched, and structs in `main` (unqualified `T.name`) are unaffected.

### Test
Added `vlib/orm/orm_module_table_prefix/` — a struct in a `models` submodule, exercised through the exact bug-report flow (compiler `create table` + runtime `new_query.insert` + `select`) on sqlite. It reproduces the mismatch: **without the fix it fails** with `no such table: models.sendsmsrequest`; with the fix it passes. Full `vlib/orm` suite (39 files) stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)