### PR TITLE
v3: use TinyCC resource root for FastC

### DIFF
--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -6889,10 +6889,11 @@ fn compile_v3_fastc_source(source string, bin_file string, prefs &pref.Preferenc
 	source_file := os.join_path_single(build_dir, 'src.c')
 	staged_binary := os.join_path_single(build_dir, 'out')
 	os.write_file(source_file, source) or { return V3FastCCompileResult{} }
-	tcc_lib_dir := os.join_path_single(tcc_dir, 'lib')
+	tcc_resources := v3_tcc_resource_flags(prefs.vroot)
 	mut cc_args := environment_c_flags.clone()
-	cc_args << ['-std=gnu11', '-I${os.join_path_single(tcc_lib_dir, 'include')}', '-L${tcc_lib_dir}',
-		'-w']
+	cc_args << ['-std=gnu11', tcc_resources.base_arg, tcc_resources.include_arg, tcc_resources.library_arg]
+	cc_args << v3_tcc_host_system_flags(prefs.normalized_target_os())
+	cc_args << '-w'
 	if v3_tcc_backtrace_enabled(prefs.normalized_target_os(), prefs.normalized_target_arch(), false) {
 		cc_args << '-bt25'
 	}

--- a/vlib/v3/tests/fastc_backend_test.v
+++ b/vlib/v3/tests/fastc_backend_test.v
@@ -144,10 +144,13 @@ fn main() {
 	assert !stdout_source.contains('=== v3 benchmark ===')
 	assert !stdout_source.contains('fastc parse+gen')
 	tcc_dir := os.join_path(os.dir(fastc_backend_vlib_dir), 'thirdparty', 'tcc')
+	tcc_lib_dir := os.join_path_single(tcc_dir, 'lib')
+	tcc_nested_dir := os.join_path_single(tcc_lib_dir, 'tcc')
+	tcc_install_dir := if os.is_dir(tcc_nested_dir) { tcc_nested_dir } else { tcc_lib_dir }
 	stdout_binary := os.join_path(root, 'stdout')
 	stdout_compile := cmdexec.run(os.join_path(tcc_dir, 'tcc.exe'), ['-std=gnu11',
-		'-I${os.join_path(tcc_dir, 'lib', 'include')}', '-L${os.join_path(tcc_dir, 'lib')}', '-w',
-		'-o', stdout_binary, stdout_c, '-lm'])
+		'-B${tcc_install_dir}', '-I${os.join_path_single(tcc_install_dir, 'include')}',
+		'-L${tcc_install_dir}', '-w', '-o', stdout_binary, stdout_c, '-lm'])
 	assert stdout_compile.exit_code == 0, stdout_compile.output
 
 	cross_stdout_c := os.join_path(root, 'cross_stdout.c')


### PR DESCRIPTION
Fixes the current master V3 CI failure in `fastc_backend_test.v` on Linux.

FastC now resolves the bundled TinyCC install root through the same helper as the normal V3 linker and passes `-B`, `-I`, and `-L` consistently. The generated-C validation in the integration test also handles both supported bundle layouts.

Validation:
- `./vnew -silent vlib/v3/tests/fastc_backend_test.v`
- `./vnew -silent vlib/v3/driver/c_compiler_flags_test.v`
- `./vnew -silent vlib/v/compiler_errors_test.v`