### PR TITLE
v3: parse keyword-named interface parameters

### DIFF
--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -2387,6 +2387,7 @@ fn (mut p Parser) interface_decl() flat.NodeId {
 			p.next() // skip (
 			mut params := []flat.NodeId{}
 			for p.tok != .rpar && p.tok != .eof {
+				param_start_offset := p.s.offset
 				mut param_is_mut := false
 				mut param_name := ''
 				mut param_pos := token.Pos{}
@@ -2395,19 +2396,20 @@ fn (mut p Parser) interface_decl() flat.NodeId {
 					p.next()
 				}
 				// Interface method params may be named (e.g. `seed_data []u32`,
-				// `node &ast.Node`) or type-only (`[]u32`). When the current token
-				// is a plain identifier and the next token starts a type, that
-				// identifier is the param name; consume it first so the array/pointer
-				// prefix of the real type is not mis-parsed onto the name
-				// (e.g. `seed_data[]`). `map`/`chan` are type heads, not names.
-				if p.tok == .name && p.lit != 'map' && p.lit != 'chan' {
+				// `module string`) or type-only (`[]u32`). When the current token can
+				// be a declaration name and the next token starts a type, consume the
+				// name first so a keyword name or an array/pointer type is not
+				// mis-parsed (e.g. as `seed_data[]`). `map`/`chan` are type heads,
+				// not names.
+				can_be_param_name := p.tok == .name
+					|| (p.tok_can_be_decl_name() && !p.can_start_type_name())
+				if can_be_param_name && p.lit != 'map' && p.lit != 'chan' {
 					nt := p.peek()
 					if nt == .name || nt == .amp || nt == .question || nt == .not
 						|| nt == .key_fn || nt == .ellipsis
 						|| (nt == .lsbr && p.peek_lbr_starts_array_type()) {
-						param_name = p.lit
 						param_pos = p.current_pos()
-						p.next()
+						param_name = p.expect_name_or_keyword()
 					}
 				}
 				mut ptype := p.parse_type_name()
@@ -2426,6 +2428,9 @@ fn (mut p Parser) interface_decl() flat.NodeId {
 					pos:    param_pos
 				})
 				if p.tok == .comma {
+					p.next()
+				}
+				if p.s.offset == param_start_offset && p.tok != .rpar && p.tok != .eof {
 					p.next()
 				}
 			}

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -2397,18 +2397,20 @@ fn (mut p Parser) interface_decl() flat.NodeId {
 				}
 				// Interface method params may be named (e.g. `seed_data []u32`,
 				// `module string`, `struct Foo`) or type-only (`[]u32`, `struct {}`).
-				// A `struct`/`union` token is an anonymous type head only before `{`;
-				// otherwise it remains available as a declaration name, matching ordinary
-				// parameter parsing. `map`/`chan` are type heads, not names.
+				// A token is a type head only when the following token can continue that
+				// specific syntax; otherwise it remains available as a declaration name,
+				// matching ordinary parameter parsing.
 				nt := p.peek()
-				is_anonymous_aggregate_type := p.tok in [.key_struct, .key_union] && nt == .lcbr
-				can_be_param_name := p.tok == .name || (p.tok_can_be_decl_name()
-					&& (!p.can_start_type_name()
-					|| (p.tok in [.key_struct, .key_union] && !is_anonymous_aggregate_type)))
-				if can_be_param_name && p.lit != 'map' && p.lit != 'chan' {
-					if nt == .name || nt == .amp || nt == .question || nt == .not
-						|| nt == .key_fn || nt == .ellipsis
-						|| (nt == .lsbr && p.peek_lbr_starts_array_type()) {
+				current_starts_type := interface_param_token_continues_type(p.tok, p.lit, nt)
+				can_be_param_name := p.tok_can_be_decl_name() && !current_starts_type
+				if can_be_param_name {
+					next_starts_type := if nt == .lsbr {
+						p.peek_lbr_starts_array_type()
+					} else {
+						token_can_start_type_name(nt)
+							|| nt in [.and, .key_union, .key_nil, .key_none]
+					}
+					if next_starts_type {
 						param_pos = p.current_pos()
 						param_name = p.expect_name_or_keyword()
 					}
@@ -11747,6 +11749,36 @@ fn token_can_start_type_name(tok token.Token) bool {
 	return tok == .name || tok == .amp || tok == .question || tok == .not || tok == .lsbr
 		|| tok == .lpar || tok == .key_fn || tok == .key_struct || tok == .ellipsis
 		|| tok == .key_mut || tok == .key_shared || tok == .key_atomic || tok == .key_typeof
+}
+
+fn interface_param_token_continues_type(tok token.Token, lit string, next token.Token) bool {
+	match tok {
+		.key_fn {
+			return next == .lpar
+		}
+		.key_typeof {
+			return next in [.lpar, .lsbr]
+		}
+		.key_struct, .key_union {
+			return next == .lcbr
+		}
+		.key_atomic, .key_shared {
+			return token_can_start_type_name(next) || next == .key_union
+		}
+		.name {
+			if lit == 'map' {
+				return next == .lsbr
+			}
+			if lit == 'chan' {
+				return next in [.name, .amp, .lsbr, .question, .not, .key_mut]
+			}
+			if lit == 'thread' {
+				return next in [.name, .amp, .lsbr, .lpar, .question, .not, .key_fn]
+			}
+		}
+		else {}
+	}
+	return false
 }
 
 // fn_type_param_with_mut supports fn type param with mut handling for parser.

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -2396,15 +2396,16 @@ fn (mut p Parser) interface_decl() flat.NodeId {
 					p.next()
 				}
 				// Interface method params may be named (e.g. `seed_data []u32`,
-				// `module string`) or type-only (`[]u32`). When the current token can
-				// be a declaration name and the next token starts a type, consume the
-				// name first so a keyword name or an array/pointer type is not
-				// mis-parsed (e.g. as `seed_data[]`). `map`/`chan` are type heads,
-				// not names.
-				can_be_param_name := p.tok == .name
-					|| (p.tok_can_be_decl_name() && !p.can_start_type_name())
+				// `module string`, `struct Foo`) or type-only (`[]u32`, `struct {}`).
+				// A `struct`/`union` token is an anonymous type head only before `{`;
+				// otherwise it remains available as a declaration name, matching ordinary
+				// parameter parsing. `map`/`chan` are type heads, not names.
+				nt := p.peek()
+				is_anonymous_aggregate_type := p.tok in [.key_struct, .key_union] && nt == .lcbr
+				can_be_param_name := p.tok == .name || (p.tok_can_be_decl_name()
+					&& (!p.can_start_type_name()
+					|| (p.tok in [.key_struct, .key_union] && !is_anonymous_aggregate_type)))
 				if can_be_param_name && p.lit != 'map' && p.lit != 'chan' {
-					nt := p.peek()
 					if nt == .name || nt == .amp || nt == .question || nt == .not
 						|| nt == .key_fn || nt == .ellipsis
 						|| (nt == .lsbr && p.peek_lbr_starts_array_type()) {

--- a/vlib/v3/tests/parser_regression_test.v
+++ b/vlib/v3/tests/parser_regression_test.v
@@ -164,15 +164,28 @@ fn test_interface_method_keyword_named_param_makes_progress() {
 
 fn test_interface_method_type_head_keyword_param_name_is_disambiguated() {
 	a := parse_parser_regression_source('interface_type_head_keyword_param_name',
-		'struct Foo {}\ninterface Commands {\n\tuse(struct Foo)\n\tmerge(union Foo)\n\tinline_struct(struct { value int })\n\tinline_union(union { value int })\n}\n')
+		'struct Foo {}\ninterface Commands {\n\tuse(struct Foo)\n\tmerge(union Foo)\n\tcallback(fn string)\n\tinspect(typeof string)\n\tlookup(map string)\n\tinline_struct(struct { value int })\n\tinline_union(union { value int })\n\tfunction_type(fn (string) int)\n\treflected_type(typeof(string))\n\tmap_type(map[string]int)\n\tchannel_type(chan string)\n}\n')
 	assert fn_decl_param_pairs(a, .interface_field, 'use') == ['struct:Foo']
 	assert fn_decl_param_pairs(a, .interface_field, 'merge') == ['union:Foo']
+	assert fn_decl_param_pairs(a, .interface_field, 'callback') == ['fn:string']
+	assert fn_decl_param_pairs(a, .interface_field, 'inspect') == ['typeof:string']
+	assert fn_decl_param_pairs(a, .interface_field, 'lookup') == ['map:string']
 	struct_params := fn_decl_param_pairs(a, .interface_field, 'inline_struct')
 	assert struct_params.len == 1
 	assert struct_params[0].starts_with(':AnonStruct_')
 	union_params := fn_decl_param_pairs(a, .interface_field, 'inline_union')
 	assert union_params.len == 1
 	assert union_params[0].starts_with(':AnonUnion_')
+	assert fn_decl_param_pairs(a, .interface_field, 'function_type') == [
+		':fn(string) int',
+	]
+	assert fn_decl_param_pairs(a, .interface_field, 'reflected_type') == [
+		':typeof(string)',
+	]
+	assert fn_decl_param_pairs(a, .interface_field, 'map_type') == [':map[string]int']
+	assert fn_decl_param_pairs(a, .interface_field, 'channel_type') == [
+		':chan string',
+	]
 }
 
 fn test_lifetime_generic_suffixes_are_erased() {

--- a/vlib/v3/tests/parser_regression_test.v
+++ b/vlib/v3/tests/parser_regression_test.v
@@ -162,6 +162,19 @@ fn test_interface_method_keyword_named_param_makes_progress() {
 	assert fn_decl_param_pairs(a, .interface_field, 'after') == ['value:int']
 }
 
+fn test_interface_method_type_head_keyword_param_name_is_disambiguated() {
+	a := parse_parser_regression_source('interface_type_head_keyword_param_name',
+		'struct Foo {}\ninterface Commands {\n\tuse(struct Foo)\n\tmerge(union Foo)\n\tinline_struct(struct { value int })\n\tinline_union(union { value int })\n}\n')
+	assert fn_decl_param_pairs(a, .interface_field, 'use') == ['struct:Foo']
+	assert fn_decl_param_pairs(a, .interface_field, 'merge') == ['union:Foo']
+	struct_params := fn_decl_param_pairs(a, .interface_field, 'inline_struct')
+	assert struct_params.len == 1
+	assert struct_params[0].starts_with(':AnonStruct_')
+	union_params := fn_decl_param_pairs(a, .interface_field, 'inline_union')
+	assert union_params.len == 1
+	assert union_params[0].starts_with(':AnonUnion_')
+}
+
 fn test_lifetime_generic_suffixes_are_erased() {
 	a := parse_parser_regression_source('lifetime_generic_suffixes',
 		'struct IgnoreMatch {}\nstruct Match[T] {}\n\ninterface Matcher {\n\tmatched[^a](item Match[IgnoreMatch[^a]]) IgnoreMatch[^a]\n}\n\nfn use(item Match[IgnoreMatch[^a]]) {}\nfn after() int {\n\treturn 1\n}\n')

--- a/vlib/v3/tests/parser_regression_test.v
+++ b/vlib/v3/tests/parser_regression_test.v
@@ -155,6 +155,13 @@ fn test_interface_method_generic_type_only_param_is_not_parsed_as_name() {
 	assert interface_method_param_types(a, 'Sink', 'read') == ['[max_len]u8']
 }
 
+fn test_interface_method_keyword_named_param_makes_progress() {
+	a := parse_parser_regression_source('interface_keyword_named_param',
+		'interface Commands {\n\tfilter(module string) string\n\tafter(value int) int\n}\n')
+	assert fn_decl_param_pairs(a, .interface_field, 'filter') == ['module:string']
+	assert fn_decl_param_pairs(a, .interface_field, 'after') == ['value:int']
+}
+
 fn test_lifetime_generic_suffixes_are_erased() {
 	a := parse_parser_regression_source('lifetime_generic_suffixes',
 		'struct IgnoreMatch {}\nstruct Match[T] {}\n\ninterface Matcher {\n\tmatched[^a](item Match[IgnoreMatch[^a]]) IgnoreMatch[^a]\n}\n\nfn use(item Match[IgnoreMatch[^a]]) {}\nfn after() int {\n\treturn 1\n}\n')


### PR DESCRIPTION
## Summary

- recognize keyword tokens such as `module` as named interface method parameters
- add a forward-progress guard to prevent malformed parameters from looping indefinitely
- add regression coverage that verifies both the keyword-named parameter and the following method

Closes #28168

## Memory

Measured on the issue Peony checkout at `c68dfb57f9d4eb6ff0b2aae71ec91037fd524410` with the identical command:

```sh
v3 -nocache -check-syntax tests/peony_test.v
```

| | Before | After |
|---|---:|---:|
| Maximum RSS | 4166.92 MiB | 224.14 MiB |
| Physical footprint | 4167.41 MiB | 222.74 MiB |
| Result | failed at the 4 GiB limit | passed |

Maximum RSS is reduced by 94.62%.

## Tests

- `./vnew -silent vlib/v3/tests/parser_regression_test.v`
- `./vnew -silent test vlib/v3/parser/` (5/5 passed)
- full Peony `-nocache -check-syntax` reproduction
- `git diff --check`