### PR TITLE
v3: reduce memory use for large builds

### DIFF
--- a/vlib/v3/README.md
+++ b/vlib/v3/README.md
@@ -84,7 +84,7 @@ currently supported collector mode. Directory builds read `subdirs` through the 
 Native C compilation uses `-fwrapv` on supported targets so signed integer overflow retains V's
 two's-complement semantics. On macOS, `-cg` links executables with exported symbols for symbolic
 backtraces while plain `-g` retains its V-source debug behavior.
-The driver monitors compiler memory throughout the build and exits when it reaches 4 GiB.
+The driver monitors compiler memory throughout the build and exits when it reaches 10 GiB.
 On macOS it uses physical footprint, matching Activity Monitor more closely; elsewhere it uses
 current RSS. Pass `-no-memory-limit`/`--no-memory-limit` to disable this safety limit.
 Stage rows recorded at pipeline boundaries report sampled peak RSS and the process peak. Timing

--- a/vlib/v3/bench/bench.v
+++ b/vlib/v3/bench/bench.v
@@ -5,9 +5,9 @@ import runtime
 import sync
 import time
 
-const default_memory_limit_kb = i64(4) * 1024 * 1024
-const self_host_memory_limit_kb = i64(4) * 1024 * 1024
-const compiler_tree_memory_limit_kb = i64(6) * 1024 * 1024
+const default_memory_limit_kb = i64(10) * 1024 * 1024
+const self_host_memory_limit_kb = i64(10) * 1024 * 1024
+const compiler_tree_memory_limit_kb = i64(10) * 1024 * 1024
 const memory_monitor_interval = 100 * time.millisecond
 
 // Step represents step data used by bench.
@@ -97,7 +97,7 @@ pub fn (mut b Bench) use_self_host_memory_limit() {
 	b.memory_limit_kb = self_host_memory_limit_kb
 }
 
-// use_compiler_tree_memory_limit raises the safety limit for tests that compile
+// use_compiler_tree_memory_limit sets the safety limit for tests that compile
 // the complete V3 compiler module without disabling the OOM guard.
 pub fn (mut b Bench) use_compiler_tree_memory_limit() {
 	b.memory_limit_kb = compiler_tree_memory_limit_kb

--- a/vlib/v3/bench/bench_test.v
+++ b/vlib/v3/bench/bench_test.v
@@ -11,8 +11,8 @@ fn test_memory_limit_error_starts_at_limit() {
 
 	message := memory_limit_error(default_memory_limit_kb, default_memory_limit_kb, 'after parse',
 		'RSS')
-	assert message.contains('4096 MiB RSS after parse')
-	assert message.contains('limit: 4 GiB')
+	assert message.contains('10240 MiB RSS after parse')
+	assert message.contains('limit: 10 GiB')
 	assert message.contains('`-no-memory-limit`')
 }
 
@@ -27,16 +27,14 @@ fn test_self_host_memory_limit() {
 	mut b := new()
 	b.use_self_host_memory_limit()
 	assert memory_limit_error(self_host_memory_limit_kb, b.memory_limit_kb, 'after transform',
-		'RSS').contains('(limit: 4 GiB)')
+		'RSS').contains('(limit: 10 GiB)')
 }
 
 fn test_compiler_tree_memory_limit() {
 	mut b := new()
 	b.use_compiler_tree_memory_limit()
-	assert memory_limit_error(self_host_memory_limit_kb, b.memory_limit_kb, 'after transform',
-		'RSS') == ''
 	assert memory_limit_error(compiler_tree_memory_limit_kb, b.memory_limit_kb, 'after transform',
-		'RSS') != ''
+		'RSS').contains('(limit: 10 GiB)')
 }
 
 fn test_step_parts_record_individual_timings() {

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -74,6 +74,8 @@ fn configure_selfhost_parallelism(building_v bool) {
 }
 
 const embedded_parallel_transform_node_limit = 10_000_000
+const scoped_serial_user_check_node_threshold = 400_000
+const scoped_serial_user_cgen_node_threshold = 500_000
 const scoped_transform_signature_headroom = 2048
 const v3_vvmrc_file_name = '.vvmrc'
 const v3_vvmrc_skip_env = 'V_SKIP_VVMRC'
@@ -2274,7 +2276,7 @@ fn cli_usage() string {
 		'  -profile [file]              write V1-compatible function profile data\n' +
 		'  -profile-fns <names>         profile only named functions and their callees\n' +
 		'  -profile-no-inline           omit @[inline] functions from the profile\n' +
-		'  -no-memory-limit             disable the 4 GiB memory safety limit\n' +
+		'  -no-memory-limit             disable the 10 GiB memory safety limit\n' +
 		'  -d <name>                    compile-time define'
 }
 
@@ -7758,8 +7760,8 @@ pub fn run(args []string) {
 	if no_memory_limit {
 		b.disable_memory_limit()
 	} else if v3_compiler_tree_input {
-		// A compiler-module test retains test-runner state in addition to the full
-		// compiler AST. Its measured peak is above the self-host-only limit.
+		// Compiler-module tests retain test-runner state in addition to the full
+		// compiler AST, so keep their guard separately configurable.
 		b.use_compiler_tree_memory_limit()
 	} else if building_v || cmd_v_module_input {
 		// Self-host transformation temporarily retains both the source and rewritten
@@ -8074,8 +8076,6 @@ pub fn run(args []string) {
 	program_cache_enabled := persistent_program_cache_enabled(cache_enabled, is_test_command
 		|| is_v3_test_file(input_file, backend, target), os.vtmp_dir())
 	force_cache_source := os.getenv('V3_CACHE_FORCE_SOURCE') == '1'
-	// Cache markers and scoped output are stable across ordered worker chunks, so cached
-	// and preallocated builds use the same parallel function-body generator.
 	mut cache_no_parallel_cgen := current_no_parallel
 	stage_macos_v3_compiler_error_fallback(macos_v3_fallback_file, 'source parsing')
 	mut p := parser.Parser.new(prefs)
@@ -8679,7 +8679,7 @@ pub fn run(args []string) {
 	mut trivial_literal_output := false
 	if !cgen_cache_hit {
 		pre_tc.verbose = prefs.verbose
-		if scope_prealloc_check && !current_no_parallel && a.missing_imports.len == 0 {
+		if scope_prealloc_check && a.missing_imports.len == 0 {
 			pre_tc.enable_scoped_parallel_workers()
 		}
 		pre_tc.reject_unsupported_generics = is_selfhost
@@ -8746,8 +8746,12 @@ pub fn run(args []string) {
 			pre_tc.check_semantics_selected(incremental_changed_names)
 		} else {
 			ck_stage_sw.restart()
-			check_was_parallel = pre_tc.check_semantics_opt(!current_no_parallel
-				&& a.missing_imports.len == 0)
+			// On large user import graphs, scoped serial batches use less memory than
+			// retaining one semantic-check accumulator per worker.
+			parallel_semantic_check := !current_no_parallel && a.missing_imports.len == 0
+				&& (building_v || !scope_prealloc_check
+				|| a.nodes.len < scoped_serial_user_check_node_threshold)
+			check_was_parallel = pre_tc.check_semantics_opt(parallel_semantic_check)
 			if verbose {
 				eprintln('  [ttime]   ck semantics     ${f64(ck_stage_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 			}
@@ -9695,6 +9699,13 @@ pub fn run(args []string) {
 		}
 	} else {
 		// C backend (default)
+		// Large generic user programs retain their transformed AST through cgen.
+		// Bounded serial batches prevent worker snapshots from overlapping that live
+		// set at the memory-limit peak; smaller programs keep the parallel fast path.
+		if scope_prealloc_cgen && !building_v && !cmd_v_build
+			&& a.nodes.len >= scoped_serial_user_cgen_node_threshold {
+			cache_no_parallel_cgen = true
+		}
 		c_standard := c_standard_flag(prefs.c99)
 		use_cached_dev_dylib := cache_state.manager.enabled && remove_binary_after_run && !is_prod
 			&& !is_shared && !is_selfhost && prefs.normalized_target_os() == 'macos'

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -90,6 +90,64 @@ fn clone_cgen_string_list(values []string) []string {
 	return cloned
 }
 
+fn clone_cgen_string_bool_lookup(values map[string]bool) map[string]bool {
+	mut cloned := map[string]bool{}
+	cloned.reserve(u32(values.len))
+	for key, value in values {
+		cloned[key.clone()] = value
+	}
+	return cloned
+}
+
+fn clone_c_inline_header(header CInlineHeader) CInlineHeader {
+	mut preserved_headers := []CPreservedHeader{cap: header.preserved_headers.len}
+	for preserved_header in header.preserved_headers {
+		preserved_headers << CPreservedHeader{
+			include_arg: preserved_header.include_arg.clone()
+			source_file: preserved_header.source_file.clone()
+		}
+	}
+	return CInlineHeader{
+		text:                      header.text.clone()
+		preserved_directives:      clone_cgen_string_list(header.preserved_directives)
+		preserved_c_fns:           clone_cgen_string_list(header.preserved_c_fns)
+		preserved_c_structs:       clone_cgen_string_list(header.preserved_c_structs)
+		preserved_c_typedef_names: clone_cgen_string_list(header.preserved_c_typedef_names)
+		preserved_headers:         preserved_headers
+	}
+}
+
+struct CgenScopedAppend {
+	scope       voidptr
+	original_sb strings.Builder
+}
+
+fn (mut g FlatGen) begin_scoped_append() CgenScopedAppend {
+	original_sb := g.sb
+	scope := cgen_worker_scope_begin(g.scope_parallel_workers)
+	if scope != unsafe { nil } {
+		g.sb = strings.new_builder(4096)
+	}
+	return CgenScopedAppend{
+		scope:       scope
+		original_sb: original_sb
+	}
+}
+
+fn (mut g FlatGen) finish_scoped_append(state CgenScopedAppend) {
+	if state.scope == unsafe { nil } {
+		return
+	}
+	data := g.sb.data
+	len := g.sb.len
+	line_start := g.line_start
+	cgen_worker_scope_leave(state.scope)
+	g.sb = state.original_sb
+	g.line_start = line_start
+	unsafe { g.sb.write_ptr(data, len) }
+	cgen_worker_scope_free(state.scope)
+}
+
 struct ActiveLock {
 	mutexes_var string
 	modes_var   string
@@ -3179,15 +3237,27 @@ fn (mut g FlatGen) gen_translation_unit_prefix() {
 	}
 	g.thread_stack_size_definition()
 	g.emit_preinclude_directives()
-	g.emit_preserved_c_directives()
+	g.emit_preserved_c_directives_scoped()
 	g.preamble()
 	if g.cache_split {
 		g.writeln('/* V3CACHE_NATIVE_DIRECTIVES_BEGIN */')
 	}
-	g.emit_c_directives(false)
+	g.emit_c_directives_scoped(false)
 	if g.cache_split {
 		g.writeln('/* V3CACHE_NATIVE_DIRECTIVES_END */')
 	}
+}
+
+fn (mut g FlatGen) emit_preserved_c_directives_scoped() {
+	state := g.begin_scoped_append()
+	g.emit_preserved_c_directives()
+	g.finish_scoped_append(state)
+}
+
+fn (mut g FlatGen) emit_c_directives_scoped(late bool) {
+	state := g.begin_scoped_append()
+	g.emit_c_directives(late)
+	g.finish_scoped_append(state)
 }
 
 fn (mut g FlatGen) gen_global_declaration_block() {
@@ -3671,7 +3741,11 @@ fn (mut g FlatGen) collect_gen_info(no_parallel bool) {
 		g.collect_c_flags_from_directives()
 	}
 	g.c_flags << g.initial_c_flags
-	g.use_system_stdint = g.translation_unit_uses_inttypes()
+	inttypes_scope := cgen_worker_scope_begin(g.scope_parallel_workers)
+	uses_system_stdint := g.translation_unit_uses_inttypes()
+	cgen_worker_scope_leave(inttypes_scope)
+	g.use_system_stdint = uses_system_stdint
+	cgen_worker_scope_free(inttypes_scope)
 	if profile {
 		g.timing_profile('  [ttime]   ci flags+stdint  ${f64(presw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 	}
@@ -4413,8 +4487,8 @@ fn (mut g FlatGen) collect_c_directive(module_name string, node flat.Node, sourc
 			g.add_c_directive(module_name, '#include ${include_arg}', before_import)
 			return true
 		}
-		if header := c_inline_header_text(include_arg, g.compiler_vroot, source_file, include_dirs,
-			g.use_system_stdint)
+		if header := c_inline_header_text_scoped(include_arg, g.compiler_vroot, source_file,
+			include_dirs, g.use_system_stdint, g.scope_parallel_workers)
 		{
 			header_text := header.text
 			late_source := c_include_is_late_source(include_arg)
@@ -4579,21 +4653,71 @@ fn (mut g FlatGen) collect_preserved_include_metadata_with_state(include_arg str
 }
 
 fn (mut g FlatGen) collect_preserved_header_tree(include_arg string, source_file string, include_dirs []string) bool {
+	probe_scope := cgen_worker_scope_begin(g.scope_parallel_workers)
+	mut preserved_path := ''
 	for path in c_include_file_paths(include_arg, g.compiler_vroot, source_file, include_dirs) {
 		mut tree_size := CHeaderTreeSize{}
 		if os.is_file(path)
 			&& c_header_tree_exceeds_inline_limit(path, g.compiler_vroot, include_dirs, mut tree_size) {
-			// Some system APIs are declared through macros that the lightweight header
-			// declaration scanner cannot expand (for example OpenSSL's X509_free).
-			// Record the known declarations only when the header will be preserved.
-			g.collect_preserved_c_fns(c_preserved_system_include_declared_fns(include_arg))
-			g.collect_preserved_c_structs(c_preserved_system_include_struct_names(include_arg))
-			g.collect_preserved_c_typedef_names(c_preserved_system_include_typedef_names(include_arg))
-			g.collect_preserved_header_file(path, include_dirs)
-			return true
+			preserved_path = path
+			break
 		}
 	}
-	return false
+	cgen_worker_scope_leave(probe_scope)
+	if preserved_path.len == 0 {
+		cgen_worker_scope_free(probe_scope)
+		return false
+	}
+	owned_path := if probe_scope == unsafe { nil } {
+		preserved_path
+	} else {
+		preserved_path.clone()
+	}
+	cgen_worker_scope_free(probe_scope)
+	// Some system APIs are declared through macros that the lightweight header
+	// declaration scanner cannot expand (for example OpenSSL's X509_free).
+	// Record the known declarations only when the header will be preserved.
+	g.collect_preserved_c_fns(c_preserved_system_include_declared_fns(include_arg))
+	g.collect_preserved_c_structs(c_preserved_system_include_struct_names(include_arg))
+	g.collect_preserved_c_typedef_names(c_preserved_system_include_typedef_names(include_arg))
+	g.collect_preserved_header_tree_file(owned_path, include_dirs)
+	return true
+}
+
+fn (mut g FlatGen) collect_preserved_header_tree_file(path string, include_dirs []string) {
+	scope := cgen_worker_scope_begin(g.scope_parallel_workers)
+	if scope == unsafe { nil } {
+		g.collect_preserved_header_file(path, include_dirs)
+		return
+	}
+	// Header macro-state snapshots can dwarf the declarations that C generation
+	// needs afterward. Keep a complete tree walk in a disposable arena, then copy
+	// only its compact declaration/name sets back to the parent arena.
+	g.inlined_c_structs = clone_cgen_string_bool_lookup(g.inlined_c_structs)
+	g.inlined_c_typedef_names = clone_cgen_string_bool_lookup(g.inlined_c_typedef_names)
+	g.inlined_c_fns = clone_cgen_string_bool_lookup(g.inlined_c_fns)
+	g.inlined_c_declared_fns = clone_cgen_string_bool_lookup(g.inlined_c_declared_fns)
+	g.inlined_c_active_macros = clone_cgen_string_bool_lookup(g.inlined_c_active_macros)
+	g.possibly_active_c_macros = clone_cgen_string_bool_lookup(g.possibly_active_c_macros)
+	g.inlined_c_static_fns = clone_cgen_string_bool_lookup(g.inlined_c_static_fns)
+	g.preserved_header_files_seen = clone_cgen_string_bool_lookup(g.preserved_header_files_seen)
+	g.preserved_macro_files_seen = clone_cgen_string_bool_lookup(g.preserved_macro_files_seen)
+	g.preserved_header_scan_results = map[string]CHeaderMacroState{}
+	g.preserved_header_scans_active = map[string]bool{}
+	g.collect_preserved_header_file(path, include_dirs)
+	cgen_worker_scope_leave(scope)
+	g.inlined_c_structs = clone_cgen_string_bool_lookup(g.inlined_c_structs)
+	g.inlined_c_typedef_names = clone_cgen_string_bool_lookup(g.inlined_c_typedef_names)
+	g.inlined_c_fns = clone_cgen_string_bool_lookup(g.inlined_c_fns)
+	g.inlined_c_declared_fns = clone_cgen_string_bool_lookup(g.inlined_c_declared_fns)
+	g.inlined_c_active_macros = clone_cgen_string_bool_lookup(g.inlined_c_active_macros)
+	g.possibly_active_c_macros = clone_cgen_string_bool_lookup(g.possibly_active_c_macros)
+	g.inlined_c_static_fns = clone_cgen_string_bool_lookup(g.inlined_c_static_fns)
+	g.preserved_header_files_seen = clone_cgen_string_bool_lookup(g.preserved_header_files_seen)
+	g.preserved_macro_files_seen = clone_cgen_string_bool_lookup(g.preserved_macro_files_seen)
+	g.preserved_header_scan_results = map[string]CHeaderMacroState{}
+	g.preserved_header_scans_active = map[string]bool{}
+	cgen_worker_scope_free(scope)
 }
 
 fn c_header_tree_exceeds_inline_limit(path string, vroot string, include_dirs []string, mut tree_size CHeaderTreeSize) bool {
@@ -4657,14 +4781,16 @@ fn (mut g FlatGen) collect_preserved_header_file_with_state_and_scope(path strin
 	}
 	strict_iso_mode := c_effective_strict_iso_mode(g.c_flags, g.c99_mode)
 	mut include_results := map[string]CHeaderIncludeResult{}
-	mut final_scan := CHeaderActiveScan{}
-	mut stable := false
 	// Resolve one include at a time, from left to right. Restarting the scan after
 	// each child applies its resulting macro state before any later include is
-	// visited, so metadata is never collected under a transient parent state.
+	// visited, so metadata is never collected under a transient parent state. Each
+	// restart uses a disposable arena: large third-party header trees otherwise
+	// retain every superseded scan until the whole C generation stage finishes.
 	for _ in 0 .. c_join_continued_lines(text).len + 2 {
+		scan_scope := cgen_worker_scope_begin(g.scope_parallel_workers)
 		scan := c_header_definitely_active_scan_with_include_results(text, state, strict_iso_mode,
 			g.target, include_results)
+		cgen_worker_scope_leave(scan_scope)
 		mut unresolved_include := -1
 		for i, include_key in scan.include_keys {
 			include_state_signature := c_header_macro_state_signature(scan.include_states[i])
@@ -4674,16 +4800,22 @@ fn (mut g FlatGen) collect_preserved_header_file_with_state_and_scope(path strin
 				break
 			}
 		}
-		final_scan = scan
 		if unresolved_include < 0 {
-			stable = true
-			break
+			result := g.finish_preserved_header_scan(scan, visit_key, collect_declarations)
+			cgen_worker_scope_free(scan_scope)
+			return result
 		}
-		include_state := scan.include_states[unresolved_include]
-		include_key := scan.include_keys[unresolved_include]
+		mut include_state := scan.include_states[unresolved_include]
+		mut include_key := scan.include_keys[unresolved_include]
 		include_is_definitely_active := scan.include_definitely_active[unresolved_include]
-		include_arg := c_include_arg(scan.include_args[unresolved_include], g.compiler_vroot,
-			real_path)
+		mut raw_include_arg := scan.include_args[unresolved_include]
+		if scan_scope != unsafe { nil } {
+			include_state = c_header_macro_state_clone(include_state)
+			include_key = include_key.clone()
+			raw_include_arg = raw_include_arg.clone()
+		}
+		cgen_worker_scope_free(scan_scope)
+		include_arg := c_include_arg(raw_include_arg, g.compiler_vroot, real_path)
 		mut found := false
 		mut result_state := CHeaderMacroState{}
 		for nested_path in c_include_file_paths(include_arg, g.compiler_vroot, real_path,
@@ -4713,11 +4845,17 @@ fn (mut g FlatGen) collect_preserved_header_file_with_state_and_scope(path strin
 			output_state:    result_state
 		}
 	}
-	if !stable {
-		// A pathological include cycle should never let uncertain metadata suppress a
-		// generated prototype. Fall back to the conservative, pre-propagation scan.
-		final_scan = c_header_definitely_active_scan(text, state, strict_iso_mode, g.target)
-	}
+	// A pathological include cycle should never let uncertain metadata suppress a
+	// generated prototype. Fall back to the conservative, pre-propagation scan.
+	fallback_scope := cgen_worker_scope_begin(g.scope_parallel_workers)
+	fallback_scan := c_header_definitely_active_scan(text, state, strict_iso_mode, g.target)
+	cgen_worker_scope_leave(fallback_scope)
+	result := g.finish_preserved_header_scan(fallback_scan, visit_key, collect_declarations)
+	cgen_worker_scope_free(fallback_scope)
+	return result
+}
+
+fn (mut g FlatGen) finish_preserved_header_scan(final_scan CHeaderActiveScan, visit_key string, collect_declarations bool) CHeaderMacroState {
 	if collect_declarations {
 		g.collect_inlined_c_structs(final_scan.text)
 		g.collect_inlined_c_fns(final_scan.text)
@@ -5123,6 +5261,24 @@ fn c_inline_header_text(include_arg string, vroot string, source_file string, in
 		unsafe { output.free() }
 	}
 	return none
+}
+
+fn c_inline_header_text_scoped(include_arg string, vroot string, source_file string, include_dirs []string, translation_unit_uses_inttypes bool, enabled bool) ?CInlineHeader {
+	scope := cgen_worker_scope_begin(enabled)
+	if scope == unsafe { nil } {
+		return c_inline_header_text(include_arg, vroot, source_file, include_dirs,
+			translation_unit_uses_inttypes)
+	}
+	header := c_inline_header_text(include_arg, vroot, source_file, include_dirs,
+		translation_unit_uses_inttypes) or {
+		cgen_worker_scope_leave(scope)
+		cgen_worker_scope_free(scope)
+		return none
+	}
+	cgen_worker_scope_leave(scope)
+	owned_header := clone_c_inline_header(header)
+	cgen_worker_scope_free(scope)
+	return owned_header
 }
 
 fn c_inline_header_file(path string, vroot string, include_dirs []string, conditional bool, use_system_stdint bool, mut seen map[string]bool, mut inlining map[string]bool, mut output strings.Builder) ?CInlineHeader {

--- a/vlib/v3/tests/driver_cli_test.v
+++ b/vlib/v3/tests/driver_cli_test.v
@@ -1755,7 +1755,7 @@ fn test_driver_rejects_invalid_cli_and_parses_vmod_subdirs() {
 	help := cmdexec.run(v3_bin, ['--help'])
 	assert help.exit_code == 0
 	assert help.output.contains('-cc <compiler>')
-	assert help.output.contains('-no-memory-limit             disable the 4 GiB memory safety limit')
+	assert help.output.contains('-no-memory-limit             disable the 10 GiB memory safety limit')
 	c_output := os.join_path(root, 'hello.c')
 	c_compile := cmdexec.run(v3_bin, ['-no-memory-limit', '-o', c_output, source])
 	assert c_compile.exit_code == 0, c_compile.output


### PR DESCRIPTION
## Summary

- release temporary C-header scans and directive buffers before C generation completes
- avoid duplicated parallel checker and C-generator worker state for very large user ASTs
- raise the V3 compiler memory safety limit from 4 GiB to 10 GiB and update its help, docs, and tests

## Memory result

For `/tmp/main-gui.v` with the custom `guard_ui` module from Gako91/vguard:

- reported 4 GiB guard failure: 4129 MiB RSS
- measured before this change with the guard disabled: about 5.45 GiB peak RSS
- measured after this change on a clean exact reproduction: 3,176,529,920 bytes, or 3029.38 MiB / 2.958 GiB peak RSS

The final generated C output is byte-for-byte identical to the pre-final known-good output.

## Test plan

- `./vnew -silent vlib/v3/bench/bench_test.v`
- `./vnew -silent test vlib/v3/gen/c/source_directive_test.v`
- `./vnew -silent test vlib/v3/gen/c/parallel_worker_test.v`
- `./vnew -silent test -run-only test_driver_rejects_invalid_cli_and_parses_vmod_subdirs vlib/v3/tests/driver_cli_test.v`
- `./vnew -silent test vlib/v3/types/checker_parallel_test.v`
- `./vnew -silent vlib/v/compiler_errors_test.v`
- `./vnew -silent vlib/v/gen/c/coutput_test.v`
- `./vnew check-md vlib/v3/README.md`
- exact `main-gui.v` reproduction completed under the default guard at 2.958 GiB

A broader `./vnew -silent test vlib/v/` run was stopped after unrelated existing runtime failures in keep-args-alive, alias/generic-reference, array-map-reference, and sorting-reference tests; all targeted suites above passed.