### PR TITLE
v3: make native module caching robust for Volt

### DIFF
--- a/vlib/v3/driver/cache_prune_test.v
+++ b/vlib/v3/driver/cache_prune_test.v
@@ -73,6 +73,35 @@ fn test_cache_native_public_include_strips_conventional_implementation_macros() 
 	assert (include.last_index('#define SOKOL_FONTSTASH_IMPL') or { -1 }) > include_pos
 }
 
+fn test_cached_native_owner_restores_stripped_implementation_context() {
+	path := os.real_path('/tmp/sokol_gl.h')
+	include_line := '#include "${c_include_path(path)}"'
+	state := &V3ModuleCacheState{
+		module_sources:        {
+			'sgl': ['/tmp/sgl.v']
+		}
+		module_native_roots:   {
+			'sgl': [path]
+		}
+		native_root_contexts:  {
+			path: ['#define SOKOL_IMPL']
+		}
+		native_root_owners:    {
+			path: 'sgl'
+		}
+		native_source_modules: {
+			'sgl': true
+		}
+	}
+	native := cache_source_with_cached_native_inputs('/* v3 cache omitted SOKOL_IMPL */\n${include_line}\n',
+		state, ['sgl'])
+	define_pos := native.source.index('#define SOKOL_IMPL') or { -1 }
+	include_pos := native.source.index(include_line) or { -1 }
+	assert native.has_native
+	assert define_pos >= 0
+	assert include_pos > define_pos
+}
+
 fn test_cache_native_public_include_detects_external_function_implementation_macro() {
 	dir := os.join_path(os.vtmp_dir(), 'v3_external_implementation_macro_${os.getpid()}')
 	os.rmdir_all(dir) or {}
@@ -82,6 +111,9 @@ fn test_cache_native_public_include_detects_external_function_implementation_mac
 	}
 	header := os.join_path(dir, 'native.h')
 	os.write_file(header, 'typedef struct { int value; } V3LibType;
+/*
+#define LIB_IMPL
+*/
 #ifdef LIB_IMPL
 int v3_lib_value(void) { return 42; }
 #endif
@@ -144,6 +176,31 @@ static int v3_private_helper(void) { return 7; }
 	// cannot collide; splitting stays safe.
 	assert !cache_native_public_include_replays_external_definition(real_header, []string{},
 		map[string]bool{}, {
+		real_header: true
+	}, []string{}, 'cc', pref.host_target())
+}
+
+fn test_cache_native_public_include_falls_back_when_isolated_preprocessing_fails() {
+	dir := os.join_path(os.vtmp_dir(), 'v3_public_replay_preprocess_fallback_${os.getpid()}')
+	os.rmdir_all(dir) or {}
+	os.mkdir_all(dir) or { panic(err) }
+	defer {
+		os.rmdir_all(dir) or {}
+	}
+	header := os.join_path(dir, 'native.h')
+	os.write_file(header, '#ifndef V3_DEPENDENCY_READY
+#error "include dependency declarations first"
+#endif
+#ifdef LIB_IMPL
+int v3_gated_helper(void) { return 7; }
+#endif
+')!
+	real_header := os.real_path(header)
+	assert !cache_native_public_include_replays_external_definition(real_header, [
+		'#define LIB_IMPL',
+	], {
+		'LIB_IMPL': true
+	}, {
 		real_header: true
 	}, []string{}, 'cc', pref.host_target())
 }
@@ -234,6 +291,15 @@ fn test_cache_c_source_definitely_active_code_filters_conditional_definitions() 
 	assert unknown.contains('always_active')
 	assert !unknown.contains('bundled_api')
 	assert !unknown.contains('library_api')
+}
+
+fn test_cache_c_source_definitely_active_code_ignores_directives_in_comments() {
+	source := '/*\n#define FEATURE\n*/\n#ifdef FEATURE\nint commented_api(void) { return 1; }\n#endif\n'
+	mut macros := cache_local_c_flag_macros(['-UFEATURE'])
+	active, complete := cache_c_source_definitely_active_code_with_status(source, mut macros)
+	assert complete
+	assert !active.contains('commented_api')
+	assert !macros['FEATURE'].is_defined
 }
 
 fn test_cache_c_source_definitely_active_code_uses_compiler_predefined_macros() {

--- a/vlib/v3/driver/cache_prune_test.v
+++ b/vlib/v3/driver/cache_prune_test.v
@@ -69,10 +69,12 @@ fn test_c_source_references_identifiers_ignores_comments_strings_and_longer_name
 fn test_cache_native_public_include_strips_conventional_implementation_macros() {
 	include := cache_native_public_include('/tmp/native.h', [
 		'#define FEATURE 1',
+		'#include "/tmp/context.h"',
 		'#define FONTSTASH_IMPLEMENTATION',
 		'#define SOKOL_FONTSTASH_IMPL',
 	], map[string]bool{})
 	assert include.contains('#define FEATURE 1')
+	assert !include.contains('context.h')
 	assert include.contains('#undef FONTSTASH_IMPLEMENTATION')
 	assert include.contains('#undef SOKOL_FONTSTASH_IMPL')
 	assert include.contains('#undef SOKOL_IMPL')

--- a/vlib/v3/driver/cache_prune_test.v
+++ b/vlib/v3/driver/cache_prune_test.v
@@ -32,6 +32,19 @@ fn test_builtin_bundle_module_inputs_do_not_reuse_the_bundle_object() {
 		@VEXEROOT)
 }
 
+fn test_cached_object_wrapper_signature_ignores_non_wrapper_prefix_changes() {
+	base := 'base signature'
+	wrapper := '/* V3CACHE_PROGRAM_WRAPPERS */\nstatic void callback(void) {}\n/* V3CACHE_PROGRAM_WRAPPERS_END */'
+	raw_source := '#define NATIVE_IMPLEMENTATION\n#include "native.h"\n${wrapper}\n/* V3CACHE_BODY_BEGIN */\n'
+	prepared_source := '#define V3CACHE_PROGRAM_UNIT 1\n${wrapper}\n/* V3CACHE_BODY_BEGIN */\n'
+	assert v3_cached_object_wrapper_compile_signature(base, raw_source) == v3_cached_object_wrapper_compile_signature(base,
+		prepared_source)
+	changed_source := prepared_source.replace('callback(void)', 'other_callback(void)')
+	assert v3_cached_object_wrapper_compile_signature(base, prepared_source) != v3_cached_object_wrapper_compile_signature(base,
+		changed_source)
+	assert v3_cached_object_wrapper_compile_signature(base, 'int declaration;') == base
+}
+
 fn test_cache_function_reference_counts_scans_source_once() {
 	candidates := {
 		'alpha__one': true
@@ -65,12 +78,12 @@ fn test_cache_native_public_include_strips_conventional_implementation_macros() 
 	assert include.contains('#undef SOKOL_IMPL')
 	include_pos := include.index('#include') or { -1 }
 	assert include_pos >= 0
-	// The switches are undefined while the header expands, then restored after it
-	// so later native directives in the same unit see the original macro state.
+	// Declaration-only replay must leave the switches undefined so later generated
+	// wrappers are emitted only by the selected owner object.
 	assert (include.index('#undef FONTSTASH_IMPLEMENTATION') or { -1 }) < include_pos
 	assert (include.index('#undef SOKOL_FONTSTASH_IMPL') or { -1 }) < include_pos
-	assert (include.last_index('#define FONTSTASH_IMPLEMENTATION') or { -1 }) > include_pos
-	assert (include.last_index('#define SOKOL_FONTSTASH_IMPL') or { -1 }) > include_pos
+	assert !include.contains('#define FONTSTASH_IMPLEMENTATION')
+	assert !include.contains('#define SOKOL_FONTSTASH_IMPL')
 }
 
 fn test_cached_native_owner_restores_stripped_implementation_context() {
@@ -130,8 +143,7 @@ int v3_lib_value(void) { return 42; }
 	include_pos := include.index('#include') or { -1 }
 	assert include_pos >= 0
 	assert (include.index('#undef LIB_IMPL') or { -1 }) < include_pos
-	// The implementation switch is restored after the header expands.
-	assert (include.last_index('#define LIB_IMPL') or { -1 }) > include_pos
+	assert !include.contains('#define LIB_IMPL')
 	// A gated external definition is stripped, so splitting the root is safe.
 	assert !cache_native_public_include_replays_external_definition(real_header, [
 		'#define LIB_IMPL',

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -3075,10 +3075,13 @@ fn cache_native_public_include(path string, context []string, implementation_mac
 			out.writeln(line)
 			continue
 		}
+		if directive == 'include' {
+			// The declaration prefix has already emitted every header that precedes
+			// this root. Replaying a physical include after an inlined copy can
+			// redefine types even when the header uses `#pragma once`.
+			continue
+		}
 		if directive != 'define' {
-			// Preceding headers are part of the exact macro context for this root.
-			// Replaying the include preserves its guarded mutations without flattening
-			// thousands of transitive definitions into unconditional directives.
 			out.writeln(line)
 			continue
 		}

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -2509,25 +2509,25 @@ fn prepare_v3_cache_external_inputs(mut state V3ModuleCacheState, a &flat.FlatAs
 		prefs.c99, prefs.target)
 	compiler_macros, compiler_macro_environment_complete := cache_c_compiler_predefined_macros(user_c_flags,
 		prefs.ccompiler, prefs.target, native_inputs_language)
-	external_inputs, native_source_roots, native_root_contexts, unscoped_inputs, static_storage_inputs, resolution_dirs, missing_resolution_paths, external_input_digests, has_untracked_c_include := cgen.cache_external_input_snapshot_with_resolved_flags(a,
+	mut external_inputs, mut native_source_roots, mut native_root_contexts, unscoped_inputs, static_storage_inputs, resolution_dirs, missing_resolution_paths, mut external_input_digests, has_untracked_c_include := cgen.cache_external_input_snapshot_with_resolved_flags(a,
 		prefs.vroot, cache_input_modules, user_c_flags, prefs.target,
 		module_cache_source_path_set(user_files), compiler_macros,
 		compiler_macro_environment_complete)
-	state.module_external_inputs = external_inputs.clone()
-	state.module_native_roots = native_source_roots.clone()
-	state.native_root_contexts = native_root_contexts.clone()
+	state.module_external_inputs = external_inputs.move()
+	state.module_native_roots = native_source_roots.move()
+	state.native_root_contexts = native_root_contexts.move()
 	state.external_input_signatures = map[string]string{}
-	state.external_input_digests = external_input_digests.clone()
+	state.external_input_digests = external_input_digests.move()
 	cache_dir := os.abs_path(state.manager.dir)
 	real_cache_dir := os.real_path(state.manager.dir)
 	state.external_resolution_dirs = resolution_dirs.filter(!v3_path_is_within(it, cache_dir)
 		&& !v3_path_is_within(it, real_cache_dir))
 	state.external_missing_paths = missing_resolution_paths.filter(
 		!v3_path_is_within(it, cache_dir) && !v3_path_is_within(it, real_cache_dir))
-	native_source_modules, can_scope_static_inputs := cache_external_input_owner_modules(state, a,
-		unscoped_inputs, static_storage_inputs, user_files, user_c_flags, prefs.ccompiler,
+	mut native_source_modules, can_scope_static_inputs := cache_external_input_owner_modules(state,
+		a, unscoped_inputs, static_storage_inputs, user_files, user_c_flags, prefs.ccompiler,
 		prefs.target)
-	state.native_source_modules = native_source_modules.clone()
+	state.native_source_modules = native_source_modules.move()
 	state.native_root_owners = map[string]string{}
 	for raw_module_name, roots in state.module_native_roots {
 		module_name := if raw_module_name == 'main' {
@@ -2572,15 +2572,15 @@ fn prepare_v3_checker_native_inputs(mut state V3ModuleCacheState, a &flat.FlatAs
 		prefs.c99, prefs.target)
 	compiler_macros, compiler_macro_environment_complete := cache_c_compiler_predefined_macros(user_c_flags,
 		prefs.ccompiler, prefs.target, native_inputs_language)
-	external_inputs, native_source_roots, native_root_contexts, _, _, resolution_dirs, missing_resolution_paths, external_input_digests, has_untracked_c_include := cgen.cache_external_input_snapshot_with_resolved_flags(a,
+	mut external_inputs, mut native_source_roots, mut native_root_contexts, _, _, resolution_dirs, missing_resolution_paths, mut external_input_digests, has_untracked_c_include := cgen.cache_external_input_snapshot_with_resolved_flags(a,
 		prefs.vroot, cache_input_modules, user_c_flags, prefs.target,
 		module_cache_source_path_set(user_files), compiler_macros,
 		compiler_macro_environment_complete)
-	state.module_external_inputs = external_inputs.clone()
-	state.module_native_roots = native_source_roots.clone()
-	state.native_root_contexts = native_root_contexts.clone()
+	state.module_external_inputs = external_inputs.move()
+	state.module_native_roots = native_source_roots.move()
+	state.native_root_contexts = native_root_contexts.move()
 	state.external_input_signatures = map[string]string{}
-	state.external_input_digests = external_input_digests.clone()
+	state.external_input_digests = external_input_digests.move()
 	cache_dir := os.abs_path(state.manager.dir)
 	real_cache_dir := os.real_path(state.manager.dir)
 	state.external_resolution_dirs = resolution_dirs.filter(!v3_path_is_within(it, cache_dir)
@@ -2859,10 +2859,15 @@ fn prepare_v3_cache_native_type_declarations(mut state V3ModuleCacheState, c_fla
 					[]string{}
 				}, c_flags, ccompiler, target) or { continue }
 				functions, _ := modulecache.c_source_function_identifiers_with_status(preprocessed)
+				mut root_has_recovered_functions := false
 				for name, present in functions {
 					if present && file_scope_identifiers[name] {
 						recovered_functions[name] = true
+						root_has_recovered_functions = true
 					}
+				}
+				if root_has_recovered_functions {
+					roots_with_function_declarations[real_root] = true
 				}
 			}
 			if recovered_functions.len > 0 {
@@ -3031,6 +3036,10 @@ fn cache_native_public_include(path string, context []string, implementation_mac
 			continue
 		}
 		if directive != 'define' {
+			// Preceding headers are part of the exact macro context for this root.
+			// Replaying the include preserves its guarded mutations without flattening
+			// thousands of transitive definitions into unconditional directives.
+			out.writeln(line)
 			continue
 		}
 		name := cache_local_c_define_name(arg)
@@ -3084,14 +3093,28 @@ fn cache_native_public_include_replays_external_definition(path string, context 
 		}
 		replay_context << line
 	}
-	preprocessed := cache_preprocessed_native_input(path, replay_context, c_flags, ccompiler,
-		target) or { return true }
 	mut replay_macros := cache_local_c_compiler_macros(c_flags, ccompiler, target)
 	cache_apply_native_root_context(replay_context, mut replay_macros)
 	mut active_paths := map[string]bool{}
 	active_source, active_complete := cache_c_source_definitely_active_code_for_path_with_status(path,
 		allowed_paths, mut active_paths, mut replay_macros, false)
-	if !active_complete {
+	// Prefer compiler-expanded storage-class macros. Some public native headers
+	// deliberately require dependency declarations to have been included first,
+	// so an isolated preprocessing probe can fail even though the generated cache
+	// unit has that dependency prefix. In that case the definitely-active raw scan
+	// still provides a conservative linkage classification; incomplete raw syntax
+	// continues to fail closed below.
+	mut linkage_source := active_source
+	mut preprocessed_complete_context := false
+	if preprocessed := cache_preprocessed_native_input(path, replay_context, c_flags, ccompiler,
+		target)
+	{
+		linkage_source = preprocessed
+		preprocessed_complete_context = true
+	} else if !active_complete {
+		if os.getenv('V3_CACHE_TRACE') != '' {
+			eprintln('  V3 module cache unresolved public native replay guard: path=${path}')
+		}
 		return true
 	}
 	// Include identifiers from active project headers reached transitively by the
@@ -3100,14 +3123,27 @@ fn cache_native_public_include_replays_external_definition(path string, context 
 	// replay it into every cached dependent.
 	file_scope := c_source_file_scope_identifiers(active_source)
 	all_functions, functions_complete :=
-		modulecache.c_source_function_identifiers_with_status(preprocessed)
+		modulecache.c_source_function_identifiers_with_status(linkage_source)
 	static_functions, static_complete :=
-		modulecache.c_source_static_function_identifiers_with_status(preprocessed)
+		modulecache.c_source_static_function_identifiers_with_status(linkage_source)
 	if !functions_complete || !static_complete {
+		if os.getenv('V3_CACHE_TRACE') != '' {
+			eprintln('  V3 module cache incomplete public native replay scan: path=${path} functions=${functions_complete} static=${static_complete}')
+		}
 		return true
 	}
 	for name, present in all_functions {
-		if present && !static_functions[name] && file_scope[name] {
+		// An exact compiler-preprocessed source is also the conservative fallback when
+		// the lightweight guard evaluator is incomplete. In that case do not filter
+		// definitions by its partial file-scope view: any surviving external definition,
+		// including one reached through an unresolved project-header branch, must disable
+		// replay. Compiler/system inline helpers with internal linkage remain excluded by
+		// the expanded static-function scan above.
+		if present && !static_functions[name]
+			&& (file_scope[name] || (preprocessed_complete_context && !active_complete)) {
+			if os.getenv('V3_CACHE_TRACE') != '' {
+				eprintln('  V3 module cache replayed external native definition: path=${path} identifier=${name}')
+			}
 			return true
 		}
 	}
@@ -3212,8 +3248,11 @@ fn cache_native_type_declarations_for_path_rec(path string, allowed_paths map[st
 	}
 	mut out := strings.new_builder(header.len)
 	mut conditionals := []V3CacheLocalCConditional{}
+	mut in_block_comment := false
 	for line in header.split_into_lines() {
-		directive, arg := cache_local_c_directive(line)
+		directive, arg, next_block_comment := cache_local_c_directive_outside_comments(line,
+			in_block_comment)
+		in_block_comment = next_block_comment
 		if directive in ['if', 'ifdef', 'ifndef'] {
 			parent_inactive := conditionals.any(it.inactive)
 			parent_ambiguous := conditionals.any(it.ambiguous)
@@ -3387,8 +3426,11 @@ fn cache_local_c_define_name(arg string) string {
 }
 
 fn cache_seed_locally_defined_c_macros(source string, mut macros map[string]V3CacheLocalCMacro) {
+	mut in_block_comment := false
 	for line in source.split_into_lines() {
-		directive, arg := cache_local_c_directive(line)
+		directive, arg, next_block_comment := cache_local_c_directive_outside_comments(line,
+			in_block_comment)
+		in_block_comment = next_block_comment
 		if directive != 'define' {
 			continue
 		}
@@ -4037,6 +4079,65 @@ fn cache_local_c_directive(line string) (string, string) {
 	return rest[..end], rest[end..].trim_space()
 }
 
+fn cache_local_c_directive_outside_comments(line string, starts_in_block_comment bool) (string, string, bool) {
+	mut directive_at := -1
+	mut at_line_start := true
+	mut in_block_comment := starts_in_block_comment
+	mut i := 0
+	for i < line.len {
+		if in_block_comment {
+			for i + 1 < line.len && (line[i] != `*` || line[i + 1] != `/`) {
+				i++
+			}
+			if i + 1 >= line.len {
+				return '', '', true
+			}
+			in_block_comment = false
+			i += 2
+			continue
+		}
+		if i + 1 < line.len && line[i] == `/` && line[i + 1] == `/` {
+			break
+		}
+		if i + 1 < line.len && line[i] == `/` && line[i + 1] == `*` {
+			in_block_comment = true
+			i += 2
+			continue
+		}
+		c := line[i]
+		if c in [`'`, `"`] {
+			at_line_start = false
+			quote := c
+			i++
+			for i < line.len {
+				if line[i] == `\\` && i + 1 < line.len {
+					i += 2
+					continue
+				}
+				i++
+				if line[i - 1] == quote {
+					break
+				}
+			}
+			continue
+		}
+		if at_line_start && c.is_space() {
+			i++
+			continue
+		}
+		if at_line_start && c == `#` {
+			directive_at = i
+		}
+		at_line_start = false
+		i++
+	}
+	if directive_at < 0 {
+		return '', '', in_block_comment
+	}
+	directive, arg := cache_local_c_directive(line[directive_at..])
+	return directive, arg, in_block_comment
+}
+
 // V3CacheActiveCSourceScan retains a possible-code view after the first unresolved guard,
 // so native declaration discovery can detect definitions omitted from the active view.
 struct V3CacheActiveCSourceScan {
@@ -4108,8 +4209,11 @@ fn cache_c_source_definitely_active_code_rec(source string, source_path string, 
 	mut possible := strings.new_builder(256)
 	mut has_ambiguity := false
 	mut conditionals := []V3CacheLocalCConditional{}
+	mut in_block_comment := false
 	for line in source.split_into_lines() {
-		directive, arg := cache_local_c_directive(line)
+		directive, arg, next_block_comment := cache_local_c_directive_outside_comments(line,
+			in_block_comment)
+		in_block_comment = next_block_comment
 		if directive in ['if', 'ifdef', 'ifndef'] {
 			parent_inactive := conditionals.any(it.inactive)
 			parent_ambiguous := conditionals.any(it.ambiguous)
@@ -11595,16 +11699,20 @@ fn cache_source_with_cached_native_inputs(source string, state &V3ModuleCacheSta
 	}
 	mut found := map[string]bool{}
 	mut out := strings.new_builder(source.len + selected_include_lines.len * 64)
+	mut pending_lines := []string{}
 	for line in source.split_into_lines() {
 		clean := line.trim_space()
+		if clean !in all_include_lines {
+			pending_lines << line
+			continue
+		}
+		is_selected := selected_include_lines[clean]
+		cache_write_native_declaration_segment(pending_lines, is_selected, mut out)
+		pending_lines.clear()
 		if selected_include_lines[clean] {
 			// The compiler-only macro suppresses fallback declarations, but must not
 			// leak into native source that did not see it in the uncached unit.
 			out.writeln('#undef V3CACHE_PROGRAM_UNIT')
-			// This occurrence is still in its original generated directive sequence,
-			// which already established the exact macro state at the include site.
-			// Replaying its saved context here can undo mutations made by an earlier
-			// header (for example, redefining a macro that header just undefined).
 			out.writeln(line)
 			out.writeln('#define V3CACHE_PROGRAM_UNIT 1')
 			found[clean] = true
@@ -11613,10 +11721,9 @@ fn cache_source_with_cached_native_inputs(source string, state &V3ModuleCacheSta
 			if declarations := state.native_type_declarations[path] {
 				out.writeln(declarations)
 			}
-		} else {
-			out.writeln(line)
 		}
 	}
+	cache_write_native_declaration_segment(pending_lines, false, mut out)
 	mut remaining := strings.new_builder(selected_order.len * 96)
 	for include_line in selected_order {
 		if !found[include_line] {
@@ -11631,6 +11738,21 @@ fn cache_source_with_cached_native_inputs(source string, state &V3ModuleCacheSta
 		source:             out.str()
 		remaining_includes: remaining.str()
 		has_native:         true
+	}
+}
+
+fn cache_write_native_declaration_segment(lines []string, restore_implementation_macros bool, mut out strings.Builder) {
+	marker := '/* v3 cache omitted '
+	for line in lines {
+		clean := line.trim_space()
+		if restore_implementation_macros && clean.starts_with(marker) && clean.ends_with(' */') {
+			name := clean[marker.len..clean.len - 3].trim_space()
+			if cache_native_implementation_macro(name) {
+				out.writeln('#define ${name}')
+				continue
+			}
+		}
+		out.writeln(line)
 	}
 }
 

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -11601,10 +11601,10 @@ fn cache_source_with_cached_native_inputs(source string, state &V3ModuleCacheSta
 			// The compiler-only macro suppresses fallback declarations, but must not
 			// leak into native source that did not see it in the uncached unit.
 			out.writeln('#undef V3CACHE_PROGRAM_UNIT')
-			path := include_paths[clean] or { '' }
-			for directive in state.native_root_contexts[path] or { []string{} } {
-				out.writeln(directive)
-			}
+			// This occurrence is still in its original generated directive sequence,
+			// which already established the exact macro state at the include site.
+			// Replaying its saved context here can undo mutations made by an earlier
+			// header (for example, redefining a macro that header just undefined).
 			out.writeln(line)
 			out.writeln('#define V3CACHE_PROGRAM_UNIT 1')
 			found[clean] = true

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -2558,6 +2558,30 @@ fn prepare_v3_cache_external_inputs(mut state V3ModuleCacheState, a &flat.FlatAs
 	return !has_untracked_c_include && can_scope_static_inputs && can_extract_native_types
 }
 
+// prepare_v3_cache_external_inputs_scoped releases the large preprocessor and
+// declaration-scanner scratch buffers while retaining the compact cache manifest.
+fn prepare_v3_cache_external_inputs_scoped(mut state V3ModuleCacheState, a &flat.FlatAst, prefs &pref.Preferences, user_files []string, user_c_flags []string, scope_enabled bool) bool {
+	if !scope_enabled {
+		return prepare_v3_cache_external_inputs(mut state, a, prefs, user_files, user_c_flags)
+	}
+	scope := prealloc_scope_begin_for_v3()
+	complete := prepare_v3_cache_external_inputs(mut state, a, prefs, user_files, user_c_flags)
+	prealloc_scope_leave_for_v3(scope)
+	state.module_external_inputs = clone_string_list_map(state.module_external_inputs)
+	state.module_native_roots = clone_string_list_map(state.module_native_roots)
+	state.native_root_contexts = clone_string_list_map(state.native_root_contexts)
+	state.native_root_owners = clone_string_string_map(state.native_root_owners)
+	state.external_input_signatures = clone_string_string_map(state.external_input_signatures)
+	state.external_input_digests = clone_string_string_map(state.external_input_digests)
+	state.external_resolution_dirs = clone_string_list(state.external_resolution_dirs)
+	state.external_missing_paths = clone_string_list(state.external_missing_paths)
+	state.native_source_modules = clone_string_bool_map(state.native_source_modules)
+	state.native_type_declarations = clone_string_string_map(state.native_type_declarations)
+	state.native_declared_functions = clone_nested_string_bool_map(state.native_declared_functions)
+	prealloc_scope_free_for_v3(scope)
+	return complete
+}
+
 // prepare_v3_checker_native_inputs resolves native `#include` source roots so
 // the checker can register their typedefs, skipping the cache-unit ownership
 // scan and native type-declaration extraction whose outputs only cache-enabled
@@ -2609,7 +2633,12 @@ fn ast_has_native_source_include(a &flat.FlatAst) bool {
 	return false
 }
 
-fn register_native_source_typedefs(mut tc types.TypeChecker, state &V3ModuleCacheState) {
+fn register_native_source_typedefs(mut tc types.TypeChecker, state &V3ModuleCacheState, scope_enabled bool) {
+	mut typedefs := map[string]bool{}
+	mut scope := unsafe { nil }
+	if scope_enabled {
+		scope = prealloc_scope_begin_for_v3()
+	}
 	for roots in state.module_native_roots.values() {
 		for path in roots {
 			source := os.read_file(path) or { continue }
@@ -2617,14 +2646,26 @@ fn register_native_source_typedefs(mut tc types.TypeChecker, state &V3ModuleCach
 				if !present || name.len == 0 {
 					continue
 				}
-				c_name := 'C.${name}'
-				if c_name !in tc.structs {
-					tc.structs[c_name] = []types.StructField{}
-				}
 				if !c_typedef_is_function_pointer(source, name) {
-					tc.c_typedef_structs[c_name] = true
+					typedefs[name] = true
+				} else if name !in typedefs {
+					typedefs[name] = false
 				}
 			}
+		}
+	}
+	if scope_enabled {
+		prealloc_scope_leave_for_v3(scope)
+		typedefs = clone_string_bool_map(typedefs)
+		prealloc_scope_free_for_v3(scope)
+	}
+	for name, is_struct in typedefs {
+		c_name := 'C.${name}'
+		if c_name !in tc.structs {
+			tc.structs[c_name] = []types.StructField{}
+		}
+		if is_struct {
+			tc.c_typedef_structs[c_name] = true
 		}
 	}
 }
@@ -3028,7 +3069,6 @@ fn cache_native_public_include(path string, context []string, implementation_mac
 	// prior owning include may leave it defined even when this header's own
 	// context is declaration-only.
 	out.writeln('#undef SOKOL_IMPL')
-	mut restored := []string{}
 	for line in context {
 		directive, arg := cache_local_c_directive(line)
 		if directive == 'undef' {
@@ -3045,20 +3085,11 @@ fn cache_native_public_include(path string, context []string, implementation_mac
 		name := cache_local_c_define_name(arg)
 		if implementation_macros[name] || cache_native_implementation_macro(name) {
 			out.writeln('#undef ${name}')
-			restored << line
 		} else {
 			out.writeln(line)
 		}
 	}
 	out.writeln('#include "${c_include_path(path)}"')
-	// The implementation switches are only suppressed while the header expands, so
-	// its definitions stay in the owner object. Restore each define afterwards so a
-	// later native directive in the same translation unit (for example a
-	// declaration-only header guarded by the same macro) observes the macro state
-	// the uncached unit left behind instead of the temporary undefined state.
-	for line in restored {
-		out.writeln(line)
-	}
 	return out.str()
 }
 
@@ -5539,6 +5570,14 @@ fn clone_string_string_map(values map[string]string) map[string]string {
 	mut cloned := map[string]string{}
 	for key, value in values {
 		cloned[key.clone()] = value.clone()
+	}
+	return cloned
+}
+
+fn clone_nested_string_bool_map(values map[string]map[string]bool) map[string]map[string]bool {
+	mut cloned := map[string]map[string]bool{}
+	for key, value in values {
+		cloned[key.clone()] = clone_string_bool_map(value)
 	}
 	return cloned
 }
@@ -8522,8 +8561,8 @@ pub fn run(args []string) {
 			mut crun_c_flags := user_c_flags.clone()
 			crun_c_flags << cgen.cache_directive_flags(a, prefs.vroot, prefs.target,
 				prefs.compile_values)
-			_ = prepare_v3_cache_external_inputs(mut cache_state, a, prefs, user_files,
-				crun_c_flags)
+			_ = prepare_v3_cache_external_inputs_scoped(mut cache_state, a, prefs, user_files,
+				crun_c_flags, scope_prealloc_stages)
 			crun_build_identity = v3_crun_build_identity(&cache_state, prefs, user_files,
 				crun_c_flags, is_strict, enable_globals_compat, input_file)
 			if crun_build_identity.len > 0 {
@@ -8595,7 +8634,7 @@ pub fn run(args []string) {
 				incremental_snapshot.declaration_signature)
 		}
 		if !external_inputs_ready
-			&& !prepare_v3_cache_external_inputs(mut cache_state, a, prefs, user_files, cache_c_flags) {
+			&& !prepare_v3_cache_external_inputs_scoped(mut cache_state, a, prefs, user_files, cache_c_flags, scope_prealloc_stages) {
 			trace_v3_cache_fallback('external C inputs cannot be assigned to cache units')
 			restart_v3_without_cache()
 		}
@@ -8766,8 +8805,8 @@ pub fn run(args []string) {
 	mut ck_stage_sw := time.new_stopwatch()
 	if !cache_state.external_inputs_ready && ast_has_native_source_include(a) {
 		if cache_state.manager.enabled {
-			_ = prepare_v3_cache_external_inputs(mut cache_state, a, prefs, user_files,
-				cache_c_flags)
+			_ = prepare_v3_cache_external_inputs_scoped(mut cache_state, a, prefs, user_files,
+				cache_c_flags, scope_prealloc_stages)
 		} else {
 			prepare_v3_checker_native_inputs(mut cache_state, a, prefs, user_files, cache_c_flags)
 		}
@@ -8831,7 +8870,7 @@ pub fn run(args []string) {
 		mut cvsw := time.new_stopwatch()
 		pre_tc.collect(a)
 		register_headerless_c_types(mut pre_tc)
-		register_native_source_typedefs(mut pre_tc, &cache_state)
+		register_native_source_typedefs(mut pre_tc, &cache_state, scope_prealloc_stages)
 		if translated_mode {
 			for file in user_files {
 				pre_tc.translated_files[file] = true
@@ -8997,8 +9036,8 @@ pub fn run(args []string) {
 			return
 		}
 		if cache_state.manager.enabled {
-			if !prepare_v3_cache_external_inputs(mut cache_state, a, prefs, user_files,
-				cache_c_flags) {
+			if !prepare_v3_cache_external_inputs_scoped(mut cache_state, a, prefs, user_files,
+				cache_c_flags, scope_prealloc_stages) {
 				trace_v3_cache_fallback('external C inputs cannot be assigned to cache units')
 				restart_v3_without_cache()
 			}
@@ -9185,8 +9224,8 @@ pub fn run(args []string) {
 		// incomplete, leave the manifest without its completeness marker so the stable
 		// retry prints the fallback notice but does not submit an unverified report.
 		if backend == 'c' && !cache_state.external_inputs_ready {
-			_ = prepare_v3_cache_external_inputs(mut cache_state, a, prefs, user_files,
-				cache_c_flags)
+			_ = prepare_v3_cache_external_inputs_scoped(mut cache_state, a, prefs, user_files,
+				cache_c_flags, scope_prealloc_stages)
 		}
 		if backend == 'c' && cache_state.external_inputs_ready {
 			fallback_report_sources = macos_v3_fallback_report_inputs(fallback_report_sources,
@@ -12490,15 +12529,33 @@ fn v3_cached_object_compile_signature(c_standard string, opt_flag string, pic_fl
 }
 
 fn v3_cached_object_wrapper_compile_signature(base string, generated_source string) string {
-	if !generated_source.contains('/* V3CACHE_PROGRAM_WRAPPERS */') {
+	start_marker := '/* V3CACHE_PROGRAM_WRAPPERS */'
+	end_marker := '/* V3CACHE_PROGRAM_WRAPPERS_END */'
+	first_start := generated_source.index(start_marker) or { return base }
+	mut sections := strings.new_builder(1024)
+	mut pos := first_start
+	for {
+		start := generated_source.index_after(start_marker, pos) or { break }
+		end := generated_source.index_after(end_marker, start + start_marker.len) or {
+			// Fail closed for cache-marked C emitted by an older compiler or a
+			// truncated section: its complete prefix is the only safe identity.
+			prefix := generated_source.all_before('/* V3CACHE_BODY_BEGIN */')
+			return '${base}\nprogram_wrappers=${sha256.hexhash(prefix)}'
+		}
+		section_end := end + end_marker.len
+		sections.write_string(generated_source[start..section_end])
+		pos = section_end
+	}
+	wrapper_source := sections.str()
+	if wrapper_source.len == 0 {
 		return base
 	}
 	// Static callback/thread/method-value wrappers are emitted in the shared C
 	// prefix and therefore become part of every cached module object. Their set is
-	// specific to the entry program, so include the complete prefix in the object
-	// key while leaving wrapper-free programs on the normal cross-project key.
-	prefix := generated_source.all_before('/* V3CACHE_BODY_BEGIN */')
-	return '${base}\nprogram_wrappers=${sha256.hexhash(prefix)}'
+	// specific to the entry program. Hash just the delimited wrapper sections so
+	// native-input pruning cannot make the cold and prepared-prefix identities
+	// disagree while leaving wrapper-free programs on the cross-project key.
+	return '${base}\nprogram_wrappers=${sha256.hexhash(wrapper_source)}'
 }
 
 fn resolve_flag_specific_cache_objects(mut state V3ModuleCacheState, compile_signature string) bool {

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -1431,6 +1431,66 @@ pub fn cache_external_input_files_with_resolved_flags(a &flat.FlatAst, vroot str
 	return inputs, native_source_roots, native_root_contexts, unscoped_inputs, static_storage_inputs, resolution_dirs, missing_resolution_paths, has_untracked_include
 }
 
+struct CCachePlacedInclude {
+	file_node      int
+	module_node    int
+	directive_node int
+}
+
+// c_cache_external_input_node_order mirrors cgen placement: preincludes are
+// emitted before the translation-unit prefix and postincludes after its bodies,
+// independent of where their V directives occur.
+fn c_cache_external_input_node_order(a &flat.FlatAst) []int {
+	mut preincludes := []CCachePlacedInclude{}
+	mut postincludes := []CCachePlacedInclude{}
+	mut normal := []int{cap: a.nodes.len}
+	mut file_node := -1
+	mut module_node := -1
+	for node_id, node in a.nodes {
+		if node.kind == .file {
+			file_node = node_id
+			module_node = -1
+		} else if node.kind == .module_decl {
+			module_node = node_id
+		}
+		if node.kind == .directive && node.value in ['preinclude', 'postinclude'] {
+			placed := CCachePlacedInclude{
+				file_node:      file_node
+				module_node:    module_node
+				directive_node: node_id
+			}
+			if node.value == 'preinclude' {
+				preincludes << placed
+			} else {
+				postincludes << placed
+			}
+			continue
+		}
+		normal << node_id
+	}
+	mut ordered := []int{cap: normal.len + (preincludes.len + postincludes.len) * 3}
+	for placed in preincludes {
+		if placed.file_node >= 0 {
+			ordered << placed.file_node
+		}
+		if placed.module_node >= 0 {
+			ordered << placed.module_node
+		}
+		ordered << placed.directive_node
+	}
+	ordered << normal
+	for placed in postincludes {
+		if placed.file_node >= 0 {
+			ordered << placed.file_node
+		}
+		if placed.module_node >= 0 {
+			ordered << placed.module_node
+		}
+		ordered << placed.directive_node
+	}
+	return ordered
+}
+
 // cache_external_input_snapshot_with_resolved_flags also returns SHA-256 digests
 // of the exact native buffers used to resolve the dependency tree.
 pub fn cache_external_input_snapshot_with_resolved_flags(a &flat.FlatAst, vroot string, source_modules map[string]bool, c_flags []string, target pref.Target, program_files map[string]bool, compiler_macros map[string]string, compiler_macro_environment_complete bool) (map[string][]string, map[string][]string, map[string][]string, map[string][]string, map[string][]string, []string, []string, map[string]string, bool) {
@@ -1463,9 +1523,11 @@ pub fn cache_external_input_snapshot_with_resolved_flags(a &flat.FlatAst, vroot 
 	mut cur_file := ''
 	mut cur_file_is_program := false
 	mut context_directives := map[string][]string{}
+	mut preinclude_context_directives := []string{}
 	mut conditional_context_mutations := map[string]bool{}
 	mut conditionals := []CCacheConditional{}
-	for node in a.nodes {
+	for node_id in c_cache_external_input_node_order(a) {
+		node := a.nodes[node_id]
 		if node.kind == .file {
 			cur_file = node.value
 			cur_file_is_program = program_files[cur_file] || program_files[os.real_path(cur_file)]
@@ -1573,12 +1635,14 @@ pub fn cache_external_input_snapshot_with_resolved_flags(a &flat.FlatAst, vroot 
 				// Objective-C++ sources are already materialized as separate native-language
 				// wrappers. Assigning them to a C cache object compiles them twice and uses
 				// the wrong language for the cached copy.
-				is_native_root := (is_source_input || node.value == 'insert')
-					&& !real_path.ends_with('.mm')
+				is_native_root := node.value in ['include', 'insert']
+					&& (is_source_input || node.value == 'insert') && !real_path.ends_with('.mm')
 				if is_native_root {
+					mut root_context := preinclude_context_directives.clone()
+					root_context << context_directives[owner_module]
 					if !c_add_cache_native_source_root(mut native_source_roots, mut
-						native_root_contexts, owner_module, real_path,
-						context_directives[owner_module], context_is_replayable) {
+						native_root_contexts, owner_module, real_path, root_context,
+						context_is_replayable) {
 						has_untracked_include = true
 					}
 				}
@@ -1595,6 +1659,11 @@ pub fn cache_external_input_snapshot_with_resolved_flags(a &flat.FlatAst, vroot 
 				}
 				for file in files {
 					c_add_cache_external_input(mut inputs, owner_module, file)
+					if node.value == 'preinclude' {
+						// Preincludes are part of every generated cache translation unit,
+						// so every object stamp must track their complete input tree.
+						c_add_cache_external_input(mut inputs, '__v3_c_flags__', file)
+					}
 					if is_source_input || include_arg.trim_space().starts_with('"') {
 						c_add_cache_external_input(mut unscoped_inputs, owner_module, file)
 						collection_key := owner_module + '\x00' + os.real_path(file)
@@ -1604,11 +1673,14 @@ pub fn cache_external_input_snapshot_with_resolved_flags(a &flat.FlatAst, vroot 
 						}
 					}
 				}
-				if !is_source_input && include_arg.trim_space().starts_with('"')
+				if node.value in ['include', 'insert'] && !is_source_input
+					&& include_arg.trim_space().starts_with('"')
 					&& files.any(active_static_storage_paths[owner_module + '\x00' + os.real_path(it)]) {
+					mut root_context := preinclude_context_directives.clone()
+					root_context << context_directives[owner_module]
 					if !c_add_cache_native_source_root(mut native_source_roots, mut
-						native_root_contexts, owner_module, real_path,
-						context_directives[owner_module], context_is_replayable) {
+						native_root_contexts, owner_module, real_path, root_context,
+						context_is_replayable) {
 						has_untracked_include = true
 					}
 				}
@@ -1617,7 +1689,7 @@ pub fn cache_external_input_snapshot_with_resolved_flags(a &flat.FlatAst, vroot 
 				// mutations into the context. This preserves conditional guards, multiline
 				// definitions, push/pop state, and include order without retaining thousands
 				// of system-header definitions.
-				if !is_source_input && node.value != 'insert' {
+				if !is_source_input && node.value == 'include' {
 					if conditionals.any(it.ambiguous) {
 						conditional_context_mutations[owner_module] = true
 					} else {
@@ -1625,6 +1697,15 @@ pub fn cache_external_input_snapshot_with_resolved_flags(a &flat.FlatAst, vroot 
 						module_context << c_cache_context_include_directive(include_arg, real_path)
 						context_directives[owner_module] = module_context
 					}
+				} else if !is_source_input && node.value == 'preinclude' {
+					directive := c_cache_context_include_directive(include_arg, real_path)
+					if directive !in preinclude_context_directives {
+						preinclude_context_directives << directive
+					}
+				} else if is_source_input && node.value in ['preinclude', 'postinclude'] {
+					// Hoisted native source files cannot be assigned to a module object
+					// without changing their generated placement.
+					has_untracked_include = true
 				}
 				break
 			}
@@ -7992,59 +8073,48 @@ fn (mut g FlatGen) collect_inlined_c_structs(text string) {
 	}
 }
 
-// collect_cache_native_c_symbols records C names supplied by a
-// native header that cache splitting preserves as an include. Without this,
-// empty C placeholders discovered while checking selector expressions can be
-// emitted as fallback structs before the header, colliding with its typedefs,
-// enum values, and field names.
+// collect_cache_native_c_symbols records type names declared by a native header
+// that cache splitting preserves as an include. Empty C placeholders discovered
+// while checking selector expressions must not be emitted before a real typedef,
+// tag, or Objective-C type declaration. Ordinary identifiers such as parameters,
+// fields, and enum values do not declare types and must not suppress placeholders.
 fn (mut g FlatGen) collect_cache_native_c_symbols(text string) {
-	mut i := 0
-	for i < text.len {
-		if text[i] == `/` && i + 1 < text.len {
-			if text[i + 1] == `/` {
-				i += 2
-				for i < text.len && text[i] != `\n` {
-					i++
-				}
-				continue
-			}
-			if text[i + 1] == `*` {
-				i += 2
-				for i + 1 < text.len && !(text[i] == `*` && text[i + 1] == `/`) {
-					i++
-				}
-				if i + 1 < text.len {
-					i += 2
-				}
-				continue
-			}
-		}
-		if text[i] in [`'`, `"`] {
-			quote := text[i]
-			i++
-			for i < text.len {
-				if text[i] == `\\` && i + 1 < text.len {
-					i += 2
-					continue
-				}
-				i++
-				if text[i - 1] == quote {
-					break
+	declarations, _ := modulecache.c_source_type_declarations_with_status(text)
+	clean_declarations := c_strip_comments(declarations)
+	for name, _ in modulecache.c_source_type_identifiers(clean_declarations) {
+		g.cache_native_c_symbols[name] = true
+	}
+	// The shared identifier extractor records aggregate tags and the final alias
+	// in a typedef. Preserve every alias in comma-separated and function typedefs.
+	for alias in c_typedef_all_aggregate_aliases(clean_declarations) {
+		g.cache_native_c_symbols[alias] = true
+	}
+	for alias in c_typedef_plain_aliases(clean_declarations) {
+		g.cache_native_c_symbols[alias] = true
+	}
+	for alias in c_typedef_fn_aliases(clean_declarations) {
+		g.cache_native_c_symbols[alias] = true
+	}
+	// Objective-C classes and protocols are type declarations too, but do not
+	// use C's struct/union/enum or typedef spelling.
+	for line in clean_declarations.split_into_lines() {
+		clean := line.trim_space()
+		for prefix in ['@interface ', '@protocol '] {
+			if clean.starts_with(prefix) {
+				name := c_header_struct_tag(clean[prefix.len..])
+				if name.len > 0 {
+					g.cache_native_c_symbols[name] = true
 				}
 			}
-			continue
 		}
-		if !c_identifier_start(text[i]) {
-			i++
-			continue
+		if clean.starts_with('@class ') {
+			for declaration in clean['@class '.len..].trim_right(';').split(',') {
+				name := c_header_struct_tag(declaration.trim_space())
+				if name.len > 0 {
+					g.cache_native_c_symbols[name] = true
+				}
+			}
 		}
-		start := i
-		i++
-		for i < text.len && c_identifier_continue(text[i]) {
-			i++
-		}
-		identifier := unsafe { text[start..i] }
-		g.cache_native_c_symbols[identifier] = true
 	}
 }
 

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -393,6 +393,7 @@ mut:
 	objective_cpp_source_requests  []ObjectiveCppSourceRequest
 	native_source_wrapper_index    int
 	inlined_c_structs              map[string]bool
+	cache_native_c_symbols         map[string]bool
 	inlined_c_typedef_names        map[string]bool
 	inlined_c_fns                  map[string]bool
 	inlined_c_declared_fns         map[string]bool
@@ -1089,6 +1090,7 @@ pub fn FlatGen.new() FlatGen {
 		native_source_contexts:          map[string][]NativeSourceContextDirective{}
 		objective_cpp_source_requests:   []ObjectiveCppSourceRequest{}
 		inlined_c_structs:               map[string]bool{}
+		cache_native_c_symbols:          map[string]bool{}
 		inlined_c_fns:                   map[string]bool{}
 		inlined_c_declared_fns:          map[string]bool{}
 		inlined_c_active_macros:         map[string]bool{}
@@ -1433,11 +1435,11 @@ pub fn cache_external_input_files_with_resolved_flags(a &flat.FlatAst, vroot str
 // of the exact native buffers used to resolve the dependency tree.
 pub fn cache_external_input_snapshot_with_resolved_flags(a &flat.FlatAst, vroot string, source_modules map[string]bool, c_flags []string, target pref.Target, program_files map[string]bool, compiler_macros map[string]string, compiler_macro_environment_complete bool) (map[string][]string, map[string][]string, map[string][]string, map[string][]string, map[string][]string, []string, []string, map[string]string, bool) {
 	include_dirs := c_flag_include_dirs(c_flags)
-	mut captured_input_texts := map[string]string{}
 	mut captured_input_digests := map[string]string{}
+	mut literal_include_macros := map[string][]string{}
 	flag_inputs, flags_have_untracked_include, mut include_macros, mut dynamic_include_macros, mut resolution_dirs, mut missing_resolution_paths := cache_c_flag_input_files_with_status(c_flags,
-		compiler_macros, compiler_macro_environment_complete, mut captured_input_texts, mut
-		captured_input_digests)
+		compiler_macros, compiler_macro_environment_complete, mut captured_input_digests, mut
+		literal_include_macros)
 	mut collect_modules := map[string]bool{}
 	for module_name, enabled in source_modules {
 		if enabled {
@@ -1519,10 +1521,16 @@ pub fn cache_external_input_snapshot_with_resolved_flags(a &flat.FlatAst, vroot 
 			}
 		}
 		if node.kind == .directive && node.value in ['define', 'undef'] {
+			// A mutation in a definitely inactive branch never reaches the C
+			// preprocessor state at a later native root. Recording it would replay
+			// dead configuration unconditionally and unnecessarily disable splitting.
+			if conditionals.any(it.inactive) {
+				continue
+			}
 			directive := c_preprocessor_directive_line(node.value, node.typ)
-			is_ambiguous := conditionals.any(it.inactive || it.ambiguous)
+			is_ambiguous := conditionals.any(it.ambiguous)
 			c_record_include_macro_definition(directive, is_ambiguous, mut include_macros, mut
-				dynamic_include_macros)
+				dynamic_include_macros, compiler_macro_environment_complete)
 			mut module_context := context_directives[owner_module]
 			module_context << directive
 			context_directives[owner_module] = module_context
@@ -1533,6 +1541,11 @@ pub fn cache_external_input_snapshot_with_resolved_flags(a &flat.FlatAst, vroot 
 		}
 		if node.kind == .directive
 			&& node.value in ['include', 'insert', 'preinclude', 'postinclude'] && node.typ.len > 0 {
+			// Do not assign a native input that the current preprocessor state has
+			// proved unreachable. Ambiguous branches still fail closed below.
+			if conditionals.any(it.inactive) {
+				continue
+			}
 			include_arg := c_include_arg_for_target(node.typ, vroot, cur_file, target)
 			if include_arg.len == 0 {
 				continue
@@ -1547,7 +1560,7 @@ pub fn cache_external_input_snapshot_with_resolved_flags(a &flat.FlatAst, vroot 
 				has_untracked_include = true
 				continue
 			}
-			context_is_replayable := !conditionals.any(it.inactive || it.ambiguous)
+			context_is_replayable := !conditionals.any(it.ambiguous)
 				&& !conditional_context_mutations[owner_module]
 			for path in c_include_file_paths(include_arg, vroot, cur_file, include_dirs) {
 				c_record_cache_resolution_path(path, mut resolution_dirs, mut
@@ -1571,13 +1584,12 @@ pub fn cache_external_input_snapshot_with_resolved_flags(a &flat.FlatAst, vroot 
 				}
 				mut active_paths := map[string]bool{}
 				mut files := []string{}
-				mut input_context := CCacheContextCapture{}
 				if c_collect_external_input_tree(path, vroot, include_dirs, mut active_paths, mut
 					collected_paths, mut ambiguous_collected_paths, mut files, mut include_macros, mut
-					dynamic_include_macros, mut resolution_dirs, mut missing_resolution_paths, mut
-					active_static_storage_paths, mut captured_input_texts, mut
+					dynamic_include_macros, mut literal_include_macros, mut resolution_dirs, mut
+					missing_resolution_paths, mut active_static_storage_paths, mut
 					captured_input_digests, owner_module, false,
-					compiler_macro_environment_complete, mut input_context)
+					compiler_macro_environment_complete)
 				{
 					has_untracked_include = true
 				}
@@ -1600,15 +1612,17 @@ pub fn cache_external_input_snapshot_with_resolved_flags(a &flat.FlatAst, vroot 
 						has_untracked_include = true
 					}
 				}
-				// A preceding quoted header can change the macro state seen by a later
-				// native root. Preserve definite mutations in replay order; if its state
-				// cannot be represented exactly, make the next root fail closed.
+				// A preceding header can change the macro state seen by a later native
+				// root. Replay the header itself instead of expanding its transitive macro
+				// mutations into the context. This preserves conditional guards, multiline
+				// definitions, push/pop state, and include order without retaining thousands
+				// of system-header definitions.
 				if !is_source_input && node.value != 'insert' {
-					if conditionals.any(it.ambiguous) || !input_context.complete {
+					if conditionals.any(it.ambiguous) {
 						conditional_context_mutations[owner_module] = true
-					} else if !conditionals.any(it.inactive) && input_context.mutations.len > 0 {
+					} else {
 						mut module_context := context_directives[owner_module]
-						module_context << input_context.mutations
+						module_context << c_cache_context_include_directive(include_arg, real_path)
 						context_directives[owner_module] = module_context
 					}
 				}
@@ -1617,9 +1631,8 @@ pub fn cache_external_input_snapshot_with_resolved_flags(a &flat.FlatAst, vroot 
 			continue
 		}
 		if path := c_embed_external_input_path(a, node) {
-			if _ := c_captured_external_input_text(path, mut captured_input_texts, mut
-				captured_input_digests)
-			{
+			if text := c_snapshot_external_input_text(path, mut captured_input_digests) {
+				unsafe { text.free() }
 				c_add_cache_external_input(mut inputs, owner_module, path)
 			} else {
 				has_untracked_include = true
@@ -1652,6 +1665,14 @@ pub fn cache_external_input_snapshot_with_resolved_flags(a &flat.FlatAst, vroot 
 	mut sorted_missing_resolution_paths := missing_resolution_paths.keys()
 	sorted_missing_resolution_paths.sort()
 	return inputs, native_source_roots, native_root_contexts, unscoped_inputs, static_storage_inputs, sorted_resolution_dirs, sorted_missing_resolution_paths, captured_input_digests, has_untracked_include
+}
+
+fn c_cache_context_include_directive(include_arg string, real_path string) string {
+	clean := include_arg.trim_space()
+	if clean.starts_with('<') {
+		return '#include ${clean}'
+	}
+	return '#include "${c_escape(real_path)}"'
 }
 
 fn c_add_cache_native_source_root(mut native_source_roots map[string][]string, mut native_root_contexts map[string][]string, owner_module string, real_path string, context []string, context_is_replayable bool) bool {
@@ -1813,14 +1834,14 @@ fn c_native_language_from_features(need_objc bool, need_cpp bool) string {
 // cache_c_flag_input_files returns forced include/macro files whose contents
 // affect every cached object compiled with the supplied C flags.
 pub fn cache_c_flag_input_files(flags []string) []string {
-	mut captured_input_texts := map[string]string{}
 	mut captured_input_digests := map[string]string{}
+	mut literal_include_macros := map[string][]string{}
 	files, _, _, _, _, _ := cache_c_flag_input_files_with_status(flags, map[string]string{}, false, mut
-		captured_input_texts, mut captured_input_digests)
+		captured_input_digests, mut literal_include_macros)
 	return files
 }
 
-fn cache_c_flag_input_files_with_status(flags []string, compiler_macros map[string]string, compiler_macro_environment_complete bool, mut captured_input_texts map[string]string, mut captured_input_digests map[string]string) ([]string, bool, map[string][]string, map[string]bool, map[string]bool, map[string]bool) {
+fn cache_c_flag_input_files_with_status(flags []string, compiler_macros map[string]string, compiler_macro_environment_complete bool, mut captured_input_digests map[string]string, mut literal_include_macros map[string][]string) ([]string, bool, map[string][]string, map[string]bool, map[string]bool, map[string]bool) {
 	include_dirs := c_flag_include_dirs(flags)
 	mut active_paths := map[string]bool{}
 	mut collected_paths := map[string]bool{}
@@ -1832,7 +1853,6 @@ fn cache_c_flag_input_files_with_status(flags []string, compiler_macros map[stri
 	mut has_untracked_include := false
 	mut include_macros, mut dynamic_include_macros := c_flag_include_macro_definitions(flags,
 		compiler_macros)
-	mut ignored_context := CCacheContextCapture{}
 	for forced_input in c_forced_include_inputs(flags) {
 		for path in c_include_file_paths('"${forced_input}"', '', '', include_dirs) {
 			c_record_cache_resolution_path(path, mut resolution_dirs, mut missing_resolution_paths)
@@ -1841,9 +1861,10 @@ fn cache_c_flag_input_files_with_status(flags []string, compiler_macros map[stri
 			}
 			if c_collect_external_input_tree(path, '', include_dirs, mut active_paths, mut
 				collected_paths, mut ambiguous_collected_paths, mut files, mut include_macros, mut
-				dynamic_include_macros, mut resolution_dirs, mut missing_resolution_paths, mut
-				active_static_storage_paths, mut captured_input_texts, mut captured_input_digests,
-				'__v3_c_flags__', false, compiler_macro_environment_complete, mut ignored_context)
+				dynamic_include_macros, mut literal_include_macros, mut resolution_dirs, mut
+				missing_resolution_paths, mut active_static_storage_paths, mut
+				captured_input_digests, '__v3_c_flags__', false,
+				compiler_macro_environment_complete)
 			{
 				has_untracked_include = true
 			}
@@ -1902,13 +1923,7 @@ mut:
 	ambiguous bool
 }
 
-struct CCacheContextCapture {
-mut:
-	mutations []string
-	complete  bool = true
-}
-
-fn c_collect_external_input_tree(path string, vroot string, include_dirs []string, mut active_paths map[string]bool, mut collected_paths map[string]bool, mut ambiguous_collected_paths map[string]bool, mut files []string, mut include_macros map[string][]string, mut dynamic_include_macros map[string]bool, mut resolution_dirs map[string]bool, mut missing_resolution_paths map[string]bool, mut active_static_storage_paths map[string]bool, mut captured_input_texts map[string]string, mut captured_input_digests map[string]string, collection_scope string, ambient_ambiguous bool, compiler_macro_environment_complete bool, mut context_capture CCacheContextCapture) bool {
+fn c_collect_external_input_tree(path string, vroot string, include_dirs []string, mut active_paths map[string]bool, mut collected_paths map[string]bool, mut ambiguous_collected_paths map[string]bool, mut files []string, mut include_macros map[string][]string, mut dynamic_include_macros map[string]bool, mut literal_include_macros map[string][]string, mut resolution_dirs map[string]bool, mut missing_resolution_paths map[string]bool, mut active_static_storage_paths map[string]bool, mut captured_input_digests map[string]string, collection_scope string, ambient_ambiguous bool, compiler_macro_environment_complete bool) bool {
 	if path.len == 0 {
 		return false
 	}
@@ -1916,8 +1931,10 @@ fn c_collect_external_input_tree(path string, vroot string, include_dirs []strin
 	if active_paths[real_path] {
 		return false
 	}
-	text := c_captured_external_input_text(real_path, mut captured_input_texts, mut
-		captured_input_digests) or { return true }
+	text := c_snapshot_external_input_text(real_path, mut captured_input_digests) or { return true }
+	defer {
+		unsafe { text.free() }
+	}
 	collection_key := collection_scope + '\x00' + real_path
 	first_collection := !collected_paths[collection_key]
 	if collected_paths[collection_key] {
@@ -1965,10 +1982,20 @@ fn c_collect_external_input_tree(path string, vroot string, include_dirs []strin
 	mut possible_source := strings.new_builder(text.len)
 	mut in_block_comment := false
 	mut conditionals := []CCacheConditional{}
-	for line in text.split_into_lines() {
+	defer {
+		unsafe { conditionals.free() }
+	}
+	mut lines := text.split_into_lines()
+	defer {
+		unsafe { lines.free() }
+	}
+	for line in lines {
 		clean, next_in_block_comment := c_preprocessor_directive_scan_line(line, in_block_comment)
 		in_block_comment = next_in_block_comment
 		directive_name := c_directive_name(clean)
+		if directive_name == 'define' {
+			c_record_literal_include_macro_definition(clean, mut literal_include_macros)
+		}
 		if directive_name in ['if', 'ifdef', 'ifndef'] {
 			parent_inactive := conditionals.any(it.inactive)
 			parent_ambiguous := conditionals.any(it.ambiguous)
@@ -2011,18 +2038,8 @@ fn c_collect_external_input_tree(path string, vroot string, include_dirs []strin
 		possible_source.writeln(line)
 		if directive_name !in ['include', 'import'] {
 			mutation_is_ambiguous := ambient_ambiguous || conditionals.any(it.ambiguous)
-			if directive_name in ['define', 'undef'] {
-				if mutation_is_ambiguous || line.trim_space().ends_with('\\') {
-					context_capture.complete = false
-				} else {
-					context_capture.mutations << clean
-				}
-			} else if directive_name == 'pragma' && (c_directive_arg(clean).contains('push_macro')
-				|| c_directive_arg(clean).contains('pop_macro')) {
-				context_capture.complete = false
-			}
 			c_record_include_macro_definition(clean, mutation_is_ambiguous, mut include_macros, mut
-				dynamic_include_macros)
+				dynamic_include_macros, compiler_macro_environment_complete)
 			continue
 		}
 		mut include_args := [c_include_arg(c_directive_arg(clean), vroot, real_path)]
@@ -2042,8 +2059,7 @@ fn c_collect_external_input_tree(path string, vroot string, include_dirs []strin
 			}
 			include_args = include_macros[macro_name].clone()
 			if include_args.len == 0 {
-				literal_values := c_literal_include_macro_values(files, captured_input_texts,
-					macro_name)
+				literal_values := literal_include_macros[macro_name].clone()
 				if literal_values.len == 1 {
 					include_args = literal_values.clone()
 					include_macros[macro_name] = include_args.clone()
@@ -2068,10 +2084,10 @@ fn c_collect_external_input_tree(path string, vroot string, include_dirs []strin
 				nested_ambiguous := ambient_ambiguous || conditionals.any(it.ambiguous)
 				if c_collect_external_input_tree(nested_path, vroot, include_dirs, mut
 					active_paths, mut collected_paths, mut ambiguous_collected_paths, mut files, mut
-					include_macros, mut dynamic_include_macros, mut resolution_dirs, mut
-					missing_resolution_paths, mut active_static_storage_paths, mut
-					captured_input_texts, mut captured_input_digests, collection_scope,
-					nested_ambiguous, compiler_macro_environment_complete, mut context_capture)
+					include_macros, mut dynamic_include_macros, mut literal_include_macros, mut
+					resolution_dirs, mut missing_resolution_paths, mut active_static_storage_paths, mut
+					captured_input_digests, collection_scope, nested_ambiguous,
+					compiler_macro_environment_complete)
 				{
 					has_untracked_include = true
 				}
@@ -2086,45 +2102,55 @@ fn c_collect_external_input_tree(path string, vroot string, include_dirs []strin
 			eprintln('  V3 module cache active static C input: module=${collection_scope} path=${real_path}')
 		}
 	}
+	unsafe { possible_text.free() }
 	unsafe { possible_source.free() }
 	return has_untracked_include
 }
 
-fn c_literal_include_macro_values(paths []string, captured_input_texts map[string]string, macro_name string) []string {
-	mut values := []string{}
-	for path in paths {
-		text := captured_input_texts[os.real_path(path)] or { continue }
-		mut in_block_comment := false
-		for line in text.split_into_lines() {
-			clean, next_in_block_comment := c_preprocessor_directive_scan_line(line,
-				in_block_comment)
-			in_block_comment = next_in_block_comment
-			if c_directive_name(clean) != 'define' {
-				continue
-			}
-			definition := c_directive_arg(clean)
-			fields := definition.fields()
-			if fields.len == 0 || fields[0] != macro_name {
-				continue
-			}
-			value := definition[macro_name.len..].trim_space()
-			if c_include_arg_is_literal(value) && value !in values {
-				values << value
-			}
-		}
+fn c_record_literal_include_macro_definition(directive string, mut literal_include_macros map[string][]string) {
+	definition := c_directive_arg(directive)
+	mut name_end := 0
+	for name_end < definition.len && !definition[name_end].is_space() {
+		name_end++
 	}
-	values.sort()
-	return values
+	if name_end == 0 || name_end >= definition.len || definition[..name_end].contains('(') {
+		return
+	}
+	name := definition[..name_end]
+	value := definition[name_end..].trim_space()
+	if !c_include_arg_is_literal(value) {
+		return
+	}
+	mut values := literal_include_macros[name]
+	if value !in values {
+		values << value
+		values.sort()
+		literal_include_macros[name] = values
+	}
 }
 
-fn c_captured_external_input_text(path string, mut captured_input_texts map[string]string, mut captured_input_digests map[string]string) ?string {
+// c_snapshot_external_input_text reads a native dependency without retaining its
+// potentially large contents. Repeated reads must match the digest of the first
+// buffer, otherwise the dependency tree no longer describes one exact snapshot.
+fn c_snapshot_external_input_text(path string, mut captured_input_digests map[string]string) ?string {
 	real_path := os.real_path(path)
-	if real_path in captured_input_texts {
-		return captured_input_texts[real_path]
+	text := os.read_file(real_path) or {
+		if os.getenv('V3_CACHE_TRACE') != '' {
+			eprintln('  V3 module cache native input read failed: path=${real_path}')
+		}
+		return none
 	}
-	text := os.read_file(real_path) or { return none }
-	captured_input_texts[real_path] = text
-	captured_input_digests[real_path] = sha256.hexhash(text)
+	digest := sha256.hexhash(text)
+	if captured_digest := captured_input_digests[real_path] {
+		if captured_digest != digest {
+			if os.getenv('V3_CACHE_TRACE') != '' {
+				eprintln('  V3 module cache native input changed during scan: path=${real_path}')
+			}
+			return none
+		}
+	} else {
+		captured_input_digests[real_path] = digest
+	}
 	return text
 }
 
@@ -2339,7 +2365,7 @@ fn c_flag_include_macro_definitions(flags []string, compiler_macros map[string]s
 	return include_macros, dynamic_include_macros
 }
 
-fn c_record_include_macro_definition(directive string, ambiguous bool, mut include_macros map[string][]string, mut dynamic_include_macros map[string]bool) {
+fn c_record_include_macro_definition(directive string, ambiguous bool, mut include_macros map[string][]string, mut dynamic_include_macros map[string]bool, compiler_macro_environment_complete bool) {
 	directive_name := c_directive_name(directive)
 	if directive_name == 'undef' {
 		fields := c_directive_arg(directive).fields()
@@ -2347,6 +2373,14 @@ fn c_record_include_macro_definition(directive string, ambiguous bool, mut inclu
 			return
 		}
 		macro_name := fields[0]
+		// An #undef in an unresolved branch is still a definite no-op when the
+		// complete compiler environment and prior directives agree that the macro
+		// is already absent. Keep that known state instead of exploring code guarded
+		// by the macro later (TargetConditionals.h uses this pattern on macOS).
+		if ambiguous && compiler_macro_environment_complete && macro_name !in include_macros
+			&& macro_name !in dynamic_include_macros {
+			return
+		}
 		include_macros.delete(macro_name)
 		if ambiguous {
 			dynamic_include_macros[macro_name] = false
@@ -2748,6 +2782,7 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	g.objective_cpp_source_requests = []ObjectiveCppSourceRequest{}
 	g.native_source_wrapper_index = 0
 	g.inlined_c_structs.clear()
+	g.cache_native_c_symbols.clear()
 	g.inlined_c_fns.clear()
 	g.inlined_c_declared_fns.clear()
 	g.inlined_c_active_macros.clear()
@@ -4581,6 +4616,9 @@ fn (mut g FlatGen) collect_c_directive(module_name string, node flat.Node, sourc
 				g.c_flags << ['-x', 'objective-c', '-x', 'none']
 			}
 			g.collect_inlined_c_structs(header_text)
+			if g.cache_split {
+				g.collect_cache_native_c_symbols(header_text)
+			}
 			g.collect_inlined_c_fns_for_cache(header_text, false, true)
 			g.collect_inlined_c_declared_fns(header_text)
 			g.collect_preserved_c_fns(header.preserved_c_fns)
@@ -7951,6 +7989,62 @@ fn (mut g FlatGen) collect_inlined_c_structs(text string) {
 	for alias in c_typedef_fn_aliases(text) {
 		g.inlined_c_structs[alias] = true
 		g.inlined_c_typedef_names[alias] = true
+	}
+}
+
+// collect_cache_native_c_symbols records C names supplied by a
+// native header that cache splitting preserves as an include. Without this,
+// empty C placeholders discovered while checking selector expressions can be
+// emitted as fallback structs before the header, colliding with its typedefs,
+// enum values, and field names.
+fn (mut g FlatGen) collect_cache_native_c_symbols(text string) {
+	mut i := 0
+	for i < text.len {
+		if text[i] == `/` && i + 1 < text.len {
+			if text[i + 1] == `/` {
+				i += 2
+				for i < text.len && text[i] != `\n` {
+					i++
+				}
+				continue
+			}
+			if text[i + 1] == `*` {
+				i += 2
+				for i + 1 < text.len && !(text[i] == `*` && text[i + 1] == `/`) {
+					i++
+				}
+				if i + 1 < text.len {
+					i += 2
+				}
+				continue
+			}
+		}
+		if text[i] in [`'`, `"`] {
+			quote := text[i]
+			i++
+			for i < text.len {
+				if text[i] == `\\` && i + 1 < text.len {
+					i += 2
+					continue
+				}
+				i++
+				if text[i - 1] == quote {
+					break
+				}
+			}
+			continue
+		}
+		if !c_identifier_start(text[i]) {
+			i++
+			continue
+		}
+		start := i
+		i++
+		for i < text.len && c_identifier_continue(text[i]) {
+			i++
+		}
+		identifier := unsafe { text[start..i] }
+		g.cache_native_c_symbols[identifier] = true
 	}
 }
 
@@ -11733,7 +11827,9 @@ fn (mut g FlatGen) gen_cast_from_mut_pointer_param_value(id flat.NodeId, ct stri
 	if pointer_type.base_type !is types.Pointer {
 		return false
 	}
-	g.write('(${ct})(*${g.cname(node.value)})')
+	g.write('(${ct})(*')
+	g.gen_mut_pointer_slot_expr(id)
+	g.write(')')
 	return true
 }
 
@@ -13376,6 +13472,9 @@ fn (mut g FlatGen) sizeof_target(value string) string {
 		|| parsed is types.Interface || parsed is types.SumType
 		|| parsed is types.Alias) {
 		return g.value_sizeof_target(parsed)
+	}
+	if g.current_param_type(value) != none || g.cur_scope_has_local_name(value) {
+		return g.local_decl_cname(value)
 	}
 	// A dotted `sizeof` target can be either a qualified type (`time.Time`) or a
 	// selector expression (`bf.p`). Resolve visible values before interpreting the

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -1556,8 +1556,13 @@ pub fn cache_external_input_snapshot_with_resolved_flags(a &flat.FlatAst, vroot 
 					continue
 				}
 				is_source_input := c_include_arg_is_source_file(include_arg)
-				if is_source_input || node.value == 'insert' {
-					real_path := os.real_path(path)
+				real_path := os.real_path(path)
+				// Objective-C++ sources are already materialized as separate native-language
+				// wrappers. Assigning them to a C cache object compiles them twice and uses
+				// the wrong language for the cached copy.
+				is_native_root := (is_source_input || node.value == 'insert')
+					&& !real_path.ends_with('.mm')
+				if is_native_root {
 					if !c_add_cache_native_source_root(mut native_source_roots, mut
 						native_root_contexts, owner_module, real_path,
 						context_directives[owner_module], context_is_replayable) {
@@ -1566,12 +1571,13 @@ pub fn cache_external_input_snapshot_with_resolved_flags(a &flat.FlatAst, vroot 
 				}
 				mut active_paths := map[string]bool{}
 				mut files := []string{}
+				mut input_context := CCacheContextCapture{}
 				if c_collect_external_input_tree(path, vroot, include_dirs, mut active_paths, mut
 					collected_paths, mut ambiguous_collected_paths, mut files, mut include_macros, mut
 					dynamic_include_macros, mut resolution_dirs, mut missing_resolution_paths, mut
 					active_static_storage_paths, mut captured_input_texts, mut
 					captured_input_digests, owner_module, false,
-					compiler_macro_environment_complete)
+					compiler_macro_environment_complete, mut input_context)
 				{
 					has_untracked_include = true
 				}
@@ -1588,11 +1594,22 @@ pub fn cache_external_input_snapshot_with_resolved_flags(a &flat.FlatAst, vroot 
 				}
 				if !is_source_input && include_arg.trim_space().starts_with('"')
 					&& files.any(active_static_storage_paths[owner_module + '\x00' + os.real_path(it)]) {
-					real_path := os.real_path(path)
 					if !c_add_cache_native_source_root(mut native_source_roots, mut
 						native_root_contexts, owner_module, real_path,
 						context_directives[owner_module], context_is_replayable) {
 						has_untracked_include = true
+					}
+				}
+				// A preceding quoted header can change the macro state seen by a later
+				// native root. Preserve definite mutations in replay order; if its state
+				// cannot be represented exactly, make the next root fail closed.
+				if !is_source_input && node.value != 'insert' {
+					if conditionals.any(it.ambiguous) || !input_context.complete {
+						conditional_context_mutations[owner_module] = true
+					} else if !conditionals.any(it.inactive) && input_context.mutations.len > 0 {
+						mut module_context := context_directives[owner_module]
+						module_context << input_context.mutations
+						context_directives[owner_module] = module_context
 					}
 				}
 				break
@@ -1815,6 +1832,7 @@ fn cache_c_flag_input_files_with_status(flags []string, compiler_macros map[stri
 	mut has_untracked_include := false
 	mut include_macros, mut dynamic_include_macros := c_flag_include_macro_definitions(flags,
 		compiler_macros)
+	mut ignored_context := CCacheContextCapture{}
 	for forced_input in c_forced_include_inputs(flags) {
 		for path in c_include_file_paths('"${forced_input}"', '', '', include_dirs) {
 			c_record_cache_resolution_path(path, mut resolution_dirs, mut missing_resolution_paths)
@@ -1825,7 +1843,7 @@ fn cache_c_flag_input_files_with_status(flags []string, compiler_macros map[stri
 				collected_paths, mut ambiguous_collected_paths, mut files, mut include_macros, mut
 				dynamic_include_macros, mut resolution_dirs, mut missing_resolution_paths, mut
 				active_static_storage_paths, mut captured_input_texts, mut captured_input_digests,
-				'__v3_c_flags__', false, compiler_macro_environment_complete)
+				'__v3_c_flags__', false, compiler_macro_environment_complete, mut ignored_context)
 			{
 				has_untracked_include = true
 			}
@@ -1884,7 +1902,13 @@ mut:
 	ambiguous bool
 }
 
-fn c_collect_external_input_tree(path string, vroot string, include_dirs []string, mut active_paths map[string]bool, mut collected_paths map[string]bool, mut ambiguous_collected_paths map[string]bool, mut files []string, mut include_macros map[string][]string, mut dynamic_include_macros map[string]bool, mut resolution_dirs map[string]bool, mut missing_resolution_paths map[string]bool, mut active_static_storage_paths map[string]bool, mut captured_input_texts map[string]string, mut captured_input_digests map[string]string, collection_scope string, ambient_ambiguous bool, compiler_macro_environment_complete bool) bool {
+struct CCacheContextCapture {
+mut:
+	mutations []string
+	complete  bool = true
+}
+
+fn c_collect_external_input_tree(path string, vroot string, include_dirs []string, mut active_paths map[string]bool, mut collected_paths map[string]bool, mut ambiguous_collected_paths map[string]bool, mut files []string, mut include_macros map[string][]string, mut dynamic_include_macros map[string]bool, mut resolution_dirs map[string]bool, mut missing_resolution_paths map[string]bool, mut active_static_storage_paths map[string]bool, mut captured_input_texts map[string]string, mut captured_input_digests map[string]string, collection_scope string, ambient_ambiguous bool, compiler_macro_environment_complete bool, mut context_capture CCacheContextCapture) bool {
 	if path.len == 0 {
 		return false
 	}
@@ -1986,8 +2010,19 @@ fn c_collect_external_input_tree(path string, vroot string, include_dirs []strin
 		}
 		possible_source.writeln(line)
 		if directive_name !in ['include', 'import'] {
-			c_record_include_macro_definition(clean, ambient_ambiguous
-				|| conditionals.any(it.ambiguous), mut include_macros, mut dynamic_include_macros)
+			mutation_is_ambiguous := ambient_ambiguous || conditionals.any(it.ambiguous)
+			if directive_name in ['define', 'undef'] {
+				if mutation_is_ambiguous || line.trim_space().ends_with('\\') {
+					context_capture.complete = false
+				} else {
+					context_capture.mutations << clean
+				}
+			} else if directive_name == 'pragma' && (c_directive_arg(clean).contains('push_macro')
+				|| c_directive_arg(clean).contains('pop_macro')) {
+				context_capture.complete = false
+			}
+			c_record_include_macro_definition(clean, mutation_is_ambiguous, mut include_macros, mut
+				dynamic_include_macros)
 			continue
 		}
 		mut include_args := [c_include_arg(c_directive_arg(clean), vroot, real_path)]
@@ -2036,7 +2071,7 @@ fn c_collect_external_input_tree(path string, vroot string, include_dirs []strin
 					include_macros, mut dynamic_include_macros, mut resolution_dirs, mut
 					missing_resolution_paths, mut active_static_storage_paths, mut
 					captured_input_texts, mut captured_input_digests, collection_scope,
-					nested_ambiguous, compiler_macro_environment_complete)
+					nested_ambiguous, compiler_macro_environment_complete, mut context_capture)
 				{
 					has_untracked_include = true
 				}

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -7908,6 +7908,9 @@ fn c_preserved_system_include_typedef_names(include_arg string) []string {
 	if include_arg.starts_with('<X11/') {
 		return c_preserved_system_include_struct_names(include_arg)
 	}
+	if include_arg in ['<Cocoa/Cocoa.h>', '<Foundation/Foundation.h>', '<objc/objc.h>'] {
+		return ['BOOL']
+	}
 	return []string{}
 }
 
@@ -8073,15 +8076,21 @@ fn (mut g FlatGen) collect_inlined_c_structs(text string) {
 	}
 }
 
-// collect_cache_native_c_symbols records type names declared by a native header
-// that cache splitting preserves as an include. Empty C placeholders discovered
-// while checking selector expressions must not be emitted before a real typedef,
-// tag, or Objective-C type declaration. Ordinary identifiers such as parameters,
-// fields, and enum values do not declare types and must not suppress placeholders.
+// collect_cache_native_c_symbols records names declared by a native header that
+// cache splitting preserves as an include. Empty C placeholders discovered while
+// checking selector expressions must not be emitted before a real typedef, tag,
+// Objective-C type declaration, or enum constant. Ordinary identifiers such as
+// parameters and fields must not suppress placeholders.
 fn (mut g FlatGen) collect_cache_native_c_symbols(text string) {
 	declarations, _ := modulecache.c_source_type_declarations_with_status(text)
 	clean_declarations := c_strip_comments(declarations)
 	for name, _ in modulecache.c_source_type_identifiers(clean_declarations) {
+		g.cache_native_c_symbols[name] = true
+	}
+	// Selector expressions expose C enum constants as placeholder types until C
+	// generation resolves them. Only collect identifiers in actual enum bodies;
+	// scanning every header token also mistakes parameters and fields for types.
+	for name in c_cache_native_enum_constants(declarations) {
 		g.cache_native_c_symbols[name] = true
 	}
 	// The shared identifier extractor records aggregate tags and the final alias
@@ -8116,6 +8125,175 @@ fn (mut g FlatGen) collect_cache_native_c_symbols(text string) {
 			}
 		}
 	}
+}
+
+fn c_cache_native_enum_constants(text string) []string {
+	mut names := []string{}
+	mut i := 0
+	for i < text.len {
+		comment_end := c_cache_native_comment_end(text, i)
+		if comment_end != i {
+			i = comment_end
+			continue
+		}
+		if text[i] in [`'`, `"`] {
+			quote := text[i]
+			i++
+			for i < text.len {
+				if text[i] == quote && !c_flag_quote_is_escaped(text, i) {
+					i++
+					break
+				}
+				i++
+			}
+			continue
+		}
+		if !c_identifier_start(text[i]) {
+			i++
+			continue
+		}
+		token_start := i
+		i++
+		for i < text.len && c_identifier_continue(text[i]) {
+			i++
+		}
+		if text[token_start..i] != 'enum' {
+			continue
+		}
+		resume := i
+		mut brace := i
+		for brace < text.len && text[brace] !in [`{`, `;`] {
+			comment_end_at_brace := c_cache_native_comment_end(text, brace)
+			if comment_end_at_brace != brace {
+				brace = comment_end_at_brace
+				continue
+			}
+			if text[brace] in [`'`, `"`] {
+				quote := text[brace]
+				brace++
+				for brace < text.len {
+					if text[brace] == quote && !c_flag_quote_is_escaped(text, brace) {
+						brace++
+						break
+					}
+					brace++
+				}
+				continue
+			}
+			brace++
+		}
+		if brace >= text.len || text[brace] != `{` {
+			i = resume
+			continue
+		}
+		mut depth := 1
+		mut paren_depth := 0
+		mut bracket_depth := 0
+		mut expect_name := true
+		i = brace + 1
+		for i < text.len && depth > 0 {
+			comment_end_in_body := c_cache_native_comment_end(text, i)
+			if comment_end_in_body != i {
+				i = comment_end_in_body
+				continue
+			}
+			if text[i] in [`'`, `"`] {
+				quote := text[i]
+				i++
+				for i < text.len {
+					if text[i] == quote && !c_flag_quote_is_escaped(text, i) {
+						i++
+						break
+					}
+					i++
+				}
+				continue
+			}
+			if text[i] == `#` && c_cache_native_line_prefix_is_space(text, i) {
+				for i < text.len && text[i] != `\n` {
+					i++
+				}
+				continue
+			}
+			match text[i] {
+				`{` {
+					depth++
+					i++
+					continue
+				}
+				`}` {
+					depth--
+					i++
+					continue
+				}
+				`(` {
+					paren_depth++
+				}
+				`)` {
+					if paren_depth > 0 {
+						paren_depth--
+					}
+				}
+				`[` {
+					bracket_depth++
+				}
+				`]` {
+					if bracket_depth > 0 {
+						bracket_depth--
+					}
+				}
+				`,` {
+					if depth == 1 && paren_depth == 0 && bracket_depth == 0 {
+						expect_name = true
+					}
+				}
+				else {}
+			}
+			if expect_name && depth == 1 && paren_depth == 0 && bracket_depth == 0
+				&& c_identifier_start(text[i]) {
+				name_start := i
+				i++
+				for i < text.len && c_identifier_continue(text[i]) {
+					i++
+				}
+				names << text[name_start..i]
+				expect_name = false
+				continue
+			}
+			i++
+		}
+		i = resume
+	}
+	return names
+}
+
+fn c_cache_native_comment_end(text string, start int) int {
+	if start + 1 >= text.len || text[start] != `/` {
+		return start
+	}
+	if text[start + 1] == `/` {
+		mut i := start + 2
+		for i < text.len && text[i] != `\n` {
+			i++
+		}
+		return i
+	}
+	if text[start + 1] == `*` {
+		mut i := start + 2
+		for i + 1 < text.len && !(text[i] == `*` && text[i + 1] == `/`) {
+			i++
+		}
+		return if i + 1 < text.len { i + 2 } else { text.len }
+	}
+	return start
+}
+
+fn c_cache_native_line_prefix_is_space(text string, pos int) bool {
+	mut start := pos
+	for start > 0 && text[start - 1] != `\n` {
+		start--
+	}
+	return text[start..pos].trim_space().len == 0
 }
 
 fn (g &FlatGen) c_source_defines_used_c_type(text string) bool {

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -14392,7 +14392,7 @@ fn (mut g FlatGen) gen_mut_pointer_slot_arg(arg_id flat.NodeId, arg_node flat.No
 	// particular, `mut p &T` is represented as `T**`; forwarding `mut p` to
 	// another such parameter must pass that slot directly, not read `*p` first.
 	if arg_node.is_mut && arg_node.kind == .ident && g.current_param_is_mut(arg_node.value) {
-		g.write(g.cname(arg_node.value))
+		g.write(g.local_decl_cname(arg_node.value))
 		return true
 	}
 	// Transform lowers a forwarded `mut p` argument to the lvalue `*p`. When p
@@ -14404,7 +14404,7 @@ fn (mut g FlatGen) gen_mut_pointer_slot_arg(arg_id flat.NodeId, arg_node flat.No
 			&& !g.current_param_is_mut_pointer(child.value) {
 			param_type := g.current_param_type(child.value) or { types.Type(types.void_) }
 			if g.tc.c_type(param_type) == g.tc.c_type(expected) {
-				g.write(g.cname(child.value))
+				g.write(g.local_decl_cname(child.value))
 				return true
 			}
 		}

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -2937,6 +2937,9 @@ fn (mut g FlatGen) spawn_wrapper_decls() {
 		seen[def] = true
 		g.writeln(def)
 	}
+	if g.cache_split && g.spawn_wrapper_defs.len > 0 {
+		g.writeln('/* V3CACHE_PROGRAM_WRAPPERS_END */')
+	}
 	if g.spawn_wrapper_defs.len > 0 {
 		g.writeln('')
 	}
@@ -3345,6 +3348,9 @@ fn (mut g FlatGen) callback_wrapper_decls() {
 	}
 	for def in g.callback_wrapper_defs {
 		g.writeln(def)
+	}
+	if g.cache_split && g.callback_wrapper_defs.len > 0 {
+		g.writeln('/* V3CACHE_PROGRAM_WRAPPERS_END */')
 	}
 	if g.callback_wrapper_defs.len > 0 {
 		g.writeln('')

--- a/vlib/v3/gen/c/for.v
+++ b/vlib/v3/gen/c/for.v
@@ -686,25 +686,25 @@ fn (g &FlatGen) for_in_map_storage_key(id flat.NodeId) string {
 
 fn (g &FlatGen) c_loop_local_name(name string) string {
 	if name.contains('.') {
-		return g.cname(name.all_after_last('.'))
+		return g.local_decl_cname(name.all_after_last('.'))
 	}
 	if name.contains('__') {
 		prefix := name.all_before_last('__')
 		suffix := name.all_after_last('__')
 		if suffix == 'index' {
-			return g.cname(suffix)
+			return g.local_decl_cname(suffix)
 		}
 		if g.has_import_alias(prefix) {
-			return g.cname(suffix)
+			return g.local_decl_cname(suffix)
 		}
 		for _, mod_name in g.modules {
 			short_mod := if mod_name.contains('.') { mod_name.all_after_last('.') } else { mod_name }
 			if prefix == short_mod {
-				return g.cname(suffix)
+				return g.local_decl_cname(suffix)
 			}
 		}
 	}
-	return g.cname(name)
+	return g.local_decl_cname(name)
 }
 
 // gen_node_inline emits node inline output for c.

--- a/vlib/v3/gen/c/names_test.v
+++ b/vlib/v3/gen/c/names_test.v
@@ -139,6 +139,7 @@ fn test_collect_cache_native_c_symbols_only_records_type_declarations() {
 	tc.structs['C.StringOnly'] = []types.StructField{}
 	tc.structs['C.UnrelatedOpaque'] = []types.StructField{}
 	tc.structs['C.HEADER_ENUM_VALUE'] = []types.StructField{}
+	tc.structs['C.BOOL'] = []types.StructField{}
 
 	g.collect_cache_native_c_symbols('// typedef int CommentOnly;\n"typedef int StringOnly;";\nint f(int UnrelatedOpaque);\ntypedef struct HeaderTag { int field_name; } HeaderAlias;\nenum HeaderEnum { HEADER_ENUM_VALUE };\ntypedef int HeaderScalar, HeaderOther;')
 
@@ -150,10 +151,21 @@ fn test_collect_cache_native_c_symbols_only_records_type_declarations() {
 	assert !g.cache_native_c_symbols['CommentOnly']
 	assert !g.cache_native_c_symbols['StringOnly']
 	assert !g.cache_native_c_symbols['UnrelatedOpaque']
-	assert !g.cache_native_c_symbols['HEADER_ENUM_VALUE']
+	assert g.cache_native_c_symbols['HEADER_ENUM_VALUE']
 	assert !g.cache_native_c_symbols['field_name']
 	assert g.skip_builtin_struct('C.HeaderScalar')
 	assert !g.skip_builtin_struct('C.UnrelatedOpaque')
+	g.inlined_c_typedef_names['BOOL'] = true
+	assert g.skip_builtin_struct('C.BOOL')
+}
+
+fn test_collect_cache_native_c_symbols_records_sokol_enum_constants() {
+	mut g := FlatGen.new()
+	header := os.read_file(os.join_path(@VEXEROOT, 'thirdparty', 'sokol', 'sokol_app.h')) or {
+		panic(err)
+	}
+	g.collect_cache_native_c_symbols(header)
+	assert g.cache_native_c_symbols['SAPP_MOUSECURSOR_DEFAULT']
 }
 
 fn test_voidptr_method_value_arg_does_not_panic_for_alias_to_voidptr() {
@@ -576,6 +588,10 @@ fn test_x11_system_headers_preserve_external_structs() {
 	assert 'XcursorImage' in c_preserved_system_include_struct_names('<X11/Xcursor/Xcursor.h>')
 	assert 'XRRCrtcInfo' in c_preserved_system_include_struct_names('<X11/extensions/Xrandr.h>')
 	assert 'XRRCrtcInfo' in c_preserved_system_include_typedef_names('<X11/extensions/Xrandr.h>')
+}
+
+fn test_apple_framework_typedef_names_are_preserved() {
+	assert 'BOOL' in c_preserved_system_include_typedef_names('<Cocoa/Cocoa.h>')
 }
 
 fn test_large_transitive_header_tree_is_preserved() {

--- a/vlib/v3/gen/c/names_test.v
+++ b/vlib/v3/gen/c/names_test.v
@@ -124,6 +124,25 @@ fn test_main_function_is_prefixed_when_declared_c_type_owns_name() {
 	assert g.fn_c_name_in_module('database', 'sqlite3') == 'database__sqlite3'
 }
 
+fn test_collect_cache_native_c_symbols_ignores_comments_and_literals() {
+	mut a := flat.FlatAst.new()
+	mut tc := types.TypeChecker.new(&a)
+	mut g := FlatGen.new()
+	g.a = &a
+	g.tc = &tc
+	tc.structs['C.HEADER_ENUM_VALUE'] = []types.StructField{}
+	tc.structs['C.CommentOnly'] = []types.StructField{}
+	tc.structs['C.StringOnly'] = []types.StructField{}
+	tc.structs['C.UnrelatedOpaque'] = []types.StructField{}
+
+	g.collect_cache_native_c_symbols('// CommentOnly\n"StringOnly"; HEADER_ENUM_VALUE,')
+
+	assert g.cache_native_c_symbols['HEADER_ENUM_VALUE']
+	assert !g.cache_native_c_symbols['CommentOnly']
+	assert !g.cache_native_c_symbols['StringOnly']
+	assert !g.cache_native_c_symbols['UnrelatedOpaque']
+}
+
 fn test_voidptr_method_value_arg_does_not_panic_for_alias_to_voidptr() {
 	mut a := flat.FlatAst.new()
 	mut tc := types.TypeChecker.new(&a)

--- a/vlib/v3/gen/c/names_test.v
+++ b/vlib/v3/gen/c/names_test.v
@@ -124,23 +124,36 @@ fn test_main_function_is_prefixed_when_declared_c_type_owns_name() {
 	assert g.fn_c_name_in_module('database', 'sqlite3') == 'database__sqlite3'
 }
 
-fn test_collect_cache_native_c_symbols_ignores_comments_and_literals() {
+fn test_collect_cache_native_c_symbols_only_records_type_declarations() {
 	mut a := flat.FlatAst.new()
 	mut tc := types.TypeChecker.new(&a)
 	mut g := FlatGen.new()
 	g.a = &a
 	g.tc = &tc
-	tc.structs['C.HEADER_ENUM_VALUE'] = []types.StructField{}
+	tc.structs['C.HeaderTag'] = []types.StructField{}
+	tc.structs['C.HeaderAlias'] = []types.StructField{}
+	tc.structs['C.HeaderEnum'] = []types.StructField{}
+	tc.structs['C.HeaderScalar'] = []types.StructField{}
+	tc.structs['C.HeaderOther'] = []types.StructField{}
 	tc.structs['C.CommentOnly'] = []types.StructField{}
 	tc.structs['C.StringOnly'] = []types.StructField{}
 	tc.structs['C.UnrelatedOpaque'] = []types.StructField{}
+	tc.structs['C.HEADER_ENUM_VALUE'] = []types.StructField{}
 
-	g.collect_cache_native_c_symbols('// CommentOnly\n"StringOnly"; HEADER_ENUM_VALUE,')
+	g.collect_cache_native_c_symbols('// typedef int CommentOnly;\n"typedef int StringOnly;";\nint f(int UnrelatedOpaque);\ntypedef struct HeaderTag { int field_name; } HeaderAlias;\nenum HeaderEnum { HEADER_ENUM_VALUE };\ntypedef int HeaderScalar, HeaderOther;')
 
-	assert g.cache_native_c_symbols['HEADER_ENUM_VALUE']
+	assert g.cache_native_c_symbols['HeaderTag']
+	assert g.cache_native_c_symbols['HeaderAlias']
+	assert g.cache_native_c_symbols['HeaderEnum']
+	assert g.cache_native_c_symbols['HeaderScalar']
+	assert g.cache_native_c_symbols['HeaderOther']
 	assert !g.cache_native_c_symbols['CommentOnly']
 	assert !g.cache_native_c_symbols['StringOnly']
 	assert !g.cache_native_c_symbols['UnrelatedOpaque']
+	assert !g.cache_native_c_symbols['HEADER_ENUM_VALUE']
+	assert !g.cache_native_c_symbols['field_name']
+	assert g.skip_builtin_struct('C.HeaderScalar')
+	assert !g.skip_builtin_struct('C.UnrelatedOpaque')
 }
 
 fn test_voidptr_method_value_arg_does_not_panic_for_alias_to_voidptr() {

--- a/vlib/v3/gen/c/source_directive_test.v
+++ b/vlib/v3/gen/c/source_directive_test.v
@@ -337,17 +337,16 @@ fn collect_external_input_tree_status(root string, entry string, ambient_ambiguo
 	mut files := []string{}
 	mut include_macros := map[string][]string{}
 	mut dynamic_include_macros := map[string]bool{}
+	mut literal_include_macros := map[string][]string{}
 	mut resolution_dirs := map[string]bool{}
 	mut missing_resolution_paths := map[string]bool{}
 	mut active_static_storage_paths := map[string]bool{}
-	mut captured_input_texts := map[string]string{}
 	mut captured_input_digests := map[string]string{}
-	mut context_capture := CCacheContextCapture{}
 	untracked := c_collect_external_input_tree(entry, '', [root], mut active_paths, mut
 		collected_paths, mut ambiguous_collected_paths, mut files, mut include_macros, mut
-		dynamic_include_macros, mut resolution_dirs, mut missing_resolution_paths, mut
-		active_static_storage_paths, mut captured_input_texts, mut captured_input_digests, 'main',
-		ambient_ambiguous, false, mut context_capture)
+		dynamic_include_macros, mut literal_include_macros, mut resolution_dirs, mut
+		missing_resolution_paths, mut active_static_storage_paths, mut captured_input_digests,
+		'main', ambient_ambiguous, false)
 	return untracked, files
 }
 

--- a/vlib/v3/gen/c/source_directive_test.v
+++ b/vlib/v3/gen/c/source_directive_test.v
@@ -342,11 +342,12 @@ fn collect_external_input_tree_status(root string, entry string, ambient_ambiguo
 	mut active_static_storage_paths := map[string]bool{}
 	mut captured_input_texts := map[string]string{}
 	mut captured_input_digests := map[string]string{}
+	mut context_capture := CCacheContextCapture{}
 	untracked := c_collect_external_input_tree(entry, '', [root], mut active_paths, mut
 		collected_paths, mut ambiguous_collected_paths, mut files, mut include_macros, mut
 		dynamic_include_macros, mut resolution_dirs, mut missing_resolution_paths, mut
 		active_static_storage_paths, mut captured_input_texts, mut captured_input_digests, 'main',
-		ambient_ambiguous, false)
+		ambient_ambiguous, false, mut context_capture)
 	return untracked, files
 }
 

--- a/vlib/v3/gen/c/struct.v
+++ b/vlib/v3/gen/c/struct.v
@@ -4956,6 +4956,9 @@ fn (g &FlatGen) skip_builtin_struct(name string) bool {
 		if g.cache_native_c_symbols[name[2..]] {
 			return true
 		}
+		if g.inlined_c_typedef_names[name[2..]] {
+			return true
+		}
 		if info := g.struct_decl_infos[name] {
 			// Platform binding files describe types supplied by their C/Objective-C
 			// headers. Emitting a fallback body can redefine Objective-C classes such

--- a/vlib/v3/gen/c/struct.v
+++ b/vlib/v3/gen/c/struct.v
@@ -4953,6 +4953,9 @@ fn (g &FlatGen) skip_builtin_struct(name string) bool {
 		return true
 	}
 	if name.starts_with('C.') {
+		if g.cache_native_c_symbols[name[2..]] {
+			return true
+		}
 		if info := g.struct_decl_infos[name] {
 			// Platform binding files describe types supplied by their C/Objective-C
 			// headers. Emitting a fallback body can redefine Objective-C classes such

--- a/vlib/v3/gen/c/target_test.v
+++ b/vlib/v3/gen/c/target_test.v
@@ -432,6 +432,80 @@ fn test_cache_input_scan_tracks_literal_include_macros() {
 	assert inputs['sample'] == expected
 }
 
+fn test_cache_input_scan_tracks_nested_literal_include_macros() {
+	dir := os.join_path(os.vtmp_dir(), 'v3_nested_macro_header_cache_inputs_${os.getpid()}')
+	os.rmdir_all(dir) or {}
+	os.mkdir_all(os.join_path(dir, 'config'))!
+	defer {
+		os.rmdir_all(dir) or {}
+	}
+	entry_header := os.join_path(dir, 'entry.h')
+	build_header := os.join_path(dir, 'build.h')
+	definitions_header := os.join_path(dir, 'config', 'definitions.h')
+	nested_header := os.join_path(dir, 'nested.h')
+	os.write_file(entry_header, '#define USE_NESTED 1
+#ifdef USE_NESTED
+#include <build.h>
+#include NESTED_API_H
+#endif
+')!
+	os.write_file(build_header, '#ifndef BUILD_H
+#define BUILD_H
+#include <config/definitions.h>
+#endif
+')!
+	os.write_file(definitions_header, '#ifndef DEFINITIONS_H
+#define DEFINITIONS_H
+#define NESTED_API_H <nested.h>
+#endif
+')!
+	os.write_file(nested_header, '#define NESTED_VALUE 1\n')!
+	source := os.join_path(dir, 'sample.v')
+	os.write_file(source, 'module sample\n#include "entry.h"\n')!
+	mut prefs := pref.new_preferences()
+	prefs.target = pref.host_target()
+	mut p := parser.Parser.new(prefs)
+	a := p.parse_file(source)
+	inputs, _, _, _, _, _, _, has_untracked := cache_external_input_files_with_resolved_flags(a,
+		'', {
+		'sample': true
+	}, ['-I', dir], prefs.target, map[string]bool{}, map[string]string{}, true)
+	assert !has_untracked
+	mut expected := [os.real_path(entry_header), os.real_path(build_header),
+		os.real_path(definitions_header), os.real_path(nested_header)]
+	expected.sort()
+	assert inputs['sample'] == expected
+}
+
+fn test_cache_input_scan_keeps_conditionally_undefined_absent_macro_known() {
+	dir := os.join_path(os.vtmp_dir(), 'v3_conditional_undef_absent_${os.getpid()}')
+	os.rmdir_all(dir) or {}
+	os.mkdir_all(dir)!
+	defer {
+		os.rmdir_all(dir) or {}
+	}
+	header := os.join_path(dir, 'platform.h')
+	os.write_file(header, '#if UNKNOWN_PLATFORM_CONDITION
+#undef ABSENT_FEATURE
+#endif
+#ifdef ABSENT_FEATURE
+#include MISSING_FEATURE_HEADER
+#endif
+')!
+	source := os.join_path(dir, 'sample.v')
+	os.write_file(source, 'module sample\n#include "platform.h"\n')!
+	mut prefs := pref.new_preferences()
+	prefs.target = pref.host_target()
+	mut p := parser.Parser.new(prefs)
+	a := p.parse_file(source)
+	inputs, _, _, _, _, _, _, has_untracked := cache_external_input_files_with_resolved_flags(a,
+		'', {
+		'sample': true
+	}, [], prefs.target, map[string]bool{}, map[string]string{}, true)
+	assert !has_untracked
+	assert inputs['sample'] == [os.real_path(header)]
+}
+
 fn test_cache_input_scan_rescans_unguarded_headers_after_macro_changes() {
 	dir := os.join_path(os.vtmp_dir(), 'v3_repeated_macro_header_cache_inputs_${os.getpid()}')
 	os.rmdir_all(dir) or {}
@@ -768,8 +842,7 @@ fn test_cache_input_scan_tracks_preceding_header_macro_mutations() {
 	assert native_roots['sample'] == [os.real_path(implementation_header)]
 	assert native_contexts[os.real_path(implementation_header)] == [
 		'#define V3_FEATURE 1',
-		'#undef V3_FEATURE',
-		'#define V3_HEADER_VALUE 73',
+		'#include "${c_escape(os.real_path(config_header))}"',
 	]
 }
 
@@ -799,7 +872,7 @@ fn test_cache_input_scan_excludes_objective_cpp_sources_from_native_roots() {
 	assert (native_roots['sample'] or { []string{} }).len == 0
 }
 
-fn test_cache_input_scan_rejects_conditional_native_root_context() {
+fn test_cache_input_scan_ignores_inactive_native_root_context_mutation() {
 	dir := os.join_path(os.vtmp_dir(), 'v3_conditional_native_header_context_${os.getpid()}')
 	os.rmdir_all(dir) or {}
 	os.mkdir_all(dir) or { panic(err) }
@@ -823,14 +896,12 @@ fn test_cache_input_scan_rejects_conditional_native_root_context() {
 		'', {
 		'sample': true
 	}, [], prefs.target, map[string]bool{}, map[string]string{}, true)
-	assert has_untracked
+	assert !has_untracked
 	assert native_roots['sample'] == [os.real_path(header)]
-	assert native_contexts[os.real_path(header)] == [
-		'#define V3_HEADER_IMPLEMENTATION',
-	]
+	assert native_contexts[os.real_path(header)].len == 0
 }
 
-fn test_cache_input_scan_rejects_conditionally_included_native_root() {
+fn test_cache_input_scan_ignores_inactive_native_root() {
 	dir := os.join_path(os.vtmp_dir(), 'v3_conditionally_included_native_root_${os.getpid()}')
 	os.rmdir_all(dir) or {}
 	os.mkdir_all(dir) or { panic(err) }
@@ -853,9 +924,9 @@ fn test_cache_input_scan_rejects_conditionally_included_native_root() {
 		'', {
 		'sample': true
 	}, [], prefs.target, map[string]bool{}, map[string]string{}, true)
-	assert has_untracked
-	assert native_roots['sample'] == [os.real_path(header)]
-	assert native_contexts[os.real_path(header)].len == 0
+	assert !has_untracked
+	assert (native_roots['sample'] or { []string{} }).len == 0
+	assert os.real_path(header) !in native_contexts
 }
 
 fn test_cache_input_scan_rejects_repeated_native_root_with_different_context() {
@@ -1081,6 +1152,27 @@ fn test_cache_input_scan_tracks_native_source_roots_for_privacy_checks() {
 	assert os.real_path(late_source) !in inputs['sample']
 	assert captured_digests[os.real_path(root_source)] == sha256.hexhash(root_source_text)
 	assert captured_digests[os.real_path(nested_source)] == sha256.hexhash(nested_source_text)
+}
+
+fn test_native_input_snapshot_rejects_bytes_changed_between_reads() {
+	dir := os.join_path(os.vtmp_dir(), 'v3_native_input_snapshot_${os.getpid()}')
+	os.rmdir_all(dir) or {}
+	os.mkdir_all(dir)!
+	defer {
+		os.rmdir_all(dir) or {}
+	}
+	header := os.join_path(dir, 'dependency.h')
+	first_text := '#define SNAPSHOT_VALUE 1\n'
+	os.write_file(header, first_text)!
+	mut captured_digests := map[string]string{}
+	first := c_snapshot_external_input_text(header, mut captured_digests) or { panic(err) }
+	assert first == first_text
+	assert captured_digests[os.real_path(header)] == sha256.hexhash(first_text)
+	assert c_snapshot_external_input_text(header, mut captured_digests) or { '' } == first_text
+	os.write_file(header, '#define SNAPSHOT_VALUE 2\n')!
+	if _ := c_snapshot_external_input_text(header, mut captured_digests) {
+		assert false, 'changed native input must invalidate the dependency snapshot'
+	}
 }
 
 fn test_termux_comptime_branch_uses_canonical_target() {

--- a/vlib/v3/gen/c/target_test.v
+++ b/vlib/v3/gen/c/target_test.v
@@ -846,6 +846,42 @@ fn test_cache_input_scan_tracks_preceding_header_macro_mutations() {
 	]
 }
 
+fn test_cache_input_scan_orders_pre_and_postincludes_like_cgen() {
+	dir := os.join_path(os.vtmp_dir(), 'v3_placed_include_context_${os.getpid()}')
+	os.rmdir_all(dir) or {}
+	os.mkdir_all(dir) or { panic(err) }
+	defer {
+		os.rmdir_all(dir) or {}
+	}
+	pre_header := os.join_path(dir, 'pre.h')
+	post_header := os.join_path(dir, 'post.h')
+	implementation_header := os.join_path(dir, 'implementation.h')
+	os.write_file(pre_header, '#define V3_PRE_READY 1\n')!
+	os.write_file(post_header, '#define V3_POST_LATE 1\n')!
+	os.write_file(implementation_header,
+		'#ifndef V3_PRE_READY\n#error missing preinclude\n#endif\n#ifdef V3_POST_LATE\nstatic int v3_wrong_postinclude_order;\n#endif\nstatic int v3_placed_include_state;\n')!
+	source := os.join_path(dir, 'sample.v')
+	// Source order is deliberately opposite to generated placement: cgen emits
+	// the preinclude first and the postinclude after all generated bodies.
+	os.write_file(source,
+		'module sample\n#postinclude "post.h"\n#insert "implementation.h"\n#preinclude "pre.h"\n')!
+	mut prefs := pref.new_preferences()
+	prefs.target = pref.host_target()
+	mut p := parser.Parser.new(prefs)
+	a := p.parse_file(source)
+	inputs, native_roots, native_contexts, _, _, _, _, has_untracked := cache_external_input_files_with_resolved_flags(a,
+		'', {
+		'sample': true
+	}, [], prefs.target, map[string]bool{}, map[string]string{}, true)
+	assert !has_untracked
+	assert native_roots['sample'] == [os.real_path(implementation_header)]
+	assert native_contexts[os.real_path(implementation_header)] == [
+		'#include "${c_escape(os.real_path(pre_header))}"',
+	]
+	assert os.real_path(pre_header) in inputs['__v3_c_flags__']
+	assert os.real_path(post_header) !in inputs['__v3_c_flags__']
+}
+
 fn test_cache_input_scan_excludes_objective_cpp_sources_from_native_roots() {
 	dir := os.join_path(os.vtmp_dir(), 'v3_objective_cpp_cache_inputs_${os.getpid()}')
 	os.rmdir_all(dir) or {}

--- a/vlib/v3/gen/c/target_test.v
+++ b/vlib/v3/gen/c/target_test.v
@@ -739,6 +739,66 @@ fn test_cache_input_scan_tracks_native_header_macro_context() {
 	assert static_inputs['sample'] == [os.real_path(header)]
 }
 
+fn test_cache_input_scan_tracks_preceding_header_macro_mutations() {
+	dir := os.join_path(os.vtmp_dir(), 'v3_native_header_mutation_context_${os.getpid()}')
+	os.rmdir_all(dir) or {}
+	os.mkdir_all(dir) or { panic(err) }
+	defer {
+		os.rmdir_all(dir) or {}
+	}
+	config_header := os.join_path(dir, 'config.h')
+	implementation_header := os.join_path(dir, 'implementation.h')
+	os.write_file(config_header, '#undef V3_FEATURE\n#define V3_HEADER_VALUE 73\n')!
+	os.write_file(implementation_header, '#ifdef V3_FEATURE\nstatic int v3_wrong_state;\n#endif\n')!
+	source := os.join_path(dir, 'sample.v')
+	os.write_file(source, 'module sample
+#define V3_FEATURE 1
+#include "config.h"
+#insert "implementation.h"
+')!
+	mut prefs := pref.new_preferences()
+	prefs.target = pref.host_target()
+	mut p := parser.Parser.new(prefs)
+	a := p.parse_file(source)
+	_, native_roots, native_contexts, _, _, _, _, has_untracked := cache_external_input_files_with_resolved_flags(a,
+		'', {
+		'sample': true
+	}, [], prefs.target, map[string]bool{}, map[string]string{}, true)
+	assert !has_untracked
+	assert native_roots['sample'] == [os.real_path(implementation_header)]
+	assert native_contexts[os.real_path(implementation_header)] == [
+		'#define V3_FEATURE 1',
+		'#undef V3_FEATURE',
+		'#define V3_HEADER_VALUE 73',
+	]
+}
+
+fn test_cache_input_scan_excludes_objective_cpp_sources_from_native_roots() {
+	dir := os.join_path(os.vtmp_dir(), 'v3_objective_cpp_cache_inputs_${os.getpid()}')
+	os.rmdir_all(dir) or {}
+	os.mkdir_all(dir) or { panic(err) }
+	defer {
+		os.rmdir_all(dir) or {}
+	}
+	objective_cpp_source := os.join_path(dir, 'implementation.mm')
+	os.write_file(objective_cpp_source,
+		'extern "C" int v3_objective_cpp_value(void) { return []() { return 1; }(); }\n')!
+	source := os.join_path(dir, 'sample.v')
+	os.write_file(source, 'module sample\n#include "implementation.mm"\n')!
+	mut prefs := pref.new_preferences()
+	prefs.target = pref.host_target()
+	mut p := parser.Parser.new(prefs)
+	a := p.parse_file(source)
+	inputs, native_roots, _, unscoped_inputs, _, _, _, has_untracked := cache_external_input_files_with_resolved_flags(a,
+		'', {
+		'sample': true
+	}, [], prefs.target, map[string]bool{}, map[string]string{}, true)
+	assert !has_untracked
+	assert inputs['sample'] == [os.real_path(objective_cpp_source)]
+	assert unscoped_inputs['sample'] == [os.real_path(objective_cpp_source)]
+	assert (native_roots['sample'] or { []string{} }).len == 0
+}
+
 fn test_cache_input_scan_rejects_conditional_native_root_context() {
 	dir := os.join_path(os.vtmp_dir(), 'v3_conditional_native_header_context_${os.getpid()}')
 	os.rmdir_all(dir) or {}

--- a/vlib/v3/tests/c_global_c_type_storage_codegen_test.v
+++ b/vlib/v3/tests/c_global_c_type_storage_codegen_test.v
@@ -410,3 +410,130 @@ pub fn owned_score() int {
 	assert !c_code.contains('C__stdout'), c_code
 	assert !c_code.contains('\nFILE* stdout'), c_code
 }
+
+fn test_map_for_bindings_shadowing_global_use_local_c_name() {
+	c_code := gen_c_for_c_global_source('map_for_binding_shadows_global', 'module main
+
+__global id int
+
+fn sum_entries(values map[int]int) int {
+	mut total := 0
+	for id, value in values {
+		total += id + value
+	}
+	return total
+}
+
+fn main() {
+	_ := sum_entries({1: 2})
+}
+')
+	assert c_code.contains('int id__local = *(int*)'), c_code
+	assert c_code.contains('total += id__local + value;'), c_code
+	assert !c_code.contains('int id = *(int*)'), c_code
+}
+
+fn test_mut_pointer_cast_uses_c_typedef_safe_parameter_name() {
+	c_code := gen_c_for_c_global_source('mut_pointer_cast_shadows_c_type', 'module main
+
+@[typedef]
+struct C.buf {
+	value int
+}
+
+fn cast_buffer(mut buf &u8) &u8 {
+	return &u8(buf)
+}
+
+fn main() {
+	mut value := u8(1)
+	mut ptr := &value
+	_ := cast_buffer(mut ptr)
+}
+')
+	assert c_code.contains('u8* cast_buffer(u8** buf__local)'), c_code
+	assert c_code.contains('return (u8*)(*buf__local);'), c_code
+	assert !c_code.contains('return (u8*)(*buf);'), c_code
+}
+
+fn test_builtin_copy_uses_c_typedef_safe_parameter_name() {
+	c_code := gen_c_for_c_global_source('builtin_copy_shadows_c_type', 'module main
+
+@[typedef]
+struct C.buf {
+	value int
+}
+
+fn copy(mut dst []u8, src []u8) int {
+	return 0
+}
+
+fn copy_buffer(mut buf []u8) int {
+	return copy(mut buf, [u8(1)])
+}
+
+fn main() {
+	mut values := [u8(0)]
+	_ := copy_buffer(mut values)
+}
+')
+	assert c_code.contains('int copy_buffer(Array* buf__local)'), c_code
+	assert c_code.contains('return copy(buf__local, '), c_code
+	assert !c_code.contains('return copy(buf, '), c_code
+}
+
+fn test_sizeof_uses_c_typedef_safe_local_name() {
+	c_code := gen_c_for_c_global_source('sizeof_local_shadows_c_type', 'module main
+
+@[typedef]
+struct C.buf {
+	value int
+}
+
+fn buffer_size() int {
+	mut buf := [1024]u8{}
+	return int(sizeof(buf))
+}
+
+fn main() {
+	_ := buffer_size()
+}
+')
+	assert c_code.contains('u8 buf__local[1024]'), c_code
+	assert c_code.contains('return (int)(sizeof(buf__local));'), c_code
+	assert !c_code.contains('return (int)(sizeof(buf));'), c_code
+}
+
+fn test_mut_interface_smartcast_loop_arg_forwards_object_pointer() {
+	c_code := gen_c_for_c_global_source('mut_interface_smartcast_loop_arg', 'module main
+
+interface Widget {
+	id int
+}
+
+struct Stack {
+mut:
+	id       int
+	children []Widget
+}
+
+fn increment(mut stack Stack) {
+	stack.id++
+}
+
+fn visit(mut stack Stack) {
+	for mut child in stack.children {
+		if mut child is Stack {
+			increment(mut child)
+		}
+	}
+}
+
+fn main() {
+	mut stack := Stack{}
+	visit(mut stack)
+}
+')
+	assert c_code.contains('increment((main__Stack*)(child->_object))'), c_code
+	assert !c_code.contains('increment(*(main__Stack*)(child->_object))'), c_code
+}

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -1658,6 +1658,49 @@ fn main() {
 	assert module_cache_artifact(cache_dir, 'owner_', '.o').len > 0
 }
 
+fn test_conventional_native_implementation_macro_is_restored_in_owner() {
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_module_cache_conventional_impl_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	write_module_cache_file(root, 'owner/native.h', '#ifdef SOKOL_TEST_IMPL
+int v3_conventional_impl_value(void) { return 42; }
+#endif
+')
+	write_module_cache_file(root, 'owner/owner.v', 'module owner
+
+#define SOKOL_TEST_IMPL
+#insert "@DIR/native.h"
+
+fn C.v3_conventional_impl_value() int
+
+pub fn value() int {
+	return C.v3_conventional_impl_value()
+}
+')
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'module main
+
+import owner
+
+fn main() {
+	println(owner.value())
+}
+')
+	cache_dir := os.join_path(root, 'cache')
+	first_output := os.join_path(root, 'first')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, first_output)
+	assert run_module_cache_binary(first_output) == '42'
+	assert module_cache_artifact(cache_dir, 'owner_', '.o').len > 0
+
+	second_output := os.join_path(root, 'second')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, second_output)
+	assert run_module_cache_binary(second_output) == '42'
+}
+
 fn test_unconditional_native_definition_disables_module_cache_split() {
 	v3_bin := build_module_cache_v3()
 	root := os.join_path(os.temp_dir(),

--- a/vlib/v3/tests/post_merge_review_fixes_test.v
+++ b/vlib/v3/tests/post_merge_review_fixes_test.v
@@ -6644,6 +6644,30 @@ fn test_cached_native_root_preserves_preceding_header_macro_mutations() {
 	assert out == '73'
 }
 
+fn test_cached_native_root_uses_generated_pre_and_postinclude_order() {
+	v3_bin := build_v3()
+	out := run_good_project(v3_bin, 'cached_native_placed_includes', {
+		'v.mod':                         "Module { name: 'cached_native_placed_includes' }\n"
+		'nativeanswer/pre.h':            '#define V3_NATIVE_PRE_READY 1\n'
+		'nativeanswer/post.h':           '#define V3_NATIVE_POST_LATE 1\n'
+		'nativeanswer/implementation.h': '#ifndef V3_NATIVE_PRE_READY\n#error missing generated preinclude context\n#endif\n#ifdef V3_NATIVE_POST_LATE\n#error postinclude replayed before native root\n#endif\nint v3_placed_include_answer(void) { return 74; }\n'
+		'nativeanswer/nativeanswer.v':   'module nativeanswer\n\n#postinclude "@DIR/post.h"\n#insert "@DIR/implementation.h"\n#preinclude "@DIR/pre.h"\n\nfn C.v3_placed_include_answer() int\n\npub fn answer() int {\n\treturn C.v3_placed_include_answer()\n}\n'
+		'main.v':                        'module main\n\nimport nativeanswer\n\nfn main() {\n\tprintln(int_str(nativeanswer.answer()))\n}\n'
+	}, 'main.v')
+	assert out == '74'
+}
+
+fn test_cached_native_parameter_name_does_not_suppress_c_type() {
+	v3_bin := build_v3()
+	out := run_good_project(v3_bin, 'cached_native_parameter_type_name', {
+		'v.mod':                       "Module { name: 'cached_native_parameter_type_name' }\n"
+		'nativeanswer/native.h':       'int v3_parameter_name_only(int Unrelated);\n'
+		'nativeanswer/nativeanswer.v': 'module nativeanswer\n\n#insert "native.h"\n\nstruct C.Unrelated {}\n\nfn accepts_unrelated(value &C.Unrelated) int {\n\treturn if isnil(value) { 75 } else { 0 }\n}\n\npub fn answer() int {\n\treturn accepts_unrelated(unsafe { nil })\n}\n'
+		'main.v':                      'module main\n\nimport nativeanswer\n\nfn main() {\n\tprintln(int_str(nativeanswer.answer()))\n}\n'
+	}, 'main.v')
+	assert out == '75'
+}
+
 fn test_bare_macro_objective_c_guards_stay_inactive() {
 	v3_bin := build_v3()
 	result := run_good_project_result(v3_bin, 'bare_macro_objective_c_guards', '', {

--- a/vlib/v3/tests/post_merge_review_fixes_test.v
+++ b/vlib/v3/tests/post_merge_review_fixes_test.v
@@ -6632,6 +6632,18 @@ fn test_imported_objective_cpp_wrapper_context() {
 	assert out == '68'
 }
 
+fn test_cached_native_root_preserves_preceding_header_macro_mutations() {
+	v3_bin := build_v3()
+	out := run_good_project(v3_bin, 'cached_native_header_macro_mutation', {
+		'v.mod':                         "Module { name: 'cached_native_header_macro_mutation' }\n"
+		'nativeanswer/config.h':         '#undef V3_NATIVE_FEATURE\n#define V3_NATIVE_HEADER_VALUE 73\n'
+		'nativeanswer/implementation.h': '#ifdef V3_NATIVE_FEATURE\nint v3_native_header_answer(void) { return 1; }\n#else\nint v3_native_header_answer(void) { return V3_NATIVE_HEADER_VALUE; }\n#endif\n'
+		'nativeanswer/nativeanswer.v':   'module nativeanswer\n\n#define V3_NATIVE_FEATURE 1\n#include "config.h"\n#insert "implementation.h"\n\nfn C.v3_native_header_answer() int\n\npub fn answer() int {\n\treturn C.v3_native_header_answer()\n}\n'
+		'main.v':                        'module main\n\nimport nativeanswer\n\nfn main() {\n\tprintln(int_str(nativeanswer.answer()))\n}\n'
+	}, 'main.v')
+	assert out == '73'
+}
+
 fn test_bare_macro_objective_c_guards_stay_inactive() {
 	v3_bin := build_v3()
 	result := run_good_project_result(v3_bin, 'bare_macro_objective_c_guards', '', {

--- a/vlib/v3/tests/post_merge_review_fixes_test.v
+++ b/vlib/v3/tests/post_merge_review_fixes_test.v
@@ -125,6 +125,25 @@ fn run_good_project(v3_bin string, name string, files map[string]string, input s
 	return run_good_project_with_flags(v3_bin, name, '', files, input)
 }
 
+fn run_good_cached_project(v3_bin string, name string, files map[string]string, input string) string {
+	root := '${tmp_test_path(name)}_project'
+	if os.exists(root) {
+		os.rmdir_all(root) or { panic(err) }
+	}
+	os.mkdir_all(root) or { panic(err) }
+	for rel, src in files {
+		write_project_file(root, rel, src)
+	}
+	input_path := if input.len == 0 { root } else { os.join_path(root, input) }
+	good_bin := tmp_test_path(name)
+	compile := os.execute('${v3_bin} ${input_path} -o ${good_bin}')
+	assert compile.exit_code == 0, compile.output
+	assert !compile.output.contains('C compilation failed'), compile.output
+	run := os.execute(good_bin)
+	assert run.exit_code == 0, run.output
+	return run.output.trim_space()
+}
+
 struct GoodProjectRun {
 	run_output     string
 	compile_output string
@@ -6642,6 +6661,18 @@ fn test_cached_native_root_preserves_preceding_header_macro_mutations() {
 		'main.v':                        'module main\n\nimport nativeanswer\n\nfn main() {\n\tprintln(int_str(nativeanswer.answer()))\n}\n'
 	}, 'main.v')
 	assert out == '73'
+}
+
+fn test_cached_native_public_replay_does_not_repeat_preceding_header() {
+	v3_bin := build_v3()
+	out := run_good_cached_project(v3_bin, 'cached_native_single_preceding_header', {
+		'v.mod':                         "Module { name: 'cached_native_single_preceding_header' }\n"
+		'nativeanswer/context.h':        '#pragma once\nstruct V3CacheContextType { int value; };\n#define V3_CACHE_CONTEXT_VALUE 76\n'
+		'nativeanswer/implementation.h': '#ifdef V3_CACHE_CONTEXT_IMPLEMENTATION\nint v3_cache_context_answer(void) { struct V3CacheContextType value = { V3_CACHE_CONTEXT_VALUE }; return value.value; }\n#else\nint v3_cache_context_answer(void);\n#endif\n'
+		'nativeanswer/nativeanswer.v':   'module nativeanswer\n\n#define V3_CACHE_CONTEXT_IMPLEMENTATION\n#include "context.h"\n#insert "implementation.h"\n#undef V3_CACHE_CONTEXT_IMPLEMENTATION\n\nfn C.v3_cache_context_answer() int\n\npub fn answer() int {\n\treturn C.v3_cache_context_answer()\n}\n'
+		'main.v':                        'module main\n\nimport nativeanswer\n\nfn main() {\n\tprintln(int_str(nativeanswer.answer()))\n}\n'
+	}, 'main.v')
+	assert out == '76'
 }
 
 fn test_cached_native_root_uses_generated_pre_and_postinclude_order() {

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -2861,6 +2861,15 @@ fn (mut t Transformer) transform_call_arg_for_param(arg_id flat.NodeId, param_ty
 			arg_type := t.node_type(arg_id)
 			if arg_type == param_type {
 				value := t.transform_expr_preserving_pointer_value(arg_id)
+				if t.has_smartcast(arg_node.value) {
+					value_node := t.a.nodes[int(value)]
+					if value_node.kind == .prefix && value_node.op == .mul
+						&& value_node.children_count > 0 {
+						pointer := t.a.child(&value_node, 0)
+						t.set_node_typ(int(pointer), param_type)
+						return pointer
+					}
+				}
 				t.set_node_typ(int(value), param_type)
 				return value
 			}


### PR DESCRIPTION
## Summary

- make native cache splitting fail closed for ambiguous Objective-C, conditional, repeated-context, macro-generated static, and Objective-C++ inputs
- keep native implementation definitions in their owning module while preserving required C declarations and type information
- release large native preprocessor and typedef-scanner scratch arenas during prealloc builds
- give callback and thread wrapper sections stable cache identities so prepared-prefix replay does not invalidate valid module objects
- add focused scanner, pruning, codegen, and module-cache regressions

## Volt benchmark

The compiler was built with -prod -prealloc. Volt itself was compiled without -prod and without a memory-limit override.

Fresh cache:
- total: 55.56 s
- peak memory: about 9.0 GiB

Warm cache:
- total: 3.78 s
- check: 1.29 ms
- type annotation: 0.00 ms
- monomorphization: 13.35 ms
- cgen: 0.56 ms
- cached C module plan: 6.31 ms
- clang/link: 2.11 s

The warm build reuses all module objects and does not restart after cache invalidation.

## Tests

- ./vnew vlib/v3/driver/cache_prune_test.v
- ./vnew test -run-only test_conventional_native_implementation_macro_is_restored_in_owner vlib/v3/tests/module_cache_test.v
- ./vnew vlib/v3/gen/c/names_test.v
- ./vnew vlib/v3/gen/c/target_test.v
- ./vnew vlib/v3/gen/c/source_directive_test.v
- ./vnew vlib/v3/tests/c_global_c_type_storage_codegen_test.v
- ./vnew -silent vlib/v/compiler_errors_test.v
- ./vnew -silent vlib/v/gen/c/coutput_test.v
- production/prealloc v3 cold and warm Volt compilation