### PR TITLE
thirdparty: fix tccbin contract bootstrap

### DIFF
--- a/.github/workflows/tccbin_automation_contract.yml
+++ b/.github/workflows/tccbin_automation_contract.yml
@@ -33,6 +33,30 @@ jobs:
           persist-credentials: false
       - name: Configure the immutable VC bootstrap snapshot
         run: git -C vc config --local core.autocrlf false
+      - name: Checkout the immutable TCC bootstrap bundle
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          repository: vlang/tccbin
+          ref: ece46f06fbe6eb701d52442f11dd59c48d166cae
+          path: thirdparty/tcc
+          fetch-depth: 0
+          filter: blob:none
+          persist-credentials: false
+      - name: Configure and verify the immutable TCC bootstrap bundle
+        shell: bash
+        run: |
+          set -euo pipefail
+          git -C thirdparty/tcc config --local core.autocrlf false
+          test "$(git -C thirdparty/tcc rev-parse HEAD)" = "ece46f06fbe6eb701d52442f11dd59c48d166cae"
+          tcc_symbolic_ref_rc=0
+          git -C thirdparty/tcc symbolic-ref --quiet HEAD >/dev/null || tcc_symbolic_ref_rc=$?
+          test "$tcc_symbolic_ref_rc" -eq 1
+          tcc_status="$(git -C thirdparty/tcc status --porcelain --untracked-files=all)"
+          test -z "$tcc_status"
+          test "$(git -C thirdparty/tcc config --local --get core.autocrlf)" = "false"
+          test -x thirdparty/tcc/tcc.exe
+          test -f thirdparty/tcc/lib/libgc.a
+          thirdparty/tcc/tcc.exe --version
       - name: Build the local compiler
         run: |
           make local=1

--- a/thirdparty/tccbin_automation/bin/live_state.v
+++ b/thirdparty/tccbin_automation/bin/live_state.v
@@ -2954,7 +2954,7 @@ fn load_live_state_inventory(automation_root string, state_git_dir string, trust
 			}
 			authenticated_historical[target_commit] = true
 		}
-		parent_commit := live_first_parent_for_commit(state_git_dir, target_commit, history) or {
+		parent_commit := live_first_parent_for_commit(target_commit, history) or {
 			return error('history_recovery_required: ${err.msg()}')
 		}
 		parent_inventory := load_live_state_inventory_at_commit(automation_root, state_git_dir,
@@ -3146,8 +3146,7 @@ fn load_live_evidence_history(state_git_dir string, head string,
 	}
 }
 
-fn live_first_parent_for_commit(state_git_dir string, commit_sha string,
-	history LiveEvidenceHistory) !string {
+fn live_first_parent_for_commit(commit_sha string, history LiveEvidenceHistory) !string {
 	if commit_sha !in history.first_parent {
 		return error('live state terminal commit is outside the authenticated first-parent history')
 	}

--- a/thirdparty/tccbin_automation/bin/reporter.v
+++ b/thirdparty/tccbin_automation/bin/reporter.v
@@ -350,7 +350,7 @@ pub fn issue_bot_zone_size_is_valid(byte_count int) bool {
 pub fn sanitize_issue_summary(summary string) string {
 	mut lines := strip_terminal_controls(summary).split_into_lines()
 	if lines.len > issue_summary_max_lines {
-		lines = lines[lines.len - issue_summary_max_lines..]
+		lines = lines[lines.len - issue_summary_max_lines..].clone()
 	}
 	mut sanitized := []string{cap: lines.len}
 	for raw_line in lines {

--- a/thirdparty/tccbin_automation/bin/schema_validator.v
+++ b/thirdparty/tccbin_automation/bin/schema_validator.v
@@ -1031,14 +1031,13 @@ fn validate_recovery_handoff_history_semantics(root JsonValue) ![]SchemaIssue {
 			issues << semantic_issue('${path}/subject_ref_head',
 				'recovery handoff ref HEAD must equal its immutable native subject SHA')
 		}
-		canonical_ref := 'thirdparty-${target_id}'
-		if require_string_member(handoff_subject, 'original_ref')! == canonical_ref
+		target_canonical_ref := 'thirdparty-${target_id}'
+		if require_string_member(handoff_subject, 'original_ref')! == target_canonical_ref
 			&& require_string_member(handoff, 'expected_canonical_head')! != require_string_member(handoff_subject, 'sha')! {
 			issues << semantic_issue('${path}/expected_canonical_head',
 				'canonical recovery handoff must retain the subject SHA as expected HEAD')
 		}
-		issues << validate_recovery_handoff_cas_semantics(root, handoff, path, handoff_id,
-			handoff_subject_hash, ordinal)!
+		issues << validate_recovery_handoff_cas_semantics(root, handoff, path, handoff_id, ordinal)!
 		state := require_string_member(handoff, 'state')!
 		if state != 'complete' {
 			unfinished_count++
@@ -1135,7 +1134,7 @@ fn current_authority_check_sources(root JsonValue) !JsonValue {
 }
 
 fn validate_recovery_handoff_cas_semantics(root JsonValue, handoff JsonValue, path string,
-	handoff_id string, handoff_subject_hash string, ordinal i64) ![]SchemaIssue {
+	handoff_id string, ordinal i64) ![]SchemaIssue {
 	mut issues := []SchemaIssue{}
 	dispatch_ids := require_array_member(handoff, 'dispatch_operation_ids')!
 	if require_integer_member(handoff, 'dispatch_generation')! != i64(dispatch_ids.len) {

--- a/thirdparty/tccbin_automation/bin/strict_json.v
+++ b/thirdparty/tccbin_automation/bin/strict_json.v
@@ -267,7 +267,7 @@ fn (mut parser StrictJsonParser) parse_string() !string {
 					if low < 0xdc00 || low > 0xdfff {
 						return error('invalid low surrogate in string escape')
 					}
-					codepoint = 0x10000 + ((codepoint - 0xd800) << 10) + (low - 0xdc00)
+					codepoint = 0x10000 + (codepoint - 0xd800) * 0x400 + (low - 0xdc00)
 				} else if codepoint >= 0xdc00 && codepoint <= 0xdfff {
 					return error('isolated low surrogate in string escape')
 				}

--- a/thirdparty/tccbin_automation/tests/strict_json_test.v
+++ b/thirdparty/tccbin_automation/tests/strict_json_test.v
@@ -42,3 +42,15 @@ fn test_jcs_preserves_valid_surrogate_pairs_as_utf8() {
 	value := bin.parse_strict_json('{"rocket":"\\uD83D\\uDE80"}') or { panic(err) }
 	assert bin.canonical_json(value) == '{"rocket":"🚀"}'
 }
+
+fn test_strict_json_preserves_surrogate_pair_boundaries() {
+	for source, expected in {
+		'"\\uD800\\uDC00"': 0x10000
+		'"\\uDBFF\\uDFFF"': 0x10ffff
+	} {
+		value := bin.parse_strict_json(source) or { panic(err) }
+		runes := value.string_value.runes()
+		assert runes.len == 1
+		assert runes[0] == rune(expected)
+	}
+}

--- a/thirdparty/tccbin_automation/tests/workflow_contract_test.v
+++ b/thirdparty/tccbin_automation/tests/workflow_contract_test.v
@@ -54,6 +54,7 @@ fn workflow_index_after(source string, needle string, offset int) int {
 fn test_pr_contract_workflow_always_exposes_both_required_checks() {
 	source := workflow_source('tccbin_automation_contract.yml')
 	vc_lock := bin.validate_vc_bootstrap_contract(automation_root()) or { panic(err) }
+	tcc_lock := 'ece46f06fbe6eb701d52442f11dd59c48d166cae'
 	assert source.contains('  pull_request:')
 	assert source.contains('  merge_group:')
 	assert !source.contains('paths:')
@@ -75,15 +76,20 @@ fn test_pr_contract_workflow_always_exposes_both_required_checks() {
 	assert source.count('timeout-minutes: 45') == 1
 	assert source.count('timeout-minutes: 30') == 1
 	assert source.count('timeout-minutes: 5') == 2
-	assert source.count('persist-credentials: false') == 3
-	assert source.count('uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1') == 1
+	assert source.count('persist-credentials: false') == 4
+	assert source.count('uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1') == 2
 	assert source.count('repository: vlang/vc') == 1
 	assert source.count('ref: ${vc_lock.commit}') == 1
 	assert source.count('path: vc') == 1
-	assert source.count('fetch-depth: 0') == 2
-	assert source.count('filter: blob:none') == 1
+	assert source.count('repository: vlang/tccbin') == 1
+	assert source.count('ref: ${tcc_lock}') == 1
+	assert source.count('path: thirdparty/tcc') == 1
+	assert source.count('fetch-depth: 0') == 3
+	assert source.count('filter: blob:none') == 2
 	assert source.count('git -C vc config --local core.autocrlf false') == 1
+	assert source.count('git -C thirdparty/tcc config --local core.autocrlf false') == 1
 	assert source.count('make local=1') == 1
+	assert !source.contains('make latest_tcc')
 	tested_checkout := '      - name: Checkout the tested revision\n' +
 		'        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683\n' +
 		'        with:\n' + '          fetch-depth: 0\n' + '          persist-credentials: false\n'
@@ -91,10 +97,16 @@ fn test_pr_contract_workflow_always_exposes_both_required_checks() {
 	vc_checkout_index := source.index('      - name: Checkout the immutable VC bootstrap snapshot') or {
 		panic('immutable VC checkout missing')
 	}
+	tcc_checkout_index := workflow_index_after(source,
+		'      - name: Checkout the immutable TCC bootstrap bundle', vc_checkout_index)
+	tcc_verify_index := workflow_index_after(source,
+		'      - name: Configure and verify the immutable TCC bootstrap bundle', tcc_checkout_index)
 	build_index := workflow_index_after(source, '      - name: Build the local compiler',
-		vc_checkout_index)
-	assert vc_checkout_index < build_index
-	vc_checkout := source[vc_checkout_index..build_index]
+		tcc_verify_index)
+	assert vc_checkout_index < tcc_checkout_index
+	assert tcc_checkout_index < tcc_verify_index
+	assert tcc_verify_index < build_index
+	vc_checkout := source[vc_checkout_index..tcc_checkout_index]
 	assert vc_checkout.count('uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1') == 1
 	assert vc_checkout.count('repository: vlang/vc') == 1
 	assert vc_checkout.count('ref: ${vc_lock.commit}') == 1
@@ -103,6 +115,28 @@ fn test_pr_contract_workflow_always_exposes_both_required_checks() {
 	assert vc_checkout.count('filter: blob:none') == 1
 	assert vc_checkout.count('persist-credentials: false') == 1
 	assert vc_checkout.count('git -C vc config --local core.autocrlf false') == 1
+	tcc_checkout := source[tcc_checkout_index..tcc_verify_index]
+	assert tcc_checkout.count('uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1') == 1
+	assert tcc_checkout.count('repository: vlang/tccbin') == 1
+	assert tcc_checkout.count('ref: ${tcc_lock}') == 1
+	assert tcc_checkout.count('path: thirdparty/tcc') == 1
+	assert tcc_checkout.count('fetch-depth: 0') == 1
+	assert tcc_checkout.count('filter: blob:none') == 1
+	assert tcc_checkout.count('persist-credentials: false') == 1
+	tcc_verify := source[tcc_verify_index..build_index]
+	assert tcc_verify.count('git -C thirdparty/tcc config --local core.autocrlf false') == 1
+	assert tcc_verify.count('test "$(git -C thirdparty/tcc rev-parse HEAD)" = "${tcc_lock}"') == 1
+	assert tcc_verify.count('tcc_symbolic_ref_rc=0') == 1
+	assert tcc_verify.count('git -C thirdparty/tcc symbolic-ref --quiet HEAD >/dev/null || tcc_symbolic_ref_rc=$?') == 1
+	assert tcc_verify.count('test "$tcc_symbolic_ref_rc" -eq 1') == 1
+	assert tcc_verify.count('tcc_status="$(git -C thirdparty/tcc status --porcelain --untracked-files=all)"') == 1
+	assert tcc_verify.count('test -z "$tcc_status"') == 1
+	assert !tcc_verify.contains('symbolic-ref --quiet HEAD || true')
+	assert !tcc_verify.contains('test -z "$(git -C thirdparty/tcc status')
+	assert tcc_verify.count('test "$(git -C thirdparty/tcc config --local --get core.autocrlf)" = "false"') == 1
+	assert tcc_verify.count('test -x thirdparty/tcc/tcc.exe') == 1
+	assert tcc_verify.count('test -f thirdparty/tcc/lib/libgc.a') == 1
+	assert tcc_verify.count('thirdparty/tcc/tcc.exe --version') == 1
 	assert !source.contains(r'${{ secrets.')
 	assert !source.contains('contents: write')
 }


### PR DESCRIPTION
## Summary

This follow-up fixes the tccbin automation contract CI introduced by #28137.

The contract worker now checks out a known-good immutable `vlang/tccbin` Linux bundle before running `make local=1`, and verifies that the checkout is exact, detached, clean, and contains a working `tcc.exe` and `libgc.a`.

It also removes the five repeated V compiler notices emitted by the tccbin automation modules.

## Why

`make local=1` correctly preserved the pinned VC snapshot, but it also disabled normal TCC provisioning. On a clean runner, the contract job therefore failed before the test suite because `thirdparty/tcc/lib/libgc.a` was missing.