### PR TITLE
v3: add vfmt + `-new-compiler` (in-process V3), fix markused helper pruning

### DIFF
--- a/cmd/v/macos_v3_args.c.v
+++ b/cmd/v/macos_v3_args.c.v
@@ -51,7 +51,9 @@ fn macos_v3_leading_option_consumes_value(option string) bool {
 
 @[markused]
 fn macos_v3_forwarded_args(prefs &pref.Preferences, raw_args []string) []string {
-	mut forwarded_args := raw_args.clone()
+	// `-new-compiler` is consumed by cmd/v to select V3; it must not reach the V3
+	// driver, which is already running and would reject it as an unknown option.
+	mut forwarded_args := raw_args.filter(it != '-new-compiler')
 	if prefs.enable_globals {
 		for i, arg in forwarded_args {
 			if arg == '--enable-globals' {

--- a/cmd/v/macos_v3_args.c.v
+++ b/cmd/v/macos_v3_args.c.v
@@ -6,6 +6,19 @@ import v.pref
 const macos_v3_compat_c99_flag = '-macos-v3-compat-c99'
 const macos_v3_internal_quiet_flag = '-macos-v3-internal-quiet'
 
+// macos_v3_non_compilation_command lists the builtin commands that carry a path
+// (or a directory) but are NOT compilation commands the V3 driver understands —
+// it only knows `run`/`build`/`test`. An unrecognized command token such as
+// `crun` or `build-module` would otherwise become V3's first input path and then
+// collide with the real target. Both dispatch gates exclude these; keep the list
+// in one place so they cannot drift. `test` is handled separately by each gate.
+@[markused]
+fn macos_v3_non_compilation_command(command string) bool {
+	return command in ['build-module', 'crun', 'help', 'version', 'new', 'init', 'install', 'link',
+		'list', 'outdated', 'remove', 'search', 'show', 'unlink', 'update', 'upgrade', 'vlib-docs',
+		'interpret', 'get', 'translate']
+}
+
 // macos_v3_force_requested reports whether `-new-compiler` should hand this
 // invocation to the embedded V3 compiler. It gates on `-old-compiler`
 // precedence, options/modes V3 cannot honor yet, and whether the command is an
@@ -24,7 +37,8 @@ fn macos_v3_force_requested(command string, prefs &pref.Preferences) bool {
 	if prefs.autofree && prefs.is_run {
 		return false
 	}
-	if prefs.path == '' || command == 'test' || command in external_tools {
+	if prefs.path == '' || command == 'test' || macos_v3_non_compilation_command(command)
+		|| command in external_tools {
 		return false
 	}
 	normalized_path := prefs.path.replace('\\', '/').trim_right('/')

--- a/cmd/v/macos_v3_args.c.v
+++ b/cmd/v/macos_v3_args.c.v
@@ -1,9 +1,41 @@
 module main
 
+import os
 import v.pref
 
 const macos_v3_compat_c99_flag = '-macos-v3-compat-c99'
 const macos_v3_internal_quiet_flag = '-macos-v3-internal-quiet'
+
+// macos_v3_force_requested reports whether `-new-compiler` should hand this
+// invocation to the embedded V3 compiler. It gates on `-old-compiler`
+// precedence, options/modes V3 cannot honor yet, and whether the command is an
+// actual compilation command (never `test`, external tools, or the `cmd/v` /
+// `vlib/v3/v3.v` bootstrap). Both the Darwin dispatcher (where it overrides the
+// default heuristic) and the non-macOS dispatcher (where it is the sole gate)
+// rely on it, so it must stay platform neutral.
+@[markused]
+fn macos_v3_force_requested(command string, prefs &pref.Preferences) bool {
+	if !prefs.new_compiler || prefs.old_compiler {
+		return false
+	}
+	if v3_has_v1_only_preferences(prefs) || (prefs.gc_set_by_flag && prefs.gc_mode != .no_gc) {
+		return false
+	}
+	if prefs.autofree && prefs.is_run {
+		return false
+	}
+	if prefs.path == '' || command == 'test' || command in external_tools {
+		return false
+	}
+	normalized_path := prefs.path.replace('\\', '/').trim_right('/')
+	if normalized_path == 'cmd/v' || normalized_path.starts_with('cmd/v/')
+		|| normalized_path.contains('/cmd/v/') || normalized_path.ends_with('/cmd/v')
+		|| normalized_path == 'vlib/v3/v3.v' || normalized_path.ends_with('/vlib/v3/v3.v') {
+		return false
+	}
+	return command in ['run', 'build'] || prefs.is_script || os.is_dir(prefs.path)
+		|| normalized_path.ends_with('.v') || normalized_path.ends_with('.vsh')
+}
 
 // These helpers are shared by the native Darwin dispatcher and the default
 // implementation selected while generating cross-platform VC sources, so this

--- a/cmd/v/macos_v3_darwin.c.v
+++ b/cmd/v/macos_v3_darwin.c.v
@@ -56,33 +56,6 @@ fn maybe_delegate_to_macos_v3(command string, prefs &pref.Preferences) ?MacosV3C
 	return launch_macos_v3_compiler(prefs, forwarded_args)
 }
 
-// macos_v3_force_requested reports whether `-new-compiler` should force the V3
-// compiler for this invocation even when the default heuristic would defer to
-// V1. It never forces V3 onto options or modes V3 cannot handle yet, and it
-// leaves the `test` command to vtest, whose per-file builds already use V3.
-fn macos_v3_force_requested(command string, prefs &pref.Preferences) bool {
-	if !prefs.new_compiler || prefs.old_compiler {
-		return false
-	}
-	if v3_has_v1_only_preferences(prefs) || (prefs.gc_set_by_flag && prefs.gc_mode != .no_gc) {
-		return false
-	}
-	if prefs.autofree && prefs.is_run {
-		return false
-	}
-	if prefs.path == '' || command == 'test' || command in external_tools {
-		return false
-	}
-	normalized_path := prefs.path.replace('\\', '/').trim_right('/')
-	if normalized_path == 'cmd/v' || normalized_path.starts_with('cmd/v/')
-		|| normalized_path.contains('/cmd/v/') || normalized_path.ends_with('/cmd/v')
-		|| normalized_path == 'vlib/v3/v3.v' || normalized_path.ends_with('/vlib/v3/v3.v') {
-		return false
-	}
-	return command in ['run', 'build'] || prefs.is_script || os.is_dir(prefs.path)
-		|| normalized_path.ends_with('.v') || normalized_path.ends_with('.vsh')
-}
-
 fn trace_macos_v3_skip(reason string) {
 	if os.getenv('V3_CACHE_TRACE') != '' {
 		eprintln('  macOS V3 dispatch skipped: ${reason}')

--- a/cmd/v/macos_v3_darwin.c.v
+++ b/cmd/v/macos_v3_darwin.c.v
@@ -31,6 +31,10 @@ fn maybe_delegate_to_macos_v3(command string, prefs &pref.Preferences) ?MacosV3C
 		return take_macos_v3_c_error_report()
 	}
 	if !macos_v3_driver_is_available() {
+		if prefs.new_compiler {
+			eprintln('`-new-compiler` requires a build that embeds the V3 compiler, which this one does not.')
+			exit(1)
+		}
 		return take_macos_v3_c_error_report()
 	}
 	all_args := util.join_env_vflags_and_os_args()
@@ -40,12 +44,43 @@ fn maybe_delegate_to_macos_v3(command string, prefs &pref.Preferences) ?MacosV3C
 		return none
 	}
 	if macos_v3_has_v1_only_leading_option(forwarded_args, command) {
+		if prefs.new_compiler {
+			eprintln('`-new-compiler` cannot be combined with a V1-only option; remove it or drop `-new-compiler`.')
+			exit(1)
+		}
 		return none
 	}
-	if !is_macos_v3_relevant_command(command, prefs) {
+	if !is_macos_v3_relevant_command(command, prefs) && !macos_v3_force_requested(command, prefs) {
 		return none
 	}
 	return launch_macos_v3_compiler(prefs, forwarded_args)
+}
+
+// macos_v3_force_requested reports whether `-new-compiler` should force the V3
+// compiler for this invocation even when the default heuristic would defer to
+// V1. It never forces V3 onto options or modes V3 cannot handle yet, and it
+// leaves the `test` command to vtest, whose per-file builds already use V3.
+fn macos_v3_force_requested(command string, prefs &pref.Preferences) bool {
+	if !prefs.new_compiler || prefs.old_compiler {
+		return false
+	}
+	if v3_has_v1_only_preferences(prefs) || (prefs.gc_set_by_flag && prefs.gc_mode != .no_gc) {
+		return false
+	}
+	if prefs.autofree && prefs.is_run {
+		return false
+	}
+	if prefs.path == '' || command == 'test' || command in external_tools {
+		return false
+	}
+	normalized_path := prefs.path.replace('\\', '/').trim_right('/')
+	if normalized_path == 'cmd/v' || normalized_path.starts_with('cmd/v/')
+		|| normalized_path.contains('/cmd/v/') || normalized_path.ends_with('/cmd/v')
+		|| normalized_path == 'vlib/v3/v3.v' || normalized_path.ends_with('/vlib/v3/v3.v') {
+		return false
+	}
+	return command in ['run', 'build'] || prefs.is_script || os.is_dir(prefs.path)
+		|| normalized_path.ends_with('.v') || normalized_path.ends_with('.vsh')
 }
 
 fn trace_macos_v3_skip(reason string) {
@@ -121,7 +156,12 @@ fn launch_macos_v3_compiler(prefs &pref.Preferences, raw_args []string) ?MacosV3
 	os.rm(fallback_file) or {}
 	c_error_dir := macos_v3_c_error_report_dir(fallback_file)
 	os.rmdir_all(c_error_dir) or {}
-	environment := macos_v3_child_environment(vexe, fallback_file, caller_environment)
+	mut environment := macos_v3_child_environment(vexe, fallback_file, caller_environment)
+	if prefs.new_compiler {
+		// The user explicitly asked for V3, so a V3 failure must be reported
+		// instead of silently retrying the build with the V1 compiler.
+		environment[macos_v3_no_fallback_env] = '1'
+	}
 	replace_macos_v3_process_environment(environment)
 	is_verbose := prefs.is_verbose
 	retry_args := os.args[1..].clone()

--- a/cmd/v/macos_v3_darwin.c.v
+++ b/cmd/v/macos_v3_darwin.c.v
@@ -102,9 +102,7 @@ fn is_macos_v3_relevant_command(command string, prefs &pref.Preferences) bool {
 	if command in external_tools {
 		return false
 	}
-	if command in ['build-module', 'help', 'version', 'new', 'init', 'install', 'link', 'list',
-		'outdated', 'remove', 'search', 'show', 'unlink', 'update', 'upgrade', 'vlib-docs',
-		'interpret', 'get', 'translate', 'crun'] {
+	if macos_v3_non_compilation_command(command) {
 		return false
 	}
 	return command in ['run', 'build', 'test'] || prefs.is_script || os.is_dir(prefs.path)

--- a/cmd/v/macos_v3_default.c.v
+++ b/cmd/v/macos_v3_default.c.v
@@ -1,9 +1,42 @@
 module main
 
+import os
 import v.pref
+import v.util
 
+// On platforms where V3 is not the default compiler, `v` still runs the V1
+// compiler normally. `-new-compiler` opts into the embedded V3 driver and runs
+// it in THIS process, the same way V3 runs by default on macOS.
 fn maybe_delegate_to_macos_v3(command string, prefs &pref.Preferences) ?MacosV3CErrorReport {
+	if prefs.new_compiler {
+		run_new_compiler_in_process(command, prefs)
+	}
 	_ = command
-	_ = prefs
 	return none
+}
+
+// run_new_compiler_in_process compiles with the embedded V3 driver (vlib/v3) in
+// the current process. It never launches a separate `v3` executable and never
+// falls back to V1, so a V3 failure is reported as-is.
+fn run_new_compiler_in_process(command string, prefs &pref.Preferences) {
+	if !macos_v3_driver_is_available() {
+		eprintln('`-new-compiler` requires a build that embeds the V3 compiler, which this one does not.')
+		exit(1)
+	}
+	raw_args := util.join_env_vflags_and_os_args()[1..]
+	if macos_v3_has_v1_only_leading_option(raw_args, command) || v3_has_v1_only_preferences(prefs)
+		|| (prefs.gc_set_by_flag && prefs.gc_mode != .no_gc) || (prefs.autofree && prefs.is_run) {
+		eprintln('`-new-compiler` cannot be combined with a V1-only option or mode; drop `-new-compiler` or the option.')
+		exit(1)
+	}
+	vexe := pref.vexe_path()
+	util.set_vroot_folder(os.dir(vexe))
+	os.setenv('VCHILD', 'true', true)
+	os.setenv('VEXE', os.real_path(vexe), true)
+	forwarded := macos_v3_forwarded_args(prefs, raw_args)
+	if prefs.is_verbose {
+		println('Running V3 compiler in process: ${util.args_quote_paths(forwarded)}')
+	}
+	macos_v3_driver_run(forwarded)
+	exit(0)
 }

--- a/cmd/v/macos_v3_default.c.v
+++ b/cmd/v/macos_v3_default.c.v
@@ -6,29 +6,37 @@ import v.util
 
 // On platforms where V3 is not the default compiler, `v` still runs the V1
 // compiler normally. `-new-compiler` opts into the embedded V3 driver and runs
-// it in THIS process, the same way V3 runs by default on macOS.
+// it in THIS process, the same way V3 runs by default on macOS. It applies the
+// same gating as the Darwin dispatcher: `-old-compiler` wins, V1-only options
+// are rejected, and only actual compilation commands are taken over (never
+// `fmt`, `version`, `test`, external tools, or the compiler bootstrap).
 fn maybe_delegate_to_macos_v3(command string, prefs &pref.Preferences) ?MacosV3CErrorReport {
-	if prefs.new_compiler {
-		run_new_compiler_in_process(command, prefs)
+	if !prefs.new_compiler || prefs.old_compiler {
+		// V1 is the default here, and `-old-compiler` takes precedence.
+		return none
 	}
-	_ = command
+	if !macos_v3_driver_is_available() {
+		eprintln('`-new-compiler` requires a build that embeds the V3 compiler, which this one does not.')
+		exit(1)
+	}
+	raw_args := util.join_env_vflags_and_os_args()[1..]
+	if macos_v3_has_v1_only_leading_option(raw_args, command) {
+		eprintln('`-new-compiler` cannot be combined with a V1-only option; drop `-new-compiler` or the option.')
+		exit(1)
+	}
+	if !macos_v3_force_requested(command, prefs) {
+		// Not a compilation command (`fmt`, `version`, `test`, external tools, ...) or
+		// a V1-only mode: leave it to the normal command routing / V1.
+		return none
+	}
+	run_new_compiler_in_process(prefs, raw_args)
 	return none
 }
 
 // run_new_compiler_in_process compiles with the embedded V3 driver (vlib/v3) in
 // the current process. It never launches a separate `v3` executable and never
 // falls back to V1, so a V3 failure is reported as-is.
-fn run_new_compiler_in_process(command string, prefs &pref.Preferences) {
-	if !macos_v3_driver_is_available() {
-		eprintln('`-new-compiler` requires a build that embeds the V3 compiler, which this one does not.')
-		exit(1)
-	}
-	raw_args := util.join_env_vflags_and_os_args()[1..]
-	if macos_v3_has_v1_only_leading_option(raw_args, command) || v3_has_v1_only_preferences(prefs)
-		|| (prefs.gc_set_by_flag && prefs.gc_mode != .no_gc) || (prefs.autofree && prefs.is_run) {
-		eprintln('`-new-compiler` cannot be combined with a V1-only option or mode; drop `-new-compiler` or the option.')
-		exit(1)
-	}
+fn run_new_compiler_in_process(prefs &pref.Preferences, raw_args []string) {
 	vexe := pref.vexe_path()
 	util.set_vroot_folder(os.dir(vexe))
 	os.setenv('VCHILD', 'true', true)

--- a/cmd/v/macos_v3_driver_notd_cross.v
+++ b/cmd/v/macos_v3_driver_notd_cross.v
@@ -1,17 +1,33 @@
 module main
 
-// The V3 driver (vlib/v3) is linked directly into `cmd/v` for every normal
-// (non cross-VC) build, so `v` can run the V3 compiler in the SAME process — on
-// macOS by default, and on any platform when `-new-compiler` is passed. The
-// cross-VC bootstrap keeps the portable stub in macos_v3_driver_d_cross.v.
-import v3.driver
+// The V3 driver (vlib/v3) is linked directly into `cmd/v` on the target
+// platforms where V3 compiles and runs — macOS (its default compiler) and Linux
+// (exercised by the V3 CI self-host). There `v` can run the V3 compiler in the
+// SAME process: on macOS by default, and on any of those platforms when
+// `-new-compiler` is passed.
+//
+// Other targets (Windows, the BSDs, and the portable `-os cross` VC generation)
+// get the stub below or the one in macos_v3_driver_d_cross.v, so V3's
+// thread/parallel code is never cross-compiled into them; `-new-compiler` then
+// reports that this build does not embed V3.
+$if macos || linux {
+	import v3.driver
 
-@[markused]
-fn macos_v3_driver_is_available() bool {
-	return true
-}
+	@[markused]
+	fn macos_v3_driver_is_available() bool {
+		return true
+	}
 
-@[markused]
-fn macos_v3_driver_run(args []string) {
-	driver.run(args)
+	@[markused]
+	fn macos_v3_driver_run(args []string) {
+		driver.run(args)
+	}
+} $else {
+	@[markused]
+	fn macos_v3_driver_is_available() bool {
+		return false
+	}
+
+	@[markused]
+	fn macos_v3_driver_run(_ []string) {}
 }

--- a/cmd/v/macos_v3_driver_notd_cross.v
+++ b/cmd/v/macos_v3_driver_notd_cross.v
@@ -1,15 +1,17 @@
 module main
 
-$if macos {
-	import v3.driver
+// The V3 driver (vlib/v3) is linked directly into `cmd/v` for every normal
+// (non cross-VC) build, so `v` can run the V3 compiler in the SAME process — on
+// macOS by default, and on any platform when `-new-compiler` is passed. The
+// cross-VC bootstrap keeps the portable stub in macos_v3_driver_d_cross.v.
+import v3.driver
 
-	@[markused]
-	fn macos_v3_driver_is_available() bool {
-		return true
-	}
+@[markused]
+fn macos_v3_driver_is_available() bool {
+	return true
+}
 
-	@[markused]
-	fn macos_v3_driver_run(args []string) {
-		driver.run(args)
-	}
+@[markused]
+fn macos_v3_driver_run(args []string) {
+	driver.run(args)
 }

--- a/cmd/v/macos_v3_test.v
+++ b/cmd/v/macos_v3_test.v
@@ -1654,6 +1654,26 @@ fn test_macos_v3_new_compiler_routing_and_precedence() {
 		new_compiler: true
 		path:         'main_test.v'
 	})
+	// V3 recognizes only run/build/test. Other builtin commands whose token the
+	// launcher turns into a path (crun -> `.v`, build-module -> directory,
+	// interpret/translate -> `.v`) must not be handed to V3, or the command token
+	// becomes its first input path and collides with the real target.
+	assert !macos_v3_force_requested('crun', &pref.Preferences{
+		new_compiler: true
+		path:         'main.v'
+	})
+	assert !macos_v3_force_requested('build-module', &pref.Preferences{
+		new_compiler: true
+		path:         os.temp_dir()
+	})
+	assert !macos_v3_force_requested('interpret', &pref.Preferences{
+		new_compiler: true
+		path:         'main.v'
+	})
+	assert !macos_v3_force_requested('translate', &pref.Preferences{
+		new_compiler: true
+		path:         'main.v'
+	})
 	// `-old-compiler` takes precedence over `-new-compiler`.
 	assert !macos_v3_force_requested('run', &pref.Preferences{
 		new_compiler: true

--- a/cmd/v/macos_v3_test.v
+++ b/cmd/v/macos_v3_test.v
@@ -1603,7 +1603,9 @@ fn test_macos_v3_force_requested_forces_v3_for_compile_targets() {
 fn test_macos_v3_force_requested_respects_hard_limits() {
 	$if macos {
 		// not requested without the flag
-		assert !macos_v3_force_requested('build', &pref.Preferences{ path: 'main.v' })
+		assert !macos_v3_force_requested('build', &pref.Preferences{
+			path: 'main.v'
+		})
 		// `-old-compiler` always wins
 		assert !macos_v3_force_requested('build', &pref.Preferences{
 			new_compiler: true
@@ -1617,8 +1619,8 @@ fn test_macos_v3_force_requested_respects_hard_limits() {
 		})
 		// V3 is never forced onto options it cannot honor yet
 		assert !macos_v3_force_requested('build', &pref.Preferences{
-			new_compiler: true
-			path:         'main.v'
+			new_compiler:   true
+			path:           'main.v'
 			use_coroutines: true
 		})
 	}

--- a/cmd/v/macos_v3_test.v
+++ b/cmd/v/macos_v3_test.v
@@ -1623,3 +1623,45 @@ fn test_macos_v3_force_requested_respects_hard_limits() {
 		})
 	}
 }
+
+// This gate is shared by the Darwin and non-macOS dispatchers, so keep it
+// unguarded: it protects command routing on every platform where `-new-compiler`
+// is accepted.
+fn test_macos_v3_new_compiler_routing_and_precedence() {
+	// Compilation commands are taken over by V3.
+	assert macos_v3_force_requested('run', &pref.Preferences{
+		new_compiler: true
+		path:         'main.v'
+	})
+	assert macos_v3_force_requested('build', &pref.Preferences{
+		new_compiler: true
+		path:         'main.v'
+	})
+	// Non-compilation commands are never handed to V3 as compiler inputs.
+	assert !macos_v3_force_requested('fmt', &pref.Preferences{
+		new_compiler: true
+		path:         'main.v'
+	})
+	assert !macos_v3_force_requested('doc', &pref.Preferences{
+		new_compiler: true
+		path:         'main.v'
+	})
+	assert !macos_v3_force_requested('version', &pref.Preferences{
+		new_compiler: true
+	})
+	// The test command stays with the vtest dispatcher.
+	assert !macos_v3_force_requested('test', &pref.Preferences{
+		new_compiler: true
+		path:         'main_test.v'
+	})
+	// `-old-compiler` takes precedence over `-new-compiler`.
+	assert !macos_v3_force_requested('run', &pref.Preferences{
+		new_compiler: true
+		old_compiler: true
+		path:         'main.v'
+	})
+	// Without the flag, V3 is not forced at all.
+	assert !macos_v3_force_requested('run', &pref.Preferences{
+		path: 'main.v'
+	})
+}

--- a/cmd/v/macos_v3_test.v
+++ b/cmd/v/macos_v3_test.v
@@ -1575,3 +1575,51 @@ fn test_macos_v3_default_executable_excludes_temporary_self_hosted_compilers() {
 		assert !is_macos_v3_default_executable('/tmp/vp')
 	}
 }
+
+fn test_macos_v3_forwarded_args_strip_new_compiler_flag() {
+	$if macos {
+		prefs := &pref.Preferences{}
+		forwarded := macos_v3_forwarded_args(prefs, ['-new-compiler', 'main.v'])
+		assert '-new-compiler' !in forwarded
+		assert 'main.v' in forwarded
+	}
+}
+
+fn test_macos_v3_force_requested_forces_v3_for_compile_targets() {
+	$if macos {
+		build := &pref.Preferences{
+			new_compiler: true
+			path:         'main.v'
+		}
+		assert macos_v3_force_requested('build', build)
+		run := &pref.Preferences{
+			new_compiler: true
+			path:         'main.v'
+		}
+		assert macos_v3_force_requested('run', run)
+	}
+}
+
+fn test_macos_v3_force_requested_respects_hard_limits() {
+	$if macos {
+		// not requested without the flag
+		assert !macos_v3_force_requested('build', &pref.Preferences{ path: 'main.v' })
+		// `-old-compiler` always wins
+		assert !macos_v3_force_requested('build', &pref.Preferences{
+			new_compiler: true
+			old_compiler: true
+			path:         'main.v'
+		})
+		// the `test` command stays with vtest
+		assert !macos_v3_force_requested('test', &pref.Preferences{
+			new_compiler: true
+			path:         'main_test.v'
+		})
+		// V3 is never forced onto options it cannot honor yet
+		assert !macos_v3_force_requested('build', &pref.Preferences{
+			new_compiler: true
+			path:         'main.v'
+			use_coroutines: true
+		})
+	}
+}

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -158,6 +158,7 @@ pub mut:
 	show_depgraph          bool // -show-depgraph, print the program module dependency graph, in a Graphviz DOT format to stdout
 	show_unused_params     bool = true // regular function params should report as unused by default.
 	old_compiler           bool   // `-old-compiler` - bypass experimental compiler dispatchers.
+	new_compiler           bool   // `-new-compiler` - force the experimental V3 compiler and disable the V1 fallback.
 	c_error_bug_report_url string // `-bug-report-url url` - override the automatic C compiler bug report endpoint.
 	dump_c_flags           string // `-dump-c-flags file.txt` - let V store all C flags, passed to the backend C compiler in `file.txt`, one C flag/value per line.
 	dump_modules           string // `-dump-modules modules.txt` - let V store all V modules, that were used by the compiled program in `modules.txt`, one module per line.
@@ -559,6 +560,9 @@ fn parse_args_impl(known_external_commands []string, args []string, show_output 
 			}
 			'-old-compiler' {
 				res.old_compiler = true
+			}
+			'-new-compiler' {
+				res.new_compiler = true
 			}
 			'-checker-fixture', '-macos-v3-compat-c99' {
 				// Passed through to the embedded V3 diagnostic fixture runner.

--- a/vlib/v/pref/pref_test.v
+++ b/vlib/v/pref/pref_test.v
@@ -544,6 +544,15 @@ fn test_old_compiler_flag_is_accepted() {
 	assert '-old-compiler' !in prefs.build_options
 }
 
+fn test_new_compiler_flag_is_accepted() {
+	target := os.join_path(vroot, 'examples', 'hello_world.v')
+	prefs, command := pref.parse_args_and_show_errors([], ['-new-compiler', target], false)
+	assert command == target
+	assert prefs.new_compiler
+	assert !prefs.old_compiler
+	assert '-new-compiler' !in prefs.build_options
+}
+
 fn test_v3_checker_fixture_flag_is_accepted() {
 	target := os.join_path(vroot, 'examples', 'hello_world.v')
 	for flag in ['-checker-fixture', '-macos-v3-compat-c99'] {

--- a/vlib/v3/README.md
+++ b/vlib/v3/README.md
@@ -40,6 +40,18 @@ non-none garbage collectors, sanitizer builds, live reload, and `-autofree run` 
 path until V3 supports their runtime behavior. Pass `-old-compiler` to explicitly select the
 compatibility compiler for another user build. Other operating systems are unchanged.
 
+Pass `-new-compiler` for the opposite: it runs the embedded V3 driver (`vlib/v3`) in the SAME
+process, exactly like the default macOS path — it never launches a separate `v3` executable. On
+macOS it forces V3 for a `run`/`build` target even when the default heuristic would defer to V1;
+on other platforms it opts into V3 (which is otherwise V1 by default). In both cases it disables
+the automatic V1 fallback so a V3 failure is reported instead of silently retried with V1. It
+never forces V3 onto options V3 cannot honor yet (those error asking you to drop the flag), leaves
+the `test` command to the test dispatcher, and errors on builds that do not embed the V3 compiler
+(the portable cross-VC bootstrap). `-old-compiler` takes precedence when both are given.
+
+To make this possible the V3 driver (`vlib/v3`) is linked into `cmd/v` on every normal build, not
+only on macOS, so `v -new-compiler` compiles in-process on all platforms.
+
 The in-process path supports the split module cache and uses parallel stages while the input
 remains within its scratch-memory safety limit.
 

--- a/vlib/v3/driver/cache_prune_test.v
+++ b/vlib/v3/driver/cache_prune_test.v
@@ -88,8 +88,9 @@ int v3_lib_value(void) { return 42; }
 	// The implementation switch is restored after the header expands.
 	assert (include.last_index('#define LIB_IMPL') or { -1 }) > include_pos
 	// A gated external definition is stripped, so splitting the root is safe.
-	assert !cache_native_public_include_replays_external_definition(real_header, ['#define LIB_IMPL'],
-		implementation_macros, []string{}, 'cc', pref.host_target())
+	assert !cache_native_public_include_replays_external_definition(real_header, [
+		'#define LIB_IMPL',
+	], implementation_macros, []string{}, 'cc', pref.host_target())
 }
 
 fn test_cache_native_public_include_replays_unconditional_external_definition() {
@@ -249,8 +250,8 @@ fn test_cache_compiler_macro_probe_uses_implicit_objective_c_language() {
 		assert '__OBJC__' in macros
 		// An Objective-C++ input defines both __OBJC__ and __cplusplus; the probe must
 		// carry __cplusplus so branches guarded by it are not discarded.
-		objc_cpp_macros, objc_cpp_complete := cache_c_compiler_predefined_macros([]string{},
-			'cc', pref.host_target(), 'objective-c++')
+		objc_cpp_macros, objc_cpp_complete := cache_c_compiler_predefined_macros([]string{}, 'cc',
+			pref.host_target(), 'objective-c++')
 		assert objc_cpp_complete
 		assert '__OBJC__' in objc_cpp_macros
 		assert '__cplusplus' in objc_cpp_macros
@@ -388,4 +389,3 @@ fn test_prune_cached_native_function_prototypes_resolves_cache_guards() {
 	assert pruned.contains('int library_api(void);')
 	assert !pruned.contains('V3CACHE_PROGRAM_UNIT')
 }
-

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -2717,8 +2717,8 @@ fn prepare_v3_cache_native_type_declarations(mut state V3ModuleCacheState, c_fla
 					// survive, the owner object (full include) and the program unit's
 					// public replay both define the symbol, so the warm cached link
 					// fails with a duplicate symbol. Fail closed instead of splitting.
-					if cache_native_public_include_replays_external_definition(real_root,
-						context, implementation_macros, c_flags, ccompiler, target)
+					if cache_native_public_include_replays_external_definition(real_root, context,
+						implementation_macros, c_flags, ccompiler, target)
 					{
 						if os.getenv('V3_CACHE_TRACE') != '' {
 							eprintln('  V3 module cache ungated native definition: module=${module_name} path=${real_root}')
@@ -2896,8 +2896,10 @@ fn cache_native_public_include_replays_external_definition(path string, context 
 		target) or { return true }
 	source := os.read_file(os.real_path(path)) or { return true }
 	file_scope := c_source_file_scope_identifiers(source)
-	all_functions, functions_complete := modulecache.c_source_function_identifiers_with_status(preprocessed)
-	static_functions, static_complete := modulecache.c_source_static_function_identifiers_with_status(preprocessed)
+	all_functions, functions_complete :=
+		modulecache.c_source_function_identifiers_with_status(preprocessed)
+	static_functions, static_complete :=
+		modulecache.c_source_static_function_identifiers_with_status(preprocessed)
 	if !functions_complete || !static_complete {
 		return true
 	}

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -6610,6 +6610,11 @@ pub fn run(args []string) {
 		} else if args[i] in ['-strict', '-cstrict'] {
 			is_strict = true
 			i++
+		} else if args[i] == '-new-compiler' {
+			// Accepted for symmetry with cmd/v's `-new-compiler`: V3 is already the
+			// compiler at this point, so selecting it again is a no-op. cmd/v strips
+			// this before forwarding; it is tolerated here for direct V3 invocations.
+			i++
 		} else if args[i] == '-ownership' || args[i] == '--ownership' {
 			// The ownership checker itself is compiled into v3 via `-d ownership`.
 			// The main V launcher pairs this flag with a target `-d ownership`, which

--- a/vlib/v3/gen/v/gen.v
+++ b/vlib/v3/gen/v/gen.v
@@ -1167,12 +1167,15 @@ fn (mut g Gen) match_cond(id flat.NodeId) {
 // (`x := <-ch` / `x = <-ch`) or a plain send/expression condition.
 fn (mut g Gen) select_branch_header(value string, conds []flat.NodeId) {
 	if conds.len == 2 && (value == 'recv' || value == 'recv_assign'
-		|| value.starts_with('recv_compound')) {
+		|| value.starts_with('recv_compound:')) {
 		g.expr(conds[0])
 		if value == 'recv' {
 			g.write(' := ')
-		} else {
+		} else if value == 'recv_assign' {
 			g.write(' = ')
+		} else {
+			// `recv_compound:<op>` preserves a compound receive such as `x += <-ch`.
+			g.write(' ${value.all_after('recv_compound:')} ')
 		}
 		g.expr(conds[1])
 		return

--- a/vlib/v3/gen/v/gen.v
+++ b/vlib/v3/gen/v/gen.v
@@ -1,0 +1,1744 @@
+// Copyright (c) 2020-2024 Joe Conigliaro. All rights reserved.
+// Use of this source code is governed by an MIT license
+// that can be found in the LICENSE file.
+//
+// V source formatter (vfmt) for the v3 flat AST.
+//
+// This is a port of the original v2 `gen/v` tree-AST formatter to v3's flat,
+// node-array AST (see vlib/v3/flat/flat.v). It walks the nodes produced by
+// vlib/v3/parser and reconstructs V source. Formatting is purely syntactic:
+// every type is stored on a node as a `typ` string, so no type checker is
+// required.
+//
+// Known limitations inherited from the flat representation:
+//   - Comments are not part of the flat AST, so they are not reproduced (this
+//     includes `// vfmt off` / `// vfmt on` markers).
+//   - `$if <const/os>` blocks are resolved and folded at parse time, so only
+//     the taken branch survives; they cannot be round-tripped. `comptime_if`
+//     nodes (deferred type/loop conditions) are handled.
+//   - `asm { ... }` and `sql { ... }` bodies are not retained by the parser.
+//   - String quote style and `r`/`c` prefixes are not stored; single quotes
+//     are emitted (contents are re-escaped so the bytes are preserved).
+module v
+
+import strings
+import v3.flat
+
+// Gen holds the formatter state for one output buffer.
+pub struct Gen {
+mut:
+	a          &flat.FlatAst = unsafe { nil }
+	out        strings.Builder
+	indent     int
+	on_newline bool
+	in_init    bool
+	// suppress_mut skips the `mut ` prefix on an assignment (used for C-style
+	// `for` loop init clauses, whose variable the parser always marks mutable).
+	suppress_mut bool
+	// attrs maps a declaration node id to its `@[...]` attribute strings. The
+	// parser stores attributes on a separate floating `.directive` node rather
+	// than as a child, so they are collected up-front in collect_attrs.
+	attrs map[int][]string
+}
+
+// Gen.new returns a fresh formatter.
+pub fn Gen.new() &Gen {
+	return &Gen{
+		out:    strings.new_builder(1000)
+		indent: -1
+	}
+}
+
+// reset clears the buffer so a Gen instance can be reused.
+pub fn (mut g Gen) reset() {
+	g.out.go_back_to(0)
+	g.indent = -1
+	g.on_newline = false
+	g.in_init = false
+}
+
+// format_file parses-independent convenience: format the file whose trailing
+// `.file` node id is `file_id` within `a`.
+pub fn format_file(a &flat.FlatAst, file_id flat.NodeId) string {
+	mut g := Gen.new()
+	return g.gen_file(a, file_id)
+}
+
+// format finds every trailing `.file` node in `a` and formats them in order,
+// separated by a blank line. Useful when a single file was parsed on its own.
+pub fn format(a &flat.FlatAst) string {
+	mut g := Gen.new()
+	mut out := strings.new_builder(1000)
+	mut first := true
+	for id in a.file_node_ids {
+		n := a.node(flat.NodeId(id))
+		if n.kind == .file && n.children_count > 0 {
+			if !first {
+				out.writeln('')
+			}
+			out.write_string(g.gen_file(a, flat.NodeId(id)))
+			first = false
+		}
+	}
+	return out.str()
+}
+
+// gen_file formats the top-level declarations of the given trailing file node.
+pub fn (mut g Gen) gen_file(a &flat.FlatAst, file_id flat.NodeId) string {
+	g.reset()
+	g.a = a
+	g.collect_attrs()
+	fnode := a.node(file_id)
+	g.top_level(a.children_of(fnode))
+	return g.out.str()
+}
+
+// output_string returns the generated V source code.
+pub fn (mut g Gen) output_string() string {
+	return g.out.str()
+}
+
+// collect_attrs indexes every floating attribute directive by the declaration
+// node id it annotates.
+fn (mut g Gen) collect_attrs() {
+	g.attrs = map[int][]string{}
+	for n in g.a.nodes {
+		if n.kind == .directive && n.value.starts_with('@attributes:') {
+			decl_id := n.value.all_after('@attributes:').int()
+			g.attrs[decl_id] = n.generic_params()
+		}
+	}
+}
+
+// top_level renders the file's top-level declarations, inserting a blank line
+// between them (but keeping consecutive imports grouped).
+fn (mut g Gen) top_level(ids []flat.NodeId) {
+	mut decls := []flat.NodeId{}
+	g.collect_top_level(ids, mut decls)
+	mut prev := flat.NodeKind.empty
+	mut wrote_any := false
+	for id in decls {
+		kind := g.a.node(id).kind
+		if wrote_any {
+			if !(prev == .import_decl && kind == .import_decl) {
+				g.writeln('')
+			}
+		}
+		g.indent++
+		g.stmt(id)
+		g.indent--
+		prev = kind
+		wrote_any = true
+	}
+}
+
+// collect_top_level flattens the file's declaration list. A folded top-level
+// `$if` is represented by the parser as a bare `.block` wrapping declarations;
+// its condition is lost, so the members are emitted directly at file scope.
+fn (mut g Gen) collect_top_level(ids []flat.NodeId, mut out []flat.NodeId) {
+	for id in ids {
+		if int(id) < 0 {
+			continue
+		}
+		n := g.a.node(id)
+		if n.kind == .empty {
+			continue
+		}
+		if n.kind == .block {
+			g.collect_top_level(g.a.children_of(n), mut out)
+		} else {
+			out << id
+		}
+	}
+}
+
+// stmt_list_ids renders a list of statements, one indentation level deeper.
+fn (mut g Gen) stmt_list_ids(ids []flat.NodeId) {
+	for id in ids {
+		if int(id) < 0 {
+			continue
+		}
+		if g.a.node(id).kind == .empty {
+			continue
+		}
+		g.indent++
+		g.stmt(id)
+		g.indent--
+	}
+}
+
+fn (mut g Gen) stmt(id flat.NodeId) {
+	if int(id) < 0 {
+		return
+	}
+	n := g.a.node(id)
+	match n.kind {
+		.module_decl {
+			g.writeln('module ${n.value}')
+		}
+		.import_decl {
+			g.import_decl(id)
+		}
+		.fn_decl, .c_fn_decl {
+			g.fn_decl(id)
+		}
+		.struct_decl {
+			g.struct_decl(id)
+		}
+		.enum_decl {
+			g.enum_decl(id)
+		}
+		.type_decl {
+			g.type_decl(id)
+		}
+		.interface_decl {
+			g.interface_decl(id)
+		}
+		.const_decl {
+			g.const_decl(id)
+		}
+		.global_decl {
+			g.global_decl(id)
+		}
+		.directive {
+			g.directive_stmt(id)
+		}
+		.expr_stmt {
+			// some parser artifacts (e.g. around dropped comments) leave an
+			// expr_stmt with no renderable expression; emit nothing for those.
+			before := g.out.len
+			g.expr(g.a.child(n, 0))
+			if g.out.len != before && !g.in_init {
+				g.writeln('')
+			}
+		}
+		.assign, .selector_assign, .index_assign, .decl_assign {
+			g.assign_stmt(id)
+		}
+		.return_stmt {
+			exprs := g.a.children_of(n)
+			if exprs.len == 0 {
+				g.writeln('return')
+			} else {
+				g.write('return ')
+				g.expr_list(exprs, ', ')
+				g.writeln('')
+			}
+		}
+		.block {
+			g.block_stmt(id)
+		}
+		.for_stmt {
+			g.for_stmt(id)
+		}
+		.for_in_stmt {
+			g.for_in_stmt(id)
+		}
+		.break_stmt {
+			g.flow_control('break', n.value)
+		}
+		.continue_stmt {
+			g.flow_control('continue', n.value)
+		}
+		.goto_stmt {
+			g.writeln('goto ${n.value}')
+		}
+		.label_stmt {
+			g.writeln('${n.value}:')
+		}
+		.match_stmt {
+			g.match_node(id)
+			if !g.in_init {
+				g.writeln('')
+			}
+		}
+		.defer_stmt {
+			g.defer_stmt(id)
+		}
+		.assert_stmt {
+			g.assert_stmt(id)
+		}
+		.comptime_if {
+			g.comptime_if(id)
+			if !g.in_init {
+				g.writeln('')
+			}
+		}
+		.comptime_for {
+			g.comptime_for(id)
+			if !g.in_init {
+				g.writeln('')
+			}
+		}
+		.select_stmt {
+			g.select_stmt(id)
+			if !g.in_init {
+				g.writeln('')
+			}
+		}
+		.asm_stmt {
+			g.writeln('asm {')
+			g.writeln('}')
+		}
+		.debugger_stmt {
+			g.writeln('\$dbg')
+		}
+		.if_expr {
+			g.if_expr(id)
+			if !g.in_init {
+				g.writeln('')
+			}
+		}
+		.empty {}
+		else {
+			g.expr(id)
+			if !g.in_init {
+				g.writeln('')
+			}
+		}
+	}
+}
+
+fn (mut g Gen) expr(id flat.NodeId) {
+	if int(id) < 0 {
+		return
+	}
+	n := g.a.node(id)
+	match n.kind {
+		.empty {}
+		.int_literal, .float_literal, .bool_literal {
+			g.write(n.value)
+		}
+		.char_literal {
+			// char values are stored verbatim (escapes not decoded)
+			g.write('`${n.value}`')
+		}
+		.string_literal {
+			g.write(quote_string(n.value))
+		}
+		.string_interp {
+			g.string_interp(id)
+		}
+		.ident {
+			g.write(n.value)
+		}
+		.nil_literal {
+			g.write('nil')
+		}
+		.none_expr {
+			g.write('none')
+		}
+		.enum_val {
+			g.write('.${n.value}')
+		}
+		.infix {
+			g.expr(g.a.child(n, 0))
+			g.write(' ${op_str(n.op)} ')
+			g.expr(g.a.child(n, 1))
+		}
+		.prefix {
+			g.prefix_expr(id)
+		}
+		.postfix {
+			if n.op == .not {
+				g.expr(g.a.child(n, 0))
+				g.write('!')
+			} else {
+				g.expr(g.a.child(n, 0))
+				g.write(op_str(n.op))
+			}
+		}
+		.paren {
+			g.write('(')
+			g.expr(g.a.child(n, 0))
+			g.write(')')
+		}
+		.call {
+			g.call_expr(id)
+		}
+		.selector {
+			g.expr(g.a.child(n, 0))
+			if n.value == '$' {
+				// comptime field access `recv.$(name_expr)`
+				g.write('.\$(')
+				g.expr(g.a.child(n, 1))
+				g.write(')')
+			} else {
+				g.write('.${n.value}')
+			}
+		}
+		.index {
+			g.index_expr(id)
+		}
+		.if_expr {
+			g.if_expr(id)
+		}
+		.match_stmt {
+			g.match_node(id)
+		}
+		.select_stmt {
+			g.select_stmt(id)
+		}
+		.struct_init {
+			g.struct_init(id)
+		}
+		.assoc {
+			g.assoc(id)
+		}
+		.array_literal {
+			g.write('[')
+			g.expr_list(g.a.children_of(n), ', ')
+			g.write(']')
+		}
+		.array_init {
+			g.write(n.typ)
+			g.write('{')
+			g.init_fields(g.a.children_of(n))
+			g.write('}')
+		}
+		.map_init {
+			g.map_init(id)
+		}
+		.field_init {
+			if n.value.len > 0 {
+				g.write('${n.value}: ')
+			}
+			g.expr(g.a.child(n, 0))
+		}
+		.fn_literal {
+			g.fn_literal(id)
+		}
+		.lambda_expr {
+			g.lambda(id)
+		}
+		.or_expr {
+			g.or_expr(id)
+		}
+		.cast_expr {
+			g.write(n.value)
+			g.write('(')
+			g.expr(g.a.child(n, 0))
+			g.write(')')
+		}
+		.as_expr {
+			g.expr(g.a.child(n, 0))
+			g.write(' as ${n.value}')
+		}
+		.is_expr {
+			g.expr(g.a.child(n, 0))
+			g.write(' is ${n.value}')
+		}
+		.in_expr {
+			g.expr(g.a.child(n, 0))
+			g.write(' in ')
+			g.expr(g.a.child(n, 1))
+		}
+		.range {
+			g.expr(g.a.child(n, 0))
+			g.write(' .. ')
+			if n.children_count > 1 {
+				g.expr(g.a.child(n, 1))
+			}
+		}
+		.spawn_expr {
+			g.write('spawn ')
+			g.expr(g.a.child(n, 0))
+		}
+		.lock_expr {
+			g.lock_expr(id)
+		}
+		.sizeof_expr {
+			g.write('sizeof(${n.value})')
+		}
+		.typeof_expr {
+			if n.value.len > 0 {
+				g.write('typeof[${n.value}]()')
+			} else {
+				g.write('typeof(')
+				g.expr(g.a.child(n, 0))
+				g.write(')')
+			}
+		}
+		.dump_expr {
+			g.write('dump(')
+			g.expr(g.a.child(n, 0))
+			g.write(')')
+		}
+		.offsetof_expr {
+			g.write('__offsetof(${n.value}, ${n.typ})')
+		}
+		.block {
+			g.block_expr(id)
+		}
+		.sql_expr {
+			g.sql_expr(id)
+		}
+		.defer_result {
+			if n.value.len > 0 {
+				g.write('\$res(${n.value})')
+			} else {
+				g.write('\$res()')
+			}
+		}
+		else {
+			g.write('/* ${n.kind} */')
+		}
+	}
+}
+
+fn (mut g Gen) prefix_expr(id flat.NodeId) {
+	n := g.a.node(id)
+	child := g.a.child(n, 0)
+	cn := g.a.node(child)
+	// `!is` / `!in` are parsed as a `.not` prefix wrapping the is/in expression.
+	if n.op == .not && cn.kind == .is_expr {
+		g.expr(g.a.child(cn, 0))
+		g.write(' !is ${cn.value}')
+		return
+	}
+	if n.op == .not && cn.kind == .in_expr {
+		g.expr(g.a.child(cn, 0))
+		g.write(' !in ')
+		g.expr(g.a.child(cn, 1))
+		return
+	}
+	if n.value == '...' {
+		g.write('...')
+		g.expr(child)
+		return
+	}
+	if n.value == 'shared' {
+		g.write('shared ')
+		g.expr(child)
+		return
+	}
+	g.write(op_str(n.op))
+	g.expr(child)
+}
+
+fn (mut g Gen) call_expr(id flat.NodeId) {
+	n := g.a.node(id)
+	children := g.a.children_of(n)
+	if children.len == 0 {
+		return
+	}
+	g.expr(children[0])
+	g.write('(')
+	args := children[1..]
+	for i, aid in args {
+		a := g.a.node(aid)
+		if a.is_mut {
+			g.write('mut ')
+		}
+		g.expr(aid)
+		if i < args.len - 1 {
+			g.write(', ')
+		}
+	}
+	g.write(')')
+}
+
+fn (mut g Gen) index_expr(id flat.NodeId) {
+	n := g.a.node(id)
+	children := g.a.children_of(n)
+	if children.len == 0 {
+		return
+	}
+	g.expr(children[0])
+	if n.value == 'range' {
+		g.write('[')
+		if children.len > 1 && int(children[1]) >= 0 {
+			g.expr(children[1])
+		}
+		g.write('..')
+		if children.len > 2 && int(children[2]) >= 0 {
+			g.expr(children[2])
+		}
+		g.write(']')
+		return
+	}
+	gate := if n.op == .gated_index { '#' } else { '' }
+	g.write('${gate}[')
+	g.expr_list(children[1..], ', ')
+	g.write(']')
+}
+
+fn (mut g Gen) struct_init(id flat.NodeId) {
+	n := g.a.node(id)
+	fields := g.a.children_of(n)
+	g.write(n.value)
+	if fields.len == 0 {
+		g.write('{}')
+		return
+	}
+	first := g.a.node(fields[0])
+	if first.value.len > 0 {
+		// named fields, one per line
+		g.writeln('{')
+		in_init := g.in_init
+		g.in_init = true
+		g.indent++
+		for fid in fields {
+			f := g.a.node(fid)
+			g.write('${f.value}: ')
+			g.expr(g.a.child(f, 0))
+			g.writeln('')
+		}
+		g.indent--
+		g.in_init = in_init
+		g.write('}')
+	} else {
+		// positional
+		g.write('{')
+		for i, fid in fields {
+			g.expr(g.a.child(g.a.node(fid), 0))
+			if i < fields.len - 1 {
+				g.write(', ')
+			}
+		}
+		g.write('}')
+	}
+}
+
+fn (mut g Gen) assoc(id flat.NodeId) {
+	n := g.a.node(id)
+	children := g.a.children_of(n)
+	g.write(n.value)
+	g.writeln('{')
+	g.indent++
+	g.write('...')
+	if children.len > 0 {
+		g.expr(children[0])
+	}
+	g.writeln('')
+	for fid in children[1..] {
+		f := g.a.node(fid)
+		g.write('${f.value}: ')
+		g.expr(g.a.child(f, 0))
+		g.writeln('')
+	}
+	g.indent--
+	g.write('}')
+}
+
+fn (mut g Gen) init_fields(ids []flat.NodeId) {
+	for i, fid in ids {
+		f := g.a.node(fid)
+		if f.value.len > 0 {
+			g.write('${f.value}: ')
+		}
+		g.expr(g.a.child(f, 0))
+		if i < ids.len - 1 {
+			g.write(', ')
+		}
+	}
+}
+
+fn (mut g Gen) map_init(id flat.NodeId) {
+	n := g.a.node(id)
+	if n.value.len > 0 {
+		g.write(n.value)
+		g.write('{}')
+		return
+	}
+	children := g.a.children_of(n)
+	if children.len == 0 {
+		g.write('{}')
+		return
+	}
+	g.write('{')
+	mut i := 0
+	for i + 1 < children.len {
+		g.expr(children[i])
+		g.write(': ')
+		g.expr(children[i + 1])
+		if i + 2 < children.len {
+			g.write(', ')
+		}
+		i += 2
+	}
+	g.write('}')
+}
+
+fn (mut g Gen) fn_literal(id flat.NodeId) {
+	n := g.a.node(id)
+	children := g.a.children_of(n)
+	mut i := 0
+	mut captures := []flat.NodeId{}
+	for i < children.len && g.a.node(children[i]).kind == .ident {
+		captures << children[i]
+		i++
+	}
+	mut params := []flat.NodeId{}
+	for i < children.len && g.a.node(children[i]).kind == .param {
+		params << children[i]
+		i++
+	}
+	body := children[i..]
+	g.write('fn')
+	gp := n.generic_params()
+	if gp.len > 0 {
+		g.write('[${gp.join(', ')}]')
+	}
+	if captures.len > 0 {
+		g.write(' [')
+		g.expr_list(captures, ', ')
+		g.write(']')
+	}
+	g.write(' ')
+	g.params(params)
+	if n.typ.len > 0 && n.typ != 'void' {
+		g.write(' ${n.typ}')
+	}
+	g.writeln(' {')
+	g.stmt_list_ids(body)
+	g.write('}')
+}
+
+fn (mut g Gen) lambda(id flat.NodeId) {
+	n := g.a.node(id)
+	children := g.a.children_of(n)
+	if children.len == 0 {
+		g.write('|| ')
+		return
+	}
+	body := children.last()
+	params := children[..children.len - 1]
+	g.write('|')
+	for i, pid in params {
+		p := g.a.node(pid)
+		if p.is_mut {
+			g.write('mut ')
+		}
+		g.write(p.value)
+		if i < params.len - 1 {
+			g.write(', ')
+		}
+	}
+	g.write('| ')
+	g.expr(body)
+}
+
+fn (mut g Gen) or_expr(id flat.NodeId) {
+	n := g.a.node(id)
+	children := g.a.children_of(n)
+	if children.len == 0 {
+		return
+	}
+	if n.value == '!' {
+		g.expr(children[0])
+		g.write('!')
+		return
+	}
+	if n.value == '?' {
+		g.expr(children[0])
+		g.write('?')
+		return
+	}
+	g.expr(children[0])
+	g.write(' or {')
+	if children.len > 1 {
+		blk := g.a.node(children[1])
+		stmts := g.a.children_of(blk)
+		if stmts.len == 0 {
+			g.write('}')
+		} else {
+			g.writeln('')
+			g.stmt_list_ids(stmts)
+			g.write('}')
+		}
+	} else {
+		g.write('}')
+	}
+}
+
+fn (mut g Gen) block_expr(id flat.NodeId) {
+	n := g.a.node(id)
+	stmts := g.a.children_of(n)
+	prefix := if n.value == 'unsafe' { 'unsafe ' } else { '' }
+	if g.in_init || stmts.len <= 1 {
+		g.write('${prefix}{ ')
+		in_init := g.in_init
+		g.in_init = true
+		for s in stmts {
+			g.stmt(s)
+		}
+		g.in_init = in_init
+		g.write(' }')
+	} else {
+		g.writeln('${prefix}{')
+		g.stmt_list_ids(stmts)
+		g.write('}')
+	}
+}
+
+fn (mut g Gen) block_stmt(id flat.NodeId) {
+	n := g.a.node(id)
+	stmts := g.a.children_of(n)
+	prefix := if n.value == 'unsafe' { 'unsafe ' } else { '' }
+	g.writeln('${prefix}{')
+	g.stmt_list_ids(stmts)
+	g.writeln('}')
+}
+
+fn (mut g Gen) lock_expr(id flat.NodeId) {
+	n := g.a.node(id)
+	children := g.a.children_of(n)
+	if children.len == 0 {
+		g.write('lock {')
+		g.write('}')
+		return
+	}
+	body := children.last()
+	objs := children[..children.len - 1]
+	kw := if n.value.starts_with('rlock') { 'rlock' } else { 'lock' }
+	g.write(kw)
+	if objs.len > 0 {
+		g.write(' ')
+		g.expr_list(objs, ', ')
+	}
+	g.writeln(' {')
+	g.stmt_list_ids(g.a.children_of(g.a.node(body)))
+	g.write('}')
+}
+
+fn (mut g Gen) sql_expr(id flat.NodeId) {
+	n := g.a.node(id)
+	g.write('sql')
+	if n.children_count > 0 {
+		g.write(' ')
+		g.expr(g.a.child(n, 0))
+	}
+	g.writeln(' {')
+	g.write('}')
+}
+
+fn (mut g Gen) string_interp(id flat.NodeId) {
+	n := g.a.node(id)
+	children := g.a.children_of(n)
+	// prefer single quotes unless a literal segment contains `'` but no `"`
+	mut has_single := false
+	mut has_double := false
+	for cid in children {
+		c := g.a.node(cid)
+		if c.kind == .string_literal {
+			if c.value.contains("'") {
+				has_single = true
+			}
+			if c.value.contains('"') {
+				has_double = true
+			}
+		}
+	}
+	quote := if has_single && !has_double { `"` } else { `'` }
+	quote_str := if quote == `"` { '"' } else { "'" }
+	g.write(quote_str)
+	for cid in children {
+		c := g.a.node(cid)
+		if c.kind == .string_literal {
+			g.write(escape_string(c.value, quote))
+		} else if c.kind == .directive && c.value == 'string_interp_format' {
+			g.write('\${')
+			g.expr(g.a.child(c, 0))
+			g.write(':${c.typ}')
+			g.write('}')
+		} else {
+			g.write('\${')
+			g.expr(cid)
+			g.write('}')
+		}
+	}
+	g.write(quote_str)
+}
+
+fn (mut g Gen) assign_stmt(id flat.NodeId) {
+	n := g.a.node(id)
+	children := g.a.children_of(n)
+	if children.len == 0 {
+		return
+	}
+	is_decl := n.kind == .decl_assign
+	opstr := if is_decl { ':=' } else { op_str(n.op) }
+	modifier, count := parse_assign_meta(n.value)
+	if modifier.len > 0 {
+		g.write('${modifier} ')
+	}
+	if n.is_mut && !g.suppress_mut {
+		g.write('mut ')
+	}
+	if count <= 1 {
+		g.expr(children[0])
+		g.write(' ${opstr} ')
+		g.expr_list(children[1..], ', ')
+	} else {
+		mut lhs := []flat.NodeId{}
+		mut rhs := []flat.NodeId{}
+		for i, c in children {
+			if i % 2 == 0 {
+				lhs << c
+			} else {
+				rhs << c
+			}
+		}
+		g.expr_list(lhs, ', ')
+		g.write(' ${opstr} ')
+		g.expr_list(rhs, ', ')
+	}
+	if !g.in_init {
+		g.writeln('')
+	}
+}
+
+fn (mut g Gen) flow_control(kw string, label string) {
+	if label.len > 0 {
+		g.writeln('${kw} ${label}')
+	} else {
+		g.writeln(kw)
+	}
+}
+
+fn (mut g Gen) for_stmt(id flat.NodeId) {
+	n := g.a.node(id)
+	children := g.a.children_of(n)
+	init := if children.len > 0 { children[0] } else { flat.empty_node }
+	cond := if children.len > 1 { children[1] } else { flat.empty_node }
+	post := if children.len > 2 { children[2] } else { flat.empty_node }
+	body := if children.len > 3 { children[3..] } else { []flat.NodeId{} }
+	in_init := g.in_init
+	g.in_init = true
+	g.write('for')
+	if n.value == 'c_style' {
+		g.write(' ')
+		if !g.is_empty(init) {
+			g.suppress_mut = true
+			g.stmt(init)
+			g.suppress_mut = false
+		}
+		g.write('; ')
+		if !g.is_empty(cond) {
+			g.expr(cond)
+		}
+		g.write('; ')
+		if !g.is_empty(post) {
+			g.stmt(post)
+		}
+		g.write(' ')
+	} else if !g.is_empty(cond) {
+		g.write(' ')
+		g.expr(cond)
+		g.write(' ')
+	} else {
+		g.write(' ')
+	}
+	g.in_init = in_init
+	g.writeln('{')
+	g.stmt_list_ids(body)
+	g.writeln('}')
+}
+
+fn (mut g Gen) for_in_stmt(id flat.NodeId) {
+	n := g.a.node(id)
+	children := g.a.children_of(n)
+	if children.len < 3 {
+		g.writeln('for {')
+		g.writeln('}')
+		return
+	}
+	header := if n.value.len > 0 { n.value.int() } else { 3 }
+	v0 := children[0]
+	v1 := children[1]
+	mut_val := n.op == .amp
+	g.write('for ')
+	if g.is_empty(v1) {
+		if mut_val {
+			g.write('mut ')
+		}
+		g.expr(v0)
+	} else {
+		g.expr(v0)
+		g.write(', ')
+		if mut_val {
+			g.write('mut ')
+		}
+		g.expr(v1)
+	}
+	g.write(' in ')
+	mut body_start := 3
+	if header >= 4 && children.len >= 4 {
+		g.expr(children[2])
+		g.write(' .. ')
+		g.expr(children[3])
+		body_start = 4
+	} else {
+		g.expr(children[2])
+	}
+	body := unsafe { children[body_start..] }
+	g.writeln(' {')
+	g.stmt_list_ids(body)
+	g.writeln('}')
+}
+
+fn (mut g Gen) if_expr(id flat.NodeId) {
+	n := g.a.node(id)
+	children := g.a.children_of(n)
+	if children.len < 2 {
+		return
+	}
+	cond := children[0]
+	cn := g.a.node(cond)
+	g.write('if ')
+	in_init := g.in_init
+	g.in_init = true
+	if cn.kind == .decl_assign {
+		g.stmt(cond)
+	} else {
+		g.expr(cond)
+	}
+	g.in_init = in_init
+	g.write(' ')
+	then_blk := g.a.node(children[1])
+	g.writeln('{')
+	g.stmt_list_ids(g.a.children_of(then_blk))
+	g.write('}')
+	if children.len > 2 {
+		else_id := children[2]
+		en := g.a.node(else_id)
+		if en.kind == .if_expr {
+			g.write(' else ')
+			g.if_expr(else_id)
+		} else {
+			g.writeln(' else {')
+			g.stmt_list_ids(g.a.children_of(en))
+			g.write('}')
+		}
+	}
+}
+
+fn (mut g Gen) match_node(id flat.NodeId) {
+	n := g.a.node(id)
+	children := g.a.children_of(n)
+	if children.len == 0 {
+		return
+	}
+	g.write('match ')
+	in_init := g.in_init
+	g.in_init = true
+	g.expr(children[0])
+	g.in_init = in_init
+	g.writeln(' {')
+	g.indent++
+	for bid in children[1..] {
+		b := g.a.node(bid)
+		bchildren := g.a.children_of(b)
+		if b.value == 'else' {
+			g.write('else')
+			g.writeln(' {')
+			g.stmt_list_ids(bchildren)
+			g.writeln('}')
+		} else {
+			ncond := b.value.int()
+			conds := if ncond <= bchildren.len { bchildren[..ncond] } else { bchildren }
+			rest := if ncond <= bchildren.len { bchildren[ncond..] } else { []flat.NodeId{} }
+			for i, c in conds {
+				if i > 0 {
+					g.write(', ')
+				}
+				g.match_cond(c)
+			}
+			g.writeln(' {')
+			g.stmt_list_ids(rest)
+			g.writeln('}')
+		}
+	}
+	g.indent--
+	g.write('}')
+}
+
+fn (mut g Gen) defer_stmt(id flat.NodeId) {
+	n := g.a.node(id)
+	g.writeln('defer {')
+	if n.children_count > 0 {
+		blk := g.a.child_node(n, 0)
+		g.stmt_list_ids(g.a.children_of(blk))
+	}
+	g.writeln('}')
+}
+
+fn (mut g Gen) assert_stmt(id flat.NodeId) {
+	n := g.a.node(id)
+	children := g.a.children_of(n)
+	if children.len == 0 {
+		return
+	}
+	g.write('assert ')
+	in_init := g.in_init
+	g.in_init = true
+	g.expr(children[0])
+	g.in_init = in_init
+	if children.len > 1 {
+		g.write(', ')
+		g.expr(children[1])
+	}
+	if !g.in_init {
+		g.writeln('')
+	}
+}
+
+fn (mut g Gen) comptime_if(id flat.NodeId) {
+	n := g.a.node(id)
+	children := g.a.children_of(n)
+	g.write('\$if ${n.value} {')
+	g.writeln('')
+	if children.len > 0 {
+		then_blk := g.a.node(children[0])
+		g.stmt_list_ids(g.a.children_of(then_blk))
+	}
+	g.write('}')
+	if children.len > 1 {
+		el := g.a.node(children[1])
+		if el.kind == .comptime_if {
+			g.write(' \$else ')
+			g.comptime_if(children[1])
+		} else {
+			g.writeln(' \$else {')
+			g.stmt_list_ids(g.a.children_of(el))
+			g.write('}')
+		}
+	}
+}
+
+fn (mut g Gen) comptime_for(id flat.NodeId) {
+	n := g.a.node(id)
+	parts := n.value.split('|')
+	loopvar := if parts.len > 0 { parts[0] } else { 'x' }
+	kind := if parts.len > 1 { parts[1] } else { 'fields' }
+	g.write('\$for ${loopvar} in ${n.typ}.${kind} {')
+	g.writeln('')
+	if n.children_count > 0 {
+		blk := g.a.child_node(n, 0)
+		g.stmt_list_ids(g.a.children_of(blk))
+	}
+	g.write('}')
+}
+
+fn (mut g Gen) select_stmt(id flat.NodeId) {
+	n := g.a.node(id)
+	g.writeln('select {')
+	g.indent++
+	for bid in g.a.children_of(n) {
+		b := g.a.node(bid)
+		bchildren := g.a.children_of(b)
+		if b.value == 'else' {
+			g.write('else')
+			g.writeln(' {')
+			g.stmt_list_ids(bchildren)
+			g.writeln('}')
+			continue
+		}
+		ncond := select_branch_cond_count(b.value)
+		conds := if ncond <= bchildren.len { bchildren[..ncond] } else { bchildren }
+		rest := if ncond <= bchildren.len { bchildren[ncond..] } else { []flat.NodeId{} }
+		g.select_branch_header(b.value, conds)
+		g.writeln(' {')
+		g.stmt_list_ids(rest)
+		g.writeln('}')
+	}
+	g.indent--
+	g.write('}')
+}
+
+// match_cond renders a match branch condition. A type pattern such as `[]T` or
+// `map[K]V` is parsed as an empty composite-literal node; emit it as a bare type
+// (without the `{}`) so it is not mistaken for the branch body.
+fn (mut g Gen) match_cond(id flat.NodeId) {
+	n := g.a.node(id)
+	if n.kind == .array_init && n.children_count == 0 && n.typ.len > 0 {
+		g.write(n.typ)
+		return
+	}
+	if n.kind == .map_init && n.children_count == 0 && n.value.len > 0 {
+		g.write(n.value)
+		return
+	}
+	g.expr(id)
+}
+
+// select_branch_header renders a select branch's guard: a receive binding
+// (`x := <-ch` / `x = <-ch`) or a plain send/expression condition.
+fn (mut g Gen) select_branch_header(value string, conds []flat.NodeId) {
+	if conds.len == 2 && (value == 'recv' || value == 'recv_assign'
+		|| value.starts_with('recv_compound')) {
+		g.expr(conds[0])
+		if value == 'recv' {
+			g.write(' := ')
+		} else {
+			g.write(' = ')
+		}
+		g.expr(conds[1])
+		return
+	}
+	g.expr_list(conds, ' ')
+}
+
+// Declarations ---------------------------------------------------------------
+
+fn (mut g Gen) import_decl(id flat.NodeId) {
+	n := g.a.node(id)
+	g.write('import ${n.value}')
+	last_seg := n.value.all_after_last('.')
+	if n.typ.len > 0 && n.typ != last_seg {
+		g.write(' as ${n.typ}')
+	}
+	symbols := g.a.children_of(n)
+	if symbols.len > 0 {
+		g.write(' { ')
+		g.expr_list(symbols, ', ')
+		g.write(' }')
+	}
+	g.writeln('')
+}
+
+fn (mut g Gen) fn_decl(id flat.NodeId) {
+	n := g.a.node(id)
+	g.emit_attrs(id)
+	if n.op == .arrow {
+		g.write('pub ')
+	}
+	children := g.a.children_of(n)
+	mut i := 0
+	mut params := []flat.NodeId{}
+	for i < children.len && g.a.node(children[i]).kind == .param {
+		params << children[i]
+		i++
+	}
+	body := children[i..]
+	mut recv := flat.empty_node
+	if params.len > 0 && g.a.node(params[0]).op == .dot {
+		recv = params[0]
+		params = unsafe { params[1..] }
+	}
+	g.write('fn ')
+	name := n.value
+	if int(recv) >= 0 {
+		rn := g.a.node(recv)
+		g.write('(')
+		if rn.is_mut {
+			g.write('mut ')
+		}
+		g.write(rn.value)
+		g.write(' ')
+		g.write(g.receiver_type(rn))
+		g.write(') ')
+		g.write(name.all_after_last('.'))
+	} else if n.kind == .c_fn_decl {
+		g.write('C.${name}')
+	} else {
+		g.write(name)
+	}
+	gp := n.generic_params()
+	if gp.len > 0 {
+		g.write('[${gp.join(', ')}]')
+	}
+	g.params(params)
+	if n.typ.len > 0 && n.typ != 'void' {
+		g.write(' ${n.typ}')
+	}
+	if n.kind == .c_fn_decl {
+		g.writeln('')
+		return
+	}
+	g.writeln(' {')
+	g.stmt_list_ids(body)
+	g.writeln('}')
+}
+
+fn (mut g Gen) params(ids []flat.NodeId) {
+	g.write('(')
+	for i, pid in ids {
+		p := g.a.node(pid)
+		if p.is_mut {
+			g.write('mut ')
+		}
+		if p.value.len > 0 {
+			g.write(p.value)
+			g.write(' ')
+		}
+		g.write(g.param_type(p))
+		if i < ids.len - 1 {
+			g.write(', ')
+		}
+	}
+	g.write(')')
+}
+
+fn (g &Gen) param_type(p &flat.Node) string {
+	mut t := p.typ
+	if p.is_mut && p.op != .amp && t.starts_with('&') {
+		t = t[1..]
+	}
+	return t
+}
+
+fn (g &Gen) receiver_type(rn &flat.Node) string {
+	mut t := rn.typ
+	if rn.is_mut && t.starts_with('&') {
+		t = t[1..]
+	}
+	return t
+}
+
+fn (mut g Gen) struct_decl(id flat.NodeId) {
+	n := g.a.node(id)
+	g.emit_attrs(id)
+	if n.op == .arrow {
+		g.write('pub ')
+	}
+	tags := n.typ
+	kw := if tag_has(tags, 'union') { 'union ' } else { 'struct ' }
+	g.write(kw)
+	g.write(n.value)
+	gp := n.generic_params()
+	if gp.len > 0 {
+		g.write('[${gp.join(', ')}]')
+	}
+	impls := tag_value(tags, 'implements')
+	if impls.len > 0 {
+		g.write(' implements ${impls.replace('|', ', ')}')
+	}
+	g.struct_fields(g.a.children_of(n))
+}
+
+fn (mut g Gen) struct_fields(fields []flat.NodeId) {
+	if fields.len > 0 {
+		g.writeln(' {')
+	} else {
+		g.write(' {')
+	}
+	g.indent++
+	mut cur_access := ''
+	for fid in fields {
+		f := g.a.node(fid)
+		if f.kind != .field_decl {
+			// e.g. a `$if` block inside the struct body
+			g.stmt(fid)
+			continue
+		}
+		gp := f.generic_params()
+		flags := if gp.len > 0 { gp[0] } else { '' }
+		access := access_label(flags)
+		if access != cur_access {
+			// access specifiers sit one level out from the fields they head
+			g.indent--
+			match access {
+				'mut' { g.writeln('mut:') }
+				'pub' { g.writeln('pub:') }
+				'pub mut' { g.writeln('pub mut:') }
+				else {}
+			}
+			g.indent++
+			cur_access = access
+		}
+		is_embed := f.value == f.typ && f.children_count == 0
+		if is_embed {
+			g.write(f.value)
+		} else {
+			g.write(f.value)
+			g.write(' ')
+			g.write(f.typ)
+			if f.children_count > 0 {
+				g.write(' = ')
+				g.expr(g.a.child(f, 0))
+			}
+		}
+		if gp.len > 1 {
+			g.write(' @[${gp[1..].join('; ')}]')
+		}
+		g.writeln('')
+	}
+	g.indent--
+	g.writeln('}')
+}
+
+fn (mut g Gen) enum_decl(id flat.NodeId) {
+	n := g.a.node(id)
+	g.emit_attrs(id)
+	if n.op == .arrow {
+		g.write('pub ')
+	}
+	g.write('enum ${n.value}')
+	gp := n.generic_params()
+	if gp.len > 0 && gp[0].len > 0 {
+		g.write(' as ${gp[0]}')
+	}
+	g.writeln(' {')
+	g.indent++
+	for fid in g.a.children_of(n) {
+		f := g.a.node(fid)
+		g.write(f.value)
+		if f.children_count > 0 {
+			g.write(' = ')
+			g.expr(g.a.child(f, 0))
+		}
+		fattrs := f.generic_params()
+		if fattrs.len > 0 {
+			g.write(' @[${fattrs.join('; ')}]')
+		}
+		g.writeln('')
+	}
+	g.indent--
+	g.writeln('}')
+}
+
+fn (mut g Gen) type_decl(id flat.NodeId) {
+	n := g.a.node(id)
+	g.emit_attrs(id)
+	if n.op == .arrow {
+		g.write('pub ')
+	}
+	g.write('type ${n.value}')
+	gp := n.generic_params()
+	if gp.len > 0 {
+		g.write('[${gp.join(', ')}]')
+	}
+	variants := g.a.children_of(n)
+	if variants.len > 0 {
+		g.write(' = ')
+		for i, vid in variants {
+			g.write(g.a.node(vid).value)
+			if i < variants.len - 1 {
+				g.write(' | ')
+			}
+		}
+	} else if n.typ.len > 0 {
+		g.write(' = ${n.typ}')
+	}
+	g.writeln('')
+}
+
+fn (mut g Gen) interface_decl(id flat.NodeId) {
+	n := g.a.node(id)
+	g.emit_attrs(id)
+	if n.op == .arrow {
+		g.write('pub ')
+	}
+	g.write('interface ${n.value}')
+	gp := n.generic_params()
+	if gp.len > 0 {
+		g.write('[${gp.join(', ')}]')
+	}
+	g.writeln(' {')
+	g.indent++
+	mut cur_mut := false
+	for fid in g.a.children_of(n) {
+		f := g.a.node(fid)
+		if f.is_mut != cur_mut {
+			if f.is_mut {
+				g.indent--
+				g.writeln('mut:')
+				g.indent++
+			}
+			cur_mut = f.is_mut
+		}
+		if f.op == .dot {
+			// method
+			g.write(f.value)
+			mgp := f.generic_params()
+			if mgp.len > 0 {
+				g.write('[${mgp.join(', ')}]')
+			}
+			g.params(g.a.children_of(f))
+			if f.typ.len > 0 {
+				g.write(' ${f.typ}')
+			}
+		} else {
+			g.write(f.value)
+			if f.typ.len > 0 {
+				g.write(' ${f.typ}')
+			}
+		}
+		g.writeln('')
+	}
+	g.indent--
+	g.writeln('}')
+}
+
+fn (mut g Gen) const_decl(id flat.NodeId) {
+	n := g.a.node(id)
+	g.emit_attrs(id)
+	pub_prefix := if n.op == .arrow { 'pub ' } else { '' }
+	fields := g.a.children_of(n)
+	if fields.len == 1 {
+		f := g.a.node(fields[0])
+		g.write('${pub_prefix}const ${f.value}')
+		if f.children_count > 0 {
+			g.write(' = ')
+			g.expr(g.a.child(f, 0))
+		} else if f.typ.len > 0 {
+			g.write(' ${f.typ}')
+		}
+		g.writeln('')
+		return
+	}
+	g.writeln('${pub_prefix}const (')
+	g.indent++
+	for fid in fields {
+		f := g.a.node(fid)
+		g.write('${f.value} = ')
+		g.expr(g.a.child(f, 0))
+		g.writeln('')
+	}
+	g.indent--
+	g.writeln(')')
+}
+
+fn (mut g Gen) global_decl(id flat.NodeId) {
+	n := g.a.node(id)
+	g.emit_attrs(id)
+	group_pub := n.op == .arrow
+	if group_pub {
+		g.write('pub ')
+	}
+	g.writeln('__global (')
+	g.indent++
+	for fid in g.a.children_of(n) {
+		f := g.a.node(fid)
+		if f.op == .arrow && !group_pub {
+			g.write('pub ')
+		}
+		if 'const' in f.generic_params() {
+			g.write('const ')
+		}
+		g.write(f.value)
+		if f.children_count > 0 {
+			if f.typ.len > 0 {
+				g.write(' ${f.typ}')
+			}
+			g.write(' = ')
+			g.expr(g.a.child(f, 0))
+		} else {
+			g.write(' ${f.typ}')
+		}
+		g.writeln('')
+	}
+	g.indent--
+	g.writeln(')')
+}
+
+fn (mut g Gen) directive_stmt(id flat.NodeId) {
+	n := g.a.node(id)
+	if n.value.starts_with('@attributes:') || n.value == 'string_interp_format' {
+		return
+	}
+	g.write('#${n.value}')
+	if n.typ.len > 0 {
+		g.write(' ${n.typ}')
+	}
+	g.writeln('')
+}
+
+fn (mut g Gen) emit_attrs(id flat.NodeId) {
+	attrs := g.attrs[int(id)] or { []string{} }
+	if attrs.len > 0 {
+		g.writeln('@[${attrs.join('; ')}]')
+	}
+}
+
+// Helpers --------------------------------------------------------------------
+
+fn (mut g Gen) expr_list(ids []flat.NodeId, sep string) {
+	mut first := true
+	for id in ids {
+		if int(id) < 0 {
+			continue
+		}
+		if !first {
+			g.write(sep)
+		}
+		g.expr(id)
+		first = false
+	}
+}
+
+fn (g &Gen) is_empty(id flat.NodeId) bool {
+	if int(id) < 0 {
+		return true
+	}
+	return g.a.node(id).kind == .empty
+}
+
+@[inline]
+fn (mut g Gen) write(str string) {
+	if g.on_newline && g.indent > 0 {
+		for _ in 0 .. g.indent {
+			g.out.write_u8(`\t`)
+		}
+	}
+	g.out.write_string(str)
+	g.on_newline = false
+}
+
+@[inline]
+fn (mut g Gen) writeln(str string) {
+	if g.on_newline && g.indent > 0 {
+		for _ in 0 .. g.indent {
+			g.out.write_u8(`\t`)
+		}
+	}
+	g.out.writeln(str)
+	g.on_newline = true
+}
+
+// op_str returns the source spelling of a flat operator.
+fn op_str(op flat.Op) string {
+	return match op {
+		.none { '' }
+		.plus { '+' }
+		.minus { '-' }
+		.mul { '*' }
+		.div { '/' }
+		.mod { '%' }
+		.eq { '==' }
+		.ne { '!=' }
+		.lt { '<' }
+		.gt { '>' }
+		.le { '<=' }
+		.ge { '>=' }
+		.amp { '&' }
+		.pipe { '|' }
+		.xor { '^' }
+		.left_shift { '<<' }
+		.right_shift { '>>' }
+		.right_shift_unsigned { '>>>' }
+		.logical_and { '&&' }
+		.logical_or { '||' }
+		.not { '!' }
+		.bit_not { '~' }
+		.assign { '=' }
+		.plus_assign { '+=' }
+		.minus_assign { '-=' }
+		.mul_assign { '*=' }
+		.div_assign { '/=' }
+		.mod_assign { '%=' }
+		.amp_assign { '&=' }
+		.pipe_assign { '|=' }
+		.xor_assign { '^=' }
+		.left_shift_assign { '<<=' }
+		.right_shift_assign { '>>=' }
+		.right_shift_unsigned_assign { '>>>=' }
+		.inc { '++' }
+		.dec { '--' }
+		.dot { '.' }
+		.arrow { '<-' } // channel send/receive
+		.gated_index { '#' }
+		.power { '**' }
+		.power_assign { '**=' }
+	}
+}
+
+// quote_string wraps a decoded string-literal value in quotes, preferring
+// single quotes and falling back to double quotes when the value contains a
+// `'` but no `"`. The contents are re-escaped because the parser stores fully
+// decoded values.
+fn quote_string(s string) string {
+	if s.contains("'") && !s.contains('"') {
+		return '"${escape_string(s, `"`)}"'
+	}
+	return "'${escape_string(s, `'`)}'"
+}
+
+// escape_string re-escapes a decoded string/char value for emission inside a
+// literal delimited by `quote`. `$` is always escaped so a literal dollar is
+// never reinterpreted as interpolation.
+fn escape_string(s string, quote u8) string {
+	mut b := strings.new_builder(s.len + 8)
+	for c in s {
+		match c {
+			`\\` { b.write_string('\\\\') }
+			`$` { b.write_string('\\\$') }
+			`\n` { b.write_string('\\n') }
+			`\r` { b.write_string('\\r') }
+			`\t` { b.write_string('\\t') }
+			0 { b.write_string('\\0') }
+			else {
+				if c == quote {
+					b.write_u8(`\\`)
+				}
+				b.write_u8(c)
+			}
+		}
+	}
+	return b.str()
+}
+
+// access_label maps a struct field flag code (from generic_params()[0]) to its
+// section keyword. Codes: `m`=mut, `p`=pub (order is mut-then-pub).
+fn access_label(flags string) string {
+	has_mut := flags.contains('m')
+	has_pub := flags.contains('p')
+	if has_pub && has_mut {
+		return 'pub mut'
+	}
+	if has_pub {
+		return 'pub'
+	}
+	if has_mut {
+		return 'mut'
+	}
+	return ''
+}
+
+// tag_has reports whether a comma-joined struct tag string contains `name`.
+fn tag_has(tags string, name string) bool {
+	for part in tags.split(',') {
+		if part.trim_space() == name {
+			return true
+		}
+	}
+	return false
+}
+
+// tag_value returns the value of a `key=value` entry in a comma-joined tag
+// string, or '' when absent.
+fn tag_value(tags string, key string) string {
+	for part in tags.split(',') {
+		p := part.trim_space()
+		if p.starts_with('${key}=') {
+			return p.all_after('${key}=')
+		}
+	}
+	return ''
+}
+
+// parse_assign_meta decodes an assignment node's `value` field into an optional
+// leading modifier keyword and the number of left-hand-side targets.
+fn parse_assign_meta(value string) (string, int) {
+	mut v := value
+	mut modifier := ''
+	for m in ['static', 'shared', 'atomic', 'volatile'] {
+		if v == m {
+			return m, 1
+		}
+		if v.starts_with('${m}:') {
+			modifier = m
+			v = v.all_after('${m}:')
+			break
+		}
+	}
+	if v.len == 0 {
+		return modifier, 1
+	}
+	if v[0] >= `0` && v[0] <= `9` {
+		return modifier, v.int()
+	}
+	return modifier, 1
+}
+
+// select_branch_cond_count returns how many leading children of a select branch
+// are conditions (the remainder is the branch body).
+fn select_branch_cond_count(value string) int {
+	return match true {
+		value == 'recv' || value == 'recv_assign' || value.starts_with('recv_compound') { 2 }
+		value == '' { 1 }
+		else { 0 }
+	}
+}

--- a/vlib/v3/gen/v/gen.v
+++ b/vlib/v3/gen/v/gen.v
@@ -1166,8 +1166,8 @@ fn (mut g Gen) match_cond(id flat.NodeId) {
 // select_branch_header renders a select branch's guard: a receive binding
 // (`x := <-ch` / `x = <-ch`) or a plain send/expression condition.
 fn (mut g Gen) select_branch_header(value string, conds []flat.NodeId) {
-	if conds.len == 2 && (value == 'recv' || value == 'recv_assign'
-		|| value.starts_with('recv_compound:')) {
+	if conds.len == 2
+		&& (value == 'recv' || value == 'recv_assign' || value.starts_with('recv_compound:')) {
 		g.expr(conds[0])
 		if value == 'recv' {
 			g.write(' := ')
@@ -1656,12 +1656,24 @@ fn escape_string(s string, quote u8) string {
 	mut b := strings.new_builder(s.len + 8)
 	for c in s {
 		match c {
-			`\\` { b.write_string('\\\\') }
-			`$` { b.write_string('\\\$') }
-			`\n` { b.write_string('\\n') }
-			`\r` { b.write_string('\\r') }
-			`\t` { b.write_string('\\t') }
-			0 { b.write_string('\\0') }
+			`\\` {
+				b.write_string('\\\\')
+			}
+			`$` {
+				b.write_string('\\\$')
+			}
+			`\n` {
+				b.write_string('\\n')
+			}
+			`\r` {
+				b.write_string('\\r')
+			}
+			`\t` {
+				b.write_string('\\t')
+			}
+			0 {
+				b.write_string('\\0')
+			}
 			else {
 				if c == quote {
 					b.write_u8(`\\`)

--- a/vlib/v3/gen/v/gen_test.v
+++ b/vlib/v3/gen/v/gen_test.v
@@ -120,6 +120,39 @@ fn test_comptime_selector() {
 	assert out.contains('owned.\$(field.name)')
 }
 
+fn test_select_compound_receive_preserves_operator() {
+	// A compound receive (`x += <-ch`) must keep its operator; emitting `=` would
+	// silently change program semantics.
+	out := vfmt('selcompound', 'fn f(ch chan int) {
+	mut x := 0
+	select {
+		x += <-ch {
+			println(x)
+		}
+	}
+}
+')
+	assert out.contains('x += <-ch'), out
+	assert !out.contains('x = <-ch'), out
+}
+
+fn test_select_receive_forms() {
+	out := vfmt('selforms', 'fn f(ch chan int) {
+	mut x := 0
+	select {
+		y := <-ch {
+			println(y)
+		}
+		x = <-ch {
+			println(x)
+		}
+	}
+}
+')
+	assert out.contains('y := <-ch'), out
+	assert out.contains('x = <-ch'), out
+}
+
 fn test_generics_and_interface() {
 	out := vfmt('gen', 'pub struct Stack[T] {\nmut:\n\tdata []T\n}\n\ninterface Reader {\n\tread(mut buf []u8) !int\nmut:\n\tpos int\n}\n')
 	assert out.contains('struct Stack[T] {')

--- a/vlib/v3/gen/v/gen_test.v
+++ b/vlib/v3/gen/v/gen_test.v
@@ -40,7 +40,8 @@ fn reparse_diagnostics(name string, src string) int {
 }
 
 fn test_fn_and_method() {
-	out := vfmt('method', 'module m\npub fn (mut p Point) inc(dx int) int {\n\tp.n += dx\n\treturn p.n\n}\n')
+	out := vfmt('method',
+		'module m\npub fn (mut p Point) inc(dx int) int {\n\tp.n += dx\n\treturn p.n\n}\n')
 	assert out == 'module m
 
 pub fn (mut p Point) inc(dx int) int {
@@ -67,7 +68,8 @@ fn test_attributes_and_pub() {
 }
 
 fn test_enum_and_types() {
-	out := vfmt('enum', 'pub enum Color as u8 {\n\tred = 1\n\tgreen\n}\n\ntype MyInt = int\ntype Sum = Foo | Bar\n')
+	out := vfmt('enum',
+		'pub enum Color as u8 {\n\tred = 1\n\tgreen\n}\n\ntype MyInt = int\ntype Sum = Foo | Bar\n')
 	assert out.contains('enum Color as u8 {')
 	assert out.contains('red = 1')
 	assert out.contains('type MyInt = int')
@@ -95,7 +97,8 @@ fn test_control_flow() {
 }
 
 fn test_match() {
-	out := vfmt('match', 'fn f(x int) string {\n\treturn match x {\n\t\t1, 2 { "a" }\n\t\telse { "b" }\n\t}\n}\n')
+	out := vfmt('match',
+		'fn f(x int) string {\n\treturn match x {\n\t\t1, 2 { "a" }\n\t\telse { "b" }\n\t}\n}\n')
 	assert out.contains('match x {')
 	assert out.contains('1, 2 {')
 	assert out.contains('else {')
@@ -154,7 +157,8 @@ fn test_select_receive_forms() {
 }
 
 fn test_generics_and_interface() {
-	out := vfmt('gen', 'pub struct Stack[T] {\nmut:\n\tdata []T\n}\n\ninterface Reader {\n\tread(mut buf []u8) !int\nmut:\n\tpos int\n}\n')
+	out := vfmt('gen',
+		'pub struct Stack[T] {\nmut:\n\tdata []T\n}\n\ninterface Reader {\n\tread(mut buf []u8) !int\nmut:\n\tpos int\n}\n')
 	assert out.contains('struct Stack[T] {')
 	assert out.contains('interface Reader {')
 	assert out.contains('read(mut buf []u8) !int')

--- a/vlib/v3/gen/v/gen_test.v
+++ b/vlib/v3/gen/v/gen_test.v
@@ -1,0 +1,163 @@
+module v
+
+import os
+import v3.parser
+import v3.pref
+import v3.flat
+
+// parse_source parses `src` on its own and returns the flat AST plus the id of
+// its trailing `.file` node (the one carrying the top-level declarations).
+fn parse_source(name string, src string) (&flat.FlatAst, flat.NodeId) {
+	path := os.join_path(os.temp_dir(), 'v3_vfmt_${name}_${os.getpid()}.v')
+	os.write_file(path, src) or { panic(err) }
+	mut p := parser.Parser.new(pref.new_preferences())
+	a := p.parse_file(path)
+	os.rm(path) or {}
+	mut fid := flat.empty_node
+	for id in a.file_node_ids {
+		n := a.nodes[id]
+		if n.kind == .file && n.children_count > 0 {
+			fid = flat.NodeId(id)
+		}
+	}
+	return a, fid
+}
+
+// vfmt formats `src` and returns the generated V source.
+fn vfmt(name string, src string) string {
+	a, fid := parse_source(name, src)
+	return format_file(a, fid)
+}
+
+// reparse_diagnostics reports how many parse diagnostics `src` produces.
+fn reparse_diagnostics(name string, src string) int {
+	path := os.join_path(os.temp_dir(), 'v3_vfmt_rp_${name}_${os.getpid()}.v')
+	os.write_file(path, src) or { panic(err) }
+	mut p := parser.Parser.new(pref.new_preferences())
+	p.parse_file(path)
+	os.rm(path) or {}
+	return p.diagnostics.len
+}
+
+fn test_fn_and_method() {
+	out := vfmt('method', 'module m\npub fn (mut p Point) inc(dx int) int {\n\tp.n += dx\n\treturn p.n\n}\n')
+	assert out == 'module m
+
+pub fn (mut p Point) inc(dx int) int {
+	p.n += dx
+	return p.n
+}
+'
+}
+
+fn test_struct_access_sections() {
+	out := vfmt('struct', 'struct Point {\n\tid int\npub mut:\n\tx int\n\ty int = 3\n}\n')
+	assert out == 'struct Point {
+	id int
+pub mut:
+	x int
+	y int = 3
+}
+'
+}
+
+fn test_attributes_and_pub() {
+	out := vfmt('attrs', '@[heap]\npub struct Foo {\n\tx int\n}\n')
+	assert out.starts_with('@[heap]\npub struct Foo {')
+}
+
+fn test_enum_and_types() {
+	out := vfmt('enum', 'pub enum Color as u8 {\n\tred = 1\n\tgreen\n}\n\ntype MyInt = int\ntype Sum = Foo | Bar\n')
+	assert out.contains('enum Color as u8 {')
+	assert out.contains('red = 1')
+	assert out.contains('type MyInt = int')
+	assert out.contains('type Sum = Foo | Bar')
+}
+
+fn test_control_flow() {
+	out := vfmt('flow', 'fn f(xs []int) {
+	for i, x in xs {
+		if x > 0 {
+			println(x)
+		} else {
+			continue
+		}
+	}
+	for j := 0; j < 3; j++ {
+	}
+}
+')
+	assert out.contains('for i, x in xs {')
+	// C-style loop var must not gain a spurious `mut`
+	assert out.contains('for j := 0; j < 3; j++ {')
+	assert !out.contains('for mut j := 0')
+	assert out.contains('} else {')
+}
+
+fn test_match() {
+	out := vfmt('match', 'fn f(x int) string {\n\treturn match x {\n\t\t1, 2 { "a" }\n\t\telse { "b" }\n\t}\n}\n')
+	assert out.contains('match x {')
+	assert out.contains('1, 2 {')
+	assert out.contains('else {')
+}
+
+fn test_string_escaping() {
+	// a literal `$` must be escaped so it is not read back as interpolation
+	out := vfmt('stresc', "fn f() {\n\ta := 'price: \$5'\n\tb := '\${x}y'\n}\n")
+	assert out.contains("'price: \\\$5'")
+	assert out.contains("'\${x}y'")
+}
+
+fn test_channel_ops() {
+	out := vfmt('chan', 'fn f() {\n\tx := <-ch\n\tch <- 5\n}\n')
+	assert out.contains('x := <-ch')
+	assert out.contains('ch <- 5')
+	assert !out.contains('->')
+}
+
+fn test_comptime_selector() {
+	out := vfmt('ctsel', 'fn f[T](owned T) {\n\tdrop_owned(owned.\$(field.name))\n}\n')
+	assert out.contains('owned.\$(field.name)')
+}
+
+fn test_generics_and_interface() {
+	out := vfmt('gen', 'pub struct Stack[T] {\nmut:\n\tdata []T\n}\n\ninterface Reader {\n\tread(mut buf []u8) !int\nmut:\n\tpos int\n}\n')
+	assert out.contains('struct Stack[T] {')
+	assert out.contains('interface Reader {')
+	assert out.contains('read(mut buf []u8) !int')
+}
+
+fn test_output_is_valid_and_idempotent() {
+	src := 'module main
+
+import os { join_path }
+
+@[heap]
+pub struct Node[T] {
+pub mut:
+	value T
+	next  &Node[T] = unsafe { nil }
+}
+
+pub fn (mut n Node[T]) push(v T) {
+	names := ["a", "b"]
+	m := {"k": 1}
+	for i, name in names {
+		println("\${i}: \${name}")
+	}
+	x := if v == n.value { 1 } else { 2 }
+	r := os.join_path("a", "b") or { panic(err) }
+	match x {
+		1, 2 { println("low") }
+		else {}
+	}
+	assert x > 0, "positive"
+}
+'
+	out1 := vfmt('rt', src)
+	// the generated source must itself parse without diagnostics
+	assert reparse_diagnostics('rt_valid', out1) == 0
+	// and formatting is a fixed point
+	out2 := vfmt('rt2', out1)
+	assert out1 == out2
+}

--- a/vlib/v3/markused/markused.v
+++ b/vlib/v3/markused/markused.v
@@ -241,7 +241,9 @@ fn mark_used_with_test_files(a &flat.FlatAst, tc &types.TypeChecker, test_files 
 	mut body_ids := []int{cap: 8192}
 	mut body_modules := []string{cap: 8192}
 	mut body_import_contexts := []int{cap: 8192}
-	collect_body_metadata := detect_reachable_generics || all_functions
+	// Body-call metadata feeds the reachability BFS's discovery of lowering-introduced
+	// implicit helpers, which is required on every path (not just generics detection).
+	collect_body_metadata := true
 	mut cache_roots := []string{}
 	mut c_interface_roots := []string{}
 	mut marked_roots := []string{}
@@ -614,7 +616,7 @@ fn mark_used_with_test_files(a &flat.FlatAst, tc &types.TypeChecker, test_files 
 	}
 	mut body_index := map[int]int{}
 	mut body_results := []BodyCalls{}
-	if detect_reachable_generics && body_ids.len >= min_eager_markused_bodies {
+	if body_ids.len >= min_eager_markused_bodies {
 		for i, id in body_ids {
 			body_index[id] = i
 		}
@@ -760,20 +762,26 @@ fn mark_used_with_test_files(a &flat.FlatAst, tc &types.TypeChecker, test_files 
 			for dependency in tc.direct_dependency_ids(node_key) {
 				calls << tc.frozen_symbol_name(dependency)
 			}
-			if detect_reachable_generics {
-				if body_i := body_index[node_key] {
-					body := body_results[body_i]
-					calls << body.calls
-					initializer_refs << body.refs
+			// The checker's dependency edges only cover source-level calls. Implicit
+			// helpers introduced by lowering (array bounds checks, `array__get`,
+			// `v_ni_index`, ...) are discovered solely by the body collector, so it must
+			// run for correctness regardless of generics detection; only the generics
+			// bookkeeping below is gated.
+			if body_i := body_index[node_key] {
+				body := body_results[body_i]
+				calls << body.calls
+				initializer_refs << body.refs
+				if detect_reachable_generics {
 					uses_generics = uses_generics || body.uses_generics
-				} else {
-					// Not part of the precollected decl set (should not happen; the BFS
-					// resolves names through the same decl scan) — collect inline.
-					node := a.node(fn_info.node_id)
-					body := collector.collect_body(node, fn_info.module,
-						collector.imports(fn_info.import_context))
-					calls << body.calls
-					initializer_refs << body.refs
+				}
+			} else {
+				// Not precollected (no eager pass, or not part of that decl set) —
+				// collect inline.
+				node := a.node(fn_info.node_id)
+				body := collector.collect_body(node, fn_info.module, collector.imports(fn_info.import_context))
+				calls << body.calls
+				initializer_refs << body.refs
+				if detect_reachable_generics {
 					uses_generics = uses_generics || body.uses_generics
 				}
 			}

--- a/vlib/v3/markused/markused.v
+++ b/vlib/v3/markused/markused.v
@@ -778,7 +778,8 @@ fn mark_used_with_test_files(a &flat.FlatAst, tc &types.TypeChecker, test_files 
 				// Not precollected (no eager pass, or not part of that decl set) —
 				// collect inline.
 				node := a.node(fn_info.node_id)
-				body := collector.collect_body(node, fn_info.module, collector.imports(fn_info.import_context))
+				body := collector.collect_body(node, fn_info.module,
+					collector.imports(fn_info.import_context))
 				calls << body.calls
 				initializer_refs << body.refs
 				if detect_reachable_generics {

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -7857,4 +7857,3 @@ fn main() {
 	assert reordered.exit_code == 0, reordered.output
 	assert run_module_cache_binary(reordered_output) == '1'
 }
-


### PR DESCRIPTION
Three related v3 changes (three commits).

### 1. vfmt for v3 (`vlib/v3/gen/v/`)
A V source formatter for v3, ported from the old v2 `gen/v` to v3's flat node AST. It walks a parsed `flat.FlatAst` and reconstructs V source. Validated to re-parse with zero diagnostics and format idempotently across the whole v3 compiler codebase and most of vlib; unit tests in `gen/v/gen_test.v`.

### 2. `-new-compiler` flag — runs vlib/v3 in-process
Symmetric to `-old-compiler`: `-new-compiler` runs the embedded V3 driver (`vlib/v3`) **in the same process** — never a separate `v3` executable — exactly like the default macOS path. It forces V3 for `run`/`build` targets and disables the automatic V1 fallback, so a V3 failure is reported instead of silently retried with V1. The V3 driver is now linked into `cmd/v` on every normal build (not only macOS), so it works cross-platform; the portable cross-VC bootstrap keeps its stub. `-old-compiler` takes precedence when both are given. pref + macos_v3 unit tests included.

### 3. Fix markused pruning of lowering-introduced builtin helpers
#28101 gated markused's body-call collection behind `detect_reachable_generics`. But the body collector is the only source of implicit helpers introduced by lowering (`array__get`, `v_ni_index`, array bounds checks, …); the checker's dependency edges cover only source-level calls. So for non-generic programs those helpers were pruned and left undeclared — which modern clang rejects (the V1 fallback and gcc's warnings masked it, so CI stayed green). This runs body-call collection on every path while keeping the generics bookkeeping gated, so #28101's self-host speedup (where `detect_reachable_generics` is already true) is intact. It also fixes the default macOS V3 path, which was silently falling back to V1 for every program.

### Testing
- `v -new-compiler run examples/hello_world.v` compiles with V3 in-process and produces a working binary (no fallback); same for generics/arrays/maps/strings and fibonacci.
- Default macOS V3 path no longer falls back to V1.
- markused test passes; vfmt/pref/macos_v3 unit tests included.
- `cmd/v` cross-compiles to Linux C (the embed + dispatch compile cross-platform).

Note: a separate, pre-existing issue remains — V3 self-host in C99 mode on modern clang fails on a generic-type forward-decl (`sync__ThreadLocalStorage_T`); it does not affect user programs or `-new-compiler`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
