### PR TITLE
v3: reduce memory for large generic builds

### DIFF
--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -75,6 +75,7 @@ fn configure_selfhost_parallelism(building_v bool) {
 
 const embedded_parallel_transform_node_limit = 10_000_000
 const scoped_serial_user_check_node_threshold = 400_000
+const scoped_serial_user_transform_node_threshold = 400_000
 const scoped_serial_user_cgen_node_threshold = 500_000
 const scoped_transform_signature_headroom = 2048
 const v3_vvmrc_file_name = '.vvmrc'
@@ -9135,8 +9136,13 @@ pub fn run(args []string) {
 					a, &pre_tc, used_fns, transform_scope)
 				retained_transform_prepare_scope = prepared_transform.take_scope()
 			} else {
+				// Large user programs keep more memory live when function-body workers
+				// overlap the transformed AST. Scoped serial batches trade a little CPU
+				// for a substantially lower peak.
+				use_parallel_transform := current_parallel_transform
+					&& a.nodes.len < scoped_serial_user_transform_node_threshold
 				transform_used_fns, transform_was_parallel, transform_errors, scoped_owned_base_nodes, retained_transform_regions = transform.transform_with_used_opt_config_scoped_workers_checked_owned(mut a,
-					&pre_tc, used_fns, current_parallel_transform, skip_transform_generics, true,
+					&pre_tc, used_fns, use_parallel_transform, skip_transform_generics, true,
 
 					building_v || trivial_literal_output, transform_scope)
 			}

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -2929,7 +2929,15 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 		g.timing_profile('  [ttime]   cg predispatch   ${f64(cgsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 		cgsw.restart()
 		if !parallel_prep_done {
-			g.collect_fixed_storage_consts(false)
+			$if !v3_no_parallel ? {
+				if g.scope_parallel_workers {
+					g.collect_fixed_storage_consts_scoped()
+				} else {
+					g.collect_fixed_storage_consts(false)
+				}
+			} $else {
+				g.collect_fixed_storage_consts(false)
+			}
 			g.precompute_param_type_index()
 			g.precompute_concrete_optional_abi_fns()
 			if effective_no_parallel {
@@ -2955,7 +2963,15 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 		g.preseed_fn_signature_fn_ptr_types()
 		g.timing_profile('  [ttime]     wr fn sigs     ${f64(cgsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 		cgsw.restart()
-		g.preseed_c_extern_fn_ptr_types()
+		$if !v3_no_parallel ? {
+			if g.scope_parallel_workers {
+				g.preseed_c_extern_fn_ptr_types_scoped()
+			} else {
+				g.preseed_c_extern_fn_ptr_types()
+			}
+		} $else {
+			g.preseed_c_extern_fn_ptr_types()
+		}
 		g.preseed_sig_type_seen = unsafe { nil }
 		g.timing_profile('  [ttime]   cg wrappers      ${f64(cgsw.elapsed().microseconds()) / 1000.0:7.2f} ms (sig+extern)')
 		cgsw.restart()
@@ -2998,7 +3014,15 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	// Function workers collect only the C symbols reached by emitted bodies.
 	// Finalize their declarations and function-pointer types after the merge.
 	g.c_extern_refs_ready = true
-	g.preseed_c_extern_fn_ptr_types()
+	$if !v3_no_parallel ? {
+		if g.scope_parallel_workers {
+			g.preseed_c_extern_fn_ptr_types_scoped()
+		} else {
+			g.preseed_c_extern_fn_ptr_types()
+		}
+	} $else {
+		g.preseed_c_extern_fn_ptr_types()
+	}
 	g.preseed_libc_compat_fns()
 	fn_code := g.sb.str()
 	// `.str()` copies out of the builder; free the emptied backing array under -gc none.
@@ -3067,11 +3091,19 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	if g.cache_split {
 		g.writeln('/* V3CACHE_SOURCE_DIRECTIVES_BEGIN */')
 	}
-	g.emit_c_source_directives()
+	g.emit_c_source_directives_scoped()
 	if g.cache_split {
 		g.writeln('/* V3CACHE_SOURCE_DIRECTIVES_END */')
 	}
-	g.c_extern_forward_decls()
+	$if !v3_no_parallel ? {
+		if g.scope_parallel_workers {
+			g.c_extern_forward_decls_scoped()
+		} else {
+			g.c_extern_forward_decls()
+		}
+	} $else {
+		g.c_extern_forward_decls()
+	}
 	if g.parallel_global_decls.len > 0 {
 		g.sb.write_string(g.parallel_global_decls)
 		unsafe { g.parallel_global_decls.free() }
@@ -3257,6 +3289,12 @@ fn (mut g FlatGen) emit_preserved_c_directives_scoped() {
 fn (mut g FlatGen) emit_c_directives_scoped(late bool) {
 	state := g.begin_scoped_append()
 	g.emit_c_directives(late)
+	g.finish_scoped_append(state)
+}
+
+fn (mut g FlatGen) emit_c_source_directives_scoped() {
+	state := g.begin_scoped_append()
+	g.emit_c_source_directives()
 	g.finish_scoped_append(state)
 }
 

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -14861,11 +14861,17 @@ fn (mut g FlatGen) cached_header_forward_decls() {
 	}
 }
 
+struct CExternForwardDecl {
+	node_idx    int
+	file        string
+	module_name string
+	specificity int
+}
+
 fn (mut g FlatGen) c_extern_forward_decls() {
 	mut cur_module := ''
 	mut cur_file := ''
-	mut decls := map[string]string{}
-	mut decl_specificity := map[string]int{}
+	mut decls := map[string]CExternForwardDecl{}
 	mut names := []string{}
 	referenced_c_externs := g.c_extern_referenced_symbols()
 	// file/module/c_fn_decl nodes only occur at the top level: iterate the
@@ -14928,24 +14934,33 @@ fn (mut g FlatGen) c_extern_forward_decls() {
 			0
 		}
 		specificity := program_decl_priority + c_extern_decl_specificity(g.a, node)
-		if cfn !in decls || specificity > decl_specificity[cfn] {
-			decls[cfn] = g.c_possibly_active_macro_extern_decl(cfn, c_macro_safe_extern_decl(cfn,
-				g.c_extern_decl_line(node, cfn)))
-			decl_specificity[cfn] = specificity
+		if cfn !in decls || specificity > decls[cfn].specificity {
+			decls[cfn] = CExternForwardDecl{
+				node_idx:    i
+				file:        cur_file
+				module_name: cur_module
+				specificity: specificity
+			}
 		}
 	}
 	names.sort()
 	for name in names {
+		decl := decls[name]
+		g.tc.cur_file = decl.file
+		g.tc.cur_module = decl.module_name
+		node := g.a.nodes[decl.node_idx]
+		line := g.c_possibly_active_macro_extern_decl(name, c_macro_safe_extern_decl(name,
+			g.c_extern_decl_line(node, name)))
 		if g.c_extern_decl_is_cached_object_fallback(name) {
 			g.writeln('#ifndef V3CACHE_PROGRAM_UNIT')
-			g.writeln(decls[name])
+			g.writeln(line)
 			g.writeln('#endif')
 		} else if name == 'task_info' || name == 'mach_task_self' {
 			g.writeln('#ifndef __APPLE__')
-			g.writeln(decls[name])
+			g.writeln(line)
 			g.writeln('#endif')
 		} else {
-			g.writeln(decls[name])
+			g.writeln(line)
 		}
 	}
 	if names.len > 0 {

--- a/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
@@ -2237,6 +2237,85 @@ fn (g &FlatGen) new_parallel_worker(worker_id int) &FlatGen {
 	return g.new_parallel_worker_config(worker_id, false)
 }
 
+// collect_fixed_storage_consts_scoped discards the full-AST scan's temporary
+// name-resolution state after copying its small result set to the master.
+fn (mut g FlatGen) collect_fixed_storage_consts_scoped() {
+	scope := cgen_worker_scope_begin(true)
+	mut worker := g.new_parallel_worker(6)
+	worker.fixed_storage_consts = g.fixed_storage_consts.clone()
+	worker.collect_fixed_storage_consts(false)
+	cgen_worker_scope_leave(scope)
+	for name, enabled in worker.fixed_storage_consts {
+		if enabled {
+			g.fixed_storage_consts[name.clone()] = true
+		}
+	}
+	cgen_worker_scope_free(scope)
+}
+
+// preseed_c_extern_fn_ptr_types_scoped keeps the C-declaration scan's large
+// resolution scratch out of the long-lived cgen arena.
+fn (mut g FlatGen) preseed_c_extern_fn_ptr_types_scoped() {
+	scope := cgen_worker_scope_begin(true)
+	mut worker := g.new_parallel_worker(7)
+	g.configure_c_extern_scan_worker(mut worker)
+	worker.preseed_c_extern_fn_ptr_types()
+	cgen_worker_scope_leave(scope)
+	g.publish_c_extern_type_discoveries(worker)
+	cgen_worker_scope_free(scope)
+}
+
+// c_extern_forward_decls_scoped renders C prototypes in a disposable worker
+// and copies only their compact text and discovered ABI types to the master.
+fn (mut g FlatGen) c_extern_forward_decls_scoped() {
+	scope := cgen_worker_scope_begin(true)
+	mut worker := g.new_parallel_worker(8)
+	g.configure_c_extern_scan_worker(mut worker)
+	worker.c_extern_forward_decls()
+	mut output := unsafe { worker.sb.reuse_as_plain_u8_array() }
+	cgen_worker_scope_leave(scope)
+	g.publish_c_extern_type_discoveries(worker)
+	unsafe { g.sb.write_ptr(output.data, output.len) }
+	unsafe { output.free() }
+	cgen_worker_scope_free(scope)
+}
+
+fn (g &FlatGen) configure_c_extern_scan_worker(mut worker FlatGen) {
+	worker.target = g.target
+	worker.needs_shared_runtime = g.needs_shared_runtime
+	worker.preinclude_directives = g.preinclude_directives
+	worker.c_directives = g.c_directives
+	worker.inlined_c_fns = g.inlined_c_fns.clone()
+	worker.inlined_c_declared_fns = g.inlined_c_declared_fns.clone()
+	worker.inlined_c_active_macros = g.inlined_c_active_macros.clone()
+	worker.possibly_active_c_macros = g.possibly_active_c_macros.clone()
+	worker.inlined_c_static_fns = g.inlined_c_static_fns.clone()
+	worker.cache_omitted_c_fns = g.cache_omitted_c_fns.clone()
+}
+
+fn (mut g FlatGen) publish_c_extern_type_discoveries(worker &FlatGen) {
+	for opt_name, val_type in worker.needed_optional_types {
+		if opt_name !in g.needed_optional_types {
+			g.needed_optional_types[opt_name.clone()] = val_type.clone()
+		}
+	}
+	for encoded, name in worker.fn_ptr_types {
+		if encoded !in g.fn_ptr_types {
+			g.fn_ptr_types[encoded.clone()] = name.clone()
+		}
+	}
+	for encoded, used in worker.used_fn_ptr_types {
+		if used {
+			g.used_fn_ptr_types[encoded.clone()] = true
+		}
+	}
+	for name, enabled in worker.libc_compat_fns {
+		if enabled {
+			g.libc_compat_fns[name.clone()] = true
+		}
+	}
+}
+
 fn (g &FlatGen) new_parallel_tail_worker(worker_id int) &FlatGen {
 	mut w := g.new_parallel_worker(worker_id)
 	w.is_shared = g.is_shared

--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -3558,7 +3558,7 @@ fn (mut t Transformer) emit_generic_fn_specialization(decl GenericFnDecl, args [
 	t.add_generated_fn_decl_context(generated_module)
 	old_params := t.active_generic_params
 	old_specialization_args := t.active_specialization_args
-	mut old_specialization_main_types := t.active_specialization_main_types.clone()
+	mut old_specialization_main_types := t.active_specialization_main_types.move()
 	t.active_generic_params = t.generic_fn_param_names(decl.node, decl.module)
 	t.active_specialization_args = concrete_args
 	t.active_specialization_main_types = t.specialization_main_type_closure(concrete_args)
@@ -3788,18 +3788,36 @@ fn (mut t Transformer) generated_fn_used_names(decl GenericFnDecl, clone_id flat
 }
 
 fn (mut t Transformer) generated_fn_body_call_names(root flat.NodeId) []string {
+	return t.generated_fn_body_call_names_filtered(root, unsafe { &t.used_struct_operator_fns },
+		false)
+}
+
+fn (mut t Transformer) generated_fn_body_candidate_call_names(root flat.NodeId, candidate_names &map[string]bool) []string {
+	return t.generated_fn_body_call_names_filtered(root, candidate_names, true)
+}
+
+fn (mut t Transformer) generated_fn_body_call_names_filtered(root flat.NodeId, candidate_names &map[string]bool, filter_candidates bool) []string {
 	mut names := []string{}
 	mut seen := map[string]bool{}
 	saved_fn_name := t.cur_fn_name
 	saved_ret_type := t.cur_fn_ret_type
-	saved_vars := t.var_types.clone()
-	saved_mut_param_values := t.mut_param_values.clone()
+	mut saved_vars := unsafe { t.var_types }
+	mut saved_var_indices := t.var_type_indices.move()
+	mut saved_mut_param_values := t.mut_param_values.move()
+	t.var_types = []VarTypeBinding{}
+	t.var_type_indices = map[string]int{}
+	t.mut_param_values = map[string]bool{}
 	t.seed_generated_fn_body_context(root)
-	t.collect_generated_fn_body_call_names(root, mut names, mut seen)
+	t.collect_generated_fn_body_call_names(root, candidate_names, filter_candidates, mut names, mut
+		seen)
 	t.cur_fn_name = saved_fn_name
 	t.cur_fn_ret_type = saved_ret_type
-	t.restore_var_types(saved_vars)
-	t.mut_param_values = saved_mut_param_values.clone()
+	t.var_types = unsafe { saved_vars }
+	t.var_type_indices = saved_var_indices.move()
+	t.mut_param_values = saved_mut_param_values.move()
+	if !isnil(t.var_type_cache) {
+		t.var_type_cache.clear()
+	}
 	return names
 }
 
@@ -3865,7 +3883,7 @@ fn (mut t Transformer) seed_generated_fn_body_context(root flat.NodeId) {
 	}
 }
 
-fn (mut t Transformer) collect_generated_fn_body_call_names(id flat.NodeId, mut names []string, mut seen map[string]bool) {
+fn (mut t Transformer) collect_generated_fn_body_call_names(id flat.NodeId, candidate_names &map[string]bool, filter_candidates bool, mut names []string, mut seen map[string]bool) {
 	if int(id) < 0 || int(id) >= t.a.nodes.len {
 		return
 	}
@@ -3876,7 +3894,8 @@ fn (mut t Transformer) collect_generated_fn_body_call_names(id flat.NodeId, mut 
 	if node.kind == .call {
 		call_name := t.generated_call_name_for_used(id, node)
 		if call_name.len > 0 {
-			t.push_generated_used_name(call_name, mut names, mut seen)
+			t.push_generated_used_name(call_name, candidate_names, filter_candidates, mut names, mut
+				seen)
 		}
 		if t.defer_nested_generic_emissions {
 			decls := t.cached_generic_fn_decls()
@@ -3891,11 +3910,13 @@ fn (mut t Transformer) collect_generated_fn_body_call_names(id flat.NodeId, mut 
 		}
 	} else if node.kind in [.ident, .selector, .cast_expr, .paren, .expr_stmt] {
 		if fn_value_name := t.generated_fn_value_name_for_used(id, node) {
-			t.push_generated_used_name(fn_value_name, mut names, mut seen)
+			t.push_generated_used_name(fn_value_name, candidate_names, filter_candidates, mut
+				names, mut seen)
 		}
 	}
 	for i in 0 .. node.children_count {
-		t.collect_generated_fn_body_call_names(t.a.child(&node, i), mut names, mut seen)
+		t.collect_generated_fn_body_call_names(t.a.child(&node, i), candidate_names,
+			filter_candidates, mut names, mut seen)
 	}
 }
 
@@ -4136,7 +4157,11 @@ fn (t &Transformer) generated_known_call_name(name string) ?string {
 	return none
 }
 
-fn (mut t Transformer) push_generated_used_name(name string, mut names []string, mut seen map[string]bool) {
+fn (mut t Transformer) push_generated_used_name(name string, candidate_names &map[string]bool, filter_candidates bool, mut names []string, mut seen map[string]bool) {
+	if filter_candidates && !(*candidate_names)[name] && !t.used_struct_operator_fns[name]
+		&& !t.late_name_may_expand_interface(name) {
+		return
+	}
 	if name.len == 0 || seen[name] {
 		return
 	}
@@ -4210,7 +4235,7 @@ fn (mut t Transformer) register_specialized_fn_signature_value(decl GenericFnDec
 	old_tc_module := if isnil(t.tc) { '' } else { t.tc.cur_module }
 	old_tc_file := if isnil(t.tc) { '' } else { t.tc.cur_file }
 	old_specialization_args := t.active_specialization_args
-	old_specialization_main_types := t.active_specialization_main_types.clone()
+	mut old_specialization_main_types := t.active_specialization_main_types.move()
 	t.active_specialization_args = args
 	t.active_specialization_main_types = t.specialization_main_type_closure(args)
 	t.cur_module = decl.module
@@ -4272,7 +4297,7 @@ fn (mut t Transformer) register_specialized_fn_signature_value(decl GenericFnDec
 	t.cur_module = old_module
 	t.cur_file = old_file
 	t.active_specialization_args = old_specialization_args
-	t.active_specialization_main_types = old_specialization_main_types.clone()
+	t.active_specialization_main_types = old_specialization_main_types.move()
 }
 
 fn (mut t Transformer) specialized_fn_return_type_text(decl GenericFnDecl, args []string) string {

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -1019,7 +1019,7 @@ fn configure_transformer(mut t Transformer, want_parallel bool, skip_generics bo
 	}
 }
 
-fn transform_after_prepare(mut t Transformer, mut a flat.FlatAst, used_fns map[string]bool, want_parallel bool, skip_generics bool) (map[string]bool, bool, []string, []int, []ScopedTransformRegion) {
+fn transform_after_prepare(mut t Transformer, mut a flat.FlatAst, _used_fns map[string]bool, want_parallel bool, skip_generics bool) (map[string]bool, bool, []string, []int, []ScopedTransformRegion) {
 	mut impl_sw := time.new_stopwatch()
 	t.cache_comptime_param_reflection_metadata()
 	if want_parallel {
@@ -1032,6 +1032,9 @@ fn transform_after_prepare(mut t Transformer, mut a flat.FlatAst, used_fns map[s
 		t.scoped_base_nodes = base_node_count
 	}
 	t.transformed_fns = []bool{len: t.a.nodes.len}
+	used_log_was_active := t.used_fns_log_active
+	used_log_start := t.used_fns_log.len
+	t.used_fns_log_active = true
 	was_parallel := t.transform_all_dispatch(want_parallel)
 	impl_sw.restart()
 	t.retain_current_worker_scope_all()
@@ -1040,16 +1043,23 @@ fn transform_after_prepare(mut t Transformer, mut a flat.FlatAst, used_fns map[s
 	// resolve before narrowing and other type-aware lowering. This is needed for
 	// non-generic programs too: a call on a narrowed sum-type variant can become a
 	// concrete primitive method only after transform.
-	mut late_names := newly_used_fn_names(used_fns, t.used_fns)
+	used_log_end := t.used_fns_log.len
+	mut late_scan_names := []string{}
 	if !t.building_v {
 		// Interface implementers can become reachable while their interface calls
 		// are transformed. Include them in the type-aware call scan so dependencies
 		// from their already-transformed bodies are queued too.
-		late_names << t.new_call_names_from_used_fn_bodies(t.used_fns, t.a.nodes.len)
+		late_candidate_names := t.late_transform_candidate_name_filter(base_node_count)
+		late_scan_names = t.new_call_names_from_used_fn_bodies(unsafe { &t.used_fns },
+			&late_candidate_names, t.a.nodes.len)
 	}
-	t.timing_profile('  [ttime] late names         ${f64(impl_sw.elapsed().microseconds()) / 1000.0:7.2f} ms (n: ${late_names.len})')
+	t.timing_profile('  [ttime] late names         ${f64(impl_sw.elapsed().microseconds()) / 1000.0:7.2f} ms (n: ${
+		used_log_end - used_log_start + late_scan_names.len})')
 	impl_sw.restart()
-	t.transform_late_used_fn_bodies(late_names, base_node_count)
+	t.transform_late_used_fn_bodies(&t.used_fns_log, used_log_start, used_log_end, base_node_count)
+	if late_scan_names.len > 0 {
+		t.transform_late_used_fn_bodies(&late_scan_names, 0, late_scan_names.len, base_node_count)
+	}
 	t.timing_profile('  [ttime] late bodies        ${f64(impl_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 	impl_sw.restart()
 	t.run_auto_str_synthesis_rounds(base_node_count)
@@ -1065,6 +1075,7 @@ fn transform_after_prepare(mut t Transformer, mut a flat.FlatAst, used_fns map[s
 	if !isnil(t.tc) {
 		t.tc.reset_body_resolve_memo()
 	}
+	t.used_fns_log_active = used_log_was_active
 	return t.used_fns, was_parallel, t.monomorph_errors, owned_base_nodes, t.retained_worker_regions
 }
 
@@ -1245,7 +1256,7 @@ fn (mut t Transformer) run_sum_eq_synthesis_rounds(node_limit int) {
 		if new_names.len == 0 {
 			return
 		}
-		t.transform_late_used_fn_bodies(new_names, node_limit)
+		t.transform_late_used_fn_bodies(&new_names, 0, new_names.len, node_limit)
 	}
 }
 
@@ -1255,7 +1266,7 @@ fn (mut t Transformer) run_default_clone_synthesis_rounds(node_limit int) {
 		if new_names.len == 0 {
 			return
 		}
-		t.transform_late_used_fn_bodies(new_names, node_limit)
+		t.transform_late_used_fn_bodies(&new_names, 0, new_names.len, node_limit)
 	}
 }
 
@@ -1263,7 +1274,7 @@ fn (mut t Transformer) run_auto_str_synthesis_rounds(node_limit int) {
 	for _ in 0 .. 16 {
 		new_names := t.synthesize_auto_str_helpers()
 		if new_names.len > 0 {
-			t.transform_late_used_fn_bodies(new_names, node_limit)
+			t.transform_late_used_fn_bodies(&new_names, 0, new_names.len, node_limit)
 		}
 		if !t.has_pending_auto_str_helpers() {
 			return
@@ -1271,13 +1282,28 @@ fn (mut t Transformer) run_auto_str_synthesis_rounds(node_limit int) {
 	}
 }
 
-fn (mut t Transformer) new_call_names_from_used_fn_bodies(used map[string]bool, node_limit int) []string {
+fn (mut t Transformer) new_call_names_from_used_fn_bodies(used &map[string]bool, candidate_names &map[string]bool, node_limit int) []string {
 	if used.len == 0 || node_limit <= 0 {
 		return []string{}
 	}
 	limit := if node_limit < t.a.nodes.len { node_limit } else { t.a.nodes.len }
 	cands := t.collect_late_scan_candidates(limit)
-	return t.scan_late_call_names_dispatch(cands, used)
+	return t.scan_late_call_names_dispatch(cands, used, candidate_names)
+}
+
+fn (mut t Transformer) late_transform_candidate_name_filter(node_limit int) map[string]bool {
+	mut names := map[string]bool{}
+	limit := if node_limit < t.a.nodes.len { node_limit } else { t.a.nodes.len }
+	for cand in t.collect_late_scan_candidates(limit) {
+		if (cand.idx < t.transformed_fns.len && t.transformed_fns[cand.idx])
+			|| t.fn_decl_has_unresolved_generics(t.a.nodes[cand.idx], cand.module) {
+			continue
+		}
+		for key in late_candidate_match_keys(t.a.nodes[cand.idx].value, cand.module) {
+			names[key] = true
+		}
+	}
+	return names
 }
 
 // collect_late_scan_candidates lists every fn_decl below `limit` with its
@@ -1313,9 +1339,8 @@ fn (t &Transformer) collect_late_scan_candidates(limit int) []LateFnCandidate {
 // transformer's private per-function context and checker caches), so disjoint
 // ranges can run on worker threads; concatenating the per-range results in
 // range order and deduplicating reproduces the serial scan exactly.
-fn (mut t Transformer) scan_late_call_names_range(cands []LateFnCandidate, used map[string]bool, start int, end int) []string {
+fn (mut t Transformer) scan_late_call_names_range(cands []LateFnCandidate, used &map[string]bool, candidate_names &map[string]bool, start int, end int) []string {
 	mut names := []string{}
-	mut seen := map[string]bool{}
 	old_module := t.cur_module
 	old_file := t.cur_file
 	for ci in start .. end {
@@ -1325,42 +1350,27 @@ fn (mut t Transformer) scan_late_call_names_range(cands []LateFnCandidate, used 
 			continue
 		}
 		if !transform_is_generated_fn_after_markused(node.value)
-			&& !late_used_fn_matches(used, node, cand.module) {
+			&& !late_used_fn_matches(*used, node, cand.module) {
 			continue
 		}
 		t.cur_file = cand.file
 		t.cur_module = cand.module
-		for call_name in t.generated_fn_body_call_names(flat.NodeId(cand.idx)) {
-			if call_name.len == 0 || seen[call_name] {
+		for call_name in t.generated_fn_body_candidate_call_names(flat.NodeId(cand.idx),
+			candidate_names) {
+			if call_name.len == 0 || (!(*candidate_names)[call_name]
+				&& !t.used_struct_operator_fns[call_name]
+				&& !t.late_name_may_expand_interface(call_name)) {
 				continue
 			}
-			if used[call_name] || used[c_name(call_name)]
-				|| late_used_fn_contains_in_module(used, call_name, cand.module) {
+			if (*used)[call_name] || (*used)[c_name(call_name)]
+				|| late_used_fn_contains_in_module(*used, call_name, cand.module) {
 				continue
 			}
-			seen[call_name] = true
 			names << call_name
 		}
 	}
 	t.cur_module = old_module
 	t.cur_file = old_file
-	return names
-}
-
-fn newly_used_fn_names(before map[string]bool, after map[string]bool) []string {
-	mut names := []string{}
-	for name, used in after {
-		if !used || name.len == 0 {
-			continue
-		}
-		if before[name] || before[c_name(name)] {
-			continue
-		}
-		if name.contains('.') && before[name.all_after_last('.')] {
-			continue
-		}
-		names << name
-	}
 	return names
 }
 
@@ -1407,8 +1417,7 @@ pub fn monomorphize_with_used_checked_config_scoped(mut a flat.FlatAst, tc &type
 // unchanged dependency body can remain in the persistent compiled prefix.
 pub fn monomorphize_with_used_checked_config_scoped_cached(mut a flat.FlatAst, tc &types.TypeChecker, used_fns map[string]bool, parallel bool, stage_scope voidptr, cached_specs []MonomorphCacheSpec) (map[string]bool, []string, []MonomorphCacheSpec) {
 	debug_started := time.ticks()
-	mut augmented_used_fns := used_fns.clone()
-	mut t := new_transformer(mut a, tc, augmented_used_fns)
+	mut t := new_transformer(mut a, tc, used_fns)
 	t.parallel_monomorphize = parallel
 	t.stage_scope = stage_scope
 	t.scoped_monomorphize = stage_scope != unsafe { nil }
@@ -1427,34 +1436,30 @@ pub fn monomorphize_with_used_checked_config_scoped_cached(mut a flat.FlatAst, t
 	t.seed_cached_monomorph_specs(cached_specs)
 	t.monomorph_profile('mono wrapper prepare: ${time.ticks() - debug_started} ms')
 	base_node_count := t.a.nodes.len
+	used_log_start := t.used_fns_log.len
+	t.used_fns_log_active = true
 	generated_names := t.monomorphize_pass()
 	t.materialize_monomorph_signature_types(t.sorted_monomorph_cache_specs())
 	t.monomorph_profile('mono wrapper pass: ${time.ticks() - debug_started} ms')
-	mut late_names := []string{}
 	for name in generated_names {
-		was_used := used_fns[name] || used_fns[c_name(name)]
-		augmented_used_fns[name] = true
-		augmented_used_fns[c_name(name)] = true
-		t.used_fns[name] = true
-		t.used_fns[c_name(name)] = true
-		if !was_used {
-			late_names << name
-		}
+		t.mark_used_fn_key(name)
+		t.mark_used_fn_key(c_name(name))
 	}
 	t.materialize_generic_structs(false)
 	t.monomorph_profile('mono wrapper generated: ${time.ticks() - debug_started} ms')
 	// generated_fn_used_names records callees while each specialization is
 	// transformed. Seed the late-body queue from those new names; that queue
 	// follows further callees recursively as it transforms each body.
-	late_names << newly_used_fn_names(used_fns, t.used_fns)
 	t.monomorph_profile('mono wrapper calls: ${time.ticks() - debug_started} ms')
-	t.transform_late_used_fn_bodies(late_names, base_node_count)
+	used_log_end := t.used_fns_log.len
+	t.transform_late_used_fn_bodies(&t.used_fns_log, used_log_start, used_log_end, base_node_count)
 	t.monomorph_profile('mono wrapper late: ${time.ticks() - debug_started} ms')
-	used_before_remaining_matches := t.used_fns.clone()
+	remaining_match_log_start := t.used_fns_log.len
 	t.lower_remaining_matches_in_used_fns()
 	t.monomorph_profile('mono wrapper matches: ${time.ticks() - debug_started} ms')
-	remaining_match_names := newly_used_fn_names(used_before_remaining_matches, t.used_fns)
-	t.transform_late_used_fn_bodies(remaining_match_names, base_node_count)
+	remaining_match_log_end := t.used_fns_log.len
+	t.transform_late_used_fn_bodies(&t.used_fns_log, remaining_match_log_start,
+		remaining_match_log_end, base_node_count)
 	t.monomorph_profile('mono wrapper late matches: ${time.ticks() - debug_started} ms')
 	t.materialize_generic_structs(true)
 	t.monomorph_profile('mono wrapper structs: ${time.ticks() - debug_started} ms')
@@ -3965,7 +3970,7 @@ fn (mut t Transformer) merge_worker_used_fns(w &Transformer) {
 	for name, used in w.used_fns {
 		if used {
 			owned_name := if scoped && !t.retain_worker_results { name.clone() } else { name }
-			t.used_fns[owned_name] = true
+			t.mark_used_fn_key(owned_name)
 		}
 	}
 	for name, used in w.used_struct_operator_fns {
@@ -4725,8 +4730,20 @@ fn transform_is_generated_fn_after_markused(name string) bool {
 	return name.starts_with('__anon_fn_') || name.contains('.__anon_fn_')
 }
 
-fn (mut t Transformer) transform_late_used_fn_bodies(names []string, node_limit int) {
-	if names.len == 0 || node_limit <= 0 {
+fn (t &Transformer) late_name_may_expand_interface(name string) bool {
+	dot := name.last_index('.') or { return false }
+	// The receiver is only probed while `name` owns its backing bytes.
+	receiver := unsafe { name[..dot] }
+	base_start := if receiver.len > 0 && receiver[0] == `&` { 1 } else { 0 }
+	generic_start := receiver.index_u8(`[`)
+	base_end := if generic_start > base_start { generic_start } else { receiver.len }
+	base := unsafe { receiver[base_start..base_end] }
+	return base in t.tc.interface_names || base in t.tc.type_aliases
+		|| t.type_alias_suffixes[base].len > 0 || base == 'IError' || base == 'builtin.IError'
+}
+
+fn (mut t Transformer) transform_late_used_fn_bodies(names &[]string, names_start int, names_end int, node_limit int) {
+	if names_end <= names_start || node_limit <= 0 {
 		return
 	}
 	mut late := map[string]bool{}
@@ -4736,20 +4753,28 @@ fn (mut t Transformer) transform_late_used_fn_bodies(names []string, node_limit 
 	old_file := t.cur_file
 	t.cur_module = ''
 	t.cur_file = ''
-	mut seed_names := names.clone()
-	for name in names {
-		if !name.contains('.') {
+	mut interface_seed_names := []string{}
+	for ni in names_start .. names_end {
+		name := (*names)[ni]
+		if !t.late_name_may_expand_interface(name) {
 			continue
 		}
-		method := name.all_after_last('.')
-		iface_name := t.resolve_interface_type_name(name.all_before_last('.'))
+		dot := name.last_index('.') or { continue }
+		// These non-owning slices are only used while `name` keeps their backing
+		// bytes alive. Avoid copying very large generic-instantiation spellings.
+		receiver := unsafe { name[..dot] }
+		method := unsafe { name[dot + 1..] }
+		iface_name := t.resolve_interface_type_name(receiver)
 		if iface_name.len > 0 {
-			seed_names << t.interface_method_implementer_names(iface_name, method)
+			interface_seed_names << t.interface_method_implementer_names(iface_name, method)
 		}
 	}
-	for name in seed_names {
+	for ni in names_start .. names_end {
+		name := (*names)[ni]
 		t.mark_fn_used_name(name)
-		add_late_used_fn_name(name, mut late, mut pending, mut queued)
+	}
+	for name in interface_seed_names {
+		t.mark_fn_used_name(name)
 	}
 	t.cur_module = old_module
 	t.cur_file = old_file
@@ -4803,6 +4828,24 @@ fn (mut t Transformer) transform_late_used_fn_bodies(names []string, node_limit 
 		for key in late_candidate_match_keys(t.a.nodes[cand.idx].value, cand.module) {
 			candidate_index[key] << ci
 		}
+	}
+	// `names` can contain very large generic-instantiation spellings. Only copy
+	// a name into the late-work maps when the index proves that it can match a
+	// body; unmatched names still remain marked used for later compiler stages.
+	for ni in names_start .. names_end {
+		name := (*names)[ni]
+		if name.len == 0
+			|| (candidate_index[name].len == 0 && candidate_index[c_name(name)].len == 0) {
+			continue
+		}
+		add_late_used_fn_name(name, mut late, mut pending, mut queued)
+	}
+	for name in interface_seed_names {
+		if name.len == 0
+			|| (candidate_index[name].len == 0 && candidate_index[c_name(name)].len == 0) {
+			continue
+		}
+		add_late_used_fn_name(name, mut late, mut pending, mut queued)
 	}
 	was_log_active := t.used_fns_log_active
 	t.used_fns_log_active = true

--- a/vlib/v3/transform/transform_parallel_d_v3_no_parallel.v
+++ b/vlib/v3/transform/transform_parallel_d_v3_no_parallel.v
@@ -34,8 +34,8 @@ fn (mut t Transformer) run_parallel_transform(items []FnWorkItem, _ int, _ int) 
 
 // scan_late_call_names_dispatch falls back to the serial late-name scan when
 // v3 is built with the internal `v3_no_parallel` define.
-fn (mut t Transformer) scan_late_call_names_dispatch(cands []LateFnCandidate, used map[string]bool) []string {
-	return t.scan_late_call_names_range(cands, used, 0, cands.len)
+fn (mut t Transformer) scan_late_call_names_dispatch(cands []LateFnCandidate, used &map[string]bool, candidate_names &map[string]bool) []string {
+	return t.scan_late_call_names_range(cands, used, candidate_names, 0, cands.len)
 }
 
 pub fn promote_scoped_texts_parallel(mut _ flat.FlatAst, _ voidptr) bool {

--- a/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
@@ -29,6 +29,7 @@ const max_parallel_monomorph_jobs = 18
 const scoped_transform_batches = 16
 const scoped_transform_max_batch_items = 2048
 const scoped_monomorph_batch_specs = 512
+const scoped_monomorph_node_threshold = 500_000
 
 $if !windows {
 	// RegionRelocateArgs is one worker region's in-place id-relocation job: the
@@ -996,6 +997,10 @@ fn (mut t Transformer) run_parallel_monomorphize_specs(specs []PendingGenericFnS
 		if specs.len == 0 {
 			return false
 		}
+		if t.scope_parallel_workers && t.scoped_monomorphize
+			&& t.a.nodes.len >= scoped_monomorph_node_threshold {
+			return t.run_scoped_monomorphize_specs(specs, mut emitted, mut generated)
+		}
 		if isnil(t.a.worker_pool) {
 			worker_count := runtime.nr_jobs() - 1
 			if worker_count <= 0 {
@@ -1349,12 +1354,23 @@ fn (mut t Transformer) run_scoped_monomorphize_specs(specs []PendingGenericFnSpe
 			t.a.children.cap)
 		wast.specialized_fn_nodes = map[int]bool{}
 		mut wtc := t.tc.fork_for_parallel_transform(wast)
-		mut w := t.fork_scoped_batch_worker(wast, wtc)
+		wtc.fn_ret_types = t.tc.fn_ret_types.clone()
+		wtc.fn_param_types = t.tc.fn_param_types.clone()
+		wtc.fn_variadic = t.tc.fn_variadic.clone()
+		wtc.specialized_generic_fns = t.tc.specialized_generic_fns.clone()
+		wtc.fn_type_modules = t.tc.fn_type_modules.clone()
+		wtc.fn_type_files = t.tc.fn_type_files.clone()
+		wtc.receiver_method_suffix_index = t.tc.receiver_method_suffix_index.clone()
+		wtc.transform_signature_maps_shared = false
+		mut w := t.fork_worker(wast, wtc)
+		w.fn_ret_types = t.fn_ret_types.clone()
+		w.receiver_method_suffix_index = t.receiver_method_suffix_index.clone()
+		w.signature_maps_shared = false
 		w.generic_fn_decls_cache = decls.clone()
 		w.generic_fn_decls_ready = true
 		w.generic_receiver_methods_by_name = t.generic_receiver_methods_by_name.clone()
 		w.parallel_monomorph_worker = true
-		w.generic_signatures_pre_registered = true
+		w.generic_signatures_pre_registered = false
 		w.defer_nested_generic_emissions = true
 		w.generic_clone_children.ensure_cap(65536)
 		mut roots := []flat.NodeId{cap: end - start}
@@ -1373,6 +1389,14 @@ fn (mut t Transformer) run_scoped_monomorphize_specs(specs []PendingGenericFnSpe
 		transform_worker_scope_leave(scope)
 
 		node_shift := t.a.nodes.len - base_nodes
+		// The parent pre-registered every specialization in this batch above.
+		// The worker must still register them privately while transforming so
+		// result/error semantics resolve correctly, but those duplicate maps live
+		// in `scope` and must not escape when the other worker results are merged.
+		w.signature_maps_changed = false
+		w.fn_ret_types_log = []string{}
+		w.tc_signature_names_log = []string{}
+		w.tc.discard_transform_signature_changes()
 		t.merge_worker_used_fns(w)
 		t.merge_worker(w, []FnWorkItem{}, base_nodes, base_children, false)
 		for name in w.generic_specialization_args_log {
@@ -1919,6 +1943,11 @@ fn (mut t Transformer) transform_scoped_helper_batches(items []FnWorkItem, max_b
 		t.a.promote_transform_texts_from(text_start, scratch_scope)
 		t.absorb_scoped_batch(batch, scratch_scope, new_node_start)
 		t.promote_scoped_ast_storage(scratch_scope)
+		for item in items[start..end] {
+			if item.fn_idx >= 0 && item.fn_idx < t.transformed_fns.len {
+				t.transformed_fns[item.fn_idx] = true
+			}
+		}
 		// absorb_scoped_batch publishes every appended node and every base-node
 		// mutation recorded by the batch. Avoid rescanning the continuously growing
 		// AST after each small batch; that makes scoped transform quadratic.
@@ -2492,13 +2521,14 @@ fn (mut t Transformer) run_parallel_transform_shared(items []FnWorkItem, base_no
 $if !windows {
 	// LateScanChunkArgs is the payload handed to each late-name-scan worker.
 	struct LateScanChunkArgs {
-		worker      voidptr // &Transformer
-		cands_ptr   voidptr // &[]LateFnCandidate
-		used        map[string]bool
-		results_ptr voidptr // &[][]string
-		index       int
-		start       int
-		end         int
+		worker          voidptr // &Transformer
+		cands_ptr       voidptr // &[]LateFnCandidate
+		used            &map[string]bool = unsafe { nil }
+		candidate_names &map[string]bool = unsafe { nil }
+		results_ptr     voidptr // &[][]string
+		index           int
+		start           int
+		end             int
 	}
 
 	// late_scan_chunk_thread runs one worker's candidate range of the late-name scan.
@@ -2507,7 +2537,8 @@ $if !windows {
 		mut w := unsafe { &Transformer(args.worker) }
 		cands := unsafe { &[]LateFnCandidate(args.cands_ptr) }
 		mut results := unsafe { &[][]string(args.results_ptr) }
-		res := w.scan_late_call_names_range(*cands, args.used, args.start, args.end)
+		res := w.scan_late_call_names_range(*cands, args.used, args.candidate_names, args.start,
+			args.end)
 		unsafe {
 			(*results)[args.index] = res
 		}
@@ -2518,14 +2549,14 @@ $if !windows {
 // scan_late_call_names_dispatch runs the late-name scan across threads when
 // there is enough work. The scan is read-only over the merged AST (each worker
 // gets a forked TypeChecker for its private memoization), and the per-range
-// results are concatenated in range order and deduplicated, which reproduces
-// the serial scan byte for byte.
-fn (mut t Transformer) scan_late_call_names_dispatch(cands []LateFnCandidate, used map[string]bool) []string {
+// results are concatenated in range order. The downstream late-work queue
+// deduplicates matching names.
+fn (mut t Transformer) scan_late_call_names_dispatch(cands []LateFnCandidate, used &map[string]bool, candidate_names &map[string]bool) []string {
 	$if windows {
-		return t.scan_late_call_names_range(cands, used, 0, cands.len)
+		return t.scan_late_call_names_range(cands, used, candidate_names, 0, cands.len)
 	} $else {
 		if !t.parallel_enabled {
-			return t.scan_late_call_names_range(cands, used, 0, cands.len)
+			return t.scan_late_call_names_range(cands, used, candidate_names, 0, cands.len)
 		}
 		// The scan clones no ASTs (workers share the merged AST read-only), so it
 		// is not bound by the clone-memory ceiling of the transform workers.
@@ -2540,7 +2571,7 @@ fn (mut t Transformer) scan_late_call_names_dispatch(cands []LateFnCandidate, us
 			n_jobs = cands.len
 		}
 		if cands.len < 256 || n_jobs <= 1 {
-			return t.scan_late_call_names_range(cands, used, 0, cands.len)
+			return t.scan_late_call_names_range(cands, used, candidate_names, 0, cands.len)
 		}
 		t.tc.freeze_type_cache_for_forks()
 		bounds := late_scan_chunk_bounds(t.a, cands, n_jobs)
@@ -2549,13 +2580,14 @@ fn (mut t Transformer) scan_late_call_names_dispatch(cands []LateFnCandidate, us
 		mut scan_workers := []voidptr{len: thread_count, init: unsafe { nil }}
 		mut args := []LateScanChunkArgs{len: n_jobs}
 		args[0] = LateScanChunkArgs{
-			worker:      voidptr(t)
-			cands_ptr:   unsafe { voidptr(&cands) }
-			used:        used
-			results_ptr: unsafe { voidptr(&results) }
-			index:       0
-			start:       bounds[0]
-			end:         bounds[1]
+			worker:          voidptr(t)
+			cands_ptr:       unsafe { voidptr(&cands) }
+			used:            unsafe { used }
+			candidate_names: unsafe { candidate_names }
+			results_ptr:     unsafe { voidptr(&results) }
+			index:           0
+			start:           bounds[0]
+			end:             bounds[1]
 		}
 		for ci in 0 .. thread_count {
 			// No AST clone: the scan never appends nodes. Only the checker is
@@ -2565,13 +2597,14 @@ fn (mut t Transformer) scan_late_call_names_dispatch(cands []LateFnCandidate, us
 			ww := t.fork_scan_worker(wtc)
 			scan_workers[ci] = voidptr(ww)
 			args[ci + 1] = LateScanChunkArgs{
-				worker:      scan_workers[ci]
-				cands_ptr:   unsafe { voidptr(&cands) }
-				used:        used
-				results_ptr: unsafe { voidptr(&results) }
-				index:       ci + 1
-				start:       bounds[ci + 1]
-				end:         bounds[ci + 2]
+				worker:          scan_workers[ci]
+				cands_ptr:       unsafe { voidptr(&cands) }
+				used:            unsafe { used }
+				candidate_names: unsafe { candidate_names }
+				results_ptr:     unsafe { voidptr(&results) }
+				index:           ci + 1
+				start:           bounds[ci + 1]
+				end:             bounds[ci + 2]
 			}
 		}
 		fail := os.getenv('V3_TEST_PTHREAD_CREATE_FAIL')
@@ -2587,13 +2620,9 @@ fn (mut t Transformer) scan_late_call_names_dispatch(cands []LateFnCandidate, us
 		t.a.worker_pool.run(tasks)
 		t.tc.unfreeze_type_cache_after_forks()
 		mut names := []string{}
-		mut seen := map[string]bool{}
 		for res in results {
 			for name in res {
-				if !seen[name] {
-					seen[name] = true
-					names << name
-				}
+				names << name
 			}
 		}
 		return names

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -1450,6 +1450,15 @@ pub fn (tc &TypeChecker) transform_signatures_changed() bool {
 	return tc.transform_signature_maps_changed
 }
 
+// discard_transform_signature_changes makes a fork's private signature tables
+// disposable when its parent has already registered the same generated
+// signatures. Other worker results can then be merged without publishing
+// pointers owned by the worker's temporary arena.
+pub fn (mut tc TypeChecker) discard_transform_signature_changes() {
+	tc.transform_signature_names_log = []string{}
+	tc.transform_signature_maps_changed = false
+}
+
 // ensure_private_transform_structs detaches struct metadata before a transform
 // worker publishes a generated capture context into its private result.
 pub fn (mut tc TypeChecker) ensure_private_transform_structs() {

--- a/vlib/v3/types/checker_scoped_transform_test.v
+++ b/vlib/v3/types/checker_scoped_transform_test.v
@@ -101,6 +101,20 @@ fn signature_map_storage_owned_by_scope(scope voidptr, layout &SignatureMapLayou
 	}
 }
 
+fn test_discard_transform_signature_changes_resets_fork_publication_state() {
+	a := flat.FlatAst.new()
+	mut tc := TypeChecker.new(&a)
+	tc.transform_signature_maps_shared = true
+	tc.ensure_private_transform_signatures()
+	tc.register_generated_fn_param_types('main.generated', [Type(int_)])
+	assert tc.transform_signatures_changed()
+	assert tc.transform_signature_names_log == ['main.generated']
+
+	tc.discard_transform_signature_changes()
+	assert !tc.transform_signatures_changed()
+	assert tc.transform_signature_names_log.len == 0
+}
+
 fn test_rebuild_scoped_transform_signatures_and_suffix_index_after_growth() {
 	$if prealloc {
 		a := flat.FlatAst.new()


### PR DESCRIPTION
## Summary

- use lower-memory scoped/serial transform and monomorphization paths for very large user ASTs
- avoid cloning large late-transform and generic-specialization maps, and filter late body scans without dropping generic operators
- move temporary C declaration/directive scans into disposable scopes and render only selected extern declarations

## Benchmark

Command:

```sh
/usr/bin/time -l ./vnew -new-compiler -nocache -path /tmp/v3-vguard.hEm3zp/vguard|@vlib|@vmodules -v -o /tmp/main-gui.c /tmp/main-gui.v
```

- latest master: 3,182,592,000 bytes RSS (3035.2 MiB)
- this branch: 2,091,368,448 bytes RSS (1994.5 MiB)
- reduction: 34.3%, with 53.5 MiB headroom below 2 GiB
- generated C: byte-identical to the validated reference (`20ed9f5821208b73ef4c0a94db88a56b34010381e67199bcb43f23dd0afd9702`)

The existing V3 compiler memory limit remains 10 GiB.

## Tests

- `./vnew -silent vlib/v/compiler_errors_test.v` (1619 passed, 1 skipped)
- `./vnew -silent vlib/v/gen/c/coutput_test.v`
- focused V3 checker, transform, monomorphization, cgen, self-host, module-cache, no-parallel, and generic-operator tests
- broad `./vnew -silent test vlib/v3/`: 310/316 passed initially; all six failures were fixed and rerun individually successfully
- exact `guard_ui` reproduction above

The unrelated broad `./vnew -silent test vlib/v/` sweep was stopped after numerous existing runtime failures under its 18-job load, including one concurrent V3 process exceeding the existing 10 GiB limit.