### PR TITLE
compiler: fix remaining V3 and macOS master CI regressions

### DIFF
--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -1143,10 +1143,13 @@ fn (mut v Builder) setup_ccompiler_options(ccompiler string) {
 			ccoptions.linker_flags << '-Wl,-export_dynamic' // clang for mac needs export_dynamic instead of -rdynamic
 			if v.pref.building_v && ccoptions.cc == .clang {
 				// ld64 otherwise lets temporary object and output paths perturb the
-				// content-derived UUID and the ad-hoc code signature.
+				// content-derived UUID and its provisional ad-hoc code signature.
+				// Suppress that signature so every linker version leaves the same
+				// unsigned layout for the normalized post-link signature below.
 				ccoptions.args << os.quoted_path('-ffile-prefix-map=${v.out_name_c}=<generated-c>')
 				ccoptions.linker_flags << '-Wl,-reproducible'
 				ccoptions.linker_flags << '-Wl,-final_output,v-compiler'
+				ccoptions.linker_flags << '-Wl,-no_adhoc_codesign'
 			}
 		} else {
 			if v.pref.ccompiler != 'x86_64-w64-mingw32-gcc' {
@@ -2374,9 +2377,8 @@ fn (v &Builder) finalize_reproducible_macos_debug_compiler() {
 			verror('could not find `codesign` to finalize the reproducible macOS compiler binary')
 			return
 		}
-		// Removing the linker's signature first also removes its output-name-dependent
-		// allocation, so the replacement has the same layout for every output path.
-		os.execute('${os.quoted_path(codesign_path)} --remove-signature ${os.quoted_path(v.pref.out_name)}')
+		// The linker leaves this compiler unsigned; add one normalized signature with
+		// a stable identifier so its layout and contents do not depend on the output path.
 		codesign_result :=
 			os.execute('${os.quoted_path(codesign_path)} --force --sign - --identifier org.vlang.v ${os.quoted_path(v.pref.out_name)}')
 		if codesign_result.exit_code != 0 {

--- a/vlib/v/builder/macos_reproducible_compiler_test.v
+++ b/vlib/v/builder/macos_reproducible_compiler_test.v
@@ -172,6 +172,9 @@ fn test_macos_debug_compiler_build_is_reproducible() {
 	assert cdebug_hashes[0] == cdebug_hashes[1], cdebug_hashes.str()
 
 	first_output := os.join_path(test_dir, 'first')
+	first_codesign_result :=
+		os.execute('codesign --verify --strict ${os.quoted_path(first_output)}')
+	assert first_codesign_result.exit_code == 0, first_codesign_result.output
 	nm_result := os.execute('nm -ap ${os.quoted_path(first_output)}')
 	assert nm_result.exit_code == 0, nm_result.output
 	oso_lines := nm_result.output.split_into_lines().filter(it.contains(' OSO '))

--- a/vlib/v3/fastcdriver/fastcdriver.v
+++ b/vlib/v3/fastcdriver/fastcdriver.v
@@ -80,6 +80,10 @@ fn canonical_output_path(path string) string {
 	return os.join_path_single(canonical_parent, os.file_name(absolute_path))
 }
 
+fn fastc_tcc_backtrace_enabled(target_os string, target_arch string) bool {
+	return !(target_os == 'macos' && target_arch == 'arm64')
+}
+
 // run builds a program using only FastC's scanner-to-C pipeline.
 pub fn run(args []string) {
 	input, output, keep_c := parse_arguments(args)
@@ -100,11 +104,13 @@ pub fn run(args []string) {
 	prefs.building_v = real_input.ends_with('/vlib/v3/v3.v')
 	prefs.selfhost = prefs.building_v
 	prefs.user_defines = ['fastc_selfhost', 'v3_backend', 'skip_arm64', 'skip_wasm', 'skip_eval']
+	backtrace_enabled := fastc_tcc_backtrace_enabled(prefs.normalized_target_os(),
+		prefs.target.arch)
 	// Mirror the driver's TinyCC compatibility plan (add_v3_tcc_compat_defines):
 	// TCC's backtrace runtime cannot be linked on macOS arm64, so builtin must
 	// not reference tcc_backtrace there. Descendant generations then compile
 	// builtin exactly like the first FastC generation did.
-	if prefs.normalized_target_os() == 'macos' && prefs.target.arch == 'arm64' {
+	if !backtrace_enabled {
 		prefs.user_defines << 'no_backtrace'
 	}
 
@@ -178,7 +184,8 @@ pub fn run(args []string) {
 	if generation.uses_threads {
 		thread_link_flag = '-lpthread '
 	}
-	command := '${os.quoted_path(tcc)} -std=gnu11 -I${os.quoted_path(os.join_path_single(tcc_lib,
+	backtrace_flag := if backtrace_enabled { '-bt25 ' } else { '' }
+	command := '${os.quoted_path(tcc)} -std=gnu11 ${backtrace_flag}-I${os.quoted_path(os.join_path_single(tcc_lib,
 		'include'))} -L${os.quoted_path(tcc_lib)} -w -o ${os.quoted_path(staged_output)} ${os.quoted_path(c_path)} ${thread_link_flag}-lm'
 	result := os.execute(command)
 	if result.exit_code != 0 {

--- a/vlib/v3/fastcdriver/fastcdriver_test.v
+++ b/vlib/v3/fastcdriver/fastcdriver_test.v
@@ -1,0 +1,8 @@
+module fastcdriver
+
+fn test_fastc_tcc_backtrace_enabled() {
+	assert !fastc_tcc_backtrace_enabled('macos', 'arm64')
+	assert fastc_tcc_backtrace_enabled('macos', 'amd64')
+	assert fastc_tcc_backtrace_enabled('linux', 'arm64')
+	assert fastc_tcc_backtrace_enabled('linux', 'amd64')
+}

--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -6465,6 +6465,7 @@ fn (mut t Transformer) generic_call_decl_key(id flat.NodeId, node flat.Node, mod
 		if base_type.len == 0 {
 			base_type = t.node_type(base_id)
 		}
+		base_type = transform_unshared_receiver_type(base_type)
 		if base_type.starts_with('&') {
 			base_type = base_type[1..]
 		}
@@ -6498,7 +6499,7 @@ fn (t &Transformer) generic_receiver_decl_matches_type(base_type string, decl Ge
 	if decl_receiver.len == 0 {
 		return false
 	}
-	mut clean_base := base_type.trim_space()
+	mut clean_base := transform_unshared_receiver_type(base_type)
 	if clean_base.starts_with('&') {
 		clean_base = clean_base[1..]
 	}
@@ -10653,11 +10654,18 @@ fn (t &Transformer) generic_decl_is_receiver_method(node flat.Node) bool {
 		return false
 	}
 	mut first_type := first.typ.trim_space()
-	if first_type.starts_with('mut ') {
-		first_type = first_type[4..].trim_space()
-	}
-	if first_type.starts_with('&') {
-		first_type = first_type[1..].trim_space()
+	for {
+		if first_type.starts_with('mut ') {
+			first_type = first_type[4..].trim_space()
+		} else if first_type.starts_with('shared ') {
+			first_type = first_type[7..].trim_space()
+		} else if first_type.starts_with('atomic ') {
+			first_type = first_type[7..].trim_space()
+		} else if first_type.starts_with('&') {
+			first_type = first_type[1..].trim_space()
+		} else {
+			break
+		}
 	}
 	method_name := generic_fn_decl_base_value(node.value)
 	clean_first := t.normalize_type_alias(first_type)
@@ -11955,7 +11963,10 @@ fn generic_arg_type_for_param(param_type string, arg_type string) string {
 }
 
 fn generic_inference_param_type(param &flat.Node) string {
-	clean := param.typ.trim_space()
+	mut clean := param.typ.trim_space()
+	for clean.starts_with('shared ') || clean.starts_with('atomic ') {
+		clean = clean[7..].trim_space()
+	}
 	// `mut value T` is represented as `&T` for storage, so that synthetic
 	// pointer must not become part of T. An explicitly declared `value &T`
 	// keeps its pointer: inferring it from an `&int` argument must bind T to


### PR DESCRIPTION
Fix three independent master CI regressions as one batch.

- recognize `shared`/`atomic` generic receivers as receiver methods during monomorphization, so calls such as `Topic[string].add` materialize their bodies
- keep FastC descendant TinyCC invocations aligned with their generated builtin backtrace references by passing `-bt25` on supported hosts
- retain the intentional macOS arm64 `no_backtrace` path
- prevent ld64 from creating an output-dependent provisional ad-hoc signature for reproducible debug compiler builds; add one normalized post-link signature instead
- verify the regular debug compiler is validly signed and add a host-independent test for the FastC backtrace target plan

Reproduces/fixes:
- macOS 14/15/26 CI: `shared_nested_lock_runtime_test.v` linked an undefined `Topic_string__add`
- V3 Linux CI: repeated `v self -b fastc` linked an undefined `tcc_backtrace`
- macOS 14/Xcode 15 CI: four equivalent debug compiler outputs had four different SHA-256 hashes

Validation:
- `./vnew -silent vlib/v3/fastcdriver/fastcdriver_test.v`
- `V_MACOS_V3_NO_FALLBACK=1 ./vnew -cc clang -silent vlib/v/tests/concurrency/shared_nested_lock_runtime_test.v`
- `./vnew -silent vlib/v3/tests/fastc_backend_test.v`
- `./vnew -silent test vlib/v3/transform/`
- `./vnew -silent test vlib/v/builder/`
- `VFLAGS="-cc clang" V_MACOS_V3_NO_FALLBACK=1 ./vnew -old-compiler -silent vlib/v/builder/macos_reproducible_compiler_test.v` (five consecutive passes)
- `./vnew -silent vlib/v/compiler_errors_test.v`