### PR TITLE
net.websocket: avoid nil dereference when closing unconnected client

### DIFF
--- a/vlib/net/websocket/websocket_client.v
+++ b/vlib/net/websocket/websocket_client.v
@@ -336,7 +336,7 @@ pub fn (mut ws Client) close(code int, message string) ! {
 	ws.debug_log('sending close, ${code}, ${message}')
 	ws_state := ws.get_state()
 	if ws_state in [.closed, .closing] || ws.conn.sock.handle <= 1 {
-		ws.debug_log('close: Websocket already closed (${ws_state}), ${message}, ${code} handle(${ws.conn.sock.handle})')
+		ws.debug_log('close: Websocket already closed (${ws_state}), ${message}, ${code}')
 		err_msg := 'Socket already closed: ${code}'
 		return error(err_msg)
 	}

--- a/vlib/net/websocket/websocket_test.v
+++ b/vlib/net/websocket/websocket_test.v
@@ -176,6 +176,15 @@ fn on_close_cb_3(mut cli websocket.Client, code int, reason string, mut res Webs
 	res.nr_closes++
 }
 
+fn test_close_unconnected_client_returns_error() ! {
+	mut client := websocket.new_client('ws://localhost:30004')!
+	client.close(1000, 'closing connection') or {
+		assert err.msg() == 'Socket already closed: 1000'
+		return
+	}
+	assert false, 'closing an unconnected client should return an error'
+}
+
 fn test_on_close_when_client_closing_connection() ! {
 	mut ws := websocket.new_server(.ip, 30004, '')
 	start_server_in_thread_and_wait_till_it_is_ready_to_accept_connections(mut ws)


### PR DESCRIPTION
## What changed

- Stop Client.close() from dereferencing its socket while formatting the already-closed debug message.
- Add a regression test that verifies closing a newly created, unconnected client returns the existing error instead of crashing.

## Why

The issue reproducer creates two clients with new_client but does not call connect on either one. Each client therefore remains closed with a nil connection. Client.close() correctly enters its already-closed error path, but that path dereferences the nil connection to include its handle in a debug message.

With connect calls added, two actual clients disconnect cleanly and Server.server_state.clients returns to zero, so the reported ServerClient lifetime problem does not reproduce on current master.

Fixes #28212

## Tests

- ./vnew vlib/net/websocket/websocket_test.v
- ./vnew -silent test vlib/net/websocket/