### PR TITLE
net.websocket: batch payload read

### DIFF
--- a/vlib/net/websocket/message.v
+++ b/vlib/net/websocket/message.v
@@ -84,16 +84,14 @@ fn (mut ws Client) read_payload(frame &Frame) ![]u8 {
 	if frame.payload_len == 0 {
 		return []u8{}
 	}
-	mut buffer := []u8{cap: frame.payload_len}
-	mut read_buf := [1]u8{}
+	mut buffer := []u8{len: frame.payload_len}
 	mut bytes_read := 0
 	for bytes_read < frame.payload_len {
-		len := ws.socket_read_ptr(&read_buf[0], 1)!
-		if len != 1 {
+		n := ws.socket_read_ptr(unsafe { &buffer[bytes_read] }, frame.payload_len - bytes_read)!
+		if n <= 0 {
 			return error('expected read all message, got zero')
 		}
-		bytes_read += len
-		buffer << read_buf[0]
+		bytes_read += n
 	}
 	if bytes_read != frame.payload_len {
 		return error('failed to read payload')

--- a/vlib/net/websocket/tests/perf_ws_read.v
+++ b/vlib/net/websocket/tests/perf_ws_read.v
@@ -1,0 +1,130 @@
+// perf_ws_read.v - benchmarks the websocket payload read path (read_payload).
+//
+// A local websocket server pushes `frames` large binary messages per round;
+// the client reads them back-to-back with read_next_message() and reports
+// throughput per round. The first (warmup) round is not counted.
+//
+// usage: perf_ws_read [total_mib] [frame_kib] [rounds]
+//   defaults:            10         1024        3
+module main
+
+import net.websocket
+import os
+import time
+
+const listen_port = 31177
+
+const connect_timeout_ms = 5000
+
+struct BenchState {
+mut:
+	chunk  []u8 // payload sent for every frame
+	frames int  // frames per round
+}
+
+// start_server spawns a server that sends the bulk data whenever it
+// receives a 'go' text message.
+fn start_server(port int, state &BenchState) ! {
+	mut s := websocket.new_server(.ip, port, '')
+	s.set_ping_interval(3600) // effectively disable pings during the bench
+	s.on_message(fn [state] (mut ws websocket.Client, msg &websocket.Message) ! {
+		if msg.payload.bytestr() == 'go' {
+			for _ in 0 .. state.frames {
+				ws.write(state.chunk, .binary_frame) or { break }
+			}
+		}
+	})
+	spawn s.listen()
+	wait_until_ready(mut s)
+}
+
+fn wait_until_ready(mut s websocket.Server) {
+	deadline := time.ticks() + connect_timeout_ms
+	for s.get_state() != .open {
+		if time.ticks() > deadline {
+			eprintln('server did not become ready in ${connect_timeout_ms}ms')
+			exit(1)
+		}
+		time.sleep(5 * time.millisecond)
+	}
+}
+
+fn main() {
+	mut total_mib := 10
+	mut frame_kib := 1024
+	mut rounds := 3
+	for i, arg in os.args[1..] {
+		v := arg.int()
+		if v <= 0 {
+			eprintln('ignoring invalid argument "${arg}"')
+			continue
+		}
+		match i {
+			0 { total_mib = v }
+			1 { frame_kib = v }
+			2 { rounds = v }
+			else {}
+		}
+	}
+	chunk_len := frame_kib * 1024
+	frames := total_mib * 1024 * 1024 / chunk_len
+	total_bytes := u64(frames) * u64(chunk_len)
+
+	state := &BenchState{
+		chunk:  []u8{len: chunk_len, init: u8((index % 251) + 1)}
+		frames: frames
+	}
+	start_server(listen_port, state)!
+
+	println('websocket payload read benchmark')
+	println('  payload/frame : ${frame_kib} KiB')
+	println('  frames/round  : ${frames}')
+	println('  total/round   : ${total_bytes / (1024 * 1024)} MiB')
+	println('  rounds        : ${rounds} (+1 warmup)')
+	println('')
+
+	mut client := websocket.new_client('ws://127.0.0.1:${listen_port}')!
+	client.connect()!
+
+	mut best := f64(0)
+	mut sum := f64(0)
+	for r in 0 .. rounds + 1 {
+		client.write_string('go')!
+		mut sw := time.new_stopwatch()
+		mut got := 0
+		for got < frames {
+			msg := client.read_next_message()!
+			match msg.opcode {
+				.binary_frame {
+					if msg.payload.len != chunk_len {
+						eprintln('bad payload size: ${msg.payload.len}, expected ${chunk_len}')
+						exit(1)
+					}
+					got++
+				}
+				.ping {
+					client.pong() or {}
+				}
+				else {}
+			}
+		}
+		elapsed_ns := f64(u64(sw.elapsed()))
+		mibs := f64(total_bytes) / 1048576.0 / (elapsed_ns / 1e9)
+		ms := elapsed_ns / 1e6
+		if r == 0 {
+			println('  warmup : ${ms:9.1f} ms   ${mibs:9.1f} MiB/s   (discarded)')
+		} else {
+			println('  round ${r} : ${ms:9.1f} ms   ${mibs:9.1f} MiB/s')
+			sum += mibs
+			if mibs > best {
+				best = mibs
+			}
+		}
+	}
+	println('')
+	println('  best : ${best:9.1f} MiB/s')
+	println('  avg  : ${sum / f64(rounds):9.1f} MiB/s')
+
+	client.close(1000, 'done') or {}
+	time.sleep(100 * time.millisecond)
+}


### PR DESCRIPTION
<!--

Please title your PR as follows: `module: description` (e.g. `time: fix date format`).
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
Read frame payloads with bulk socket reads into a preallocated buffer, improving large-message receive throughput by ~2000x(1.2MB/s -> ~2944MB/s for 10MiB transfers on loopback).

orig:
```sh
$ ./perf_ws
2026-08-25T23:17:06.543843Z [INFO ] websocket server: start listen on port 31177
websocket payload read benchmark
  payload/frame : 1024 KiB
  frames/round  : 10
  total/round   : 10 MiB
  rounds        : 3 (+1 warmup)

2026-08-25T23:17:06.549079Z [INFO ] connecting to host ws://127.0.0.1:31177
2026-08-25T23:17:06.549716Z [INFO ] Starting client listener, server(true)...
2026-08-25T23:17:06.549868Z [INFO ] successfully connected to host ws://127.0.0.1:31177
  warmup :    7978.9 ms         1.3 MiB/s   (discarded)
  round 1 :    7958.1 ms         1.3 MiB/s
  round 2 :    8059.8 ms         1.2 MiB/s
  round 3 :    8067.0 ms         1.2 MiB/s

  best :       1.3 MiB/s
  avg  :       1.2 MiB/s
2026-08-25T23:17:38.614096Z [INFO ] Quit client listener, server(true)...
``` 

fixed:
```
$ ./perf_ws_new
2026-08-25T23:17:00.238939Z [INFO ] websocket server: start listen on port 31177
websocket payload read benchmark
  payload/frame : 1024 KiB
  frames/round  : 10
  total/round   : 10 MiB
  rounds        : 3 (+1 warmup)

2026-08-25T23:17:00.244184Z [INFO ] connecting to host ws://127.0.0.1:31177
2026-08-25T23:17:00.244824Z [INFO ] Starting client listener, server(true)...
2026-08-25T23:17:00.244993Z [INFO ] successfully connected to host ws://127.0.0.1:31177
  warmup :       5.7 ms      1745.5 MiB/s   (discarded)
  round 1 :       3.3 ms      3018.2 MiB/s
  round 2 :       3.4 ms      2983.2 MiB/s
  round 3 :       3.5 ms      2832.8 MiB/s

  best :    3018.2 MiB/s
  avg  :    2944.7 MiB/s
2026-08-25T23:17:00.261191Z [INFO ] Quit client listener, server(true)...
```