### PR TITLE
fix: sync v reduce help text with actual flag definitions

### DIFF
--- a/vlib/v/help/other/reduce.txt
+++ b/vlib/v/help/other/reduce.txt
@@ -1,4 +1,4 @@
-Description: `v reduce file.v` will try to minimise the given source 
+Description: `v reduce file.v` will try to minimise the given source
 code `file.v`, to its smallest version, that still leads to a V compiler
 error. The result of the reduction, will be stored in a file named
 `rpdc.v` in the current folder.
@@ -6,12 +6,20 @@ error. The result of the reduction, will be stored in a file named
 Usage: v reduce path/to/file_to_reduce.v [options] [ARGS]
 
 Options:
-  -e, --error_msg <string>  the error message you want to reproduce, 
+  -m, --error_msg <string>  the error message you want to reproduce,
                             default: 'C compilation error'
-							
-  -c, --command <string>    the command used to try to reproduce the error,
-                            default: `'/home/delian/code/v/v' -no-skip-unused`
 
-  -w, --fmt                 run `v fmt -w rpdc.v`, after the reduction is done
+  -c, --command <string>    the command used to try to reproduce the error,
+                            default: `'<VEXE>' -no-skip-unused`, will replace
+                            PATH with the path of the folder where it is run
+
+  -p, --cp                  if used v reduce will copy the whole folder of the
+                            project
+
+  -t, --to <int>            sets a timeout for the command, default=0: no
+                            timeout
+
+  -w, --fmt                 enable v fmt for the output (rpdc_file_name.v)
+
   -h, --help                display this help and exit
   --version                 output version information and exit


### PR DESCRIPTION
This fixes #28136: the `v help reduce` page and the `v reduce -h` output were out of sync with the actual flag definitions in `cmd/tools/vreduce.v`.

## What was wrong

- `v help reduce` printed a static text file (`vlib/v/help/other/reduce.txt`) that:
  - documented `-e, --error_msg` while the code defines the short flag as `-m`
  - omitted the `-p, --cp` (copy project) and `-t, --to <int>` (timeout) options entirely
  - hardcoded a stale path to a developer's V install in the default command example
- `v reduce -h` prints the usage compiled into the code, which is the source of truth

## Changes

- Updated `vlib/v/help/other/reduce.txt` to match the compiled flag definitions:
  - `-e` → `-m, --error_msg <string>`
  - added `-p, --cp` — copy the whole project folder
  - added `-t, --to <int>` — set a timeout for the command
  - replaced the hardcoded developer path with a generic `<VEXE>` description
  - aligned the `-c, --command` description with the code comment
