### PR TITLE
fix: assert interface smartcast emits (T*)(x._object) instead of &x

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -14140,7 +14140,16 @@ fn (mut g Gen) as_cast(node ast.AsCast) {
 		mut is_optional_ident_var := false
 		mut wrap_in_addr := false
 		if g.inside_smartcast {
-			if node.expr.is_lvalue() {
+			if expr_type_sym.kind == .interface && sym.kind != .interface {
+				// For interface → concrete smartcast (e.g. after `assert err is MyError`),
+				// emit (T*)(expr._object) instead of &expr (which would take the address
+				// of the interface box, giving garbage field reads).
+				dot := if node.expr_type.is_ptr() { '->' } else { '.' }
+				g.write('(${styp}*)(')
+				g.expr(node.expr)
+				g.write('${dot}_object)')
+				is_optional_ident_var = true
+			} else if node.expr.is_lvalue() {
 				g.write('&')
 			} else {
 				wrap_in_addr = true

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -13931,8 +13931,10 @@ fn (mut g Gen) as_cast_option_payload_expr_from_expr(typ ast.Type, expr ast.Expr
 	return g.as_cast_option_payload_expr(typ, g.expr_string(expr), false)
 }
 
-fn (mut g Gen) write_as_cast_call_start(styp string, sym ast.TypeSymbol) {
+fn (mut g Gen) write_as_cast_call_start(styp string, sym ast.TypeSymbol, target_is_ptr bool) {
 	if sym.info is ast.FnType {
+		g.write('(${styp})')
+	} else if target_is_ptr {
 		g.write('(${styp})')
 	} else if g.inside_smartcast {
 		g.write('(${styp}*)')
@@ -14054,7 +14056,7 @@ fn (mut g Gen) as_cast(node ast.AsCast) {
 			}
 			obj_expr := '(${expr_str})${dot}_${payload_member}'
 			tag_expr := '(${expr_str})${dot}_typ'
-			g.write_as_cast_call_start(styp, sym)
+			g.write_as_cast_call_start(styp, sym, unwrapped_node_typ.is_ptr())
 			g.write_as_cast_call(obj_expr, tag_expr, sidx, index_exprs)
 		} else {
 			expr_str := if expr_is_option {
@@ -14064,7 +14066,7 @@ fn (mut g Gen) as_cast(node ast.AsCast) {
 			}
 			obj_expr := '(${expr_str})${dot}_${payload_member}'
 			tag_expr := '(${expr_str})${dot}_typ'
-			g.write_as_cast_call_start(styp, sym)
+			g.write_as_cast_call_start(styp, sym, unwrapped_node_typ.is_ptr())
 			g.write_as_cast_call(obj_expr, tag_expr, sidx, index_exprs)
 		}
 
@@ -14109,21 +14111,26 @@ fn (mut g Gen) as_cast(node ast.AsCast) {
 		expr_type_sym.info = info
 	} else if mut expr_type_sym.info is ast.Interface && node.expr_type != node.typ {
 		dot := if node.expr_type.is_ptr() { '->' } else { '.' }
-		matching_variants := g.matching_interface_variant_types(expr_type_sym, unwrapped_node_typ)
+		runtime_target_type := if unwrapped_node_typ.is_ptr() {
+			unwrapped_node_typ.deref()
+		} else {
+			unwrapped_node_typ
+		}
+		matching_variants := g.matching_interface_variant_types(expr_type_sym, runtime_target_type)
 		index_exprs := g.type_idx_exprs_for_types(matching_variants)
-		payload_sym := g.table.sym(g.as_cast_payload_type(unwrapped_node_typ, matching_variants))
-		sidx := g.type_sidx(unwrapped_node_typ)
+		payload_sym := g.table.sym(g.as_cast_payload_type(runtime_target_type, matching_variants))
+		sidx := g.type_sidx(runtime_target_type)
 		if as_cast_operand_needs_tmp_eval(node.expr) {
 			tmp_var := g.expr_to_ctemp_before_stmt(node.expr, node.expr_type).name
 			obj_expr := '${tmp_var}${dot}_${payload_sym.cname}'
 			tag_expr := 'v_typeof_interface_idx_${expr_type_sym.cname}(${tmp_var}${dot}_typ)'
-			g.write_as_cast_call_start(styp, sym)
+			g.write_as_cast_call_start(styp, sym, unwrapped_node_typ.is_ptr())
 			g.write_as_cast_call(obj_expr, tag_expr, sidx, index_exprs)
 		} else {
 			expr_str := g.expr_string(node.expr)
 			obj_expr := '(${expr_str})${dot}_${payload_sym.cname}'
 			tag_expr := 'v_typeof_interface_idx_${expr_type_sym.cname}((${expr_str})${dot}_typ)'
-			g.write_as_cast_call_start(styp, sym)
+			g.write_as_cast_call_start(styp, sym, unwrapped_node_typ.is_ptr())
 			g.write_as_cast_call(obj_expr, tag_expr, sidx, index_exprs)
 		}
 
@@ -14145,7 +14152,8 @@ fn (mut g Gen) as_cast(node ast.AsCast) {
 				// emit (T*)(expr._object) instead of &expr (which would take the address
 				// of the interface box, giving garbage field reads).
 				dot := if node.expr_type.is_ptr() { '->' } else { '.' }
-				g.write('(${styp}*)(')
+				cast_type := if node.typ.is_ptr() { styp } else { '${styp}*' }
+				g.write('(${cast_type})(')
 				g.expr(node.expr)
 				g.write('${dot}_object)')
 				is_optional_ident_var = true

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -13931,10 +13931,10 @@ fn (mut g Gen) as_cast_option_payload_expr_from_expr(typ ast.Type, expr ast.Expr
 	return g.as_cast_option_payload_expr(typ, g.expr_string(expr), false)
 }
 
-fn (mut g Gen) write_as_cast_call_start(styp string, sym ast.TypeSymbol, target_is_ptr bool) {
+fn (mut g Gen) write_as_cast_call_start(styp string, sym ast.TypeSymbol, payload_is_direct_ptr bool) {
 	if sym.info is ast.FnType {
 		g.write('(${styp})')
-	} else if target_is_ptr {
+	} else if payload_is_direct_ptr {
 		g.write('(${styp})')
 	} else if g.inside_smartcast {
 		g.write('(${styp}*)')
@@ -14056,7 +14056,7 @@ fn (mut g Gen) as_cast(node ast.AsCast) {
 			}
 			obj_expr := '(${expr_str})${dot}_${payload_member}'
 			tag_expr := '(${expr_str})${dot}_typ'
-			g.write_as_cast_call_start(styp, sym, unwrapped_node_typ.is_ptr())
+			g.write_as_cast_call_start(styp, sym, false)
 			g.write_as_cast_call(obj_expr, tag_expr, sidx, index_exprs)
 		} else {
 			expr_str := if expr_is_option {
@@ -14066,7 +14066,7 @@ fn (mut g Gen) as_cast(node ast.AsCast) {
 			}
 			obj_expr := '(${expr_str})${dot}_${payload_member}'
 			tag_expr := '(${expr_str})${dot}_typ'
-			g.write_as_cast_call_start(styp, sym, unwrapped_node_typ.is_ptr())
+			g.write_as_cast_call_start(styp, sym, false)
 			g.write_as_cast_call(obj_expr, tag_expr, sidx, index_exprs)
 		}
 

--- a/vlib/v/gen/c/testdata/assert_interface_pointer_smartcast.c.must_have
+++ b/vlib/v/gen/c/testdata/assert_interface_pointer_smartcast.c.must_have
@@ -1,0 +1,1 @@
+(main__PointerSmartcastError*)builtin____as_cast((err)._main__PointerSmartcastError

--- a/vlib/v/gen/c/testdata/assert_interface_pointer_smartcast.vv
+++ b/vlib/v/gen/c/testdata/assert_interface_pointer_smartcast.vv
@@ -1,0 +1,24 @@
+struct PointerSmartcastError {
+	Error
+pub:
+	reason string
+}
+
+fn (err &PointerSmartcastError) msg() string {
+	return err.reason
+}
+
+fn fail_with_pointer_error() ! {
+	return &PointerSmartcastError{
+		reason: 'boom'
+	}
+}
+
+fn main() {
+	fail_with_pointer_error() or {
+		assert err is &PointerSmartcastError
+		assert err.reason == 'boom'
+		return
+	}
+	assert false
+}

--- a/vlib/v/gen/c/testdata/generic_pointer_sumtype_as_cast.c.must_have
+++ b/vlib/v/gen/c/testdata/generic_pointer_sumtype_as_cast.c.must_have
@@ -1,0 +1,1 @@
+*(int**)builtin____as_cast

--- a/vlib/v/gen/c/testdata/generic_pointer_sumtype_as_cast.vv
+++ b/vlib/v/gen/c/testdata/generic_pointer_sumtype_as_cast.vv
@@ -1,0 +1,17 @@
+struct None {}
+
+type Maybe[T] = None | T
+
+fn some[T](value T) Maybe[T] {
+	return Maybe[T](value)
+}
+
+fn unwrap[T](value Maybe[T]) T {
+	return value as T
+}
+
+fn main() {
+	value := 7
+	ptr := unwrap[&int](some[&int](&value))
+	assert *ptr == 7
+}

--- a/vlib/v/tests/interfaces/interface_pointer_smartcast_test.v
+++ b/vlib/v/tests/interfaces/interface_pointer_smartcast_test.v
@@ -68,6 +68,31 @@ fn test_interface_pointer_smartcast_method_call() {
 	}
 }
 
+struct PointerSmartcastError {
+	Error
+pub:
+	reason string
+}
+
+fn (err &PointerSmartcastError) msg() string {
+	return 'pointer error: ${err.reason}'
+}
+
+fn fail_with_pointer_error() ! {
+	return &PointerSmartcastError{
+		reason: 'boom'
+	}
+}
+
+fn test_assert_interface_pointer_smartcast_method_call() {
+	fail_with_pointer_error() or {
+		assert err is &PointerSmartcastError
+		assert err.reason == 'boom'
+		return
+	}
+	assert false
+}
+
 fn test_mut_interface_pointer_smartcast_method_call() {
 	mut actor := Actor(&Mob{
 		id:   2


### PR DESCRIPTION
### Description

This PR fixes a code generation bug where `assert err is SomeError` followed by accessing fields or methods of the smart-cast variable produces garbage.

### Root Cause

When `apply_assert_autocasts` wraps an interface variable as an `AsCast`, the `as_cast()` code generator's fallback branch (used when `inside_smartcast` is true) emits `&x` — the address of the interface box (`IError*`). This is incorrect for interface-to-concrete smartcasts, because the interface box header (`_typ`, `_object`) is read as if it were the concrete struct's fields, yielding garbage.

### Fix

In the `as_cast()` fallback branch, when `inside_smartcast` is true and the source type is an interface while the target type is a concrete (non-interface) type, emit `(T*)(expr._object)` instead of `&expr`. This matches the correct unwrapping that `if err is SomeError { ... }` already generates.

### Before (assert smartcast)

```c
int _t1 = (int)(err._typ);
if (!(_t1 == 1654694011)) { /* panic */ }
println(MyError__msg(&err));  // &err → IError*, wrong!
```

### After (assert smartcast)

```c
int _t1 = (int)(err._typ);
if (!(_t1 == 1654694011)) { /* panic */ }
println(MyError__msg((main__MyError*)(err._object)));  // correct
```

### Testing

The existing test `vlib/v/tests/assert_interface_smartcast_test.v` (or similar) can be used to verify this fix. The issue provides a minimal reproduction case.

Fixes #28143