### PR TITLE
v3: fix Peony compilation regressions

### DIFF
--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -12358,6 +12358,13 @@ fn (mut g FlatGen) gen_expr_with_expected_type(id flat.NodeId, expected types.Ty
 			actual = local_type
 		}
 	}
+	if node.kind == .selector {
+		if node.typ.len > 0 && (node.typ.starts_with('?') || node.typ.starts_with('!')) {
+			actual = g.tc.parse_resolution_type(node.typ)
+		} else if declared_type := g.selector_declared_type(id) {
+			actual = declared_type
+		}
+	}
 	if expected is types.String && actual is types.Pointer
 		&& g.pointer_stringifies_as_address(actual.base_type)
 		&& !g.type_names_match(actual.base_type, expected) {
@@ -13269,6 +13276,14 @@ fn (g &FlatGen) selector_declared_type(id flat.NodeId) ?types.Type {
 fn (g &FlatGen) selector_base_expr_type(id flat.NodeId) types.Type {
 	if int(id) >= 0 && int(id) < g.a.nodes.len {
 		node := g.a.nodes[int(id)]
+		if node.kind == .ident {
+			if typ := g.current_param_type(node.value) {
+				return typ
+			}
+			if typ := g.local_ident_type(node.value) {
+				return typ
+			}
+		}
 		if node.kind == .or_expr && node.children_count > 0 {
 			source_id := g.a.child(&node, 0)
 			source_type := g.or_expr_source_type(source_id, g.a.nodes[int(source_id)])
@@ -15737,6 +15752,18 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 				g.gen_expr(g.a.child(&child, 0))
 				return
 			}
+			if node.op == .amp && child.kind == .selector && child.children_count > 0 {
+				base_id := g.a.child(&child, 0)
+				base := g.a.nodes[int(base_id)]
+				if base.kind == .index && base.children_count > 0 {
+					index_base_type := map_str_clean_type(g.usable_expr_type(g.a.child(&base, 0)))
+					if index_base_type is types.Map {
+						g.write('&')
+						gen_expr_lvalue(mut g, child_id)
+						return
+					}
+				}
+			}
 			if node.op == .amp && g.gen_amp_c_string_literal(child_id, child) {
 				return
 			} else if node.op == .amp && g.gen_current_mut_param_address(id) {
@@ -15946,7 +15973,7 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 					return
 				}
 			}
-			mut base_type0 := g.usable_expr_type(base_id)
+			mut base_type0 := g.selector_base_expr_type(base_id)
 			base_is_source_mut_pointer_deref := g.source_mut_pointer_param_deref_type(base_id) != none
 			if deref_type := g.source_mut_pointer_param_deref_type(base_id) {
 				base_type0 = deref_type
@@ -16211,6 +16238,24 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 				}
 			} else if g.gen_struct_default_global_selector(base, node.value, node.op) {
 				// handled
+			} else if g.selector_declared_type(id) != none {
+				// An explicitly declared field shadows any same-named field promoted
+				// through an embedded struct. Use the declared receiver type rather
+				// than a stale short-name lookup from another module.
+				needs_paren := base.kind !in [.ident, .selector]
+				if needs_paren {
+					g.write('(')
+				}
+				g.gen_expr(base_id)
+				if needs_paren {
+					g.write(')')
+				}
+				if node.op == .arrow || base_type0 is types.Pointer {
+					g.write('->')
+				} else {
+					g.write('.')
+				}
+				g.write(g.cname(node.value))
 			} else if embedded := g.direct_embedded_field_for_selector(base_type0, node.value) {
 				needs_paren := base.kind !in [.ident, .selector]
 				if needs_paren {

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -15752,17 +15752,11 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 				g.gen_expr(g.a.child(&child, 0))
 				return
 			}
-			if node.op == .amp && child.kind == .selector && child.children_count > 0 {
-				base_id := g.a.child(&child, 0)
-				base := g.a.nodes[int(base_id)]
-				if base.kind == .index && base.children_count > 0 {
-					index_base_type := map_str_clean_type(g.usable_expr_type(g.a.child(&base, 0)))
-					if index_base_type is types.Map {
-						g.write('&')
-						gen_expr_lvalue(mut g, child_id)
-						return
-					}
-				}
+			if node.op == .amp && child.kind == .selector && child.children_count > 0
+				&& g.is_map_entry_lvalue(g.a.child(&child, 0)) {
+				g.write('&')
+				gen_expr_lvalue(mut g, child_id)
+				return
 			}
 			if node.op == .amp && g.gen_amp_c_string_literal(child_id, child) {
 				return

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -6320,7 +6320,7 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 						}
 					}
 					{
-						base_type := g.usable_expr_type(g.a.child(fn_node, 0))
+						base_type := g.receiver_base_type(g.a.child(fn_node, 0))
 						clean_type := concrete_receiver_type(base_type)
 						if g.gen_thread_wait_call(fn_node) {
 							return
@@ -6479,7 +6479,7 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 					g.write(')')
 					return
 				} else {
-					base_type := g.usable_expr_type(g.a.child(fn_node, 0))
+					base_type := g.receiver_base_type(g.a.child(fn_node, 0))
 					clean_type := concrete_receiver_type(base_type)
 					if cgen_is_channel_close_receiver_type(clean_type) && fn_node.value == 'close' {
 						g.gen_channel_close_call(g.a.child(fn_node, 0), node)
@@ -7509,8 +7509,26 @@ fn (g &FlatGen) receiver_base_type(base_id flat.NodeId) types.Type {
 		return types.Type(types.void_)
 	}
 	base := g.a.nodes[int(base_id)]
+	if base.kind == .paren && base.typ.len > 0 {
+		declared := g.parse_node_type(&base)
+		if declared !is types.Unknown && declared !is types.Void {
+			return declared
+		}
+	}
+	if base.kind == .selector {
+		if typ := g.selector_declared_type(base_id) {
+			return typ
+		}
+	}
 	if base.kind == .ident {
 		if typ := g.current_param_type(base.value) {
+			if base.typ.len > 0 {
+				declared := g.parse_node_type(&base)
+				if declared !is types.Unknown && declared !is types.Void
+					&& declared.name() != typ.name() && base.typ.contains('.') {
+					return declared
+				}
+			}
 			return typ
 		}
 		if typ := g.current_param_map_type(base.value) {
@@ -11526,6 +11544,29 @@ fn (mut g FlatGen) gen_optional_arg_with_abi(arg_id flat.NodeId, expected types.
 		return true
 	}
 	arg_node := g.a.nodes[int(arg_id)]
+	if arg_node.kind == .selector && arg_node.typ.len > 0
+		&& (arg_node.typ.starts_with('?') || arg_node.typ.starts_with('!')) {
+		g.gen_expr(arg_id)
+		return true
+	}
+	if !concrete_abi && arg_node.kind in [.selector, .paren, .expr_stmt] {
+		declared := optional_result_unalias_type(g.or_expr_source_type(arg_id, arg_node))
+		if declared is types.OptionType || declared is types.ResultType {
+			if g.optional_type_name(declared) == g.optional_type_name(expected) {
+				g.gen_expr(arg_id)
+				return true
+			}
+		}
+	}
+	if arg_node.kind == .selector {
+		if declared_type := g.selector_declared_type(arg_id) {
+			declared := optional_result_unalias_type(declared_type)
+			if declared is types.OptionType || declared is types.ResultType {
+				g.gen_expr(arg_id)
+				return true
+			}
+		}
+	}
 	// The checker can contextually type a plain call as `?T` when it is used
 	// where an option is expected. The callee's declared return type remains
 	// authoritative: only treat a call as an already materialized option when
@@ -11564,7 +11605,14 @@ fn (mut g FlatGen) gen_optional_arg_with_abi(arg_id flat.NodeId, expected types.
 			}
 		}
 	}
-	arg_type := g.usable_expr_type(arg_id)
+	mut arg_type := g.usable_expr_type(arg_id)
+	if arg_node.kind == .selector {
+		if arg_node.typ.len > 0 && (arg_node.typ.starts_with('?') || arg_node.typ.starts_with('!')) {
+			arg_type = g.tc.parse_resolution_type(arg_node.typ)
+		} else if declared_type := g.selector_declared_type(arg_id) {
+			arg_type = declared_type
+		}
+	}
 	arg_optional_type := optional_result_unalias_type(arg_type)
 	if !plain_call_in_optional_context
 		&& (arg_optional_type is types.OptionType || arg_optional_type is types.ResultType) {
@@ -12861,6 +12909,21 @@ fn (g &FlatGen) resolved_receiver_method_for_call(resolved string, node flat.Nod
 	params := g.tc.fn_param_types[resolved] or { return none }
 	if params.len != node.children_count {
 		return none
+	}
+	if params.len > 0 && node.children_count > 0 {
+		callee := g.a.child_node(&node, 0)
+		if callee.kind == .selector && callee.children_count > 0 {
+			base_id := g.a.child(callee, 0)
+			base_type := g.receiver_base_type(base_id)
+			base_name := g.type_lookup_name(types.unwrap_pointer(base_type))
+			expected_name := g.embedded_receiver_expected_name(params[0])
+			if base_name.len > 0 && expected_name.len > 0 && base_name != expected_name {
+				if _ := g.embedded_receiver_path_for_expected(base_type, params[0]) {
+				} else {
+					return none
+				}
+			}
+		}
 	}
 	return resolved
 }

--- a/vlib/v3/gen/c/interface.v
+++ b/vlib/v3/gen/c/interface.v
@@ -1339,6 +1339,14 @@ fn (mut g FlatGen) gen_interface_pointer_value_expr(id flat.NodeId, expected typ
 
 fn (mut g FlatGen) interface_source_type(id flat.NodeId) types.Type {
 	node := g.a.node(id)
+	if node.kind == .ident {
+		if local_type := g.local_ident_type(node.value) {
+			return local_type
+		}
+		if param_type := g.current_param_type(node.value) {
+			return param_type
+		}
+	}
 	if node.kind == .ident && g.current_param_type(node.value) == none
 		&& !g.cur_scope_has_local_name(node.value) {
 		current_global_name := qualify_name_in_module(g.tc.cur_module, node.value)

--- a/vlib/v3/gen/c/stmt.v
+++ b/vlib/v3/gen/c/stmt.v
@@ -51,12 +51,20 @@ fn gen_expr_lvalue(mut g FlatGen, id flat.NodeId) {
 			if index_base_type is types.Map {
 				gen_expr_lvalue(mut g, base_id)
 				base_type := g.usable_expr_type(base_id)
-				if base_type is types.Pointer || cgen_unalias_type(base_type) is types.Pointer {
-					g.write('->')
-				} else {
-					g.write('.')
+				mut is_ptr := base_type is types.Pointer
+					|| cgen_unalias_type(base_type) is types.Pointer
+				if embedded_path := g.embedded_field_path_for_promoted_selector(base_type,
+					node.value)
+				{
+					for embedded in embedded_path {
+						op := if is_ptr { '->' } else { '.' }
+						g.write('${op}${g.cname(embedded.name)}')
+						is_ptr = embedded.typ is types.Pointer
+							|| cgen_unalias_type(embedded.typ) is types.Pointer
+					}
 				}
-				g.write(g.cname(node.value))
+				op := if is_ptr { '->' } else { '.' }
+				g.write('${op}${g.cname(node.value)}')
 				return
 			}
 		}

--- a/vlib/v3/gen/c/stmt.v
+++ b/vlib/v3/gen/c/stmt.v
@@ -36,6 +36,31 @@ fn gen_expr_lvalue(mut g FlatGen, id flat.NodeId) {
 		g.gen_mut_pointer_slot_expr(id)
 		return
 	}
+	if node.kind == .paren && node.children_count > 0 {
+		g.write('(')
+		gen_expr_lvalue(mut g, g.a.child(&node, 0))
+		g.write(')')
+		return
+	}
+	if node.kind == .selector && node.children_count > 0 {
+		base_id := g.a.child(&node, 0)
+		base := g.a.nodes[int(base_id)]
+		if base.kind == .index && base.children_count > 0 {
+			index_base_id := g.a.child(&base, 0)
+			index_base_type := map_str_clean_type(g.usable_expr_type(index_base_id))
+			if index_base_type is types.Map {
+				gen_expr_lvalue(mut g, base_id)
+				base_type := g.usable_expr_type(base_id)
+				if base_type is types.Pointer || cgen_unalias_type(base_type) is types.Pointer {
+					g.write('->')
+				} else {
+					g.write('.')
+				}
+				g.write(g.cname(node.value))
+				return
+			}
+		}
+	}
 	if node.kind == .index {
 		base_id := g.a.child(&node, 0)
 		base_type := g.usable_expr_type(base_id)
@@ -2743,7 +2768,7 @@ fn (mut g FlatGen) gen_node(id flat.NodeId) {
 								&& !g.or_value_temp_matches_array_return(ret_node, base)
 								&& !g.call_constructs_type(ret_id, base)
 								&& !g.clone_call_matches_base(ret_node, base)
-								&& expr_value_type !is types.Primitive
+								&& base !is types.Interface && expr_value_type !is types.Primitive
 								&& expr_value_type !is types.Unknown {
 								if g.cur_fn_ret is types.ResultType {
 									if result_err := g.result_error_from_expr_string(ret_id) {
@@ -7495,6 +7520,39 @@ fn (g &FlatGen) is_noreturn_call(id flat.NodeId) bool {
 	return false
 }
 
+// stmt_tail_exits reports whether a statement or expression always leaves the
+// enclosing control-flow scope. Lowered exhaustive matches are represented as
+// if/else chains, and do not produce a value when every arm exits.
+fn (g &FlatGen) stmt_tail_exits(id flat.NodeId) bool {
+	if !g.valid_node_id(id) {
+		return false
+	}
+	node := g.a.nodes[int(id)]
+	match node.kind {
+		.return_stmt, .break_stmt, .continue_stmt {
+			return true
+		}
+		.block, .expr_stmt {
+			if node.children_count == 0 {
+				return false
+			}
+			return g.stmt_tail_exits(g.a.child(&node, node.children_count - 1))
+		}
+		.call {
+			return g.is_noreturn_call(id)
+		}
+		.if_expr {
+			if node.children_count < 3 {
+				return false
+			}
+			return g.stmt_tail_exits(g.a.child(&node, 1)) && g.stmt_tail_exits(g.a.child(&node, 2))
+		}
+		else {
+			return false
+		}
+	}
+}
+
 // tmp_name supports tmp name handling for FlatGen.
 fn (mut g FlatGen) tmp_name() string {
 	g.tmp_count++
@@ -7818,6 +7876,8 @@ fn (mut g FlatGen) gen_or_body_value(or_body flat.Node, value_name string, value
 				g.write('return ')
 				g.gen_optional_error_from_call(fn_opt_ct, g.a.nodes[int(expr_id)])
 				g.write(';')
+			} else if g.stmt_tail_exits(expr_id) {
+				g.gen_node(expr_id)
 			} else if g.is_noreturn_call(expr_id) || g.tc.resolve_type(expr_id) is types.Void {
 				// A diverging/void or-body tail (e.g. `panic(..)`/`exit(..)`) yields no
 				// value; emit it as a bare statement instead of assigning void.

--- a/vlib/v3/gen/c/stmt.v
+++ b/vlib/v3/gen/c/stmt.v
@@ -29,6 +29,22 @@ fn gen_map_index_lvalue(mut g FlatGen, node flat.Node, base_id flat.NodeId, map_
 	g.write('))')
 }
 
+fn (g &FlatGen) is_map_entry_lvalue(id flat.NodeId) bool {
+	if int(id) < 0 || int(id) >= g.a.nodes.len {
+		return false
+	}
+	node := g.a.nodes[int(id)]
+	if node.kind in [.paren, .selector] && node.children_count > 0 {
+		return g.is_map_entry_lvalue(g.a.child(&node, 0))
+	}
+	if node.kind != .index || node.children_count == 0 {
+		return false
+	}
+	base_id := g.a.child(&node, 0)
+	base_type := map_str_clean_type(g.usable_expr_type(base_id))
+	return base_type is types.Map
+}
+
 // gen_expr_lvalue emits expr lvalue output for c.
 fn gen_expr_lvalue(mut g FlatGen, id flat.NodeId) {
 	node := g.a.nodes[int(id)]
@@ -44,29 +60,22 @@ fn gen_expr_lvalue(mut g FlatGen, id flat.NodeId) {
 	}
 	if node.kind == .selector && node.children_count > 0 {
 		base_id := g.a.child(&node, 0)
-		base := g.a.nodes[int(base_id)]
-		if base.kind == .index && base.children_count > 0 {
-			index_base_id := g.a.child(&base, 0)
-			index_base_type := map_str_clean_type(g.usable_expr_type(index_base_id))
-			if index_base_type is types.Map {
-				gen_expr_lvalue(mut g, base_id)
-				base_type := g.usable_expr_type(base_id)
-				mut is_ptr := base_type is types.Pointer
-					|| cgen_unalias_type(base_type) is types.Pointer
-				if embedded_path := g.embedded_field_path_for_promoted_selector(base_type,
-					node.value)
-				{
-					for embedded in embedded_path {
-						op := if is_ptr { '->' } else { '.' }
-						g.write('${op}${g.cname(embedded.name)}')
-						is_ptr = embedded.typ is types.Pointer
-							|| cgen_unalias_type(embedded.typ) is types.Pointer
-					}
+		if g.is_map_entry_lvalue(base_id) {
+			gen_expr_lvalue(mut g, base_id)
+			base_type := g.usable_expr_type(base_id)
+			mut is_ptr := base_type is types.Pointer
+				|| cgen_unalias_type(base_type) is types.Pointer
+			if embedded_path := g.embedded_field_path_for_promoted_selector(base_type, node.value) {
+				for embedded in embedded_path {
+					op := if is_ptr { '->' } else { '.' }
+					g.write('${op}${g.cname(embedded.name)}')
+					is_ptr = embedded.typ is types.Pointer
+						|| cgen_unalias_type(embedded.typ) is types.Pointer
 				}
-				op := if is_ptr { '->' } else { '.' }
-				g.write('${op}${g.cname(node.value)}')
-				return
 			}
+			op := if is_ptr { '->' } else { '.' }
+			g.write('${op}${g.cname(node.value)}')
+			return
 		}
 	}
 	if node.kind == .index {

--- a/vlib/v3/gen/c/struct.v
+++ b/vlib/v3/gen/c/struct.v
@@ -736,6 +736,39 @@ fn (g &FlatGen) unique_qualified_struct_c_type(short_ct string) ?string {
 	return none
 }
 
+fn (g &FlatGen) unique_qualified_interface_c_type(short_ct string) ?string {
+	matches := g.qualified_interface_c_types(short_ct)
+	local_ct := g.cname(qualify_name_in_module(g.tc.cur_module, short_ct))
+	if local_ct in matches {
+		return local_ct
+	}
+	if matches.len == 1 && matches[0] != short_ct {
+		return matches[0]
+	}
+	return none
+}
+
+fn (g &FlatGen) qualified_interface_c_types(short_ct string) []string {
+	if short_ct.len == 0 {
+		return []string{}
+	}
+	mut matches := []string{}
+	for type_name, _ in g.tc.interface_names {
+		candidate_ct := g.cname(type_name)
+		if candidate_ct != short_ct && !candidate_ct.ends_with('__${short_ct}') {
+			continue
+		}
+		if candidate_ct !in matches {
+			matches << candidate_ct
+		}
+	}
+	return matches
+}
+
+fn (g &FlatGen) ambiguous_qualified_interface_c_type(short_ct string) bool {
+	return g.qualified_interface_c_types(short_ct).len > 1
+}
+
 fn (g &FlatGen) generic_struct_init_context_matches(init_name string, expected_name string) bool {
 	init_base, init_args, init_ok := g.shared_generic_app_parts(init_name)
 	expected_base, expected_args, expected_ok := g.shared_generic_app_parts(expected_name)

--- a/vlib/v3/gen/c/struct.v
+++ b/vlib/v3/gen/c/struct.v
@@ -761,8 +761,9 @@ fn (g &FlatGen) qualified_interface_c_types(short_ct string) []string {
 	return matches
 }
 
-fn (g &FlatGen) ambiguous_qualified_interface_c_type(short_ct string) bool {
-	return g.qualified_interface_c_types(short_ct).len > 1
+fn (g &FlatGen) stale_ambiguous_qualified_interface_c_type(short_ct string) bool {
+	matches := g.qualified_interface_c_types(short_ct)
+	return matches.len > 1 && short_ct !in matches
 }
 
 fn (g &FlatGen) generic_struct_init_context_matches(init_name string, expected_name string) bool {

--- a/vlib/v3/gen/c/struct.v
+++ b/vlib/v3/gen/c/struct.v
@@ -738,10 +738,6 @@ fn (g &FlatGen) unique_qualified_struct_c_type(short_ct string) ?string {
 
 fn (g &FlatGen) unique_qualified_interface_c_type(short_ct string) ?string {
 	matches := g.qualified_interface_c_types(short_ct)
-	local_ct := g.cname(qualify_name_in_module(g.tc.cur_module, short_ct))
-	if local_ct in matches {
-		return local_ct
-	}
 	if matches.len == 1 && matches[0] != short_ct {
 		return matches[0]
 	}

--- a/vlib/v3/gen/c/types.v
+++ b/vlib/v3/gen/c/types.v
@@ -848,7 +848,7 @@ fn (mut g FlatGen) emit_optional_typedef(opt_name string, val_type string) bool 
 		return false
 	}
 	bare_val_type := val_type.trim_right('*')
-	if !bare_val_type.contains('__') && g.ambiguous_qualified_interface_c_type(bare_val_type) {
+	if !bare_val_type.contains('__') && g.stale_ambiguous_qualified_interface_c_type(bare_val_type) {
 		// A stale unqualified signature cannot identify which imported interface it
 		// belongs to. Its concrete, module-qualified signature registers the usable
 		// typedef; do not emit an invalid C type for the ambiguous collector entry.

--- a/vlib/v3/gen/c/types.v
+++ b/vlib/v3/gen/c/types.v
@@ -359,6 +359,12 @@ fn (mut g FlatGen) optional_payload_c_type(t types.Type) string {
 			return qualified + pointer_suffix
 		}
 	}
+	// A stale declaration spelling can also lose the nominal kind and represent
+	// an interface as a bare struct. Check the interface registry independently
+	// so `!Value` from another module still uses that module's interface typedef.
+	if qualified := g.unique_qualified_interface_c_type(ct) {
+		return qualified + pointer_suffix
+	}
 	return ct + pointer_suffix
 }
 
@@ -838,6 +844,14 @@ fn (mut g FlatGen) emit_optional_typedef(opt_name string, val_type string) bool 
 		return false
 	}
 	if g.cached_support_identifiers[opt_name] {
+		g.emitted_optional_types[opt_name] = true
+		return false
+	}
+	bare_val_type := val_type.trim_right('*')
+	if !bare_val_type.contains('__') && g.ambiguous_qualified_interface_c_type(bare_val_type) {
+		// A stale unqualified signature cannot identify which imported interface it
+		// belongs to. Its concrete, module-qualified signature registers the usable
+		// typedef; do not emit an invalid C type for the ambiguous collector entry.
 		g.emitted_optional_types[opt_name] = true
 		return false
 	}

--- a/vlib/v3/gen/c/types.v
+++ b/vlib/v3/gen/c/types.v
@@ -360,12 +360,23 @@ fn (mut g FlatGen) optional_payload_c_type(t types.Type) string {
 		}
 	}
 	// A stale declaration spelling can also lose the nominal kind and represent
-	// an interface as a bare struct. Check the interface registry independently
-	// so `!Value` from another module still uses that module's interface typedef.
-	if qualified := g.unique_qualified_interface_c_type(ct) {
-		return qualified + pointer_suffix
+	// an interface as a bare struct. Only consult the interface registry for
+	// interface-like semantic types; concrete qualified types such as `C.Value`
+	// can legitimately share their bare C spelling with a V interface.
+	if optional_payload_may_have_stale_interface_spelling(t) {
+		if qualified := g.unique_qualified_interface_c_type(ct) {
+			return qualified + pointer_suffix
+		}
 	}
 	return ct + pointer_suffix
+}
+
+fn optional_payload_may_have_stale_interface_spelling(t types.Type) bool {
+	mut clean := cgen_unalias_type(t)
+	for clean is types.Pointer {
+		clean = cgen_unalias_type(clean.base_type)
+	}
+	return clean is types.Interface || (clean is types.Struct && !clean.name.contains('.'))
 }
 
 fn optional_payload_is_bare_struct(t types.Type) bool {

--- a/vlib/v3/gen/c/types_test.v
+++ b/vlib/v3/gen/c/types_test.v
@@ -86,7 +86,7 @@ fn test_optional_payload_does_not_qualify_ambiguous_interface() {
 		name: 'Value'
 	})
 	assert g.optional_payload_c_type(value_type) == 'Value'
-	assert g.ambiguous_qualified_interface_c_type('Value')
+	assert g.stale_ambiguous_qualified_interface_c_type('Value')
 }
 
 fn test_declaration_signature_scan_ignores_unscoped_regular_fn_nodes() {

--- a/vlib/v3/gen/c/types_test.v
+++ b/vlib/v3/gen/c/types_test.v
@@ -54,6 +54,24 @@ fn test_optional_payload_qualifies_concrete_generic_struct() {
 	assert g.needed_optional_types['Optional_json2__StructKeyDecodeResult_TestEchoArgs'] == 'json2__StructKeyDecodeResult_TestEchoArgs'
 }
 
+fn test_optional_payload_qualifies_interface() {
+	mut ast := &flat.FlatAst{}
+	mut tc := types.TypeChecker.new(ast)
+	tc.interface_names['firebird.Value'] = true
+	mut g := FlatGen.new()
+	g.a = ast
+	g.tc = &tc
+
+	value_type := types.Type(types.Interface{
+		name: 'Value'
+	})
+	assert g.optional_payload_c_type(value_type) == 'firebird__Value'
+	result_type := types.Type(types.ResultType{
+		base_type: value_type
+	})
+	assert g.concrete_optional_type_name(result_type) == 'Optional_firebird__Value'
+}
+
 fn test_declaration_signature_scan_ignores_unscoped_regular_fn_nodes() {
 	mut ast := flat.FlatAst.new()
 	ast.add_node(flat.Node{

--- a/vlib/v3/gen/c/types_test.v
+++ b/vlib/v3/gen/c/types_test.v
@@ -72,6 +72,23 @@ fn test_optional_payload_qualifies_interface() {
 	assert g.concrete_optional_type_name(result_type) == 'Optional_firebird__Value'
 }
 
+fn test_optional_payload_does_not_qualify_ambiguous_interface() {
+	mut ast := &flat.FlatAst{}
+	mut tc := types.TypeChecker.new(ast)
+	tc.cur_module = 'json2'
+	tc.interface_names['firebird.Value'] = true
+	tc.interface_names['json2.Value'] = true
+	mut g := FlatGen.new()
+	g.a = ast
+	g.tc = &tc
+
+	value_type := types.Type(types.Interface{
+		name: 'Value'
+	})
+	assert g.optional_payload_c_type(value_type) == 'Value'
+	assert g.ambiguous_qualified_interface_c_type('Value')
+}
+
 fn test_declaration_signature_scan_ignores_unscoped_regular_fn_nodes() {
 	mut ast := flat.FlatAst.new()
 	ast.add_node(flat.Node{

--- a/vlib/v3/gen/c/types_test.v
+++ b/vlib/v3/gen/c/types_test.v
@@ -72,6 +72,25 @@ fn test_optional_payload_qualifies_interface() {
 	assert g.concrete_optional_type_name(result_type) == 'Optional_firebird__Value'
 }
 
+fn test_optional_payload_keeps_concrete_c_type_with_interface_collision() {
+	mut ast := &flat.FlatAst{}
+	mut tc := types.TypeChecker.new(ast)
+	tc.interface_names['pkg.Value'] = true
+	mut g := FlatGen.new()
+	g.a = ast
+	g.tc = &tc
+
+	value_type := types.Type(types.Struct{
+		name: 'C.Value'
+	})
+	assert g.value_c_type(value_type) == 'Value'
+	assert g.optional_payload_c_type(value_type) == 'Value'
+	result_type := types.Type(types.ResultType{
+		base_type: value_type
+	})
+	assert g.concrete_optional_type_name(result_type) == 'Optional_Value'
+}
+
 fn test_optional_payload_does_not_qualify_ambiguous_interface() {
 	mut ast := &flat.FlatAst{}
 	mut tc := types.TypeChecker.new(ast)

--- a/vlib/v3/tests/local_ierror_interface_codegen_test.v
+++ b/vlib/v3/tests/local_ierror_interface_codegen_test.v
@@ -60,11 +60,31 @@ pub fn show_ref(err &IError) string {
 	src := os.join_path(root, 'main.v')
 	os.write_file(src, 'import pkg
 
+struct BuiltinErr {
+	text string
+}
+
+fn (err BuiltinErr) msg() string {
+	return err.text
+}
+
+fn (err BuiltinErr) code() int {
+	return 7
+}
+
+fn payload() !IError {
+	return BuiltinErr{
+		text: "builtin"
+	}
+}
+
 fn main() {
 	err := pkg.make()
 	println(pkg.show(err))
 	ref := pkg.make_ref()
 	println(pkg.show_ref(ref))
+	builtin := payload() or { panic(err) }
+	println(builtin.msg())
 }
 	') or {
 		panic(err)
@@ -84,8 +104,9 @@ fn main() {
 	assert !c_code.contains('string pkg__show(IError err)'), c_code
 	assert !c_code.contains('\nIError* pkg__make_ref'), c_code
 	assert !c_code.contains('string pkg__show_ref(IError* err)'), c_code
+	assert c_code.contains('typedef struct Optional_IError {'), c_code
 
 	run := os.execute(bin)
 	assert run.exit_code == 0, run.output
-	assert run.output.trim_space() == 'local\nlocal-ref'
+	assert run.output.trim_space() == 'local\nlocal-ref\nbuiltin'
 }

--- a/vlib/v3/tests/pointer_map_lvalue_codegen_test.v
+++ b/vlib/v3/tests/pointer_map_lvalue_codegen_test.v
@@ -33,6 +33,11 @@ struct Item {
 	Inner
 }
 
+struct NestedItem {
+mut:
+	inner Inner
+}
+
 fn update(m_ref &map[string][]int, ch chan []int) int {
 	mut x := 0
 	unsafe {
@@ -55,6 +60,9 @@ fn main() {
 	mut items := map[string]Item{}
 	items['key'].values << 17
 	assert items['key'].values == [17]
+	mut nested := map[string]NestedItem{}
+	nested['key'].inner.values << 23
+	assert nested['key'].inner.values == [23]
 	println('\${values['key'][0] + values['key'][1]}:\${x}')
 }
 ") or {
@@ -70,5 +78,6 @@ fn main() {
 	compact := generated.replace('\t', '').replace(' ', '').replace('\n', '')
 	assert compact.contains('map__get_or_set(m_ref,'), generated
 	assert compact.contains('.Inner.values'), generated
+	assert compact.contains('map__get_or_set(&nested,'), generated
 	assert !compact.contains('(m_ref)[_str_'), generated
 }

--- a/vlib/v3/tests/pointer_map_lvalue_codegen_test.v
+++ b/vlib/v3/tests/pointer_map_lvalue_codegen_test.v
@@ -24,6 +24,15 @@ fn test_pointer_map_index_is_preserved_in_multi_return_lvalue() {
 	return [7], 9
 }
 
+struct Inner {
+mut:
+	values []int
+}
+
+struct Item {
+	Inner
+}
+
 fn update(m_ref &map[string][]int, ch chan []int) int {
 	mut x := 0
 	unsafe {
@@ -43,6 +52,9 @@ fn main() {
 	ch := chan []int{cap: 1}
 	ch <- [13]
 	x := update(&values, ch)
+	mut items := map[string]Item{}
+	items['key'].values << 17
+	assert items['key'].values == [17]
 	println('\${values['key'][0] + values['key'][1]}:\${x}')
 }
 ") or {
@@ -57,5 +69,6 @@ fn main() {
 	generated := os.read_file(bin + '.c') or { panic(err) }
 	compact := generated.replace('\t', '').replace(' ', '').replace('\n', '')
 	assert compact.contains('map__get_or_set(m_ref,'), generated
+	assert compact.contains('.Inner.values'), generated
 	assert !compact.contains('(m_ref)[_str_'), generated
 }

--- a/vlib/v3/tests/review_transform_regressions_test.v
+++ b/vlib/v3/tests/review_transform_regressions_test.v
@@ -281,6 +281,34 @@ fn main() {
 	assert out == '7\n9'
 }
 
+fn test_interface_pointer_receiver_dispatch_preserves_pointer_depth() {
+	v3_bin := build_v3_review_transform()
+	out := run_good(v3_bin, 'interface_pointer_receiver_dispatch', 'interface Reader {
+	read() int
+}
+
+struct Value {
+	n int
+}
+
+fn (value Value) read() int {
+	return value.n
+}
+
+fn use(reader &Reader) int {
+	return reader.read()
+}
+
+fn main() {
+	reader := Reader(Value{
+		n: 42
+	})
+	println(use(&reader))
+}
+')
+	assert out == '42'
+}
+
 fn test_issue_28180_module_collisions_and_embedded_generic_middleware() {
 	v3_bin := build_v3_review_transform()
 	// The reported regression is a compiler failure; keep unrelated runtime

--- a/vlib/v3/tests/review_transform_regressions_test.v
+++ b/vlib/v3/tests/review_transform_regressions_test.v
@@ -170,6 +170,175 @@ fn main() {
 	assert out == 'true'
 }
 
+fn test_array_append_to_map_value_struct_field_uses_mutable_map_entry() {
+	v3_bin := build_v3_review_transform()
+	out := run_good(v3_bin, 'array_append_to_map_value_struct_field', 'struct Item {
+mut:
+	values []int
+}
+
+fn append_value(mut items map[string]Item, key string, value int) {
+	items[key].values << value
+}
+
+fn main() {
+	mut items := {
+		"first": Item{}
+	}
+	append_value(mut items, "first", 7)
+	println(items["first"].values)
+}
+')
+	assert out == '[7]'
+}
+
+fn test_or_block_match_with_break_has_no_value_assignment() {
+	v3_bin := build_v3_review_transform()
+	out := run_good(v3_bin, 'or_block_match_break', 'struct NoIdle {}
+
+fn (_ NoIdle) msg() string {
+	return "no idle value"
+}
+
+fn (_ NoIdle) code() int {
+	return 0
+}
+
+fn pop_idle() !int {
+	return NoIdle{}
+}
+
+fn get() !int {
+	for {
+		value := pop_idle() or {
+			match err {
+				NoIdle {
+					break
+				}
+				else {
+					return err
+				}
+			}
+		}
+		return value
+	}
+	return 7
+}
+
+fn main() {
+	println(get() or { panic(err) })
+}
+')
+	assert out == '7'
+}
+
+fn test_result_payload_converts_to_interface_and_sum_type() {
+	v3_bin := build_v3_review_transform()
+	out := run_good(v3_bin, 'result_interface_and_sum_payload', 'interface Number {
+	number() int
+}
+
+struct Item {
+	value int
+}
+
+fn (item Item) number() int {
+	return item.value
+}
+
+struct ArrayValue {
+	value int
+}
+
+type Value = ArrayValue | string
+
+fn load_item() !Item {
+	return Item{7}
+}
+
+fn load_number() !Number {
+	return load_item()!
+}
+
+fn load_array() !ArrayValue {
+	return ArrayValue{9}
+}
+
+fn load_value() !Value {
+	return load_array()!
+}
+
+fn main() {
+	number := load_number() or { panic(err) }
+	value := load_value() or { panic(err) }
+	println(number.number())
+	match value {
+		ArrayValue { println(value.value) }
+		else {}
+	}
+}
+')
+	assert out == '7\n9'
+}
+
+fn test_issue_28180_module_collisions_and_embedded_generic_middleware() {
+	v3_bin := build_v3_review_transform()
+	// The reported regression is a compiler failure; keep unrelated runtime
+	// deinitialization outside this coverage.
+	_ = compile_good_project(v3_bin, 'issue_28180_module_collisions', '-nocache', {
+		'v.mod':     'Module {
+	name: "issue_28180"
+}
+'
+		'main.v':    'module main
+
+import app
+
+fn main() {
+	_ = app.new()
+	println("ok")
+}
+'
+		'app/app.v': 'module app
+
+import context
+import veb
+
+pub struct Context {
+	veb.Context
+}
+
+@[heap]
+pub struct App {
+	veb.Middleware[Context]
+}
+
+struct Params {
+	name ?string
+}
+
+fn (mut app App) middleware(mut ctx Context) bool {
+	return true
+}
+
+pub fn new() &App {
+	mut base_ctx := context.background()
+	_ = base_ctx.done()
+	params := Params{
+		name: "item"
+	}
+	if name := params.name {
+		assert name == "item"
+	}
+	mut app := &App{}
+	app.use(handler: app.middleware)
+	app.route_use("/admin", handler: app.middleware, after: true)
+	return app
+}
+'
+	}, '')
+}
+
 fn test_return_match_map_lookup_guard_keeps_presence_check() {
 	v3_bin := build_v3_review_transform()
 	out := run_good_with_flags(v3_bin, 'return_match_map_lookup_guard', '-building-v', 'struct Local {
@@ -409,6 +578,13 @@ fn run_good_project(v3_bin string, name string, files map[string]string, input s
 }
 
 fn run_good_project_with_flags(v3_bin string, name string, flags string, files map[string]string, input string) string {
+	good_bin := compile_good_project(v3_bin, name, flags, files, input)
+	run := os.execute(good_bin)
+	assert run.exit_code == 0, '${name}: run failed\n${run.output}'
+	return run.output.trim_space()
+}
+
+fn compile_good_project(v3_bin string, name string, flags string, files map[string]string, input string) string {
 	root := os.join_path(os.temp_dir(), 'v3_${name}_project')
 	if os.exists(root) {
 		os.rmdir_all(root) or { panic(err) }
@@ -422,9 +598,7 @@ fn run_good_project_with_flags(v3_bin string, name string, flags string, files m
 	compile := os.execute('${v3_bin} ${flags} ${input_path} -b c -o ${good_bin}')
 	assert compile.exit_code == 0, '${name}: compile failed\n${compile.output}'
 	assert !compile.output.contains('C compilation failed'), '${name}: C compilation failed\n${compile.output}'
-	run := os.execute(good_bin)
-	assert run.exit_code == 0, '${name}: run failed\n${run.output}'
-	return run.output.trim_space()
+	return good_bin
 }
 
 fn gen_c_from_project(v3_bin string, name string, files map[string]string, input string) string {

--- a/vlib/v3/tests/review_transform_regressions_test.v
+++ b/vlib/v3/tests/review_transform_regressions_test.v
@@ -309,6 +309,97 @@ fn main() {
 	assert out == '42'
 }
 
+fn test_interface_field_receiver_preserves_smartcast_projection() {
+	v3_bin := build_v3_review_transform()
+	out := run_good(v3_bin, 'interface_field_receiver_smartcast', 'interface Reader {
+	read() int
+}
+
+struct Source {
+	n int
+}
+
+fn (source Source) read() int {
+	return source.n
+}
+
+struct Holder {
+	reader Reader
+}
+
+type Value = Holder | string
+
+fn read_value(value Value) int {
+	return match value {
+		Holder { value.reader.read() }
+		else { -1 }
+	}
+}
+
+fn main() {
+	value := Value(Holder{
+		reader: Reader(Source{
+			n: 37
+		})
+	})
+	println(read_value(value))
+}
+')
+	assert out == '37'
+}
+
+fn test_result_c_payload_does_not_use_colliding_interface() {
+	v3_bin := build_v3_review_transform()
+	out := run_good_project(v3_bin, 'result_c_payload_interface_collision', {
+		'v.mod':     "Module { name: 'result_c_payload_interface_collision' }\n"
+		'native.h':  'typedef struct { int value; } Value;\n'
+		'pkg/pkg.v': 'module pkg
+
+pub interface Value {
+	number() int
+}
+
+pub fn read(value Value) int {
+	return value.number()
+}
+'
+		'main.v':    'module main
+
+#insert "native.h"
+
+import pkg
+
+@[typedef]
+struct C.Value {
+	value int
+}
+
+struct Box {
+	n int
+}
+
+fn (box Box) number() int {
+	return box.n
+}
+
+fn load() !C.Value {
+	return C.Value{
+		value: 41
+	}
+}
+
+fn main() {
+	native := load() or { panic(err) }
+	println(native.value)
+	println(pkg.read(Box{
+		n: 43
+	}))
+}
+'
+	}, 'main.v')
+	assert out == '41\n43'
+}
+
 fn test_issue_28180_module_collisions_and_embedded_generic_middleware() {
 	v3_bin := build_v3_review_transform()
 	// The reported regression is a compiler failure; keep unrelated runtime

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -226,12 +226,12 @@ fn (t &Transformer) resolve_receiver_method_name(base_id flat.NodeId, method str
 		raw_var_clean = raw_clean
 		if raw_clean.len > 0 && raw_clean != base_type {
 			if alias_method := t.resolve_alias_receiver_method(raw_clean, method) {
-				if t.receiver_method_matches_base_type(alias_method, base_id) {
+				if t.receiver_method_matches_type_name(alias_method, raw_clean) {
 					return alias_method
 				}
 			}
 			if method_name := t.resolve_receiver_method_for_type(raw_clean, method) {
-				if t.receiver_method_matches_base_type(method_name, base_id) {
+				if t.receiver_method_matches_type_name(method_name, raw_clean) {
 					return method_name
 				}
 			}
@@ -1068,7 +1068,11 @@ fn (mut t Transformer) transform_call_args(id flat.NodeId, node flat.Node) flat.
 			param_type_names = t.call_param_type_names(params)
 		}
 	}
-	param_offset := t.call_param_offset_for_node(call_name, node, params)
+	param_offset := if t.call_is_selector_form(node) && t.concrete_generic_call_is_method(id) {
+		1
+	} else {
+		t.call_param_offset_for_node(call_name, node, params)
+	}
 	explicit_args := int(node.children_count) - 1
 	expected_explicit := params.len - param_offset
 	variadic_arg_pos := 1 + params.len - 1 - param_offset
@@ -11454,10 +11458,13 @@ fn (mut t Transformer) try_lower_receiver_method_call(id flat.NodeId, node flat.
 	smartcast_method := t.resolve_smartcast_sum_receiver_method(base_id, method) or { '' }
 	if !isnil(t.tc) && smartcast_method.len == 0 {
 		if resolved_method := t.tc.resolved_call_name(id) {
-			if t.receiver_method_name_is_open_generic(resolved_method) {
+			direct_method := t.resolve_receiver_method_name(base_id, method)
+			if direct_method.len > 0 && direct_method != resolved_method {
+				// The declared receiver type is newer than a checker call entry captured
+				// through a colliding short name. Resolve it through the normal path below.
+			} else if t.receiver_method_name_is_open_generic(resolved_method) {
 				return none
-			}
-			if t.is_known_fn_name(resolved_method) {
+			} else if t.is_known_fn_name(resolved_method) {
 				params := t.call_param_types(resolved_method)
 				if t.resolved_call_uses_receiver_type(base_id, base_type, params) {
 					if !t.validate_resolved_receiver_method_args(node, base_id, resolved_method) {
@@ -12294,6 +12301,19 @@ fn (t &Transformer) resolved_call_uses_receiver_type(base_id flat.NodeId, receiv
 	mut base_type := receiver_type
 	if base_type.starts_with('&') {
 		base_type = base_type[1..]
+	}
+	if raw_type := t.raw_var_type_for_expr(base_id) {
+		raw_base_type := t.trim_pointer_type(raw_type)
+		if raw_base_type.len > 0 && !t.generic_arg_is_unresolved(raw_base_type)
+			&& t.normalize_type_alias(raw_base_type) != t.normalize_type_alias(base_type) {
+			if t.normalize_type_alias(raw_base_type) == t.normalize_type_alias(param_type) {
+				return true
+			}
+			if _ := t.embedded_receiver_path(raw_base_type, param_type) {
+				return true
+			}
+			return false
+		}
 	}
 	if base_type.len == 0 {
 		return true

--- a/vlib/v3/transform/if.v
+++ b/vlib/v3/transform/if.v
@@ -60,7 +60,13 @@ fn (mut t Transformer) try_expand_if_guard(_id flat.NodeId, node flat.Node) ?[]f
 		rhs_expr = t.transform_expr(rhs_id)
 	}
 	if !t.is_optional_type_name(t.node_type(rhs_expr)) {
-		t.set_node_typ(int(rhs_expr), rhs_type)
+		rhs_node := t.a.nodes[int(rhs_expr)]
+		if rhs_node.kind == .selector && rhs_node.children_count > 0 {
+			rhs_expr = t.make_selector_op(t.a.child(&rhs_node, 0), rhs_node.value, rhs_type,
+				rhs_node.op)
+		} else {
+			t.set_node_typ(int(rhs_expr), rhs_type)
+		}
 	}
 	mut prelude := []flat.NodeId{}
 	t.drain_pending(mut prelude)

--- a/vlib/v3/transform/interface.v
+++ b/vlib/v3/transform/interface.v
@@ -140,6 +140,14 @@ fn (t &Transformer) resolve_interface_type_name(name string) string {
 }
 
 fn (t &Transformer) resolve_interface_type_name_uncached(name string) string {
+	raw_clean := t.trim_pointer_type(name)
+	raw_base, _, raw_is_generic := generic_app_parts(raw_clean)
+	if raw_is_generic && raw_base in t.tc.interface_names {
+		return raw_base
+	}
+	if raw_clean in t.tc.interface_names {
+		return raw_clean
+	}
 	mut clean := t.trim_pointer_type(t.normalize_type_alias(name))
 	base, _, is_generic := generic_app_parts(clean)
 	if is_generic {
@@ -926,10 +934,17 @@ fn (mut t Transformer) transform_interface_cast(id flat.NodeId, node flat.Node) 
 // transform_interface_method_call transforms the arguments of a vtable-dispatched
 // interface call using the abstract method's signature.
 fn (mut t Transformer) transform_interface_method_call(id flat.NodeId, node flat.Node) flat.NodeId {
+	mut interface_name := ''
+	mut interface_base := flat.empty_node
 	if node.children_count > 0 {
 		callee := t.a.child_node(&node, 0)
 		if callee.kind == .selector && callee.children_count > 0 {
 			base_id := t.a.child(callee, 0)
+			interface_base = base_id
+			interface_name = t.resolve_interface_type_name(t.original_expr_type(base_id))
+			if interface_name.len == 0 {
+				interface_name = t.resolve_interface_type_name(t.node_type(base_id))
+			}
 			if _ := t.raw_const_type_name_for_expr(base_id) {
 				// A module-qualified interface constant (`net.err_foo.code()`) is
 				// syntactically a selector chain. Lower it to the interface wrapper
@@ -945,5 +960,48 @@ fn (mut t Transformer) transform_interface_method_call(id flat.NodeId, node flat
 			}
 		}
 	}
-	return t.transform_call_args(id, node)
+	transformed_id := t.transform_call_args(id, node)
+	if interface_name.len == 0 {
+		return transformed_id
+	}
+	transformed := t.a.nodes[int(transformed_id)]
+	if transformed.kind != .call || transformed.children_count == 0 {
+		return transformed_id
+	}
+	callee := t.a.child_node(&transformed, 0)
+	if callee.kind != .selector || callee.children_count == 0 {
+		return transformed_id
+	}
+	base := t.a.child(callee, 0)
+	base_node := t.a.nodes[int(base)]
+	original_base := if interface_base != flat.empty_node {
+		t.a.nodes[int(interface_base)]
+	} else {
+		base_node
+	}
+	typed_receiver := if original_base.kind == .selector && original_base.children_count > 0
+		&& t.a.child_node(&original_base, 0).kind == .ident {
+		original_ident := t.a.child_node(&original_base, 0)
+		ident := t.make_ident(original_ident.value)
+		if original_ident.typ.len > 0 {
+			t.set_node_typ(int(ident), original_ident.typ)
+		}
+		t.make_selector_op(ident, original_base.value, interface_name, original_base.op)
+	} else if original_base.kind == .ident {
+		ident := t.make_ident(original_base.value)
+		t.set_node_typ(int(ident), interface_name)
+		ident
+	} else if base_node.kind == .selector && base_node.children_count > 0 {
+		t.make_selector_op(t.a.child(&base_node, 0), base_node.value, interface_name, base_node.op)
+	} else {
+		base
+	}
+	typed_base := t.make_paren(typed_receiver)
+	t.set_node_typ(int(typed_base), interface_name)
+	typed_callee := t.make_selector(typed_base, callee.value, callee.typ)
+	mut args := []flat.NodeId{cap: int(transformed.children_count) - 1}
+	for i in 1 .. transformed.children_count {
+		args << t.a.child(&transformed, i)
+	}
+	return t.make_call_expr_typed(typed_callee, args, transformed.typ)
 }

--- a/vlib/v3/transform/interface.v
+++ b/vlib/v3/transform/interface.v
@@ -991,7 +991,9 @@ fn (mut t Transformer) transform_interface_method_call(id flat.NodeId, node flat
 	} else {
 		base_node
 	}
-	typed_receiver := if original_base.kind == .selector && original_base.children_count > 0
+	typed_receiver := if t.interface_receiver_has_variant_projection(base) {
+		t.retype_interface_receiver(base, interface_receiver_type)
+	} else if original_base.kind == .selector && original_base.children_count > 0
 		&& t.a.child_node(&original_base, 0).kind == .ident {
 		original_ident := t.a.child_node(&original_base, 0)
 		ident := t.make_ident(original_ident.value)
@@ -1017,4 +1019,29 @@ fn (mut t Transformer) transform_interface_method_call(id flat.NodeId, node flat
 		args << t.a.child(&transformed, i)
 	}
 	return t.make_call_expr_typed(typed_callee, args, transformed.typ)
+}
+
+fn (t &Transformer) interface_receiver_has_variant_projection(id flat.NodeId) bool {
+	if int(id) < 0 || int(id) >= t.a.nodes.len {
+		return false
+	}
+	if _ := t.generated_variant_access_type(id) {
+		return true
+	}
+	node := t.a.nodes[int(id)]
+	if node.kind in [.selector, .prefix, .paren] && node.children_count > 0 {
+		return t.interface_receiver_has_variant_projection(t.a.child(&node, 0))
+	}
+	return false
+}
+
+fn (mut t Transformer) retype_interface_receiver(id flat.NodeId, typ string) flat.NodeId {
+	node := t.a.nodes[int(id)]
+	mut children := []flat.NodeId{cap: int(node.children_count)}
+	for i in 0 .. node.children_count {
+		children << t.a.child(&node, i)
+	}
+	retyped := t.copy_node_with_children(node, children)
+	t.set_node_typ(int(retyped), typ)
+	return retyped
 }

--- a/vlib/v3/transform/interface.v
+++ b/vlib/v3/transform/interface.v
@@ -186,6 +186,11 @@ fn (t &Transformer) resolve_interface_type_name_uncached(name string) string {
 	return ''
 }
 
+fn interface_type_with_pointer_depth(source_type string, interface_name string) string {
+	depth, _ := pointer_type_depth_and_base(source_type)
+	return '&'.repeat(depth) + interface_name
+}
+
 // transform_interface_value_for_type supports transform_interface_value_for_type handling.
 // `share_source` makes the boxed `_object` point at the source lvalue instead of a
 // heap copy; it is only safe when the source is guaranteed to outlive the box
@@ -935,15 +940,22 @@ fn (mut t Transformer) transform_interface_cast(id flat.NodeId, node flat.Node) 
 // interface call using the abstract method's signature.
 fn (mut t Transformer) transform_interface_method_call(id flat.NodeId, node flat.Node) flat.NodeId {
 	mut interface_name := ''
+	mut interface_receiver_type := ''
 	mut interface_base := flat.empty_node
 	if node.children_count > 0 {
 		callee := t.a.child_node(&node, 0)
 		if callee.kind == .selector && callee.children_count > 0 {
 			base_id := t.a.child(callee, 0)
 			interface_base = base_id
-			interface_name = t.resolve_interface_type_name(t.original_expr_type(base_id))
+			mut receiver_source_type := t.original_expr_type(base_id)
+			interface_name = t.resolve_interface_type_name(receiver_source_type)
 			if interface_name.len == 0 {
-				interface_name = t.resolve_interface_type_name(t.node_type(base_id))
+				receiver_source_type = t.node_type(base_id)
+				interface_name = t.resolve_interface_type_name(receiver_source_type)
+			}
+			if interface_name.len > 0 {
+				interface_receiver_type = interface_type_with_pointer_depth(receiver_source_type,
+					interface_name)
 			}
 			if _ := t.raw_const_type_name_for_expr(base_id) {
 				// A module-qualified interface constant (`net.err_foo.code()`) is
@@ -986,18 +998,19 @@ fn (mut t Transformer) transform_interface_method_call(id flat.NodeId, node flat
 		if original_ident.typ.len > 0 {
 			t.set_node_typ(int(ident), original_ident.typ)
 		}
-		t.make_selector_op(ident, original_base.value, interface_name, original_base.op)
+		t.make_selector_op(ident, original_base.value, interface_receiver_type, original_base.op)
 	} else if original_base.kind == .ident {
 		ident := t.make_ident(original_base.value)
-		t.set_node_typ(int(ident), interface_name)
+		t.set_node_typ(int(ident), interface_receiver_type)
 		ident
 	} else if base_node.kind == .selector && base_node.children_count > 0 {
-		t.make_selector_op(t.a.child(&base_node, 0), base_node.value, interface_name, base_node.op)
+		t.make_selector_op(t.a.child(&base_node, 0), base_node.value, interface_receiver_type,
+			base_node.op)
 	} else {
 		base
 	}
 	typed_base := t.make_paren(typed_receiver)
-	t.set_node_typ(int(typed_base), interface_name)
+	t.set_node_typ(int(typed_base), interface_receiver_type)
 	typed_callee := t.make_selector(typed_base, callee.value, callee.typ)
 	mut args := []flat.NodeId{cap: int(transformed.children_count) - 1}
 	for i in 1 .. transformed.children_count {

--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -4888,6 +4888,12 @@ fn (mut t Transformer) concrete_generic_call_is_variadic(id flat.NodeId, node fl
 	return generic_param_text_is_variadic(last_param)
 }
 
+fn (mut t Transformer) concrete_generic_call_is_method(id flat.NodeId) bool {
+	spec := t.generic_call_spec_cache[int(id)] or { return false }
+	decl := t.cached_generic_fn_decls()[spec.decl_key] or { return false }
+	return t.generic_decl_is_receiver_method(decl.node)
+}
+
 fn (mut t Transformer) cached_generic_fn_decls() map[string]GenericFnDecl {
 	if t.skip_generics {
 		if !t.generic_fn_decls_ready {
@@ -6481,7 +6487,14 @@ fn (mut t Transformer) generic_call_decl_key(id flat.NodeId, node flat.Node, mod
 		}
 		for key in method_keys {
 			if decl := decls[key] {
-				if !t.generic_receiver_decl_matches_type(base_type, decl, module_name) {
+				mut receiver_matches := t.generic_receiver_decl_matches_type(base_type, decl,
+					module_name)
+				if !receiver_matches {
+					mut seen := map[string]bool{}
+					receiver_matches = t.generic_decl_matches_embedded_receiver(base_type, decl,
+						module_name, mut seen)
+				}
+				if !receiver_matches {
 					continue
 				}
 				if !t.generic_call_arg_count_matches_decl(node, decl) {
@@ -7768,9 +7781,12 @@ fn (t &Transformer) generic_arg_for_decl_module(arg string, module_name string) 
 
 fn (t &Transformer) inherited_generic_arg_for_decl_module(arg string, module_name string, outer_args []string) string {
 	clean := arg.trim_space()
+	normalized := t.normalize_type_in_module(clean, module_name)
 	for outer_arg in outer_args {
-		if outer_arg.trim_space() == clean {
-			return arg
+		outer_clean := outer_arg.trim_space()
+		if outer_clean == clean
+			|| t.normalize_type_in_module(outer_clean, module_name) == normalized {
+			return outer_arg
 		}
 	}
 	return t.generic_arg_for_decl_module(arg, module_name)

--- a/vlib/v3/transform/monomorphize_test.v
+++ b/vlib/v3/transform/monomorphize_test.v
@@ -13,6 +13,27 @@ fn test_generic_unresolved_type_detects_multi_return_placeholders() {
 	assert !t.generic_arg_is_unresolved('(f64, f64)')
 }
 
+fn test_zero_value_normalizes_generic_alias_but_preserves_generic_struct() {
+	mut a := flat.FlatAst.new()
+	mut tc := types.TypeChecker.new(&a)
+	tc.type_aliases['Values'] = '[]T'
+	tc.type_alias_generic_params['Values'] = ['T']
+	tc.structs['Box'] = []types.StructField{}
+	mut t := new_transformer(mut a, &tc, map[string]bool{})
+
+	alias_zero_id := t.zero_value_for_type('Values[int]')
+	alias_zero := t.a.nodes[int(alias_zero_id)]
+	assert alias_zero.kind == .array_init
+	assert alias_zero.value == 'int'
+	assert alias_zero.typ == '[]int'
+
+	struct_zero_id := t.zero_value_for_type('Box[int]')
+	struct_zero := t.a.nodes[int(struct_zero_id)]
+	assert struct_zero.kind == .struct_init
+	assert struct_zero.value == 'Box[int]'
+	assert struct_zero.typ == 'Box[int]'
+}
+
 fn test_explicit_generic_fn_value_candidates_resolve_selective_import() {
 	mut a := flat.FlatAst.new()
 	base_id := a.add_node(flat.Node{

--- a/vlib/v3/transform/or.v
+++ b/vlib/v3/transform/or.v
@@ -949,6 +949,11 @@ fn (mut t Transformer) or_expr_types(expr_id flat.NodeId, fallback_type string) 
 			if thread_ret := t.thread_wait_or_expr_type(expr_node) {
 				return t.canonical_or_expr_types(thread_ret)
 			}
+			if t.is_optional_type_name(expr_node.typ)
+				&& t.generic_type_text_contains_alias(expr_node.typ, t.cur_module)
+				&& !t.generic_arg_is_unresolved(expr_node.typ) {
+				return specialized_or_expr_types(expr_node.typ)
+			}
 			if expr_node.children_count > 0 {
 				callee := t.a.child_node(&expr_node, 0)
 				if callee.kind == .ident && t.generic_callee_is_specialization(callee.value)
@@ -1362,7 +1367,10 @@ fn (mut t Transformer) zero_value_for_type(typ string) flat.NodeId {
 	if clean.len > 1 && (clean[0] == `?` || clean[0] == `!`) {
 		return t.make_optional_none(clean)
 	}
-	clean = t.normalize_type_alias(clean)
+	_, _, is_generic_app := generic_app_parts(clean)
+	if !is_generic_app {
+		clean = t.normalize_type_alias(clean)
+	}
 	if clean.starts_with('fn(') || clean.starts_with('fn (') || clean.starts_with('fn_ptr:') {
 		return t.make_cast(clean, t.make_int_literal(0), clean)
 	}
@@ -1520,10 +1528,26 @@ fn (mut t Transformer) lower_or_expr_to_temp(id flat.NodeId, node flat.Node) fla
 	}
 
 	prelude << t.make_decl_assign_typed(opt_tmp, new_expr, expr_type)
-	storage_value_type := if t.is_fixed_array_type(value_type) {
+	storage_value_type0 := if t.is_fixed_array_type(value_type) {
 		t.resolved_fixed_array_canonical_type(value_type)
 	} else {
 		t.shared_alias_storage_type(value_type)
+	}
+	mut storage_value_type := storage_value_type0
+	storage_normalized := t.normalize_type_in_module(storage_value_type0, t.cur_module)
+	if t.is_optional_type_name(t.cur_fn_ret_type) {
+		return_value_type := t.optional_base_type(t.qualify_optional_type(t.cur_fn_ret_type))
+		if return_value_type != storage_value_type0
+			&& t.normalize_type_in_module(return_value_type, t.cur_module) == storage_normalized {
+			storage_value_type = return_value_type
+		}
+	}
+	for active_arg in t.active_specialization_args {
+		if active_arg != storage_value_type0
+			&& t.normalize_type_in_module(active_arg, t.cur_module) == storage_normalized {
+			storage_value_type = active_arg
+			break
+		}
 	}
 	prelude << t.make_stack_value_decl_assign_typed(val_tmp,
 		t.zero_value_for_type(storage_value_type), storage_value_type)

--- a/vlib/v3/transform/or.v
+++ b/vlib/v3/transform/or.v
@@ -1368,7 +1368,9 @@ fn (mut t Transformer) zero_value_for_type(typ string) flat.NodeId {
 		return t.make_optional_none(clean)
 	}
 	_, _, is_generic_app := generic_app_parts(clean)
-	if !is_generic_app {
+	if expanded := t.expand_generic_type_alias(clean) {
+		clean = t.normalize_type_alias(expanded)
+	} else if !is_generic_app {
 		clean = t.normalize_type_alias(clean)
 	}
 	if clean.starts_with('fn(') || clean.starts_with('fn (') || clean.starts_with('fn_ptr:') {

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -10326,12 +10326,6 @@ fn (mut t Transformer) transform_return_child(child_id flat.NodeId, child_index 
 	if copied := t.heap_copy_local_address_return(child_id) {
 		return copied
 	}
-	if int(child_id) >= 0 && int(child_id) < t.a.nodes.len {
-		child := t.a.nodes[int(child_id)]
-		if child.kind == .or_expr {
-			return t.transform_expr(child_id)
-		}
-	}
 	target_type := t.return_child_target_type(child_index, total_children)
 	mut return_child_id := child_id
 	if rewritten := t.rewrite_escaping_interface_box_return_expr(child_id) {
@@ -10348,15 +10342,18 @@ fn (mut t Transformer) transform_return_child(child_id flat.NodeId, child_index 
 		if child.kind in [.lambda_expr, .fn_literal] {
 			return t.transform_expr_for_type(return_child_id, target_type)
 		}
+		payload_type := t.optional_base_type(t.qualify_optional_type(target_type))
+		resolved_payload_type := t.resolve_sum_name(payload_type)
 		if child.kind == .or_expr {
+			if resolved_payload_type in t.sum_types {
+				return t.wrap_sum_value(t.transform_expr(return_child_id), resolved_payload_type)
+			}
 			return t.transform_expr_for_type(return_child_id, target_type)
 		}
 		if child.kind in [.if_expr, .match_stmt]
 			&& t.return_expr_is_optional_result(return_child_id) {
 			return t.transform_expr_for_type(return_child_id, target_type)
 		}
-		payload_type := t.optional_base_type(t.qualify_optional_type(target_type))
-		resolved_payload_type := t.resolve_sum_name(payload_type)
 		if resolved_payload_type in t.sum_types {
 			return t.wrap_sum_value(return_child_id, resolved_payload_type)
 		}
@@ -12870,7 +12867,8 @@ fn (mut t Transformer) transform_match_expr_for_type(_id flat.NodeId, node flat.
 		return none
 	}
 	mut actual_result_type := t.match_expr_type(node)
-	if actual_result_type.len == 0 || actual_result_type == 'void' {
+	if actual_result_type.len == 0 || actual_result_type == 'void'
+		|| t.generic_arg_is_unresolved(actual_result_type) {
 		actual_result_type = target_type
 	}
 	if t.is_fn_pointer_type_name(target_type) {


### PR DESCRIPTION
## Summary

- preserve qualified interface, optional/result, sum, and generic alias types through V3 transformation and C generation
- generate mutable map-entry lvalues and terminating `or`-block control flow correctly
- resolve embedded generic middleware methods and colliding module receiver/interface names, with focused regression coverage

## Tests

- `./vnew -silent vlib/v/compiler_errors_test.v` (1619 passed, 1 skipped)
- `./vnew -nocache -silent vlib/v3/gen/c/types_test.v`
- focused V3 compile/run regressions for map-field append, terminating `or` match, result-to-interface/sum conversion, and veb module collisions
- forced V3 compile of Peony `c68dfb57f9d4eb6ff0b2aae71ec91037fd524410` with `V_MACOS_V3_NO_FALLBACK=1`

Broad `vlib/v/` and `vlib/v3/` runs were attempted but hit existing macOS V3 `rand.PRNG.free` deinit panics unrelated to this change.

Fixes #28180