### PR TITLE
thirdparty: add managed tccbin baseline activation

### DIFF
--- a/doc/tccbin_automation.md
+++ b/doc/tccbin_automation.md
@@ -256,13 +256,16 @@ blob, provenance, contract-binding, and publication decision to the existing sta
 
 ```sh
 tccbin-automation candidate-preflight \
-  <target-id> <monthly|legacy-onboard> <candidate-repo-root> \
+  <target-id> <monthly|legacy-onboard|baseline-activate> <candidate-repo-root> \
   <base-sha> <candidate-sha> <work-root> <publish-requested>
 ```
 
 The successful work root contains detached `base-source/` and `candidate-source/` clones and the
 payload-only `payload/`. A caller may continue only when the command reports both `eligible=true`
 and, for publication, `publish_allowed=true`.
+
+`baseline-activate` is validation-only: `publish-requested=true` is rejected immediately after its
+reviewed policy is loaded and before candidate input or a work root is touched.
 
 ### Candidate composition and dormant legacy onboarding
 
@@ -280,7 +283,7 @@ publication-disabled candidate preflight.
 
 ```sh
 tccbin-automation candidate-compose \
-  <target-id> <monthly|legacy-onboard> <base-repo-root> <base-sha> \
+  <target-id> <monthly|legacy-onboard|baseline-activate> <base-repo-root> <base-sha> \
   <raw-root> <manifest> <result-root>
 ```
 
@@ -299,6 +302,104 @@ ID and hash, recipe
 identity, patch and transform semantics without byte hashes, probes and effects, and the static
 partition of overlays, inventory, and outputs. Runtime contract identity, resolved source and
 toolchain observations, byte digests, and derived provenance status remain outside that policy.
+
+### Dormant managed-baseline activation
+
+`baseline-activate` is the one-time migration boundary for the six manifest-bearing Phase A
+baselines. It is distinct from `legacy-onboard`: the reviewed base already contains an automation
+manifest, so it cannot satisfy the legacy rule that the base manifest be absent. It is also
+distinct from `monthly`: every Phase A base has an all-null toolchain binding and incomplete
+provenance, while a monthly transition requires authenticated producer observations under the
+same non-null reviewed profile in both manifests.
+
+Each target's `managed_baseline_activation` registry object seals the exact integrated Phase A
+commit, tree, sole parent, manifest byte hash, and the immutable contract repository/SHA recorded
+by that manifest. The six reviewed anchors are:
+
+- `freebsd-amd64`
+  - Baseline commit: `e71cda6242e88e47312ca9bfc4548b0579636e0c`
+  - Baseline tree: `9438879ad9906e970d45bafacf6ce2cc63ae4c53`
+  - Sole parent: `fdf5cdfea6ea84612e068bc3bea433dbba263404`
+  - Manifest SHA-256: `a9c2f15451a7e94261c6dd4d9e47cc3965414a2179d04af5902dffc9471a4db3`
+- `linux-amd64`
+  - Baseline commit: `d6e7ac1b1bcc98aed734a6ecbfa8509f24606c74`
+  - Baseline tree: `22851c0f356fefcb63718ce63d50a870150a491c`
+  - Sole parent: `ece46f06fbe6eb701d52442f11dd59c48d166cae`
+  - Manifest SHA-256: `bcdce1bea1facb24175229a16dc6e8a2c4210aafc05f0526b2728dc060223ed4`
+- `macos-amd64`
+  - Baseline commit: `199fa78395ca413aac23d02ec69cc5e7b1d805a2`
+  - Baseline tree: `db67711bfeb33be63dbc8eb03ecdddc2e127cc8c`
+  - Sole parent: `da8ac5a4369accc67c485191d02535d77718a1c8`
+  - Manifest SHA-256: `09dc54928f4690cfee7fd113de93f36479a40cabd10eeb3ee416a3175b42270a`
+- `macos-arm64`
+  - Baseline commit: `1d0ad0ecf70a91a1df64cebf215e683b1d5aedb5`
+  - Baseline tree: `96af5121f065310ba9168e3e2dc61adf340e2738`
+  - Sole parent: `274abd2466a14861b75e5b91fd946ad27d114499`
+  - Manifest SHA-256: `be45aaee1e65cc1ed2ee6bd2f121d72cbc248887ffa3d57f4b6d59cb6ea73525`
+- `openbsd-amd64`
+  - Baseline commit: `8c7d96c75ea8548f007432d70f1ae33cccd81838`
+  - Baseline tree: `f75c4862711184c4c191a73e6f996eb421bd37b4`
+  - Sole parent: `45230fde96c17fff4baf37deb55e90803c043063`
+  - Manifest SHA-256: `873b62af697ba25f0abe5887ba05972a93bd48990233853b362bed6cb9137699`
+- `windows-amd64`
+  - Baseline commit: `86ae5844b8b56071b21ae3aa138b247d5eb9ddd9`
+  - Baseline tree: `818d7794ebdf41de60e5679d485e3a5d49272171`
+  - Sole parent: `f7c7199bb87fda8b80b31fefa470b2efc952326b`
+  - Manifest SHA-256: `b5728124ecf8dc01e4f16cf4188411d6f633bb57997ef36df2dc5fd182e8535a`
+
+All six anchors bind `base_contract_repository=vlang/v` and
+`base_contract_sha=7545e515b434cd399333d43659238427d72e22e7`. Their policy path/hash pairs
+are deliberately null. Consequently, `baseline-activate` stops with
+`target has no reviewed managed baseline activation policy` before it reads candidate input. A
+future reviewed policy will be canonical JSON at
+`baseline-activation/<target>.policy.json`, using onboarding-policy projection v2 and binding the
+resolved target toolchain profile. Projection v1 remains exclusive to legacy onboarding. The v2
+policy has one closed `source_commit_evidence` entry for every source and no extra entry. External
+sources seal ID, repository, ref, commit SHA, tree SHA, and canonical base64 of the bounded raw Git
+commit object. The validator reconstructs `SHA1("commit <length>\0" + raw)`, requires the first
+and only `tree` header to match, and compares the candidate's complete five-field source tuple to
+that reviewed evidence. Candidate source or provenance fields are never their own authority.
+
+The Windows `v-libgc` entry instead has only `authority=runtime-contract`, its fixed source ID,
+repository, and ref; it cannot auto-pin a SHA or tree into the policy stored by the same V commit.
+At activation time its candidate SHA must equal the embedded runtime contract SHA, and its tree
+must equal the tree resolved for that exact commit in a separate hardened V Git checkout. That
+checkout must be a complete SHA-1 repository with `core.autocrlf=false`, no redirects, alternates,
+grafts, or replacement refs, the exact `vlang/v` HTTPS origin, and a clean tracked, detached HEAD at
+the runtime SHA. The updater must supply this private checkout; a mutable Actions branch checkout
+is not activation authority. The base anchors remain audit inputs only: they are not source
+provenance, native evidence, last-known-good tuples, or permission to seed durable state.
+
+For an activated candidate, every payload entry with complete provenance binds its provenance
+repository to the SHA from reviewed commit evidence, or to the runtime SHA for `vlang/v`.
+`vlang/tccbin` provenance instead binds to the sealed baseline commit. Unknown repositories,
+sources absent from the target's closed source matrix, and SHAs borrowed from a different source
+are rejected.
+
+This foundation introduces no production profile, onboarding or baseline-activation policy,
+producer observation, source SHA/tree resolution, complete payload provenance, state writer,
+candidate ref, check producer, or publication path. It therefore cannot make a target eligible
+and cannot publish even when a caller requests publication. In particular, the current Phase A
+manifests keep every source SHA/tree and toolchain member null and classify every payload entry as
+incomplete; Windows additionally retains its separately reviewed opaque `openlibm.o` acceptance.
+
+The updater is not yet a producer for this transition. Its Unix jobs still invoke the legacy
+in-place recipes instead of setting `TCCBIN_DEFER_COMMIT=1`, producing a private RAW root, and
+calling `candidate-compose`; Windows is not present in its selectable target matrices. The current
+Linux and BSD jobs also request moving `ubuntu-latest` hosts while the reviewed profile model
+requires `ubuntu-24.04`, the macOS ARM64 updater job requests `macos-latest` while the model
+requires `macos-15`, the Windows branch requests `windows-latest` while the model requires
+`windows-2022`, and BSD cross-platform-actions runtime assets remain unauthenticated. These gaps,
+plus native producer/validator observations and external evidence transport, must be closed before
+any policy pair is populated.
+
+Patch and transform retirement is likewise not activated here. The current manifest vocabulary
+records Windows patch state and effect/probe bindings, but no workflow yet builds an otherwise
+identical unpatched counterfactual, derives a closed
+`required`/`redundant`/`broken`/`unknown` verdict, or authorizes a removal or issue write. Until a
+later reviewed lifecycle binds those facts durably, an apply failure, unexpected pass, or changed
+effect remains fail-closed and requires human review; it must never be interpreted as proof that a
+patch or transform can be silently dropped.
 
 ### Dormant toolchain identity profiles
 
@@ -711,7 +812,20 @@ fresh exact validation and the resolving commit recorded in the ledger.
 The contract and validators merge before any tccbin manifest. Fork manifests use
 `contract_mode=fork-dry-run` and cannot publish. After the V contract is merged, every managed
 tccbin manifest must point to the immutable merged V SHA in production mode and rerun all gates.
-Only after those branch changes merge can a V follow-up activate their exact upstream HEADs.
+Only after those branch changes merge can a V follow-up seal their exact upstream HEADs as dormant
+managed-baseline anchors. Sealing is not activation: the baseline policy pairs and all six
+toolchain-profile triples remain null, provenance remains incomplete, and no durable state is
+seeded.
+
+Before a real `baseline-activate` candidate can be composed, a later reviewed phase must make the
+authentication and evidence-transport infrastructure authoritative, add the six resolved profiles
+and baseline policies, authenticate the producer environments, resolve every source SHA/tree, and
+generate complete per-file provenance. Validator observations and candidate-bound native proofs
+are produced and transported only after `candidate-compose` creates the immutable candidate ref;
+they are required before that candidate may enter durable eligibility or be published.
+The updater must first use deferred RAW builds plus `candidate-compose` for all six targets,
+including a native Windows producer. Patch/transform counterfactual classification and the BSD
+runtime-asset boundary must also fail closed until their own evidence paths are authoritative.
 
 Build-only validation precedes targeted manual publication. Each target needs two consecutive,
 fully green targeted publications before a repository owner may set its monthly target unlock to

--- a/thirdparty/tccbin_automation/bin/candidate_composition.v
+++ b/thirdparty/tccbin_automation/bin/candidate_composition.v
@@ -34,8 +34,13 @@ pub fn compose_candidate_for_execution(automation_root string, request Candidate
 		return error('candidate composition target is not managed')
 	}
 	mut onboarding_policy := JsonValue{}
+	mut activation_binding := ManagedBaselineActivationBinding{}
+	mut activation_policy := JsonValue{}
 	if request.kind == .legacy_onboard {
 		_, onboarding_policy = reviewed_legacy_onboarding_binding(automation_root,
+			request.target_id, request.base_sha)!
+	} else if request.kind == .baseline_activate {
+		activation_binding, activation_policy = reviewed_managed_baseline_activation_binding(automation_root,
 			request.target_id, request.base_sha)!
 	}
 	if !is_lower_hex_40(request.base_sha) {
@@ -43,6 +48,7 @@ pub fn compose_candidate_for_execution(automation_root string, request Candidate
 	}
 	base_root, raw_root, manifest_source_path, result_root := validate_candidate_composition_roots(automation_root,
 		request)!
+	contract_root := canonical_contract_root(os.join_path(automation_root, '..', '..'))!
 	validate_composition_base_repository(base_root, request.base_sha)!
 
 	result_parent := os.dir(result_root)
@@ -69,8 +75,11 @@ pub fn compose_candidate_for_execution(automation_root string, request Candidate
 			return error('monthly composition base manifest failed with ${base_issues.len} issue(s)')
 		}
 		base_manifest = parse_strict_json(os.read_file(manifest_destination)!)!
-	} else {
+	} else if request.kind == .legacy_onboard {
 		attest_legacy_candidate_manifest_absent(candidate_root, request.base_sha)!
+	} else {
+		base_manifest = attest_managed_baseline_activation_base(automation_root, request.target_id,
+			candidate_root, request.base_sha, manifest_destination, activation_binding)!
 	}
 	materialize_candidate_manifest(candidate_root, request.base_sha, request.kind,
 		manifest_source_path)!
@@ -87,9 +96,12 @@ pub fn compose_candidate_for_execution(automation_root string, request Candidate
 		validate_manifest_legacy_onboarding_policy(manifest, onboarding_policy)!
 		validate_legacy_onboarding_base_controls(automation_root, candidate_root, request.base_sha,
 			manifest)!
-	} else {
+	} else if request.kind == .monthly {
 		validate_candidate_policy_projection(base_manifest, manifest)!
 		validate_composition_control_inputs(candidate_root, request.base_sha, manifest)!
+	} else {
+		validate_managed_baseline_activation_candidate(base_manifest, manifest, runtime,
+			activation_binding, activation_policy, contract_root)!
 	}
 
 	compose_declared_candidate_payload(candidate_root, request.base_sha, raw_root, manifest)!
@@ -216,7 +228,7 @@ fn validate_composition_base_repository(root string, base_sha string) ! {
 
 fn materialize_candidate_manifest(candidate_root string, base_sha string,
 	kind CandidateTransitionKind, source_path string) ! {
-	if kind == .monthly {
+	if kind != .legacy_onboard {
 		attest_candidate_manifest_present(candidate_root, base_sha)!
 	} else {
 		attest_legacy_candidate_manifest_absent(candidate_root, base_sha)!
@@ -251,7 +263,7 @@ fn materialize_candidate_manifest(candidate_root string, base_sha string,
 		|| temporary_observation.nlink != 1 {
 		return error('candidate manifest temporary materialization is not a private regular file')
 	}
-	if kind == .monthly {
+	if kind != .legacy_onboard {
 		attest_candidate_manifest_present(candidate_root, base_sha)!
 		os.rm(destination_path)!
 	} else {

--- a/thirdparty/tccbin_automation/bin/candidate_staging.v
+++ b/thirdparty/tccbin_automation/bin/candidate_staging.v
@@ -8,13 +8,23 @@ const candidate_transition_max_status_bytes = u64(1024 * 1024)
 pub enum CandidateTransitionKind {
 	monthly
 	legacy_onboard
+	baseline_activate
 }
 
 pub fn parse_candidate_transition_kind(source string) !CandidateTransitionKind {
 	return match source {
-		'monthly' { .monthly }
-		'legacy-onboard' { .legacy_onboard }
-		else { return error('candidate transition kind must be monthly or legacy-onboard') }
+		'monthly' {
+			.monthly
+		}
+		'legacy-onboard' {
+			.legacy_onboard
+		}
+		'baseline-activate' {
+			.baseline_activate
+		}
+		else {
+			return error('candidate transition kind must be monthly, legacy-onboard, or baseline-activate')
+		}
 	}
 }
 
@@ -117,9 +127,17 @@ pub fn evaluate_candidate_manifest_for_execution(automation_root string, target_
 		return error('candidate transition target is not managed')
 	}
 	mut onboarding_policy := JsonValue{}
+	mut activation_binding := ManagedBaselineActivationBinding{}
+	mut activation_policy := JsonValue{}
 	if kind == .legacy_onboard {
 		_, onboarding_policy = reviewed_legacy_onboarding_binding(automation_root, target_id,
 			base_sha)!
+	} else if kind == .baseline_activate {
+		activation_binding, activation_policy = reviewed_managed_baseline_activation_binding(automation_root,
+			target_id, base_sha)!
+	}
+	if kind == .baseline_activate && publish_requested {
+		return error('managed baseline activation publication is disabled pending native publication proof')
 	}
 	if !is_lower_hex_40(base_sha) || !is_lower_hex_40(candidate_sha) || base_sha == candidate_sha {
 		return error('candidate base and candidate must be distinct full lowercase commit SHAs')
@@ -155,7 +173,7 @@ pub fn evaluate_candidate_manifest_for_execution(automation_root string, target_
 	manifest_path := os.join_path(source_root, candidate_manifest_path)
 	base_manifest_path := os.join_path(base_root, candidate_manifest_path)
 	attest_candidate_manifest_present(source_root, candidate_sha)!
-	if kind == .monthly {
+	if kind != .legacy_onboard {
 		attest_candidate_manifest_present(base_root, base_sha)!
 	} else {
 		attest_legacy_candidate_manifest_absent(base_root, base_sha)!
@@ -180,11 +198,17 @@ pub fn evaluate_candidate_manifest_for_execution(automation_root string, target_
 		base_manifest := parse_strict_json(os.read_file(base_manifest_path)!)!
 		validate_candidate_base_controls(base_root, base_sha, base_manifest_path, base_manifest)!
 		validate_candidate_transition(base_root, base_sha, candidate_sha, base_manifest, manifest)!
-	} else {
+	} else if kind == .legacy_onboard {
 		validate_manifest_legacy_onboarding_policy(manifest, onboarding_policy)!
 		validate_legacy_onboarding_base_controls(automation_root, base_root, base_sha, manifest)!
 		validate_legacy_onboarding_transition(automation_root, base_root, base_sha, candidate_sha,
 			manifest)!
+	} else {
+		base_manifest := attest_managed_baseline_activation_base(automation_root, target_id,
+			base_root, base_sha, base_manifest_path, activation_binding)!
+		validate_managed_baseline_activation_candidate(base_manifest, manifest, runtime,
+			activation_binding, activation_policy, contract_root)!
+		validate_managed_baseline_activation_transition(base_root, base_sha, candidate_sha)!
 	}
 	export_candidate_payload(source_root, payload_root, manifest)!
 	validate_independent_candidate_checkout(base_root, base_sha)!
@@ -196,8 +220,244 @@ pub fn evaluate_candidate_manifest_for_execution(automation_root string, target_
 		source_git_root: source_root
 		source_git_ref:  candidate_sha
 	}, runtime, publish_requested)!
+	if kind == .baseline_activate && !decision.eligible {
+		return error('managed baseline activation preflight did not authenticate the candidate')
+	}
 	keep_work_root = true
 	return decision
+}
+
+fn attest_managed_baseline_activation_base(automation_root string, target_id string,
+	base_root string, base_sha string, manifest_path string,
+	binding ManagedBaselineActivationBinding) !JsonValue {
+	if base_sha != binding.base_sha {
+		return error('managed baseline activation base differs from the reviewed target pin')
+	}
+	tree := successful_candidate_git(base_root, ['rev-parse', '${base_sha}^{tree}'],
+		'managed baseline activation base tree cannot be resolved')!.trim_space()
+	if tree != binding.base_tree {
+		return error('managed baseline activation base tree differs from the reviewed pin')
+	}
+	raw_commit := successful_candidate_git(base_root, ['cat-file', 'commit', base_sha],
+		'managed baseline activation base commit cannot be inspected')!
+	if !raw_commit_has_exact_parent(raw_commit, binding.parent_sha) {
+		return error('managed baseline activation base parent differs from the reviewed pin')
+	}
+	manifest_observation := attest_candidate_manifest_present(base_root, base_sha)!
+	if manifest_observation.sha256 != binding.base_manifest_sha256
+		|| manifest_observation.sha256 != sha256_file(manifest_path)! {
+		return error('managed baseline activation base manifest differs from the reviewed pin')
+	}
+	base_issues := validate_manifest(automation_root, manifest_path)!
+	if base_issues.len > 0 {
+		return error('managed baseline activation base manifest failed with ${base_issues.len} issue(s)')
+	}
+	manifest := parse_strict_json(os.read_file(manifest_path)!)!
+	if require_string_member(manifest, 'target_id')! != target_id {
+		return error('managed baseline activation base target differs from the request')
+	}
+	if require_string_member(manifest, 'contract_repository')! != binding.base_contract_repository
+		|| require_string_member(manifest, 'contract_sha')! != binding.base_contract_sha {
+		return error('managed baseline activation base contract differs from the reviewed pin')
+	}
+	if require_string_member(manifest, 'contract_mode')! != 'production'
+		|| require_string_member(manifest, 'provenance_status')! != 'incomplete' {
+		return error('managed baseline activation base must be the reviewed incomplete production manifest')
+	}
+	profile_id, profile_sha256, producer := manifest_toolchain_members(manifest)!
+	if profile_id != '' || profile_sha256 != '' || producer.kind != .null_value {
+		return error('managed baseline activation base toolchain must remain entirely unresolved')
+	}
+	for source in require_array_member(manifest, 'sources')! {
+		if require_member(source, 'sha')!.kind != .null_value
+			|| require_member(source, 'tree')!.kind != .null_value {
+			return error('managed baseline activation base sources must remain entirely unresolved')
+		}
+	}
+	for collection in ['overlays', 'inventory', 'outputs'] {
+		for entry in require_array_member(manifest, collection)! {
+			provenance := require_object_member(entry, 'provenance')!
+			if require_string_member(provenance, 'status')! != 'incomplete'
+				|| require_member(provenance, 'repository')!.kind != .null_value
+				|| require_member(provenance, 'sha')!.kind != .null_value
+				|| require_member(provenance, 'source_path')!.kind != .null_value
+				|| require_member(provenance, 'license')!.kind != .null_value {
+				return error('managed baseline activation base payload provenance must remain entirely unresolved')
+			}
+		}
+	}
+	validate_candidate_base_controls(base_root, base_sha, manifest_path, manifest)!
+	return manifest
+}
+
+fn validate_managed_baseline_activation_candidate(base_manifest JsonValue, manifest JsonValue,
+	runtime RuntimeContractBinding, binding ManagedBaselineActivationBinding, policy JsonValue,
+	contract_root string) ! {
+	validate_manifest_managed_baseline_activation_policy(manifest, policy)!
+	evidence := managed_baseline_source_commit_evidence(policy)!
+	if runtime.repository != binding.base_contract_repository
+		|| require_string_member(manifest, 'contract_repository')! != binding.base_contract_repository
+		|| require_string_member(manifest, 'contract_mode')! != require_string_member(base_manifest, 'contract_mode')!
+		|| require_string_member(manifest, 'contract_mode')! != 'production' {
+		return error('managed baseline activation candidate must retain the production contract authority')
+	}
+	if runtime.sha == binding.base_contract_sha {
+		return error('managed baseline activation runtime contract must differ from the reviewed base')
+	}
+	if require_string_member(manifest, 'v_source_sha')! != runtime.sha {
+		return error('managed baseline activation V source must equal the runtime contract SHA')
+	}
+	for key in ['schema_version', 'contract_version', 'target_id', 'branch', 'recipe', 'patches',
+		'transforms', 'header_effects', 'integrations', 'probes', 'affected_targets'] {
+		if !json_equal(require_member(base_manifest, key)!, require_member(manifest, key)!) {
+			return error('managed baseline activation changed immutable manifest policy')
+		}
+	}
+	base_sources := require_array_member(base_manifest, 'sources')!
+	sources := require_array_member(manifest, 'sources')!
+	if base_sources.len != sources.len {
+		return error('managed baseline activation changed the reviewed source set')
+	}
+	mut runtime_tree := ''
+	for authority in evidence {
+		if authority.authority == 'runtime-contract' {
+			runtime_tree = validate_managed_baseline_runtime_contract_checkout(contract_root,
+				runtime)!
+		}
+	}
+	for index, source in sources {
+		base_source := base_sources[index]
+		for key in ['id', 'repository', 'ref'] {
+			if !json_equal(require_member(base_source, key)!, require_member(source, key)!) {
+				return error('managed baseline activation changed immutable source policy')
+			}
+		}
+		if require_member(base_source, 'sha')!.kind != .null_value
+			|| require_member(base_source, 'tree')!.kind != .null_value {
+			return error('managed baseline activation base sources must remain entirely unresolved')
+		}
+		sha := require_string_member(source, 'sha')!
+		tree := require_string_member(source, 'tree')!
+		if !is_lower_hex_40(sha) || !is_lower_hex_40(tree) {
+			return error('managed baseline activation candidate sources must resolve to exact Git objects')
+		}
+		mut evidence_matches := 0
+		for authority in evidence {
+			if authority.id != require_string_member(source, 'id')! {
+				continue
+			}
+			evidence_matches++
+			expected_sha := if authority.authority == 'runtime-contract' {
+				runtime.sha
+			} else {
+				authority.sha
+			}
+			expected_tree := if authority.authority == 'runtime-contract' {
+				runtime_tree
+			} else {
+				authority.tree
+			}
+			if sha != expected_sha || tree != expected_tree {
+				return error('managed baseline activation source differs from reviewed commit evidence')
+			}
+		}
+		if evidence_matches != 1 {
+			return error('managed baseline activation source has no unique reviewed commit evidence')
+		}
+	}
+	for collection in ['overlays', 'inventory', 'outputs'] {
+		base_entries := require_array_member(base_manifest, collection)!
+		entries := require_array_member(manifest, collection)!
+		if base_entries.len != entries.len {
+			return error('managed baseline activation changed immutable payload membership')
+		}
+		for index, entry in entries {
+			if !json_equal(managed_baseline_payload_entry_projection(base_entries[index])!,
+				managed_baseline_payload_entry_projection(entry)!) {
+				return error('managed baseline activation changed immutable payload bytes or policy')
+			}
+		}
+	}
+	status := require_string_member(manifest, 'provenance_status')!
+	if status !in ['complete', 'opaque-accepted'] || !manifest_sources_are_resolved(manifest)!
+		|| !manifest_toolchain_is_resolved(manifest)! {
+		return error('managed baseline activation candidate must have complete resolved provenance')
+	}
+	validate_managed_baseline_activation_payload_provenance(manifest, binding, runtime, evidence)!
+}
+
+fn validate_managed_baseline_activation_payload_provenance(manifest JsonValue,
+	binding ManagedBaselineActivationBinding, runtime RuntimeContractBinding,
+	evidence []ManagedBaselineSourceCommitEvidence) ! {
+	for collection in ['overlays', 'inventory', 'outputs'] {
+		for entry in require_array_member(manifest, collection)! {
+			provenance := require_object_member(entry, 'provenance')!
+			repository := require_member(provenance, 'repository')!
+			sha := require_member(provenance, 'sha')!
+			if require_string_member(provenance, 'status')! == 'incomplete' {
+				continue
+			}
+			if repository.kind != .string_value || sha.kind != .string_value {
+				return error('managed baseline activation complete payload provenance must resolve repository and SHA')
+			}
+			expected_sha := match repository.string_value {
+				'TinyCC/tinycc' {
+					managed_baseline_activation_evidence_sha(evidence, 'tinycc', runtime)!
+				}
+				'ivmai/bdwgc' {
+					managed_baseline_activation_evidence_sha(evidence, 'bdwgc', runtime)!
+				}
+				'bdwgc/libatomic_ops' {
+					managed_baseline_activation_evidence_sha(evidence, 'libatomic_ops', runtime)!
+				}
+				'vlang/tccbin' {
+					binding.base_sha
+				}
+				'vlang/v' {
+					managed_baseline_activation_evidence_sha(evidence, 'v-libgc', runtime)!
+				}
+				else {
+					return error('managed baseline activation payload provenance repository is not an authenticated authority')
+				}
+			}
+			if sha.string_value != expected_sha {
+				return error('managed baseline activation payload provenance SHA differs from its authenticated authority')
+			}
+		}
+	}
+}
+
+fn managed_baseline_activation_evidence_sha(evidence []ManagedBaselineSourceCommitEvidence,
+	source_id string, runtime RuntimeContractBinding) !string {
+	mut matches := 0
+	mut expected_sha := ''
+	for authority in evidence {
+		if authority.id == source_id {
+			matches++
+			expected_sha = if authority.authority == 'runtime-contract' {
+				runtime.sha
+			} else {
+				authority.sha
+			}
+		}
+	}
+	if matches != 1 || !is_lower_hex_40(expected_sha) {
+		return error('managed baseline activation payload provenance authority is absent or ambiguous')
+	}
+	return expected_sha
+}
+
+fn managed_baseline_payload_entry_projection(entry JsonValue) !JsonValue {
+	return select_object_members(entry, ['path', 'kind', 'git_mode', 'sha256', 'symlink_target',
+		'role', 'opaque', 'opaque_acceptance_id', 'format', 'object_type', 'machine', 'os_abi'])!
+}
+
+fn validate_managed_baseline_activation_transition(repository_root string, base_sha string,
+	candidate_sha string) ! {
+	diff := read_candidate_transition_status(repository_root, base_sha, candidate_sha)!
+	if diff != 'M\x00${candidate_manifest_path}\x00' {
+		return error('managed baseline activation transition must modify only the authoritative manifest')
+	}
 }
 
 fn validate_candidate_base_controls(base_root string, base_sha string, manifest_path string,
@@ -374,6 +634,76 @@ fn canonical_candidate_work_root(path string) !string {
 	}
 	canonical_parent := canonical_contract_root(parent)!
 	return '${canonical_parent}/${base}'
+}
+
+fn validate_managed_baseline_runtime_contract_checkout(root string,
+	runtime RuntimeContractBinding) !string {
+	if runtime.repository != 'vlang/v' {
+		return error('managed baseline runtime source requires the vlang/v contract authority')
+	}
+	inside := successful_candidate_git(root, ['rev-parse', '--is-inside-work-tree'],
+		'managed baseline runtime contract checkout cannot be inspected')!
+	if inside.trim_space() != 'true' {
+		return error('managed baseline runtime contract root is not a Git worktree')
+	}
+	toplevel := successful_candidate_git(root, ['rev-parse', '--show-toplevel'],
+		'managed baseline runtime contract top level cannot be resolved')!
+	if canonical_contract_root(toplevel.trim_space())! != root {
+		return error('managed baseline runtime contract root differs from its Git top level')
+	}
+	object_format := successful_candidate_git(root, ['rev-parse', '--show-object-format'],
+		'managed baseline runtime contract object format cannot be resolved')!
+	if object_format.trim_space() != 'sha1' {
+		return error('managed baseline runtime contract must use the SHA-1 Git object format')
+	}
+	shallow := successful_candidate_git(root, ['rev-parse', '--is-shallow-repository'],
+		'managed baseline runtime contract shallow state cannot be resolved')!
+	if shallow.trim_space() != 'false' {
+		return error('managed baseline runtime contract must contain complete non-shallow history')
+	}
+	autocrlf := successful_candidate_git(root, ['config', '--local', '--get', 'core.autocrlf'],
+		'managed baseline runtime contract must set core.autocrlf=false locally')!
+	if autocrlf.trim_space() != 'false' {
+		return error('managed baseline runtime contract must set core.autocrlf=false locally')
+	}
+	validate_candidate_local_git_config(root)!
+	validate_candidate_git_storage(root)!
+	origin := successful_candidate_git(root, ['remote', 'get-url', 'origin'],
+		'managed baseline runtime contract origin cannot be resolved')!.trim_space()
+	if origin !in ['https://github.com/vlang/v', 'https://github.com/vlang/v.git'] {
+		return error('managed baseline runtime contract origin is not the vlang/v HTTPS repository')
+	}
+	replacements := successful_candidate_git(root, ['for-each-ref', '--format=%(refname)',
+		'refs/replace/'], 'managed baseline runtime contract replacement refs cannot be inspected')!
+	if replacements != '' {
+		return error('managed baseline runtime contract must not contain replacement refs')
+	}
+	resolved := successful_candidate_git(root,
+		['rev-parse', '--verify', '${runtime.sha}^{commit}'],
+		'managed baseline runtime contract commit cannot be resolved without lazy fetching')!
+	if resolved.trim_space() != runtime.sha {
+		return error('managed baseline runtime contract commit resolution is not exact')
+	}
+	head := successful_candidate_git(root, ['rev-parse', 'HEAD'],
+		'managed baseline runtime contract HEAD cannot be resolved')!
+	if head.trim_space() != runtime.sha {
+		return error('managed baseline runtime contract checkout is not at the runtime SHA')
+	}
+	symbolic := candidate_repository_git(root, ['symbolic-ref', '-q', 'HEAD'])!
+	if symbolic.exit_code != 1 || symbolic.output != '' {
+		return error('managed baseline runtime contract checkout must be detached')
+	}
+	status := successful_candidate_git(root, ['status', '--porcelain=v1', '--untracked-files=no'],
+		'managed baseline runtime contract status cannot be inspected')!
+	if status != '' {
+		return error('managed baseline runtime contract checkout must have no tracked changes')
+	}
+	tree := successful_candidate_git(root, ['rev-parse', '--verify', '${runtime.sha}^{tree}'],
+		'managed baseline runtime contract tree cannot be resolved')!.trim_space()
+	if !is_lower_hex_40(tree) {
+		return error('managed baseline runtime contract tree is not an exact Git object ID')
+	}
+	return tree
 }
 
 fn candidate_git(args []string) !os.Result {

--- a/thirdparty/tccbin_automation/bin/cmd/main.v
+++ b/thirdparty/tccbin_automation/bin/cmd/main.v
@@ -62,7 +62,7 @@ fn main() {
 		}
 		'candidate-preflight' {
 			if os.args.len != 9 || os.args[8] !in ['true', 'false'] {
-				eprintln('usage: tccbin-automation candidate-preflight <target-id> <monthly|legacy-onboard> <candidate-repo-root> <base-sha> <candidate-sha> <work-root> <publish-requested>')
+				eprintln('usage: tccbin-automation candidate-preflight <target-id> <monthly|legacy-onboard|baseline-activate> <candidate-repo-root> <base-sha> <candidate-sha> <work-root> <publish-requested>')
 				exit(2)
 			}
 			kind := bin.parse_candidate_transition_kind(os.args[3]) or {
@@ -81,7 +81,7 @@ fn main() {
 		}
 		'candidate-compose' {
 			if os.args.len != 9 {
-				eprintln('usage: tccbin-automation candidate-compose <target-id> <monthly|legacy-onboard> <base-repo-root> <base-sha> <raw-root> <manifest> <result-root>')
+				eprintln('usage: tccbin-automation candidate-compose <target-id> <monthly|legacy-onboard|baseline-activate> <base-repo-root> <base-sha> <raw-root> <manifest> <result-root>')
 				exit(2)
 			}
 			kind := bin.parse_candidate_transition_kind(os.args[3]) or {

--- a/thirdparty/tccbin_automation/bin/contract.v
+++ b/thirdparty/tccbin_automation/bin/contract.v
@@ -1,6 +1,8 @@
 module bin
 
+import crypto.sha1
 import crypto.sha256
+import encoding.base64
 import os
 
 const managed_target_ids = [
@@ -45,9 +47,15 @@ const normalized_gate_ids = [
 
 const staged_provenance_incomplete_error = 'staged provenance is incomplete'
 
+const managed_baseline_contract_sha = '7545e515b434cd399333d43659238427d72e22e7'
+
 const toolchain_identity_document_max_bytes = u64(512 * 1024)
 
 const toolchain_identity_document_buffer_bytes = 16 * 1024
+
+const managed_baseline_source_commit_max_bytes = 64 * 1024
+
+const managed_baseline_source_commit_base64_max_bytes = 87_384
 
 // FingerprintSet keeps the three non-interchangeable hashes of a bundle contract.
 pub struct FingerprintSet {
@@ -127,6 +135,27 @@ struct LegacyOnboardingBinding {
 	base_sha      string
 	policy_path   string
 	policy_sha256 string
+}
+
+struct ManagedBaselineActivationBinding {
+	base_sha                 string
+	base_tree                string
+	parent_sha               string
+	base_manifest_sha256     string
+	base_contract_repository string
+	base_contract_sha        string
+	policy_path              string
+	policy_sha256            string
+}
+
+struct ManagedBaselineSourceCommitEvidence {
+	id                string
+	repository        string
+	ref               string
+	authority         string
+	sha               string
+	tree              string
+	raw_commit_base64 string
 }
 
 struct ToolchainProfileBinding {
@@ -491,6 +520,7 @@ pub fn validate_registry(automation_root string) ![]SchemaIssue {
 	issues << validate_registry_semantics(registry)!
 	if issues.len == 0 {
 		issues << validate_registry_onboarding_policies(automation_root, registry)!
+		issues << validate_registry_managed_baseline_activation_policies(automation_root, registry)!
 		issues << validate_registry_toolchain_profiles(automation_root, registry)!
 	}
 	return issues
@@ -1207,6 +1237,23 @@ fn validate_registry_onboarding_policies(automation_root string, registry JsonVa
 	return issues
 }
 
+fn validate_registry_managed_baseline_activation_policies(automation_root string,
+	registry JsonValue) ![]SchemaIssue {
+	mut issues := []SchemaIssue{}
+	for target in require_array_member(registry, 'managed_ci_targets')! {
+		target_id := require_string_member(target, 'id')!
+		binding := managed_baseline_activation_binding(target)!
+		if binding.policy_path == '' {
+			continue
+		}
+		load_managed_baseline_activation_policy(automation_root, target_id, binding,
+			toolchain_profile_binding(target)!) or {
+			issues << SchemaIssue{'$/managed_ci_targets', err.msg()}
+		}
+	}
+	return issues
+}
+
 fn legacy_onboarding_binding(target JsonValue) !LegacyOnboardingBinding {
 	onboarding := require_object_member(target, 'legacy_onboarding')!
 	policy_path := require_nullable_string_member(onboarding, 'policy_path')!
@@ -1218,6 +1265,25 @@ fn legacy_onboarding_binding(target JsonValue) !LegacyOnboardingBinding {
 		base_sha:      require_string_member(onboarding, 'base_sha')!
 		policy_path:   policy_path
 		policy_sha256: policy_sha256
+	}
+}
+
+fn managed_baseline_activation_binding(target JsonValue) !ManagedBaselineActivationBinding {
+	activation := require_object_member(target, 'managed_baseline_activation')!
+	policy_path := require_nullable_string_member(activation, 'policy_path')!
+	policy_sha256 := require_nullable_string_member(activation, 'policy_sha256')!
+	if (policy_path == '') != (policy_sha256 == '') {
+		return error('managed baseline activation policy path and hash must both be null or both be resolved')
+	}
+	return ManagedBaselineActivationBinding{
+		base_sha:                 require_string_member(activation, 'base_sha')!
+		base_tree:                require_string_member(activation, 'base_tree')!
+		parent_sha:               require_string_member(activation, 'parent_sha')!
+		base_manifest_sha256:     require_string_member(activation, 'base_manifest_sha256')!
+		base_contract_repository: require_string_member(activation, 'base_contract_repository')!
+		base_contract_sha:        require_string_member(activation, 'base_contract_sha')!
+		policy_path:              policy_path
+		policy_sha256:            policy_sha256
 	}
 }
 
@@ -1233,6 +1299,22 @@ fn reviewed_legacy_onboarding_binding(automation_root string, target_id string,
 		return error('legacy onboarding base differs from the reviewed target pin')
 	}
 	policy := load_legacy_onboarding_policy(automation_root, target_id, binding,
+		toolchain_profile_binding(target)!)!
+	return binding, policy
+}
+
+fn reviewed_managed_baseline_activation_binding(automation_root string, target_id string,
+	base_sha string) !(ManagedBaselineActivationBinding, JsonValue) {
+	registry := parse_strict_json(os.read_file(os.join_path(automation_root, 'targets.json'))!)!
+	target := registry_target_by_id(registry, target_id)!
+	binding := managed_baseline_activation_binding(target)!
+	if binding.policy_path == '' {
+		return error('target has no reviewed managed baseline activation policy')
+	}
+	if base_sha != binding.base_sha {
+		return error('managed baseline activation base differs from the reviewed target pin')
+	}
+	policy := load_managed_baseline_activation_policy(automation_root, target_id, binding,
 		toolchain_profile_binding(target)!)!
 	return binding, policy
 }
@@ -1260,6 +1342,9 @@ fn load_legacy_onboarding_policy(automation_root string, target_id string,
 	if policy_issues.len > 0 {
 		return error('legacy onboarding policy schema failed with ${policy_issues.len} issue(s)')
 	}
+	if require_integer_member(policy, 'projection_version')! != 1 {
+		return error('legacy onboarding policy must retain projection version 1')
+	}
 	if require_string_member(policy, 'target_id')! != target_id {
 		return error('legacy onboarding policy target differs from its registry target')
 	}
@@ -1271,6 +1356,50 @@ fn load_legacy_onboarding_policy(automation_root string, target_id string,
 	}
 	if json_sha256(policy) != binding.policy_sha256 {
 		return error('legacy onboarding policy hash differs from the registry')
+	}
+	return policy
+}
+
+fn load_managed_baseline_activation_policy(automation_root string, target_id string,
+	binding ManagedBaselineActivationBinding,
+	toolchain_binding ToolchainProfileBinding) !JsonValue {
+	expected_path := 'baseline-activation/${target_id}.policy.json'
+	if binding.policy_path != expected_path || !contract_relative_path_is_safe(binding.policy_path) {
+		return error('managed baseline activation policy path differs from the exact target path')
+	}
+	validate_staged_parent_chain(automation_root, binding.policy_path) or {
+		return error('managed baseline activation policy parent chain is not physical')
+	}
+	policy_path := os.join_path(automation_root, binding.policy_path)
+	if !os.is_file(policy_path) || os.is_link(policy_path) {
+		return error('managed baseline activation policy is not a physical regular file')
+	}
+	policy_source := read_stable_toolchain_document(policy_path,
+		'managed baseline activation policy')!
+	policy := parse_strict_json(policy_source)!
+	if policy_source != canonical_json(policy) {
+		return error('managed baseline activation policy bytes must be exact canonical JSON')
+	}
+	policy_issues := validate_json_value(os.join_path(automation_root, 'schemas',
+		'onboarding-policy.schema.json'), policy)!
+	if policy_issues.len > 0 {
+		return error('managed baseline activation policy schema failed with ${policy_issues.len} issue(s)')
+	}
+	if require_integer_member(policy, 'projection_version')! != 2 {
+		return error('managed baseline activation policy must use projection version 2')
+	}
+	managed_baseline_source_commit_evidence(policy)!
+	if require_string_member(policy, 'target_id')! != target_id {
+		return error('managed baseline activation policy target differs from its registry target')
+	}
+	policy_toolchain := require_object_member(policy, 'toolchain')!
+	if toolchain_binding.profile_id == ''
+		|| require_string_member(policy_toolchain, 'profile_id')! != toolchain_binding.profile_id
+		|| require_string_member(policy_toolchain, 'profile_sha256')! != toolchain_binding.profile_sha256 {
+		return error('managed baseline activation policy toolchain differs from the reviewed target profile')
+	}
+	if json_sha256(policy) != binding.policy_sha256 {
+		return error('managed baseline activation policy hash differs from the registry')
 	}
 	return policy
 }
@@ -1344,6 +1473,148 @@ pub fn legacy_onboarding_policy_projection(manifest JsonValue) !JsonValue {
 	])!
 }
 
+// managed_baseline_activation_policy_projection adds an independent, reviewed commit-object
+// authority to the otherwise static onboarding projection. The legacy version 1 projection is
+// deliberately left byte-for-byte unchanged.
+pub fn managed_baseline_activation_policy_projection(manifest JsonValue,
+	source_commit_evidence JsonValue) !JsonValue {
+	legacy := legacy_onboarding_policy_projection(manifest)!
+	mut keys := legacy.object_keys.clone()
+	mut values := legacy.object_values.clone()
+	values[0] = JsonValue{
+		kind:      .integer
+		int_value: 2
+	}
+	keys << 'source_commit_evidence'
+	values << source_commit_evidence
+	projection := object_value_from_pairs(keys, values)!
+	managed_baseline_source_commit_evidence(projection)!
+	return projection
+}
+
+fn managed_baseline_source_commit_evidence(policy JsonValue) ![]ManagedBaselineSourceCommitEvidence {
+	if require_integer_member(policy, 'projection_version')! != 2 {
+		return error('managed baseline source commit evidence requires projection version 2')
+	}
+	sources := require_array_member(policy, 'sources')!
+	entries := require_array_member(policy, 'source_commit_evidence')!
+	if sources.len == 0 || sources.len > 3 || entries.len != sources.len {
+		return error('managed baseline source commit evidence must be bijective with the source matrix')
+	}
+	mut source_ids := []string{cap: sources.len}
+	for source in sources {
+		source_id := require_string_member(source, 'id')!
+		if source_id in source_ids {
+			return error('managed baseline source matrix contains a duplicate source ID')
+		}
+		source_ids << source_id
+	}
+	mut evidence := []ManagedBaselineSourceCommitEvidence{cap: entries.len}
+	mut evidence_ids := []string{cap: entries.len}
+	for entry in entries {
+		authority := require_string_member(entry, 'authority')!
+		mut parsed := ManagedBaselineSourceCommitEvidence{
+			id:         require_string_member(entry, 'id')!
+			repository: require_string_member(entry, 'repository')!
+			ref:        require_string_member(entry, 'ref')!
+			authority:  authority
+		}
+		if parsed.id in evidence_ids {
+			return error('managed baseline source commit evidence contains a duplicate source ID')
+		}
+		if authority == 'source-commit-object' {
+			require_exact_keys(entry, ['id', 'repository', 'ref', 'authority', 'sha', 'tree',
+				'raw_commit_base64'])!
+			if parsed.id !in ['tinycc', 'bdwgc', 'libatomic_ops'] {
+				return error('managed baseline external commit authority has an unsupported source ID')
+			}
+			parsed = ManagedBaselineSourceCommitEvidence{
+				...parsed
+				sha:               require_string_member(entry, 'sha')!
+				tree:              require_string_member(entry, 'tree')!
+				raw_commit_base64: require_string_member(entry, 'raw_commit_base64')!
+			}
+			validate_managed_baseline_raw_commit_evidence(parsed)!
+		} else if authority == 'runtime-contract' {
+			require_exact_keys(entry, ['id', 'repository', 'ref', 'authority'])!
+			if parsed.id != 'v-libgc' || parsed.repository != 'https://github.com/vlang/v.git'
+				|| parsed.ref != 'master' {
+				return error('managed baseline runtime-contract authority is restricted to v-libgc')
+			}
+		} else {
+			return error('managed baseline source commit evidence authority is unsupported')
+		}
+		evidence_ids << parsed.id
+		evidence << parsed
+	}
+	for entry in evidence {
+		if entry.id !in source_ids {
+			return error('managed baseline source commit evidence contains an unreferenced source ID')
+		}
+	}
+	for index, source in sources {
+		source_id := require_string_member(source, 'id')!
+		entry := evidence[index]
+		if entry.id != source_id {
+			return error('managed baseline source commit evidence order differs from the source matrix')
+		}
+		if entry.repository != require_string_member(source, 'repository')!
+			|| entry.ref != require_string_member(source, 'ref')! {
+			return error('managed baseline source commit evidence changed source repository or ref')
+		}
+	}
+	return evidence
+}
+
+fn validate_managed_baseline_raw_commit_evidence(
+	evidence ManagedBaselineSourceCommitEvidence) ! {
+	if !is_lower_hex_40(evidence.sha) || !is_lower_hex_40(evidence.tree) {
+		return error('managed baseline commit evidence must use lowercase SHA-1 object IDs')
+	}
+	if evidence.raw_commit_base64.len < 4
+		|| evidence.raw_commit_base64.len > managed_baseline_source_commit_base64_max_bytes {
+		return error('managed baseline raw commit evidence exceeds its encoded byte bound')
+	}
+	raw := base64.decode(evidence.raw_commit_base64)
+	if raw.len == 0 || raw.len > managed_baseline_source_commit_max_bytes
+		|| base64.encode(raw) != evidence.raw_commit_base64 {
+		return error('managed baseline raw commit evidence is not canonical bounded base64')
+	}
+	mut material := 'commit ${raw.len}\x00'.bytes()
+	material << raw
+	if sha1.sum(material).hex() != evidence.sha {
+		return error('managed baseline raw commit evidence SHA differs from its Git object ID')
+	}
+	raw_source := raw.bytestr()
+	header_end := raw_source.index('\n\n') or {
+		return error('managed baseline raw commit evidence has no complete Git commit header')
+	}
+	header := raw_source[..header_end]
+	if header == '' || header.contains('\x00') || header.contains('\r') {
+		return error('managed baseline raw commit evidence has a malformed Git commit header')
+	}
+	lines := header.split('\n')
+	mut tree_count := 0
+	mut observed_tree := ''
+	for index, line in lines {
+		if line == '' {
+			return error('managed baseline raw commit evidence has a malformed Git commit header')
+		}
+		if line.starts_with('tree ') {
+			tree_count++
+			if index == 0 {
+				observed_tree = line.all_after('tree ')
+			}
+		}
+	}
+	if tree_count != 1 || observed_tree == '' || !is_lower_hex_40(observed_tree) {
+		return error('managed baseline raw commit evidence must start with one exact tree header')
+	}
+	if observed_tree != evidence.tree {
+		return error('managed baseline raw commit evidence tree differs from its declared tree')
+	}
+}
+
 // manifest_toolchain_profile_projection intentionally excludes the producer observation. A
 // monthly build may refresh observed facts, but it cannot migrate the reviewed profile authority.
 fn manifest_toolchain_profile_projection(manifest JsonValue) !JsonValue {
@@ -1364,6 +1635,15 @@ fn validate_manifest_legacy_onboarding_policy(manifest JsonValue, policy JsonVal
 	}
 }
 
+fn validate_manifest_managed_baseline_activation_policy(manifest JsonValue,
+	policy JsonValue) ! {
+	projection := managed_baseline_activation_policy_projection(manifest, require_member(policy,
+		'source_commit_evidence')!)!
+	if !json_equal(projection, policy) {
+		return error('candidate manifest differs from the reviewed managed baseline activation policy')
+	}
+}
+
 // validate_registry_semantics checks the immutable six-target graph independently of I/O.
 pub fn validate_registry_semantics(registry JsonValue) ![]SchemaIssue {
 	mut issues := []SchemaIssue{}
@@ -1378,6 +1658,9 @@ pub fn validate_registry_semantics(registry JsonValue) ![]SchemaIssue {
 	mut actual_branches := []string{}
 	mut seen_target_rows := []string{}
 	mut onboarding_base_shas := []string{}
+	mut managed_baseline_shas := []string{}
+	mut managed_baseline_trees := []string{}
+	mut managed_baseline_manifest_hashes := []string{}
 	mut toolchain_profile_ids := []string{}
 	for target in managed {
 		target_id := require_string_member(target, 'id')!
@@ -1388,6 +1671,26 @@ pub fn validate_registry_semantics(registry JsonValue) ![]SchemaIssue {
 			issues << SchemaIssue{'$/managed_ci_targets', 'legacy onboarding base SHAs must be unique'}
 		}
 		onboarding_base_shas << binding.base_sha
+		activation := managed_baseline_activation_binding(target)!
+		if activation.base_sha in managed_baseline_shas {
+			issues << SchemaIssue{'$/managed_ci_targets', 'managed baseline activation SHAs must be unique'}
+		}
+		managed_baseline_shas << activation.base_sha
+		if activation.base_tree in managed_baseline_trees {
+			issues << SchemaIssue{'$/managed_ci_targets', 'managed baseline activation trees must be unique'}
+		}
+		managed_baseline_trees << activation.base_tree
+		if activation.base_manifest_sha256 in managed_baseline_manifest_hashes {
+			issues << SchemaIssue{'$/managed_ci_targets', 'managed baseline activation manifest hashes must be unique'}
+		}
+		managed_baseline_manifest_hashes << activation.base_manifest_sha256
+		if activation.parent_sha != binding.base_sha || activation.base_sha == activation.parent_sha {
+			issues << SchemaIssue{'$/managed_ci_targets', 'managed baseline activation parent must equal the distinct legacy onboarding base'}
+		}
+		if activation.base_contract_repository != 'vlang/v'
+			|| activation.base_contract_sha != managed_baseline_contract_sha {
+			issues << SchemaIssue{'$/managed_ci_targets', 'managed baseline activation contract binding must equal the reviewed Phase A contract'}
+		}
 		toolchain_binding := toolchain_profile_binding(target)!
 		if toolchain_binding.profile_id != '' {
 			if toolchain_binding.profile_id in toolchain_profile_ids {
@@ -2471,6 +2774,11 @@ fn validate_registry_target_tuple(target JsonValue) ![]SchemaIssue {
 	binding := legacy_onboarding_binding(target)!
 	if binding.policy_path != '' && binding.policy_path != 'onboarding/${target_id}.policy.json' {
 		issues << SchemaIssue{'$/managed_ci_targets', 'managed target legacy onboarding policy path is not exact'}
+	}
+	activation := managed_baseline_activation_binding(target)!
+	if activation.policy_path != ''
+		&& activation.policy_path != 'baseline-activation/${target_id}.policy.json' {
+		issues << SchemaIssue{'$/managed_ci_targets', 'managed target baseline activation policy path is not exact'}
 	}
 	toolchain_binding := toolchain_profile_binding(target)!
 	if toolchain_binding.profile_path != ''

--- a/thirdparty/tccbin_automation/schemas/onboarding-policy.schema.json
+++ b/thirdparty/tccbin_automation/schemas/onboarding-policy.schema.json
@@ -21,7 +21,7 @@
     "payload_policy"
   ],
   "properties": {
-    "projection_version": {"type": "integer", "const": 1},
+    "projection_version": {"type": "integer", "enum": [1, 2]},
     "schema_version": {"type": "integer", "const": 1},
     "contract_version": {"$ref": "common.schema.json#/$defs/contract_version"},
     "target_id": {"$ref": "common.schema.json#/$defs/target_id"},
@@ -39,6 +39,18 @@
           "repository": {"type": "string", "minLength": 3, "maxLength": 256},
           "ref": {"type": "string", "minLength": 1, "maxLength": 256}
         }
+      }
+    },
+    "source_commit_evidence": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 3,
+      "uniqueItems": true,
+      "items": {
+        "oneOf": [
+          {"$ref": "#/$defs/source_commit_object_evidence"},
+          {"$ref": "#/$defs/runtime_contract_evidence"}
+        ]
       }
     },
     "recipe": {
@@ -119,7 +131,59 @@
       }
     }
   },
+  "allOf": [
+    {
+      "if": {
+        "properties": {"projection_version": {"const": 1}},
+        "required": ["projection_version"]
+      },
+      "then": {"not": {"required": ["source_commit_evidence"]}}
+    },
+    {
+      "if": {
+        "properties": {"projection_version": {"const": 2}},
+        "required": ["projection_version"]
+      },
+      "then": {"required": ["source_commit_evidence"]}
+    }
+  ],
   "$defs": {
+    "source_commit_object_evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "repository",
+        "ref",
+        "authority",
+        "sha",
+        "tree",
+        "raw_commit_base64"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "enum": ["tinycc", "bdwgc", "libatomic_ops"]
+        },
+        "repository": {"type": "string", "minLength": 3, "maxLength": 256},
+        "ref": {"type": "string", "minLength": 1, "maxLength": 256},
+        "authority": {"type": "string", "const": "source-commit-object"},
+        "sha": {"$ref": "common.schema.json#/$defs/sha40"},
+        "tree": {"$ref": "common.schema.json#/$defs/sha40"},
+        "raw_commit_base64": {"type": "string", "minLength": 4, "maxLength": 87384}
+      }
+    },
+    "runtime_contract_evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "repository", "ref", "authority"],
+      "properties": {
+        "id": {"type": "string", "const": "v-libgc"},
+        "repository": {"type": "string", "const": "https://github.com/vlang/v.git"},
+        "ref": {"type": "string", "const": "master"},
+        "authority": {"type": "string", "const": "runtime-contract"}
+      }
+    },
     "static_patch": {
       "type": "object",
       "additionalProperties": false,

--- a/thirdparty/tccbin_automation/schemas/targets.schema.json
+++ b/thirdparty/tccbin_automation/schemas/targets.schema.json
@@ -36,6 +36,7 @@
           "publish_unlock_variable",
           "affected_targets",
           "legacy_onboarding",
+          "managed_baseline_activation",
           "toolchain_profile"
         ],
         "properties": {
@@ -67,6 +68,45 @@
                   {
                     "type": "string",
                     "pattern": "^onboarding/[a-z0-9][a-z0-9._\\-]+\\.policy\\.json$"
+                  }
+                ]
+              },
+              "policy_sha256": {"$ref": "common.schema.json#/$defs/nullable_sha256"}
+            },
+            "allOf": [
+              {
+                "if": {"properties": {"policy_path": {"type": "null"}}},
+                "then": {"properties": {"policy_sha256": {"type": "null"}}},
+                "else": {"properties": {"policy_sha256": {"$ref": "common.schema.json#/$defs/sha256"}}}
+              }
+            ]
+          },
+          "managed_baseline_activation": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "base_sha",
+              "base_tree",
+              "parent_sha",
+              "base_manifest_sha256",
+              "base_contract_repository",
+              "base_contract_sha",
+              "policy_path",
+              "policy_sha256"
+            ],
+            "properties": {
+              "base_sha": {"$ref": "common.schema.json#/$defs/sha40"},
+              "base_tree": {"$ref": "common.schema.json#/$defs/sha40"},
+              "parent_sha": {"$ref": "common.schema.json#/$defs/sha40"},
+              "base_manifest_sha256": {"$ref": "common.schema.json#/$defs/sha256"},
+              "base_contract_repository": {"type": "string", "const": "vlang/v"},
+              "base_contract_sha": {"$ref": "common.schema.json#/$defs/sha40"},
+              "policy_path": {
+                "oneOf": [
+                  {"type": "null"},
+                  {
+                    "type": "string",
+                    "pattern": "^baseline-activation/[a-z0-9][a-z0-9._\\-]+\\.policy\\.json$"
                   }
                 ]
               },

--- a/thirdparty/tccbin_automation/targets.json
+++ b/thirdparty/tccbin_automation/targets.json
@@ -33,6 +33,16 @@
         "policy_path": null,
         "policy_sha256": null
       },
+      "managed_baseline_activation": {
+        "base_sha": "e71cda6242e88e47312ca9bfc4548b0579636e0c",
+        "base_tree": "9438879ad9906e970d45bafacf6ce2cc63ae4c53",
+        "parent_sha": "fdf5cdfea6ea84612e068bc3bea433dbba263404",
+        "base_manifest_sha256": "a9c2f15451a7e94261c6dd4d9e47cc3965414a2179d04af5902dffc9471a4db3",
+        "base_contract_repository": "vlang/v",
+        "base_contract_sha": "7545e515b434cd399333d43659238427d72e22e7",
+        "policy_path": null,
+        "policy_sha256": null
+      },
       "toolchain_profile": {
         "profile_id": null,
         "profile_path": null,
@@ -50,6 +60,16 @@
       "affected_targets": ["linux-amd64"],
       "legacy_onboarding": {
         "base_sha": "ece46f06fbe6eb701d52442f11dd59c48d166cae",
+        "policy_path": null,
+        "policy_sha256": null
+      },
+      "managed_baseline_activation": {
+        "base_sha": "d6e7ac1b1bcc98aed734a6ecbfa8509f24606c74",
+        "base_tree": "22851c0f356fefcb63718ce63d50a870150a491c",
+        "parent_sha": "ece46f06fbe6eb701d52442f11dd59c48d166cae",
+        "base_manifest_sha256": "bcdce1bea1facb24175229a16dc6e8a2c4210aafc05f0526b2728dc060223ed4",
+        "base_contract_repository": "vlang/v",
+        "base_contract_sha": "7545e515b434cd399333d43659238427d72e22e7",
         "policy_path": null,
         "policy_sha256": null
       },
@@ -73,6 +93,16 @@
         "policy_path": null,
         "policy_sha256": null
       },
+      "managed_baseline_activation": {
+        "base_sha": "199fa78395ca413aac23d02ec69cc5e7b1d805a2",
+        "base_tree": "db67711bfeb33be63dbc8eb03ecdddc2e127cc8c",
+        "parent_sha": "da8ac5a4369accc67c485191d02535d77718a1c8",
+        "base_manifest_sha256": "09dc54928f4690cfee7fd113de93f36479a40cabd10eeb3ee416a3175b42270a",
+        "base_contract_repository": "vlang/v",
+        "base_contract_sha": "7545e515b434cd399333d43659238427d72e22e7",
+        "policy_path": null,
+        "policy_sha256": null
+      },
       "toolchain_profile": {
         "profile_id": null,
         "profile_path": null,
@@ -90,6 +120,16 @@
       "affected_targets": ["macos-arm64"],
       "legacy_onboarding": {
         "base_sha": "274abd2466a14861b75e5b91fd946ad27d114499",
+        "policy_path": null,
+        "policy_sha256": null
+      },
+      "managed_baseline_activation": {
+        "base_sha": "1d0ad0ecf70a91a1df64cebf215e683b1d5aedb5",
+        "base_tree": "96af5121f065310ba9168e3e2dc61adf340e2738",
+        "parent_sha": "274abd2466a14861b75e5b91fd946ad27d114499",
+        "base_manifest_sha256": "be45aaee1e65cc1ed2ee6bd2f121d72cbc248887ffa3d57f4b6d59cb6ea73525",
+        "base_contract_repository": "vlang/v",
+        "base_contract_sha": "7545e515b434cd399333d43659238427d72e22e7",
         "policy_path": null,
         "policy_sha256": null
       },
@@ -113,6 +153,16 @@
         "policy_path": null,
         "policy_sha256": null
       },
+      "managed_baseline_activation": {
+        "base_sha": "8c7d96c75ea8548f007432d70f1ae33cccd81838",
+        "base_tree": "f75c4862711184c4c191a73e6f996eb421bd37b4",
+        "parent_sha": "45230fde96c17fff4baf37deb55e90803c043063",
+        "base_manifest_sha256": "873b62af697ba25f0abe5887ba05972a93bd48990233853b362bed6cb9137699",
+        "base_contract_repository": "vlang/v",
+        "base_contract_sha": "7545e515b434cd399333d43659238427d72e22e7",
+        "policy_path": null,
+        "policy_sha256": null
+      },
       "toolchain_profile": {
         "profile_id": null,
         "profile_path": null,
@@ -130,6 +180,16 @@
       "affected_targets": ["windows-amd64"],
       "legacy_onboarding": {
         "base_sha": "f7c7199bb87fda8b80b31fefa470b2efc952326b",
+        "policy_path": null,
+        "policy_sha256": null
+      },
+      "managed_baseline_activation": {
+        "base_sha": "86ae5844b8b56071b21ae3aa138b247d5eb9ddd9",
+        "base_tree": "818d7794ebdf41de60e5679d485e3a5d49272171",
+        "parent_sha": "f7c7199bb87fda8b80b31fefa470b2efc952326b",
+        "base_manifest_sha256": "b5728124ecf8dc01e4f16cf4188411d6f633bb57997ef36df2dc5fd182e8535a",
+        "base_contract_repository": "vlang/v",
+        "base_contract_sha": "7545e515b434cd399333d43659238427d72e22e7",
         "policy_path": null,
         "policy_sha256": null
       },

--- a/thirdparty/tccbin_automation/tests/provenance_test.v
+++ b/thirdparty/tccbin_automation/tests/provenance_test.v
@@ -1,7 +1,9 @@
 module tests
 
+import crypto.sha1
 import os
 import crypto.sha256
+import encoding.base64
 import tccbin_automation.bin
 
 fn C.tccbin_open_directory_no_follow(path &char) int
@@ -403,6 +405,489 @@ struct LegacyCompositionFixture {
 	manifest_source string
 }
 
+struct ManagedBaselineActivationFixture {
+	base                      string
+	automation_root           string
+	contract_root             string
+	target_id                 string
+	base_repo_root            string
+	raw_root                  string
+	manifest_path             string
+	result_root               string
+	base_sha                  string
+	parent_sha                string
+	base_tree                 string
+	base_manifest_source      string
+	candidate_manifest_source string
+	policy_path               string
+	policy_sha256             string
+	producer_source           string
+	runtime                   bin.RuntimeContractBinding
+	source_commit_evidence    bin.JsonValue
+}
+
+const managed_baseline_phase_a_contract_sha = '7545e515b434cd399333d43659238427d72e22e7'
+
+fn activation_string(value string) bin.JsonValue {
+	return bin.JsonValue{
+		kind:         .string_value
+		string_value: value
+	}
+}
+
+fn activation_object_with_replacements(value bin.JsonValue,
+	replacements map[string]bin.JsonValue) bin.JsonValue {
+	assert value.kind == .object
+	mut values := value.object_values.clone()
+	for key, replacement in replacements {
+		index := value.object_keys.index(key)
+		assert index >= 0, key
+		values[index] = replacement
+	}
+	return bin.JsonValue{
+		kind:          .object
+		object_keys:   value.object_keys.clone()
+		object_values: values
+	}
+}
+
+fn activation_array(values []bin.JsonValue) bin.JsonValue {
+	return bin.JsonValue{
+		kind:        .array
+		array_value: values
+	}
+}
+
+fn activation_unresolved_provenance(value bin.JsonValue) bin.JsonValue {
+	return activation_object_with_replacements(value, {
+		'status':      activation_string('incomplete')
+		'repository':  bin.JsonValue{
+			kind: .null_value
+		}
+		'sha':         bin.JsonValue{
+			kind: .null_value
+		}
+		'source_path': bin.JsonValue{
+			kind: .null_value
+		}
+		'license':     bin.JsonValue{
+			kind: .null_value
+		}
+	})
+}
+
+fn activation_candidate_manifest(source string, runtime_sha string) string {
+	root := bin.parse_strict_json(source) or { panic(err) }
+	return bin.canonical_json(activation_object_with_replacements(root, {
+		'contract_repository': activation_string('vlang/v')
+		'contract_sha':        activation_string(runtime_sha)
+		'contract_mode':       activation_string('production')
+		'v_source_sha':        activation_string(runtime_sha)
+	}))
+}
+
+fn activation_candidate_manifest_with_runtime_source(source string, runtime_sha string,
+	runtime_tree string) string {
+	root := bin.parse_strict_json(activation_candidate_manifest(source, runtime_sha)) or {
+		panic(err)
+	}
+	sources_value := root.object_value('sources') or { panic('sources missing') }
+	mut sources := sources_value.array_value.clone()
+	mut found := false
+	for index, candidate_source in sources {
+		id := candidate_source.object_value('id') or { panic('source ID missing') }
+		if id.string_value == 'v-libgc' {
+			sources[index] = activation_object_with_replacements(candidate_source, {
+				'sha':  activation_string(runtime_sha)
+				'tree': activation_string(runtime_tree)
+			})
+			found = true
+		}
+	}
+	assert found
+	return bin.canonical_json(activation_object_with_replacements(root, {
+		'sources': activation_array(sources)
+	}))
+}
+
+fn activation_manifest_with_repository_provenance_sha(source string, repository string,
+	sha string) string {
+	root := bin.parse_strict_json(source) or { panic(err) }
+	mut replacements := map[string]bin.JsonValue{}
+	for collection in ['overlays', 'inventory', 'outputs'] {
+		collection_value := root.object_value(collection) or { panic('${collection} missing') }
+		mut entries := collection_value.array_value.clone()
+		for index, entry in entries {
+			provenance := entry.object_value('provenance') or { panic('provenance missing') }
+			provenance_repository := provenance.object_value('repository') or {
+				panic('provenance repository missing')
+			}
+			if provenance_repository.kind == .string_value
+				&& provenance_repository.string_value == repository {
+				entries[index] = activation_object_with_replacements(entry, {
+					'provenance': activation_object_with_replacements(provenance, {
+						'sha': activation_string(sha)
+					})
+				})
+			}
+		}
+		replacements[collection] = activation_array(entries)
+	}
+	return bin.canonical_json(activation_object_with_replacements(root, replacements))
+}
+
+fn activation_base_manifest(candidate_source string) string {
+	root := bin.parse_strict_json(candidate_source) or { panic(err) }
+	mut sources := []bin.JsonValue{}
+	source_values := root.object_value('sources') or { panic('sources missing') }
+	for source in source_values.array_value {
+		sources << activation_object_with_replacements(source, {
+			'sha':  bin.JsonValue{
+				kind: .null_value
+			}
+			'tree': bin.JsonValue{
+				kind: .null_value
+			}
+		})
+	}
+	mut replacements := {
+		'contract_sha':      activation_string(managed_baseline_phase_a_contract_sha)
+		'v_source_sha':      activation_string(managed_baseline_phase_a_contract_sha)
+		'provenance_status': activation_string('incomplete')
+		'sources':           activation_array(sources)
+		'toolchain':         bin.parse_strict_json('{"profile_id":null,"profile_sha256":null,"producer_observation":null}') or {
+			panic(err)
+		}
+	}
+	for collection in ['overlays', 'inventory', 'outputs'] {
+		mut entries := []bin.JsonValue{}
+		collection_value := root.object_value(collection) or { panic('${collection} missing') }
+		for entry in collection_value.array_value {
+			provenance := entry.object_value('provenance') or { panic('provenance missing') }
+			entries << activation_object_with_replacements(entry, {
+				'provenance': activation_unresolved_provenance(provenance)
+			})
+		}
+		replacements[collection] = activation_array(entries)
+	}
+	return bin.canonical_json(activation_object_with_replacements(root, replacements))
+}
+
+fn activation_registry_with_binding(source string, target_id string, parent_sha string,
+	base_sha string, base_tree string, base_manifest_sha256 string, policy_path string,
+	policy_sha256 string) string {
+	root := bin.parse_strict_json(source) or { panic(err) }
+	managed := root.object_value('managed_ci_targets') or { panic('managed targets missing') }
+	mut targets := managed.array_value.clone()
+	mut found := false
+	for index, target in targets {
+		id := target.object_value('id') or { panic('target ID missing') }
+		if id.string_value != target_id {
+			continue
+		}
+		legacy := target.object_value('legacy_onboarding') or { panic('legacy binding missing') }
+		activation := bin.parse_strict_json('{"base_sha":"${base_sha}","base_tree":"${base_tree}","parent_sha":"${parent_sha}","base_manifest_sha256":"${base_manifest_sha256}","base_contract_repository":"vlang/v","base_contract_sha":"${managed_baseline_phase_a_contract_sha}","policy_path":"${policy_path}","policy_sha256":"${policy_sha256}"}') or {
+			panic(err)
+		}
+		targets[index] = activation_object_with_replacements(target, {
+			'legacy_onboarding':           activation_object_with_replacements(legacy, {
+				'base_sha': activation_string(parent_sha)
+			})
+			'managed_baseline_activation': activation
+		})
+		found = true
+		break
+	}
+	assert found
+	return bin.canonical_json(activation_object_with_replacements(root, {
+		'managed_ci_targets': activation_array(targets)
+	}))
+}
+
+fn prepare_managed_baseline_activation_fixture(suffix string) ManagedBaselineActivationFixture {
+	fixture := prepare_complete_candidate('managed-baseline-${suffix}', false, '')
+	runtime := bin.RuntimeContractBinding{
+		repository: 'vlang/v'
+		sha:        'a'.repeat(40)
+	}
+	unsealed_candidate_source := activation_candidate_manifest(fixture.manifest_source, runtime.sha)
+	evidence_fixture := managed_baseline_evidence_fixture(unsealed_candidate_source)
+	candidate_source := evidence_fixture.manifest_source
+	base_source := activation_base_manifest(candidate_source)
+	os.write_file(fixture.manifest_path, base_source) or { panic(err) }
+	base_sha := commit_candidate_paths(fixture.source_repo, [
+		'automation/bundle-manifest.json',
+	], 'reviewed incomplete managed baseline')
+	parent_result := os.exec(['git', '-C', fixture.source_repo, 'rev-parse', '${base_sha}^'])
+	tree_result := os.exec(['git', '-C', fixture.source_repo, 'rev-parse', '${base_sha}^{tree}'])
+	assert parent_result.exit_code == 0, parent_result.output
+	assert tree_result.exit_code == 0, tree_result.output
+	parent_sha := parent_result.output.trim_space()
+	base_tree := tree_result.output.trim_space()
+	manifest_path := os.join_path(fixture.base, 'managed-baseline-candidate.json')
+	os.write_file(manifest_path, candidate_source) or { panic(err) }
+	manifest := bin.parse_strict_json(candidate_source) or { panic(err) }
+	policy := bin.managed_baseline_activation_policy_projection(manifest, evidence_fixture.evidence) or {
+		panic(err)
+	}
+	policy_source := bin.canonical_json(policy)
+	policy_sha256 := sha256_bytes(policy_source.bytes())
+	policy_relative_path := 'baseline-activation/linux-amd64.policy.json'
+	policy_path := os.join_path(fixture.automation_root, policy_relative_path)
+	os.mkdir_all(os.dir(policy_path)) or { panic(err) }
+	os.write_file(policy_path, policy_source) or { panic(err) }
+	registry_path := os.join_path(fixture.automation_root, 'targets.json')
+	registry_source := os.read_file(registry_path) or { panic(err) }
+	os.write_file(registry_path, activation_registry_with_binding(registry_source, 'linux-amd64',
+		parent_sha, base_sha, base_tree, sha256_bytes(base_source.bytes()), policy_relative_path,
+		policy_sha256)) or { panic(err) }
+	registry_issues := bin.validate_registry(fixture.automation_root) or { panic(err) }
+	assert registry_issues.len == 0, '${registry_issues}'
+	base_issues := bin.validate_manifest(fixture.automation_root, fixture.manifest_path) or {
+		panic(err)
+	}
+	assert base_issues.len == 0, '${base_issues}'
+	return ManagedBaselineActivationFixture{
+		base:                      fixture.base
+		automation_root:           fixture.automation_root
+		contract_root:             fixture.authority.contract_root
+		target_id:                 'linux-amd64'
+		base_repo_root:            fixture.source_repo
+		raw_root:                  fixture.staging_root
+		manifest_path:             manifest_path
+		result_root:               os.join_path(fixture.base, 'managed-baseline-result')
+		base_sha:                  base_sha
+		parent_sha:                parent_sha
+		base_tree:                 base_tree
+		base_manifest_source:      base_source
+		candidate_manifest_source: candidate_source
+		policy_path:               policy_path
+		policy_sha256:             policy_sha256
+		producer_source:           fixture.authority.producer_source
+		runtime:                   runtime
+		source_commit_evidence:    evidence_fixture.evidence
+	}
+}
+
+fn initialize_managed_baseline_runtime_contract_checkout(contract_root string) (string, string) {
+	for args in [
+		['git', '-C', contract_root, 'init', '-q'],
+		['git', '-C', contract_root, 'config', 'user.email', 'ci@example.invalid'],
+		['git', '-C', contract_root, 'config', 'user.name', 'Contract Test'],
+		['git', '-C', contract_root, 'config', 'core.autocrlf', 'false'],
+		['git', '-C', contract_root, 'remote', 'add', 'origin', 'https://github.com/vlang/v.git'],
+		['git', '-C', contract_root, 'add', '--all'],
+		['git', '-C', contract_root, 'commit', '-qm', 'runtime contract authority'],
+	] {
+		result := os.exec(args)
+		assert result.exit_code == 0, result.output
+	}
+	sha_result := os.exec(['git', '-C', contract_root, 'rev-parse', 'HEAD'])
+	tree_result := os.exec(['git', '-C', contract_root, 'rev-parse', 'HEAD^{tree}'])
+	assert sha_result.exit_code == 0, sha_result.output
+	assert tree_result.exit_code == 0, tree_result.output
+	sha := sha_result.output.trim_space()
+	tree := tree_result.output.trim_space()
+	detach := os.exec(['git', '-C', contract_root, 'checkout', '--detach', '-q', sha])
+	assert detach.exit_code == 0, detach.output
+	return sha, tree
+}
+
+fn prepare_managed_baseline_runtime_activation_fixture(
+	suffix string) ManagedBaselineActivationFixture {
+	fixture := prepare_t2b_windows_matrix_candidate('managed-baseline-runtime-${suffix}')
+	provisional_runtime_sha := 'a'.repeat(40)
+	provisional_runtime_tree := activation_source_tree(fixture.manifest_source, 'v-libgc')
+	provisional_candidate := activation_candidate_manifest_with_runtime_source(fixture.manifest_source,
+		provisional_runtime_sha, provisional_runtime_tree)
+	evidence_fixture := managed_baseline_evidence_fixture(provisional_candidate)
+	base_source := activation_base_manifest(evidence_fixture.manifest_source)
+	os.write_file(fixture.manifest_path, base_source) or { panic(err) }
+	base_sha := commit_candidate_paths(fixture.source_repo, [
+		'automation/bundle-manifest.json',
+	], 'reviewed incomplete Windows managed baseline')
+	parent_result := os.exec(['git', '-C', fixture.source_repo, 'rev-parse', '${base_sha}^'])
+	base_tree_result :=
+		os.exec(['git', '-C', fixture.source_repo, 'rev-parse', '${base_sha}^{tree}'])
+	assert parent_result.exit_code == 0, parent_result.output
+	assert base_tree_result.exit_code == 0, base_tree_result.output
+	parent_sha := parent_result.output.trim_space()
+	base_tree := base_tree_result.output.trim_space()
+	policy_manifest := bin.parse_strict_json(evidence_fixture.manifest_source) or { panic(err) }
+	policy := bin.managed_baseline_activation_policy_projection(policy_manifest,
+		evidence_fixture.evidence) or { panic(err) }
+	policy_source := bin.canonical_json(policy)
+	policy_sha256 := sha256_bytes(policy_source.bytes())
+	policy_relative_path := 'baseline-activation/windows-amd64.policy.json'
+	policy_path := os.join_path(fixture.automation_root, policy_relative_path)
+	os.mkdir_all(os.dir(policy_path)) or { panic(err) }
+	os.write_file(policy_path, policy_source) or { panic(err) }
+	registry_path := os.join_path(fixture.automation_root, 'targets.json')
+	registry_source := os.read_file(registry_path) or { panic(err) }
+	os.write_file(registry_path, activation_registry_with_binding(registry_source, 'windows-amd64',
+		parent_sha, base_sha, base_tree, sha256_bytes(base_source.bytes()), policy_relative_path,
+		policy_sha256)) or { panic(err) }
+	runtime_sha, runtime_tree :=
+		initialize_managed_baseline_runtime_contract_checkout(fixture.authority.contract_root)
+	mut candidate_source := activation_candidate_manifest_with_runtime_source(evidence_fixture.manifest_source,
+		runtime_sha, runtime_tree)
+	candidate_source = activation_manifest_with_repository_provenance_sha(candidate_source,
+		'vlang/tccbin', base_sha)
+	manifest_path := os.join_path(fixture.base, 'managed-baseline-runtime-candidate.json')
+	os.write_file(manifest_path, candidate_source) or { panic(err) }
+	registry_issues := bin.validate_registry(fixture.automation_root) or { panic(err) }
+	assert registry_issues.len == 0, '${registry_issues}'
+	base_issues := bin.validate_manifest(fixture.automation_root, fixture.manifest_path) or {
+		panic(err)
+	}
+	assert base_issues.len == 0, '${base_issues}'
+	candidate_issues := bin.validate_manifest(fixture.automation_root, manifest_path) or {
+		panic(err)
+	}
+	assert candidate_issues.len == 0, '${candidate_issues}'
+	return ManagedBaselineActivationFixture{
+		base:                      fixture.base
+		automation_root:           fixture.automation_root
+		contract_root:             fixture.authority.contract_root
+		target_id:                 'windows-amd64'
+		base_repo_root:            fixture.source_repo
+		raw_root:                  fixture.staging_root
+		manifest_path:             manifest_path
+		result_root:               os.join_path(fixture.base, 'managed-baseline-runtime-result')
+		base_sha:                  base_sha
+		parent_sha:                parent_sha
+		base_tree:                 base_tree
+		base_manifest_source:      base_source
+		candidate_manifest_source: candidate_source
+		policy_path:               policy_path
+		policy_sha256:             policy_sha256
+		producer_source:           fixture.authority.producer_source
+		runtime:                   bin.RuntimeContractBinding{
+			repository: 'vlang/v'
+			sha:        runtime_sha
+		}
+		source_commit_evidence:    evidence_fixture.evidence
+	}
+}
+
+fn replace_managed_baseline_activation_policy(fixture ManagedBaselineActivationFixture,
+	manifest_source string) {
+	manifest := bin.parse_strict_json(manifest_source) or { panic(err) }
+	policy := bin.managed_baseline_activation_policy_projection(manifest,
+		fixture.source_commit_evidence) or { panic(err) }
+	policy_source := bin.canonical_json(policy)
+	new_hash := sha256_bytes(policy_source.bytes())
+	registry_path := os.join_path(fixture.automation_root, 'targets.json')
+	mut registry_source := os.read_file(registry_path) or { panic(err) }
+	assert registry_source.count(fixture.policy_sha256) == 1
+	registry_source = registry_source.replace_once(fixture.policy_sha256, new_hash)
+	os.write_file(fixture.policy_path, policy_source) or { panic(err) }
+	os.write_file(registry_path, registry_source) or { panic(err) }
+}
+
+fn activation_manifest_with_unobserved_producer(source string) string {
+	root := bin.parse_strict_json(source) or { panic(err) }
+	toolchain := root.object_value('toolchain') or { panic('toolchain missing') }
+	return bin.canonical_json(activation_object_with_replacements(root, {
+		'provenance_status': activation_string('incomplete')
+		'toolchain':         activation_object_with_replacements(toolchain, {
+			'producer_observation': bin.JsonValue{
+				kind: .null_value
+			}
+		})
+	}))
+}
+
+fn activation_manifest_with_first_inventory_sha(source string, sha string) string {
+	root := bin.parse_strict_json(source) or { panic(err) }
+	inventory := root.object_value('inventory') or { panic('inventory missing') }
+	mut entries := inventory.array_value.clone()
+	assert entries.len > 0
+	entries[0] = activation_object_with_replacements(entries[0], {
+		'sha256': activation_string(sha)
+	})
+	return bin.canonical_json(activation_object_with_replacements(root, {
+		'inventory': activation_array(entries)
+	}))
+}
+
+fn activation_manifest_with_first_inventory_provenance(source string, repository string,
+	sha string) string {
+	root := bin.parse_strict_json(source) or { panic(err) }
+	inventory := root.object_value('inventory') or { panic('inventory missing') }
+	mut entries := inventory.array_value.clone()
+	assert entries.len > 0
+	provenance := entries[0].object_value('provenance') or { panic('provenance missing') }
+	entries[0] = activation_object_with_replacements(entries[0], {
+		'provenance': activation_object_with_replacements(provenance, {
+			'repository': activation_string(repository)
+			'sha':        activation_string(sha)
+		})
+	})
+	return bin.canonical_json(activation_object_with_replacements(root, {
+		'inventory': activation_array(entries)
+	}))
+}
+
+fn activation_manifest_with_recipe_version(source string, version i64) string {
+	root := bin.parse_strict_json(source) or { panic(err) }
+	recipe := root.object_value('recipe') or { panic('recipe missing') }
+	return bin.canonical_json(activation_object_with_replacements(root, {
+		'recipe': activation_object_with_replacements(recipe, {
+			'version': bin.JsonValue{
+				kind:      .integer
+				int_value: version
+			}
+		})
+	}))
+}
+
+fn activation_source_sha(source string, source_id string) string {
+	root := bin.parse_strict_json(source) or { panic(err) }
+	sources := root.object_value('sources') or { panic('sources missing') }
+	for candidate_source in sources.array_value {
+		id := candidate_source.object_value('id') or { panic('source ID missing') }
+		if id.string_value == source_id {
+			return (candidate_source.object_value('sha') or { panic('source SHA missing') }).string_value
+		}
+	}
+	panic('source ${source_id} missing')
+}
+
+fn activation_source_tree(source string, source_id string) string {
+	root := bin.parse_strict_json(source) or { panic(err) }
+	sources := root.object_value('sources') or { panic('sources missing') }
+	for candidate_source in sources.array_value {
+		id := candidate_source.object_value('id') or { panic('source ID missing') }
+		if id.string_value == source_id {
+			return (candidate_source.object_value('tree') or { panic('source tree missing') }).string_value
+		}
+	}
+	panic('source ${source_id} missing')
+}
+
+fn activation_first_source_evidence_with_replacements(evidence bin.JsonValue,
+	replacements map[string]bin.JsonValue) bin.JsonValue {
+	assert evidence.kind == .array
+	mut entries := evidence.array_value.clone()
+	assert entries.len > 0
+	entries[0] = activation_object_with_replacements(entries[0], replacements)
+	return activation_array(entries)
+}
+
+fn managed_baseline_projection_error(manifest_source string, evidence bin.JsonValue) string {
+	manifest := bin.parse_strict_json(manifest_source) or { panic(err) }
+	mut message := ''
+	bin.managed_baseline_activation_policy_projection(manifest, evidence) or { message = err.msg() }
+	return message
+}
+
+fn activation_git_commit_oid(raw []u8) string {
+	mut material := 'commit ${raw.len}\x00'.bytes()
+	material << raw
+	return sha1.sum(material).hex()
+}
+
 fn runtime_contract_binding(production bool) bin.RuntimeContractBinding {
 	return bin.RuntimeContractBinding{
 		repository: if production { 'vlang/v' } else { 'GGRei/v' }
@@ -767,6 +1252,10 @@ fn prepare_legacy_composition_fixture(suffix string,
 	assert registry_source.count(registry_marker) == 1
 	registry_source = registry_source.replace_once(registry_marker,
 		'"base_sha": "${base_sha}",\n        "policy_path": "${policy_relative_path}",\n        "policy_sha256": "${policy_hash}"')
+	activation_parent_marker := '"parent_sha": "ece46f06fbe6eb701d52442f11dd59c48d166cae"'
+	assert registry_source.count(activation_parent_marker) == 1
+	registry_source = registry_source.replace_once(activation_parent_marker,
+		'"parent_sha": "${base_sha}"')
 	os.write_file(os.join_path(contract_automation_root, 'targets.json'), registry_source) or {
 		panic(err)
 	}
@@ -2635,8 +3124,8 @@ fn update_legacy_fixture_base_sha(fixture LegacyCompositionFixture, old_sha stri
 	new_sha string) {
 	registry_path := os.join_path(fixture.automation_root, 'targets.json')
 	mut registry_source := os.read_file(registry_path) or { panic(err) }
-	assert registry_source.count(old_sha) == 1
-	registry_source = registry_source.replace_once(old_sha, new_sha)
+	assert registry_source.count(old_sha) == 2
+	registry_source = registry_source.replace(old_sha, new_sha)
 	os.write_file(registry_path, registry_source) or { panic(err) }
 }
 
@@ -2724,6 +3213,841 @@ fn prepare_windows_immutable_transform_candidate(suffix string) (CompleteCandida
 		manifest_source: manifest_source
 		authority:       authority
 	}, base_sha, candidate_sha
+}
+
+fn test_managed_baseline_activation_parser_and_both_entrypoints_are_dormant_by_default() {
+	assert bin.parse_candidate_transition_kind('baseline-activate') or { panic(err) } == .baseline_activate
+	mut parse_message := ''
+	bin.parse_candidate_transition_kind('baseline_activate') or { parse_message = err.msg() }
+	assert parse_message == 'candidate transition kind must be monthly, legacy-onboard, or baseline-activate'
+
+	result_root := os.join_path(os.temp_dir(), 'tccbin-dormant-activation-result-${os.getpid()}')
+	work_root := os.join_path(os.temp_dir(), 'tccbin-dormant-activation-work-${os.getpid()}')
+	os.rmdir_all(result_root) or {}
+	os.rmdir_all(work_root) or {}
+	runtime := bin.RuntimeContractBinding{
+		repository: 'vlang/v'
+		sha:        'a'.repeat(40)
+	}
+	compose_message := candidate_composition_error(bin.CandidateCompositionRequest{
+		target_id:      'linux-amd64'
+		kind:           .baseline_activate
+		base_repo_root: '/absent/base-repository'
+		base_sha:       '0'.repeat(40)
+		raw_root:       '/absent/raw-root'
+		manifest_path:  '/absent/manifest.json'
+		result_root:    result_root
+	}, runtime)
+	assert compose_message == 'target has no reviewed managed baseline activation policy'
+	mut preflight_message := ''
+	bin.evaluate_candidate_manifest_for_execution(automation_root(), 'linux-amd64',
+		.baseline_activate, '/absent/candidate-repository', '0'.repeat(40), '1'.repeat(40),
+		work_root, runtime, false) or { preflight_message = err.msg() }
+	assert preflight_message == 'target has no reviewed managed baseline activation policy'
+	assert !os.exists(result_root)
+	assert !os.exists(work_root)
+}
+
+fn test_managed_baseline_activation_composes_only_a_complete_manifest_direct_child() {
+	fixture := prepare_managed_baseline_activation_fixture('complete')
+	defer {
+		os.rmdir_all(fixture.base) or {}
+	}
+	os.write_file(os.join_path(fixture.raw_root, 'raw-extra-must-not-enter.txt'), 'ignored\n') or {
+		panic(err)
+	}
+	result := bin.compose_candidate_for_execution(fixture.automation_root, bin.CandidateCompositionRequest{
+		target_id:      'linux-amd64'
+		kind:           .baseline_activate
+		base_repo_root: fixture.base_repo_root
+		base_sha:       fixture.base_sha
+		raw_root:       fixture.raw_root
+		manifest_path:  fixture.manifest_path
+		result_root:    fixture.result_root
+	}, fixture.runtime) or { panic(err) }
+	assert result.kind == .baseline_activate
+	assert result.base_sha == fixture.base_sha
+	assert result.decision.eligible
+	assert !result.decision.publish_allowed
+	mut exposed := os.ls(fixture.result_root) or { panic(err) }
+	exposed.sort()
+	assert exposed == ['candidate-repository']
+	repository := os.join_path(fixture.result_root, 'candidate-repository')
+	assert (os.read_file(os.join_path(repository, 'automation', 'bundle-manifest.json')) or {
+		panic(err)
+	}) == fixture.candidate_manifest_source
+	assert !os.exists(os.join_path(repository, 'raw-extra-must-not-enter.txt'))
+	diff := os.exec(['git', '--no-replace-objects', '-C', repository, 'diff-tree', '--no-commit-id',
+		'--name-status', '-r', '--no-renames', fixture.base_sha, result.candidate_sha, '--'])
+	parent := os.exec(['git', '--no-replace-objects', '-C', repository, 'rev-parse', 'HEAD^'])
+	status := os.exec(['git', '--no-replace-objects', '-C', repository, 'status', '--porcelain=v1',
+		'--untracked-files=all', '--ignored=matching'])
+	assert diff.exit_code == 0 && diff.output == 'M\tautomation/bundle-manifest.json\n'
+	assert parent.exit_code == 0 && parent.output.trim_space() == fixture.base_sha
+	assert status.exit_code == 0 && status.output == ''
+	for path in ['src/tcc.c', 'tcc.exe'] {
+		base_mode, base_oid := candidate_git_entry_for_test(repository, fixture.base_sha, path)
+		candidate_mode, candidate_oid := candidate_git_entry_for_test(repository,
+			result.candidate_sha, path)
+		assert candidate_mode == base_mode
+		assert candidate_oid == base_oid
+	}
+}
+
+fn test_managed_baseline_activation_binds_v_libgc_to_a_hardened_runtime_checkout() {
+	fixture := prepare_managed_baseline_runtime_activation_fixture('runtime-positive')
+	defer {
+		os.rmdir_all(fixture.base) or {}
+	}
+	result := bin.compose_candidate_for_execution(fixture.automation_root, bin.CandidateCompositionRequest{
+		target_id:      fixture.target_id
+		kind:           .baseline_activate
+		base_repo_root: fixture.base_repo_root
+		base_sha:       fixture.base_sha
+		raw_root:       fixture.raw_root
+		manifest_path:  fixture.manifest_path
+		result_root:    fixture.result_root
+	}, fixture.runtime) or { panic(err) }
+	assert result.decision.eligible
+	assert !result.decision.publish_allowed
+	runtime_tree := os.exec(['git', '-C', fixture.contract_root, 'rev-parse',
+		'${fixture.runtime.sha}^{tree}'])
+	assert runtime_tree.exit_code == 0, runtime_tree.output
+	assert activation_source_tree(fixture.candidate_manifest_source, 'v-libgc') == runtime_tree.output.trim_space()
+}
+
+fn test_managed_baseline_activation_rejects_a_non_authoritative_runtime_origin() {
+	fixture := prepare_managed_baseline_runtime_activation_fixture('runtime-origin-negative')
+	defer {
+		os.rmdir_all(fixture.base) or {}
+	}
+	changed_origin := os.exec(['git', '-C', fixture.contract_root, 'remote', 'set-url', 'origin',
+		'https://example.invalid/untrusted/v.git'])
+	assert changed_origin.exit_code == 0, changed_origin.output
+	message := candidate_composition_error_at(fixture.automation_root, bin.CandidateCompositionRequest{
+		target_id:      fixture.target_id
+		kind:           .baseline_activate
+		base_repo_root: fixture.base_repo_root
+		base_sha:       fixture.base_sha
+		raw_root:       fixture.raw_root
+		manifest_path:  fixture.manifest_path
+		result_root:    fixture.result_root
+	}, fixture.runtime)
+	assert message == 'managed baseline runtime contract origin is not the vlang/v HTTPS repository'
+	assert !os.exists(fixture.result_root)
+	assert_no_candidate_composition_scratch(fixture.base)
+}
+
+fn test_managed_baseline_activation_rejects_runtime_tree_and_head_drift() {
+	fixture := prepare_managed_baseline_runtime_activation_fixture('runtime-tree-head-negative')
+	defer {
+		os.rmdir_all(fixture.base) or {}
+	}
+	wrong_tree_source := activation_candidate_manifest_with_runtime_source(fixture.candidate_manifest_source,
+		fixture.runtime.sha, '9'.repeat(40))
+	os.write_file(fixture.manifest_path, wrong_tree_source) or { panic(err) }
+	tree_message := candidate_composition_error_at(fixture.automation_root, bin.CandidateCompositionRequest{
+		target_id:      fixture.target_id
+		kind:           .baseline_activate
+		base_repo_root: fixture.base_repo_root
+		base_sha:       fixture.base_sha
+		raw_root:       fixture.raw_root
+		manifest_path:  fixture.manifest_path
+		result_root:    fixture.result_root
+	}, fixture.runtime)
+	assert tree_message == 'managed baseline activation source differs from reviewed commit evidence'
+	assert !os.exists(fixture.result_root)
+	assert_no_candidate_composition_scratch(fixture.base)
+	os.write_file(fixture.manifest_path, fixture.candidate_manifest_source) or { panic(err) }
+	os.write_file(os.join_path(fixture.contract_root, 'runtime-head-drift.txt'), 'drift\n') or {
+		panic(err)
+	}
+	for args in [
+		['git', '-C', fixture.contract_root, 'add', '--all'],
+		['git', '-C', fixture.contract_root, '-c', 'commit.gpgsign=false', 'commit', '-qm',
+			'runtime head drift'],
+	] {
+		result := os.exec(args)
+		assert result.exit_code == 0, result.output
+	}
+	head_message := candidate_composition_error_at(fixture.automation_root, bin.CandidateCompositionRequest{
+		target_id:      fixture.target_id
+		kind:           .baseline_activate
+		base_repo_root: fixture.base_repo_root
+		base_sha:       fixture.base_sha
+		raw_root:       fixture.raw_root
+		manifest_path:  fixture.manifest_path
+		result_root:    fixture.result_root
+	}, fixture.runtime)
+	assert head_message == 'managed baseline runtime contract checkout is not at the runtime SHA'
+	assert !os.exists(fixture.result_root)
+	assert_no_candidate_composition_scratch(fixture.base)
+}
+
+fn test_managed_baseline_activation_rejects_altered_raw_without_exposing_a_partial_result() {
+	fixture := prepare_managed_baseline_activation_fixture('raw-altered')
+	defer {
+		os.rmdir_all(fixture.base) or {}
+	}
+	os.write_file(os.join_path(fixture.raw_root, 'src', 'tcc.c'), 'untrusted replacement\n') or {
+		panic(err)
+	}
+	message := candidate_composition_error_at(fixture.automation_root, bin.CandidateCompositionRequest{
+		target_id:      'linux-amd64'
+		kind:           .baseline_activate
+		base_repo_root: fixture.base_repo_root
+		base_sha:       fixture.base_sha
+		raw_root:       fixture.raw_root
+		manifest_path:  fixture.manifest_path
+		result_root:    fixture.result_root
+	}, fixture.runtime)
+	assert message == 'candidate RAW entry differs from its manifest declaration'
+	assert !os.exists(fixture.result_root)
+	assert_no_candidate_composition_scratch(fixture.base)
+}
+
+fn test_managed_baseline_activation_rejects_absent_raw_without_exposing_a_partial_result() {
+	fixture := prepare_managed_baseline_activation_fixture('raw-absent')
+	defer {
+		os.rmdir_all(fixture.base) or {}
+	}
+	os.rm(os.join_path(fixture.raw_root, 'src', 'tcc.c')) or { panic(err) }
+	message := candidate_composition_error_at(fixture.automation_root, bin.CandidateCompositionRequest{
+		target_id:      'linux-amd64'
+		kind:           .baseline_activate
+		base_repo_root: fixture.base_repo_root
+		base_sha:       fixture.base_sha
+		raw_root:       fixture.raw_root
+		manifest_path:  fixture.manifest_path
+		result_root:    fixture.result_root
+	}, fixture.runtime)
+	assert message == 'declared payload path is absent from staging'
+	assert !os.exists(fixture.result_root)
+	assert_no_candidate_composition_scratch(fixture.base)
+}
+
+fn test_managed_baseline_activation_candidate_preflight_exports_an_independent_payload() {
+	fixture := prepare_managed_baseline_activation_fixture('preflight-complete')
+	defer {
+		os.rmdir_all(fixture.base) or {}
+	}
+	os.write_file(os.join_path(fixture.base_repo_root, 'automation', 'bundle-manifest.json'),
+		fixture.candidate_manifest_source) or { panic(err) }
+	candidate_sha := commit_candidate_paths(fixture.base_repo_root, [
+		'automation/bundle-manifest.json',
+	], 'activate reviewed managed baseline manifest')
+	work_root := os.join_path(fixture.base, 'managed-baseline-preflight-success')
+	decision := bin.evaluate_candidate_manifest_for_execution(fixture.automation_root,
+		'linux-amd64', .baseline_activate, fixture.base_repo_root, fixture.base_sha, candidate_sha,
+		work_root, fixture.runtime, false) or { panic(err) }
+	assert decision.eligible
+	assert !decision.publish_allowed
+	assert decision.reason == 'authenticated_staging'
+	payload_root := os.join_path(work_root, 'payload')
+	source_root := os.join_path(work_root, 'candidate-source')
+	assert os.is_dir(payload_root)
+	assert !os.exists(os.join_path(payload_root, '.git'))
+	assert !os.exists(os.join_path(payload_root, 'automation'))
+	parent := os.exec(['git', '--no-replace-objects', '-C', source_root, 'rev-parse', 'HEAD^'])
+	diff := os.exec(['git', '--no-replace-objects', '-C', source_root, 'diff-tree', '--no-commit-id',
+		'--name-status', '-r', '--no-renames', fixture.base_sha, candidate_sha, '--'])
+	assert parent.exit_code == 0 && parent.output.trim_space() == fixture.base_sha
+	assert diff.exit_code == 0 && diff.output == 'M\tautomation/bundle-manifest.json\n'
+	for path in ['src/tcc.c', 'tcc.exe'] {
+		assert os.read_bytes(os.join_path(payload_root, path)) or { panic(err) } == os.read_bytes(os.join_path(source_root,
+			path)) or { panic(err) }
+	}
+	$if !windows {
+		payload_stat := os.lstat(os.join_path(payload_root, 'tcc.exe')) or { panic(err) }
+		source_stat := os.lstat(os.join_path(source_root, 'tcc.exe')) or { panic(err) }
+		assert payload_stat.dev != source_stat.dev || payload_stat.inode != source_stat.inode
+		assert payload_stat.nlink == 1
+	}
+}
+
+fn test_managed_baseline_activation_attests_the_exact_reviewed_base_before_exposure() {
+	fixture := prepare_managed_baseline_activation_fixture('base-tree-pin')
+	defer {
+		os.rmdir_all(fixture.base) or {}
+	}
+	registry_path := os.join_path(fixture.automation_root, 'targets.json')
+	mut registry_source := os.read_file(registry_path) or { panic(err) }
+	assert registry_source.count(fixture.base_tree) == 1
+	registry_source = registry_source.replace_once(fixture.base_tree, '8'.repeat(40))
+	os.write_file(registry_path, registry_source) or { panic(err) }
+	message := candidate_composition_error_at(fixture.automation_root, bin.CandidateCompositionRequest{
+		target_id:      'linux-amd64'
+		kind:           .baseline_activate
+		base_repo_root: fixture.base_repo_root
+		base_sha:       fixture.base_sha
+		raw_root:       fixture.raw_root
+		manifest_path:  fixture.manifest_path
+		result_root:    fixture.result_root
+	}, fixture.runtime)
+	assert message == 'managed baseline activation base tree differs from the reviewed pin'
+	assert !os.exists(fixture.result_root)
+	assert_no_candidate_composition_scratch(fixture.base)
+}
+
+fn test_managed_baseline_activation_rejects_wrong_manifest_and_parent_pins() {
+	manifest_fixture := prepare_managed_baseline_activation_fixture('base-manifest-pin')
+	defer {
+		os.rmdir_all(manifest_fixture.base) or {}
+	}
+	manifest_registry_path := os.join_path(manifest_fixture.automation_root, 'targets.json')
+	mut manifest_registry := os.read_file(manifest_registry_path) or { panic(err) }
+	base_manifest_sha256 := sha256_bytes(manifest_fixture.base_manifest_source.bytes())
+	assert manifest_registry.count(base_manifest_sha256) == 1
+	manifest_registry = manifest_registry.replace_once(base_manifest_sha256, '6'.repeat(64))
+	os.write_file(manifest_registry_path, manifest_registry) or { panic(err) }
+	manifest_message := candidate_composition_error_at(manifest_fixture.automation_root, bin.CandidateCompositionRequest{
+		target_id:      'linux-amd64'
+		kind:           .baseline_activate
+		base_repo_root: manifest_fixture.base_repo_root
+		base_sha:       manifest_fixture.base_sha
+		raw_root:       manifest_fixture.raw_root
+		manifest_path:  manifest_fixture.manifest_path
+		result_root:    manifest_fixture.result_root
+	}, manifest_fixture.runtime)
+	assert manifest_message == 'managed baseline activation base manifest differs from the reviewed pin'
+	assert !os.exists(manifest_fixture.result_root)
+	assert_no_candidate_composition_scratch(manifest_fixture.base)
+
+	parent_fixture := prepare_managed_baseline_activation_fixture('base-parent-pin')
+	defer {
+		os.rmdir_all(parent_fixture.base) or {}
+	}
+	parent_registry_path := os.join_path(parent_fixture.automation_root, 'targets.json')
+	mut parent_registry := os.read_file(parent_registry_path) or { panic(err) }
+	parent_marker := '"parent_sha":"${parent_fixture.parent_sha}"'
+	assert parent_registry.count(parent_marker) == 1
+	parent_registry = parent_registry.replace_once(parent_marker,
+		'"parent_sha":"${'8'.repeat(40)}"')
+	os.write_file(parent_registry_path, parent_registry) or { panic(err) }
+	parent_message := candidate_composition_error_at(parent_fixture.automation_root, bin.CandidateCompositionRequest{
+		target_id:      'linux-amd64'
+		kind:           .baseline_activate
+		base_repo_root: parent_fixture.base_repo_root
+		base_sha:       parent_fixture.base_sha
+		raw_root:       parent_fixture.raw_root
+		manifest_path:  parent_fixture.manifest_path
+		result_root:    parent_fixture.result_root
+	}, parent_fixture.runtime)
+	assert parent_message == 'managed baseline activation base parent differs from the reviewed pin'
+	assert !os.exists(parent_fixture.result_root)
+	assert_no_candidate_composition_scratch(parent_fixture.base)
+}
+
+fn test_managed_baseline_activation_rejects_old_runtime_and_contract_authority_migration() {
+	old_runtime_fixture := prepare_managed_baseline_activation_fixture('old-runtime')
+	defer {
+		os.rmdir_all(old_runtime_fixture.base) or {}
+	}
+	old_runtime_root := bin.parse_strict_json(old_runtime_fixture.candidate_manifest_source) or {
+		panic(err)
+	}
+	old_runtime_source := bin.canonical_json(activation_object_with_replacements(old_runtime_root, {
+		'contract_sha': activation_string(managed_baseline_phase_a_contract_sha)
+		'v_source_sha': activation_string(managed_baseline_phase_a_contract_sha)
+	}))
+	os.write_file(old_runtime_fixture.manifest_path, old_runtime_source) or { panic(err) }
+	old_runtime := bin.RuntimeContractBinding{
+		repository: 'vlang/v'
+		sha:        managed_baseline_phase_a_contract_sha
+	}
+	old_runtime_message := candidate_composition_error_at(old_runtime_fixture.automation_root, bin.CandidateCompositionRequest{
+		target_id:      'linux-amd64'
+		kind:           .baseline_activate
+		base_repo_root: old_runtime_fixture.base_repo_root
+		base_sha:       old_runtime_fixture.base_sha
+		raw_root:       old_runtime_fixture.raw_root
+		manifest_path:  old_runtime_fixture.manifest_path
+		result_root:    old_runtime_fixture.result_root
+	}, old_runtime)
+	assert old_runtime_message == 'managed baseline activation runtime contract must differ from the reviewed base'
+	assert !os.exists(old_runtime_fixture.result_root)
+	assert_no_candidate_composition_scratch(old_runtime_fixture.base)
+
+	authority_fixture := prepare_managed_baseline_activation_fixture('contract-authority')
+	defer {
+		os.rmdir_all(authority_fixture.base) or {}
+	}
+	authority_root := bin.parse_strict_json(authority_fixture.candidate_manifest_source) or {
+		panic(err)
+	}
+	authority_source := bin.canonical_json(activation_object_with_replacements(authority_root, {
+		'contract_repository': activation_string('GGRei/v')
+		'contract_mode':       activation_string('fork-dry-run')
+	}))
+	os.write_file(authority_fixture.manifest_path, authority_source) or { panic(err) }
+	fork_runtime := bin.RuntimeContractBinding{
+		repository: 'GGRei/v'
+		sha:        authority_fixture.runtime.sha
+	}
+	authority_message := candidate_composition_error_at(authority_fixture.automation_root, bin.CandidateCompositionRequest{
+		target_id:      'linux-amd64'
+		kind:           .baseline_activate
+		base_repo_root: authority_fixture.base_repo_root
+		base_sha:       authority_fixture.base_sha
+		raw_root:       authority_fixture.raw_root
+		manifest_path:  authority_fixture.manifest_path
+		result_root:    authority_fixture.result_root
+	}, fork_runtime)
+	assert authority_message == 'managed baseline activation candidate must retain the production contract authority'
+	assert !os.exists(authority_fixture.result_root)
+	assert_no_candidate_composition_scratch(authority_fixture.base)
+}
+
+fn test_managed_baseline_activation_rejects_incomplete_candidates_without_exposure() {
+	fixture := prepare_managed_baseline_activation_fixture('incomplete')
+	defer {
+		os.rmdir_all(fixture.base) or {}
+	}
+	incomplete_source :=
+		activation_manifest_with_unobserved_producer(fixture.candidate_manifest_source)
+	os.write_file(fixture.manifest_path, incomplete_source) or { panic(err) }
+	message := candidate_composition_error_at(fixture.automation_root, bin.CandidateCompositionRequest{
+		target_id:      'linux-amd64'
+		kind:           .baseline_activate
+		base_repo_root: fixture.base_repo_root
+		base_sha:       fixture.base_sha
+		raw_root:       fixture.raw_root
+		manifest_path:  fixture.manifest_path
+		result_root:    fixture.result_root
+	}, fixture.runtime)
+	assert message == 'managed baseline activation candidate must have complete resolved provenance'
+	assert !os.exists(fixture.result_root)
+	assert_no_candidate_composition_scratch(fixture.base)
+}
+
+fn test_managed_baseline_activation_closes_reviewed_policy_and_payload_byte_drift() {
+	payload_fixture := prepare_managed_baseline_activation_fixture('payload-sha-drift')
+	defer {
+		os.rmdir_all(payload_fixture.base) or {}
+	}
+	payload_drift := activation_manifest_with_first_inventory_sha(payload_fixture.candidate_manifest_source,
+		'7'.repeat(64))
+	os.write_file(payload_fixture.manifest_path, payload_drift) or { panic(err) }
+	payload_message := candidate_composition_error_at(payload_fixture.automation_root, bin.CandidateCompositionRequest{
+		target_id:      'linux-amd64'
+		kind:           .baseline_activate
+		base_repo_root: payload_fixture.base_repo_root
+		base_sha:       payload_fixture.base_sha
+		raw_root:       payload_fixture.raw_root
+		manifest_path:  payload_fixture.manifest_path
+		result_root:    payload_fixture.result_root
+	}, payload_fixture.runtime)
+	assert payload_message == 'managed baseline activation changed immutable payload bytes or policy'
+	assert !os.exists(payload_fixture.result_root)
+	assert_no_candidate_composition_scratch(payload_fixture.base)
+
+	policy_fixture := prepare_managed_baseline_activation_fixture('reviewed-policy-drift')
+	defer {
+		os.rmdir_all(policy_fixture.base) or {}
+	}
+	policy_drift :=
+		activation_manifest_with_recipe_version(policy_fixture.candidate_manifest_source, 2)
+	replace_managed_baseline_activation_policy(policy_fixture, policy_drift)
+	os.write_file(policy_fixture.manifest_path, policy_drift) or { panic(err) }
+	policy_message := candidate_composition_error_at(policy_fixture.automation_root, bin.CandidateCompositionRequest{
+		target_id:      'linux-amd64'
+		kind:           .baseline_activate
+		base_repo_root: policy_fixture.base_repo_root
+		base_sha:       policy_fixture.base_sha
+		raw_root:       policy_fixture.raw_root
+		manifest_path:  policy_fixture.manifest_path
+		result_root:    policy_fixture.result_root
+	}, policy_fixture.runtime)
+	assert policy_message == 'managed baseline activation changed immutable manifest policy'
+	assert !os.exists(policy_fixture.result_root)
+	assert_no_candidate_composition_scratch(policy_fixture.base)
+}
+
+fn test_managed_baseline_activation_rejects_arbitrary_payload_provenance_sha_without_exposure() {
+	fixture := prepare_managed_baseline_activation_fixture('arbitrary-provenance-sha')
+	defer {
+		os.rmdir_all(fixture.base) or {}
+	}
+	malicious_source := activation_manifest_with_first_inventory_provenance(fixture.candidate_manifest_source,
+		'TinyCC/tinycc', '9'.repeat(40))
+	os.write_file(fixture.manifest_path, malicious_source) or { panic(err) }
+	message := candidate_composition_error_at(fixture.automation_root, bin.CandidateCompositionRequest{
+		target_id:      'linux-amd64'
+		kind:           .baseline_activate
+		base_repo_root: fixture.base_repo_root
+		base_sha:       fixture.base_sha
+		raw_root:       fixture.raw_root
+		manifest_path:  fixture.manifest_path
+		result_root:    fixture.result_root
+	}, fixture.runtime)
+	assert message == 'managed baseline activation payload provenance SHA differs from its authenticated authority'
+	assert !os.exists(fixture.result_root)
+	assert_no_candidate_composition_scratch(fixture.base)
+}
+
+fn test_managed_baseline_activation_rejects_coordinated_source_and_provenance_sha_drift() {
+	fixture := prepare_managed_baseline_activation_fixture('coordinated-source-provenance-sha')
+	defer {
+		os.rmdir_all(fixture.base) or {}
+	}
+	reviewed_sha := activation_source_sha(fixture.candidate_manifest_source, 'tinycc')
+	malicious_source := fixture.candidate_manifest_source.replace(reviewed_sha, '9'.repeat(40))
+	os.write_file(fixture.manifest_path, malicious_source) or { panic(err) }
+	message := candidate_composition_error_at(fixture.automation_root, bin.CandidateCompositionRequest{
+		target_id:      'linux-amd64'
+		kind:           .baseline_activate
+		base_repo_root: fixture.base_repo_root
+		base_sha:       fixture.base_sha
+		raw_root:       fixture.raw_root
+		manifest_path:  fixture.manifest_path
+		result_root:    fixture.result_root
+	}, fixture.runtime)
+	assert message == 'managed baseline activation source differs from reviewed commit evidence'
+	assert !os.exists(fixture.result_root)
+	assert_no_candidate_composition_scratch(fixture.base)
+}
+
+fn test_managed_baseline_activation_rejects_source_tree_drift() {
+	fixture := prepare_managed_baseline_activation_fixture('source-tree-drift')
+	defer {
+		os.rmdir_all(fixture.base) or {}
+	}
+	reviewed_tree := activation_source_tree(fixture.candidate_manifest_source, 'tinycc')
+	malicious_source := fixture.candidate_manifest_source.replace(reviewed_tree, '9'.repeat(40))
+	os.write_file(fixture.manifest_path, malicious_source) or { panic(err) }
+	message := candidate_composition_error_at(fixture.automation_root, bin.CandidateCompositionRequest{
+		target_id:      'linux-amd64'
+		kind:           .baseline_activate
+		base_repo_root: fixture.base_repo_root
+		base_sha:       fixture.base_sha
+		raw_root:       fixture.raw_root
+		manifest_path:  fixture.manifest_path
+		result_root:    fixture.result_root
+	}, fixture.runtime)
+	assert message == 'managed baseline activation source differs from reviewed commit evidence'
+	assert !os.exists(fixture.result_root)
+	assert_no_candidate_composition_scratch(fixture.base)
+}
+
+fn test_managed_baseline_activation_commit_evidence_is_closed_bounded_and_self_authenticating() {
+	fixture := prepare_managed_baseline_activation_fixture('commit-evidence-negative-matrix')
+	defer {
+		os.rmdir_all(fixture.base) or {}
+	}
+	first := fixture.source_commit_evidence.array_value[0]
+	raw_base64 := (first.object_value('raw_commit_base64') or {
+		panic('raw commit evidence missing')
+	}).string_value
+	raw := base64.decode(raw_base64)
+	mut tampered_raw := raw.clone()
+	tampered_raw[tampered_raw.len - 1] = if tampered_raw[tampered_raw.len - 1] == `x` {
+		`y`
+	} else {
+		`x`
+	}
+	tampered := activation_first_source_evidence_with_replacements(fixture.source_commit_evidence, {
+		'raw_commit_base64': activation_string(base64.encode(tampered_raw))
+	})
+	assert managed_baseline_projection_error(fixture.candidate_manifest_source, tampered) == 'managed baseline raw commit evidence SHA differs from its Git object ID'
+
+	wrong_sha := activation_first_source_evidence_with_replacements(fixture.source_commit_evidence, {
+		'sha': activation_string('9'.repeat(40))
+	})
+	assert managed_baseline_projection_error(fixture.candidate_manifest_source, wrong_sha) == 'managed baseline raw commit evidence SHA differs from its Git object ID'
+
+	wrong_tree := activation_first_source_evidence_with_replacements(fixture.source_commit_evidence, {
+		'tree': activation_string('9'.repeat(40))
+	})
+	assert managed_baseline_projection_error(fixture.candidate_manifest_source, wrong_tree) == 'managed baseline raw commit evidence tree differs from its declared tree'
+
+	malformed_raw := 'author Missing Tree <source@example.invalid> 0 +0000\n\nmalformed\n'.bytes()
+	malformed := activation_first_source_evidence_with_replacements(fixture.source_commit_evidence, {
+		'sha':               activation_string(activation_git_commit_oid(malformed_raw))
+		'raw_commit_base64': activation_string(base64.encode(malformed_raw))
+	})
+	assert managed_baseline_projection_error(fixture.candidate_manifest_source, malformed) == 'managed baseline raw commit evidence must start with one exact tree header'
+	reviewed_tree := (first.object_value('tree') or { panic('evidence tree missing') }).string_value
+	nonfirst_tree_raw :=
+		'author Wrong Order <source@example.invalid> 0 +0000\ntree ${reviewed_tree}\n\nmalformed\n'.bytes()
+	nonfirst_tree := activation_first_source_evidence_with_replacements(fixture.source_commit_evidence, {
+		'sha':               activation_string(activation_git_commit_oid(nonfirst_tree_raw))
+		'raw_commit_base64': activation_string(base64.encode(nonfirst_tree_raw))
+	})
+	assert managed_baseline_projection_error(fixture.candidate_manifest_source, nonfirst_tree) == 'managed baseline raw commit evidence must start with one exact tree header'
+	duplicate_tree_raw := 'tree ${reviewed_tree}\ntree ${reviewed_tree}\n\nmalformed\n'.bytes()
+	duplicate_tree_header := activation_first_source_evidence_with_replacements(fixture.source_commit_evidence, {
+		'sha':               activation_string(activation_git_commit_oid(duplicate_tree_raw))
+		'raw_commit_base64': activation_string(base64.encode(duplicate_tree_raw))
+	})
+	assert managed_baseline_projection_error(fixture.candidate_manifest_source,
+		duplicate_tree_header) == 'managed baseline raw commit evidence must start with one exact tree header'
+	carriage_return_raw := 'tree ${reviewed_tree}\r\n\nmalformed\n'.bytes()
+	carriage_return := activation_first_source_evidence_with_replacements(fixture.source_commit_evidence, {
+		'sha':               activation_string(activation_git_commit_oid(carriage_return_raw))
+		'raw_commit_base64': activation_string(base64.encode(carriage_return_raw))
+	})
+	assert managed_baseline_projection_error(fixture.candidate_manifest_source, carriage_return) == 'managed baseline raw commit evidence has a malformed Git commit header'
+	nul_header_raw := 'tree ${reviewed_tree}\x00\n\nmalformed\n'.bytes()
+	nul_header := activation_first_source_evidence_with_replacements(fixture.source_commit_evidence, {
+		'sha':               activation_string(activation_git_commit_oid(nul_header_raw))
+		'raw_commit_base64': activation_string(base64.encode(nul_header_raw))
+	})
+	assert managed_baseline_projection_error(fixture.candidate_manifest_source, nul_header) == 'managed baseline raw commit evidence has a malformed Git commit header'
+	no_separator_raw :=
+		'tree ${reviewed_tree}\nauthor Missing Separator <source@example.invalid> 0 +0000\n'.bytes()
+	no_separator := activation_first_source_evidence_with_replacements(fixture.source_commit_evidence, {
+		'sha':               activation_string(activation_git_commit_oid(no_separator_raw))
+		'raw_commit_base64': activation_string(base64.encode(no_separator_raw))
+	})
+	assert managed_baseline_projection_error(fixture.candidate_manifest_source, no_separator) == 'managed baseline raw commit evidence has no complete Git commit header'
+
+	noncanonical := activation_first_source_evidence_with_replacements(fixture.source_commit_evidence, {
+		'raw_commit_base64': activation_string('${raw_base64}=')
+	})
+	assert managed_baseline_projection_error(fixture.candidate_manifest_source, noncanonical) == 'managed baseline raw commit evidence is not canonical bounded base64'
+
+	duplicate := activation_array([first, first])
+	assert managed_baseline_projection_error(fixture.candidate_manifest_source, duplicate) == 'managed baseline source commit evidence contains a duplicate source ID'
+	manifest := bin.parse_strict_json(fixture.candidate_manifest_source) or { panic(err) }
+	sources_value := manifest.object_value('sources') or { panic('sources missing') }
+	mut duplicate_sources := sources_value.array_value.clone()
+	duplicate_sources[1] = activation_object_with_replacements(duplicate_sources[1], {
+		'id': activation_string('tinycc')
+	})
+	duplicate_source_manifest := bin.canonical_json(activation_object_with_replacements(manifest, {
+		'sources': activation_array(duplicate_sources)
+	}))
+	assert managed_baseline_projection_error(duplicate_source_manifest,
+		fixture.source_commit_evidence) == 'managed baseline source matrix contains a duplicate source ID'
+	mut open_entry_keys := first.object_keys.clone()
+	mut open_entry_values := first.object_values.clone()
+	open_entry_keys << 'unexpected'
+	open_entry_values << bin.JsonValue{
+		kind:       .boolean
+		bool_value: true
+	}
+	open_entry := bin.JsonValue{
+		kind:          .object
+		object_keys:   open_entry_keys
+		object_values: open_entry_values
+	}
+	open_evidence := activation_array([open_entry, fixture.source_commit_evidence.array_value[1]])
+	assert managed_baseline_projection_error(fixture.candidate_manifest_source, open_evidence) == 'closed contract object has missing, duplicate, or unknown members'
+	permuted := activation_array([fixture.source_commit_evidence.array_value[1], first])
+	assert managed_baseline_projection_error(fixture.candidate_manifest_source, permuted) == 'managed baseline source commit evidence order differs from the source matrix'
+	unsupported_id := activation_first_source_evidence_with_replacements(fixture.source_commit_evidence, {
+		'id': activation_string('unreviewed')
+	})
+	assert managed_baseline_projection_error(fixture.candidate_manifest_source, unsupported_id) == 'managed baseline external commit authority has an unsupported source ID'
+	unreferenced_id := activation_first_source_evidence_with_replacements(fixture.source_commit_evidence, {
+		'id': activation_string('libatomic_ops')
+	})
+	assert managed_baseline_projection_error(fixture.candidate_manifest_source, unreferenced_id) == 'managed baseline source commit evidence contains an unreferenced source ID'
+	mismatched_repository := activation_first_source_evidence_with_replacements(fixture.source_commit_evidence, {
+		'repository': activation_string('https://example.invalid/tinycc.git')
+	})
+	assert managed_baseline_projection_error(fixture.candidate_manifest_source,
+		mismatched_repository) == 'managed baseline source commit evidence changed source repository or ref'
+	mismatched_ref := activation_first_source_evidence_with_replacements(fixture.source_commit_evidence, {
+		'ref': activation_string('unreviewed')
+	})
+	assert managed_baseline_projection_error(fixture.candidate_manifest_source, mismatched_ref) == 'managed baseline source commit evidence changed source repository or ref'
+	unsupported_authority := activation_first_source_evidence_with_replacements(fixture.source_commit_evidence, {
+		'authority': activation_string('unreviewed')
+	})
+	assert managed_baseline_projection_error(fixture.candidate_manifest_source,
+		unsupported_authority) == 'managed baseline source commit evidence authority is unsupported'
+	missing := activation_array([first])
+	assert managed_baseline_projection_error(fixture.candidate_manifest_source, missing) == 'managed baseline source commit evidence must be bijective with the source matrix'
+	oversize := activation_first_source_evidence_with_replacements(fixture.source_commit_evidence, {
+		'raw_commit_base64': activation_string('A'.repeat(87_385))
+	})
+	assert managed_baseline_projection_error(fixture.candidate_manifest_source, oversize) == 'managed baseline raw commit evidence exceeds its encoded byte bound'
+	decoded_oversize_raw := []u8{len: 65_537, init: `x`}
+	decoded_oversize := activation_first_source_evidence_with_replacements(fixture.source_commit_evidence, {
+		'raw_commit_base64': activation_string(base64.encode(decoded_oversize_raw))
+	})
+	assert base64.encode(decoded_oversize_raw).len == 87_384
+	assert managed_baseline_projection_error(fixture.candidate_manifest_source, decoded_oversize) == 'managed baseline raw commit evidence is not canonical bounded base64'
+}
+
+fn test_managed_baseline_activation_rejects_publication_before_candidate_input() {
+	fixture := prepare_managed_baseline_activation_fixture('publication-disabled')
+	defer {
+		os.rmdir_all(fixture.base) or {}
+	}
+	work_root := os.join_path(fixture.base, 'publication-work-must-remain-absent')
+	mut message := ''
+	bin.evaluate_candidate_manifest_for_execution(fixture.automation_root, 'linux-amd64',
+		.baseline_activate, '/absent/candidate-repository', fixture.base_sha, '9'.repeat(40),
+		work_root, fixture.runtime, true) or { message = err.msg() }
+	assert message == 'managed baseline activation publication is disabled pending native publication proof'
+	assert !os.exists(work_root)
+}
+
+fn test_managed_baseline_activation_rejects_valid_evidence_outside_the_registry_hash() {
+	fixture := prepare_managed_baseline_activation_fixture('evidence-registry-hash')
+	defer {
+		os.rmdir_all(fixture.base) or {}
+	}
+	first := fixture.source_commit_evidence.array_value[0]
+	tree := (first.object_value('tree') or { panic('evidence tree missing') }).string_value
+	raw :=
+		'tree ${tree}\nauthor Alternate Source <source@example.invalid> 1 +0000\ncommitter Alternate Source <source@example.invalid> 1 +0000\n\nalternate reviewed source\n'.bytes()
+	mutated_evidence := activation_first_source_evidence_with_replacements(fixture.source_commit_evidence, {
+		'sha':               activation_string(activation_git_commit_oid(raw))
+		'raw_commit_base64': activation_string(base64.encode(raw))
+	})
+	manifest := bin.parse_strict_json(fixture.candidate_manifest_source) or { panic(err) }
+	mutated_policy := bin.managed_baseline_activation_policy_projection(manifest, mutated_evidence) or {
+		panic(err)
+	}
+	os.write_file(fixture.policy_path, bin.canonical_json(mutated_policy)) or { panic(err) }
+	message := candidate_composition_error_at(fixture.automation_root, bin.CandidateCompositionRequest{
+		target_id:      fixture.target_id
+		kind:           .baseline_activate
+		base_repo_root: fixture.base_repo_root
+		base_sha:       fixture.base_sha
+		raw_root:       fixture.raw_root
+		manifest_path:  fixture.manifest_path
+		result_root:    fixture.result_root
+	}, fixture.runtime)
+	assert message == 'managed baseline activation policy hash differs from the registry'
+	assert !os.exists(fixture.result_root)
+	assert_no_candidate_composition_scratch(fixture.base)
+}
+
+fn test_managed_baseline_activation_preflight_rejects_cross_source_provenance_sha_without_exposure() {
+	fixture := prepare_managed_baseline_activation_fixture('cross-source-provenance-sha')
+	defer {
+		os.rmdir_all(fixture.base) or {}
+	}
+	malicious_source := activation_manifest_with_first_inventory_provenance(fixture.candidate_manifest_source,
+		'TinyCC/tinycc', activation_source_sha(fixture.candidate_manifest_source, 'bdwgc'))
+	os.write_file(os.join_path(fixture.base_repo_root, 'automation', 'bundle-manifest.json'),
+		malicious_source) or { panic(err) }
+	candidate_sha := commit_candidate_paths(fixture.base_repo_root, [
+		'automation/bundle-manifest.json',
+	], 'attempt cross-source managed baseline provenance')
+	work_root := os.join_path(fixture.base, 'cross-source-provenance-preflight')
+	mut message := ''
+	bin.evaluate_candidate_manifest_for_execution(fixture.automation_root, 'linux-amd64',
+		.baseline_activate, fixture.base_repo_root, fixture.base_sha, candidate_sha, work_root,
+		fixture.runtime, false) or { message = err.msg() }
+	assert message == 'managed baseline activation payload provenance SHA differs from its authenticated authority'
+	assert !os.exists(work_root)
+}
+
+fn test_managed_baseline_activation_rejects_unreviewed_payload_provenance_repository() {
+	fixture := prepare_managed_baseline_activation_fixture('unreviewed-provenance-repository')
+	defer {
+		os.rmdir_all(fixture.base) or {}
+	}
+	malicious_source := activation_manifest_with_first_inventory_provenance(fixture.candidate_manifest_source,
+		'example/unreviewed', '9'.repeat(40))
+	replace_managed_baseline_activation_policy(fixture, malicious_source)
+	os.write_file(fixture.manifest_path, malicious_source) or { panic(err) }
+	message := candidate_composition_error_at(fixture.automation_root, bin.CandidateCompositionRequest{
+		target_id:      'linux-amd64'
+		kind:           .baseline_activate
+		base_repo_root: fixture.base_repo_root
+		base_sha:       fixture.base_sha
+		raw_root:       fixture.raw_root
+		manifest_path:  fixture.manifest_path
+		result_root:    fixture.result_root
+	}, fixture.runtime)
+	assert message == 'managed baseline activation payload provenance repository is not an authenticated authority'
+	assert !os.exists(fixture.result_root)
+	assert_no_candidate_composition_scratch(fixture.base)
+}
+
+fn assert_managed_baseline_activation_rejects_absent_payload_provenance_source(suffix string,
+	repository string, sha string) {
+	fixture := prepare_managed_baseline_activation_fixture(suffix)
+	defer {
+		os.rmdir_all(fixture.base) or {}
+	}
+	malicious_source := activation_manifest_with_first_inventory_provenance(fixture.candidate_manifest_source,
+		repository, sha)
+	replace_managed_baseline_activation_policy(fixture, malicious_source)
+	os.write_file(fixture.manifest_path, malicious_source) or { panic(err) }
+	message := candidate_composition_error_at(fixture.automation_root, bin.CandidateCompositionRequest{
+		target_id:      'linux-amd64'
+		kind:           .baseline_activate
+		base_repo_root: fixture.base_repo_root
+		base_sha:       fixture.base_sha
+		raw_root:       fixture.raw_root
+		manifest_path:  fixture.manifest_path
+		result_root:    fixture.result_root
+	}, fixture.runtime)
+	assert message == 'managed baseline activation payload provenance authority is absent or ambiguous'
+	assert !os.exists(fixture.result_root)
+	assert_no_candidate_composition_scratch(fixture.base)
+}
+
+fn test_managed_baseline_activation_rejects_provenance_authority_absent_from_target_sources() {
+	assert_managed_baseline_activation_rejects_absent_payload_provenance_source('absent-libatomic-provenance',
+		'bdwgc/libatomic_ops', '1'.repeat(40))
+	assert_managed_baseline_activation_rejects_absent_payload_provenance_source('absent-v-libgc-provenance',
+		'vlang/v', 'a'.repeat(40))
+}
+
+fn assert_managed_baseline_activation_accepts_payload_provenance_authority(suffix string,
+	repository string) {
+	fixture := prepare_managed_baseline_activation_fixture(suffix)
+	defer {
+		os.rmdir_all(fixture.base) or {}
+	}
+	sha := match repository {
+		'ivmai/bdwgc' { activation_source_sha(fixture.candidate_manifest_source, 'bdwgc') }
+		'vlang/tccbin' { fixture.base_sha }
+		else { panic('unsupported positive provenance authority') }
+	}
+	candidate_source := activation_manifest_with_first_inventory_provenance(fixture.candidate_manifest_source,
+		repository, sha)
+	replace_managed_baseline_activation_policy(fixture, candidate_source)
+	os.write_file(fixture.manifest_path, candidate_source) or { panic(err) }
+	result := bin.compose_candidate_for_execution(fixture.automation_root, bin.CandidateCompositionRequest{
+		target_id:      'linux-amd64'
+		kind:           .baseline_activate
+		base_repo_root: fixture.base_repo_root
+		base_sha:       fixture.base_sha
+		raw_root:       fixture.raw_root
+		manifest_path:  fixture.manifest_path
+		result_root:    fixture.result_root
+	}, fixture.runtime) or { panic(err) }
+	assert result.decision.eligible
+	assert !result.decision.publish_allowed
+}
+
+fn test_managed_baseline_activation_accepts_exact_source_and_baseline_provenance_shas() {
+	assert_managed_baseline_activation_accepts_payload_provenance_authority('bdwgc-provenance',
+		'ivmai/bdwgc')
+	assert_managed_baseline_activation_accepts_payload_provenance_authority('baseline-provenance',
+		'vlang/tccbin')
+}
+
+fn test_managed_baseline_activation_preflight_rejects_any_non_manifest_tree_delta() {
+	fixture := prepare_managed_baseline_activation_fixture('tree-closure')
+	defer {
+		os.rmdir_all(fixture.base) or {}
+	}
+	os.write_file(os.join_path(fixture.base_repo_root, 'automation', 'bundle-manifest.json'),
+		fixture.candidate_manifest_source) or { panic(err) }
+	os.write_file(os.join_path(fixture.base_repo_root, 'README.md'), 'unreviewed tree delta\n') or {
+		panic(err)
+	}
+	candidate_sha := commit_candidate_paths(fixture.base_repo_root, [
+		'automation/bundle-manifest.json',
+		'README.md',
+	], 'attempt non-manifest activation delta')
+	work_root := os.join_path(fixture.base, 'managed-baseline-preflight-work')
+	mut message := ''
+	bin.evaluate_candidate_manifest_for_execution(fixture.automation_root, 'linux-amd64',
+		.baseline_activate, fixture.base_repo_root, fixture.base_sha, candidate_sha, work_root,
+		fixture.runtime, false) or { message = err.msg() }
+	assert message == 'managed baseline activation transition must modify only the authoritative manifest'
+	assert !os.exists(work_root)
 }
 
 fn test_candidate_preflight_exports_an_independent_payload_and_binds_publication() {

--- a/thirdparty/tccbin_automation/tests/receiver_protocol_test.v
+++ b/thirdparty/tccbin_automation/tests/receiver_protocol_test.v
@@ -1205,7 +1205,7 @@ fn prepare_live_multi_source_atomic_state(suffix string,
 	assert os.execute('git -C ${os.quoted_path(work_root)} commit --allow-empty -qm atomic-head-k2').exit_code == 0
 	head := os.execute('git -C ${os.quoted_path(work_root)} rev-parse HEAD').output.trim_space()
 	clone :=
-		os.execute('git clone -q --bare ${os.quoted_path(work_root)} ${os.quoted_path(bare_root)}')
+		os.execute('git clone -q --bare --no-local ${os.quoted_path(work_root)} ${os.quoted_path(bare_root)}')
 	assert clone.exit_code == 0, clone.output
 	proof := live_state_proof_set(os.real_path(bare_root), head, [target_commit])
 	freebsd_root := bin.parse_strict_json(freebsd_target) or { panic(err) }
@@ -1532,7 +1532,7 @@ fn prepare_live_source_atomic_state(suffix string,
 		head = os.execute('git -C ${os.quoted_path(work_root)} rev-parse HEAD').output.trim_space()
 	}
 	clone :=
-		os.execute('git clone -q --bare ${os.quoted_path(work_root)} ${os.quoted_path(bare_root)}')
+		os.execute('git clone -q --bare --no-local ${os.quoted_path(work_root)} ${os.quoted_path(bare_root)}')
 	assert clone.exit_code == 0, clone.output
 	proof := if options.non_first_parent_evidence_at_h {
 		live_state_proof(os.real_path(bare_root), head)
@@ -1622,7 +1622,8 @@ fn prepare_live_state_inventory(suffix string, target_source string, removed_rel
 	assert head.exit_code == 0
 	bare_root := '${root}.git'
 	os.rmdir_all(bare_root) or {}
-	clone := os.execute('git clone -q --bare ${os.quoted_path(root)} ${os.quoted_path(bare_root)}')
+	clone :=
+		os.execute('git clone -q --bare --no-local ${os.quoted_path(root)} ${os.quoted_path(bare_root)}')
 	assert clone.exit_code == 0, clone.output
 	os.rmdir_all(root) or {}
 	return os.real_path(bare_root), head.output.trim_space()
@@ -2586,7 +2587,7 @@ fn test_live_state_reader_fails_closed_on_corrupt_duplicate_symlink_or_wrong_che
 	assert os.execute('git -C ${os.quoted_path(work_root)} commit -qm symlink').exit_code == 0
 	symlink_head :=
 		os.execute('git -C ${os.quoted_path(work_root)} rev-parse HEAD').output.trim_space()
-	assert os.execute('git clone -q --bare ${os.quoted_path(work_root)} ${os.quoted_path(symlink_bare)}').exit_code == 0
+	assert os.execute('git clone -q --bare --no-local ${os.quoted_path(work_root)} ${os.quoted_path(symlink_bare)}').exit_code == 0
 	symlinked := bin.inspect_live_receiver_state(automation_root(), os.real_path(symlink_bare),
 		live_state_trust(), live_state_proof(os.real_path(symlink_bare), symlink_head),
 		live_handoff_id) or { panic(err) }

--- a/thirdparty/tccbin_automation/tests/schema_contract_test.v
+++ b/thirdparty/tccbin_automation/tests/schema_contract_test.v
@@ -360,6 +360,18 @@ fn registry_with_toolchain_profile(registry_source string, target_id string, pro
 		tail.replace_once(binding_marker, '"toolchain_profile": {\n        "profile_id": "${profile_id}",\n        "profile_path": "${profile_path}",\n        "profile_sha256": "${profile_sha256}"\n      }')
 }
 
+fn registry_with_managed_baseline_activation_policy(registry_source string, target_id string,
+	policy_path string, policy_sha256 string) string {
+	target_marker := '"id": "${target_id}"'
+	target_offset := registry_source.index(target_marker) or { panic('target marker missing') }
+	prefix := registry_source[..target_offset]
+	tail := registry_source[target_offset..]
+	binding_marker := '"policy_path": null,\n        "policy_sha256": null\n      },\n      "toolchain_profile"'
+	assert tail.count(binding_marker) > 0
+	return prefix +
+		tail.replace_once(binding_marker, '"policy_path": "${policy_path}",\n        "policy_sha256": "${policy_sha256}"\n      },\n      "toolchain_profile"')
+}
+
 fn test_all_schema_patterns_compile_and_contract_boundaries_are_discriminating() {
 	occurrences := schema_pattern_occurrences()
 	assert occurrences.len > 0
@@ -1566,6 +1578,10 @@ fn test_registry_rejects_every_semantic_tuple_drift() {
 			'"affected_targets": ["linux-amd64"]'),
 		source.replace_once('fdf5cdfea6ea84612e068bc3bea433dbba263404',
 			'ece46f06fbe6eb701d52442f11dd59c48d166cae'),
+		source.replace_once('"base_contract_sha": "7545e515b434cd399333d43659238427d72e22e7"',
+			'"base_contract_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"'),
+		source.replace_once('"parent_sha": "fdf5cdfea6ea84612e068bc3bea433dbba263404"',
+			'"parent_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"'),
 		source.replace_once('"path": "lib/openlibm.o"', '"path": "lib/other.o"'),
 		source.replace_once('"architectures": ["x64"]', '"architectures": ["i386"]'),
 	]
@@ -1574,6 +1590,87 @@ fn test_registry_rejects_every_semantic_tuple_drift() {
 		issues := bin.validate_registry_semantics(registry) or { panic(err) }
 		assert issues.len > 0
 	}
+}
+
+fn test_production_registry_locks_the_six_managed_baseline_activation_tuples() {
+	registry_source := os.read_file(os.join_path(automation_root(), 'targets.json')) or {
+		panic(err)
+	}
+	registry := bin.parse_strict_json(registry_source) or { panic(err) }
+	managed := registry.object_value('managed_ci_targets') or { panic('managed targets missing') }
+	expected := {
+		'freebsd-amd64': [
+			'e71cda6242e88e47312ca9bfc4548b0579636e0c',
+			'9438879ad9906e970d45bafacf6ce2cc63ae4c53',
+			'fdf5cdfea6ea84612e068bc3bea433dbba263404',
+			'a9c2f15451a7e94261c6dd4d9e47cc3965414a2179d04af5902dffc9471a4db3',
+		]
+		'linux-amd64':   [
+			'd6e7ac1b1bcc98aed734a6ecbfa8509f24606c74',
+			'22851c0f356fefcb63718ce63d50a870150a491c',
+			'ece46f06fbe6eb701d52442f11dd59c48d166cae',
+			'bcdce1bea1facb24175229a16dc6e8a2c4210aafc05f0526b2728dc060223ed4',
+		]
+		'macos-amd64':   [
+			'199fa78395ca413aac23d02ec69cc5e7b1d805a2',
+			'db67711bfeb33be63dbc8eb03ecdddc2e127cc8c',
+			'da8ac5a4369accc67c485191d02535d77718a1c8',
+			'09dc54928f4690cfee7fd113de93f36479a40cabd10eeb3ee416a3175b42270a',
+		]
+		'macos-arm64':   [
+			'1d0ad0ecf70a91a1df64cebf215e683b1d5aedb5',
+			'96af5121f065310ba9168e3e2dc61adf340e2738',
+			'274abd2466a14861b75e5b91fd946ad27d114499',
+			'be45aaee1e65cc1ed2ee6bd2f121d72cbc248887ffa3d57f4b6d59cb6ea73525',
+		]
+		'openbsd-amd64': [
+			'8c7d96c75ea8548f007432d70f1ae33cccd81838',
+			'f75c4862711184c4c191a73e6f996eb421bd37b4',
+			'45230fde96c17fff4baf37deb55e90803c043063',
+			'873b62af697ba25f0abe5887ba05972a93bd48990233853b362bed6cb9137699',
+		]
+		'windows-amd64': [
+			'86ae5844b8b56071b21ae3aa138b247d5eb9ddd9',
+			'818d7794ebdf41de60e5679d485e3a5d49272171',
+			'f7c7199bb87fda8b80b31fefa470b2efc952326b',
+			'b5728124ecf8dc01e4f16cf4188411d6f633bb57997ef36df2dc5fd182e8535a',
+		]
+	}
+	mut observed := map[string][]string{}
+	for target in managed.array_value {
+		id := (target.object_value('id') or { panic('target id missing') }).string_value
+		activation := target.object_value('managed_baseline_activation') or {
+			panic('managed baseline activation binding missing')
+		}
+		observed[id] = [
+			(activation.object_value('base_sha') or { panic('base SHA missing') }).string_value,
+			(activation.object_value('base_tree') or { panic('base tree missing') }).string_value,
+			(activation.object_value('parent_sha') or { panic('parent SHA missing') }).string_value,
+			(activation.object_value('base_manifest_sha256') or {
+				panic('base manifest SHA-256 missing')
+			}).string_value,
+		]
+		assert (activation.object_value('base_contract_repository') or {
+			panic('base contract repository missing')
+		}).string_value == 'vlang/v'
+		assert (activation.object_value('base_contract_sha') or {
+			panic('base contract SHA missing')
+		}).string_value == '7545e515b434cd399333d43659238427d72e22e7'
+		assert (activation.object_value('policy_path') or {
+			panic('activation policy path missing')
+		}).kind == .null_value
+		assert (activation.object_value('policy_sha256') or {
+			panic('activation policy hash missing')
+		}).kind == .null_value
+	}
+	assert observed == expected
+
+	half_pair := registry_source.replace_once('"policy_path": null,\n        "policy_sha256": null\n      },\n      "toolchain_profile"',
+		'"policy_path": "baseline-activation/freebsd-amd64.policy.json",\n        "policy_sha256": null\n      },\n      "toolchain_profile"')
+	half_pair_issues := validate_schema_source('targets.schema.json', half_pair,
+		'managed-baseline-activation-half-pair')
+	assert half_pair_issues.len == 1, '${half_pair_issues}'
+	assert half_pair_issues[0].path == '$/managed_ci_targets/0/managed_baseline_activation/policy_sha256'
 }
 
 fn test_production_registry_locks_the_six_reviewed_legacy_base_literals() {
@@ -1886,6 +1983,87 @@ fn test_legacy_onboarding_registry_is_dormant_until_one_canonical_policy_is_revi
 	assert noncanonical_issues[0].message == 'legacy onboarding policy bytes must be exact canonical JSON'
 }
 
+fn test_managed_baseline_activation_policy_loader_is_dormant_and_closed() {
+	root := automation_root()
+	temporary := os.join_path(os.temp_dir(), 'tccbin-baseline-activation-policy-${os.getpid()}')
+	os.rmdir_all(temporary) or {}
+	os.mkdir_all(temporary) or { panic(err) }
+	defer {
+		os.rmdir_all(temporary) or {}
+	}
+	os.cp_all(os.join_path(root, 'schemas'), os.join_path(temporary, 'schemas'), true) or {
+		panic(err)
+	}
+	registry_source := os.read_file(os.join_path(root, 'targets.json')) or { panic(err) }
+	evidence_fixture := managed_baseline_evidence_fixture(schema_fixture_with_resolved_producer('manifest-complete.valid.json',
+		'linux-amd64'))
+	manifest := bin.parse_strict_json(evidence_fixture.manifest_source) or { panic(err) }
+	policy := bin.managed_baseline_activation_policy_projection(manifest, evidence_fixture.evidence) or {
+		panic(err)
+	}
+	policy_source := bin.canonical_json(policy)
+	policy_hash := bin.json_sha256(policy)
+	policy_relative_path := 'baseline-activation/linux-amd64.policy.json'
+	policy_path := os.join_path(temporary, policy_relative_path)
+	os.mkdir_all(os.dir(policy_path)) or { panic(err) }
+	os.write_file(policy_path, policy_source) or { panic(err) }
+
+	profile_source := t2a_profile_source('linux-amd64')
+	profile := bin.parse_strict_json(profile_source) or { panic(err) }
+	profile_sha256 := bin.json_sha256(profile)
+	profile_relative_path := 'toolchain-profiles/linux-amd64.profile.json'
+	profile_path := os.join_path(temporary, profile_relative_path)
+	os.mkdir_all(os.dir(profile_path)) or { panic(err) }
+	os.write_file(profile_path, profile_source) or { panic(err) }
+	with_profile := registry_with_toolchain_profile(registry_source, 'linux-amd64',
+		'linux-amd64-synthetic-v1', profile_relative_path, profile_sha256)
+	resolved_registry := registry_with_managed_baseline_activation_policy(with_profile,
+		'linux-amd64', policy_relative_path, policy_hash)
+	os.write_file(os.join_path(temporary, 'targets.json'), resolved_registry) or { panic(err) }
+	issues := bin.validate_registry(temporary) or { panic(err) }
+	assert issues.len == 0, '${issues}'
+	mut missing_evidence_keys := policy.object_keys.clone()
+	mut missing_evidence_values := policy.object_values.clone()
+	evidence_index := missing_evidence_keys.index('source_commit_evidence')
+	assert evidence_index >= 0
+	missing_evidence_keys.delete(evidence_index)
+	missing_evidence_values.delete(evidence_index)
+	missing_evidence_policy := bin.JsonValue{
+		kind:          .object
+		object_keys:   missing_evidence_keys
+		object_values: missing_evidence_values
+	}
+	missing_evidence_issues := validate_schema_source('onboarding-policy.schema.json',
+		bin.canonical_json(missing_evidence_policy), 'baseline-activation-v2-missing-evidence')
+	assert missing_evidence_issues.len > 0
+	mut legacy_with_evidence_values := policy.object_values.clone()
+	legacy_with_evidence_values[0] = bin.JsonValue{
+		kind:      .integer
+		int_value: 1
+	}
+	legacy_with_evidence_policy := bin.JsonValue{
+		kind:          .object
+		object_keys:   policy.object_keys.clone()
+		object_values: legacy_with_evidence_values
+	}
+	legacy_with_evidence_issues := validate_schema_source('onboarding-policy.schema.json',
+		bin.canonical_json(legacy_with_evidence_policy), 'legacy-v1-with-source-evidence')
+	assert legacy_with_evidence_issues.len > 0
+
+	wrong_path_registry := resolved_registry.replace_once(policy_relative_path,
+		'baseline-activation/freebsd-amd64.policy.json')
+	os.write_file(os.join_path(temporary, 'targets.json'), wrong_path_registry) or { panic(err) }
+	wrong_path_issues := bin.validate_registry(temporary) or { panic(err) }
+	assert wrong_path_issues.len == 1, '${wrong_path_issues}'
+	assert wrong_path_issues[0].message == 'managed target baseline activation policy path is not exact'
+
+	os.write_file(policy_path, '${policy_source}\n') or { panic(err) }
+	os.write_file(os.join_path(temporary, 'targets.json'), resolved_registry) or { panic(err) }
+	noncanonical_issues := bin.validate_registry(temporary) or { panic(err) }
+	assert noncanonical_issues.len == 1, '${noncanonical_issues}'
+	assert noncanonical_issues[0].message == 'managed baseline activation policy bytes must be exact canonical JSON'
+}
+
 fn test_legacy_onboarding_policy_projection_excludes_only_dynamic_identity_and_bytes() {
 	source := schema_fixture_with_resolved_producer('manifest-complete.valid.json', 'linux-amd64')
 	manifest := bin.parse_strict_json(source) or { panic(err) }
@@ -1972,9 +2150,10 @@ fn test_legacy_onboarding_policy_projection_excludes_only_dynamic_identity_and_b
 fn test_candidate_compose_cli_has_an_explicit_mode_and_no_stdout_result_protocol() {
 	assert bin.parse_candidate_transition_kind('monthly') or { panic(err) } == .monthly
 	assert bin.parse_candidate_transition_kind('legacy-onboard') or { panic(err) } == .legacy_onboard
+	assert bin.parse_candidate_transition_kind('baseline-activate') or { panic(err) } == .baseline_activate
 	mut rejected := ''
 	bin.parse_candidate_transition_kind('legacy') or { rejected = err.msg() }
-	assert rejected == 'candidate transition kind must be monthly or legacy-onboard'
+	assert rejected == 'candidate transition kind must be monthly, legacy-onboard, or baseline-activate'
 	source := os.read_file(os.join_path(automation_root(), 'bin', 'cmd', 'main.v')) or {
 		panic(err)
 	}
@@ -1984,10 +2163,10 @@ fn test_candidate_compose_cli_has_an_explicit_mode_and_no_stdout_result_protocol
 	}
 	block := source[start..start + finish_relative]
 	assert block.contains('if os.args.len != 9')
-	assert block.contains('<target-id> <monthly|legacy-onboard>')
+	assert block.contains('<target-id> <monthly|legacy-onboard|baseline-activate>')
 	assert block.count('bin.compose_candidate_for_execution(') == 1
 	assert block.split_into_lines().all(!it.trim_space().starts_with('print'))
-	assert source.contains('candidate-preflight <target-id> <monthly|legacy-onboard>')
+	assert source.contains('candidate-preflight <target-id> <monthly|legacy-onboard|baseline-activate>')
 	composition_source := os.read_file(os.join_path(automation_root(), 'bin',
 		'candidate_composition.v')) or { panic(err) }
 	assert composition_source.count("['hash-object', '-w', '--no-filters', '--',") == 2

--- a/thirdparty/tccbin_automation/tests/toolchain_manifest_test_support.v
+++ b/thirdparty/tccbin_automation/tests/toolchain_manifest_test_support.v
@@ -1,8 +1,151 @@
 module tests
 
 import crypto.sha256
+import encoding.base64
 import os
 import tccbin_automation.bin
+
+struct ManagedBaselineEvidenceFixture {
+	manifest_source string
+	evidence        bin.JsonValue
+}
+
+fn managed_baseline_string(value string) bin.JsonValue {
+	return bin.JsonValue{
+		kind:         .string_value
+		string_value: value
+	}
+}
+
+fn managed_baseline_replace_member(value bin.JsonValue, key string,
+	replacement bin.JsonValue) bin.JsonValue {
+	mut values := value.object_values.clone()
+	index := value.object_keys.index(key)
+	assert index >= 0, key
+	values[index] = replacement
+	return bin.JsonValue{
+		kind:          .object
+		object_keys:   value.object_keys.clone()
+		object_values: values
+	}
+}
+
+fn managed_baseline_resolve_manifest_source(source string, source_id string, sha string,
+	tree string) string {
+	root := bin.parse_strict_json(source) or { panic(err) }
+	sources_value := root.object_value('sources') or { panic('sources missing') }
+	mut sources := sources_value.array_value.clone()
+	mut old_sha := ''
+	mut found := false
+	for index, candidate_source in sources {
+		id := candidate_source.object_value('id') or { panic('source ID missing') }
+		if id.string_value == source_id {
+			old_sha = (candidate_source.object_value('sha') or { panic('source SHA missing') }).string_value
+			sources[index] = managed_baseline_replace_member(managed_baseline_replace_member(candidate_source,
+				'sha', managed_baseline_string(sha)), 'tree', managed_baseline_string(tree))
+			found = true
+		}
+	}
+	assert found
+	mut updated := managed_baseline_replace_member(root, 'sources', bin.JsonValue{
+		kind:        .array
+		array_value: sources
+	})
+	for collection in ['overlays', 'inventory', 'outputs'] {
+		collection_value := updated.object_value(collection) or { panic('${collection} missing') }
+		mut entries := collection_value.array_value.clone()
+		for index, entry in entries {
+			provenance := entry.object_value('provenance') or { panic('provenance missing') }
+			provenance_sha := provenance.object_value('sha') or { panic('provenance SHA missing') }
+			if provenance_sha.kind == .string_value && provenance_sha.string_value == old_sha {
+				entries[index] = managed_baseline_replace_member(entry, 'provenance', managed_baseline_replace_member(provenance,
+					'sha', managed_baseline_string(sha)))
+			}
+		}
+		updated = managed_baseline_replace_member(updated, collection, bin.JsonValue{
+			kind:        .array
+			array_value: entries
+		})
+	}
+	return bin.canonical_json(updated)
+}
+
+fn managed_baseline_evidence_fixture(manifest_source string) ManagedBaselineEvidenceFixture {
+	manifest := bin.parse_strict_json(manifest_source) or { panic(err) }
+	sources := (manifest.object_value('sources') or { panic('sources missing') }).array_value
+	evidence_root := os.join_path(os.temp_dir(), 'tccbin-reviewed-source-evidence-${os.getpid()}')
+	os.rmdir_all(evidence_root) or {}
+	os.mkdir_all(evidence_root) or { panic(err) }
+	defer {
+		os.rmdir_all(evidence_root) or {}
+	}
+	mut resolved_source := bin.canonical_json(manifest)
+	mut entries := []bin.JsonValue{cap: sources.len}
+	for source in sources {
+		id := (source.object_value('id') or { panic('source ID missing') }).string_value
+		repository := source.object_value('repository') or { panic('source repository missing') }
+		reference := source.object_value('ref') or { panic('source ref missing') }
+		if id == 'v-libgc' {
+			entries << bin.JsonValue{
+				kind:          .object
+				object_keys:   ['id', 'repository', 'ref', 'authority']
+				object_values: [source.object_value('id') or { panic('source ID missing') },
+					repository, reference, bin.JsonValue{
+						kind:         .string_value
+						string_value: 'runtime-contract'
+					}]
+			}
+			continue
+		}
+		source_root := os.join_path(evidence_root, id)
+		os.mkdir_all(source_root) or { panic(err) }
+		os.write_file(os.join_path(source_root, 'reviewed-source.txt'), '${id}\n') or { panic(err) }
+		for args in [
+			['git', '-C', source_root, 'init', '-q', '--object-format=sha1'],
+			['git', '-C', source_root, 'config', 'user.email', 'source@example.invalid'],
+			['git', '-C', source_root, 'config', 'user.name', 'Reviewed Source'],
+			['git', '-C', source_root, 'add', '--all'],
+			['git', '-C', source_root, '-c', 'commit.gpgsign=false', 'commit', '-qm',
+				'reviewed ${id} source'],
+		] {
+			result := os.exec(args)
+			assert result.exit_code == 0, result.output
+		}
+		sha_result := os.exec(['git', '-C', source_root, 'rev-parse', 'HEAD'])
+		tree_result := os.exec(['git', '-C', source_root, 'rev-parse', 'HEAD^{tree}'])
+		assert sha_result.exit_code == 0, sha_result.output
+		assert tree_result.exit_code == 0, tree_result.output
+		sha := sha_result.output.trim_space()
+		tree := tree_result.output.trim_space()
+		raw_result := os.exec(['git', '-C', source_root, 'cat-file', 'commit', sha])
+		assert raw_result.exit_code == 0, raw_result.output
+		raw := raw_result.output.bytes()
+		resolved_source = managed_baseline_resolve_manifest_source(resolved_source, id, sha, tree)
+		entries << bin.JsonValue{
+			kind:          .object
+			object_keys:   ['id', 'repository', 'ref', 'authority', 'sha', 'tree',
+				'raw_commit_base64']
+			object_values: [source.object_value('id') or { panic('source ID missing') },
+				repository, reference, bin.JsonValue{
+					kind:         .string_value
+					string_value: 'source-commit-object'
+				}, bin.JsonValue{
+					kind:         .string_value
+					string_value: sha
+				}, managed_baseline_string(tree), bin.JsonValue{
+					kind:         .string_value
+					string_value: base64.encode(raw)
+				}]
+		}
+	}
+	return ManagedBaselineEvidenceFixture{
+		manifest_source: resolved_source
+		evidence:        bin.JsonValue{
+			kind:        .array
+			array_value: entries
+		}
+	}
+}
 
 struct SyntheticToolchainAuthority {
 	root            string


### PR DESCRIPTION
## Summary

This follow-up records the exact six managed tccbin Phase A baselines merged in `vlang/tccbin` and adds a dedicated `baseline-activate` transition.

The registry now pins each baseline commit, tree, sole parent, manifest hash, and immutable V contract binding. The new transition attests that exact base, requires a manifest-only direct child, verifies that deferred RAW outputs reproduce the reviewed payload byte-for-byte, and accepts only complete provenance under a separately reviewed activation policy.

## Why

The six merged baselines already contain incomplete manifests, so they cannot use `legacy-onboard`, which requires a manifest-free base. They also cannot use `monthly`, which requires an already resolved and unchanged toolchain profile.

A separate one-time transition keeps both existing modes strict while providing a closed path for future activation.

## Safety

The transition is intentionally dormant, all six activation policy bindings and toolchain profiles remain null, so both compose and preflight stop before reading candidate input.

This change does not add producer wiring, state, secrets, unlocks, or publication capability. Future policies, authenticated toolchains, complete provenance, producer integration, and native evidence remain separate reviewed follow-ups.