### PR TITLE
tools: stream v self output during v up

### DIFF
--- a/cmd/tools/vup.v
+++ b/cmd/tools/vup.v
@@ -133,15 +133,19 @@ fn (app App) recompile_v() bool {
 		return app.make(vself)
 	}
 
-	self_result := os.execute(vself)
-	if self_result.exit_code == 0 {
-		println(self_result.output.trim_space())
+	// Let `v self` inherit the terminal instead of buffering all of its output.
+	// Rebuilding a V3-enabled compiler can take several seconds, and hiding the
+	// initial "V self compiling" status makes `v up` appear to hang after TCC.
+	mut self_process := os.new_process(vexe_path)
+	self_process.set_args(if app.is_prod { ['-prod', 'self'] } else { ['self'] })
+	self_process.wait()
+	self_exit_code := self_process.code
+	self_process.close()
+	if self_exit_code == 0 {
 		println('> Done recompiling.')
 		return true
-	} else {
-		println('> `${vself}` failed, running `make`...')
-		app.vprintln(self_result.output.trim_space())
 	}
+	println('> `${vself}` failed, running `make`...')
 	return app.make(vself)
 }
 

--- a/cmd/tools/vup.v
+++ b/cmd/tools/vup.v
@@ -133,14 +133,21 @@ fn (app App) recompile_v() bool {
 		return app.make(vself)
 	}
 
-	// Let `v self` inherit the terminal instead of buffering all of its output.
-	// Rebuilding a V3-enabled compiler can take several seconds, and hiding the
-	// initial "V self compiling" status makes `v up` appear to hang after TCC.
-	mut self_process := os.new_process(vexe_path)
-	self_process.set_args(if app.is_prod { ['-prod', 'self'] } else { ['self'] })
-	self_process.wait()
-	self_exit_code := self_process.code
-	self_process.close()
+	// Let `v self` inherit stdio instead of buffering all of its output. Rebuilding
+	// a V3-enabled compiler can take several seconds, and hiding the initial status
+	// makes `v up` appear to hang after TCC. On Windows the default `os.Process`
+	// launch does not wire inherited standard handles into STARTUPINFO, while
+	// `os.system` does preserve redirected stdout and stderr through `_wsystem`.
+	mut self_exit_code := -1
+	$if windows {
+		self_exit_code = os.system(vself)
+	} $else {
+		mut self_process := os.new_process(vexe_path)
+		self_process.set_args(if app.is_prod { ['-prod', 'self'] } else { ['self'] })
+		self_process.wait()
+		self_exit_code = self_process.code
+		self_process.close()
+	}
 	if self_exit_code == 0 {
 		println('> Done recompiling.')
 		return true


### PR DESCRIPTION
## Summary

- stream `v self` output directly while `v up` rebuilds the compiler
- show the existing `V self compiling...` status instead of an apparent pause after the TCC refresh
- preserve the existing `make` fallback when the self-build fails

## Testing

- `./vnew fmt -w cmd/tools/vup.v`
- compiled `cmd/tools/vup.v` with `-g -gc none`
- `./vnew test cmd/tools/diagnostic_tools_no_libgc_test.v`
- cross-compiled `cmd/tools/vup.v` to Linux and Windows C output
- isolated slow-self smoke test verified output appears before the child exits