### PR TITLE
v3 migrations: verify callback lock ownership

### DIFF
--- a/vlib/v3/migrations/README.md
+++ b/vlib/v3/migrations/README.md
@@ -102,18 +102,22 @@ The migrator accepts `orm.TransactionalConnection` implementations, and `Config.
 can override whether per-migration transaction methods are used for DDL. SQLite's immediate lock
 transaction still covers each mutating workflow; failed acquisition and commit paths roll back and
 remove their temporary transaction probes. Migration names containing NUL bytes are rejected before
-any database access. PostgreSQL migrations reject `orm.DB` decorators without probing their
+any database access. PostgreSQL migrators reject `orm.DB` decorators without probing their
 transactions; pass a direct session-pinned `pg.Conn` without an active transaction. Mutating and
 inspection workflows reject existing transactions, including `pg.Tx`, before resolving or retaining
 the history schema. Unqualified PostgreSQL history tables resolve an existing persistent relation
 before falling back to the normal creation schema for inspection, creation, and lock namespacing.
 Temporary relations are ignored unless explicitly qualified in `Config.table`.
 PostgreSQL transactions opened by callbacks in `never` mode are rolled back and rejected before the
-advisory migration lock is released, including when an aborted transaction makes the history write
-fail. In transactional modes, callbacks cannot end the migrator-owned PostgreSQL transaction before
-history is written. MySQL `always` mode verifies an owned savepoint before writing history. SQLite
-callbacks likewise cannot end or replace the original immediate lock transaction before the history
-write.
+advisory migration lock is released, including when an aborted transaction prevents post-callback
+lock verification. After every successful PostgreSQL `up` or `down` callback, the backend's
+exclusive advisory lock is verified before history is written; callbacks that release the
+deterministic key or all advisory locks are rejected. In transactional modes, callbacks cannot end
+the migrator-owned PostgreSQL transaction before history is written. After every successful MySQL
+`up` or `down` callback, named-lock ownership is verified before history is written; callbacks that
+release the deterministic name or all named locks are rejected. MySQL `always` mode also verifies an
+owned savepoint before writing history. SQLite callbacks likewise cannot end or replace the original
+immediate lock transaction before the history write.
 MySQL migrations and inspections also reject connections with active transactions or disabled
 session autocommit, using a unique savepoint name for each transaction-state probe. An unqualified
 MySQL history table is resolved and retained on first use, so later database changes on the same

--- a/vlib/v3/migrations/migrations.v
+++ b/vlib/v3/migrations/migrations.v
@@ -739,6 +739,37 @@ fn migration_lock_result(rows []orm.Row) bool {
 	return rows.len == 1 && rows[0].vals.len > 0 && rows[0].vals[0] in ['1', 't', 'true']
 }
 
+fn postgresql_migration_lock_owned_query(key i64) string {
+	return "SELECT EXISTS (SELECT 1 FROM pg_catalog.pg_locks WHERE locktype = 'advisory' AND pid = pg_catalog.pg_backend_pid() AND mode = 'ExclusiveLock' AND granted AND ((classid::bigint << 32) | objid::bigint) = ${key} AND objsubid = 1);"
+}
+
+fn (m &Migrator) verify_postgresql_migration_lock(mut ctx Context) ! {
+	key := m.pg_lock_key or {
+		return error('cannot verify PostgreSQL migration lock before it is acquired')
+	}
+
+	rows := ctx.execute(postgresql_migration_lock_owned_query(key))!
+	if !migration_lock_result(rows) {
+		return error('PostgreSQL migration callback released the migration advisory lock before history was recorded')
+	}
+}
+
+fn mysql_migration_lock_owned_query(name string) string {
+	return "SELECT COALESCE(IS_USED_LOCK('${name}') = CONNECTION_ID(), 0);"
+}
+
+fn (m &Migrator) verify_mysql_migration_lock(mut ctx Context) ! {
+	name := m.mysql_lock_name
+	if name == '' {
+		return error('cannot verify MySQL migration lock before it is acquired')
+	}
+
+	rows := ctx.execute(mysql_migration_lock_owned_query(name))!
+	if !migration_lock_result(rows) {
+		return error('MySQL migration callback released the named migration lock before history was recorded')
+	}
+}
+
 fn (mut m Migrator) prepare_sqlite_transaction_probe() ! {
 	m.sqlite_transaction_probe = 'v3_migrations_transaction_${time.now().unix_nano()}'
 	table := sqlite_transaction_probe_table_sql(m.sqlite_transaction_probe)
@@ -845,6 +876,13 @@ fn (mut m Migrator) run_up(migration Migration) !AppliedMigration {
 				}
 				return transaction_err
 			}
+			m.verify_postgresql_migration_lock(mut ctx) or {
+				lock_err := err
+				tx.rollback() or {
+					return error('${lock_err.msg()}; rollback failed: ${err.msg()}')
+				}
+				return lock_err
+			}
 		} else if m.config.dialect == .mysql {
 			m.verify_mysql_owned_transaction(mysql_transaction_savepoint) or {
 				transaction_err := err
@@ -852,6 +890,13 @@ fn (mut m Migrator) run_up(migration Migration) !AppliedMigration {
 					return error('${transaction_err.msg()}; rollback failed: ${err.msg()}')
 				}
 				return transaction_err
+			}
+			m.verify_mysql_migration_lock(mut ctx) or {
+				lock_err := err
+				tx.rollback() or {
+					return error('${lock_err.msg()}; rollback failed: ${err.msg()}')
+				}
+				return lock_err
 			}
 		}
 		ctx.execute(m.history_insert_sql(migration, applied_at)) or {
@@ -871,8 +916,28 @@ fn (mut m Migrator) run_up(migration Migration) !AppliedMigration {
 			}
 			return migration_err
 		}
-		if m.config.dialect == .sqlite {
-			m.verify_sqlite_lock_transaction()!
+		match m.config.dialect {
+			.sqlite {
+				m.verify_sqlite_lock_transaction()!
+			}
+			.pg {
+				m.verify_postgresql_migration_lock(mut ctx) or {
+					lock_err := err
+					m.validate_session_after_callback() or {
+						return error('${lock_err.msg()}; ${err.msg()}')
+					}
+					return lock_err
+				}
+			}
+			.mysql {
+				m.verify_mysql_migration_lock(mut ctx) or {
+					lock_err := err
+					m.validate_session_after_callback() or {
+						return error('${lock_err.msg()}; ${err.msg()}')
+					}
+					return lock_err
+				}
+			}
 		}
 		ctx.execute(m.history_insert_sql(migration, applied_at)) or {
 			history_err := err
@@ -928,6 +993,13 @@ fn (mut m Migrator) run_down(migration Migration) ! {
 				}
 				return transaction_err
 			}
+			m.verify_postgresql_migration_lock(mut ctx) or {
+				lock_err := err
+				tx.rollback() or {
+					return error('${lock_err.msg()}; transaction rollback failed: ${err.msg()}')
+				}
+				return lock_err
+			}
 		} else if m.config.dialect == .mysql {
 			m.verify_mysql_owned_transaction(mysql_transaction_savepoint) or {
 				transaction_err := err
@@ -935,6 +1007,13 @@ fn (mut m Migrator) run_down(migration Migration) ! {
 					return error('${transaction_err.msg()}; transaction rollback failed: ${err.msg()}')
 				}
 				return transaction_err
+			}
+			m.verify_mysql_migration_lock(mut ctx) or {
+				lock_err := err
+				tx.rollback() or {
+					return error('${lock_err.msg()}; transaction rollback failed: ${err.msg()}')
+				}
+				return lock_err
 			}
 		}
 		ctx.execute(m.history_delete_sql(migration.version)) or {
@@ -954,8 +1033,28 @@ fn (mut m Migrator) run_down(migration Migration) ! {
 			}
 			return migration_err
 		}
-		if m.config.dialect == .sqlite {
-			m.verify_sqlite_lock_transaction()!
+		match m.config.dialect {
+			.sqlite {
+				m.verify_sqlite_lock_transaction()!
+			}
+			.pg {
+				m.verify_postgresql_migration_lock(mut ctx) or {
+					lock_err := err
+					m.validate_session_after_callback() or {
+						return error('${lock_err.msg()}; ${err.msg()}')
+					}
+					return lock_err
+				}
+			}
+			.mysql {
+				m.verify_mysql_migration_lock(mut ctx) or {
+					lock_err := err
+					m.validate_session_after_callback() or {
+						return error('${lock_err.msg()}; ${err.msg()}')
+					}
+					return lock_err
+				}
+			}
 		}
 		ctx.execute(m.history_delete_sql(migration.version)) or {
 			history_err := err

--- a/vlib/v3/migrations/migrations_test.v
+++ b/vlib/v3/migrations/migrations_test.v
@@ -21,6 +21,8 @@ mut:
 	postgresql_table_schema   string = 'public'
 	postgresql_probe_value    string
 	postgresql_aborted        bool
+	postgresql_lock_held      bool
+	mysql_lock_held           bool
 	sqlite_table_schema       string = 'main'
 	sqlite_version            string = '3.46.0'
 	fail_sqlite_lock          bool
@@ -122,6 +124,17 @@ fn (mut conn RecordingConnection) execute(query string) ![]orm.Row {
 			vals: [conn.postgresql_probe_value]
 		}]
 	}
+	if query.starts_with('SELECT pg_advisory_lock(') {
+		conn.postgresql_lock_held = true
+	}
+	if query == 'SELECT pg_advisory_unlock_all();' {
+		conn.postgresql_lock_held = false
+	}
+	if query.starts_with('SELECT EXISTS (SELECT 1 FROM pg_catalog.pg_locks WHERE ') {
+		return [orm.Row{
+			vals: [if conn.postgresql_lock_held { 't' } else { 'f' }]
+		}]
+	}
 	if query.starts_with('SELECT version, name, applied_at FROM ') {
 		return conn.history_rows.clone()
 	}
@@ -177,10 +190,36 @@ fn (mut conn RecordingConnection) execute(query string) ![]orm.Row {
 			vals: [conn.sqlite_version]
 		}]
 	}
-	if query.starts_with('SELECT GET_LOCK(') || query.starts_with('SELECT RELEASE_LOCK(')
-		|| query.starts_with('SELECT pg_advisory_unlock(') {
+	if query.starts_with('SELECT pg_advisory_unlock(') {
+		was_held := conn.postgresql_lock_held
+		conn.postgresql_lock_held = false
+		return [orm.Row{
+			vals: [if was_held { 't' } else { 'f' }]
+		}]
+	}
+	if query.starts_with('SELECT GET_LOCK(') {
+		conn.mysql_lock_held = true
 		return [orm.Row{
 			vals: ['1']
+		}]
+	}
+	if query == 'SELECT RELEASE_ALL_LOCKS();' {
+		was_held := conn.mysql_lock_held
+		conn.mysql_lock_held = false
+		return [orm.Row{
+			vals: [if was_held { '1' } else { '0' }]
+		}]
+	}
+	if query.starts_with('SELECT COALESCE(IS_USED_LOCK(') {
+		return [orm.Row{
+			vals: [if conn.mysql_lock_held { '1' } else { '0' }]
+		}]
+	}
+	if query.starts_with('SELECT RELEASE_LOCK(') {
+		was_held := conn.mysql_lock_held
+		conn.mysql_lock_held = false
+		return [orm.Row{
+			vals: [if was_held { '1' } else { '0' }]
 		}]
 	}
 	return []
@@ -385,6 +424,15 @@ fn start_mysql_transaction(mut ctx Context) ! {
 	ctx.execute('START TRANSACTION;')!
 }
 
+fn unlock_all_mysql_named_locks(mut ctx Context) ! {
+	ctx.execute('SELECT RELEASE_ALL_LOCKS();')!
+}
+
+fn unlock_mysql_migration_lock(mut ctx Context) ! {
+	name := mysql_migration_lock_name('test_database', 'schema_migrations', 0)
+	ctx.execute("SELECT RELEASE_LOCK('${name}');")!
+}
+
 fn start_postgresql_transaction(mut ctx Context) ! {
 	ctx.execute('BEGIN;')!
 }
@@ -397,6 +445,15 @@ fn abort_postgresql_transaction_and_catch_error(mut ctx Context) ! {
 
 fn rollback_callback_transaction(mut ctx Context) ! {
 	ctx.execute('ROLLBACK;')!
+}
+
+fn unlock_all_postgresql_advisory_locks(mut ctx Context) ! {
+	ctx.execute('SELECT pg_advisory_unlock_all();')!
+}
+
+fn unlock_postgresql_migration_lock(mut ctx Context) ! {
+	key := postgresql_migration_lock_key('public', 'schema_migrations')
+	ctx.execute('SELECT pg_advisory_unlock(${key});')!
 }
 
 fn create_sqlite_table_then_rollback(mut ctx Context) ! {
@@ -823,7 +880,7 @@ fn test_postgresql_callback_transactions_are_rolled_back_before_unlocking() {
 	assert down_recorder.queries.last() == 'SELECT pg_advisory_unlock(${key});'
 }
 
-fn test_postgresql_history_write_errors_rollback_callback_transaction_state() {
+fn test_postgresql_lock_verification_errors_rollback_callback_transaction_state() {
 	migration := Migration{
 		version: 1
 		name:    'aborted_transaction'
@@ -837,15 +894,17 @@ fn test_postgresql_history_write_errors_rollback_callback_transaction_state() {
 	})!
 	mut error_message := ''
 	up_runner.migrate() or { error_message = err.msg() }
-	assert error_message.contains('could not record migration 1: current PostgreSQL transaction is aborted')
+	assert error_message.contains('current PostgreSQL transaction is aborted')
+	assert error_message.contains('PostgreSQL migration callback left unsafe session state')
 	assert !up_recorder.in_transaction
 	assert !up_recorder.postgresql_aborted
 	up_inserts := up_recorder.queries.filter(it.starts_with('INSERT INTO '))
-	assert up_inserts.len == 1
-	up_insert_index := up_recorder.queries.index(up_inserts[0])
-	assert up_insert_index > up_recorder.queries.index('force PostgreSQL statement error;')
-	assert up_recorder.queries.index('ORM ROLLBACK') > up_insert_index
+	assert up_inserts.len == 0
 	key := postgresql_migration_lock_key('public', 'schema_migrations')
+	lock_check := postgresql_migration_lock_owned_query(key)
+	lock_check_index := up_recorder.queries.index(lock_check)
+	assert lock_check_index > up_recorder.queries.index('force PostgreSQL statement error;')
+	assert up_recorder.queries.index('ORM ROLLBACK') > lock_check_index
 	assert up_recorder.queries.last() == 'SELECT pg_advisory_unlock(${key});'
 
 	mut down_recorder := &RecordingConnection{
@@ -861,14 +920,15 @@ fn test_postgresql_history_write_errors_rollback_callback_transaction_state() {
 	})!
 	error_message = ''
 	down_runner.rollback(1) or { error_message = err.msg() }
-	assert error_message.contains('could not remove migration 1 from history: current PostgreSQL transaction is aborted')
+	assert error_message.contains('current PostgreSQL transaction is aborted')
+	assert error_message.contains('PostgreSQL migration callback left unsafe session state')
 	assert !down_recorder.in_transaction
 	assert !down_recorder.postgresql_aborted
 	down_deletes := down_recorder.queries.filter(it.starts_with('DELETE FROM '))
-	assert down_deletes.len == 1
-	down_delete_index := down_recorder.queries.index(down_deletes[0])
-	assert down_delete_index > down_recorder.queries.index('force PostgreSQL statement error;')
-	assert down_recorder.queries.index('ORM ROLLBACK') > down_delete_index
+	assert down_deletes.len == 0
+	down_lock_check_index := down_recorder.queries.index(lock_check)
+	assert down_lock_check_index > down_recorder.queries.index('force PostgreSQL statement error;')
+	assert down_recorder.queries.index('ORM ROLLBACK') > down_lock_check_index
 	assert down_recorder.queries.last() == 'SELECT pg_advisory_unlock(${key});'
 }
 
@@ -913,6 +973,68 @@ fn test_postgresql_owned_transaction_is_verified_before_history_writes() {
 	}
 }
 
+fn test_postgresql_advisory_lock_is_verified_before_history_writes() {
+	migrations := [
+		Migration{
+			version: 1
+			name:    'unlock_all'
+			up:      unlock_all_postgresql_advisory_locks
+			down:    unlock_all_postgresql_advisory_locks
+		},
+		Migration{
+			version: 1
+			name:    'unlock_migration_lock'
+			up:      unlock_postgresql_migration_lock
+			down:    unlock_postgresql_migration_lock
+		},
+	]
+	for migration in migrations {
+		for mode in [TransactionMode.automatic, .always, .never] {
+			mut up_recorder := &RecordingConnection{}
+			mut up_runner := new(mut up_recorder, [migration], Config{
+				dialect:          .pg
+				transaction_mode: mode
+			})!
+			mut error_message := ''
+			up_runner.migrate() or { error_message = err.msg() }
+			assert error_message.contains('PostgreSQL migration callback released the migration advisory lock before history was recorded')
+			assert up_recorder.queries.filter(it.starts_with('INSERT INTO ')).len == 0
+			key := postgresql_migration_lock_key('public', 'schema_migrations')
+			lock_check := postgresql_migration_lock_owned_query(key)
+			callback_index := up_recorder.queries.index(if migration.name == 'unlock_all' {
+				'SELECT pg_advisory_unlock_all();'
+			} else {
+				'SELECT pg_advisory_unlock(${key});'
+			})
+			assert callback_index >= 0
+			assert up_recorder.queries.index(lock_check) > callback_index
+
+			mut down_recorder := &RecordingConnection{
+				history_rows: [
+					orm.Row{
+						vals: ['1', migration.name, '2026-08-16T00:00:00Z']
+					},
+				]
+			}
+			mut down_runner := new(mut down_recorder, [migration], Config{
+				dialect:          .pg
+				transaction_mode: mode
+			})!
+			error_message = ''
+			down_runner.rollback(1) or { error_message = err.msg() }
+			assert error_message.contains('PostgreSQL migration callback released the migration advisory lock before history was recorded')
+			assert down_recorder.queries.filter(it.starts_with('DELETE FROM ')).len == 0
+			down_callback_index := down_recorder.queries.index(if migration.name == 'unlock_all' {
+				'SELECT pg_advisory_unlock_all();'
+			} else {
+				'SELECT pg_advisory_unlock(${key});'
+			})
+			assert down_callback_index >= 0
+			assert down_recorder.queries.index(lock_check) > down_callback_index
+		}
+	}
+}
+
 fn test_mysql_owned_transaction_is_verified_before_history_writes() {
 	migration := Migration{
 		version: 1
@@ -949,6 +1071,65 @@ fn test_mysql_owned_transaction_is_verified_before_history_writes() {
 	assert !down_recorder.in_transaction
 	assert down_recorder.queries.filter(it.starts_with('DELETE FROM ')).len == 0
 	assert down_recorder.queries.last().starts_with('SELECT RELEASE_LOCK(')
+}
+
+fn test_mysql_named_lock_is_verified_before_history_writes() {
+	migrations := [
+		Migration{
+			version: 1
+			name:    'unlock_all'
+			up:      unlock_all_mysql_named_locks
+			down:    unlock_all_mysql_named_locks
+		},
+		Migration{
+			version: 1
+			name:    'unlock_migration_lock'
+			up:      unlock_mysql_migration_lock
+			down:    unlock_mysql_migration_lock
+		},
+	]
+	for migration in migrations {
+		for mode in [TransactionMode.automatic, .always, .never] {
+			mut up_recorder := &RecordingConnection{}
+			mut up_runner := new(mut up_recorder, [migration], Config{
+				dialect:          .mysql
+				transaction_mode: mode
+			})!
+			mut error_message := ''
+			up_runner.migrate() or { error_message = err.msg() }
+			assert error_message.contains('MySQL migration callback released the named migration lock before history was recorded')
+			assert up_recorder.queries.filter(it.starts_with('INSERT INTO ')).len == 0
+			name := mysql_migration_lock_name('test_database', 'schema_migrations', 0)
+			lock_check := mysql_migration_lock_owned_query(name)
+			callback_query := if migration.name == 'unlock_all' {
+				'SELECT RELEASE_ALL_LOCKS();'
+			} else {
+				"SELECT RELEASE_LOCK('${name}');"
+			}
+			callback_index := up_recorder.queries.index(callback_query)
+			assert callback_index >= 0
+			assert up_recorder.queries.index(lock_check) > callback_index
+
+			mut down_recorder := &RecordingConnection{
+				history_rows: [
+					orm.Row{
+						vals: ['1', migration.name, '2026-08-16T00:00:00Z']
+					},
+				]
+			}
+			mut down_runner := new(mut down_recorder, [migration], Config{
+				dialect:          .mysql
+				transaction_mode: mode
+			})!
+			error_message = ''
+			down_runner.rollback(1) or { error_message = err.msg() }
+			assert error_message.contains('MySQL migration callback released the named migration lock before history was recorded')
+			assert down_recorder.queries.filter(it.starts_with('DELETE FROM ')).len == 0
+			down_callback_index := down_recorder.queries.index(callback_query)
+			assert down_callback_index >= 0
+			assert down_recorder.queries.index(lock_check) > down_callback_index
+		}
+	}
 }
 
 fn test_sqlite_callback_cannot_end_lock_transaction_before_history_writes() {


### PR DESCRIPTION
## Summary
- verify PostgreSQL advisory-lock ownership after successful up and down callbacks
- verify MySQL named-lock ownership before mutating migration history
- reject callbacks that release migration locks, with rollback/session cleanup and regression coverage
- document the callback lock guarantees

## Testing
- ./vnew -silent test vlib/v3/migrations/
- ./vnew check-md vlib/v3/migrations/README.md
- ./vnew fmt -w vlib/v3/migrations/migrations.v
- ./vnew fmt -w vlib/v3/migrations/migrations_test.v