### PR TITLE
v3: reduce peak memory for large monomorph builds

### DIFF
--- a/vlib/v3/README.md
+++ b/vlib/v3/README.md
@@ -84,7 +84,8 @@ The driver monitors compiler memory throughout the build and exits when it reach
 (4 GiB for compiler self-host builds).
 On macOS it uses physical footprint, matching Activity Monitor more closely; elsewhere it uses
 current RSS. Pass `-no-memory-limit`/`--no-memory-limit` to disable this safety limit.
-On macOS, each stage benchmark prints physical footprint immediately after RSS.
+Each stage benchmark reports its sampled peak RSS and the process peak. On macOS it also prints
+physical footprint immediately after RSS.
 
 Generated C represents `thread` values with a typed wrapper around `pthread_t`. `spawn` and
 detached standard-library workers use the target's default thread stack (8 MiB on 64-bit targets

--- a/vlib/v3/README.md
+++ b/vlib/v3/README.md
@@ -84,7 +84,8 @@ The driver monitors compiler memory throughout the build and exits when it reach
 (4 GiB for compiler self-host builds).
 On macOS it uses physical footprint, matching Activity Monitor more closely; elsewhere it uses
 current RSS. Pass `-no-memory-limit`/`--no-memory-limit` to disable this safety limit.
-Each stage benchmark reports its sampled peak RSS and the process peak. On macOS it also prints
+Stage rows recorded at pipeline boundaries report sampled peak RSS and the process peak. Timing
+breakdowns reconstructed after a stage omit the sampled peak. On macOS each row also prints
 physical footprint immediately after RSS.
 
 Generated C represents `thread` values with a typed wrapper around `pthread_t`. `spawn` and

--- a/vlib/v3/bench/bench.v
+++ b/vlib/v3/bench/bench.v
@@ -45,26 +45,27 @@ struct LimitMemory {
 
 @[heap]
 struct StageMemoryMonitor {
-	mutex &sync.Mutex = sync.new_mutex()
+	mutex &sync.Mutex     = sync.new_mutex()
+	wake  &sync.Semaphore = sync.new_semaphore()
 mut:
 	rss_peak_kb i64
-	stop        bool
 }
 
 // Bench represents bench data used by bench.
 pub struct Bench {
 mut:
-	steps                  []Step
-	metrics                []Metric
-	total_sw               time.StopWatch
-	step_sw                time.StopWatch
-	last_allocation_count  u64
-	last_allocated_bytes   u64
-	memory_limit_kb        i64
-	quiet                  bool
-	stage_memory           &StageMemoryMonitor = unsafe { nil }
-	memory_monitor_thread  thread
-	memory_monitor_started bool
+	steps                   []Step
+	metrics                 []Metric
+	total_sw                time.StopWatch
+	step_sw                 time.StopWatch
+	last_allocation_count   u64
+	last_allocated_bytes    u64
+	memory_limit_kb         i64
+	quiet                   bool
+	stage_memory            &StageMemoryMonitor = unsafe { nil }
+	memory_monitor_interval i64
+	memory_monitor_thread   thread
+	memory_monitor_started  bool
 }
 
 // new creates a new value for bench.
@@ -72,15 +73,17 @@ pub fn new() Bench {
 	allocations := current_allocation_stats()
 	ram_kb := current_rss_kb()
 	return Bench{
-		total_sw:              time.new_stopwatch()
-		step_sw:               time.new_stopwatch()
-		last_allocation_count: allocations.allocation_count
-		last_allocated_bytes:  allocations.allocated_bytes
-		memory_limit_kb:       default_memory_limit_kb
-		stage_memory:          &StageMemoryMonitor{
+		total_sw:                time.new_stopwatch()
+		step_sw:                 time.new_stopwatch()
+		last_allocation_count:   allocations.allocation_count
+		last_allocated_bytes:    allocations.allocated_bytes
+		memory_limit_kb:         default_memory_limit_kb
+		stage_memory:            &StageMemoryMonitor{
 			mutex:       sync.new_mutex()
+			wake:        sync.new_semaphore()
 			rss_peak_kb: ram_kb
 		}
+		memory_monitor_interval: memory_monitor_interval
 	}
 }
 
@@ -108,21 +111,21 @@ pub fn (mut b Bench) set_quiet() {
 // start_memory_monitor starts the compiler memory safety watchdog.
 pub fn (mut b Bench) start_memory_monitor() {
 	if b.memory_limit_kb > 0 || !b.quiet {
-		b.memory_monitor_thread = spawn monitor_stage_memory(b.stage_memory, b.memory_limit_kb)
+		b.memory_monitor_thread = spawn monitor_stage_memory(b.stage_memory, b.memory_limit_kb,
+			b.memory_monitor_interval)
 		b.memory_monitor_started = true
 	}
 }
 
-fn monitor_stage_memory(state &StageMemoryMonitor, limit_kb i64) {
+fn monitor_stage_memory(state &StageMemoryMonitor, limit_kb i64, interval i64) {
+	mut wake := unsafe { &sync.Semaphore(voidptr(state.wake)) }
 	for {
-		time.sleep(memory_monitor_interval)
+		if wake.timed_wait(interval) {
+			return
+		}
 		ram_kb := current_rss_kb()
 		mut monitor := unsafe { &StageMemoryMonitor(voidptr(state)) }
 		monitor.mutex.lock()
-		if monitor.stop {
-			monitor.mutex.unlock()
-			return
-		}
 		if ram_kb > monitor.rss_peak_kb {
 			monitor.rss_peak_kb = ram_kb
 		}
@@ -144,9 +147,8 @@ pub fn (mut b Bench) stop_memory_monitor() {
 		return
 	}
 	mut monitor := unsafe { &StageMemoryMonitor(voidptr(b.stage_memory)) }
-	monitor.mutex.lock()
-	monitor.stop = true
-	monitor.mutex.unlock()
+	mut wake := unsafe { &sync.Semaphore(voidptr(monitor.wake)) }
+	wake.post()
 	b.memory_monitor_thread.wait()
 	b.memory_monitor_started = false
 }
@@ -196,7 +198,7 @@ pub fn (b &Bench) current_step_time_us() i64 {
 // account for their full wall time.
 pub fn (mut b Bench) step_measured(name string, elapsed_us i64) {
 	allocations := current_allocation_stats()
-	b.report_step(name, false, elapsed_us, 0, 0, allocations.enabled)
+	b.report_step(name, false, elapsed_us, 0, 0, allocations.enabled, false)
 }
 
 // step_parallel records a pipeline step, appending "(parallel)" to its name
@@ -206,7 +208,7 @@ pub fn (mut b Bench) step_parallel(name string, parallel bool) {
 	allocations := current_allocation_stats()
 	b.report_step(name, parallel, elapsed_us,
 		allocations.allocation_count - b.last_allocation_count,
-		allocations.allocated_bytes - b.last_allocated_bytes, allocations.enabled)
+		allocations.allocated_bytes - b.last_allocated_bytes, allocations.enabled, true)
 	b.finish_step_report()
 }
 
@@ -224,6 +226,9 @@ pub fn (mut b Bench) step_parts(parts []StepPart) {
 	}
 	mut reported_allocation_count := u64(0)
 	mut reported_allocated_bytes := u64(0)
+	// These timings are split retrospectively, so discard the sampled peak at
+	// the real enclosing-stage boundary instead of assigning it to one part.
+	_ = b.finish_stage_memory(current_rss_kb())
 	for idx, part in parts {
 		is_last := idx == parts.len - 1
 		allocation_count := if is_last || total_us <= 0 {
@@ -237,17 +242,17 @@ pub fn (mut b Bench) step_parts(parts []StepPart) {
 			u64(i64(total_allocated_bytes) * part.time_us / total_us)
 		}
 		b.report_step(part.name, part.parallel, part.time_us, allocation_count, allocated_bytes,
-			allocations.enabled)
+			allocations.enabled, false)
 		reported_allocation_count += allocation_count
 		reported_allocated_bytes += allocated_bytes
 	}
 	b.finish_step_report()
 }
 
-fn (mut b Bench) report_step(name string, parallel bool, elapsed_us i64, allocation_count u64, allocated_bytes u64, allocations_enabled bool) {
+fn (mut b Bench) report_step(name string, parallel bool, elapsed_us i64, allocation_count u64, allocated_bytes u64, allocations_enabled bool, has_stage_peak bool) {
 	label := if parallel { '${name} (parallel)' } else { name }
 	ram_kb := current_rss_kb()
-	stage_peak_ram_kb := b.finish_stage_memory(ram_kb)
+	stage_peak_ram_kb := if has_stage_peak { b.finish_stage_memory(ram_kb) } else { i64(0) }
 	peak_ram_kb := peak_rss_kb()
 	memory := current_limit_memory()
 	if b.memory_limit_kb > 0 {
@@ -258,9 +263,14 @@ fn (mut b Bench) report_step(name string, parallel bool, elapsed_us i64, allocat
 		}
 	}
 	ram_mb := f64(ram_kb) / 1024.0
-	stage_peak_ram_mb := f64(stage_peak_ram_kb) / 1024.0
 	peak_ram_mb := f64(peak_ram_kb) / 1024.0
 	footprint_suffix := physical_footprint_suffix(memory)
+	stage_peak_suffix := if has_stage_peak {
+		stage_peak_ram_mb := f64(stage_peak_ram_kb) / 1024.0
+		'   ${stage_peak_ram_mb:6.0f} MB stage peak'
+	} else {
+		''
+	}
 	ms := f64(elapsed_us) / 1000.0
 	allocation_suffix := if allocations_enabled {
 		allocated_mb := f64(allocated_bytes) / (1024.0 * 1024.0)
@@ -269,7 +279,7 @@ fn (mut b Bench) report_step(name string, parallel bool, elapsed_us i64, allocat
 		''
 	}
 	if !b.quiet {
-		println('  ${label:-20s} ${ms:8.2f} ms   ${ram_mb:6.0f} MB RSS${footprint_suffix}   ${stage_peak_ram_mb:6.0f} MB stage peak   ${peak_ram_mb:6.0f} MB peak${allocation_suffix}')
+		println('  ${label:-20s} ${ms:8.2f} ms   ${ram_mb:6.0f} MB RSS${footprint_suffix}${stage_peak_suffix}   ${peak_ram_mb:6.0f} MB peak${allocation_suffix}')
 	}
 	b.steps << Step{
 		name:              label

--- a/vlib/v3/bench/bench.v
+++ b/vlib/v3/bench/bench.v
@@ -48,20 +48,23 @@ struct StageMemoryMonitor {
 	mutex &sync.Mutex = sync.new_mutex()
 mut:
 	rss_peak_kb i64
+	stop        bool
 }
 
 // Bench represents bench data used by bench.
 pub struct Bench {
 mut:
-	steps                 []Step
-	metrics               []Metric
-	total_sw              time.StopWatch
-	step_sw               time.StopWatch
-	last_allocation_count u64
-	last_allocated_bytes  u64
-	memory_limit_kb       i64
-	quiet                 bool
-	stage_memory          &StageMemoryMonitor = unsafe { nil }
+	steps                  []Step
+	metrics                []Metric
+	total_sw               time.StopWatch
+	step_sw                time.StopWatch
+	last_allocation_count  u64
+	last_allocated_bytes   u64
+	memory_limit_kb        i64
+	quiet                  bool
+	stage_memory           &StageMemoryMonitor = unsafe { nil }
+	memory_monitor_thread  thread
+	memory_monitor_started bool
 }
 
 // new creates a new value for bench.
@@ -103,9 +106,10 @@ pub fn (mut b Bench) set_quiet() {
 }
 
 // start_memory_monitor starts the compiler memory safety watchdog.
-pub fn (b &Bench) start_memory_monitor() {
+pub fn (mut b Bench) start_memory_monitor() {
 	if b.memory_limit_kb > 0 || !b.quiet {
-		spawn monitor_stage_memory(b.stage_memory, b.memory_limit_kb)
+		b.memory_monitor_thread = spawn monitor_stage_memory(b.stage_memory, b.memory_limit_kb)
+		b.memory_monitor_started = true
 	}
 }
 
@@ -115,6 +119,10 @@ fn monitor_stage_memory(state &StageMemoryMonitor, limit_kb i64) {
 		ram_kb := current_rss_kb()
 		mut monitor := unsafe { &StageMemoryMonitor(voidptr(state)) }
 		monitor.mutex.lock()
+		if monitor.stop {
+			monitor.mutex.unlock()
+			return
+		}
 		if ram_kb > monitor.rss_peak_kb {
 			monitor.rss_peak_kb = ram_kb
 		}
@@ -128,6 +136,19 @@ fn monitor_stage_memory(state &StageMemoryMonitor, limit_kb i64) {
 			}
 		}
 	}
+}
+
+// stop_memory_monitor stops and joins the sampler before its benchmark state is released.
+pub fn (mut b Bench) stop_memory_monitor() {
+	if !b.memory_monitor_started {
+		return
+	}
+	mut monitor := unsafe { &StageMemoryMonitor(voidptr(b.stage_memory)) }
+	monitor.mutex.lock()
+	monitor.stop = true
+	monitor.mutex.unlock()
+	b.memory_monitor_thread.wait()
+	b.memory_monitor_started = false
 }
 
 fn monitor_memory_limit(limit_kb i64) {

--- a/vlib/v3/bench/bench.v
+++ b/vlib/v3/bench/bench.v
@@ -2,6 +2,7 @@ module bench
 
 import os
 import runtime
+import sync
 import time
 
 const default_memory_limit_kb = i64(9) * 256 * 1024
@@ -12,12 +13,13 @@ const memory_monitor_interval = 100 * time.millisecond
 // Step represents step data used by bench.
 pub struct Step {
 pub:
-	name             string
-	time_us          i64
-	ram_kb           i64
-	peak_ram_kb      i64
-	allocation_count u64
-	allocated_bytes  u64
+	name              string
+	time_us           i64
+	ram_kb            i64
+	stage_peak_ram_kb i64
+	peak_ram_kb       i64
+	allocation_count  u64
+	allocated_bytes   u64
 }
 
 // StepPart describes one measured part of a pipeline step.
@@ -41,6 +43,13 @@ struct LimitMemory {
 	metric string
 }
 
+@[heap]
+struct StageMemoryMonitor {
+	mutex &sync.Mutex = sync.new_mutex()
+mut:
+	rss_peak_kb i64
+}
+
 // Bench represents bench data used by bench.
 pub struct Bench {
 mut:
@@ -52,17 +61,23 @@ mut:
 	last_allocated_bytes  u64
 	memory_limit_kb       i64
 	quiet                 bool
+	stage_memory          &StageMemoryMonitor = unsafe { nil }
 }
 
 // new creates a new value for bench.
 pub fn new() Bench {
 	allocations := current_allocation_stats()
+	ram_kb := current_rss_kb()
 	return Bench{
 		total_sw:              time.new_stopwatch()
 		step_sw:               time.new_stopwatch()
 		last_allocation_count: allocations.allocation_count
 		last_allocated_bytes:  allocations.allocated_bytes
 		memory_limit_kb:       default_memory_limit_kb
+		stage_memory:          &StageMemoryMonitor{
+			mutex:       sync.new_mutex()
+			rss_peak_kb: ram_kb
+		}
 	}
 }
 
@@ -89,8 +104,29 @@ pub fn (mut b Bench) set_quiet() {
 
 // start_memory_monitor starts the compiler memory safety watchdog.
 pub fn (b &Bench) start_memory_monitor() {
-	if b.memory_limit_kb > 0 {
-		spawn monitor_memory_limit(b.memory_limit_kb)
+	if b.memory_limit_kb > 0 || !b.quiet {
+		spawn monitor_stage_memory(b.stage_memory, b.memory_limit_kb)
+	}
+}
+
+fn monitor_stage_memory(state &StageMemoryMonitor, limit_kb i64) {
+	for {
+		time.sleep(memory_monitor_interval)
+		ram_kb := current_rss_kb()
+		mut monitor := unsafe { &StageMemoryMonitor(voidptr(state)) }
+		monitor.mutex.lock()
+		if ram_kb > monitor.rss_peak_kb {
+			monitor.rss_peak_kb = ram_kb
+		}
+		monitor.mutex.unlock()
+		if limit_kb > 0 {
+			memory := current_limit_memory()
+			message := memory_limit_error(memory.kb, limit_kb, 'during compilation', memory.metric)
+			if message.len > 0 {
+				eprintln(message)
+				exit(1)
+			}
+		}
 	}
 }
 
@@ -104,6 +140,22 @@ fn monitor_memory_limit(limit_kb i64) {
 			exit(1)
 		}
 	}
+}
+
+fn (mut b Bench) finish_stage_memory(current_ram_kb i64) i64 {
+	if isnil(b.stage_memory) {
+		return current_ram_kb
+	}
+	mut monitor := unsafe { &StageMemoryMonitor(voidptr(b.stage_memory)) }
+	monitor.mutex.lock()
+	stage_peak_kb := if monitor.rss_peak_kb > current_ram_kb {
+		monitor.rss_peak_kb
+	} else {
+		current_ram_kb
+	}
+	monitor.rss_peak_kb = current_ram_kb
+	monitor.mutex.unlock()
+	return stage_peak_kb
 }
 
 // step records a serial pipeline step.
@@ -174,6 +226,7 @@ pub fn (mut b Bench) step_parts(parts []StepPart) {
 fn (mut b Bench) report_step(name string, parallel bool, elapsed_us i64, allocation_count u64, allocated_bytes u64, allocations_enabled bool) {
 	label := if parallel { '${name} (parallel)' } else { name }
 	ram_kb := current_rss_kb()
+	stage_peak_ram_kb := b.finish_stage_memory(ram_kb)
 	peak_ram_kb := peak_rss_kb()
 	memory := current_limit_memory()
 	if b.memory_limit_kb > 0 {
@@ -184,6 +237,7 @@ fn (mut b Bench) report_step(name string, parallel bool, elapsed_us i64, allocat
 		}
 	}
 	ram_mb := f64(ram_kb) / 1024.0
+	stage_peak_ram_mb := f64(stage_peak_ram_kb) / 1024.0
 	peak_ram_mb := f64(peak_ram_kb) / 1024.0
 	footprint_suffix := physical_footprint_suffix(memory)
 	ms := f64(elapsed_us) / 1000.0
@@ -194,15 +248,16 @@ fn (mut b Bench) report_step(name string, parallel bool, elapsed_us i64, allocat
 		''
 	}
 	if !b.quiet {
-		println('  ${label:-20s} ${ms:8.2f} ms   ${ram_mb:6.0f} MB RSS${footprint_suffix}   ${peak_ram_mb:6.0f} MB peak${allocation_suffix}')
+		println('  ${label:-20s} ${ms:8.2f} ms   ${ram_mb:6.0f} MB RSS${footprint_suffix}   ${stage_peak_ram_mb:6.0f} MB stage peak   ${peak_ram_mb:6.0f} MB peak${allocation_suffix}')
 	}
 	b.steps << Step{
-		name:             label
-		time_us:          elapsed_us
-		ram_kb:           ram_kb
-		peak_ram_kb:      peak_ram_kb
-		allocation_count: allocation_count
-		allocated_bytes:  allocated_bytes
+		name:              label
+		time_us:           elapsed_us
+		ram_kb:            ram_kb
+		stage_peak_ram_kb: stage_peak_ram_kb
+		peak_ram_kb:       peak_ram_kb
+		allocation_count:  allocation_count
+		allocated_bytes:   allocated_bytes
 	}
 }
 

--- a/vlib/v3/bench/bench.v
+++ b/vlib/v3/bench/bench.v
@@ -123,9 +123,11 @@ fn monitor_stage_memory(state &StageMemoryMonitor, limit_kb i64, interval i64) {
 		if wake.timed_wait(interval) {
 			return
 		}
-		ram_kb := current_rss_kb()
 		mut monitor := unsafe { &StageMemoryMonitor(voidptr(state)) }
 		monitor.mutex.lock()
+		// Serialize the measurement itself with stage resets so a sample read
+		// before a boundary cannot be published into the following stage.
+		ram_kb := current_rss_kb()
 		if ram_kb > monitor.rss_peak_kb {
 			monitor.rss_peak_kb = ram_kb
 		}

--- a/vlib/v3/bench/bench_test.v
+++ b/vlib/v3/bench/bench_test.v
@@ -1,6 +1,7 @@
 module bench
 
 import os
+import time
 
 const memory_monitor_test_child = 'V3_MEMORY_MONITOR_TEST_CHILD'
 
@@ -56,8 +57,12 @@ fn test_step_parts_record_individual_timings() {
 	assert b.steps.len == 2
 	assert b.steps[0].name == 'parse .vh (parallel)'
 	assert b.steps[0].time_us == 1250
+	assert b.steps[0].stage_peak_ram_kb == 0
 	assert b.steps[1].name == 'parse .v'
 	assert b.steps[1].time_us == 2750
+	assert b.steps[1].stage_peak_ram_kb == 0
+	b.step_measured('ownership', 500)
+	assert b.steps[2].stage_peak_ram_kb == 0
 }
 
 fn test_finish_stage_memory_reports_and_resets_sampled_peak() {
@@ -77,9 +82,12 @@ fn test_finish_stage_memory_reports_and_resets_sampled_peak() {
 fn test_stage_memory_monitor_stops_before_state_release() {
 	mut b := new()
 	b.disable_memory_limit()
+	b.memory_monitor_interval = time.minute
 	b.start_memory_monitor()
+	stopwatch := time.new_stopwatch()
 	b.stop_memory_monitor()
 	assert !b.memory_monitor_started
+	assert stopwatch.elapsed() < time.second
 }
 
 fn test_limit_memory_metric_is_available() {

--- a/vlib/v3/bench/bench_test.v
+++ b/vlib/v3/bench/bench_test.v
@@ -60,6 +60,20 @@ fn test_step_parts_record_individual_timings() {
 	assert b.steps[1].time_us == 2750
 }
 
+fn test_finish_stage_memory_reports_and_resets_sampled_peak() {
+	mut b := new()
+	current := current_rss_kb()
+	mut monitor := unsafe { &StageMemoryMonitor(voidptr(b.stage_memory)) }
+	monitor.mutex.lock()
+	monitor.rss_peak_kb = current + 2048
+	monitor.mutex.unlock()
+	assert b.finish_stage_memory(current) == current + 2048
+	monitor.mutex.lock()
+	reset_peak := monitor.rss_peak_kb
+	monitor.mutex.unlock()
+	assert reset_peak == current
+}
+
 fn test_limit_memory_metric_is_available() {
 	memory := current_limit_memory()
 	assert memory.kb > 0

--- a/vlib/v3/bench/bench_test.v
+++ b/vlib/v3/bench/bench_test.v
@@ -74,6 +74,14 @@ fn test_finish_stage_memory_reports_and_resets_sampled_peak() {
 	assert reset_peak == current
 }
 
+fn test_stage_memory_monitor_stops_before_state_release() {
+	mut b := new()
+	b.disable_memory_limit()
+	b.start_memory_monitor()
+	b.stop_memory_monitor()
+	assert !b.memory_monitor_started
+}
+
 fn test_limit_memory_metric_is_available() {
 	memory := current_limit_memory()
 	assert memory.kb > 0

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -8612,11 +8612,11 @@ pub fn run(args []string) {
 		if !building_v {
 			if uses_generics && (!incremental_cache_hit || incremental_needs_monomorphize) {
 				if scope_prealloc_stages {
-					// Volt's reachable specialization set settles just below 4x the
-					// transformed node count. Reserving that bounded final size avoids
-					// growing 3x caches to 6x inside the disposable monomorph arena and
-					// then copying those oversized arrays back into the parent.
-					pre_tc.materialize_sparse_transform_node_caches(a.nodes.len, a.nodes.len * 4)
+					// Volt's reachable specialization set settles near 2.3x the
+					// transformed node count. A 3x reservation keeps the dense semantic
+					// caches stable through monomorphization without retaining a fourth
+					// mostly-empty copy of every node-indexed slab.
+					pre_tc.materialize_sparse_transform_node_caches(a.nodes.len, a.nodes.len * 3)
 				}
 				// Generic lowering rewrites and clones call nodes in disposable arenas.
 				// Resolve their final names from the owned transformed AST instead of
@@ -8692,10 +8692,10 @@ pub fn run(args []string) {
 				eprintln('mono AST before reserve: ${a.nodes.len}/${a.nodes.cap} nodes, ${a.children.len}/${a.children.cap} children')
 			}
 			base_monomorph_nodes := a.nodes.len
-			// Volt's current generic closure retains about 5x the transformed node
-			// and child counts. Reserve that measured final size directly so one
-			// slightly-larger closure does not double both multi-million-item slabs.
-			reserve_flat_ast_exact(mut a, a.nodes.len * 5 + 65536, a.children.len * 5 + 65536)
+			// Volt's current generic closure retains about 2.3x the transformed node
+			// and child counts. Four times the input leaves each parallel append region
+			// enough headroom while avoiding a fifth mostly-empty AST slab.
+			reserve_flat_ast_exact(mut a, a.nodes.len * 4 + 65536, a.children.len * 4 + 65536)
 			monomorph_nodes_cap := a.nodes.cap
 			monomorph_children_cap := a.children.cap
 			base_specialized_fns := a.specialized_fn_nodes.len

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -7218,6 +7218,9 @@ pub fn run(args []string) {
 		b.use_self_host_memory_limit()
 	}
 	b.start_memory_monitor()
+	defer {
+		b.stop_memory_monitor()
+	}
 	mut c_object_cache_stats := CObjectCacheStats{}
 	if !silent {
 		println('=== v3 benchmark ===')

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -2981,6 +2981,11 @@ fn (mut g FlatGen) gen_mut_sum_lvalue_arg(arg_id flat.NodeId, expected types.Typ
 	mut lvalue_id := arg_id
 	if int(arg_id) >= 0 && int(arg_id) < g.a.nodes.len {
 		arg_node := g.a.nodes[int(arg_id)]
+		// Interface values use the sum-value ABI, and some call paths reach this
+		// helper before the general argument handling below.
+		if g.gen_lowered_mut_value_storage_arg(arg_id, arg_node, expected) {
+			return true
+		}
 		if arg_node.kind == .prefix && arg_node.op == .amp && arg_node.children_count > 0 {
 			lvalue_id = g.a.child(&arg_node, 0)
 		}
@@ -7055,6 +7060,11 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 				}
 				if !is_c_call && arg_idx < typed_param_count
 					&& g.gen_mut_sum_lvalue_arg(arg_id, param_types[arg_idx]) {
+					g.expected_enum = ''
+					continue
+				}
+				if !is_c_call && arg_idx < typed_param_count
+					&& g.gen_lowered_mut_value_storage_arg(arg_id, arg_node, param_types[arg_idx]) {
 					g.expected_enum = ''
 					continue
 				}
@@ -12909,6 +12919,10 @@ fn (mut g FlatGen) gen_call_args(fn_name string, node flat.Node, start int) {
 			continue
 		}
 		if arg_idx < typed_param_count
+			&& g.gen_lowered_mut_value_storage_arg(arg_id, arg_node, param_types[arg_idx]) {
+			continue
+		}
+		if arg_idx < typed_param_count
 			&& g.gen_mut_pointer_slot_arg(arg_id, arg_node, param_types[arg_idx]) {
 			continue
 		}
@@ -14018,6 +14032,25 @@ fn (mut g FlatGen) gen_mut_pointer_slot_arg(arg_id flat.NodeId, arg_node flat.No
 	g.write('&((${ct}[]){')
 	g.gen_expr_with_expected_type(arg_id, expected_base)
 	g.write('})[0]')
+	return true
+}
+
+fn (mut g FlatGen) gen_lowered_mut_value_storage_arg(arg_id flat.NodeId, arg_node flat.Node, expected types.Type) bool {
+	if arg_node.kind != .prefix || arg_node.op != .mul || arg_node.children_count != 1 {
+		return false
+	}
+	child_id := g.a.child(&arg_node, 0)
+	child := g.a.nodes[int(child_id)]
+	// Mutable array iteration stores the value as `T*` and lowers an ordinary
+	// expression to `*value`. In a source `mut value` argument the callee expects
+	// that storage pointer itself, including when T is an interface value.
+	if child.kind != .ident || !child.is_mut || !g.local_storage_is_pointer(child.value) {
+		return false
+	}
+	if g.tc.c_type(g.usable_expr_type(arg_id)) != g.tc.c_type(expected) {
+		return false
+	}
+	g.gen_expr(child_id)
 	return true
 }
 

--- a/vlib/v3/gen/c/stmt.v
+++ b/vlib/v3/gen/c/stmt.v
@@ -4649,6 +4649,16 @@ fn (g &FlatGen) usable_expr_type_uncached(id flat.NodeId) types.Type {
 			return types.Type(types.String{})
 		}
 		if node.kind == .prefix && node.children_count > 0 {
+			// Lowering can insert a storage dereference around mutable map values.
+			// Its child keeps the source value type while the prefix annotation is
+			// the semantic type after removing only the hidden C storage layer.
+			// Prefer that exact annotation before deriving a source-level `*p` type.
+			if node.typ.len > 0 {
+				annotated := g.tc.parse_type(node.typ)
+				if annotated is types.Pointer && !decl_annotation_is_unusable(annotated, node.typ) {
+					return annotated
+				}
+			}
 			child_type := g.usable_expr_type(g.a.child(&node, 0))
 			if node.op == .amp {
 				return types.Type(types.Pointer{

--- a/vlib/v3/gen/c/stmt_test.v
+++ b/vlib/v3/gen/c/stmt_test.v
@@ -25,6 +25,34 @@ fn stmt_test_prefix(mut a flat.FlatAst, op flat.Op, child flat.NodeId) flat.Node
 	})
 }
 
+fn test_lowered_storage_dereference_prefers_annotated_pointer_type() {
+	mut a := flat.FlatAst.new()
+	mut tc := types.TypeChecker.new(&a)
+	mut g := FlatGen.new()
+	g.a = &a
+	g.tc = &tc
+	pointer_type := types.Type(types.Pointer{
+		base_type: types.Type(types.int_)
+	})
+	value_id := stmt_test_node(mut a, .ident, 'value', [])
+	tc.register_synth_type(value_id, pointer_type)
+	children_start := a.children.len
+	a.children << value_id
+	deref_id := a.add_node(flat.Node{
+		kind:           .prefix
+		op:             .mul
+		typ:            '&int'
+		children_start: i32(children_start)
+		children_count: 1
+	})
+
+	actual := g.usable_expr_type(deref_id)
+	assert actual is types.Pointer
+	if actual is types.Pointer {
+		assert actual.base_type == types.Type(types.int_)
+	}
+}
+
 fn test_primitive_fixed_array_zero_initializer_is_compact() {
 	mut a := flat.FlatAst.new()
 	mut tc := types.TypeChecker.new(&a)

--- a/vlib/v3/tests/mutable_interface_array_value_test.v
+++ b/vlib/v3/tests/mutable_interface_array_value_test.v
@@ -1,0 +1,27 @@
+interface MutableInterfaceArrayValue {
+	value() int
+}
+
+struct MutableInterfaceArrayItem {
+	n int
+}
+
+fn (item MutableInterfaceArrayItem) value() int {
+	return item.n
+}
+
+fn read_mutable_interface(mut item MutableInterfaceArrayValue) int {
+	return item.value()
+}
+
+fn test_mutable_interface_array_value_passes_storage_pointer() {
+	mut values := []MutableInterfaceArrayValue{}
+	values << MutableInterfaceArrayItem{
+		n: 7
+	}
+	mut result := 0
+	for mut value in values {
+		result = read_mutable_interface(mut value)
+	}
+	assert result == 7
+}

--- a/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
@@ -949,17 +949,8 @@ fn (mut t Transformer) run_parallel_monomorphize_specs(specs []PendingGenericFnS
 			t.a.worker_pool = workers.new(runtime.nr_jobs() - 1)
 		}
 		available_jobs := t.a.worker_pool.size() + 1
-		// Forked checkers carry substantial semantic indexes. Small programs do not have
-		// enough specialization work to repay a full machine-sized set of those clones.
-		mut job_limit := if t.a.nodes.len < 1_000_000 {
-			int_min(available_jobs, 4)
-		} else {
-			available_jobs
-		}
 		configured_jobs := os.getenv('V3_MONOMORPH_JOBS').int()
-		if configured_jobs > 0 && configured_jobs < job_limit {
-			job_limit = configured_jobs
-		}
+		job_limit := monomorph_job_limit(available_jobs, t.a.nodes.len, configured_jobs)
 		n_jobs := monomorph_job_count(job_limit, specs.len)
 		if n_jobs <= 1 {
 			return false
@@ -1397,6 +1388,19 @@ fn monomorph_job_count(n_runtime_jobs int, n_specs int) int {
 		n = n_specs
 	}
 	return n
+}
+
+fn monomorph_job_limit(available_jobs int, node_count int, configured_jobs int) int {
+	if available_jobs <= 1 {
+		return 1
+	}
+	if configured_jobs > 0 {
+		return int_min(available_jobs, configured_jobs)
+	}
+	// Each helper retains a forked checker and its disposable specialization arena
+	// until the final publication barrier. Two workers keep large applications under
+	// the normal memory budget; smaller programs retain the lower-latency four-way path.
+	return int_min(available_jobs, if node_count >= 500_000 { 2 } else { 4 })
 }
 
 // monomorph_regions_can_merge_in_place reports whether sequential leftward

--- a/vlib/v3/transform/transform_parallel_test.v
+++ b/vlib/v3/transform/transform_parallel_test.v
@@ -12,6 +12,16 @@ fn test_monomorph_job_count_does_not_start_empty_workers() {
 	}
 }
 
+fn test_monomorph_job_limit_caps_large_programs() {
+	$if !v3_no_parallel ? {
+		assert monomorph_job_limit(12, 499_999, 0) == 4
+		assert monomorph_job_limit(12, 500_000, 0) == 2
+		assert monomorph_job_limit(1, 500_000, 0) == 1
+		assert monomorph_job_limit(12, 500_000, 6) == 6
+		assert monomorph_job_limit(4, 500_000, 8) == 4
+	}
+}
+
 fn test_generated_calls_publish_exact_resolution_except_cgen_intrinsics() {
 	mut a := flat.FlatAst.new()
 	mut tc := types.TypeChecker.new(&a)


### PR DESCRIPTION
## Summary

- report sampled RSS for every V3 stage, the per-stage peak, and the process peak
- cap automatic monomorphization at two workers for ASTs with at least 500,000 nodes while preserving explicit `V3_MONOMORPH_JOBS` overrides
- reduce oversized self-host AST and semantic-cache reservations
- preserve lowered mutable value-storage pointers through C generation, including mutable interface values from arrays
- stop and join the stage-memory sampler before releasing its benchmark state

These changes target generic-heavy applications such as Volt, where parallel monomorphization previously retained several large checker and AST copies concurrently.

## Tests

- `./vnew -old-compiler -gc none -path vlib test vlib/v3/bench/bench_test.v`
- `./vnew -old-compiler -gc none -path vlib test vlib/v3/transform/transform_parallel_test.v`
- `./vnew -old-compiler -gc none -path vlib test vlib/v3/gen/c/stmt_test.v`
- `./vnew -new-compiler -nocache test vlib/v3/tests/mutable_interface_array_value_test.v`
- `./vnew check-md vlib/v3/README.md`
- `git diff --check origin/master...HEAD`