### PR TITLE
v3: FastC selfhost — 363 MB to 223 MB RSS, 326 ms to 216 ms

### DIFF
--- a/vlib/v3/gen/fastc/fastc.v
+++ b/vlib/v3/gen/fastc/fastc.v
@@ -919,7 +919,7 @@ fn generate_source_files(sources []FastcSourceFile, prefs &pref.Preferences) !st
 	for source_file in sources {
 		mut file_set := token.FileSet.new()
 		mut file := file_set.add_file(source_file.path, source_file.source.len)
-		file.index_lines(source_file.source)
+		file.index_lines_without_digest(source_file.source)
 		mut gen := Parser{
 			prefs:                   unsafe { prefs }
 			path:                    source_file.path
@@ -1275,10 +1275,20 @@ fn fastc_resolve_source_files(paths []string, prefs &pref.Preferences) ![]FastcS
 	}
 	mut seen := map[string]bool{}
 	mut sources := []FastcSourceFile{}
+	// Modules are re-discovered once per importing file; canonicalization and
+	// directory enumeration are syscalls, so both are memoized for the walk.
+	mut real_path_cache := map[string]string{}
+	mut module_dir_files := map[string][]string{}
 	for queue.len > 0 {
 		queued := queue[0]
 		queue.delete(0)
-		path := os.real_path(queued.path)
+		mut path := ''
+		if cached := real_path_cache[queued.path] {
+			path = cached
+		} else {
+			path = os.real_path(queued.path)
+			real_path_cache[queued.path] = path
+		}
 		if seen[path] {
 			continue
 		}
@@ -1316,12 +1326,27 @@ fn fastc_resolve_source_files(paths []string, prefs &pref.Preferences) ![]FastcS
 			if module_dir == '' {
 				return error('fastc cannot resolve imported module `${imported_module}` from `${path}`')
 			}
-			for module_file in pref.get_v_files_from_dir_for_target(module_dir, prefs.user_defines,
-				prefs.target) {
-				if !fastc_source_file_matches_backend(module_file) {
-					continue
+			mut module_files := []string{}
+			if cached := module_dir_files[module_dir] {
+				module_files = cached.clone()
+			} else {
+				for module_file in pref.get_v_files_from_dir_for_target(module_dir,
+					prefs.user_defines, prefs.target) {
+					if fastc_source_file_matches_backend(module_file) {
+						module_files << module_file
+					}
 				}
-				if !seen[os.real_path(module_file)] {
+				module_dir_files[module_dir] = module_files
+			}
+			for module_file in module_files {
+				mut module_file_real := ''
+				if cached := real_path_cache[module_file] {
+					module_file_real = cached
+				} else {
+					module_file_real = os.real_path(module_file)
+					real_path_cache[module_file] = module_file_real
+				}
+				if !seen[module_file_real] {
 					queue << FastcQueuedSource{
 						path:        module_file
 						module_name: imported_module
@@ -1455,7 +1480,7 @@ fn fastc_source_file_matches_backend(path string) bool {
 fn fastc_scan_source_header(source string, path string, prefs &pref.Preferences) !FastcSourceHeader {
 	mut file_set := token.FileSet.new()
 	mut file := file_set.add_file(path, source.len)
-	file.index_lines(source)
+	file.index_lines_without_digest(source)
 	mut scan := scanner.new_scanner(prefs, .normal)
 	scan.init(file, source)
 	mut module_name := ''
@@ -1669,7 +1694,7 @@ fn fastc_register_selective_imports(import_path string, selected_names []string,
 fn collect_declared_types(source string, path string, module_name string, prefs &pref.Preferences, mut declared_types map[string]bool, mut declared_kinds map[string]FastcDeclaredTypeKind, mut enum_flags map[string]bool, mut params_structs map[string]bool) ! {
 	mut file_set := token.FileSet.new()
 	mut file := file_set.add_file(path, source.len)
-	file.index_lines(source)
+	file.index_lines_without_digest(source)
 	mut scan := scanner.new_scanner(prefs, .normal)
 	scan.init(file, source)
 	mut brace_depth := 0
@@ -1764,7 +1789,7 @@ fn collect_declared_types(source string, path string, module_name string, prefs 
 fn collect_constant_names(source string, path string, module_name string, prefs &pref.Preferences, mut constants map[string]string, mut public_constants map[string]bool) ! {
 	mut file_set := token.FileSet.new()
 	mut file := file_set.add_file(path, source.len)
-	file.index_lines(source)
+	file.index_lines_without_digest(source)
 	mut scan := scanner.new_scanner(prefs, .normal)
 	scan.init(file, source)
 	mut brace_depth := 0
@@ -1846,7 +1871,7 @@ fn fastc_register_constant(module_name string, name string, is_public bool, path
 fn collect_global_names(source string, path string, header FastcSourceHeader, prefs &pref.Preferences, mut globals map[string]string, mut public_globals map[string]bool) ! {
 	mut file_set := token.FileSet.new()
 	mut file := file_set.add_file(path, source.len)
-	file.index_lines(source)
+	file.index_lines_without_digest(source)
 	mut scan := scanner.new_scanner(prefs, .normal)
 	scan.init(file, source)
 	mut depth := 0
@@ -1926,7 +1951,7 @@ fn fastc_generate_global_declarations(sources []FastcSourceFile, prefs &pref.Pre
 		mut initializers := strings.new_builder(256)
 		mut file_set := token.FileSet.new()
 		mut file := file_set.add_file(source_file.path, source_file.source.len)
-		file.index_lines(source_file.source)
+		file.index_lines_without_digest(source_file.source)
 		mut gen := Parser{
 			prefs:                  unsafe { prefs }
 			path:                   source_file.path
@@ -2105,7 +2130,7 @@ fn fastc_render_struct_field_defaults(prefs &pref.Preferences, declared_types ma
 			default_path := '${field.path}:${field.name}:default'
 			mut file_set := token.FileSet.new()
 			mut file := file_set.add_file(default_path, field.default_source.len)
-			file.index_lines(field.default_source)
+			file.index_lines_without_digest(field.default_source)
 			mut gen := Parser{
 				prefs:                  unsafe { prefs }
 				path:                   default_path
@@ -2161,7 +2186,7 @@ fn fastc_generate_constant_declarations(sources []FastcSourceFile, prefs &pref.P
 	for source_file in ordered_sources {
 		mut file_set := token.FileSet.new()
 		mut file := file_set.add_file(source_file.path, source_file.source.len)
-		file.index_lines(source_file.source)
+		file.index_lines_without_digest(source_file.source)
 		mut gen := Parser{
 			prefs:                  unsafe { prefs }
 			path:                   source_file.path
@@ -2582,7 +2607,7 @@ fn fastc_c_composite_definition_end(source string, start int) ?int {
 fn fastc_emit_source_type_declarations(source_file FastcSourceFile, prefs &pref.Preferences, declared_types map[string]bool, declared_kinds map[string]FastcDeclaredTypeKind, constants map[string]string, public_constants map[string]bool, mut struct_fields map[string]map[string]string, mut struct_field_info map[string][]FastcStructField, mut composite_types map[string]bool, mut alias_base_types map[string]string, mut enum_infos []FastcEnumInfo, mut out strings.Builder) ! {
 	mut file_set := token.FileSet.new()
 	mut file := file_set.add_file(source_file.path, source_file.source.len)
-	file.index_lines(source_file.source)
+	file.index_lines_without_digest(source_file.source)
 	mut scan := scanner.new_scanner(prefs, .normal)
 	scan.init(file, source_file.source)
 	mut depth := 0
@@ -3644,7 +3669,7 @@ fn fastc_scan_selected_comptime_branch(mut scan scanner.Scanner, first token.Tok
 fn fastc_collect_selected_comptime_function_signatures(source string, path string, header FastcSourceHeader, prefs &pref.Preferences, declared_types map[string]bool, params_structs map[string]bool, mut functions map[string]FastcFunctionSignature) ! {
 	mut file_set := token.FileSet.new()
 	mut file := file_set.add_file(path, source.len)
-	file.index_lines(source)
+	file.index_lines_without_digest(source)
 	mut scan := scanner.new_scanner(prefs, .normal)
 	scan.init(file, source)
 	mut brace_depth := 0
@@ -3678,7 +3703,7 @@ fn fastc_parameter_is_params_struct(parameter_type string, params_structs map[st
 fn collect_function_signatures(source string, path string, header FastcSourceHeader, prefs &pref.Preferences, declared_types map[string]bool, params_structs map[string]bool, mut functions map[string]FastcFunctionSignature) ! {
 	mut file_set := token.FileSet.new()
 	mut file := file_set.add_file(path, source.len)
-	file.index_lines(source)
+	file.index_lines_without_digest(source)
 	mut scan := scanner.new_scanner(prefs, .normal)
 	scan.init(file, source)
 	mut brace_depth := 0
@@ -3953,7 +3978,7 @@ fn fastc_collect_referenced_function_names(sources []FastcSourceFile, prefs &pre
 	for source_file in sources {
 		mut file_set := token.FileSet.new()
 		mut file := file_set.add_file(source_file.path, source_file.source.len)
-		file.index_lines(source_file.source)
+		file.index_lines_without_digest(source_file.source)
 		mut scan := scanner.new_scanner(prefs, .normal)
 		scan.init(file, source_file.source)
 		mut previous := token.Token.unknown
@@ -4110,7 +4135,7 @@ fn fastc_collect_type_default_references(mut scan scanner.Scanner, first token.T
 fn collect_interface_method_signatures(source string, path string, header FastcSourceHeader, prefs &pref.Preferences, declared_types map[string]bool, mut functions map[string]FastcFunctionSignature, mut interface_methods map[string]bool, mut interface_fields map[string]FastcInterfaceField) ! {
 	mut file_set := token.FileSet.new()
 	mut file := file_set.add_file(path, source.len)
-	file.index_lines(source)
+	file.index_lines_without_digest(source)
 	mut scan := scanner.new_scanner(prefs, .normal)
 	scan.init(file, source)
 	mut tok := scan.scan()
@@ -13659,10 +13684,18 @@ fn fastc_boolean_operator_precedence(tok token.Token) int {
 	return -1
 }
 
-fn fastc_top_level_operator_index(tokens []FastcExpressionToken, start int, end int, precedence int) ?int {
+// fastc_lowest_precedence_operator_index returns the leftmost top-level
+// boolean operator of the lowest available precedence class (`||`, then `&&`,
+// then comparisons) in one pass. Equivalent to probing each class with a full
+// scan, which previously tripled the per-inference-step token traffic.
+@[direct_array_access]
+fn fastc_lowest_precedence_operator_index(tokens []FastcExpressionToken, start int, end int) ?int {
 	mut depth := 0
+	mut first_and := -1
+	mut first_comparison := -1
 	for i in start .. end {
-		match tokens[i].tok {
+		tok := tokens[i].tok
+		match tok {
 			.lpar, .lsbr, .lcbr {
 				depth++
 				continue
@@ -13673,10 +13706,29 @@ fn fastc_top_level_operator_index(tokens []FastcExpressionToken, start int, end 
 			}
 			else {}
 		}
-		if depth == 0 && fastc_boolean_operator_precedence(tokens[i].tok) == precedence && i > start
-			&& i + 1 < end {
+		if depth != 0 || i == start || i + 1 >= end {
+			continue
+		}
+		precedence := fastc_boolean_operator_precedence(tok)
+		if precedence == 0 {
+			// Nothing binds looser than the leftmost `||`.
 			return i
 		}
+		if precedence == 1 {
+			if first_and == -1 {
+				first_and = i
+			}
+		} else if precedence == 2 {
+			if first_comparison == -1 {
+				first_comparison = i
+			}
+		}
+	}
+	if first_and != -1 {
+		return first_and
+	}
+	if first_comparison != -1 {
+		return first_comparison
 	}
 	return none
 }
@@ -13782,13 +13834,7 @@ fn (g &Parser) infer_expression_type(tokens []FastcExpressionToken) !string {
 		_ = g.infer_expression_type(tokens[start + 1..end])!
 		return 'bool'
 	}
-	if operator_index := fastc_top_level_operator_index(tokens, start, end, 0) {
-		return g.infer_boolean_binary_expression_type(tokens, start, end, operator_index)!
-	}
-	if operator_index := fastc_top_level_operator_index(tokens, start, end, 1) {
-		return g.infer_boolean_binary_expression_type(tokens, start, end, operator_index)!
-	}
-	if operator_index := fastc_top_level_operator_index(tokens, start, end, 2) {
+	if operator_index := fastc_lowest_precedence_operator_index(tokens, start, end) {
 		return g.infer_boolean_binary_expression_type(tokens, start, end, operator_index)!
 	}
 	if end - start == 1 {

--- a/vlib/v3/gen/fastc/fastc.v
+++ b/vlib/v3/gen/fastc/fastc.v
@@ -770,6 +770,25 @@ mut:
 	last_multi_return_types  []string
 	fixed_array_types        map[string]string
 	composite_types          map[string]bool
+	expression_depth         int
+	// Comparison-handler results memoized per token subrange for the duration
+	// of one top-level expression (see fastc_comparison_memo_key). The boolean
+	// operator scans in those handlers re-recurse over shared subranges;
+	// without the memo that search re-renders the same ranges combinatorially.
+	comparison_memo map[i64]FastcRenderedExpression
+	has_c_functions bool
+}
+
+// fastc_comparison_memo_key identifies a token subrange within the current
+// expression. Every recursive slice shares the top array's backing storage, so
+// the data pointer plus length is exact; `tag` separates the two comparison
+// handlers. Token arrays are 8-byte aligned and prealloc never reuses a
+// buffer while the memo is live (it is cleared per top-level expression).
+fn fastc_comparison_memo_key(tokens []FastcExpressionToken, tag i64) i64 {
+	if tokens.len >= 32768 {
+		return 0
+	}
+	return (i64(tokens.data) >> 3 << 16) | (i64(tokens.len) & 0x7fff) | (tag << 62)
 }
 
 // generate scans V source and emits C as each declaration and statement is consumed. It does
@@ -843,6 +862,7 @@ fn generate_source_files(sources []FastcSourceFile, prefs &pref.Preferences) !st
 			interface_fields)!
 	}
 	used_function_names := fastc_collect_referenced_function_names(sources, prefs, functions)
+	has_c_functions := fastc_functions_declare_c(functions)
 	fastc_prefixed_c_names := fastc_reserved_temporary_c_names(functions, globals)
 	module_init_calls := fastc_module_init_calls(sources, functions)!
 	module_cleanup_calls := fastc_module_cleanup_calls(sources, functions)!
@@ -908,6 +928,8 @@ fn generate_source_files(sources []FastcSourceFile, prefs &pref.Preferences) !st
 			declared_types:          declared_types
 			declared_type_c_names:   declared_type_c_names
 			fastc_prefixed_c_names:  fastc_prefixed_c_names
+			has_c_functions:         has_c_functions
+			comparison_memo:         map[i64]FastcRenderedExpression{}
 			declared_kinds:          declared_kinds
 			enum_flags:              enum_flags
 			alias_base_types:        type_output.alias_base_types
@@ -1898,6 +1920,7 @@ fn fastc_register_global(header FastcSourceHeader, name string, is_public bool, 
 fn fastc_generate_global_declarations(sources []FastcSourceFile, prefs &pref.Preferences, declared_types map[string]bool, declared_type_c_names map[string]string, fastc_prefixed_c_names []string, declared_kinds map[string]FastcDeclaredTypeKind, enum_flags map[string]bool, alias_base_types map[string]string, struct_fields map[string]map[string]string, struct_field_info map[string][]FastcStructField, functions map[string]FastcFunctionSignature, constants map[string]string, constant_values map[string]string, public_constants map[string]bool, constant_types map[string]string, globals map[string]string, public_globals map[string]bool, mut global_types map[string]string) !FastcGlobalDeclarations {
 	mut out := strings.new_builder(1024)
 	mut module_initializers := map[string]string{}
+	helper_has_c_functions := fastc_functions_declare_c(functions)
 	ordered_sources := fastc_sources_in_dependency_order(sources)!
 	for source_file in ordered_sources {
 		mut initializers := strings.new_builder(256)
@@ -1912,6 +1935,8 @@ fn fastc_generate_global_declarations(sources []FastcSourceFile, prefs &pref.Pre
 			declared_types:         declared_types
 			declared_type_c_names:  declared_type_c_names
 			fastc_prefixed_c_names: fastc_prefixed_c_names
+			has_c_functions:        helper_has_c_functions
+			comparison_memo:        map[i64]FastcRenderedExpression{}
 			declared_kinds:         declared_kinds
 			enum_flags:             enum_flags
 			alias_base_types:       alias_base_types
@@ -2068,6 +2093,7 @@ fn (mut g Parser) parse_global_declaration(mut out strings.Builder, mut initiali
 }
 
 fn fastc_render_struct_field_defaults(prefs &pref.Preferences, declared_types map[string]bool, declared_type_c_names map[string]string, fastc_prefixed_c_names []string, declared_kinds map[string]FastcDeclaredTypeKind, enum_flags map[string]bool, alias_base_types map[string]string, struct_fields map[string]map[string]string, mut struct_field_info map[string][]FastcStructField, functions map[string]FastcFunctionSignature, constants map[string]string, public_constants map[string]bool, constant_types map[string]string, globals map[string]string, public_globals map[string]bool, global_types map[string]string) ! {
+	helper_has_c_functions := fastc_functions_declare_c(functions)
 	mut type_names := struct_field_info.keys()
 	type_names.sort()
 	for type_name in type_names {
@@ -2088,6 +2114,8 @@ fn fastc_render_struct_field_defaults(prefs &pref.Preferences, declared_types ma
 				declared_types:         declared_types
 				declared_type_c_names:  declared_type_c_names
 				fastc_prefixed_c_names: fastc_prefixed_c_names
+				has_c_functions:        helper_has_c_functions
+				comparison_memo:        map[i64]FastcRenderedExpression{}
 				declared_kinds:         declared_kinds
 				enum_flags:             enum_flags
 				alias_base_types:       alias_base_types
@@ -2128,6 +2156,7 @@ fn fastc_render_struct_field_defaults(prefs &pref.Preferences, declared_types ma
 
 fn fastc_generate_constant_declarations(sources []FastcSourceFile, prefs &pref.Preferences, declared_types map[string]bool, declared_type_c_names map[string]string, fastc_prefixed_c_names []string, declared_kinds map[string]FastcDeclaredTypeKind, enum_flags map[string]bool, alias_base_types map[string]string, struct_fields map[string]map[string]string, struct_field_info map[string][]FastcStructField, functions map[string]FastcFunctionSignature, constants map[string]string, public_constants map[string]bool, globals map[string]string, public_globals map[string]bool, mut constant_types map[string]string) !FastcConstantDeclarations {
 	mut values := []FastcConstantValue{}
+	helper_has_c_functions := fastc_functions_declare_c(functions)
 	ordered_sources := fastc_sources_in_dependency_order(sources)!
 	for source_file in ordered_sources {
 		mut file_set := token.FileSet.new()
@@ -2141,6 +2170,8 @@ fn fastc_generate_constant_declarations(sources []FastcSourceFile, prefs &pref.P
 			declared_types:         declared_types
 			declared_type_c_names:  declared_type_c_names
 			fastc_prefixed_c_names: fastc_prefixed_c_names
+			has_c_functions:        helper_has_c_functions
+			comparison_memo:        map[i64]FastcRenderedExpression{}
 			declared_kinds:         declared_kinds
 			enum_flags:             enum_flags
 			alias_base_types:       alias_base_types
@@ -7223,6 +7254,21 @@ fn (mut g Parser) read_statement_expression_with_prefix(prefix string, stops []t
 }
 
 fn (mut g Parser) read_expression_with_prefix_mode(prefix string, stops []token.Token, allow_mutation_statement bool, allow_declaration_guard bool) !string {
+	g.expression_depth++
+	if g.expression_depth == 1 && g.comparison_memo.len > 0 {
+		// Memoized comparison renders are only valid while the expression's
+		// token buffers and locals are live and unchanged; a new top-level
+		// expression starts a fresh generation.
+		g.comparison_memo.clear()
+	}
+	defer {
+		g.expression_depth--
+	}
+	return g.read_expression_with_prefix_mode_impl(prefix, stops, allow_mutation_statement,
+		allow_declaration_guard)
+}
+
+fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []token.Token, allow_mutation_statement bool, allow_declaration_guard bool) !string {
 	if g.selfhost && prefix == '' && g.tok == .lcbr && token.Token.lcbr !in stops {
 		return g.read_inferred_map_literal()!
 	}
@@ -10859,6 +10905,30 @@ fn (g &Parser) struct_equality_source(left string, right string, typ string, see
 }
 
 fn (g &Parser) render_struct_comparison_expression(tokens []FastcExpressionToken) ?FastcRenderedExpression {
+	memo_key := fastc_comparison_memo_key(tokens, 0)
+	if memo_key != 0 {
+		if cached := g.comparison_memo[memo_key] {
+			if cached.source == '' {
+				return none
+			}
+			return cached
+		}
+	}
+	mut result := FastcRenderedExpression{}
+	if rendered := g.render_struct_comparison_expression_impl(tokens) {
+		result = rendered
+	}
+	if memo_key != 0 {
+		mut w := unsafe { &Parser(g) }
+		w.comparison_memo[memo_key] = result
+	}
+	if result.source == '' {
+		return none
+	}
+	return result
+}
+
+fn (g &Parser) render_struct_comparison_expression_impl(tokens []FastcExpressionToken) ?FastcRenderedExpression {
 	if tokens.len >= 3 && tokens[0].tok == .lpar && tokens.last().tok == .rpar {
 		close := fastc_matching_rpar(tokens, 0) or { -1 }
 		if close == tokens.len - 1 {
@@ -11116,6 +11186,30 @@ fn (g &Parser) render_string_comparison_expression(tokens []FastcExpressionToken
 }
 
 fn (g &Parser) render_mixed_integer_comparison_expression(tokens []FastcExpressionToken) ?FastcRenderedExpression {
+	memo_key := fastc_comparison_memo_key(tokens, 1)
+	if memo_key != 0 {
+		if cached := g.comparison_memo[memo_key] {
+			if cached.source == '' {
+				return none
+			}
+			return cached
+		}
+	}
+	mut result := FastcRenderedExpression{}
+	if rendered := g.render_mixed_integer_comparison_expression_impl(tokens) {
+		result = rendered
+	}
+	if memo_key != 0 {
+		mut w := unsafe { &Parser(g) }
+		w.comparison_memo[memo_key] = result
+	}
+	if result.source == '' {
+		return none
+	}
+	return result
+}
+
+fn (g &Parser) render_mixed_integer_comparison_expression_impl(tokens []FastcExpressionToken) ?FastcRenderedExpression {
 	if tokens.len >= 3 && tokens[0].tok == .lpar && tokens.last().tok == .rpar {
 		close := fastc_matching_rpar(tokens, 0) or { -1 }
 		if close == tokens.len - 1 {
@@ -12692,7 +12786,14 @@ fn (g &Parser) validate_expression_name(name string, previous token.Token) ! {
 }
 
 fn (g &Parser) has_declared_c_function() bool {
-	for function_key in g.functions.keys() {
+	return g.has_c_functions
+}
+
+// fastc_functions_declare_c collects once whether any collected function key
+// names a `C.` function; has_declared_c_function previously cloned every
+// function key per name-resolution query to answer this fixed question.
+fn fastc_functions_declare_c(functions map[string]FastcFunctionSignature) bool {
+	for function_key, _ in functions {
 		if function_key.starts_with('C.') {
 			return true
 		}

--- a/vlib/v3/token/position.v
+++ b/vlib/v3/token/position.v
@@ -159,8 +159,11 @@ pub fn (mut f File) index_lines(src string) {
 // index_lines_without_digest records line starts only. FastC builds a fresh
 // file index per source file for every collection and generation pass and
 // never consumes source digests; hashing every pass dominated its runtime.
+// Any previously stored digest described a different source than the new
+// line table, so integrity consumers must not see it as current.
 pub fn (mut f File) index_lines_without_digest(src string) {
 	f.line_offsets = [0]
+	f.has_source_digest = false
 	for i, ch in src {
 		if ch == `\n` {
 			f.line_offsets << i + 1

--- a/vlib/v3/token/position.v
+++ b/vlib/v3/token/position.v
@@ -145,14 +145,22 @@ pub fn (mut f File) add_line(offset int) {
 	f.line_offsets << offset
 }
 
-// index_lines records every source-line start for logarithmic position lookup.
+// index_lines records every source-line start for logarithmic position lookup
+// and stores the source digest consumed by cache and fallback verification.
 pub fn (mut f File) index_lines(src string) {
-	f.line_offsets = [0]
+	f.index_lines_without_digest(src)
 	digest := sha256.sum(src.bytes())
 	for i in 0 .. sha256.size {
 		f.source_digest[i] = digest[i]
 	}
 	f.has_source_digest = true
+}
+
+// index_lines_without_digest records line starts only. FastC builds a fresh
+// file index per source file for every collection and generation pass and
+// never consumes source digests; hashing every pass dominated its runtime.
+pub fn (mut f File) index_lines_without_digest(src string) {
+	f.line_offsets = [0]
 	for i, ch in src {
 		if ch == `\n` {
 			f.line_offsets << i + 1


### PR DESCRIPTION
## Summary

Two commits that together cut the FastC selfhost build (`v3 -selfhost -b fastc -nocache v3.v`) from **363 MB / ~326 ms** to **223 MB / ~216 ms**.

### Commit 1 — memory: memoize the comparison handlers

Per-phase allocation tracing (`-d prealloc_stats`) attributed 227 MB of 322 MB of arena allocations to per-file generation, almost all under `render_struct_comparison_expression` and `render_mixed_integer_comparison_expression`. Both split at every top-level `&&`/`||` and recursively re-render **both** sides per operator, so ordinary boolean chains with no struct or mixed-sign comparison re-explored overlapping subranges combinatorially (fastc.v alone: 118 MB, 253 B allocated per source byte; token/util.v: 24.7 MB from 7 KB of source). Both handlers are now memoized per token subrange for the duration of one top-level expression — recursive slices share the top expression's backing array, so `(slice data pointer, length)` is an exact key. `has_declared_c_function` also stops cloning every function key per query.

### Commit 2 — time: drop redundant hashing, syscalls, and rescans

- `File.index_lines` sha256-digests the whole source for the AST pipeline's cache/fallback verification. FastC rebuilds file indexes every collection and generation pass (1,938 calls ≈ 8 full-source digests per file) and never reads a digest — over half the instrumented runtime. FastC now uses a new `index_lines_without_digest`; the AST parser path digests exactly as before.
- Module resolution canonicalized and re-enumerated every imported module's directory once per importing file (636 `os.real_path` calls ≈ 20 ms of syscalls, plus repeated directory listings). Both are memoized for the resolution walk; queue order and dedup keys are unchanged.
- Type inference probed each token range with three sequential top-level operator scans; one pass now records the leftmost operator per precedence class.

The new code stays inside the FastC-compilable subset (explicit map init at Parser construction, no `or { StructLiteral{} }`, no value-tail `or` blocks — FastC mis-renders or rejects those forms).

## Results (M-series macOS)

| `-selfhost -b fastc -nocache` | before | after |
|---|---|---|
| peak RSS | 363 MB | **223 MB** |
| arena allocations | 322 MB / 6.03M | ~145 MB / ~2.5M |
| fastc parse+gen | 258 ms | **~155 ms** |
| total | 326 ms | **~216 ms** |

For scale: the regular C backend self-host is ~920 ms / ~1 GB — FastC is now ~4.3× faster and ~4.5× leaner.

## Verification

- Emitted C is **byte-identical** to the unmodified compiler on the same input (checked after each commit).
- Selfhost chain `v3 → v4f → v5f → v6f` completes with `V_MACOS_V3_NO_FALLBACK=1`; generation-2 and generation-3 outputs are byte-identical.
- Regular C-backend self-host build unaffected (check ~146 ms, total ~913 ms).
- Non-selfhost `-b fastc` smoke test runs correctly; `v fmt -verify` passes on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)