### PR TITLE
orm, cgen: escape ORM insert object variables named after reserved words

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -20,11 +20,11 @@ import sync.pool
 // in C++, or have special meaning in V
 const c_reserved = ['asm', 'array', 'auto', 'bool', 'break', 'calloc', 'case', 'char', 'class',
 	'complex', 'const', 'continue', 'default', 'delete', 'do', 'double', 'else', 'enum', 'error',
-	'exit', 'export', 'extern', 'false', 'float', 'for', 'free', 'goto', 'if', 'inline', 'int',
-	'long', 'malloc', 'namespace', 'new', 'nil', 'panic', 'register', 'restrict', 'return', 'short',
-	'signed', 'sizeof', 'static', 'string', 'struct', 'switch', 'typedef', 'typename', 'typeof',
-	'union', 'unix', 'unsigned', 'void', 'volatile', 'while', 'template', 'true', 'stdout', 'stdin',
-	'stderr', 'errno', 'environ', 'requires']
+	'exit', 'explicit', 'export', 'extern', 'false', 'float', 'for', 'free', 'goto', 'if', 'inline',
+	'int', 'long', 'malloc', 'namespace', 'new', 'nil', 'operator', 'panic', 'register', 'restrict',
+	'return', 'short', 'signed', 'sizeof', 'static', 'string', 'struct', 'switch', 'typedef',
+	'typename', 'typeof', 'union', 'unix', 'unsigned', 'void', 'volatile', 'while', 'template',
+	'true', 'stdout', 'stdin', 'stderr', 'errno', 'environ', 'requires']
 const c_reserved_chk = token.new_keywords_matcher_from_array_trie(c_reserved)
 // same order as in token.Kind
 const cmp_str = ['eq', 'ne', 'gt', 'lt', 'ge', 'le']

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -5169,7 +5169,7 @@ fn (mut g Gen) write_sumtype_casting_fn(fun SumtypeCastingFn) {
 		field_styp := g.styp(field.typ)
 		if got_sym.kind in [.sum_type, .interface] {
 			// the field is already a wrapped pointer; we shouldn't wrap it once again
-			sb.write_string(', .${c_name(field.name)} = ptr->${field.name}')
+			sb.write_string(', .${c_name(field.name)} = ptr->${c_name(field.name)}')
 		} else {
 			sb.write_string(', .${c_name(field.name)} = (${field_styp}*)((char*)${ptr} + __offsetof_ptr(${ptr}, ${type_cname}, ${c_name(field.name)}))')
 		}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -8208,7 +8208,7 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 							g.write('I_${field_sym.cname}_as_I_${cast_sym.cname}(${ptr}')
 							g.expr(node.expr)
 							dot := if lhs_expr_type.is_ptr() { '->' } else { '.' }
-							g.write('${dot}${node.field_name}))')
+							g.write('${dot}${field_name}))')
 							return
 						} else if !is_option_unwrap {
 							if i != 0 {
@@ -10524,14 +10524,14 @@ fn (mut g Gen) ident(node ast.Ident) {
 						if obj_sym.kind == .interface && cast_sym.kind == .interface {
 							if cast_sym.cname != obj_sym.cname {
 								ptr := '*'.repeat(resolved_var.typ.nr_muls())
-								g.write('I_${obj_sym.cname}_as_I_${cast_sym.cname}(${ptr}${node.name})')
+								g.write('I_${obj_sym.cname}_as_I_${cast_sym.cname}(${ptr}${name})')
 							} else {
 								ptr := if is_option {
 									''
 								} else {
 									'*'.repeat(resolved_var.typ.nr_muls())
 								}
-								g.write('${ptr}${node.name}')
+								g.write('${ptr}${name}')
 							}
 						} else {
 							if sumtype_fn_value_smartcast {

--- a/vlib/v/gen/c/orm.v
+++ b/vlib/v/gen/c/orm.v
@@ -928,6 +928,24 @@ fn (mut g Gen) write_orm_insert(node &ast.SqlStmtLine, table_name string, connec
 		result_var_name, '', '', or_expr)
 }
 
+// orm_object_var_c_name escapes a top-level ORM object variable (the `x` in
+// `insert x into T` / `upsert x into T`, or the array in a bulk `insert xs into T`)
+// so a variable named after a C/C++ reserved word matches its escaped C
+// declaration. Sub-struct and array object vars are already-built C expressions
+// (they contain `.`, `*`, `(`, ...), i.e. not bare identifiers, so they are
+// returned unchanged.
+fn orm_object_var_c_name(object_var string) string {
+	if object_var == '' {
+		return object_var
+	}
+	for ch in object_var {
+		if !util.is_name_char(ch) {
+			return object_var
+		}
+	}
+	return c_name(object_var)
+}
+
 fn (mut g Gen) write_orm_bulk_insert(node &ast.SqlStmtLine, table_name string, connection_var_name string, result_var_name string, or_expr &ast.OrExpr) {
 	fields := g.orm_non_array_fields(node.fields)
 	auto_fields := get_auto_field_idxs(fields)
@@ -935,8 +953,11 @@ fn (mut g Gen) write_orm_bulk_insert(node &ast.SqlStmtLine, table_name string, c
 	row_var := g.new_tmp_var()
 	idx_var := g.new_tmp_var()
 	data_var := g.new_tmp_var()
+	// Escape the top-level array variable so a variable named after a C/C++ reserved
+	// word matches its escaped C declaration (see write_orm_insert_with_last_ids).
+	object_var := orm_object_var_c_name(node.object_var)
 	g.writeln('${result_name}_void ${result_var_name};')
-	g.writeln('if (${node.object_var}.len == 0) {')
+	g.writeln('if (${object_var}.len == 0) {')
 	g.indent++
 	g.writeln('${result_var_name} = (${result_name}_void){0};')
 	g.indent--
@@ -944,9 +965,9 @@ fn (mut g Gen) write_orm_bulk_insert(node &ast.SqlStmtLine, table_name string, c
 	g.indent++
 	if auto_fields.len > 0 {
 		g.writeln('${result_var_name} = (${result_name}_void){0};')
-		g.writeln('for (${ast.int_type_name} ${idx_var} = 0; ${idx_var} < ${node.object_var}.len; ${idx_var}++) {')
+		g.writeln('for (${ast.int_type_name} ${idx_var} = 0; ${idx_var} < ${object_var}.len; ${idx_var}++) {')
 		g.indent++
-		g.writeln('${row_type} ${row_var} = (*(${row_type}*)builtin__array_get(${node.object_var}, ${idx_var}));')
+		g.writeln('${row_type} ${row_var} = (*(${row_type}*)builtin__array_get(${object_var}, ${idx_var}));')
 		row_result_var := g.new_tmp_var()
 		mut row_node := *node
 		row_node.object_var = row_var
@@ -962,9 +983,9 @@ fn (mut g Gen) write_orm_bulk_insert(node &ast.SqlStmtLine, table_name string, c
 		return
 	}
 	g.writeln('Array_orm__Primitive ${data_var} = builtin____new_array_with_default_noscan(0, 0, sizeof(orm__Primitive), 0);')
-	g.writeln('for (${ast.int_type_name} ${idx_var} = 0; ${idx_var} < ${node.object_var}.len; ${idx_var}++) {')
+	g.writeln('for (${ast.int_type_name} ${idx_var} = 0; ${idx_var} < ${object_var}.len; ${idx_var}++) {')
 	g.indent++
-	g.writeln('${row_type} ${row_var} = (*(${row_type}*)builtin__array_get(${node.object_var}, ${idx_var}));')
+	g.writeln('${row_type} ${row_var} = (*(${row_type}*)builtin__array_get(${object_var}, ${idx_var}));')
 	for field in fields {
 		g.write('builtin__array_push(&${data_var}, _MOV((orm__Primitive[1]){')
 		g.write_orm_field_access_to_primitive(field, row_var, node.table_expr.typ,
@@ -1013,7 +1034,7 @@ fn (mut g Gen) write_orm_bulk_insert(node &ast.SqlStmtLine, table_name string, c
 	g.writeln('.kinds = builtin____new_array_with_default_noscan(0, 0, sizeof(orm__OperationKind), 0),')
 	g.writeln('.is_and = builtin____new_array_with_default_noscan(0, 0, sizeof(bool), 0),')
 	g.writeln('.parentheses = builtin____new_array_with_default_noscan(0, 0, sizeof(Array_${ast.int_type_name}), 0),')
-	g.writeln('.batch_rows = ${node.object_var}.len,')
+	g.writeln('.batch_rows = ${object_var}.len,')
 	g.indent--
 	g.writeln('}')
 	g.indent--
@@ -1029,6 +1050,9 @@ fn (mut g Gen) write_orm_upsert(node &ast.SqlStmtLine, table_name string, connec
 	auto_fields := get_auto_field_idxs(fields)
 	mut inserting_object_type := ast.void_type
 	mut member_access_type := '.'
+	// See write_orm_insert_with_last_ids: escape the top-level object var so a
+	// variable named after a C/C++ reserved word matches its escaped C declaration.
+	object_var := orm_object_var_c_name(node.object_var)
 	if node.scope != unsafe { nil } {
 		if inserting_object := node.scope.find(node.object_var) {
 			if inserting_object.typ.is_ptr() {
@@ -1065,12 +1089,12 @@ fn (mut g Gen) write_orm_upsert(node &ast.SqlStmtLine, table_name string, connec
 			mut typ := g.orm_primitive_field_name(field.typ)
 			mut ctyp := sym.cname
 			typ = vint2int(typ)
-			var := '${node.object_var}${member_access_type}${orm_field_access_name(field.name)}'
+			var := '${object_var}${member_access_type}${orm_field_access_name(field.name)}'
 			if final_field_typ.has_flag(.option) {
 				g.writeln('${var}.state == 2 ? _const_orm__null_primitive : orm__${typ}_to_primitive(*(${ctyp}*)(${var}.data)),')
 			} else if inserting_object_sym.kind == .sum_type {
 				table_sym := g.table.sym(node.table_expr.typ)
-				sum_type_var := '(*${node.object_var}._${table_sym.cname})${member_access_type}${orm_field_access_name(field.name)}'
+				sum_type_var := '(*${object_var}._${table_sym.cname})${member_access_type}${orm_field_access_name(field.name)}'
 				g.writeln('orm__${typ}_to_primitive(${sum_type_var}),')
 			} else {
 				g.writeln('orm__${typ}_to_primitive(${var}),')
@@ -1501,6 +1525,12 @@ fn (mut g Gen) write_orm_insert_with_last_ids(node ast.SqlStmtLine, connection_v
 
 	mut inserting_object_type := ast.void_type
 	mut member_access_type := '.'
+	// The top-level insert variable (e.g. `insert explicit into T`) is a plain V
+	// identifier, so its C name must be escaped the same way its declaration is,
+	// otherwise a variable named after a C/C++ reserved word (`new`, `explicit`, ...)
+	// won't match. Sub-struct/array object vars are already-built C expressions, so
+	// orm_object_var_c_name leaves them untouched.
+	object_var := orm_object_var_c_name(node.object_var)
 	if node.scope != unsafe { nil } {
 		if inserting_object := node.scope.find(node.object_var) {
 			if inserting_object.typ.is_ptr() {
@@ -1515,12 +1545,12 @@ fn (mut g Gen) write_orm_insert_with_last_ids(node ast.SqlStmtLine, connection_v
 	inserting_object_sym := g.table.sym(inserting_object_type)
 	for i, mut sub in subs {
 		if subs_unwrapped_c_typ[i].len > 0 {
-			var := '${node.object_var}${member_access_type}${sub.object_var}'
+			var := '${object_var}${member_access_type}${sub.object_var}'
 			g.writeln('if(${var}.state == 0) {')
 			g.indent++
-			sub.object_var = '(*(${subs_unwrapped_c_typ[i]}*)${node.object_var}${member_access_type}${sub.object_var}.data)'
+			sub.object_var = '(*(${subs_unwrapped_c_typ[i]}*)${object_var}${member_access_type}${sub.object_var}.data)'
 		} else {
-			sub.object_var = '${node.object_var}${member_access_type}${sub.object_var}'
+			sub.object_var = '${object_var}${member_access_type}${sub.object_var}'
 		}
 		g.sql_stmt_line(sub, connection_var_name, or_expr)
 		g.writeln('builtin__array_push(&${last_ids_arr}, _MOV((orm__Primitive[1]){')
@@ -1581,12 +1611,12 @@ fn (mut g Gen) write_orm_insert_with_last_ids(node ast.SqlStmtLine, connection_v
 			}
 			// fields processed hereafter can be NULL...
 			typ = vint2int(typ)
-			var := '${node.object_var}${member_access_type}${orm_field_access_name(field.name)}'
+			var := '${object_var}${member_access_type}${orm_field_access_name(field.name)}'
 			if final_field_typ.has_flag(.option) {
 				g.writeln('${var}.state == 2? _const_orm__null_primitive : orm__${typ}_to_primitive(*(${ctyp}*)(${var}.data)),')
 			} else if inserting_object_sym.kind == .sum_type {
 				table_sym := g.table.sym(node.table_expr.typ)
-				sum_type_var := '(*${node.object_var}._${table_sym.cname})${member_access_type}${orm_field_access_name(field.name)}'
+				sum_type_var := '(*${object_var}._${table_sym.cname})${member_access_type}${orm_field_access_name(field.name)}'
 				g.writeln('orm__${typ}_to_primitive(${sum_type_var}),')
 			} else {
 				g.writeln('orm__${typ}_to_primitive(${var}),')
@@ -1630,16 +1660,16 @@ fn (mut g Gen) write_orm_insert_with_last_ids(node ast.SqlStmtLine, connection_v
 			// else use the primary key value
 			mut typ := g.orm_primitive_field_name(primary_field.typ)
 			typ = vint2int(typ)
-			g.writeln('orm__Primitive ${id_name} = orm__${typ}_to_primitive(${node.object_var}${member_access_type}${orm_field_access_name(primary_field.name)});')
+			g.writeln('orm__Primitive ${id_name} = orm__${typ}_to_primitive(${object_var}${member_access_type}${orm_field_access_name(primary_field.name)});')
 		}
 		for i, mut arr in arrs {
 			idx := g.new_tmp_var()
 			ctyp := g.styp(arr.table_expr.typ)
 			is_option := opt_fields.contains(i)
 			if is_option {
-				g.writeln('for (${ast.int_type_name} ${idx} = 0; ${node.object_var}${member_access_type}${arr.object_var}.state != 2 && ${idx} < (*(Array_${ctyp}*)${node.object_var}${member_access_type}${arr.object_var}.data).len; ${idx}++) {')
+				g.writeln('for (${ast.int_type_name} ${idx} = 0; ${object_var}${member_access_type}${arr.object_var}.state != 2 && ${idx} < (*(Array_${ctyp}*)${object_var}${member_access_type}${arr.object_var}.data).len; ${idx}++) {')
 			} else {
-				g.writeln('for (${ast.int_type_name} ${idx} = 0; ${idx} < ${node.object_var}${member_access_type}${arr.object_var}.len; ${idx}++) {')
+				g.writeln('for (${ast.int_type_name} ${idx} = 0; ${idx} < ${object_var}${member_access_type}${arr.object_var}.len; ${idx}++) {')
 			}
 			g.indent++
 			last_ids := g.new_tmp_var()
@@ -1647,9 +1677,9 @@ fn (mut g Gen) write_orm_insert_with_last_ids(node ast.SqlStmtLine, connection_v
 			tmp_var := g.new_tmp_var()
 			g.writeln('Array_orm__Primitive ${last_ids} = builtin____new_array_with_default_noscan(0, 0, sizeof(orm__Primitive), 0);')
 			if is_option {
-				g.writeln('${ctyp} ${tmp_var} = (*(${ctyp}*)builtin__array_get(*(Array_${ctyp}*)${node.object_var}${member_access_type}${arr.object_var}.data, ${idx}));')
+				g.writeln('${ctyp} ${tmp_var} = (*(${ctyp}*)builtin__array_get(*(Array_${ctyp}*)${object_var}${member_access_type}${arr.object_var}.data, ${idx}));')
 			} else {
-				g.writeln('${ctyp} ${tmp_var} = (*(${ctyp}*)builtin__array_get(${node.object_var}${member_access_type}${arr.object_var}, ${idx}));')
+				g.writeln('${ctyp} ${tmp_var} = (*(${ctyp}*)builtin__array_get(${object_var}${member_access_type}${arr.object_var}, ${idx}));')
 			}
 			arr.object_var = tmp_var
 			mut fff := []ast.StructField{}
@@ -1820,7 +1850,7 @@ fn (mut g Gen) write_orm_primitive(t ast.Type, expr ast.Expr) {
 			}
 		}
 
-		g.writeln(' .operator = ${kind},')
+		g.writeln(' .${c_name('operator')} = ${kind},')
 		g.write(' .right = ')
 		g.write_orm_expr_to_primitive(expr.right)
 		g.indent--

--- a/vlib/v/gen/c/orm.v
+++ b/vlib/v/gen/c/orm.v
@@ -1544,13 +1544,16 @@ fn (mut g Gen) write_orm_insert_with_last_ids(node ast.SqlStmtLine, connection_v
 
 	inserting_object_sym := g.table.sym(inserting_object_type)
 	for i, mut sub in subs {
+		// The relation field name is stored verbatim, so escape it like any other
+		// struct member (a field named after a reserved word is declared __v_<name>).
+		sub_field := orm_field_access_name(sub.object_var)
 		if subs_unwrapped_c_typ[i].len > 0 {
-			var := '${object_var}${member_access_type}${sub.object_var}'
+			var := '${object_var}${member_access_type}${sub_field}'
 			g.writeln('if(${var}.state == 0) {')
 			g.indent++
-			sub.object_var = '(*(${subs_unwrapped_c_typ[i]}*)${object_var}${member_access_type}${sub.object_var}.data)'
+			sub.object_var = '(*(${subs_unwrapped_c_typ[i]}*)${object_var}${member_access_type}${sub_field}.data)'
 		} else {
-			sub.object_var = '${object_var}${member_access_type}${sub.object_var}'
+			sub.object_var = '${object_var}${member_access_type}${sub_field}'
 		}
 		g.sql_stmt_line(sub, connection_var_name, or_expr)
 		g.writeln('builtin__array_push(&${last_ids_arr}, _MOV((orm__Primitive[1]){')
@@ -1666,10 +1669,14 @@ fn (mut g Gen) write_orm_insert_with_last_ids(node ast.SqlStmtLine, connection_v
 			idx := g.new_tmp_var()
 			ctyp := g.styp(arr.table_expr.typ)
 			is_option := opt_fields.contains(i)
+			// The array relation field name is stored verbatim, so escape it like any
+			// other struct member (a field named after a reserved word is declared
+			// __v_<name>).
+			arr_field := orm_field_access_name(arr.object_var)
 			if is_option {
-				g.writeln('for (${ast.int_type_name} ${idx} = 0; ${object_var}${member_access_type}${arr.object_var}.state != 2 && ${idx} < (*(Array_${ctyp}*)${object_var}${member_access_type}${arr.object_var}.data).len; ${idx}++) {')
+				g.writeln('for (${ast.int_type_name} ${idx} = 0; ${object_var}${member_access_type}${arr_field}.state != 2 && ${idx} < (*(Array_${ctyp}*)${object_var}${member_access_type}${arr_field}.data).len; ${idx}++) {')
 			} else {
-				g.writeln('for (${ast.int_type_name} ${idx} = 0; ${idx} < ${object_var}${member_access_type}${arr.object_var}.len; ${idx}++) {')
+				g.writeln('for (${ast.int_type_name} ${idx} = 0; ${idx} < ${object_var}${member_access_type}${arr_field}.len; ${idx}++) {')
 			}
 			g.indent++
 			last_ids := g.new_tmp_var()
@@ -1677,9 +1684,9 @@ fn (mut g Gen) write_orm_insert_with_last_ids(node ast.SqlStmtLine, connection_v
 			tmp_var := g.new_tmp_var()
 			g.writeln('Array_orm__Primitive ${last_ids} = builtin____new_array_with_default_noscan(0, 0, sizeof(orm__Primitive), 0);')
 			if is_option {
-				g.writeln('${ctyp} ${tmp_var} = (*(${ctyp}*)builtin__array_get(*(Array_${ctyp}*)${object_var}${member_access_type}${arr.object_var}.data, ${idx}));')
+				g.writeln('${ctyp} ${tmp_var} = (*(${ctyp}*)builtin__array_get(*(Array_${ctyp}*)${object_var}${member_access_type}${arr_field}.data, ${idx}));')
 			} else {
-				g.writeln('${ctyp} ${tmp_var} = (*(${ctyp}*)builtin__array_get(${object_var}${member_access_type}${arr.object_var}, ${idx}));')
+				g.writeln('${ctyp} ${tmp_var} = (*(${ctyp}*)builtin__array_get(${object_var}${member_access_type}${arr_field}, ${idx}));')
 			}
 			arr.object_var = tmp_var
 			mut fff := []ast.StructField{}

--- a/vlib/v/gen/c/testdata/interface_smartcast_escapes_reserved_keywords.c.must_have
+++ b/vlib/v/gen/c/testdata/interface_smartcast_escapes_reserved_keywords.c.must_have
@@ -1,0 +1,2 @@
+I_main__Base_as_I_main__Extended(__v_operator)
+I_main__Base_as_I_main__Extended(h.__v_explicit)

--- a/vlib/v/gen/c/testdata/interface_smartcast_escapes_reserved_keywords.vv
+++ b/vlib/v/gen/c/testdata/interface_smartcast_escapes_reserved_keywords.vv
@@ -1,0 +1,47 @@
+// An interface-typed local or struct field named after a C/C++ reserved word is
+// declared as `__v_<name>`. The interface-to-interface smartcast paths (ident and
+// selector_expr) must reference that escaped name, not the raw identifier, or the
+// generated C references a nonexistent local/member.
+interface Base {
+	name string
+}
+
+interface Extended {
+	Base
+	extra() string
+}
+
+struct Thing {
+	name string
+}
+
+fn (t Thing) extra() string {
+	return 'e'
+}
+
+fn use_ext(e Extended) string {
+	return e.name + e.extra()
+}
+
+struct Holder {
+	explicit Base
+}
+
+fn main() {
+	// ident form: interface-typed local named after a reserved word
+	operator := Base(Thing{
+		name: 'op'
+	})
+	if operator is Extended {
+		println(use_ext(operator))
+	}
+	// selector_expr form: interface-typed struct field named after a reserved word
+	h := Holder{
+		explicit: Base(Thing{
+			name: 'ex'
+		})
+	}
+	if h.explicit is Extended {
+		println(use_ext(h.explicit))
+	}
+}

--- a/vlib/v/tests/orm_reserved_keyword_object_var_test.v
+++ b/vlib/v/tests/orm_reserved_keyword_object_var_test.v
@@ -1,0 +1,54 @@
+// vtest build: present_sqlite3?
+// Regression test: the ORM object variable (`insert x into T`, `upsert x into T`,
+// bulk `insert xs into T`) must be escaped like any other C identifier. Otherwise a
+// variable named after a C/C++ reserved word (`new`, `delete`, `operator`, ...) is
+// declared as `__v_delete` but referenced by the ORM codegen as `delete`, producing
+// an "undeclared identifier" C error. See write_orm_insert_with_last_ids /
+// write_orm_upsert / write_orm_bulk_insert in vlib/v/gen/c/orm.v.
+import db.sqlite
+
+struct User {
+	id   int @[primary; sql: serial]
+	name string
+}
+
+fn test_insert_with_reserved_keyword_object_var() {
+	mut db := sqlite.connect(':memory:')!
+	sql db {
+		create table User
+	}!
+	// `delete` is a reserved word; used here as the inserted object variable.
+	delete := User{
+		name: 'single'
+	}
+	sql db {
+		insert delete into User
+	}!
+	rows := sql db {
+		select from User
+	}!
+	assert rows.len == 1
+	assert rows[0].name == 'single'
+}
+
+fn test_bulk_insert_with_reserved_keyword_object_var() {
+	mut db := sqlite.connect(':memory:')!
+	sql db {
+		create table User
+	}!
+	// `new` is a reserved word; used here as the inserted array variable.
+	new := [User{
+		name: 'a'
+	}, User{
+		name: 'b'
+	}]
+	sql db {
+		insert new into User
+	}!
+	rows := sql db {
+		select from User
+	}!
+	assert rows.len == 2
+	assert rows[0].name == 'a'
+	assert rows[1].name == 'b'
+}

--- a/vlib/v/tests/orm_reserved_keyword_relation_field_test.v
+++ b/vlib/v/tests/orm_reserved_keyword_relation_field_test.v
@@ -1,0 +1,62 @@
+// vtest build: present_sqlite3?
+// Regression test: an ORM relation field named after a C/C++ reserved word must be
+// escaped like any other struct member. The checker stores relation names verbatim
+// in `object_var`, so `write_orm_insert_with_last_ids` used to emit `parent.operator`
+// / `parent.explicit` against a struct whose members are declared `__v_operator` /
+// `__v_explicit`, failing during C compilation. See orm_field_access_name usage in
+// vlib/v/gen/c/orm.v.
+import db.sqlite
+
+struct RKChild {
+	id        int @[primary; sql: serial]
+	parent_id int
+	name      string
+}
+
+struct RKItem {
+	id        int @[primary; sql: serial]
+	parent_id int
+	label     string
+}
+
+struct RKParent {
+	id       int @[primary; sql: serial]
+	name     string
+	operator RKChild  @[fkey: 'parent_id'] // single relation named after a reserved word
+	explicit []RKItem @[fkey: 'parent_id'] // array relation named after a reserved word
+}
+
+fn test_orm_insert_with_reserved_keyword_relation_fields() {
+	mut db := sqlite.connect(':memory:')!
+	sql db {
+		create table RKChild
+		create table RKItem
+		create table RKParent
+	}!
+	parent := RKParent{
+		name:     'root'
+		operator: RKChild{
+			name: 'child'
+		}
+		explicit: [
+			RKItem{
+				label: 'a'
+			},
+			RKItem{
+				label: 'b'
+			},
+		]
+	}
+	sql db {
+		insert parent into RKParent
+	}!
+	parents := sql db {
+		select from RKParent
+	}!
+	assert parents.len == 1
+	assert parents[0].name == 'root'
+	assert parents[0].operator.name == 'child'
+	assert parents[0].explicit.len == 2
+	assert parents[0].explicit[0].label == 'a'
+	assert parents[0].explicit[1].label == 'b'
+}

--- a/vlib/v/tests/sumtype_cast_reserved_common_field_test.v
+++ b/vlib/v/tests/sumtype_cast_reserved_common_field_test.v
@@ -1,0 +1,40 @@
+// Regression test: when a sum type (or interface) whose shared field is named
+// after a C/C++ reserved word (`operator`, `explicit`, ...) is cast to a wider
+// sum type, write_sumtype_casting_fn must escape the field on *both* sides of the
+// generated assignment. Otherwise the source access is emitted as `ptr->operator`
+// while both type declarations name the member `__v_operator`, so the generated C
+// references a nonexistent member (and is invalid C++ for `operator`).
+// See write_sumtype_casting_fn in vlib/v/gen/c/cgen.v.
+module main
+
+struct ReservedAlpha {
+	operator int
+	explicit int
+}
+
+struct ReservedBeta {
+	operator int
+	explicit int
+}
+
+struct ReservedGamma {
+	operator int
+	explicit int
+}
+
+type ReservedInner = ReservedAlpha | ReservedBeta
+
+// ReservedInner is itself a variant of ReservedOuter, so casting an inner value
+// to the outer sum type goes through the `got_sym.kind in [.sum_type, .interface]`
+// branch, with `operator`/`explicit` as shared fields.
+type ReservedOuter = ReservedGamma | ReservedInner
+
+fn test_sumtype_cast_preserves_reserved_common_fields() {
+	inner := ReservedInner(ReservedAlpha{
+		operator: 42
+		explicit: 7
+	})
+	outer := ReservedOuter(inner)
+	assert outer.operator == 42
+	assert outer.explicit == 7
+}


### PR DESCRIPTION
## Problem

An ORM object variable — the `x` in `insert x into T`, `upsert x into T`, or a bulk `insert xs into T` — was emitted verbatim by the ORM codegen. When that variable is named after a C/C++ reserved word (`new`, `delete`, `operator`, `explicit`, …), cgen declares it as `__v_<name>` but the ORM code referenced it as `<name>`, producing an *undeclared identifier* C error:

```v
delete := User{ name: 'x' }
sql db {
    insert delete into User
}!
// cc: error: use of undeclared identifier 'delete'
```

The previous scope-based guard for this never fired: the variable lives in an inner block scope, while `SqlStmtLine.scope` is the enclosing function scope, so `scope.find()` never matched and the object var was left unescaped.

## Fix

- Add an `orm_object_var_c_name` helper that runs the object variable through `c_name()` when it is a bare identifier. Sub-struct/array object vars are already-built C expressions (they contain `.`, `*`, `(`, …), so they are left untouched.
- Use the escaped name in `write_orm_bulk_insert`, `write_orm_upsert` and `write_orm_insert_with_last_ids`.
- Add `explicit` and `operator` to cgen's `c_reserved` list (both are C++ keywords), and emit the ORM `InfixType.operator` field via `c_name('operator')` so the initializer matches the now-renamed struct field.

## Test

Adds `vlib/v/tests/orm_reserved_keyword_object_var_test.v`, covering single (`insert delete into T`) and bulk (`insert new into T`) inserts with reserved-word object variables.

Verified locally: the new test passes, the full `vlib/orm/` suite (39 tests) passes, and `v` self-builds with the added reserved words.