### PR TITLE
compiler: fix post-merge CI regressions

### DIFF
--- a/vlib/v/gen/c/consts_and_globals.v
+++ b/vlib/v/gen/c/consts_and_globals.v
@@ -694,8 +694,8 @@ fn (mut g Gen) global_decl(node ast.GlobalDecl) {
 }
 
 // write_prealloc_tls_global emits the definition of the thread-local prealloc arena
-// root (`g_memory_block`). Regular C compilers back it with a `_Thread_local` variable
-// so each thread bump-allocates from its own arena. TinyCC on macOS has no working
+// root (`g_memory_block`). C compilers use `_Thread_local`, while C++ compilers use
+// `thread_local`, so each thread bump-allocates from its own arena. TinyCC on macOS has no working
 // thread-local storage (a store to a `_Thread_local` variable segfaults), so there the
 // same identifier is redirected to per-thread storage held in a pthread key. Both variants
 // are emitted because the same generated C can be compiled by TCC or the system compiler.
@@ -718,13 +718,15 @@ fn (mut g Gen) write_prealloc_tls_global(mut def_builder strings.Builder, linkag
 	def_builder.writeln('\treturn slot;')
 	def_builder.writeln('}')
 	def_builder.writeln('#define ${cname} (*(${styp} *)v_prealloc_tls_slot())')
+	def_builder.writeln('#elif defined(__cplusplus)')
+	def_builder.writeln('${linkage}thread_local ${styp} ${cname}; // global 6')
 	def_builder.writeln('#else')
 	def_builder.writeln('${linkage}_Thread_local ${styp} ${cname}; // global 6')
 	def_builder.writeln('#endif')
 }
 
 fn (g &Gen) prealloc_tls_global_extern(styp string, cname string) string {
-	return '#if defined(__TINYC__) && defined(__APPLE__)\nvoid **v_prealloc_tls_slot(void);\n#define ${cname} (*(${styp} *)v_prealloc_tls_slot())\n#else\nextern _Thread_local ${styp} ${cname};\n#endif'
+	return '#if defined(__TINYC__) && defined(__APPLE__)\nvoid **v_prealloc_tls_slot(void);\n#define ${cname} (*(${styp} *)v_prealloc_tls_slot())\n#elif defined(__cplusplus)\nextern thread_local ${styp} ${cname};\n#else\nextern _Thread_local ${styp} ${cname};\n#endif'
 }
 
 fn (mut g Gen) sort_globals_consts() {

--- a/vlib/v/gen/c/link_generated_c_files_test.v
+++ b/vlib/v/gen/c/link_generated_c_files_test.v
@@ -5,6 +5,56 @@ import v.pref
 
 const test_vexe = os.quoted_path(@VEXE)
 
+fn test_prealloc_tls_global_has_cplusplus_thread_local_branch() {
+	$if windows {
+		return
+	}
+	workdir := os.join_path(os.vtmp_dir(), 'v_cgen_prealloc_cplusplus_${os.getpid()}')
+	os.mkdir_all(workdir)!
+	defer {
+		os.rmdir_all(workdir) or {}
+	}
+	source_path := os.join_path(workdir, 'main.v')
+	generated_c_path := os.join_path(workdir, 'main.c')
+	os.write_file(source_path, 'fn main() {}\n')!
+
+	emit_cmd := '${test_vexe} -message-limit 199 -gc none -prealloc -o ${os.quoted_path(generated_c_path)} ${os.quoted_path(source_path)}'
+	emit_result := os.execute(emit_cmd)
+	assert emit_result.exit_code == 0, '${emit_cmd}\n${emit_result.output}'
+	generated := os.read_file(generated_c_path)!
+	assert generated.contains('#elif defined(__cplusplus)\nthread_local VMemoryBlock* g_memory_block; // global 6'), generated
+
+	assert generated.contains('#else\n_Thread_local VMemoryBlock* g_memory_block; // global 6'), generated
+}
+
+fn test_parallel_cc_prealloc_tls_extern_has_cplusplus_thread_local_branch() {
+	workdir := os.join_path(os.vtmp_dir(), 'v_cgen_parallel_prealloc_cplusplus_${os.getpid()}')
+	os.mkdir_all(workdir)!
+	defer {
+		os.rmdir_all(workdir) or {}
+	}
+	source_path := os.join_path(workdir, 'main.v')
+	os.write_file(source_path, 'fn main() {}\n')!
+	mut prefs, _ := pref.parse_args_and_show_errors([], [
+		'',
+		'-parallel-cc',
+		'-gc',
+		'none',
+		'-prealloc',
+		source_path,
+	], false)
+	mut b := builder.new_builder(prefs)
+	mut files := b.get_builtin_files()
+	files << b.get_user_files()
+	b.set_module_lookup_paths()
+	b.front_and_middle_stages(files)!
+	result := c.gen(b.parsed_files, mut b.table, b.pref)
+	externs := result.extern_str.replace('\r\n', '\n')
+	assert externs.contains('#elif defined(__cplusplus)\nextern thread_local VMemoryBlock* g_memory_block;'), externs
+
+	assert externs.contains('#else\nextern _Thread_local VMemoryBlock* g_memory_block;'), externs
+}
+
 fn test_is_o_generated_c_files_can_be_linked_together() {
 	cc_path := os.find_abs_path_of_executable('cc') or { return }
 	cc := os.quoted_path(cc_path)

--- a/vlib/v3/fastcdriver/fastcdriver.v
+++ b/vlib/v3/fastcdriver/fastcdriver.v
@@ -114,7 +114,9 @@ pub fn run(args []string) {
 		repeat = 1
 	}
 	if bench && repeat > 1 {
-		mut warm := fastc.generate_files_with_source_paths([real_input], prefs) or { fail(err.msg()) }
+		mut warm := fastc.generate_files_with_source_paths([real_input], prefs) or {
+			fail(err.msg())
+		}
 		warm = warm
 		mut best_us := i64(0)
 		mut sw2 := time.new_stopwatch()

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -2851,6 +2851,7 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	g.has_builtins = g.tc.has_builtins
 	g.precompute_shared_alias_pointer_shorts()
 	g.collect_gen_info(effective_no_parallel)
+	g.precompute_const_short_index()
 	g.precompute_local_global_suffix_names()
 	g.preintern_json_encode_strings()
 	g.timing_profile('  [ttime] cg collect_info    ${f64(cgsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
@@ -13571,9 +13572,9 @@ fn (g &FlatGen) const_ref_name(name string) string {
 }
 
 fn (g &FlatGen) unique_const_ref_name(short_name string) ?string {
-	// Iterating every const per query cost ~70us a call; the short-name index
-	// is built once (const_vals is complete after collect_gen_info) and maps a
-	// short name to its unique primary const ('' = ambiguous).
+	// Iterating every const per query cost ~70us a call. Normal generation
+	// freezes the short-name index before workers start; the lazy build remains
+	// for focused helpers that call this method without running the full setup.
 	if isnil(g.const_short_index) {
 		return g.unique_const_ref_name_scan(short_name)
 	}
@@ -13618,6 +13619,15 @@ fn (g &FlatGen) unique_const_ref_name_scan(short_name string) ?string {
 		return none
 	}
 	return found
+}
+
+fn (mut g FlatGen) precompute_const_short_index() {
+	if isnil(g.const_short_index) {
+		g.const_short_index = &ConstShortIndex{}
+	}
+	mut idx := g.const_short_index
+	idx.entries = g.build_unique_const_ref_names()
+	idx.built = true
 }
 
 // const_ref_name_from_node converts const ref name from node data for c.

--- a/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
@@ -2556,9 +2556,8 @@ fn (g &FlatGen) new_parallel_worker_config(worker_id int, result_only bool) &Fla
 		c_name_cache:                    &CNameCache{
 			base: if !isnil(g.c_name_cache.base) { g.c_name_cache.base } else { g.c_name_cache }
 		}
-		// The const short-name index is read-only after its first build (the
-		// master queries it during the const precompute, before the forks);
-		// sharing it avoids a rebuild per worker.
+		// The master freezes the const short-name index before forking workers;
+		// sharing the read-only index avoids a rebuild per worker.
 		const_short_index:               g.const_short_index
 		mut_recv_facts:                  &FnNameFactCache{}
 		local_typedef_shadow_facts:      &FnNameFactCache{}

--- a/vlib/v3/gen/c/names.v
+++ b/vlib/v3/gen/c/names.v
@@ -81,7 +81,8 @@ fn (mut c CNameCache) remember(name string, value string) {
 }
 
 // ConstShortIndex maps a const short name to its unique primary const name
-// ('' marks an ambiguous short name); built lazily on first query.
+// ('' marks an ambiguous short name). Full generation freezes it before
+// parallel workers start; focused helpers may still build it lazily.
 @[heap]
 struct ConstShortIndex {
 mut:

--- a/vlib/v3/gen/c/parallel_worker_test.v
+++ b/vlib/v3/gen/c/parallel_worker_test.v
@@ -55,6 +55,24 @@ fn test_scoped_parallel_worker_reuses_preselected_functions_and_c_extern_refs() 
 	assert w.c_extern_refs_ready
 }
 
+fn test_parallel_worker_shares_precomputed_const_short_index() {
+	mut g, _ := parallel_worker_test_gen(true)
+	g.const_vals = {
+		'moda.only':   flat.NodeId(0)
+		'moda.answer': flat.NodeId(1)
+		'modb.answer': flat.NodeId(2)
+	}
+	g.precompute_const_short_index()
+	assert g.const_short_index.built
+	assert g.const_short_index.entries['only'] == 'moda.only'
+	assert g.const_short_index.entries['answer'] == ''
+
+	w := g.new_parallel_worker(1)
+	assert w.const_short_index == g.const_short_index
+	assert w.unique_const_ref_name('only') or { '' } == 'moda.only'
+	assert w.unique_const_ref_name('answer') == none
+}
+
 fn test_parallel_worker_preserves_test_assertion_stats_mode() {
 	mut g, _ := parallel_worker_test_gen(true)
 	g.show_test_stats = true

--- a/vlib/v3/gen/fastc/fastc_test.v
+++ b/vlib/v3/gen/fastc/fastc_test.v
@@ -4881,8 +4881,8 @@ fn test_selfhost_composite_ordering_moves_one_line_interfaces_before_fields() {
 			'wr': 'Writer'
 		}
 	}, {
-		fastc_type_key('main', 'Holder'): FastcDeclaredTypeKind.struct_
-		fastc_type_key('main', 'Writer'): FastcDeclaredTypeKind.interface_
+		'Holder': true
+		'Writer': true
 	})
 	writer_index := ordered.index('struct Writer {') or { -1 }
 	holder_index := ordered.index('struct Holder {') or { -1 }

--- a/vlib/v3/gen/fastc/signatures.v
+++ b/vlib/v3/gen/fastc/signatures.v
@@ -144,7 +144,8 @@ fn collect_function_signatures(source string, path string, header FastcSourceHea
 					return error('fastc method receiver: ${err.msg()}')
 				}
 				if receiver_key == '' {
-					receiver_key = fastc_semantic_declared_type_key(receiver_type, declared_type_c_names)
+					receiver_key = fastc_semantic_declared_type_key(receiver_type,
+						declared_type_c_names)
 				}
 				if receiver_is_mut && !receiver_type.ends_with('*') {
 					receiver_type += '*'

--- a/vlib/v3/token/position.v
+++ b/vlib/v3/token/position.v
@@ -149,6 +149,11 @@ pub fn (mut f File) add_line(offset int) {
 // and stores the source digest consumed by cache and fallback verification.
 pub fn (mut f File) index_lines(src string) {
 	f.index_lines_without_digest(src)
+	for i, c in src {
+		if c == `\n` {
+			f.line_offsets << i + 1
+		}
+	}
 	digest := sha256.sum(src.bytes())
 	for i in 0 .. sha256.size {
 		f.source_digest[i] = digest[i]


### PR DESCRIPTION
## Summary

- restore V3 source line indexing while keeping the FastC no-index path cheap
- freeze the shared V3 const short-name index before parallel codegen workers start
- emit C++11 thread_local storage for the prealloc arena
- format the two FastC files rejected by CI and update the stale FastC ordering test call

These failures reproduce on master at ba581056712b55b95bb0f9d295f660a4b579b517 and were visible in the checks for #28208.

## Validation

- ./vnew -silent test-fmt
- ./vnew -silent vlib/v/compiler_errors_test.v
- ./vnew -silent vlib/v/gen/c/coutput_test.v
- ./vnew -silent vlib/v/gen/c/link_generated_c_files_test.v
- ./vnew -silent test vlib/v3/gen/c/
- ./vnew -silent vlib/v3/gen/fastc/fastc_test.v
- V3 error format, coverage, and token position tests
- six simultaneous strict V3 builds of the three failing VSL examples
- exact V3 CI driver passed its first six serial batches, 96 unit files, before the remaining multi-hour sweep was stopped locally

The stale TCC automation contract test is intentionally not included because it lives under thirdparty and should be handled as a separate batch.