### PR TITLE
v3: snapshot native fallback inputs during traversal

### DIFF
--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -96,6 +96,7 @@ mut:
 	native_root_contexts      map[string][]string
 	native_root_owners        map[string]string
 	external_input_signatures map[string]string
+	external_input_digests    map[string]string
 	external_resolution_dirs  []string
 	external_missing_paths    []string
 	external_inputs_ready     bool
@@ -2436,12 +2437,15 @@ fn v3_cgen_cache_input(state &V3ModuleCacheState, user_files []string, user_c_fl
 			dependencies['external:${module_name}:${path}'] = state.external_input_signatures[key] or {
 				modulecache.file_signature(path)
 			}
+			if digest := state.external_input_digests[os.real_path(path)] {
+				dependencies['external-sha256:${module_name}:${path}'] = digest
+			}
 			dependencies['external-meta:${module_name}:${path}'] =
 				modulecache.file_metadata_signature(path)
 		}
 	}
 	if state.external_inputs_ready {
-		dependencies['external-state:manifest'] = 'v3-external-inputs-4'
+		dependencies['external-state:manifest'] = 'v3-external-inputs-5'
 		mut root_modules := state.module_native_roots.keys()
 		root_modules.sort()
 		for module_name in root_modules {
@@ -2500,7 +2504,7 @@ fn prepare_v3_cache_external_inputs(mut state V3ModuleCacheState, a &flat.FlatAs
 		prefs.c99, prefs.target)
 	compiler_macros, compiler_macro_environment_complete := cache_c_compiler_predefined_macros(user_c_flags,
 		prefs.ccompiler, prefs.target, native_inputs_language)
-	external_inputs, native_source_roots, native_root_contexts, unscoped_inputs, static_storage_inputs, resolution_dirs, missing_resolution_paths, has_untracked_c_include := cgen.cache_external_input_files_with_resolved_flags(a,
+	external_inputs, native_source_roots, native_root_contexts, unscoped_inputs, static_storage_inputs, resolution_dirs, missing_resolution_paths, external_input_digests, has_untracked_c_include := cgen.cache_external_input_snapshot_with_resolved_flags(a,
 		prefs.vroot, cache_input_modules, user_c_flags, prefs.target,
 		module_cache_source_path_set(user_files), compiler_macros,
 		compiler_macro_environment_complete)
@@ -2508,6 +2512,7 @@ fn prepare_v3_cache_external_inputs(mut state V3ModuleCacheState, a &flat.FlatAs
 	state.module_native_roots = native_source_roots.clone()
 	state.native_root_contexts = native_root_contexts.clone()
 	state.external_input_signatures = map[string]string{}
+	state.external_input_digests = external_input_digests.clone()
 	cache_dir := os.abs_path(state.manager.dir)
 	real_cache_dir := os.real_path(state.manager.dir)
 	state.external_resolution_dirs = resolution_dirs.filter(!v3_path_is_within(it, cache_dir)
@@ -2536,6 +2541,7 @@ fn prepare_v3_cache_external_inputs(mut state V3ModuleCacheState, a &flat.FlatAs
 		prefs.ccompiler, prefs.target)
 	state.external_inputs_ready = true
 	state.external_inputs_complete = !has_untracked_c_include
+		&& v3_external_input_digests_complete(state)
 	if os.getenv('V3_CACHE_TRACE') != '' {
 		if has_untracked_c_include {
 			eprintln('  V3 module cache external input miss: reason=unresolved C include')
@@ -4169,6 +4175,30 @@ fn v3_external_input_key(module_name string, path string) string {
 	return '${module_name}\x00${path}'
 }
 
+fn v3_sha256_hex_digest_is_valid(digest string) bool {
+	return digest.len == sha256.size * 2 && digest.bytes().all(it.is_hex_digit())
+}
+
+fn v3_external_input_digests_complete(state &V3ModuleCacheState) bool {
+	for paths in state.module_external_inputs.values() {
+		for path in paths {
+			digest := state.external_input_digests[os.real_path(path)] or { return false }
+			if !v3_sha256_hex_digest_is_valid(digest) {
+				return false
+			}
+		}
+	}
+	for paths in state.module_native_roots.values() {
+		for path in paths {
+			digest := state.external_input_digests[os.real_path(path)] or { return false }
+			if !v3_sha256_hex_digest_is_valid(digest) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
 fn v3_external_cache_path(key string, prefix string) ?V3ExternalCachePath {
 	if !key.starts_with(prefix) {
 		return none
@@ -4186,9 +4216,9 @@ fn v3_external_cache_path(key string, prefix string) ?V3ExternalCachePath {
 
 fn restore_v3_cache_external_inputs(mut state V3ModuleCacheState, user_files []string, user_c_flags []string, ccompiler string, target pref.Target, incremental_declaration_signature string) bool {
 	base_input := v3_cgen_cache_input(state, user_files, user_c_flags)
-	prefixes := ['external:', 'external-meta:', 'external-root:', 'external-root-owner:',
-		'external-context:', 'external-owner:', 'external-dir:', 'external-missing:',
-		'external-state:']
+	prefixes := ['external:', 'external-sha256:', 'external-meta:', 'external-root:',
+		'external-root-owner:', 'external-context:', 'external-owner:', 'external-dir:',
+		'external-missing:', 'external-state:']
 	mut restored := map[string]string{}
 	if exact := state.manager.cached_cgen_dependency_inputs(base_input.source_files,
 		base_input.generation_signature, base_input.dependency_inputs, prefixes)
@@ -4202,17 +4232,31 @@ fn restore_v3_cache_external_inputs(mut state V3ModuleCacheState, user_files []s
 			incremental_declaration_signature, base_input.generation_signature,
 			base_input.dependency_inputs, prefixes) or { return false }
 	}
-	if restored['external-state:manifest'] or { '' } != 'v3-external-inputs-4' {
+	if restored['external-state:manifest'] or { '' } != 'v3-external-inputs-5' {
 		return false
 	}
 	mut external_inputs := map[string][]string{}
 	mut external_signatures := map[string]string{}
+	mut external_digests := map[string]string{}
 	for key, signature in restored {
 		input := v3_external_cache_path(key, 'external:') or { continue }
 		metadata_key := 'external-meta:${input.module_name}:${input.path}'
 		metadata := restored[metadata_key] or { return false }
+		digest_key := 'external-sha256:${input.module_name}:${input.path}'
+		digest := restored[digest_key] or { return false }
 		if metadata.len == 0 || modulecache.file_metadata_signature(input.path) != metadata {
 			return false
+		}
+		if !v3_sha256_hex_digest_is_valid(digest) {
+			return false
+		}
+		real_path := os.real_path(input.path)
+		if old_digest := external_digests[real_path] {
+			if old_digest != digest {
+				return false
+			}
+		} else {
+			external_digests[real_path] = digest
 		}
 		mut paths := external_inputs[input.module_name]
 		paths << input.path
@@ -4221,6 +4265,11 @@ fn restore_v3_cache_external_inputs(mut state V3ModuleCacheState, user_files []s
 	}
 	for key, _ in restored {
 		if input := v3_external_cache_path(key, 'external-meta:') {
+			if 'external:${input.module_name}:${input.path}' !in restored {
+				return false
+			}
+		}
+		if input := v3_external_cache_path(key, 'external-sha256:') {
 			if 'external:${input.module_name}:${input.path}' !in restored {
 				return false
 			}
@@ -4348,6 +4397,7 @@ fn restore_v3_cache_external_inputs(mut state V3ModuleCacheState, user_files []s
 	missing_resolution_paths.sort()
 	state.module_external_inputs = external_inputs.clone()
 	state.external_input_signatures = external_signatures.clone()
+	state.external_input_digests = external_digests.clone()
 	state.module_native_roots = native_roots.clone()
 	state.native_root_contexts = native_root_contexts.clone()
 	state.native_root_owners = native_root_owners.clone()
@@ -4358,7 +4408,10 @@ fn restore_v3_cache_external_inputs(mut state V3ModuleCacheState, user_files []s
 	state.external_resolution_dirs = resolution_dirs.clone()
 	state.external_missing_paths = missing_resolution_paths.clone()
 	state.external_inputs_ready = true
-	state.external_inputs_complete = true
+	state.external_inputs_complete = v3_external_input_digests_complete(state)
+	if !state.external_inputs_complete {
+		return false
+	}
 	return true
 }
 
@@ -6477,8 +6530,11 @@ fn macos_v3_fallback_report_inputs(v_sources map[string]string, state &V3ModuleC
 	}
 	mut native_digests := map[string]string{}
 	for path in native_paths.keys() {
-		content := os.read_bytes(path) or { return inputs }
-		native_digests['${v3_fallback_native_input_prefix}${path}'] = sha256.sum(content).hex()
+		digest := state.external_input_digests[path] or { return inputs }
+		if !v3_sha256_hex_digest_is_valid(digest) {
+			return inputs
+		}
+		native_digests['${v3_fallback_native_input_prefix}${path}'] = digest
 	}
 	for key, digest in native_digests {
 		inputs[key] = digest
@@ -7745,6 +7801,7 @@ pub fn run(args []string) {
 		native_root_contexts:      map[string][]string{}
 		native_root_owners:        map[string]string{}
 		external_input_signatures: map[string]string{}
+		external_input_digests:    map[string]string{}
 		dependency_metadata:       map[string]string{}
 		cached_source_digests:     map[string]string{}
 		fallback_required_modules: map[string]bool{}

--- a/vlib/v3/driver/environment_test.v
+++ b/vlib/v3/driver/environment_test.v
@@ -175,6 +175,8 @@ fn test_macos_v3_fallback_report_inputs_snapshot_native_dependencies() {
 	os.write_file(source_candidate, native_source)!
 	header_path := os.real_path(header_candidate)
 	source_path := os.real_path(source_candidate)
+	header_digest := sha256.hexhash(header_source)
+	source_digest := sha256.hexhash(native_source)
 	state := V3ModuleCacheState{
 		module_external_inputs:   {
 			'main': [header_path, source_path]
@@ -182,19 +184,23 @@ fn test_macos_v3_fallback_report_inputs_snapshot_native_dependencies() {
 		module_native_roots:      {
 			'main': [source_path]
 		}
+		external_input_digests:   {
+			header_path: header_digest
+			source_path: source_digest
+		}
 		external_inputs_ready:    true
 		external_inputs_complete: true
 	}
+	// A watcher can replace a root after traversal. The fallback manifest must retain
+	// the digest captured from the bytes that selected the original dependency tree.
+	os.write_file(header_path, '#include "late.h"\n#define PROJECT_VALUE 42\n')!
 	inputs := macos_v3_fallback_report_inputs({
 		'/project/main.v': sha256.hexhash('module main')
 	}, &state)
 	assert inputs['/project/main.v'] == sha256.hexhash('module main')
 	assert inputs[v3_fallback_native_manifest_key] == sha256.hexhash(v3_fallback_native_manifest_value)
-	assert inputs['${v3_fallback_native_input_prefix}${header_path}'] == sha256.hexhash(header_source)
-	assert inputs['${v3_fallback_native_input_prefix}${source_path}'] == sha256.hexhash(native_source)
-	// The snapshot remains tied to the bytes V3 resolved, even if a watcher rewrites a
-	// dependency before the compatibility compiler runs.
-	os.write_file(header_path, '#define PROJECT_VALUE 42\n')!
+	assert inputs['${v3_fallback_native_input_prefix}${header_path}'] == header_digest
+	assert inputs['${v3_fallback_native_input_prefix}${source_path}'] == source_digest
 	assert inputs['${v3_fallback_native_input_prefix}${header_path}'] != sha256.hexhash(os.read_file(header_path)!)
 }
 

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -1,5 +1,6 @@
 module c
 
+import crypto.sha256
 import os
 import strings
 import time
@@ -1358,9 +1359,21 @@ pub fn cache_external_input_files(a &flat.FlatAst, vroot string, source_modules 
 // are the first nonexistent path components searched. Directives from program_files
 // belong to the program translation unit even when a library test declares that module.
 pub fn cache_external_input_files_with_resolved_flags(a &flat.FlatAst, vroot string, source_modules map[string]bool, c_flags []string, target pref.Target, program_files map[string]bool, compiler_macros map[string]string, compiler_macro_environment_complete bool) (map[string][]string, map[string][]string, map[string][]string, map[string][]string, map[string][]string, []string, []string, bool) {
+	inputs, native_source_roots, native_root_contexts, unscoped_inputs, static_storage_inputs, resolution_dirs, missing_resolution_paths, _, has_untracked_include := cache_external_input_snapshot_with_resolved_flags(a,
+		vroot, source_modules, c_flags, target, program_files, compiler_macros,
+		compiler_macro_environment_complete)
+	return inputs, native_source_roots, native_root_contexts, unscoped_inputs, static_storage_inputs, resolution_dirs, missing_resolution_paths, has_untracked_include
+}
+
+// cache_external_input_snapshot_with_resolved_flags also returns SHA-256 digests
+// of the exact native buffers used to resolve the dependency tree.
+pub fn cache_external_input_snapshot_with_resolved_flags(a &flat.FlatAst, vroot string, source_modules map[string]bool, c_flags []string, target pref.Target, program_files map[string]bool, compiler_macros map[string]string, compiler_macro_environment_complete bool) (map[string][]string, map[string][]string, map[string][]string, map[string][]string, map[string][]string, []string, []string, map[string]string, bool) {
 	include_dirs := c_flag_include_dirs(c_flags)
+	mut captured_input_texts := map[string]string{}
+	mut captured_input_digests := map[string]string{}
 	flag_inputs, flags_have_untracked_include, mut include_macros, mut dynamic_include_macros, mut resolution_dirs, mut missing_resolution_paths := cache_c_flag_input_files_with_status(c_flags,
-		compiler_macros, compiler_macro_environment_complete)
+		compiler_macros, compiler_macro_environment_complete, mut captured_input_texts, mut
+		captured_input_digests)
 	mut collect_modules := map[string]bool{}
 	for module_name, enabled in source_modules {
 		if enabled {
@@ -1492,7 +1505,8 @@ pub fn cache_external_input_files_with_resolved_flags(a &flat.FlatAst, vroot str
 				if c_collect_external_input_tree(path, vroot, include_dirs, mut active_paths, mut
 					collected_paths, mut ambiguous_collected_paths, mut files, mut include_macros, mut
 					dynamic_include_macros, mut resolution_dirs, mut missing_resolution_paths, mut
-					active_static_storage_paths, owner_module, false,
+					active_static_storage_paths, mut captured_input_texts, mut
+					captured_input_digests, owner_module, false,
 					compiler_macro_environment_complete)
 				{
 					has_untracked_include = true
@@ -1522,7 +1536,13 @@ pub fn cache_external_input_files_with_resolved_flags(a &flat.FlatAst, vroot str
 			continue
 		}
 		if path := c_embed_external_input_path(a, node) {
-			c_add_cache_external_input(mut inputs, owner_module, path)
+			if _ := c_captured_external_input_text(path, mut captured_input_texts, mut
+				captured_input_digests)
+			{
+				c_add_cache_external_input(mut inputs, owner_module, path)
+			} else {
+				has_untracked_include = true
+			}
 		}
 	}
 	if flags_have_untracked_include {
@@ -1550,7 +1570,7 @@ pub fn cache_external_input_files_with_resolved_flags(a &flat.FlatAst, vroot str
 	sorted_resolution_dirs.sort()
 	mut sorted_missing_resolution_paths := missing_resolution_paths.keys()
 	sorted_missing_resolution_paths.sort()
-	return inputs, native_source_roots, native_root_contexts, unscoped_inputs, static_storage_inputs, sorted_resolution_dirs, sorted_missing_resolution_paths, has_untracked_include
+	return inputs, native_source_roots, native_root_contexts, unscoped_inputs, static_storage_inputs, sorted_resolution_dirs, sorted_missing_resolution_paths, captured_input_digests, has_untracked_include
 }
 
 fn c_add_cache_native_source_root(mut native_source_roots map[string][]string, mut native_root_contexts map[string][]string, owner_module string, real_path string, context []string, context_is_replayable bool) bool {
@@ -1712,11 +1732,14 @@ fn c_native_language_from_features(need_objc bool, need_cpp bool) string {
 // cache_c_flag_input_files returns forced include/macro files whose contents
 // affect every cached object compiled with the supplied C flags.
 pub fn cache_c_flag_input_files(flags []string) []string {
-	files, _, _, _, _, _ := cache_c_flag_input_files_with_status(flags, map[string]string{}, false)
+	mut captured_input_texts := map[string]string{}
+	mut captured_input_digests := map[string]string{}
+	files, _, _, _, _, _ := cache_c_flag_input_files_with_status(flags, map[string]string{}, false, mut
+		captured_input_texts, mut captured_input_digests)
 	return files
 }
 
-fn cache_c_flag_input_files_with_status(flags []string, compiler_macros map[string]string, compiler_macro_environment_complete bool) ([]string, bool, map[string][]string, map[string]bool, map[string]bool, map[string]bool) {
+fn cache_c_flag_input_files_with_status(flags []string, compiler_macros map[string]string, compiler_macro_environment_complete bool, mut captured_input_texts map[string]string, mut captured_input_digests map[string]string) ([]string, bool, map[string][]string, map[string]bool, map[string]bool, map[string]bool) {
 	include_dirs := c_flag_include_dirs(flags)
 	mut active_paths := map[string]bool{}
 	mut collected_paths := map[string]bool{}
@@ -1737,8 +1760,8 @@ fn cache_c_flag_input_files_with_status(flags []string, compiler_macros map[stri
 			if c_collect_external_input_tree(path, '', include_dirs, mut active_paths, mut
 				collected_paths, mut ambiguous_collected_paths, mut files, mut include_macros, mut
 				dynamic_include_macros, mut resolution_dirs, mut missing_resolution_paths, mut
-				active_static_storage_paths, '__v3_c_flags__', false,
-				compiler_macro_environment_complete)
+				active_static_storage_paths, mut captured_input_texts, mut captured_input_digests,
+				'__v3_c_flags__', false, compiler_macro_environment_complete)
 			{
 				has_untracked_include = true
 			}
@@ -1778,7 +1801,7 @@ pub fn tokenize_c_flag(value string) []string {
 }
 
 fn c_add_cache_external_input(mut inputs map[string][]string, module_name string, path string) {
-	if module_name.len == 0 || path.len == 0 || !os.is_file(path) {
+	if module_name.len == 0 || path.len == 0 {
 		return
 	}
 	real_path := os.real_path(path)
@@ -1797,19 +1820,19 @@ mut:
 	ambiguous bool
 }
 
-fn c_collect_external_input_tree(path string, vroot string, include_dirs []string, mut active_paths map[string]bool, mut collected_paths map[string]bool, mut ambiguous_collected_paths map[string]bool, mut files []string, mut include_macros map[string][]string, mut dynamic_include_macros map[string]bool, mut resolution_dirs map[string]bool, mut missing_resolution_paths map[string]bool, mut active_static_storage_paths map[string]bool, collection_scope string, ambient_ambiguous bool, compiler_macro_environment_complete bool) bool {
-	if path.len == 0 || !os.is_file(path) {
+fn c_collect_external_input_tree(path string, vroot string, include_dirs []string, mut active_paths map[string]bool, mut collected_paths map[string]bool, mut ambiguous_collected_paths map[string]bool, mut files []string, mut include_macros map[string][]string, mut dynamic_include_macros map[string]bool, mut resolution_dirs map[string]bool, mut missing_resolution_paths map[string]bool, mut active_static_storage_paths map[string]bool, mut captured_input_texts map[string]string, mut captured_input_digests map[string]string, collection_scope string, ambient_ambiguous bool, compiler_macro_environment_complete bool) bool {
+	if path.len == 0 {
 		return false
 	}
 	real_path := os.real_path(path)
 	if active_paths[real_path] {
 		return false
 	}
+	text := c_captured_external_input_text(real_path, mut captured_input_texts, mut
+		captured_input_digests) or { return true }
 	collection_key := collection_scope + '\x00' + real_path
 	first_collection := !collected_paths[collection_key]
-	mut text := ''
 	if collected_paths[collection_key] {
-		text = os.read_file(real_path) or { return true }
 		if guard := c_whole_file_guard_macro(text) {
 			// The preprocessor skips a repeat include only while the guard is definitely
 			// still defined: `#pragma once` always is, and an `#ifndef NAME` guard is when
@@ -1838,9 +1861,6 @@ fn c_collect_external_input_tree(path string, vroot string, include_dirs []strin
 			ambiguous_collected_paths[collection_key] = true
 		}
 		files << real_path
-	}
-	if text.len == 0 {
-		text = os.read_file(real_path) or { return false }
 	}
 	if first_collection {
 		if guard := c_whole_file_guard_macro(text) {
@@ -1923,7 +1943,8 @@ fn c_collect_external_input_tree(path string, vroot string, include_dirs []strin
 			}
 			include_args = include_macros[macro_name].clone()
 			if include_args.len == 0 {
-				literal_values := c_literal_include_macro_values(files, macro_name)
+				literal_values := c_literal_include_macro_values(files, captured_input_texts,
+					macro_name)
 				if literal_values.len == 1 {
 					include_args = literal_values.clone()
 					include_macros[macro_name] = include_args.clone()
@@ -1949,7 +1970,8 @@ fn c_collect_external_input_tree(path string, vroot string, include_dirs []strin
 				if c_collect_external_input_tree(nested_path, vroot, include_dirs, mut
 					active_paths, mut collected_paths, mut ambiguous_collected_paths, mut files, mut
 					include_macros, mut dynamic_include_macros, mut resolution_dirs, mut
-					missing_resolution_paths, mut active_static_storage_paths, collection_scope,
+					missing_resolution_paths, mut active_static_storage_paths, mut
+					captured_input_texts, mut captured_input_digests, collection_scope,
 					nested_ambiguous, compiler_macro_environment_complete)
 				{
 					has_untracked_include = true
@@ -1969,10 +1991,10 @@ fn c_collect_external_input_tree(path string, vroot string, include_dirs []strin
 	return has_untracked_include
 }
 
-fn c_literal_include_macro_values(paths []string, macro_name string) []string {
+fn c_literal_include_macro_values(paths []string, captured_input_texts map[string]string, macro_name string) []string {
 	mut values := []string{}
 	for path in paths {
-		text := os.read_file(path) or { continue }
+		text := captured_input_texts[os.real_path(path)] or { continue }
 		mut in_block_comment := false
 		for line in text.split_into_lines() {
 			clean, next_in_block_comment := c_preprocessor_directive_scan_line(line,
@@ -1994,6 +2016,17 @@ fn c_literal_include_macro_values(paths []string, macro_name string) []string {
 	}
 	values.sort()
 	return values
+}
+
+fn c_captured_external_input_text(path string, mut captured_input_texts map[string]string, mut captured_input_digests map[string]string) ?string {
+	real_path := os.real_path(path)
+	if real_path in captured_input_texts {
+		return captured_input_texts[real_path]
+	}
+	text := os.read_file(real_path) or { return none }
+	captured_input_texts[real_path] = text
+	captured_input_digests[real_path] = sha256.hexhash(text)
+	return text
 }
 
 // c_whole_file_guard_macro returns the include guard that gates a whole-file

--- a/vlib/v3/gen/c/source_directive_test.v
+++ b/vlib/v3/gen/c/source_directive_test.v
@@ -340,10 +340,13 @@ fn collect_external_input_tree_status(root string, entry string, ambient_ambiguo
 	mut resolution_dirs := map[string]bool{}
 	mut missing_resolution_paths := map[string]bool{}
 	mut active_static_storage_paths := map[string]bool{}
+	mut captured_input_texts := map[string]string{}
+	mut captured_input_digests := map[string]string{}
 	untracked := c_collect_external_input_tree(entry, '', [root], mut active_paths, mut
 		collected_paths, mut ambiguous_collected_paths, mut files, mut include_macros, mut
 		dynamic_include_macros, mut resolution_dirs, mut missing_resolution_paths, mut
-		active_static_storage_paths, 'main', ambient_ambiguous, false)
+		active_static_storage_paths, mut captured_input_texts, mut captured_input_digests, 'main',
+		ambient_ambiguous, false)
 	return untracked, files
 }
 

--- a/vlib/v3/gen/c/target_test.v
+++ b/vlib/v3/gen/c/target_test.v
@@ -1,5 +1,6 @@
 module c
 
+import crypto.sha256
 import os
 import v3.parser
 import v3.pref
@@ -971,8 +972,10 @@ fn test_cache_input_scan_tracks_native_source_roots_for_privacy_checks() {
 	nested_source := os.join_path(dir, 'nested.c')
 	direct_header := os.join_path(dir, 'direct.h')
 	nested_header := os.join_path(dir, 'nested.h')
-	os.write_file(root_source, '#include "nested.c"\n') or { panic(err) }
-	os.write_file(nested_source, 'static int nested_value(void) { return 42; }\n') or { panic(err) }
+	root_source_text := '#include "nested.c"\n'
+	nested_source_text := 'static int nested_value(void) { return 42; }\n'
+	os.write_file(root_source, root_source_text) or { panic(err) }
+	os.write_file(nested_source, nested_source_text) or { panic(err) }
 	os.write_file(direct_header, '#include "nested.h"\n') or { panic(err) }
 	os.write_file(nested_header, 'static int header_value(void) { return 1; }\n') or { panic(err) }
 	source := os.join_path(dir, 'sample.v')
@@ -983,7 +986,7 @@ fn test_cache_input_scan_tracks_native_source_roots_for_privacy_checks() {
 	prefs.target = pref.host_target()
 	mut p := parser.Parser.new(prefs)
 	a := p.parse_file(source)
-	inputs, native_roots, _, unscoped_inputs, static_inputs, _, _, has_untracked := cache_external_input_files_with_resolved_flags(a,
+	inputs, native_roots, _, unscoped_inputs, static_inputs, _, _, captured_digests, has_untracked := cache_external_input_snapshot_with_resolved_flags(a,
 		'', {
 		'sample': true
 	}, [], prefs.target, map[string]bool{}, map[string]string{}, false)
@@ -1009,6 +1012,15 @@ fn test_cache_input_scan_tracks_native_source_roots_for_privacy_checks() {
 		os.real_path(direct_header)]
 	assert program_unscoped['main'] == expected_inputs
 	assert 'sample' !in program_inputs
+	late_source := os.join_path(dir, 'late.c')
+	os.write_file(late_source, 'static int late_value(void) { return 7; }\n')!
+	os.write_file(root_source, '#include "nested.c"\n#include "late.c"\n')!
+	os.write_file(nested_source, 'static int nested_value(void) { return 43; }\n')!
+	// The dependency set and digests describe one traversal snapshot. Reopening the
+	// paths here would combine the old tree with new root/child bytes.
+	assert os.real_path(late_source) !in inputs['sample']
+	assert captured_digests[os.real_path(root_source)] == sha256.hexhash(root_source_text)
+	assert captured_digests[os.real_path(nested_source)] == sha256.hexhash(nested_source_text)
 }
 
 fn test_termux_comptime_branch_uses_canonical_target() {


### PR DESCRIPTION
## Summary

- capture native input bytes and SHA-256 digests during dependency traversal
- preserve those digests through cold and warm module-cache state
- stage fallback reports only when the complete captured manifest is available
- add regressions for atomic native-input replacement during traversal

Follow-up to #28131.

Addresses https://github.com/vlang/v/pull/28131#discussion_r3845112840

## Tests

- `./v -g -keepc -o ./vnew cmd/v`
- `./vnew -silent vlib/v3/driver/environment_test.v`
- `./vnew -silent vlib/v3/gen/c/target_test.v`
- `./vnew -silent vlib/v3/gen/c/source_directive_test.v`
- `./vnew -silent test -run-only test_macos_v3_discards_fallback_report_when_native_input_changes cmd/v/macos_v3_test.v`
- four selected external-input/module-cache invalidation cases in `vlib/v3/tests/module_cache_test.v`
- `./vnew -silent vlib/v/compiler_errors_test.v` (1619 passed, 1 skipped)