### PR TITLE
live: forward -enable-globals to the live recompilation step

### DIFF
--- a/vlib/v/gen/c/live.v
+++ b/vlib/v/gen/c/live.v
@@ -173,6 +173,9 @@ fn (mut g Gen) generate_hotcode_reloading_main_caller() {
 	if so_debug_flag != '' {
 		vopts_parts << so_debug_flag
 	}
+	if g.pref.enable_globals {
+		vopts_parts << '-enable-globals'
+	}
 	if forwarded_define_vopts != '' {
 		vopts_parts << forwarded_define_vopts
 	}


### PR DESCRIPTION
Fix #28125

When running `v -enable-globals -live run main.v`, the live recompilation step did not pass `-enable-globals` to the shared library compilation, causing a spurious error:

```
recompilation error:
main.v:5:1: error: use `v -enable-globals ...` to enable globals
```

The fix adds `-enable-globals` to the `vopts` forwarded to the live recompilation step when `pref.enable_globals` is true.

Verified locally: `v -enable-globals -live run` on a __global test program now works correctly.