### PR TITLE
vself: support -b fastc

### DIFF
--- a/cmd/tools/vself.v
+++ b/cmd/tools/vself.v
@@ -30,6 +30,10 @@ fn main() {
 	os.setenv('VCOLORS', 'always', true)
 	repeat_count, mut args := extract_repeat_count(args_[1..].filter(it != 'self'))
 	fastc_self_build := uses_fastc_backend(args)
+	if fastc_self_build && '-prod' in args {
+		eprintln('`v self -b fastc` does not support `-prod`; remove `-prod`.')
+		exit(1)
+	}
 	if fastc_self_build {
 		args = normalize_fastc_backend_args(args)
 	}

--- a/cmd/tools/vself.v
+++ b/cmd/tools/vself.v
@@ -11,7 +11,8 @@ const is_debug = args_.contains('-debug')
 const vexe = os.getenv_opt('VEXE') or { @VEXE }
 
 const vroot = os.dir(vexe)
-const vself_flags_with_values = ['-o', '-os', '-cc', '-gc', '-cf', '-cflags', '-d', '-define']
+const vself_flags_with_values = ['-o', '-os', '-cc', '-gc', '-cf', '-cflags', '-d', '-define',
+	'-b', '-backend']
 
 fn main() {
 	// make testing `v up` easier, by providing a way to force `v self` to fail,
@@ -28,7 +29,9 @@ fn main() {
 	os.chdir(vroot)!
 	os.setenv('VCOLORS', 'always', true)
 	repeat_count, mut args := extract_repeat_count(args_[1..].filter(it != 'self'))
-	if args.len == 0 || ('-cc' !in args && '-prod' !in args && '-parallel-cc' !in args) {
+	fastc_self_build := uses_fastc_backend(args)
+	if !fastc_self_build
+		&& (args.len == 0 || ('-cc' !in args && '-prod' !in args && '-parallel-cc' !in args)) {
 		// compiling by default, i.e. `v self`:
 		uos := os.user_os()
 		uname := os.uname()
@@ -51,11 +54,13 @@ fn main() {
 	sargs := if obinary != '' { jargs } else { '${jargs} -o v2' }
 	options := if args.len > 0 { '(${sargs})' } else { '' }
 	final_binary := if obinary != '' { obinary } else { 'v2' }
-	pgo_cc_kind := pgo_compiler_kind(args)
+	pgo_cc_kind := if fastc_self_build { '' } else { pgo_compiler_kind(args) }
+	compilation_source := if fastc_self_build { 'vlib/v3/v3.v' } else { 'cmd/v' }
+	compile_args := if fastc_self_build { '${sargs} -selfhost' } else { sargs }
 	for run_idx in 0 .. repeat_count {
 		run_label := if repeat_count > 1 { ' [${run_idx + 1}/${repeat_count}]' } else { '' }
 		println('V self compiling${run_label} ${options}...')
-		cmd := '${os.quoted_path(vexe)} ${sargs} ${os.quoted_path('cmd/v')}'
+		cmd := '${os.quoted_path(vexe)} ${compile_args} ${os.quoted_path(compilation_source)}'
 		mut used_pgo := false
 		if pgo_cc_kind != '' {
 			used_pgo = compile_with_pgo(vroot, vexe, args, final_binary, pgo_cc_kind)
@@ -63,7 +68,12 @@ fn main() {
 				eprintln('PGO self-build failed; falling back to a regular self-build.')
 			}
 		}
-		if !used_pgo {
+		if fastc_self_build {
+			run_cmd(cmd) or {
+				eprintln('cannot compile to `${vroot}`: \n${err.msg()}')
+				exit(1)
+			}
+		} else if !used_pgo {
 			if !try_compile(cmd) {
 				bootstrap_self_build(vroot, clone_args(args), final_binary) or {
 					eprintln('cannot compile to `${vroot}`: \n${err.msg()}')
@@ -79,6 +89,20 @@ fn main() {
 		return
 	}
 	println('V built successfully as executable "${vexe_name}".')
+}
+
+fn uses_fastc_backend(args []string) bool {
+	mut backend := ''
+	mut i := 0
+	for i < args.len {
+		if args[i] in ['-b', '-backend'] && i + 1 < args.len {
+			backend = args[i + 1]
+			i += 2
+			continue
+		}
+		i++
+	}
+	return backend == 'fastc'
 }
 
 fn repeat_count_arg(arg string) int {

--- a/cmd/tools/vself.v
+++ b/cmd/tools/vself.v
@@ -134,12 +134,17 @@ fn uses_fastc_backend(args []string) bool {
 	mut backend := ''
 	mut i := 0
 	for i < args.len {
-		if args[i] in ['-b', '-backend'] && i + 1 < args.len {
+		arg := args[i]
+		if arg in ['-b', '-backend'] && i + 1 < args.len {
 			backend = args[i + 1]
 			i += 2
 			continue
 		}
-		i++
+		if (arg == '-cf' || pref.option_may_consume_value(arg)) && i + 1 < args.len {
+			i += 2
+		} else {
+			i++
+		}
 	}
 	return backend == 'fastc'
 }
@@ -148,12 +153,18 @@ fn normalize_fastc_backend_args(args []string) []string {
 	mut normalized := []string{cap: args.len}
 	mut i := 0
 	for i < args.len {
-		if args[i] in ['-b', '-backend'] && i + 1 < args.len {
+		arg := args[i]
+		if arg in ['-b', '-backend'] && i + 1 < args.len {
 			i += 2
 			continue
 		}
-		normalized << args[i]
-		i++
+		normalized << arg
+		if (arg == '-cf' || pref.option_may_consume_value(arg)) && i + 1 < args.len {
+			normalized << args[i + 1]
+			i += 2
+		} else {
+			i++
+		}
 	}
 	normalized << ['-b', 'fastc']
 	return normalized

--- a/cmd/tools/vself.v
+++ b/cmd/tools/vself.v
@@ -145,12 +145,11 @@ fn unsupported_fastc_repeat_args(args []string) []string {
 	mut i := 0
 	for i < args.len {
 		arg := args[i]
-		if arg in ['-b', '-gc', '-cc'] && i + 1 < args.len {
+		if arg in ['-b', '-gc'] && i + 1 < args.len {
 			value := args[i + 1]
 			supported := match arg {
 				'-b' { value == 'fastc' }
 				'-gc' { value == 'none' }
-				'-cc' { value in ['tinyc', 'tcc'] }
 				else { false }
 			}
 			if !supported {

--- a/cmd/tools/vself.v
+++ b/cmd/tools/vself.v
@@ -30,6 +30,9 @@ fn main() {
 	os.setenv('VCOLORS', 'always', true)
 	repeat_count, mut args := extract_repeat_count(args_[1..].filter(it != 'self'))
 	fastc_self_build := uses_fastc_backend(args)
+	if fastc_self_build {
+		args = normalize_fastc_backend_args(args)
+	}
 	if !fastc_self_build
 		&& (args.len == 0 || ('-cc' !in args && '-prod' !in args && '-parallel-cc' !in args)) {
 		// compiling by default, i.e. `v self`:
@@ -39,7 +42,7 @@ fn main() {
 			// Apple silicon, like m1, m2 etc
 			// Use tcc by default for V, since tinycc is much faster and also
 			// it already supports compiling many programs like V itself, that do not depend on inlined objective-C code
-			args << '-cc tcc'
+			args << ['-cc', 'tcc']
 		} else if uos == 'linux' && uname.machine in ['arm64', 'aarch64'] {
 			// Bundled TCC can hang while bootstrapping V on Linux ARM64, so
 			// prefer the system compiler for self-builds there.
@@ -49,18 +52,22 @@ fn main() {
 	if !has_gc_arg(args) {
 		args << ['-gc', 'none']
 	}
-	jargs := args.join(' ')
 	obinary := cmdline.option(args, '-o', '')
-	sargs := if obinary != '' { jargs } else { '${jargs} -o v2' }
-	options := if args.len > 0 { '(${sargs})' } else { '' }
+	mut compile_args := clone_args(args)
+	if obinary == '' {
+		compile_args << ['-o', 'v2']
+	}
+	if fastc_self_build {
+		compile_args << '-selfhost'
+	}
+	options := if args.len > 0 { '(${compile_args.join(' ')})' } else { '' }
 	final_binary := if obinary != '' { obinary } else { 'v2' }
 	pgo_cc_kind := if fastc_self_build { '' } else { pgo_compiler_kind(args) }
 	compilation_source := if fastc_self_build { 'vlib/v3/v3.v' } else { 'cmd/v' }
-	compile_args := if fastc_self_build { '${sargs} -selfhost' } else { sargs }
 	for run_idx in 0 .. repeat_count {
 		run_label := if repeat_count > 1 { ' [${run_idx + 1}/${repeat_count}]' } else { '' }
 		println('V self compiling${run_label} ${options}...')
-		cmd := '${os.quoted_path(vexe)} ${compile_args} ${os.quoted_path(compilation_source)}'
+		cmd := compose_v_cmd(vexe, compile_args, compilation_source)
 		mut used_pgo := false
 		if pgo_cc_kind != '' {
 			used_pgo = compile_with_pgo(vroot, vexe, args, final_binary, pgo_cc_kind)
@@ -103,6 +110,21 @@ fn uses_fastc_backend(args []string) bool {
 		i++
 	}
 	return backend == 'fastc'
+}
+
+fn normalize_fastc_backend_args(args []string) []string {
+	mut normalized := []string{cap: args.len}
+	mut i := 0
+	for i < args.len {
+		if args[i] in ['-b', '-backend'] && i + 1 < args.len {
+			i += 2
+			continue
+		}
+		normalized << args[i]
+		i++
+	}
+	normalized << ['-b', 'fastc']
+	return normalized
 }
 
 fn repeat_count_arg(arg string) int {

--- a/cmd/tools/vself.v
+++ b/cmd/tools/vself.v
@@ -28,7 +28,7 @@ fn main() {
 		'Please install V from source, to use `${vexe_name} self` .')
 	os.chdir(vroot)!
 	os.setenv('VCOLORS', 'always', true)
-	repeat_count, mut args := extract_repeat_count(args_[1..].filter(it != 'self'))
+	repeat_count, mut args := extract_repeat_count(args_[1..])
 	fastc_self_build := uses_fastc_backend(args)
 	if fastc_self_build && '-prod' in args {
 		eprintln('`v self -b fastc` does not support `-prod`; remove `-prod`.')
@@ -148,6 +148,7 @@ fn extract_repeat_count(args []string) (int, []string) {
 	mut repeat_count := 1
 	mut filtered := []string{cap: args.len}
 	mut should_skip_repeat_check := false
+	mut removed_self_command := false
 	for arg in args {
 		if should_skip_repeat_check {
 			filtered << arg
@@ -157,6 +158,10 @@ fn extract_repeat_count(args []string) (int, []string) {
 		if arg in vself_flags_with_values {
 			filtered << arg
 			should_skip_repeat_check = true
+			continue
+		}
+		if !removed_self_command && arg == 'self' {
+			removed_self_command = true
 			continue
 		}
 		if repeat_count == 1 {

--- a/cmd/tools/vself.v
+++ b/cmd/tools/vself.v
@@ -28,7 +28,9 @@ fn main() {
 		'Please install V from source, to use `${vexe_name} self` .')
 	os.chdir(vroot)!
 	os.setenv('VCOLORS', 'always', true)
-	repeat_count, mut args := extract_repeat_count(args_[1..])
+	vflags_count := os.getenv('VSELF_VFLAGS_COUNT').int()
+	os.unsetenv('VSELF_VFLAGS_COUNT')
+	repeat_count, mut args := extract_repeat_count(args_[1..], vflags_count)
 	fastc_self_build := uses_fastc_backend(args)
 	if fastc_self_build && '-prod' in args {
 		eprintln('`v self -b fastc` does not support `-prod`; remove `-prod`.')
@@ -64,14 +66,19 @@ fn main() {
 	if fastc_self_build {
 		compile_args << '-selfhost'
 	}
-	options := if args.len > 0 { '(${compile_args.join(' ')})' } else { '' }
 	final_binary := if obinary != '' { obinary } else { 'v2' }
 	pgo_cc_kind := if fastc_self_build { '' } else { pgo_compiler_kind(args) }
 	compilation_source := if fastc_self_build { 'vlib/v3/v3.v' } else { 'cmd/v' }
 	for run_idx in 0 .. repeat_count {
 		run_label := if repeat_count > 1 { ' [${run_idx + 1}/${repeat_count}]' } else { '' }
+		run_compile_args := if fastc_self_build && obinary == '' && run_idx > 0 {
+			fastc_descendant_compile_args(compile_args, final_binary)
+		} else {
+			compile_args
+		}
+		options := if args.len > 0 { '(${run_compile_args.join(' ')})' } else { '' }
 		println('V self compiling${run_label} ${options}...')
-		cmd := compose_v_cmd(vexe, compile_args, compilation_source)
+		cmd := compose_v_cmd(vexe, run_compile_args, compilation_source)
 		mut used_pgo := false
 		if pgo_cc_kind != '' {
 			used_pgo = compile_with_pgo(vroot, vexe, args, final_binary, pgo_cc_kind)
@@ -131,6 +138,19 @@ fn normalize_fastc_backend_args(args []string) []string {
 	return normalized
 }
 
+fn fastc_descendant_compile_args(args []string, output string) []string {
+	// The standalone FastC driver has a deliberately narrow CLI. Once it replaces
+	// v, retain only the self-build arguments that it can honor.
+	mut descendant_args := []string{cap: 9}
+	for arg in args {
+		if arg in ['-silent', '-keepc'] && arg !in descendant_args {
+			descendant_args << arg
+		}
+	}
+	descendant_args << ['-b', 'fastc', '-gc', 'none', '-o', output, '-selfhost']
+	return descendant_args
+}
+
 fn repeat_count_arg(arg string) int {
 	if arg.len < 2 || arg[0] != `x` {
 		return 0
@@ -144,12 +164,14 @@ fn repeat_count_arg(arg string) int {
 	return if count > 0 { count } else { 0 }
 }
 
-fn extract_repeat_count(args []string) (int, []string) {
+fn extract_repeat_count(args []string, protected_prefix_count int) (int, []string) {
 	mut repeat_count := 1
 	mut filtered := []string{cap: args.len}
 	mut should_skip_repeat_check := false
 	mut removed_self_command := false
-	for arg in args {
+	prefix_count := int_min(int_max(protected_prefix_count, 0), args.len)
+	filtered << args[..prefix_count]
+	for arg in args[prefix_count..] {
 		if should_skip_repeat_check {
 			filtered << arg
 			should_skip_repeat_check = false

--- a/cmd/tools/vself.v
+++ b/cmd/tools/vself.v
@@ -2,6 +2,7 @@ module main
 
 import os
 import os.cmdline
+import v.pref
 import v.util.recompilation
 
 const args_ = arguments()
@@ -11,8 +12,6 @@ const is_debug = args_.contains('-debug')
 const vexe = os.getenv_opt('VEXE') or { @VEXE }
 
 const vroot = os.dir(vexe)
-const vself_flags_with_values = ['-o', '-os', '-cc', '-gc', '-cf', '-cflags', '-d', '-define',
-	'-b', '-backend']
 
 fn main() {
 	// make testing `v up` easier, by providing a way to force `v self` to fail,
@@ -28,9 +27,9 @@ fn main() {
 		'Please install V from source, to use `${vexe_name} self` .')
 	os.chdir(vroot)!
 	os.setenv('VCOLORS', 'always', true)
-	vflags_count := os.getenv('VSELF_VFLAGS_COUNT').int()
-	os.unsetenv('VSELF_VFLAGS_COUNT')
-	repeat_count, mut args := extract_repeat_count(args_[1..], vflags_count)
+	command_index := os.getenv('VSELF_COMMAND_INDEX').int()
+	os.unsetenv('VSELF_COMMAND_INDEX')
+	repeat_count, mut args := extract_repeat_count(args_[1..], command_index)
 	fastc_self_build := uses_fastc_backend(args)
 	if fastc_self_build && '-prod' in args {
 		eprintln('`v self -b fastc` does not support `-prod`; remove `-prod`.')
@@ -59,6 +58,14 @@ fn main() {
 		args << ['-gc', 'none']
 	}
 	obinary := cmdline.option(args, '-o', '')
+	if fastc_self_build && repeat_count > 1 && obinary == '' {
+		unsupported := unsupported_fastc_repeat_args(args)
+		if unsupported.len > 0 {
+			eprintln('`v self -b fastc xN` cannot preserve these options across repeated replacement builds: ${unsupported.join(' ')}')
+			eprintln('Remove the options, use `x1`, or specify `-o` to keep the original compiler.')
+			exit(1)
+		}
+	}
 	mut compile_args := clone_args(args)
 	if obinary == '' {
 		compile_args << ['-o', 'v2']
@@ -71,14 +78,9 @@ fn main() {
 	compilation_source := if fastc_self_build { 'vlib/v3/v3.v' } else { 'cmd/v' }
 	for run_idx in 0 .. repeat_count {
 		run_label := if repeat_count > 1 { ' [${run_idx + 1}/${repeat_count}]' } else { '' }
-		run_compile_args := if fastc_self_build && obinary == '' && run_idx > 0 {
-			fastc_descendant_compile_args(compile_args, final_binary)
-		} else {
-			compile_args
-		}
-		options := if args.len > 0 { '(${run_compile_args.join(' ')})' } else { '' }
+		options := if args.len > 0 { '(${compile_args.join(' ')})' } else { '' }
 		println('V self compiling${run_label} ${options}...')
-		cmd := compose_v_cmd(vexe, run_compile_args, compilation_source)
+		cmd := compose_v_cmd(vexe, compile_args, compilation_source)
 		mut used_pgo := false
 		if pgo_cc_kind != '' {
 			used_pgo = compile_with_pgo(vroot, vexe, args, final_binary, pgo_cc_kind)
@@ -138,17 +140,39 @@ fn normalize_fastc_backend_args(args []string) []string {
 	return normalized
 }
 
-fn fastc_descendant_compile_args(args []string, output string) []string {
-	// The standalone FastC driver has a deliberately narrow CLI. Once it replaces
-	// v, retain only the self-build arguments that it can honor.
-	mut descendant_args := []string{cap: 9}
-	for arg in args {
-		if arg in ['-silent', '-keepc'] && arg !in descendant_args {
-			descendant_args << arg
+fn unsupported_fastc_repeat_args(args []string) []string {
+	mut unsupported := []string{}
+	mut i := 0
+	for i < args.len {
+		arg := args[i]
+		if arg in ['-b', '-gc', '-cc'] && i + 1 < args.len {
+			value := args[i + 1]
+			supported := match arg {
+				'-b' { value == 'fastc' }
+				'-gc' { value == 'none' }
+				'-cc' { value in ['tinyc', 'tcc'] }
+				else { false }
+			}
+			if !supported {
+				unsupported << '${arg} ${value}'
+			}
+			i += 2
+			continue
 		}
+		if arg in ['-silent', '-keepc'] {
+			i++
+			continue
+		}
+		mut option := arg
+		if (arg == '-cf' || pref.option_may_consume_value(arg)) && i + 1 < args.len {
+			option += ' ${args[i + 1]}'
+			i += 2
+		} else {
+			i++
+		}
+		unsupported << option
 	}
-	descendant_args << ['-b', 'fastc', '-gc', 'none', '-o', output, '-selfhost']
-	return descendant_args
+	return unsupported
 }
 
 fn repeat_count_arg(arg string) int {
@@ -177,7 +201,7 @@ fn extract_repeat_count(args []string, protected_prefix_count int) (int, []strin
 			should_skip_repeat_check = false
 			continue
 		}
-		if arg in vself_flags_with_values {
+		if arg == '-cf' || pref.option_may_consume_value(arg) {
 			filtered << arg
 			should_skip_repeat_check = true
 			continue

--- a/cmd/tools/vself.v
+++ b/cmd/tools/vself.v
@@ -57,7 +57,7 @@ fn main() {
 	if !has_gc_arg(args) {
 		args << ['-gc', 'none']
 	}
-	obinary := cmdline.option(args, '-o', '')
+	obinary := self_build_output(args)
 	if fastc_self_build && repeat_count > 1 && obinary == '' {
 		unsupported := unsupported_fastc_repeat_args(args)
 		if unsupported.len > 0 {
@@ -109,6 +109,25 @@ fn main() {
 		return
 	}
 	println('V built successfully as executable "${vexe_name}".')
+}
+
+fn self_build_output(args []string) string {
+	mut output := ''
+	mut i := 0
+	for i < args.len {
+		arg := args[i]
+		if arg in ['-o', '-output'] && i + 1 < args.len {
+			output = args[i + 1]
+			i += 2
+			continue
+		}
+		if (arg == '-cf' || pref.option_may_consume_value(arg)) && i + 1 < args.len {
+			i += 2
+		} else {
+			i++
+		}
+	}
+	return output
 }
 
 fn uses_fastc_backend(args []string) bool {

--- a/cmd/v/v.v
+++ b/cmd/v/v.v
@@ -128,7 +128,8 @@ fn main() {
 		return
 	}
 	mut args_and_flags := util.join_env_vflags_and_os_args()[1..]
-	prefs, command := pref.parse_args_for_launcher(external_tools, args_and_flags, true)
+	prefs, command, command_idx := pref.parse_args_for_launcher_with_command_index(external_tools,
+		args_and_flags, true)
 	maybe_delegate_to_vvmrc(command, prefs)
 	maybe_delegate_to_ownership(command, prefs, args_and_flags)
 	macos_v3_c_error_report := maybe_delegate_to_macos_v3(command, prefs)
@@ -148,15 +149,10 @@ fn main() {
 		if command == 'self' {
 			// vself forwards compiler flags to the compiler it builds. Pass merged
 			// VFLAGS once as arguments, then keep them out of vself's own recompilation.
-			// Preserve their boundary so vself never interprets a flag value as one of
-			// its positional arguments.
+			// Preserve the parser's authoritative command boundary so vself never
+			// interprets a flag value as one of its positional arguments.
 			tool_args = args_and_flags.clone()
-			process_args := os.args[1..]
-			mut merged_prefix_count := args_and_flags.len - process_args.len
-			if merged_prefix_count < 0 || args_and_flags[merged_prefix_count..] != process_args {
-				merged_prefix_count = 0
-			}
-			os.setenv('VSELF_VFLAGS_COUNT', merged_prefix_count.str(), true)
+			os.setenv('VSELF_COMMAND_INDEX', command_idx.str(), true)
 			os.unsetenv('VFLAGS')
 			os.unsetenv('VOSARGS')
 		}

--- a/cmd/v/v.v
+++ b/cmd/v/v.v
@@ -144,7 +144,15 @@ fn main() {
 	// Note for future contributors: Please add new subcommands in the `match` block below.
 	if command in external_tools {
 		// External tools
-		util.launch_tool(prefs.is_verbose, 'v' + command, os.args[1..])
+		mut tool_args := os.args[1..].clone()
+		if command == 'self' {
+			// vself forwards compiler flags to the compiler it builds. Pass merged
+			// VFLAGS once as arguments, then keep them out of vself's own recompilation.
+			tool_args = args_and_flags.clone()
+			os.unsetenv('VFLAGS')
+			os.unsetenv('VOSARGS')
+		}
+		util.launch_tool(prefs.is_verbose, 'v' + command, tool_args)
 		return
 	}
 	match command {

--- a/cmd/v/v.v
+++ b/cmd/v/v.v
@@ -148,7 +148,15 @@ fn main() {
 		if command == 'self' {
 			// vself forwards compiler flags to the compiler it builds. Pass merged
 			// VFLAGS once as arguments, then keep them out of vself's own recompilation.
+			// Preserve their boundary so vself never interprets a flag value as one of
+			// its positional arguments.
 			tool_args = args_and_flags.clone()
+			process_args := os.args[1..]
+			mut merged_prefix_count := args_and_flags.len - process_args.len
+			if merged_prefix_count < 0 || args_and_flags[merged_prefix_count..] != process_args {
+				merged_prefix_count = 0
+			}
+			os.setenv('VSELF_VFLAGS_COUNT', merged_prefix_count.str(), true)
 			os.unsetenv('VFLAGS')
 			os.unsetenv('VOSARGS')
 		}

--- a/vlib/v/help/default.txt
+++ b/vlib/v/help/default.txt
@@ -62,8 +62,8 @@ V supports the following commands:
 * Installation Management Utilities:
   symlink                      Create a symbolic link for V.
   up                           Run the V self-updater.
-  self [-prod] [-b backend]    Run the V self-compiler, use -prod to optimize
-                               compilation.
+  self [-prod | -b fastc]      Run the V self-compiler. Use -prod to optimize
+                               C builds; FastC self-builds do not support it.
   version                      Print the version text and exits.
 
 * Package Management Utilities:

--- a/vlib/v/help/default.txt
+++ b/vlib/v/help/default.txt
@@ -62,7 +62,7 @@ V supports the following commands:
 * Installation Management Utilities:
   symlink                      Create a symbolic link for V.
   up                           Run the V self-updater.
-  self [-prod]                 Run the V self-compiler, use -prod to optimize
+  self [-prod] [-b backend]    Run the V self-compiler, use -prod to optimize
                                compilation.
   version                      Print the version text and exits.
 

--- a/vlib/v/help/installation/self.txt
+++ b/vlib/v/help/installation/self.txt
@@ -10,3 +10,5 @@ Options:
   With -prod and clang/gcc, `v self` may use PGO automatically when tools are available.
   On macOS and Linux, `-b fastc` builds the standalone experimental V3 FastC compiler.
   `-prod` cannot be combined with `-b fastc`.
+  FastC replacement builds (`xN` without `-o`) reject options that the standalone compiler
+  cannot preserve across every generation.

--- a/vlib/v/help/installation/self.txt
+++ b/vlib/v/help/installation/self.txt
@@ -6,3 +6,4 @@ Usage:
 Options:
   All other options are passed to the build command. (e.g. -prod)
   With -prod and clang/gcc, `v self` may use PGO automatically when tools are available.
+  On macOS and Linux, `-b fastc` builds the standalone experimental V3 FastC compiler.

--- a/vlib/v/help/installation/self.txt
+++ b/vlib/v/help/installation/self.txt
@@ -2,8 +2,11 @@ Rebuild V with the passed options.
 
 Usage:
   v self
+  v self -prod
+  v self -b fastc
 
 Options:
   All other options are passed to the build command. (e.g. -prod)
   With -prod and clang/gcc, `v self` may use PGO automatically when tools are available.
   On macOS and Linux, `-b fastc` builds the standalone experimental V3 FastC compiler.
+  `-prod` cannot be combined with `-b fastc`.

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -429,7 +429,8 @@ fn optional_arg_value(args []string, idx int, command string, known_external_com
 }
 
 pub fn parse_args_and_show_errors(known_external_commands []string, args []string, show_output bool) (&Preferences, string) {
-	return parse_args_impl(known_external_commands, args, show_output, false)
+	prefs, command, _ := parse_args_impl(known_external_commands, args, show_output, false)
+	return prefs, command
 }
 
 // parse_args_for_launcher works like parse_args_and_show_errors, but once a known external command
@@ -438,10 +439,29 @@ pub fn parse_args_and_show_errors(known_external_commands []string, args []strin
 // the original os.args on to the tool verbatim. Do NOT use it when you actually need the V
 // preferences that follow the command name, for example `v fmt -translated file.v`; see vlang/v#28114.
 pub fn parse_args_for_launcher(known_external_commands []string, args []string, show_output bool) (&Preferences, string) {
+	prefs, command, _ := parse_args_impl(known_external_commands, args, show_output, true)
+	return prefs, command
+}
+
+// parse_args_for_launcher_with_command_index also returns the exact command token index.
+pub fn parse_args_for_launcher_with_command_index(known_external_commands []string, args []string, show_output bool) (&Preferences, string, int) {
 	return parse_args_impl(known_external_commands, args, show_output, true)
 }
 
-fn parse_args_impl(known_external_commands []string, args []string, show_output bool, pass_external_command_args bool) (&Preferences, string) {
+// option_may_consume_value reports whether an option can consume the following argument.
+pub fn option_may_consume_value(option string) bool {
+	return option in ['-wasm-stack-top', '-arch', '-assert', '-e', '-subsystem', '-icon', '--icon',
+		'-seticon', '--seticon', '-gc', '-print_autofree_vars_in_fn', '-trace-fns', '-prof',
+		'-profile', '-cov', '-coverage', '-profile-fns', '-bug-report-url', '-run-only', '-exclude',
+		'-file-list', '-test-runner', '-dump-c-flags', '-dump-modules', '-dump-files',
+		'-dump-defines', '-generate-c-project', '-macosx-version-min', '-os', '-printfn', '-cflags',
+		'-ldflags', '-d', '-define', '-message-limit', '-thread-stack-size', '-cc', '-c++',
+		'-checker-match-exhaustive-cutoff-limit', '-o', '-output', '-b', '-backend',
+		'-compile-backend', '--compile-backend', '-path', '-bare-builtin-dir', '-custom-prelude',
+		'-raw-vsh-tmp-prefix', '-cmain', '-line-info']
+}
+
+fn parse_args_impl(known_external_commands []string, args []string, show_output bool, pass_external_command_args bool) (&Preferences, string, int) {
 	mut res := &Preferences{}
 	detect_musl(mut res)
 	$if x64 {
@@ -1414,7 +1434,7 @@ fn parse_args_impl(known_external_commands []string, args []string, show_output 
 		}
 	}
 
-	return res, command
+	return res, command, command_idx
 }
 
 @[noreturn]

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -571,6 +571,9 @@ fn parse_args_impl(known_external_commands []string, args []string, show_output 
 				res.new_compiler = true
 				new_compiler_set_by_flag = true
 			}
+			'-selfhost' {
+				// Passed through to the embedded V3 driver for FastC compiler builds.
+			}
 			'-checker-fixture', '-macos-v3-compat-c99' {
 				// Passed through to the embedded V3 diagnostic fixture runner.
 			}

--- a/vlib/v/pref/pref_test.v
+++ b/vlib/v/pref/pref_test.v
@@ -147,6 +147,17 @@ fn test_launcher_leaves_flags_after_a_known_external_command_for_the_tool() {
 	assert prefs.eval_argument == ''
 }
 
+fn test_launcher_reports_external_command_index() {
+	_, command, command_idx := pref.parse_args_for_launcher_with_command_index([
+		'self',
+	], ['-exclude', 'x2', 'self', '-o', 'vnew'], false)
+	assert command == 'self'
+	assert command_idx == 2
+	assert pref.option_may_consume_value('-exclude')
+	assert pref.option_may_consume_value('-profile')
+	assert !pref.option_may_consume_value('-g')
+}
+
 fn test_non_launcher_parse_keeps_v_flags_after_the_command() {
 	// vfmt and similar tools recognize their own command name (`fmt`), but still rely on the
 	// general V preference flags that follow it. The default parser (non-launcher mode) must

--- a/vlib/v3/gen/fastc/render.v
+++ b/vlib/v3/gen/fastc/render.v
@@ -567,8 +567,9 @@ fn (g &Parser) render_empty_struct_initializer(c_type string) string {
 		}
 		return '(${c_type}){0}'
 	}
-	return g.render_struct_literal_with_defaults(c_type, layout_type, []string{}, rendered_fields,
-		rendered_fields_by_name).source
+	empty_initializers := []string{}
+	return g.render_struct_literal_with_defaults(c_type, layout_type, empty_initializers,
+		rendered_fields, rendered_fields_by_name).source
 }
 
 fn (g &Parser) render_named_struct_initializer(c_type string, fields [][]FastcExpressionToken) ?string {

--- a/vlib/v3/tests/fastc_backend_test.v
+++ b/vlib/v3/tests/fastc_backend_test.v
@@ -24,9 +24,13 @@ fn test_v_self_accepts_fastc_backend() {
 	defer {
 		os.rmdir_all(root) or {}
 	}
-	selfhost_binary := os.join_path(root, 'vfastc')
-	self_build := cmdexec.run(@VEXE, ['self', '-silent', '-b', 'fastc', '-o', selfhost_binary])
+	selfhost_binary := os.join_path(root, 'v fastc')
+	self_build := cmdexec.run(@VEXE, ['self', '-silent', '-backend', 'fastc', 'x2', '-o',
+		selfhost_binary])
 	assert self_build.exit_code == 0, self_build.output
+	assert self_build.output.count('V self compiling') == 2, self_build.output
+	assert self_build.output.contains('-b fastc'), self_build.output
+	assert !self_build.output.contains('-backend fastc'), self_build.output
 	assert os.is_executable(selfhost_binary)
 	source := os.join_path(root, 'main.v')
 	write_fastc_test_source(source, 'module main\nfn main() { println(42) }\n')

--- a/vlib/v3/tests/fastc_backend_test.v
+++ b/vlib/v3/tests/fastc_backend_test.v
@@ -3,6 +3,7 @@ import v3.cmdexec
 
 const fastc_backend_v3_dir = os.dir(os.dir(@FILE))
 const fastc_backend_vlib_dir = os.dir(fastc_backend_v3_dir)
+const fastc_backend_vroot = os.dir(fastc_backend_vlib_dir)
 const fastc_backend_v3_source = os.join_path(fastc_backend_v3_dir, 'v3.v')
 
 struct UnsupportedFastCInvocation {
@@ -14,9 +15,10 @@ fn write_fastc_test_source(path string, source string) {
 	os.write_file(path, source) or { panic(err) }
 }
 
-fn run_with_vflags(program string, args []string, flags string) os.Result {
+fn run_with_v_environment(program string, args []string, flags string, vexe string) os.Result {
 	old_vflags := os.getenv_opt('VFLAGS')
 	old_vosargs := os.getenv_opt('VOSARGS')
+	old_vexe := os.getenv_opt('VEXE')
 	defer {
 		if value := old_vflags {
 			os.setenv('VFLAGS', value, true)
@@ -28,9 +30,19 @@ fn run_with_vflags(program string, args []string, flags string) os.Result {
 		} else {
 			os.unsetenv('VOSARGS')
 		}
+		if value := old_vexe {
+			os.setenv('VEXE', value, true)
+		} else {
+			os.unsetenv('VEXE')
+		}
 	}
-	os.setenv('VFLAGS', flags, true)
+	if flags == '' {
+		os.unsetenv('VFLAGS')
+	} else {
+		os.setenv('VFLAGS', flags, true)
+	}
 	os.unsetenv('VOSARGS')
+	os.setenv('VEXE', vexe, true)
 	return cmdexec.run(program, args)
 }
 
@@ -44,10 +56,19 @@ fn test_v_self_accepts_fastc_backend() {
 	defer {
 		os.rmdir_all(root) or {}
 	}
+	vflags_value_binary := os.join_path(root, 'v from x2 value')
+	vflags_value_build := run_with_v_environment(@VEXE,
+		['self', '-silent', '-o', vflags_value_binary], '-exclude x2', @VEXE)
+	assert vflags_value_build.exit_code == 0, vflags_value_build.output
+	assert vflags_value_build.output.count('V self compiling') == 1, vflags_value_build.output
+	assert vflags_value_build.output.contains('-exclude x2'), vflags_value_build.output
+	assert os.is_executable(vflags_value_binary)
+
 	vflags_binary := os.join_path(root, 'v fastc from vflags')
-	vflags_self_build := run_with_vflags(@VEXE, ['self', '-silent', '-o', vflags_binary],
-		'-d self -b fastc')
+	vflags_self_build := run_with_v_environment(@VEXE, ['self', '-silent', '-o', vflags_binary],
+		'-d self -b fastc', @VEXE)
 	assert vflags_self_build.exit_code == 0, vflags_self_build.output
+	assert vflags_self_build.output.count('V self compiling') == 1, vflags_self_build.output
 	assert vflags_self_build.output.contains('-d self'), vflags_self_build.output
 	assert vflags_self_build.output.contains('-b fastc'), vflags_self_build.output
 	assert os.is_executable(vflags_binary)
@@ -60,6 +81,25 @@ fn test_v_self_accepts_fastc_backend() {
 	assert self_build.output.contains('-b fastc'), self_build.output
 	assert !self_build.output.contains('-backend fastc'), self_build.output
 	assert os.is_executable(selfhost_binary)
+
+	isolated_vroot := os.join_path(root, 'isolated_vroot')
+	os.mkdir_all(isolated_vroot) or { panic(err) }
+	for directory in ['cmd', 'vlib', 'thirdparty'] {
+		os.symlink(os.join_path(fastc_backend_vroot, directory), os.join_path(isolated_vroot,
+			directory)) or { panic(err) }
+	}
+	isolated_vexe := os.join_path(isolated_vroot, 'v')
+	os.cp(@VEXE, isolated_vexe) or { panic(err) }
+	descendant_unsupported_flag := $if linux { '-g' } $else { '-no-parallel' }
+	repeated_build := run_with_v_environment(isolated_vexe, ['self', '-silent', '-b', 'fastc',
+		descendant_unsupported_flag, 'x2'], '', isolated_vexe)
+	assert repeated_build.exit_code == 0, repeated_build.output
+	compiling_lines :=
+		repeated_build.output.split_into_lines().filter(it.contains('V self compiling'))
+	assert compiling_lines.len == 2, repeated_build.output
+	assert compiling_lines[0].contains(descendant_unsupported_flag), repeated_build.output
+	assert !compiling_lines[1].contains(descendant_unsupported_flag), repeated_build.output
+	assert os.is_executable(isolated_vexe)
 
 	prod_build := cmdexec.run(@VEXE, ['self', '-silent', '-prod', '-b', 'fastc', '-o',
 		os.join_path(root, 'v prod')])

--- a/vlib/v3/tests/fastc_backend_test.v
+++ b/vlib/v3/tests/fastc_backend_test.v
@@ -57,11 +57,12 @@ fn test_v_self_accepts_fastc_backend() {
 		os.rmdir_all(root) or {}
 	}
 	vflags_value_binary := os.join_path(root, 'v from x2 value')
-	vflags_value_build := run_with_v_environment(@VEXE,
-		['self', '-silent', '-o', vflags_value_binary], '-exclude x2', @VEXE)
+	vflags_value_build := run_with_v_environment(@VEXE, ['-exclude', 'x2', 'self', '-silent', '-o',
+		vflags_value_binary], '-exclude x3', @VEXE)
 	assert vflags_value_build.exit_code == 0, vflags_value_build.output
 	assert vflags_value_build.output.count('V self compiling') == 1, vflags_value_build.output
 	assert vflags_value_build.output.contains('-exclude x2'), vflags_value_build.output
+	assert vflags_value_build.output.contains('-exclude x3'), vflags_value_build.output
 	assert os.is_executable(vflags_value_binary)
 
 	vflags_binary := os.join_path(root, 'v fastc from vflags')
@@ -90,15 +91,20 @@ fn test_v_self_accepts_fastc_backend() {
 	}
 	isolated_vexe := os.join_path(isolated_vroot, 'v')
 	os.cp(@VEXE, isolated_vexe) or { panic(err) }
-	descendant_unsupported_flag := $if linux { '-g' } $else { '-no-parallel' }
+	unsupported_repeat := run_with_v_environment(isolated_vexe, ['self', '-silent', '-b', 'fastc',
+		'-g', 'x2'], '', isolated_vexe)
+	assert unsupported_repeat.exit_code != 0
+	assert unsupported_repeat.output.contains('cannot preserve'), unsupported_repeat.output
+	assert unsupported_repeat.output.contains('-g'), unsupported_repeat.output
+	assert unsupported_repeat.output.count('V self compiling') == 0, unsupported_repeat.output
+	assert !os.exists(os.join_path(isolated_vroot, 'v_old'))
+
 	repeated_build := run_with_v_environment(isolated_vexe, ['self', '-silent', '-b', 'fastc',
-		descendant_unsupported_flag, 'x2'], '', isolated_vexe)
+		'x2'], '', isolated_vexe)
 	assert repeated_build.exit_code == 0, repeated_build.output
 	compiling_lines :=
 		repeated_build.output.split_into_lines().filter(it.contains('V self compiling'))
 	assert compiling_lines.len == 2, repeated_build.output
-	assert compiling_lines[0].contains(descendant_unsupported_flag), repeated_build.output
-	assert !compiling_lines[1].contains(descendant_unsupported_flag), repeated_build.output
 	assert os.is_executable(isolated_vexe)
 
 	prod_build := cmdexec.run(@VEXE, ['self', '-silent', '-prod', '-b', 'fastc', '-o',

--- a/vlib/v3/tests/fastc_backend_test.v
+++ b/vlib/v3/tests/fastc_backend_test.v
@@ -74,6 +74,16 @@ fn test_v_self_accepts_fastc_backend() {
 	assert vflags_self_build.output.contains('-b fastc'), vflags_self_build.output
 	assert os.is_executable(vflags_binary)
 
+	vflags_backend_value_binary := os.join_path(root, 'v fastc backend value')
+	vflags_backend_value_build := run_with_v_environment(@VEXE, ['self', '-b', 'fastc', '-o',
+		vflags_backend_value_binary], '-exclude -b', @VEXE)
+	assert vflags_backend_value_build.exit_code != 0
+	assert vflags_backend_value_build.output.count('V self compiling') == 1, vflags_backend_value_build.output
+	assert vflags_backend_value_build.output.contains('-exclude -b'), vflags_backend_value_build.output
+	assert !vflags_backend_value_build.output.contains('-exclude fastc'), vflags_backend_value_build.output
+	assert vflags_backend_value_build.output.contains('only supported by the V1 compiler'), vflags_backend_value_build.output
+	assert !os.exists(vflags_backend_value_binary)
+
 	selfhost_binary := os.join_path(root, 'v fastc')
 	self_build := cmdexec.run(@VEXE, ['self', '-silent', '-backend', 'fastc', 'x2', '-o',
 		selfhost_binary])

--- a/vlib/v3/tests/fastc_backend_test.v
+++ b/vlib/v3/tests/fastc_backend_test.v
@@ -91,6 +91,15 @@ fn test_v_self_accepts_fastc_backend() {
 	}
 	isolated_vexe := os.join_path(isolated_vroot, 'v')
 	os.cp(@VEXE, isolated_vexe) or { panic(err) }
+	for ccompiler in ['tcc', 'tinyc'] {
+		unsupported_cc_repeat := run_with_v_environment(isolated_vexe, ['self', '-silent', '-b',
+			'fastc', '-cc', ccompiler, 'x2'], '', isolated_vexe)
+		assert unsupported_cc_repeat.exit_code != 0
+		assert unsupported_cc_repeat.output.contains('cannot preserve'), unsupported_cc_repeat.output
+		assert unsupported_cc_repeat.output.contains('-cc ${ccompiler}'), unsupported_cc_repeat.output
+		assert unsupported_cc_repeat.output.count('V self compiling') == 0, unsupported_cc_repeat.output
+		assert !os.exists(os.join_path(isolated_vroot, 'v_old'))
+	}
 	unsupported_repeat := run_with_v_environment(isolated_vexe, ['self', '-silent', '-b', 'fastc',
 		'-g', 'x2'], '', isolated_vexe)
 	assert unsupported_repeat.exit_code != 0

--- a/vlib/v3/tests/fastc_backend_test.v
+++ b/vlib/v3/tests/fastc_backend_test.v
@@ -14,6 +14,30 @@ fn write_fastc_test_source(path string, source string) {
 	os.write_file(path, source) or { panic(err) }
 }
 
+fn test_v_self_accepts_fastc_backend() {
+	$if !macos && !linux {
+		return
+	}
+	root := os.join_path(os.vtmp_dir(), 'v_self_fastc_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	selfhost_binary := os.join_path(root, 'vfastc')
+	self_build := cmdexec.run(@VEXE, ['self', '-silent', '-b', 'fastc', '-o', selfhost_binary])
+	assert self_build.exit_code == 0, self_build.output
+	assert os.is_executable(selfhost_binary)
+	source := os.join_path(root, 'main.v')
+	write_fastc_test_source(source, 'module main\nfn main() { println(42) }\n')
+	program := os.join_path(root, 'program')
+	compile := cmdexec.run(selfhost_binary, ['-b', 'fastc', '-o', program, source])
+	assert compile.exit_code == 0, compile.output
+	run := cmdexec.run(program, [])
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == '42'
+}
+
 fn test_fastc_backend_parses_directly_to_c_without_ast_fallback() {
 	root := os.join_path(os.vtmp_dir(), 'v3_fastc_backend_${os.getpid()}')
 	os.rmdir_all(root) or {}

--- a/vlib/v3/tests/fastc_backend_test.v
+++ b/vlib/v3/tests/fastc_backend_test.v
@@ -14,6 +14,26 @@ fn write_fastc_test_source(path string, source string) {
 	os.write_file(path, source) or { panic(err) }
 }
 
+fn run_with_vflags(program string, args []string, flags string) os.Result {
+	old_vflags := os.getenv_opt('VFLAGS')
+	old_vosargs := os.getenv_opt('VOSARGS')
+	defer {
+		if value := old_vflags {
+			os.setenv('VFLAGS', value, true)
+		} else {
+			os.unsetenv('VFLAGS')
+		}
+		if value := old_vosargs {
+			os.setenv('VOSARGS', value, true)
+		} else {
+			os.unsetenv('VOSARGS')
+		}
+	}
+	os.setenv('VFLAGS', flags, true)
+	os.unsetenv('VOSARGS')
+	return cmdexec.run(program, args)
+}
+
 fn test_v_self_accepts_fastc_backend() {
 	$if !macos && !linux {
 		return
@@ -24,6 +44,13 @@ fn test_v_self_accepts_fastc_backend() {
 	defer {
 		os.rmdir_all(root) or {}
 	}
+	vflags_binary := os.join_path(root, 'v fastc from vflags')
+	vflags_self_build := run_with_vflags(@VEXE, ['self', '-silent', '-o', vflags_binary],
+		'-b fastc')
+	assert vflags_self_build.exit_code == 0, vflags_self_build.output
+	assert vflags_self_build.output.contains('-b fastc'), vflags_self_build.output
+	assert os.is_executable(vflags_binary)
+
 	selfhost_binary := os.join_path(root, 'v fastc')
 	self_build := cmdexec.run(@VEXE, ['self', '-silent', '-backend', 'fastc', 'x2', '-o',
 		selfhost_binary])
@@ -32,6 +59,12 @@ fn test_v_self_accepts_fastc_backend() {
 	assert self_build.output.contains('-b fastc'), self_build.output
 	assert !self_build.output.contains('-backend fastc'), self_build.output
 	assert os.is_executable(selfhost_binary)
+
+	prod_build := cmdexec.run(@VEXE, ['self', '-silent', '-prod', '-b', 'fastc', '-o',
+		os.join_path(root, 'v prod')])
+	assert prod_build.exit_code != 0
+	assert prod_build.output.contains('does not support `-prod`'), prod_build.output
+
 	source := os.join_path(root, 'main.v')
 	write_fastc_test_source(source, 'module main\nfn main() { println(42) }\n')
 	program := os.join_path(root, 'program')

--- a/vlib/v3/tests/fastc_backend_test.v
+++ b/vlib/v3/tests/fastc_backend_test.v
@@ -91,6 +91,13 @@ fn test_v_self_accepts_fastc_backend() {
 	}
 	isolated_vexe := os.join_path(isolated_vroot, 'v')
 	os.cp(@VEXE, isolated_vexe) or { panic(err) }
+	output_alias_binary := os.join_path(root, 'v fastc output alias')
+	output_alias_build := run_with_v_environment(isolated_vexe, ['self', '-silent', '-b', 'fastc',
+		'-output', output_alias_binary], '', isolated_vexe)
+	assert output_alias_build.exit_code == 0, output_alias_build.output
+	assert output_alias_build.output.count('V self compiling') == 1, output_alias_build.output
+	assert os.is_executable(output_alias_binary)
+	assert !os.exists(os.join_path(isolated_vroot, 'v_old'))
 	for ccompiler in ['tcc', 'tinyc'] {
 		unsupported_cc_repeat := run_with_v_environment(isolated_vexe, ['self', '-silent', '-b',
 			'fastc', '-cc', ccompiler, 'x2'], '', isolated_vexe)

--- a/vlib/v3/tests/fastc_backend_test.v
+++ b/vlib/v3/tests/fastc_backend_test.v
@@ -46,8 +46,9 @@ fn test_v_self_accepts_fastc_backend() {
 	}
 	vflags_binary := os.join_path(root, 'v fastc from vflags')
 	vflags_self_build := run_with_vflags(@VEXE, ['self', '-silent', '-o', vflags_binary],
-		'-b fastc')
+		'-d self -b fastc')
 	assert vflags_self_build.exit_code == 0, vflags_self_build.output
+	assert vflags_self_build.output.contains('-d self'), vflags_self_build.output
 	assert vflags_self_build.output.contains('-b fastc'), vflags_self_build.output
 	assert os.is_executable(vflags_binary)
 


### PR DESCRIPTION
## Summary

- make `v self -b fastc` build the standalone V3 FastC compiler from `vlib/v3/v3.v`
- skip incompatible default C compiler selection, PGO, and portable bootstrap fallback for FastC self-builds
- accept the internal `-selfhost` passthrough flag and fix empty struct initializer rendering exposed by self-hosting
- add an end-to-end regression test and document the backend option

## Testing

- `./v -g -keepc -o ./vnew cmd/v`
- `./vnew self -silent -b fastc -o /tmp/v-fastc-self-smoke`
- generated FastC compiler successfully compiled and ran `examples/hello_world.v`
- `./vnew -silent test vlib/v3/tests/fastc_backend_test.v`
- `./vnew -silent test vlib/v3/gen/fastc/fastc_test.v`
- `./vnew -silent vlib/v/compiler_errors_test.v`
- `./vnew -silent test vlib/v/pref/`
- `./vnew -silent test vlib/v/help/help_test.v`
- `./vnew -silent test vlib/v/` (2253 passed, 26 skipped, 89 failures in unrelated existing V3/compiler areas)