### PR TITLE
v3 migrations: reject PostgreSQL inspection transactions

### DIFF
--- a/vlib/v3/migrations/README.md
+++ b/vlib/v3/migrations/README.md
@@ -103,11 +103,11 @@ can override whether per-migration transaction methods are used for DDL. SQLite'
 transaction still covers each mutating workflow; failed acquisition and commit paths roll back and
 remove their temporary transaction probes. Migration names containing NUL bytes are rejected before
 any database access. PostgreSQL migrations reject `orm.DB` decorators without probing their
-transactions; pass a direct session-pinned `pg.Conn` without an active transaction. Existing
-transactions, including `pg.Tx`, are rejected in every transaction mode so the session lock cannot
-be released before their work commits. Unqualified PostgreSQL history tables resolve an existing
-persistent relation before falling back to the normal creation schema for inspection, creation,
-and lock namespacing. Temporary relations are ignored unless explicitly qualified in `Config.table`.
+transactions; pass a direct session-pinned `pg.Conn` without an active transaction. Mutating and
+inspection workflows reject existing transactions, including `pg.Tx`, before resolving or retaining
+the history schema. Unqualified PostgreSQL history tables resolve an existing persistent relation
+before falling back to the normal creation schema for inspection, creation, and lock namespacing.
+Temporary relations are ignored unless explicitly qualified in `Config.table`.
 PostgreSQL transactions opened by callbacks in `never` mode are rolled back and rejected before the
 advisory migration lock is released, including when an aborted transaction makes the history write
 fail. In transactional modes, callbacks cannot end the migrator-owned PostgreSQL transaction before

--- a/vlib/v3/migrations/migrations.v
+++ b/vlib/v3/migrations/migrations.v
@@ -406,6 +406,9 @@ fn (m &Migrator) find_migration(version i64) ?Migration {
 fn (mut m Migrator) ensure_history_table() ! {
 	match m.config.dialect {
 		.pg {
+			if m.pg_lock_key == none {
+				m.reject_existing_postgresql_transaction()!
+			}
 			m.resolve_postgresql_history_schema()!
 		}
 		.mysql {

--- a/vlib/v3/migrations/migrations_test.v
+++ b/vlib/v3/migrations/migrations_test.v
@@ -1344,6 +1344,41 @@ fn test_postgresql_inspection_resolves_and_retains_existing_history_schema() {
 	assert query.contains('n.oid <> pg_catalog.pg_my_temp_schema()')
 }
 
+fn test_postgresql_inspection_rejects_active_transaction_without_retaining_schema() {
+	mut recorder := &RecordingConnection{
+		schema:         'transaction_schema'
+		in_transaction: true
+	}
+	mut runner := new(mut recorder, []Migration{}, Config{
+		dialect: .pg
+	})!
+	expected_error := 'PostgreSQL migrations require a connection without an already-open transaction; pg.Tx and transactional pg.Conn values are not supported'
+
+	mut error_message := ''
+	runner.applied() or { error_message = err.msg() }
+	assert error_message == expected_error
+	error_message = ''
+	runner.pending() or { error_message = err.msg() }
+	assert error_message == expected_error
+	error_message = ''
+	runner.current_version() or { error_message = err.msg() }
+	assert error_message == expected_error
+	error_message = ''
+	runner.status() or { error_message = err.msg() }
+	assert error_message == expected_error
+	assert runner.resolved_history_namespace == ''
+	assert recorder.queries.filter(it == postgresql_history_schema_query('schema_migrations')).len == 0
+	assert recorder.queries.filter(it.starts_with('CREATE TABLE IF NOT EXISTS ')).len == 0
+	assert recorder.queries.filter(it == postgresql_transaction_probe_read_query()).len == 4
+
+	recorder.execute('ROLLBACK;')!
+	recorder.schema = 'public'
+	assert runner.migrate()!.len == 0
+	assert runner.resolved_history_namespace == 'public'
+	key := postgresql_migration_lock_key('public', 'schema_migrations')
+	assert 'SELECT pg_advisory_lock(${key});' in recorder.queries
+}
+
 fn test_mysql_inspection_resolves_and_retains_history_database() {
 	mut recorder := &RecordingConnection{
 		database:     'app'


### PR DESCRIPTION
## Summary

- reject caller-owned PostgreSQL transactions before inspection resolves the history schema
- prevent a transaction-local search_path from being cached and reused after rollback
- cover applied, pending, current_version, status, and later migrator reuse

This is a focused follow-up to #28099 and its unresolved inspection feedback:
https://github.com/vlang/v/pull/28099#discussion_r3792067018

#28118 mentions the same inspection bug but currently contains only workflow and encoded-payload files. This PR commits the source change directly. It intentionally excludes callback lock-ownership probes because a post-callback query cannot detect release and reacquisition or recursive acquisition on the exposed session.

## Validation

- VFLAGS=-gc none ./vnew -silent test vlib/v3/migrations/
- VFLAGS=-gc none ./vnew vet vlib/v3/migrations
- VFLAGS=-gc none ./vnew check-md vlib/v3/migrations/README.md
- ./vnew fmt -w vlib/v3/migrations/migrations.v
- ./vnew fmt -w vlib/v3/migrations/migrations_test.v
- git diff --check