### PR TITLE
v3: clean up transform helpers/inits; cmd/v: fix v3.v bootstrap dispatch on macOS

### DIFF
--- a/cmd/v/macos_v3_args.c.v
+++ b/cmd/v/macos_v3_args.c.v
@@ -19,6 +19,27 @@ fn macos_v3_non_compilation_command(command string) bool {
 		'interpret', 'get', 'translate']
 }
 
+// is_macos_v3_compiler_bootstrap reports whether `normalized_path` targets the
+// `vlib/v3/v3.v` compiler bootstrap, which must build with the compatibility
+// compiler rather than the embedded V3 driver. It matches the repo-relative path
+// and any path ending in it, and also resolves a bare `v3.v` (for example when
+// invoked from inside `vlib/v3`) through its real path, so the bootstrap is
+// recognized regardless of the working directory. Both dispatch gates rely on
+// it, so keep the detection in one place to stop them drifting.
+@[markused]
+fn is_macos_v3_compiler_bootstrap(normalized_path string) bool {
+	if normalized_path == 'vlib/v3/v3.v' || normalized_path.ends_with('/vlib/v3/v3.v') {
+		return true
+	}
+	// Only a file literally named `v3.v` can be the bootstrap; skip the real-path
+	// resolution (a filesystem lookup) for every other compilation target.
+	if os.base(normalized_path) != 'v3.v' {
+		return false
+	}
+	real_path := os.real_path(normalized_path).replace('\\', '/').trim_right('/')
+	return real_path == 'vlib/v3/v3.v' || real_path.ends_with('/vlib/v3/v3.v')
+}
+
 // macos_v3_force_requested reports whether `-new-compiler` should hand this
 // invocation to the embedded V3 compiler. It gates on `-old-compiler`
 // precedence, options/modes V3 cannot honor yet, and whether the command is an
@@ -44,7 +65,7 @@ fn macos_v3_force_requested(command string, prefs &pref.Preferences) bool {
 	normalized_path := prefs.path.replace('\\', '/').trim_right('/')
 	if normalized_path == 'cmd/v' || normalized_path.starts_with('cmd/v/')
 		|| normalized_path.contains('/cmd/v/') || normalized_path.ends_with('/cmd/v')
-		|| normalized_path == 'vlib/v3/v3.v' || normalized_path.ends_with('/vlib/v3/v3.v') {
+		|| is_macos_v3_compiler_bootstrap(normalized_path) {
 		return false
 	}
 	return command in ['run', 'build'] || prefs.is_script || os.is_dir(prefs.path)

--- a/cmd/v/macos_v3_darwin.c.v
+++ b/cmd/v/macos_v3_darwin.c.v
@@ -95,7 +95,7 @@ fn is_macos_v3_relevant_command(command string, prefs &pref.Preferences) bool {
 	// modes use V3 by default.
 	if normalized_path == 'cmd/v' || normalized_path.starts_with('cmd/v/')
 		|| normalized_path.contains('/cmd/v/') || normalized_path.ends_with('/cmd/v')
-		|| normalized_path == 'vlib/v3/v3.v' || normalized_path.ends_with('/vlib/v3/v3.v')
+		|| is_macos_v3_compiler_bootstrap(normalized_path)
 		|| is_macos_v3_internal_tool_bootstrap(normalized_path, os.getenv('VCHILD') == 'true') {
 		return false
 	}

--- a/cmd/v/macos_v3_test.v
+++ b/cmd/v/macos_v3_test.v
@@ -228,17 +228,34 @@ fn test_macos_v3_compiler_bootstrap_is_detected_from_any_cwd() {
 
 	// A bare `v3.v` invoked from inside vlib/v3 must resolve to the bootstrap so
 	// it builds with the compatibility compiler instead of the embedded V3 driver.
-	repo_root := os.dir(os.dir(os.real_path(@FILE)))
-	v3_dir := os.join_path(repo_root, 'vlib', 'v3')
-	if os.exists(os.join_path(v3_dir, 'v3.v')) {
-		saved := os.getwd()
-		os.chdir(v3_dir) or { return }
-		bare := is_macos_v3_compiler_bootstrap('v3.v')
-		dotted := is_macos_v3_compiler_bootstrap('./v3.v')
-		os.chdir(saved) or {}
-		assert bare
-		assert dotted
+	// Use an isolated <tmp>/vlib/v3/v3.v so this exercises the real-path
+	// resolution unconditionally, independent of where this test file lives.
+	root := os.join_path(os.real_path(os.vtmp_dir()), 'macos_v3_bootstrap_${os.getpid()}')
+	v3_dir := os.join_path(root, 'vlib', 'v3')
+	other_dir := os.join_path(root, 'elsewhere')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(v3_dir) or { panic(err) }
+	os.mkdir_all(other_dir) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
 	}
+	os.write_file(os.join_path(v3_dir, 'v3.v'), 'module main\n') or { panic(err) }
+	os.write_file(os.join_path(other_dir, 'v3.v'), 'module main\n') or { panic(err) }
+
+	saved := os.getwd()
+	defer {
+		os.chdir(saved) or {}
+	}
+	os.chdir(v3_dir) or { panic(err) }
+	bare := is_macos_v3_compiler_bootstrap('v3.v')
+	dotted := is_macos_v3_compiler_bootstrap('./v3.v')
+	// A bare `v3.v` that is not under vlib/v3 must stay on the V3 path.
+	os.chdir(other_dir) or { panic(err) }
+	non_bootstrap := is_macos_v3_compiler_bootstrap('v3.v')
+	os.chdir(saved) or {}
+	assert bare
+	assert dotted
+	assert !non_bootstrap
 }
 
 fn test_macos_v3_dispatch_allows_the_implicit_gc_default() {

--- a/cmd/v/macos_v3_test.v
+++ b/cmd/v/macos_v3_test.v
@@ -217,6 +217,30 @@ fn test_macos_v3_relevant_command_selects_user_compilation_and_tests() {
 	}
 }
 
+fn test_macos_v3_compiler_bootstrap_is_detected_from_any_cwd() {
+	// Repo-relative and absolute spellings are recognized directly.
+	assert is_macos_v3_compiler_bootstrap('vlib/v3/v3.v')
+	assert is_macos_v3_compiler_bootstrap('/home/user/v/vlib/v3/v3.v')
+	// Non-bootstrap targets stay on the V3 path.
+	assert !is_macos_v3_compiler_bootstrap('main.v')
+	assert !is_macos_v3_compiler_bootstrap('cmd/v')
+	assert !is_macos_v3_compiler_bootstrap('some/other/place/v3.v')
+
+	// A bare `v3.v` invoked from inside vlib/v3 must resolve to the bootstrap so
+	// it builds with the compatibility compiler instead of the embedded V3 driver.
+	repo_root := os.dir(os.dir(os.real_path(@FILE)))
+	v3_dir := os.join_path(repo_root, 'vlib', 'v3')
+	if os.exists(os.join_path(v3_dir, 'v3.v')) {
+		saved := os.getwd()
+		os.chdir(v3_dir) or { return }
+		bare := is_macos_v3_compiler_bootstrap('v3.v')
+		dotted := is_macos_v3_compiler_bootstrap('./v3.v')
+		os.chdir(saved) or {}
+		assert bare
+		assert dotted
+	}
+}
+
 fn test_macos_v3_dispatch_allows_the_implicit_gc_default() {
 	$if macos {
 		implicit_gc, _ := pref.parse_args_and_show_errors([], ['', 'main.v'], false)

--- a/vlib/v3/transform/array.v
+++ b/vlib/v3/transform/array.v
@@ -11,8 +11,8 @@ fn (mut t Transformer) make_array_new_call(elem_type string, len_expr flat.NodeI
 	} else {
 		elem_type
 	}
-	return t.make_call_typed('array_new', arr3(t.make_sizeof_type(storage_size_type), len_expr,
-		cap_expr), '[]${elem_type}')
+	return t.make_call_typed('array_new',
+		[t.make_sizeof_type(storage_size_type), len_expr, cap_expr], '[]${elem_type}')
 }
 
 fn shared_array_inner_type_text(raw string) ?string {
@@ -91,7 +91,7 @@ fn (mut t Transformer) try_lower_array_repeat_call(_id flat.NodeId, node flat.No
 	base := t.transform_expr(base_id)
 	count := t.transform_expr(count_id)
 	selector := t.make_selector(base, 'repeat_to_depth', '')
-	return t.make_call_expr_typed(selector, arr2(count, t.make_int_literal(depth)), node.typ)
+	return t.make_call_expr_typed(selector, [count, t.make_int_literal(depth)], node.typ)
 }
 
 // make_plain_array_repeat_value preserves the repeated result before destroying a
@@ -104,11 +104,13 @@ fn (mut t Transformer) make_plain_array_repeat_value(base_id flat.NodeId, count_
 	count := t.transform_expr_for_type(count_id, 'int')
 	repeat_selector := t.make_selector(stable_source, 'repeat_to_depth', '')
 	clone_depth := array_repeat_clone_depth(array_type)
-	repeated := t.make_call_expr_typed(repeat_selector,
-		arr2(count, t.make_int_literal(clone_depth)), array_type)
+	repeated := t.make_call_expr_typed(repeat_selector, [count, t.make_int_literal(clone_depth)],
+		array_type)
 	out_name := t.new_temp('plain_array_repeat')
 	t.pending_stmts << t.make_decl_assign_typed(out_name, repeated, array_type)
-	t.pending_stmts << t.make_expr_stmt(t.make_call_typed('drop_owned', arr1(stable_source), 'void'))
+	t.pending_stmts << t.make_expr_stmt(t.make_call_typed('drop_owned', [
+		stable_source,
+	], 'void'))
 	result := t.make_ident(out_name)
 	t.set_node_typ(int(result), array_type)
 	return result
@@ -131,7 +133,7 @@ fn (mut t Transformer) make_owned_array_repeat_value(base_id flat.NodeId, count_
 		'owned_array_repeat_source')
 	count := t.transform_expr_for_type(count_id, 'int')
 	repeat_selector := t.make_selector(stable_source, 'repeat_to_depth', '')
-	storage_repeat := t.make_call_expr_typed(repeat_selector, arr2(count, t.make_int_literal(0)),
+	storage_repeat := t.make_call_expr_typed(repeat_selector, [count, t.make_int_literal(0)],
 		array_type)
 	out_name := t.new_temp('owned_array_repeat')
 	idx_name := t.new_temp('owned_array_repeat_idx')
@@ -151,8 +153,9 @@ fn (mut t Transformer) make_owned_array_repeat_value(base_id flat.NodeId, count_
 		skip_ownership_drops: true
 	})
 	if source_is_owned_temporary {
-		t.pending_stmts << t.make_expr_stmt(t.make_call_typed('drop_owned', arr1(stable_source),
-			'void'))
+		t.pending_stmts << t.make_expr_stmt(t.make_call_typed('drop_owned', [
+			stable_source,
+		], 'void'))
 	}
 	result := t.make_ident(out_name)
 	t.set_node_typ(int(result), array_type)
@@ -254,18 +257,20 @@ fn array_nested_eq_depth(typ string) int {
 fn (mut t Transformer) make_array_push_many_call(lhs_addr flat.NodeId, rhs flat.NodeId, rhs_type string) flat.NodeId {
 	t.mark_fn_used('array__push_many')
 	rhs_value := t.stable_transformed_expr_for_reuse(rhs, rhs_type, 'push_many')
-	return t.make_call_typed('array__push_many', arr3(lhs_addr, t.make_selector(rhs_value, 'data',
-		'voidptr'), t.make_selector(rhs_value, 'len', 'int')), 'void')
+	return t.make_call_typed('array__push_many', [lhs_addr,
+		t.make_selector(rhs_value, 'data', 'voidptr'), t.make_selector(rhs_value, 'len', 'int')],
+		'void')
 }
 
 fn (mut t Transformer) make_array_insert_many_call(lhs_addr flat.NodeId, index flat.NodeId, rhs flat.NodeId, rhs_type string) flat.NodeId {
 	if t.is_fixed_array_type(rhs_type) {
-		return t.make_call_typed('array__insert_many', arr4(lhs_addr, index, rhs,
-			t.make_fixed_array_len_expr(rhs_type)), 'void')
+		return t.make_call_typed('array__insert_many', [lhs_addr, index, rhs,
+			t.make_fixed_array_len_expr(rhs_type)], 'void')
 	}
 	rhs_value := t.stable_transformed_expr_for_reuse(rhs, rhs_type, 'insert_many')
-	return t.make_call_typed('array__insert_many', arr4(lhs_addr, index, t.make_selector(rhs_value,
-		'data', 'voidptr'), t.make_selector(rhs_value, 'len', 'int')), 'void')
+	return t.make_call_typed('array__insert_many', [lhs_addr, index,
+		t.make_selector(rhs_value, 'data', 'voidptr'), t.make_selector(rhs_value, 'len', 'int')],
+		'void')
 }
 
 fn (mut t Transformer) transform_array_many_rhs(id flat.NodeId, node flat.Node, array_type string) flat.NodeId {
@@ -320,7 +325,9 @@ fn (mut t Transformer) make_array_clone_from_owned_temporary(source flat.NodeId,
 	out_name := t.new_temp('array_clone')
 	cloned := t.make_array_clone_value(stable_source, array_type)
 	t.pending_stmts << t.make_decl_assign_typed(out_name, cloned, array_type)
-	t.pending_stmts << t.make_expr_stmt(t.make_call_typed('drop_owned', arr1(stable_source), 'void'))
+	t.pending_stmts << t.make_expr_stmt(t.make_call_typed('drop_owned', [
+		stable_source,
+	], 'void'))
 	result := t.make_ident(out_name)
 	t.set_node_typ(int(result), array_type)
 	return result
@@ -347,8 +354,9 @@ fn (mut t Transformer) make_array_reverse_call(base_id flat.NodeId, base_type st
 		clone := t.make_array_clone_call(base_id, base_type)
 		stable_clone := t.stable_transformed_expr_for_reuse(clone, clean_type, 'owned_reverse')
 		t.mark_fn_used('array__reverse_in_place')
-		reverse := t.make_call_typed('array__reverse_in_place', arr1(t.runtime_addr(stable_clone,
-			clean_type)), 'void')
+		reverse := t.make_call_typed('array__reverse_in_place', [
+			t.runtime_addr(stable_clone, clean_type),
+		], 'void')
 		t.pending_stmts << t.make_expr_stmt(reverse)
 		return stable_clone
 	}
@@ -357,17 +365,19 @@ fn (mut t Transformer) make_array_reverse_call(base_id flat.NodeId, base_type st
 		receiver = t.make_prefix(.mul, receiver)
 		t.set_node_typ(int(receiver), clean_type)
 	}
-	return t.make_call_typed('array__reverse', arr1(receiver), clean_type)
+	return t.make_call_typed('array__reverse', [receiver], clean_type)
 }
 
 fn (mut t Transformer) make_array_clone_value(receiver flat.NodeId, base_type string) flat.NodeId {
 	clean_type := if base_type.starts_with('&') { base_type[1..] } else { base_type }
 	depth := array_repeat_clone_depth(clean_type)
 	if depth > 0 {
-		return t.make_call_typed('array__clone_to_depth', arr2(t.runtime_addr(receiver, base_type),
-			t.make_int_literal(depth)), clean_type)
+		return t.make_call_typed('array__clone_to_depth', [
+			t.runtime_addr(receiver, base_type),
+			t.make_int_literal(depth),
+		], clean_type)
 	}
-	return t.make_call_typed('array__clone', arr1(t.runtime_addr(receiver, base_type)), clean_type)
+	return t.make_call_typed('array__clone', [t.runtime_addr(receiver, base_type)], clean_type)
 }
 
 fn (mut t Transformer) clone_nested_array_spread_value(spread flat.NodeId, spread_type string) flat.NodeId {
@@ -629,8 +639,10 @@ fn (mut t Transformer) lower_array_literal_to_runtime(id flat.NodeId, node flat.
 			t.transform_expr_for_type(elem_id, elem_type)
 		}
 		t.pending_stmts << t.make_decl_assign_typed(value_name, value, elem_type)
-		call := t.make_call_typed('array_push', arr2(t.make_prefix(.amp, t.make_ident(tmp_name)), t.make_prefix(.amp,
-			t.make_ident(value_name))), 'void')
+		call := t.make_call_typed('array_push', [
+			t.make_prefix(.amp, t.make_ident(tmp_name)),
+			t.make_prefix(.amp, t.make_ident(value_name)),
+		], 'void')
 		t.pending_stmts << t.make_expr_stmt(call)
 	}
 	result := t.make_ident(tmp_name)
@@ -685,8 +697,9 @@ fn (mut t Transformer) append_array_literal_spread(out_name string, spread_id fl
 			stable_source, array_type)
 		t.pending_stmts << t.make_expr_stmt(call)
 		if source_is_owned_temporary {
-			t.pending_stmts << t.make_expr_stmt(t.make_call_typed('drop_owned',
-				arr1(stable_source), 'void'))
+			t.pending_stmts << t.make_expr_stmt(t.make_call_typed('drop_owned', [
+				stable_source,
+			], 'void'))
 		}
 		return
 	}
@@ -703,14 +716,17 @@ fn (mut t Transformer) append_array_literal_spread(out_name string, spread_id fl
 	mut body := t.pending_stmts[pending_start..].clone()
 	t.pending_stmts = t.pending_stmts[..pending_start].clone()
 	body << t.make_decl_assign_typed(value_name, cloned_elem, elem_type)
-	body << t.make_expr_stmt(t.make_call_typed('array_push', arr2(t.make_prefix(.amp,
-		t.make_ident(out_name)), t.make_prefix(.amp, t.make_ident(value_name))), 'void'))
+	body << t.make_expr_stmt(t.make_call_typed('array_push', [
+		t.make_prefix(.amp, t.make_ident(out_name)),
+		t.make_prefix(.amp, t.make_ident(value_name)),
+	], 'void'))
 	t.pending_stmts << t.make_for_stmt(init, cond, post, body, flat.Node{
 		skip_ownership_drops: true
 	})
 	if source_is_owned_temporary {
-		t.pending_stmts << t.make_expr_stmt(t.make_call_typed('drop_owned', arr1(stable_source),
-			'void'))
+		t.pending_stmts << t.make_expr_stmt(t.make_call_typed('drop_owned', [
+			stable_source,
+		], 'void'))
 	}
 }
 
@@ -896,8 +912,10 @@ fn (mut t Transformer) transform_array_literal_for_type(id flat.NodeId, node fla
 			t.transform_expr_for_type(elem_id, elem_type)
 		}
 		t.pending_stmts << t.make_decl_assign_typed(value_name, value, elem_type)
-		call := t.make_call_typed('array_push', arr2(t.make_prefix(.amp, t.make_ident(tmp_name)), t.make_prefix(.amp,
-			t.make_ident(value_name))), 'void')
+		call := t.make_call_typed('array_push', [
+			t.make_prefix(.amp, t.make_ident(tmp_name)),
+			t.make_prefix(.amp, t.make_ident(value_name)),
+		], 'void')
 		t.pending_stmts << t.make_expr_stmt(call)
 	}
 	result := t.make_ident(tmp_name)
@@ -1299,8 +1317,8 @@ fn (mut t Transformer) try_lower_array_append_stmt(id flat.NodeId) ?[]flat.NodeI
 	lhs_addr := t.runtime_addr(lhs, lhs_type)
 	if push_many {
 		call := if t.is_fixed_array_type(rhs_type) {
-			t.make_call_typed('array_push_many_ptr', arr3(lhs_addr, rhs,
-				t.make_fixed_array_len_expr(rhs_type)), 'void')
+			t.make_call_typed('array_push_many_ptr', [lhs_addr, rhs,
+				t.make_fixed_array_len_expr(rhs_type)], 'void')
 		} else {
 			t.make_array_push_many_call(lhs_addr, rhs, rhs_type)
 		}
@@ -1317,8 +1335,8 @@ fn (mut t Transformer) try_lower_array_append_stmt(id flat.NodeId) ?[]flat.NodeI
 	value_name := t.new_temp('arr_val')
 	value_type := t.shared_array_lhs_inner_type(lhs_id) or { elem_type }
 	result << t.make_decl_assign_typed(value_name, rhs, value_type)
-	push_call := t.make_call_typed('array_push', arr2(lhs_addr, t.make_prefix(.amp,
-		t.make_ident(value_name))), 'void')
+	push_call := t.make_call_typed('array_push', [lhs_addr,
+		t.make_prefix(.amp, t.make_ident(value_name))], 'void')
 	if shared_inner := t.shared_array_lhs_inner_type(lhs_id) {
 		t.set_node_value(int(push_call), 'shared_array_push:${shared_inner}')
 	}
@@ -1491,8 +1509,8 @@ fn (mut t Transformer) try_lower_optional_array_append_stmt(_node flat.Node, lhs
 	lhs_addr := t.runtime_addr(t.make_selector(source, 'value', array_type), array_type)
 	if push_many {
 		call := if t.is_fixed_array_type(rhs_type) {
-			t.make_call_typed('array_push_many_ptr', arr3(lhs_addr, rhs,
-				t.make_fixed_array_len_expr(rhs_type)), 'void')
+			t.make_call_typed('array_push_many_ptr', [lhs_addr, rhs,
+				t.make_fixed_array_len_expr(rhs_type)], 'void')
 		} else {
 			t.make_array_push_many_call(lhs_addr, rhs, rhs_type)
 		}
@@ -1502,8 +1520,8 @@ fn (mut t Transformer) try_lower_optional_array_append_stmt(_node flat.Node, lhs
 	}
 	value_name := t.new_temp('arr_val')
 	result << t.make_decl_assign_typed(value_name, rhs, elem_type)
-	result << t.make_expr_stmt(t.make_call_typed('array_push', arr2(lhs_addr, t.make_prefix(.amp,
-		t.make_ident(value_name))), 'void'))
+	result << t.make_expr_stmt(t.make_call_typed('array_push', [lhs_addr,
+		t.make_prefix(.amp, t.make_ident(value_name))], 'void'))
 	return result
 }
 
@@ -1623,8 +1641,8 @@ fn (mut t Transformer) lower_array_prepend_call(node flat.Node, fn_node flat.Nod
 	t.mark_fn_used('array__prepend')
 	t.mark_fn_used('array__insert')
 	t.mark_fn_used('array__needs_unique_shift')
-	return t.make_call_typed('array__prepend', arr2(t.runtime_addr(base, base_type), t.make_prefix(.amp,
-		t.make_ident(value_name))), 'void')
+	return t.make_call_typed('array__prepend', [t.runtime_addr(base, base_type),
+		t.make_prefix(.amp, t.make_ident(value_name))], 'void')
 }
 
 // lower_array_insert_call builds lower array insert call data for transform.
@@ -1675,8 +1693,8 @@ fn (mut t Transformer) lower_array_insert_call(node flat.Node, fn_node flat.Node
 	t.pending_stmts << t.make_decl_assign_typed(value_name, value, elem_type)
 	t.mark_fn_used('array__insert')
 	t.mark_fn_used('array__needs_unique_shift')
-	return t.make_call_typed('array__insert', arr3(t.runtime_addr(base, base_type), index, t.make_prefix(.amp,
-		t.make_ident(value_name))), 'void')
+	return t.make_call_typed('array__insert', [t.runtime_addr(base, base_type), index,
+		t.make_prefix(.amp, t.make_ident(value_name))], 'void')
 }
 
 fn (mut t Transformer) lower_array_push_many_call(node flat.Node, fn_node flat.Node, base_type string, elem_type string) ?flat.NodeId {
@@ -1697,12 +1715,12 @@ fn (mut t Transformer) lower_array_push_many_call(node flat.Node, fn_node flat.N
 		}
 		value_name := t.new_temp('arr_val')
 		t.pending_stmts << t.make_decl_assign_typed(value_name, value, elem_type)
-		return t.make_call_typed('array_push_many_ptr', arr3(base_addr, t.make_prefix(.amp,
-			t.make_ident(value_name)), t.make_int_literal(1)), 'void')
+		return t.make_call_typed('array_push_many_ptr', [base_addr,
+			t.make_prefix(.amp, t.make_ident(value_name)), t.make_int_literal(1)], 'void')
 	}
 	value := t.transform_expr(value_id)
 	count := t.transform_expr_for_type(count_id, 'int')
-	return t.make_call_typed('array_push_many_ptr', arr3(base_addr, value, count), 'void')
+	return t.make_call_typed('array_push_many_ptr', [base_addr, value, count], 'void')
 }
 
 fn (t &Transformer) push_many_count_is_type_name(id flat.NodeId) bool {
@@ -2128,8 +2146,7 @@ fn (mut t Transformer) array_get_value(base flat.NodeId, index flat.NodeId, elem
 	if t.array_get_base_is_fixed_array(base) {
 		return t.make_index(base, index, elem_type)
 	}
-	get_call := t.make_call_typed('array_get', arr2(t.array_get_runtime_base(base), index),
-		'voidptr')
+	get_call := t.make_call_typed('array_get', [t.array_get_runtime_base(base), index], 'voidptr')
 	ptr := t.make_cast('&${elem_type}', get_call, '&${elem_type}')
 	value := t.make_prefix(.mul, ptr)
 	t.set_node_typ(int(value), elem_type)
@@ -2144,8 +2161,7 @@ fn (mut t Transformer) array_get_ptr(base flat.NodeId, index flat.NodeId, elem_t
 		t.set_node_typ(int(ptr), '&${elem_type}')
 		return ptr
 	}
-	get_call := t.make_call_typed('array_get', arr2(t.array_get_runtime_base(base), index),
-		'voidptr')
+	get_call := t.make_call_typed('array_get', [t.array_get_runtime_base(base), index], 'voidptr')
 	return t.make_cast('&${elem_type}', get_call, '&${elem_type}')
 }
 
@@ -2284,15 +2300,15 @@ fn (mut t Transformer) transform_array_predicate(predicate_id flat.NodeId, defau
 	t.pending_stmts.clear()
 	mut callback_setup := []flat.NodeId{}
 	predicate := if predicate_fn_name.len > 0 {
-		t.make_call_typed(predicate_fn_name, arr1(t.make_ident(elem_name)), 'bool')
+		t.make_call_typed(predicate_fn_name, [t.make_ident(elem_name)], 'bool')
 	} else if predicate_is_fn_value || predicate_allocates_closure {
 		fn_value, setup := t.materialize_array_callback(predicate_id, prefix)
 		callback_setup = setup.clone()
 		fn_value_node := t.a.nodes[int(fn_value)]
 		if fn_value_node.kind == .ident {
-			t.make_call_typed(fn_value_node.value, arr1(t.make_ident(elem_name)), 'bool')
+			t.make_call_typed(fn_value_node.value, [t.make_ident(elem_name)], 'bool')
 		} else {
-			t.make_call_expr_typed(fn_value, arr1(t.make_ident(elem_name)), 'bool')
+			t.make_call_expr_typed(fn_value, [t.make_ident(elem_name)], 'bool')
 		}
 	} else {
 		t.transform_expr(predicate_source)
@@ -2338,12 +2354,13 @@ fn (mut t Transformer) lower_array_filter_call(node flat.Node, fn_node flat.Node
 		cleanup_guard_name = t.new_temp('filter_values_live')
 		prefix << t.make_decl_assign_typed(cleanup_guard_name, t.make_bool_literal(true), 'bool')
 		deferred_drops := [
-			t.make_expr_stmt(t.make_call_typed('drop_owned', arr1(base), 'void')),
-			t.make_expr_stmt(t.make_call_typed('drop_owned', arr1(t.make_ident(out_name)), 'void')),
+			t.make_expr_stmt(t.make_call_typed('drop_owned', [base], 'void')),
+			t.make_expr_stmt(t.make_call_typed('drop_owned', [
+				t.make_ident(out_name)], 'void')),
 		]
 		guarded_drop := t.make_if_with_skip_ownership_drops(t.make_ident(cleanup_guard_name),
 			t.make_block(deferred_drops), t.make_empty())
-		defer_body := t.make_block(arr1(guarded_drop))
+		defer_body := t.make_block([guarded_drop])
 		defer_start := t.a.children.len
 		t.a.children << defer_body
 		prefix << t.a.add_node(flat.Node{
@@ -2395,15 +2412,15 @@ fn (mut t Transformer) lower_array_filter_call(node flat.Node, fn_node flat.Node
 	t.pending_stmts.clear()
 	mut callback_setup := []flat.NodeId{}
 	predicate := if predicate_fn_name.len > 0 {
-		t.make_call_typed(predicate_fn_name, arr1(t.make_ident(elem_name)), 'bool')
+		t.make_call_typed(predicate_fn_name, [t.make_ident(elem_name)], 'bool')
 	} else if predicate_is_fn_value || predicate_allocates_closure {
 		fn_value, setup := t.materialize_array_callback(predicate_id, 'filter_callback')
 		callback_setup = setup.clone()
 		fn_value_node := t.a.nodes[int(fn_value)]
 		if fn_value_node.kind == .ident {
-			t.make_call_typed(fn_value_node.value, arr1(t.make_ident(elem_name)), 'bool')
+			t.make_call_typed(fn_value_node.value, [t.make_ident(elem_name)], 'bool')
 		} else {
-			t.make_call_expr_typed(fn_value, arr1(t.make_ident(elem_name)), 'bool')
+			t.make_call_expr_typed(fn_value, [t.make_ident(elem_name)], 'bool')
 		}
 	} else {
 		t.transform_expr(predicate_source)
@@ -2433,8 +2450,10 @@ fn (mut t Transformer) lower_array_filter_call(node flat.Node, fn_node flat.Node
 		pushed_name = t.new_temp('filter_value')
 		then_body << t.make_decl_assign_typed(pushed_name, cloned_elem, elem_type)
 	}
-	push_call := t.make_call_typed('array_push', arr2(t.make_prefix(.amp, t.make_ident(out_name)), t.make_prefix(.amp,
-		t.make_ident(pushed_name))), 'void')
+	push_call := t.make_call_typed('array_push', [
+		t.make_prefix(.amp, t.make_ident(out_name)),
+		t.make_prefix(.amp, t.make_ident(pushed_name)),
+	], 'void')
 	then_body << t.make_expr_stmt(push_call)
 	then_block := t.make_block(then_body)
 	loop_body << t.make_if(predicate, then_block, t.make_empty())
@@ -2442,7 +2461,7 @@ fn (mut t Transformer) lower_array_filter_call(node flat.Node, fn_node flat.Node
 		skip_ownership_drops: true
 	})
 	if source_needs_drop {
-		prefix << t.make_expr_stmt(t.make_call_typed('drop_owned', arr1(base), 'void'))
+		prefix << t.make_expr_stmt(t.make_call_typed('drop_owned', [base], 'void'))
 		prefix << t.make_assign(t.make_ident(cleanup_guard_name), t.make_bool_literal(false))
 	}
 	for stmt in prefix {
@@ -2541,15 +2560,15 @@ fn (mut t Transformer) lower_array_map_call(node flat.Node, fn_node flat.Node, b
 	t.pending_stmts.clear()
 	mut callback_setup := []flat.NodeId{}
 	mapped_expr := if map_fn_name.len > 0 {
-		t.make_call_typed(map_fn_name, arr1(t.make_ident(elem_name)), result_elem_type)
+		t.make_call_typed(map_fn_name, [t.make_ident(elem_name)], result_elem_type)
 	} else if map_expr_is_fn_value || map_callback_allocates_closure {
 		fn_value, setup := t.materialize_array_callback(map_expr_id, 'map_callback')
 		callback_setup = setup.clone()
 		fn_value_node := t.a.nodes[int(fn_value)]
 		if fn_value_node.kind == .ident && result_elem_type.len > 0 {
-			t.make_call_typed(fn_value_node.value, arr1(t.make_ident(elem_name)), result_elem_type)
+			t.make_call_typed(fn_value_node.value, [t.make_ident(elem_name)], result_elem_type)
 		} else {
-			t.make_call_expr_typed(fn_value, arr1(t.make_ident(elem_name)), result_elem_type)
+			t.make_call_expr_typed(fn_value, [t.make_ident(elem_name)], result_elem_type)
 		}
 	} else if has_bound_method_array {
 		t.make_cast(result_elem_type, t.make_cast('usize', t.make_ident(elem_name), 'usize'),
@@ -2624,12 +2643,13 @@ fn (mut t Transformer) lower_array_map_call(node flat.Node, fn_node flat.Node, b
 		cleanup_guard_name = t.new_temp('map_values_live')
 		prefix << t.make_decl_assign_typed(cleanup_guard_name, t.make_bool_literal(true), 'bool')
 		deferred_drops := [
-			t.make_expr_stmt(t.make_call_typed('drop_owned', arr1(base), 'void')),
-			t.make_expr_stmt(t.make_call_typed('drop_owned', arr1(t.make_ident(out_name)), 'void')),
+			t.make_expr_stmt(t.make_call_typed('drop_owned', [base], 'void')),
+			t.make_expr_stmt(t.make_call_typed('drop_owned', [
+				t.make_ident(out_name)], 'void')),
 		]
 		guarded_drop := t.make_if_with_skip_ownership_drops(t.make_ident(cleanup_guard_name),
 			t.make_block(deferred_drops), t.make_empty())
-		defer_body := t.make_block(arr1(guarded_drop))
+		defer_body := t.make_block([guarded_drop])
 		defer_start := t.a.children.len
 		t.a.children << defer_body
 		prefix << t.a.add_node(flat.Node{
@@ -2663,13 +2683,15 @@ fn (mut t Transformer) lower_array_map_call(node flat.Node, fn_node flat.Node, b
 		pushed_name = t.new_temp('map_cloned_val')
 		loop_body << t.make_decl_assign_typed(pushed_name, cloned_value, result_elem_type)
 	}
-	loop_body << t.make_expr_stmt(t.make_call_typed('array_push', arr2(t.make_prefix(.amp,
-		t.make_ident(out_name)), t.make_prefix(.amp, t.make_ident(pushed_name))), 'void'))
+	loop_body << t.make_expr_stmt(t.make_call_typed('array_push', [
+		t.make_prefix(.amp, t.make_ident(out_name)),
+		t.make_prefix(.amp, t.make_ident(pushed_name)),
+	], 'void'))
 	prefix << t.make_for_stmt(init, cond, post, loop_body, flat.Node{
 		skip_ownership_drops: true
 	})
 	if source_needs_drop {
-		prefix << t.make_expr_stmt(t.make_call_typed('drop_owned', arr1(base), 'void'))
+		prefix << t.make_expr_stmt(t.make_call_typed('drop_owned', [base], 'void'))
 		prefix << t.make_assign(t.make_ident(cleanup_guard_name), t.make_bool_literal(false))
 	}
 	for stmt in prefix {
@@ -3108,10 +3130,11 @@ fn (mut t Transformer) lower_array_count_call(node flat.Node, fn_node flat.Node,
 	if source_is_owned_temporary {
 		cleanup_guard_name = t.new_temp('count_source_live')
 		prefix << t.make_decl_assign_typed(cleanup_guard_name, t.make_bool_literal(true), 'bool')
-		deferred_drop := t.make_expr_stmt(t.make_call_typed('drop_owned', arr1(base), 'void'))
-		guarded_drop := t.make_if_with_skip_ownership_drops(t.make_ident(cleanup_guard_name),
-			t.make_block(arr1(deferred_drop)), t.make_empty())
-		defer_body := t.make_block(arr1(guarded_drop))
+		deferred_drop := t.make_expr_stmt(t.make_call_typed('drop_owned', [base], 'void'))
+		guarded_drop := t.make_if_with_skip_ownership_drops(t.make_ident(cleanup_guard_name), t.make_block([
+			deferred_drop,
+		]), t.make_empty())
+		defer_body := t.make_block([guarded_drop])
 		defer_start := t.a.children.len
 		t.a.children << defer_body
 		prefix << t.a.add_node(flat.Node{
@@ -3138,12 +3161,12 @@ fn (mut t Transformer) lower_array_count_call(node flat.Node, fn_node flat.Node,
 		loop_body << stmt
 	}
 	inc := t.make_assign_op(t.make_ident(result_name), t.make_int_literal(1), .plus_assign)
-	loop_body << t.make_if(predicate, t.make_block(arr1(inc)), t.make_empty())
+	loop_body << t.make_if(predicate, t.make_block([inc]), t.make_empty())
 	prefix << t.make_for_stmt(init, cond, post, loop_body, flat.Node{
 		skip_ownership_drops: true
 	})
 	if source_is_owned_temporary {
-		prefix << t.make_expr_stmt(t.make_call_typed('drop_owned', arr1(base), 'void'))
+		prefix << t.make_expr_stmt(t.make_call_typed('drop_owned', [base], 'void'))
 		prefix << t.make_assign(t.make_ident(cleanup_guard_name), t.make_bool_literal(false))
 	}
 	for stmt in prefix {
@@ -3177,10 +3200,11 @@ fn (mut t Transformer) lower_array_any_all_call(node flat.Node, fn_node flat.Nod
 	if source_is_owned_temporary {
 		cleanup_guard_name = t.new_temp('${method}_source_live')
 		prefix << t.make_decl_assign_typed(cleanup_guard_name, t.make_bool_literal(true), 'bool')
-		deferred_drop := t.make_expr_stmt(t.make_call_typed('drop_owned', arr1(base), 'void'))
-		guarded_drop := t.make_if_with_skip_ownership_drops(t.make_ident(cleanup_guard_name),
-			t.make_block(arr1(deferred_drop)), t.make_empty())
-		defer_body := t.make_block(arr1(guarded_drop))
+		deferred_drop := t.make_expr_stmt(t.make_call_typed('drop_owned', [base], 'void'))
+		guarded_drop := t.make_if_with_skip_ownership_drops(t.make_ident(cleanup_guard_name), t.make_block([
+			deferred_drop,
+		]), t.make_empty())
+		defer_body := t.make_block([guarded_drop])
 		defer_start := t.a.children.len
 		t.a.children << defer_body
 		prefix << t.a.add_node(flat.Node{
@@ -3209,16 +3233,16 @@ fn (mut t Transformer) lower_array_any_all_call(node flat.Node, fn_node flat.Nod
 	if method == 'all' {
 		not_predicate := t.make_prefix(.not, t.make_paren(predicate))
 		assign_false := t.make_assign(t.make_ident(result_name), t.make_bool_literal(false))
-		loop_body << t.make_if(not_predicate, t.make_block(arr1(assign_false)), t.make_empty())
+		loop_body << t.make_if(not_predicate, t.make_block([assign_false]), t.make_empty())
 	} else {
 		assign_true := t.make_assign(t.make_ident(result_name), t.make_bool_literal(true))
-		loop_body << t.make_if(predicate, t.make_block(arr1(assign_true)), t.make_empty())
+		loop_body << t.make_if(predicate, t.make_block([assign_true]), t.make_empty())
 	}
 	prefix << t.make_for_stmt(init, cond, post, loop_body, flat.Node{
 		skip_ownership_drops: true
 	})
 	if source_is_owned_temporary {
-		prefix << t.make_expr_stmt(t.make_call_typed('drop_owned', arr1(base), 'void'))
+		prefix << t.make_expr_stmt(t.make_call_typed('drop_owned', [base], 'void'))
 		prefix << t.make_assign(t.make_ident(cleanup_guard_name), t.make_bool_literal(false))
 	}
 	for stmt in prefix {
@@ -3335,7 +3359,7 @@ fn (mut t Transformer) make_array_default_sort_stmt(base flat.NodeId, elem_type 
 	if int(cmp_id) < 0 {
 		if helper := t.array_default_sort_runtime_helper(elem_type) {
 			base_addr := t.make_prefix(.amp, base)
-			return t.make_expr_stmt(t.make_call_typed(helper, arr1(base_addr), 'void'))
+			return t.make_expr_stmt(t.make_call_typed(helper, [base_addr], 'void'))
 		}
 	}
 	i_name := t.new_temp('sort_i')
@@ -3435,7 +3459,7 @@ fn (mut t Transformer) array_sort_less_expr(base flat.NodeId, elem_type string, 
 		return cmp
 	}
 	if elem_type == 'string' {
-		return t.make_call_typed('string__lt', arr2(cur, prev), 'bool')
+		return t.make_call_typed('string__lt', [cur, prev], 'bool')
 	}
 	if cmp := t.array_sort_struct_less_expr(cur, prev, elem_type) {
 		return cmp
@@ -3452,7 +3476,7 @@ fn (mut t Transformer) array_sort_struct_less_expr(cur flat.NodeId, prev flat.No
 		return none
 	}
 	call_info := t.struct_operator_call_info(struct_type, .lt) or { return none }
-	args := if call_info.reverse { arr2(prev, cur) } else { arr2(cur, prev) }
+	args := if call_info.reverse { [prev, cur] } else { [cur, prev] }
 	t.mark_fn_used_name(call_info.name)
 	call := t.make_call_typed(call_info.name, args, 'bool')
 	if call_info.negate {
@@ -3480,7 +3504,7 @@ fn (mut t Transformer) array_sort_simple_operator_expr(node flat.Node, cur flat.
 	call_info := t.struct_operator_call_info(struct_type, node.op) or { return none }
 	lhs := if lhs_node.value == 'a' { cur } else { prev }
 	rhs := if rhs_node.value == 'a' { cur } else { prev }
-	args := if call_info.reverse { arr2(rhs, lhs) } else { arr2(lhs, rhs) }
+	args := if call_info.reverse { [rhs, lhs] } else { [lhs, rhs] }
 	t.mark_fn_used_name(call_info.name)
 	call := t.make_call_typed(call_info.name, args, node.typ)
 	if call_info.negate {
@@ -3505,7 +3529,7 @@ fn (mut t Transformer) array_sort_compare_less_expr(base flat.NodeId, elem_type 
 			}
 		}
 	}
-	call := t.make_call_expr_typed(cmp, arr2(cur_arg, prev_arg), 'int')
+	call := t.make_call_expr_typed(cmp, [cur_arg, prev_arg], 'int')
 	return t.make_infix(.lt, call, t.make_int_literal(0))
 }
 

--- a/vlib/v3/transform/comptime.v
+++ b/vlib/v3/transform/comptime.v
@@ -331,7 +331,7 @@ fn (mut t Transformer) expand_comptime_for(id flat.NodeId, node flat.Node) []fla
 	// one-letter name from another function, but this template's `T` must not be
 	// expanded until its specialization is cloned.
 	if is_generic_fn_placeholder_name(node.typ) && t.generic_arg_is_unresolved(node.typ) {
-		return arr1(id)
+		return [id]
 	}
 	base_type := if kind == 'methods' {
 		source := t.comptime_for_value_source_type(node.typ) or { node.typ }
@@ -343,7 +343,7 @@ fn (mut t Transformer) expand_comptime_for(id flat.NodeId, node flat.Node) []fla
 	// Its metadata and `$zero(field.typ)` children are needed when the concrete
 	// specialization is cloned later; erasing them here leaves empty child ids.
 	if t.generic_arg_is_unresolved(base_type) {
-		return arr1(id)
+		return [id]
 	}
 	t.ignore_comptime_for_subtree(id)
 	body_id := t.a.child(&node, 0)
@@ -3410,7 +3410,7 @@ fn (mut t Transformer) clone_field_subst_scoped(id flat.NodeId, var_name string,
 		arg := t.a.child_node(&node, 1)
 		if callee.kind == .ident && callee.value == '__v3_isreftype' && arg.kind == .ident
 			&& arg.value == var_name {
-			return t.make_call('__v3_isreftype', arr1(t.make_sizeof_type(fm.comptime_typ)))
+			return t.make_call('__v3_isreftype', [t.make_sizeof_type(fm.comptime_typ)])
 		}
 	}
 	if node.kind == .ident && node.value == var_name {

--- a/vlib/v3/transform/expr.v
+++ b/vlib/v3/transform/expr.v
@@ -85,14 +85,14 @@ fn (mut t Transformer) transform_infix_string_ops(_id flat.NodeId, node flat.Nod
 			if lhs.kind == .string_literal && rhs.kind == .string_literal {
 				result = t.make_string_literal(lhs.value + rhs.value)
 			} else {
-				result = t.make_call('string__plus', arr2(new_lhs, new_rhs))
+				result = t.make_call('string__plus', [new_lhs, new_rhs])
 			}
 		}
 		.eq {
-			result = t.make_call('string__eq', arr2(new_lhs, new_rhs))
+			result = t.make_call('string__eq', [new_lhs, new_rhs])
 		}
 		.ne {
-			eq_call := t.make_call('string__eq', arr2(new_lhs, new_rhs))
+			eq_call := t.make_call('string__eq', [new_lhs, new_rhs])
 			start := t.a.children.len
 			t.a.children << eq_call
 			result = t.a.add_node(flat.Node{
@@ -103,15 +103,15 @@ fn (mut t Transformer) transform_infix_string_ops(_id flat.NodeId, node flat.Nod
 			})
 		}
 		.lt {
-			result = t.make_call('string__lt', arr2(new_lhs, new_rhs))
+			result = t.make_call('string__lt', [new_lhs, new_rhs])
 		}
 		.gt {
 			// a > b  ->  string__lt(b, a)
-			result = t.make_call('string__lt', arr2(new_rhs, new_lhs))
+			result = t.make_call('string__lt', [new_rhs, new_lhs])
 		}
 		.le {
 			// a <= b  ->  !(b < a)  ->  !string__lt(rhs, lhs)
-			lt_call := t.make_call('string__lt', arr2(new_rhs, new_lhs))
+			lt_call := t.make_call('string__lt', [new_rhs, new_lhs])
 			start := t.a.children.len
 			t.a.children << lt_call
 			result = t.a.add_node(flat.Node{
@@ -123,7 +123,7 @@ fn (mut t Transformer) transform_infix_string_ops(_id flat.NodeId, node flat.Nod
 		}
 		.ge {
 			// a >= b  ->  !(a < b)  ->  !string__lt(lhs, rhs)
-			lt_call := t.make_call('string__lt', arr2(new_lhs, new_rhs))
+			lt_call := t.make_call('string__lt', [new_lhs, new_rhs])
 			start := t.a.children.len
 			t.a.children << lt_call
 			result = t.a.add_node(flat.Node{
@@ -360,13 +360,12 @@ fn (mut t Transformer) transform_infix_array_ops(_id flat.NodeId, node flat.Node
 	eq_call := if t.array_elem_needs_element_eq(elem_type) {
 		t.make_array_elementwise_eq_call(new_lhs, new_rhs, elem_type, lhs_type, rhs_type, node)
 	} else if elem_type.starts_with('[]') {
-		t.make_call_typed('array_eq_array', arr3(new_lhs, new_rhs,
-			t.make_int_literal(array_nested_eq_depth(lhs_type))), 'bool')
+		t.make_call_typed('array_eq_array', [new_lhs, new_rhs,
+			t.make_int_literal(array_nested_eq_depth(lhs_type))], 'bool')
 	} else if elem_type == 'string' {
-		t.make_call_typed('array_eq_string', arr2(new_lhs, new_rhs), 'bool')
+		t.make_call_typed('array_eq_string', [new_lhs, new_rhs], 'bool')
 	} else {
-		t.make_call_typed('array_eq_raw', arr3(new_lhs, new_rhs, t.make_sizeof_type(elem_type)),
-			'bool')
+		t.make_call_typed('array_eq_raw', [new_lhs, new_rhs, t.make_sizeof_type(elem_type)], 'bool')
 	}
 	if node.op == .ne {
 		return t.make_prefix(.not, eq_call)
@@ -566,7 +565,7 @@ fn (mut t Transformer) transform_infix_map_ops(_id flat.NodeId, node flat.Node) 
 	eq_call := if value_type.len > 0 && t.map_value_needs_element_eq(value_type) {
 		t.make_map_elementwise_eq_call(new_lhs, new_rhs, map_type, node)
 	} else {
-		t.make_call_typed('map_map_eq', arr2(new_lhs, new_rhs), 'bool')
+		t.make_call_typed('map_map_eq', [new_lhs, new_rhs], 'bool')
 	}
 	if node.op == .ne {
 		return t.make_prefix(.not, eq_call)
@@ -719,11 +718,11 @@ fn (mut t Transformer) transform_infix_interface_ops(_id flat.NodeId, node flat.
 				lhs_typ := t.make_selector(lhs_err, '_typ', 'int')
 				rhs_typ := t.make_selector(rhs_err, '_typ', 'int')
 				type_eq := t.make_infix(.eq, lhs_typ, rhs_typ)
-				lhs_msg := t.make_call_typed('IError__msg', arr1(lhs_addr), 'string')
-				rhs_msg := t.make_call_typed('IError__msg', arr1(rhs_addr), 'string')
-				msg_eq := t.make_call_typed('string__eq', arr2(lhs_msg, rhs_msg), 'bool')
-				lhs_code := t.make_call_typed('IError__code', arr1(lhs_addr), 'int')
-				rhs_code := t.make_call_typed('IError__code', arr1(rhs_addr), 'int')
+				lhs_msg := t.make_call_typed('IError__msg', [lhs_addr], 'string')
+				rhs_msg := t.make_call_typed('IError__msg', [rhs_addr], 'string')
+				msg_eq := t.make_call_typed('string__eq', [lhs_msg, rhs_msg], 'bool')
+				lhs_code := t.make_call_typed('IError__code', [lhs_addr], 'int')
+				rhs_code := t.make_call_typed('IError__code', [rhs_addr], 'int')
 				code_eq := t.make_infix(.eq, lhs_code, rhs_code)
 				err_eq := t.make_infix(.logical_and, type_eq, t.make_infix(.logical_and, msg_eq,
 					code_eq))
@@ -898,9 +897,9 @@ fn (mut t Transformer) transform_infix_struct_ops(_id flat.NodeId, node flat.Nod
 				node.children_start + 1]), 'op_rhs')
 		}
 		args := if call_info.reverse {
-			arr2(call_rhs, call_lhs)
+			[call_rhs, call_lhs]
 		} else {
-			arr2(call_lhs, call_rhs)
+			[call_lhs, call_rhs]
 		}
 		t.mark_struct_operator_used_name(call_info.name)
 		ret_type := t.infix_struct_operator_result_type(node, struct_type)
@@ -927,8 +926,8 @@ fn (mut t Transformer) transform_infix_struct_ops(_id flat.NodeId, node flat.Nod
 			}
 			return field_eq
 		}
-		cmp := t.make_call_typed('C.memcmp', arr3(t.make_prefix(.amp, lhs),
-			t.make_prefix(.amp, rhs), t.make_sizeof_type(struct_type)), 'int')
+		cmp := t.make_call_typed('C.memcmp', [t.make_prefix(.amp, lhs),
+			t.make_prefix(.amp, rhs), t.make_sizeof_type(struct_type)], 'int')
 		return t.make_infix(node.op, cmp, t.make_int_literal(0))
 	}
 	if eq_fn := t.struct_operator_fn_name(struct_type, '==') {
@@ -938,7 +937,7 @@ fn (mut t Transformer) transform_infix_struct_ops(_id flat.NodeId, node flat.Nod
 		lhs := t.transform_expr(lhs_id)
 		rhs := t.transform_expr(t.a.children[node.children_start + 1])
 		t.mark_struct_operator_used_name(eq_fn)
-		eq_call := t.make_call_typed(eq_fn, arr2(lhs, rhs), 'bool')
+		eq_call := t.make_call_typed(eq_fn, [lhs, rhs], 'bool')
 		if node.op == .ne {
 			return t.make_prefix(.not, eq_call)
 		}
@@ -1068,9 +1067,9 @@ fn (mut t Transformer) transform_transformed_struct_eq(node flat.Node, lhs flat.
 		call_lhs := t.stable_transformed_expr_for_reuse(lhs, lhs_type, 'op_lhs')
 		call_rhs := t.stable_transformed_expr_for_reuse(rhs, rhs_type, 'op_rhs')
 		args := if call_info.reverse {
-			arr2(call_rhs, call_lhs)
+			[call_rhs, call_lhs]
 		} else {
-			arr2(call_lhs, call_rhs)
+			[call_lhs, call_rhs]
 		}
 		t.mark_struct_operator_used_name(call_info.name)
 		ret_type := t.infix_struct_operator_result_type(node, struct_type)
@@ -1094,7 +1093,7 @@ fn (mut t Transformer) transform_transformed_struct_eq(node flat.Node, lhs flat.
 		call_lhs := t.stable_transformed_expr_for_reuse(lhs, lhs_type, 'eq_lhs')
 		call_rhs := t.stable_transformed_expr_for_reuse(rhs, rhs_type, 'eq_rhs')
 		t.mark_struct_operator_used_name(eq_fn)
-		eq_call := t.make_call_typed(eq_fn, arr2(call_lhs, call_rhs), 'bool')
+		eq_call := t.make_call_typed(eq_fn, [call_lhs, call_rhs], 'bool')
 		if node.op == .ne {
 			return t.make_prefix(.not, eq_call)
 		}
@@ -1108,8 +1107,8 @@ fn (mut t Transformer) transform_transformed_struct_eq(node flat.Node, lhs flat.
 		}
 		return field_eq
 	}
-	cmp := t.make_call_typed('C.memcmp', arr3(t.make_prefix(.amp, cmp_lhs), t.make_prefix(.amp,
-		cmp_rhs), t.make_sizeof_type(struct_type)), 'int')
+	cmp := t.make_call_typed('C.memcmp', [t.make_prefix(.amp, cmp_lhs),
+		t.make_prefix(.amp, cmp_rhs), t.make_sizeof_type(struct_type)], 'int')
 	return t.make_infix(node.op, cmp, t.make_int_literal(0))
 }
 
@@ -2089,7 +2088,7 @@ fn (mut t Transformer) transform_in_expr(id flat.NodeId, node flat.Node) flat.No
 				}
 				new_lhs := t.transform_expr_for_type(lhs_id, elem)
 				fn_name := array_contains_fn_name(elem)
-				result = t.make_call_typed(fn_name, arr2(new_rhs, new_lhs), 'bool')
+				result = t.make_call_typed(fn_name, [new_rhs, new_lhs], 'bool')
 			}
 		} else if rhs.kind in [.ident, .selector] && (rhs_type.len == 0 || rhs_type == 'unknown') {
 			new_lhs := t.transform_expr(lhs_id)
@@ -2104,7 +2103,7 @@ fn (mut t Transformer) transform_in_expr(id flat.NodeId, node flat.Node) flat.No
 			}
 			if elem.len > 0 {
 				fn_name := array_contains_fn_name(elem)
-				result = t.make_call_typed(fn_name, arr2(new_rhs, new_lhs), 'bool')
+				result = t.make_call_typed(fn_name, [new_rhs, new_lhs], 'bool')
 			}
 		} else if t.is_fixed_array_type(clean_rhs_type) {
 			if lowered := t.lower_array_membership_expr(rhs_id, lhs_id, rhs_type, false, node) {
@@ -2116,7 +2115,7 @@ fn (mut t Transformer) transform_in_expr(id flat.NodeId, node flat.Node) flat.No
 				elem := fixed_array_elem_type(clean_rhs_type)
 				fn_name := fixed_array_contains_fn_name(elem)
 				len_expr := t.make_fixed_array_len_expr(clean_rhs_type)
-				result = t.make_call_typed(fn_name, arr3(new_rhs, len_expr, new_lhs), 'bool')
+				result = t.make_call_typed(fn_name, [new_rhs, len_expr, new_lhs], 'bool')
 			}
 		} else if clean_rhs_type == 'string' {
 			new_lhs := t.transform_expr(lhs_id)
@@ -2126,7 +2125,7 @@ fn (mut t Transformer) transform_in_expr(id flat.NodeId, node flat.Node) flat.No
 			} else {
 				'string__contains'
 			}
-			result = t.make_call_typed(fn_name, arr2(new_rhs, new_lhs), 'bool')
+			result = t.make_call_typed(fn_name, [new_rhs, new_lhs], 'bool')
 		} else if clean_rhs_type.starts_with('map[') || clean_rhs_type == 'map' {
 			if lowered := t.lower_map_membership_expr(rhs_id, lhs_id, rhs_type) {
 				result = lowered
@@ -2228,8 +2227,7 @@ fn (mut t Transformer) lower_const_string_array_membership_expr(base_id flat.Nod
 	base_value := t.transform_expr(base_id)
 	base_data := t.make_cast('&string', t.make_selector(base_value, 'data', 'voidptr'), '&string')
 	len_expr := t.make_int_literal(expr.children_count)
-	return t.make_call_typed('fixed_array_contains_string', arr3(base_data, len_expr, needle),
-		'bool')
+	return t.make_call_typed('fixed_array_contains_string', [base_data, len_expr, needle], 'bool')
 }
 
 // lower_type_pattern_membership builds lower type pattern membership data for transform.
@@ -2387,7 +2385,7 @@ fn (mut t Transformer) lower_array_membership_expr(base_id flat.NodeId, needle_i
 	mut loop_body := t.pending_stmts[pending_start..].clone()
 	t.pending_stmts = t.pending_stmts[..pending_start].clone()
 	assign_true := t.make_assign(t.make_ident(result_name), t.make_bool_literal(true))
-	then_block := t.make_block(arr1(assign_true))
+	then_block := t.make_block([assign_true])
 	loop_body << t.make_if(eq_expr, then_block, t.make_empty())
 	prefix << t.make_for_stmt(init, cond, post, loop_body, src)
 	for stmt in prefix {
@@ -2453,7 +2451,7 @@ fn (mut t Transformer) lower_array_index_expr(base_id flat.NodeId, needle_id fla
 	not_found := t.make_infix(.lt, t.make_ident(result_name), t.make_int_literal(0))
 	found_cond := t.make_infix(.logical_and, not_found, eq_expr)
 	assign_idx := t.make_assign(t.make_ident(result_name), t.make_ident(idx_name))
-	loop_body << t.make_if(found_cond, t.make_block(arr1(assign_idx)), t.make_empty())
+	loop_body << t.make_if(found_cond, t.make_block([assign_idx]), t.make_empty())
 	prefix << t.make_for_stmt(init, cond, post, loop_body, src)
 	for stmt in prefix {
 		t.pending_stmts << stmt
@@ -2519,7 +2517,7 @@ fn (mut t Transformer) lower_array_last_index_expr(base_id flat.NodeId, needle_i
 	not_found := t.make_infix(.lt, t.make_ident(result_name), t.make_int_literal(0))
 	found_cond := t.make_infix(.logical_and, not_found, eq_expr)
 	assign_idx := t.make_assign(t.make_ident(result_name), t.make_ident(idx_name))
-	loop_body << t.make_if(found_cond, t.make_block(arr1(assign_idx)), t.make_empty())
+	loop_body << t.make_if(found_cond, t.make_block([assign_idx]), t.make_empty())
 	prefix << t.make_for_stmt(init, cond, post, loop_body, src)
 	for stmt in prefix {
 		t.pending_stmts << stmt
@@ -2570,7 +2568,7 @@ fn (mut t Transformer) make_membership_eq_expr_with_seen(lhs flat.NodeId, rhs fl
 		}
 	}
 	if clean == 'string' {
-		return t.make_call_typed('string__eq', arr2(lhs, rhs), 'bool')
+		return t.make_call_typed('string__eq', [lhs, rhs], 'bool')
 	}
 	map_type := t.clean_map_type(clean)
 	if map_type.starts_with('map[') {
@@ -2583,12 +2581,12 @@ fn (mut t Transformer) make_membership_eq_expr_with_seen(lhs flat.NodeId, rhs fl
 			}
 			return t.make_map_elementwise_eq_call_with_seen(lhs, rhs, map_type, src, seen)
 		}
-		return t.make_call_typed('map_map_eq', arr2(lhs, rhs), 'bool')
+		return t.make_call_typed('map_map_eq', [lhs, rhs], 'bool')
 	}
 	if clean.starts_with('[]') {
 		inner := clean[2..]
 		if inner == 'string' {
-			return t.make_call_typed('array_eq_string', arr2(lhs, rhs), 'bool')
+			return t.make_call_typed('array_eq_string', [lhs, rhs], 'bool')
 		}
 		if t.array_elem_needs_element_eq(inner) {
 			src := if int(lhs) >= 0 && int(lhs) < t.a.nodes.len {
@@ -2600,10 +2598,10 @@ fn (mut t Transformer) make_membership_eq_expr_with_seen(lhs flat.NodeId, rhs fl
 				seen)
 		}
 		if inner.starts_with('[]') {
-			return t.make_call_typed('array_eq_array', arr3(lhs, rhs,
-				t.make_int_literal(array_nested_eq_depth(clean))), 'bool')
+			return t.make_call_typed('array_eq_array', [lhs, rhs,
+				t.make_int_literal(array_nested_eq_depth(clean))], 'bool')
 		}
-		return t.make_call_typed('array_eq_raw', arr3(lhs, rhs, t.make_sizeof_type(inner)), 'bool')
+		return t.make_call_typed('array_eq_raw', [lhs, rhs, t.make_sizeof_type(inner)], 'bool')
 	}
 	if t.is_fixed_array_type(clean) {
 		clean = t.resolved_fixed_array_canonical_type(clean)
@@ -2614,8 +2612,8 @@ fn (mut t Transformer) make_membership_eq_expr_with_seen(lhs flat.NodeId, rhs fl
 		}
 		lhs_value := t.stable_transformed_expr_for_reuse(lhs, clean, 'fixed_eq_lhs')
 		rhs_value := t.stable_transformed_expr_for_reuse(rhs, clean, 'fixed_eq_rhs')
-		cmp := t.make_call_typed('C.memcmp', arr3(t.fixed_array_memcmp_addr(lhs_value),
-			t.fixed_array_memcmp_addr(rhs_value), t.make_sizeof_type(clean)), 'int')
+		cmp := t.make_call_typed('C.memcmp', [t.fixed_array_memcmp_addr(lhs_value),
+			t.fixed_array_memcmp_addr(rhs_value), t.make_sizeof_type(clean)], 'int')
 		return t.make_infix(.eq, cmp, t.make_int_literal(0))
 	}
 	if t.is_optional_type_name(clean) {
@@ -2634,18 +2632,18 @@ fn (mut t Transformer) make_membership_eq_expr_with_seen(lhs flat.NodeId, rhs fl
 	if struct_type.len > 0 {
 		if method_name := t.struct_operator_fn_name_any(struct_type, '==') {
 			t.mark_fn_used_name(method_name)
-			return t.make_call_typed(method_name, arr2(lhs, rhs), 'bool')
+			return t.make_call_typed(method_name, [lhs, rhs], 'bool')
 		}
 		if struct_type in seen {
-			cmp := t.make_call_typed('C.memcmp', arr3(t.make_prefix(.amp, lhs),
-				t.make_prefix(.amp, rhs), t.make_sizeof_type(struct_type)), 'int')
+			cmp := t.make_call_typed('C.memcmp', [t.make_prefix(.amp, lhs),
+				t.make_prefix(.amp, rhs), t.make_sizeof_type(struct_type)], 'int')
 			return t.make_infix(.eq, cmp, t.make_int_literal(0))
 		}
 		if field_eq := t.make_struct_field_eq_expr_with_seen(lhs, rhs, struct_type, seen) {
 			return field_eq
 		}
-		cmp := t.make_call_typed('C.memcmp', arr3(t.make_prefix(.amp, lhs),
-			t.make_prefix(.amp, rhs), t.make_sizeof_type(struct_type)), 'int')
+		cmp := t.make_call_typed('C.memcmp', [t.make_prefix(.amp, lhs),
+			t.make_prefix(.amp, rhs), t.make_sizeof_type(struct_type)], 'int')
 		return t.make_infix(.eq, cmp, t.make_int_literal(0))
 	}
 	return t.make_infix(.eq, lhs, rhs)
@@ -2698,7 +2696,7 @@ fn (mut t Transformer) make_sum_semantic_eq_expr(lhs flat.NodeId, rhs flat.NodeI
 		}
 	}
 	t.mark_fn_used_name(helper)
-	return t.make_call_typed(helper, arr2(lhs, rhs), 'bool')
+	return t.make_call_typed(helper, [lhs, rhs], 'bool')
 }
 
 fn (t &Transformer) sum_eq_type_and_variants(sum_type string) ?(string, []string) {
@@ -2844,7 +2842,7 @@ fn (mut t Transformer) build_sum_eq_helper_fn(clean_sum string) {
 	tag_ne := t.make_infix(.ne, t.make_sum_tag_selector(lhs_value, .dot),
 		t.make_sum_tag_selector(rhs_value, .dot))
 	ret_false := t.make_return(t.make_bool_literal(false), 'bool')
-	stmts << t.make_if(tag_ne, t.make_block(arr1(ret_false)), t.make_empty())
+	stmts << t.make_if(tag_ne, t.make_block([ret_false]), t.make_empty())
 	result_name := t.new_temp('sum_eq_res')
 	stmts << t.make_decl_assign_typed(result_name, t.make_bool_literal(true), 'bool')
 	for variant in variants {
@@ -2869,15 +2867,16 @@ fn (mut t Transformer) build_sum_eq_helper_fn(clean_sum string) {
 		pending_start := t.pending_stmts.len
 		payload_eq := if t.is_sum_type_name(qv) && t.resolve_sum_name(qv) == clean_sum {
 			// a variant that aliases back to this same sum: recurse via the helper
-			t.make_call_typed(helper, arr2(lhs_payload, rhs_payload), 'bool')
+			t.make_call_typed(helper, [lhs_payload, rhs_payload], 'bool')
 		} else {
 			t.make_membership_eq_expr_with_seen(lhs_payload, rhs_payload, qv, []string{})
 		}
 		mut body_stmts := t.pending_stmts[pending_start..].clone()
 		t.pending_stmts = t.pending_stmts[..pending_start].clone()
 		set_false := t.make_assign(t.make_ident(result_name), t.make_bool_literal(false))
-		body_stmts << t.make_if(t.make_prefix(.not, t.make_paren(payload_eq)),
-			t.make_block(arr1(set_false)), t.make_empty())
+		body_stmts << t.make_if(t.make_prefix(.not, t.make_paren(payload_eq)), t.make_block([
+			set_false,
+		]), t.make_empty())
 		guard := t.make_infix(.logical_and, t.make_ident(result_name), t.make_sum_is_check(lhs_value,
 			clean_sum, clean_sum, variant))
 		stmts << t.make_if(guard, t.make_block(body_stmts), t.make_empty())
@@ -2931,8 +2930,8 @@ fn (mut t Transformer) register_sum_eq_helper_signature(helper string, clean_sum
 fn (mut t Transformer) make_memcmp_eq_expr(lhs flat.NodeId, rhs flat.NodeId, typ string, prefix string) flat.NodeId {
 	lhs_value := t.stable_transformed_expr_for_reuse(lhs, typ, '${prefix}_lhs')
 	rhs_value := t.stable_transformed_expr_for_reuse(rhs, typ, '${prefix}_rhs')
-	cmp := t.make_call_typed('C.memcmp', arr3(t.fixed_array_memcmp_addr(lhs_value),
-		t.fixed_array_memcmp_addr(rhs_value), t.make_sizeof_type(typ)), 'int')
+	cmp := t.make_call_typed('C.memcmp', [t.fixed_array_memcmp_addr(lhs_value),
+		t.fixed_array_memcmp_addr(rhs_value), t.make_sizeof_type(typ)], 'int')
 	return t.make_infix(.eq, cmp, t.make_int_literal(0))
 }
 
@@ -2982,8 +2981,9 @@ fn (mut t Transformer) make_optional_semantic_eq_expr(lhs flat.NodeId, rhs flat.
 	compare_values := t.make_infix(.logical_and, t.make_ident(result_name), t.make_selector(lhs_value,
 		'ok', 'bool'))
 	set_false := t.make_assign(t.make_ident(result_name), t.make_bool_literal(false))
-	body_stmts << t.make_if(t.make_prefix(.not, t.make_paren(value_eq)),
-		t.make_block(arr1(set_false)), t.make_empty())
+	body_stmts << t.make_if(t.make_prefix(.not, t.make_paren(value_eq)), t.make_block([
+		set_false,
+	]), t.make_empty())
 	t.pending_stmts << t.make_if(compare_values, t.make_block(body_stmts), t.make_empty())
 	result := t.make_ident(result_name)
 	t.set_node_typ(int(result), 'bool')
@@ -3094,8 +3094,9 @@ fn (mut t Transformer) make_array_elementwise_eq_call_with_seen(lhs flat.NodeId,
 	mut body_stmts := t.pending_stmts[pending_start..].clone()
 	t.pending_stmts = t.pending_stmts[..pending_start].clone()
 	set_false := t.make_assign(t.make_ident(result_name), t.make_bool_literal(false))
-	body_stmts << t.make_if(t.make_prefix(.not, t.make_paren(elem_eq)),
-		t.make_block(arr1(set_false)), t.make_empty())
+	body_stmts << t.make_if(t.make_prefix(.not, t.make_paren(elem_eq)), t.make_block([
+		set_false,
+	]), t.make_empty())
 	t.pending_stmts << t.make_for_stmt(init, cond, post, body_stmts, src)
 	result := t.make_ident(result_name)
 	t.set_node_typ(int(result), 'bool')
@@ -3127,8 +3128,9 @@ fn (mut t Transformer) make_fixed_array_elementwise_eq_expr_with_seen(lhs flat.N
 	mut body_stmts := t.pending_stmts[pending_start..].clone()
 	t.pending_stmts = t.pending_stmts[..pending_start].clone()
 	set_false := t.make_assign(t.make_ident(result_name), t.make_bool_literal(false))
-	body_stmts << t.make_if(t.make_prefix(.not, t.make_paren(elem_eq)),
-		t.make_block(arr1(set_false)), t.make_empty())
+	body_stmts << t.make_if(t.make_prefix(.not, t.make_paren(elem_eq)), t.make_block([
+		set_false,
+	]), t.make_empty())
 	t.pending_stmts << t.make_for_stmt(init,
 		t.make_infix(.logical_and, t.make_ident(result_name), cond), post, body_stmts, flat.Node{})
 	result := t.make_ident(result_name)
@@ -3148,7 +3150,7 @@ fn (mut t Transformer) make_map_elementwise_eq_call_with_seen(lhs flat.NodeId, r
 		raw_value_type
 	}
 	if key_type.len == 0 || value_type.len == 0 {
-		return t.make_call_typed('v3_map_map_eq', arr2(lhs, rhs), 'bool')
+		return t.make_call_typed('v3_map_map_eq', [lhs, rhs], 'bool')
 	}
 	lhs_value := t.stable_transformed_expr_for_reuse(lhs, map_type, 'map_eq_lhs')
 	rhs_value := t.stable_transformed_expr_for_reuse(rhs, map_type, 'map_eq_rhs')
@@ -3177,7 +3179,7 @@ fn (mut t Transformer) make_map_elementwise_eq_call_with_seen(lhs flat.NodeId, r
 	failed := t.make_infix(.logical_or, missing, value_diff)
 	active := t.make_infix(.logical_and, t.make_ident(result_name), failed)
 	set_false := t.make_assign(t.make_ident(result_name), t.make_bool_literal(false))
-	body << t.make_if(active, t.make_block(arr1(set_false)), t.make_empty())
+	body << t.make_if(active, t.make_block([set_false]), t.make_empty())
 	start := t.a.children.len
 	t.a.children << key_ident
 	t.a.children << val_ident
@@ -3247,11 +3249,11 @@ fn (mut t Transformer) make_interface_semantic_eq_expr(lhs flat.NodeId, rhs flat
 	empty_eq := if t.is_builtin_ierror_interface_name(iface) {
 		lhs_addr := t.make_prefix(.amp, lhs_value)
 		rhs_addr := t.make_prefix(.amp, rhs_value)
-		lhs_msg := t.make_call_typed('IError__msg', arr1(lhs_addr), 'string')
-		rhs_msg := t.make_call_typed('IError__msg', arr1(rhs_addr), 'string')
-		msg_eq := t.make_call_typed('string__eq', arr2(lhs_msg, rhs_msg), 'bool')
-		lhs_code := t.make_call_typed('IError__code', arr1(lhs_addr), 'int')
-		rhs_code := t.make_call_typed('IError__code', arr1(rhs_addr), 'int')
+		lhs_msg := t.make_call_typed('IError__msg', [lhs_addr], 'string')
+		rhs_msg := t.make_call_typed('IError__msg', [rhs_addr], 'string')
+		msg_eq := t.make_call_typed('string__eq', [lhs_msg, rhs_msg], 'bool')
+		lhs_code := t.make_call_typed('IError__code', [lhs_addr], 'int')
+		rhs_code := t.make_call_typed('IError__code', [rhs_addr], 'int')
 		code_eq := t.make_infix(.eq, lhs_code, rhs_code)
 		t.make_infix(.logical_and, zero_tags, t.make_infix(.logical_and, msg_eq, code_eq))
 	} else {

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -1451,7 +1451,7 @@ fn (mut t Transformer) try_lower_join_path_call(id flat.NodeId, node flat.Node) 
 	mut result := t.transform_expr(t.a.child(&node, 1))
 	for i in 2 .. node.children_count {
 		arg := t.transform_expr(t.a.child(&node, i))
-		result = t.make_call_typed('os.join_path_single', arr2(result, arg), 'string')
+		result = t.make_call_typed('os.join_path_single', [result, arg], 'string')
 	}
 	return result
 }
@@ -3658,8 +3658,10 @@ fn (mut t Transformer) pack_variadic_args(node flat.Node, first_arg int, elem_ty
 			t.make_int_literal(0), t.make_int_literal(1)), array_type)
 		value_name := t.new_temp('vararg')
 		t.pending_stmts << t.make_decl_assign_typed(value_name, named_arg, expected_enum)
-		t.pending_stmts << t.make_expr_stmt(t.make_call_typed('array_push', arr2(t.make_prefix(.amp,
-			t.make_ident(tmp_name)), t.make_prefix(.amp, t.make_ident(value_name))), 'void'))
+		t.pending_stmts << t.make_expr_stmt(t.make_call_typed('array_push', [
+			t.make_prefix(.amp, t.make_ident(tmp_name)),
+			t.make_prefix(.amp, t.make_ident(value_name)),
+		], 'void'))
 		t.set_var_type(tmp_name, array_type)
 		return t.make_ident(tmp_name)
 	}
@@ -3779,8 +3781,10 @@ fn (mut t Transformer) append_variadic_value_push(tmp_name string, value flat.No
 		storage_value := if elem_type is types.Interface { t.make_paren(value) } else { value }
 		t.pending_stmts << t.make_decl_assign_typed(value_name, storage_value, expected_elem)
 	}
-	t.pending_stmts << t.make_expr_stmt(t.make_call_typed('array_push', arr2(t.make_prefix(.amp,
-		t.make_ident(tmp_name)), t.make_prefix(.amp, t.make_ident(value_name))), 'void'))
+	t.pending_stmts << t.make_expr_stmt(t.make_call_typed('array_push', [
+		t.make_prefix(.amp, t.make_ident(tmp_name)),
+		t.make_prefix(.amp, t.make_ident(value_name)),
+	], 'void'))
 }
 
 fn variadic_elem_is_voidptr(typ types.Type) bool {
@@ -4268,7 +4272,7 @@ fn (t &Transformer) enum_str_method_name(typ string) ?string {
 // one. Mirrors the struct-str qualification so the C name matches cgen's enum_decls naming.
 fn (mut t Transformer) enum_autostr_call(expr flat.NodeId, typ string) flat.NodeId {
 	qualified := t.enum_autostr_type_name(typ)
-	return t.make_call_typed('${c_name(qualified)}__autostr', arr1(expr), 'string')
+	return t.make_call_typed('${c_name(qualified)}__autostr', [expr], 'string')
 }
 
 fn (t &Transformer) enum_autostr_type_name(typ string) string {
@@ -4404,7 +4408,7 @@ fn (mut t Transformer) wrap_string_conversion(expr flat.NodeId, typ string) flat
 			}
 			if parsed is types.Enum {
 				if method := t.enum_str_method_name(clean_typ) {
-					return t.make_call_typed(method, arr1(expr), 'string')
+					return t.make_call_typed(method, [expr], 'string')
 				}
 				return t.enum_autostr_call(expr, clean_typ)
 			}
@@ -4413,14 +4417,14 @@ fn (mut t Transformer) wrap_string_conversion(expr flat.NodeId, typ string) flat
 			qparsed := t.tc.parse_type(qtyp)
 			if qparsed is types.Enum {
 				if method := t.enum_str_method_name(qtyp) {
-					return t.make_call_typed(method, arr1(expr), 'string')
+					return t.make_call_typed(method, [expr], 'string')
 				}
 				return t.enum_autostr_call(expr, qtyp)
 			}
 		}
 	}
 	if is_ref && clean_typ == 'string' {
-		return t.make_call_typed('ptr_str', arr1(expr), 'string')
+		return t.make_call_typed('ptr_str', [expr], 'string')
 	}
 	if clean_typ == 'string' {
 		return expr
@@ -4435,8 +4439,8 @@ fn (mut t Transformer) wrap_string_conversion(expr flat.NodeId, typ string) flat
 	}
 	if clean_typ.starts_with('chan ') {
 		channel_value := if is_ref { t.make_prefix(.mul, expr) } else { expr }
-		return t.make_call_typed('v3_chan_str', arr2(channel_value,
-			t.make_string_literal(clean_typ[5..].trim_space())), 'string')
+		return t.make_call_typed('v3_chan_str', [channel_value,
+			t.make_string_literal(clean_typ[5..].trim_space())], 'string')
 	}
 	if clean_typ.starts_with('fn(') || clean_typ.starts_with('fn (') {
 		return t.make_string_literal(stringify_fn_type_display(clean_typ))
@@ -4469,77 +4473,76 @@ fn (mut t Transformer) wrap_string_conversion(expr flat.NodeId, typ string) flat
 			method_name := '${iface_name}.str'
 			t.mark_fn_used_name(method_name)
 			t.mark_interface_method_implementers_used(iface_name, 'str')
-			return t.make_call_typed(method_name, arr1(t.make_prefix(.amp, value)), 'string')
+			return t.make_call_typed(method_name, [t.make_prefix(.amp, value)], 'string')
 		}
 	}
 	if is_ref || clean_typ in ['voidptr', 'byteptr', 'charptr'] {
-		return t.make_call_typed('ptr_str', arr1(expr), 'string')
+		return t.make_call_typed('ptr_str', [expr], 'string')
 	}
 	if clean_typ == 'IError' || clean_typ == 'builtin.IError' {
-		return t.make_call_typed('IError.str', arr1(expr), 'string')
+		return t.make_call_typed('IError.str', [expr], 'string')
 	}
 	if iface_name.len > 0 {
 		str_key := '${iface_name}.str'
 		known_str := str_key in t.fn_ret_types || (!isnil(t.tc) && str_key in t.tc.fn_ret_types)
 		if known_str {
-			return t.make_call_typed(str_key, arr1(expr), 'string')
+			return t.make_call_typed(str_key, [expr], 'string')
 		}
 		return t.lower_interface_auto_str(expr, iface_name)
 	}
 	if clean_typ.starts_with('[]') || clean_typ.starts_with('map[') {
 		if method_name := t.resolve_receiver_method_for_type(clean_typ, 'str') {
 			t.mark_fn_used_name(method_name)
-			return t.make_call_typed(method_name, arr1(expr), 'string')
+			return t.make_call_typed(method_name, [expr], 'string')
 		}
 	}
 	match clean_typ {
 		'bool' {
-			return t.make_call_typed('bool.str', arr1(expr), 'string')
+			return t.make_call_typed('bool.str', [expr], 'string')
 		}
 		'u8', 'byte', 'u16', 'u32', 'usize' {
 			// C integer promotion would pass an untruncated `int` into the u64
 			// param (`u8(255) + u8(1)` is 256 in C); cast back to the value
 			// type first so the arithmetic wraps at the V type's width.
 			truncated := t.make_cast(clean_typ, expr, clean_typ)
-			return t.make_call_typed('strconv__format_uint',
-				arr2(truncated, t.make_int_literal(10)), 'string')
-		}
-		'u64' {
-			return t.make_call_typed('u64.str', arr1(expr), 'string')
-		}
-		'int', 'int literal' {
-			return t.make_call_typed('int.str', arr1(expr), 'string')
-		}
-		'i8' {
-			return t.make_call_typed('i8.str', arr1(expr), 'string')
-		}
-		'i16' {
-			return t.make_call_typed('i16.str', arr1(expr), 'string')
-		}
-		'i32' {
-			return t.make_call_typed('i32.str', arr1(expr), 'string')
-		}
-		'i64' {
-			return t.make_call_typed('i64.str', arr1(expr), 'string')
-		}
-		'char' {
-			return t.make_call_typed('v3_char_string', arr1(t.make_cast('int', expr, 'int')),
+			return t.make_call_typed('strconv__format_uint', [truncated, t.make_int_literal(10)],
 				'string')
 		}
+		'u64' {
+			return t.make_call_typed('u64.str', [expr], 'string')
+		}
+		'int', 'int literal' {
+			return t.make_call_typed('int.str', [expr], 'string')
+		}
+		'i8' {
+			return t.make_call_typed('i8.str', [expr], 'string')
+		}
+		'i16' {
+			return t.make_call_typed('i16.str', [expr], 'string')
+		}
+		'i32' {
+			return t.make_call_typed('i32.str', [expr], 'string')
+		}
+		'i64' {
+			return t.make_call_typed('i64.str', [expr], 'string')
+		}
+		'char' {
+			return t.make_call_typed('v3_char_string', [t.make_cast('int', expr, 'int')], 'string')
+		}
 		'isize' {
-			return t.make_call_typed('strconv__format_int', arr2(expr, t.make_int_literal(10)),
+			return t.make_call_typed('strconv__format_int', [expr, t.make_int_literal(10)],
 				'string')
 		}
 		'f32' {
-			return t.make_call_typed('f32.str', arr1(expr), 'string')
+			return t.make_call_typed('f32.str', [expr], 'string')
 		}
 		'f64', 'float literal' {
-			return t.make_call_typed('f64.str', arr1(expr), 'string')
+			return t.make_call_typed('f64.str', [expr], 'string')
 		}
 		else {
 			if clean_typ in t.enum_types {
 				if method := t.enum_str_method_name(clean_typ) {
-					return t.make_call_typed(method, arr1(expr), 'string')
+					return t.make_call_typed(method, [expr], 'string')
 				}
 				return t.enum_autostr_call(expr, clean_typ)
 			}
@@ -4550,7 +4553,7 @@ fn (mut t Transformer) wrap_string_conversion(expr flat.NodeId, typ string) flat
 			}
 			if qenum in t.enum_types {
 				if method := t.enum_str_method_name(qenum) {
-					return t.make_call_typed(method, arr1(expr), 'string')
+					return t.make_call_typed(method, [expr], 'string')
 				}
 				return t.enum_autostr_call(expr, qenum)
 			}
@@ -4561,7 +4564,7 @@ fn (mut t Transformer) wrap_string_conversion(expr flat.NodeId, typ string) flat
 				qualified := aggregate_type
 				if str_fn := t.aggregate_str_method_name(qualified) {
 					t.mark_fn_used_name(str_fn)
-					return t.make_call_typed(str_fn, arr1(expr), 'string')
+					return t.make_call_typed(str_fn, [expr], 'string')
 				}
 				if t.building_v && t.auto_str_synthesis_type != qualified {
 					return t.request_auto_str_helper(expr, qualified)
@@ -4578,7 +4581,7 @@ fn (mut t Transformer) wrap_string_conversion(expr flat.NodeId, typ string) flat
 			} else if clean_typ.len > 0 && clean_typ.starts_with('map[') {
 				return t.lower_map_str(expr, clean_typ)
 			} else if clean_typ == 'rune' {
-				return t.make_call_typed('rune.str', arr1(expr), 'string')
+				return t.make_call_typed('rune.str', [expr], 'string')
 			} else {
 				return expr
 			}
@@ -4614,8 +4617,9 @@ fn (mut t Transformer) lower_interface_auto_str_with_nil(expr flat.NodeId, iface
 			t.make_int_literal(0))
 		tag_is_zero := t.make_infix(.eq, tag, t.make_int_literal(0))
 		nil_cond := t.make_infix(.logical_and, tag_is_zero, object_is_nil)
-		t.pending_stmts << t.make_if(nil_cond, t.make_block(arr1(t.make_assign(t.make_ident(result_name),
-			t.make_string_literal('nil')))), t.make_empty())
+		t.pending_stmts << t.make_if(nil_cond, t.make_block([
+			t.make_assign(t.make_ident(result_name), t.make_string_literal('nil')),
+		]), t.make_empty())
 	}
 	impl_names := if t.is_builtin_ierror_interface_name(iface_name) {
 		t.tc.ierror_impl_names()
@@ -4808,7 +4812,7 @@ fn (mut t Transformer) request_auto_str_helper(expr flat.NodeId, aggregate strin
 		}
 	}
 	t.mark_fn_used_name(helper)
-	return t.make_call_typed(helper, arr1(expr), 'string')
+	return t.make_call_typed(helper, [expr], 'string')
 }
 
 fn (t &Transformer) has_pending_auto_str_helpers() bool {
@@ -5008,11 +5012,11 @@ fn (mut t Transformer) lower_ref_str_guarded(expr flat.NodeId, aggregate string,
 	saved := t.pending_stmts.clone()
 	t.pending_stmts.clear()
 	value_str := if str_fn.len > 0 && t.str_method_has_pointer_receiver(str_fn) {
-		t.make_call_typed(str_fn, arr1(t.make_ident(ptr_name)), 'string')
+		t.make_call_typed(str_fn, [t.make_ident(ptr_name)], 'string')
 	} else if str_fn.len > 0 {
 		value := t.make_prefix(.mul, t.make_ident(ptr_name))
 		t.set_node_typ(int(value), aggregate)
-		t.make_call_typed(str_fn, arr1(value), 'string')
+		t.make_call_typed(str_fn, [value], 'string')
 	} else {
 		t.wrap_string_conversion(t.make_prefix(.mul, t.make_ident(ptr_name)), aggregate)
 	}
@@ -5050,8 +5054,9 @@ fn (mut t Transformer) lower_ref_value_str(expr flat.NodeId, typ string, nil_tex
 	t.set_var_type(ptr_name, typ)
 	t.pending_stmts << t.make_decl_assign_typed(res_name, t.make_string_literal(nil_text), 'string')
 	if t.ref_value_str_reaches_large_circular_graph(elem_type) {
-		then_body := t.make_block(arr1(t.make_assign(t.make_ident(res_name),
-			t.make_string_literal('&<circular>'))))
+		then_body := t.make_block([
+			t.make_assign(t.make_ident(res_name), t.make_string_literal('&<circular>')),
+		])
 		cond := t.make_infix(.ne, t.make_ident(ptr_name), t.a.add(.nil_literal))
 		t.pending_stmts << t.make_if(cond, then_body, t.make_empty())
 		t.unset_var_type(ptr_name)
@@ -5256,7 +5261,7 @@ fn (mut t Transformer) alias_custom_str_call(expr flat.NodeId, alias_name string
 			receiver = t.make_ident(tmp_name)
 		}
 	}
-	return t.make_call_typed(str_fn, arr1(receiver), 'string')
+	return t.make_call_typed(str_fn, [receiver], 'string')
 }
 
 fn (mut t Transformer) alias_custom_str_method_name(alias_name string) ?string {
@@ -5445,8 +5450,8 @@ fn (mut t Transformer) lower_struct_str(expr flat.NodeId, struct_type string) ?f
 		if t.struct_str_field_needs_indent(raw_field_type) {
 			t.mark_fn_used_name('string.replace')
 			t.mark_fn_used_name('string__replace')
-			field_str = t.make_call_typed('string.replace', arr3(field_str,
-				t.make_string_literal('\n'), t.make_string_literal('\n    ')), 'string')
+			field_str = t.make_call_typed('string.replace', [field_str, t.make_string_literal('\n'),
+				t.make_string_literal('\n    ')], 'string')
 		}
 		result = t.string_plus(result, t.make_string_literal('    ${field.name}: '))
 		result = t.string_plus(result, field_str)
@@ -5607,10 +5612,10 @@ fn (mut t Transformer) lower_charptr_struct_field_str(expr flat.NodeId) flat.Nod
 	t.pending_stmts << t.make_decl_assign_typed(res_name, t.make_string_literal('C""'), 'string')
 	t.mark_fn_used_name('charptr.vstring')
 	t.mark_fn_used_name('charptr__vstring')
-	raw := t.make_call_typed('charptr.vstring', arr1(t.make_ident(ptr_name)), 'string')
+	raw := t.make_call_typed('charptr.vstring', [t.make_ident(ptr_name)], 'string')
 	quoted := t.string_plus(t.string_plus(t.make_string_literal('C"'), raw),
 		t.make_string_literal('"'))
-	then_body := t.make_block(arr1(t.make_assign(t.make_ident(res_name), quoted)))
+	then_body := t.make_block([t.make_assign(t.make_ident(res_name), quoted)])
 	cond := t.make_infix(.ne, t.make_ident(ptr_name), t.a.add(.nil_literal))
 	t.pending_stmts << t.make_if(cond, then_body, t.make_empty())
 	return t.make_ident(res_name)
@@ -6248,7 +6253,7 @@ fn (mut t Transformer) build_sum_str_chain(base flat.NodeId, tag flat.NodeId, su
 	cond := t.make_infix(.eq, tag, t.make_int_literal(t.sum_type_index(sum_name, variant)))
 	then_block := t.make_block(then_stmts)
 	else_expr := t.build_sum_str_chain(base, tag, sum_name, sum_display, variants, idx + 1)
-	else_block := t.make_block(arr1(t.make_expr_stmt(else_expr)))
+	else_block := t.make_block([t.make_expr_stmt(else_expr)])
 	start := t.a.children.len
 	t.a.children << cond
 	t.a.children << then_block
@@ -6270,7 +6275,7 @@ fn (mut t Transformer) wrap_formatted_string_conversion(expr flat.NodeId, typ st
 		// lowercase form first so width/zero-padding flags are honored, then
 		// upper-case the whole result.
 		lowered := t.wrap_formatted_string_conversion(expr, typ, format.replace('X', 'x'))
-		return t.make_call_typed('v3_string_upper_ascii', arr1(lowered), 'string')
+		return t.make_call_typed('v3_string_upper_ascii', [lowered], 'string')
 	}
 	mut clean_typ := typ
 	if clean_typ.starts_with('&') {
@@ -6293,10 +6298,10 @@ fn (mut t Transformer) wrap_formatted_string_conversion(expr flat.NodeId, typ st
 	if repeat_count, upper := string_repeat_format(format) {
 		if clean_typ == 'string' || normalized_typ == 'string' {
 			t.mark_fn_used('string__repeat')
-			repeated := t.make_call_typed('string__repeat', arr2(expr,
-				t.make_int_literal(repeat_count)), 'string')
+			repeated := t.make_call_typed('string__repeat',
+				[expr, t.make_int_literal(repeat_count)], 'string')
 			return if upper {
-				t.make_call_typed('v3_string_upper_ascii', arr1(repeated), 'string')
+				t.make_call_typed('v3_string_upper_ascii', [repeated], 'string')
 			} else {
 				repeated
 			}
@@ -6305,7 +6310,7 @@ fn (mut t Transformer) wrap_formatted_string_conversion(expr flat.NodeId, typ st
 	if format == 'p' && (normalized_typ.starts_with('&')
 		|| clean_typ in ['voidptr', 'byteptr', 'charptr']
 		|| t.expr_is_mut_param_pointer_value(expr)) {
-		return t.make_call_typed('ptr_str', arr1(expr), 'string')
+		return t.make_call_typed('ptr_str', [expr], 'string')
 	}
 	if normalized_typ.starts_with('&') && format != 'p' {
 		elem_type := normalized_typ[1..]
@@ -6337,12 +6342,13 @@ fn (mut t Transformer) wrap_formatted_string_conversion(expr flat.NodeId, typ st
 			} else {
 				t.make_cast('f64', expr, 'f64')
 			}
-			mut formatted := t.make_call_typed('v3_f64_fixed', arr2(arg,
-				t.make_int_literal(decimal_format.precision)), 'string')
+			mut formatted := t.make_call_typed('v3_f64_fixed', [arg,
+				t.make_int_literal(decimal_format.precision)], 'string')
 			if decimal_format.width > 0 || decimal_format.left {
 				left := if decimal_format.left { 1 } else { 0 }
-				formatted = t.make_call_typed('v3_string_pad', arr3(formatted,
-					t.make_int_literal(decimal_format.width), t.make_int_literal(left)), 'string')
+				formatted = t.make_call_typed('v3_string_pad', [formatted,
+					t.make_int_literal(decimal_format.width),
+					t.make_int_literal(left)], 'string')
 			}
 			return formatted
 		}
@@ -6354,16 +6360,18 @@ fn (mut t Transformer) wrap_formatted_string_conversion(expr flat.NodeId, typ st
 			} else {
 				t.make_cast('f64', expr, 'f64')
 			}
-			mut formatted := t.make_call_typed('v3_f64_exp', arr3(arg,
-				t.make_int_literal(exp_format.precision), t.make_int_literal(if exp_format.upper {
-				1
-			} else {
-				0
-			})), 'string')
+			mut formatted := t.make_call_typed('v3_f64_exp', [arg,
+				t.make_int_literal(exp_format.precision),
+				t.make_int_literal(if exp_format.upper {
+					1
+				} else {
+					0
+				})],
+				'string')
 			if exp_format.width > 0 || exp_format.left {
 				left := if exp_format.left { 1 } else { 0 }
-				formatted = t.make_call_typed('v3_string_pad', arr3(formatted,
-					t.make_int_literal(exp_format.width), t.make_int_literal(left)), 'string')
+				formatted = t.make_call_typed('v3_string_pad', [formatted,
+					t.make_int_literal(exp_format.width), t.make_int_literal(left)], 'string')
 			}
 			return formatted
 		}
@@ -6376,9 +6384,9 @@ fn (mut t Transformer) wrap_formatted_string_conversion(expr flat.NodeId, typ st
 			expr
 		}
 		t.mark_fn_used(fn_name)
-		formatted := t.make_call_typed(fn_name, arr1(arg), 'string')
+		formatted := t.make_call_typed(fn_name, [arg], 'string')
 		return if format == 'G' {
-			t.make_call_typed('v3_string_upper_ascii', arr1(formatted), 'string')
+			t.make_call_typed('v3_string_upper_ascii', [formatted], 'string')
 		} else {
 			formatted
 		}
@@ -6390,16 +6398,19 @@ fn (mut t Transformer) wrap_formatted_string_conversion(expr flat.NodeId, typ st
 			} else {
 				t.make_cast('f64', expr, 'f64')
 			}
-			mut formatted := t.make_call_typed('v3_f64_general', arr3(arg,
-				t.make_int_literal(general_format.precision), t.make_int_literal(if general_format.upper {
-				1
-			} else {
-				0
-			})), 'string')
+			mut formatted := t.make_call_typed('v3_f64_general', [arg,
+				t.make_int_literal(general_format.precision),
+				t.make_int_literal(if general_format.upper {
+					1
+				} else {
+					0
+				})],
+				'string')
 			if general_format.width > 0 || general_format.left {
 				left := if general_format.left { 1 } else { 0 }
-				formatted = t.make_call_typed('v3_string_pad', arr3(formatted,
-					t.make_int_literal(general_format.width), t.make_int_literal(left)), 'string')
+				formatted = t.make_call_typed('v3_string_pad', [formatted,
+					t.make_int_literal(general_format.width),
+					t.make_int_literal(left)], 'string')
 			}
 			return formatted
 		}
@@ -6412,14 +6423,16 @@ fn (mut t Transformer) wrap_formatted_string_conversion(expr flat.NodeId, typ st
 			} else {
 				t.make_cast('int', expr, 'int')
 			}
-			mut converted := t.make_call_typed('v3_char_string', arr1(arg), 'string')
+			mut converted := t.make_call_typed('v3_char_string', [arg], 'string')
 			if char_format.width > 1 || char_format.left {
-				converted = t.make_call_typed('v3_string_pad', arr3(converted,
-					t.make_int_literal(char_format.width), t.make_int_literal(if char_format.left {
-					1
-				} else {
-					0
-				})), 'string')
+				converted = t.make_call_typed('v3_string_pad', [converted,
+					t.make_int_literal(char_format.width),
+					t.make_int_literal(if char_format.left {
+						1
+					} else {
+						0
+					})],
+					'string')
 			}
 			return converted
 		}
@@ -6427,19 +6440,19 @@ fn (mut t Transformer) wrap_formatted_string_conversion(expr flat.NodeId, typ st
 	if base := integer_format_base(format) {
 		if clean_typ in ['u8', 'byte', 'u16', 'u32', 'u64', 'usize'] {
 			arg := t.widened_unsigned_format_arg(expr, clean_typ)
-			formatted := t.make_call_typed('strconv__format_uint', arr2(arg,
-				t.make_int_literal(base)), 'string')
+			formatted := t.make_call_typed('strconv__format_uint', [arg, t.make_int_literal(base)],
+				'string')
 			return if format == 'X' {
-				t.make_call_typed('v3_string_upper_ascii', arr1(formatted), 'string')
+				t.make_call_typed('v3_string_upper_ascii', [formatted], 'string')
 			} else {
 				formatted
 			}
 		}
 		if clean_typ in ['int', 'i8', 'i16', 'i32', 'i64', 'isize', 'rune'] {
-			formatted := t.make_call_typed('strconv__format_int', arr2(expr,
-				t.make_int_literal(base)), 'string')
+			formatted := t.make_call_typed('strconv__format_int', [expr, t.make_int_literal(base)],
+				'string')
 			return if format == 'X' {
-				t.make_call_typed('v3_string_upper_ascii', arr1(formatted), 'string')
+				t.make_call_typed('v3_string_upper_ascii', [formatted], 'string')
 			} else {
 				formatted
 			}
@@ -6448,25 +6461,25 @@ fn (mut t Transformer) wrap_formatted_string_conversion(expr flat.NodeId, typ st
 	if base_format := zero_padded_integer_base_format(format) {
 		converted := if clean_typ in ['u8', 'byte', 'u16', 'u32', 'u64', 'usize'] {
 			arg := t.widened_unsigned_format_arg(expr, clean_typ)
-			t.make_call_typed('strconv__format_uint', arr2(arg,
-				t.make_int_literal(base_format.base)), 'string')
+			t.make_call_typed('strconv__format_uint', [arg, t.make_int_literal(base_format.base)],
+				'string')
 		} else if clean_typ in ['int', 'i8', 'i16', 'i32', 'i64', 'isize', 'rune'] {
 			arg := if clean_typ == 'i64' {
 				expr
 			} else {
 				t.make_cast('i64', expr, 'i64')
 			}
-			t.make_call_typed('strconv__format_int',
-				arr2(arg, t.make_int_literal(base_format.base)), 'string')
+			t.make_call_typed('strconv__format_int', [arg, t.make_int_literal(base_format.base)],
+				'string')
 		} else {
 			t.wrap_string_conversion(expr, typ)
 		}
-		return t.make_call_typed('v3_string_zpad', arr2(converted,
-			t.make_int_literal(base_format.width)), 'string')
+		return t.make_call_typed('v3_string_zpad',
+			[converted, t.make_int_literal(base_format.width)], 'string')
 	}
 	if width := left_zero_padded_decimal_width(format) {
 		converted := t.wrap_formatted_string_conversion(expr, typ, 'd')
-		return t.make_call_typed('v3_string_rpad_zero', arr2(converted, t.make_int_literal(width)),
+		return t.make_call_typed('v3_string_rpad_zero', [converted, t.make_int_literal(width)],
 			'string')
 	}
 	if width := zero_padded_decimal_width(format) {
@@ -6474,8 +6487,7 @@ fn (mut t Transformer) wrap_formatted_string_conversion(expr flat.NodeId, typ st
 			'u16', 'u32', 'u64'] {
 			if clean_typ in ['u64', 'usize', 'u32', 'u16', 'u8', 'byte'] {
 				arg := t.widened_unsigned_format_arg(expr, clean_typ)
-				return t.make_call_typed('v3_u64_zpad', arr2(arg, t.make_int_literal(width)),
-					'string')
+				return t.make_call_typed('v3_u64_zpad', [arg, t.make_int_literal(width)], 'string')
 			}
 			if clean_typ in ['i64', 'isize', 'i32', 'i16', 'i8', 'rune'] {
 				arg := if clean_typ == 'i64' {
@@ -6483,29 +6495,26 @@ fn (mut t Transformer) wrap_formatted_string_conversion(expr flat.NodeId, typ st
 				} else {
 					t.make_cast('i64', expr, 'i64')
 				}
-				return t.make_call_typed('v3_i64_zpad', arr2(arg, t.make_int_literal(width)),
-					'string')
+				return t.make_call_typed('v3_i64_zpad', [arg, t.make_int_literal(width)], 'string')
 			}
-			return t.make_call_typed('v3_int_zpad', arr2(expr, t.make_int_literal(width)), 'string')
+			return t.make_call_typed('v3_int_zpad', [expr, t.make_int_literal(width)], 'string')
 		}
 	}
 	if width := static_format_width(format) {
 		mut converted := if base := integer_format_base_suffix(format) {
 			if clean_typ in ['u8', 'byte', 'u16', 'u32', 'u64', 'usize'] {
 				arg := t.widened_unsigned_format_arg(expr, clean_typ)
-				t.make_call_typed('strconv__format_uint', arr2(arg, t.make_int_literal(base)),
-					'string')
+				t.make_call_typed('strconv__format_uint', [arg, t.make_int_literal(base)], 'string')
 			} else if clean_typ in ['int', 'i8', 'i16', 'i32', 'i64', 'isize', 'rune'] {
-				t.make_call_typed('strconv__format_int', arr2(expr, t.make_int_literal(base)),
-					'string')
+				t.make_call_typed('strconv__format_int', [expr, t.make_int_literal(base)], 'string')
 			} else {
 				t.wrap_string_conversion(expr, typ)
 			}
 		} else {
 			t.wrap_string_conversion(expr, typ)
 		}
-		return t.make_call_typed('v3_string_pad', arr3(converted, t.make_int_literal(width),
-			t.make_int_literal(0)), 'string')
+		return t.make_call_typed('v3_string_pad', [converted, t.make_int_literal(width),
+			t.make_int_literal(0)], 'string')
 	}
 	return t.wrap_string_conversion(expr, typ)
 }
@@ -6551,7 +6560,7 @@ fn (mut t Transformer) lower_pointer_format_s(expr flat.NodeId, typ string, elem
 	t.set_node_typ(int(value), elem_type)
 	value_str := t.string_plus(t.make_string_literal('&'), t.wrap_string_conversion(value,
 		elem_type))
-	then_body := t.make_block(arr1(t.make_assign(t.make_ident(res_name), value_str)))
+	then_body := t.make_block([t.make_assign(t.make_ident(res_name), value_str)])
 	cond := t.make_infix(.ne, t.make_ident(ptr_name), t.a.add(.nil_literal))
 	t.pending_stmts << t.make_if(cond, then_body, t.make_empty())
 	return t.make_ident(res_name)
@@ -6560,21 +6569,21 @@ fn (mut t Transformer) lower_pointer_format_s(expr flat.NodeId, typ string, elem
 fn (mut t Transformer) dynamic_format_conversion(expr flat.NodeId, typ string, clean_typ string, format string) ?flat.NodeId {
 	if width := t.dynamic_width_expr(format) {
 		converted := t.wrap_string_conversion(expr, typ)
-		return t.make_call_typed('v3_string_pad', arr3(converted, width, t.make_int_literal(0)),
+		return t.make_call_typed('v3_string_pad', [converted, width, t.make_int_literal(0)],
 			'string')
 	}
 	if width := t.dynamic_zero_width_expr(format) {
 		if clean_typ in ['int', 'i8', 'i16', 'i32', 'i64', 'isize', 'rune', 'usize', 'u8', 'byte',
 			'u16', 'u32', 'u64'] {
 			converted := t.wrap_formatted_string_conversion(expr, typ, 'd')
-			return t.make_call_typed('v3_string_zpad', arr2(converted, width), 'string')
+			return t.make_call_typed('v3_string_zpad', [converted, width], 'string')
 		}
 	}
 	if width := t.dynamic_plus_width_expr(format) {
 		if clean_typ in ['int', 'i8', 'i16', 'i32', 'i64', 'isize', 'rune'] {
 			converted := t.signed_plus_string(expr, clean_typ)
-			return t.make_call_typed('v3_string_pad',
-				arr3(converted, width, t.make_int_literal(0)), 'string')
+			return t.make_call_typed('v3_string_pad', [converted, width, t.make_int_literal(0)],
+				'string')
 		}
 	}
 	if width_name, precision_name := dynamic_float_width_precision(format) {
@@ -6584,10 +6593,10 @@ fn (mut t Transformer) dynamic_format_conversion(expr flat.NodeId, typ string, c
 			} else {
 				t.make_cast('f64', expr, 'f64')
 			}
-			formatted := t.make_call_typed('v3_f64_fixed', arr2(arg, t.make_ident(precision_name)),
+			formatted := t.make_call_typed('v3_f64_fixed', [arg, t.make_ident(precision_name)],
 				'string')
-			return t.make_call_typed('v3_string_pad', arr3(formatted, t.make_ident(width_name),
-				t.make_int_literal(0)), 'string')
+			return t.make_call_typed('v3_string_pad', [formatted, t.make_ident(width_name),
+				t.make_int_literal(0)], 'string')
 		}
 	}
 	return none
@@ -6654,8 +6663,10 @@ fn (mut t Transformer) signed_plus_string(expr flat.NodeId, typ string) flat.Nod
 	base_text := t.wrap_formatted_string_conversion(value, typ, 'd')
 	t.pending_stmts << t.make_decl_assign_typed(text_name, base_text, 'string')
 	cond := t.make_infix(.ge, value, t.make_int_literal(0))
-	then_body := t.make_block(arr1(t.make_assign(t.make_ident(text_name), t.string_plus(t.make_string_literal('+'),
-		t.make_ident(text_name)))))
+	then_body := t.make_block([
+		t.make_assign(t.make_ident(text_name), t.string_plus(t.make_string_literal('+'),
+			t.make_ident(text_name))),
+	])
 	t.pending_stmts << t.make_if(cond, then_body, t.make_empty())
 	return t.make_ident(text_name)
 }
@@ -7043,14 +7054,14 @@ fn (mut t Transformer) generic_receiver_str_call(expr flat.NodeId, typ string) ?
 	}
 	method_name := '${clean_typ}.str'
 	t.mark_fn_used_name(method_name)
-	return t.make_call_typed(method_name, arr1(expr), 'string')
+	return t.make_call_typed(method_name, [expr], 'string')
 }
 
 // append_string builds `result = result + piece` using the runtime string concat helper.
 // Using string__plus directly (instead of `+=`) keeps the synthesized node independent of
 // type resolution for the freshly-introduced temp.
 fn (mut t Transformer) append_string(result_name string, piece flat.NodeId) flat.NodeId {
-	concat := t.make_call_typed('string__plus', arr2(t.make_ident(result_name), piece), 'string')
+	concat := t.make_call_typed('string__plus', [t.make_ident(result_name), piece], 'string')
 	return t.make_assign(t.make_ident(result_name), concat)
 }
 
@@ -7121,7 +7132,7 @@ fn (mut t Transformer) lower_array_str(arr_expr flat.NodeId, base_type string) f
 	// `if idx > 0 { result = result + ', ' }`
 	sep_cond := t.make_infix(.gt, t.make_ident(idx_name), t.make_int_literal(0))
 	sep_stmt := t.append_string(result_name, t.make_string_literal(', '))
-	loop_body << t.make_if(sep_cond, t.make_block(arr1(sep_stmt)), t.make_empty())
+	loop_body << t.make_if(sep_cond, t.make_block([sep_stmt]), t.make_empty())
 	// element text (recurses; may push its own statements for nested arrays/optionals)
 	t.set_var_type(elem_name, elem_type)
 	elem_str := if t.array_elem_str_is_direct_circular(elem_type) {
@@ -7289,9 +7300,9 @@ fn (mut t Transformer) lower_map_str(map_expr flat.NodeId, map_type string) flat
 	} else {
 		t.transform_expr_for_type(map_expr, map_type)
 	}
-	return t.make_call_typed('v3_map_str', arr4(lowered, t.make_int_literal(key_kind),
-		t.make_int_literal(value_kind),
-		t.make_int_literal(t.map_str_fixed_len_for_type(value_type))), 'string')
+	return t.make_call_typed('v3_map_str', [lowered, t.make_int_literal(key_kind),
+		t.make_int_literal(value_kind), t.make_int_literal(t.map_str_fixed_len_for_type(value_type))],
+		'string')
 }
 
 fn (t &Transformer) expr_is_transformed_deref(id flat.NodeId) bool {
@@ -7319,7 +7330,7 @@ fn (mut t Transformer) lower_typed_map_str(map_expr flat.NodeId, map_type string
 	value_kind := t.map_str_kind_for_type(value_type)
 	key_storage_type := t.map_key_storage_type(key_type)
 	keys_type := '[]${key_storage_type}'
-	keys_call := t.make_call_typed('map__keys', arr1(t.runtime_addr(base, map_type)), keys_type)
+	keys_call := t.make_call_typed('map__keys', [t.runtime_addr(base, map_type)], keys_type)
 	prefix << t.make_decl_assign_typed(result_name, t.make_string_literal('{'), 'string')
 	prefix << t.make_decl_assign_typed(keys_name, keys_call, keys_type)
 	init := t.make_decl_assign_typed(idx_name, t.make_int_literal(0), 'int')
@@ -7337,7 +7348,7 @@ fn (mut t Transformer) lower_typed_map_str(map_expr flat.NodeId, map_type string
 	loop_body << value_decl
 	sep_cond := t.make_infix(.gt, t.make_ident(idx_name), t.make_int_literal(0))
 	sep_stmt := t.append_string(result_name, t.make_string_literal(', '))
-	loop_body << t.make_if(sep_cond, t.make_block(arr1(sep_stmt)), t.make_empty())
+	loop_body << t.make_if(sep_cond, t.make_block([sep_stmt]), t.make_empty())
 	key_str := t.map_str_loop_piece(key_name, key_type, key_kind, 0)
 	t.drain_pending(mut loop_body)
 	loop_body << t.append_string(result_name, key_str)
@@ -7356,9 +7367,12 @@ fn (mut t Transformer) lower_typed_map_str(map_expr flat.NodeId, map_type string
 
 fn (mut t Transformer) map_str_loop_piece(name string, typ string, kind int, fixed_len int) flat.NodeId {
 	if kind != 0 {
-		return t.make_call_typed('v3_map_str_piece', arr4(t.make_prefix(.amp, t.make_ident(name)),
-			t.make_int_literal(kind), t.make_sizeof_type(typ), t.make_int_literal(fixed_len)),
-			'string')
+		return t.make_call_typed('v3_map_str_piece', [
+			t.make_prefix(.amp, t.make_ident(name)),
+			t.make_int_literal(kind),
+			t.make_sizeof_type(typ),
+			t.make_int_literal(fixed_len),
+		], 'string')
 	}
 	t.set_var_type(name, typ)
 	piece := if typ.starts_with('&') {
@@ -7493,14 +7507,15 @@ fn (mut t Transformer) wrap_optional_string_conversion(expr flat.NodeId, typ str
 	some_str := t.string_plus(t.string_plus(t.make_string_literal(option_prefix), value_str),
 		t.make_string_literal(')'))
 	assign_some := t.make_assign(t.make_ident(res_name), some_str)
-	t.pending_stmts << t.make_if(t.make_selector(t.make_ident(opt_name), 'ok', 'bool'),
-		t.make_block(arr1(assign_some)), t.make_empty())
+	t.pending_stmts << t.make_if(t.make_selector(t.make_ident(opt_name), 'ok', 'bool'), t.make_block([
+		assign_some,
+	]), t.make_empty())
 	return t.make_ident(res_name)
 }
 
 // string_plus supports string plus handling for Transformer.
 fn (mut t Transformer) string_plus(left flat.NodeId, right flat.NodeId) flat.NodeId {
-	return t.make_call_typed('string__plus', arr2(left, right), 'string')
+	return t.make_call_typed('string__plus', [left, right], 'string')
 }
 
 // is_flag_enum_type reports whether is flag enum type applies in transform.
@@ -7819,20 +7834,23 @@ fn (mut t Transformer) make_compiler_default_clone_value(source flat.NodeId, typ
 				}
 			}
 		}
-		cloned_err := t.make_call_typed('__v3_clone_owned_ierror', arr1(source_err), 'IError')
-		else_branch := t.make_block(arr1(t.make_assign_without_ownership_drop(t.make_ident(out_name), t.make_optional_none_with_err(clean,
-			cloned_err))))
+		cloned_err := t.make_call_typed('__v3_clone_owned_ierror', [source_err], 'IError')
+		else_branch := t.make_block([
+			t.make_assign_without_ownership_drop(t.make_ident(out_name), t.make_optional_none_with_err(clean,
+				cloned_err)),
+		])
 		t.pending_stmts << t.make_if(t.make_selector(stable_source, 'ok', 'bool'),
 			t.make_block(body), else_branch)
 		if source_is_owned_temporary {
-			t.pending_stmts << t.make_expr_stmt(t.make_call_typed('drop_owned',
-				arr1(stable_source), 'void'))
+			t.pending_stmts << t.make_expr_stmt(t.make_call_typed('drop_owned', [
+				stable_source,
+			], 'void'))
 		}
 		return t.make_ident(out_name)
 	}
 	if clean == 'string' {
 		t.mark_fn_used('string__clone')
-		return t.make_call_typed('string__clone', arr1(source), 'string')
+		return t.make_call_typed('string__clone', [source], 'string')
 	}
 	if clean.starts_with('[]') {
 		return t.make_compiler_default_array_clone_value(source, clean,
@@ -7861,7 +7879,7 @@ fn (mut t Transformer) make_compiler_default_clone_value(source flat.NodeId, typ
 				receiver = t.runtime_addr(source, clean)
 			}
 			t.mark_fn_used_name(method_name)
-			return t.make_call_typed(method_name, arr1(receiver), t.receiver_method_return_type(method_name,
+			return t.make_call_typed(method_name, [receiver], t.receiver_method_return_type(method_name,
 				clean))
 		}
 	}
@@ -7903,7 +7921,7 @@ fn (mut t Transformer) make_compiler_default_clone_value(source flat.NodeId, typ
 		if source_fields_are_owned {
 			cloned_name := t.new_temp('derived_clone_field')
 			t.pending_stmts << t.make_decl_assign_typed(cloned_name, cloned_field, field_type)
-			drop_call := t.make_call_typed('drop_owned', arr1(source_field), 'void')
+			drop_call := t.make_call_typed('drop_owned', [source_field], 'void')
 			t.pending_stmts << t.make_expr_stmt(drop_call)
 			cloned_field = t.make_ident(cloned_name)
 		}
@@ -7950,8 +7968,9 @@ fn (mut t Transformer) make_compiler_default_sum_clone_value(source flat.NodeId,
 		t.pending_stmts << t.make_if(cond, t.make_block(body), t.make_empty())
 	}
 	if source_is_owned_temporary {
-		t.pending_stmts << t.make_expr_stmt(t.make_call_typed('drop_owned', arr1(stable_source),
-			'void'))
+		t.pending_stmts << t.make_expr_stmt(t.make_call_typed('drop_owned', [
+			stable_source,
+		], 'void'))
 	}
 	result := t.make_ident(out_name)
 	t.set_node_typ(int(result), sum_type)
@@ -7973,7 +7992,7 @@ fn (mut t Transformer) request_default_clone_helper(source flat.NodeId, typ stri
 	t.mark_fn_used_name(helper)
 	address := t.runtime_addr(source, typ)
 	argument := t.make_cast('voidptr', address, 'voidptr')
-	return t.make_call_typed(helper, arr1(argument), typ)
+	return t.make_call_typed(helper, [argument], typ)
 }
 
 // synthesize_default_clone_helpers drains recursive compiler-provided IClone
@@ -8104,8 +8123,9 @@ fn (mut t Transformer) make_compiler_default_array_clone_value(source flat.NodeI
 	out_name := t.new_temp('derived_clone_array')
 	idx_name := t.new_temp('derived_clone_array_idx')
 	t.mark_fn_used('array__clone')
-	storage_clone := t.make_call_typed('array__clone', arr1(t.runtime_addr(stable_source,
-		array_type)), array_type)
+	storage_clone := t.make_call_typed('array__clone', [
+		t.runtime_addr(stable_source, array_type),
+	], array_type)
 	t.pending_stmts << t.make_decl_assign_typed(out_name, storage_clone, array_type)
 	init := t.make_decl_assign_typed(idx_name, t.make_int_literal(0), 'int')
 	cond := t.make_infix(.lt, t.make_ident(idx_name), t.make_selector(t.make_ident(out_name),
@@ -8122,8 +8142,9 @@ fn (mut t Transformer) make_compiler_default_array_clone_value(source flat.NodeI
 		skip_ownership_drops: true
 	})
 	if source_is_owned_temporary {
-		t.pending_stmts << t.make_expr_stmt(t.make_call_typed('drop_owned', arr1(stable_source),
-			'void'))
+		t.pending_stmts << t.make_expr_stmt(t.make_call_typed('drop_owned', [
+			stable_source,
+		], 'void'))
 	}
 	result := t.make_ident(out_name)
 	t.set_node_typ(int(result), array_type)
@@ -8160,8 +8181,9 @@ fn (mut t Transformer) make_compiler_default_fixed_array_clone_value(source flat
 		skip_ownership_drops: true
 	})
 	if source_is_owned_temporary {
-		t.pending_stmts << t.make_expr_stmt(t.make_call_typed('drop_owned', arr1(stable_source),
-			'void'))
+		t.pending_stmts << t.make_expr_stmt(t.make_call_typed('drop_owned', [
+			stable_source,
+		], 'void'))
 	}
 	result := t.make_ident(out_name)
 	t.set_node_typ(int(result), fixed_type)
@@ -8182,15 +8204,17 @@ fn (mut t Transformer) make_compiler_default_map_clone_value(source flat.NodeId,
 		'derived_clone_map_source')
 	if key_type.len == 0 || value_type.len == 0 || (!key_needs_clone && !value_needs_clone) {
 		t.mark_fn_used('map__clone')
-		storage_clone := t.make_call_typed('map__clone', arr1(t.runtime_addr(stable_source,
-			map_type)), map_type)
+		storage_clone := t.make_call_typed('map__clone', [
+			t.runtime_addr(stable_source, map_type),
+		], map_type)
 		if !source_is_owned_temporary {
 			return storage_clone
 		}
 		out_name := t.new_temp('derived_clone_map')
 		t.pending_stmts << t.make_decl_assign_typed(out_name, storage_clone, map_type)
-		t.pending_stmts << t.make_expr_stmt(t.make_call_typed('drop_owned', arr1(stable_source),
-			'void'))
+		t.pending_stmts << t.make_expr_stmt(t.make_call_typed('drop_owned', [
+			stable_source,
+		], 'void'))
 		result := t.make_ident(out_name)
 		t.set_node_typ(int(result), map_type)
 		return result
@@ -8224,8 +8248,9 @@ fn (mut t Transformer) make_compiler_default_map_clone_value(source flat.NodeId,
 	body << t.make_decl_assign_typed(value_name, cloned_value, value_type)
 	body << t.make_map_set_stmt(t.make_ident(out_name), map_type, map_key_name, value_name)
 	if clean_key_type == 'string' {
-		body << t.make_expr_stmt(t.make_call_typed('drop_owned', arr1(t.make_ident(key_name)),
-			'void'))
+		body << t.make_expr_stmt(t.make_call_typed('drop_owned', [
+			t.make_ident(key_name),
+		], 'void'))
 	}
 	start := t.a.children.len
 	t.a.children << t.make_ident(key_name)
@@ -8242,8 +8267,9 @@ fn (mut t Transformer) make_compiler_default_map_clone_value(source flat.NodeId,
 		skip_ownership_drops: true
 	})
 	if source_is_owned_temporary {
-		t.pending_stmts << t.make_expr_stmt(t.make_call_typed('drop_owned', arr1(stable_source),
-			'void'))
+		t.pending_stmts << t.make_expr_stmt(t.make_call_typed('drop_owned', [
+			stable_source,
+		], 'void'))
 	}
 	result := t.make_ident(out_name)
 	t.set_node_typ(int(result), map_type)
@@ -8634,14 +8660,14 @@ fn (mut t Transformer) try_lower_array_method_call(call_id flat.NodeId, node fla
 					clean_base_type, node)
 			}
 			if elem_type.starts_with('[]') {
-				return t.make_call_typed('array_eq_array', arr3(receiver, arg,
-					t.make_int_literal(array_nested_eq_depth(clean_base_type))), 'bool')
+				return t.make_call_typed('array_eq_array', [receiver, arg,
+					t.make_int_literal(array_nested_eq_depth(clean_base_type))], 'bool')
 			}
 			if elem_type == 'string' {
-				return t.make_call_typed('array_eq_string', arr2(receiver, arg), 'bool')
+				return t.make_call_typed('array_eq_string', [receiver, arg], 'bool')
 			}
-			return t.make_call_typed('array_eq_raw', arr3(receiver, arg,
-				t.make_sizeof_type(elem_type)), 'bool')
+			return t.make_call_typed('array_eq_raw',
+				[receiver, arg, t.make_sizeof_type(elem_type)], 'bool')
 		}
 		else {}
 	}
@@ -8688,7 +8714,7 @@ fn (mut t Transformer) try_lower_array_method_call(call_id flat.NodeId, node fla
 			} else {
 				'array_contains_int'
 			}
-			return t.make_call_typed(fn_name, arr2(receiver, arg), 'bool')
+			return t.make_call_typed(fn_name, [receiver, arg], 'bool')
 		}
 		'index' {
 			if node.children_count < 2 {
@@ -8701,7 +8727,7 @@ fn (mut t Transformer) try_lower_array_method_call(call_id flat.NodeId, node fla
 			receiver := t.transform_expr(base_id)
 			arg := t.transform_expr(arg_id)
 			fn_name := if elem_type == 'string' { 'array_index_string' } else { 'array_index_int' }
-			return t.make_call_typed(fn_name, arr2(receiver, arg), 'int')
+			return t.make_call_typed(fn_name, [receiver, arg], 'int')
 		}
 		'last_index' {
 			if node.children_count < 2 {
@@ -8719,7 +8745,7 @@ fn (mut t Transformer) try_lower_array_method_call(call_id flat.NodeId, node fla
 			}
 			receiver := t.transform_expr(base_id)
 			arg := t.transform_expr(t.a.children[node.children_start + 1])
-			return t.make_call_typed('Array_string__join', arr2(receiver, arg), 'string')
+			return t.make_call_typed('Array_string__join', [receiver, arg], 'string')
 		}
 		else {
 			if array_method_stays_in_cgen(fn_node.value) {
@@ -8805,8 +8831,9 @@ fn (mut t Transformer) lower_owned_array_accessor_call(base_id flat.NodeId, base
 		t.set_node_typ(int(array_value), clean_base_type)
 	}
 	empty := t.make_infix(.eq, t.make_selector(array_value, 'len', 'int'), t.make_int_literal(0))
-	t.pending_stmts << t.make_if(empty,
-		t.make_block(arr1(t.make_panic_stmt('array.${method}: array is empty'))), t.make_empty())
+	t.pending_stmts << t.make_if(empty, t.make_block([
+		t.make_panic_stmt('array.${method}: array is empty'),
+	]), t.make_empty())
 	index := if method == 'first' {
 		t.make_int_literal(0)
 	} else {
@@ -8819,7 +8846,7 @@ fn (mut t Transformer) lower_owned_array_accessor_call(base_id flat.NodeId, base
 	}
 	result_name := t.new_temp('array_accessor_result')
 	t.pending_stmts << t.make_decl_assign_typed(result_name, cloned, elem_type)
-	t.pending_stmts << t.make_expr_stmt(t.make_call_typed('drop_owned', arr1(array_value), 'void'))
+	t.pending_stmts << t.make_expr_stmt(t.make_call_typed('drop_owned', [array_value], 'void'))
 	return t.make_ident(result_name)
 }
 
@@ -8854,8 +8881,9 @@ fn (mut t Transformer) lower_owned_array_removal_call(node flat.Node, base_id fl
 			index := t.stable_transformed_expr_for_reuse(t.transform_expr_for_type(t.a.child(&node, 1),
 				'int'), 'int', 'array_delete_index')
 			args << index
-			drop_stmts << t.make_expr_stmt(t.make_call_typed('drop_owned', arr1(t.make_index(array_value,
-				index, elem_type)), 'void'))
+			drop_stmts << t.make_expr_stmt(t.make_call_typed('drop_owned', [
+				t.make_index(array_value, index, elem_type),
+			], 'void'))
 			valid_drop_range = t.make_infix(.logical_and, t.make_infix(.ge, index,
 				t.make_int_literal(0)), t.make_infix(.lt, index, t.make_selector(array_value,
 				'len', 'int')))
@@ -8904,8 +8932,9 @@ fn (mut t Transformer) lower_owned_array_removal_call(node flat.Node, base_id fl
 		'delete_last' {
 			last := t.make_infix(.minus, t.make_selector(array_value, 'len', 'int'),
 				t.make_int_literal(1))
-			drop_stmts << t.make_expr_stmt(t.make_call_typed('drop_owned', arr1(t.make_index(array_value,
-				last, elem_type)), 'void'))
+			drop_stmts << t.make_expr_stmt(t.make_call_typed('drop_owned', [
+				t.make_index(array_value, last, elem_type),
+			], 'void'))
 			valid_drop_range = t.make_infix(.gt, t.make_selector(array_value, 'len', 'int'),
 				t.make_int_literal(0))
 		}
@@ -8959,8 +8988,8 @@ fn (mut t Transformer) append_owned_array_drop_prefix(array_value flat.NodeId, e
 	cond := t.make_infix(.logical_and, below_count, below_len)
 	post := t.make_expr_stmt(t.make_postfix(t.make_ident(idx_name), .inc))
 	elem := t.make_index(array_value, t.make_ident(idx_name), elem_type)
-	drop_stmt := t.make_expr_stmt(t.make_call_typed('drop_owned', arr1(elem), 'void'))
-	stmts << t.make_for_stmt(init, cond, post, arr1(drop_stmt), flat.Node{
+	drop_stmt := t.make_expr_stmt(t.make_call_typed('drop_owned', [elem], 'void'))
+	stmts << t.make_for_stmt(init, cond, post, [drop_stmt], flat.Node{
 		skip_ownership_drops: true
 	})
 }
@@ -8971,8 +9000,8 @@ fn (mut t Transformer) append_owned_array_drop_range(array_value flat.NodeId, el
 	cond := t.make_infix(.lt, t.make_ident(idx_name), end)
 	post := t.make_expr_stmt(t.make_postfix(t.make_ident(idx_name), .inc))
 	elem := t.make_index(array_value, t.make_ident(idx_name), elem_type)
-	drop_stmt := t.make_expr_stmt(t.make_call_typed('drop_owned', arr1(elem), 'void'))
-	stmts << t.make_for_stmt(init, cond, post, arr1(drop_stmt), flat.Node{
+	drop_stmt := t.make_expr_stmt(t.make_call_typed('drop_owned', [elem], 'void'))
+	stmts << t.make_for_stmt(init, cond, post, [drop_stmt], flat.Node{
 		skip_ownership_drops: true
 	})
 }
@@ -9041,10 +9070,11 @@ fn (mut t Transformer) try_lower_ignored_owned_array_pop_stmt(call_id flat.NodeI
 	}
 	popped_name := t.new_temp('ignored_array_pop')
 	result << t.make_decl_assign_typed(popped_name, popped, elem_type)
-	drop_result := t.make_expr_stmt(t.make_call_typed('drop_owned',
-		arr1(t.make_ident(popped_name)), 'void'))
+	drop_result := t.make_expr_stmt(t.make_call_typed('drop_owned', [
+		t.make_ident(popped_name),
+	], 'void'))
 	if fn_node.value in ['pop', 'pop_left'] {
-		drop_block := t.make_block(arr1(drop_result))
+		drop_block := t.make_block([drop_result])
 		start := t.a.children.len
 		t.a.children << t.make_ident(drop_result_guard_name)
 		t.a.children << drop_block
@@ -9236,8 +9266,7 @@ fn (mut t Transformer) try_lower_map_method_call(call_id flat.NodeId, node flat.
 		}
 		if isnil(t.tc) || !t.tc.ownership_type_requires_destruction(t.tc.parse_type(clean_type)) {
 			t.mark_fn_used('map__clone')
-			return t.make_call_typed('map__clone', arr1(t.runtime_addr(source, clean_type)),
-				clean_type)
+			return t.make_call_typed('map__clone', [t.runtime_addr(source, clean_type)], clean_type)
 		}
 		// The checker rejects this call. Do not lower it to the unsafe raw clone while
 		// processing the invalid program.
@@ -9264,8 +9293,9 @@ fn (mut t Transformer) try_lower_map_method_call(call_id flat.NodeId, node flat.
 				fn_node.value)
 		}
 		t.mark_fn_used('map__${fn_node.value}')
-		call := t.make_call_typed('map__${fn_node.value}', arr1(t.runtime_addr(base, base_type)),
-			'void')
+		call := t.make_call_typed('map__${fn_node.value}', [
+			t.runtime_addr(base, base_type),
+		], 'void')
 		if fn_node.value == 'free' && !isnil(t.tc)
 			&& t.tc.ownership_type_requires_destruction(t.tc.parse_type(clean_type)) {
 			mut map_value := base
@@ -9283,7 +9313,7 @@ fn (mut t Transformer) try_lower_map_method_call(call_id flat.NodeId, node flat.
 	}
 	if fn_node.value == 'move' {
 		t.mark_fn_used('map__move')
-		return t.make_call_typed('map__move', arr1(t.runtime_addr(base, base_type)), clean_type)
+		return t.make_call_typed('map__move', [t.runtime_addr(base, base_type)], clean_type)
 	}
 	if fn_node.value == 'reserve' {
 		if node.children_count < 2 {
@@ -9291,7 +9321,7 @@ fn (mut t Transformer) try_lower_map_method_call(call_id flat.NodeId, node flat.
 		}
 		t.mark_fn_used('map__reserve')
 		capacity := t.transform_expr_for_type(t.a.child(&node, 1), 'u32')
-		return t.make_call_typed('map__reserve', arr2(t.runtime_addr(base, base_type), capacity),
+		return t.make_call_typed('map__reserve', [t.runtime_addr(base, base_type), capacity],
 			'void')
 	}
 	if fn_node.value == 'delete' {
@@ -9314,17 +9344,21 @@ fn (mut t Transformer) try_lower_map_method_call(call_id flat.NodeId, node flat.
 			key_type, value_type)
 		if handled_delete {
 			if cleanup_key {
-				t.pending_stmts << t.make_expr_stmt(t.make_call_typed('drop_owned',
-					arr1(t.make_ident(key_name)), 'void'))
+				t.pending_stmts << t.make_expr_stmt(t.make_call_typed('drop_owned', [
+					t.make_ident(key_name),
+				], 'void'))
 			}
 			return t.make_empty()
 		}
-		delete_call := t.make_call_typed('map__delete', arr2(t.runtime_addr(base, base_type), t.make_prefix(.amp,
-			t.make_ident(key_name))), 'void')
+		delete_call := t.make_call_typed('map__delete', [
+			t.runtime_addr(base, base_type),
+			t.make_prefix(.amp, t.make_ident(key_name)),
+		], 'void')
 		if cleanup_key {
 			t.pending_stmts << t.make_expr_stmt(delete_call)
-			t.pending_stmts << t.make_expr_stmt(t.make_call_typed('drop_owned',
-				arr1(t.make_ident(key_name)), 'void'))
+			t.pending_stmts << t.make_expr_stmt(t.make_call_typed('drop_owned', [
+				t.make_ident(key_name),
+			], 'void'))
 			return t.make_empty()
 		}
 		return delete_call
@@ -9347,8 +9381,9 @@ fn (mut t Transformer) try_lower_map_method_call(call_id flat.NodeId, node flat.
 			source_is_owned_temporary)
 	}
 	t.mark_fn_used('map__${fn_node.value}')
-	items := t.make_call_typed('map__${fn_node.value}', arr1(t.runtime_addr(base, base_type)),
-		'[]${elem_type}')
+	items := t.make_call_typed('map__${fn_node.value}', [
+		t.runtime_addr(base, base_type),
+	], '[]${elem_type}')
 	if !source_is_owned_temporary || isnil(t.tc)
 		|| !t.tc.ownership_type_requires_destruction(t.tc.parse_type(clean_type)) {
 		return items
@@ -9358,7 +9393,7 @@ fn (mut t Transformer) try_lower_map_method_call(call_id flat.NodeId, node flat.
 	// even when their scalar items need no per-entry clone work.
 	out_name := t.new_temp('map_items')
 	t.pending_stmts << t.make_decl_assign_typed(out_name, items, '[]${elem_type}')
-	t.pending_stmts << t.make_expr_stmt(t.make_call_typed('drop_owned', arr1(base), 'void'))
+	t.pending_stmts << t.make_expr_stmt(t.make_call_typed('drop_owned', [base], 'void'))
 	result := t.make_ident(out_name)
 	t.set_node_typ(int(result), '[]${elem_type}')
 	return result
@@ -9383,8 +9418,10 @@ fn (mut t Transformer) make_owned_map_items_value(source flat.NodeId, map_type s
 	mut body := t.pending_stmts[pending_start..].clone()
 	t.pending_stmts = t.pending_stmts[..pending_start].clone()
 	body << t.make_decl_assign_typed(item_name, cloned_item, item_type)
-	body << t.make_expr_stmt(t.make_call_typed('array_push', arr2(t.runtime_addr(t.make_ident(out_name),
-		'[]${item_type}'), t.make_prefix(.amp, t.make_ident(item_name))), 'void'))
+	body << t.make_expr_stmt(t.make_call_typed('array_push', [
+		t.runtime_addr(t.make_ident(out_name), '[]${item_type}'),
+		t.make_prefix(.amp, t.make_ident(item_name)),
+	], 'void'))
 	t.mark_fn_used('array_push')
 	start := t.a.children.len
 	if take_keys {
@@ -9406,8 +9443,9 @@ fn (mut t Transformer) make_owned_map_items_value(source flat.NodeId, map_type s
 		skip_ownership_drops: true
 	})
 	if source_is_owned_temporary {
-		t.pending_stmts << t.make_expr_stmt(t.make_call_typed('drop_owned', arr1(stable_source),
-			'void'))
+		t.pending_stmts << t.make_expr_stmt(t.make_call_typed('drop_owned', [
+			stable_source,
+		], 'void'))
 	}
 	result := t.make_ident(out_name)
 	t.set_node_typ(int(result), '[]${item_type}')
@@ -9442,15 +9480,17 @@ fn (mut t Transformer) append_owned_map_entries_drop_before_reset(map_expr flat.
 			'&${key_type_name}')
 		stored_key := t.make_prefix(.mul, stored_key_ptr)
 		t.set_node_typ(int(stored_key), key_type_name)
-		body << t.make_expr_stmt(t.make_call_typed('drop_owned', arr1(stored_key), 'void'))
+		body << t.make_expr_stmt(t.make_call_typed('drop_owned', [stored_key], 'void'))
 		if clean_key_type == 'string' {
-			body << t.make_expr_stmt(t.make_call_typed('drop_owned', arr1(t.make_ident(key_name)),
-				'void'))
+			body << t.make_expr_stmt(t.make_call_typed('drop_owned', [
+				t.make_ident(key_name),
+			], 'void'))
 		}
 	}
 	if value_requires_drop {
-		body << t.make_expr_stmt(t.make_call_typed('drop_owned', arr1(t.make_ident(value_name)),
-			'void'))
+		body << t.make_expr_stmt(t.make_call_typed('drop_owned', [
+			t.make_ident(value_name),
+		], 'void'))
 	}
 	start := t.a.children.len
 	if key_requires_drop {
@@ -9513,15 +9553,19 @@ fn (mut t Transformer) append_owned_map_entry_delete_with_drops(map_expr flat.No
 		saved_value_name = t.new_temp('map_deleted_value')
 		body << t.make_decl_assign_typed(saved_value_name, stored_value, value_type_name)
 	}
-	body << t.make_expr_stmt(t.make_call_typed('map__delete', arr2(t.runtime_addr(map_expr,
-		map_type), t.make_prefix(.amp, t.make_ident(key_name))), 'void'))
+	body << t.make_expr_stmt(t.make_call_typed('map__delete', [
+		t.runtime_addr(map_expr, map_type),
+		t.make_prefix(.amp, t.make_ident(key_name)),
+	], 'void'))
 	if key_requires_drop {
-		body << t.make_expr_stmt(t.make_call_typed('drop_owned',
-			arr1(t.make_ident(saved_key_name)), 'void'))
+		body << t.make_expr_stmt(t.make_call_typed('drop_owned', [
+			t.make_ident(saved_key_name),
+		], 'void'))
 	}
 	if value_requires_drop {
-		body << t.make_expr_stmt(t.make_call_typed('drop_owned',
-			arr1(t.make_ident(saved_value_name)), 'void'))
+		body << t.make_expr_stmt(t.make_call_typed('drop_owned', [
+			t.make_ident(saved_value_name),
+		], 'void'))
 	}
 	found := t.make_infix(.ne, t.make_ident(value_ptr_name), t.a.add(.nil_literal))
 	body_block := t.make_block(body)
@@ -9640,7 +9684,7 @@ fn (mut t Transformer) lower_runtime_channel_close(base_id flat.NodeId, node fla
 	} else {
 		t.set_node_typ(int(receiver), '&sync.Channel')
 	}
-	return t.make_call_expr_typed(fn_expr, arr2(receiver, errs), 'void')
+	return t.make_call_expr_typed(fn_expr, [receiver, errs], 'void')
 }
 
 // try_lower_move_method_call supports try lower move method call handling for Transformer.
@@ -10210,7 +10254,7 @@ fn (mut t Transformer) try_lower_builtin_call(_id flat.NodeId, node flat.Node) ?
 			}
 			arg_id := t.a.child(&node, 1)
 			arg := t.stringify_expr(arg_id)
-			return t.make_call(name, arr1(arg))
+			return t.make_call(name, [arg])
 		}
 		'panic' {
 			if node.children_count == 2 {
@@ -10218,8 +10262,9 @@ fn (mut t Transformer) try_lower_builtin_call(_id flat.NodeId, node flat.Node) ?
 				arg_type := t.node_type(arg_id)
 				if arg_type == 'IError' {
 					arg := t.transform_expr(arg_id)
-					return t.make_call('panic',
-						arr1(t.make_method_call(arg, 'str', []flat.NodeId{})))
+					return t.make_call('panic', [
+						t.make_method_call(arg, 'str', []flat.NodeId{}),
+					])
 				}
 			}
 			return none
@@ -10240,7 +10285,7 @@ fn (mut t Transformer) lower_specialized_enum_from_call(node flat.Node, enum_typ
 	arg := t.transform_expr(t.a.child(&node, 1))
 	base := t.make_ident(enum_type)
 	callee := t.make_selector(base, 'from', '')
-	return t.make_call_expr_typed(callee, arr1(arg), '!${enum_type}')
+	return t.make_call_expr_typed(callee, [arg], '!${enum_type}')
 }
 
 fn (mut t Transformer) validate_specialized_enum_from_call(call_id flat.NodeId, node flat.Node) bool {
@@ -10475,8 +10520,8 @@ fn (mut t Transformer) try_lower_copy_call(node flat.Node) ?flat.NodeId {
 		slice := t.transform_expr(dst_id)
 		tmp_name := t.new_temp('copy_dst')
 		t.pending_stmts << t.make_decl_assign_typed(tmp_name, slice, '[]u8')
-		return t.make_call_typed('copy', arr2(t.make_prefix(.amp, t.make_ident(tmp_name)), src),
-			'int')
+		return t.make_call_typed('copy', [t.make_prefix(.amp, t.make_ident(tmp_name)),
+			src], 'int')
 	}
 	dst_expr := t.transform_expr(dst_id)
 	// a `mut` param destination is already a pointer; taking its address again
@@ -10486,7 +10531,7 @@ fn (mut t Transformer) try_lower_copy_call(node flat.Node) ?flat.NodeId {
 	} else {
 		t.make_prefix(.amp, dst_expr)
 	}
-	return t.make_call_typed('copy', arr2(dst, src), 'int')
+	return t.make_call_typed('copy', [dst, src], 'int')
 }
 
 fn (t &Transformer) copy_mut_arg_value(id flat.NodeId) flat.NodeId {
@@ -10632,7 +10677,7 @@ fn (mut t Transformer) try_lower_flag_default_value_call(node flat.Node) ?flat.N
 		arg_type = t.node_type(arg)
 	}
 	if t.normalize_type_alias(arg_type) == 'string' {
-		escaped := t.make_call_typed('escape_default_string', arr1(arg), 'string')
+		escaped := t.make_call_typed('escape_default_string', [arg], 'string')
 		return t.string_plus(t.string_plus(t.make_string_literal('"'), escaped),
 			t.make_string_literal('"'))
 	}
@@ -10724,8 +10769,8 @@ fn (mut t Transformer) build_interface_type_idx_chain(tag flat.NodeId, iface_nam
 	if idx >= impls.len {
 		is_container := t.make_infix(.lt, tag, t.make_int_literal(0))
 		container_idx := t.make_infix(.amp, tag, t.make_int_literal(0x7fffffff))
-		then_block := t.make_block(arr1(t.make_expr_stmt(container_idx)))
-		else_block := t.make_block(arr1(t.make_expr_stmt(t.make_int_literal(0))))
+		then_block := t.make_block([t.make_expr_stmt(container_idx)])
+		else_block := t.make_block([t.make_expr_stmt(t.make_int_literal(0))])
 		start := t.a.children.len
 		t.a.children << is_container
 		t.a.children << then_block
@@ -10742,10 +10787,11 @@ fn (mut t Transformer) build_interface_type_idx_chain(tag flat.NodeId, iface_nam
 		return t.build_interface_type_idx_chain(tag, iface_name, impls, idx + 1)
 	}
 	cond := t.make_infix(.eq, tag, t.make_int_literal(type_id))
-	then_block :=
-		t.make_block(arr1(t.make_expr_stmt(t.make_int_literal(t.type_index_for_type_name(impl)))))
+	then_block := t.make_block([
+		t.make_expr_stmt(t.make_int_literal(t.type_index_for_type_name(impl))),
+	])
 	else_expr := t.build_interface_type_idx_chain(tag, iface_name, impls, idx + 1)
-	else_block := t.make_block(arr1(t.make_expr_stmt(else_expr)))
+	else_block := t.make_block([t.make_expr_stmt(else_expr)])
 	start := t.a.children.len
 	t.a.children << cond
 	t.a.children << then_block
@@ -10768,9 +10814,9 @@ fn (mut t Transformer) build_interface_type_name_chain(tag flat.NodeId, iface_na
 	}
 	display := if impl.contains('.') { impl.all_after_last('.') } else { impl }
 	cond := t.make_infix(.eq, tag, t.make_int_literal(type_id))
-	then_block := t.make_block(arr1(t.make_expr_stmt(t.make_string_literal(display))))
+	then_block := t.make_block([t.make_expr_stmt(t.make_string_literal(display))])
 	else_expr := t.build_interface_type_name_chain(tag, iface_name, impls, idx + 1)
-	else_block := t.make_block(arr1(t.make_expr_stmt(else_expr)))
+	else_block := t.make_block([t.make_expr_stmt(else_expr)])
 	start := t.a.children.len
 	t.a.children << cond
 	t.a.children << then_block
@@ -10791,9 +10837,9 @@ fn (mut t Transformer) build_sum_type_name_chain(tag flat.NodeId, sum_name strin
 	variant := variants[idx]
 	display := if variant.contains('.') { variant.all_after_last('.') } else { variant }
 	cond := t.make_infix(.eq, tag, t.make_int_literal(t.sum_type_index(sum_name, variant)))
-	then_block := t.make_block(arr1(t.make_expr_stmt(t.make_string_literal(display))))
+	then_block := t.make_block([t.make_expr_stmt(t.make_string_literal(display))])
 	else_expr := t.build_sum_type_name_chain(tag, sum_name, variants, idx + 1)
-	else_block := t.make_block(arr1(t.make_expr_stmt(else_expr)))
+	else_block := t.make_block([t.make_expr_stmt(else_expr)])
 	start := t.a.children.len
 	t.a.children << cond
 	t.a.children << then_block
@@ -10812,10 +10858,11 @@ fn (mut t Transformer) build_sum_type_idx_chain(tag flat.NodeId, sum_name string
 	}
 	variant := variants[idx]
 	cond := t.make_infix(.eq, tag, t.make_int_literal(t.sum_type_index(sum_name, variant)))
-	then_block :=
-		t.make_block(arr1(t.make_expr_stmt(t.make_int_literal(t.type_index_for_type_name(variant)))))
+	then_block := t.make_block([
+		t.make_expr_stmt(t.make_int_literal(t.type_index_for_type_name(variant))),
+	])
 	else_expr := t.build_sum_type_idx_chain(tag, sum_name, variants, idx + 1)
-	else_block := t.make_block(arr1(t.make_expr_stmt(else_expr)))
+	else_block := t.make_block([t.make_expr_stmt(else_expr)])
 	start := t.a.children.len
 	t.a.children << cond
 	t.a.children << then_block
@@ -10891,8 +10938,10 @@ fn (mut t Transformer) try_lower_pool_generic_method_call(node flat.Node) ?flat.
 	t.set_node_typ(int(value), out_elem_type)
 	value_name := t.new_temp('pool_result')
 	value_decl := t.make_decl_assign_typed(value_name, value, out_elem_type)
-	push_call := t.make_call_typed('array_push', arr2(t.make_prefix(.amp, t.make_ident(result_name)), t.make_prefix(.amp,
-		t.make_ident(value_name))), 'void')
+	push_call := t.make_call_typed('array_push', [
+		t.make_prefix(.amp, t.make_ident(result_name)),
+		t.make_prefix(.amp, t.make_ident(value_name)),
+	], 'void')
 	loop_body := [value_decl, t.make_expr_stmt(push_call)]
 	prefix << t.make_for_stmt(init, cond, post, loop_body, node)
 	for stmt in prefix {
@@ -11035,7 +11084,7 @@ fn (mut t Transformer) try_lower_receiver_method_call(id flat.NodeId, node flat.
 		builtin_base_type = 'u8'
 	}
 	if base_type == '[]rune' && method == 'string' {
-		return t.make_call_typed('Array_rune__string', arr1(t.transform_expr(base_id)), 'string')
+		return t.make_call_typed('Array_rune__string', [t.transform_expr(base_id)], 'string')
 	}
 	if method == 'str' && t.is_array_transform_call(base_id) {
 		base := t.transform_expr(base_id)
@@ -11114,14 +11163,14 @@ fn (mut t Transformer) try_lower_receiver_method_call(id flat.NodeId, node flat.
 		return t.wrap_string_conversion(t.transform_expr(base_id), stringify_type)
 	}
 	if builtin_base_type == 'string' && method == 'hex' && !base_is_pointer {
-		return t.make_call_typed('string.hex', arr1(t.transform_expr(base_id)), 'string')
+		return t.make_call_typed('string.hex', [t.transform_expr(base_id)], 'string')
 	}
 	if base_type == '[]u8' || base_type == '[]byte' {
 		if method == 'bytestr' {
-			return t.make_call_typed('Array_u8__bytestr', arr1(t.transform_expr(base_id)), 'string')
+			return t.make_call_typed('Array_u8__bytestr', [t.transform_expr(base_id)], 'string')
 		}
 		if method == 'hex' && !base_is_pointer {
-			return t.make_call_typed('Array_u8__hex', arr1(t.transform_expr(base_id)), 'string')
+			return t.make_call_typed('Array_u8__hex', [t.transform_expr(base_id)], 'string')
 		}
 	}
 	mut pointer_method := t.pointer_builtin_vbytes_method(base_is_pointer, builtin_base_type,
@@ -11151,16 +11200,17 @@ fn (mut t Transformer) try_lower_receiver_method_call(id flat.NodeId, node flat.
 		}
 	}
 	if builtin_base_type == 'u8' && method in ['is_space', 'is_digit', 'is_hex_digit', 'is_letter'] {
-		return t.make_call_typed('u8__${method}', arr1(t.transform_expr(base_id)), 'bool')
+		return t.make_call_typed('u8__${method}', [t.transform_expr(base_id)], 'bool')
 	}
 	if !base_is_pointer
 		&& builtin_base_type in ['u8', 'i8', 'u16', 'i16', 'u32', 'int', 'u64', 'i64', 'rune']
 		&& method in ['hex', 'hex_full'] {
-		return t.make_call_typed('${builtin_base_type}__${method}',
-			arr1(t.transform_expr(base_id)), 'string')
+		return t.make_call_typed('${builtin_base_type}__${method}', [
+			t.transform_expr(base_id),
+		], 'string')
 	}
 	if !base_is_pointer && builtin_base_type == 'voidptr' && method == 'hex_full' {
-		return t.make_call_typed('voidptr__hex_full', arr1(t.transform_expr(base_id)), 'string')
+		return t.make_call_typed('voidptr__hex_full', [t.transform_expr(base_id)], 'string')
 	}
 	if base_type.starts_with('[]') || base_type.starts_with('map[') {
 		if base_type.starts_with('[]') {
@@ -13121,7 +13171,7 @@ fn (mut t Transformer) make_spread_index_for_expected_param(base flat.NodeId, of
 		fn_name := 'string__${typ}'
 		t.mark_fn_used_name('string.${typ}')
 		t.mark_fn_used_name(fn_name)
-		return t.make_call_typed(fn_name, arr1(id), typ)
+		return t.make_call_typed(fn_name, [id], typ)
 	}
 	t.set_node_typ(int(id), typ)
 	return id
@@ -13275,7 +13325,7 @@ fn (mut t Transformer) lower_string_count_call(node flat.Node, fn_node flat.Node
 	loop_body << elem_decl
 	t.drain_pending(mut loop_body)
 	inc := t.make_assign_op(t.make_ident(result_name), t.make_int_literal(1), .plus_assign)
-	loop_body << t.make_if(predicate, t.make_block(arr1(inc)), t.make_empty())
+	loop_body << t.make_if(predicate, t.make_block([inc]), t.make_empty())
 	prefix << t.make_for_stmt(init, cond, post, loop_body, node)
 	for stmt in prefix {
 		t.pending_stmts << stmt

--- a/vlib/v3/transform/for.v
+++ b/vlib/v3/transform/for.v
@@ -17,7 +17,7 @@ struct UnsignedInclusiveForPost {
 // transform_for_body transforms transform for body data for transform.
 fn (mut t Transformer) transform_for_body(id flat.NodeId, node flat.Node) []flat.NodeId {
 	if node.children_count < 3 {
-		return arr1(id)
+		return [id]
 	}
 	// child 0: init statement
 	init_id := t.a.child(&node, 0)
@@ -112,7 +112,7 @@ fn (mut t Transformer) transform_for_body(id flat.NodeId, node flat.Node) []flat
 			guarded_body << stmt
 		}
 		not_cond := t.make_prefix(.not, t.make_paren(new_cond))
-		break_block := t.make_block(arr1(t.a.add(.break_stmt)))
+		break_block := t.make_block([t.a.add(.break_stmt)])
 		guarded_body << t.make_if(not_cond, break_block, t.make_block([]flat.NodeId{}))
 		for stmt in new_body {
 			guarded_body << stmt
@@ -147,7 +147,7 @@ fn (mut t Transformer) transform_for_body(id flat.NodeId, node flat.Node) []flat
 			new_id,
 		]
 	}
-	return arr1(new_id)
+	return [new_id]
 }
 
 fn (mut t Transformer) unsigned_inclusive_for_post_body(cond_id flat.NodeId, post_id flat.NodeId) ?UnsignedInclusiveForPost {
@@ -188,7 +188,7 @@ fn (mut t Transformer) unsigned_inclusive_for_post_body(cond_id flat.NodeId, pos
 	done := t.unsigned_loop_post_would_overflow(loop_node.value, loop_type, post_expr.op)
 	t.set_node_typ(int(done), 'bool')
 	break_stmt := t.a.add(.break_stmt)
-	post_body << t.make_if(done, t.make_block(arr1(break_stmt)), t.make_empty())
+	post_body << t.make_if(done, t.make_block([break_stmt]), t.make_empty())
 	post_body << t.transform_stmt(post_id)
 	return UnsignedInclusiveForPost{
 		cond:        new_cond
@@ -335,7 +335,7 @@ fn (mut t Transformer) rewrite_continue_to_for_post_label_in_children(id flat.No
 fn (mut t Transformer) transform_for_in_body(id flat.NodeId, node flat.Node) []flat.NodeId {
 	header_count := node.value.int()
 	if header_count < 3 || node.children_count < 3 {
-		return arr1(id)
+		return [id]
 	}
 	key_id := t.a.child(&node, 0) // loop var ident — pass through (do not transform a binding)
 	val_id := t.a.child(&node, 1) // may be flat.empty_node (-1)
@@ -647,11 +647,13 @@ fn (mut t Transformer) rebuild_for_in_stmt(_id flat.NodeId, node flat.Node) []fl
 	if cleanup_owned_container {
 		cleanup_guard_name = t.new_temp('for_map_container_live')
 		prefix << t.make_decl_assign_typed(cleanup_guard_name, t.make_bool_literal(true), 'bool')
-		deferred_drop := t.make_expr_stmt(t.make_call_typed('drop_owned', arr1(new_container),
-			'void'))
-		guarded_drop := t.make_if_with_skip_ownership_drops(t.make_ident(cleanup_guard_name),
-			t.make_block(arr1(deferred_drop)), t.make_empty())
-		defer_body := t.make_block(arr1(guarded_drop))
+		deferred_drop := t.make_expr_stmt(t.make_call_typed('drop_owned', [
+			new_container,
+		], 'void'))
+		guarded_drop := t.make_if_with_skip_ownership_drops(t.make_ident(cleanup_guard_name), t.make_block([
+			deferred_drop,
+		]), t.make_empty())
+		defer_body := t.make_block([guarded_drop])
 		defer_start := t.a.children.len
 		t.a.children << defer_body
 		prefix << t.a.add_node(flat.Node{
@@ -671,7 +673,7 @@ fn (mut t Transformer) rebuild_for_in_stmt(_id flat.NodeId, node flat.Node) []fl
 		skip_ownership_drops: node.skip_ownership_drops
 	})
 	if cleanup_owned_container {
-		prefix << t.make_expr_stmt(t.make_call_typed('drop_owned', arr1(new_container), 'void'))
+		prefix << t.make_expr_stmt(t.make_call_typed('drop_owned', [new_container], 'void'))
 		prefix << t.make_assign(t.make_ident(cleanup_guard_name), t.make_bool_literal(false))
 	}
 	return prefix
@@ -826,11 +828,11 @@ fn (t &Transformer) iterator_for_in_elem_type_from_next_return(ret types.Type) ?
 // lower_range_for_in builds lower range for in data for transform.
 fn (mut t Transformer) lower_range_for_in(id flat.NodeId, node flat.Node, key_id flat.NodeId, low_id flat.NodeId, high_id flat.NodeId, body_ids []flat.NodeId) []flat.NodeId {
 	if int(key_id) < 0 {
-		return arr1(id)
+		return [id]
 	}
 	key := t.a.nodes[int(key_id)]
 	if key.kind != .ident || key.value.len == 0 {
-		return arr1(id)
+		return [id]
 	}
 	range_type := t.range_loop_var_type_name(low_id)
 	low := t.stable_expr_for_reuse(low_id)
@@ -865,20 +867,20 @@ fn (t &Transformer) range_loop_var_type_name(low_id flat.NodeId) string {
 
 fn (mut t Transformer) lower_iterator_for_in(id flat.NodeId, node flat.Node, key_id flat.NodeId, val_id flat.NodeId, container_id flat.NodeId, iter_type string, info IteratorForInInfo, has_index bool, body_ids []flat.NodeId) []flat.NodeId {
 	if int(key_id) < 0 {
-		return arr1(id)
+		return [id]
 	}
 	key := t.a.nodes[int(key_id)]
 	if key.kind != .ident || key.value.len == 0 {
-		return arr1(id)
+		return [id]
 	}
 	mut elem_name := key.value
 	if has_index {
 		if int(val_id) < 0 {
-			return arr1(id)
+			return [id]
 		}
 		val := t.a.nodes[int(val_id)]
 		if val.kind != .ident || val.value.len == 0 {
-			return arr1(id)
+			return [id]
 		}
 		elem_name = val.value
 	}
@@ -898,11 +900,12 @@ fn (mut t Transformer) lower_iterator_for_in(id flat.NodeId, node flat.Node, key
 	elem_type := info.elem_type
 	t.set_var_type(elem_name, elem_type)
 	t.mark_fn_used_name(info.next_method)
-	next_call := t.make_call_typed(info.next_method, arr1(t.make_prefix(.amp,
-		t.make_ident(iter_name))), '?${elem_type}')
+	next_call := t.make_call_typed(info.next_method, [
+		t.make_prefix(.amp, t.make_ident(iter_name)),
+	], '?${elem_type}')
 	next_decl := t.make_decl_assign_typed(next_name, next_call, '?${elem_type}')
 	no_value := t.make_prefix(.not, t.make_selector(t.make_ident(next_name), 'ok', 'bool'))
-	break_if_done := t.make_if(no_value, t.make_block(arr1(t.a.add(.break_stmt))), t.make_empty())
+	break_if_done := t.make_if(no_value, t.make_block([t.a.add(.break_stmt)]), t.make_empty())
 	elem_decl := t.make_decl_assign_typed(elem_name, t.make_selector(t.make_ident(next_name),
 		'value', elem_type), elem_type)
 	mut loop_body := []flat.NodeId{}
@@ -923,11 +926,11 @@ fn (mut t Transformer) lower_iterator_for_in(id flat.NodeId, node flat.Node, key
 @[direct_array_access]
 fn (mut t Transformer) lower_indexed_for_in(id flat.NodeId, node flat.Node, key_id flat.NodeId, val_id flat.NodeId, container_id flat.NodeId, iter_type string, has_index bool, body_ids []flat.NodeId) []flat.NodeId {
 	if int(key_id) < 0 {
-		return arr1(id)
+		return [id]
 	}
 	key := t.a.nodes[int(key_id)]
 	if key.kind != .ident || key.value.len == 0 {
-		return arr1(id)
+		return [id]
 	}
 	container_node := if int(container_id) >= 0 { t.a.nodes[int(container_id)] } else { flat.Node{} }
 	checker_container_type := t.raw_checker_node_type(container_id)
@@ -1008,7 +1011,7 @@ fn (mut t Transformer) lower_indexed_for_in(id flat.NodeId, node flat.Node, key_
 	}
 	elem_type := t.infer_for_in_elem_type(actual_iter_type, node)
 	if elem_type.len == 0 {
-		return arr1(id)
+		return [id]
 	}
 	mut idx_name := key.value
 	if !has_index || key.value == '_' {
@@ -1017,11 +1020,11 @@ fn (mut t Transformer) lower_indexed_for_in(id flat.NodeId, node flat.Node, key_
 	mut elem_name := key.value
 	if has_index {
 		if int(val_id) < 0 {
-			return arr1(id)
+			return [id]
 		}
 		val := t.a.nodes[int(val_id)]
 		if val.kind != .ident || val.value.len == 0 {
-			return arr1(id)
+			return [id]
 		}
 		elem_name = val.value
 	}
@@ -1093,11 +1096,13 @@ fn (mut t Transformer) lower_indexed_for_in(id flat.NodeId, node flat.Node, key_
 	if cleanup_temporary {
 		cleanup_guard_name = t.new_temp('for_container_live')
 		prefix << t.make_decl_assign_typed(cleanup_guard_name, t.make_bool_literal(true), 'bool')
-		deferred_drop := t.make_expr_stmt(t.make_call_typed('drop_owned', arr1(cleanup_target),
-			'void'))
-		guarded_drop := t.make_if_with_skip_ownership_drops(t.make_ident(cleanup_guard_name),
-			t.make_block(arr1(deferred_drop)), t.make_empty())
-		defer_body := t.make_block(arr1(guarded_drop))
+		deferred_drop := t.make_expr_stmt(t.make_call_typed('drop_owned', [
+			cleanup_target,
+		], 'void'))
+		guarded_drop := t.make_if_with_skip_ownership_drops(t.make_ident(cleanup_guard_name), t.make_block([
+			deferred_drop,
+		]), t.make_empty())
+		defer_body := t.make_block([guarded_drop])
 		defer_start := t.a.children.len
 		t.a.children << defer_body
 		prefix << t.a.add_node(flat.Node{
@@ -1109,12 +1114,12 @@ fn (mut t Transformer) lower_indexed_for_in(id flat.NodeId, node flat.Node, key_
 	for_stmt := t.make_for_stmt(init, cond, post, new_body, node)
 	if int(optional_container) >= 0 {
 		ok_cond := t.make_selector(optional_container, 'ok', 'bool')
-		prefix << t.make_if(ok_cond, t.make_block(arr1(for_stmt)), t.make_empty())
+		prefix << t.make_if(ok_cond, t.make_block([for_stmt]), t.make_empty())
 	} else {
 		prefix << for_stmt
 	}
 	if cleanup_temporary {
-		prefix << t.make_expr_stmt(t.make_call_typed('drop_owned', arr1(cleanup_target), 'void'))
+		prefix << t.make_expr_stmt(t.make_call_typed('drop_owned', [cleanup_target], 'void'))
 		prefix << t.make_assign(t.make_ident(cleanup_guard_name), t.make_bool_literal(false))
 	}
 	return prefix

--- a/vlib/v3/transform/if.v
+++ b/vlib/v3/transform/if.v
@@ -149,8 +149,8 @@ fn (mut t Transformer) expand_channel_receive_if_guard(node flat.Node, lhs_name 
 	channel_cast := t.make_cast('&sync.Channel', channel_source, '&sync.Channel')
 	prelude << t.make_decl_assign_typed(channel_name, channel_cast, '&sync.Channel')
 	t.mark_fn_used('sync__Channel__pop')
-	pop_call := t.make_call_typed('sync__Channel__pop', arr2(t.make_ident(channel_name), t.make_prefix(.amp,
-		t.make_ident(val_name))), 'bool')
+	pop_call := t.make_call_typed('sync__Channel__pop', [t.make_ident(channel_name),
+		t.make_prefix(.amp, t.make_ident(val_name))], 'bool')
 	prelude << t.make_decl_assign_typed(ok_name, pop_call, 'bool')
 
 	then_id := t.a.child(&node, 1)
@@ -1479,7 +1479,7 @@ fn (mut t Transformer) transform_if_branch_as_block(branch_id flat.NodeId) flat.
 		return t.make_block(children)
 	}
 	mut stmts := []flat.NodeId{}
-	if t.is_stmt_kind_id(node_kind_id(branch)) {
+	if t.is_stmt_kind_id(int(branch.kind)) {
 		expanded := t.transform_stmt(branch_id)
 		t.drain_pending(mut stmts)
 		stmts << expanded

--- a/vlib/v3/transform/interface.v
+++ b/vlib/v3/transform/interface.v
@@ -37,7 +37,7 @@ fn (mut t Transformer) heap_copy_interface_expr(expr flat.NodeId, iface_name str
 	t.pending_stmts << t.make_decl_assign_typed(tmp_name, expr, iface_name)
 	addr := t.make_prefix(.amp, t.make_ident(tmp_name))
 	size := t.make_sizeof_type(iface_name)
-	dup := t.make_non_aliasing_allocation_call('memdup', arr2(addr, size), 'voidptr')
+	dup := t.make_non_aliasing_allocation_call('memdup', [addr, size], 'voidptr')
 	cast := t.make_cast(target_type, dup, target_type)
 	t.set_node_typ(int(cast), target_type)
 	return cast
@@ -645,8 +645,8 @@ fn (t &Transformer) heaped_amp_local_address_child(id flat.NodeId) ?flat.NodeId 
 
 fn (mut t Transformer) null_safe_interface_pointer_field(source flat.NodeId, value flat.NodeId, field_type string) flat.NodeId {
 	cond := t.make_infix(.ne, source, t.a.add(.nil_literal))
-	then_block := t.make_block(arr1(t.make_expr_stmt(value)))
-	else_block := t.make_block(arr1(t.make_expr_stmt(t.zero_value_for_type(field_type))))
+	then_block := t.make_block([t.make_expr_stmt(value)])
+	else_block := t.make_block([t.make_expr_stmt(t.zero_value_for_type(field_type))])
 	start := t.a.children.len
 	t.a.children << cond
 	t.a.children << then_block
@@ -760,7 +760,7 @@ fn (mut t Transformer) make_interface_literal_from_expr(id flat.NodeId, iface_na
 	} else {
 		addr := t.make_prefix(.amp, source)
 		size := t.make_sizeof_type(concrete_type)
-		dup := t.make_non_aliasing_allocation_call('memdup', arr2(addr, size), 'voidptr')
+		dup := t.make_non_aliasing_allocation_call('memdup', [addr, size], 'voidptr')
 		if t.interface_box_object_cast_needs_raw_call(concrete_type) {
 			t.set_node_typ(int(dup), '&${concrete_type}')
 			dup

--- a/vlib/v3/transform/map.v
+++ b/vlib/v3/transform/map.v
@@ -214,8 +214,9 @@ fn (mut t Transformer) make_map_get_expr(map_expr flat.NodeId, base_type string,
 	} else {
 		effective_value_type
 	}
-	call := t.make_call_typed('map__get', arr3(t.runtime_addr(map_expr, base_type), t.make_prefix(.amp,
-		t.make_ident(key_name)), t.make_prefix(.amp, t.make_ident(zero_name))), 'voidptr')
+	call := t.make_call_typed('map__get', [t.runtime_addr(map_expr, base_type),
+		t.make_prefix(.amp, t.make_ident(key_name)), t.make_prefix(.amp, t.make_ident(zero_name))],
+		'voidptr')
 	cast := t.make_cast('&${clean_value_type}', call, '&${clean_value_type}')
 	result := t.make_prefix(.mul, cast)
 	t.set_node_typ(int(result), clean_value_type)
@@ -235,25 +236,26 @@ fn (t &Transformer) fixed_array_type_contains_map(typ string) bool {
 
 // make_map_get_check_expr builds make map get check expr data for transform.
 fn (mut t Transformer) make_map_get_check_expr(map_expr flat.NodeId, base_type string, key_name string) flat.NodeId {
-	return t.make_call_typed('map__get_check', arr2(t.runtime_addr(map_expr, base_type), t.make_prefix(.amp,
-		t.make_ident(key_name))), 'voidptr')
+	return t.make_call_typed('map__get_check', [t.runtime_addr(map_expr, base_type),
+		t.make_prefix(.amp, t.make_ident(key_name))], 'voidptr')
 }
 
 fn (mut t Transformer) make_map_get_key_check_expr(map_expr flat.NodeId, base_type string, key_name string) flat.NodeId {
-	return t.make_call_typed('map__get_key_check', arr2(t.runtime_addr(map_expr, base_type), t.make_prefix(.amp,
-		t.make_ident(key_name))), 'voidptr')
+	return t.make_call_typed('map__get_key_check', [t.runtime_addr(map_expr, base_type),
+		t.make_prefix(.amp, t.make_ident(key_name))], 'voidptr')
 }
 
 // make_map_exists_expr builds make map exists expr data for transform.
 fn (mut t Transformer) make_map_exists_expr(map_expr flat.NodeId, base_type string, key_name string) flat.NodeId {
-	return t.make_call_typed('map__exists', arr2(t.runtime_addr(map_expr, base_type), t.make_prefix(.amp,
-		t.make_ident(key_name))), 'bool')
+	return t.make_call_typed('map__exists', [t.runtime_addr(map_expr, base_type),
+		t.make_prefix(.amp, t.make_ident(key_name))], 'bool')
 }
 
 // make_map_set_stmt builds make map set stmt data for transform.
 fn (mut t Transformer) make_map_set_stmt(map_expr flat.NodeId, base_type string, key_name string, value_name string) flat.NodeId {
-	call := t.make_call_typed('map__set', arr3(t.runtime_addr(map_expr, base_type), t.make_prefix(.amp,
-		t.make_ident(key_name)), t.make_prefix(.amp, t.make_ident(value_name))), 'void')
+	call := t.make_call_typed('map__set', [t.runtime_addr(map_expr, base_type),
+		t.make_prefix(.amp, t.make_ident(key_name)), t.make_prefix(.amp, t.make_ident(value_name))],
+		'void')
 	return t.make_expr_stmt(call)
 }
 
@@ -318,8 +320,9 @@ fn (mut t Transformer) lower_map_membership_expr(map_id flat.NodeId, key_id flat
 	if cleanup_key {
 		result_name := t.new_temp('map_exists')
 		t.pending_stmts << t.make_decl_assign_typed(result_name, exists, 'bool')
-		t.pending_stmts << t.make_expr_stmt(t.make_call_typed('drop_owned',
-			arr1(t.make_ident(key_name)), 'void'))
+		t.pending_stmts << t.make_expr_stmt(t.make_call_typed('drop_owned', [
+			t.make_ident(key_name),
+		], 'void'))
 		return t.make_ident(result_name)
 	}
 	return exists
@@ -356,8 +359,9 @@ fn (mut t Transformer) try_lower_map_index_expr(id flat.NodeId, node flat.Node) 
 		result := t.lower_owned_map_index_move(map_source_id, map_expr, base_type, key_name,
 			value_type)
 		if cleanup_key {
-			t.pending_stmts << t.make_expr_stmt(t.make_call_typed('drop_owned',
-				arr1(t.make_ident(key_name)), 'void'))
+			t.pending_stmts << t.make_expr_stmt(t.make_call_typed('drop_owned', [
+				t.make_ident(key_name),
+			], 'void'))
 		}
 		return result
 	}
@@ -369,12 +373,14 @@ fn (mut t Transformer) try_lower_map_index_expr(id flat.NodeId, node flat.Node) 
 		result_name := t.new_temp('map_index_value')
 		t.pending_stmts << t.make_decl_assign_typed(result_name, value, value_type)
 		if cleanup_key {
-			t.pending_stmts << t.make_expr_stmt(t.make_call_typed('drop_owned',
-				arr1(t.make_ident(key_name)), 'void'))
+			t.pending_stmts << t.make_expr_stmt(t.make_call_typed('drop_owned', [
+				t.make_ident(key_name),
+			], 'void'))
 		}
 		if source_is_owned_temporary {
-			t.pending_stmts << t.make_expr_stmt(t.make_call_typed('drop_owned', arr1(map_expr),
-				'void'))
+			t.pending_stmts << t.make_expr_stmt(t.make_call_typed('drop_owned', [
+				map_expr,
+			], 'void'))
 		}
 		result := t.make_ident(result_name)
 		t.set_node_typ(int(result), value_type)
@@ -413,7 +419,7 @@ fn (mut t Transformer) lower_owned_map_index_move(source_id flat.NodeId, map_exp
 		skip_ownership_drops: true
 	})
 	if !map_type.starts_with('&') && !t.expr_can_take_address(source_id) {
-		t.pending_stmts << t.make_expr_stmt(t.make_call_typed('drop_owned', arr1(map_expr), 'void'))
+		t.pending_stmts << t.make_expr_stmt(t.make_call_typed('drop_owned', [map_expr], 'void'))
 	}
 	result := t.make_ident(result_name)
 	t.set_node_typ(int(result), value_type)
@@ -478,8 +484,9 @@ fn (mut t Transformer) transform_map_index_or_expr(id flat.NodeId, node flat.Nod
 		info.base_type, key_name), 'voidptr')
 	if !isnil(t.tc) && t.map_key_expr_creates_owned_value(info.key_id, info.key_type)
 		&& t.tc.ownership_type_requires_destruction(t.tc.parse_type(info.key_type)) {
-		prelude << t.make_expr_stmt(t.make_call_typed('drop_owned', arr1(t.make_ident(key_name)),
-			'void'))
+		prelude << t.make_expr_stmt(t.make_call_typed('drop_owned', [
+			t.make_ident(key_name),
+		], 'void'))
 	}
 	prelude << t.make_decl_assign_typed(val_name, t.zero_value_for_type(result_type), result_type)
 	move_found_value := !isnil(t.tc) && t.tc.ownership_index_read_moves_value(expr_id)
@@ -554,9 +561,9 @@ fn (mut t Transformer) make_clear_map_ptr_value(ptr_name string, value_type stri
 fn (mut t Transformer) lower_map_or_body_to_stmts(body_id flat.NodeId, target_name string, target_type string, mode string, err_expr flat.NodeId) []flat.NodeId {
 	if mode == '!' || mode == '?' {
 		if t.is_optional_type_name(t.cur_fn_ret_type) {
-			return arr1(t.make_none_return_stmt_with_err_expr(err_expr))
+			return [t.make_none_return_stmt_with_err_expr(err_expr)]
 		}
-		return arr1(t.make_panic_stmt('option/result propagation failed'))
+		return [t.make_panic_stmt('option/result propagation failed')]
 	}
 	if int(body_id) < 0 {
 		return []flat.NodeId{}
@@ -564,16 +571,18 @@ fn (mut t Transformer) lower_map_or_body_to_stmts(body_id flat.NodeId, target_na
 	body := t.a.nodes[int(body_id)]
 	if body.kind != .block {
 		if body.kind == .call && t.is_error_call(body) && t.is_optional_type_name(t.cur_fn_ret_type) {
-			return arr1(t.make_return(body_id, t.cur_fn_ret_type))
+			return [t.make_return(body_id, t.cur_fn_ret_type)]
 		}
 		if body.kind == .none_expr && t.map_value_type_is_optional(target_type) {
-			return arr1(t.make_assign(t.make_ident(target_name), t.make_optional_none(target_type)))
+			return [
+				t.make_assign(t.make_ident(target_name), t.make_optional_none(target_type)),
+			]
 		}
 		if body.kind == .none_expr && !t.is_optional_type_name(target_type)
 			&& t.is_optional_type_name(t.cur_fn_ret_type) {
-			return arr1(t.make_none_return_stmt())
+			return [t.make_none_return_stmt()]
 		}
-		return arr1(t.make_assign(t.make_ident(target_name), t.transform_expr(body_id)))
+		return [t.make_assign(t.make_ident(target_name), t.transform_expr(body_id))]
 	}
 	mut result := []flat.NodeId{}
 	if body.children_count == 0 {
@@ -751,13 +760,14 @@ fn (mut t Transformer) append_owned_map_set_key_cleanup(key_name string, cleanup
 	if !cleanup {
 		return
 	}
-	drop_stmt := t.make_expr_stmt(t.make_call_typed('drop_owned', arr1(t.make_ident(key_name)),
-		'void'))
+	drop_stmt := t.make_expr_stmt(t.make_call_typed('drop_owned', [
+		t.make_ident(key_name),
+	], 'void'))
 	if existing_name.len == 0 {
 		result << drop_stmt
 		return
 	}
-	result << t.make_if(t.make_ident(existing_name), t.make_block(arr1(drop_stmt)), t.make_empty())
+	result << t.make_if(t.make_ident(existing_name), t.make_block([drop_stmt]), t.make_empty())
 }
 
 // map_key_expr_creates_owned_value includes ownership-bearing expressions recognized by
@@ -841,9 +851,9 @@ fn (mut t Transformer) append_map_value_drop_before_set(map_expr flat.NodeId, ma
 	old_value_ptr := t.make_cast('&${value_type_name}', ptr_ident, '&${value_type_name}')
 	old_value := t.make_prefix(.mul, old_value_ptr)
 	t.set_node_typ(int(old_value), value_type_name)
-	drop_call := t.make_call_typed('drop_owned', arr1(old_value), 'void')
+	drop_call := t.make_call_typed('drop_owned', [old_value], 'void')
 	found := t.make_infix(.ne, ptr_ident, t.a.add(.nil_literal))
-	result << t.make_if(found, t.make_block(arr1(t.make_expr_stmt(drop_call))), t.make_empty())
+	result << t.make_if(found, t.make_block([t.make_expr_stmt(drop_call)]), t.make_empty())
 }
 
 // try_lower_nested_map_index_assign lowers `m[k1][k2] = value` by updating the
@@ -1053,13 +1063,16 @@ fn (mut t Transformer) try_lower_nested_map_delete_call(node flat.Node, base_id 
 	handled_delete := t.append_owned_map_entry_delete_with_drops(inner_map_expr, inner_map_type,
 		inner_key_name, inner_key_type, inner_value_type)
 	if !handled_delete {
-		t.pending_stmts << t.make_expr_stmt(t.make_call_typed('map__delete', arr2(t.runtime_addr(inner_map_expr,
-			inner_map_type), t.make_prefix(.amp, t.make_ident(inner_key_name))), 'void'))
+		t.pending_stmts << t.make_expr_stmt(t.make_call_typed('map__delete', [
+			t.runtime_addr(inner_map_expr, inner_map_type),
+			t.make_prefix(.amp, t.make_ident(inner_key_name)),
+		], 'void'))
 	}
 	if inner_key_is_owned && !isnil(t.tc)
 		&& t.tc.ownership_type_requires_destruction(t.tc.parse_type(inner_key_type)) {
-		t.pending_stmts << t.make_expr_stmt(t.make_call_typed('drop_owned',
-			arr1(t.make_ident(inner_key_name)), 'void'))
+		t.pending_stmts << t.make_expr_stmt(t.make_call_typed('drop_owned', [
+			t.make_ident(inner_key_name),
+		], 'void'))
 	}
 	t.pending_stmts << t.make_map_set_stmt(map_expr, outer_info.base_type, outer_key_name,
 		inner_name)
@@ -1230,10 +1243,10 @@ fn (mut t Transformer) append_owned_lvalue_drop_before_assign_if(lvalue flat.Nod
 	if isnil(t.tc) || !t.tc.ownership_type_requires_destruction(t.tc.parse_type(type_name)) {
 		return
 	}
-	drop_call := t.make_call_typed('drop_owned', arr1(lvalue), 'void')
+	drop_call := t.make_call_typed('drop_owned', [lvalue], 'void')
 	drop_stmt := t.make_expr_stmt(drop_call)
 	if int(guard) >= 0 {
-		result << t.make_if(guard, t.make_block(arr1(drop_stmt)), t.make_empty())
+		result << t.make_if(guard, t.make_block([drop_stmt]), t.make_empty())
 		return
 	}
 	result << drop_stmt
@@ -1274,7 +1287,7 @@ fn (mut t Transformer) lower_map_index_compound_with_info(info MapIndexInfo, map
 	current_name := t.load_map_index_current(info, map_expr, key_name, mut result)
 	rhs := t.transform_expr(rhs_id)
 	new_value := if info.value_type == 'string' && op == .plus {
-		t.make_call_typed('string__plus', arr2(t.make_ident(current_name), rhs), 'string')
+		t.make_call_typed('string__plus', [t.make_ident(current_name), rhs], 'string')
 	} else {
 		t.make_infix(op, t.make_ident(current_name), rhs)
 	}
@@ -1529,8 +1542,11 @@ fn (mut t Transformer) lower_map_init_to_runtime(id flat.NodeId, node flat.Node)
 				t.pending_stmts << stmt
 			}
 		}
-		call := t.make_call_typed('map__set', arr3(t.make_prefix(.amp, t.make_ident(tmp_name)), t.make_prefix(.amp,
-			t.make_ident(key_name)), t.make_prefix(.amp, t.make_ident(value_name))), 'void')
+		call := t.make_call_typed('map__set', [
+			t.make_prefix(.amp, t.make_ident(tmp_name)),
+			t.make_prefix(.amp, t.make_ident(key_name)),
+			t.make_prefix(.amp, t.make_ident(value_name)),
+		], 'void')
 		t.pending_stmts << t.make_expr_stmt(call)
 		if int(value_id) in t.local_closure_field_cleanups {
 			t.pending_stmts << t.make_local_closure_cleanup_defer(value_name)

--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -3541,7 +3541,7 @@ fn (mut t Transformer) emit_generic_fn_specialization(decl GenericFnDecl, args [
 	t.reset_var_types()
 	for i in 0 .. decl.node.children_count {
 		param_child := t.a.child_node(&decl.node, i)
-		if node_kind_id(param_child) != 75 {
+		if int(param_child.kind) != 75 {
 			if t.prefix_param_scan {
 				break
 			}
@@ -3781,7 +3781,7 @@ fn (mut t Transformer) seed_generated_fn_body_context(root flat.NodeId) {
 			continue
 		}
 		child := t.a.nodes[int(child_id)]
-		if node_kind_id(child) != 75 {
+		if int(child.kind) != 75 {
 			if t.prefix_param_scan {
 				break
 			}

--- a/vlib/v3/transform/or.v
+++ b/vlib/v3/transform/or.v
@@ -434,12 +434,13 @@ fn (mut t Transformer) transform_channel_receive_or_expr(id flat.NodeId, node fl
 	}
 	channel_cast := t.make_cast('&sync.Channel', channel_source, '&sync.Channel')
 	prelude << t.make_decl_assign_typed(channel_name, channel_cast, '&sync.Channel')
-	pop_call := t.make_call_typed('sync__Channel__pop', arr2(t.make_ident(channel_name), t.make_prefix(.amp,
-		t.make_ident(val_name))), 'bool')
+	pop_call := t.make_call_typed('sync__Channel__pop', [t.make_ident(channel_name),
+		t.make_prefix(.amp, t.make_ident(val_name))], 'bool')
 	prelude << t.make_decl_assign_typed(ok_name, pop_call, 'bool')
 	t.mark_fn_used('sync__Channel__closed_error')
-	err_expr := t.make_call_typed('sync__Channel__closed_error', arr1(t.make_ident(channel_name)),
-		'IError')
+	err_expr := t.make_call_typed('sync__Channel__closed_error', [
+		t.make_ident(channel_name),
+	], 'IError')
 	else_block := t.make_block(t.lower_or_body_to_stmts_with_err_expr(body_id, val_name,
 		info.value_type, node.value, err_expr))
 	t.pending_stmts = outer_pending
@@ -484,9 +485,9 @@ fn (mut t Transformer) transform_string_slice_or_expr(id flat.NodeId, node flat.
 	ordered := t.make_infix(.le, t.make_ident(start_name), t.make_ident(end_name))
 	upper_ok := t.make_infix(.le, t.make_ident(end_name), t.make_selector(base_expr, 'len', 'int'))
 	bounds_ok := t.make_infix(.logical_and, t.make_infix(.logical_and, lower_ok, ordered), upper_ok)
-	slice_call := t.make_call_typed('string__substr', arr3(base_expr, t.make_ident(start_name),
-		t.make_ident(end_name)), 'string')
-	then_block := t.make_block(arr1(t.make_assign(t.make_ident(val_name), slice_call)))
+	slice_call := t.make_call_typed('string__substr', [base_expr, t.make_ident(start_name),
+		t.make_ident(end_name)], 'string')
+	then_block := t.make_block([t.make_assign(t.make_ident(val_name), slice_call)])
 	else_block := t.make_block(t.lower_or_body_to_stmts_with_err_expr(body_id, val_name, 'string',
 		node.value, t.make_ierror_none()))
 	t.pending_stmts = outer_pending
@@ -549,7 +550,7 @@ fn (mut t Transformer) transform_array_index_or_expr(id flat.NodeId, node flat.N
 		neg_cond := t.make_infix(.lt, t.make_ident(index_name), t.make_int_literal(0))
 		wrap_assign := t.make_assign(t.make_ident(index_name), t.make_infix(.plus,
 			t.make_ident(index_name), t.array_index_len_expr(info, base_expr)))
-		prelude << t.make_if(neg_cond, t.make_block(arr1(wrap_assign)), t.make_empty())
+		prelude << t.make_if(neg_cond, t.make_block([wrap_assign]), t.make_empty())
 	}
 	prelude << t.make_decl_assign_typed(val_name, t.zero_value_for_type(result_type), result_type)
 
@@ -576,14 +577,14 @@ fn (mut t Transformer) transform_array_index_or_expr(id flat.NodeId, node flat.N
 		opt_else_block := t.make_block(t.lower_or_body_to_stmts_with_err_expr(body_id, val_name,
 			result_type, node.value, opt_err_expr))
 		then_block = t.make_block([opt_decl,
-			t.make_if(ok_cond, t.make_block(arr1(assign_found)), opt_else_block)])
+			t.make_if(ok_cond, t.make_block([assign_found]), opt_else_block)])
 	} else {
 		index_value := if wrap_found_value {
 			t.make_optional_some(index_value0, result_type)
 		} else {
 			index_value0
 		}
-		then_block = t.make_block(arr1(t.make_assign(t.make_ident(val_name), index_value)))
+		then_block = t.make_block([t.make_assign(t.make_ident(val_name), index_value)])
 	}
 	mut opt_else := flat.empty_node
 	if info.base_optional {
@@ -597,8 +598,9 @@ fn (mut t Transformer) transform_array_index_or_expr(id flat.NodeId, node flat.N
 	}
 	if info.base_optional {
 		opt_ok := t.make_selector(t.make_ident(base_opt_name), 'ok', 'bool')
-		t.pending_stmts << t.make_if(opt_ok, t.make_block(arr1(t.make_if(found_cond, then_block,
-			else_block))), opt_else)
+		t.pending_stmts << t.make_if(opt_ok, t.make_block([
+			t.make_if(found_cond, then_block, else_block),
+		]), opt_else)
 	} else {
 		t.pending_stmts << t.make_if(found_cond, then_block, else_block)
 	}
@@ -830,16 +832,16 @@ fn (mut t Transformer) transform_enum_from_string_or_expr(id flat.NodeId, node f
 	mut else_block := t.make_block(t.lower_or_body_to_stmts(body_id, val_name, info.enum_type,
 		node.value, ''))
 	for i := members.len - 1; i >= 0; i-- {
-		cond := t.make_call_typed('string__eq', arr2(t.make_ident(str_name),
-			t.make_string_literal(members[i].name)), 'bool')
+		cond := t.make_call_typed('string__eq', [t.make_ident(str_name),
+			t.make_string_literal(members[i].name)], 'bool')
 		assign := t.make_assign(t.make_ident(val_name), t.enum_from_string_member_value(info,
 			members[i]))
-		then_block := t.make_block(arr1(assign))
+		then_block := t.make_block([assign])
 		else_block = t.make_if(cond, then_block, else_block)
 	}
 	if info.accept_empty {
-		cond := t.make_call_typed('string__eq', arr2(t.make_ident(str_name),
-			t.make_string_literal('')), 'bool')
+		cond := t.make_call_typed('string__eq', [t.make_ident(str_name),
+			t.make_string_literal('')], 'bool')
 		else_block = t.make_if(cond, t.make_block([]flat.NodeId{}), else_block)
 	}
 	t.pending_stmts = outer_pending
@@ -872,19 +874,19 @@ fn (mut t Transformer) try_lower_enum_from_string_call(call_id flat.NodeId, _nod
 
 	mut else_block := t.make_block([]flat.NodeId{})
 	for i := members.len - 1; i >= 0; i-- {
-		cond := t.make_call_typed('string__eq', arr2(t.make_ident(str_name),
-			t.make_string_literal(members[i].name)), 'bool')
+		cond := t.make_call_typed('string__eq', [t.make_ident(str_name),
+			t.make_string_literal(members[i].name)], 'bool')
 		assign_val := t.make_assign(t.make_ident(val_name), t.enum_from_string_member_value(info,
 			members[i]))
 		assign_ok := t.make_assign(t.make_ident(ok_name), t.make_bool_literal(true))
-		then_block := t.make_block(arr2(assign_val, assign_ok))
+		then_block := t.make_block([assign_val, assign_ok])
 		else_block = t.make_if(cond, then_block, else_block)
 	}
 	if info.accept_empty {
-		cond := t.make_call_typed('string__eq', arr2(t.make_ident(str_name),
-			t.make_string_literal('')), 'bool')
+		cond := t.make_call_typed('string__eq', [t.make_ident(str_name),
+			t.make_string_literal('')], 'bool')
 		assign_ok := t.make_assign(t.make_ident(ok_name), t.make_bool_literal(true))
-		else_block = t.make_if(cond, t.make_block(arr1(assign_ok)), else_block)
+		else_block = t.make_if(cond, t.make_block([assign_ok]), else_block)
 	}
 	t.pending_stmts = outer_pending
 	for stmt in prelude {
@@ -894,7 +896,7 @@ fn (mut t Transformer) try_lower_enum_from_string_call(call_id flat.NodeId, _nod
 
 	ok_field := t.make_sum_literal_field('ok', t.make_ident(ok_name), 'bool')
 	value_field := t.make_sum_literal_field('value', t.make_ident(val_name), info.enum_type)
-	err_expr := t.make_call_typed('error', arr1(t.make_string_literal('invalid value')), 'IError')
+	err_expr := t.make_call_typed('error', [t.make_string_literal('invalid value')], 'IError')
 	err_field := t.make_sum_literal_field('err', err_expr, 'IError')
 	start := t.a.children.len
 	t.a.children << ok_field
@@ -1397,7 +1399,7 @@ fn (mut t Transformer) zero_value_for_type(typ string) flat.NodeId {
 
 // make_panic_stmt builds make panic stmt data for transform.
 fn (mut t Transformer) make_panic_stmt(message string) flat.NodeId {
-	call := t.make_call('panic', arr1(t.make_string_literal(message)))
+	call := t.make_call('panic', [t.make_string_literal(message)])
 	return t.make_expr_stmt(call)
 }
 
@@ -1513,7 +1515,7 @@ fn (mut t Transformer) lower_or_expr_to_temp(id flat.NodeId, node flat.Node) fla
 	ok_cond := t.make_selector(opt_ident, 'ok', 'bool')
 	value_expr := t.make_selector(t.make_ident(opt_tmp), 'value', storage_value_type)
 	then_assign := t.make_assign(t.make_ident(val_tmp), value_expr)
-	then_block := t.make_block_skip_scope_drops(arr1(then_assign))
+	then_block := t.make_block_skip_scope_drops([then_assign])
 	else_stmts := if multi_types := t.multi_return_types_for_expr(expr_id, 0) {
 		t.lower_or_body_to_multi_return_stmts(body_id, val_tmp, storage_value_type, multi_types,
 			node.value, opt_tmp)
@@ -1573,11 +1575,11 @@ fn (mut t Transformer) transform_or_body_for_codegen(body_id flat.NodeId) flat.N
 	if body.kind == .block {
 		return t.make_block(t.transform_stmts(t.a.children_of(&body)))
 	}
-	if t.is_stmt_kind_id(node_kind_id(body)) {
+	if t.is_stmt_kind_id(int(body.kind)) {
 		return t.make_block(t.transform_stmt(body_id))
 	}
 	new_expr := t.transform_expr(body_id)
-	return t.make_block(arr1(t.make_expr_stmt(new_expr)))
+	return t.make_block([t.make_expr_stmt(new_expr)])
 }
 
 fn (mut t Transformer) transform_nested_optional_or_expr(expr_id flat.NodeId, or_node flat.Node) ?flat.NodeId {
@@ -1723,8 +1725,8 @@ fn (mut t Transformer) lower_nested_optional_logical_infix_part(expr flat.Node, 
 		lhs_part.expr
 	}
 	lhs_assign := t.make_assign(t.make_ident(logic_name), lhs_part.expr)
-	logical_if := t.make_if(cond, t.make_block(rhs_stmts), t.make_block(arr1(lhs_assign)))
-	stmts << t.make_guarded_nested_optional_step(ok_name, arr1(logical_if))
+	logical_if := t.make_if(cond, t.make_block(rhs_stmts), t.make_block([lhs_assign]))
+	stmts << t.make_guarded_nested_optional_step(ok_name, [logical_if])
 	return NestedOptionalPart{
 		expr:    t.make_ident(logic_name)
 		stmts:   stmts
@@ -1759,7 +1761,7 @@ fn (mut t Transformer) lower_optional_leaf_with_outer_or(expr_id flat.NodeId, or
 	opt_ident := t.make_ident(opt_tmp)
 	ok_cond := t.make_selector(opt_ident, 'ok', 'bool')
 	value_expr := t.make_selector(t.make_ident(opt_tmp), 'value', value_type)
-	then_block := t.make_block(arr1(t.make_assign(t.make_ident(val_tmp), value_expr)))
+	then_block := t.make_block([t.make_assign(t.make_ident(val_tmp), value_expr)])
 	mut else_stmts := t.lower_or_body_to_stmts(body_id, result_name, result_type, or_node.value,
 		opt_tmp)
 	else_stmts << t.make_assign(t.make_ident(ok_name), t.make_bool_literal(false))
@@ -1993,9 +1995,9 @@ fn (mut t Transformer) lower_or_body_to_multi_return_stmts(body_id flat.NodeId, 
 fn (mut t Transformer) lower_or_body_to_multi_return_stmts_with_err_expr(body_id flat.NodeId, target_name string, target_type string, field_types []types.Type, mode string, err_expr flat.NodeId) []flat.NodeId {
 	if mode == '!' || mode == '?' {
 		if t.is_optional_type_name(t.cur_fn_ret_type) {
-			return arr1(t.make_none_return_stmt_with_err_expr(err_expr))
+			return [t.make_none_return_stmt_with_err_expr(err_expr)]
 		}
-		return arr1(t.make_panic_stmt('option/result propagation failed'))
+		return [t.make_panic_stmt('option/result propagation failed')]
 	}
 	if int(body_id) < 0 || target_name.len == 0 || field_types.len == 0 {
 		return t.lower_or_body_to_stmts_with_err_expr(body_id, target_name, target_type, mode,
@@ -2214,9 +2216,9 @@ fn (mut t Transformer) lower_or_body_to_stmts_with_err_expr(body_id flat.NodeId,
 	}
 	if mode == '!' || mode == '?' {
 		if t.is_optional_type_name(t.cur_fn_ret_type) {
-			return arr1(t.make_none_return_stmt_with_err_expr(err_expr))
+			return [t.make_none_return_stmt_with_err_expr(err_expr)]
 		}
-		return arr1(t.make_panic_stmt('option/result propagation failed'))
+		return [t.make_panic_stmt('option/result propagation failed')]
 	}
 	if int(body_id) < 0 {
 		return []flat.NodeId{}
@@ -2224,7 +2226,7 @@ fn (mut t Transformer) lower_or_body_to_stmts_with_err_expr(body_id flat.NodeId,
 	body := t.a.nodes[int(body_id)]
 	if body.kind != .block {
 		if body.kind == .none_expr && t.is_optional_type_name(t.cur_fn_ret_type) {
-			return arr1(t.make_none_return_stmt())
+			return [t.make_none_return_stmt()]
 		}
 		if body.kind == .call && t.is_noreturn_call(body_id) {
 			value := t.transform_expr(body_id)
@@ -2242,7 +2244,7 @@ fn (mut t Transformer) lower_or_body_to_stmts_with_err_expr(body_id flat.NodeId,
 			}
 			return result
 		}
-		return arr1(t.make_assign(t.make_ident(target_name), t.transform_expr(body_id)))
+		return [t.make_assign(t.make_ident(target_name), t.transform_expr(body_id))]
 	}
 	mut result := []flat.NodeId{}
 	if body.children_count == 0 {

--- a/vlib/v3/transform/return.v
+++ b/vlib/v3/transform/return.v
@@ -16,11 +16,11 @@ const transformed_direct_optional_forward_value_prefix = '__transformed_direct_o
 // This is a hook for future sum type return wrapping at the transform level.
 fn (mut t Transformer) transform_return_with_sumtype_wrap(id flat.NodeId, node flat.Node) []flat.NodeId {
 	if node.children_count == 0 {
-		return arr1(id)
+		return [id]
 	}
 	// Check if current function returns a sum type
 	if t.cur_fn_ret_type.len == 0 || t.cur_fn_ret_type !in t.sum_types {
-		return arr1(id)
+		return [id]
 	}
 	// Check if the return value is a struct init whose type is a variant
 	child_id := t.a.child(&node, 0)
@@ -32,11 +32,11 @@ fn (mut t Transformer) transform_return_with_sumtype_wrap(id flat.NodeId, node f
 				// This is a variant being returned as a sum type.
 				// For now, pass through - C gen handles the wrapping.
 				// TODO: Generate explicit sum type wrapping here.
-				return arr1(id)
+				return [id]
 			}
 		}
 	}
-	return arr1(id)
+	return [id]
 }
 
 // branch_tail_expr extracts the tail EXPRESSION id from a branch block,
@@ -60,7 +60,7 @@ fn (t &Transformer) branch_tail_expr(block_id flat.NodeId) flat.NodeId {
 
 // make_return builds a `return <val>` statement node with the given type.
 fn (mut t Transformer) make_return(val flat.NodeId, ret_typ string) flat.NodeId {
-	return t.make_return_values(arr1(val), ret_typ)
+	return t.make_return_values([val], ret_typ)
 }
 
 fn (mut t Transformer) make_direct_optional_forward_return(val flat.NodeId, ret_typ string) flat.NodeId {
@@ -145,7 +145,7 @@ fn (mut t Transformer) mark_transformed_return(ret_id flat.NodeId, source_id fla
 }
 
 fn (mut t Transformer) make_transformed_return(val flat.NodeId, ret_typ string, source_id flat.NodeId) flat.NodeId {
-	return t.make_transformed_return_values(arr1(val), ret_typ, source_id)
+	return t.make_transformed_return_values([val], ret_typ, source_id)
 }
 
 fn (mut t Transformer) make_transformed_return_values(vals []flat.NodeId, ret_typ string, source_id flat.NodeId) flat.NodeId {
@@ -304,12 +304,12 @@ fn (mut t Transformer) try_expand_return_optional_expr(source_return_id flat.Nod
 	value := t.make_selector(t.make_ident(tmp_name), 'value', t.optional_base_type(expr_type))
 	then_block := t.try_convert_forwarded_wrapped_multi_return(value, expr_type, ret_type,
 		source_return_id) or {
-		t.make_block(arr1(t.make_transformed_return(value, ret_type, source_return_id)))
+		t.make_block([t.make_transformed_return(value, ret_type, source_return_id)])
 	}
 	err_expr := t.make_selector(t.make_ident(tmp_name), 'err', 'IError')
 	err_return := t.make_none_return_stmt_with_err_expr(err_expr)
 	t.mark_transformed_return(err_return, source_return_id)
-	else_block := t.make_block(arr1(err_return))
+	else_block := t.make_block([err_return])
 	result << t.make_if(ok_cond, then_block, else_block)
 	return result
 }
@@ -671,8 +671,10 @@ fn (mut t Transformer) convert_forwarded_array_to_dynamic(value_id flat.NodeId, 
 	t.pending_stmts = t.pending_stmts[..body_pending_start].clone()
 	value_name := t.new_temp('return_array_value')
 	body << t.make_decl_assign_typed(value_name, converted, t.semantic_type_name(expected_elem))
-	body << t.make_expr_stmt(t.make_call_typed('array_push', arr2(t.make_prefix(.amp,
-		t.make_ident(out_name)), t.make_prefix(.amp, t.make_ident(value_name))), 'void'))
+	body << t.make_expr_stmt(t.make_call_typed('array_push', [
+		t.make_prefix(.amp, t.make_ident(out_name)),
+		t.make_prefix(.amp, t.make_ident(value_name)),
+	], 'void'))
 	prefix << t.make_for_stmt(init, cond, post, body, src)
 	for stmt in prefix {
 		t.pending_stmts << stmt
@@ -725,8 +727,7 @@ fn (mut t Transformer) convert_forwarded_map(value_id flat.NodeId, actual_type t
 	keys_type := '[]${actual_key_storage}'
 	prefix << t.make_decl_assign_typed(out_name, t.make_new_map_call(expected_map_type),
 		t.semantic_type_name(expected_type))
-	keys_call := t.make_call_typed('map__keys', arr1(t.runtime_addr(base, actual_map_type)),
-		keys_type)
+	keys_call := t.make_call_typed('map__keys', [t.runtime_addr(base, actual_map_type)], keys_type)
 	prefix << t.make_decl_assign_typed(keys_name, keys_call, keys_type)
 	init := t.make_decl_assign_typed(idx_name, t.make_int_literal(0), 'int')
 	cond := t.make_infix(.lt, t.make_ident(idx_name), t.make_selector(t.make_ident(keys_name),
@@ -875,7 +876,7 @@ fn (mut t Transformer) build_return_if_chain(if_id flat.NodeId, ret_typ string, 
 		if else_node.kind == .if_expr {
 			// else-if chain: recurse, wrap resulting if-stmt in a block
 			inner := t.build_return_if_chain(else_id, ret_typ, extra_return_vals, source_return_id)
-			else_block = t.make_block(arr1(inner))
+			else_block = t.make_block([inner])
 		} else {
 			else_block = t.return_block_from_branch(else_id, ret_typ, extra_return_vals,
 				source_return_id)
@@ -917,7 +918,9 @@ fn (mut t Transformer) try_expand_return_if(source_return_id flat.NodeId, node f
 		extra_return_vals << t.a.child(&node, i)
 	}
 	ret_typ := if t.cur_fn_ret_type.len > 0 { t.cur_fn_ret_type } else { node.typ }
-	return arr1(t.build_return_if_chain(val_id, ret_typ, extra_return_vals, source_return_id))
+	return [
+		t.build_return_if_chain(val_id, ret_typ, extra_return_vals, source_return_id),
+	]
 }
 
 fn (t &Transformer) match_branch_tuple_parts(branch flat.Node, body_start_idx int, count int) ?TupleBlockParts {

--- a/vlib/v3/transform/sum.v
+++ b/vlib/v3/transform/sum.v
@@ -1391,8 +1391,9 @@ fn (mut t Transformer) transform_as_expr(id flat.NodeId, node flat.Node) flat.No
 				actual_type_id := t.make_selector_op(source, '_typ', 'int', field_op)
 				mismatch := t.make_infix(.ne, actual_type_id, t.make_int_literal(type_id))
 				message := 'as cast: cannot cast interface value to `${target_type}`'
-				t.pending_stmts << t.make_if(mismatch,
-					t.make_block(arr1(t.make_panic_stmt(message))), t.make_empty())
+				t.pending_stmts << t.make_if(mismatch, t.make_block([
+					t.make_panic_stmt(message),
+				]), t.make_empty())
 				object := t.make_selector_op(source, '_object', 'voidptr', field_op)
 				cast := t.make_cast('&${target_type}', object, '&${target_type}')
 				current := t.make_prefix(.mul, cast)

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -6,43 +6,15 @@ import v3.flat
 import v3.gen.c.naming
 import v3.types
 
-// arr1 supports arr1 handling for transform.
-fn arr1(a flat.NodeId) []flat.NodeId {
-	mut r := []flat.NodeId{}
-	r << a
-	return r
-}
-
-// arr2 supports arr2 handling for transform.
-fn arr2(a flat.NodeId, b flat.NodeId) []flat.NodeId {
-	mut r := []flat.NodeId{}
-	r << a
-	r << b
-	return r
-}
-
-// arr3 supports arr3 handling for transform.
-fn arr3(a flat.NodeId, b flat.NodeId, c flat.NodeId) []flat.NodeId {
-	mut r := []flat.NodeId{}
-	r << a
-	r << b
-	r << c
-	return r
-}
-
-// arr4 supports arr4 handling for transform.
-fn arr4(a flat.NodeId, b flat.NodeId, c flat.NodeId, d flat.NodeId) []flat.NodeId {
-	mut r := []flat.NodeId{}
-	r << a
-	r << b
-	r << c
-	r << d
-	return r
-}
-
-// node_kind_id supports node kind id handling for transform.
-fn node_kind_id(node flat.Node) int {
-	return int(node.kind)
+@[inline]
+fn same_transform_text(a string, b string) bool {
+	if a.len != b.len {
+		return false
+	}
+	if unsafe { a.str == b.str } {
+		return true
+	}
+	return a == b
 }
 
 // short_name_view returns the suffix after the final dot without allocating.
@@ -64,17 +36,6 @@ fn owner_name_view(name string) string {
 		}
 	}
 	return name
-}
-
-@[inline]
-fn same_transform_text(a string, b string) bool {
-	if a.len != b.len {
-		return false
-	}
-	if unsafe { a.str == b.str } {
-		return true
-	}
-	return a == b
 }
 
 // option_unwrap_marker tags a SmartcastContext produced by an `x != none`
@@ -1327,7 +1288,7 @@ fn (t &Transformer) collect_late_scan_candidates(limit int) []LateFnCandidate {
 	mut cur_file := ''
 	for i in 0 .. limit {
 		node := t.a.nodes[i]
-		kind_id := node_kind_id(node)
+		kind_id := int(node.kind)
 		if kind_id == 77 {
 			cur_file = node.value
 			cur_module = ''
@@ -1554,76 +1515,28 @@ fn new_transformer(mut a flat.FlatAst, tc &types.TypeChecker, used_fns map[strin
 // existing AST. It is also the baseline for parallel workers: worker forks add
 // only the frozen program indexes they are allowed to share.
 fn new_transformer_view(a &flat.FlatAst, tc &types.TypeChecker, used_fns map[string]bool) Transformer {
+	// Map fields not listed here are auto-initialized to empty maps by V; only
+	// the non-default fields (the AST/type-checker views and the pointer-backed
+	// lookup caches, which would otherwise be nil) need explicit values.
 	return Transformer{
-		a:                                 a
-		tc:                                unsafe { tc }
-		has_spawn_expr:                    tc.threads_condition_value()
-		refined_node_types:                map[int]string{}
-		fn_value_locals:                   map[string]string{}
-		mut_param_values:                  map[string]bool{}
-		fixed_array_param_values:          map[string]bool{}
-		mut_value_ident_nodes:             map[int]bool{}
-		pointer_value_lvalues:             map[string]bool{}
-		pointer_value_rvalues:             map[string]bool{}
-		addr_lvalue_pointer_locals:        map[string]bool{}
-		orm_initialized_fields:            map[string][]string{}
-		sql_query_data_aliases:            map[string][]string{}
-		bound_method_arrays:               map[string]BoundMethodArrayInfo{}
-		comptime_field_metas_cache:        map[string][]FieldMeta{}
-		comptime_reflected_for_roles:      map[string]u8{}
-		const_array_fixed_storage_cache:   map[string]i8{}
-		invalidated_smartcasts:            map[string]bool{}
-		escaping_amp_ptrs:                 map[string]bool{}
-		escaping_amp_sources:              map[string]bool{}
-		heaped_amp_locals:                 map[string]bool{}
-		escaping_interface_box_locals:     map[string]bool{}
-		local_closure_cleanup_decls:       map[int]string{}
-		local_closure_cleanup_values:      map[int]string{}
-		local_closure_cleanup_assigns:     map[int]string{}
-		local_closure_field_cleanups:      map[int]bool{}
-		exclusive_closure_return_fns:      map[string]bool{}
-		mut_fixed_array_capture_sources:   map[string]bool{}
-		generic_specialization_args:       map[string][]string{}
-		generic_fn_specs_in_progress:      map[string]bool{}
-		generic_fn_spec_nodes:             map[string]flat.NodeId{}
-		monomorph_cache_specs:             map[string]MonomorphCacheSpec{}
-		specialization_decl_nodes_by_name: map[string][]int{}
-		pending_generic_fn_spec_keys:      map[string]bool{}
-		generic_receiver_methods_by_name:  map[string][]string{}
-		generic_call_spec_cache:           map[int]GenericCallSpec{}
-		generic_call_spec_misses:          map[int]bool{}
-		monomorph_error_seen:              map[string]bool{}
-		call_param_types_decl_cache:       map[int][]types.Type{}
-		call_param_types_decl_misses:      map[string]bool{}
-		call_param_types_decl_index:       map[string]FnParamDeclRef{}
-		enum_backing_types:                map[string]string{}
-		sum_variant_names:                 map[string]bool{}
-		receiver_method_suffix_index:      map[string]string{}
-		declared_fn_name_counts:           map[string]u8{}
-		variadic_suffix_index:             map[string]i8{}
-		used_fns:                          used_fns.clone()
-		comptime_reflected_params:         map[string][]ParamMeta{}
-		interface_boxed_types:             map[string]bool{}
-		interface_boxed_impl_processed:    map[string]bool{}
-		interface_impl_indexes:            map[string]&types.InterfaceImplIndex{}
-		interface_var_concrete_types:      map[string]string{}
-		interface_box_param_cache:         &BoolLookupCache{
+		a:                           a
+		tc:                          unsafe { tc }
+		has_spawn_expr:              tc.threads_condition_value()
+		used_fns:                    used_fns.clone()
+		interface_box_param_cache:   &BoolLookupCache{
 			entries: map[string]i8{}
 		}
-		alias_receiver_method_cache:       &LookupCache{
+		alias_receiver_method_cache: &LookupCache{
 			entries: map[string]string{}
 			misses:  map[string]bool{}
 		}
-		call_variadic_cache:               &BoolLookupCache{
+		call_variadic_cache:         &BoolLookupCache{
 			entries: map[string]i8{}
 		}
-		str_alias_cache:                   &LookupCache{
+		str_alias_cache:             &LookupCache{
 			entries: map[string]string{}
 			misses:  map[string]bool{}
 		}
-		var_type_indices:                  map[string]int{}
-		scoped_owned_base_nodes:           map[int]bool{}
-		scoped_promoted_texts:             map[string]string{}
 	}
 }
 
@@ -1720,6 +1633,9 @@ fn local_method_fn_name_needs_module_prefix(name string) bool {
 }
 
 fn (mut t Transformer) prepare() {
+	// Optional experimental override of the autostr nesting cap; see
+	// max_stringify_nesting_depth. Left in place as a runtime knob for tuning the
+	// combinatorial autostr expansion without a recompile.
 	cap_env := os.getenv('V3_STR_CAP')
 	if cap_env != '' {
 		t.stringify_depth_cap = cap_env.int()
@@ -3053,7 +2969,7 @@ fn (mut t Transformer) transform_all() {
 	mut transformed_count := 0
 	for i in 0 .. node_count {
 		node := t.a.nodes[i]
-		kind_id := node_kind_id(node)
+		kind_id := int(node.kind)
 		if kind_id == 77 {
 			t.cur_file = node.value
 			t.cur_module = t.tc.file_modules[node.value] or { '' }
@@ -3092,7 +3008,7 @@ fn (t &Transformer) has_entry_main() bool {
 	}
 	mut cur_module := ''
 	for node in t.a.nodes {
-		kind_id := node_kind_id(node)
+		kind_id := int(node.kind)
 		if kind_id == 77 {
 			cur_module = ''
 			continue
@@ -3389,7 +3305,7 @@ fn (mut t Transformer) transform_serial_then_collect_pure(literal_decls []int) [
 		span_cost := i - prev_tl_any
 		prev_tl_any = i
 		node := t.a.nodes[i]
-		kind_id := node_kind_id(node)
+		kind_id := int(node.kind)
 		if kind_id == 77 {
 			t.cur_file = node.value
 			t.cur_module = t.tc.file_modules[node.value] or { '' }
@@ -3548,7 +3464,7 @@ fn (mut t Transformer) collect_literal_fn_decls(limit int) []int {
 	mut literal_pending := false
 	for i in 0 .. limit {
 		node := t.a.nodes[i]
-		kid := node_kind_id(node)
+		kid := int(node.kind)
 		// 21 = fn_literal, 32 = lambda_expr (see fn_subtree_scan's old check).
 		if kid == 21 || kid == 32 {
 			literal_pending = true
@@ -4842,7 +4758,7 @@ fn (mut t Transformer) transform_late_used_fn_bodies(names []string, node_limit 
 	// of candidate fn_decls, their (file, module) context, and their generic-ness
 	// never change across rounds. Re-deriving all of this every round previously
 	// made this pass O(pending * nodes): a full node walk (millions of
-	// node_kind_id calls) plus a repeated fn_decl_has_unresolved_generics check
+	// node-kind reads) plus a repeated fn_decl_has_unresolved_generics check
 	// on every non-matching fn_decl.
 	mut candidates := []LateFnCandidate{}
 	mut scan_file := ''
@@ -4859,7 +4775,7 @@ fn (mut t Transformer) transform_late_used_fn_bodies(names []string, node_limit 
 			continue
 		}
 		node := t.a.nodes[i]
-		kind_id := node_kind_id(node)
+		kind_id := int(node.kind)
 		if kind_id == 77 {
 			scan_file = node.value
 			scan_module = ''
@@ -5391,7 +5307,7 @@ fn (mut t Transformer) transform_const_string_interp(_id flat.NodeId, node flat.
 	}
 	mut expr := parts[0]
 	for i in 1 .. parts.len {
-		expr = t.make_call_typed('string__plus', arr2(expr, parts[i]), 'string')
+		expr = t.make_call_typed('string__plus', [expr, parts[i]], 'string')
 	}
 	mut stmts := []flat.NodeId{}
 	t.drain_pending(mut stmts)
@@ -5847,12 +5763,12 @@ fn (mut t Transformer) make_memdup_call_for_type(addr flat.NodeId, type_name str
 		align_arg := if align.len > 0 {
 			t.make_int_literal_typed(align, 'usize')
 		} else {
-			t.make_call_typed('__alignof__', arr1(t.make_ident(type_name)), 'usize')
+			t.make_call_typed('__alignof__', [t.make_ident(type_name)], 'usize')
 		}
-		return t.make_non_aliasing_allocation_call('v3_aligned_memdup',
-			arr3(addr, size, align_arg), 'voidptr')
+		return t.make_non_aliasing_allocation_call('v3_aligned_memdup', [addr, size, align_arg],
+			'voidptr')
 	}
-	return t.make_non_aliasing_allocation_call('memdup', arr2(addr, size), 'voidptr')
+	return t.make_non_aliasing_allocation_call('memdup', [addr, size], 'voidptr')
 }
 
 fn (mut t Transformer) make_non_aliasing_allocation_call(name string, args []flat.NodeId, typ string) flat.NodeId {
@@ -8525,7 +8441,7 @@ fn (mut t Transformer) transform_fn_body(fn_idx int) {
 			continue
 		}
 		child := t.a.nodes[int(child_id)]
-		if node_kind_id(child) != 75 {
+		if int(child.kind) != 75 {
 			if t.prefix_param_scan {
 				break
 			}
@@ -8607,7 +8523,7 @@ fn (mut t Transformer) transform_fn_body(fn_idx int) {
 				continue
 			}
 			child := t.a.nodes[int(child_id)]
-			if node_kind_id(child) != 75 {
+			if int(child.kind) != 75 {
 				body_ids << child_id
 			}
 		}
@@ -8646,7 +8562,7 @@ fn (mut t Transformer) transform_fn_body(fn_idx int) {
 				continue
 			}
 			child := t.a.nodes[int(child_id)]
-			if node_kind_id(child) == 75 {
+			if int(child.kind) == 75 {
 				new_children << child_id
 			}
 		}
@@ -8820,11 +8736,11 @@ pub fn (mut t Transformer) transform_stmts(ids []flat.NodeId) []flat.NodeId {
 		id := ids[i]
 		if int(id) >= 0 && i + 1 < ids.len {
 			node := t.a.nodes[int(id)]
-			if node_kind_id(node) == 44 && node.children_count == 0 && t.cur_fn_ret_type.len > 0
+			if int(node.kind) == 44 && node.children_count == 0 && t.cur_fn_ret_type.len > 0
 				&& t.cur_fn_ret_type != 'void' {
 				next_id := ids[i + 1]
 				next_node := t.a.nodes[int(next_id)]
-				if node_kind_id(next_node) == 39 && next_node.children_count > 0 {
+				if int(next_node.kind) == 39 && next_node.children_count > 0 {
 					expr_id := t.a.child(&next_node, 0)
 					start := t.a.children.len
 					t.a.children << expr_id
@@ -9003,10 +8919,10 @@ fn (mut t Transformer) transform_labeled_multi_init_loop(label string, block_id 
 @[direct_array_access]
 pub fn (mut t Transformer) transform_stmt(id flat.NodeId) []flat.NodeId {
 	if int(id) < 0 {
-		return arr1(id)
+		return [id]
 	}
 	node := t.a.nodes[int(id)]
-	kind_id := node_kind_id(node)
+	kind_id := int(node.kind)
 	if kind_id == 44 {
 		return t.transform_return_stmt(id, node)
 	}
@@ -9032,7 +8948,7 @@ pub fn (mut t Transformer) transform_stmt(id flat.NodeId) []flat.NodeId {
 		return t.transform_if_stmt(id, node)
 	}
 	if kind_id == 50 {
-		return arr1(t.lower_one_match(node))
+		return [t.lower_one_match(node)]
 	}
 	if kind_id == 52 {
 		return t.transform_defer_stmt(id, node)
@@ -9075,7 +8991,7 @@ pub fn (mut t Transformer) transform_stmt(id flat.NodeId) []flat.NodeId {
 			return t.transform_if_stmt(id, node)
 		}
 		.match_stmt {
-			return arr1(t.lower_one_match(node))
+			return [t.lower_one_match(node)]
 		}
 		.defer_stmt {
 			return t.transform_defer_stmt(id, node)
@@ -9087,7 +9003,7 @@ pub fn (mut t Transformer) transform_stmt(id flat.NodeId) []flat.NodeId {
 			return t.transform_select_stmt(id, node)
 		}
 		else {
-			return arr1(id)
+			return [id]
 		}
 	}
 }
@@ -9112,7 +9028,7 @@ pub fn (mut t Transformer) transform_expr(id flat.NodeId) flat.NodeId {
 	if optional_wrapper_access_marker in node.generic_params() {
 		return id
 	}
-	kind_id := node_kind_id(node)
+	kind_id := int(node.kind)
 	if kind_id == 8 {
 		return t.transform_infix_expr(id, node)
 	}
@@ -9439,7 +9355,7 @@ fn (mut t Transformer) transform_dump_expr(node flat.Node) flat.NodeId {
 		prefix :=
 			t.make_string_literal('[${dump_relative_source_path(path)}:${line}] ${expr_text}: ')
 		message := t.string_plus(prefix, value_text)
-		t.pending_stmts << t.make_expr_stmt(t.make_call('eprintln', arr1(message)))
+		t.pending_stmts << t.make_expr_stmt(t.make_call('eprintln', [message]))
 	}
 	return t.make_ident(temp_name)
 }
@@ -10243,7 +10159,7 @@ pub fn (mut t Transformer) transform_lvalue(id flat.NodeId) flat.NodeId {
 // transform_return_stmt transforms transform return stmt data for transform.
 fn (mut t Transformer) transform_return_stmt(id flat.NodeId, node flat.Node) []flat.NodeId {
 	if node.children_count == 0 {
-		return arr1(id)
+		return [id]
 	}
 	source_return_id := t.return_drop_source_id(id, node)
 	if expanded := t.try_expand_return_if(source_return_id, node) {
@@ -10649,7 +10565,7 @@ fn (mut t Transformer) heap_copy_escaping_interface_box_local(name string) ?stri
 		object_lhs := t.make_selector(t.make_ident(tmp_name), '_object', 'voidptr')
 		object_rhs := t.make_selector(t.make_ident(tmp_name), '_object', 'voidptr')
 		dup := t.make_memdup_call_for_type(object_rhs, impl)
-		t.pending_stmts << t.make_if(cond, t.make_block(arr1(t.make_assign(object_lhs, dup))),
+		t.pending_stmts << t.make_if(cond, t.make_block([t.make_assign(object_lhs, dup)]),
 			t.make_empty())
 	}
 	return tmp_name
@@ -10794,7 +10710,7 @@ fn (mut t Transformer) precompute_const_array_fixed_storage() {
 	mut cur_module := 'main'
 	mut cur_file := ''
 	for idx, node in t.a.nodes {
-		kind_id := node_kind_id(node)
+		kind_id := int(node.kind)
 		if kind_id == 77 {
 			cur_file = node.value
 			cur_module = 'main'
@@ -10910,7 +10826,7 @@ fn (t &Transformer) const_array_literal_requires_fixed_storage_uncached(key stri
 		key
 	}
 	for idx, node in t.a.nodes {
-		kind_id := node_kind_id(node)
+		kind_id := int(node.kind)
 		if kind_id == 77 {
 			cur_file = node.value
 			cur_module = 'main'
@@ -11061,7 +10977,7 @@ fn qualified_const_key_matches(key string, qualifier string, name string) bool {
 // transform_assign_stmt transforms transform assign stmt data for transform.
 fn (mut t Transformer) transform_assign_stmt(id flat.NodeId, node flat.Node) []flat.NodeId {
 	if node.children_count == 0 {
-		return arr1(id)
+		return [id]
 	}
 	if expanded := t.try_expand_multi_return_assign(node) {
 		return expanded
@@ -11230,7 +11146,7 @@ fn (mut t Transformer) transform_assign_stmt(id flat.NodeId, node flat.Node) []f
 			result << t.make_decl_assign_typed(tmp_name, tmp_value, tmp_type)
 			lvalue := t.stabilize_transformed_lvalue_for_reuse(new_children[0])
 			t.drain_pending(mut result)
-			drop_call := t.make_call_typed('drop_owned', arr1(lvalue), 'void')
+			drop_call := t.make_call_typed('drop_owned', [lvalue], 'void')
 			result << t.make_expr_stmt(drop_call)
 			result << t.make_assign_after_owned_drop(lvalue, t.make_ident(tmp_name))
 			t.invalidate_smartcast_for_lvalue(t.a.child(&node, 0))
@@ -11267,8 +11183,9 @@ fn (mut t Transformer) transform_assign_stmt(id flat.NodeId, node flat.Node) []f
 		tmp_name := t.new_temp('closure_assign')
 		result << t.make_decl_assign_typed(tmp_name, new_children[1], closure_type)
 		destroy_condition := t.make_infix(.ne, t.make_ident(tmp_name), t.make_ident(cleanup_name))
-		result << t.make_if(destroy_condition,
-			t.make_block(arr1(t.make_local_closure_destroy_stmt(cleanup_name))), t.make_empty())
+		result << t.make_if(destroy_condition, t.make_block([
+			t.make_local_closure_destroy_stmt(cleanup_name),
+		]), t.make_empty())
 		result << t.make_assign(new_children[0], t.make_ident(tmp_name))
 		if post_assign := t.fn_value_self_capture_refresh_stmt(node, new_children) {
 			result << post_assign
@@ -11548,14 +11465,14 @@ fn (mut t Transformer) stabilize_transformed_lvalue_for_reuse(id flat.NodeId) fl
 			}
 			child := t.stabilize_transformed_lvalue_component(t.a.child(&node, 0),
 				'drop_lvalue_pointer')
-			return t.rebuild_transformed_lvalue(node, arr1(child))
+			return t.rebuild_transformed_lvalue(node, [child])
 		}
 		.paren {
 			if node.children_count == 0 {
 				return id
 			}
 			child := t.stabilize_transformed_lvalue_for_reuse(t.a.child(&node, 0))
-			return t.rebuild_transformed_lvalue(node, arr1(child))
+			return t.rebuild_transformed_lvalue(node, [child])
 		}
 		else {
 			return id
@@ -11656,10 +11573,12 @@ fn (mut t Transformer) optional_selector_lvalue_guard_stmts(body_id flat.NodeId,
 	err_expr := t.make_selector(guard_source, 'err', 'IError')
 	if mode == '!' || mode == '?' {
 		if t.is_optional_type_name(t.cur_fn_ret_type) {
-			return arr1(t.make_return(t.make_optional_none_with_err(t.cur_fn_ret_type, err_expr),
-				t.cur_fn_ret_type))
+			return [
+				t.make_return(t.make_optional_none_with_err(t.cur_fn_ret_type, err_expr),
+					t.cur_fn_ret_type),
+			]
 		}
-		return arr1(t.make_panic_stmt('option/result propagation failed'))
+		return [t.make_panic_stmt('option/result propagation failed')]
 	}
 	return t.lower_or_body_to_stmts_with_err_expr(body_id, '', '', mode, err_expr)
 }
@@ -11790,8 +11709,8 @@ fn (mut t Transformer) try_lower_struct_compound_assign(node flat.Node) ?[]flat.
 	method_name := t.struct_operator_fn_name(operator_type, op_name) or { return none }
 	rhs := t.transform_expr_for_type(rhs_id, lhs_type)
 	t.mark_fn_used_name(method_name)
-	call := t.make_call_typed(method_name, arr2(t.make_ident(lhs.value), rhs), lhs_type)
-	return arr1(t.make_assign(t.make_ident(lhs.value), call))
+	call := t.make_call_typed(method_name, [t.make_ident(lhs.value), rhs], lhs_type)
+	return [t.make_assign(t.make_ident(lhs.value), call)]
 }
 
 fn (mut t Transformer) compound_assign_operator_type(lhs_id flat.NodeId, lhs_type string, op_name string) ?string {
@@ -12078,7 +11997,7 @@ fn (mut t Transformer) build_interface_field_assign_chain(base_ptr flat.NodeId, 
 	then_stmt := t.make_assign_op(field_lhs, rhs, op)
 	else_stmt := t.build_interface_field_assign_chain(base_ptr, impl_index, field, field_type, rhs,
 		op, idx + 1)
-	return t.make_if(cond, t.make_block(arr1(then_stmt)), else_stmt)
+	return t.make_if(cond, t.make_block([then_stmt]), else_stmt)
 }
 
 fn (mut t Transformer) lower_interface_field_selector(base flat.NodeId, base_type string, iface_name string, field string, field_type string) flat.NodeId {
@@ -12117,10 +12036,10 @@ fn (mut t Transformer) build_interface_field_selector_chain(base flat.NodeId, ba
 		return t.build_interface_field_selector_chain(base, base_type, iface_name, impl_index,
 			field, field_type, fallback, idx + 1)
 	}
-	then_block := t.make_block(arr1(t.make_expr_stmt(value)))
+	then_block := t.make_block([t.make_expr_stmt(value)])
 	else_expr := t.build_interface_field_selector_chain(base, base_type, iface_name, impl_index,
 		field, field_type, fallback, idx + 1)
-	else_block := t.make_block(arr1(t.make_expr_stmt(else_expr)))
+	else_block := t.make_block([t.make_expr_stmt(else_expr)])
 	start := t.a.children.len
 	t.a.children << cond
 	t.a.children << then_block
@@ -12219,7 +12138,7 @@ fn (mut t Transformer) build_sum_shared_field_assign_chain(base flat.NodeId, sum
 		}
 		then_stmt = t.make_assign_op(field_lhs, rhs, op)
 	}
-	then_block := t.make_block(arr1(then_stmt))
+	then_block := t.make_block([then_stmt])
 	else_stmt := t.build_sum_shared_field_assign_chain(base, sum_type, resolved_sum, variants,
 		field, field_type, rhs, op, idx + 1)
 	return t.make_if(cond, then_block, else_stmt)
@@ -12314,14 +12233,16 @@ fn (mut t Transformer) try_lower_pointer_value_assign(node flat.Node) ?[]flat.No
 			return none
 		}
 		new_lhs := t.make_prefix(.mul, t.make_ident(lhs.value))
-		return arr1(t.make_assign_op(new_lhs, t.transform_expr(rhs_id), node.op))
+		return [t.make_assign_op(new_lhs, t.transform_expr(rhs_id), node.op)]
 	}
 	if !t.pointer_value_lvalues[lhs.value] {
 		return none
 	}
 	if lhs.value in t.heaped_amp_locals {
 		new_lhs := t.make_prefix(.mul, t.make_ident(lhs.value))
-		return arr1(t.make_assign(new_lhs, t.transform_expr_for_type(rhs_id, lhs_value_type_raw)))
+		return [
+			t.make_assign(new_lhs, t.transform_expr_for_type(rhs_id, lhs_value_type_raw)),
+		]
 	}
 	rhs_node := t.a.nodes[int(rhs_id)]
 	if rhs_node.kind == .prefix && rhs_node.op == .amp {
@@ -12345,7 +12266,9 @@ fn (mut t Transformer) try_lower_pointer_value_assign(node flat.Node) ?[]flat.No
 		return none
 	}
 	new_lhs := t.make_prefix(.mul, t.make_ident(lhs.value))
-	return arr1(t.make_assign(new_lhs, t.transform_expr_for_type(rhs_id, lhs_value_type_raw)))
+	return [
+		t.make_assign(new_lhs, t.transform_expr_for_type(rhs_id, lhs_value_type_raw)),
+	]
 }
 
 fn (t &Transformer) pointer_value_assign_rhs_matches(lhs_value_type_raw string, lhs_value_type string, rhs_type string) bool {
@@ -13129,7 +13052,7 @@ fn (mut t Transformer) make_ierror_none() flat.NodeId {
 	none_value := t.make_struct_init('None__')
 	addr := t.make_prefix(.amp, none_value)
 	size := t.make_sizeof_type('None__')
-	dup := t.make_non_aliasing_allocation_call('memdup', arr2(addr, size), 'voidptr')
+	dup := t.make_non_aliasing_allocation_call('memdup', [addr, size], 'voidptr')
 	object := t.make_cast('&None__', dup, '&None__')
 	type_id := t.ierror_none_type_id
 	fields := [
@@ -13302,16 +13225,16 @@ fn (mut t Transformer) try_lower_string_compound_assign(_id flat.NodeId, node fl
 		t.transform_expr(rhs_id)
 	}
 	lhs_copy := t.make_ident(lhs.value)
-	concat := t.make_call('string__plus', arr2(lhs_copy, new_rhs))
+	concat := t.make_call('string__plus', [lhs_copy, new_rhs])
 	new_lhs := t.make_ident(lhs.value)
-	return arr1(t.make_assign(new_lhs, concat))
+	return [t.make_assign(new_lhs, concat)]
 }
 
 // transform_decl_assign_stmt transforms transform decl assign stmt data for transform.
 @[direct_array_access]
 fn (mut t Transformer) transform_decl_assign_stmt(id flat.NodeId, node flat.Node) []flat.NodeId {
 	if node.children_count == 0 {
-		return arr1(id)
+		return [id]
 	}
 	source_rhs_id := if node.children_count == 2 {
 		t.a.child(&node, 1)
@@ -13840,7 +13763,7 @@ fn (mut t Transformer) append_local_closure_aggregate_value_cleanup(value flat.N
 
 fn (mut t Transformer) make_local_closure_cleanup_defer(name string) flat.NodeId {
 	destroy_stmt := t.make_local_closure_destroy_stmt(name)
-	body := t.make_block(arr1(destroy_stmt))
+	body := t.make_block([destroy_stmt])
 	start := t.a.children.len
 	t.a.children << body
 	return t.a.add_node(flat.Node{
@@ -13857,7 +13780,7 @@ fn (mut t Transformer) make_local_closure_destroy_stmt(name string) flat.NodeId 
 		t.set_node_typ(int(closure_value), closure_type)
 	}
 	closure_ptr := t.make_cast('voidptr', closure_value, 'voidptr')
-	destroy := t.make_call_typed('closure.closure_try_destroy', arr1(closure_ptr), 'void')
+	destroy := t.make_call_typed('closure.closure_try_destroy', [closure_ptr], 'void')
 	t.mark_fn_used_name('closure.closure_try_destroy')
 	return t.make_expr_stmt(destroy)
 }
@@ -14061,7 +13984,7 @@ fn (mut t Transformer) try_expand_multi_return_assign(node flat.Node) ?[]flat.No
 	}
 	if rhs.kind == .match_stmt {
 		if expanded := t.expand_multi_return_match_assign(rhs_id, rhs, lhs_ids) {
-			return arr1(expanded)
+			return [expanded]
 		}
 	}
 	if rhs_types := t.multi_return_types_for_expr(rhs_id, lhs_ids.len) {
@@ -15110,7 +15033,7 @@ fn (t &Transformer) tuple_value_type(id flat.NodeId) string {
 // transform_expr_stmt transforms transform expr stmt data for transform.
 fn (mut t Transformer) transform_expr_stmt(id flat.NodeId, node flat.Node) []flat.NodeId {
 	if node.children_count == 0 {
-		return arr1(id)
+		return [id]
 	}
 	child_id := t.a.children[node.children_start]
 	child := t.a.nodes[int(child_id)]
@@ -15184,7 +15107,7 @@ fn (mut t Transformer) transform_expr_stmt(id flat.NodeId, node flat.Node) []fla
 		return lowered
 	}
 	if lowered := t.try_lower_flag_enum_stmt(child_id) {
-		return arr1(lowered)
+		return [lowered]
 	}
 	new_child := t.transform_expr(child_id)
 	if child.kind == .select_stmt && t.a.node(new_child).kind == .block {
@@ -15432,15 +15355,15 @@ fn (mut t Transformer) transform_block_stmt(id flat.NodeId, node flat.Node) []fl
 	}
 	new_children := t.transform_stmts(child_ids)
 	if t.rewrite_children_in_place(id, new_children) {
-		return arr1(id)
+		return [id]
 	}
 	new_block := t.make_block(new_children)
 	t.set_node_value(int(new_block), node.value)
-	return arr1(new_block)
+	return [new_block]
 }
 
 fn (mut t Transformer) transform_comptime_if_stmt(_id flat.NodeId, node flat.Node) []flat.NodeId {
-	take_then := t.comptime_type_condition_value(node.value) or { return arr1(_id) }
+	take_then := t.comptime_type_condition_value(node.value) or { return [_id] }
 	branch_index := if take_then { 0 } else { 1 }
 	for i in 0 .. node.children_count {
 		if i != branch_index {
@@ -16080,7 +16003,7 @@ fn (mut t Transformer) transform_lock_node(id flat.NodeId, node flat.Node) flat.
 			t.set_node_typ(int(new_block), node.typ)
 		}
 		new_block
-	} else if t.is_stmt_kind_id(node_kind_id(body)) {
+	} else if t.is_stmt_kind_id(int(body.kind)) {
 		t.make_block(t.transform_stmt(body_id))
 	} else {
 		t.transform_expr(body_id)
@@ -16134,7 +16057,7 @@ fn (mut t Transformer) transform_if_stmt(id flat.NodeId, node flat.Node) []flat.
 			branch_id := t.a.child(&node, branch_index)
 			branch := t.a.nodes[int(branch_id)]
 			if branch.kind == .block {
-				return arr1(t.transform_block_expr(branch_id, branch))
+				return [t.transform_block_expr(branch_id, branch)]
 			}
 			return t.transform_stmt(branch_id)
 		}
@@ -16146,19 +16069,19 @@ fn (mut t Transformer) transform_if_stmt(id flat.NodeId, node flat.Node) []flat.
 // transform_defer_stmt transforms transform defer stmt data for transform.
 fn (mut t Transformer) transform_defer_stmt(id flat.NodeId, node flat.Node) []flat.NodeId {
 	if node.children_count == 0 {
-		return arr1(id)
+		return [id]
 	}
 	body_id := t.a.child(&node, 0)
 	if int(body_id) < 0 {
-		return arr1(id)
+		return [id]
 	}
 	body := t.a.nodes[int(body_id)]
 	new_body := if body.kind == .block {
 		t.transform_block_expr(body_id, body)
-	} else if t.is_stmt_kind_id(node_kind_id(body)) {
+	} else if t.is_stmt_kind_id(int(body.kind)) {
 		t.make_block(t.transform_stmt(body_id))
 	} else {
-		t.make_block(arr1(t.transform_expr(body_id)))
+		t.make_block([t.transform_expr(body_id)])
 	}
 	new_id := if t.rewrite_one_child_in_place(id, new_body) {
 		id
@@ -16174,11 +16097,11 @@ fn (mut t Transformer) transform_defer_stmt(id flat.NodeId, node flat.Node) []fl
 			typ:            node.typ
 		})
 	}
-	return arr1(new_id)
+	return [new_id]
 }
 
 fn (mut t Transformer) transform_select_stmt(id flat.NodeId, node flat.Node) []flat.NodeId {
-	return arr1(t.transform_select_expr(id, node))
+	return [t.transform_select_expr(id, node)]
 }
 
 fn (mut t Transformer) transform_select_expr(id flat.NodeId, node flat.Node) flat.NodeId {
@@ -16189,7 +16112,7 @@ fn (mut t Transformer) transform_select_expr(id flat.NodeId, node flat.Node) fla
 			for i in 0 .. branch.children_count {
 				child_id := t.a.child(branch, i)
 				child := t.a.node(child_id)
-				if t.is_stmt_kind_id(node_kind_id(child)) {
+				if t.is_stmt_kind_id(int(child.kind)) {
 					body << t.transform_stmt(child_id)
 				} else {
 					body << t.transform_expr(child_id)
@@ -16316,7 +16239,7 @@ fn (mut t Transformer) transform_select_branch(id flat.NodeId) flat.NodeId {
 	for i in body_start .. branch.children_count {
 		child_id := t.a.child(&branch, i)
 		child := t.a.nodes[int(child_id)]
-		if t.is_stmt_kind_id(node_kind_id(child)) {
+		if t.is_stmt_kind_id(int(child.kind)) {
 			for expanded in t.transform_stmt(child_id) {
 				children << expanded
 			}
@@ -16381,13 +16304,13 @@ fn (mut t Transformer) restore_shadowed_smartcast_state(name string, base_smartc
 // Generic handler: rebuild a node with all children recursively transformed.
 fn (mut t Transformer) transform_children_stmt(id flat.NodeId, node flat.Node) []flat.NodeId {
 	if node.children_count == 0 {
-		return arr1(id)
+		return [id]
 	}
 	mut new_children := []flat.NodeId{cap: int(node.children_count)}
 	for i in 0 .. node.children_count {
 		child_id := t.a.child(&node, i)
 		child := t.a.nodes[int(child_id)]
-		if t.is_stmt_kind_id(node_kind_id(child)) {
+		if t.is_stmt_kind_id(int(child.kind)) {
 			expanded := t.transform_stmt(child_id)
 			for eid in expanded {
 				new_children << eid
@@ -16397,7 +16320,7 @@ fn (mut t Transformer) transform_children_stmt(id flat.NodeId, node flat.Node) [
 		}
 	}
 	if t.rewrite_children_in_place(id, new_children) {
-		return arr1(id)
+		return [id]
 	}
 	start := t.a.children.len
 	for nc in new_children {
@@ -16413,7 +16336,7 @@ fn (mut t Transformer) transform_children_stmt(id flat.NodeId, node flat.Node) [
 		value:          node.value
 		typ:            node.typ
 	})
-	return arr1(new_id)
+	return [new_id]
 }
 
 // transform_assert_stmt lowers a value `if`/`match` used as the assert
@@ -16422,7 +16345,7 @@ fn (mut t Transformer) transform_children_stmt(id flat.NodeId, node flat.Node) [
 // which is not a C expression, and emits an empty `if (!())` condition.
 fn (mut t Transformer) transform_assert_stmt(id flat.NodeId, node flat.Node) []flat.NodeId {
 	if node.children_count == 0 {
-		return arr1(id)
+		return [id]
 	}
 	cond_id := t.a.child(&node, 0)
 	cond := t.a.nodes[int(cond_id)]
@@ -16435,7 +16358,7 @@ fn (mut t Transformer) transform_assert_stmt(id flat.NodeId, node flat.Node) []f
 	for i in 1 .. node.children_count {
 		child_id := t.a.child(&node, i)
 		child := t.a.nodes[int(child_id)]
-		if t.is_stmt_kind_id(node_kind_id(child)) {
+		if t.is_stmt_kind_id(int(child.kind)) {
 			for eid in t.transform_stmt(child_id) {
 				new_children << eid
 			}
@@ -16444,7 +16367,7 @@ fn (mut t Transformer) transform_assert_stmt(id flat.NodeId, node flat.Node) []f
 		}
 	}
 	if t.rewrite_children_in_place(id, new_children) {
-		return arr1(id)
+		return [id]
 	}
 	start := t.a.children.len
 	for nc in new_children {
@@ -16460,7 +16383,7 @@ fn (mut t Transformer) transform_assert_stmt(id flat.NodeId, node flat.Node) []f
 		value:          node.value
 		typ:            node.typ
 	})
-	return arr1(new_id)
+	return [new_id]
 }
 
 // --- expr handlers (skeleton - identity transforms with child recursion) ---
@@ -16479,7 +16402,7 @@ fn (mut t Transformer) transform_children_expr(id flat.NodeId, node flat.Node) f
 			continue
 		}
 		child := t.a.nodes[int(child_id)]
-		if t.is_stmt_kind_id(node_kind_id(child)) {
+		if t.is_stmt_kind_id(int(child.kind)) {
 			expanded := t.transform_stmt(child_id)
 			if expanded.len == 1 {
 				new_children << expanded[0]
@@ -17094,8 +17017,8 @@ fn (mut t Transformer) lower_gated_scalar_index(node flat.Node) ?flat.NodeId {
 	t.set_node_typ(int(cond), 'bool')
 	wrapped := t.make_infix(.plus, idx, len_sel)
 	t.set_node_typ(int(wrapped), 'int')
-	then_block := t.make_block(arr1(t.make_expr_stmt(wrapped)))
-	else_block := t.make_block(arr1(t.make_expr_stmt(idx)))
+	then_block := t.make_block([t.make_expr_stmt(wrapped)])
+	else_block := t.make_block([t.make_expr_stmt(idx)])
 	if_start := t.a.children.len
 	t.a.children << cond
 	t.a.children << then_block
@@ -17230,8 +17153,9 @@ fn (mut t Transformer) lower_owned_array_index_move(source_id flat.NodeId, index
 	t.pending_stmts << t.make_index_assign(t.make_index(array_value, index_value, elem_type),
 		t.zero_value_for_type(elem_type))
 	if source_is_owned_temporary {
-		t.pending_stmts << t.make_expr_stmt(t.make_call_typed('drop_owned', arr1(array_value),
-			'void'))
+		t.pending_stmts << t.make_expr_stmt(t.make_call_typed('drop_owned', [
+			array_value,
+		], 'void'))
 	}
 	result := t.make_ident(result_name)
 	t.set_node_typ(int(result), elem_type)
@@ -18242,10 +18166,10 @@ fn (mut t Transformer) build_sum_shared_field_chain(base flat.NodeId, sum_type s
 			t.make_selector_op(variant_base, field, field_type, if use_ptr { .arrow } else { .dot })
 		}
 	}
-	then_block := t.make_block(arr1(t.make_expr_stmt(value)))
+	then_block := t.make_block([t.make_expr_stmt(value)])
 	else_expr := t.build_sum_shared_field_chain(base, sum_type, resolved_sum, variants, field,
 		field_type, idx + 1)
-	else_block := t.make_block(arr1(t.make_expr_stmt(else_expr)))
+	else_block := t.make_block([t.make_expr_stmt(else_expr)])
 	start := t.a.children.len
 	t.a.children << cond
 	t.a.children << then_block
@@ -18550,7 +18474,7 @@ fn (mut t Transformer) transform_prefix_expr(id flat.NodeId, node flat.Node) fla
 			// temporary.
 			value := t.transform_expr(child_id)
 			result_type := if node.typ.len > 0 { node.typ } else { '&${child_type}' }
-			return t.make_call_typed('v3_heap_array', arr1(value), result_type)
+			return t.make_call_typed('v3_heap_array', [value], result_type)
 		}
 		if child.kind == .map_init && t.normalize_type_alias(child_type).starts_with('map[') {
 			// Like `&[]T{}`, `&map[K]V{}` owns a heap-allocated container header.
@@ -18832,7 +18756,7 @@ fn (mut t Transformer) transform_optional_value_to_pointer(source_id flat.NodeId
 	some := t.make_optional_some(addr, target_type)
 	assign := t.make_assign(t.make_ident(result_name), some)
 	ok := t.make_selector(source_value, 'ok', 'bool')
-	t.pending_stmts << t.make_if(ok, t.make_block(arr1(assign)), t.make_empty())
+	t.pending_stmts << t.make_if(ok, t.make_block([assign]), t.make_empty())
 	result := t.make_ident(result_name)
 	t.set_node_typ(int(result), target_type)
 	return result
@@ -18859,7 +18783,7 @@ fn (mut t Transformer) transform_optional_value_to_sum(source_id flat.NodeId, so
 	some := t.make_optional_some(sum_value, target_optional)
 	assign := t.make_assign(t.make_ident(result_name), some)
 	ok := t.make_selector(source_value, 'ok', 'bool')
-	t.pending_stmts << t.make_if(ok, t.make_block(arr1(assign)), t.make_empty())
+	t.pending_stmts << t.make_if(ok, t.make_block([assign]), t.make_empty())
 	result := t.make_ident(result_name)
 	t.set_node_typ(int(result), target_optional)
 	return result


### PR DESCRIPTION
## What

Two related changes that came out of resolving the `XTODO` markers in `vlib/v3/transform/transform.v` and then verifying self-host performance.

### 1. `v3`: transform helper/init cleanup (resolves the 3 XTODOs)
- Remove the `arr1`/`arr2`/`arr3`/`arr4` wrappers and `node_kind_id`, replacing every call site in the transform module with plain array literals (`[a, b, ...]`) and `int(node.kind)`.
- Drop the empty `map[...]{}` initializers from `new_transformer_view` — V auto-initializes those struct map fields, so only the AST/type-checker views, `used_fns`, and the pointer-backed lookup caches (which would otherwise be nil) need explicit values.
- Keep the `V3_STR_CAP` experimental autostr-cap override (documented in `fn.v`) and replace the `// XTODO is this needed` marker with an explanatory comment.

### 2. `cmd/v`: route a bare `v3.v` bootstrap to the compat compiler on macOS
The macOS dispatch gates only recognized the v3 bootstrap by the literal path `vlib/v3/v3.v`. Building it as a bare `v3.v` from inside `vlib/v3` (e.g. `../../v -prealloc -prod -o v3 v3.v`) was treated as an ordinary `.v` build and delegated to the embedded V3 driver instead of the compatibility compiler (which then crashes and only survives via the auto-fallback retry). A shared `is_macos_v3_compiler_bootstrap()` helper now also resolves a file literally named `v3.v` through its real path, and both `is_macos_v3_relevant_command` and `macos_v3_force_requested` use it so they can't drift. The extra real-path lookup only runs for a `v3.v` target.

## Verification
- `v fmt -verify` clean on all changed files; `v3` builds.
- Transform unit tests (`v test vlib/v3/transform/`) pass 7/7.
- New dispatcher test `test_macos_v3_compiler_bootstrap_is_detected_from_any_cwd`; before/after, the bare-`v3.v` invocation goes from "embedded V3 invoked → segfault → fallback" to a clean compat build.
- **No self-host performance regression** (`-prod`, 5 runs each, baseline @ HEAD vs. this branch):

  | metric | baseline | this PR |
  |---|---|---|
  | transform, median | 121.4 ms | 118.6 ms |
  | transform, min | 111.4 ms | 109.3 ms |
  | transform RSS | ~1.09 GB | ~1.09 GB |
  | cgen, mean | ~152.8 ms | ~152.9 ms |
  | prod v3 binary size | 14,096,904 B | 14,096,904 B (byte-identical) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)