### PR TITLE
v3: stop early on conflicting C declarations

### DIFF
--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -8726,6 +8726,12 @@ pub fn run(args []string) {
 		}
 		mut cvsw := time.new_stopwatch()
 		pre_tc.collect(a)
+		if has_conflicting_c_declaration_errors(pre_tc.errors) {
+			if !macos_v3_fallback_suppresses_diagnostics(macos_v3_fallback_file) {
+				print_type_diagnostics(a, pre_tc.notices, pre_tc.errors, is_checker_fixture)
+			}
+			exit(1)
+		}
 		register_headerless_c_types(mut pre_tc)
 		register_native_source_typedefs(mut pre_tc, &cache_state)
 		if translated_mode {
@@ -12835,6 +12841,13 @@ fn print_type_diagnostics(a &flat.FlatAst, notices []types.TypeError, type_error
 	if !all_errors && ordered_errors.len > max_errors {
 		eprintln('... and ${ordered_errors.len - max_errors} more errors')
 	}
+}
+
+fn has_conflicting_c_declaration_errors(errors []types.TypeError) bool {
+	return errors.any(it.kind == .duplicate_decl
+		&& (it.msg.starts_with('cannot redeclare C struct `')
+		|| (it.msg.starts_with('C function `')
+		&& it.msg.contains('was already declared with a different signature'))))
 }
 
 fn unused_notice_is_parameter_redefinition_cascade(a &flat.FlatAst, notice types.TypeError, type_errors []types.TypeError) bool {

--- a/vlib/v3/tests/c_struct_redeclaration_test.v
+++ b/vlib/v3/tests/c_struct_redeclaration_test.v
@@ -85,10 +85,13 @@ fn test_c_struct_redeclaration_checks_field_signature() {
 		'v.mod':  'Module { name: "shared_header_modules" }\n'
 		'a/a.v':  'module a\n\npub struct C.SharedHeader {\n\tx int\n}\n\npub fn touch_a() int {\n\treturn 1\n}\n'
 		'b/b.v':  'module b\n\npub struct C.SharedHeader {\n\ty byteptr\n}\n\npub fn touch_b() int {\n\treturn 2\n}\n'
-		'main.v': 'module main\n\nimport a\nimport b\n\nfn main() {\n\tprintln(int_str(a.touch_a() + b.touch_b()))\n}\n'
+		'main.v': 'module main\n\nimport a\nimport b\n\nfn main() {\n\t$compile_error("semantic checking continued after C declaration conflict")\n\tprintln(int_str(a.touch_a() + b.touch_b()))\n}\n'
 	})
 	assert cross_module_bad.exit_code != 0, cross_module_bad.output
 	assert cross_module_bad.output.contains('cannot redeclare C struct `C.SharedHeader`'), cross_module_bad.output
+	assert cross_module_bad.output.contains('/b/b.v:3:'), cross_module_bad.output
+	assert !cross_module_bad.output.contains('semantic checking continued after C declaration conflict'), cross_module_bad.output
+
 	assert !cross_module_bad.output.contains('C compilation failed'), cross_module_bad.output
 
 	shared_header_good := run_v3_source_cgen(v3_bin, 'good_cjson_shared_header_redeclaration',

--- a/vlib/v3/token/position.v
+++ b/vlib/v3/token/position.v
@@ -148,7 +148,12 @@ pub fn (mut f File) add_line(offset int) {
 // index_lines records every source-line start for logarithmic position lookup
 // and stores the source digest consumed by cache and fallback verification.
 pub fn (mut f File) index_lines(src string) {
-	f.index_lines_without_digest(src)
+	f.line_offsets = [0]
+	for i, ch in src {
+		if ch == `\n` {
+			f.line_offsets << i + 1
+		}
+	}
 	digest := sha256.sum(src.bytes())
 	for i in 0 .. sha256.size {
 		f.source_digest[i] = digest[i]

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -2275,6 +2275,10 @@ fn (mut tc TypeChecker) record_error_unfiltered(kind TypeErrorKind, msg string, 
 	tc.errors << tc.make_type_error(kind, msg, node)
 }
 
+fn (mut tc TypeChecker) record_error_unfiltered_at(kind TypeErrorKind, msg string, node flat.NodeId, pos token.Pos) {
+	tc.errors << tc.make_type_error_at(kind, msg, node, pos)
+}
+
 fn (tc &TypeChecker) make_type_error(kind TypeErrorKind, msg string, node flat.NodeId) TypeError {
 	return tc.make_type_error_at(kind, msg, node, tc.node_pos(node))
 }
@@ -3897,8 +3901,15 @@ fn (mut tc TypeChecker) check_c_struct_redeclarations(a &flat.FlatAst) {
 						existing_module := c_struct_decl_modules[qname] or { '' }
 						if !tc.c_struct_redeclaration_allowed(qname, existing_file, tc.cur_file,
 							existing_module, tc.cur_module) {
-							tc.record_error_unfiltered(.duplicate_decl,
-								'cannot redeclare C struct `${qname}`', flat.NodeId(node_idx))
+							node_id := flat.NodeId(node_idx)
+							keyword := if comma_attr_text_has(node.typ, 'union') {
+								'union'
+							} else {
+								'struct'
+							}
+							tc.record_error_unfiltered_at(.duplicate_decl,
+								'cannot redeclare C struct `${qname}`', node_id, tc.declaration_keyword_name_pos(node_id,
+								keyword))
 						}
 					}
 					existing_fields := c_struct_decl_signature_field_count(existing_sig)


### PR DESCRIPTION
## Summary

- stop V3 before semantic checking when collection already found conflicting C struct or function declarations
- report conflicting C struct declarations at the declaration name
- extend the C struct redeclaration regression test to prove semantic checking does not continue

This prevents large GUI builds with incompatible X11 declarations from consuming memory until the V3 RSS limit. The source conflict still produces a normal compiler error.

## Memory validation

On native Debian ARM64 under QEMU, compiling the reported VGuard GUI graph now exits in 0.24 seconds with 487,248 KB maximum RSS (~476 MiB), instead of reaching the 10 GiB compiler limit. The same graph cross-compiled for Linux on macOS peaked at approximately 468 MiB.

## Tests

- `./vnew vlib/v3/tests/c_struct_redeclaration_test.v`
- `./vnew vlib/v3/tests/c_fn_redeclaration_and_empty_struct_test.v`
- `./vnew vlib/v3/token/token_test.v`
- `./vnew vlib/v3/errors/format_test.v`
- `./vnew vlib/v3/tests/source_integrity_test.v`
- `./vnew -silent vlib/v/compiler_errors_test.v` (1,619 passed, 1 skipped)
- native Debian VGuard GUI reproduction

A full `vlib/v3/` run was stopped after 60/319 passing tests because its unrestricted parallel runner caused excessive concurrent memory pressure; no failures occurred before it was stopped.