### PR TITLE
crypto.scram: add SCRAM (RFC 5802 / RFC 7677) client and server

### DIFF
--- a/examples/scram.v
+++ b/examples/scram.v
@@ -1,0 +1,107 @@
+// SCRAM example program: registers a user, authenticates it, then shows
+// what happens when the password is wrong and when the server cannot
+// prove itself.
+//
+// Run with:  v run examples/scram.v
+import crypto.scram
+
+// A stand-in for the table a real server would keep. SCRAM never stores
+// the password, only the salt, the iteration count and two derived keys.
+struct UserStore {
+mut:
+	records map[string]scram.Credentials
+}
+
+fn (mut s UserStore) register(username string, password string) ! {
+	s.records[username] = scram.new_credentials(.sha256, password)!
+}
+
+fn main() {
+	mut store := UserStore{}
+	store.register('alice', 'correct horse battery staple')!
+	println('registered alice: stored ${store.records['alice'].stored_key.len} byte keys, no password')
+
+	demo_successful_login(store)!
+	demo_wrong_password(store)!
+	demo_impostor_server(store)!
+}
+
+// The nominal exchange. In a real program the two halves sit on either
+// side of a socket and only the four strings travel.
+fn demo_successful_login(store UserStore) ! {
+	println('\n--- a successful login ---')
+	mut server := new_server_for(store)!
+	mut client := scram.new_client(username: 'alice', password: 'correct horse battery staple')!
+
+	client_first := client.first()!
+	println('C: ${client_first}')
+	server_first := server.first(client_first)!
+	println('S: ${server_first}')
+	client_final := client.final(server_first)!
+	println('C: ${client_final}')
+	server_final := server.final(client_final)!
+	println('S: ${server_final}')
+
+	// Only now is the connection authenticated, in both directions.
+	client.verify(server_final)!
+	println('=> ${server.username()} is authenticated, and the server proved itself too')
+}
+
+// A wrong password produces a well formed exchange that fails on the
+// proof. The server answers with an `e=` code rather than hanging up, so
+// the client can tell a refusal from a broken connection.
+fn demo_wrong_password(store UserStore) ! {
+	println('\n--- a wrong password ---')
+	mut server := new_server_for(store)!
+	mut client := scram.new_client(username: 'alice', password: 'hunter2')!
+
+	server_first := server.first(client.first()!)!
+	refusal := server.final(client.final(server_first)!) or {
+		println('server: ${err}')
+		scram.server_error_message('invalid-proof')
+	}
+	client.verify(refusal) or {
+		println('client: ${err}')
+		if err is scram.ServerError {
+			println('=> the server refused with the code `${err.code}`')
+		}
+		return
+	}
+	println('=> unreachable: a wrong password was accepted')
+}
+
+// The step everyone is tempted to skip. A server that does not hold the
+// credentials can still answer the first three messages; it cannot sign
+// the fourth. Dropping `verify` turns SCRAM into a one-way protocol and
+// throws away its protection against a relay.
+fn demo_impostor_server(store UserStore) ! {
+	println('\n--- a server that cannot prove itself ---')
+	mut server := new_server_for(store)!
+	mut client := scram.new_client(username: 'alice', password: 'correct horse battery staple')!
+
+	server_first := server.first(client.first()!)!
+	server.final(client.final(server_first)!)!
+	// Everything above succeeded; the impostor now has to sign the
+	// transcript, and forges the signature instead.
+	forged := 'v=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA='
+	client.verify(forged) or {
+		println('client: ${err}')
+		println('=> the client refused the server, and never revealed the password')
+		return
+	}
+	println('=> unreachable: a forged server signature was accepted')
+}
+
+// new_server_for wires a server to the user store. Returning an error
+// for an unknown user is the simple choice made here; a public facing
+// server should answer with credentials derived from a server-side
+// secret instead, so that probing for user names tells an attacker
+// nothing. See RFC 5802 section 7.
+fn new_server_for(store UserStore) !&scram.Server {
+	return scram.new_server(
+		mechanism: .sha256
+		lookup:    fn [store] (username string) !scram.Credentials {
+			return store.records[username] or { error('unknown user: ${username}') }
+		}
+	)
+}

--- a/vlib/crypto/scram/README.md
+++ b/vlib/crypto/scram/README.md
@@ -1,0 +1,241 @@
+## Description
+
+`crypto.scram` implements the Salted Challenge Response Authentication
+Mechanism (SCRAM) family of SASL mechanisms: `SCRAM-SHA-1` (RFC 5802),
+`SCRAM-SHA-256` (RFC 7677) and `SCRAM-SHA-512`, with and without channel
+binding.
+
+SCRAM is a password authentication protocol that never puts the password
+on the wire. The client proves it knows the password, the server proves
+it too, and neither side can replay a recorded exchange:
+
+* the password is stretched with PBKDF2 under a per-user salt, so the
+  server stores two derived keys instead of anything reversible;
+* what the client sends is a *proof* computed over both nonces and both
+  messages, so it is worthless outside the exchange that produced it;
+* the server signs the same transcript back, so a client that reaches
+  the end of the exchange knows it is talking to a server that holds the
+  real credentials, not to something that merely accepted its proof.
+
+It is what PostgreSQL 10+, MongoDB 3.0+, Kafka, LDAP, XMPP and the SASL
+profiles of IMAP and SMTP authenticate with. If you are writing a driver
+for any of them in V, this is the piece that used to be missing.
+
+The module has no dependencies outside `vlib` and no C dependency: it is
+built on `crypto.hmac`, `crypto.sha1`, `crypto.sha256`, `crypto.sha512`,
+`crypto.rand`, `crypto.subtle` and `encoding.base64`.
+
+## Usage
+
+The exchange is four messages. The client produces the first and third,
+the server the second and fourth. That maps to three calls on `Client`
+and two on `Server`, each one taking the message the peer just sent and
+returning the message to send back.
+
+### Authenticating against a server
+
+This is the case you want most of the time. Everything the transport has
+to do is carry four opaque ASCII strings.
+
+```v ignore
+import crypto.scram
+
+mut client := scram.new_client(username: 'user', password: 'pencil')!
+
+// 1. announce the mechanism and send the first message
+send(client.mechanism_name(), client.first()!)
+// 2. answer the server challenge
+final := client.final(receive())!
+send_payload(final)
+// 3. check that the server proved itself too — never skip this step
+client.verify(receive())!
+```
+
+Do not treat the connection as authenticated before `verify` returns. A
+server that answers the first three messages and fails the fourth does
+not hold your credentials.
+
+### Storing credentials
+
+A server never stores a password. `new_credentials` derives the record it
+does store, with a fresh random salt:
+
+```v
+import crypto.scram
+
+fn main() {
+	credentials := scram.new_credentials(.sha256, 'pencil')!
+	// Persist all four fields; none of them lets you recover the password.
+	println(credentials.mechanism.name())
+	println(credentials.salt.len)
+	println(credentials.iterations)
+	println(credentials.stored_key.len)
+}
+```
+
+Use `derive_credentials` instead when the salt and iteration count are
+imposed, for instance to reproduce a record another implementation wrote.
+
+`encode` and `parse_credentials` turn a record into one line and back, in
+the format of RFC 5803 laid out in the `authPassword` syntax of RFC 3112:
+
+```v
+import crypto.scram
+
+fn main() {
+	credentials := scram.derive_credentials(.sha256, 'pencil', 'saltsaltsaltsalt'.bytes(), 4096)!
+	line := credentials.encode()
+	// SCRAM-SHA-256$4096:c2FsdHNhbHRzYWx0c2FsdA==$Y7KMtn...:c1MMj1...
+	restored := scram.parse_credentials(line)!
+	assert restored.stored_key == credentials.stored_key
+}
+```
+
+That is the same layout PostgreSQL stores in `pg_authid.rolpassword`, so a
+record written here can be read by a PostgreSQL server or an LDAP
+directory, and the other way round. Treat the line as a secret: the server
+key in it is enough to impersonate the server to that user.
+
+Printing is safe by default. `Client`, `Server` and `Credentials` define
+their own `str()`, so a `println(client)` while debugging shows the state
+and the user name but never the password or the keys — V would otherwise
+format every field, including the secrets.
+
+### Authenticating a client
+
+`Server` reads credentials through a callback, so it does not care where
+they are stored:
+
+```v
+import crypto.scram
+
+fn main() {
+	credentials := scram.new_credentials(.sha256, 'pencil')!
+
+	mut server := scram.new_server(
+		lookup: fn [credentials] (username string) !scram.Credentials {
+			// Look the user up in your database here.
+			return credentials
+		}
+	)!
+	mut client := scram.new_client(username: 'user', password: 'pencil')!
+
+	server_first := server.first(client.first()!)!
+	server_final := server.final(client.final(server_first)!)!
+	client.verify(server_final)!
+
+	println('${server.username()} authenticated: ${client.done() && server.done()}')
+}
+```
+
+When `final` returns an `AuthenticationFailed`, answer the client with
+`scram.server_error_message('invalid-proof')` rather than closing the
+connection, so it can tell a refusal from a network failure.
+
+## Errors
+
+Four typed errors let a caller react without parsing strings:
+
+| Error | Meaning |
+| :--- | :--- |
+| `MalformedMessage` | the peer did not send a valid SCRAM message |
+| `AuthenticationFailed` | the peer failed to prove what it claimed |
+| `UnsupportedMechanism` | `mechanism_from_name` did not recognise a name |
+| `ServerError` | the server refused with an `e=` code |
+
+Calling the steps out of order, or configuring a client without a user
+name, returns a plain `error()` instead: those are bugs in the calling
+code, not protocol outcomes.
+
+## Channel binding
+
+Channel binding ties the exchange to the TLS connection carrying it, so
+that a proxy which terminates TLS cannot relay a valid exchange. It is
+what the `-PLUS` mechanism names mean.
+
+This module does not reach into the TLS layer: pass the binding data in
+and it will use it.
+
+```v
+import crypto.scram
+
+fn main() {
+	binding := scram.ChannelBinding{
+		mode: .required
+		name: 'tls-server-end-point' // RFC 5929; or 'tls-exporter', RFC 9266
+		data: certificate_hash()
+	}
+	mut client := scram.new_client(
+		username:        'user'
+		password:        'pencil'
+		channel_binding: binding
+	)!
+	println(client.mechanism_name()) // SCRAM-SHA-256-PLUS
+}
+
+fn certificate_hash() []u8 {
+	return []u8{len: 32}
+}
+```
+
+If the server advertised no `-PLUS` mechanism but your client supports
+channel binding, set `mode: .unsupported_by_server`. That sends the GS2
+`y` flag, which lets a server that *does* offer `-PLUS` detect that its
+advertised list was stripped in transit. Leaving the default
+`.not_supported` in that situation silently gives up the protection.
+
+## Security notes
+
+**Normalisation.** RFC 5802 passes the password through SASLprep
+(RFC 4013) before hashing. V has no stringprep implementation, so this
+module hashes the UTF-8 bytes it is given. ASCII passwords are
+unaffected. For a non-ASCII password, normalise it before calling, or
+two clients spelling the same password differently will disagree.
+
+**Iteration count.** A client refuses a server asking for fewer than
+`default_min_iterations` (4096, the floor in RFC 7677 §4), because a low
+count makes an offline attack on a recorded exchange cheap. Lower it
+with `ClientConfig.min_iterations` only for a legacy server that leaves
+no choice. `new_credentials` writes `default_iterations` (32768).
+
+**User enumeration.** Returning an error from the `lookup` callback tells
+the caller — and through it, an attacker — that a user name does not
+exist. RFC 5802 §7 suggests answering unknown users with credentials
+derived from a server-side secret, so they are indistinguishable from a
+wrong password. That policy belongs to the application, which is why the
+module leaves it in the callback.
+
+**Timing.** Proofs and signatures are compared with
+`crypto.subtle.constant_time_compare`.
+
+**What SCRAM does not do.** It authenticates, it does not authorize:
+`Server.authzid()` is a request from the client, not a granted right.
+And without channel binding, SCRAM over an unauthenticated channel is
+still vulnerable to a relay; use it over TLS.
+
+## Conformance
+
+`conformance_test.v` drives both halves of the exchange against eight
+vectors and checks all four messages byte for byte, plus the salted
+password, stored key and server key behind them.
+
+The first two vectors are the normative examples of RFC 5802 §5 and
+RFC 7677 §3, transcribed from the RFC text. The other six cover what the
+RFCs leave without an example: SHA-512, a user name needing `saslname`
+escaping, an authorization identity, channel binding and a non-ASCII
+password.
+
+All eight were generated by an implementation written independently from
+RFC 5802 §3, then replayed through `github.com/xdg-go/scram` v1.2.0 — the
+library the MongoDB Go driver authenticates with — which agrees on every
+message. `Hi()` is additionally checked against `crypto.pbkdf2`, which is
+an unrelated implementation of the same primitive already in vlib.
+
+## References
+
+* RFC 5802 — SCRAM-SHA-1 and the SCRAM family
+* RFC 7677 — SCRAM-SHA-256
+* RFC 5801 — the GS2 header
+* RFC 5929 — `tls-server-end-point` channel binding
+* RFC 9266 — `tls-exporter` channel binding
+* RFC 4013 — SASLprep

--- a/vlib/crypto/scram/README.md
+++ b/vlib/crypto/scram/README.md
@@ -178,6 +178,10 @@ fn certificate_hash() []u8 {
 }
 ```
 
+`data` is mandatory when `mode` is `.required`: a binding with a name but
+no data is refused at construction, because it would otherwise announce a
+`-PLUS` mechanism and complete an exchange that binds nothing.
+
 If the server advertised no `-PLUS` mechanism but your client supports
 channel binding, set `mode: .unsupported_by_server`. That sends the GS2
 `y` flag, which lets a server that *does* offer `-PLUS` detect that its

--- a/vlib/crypto/scram/README.md
+++ b/vlib/crypto/scram/README.md
@@ -188,6 +188,15 @@ channel binding, set `mode: .unsupported_by_server`. That sends the GS2
 advertised list was stripped in transit. Leaving the default
 `.not_supported` in that situation silently gives up the protection.
 
+The other half of that check is on the server, and it needs a fact the
+mode cannot carry. `ServerConfig.channel_binding.mode` describes the
+exchange in front of it; whether the server *advertises* `-PLUS` is a
+separate question, because a server usually lists both names and lets the
+client choose. Set `advertises_plus: true` whenever the `-PLUS` name is in
+the list, including on exchanges where the client picked the base
+mechanism — that is exactly where a `y` flag means the list was tampered
+with. Without it a stripped advertisement goes undetected.
+
 ## Security notes
 
 **Normalisation.** RFC 5802 passes the password through SASLprep

--- a/vlib/crypto/scram/README.md
+++ b/vlib/crypto/scram/README.md
@@ -202,6 +202,13 @@ count makes an offline attack on a recorded exchange cheap. Lower it
 with `ClientConfig.min_iterations` only for a legacy server that leaves
 no choice. `new_credentials` writes `default_iterations` (32768).
 
+A client also refuses a count above `default_max_iterations` (2^20). The
+count is chosen by the server and consumed before the server has been
+authenticated, so without a ceiling a hostile endpoint turns a short
+message into minutes of client CPU. Raise it with
+`ClientConfig.max_iterations` if you really talk to a server that asks
+for more.
+
 **User enumeration.** Returning an error from the `lookup` callback tells
 the caller — and through it, an attacker — that a user name does not
 exist. RFC 5802 §7 suggests answering unknown users with credentials

--- a/vlib/crypto/scram/README.md
+++ b/vlib/crypto/scram/README.md
@@ -77,8 +77,8 @@ fn main() {
 Use `derive_credentials` instead when the salt and iteration count are
 imposed, for instance to reproduce a record another implementation wrote.
 
-`encode` and `parse_credentials` turn a record into one line and back, in
-the format of RFC 5803 laid out in the `authPassword` syntax of RFC 3112:
+`encode` and `parse_credentials` turn a record into this one-line format and
+back:
 
 ```v
 import crypto.scram
@@ -92,11 +92,13 @@ fn main() {
 }
 ```
 
-For SCRAM-SHA-256, that is also the layout PostgreSQL stores in
-`pg_authid.rolpassword`, so a SHA-256 record written here can be read by a
-PostgreSQL server or an LDAP directory, and the other way round. PostgreSQL
-does not accept SCRAM-SHA-1 or SCRAM-SHA-512 records. Treat the line as a
-secret: the server key in it is enough to impersonate the server to that user.
+For SCRAM-SHA-1, this is the RFC 5803 `authPassword` scheme laid out in the
+syntax of RFC 3112 and can interoperate with LDAP implementations of that RFC.
+For SCRAM-SHA-256, it is the layout PostgreSQL stores in
+`pg_authid.rolpassword`. PostgreSQL does not accept SCRAM-SHA-1 or
+SCRAM-SHA-512 records, while RFC 5803 does not define SCRAM-SHA-256 or
+SCRAM-SHA-512 records for LDAP. Treat the line as a secret: the server key in
+it is enough to impersonate the server to that user.
 
 Printing is safe by default. `Client`, `Server` and `Credentials` define
 their own `str()`, so a `println(client)` while debugging shows the state

--- a/vlib/crypto/scram/README.md
+++ b/vlib/crypto/scram/README.md
@@ -210,7 +210,11 @@ and ensures equivalent spellings do not disagree. User names use SASLprep
 (RFC 4013). On the server, supply `ServerConfig.prepare_username` to apply it
 before credential lookup. Without that callback the server accepts only
 printable ASCII user names, whose SASLprep form is unchanged, and rejects
-non-ASCII or control characters.
+non-ASCII or control characters. Prepare a client's authorization identity
+with the application protocol's profile before sending it. On the server,
+`ServerConfig.prepare_authzid` applies that profile to the untrusted peer value
+before `Server.authzid()` exposes it; without the callback, only printable ASCII
+authorization identities are accepted.
 
 **Iteration count.** A client refuses a server asking for fewer than
 `default_min_iterations` (4096, the floor in RFC 7677 §4), because a low

--- a/vlib/crypto/scram/README.md
+++ b/vlib/crypto/scram/README.md
@@ -199,11 +199,13 @@ with. Without it a stripped advertisement goes undetected.
 
 ## Security notes
 
-**Normalisation.** RFC 5802 passes the password through SASLprep
-(RFC 4013) before hashing. V has no stringprep implementation, so this
-module hashes the UTF-8 bytes it is given. ASCII passwords are
-unaffected. For a non-ASCII password, normalise it before calling, or
-two clients spelling the same password differently will disagree.
+**Normalisation.** RFC 5802 passes passwords and user names through
+SASLprep (RFC 4013). V has no stringprep implementation, so this module
+hashes the password bytes it is given; normalise non-ASCII passwords before
+calling, or two equivalent spellings will disagree. On the server, supply
+`ServerConfig.prepare_username` to apply SASLprep before credential lookup.
+Without that callback the server accepts only printable ASCII user names,
+whose SASLprep form is unchanged, and rejects non-ASCII or control characters.
 
 **Iteration count.** A client refuses a server asking for fewer than
 `default_min_iterations` (4096, the floor in RFC 7677 §4), because a low

--- a/vlib/crypto/scram/README.md
+++ b/vlib/crypto/scram/README.md
@@ -199,13 +199,15 @@ with. Without it a stripped advertisement goes undetected.
 
 ## Security notes
 
-**Normalisation.** RFC 5802 passes passwords and user names through
-SASLprep (RFC 4013). V has no stringprep implementation, so this module
-hashes the password bytes it is given; normalise non-ASCII passwords before
-calling, or two equivalent spellings will disagree. On the server, supply
-`ServerConfig.prepare_username` to apply SASLprep before credential lookup.
-Without that callback the server accepts only printable ASCII user names,
-whose SASLprep form is unchanged, and rejects non-ASCII or control characters.
+**Normalisation.** SCRAM-SHA-1 passes passwords through SASLprep (RFC 4013),
+while SCRAM-SHA-256 uses the PRECIS OpaqueString profile (RFC 8265). V implements
+neither profile, so this module hashes the password bytes it is given. Prepare
+non-ASCII passwords with the profile for the selected mechanism before calling,
+or two equivalent spellings can disagree. User names use SASLprep (RFC 4013).
+On the server, supply `ServerConfig.prepare_username` to apply it before
+credential lookup. Without that callback the server accepts only printable
+ASCII user names, whose SASLprep form is unchanged, and rejects non-ASCII or
+control characters.
 
 **Iteration count.** A client refuses a server asking for fewer than
 `default_min_iterations` (4096, the floor in RFC 7677 §4), because a low

--- a/vlib/crypto/scram/README.md
+++ b/vlib/crypto/scram/README.md
@@ -35,7 +35,8 @@ returning the message to send back.
 ### Authenticating against a server
 
 This is the case you want most of the time. Everything the transport has
-to do is carry four opaque ASCII strings.
+to do is carry four opaque SCRAM payloads. They can contain UTF-8 user or
+authorization identities, so preserve their bytes without re-encoding them.
 
 ```v ignore
 import crypto.scram
@@ -202,12 +203,13 @@ with. Without it a stripped advertisement goes undetected.
 **Normalisation.** SCRAM-SHA-1 passes passwords through SASLprep (RFC 4013),
 while SCRAM-SHA-256 uses the PRECIS OpaqueString profile (RFC 8265). V implements
 neither profile, so this module hashes the password bytes it is given. Prepare
-non-ASCII passwords with the profile for the selected mechanism before calling,
-or two equivalent spellings can disagree. User names use SASLprep (RFC 4013).
-On the server, supply `ServerConfig.prepare_username` to apply it before
-credential lookup. Without that callback the server accepts only printable
-ASCII user names, whose SASLprep form is unchanged, and rejects non-ASCII or
-control characters.
+and validate every password, including ASCII input, with the profile for the
+selected mechanism before calling. Preparation rejects prohibited characters
+and ensures equivalent spellings do not disagree. User names use SASLprep
+(RFC 4013). On the server, supply `ServerConfig.prepare_username` to apply it
+before credential lookup. Without that callback the server accepts only
+printable ASCII user names, whose SASLprep form is unchanged, and rejects
+non-ASCII or control characters.
 
 **Iteration count.** A client refuses a server asking for fewer than
 `default_min_iterations` (4096, the floor in RFC 7677 §4), because a low

--- a/vlib/crypto/scram/README.md
+++ b/vlib/crypto/scram/README.md
@@ -92,10 +92,11 @@ fn main() {
 }
 ```
 
-That is the same layout PostgreSQL stores in `pg_authid.rolpassword`, so a
-record written here can be read by a PostgreSQL server or an LDAP
-directory, and the other way round. Treat the line as a secret: the server
-key in it is enough to impersonate the server to that user.
+For SCRAM-SHA-256, that is also the layout PostgreSQL stores in
+`pg_authid.rolpassword`, so a SHA-256 record written here can be read by a
+PostgreSQL server or an LDAP directory, and the other way round. PostgreSQL
+does not accept SCRAM-SHA-1 or SCRAM-SHA-512 records. Treat the line as a
+secret: the server key in it is enough to impersonate the server to that user.
 
 Printing is safe by default. `Client`, `Server` and `Credentials` define
 their own `str()`, so a `println(client)` while debugging shows the state

--- a/vlib/crypto/scram/adversarial_test.v
+++ b/vlib/crypto/scram/adversarial_test.v
@@ -182,3 +182,61 @@ fn test_a_count_between_the_floor_and_the_ceiling_is_still_accepted() {
 	client.verify(server_final)!
 	assert client.done() && server.done()
 }
+
+// plus_advertising_server offers both the base and the `-PLUS` mechanism, and
+// this exchange runs the base one — the case where a stripped advertisement
+// is invisible to the mode alone.
+fn plus_advertising_server() !&Server {
+	credentials := derive_credentials(.sha256, 'pencil', 'saltsaltsaltsalt'.bytes(), 4096)!
+	return new_server(
+		advertises_plus: true
+		lookup:          fn [credentials] (username string) !Credentials {
+			return credentials
+		}
+	)
+}
+
+fn test_a_y_flag_is_a_downgrade_when_the_server_advertises_plus() {
+	// The client says it supports channel binding and saw no `-PLUS` in the
+	// list. This server put one there, so something rewrote the list.
+	mut server := plus_advertising_server()!
+	mut client := new_client(
+		username:        'user'
+		password:        'pencil'
+		channel_binding: ChannelBinding{
+			mode: .unsupported_by_server
+		}
+	)!
+	server.first(client.first()!) or {
+		assert err is AuthenticationFailed
+		assert err.msg().contains('altered in transit')
+		return
+	}
+	assert false, 'the server accepted a `y` flag while advertising a -PLUS mechanism'
+}
+
+fn test_an_n_flag_stays_valid_when_the_server_advertises_plus() {
+	// A client that cannot do channel binding at all is not being downgraded,
+	// so the same server must still authenticate it.
+	mut server := plus_advertising_server()!
+	mut client := new_client(username: 'user', password: 'pencil')!
+	server_final := server.final(client.final(server.first(client.first()!)!)!)!
+	client.verify(server_final)!
+	assert client.done() && server.done()
+}
+
+fn test_a_y_flag_is_legitimate_when_the_server_advertises_no_plus() {
+	// Unchanged behaviour for a server that really offers nothing better.
+	credentials := derive_credentials(.sha256, 'pencil', 'saltsaltsaltsalt'.bytes(), 4096)!
+	mut server := server_with(credentials)!
+	mut client := new_client(
+		username:        'user'
+		password:        'pencil'
+		channel_binding: ChannelBinding{
+			mode: .unsupported_by_server
+		}
+	)!
+	server_final := server.final(client.final(server.first(client.first()!)!)!)!
+	client.verify(server_final)!
+	assert client.done() && server.done()
+}

--- a/vlib/crypto/scram/adversarial_test.v
+++ b/vlib/crypto/scram/adversarial_test.v
@@ -1,0 +1,134 @@
+// What a hostile or misconfigured peer gets to choose. The conformance
+// vectors check that two honest peers agree; these check that a peer which
+// does not play along cannot obtain a protection it has not earned, and
+// cannot make a configuration mistake look like a wrong password.
+module scram
+
+// bound_binding is a complete channel binding, as a caller with access to its
+// TLS layer would build one.
+fn bound_binding() ChannelBinding {
+	return ChannelBinding{
+		mode: .required
+		name: 'tls-server-end-point'
+		data: 'a hash of the server certificate'.bytes()
+	}
+}
+
+// server_with builds a server that answers every user with `credentials`.
+fn server_with(credentials Credentials) !&Server {
+	return new_server(
+		lookup: fn [credentials] (username string) !Credentials {
+			return credentials
+		}
+	)
+}
+
+fn test_channel_binding_without_data_is_refused_rather_than_binding_nothing() {
+	// `p=` announces a -PLUS mechanism, so an exchange that reaches the wire
+	// without binding data leaves both peers believing the connection is tied
+	// to their TLS channel when nothing ties it.
+	starved := ChannelBinding{
+		mode: .required
+		name: 'tls-exporter'
+	}
+	new_client(username: 'user', password: 'pencil', channel_binding: starved) or {
+		assert err.msg().contains('channel binding data is required')
+		new_server(
+			channel_binding: starved
+			lookup:          fn (username string) !Credentials {
+				return new_credentials(.sha256, 'pencil')!
+			}
+		) or {
+			assert err.msg().contains('channel binding data is required')
+			return
+		}
+		assert false, 'the server accepted a .required binding with no data'
+	}
+	assert false, 'the client accepted a .required binding with no data'
+}
+
+fn test_a_complete_channel_binding_still_works() {
+	// The check above must not have made channel binding unusable.
+	mut client :=
+		new_client(username: 'user', password: 'pencil', channel_binding: bound_binding())!
+	assert client.mechanism_name() == 'SCRAM-SHA-256-PLUS'
+	assert client.first()!.starts_with('p=tls-server-end-point,,')
+}
+
+fn test_credentials_of_the_wrong_length_are_a_configuration_error() {
+	// Truncated keys fail the proof check on their own, but as an
+	// `AuthenticationFailed`, which reads as a user typing the wrong password.
+	truncated := Credentials{
+		mechanism:  .sha256
+		salt:       'saltsaltsaltsalt'.bytes()
+		iterations: 4096
+		stored_key: [u8(1), 2, 3]
+		server_key: [u8(4), 5, 6]
+	}
+	mut server := server_with(truncated)!
+	mut client := new_client(username: 'user', password: 'pencil')!
+	server.first(client.first()!) or {
+		assert err !is AuthenticationFailed
+		assert err.msg().contains('3 and 3 byte keys')
+		assert err.msg().contains('needs 32')
+		return
+	}
+	assert false, 'the server accepted credentials with 3 byte keys'
+}
+
+fn test_an_empty_authzid_in_the_gs2_header_is_malformed() {
+	// `a=` with nothing after it is not an absent authzid: RFC 5802 §7 spells
+	// authzid as `a=` saslname, and saslname is `1*`.
+	mut server := server_with(new_credentials(.sha256, 'pencil')!)!
+	server.first('n,a=,n=user,r=clientnonce') or {
+		assert err is MalformedMessage
+		assert err.msg().contains('authorization identity')
+		return
+	}
+	assert false, 'the server accepted an empty `a=` authorization identity'
+}
+
+fn test_an_attribute_injected_into_the_client_first_message_breaks_the_proof() {
+	// Nothing rejects a duplicate `r=` outright, because the whole message
+	// goes into the auth message on both sides. That is what has to hold: an
+	// injected attribute must make the exchange fail, not pass unnoticed.
+	credentials := derive_credentials(.sha256, 'pencil', 'saltsaltsaltsalt'.bytes(), 4096)!
+	mut server := server_with(credentials)!
+	mut client := new_client(username: 'user', password: 'pencil')!
+	client_first := client.first()!
+	server_first := server.first('${client_first},r=injected')!
+	server.final(client.final(server_first)!) or {
+		assert err is AuthenticationFailed
+		return
+	}
+	assert false, 'an attribute injected into the client-first-message went unnoticed'
+}
+
+fn test_an_extension_injected_into_the_server_first_message_breaks_the_proof() {
+	// Unknown extensions are ignored, as RFC 5802 §7 requires, but they are
+	// still covered by the auth message, so rewriting one is detected.
+	credentials := derive_credentials(.sha256, 'pencil', 'saltsaltsaltsalt'.bytes(), 4096)!
+	mut server := server_with(credentials)!
+	mut client := new_client(username: 'user', password: 'pencil')!
+	server_first := server.first(client.first()!)!
+	server.final(client.final('${server_first},x=injected')!) or {
+		assert err is AuthenticationFailed
+		return
+	}
+	assert false, 'an extension injected into the server-first-message went unnoticed'
+}
+
+fn test_a_proof_of_the_wrong_length_is_refused_before_it_is_used() {
+	credentials := derive_credentials(.sha256, 'pencil', 'saltsaltsaltsalt'.bytes(), 4096)!
+	mut server := server_with(credentials)!
+	mut client := new_client(username: 'user', password: 'pencil')!
+	server_first := server.first(client.first()!)!
+	client_final := client.final(server_first)!
+	without_proof := client_final.all_before(',p=')
+	server.final('${without_proof},p=AAAA') or {
+		assert err is AuthenticationFailed
+		assert err.msg().contains('3 bytes, expected 32')
+		return
+	}
+	assert false, 'the server accepted a 3 byte proof'
+}

--- a/vlib/crypto/scram/adversarial_test.v
+++ b/vlib/crypto/scram/adversarial_test.v
@@ -132,3 +132,53 @@ fn test_a_proof_of_the_wrong_length_is_refused_before_it_is_used() {
 	}
 	assert false, 'the server accepted a 3 byte proof'
 }
+
+fn test_an_absurd_iteration_count_is_refused_without_doing_the_work() {
+	// The grammar allows nine digits, and `hi()` would run every one of them
+	// before the server has proved anything at all.
+	mut client := new_client(username: 'user', password: 'pencil', nonce: 'clientnonce')!
+	_ := client.first()!
+	client.final('r=clientnonceserver,s=c2FsdHNhbHRzYWx0c2FsdA==,i=999999999') or {
+		assert err is AuthenticationFailed
+		assert err.msg().contains('above the configured maximum of ${default_max_iterations}')
+		return
+	}
+	assert false, 'the client accepted 999999999 iterations'
+}
+
+fn test_the_iteration_count_ceiling_is_configurable() {
+	mut strict := new_client(
+		username:       'user'
+		password:       'pencil'
+		nonce:          'clientnonce'
+		max_iterations: 8192
+	)!
+	_ := strict.first()!
+	strict.final('r=clientnonceserver,s=c2FsdHNhbHRzYWx0c2FsdA==,i=32768') or {
+		assert err is AuthenticationFailed
+		assert err.msg().contains('above the configured maximum of 8192')
+		return
+	}
+	assert false, 'the client accepted 32768 iterations against a ceiling of 8192'
+}
+
+fn test_a_ceiling_below_the_floor_is_refused_at_construction() {
+	// 1024 is below the 4096 floor, so no count could ever be accepted: a
+	// client configured that way would fail every exchange for a reason that
+	// looks like the server's fault.
+	new_client(username: 'user', password: 'pencil', max_iterations: 1024) or {
+		assert err.msg().contains('must not be below min_iterations')
+		return
+	}
+	assert false, 'accepted a ceiling below the floor'
+}
+
+fn test_a_count_between_the_floor_and_the_ceiling_is_still_accepted() {
+	credentials := derive_credentials(.sha256, 'pencil', 'saltsaltsaltsalt'.bytes(),
+		default_iterations)!
+	mut server := server_with(credentials)!
+	mut client := new_client(username: 'user', password: 'pencil')!
+	server_final := server.final(client.final(server.first(client.first()!)!)!)!
+	client.verify(server_final)!
+	assert client.done() && server.done()
+}

--- a/vlib/crypto/scram/adversarial_test.v
+++ b/vlib/crypto/scram/adversarial_test.v
@@ -240,3 +240,33 @@ fn test_a_y_flag_is_legitimate_when_the_server_advertises_no_plus() {
 	client.verify(server_final)!
 	assert client.done() && server.done()
 }
+
+fn test_a_server_nonce_that_is_not_printable_is_refused() {
+	// A valid prefix is not enough: the suffix is the server's to choose, and
+	// the client echoes the whole thing back on the wire.
+	suffixes := {
+		'a space':          'has space'
+		'a control byte':   'has\x01control'
+		'a non-ASCII byte': 'hasé'
+		'a delete byte':    'has\x7f'
+	}
+	for what, suffix in suffixes {
+		mut client := new_client(username: 'user', password: 'pencil', nonce: 'clientnonce')!
+		_ := client.first()!
+		client.final('r=clientnonce${suffix},s=c2FsdHNhbHRzYWx0c2FsdA==,i=4096') or {
+			assert err is MalformedMessage, what
+			assert err.msg().contains('not a printable string'), what
+			continue
+		}
+		assert false, 'the client accepted a server nonce with ${what}'
+	}
+}
+
+fn test_a_printable_server_nonce_is_still_accepted() {
+	// The `printable` range is 0x21-0x7E minus the comma, which is wider than
+	// the base64 alphabet a generated nonce uses.
+	mut client := new_client(username: 'user', password: 'pencil', nonce: 'clientnonce')!
+	_ := client.first()!
+	client_final := client.final('r=clientnonce~!@#\$%^&*()_+,s=c2FsdHNhbHRzYWx0c2FsdA==,i=4096')!
+	assert client_final.contains('r=clientnonce~!@#\$%^&*()_+,')
+}

--- a/vlib/crypto/scram/adversarial_test.v
+++ b/vlib/crypto/scram/adversarial_test.v
@@ -88,20 +88,17 @@ fn test_an_empty_authzid_in_the_gs2_header_is_malformed() {
 	assert false, 'the server accepted an empty `a=` authorization identity'
 }
 
-fn test_an_attribute_injected_into_the_client_first_message_breaks_the_proof() {
-	// Nothing rejects a duplicate `r=` outright, because the whole message
-	// goes into the auth message on both sides. That is what has to hold: an
-	// injected attribute must make the exchange fail, not pass unnoticed.
+fn test_a_duplicate_attribute_in_the_client_first_message_is_malformed() {
 	credentials := derive_credentials(.sha256, 'pencil', 'saltsaltsaltsalt'.bytes(), 4096)!
 	mut server := server_with(credentials)!
 	mut client := new_client(username: 'user', password: 'pencil')!
 	client_first := client.first()!
-	server_first := server.first('${client_first},r=injected')!
-	server.final(client.final(server_first)!) or {
-		assert err is AuthenticationFailed
+	server.first('${client_first},r=injected') or {
+		assert err is MalformedMessage
+		assert err.msg().contains('duplicate `r=` attribute')
 		return
 	}
-	assert false, 'an attribute injected into the client-first-message went unnoticed'
+	assert false, 'the server accepted a duplicate `r=` attribute'
 }
 
 fn test_an_extension_injected_into_the_server_first_message_breaks_the_proof() {

--- a/vlib/crypto/scram/adversarial_test.v
+++ b/vlib/crypto/scram/adversarial_test.v
@@ -170,6 +170,19 @@ fn test_a_ceiling_below_the_floor_is_refused_at_construction() {
 	assert false, 'accepted a ceiling below the floor'
 }
 
+fn test_an_iteration_floor_above_the_wire_maximum_is_refused_at_construction() {
+	new_client(
+		username:       'user'
+		password:       'pencil'
+		min_iterations: max_wire_iterations + 1
+		max_iterations: max_wire_iterations + 1
+	) or {
+		assert err.msg().contains('must not exceed the SCRAM wire maximum of ${max_wire_iterations}')
+		return
+	}
+	assert false, 'accepted an iteration floor above the SCRAM wire maximum'
+}
+
 fn test_a_count_between_the_floor_and_the_ceiling_is_still_accepted() {
 	credentials := derive_credentials(.sha256, 'pencil', 'saltsaltsaltsalt'.bytes(),
 		default_iterations)!

--- a/vlib/crypto/scram/attributes.v
+++ b/vlib/crypto/scram/attributes.v
@@ -40,7 +40,8 @@ pub:
 	// when `mode` is `.required`, ignored otherwise.
 	name string
 	// data is the binding data from the TLS layer. Required when `mode` is
-	// `.required`, ignored otherwise.
+	// `.required` — an empty value is refused rather than producing a `-PLUS`
+	// exchange that binds nothing — and ignored otherwise.
 	data []u8
 }
 
@@ -59,6 +60,13 @@ fn (cb ChannelBinding) gs2_flag() !string {
 			}
 			if cb.name.contains(',') || cb.name.contains('=') {
 				return error('scram: the channel binding name must not contain a comma or an equals sign')
+			}
+			// Without data there is nothing to bind to, yet the exchange would
+			// still announce a `-PLUS` mechanism and succeed against a peer that
+			// forgot it too: the only failure mode of this module that would
+			// leave a caller believing in a protection it does not have.
+			if cb.data.len == 0 {
+				return error('scram: channel binding data is required when mode is .required, otherwise the exchange announces a -PLUS mechanism that binds nothing')
 			}
 			return 'p=${cb.name}'
 		}
@@ -190,16 +198,6 @@ fn parse_attributes(message string) ![]Attribute {
 		}
 	}
 	return out
-}
-
-// find returns the value of the first attribute named `key`.
-fn (attrs []Attribute) find(key u8) ?string {
-	for attr in attrs {
-		if attr.key == key {
-			return attr.value
-		}
-	}
-	return none
 }
 
 // decode_base64 decodes a base64 attribute value, rejecting anything that is

--- a/vlib/crypto/scram/attributes.v
+++ b/vlib/crypto/scram/attributes.v
@@ -1,0 +1,243 @@
+// Message grammar helpers: the GS2 header that prefixes the
+// client-first-message, the escaping rules for user names, and the
+// comma-separated `key=value` list every SCRAM message is made of.
+// See RFC 5802 §7 for the ABNF these follow.
+module scram
+
+import encoding.base64
+
+// ChannelBindingMode says how an exchange relates to the TLS channel
+// underneath it, and becomes the GS2 `cbind-flag` on the wire. The
+// distinction between `.not_supported` and `.unsupported_by_server` is not
+// cosmetic: it is what lets a server detect an attacker stripping the
+// `-PLUS` mechanisms from its advertised list.
+pub enum ChannelBindingMode {
+	// not_supported sends `n`: this client cannot do channel binding at all.
+	not_supported
+	// unsupported_by_server sends `y`: this client supports channel binding,
+	// but the server did not advertise a `-PLUS` mechanism. A server that did
+	// advertise one must then abort, since only a downgrade attack explains it.
+	unsupported_by_server
+	// required sends `p=<name>`: the exchange is bound to the channel, and
+	// both sides must agree on `name` and `data`. Use the `-PLUS` mechanism
+	// name in that case.
+	required
+}
+
+// ChannelBinding describes the channel binding of an exchange. The default
+// value means no channel binding, which is what a client without access to
+// its TLS layer should use.
+//
+// This module never derives binding data itself: `data` comes from the TLS
+// stack, and the caller passes it in. For `tls-server-end-point` (RFC 5929)
+// it is the hash of the server certificate; for `tls-exporter` (RFC 9266) it
+// is a TLS exporter output.
+pub struct ChannelBinding {
+pub:
+	// mode selects the GS2 `cbind-flag`.
+	mode ChannelBindingMode = .not_supported
+	// name is the channel binding type, e.g. `tls-server-end-point`. Required
+	// when `mode` is `.required`, ignored otherwise.
+	name string
+	// data is the binding data from the TLS layer. Required when `mode` is
+	// `.required`, ignored otherwise.
+	data []u8
+}
+
+// gs2_flag renders the GS2 `cbind-flag` of RFC 5802 §7.
+fn (cb ChannelBinding) gs2_flag() !string {
+	match cb.mode {
+		.not_supported {
+			return 'n'
+		}
+		.unsupported_by_server {
+			return 'y'
+		}
+		.required {
+			if cb.name == '' {
+				return error('scram: a channel binding name is required when mode is .required')
+			}
+			if cb.name.contains(',') || cb.name.contains('=') {
+				return error('scram: the channel binding name must not contain a comma or an equals sign')
+			}
+			return 'p=${cb.name}'
+		}
+	}
+}
+
+// gs2_header renders the full GS2 header of RFC 5802 §7, which prefixes the
+// client-first-message and is repeated, base64 encoded, in the `c=` attribute
+// of the client-final-message so that it cannot be tampered with in transit.
+fn (cb ChannelBinding) gs2_header(authzid string) !string {
+	flag := cb.gs2_flag()!
+	if authzid == '' {
+		return '${flag},,'
+	}
+	return '${flag},a=${escape_saslname(authzid)},'
+}
+
+// cbind_input returns the value the `c=` attribute base64 encodes: the GS2
+// header, followed by the binding data when channel binding is in use.
+fn (cb ChannelBinding) cbind_input(gs2_header string) []u8 {
+	mut out := gs2_header.bytes()
+	if cb.mode == .required {
+		out << cb.data
+	}
+	return out
+}
+
+// escape_saslname applies the `saslname` escaping of RFC 5802 §5.1. A comma
+// would end the attribute, so it becomes `=2C`; the equals sign that
+// introduces the escape becomes `=3D`.
+fn escape_saslname(name string) string {
+	if !name.contains_any('=,') {
+		return name
+	}
+	mut out := []u8{cap: name.len + 8}
+	for c in name {
+		if c == `=` {
+			out << '=3D'.bytes()
+		} else if c == `,` {
+			out << '=2C'.bytes()
+		} else {
+			out << c
+		}
+	}
+	return out.bytestr()
+}
+
+// unescape_saslname reverses `escape_saslname`. Any other `=` sequence is
+// invalid per RFC 5802 §5.1 and is rejected rather than passed through, so a
+// peer cannot smuggle a name past a check by inventing an escape.
+fn unescape_saslname(name string) !string {
+	if !name.contains('=') {
+		if name.contains(',') {
+			return MalformedMessage{
+				reason: 'unescaped comma in a user name'
+			}
+		}
+		return name
+	}
+	mut out := []u8{cap: name.len}
+	mut i := 0
+	for i < name.len {
+		c := name[i]
+		if c == `,` {
+			return MalformedMessage{
+				reason: 'unescaped comma in a user name'
+			}
+		}
+		if c != `=` {
+			out << c
+			i++
+			continue
+		}
+		if i + 3 > name.len {
+			return MalformedMessage{
+				reason: 'truncated escape sequence in a user name'
+			}
+		}
+		match name[i..i + 3] {
+			'=2C' {
+				out << u8(`,`)
+			}
+			'=3D' {
+				out << u8(`=`)
+			}
+			else {
+				return MalformedMessage{
+					reason: 'invalid escape sequence `${name[i..i + 3]}` in a user name'
+				}
+			}
+		}
+		i += 3
+	}
+	return out.bytestr()
+}
+
+// Attribute is one `key=value` pair of a SCRAM message. Keys are single
+// letters, which is why `key` is a `u8` rather than a string.
+struct Attribute {
+	key   u8
+	value string
+}
+
+// parse_attributes splits a SCRAM message into its attributes. Values are
+// returned verbatim; a comma always separates attributes, because the
+// grammar of RFC 5802 §7 excludes it from every value.
+fn parse_attributes(message string) ![]Attribute {
+	if message == '' {
+		return MalformedMessage{
+			reason: 'empty message'
+		}
+	}
+	parts := message.split(',')
+	mut out := []Attribute{cap: parts.len}
+	for part in parts {
+		if part.len < 3 || part[1] != `=` {
+			return MalformedMessage{
+				reason: 'expected a `key=value` attribute, got `${part}`'
+			}
+		}
+		if !part[0].is_letter() {
+			return MalformedMessage{
+				reason: 'attribute names must be letters, got `${part[0].ascii_str()}`'
+			}
+		}
+		out << Attribute{
+			key:   part[0]
+			value: part[2..]
+		}
+	}
+	return out
+}
+
+// find returns the value of the first attribute named `key`.
+fn (attrs []Attribute) find(key u8) ?string {
+	for attr in attrs {
+		if attr.key == key {
+			return attr.value
+		}
+	}
+	return none
+}
+
+// decode_base64 decodes a base64 attribute value, rejecting anything that is
+// not canonical base64. `base64.decode` reports no error of its own, so the
+// check is a round trip: only a canonical encoding survives it unchanged.
+fn decode_base64(value string, what string) ![]u8 {
+	decoded := base64.decode(value)
+	if base64.encode(decoded) != value {
+		return MalformedMessage{
+			reason: '${what} is not valid base64'
+		}
+	}
+	return decoded
+}
+
+// parse_positive_int parses an unsigned decimal attribute value. RFC 5802 §7
+// spells the iteration count as a `posit-number`, which forbids a sign, a
+// leading zero and any surrounding space, so the parse is deliberately strict
+// rather than using the lenient `string.int()`.
+fn parse_positive_int(value string, what string) !int {
+	if value == '' || value.len > 9 {
+		return MalformedMessage{
+			reason: 'invalid ${what} `${value}`'
+		}
+	}
+	if value[0] == `0` {
+		return MalformedMessage{
+			reason: 'invalid ${what} `${value}`: leading zeroes are not allowed'
+		}
+	}
+	mut n := 0
+	for c in value {
+		if c < `0` || c > `9` {
+			return MalformedMessage{
+				reason: 'invalid ${what} `${value}`'
+			}
+		}
+		n = n * 10 + int(c - `0`)
+	}
+	return n
+}

--- a/vlib/crypto/scram/attributes.v
+++ b/vlib/crypto/scram/attributes.v
@@ -206,6 +206,11 @@ fn parse_attributes(message string) ![]Attribute {
 				reason: 'attribute names must be letters, got `${part[0].ascii_str()}`'
 			}
 		}
+		if part[2..].contains('\0') {
+			return MalformedMessage{
+				reason: 'attribute values must not contain a NUL byte'
+			}
+		}
 		if part[0] == `m` && out.len > 0 {
 			return MalformedMessage{
 				reason: 'the mandatory extension attribute `m=` must be first'

--- a/vlib/crypto/scram/attributes.v
+++ b/vlib/crypto/scram/attributes.v
@@ -170,6 +170,11 @@ struct Attribute {
 	value string
 }
 
+// is_server_error_value checks the extension alphabet of RFC 5802 §7.
+fn is_server_error_value(value string) bool {
+	return value != '' && value.bytes().all(it.is_alnum() || it in [`.`, `-`, `_`])
+}
+
 // parse_attributes splits a SCRAM message into its attributes. Values are
 // returned verbatim; a comma always separates attributes, because the
 // grammar of RFC 5802 §7 excludes it from every value.
@@ -181,6 +186,7 @@ fn parse_attributes(message string) ![]Attribute {
 	}
 	parts := message.split(',')
 	mut out := []Attribute{cap: parts.len}
+	mut seen := [256]bool{}
 	for part in parts {
 		if part.len < 3 || part[1] != `=` {
 			return MalformedMessage{
@@ -192,6 +198,12 @@ fn parse_attributes(message string) ![]Attribute {
 				reason: 'attribute names must be letters, got `${part[0].ascii_str()}`'
 			}
 		}
+		if seen[part[0]] {
+			return MalformedMessage{
+				reason: 'duplicate `${part[0].ascii_str()}=` attribute'
+			}
+		}
+		seen[part[0]] = true
 		out << Attribute{
 			key:   part[0]
 			value: part[2..]

--- a/vlib/crypto/scram/attributes.v
+++ b/vlib/crypto/scram/attributes.v
@@ -81,7 +81,7 @@ fn (cb ChannelBinding) gs2_header(authzid string) !string {
 	if authzid == '' {
 		return '${flag},,'
 	}
-	return '${flag},a=${escape_saslname(authzid)},'
+	return '${flag},a=${escape_saslname(authzid)!},'
 }
 
 // cbind_input returns the value the `c=` attribute base64 encodes: the GS2
@@ -97,7 +97,10 @@ fn (cb ChannelBinding) cbind_input(gs2_header string) []u8 {
 // escape_saslname applies the `saslname` escaping of RFC 5802 §5.1. A comma
 // would end the attribute, so it becomes `=2C`; the equals sign that
 // introduces the escape becomes `=3D`.
-fn escape_saslname(name string) string {
+fn escape_saslname(name string) !string {
+	if name.contains('\0') {
+		return error('scram: a SASL name must not contain a NUL byte')
+	}
 	if !name.contains_any('=,') {
 		return name
 	}
@@ -118,6 +121,11 @@ fn escape_saslname(name string) string {
 // invalid per RFC 5802 §5.1 and is rejected rather than passed through, so a
 // peer cannot smuggle a name past a check by inventing an escape.
 fn unescape_saslname(name string) !string {
+	if name.contains('\0') {
+		return MalformedMessage{
+			reason: 'a SASL name must not contain a NUL byte'
+		}
+	}
 	if !name.contains('=') {
 		if name.contains(',') {
 			return MalformedMessage{
@@ -188,7 +196,7 @@ fn parse_attributes(message string) ![]Attribute {
 	mut out := []Attribute{cap: parts.len}
 	mut seen := [256]bool{}
 	for part in parts {
-		if part.len < 3 || part[1] != `=` {
+		if part.len < 2 || part[1] != `=` {
 			return MalformedMessage{
 				reason: 'expected a `key=value` attribute, got `${part}`'
 			}
@@ -196,6 +204,11 @@ fn parse_attributes(message string) ![]Attribute {
 		if !part[0].is_letter() {
 			return MalformedMessage{
 				reason: 'attribute names must be letters, got `${part[0].ascii_str()}`'
+			}
+		}
+		if part[0] == `m` && out.len > 0 {
+			return MalformedMessage{
+				reason: 'the mandatory extension attribute `m=` must be first'
 			}
 		}
 		if seen[part[0]] {

--- a/vlib/crypto/scram/attributes.v
+++ b/vlib/crypto/scram/attributes.v
@@ -234,6 +234,28 @@ fn parse_attributes(message string) ![]Attribute {
 // not canonical base64. `base64.decode` reports no error of its own, so the
 // check is a round trip: only a canonical encoding survives it unchanged.
 fn decode_base64(value string, what string) ![]u8 {
+	if value.len % 4 != 0 {
+		return MalformedMessage{
+			reason: '${what} is not valid base64'
+		}
+	}
+	mut padding := 0
+	for i, c in value {
+		if c == `=` {
+			padding++
+			if i < value.len - 2 || padding > 2 {
+				return MalformedMessage{
+					reason: '${what} is not valid base64'
+				}
+			}
+			continue
+		}
+		if padding > 0 || !(c.is_alnum() || c == `+` || c == `/`) {
+			return MalformedMessage{
+				reason: '${what} is not valid base64'
+			}
+		}
+	}
 	decoded := base64.decode(value)
 	if base64.encode(decoded) != value {
 		return MalformedMessage{

--- a/vlib/crypto/scram/attributes.v
+++ b/vlib/crypto/scram/attributes.v
@@ -58,8 +58,8 @@ fn (cb ChannelBinding) gs2_flag() !string {
 			if cb.name == '' {
 				return error('scram: a channel binding name is required when mode is .required')
 			}
-			if cb.name.contains(',') || cb.name.contains('=') {
-				return error('scram: the channel binding name must not contain a comma or an equals sign')
+			if !cb.name.bytes().all(it.is_alnum() || it == `.` || it == `-`) {
+				return error('scram: the channel binding name must only contain ASCII letters, digits, dots, and hyphens')
 			}
 			// Without data there is nothing to bind to, yet the exchange would
 			// still announce a `-PLUS` mechanism and succeed against a peer that

--- a/vlib/crypto/scram/attributes.v
+++ b/vlib/crypto/scram/attributes.v
@@ -187,9 +187,11 @@ struct Attribute {
 	value string
 }
 
-// is_server_error_value checks the extension alphabet of RFC 5802 §7.
+// is_server_error_value checks the general `value` production that RFC 5802
+// §7 uses for extension errors.
 fn is_server_error_value(value string) bool {
-	return value != '' && value.bytes().all(it.is_alnum() || it in [`.`, `-`, `_`])
+	return value != '' && !value.contains('\0') && !value.contains(',')
+		&& validate.utf8_string(value)
 }
 
 // parse_attributes splits a SCRAM message into its attributes. Values are

--- a/vlib/crypto/scram/attributes.v
+++ b/vlib/crypto/scram/attributes.v
@@ -205,7 +205,7 @@ fn parse_attributes(message string) ![]Attribute {
 	mut out := []Attribute{cap: parts.len}
 	mut seen := [256]bool{}
 	for part in parts {
-		if part.len < 2 || part[1] != `=` {
+		if part.len < 3 || part[1] != `=` {
 			return MalformedMessage{
 				reason: 'expected a `key=value` attribute, got `${part}`'
 			}

--- a/vlib/crypto/scram/attributes.v
+++ b/vlib/crypto/scram/attributes.v
@@ -5,6 +5,7 @@
 module scram
 
 import encoding.base64
+import encoding.utf8.validate
 
 // ChannelBindingMode says how an exchange relates to the TLS channel
 // underneath it, and becomes the GS2 `cbind-flag` on the wire. The
@@ -209,6 +210,11 @@ fn parse_attributes(message string) ![]Attribute {
 		if part[2..].contains('\0') {
 			return MalformedMessage{
 				reason: 'attribute values must not contain a NUL byte'
+			}
+		}
+		if !validate.utf8_string(part[2..]) {
+			return MalformedMessage{
+				reason: 'attribute values must contain valid UTF-8'
 			}
 		}
 		if part[0] == `m` && out.len > 0 {

--- a/vlib/crypto/scram/attributes.v
+++ b/vlib/crypto/scram/attributes.v
@@ -102,6 +102,9 @@ fn escape_saslname(name string) !string {
 	if name.contains('\0') {
 		return error('scram: a SASL name must not contain a NUL byte')
 	}
+	if !validate.utf8_string(name) {
+		return error('scram: a SASL name must contain valid UTF-8')
+	}
 	if !name.contains_any('=,') {
 		return name
 	}
@@ -125,6 +128,11 @@ fn unescape_saslname(name string) !string {
 	if name.contains('\0') {
 		return MalformedMessage{
 			reason: 'a SASL name must not contain a NUL byte'
+		}
+	}
+	if !validate.utf8_string(name) {
+		return MalformedMessage{
+			reason: 'a SASL name must contain valid UTF-8'
 		}
 	}
 	if !name.contains('=') {

--- a/vlib/crypto/scram/attributes_test.v
+++ b/vlib/crypto/scram/attributes_test.v
@@ -76,13 +76,6 @@ fn test_parse_attributes_refuses_malformed_input() {
 	}
 }
 
-fn test_find_returns_the_first_matching_attribute() {
-	attrs := parse_attributes('r=one,s=two,r=three')!
-	assert attrs.find(`r`)? == 'one'
-	assert attrs.find(`s`)? == 'two'
-	assert attrs.find(`z`) == none
-}
-
 fn test_parse_positive_int_follows_the_posit_number_rule() {
 	assert parse_positive_int('1', 'n')! == 1
 	assert parse_positive_int('4096', 'n')! == 4096

--- a/vlib/crypto/scram/attributes_test.v
+++ b/vlib/crypto/scram/attributes_test.v
@@ -1,0 +1,219 @@
+// Unit tests for the message grammar helpers of RFC 5802 §7.
+module scram
+
+fn test_escape_saslname_escapes_only_what_the_grammar_forbids() {
+	assert escape_saslname('user') == 'user'
+	assert escape_saslname('') == ''
+	assert escape_saslname('a,b') == 'a=2Cb'
+	assert escape_saslname('a=b') == 'a=3Db'
+	assert escape_saslname('a,b=c') == 'a=2Cb=3Dc'
+	assert escape_saslname(',') == '=2C'
+	assert escape_saslname('=') == '=3D'
+	// An equals sign must be escaped before a comma, otherwise the `=` of the
+	// `=2C` produced for the comma would be escaped in turn.
+	assert escape_saslname('=,') == '=3D=2C'
+	assert escape_saslname('=2C') == '=3D2C'
+	// Non-ASCII passes through: the grammar is defined over UTF-8 octets.
+	assert escape_saslname('rené') == 'rené'
+}
+
+fn test_unescape_saslname_reverses_escape_saslname() {
+	for name in ['user', '', 'a,b', 'a=b', 'a,b=c', ',', '=', '=,', '=2C', 'rené', '=3D=2C=3D'] {
+		assert unescape_saslname(escape_saslname(name))! == name, name
+	}
+}
+
+fn test_unescape_saslname_refuses_anything_it_did_not_produce() {
+	cases := {
+		'an unknown escape':           'a=FFb'
+		'a lowercase escape':          'a=2cb'
+		'a truncated escape':          'ab='
+		'a nearly truncated one':      'ab=2'
+		'a raw comma':                 'a,b'
+		'a raw comma after an escape': '=2C,'
+	}
+	for what, name in cases {
+		unescape_saslname(name) or {
+			assert err is MalformedMessage, what
+			continue
+		}
+		assert false, 'accepted ${what}: `${name}`'
+	}
+}
+
+fn test_parse_attributes_splits_a_well_formed_message() {
+	attrs := parse_attributes('r=abc,s=c2FsdA==,i=4096')!
+	assert attrs.len == 3
+	assert attrs[0].key == `r` && attrs[0].value == 'abc'
+	assert attrs[1].key == `s` && attrs[1].value == 'c2FsdA=='
+	assert attrs[2].key == `i` && attrs[2].value == '4096'
+}
+
+fn test_parse_attributes_keeps_equals_signs_inside_values() {
+	// Base64 padding lives in the value, so only the first `=` separates.
+	attrs := parse_attributes('p=dGVzdA==')!
+	assert attrs.len == 1
+	assert attrs[0].value == 'dGVzdA=='
+}
+
+fn test_parse_attributes_refuses_malformed_input() {
+	cases := {
+		'an empty message':       ''
+		'no equals sign':         'abc'
+		'an empty value':         'r='
+		'a long name':            'rr=abc'
+		'a digit as a name':      '1=abc'
+		'a punctuation name':     '-=abc'
+		'an empty trailing part': 'r=abc,'
+		'an empty leading part':  ',r=abc'
+	}
+	for what, message in cases {
+		parse_attributes(message) or {
+			assert err is MalformedMessage, what
+			continue
+		}
+		assert false, 'accepted ${what}: `${message}`'
+	}
+}
+
+fn test_find_returns_the_first_matching_attribute() {
+	attrs := parse_attributes('r=one,s=two,r=three')!
+	assert attrs.find(`r`)? == 'one'
+	assert attrs.find(`s`)? == 'two'
+	assert attrs.find(`z`) == none
+}
+
+fn test_parse_positive_int_follows_the_posit_number_rule() {
+	assert parse_positive_int('1', 'n')! == 1
+	assert parse_positive_int('4096', 'n')! == 4096
+	assert parse_positive_int('999999999', 'n')! == 999999999
+}
+
+fn test_parse_positive_int_refuses_anything_lenient() {
+	cases := {
+		'empty':            ''
+		'a leading zero':   '04096'
+		'just zero':        '0'
+		'a plus sign':      '+1'
+		'a minus sign':     '-1'
+		'a space':          ' 1'
+		'a trailing space': '1 '
+		'a float':          '1.5'
+		'hexadecimal':      '0x10'
+		'letters':          'lots'
+		'too many digits':  '1234567890'
+	}
+	for what, value in cases {
+		parse_positive_int(value, 'iteration count') or {
+			assert err is MalformedMessage, what
+			continue
+		}
+		assert false, 'accepted ${what}: `${value}`'
+	}
+}
+
+fn test_decode_base64_refuses_non_canonical_encodings() {
+	assert decode_base64('', 'x')! == []u8{}
+	assert decode_base64('dGVzdA==', 'x')! == 'test'.bytes()
+	for value in ['dGVzdA', 'dGVzdA=', 'dGVzdA===', 'not!base64', 'dGVz dA==', '===='] {
+		decode_base64(value, 'the salt') or {
+			assert err.msg() == 'scram: malformed message: the salt is not valid base64'
+			assert err is MalformedMessage, value
+			continue
+		}
+		assert false, 'accepted the non-canonical base64 `${value}`'
+	}
+}
+
+fn test_gs2_header_rendering() {
+	none_binding := ChannelBinding{}
+	assert none_binding.gs2_header('')! == 'n,,'
+	assert none_binding.gs2_header('admin')! == 'n,a=admin,'
+	assert none_binding.gs2_header('a,b')! == 'n,a=a=2Cb,'
+
+	downgraded := ChannelBinding{
+		mode: .unsupported_by_server
+	}
+	assert downgraded.gs2_header('')! == 'y,,'
+
+	bound := ChannelBinding{
+		mode: .required
+		name: 'tls-server-end-point'
+		data: [u8(1), 2, 3]
+	}
+	assert bound.gs2_header('')! == 'p=tls-server-end-point,,'
+	assert bound.gs2_header('admin')! == 'p=tls-server-end-point,a=admin,'
+}
+
+fn test_gs2_header_refuses_an_unusable_binding_name() {
+	for name in ['', 'has,comma', 'has=equals'] {
+		binding := ChannelBinding{
+			mode: .required
+			name: name
+			data: [u8(1)]
+		}
+		binding.gs2_header('') or { continue }
+		assert false, 'accepted the channel binding name `${name}`'
+	}
+}
+
+fn test_cbind_input_appends_data_only_when_bound() {
+	none_binding := ChannelBinding{}
+	assert none_binding.cbind_input('n,,') == 'n,,'.bytes()
+
+	// Data set but not bound: it must be ignored, not silently mixed in.
+	unused := ChannelBinding{
+		mode: .unsupported_by_server
+		data: [u8(9), 9]
+	}
+	assert unused.cbind_input('y,,') == 'y,,'.bytes()
+
+	bound := ChannelBinding{
+		mode: .required
+		name: 'tls-exporter'
+		data: [u8(1), 2, 3]
+	}
+	mut expected := 'p=tls-exporter,,'.bytes()
+	expected << [u8(1), 2, 3]
+	assert bound.cbind_input('p=tls-exporter,,') == expected
+}
+
+fn test_split_gs2_header_separates_the_three_parts() {
+	header, authzid, bare := split_gs2_header('n,,n=user,r=abc')!
+	assert header == 'n,,'
+	assert authzid == ''
+	assert bare == 'n=user,r=abc'
+
+	header2, authzid2, bare2 := split_gs2_header('y,a=admin,n=user,r=abc')!
+	assert header2 == 'y,a=admin,'
+	assert authzid2 == 'admin'
+	assert bare2 == 'n=user,r=abc'
+
+	header3, authzid3, bare3 := split_gs2_header('p=tls-exporter,a=a=2Cb,n=user,r=abc')!
+	assert header3 == 'p=tls-exporter,a=a=2Cb,'
+	assert authzid3 == 'a,b'
+	assert bare3 == 'n=user,r=abc'
+}
+
+fn test_split_gs2_header_refuses_a_broken_header() {
+	for message in ['', 'n', 'n,', 'nn=user,r=abc', 'n,zz,n=user'] {
+		split_gs2_header(message) or {
+			assert err is MalformedMessage, message
+			continue
+		}
+		assert false, 'accepted the GS2 header of `${message}`'
+	}
+}
+
+fn test_validate_nonce_matches_the_printable_rule() {
+	// RFC 5802 §7: printable is 0x21-0x7E minus the comma.
+	validate_nonce('!')!
+	validate_nonce('~')!
+	validate_nonce('rOprNGfwEbeRWgbNEkqO')!
+	validate_nonce('%hvYDpWUa2RaTCAfuxFIlj)hNlF\$k0')!
+	validate_nonce('a+b/c=')!
+	for bad in ['', ' ', 'a,b', 'a b', 'tab\there', 'nul\0here', 'newline\n', 'é'] {
+		validate_nonce(bad) or { continue }
+		assert false, 'accepted the nonce `${bad}`'
+	}
+}

--- a/vlib/crypto/scram/attributes_test.v
+++ b/vlib/crypto/scram/attributes_test.v
@@ -74,6 +74,14 @@ fn test_parse_attributes_keeps_equals_signs_inside_values() {
 	assert attrs[0].value == 'dGVzdA=='
 }
 
+fn test_parse_attributes_keeps_equals_signs_in_extension_values() {
+	// RFC 5802 §7 defines value-char as value-safe-char or `=`, and uses
+	// that value production for extension attributes.
+	attrs := parse_attributes('x=a=b')!
+	assert attrs.len == 1
+	assert attrs[0].key == `x` && attrs[0].value == 'a=b'
+}
+
 fn test_parse_attributes_accepts_an_empty_extension_value() {
 	attrs := parse_attributes('x=')!
 	assert attrs.len == 1

--- a/vlib/crypto/scram/attributes_test.v
+++ b/vlib/crypto/scram/attributes_test.v
@@ -153,7 +153,8 @@ fn test_parse_positive_int_refuses_anything_lenient() {
 fn test_decode_base64_refuses_non_canonical_encodings() {
 	assert decode_base64('', 'x')! == []u8{}
 	assert decode_base64('dGVzdA==', 'x')! == 'test'.bytes()
-	for value in ['dGVzdA', 'dGVzdA=', 'dGVzdA===', 'not!base64', 'dGVz dA==', '===='] {
+	for value in ['dGVzdA', 'dGVzdA=', 'dGVzdA===', 'not!base64', 'dGVz dA==', '====',
+		'{AAA', 'AAA{', '=AAA', 'AA=A'] {
 		decode_base64(value, 'the salt') or {
 			assert err.msg() == 'scram: malformed message: the salt is not valid base64'
 			assert err is MalformedMessage, value

--- a/vlib/crypto/scram/attributes_test.v
+++ b/vlib/crypto/scram/attributes_test.v
@@ -139,7 +139,8 @@ fn test_gs2_header_rendering() {
 }
 
 fn test_gs2_header_refuses_an_unusable_binding_name() {
-	for name in ['', 'has,comma', 'has=equals'] {
+	for name in ['', 'has,comma', 'has=equals', 'has space', 'has_underscore', 'control\0byte',
+		'café'] {
 		binding := ChannelBinding{
 			mode: .required
 			name: name
@@ -148,6 +149,15 @@ fn test_gs2_header_refuses_an_unusable_binding_name() {
 		binding.gs2_header('') or { continue }
 		assert false, 'accepted the channel binding name `${name}`'
 	}
+}
+
+fn test_gs2_header_accepts_the_complete_binding_name_alphabet() {
+	binding := ChannelBinding{
+		mode: .required
+		name: 'AZaz09.-'
+		data: [u8(1)]
+	}
+	assert binding.gs2_header('')! == 'p=AZaz09.-,,'
 }
 
 fn test_cbind_input_appends_data_only_when_bound() {

--- a/vlib/crypto/scram/attributes_test.v
+++ b/vlib/crypto/scram/attributes_test.v
@@ -71,6 +71,17 @@ fn test_parse_attributes_accepts_an_empty_extension_value() {
 	assert attrs[0].key == `x` && attrs[0].value == ''
 }
 
+fn test_parse_attributes_refuses_a_nul_byte_in_any_value() {
+	for message in ['x=\0', 'r=nonce,x=before\0after'] {
+		parse_attributes(message) or {
+			assert err is MalformedMessage, message
+			assert err.msg().contains('must not contain a NUL byte'), message
+			continue
+		}
+		assert false, 'accepted a NUL byte in `${message}`'
+	}
+}
+
 fn test_parse_attributes_refuses_duplicate_names() {
 	for message in ['r=one,r=two', 'r=one,s=c2FsdA==,r=two'] {
 		parse_attributes(message) or {

--- a/vlib/crypto/scram/attributes_test.v
+++ b/vlib/crypto/scram/attributes_test.v
@@ -71,6 +71,12 @@ fn test_parse_attributes_accepts_an_empty_extension_value() {
 	assert attrs[0].key == `x` && attrs[0].value == ''
 }
 
+fn test_parse_attributes_accepts_a_utf8_extension_value() {
+	attrs := parse_attributes('x=rené')!
+	assert attrs.len == 1
+	assert attrs[0].key == `x` && attrs[0].value == 'rené'
+}
+
 fn test_parse_attributes_refuses_a_nul_byte_in_any_value() {
 	for message in ['x=\0', 'r=nonce,x=before\0after'] {
 		parse_attributes(message) or {
@@ -80,6 +86,16 @@ fn test_parse_attributes_refuses_a_nul_byte_in_any_value() {
 		}
 		assert false, 'accepted a NUL byte in `${message}`'
 	}
+}
+
+fn test_parse_attributes_refuses_invalid_utf8_in_any_value() {
+	message := [u8(`x`), `=`, 0xff].bytestr()
+	parse_attributes(message) or {
+		assert err is MalformedMessage
+		assert err.msg().contains('must contain valid UTF-8')
+		return
+	}
+	assert false, 'accepted invalid UTF-8 in an attribute value'
 }
 
 fn test_parse_attributes_refuses_duplicate_names() {

--- a/vlib/crypto/scram/attributes_test.v
+++ b/vlib/crypto/scram/attributes_test.v
@@ -25,6 +25,15 @@ fn test_escape_saslname_refuses_a_nul_byte() {
 	assert false, 'accepted a NUL byte in a SASL name'
 }
 
+fn test_escape_saslname_refuses_invalid_utf8() {
+	name := [u8(0xff)].bytestr()
+	escape_saslname(name) or {
+		assert err.msg().contains('must contain valid UTF-8')
+		return
+	}
+	assert false, 'accepted invalid UTF-8 in a SASL name'
+}
+
 fn test_unescape_saslname_reverses_escape_saslname() {
 	for name in ['user', '', 'a,b', 'a=b', 'a,b=c', ',', '=', '=,', '=2C', 'rené', '=3D=2C=3D'] {
 		assert unescape_saslname(escape_saslname(name)!)! == name, name
@@ -258,6 +267,17 @@ fn test_split_gs2_header_separates_the_three_parts() {
 	assert header3 == 'p=tls-exporter,a=a=2Cb,'
 	assert authzid3 == 'a,b'
 	assert bare3 == 'n=user,r=abc'
+}
+
+fn test_split_gs2_header_refuses_invalid_utf8_authzid() {
+	client_first := [u8(`n`), `,`, `a`, `=`, 0xff, `,`, `n`, `=`, `u`, `s`, `e`, `r`, `,`,
+		`r`, `=`, `a`, `b`, `c`].bytestr()
+	split_gs2_header(client_first) or {
+		assert err is MalformedMessage
+		assert err.msg().contains('must contain valid UTF-8')
+		return
+	}
+	assert false, 'accepted invalid UTF-8 in a GS2 authorization identity'
 }
 
 fn test_split_gs2_header_refuses_a_broken_header() {

--- a/vlib/crypto/scram/attributes_test.v
+++ b/vlib/crypto/scram/attributes_test.v
@@ -2,24 +2,32 @@
 module scram
 
 fn test_escape_saslname_escapes_only_what_the_grammar_forbids() {
-	assert escape_saslname('user') == 'user'
-	assert escape_saslname('') == ''
-	assert escape_saslname('a,b') == 'a=2Cb'
-	assert escape_saslname('a=b') == 'a=3Db'
-	assert escape_saslname('a,b=c') == 'a=2Cb=3Dc'
-	assert escape_saslname(',') == '=2C'
-	assert escape_saslname('=') == '=3D'
+	assert escape_saslname('user')! == 'user'
+	assert escape_saslname('')! == ''
+	assert escape_saslname('a,b')! == 'a=2Cb'
+	assert escape_saslname('a=b')! == 'a=3Db'
+	assert escape_saslname('a,b=c')! == 'a=2Cb=3Dc'
+	assert escape_saslname(',')! == '=2C'
+	assert escape_saslname('=')! == '=3D'
 	// An equals sign must be escaped before a comma, otherwise the `=` of the
 	// `=2C` produced for the comma would be escaped in turn.
-	assert escape_saslname('=,') == '=3D=2C'
-	assert escape_saslname('=2C') == '=3D2C'
+	assert escape_saslname('=,')! == '=3D=2C'
+	assert escape_saslname('=2C')! == '=3D2C'
 	// Non-ASCII passes through: the grammar is defined over UTF-8 octets.
-	assert escape_saslname('rené') == 'rené'
+	assert escape_saslname('rené')! == 'rené'
+}
+
+fn test_escape_saslname_refuses_a_nul_byte() {
+	escape_saslname('nul\0name') or {
+		assert err.msg().contains('must not contain a NUL byte')
+		return
+	}
+	assert false, 'accepted a NUL byte in a SASL name'
 }
 
 fn test_unescape_saslname_reverses_escape_saslname() {
 	for name in ['user', '', 'a,b', 'a=b', 'a,b=c', ',', '=', '=,', '=2C', 'rené', '=3D=2C=3D'] {
-		assert unescape_saslname(escape_saslname(name))! == name, name
+		assert unescape_saslname(escape_saslname(name)!)! == name, name
 	}
 }
 
@@ -31,6 +39,7 @@ fn test_unescape_saslname_refuses_anything_it_did_not_produce() {
 		'a nearly truncated one':      'ab=2'
 		'a raw comma':                 'a,b'
 		'a raw comma after an escape': '=2C,'
+		'a NUL byte':                  'nul\0name'
 	}
 	for what, name in cases {
 		unescape_saslname(name) or {
@@ -56,6 +65,12 @@ fn test_parse_attributes_keeps_equals_signs_inside_values() {
 	assert attrs[0].value == 'dGVzdA=='
 }
 
+fn test_parse_attributes_accepts_an_empty_extension_value() {
+	attrs := parse_attributes('x=')!
+	assert attrs.len == 1
+	assert attrs[0].key == `x` && attrs[0].value == ''
+}
+
 fn test_parse_attributes_refuses_duplicate_names() {
 	for message in ['r=one,r=two', 'r=one,s=c2FsdA==,r=two'] {
 		parse_attributes(message) or {
@@ -67,11 +82,19 @@ fn test_parse_attributes_refuses_duplicate_names() {
 	}
 }
 
+fn test_parse_attributes_refuses_a_nonleading_mandatory_extension() {
+	parse_attributes('r=nonce,m=feature') or {
+		assert err is MalformedMessage
+		assert err.msg().contains('mandatory extension attribute `m=` must be first')
+		return
+	}
+	assert false, 'accepted a non-leading mandatory extension'
+}
+
 fn test_parse_attributes_refuses_malformed_input() {
 	cases := {
 		'an empty message':       ''
 		'no equals sign':         'abc'
-		'an empty value':         'r='
 		'a long name':            'rr=abc'
 		'a digit as a name':      '1=abc'
 		'a punctuation name':     '-=abc'

--- a/vlib/crypto/scram/attributes_test.v
+++ b/vlib/crypto/scram/attributes_test.v
@@ -82,10 +82,12 @@ fn test_parse_attributes_keeps_equals_signs_in_extension_values() {
 	assert attrs[0].key == `x` && attrs[0].value == 'a=b'
 }
 
-fn test_parse_attributes_accepts_an_empty_extension_value() {
-	attrs := parse_attributes('x=')!
-	assert attrs.len == 1
-	assert attrs[0].key == `x` && attrs[0].value == ''
+fn test_parse_attributes_refuses_an_empty_extension_value() {
+	parse_attributes('x=') or {
+		assert err is MalformedMessage
+		return
+	}
+	assert false, 'accepted an empty extension value'
 }
 
 fn test_parse_attributes_accepts_a_utf8_extension_value() {

--- a/vlib/crypto/scram/attributes_test.v
+++ b/vlib/crypto/scram/attributes_test.v
@@ -56,6 +56,17 @@ fn test_parse_attributes_keeps_equals_signs_inside_values() {
 	assert attrs[0].value == 'dGVzdA=='
 }
 
+fn test_parse_attributes_refuses_duplicate_names() {
+	for message in ['r=one,r=two', 'r=one,s=c2FsdA==,r=two'] {
+		parse_attributes(message) or {
+			assert err is MalformedMessage, message
+			assert err.msg().contains('duplicate `r=` attribute'), message
+			continue
+		}
+		assert false, 'accepted duplicate attributes in `${message}`'
+	}
+}
+
 fn test_parse_attributes_refuses_malformed_input() {
 	cases := {
 		'an empty message':       ''

--- a/vlib/crypto/scram/client.v
+++ b/vlib/crypto/scram/client.v
@@ -166,6 +166,16 @@ pub fn (mut c Client) final(server_first string) !string {
 		}
 	}
 	nonce := attrs[0].value
+	// The whole received value is checked, not just the part this client
+	// contributed: it is echoed verbatim in the client-final-message and in
+	// the auth message, so it has to satisfy the same `printable` rule the
+	// server already applies to the client nonce. Extending a valid prefix
+	// with spaces or control bytes is not a valid nonce.
+	validate_nonce(nonce) or {
+		return MalformedMessage{
+			reason: 'the server nonce is not a printable string'
+		}
+	}
 	// The server nonce must extend the client one. If it does not, the reply
 	// belongs to another exchange, so it is a replay rather than a bad password.
 	if !nonce.starts_with(c.client_nonce) || nonce.len == c.client_nonce.len {

--- a/vlib/crypto/scram/client.v
+++ b/vlib/crypto/scram/client.v
@@ -30,6 +30,10 @@ pub:
 	// Lowering it below `default_min_iterations` weakens the protection an
 	// intercepted exchange gets against an offline attack.
 	min_iterations int = default_min_iterations
+	// max_iterations is the largest iteration count accepted from the server.
+	// Raising it lets a hostile server spend more of this client's CPU on a
+	// single message; see `default_max_iterations`.
+	max_iterations int = default_max_iterations
 	// nonce overrides the generated client nonce. Leave it empty outside of
 	// tests: a nonce that repeats across exchanges destroys replay protection.
 	nonce string
@@ -60,6 +64,7 @@ pub struct Client {
 	authzid         string
 	channel_binding ChannelBinding
 	min_iterations  int
+	max_iterations  int
 	gs2_header      string
 	client_nonce    string
 mut:
@@ -83,6 +88,9 @@ pub fn new_client(config ClientConfig) !&Client {
 	if config.min_iterations < 1 {
 		return error('scram: min_iterations must be at least 1, got ${config.min_iterations}')
 	}
+	if config.max_iterations < config.min_iterations {
+		return error('scram: max_iterations (${config.max_iterations}) must not be below min_iterations (${config.min_iterations})')
+	}
 	nonce := if config.nonce == '' { generate_nonce()! } else { config.nonce }
 	validate_nonce(nonce)!
 	return &Client{
@@ -92,6 +100,7 @@ pub fn new_client(config ClientConfig) !&Client {
 		authzid:         config.authzid
 		channel_binding: config.channel_binding
 		min_iterations:  config.min_iterations
+		max_iterations:  config.max_iterations
 		gs2_header:      config.channel_binding.gs2_header(config.authzid)!
 		client_nonce:    nonce
 	}
@@ -134,7 +143,8 @@ pub fn (mut c Client) first() !string {
 // final consumes the server-first-message and returns the
 // client-final-message, which carries the proof that this client knows the
 // password. The server's salt and iteration count are validated here, so a
-// server cannot weaken the exchange by asking for a trivial amount of work.
+// server can neither weaken the exchange by asking for a trivial amount of
+// work, nor stall this client by asking for an absurd amount of it.
 pub fn (mut c Client) final(server_first string) !string {
 	if c.state != .awaiting_server_first {
 		return error('scram: final() must be called once, after first(), with the server-first-message')
@@ -173,6 +183,14 @@ pub fn (mut c Client) final(server_first string) !string {
 	if iterations < c.min_iterations {
 		return AuthenticationFailed{
 			reason: 'the server asked for ${iterations} iterations, below the configured minimum of ${c.min_iterations}'
+		}
+	}
+	// The ceiling is checked before `hi()` rather than after: the point is to
+	// never start the work, since a server that names an absurd count is
+	// spending this client's CPU rather than protecting its own passwords.
+	if iterations > c.max_iterations {
+		return AuthenticationFailed{
+			reason: 'the server asked for ${iterations} iterations, above the configured maximum of ${c.max_iterations}'
 		}
 	}
 

--- a/vlib/crypto/scram/client.v
+++ b/vlib/crypto/scram/client.v
@@ -1,0 +1,221 @@
+// The client half of a SCRAM exchange: three calls, in order, one per
+// message the client has to produce or check.
+module scram
+
+import crypto.subtle
+import encoding.base64
+
+// ClientConfig configures one client-side exchange. Only `username` and
+// `password` are mandatory; the defaults give an RFC 7677 compliant
+// `SCRAM-SHA-256` client without channel binding.
+@[params]
+pub struct ClientConfig {
+pub:
+	// username is the authentication identity. It is escaped as needed, so it
+	// may contain commas and equals signs.
+	username string @[required]
+	// password is the secret. See the SASLprep note in the module README if it
+	// may contain non-ASCII characters. It is required rather than defaulted,
+	// so that an exchange is never attempted with an empty password by accident.
+	password string @[required]
+	// mechanism selects the hash. Prefer the default over `.sha1`, which
+	// survives only for servers that offer nothing better.
+	mechanism Mechanism = .sha256
+	// authzid is the authorization identity, when it differs from `username`.
+	// Leave it empty in the common case where a user authenticates as itself.
+	authzid string
+	// channel_binding binds the exchange to the TLS channel underneath it.
+	channel_binding ChannelBinding
+	// min_iterations is the smallest iteration count accepted from the server.
+	// Lowering it below `default_min_iterations` weakens the protection an
+	// intercepted exchange gets against an offline attack.
+	min_iterations int = default_min_iterations
+	// nonce overrides the generated client nonce. Leave it empty outside of
+	// tests: a nonce that repeats across exchanges destroys replay protection.
+	nonce string
+}
+
+// ClientState tracks which message the client expects next, so that steps
+// called out of order fail loudly instead of producing a wrong exchange.
+enum ClientState {
+	awaiting_first
+	awaiting_server_first
+	awaiting_server_final
+	done
+	// failed is entered by any step that does not run to completion, so that a
+	// caller which ignores an error cannot mistake a refused exchange for a
+	// successful one, and cannot retry a step on the same nonce.
+	failed
+}
+
+// Client drives the client side of one SCRAM exchange. Create it with
+// `new_client`, then call `first`, `final` and `verify` in that order. It
+// holds the password for the duration of the exchange and is not safe to
+// share between threads.
+@[heap]
+pub struct Client {
+	mechanism       Mechanism
+	username        string
+	password        string
+	authzid         string
+	channel_binding ChannelBinding
+	min_iterations  int
+	gs2_header      string
+	client_nonce    string
+mut:
+	first_bare   string
+	auth_message string
+	server_key   []u8
+	state        ClientState = .awaiting_first
+}
+
+// new_client creates a client for one SCRAM exchange.
+//
+// Example:
+// ```v
+// mut client := scram.new_client(username: 'user', password: 'pencil')!
+// assert client.mechanism_name() == 'SCRAM-SHA-256'
+// ```
+pub fn new_client(config ClientConfig) !&Client {
+	if config.username == '' {
+		return error('scram: the username must not be empty')
+	}
+	if config.min_iterations < 1 {
+		return error('scram: min_iterations must be at least 1, got ${config.min_iterations}')
+	}
+	nonce := if config.nonce == '' { generate_nonce()! } else { config.nonce }
+	validate_nonce(nonce)!
+	return &Client{
+		mechanism:       config.mechanism
+		username:        config.username
+		password:        config.password
+		authzid:         config.authzid
+		channel_binding: config.channel_binding
+		min_iterations:  config.min_iterations
+		gs2_header:      config.channel_binding.gs2_header(config.authzid)!
+		client_nonce:    nonce
+	}
+}
+
+// str renders a Client without its secrets. The password and the derived
+// keys are deliberately left out: V formats structs automatically, so a
+// `println(client)` while debugging would otherwise write the password to
+// wherever the logs go.
+pub fn (c &Client) str() string {
+	return 'scram.Client{ mechanism: ${c.mechanism_name()}, username: ${c.username}, state: ${c.state} }'
+}
+
+// mechanism_name returns the SASL mechanism name to announce to the server,
+// which is the `-PLUS` spelling when channel binding is in use.
+pub fn (c &Client) mechanism_name() string {
+	if c.channel_binding.mode == .required {
+		return c.mechanism.name_plus()
+	}
+	return c.mechanism.name()
+}
+
+// done reports whether the exchange finished successfully, which is only true
+// once `verify` has accepted the server-final-message.
+pub fn (c &Client) done() bool {
+	return c.state == .done
+}
+
+// first returns the client-first-message to send to the server. It carries no
+// secret, only the user name and the client nonce.
+pub fn (mut c Client) first() !string {
+	if c.state != .awaiting_first {
+		return error('scram: first() must be called exactly once, at the start of the exchange')
+	}
+	c.first_bare = 'n=${escape_saslname(c.username)},r=${c.client_nonce}'
+	c.state = .awaiting_server_first
+	return '${c.gs2_header}${c.first_bare}'
+}
+
+// final consumes the server-first-message and returns the
+// client-final-message, which carries the proof that this client knows the
+// password. The server's salt and iteration count are validated here, so a
+// server cannot weaken the exchange by asking for a trivial amount of work.
+pub fn (mut c Client) final(server_first string) !string {
+	if c.state != .awaiting_server_first {
+		return error('scram: final() must be called once, after first(), with the server-first-message')
+	}
+	// Every early return below is a failure, so the state moves first and is
+	// only advanced again once the message has been produced.
+	c.state = .failed
+	attrs := parse_attributes(server_first)!
+	// RFC 5802 §5.1: `m=` announces an extension the client must understand.
+	// This module understands none, so its presence has to end the exchange.
+	if attrs[0].key == `m` {
+		return MalformedMessage{
+			reason: 'the server requires the unsupported mandatory extension `${attrs[0].value}`'
+		}
+	}
+	if attrs.len < 3 || attrs[0].key != `r` || attrs[1].key != `s` || attrs[2].key != `i` {
+		return MalformedMessage{
+			reason: 'the server-first-message must be `r=`, then `s=`, then `i=`'
+		}
+	}
+	nonce := attrs[0].value
+	// The server nonce must extend the client one. If it does not, the reply
+	// belongs to another exchange, so it is a replay rather than a bad password.
+	if !nonce.starts_with(c.client_nonce) || nonce.len == c.client_nonce.len {
+		return AuthenticationFailed{
+			reason: 'the server nonce does not extend the client nonce'
+		}
+	}
+	salt := decode_base64(attrs[1].value, 'the salt')!
+	if salt.len == 0 {
+		return MalformedMessage{
+			reason: 'the salt must not be empty'
+		}
+	}
+	iterations := parse_positive_int(attrs[2].value, 'iteration count')!
+	if iterations < c.min_iterations {
+		return AuthenticationFailed{
+			reason: 'the server asked for ${iterations} iterations, below the configured minimum of ${c.min_iterations}'
+		}
+	}
+
+	cbind := base64.encode(c.channel_binding.cbind_input(c.gs2_header))
+	final_bare := 'c=${cbind},r=${nonce}'
+	c.auth_message = '${c.first_bare},${server_first},${final_bare}'
+
+	salted := c.mechanism.hi(c.password.bytes(), salt, iterations)
+	client_key := c.mechanism.hmac(salted, 'Client Key'.bytes())
+	stored_key := c.mechanism.hash(client_key)
+	client_signature := c.mechanism.hmac(stored_key, c.auth_message.bytes())
+	c.server_key = c.mechanism.hmac(salted, 'Server Key'.bytes())
+	c.state = .awaiting_server_final
+	return '${final_bare},p=${base64.encode(xor(client_key, client_signature))}'
+}
+
+// verify checks the server-final-message. It returns without a value when the
+// server proved that it holds the credentials for this user, which is the
+// point at which the connection may be trusted. A `ServerError` means the
+// server refused the exchange; an `AuthenticationFailed` means it answered
+// but could not sign the exchange, so it is not the server it claims to be.
+pub fn (mut c Client) verify(server_final string) ! {
+	if c.state != .awaiting_server_final {
+		return error('scram: verify() must be called once, after final(), with the server-final-message')
+	}
+	c.state = .failed
+	attrs := parse_attributes(server_final)!
+	if attrs[0].key == `e` {
+		return ServerError{
+			code: attrs[0].value
+		}
+	}
+	if attrs[0].key != `v` {
+		return MalformedMessage{
+			reason: 'the server-final-message must start with `v=` or `e=`'
+		}
+	}
+	signature := decode_base64(attrs[0].value, 'the server signature')!
+	expected := c.mechanism.hmac(c.server_key, c.auth_message.bytes())
+	if subtle.constant_time_compare(signature, expected) != 1 {
+		return AuthenticationFailed{
+			reason: 'the server signature does not match'
+		}
+	}
+	c.state = .done
+}

--- a/vlib/crypto/scram/client.v
+++ b/vlib/crypto/scram/client.v
@@ -233,6 +233,17 @@ pub fn (mut c Client) verify(server_final string) ! {
 	}
 	c.state = .failed
 	attrs := parse_attributes(server_final)!
+	mut has_verifier := false
+	mut has_error := false
+	for attr in attrs {
+		has_verifier = has_verifier || attr.key == `v`
+		has_error = has_error || attr.key == `e`
+	}
+	if has_verifier && has_error {
+		return MalformedMessage{
+			reason: 'the server-final-message must not contain both `v=` and `e=`'
+		}
+	}
 	if attrs[0].key == `e` {
 		if !is_server_error_value(attrs[0].value) {
 			return MalformedMessage{

--- a/vlib/crypto/scram/client.v
+++ b/vlib/crypto/scram/client.v
@@ -94,6 +94,9 @@ pub fn new_client(config ClientConfig) !&Client {
 	if config.min_iterations < 1 {
 		return error('scram: min_iterations must be at least 1, got ${config.min_iterations}')
 	}
+	if config.min_iterations > max_wire_iterations {
+		return error('scram: min_iterations must not exceed the SCRAM wire maximum of ${max_wire_iterations}, got ${config.min_iterations}')
+	}
 	if config.max_iterations < config.min_iterations {
 		return error('scram: max_iterations (${config.max_iterations}) must not be below min_iterations (${config.min_iterations})')
 	}

--- a/vlib/crypto/scram/client.v
+++ b/vlib/crypto/scram/client.v
@@ -85,6 +85,7 @@ pub fn new_client(config ClientConfig) !&Client {
 	if config.username == '' {
 		return error('scram: the username must not be empty')
 	}
+	escape_saslname(config.username)!
 	if config.min_iterations < 1 {
 		return error('scram: min_iterations must be at least 1, got ${config.min_iterations}')
 	}
@@ -135,7 +136,7 @@ pub fn (mut c Client) first() !string {
 	if c.state != .awaiting_first {
 		return error('scram: first() must be called exactly once, at the start of the exchange')
 	}
-	c.first_bare = 'n=${escape_saslname(c.username)},r=${c.client_nonce}'
+	c.first_bare = 'n=${escape_saslname(c.username)!},r=${c.client_nonce}'
 	c.state = .awaiting_server_first
 	return '${c.gs2_header}${c.first_bare}'
 }
@@ -241,6 +242,11 @@ pub fn (mut c Client) verify(server_final string) ! {
 	if attrs[0].key != `v` {
 		return MalformedMessage{
 			reason: 'the server-final-message must start with `v=` or `e=`'
+		}
+	}
+	if attrs[0].value == '' {
+		return MalformedMessage{
+			reason: 'the server signature must not be empty'
 		}
 	}
 	signature := decode_base64(attrs[0].value, 'the server signature')!

--- a/vlib/crypto/scram/client.v
+++ b/vlib/crypto/scram/client.v
@@ -229,6 +229,11 @@ pub fn (mut c Client) verify(server_final string) ! {
 	c.state = .failed
 	attrs := parse_attributes(server_final)!
 	if attrs[0].key == `e` {
+		if !is_server_error_value(attrs[0].value) {
+			return MalformedMessage{
+				reason: 'the server error is not a valid token'
+			}
+		}
 		return ServerError{
 			code: attrs[0].value
 		}

--- a/vlib/crypto/scram/client.v
+++ b/vlib/crypto/scram/client.v
@@ -11,8 +11,10 @@ import encoding.base64
 @[params]
 pub struct ClientConfig {
 pub:
-	// username is the authentication identity. It is escaped as needed, so it
-	// may contain commas and equals signs.
+	// username is the authentication identity. Apply SASLprep (RFC 4013) before
+	// passing every value, including ASCII input. This module validates UTF-8
+	// and NUL but does not normalize the value. Commas and equals signs are
+	// escaped on the wire.
 	username string @[required]
 	// password is the secret. Prepare and validate it before passing it:
 	// SASLprep for `.sha1`, PRECIS OpaqueString for `.sha256`, and the profile

--- a/vlib/crypto/scram/client.v
+++ b/vlib/crypto/scram/client.v
@@ -14,9 +14,11 @@ pub:
 	// username is the authentication identity. It is escaped as needed, so it
 	// may contain commas and equals signs.
 	username string @[required]
-	// password is the secret. See the SASLprep note in the module README if it
-	// may contain non-ASCII characters. It is required rather than defaulted,
-	// so that an exchange is never attempted with an empty password by accident.
+	// password is the secret. Prepare and validate it before passing it:
+	// SASLprep for `.sha1`, PRECIS OpaqueString for `.sha256`, and the profile
+	// agreed with the peer for `.sha512`. The module hashes its bytes unchanged.
+	// It is required so an exchange is never attempted with an empty password
+	// by accident.
 	password string @[required]
 	// mechanism selects the hash. Prefer the default over `.sha1`, which
 	// survives only for servers that offer nothing better.

--- a/vlib/crypto/scram/client.v
+++ b/vlib/crypto/scram/client.v
@@ -26,6 +26,7 @@ pub:
 	// survives only for servers that offer nothing better.
 	mechanism Mechanism = .sha256
 	// authzid is the authorization identity, when it differs from `username`.
+	// Prepare it with the application protocol's profile before passing it.
 	// Leave it empty in the common case where a user authenticates as itself.
 	authzid string
 	// channel_binding binds the exchange to the TLS channel underneath it.

--- a/vlib/crypto/scram/client_test.v
+++ b/vlib/crypto/scram/client_test.v
@@ -1,0 +1,310 @@
+// Client behaviour: what it accepts, and everything it must refuse.
+//
+// The happy path is covered by `conformance_test.v`; this file is about the
+// checks that stand between a client and a hostile or broken server.
+module scram
+
+// The RFC 7677 §3 exchange, reused as a starting point that is known good, so
+// that each test can change exactly one thing and watch the client react.
+const rfc_nonce = 'rOprNGfwEbeRWgbNEkqO'
+const rfc_server_first = 'r=rOprNGfwEbeRWgbNEkqO%hvYDpWUa2RaTCAfuxFIlj)hNlF\$k0,s=W22ZaJ0SNY7soEsUEjb6gQ==,i=4096'
+const rfc_server_final = 'v=6rriTRBi23WpRR/wtup+mMhUZUn/dB5nLTJRsjl95G4='
+
+fn rfc_client() &Client {
+	return new_client(username: 'user', password: 'pencil', nonce: rfc_nonce) or { panic(err) }
+}
+
+fn test_new_client_rejects_an_empty_username() {
+	new_client(username: '', password: 'pencil') or {
+		assert err.msg() == 'scram: the username must not be empty'
+		return
+	}
+	assert false, 'accepted an empty username'
+}
+
+fn test_new_client_rejects_an_unusable_nonce() {
+	// An empty `nonce` is the documented request for a generated one, so the
+	// unusable values are the ones that would break the message grammar.
+	for bad in ['a,b', 'with space', 'nul\0byte', 'trailing\n'] {
+		new_client(username: 'user', password: 'pencil', nonce: bad) or { continue }
+		assert false, 'accepted the nonce `${bad}`'
+	}
+}
+
+fn test_new_client_rejects_channel_binding_without_a_name() {
+	new_client(
+		username:        'user'
+		password:        'pencil'
+		channel_binding: ChannelBinding{
+			mode: .required
+			data: [u8(1), 2, 3]
+		}
+	) or {
+		assert err.msg().contains('channel binding name is required')
+		return
+	}
+	assert false, 'accepted channel binding without a type name'
+}
+
+fn test_an_empty_password_is_allowed() {
+	// SCRAM has no opinion on password length, and a server may well store
+	// credentials for one. Refusing it here would be this module inventing a
+	// policy that belongs to the application.
+	mut client := new_client(username: 'user', password: '', nonce: rfc_nonce)!
+	assert client.first()! == 'n,,n=user,r=${rfc_nonce}'
+	assert client.final(rfc_server_first)!.contains(',p=')
+}
+
+fn test_mechanism_name_follows_the_channel_binding() {
+	plain := new_client(username: 'user', password: 'pencil')!
+	assert plain.mechanism_name() == 'SCRAM-SHA-256'
+	sha1_client := new_client(username: 'user', password: 'pencil', mechanism: .sha1)!
+	assert sha1_client.mechanism_name() == 'SCRAM-SHA-1'
+	bound := new_client(
+		username:        'user'
+		password:        'pencil'
+		channel_binding: ChannelBinding{
+			mode: .required
+			name: 'tls-server-end-point'
+			data: [u8(1), 2, 3]
+		}
+	)!
+	assert bound.mechanism_name() == 'SCRAM-SHA-256-PLUS'
+}
+
+fn test_the_gs2_flag_reflects_the_channel_binding_mode() {
+	mut unsupported := new_client(username: 'user', password: 'pencil', nonce: rfc_nonce)!
+	assert unsupported.first()!.starts_with('n,,')
+
+	mut downgraded := new_client(
+		username:        'user'
+		password:        'pencil'
+		nonce:           rfc_nonce
+		channel_binding: ChannelBinding{
+			mode: .unsupported_by_server
+		}
+	)!
+	assert downgraded.first()!.starts_with('y,,')
+
+	mut bound := new_client(
+		username:        'user'
+		password:        'pencil'
+		nonce:           rfc_nonce
+		channel_binding: ChannelBinding{
+			mode: .required
+			name: 'tls-server-end-point'
+			data: [u8(1), 2, 3]
+		}
+	)!
+	assert bound.first()!.starts_with('p=tls-server-end-point,,')
+}
+
+fn test_the_authzid_is_escaped_in_the_gs2_header() {
+	mut client := new_client(
+		username: 'user'
+		password: 'pencil'
+		authzid:  'a,b=c'
+		nonce:    rfc_nonce
+	)!
+	assert client.first()!.starts_with('n,a=a=2Cb=3Dc,')
+}
+
+fn test_the_username_is_escaped_in_the_first_message() {
+	mut client := new_client(username: 'a,b=c', password: 'pencil', nonce: rfc_nonce)!
+	assert client.first()! == 'n,,n=a=2Cb=3Dc,r=${rfc_nonce}'
+}
+
+fn test_the_steps_must_be_called_in_order() {
+	mut client := rfc_client()
+	client.final(rfc_server_first) or {
+		assert err.msg().contains('final() must be called once, after first()')
+		client.verify(rfc_server_final) or {
+			assert err.msg().contains('verify() must be called once, after final()')
+			client.first()!
+			client.first() or {
+				assert err.msg().contains('first() must be called exactly once')
+				return
+			}
+			assert false, 'first() ran twice'
+		}
+		assert false, 'verify() ran before final()'
+	}
+	assert false, 'final() ran before first()'
+}
+
+fn test_a_server_nonce_that_does_not_extend_the_client_nonce_is_refused() {
+	cases := {
+		'a different nonce entirely': 'r=somethingelse,s=W22ZaJ0SNY7soEsUEjb6gQ==,i=4096'
+		'the client nonce unchanged': 'r=${rfc_nonce},s=W22ZaJ0SNY7soEsUEjb6gQ==,i=4096'
+		'a prefix of it':             'r=${rfc_nonce[..4]},s=W22ZaJ0SNY7soEsUEjb6gQ==,i=4096'
+	}
+	for what, server_first in cases {
+		mut client := rfc_client()
+		client.first()!
+		client.final(server_first) or {
+			assert err is AuthenticationFailed, what
+			continue
+		}
+		assert false, 'accepted ${what}'
+	}
+}
+
+fn test_a_low_iteration_count_is_refused() {
+	for count in [1, 100, 4095] {
+		mut client := rfc_client()
+		client.first()!
+		client.final('r=${rfc_nonce}srv,s=W22ZaJ0SNY7soEsUEjb6gQ==,i=${count}') or {
+			assert err.msg().contains('below the configured minimum of 4096')
+			assert err is AuthenticationFailed
+			continue
+		}
+		assert false, 'accepted ${count} iterations'
+	}
+}
+
+fn test_the_iteration_floor_can_be_lowered_deliberately() {
+	// Some deployments predate RFC 7677 §4 and still use 1000. Talking to them
+	// has to be possible, but only by saying so explicitly.
+	mut client := new_client(
+		username:       'user'
+		password:       'pencil'
+		nonce:          rfc_nonce
+		min_iterations: 1000
+	)!
+	client.first()!
+	assert client.final('r=${rfc_nonce}srv,s=W22ZaJ0SNY7soEsUEjb6gQ==,i=1000')!.contains(',p=')
+}
+
+fn test_a_malformed_server_first_message_is_refused() {
+	cases := {
+		'empty':                          ''
+		'no attributes':                  'garbage'
+		'attribute with no value':        'r=,s=W22ZaJ0SNY7soEsUEjb6gQ==,i=4096'
+		'wrong attribute order':          's=W22ZaJ0SNY7soEsUEjb6gQ==,r=${rfc_nonce}srv,i=4096'
+		'missing iteration count':        'r=${rfc_nonce}srv,s=W22ZaJ0SNY7soEsUEjb6gQ=='
+		'salt is not base64':             'r=${rfc_nonce}srv,s=not!base64,i=4096'
+		'salt is empty':                  'r=${rfc_nonce}srv,s=,i=4096'
+		'iterations are not a number':    'r=${rfc_nonce}srv,s=W22ZaJ0SNY7soEsUEjb6gQ==,i=lots'
+		'iterations are negative':        'r=${rfc_nonce}srv,s=W22ZaJ0SNY7soEsUEjb6gQ==,i=-1'
+		'iterations have a leading zero': 'r=${rfc_nonce}srv,s=W22ZaJ0SNY7soEsUEjb6gQ==,i=04096'
+		'a numeric attribute name':       'r=${rfc_nonce}srv,s=W22ZaJ0SNY7soEsUEjb6gQ==,1=4096'
+	}
+	for what, server_first in cases {
+		mut client := rfc_client()
+		client.first()!
+		client.final(server_first) or {
+			assert err is MalformedMessage, '${what}: ${err}'
+			continue
+		}
+		assert false, 'accepted a server-first-message with ${what}'
+	}
+}
+
+fn test_a_mandatory_extension_from_the_server_ends_the_exchange() {
+	mut client := rfc_client()
+	client.first()!
+	client.final('m=somefeature,r=${rfc_nonce}srv,s=W22ZaJ0SNY7soEsUEjb6gQ==,i=4096') or {
+		assert err.msg().contains('unsupported mandatory extension `somefeature`')
+		assert err is MalformedMessage
+		return
+	}
+	assert false, 'ignored a mandatory extension'
+}
+
+fn test_a_wrong_server_signature_is_refused() {
+	mut client := rfc_client()
+	client.first()!
+	client.final(rfc_server_first)!
+	client.verify('v=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=') or {
+		assert err.msg().contains('server signature does not match')
+		assert err is AuthenticationFailed
+		assert !client.done()
+		return
+	}
+	assert false, 'accepted a forged server signature'
+}
+
+fn test_a_server_signature_of_the_wrong_length_is_refused() {
+	mut client := rfc_client()
+	client.first()!
+	client.final(rfc_server_first)!
+	client.verify('v=AAAA') or {
+		assert err is AuthenticationFailed
+		return
+	}
+	assert false, 'accepted a truncated server signature'
+}
+
+fn test_a_wrong_password_is_only_caught_by_the_server_signature() {
+	// The client cannot know the password is wrong before the server answers:
+	// this is what makes the last step mandatory rather than decorative.
+	mut client := new_client(username: 'user', password: 'wrong', nonce: rfc_nonce)!
+	client.first()!
+	proof := client.final(rfc_server_first)!
+	assert proof.contains(',p=')
+	client.verify(rfc_server_final) or {
+		assert err is AuthenticationFailed
+		return
+	}
+	assert false, 'a wrong password produced a valid exchange'
+}
+
+fn test_a_server_refusal_surfaces_as_a_server_error() {
+	mut client := rfc_client()
+	client.first()!
+	client.final(rfc_server_first)!
+	client.verify('e=invalid-proof') or {
+		if err is ServerError {
+			assert err.code == 'invalid-proof'
+		}
+		assert err.msg() == 'scram: server refused the exchange: invalid-proof'
+		assert err is ServerError
+		return
+	}
+	assert false, 'a server refusal was treated as a success'
+}
+
+fn test_a_malformed_server_final_message_is_refused() {
+	for server_final in ['', 'garbage', 'x=something', 'v=not!base64', 'v='] {
+		mut client := rfc_client()
+		client.first()!
+		client.final(rfc_server_first)!
+		client.verify(server_final) or {
+			assert err is MalformedMessage, server_final
+			continue
+		}
+		assert false, 'accepted the server-final-message `${server_final}`'
+	}
+}
+
+fn test_a_refused_exchange_is_not_reported_as_done() {
+	mut client := rfc_client()
+	client.first()!
+	client.final(rfc_server_first)!
+	client.verify('e=invalid-proof') or {
+		// The exchange ended, but it ended badly: a caller that only looks at
+		// `done()` must not conclude it authenticated.
+		assert !client.done()
+		// And the step cannot be retried against the same nonce.
+		client.verify(rfc_server_final) or {
+			assert err.msg().contains('verify() must be called once')
+			return
+		}
+		assert false, 'verify() ran a second time after a refusal'
+	}
+	assert false, 'a server refusal was treated as a success'
+}
+
+fn test_a_failed_step_cannot_be_retried() {
+	mut client := rfc_client()
+	client.first()!
+	client.final('r=nope,s=W22ZaJ0SNY7soEsUEjb6gQ==,i=4096') or {
+		client.final(rfc_server_first) or {
+			assert err.msg().contains('final() must be called once')
+			assert !client.done()
+			return
+		}
+		assert false, 'final() ran again after a failure'
+	}
+	assert false, 'accepted a bad server nonce'
+}

--- a/vlib/crypto/scram/client_test.v
+++ b/vlib/crypto/scram/client_test.v
@@ -264,6 +264,19 @@ fn test_a_server_refusal_surfaces_as_a_server_error() {
 	assert false, 'a server refusal was treated as a success'
 }
 
+fn test_an_invalid_server_refusal_is_malformed() {
+	for code in ['has space', 'has=equals', 'control\0byte', 'café'] {
+		mut client := rfc_client()
+		client.first()!
+		client.final(rfc_server_first)!
+		client.verify('e=${code}') or {
+			assert err is MalformedMessage, code
+			continue
+		}
+		assert false, 'accepted the invalid server error `${code}`'
+	}
+}
+
 fn test_a_malformed_server_final_message_is_refused() {
 	for server_final in ['', 'garbage', 'x=something', 'v=not!base64', 'v='] {
 		mut client := rfc_client()

--- a/vlib/crypto/scram/client_test.v
+++ b/vlib/crypto/scram/client_test.v
@@ -289,6 +289,21 @@ fn test_an_invalid_server_refusal_is_malformed() {
 	}
 }
 
+fn test_a_server_final_message_cannot_contain_a_verifier_and_an_error() {
+	for server_final in ['${rfc_server_final},e=invalid-proof', 'e=invalid-proof,${rfc_server_final}'] {
+		mut client := rfc_client()
+		client.first()!
+		client.final(rfc_server_first)!
+		client.verify(server_final) or {
+			assert err is MalformedMessage, server_final
+			assert err.msg().contains('must not contain both `v=` and `e=`'), server_final
+			assert !client.done()
+			continue
+		}
+		assert false, 'accepted conflicting server-final attributes `${server_final}`'
+	}
+}
+
 fn test_a_malformed_server_final_message_is_refused() {
 	for server_final in ['', 'garbage', 'x=something', 'v=not!base64', 'v='] {
 		mut client := rfc_client()

--- a/vlib/crypto/scram/client_test.v
+++ b/vlib/crypto/scram/client_test.v
@@ -276,16 +276,19 @@ fn test_a_server_refusal_surfaces_as_a_server_error() {
 	assert false, 'a server refusal was treated as a success'
 }
 
-fn test_an_invalid_server_refusal_is_malformed() {
-	for code in ['has space', 'has=equals', 'control\0byte', 'café'] {
+fn test_extension_server_refusals_accept_the_full_value_alphabet() {
+	for code in ['rate_limit', 'has=equals', 'has space', 'café'] {
 		mut client := rfc_client()
 		client.first()!
 		client.final(rfc_server_first)!
 		client.verify('e=${code}') or {
-			assert err is MalformedMessage, code
+			assert err is ServerError, code
+			if err is ServerError {
+				assert err.code == code
+			}
 			continue
 		}
-		assert false, 'accepted the invalid server error `${code}`'
+		assert false, 'a server refusal was treated as a success'
 	}
 }
 

--- a/vlib/crypto/scram/client_test.v
+++ b/vlib/crypto/scram/client_test.v
@@ -22,6 +22,18 @@ fn test_new_client_rejects_an_empty_username() {
 	assert false, 'accepted an empty username'
 }
 
+fn test_new_client_rejects_nul_bytes_in_sasl_names() {
+	new_client(username: 'nul\0name', password: 'pencil') or {
+		assert err.msg().contains('must not contain a NUL byte')
+		new_client(username: 'user', password: 'pencil', authzid: 'nul\0authzid') or {
+			assert err.msg().contains('must not contain a NUL byte')
+			return
+		}
+		assert false, 'accepted a NUL byte in the authorization identity'
+	}
+	assert false, 'accepted a NUL byte in the username'
+}
+
 fn test_new_client_rejects_an_unusable_nonce() {
 	// An empty `nonce` is the documented request for a generated one, so the
 	// unusable values are the ones that would break the message grammar.

--- a/vlib/crypto/scram/conformance_test.v
+++ b/vlib/crypto/scram/conformance_test.v
@@ -1,0 +1,289 @@
+// Conformance vectors for the SCRAM exchange.
+//
+// The first two are the normative examples of RFC 5802 §5 (SCRAM-SHA-1) and
+// RFC 7677 §3 (SCRAM-SHA-256), reproduced verbatim from the RFC text. The
+// others cover what the RFCs leave without an example: SHA-512, a user name
+// needing `saslname` escaping, an authorization identity, channel binding,
+// and a non-ASCII password.
+//
+// Every vector was produced by an independent implementation written straight
+// from RFC 5802 §3, and every one of them — the two normative ones included —
+// was then replayed through `github.com/xdg-go/scram` v1.2.0, the library the
+// MongoDB Go driver authenticates with, which agrees on all four messages.
+module scram
+
+import crypto.pbkdf2
+import crypto.sha256
+import crypto.sha512
+import encoding.base64
+import encoding.hex
+
+// server_nonce_of returns the part of a vector's combined nonce that the
+// server contributed, so a `Server` can be pinned to reproduce the vector.
+fn server_nonce_of(v Vector) string {
+	nonce := v.server_first.all_after('r=').all_before(',')
+	return nonce[v.client_nonce.len..]
+}
+
+// client_for builds a Client pinned to a vector's nonce and channel binding.
+fn client_for(v Vector) !&Client {
+	mut binding := ChannelBinding{}
+	if v.cbind_name != '' {
+		binding = ChannelBinding{
+			mode: .required
+			name: v.cbind_name
+			data: v.cbind_data
+		}
+	}
+	return new_client(
+		username:        v.username
+		password:        v.password
+		mechanism:       v.mechanism
+		authzid:         v.authzid
+		channel_binding: binding
+		nonce:           v.client_nonce
+	)
+}
+
+// credentials_for rebuilds the server side record of a vector's user.
+fn credentials_for(v Vector) !Credentials {
+	salt := base64.decode(v.server_first.all_after(',s=').all_before(',i='))
+	return derive_credentials(v.mechanism, v.password, salt, v.iterations)!
+}
+
+fn test_client_reproduces_the_reference_messages() {
+	for v in vectors {
+		mut client := client_for(v)!
+		assert client.first()! == v.client_first, v.name
+		assert client.final(v.server_first)! == v.client_final, v.name
+		client.verify(v.server_final) or { assert false, '${v.name}: ${err}' }
+		assert client.done(), v.name
+	}
+}
+
+fn test_server_reproduces_the_reference_messages() {
+	for v in vectors {
+		creds := credentials_for(v)!
+		mut binding := ChannelBinding{}
+		if v.cbind_name != '' {
+			binding = ChannelBinding{
+				mode: .required
+				name: v.cbind_name
+				data: v.cbind_data
+			}
+		}
+		mut server := new_server(
+			mechanism:       v.mechanism
+			channel_binding: binding
+			nonce:           server_nonce_of(v)
+			lookup:          fn [creds] (username string) !Credentials {
+				return creds
+			}
+		)!
+		assert server.first(v.client_first)! == v.server_first, v.name
+		assert server.final(v.client_final)! == v.server_final, v.name
+		assert server.done(), v.name
+		assert server.username() == v.username, v.name
+		assert server.authzid() == v.authzid, v.name
+	}
+}
+
+fn test_derive_credentials_matches_the_reference_keys() {
+	for v in vectors {
+		creds := credentials_for(v)!
+		assert creds.stored_key.hex() == v.stored_hex, v.name
+		assert creds.server_key.hex() == v.server_hex, v.name
+		assert creds.iterations == v.iterations, v.name
+		assert creds.mechanism == v.mechanism, v.name
+	}
+}
+
+fn test_hi_matches_the_reference_salted_passwords() {
+	for v in vectors {
+		salt := base64.decode(v.server_first.all_after(',s=').all_before(',i='))
+		salted := v.mechanism.hi(v.password.bytes(), salt, v.iterations)
+		assert salted.hex() == v.salted_hex, v.name
+		assert salted.len == v.mechanism.size(), v.name
+	}
+}
+
+// Hi() is PBKDF2 with a single output block, so it must agree with the
+// unrelated implementation already in vlib.
+fn test_hi_agrees_with_crypto_pbkdf2() {
+	password := 'pencil'.bytes()
+	salt := hex.decode('4142434445464748')!
+	for iterations in [1, 2, 1000, 4096] {
+		sha256_expected := pbkdf2.key(password, salt, iterations, sha256.size, sha256.new())!
+		assert Mechanism.sha256.hi(password, salt, iterations) == sha256_expected
+		sha512_expected := pbkdf2.key(password, salt, iterations, sha512.size, sha512.new())!
+		assert Mechanism.sha512.hi(password, salt, iterations) == sha512_expected
+	}
+}
+
+struct Vector {
+	name         string
+	mechanism    Mechanism
+	username     string
+	password     string
+	authzid      string
+	cbind_name   string
+	cbind_data   []u8
+	client_nonce string
+	iterations   int
+	client_first string
+	server_first string
+	client_final string
+	server_final string
+	salted_hex   string
+	stored_hex   string
+	server_hex   string
+}
+
+const vectors = [
+	Vector{
+		name:         'rfc5802_sha1'
+		mechanism:    .sha1
+		username:     'user'
+		password:     'pencil'
+		authzid:      ''
+		cbind_name:   ''
+		cbind_data:   []u8{}
+		client_nonce: 'fyko+d2lbbFgONRv9qkxdawL'
+		iterations:   4096
+		client_first: 'n,,n=user,r=fyko+d2lbbFgONRv9qkxdawL'
+		server_first: 'r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,s=QSXCR+Q6sek8bf92,i=4096'
+		client_final: 'c=biws,r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,p=v0X8v3Bz2T0CJGbJQyF0X+HI4Ts='
+		server_final: 'v=rmF9pqV8S7suAoZWja4dJRkFsKQ='
+		salted_hex:   '1d96ee3a529b5a5f9e47c01f229a2cb8a6e15f7d'
+		stored_hex:   'e9d94660c39d65c38fbad91c358f14da0eef2bd6'
+		server_hex:   '0fe09258b3ac852ba502cc62ba903eaacdbf7d31'
+	},
+	Vector{
+		name:         'rfc7677_sha256'
+		mechanism:    .sha256
+		username:     'user'
+		password:     'pencil'
+		authzid:      ''
+		cbind_name:   ''
+		cbind_data:   []u8{}
+		client_nonce: 'rOprNGfwEbeRWgbNEkqO'
+		iterations:   4096
+		client_first: 'n,,n=user,r=rOprNGfwEbeRWgbNEkqO'
+		server_first: 'r=rOprNGfwEbeRWgbNEkqO%hvYDpWUa2RaTCAfuxFIlj)hNlF\$k0,s=W22ZaJ0SNY7soEsUEjb6gQ==,i=4096'
+		client_final: 'c=biws,r=rOprNGfwEbeRWgbNEkqO%hvYDpWUa2RaTCAfuxFIlj)hNlF\$k0,p=dHzbZapWIk4jUhN+Ute9ytag9zjfMHgsqmmiz7AndVQ='
+		server_final: 'v=6rriTRBi23WpRR/wtup+mMhUZUn/dB5nLTJRsjl95G4='
+		salted_hex:   'c4a49510323ab4f952cac1fa99441939e78ea74d6be81ddf7096e87513dc615d'
+		stored_hex:   '586e5df283e6dceb5c3e791d8b8528ec191e664045ce971792e2e6b5bb13e2a6'
+		server_hex:   'c1f3cbc1c13a9d35a14c0990eed97629ea225863e566a4314ab99f3f00e5d9d5'
+	},
+	Vector{
+		name:         'sha512'
+		mechanism:    .sha512
+		username:     'user'
+		password:     'pencil'
+		authzid:      ''
+		cbind_name:   ''
+		cbind_data:   []u8{}
+		client_nonce: 'rOprNGfwEbeRWgbNEkqO'
+		iterations:   4096
+		client_first: 'n,,n=user,r=rOprNGfwEbeRWgbNEkqO'
+		server_first: 'r=rOprNGfwEbeRWgbNEkqO%hvYDpWUa2RaTCAfuxFIlj)hNlF\$k0,s=W22ZaJ0SNY7soEsUEjb6gQ==,i=4096'
+		client_final: 'c=biws,r=rOprNGfwEbeRWgbNEkqO%hvYDpWUa2RaTCAfuxFIlj)hNlF\$k0,p=gMGXRcevScNtxZ6/8lQYpGtnsNAc3mGcmNomv+xnoOMw+3R2xNJdMNnzMlTN8PPC6wdp6dybEmDYXYTxwnYPJQ=='
+		server_final: 'v=ZQnYEgWQMFmmsM8aQMF0nDDCy/AgCzkwk8CmMZYcMg0vSVlKDanekLtifDSeVGT4+5ZxXnJq199RVG2rR7N7Zw=='
+		salted_hex:   'f16efe1be67f1d09502ebd5ed9262fddffba5a377ab4f0b687e5ed5ba0f50686b8a4ae166476da8ab3b951d2fa9238b63998f45461bc33a464814949cec9631d'
+		stored_hex:   'e8002e6f7d3ae446119b216933644dc2a2be7869eb918b8459b5e7d7d2ec12606aceef106825cd735170a675fd3611f684affad1dce3f43a0ee43bd590e1dbbe'
+		server_hex:   '8d91db6230b5687874fe129bc7206e1858c3ae08e02934f57ac03b6b05a229c459d28ff46f5c9611e6c179256490215ec1ff759cb0df285db89af0f99e613aac'
+	},
+	Vector{
+		name:         'escaped_username'
+		mechanism:    .sha256
+		username:     'a,b=c'
+		password:     'pencil'
+		authzid:      ''
+		cbind_name:   ''
+		cbind_data:   []u8{}
+		client_nonce: 'clientnoncevalue'
+		iterations:   4096
+		client_first: 'n,,n=a=2Cb=3Dc,r=clientnoncevalue'
+		server_first: 'r=clientnoncevalueservernoncevalue,s=c2FsdHNhbHRzYWx0,i=4096'
+		client_final: 'c=biws,r=clientnoncevalueservernoncevalue,p=mAxDUCU7uqrX8ugJFx0YeyeR6SpsPh8NwIg3VVhYOPI='
+		server_final: 'v=bs9NAJ5oBl5qTt4nBsh+jI8HTkH4f00eDZnDbuCO/NA='
+		salted_hex:   '1ae0aa4d817a79c294fe005e1c565d2240d9a26eb79e762d67a5ed080c0c446a'
+		stored_hex:   '5f256a1f2488e060b439c6441c60acee66179c113baf08b221600a03cb121bd2'
+		server_hex:   '73f468f717e0f4d36ee0a62acd79f87e30a604745e1e24525cdb54d5b8c3445b'
+	},
+	Vector{
+		name:         'authzid'
+		mechanism:    .sha256
+		username:     'user'
+		password:     'pencil'
+		authzid:      'admin'
+		cbind_name:   ''
+		cbind_data:   []u8{}
+		client_nonce: 'clientnoncevalue'
+		iterations:   4096
+		client_first: 'n,a=admin,n=user,r=clientnoncevalue'
+		server_first: 'r=clientnoncevalueservernoncevalue,s=c2FsdHNhbHRzYWx0,i=4096'
+		client_final: 'c=bixhPWFkbWluLA==,r=clientnoncevalueservernoncevalue,p=3FfNqGToGB71FEKlZCL+JtZgjEJvYdT9R5sKBAO3AfM='
+		server_final: 'v=1RSa3Iu5z5Iet9kidUeNJmAKeOdyBzwQMIXtAfuvWtU='
+		salted_hex:   '1ae0aa4d817a79c294fe005e1c565d2240d9a26eb79e762d67a5ed080c0c446a'
+		stored_hex:   '5f256a1f2488e060b439c6441c60acee66179c113baf08b221600a03cb121bd2'
+		server_hex:   '73f468f717e0f4d36ee0a62acd79f87e30a604745e1e24525cdb54d5b8c3445b'
+	},
+	Vector{
+		name:         'channel_binding'
+		mechanism:    .sha256
+		username:     'user'
+		password:     'pencil'
+		authzid:      ''
+		cbind_name:   'tls-server-end-point'
+		cbind_data:   [u8(0x00), 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b,
+			0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19,
+			0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f]
+		client_nonce: 'clientnoncevalue'
+		iterations:   4096
+		client_first: 'p=tls-server-end-point,,n=user,r=clientnoncevalue'
+		server_first: 'r=clientnoncevalueservernoncevalue,s=c2FsdHNhbHRzYWx0,i=4096'
+		client_final: 'c=cD10bHMtc2VydmVyLWVuZC1wb2ludCwsAAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8=,r=clientnoncevalueservernoncevalue,p=Bl9ZPqOc0PRnfQbcsxDBdHFvs/irfY5cAY9///2hXEw='
+		server_final: 'v=ctaZtb0RgoPWp5lsaMAammetaiK6ZitqSzKlJMWRv6U='
+		salted_hex:   '1ae0aa4d817a79c294fe005e1c565d2240d9a26eb79e762d67a5ed080c0c446a'
+		stored_hex:   '5f256a1f2488e060b439c6441c60acee66179c113baf08b221600a03cb121bd2'
+		server_hex:   '73f468f717e0f4d36ee0a62acd79f87e30a604745e1e24525cdb54d5b8c3445b'
+	},
+	Vector{
+		name:         'utf8_password'
+		mechanism:    .sha256
+		username:     'rené'
+		password:     'pässwörd'
+		authzid:      ''
+		cbind_name:   ''
+		cbind_data:   []u8{}
+		client_nonce: 'clientnoncevalue'
+		iterations:   10000
+		client_first: 'n,,n=rené,r=clientnoncevalue'
+		server_first: 'r=clientnoncevalueservernoncevalue,s=c2FsdHNhbHRzYWx0,i=10000'
+		client_final: 'c=biws,r=clientnoncevalueservernoncevalue,p=NrtHNv7awL5KZ/rOvK46mzfMvAxvk4UiNkTBxGaEK1I='
+		server_final: 'v=faJh6FpEnTwYd397AElAHqIB5g5AwZIFNA5uT6Fv2Vo='
+		salted_hex:   'd6c4b3c07b85efc838b771f7fbdc0456d41226b2d13e9c7577199a3571d272fb'
+		stored_hex:   '59c2e0b1992277a63efacab663766bc8476fb36389eda40c8ee65ed1c470794a'
+		server_hex:   '90a296069bfd8fb1d08394eab964701a562c316ae8343c122524628d30518b0d'
+	},
+	Vector{
+		name:         'min_iterations'
+		mechanism:    .sha1
+		username:     'user'
+		password:     'pencil'
+		authzid:      ''
+		cbind_name:   ''
+		cbind_data:   []u8{}
+		client_nonce: 'clientnoncevalue'
+		iterations:   4096
+		client_first: 'n,,n=user,r=clientnoncevalue'
+		server_first: 'r=clientnoncevalueservernoncevalue,s=c2FsdHNhbHRzYWx0,i=4096'
+		client_final: 'c=biws,r=clientnoncevalueservernoncevalue,p=gAEjRo87i97AqQag7Xa7LkE/Ohc='
+		server_final: 'v=7jImVhD+ep8a6fy+p1OzhHs4ND0='
+		salted_hex:   '0885e928b73f79ce2d1e05ef72d6a3148c3b66e8'
+		stored_hex:   'c46c6e5e4034522126ce29b6f1b3427d5e0998bf'
+		server_hex:   '591299d40b67907afa1d913afffa25e01c5b13b6'
+	},
+]

--- a/vlib/crypto/scram/conformance_test.v
+++ b/vlib/crypto/scram/conformance_test.v
@@ -76,6 +76,10 @@ fn test_server_reproduces_the_reference_messages() {
 			mechanism:       v.mechanism
 			channel_binding: binding
 			nonce:           server_nonce_of(v)
+			// The vectors' UTF-8 user names are already in their SASLprep form.
+			prepare_username: fn (username string) !string {
+				return username
+			}
 			lookup:          fn [creds] (username string) !Credentials {
 				return creds
 			}

--- a/vlib/crypto/scram/errors.v
+++ b/vlib/crypto/scram/errors.v
@@ -1,0 +1,73 @@
+// Typed errors returned by this module. Callers can tell the three
+// situations that matter apart without parsing strings: the peer sent
+// something that is not a SCRAM message, the peer failed to prove what it
+// claimed, or the exchange was refused. Programming errors — calling the
+// steps out of order, passing an empty username — are returned as plain
+// `error('...')` values, because there is nothing to branch on.
+module scram
+
+// MalformedMessage means the bytes received do not form a valid SCRAM
+// message. This is a permanent error: retrying will not help, and it usually
+// points at a peer that speaks a different protocol or a corrupted transport.
+pub struct MalformedMessage {
+	Error
+pub:
+	// reason names the check that failed.
+	reason string
+}
+
+// msg formats a MalformedMessage for `IError.msg()`.
+pub fn (e &MalformedMessage) msg() string {
+	return 'scram: malformed message: ${e.reason}'
+}
+
+// AuthenticationFailed means the exchange was well formed but the peer did
+// not prove what it claimed. On the server that means a wrong password; on
+// the client it means the server could not sign the exchange, so it does not
+// hold the credentials it should — treat the connection as hostile rather
+// than retrying.
+//
+// It is deliberately not split into finer variants: telling a caller *why*
+// authentication failed is exactly the information an attacker wants.
+pub struct AuthenticationFailed {
+	Error
+pub:
+	// reason is a short diagnostic for logs. Do not relay it to a remote peer.
+	reason string
+}
+
+// msg formats an AuthenticationFailed for `IError.msg()`.
+pub fn (e &AuthenticationFailed) msg() string {
+	return 'scram: authentication failed: ${e.reason}'
+}
+
+// UnsupportedMechanism means a mechanism name is not one this module
+// implements. It is returned by `mechanism_from_name`, typically while
+// picking a mechanism out of the list a server advertises.
+pub struct UnsupportedMechanism {
+	Error
+pub:
+	// name is the mechanism name that was not recognised.
+	name string
+}
+
+// msg formats an UnsupportedMechanism for `IError.msg()`.
+pub fn (e &UnsupportedMechanism) msg() string {
+	return 'scram: unsupported mechanism: ${e.name}'
+}
+
+// ServerError carries the `e=` attribute of a server-final-message, which is
+// how a server reports a refusal instead of signing the exchange. RFC 5802
+// §7 defines the values, `invalid-proof` and `unknown-user` being the common
+// ones, but a server may send any token, so do not assume the set is closed.
+pub struct ServerError {
+	Error
+pub:
+	// code is the `server-error-value` sent by the server, verbatim.
+	code string
+}
+
+// msg formats a ServerError for `IError.msg()`.
+pub fn (e &ServerError) msg() string {
+	return 'scram: server refused the exchange: ${e.code}'
+}

--- a/vlib/crypto/scram/errors.v
+++ b/vlib/crypto/scram/errors.v
@@ -59,7 +59,8 @@ pub fn (e &UnsupportedMechanism) msg() string {
 // ServerError carries the `e=` attribute of a server-final-message, which is
 // how a server reports a refusal instead of signing the exchange. RFC 5802
 // §7 defines the values, `invalid-proof` and `unknown-user` being the common
-// ones, but a server may send any token, so do not assume the set is closed.
+// ones, but a server may send any valid extension value, so do not assume the
+// set is closed.
 pub struct ServerError {
 	Error
 pub:

--- a/vlib/crypto/scram/scram.v
+++ b/vlib/crypto/scram/scram.v
@@ -1,0 +1,354 @@
+// Package scram implements the Salted Challenge Response Authentication
+// Mechanism (SCRAM) family of SASL mechanisms:
+//
+// * `SCRAM-SHA-1`   — RFC 5802
+// * `SCRAM-SHA-256` — RFC 7677
+// * `SCRAM-SHA-512` — same construction, registered with IANA
+//
+// SCRAM lets a client prove that it knows a password without ever sending
+// it, and lets the client verify in the same round trip that the server
+// knows it too (mutual authentication). The server stores only two derived
+// keys, so a stolen credential database does not directly hand out
+// passwords, and every exchange is salted and nonce'd, so recordings of an
+// exchange cannot be replayed.
+//
+// It is the authentication mechanism of PostgreSQL (10+), MongoDB (3.0+),
+// Kafka (SASL/SCRAM), LDAP, XMPP and the SASL profiles of IMAP and SMTP.
+//
+// The exchange is four messages: this module models it as three calls on the
+// client and two on the server, each one taking the message the peer just
+// sent and returning the message to send back. Driving both halves in
+// process, which is also what a test does, shows the whole protocol:
+//
+// Example:
+// ```v
+// creds := scram.new_credentials(.sha256, 'pencil')!
+// mut server := scram.new_server(lookup: fn [creds] (username string) !scram.Credentials {
+// 	return creds
+// })!
+// mut client := scram.new_client(username: 'user', password: 'pencil')!
+//
+// server_first := server.first(client.first()!)!
+// server_final := server.final(client.final(server_first)!)!
+// client.verify(server_final)!
+//
+// assert client.done() && server.done()
+// ```
+//
+// Against a real server only the client half is used: send `client.first()`,
+// feed the reply to `client.final()`, send that, and hand the last reply to
+// `client.verify()`. The transport is not this module's concern — SCRAM
+// messages are ASCII strings that a protocol such as PostgreSQL's or
+// MongoDB's carries as SASL payloads.
+//
+// Both `Client` and `Server` are single-use: one value drives exactly one
+// authentication exchange, and calling the steps out of order is an error
+// rather than undefined behaviour.
+module scram
+
+import crypto.hmac
+import crypto.rand
+import crypto.sha1
+import crypto.sha256
+import crypto.sha512
+import encoding.base64
+
+// default_min_iterations is the smallest PBKDF2 iteration count a client
+// accepts from a server unless `ClientConfig.min_iterations` says otherwise.
+// RFC 7677 §4 requires clients to reject anything below 4096, because a low
+// count makes an offline attack on an intercepted exchange cheap.
+pub const default_min_iterations = 4096
+
+// default_iterations is the iteration count used by `new_credentials` when
+// the caller does not pick one. RFC 7677 §4 gives 4096 as the floor; this
+// module defaults an order of magnitude above it, which stays well under a
+// millisecond of CPU per login on current hardware.
+pub const default_iterations = 32768
+
+// default_salt_size is the number of random bytes `new_credentials` uses for
+// a salt, matching the 16 octets recommended by RFC 5802 §5.1.
+pub const default_salt_size = 16
+
+// nonce_size is the number of random bytes behind a generated nonce. The
+// base64 spelling that goes on the wire is longer, and comfortably above the
+// entropy RFC 5802 §5.1 asks for.
+const nonce_size = 24
+
+// Mechanism selects the hash function of a SCRAM exchange, which is the only
+// thing that varies between the members of the SCRAM family.
+pub enum Mechanism {
+	sha1
+	sha256
+	sha512
+}
+
+// name returns the IANA SASL mechanism name, such as `SCRAM-SHA-256`.
+pub fn (m Mechanism) name() string {
+	return match m {
+		.sha1 { 'SCRAM-SHA-1' }
+		.sha256 { 'SCRAM-SHA-256' }
+		.sha512 { 'SCRAM-SHA-512' }
+	}
+}
+
+// name_plus returns the channel binding spelling of the mechanism name, such
+// as `SCRAM-SHA-256-PLUS`. Advertise this name when the exchange is bound to
+// the underlying TLS channel, i.e. when `ChannelBinding.mode` is `.required`.
+pub fn (m Mechanism) name_plus() string {
+	return '${m.name()}-PLUS'
+}
+
+// size returns the digest length of the mechanism in bytes, which is also the
+// length of every key and proof it produces.
+pub fn (m Mechanism) size() int {
+	return match m {
+		.sha1 { sha1.size }
+		.sha256 { sha256.size }
+		.sha512 { sha512.size }
+	}
+}
+
+// mechanism_from_name maps an IANA SASL mechanism name to a `Mechanism`.
+// Both spellings are accepted, so `SCRAM-SHA-256` and `SCRAM-SHA-256-PLUS`
+// both return `.sha256`; whether channel binding is in use is carried by
+// `ChannelBinding`, not by the mechanism. Use it to pick a mechanism from the
+// list a server advertises.
+pub fn mechanism_from_name(name string) !Mechanism {
+	match name {
+		'SCRAM-SHA-1', 'SCRAM-SHA-1-PLUS' {
+			return .sha1
+		}
+		'SCRAM-SHA-256', 'SCRAM-SHA-256-PLUS' {
+			return .sha256
+		}
+		'SCRAM-SHA-512', 'SCRAM-SHA-512-PLUS' {
+			return .sha512
+		}
+		else {
+			return UnsupportedMechanism{
+				name: name
+			}
+		}
+	}
+}
+
+// block_size returns the internal block size of the hash, needed by HMAC.
+fn (m Mechanism) block_size() int {
+	return match m {
+		.sha1 { sha1.block_size }
+		.sha256 { sha256.block_size }
+		.sha512 { sha512.block_size }
+	}
+}
+
+// hash is the `H()` of RFC 5802 §2.2.
+fn (m Mechanism) hash(data []u8) []u8 {
+	return match m {
+		.sha1 { sha1.sum(data) }
+		.sha256 { sha256.sum256(data) }
+		.sha512 { sha512.sum512(data) }
+	}
+}
+
+// hmac is the `HMAC()` of RFC 5802 §2.2.
+fn (m Mechanism) hmac(key []u8, data []u8) []u8 {
+	return match m {
+		.sha1 { hmac.new(key, data, sha1.sum, sha1.block_size) }
+		.sha256 { hmac.new(key, data, sha256.sum256, sha256.block_size) }
+		.sha512 { hmac.new(key, data, sha512.sum512, sha512.block_size) }
+	}
+}
+
+// hi is the `Hi(str, salt, i)` of RFC 5802 §2.2: PBKDF2 (RFC 2898) with HMAC
+// as the pseudorandom function and an output length equal to the digest size.
+// Because exactly one block is requested, the block index is the constant
+// `INT(1)` and no outer loop over blocks is needed.
+fn (m Mechanism) hi(password []u8, salt []u8, iterations int) []u8 {
+	mut block := []u8{cap: salt.len + 4}
+	block << salt
+	block << [u8(0), 0, 0, 1]
+	mut u := m.hmac(password, block)
+	mut result := u.clone()
+	for _ in 1 .. iterations {
+		u = m.hmac(password, u)
+		for i in 0 .. result.len {
+			result[i] ^= u[i]
+		}
+	}
+	return result
+}
+
+// Credentials is what a SCRAM server stores for one user. It is derived from
+// the password but does not allow recovering it, and `stored_key` alone is
+// not enough to authenticate as the user — that is the whole point of the
+// mechanism. `server_key`, on the other hand, does let its holder impersonate
+// the *server*, so it deserves the same protection as any secret.
+pub struct Credentials {
+pub:
+	// mechanism is the hash the keys below were derived with. Credentials are
+	// not interchangeable between mechanisms.
+	mechanism Mechanism
+	// salt is the per-user random salt, sent to the client in cleartext.
+	salt []u8
+	// iterations is the PBKDF2 iteration count used to derive the keys.
+	iterations int
+	// stored_key is `H(HMAC(SaltedPassword, "Client Key"))`, used to check the
+	// proof a client sends.
+	stored_key []u8
+	// server_key is `HMAC(SaltedPassword, "Server Key")`, used to sign the
+	// server-final-message so the client can authenticate the server.
+	server_key []u8
+}
+
+// str renders Credentials without their key material. `stored_key` and
+// `server_key` are secrets — `server_key` in particular lets its holder
+// impersonate the server — and V formats structs automatically, so the
+// default rendering would leak them into any log that prints a record.
+pub fn (c Credentials) str() string {
+	return 'scram.Credentials{ mechanism: ${c.mechanism.name()}, salt: ${c.salt.len} bytes, iterations: ${c.iterations} }'
+}
+
+// derive_credentials computes the credentials a server stores for `password`,
+// using a salt and iteration count the caller chooses. Use it when you need
+// to reproduce an existing record; prefer `new_credentials` for a fresh user,
+// as it picks a random salt for you.
+//
+// The password must already be normalised: see the SASLprep note in the
+// module README.
+pub fn derive_credentials(mechanism Mechanism, password string, salt []u8, iterations int) !Credentials {
+	if salt.len == 0 {
+		return error('scram: the salt must not be empty')
+	}
+	if iterations < 1 {
+		return error('scram: the iteration count must be at least 1, got ${iterations}')
+	}
+	salted := mechanism.hi(password.bytes(), salt, iterations)
+	client_key := mechanism.hmac(salted, 'Client Key'.bytes())
+	return Credentials{
+		mechanism:  mechanism
+		salt:       salt.clone()
+		iterations: iterations
+		stored_key: mechanism.hash(client_key)
+		server_key: mechanism.hmac(salted, 'Server Key'.bytes())
+	}
+}
+
+// new_credentials derives the credentials a server stores for a new user,
+// with a freshly generated random salt of `default_salt_size` bytes and
+// `default_iterations` iterations.
+//
+// Example:
+// ```v
+// credentials := scram.new_credentials(.sha256, 'pencil')!
+// assert credentials.salt.len == scram.default_salt_size
+// assert credentials.iterations == scram.default_iterations
+// ```
+pub fn new_credentials(mechanism Mechanism, password string) !Credentials {
+	salt := rand.bytes(default_salt_size)!
+	return derive_credentials(mechanism, password, salt, default_iterations)!
+}
+
+// encode renders the credentials in the storage format of RFC 5803, laid out
+// in the `authPassword` syntax of RFC 3112 §2:
+//
+//     <mechanism> "$" <iterations> ":" <salt> "$" <stored key> ":" <server key>
+//
+// with the three binary fields in base64. It is the format PostgreSQL keeps
+// in `pg_authid.rolpassword`, so a record written here can be read by an
+// LDAP directory or a PostgreSQL server, and vice versa.
+//
+// The result is a secret: `server_key` lets its holder impersonate the
+// server to any client of this user.
+//
+// Example:
+// ```v
+// credentials := scram.derive_credentials(.sha256, 'pencil', 'saltsaltsaltsalt'.bytes(),
+// 	4096)!
+// encoded := credentials.encode()
+// assert encoded.starts_with('SCRAM-SHA-256\$4096:')
+// assert scram.parse_credentials(encoded)!.stored_key == credentials.stored_key
+// ```
+pub fn (c Credentials) encode() string {
+	return '${c.mechanism.name()}\$${c.iterations}:${base64.encode(c.salt)}\$${base64.encode(c.stored_key)}:${base64.encode(c.server_key)}'
+}
+
+// parse_credentials reads back what `Credentials.encode` wrote, and with it
+// any RFC 5803 record. Every field is validated, including the key lengths
+// against the mechanism, so a truncated or hand-edited record is rejected
+// rather than silently producing an account nobody can log into.
+pub fn parse_credentials(encoded string) !Credentials {
+	fields := encoded.split('\$')
+	if fields.len != 3 {
+		return MalformedMessage{
+			reason: 'a stored credential must be `mechanism\$info\$value`'
+		}
+	}
+	if fields[0].ends_with('-PLUS') {
+		// RFC 5803 §2: the stored scheme names the hash, never the channel
+		// binding variant, since the two share the same key material.
+		return MalformedMessage{
+			reason: 'a stored credential must not name a `-PLUS` mechanism'
+		}
+	}
+	mechanism := mechanism_from_name(fields[0])!
+	info := fields[1].split(':')
+	value := fields[2].split(':')
+	if info.len != 2 || value.len != 2 {
+		return MalformedMessage{
+			reason: 'a stored credential must be `mechanism\$iterations:salt\$stored:server`'
+		}
+	}
+	iterations := parse_positive_int(info[0], 'iteration count')!
+	salt := decode_base64(info[1], 'the salt')!
+	if salt.len == 0 {
+		return MalformedMessage{
+			reason: 'the salt must not be empty'
+		}
+	}
+	stored_key := decode_base64(value[0], 'the stored key')!
+	server_key := decode_base64(value[1], 'the server key')!
+	if stored_key.len != mechanism.size() || server_key.len != mechanism.size() {
+		return MalformedMessage{
+			reason: 'a ${mechanism.name()} credential needs ${mechanism.size()} byte keys, got ${stored_key.len} and ${server_key.len}'
+		}
+	}
+	return Credentials{
+		mechanism:  mechanism
+		salt:       salt
+		iterations: iterations
+		stored_key: stored_key
+		server_key: server_key
+	}
+}
+
+// generate_nonce returns a fresh base64 nonce drawn from the CSPRNG. Every
+// character of the base64 alphabet is a legal SCRAM `printable` character,
+// so the result never needs escaping.
+fn generate_nonce() !string {
+	return base64.encode(rand.bytes(nonce_size)!)
+}
+
+// xor returns the byte-wise exclusive or of two equal length slices, which is
+// how a proof is built from a key and a signature, and how the key is
+// recovered from the proof on the other side.
+fn xor(a []u8, b []u8) []u8 {
+	mut out := []u8{len: a.len}
+	for i in 0 .. a.len {
+		out[i] = a[i] ^ b[i]
+	}
+	return out
+}
+
+// validate_nonce rejects nonces that would break the message grammar. SCRAM
+// nonces are `printable` (RFC 5802 §7): US-ASCII 0x21-0x7E except the comma,
+// which separates attributes.
+fn validate_nonce(nonce string) ! {
+	if nonce == '' {
+		return error('scram: the nonce must not be empty')
+	}
+	for c in nonce {
+		if c < 0x21 || c > 0x7e || c == `,` {
+			return error('scram: the nonce must only contain printable US-ASCII characters other than a comma')
+		}
+	}
+}

--- a/vlib/crypto/scram/scram.v
+++ b/vlib/crypto/scram/scram.v
@@ -59,6 +59,16 @@ import encoding.base64
 // count makes an offline attack on an intercepted exchange cheap.
 pub const default_min_iterations = 4096
 
+// default_max_iterations is the largest PBKDF2 iteration count a client
+// accepts from a server unless `ClientConfig.max_iterations` says otherwise.
+// The count is a number a server picks, and deriving the salted password
+// happens before anything about that server has been authenticated, so
+// without a ceiling a hostile endpoint turns a few bytes of
+// server-first-message into unbounded work on the client: at the 999999999
+// the grammar allows, that is tens of minutes of CPU per connection. 2^20 is
+// three orders of magnitude above what deployments use in practice.
+pub const default_max_iterations = 1_048_576
+
 // default_iterations is the iteration count used by `new_credentials` when
 // the caller does not pick one. RFC 7677 §4 gives 4096 as the floor; this
 // module defaults an order of magnitude above it, which stays well under a

--- a/vlib/crypto/scram/scram.v
+++ b/vlib/crypto/scram/scram.v
@@ -248,6 +248,10 @@ pub fn derive_credentials(mechanism Mechanism, password string, salt []u8, itera
 // with a freshly generated random salt of `default_salt_size` bytes and
 // `default_iterations` iterations.
 //
+// Prepare and validate the password before calling: SASLprep for `.sha1`,
+// PRECIS OpaqueString for `.sha256`, and the profile agreed with the peer for
+// `.sha512`. This function hashes the supplied bytes unchanged.
+//
 // Example:
 // ```v
 // credentials := scram.new_credentials(.sha256, 'pencil')!

--- a/vlib/crypto/scram/scram.v
+++ b/vlib/crypto/scram/scram.v
@@ -273,9 +273,10 @@ pub fn new_credentials(mechanism Mechanism, password string) !Credentials {
 //
 //     <mechanism> "$" <iterations> ":" <salt> "$" <stored key> ":" <server key>
 //
-// with the three binary fields in base64. It is the format PostgreSQL keeps
-// in `pg_authid.rolpassword`, so a record written here can be read by an
-// LDAP directory or a PostgreSQL server, and vice versa.
+// with the three binary fields in base64. For `.sha256`, it is also the format
+// PostgreSQL keeps in `pg_authid.rolpassword`, so a SHA-256 record written here
+// can be read by an LDAP directory or a PostgreSQL server, and vice versa.
+// PostgreSQL does not accept the `.sha1` or `.sha512` records.
 //
 // The result is a secret: `server_key` lets its holder impersonate the
 // server to any client of this user.

--- a/vlib/crypto/scram/scram.v
+++ b/vlib/crypto/scram/scram.v
@@ -38,8 +38,8 @@
 // Against a real server only the client half is used: send `client.first()`,
 // feed the reply to `client.final()`, send that, and hand the last reply to
 // `client.verify()`. The transport is not this module's concern — SCRAM
-// messages are ASCII strings that a protocol such as PostgreSQL's or
-// MongoDB's carries as SASL payloads.
+// messages are byte-preserving strings that may contain UTF-8 identities. A
+// protocol such as PostgreSQL or MongoDB carries them as SASL payloads.
 //
 // Both `Client` and `Server` are single-use: one value drives exactly one
 // authentication exchange, and calling the steps out of order is an error
@@ -223,8 +223,9 @@ pub fn (c Credentials) str() string {
 // to reproduce an existing record; prefer `new_credentials` for a fresh user,
 // as it picks a random salt for you.
 //
-// The password must already be normalised: see the SASLprep note in the
-// module README.
+// Prepare and validate the password before calling: SASLprep for `.sha1`,
+// PRECIS OpaqueString for `.sha256`, and the profile agreed with the peer for
+// `.sha512`. This function hashes the supplied bytes unchanged.
 pub fn derive_credentials(mechanism Mechanism, password string, salt []u8, iterations int) !Credentials {
 	if salt.len == 0 {
 		return error('scram: the salt must not be empty')

--- a/vlib/crypto/scram/scram.v
+++ b/vlib/crypto/scram/scram.v
@@ -268,15 +268,16 @@ pub fn new_credentials(mechanism Mechanism, password string) !Credentials {
 	return derive_credentials(mechanism, password, salt, default_iterations)!
 }
 
-// encode renders the credentials in the storage format of RFC 5803, laid out
-// in the `authPassword` syntax of RFC 3112 §2:
+// encode renders the credentials in this one-line storage format:
 //
 //     <mechanism> "$" <iterations> ":" <salt> "$" <stored key> ":" <server key>
 //
-// with the three binary fields in base64. For `.sha256`, it is also the format
-// PostgreSQL keeps in `pg_authid.rolpassword`, so a SHA-256 record written here
-// can be read by an LDAP directory or a PostgreSQL server, and vice versa.
-// PostgreSQL does not accept the `.sha1` or `.sha512` records.
+// with the three binary fields in base64. For `.sha1`, this is the RFC 5803
+// `authPassword` scheme laid out in the syntax of RFC 3112 §2 and can
+// interoperate with LDAP implementations of that RFC. For `.sha256`, it is
+// the format PostgreSQL keeps in `pg_authid.rolpassword`. PostgreSQL does not
+// accept the `.sha1` or `.sha512` records, and RFC 5803 does not define the
+// `.sha256` or `.sha512` records for LDAP.
 //
 // The result is a secret: `server_key` lets its holder impersonate the
 // server to any client of this user.
@@ -293,10 +294,11 @@ pub fn (c Credentials) encode() string {
 	return '${c.mechanism.name()}\$${c.iterations}:${base64.encode(c.salt)}\$${base64.encode(c.stored_key)}:${base64.encode(c.server_key)}'
 }
 
-// parse_credentials reads back what `Credentials.encode` wrote, and with it
-// any RFC 5803 record. Every field is validated, including the key lengths
-// against the mechanism, so a truncated or hand-edited record is rejected
-// rather than silently producing an account nobody can log into.
+// parse_credentials reads back what `Credentials.encode` wrote, including
+// RFC 5803 SCRAM-SHA-1 records and PostgreSQL SCRAM-SHA-256 records. Every
+// field is validated, including the key lengths against the mechanism, so a
+// truncated or hand-edited record is rejected rather than silently producing
+// an account nobody can log into.
 pub fn parse_credentials(encoded string) !Credentials {
 	fields := encoded.split('\$')
 	if fields.len != 3 {

--- a/vlib/crypto/scram/scram.v
+++ b/vlib/crypto/scram/scram.v
@@ -71,8 +71,9 @@ pub const default_max_iterations = 1_048_576
 
 // default_iterations is the iteration count used by `new_credentials` when
 // the caller does not pick one. RFC 7677 §4 gives 4096 as the floor; this
-// module defaults an order of magnitude above it, which stays well under a
-// millisecond of CPU per login on current hardware.
+// module defaults an order of magnitude above it. Derivation typically takes
+// tens of milliseconds on contemporary desktop CPUs; benchmark the target
+// deployment when sizing authentication capacity.
 pub const default_iterations = 32768
 
 // default_salt_size is the number of random bytes `new_credentials` uses for
@@ -83,6 +84,7 @@ pub const default_salt_size = 16
 // base64 spelling that goes on the wire is longer, and comfortably above the
 // entropy RFC 5802 §5.1 asks for.
 const nonce_size = 24
+const max_wire_iterations = 999_999_999
 
 // Mechanism selects the hash function of a SCRAM exchange, which is the only
 // thing that varies between the members of the SCRAM family.
@@ -232,6 +234,9 @@ pub fn derive_credentials(mechanism Mechanism, password string, salt []u8, itera
 	}
 	if iterations < 1 {
 		return error('scram: the iteration count must be at least 1, got ${iterations}')
+	}
+	if iterations > max_wire_iterations {
+		return error('scram: the iteration count must not exceed ${max_wire_iterations}, got ${iterations}')
 	}
 	salted := mechanism.hi(password.bytes(), salt, iterations)
 	client_key := mechanism.hmac(salted, 'Client Key'.bytes())

--- a/vlib/crypto/scram/scram_test.v
+++ b/vlib/crypto/scram/scram_test.v
@@ -1,0 +1,151 @@
+// Unit tests for the pieces of the module that do not need a full exchange.
+module scram
+
+import encoding.hex
+
+fn test_mechanism_names() {
+	assert Mechanism.sha1.name() == 'SCRAM-SHA-1'
+	assert Mechanism.sha256.name() == 'SCRAM-SHA-256'
+	assert Mechanism.sha512.name() == 'SCRAM-SHA-512'
+	assert Mechanism.sha256.name_plus() == 'SCRAM-SHA-256-PLUS'
+	assert Mechanism.sha1.size() == 20
+	assert Mechanism.sha256.size() == 32
+	assert Mechanism.sha512.size() == 64
+}
+
+fn test_mechanism_from_name_accepts_both_spellings() {
+	assert mechanism_from_name('SCRAM-SHA-1')! == .sha1
+	assert mechanism_from_name('SCRAM-SHA-256')! == .sha256
+	assert mechanism_from_name('SCRAM-SHA-512')! == .sha512
+	assert mechanism_from_name('SCRAM-SHA-256-PLUS')! == .sha256
+	assert mechanism_from_name('SCRAM-SHA-512-PLUS')! == .sha512
+}
+
+fn test_mechanism_from_name_rejects_the_rest() {
+	for name in ['', 'PLAIN', 'CRAM-MD5', 'scram-sha-256', 'SCRAM-SHA-224'] {
+		mechanism_from_name(name) or {
+			assert err.msg() == 'scram: unsupported mechanism: ${name}'
+			assert err is UnsupportedMechanism, name
+			continue
+		}
+		assert false, 'accepted the unsupported mechanism `${name}`'
+	}
+}
+
+fn test_new_credentials_generates_a_fresh_salt() {
+	first := new_credentials(.sha256, 'pencil')!
+	second := new_credentials(.sha256, 'pencil')!
+	assert first.salt.len == default_salt_size
+	assert first.iterations == default_iterations
+	assert first.stored_key.len == 32
+	assert first.server_key.len == 32
+	// The same password must not produce the same record twice, otherwise
+	// a stolen database would show which users share a password.
+	assert first.salt != second.salt
+	assert first.stored_key != second.stored_key
+}
+
+fn test_derive_credentials_rejects_unusable_parameters() {
+	derive_credentials(.sha256, 'pencil', []u8{}, 4096) or {
+		assert err.msg() == 'scram: the salt must not be empty'
+		derive_credentials(.sha256, 'pencil', 'salt'.bytes(), 0) or {
+			assert err.msg() == 'scram: the iteration count must be at least 1, got 0'
+			return
+		}
+		assert false, 'accepted a zero iteration count'
+	}
+	assert false, 'accepted an empty salt'
+}
+
+fn test_generated_nonces_are_unique_and_printable() {
+	mut seen := map[string]bool{}
+	for _ in 0 .. 256 {
+		nonce := generate_nonce()!
+		assert !seen[nonce], 'the CSPRNG repeated a nonce'
+		seen[nonce] = true
+		validate_nonce(nonce)!
+	}
+}
+
+fn test_xor_is_its_own_inverse() {
+	a := hex.decode('00112233445566778899aabbccddeeff')!
+	b := hex.decode('ffeeddccbbaa99887766554433221100')!
+	assert xor(xor(a, b), b) == a
+	assert xor(a, a) == []u8{len: a.len}
+}
+
+fn test_credentials_survive_a_storage_round_trip() {
+	for mechanism in [Mechanism.sha1, .sha256, .sha512] {
+		original := derive_credentials(mechanism, 'pencil', 'saltsaltsaltsalt'.bytes(), 4096)!
+		restored := parse_credentials(original.encode())!
+		assert restored.mechanism == original.mechanism, mechanism.name()
+		assert restored.salt == original.salt, mechanism.name()
+		assert restored.iterations == original.iterations, mechanism.name()
+		assert restored.stored_key == original.stored_key, mechanism.name()
+		assert restored.server_key == original.server_key, mechanism.name()
+	}
+}
+
+fn test_encode_matches_the_rfc_5803_layout() {
+	credentials := derive_credentials(.sha256, 'pencil', 'saltsaltsaltsalt'.bytes(), 4096)!
+	encoded := credentials.encode()
+	// mechanism $ iterations : salt $ stored : server
+	assert encoded.starts_with('SCRAM-SHA-256\$4096:c2FsdHNhbHRzYWx0c2FsdA==\$')
+	assert encoded.split('\$').len == 3
+	assert encoded.split('\$')[2].split(':').len == 2
+}
+
+fn test_parse_credentials_refuses_a_broken_record() {
+	good := derive_credentials(.sha256, 'pencil', 'saltsaltsaltsalt'.bytes(), 4096)!.encode()
+	parts := good.split('\$')
+	cases := {
+		'empty':                      ''
+		'no separators':              'SCRAM-SHA-256'
+		'one separator':              '${parts[0]}\$${parts[1]}'
+		'an unknown mechanism':       'SCRAM-MD5\$${parts[1]}\$${parts[2]}'
+		'a -PLUS mechanism':          'SCRAM-SHA-256-PLUS\$${parts[1]}\$${parts[2]}'
+		'no colon in the info':       '${parts[0]}\$4096\$${parts[2]}'
+		'no colon in the value':      '${parts[0]}\$${parts[1]}\$abcd'
+		'a zero iteration count':     '${parts[0]}\$0:c2FsdA==\$${parts[2]}'
+		'a salt that is not base64':  '${parts[0]}\$4096:not!base64\$${parts[2]}'
+		'an empty salt':              '${parts[0]}\$4096:\$${parts[2]}'
+		'keys of the wrong length':   '${parts[0]}\$${parts[1]}\$c2hvcnQ=:c2hvcnQ='
+		'keys for another mechanism': 'SCRAM-SHA-512\$${parts[1]}\$${parts[2]}'
+	}
+	for what, record in cases {
+		parse_credentials(record) or {
+			assert err is MalformedMessage || err is UnsupportedMechanism, '${what}: ${err}'
+			continue
+		}
+		assert false, 'accepted a record with ${what}'
+	}
+}
+
+fn test_secrets_are_not_rendered_by_str() {
+	// V formats structs automatically, so anything printed while debugging must
+	// not carry the password or the key material.
+	client := new_client(username: 'alice', password: 'sup3r-s3cret')!
+	assert !client.str().contains('sup3r-s3cret')
+	assert client.str().contains('alice')
+
+	credentials := derive_credentials(.sha256, 'sup3r-s3cret', 'saltsalt'.bytes(), 4096)!
+	rendered := '${credentials}'
+	assert !rendered.contains(credentials.server_key.hex())
+	assert !rendered.contains(credentials.stored_key.hex())
+	assert !rendered.contains('${credentials.server_key}')
+	assert rendered.contains('SCRAM-SHA-256')
+
+	mut server := new_server(
+		lookup: fn [credentials] (username string) !Credentials {
+			return credentials
+		}
+	)!
+	server.first(client_first_of('alice'))!
+	assert !server.str().contains('${credentials.server_key}')
+	assert server.str().contains('alice')
+}
+
+fn client_first_of(username string) string {
+	mut client := new_client(username: username, password: 'sup3r-s3cret') or { panic(err) }
+	return client.first() or { panic(err) }
+}

--- a/vlib/crypto/scram/scram_test.v
+++ b/vlib/crypto/scram/scram_test.v
@@ -57,6 +57,14 @@ fn test_derive_credentials_rejects_unusable_parameters() {
 	assert false, 'accepted an empty salt'
 }
 
+fn test_derive_credentials_rejects_an_iteration_count_above_the_wire_limit() {
+	derive_credentials(.sha256, 'pencil', 'salt'.bytes(), max_wire_iterations + 1) or {
+		assert err.msg().contains('must not exceed ${max_wire_iterations}')
+		return
+	}
+	assert false, 'derived credentials with an iteration count outside the wire grammar'
+}
+
 fn test_generated_nonces_are_unique_and_printable() {
 	mut seen := map[string]bool{}
 	for _ in 0 .. 256 {

--- a/vlib/crypto/scram/server.v
+++ b/vlib/crypto/scram/server.v
@@ -13,11 +13,18 @@ pub:
 	// mechanism selects the hash. It must match the mechanism the credentials
 	// returned by `lookup` were derived with.
 	mechanism Mechanism = .sha256
-	// channel_binding describes what this server offers. Set `mode` to
-	// `.required` when the server advertises a `-PLUS` mechanism: a client
-	// that then claims the server offered none is being downgraded, and the
-	// exchange is aborted.
+	// channel_binding describes what *this exchange* uses. Set `mode` to
+	// `.required` when the client picked the `-PLUS` mechanism, and leave it
+	// at the default when it picked the base one.
 	channel_binding ChannelBinding
+	// advertises_plus says whether this server offers a `-PLUS` mechanism at
+	// all, which is a different question from what this exchange uses: a
+	// server commonly lists both `SCRAM-SHA-256` and `SCRAM-SHA-256-PLUS` and
+	// lets the client choose. Set it to true whenever the `-PLUS` name is in
+	// the advertised list, including on the exchanges where the client chose
+	// the base mechanism — that is precisely where a stripped advertisement
+	// has to be detected. `mode: .required` implies it.
+	advertises_plus bool
 	// nonce overrides the generated server nonce. Leave it empty outside of
 	// tests.
 	nonce string
@@ -50,6 +57,7 @@ enum ServerState {
 pub struct Server {
 	mechanism       Mechanism
 	channel_binding ChannelBinding
+	advertises_plus bool
 	server_nonce    string
 	lookup          fn (username string) !Credentials = unsafe { nil }
 mut:
@@ -81,6 +89,7 @@ pub fn new_server(config ServerConfig) !&Server {
 	return &Server{
 		mechanism:       config.mechanism
 		channel_binding: config.channel_binding
+		advertises_plus: config.advertises_plus || config.channel_binding.mode == .required
 		server_nonce:    nonce
 		lookup:          config.lookup
 	}
@@ -254,7 +263,9 @@ pub fn (mut s Server) final(client_final string) !string {
 // check_cbind_flag compares the GS2 `cbind-flag` the client sent with what
 // this server offers. The `y` case is the downgrade check of RFC 5802 §6: a
 // client only sends it when the server advertised no `-PLUS` mechanism, so a
-// server that did advertise one knows the list was tampered with.
+// server that did advertise one knows the list was tampered with. Which is
+// why the check reads `advertises_plus` and not the mode: on an exchange
+// that runs the base mechanism the mode says nothing about the list.
 fn (s &Server) check_cbind_flag(gs2_header string) ! {
 	flag := gs2_header.all_before(',')
 	match s.channel_binding.mode {
@@ -274,6 +285,14 @@ fn (s &Server) check_cbind_flag(gs2_header string) ! {
 			if flag != 'n' && flag != 'y' {
 				return MalformedMessage{
 					reason: 'unknown GS2 channel binding flag `${flag}`'
+				}
+			}
+			// `y` asserts something about the mechanism list this server sent,
+			// and this server knows what it sent. `n` stays valid: a client
+			// that cannot do channel binding at all is not being downgraded.
+			if flag == 'y' && s.advertises_plus {
+				return AuthenticationFailed{
+					reason: 'the client claims this server advertises no -PLUS mechanism, but it does: the advertised list was altered in transit'
 				}
 			}
 		}

--- a/vlib/crypto/scram/server.v
+++ b/vlib/crypto/scram/server.v
@@ -173,6 +173,13 @@ pub fn (mut s Server) first(client_first string) !string {
 	if credentials.salt.len == 0 || credentials.iterations < 1 {
 		return error('scram: the stored credentials for `${username}` are incomplete')
 	}
+	// Keys of the wrong length would fail the proof check further down, which
+	// reports a wrong password: a misconfigured store must not be diagnosed as
+	// a user typing the wrong thing.
+	if credentials.stored_key.len != s.mechanism.size()
+		|| credentials.server_key.len != s.mechanism.size() {
+		return error('scram: the stored credentials for `${username}` hold ${credentials.stored_key.len} and ${credentials.server_key.len} byte keys, but ${s.mechanism.name()} needs ${s.mechanism.size()}')
+	}
 
 	s.username = username
 	s.authzid = authzid
@@ -298,6 +305,13 @@ fn split_gs2_header(client_first string) !(string, string, string) {
 			}
 		}
 		authzid = unescape_saslname(authzid_part[2..])!
+		// RFC 5802 §7 spells authzid as `a=` saslname, and saslname is `1*`:
+		// an `a=` that carries nothing is malformed, not an absent authzid.
+		if authzid == '' {
+			return MalformedMessage{
+				reason: 'the `a=` authorization identity of the GS2 header is empty'
+			}
+		}
 	}
 	return header, authzid, rest[authzid_end + 1..]
 }

--- a/vlib/crypto/scram/server.v
+++ b/vlib/crypto/scram/server.v
@@ -1,0 +1,303 @@
+// The server half of a SCRAM exchange: two calls, one per message the
+// server has to answer.
+module scram
+
+import crypto.subtle
+import encoding.base64
+
+// ServerConfig configures one server-side exchange. `lookup` is mandatory:
+// it is how the server obtains the credentials it stored for a user.
+@[params]
+pub struct ServerConfig {
+pub:
+	// mechanism selects the hash. It must match the mechanism the credentials
+	// returned by `lookup` were derived with.
+	mechanism Mechanism = .sha256
+	// channel_binding describes what this server offers. Set `mode` to
+	// `.required` when the server advertises a `-PLUS` mechanism: a client
+	// that then claims the server offered none is being downgraded, and the
+	// exchange is aborted.
+	channel_binding ChannelBinding
+	// nonce overrides the generated server nonce. Leave it empty outside of
+	// tests.
+	nonce string
+	// lookup returns the credentials stored for `username`, which arrives
+	// already unescaped.
+	//
+	// Returning an error aborts the exchange; the caller should then answer
+	// `server_error_message('unknown-user')`. Note that doing so tells an
+	// attacker which user names exist. RFC 5802 §7 suggests answering unknown
+	// users with credentials derived from a server-side secret instead, so
+	// that they are indistinguishable from a wrong password — that policy
+	// belongs to the application, which is why it lives in this callback.
+	lookup fn (username string) !Credentials @[required]
+}
+
+// ServerState tracks which message the server expects next.
+enum ServerState {
+	awaiting_client_first
+	awaiting_client_final
+	done
+	// failed is entered by any step that does not run to completion, so that a
+	// rejected client cannot try another proof against the same nonce.
+	failed
+}
+
+// Server drives the server side of one SCRAM exchange. Create it with
+// `new_server`, then call `first` and `final` in that order. It is not safe
+// to share between threads; use one value per connection.
+@[heap]
+pub struct Server {
+	mechanism       Mechanism
+	channel_binding ChannelBinding
+	server_nonce    string
+	lookup          fn (username string) !Credentials = unsafe { nil }
+mut:
+	username     string
+	authzid      string
+	gs2_header   string
+	nonce        string
+	credentials  Credentials
+	auth_message string
+	state        ServerState = .awaiting_client_first
+}
+
+// new_server creates a server for one SCRAM exchange.
+//
+// Example:
+// ```v
+// creds := scram.new_credentials(.sha256, 'pencil')!
+// mut server := scram.new_server(lookup: fn [creds] (username string) !scram.Credentials {
+// 	return creds
+// })!
+// assert server.mechanism_name() == 'SCRAM-SHA-256'
+// ```
+pub fn new_server(config ServerConfig) !&Server {
+	nonce := if config.nonce == '' { generate_nonce()! } else { config.nonce }
+	validate_nonce(nonce)!
+	// Rendering the header once here surfaces an incomplete channel binding
+	// configuration at construction time rather than mid-exchange.
+	config.channel_binding.gs2_flag()!
+	return &Server{
+		mechanism:       config.mechanism
+		channel_binding: config.channel_binding
+		server_nonce:    nonce
+		lookup:          config.lookup
+	}
+}
+
+// str renders a Server without its secrets, for the same reason as
+// `Client.str`: the credentials it holds must not reach a log through an
+// incidental `println`.
+pub fn (s &Server) str() string {
+	return 'scram.Server{ mechanism: ${s.mechanism_name()}, username: ${s.username}, state: ${s.state} }'
+}
+
+// mechanism_name returns the SASL mechanism name this server implements,
+// which is the `-PLUS` spelling when it requires channel binding.
+pub fn (s &Server) mechanism_name() string {
+	if s.channel_binding.mode == .required {
+		return s.mechanism.name_plus()
+	}
+	return s.mechanism.name()
+}
+
+// username returns the authentication identity the client sent, unescaped.
+// It is only meaningful once `first` has returned, and only trustworthy once
+// `final` has succeeded.
+pub fn (s &Server) username() string {
+	return s.username
+}
+
+// authzid returns the authorization identity the client asked for, or an
+// empty string when it did not ask for one. Authorizing it is the
+// application's job: SCRAM only proves who the client is, never what it may
+// act as.
+pub fn (s &Server) authzid() string {
+	return s.authzid
+}
+
+// done reports whether the exchange finished successfully.
+pub fn (s &Server) done() bool {
+	return s.state == .done
+}
+
+// server_error_message renders a server-final-message that refuses the
+// exchange, as defined by RFC 5802 §7. Common codes are `invalid-proof`,
+// `unknown-user` and `invalid-encoding`; a client surfaces the value as a
+// `ServerError`.
+pub fn server_error_message(code string) string {
+	if code == '' || code.contains(',') {
+		return 'e=other-error'
+	}
+	return 'e=${code}'
+}
+
+// first consumes the client-first-message and returns the
+// server-first-message, which carries the user's salt, the iteration count
+// and the combined nonce.
+pub fn (mut s Server) first(client_first string) !string {
+	if s.state != .awaiting_client_first {
+		return error('scram: first() must be called exactly once, with the client-first-message')
+	}
+	s.state = .failed
+	gs2_header, authzid, bare := split_gs2_header(client_first)!
+	s.check_cbind_flag(gs2_header)!
+	attrs := parse_attributes(bare)!
+	if attrs[0].key == `m` {
+		return MalformedMessage{
+			reason: 'the client requires the unsupported mandatory extension `${attrs[0].value}`'
+		}
+	}
+	if attrs.len < 2 || attrs[0].key != `n` || attrs[1].key != `r` {
+		return MalformedMessage{
+			reason: 'the client-first-message must be `n=`, then `r=`'
+		}
+	}
+	username := unescape_saslname(attrs[0].value)!
+	if username == '' {
+		return MalformedMessage{
+			reason: 'the user name must not be empty'
+		}
+	}
+	client_nonce := attrs[1].value
+	validate_nonce(client_nonce) or {
+		return MalformedMessage{
+			reason: 'the client nonce is not a printable string'
+		}
+	}
+	credentials := s.lookup(username)!
+	if credentials.mechanism != s.mechanism {
+		return error('scram: the stored credentials for `${username}` are for ${credentials.mechanism.name()}, but this server speaks ${s.mechanism.name()}')
+	}
+	if credentials.salt.len == 0 || credentials.iterations < 1 {
+		return error('scram: the stored credentials for `${username}` are incomplete')
+	}
+
+	s.username = username
+	s.authzid = authzid
+	s.gs2_header = gs2_header
+	s.credentials = credentials
+	s.nonce = '${client_nonce}${s.server_nonce}'
+	server_first := 'r=${s.nonce},s=${base64.encode(credentials.salt)},i=${credentials.iterations}'
+	s.auth_message = '${bare},${server_first}'
+	s.state = .awaiting_client_final
+	return server_first
+}
+
+// final consumes the client-final-message, checks the client's proof and
+// returns the server-final-message. An `AuthenticationFailed` here means a
+// wrong password; answer the client with
+// `server_error_message('invalid-proof')` rather than closing silently, so
+// that it can tell a refusal from a broken connection.
+pub fn (mut s Server) final(client_final string) !string {
+	if s.state != .awaiting_client_final {
+		return error('scram: final() must be called once, after first(), with the client-final-message')
+	}
+	s.state = .failed
+	attrs := parse_attributes(client_final)!
+	if attrs.len < 3 || attrs[0].key != `c` || attrs[1].key != `r` {
+		return MalformedMessage{
+			reason: 'the client-final-message must be `c=`, then `r=`, then `p=`'
+		}
+	}
+	last := attrs[attrs.len - 1]
+	if last.key != `p` {
+		return MalformedMessage{
+			reason: 'the client-final-message must end with `p=`'
+		}
+	}
+	// The client echoes the GS2 header it actually sent. Comparing it with the
+	// one received in the client-first-message is what makes a rewritten
+	// header — a stripped channel binding, an injected authzid — detectable.
+	expected_cbind := base64.encode(s.channel_binding.cbind_input(s.gs2_header))
+	if attrs[0].value != expected_cbind {
+		return AuthenticationFailed{
+			reason: 'the channel binding data does not match the GS2 header of the client-first-message'
+		}
+	}
+	if attrs[1].value != s.nonce {
+		return AuthenticationFailed{
+			reason: 'the client nonce does not match the one of this exchange'
+		}
+	}
+	proof := decode_base64(last.value, 'the client proof')!
+	if proof.len != s.mechanism.size() {
+		return AuthenticationFailed{
+			reason: 'the client proof is ${proof.len} bytes, expected ${s.mechanism.size()}'
+		}
+	}
+
+	without_proof := client_final#[..-(last.value.len + 3)]
+	auth_message := '${s.auth_message},${without_proof}'
+	client_signature := s.mechanism.hmac(s.credentials.stored_key, auth_message.bytes())
+	// ClientKey is recovered from the proof, then hashed: the result must be
+	// the StoredKey, which is all the server keeps. See RFC 5802 §3.
+	client_key := xor(proof, client_signature)
+	if subtle.constant_time_compare(s.mechanism.hash(client_key), s.credentials.stored_key) != 1 {
+		return AuthenticationFailed{
+			reason: 'the client proof does not match the stored key'
+		}
+	}
+	s.state = .done
+	signature := s.mechanism.hmac(s.credentials.server_key, auth_message.bytes())
+	return 'v=${base64.encode(signature)}'
+}
+
+// check_cbind_flag compares the GS2 `cbind-flag` the client sent with what
+// this server offers. The `y` case is the downgrade check of RFC 5802 §6: a
+// client only sends it when the server advertised no `-PLUS` mechanism, so a
+// server that did advertise one knows the list was tampered with.
+fn (s &Server) check_cbind_flag(gs2_header string) ! {
+	flag := gs2_header.all_before(',')
+	match s.channel_binding.mode {
+		.required {
+			if flag != 'p=${s.channel_binding.name}' {
+				return AuthenticationFailed{
+					reason: 'this server requires the `${s.channel_binding.name}` channel binding, but the client sent `${flag}`'
+				}
+			}
+		}
+		.not_supported, .unsupported_by_server {
+			if flag.starts_with('p=') {
+				return MalformedMessage{
+					reason: 'the client asked for the `${flag#[2..]}` channel binding, which this server does not offer'
+				}
+			}
+			if flag != 'n' && flag != 'y' {
+				return MalformedMessage{
+					reason: 'unknown GS2 channel binding flag `${flag}`'
+				}
+			}
+		}
+	}
+}
+
+// split_gs2_header splits a client-first-message into its GS2 header, the
+// authorization identity that header carries, and the
+// client-first-message-bare that follows it.
+fn split_gs2_header(client_first string) !(string, string, string) {
+	flag_end := client_first.index(',') or {
+		return MalformedMessage{
+			reason: 'the client-first-message has no GS2 header'
+		}
+	}
+	rest := client_first[flag_end + 1..]
+	authzid_end := rest.index(',') or {
+		return MalformedMessage{
+			reason: 'the GS2 header of the client-first-message is incomplete'
+		}
+	}
+	header := client_first[..flag_end + authzid_end + 2]
+	authzid_part := rest[..authzid_end]
+	mut authzid := ''
+	if authzid_part != '' {
+		if !authzid_part.starts_with('a=') {
+			return MalformedMessage{
+				reason: 'expected `a=` in the GS2 header, got `${authzid_part}`'
+			}
+		}
+		authzid = unescape_saslname(authzid_part[2..])!
+	}
+	return header, authzid, rest[authzid_end + 1..]
+}

--- a/vlib/crypto/scram/server.v
+++ b/vlib/crypto/scram/server.v
@@ -35,12 +35,12 @@ pub:
 	// lookup returns the credentials stored for `username`, which arrives
 	// already unescaped and prepared.
 	//
-	// Returning an error aborts the exchange; the caller should then answer
-	// `server_error_message('unknown-user')`. Note that doing so tells an
-	// attacker which user names exist. RFC 5802 §7 suggests answering unknown
-	// users with credentials derived from a server-side secret instead, so
-	// that they are indistinguishable from a wrong password — that policy
-	// belongs to the application, which is why it lives in this callback.
+	// Returning an error aborts the exchange before a server challenge exists;
+	// report that through the enclosing SASL protocol, not as a SCRAM
+	// server-final-message. To avoid revealing which user names exist, RFC 5802
+	// §7 suggests returning credentials derived from a server-side secret for
+	// unknown users and continuing the exchange. That policy belongs to the
+	// application, which is why it lives in this callback.
 	lookup fn (username string) !Credentials @[required]
 }
 

--- a/vlib/crypto/scram/server.v
+++ b/vlib/crypto/scram/server.v
@@ -136,7 +136,7 @@ pub fn (s &Server) done() bool {
 // `unknown-user` and `invalid-encoding`; a client surfaces the value as a
 // `ServerError`.
 pub fn server_error_message(code string) string {
-	if code == '' || !code.bytes().all(it.is_alnum() || it in [`.`, `-`, `_`]) {
+	if !is_server_error_value(code) {
 		return 'e=other-error'
 	}
 	return 'e=${code}'

--- a/vlib/crypto/scram/server.v
+++ b/vlib/crypto/scram/server.v
@@ -28,8 +28,12 @@ pub:
 	// nonce overrides the generated server nonce. Leave it empty outside of
 	// tests.
 	nonce string
+	// prepare_username applies SASLprep (RFC 4013) to the authentication identity
+	// before `lookup`. When omitted, the server accepts only printable ASCII,
+	// whose SASLprep form is unchanged; non-ASCII identities require a callback.
+	prepare_username fn (username string) !string = unsafe { nil }
 	// lookup returns the credentials stored for `username`, which arrives
-	// already unescaped.
+	// already unescaped and prepared.
 	//
 	// Returning an error aborts the exchange; the caller should then answer
 	// `server_error_message('unknown-user')`. Note that doing so tells an
@@ -60,6 +64,7 @@ pub struct Server {
 	advertises_plus bool
 	server_nonce    string
 	lookup          fn (username string) !Credentials = unsafe { nil }
+	prepare_username fn (username string) !string = unsafe { nil }
 mut:
 	username     string
 	authzid      string
@@ -92,7 +97,21 @@ pub fn new_server(config ServerConfig) !&Server {
 		advertises_plus: config.advertises_plus || config.channel_binding.mode == .required
 		server_nonce:    nonce
 		lookup:          config.lookup
+		prepare_username: if config.prepare_username == unsafe { nil } {
+			prepare_ascii_username
+		} else {
+			config.prepare_username
+		}
 	}
+}
+
+fn prepare_ascii_username(username string) !string {
+	for c in username.bytes() {
+		if c < ` ` || c > `~` {
+			return error('non-ASCII and control characters require ServerConfig.prepare_username with SASLprep')
+		}
+	}
+	return username
 }
 
 // str renders a Server without its secrets, for the same reason as
@@ -111,7 +130,7 @@ pub fn (s &Server) mechanism_name() string {
 	return s.mechanism.name()
 }
 
-// username returns the authentication identity the client sent, unescaped.
+// username returns the authentication identity the client sent, unescaped and prepared.
 // It is only meaningful once `first` has returned, and only trustworthy once
 // `final` has succeeded.
 pub fn (s &Server) username() string {
@@ -163,7 +182,12 @@ pub fn (mut s Server) first(client_first string) !string {
 			reason: 'the client-first-message must be `n=`, then `r=`'
 		}
 	}
-	username := unescape_saslname(attrs[0].value)!
+	wire_username := unescape_saslname(attrs[0].value)!
+	username := s.prepare_username(wire_username) or {
+		return MalformedMessage{
+			reason: 'invalid user name: ${err.msg()}'
+		}
+	}
 	if username == '' {
 		return MalformedMessage{
 			reason: 'the user name must not be empty'

--- a/vlib/crypto/scram/server.v
+++ b/vlib/crypto/scram/server.v
@@ -206,6 +206,9 @@ pub fn (mut s Server) first(client_first string) !string {
 	if credentials.salt.len == 0 || credentials.iterations < 1 {
 		return error('scram: the stored credentials for `${username}` are incomplete')
 	}
+	if credentials.iterations > max_wire_iterations {
+		return error('scram: the stored credentials for `${username}` use ${credentials.iterations} iterations, above the SCRAM wire maximum of ${max_wire_iterations}')
+	}
 	// Keys of the wrong length would fail the proof check further down, which
 	// reports a wrong password: a misconfigured store must not be diagnosed as
 	// a user typing the wrong thing.

--- a/vlib/crypto/scram/server.v
+++ b/vlib/crypto/scram/server.v
@@ -136,7 +136,7 @@ pub fn (s &Server) done() bool {
 // `unknown-user` and `invalid-encoding`; a client surfaces the value as a
 // `ServerError`.
 pub fn server_error_message(code string) string {
-	if code == '' || code.contains(',') {
+	if code == '' || !code.bytes().all(it.is_alnum() || it in [`.`, `-`, `_`]) {
 		return 'e=other-error'
 	}
 	return 'e=${code}'

--- a/vlib/crypto/scram/server.v
+++ b/vlib/crypto/scram/server.v
@@ -32,6 +32,11 @@ pub:
 	// before `lookup`. When omitted, the server accepts only printable ASCII,
 	// whose SASLprep form is unchanged; non-ASCII identities require a callback.
 	prepare_username fn (username string) !string = unsafe { nil }
+	// prepare_authzid applies the application protocol's preparation profile to
+	// a requested authorization identity before `authzid()` exposes it. When
+	// omitted, only printable ASCII is accepted. The callback is not called when
+	// the client sends no authorization identity.
+	prepare_authzid fn (authzid string) !string = unsafe { nil }
 	// lookup returns the credentials stored for `username`, which arrives
 	// already unescaped and prepared.
 	//
@@ -63,8 +68,9 @@ pub struct Server {
 	channel_binding ChannelBinding
 	advertises_plus bool
 	server_nonce    string
-	lookup          fn (username string) !Credentials = unsafe { nil }
+	lookup           fn (username string) !Credentials = unsafe { nil }
 	prepare_username fn (username string) !string = unsafe { nil }
+	prepare_authzid  fn (authzid string) !string = unsafe { nil }
 mut:
 	username     string
 	authzid      string
@@ -102,16 +108,30 @@ pub fn new_server(config ServerConfig) !&Server {
 		} else {
 			config.prepare_username
 		}
+		prepare_authzid: if config.prepare_authzid == unsafe { nil } {
+			prepare_ascii_authzid
+		} else {
+			config.prepare_authzid
+		}
 	}
 }
 
 fn prepare_ascii_username(username string) !string {
-	for c in username.bytes() {
+	return prepare_ascii_identity(username, 'prepare_username with SASLprep')
+}
+
+fn prepare_ascii_authzid(authzid string) !string {
+	return prepare_ascii_identity(authzid,
+		"prepare_authzid with the application protocol's preparation profile")
+}
+
+fn prepare_ascii_identity(identity string, config_hint string) !string {
+	for c in identity.bytes() {
 		if c < ` ` || c > `~` {
-			return error('non-ASCII and control characters require ServerConfig.prepare_username with SASLprep')
+			return error('non-ASCII and control characters require ServerConfig.${config_hint}')
 		}
 	}
-	return username
+	return identity
 }
 
 // str renders a Server without its secrets, for the same reason as
@@ -137,10 +157,10 @@ pub fn (s &Server) username() string {
 	return s.username
 }
 
-// authzid returns the authorization identity the client asked for, or an
-// empty string when it did not ask for one. Authorizing it is the
-// application's job: SCRAM only proves who the client is, never what it may
-// act as.
+// authzid returns the authorization identity the client asked for, unescaped
+// and prepared by `ServerConfig.prepare_authzid`, or an empty string when it
+// did not ask for one. Authorizing it is the application's job: SCRAM only
+// proves who the client is, never what it may act as.
 pub fn (s &Server) authzid() string {
 	return s.authzid
 }
@@ -169,8 +189,22 @@ pub fn (mut s Server) first(client_first string) !string {
 		return error('scram: first() must be called exactly once, with the client-first-message')
 	}
 	s.state = .failed
-	gs2_header, authzid, bare := split_gs2_header(client_first)!
+	gs2_header, wire_authzid, bare := split_gs2_header(client_first)!
 	s.check_cbind_flag(gs2_header)!
+	authzid := if wire_authzid == '' {
+		''
+	} else {
+		s.prepare_authzid(wire_authzid) or {
+			return MalformedMessage{
+				reason: 'invalid authorization identity: ${err.msg()}'
+			}
+		}
+	}
+	if wire_authzid != '' && authzid == '' {
+		return MalformedMessage{
+			reason: 'the prepared authorization identity must not be empty'
+		}
+	}
 	attrs := parse_attributes(bare)!
 	if attrs[0].key == `m` {
 		return MalformedMessage{

--- a/vlib/crypto/scram/server_test.v
+++ b/vlib/crypto/scram/server_test.v
@@ -1,0 +1,401 @@
+// Server behaviour: the checks that stand between a server and a client that
+// guesses, replays or rewrites parts of the exchange.
+module scram
+
+import encoding.base64
+
+// pencil_credentials is the record a server would have stored for `user`.
+fn pencil_credentials(mechanism Mechanism) Credentials {
+	return derive_credentials(mechanism, 'pencil', 'saltsaltsaltsalt'.bytes(), 4096) or {
+		panic(err)
+	}
+}
+
+// server_for builds a server that knows exactly one user.
+fn server_for(mechanism Mechanism, binding ChannelBinding) &Server {
+	creds := pencil_credentials(mechanism)
+	return new_server(
+		mechanism:       mechanism
+		channel_binding: binding
+		lookup:          fn [creds] (username string) !Credentials {
+			return creds
+		}
+	) or { panic(err) }
+}
+
+// run_exchange drives both halves and returns the two clients' view of it.
+fn run_exchange(mut client Client, mut server Server) ! {
+	server_first := server.first(client.first()!)!
+	server_final := server.final(client.final(server_first)!)!
+	client.verify(server_final)!
+}
+
+fn test_a_full_exchange_succeeds_for_every_mechanism() {
+	for mechanism in [Mechanism.sha1, .sha256, .sha512] {
+		mut server := server_for(mechanism, ChannelBinding{})
+		mut client := new_client(username: 'user', password: 'pencil', mechanism: mechanism)!
+		run_exchange(mut client, mut server) or { assert false, '${mechanism.name()}: ${err}' }
+		assert client.done(), mechanism.name()
+		assert server.done(), mechanism.name()
+		assert server.username() == 'user', mechanism.name()
+	}
+}
+
+fn test_a_full_exchange_succeeds_with_a_randomly_salted_record() {
+	creds := new_credentials(.sha256, 'pencil')!
+	mut server := new_server(
+		lookup: fn [creds] (username string) !Credentials {
+			return creds
+		}
+	)!
+	mut client := new_client(username: 'user', password: 'pencil')!
+	run_exchange(mut client, mut server)!
+	assert client.done() && server.done()
+}
+
+fn test_a_full_exchange_succeeds_with_channel_binding() {
+	binding := ChannelBinding{
+		mode: .required
+		name: 'tls-server-end-point'
+		data: 'a hash of the server certificate'.bytes()
+	}
+	mut server := server_for(.sha256, binding)
+	mut client := new_client(
+		username:        'user'
+		password:        'pencil'
+		channel_binding: binding
+	)!
+	run_exchange(mut client, mut server)!
+	assert client.mechanism_name() == 'SCRAM-SHA-256-PLUS'
+	assert server.mechanism_name() == 'SCRAM-SHA-256-PLUS'
+}
+
+fn test_a_full_exchange_carries_the_authorization_identity() {
+	mut server := server_for(.sha256, ChannelBinding{})
+	mut client := new_client(username: 'user', password: 'pencil', authzid: 'admin,role=x')!
+	run_exchange(mut client, mut server)!
+	assert server.authzid() == 'admin,role=x'
+	assert server.username() == 'user'
+}
+
+fn test_a_full_exchange_carries_an_escaped_user_name() {
+	creds := pencil_credentials(.sha256)
+	mut server := new_server(
+		lookup: fn [creds] (username string) !Credentials {
+			assert username == 'a,b=c'
+			return creds
+		}
+	)!
+	mut client := new_client(username: 'a,b=c', password: 'pencil')!
+	run_exchange(mut client, mut server)!
+	assert server.username() == 'a,b=c'
+}
+
+fn test_a_wrong_password_is_refused() {
+	mut server := server_for(.sha256, ChannelBinding{})
+	mut client := new_client(username: 'user', password: 'crayon')!
+	run_exchange(mut client, mut server) or {
+		assert err.msg().contains('client proof does not match')
+		assert err is AuthenticationFailed
+		assert !server.done()
+		return
+	}
+	assert false, 'a wrong password was accepted'
+}
+
+fn test_an_unknown_user_aborts_the_exchange() {
+	mut server := new_server(
+		lookup: fn (username string) !Credentials {
+			return error('no such user: ${username}')
+		}
+	)!
+	mut client := new_client(username: 'ghost', password: 'pencil')!
+	server.first(client.first()!) or {
+		assert err.msg() == 'no such user: ghost'
+		return
+	}
+	assert false, 'an unknown user was let through'
+}
+
+fn test_credentials_for_another_mechanism_are_refused() {
+	creds := pencil_credentials(.sha1)
+	mut server := new_server(
+		mechanism: .sha256
+		lookup:    fn [creds] (username string) !Credentials {
+			return creds
+		}
+	)!
+	mut client := new_client(username: 'user', password: 'pencil')!
+	server.first(client.first()!) or {
+		assert err.msg().contains('are for SCRAM-SHA-1, but this server speaks SCRAM-SHA-256')
+		return
+	}
+	assert false, 'mismatched credentials were used'
+}
+
+fn test_incomplete_credentials_are_refused() {
+	for creds in [
+		Credentials{
+			mechanism:  .sha256
+			salt:       []u8{}
+			iterations: 4096
+		},
+		Credentials{
+			mechanism:  .sha256
+			salt:       'salt'.bytes()
+			iterations: 0
+		},
+	] {
+		mut server := new_server(
+			lookup: fn [creds] (username string) !Credentials {
+				return creds
+			}
+		)!
+		mut client := new_client(username: 'user', password: 'pencil')!
+		server.first(client.first()!) or {
+			assert err.msg().contains('incomplete')
+			continue
+		}
+		assert false, 'incomplete credentials were used'
+	}
+}
+
+fn test_the_steps_must_be_called_in_order() {
+	mut server := server_for(.sha256, ChannelBinding{})
+	server.final('c=biws,r=x,p=y') or {
+		assert err.msg().contains('final() must be called once, after first()')
+		mut client := new_client(username: 'user', password: 'pencil')!
+		first := client.first()!
+		server.first(first)!
+		server.first(first) or {
+			assert err.msg().contains('first() must be called exactly once')
+			return
+		}
+		assert false, 'first() ran twice'
+	}
+	assert false, 'final() ran before first()'
+}
+
+fn test_a_malformed_client_first_message_is_refused() {
+	cases := {
+		'empty':                    ''
+		'no GS2 header':            'n=user'
+		'an incomplete GS2 header': 'n,n=user,r=abc'
+		'an unknown GS2 flag':      'z,,n=user,r=abc'
+		'a bad authzid marker':     'n,zz,n=user,r=abc'
+		'a missing user name':      'n,,r=abc'
+		'an empty user name':       'n,,n=,r=abc'
+		'a missing nonce':          'n,,n=user'
+		'a bad escape in the name': 'n,,n=a=FFb,r=abc'
+		'a mandatory extension':    'n,,m=feature,n=user,r=abc'
+		'a nonce with a space':     'n,,n=user,r=a b'
+	}
+	for what, client_first in cases {
+		mut server := server_for(.sha256, ChannelBinding{})
+		server.first(client_first) or {
+			assert err is MalformedMessage, '${what}: ${err}'
+			continue
+		}
+		assert false, 'accepted a client-first-message with ${what}'
+	}
+}
+
+fn test_a_malformed_client_final_message_is_refused() {
+	cases := {
+		'empty':                      ''
+		'a missing channel binding':  'r=NONCE,p=AAAA'
+		'a missing proof':            'c=biws,r=NONCE'
+		'the proof not last':         'c=biws,p=AAAA,r=NONCE'
+		'a proof that is not base64': 'c=biws,r=NONCE,p=not!base64'
+	}
+	for what, template in cases {
+		mut server := server_for(.sha256, ChannelBinding{})
+		mut client := new_client(username: 'user', password: 'pencil')!
+		server_first := server.first(client.first()!)!
+		nonce := server_first.all_after('r=').all_before(',')
+		server.final(template.replace('NONCE', nonce)) or {
+			assert err is MalformedMessage, '${what}: ${err}'
+			continue
+		}
+		assert false, 'accepted a client-final-message with ${what}'
+	}
+}
+
+fn test_a_proof_of_the_wrong_length_is_refused() {
+	mut server := server_for(.sha256, ChannelBinding{})
+	mut client := new_client(username: 'user', password: 'pencil')!
+	server_first := server.first(client.first()!)!
+	nonce := server_first.all_after('r=').all_before(',')
+	server.final('c=biws,r=${nonce},p=${base64.encode([u8(1), 2, 3])}') or {
+		assert err.msg().contains('is 3 bytes, expected 32')
+		assert err is AuthenticationFailed
+		return
+	}
+	assert false, 'accepted a short proof'
+}
+
+fn test_a_replayed_nonce_from_another_exchange_is_refused() {
+	mut server := server_for(.sha256, ChannelBinding{})
+	mut client := new_client(username: 'user', password: 'pencil')!
+	server.first(client.first()!)!
+	// A client-final-message that is internally consistent, but built on the
+	// nonce of a different exchange.
+	mut other_server := server_for(.sha256, ChannelBinding{})
+	mut other_client := new_client(username: 'user', password: 'pencil')!
+	other_first := other_server.first(other_client.first()!)!
+	stolen := other_client.final(other_first)!
+	server.final(stolen) or {
+		assert err.msg().contains('nonce does not match')
+		assert err is AuthenticationFailed
+		return
+	}
+	assert false, 'a message from another exchange was accepted'
+}
+
+fn test_a_rewritten_channel_binding_is_refused() {
+	mut server := server_for(.sha256, ChannelBinding{})
+	mut client := new_client(username: 'user', password: 'pencil')!
+	server_first := server.first(client.first()!)!
+	final := client.final(server_first)!
+	// `biws` is base64 of `n,,`; swap it for the base64 of a header claiming an
+	// authorization identity the client never asked for.
+	forged := final.replace('c=biws,', 'c=${base64.encode('n,a=root,'.bytes())},')
+	server.final(forged) or {
+		assert err.msg().contains('channel binding data does not match')
+		assert err is AuthenticationFailed
+		return
+	}
+	assert false, 'a rewritten GS2 header was accepted'
+}
+
+fn test_a_stripped_channel_binding_is_detected_as_a_downgrade() {
+	// The server offers -PLUS, so a client that claims it did not is either
+	// broken or being downgraded by something in the middle.
+	binding := ChannelBinding{
+		mode: .required
+		name: 'tls-server-end-point'
+		data: 'binding data'.bytes()
+	}
+	mut server := server_for(.sha256, binding)
+	mut client := new_client(
+		username:        'user'
+		password:        'pencil'
+		channel_binding: ChannelBinding{
+			mode: .unsupported_by_server
+		}
+	)!
+	server.first(client.first()!) or {
+		assert err.msg().contains('requires the `tls-server-end-point` channel binding')
+		assert err is AuthenticationFailed
+		return
+	}
+	assert false, 'a downgraded exchange was accepted'
+}
+
+fn test_a_channel_binding_the_server_does_not_offer_is_refused() {
+	mut server := server_for(.sha256, ChannelBinding{})
+	mut client := new_client(
+		username:        'user'
+		password:        'pencil'
+		channel_binding: ChannelBinding{
+			mode: .required
+			name: 'tls-exporter'
+			data: 'binding data'.bytes()
+		}
+	)!
+	server.first(client.first()!) or {
+		assert err.msg().contains('`tls-exporter` channel binding, which this server does not offer')
+		assert err is MalformedMessage
+		return
+	}
+	assert false, 'accepted a channel binding the server does not offer'
+}
+
+fn test_a_different_binding_type_is_refused() {
+	mut server := server_for(.sha256, ChannelBinding{
+		mode: .required
+		name: 'tls-server-end-point'
+		data: 'binding data'.bytes()
+	})
+	mut client := new_client(
+		username:        'user'
+		password:        'pencil'
+		channel_binding: ChannelBinding{
+			mode: .required
+			name: 'tls-exporter'
+			data: 'binding data'.bytes()
+		}
+	)!
+	server.first(client.first()!) or {
+		assert err is AuthenticationFailed
+		return
+	}
+	assert false, 'accepted a mismatched channel binding type'
+}
+
+fn test_different_binding_data_is_refused() {
+	// Same type on both sides, different data: this is the case channel
+	// binding exists for, a proxy terminating TLS in the middle.
+	mut server := server_for(.sha256, ChannelBinding{
+		mode: .required
+		name: 'tls-server-end-point'
+		data: 'the real certificate'.bytes()
+	})
+	mut client := new_client(
+		username:        'user'
+		password:        'pencil'
+		channel_binding: ChannelBinding{
+			mode: .required
+			name: 'tls-server-end-point'
+			data: 'the proxy certificate'.bytes()
+		}
+	)!
+	server_first := server.first(client.first()!)!
+	server.final(client.final(server_first)!) or {
+		assert err.msg().contains('channel binding data does not match')
+		assert err is AuthenticationFailed
+		return
+	}
+	assert false, 'accepted an exchange bound to a different channel'
+}
+
+fn test_server_error_message_renders_a_refusal() {
+	assert server_error_message('invalid-proof') == 'e=invalid-proof'
+	assert server_error_message('unknown-user') == 'e=unknown-user'
+	// A code that would break the grammar is replaced rather than emitted.
+	assert server_error_message('') == 'e=other-error'
+	assert server_error_message('has,comma') == 'e=other-error'
+}
+
+fn test_a_refusal_travels_to_the_client() {
+	mut server := server_for(.sha256, ChannelBinding{})
+	mut client := new_client(username: 'user', password: 'crayon')!
+	server_first := server.first(client.first()!)!
+	final := client.final(server_first)!
+	refusal := server.final(final) or { server_error_message('invalid-proof') }
+	client.verify(refusal) or {
+		assert err is ServerError
+		return
+	}
+	assert false, 'the client did not see the refusal'
+}
+
+fn test_a_rejected_client_cannot_try_another_proof() {
+	// One Server value is one exchange. Letting a rejected client send a second
+	// proof would turn a fixed nonce into an offline guessing oracle.
+	mut server := server_for(.sha256, ChannelBinding{})
+	mut client := new_client(username: 'user', password: 'crayon')!
+	server_first := server.first(client.first()!)!
+	server.final(client.final(server_first)!) or {
+		assert !server.done()
+		mut honest := new_client(username: 'user', password: 'pencil', nonce: 'x')!
+		honest.first()!
+		second_try := honest.final(server_first) or { '' }
+		server.final(second_try) or {
+			assert err.msg().contains('final() must be called once')
+			return
+		}
+		assert false, 'the server accepted a second proof'
+	}
+	assert false, 'a wrong password was accepted'
+}

--- a/vlib/crypto/scram/server_test.v
+++ b/vlib/crypto/scram/server_test.v
@@ -91,6 +91,38 @@ fn test_a_full_exchange_carries_an_escaped_user_name() {
 	assert server.username() == 'a,b=c'
 }
 
+fn test_the_server_prepares_the_username_before_lookup() {
+	creds := pencil_credentials(.sha256)
+	mut server := new_server(
+		nonce: 'servernonce'
+		prepare_username: fn (username string) !string {
+			return username.replace('\u00ad', '')
+		}
+		lookup: fn [creds] (username string) !Credentials {
+			assert username == 'IX'
+			return creds
+		}
+	)!
+	server.first('n,,n=I\u00adX,r=clientnonce')!
+	assert server.username() == 'IX'
+}
+
+fn test_the_server_rejects_unprepared_non_ascii_usernames_by_default() {
+	creds := pencil_credentials(.sha256)
+	mut server := new_server(
+		nonce:  'servernonce'
+		lookup: fn [creds] (username string) !Credentials {
+			return creds
+		}
+	)!
+	server.first('n,,n=I\u00adX,r=clientnonce') or {
+		assert err is MalformedMessage
+		assert err.msg().contains('ServerConfig.prepare_username with SASLprep')
+		return
+	}
+	assert false, 'accepted an unprepared non-ASCII username'
+}
+
 fn test_a_wrong_password_is_refused() {
 	mut server := server_for(.sha256, ChannelBinding{})
 	mut client := new_client(username: 'user', password: 'crayon')!

--- a/vlib/crypto/scram/server_test.v
+++ b/vlib/crypto/scram/server_test.v
@@ -192,6 +192,25 @@ fn test_incomplete_credentials_are_refused() {
 	}
 }
 
+fn test_stored_iteration_count_must_fit_the_wire_grammar() {
+	base := pencil_credentials(.sha256)
+	creds := Credentials{
+		...base
+		iterations: max_wire_iterations + 1
+	}
+	mut server := new_server(
+		lookup: fn [creds] (username string) !Credentials {
+			return creds
+		}
+	)!
+	mut client := new_client(username: 'user', password: 'pencil')!
+	server.first(client.first()!) or {
+		assert err.msg().contains('above the SCRAM wire maximum of ${max_wire_iterations}')
+		return
+	}
+	assert false, 'sent an iteration count that the SCRAM grammar cannot represent'
+}
+
 fn test_the_steps_must_be_called_in_order() {
 	mut server := server_for(.sha256, ChannelBinding{})
 	server.final('c=biws,r=x,p=y') or {

--- a/vlib/crypto/scram/server_test.v
+++ b/vlib/crypto/scram/server_test.v
@@ -362,9 +362,11 @@ fn test_different_binding_data_is_refused() {
 fn test_server_error_message_renders_a_refusal() {
 	assert server_error_message('invalid-proof') == 'e=invalid-proof'
 	assert server_error_message('unknown-user') == 'e=unknown-user'
+	assert server_error_message('AZaz09.-_') == 'e=AZaz09.-_'
 	// A code that would break the grammar is replaced rather than emitted.
-	assert server_error_message('') == 'e=other-error'
-	assert server_error_message('has,comma') == 'e=other-error'
+	for code in ['', 'has,comma', 'has=equals', 'has space', 'control\0byte', 'café'] {
+		assert server_error_message(code) == 'e=other-error', code
+	}
 }
 
 fn test_a_refusal_travels_to_the_client() {

--- a/vlib/crypto/scram/server_test.v
+++ b/vlib/crypto/scram/server_test.v
@@ -78,6 +78,37 @@ fn test_a_full_exchange_carries_the_authorization_identity() {
 	assert server.username() == 'user'
 }
 
+fn test_the_server_prepares_the_authorization_identity_before_exposing_it() {
+	creds := pencil_credentials(.sha256)
+	mut server := new_server(
+		nonce: 'servernonce'
+		prepare_authzid: fn (authzid string) !string {
+			return authzid.replace('\u00ad', '')
+		}
+		lookup: fn [creds] (username string) !Credentials {
+			return creds
+		}
+	)!
+	server.first('n,a=admin\u00adrole,n=user,r=clientnonce')!
+	assert server.authzid() == 'adminrole'
+}
+
+fn test_the_server_rejects_unprepared_non_ascii_authorization_identities_by_default() {
+	creds := pencil_credentials(.sha256)
+	mut server := new_server(
+		nonce:  'servernonce'
+		lookup: fn [creds] (username string) !Credentials {
+			return creds
+		}
+	)!
+	server.first('n,a=admin\u00adrole,n=user,r=clientnonce') or {
+		assert err is MalformedMessage
+		assert err.msg().contains('ServerConfig.prepare_authzid')
+		return
+	}
+	assert false, 'accepted an unprepared non-ASCII authorization identity'
+}
+
 fn test_a_full_exchange_carries_an_escaped_user_name() {
 	creds := pencil_credentials(.sha256)
 	mut server := new_server(

--- a/vlib/crypto/scram/server_test.v
+++ b/vlib/crypto/scram/server_test.v
@@ -444,11 +444,14 @@ fn test_different_binding_data_is_refused() {
 fn test_server_error_message_renders_a_refusal() {
 	assert server_error_message('invalid-proof') == 'e=invalid-proof'
 	assert server_error_message('unknown-user') == 'e=unknown-user'
-	assert server_error_message('AZaz09.-_') == 'e=AZaz09.-_'
+	for code in ['AZaz09.-_', 'has=equals', 'has space', 'café'] {
+		assert server_error_message(code) == 'e=${code}', code
+	}
 	// A code that would break the grammar is replaced rather than emitted.
-	for code in ['', 'has,comma', 'has=equals', 'has space', 'control\0byte', 'café'] {
+	for code in ['', 'has,comma', 'control\0byte'] {
 		assert server_error_message(code) == 'e=other-error', code
 	}
+	assert server_error_message([u8(0xff)].bytestr()) == 'e=other-error'
 }
 
 fn test_a_refusal_travels_to_the_client() {


### PR DESCRIPTION
Adds `vlib/crypto/scram`, a pure V implementation of the SCRAM family of SASL mechanisms: `SCRAM-SHA-1` (RFC 5802), `SCRAM-SHA-256` (RFC 7677) and `SCRAM-SHA-512`, client and server, with and without channel binding.

## Why adding SCRAM

SCRAM is the password authentication mechanism of PostgreSQL 10+, MongoDB 3.0+, Kafka (SASL/SCRAM), LDAP, XMPP and the SASL profiles of IMAP and SMTP. 

This module is the smallest piece that would unblock the most work for many tools a pure V PostgreSQL wire driver needs SCRAM-SHA-256 and nothing else that vlib lacks, MongoDB needs SCRAM-SHA-1 and SCRAM-SHA-256, Kafka needs SCRAM-SHA-256 and SCRAM-SHA-512, LDAP needs it for SASL binds. 

Beyond drivers, it gives V applications a great way to authenticate users: the password never travels, the server stores two derived keys instead of a reversible secret, the exchange is salted and nonce'd so a recording cannot be replayed, and the client authenticates the server in the same round trip.

## API

Three calls on the client, two on the server, each taking the message the peer just sent and returning the message to send back.

```v ignore
mut client := scram.new_client(username: 'user', password: 'pencil')!
send(client.mechanism_name(), client.first()!)
send(client.final(receive())!)
client.verify(receive())!
```

`new_credentials` / `derive_credentials` produce what a server stores; `Credentials.encode` and `parse_credentials` serialise a record in the RFC 5803 format laid out in the RFC 3112 `authPassword` syntax, which is the same layout PostgreSQL keeps in `pg_authid.rolpassword`. `new_server` takes a `lookup` callback so the module never touches storage. Four typed errors (`MalformedMessage`, `AuthenticationFailed`, `UnsupportedMechanism`, `ServerError`) cover the protocol outcomes; misuse of the API returns a plain `error()`.

## Conformance

The two normative vectors — RFC 5802 §5 for SCRAM-SHA-1 and RFC 7677 §3 for SCRAM-SHA-256 — are reproduced byte for byte, in both directions: the V client emits exactly the RFC's client-first and client-final messages, and the V server emits exactly its server-first and server-final messages. Six further vectors cover what the RFCs leave without an example: SHA-512, a user name needing `saslname` escaping, an authorization identity, channel binding, and a non-ASCII password.

Validation used three independent sources rather than self-consistency:

- an implementation written directly from RFC 5802 §3, which reproduces both normative vectors before being used to generate the other six;
- `github.com/xdg-go/scram` v1.2.0, the library the MongoDB Go driver authenticates with, which was replayed over all eight vectors and agrees on all four messages of each;
- live interoperability over TCP with random nonces, in both directions: the V client authenticates against a Go server, and a Go client authenticates against the V server, each side verifying the other's signature.

`Hi()` is additionally checked against `crypto.pbkdf2`, an unrelated implementation of the same primitive already in vlib, across four iteration counts and two hashes.

75 test functions, 647 assertions, over five files.

## Security properties

- The client rejects an iteration count below 4096 (RFC 7677 §4), configurable but not silently lowerable.
- The server detects a stripped `-PLUS` advertisement through the GS2 `y` flag (RFC 5802 §6), and rejects a `c=` attribute that does not match the GS2 header it received, which is what makes a rewritten header or an injected authorization identity detectable.
- Proofs and signatures are compared with `crypto.subtle.constant_time_compare`.
- `Client` and `Server` are single use, and any step that does not run to completion moves the state machine to `failed`: a refused exchange never reports `done() == true`, and a rejected client cannot try a second proof against the same nonce.
- Message parsing is strict rather than lenient: `posit-number` rules on the iteration count (no sign, no leading zero), canonical base64 only, rejection of invalid `saslname` escapes, and a mandatory `m=` extension from either peer ends the exchange rather than being ignored.
- `Client`, `Server` and `Credentials` define their own `str()`. V formats structs automatically, so without it a `println(client)` during debugging writes the plaintext password to the logs, and interpolating a `Credentials` writes the server key — the value that lets its holder impersonate the server.

## Performance

`derive_credentials` at 32768 iterations takes 49.9 ms against 3.99 ms for `xdg-go/pbkdf2` on the same machine and parameters. The gap is not in this module. `crypto.sha256.sum256` is 4.5× slower than Go's (58.5 ms vs 13.0 ms for 65536 hashes of 96 bytes) on my Mac M3, Go using the ARM64 SHA2 instructions where V's implementation is portable V; and `crypto.hmac.new` adds nothing measurable above the two hashes it performs. A variant of `hi()` with precomputed HMAC pads and reused buffers was implemented and measured at 1% faster, so the version that reads like RFC 5802 §2.2 was kept.

The remaining 2× would come from the PBKDF2 key schedule reuse Go performs — two hash compressions per iteration instead of four — which requires forking the hash state after absorbing the ipad block. `sha256.Digest.clone()` already exists but is private, so that optimisation is not reachable from outside `crypto.sha256`. Making it public would speed up `crypto.pbkdf2` as much as this module and is left as a separate change rather than widening this one across three hash modules.

## Out of scope

- SASLprep (RFC 4013) normalisation of the password: V has no stringprep implementation, so the module hashes the UTF-8 bytes it is given, and the README says so. ASCII passwords are unaffected.
- Deriving channel binding data from a TLS connection: the caller passes `tls-server-end-point` or `tls-exporter` data in. The protocol side of `-PLUS` is fully implemented and tested.

## Checks

`v fmt -verify`, `v vet -W`, `v missdoc`, `v doc -check-examples`, `v check-md` and `v test` are all clean on the new files, and `examples/scram.v` builds and runs.