### PR TITLE
vpm: warn when a module name is normalized into a different import path

### DIFF
--- a/cmd/tools/vpm/common.v
+++ b/cmd/tools/vpm/common.v
@@ -230,6 +230,16 @@ fn normalize_mod_path(path string) string {
 	return path.replace('-', '_').to_lower()
 }
 
+// Derive the import path of an installed module from its location relative to
+// `vmodules`. E.g. `<vmodules>/spytheman/vtray` -> `spytheman.vtray`.
+// Normalize both sides via `real_path` so macOS's `/tmp` -> `/private/tmp`
+// resolution doesn't leave the prefix unstripped.
+fn import_path_of(install_path string) string {
+	vmodules_real := os.real_path(settings.vmodules_path)
+	rel_install_path := install_path.trim_string_left(vmodules_real).trim_left(os.path_separator)
+	return rel_install_path.replace(os.path_separator, '.')
+}
+
 fn get_all_modules_for_search() []string {
 	working_server_url := get_working_server_url()
 	verbose_println_more(@FILE_LINE, @FN, 'working_server_url: ${working_server_url}')

--- a/cmd/tools/vpm/common.v
+++ b/cmd/tools/vpm/common.v
@@ -371,7 +371,7 @@ fn get_path_of_existing_module(mod_name string) ?string {
 	if is_url {
 		publisher, name := get_ident_from_url(mod_name) or { '', '' }
 		if publisher != '' && name != '' {
-			rel_path := normalize_mod_path(os.join_path(publisher, name))
+			rel_path := direct_install_mod_path(publisher, name)
 			path := os.real_path(os.join_path(settings.vmodules_path, rel_path))
 			if os.exists(path) && os.is_dir(path) {
 				verbose_println_more(@FILE_LINE, @FN, 'mod_name: ${mod_name}, found path: ${path}')
@@ -392,6 +392,10 @@ fn get_path_of_existing_module(mod_name string) ?string {
 	}
 	verbose_println_more(@FILE_LINE, @FN, 'mod_name: ${mod_name}, found path: ${path}')
 	return path
+}
+
+fn direct_install_mod_path(publisher string, manifest_name string) string {
+	return normalize_mod_path(os.join_path(publisher, manifest_name.replace('.', os.path_separator)))
 }
 
 fn get_working_server_url() string {

--- a/cmd/tools/vpm/common.v
+++ b/cmd/tools/vpm/common.v
@@ -377,9 +377,7 @@ fn get_path_of_existing_module(mod_name string) ?string {
 	if is_url {
 		publisher, name := get_ident_from_url(mod_name) or { '', '' }
 		if publisher != '' && name != '' {
-			rel_path := direct_install_mod_path(publisher, name)
-			path := os.real_path(os.join_path(settings.vmodules_path, rel_path))
-			if os.exists(path) && os.is_dir(path) {
+			if path := get_path_of_existing_url_module(settings.vmodules_path, publisher, name) {
 				verbose_println_more(@FILE_LINE, @FN, 'mod_name: ${mod_name}, found path: ${path}')
 				return path
 			}
@@ -401,7 +399,20 @@ fn get_path_of_existing_module(mod_name string) ?string {
 }
 
 fn direct_install_mod_path(publisher string, manifest_name string) string {
-	return normalize_mod_path(os.join_path(publisher, manifest_name.replace('.', os.path_separator)))
+	return normalize_mod_path(os.join_path(publisher.replace('.', os.path_separator), manifest_name.replace('.',
+		os.path_separator)))
+}
+
+fn get_path_of_existing_url_module(vmodules_path string, publisher string, name string) ?string {
+	new_path := direct_install_mod_path(publisher, name)
+	legacy_path := normalize_mod_path(os.join_path(publisher, name))
+	for rel_path in [new_path, legacy_path] {
+		path := os.real_path(os.join_path(vmodules_path, rel_path))
+		if os.exists(path) && os.is_dir(path) {
+			return path
+		}
+	}
+	return none
 }
 
 fn cleanup_empty_module_parent_dirs(module_path string) {

--- a/cmd/tools/vpm/common.v
+++ b/cmd/tools/vpm/common.v
@@ -404,6 +404,19 @@ fn direct_install_mod_path(publisher string, manifest_name string) string {
 	return normalize_mod_path(os.join_path(publisher, manifest_name.replace('.', os.path_separator)))
 }
 
+fn cleanup_empty_module_parent_dirs(module_path string) {
+	vmodules_path := real_path_with_missing_suffix(settings.vmodules_path)
+	mut parent := real_path_with_missing_suffix(os.dir(module_path))
+	for parent != vmodules_path && parent.starts_with(vmodules_path + os.path_separator)
+		&& parent != os.dir(parent) {
+		if !os.is_dir(parent) || !os.is_dir_empty(parent) {
+			break
+		}
+		os.rmdir(parent) or { break }
+		parent = os.dir(parent)
+	}
+}
+
 fn get_working_server_url() string {
 	is_initial_selection := selected_server_url(false, '') == ''
 	for url in active_server_urls() {

--- a/cmd/tools/vpm/common.v
+++ b/cmd/tools/vpm/common.v
@@ -336,27 +336,30 @@ fn normalize_repo_lookup_url(raw_url string) !string {
 }
 
 fn get_installed_modules() []string {
-	dirs := os.ls(settings.vmodules_path) or { return [] }
+	return get_installed_modules_in(settings.vmodules_path)
+}
+
+fn get_installed_modules_in(vmodules_path string) []string {
 	mut modules := []string{}
-	for dir in dirs {
-		adir := os.join_path(settings.vmodules_path, dir)
-		if dir in excluded_dirs || !os.is_dir(adir) {
-			continue
-		}
-		if os.exists(os.join_path(adir, 'v.mod')) && os.exists(os.join_path(adir, '.git', 'config')) {
-			// an official vlang module with a short module name, like `vsl`, `ui` or `markdown`
-			modules << dir
-			continue
-		}
-		author := dir
-		mods := os.ls(adir) or { continue }
-		for m in mods {
-			vcs_used_in_dir(os.join_path(adir, m)) or { continue }
-			modules << '${author}.${m}'
-		}
-	}
+	collect_installed_modules(vmodules_path, '', true, mut modules)
 	verbose_println_more(@FILE_LINE, @FN, 'found modules: ${modules}')
 	return modules
+}
+
+fn collect_installed_modules(path string, prefix string, is_root bool, mut modules []string) {
+	dirs := os.ls(path) or { return }
+	for dir in dirs {
+		module_path := os.join_path(path, dir)
+		if (is_root && dir in excluded_dirs) || !os.is_dir(module_path) || os.is_link(module_path) {
+			continue
+		}
+		module_name := if prefix == '' { dir } else { '${prefix}.${dir}' }
+		if vcs_used_in_dir(module_path) != none {
+			modules << module_name
+			continue
+		}
+		collect_installed_modules(module_path, module_name, false, mut modules)
+	}
 }
 
 fn get_path_of_existing_module(mod_name string) ?string {

--- a/cmd/tools/vpm/common.v
+++ b/cmd/tools/vpm/common.v
@@ -335,6 +335,25 @@ fn normalize_repo_lookup_url(raw_url string) !string {
 	return '${host}/${path}'
 }
 
+fn normalize_clone_source_url(raw_url string) !string {
+	normalized_url := if raw_url.starts_with('git@') {
+		'ssh://' + raw_url['git@'.len..].replace(':', '/')
+	} else {
+		raw_url
+	}
+	url := urllib.parse(normalized_url) or {
+		return error('failed to parse module URL `${raw_url}`.')
+	}
+	host := url.hostname().trim_space().to_lower()
+	port := url.port()
+	path := url.path.trim_space().trim_right('/').trim_left('/').trim_string_right('.git')
+	if host == '' || path == '' {
+		return error('failed to normalize module URL `${raw_url}`.')
+	}
+	authority := if port == '' { host } else { '${host}:${port}' }
+	return '${authority}/${path}'
+}
+
 fn get_installed_modules() []string {
 	return get_installed_modules_in(settings.vmodules_path)
 }

--- a/cmd/tools/vpm/common.v
+++ b/cmd/tools/vpm/common.v
@@ -350,10 +350,16 @@ fn collect_installed_modules(path string, prefix string, is_root bool, mut modul
 	dirs := os.ls(path) or { return }
 	for dir in dirs {
 		module_path := os.join_path(path, dir)
-		if (is_root && dir in excluded_dirs) || !os.is_dir(module_path) || os.is_link(module_path) {
+		if (is_root && dir in excluded_dirs) || !os.is_dir(module_path) {
 			continue
 		}
 		module_name := if prefix == '' { dir } else { '${prefix}.${dir}' }
+		if os.is_link(module_path) {
+			if vcs_used_in_dir(module_path) != none {
+				modules << module_name
+			}
+			continue
+		}
 		if vcs_used_in_dir(module_path) != none {
 			modules << module_name
 			continue

--- a/cmd/tools/vpm/common.v
+++ b/cmd/tools/vpm/common.v
@@ -235,8 +235,14 @@ fn normalize_mod_path(path string) string {
 // Normalize both sides via `real_path` so macOS's `/tmp` -> `/private/tmp`
 // resolution doesn't leave the prefix unstripped.
 fn import_path_of(install_path string) string {
-	vmodules_real := os.real_path(settings.vmodules_path)
-	rel_install_path := install_path.trim_string_left(vmodules_real).trim_left(os.path_separator)
+	return import_path_relative_to(install_path, settings.vmodules_path)
+}
+
+fn import_path_relative_to(install_path string, vmodules_path string) string {
+	vmodules_real := os.real_path(vmodules_path)
+	install_path_real := os.real_path(install_path)
+	rel_install_path :=
+		install_path_real.trim_string_left(vmodules_real).trim_left(os.path_separator)
 	return rel_install_path.replace(os.path_separator, '.')
 }
 

--- a/cmd/tools/vpm/common.v
+++ b/cmd/tools/vpm/common.v
@@ -346,7 +346,8 @@ fn normalize_clone_source_url(raw_url string) !string {
 	}
 	host := url.hostname().trim_space().to_lower()
 	port := url.port()
-	path := url.path.trim_space().trim_right('/').trim_left('/').trim_string_right('.git')
+	raw_path := url.path.trim_space().trim_right('/').trim_left('/').trim_string_right('.git')
+	path := if host == 'github.com' { raw_path.to_lower() } else { raw_path }
 	if host == '' || path == '' {
 		return error('failed to normalize module URL `${raw_url}`.')
 	}
@@ -360,12 +361,18 @@ fn get_installed_modules() []string {
 
 fn get_installed_modules_in(vmodules_path string) []string {
 	mut modules := []string{}
-	collect_installed_modules(vmodules_path, '', true, mut modules)
+	mut visited := map[string]bool{}
+	collect_installed_modules(vmodules_path, '', true, mut modules, mut visited)
 	verbose_println_more(@FILE_LINE, @FN, 'found modules: ${modules}')
 	return modules
 }
 
-fn collect_installed_modules(path string, prefix string, is_root bool, mut modules []string) {
+fn collect_installed_modules(path string, prefix string, is_root bool, mut modules []string, mut visited map[string]bool) {
+	real_path := os.real_path(path)
+	if real_path in visited {
+		return
+	}
+	visited[real_path] = true
 	dirs := os.ls(path) or { return }
 	for dir in dirs {
 		module_path := os.join_path(path, dir)
@@ -373,17 +380,13 @@ fn collect_installed_modules(path string, prefix string, is_root bool, mut modul
 			continue
 		}
 		module_name := if prefix == '' { dir } else { '${prefix}.${dir}' }
-		if os.is_link(module_path) {
-			if vcs_used_in_dir(module_path) != none {
+		if vcs_used_in_dir(module_path) != none {
+			if os.is_file(os.join_path(module_path, 'v.mod')) {
 				modules << module_name
 			}
 			continue
 		}
-		if vcs_used_in_dir(module_path) != none {
-			modules << module_name
-			continue
-		}
-		collect_installed_modules(module_path, module_name, false, mut modules)
+		collect_installed_modules(module_path, module_name, false, mut modules, mut visited)
 	}
 }
 
@@ -437,8 +440,7 @@ fn get_path_of_existing_url_module(vmodules_path string, publisher string, name 
 fn cleanup_empty_module_parent_dirs(module_path string) {
 	vmodules_path := real_path_with_missing_suffix(settings.vmodules_path)
 	mut parent := real_path_with_missing_suffix(os.dir(module_path))
-	for parent != vmodules_path && parent.starts_with(vmodules_path + os.path_separator)
-		&& parent != os.dir(parent) {
+	for path_is_below(parent, vmodules_path) && parent != os.dir(parent) {
 		if !os.is_dir(parent) || !os.is_dir_empty(parent) {
 			break
 		}

--- a/cmd/tools/vpm/common.v
+++ b/cmd/tools/vpm/common.v
@@ -380,14 +380,39 @@ fn collect_installed_modules(path string, prefix string, is_root bool, mut modul
 			continue
 		}
 		module_name := if prefix == '' { dir } else { '${prefix}.${dir}' }
-		if vcs_used_in_dir(module_path) != none {
-			if os.is_file(os.join_path(module_path, 'v.mod')) {
+		if vcs := vcs_used_in_dir(module_path) {
+			if os.is_file(os.join_path(module_path, 'v.mod'))
+				|| is_manifestless_registered_checkout(module_path, module_name, vcs) {
 				modules << module_name
 			}
 			continue
 		}
 		collect_installed_modules(module_path, module_name, false, mut modules, mut visited)
 	}
+}
+
+fn is_manifestless_registered_checkout(module_path string, module_name string, vcs VCS) bool {
+	parts := module_name.split('.')
+	if parts.len != 2 {
+		return false
+	}
+	remote := match vcs {
+		.git {
+			result := os.execute_opt('git -C ${os.quoted_path(module_path)} remote get-url origin') or {
+				return false
+			}
+			result.output.trim_space()
+		}
+		.hg {
+			result := os.execute_opt('hg -R ${os.quoted_path(module_path)} paths default') or {
+				return false
+			}
+			result.output.trim_space()
+		}
+	}
+	publisher, _ := get_ident_from_url(remote) or { return false }
+	remote_owner := publisher.split('/')[0]
+	return normalize_mod_path(remote_owner) == normalize_mod_path(parts[0])
 }
 
 fn get_path_of_existing_module(mod_name string) ?string {

--- a/cmd/tools/vpm/install.v
+++ b/cmd/tools/vpm/install.v
@@ -94,10 +94,24 @@ fn install_modules(modules []Module, selected_server_url string) {
 			}
 		}
 		println('Installed `${m.name}` in ${m.install_path_fmted} .')
+		m.warn_on_normalized_name()
 	}
 	if errors > 0 {
 		exit(1)
 	}
+}
+
+// Module names may contain characters that are not valid in V import paths, e.g. `-`.
+// Those are normalized away when the module is placed into `vmodules`, so point out
+// the resulting import path instead of leaving the mismatch for the compiler to report.
+fn (m Module) warn_on_normalized_name() {
+	import_path := import_path_of(m.install_path)
+	if import_path == m.name {
+		return
+	}
+	vpm_warn('`${m.name}` is not a valid V import path, it was installed as `${import_path}`.',
+		details: 'Use `import ${import_path}` to import it.\nConsider renaming the `name` field in the `v.mod` of the module.'
+	)
 }
 
 fn (m Module) install() InstallResult {

--- a/cmd/tools/vpm/install.v
+++ b/cmd/tools/vpm/install.v
@@ -125,8 +125,7 @@ fn (m Module) normalized_name_warning_details(import_path string) string {
 }
 
 fn (m Module) name_was_normalized() bool {
-	normalized_name :=
-		normalize_mod_path(m.name.replace('.', os.path_separator)).replace(os.path_separator, '.')
+	normalized_name := direct_install_mod_path('', m.name).replace(os.path_separator, '.')
 	return normalized_name != m.name
 }
 
@@ -134,8 +133,7 @@ fn (m Module) manifest_name_was_normalized() bool {
 	if m.manifest.name == '' {
 		return false
 	}
-	normalized_name :=
-		normalize_mod_path(m.manifest.name.replace('.', os.path_separator)).replace(os.path_separator, '.')
+	normalized_name := direct_install_mod_path('', m.manifest.name).replace(os.path_separator, '.')
 	return normalized_name != m.manifest.name
 }
 

--- a/cmd/tools/vpm/install.v
+++ b/cmd/tools/vpm/install.v
@@ -177,6 +177,10 @@ fn (m Module) install() InstallResult {
 			return .skipped
 		}
 	}
+	if os.exists(m.install_path) {
+		vpm_error('refusing to install `${m.name}`: destination `${m.install_path_fmted}` already exists.')
+		return .failed
+	}
 	println('Installing `${m.name}`...')
 	// When the module should be relocated into a subdirectory we need to make sure
 	// it exists to not run into permission errors.

--- a/cmd/tools/vpm/install.v
+++ b/cmd/tools/vpm/install.v
@@ -145,6 +145,10 @@ fn (m Module) install() InstallResult {
 		vpm_error('refusing to install `${m.name}` outside the V modules directory.')
 		return .failed
 	}
+	if install_path_has_symlinked_ancestor(m.install_path, settings.vmodules_path) {
+		vpm_error('refusing to install `${m.name}` inside a symlinked module namespace.')
+		return .failed
+	}
 	if ancestor := vcs_backed_install_ancestor(m.install_path, settings.vmodules_path) {
 		vpm_error('refusing to install `${m.name}` inside existing module `${fmt_mod_path(ancestor)}`.')
 		return .failed
@@ -212,6 +216,22 @@ fn path_is_below(path string, root string) bool {
 	}
 	boundary := if root.ends_with(os.path_separator) { root } else { root + os.path_separator }
 	return path.starts_with(boundary)
+}
+
+fn install_path_has_symlinked_ancestor(install_path string, vmodules_path string) bool {
+	vmodules_root := os.abs_path(vmodules_path)
+	mut parent := os.dir(os.abs_path(install_path))
+	for path_is_below(parent, vmodules_root) {
+		if os.is_link(parent) {
+			return true
+		}
+		next := os.dir(parent)
+		if next == parent {
+			break
+		}
+		parent = next
+	}
+	return false
 }
 
 fn vcs_backed_install_ancestor(install_path string, vmodules_path string) ?string {

--- a/cmd/tools/vpm/install.v
+++ b/cmd/tools/vpm/install.v
@@ -143,6 +143,10 @@ fn (m Module) install() InstallResult {
 	defer {
 		os.rmdir_all(m.tmp_path) or {}
 	}
+	if ancestor := vcs_backed_install_ancestor(m.install_path, settings.vmodules_path) {
+		vpm_error('refusing to install `${m.name}` inside existing module `${fmt_mod_path(ancestor)}`.')
+		return .failed
+	}
 	// Run this check unconditionally — `m.is_installed` is computed via
 	// `git ls-remote`, which itself fails when `.git` is corrupted or
 	// inaccessible, so relying on it here would skip the guard in exactly
@@ -188,6 +192,22 @@ fn (m Module) install() InstallResult {
 		return .failed
 	}
 	return .installed
+}
+
+fn vcs_backed_install_ancestor(install_path string, vmodules_path string) ?string {
+	vmodules_root := os.real_path(vmodules_path)
+	mut parent := os.real_path(os.dir(install_path))
+	for parent != vmodules_root && parent.starts_with(vmodules_root + os.path_separator) {
+		if vcs_used_in_dir(parent) != none {
+			return parent
+		}
+		next := os.dir(parent)
+		if next == parent {
+			break
+		}
+		parent = next
+	}
+	return none
 }
 
 fn (m Module) confirm_install() bool {

--- a/cmd/tools/vpm/install.v
+++ b/cmd/tools/vpm/install.v
@@ -203,13 +203,21 @@ fn (m Module) install() InstallResult {
 fn install_path_is_in_vmodules(install_path string, vmodules_path string) bool {
 	vmodules_root := real_path_with_missing_suffix(vmodules_path)
 	resolved_install_path := real_path_with_missing_suffix(install_path)
-	return resolved_install_path.starts_with(vmodules_root + os.path_separator)
+	return path_is_below(resolved_install_path, vmodules_root)
+}
+
+fn path_is_below(path string, root string) bool {
+	if path == root {
+		return false
+	}
+	boundary := if root.ends_with(os.path_separator) { root } else { root + os.path_separator }
+	return path.starts_with(boundary)
 }
 
 fn vcs_backed_install_ancestor(install_path string, vmodules_path string) ?string {
 	vmodules_root := real_path_with_missing_suffix(vmodules_path)
 	mut parent := real_path_with_missing_suffix(os.dir(install_path))
-	for parent != vmodules_root && parent.starts_with(vmodules_root + os.path_separator) {
+	for path_is_below(parent, vmodules_root) {
 		if vcs_used_in_dir(parent) != none {
 			return parent
 		}

--- a/cmd/tools/vpm/install.v
+++ b/cmd/tools/vpm/install.v
@@ -105,13 +105,21 @@ fn install_modules(modules []Module, selected_server_url string) {
 // Those are normalized away when the module is placed into `vmodules`, so point out
 // the resulting import path instead of leaving the mismatch for the compiler to report.
 fn (m Module) warn_on_normalized_name() {
-	import_path := import_path_of(m.install_path)
-	if import_path == m.name {
+	// Direct HTTP installs intentionally add the repository owner to the install path. That prefix
+	// is not a normalization of the manifest name and should not trigger this warning on its own.
+	if !m.name_was_normalized() {
 		return
 	}
+	import_path := import_path_of(m.install_path)
 	vpm_warn('`${m.name}` is not a valid V import path, it was installed as `${import_path}`.',
-		details: 'Use `import ${import_path}` to import it.\nConsider renaming the `name` field in the `v.mod` of the module.'
+		details: 'Use `${import_path}` as the normalized import prefix (for example, `import ${import_path}` when the package root is a module).\nConsider renaming the `name` field in the `v.mod` of the module.'
 	)
+}
+
+fn (m Module) name_was_normalized() bool {
+	normalized_name :=
+		normalize_mod_path(m.name.replace('.', os.path_separator)).replace(os.path_separator, '.')
+	return normalized_name != m.name
 }
 
 fn (m Module) install() InstallResult {

--- a/cmd/tools/vpm/install.v
+++ b/cmd/tools/vpm/install.v
@@ -143,6 +143,10 @@ fn (m Module) install() InstallResult {
 	defer {
 		os.rmdir_all(m.tmp_path) or {}
 	}
+	if !install_path_is_in_vmodules(m.install_path, settings.vmodules_path) {
+		vpm_error('refusing to install `${m.name}` outside the V modules directory.')
+		return .failed
+	}
 	if ancestor := vcs_backed_install_ancestor(m.install_path, settings.vmodules_path) {
 		vpm_error('refusing to install `${m.name}` inside existing module `${fmt_mod_path(ancestor)}`.')
 		return .failed
@@ -198,9 +202,15 @@ fn (m Module) install() InstallResult {
 	return .installed
 }
 
+fn install_path_is_in_vmodules(install_path string, vmodules_path string) bool {
+	vmodules_root := real_path_with_missing_suffix(vmodules_path)
+	resolved_install_path := real_path_with_missing_suffix(install_path)
+	return resolved_install_path.starts_with(vmodules_root + os.path_separator)
+}
+
 fn vcs_backed_install_ancestor(install_path string, vmodules_path string) ?string {
-	vmodules_root := os.real_path(vmodules_path)
-	mut parent := os.real_path(os.dir(install_path))
+	vmodules_root := real_path_with_missing_suffix(vmodules_path)
+	mut parent := real_path_with_missing_suffix(os.dir(install_path))
 	for parent != vmodules_root && parent.starts_with(vmodules_root + os.path_separator) {
 		if vcs_used_in_dir(parent) != none {
 			return parent
@@ -212,6 +222,24 @@ fn vcs_backed_install_ancestor(install_path string, vmodules_path string) ?strin
 		parent = next
 	}
 	return none
+}
+
+fn real_path_with_missing_suffix(path string) string {
+	mut existing := path
+	mut missing := []string{}
+	for !os.exists(existing) {
+		parent := os.dir(existing)
+		if parent == existing {
+			break
+		}
+		missing << os.file_name(existing)
+		existing = parent
+	}
+	mut resolved := os.real_path(existing)
+	for i := missing.len - 1; i >= 0; i-- {
+		resolved = os.join_path(resolved, missing[i])
+	}
+	return resolved
 }
 
 fn (m Module) confirm_install() bool {

--- a/cmd/tools/vpm/install.v
+++ b/cmd/tools/vpm/install.v
@@ -112,14 +112,31 @@ fn (m Module) warn_on_normalized_name() {
 	}
 	import_path := import_path_of(m.install_path)
 	vpm_warn('`${m.name}` is not a valid V import path, it was installed as `${import_path}`.',
-		details: 'Use `${import_path}` as the normalized import prefix (for example, `import ${import_path}` when the package root is a module).\nConsider renaming the `name` field in the `v.mod` of the module.'
+		details: m.normalized_name_warning_details(import_path)
 	)
+}
+
+fn (m Module) normalized_name_warning_details(import_path string) string {
+	mut details := 'Use `${import_path}` as the normalized import prefix (for example, `import ${import_path}` when the package root is a module).'
+	if m.manifest_name_was_normalized() {
+		details += '\nConsider renaming the `name` field in the `v.mod` of the module.'
+	}
+	return details
 }
 
 fn (m Module) name_was_normalized() bool {
 	normalized_name :=
 		normalize_mod_path(m.name.replace('.', os.path_separator)).replace(os.path_separator, '.')
 	return normalized_name != m.name
+}
+
+fn (m Module) manifest_name_was_normalized() bool {
+	if m.manifest.name == '' {
+		return false
+	}
+	normalized_name :=
+		normalize_mod_path(m.manifest.name.replace('.', os.path_separator)).replace(os.path_separator, '.')
+	return normalized_name != m.manifest.name
 }
 
 fn (m Module) install() InstallResult {

--- a/cmd/tools/vpm/install_local_test.v
+++ b/cmd/tools/vpm/install_local_test.v
@@ -114,6 +114,33 @@ fn test_update_and_remove_with_capitalized_ident() {
 	assert !os.exists(publisher_dir)
 }
 
+// A module named e.g. `my-mod` is installed as `my_mod`, since `-` is not valid
+// in a V import path. Make sure the mismatch is reported with the resulting
+// import path, instead of leaving users to guess it.
+fn test_install_warns_about_normalized_module_name() {
+	vmodules_path := os.join_path(test_path, 'vmodules_normalized_name')
+	test_utils.set_test_env(vmodules_path)
+	repo_path := os.join_path(test_path, 'hyphenated_repo')
+	create_local_git_module(repo_path, 'my-mod')
+
+	res := cmd_ok(@LOCATION, '${vexe} install ${os.quoted_path(repo_path)}')
+	assert res.output.contains('`my-mod` is not a valid V import path, it was installed as `my_mod`.'), res.output
+	assert res.output.contains('Use `import my_mod` to import it.'), res.output
+	assert os.exists(os.join_path(vmodules_path, 'my_mod', 'v.mod'))
+}
+
+// Counterpart of the test above: a module name that is already a valid import
+// path must not trigger the warning.
+fn test_install_does_not_warn_about_valid_module_name() {
+	vmodules_path := os.join_path(test_path, 'vmodules_valid_name')
+	test_utils.set_test_env(vmodules_path)
+	repo_path := os.join_path(test_path, 'valid_name_repo')
+	create_local_git_module(repo_path, 'my_mod')
+
+	res := cmd_ok(@LOCATION, '${vexe} install ${os.quoted_path(repo_path)}')
+	assert !res.output.contains('is not a valid V import path'), res.output
+}
+
 fn create_local_git_module(repo_path string, module_name string) {
 	os.mkdir_all(repo_path) or { panic(err) }
 	os.write_file(os.join_path(repo_path, 'v.mod'),

--- a/cmd/tools/vpm/install_local_test.v
+++ b/cmd/tools/vpm/install_local_test.v
@@ -3,7 +3,7 @@ module main
 import os
 import rand
 import v.vmod
-import test_utils { cmd_ok }
+import test_utils { cmd_fail, cmd_ok }
 
 const test_path = os.join_path(os.vtmp_dir(), 'vpm_install_local_test_${rand.ulid()}')
 
@@ -141,6 +141,18 @@ fn test_install_maps_manifest_dots_to_import_directories() {
 	assert res.output.contains('Use `foo.bar.baz` as the normalized import prefix'), res.output
 	assert os.exists(os.join_path(vmodules_path, 'foo', 'bar', 'baz', 'v.mod'))
 	assert 'foo.bar.baz' in get_installed_modules_in(vmodules_path)
+}
+
+fn test_dotted_install_does_not_nest_inside_existing_module() {
+	vmodules_path := os.join_path(test_path, 'vmodules_nested_module')
+	test_utils.set_test_env(vmodules_path)
+	create_local_git_module(os.join_path(vmodules_path, 'foo'), 'foo')
+	repo_path := os.join_path(test_path, 'nested_dotted_repo')
+	create_local_git_module(repo_path, 'foo.bar')
+
+	res := cmd_fail(@LOCATION, '${vexe} install ${os.quoted_path(repo_path)}')
+	assert res.output.contains('refusing to install `foo.bar` inside existing module'), res.output
+	assert !os.exists(os.join_path(vmodules_path, 'foo', 'bar'))
 }
 
 fn test_installed_module_discovery_preserves_vcs_links() {

--- a/cmd/tools/vpm/install_local_test.v
+++ b/cmd/tools/vpm/install_local_test.v
@@ -218,6 +218,13 @@ fn test_direct_install_rejects_different_repository_at_same_path() {
 	assert os.real_path(remote) == os.real_path(first_repo_path)
 }
 
+fn test_clone_source_identity_preserves_repository_path_case_and_port() {
+	base := normalized_clone_source('https://example.com/Owner/Repo.git')
+	assert base == normalized_clone_source('git@example.com:Owner/Repo.git')
+	assert base != normalized_clone_source('https://example.com/owner/repo.git')
+	assert base != normalized_clone_source('https://example.com:8443/Owner/Repo.git')
+}
+
 fn test_dotted_install_does_not_follow_linked_namespace() {
 	$if !windows {
 		vmodules_path := os.join_path(test_path, 'vmodules_linked_namespace')

--- a/cmd/tools/vpm/install_local_test.v
+++ b/cmd/tools/vpm/install_local_test.v
@@ -155,6 +155,16 @@ fn test_install_warns_when_repeated_dots_are_collapsed() {
 	assert os.exists(os.join_path(vmodules_path, 'foo', 'bar', 'v.mod'))
 }
 
+fn test_install_path_containment_supports_filesystem_roots() {
+	mut filesystem_root := os.real_path(os.getwd())
+	for os.dir(filesystem_root) != filesystem_root {
+		filesystem_root = os.dir(filesystem_root)
+	}
+	assert install_path_is_in_vmodules(os.join_path(filesystem_root, 'vpm_test_module'),
+		filesystem_root)
+	assert !install_path_is_in_vmodules(filesystem_root, filesystem_root)
+}
+
 fn test_dotted_install_does_not_nest_inside_existing_module() {
 	vmodules_path := os.join_path(test_path, 'vmodules_nested_module')
 	test_utils.set_test_env(vmodules_path)

--- a/cmd/tools/vpm/install_local_test.v
+++ b/cmd/tools/vpm/install_local_test.v
@@ -155,6 +155,24 @@ fn test_dotted_install_does_not_nest_inside_existing_module() {
 	assert !os.exists(os.join_path(vmodules_path, 'foo', 'bar'))
 }
 
+fn test_dotted_install_does_not_nest_inside_git_worktree() {
+	vmodules_path := os.join_path(test_path, 'vmodules_worktree_ancestor')
+	test_utils.set_test_env(vmodules_path)
+	source_repo_path := os.join_path(test_path, 'worktree_ancestor_source')
+	create_local_git_module(source_repo_path, 'foo')
+	worktree_path := os.join_path(vmodules_path, 'foo')
+	os.mkdir_all(vmodules_path) or { panic(err) }
+	cmd_ok(@LOCATION,
+		'git -C ${os.quoted_path(source_repo_path)} worktree add -b vpm-test ${os.quoted_path(worktree_path)}')
+	assert os.is_file(os.join_path(worktree_path, '.git'))
+	nested_repo_path := os.join_path(test_path, 'worktree_ancestor_nested')
+	create_local_git_module(nested_repo_path, 'foo.bar')
+
+	res := cmd_fail(@LOCATION, '${vexe} install ${os.quoted_path(nested_repo_path)}')
+	assert res.output.contains('refusing to install `foo.bar` inside existing module'), res.output
+	assert !os.exists(os.join_path(worktree_path, 'bar'))
+}
+
 fn test_root_install_does_not_replace_existing_module_namespace() {
 	vmodules_path := os.join_path(test_path, 'vmodules_existing_namespace')
 	test_utils.set_test_env(vmodules_path)

--- a/cmd/tools/vpm/install_local_test.v
+++ b/cmd/tools/vpm/install_local_test.v
@@ -143,6 +143,18 @@ fn test_install_maps_manifest_dots_to_import_directories() {
 	assert 'foo.bar.baz' in get_installed_modules_in(vmodules_path)
 }
 
+fn test_installed_module_discovery_preserves_vcs_links() {
+	$if !windows {
+		vmodules_path := os.join_path(test_path, 'vmodules_linked_module')
+		repo_path := os.join_path(test_path, 'linked_module_repo')
+		create_local_git_module(repo_path, 'author.linked')
+		publisher_path := os.join_path(vmodules_path, 'author')
+		os.mkdir_all(publisher_path) or { panic(err) }
+		os.symlink(repo_path, os.join_path(publisher_path, 'linked')) or { panic(err) }
+		assert 'author.linked' in get_installed_modules_in(vmodules_path)
+	}
+}
+
 // A publisher directory added for a direct HTTP install is intentional and does not mean that
 // the manifest name itself was normalized.
 fn test_publisher_prefix_does_not_look_like_name_normalization() {

--- a/cmd/tools/vpm/install_local_test.v
+++ b/cmd/tools/vpm/install_local_test.v
@@ -143,6 +143,18 @@ fn test_install_maps_manifest_dots_to_import_directories() {
 	assert 'foo.bar.baz' in get_installed_modules_in(vmodules_path)
 }
 
+fn test_install_warns_when_repeated_dots_are_collapsed() {
+	vmodules_path := os.join_path(test_path, 'vmodules_repeated_dots')
+	test_utils.set_test_env(vmodules_path)
+	repo_path := os.join_path(test_path, 'repeated_dots_repo')
+	create_local_git_module(repo_path, 'foo..bar')
+
+	res := cmd_ok(@LOCATION, '${vexe} install ${os.quoted_path(repo_path)}')
+	assert res.output.contains('`foo..bar` is not a valid V import path, it was installed as `foo.bar`.'), res.output
+
+	assert os.exists(os.join_path(vmodules_path, 'foo', 'bar', 'v.mod'))
+}
+
 fn test_dotted_install_does_not_nest_inside_existing_module() {
 	vmodules_path := os.join_path(test_path, 'vmodules_nested_module')
 	test_utils.set_test_env(vmodules_path)

--- a/cmd/tools/vpm/install_local_test.v
+++ b/cmd/tools/vpm/install_local_test.v
@@ -133,13 +133,14 @@ fn test_install_maps_manifest_dots_to_import_directories() {
 	vmodules_path := os.join_path(test_path, 'vmodules_dotted_name')
 	test_utils.set_test_env(vmodules_path)
 	repo_path := os.join_path(test_path, 'dotted_repo')
-	create_local_git_module(repo_path, 'Foo.bar')
+	create_local_git_module(repo_path, 'Foo.bar.baz')
 
 	res := cmd_ok(@LOCATION, '${vexe} install ${os.quoted_path(repo_path)}')
-	assert res.output.contains('`Foo.bar` is not a valid V import path, it was installed as `foo.bar`.'), res.output
+	assert res.output.contains('`Foo.bar.baz` is not a valid V import path, it was installed as `foo.bar.baz`.'), res.output
 
-	assert res.output.contains('Use `foo.bar` as the normalized import prefix'), res.output
-	assert os.exists(os.join_path(vmodules_path, 'foo', 'bar', 'v.mod'))
+	assert res.output.contains('Use `foo.bar.baz` as the normalized import prefix'), res.output
+	assert os.exists(os.join_path(vmodules_path, 'foo', 'bar', 'baz', 'v.mod'))
+	assert 'foo.bar.baz' in get_installed_modules_in(vmodules_path)
 }
 
 // A publisher directory added for a direct HTTP install is intentional and does not mean that

--- a/cmd/tools/vpm/install_local_test.v
+++ b/cmd/tools/vpm/install_local_test.v
@@ -209,10 +209,18 @@ fn test_direct_install_rejects_different_repository_at_same_path() {
 	create_local_git_module(first_repo_path, 'foo.bar')
 	create_local_git_module(second_repo_path, 'foo.bar')
 	cmd_ok(@LOCATION, '${vexe} install ${os.quoted_path(first_repo_path)}')
+	installed_path := os.join_path(vmodules_path, 'foo', 'bar')
+	mut registered_mod := Module{
+		name:         'foo.bar'
+		url:          second_repo_path
+		install_path: installed_path
+		vcs:          VCS.git
+	}
+	registered_mod.get_installed()
+	assert !registered_mod.is_installed
 
 	res := cmd_fail(@LOCATION, '${vexe} install ${os.quoted_path(second_repo_path)}')
 	assert res.output.contains('refusing to install `foo.bar`: destination'), res.output
-	installed_path := os.join_path(vmodules_path, 'foo', 'bar')
 	remote :=
 		cmd_ok(@LOCATION, 'git -C ${os.quoted_path(installed_path)} remote get-url origin').output.trim_space()
 	assert os.real_path(remote) == os.real_path(first_repo_path)

--- a/cmd/tools/vpm/install_local_test.v
+++ b/cmd/tools/vpm/install_local_test.v
@@ -201,6 +201,23 @@ fn test_root_install_does_not_replace_existing_module_namespace() {
 	assert entries == ['bar']
 }
 
+fn test_direct_install_rejects_different_repository_at_same_path() {
+	vmodules_path := os.join_path(test_path, 'vmodules_repository_collision')
+	test_utils.set_test_env(vmodules_path)
+	first_repo_path := os.join_path(test_path, 'repository_collision_first')
+	second_repo_path := os.join_path(test_path, 'repository_collision_second')
+	create_local_git_module(first_repo_path, 'foo.bar')
+	create_local_git_module(second_repo_path, 'foo.bar')
+	cmd_ok(@LOCATION, '${vexe} install ${os.quoted_path(first_repo_path)}')
+
+	res := cmd_fail(@LOCATION, '${vexe} install ${os.quoted_path(second_repo_path)}')
+	assert res.output.contains('refusing to install `foo.bar`: destination'), res.output
+	installed_path := os.join_path(vmodules_path, 'foo', 'bar')
+	remote :=
+		cmd_ok(@LOCATION, 'git -C ${os.quoted_path(installed_path)} remote get-url origin').output.trim_space()
+	assert os.real_path(remote) == os.real_path(first_repo_path)
+}
+
 fn test_dotted_install_does_not_follow_linked_namespace() {
 	$if !windows {
 		vmodules_path := os.join_path(test_path, 'vmodules_linked_namespace')

--- a/cmd/tools/vpm/install_local_test.v
+++ b/cmd/tools/vpm/install_local_test.v
@@ -155,6 +155,22 @@ fn test_dotted_install_does_not_nest_inside_existing_module() {
 	assert !os.exists(os.join_path(vmodules_path, 'foo', 'bar'))
 }
 
+fn test_root_install_does_not_replace_existing_module_namespace() {
+	vmodules_path := os.join_path(test_path, 'vmodules_existing_namespace')
+	test_utils.set_test_env(vmodules_path)
+	nested_repo_path := os.join_path(test_path, 'existing_namespace_nested_repo')
+	create_local_git_module(nested_repo_path, 'foo.bar')
+	cmd_ok(@LOCATION, '${vexe} install ${os.quoted_path(nested_repo_path)}')
+	root_repo_path := os.join_path(test_path, 'existing_namespace_root_repo')
+	create_local_git_module(root_repo_path, 'foo')
+
+	res := cmd_fail(@LOCATION, '${vexe} install ${os.quoted_path(root_repo_path)}')
+	assert res.output.contains('refusing to install `foo`: destination'), res.output
+	assert os.exists(os.join_path(vmodules_path, 'foo', 'bar', 'v.mod'))
+	entries := os.ls(os.join_path(vmodules_path, 'foo')) or { panic(err) }
+	assert entries == ['bar']
+}
+
 fn test_installed_module_discovery_preserves_vcs_links() {
 	$if !windows {
 		vmodules_path := os.join_path(test_path, 'vmodules_linked_module')

--- a/cmd/tools/vpm/install_local_test.v
+++ b/cmd/tools/vpm/install_local_test.v
@@ -323,7 +323,19 @@ fn test_installed_module_discovery_ignores_unrelated_vcs_directories() {
 	unrelated_path := os.join_path(vmodules_path, 'cache', 'unrelated')
 	os.mkdir_all(unrelated_path) or { panic(err) }
 	cmd_ok(@LOCATION, 'git init ${os.quoted_path(unrelated_path)}')
+	cmd_ok(@LOCATION,
+		'git -C ${os.quoted_path(unrelated_path)} remote add origin https://github.com/other/repository')
 	assert 'cache.unrelated' !in get_installed_modules_in(vmodules_path)
+}
+
+fn test_installed_module_discovery_preserves_manifestless_registered_checkout() {
+	vmodules_path := os.join_path(test_path, 'vmodules_manifestless_registered')
+	module_path := os.join_path(vmodules_path, 'spytheman', 'regex')
+	os.mkdir_all(module_path) or { panic(err) }
+	cmd_ok(@LOCATION, 'git init ${os.quoted_path(module_path)}')
+	cmd_ok(@LOCATION,
+		'git -C ${os.quoted_path(module_path)} remote add origin https://github.com/spytheman/v-regex')
+	assert 'spytheman.regex' in get_installed_modules_in(vmodules_path)
 }
 
 // A publisher directory added for a direct HTTP install is intentional and does not mean that

--- a/cmd/tools/vpm/install_local_test.v
+++ b/cmd/tools/vpm/install_local_test.v
@@ -171,6 +171,35 @@ fn test_root_install_does_not_replace_existing_module_namespace() {
 	assert entries == ['bar']
 }
 
+fn test_dotted_install_does_not_follow_linked_namespace() {
+	$if !windows {
+		vmodules_path := os.join_path(test_path, 'vmodules_linked_namespace')
+		test_utils.set_test_env(vmodules_path)
+		os.mkdir_all(vmodules_path) or { panic(err) }
+		linked_repo_path := os.join_path(test_path, 'linked_namespace_repo')
+		create_local_git_module(linked_repo_path, 'foo')
+		os.symlink(linked_repo_path, os.join_path(vmodules_path, 'foo')) or { panic(err) }
+		nested_repo_path := os.join_path(test_path, 'linked_namespace_nested_repo')
+		create_local_git_module(nested_repo_path, 'foo.bar')
+
+		res := cmd_fail(@LOCATION, '${vexe} install ${os.quoted_path(nested_repo_path)}')
+		assert res.output.contains('refusing to install `foo.bar` outside the V modules directory'), res.output
+
+		assert !os.exists(os.join_path(linked_repo_path, 'bar'))
+	}
+}
+
+fn test_remove_prunes_deep_empty_module_namespaces() {
+	vmodules_path := os.join_path(test_path, 'vmodules_remove_namespaces')
+	test_utils.set_test_env(vmodules_path)
+	repo_path := os.join_path(test_path, 'remove_namespaces_repo')
+	create_local_git_module(repo_path, 'foo.bar.baz')
+	cmd_ok(@LOCATION, '${vexe} install ${os.quoted_path(repo_path)}')
+
+	cmd_ok(@LOCATION, '${vexe} remove foo.bar.baz')
+	assert !os.exists(os.join_path(vmodules_path, 'foo'))
+}
+
 fn test_installed_module_discovery_preserves_vcs_links() {
 	$if !windows {
 		vmodules_path := os.join_path(test_path, 'vmodules_linked_module')

--- a/cmd/tools/vpm/install_local_test.v
+++ b/cmd/tools/vpm/install_local_test.v
@@ -154,6 +154,15 @@ fn test_publisher_prefix_does_not_look_like_name_normalization() {
 	assert Module{
 		name: 'my-mod'
 	}.name_was_normalized()
+	registered := Module{
+		name:     'IsaiahPatton.iui'
+		manifest: vmod.Manifest{
+			name: 'iui'
+		}
+	}
+	assert !registered.normalized_name_warning_details('isaiahpatton.iui').contains('Consider renaming')
+	assert direct_install_mod_path('publisher', 'foo.bar') == os.join_path('publisher', 'foo',
+		'bar')
 }
 
 fn test_import_path_canonicalizes_the_installed_leaf() {

--- a/cmd/tools/vpm/install_local_test.v
+++ b/cmd/tools/vpm/install_local_test.v
@@ -125,8 +125,32 @@ fn test_install_warns_about_normalized_module_name() {
 
 	res := cmd_ok(@LOCATION, '${vexe} install ${os.quoted_path(repo_path)}')
 	assert res.output.contains('`my-mod` is not a valid V import path, it was installed as `my_mod`.'), res.output
-	assert res.output.contains('Use `import my_mod` to import it.'), res.output
+	assert res.output.contains('Use `my_mod` as the normalized import prefix'), res.output
 	assert os.exists(os.join_path(vmodules_path, 'my_mod', 'v.mod'))
+}
+
+// A publisher directory added for a direct HTTP install is intentional and does not mean that
+// the manifest name itself was normalized.
+fn test_publisher_prefix_does_not_look_like_name_normalization() {
+	m := Module{
+		name:         'hashmap'
+		install_path: os.join_path(settings.vmodules_path, 'wertzui123', 'hashmap')
+	}
+	assert !m.name_was_normalized()
+	assert Module{
+		name: 'my-mod'
+	}.name_was_normalized()
+}
+
+fn test_import_path_canonicalizes_the_installed_leaf() {
+	$if !windows {
+		real_vmodules := os.join_path(test_path, 'canonical_vmodules')
+		linked_vmodules := os.join_path(test_path, 'linked_vmodules')
+		installed_path := os.join_path(real_vmodules, 'my_mod')
+		os.mkdir_all(installed_path) or { panic(err) }
+		os.symlink(real_vmodules, linked_vmodules) or { panic(err) }
+		assert import_path_relative_to(os.join_path(linked_vmodules, 'my_mod'), linked_vmodules) == 'my_mod'
+	}
 }
 
 // Counterpart of the test above: a module name that is already a valid import

--- a/cmd/tools/vpm/install_local_test.v
+++ b/cmd/tools/vpm/install_local_test.v
@@ -129,6 +129,19 @@ fn test_install_warns_about_normalized_module_name() {
 	assert os.exists(os.join_path(vmodules_path, 'my_mod', 'v.mod'))
 }
 
+fn test_install_maps_manifest_dots_to_import_directories() {
+	vmodules_path := os.join_path(test_path, 'vmodules_dotted_name')
+	test_utils.set_test_env(vmodules_path)
+	repo_path := os.join_path(test_path, 'dotted_repo')
+	create_local_git_module(repo_path, 'Foo.bar')
+
+	res := cmd_ok(@LOCATION, '${vexe} install ${os.quoted_path(repo_path)}')
+	assert res.output.contains('`Foo.bar` is not a valid V import path, it was installed as `foo.bar`.'), res.output
+
+	assert res.output.contains('Use `foo.bar` as the normalized import prefix'), res.output
+	assert os.exists(os.join_path(vmodules_path, 'foo', 'bar', 'v.mod'))
+}
+
 // A publisher directory added for a direct HTTP install is intentional and does not mean that
 // the manifest name itself was normalized.
 fn test_publisher_prefix_does_not_look_like_name_normalization() {

--- a/cmd/tools/vpm/install_local_test.v
+++ b/cmd/tools/vpm/install_local_test.v
@@ -250,6 +250,17 @@ fn test_publisher_prefix_does_not_look_like_name_normalization() {
 	assert !registered.normalized_name_warning_details('isaiahpatton.iui').contains('Consider renaming')
 	assert direct_install_mod_path('publisher', 'foo.bar') == os.join_path('publisher', 'foo',
 		'bar')
+	assert direct_install_mod_path('acme.inc', 'my-mod') == os.join_path('acme', 'inc', 'my_mod')
+}
+
+fn test_url_lookup_preserves_legacy_dotted_layout() {
+	vmodules_path := os.join_path(test_path, 'vmodules_legacy_url_layout')
+	legacy_path := os.join_path(vmodules_path, 'publisher', 'foo.bar')
+	os.mkdir_all(legacy_path) or { panic(err) }
+	found := get_path_of_existing_url_module(vmodules_path, 'publisher', 'foo.bar') or {
+		panic(err)
+	}
+	assert found == os.real_path(legacy_path)
 }
 
 fn test_import_path_canonicalizes_the_installed_leaf() {

--- a/cmd/tools/vpm/install_local_test.v
+++ b/cmd/tools/vpm/install_local_test.v
@@ -241,6 +241,8 @@ fn test_clone_source_identity_preserves_repository_path_case_and_port() {
 	assert base == normalized_clone_source('git@example.com:Owner/Repo.git')
 	assert base != normalized_clone_source('https://example.com/owner/repo.git')
 	assert base != normalized_clone_source('https://example.com:8443/Owner/Repo.git')
+	github := normalized_clone_source('https://github.com/Owner/Repo.git')
+	assert github == normalized_clone_source('git@github.com:owner/repo.git')
 }
 
 fn test_dotted_install_does_not_follow_linked_namespace() {
@@ -258,6 +260,23 @@ fn test_dotted_install_does_not_follow_linked_namespace() {
 		assert res.output.contains('refusing to install `foo.bar` outside the V modules directory'), res.output
 
 		assert !os.exists(os.join_path(linked_repo_path, 'bar'))
+	}
+}
+
+fn test_dotted_install_rejects_linked_namespace_inside_vmodules() {
+	$if !windows {
+		vmodules_path := os.join_path(test_path, 'vmodules_internal_linked_namespace')
+		test_utils.set_test_env(vmodules_path)
+		real_namespace := os.join_path(vmodules_path, 'real_namespace')
+		os.mkdir_all(real_namespace) or { panic(err) }
+		os.symlink(real_namespace, os.join_path(vmodules_path, 'foo')) or { panic(err) }
+		repo_path := os.join_path(test_path, 'internal_linked_namespace_repo')
+		create_local_git_module(repo_path, 'foo.bar')
+
+		res := cmd_fail(@LOCATION, '${vexe} install ${os.quoted_path(repo_path)}')
+		assert res.output.contains('refusing to install `foo.bar` inside a symlinked module namespace'), res.output
+
+		assert !os.exists(os.join_path(real_namespace, 'bar'))
 	}
 }
 
@@ -282,6 +301,29 @@ fn test_installed_module_discovery_preserves_vcs_links() {
 		os.symlink(repo_path, os.join_path(publisher_path, 'linked')) or { panic(err) }
 		assert 'author.linked' in get_installed_modules_in(vmodules_path)
 	}
+}
+
+fn test_installed_module_discovery_follows_linked_namespaces_without_cycles() {
+	$if !windows {
+		vmodules_path := os.join_path(test_path, 'vmodules_linked_discovery_namespace')
+		namespace_path := os.join_path(test_path, 'linked_discovery_namespace')
+		create_local_git_module(os.join_path(namespace_path, 'pkg'), 'author.pkg')
+		os.symlink(namespace_path, os.join_path(namespace_path, 'cycle')) or { panic(err) }
+		os.mkdir_all(vmodules_path) or { panic(err) }
+		os.symlink(namespace_path, os.join_path(vmodules_path, 'author')) or { panic(err) }
+
+		modules := get_installed_modules_in(vmodules_path)
+		assert 'author.pkg' in modules
+		assert modules.len == 1
+	}
+}
+
+fn test_installed_module_discovery_ignores_unrelated_vcs_directories() {
+	vmodules_path := os.join_path(test_path, 'vmodules_unrelated_repository')
+	unrelated_path := os.join_path(vmodules_path, 'cache', 'unrelated')
+	os.mkdir_all(unrelated_path) or { panic(err) }
+	cmd_ok(@LOCATION, 'git init ${os.quoted_path(unrelated_path)}')
+	assert 'cache.unrelated' !in get_installed_modules_in(vmodules_path)
 }
 
 // A publisher directory added for a direct HTTP install is intentional and does not mean that

--- a/cmd/tools/vpm/link.v
+++ b/cmd/tools/vpm/link.v
@@ -73,7 +73,7 @@ fn vpm_unlink(query []string) {
 		vpm_error('failed to unlink `${project.name}`.', details: err.msg())
 		exit(1)
 	}
-	cleanup_empty_link_parent_dirs(project.link_path)
+	cleanup_empty_module_parent_dirs(project.link_path)
 	println('Unlinked `${project.name}` from `${fmt_mod_path(project.link_path)}`.')
 }
 
@@ -118,21 +118,5 @@ fn remove_symlink(path string) ! {
 		} $else {
 			return err
 		}
-	}
-}
-
-fn cleanup_empty_link_parent_dirs(link_path string) {
-	vmodules_path := if os.is_dir(settings.vmodules_path) {
-		os.real_path(settings.vmodules_path)
-	} else {
-		settings.vmodules_path
-	}
-	mut parent := os.dir(link_path)
-	for parent != vmodules_path && parent != os.dir(parent) {
-		if !os.is_dir(parent) || !os.is_dir_empty(parent) {
-			break
-		}
-		os.rmdir(parent) or { break }
-		parent = os.dir(parent)
 	}
 }

--- a/cmd/tools/vpm/parse.v
+++ b/cmd/tools/vpm/parse.v
@@ -157,8 +157,7 @@ fn (mut p Parser) parse_module(m string, mut selector VpmInstallServerSelector) 
 		mod_path := if registered_name != '' {
 			normalize_mod_path(final_name.replace('.', os.path_separator))
 		} else {
-			normalize_mod_path(os.join_path(if kind == .http { publisher } else { '' }, manifest.name.replace('.',
-				os.path_separator)))
+			direct_install_mod_path(if kind == .http { publisher } else { '' }, manifest.name)
 		}
 		Module{
 			name:         final_name

--- a/cmd/tools/vpm/parse.v
+++ b/cmd/tools/vpm/parse.v
@@ -327,7 +327,7 @@ fn normalized_clone_source(raw_source string) string {
 		|| raw.starts_with('../') || raw.starts_with('~/') || os.exists(local_path) {
 		return 'file://' + os.real_path(local_path)
 	}
-	return normalize_repo_lookup_url(raw) or { raw.trim_string_right('.git').to_lower() }
+	return normalize_clone_source_url(raw) or { raw.trim_string_right('.git') }
 }
 
 fn get_tmp_path(relative_path string) !string {

--- a/cmd/tools/vpm/parse.v
+++ b/cmd/tools/vpm/parse.v
@@ -276,6 +276,9 @@ fn is_local_repository(query string) bool {
 }
 
 fn (mut m Module) get_installed() {
+	if m.is_external && !m.existing_checkout_matches_source() {
+		return
+	}
 	refs := os.execute_opt('git ls-remote --refs ${m.install_path}') or { return }
 	vpm_log(@FILE_LINE, @FN, 'refs: ${refs}')
 	m.is_installed = true
@@ -294,6 +297,37 @@ fn (mut m Module) get_installed() {
 			m.installed_version = tag
 		}
 	}
+}
+
+fn (m Module) existing_checkout_matches_source() bool {
+	if !os.is_dir(m.install_path) {
+		return false
+	}
+	existing_url := match settings.vcs {
+		.git {
+			result := os.execute_opt('git -C ${os.quoted_path(m.install_path)} remote get-url origin') or {
+				return false
+			}
+			result.output.trim_space()
+		}
+		.hg {
+			result := os.execute_opt('hg -R ${os.quoted_path(m.install_path)} paths default') or {
+				return false
+			}
+			result.output.trim_space()
+		}
+	}
+	return normalized_clone_source(existing_url) == normalized_clone_source(m.url)
+}
+
+fn normalized_clone_source(raw_source string) string {
+	raw := raw_source.trim_space()
+	local_path := os.expand_tilde_to_home(raw.trim_string_left('file://'))
+	if raw.starts_with('file://') || os.is_abs_path(local_path) || raw.starts_with('./')
+		|| raw.starts_with('../') || raw.starts_with('~/') || os.exists(local_path) {
+		return 'file://' + os.real_path(local_path)
+	}
+	return normalize_repo_lookup_url(raw) or { raw.trim_string_right('.git').to_lower() }
 }
 
 fn get_tmp_path(relative_path string) !string {

--- a/cmd/tools/vpm/parse.v
+++ b/cmd/tools/vpm/parse.v
@@ -157,8 +157,8 @@ fn (mut p Parser) parse_module(m string, mut selector VpmInstallServerSelector) 
 		mod_path := if registered_name != '' {
 			normalize_mod_path(final_name.replace('.', os.path_separator))
 		} else {
-			normalize_mod_path(os.join_path(if kind == .http { publisher } else { '' },
-				manifest.name))
+			normalize_mod_path(os.join_path(if kind == .http { publisher } else { '' }, manifest.name.replace('.',
+				os.path_separator)))
 		}
 		Module{
 			name:         final_name

--- a/cmd/tools/vpm/parse.v
+++ b/cmd/tools/vpm/parse.v
@@ -276,7 +276,7 @@ fn is_local_repository(query string) bool {
 }
 
 fn (mut m Module) get_installed() {
-	if m.is_external && !m.existing_checkout_matches_source() {
+	if m.url != '' && !m.existing_checkout_matches_source() {
 		return
 	}
 	refs := os.execute_opt('git ls-remote --refs ${m.install_path}') or { return }
@@ -303,7 +303,8 @@ fn (m Module) existing_checkout_matches_source() bool {
 	if !os.is_dir(m.install_path) {
 		return false
 	}
-	existing_url := match settings.vcs {
+	vcs := m.vcs or { settings.vcs }
+	existing_url := match vcs {
 		.git {
 			result := os.execute_opt('git -C ${os.quoted_path(m.install_path)} remote get-url origin') or {
 				return false

--- a/cmd/tools/vpm/parse.v
+++ b/cmd/tools/vpm/parse.v
@@ -163,7 +163,7 @@ fn (mut p Parser) parse_module(m string, mut selector VpmInstallServerSelector) 
 			name:         final_name
 			url:          ident
 			version:      version
-			install_path: os.real_path(os.join_path(settings.vmodules_path, mod_path))
+			install_path: os.abs_path(os.join_path(settings.vmodules_path, mod_path))
 			is_external:  true
 			tmp_path:     tmp_path
 			manifest:     manifest
@@ -222,7 +222,7 @@ fn (mut p Parser) parse_module(m string, mut selector VpmInstallServerSelector) 
 			url:          info.url
 			version:      version
 			vcs:          vcs
-			install_path: os.real_path(os.join_path(settings.vmodules_path, mod_path))
+			install_path: os.abs_path(os.join_path(settings.vmodules_path, mod_path))
 			tmp_path:     tmp_path
 			manifest:     manifest
 		}

--- a/cmd/tools/vpm/update.v
+++ b/cmd/tools/vpm/update.v
@@ -44,11 +44,7 @@ fn update_module(mut pp pool.PoolProcessor, idx int, _wid int) &UpdateResult {
 	// Derive the canonical module name from the install path so URL-based
 	// updates report the registered name (e.g. `spytheman.vtray` for
 	// `<vmodules>/spytheman/vtray`) instead of the bare URL-derived `vtray`.
-	// Normalize both sides via real_path so macOS's `/tmp` -> `/private/tmp`
-	// resolution doesn't leave the prefix unstripped.
-	vmodules_real := os.real_path(settings.vmodules_path)
-	rel_install_path := install_path.trim_string_left(vmodules_real).trim_left(os.path_separator)
-	name := rel_install_path.replace(os.path_separator, '.')
+	name := import_path_of(install_path)
 	vcs := vcs_used_in_dir(install_path) or {
 		vpm_error('failed to find version control system for `${name}`.', verbose: true)
 		return &UpdateResult{}

--- a/cmd/tools/vpm/vcs.v
+++ b/cmd/tools/vpm/vcs.v
@@ -84,7 +84,8 @@ fn (vcs &VCS) is_executable() ! {
 
 fn vcs_used_in_dir(dir string) ?VCS {
 	for vcs, info in vcs_info {
-		if os.is_dir(os.real_path(os.join_path(dir, info.dir))) {
+		vcs_path := os.real_path(os.join_path(dir, info.dir))
+		if os.is_dir(vcs_path) || (vcs == .git && os.is_file(vcs_path)) {
 			return vcs
 		}
 	}

--- a/cmd/tools/vpm/vpm.v
+++ b/cmd/tools/vpm/vpm.v
@@ -160,16 +160,7 @@ fn vpm_remove(query []string) {
 		println('Removing module "${m}" from ${fmt_mod_path(final_module_path)} ...')
 		vpm_log(@FILE_LINE, @FN, 'removing: ${final_module_path}')
 		rmdir_all(final_module_path) or { vpm_error(err.msg(), verbose: true) }
-		// Delete author directory if it is empty.
-		author := normalize_mod_path(m.split('.')[0])
-		author_dir := os.real_path(os.join_path(settings.vmodules_path, author))
-		if !os.exists(author_dir) {
-			continue
-		}
-		if os.is_dir_empty(author_dir) {
-			verbose_println('Removing author folder ${author_dir}')
-			rmdir_all(author_dir) or { vpm_error(err.msg(), verbose: true) }
-		}
+		cleanup_empty_module_parent_dirs(final_module_path)
 	}
 }
 

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -6218,6 +6218,21 @@ folder containing `v.mod`.
 V packages are installed normally in your `~/.vmodules` folder. That
 location can be overridden by setting the env variable `VMODULES`.
 
+### Package names and import paths
+
+A package name can contain characters that are not valid in a V import
+path, for example `-` or uppercase letters. Such names are normalized
+when the package is installed: `-` becomes `_` and the name is
+lowercased. A package named `my-mod` is therefore installed as
+`~/.vmodules/my_mod` and imported with `import my_mod`. The same applies
+to the publisher part of a VPM package name, so `Some-Publisher.repo` is
+installed as `~/.vmodules/some_publisher/repo` and imported with
+`import some_publisher.repo`.
+
+`v install` prints a warning with the resulting import path whenever it
+has to normalize a name. If you publish a package, prefer a `name` in
+`v.mod` that is already a valid import path.
+
 ### Package commands
 
 You can use the V frontend to do package operations, just like you can

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -6229,9 +6229,11 @@ to the publisher part of a VPM package name, so `Some-Publisher.repo` is
 installed as `~/.vmodules/some_publisher/repo` and imported with
 `import some_publisher.repo`.
 
-`v install` prints a warning with the resulting import path whenever it
-has to normalize a name. If you publish a package, prefer a `name` in
-`v.mod` that is already a valid import path.
+`v install` prints a warning with the resulting import prefix whenever it
+has to normalize a name. A package may contain only nested modules, so append
+the nested module path when needed (for example, `import my_mod.json`). If you
+publish a package, prefer a `name` in `v.mod` that is already a valid import
+path.
 
 ### Package commands
 


### PR DESCRIPTION
V import paths cannot contain `-`, so `vpm` normalizes module names via `normalize_mod_path` (`-` -> `_`, lowercased) when placing a module into `vmodules`.

That normalization is silent. A module published as `my-mod` is installed as:

```
Installing `my-mod`...
Installed `my-mod` in ~/.vmodules/my_mod .
```

The reported name is `my-mod`, but `import my-mod` does not compile, and nothing tells the user that the usable import path is `my_mod`. The same applies to capitalized names and to hyphenated publishers registered on VPM (`something-other.repo` -> `something_other/repo`).

This adds a warning right after the install line, whenever the on-disk import path differs from the module name:

```
Installed `my-mod` in ~/.vmodules/my_mod .
warning: `my-mod` is not a valid V import path, it was installed as `my_mod`.
details: Use `import my_mod` to import it.
         Consider renaming the `name` field in the `v.mod` of the module.
```

Modules whose name is already a valid import path are unaffected.

The import path is derived by `import_path_of/1`, extracted from `update_module`, which already computed the same relative-path-to-dotted-name mapping.

Tests added to `install_local_test.v` for both the warning and the no-warning case.
