### PR TITLE
ci: run architecture jobs for V3 changes

### DIFF
--- a/.github/workflows/riscv64_linux_ci.yml
+++ b/.github/workflows/riscv64_linux_ci.yml
@@ -6,7 +6,8 @@ on:
     branches:
       - master
     paths-ignore:
-      - 'vlib/v3/**'
+      # vlib/v3/** is intentionally NOT ignored: V3 is the default compiler on
+      # Linux, including this riscv64 runner.
       - '**.md'
       - '**.yml'
       - '!**/riscv64_linux_ci.yml'
@@ -31,6 +32,7 @@ on:
       - 'vlib/strings/**'
       - 'vlib/sync/**'
       - 'vlib/v/**'
+      - 'vlib/v3/**'
       - 'thirdparty/**'
       - 'vc/**'
       - 'v.mod'

--- a/.github/workflows/riscv64_linux_ci.yml
+++ b/.github/workflows/riscv64_linux_ci.yml
@@ -80,6 +80,10 @@ jobs:
             make
             file ./v
             ls -la ./v
+            # V3 is the default compiler on Linux. Keep bootstrap fallback-compatible,
+            # then make ordinary test compilation fail instead of silently retrying V1.
+            export V_MACOS_V3_NO_FALLBACK=1
             ./v test vlib/builtin vlib/os vlib/encoding/binary
-            ./v test vlib/v/slow_tests/assembly
+            # Inline assembly is an intentional V3 compatibility fallback.
+            V_MACOS_V3_NO_FALLBACK=0 ./v test vlib/v/slow_tests/assembly
             VTEST_ONLY=closure ./v test vlib/v/tests

--- a/.github/workflows/s390x_linux_ci.yml
+++ b/.github/workflows/s390x_linux_ci.yml
@@ -6,7 +6,8 @@ on:
     branches:
       - master
     paths-ignore:
-      - 'vlib/v3/**'
+      # vlib/v3/** is intentionally NOT ignored: V3 is the default compiler on
+      # Linux, including this s390x runner.
       - '**.md'
       - '**.yml'
       - '!**/s390x_linux_ci.yml'
@@ -31,6 +32,7 @@ on:
       - 'vlib/strings/**'
       - 'vlib/sync/**'
       - 'vlib/v/**'
+      - 'vlib/v3/**'
       - 'thirdparty/**'
       - 'vc/**'
       - 'v.mod'

--- a/.github/workflows/s390x_linux_ci.yml
+++ b/.github/workflows/s390x_linux_ci.yml
@@ -78,5 +78,8 @@ jobs:
             make
             file ./v
             ls -la ./v
+            # V3 is the default compiler on Linux. Keep bootstrap fallback-compatible,
+            # then make ordinary test compilation fail instead of silently retrying V1.
+            export V_MACOS_V3_NO_FALLBACK=1
             ./v test vlib/builtin vlib/os vlib/encoding/binary
             ./v test vlib/v/tests/fns/closure_test.v


### PR DESCRIPTION
Summary:
- run s390x CI when V3 sources change
- run riscv64 CI when V3 sources change
- include V3 source changes in both pull-request path filters

Why:
V3 is now the default compiler on Linux, but these architecture workflows still excluded vlib/v3 changes. Recent V3 fixes therefore required manual workflow dispatches to validate s390x and riscv64.

Validation:
- npx --yes prettier --check .github/workflows/s390x_linux_ci.yml .github/workflows/riscv64_linux_ci.yml
- git diff --check