### PR TITLE
v3: fix global and primitive method collisions

### DIFF
--- a/vlib/v/tests/fns/closure_of_method_defined_on_alias_test.v
+++ b/vlib/v/tests/fns/closure_of_method_defined_on_alias_test.v
@@ -1,8 +1,18 @@
 type UInt = u32
 
+type Label = int
+
 fn (me UInt) member() u32 {
 	println('member called')
 	return me * 10
+}
+
+fn (me Label) str() string {
+	return 'alias'
+}
+
+fn call_string_callback(callback fn () string) string {
+	return callback()
 }
 
 fn test_1() {
@@ -12,4 +22,8 @@ fn test_1() {
 	res := x()
 	println('done')
 	assert res == 40
+}
+
+fn test_plain_primitive_method_value_takes_precedence_over_alias_method() {
+	assert call_string_callback(int(7).str) == '7'
 }

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -21270,7 +21270,15 @@ fn (g &FlatGen) global_c_name(name string) string {
 }
 
 fn (g &FlatGen) c_namespace_global_c_name(raw_name string) string {
+	// Legacy closure tests expose the internal runtime global as `C.g_closure`.
+	// Other C globals must keep their external C symbol, even when a V global collides.
+	if raw_name != 'g_closure' {
+		return raw_name
+	}
 	if module_name := g.global_modules[raw_name] {
+		if module_name != 'closure' {
+			return raw_name
+		}
 		qualified := qualify_name_in_module(module_name, raw_name)
 		if qualified in g.global_types
 			&& ('C.${raw_name}' in g.global_types || 'C.${raw_name}' in g.tc.c_globals) {

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -3143,8 +3143,10 @@ fn (mut g FlatGen) gen_method_value_closure(selector_id flat.NodeId, base_id fla
 	} else if clean is types.String || clean is types.Primitive || clean is types.Char
 		|| clean is types.Rune {
 		receiver_name = clean.name()
-		if alias_method := g.find_alias_method(receiver_name, method) {
-			receiver_name = alias_method.all_before_last('.')
+		if g.resolve_method_name(receiver_name, method).len == 0 {
+			if alias_method := g.find_alias_method(receiver_name, method) {
+				receiver_name = alias_method.all_before_last('.')
+			}
 		}
 	} else {
 		alias_method := g.find_alias_method(clean.name(), method) or { return false }

--- a/vlib/v3/tests/c_global_c_type_storage_codegen_test.v
+++ b/vlib/v3/tests/c_global_c_type_storage_codegen_test.v
@@ -303,6 +303,55 @@ fn main() {
 	assert !c_code.contains('\nFILE* stdout'), c_code
 }
 
+fn test_c_namespace_global_keeps_name_when_v_global_collides() {
+	c_code := gen_c_for_c_global_sources('c_namespace_global_collision', {
+		'main.v':      'module main
+
+import moda
+
+fn main() {
+	moda.set_both()
+}
+'
+		'moda/moda.v': 'module moda
+
+__global C.foo int
+__global foo int
+
+pub fn set_both() {
+	C.foo = 7
+	foo = 11
+}
+'
+	})
+	assert c_code.contains('foo = 7;'), c_code
+	assert c_code.contains('moda__foo = 11;'), c_code
+	assert !c_code.contains('moda__foo = 7;'), c_code
+}
+
+fn test_legacy_closure_c_global_uses_runtime_storage() {
+	c_code := gen_c_for_c_global_sources('legacy_closure_c_global', {
+		'main.v':            'module main
+
+__global C.g_closure int
+
+fn closure_value() int {
+	return C.g_closure
+}
+
+fn main() {
+	_ := closure_value()
+}
+'
+		'closure/closure.v': 'module closure
+
+__global g_closure int
+'
+	})
+	assert c_code.contains('return closure__g_closure;'), c_code
+	assert !c_code.contains('return g_closure;'), c_code
+}
+
 fn test_empty_c_struct_initializer_uses_portable_zero_value() {
 	c_code := gen_c_for_c_global_source('empty_c_struct_initializer', 'struct C.NativeDesc {
 	value int


### PR DESCRIPTION
## Summary

- keep unrelated `C.*` globals in the external C namespace when V globals share the same raw name
- retain the intentional legacy `C.g_closure` bridge to `closure.g_closure`
- prefer real primitive methods over alias-method fallback for bound method values
- add regressions for both codegen collisions

This addresses follow-up review feedback from:
- https://github.com/vlang/v/pull/28197#discussion_r3866076515
- https://github.com/vlang/v/pull/28197#discussion_r3866076527

## Tests

- `./v -g -keepc -o ./vnew cmd/v`
- `./vnew -silent vlib/v3/tests/c_global_c_type_storage_codegen_test.v`
- `./vnew -silent test vlib/v3/gen/c/`
- `./vnew -silent vlib/v/compiler_errors_test.v`
- `./vnew -silent test vlib/v/tests/fns/closure_of_method_defined_on_alias_test.v`
- standalone V3 build, compile, and execution of `vlib/v/tests/fns/closure_of_method_defined_on_alias_test.v`
