### PR TITLE
v3: speed up compiling cmd/v

### DIFF
--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -8587,7 +8587,14 @@ pub fn run(args []string) {
 		} else {
 			b.step_parallel('transform', transform_was_parallel)
 		}
-		pre_tc.refresh_rewritten_parent_index(a)
+		// Self-host C generation consumes the transformer's explicit node types and
+		// the checker's resolved-call sidecars; it does not perform a second semantic
+		// annotation walk. Keep the checked source parent index in that fast path
+		// instead of rebuilding parents for 1M+ appended lowering nodes that no later
+		// stage queries.
+		if !building_v {
+			pre_tc.refresh_rewritten_parent_index(a)
+		}
 		if transform_errors.len > 0 {
 			eprintln('type checker found ${transform_errors.len} error(s):')
 			for message in transform_errors {

--- a/vlib/v3/flat/flat.v
+++ b/vlib/v3/flat/flat.v
@@ -741,6 +741,14 @@ pub fn (mut a FlatAst) add_node(node Node) NodeId {
 	id := NodeId(a.nodes.len)
 	mut stored := node
 	stored.set_type_text_id(a.node_type_text_id(stored.typ, stored.type_text_id()))
+	if a.nodes.len < a.nodes.cap {
+		unsafe {
+			mut slot := &Node(&u8(a.nodes.data) + usize(a.nodes.len) * sizeof(Node))
+			*slot = stored
+			a.nodes.len++
+		}
+		return id
+	}
 	a.nodes << stored
 	return id
 }
@@ -760,6 +768,14 @@ pub fn (mut a FlatAst) begin_children() int {
 
 // add_child updates add child state for FlatAst.
 pub fn (mut a FlatAst) add_child(id NodeId) {
+	if a.children.len < a.children.cap {
+		unsafe {
+			mut slot := &NodeId(&u8(a.children.data) + usize(a.children.len) * sizeof(NodeId))
+			*slot = id
+			a.children.len++
+		}
+		return
+	}
 	a.children << id
 }
 

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -171,6 +171,18 @@ mut:
 	values     []types.Type
 }
 
+@[heap]
+struct SumVariantActualCache {
+mut:
+	by_sum map[string]&SumVariantActualEntries
+}
+
+@[heap]
+struct SumVariantActualEntries {
+mut:
+	values map[string]string
+}
+
 fn (mut g FlatGen) begin_usable_expr_type_memo() {
 	if !g.memo_usable_expr_types {
 		return
@@ -300,12 +312,14 @@ mut:
 	local_pointer_storage_by_owner map[string]bool   // exact scope binding owner -> C storage is already a pointer
 	local_c_type_by_owner          map[string]string // exact scope binding owner -> emitted C declaration type
 	local_mutable_by_owner         map[string]bool
-	local_pointer_alias_by_owner   map[string]string   // exact scope binding owner -> stack local whose address is stored
-	local_pointer_alias_mut_param  map[string]bool     // exact scope binding owner -> alias source is a mut parameter
-	local_raw_type_by_owner        map[string]string   // exact scope binding owner -> source-level raw type text
-	local_shared_storage_by_owner  map[string]bool     // exact scope binding owner -> C storage is a shared wrapper pointer
-	local_fn_value_c_name_by_owner map[string]string   // exact scope binding owner -> lifted fn-literal C name
-	sum_name_lookup                map[string]string   // full/short sum type name -> canonical sum type name
+	local_pointer_alias_by_owner   map[string]string            // exact scope binding owner -> stack local whose address is stored
+	local_pointer_alias_mut_param  map[string]bool              // exact scope binding owner -> alias source is a mut parameter
+	local_raw_type_by_owner        map[string]string            // exact scope binding owner -> source-level raw type text
+	local_shared_storage_by_owner  map[string]bool              // exact scope binding owner -> C storage is a shared wrapper pointer
+	local_fn_value_c_name_by_owner map[string]string            // exact scope binding owner -> lifted fn-literal C name
+	sum_name_lookup                map[string]string            // full/short sum type name -> canonical sum type name
+	sum_variant_lookup             map[string]map[string]string // sum name -> exact/short variant -> canonical variant
+	sum_variant_actual_cache       &SumVariantActualCache = &SumVariantActualCache{} // sum name + semantic actual type -> canonical variant (empty means miss)
 	module_init_fns                []string            // C names of module-level `init()` fns, in source order
 	module_init_fn_modules         map[string]string   // C init fn name -> V module name
 	module_cleanup_fns             []string            // C names of module-level `cleanup()` fns, in source order
@@ -395,6 +409,7 @@ mut:
 	output_path                  string
 	output_error                 string
 	c99_mode                     bool
+	trace_calls                  bool
 	inside_trace_call            bool
 	skip_generics                bool
 	skip_enum_autostr            bool
@@ -410,6 +425,7 @@ mut:
 	cur_param_names              []string
 	cur_param_type_values        []types.Type
 	cur_param_types              map[string]types.Type
+	cur_param_name_bits          u64
 	cur_concrete_optional_params map[string]bool
 	cur_mut_params               map[string]bool
 	cur_mut_pointer_params       map[string]bool
@@ -990,6 +1006,8 @@ pub fn FlatGen.new() FlatGen {
 		local_fn_value_c_name_by_owner:  map[string]string{}
 		shadowed_global_locals:          map[string]bool{}
 		sum_name_lookup:                 map[string]string{}
+		sum_variant_lookup:              map[string]map[string]string{}
+		sum_variant_actual_cache:        &SumVariantActualCache{}
 		module_init_fns:                 []string{}
 		module_init_fn_modules:          map[string]string{}
 		module_cleanup_fns:              []string{}
@@ -1196,6 +1214,7 @@ pub fn (mut g FlatGen) set_suppress_main(enabled bool) {
 // directives resolves configured values over fallbacks.
 pub fn (mut g FlatGen) set_compile_values(values map[string]string) {
 	g.compile_values = values.clone()
+	g.trace_calls = 'trace' in g.compile_values
 }
 
 // set_cache_split enables stable cache markers and string symbols in generated C.
@@ -2542,6 +2561,8 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	g.local_fn_value_c_name_by_owner.clear()
 	g.shadowed_global_locals.clear()
 	g.sum_name_lookup.clear()
+	g.sum_variant_lookup.clear()
+	g.sum_variant_actual_cache.by_sum.clear()
 	g.module_init_fns = []string{}
 	g.module_init_fn_modules.clear()
 	g.module_cleanup_fns = []string{}
@@ -2604,6 +2625,7 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	g.cur_param_names = []string{}
 	g.cur_param_type_values = []types.Type{}
 	g.cur_param_types.clear()
+	g.cur_param_name_bits = 0
 	g.cur_concrete_optional_params.clear()
 	g.cur_mut_params.clear()
 	g.cur_mut_pointer_params.clear()
@@ -3572,6 +3594,7 @@ fn (mut g FlatGen) collect_gen_info() {
 		&& g.incremental_fn_names.len == 0 && par_cgen_prep_enabled()
 	top_level_nodes := g.top_level_nodes()
 	fn_preps := g.collect_gen_info_fn_preps(top_level_nodes)
+	has_parallel_fn_preps := fn_preps.len == top_level_nodes.len
 	for top_level_pos, node_idx in top_level_nodes {
 		node := g.a.nodes[node_idx]
 		kind_id := node_kind_id(node)
@@ -3599,8 +3622,13 @@ fn (mut g FlatGen) collect_gen_info() {
 		}
 		if kind_id == 61 {
 			ci_t0 := if profile { time.sys_mono_now() } else { u64(0) }
-			full_name := qualify_name_in_module(cur_module, node.value)
-			if g.has_used_fn_filter() && !g.used_fn_contains_in_module(node.value, cur_module) {
+			mut prep := CollectGenFnPrep{}
+			if has_parallel_fn_preps {
+				prep = fn_preps[top_level_pos]
+			}
+			if (has_parallel_fn_preps && !prep.prepared)
+				|| (!has_parallel_fn_preps && g.has_used_fn_filter()
+				&& !g.used_fn_contains_in_module(node.value, cur_module)) {
 				if g.incremental_fn_names.len == 0 {
 					g.preseed_unused_fn_ptr_param_types(node, cur_module, cur_file)
 				}
@@ -3609,12 +3637,11 @@ fn (mut g FlatGen) collect_gen_info() {
 				}
 				continue
 			}
+			full_name := qualify_name_in_module(cur_module, node.value)
 			g.register_fn_decl_node(node.value, cur_module, flat.NodeId(node_idx))
 			ci_p0 := if profile { time.sys_mono_now() } else { u64(0) }
-			prep := if top_level_pos < fn_preps.len && fn_preps[top_level_pos].prepared {
-				fn_preps[top_level_pos]
-			} else {
-				g.compute_collect_gen_fn_prep(node, cur_module, cur_file)
+			if !has_parallel_fn_preps {
+				prep = g.compute_collect_gen_fn_prep(node, cur_module, cur_file)
 			}
 			ptypes := prep.ptypes
 			shared_params := prep.shared_params
@@ -11326,8 +11353,38 @@ fn (g &FlatGen) sum_type_for_expected_value(expected types.Type) ?types.SumType 
 
 fn (g &FlatGen) sum_variant_for_actual(sum_name0 string, actual types.Type) ?string {
 	sum_name := g.resolve_sum_name(sum_name0)
+	actual_name := actual.name()
+	if sum_cache := g.sum_variant_actual_cache.by_sum[sum_name] {
+		if cached := sum_cache.values[actual_name] {
+			if cached.len > 0 {
+				return cached
+			}
+			return none
+		}
+	}
+	result := g.sum_variant_for_actual_uncached(sum_name, actual, actual_name) or {
+		mut cache := g.sum_variant_actual_cache
+		mut sum_cache := cache.by_sum[sum_name] or {
+			created := &SumVariantActualEntries{}
+			cache.by_sum[sum_name] = created
+			created
+		}
+		sum_cache.values[actual_name] = ''
+		return none
+	}
+	mut cache := g.sum_variant_actual_cache
+	mut sum_cache := cache.by_sum[sum_name] or {
+		created := &SumVariantActualEntries{}
+		cache.by_sum[sum_name] = created
+		created
+	}
+	sum_cache.values[actual_name] = result
+	return result
+}
+
+fn (g &FlatGen) sum_variant_for_actual_uncached(sum_name string, actual types.Type, actual_name string) ?string {
 	variants := g.tc.sum_types[sum_name] or { return none }
-	mut variant := g.resolve_variant(sum_name, actual.name())
+	mut variant := g.resolve_variant(sum_name, actual_name)
 	if variant in variants {
 		return variant
 	}
@@ -13618,9 +13675,11 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 		g.write('0')
 		return
 	}
-	if replacement := g.assert_expr_overrides[int(id)] {
-		g.write(replacement)
-		return
+	if g.assert_expr_overrides.len > 0 {
+		if replacement := g.assert_expr_overrides[int(id)] {
+			g.write(replacement)
+			return
+		}
 	}
 	node := unsafe { &g.a.nodes[int(id)] }
 	match node.kind {
@@ -13738,8 +13797,7 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 					return
 				}
 			}
-			is_current_param := node.value in g.cur_param_names
-				|| g.current_param_type(node.value) != none
+			is_current_param := g.current_param_type(node.value) != none
 			is_local := if is_current_param {
 				true
 			} else if owner := g.tc.cur_scope.lookup_owner(node.value) {
@@ -13747,8 +13805,12 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 			} else {
 				false
 			}
-			current_global_name := qualify_name_in_module(g.tc.cur_module, node.value)
-			is_current_module_global := current_global_name in g.global_types
+			current_global_name := if is_local {
+				''
+			} else {
+				qualify_name_in_module(g.tc.cur_module, node.value)
+			}
+			is_current_module_global := !is_local && current_global_name in g.global_types
 			const_name := if !is_local && !is_current_module_global {
 				g.const_ref_name(node.value)
 			} else {
@@ -18994,8 +19056,9 @@ fn (mut g FlatGen) collect_fixed_array_typedefs_needed() map[string]FixedArrayTy
 		g.tc.cur_module = cur_module
 		// Struct-init node types use scratch text while fields are transformed; the
 		// declared struct metadata above is the authoritative fixed-array source.
-		if node.kind != .struct_init && fixed_array_type_text_may_need_typedef(node.typ)
-			&& fixed_array_text_first_seen(node.typ, cur_module, mut text_seen) {
+		if node.kind != .struct_init && node.typ.len > 1
+			&& fixed_array_text_first_seen(node.typ, cur_module, mut text_seen)
+			&& fixed_array_type_text_may_need_typedef(node.typ) {
 			g.collect_fixed_array_typedef_text(node.typ, cur_module, mut needed)
 		}
 		match node.kind {

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -73,6 +73,14 @@ struct FlatFnGenCandidate {
 	item           FlatFnGenItem
 }
 
+struct PreferredFlatFnCandidate {
+mut:
+	node_id                     int = -1
+	rank                        int
+	has_program_specialization  bool
+	preferred_is_specialization bool
+}
+
 struct DirectArrayAccessFns {
 	node_ids         map[int]bool
 	source_positions map[u64]bool
@@ -125,9 +133,7 @@ fn (mut g FlatGen) ensure_fn_gen_items() []FlatFnGenItem {
 
 // collect_fn_gen_items updates collect fn gen items state for c.
 fn (mut g FlatGen) collect_fn_gen_items() []FlatFnGenItem {
-	direct_array_access_fns := g.direct_array_access_fns()
-	ignore_overflow_fns := g.function_attribute_fns('ignore_overflow')
-	program_modules := g.cache_program_module_names()
+	direct_array_access_fns, ignore_overflow_fns, program_modules := g.fn_gen_selection_info()
 	// Defer cost/prep until after preferred-file and emission filtering. When
 	// the parallel path asks for prep, that walk also collects C-extern refs.
 	prep := g.want_parallel_prep
@@ -139,24 +145,21 @@ fn (mut g FlatGen) collect_fn_gen_items() []FlatFnGenItem {
 		g.collect_fn_gen_candidates_range(nodes, 0, nodes.len, '', '', direct_array_access_fns,
 			ignore_overflow_fns, program_modules)
 	}
-	mut preferred_fns := map[string]int{}
-	mut ranks := map[string]int{}
-	mut program_specializations := map[string]bool{}
-	mut preferred_program_specializations := map[string]bool{}
+	mut preferred_fns := map[string]PreferredFlatFnCandidate{}
+	preferred_fns.reserve(u32(candidates.len))
 	for candidate in candidates {
+		mut preferred := preferred_fns[candidate.preferred_name] or { PreferredFlatFnCandidate{} }
 		if candidate.item.is_program_specialization {
-			program_specializations[candidate.preferred_name] = true
+			preferred.has_program_specialization = true
 		}
 		rank := c_backend_fn_file_rank(candidate.item.file)
-		preferred_is_program_specialization := program_specializations[candidate.preferred_name]
-		if candidate.preferred_name !in preferred_fns
-			|| rank > ranks[candidate.preferred_name]
-			|| (rank == ranks[candidate.preferred_name] && preferred_is_program_specialization
-			&& !preferred_program_specializations[candidate.preferred_name]) {
-			preferred_fns[candidate.preferred_name] = int(candidate.item.node_id)
-			ranks[candidate.preferred_name] = rank
-			preferred_program_specializations[candidate.preferred_name] = preferred_is_program_specialization
+		if preferred.node_id < 0 || rank > preferred.rank || (rank == preferred.rank
+			&& preferred.has_program_specialization && !preferred.preferred_is_specialization) {
+			preferred.node_id = int(candidate.item.node_id)
+			preferred.rank = rank
+			preferred.preferred_is_specialization = preferred.has_program_specialization
 		}
+		preferred_fns[candidate.preferred_name] = preferred
 	}
 	mut items := []FlatFnGenItem{cap: candidates.len}
 	mut prep_stack := []flat.NodeId{cap: 256}
@@ -173,10 +176,9 @@ fn (mut g FlatGen) collect_fn_gen_items() []FlatFnGenItem {
 		g.preseed_type_seen = &PreseedTypeSeen{}
 	}
 	for candidate in candidates {
-		if preferred_idx := preferred_fns[candidate.preferred_name] {
-			if preferred_idx != int(candidate.item.node_id) {
-				continue
-			}
+		preferred := preferred_fns[candidate.preferred_name]
+		if preferred.node_id != int(candidate.item.node_id) {
+			continue
 		}
 		item := candidate.item
 		qfn := item.c_name
@@ -208,7 +210,7 @@ fn (mut g FlatGen) collect_fn_gen_items() []FlatFnGenItem {
 			module:                    item.module
 			c_name:                    item.c_name
 			cost:                      cost
-			is_program_specialization: program_specializations[candidate.preferred_name]
+			is_program_specialization: preferred.has_program_specialization
 			is_program:                item.is_program
 			direct_array_access:       item.direct_array_access
 			ignore_overflow:           item.ignore_overflow
@@ -290,49 +292,40 @@ fn (mut g FlatGen) collect_fn_gen_candidates_range(nodes []int, start int, end i
 	return candidates
 }
 
-fn (g &FlatGen) cache_program_module_names() map[string]bool {
-	mut modules := map[string]bool{}
-	if g.cache_program_files.len == 0 {
-		return modules
-	}
+fn (g &FlatGen) fn_gen_selection_info() (DirectArrayAccessFns, DirectArrayAccessFns, map[string]bool) {
+	mut direct_node_ids := map[int]bool{}
+	mut direct_source_positions := map[u64]bool{}
+	mut overflow_node_ids := map[int]bool{}
+	mut overflow_source_positions := map[u64]bool{}
+	mut program_modules := map[string]bool{}
 	mut cur_file_is_program := false
-	for id in g.top_level_nodes() {
-		node := g.a.nodes[id]
-		if node.kind == .file {
-			cur_file_is_program = g.cache_program_files[node.value]
-				|| g.cache_program_files[os.real_path(node.value)]
-			continue
-		}
-		if cur_file_is_program && node.kind == .module_decl {
-			modules[node.value] = true
-		}
-	}
-	return modules
-}
-
-fn (g &FlatGen) direct_array_access_fns() DirectArrayAccessFns {
-	if g.force_bounds_checking {
-		return DirectArrayAccessFns{}
-	}
-	return g.function_attribute_fns('direct_array_access')
-}
-
-fn (g &FlatGen) function_attribute_fns(attr_name string) DirectArrayAccessFns {
-	mut node_ids := map[int]bool{}
-	mut source_positions := map[u64]bool{}
 	for directive_idx in g.top_level_nodes() {
 		directive := g.a.nodes[directive_idx]
+		if directive.kind == .file {
+			cur_file_is_program = g.cache_program_files[directive.value]
+				|| g.cache_program_files[os.real_path(directive.value)]
+			continue
+		}
+		if directive.kind == .module_decl {
+			if cur_file_is_program {
+				program_modules[directive.value] = true
+			}
+			continue
+		}
 		if directive.kind != .directive || !directive.value.starts_with('@attributes:') {
 			continue
 		}
-		mut has_attr := false
+		mut has_direct_array_access := false
+		mut has_ignore_overflow := false
 		for raw_attr in directive.generic_params() {
-			if raw_attr.all_before(':').trim_space() == attr_name {
-				has_attr = true
-				break
+			attr_name := raw_attr.all_before(':').trim_space()
+			if attr_name == 'direct_array_access' && !g.force_bounds_checking {
+				has_direct_array_access = true
+			} else if attr_name == 'ignore_overflow' {
+				has_ignore_overflow = true
 			}
 		}
-		if !has_attr {
+		if !has_direct_array_access && !has_ignore_overflow {
 			continue
 		}
 		target_idx := directive.value['@attributes:'.len..].int()
@@ -343,15 +336,26 @@ fn (g &FlatGen) function_attribute_fns(attr_name string) DirectArrayAccessFns {
 		// Generic templates can be replaced with an empty node after their
 		// concrete declarations are cloned. The directive keeps targeting the
 		// template id, and both nodes retain its source position.
-		node_ids[target_idx] = true
-		if target.pos.is_valid() {
-			source_positions[flat_fn_source_position_key(target)] = true
+		if has_direct_array_access {
+			direct_node_ids[target_idx] = true
+			if target.pos.is_valid() {
+				direct_source_positions[flat_fn_source_position_key(target)] = true
+			}
+		}
+		if has_ignore_overflow {
+			overflow_node_ids[target_idx] = true
+			if target.pos.is_valid() {
+				overflow_source_positions[flat_fn_source_position_key(target)] = true
+			}
 		}
 	}
 	return DirectArrayAccessFns{
-		node_ids:         node_ids
-		source_positions: source_positions
-	}
+		node_ids:         direct_node_ids
+		source_positions: direct_source_positions
+	}, DirectArrayAccessFns{
+		node_ids:         overflow_node_ids
+		source_positions: overflow_source_positions
+	}, program_modules
 }
 
 fn flat_fn_gen_item_cost(a &flat.FlatAst, node_id flat.NodeId) int {
@@ -831,7 +835,7 @@ fn cgen_is_operator_overload_fn(name string) bool {
 	if !name.contains('.') {
 		return false
 	}
-	method := name.all_after_last('.')
+	method := c_short_name_view(name)
 	return method in ['+', '-', '*', '/', '%', '==', '!=', '<', '>', '<=', '>=', '[]', '[]=']
 }
 
@@ -948,7 +952,7 @@ fn (g &FlatGen) qualified_fn_name_in_module_c(module_name string, name string) s
 		&& (module_name.len == 0 || module_name == 'main' || module_name == 'builtin') {
 		return 'v_panic'
 	}
-	synthetic_name := name.all_after_last('.')
+	synthetic_name := c_short_name_view(name)
 	if synthetic_name.starts_with('__v3_sum_eq_') || synthetic_name.starts_with('__v3_autostr_') {
 		return g.cname(synthetic_name)
 	}
@@ -956,7 +960,7 @@ fn (g &FlatGen) qualified_fn_name_in_module_c(module_name string, name string) s
 		clean_name := name.trim_string_left('main.')
 		if clean_name.contains('.') {
 			receiver := clean_name.all_before_last('.')
-			method := clean_name.all_after_last('.')
+			method := c_short_name_view(clean_name)
 			return 'main__${g.cname(receiver)}_${g.cname(method)}'
 		}
 		return 'main__${g.cname(clean_name)}'
@@ -981,7 +985,7 @@ fn qualified_fn_name_in_module(module_name string, name string) string {
 		&& (module_name.len == 0 || module_name == 'main' || module_name == 'builtin') {
 		return 'v_panic'
 	}
-	synthetic_name := name.all_after_last('.')
+	synthetic_name := c_short_name_view(name)
 	if synthetic_name.starts_with('__v3_sum_eq_') || synthetic_name.starts_with('__v3_autostr_') {
 		return c_name(synthetic_name)
 	}
@@ -1085,7 +1089,7 @@ fn (g &FlatGen) c_fn_symbol_exists(candidate string) bool {
 
 // direct_call_name supports direct call name handling for FlatGen.
 fn (mut g FlatGen) direct_call_name(name string) string {
-	synthetic_name := name.all_after_last('.')
+	synthetic_name := c_short_name_view(name)
 	if synthetic_name.starts_with('__v3_sum_eq_') || synthetic_name.starts_with('__v3_autostr_') {
 		return g.cname(synthetic_name)
 	}
@@ -4273,6 +4277,7 @@ fn (mut g FlatGen) gen_fn_in_module(node_id flat.NodeId, node flat.Node, module_
 	g.cur_param_names.clear()
 	g.cur_param_type_values.clear()
 	g.cur_param_types.clear()
+	g.cur_param_name_bits = 0
 	g.cur_concrete_optional_params.clear()
 	g.cur_mut_params.clear()
 	g.cur_mut_pointer_params.clear()
@@ -4302,6 +4307,7 @@ fn (mut g FlatGen) gen_fn_in_module(node_id flat.NodeId, node flat.Node, module_
 				g.cur_param_names << p.value
 				g.cur_param_type_values << param_type
 				g.cur_param_types[p.value] = param_type
+				g.cur_param_name_bits |= current_param_name_bit(p.value)
 				owner := g.tc.cur_scope.insert_with_owner(p.value, param_type)
 				if shared_ct := g.shared_param_c_type(p.typ) {
 					g.declare_local_c_type(owner, shared_ct)
@@ -4580,6 +4586,7 @@ fn (mut g FlatGen) gen_top_level_main(stmts []TopLevelStmt) {
 	g.set_cur_fn_ret(types.Type(types.void_))
 	old_param_names := g.cur_param_names
 	old_param_type_values := g.cur_param_type_values
+	old_param_name_bits := g.cur_param_name_bits
 	mut old_param_types := g.cur_param_types.move()
 	mut old_concrete_optional_params := g.cur_concrete_optional_params.move()
 	mut old_mut_params := g.cur_mut_params.move()
@@ -4587,6 +4594,7 @@ fn (mut g FlatGen) gen_top_level_main(stmts []TopLevelStmt) {
 	mut old_mut_param_owners := g.cur_mut_param_owners.move()
 	g.cur_param_names = []string{}
 	g.cur_param_type_values = []types.Type{}
+	g.cur_param_name_bits = 0
 	g.cur_param_types = map[string]types.Type{}
 	g.cur_concrete_optional_params = map[string]bool{}
 	g.cur_mut_params = map[string]bool{}
@@ -4637,6 +4645,7 @@ fn (mut g FlatGen) gen_top_level_main(stmts []TopLevelStmt) {
 	}
 	g.cur_param_names = old_param_names
 	g.cur_param_type_values = old_param_type_values
+	g.cur_param_name_bits = old_param_name_bits
 	g.cur_param_types = old_param_types.move()
 	g.cur_concrete_optional_params = old_concrete_optional_params.move()
 	g.cur_mut_params = old_mut_params.move()
@@ -5471,7 +5480,7 @@ fn (mut g FlatGen) gen_owned_capture_closure_create(id flat.NodeId, node flat.No
 }
 
 fn (g &FlatGen) trace_call_name(fn_node flat.Node, fn_name string, target_name string, resolved_target_name string) ?string {
-	if 'trace' !in g.compile_values || g.inside_trace_call {
+	if !g.trace_calls || g.inside_trace_call {
 		return none
 	}
 	if g.tc.cur_module in ['builtin', 'debug'] {
@@ -9710,6 +9719,9 @@ fn (g &FlatGen) current_param_type(name string) ?types.Type {
 	if g.cur_param_types.len == 0 {
 		return none
 	}
+	if g.cur_param_name_bits != 0 && g.cur_param_name_bits & current_param_name_bit(name) == 0 {
+		return none
+	}
 	typ := g.cur_param_types[name] or { return none }
 	if g.cur_mut_params.len > 0 && g.current_mut_param_binding_is_shadowed(name) {
 		return none
@@ -9721,11 +9733,23 @@ fn (g &FlatGen) current_param_map_type(name string) ?types.Type {
 	if g.cur_param_types.len == 0 {
 		return none
 	}
+	if g.cur_param_name_bits != 0 && g.cur_param_name_bits & current_param_name_bit(name) == 0 {
+		return none
+	}
 	typ := g.cur_param_types[name] or { return none }
 	if g.cur_mut_params.len > 0 && g.current_mut_param_binding_is_shadowed(name) {
 		return none
 	}
 	return typ
+}
+
+@[direct_array_access; inline]
+fn current_param_name_bit(name string) u64 {
+	if name.len == 0 {
+		return 1
+	}
+	idx := (name.len * 17 + int(name[0]) * 5 + int(name[name.len - 1]) * 3) & 63
+	return u64(1) << idx
 }
 
 fn (g &FlatGen) call_uses_concrete_optional_params(name string) bool {
@@ -14240,7 +14264,9 @@ fn (mut g FlatGen) forward_decls() {
 		g.sb = strings.new_builder(16384)
 		g.line_start = true
 		g.tc = g.clone_parallel_type_checker()
-		g.c_name_cache = &CNameCache{}
+		g.c_name_cache = &CNameCache{
+			base: master_c_name_cache
+		}
 		// Context-cache entries can own strings allocated by this disposable
 		// batch. Disable them until the master caches are restored.
 		g.import_alias_cache = unsafe { nil }
@@ -15395,6 +15421,7 @@ fn (mut g FlatGen) insert_cur_implicit_veb_ctx_param(node flat.Node) {
 	g.cur_param_names = names
 	g.cur_param_type_values = type_values
 	g.cur_param_types['ctx'] = ctx_type
+	g.cur_param_name_bits |= current_param_name_bit('ctx')
 	g.tc.cur_scope.insert('ctx', ctx_type)
 }
 

--- a/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
@@ -220,6 +220,7 @@ $if !windows {
 			g := unsafe { &FlatGen(a.g) }
 			mut text_cache := &PrepTypTextCache{}
 			mut type_seen := &PreseedTypeSeen{}
+			mut resolved_call_cache := &ResolvedCallTypeCache{}
 			mut cur_file := ''
 			mut cur_module := ''
 			for idx in a.start .. a.end {
@@ -233,7 +234,7 @@ $if !windows {
 					}
 					cost, needs_prelude_scan := exact_flat_fn_gen_item_cost_and_prep(g,
 						items[idx].node_id, idx, mut a.refs, mut stack, mut a.cands, mut
-						text_cache, mut type_seen)
+						text_cache, mut type_seen, mut resolved_call_cache)
 					items[idx].cost = cost
 					items[idx].skip_prelude_scan = !needs_prelude_scan
 				}
@@ -1913,6 +1914,9 @@ fn (g &FlatGen) parallel_cached_expr_type(id flat.NodeId, node &flat.Node) ?type
 		return none
 	}
 	if g.tc.parallel_check_sparse && (idx < g.tc.check_range_lo || idx > g.tc.check_range_hi) {
+		if g.tc.sparse_expr_type_values.len == 0 && node.kind != .call {
+			return none
+		}
 		if t := g.tc.sparse_expr_type_values[idx] {
 			return t
 		}
@@ -1948,13 +1952,22 @@ struct FlatCgenPrepCandidate {
 	item_idx int
 }
 
+struct ResolvedCallTypeCache {
+mut:
+	ptrs   [4096]voidptr
+	lens   [4096]int
+	values [4096]types.Type
+	seen   [4096]bool
+	found  [4096]bool
+}
+
 // exact_flat_fn_gen_item_cost_and_prep is exact_flat_fn_gen_item_cost plus the
 // candidate collection of the former serial fused prep walk: distinct type
 // texts and distinct cached expression types, in encounter order. All FlatGen
 // and checker access is read-only (nothing writes the dense expr caches during
 // cgen; every remember_expr_type caller is a mut check-phase path).
 @[direct_array_access]
-fn exact_flat_fn_gen_item_cost_and_prep(g &FlatGen, node_id flat.NodeId, item_idx int, mut c_extern_refs map[string]bool, mut stack []flat.NodeId, mut cands []FlatCgenPrepCandidate, mut text_cache PrepTypTextCache, mut type_seen PreseedTypeSeen) (int, bool) {
+fn exact_flat_fn_gen_item_cost_and_prep(g &FlatGen, node_id flat.NodeId, item_idx int, mut c_extern_refs map[string]bool, mut stack []flat.NodeId, mut cands []FlatCgenPrepCandidate, mut text_cache PrepTypTextCache, mut type_seen PreseedTypeSeen, mut resolved_call_cache ResolvedCallTypeCache) (int, bool) {
 	a := g.a
 	mut cost := 0
 	mut needs_prelude_scan := false
@@ -1985,7 +1998,7 @@ fn exact_flat_fn_gen_item_cost_and_prep(g &FlatGen, node_id flat.NodeId, item_id
 				}
 			}
 		}
-		if parallel_type_text_may_preseed(g, node.typ) {
+		if node.typ.len > 0 {
 			slot := int((u64(voidptr(node.typ.str)) >> 4) & 4095)
 			if text_cache.gens[slot] != text_cache.generation
 				|| text_cache.ptrs[slot] != voidptr(node.typ.str)
@@ -1993,13 +2006,16 @@ fn exact_flat_fn_gen_item_cost_and_prep(g &FlatGen, node_id flat.NodeId, item_id
 				text_cache.ptrs[slot] = voidptr(node.typ.str)
 				text_cache.gens[slot] = text_cache.generation
 				text_cache.lens[slot] = node.typ.len
-				cands << FlatCgenPrepCandidate{
-					text:     node.typ
-					item_idx: item_idx
+				text_cache.verdicts[slot] = parallel_type_text_may_preseed(g, node.typ)
+				if text_cache.verdicts[slot] {
+					cands << FlatCgenPrepCandidate{
+						text:     node.typ
+						item_idx: item_idx
+					}
 				}
 			}
 		}
-		if expr_type := g.parallel_cached_expr_type(id, node) {
+		if expr_type := g.parallel_cached_expr_type_with_cache(id, node, mut resolved_call_cache) {
 			w0, w1, slot := preseed_type_words(expr_type)
 			if !type_seen.seen[slot] || type_seen.w0[slot] != w0 || type_seen.w1[slot] != w1 {
 				type_seen.w0[slot] = w0
@@ -2020,6 +2036,42 @@ fn exact_flat_fn_gen_item_cost_and_prep(g &FlatGen, node_id flat.NodeId, item_id
 		}
 	}
 	return cost, needs_prelude_scan
+}
+
+@[direct_array_access]
+fn (g &FlatGen) parallel_cached_expr_type_with_cache(id flat.NodeId, node &flat.Node, mut cache ResolvedCallTypeCache) ?types.Type {
+	idx := int(id)
+	if idx < 0 {
+		return none
+	}
+	if g.tc.parallel_check_sparse && (idx < g.tc.check_range_lo || idx > g.tc.check_range_hi) {
+		return g.parallel_cached_expr_type(id, node)
+	}
+	if idx < g.tc.expr_type_set.len && idx < g.tc.expr_type_values.len && g.tc.expr_type_set[idx] {
+		return g.tc.expr_type_values[idx]
+	}
+	if node.kind != .call || idx >= g.tc.resolved_call_set.len
+		|| idx >= g.tc.resolved_call_names.len || !g.tc.resolved_call_set[idx] {
+		return none
+	}
+	name := g.tc.resolved_call_names[idx]
+	slot := int((u64(voidptr(name.str)) >> 4 ^ u64(name.len)) & 4095)
+	if cache.seen[slot] && cache.ptrs[slot] == voidptr(name.str) && cache.lens[slot] == name.len {
+		if cache.found[slot] {
+			return cache.values[slot]
+		}
+		return none
+	}
+	cache.ptrs[slot] = voidptr(name.str)
+	cache.lens[slot] = name.len
+	cache.seen[slot] = true
+	if typ := g.tc.fn_ret_types[name] {
+		cache.values[slot] = typ
+		cache.found[slot] = true
+		return typ
+	}
+	cache.found[slot] = false
+	return none
 }
 
 // parallel_type_text_may_preseed cheaply rejects builtin/container type text
@@ -2291,6 +2343,8 @@ fn (g &FlatGen) new_parallel_worker_config(worker_id int, result_only bool) &Fla
 		ierror_method_emit_names:       g.ierror_method_emit_names
 		recursive_drop_helpers:         g.recursive_drop_helpers
 		sum_name_lookup:                g.sum_name_lookup
+		sum_variant_lookup:             g.sum_variant_lookup
+		sum_variant_actual_cache:       &SumVariantActualCache{}
 		module_init_fns:                g.module_init_fns
 		module_init_fn_modules:         g.module_init_fn_modules
 		module_cleanup_fns:             g.module_cleanup_fns
@@ -2306,6 +2360,7 @@ fn (g &FlatGen) new_parallel_worker_config(worker_id int, result_only bool) &Fla
 		has_builtins:                   g.has_builtins
 		cache_split:                    g.cache_split
 		compile_values:                 g.compile_values
+		trace_calls:                    g.trace_calls
 		skip_generics:                  g.skip_generics
 		tmp_count:                      (worker_id + 1) * 100_000
 		line_start:                     true
@@ -2365,6 +2420,7 @@ fn (g &FlatGen) new_parallel_worker_config(worker_id int, result_only bool) &Fla
 		} else {
 			g.cur_param_types.clone()
 		}
+		cur_param_name_bits:            g.cur_param_name_bits
 		cur_concrete_optional_params:   if result_only {
 			g.cur_concrete_optional_params
 		} else {

--- a/vlib/v3/gen/c/interface.v
+++ b/vlib/v3/gen/c/interface.v
@@ -118,10 +118,9 @@ fn (g &FlatGen) sum_type_index_resolved(sum_name string, variant string) int {
 		// vs the registered `map[string]toml.ast.Value`) match on the
 		// module-stripped spelling only when that spelling is unambiguous.
 		if variant.contains('.') || variant.contains('[') {
-			short_variant := short_module_type_text(variant)
 			mut short_match := 0
 			for i, v in g.tc.sum_types[sum_name] {
-				if short_module_type_text(v) == short_variant {
+				if short_module_type_texts_equal(v, variant) {
 					if short_match != 0 {
 						return 0
 					}
@@ -429,12 +428,24 @@ fn (g &FlatGen) resolve_sum_name(sum_name string) string {
 
 fn (mut g FlatGen) precompute_sum_name_lookup() {
 	g.sum_name_lookup = map[string]string{}
-	for name, _ in g.tc.sum_types {
+	g.sum_variant_lookup = map[string]map[string]string{}
+	for name, variants in g.tc.sum_types {
 		g.sum_name_lookup[name] = name
 		short := c_short_name_view(name)
 		if short.len > 0 && short !in g.sum_name_lookup {
 			g.sum_name_lookup[short] = name
 		}
+		mut lookup := map[string]string{}
+		for variant in variants {
+			lookup[variant] = variant
+		}
+		for variant in variants {
+			variant_short := c_short_name_view(variant)
+			if variant_short.len > 0 && variant_short !in lookup {
+				lookup[variant_short] = variant
+			}
+		}
+		g.sum_variant_lookup[name] = lookup.move()
 	}
 }
 
@@ -442,16 +453,9 @@ fn (mut g FlatGen) precompute_sum_name_lookup() {
 fn (g &FlatGen) resolve_variant(sum_name string, variant string) string {
 	resolved_sum := g.resolve_sum_name(sum_name)
 	normalized_variant := g.normalize_variant_name(variant)
-	if resolved_sum in g.tc.sum_types {
-		for v in g.tc.sum_types[resolved_sum] {
-			if v == normalized_variant {
-				return normalized_variant
-			}
-		}
-		for v in g.tc.sum_types[resolved_sum] {
-			if v.all_after_last('.') == normalized_variant {
-				return v
-			}
+	if lookup := g.sum_variant_lookup[resolved_sum] {
+		if resolved := lookup[normalized_variant] {
+			return resolved
 		}
 	}
 	return normalized_variant
@@ -2092,32 +2096,69 @@ fn (g &FlatGen) interface_concrete_type(concrete string) types.Type {
 	return g.tc.parse_type(concrete)
 }
 
-// short_module_type_text strips module qualifiers from every identifier in a
-// type text: `map[string]toml.ast.Value` -> `map[string]Value`.
-fn short_module_type_text(text string) string {
-	mut out := []u8{cap: text.len}
-	mut i := 0
-	for i < text.len {
-		c := text[i]
-		if (c >= `a` && c <= `z`) || (c >= `A` && c <= `Z`) || c == `_` {
-			start := i
-			for i < text.len {
-				c2 := text[i]
-				if (c2 >= `a` && c2 <= `z`) || (c2 >= `A` && c2 <= `Z`)
-					|| (c2 >= `0` && c2 <= `9`) || c2 == `_` || c2 == `.` {
-					i++
-				} else {
-					break
-				}
+// short_module_type_texts_equal compares the module-stripped spellings without
+// allocating either temporary text. Identifier tokens retain only the suffix
+// after their final dot; punctuation is compared byte for byte.
+@[direct_array_access]
+fn short_module_type_texts_equal(a string, b string) bool {
+	mut ai := 0
+	mut bi := 0
+	for ai < a.len && bi < b.len {
+		ac := a[ai]
+		bc := b[bi]
+		a_ident := (ac >= `a` && ac <= `z`) || (ac >= `A` && ac <= `Z`) || ac == `_`
+		b_ident := (bc >= `a` && bc <= `z`) || (bc >= `A` && bc <= `Z`) || bc == `_`
+		if a_ident != b_ident {
+			return false
+		}
+		if !a_ident {
+			if ac != bc {
+				return false
 			}
-			token := text[start..i]
-			unsafe { out.push_many(token.all_after_last('.').str, token.all_after_last('.').len) }
+			ai++
+			bi++
 			continue
 		}
-		out << c
-		i++
+		mut a_short := ai
+		mut b_short := bi
+		mut a_end := ai
+		mut b_end := bi
+		for a_end < a.len {
+			c := a[a_end]
+			if (c >= `a` && c <= `z`) || (c >= `A` && c <= `Z`)
+				|| (c >= `0` && c <= `9`) || c == `_` || c == `.` {
+				if c == `.` {
+					a_short = a_end + 1
+				}
+				a_end++
+				continue
+			}
+			break
+		}
+		for b_end < b.len {
+			c := b[b_end]
+			if (c >= `a` && c <= `z`) || (c >= `A` && c <= `Z`)
+				|| (c >= `0` && c <= `9`) || c == `_` || c == `.` {
+				if c == `.` {
+					b_short = b_end + 1
+				}
+				b_end++
+				continue
+			}
+			break
+		}
+		if a_end - a_short != b_end - b_short {
+			return false
+		}
+		for offset in 0 .. a_end - a_short {
+			if a[a_short + offset] != b[b_short + offset] {
+				return false
+			}
+		}
+		ai = a_end
+		bi = b_end
 	}
-	return out.bytestr()
+	return ai == a.len && bi == b.len
 }
 
 fn (mut g FlatGen) interface_implicit_str_expr(typ types.Type, expr string, quote_string bool, mut stack []string) ?string {

--- a/vlib/v3/gen/c/names.v
+++ b/vlib/v3/gen/c/names.v
@@ -30,6 +30,31 @@ fn c_name_recent_slot(name string) int {
 	return int(((u64(voidptr(name.str)) >> 4) ^ u64(name.len)) & 1023)
 }
 
+// c_name_is_pre_sanitized reports names that are already unambiguously in V's
+// module-qualified C spelling. C keywords, libc collisions and special builtin
+// rewrites never contain `__`, so these names can bypass the map-backed slow
+// path after their direct-cache miss.
+@[direct_array_access; inline]
+fn c_name_is_pre_sanitized(name string) bool {
+	mut previous_underscore := false
+	mut has_double_underscore := false
+	for i in 0 .. name.len {
+		c := name[i]
+		if (c < `a` || c > `z`) && (c < `A` || c > `Z`) && (c < `0` || c > `9`) && c != `_` {
+			return false
+		}
+		if c == `_` {
+			if previous_underscore {
+				has_double_underscore = true
+			}
+			previous_underscore = true
+		} else {
+			previous_underscore = false
+		}
+	}
+	return has_double_underscore
+}
+
 @[inline]
 fn (c &CNameCache) recent(name string) ?string {
 	if name.len > 65535 {
@@ -228,6 +253,12 @@ fn (g &FlatGen) cname(name string) string {
 		cache.last_name = name
 		cache.last_value = cached
 		return cached
+	}
+	if c_name_is_pre_sanitized(name) {
+		cache.last_name = name
+		cache.last_value = name
+		cache.remember(name, name)
+		return name
 	}
 	if cached := cache.entries[name] {
 		cache.last_name = name

--- a/vlib/v3/gen/c/names_test.v
+++ b/vlib/v3/gen/c/names_test.v
@@ -21,6 +21,15 @@ fn test_c_name_sanitize_escaped_keywords() {
 	assert c_name('Kind.@asm') == 'Kind___v_asm'
 }
 
+fn test_c_name_pre_sanitized_classifier() {
+	assert c_name_is_pre_sanitized('main__run')
+	assert c_name_is_pre_sanitized('foo__Bar__method')
+	assert !c_name_is_pre_sanitized('send')
+	assert !c_name_is_pre_sanitized('C.printf')
+	assert !c_name_is_pre_sanitized('foo__bar-baz')
+	assert !c_name_is_pre_sanitized('_str_1')
+}
+
 fn test_c_name_sanitizes_compound_generic_type_arguments() {
 	name :=
 		c_name('json2.StructKeyDecodeResult[fn(&mbedtls.SSLListener, string) !&mbedtls.SSLCerts]')

--- a/vlib/v3/gen/c/stmt.v
+++ b/vlib/v3/gen/c/stmt.v
@@ -4962,7 +4962,7 @@ fn (g &FlatGen) type_names_match(a types.Type, b types.Type) bool {
 	if a_name == b_name {
 		return true
 	}
-	return short_module_type_text(a_name) == short_module_type_text(b_name)
+	return short_module_type_texts_equal(a_name, b_name)
 }
 
 fn (g &FlatGen) array_abi_types_match(a types.Type, b types.Type) bool {

--- a/vlib/v3/gen/c/str_intp.v
+++ b/vlib/v3/gen/c/str_intp.v
@@ -383,8 +383,8 @@ fn (mut g FlatGen) string_literals_from(start int) {
 
 // intern_string supports intern string handling for FlatGen.
 fn (mut g FlatGen) intern_string(s string) int {
-	if s in g.str_lit_ids {
-		return g.str_lit_ids[s]
+	if id := g.str_lit_ids[s] {
+		return id
 	}
 	if g.str_lits_shared {
 		g.str_lits = g.str_lits.clone()

--- a/vlib/v3/gen/c/struct.v
+++ b/vlib/v3/gen/c/struct.v
@@ -3748,9 +3748,10 @@ fn (g &FlatGen) find_struct_decl_preferred(type_name string) ?StructDeclInfo {
 }
 
 fn (g &FlatGen) find_struct_decl_preferred_uncached(type_name string) ?StructDeclInfo {
-	short_name := if type_name.contains('.') { type_name.all_after_last('.') } else { type_name }
-	preferred_name := if !type_name.contains('.') && g.tc.cur_module.len > 0
-		&& g.tc.cur_module != 'main' && g.tc.cur_module != 'builtin' {
+	has_dot := type_name.contains('.')
+	short_name := if has_dot { c_short_name_view(type_name) } else { type_name }
+	preferred_name := if !has_dot && g.tc.cur_module.len > 0 && g.tc.cur_module != 'main'
+		&& g.tc.cur_module != 'builtin' {
 		'${g.tc.cur_module}.${type_name}'
 	} else {
 		type_name
@@ -3760,7 +3761,7 @@ fn (g &FlatGen) find_struct_decl_preferred_uncached(type_name string) ?StructDec
 			return info
 		}
 	}
-	if type_name.contains('.') {
+	if has_dot {
 		if info := g.struct_decl_infos[type_name] {
 			return info
 		}

--- a/vlib/v3/gen/c/types.v
+++ b/vlib/v3/gen/c/types.v
@@ -394,19 +394,35 @@ fn (mut g FlatGen) collect_optional_typedefs() {
 	g.collect_declaration_signature_types()
 	// Calls without a resolved expression type are the only optional-type source
 	// not covered by the shared declaration-signature scan.
+	mut seen_type_ids := []bool{len: 65536}
+	mut seen_type_texts := map[string]bool{}
 	for idx, node in g.a.nodes {
 		if node.kind != .call || (idx < g.tc.expr_type_set.len && g.tc.expr_type_set[idx]) {
 			continue
 		}
 		if idx < g.tc.resolved_call_set.len && g.tc.resolved_call_set[idx] {
 			name := g.tc.resolved_call_names[idx]
-			if typ := g.tc.fn_ret_types[name] {
-				g.collect_optional_typedef_type(typ)
+			if name in g.tc.fn_ret_types {
+				// collect_declaration_signature_types() already processed this exact
+				// return entry; only calls without checker return metadata need their
+				// transformed node spelling inspected below.
 				continue
 			}
 		}
 		if node.typ.len > 0 && node.typ !in ['int', 'array', 'map', 'unknown']
 			&& cgen_type_text_is_complete(node.typ) {
+			type_id := node.type_text_id()
+			if type_id != 0 {
+				if seen_type_ids[int(type_id)] {
+					continue
+				}
+				seen_type_ids[int(type_id)] = true
+			} else {
+				if node.typ in seen_type_texts {
+					continue
+				}
+				seen_type_texts[node.typ] = true
+			}
 			g.collect_optional_typedef_type(g.parse_node_type(&node))
 		}
 	}
@@ -449,7 +465,8 @@ fn (mut g FlatGen) collect_declaration_signature_types() {
 	// Parallel monomorph workers can append concrete declarations before their
 	// checker signature maps are merged. Read declaration nodes directly too, so
 	// an option/result used only by a worker specialization still gets a typedef.
-	for idx, node in g.a.nodes {
+	for idx in g.top_level_nodes() {
+		node := g.a.nodes[idx]
 		if node.kind != .fn_decl {
 			continue
 		}

--- a/vlib/v3/markused/markused.v
+++ b/vlib/v3/markused/markused.v
@@ -261,6 +261,9 @@ fn mark_used_with_test_files(a &flat.FlatAst, tc &types.TypeChecker, test_files 
 			import_contexts = prepared.import_contexts
 			marked_roots = prepared.marked_roots
 			c_interface_roots = prepared.c_interface_roots
+			body_ids = prepared.body_ids
+			body_modules = prepared.body_modules
+			body_import_contexts = prepared.body_import_contexts
 		}
 	}
 
@@ -585,26 +588,27 @@ fn mark_used_with_test_files(a &flat.FlatAst, tc &types.TypeChecker, test_files 
 	mut not_in_cg := 0
 	mut total_callees := 0
 	collector := CallCollector{
-		a:                       a
-		tc:                      tc
-		fn_decls:                fn_decls
-		fn_suffixes:             fn_name_suffixes
-		struct_decls:            struct_decls
-		const_decls:             const_decls
-		const_suffixes:          const_name_suffixes
-		import_contexts:         import_contexts
-		selective_alias_targets: if detect_reachable_generics {
+		a:                                a
+		tc:                               tc
+		fn_decls:                         fn_decls
+		fn_suffixes:                      fn_name_suffixes
+		struct_decls:                     struct_decls
+		const_decls:                      const_decls
+		const_suffixes:                   const_name_suffixes
+		import_contexts:                  import_contexts
+		selective_alias_targets:          if detect_reachable_generics {
 			markused_selective_alias_targets(tc)
 		} else {
 			map[string][]string{}
 		}
-		iface_param_gate:        if detect_reachable_generics {
+		iface_param_gate:                 if detect_reachable_generics {
 			markused_interface_param_gate(tc)
 		} else {
 			map[string]bool{}
 		}
-		generic_type_bases:      generic_type_bases
-		detect_generics:         detect_reachable_generics
+		generic_type_bases:               generic_type_bases
+		detect_generics:                  detect_reachable_generics
+		body_checker_edges_authoritative: use_prepared && !detect_reachable_generics
 	}
 	// Precollect every body's call/initializer-ref lists up front (across
 	// threads when available): the BFS below then only does the cheap
@@ -1751,6 +1755,9 @@ mut:
 	marked_roots          []string
 	c_interface_roots     []string
 	auto_roots            []string
+	body_ids              []int
+	body_modules          []string
+	body_import_contexts  []int
 	needs_closure_runtime bool
 	scope                 voidptr
 	ready                 bool
@@ -1786,14 +1793,17 @@ pub fn (mut prepared PreparedMarkusedDecls) release() {
 
 fn build_prepared_markused_declarations(a &flat.FlatAst, tc &types.TypeChecker) &PreparedMarkusedDecls {
 	mut result := &PreparedMarkusedDecls{
-		fn_decls:            map[string]FnDeclInfo{}
-		fn_decl_lists:       map[string][]FnDeclInfo{}
-		struct_decls:        map[string]StructDeclInfo{}
-		const_decls:         map[string]ConstDeclInfo{}
-		fn_name_suffixes:    map[string]bool{}
-		const_name_suffixes: map[string]bool{}
-		suffix_map:          map[string][]string{}
-		import_contexts:     []map[string]string{cap: 256}
+		fn_decls:             map[string]FnDeclInfo{}
+		fn_decl_lists:        map[string][]FnDeclInfo{}
+		struct_decls:         map[string]StructDeclInfo{}
+		const_decls:          map[string]ConstDeclInfo{}
+		fn_name_suffixes:     map[string]bool{}
+		const_name_suffixes:  map[string]bool{}
+		suffix_map:           map[string][]string{}
+		import_contexts:      []map[string]string{cap: 256}
+		body_ids:             []int{cap: 8192}
+		body_modules:         []string{cap: 8192}
+		body_import_contexts: []int{cap: 8192}
 	}
 	result.import_contexts << map[string]string{}
 	result.fn_decls.reserve(u32(tc.fn_ret_types.len))
@@ -1876,6 +1886,9 @@ fn build_prepared_markused_declarations(a &flat.FlatAst, tc &types.TypeChecker) 
 		fn_decl_file := tc.fn_type_files[decl_qname] or { decl_file }
 		fn_decl_module := tc.fn_type_modules[decl_qname] or { decl_module }
 		fn_decl_import_context := import_context_by_file[fn_decl_file] or { decl_import_context }
+		result.body_ids << node_idx
+		result.body_modules << fn_decl_module
+		result.body_import_contexts << fn_decl_import_context
 		has_dot := node.value.index_u8(`.`) >= 0
 		can_suffix_match := !markused_fn_decl_is_generic_template(node, a)
 		info := FnDeclInfo{
@@ -1973,7 +1986,8 @@ struct CallCollector {
 	generic_type_bases map[string]bool
 	// Self-host builds are known not to need monomorphization, so they can omit
 	// generic-only reachability probes while preserving ordinary call collection.
-	detect_generics bool
+	detect_generics                  bool
+	body_checker_edges_authoritative bool
 }
 
 fn (c &CallCollector) imports(context int) map[string]string {
@@ -4408,7 +4422,8 @@ fn (c &CallCollector) collect_body(node &flat.Node, cur_module string, imports m
 	}
 	result.uses_generics = c.collect_calls_with_locals_and_generics(node, cur_module, imports,
 		receiver_name, receiver_struct, local_values, local_types, visible_local_idents,
-		c.detect_generics, result.uses_generics, mut result.calls, mut result.refs, true)
+		c.body_checker_edges_authoritative, c.detect_generics, result.uses_generics, mut
+		result.calls, mut result.refs, true)
 	return result
 }
 
@@ -4426,18 +4441,19 @@ fn (c &CallCollector) collect_bodies_range(body_ids []int, body_modules []string
 // TypeChecker. The lookup maps are shared read-only.
 fn (c &CallCollector) fork_with_tc(wtc &types.TypeChecker) CallCollector {
 	return CallCollector{
-		a:                       c.a
-		tc:                      wtc
-		fn_decls:                c.fn_decls
-		fn_suffixes:             c.fn_suffixes
-		struct_decls:            c.struct_decls
-		const_decls:             c.const_decls
-		const_suffixes:          c.const_suffixes
-		import_contexts:         c.import_contexts
-		selective_alias_targets: c.selective_alias_targets
-		iface_param_gate:        c.iface_param_gate
-		generic_type_bases:      c.generic_type_bases
-		detect_generics:         c.detect_generics
+		a:                                c.a
+		tc:                               wtc
+		fn_decls:                         c.fn_decls
+		fn_suffixes:                      c.fn_suffixes
+		struct_decls:                     c.struct_decls
+		const_decls:                      c.const_decls
+		const_suffixes:                   c.const_suffixes
+		import_contexts:                  c.import_contexts
+		selective_alias_targets:          c.selective_alias_targets
+		iface_param_gate:                 c.iface_param_gate
+		generic_type_bases:               c.generic_type_bases
+		detect_generics:                  c.detect_generics
+		body_checker_edges_authoritative: c.body_checker_edges_authoritative
 	}
 }
 
@@ -4463,8 +4479,8 @@ fn (c &CallCollector) collect_calls_with_generic_usage(node &flat.Node, cur_modu
 	uses_generics := c.node_uses_generics(node, cur_module, imports)
 	mut no_refs := []string{}
 	return c.collect_calls_with_locals_and_generics(node, cur_module, imports, receiver_name,
-		receiver_struct, local_values, local_types, visible_local_idents, true, uses_generics, mut
-		calls, mut no_refs, false)
+		receiver_struct, local_values, local_types, visible_local_idents, false, true,
+		uses_generics, mut calls, mut no_refs, false)
 }
 
 // collect_calls_with_locals is collect_calls with the per-body local-value
@@ -4475,12 +4491,12 @@ fn (c &CallCollector) collect_calls_with_locals(node &flat.Node, cur_module stri
 	uses_generics := false
 	mut no_refs := []string{}
 	_ = c.collect_calls_with_locals_and_generics(node, cur_module, imports, receiver_name,
-		receiver_struct, local_values, local_types, visible_local_idents, false, uses_generics, mut
-		calls, mut no_refs, false)
+		receiver_struct, local_values, local_types, visible_local_idents, false, false,
+		uses_generics, mut calls, mut no_refs, false)
 }
 
 @[direct_array_access]
-fn (c &CallCollector) collect_calls_with_locals_and_generics(node &flat.Node, cur_module string, imports map[string]string, receiver_name string, receiver_struct string, local_values map[string]bool, local_types map[string]string, visible_local_idents map[int]bool, detect_generics bool, initial_uses_generics bool, mut calls []string, mut initializer_refs []string, collect_initializer_refs bool) bool {
+fn (c &CallCollector) collect_calls_with_locals_and_generics(node &flat.Node, cur_module string, imports map[string]string, receiver_name string, receiver_struct string, local_values map[string]bool, local_types map[string]string, visible_local_idents map[int]bool, source_edges_authoritative bool, detect_generics bool, initial_uses_generics bool, mut calls []string, mut initializer_refs []string, collect_initializer_refs bool) bool {
 	mut uses_generics := initial_uses_generics
 	if cur_module == 'ast' && node.value == 'TypeSymbol.find_method_with_generic_parent' {
 		c.add_typed_receiver_method_name('ast.Table.find_structured_receiver_method', mut calls)
@@ -4517,8 +4533,10 @@ fn (c &CallCollector) collect_calls_with_locals_and_generics(node &flat.Node, cu
 					c.add_initializer_ref_candidates(child.value, cur_module, imports, mut
 						initializer_refs)
 				}
-				c.collect_fn_value_ident(child_id, child.value, cur_module, imports, name_is_local, mut
-					calls)
+				if !source_edges_authoritative {
+					c.collect_fn_value_ident(child_id, child.value, cur_module, imports,
+						name_is_local, mut calls)
+				}
 			}
 			.selector {
 				if collect_initializer_ref && !c.selector_base_is_local(child, local_values)
@@ -4531,7 +4549,7 @@ fn (c &CallCollector) collect_calls_with_locals_and_generics(node &flat.Node, cu
 				}
 				if c.selector_is_enum_value(child, cur_module, imports, local_values) {
 					// Enum fields are values even when a method has the same name.
-				} else {
+				} else if !source_edges_authoritative {
 					c.collect_fn_value_selector(child_id, child, cur_module, imports, mut calls)
 				}
 			}
@@ -4550,7 +4568,7 @@ fn (c &CallCollector) collect_calls_with_locals_and_generics(node &flat.Node, cu
 						imports, local_values, mut calls)
 				}
 				c.collect_lowered_join_path_single(child, resolved_call, mut calls)
-				if child.children_count > 0 {
+				if !source_edges_authoritative && child.children_count > 0 {
 					callee_id := c.a.child(child, 0)
 					if int(callee_id) >= 0 {
 						mut callee := c.a.nodes[int(callee_id)]
@@ -4716,18 +4734,20 @@ fn (c &CallCollector) collect_calls_with_locals_and_generics(node &flat.Node, cu
 							calls << resolved_call
 						}
 					}
-				} else if resolved_call.len > 0 {
+				} else if !source_edges_authoritative && resolved_call.len > 0 {
 					calls << resolved_call
 				}
-				for ci in 1 .. child.children_count {
-					arg_id := c.a.child(child, ci)
-					if int(arg_id) >= 0 {
-						arg := c.a.nodes[int(arg_id)]
-						if arg.kind == .ident && arg.value.len > 0 {
-							arg_is_local := markused_ident_is_visible_local(arg_id, arg.value,
-								local_values, visible_local_idents)
-							c.collect_fn_value_ident(arg_id, arg.value, cur_module, imports,
-								arg_is_local, mut calls)
+				if !source_edges_authoritative {
+					for ci in 1 .. child.children_count {
+						arg_id := c.a.child(child, ci)
+						if int(arg_id) >= 0 {
+							arg := c.a.nodes[int(arg_id)]
+							if arg.kind == .ident && arg.value.len > 0 {
+								arg_is_local := markused_ident_is_visible_local(arg_id, arg.value,
+									local_values, visible_local_idents)
+								c.collect_fn_value_ident(arg_id, arg.value, cur_module, imports,
+									arg_is_local, mut calls)
+							}
 						}
 					}
 				}
@@ -4872,7 +4892,7 @@ fn (c &CallCollector) call_callee_expr_to_collect(node &flat.Node) ?flat.NodeId 
 			return none
 		}
 		base_id := c.a.child(callee, 0)
-		if int(base_id) >= 0 && (c.expr_contains_call(base_id) || c.expr_contains_index(base_id)) {
+		if int(base_id) >= 0 && c.expr_contains_call_or_index(base_id) {
 			return base_id
 		}
 		return none
@@ -4886,7 +4906,7 @@ fn (c &CallCollector) call_callee_expr_to_collect(node &flat.Node) ?flat.NodeId 
 	return none
 }
 
-fn (c &CallCollector) expr_contains_index(id flat.NodeId) bool {
+fn (c &CallCollector) expr_contains_call_or_index(id flat.NodeId) bool {
 	if int(id) < 0 {
 		return false
 	}
@@ -4897,7 +4917,7 @@ fn (c &CallCollector) expr_contains_index(id flat.NodeId) bool {
 			continue
 		}
 		node := c.a.node(cur_id)
-		if node.kind == .index {
+		if node.kind in [.call, .index] {
 			return true
 		}
 		for i in 0 .. node.children_count {

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -67,8 +67,10 @@ mut:
 	next_file_id          int = 1
 	cur_module            string
 	cur_fn                string
-	cur_veb_ctx_name      string   // source-level name of the active veb request context
-	veb_tmpl_counter      int      // monotonic id for unique `$veb.html`/`$tmpl` builder var names
+	cur_veb_ctx_name      string // source-level name of the active veb request context
+	veb_tmpl_counter      int    // monotonic id for unique `$veb.html`/`$tmpl` builder var names
+	has_veb_template      bool
+	may_have_local_types  bool
 	cur_struct            string   // receiver type name of the current method, for `@STRUCT`
 	cur_method_is_static  bool     // distinguishes `Type.method()` from `(x Type) method()` for `@LOCATION`
 	defer_depth           int      // >0 while parsing a `defer` block body; gates `$res()` to defer contexts only
@@ -297,6 +299,8 @@ pub fn (mut p Parser) parse_into(path string) {
 	// every source buffer so those views remain valid through later phases.
 	p.a.source_buffers << src
 	stable_src := p.a.source_buffers.last()
+	p.has_veb_template = false
+	p.may_have_local_types = stable_src.contains('struct') || stable_src.contains('union')
 	p.unsupported_inline_asm_guards.clear()
 	if !p.prefs.supports_inline_asm {
 		p.precollect_unsupported_inline_asm_guards(stable_src, p.prefs.target.arch)
@@ -12577,6 +12581,9 @@ fn local_type_decl_name_for_scope(name string, scope string) string {
 }
 
 fn (mut p Parser) predeclare_local_type_names_in_block(open_brace_pos int) {
+	if !p.may_have_local_types {
+		return
+	}
 	scope := p.current_local_type_scope()
 	if scope.len == 0 || open_brace_pos < 0 || open_brace_pos >= p.s.src.len {
 		return

--- a/vlib/v3/parser/tmpl.v
+++ b/vlib/v3/parser/tmpl.v
@@ -1120,6 +1120,7 @@ fn (mut p Parser) parse_veb_template_expr(is_html bool) flat.NodeId {
 		return p.add_val_id(5, '')
 	}
 	path := p.resolve_veb_template_path(is_html, arg)
+	p.has_veb_template = true
 	return p.add_node(flat.Node{
 		kind:  .veb_template
 		value: path
@@ -1580,6 +1581,9 @@ fn template_interpolation_expr_span(line string, at int) ?(int, int) {
 // `mut <b> := ''; <writes>; return <context>.html(<b>)`, and `x := $tmpl(p)` becomes
 // `mut <b> := ''; <writes>; x := <b>`. Returns none for any other statement.
 fn (mut p Parser) expand_veb_template_stmt(stmt_id flat.NodeId) ?[]flat.NodeId {
+	if !p.has_veb_template {
+		return none
+	}
 	if int(stmt_id) < 0 || int(stmt_id) >= p.a.nodes.len {
 		return none
 	}

--- a/vlib/v3/tests/markused_test.v
+++ b/vlib/v3/tests/markused_test.v
@@ -430,6 +430,44 @@ fn main() {
 	assert used['new_map']
 }
 
+fn test_prepared_markused_combines_exact_and_lowered_dependencies() {
+	src := os.join_path(os.temp_dir(), 'v3_markused_prepared_exact_edges.v')
+	os.write_file(src, '
+fn direct_target() {}
+fn callback_target() {}
+fn take_callback(callback fn ()) { callback() }
+fn default_target() int { return 1 }
+
+struct Config {
+	value int = default_target()
+}
+
+fn main() {
+	direct_target()
+	take_callback(callback_target)
+	_ := Config{}
+}
+') or {
+		panic(err)
+	}
+	prefs := pref.new_preferences()
+	mut p := parser.Parser.new(prefs)
+	mut a := p.parse_file(src)
+	mut tc := types.TypeChecker.new(a)
+	tc.enable_globals = true
+	tc.collect(a)
+	tc.diagnostic_files[src] = true
+	prepared_thread := spawn markused.prepare_markused_declarations(a, &tc, true)
+	tc.check_semantics()
+	assert tc.errors.len == 0, tc.errors.str()
+	mut prepared := prepared_thread.wait()
+	used := markused.mark_used_without_generic_detection_prepared(a, &tc, mut prepared)
+	prepared.release()
+	assert used['direct_target']
+	assert used['callback_target']
+	assert used['default_target']
+}
+
 fn test_self_typed_default_collects_explicit_initializer_calls() {
 	used := mark_used_source('self_typed_default_explicit_call', '
 interface Value {}

--- a/vlib/v3/transform/expr.v
+++ b/vlib/v3/transform/expr.v
@@ -1225,7 +1225,7 @@ fn (t &Transformer) is_type_alias_name(name string) bool {
 	}
 	if !isnil(t.type_alias_name_cache) {
 		mut cache := t.type_alias_name_cache
-		if cache.module != t.cur_module {
+		if !same_transform_text(cache.module, t.cur_module) {
 			cache.module = t.cur_module
 			cache.entries.clear()
 			cache.last_name = ''

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -332,7 +332,7 @@ fn (t &Transformer) resolve_collection_receiver_method_name(base_id flat.NodeId,
 fn (t &Transformer) resolve_receiver_method_for_type(receiver_type string, method string) ?string {
 	if !isnil(t.receiver_method_cache) {
 		mut cache := t.receiver_method_cache
-		if cache.module != t.cur_module || cache.fn_count != t.fn_ret_types.len {
+		if !same_transform_text(cache.module, t.cur_module) || cache.fn_count != t.fn_ret_types.len {
 			cache.module = t.cur_module
 			cache.fn_count = t.fn_ret_types.len
 			cache.entries.clear()
@@ -5327,7 +5327,7 @@ fn (t &Transformer) lookup_str_alias_uncached(clean_typ string) ?string {
 			}
 		}
 		for aname, target in t.tc.type_aliases {
-			if aname.all_after_last('.') == clean_typ {
+			if short_name_view(aname) == clean_typ {
 				return target
 			}
 		}
@@ -13574,7 +13574,7 @@ fn (t &Transformer) checker_resolved_non_builtin_return_type_uncached(id flat.No
 	}
 	if node.children_count > 0 && t.cur_module.len > 0 && t.cur_module !in ['main', 'builtin'] {
 		fn_node := t.a.child_node(&node, 0)
-		short_name := name.all_after_last('.')
+		short_name := short_name_view(name)
 		if fn_node.kind == .ident && fn_node.value == short_name {
 			qname := '${t.cur_module}.${short_name}'
 			if ret := t.tc.fn_ret_types[qname] {

--- a/vlib/v3/transform/interface.v
+++ b/vlib/v3/transform/interface.v
@@ -123,7 +123,8 @@ fn (t &Transformer) resolve_interface_type_name(name string) string {
 		return t.resolve_interface_type_name_uncached(name)
 	}
 	mut cache := t.interface_type_cache
-	if cache.module != t.cur_module || cache.file != t.cur_file {
+	if !same_transform_text(cache.module, t.cur_module)
+		|| !same_transform_text(cache.file, t.cur_file) {
 		cache.module = t.cur_module
 		cache.file = t.cur_file
 		cache.entries.clear()

--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -12526,7 +12526,7 @@ fn (t &Transformer) generic_arg_is_unresolved(arg string) bool {
 	// (both fixed during body transforms), memoized per (module, text).
 	if !isnil(t.generic_unresolved_cache) {
 		mut cache := t.generic_unresolved_cache
-		if cache.module != t.cur_module {
+		if !same_transform_text(cache.module, t.cur_module) {
 			cache.module = t.cur_module
 			cache.entries.clear()
 			cache.last_name = ''

--- a/vlib/v3/transform/sum.v
+++ b/vlib/v3/transform/sum.v
@@ -125,7 +125,7 @@ fn (t &Transformer) resolve_sum_name(sum_name string) string {
 		return t.resolve_sum_name_uncached(sum_name)
 	}
 	mut c := t.sum_cache
-	if c.module != t.cur_module {
+	if !same_transform_text(c.module, t.cur_module) {
 		c.module = t.cur_module
 		c.entries.clear()
 		c.clear_recent()
@@ -184,7 +184,8 @@ fn (t &Transformer) resolve_sum_name_uncached(sum_name string) string {
 			return resolved_base
 		}
 	}
-	if sum_name.contains('.') {
+	has_dot := sum_name.contains('.')
+	if has_dot {
 		// Import-aliased module path: `tast.Value` names `sub.tast.Value`.
 		// The full-suffix match runs before the bare short-name fallback so an
 		// unrelated short `Value` sum cannot shadow the aliased one; ambiguous
@@ -215,22 +216,21 @@ fn (t &Transformer) resolve_sum_name_uncached(sum_name string) string {
 		if !suffix_ambiguous && suffix_match.len > 0 {
 			return suffix_match
 		}
-		short_sum := sum_name.all_after_last('.')
+		short_sum := short_name_view(sum_name)
 		if short_sum in t.sum_types {
 			return short_sum
 		}
 	}
-	if !sum_name.contains('.') && t.cur_module.len > 0 && t.cur_module != 'main'
-		&& t.cur_module != 'builtin' {
+	if !has_dot && t.cur_module.len > 0 && t.cur_module != 'main' && t.cur_module != 'builtin' {
 		qsum := '${t.cur_module}.${sum_name}'
 		if qsum in t.sum_types {
 			return qsum
 		}
 	}
-	if !sum_name.contains('.') {
+	if !has_dot {
 		mut found := ''
 		for key, _ in t.sum_types {
-			if key.contains('.') && key.all_after_last('.') == sum_name {
+			if key.contains('.') && short_name_view(key) == sum_name {
 				if found.len > 0 && found != key {
 					found = ''
 					break
@@ -246,23 +246,22 @@ fn (t &Transformer) resolve_sum_name_uncached(sum_name string) string {
 		if sum_name in t.tc.sum_types {
 			return sum_name
 		}
-		if sum_name.contains('.') {
-			short_sum := sum_name.all_after_last('.')
+		if has_dot {
+			short_sum := short_name_view(sum_name)
 			if short_sum in t.tc.sum_types {
 				return short_sum
 			}
 		}
-		if !sum_name.contains('.') && t.cur_module.len > 0 && t.cur_module != 'main'
-			&& t.cur_module != 'builtin' {
+		if !has_dot && t.cur_module.len > 0 && t.cur_module != 'main' && t.cur_module != 'builtin' {
 			qsum := '${t.cur_module}.${sum_name}'
 			if qsum in t.tc.sum_types {
 				return qsum
 			}
 		}
-		if !sum_name.contains('.') {
+		if !has_dot {
 			mut found := ''
 			for key, _ in t.tc.sum_types {
-				if key.contains('.') && key.all_after_last('.') == sum_name {
+				if key.contains('.') && short_name_view(key) == sum_name {
 					if found.len > 0 && found != key {
 						found = ''
 						break

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -66,6 +66,17 @@ fn owner_name_view(name string) string {
 	return name
 }
 
+@[inline]
+fn same_transform_text(a string, b string) bool {
+	if a.len != b.len {
+		return false
+	}
+	if unsafe { a.str == b.str } {
+		return true
+	}
+	return a == b
+}
+
 // option_unwrap_marker tags a SmartcastContext produced by an `x != none`
 // condition: variant_name holds the option's base type and the access is
 // lowered to the option's `.value` field instead of a sum union field.
@@ -196,6 +207,7 @@ mut:
 	cur_fn_ret_type                 string
 	cur_fn_is_generic               bool
 	cur_fn_manualfree               bool
+	literal_free_fn_body            bool // work item is proven to contain no closure literals
 	cur_fn_variadic_param           string
 	skip_generics                   bool
 	building_v                      bool
@@ -391,6 +403,7 @@ mut:
 	parallel_monomorph_scan_start      int
 	parallel_monomorph_scan_end        int
 	fn_scan_costs                      []int
+	fn_escape_scan_flags               []u8
 	literal_fn_decls                   []int
 	literal_fn_decls_ready             bool
 	parallel_monomorph_struct_specs    map[string]string
@@ -429,15 +442,17 @@ mut:
 	// such writes stayed in the discarded clone) or deferred until after join
 	// (master, defer_oor_writes — matching the old path where the master's
 	// writes landed on the shared AST).
-	base_write_intercept bool
-	defer_oor_writes     bool
-	shared_base_nodes    int = -1
-	shared_base_children int = -1
-	item_range_lo        int = -1
-	item_range_hi        int = -1
-	memo_node_types      bool
-	node_type_memo       &NodeTypeMemo = unsafe { nil }
-	deferred_base_writes []DeferredBaseWrite
+	base_write_intercept    bool
+	defer_oor_writes        bool
+	shared_base_nodes       int = -1
+	shared_base_children    int = -1
+	item_range_lo           int = -1
+	item_range_hi           int = -1
+	item_escape_scan_known  bool
+	item_escape_scan_needed bool
+	memo_node_types         bool
+	node_type_memo          &NodeTypeMemo = unsafe { nil }
+	deferred_base_writes    []DeferredBaseWrite
 	// Prealloc self-host builds put helper-thread scratch allocations in
 	// disposable arenas. The worker's surviving AST strings are cloned by the
 	// master before that arena is released.
@@ -3202,12 +3217,14 @@ fn (mut t Transformer) append_transformed_top_level_stmts(mut out []flat.NodeId,
 // the file/module context active at its declaration and a rough cost estimate
 // (subtree node count) used to balance work across parallel workers.
 struct FnWorkItem {
-	fn_idx   int
-	range_lo int // first node id of this fn's subtree (fn subtree = [range_lo, fn_idx])
-	file     string
-	module   string
-	cost     int
-	rank     i64
+	fn_idx             int
+	range_lo           int // first node id of this fn's subtree (fn subtree = [range_lo, fn_idx])
+	file               string
+	module             string
+	cost               int
+	rank               i64
+	escape_scan_known  bool
+	escape_scan_needed bool
 }
 
 // DeferredBaseWrite is an in-place base-node write recorded by the master
@@ -3405,6 +3422,11 @@ fn (mut t Transformer) transform_serial_then_collect_pure(literal_decls []int) [
 			} else {
 				int(node.children_count) + 1
 			}
+			escape_scan_flags := if i < t.fn_escape_scan_flags.len {
+				t.fn_escape_scan_flags[i]
+			} else {
+				u8(0)
+			}
 			if has_literal {
 				old_range_lo := t.item_range_lo
 				old_range_hi := t.item_range_hi
@@ -3440,22 +3462,26 @@ fn (mut t Transformer) transform_serial_then_collect_pure(literal_decls []int) [
 				}
 				if str_est > deferred_str_expansion_threshold {
 					t.deferred_str_items << FnWorkItem{
-						fn_idx:   i
-						range_lo: range_lo
-						file:     t.cur_file
-						module:   t.cur_module
-						cost:     cost
-						rank:     i64(cost) * 1_000_000_000 - i64(i)
+						fn_idx:             i
+						range_lo:           range_lo
+						file:               t.cur_file
+						module:             t.cur_module
+						cost:               cost
+						rank:               i64(cost) * 1_000_000_000 - i64(i)
+						escape_scan_known:  escape_scan_flags & 1 != 0
+						escape_scan_needed: escape_scan_flags & 2 != 0
 					}
 				} else {
 					adj_cost := cost + str_est
 					pure << FnWorkItem{
-						fn_idx:   i
-						range_lo: range_lo
-						file:     t.cur_file
-						module:   t.cur_module
-						cost:     adj_cost
-						rank:     i64(adj_cost) * 1_000_000_000 - i64(i)
+						fn_idx:             i
+						range_lo:           range_lo
+						file:               t.cur_file
+						module:             t.cur_module
+						cost:               adj_cost
+						rank:               i64(adj_cost) * 1_000_000_000 - i64(i)
+						escape_scan_known:  escape_scan_flags & 1 != 0
+						escape_scan_needed: escape_scan_flags & 2 != 0
 					}
 				}
 			}
@@ -3470,6 +3496,7 @@ fn (mut t Transformer) transform_serial_then_collect_pure(literal_decls []int) [
 		}
 	}
 	t.fn_scan_costs = []int{}
+	t.fn_escape_scan_flags = []u8{}
 	t.timing_profile('  [ttime]   sc consts ${const_ms:.2f} ms, closures ${lit_ms:.2f} ms, interp est ${est_ms:.2f} ms')
 	return pure
 }
@@ -3485,13 +3512,19 @@ fn (mut t Transformer) transform_serial_then_collect_pure(literal_decls []int) [
 fn (mut t Transformer) collect_literal_fn_decls(limit int) []int {
 	mut result := []int{cap: 64}
 	mut flags := []u8{len: limit}
-	if scan_literal_decl_flags_parallel(t.a, limit, mut flags) {
+	mut escape_flags := []u8{len: limit}
+	if scan_literal_decl_flags_parallel(t, limit, mut flags, mut escape_flags) {
 		mut literal_pending := false
+		mut escape_scan_needed := false
 		mut span_cost := 0
 		t.fn_scan_costs = []int{len: limit}
+		t.fn_escape_scan_flags = []u8{len: limit}
 		for i in 0 .. flags.len {
 			flag := flags[i]
 			span_cost += int(flag & 15)
+			if escape_flags[i] != 0 {
+				escape_scan_needed = true
+			}
 			if flag & 16 != 0 {
 				literal_pending = true
 			}
@@ -3501,11 +3534,13 @@ fn (mut t Transformer) collect_literal_fn_decls(limit int) []int {
 				}
 				literal_pending = false
 				t.fn_scan_costs[i] = span_cost
+				t.fn_escape_scan_flags[i] = 1 | if escape_scan_needed { u8(2) } else { u8(0) }
 			} else if flag & 64 != 0 {
 				literal_pending = false
 			}
 			if flag & 128 != 0 {
 				span_cost = 0
+				escape_scan_needed = false
 			}
 		}
 		return result
@@ -3536,11 +3571,18 @@ fn (mut t Transformer) transform_pure_items_serial(items []FnWorkItem) {
 	// NOTE: arming the checker's BodyResolveMemo per item here was measured a
 	// wash (2026-08): transform's tc-level resolve repeats are already absorbed
 	// by trust_checked_expr_types and the transformer's own caches.
+	old_literal_free_fn_body := t.literal_free_fn_body
+	t.literal_free_fn_body = true
+	defer {
+		t.literal_free_fn_body = old_literal_free_fn_body
+	}
 	for it in items {
 		t.cur_file = it.file
 		t.cur_module = it.module
 		t.item_range_lo = it.range_lo
 		t.item_range_hi = it.fn_idx
+		t.item_escape_scan_known = it.escape_scan_known
+		t.item_escape_scan_needed = it.escape_scan_needed
 		if t.memo_node_types {
 			t.begin_node_type_memo(it.range_lo, it.fn_idx)
 		}
@@ -3558,6 +3600,8 @@ fn (mut t Transformer) transform_pure_items_serial(items []FnWorkItem) {
 	t.end_node_type_memo()
 	t.item_range_lo = -1
 	t.item_range_hi = -1
+	t.item_escape_scan_known = false
+	t.item_escape_scan_needed = false
 }
 
 // transform_deferred_str_items lowers the functions held back from the parallel
@@ -6252,8 +6296,14 @@ fn (mut t Transformer) heap_escaping_source_decl(node flat.Node, var_name string
 // from fields; the source type is checked at rewrite time when `v`'s type is known.
 fn (mut t Transformer) mark_escaping_amp_ptrs(body_ids []flat.NodeId) {
 	t.reset_escaping_amp_state()
-	if t.fast_escape_precheck && !t.escape_scan_may_be_needed(body_ids) {
-		return
+	if t.fast_escape_precheck {
+		if t.item_escape_scan_known {
+			if !t.item_escape_scan_needed {
+				return
+			}
+		} else if !t.escape_scan_may_be_needed(body_ids) {
+			return
+		}
 	}
 	mut amp_ptrs := map[string]bool{}
 	mut amp_sources := map[string][]string{} // pointer `p` -> possible source locals `v`
@@ -8570,8 +8620,10 @@ fn (mut t Transformer) transform_fn_body(fn_idx int) {
 		t.pointer_value_rvalues[name] = true
 	}
 	t.mark_local_closure_cleanup_decls(body_ids)
-	for id in body_ids {
-		t.collect_mut_capture_sources(id)
+	if !t.literal_free_fn_body {
+		for id in body_ids {
+			t.collect_mut_capture_sources(id)
+		}
 	}
 	// The escape pre-pass may query expression types before local declarations
 	// have populated var_types. Do not let those provisional answers leak into
@@ -10953,7 +11005,7 @@ fn (t &Transformer) const_ref_matches_key_in_context(id flat.NodeId, module_name
 		return true
 	}
 	base := name.all_before_last('.')
-	field := name.all_after_last('.')
+	field := short_name_view(name)
 	resolved_base := t.tc.file_imports[file_import_key(file, base)] or { base }
 	if qualified_const_key_matches(key, resolved_base, field) {
 		return true
@@ -10995,7 +11047,7 @@ fn (t &Transformer) const_ref_may_match_key(id flat.NodeId, key string, key_shor
 	if node.kind == .ident && !isnil(t.tc) {
 		base := node.value.all_before_last('.')
 		if resolved_base := t.tc.file_imports[file_import_key(file, base)] {
-			return qualified_const_key_matches(key, resolved_base, node.value.all_after_last('.'))
+			return qualified_const_key_matches(key, resolved_base, short_name_view(node.value))
 		}
 	}
 	return false
@@ -20938,6 +20990,26 @@ fn (t &Transformer) variant_names_match(a string, b string) bool {
 }
 
 fn (t &Transformer) variant_names_match_uncached(a string, b string) bool {
+	a_has_bracket := a.contains('[')
+	b_has_bracket := b.contains('[')
+	if !a_has_bracket && !b_has_bracket {
+		a_has_dot := a.contains('.')
+		b_has_dot := b.contains('.')
+		if a_has_dot || b_has_dot {
+			if !a.starts_with('&') && !b.starts_with('&') {
+				if short_name_view(a) == short_name_view(b) {
+					return true
+				}
+			} else if t.variant_short_name(a) == t.variant_short_name(b) {
+				return true
+			}
+		}
+		if (a.contains('fn') || b.contains('fn'))
+			&& canonical_fn_variant_name(a) == canonical_fn_variant_name(b) {
+			return true
+		}
+		return false
+	}
 	a_is_container := a.starts_with('[]') || a.starts_with('map[') || t.is_fixed_array_type(a)
 	b_is_container := b.starts_with('[]') || b.starts_with('map[') || t.is_fixed_array_type(b)
 	if a_is_container && b_is_container && !t.generic_arg_is_unresolved(a)
@@ -20954,11 +21026,6 @@ fn (t &Transformer) variant_names_match_uncached(a string, b string) bool {
 	if (a.contains('fn') || b.contains('fn'))
 		&& canonical_fn_variant_name(a) == canonical_fn_variant_name(b) {
 		return true
-	}
-	a_has_bracket := a.contains('[')
-	b_has_bracket := b.contains('[')
-	if !a_has_bracket && !b_has_bracket {
-		return false
 	}
 	if t.is_fixed_array_type(a) && t.is_fixed_array_type(b) {
 		return t.resolved_fixed_array_canonical_type(a) == t.resolved_fixed_array_canonical_type(b)
@@ -22181,7 +22248,7 @@ fn (t &Transformer) const_type_key_in_context(name string, module_name string, f
 		return name
 	}
 	base := name.all_before_last('.')
-	field := name.all_after_last('.')
+	field := short_name_view(name)
 	resolved_base := if mod := t.tc.file_imports[file_import_key(file, base)] {
 		mod
 	} else {

--- a/vlib/v3/transform/transform_parallel_d_v3_no_parallel.v
+++ b/vlib/v3/transform/transform_parallel_d_v3_no_parallel.v
@@ -3,7 +3,7 @@ module transform
 import v3.flat
 import v3.types
 
-fn scan_literal_decl_flags_parallel(_ &flat.FlatAst, _ int, mut _ []u8) bool {
+fn scan_literal_decl_flags_parallel(_ &Transformer, _ int, mut _ []u8, mut _ []u8) bool {
 	return false
 }
 

--- a/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
@@ -212,10 +212,12 @@ $if !windows {
 
 // TopLevelKindScanArgs is the payload for one top-level-kind flag-scan worker.
 struct TopLevelKindScanArgs {
-	a                 &flat.FlatAst = unsafe { nil }
+	a                 &flat.FlatAst      = unsafe { nil }
+	tc                &types.TypeChecker = unsafe { nil }
 	start             int
 	end               int
 	flags             voidptr // &u8 base of the per-node flag array (index 0 == node `base`)
+	escape_flags      voidptr // optional &u8 base for escape-precheck candidates
 	base              int
 	prefix_param_scan bool
 }
@@ -227,6 +229,7 @@ $if !windows {
 	fn literal_decl_scan_thread(arg voidptr) voidptr {
 		a := unsafe { &TopLevelKindScanArgs(arg) }
 		flags := unsafe { &u8(a.flags) }
+		escape_flags := unsafe { &u8(a.escape_flags) }
 		for i in a.start .. a.end {
 			node := unsafe { &a.a.nodes[i] }
 			mut flag := match node.kind {
@@ -267,6 +270,32 @@ $if !windows {
 			unsafe {
 				flags[i - a.base] = flag
 			}
+			mut may_escape := node.kind == .prefix && node.op == .amp
+			if !may_escape && node.kind == .call && node.children_count > 1 {
+				name := a.tc.resolved_call_name(flat.NodeId(i)) or {
+					unsafe {
+						escape_flags[i - a.base] = 1
+					}
+					continue
+				}
+				params := a.tc.fn_param_types[name] or {
+					unsafe {
+						escape_flags[i - a.base] = 1
+					}
+					continue
+				}
+				for param in params {
+					if escape_type_is_void_pointer(param) {
+						may_escape = true
+						break
+					}
+				}
+			}
+			if may_escape {
+				unsafe {
+					escape_flags[i - a.base] = 1
+				}
+			}
 		}
 		return unsafe { nil }
 	}
@@ -299,11 +328,13 @@ $if !windows {
 // scan_literal_decl_flags_parallel fills the sparse literal/declaration flags
 // used by collect_literal_fn_decls. The master can then word-scan the compact
 // byte array instead of streaming every full AST node header.
-fn scan_literal_decl_flags_parallel(a &flat.FlatAst, limit int, mut flags []u8) bool {
+fn scan_literal_decl_flags_parallel(t &Transformer, limit int, mut flags []u8, mut escape_flags []u8) bool {
 	$if windows {
 		return false
 	} $else {
-		if isnil(a.worker_pool) || limit < 65536 || limit > a.nodes.len || flags.len < limit {
+		a := t.a
+		if isnil(t.tc) || isnil(a.worker_pool) || limit < 65536 || limit > a.nodes.len
+			|| flags.len < limit || escape_flags.len < limit {
 			return false
 		}
 		n_jobs := a.worker_pool.size() + 1
@@ -319,10 +350,12 @@ fn scan_literal_decl_flags_parallel(a &flat.FlatAst, limit int, mut flags []u8) 
 				break
 			}
 			args << TopLevelKindScanArgs{
-				a:     a
-				start: start
-				end:   end
-				flags: flags.data
+				a:            a
+				tc:           t.tc
+				start:        start
+				end:          end
+				flags:        flags.data
+				escape_flags: escape_flags.data
 			}
 		}
 		mut tasks := []workers.Task{cap: args.len}

--- a/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
@@ -226,6 +226,8 @@ $if !windows {
 	// literal_decl_scan_thread marks the sparse node kinds needed to associate
 	// a function literal with its containing top-level declaration. The low
 	// nibble is also a cheap transform-cost weight used to balance fn workers.
+	// Genuine top-level boundaries are marked by the master after the scan: node
+	// kind alone cannot distinguish a top-level type from a local type declaration.
 	fn literal_decl_scan_thread(arg voidptr) voidptr {
 		a := unsafe { &TopLevelKindScanArgs(arg) }
 		flags := unsafe { &u8(a.flags) }
@@ -262,10 +264,6 @@ $if !windows {
 				flag |= 32
 			} else if node.kind in [.const_decl, .global_decl] {
 				flag |= 64
-			}
-			if node.kind in [.file, .module_decl, .struct_decl, .type_decl, .interface_decl,
-				.enum_decl, .import_decl, .const_decl, .global_decl, .fn_decl, .c_fn_decl] {
-				flag |= 128
 			}
 			unsafe {
 				flags[i - a.base] = flag
@@ -334,7 +332,8 @@ fn scan_literal_decl_flags_parallel(t &Transformer, limit int, mut flags []u8, m
 	} $else {
 		a := t.a
 		if isnil(t.tc) || isnil(a.worker_pool) || limit < 65536 || limit > a.nodes.len
-			|| flags.len < limit || escape_flags.len < limit {
+			|| flags.len < limit || escape_flags.len < limit || t.tc.top_level_idx.len == 0
+			|| t.tc.top_level_idx_nodes_len != limit {
 			return false
 		}
 		n_jobs := a.worker_pool.size() + 1
@@ -367,6 +366,25 @@ fn scan_literal_decl_flags_parallel(t &Transformer, limit int, mut flags []u8, m
 			}
 		}
 		a.worker_pool.run(tasks)
+		// top_level_idx also contains synthesized anonymous/function-local type
+		// declarations so later passes can find them. They are not subtree
+		// boundaries: an escape candidate before one still belongs to the enclosing
+		// function. Exclude those exact ids while marking reset points.
+		mut synthetic_pos := 0
+		for idx in t.tc.top_level_idx {
+			for synthetic_pos < t.tc.synthetic_top_level_type_ids.len
+				&& t.tc.synthetic_top_level_type_ids[synthetic_pos] < idx {
+				synthetic_pos++
+			}
+			if synthetic_pos < t.tc.synthetic_top_level_type_ids.len
+				&& t.tc.synthetic_top_level_type_ids[synthetic_pos] == idx {
+				synthetic_pos++
+				continue
+			}
+			if idx >= 0 && idx < limit {
+				flags[idx] |= u8(128)
+			}
+		}
 		return true
 	}
 }

--- a/vlib/v3/transform/transform_parallel_test.v
+++ b/vlib/v3/transform/transform_parallel_test.v
@@ -212,3 +212,48 @@ fn test_skipped_literal_decl_does_not_hide_later_closure() {
 	assert pure.len == 1
 	assert pure[0].fn_idx == helper_idx
 }
+
+fn test_parallel_escape_precheck_preserves_candidate_across_local_type_decl() {
+	$if !v3_no_parallel ? {
+		mut a := flat.FlatAst.new()
+		a.nodes = []flat.Node{len: 65536}
+		a.nodes[1] = flat.Node{
+			kind: .prefix
+			op:   .amp
+		}
+		a.nodes[2] = flat.Node{
+			kind:  .struct_decl
+			value: 'Local@local@first'
+		}
+		a.nodes[3] = flat.Node{
+			kind:  .fn_decl
+			value: 'first'
+		}
+		a.nodes[4] = flat.Node{
+			kind: .prefix
+			op:   .amp
+		}
+		a.nodes[5] = flat.Node{
+			kind:  .struct_decl
+			value: 'TopLevel'
+		}
+		a.nodes[6] = flat.Node{
+			kind:  .fn_decl
+			value: 'second'
+		}
+		a.ensure_workers(2)
+		defer {
+			a.close_workers()
+		}
+		mut tc := types.TypeChecker.new(&a)
+		tc.top_level_idx = [0, 2, 3, 5, 6]
+		tc.top_level_idx_nodes_len = a.nodes.len
+		tc.synthetic_top_level_type_ids = [2]
+		mut t := new_transformer(mut a, &tc, map[string]bool{})
+
+		t.collect_literal_fn_decls(t.a.nodes.len)
+
+		assert t.fn_escape_scan_flags[3] == 3
+		assert t.fn_escape_scan_flags[6] == 1
+	}
+}

--- a/vlib/v3/transform/type_propagation.v
+++ b/vlib/v3/transform/type_propagation.v
@@ -1097,9 +1097,6 @@ fn (t &Transformer) normalize_type_alias(typ string) string {
 	if typ.len == 0 || isnil(t.tc) {
 		return typ
 	}
-	if is_plain_builtin_alias_type(typ) {
-		return typ
-	}
 	if isnil(t.alias_cache) {
 		return t.normalize_type_alias_uncached(typ)
 	}
@@ -1109,7 +1106,7 @@ fn (t &Transformer) normalize_type_alias(typ string) string {
 		&& unsafe { c.canonical_types[recent_slot].str == typ.str } {
 		return c.canonical_results[recent_slot]
 	}
-	if c.module != t.cur_module || c.file != t.cur_file {
+	if !same_transform_text(c.module, t.cur_module) || !same_transform_text(c.file, t.cur_file) {
 		c.module = t.cur_module
 		c.file = t.cur_file
 		c.entries.clear()
@@ -1435,11 +1432,14 @@ fn is_generic_placeholder_type_name(typ string) bool {
 
 // normalize_type_in_module transforms normalize type in module data for transform.
 fn (t &Transformer) normalize_type_in_module(typ string, mod string) string {
+	if is_plain_builtin_alias_type(typ) {
+		return typ
+	}
 	if isnil(t.module_type_cache) {
 		return t.normalize_type_in_module_uncached(typ, mod)
 	}
 	mut cache := t.module_type_cache
-	if cache.module != mod || cache.file != t.cur_file {
+	if !same_transform_text(cache.module, mod) || !same_transform_text(cache.file, t.cur_file) {
 		cache.module = mod
 		cache.file = t.cur_file
 		cache.entries.clear()
@@ -1860,7 +1860,8 @@ fn (t &Transformer) checker_type_over_struct_guess(id flat.NodeId, guessed strin
 		guessed_c_type = t.tc.c_type(guessed_type)
 	} else {
 		mut cache := t.struct_guess_cache
-		if cache.module != t.cur_module || cache.file != t.cur_file {
+		if !same_transform_text(cache.module, t.cur_module)
+			|| !same_transform_text(cache.file, t.cur_file) {
 			cache.module = t.cur_module
 			cache.file = t.cur_file
 			cache.entries.clear()

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -854,8 +854,13 @@ pub mut:
 	// `collect`; no later phase of the check step appends declarations. Phases
 	// after the check (transform) may grow the AST: top_level_idx_nodes_len
 	// records the node count the index covers.
-	top_level_idx                 []int
-	top_level_idx_nodes_len       int
+	top_level_idx           []int
+	top_level_idx_nodes_len int
+	// Anonymous and function-local struct declarations are synthesized below
+	// the file's top-level declaration tree. The direct-parent pass records their
+	// sorted node ids so collect_top_level_idx_fast can merge them without
+	// rescanning every gap between parser-recorded declarations.
+	synthetic_top_level_type_ids  []int
 	expected_expr_id              int  = -1
 	expected_expr_type            Type = Type(void_)
 	cur_fn_ret_type               Type = Type(void_)
@@ -1258,6 +1263,7 @@ fn (tc &TypeChecker) fork_program_view(ast &flat.FlatAst, direct_dependencies_by
 		pending_ierror_errors:              []PendingIerrorError{}
 		top_level_idx:                      tc.top_level_idx
 		top_level_idx_nodes_len:            tc.top_level_idx_nodes_len
+		synthetic_top_level_type_ids:       tc.synthetic_top_level_type_ids
 		direct_parent_ids:                  tc.direct_parent_ids
 		rewritten_parent_ids:               tc.rewritten_parent_ids
 		value_used_nodes:                   tc.value_used_nodes
@@ -1657,6 +1663,7 @@ fn (mut tc TypeChecker) init_direct_parent_index(a &flat.FlatAst) {
 	tc.translated_files = map[string]bool{}
 	tc.has_globals_files = map[string]bool{}
 	tc.strings_builder_candidates = []int{cap: 1024}
+	tc.synthetic_top_level_type_ids = []int{cap: 2048}
 	tc.has_goto_nodes = false
 }
 
@@ -1666,6 +1673,10 @@ fn (mut tc TypeChecker) fill_direct_parent_edges(a &flat.FlatAst) {
 		fn_cost += 1 + int(node.children_count) * 2
 		if node.kind == .goto_stmt {
 			tc.has_goto_nodes = true
+		}
+		if node.kind == .struct_decl
+			&& (is_anonymous_struct_name(node.value) || node.value.contains('@local@')) {
+			tc.synthetic_top_level_type_ids << parent_idx
 		}
 		for child_idx in 0 .. node.children_count {
 			child := a.child(&node, child_idx)
@@ -2503,26 +2514,34 @@ fn (mut tc TypeChecker) collect_top_level_idx_fast(a &flat.FlatAst, inactive []b
 			}
 		}
 	}
+	mut synthetic_pos := 0
 	for k := 0; k + 1 < a.file_node_ids.len; k += 2 {
 		marker := a.file_node_ids[k]
 		trailing := a.file_node_ids[k + 1]
+		for synthetic_pos < tc.synthetic_top_level_type_ids.len
+			&& tc.synthetic_top_level_type_ids[synthetic_pos] <= marker {
+			synthetic_pos++
+		}
 		idx_file := a.nodes[marker].value
 		tc.top_level_idx << marker
 		tnode := a.nodes[trailing]
 		mut idx_module := ''
-		mut synthetic_scan_start := marker + 1
 		for ci in 0 .. tnode.children_count {
 			decl_idx := int(a.child(&tnode, ci))
-			for synthetic_idx in synthetic_scan_start .. decl_idx {
-				synthetic := a.nodes[synthetic_idx]
-				if synthetic.kind == .struct_decl && (is_anonymous_struct_name(synthetic.value)
-					|| synthetic.value.contains('@local@')) {
+			for synthetic_pos < tc.synthetic_top_level_type_ids.len
+				&& tc.synthetic_top_level_type_ids[synthetic_pos] < decl_idx {
+				synthetic_idx := tc.synthetic_top_level_type_ids[synthetic_pos]
+				if synthetic_idx < trailing {
 					idx_module = tc.collect_index_child(a, synthetic_idx, idx_file, idx_module,
 						inactive)
 				}
+				synthetic_pos++
 			}
 			idx_module = tc.collect_index_child(a, decl_idx, idx_file, idx_module, inactive)
-			synthetic_scan_start = decl_idx + 1
+			if synthetic_pos < tc.synthetic_top_level_type_ids.len
+				&& tc.synthetic_top_level_type_ids[synthetic_pos] == decl_idx {
+				synthetic_pos++
+			}
 			// apply_decl_attrs emits module attributes as the node immediately
 			// following the module declaration, outside the trailing file node's
 			// declaration children.
@@ -2535,13 +2554,11 @@ fn (mut tc TypeChecker) collect_top_level_idx_fast(a &flat.FlatAst, inactive []b
 				}
 			}
 		}
-		for synthetic_idx in synthetic_scan_start .. trailing {
-			synthetic := a.nodes[synthetic_idx]
-			if synthetic.kind == .struct_decl && (is_anonymous_struct_name(synthetic.value)
-				|| synthetic.value.contains('@local@')) {
-				idx_module = tc.collect_index_child(a, synthetic_idx, idx_file, idx_module,
-					inactive)
-			}
+		for synthetic_pos < tc.synthetic_top_level_type_ids.len
+			&& tc.synthetic_top_level_type_ids[synthetic_pos] < trailing {
+			synthetic_idx := tc.synthetic_top_level_type_ids[synthetic_pos]
+			idx_module = tc.collect_index_child(a, synthetic_idx, idx_file, idx_module, inactive)
+			synthetic_pos++
 		}
 		tc.top_level_idx << trailing
 	}
@@ -2773,6 +2790,7 @@ pub fn (mut tc TypeChecker) collect(a &flat.FlatAst) {
 	if file_index_usable(a) {
 		tc.collect_top_level_idx_fast(a, inactive_comptime_nodes)
 		tc.top_level_idx_nodes_len = a.nodes.len
+		tc.reserve_collect_maps()
 		tc.timing_profile('  [ttime]     ck c idx       ${f64(ck_c_sw.elapsed().microseconds()) / 1000.0:7.2f} ms (fast)')
 		tc.collect_after_index(a)
 		return
@@ -2830,6 +2848,12 @@ pub fn (mut tc TypeChecker) collect(a &flat.FlatAst) {
 		}
 	}
 	tc.top_level_idx_nodes_len = a.nodes.len
+	tc.reserve_collect_maps()
+	tc.timing_profile('  [ttime]     ck c idx       ${f64(ck_c_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+	tc.collect_after_index(a)
+}
+
+fn (mut tc TypeChecker) reserve_collect_maps() {
 	// The collection passes below fill the signature/type tables from empty;
 	// with ~10k declarations each hot map otherwise pays a dozen doubling
 	// rehashes. Reserve once from the now-known top-level count (short-name and
@@ -2868,8 +2892,6 @@ pub fn (mut tc TypeChecker) collect(a &flat.FlatAst) {
 			}
 		}
 	}
-	tc.timing_profile('  [ttime]     ck c idx       ${f64(ck_c_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
-	tc.collect_after_index(a)
 }
 
 fn (mut tc TypeChecker) check_alias_declaration_cycles() {

--- a/vlib/v3/types/checker_comptime.v
+++ b/vlib/v3/types/checker_comptime.v
@@ -9391,13 +9391,18 @@ fn (tc &TypeChecker) direct_parent_kind(id flat.NodeId) flat.NodeKind {
 	return .empty
 }
 
+@[direct_array_access; inline]
 fn (tc &TypeChecker) direct_parent_id(id flat.NodeId) flat.NodeId {
 	idx := int(id)
+	if tc.direct_parent_index_trusted && idx >= 0 && idx < tc.direct_parent_ids.len {
+		return tc.direct_parent_ids[idx]
+	}
+	return tc.direct_parent_id_untrusted(id, idx)
+}
+
+fn (tc &TypeChecker) direct_parent_id_untrusted(id flat.NodeId, idx int) flat.NodeId {
 	if idx >= 0 && idx < tc.direct_parent_ids.len {
 		parent_id := tc.direct_parent_ids[idx]
-		if tc.direct_parent_index_trusted {
-			return parent_id
-		}
 		if parent_id != flat.empty_node {
 			parent := tc.a.node(parent_id)
 			for i in 0 .. parent.children_count {

--- a/vlib/v3/types/checker_parallel.v
+++ b/vlib/v3/types/checker_parallel.v
@@ -37,6 +37,89 @@ struct CheckWorkItem {
 	rank     i64
 }
 
+struct InterfaceImplChunkArgs {
+	checker     voidptr
+	iface_names voidptr
+	results     voidptr
+	start       int
+	end         int
+}
+
+struct InterfaceImplResults {
+mut:
+	items []&InterfaceImplIndex
+}
+
+fn interface_impl_index_chunk_thread(arg voidptr) voidptr {
+	a := unsafe { &InterfaceImplChunkArgs(arg) }
+	tc := unsafe { &TypeChecker(a.checker) }
+	iface_names := unsafe { &[]string(a.iface_names) }
+	mut results := unsafe { &InterfaceImplResults(a.results) }
+	for i in a.start .. a.end {
+		iface_name := unsafe { iface_names[i] }
+		impls := if is_builtin_ierror_name(iface_name) {
+			tc.ierror_impl_names()
+		} else {
+			tc.interface_impl_names_uncached(iface_name)
+		}
+		results.items[i] = &InterfaceImplIndex{
+			names: impls
+			ids:   stable_interface_type_ids(impls)
+		}
+	}
+	return unsafe { nil }
+}
+
+fn (mut tc TypeChecker) prepare_interface_impl_indexes_parallel(iface_names []string) bool {
+	$if windows {
+		return false
+	} $else {
+		if iface_names.len < 8 || isnil(tc.a) || isnil(tc.a.worker_pool) {
+			return false
+		}
+		n_jobs := int_min(tc.a.worker_pool.size() + 1, iface_names.len)
+		if n_jobs <= 1 {
+			return false
+		}
+		tc.install_type_cache_overlay()
+		mut checkers := []&TypeChecker{cap: n_jobs}
+		checkers << tc
+		for _ in 1 .. n_jobs {
+			checkers << tc.fork_for_parallel_transform(tc.a)
+		}
+		mut results := &InterfaceImplResults{
+			items: []&InterfaceImplIndex{cap: iface_names.len}
+		}
+		for _ in iface_names {
+			results.items << &InterfaceImplIndex(unsafe { nil })
+		}
+		mut args := []InterfaceImplChunkArgs{cap: n_jobs}
+		mut tasks := []workers.Task{cap: n_jobs}
+		for job in 0 .. n_jobs {
+			args << InterfaceImplChunkArgs{
+				checker:     voidptr(checkers[job])
+				iface_names: unsafe { voidptr(&iface_names) }
+				results:     voidptr(results)
+				start:       iface_names.len * job / n_jobs
+				end:         iface_names.len * (job + 1) / n_jobs
+			}
+			tasks << workers.Task{
+				run:        interface_impl_index_chunk_thread
+				arg:        unsafe { voidptr(&args[job]) }
+				force_sync: job == 0
+			}
+		}
+		tc.a.worker_pool.run(tasks)
+		tc.restore_type_cache_base()
+		for i, iface_name in iface_names {
+			if !isnil(results.items[i]) {
+				tc.interface_impl_indexes[iface_name] = results.items[i]
+			}
+		}
+		return true
+	}
+}
+
 struct UnusedFnVarCandidate {
 	name   string
 	lhs_id flat.NodeId

--- a/vlib/v3/types/checker_tail_stmt.v
+++ b/vlib/v3/types/checker_tail_stmt.v
@@ -10811,9 +10811,32 @@ pub fn (mut tc TypeChecker) prepare_interface_requirement_indexes() {
 	tc.interface_method_names_index = map[string][]string{}
 	tc.interface_abstract_index = map[string][]string{}
 	tc.interface_field_list_index = map[string][]StructField{}
+	mut direct_methods := map[string][]string{}
+	for iface_name in tc.interface_names.keys() {
+		name := tc.interface_metadata_name(iface_name)
+		if name !in direct_methods {
+			direct_methods[name] = []string{}
+		}
+	}
+	// Default interface methods are stored with ordinary function signatures.
+	// Index them once instead of scanning the full signature table separately
+	// for every interface (and again for each embedded-interface traversal).
+	for key, _ in tc.fn_ret_types {
+		dot := key.last_index_u8(`.`)
+		if dot <= 0 {
+			continue
+		}
+		receiver := key[..dot]
+		mut methods := direct_methods[receiver] or { continue }
+		method := key[dot + 1..]
+		if method !in methods {
+			methods << method
+			direct_methods[receiver] = methods
+		}
+	}
 	for iface_name in tc.interface_names.keys() {
 		mut seen_methods := map[string]bool{}
-		methods := tc.interface_method_names_inner(iface_name, mut seen_methods)
+		methods := tc.interface_method_names_indexed(iface_name, direct_methods, mut seen_methods)
 		mut seen_abstract := map[string]bool{}
 		abstract_methods := tc.interface_abstract_method_names_inner(iface_name, mut seen_abstract)
 		mut seen_fields := map[string]bool{}
@@ -10831,21 +10854,46 @@ pub fn (mut tc TypeChecker) prepare_interface_requirement_indexes() {
 	tc.interface_query_indexes_ready = true
 }
 
+fn (tc &TypeChecker) interface_method_names_indexed(iface_name string, direct_methods map[string][]string, mut seen map[string]bool) []string {
+	name := tc.interface_metadata_name(iface_name)
+	if name in seen {
+		return []string{}
+	}
+	seen[name] = true
+	mut methods := []string{}
+	for embed in tc.interface_embeds[name] or { []string{} } {
+		for method in tc.interface_method_names_indexed(embed, direct_methods, mut seen) {
+			if method !in methods {
+				methods << method
+			}
+		}
+	}
+	for method in direct_methods[name] or { []string{} } {
+		if method !in methods {
+			methods << method
+		}
+	}
+	return methods
+}
+
 // prepare_interface_query_indexes publishes immutable interface requirements and
 // implementer lists for transform workers.
 pub fn (mut tc TypeChecker) prepare_interface_query_indexes() {
 	tc.prepare_interface_requirement_indexes()
 	tc.interface_impl_indexes = map[string]&InterfaceImplIndex{}
 	tc.interface_impl_candidates_at_index = tc.interface_impl_candidate_names()
-	for iface_name in tc.interface_names.keys() {
-		impls := if is_builtin_ierror_name(iface_name) {
-			tc.ierror_impl_names()
-		} else {
-			tc.interface_impl_names(iface_name)
-		}
-		tc.interface_impl_indexes[iface_name] = &InterfaceImplIndex{
-			names: impls
-			ids:   stable_interface_type_ids(impls)
+	iface_names := tc.interface_names.keys()
+	if !tc.prepare_interface_impl_indexes_parallel(iface_names) {
+		for iface_name in iface_names {
+			impls := if is_builtin_ierror_name(iface_name) {
+				tc.ierror_impl_names()
+			} else {
+				tc.interface_impl_names(iface_name)
+			}
+			tc.interface_impl_indexes[iface_name] = &InterfaceImplIndex{
+				names: impls
+				ids:   stable_interface_type_ids(impls)
+			}
 		}
 	}
 	// The immutable transform indexes above preserve the pre-monomorphization
@@ -12649,7 +12697,11 @@ fn (tc &TypeChecker) subtree_assigns_key(root flat.NodeId, key string) bool {
 		}
 	}
 	for i in 0 .. node.children_count {
-		if tc.subtree_assigns_key(tc.a.child(node, i), key) {
+		child_id := tc.a.child(node, i)
+		// Assignments and mutating calls always have children. Avoid recursing into
+		// the much more numerous ident/literal leaves, which cannot invalidate a
+		// smartcast on their own.
+		if tc.a.node(child_id).children_count > 0 && tc.subtree_assigns_key(child_id, key) {
 			return true
 		}
 	}
@@ -15031,16 +15083,14 @@ fn (tc &TypeChecker) resolve_type_uncached(id flat.NodeId) Type {
 					return typ
 				}
 			}
-			if qname in tc.const_types {
-				return tc.const_types[qname] or { unknown_type('unknown const `${qname}`') }
+			if typ := tc.const_types[qname] {
+				return typ
 			}
 			if typ := tc.file_scope.lookup(node.value) {
 				return typ
 			}
-			if node.value in tc.const_types {
-				return tc.const_types[node.value] or {
-					unknown_type('unknown const `${node.value}`')
-				}
+			if typ := tc.const_types[node.value] {
+				return typ
 			}
 			if typ := tc.fn_value_type(node.value) {
 				return typ
@@ -15083,15 +15133,11 @@ fn (tc &TypeChecker) resolve_type_uncached(id flat.NodeId) Type {
 				base_node := tc.a.child_node(fn_node, 0)
 				if base_node.kind == .ident && base_node.value == 'C' {
 					c_fn_name := 'C.${fn_node.value}'
-					if c_fn_name in tc.fn_ret_types {
-						return tc.fn_ret_types[c_fn_name] or {
-							unknown_type('unknown return type for `${c_fn_name}`')
-						}
+					if ret := tc.fn_ret_types[c_fn_name] {
+						return ret
 					}
-					if fn_node.value in tc.fn_ret_types {
-						return tc.fn_ret_types[fn_node.value] or {
-							unknown_type('unknown return type for `${fn_node.value}`')
-						}
+					if ret := tc.fn_ret_types[fn_node.value] {
+						return ret
 					}
 					return Type(Struct{
 						name: c_fn_name
@@ -15126,10 +15172,8 @@ fn (tc &TypeChecker) resolve_type_uncached(id flat.NodeId) Type {
 					if base_node.value in tc.structs || base_node.value in tc.enum_names {
 						qname := tc.qualify_name(base_node.value)
 						sname := '${qname}.${fn_node.value}'
-						if sname in tc.fn_ret_types {
-							return tc.fn_ret_types[sname] or {
-								unknown_type('unknown return type for `${sname}`')
-							}
+						if ret := tc.fn_ret_types[sname] {
+							return ret
 						}
 					} else {
 						if static_name := tc.static_assoc_fn_key_for_base(base_node.value,
@@ -15145,10 +15189,8 @@ fn (tc &TypeChecker) resolve_type_uncached(id flat.NodeId) Type {
 					if inner.kind == .ident {
 						mod_name := tc.resolve_import_alias(inner.value) or { inner.value }
 						full_name := '${mod_name}.${base_node.value}.${fn_node.value}'
-						if full_name in tc.fn_ret_types {
-							return tc.fn_ret_types[full_name] or {
-								unknown_type('unknown return type for `${full_name}`')
-							}
+						if ret := tc.fn_ret_types[full_name] {
+							return ret
 						}
 						if static_name := tc.static_assoc_fn_key_for_base('${mod_name}.${base_node.value}',
 							fn_node.value)
@@ -15182,12 +15224,8 @@ fn (tc &TypeChecker) resolve_type_uncached(id flat.NodeId) Type {
 					candidates := receiver_method_name_candidates(clean_type, fn_node.value,
 						tc.cur_module)
 					for mname in candidates {
-						if mname in tc.fn_ret_types {
-							return tc.alias_return_type_from_text(mname) or {
-								tc.fn_ret_types[mname] or {
-									unknown_type('unknown return type for `${mname}`')
-								}
-							}
+						if ret := tc.fn_ret_types[mname] {
+							return tc.alias_return_type_from_text(mname) or { ret }
 						}
 					}
 					if mname := tc.unique_receiver_method_suffix_match(candidates) {
@@ -15275,22 +15313,16 @@ fn (tc &TypeChecker) resolve_type_uncached(id flat.NodeId) Type {
 					arr_mname1 := '[]${short_elem}.${fn_node.value}'
 					if mod_prefix.len > 0 {
 						arr_mkey := '${mod_prefix}.${arr_mname1}'
-						if arr_mkey in tc.fn_ret_types {
-							return tc.fn_ret_types[arr_mkey] or {
-								unknown_type('unknown return type for `${arr_mkey}`')
-							}
+						if ret := tc.fn_ret_types[arr_mkey] {
+							return ret
 						}
 					}
-					if arr_mname1 in tc.fn_ret_types {
-						return tc.fn_ret_types[arr_mname1] or {
-							unknown_type('unknown return type for `${arr_mname1}`')
-						}
+					if ret := tc.fn_ret_types[arr_mname1] {
+						return ret
 					}
 					array_mname := 'array.${fn_node.value}'
-					if array_mname in tc.fn_ret_types {
-						return tc.fn_ret_types[array_mname] or {
-							unknown_type('unknown return type for `${array_mname}`')
-						}
+					if ret := tc.fn_ret_types[array_mname] {
+						return ret
 					}
 					return unknown_type('unknown array method `${fn_node.value}`')
 				}
@@ -15321,19 +15353,15 @@ fn (tc &TypeChecker) resolve_type_uncached(id flat.NodeId) Type {
 						}
 					}
 					map_mname := 'map.${fn_node.value}'
-					if map_mname in tc.fn_ret_types {
-						return tc.fn_ret_types[map_mname] or {
-							unknown_type('unknown return type for `${map_mname}`')
-						}
+					if ret := tc.fn_ret_types[map_mname] {
+						return ret
 					}
 					return unknown_type('unknown map method `${fn_node.value}`')
 				}
 				if clean_type is String {
 					mname := 'string.${fn_node.value}'
-					if mname in tc.fn_ret_types {
-						return tc.fn_ret_types[mname] or {
-							unknown_type('unknown return type for `${mname}`')
-						}
+					if ret := tc.fn_ret_types[mname] {
+						return ret
 					}
 				}
 				if fn_node.value == 'str'
@@ -15346,29 +15374,23 @@ fn (tc &TypeChecker) resolve_type_uncached(id flat.NodeId) Type {
 				}
 				if clean_type is Alias {
 					mname := '${clean_type.name}.${fn_node.value}'
-					if mname in tc.fn_ret_types {
-						return tc.fn_ret_types[mname] or {
-							unknown_type('unknown return type for `${mname}`')
-						}
+					if ret := tc.fn_ret_types[mname] {
+						return ret
 					}
 					base_name := resolve_type_name_for_method(clean_type.base_type)
 					if base_name.len > 0 {
 						for base_mname in receiver_method_name_candidates(clean_type.base_type,
 							fn_node.value, tc.cur_module) {
-							if base_mname in tc.fn_ret_types {
-								return tc.fn_ret_types[base_mname] or {
-									unknown_type('unknown return type for `${base_mname}`')
-								}
+							if ret := tc.fn_ret_types[base_mname] {
+								return ret
 							}
 						}
 					}
 				}
 				if clean_type is Struct {
 					mname := '${clean_type.name}.${fn_node.value}'
-					if mname in tc.fn_ret_types {
-						return tc.fn_ret_types[mname] or {
-							unknown_type('unknown return type for `${mname}`')
-						}
+					if ret := tc.fn_ret_types[mname] {
+						return ret
 					}
 					// A method on a concrete generic instance (`Box[int].clone`) is
 					// registered under the open form (`Box[T].clone`); resolve it so the
@@ -15380,18 +15402,14 @@ fn (tc &TypeChecker) resolve_type_uncached(id flat.NodeId) Type {
 				}
 				if clean_type is Interface {
 					mname := '${clean_type.name}.${fn_node.value}'
-					if mname in tc.fn_ret_types {
-						return tc.fn_ret_types[mname] or {
-							unknown_type('unknown return type for `${mname}`')
-						}
+					if ret := tc.fn_ret_types[mname] {
+						return ret
 					}
 				}
 				if clean_type is SumType {
 					mname := '${clean_type.name}.${fn_node.value}'
-					if mname in tc.fn_ret_types {
-						return tc.fn_ret_types[mname] or {
-							unknown_type('unknown return type for `${mname}`')
-						}
+					if ret := tc.fn_ret_types[mname] {
+						return ret
 					}
 				}
 				if clean_type is Enum {
@@ -15399,18 +15417,14 @@ fn (tc &TypeChecker) resolve_type_uncached(id flat.NodeId) Type {
 						return Type(string_)
 					}
 					mname := '${clean_type.name}.${fn_node.value}'
-					if mname in tc.fn_ret_types {
-						return tc.fn_ret_types[mname] or {
-							unknown_type('unknown return type for `${mname}`')
-						}
+					if ret := tc.fn_ret_types[mname] {
+						return ret
 					}
 				}
 				if clean_type is Primitive {
 					mname := '${prim_c_type_from(clean_type.props, clean_type.size)}.${fn_node.value}'
-					if mname in tc.fn_ret_types {
-						return tc.fn_ret_types[mname] or {
-							unknown_type('unknown return type for `${mname}`')
-						}
+					if ret := tc.fn_ret_types[mname] {
+						return ret
 					}
 				}
 			}
@@ -15420,16 +15434,12 @@ fn (tc &TypeChecker) resolve_type_uncached(id flat.NodeId) Type {
 				}
 			}
 			if imported_name := tc.resolve_selective_import_symbol(fn_node.value) {
-				if imported_name in tc.fn_ret_types {
-					return tc.fn_ret_types[imported_name] or {
-						unknown_type('unknown return type for `${imported_name}`')
-					}
+				if ret := tc.fn_ret_types[imported_name] {
+					return ret
 				}
 			}
-			if fn_node.value in tc.fn_ret_types {
-				return tc.fn_ret_types[fn_node.value] or {
-					unknown_type('unknown return type for `${fn_node.value}`')
-				}
+			if ret := tc.fn_ret_types[fn_node.value] {
+				return ret
 			}
 			if node.typ.len > 0 {
 				return tc.parse_type(node.typ)


### PR DESCRIPTION
## Summary

- reduce V3 checker setup and lookup overhead with precomputed indices and worker-local caches
- make markused retain prepared declaration metadata and collect exact source/default-argument dependencies in parallel
- avoid redundant transform annotation, capture scans, type normalization, and synthetic indexing work
- reduce C generator allocation and repeated name/type/field lookups, including faster parallel function preparation
- add regression coverage for prepared markused declarations and C name handling

The changes were selected using `v -profile` while repeatedly compiling `cmd/v`.

## Performance

Median of 11 balanced alternating runs on macOS, using `-nocache -no-memory-limit` and emitting C so external C compiler time is excluded:

| Stage | master | this PR |
| --- | ---: | ---: |
| Parse/imports | 98.45 ms | 93.90 ms |
| Check | 186.62 ms | 161.04 ms |
| Markused | 292.56 ms | 47.61 ms |
| Transform | 175.35 ms | 171.91 ms |
| Annotate/finalize | 17.72 ms | 0.04 ms |
| C generation | 234.20 ms | 211.96 ms |
| **Total** | **1007.99 ms** | **690.40 ms** |

This is a 31.5% reduction in compiler-stage time, or about 1.46x faster than master at `aaaf0c77f`.

## Testing

- `./v -g -keepc -o ./vnew cmd/v`
- `./vnew -silent vlib/v3/tests/markused_test.v`
- `./vnew -silent test vlib/v3/types/`
- `./vnew -silent test vlib/v3/transform/`
- `./vnew -silent vlib/v3/gen/c/types_test.v`
- `./vnew -silent vlib/v3/gen/c/parallel_worker_test.v`
- `./vnew -silent vlib/v3/gen/c/names_test.v`
- `./vnew -silent vlib/v/gen/c/coutput_test.v`
- `./vnew_stage2 -silent vlib/v/compiler_errors_test.v` (1619 passed)
- V3-built `cmd/v` compiled and ran `examples/hello_world.v`

A full `./vnew_stage2 -silent test vlib/v/` run completed with 2333 passed, 26 skipped, and 4 failures. The isolated failures were outside the touched V3 paths: two existing V1 autofree/labeled-continue failures, three stale inout assertion expectations counted by one test runner, and a V3 executable-basename dispatch limitation when the compiler is named `vnew_stage2`. The normal `./vnew` C output test passes independently.
