### PR TITLE
v3: fix VGuard compilation with prealloc

### DIFF
--- a/vlib/clipboard/x11/clipboard.c.v
+++ b/vlib/clipboard/x11/clipboard.c.v
@@ -37,7 +37,7 @@ type Time = u64
 pub struct C.XSelectionEvent {
 pub mut:
 	type      int
-	display   voidptr
+	display   &C.Display = unsafe { nil }
 	requestor Window
 	selection Atom
 	target    Atom
@@ -55,7 +55,7 @@ pub mut:
 @[typedef]
 pub struct C.XSelectionRequestEvent {
 pub mut:
-	display   voidptr
+	display   &C.Display = unsafe { nil }
 	owner     Window
 	requestor Window
 	selection Atom

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -9704,7 +9704,6 @@ pub fn run(args []string) {
 			monomorph_used_fns, monomorph_errors, generated_monomorph_specs = transform.monomorphize_with_used_checked_config_scoped_cached(mut a,
 				&pre_tc, monomorph_input_used, !current_no_parallel
 				&& should_parallel_monomorphize(), monomorph_scope, cached_monomorph_specs)
-			parse_cache_enabled := pre_tc.type_cache_parse_enabled()
 			prealloc_scope_leave_for_v3(monomorph_scope)
 			// Specialization can rewrite payload text on pre-existing nodes as
 			// well as append new nodes. Publish every string still owned by the
@@ -9739,7 +9738,10 @@ pub fn run(args []string) {
 			monomorph_used_fns = clone_string_bool_map(monomorph_used_fns)
 			monomorph_errors = clone_string_list(monomorph_errors)
 			generated_monomorph_specs = clone_monomorph_cache_specs(generated_monomorph_specs)
-			pre_tc.set_fresh_type_cache(parse_cache_enabled)
+			// Scoped specialization can leave parse-cache key text in a disposable
+			// worker arena. Cgen must reparse from the promoted AST instead of reading
+			// those keys after the monomorph scope is released.
+			pre_tc.set_fresh_type_cache(false)
 			prealloc_scope_free_for_v3(monomorph_scope)
 		} else {
 			monomorph_used_fns, monomorph_errors, generated_monomorph_specs = transform.monomorphize_with_used_checked_config_scoped_cached(mut a,


### PR DESCRIPTION
## Summary

- align clipboard X11 selection declarations with the matching Sokol/Xlib declarations
- discard parse-type cache entries after scoped monomorphization before freeing their worker arena
- prevent VGuard Cgen from reading stale cache keys and falling back to the stable compiler

The uploaded verbose log stopped immediately after C declaration resolution because clipboard declared the X11 display fields as voidptr while Sokol declared them as &C.Display. Once that conflict was corrected, VGuard exposed stale parse-cache keys retained from the disposable monomorphization scope. Cgen now reparses promoted AST text after that boundary.

## Testing

- ./v -g -keepc -o ./vnew cmd/v
- ./vnew -silent vlib/v/compiler_errors_test.v (1619 passed, 1 skipped)
- ./vnew -silent test vlib/v3/driver/ (6 passed)
- macOS full VGuard V3 frontend with fallback disabled: 2,085,847,040 bytes peak RSS (1.94 GiB), exit 0
- Debian ARM64 full VGuard V3 frontend: 1,897,092 KiB peak RSS (1.81 GiB), exit 0