### PR TITLE
cgen: fix fixed array assignment with temporary expressions

### DIFF
--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -1585,28 +1585,21 @@ fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 					&& g.table.final_sym(left.left_type).kind == .map
 				g.is_assign_lhs = left_is_map_index
 				left_expr := g.expr_string(left)
-				if !is_fixed_array_init && assign_expr_unwraps_option_or_result(val) {
-					// val has an or-block — its code generator emits unwrap
-					// statements via go_before_last_stmt(), so we must emit
-					// memcpy() inline. Capturing val with expr_string() would
-					// slurp those statements into the memcpy() argument list.
+				if !is_fixed_array_init {
+					// The value code generator may emit temporary declarations via
+					// go_before_last_stmt(), so emit memcpy() inline. Capturing val with
+					// expr_string() would slurp those declarations into its argument list.
 					g.write('memcpy(${left_expr}, ')
 					g.expr(val)
 					g.writeln(', sizeof(${arr_typ}));')
 				} else {
-					mut fixed_right_expr := ''
-					if is_fixed_array_init {
-						right := val as ast.ArrayInit
-						right_var := g.new_tmp_var()
-						g.write('${arr_typ} ${right_var} = ')
-						g.expr(right)
-						g.writeln(';')
-						fixed_right_expr = right_var
-					} else {
-						fixed_right_expr = g.expr_string(val)
-					}
+					right := val as ast.ArrayInit
+					right_var := g.new_tmp_var()
+					g.write('${arr_typ} ${right_var} = ')
+					g.expr(right)
+					g.writeln(';')
 					g.writeln('')
-					g.writeln('memcpy(${left_expr}, ${fixed_right_expr}, sizeof(${arr_typ}));')
+					g.writeln('memcpy(${left_expr}, ${right_var}, sizeof(${arr_typ}));')
 				}
 				g.is_assign_lhs = old_is_assign_lhs
 				g.is_assign_lhs = false

--- a/vlib/v/tests/fixed_array_expr_field_assign_test.v
+++ b/vlib/v/tests/fixed_array_expr_field_assign_test.v
@@ -36,3 +36,30 @@ fn test_fixed_array_field_assign_from_match_expr() {
 	fixed_array_expr_set_match(mut mesh, false)
 	assert mesh.highlight == fixed_array_expr_lo
 }
+
+struct FixedArrayExprBoard {
+mut:
+	cells [4][4]int
+}
+
+fn fixed_array_expr_board_of(values [][]int) [4][4]int {
+	mut board := [4][4]int{}
+	for row in 0 .. 4 {
+		for column in 0 .. 4 {
+			board[row][column] = values[row][column]
+		}
+	}
+	return board
+}
+
+fn test_fixed_array_field_assign_from_call_with_array_init_argument() {
+	mut board := FixedArrayExprBoard{}
+	board.cells = fixed_array_expr_board_of([
+		[0, 0, 0, 2],
+		[0, 0, 0, 0],
+		[0, 2, 0, 0],
+		[0, 0, 0, 0],
+	])
+	assert board.cells[0][3] == 2
+	assert board.cells[2][1] == 2
+}


### PR DESCRIPTION
## Summary

- emit non-literal fixed-array assignment values inline so nested temporary declarations are hoisted before memcpy
- add a regression test for assigning a function-returned 2D fixed array when the call receives nested dynamic array literals

Fixes #28169

## Tests

- ./vnew -old-compiler -gc boehm_full_opt vlib/v/tests/fixed_array_expr_field_assign_test.v
- ./vnew vlib/v/tests/fixed_array_expr_field_assign_test.v
- ./vnew -old-compiler -silent test vlib/v/tests/assign/
- ./vnew -silent vlib/v/compiler_errors_test.v