### PR TITLE
tests: add regression test for ?Alias struct field initialized from ?T function call (fixes #28148)

### DIFF
--- a/vlib/v/tests/option_alias_struct_field_init_28148_test.v
+++ b/vlib/v/tests/option_alias_struct_field_init_28148_test.v
@@ -1,0 +1,54 @@
+// Regression test for https://github.com/vlang/v/issues/28148:
+// initializing a struct field declared as `?Alias` (where `type Alias = T`)
+// from an expression whose type is `?T` (e.g. a function returning `?T`)
+// must compile and produce the wrapped value, both for `none` and for a
+// present value. Before the fix, cgen emitted the field with the alias's
+// own option C type (`_option_main__LocaleCode`) while the init expression
+// had the base type's option C type (`_option_string`), causing a
+// incompatible-pointer-types C error for the non-none path.
+
+type LocaleCode28148 = string
+
+struct LocaleContext28148 {
+	locale_code ?LocaleCode28148
+}
+
+fn get_locale_or_none_28148(m map[string]string, k string) ?string {
+	if k in m {
+		return m[k]
+	}
+	return none
+}
+
+fn test_option_alias_struct_field_from_opt_string_present() {
+	m := {
+		'locale': 'en_US'
+	}
+	lctx := LocaleContext28148{
+		locale_code: get_locale_or_none_28148(m, 'locale')
+	}
+	assert lctx.locale_code? == 'en_US'
+}
+
+fn test_option_alias_struct_field_from_opt_string_none() {
+	m := map[string]string{}
+	lctx := LocaleContext28148{
+		locale_code: get_locale_or_none_28148(m, 'locale')
+	}
+	assert lctx.locale_code == none
+}
+
+fn test_option_alias_struct_field_from_plain_string() {
+	lctx := LocaleContext28148{
+		locale_code: 'zh_CN'
+	}
+	assert lctx.locale_code? == 'zh_CN'
+}
+
+fn test_option_alias_struct_field_from_alias_value() {
+	code := LocaleCode28148('ja_JP')
+	lctx := LocaleContext28148{
+		locale_code: code
+	}
+	assert lctx.locale_code? == 'ja_JP'
+}


### PR DESCRIPTION
Fixes #28148

Adds a regression test covering assignment of a `?T` expression (function call returning `?string`) to a struct field whose type is `?Alias` (where `type Alias = T`).

Before the `Optional_` representation change, cgen generated different C option type names for the alias and the underlying type (`_option_main__LocaleCode` vs `_option_string`), causing a C compilation error on the non-none path.

Test cases:
- Field init from `?string` fn with a present value
- Field init from `?string` fn returning `none`
- Field init from a plain `string` literal
- Field init from a variable of the alias type itself