### PR TITLE
v3: fix remaining architecture and FastC CI regressions

### DIFF
--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -6889,10 +6889,11 @@ fn compile_v3_fastc_source(source string, bin_file string, prefs &pref.Preferenc
 	source_file := os.join_path_single(build_dir, 'src.c')
 	staged_binary := os.join_path_single(build_dir, 'out')
 	os.write_file(source_file, source) or { return V3FastCCompileResult{} }
-	tcc_lib_dir := os.join_path_single(tcc_dir, 'lib')
+	tcc_resources := v3_tcc_resource_flags(prefs.vroot)
 	mut cc_args := environment_c_flags.clone()
-	cc_args << ['-std=gnu11', '-I${os.join_path_single(tcc_lib_dir, 'include')}', '-L${tcc_lib_dir}',
-		'-w']
+	cc_args << ['-std=gnu11', tcc_resources.base_arg, tcc_resources.include_arg, tcc_resources.library_arg]
+	cc_args << v3_tcc_host_system_flags(prefs.normalized_target_os())
+	cc_args << '-w'
 	if v3_tcc_backtrace_enabled(prefs.normalized_target_os(), prefs.normalized_target_arch(), false) {
 		cc_args << '-bt25'
 	}

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -15605,7 +15605,7 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 				g.expected_enum = old_selector_enum
 			}
 			if base.kind == .ident && base.value == 'C' {
-				g.write(c_winapi_wide_export_name(node.value))
+				g.write(c_winapi_wide_export_name(g.c_namespace_global_c_name(node.value)))
 			} else if enum_selector_qbase.len > 0 {
 				ekey := '${enum_selector_qbase}.${node.value}'
 				if expr := g.enum_value_expr_for_key(ekey) {
@@ -21229,6 +21229,17 @@ fn (g &FlatGen) global_c_name(name string) string {
 		return g.cname(name[2..])
 	}
 	return g.cname(name)
+}
+
+fn (g &FlatGen) c_namespace_global_c_name(raw_name string) string {
+	if module_name := g.global_modules[raw_name] {
+		qualified := qualify_name_in_module(module_name, raw_name)
+		if qualified in g.global_types
+			&& ('C.${raw_name}' in g.global_types || 'C.${raw_name}' in g.tc.c_globals) {
+			return g.global_c_name(qualified)
+		}
+	}
+	return raw_name
 }
 
 fn (mut g FlatGen) fn_capture_shared_global_c_type(name string) ?string {

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -3143,6 +3143,9 @@ fn (mut g FlatGen) gen_method_value_closure(selector_id flat.NodeId, base_id fla
 	} else if clean is types.String || clean is types.Primitive || clean is types.Char
 		|| clean is types.Rune {
 		receiver_name = clean.name()
+		if alias_method := g.find_alias_method(receiver_name, method) {
+			receiver_name = alias_method.all_before_last('.')
+		}
 	} else {
 		alias_method := g.find_alias_method(clean.name(), method) or { return false }
 		receiver_name = alias_method.all_before_last('.')
@@ -3642,7 +3645,11 @@ fn (mut g FlatGen) ensure_fn_value_spawn_wrapper(fn_ct string, args []SpawnPacke
 	}
 	suffix = suffix.replace('*', 'ptr').replace(' ', '_')
 	struct_name := g.cname('fn_value_thread_args_${suffix}')
-	wrapper_name := g.cname('fn_value_args_thread_wrapper_${suffix}')
+	wrapper_name := g.cname('fn_value_args_thread_wrapper_${suffix}${if destroys_fn {
+		'_destroy'
+	} else {
+		''
+	}}')
 	key := 'fnvalue|${fn_ct}|${ret_ct}|${signature}|captures:${capture_signature}|destroy:${destroys_fn}'
 	if name := g.spawn_wrapper_names[key] {
 		return name, struct_name

--- a/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
@@ -2381,6 +2381,7 @@ fn (g &FlatGen) new_parallel_worker_config(worker_id int, result_only bool) &Fla
 		compiler_vexe:                  g.compiler_vexe
 		compiler_vexe_env_setup:        g.compiler_vexe_env_setup
 		ccompiler:                      g.ccompiler
+		target:                         g.target
 		suppress_main:                  g.suppress_main
 		cur_param_names:                if result_only {
 			g.cur_param_names

--- a/vlib/v3/gen/c/map_test.v
+++ b/vlib/v3/gen/c/map_test.v
@@ -1,0 +1,17 @@
+module c
+
+import v3.types
+
+fn test_map_integer_callback_size_suffix_uses_target_pointer_width() {
+	for key_type in [types.Type(types.voidptr_), types.Type(types.isize_), types.Type(types.usize_)] {
+		assert map_integer_callback_size_suffix(key_type, 'void*', 32) == '4'
+		assert map_integer_callback_size_suffix(key_type, 'void*', 64) == '8'
+	}
+}
+
+fn test_map_integer_callback_size_suffix_uses_scalar_width() {
+	assert map_integer_callback_size_suffix(types.Type(types.u8_), 'u8', 64) == '1'
+	assert map_integer_callback_size_suffix(types.Type(types.u16_), 'u16', 64) == '2'
+	assert map_integer_callback_size_suffix(types.Type(types.u32_), 'u32', 64) == '4'
+	assert map_integer_callback_size_suffix(types.Type(types.u64_), 'u64', 32) == '8'
+}

--- a/vlib/v3/gen/c/parallel_worker_test.v
+++ b/vlib/v3/gen/c/parallel_worker_test.v
@@ -1,6 +1,7 @@
 module c
 
 import v3.flat
+import v3.pref
 import v3.types
 
 fn parallel_worker_test_gen(scoped bool) (&FlatGen, &types.TypeChecker) {
@@ -59,6 +60,13 @@ fn test_parallel_worker_preserves_test_assertion_stats_mode() {
 	g.show_test_stats = true
 	w := g.new_parallel_worker(1)
 	assert w.show_test_stats
+}
+
+fn test_parallel_worker_preserves_target() {
+	mut g, _ := parallel_worker_test_gen(true)
+	g.target = pref.target_from('linux', 'x86') or { panic(err) }
+	w := g.new_parallel_worker(1)
+	assert w.target == g.target
 }
 
 fn test_windows_filelock_method_preseeds_parallel_compat_helpers() {

--- a/vlib/v3/gen/c/struct.v
+++ b/vlib/v3/gen/c/struct.v
@@ -4798,17 +4798,25 @@ fn (g &FlatGen) map_callback_names(key_type types.Type) (string, string, string,
 	} else {
 		g.tc.c_type(key_type)
 	}
-	mut size_suffix := '4'
-	if c_key in ['u8', 'i8', 'bool', 'char'] {
-		size_suffix = '1'
-	} else if c_key in ['u16', 'i16'] {
-		size_suffix = '2'
-	} else if c_key in ['i64', 'u64', 'isize', 'usize', 'f64', 'double', 'voidptr']
-		|| c_key.starts_with('arc__Arc_') {
-		size_suffix = '8'
-	}
+	size_suffix := map_integer_callback_size_suffix(clean_key, c_key, g.target.pointer_bits)
 
 	return 'map_hash_int_${size_suffix}', 'map_eq_int_${size_suffix}', 'map_clone_int_${size_suffix}', 'map_free_nop'
+}
+
+fn map_integer_callback_size_suffix(key_type types.Type, c_key string, pointer_bits int) string {
+	if c_key in ['u8', 'i8', 'bool', 'char'] {
+		return '1'
+	}
+	if c_key in ['u16', 'i16'] {
+		return '2'
+	}
+	if key_type is types.Pointer || key_type is types.ISize || key_type is types.USize {
+		return if pointer_bits == 32 { '4' } else { '8' }
+	}
+	if c_key in ['i64', 'u64', 'f64', 'double'] || c_key.starts_with('arc__Arc_') {
+		return '8'
+	}
+	return '4'
 }
 
 fn (mut g FlatGen) precompute_fixed_array_map_key_types() {

--- a/vlib/v3/tests/fastc_backend_test.v
+++ b/vlib/v3/tests/fastc_backend_test.v
@@ -144,10 +144,13 @@ fn main() {
 	assert !stdout_source.contains('=== v3 benchmark ===')
 	assert !stdout_source.contains('fastc parse+gen')
 	tcc_dir := os.join_path(os.dir(fastc_backend_vlib_dir), 'thirdparty', 'tcc')
+	tcc_lib_dir := os.join_path_single(tcc_dir, 'lib')
+	tcc_nested_dir := os.join_path_single(tcc_lib_dir, 'tcc')
+	tcc_install_dir := if os.is_dir(tcc_nested_dir) { tcc_nested_dir } else { tcc_lib_dir }
 	stdout_binary := os.join_path(root, 'stdout')
 	stdout_compile := cmdexec.run(os.join_path(tcc_dir, 'tcc.exe'), ['-std=gnu11',
-		'-I${os.join_path(tcc_dir, 'lib', 'include')}', '-L${os.join_path(tcc_dir, 'lib')}', '-w',
-		'-o', stdout_binary, stdout_c, '-lm'])
+		'-B${tcc_install_dir}', '-I${os.join_path_single(tcc_install_dir, 'include')}',
+		'-L${tcc_install_dir}', '-w', '-o', stdout_binary, stdout_c, '-lm'])
 	assert stdout_compile.exit_code == 0, stdout_compile.output
 
 	cross_stdout_c := os.join_path(root, 'cross_stdout.c')

--- a/vlib/v3/transform/comptime.v
+++ b/vlib/v3/transform/comptime.v
@@ -8,6 +8,7 @@ import v3.types
 
 const comptime_unsupported_late_generic_call = '__v3_comptime_unsupported_late_generic_call'
 const comptime_method_selector_marker = '__v3_comptime_method_selector'
+const comptime_method_selector_fn_type_prefix = '__v3_comptime_method_selector_fn_type:'
 
 // vmod_root supports vmod root handling for Transformer.
 fn (t &Transformer) vmod_root() string {
@@ -1321,7 +1322,14 @@ fn (mut t Transformer) clone_method_subst_scoped(id flat.NodeId, var_name string
 				inner_vars)
 		}
 	}
-	return t.clone_method_subst_children(node, var_name, method, inner_vars)
+	clone := t.clone_method_subst_children(node, var_name, method, inner_vars)
+	if node.kind == .ident {
+		semantic_type := t.node_type(id)
+		if semantic_type.len > 0 && semantic_type != 'unknown' {
+			t.set_node_typ(int(clone), semantic_type)
+		}
+	}
+	return clone
 }
 
 fn (t &Transformer) method_if_condition_value(id flat.NodeId, var_name string, method MethodMeta) ?bool {
@@ -1412,13 +1420,15 @@ fn (mut t Transformer) make_param_array_literal(params []ParamMeta, module_name 
 fn (mut t Transformer) make_comptime_method_selector(receiver flat.NodeId, method MethodMeta) flat.NodeId {
 	start := t.a.children.len
 	t.a.children << receiver
+	fn_type := fn_literal_value_type_text_from_text(method.params.map(it.typ), method.return_type)
 	return t.a.add_node(flat.Node{
 		kind:           .selector
 		children_start: start
 		children_count: 1
 		value:          method.name
 		typ:            method.return_type
-		payload:        flat.node_payload([comptime_method_selector_marker])
+		payload:        flat.node_payload([comptime_method_selector_marker,
+			comptime_method_selector_fn_type_prefix + fn_type])
 	})
 }
 
@@ -1477,9 +1487,13 @@ fn (mut t Transformer) clone_method_subst_children_with_value(node flat.Node, va
 	child_inner_vars := comptime_nested_loop_vars(node, var_name, inner_vars)
 	mut children := []flat.NodeId{cap: int(node.children_count)}
 	for i in 0 .. node.children_count {
-		if child := t.clone_method_subst_scoped(t.a.child(&node, i), var_name, method,
-			child_inner_vars)
-		{
+		child_id := t.a.child(&node, i)
+		child_node := t.a.node(child_id)
+		if node.kind in [.fn_literal, .lambda_expr] && child_node.kind == .ident
+			&& child_node.value == var_name {
+			continue
+		}
+		if child := t.clone_method_subst_scoped(child_id, var_name, method, child_inner_vars) {
 			children << child
 		}
 	}

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -854,9 +854,22 @@ fn (mut t Transformer) normalize_generic_call_expr(id flat.NodeId, node flat.Nod
 		children_start: start
 		children_count: flat.child_count(children.len)
 		pos:            node.pos
-		value:          type_arg
+		value:          if t.generic_call_base_is_fn_value(base_id, base) { '' } else { type_arg }
 		typ:            node.typ
 	})
+}
+
+fn (t &Transformer) generic_call_base_is_fn_value(base_id flat.NodeId, base flat.Node) bool {
+	if base.kind != .ident || t.is_known_fn_name(base.value) || t.is_known_type_name(base.value) {
+		return false
+	}
+	for candidate in [t.raw_var_type(base.value), t.var_type(base.value), base.typ,
+		t.node_type(base_id)] {
+		if t.is_fn_pointer_type_name(candidate) {
+			return true
+		}
+	}
+	return false
 }
 
 // generic_call_type_arg_name supports generic call type arg name handling for Transformer.
@@ -1045,8 +1058,10 @@ fn (mut t Transformer) transform_call_args(id flat.NodeId, node flat.Node) flat.
 	}
 	mut params := t.call_param_types_for_node(call_name, node)
 	mut param_type_names := t.call_param_type_names(params)
+	mut is_generic_variadic := false
 	if concrete_params := t.concrete_generic_call_param_types(id, node) {
 		params = concrete_params.clone()
+		is_generic_variadic = t.concrete_generic_call_is_variadic(id, node)
 		if concrete_names := t.concrete_generic_call_param_type_names(id, node) {
 			param_type_names = concrete_names.clone()
 		} else {
@@ -1061,7 +1076,7 @@ fn (mut t Transformer) transform_call_args(id flat.NodeId, node flat.Node) flat.
 		&& t.call_arg_is_spread(t.a.child(&node, variadic_arg_pos))
 	is_c_variadic := t.tc.c_variadic_fns[call_name]
 	is_variadic := !is_c_variadic && (t.call_is_variadic(call_name)
-		|| (params.len > 0 && params[params.len - 1] is types.Array
+		|| is_generic_variadic || (params.len > 0 && params[params.len - 1] is types.Array
 		&& (explicit_args > expected_explicit || has_spread_at_variadic_slot)))
 	variadic_idx := if is_variadic && params.len > 0 && params[params.len - 1] is types.Array {
 		params.len - 1
@@ -1073,11 +1088,12 @@ fn (mut t Transformer) transform_call_args(id flat.NodeId, node flat.Node) flat.
 	t.in_call_callee = true
 	callee_id := t.a.children[node.children_start]
 	immediate_bound_method := t.immediate_bound_method_value_allocates_runtime_closure(callee_id)
+	immediate_fresh_closure := immediate_bound_method || t.call_returns_exclusive_closure(callee_id)
 	mut immediate_closure_type := ''
-	if immediate_bound_method {
+	if immediate_fresh_closure {
 		immediate_closure_type = t.fresh_runtime_closure_type(callee_id) or { '' }
 		if immediate_closure_type.len > 0 {
-			// If/match callback branches otherwise retain the bound method's return
+			// If/match callback branches otherwise retain the callee's return
 			// type on their value temporary instead of the callback type.
 			t.set_fresh_runtime_closure_expr_type(callee_id, immediate_closure_type)
 		}
@@ -1096,7 +1112,7 @@ fn (mut t Transformer) transform_call_args(id flat.NodeId, node flat.Node) flat.
 		}
 	}
 	t.in_call_callee = saved_in_call_callee
-	if t.fn_literal_has_runtime_captures(callee_id) || immediate_bound_method {
+	if t.fn_literal_has_runtime_captures(callee_id) || immediate_fresh_closure {
 		closure_type := if immediate_closure_type.len > 0 {
 			immediate_closure_type
 		} else {

--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -4839,6 +4839,30 @@ fn (mut t Transformer) concrete_generic_call_param_type_names(id flat.NodeId, no
 	return t.specialized_generic_call_param_type_texts(decl, args)
 }
 
+fn (mut t Transformer) concrete_generic_call_is_variadic(id flat.NodeId, node flat.Node) bool {
+	if t.skip_generics || node.kind != .call || node.children_count == 0 {
+		return false
+	}
+	decls := t.cached_generic_fn_decls()
+	if decls.len == 0 {
+		return false
+	}
+	decl_key, _ := t.cached_generic_call_specialization(id, node, t.cur_module, decls) or {
+		return false
+	}
+	decl := decls[decl_key] or { return false }
+	mut last_param := ''
+	for i in 0 .. decl.node.children_count {
+		child := t.a.child_node(&decl.node, i)
+		if child.kind == .param {
+			last_param = child.typ
+		} else if t.prefix_param_scan {
+			break
+		}
+	}
+	return generic_param_text_is_variadic(last_param)
+}
+
 fn (mut t Transformer) cached_generic_fn_decls() map[string]GenericFnDecl {
 	if t.skip_generics {
 		if !t.generic_fn_decls_ready {

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -11306,12 +11306,16 @@ fn (t &Transformer) discarded_closure_value_is_exclusive(id flat.NodeId) bool {
 	if t.expr_allocates_fresh_runtime_closure(id) {
 		return true
 	}
+	return t.call_returns_exclusive_closure(id)
+}
+
+fn (t &Transformer) call_returns_exclusive_closure(id flat.NodeId) bool {
 	if int(id) < 0 || int(id) >= t.a.nodes.len {
 		return false
 	}
 	node := t.a.nodes[int(id)]
 	if node.kind in [.paren, .cast_expr] && node.children_count == 1 {
-		return t.discarded_closure_value_is_exclusive(t.a.child(&node, 0))
+		return t.call_returns_exclusive_closure(t.a.child(&node, 0))
 	}
 	if node.kind != .call {
 		return false
@@ -21477,6 +21481,22 @@ fn (t &Transformer) infer_decl_type(node &flat.Node) string {
 	}
 	if t.validating_generic_spec && node.typ.contains('main.') && decl_type_is_usable(node.typ) {
 		return node.typ
+	}
+	if node.children_count == 2 {
+		rhs_id := t.a.child(node, 1)
+		rhs := t.a.node(rhs_id)
+		if rhs.kind == .fn_literal {
+			if fn_type := t.fn_value_type_name(rhs_id) {
+				return fn_type
+			}
+		}
+		if rhs.kind == .selector && comptime_method_selector_marker in rhs.generic_params() {
+			for param in rhs.generic_params() {
+				if param.starts_with(comptime_method_selector_fn_type_prefix) {
+					return param.all_after(comptime_method_selector_fn_type_prefix)
+				}
+			}
+		}
 	}
 	if !isnil(t.tc) && node.children_count > 0 {
 		// Use only the type that the checker recorded for this declaration. Falling

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -15203,7 +15203,7 @@ fn (mut tc TypeChecker) check_comptime_for_members(_id flat.NodeId, node flat.No
 	tc.check_comptime_reflection_condition_types(body_id, parts[0])
 	if parts[1] == 'methods' {
 		mut invalid_uses := []flat.NodeId{}
-		tc.collect_anon_fn_comptime_method_uses(body_id, parts[0], false, mut invalid_uses)
+		tc.collect_anon_fn_comptime_method_uses(body_id, parts[0], false, false, mut invalid_uses)
 		if invalid_uses.len > 0 {
 			file := tc.a.source_files[node.pos.id] or { &token.File{} }
 			source := tc.source_texts_by_file[file.name] or { '' }
@@ -15595,10 +15595,29 @@ fn (mut tc TypeChecker) check_comptime_attribute_members(id flat.NodeId, var_nam
 	}
 }
 
-fn (tc &TypeChecker) collect_anon_fn_comptime_method_uses(id flat.NodeId, var_name string, inside_anon_fn bool, mut uses []flat.NodeId) {
+fn (tc &TypeChecker) fn_literal_directly_captures_ident(node flat.Node, var_name string) bool {
+	if node.kind !in [.fn_literal, .lambda_expr] {
+		return false
+	}
+	for i in 0 .. node.children_count {
+		child := tc.a.child_node(&node, i)
+		if child.kind == .ident && child.value == var_name {
+			return true
+		}
+	}
+	return false
+}
+
+fn (tc &TypeChecker) collect_anon_fn_comptime_method_uses(id flat.NodeId, var_name string, inside_anon_fn bool, captured bool, mut uses []flat.NodeId) {
 	node := tc.a.node(id)
 	is_inside := inside_anon_fn || node.kind in [.fn_literal, .lambda_expr]
-	if is_inside && node.kind == .selector && node.value == '$' && node.children_count > 1 {
+	inside_capture := if node.kind in [.fn_literal, .lambda_expr] {
+		tc.fn_literal_directly_captures_ident(node, var_name)
+	} else {
+		captured
+	}
+	if is_inside && !inside_capture && node.kind == .selector && node.value == '$'
+		&& node.children_count > 1 {
 		method_var := tc.a.child_node(node, 1)
 		if method_var.kind == .ident && method_var.value == var_name {
 			uses << id
@@ -15606,7 +15625,8 @@ fn (tc &TypeChecker) collect_anon_fn_comptime_method_uses(id flat.NodeId, var_na
 		}
 	}
 	for i in 0 .. node.children_count {
-		tc.collect_anon_fn_comptime_method_uses(tc.a.child(node, i), var_name, is_inside, mut uses)
+		tc.collect_anon_fn_comptime_method_uses(tc.a.child(node, i), var_name, is_inside,
+			inside_capture, mut uses)
 	}
 }
 

--- a/vlib/v3/types/checker_tail.v
+++ b/vlib/v3/types/checker_tail.v
@@ -514,8 +514,8 @@ fn (tc &TypeChecker) assignment_types_compatible(rhs_id flat.NodeId, rhs_type Ty
 }
 
 fn (tc &TypeChecker) fn_storage_voidptr_mismatch(expr_id flat.NodeId, actual Type, expected Type) bool {
-	return is_fn_pointer_type(expected) && fn_param_is_voidptr_type(actual)
-		&& !tc.expr_is_unsafe_nil(expr_id)
+	return is_fn_pointer_type(expected) && fn_param_is_voidptr_type(actual) && tc.unsafe_depth == 0
+		&& !tc.current_fn_declared_unsafe() && !tc.expr_is_unsafe_nil(expr_id)
 }
 
 fn (tc &TypeChecker) direct_sum_assignment_variant_matches(actual Type, expected SumType) bool {

--- a/vlib/v3/types/checker_tail_stmt.v
+++ b/vlib/v3/types/checker_tail_stmt.v
@@ -16398,6 +16398,12 @@ fn (tc &TypeChecker) c_type_uncached(t Type) string {
 		}
 		if t.name.starts_with('C.') {
 			raw := t.name[2..]
+			if raw.starts_with('builtin__closure__') {
+				closure_name := 'closure.${raw['builtin__closure__'.len..]}'
+				if closure_name in tc.structs {
+					return tc.c_struct_type_name(closure_name)
+				}
+			}
 			// A struct declared `@[typedef] struct C.foo {}` is referenced by its
 			// typedef name (`foo`), never as `struct foo` — the C header (and v3's own
 			// emitted `typedef struct {...} foo;`) has no matching `struct foo` tag, so


### PR DESCRIPTION
Fixes the remaining completed/reproduced V3 failures on current master as one CI repair batch.

This batch:
- uses target pointer width for map pointer hash/equality callbacks, including parallel C-gen workers
- preserves compile-time method closures and function-valued generic calls through transform
- restores generic variadic packing and specialized closure return types
- fixes alias method closures, unsafe function storage, and spawn-wrapper deduplication
- resolves legacy closure-runtime C names and matching V globals
- reclaims exclusive closures invoked directly as call targets
- gives FastC the bundled TinyCC resource root on Linux

Validation:
- all 9 affected strict V3 architecture test files pass with a standalone V3 compiler
- `./vnew -silent vlib/v3/gen/c/map_test.v`
- `./vnew -silent vlib/v3/gen/c/parallel_worker_test.v`
- `./vnew -silent vlib/v3/tests/fastc_backend_test.v`
- `./vnew -silent vlib/v3/driver/c_compiler_flags_test.v`
- `./vnew -silent test vlib/v3/transform/`
- `./vnew -silent test vlib/v3/types/`
- `./vnew -silent test vlib/v3/gen/c/`
- `./vnew -silent vlib/v/compiler_errors_test.v`