### PR TITLE
v3: fix FastC spawn review edge cases

### DIFF
--- a/vlib/v3/gen/fastc/expr.v
+++ b/vlib/v3/gen/fastc/expr.v
@@ -255,6 +255,27 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 			previous_token_end = g.s.pos
 			continue
 		}
+		if g.selfhost && g.tok == .key_spawn {
+			spawned := g.read_spawn_expression()!
+			spawned_type := g.last_expression_type
+			if result.len > 0 && fastc_needs_space(result.last(), spawned)
+				&& !previous_module_separator {
+				result.write_u8(` `)
+			}
+			result.write_string(spawned)
+			// The eager spawn parser consumes the complete call. Keep it as one
+			// typed atom so enclosing calls, appends, and operators can infer it.
+			expression_tokens << FastcExpressionToken{
+				tok: .name
+				lit: spawned
+				typ: spawned_type
+			}
+			previous_token = .name
+			previous_lit = spawned
+			previous_module_separator = false
+			previous_token_end = g.s.pos
+			continue
+		}
 		if g.selfhost && g.tok == .key_or {
 			or_expression_is_statement := g.expression_tokens_are_statement(expression_tokens)
 			or_return_types := g.multi_return_types_for_expression(expression_tokens)

--- a/vlib/v3/gen/fastc/fastc.v
+++ b/vlib/v3/gen/fastc/fastc.v
@@ -1,8 +1,6 @@
 module fastc
 
-import os
 import strings
-import v3.gen.c.naming
 import v3.pref
 import v3.scanner
 import v3.token

--- a/vlib/v3/gen/fastc/fastc_test.v
+++ b/vlib/v3/gen/fastc/fastc_test.v
@@ -112,7 +112,11 @@ fn test_selfhost_spawn_accepts_explicit_and_omitted_params_structs() {
 
 @[params]
 struct Config {
-	value int
+	value int = default_value()
+}
+
+fn default_value() int {
+	return 1234
 }
 
 fn configured(base int, config Config) int {
@@ -128,7 +132,7 @@ fn main() {
 ',
 		'spawn_params_struct.v', prefs) or { panic(err) }
 	assert c_source.contains('args->result = configured(args->arg0, args->arg1);'), c_source
-	assert c_source.contains('(Config){0}'), c_source
+	assert c_source.contains('__v_fastc_struct_default.value=(default_value());'), c_source
 }
 
 fn test_generate_and_compile_without_flat_ast() {

--- a/vlib/v3/gen/fastc/fastc_test.v
+++ b/vlib/v3/gen/fastc/fastc_test.v
@@ -123,16 +123,31 @@ fn configured(base int, config Config) int {
 	return base + config.value
 }
 
+@[params]
+struct PointerConfig {
+	value int
+}
+
+fn configured_pointer(config &PointerConfig) int {
+	return config.value
+}
+
 fn main() {
 	explicit := spawn configured(1, Config{value: 2})
 	omitted := spawn configured(4)
+	named := spawn configured(5, value: 6)
+	pointer := spawn configured_pointer()
 	println(explicit.wait())
 	println(omitted.wait())
+	println(named.wait())
+	println(pointer.wait())
 }
 ',
 		'spawn_params_struct.v', prefs) or { panic(err) }
 	assert c_source.contains('args->result = configured(args->arg0, args->arg1);'), c_source
 	assert c_source.contains('__v_fastc_struct_default.value=(default_value());'), c_source
+	assert c_source.contains('.value=(__v_fastc_struct_field_0)'), c_source
+	assert c_source.contains('v_fastc_interface_box(&(PointerConfig){0}, sizeof(PointerConfig))'), c_source
 }
 
 fn test_generate_and_compile_without_flat_ast() {

--- a/vlib/v3/gen/fastc/fastc_test.v
+++ b/vlib/v3/gen/fastc/fastc_test.v
@@ -6,6 +6,131 @@ import v3.pref
 import v3.scanner
 import v3.token
 
+fn test_fastc_chunk_bounds_reserve_files_for_later_workers() {
+	sources := [
+		FastcSourceFile{
+			source: 'a'.repeat(90)
+		},
+		FastcSourceFile{
+			source: 'b'.repeat(90)
+		},
+		FastcSourceFile{
+			source: 'c'.repeat(90)
+		},
+		FastcSourceFile{
+			source: 'd'.repeat(300)
+		},
+	]
+	assert fastc_chunk_bounds(sources, 2) == [0, 3, 3, 4]
+}
+
+fn test_selfhost_spawn_nested_wait_statement_and_helper_names() {
+	$if windows {
+		return
+	}
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	foo_start := fastc_spawn_start_name('foo')
+	foo_creator := '${foo_start}_c1'
+	foo_c1_creator := fastc_spawn_start_name('foo_c1')
+	void_waiter := fastc_thread_wait_name(fastc_thread_type_name(''))
+	int_waiter := fastc_thread_wait_name(fastc_thread_type_name('int'))
+	assert foo_creator != foo_c1_creator
+	source := 'module main
+
+fn foo() int {
+	return 1
+}
+
+fn foo_c1() int {
+	return 2
+}
+
+fn ${foo_start}() int {
+	return 0
+}
+
+fn finish() {}
+
+fn main() {
+	first := spawn foo()
+	mut threads := [first]
+	threads << spawn foo_c1()
+	println(threads[0].wait())
+	println(threads[1].wait())
+	println((spawn foo()).wait())
+	done := spawn finish()
+	done.wait()
+}
+'
+	c_source := generate(source, 'selfhost_spawn_regressions.v', prefs) or { panic(err) }
+	assert c_source.contains('args->result = foo();'), c_source
+	assert c_source.contains('args->result = foo_c1();'), c_source
+	assert c_source.contains('${foo_creator}()'), c_source
+	assert c_source.contains('${foo_c1_creator}()'), c_source
+	assert !c_source.contains('spawn foo_c1'), c_source
+	assert c_source.contains('${int_waiter}((${foo_creator}()))'), c_source
+	assert c_source.contains('${void_waiter}(done);'), c_source
+}
+
+fn test_selfhost_spawn_rejects_disabled_callee_before_arguments() {
+	$if windows {
+		return
+	}
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	mut message := ''
+	_ := generate('module main
+
+@[if fastc_missing_define ?]
+fn traced(value int) {}
+
+fn side_effect() int {
+	println(99)
+	return 1
+}
+
+fn main() {
+	t := spawn traced(side_effect())
+	t.wait()
+}
+',
+		'disabled_spawn.v', prefs) or {
+		message = err.msg()
+		''
+	}
+	assert message.contains('spawn of disabled function `traced`'), message
+}
+
+fn test_selfhost_spawn_accepts_explicit_and_omitted_params_structs() {
+	$if windows {
+		return
+	}
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+@[params]
+struct Config {
+	value int
+}
+
+fn configured(base int, config Config) int {
+	return base + config.value
+}
+
+fn main() {
+	explicit := spawn configured(1, Config{value: 2})
+	omitted := spawn configured(4)
+	println(explicit.wait())
+	println(omitted.wait())
+}
+',
+		'spawn_params_struct.v', prefs) or { panic(err) }
+	assert c_source.contains('args->result = configured(args->arg0, args->arg1);'), c_source
+	assert c_source.contains('(Config){0}'), c_source
+}
+
 fn test_generate_and_compile_without_flat_ast() {
 	source := 'module main
 
@@ -752,7 +877,7 @@ pub fn ping() {}
 	}
 	assert resolved_modules == ['main', 'alpha']
 	prefs.building_v = true
-	c_source := generate_source_files(sources, prefs) or { panic(err) }
+	c_source, _ := generate_source_files(sources, prefs) or { panic(err) }
 	assert c_source.contains('\talpha__init();'), c_source
 	assert c_source.contains('\talpha__cleanup();'), c_source
 	assert !c_source.contains('beta__init'), c_source
@@ -1185,7 +1310,7 @@ pub fn make() Settings {
 		'module main\nimport records\nfn main() { value := records.Settings{secret: 1}; println(value.visible) }\n',
 	] {
 		mut message := ''
-		_ := generate_source_files([
+		unused_source, _ := generate_source_files([
 			FastcSourceFile{
 				path:   main_file
 				source: source
@@ -1200,13 +1325,14 @@ pub fn make() Settings {
 			},
 		], prefs) or {
 			message = err.msg()
-			''
+			'', false
 		}
+		_ = unused_source
 		assert message.contains('private field `Settings.secret` from imported module `records`'), message
 	}
 
 	valid_source := 'module main\nimport records\nfn main() { value := records.Settings{visible: 2}; println(value.visible) }\n'
-	c_source := generate_source_files([
+	c_source, _ := generate_source_files([
 		FastcSourceFile{
 			path:   main_file
 			source: valid_source
@@ -1251,7 +1377,7 @@ fn main() {
 }
 '
 	mut message := ''
-	_ := generate_source_files([
+	unused_source, _ := generate_source_files([
 		FastcSourceFile{
 			path:   main_file
 			source: invalid_source
@@ -1264,8 +1390,9 @@ fn main() {
 		},
 	], prefs) or {
 		message = err.msg()
-		''
+		'', false
 	}
+	_ = unused_source
 	assert message.contains('mutation of immutable field `Config.read_only`'), message
 
 	valid_source := 'module main
@@ -1277,7 +1404,7 @@ fn main() {
 	config.writable = 2
 }
 '
-	c_source := generate_source_files([
+	c_source, _ := generate_source_files([
 		FastcSourceFile{
 			path:   main_file
 			source: valid_source
@@ -2610,7 +2737,7 @@ fn main() {
 }
 '
 	mut field_message := ''
-	_ := generate_source_files([
+	unused_source, _ := generate_source_files([
 		FastcSourceFile{
 			path:   'immutable_flag_field.v'
 			source: main_source
@@ -2625,8 +2752,9 @@ fn main() {
 		},
 	], prefs) or {
 		field_message = err.msg()
-		''
+		'', false
 	}
+	_ = unused_source
 	assert field_message.contains('receiver field `Config.permissions` is not `pub mut`'), field_message
 
 	c_source := generate('module main
@@ -4323,7 +4451,7 @@ fn main() {
 	copy_byte(mut file, []u8{}, 0)
 }
 '
-	c_source := generate_source_files([
+	c_source, _ := generate_source_files([
 		FastcSourceFile{
 			path:   'main.v'
 			source: main_source

--- a/vlib/v3/gen/fastc/parallel_nix.c.v
+++ b/vlib/v3/gen/fastc/parallel_nix.c.v
@@ -6,7 +6,8 @@ fn C.sysconf(name int) i64
 
 // fastc_nr_cpus reports the host's online CPU count for parallel generation.
 fn fastc_nr_cpus() int {
-	count := int(C.sysconf(C._SC_NPROCESSORS_ONLN))
+	// sysconf is a libc call; validate its result before using it as a count.
+	count := unsafe { int(C.sysconf(C._SC_NPROCESSORS_ONLN)) }
 	if count < 1 {
 		return 1
 	}

--- a/vlib/v3/gen/fastc/parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/fastc/parallel_notd_v3_no_parallel.v
@@ -41,7 +41,10 @@ fn fastc_chunk_bounds(sources []FastcSourceFile, jobs int) []int {
 	for chunk_idx in 0 .. jobs {
 		mut end := start
 		target := total_size * i64(chunk_idx + 1) / i64(jobs)
-		for end < sources.len && (chunk_idx == jobs - 1 || consumed < target || end == start) {
+		// Leave one file for every later chunk even when a large file keeps the
+		// current chunk below its cumulative size target.
+		last_available := sources.len - (jobs - chunk_idx - 1)
+		for end < last_available && (chunk_idx == jobs - 1 || consumed < target || end == start) {
 			consumed += i64(sources[end].source.len) + 1
 			end++
 		}

--- a/vlib/v3/gen/fastc/render.v
+++ b/vlib/v3/gen/fastc/render.v
@@ -513,6 +513,61 @@ fn (g &Parser) render_enum_print_expression(tokens []FastcExpressionToken) ?Fast
 	}
 }
 
+fn (g &Parser) render_struct_literal_with_defaults(c_type string, layout_type string, explicit_initializers []string, rendered_fields []string, rendered_fields_by_name map[string]string) FastcRenderedExpression {
+	base_type := c_type.trim_right('*')
+	mut assignments := []string{cap: rendered_fields.len}
+	mut initializers := []string{}
+	mut initialized_fields := map[string]bool{}
+	for field in g.struct_field_info[layout_type] {
+		if fastc_fixed_array_element_type(field.typ) == none {
+			continue
+		}
+		if rendered_field := rendered_fields_by_name[field.name] {
+			initializers << rendered_field
+			initialized_fields[rendered_field] = true
+		}
+	}
+	for field in rendered_fields {
+		if field in initialized_fields {
+			continue
+		}
+		assignments << '__v_fastc_struct_default${field};'
+	}
+	initializer := if initializers.len > 0 {
+		'(${base_type}){${initializers.join(',')}}'
+	} else {
+		'(${base_type}){0}'
+	}
+	result := if c_type.ends_with('*') {
+		'(${c_type})v_fastc_interface_box(&__v_fastc_struct_default, sizeof(${base_type}))'
+	} else {
+		'__v_fastc_struct_default'
+	}
+	return FastcRenderedExpression{
+		source: '({ ${explicit_initializers.join(' ')} ${base_type} __v_fastc_struct_default = ${initializer}; ${assignments.join(' ')} ${result}; })'
+		typ:    c_type
+	}
+}
+
+fn (g &Parser) render_empty_struct_initializer(c_type string) string {
+	layout_type := c_type.trim_right('*')
+	mut rendered_fields := []string{}
+	mut rendered_fields_by_name := map[string]string{}
+	for field in g.struct_field_info[layout_type] {
+		if field.default_value == '' {
+			continue
+		}
+		rendered_field := '.${fastc_c_identifier(field.name)}=(${field.default_value})'
+		rendered_fields << rendered_field
+		rendered_fields_by_name[field.name] = rendered_field
+	}
+	if rendered_fields.len == 0 {
+		return '(${c_type}){0}'
+	}
+	return g.render_struct_literal_with_defaults(c_type, layout_type, []string{}, rendered_fields,
+		rendered_fields_by_name).source
+}
+
 fn (g &Parser) render_struct_literal_expression(tokens []FastcExpressionToken) ?FastcRenderedExpression {
 	mut open := -1
 	mut delimiter_depth := 0
@@ -791,39 +846,8 @@ fn (g &Parser) render_struct_literal_expression(tokens []FastcExpressionToken) ?
 		}
 	}
 	if has_applied_defaults {
-		base_type := c_type.trim_right('*')
-		mut assignments := []string{cap: rendered_fields.len}
-		mut initializers := []string{}
-		mut initialized_fields := map[string]bool{}
-		for field in g.struct_field_info[layout_type] {
-			if fastc_fixed_array_element_type(field.typ) == none {
-				continue
-			}
-			if rendered_field := rendered_fields_by_name[field.name] {
-				initializers << rendered_field
-				initialized_fields[rendered_field] = true
-			}
-		}
-		for field in rendered_fields {
-			if field in initialized_fields {
-				continue
-			}
-			assignments << '__v_fastc_struct_default${field};'
-		}
-		initializer := if initializers.len > 0 {
-			'(${base_type}){${initializers.join(',')}}'
-		} else {
-			'(${base_type}){0}'
-		}
-		result := if c_type.ends_with('*') {
-			'(${c_type})v_fastc_interface_box(&__v_fastc_struct_default, sizeof(${base_type}))'
-		} else {
-			'__v_fastc_struct_default'
-		}
-		return FastcRenderedExpression{
-			source: '({ ${explicit_initializers.join(' ')} ${base_type} __v_fastc_struct_default = ${initializer}; ${assignments.join(' ')} ${result}; })'
-			typ:    c_type
-		}
+		return g.render_struct_literal_with_defaults(c_type, layout_type, explicit_initializers,
+			rendered_fields, rendered_fields_by_name)
 	}
 	literal_source := if c_type.ends_with('*') {
 		'(${c_type})v_fastc_interface_box(&(${c_type.trim_right('*')}){${rendered_fields.join(',')}}, sizeof(${c_type.trim_right('*')}))'
@@ -1950,7 +1974,7 @@ fn (g &Parser) render_missing_call_arguments(tokens []FastcExpressionToken) ?Fas
 		rendered_arguments << rendered_argument
 	}
 	for parameter_type in signature.parameter_types[call_args.len..] {
-		rendered_arguments << '(${parameter_type}){0}'
+		rendered_arguments << g.render_empty_struct_initializer(parameter_type)
 	}
 	call_name := if function_key.starts_with('C.') {
 		function_key.all_after_last('.')

--- a/vlib/v3/gen/fastc/render.v
+++ b/vlib/v3/gen/fastc/render.v
@@ -562,10 +562,42 @@ fn (g &Parser) render_empty_struct_initializer(c_type string) string {
 		rendered_fields_by_name[field.name] = rendered_field
 	}
 	if rendered_fields.len == 0 {
+		if c_type.ends_with('*') {
+			return '(${c_type})v_fastc_interface_box(&(${layout_type}){0}, sizeof(${layout_type}))'
+		}
 		return '(${c_type}){0}'
 	}
 	return g.render_struct_literal_with_defaults(c_type, layout_type, []string{}, rendered_fields,
 		rendered_fields_by_name).source
+}
+
+fn (g &Parser) render_named_struct_initializer(c_type string, fields [][]FastcExpressionToken) ?string {
+	mut tokens := [
+		FastcExpressionToken{
+			tok: .name
+			lit: c_type
+			typ: c_type
+		},
+		FastcExpressionToken{
+			tok: .lcbr
+			lit: '{'
+		},
+	]
+	for index, field in fields {
+		if index > 0 {
+			tokens << FastcExpressionToken{
+				tok: .comma
+				lit: ','
+			}
+		}
+		tokens << field
+	}
+	tokens << FastcExpressionToken{
+		tok: .rcbr
+		lit: '}'
+	}
+	rendered := g.render_struct_literal_expression(tokens) or { return none }
+	return rendered.source
 }
 
 fn (g &Parser) render_struct_literal_expression(tokens []FastcExpressionToken) ?FastcRenderedExpression {
@@ -590,7 +622,11 @@ fn (g &Parser) render_struct_literal_expression(tokens []FastcExpressionToken) ?
 	}
 	is_c_struct_literal := open == 3 && tokens[0].tok == .name && tokens[0].lit == 'C'
 		&& tokens[1].tok == .dot && tokens[2].tok == .name
-	mut c_type := g.type_from_expression_tokens(tokens[..open]) or { '' }
+	mut c_type := if open == 1 && tokens[0].typ != '' {
+		tokens[0].typ
+	} else {
+		g.type_from_expression_tokens(tokens[..open]) or { '' }
+	}
 	if c_type == '' && is_c_struct_literal {
 		c_type = if '#Cstruct#${tokens[2].lit}' in g.declared_types {
 			'struct ${tokens[2].lit}'
@@ -1897,7 +1933,7 @@ fn (g &Parser) render_missing_call_arguments(tokens []FastcExpressionToken) ?Fas
 			break
 		}
 	}
-	if named_start >= 0 && named_start < signature.parameter_types.len {
+	if signature.last_parameter_is_params && named_start == signature.parameter_types.len - 1 {
 		mut rendered_arguments := []string{}
 		for argument_index, argument in call_args[..named_start] {
 			expected_type := if argument_index < signature.parameter_types.len {
@@ -1911,15 +1947,9 @@ fn (g &Parser) render_missing_call_arguments(tokens []FastcExpressionToken) ?Fas
 			rendered_arguments << rendered_argument
 		}
 		parameter_type := signature.parameter_types[named_start]
-		mut fields := []string{}
-		for argument in call_args[named_start..] {
-			if argument.len < 3 || argument[0].tok != .name || argument[1].tok != .colon {
-				return none
-			}
-			value := g.render_call_argument_expression(argument[2..], '') or { return none }
-			fields << '.${fastc_c_identifier(argument[0].lit)}=${value}'
-		}
-		rendered_arguments << '(${parameter_type}){${fields.join(',')}}'
+		named_initializer := g.render_named_struct_initializer(parameter_type,
+			call_args[named_start..]) or { return none }
+		rendered_arguments << named_initializer
 		return FastcRenderedExpression{
 			source: '${fastc_c_function_name_for_key(function_key)}(${rendered_arguments.join(',')})'
 			typ:    signature.return_type

--- a/vlib/v3/gen/fastc/spawn.v
+++ b/vlib/v3/gen/fastc/spawn.v
@@ -135,7 +135,7 @@ fn (mut g Parser) read_spawn_expression() !string {
 	g.next()
 	if signature.last_parameter_is_params && arguments.len + 1 == signature.parameter_types.len {
 		parameter_type := signature.parameter_types.last()
-		arguments << '(${parameter_type}){0}'
+		arguments << g.render_empty_struct_initializer(parameter_type)
 	}
 	if arguments.len != signature.parameter_types.len {
 		return g.unsupported('spawn of `${callee}` with ${arguments.len} arguments, expected ${signature.parameter_types.len}')

--- a/vlib/v3/gen/fastc/spawn.v
+++ b/vlib/v3/gen/fastc/spawn.v
@@ -103,9 +103,62 @@ fn (mut g Parser) read_spawn_expression() !string {
 	}
 	g.next()
 	mut arguments := []string{}
+	mut named_params := [][]FastcExpressionToken{}
+	mut named_param_names := map[string]bool{}
 	for g.tok != .rpar {
 		if g.tok == .eof {
 			return g.unsupported('unfinished spawn call')
+		}
+		mut is_named_param := false
+		if signature.last_parameter_is_params && g.tok == .name {
+			mut lookahead := g.s
+			is_named_param = lookahead.scan() == .colon
+		}
+		if is_named_param {
+			parameter_index := signature.parameter_types.len - 1
+			if arguments.len != parameter_index {
+				return g.unsupported('spawn named params fields before all positional arguments')
+			}
+			field_name := g.lit
+			if field_name in named_param_names {
+				return g.unsupported('duplicate spawn params field `${field_name}`')
+			}
+			parameter_type := signature.parameter_types.last()
+			field := g.struct_field_metadata(parameter_type, field_name) or {
+				return g.unsupported('unknown spawn params field `${field_name}`')
+			}
+			if !g.struct_field_is_visible(field) {
+				return g.unsupported('private spawn params field `${field_name}`')
+			}
+			g.next()
+			g.expect(.colon)!
+			if g.tok in [.comma, .rpar] {
+				return g.unsupported('empty spawn params field `${field_name}`')
+			}
+			previous_expected_type := g.expected_expression_type
+			g.expected_expression_type = field.typ
+			_ = g.read_expression([token.Token.comma, token.Token.rpar])!
+			g.expected_expression_type = previous_expected_type
+			mut named_tokens := [
+				FastcExpressionToken{
+					tok: .name
+					lit: field_name
+				},
+				FastcExpressionToken{
+					tok: .colon
+					lit: ':'
+				},
+			]
+			named_tokens << g.last_expression.clone()
+			named_params << named_tokens
+			named_param_names[field_name] = true
+			if g.tok == .comma {
+				g.next()
+			}
+			continue
+		}
+		if named_params.len > 0 {
+			return g.unsupported('positional spawn argument after named params fields')
 		}
 		if g.tok == .key_mut {
 			return g.unsupported('spawn with a `mut` argument')
@@ -133,7 +186,14 @@ fn (mut g Parser) read_spawn_expression() !string {
 		}
 	}
 	g.next()
-	if signature.last_parameter_is_params && arguments.len + 1 == signature.parameter_types.len {
+	if named_params.len > 0 {
+		parameter_type := signature.parameter_types.last()
+		named_initializer := g.render_named_struct_initializer(parameter_type, named_params) or {
+			return g.unsupported('spawn named params initializer for `${callee}`')
+		}
+		arguments << named_initializer
+	} else if signature.last_parameter_is_params
+		&& arguments.len + 1 == signature.parameter_types.len {
 		parameter_type := signature.parameter_types.last()
 		arguments << g.render_empty_struct_initializer(parameter_type)
 	}

--- a/vlib/v3/gen/fastc/spawn.v
+++ b/vlib/v3/gen/fastc/spawn.v
@@ -1,5 +1,6 @@
 module fastc
 
+import strings
 import v3.token
 
 // FastC lowers `spawn f(args)` to a generated pthread creator: the arguments
@@ -13,15 +14,16 @@ const fastc_thread_type_prefix = '__v_fastc_thread_'
 const c_spawn_runtime = r'#include <pthread.h>
 '
 
-// fastc_type_text_hash is an FNV-1a digest of a type spelling. The readable
-// sanitized name alone is lossy (`Foo*` and a declared `Foo_ptr` collapse),
-// so thread type names append this stable discriminator to stay injective.
-fn fastc_type_text_hash(text string) string {
-	mut digest := u32(2166136261)
-	for i in 0 .. text.len {
-		digest = (digest ^ u32(text[i])) * 16777619
+// fastc_name_key hex-encodes the original UTF-8 bytes. The readable sanitized
+// part of a generated name is lossy, so this C-safe key keeps names injective.
+fn fastc_name_key(text string) string {
+	hex_digits := '0123456789abcdef'
+	mut encoded := strings.new_builder(text.len * 2)
+	for value in text.bytes() {
+		encoded.write_u8(hex_digits[value >> 4])
+		encoded.write_u8(hex_digits[value & 0x0f])
 	}
-	return digest.hex()
+	return encoded.str()
 }
 
 fn fastc_thread_type_name(value_type string) string {
@@ -29,7 +31,7 @@ fn fastc_thread_type_name(value_type string) string {
 		return '${fastc_thread_type_prefix}void'
 	}
 	sanitized := value_type.replace('*', '_ptr').replace(' ', '_').replace('.', '__')
-	return '${fastc_thread_type_prefix}${sanitized}_${fastc_type_text_hash(value_type)}'
+	return '${fastc_thread_type_prefix}k${fastc_name_key(value_type)}_${sanitized}'
 }
 
 fn fastc_thread_wait_name(thread_type string) string {
@@ -75,13 +77,19 @@ fn (mut g Parser) read_spawn_expression() !string {
 	signature := g.functions[function_key] or {
 		return g.unsupported('spawn of undeclared function `${callee}`')
 	}
+	// Ordinary disabled calls elide the call and its arguments. A spawn cannot
+	// provide a valid thread handle for an elided call, so reject it before
+	// parsing any arguments.
+	if signature.is_disabled {
+		return g.unsupported('spawn of disabled function `${callee}`')
+	}
 	// Mirror validate_expression_calls: read_spawn_expression consumes the
 	// call eagerly, so the ordinary call-visibility validation never runs.
 	if !signature.is_public && signature.module_name != '' && signature.module_name != g.module_name
 		&& signature.module_name != 'builtin' && signature.module_name in g.imports.values() {
 		return g.unsupported('spawn of private function `${callee}` from imported module `${signature.module_name}`')
 	}
-	if signature.is_variadic || signature.last_parameter_is_params {
+	if signature.is_variadic {
 		return g.unsupported('spawn of variadic function `${callee}`')
 	}
 	if signature.option_type != '' {
@@ -125,6 +133,10 @@ fn (mut g Parser) read_spawn_expression() !string {
 		}
 	}
 	g.next()
+	if signature.last_parameter_is_params && arguments.len + 1 == signature.parameter_types.len {
+		parameter_type := signature.parameter_types.last()
+		arguments << '(${parameter_type}){0}'
+	}
 	if arguments.len != signature.parameter_types.len {
 		return g.unsupported('spawn of `${callee}` with ${arguments.len} arguments, expected ${signature.parameter_types.len}')
 	}
@@ -144,7 +156,15 @@ fn (mut g Parser) read_spawn_expression() !string {
 }
 
 fn fastc_spawn_start_name(function_key string) string {
-	return '__v_fastc_spawn_start_${fastc_c_identifier(fastc_c_function_name_for_key(function_key))}'
+	return '__v_fastc_spawn_start_${fastc_spawn_target_stem(function_key)}'
+}
+
+// fastc_spawn_target_stem puts the injective target key before the readable C
+// name. A collision suffix on one target therefore cannot equal another
+// target's natural generated name, and parallel file parsers choose alike.
+fn fastc_spawn_target_stem(function_key string) string {
+	readable := fastc_c_identifier(fastc_c_function_name_for_key(function_key))
+	return 'k${fastc_name_key(function_key)}_${readable}'
 }
 
 // fastc_unclaimed_generated_name screens a deterministic generated name
@@ -214,10 +234,9 @@ fn (mut g Parser) register_spawn_helpers(function_key string, thread_type string
 		return
 	}
 	target := fastc_c_function_name_for_key(function_key)
-	args_struct :=
-		g.fastc_unclaimed_generated_name('__v_fastc_spawn_args_${fastc_c_identifier(target)}')
-	run_name :=
-		g.fastc_unclaimed_generated_name('__v_fastc_spawn_run_${fastc_c_identifier(target)}')
+	target_stem := fastc_spawn_target_stem(function_key)
+	args_struct := g.fastc_unclaimed_generated_name('__v_fastc_spawn_args_${target_stem}')
+	run_name := g.fastc_unclaimed_generated_name('__v_fastc_spawn_run_${target_stem}')
 	mut fields := ''
 	if value_type != '' {
 		fields += '\t${value_type} result;\n'

--- a/vlib/v3/gen/fastc/stmt.v
+++ b/vlib/v3/gen/fastc/stmt.v
@@ -962,6 +962,11 @@ fn (g &Parser) expression_tokens_are_statement(expression_tokens []FastcExpressi
 			}
 			receiver_start := fastc_method_receiver_start(tokens, i - 1)
 			receiver_type := g.infer_expression_type(tokens[receiver_start..i - 1]) or { continue }
+			if tokens[i].lit == 'wait' && receiver_type.starts_with(fastc_thread_type_prefix) {
+				// Generated thread waiters are absent from g.functions, but joining
+				// a void-returning spawn is still a valid standalone statement.
+				return true
+			}
 			if g.method_function_key(receiver_type, tokens[i].lit) in g.functions
 				|| g.struct_member_type(receiver_type, tokens[i].lit) != '' {
 				return true


### PR DESCRIPTION
## Summary

- preserve file coverage when balancing parallel FastC chunks
- lower nested spawn expressions and standalone void waits correctly
- make generated spawn names injective across targets and user symbols
- reject disabled spawned callees before parsing their arguments
- support explicit and omitted params structs in spawned calls, including non-zero field defaults
- remove the remaining FastC warning diagnostics

This is a follow-up to #28190 for review feedback that arrived after it merged.

## Testing

- ./v -g -keepc -o ./vnew cmd/v
- ./vnew -silent vlib/v3/gen/fastc/fastc_test.v
- ./vnew -silent vlib/v/compiler_errors_test.v (1619 passed, 1 skipped)
- git diff --check