### PR TITLE
checker: report clear error for comma in declaration assignment instead of panicking

### DIFF
--- a/vlib/v/checker/assign.v
+++ b/vlib/v/checker/assign.v
@@ -158,6 +158,14 @@ fn (mut c Checker) assign_stmt(mut node ast.AssignStmt) {
 		c.inside_recheck = old_recheck
 	}
 	for i, mut right in node.right {
+		// early check: if right-side has more values than left-side for a declaration
+		// (e.g. `x := a, b` — comma not valid in expression), produce a clear error
+		// and exit before any out-of-bounds access on node.left
+		if is_decl && i >= node.left.len {
+			c.error('unexpected `,` in expression, use `;` or a new line to separate statements',
+				right.pos())
+			return
+		}
 		if right in [ast.ArrayInit, ast.CallExpr, ast.ComptimeCall, ast.DumpExpr, ast.IfExpr,
 			ast.LockExpr, ast.MapInit, ast.MatchExpr, ast.ParExpr, ast.SelectorExpr, ast.StructInit] {
 			if right in [ast.ArrayInit, ast.IfExpr, ast.MapInit, ast.MatchExpr, ast.StructInit]

--- a/vlib/v/checker/tests/comma_in_decl_assign_err.out
+++ b/vlib/v/checker/tests/comma_in_decl_assign_err.out
@@ -1,0 +1,19 @@
+vlib/v/checker/tests/comma_in_decl_assign_err.vv:3:24: error: unexpected `,` in expression, use `;` or a new line to separate statements
+    1 | fn main() {
+    2 |     a := [1, 2, 3]
+    3 |     mut b := a.clone(), a.clone()
+      |                           ~~~~~~~
+    4 |     println(b)
+    5 | }
+vlib/v/checker/tests/comma_in_decl_assign_err.vv:4:10: error: invalid variable `b`
+    2 |     a := [1, 2, 3]
+    3 |     mut b := a.clone(), a.clone()
+    4 |     println(b)
+      |             ^
+    5 | }
+vlib/v/checker/tests/comma_in_decl_assign_err.vv:4:2: error: `println` can not print void expressions
+    2 |     a := [1, 2, 3]
+    3 |     mut b := a.clone(), a.clone()
+    4 |     println(b)
+      |     ~~~~~~~~~~
+    5 | }

--- a/vlib/v/checker/tests/comma_in_decl_assign_err.vv
+++ b/vlib/v/checker/tests/comma_in_decl_assign_err.vv
@@ -1,0 +1,5 @@
+fn main() {
+	a := [1, 2, 3]
+	mut b := a.clone(), a.clone()
+	println(b)
+}


### PR DESCRIPTION
Fixes #28138

## Problem

When a declaration assignment contains a comma-separated expression, e.g.

```v
mut output := example.split(" "),join(",")
```

the compiler panics with:

```
V panic: array.get: index out of range (i,a.len):1, 1
```

instead of producing a clear error message.

## Root cause

The checker's `assign_stmt` loop iterates over `node.right` but accesses
`node.left[i]` without checking that `i` is within bounds of `node.left`.
When the right side has more expressions than the left side (triggered by
a comma in the RHS of a `:=` assignment), this causes an array bounds
panic.

## Fix

Add an early guard in the loop: when `is_decl` and `i >= node.left.len`,
emit `unexpected \`, \` in expression, use \`;\` or a new line to separate
statements` and return early from the checker. This prevents the
out-of-bounds access and provides a clear diagnostic.

## Test

Added `vlib/v/checker/tests/comma_in_decl_assign_err.vv` with matching
`.out` file.

Closes #28138