### PR TITLE
v3: fix -autofree on literal-only programs

### DIFF
--- a/.github/workflows/macos_ci.yml
+++ b/.github/workflows/macos_ci.yml
@@ -206,6 +206,8 @@ jobs:
         run: v run ci/macos_ci.vsh self_tests
       - name: Build examples
         run: v run ci/macos_ci.vsh build_examples
+      - name: Build hello_world with -autofree
+        run: v run ci/macos_ci.vsh build_hello_world_autofree
       - name: Build tetris with -autofree
         run: v run ci/macos_ci.vsh build_tetris_autofree
       - name: Build blog tutorial with -autofree

--- a/ci/macos_ci.vsh
+++ b/ci/macos_ci.vsh
@@ -77,6 +77,14 @@ fn build_examples_v_compiled_with_tcc() {
 	}
 }
 
+fn build_hello_world_autofree() {
+	// The smallest possible program. Its body is only literal `println` calls, which
+	// is its own code path through markused, so the larger `-autofree` builds below
+	// do not cover it.
+	exec('v -autofree -o hello_world examples/hello_world.v')
+	exec('./hello_world')
+}
+
 fn build_tetris_autofree() {
 	exec('v -autofree -o tetris examples/tetris/tetris.v')
 }
@@ -149,6 +157,7 @@ const all_tasks = {
 	'test_pure_v_math_module':            Task{test_pure_v_math_module, 'Test pure V math module'}
 	'self_tests':                         Task{self_tests, 'Self tests'}
 	'build_examples':                     Task{build_examples, 'Build examples'}
+	'build_hello_world_autofree':         Task{build_hello_world_autofree, 'Build hello_world with -autofree'}
 	'build_tetris_autofree':              Task{build_tetris_autofree, 'Build tetris with -autofree'}
 	'build_blog_autofree':                Task{build_blog_autofree, 'Build blog tutorial with -autofree'}
 	'build_examples_prod':                Task{build_examples_prod, 'Build examples with -prod'}

--- a/vlib/v3/markused/markused.v
+++ b/vlib/v3/markused/markused.v
@@ -445,6 +445,20 @@ fn mark_used_with_test_files(a &flat.FlatAst, tc &types.TypeChecker, test_files 
 		for seed in ['builtin.none__', 'builtin.error_sentinel'] {
 			enqueue(seed, mut used, mut queue)
 		}
+		// The synthesized `_result` destructor releases the concrete object behind a
+		// failed result's IError, so it names the destructor of every IError
+		// implementer. Cgen emits that helper for every ownership build, and those
+		// calls have no source-AST call site either, so root them beside the
+		// sentinels. This must stay outside the `trivial_literal_output` fast path
+		// below: the helper is emitted there too, and `MessageError.free` is what a
+		// `-autofree` build of a literal-only program would otherwise call without a
+		// definition.
+		ierror_destructor := if tc.autofree_mode { 'free' } else { 'drop' }
+		for impl in tc.ierror_impl_names() {
+			for alias in interface_implementer_method_aliases(impl, ierror_destructor, tc) {
+				enqueue(alias, mut used, mut queue)
+			}
+		}
 	}
 	enqueue_main_module_roots(fn_decls, mut used, mut queue)
 	if use_prepared {

--- a/vlib/v3/tests/ownership/ownership_test.v
+++ b/vlib/v3/tests/ownership/ownership_test.v
@@ -3563,3 +3563,28 @@ fn main() {
 ')
 	assert ok.exit_code == 0, ok.output
 }
+
+// A program whose body is only literal `println` calls takes markused's
+// trivial-literal-output fast path, which skips the ownership destructor seeds.
+// Cgen still emits the `_result` destructor there, and in `-autofree` mode that
+// helper calls `MessageError.free`, so the fast path has to root the IError
+// implementers' destructors too. Without that, `hello world` fails to build with
+// `use of undeclared identifier 'MessageError__free'`.
+fn test_autofree_literal_only_program_keeps_ierror_destructors() {
+	v3_bin := ownership_build_v3()
+	ok := run_autofree_check(v3_bin, 'literal_only_println', "
+fn main() {
+	println('hello')
+}
+")
+	assert ok.exit_code == 0, ok.output
+
+	ok_multi := run_autofree_check(v3_bin, 'literal_only_mixed_output', "
+fn main() {
+	print('a')
+	eprintln('b')
+	println('c')
+}
+")
+	assert ok_multi.exit_code == 0, ok_multi.output
+}


### PR DESCRIPTION
`v -autofree` fails to build any program whose body is only literal print calls, including `examples/hello_world.v`, with `use of undeclared identifier 'MessageError__free'`.
markused's trivial-literal fast path skipped the ownership destructor seeds while cgen still emitted the `_result` destructor that calls them, so this roots the IError implementers' destructors beside the IError sentinels that are already seeded unconditionally.