### PR TITLE
toml: fix -ownership build failure in parser next()

### DIFF
--- a/vlib/toml/parser/parser.v
+++ b/vlib/toml/parser/parser.v
@@ -149,12 +149,15 @@ fn (mut p Parser) next() ! {
 	p.prev_tok = p.tok
 	p.tok = p.peek_tok
 	if p.tokens.len > 0 {
-		p.peek_tok = p.tokens.first()
+		// Take the front token out and drop the emptied slot. Indexing (instead of
+		// `first()`) moves the element in `-ownership` mode, so `token.Token` needs no
+		// clone; in the default backend it is an ordinary copy followed by a delete.
+		p.peek_tok = p.tokens[0]
 		p.tokens.delete(0)
 		p.peek(1)!
 	} else {
 		p.peek(1)!
-		p.peek_tok = p.tokens.first()
+		p.peek_tok = p.tokens[0]
 		p.tokens.delete(0)
 	}
 }


### PR DESCRIPTION
### What

Fixes the C compilation failure reported in #28193 when building a project that imports `toml` with `-ownership`:

```
error: assigning to 'token__Token' (aka 'struct token__Token') from incompatible type 'int'
 14387 |   p->peek_tok = 0;
```

### Why it happens

`toml.parser.Parser.next()` advances the token stream with:

```v
p.peek_tok = p.tokens.first()
p.tokens.delete(0)
```

Under `-ownership`, `token.Token` is a *move-only* struct — it owns its `lit` string and does not implement `IClone` — so `[]token.Token.first()` cannot produce an independent copy of the element. For code in the **top** module the ownership checker rejects this (`cannot return an independent array element: token.Token requires ownership destruction but has no clone() method`), but for an **imported** module (like `toml`) the check does not fire, and cgen falls through to the "invalid program" placeholder, emitting `p->peek_tok = 0;` — an `int` assigned to a struct, which the C compiler rejects.

### The fix

`first()` immediately followed by `delete(0)` is a *pop-front*: read the element, then drop the slot. Indexing `p.tokens[0]` expresses exactly that, and in ownership mode indexing **moves** the element out (no clone required), so `token.Token` no longer needs `IClone`. In the default backend `p.tokens[0]` is an ordinary copy, identical in effect to `first()`, so behaviour is unchanged there.

- `vlib/toml/tests/toml_test.v` (the full toml-lang/toml-test suite) passes.
- `vlib/toml/tests/reflect_test.v` (exercised by the v3 suite) passes.

### Note — a separate, deeper `-ownership` issue remains

This PR only removes the **compile-time** error. While diagnosing it I found that `toml`'s parser still mis-runs under `-ownership` because of a distinct, more fundamental ownership-analysis bug: reading a heap-owning struct field into a local **aliases** the field instead of copying it, so the value dangles once the field is later reassigned/moved. Minimal repro (prints garbage under `-ownership`, correct otherwise):

```v
struct Holder {
mut:
	name string
}

fn build(a string, b string) string {
	mut s := a
	s += b
	return s
}

fn run() string {
	mut h := Holder{ name: build('XX', 'YY') }
	n := h.name          // n aliases h.name instead of copying it
	h.name = build('AA', 'BB') // frees the old 'XXYY' that n still points at
	return n             // -> use-after-free ("reas"/garbage) under -ownership
}

fn main() {
	println(run()) // expected: XXYY
}
```

In `toml` this surfaces via the token rotation in `next()` freeing the strings that the parsed keys/values still reference, so `parse_text('field = "some"')` currently decodes to an empty value under `-ownership`. That is a compiler-side fix (clone/keep-alive on field read) and is out of scope for this build-error fix; happy to file it as a separate issue.

Related: #28193