### PR TITLE
vvet: count module-qualified function calls

### DIFF
--- a/cmd/tools/vvet/analyze.v
+++ b/cmd/tools/vvet/analyze.v
@@ -107,7 +107,7 @@ fn (mut vt VetAnalyze) expr(vet &Vet, expr ast.Expr) {
 					expr.pos)
 			} else {
 				lock vt.call_counter {
-					fn_name := if expr.name.contains('.') {
+					fn_name := if expr.name.contains('.') || expr.mod == 'builtin' {
 						expr.name
 					} else {
 						'${expr.mod}.${expr.name}'

--- a/cmd/tools/vvet/analyze.v
+++ b/cmd/tools/vvet/analyze.v
@@ -29,12 +29,13 @@ const long_fns_cutoff = os.getenv_opt('VET_LONG_FNS_CUTOFF') or { '300' }.int()
 
 struct VetAnalyze {
 mut:
-	repeated_expr_cutoff  shared map[string]int // repeated code cutoff	
-	repeated_expr         shared map[string]map[string]map[string][]token.Pos // repeated exprs in fn scope
-	potential_non_inlined shared map[string]map[string]token.Pos              // fns might be inlined
-	call_counter          shared map[string]int // fn call counter
-	builtin_call_counter  shared map[string]int // unqualified fn call counter, keyed by bare name (for builtin fns)
-	cur_fn                ast.FnDecl            // current fn declaration
+	repeated_expr_cutoff     shared map[string]int // repeated code cutoff	
+	repeated_expr            shared map[string]map[string]map[string][]token.Pos // repeated exprs in fn scope
+	potential_non_inlined    shared map[string]map[string]token.Pos              // fns might be inlined
+	call_counter             shared map[string]int // fn call counter
+	unqualified_call_counter shared map[string]int // calls keyed by `<caller module>.<bare name>`
+	declared_fns             shared map[string]bool // all function declarations, keyed by fkey
+	cur_fn                   ast.FnDecl            // current fn declaration
 }
 
 // stmt checks for repeated code in statements
@@ -116,12 +117,11 @@ fn (mut vt VetAnalyze) expr(vet &Vet, expr ast.Expr) {
 					vt.call_counter[fn_name]++
 				}
 				if !expr.name.contains('.') {
-					// Builtin functions have a bare `fkey()` (e.g. `println`), but an
-					// unqualified call from another module is stored with the caller's
-					// module (e.g. `main.println`). Count unqualified calls by bare name
-					// too, so builtin calls from any module contribute to the threshold.
-					lock vt.builtin_call_counter {
-						vt.builtin_call_counter[expr.name]++
+					// Keep the caller module so builtin fallback calls can later be
+					// distinguished from calls shadowed by a same-module function.
+					caller_fn_name := '${expr.mod}.${expr.name}'
+					lock vt.unqualified_call_counter {
+						vt.unqualified_call_counter[caller_fn_name]++
 					}
 				}
 				vt.save_expr(callexpr_cutoff,
@@ -155,12 +155,16 @@ fn (mut vt VetAnalyze) long_or_empty_fns(mut vet Vet, fn_decl ast.FnDecl) {
 
 // potential_non_inlined checks for potential fns to be inlined
 fn (mut vt VetAnalyze) potential_non_inlined(mut vet Vet, fn_decl ast.FnDecl) {
+	fn_key := fn_decl.fkey()
+	lock vt.declared_fns {
+		vt.declared_fns[fn_key] = true
+	}
 	nr_lines := fn_decl.end_pos.line_nr - fn_decl.pos.line_nr - 2
 	if nr_lines < short_fns_cutoff {
 		attr := fn_decl.attrs.find_first('inline')
 		if attr == none {
 			lock vt.potential_non_inlined {
-				vt.potential_non_inlined[fn_decl.fkey()][vet.file] = fn_decl.pos
+				vt.potential_non_inlined[fn_key][vet.file] = fn_decl.pos
 			}
 		}
 	}
@@ -190,14 +194,27 @@ fn (mut vt VetAnalyze) vet_repeated_code(mut vet Vet) {
 
 // vet_inlining_fn reports possible fn to be inlined
 fn (mut vt VetAnalyze) vet_inlining_fn(mut vet Vet) {
+	mut declared_fns := map[string]bool{}
+	rlock vt.declared_fns {
+		declared_fns = vt.declared_fns.clone()
+	}
+	mut unqualified_calls := map[string]int{}
+	rlock vt.unqualified_call_counter {
+		unqualified_calls = vt.unqualified_call_counter.clone()
+	}
+	mut builtin_calls := map[string]int{}
+	for caller_fn_name, count in unqualified_calls {
+		caller_mod := caller_fn_name.all_before_last('.')
+		if caller_mod == 'builtin' || caller_fn_name !in declared_fns {
+			builtin_calls[caller_fn_name.all_after_last('.')] += count
+		}
+	}
 	for fn_name, info in vt.potential_non_inlined {
 		for file, pos in info {
-			// A bare key (no module prefix) belongs to a builtin function, whose
-			// unqualified calls from other modules are tracked by bare name.
 			calls := if fn_name.contains('.') {
 				vt.call_counter[fn_name] or { 0 }
 			} else {
-				vt.builtin_call_counter[fn_name] or { 0 }
+				builtin_calls[fn_name] or { 0 }
 			}
 			if calls < fns_call_cutoff {
 				continue

--- a/cmd/tools/vvet/analyze.v
+++ b/cmd/tools/vvet/analyze.v
@@ -107,7 +107,12 @@ fn (mut vt VetAnalyze) expr(vet &Vet, expr ast.Expr) {
 					expr.pos)
 			} else {
 				lock vt.call_counter {
-					vt.call_counter[expr.name]++
+					fn_name := if expr.name.contains('.') {
+						expr.name
+					} else {
+						'${expr.mod}.${expr.name}'
+					}
+					vt.call_counter[fn_name]++
 				}
 				vt.save_expr(callexpr_cutoff,
 					'${expr.name}(${expr.args.map(it.str()).join(', ')})', vet.file, expr.pos)

--- a/cmd/tools/vvet/analyze.v
+++ b/cmd/tools/vvet/analyze.v
@@ -33,6 +33,7 @@ mut:
 	repeated_expr         shared map[string]map[string]map[string][]token.Pos // repeated exprs in fn scope
 	potential_non_inlined shared map[string]map[string]token.Pos              // fns might be inlined
 	call_counter          shared map[string]int // fn call counter
+	builtin_call_counter  shared map[string]int // unqualified fn call counter, keyed by bare name (for builtin fns)
 	cur_fn                ast.FnDecl            // current fn declaration
 }
 
@@ -114,6 +115,15 @@ fn (mut vt VetAnalyze) expr(vet &Vet, expr ast.Expr) {
 					}
 					vt.call_counter[fn_name]++
 				}
+				if !expr.name.contains('.') {
+					// Builtin functions have a bare `fkey()` (e.g. `println`), but an
+					// unqualified call from another module is stored with the caller's
+					// module (e.g. `main.println`). Count unqualified calls by bare name
+					// too, so builtin calls from any module contribute to the threshold.
+					lock vt.builtin_call_counter {
+						vt.builtin_call_counter[expr.name]++
+					}
+				}
 				vt.save_expr(callexpr_cutoff,
 					'${expr.name}(${expr.args.map(it.str()).join(', ')})', vet.file, expr.pos)
 			}
@@ -182,7 +192,13 @@ fn (mut vt VetAnalyze) vet_repeated_code(mut vet Vet) {
 fn (mut vt VetAnalyze) vet_inlining_fn(mut vet Vet) {
 	for fn_name, info in vt.potential_non_inlined {
 		for file, pos in info {
-			calls := vt.call_counter[fn_name] or { 0 }
+			// A bare key (no module prefix) belongs to a builtin function, whose
+			// unqualified calls from other modules are tracked by bare name.
+			calls := if fn_name.contains('.') {
+				vt.call_counter[fn_name] or { 0 }
+			} else {
+				vt.builtin_call_counter[fn_name] or { 0 }
+			}
 			if calls < fns_call_cutoff {
 				continue
 			}

--- a/cmd/tools/vvet/tests/function_inlining.out
+++ b/cmd/tools/vvet/tests/function_inlining.out
@@ -1,0 +1,1 @@
+cmd/tools/vvet/tests/function_inlining.vv:2: notice: add fn might be inlined (possibly called at least 10 times)

--- a/cmd/tools/vvet/tests/function_inlining.vv
+++ b/cmd/tools/vvet/tests/function_inlining.vv
@@ -1,0 +1,17 @@
+// vtest vflags: -I
+fn add(a int, b int) int {
+	return a + b
+}
+
+fn main() {
+	println(add(1, 1))
+	println(add(2, 2))
+	println(add(3, 3))
+	println(add(4, 4))
+	println(add(5, 5))
+	println(add(6, 6))
+	println(add(7, 7))
+	println(add(8, 8))
+	println(add(9, 9))
+	println(add(10, 10))
+}

--- a/cmd/tools/vvet/tests/function_inlining.vv
+++ b/cmd/tools/vvet/tests/function_inlining.vv
@@ -4,14 +4,16 @@ fn add(a int, b int) int {
 }
 
 fn main() {
-	println(add(1, 1))
-	println(add(2, 2))
-	println(add(3, 3))
-	println(add(4, 4))
-	println(add(5, 5))
-	println(add(6, 6))
-	println(add(7, 7))
-	println(add(8, 8))
-	println(add(9, 9))
-	println(add(10, 10))
+	for i in 0 .. 10_000 {
+		println(add(i, i))
+		println(add(i, i))
+		println(add(i, i))
+		println(add(i, i))
+		println(add(i, i))
+		println(add(i, i))
+		println(add(i, i))
+		println(add(i, i))
+		println(add(i, i))
+		println(add(i, i))
+	}
 }

--- a/cmd/tools/vvet/vet_test.v
+++ b/cmd/tools/vvet/vet_test.v
@@ -29,6 +29,36 @@ fn test_vet() {
 	assert fails == 0
 }
 
+// test_builtin_inline_calls_from_other_modules verifies that unqualified calls
+// to a builtin function made from another module still contribute to its inline
+// threshold. Builtin declarations have a bare `fkey()` (e.g. `my_helper`), while
+// the parser records such calls with the caller's module (e.g. `main.my_helper`),
+// so they must be resolved back to the bare builtin key when counting.
+fn test_builtin_inline_calls_from_other_modules() {
+	vexe := os.getenv('VEXE')
+	// Note: `os.temp_dir()` (not `os.vtmp_dir()`) is used on purpose, since `v vet`
+	// filters out paths located inside `VTMP`.
+	tmp := os.join_path(os.temp_dir(), 'vvet_builtin_inline_${os.getpid()}')
+	os.rmdir_all(tmp) or {}
+	os.mkdir_all(os.join_path(tmp, 'builtin'))!
+	defer {
+		os.rmdir_all(tmp) or {}
+	}
+	// A `v.mod` at the root makes the `builtin` sub folder resolve to `module builtin`.
+	os.write_file(os.join_path(tmp, 'v.mod'), "Module {\n\tname: 'vvet_builtin_inline'\n}\n")!
+	os.write_file(os.join_path(tmp, 'builtin', 'helper.v'),
+		'module builtin\n\nfn my_helper(a int, b int) int {\n\treturn a + b\n}\n')!
+	mut calls := []string{}
+	for _ in 0 .. 10 {
+		calls << '\tprintln(my_helper(1, 1))'
+	}
+	os.write_file(os.join_path(tmp, 'caller.v'),
+		'module main\n\nfn main() {\n${calls.join('\n')}\n}\n')!
+	res := os.execute('${os.quoted_path(vexe)} vet -nocolor -I ${os.quoted_path(tmp)}')
+	assert res.exit_code >= 0, res.output
+	assert res.output.contains('my_helper fn might be inlined'), res.output
+}
+
 fn get_tests_in_dir(dir string) []string {
 	files := os.ls(dir) or { panic(err) }
 	mut tests := files.filter(it.ends_with('.vv'))

--- a/cmd/tools/vvet/vet_test.v
+++ b/cmd/tools/vvet/vet_test.v
@@ -59,6 +59,47 @@ fn test_builtin_inline_calls_from_other_modules() {
 	assert res.output.contains('my_helper fn might be inlined'), res.output
 }
 
+// test_local_function_shadows_builtin_inline_calls verifies that unqualified calls
+// are not credited to a same-named builtin function when the caller module declares
+// its own function.
+fn test_local_function_shadows_builtin_inline_calls() {
+	vexe := os.getenv('VEXE')
+	tmp := os.join_path(os.temp_dir(), 'vvet_builtin_shadow_${os.getpid()}')
+	os.rmdir_all(tmp) or {}
+	os.mkdir_all(os.join_path(tmp, 'builtin'))!
+	defer {
+		os.rmdir_all(tmp) or {}
+	}
+	os.write_file(os.join_path(tmp, 'v.mod'), "Module {\n\tname: 'vvet_builtin_shadow'\n}\n")!
+	os.write_file(os.join_path(tmp, 'builtin', 'helper.v'),
+		'module builtin\n\nfn my_helper(a int, b int) int {\n\treturn a + b\n}\n')!
+	mut calls := []string{}
+	for _ in 0 .. 10 {
+		calls << '\tprintln(my_helper(1, 1))'
+	}
+	os.write_file(os.join_path(tmp, 'caller.v'),
+		"module main\n\n@[inline]\nfn my_helper(a int, b int) int {\n\treturn a + b\n}\n\nfn main() {\n${calls.join('\n')}\n}\n")!
+	res := os.execute('${os.quoted_path(vexe)} vet -nocolor -I ${os.quoted_path(tmp)}')
+	assert res.exit_code >= 0, res.output
+	assert !res.output.contains('my_helper fn might be inlined'), res.output
+}
+
+// test_for_c_body_is_analyzed_before_increment verifies that stateful vet checks
+// observe a C-style loop body before an assignment in its increment clause.
+fn test_for_c_body_is_analyzed_before_increment() {
+	vexe := os.getenv('VEXE')
+	path := os.join_path(os.temp_dir(), 'vvet_for_c_order_${os.getpid()}.v')
+	os.rm(path) or {}
+	defer {
+		os.rm(path) or {}
+	}
+	os.write_file(path,
+		"import regex\n\nfn main() {\n\tmut re := regex.new()\n\tfor ; false; re = 0 {\n\t\tre.compile_opt(r'foo|bar') or { panic(err) }\n\t}\n}\n")!
+	res := os.execute('${os.quoted_path(vexe)} vet -nocolor ${os.quoted_path(path)}')
+	assert res.exit_code >= 0, res.output
+	assert res.output.contains('Confusing regex `|` in `foo|bar`'), res.output
+}
+
 fn get_tests_in_dir(dir string) []string {
 	files := os.ls(dir) or { panic(err) }
 	mut tests := files.filter(it.ends_with('.vv'))

--- a/cmd/tools/vvet/vvet.v
+++ b/cmd/tools/vvet/vvet.v
@@ -315,8 +315,8 @@ fn (mut vt Vet) stmt(stmt ast.Stmt) {
 		ast.ForCStmt {
 			vt.stmt(stmt.init)
 			vt.expr(stmt.cond)
-			vt.stmt(stmt.inc)
 			vt.stmts(stmt.stmts)
+			vt.stmt(stmt.inc)
 		}
 		ast.ForInStmt {
 			vt.expr(stmt.cond)

--- a/cmd/tools/vvet/vvet.v
+++ b/cmd/tools/vvet/vvet.v
@@ -312,6 +312,21 @@ fn (mut vt Vet) stmt(stmt ast.Stmt) {
 			vt.analyze.cur_fn = old_fn_decl
 			vt.regex_vars = old_regex_vars.clone()
 		}
+		ast.ForCStmt {
+			vt.stmt(stmt.init)
+			vt.expr(stmt.cond)
+			vt.stmt(stmt.inc)
+			vt.stmts(stmt.stmts)
+		}
+		ast.ForInStmt {
+			vt.expr(stmt.cond)
+			vt.expr(stmt.high)
+			vt.stmts(stmt.stmts)
+		}
+		ast.ForStmt {
+			vt.expr(stmt.cond)
+			vt.stmts(stmt.stmts)
+		}
 		ast.StructDecl {
 			vt.exprs(stmt.fields.map(it.default_expr))
 		}


### PR DESCRIPTION
## Summary

- qualify unqualified function calls with their parser module before counting them
- traverse `for`, C-style `for`, and `for in` expressions and bodies during vet analysis
- add an `-I` regression fixture with calls inside the reported range-loop form

## Testing

- `VFLAGS="-gc none" ./vnew cmd/tools/vvet/vet_test.v`

Fixes #28153