### PR TITLE
v3: support .vv source inputs

### DIFF
--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -6372,7 +6372,7 @@ fn v3_profile_optional_arg_value(args []string, idx int, command_seen bool) (str
 		return '-', false
 	}
 	if !command_seen && (next in ['run', 'build', 'test', 'doc'] || next.ends_with('.v')
-		|| next.ends_with('.vsh') || os.is_dir(next)
+		|| next.ends_with('.vv') || next.ends_with('.vsh') || os.is_dir(next)
 		|| !v3_has_following_positional_arg(args, idx + 2)) {
 		return '-', false
 	}

--- a/vlib/v3/driver/implicit_import_test.v
+++ b/vlib/v3/driver/implicit_import_test.v
@@ -10,6 +10,14 @@ fn test_default_bin_file_strips_backend_source_extension() {
 	assert default_bin_file_for_input('foo.js.v') == 'foo'
 	assert default_bin_file_for_input('foo.wasm.v') == 'foo'
 	assert default_bin_file_for_input('foo.v') == 'foo'
+	assert default_bin_file_for_input('foo.vv') == 'foo'
+}
+
+fn test_profile_optional_arg_recognizes_vv_source() {
+	value, consumed := v3_profile_optional_arg_value(['-profile', 'fixture.vv', '-o', 'out'], 0,
+		false)
+	assert value == '-'
+	assert !consumed
 }
 
 fn test_default_bin_file_uses_safe_hidden_source_name() {

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -305,7 +305,7 @@ pub fn (mut p Parser) parse_into(path string) {
 	if !p.prefs.supports_inline_asm {
 		p.precollect_unsupported_inline_asm_guards(stable_src, p.prefs.target.arch)
 	}
-	if path.ends_with('.v') {
+	if path.ends_with('.v') || path.ends_with('.vv') {
 		p.parsed_v_files++
 		p.parsed_v_file_paths << path
 	} else if path.ends_with('.vh') {

--- a/vlib/v3/tests/parser_regression_test.v
+++ b/vlib/v3/tests/parser_regression_test.v
@@ -44,6 +44,18 @@ fn parse_parser_regression_backend_diagnostics(name string, source string, backe
 	return p.diagnostics
 }
 
+fn test_vv_input_is_counted_as_v_source() {
+	path := os.join_path(os.temp_dir(), 'v3_parser_source_count_${os.getpid()}.vv')
+	os.write_file(path, 'fn main() {}\n') or { panic(err) }
+	defer {
+		os.rm(path) or {}
+	}
+	mut p := parser.Parser.new(pref.new_preferences())
+	p.parse_into(path)
+	assert p.parsed_v_files == 1
+	assert p.parsed_v_file_paths == [path]
+}
+
 // interface_method_param_types supports interface method param types handling for v3 tests.
 fn interface_method_param_types(a &flat.FlatAst, iface string, method string) []string {
 	for node in a.nodes {

--- a/vlib/v3/tests/type_checker_errors_test.v
+++ b/vlib/v3/tests/type_checker_errors_test.v
@@ -584,6 +584,23 @@ fn test_type_checker_reports_core_semantic_errors() {
 	}, 'main.v', 'cannot append `[]modb.Foo` to `[]moda.Foo`')
 }
 
+fn test_vv_input_with_comma_in_decl_assign_is_rejected_without_overwrite() {
+	v3_bin := build_v3()
+	source_path := unique_temp_path('comma_in_decl_assign') + '.vv'
+	default_output := source_path.all_before_last('.vv')
+	source := 'fn main() {\n\ta := [1, 2, 3]\n\tmut b := a.clone(), a.clone()\n\tprintln(b)\n}\n'
+	os.write_file(source_path, source) or { panic(err) }
+	defer {
+		os.rm(source_path) or {}
+		os.rm(default_output) or {}
+	}
+	result := os.execute('${v3_bin} -nocache ${source_path}')
+	assert result.exit_code != 0, 'expected compile failure, got success: ${result.output}'
+	assert result.output.contains('unexpected `,` in expression, use `;` or a new line to separate statements'), result.output
+
+	assert (os.read_file(source_path) or { panic(err) }) == source
+}
+
 fn test_interface_container_as_cast_requirements() {
 	v3_bin := build_v3()
 	run_bad(v3_bin, 'bad_nonempty_interface_as_array_pattern',

--- a/vlib/v3/types/checker_comptime.v
+++ b/vlib/v3/types/checker_comptime.v
@@ -13406,6 +13406,15 @@ fn (mut tc TypeChecker) check_multi_value_list_decl_assign(id flat.NodeId, node 
 	if lhs_ids.len == 0 || rhs_count <= 1 {
 		return false
 	}
+	if lhs_ids.len == 1 {
+		first_rhs_id := tc.multi_assign_rhs_id(node, 0)
+		tc.check_node(first_rhs_id)
+		unexpected_rhs_id := tc.multi_assign_rhs_id(node, 1)
+		tc.record_error(.assignment_mismatch,
+			'unexpected `,` in expression, use `;` or a new line to separate statements',
+			unexpected_rhs_id)
+		return true
+	}
 	mut rhs_ids := []flat.NodeId{cap: rhs_count}
 	mut multi_ids := []flat.NodeId{}
 	mut multi_types := []MultiReturn{}


### PR DESCRIPTION
## Summary

- treat `.vv` files as V sources in V3 parser metrics and `-profile` argument handling
- report a clear comma diagnostic for single-name declarations with multiple RHS expressions
- add regressions ensuring direct `.vv` compilation does not overwrite the source file

Follow-up to #28145.

## Testing

- `./vnew -old-compiler -silent vlib/v3/driver/implicit_import_test.v`
- `./vnew -old-compiler -silent -run-only test_vv_input_is_counted_as_v_source vlib/v3/tests/parser_regression_test.v`
- `./vnew -old-compiler -silent -run-only test_vv_input_with_comma_in_decl_assign_is_rejected_without_overwrite vlib/v3/tests/type_checker_errors_test.v`
- `./vnew -old-compiler -silent test vlib/v3/parser/`
- `./vnew -old-compiler -silent test vlib/v3/types/`
- `./vnew -old-compiler -silent test vlib/v3/driver/`