### PR TITLE
vrepeat: implement verbose command output

### DIFF
--- a/cmd/tools/vrepeat.v
+++ b/cmd/tools/vrepeat.v
@@ -149,6 +149,22 @@ fn flushed_print(s string) {
 	flush_stdout()
 }
 
+fn (context &Context) verbose_command(cmd string) {
+	if context.verbose {
+		println('\n> ${cmd}')
+	}
+}
+
+fn (context &Context) verbose_result(result os.Result) {
+	if !context.verbose {
+		return
+	}
+	println('  exit code: ${result.exit_code}')
+	if result.output != '' {
+		println(result.output.trim_right('\r\n'))
+	}
+}
+
 fn (mut context Context) clear_line() {
 	if context.is_silent {
 		return
@@ -207,9 +223,11 @@ fn (mut context Context) run() {
 			if context.warmup > 0 {
 				for i in 0 .. context.warmup {
 					context.flushed_print('${line_prefix}, warm up run: ${i + 1:4}/${context.warmup:-4}, took: ${f64(duration) / 1000:6.1f}ms ...')
+					context.verbose_command(cmd)
 					mut sw := time.new_stopwatch()
 					res := os.execute(cmd)
 					duration = i64(sw.elapsed().microseconds())
+					context.verbose_result(res)
 					mut should_show_fail_output := false
 					if res.exit_code != 0 && !context.ignore_failed {
 						if context.fail_count[cmd] == 0 {
@@ -226,9 +244,11 @@ fn (mut context Context) run() {
 				}
 			}
 			for i in 0 .. context.run_count {
+				context.verbose_command(cmd)
 				mut sw := time.new_stopwatch()
 				res := os.execute(cmd)
 				duration = i64(sw.elapsed().microseconds())
+				context.verbose_result(res)
 				//
 				mut should_show_fail_output := false
 				if res.exit_code != 0 && !context.ignore_failed {
@@ -443,7 +463,8 @@ fn (mut context Context) parse_options() ! {
 	}
 	context.show_output = fp.bool('output', `O`, false,
 		'Show command stdout/stderr in the progress indicator for each command. Note: slower, for verbose commands.')
-	context.verbose = fp.bool('verbose', `v`, false, 'Be more verbose.')
+	context.verbose = fp.bool('verbose', `v`, false,
+		'Print each command, its exit code, and its output.')
 	context.fail_on_maxtime = fp.int('max_time', `m`, max_time,
 		'Fail with exit code 2, when first cmd takes above M milliseconds (regression). Default: ${max_time}')
 	context.fail_on_regress_percent = fp.int('fail_percent', `f`, max_fail_percent,

--- a/cmd/tools/vrepeat_test.v
+++ b/cmd/tools/vrepeat_test.v
@@ -3,12 +3,12 @@ import os
 const vexe = @VEXE
 
 fn test_verbose_prints_command_result() {
-	command := '${os.quoted_path(vexe)} version'
+	command := 'echo vrepeat_verbose_output'
 	for option in ['-v', '--verbose'] {
 		result :=
 			os.execute('${os.quoted_path(vexe)} repeat -S -r 1 -w 0 ${option} ${os.quoted_path(command)}')
 		assert result.exit_code == 0, result.output
 		assert result.output.contains('exit code: 0'), result.output
-		assert result.output.contains('V 0.'), result.output
+		assert result.output.split_into_lines().any(it.trim_right('\r') == 'vrepeat_verbose_output'), result.output
 	}
 }

--- a/cmd/tools/vrepeat_test.v
+++ b/cmd/tools/vrepeat_test.v
@@ -1,0 +1,14 @@
+import os
+
+const vexe = @VEXE
+
+fn test_verbose_prints_command_result() {
+	command := '${os.quoted_path(vexe)} version'
+	for option in ['-v', '--verbose'] {
+		result :=
+			os.execute('${os.quoted_path(vexe)} repeat -S -r 1 -w 0 ${option} ${os.quoted_path(command)}')
+		assert result.exit_code == 0, result.output
+		assert result.output.contains('exit code: 0'), result.output
+		assert result.output.contains('V 0.'), result.output
+	}
+}

--- a/vlib/v/help/other/repeat.txt
+++ b/vlib/v/help/other/repeat.txt
@@ -18,7 +18,7 @@ Options:
                             By default, VEXE will be set to "", to allow for measuring different V executables. Use this option to override it
   -n, --newline             Use \n, do not overwrite the last line. Produces more output, but easier to diagnose.
   -O, --output              Show command stdout/stderr in the progress indicator for each command. Note: slower, for verbose commands.
-  -v, --verbose             Be more verbose.
+  -v, --verbose             Print each command, its exit code, and its output.
   -m, --max_time <int>      Fail with exit code 2, when first cmd takes above M milliseconds (regression). Default: 60000
   -f, --fail_percent <int>  Fail with exit code 3, when first cmd is X% slower than the rest (regression). Default: 100000
   -t, --template <string>   Command template. {T} will be substituted with the current command. Default: {T}. 


### PR DESCRIPTION
## Summary

- make `-v` and `--verbose` print each warm-up and measured command
- print each command exit code and captured output without changing failure handling
- document the verbose output and cover both aliases with a regression test

## Testing

- `VFLAGS="-gc none" ./vnew cmd/tools/vrepeat_test.v`

Fixes #28162