### PR TITLE
v3: use target width for pointer map callbacks

### DIFF
--- a/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
@@ -2381,6 +2381,7 @@ fn (g &FlatGen) new_parallel_worker_config(worker_id int, result_only bool) &Fla
 		compiler_vexe:                  g.compiler_vexe
 		compiler_vexe_env_setup:        g.compiler_vexe_env_setup
 		ccompiler:                      g.ccompiler
+		target:                         g.target
 		suppress_main:                  g.suppress_main
 		cur_param_names:                if result_only {
 			g.cur_param_names

--- a/vlib/v3/gen/c/map_test.v
+++ b/vlib/v3/gen/c/map_test.v
@@ -1,0 +1,17 @@
+module c
+
+import v3.types
+
+fn test_map_integer_callback_size_suffix_uses_target_pointer_width() {
+	for key_type in [types.Type(types.voidptr_), types.Type(types.isize_), types.Type(types.usize_)] {
+		assert map_integer_callback_size_suffix(key_type, 'void*', 32) == '4'
+		assert map_integer_callback_size_suffix(key_type, 'void*', 64) == '8'
+	}
+}
+
+fn test_map_integer_callback_size_suffix_uses_scalar_width() {
+	assert map_integer_callback_size_suffix(types.Type(types.u8_), 'u8', 64) == '1'
+	assert map_integer_callback_size_suffix(types.Type(types.u16_), 'u16', 64) == '2'
+	assert map_integer_callback_size_suffix(types.Type(types.u32_), 'u32', 64) == '4'
+	assert map_integer_callback_size_suffix(types.Type(types.u64_), 'u64', 32) == '8'
+}

--- a/vlib/v3/gen/c/parallel_worker_test.v
+++ b/vlib/v3/gen/c/parallel_worker_test.v
@@ -1,6 +1,7 @@
 module c
 
 import v3.flat
+import v3.pref
 import v3.types
 
 fn parallel_worker_test_gen(scoped bool) (&FlatGen, &types.TypeChecker) {
@@ -59,6 +60,13 @@ fn test_parallel_worker_preserves_test_assertion_stats_mode() {
 	g.show_test_stats = true
 	w := g.new_parallel_worker(1)
 	assert w.show_test_stats
+}
+
+fn test_parallel_worker_preserves_target() {
+	mut g, _ := parallel_worker_test_gen(true)
+	g.target = pref.target_from('linux', 'x86') or { panic(err) }
+	w := g.new_parallel_worker(1)
+	assert w.target == g.target
 }
 
 fn test_windows_filelock_method_preseeds_parallel_compat_helpers() {

--- a/vlib/v3/gen/c/struct.v
+++ b/vlib/v3/gen/c/struct.v
@@ -4798,17 +4798,25 @@ fn (g &FlatGen) map_callback_names(key_type types.Type) (string, string, string,
 	} else {
 		g.tc.c_type(key_type)
 	}
-	mut size_suffix := '4'
-	if c_key in ['u8', 'i8', 'bool', 'char'] {
-		size_suffix = '1'
-	} else if c_key in ['u16', 'i16'] {
-		size_suffix = '2'
-	} else if c_key in ['i64', 'u64', 'isize', 'usize', 'f64', 'double', 'voidptr']
-		|| c_key.starts_with('arc__Arc_') {
-		size_suffix = '8'
-	}
+	size_suffix := map_integer_callback_size_suffix(clean_key, c_key, g.target.pointer_bits)
 
 	return 'map_hash_int_${size_suffix}', 'map_eq_int_${size_suffix}', 'map_clone_int_${size_suffix}', 'map_free_nop'
+}
+
+fn map_integer_callback_size_suffix(key_type types.Type, c_key string, pointer_bits int) string {
+	if c_key in ['u8', 'i8', 'bool', 'char'] {
+		return '1'
+	}
+	if c_key in ['u16', 'i16'] {
+		return '2'
+	}
+	if key_type is types.Pointer || key_type is types.ISize || key_type is types.USize {
+		return if pointer_bits == 32 { '4' } else { '8' }
+	}
+	if c_key in ['i64', 'u64', 'f64', 'double'] || c_key.starts_with('arc__Arc_') {
+		return '8'
+	}
+	return '4'
 }
 
 fn (mut g FlatGen) precompute_fixed_array_map_key_types() {


### PR DESCRIPTION
## Summary

- select V3 map hash/equality/clone callbacks for pointer-sized keys from the target pointer width
- propagate the target into parallel C generator workers
- cover pointer-sized callback selection on 32-bit and 64-bit targets

This fixes the s390x V3 failure in `vlib/builtin/map_test.v:test_voidptr_keys`, where a 64-bit `voidptr` key incorrectly used 4-byte callbacks.

## Tests

- `./vnew -silent test vlib/v3/gen/c/map_test.v vlib/v3/gen/c/parallel_worker_test.v`
- `./vnew -silent test vlib/v3/gen/c/`
- built standalone V3 and ran `vlib/builtin/map_test.v`
- generated x86 and s390x C and verified all `voidptr` map callbacks use the target width