### PR TITLE
net.http: h2_server.v CONNECT pseudo-header validation (RFC 9113 §8.5)

### DIFF
--- a/vlib/net/http/h2_server.v
+++ b/vlib/net/http/h2_server.v
@@ -88,15 +88,34 @@ fn h2_request_field_error(name string, value string) string {
 
 // h2_validate_request_pseudo enforces the RFC 9113 §8.1.2/§8.3 rules a request
 // header list must satisfy: only the request pseudo-headers, each at most once,
-// all appearing before any regular field, with :method, :path and :scheme
-// present; every regular field must pass h2_request_field_error. A non-ok return
-// means the request is malformed (a stream error at the call site).
+// all appearing before any regular field; every regular field must pass
+// h2_request_field_error. A non-ok return means the request is malformed (a
+// stream error at the call site).
+//
+// Mandatory-pseudo-header shape depends on :method (RFC 9113 §8.5, "The
+// CONNECT Method"): an ORDINARY request needs :method/:path/:scheme, but a
+// CONNECT request "MUST omit" :scheme and :path entirely and instead needs
+// :authority ("contains the host and port to connect to"). "A CONNECT
+// request that does not conform to these restrictions is malformed."
+// Extended CONNECT (RFC 8441's `:protocol`, e.g. WebSockets-over-HTTP/2)
+// is NOT handled here -- a documented v1 scope limit, not an oversight:
+// this function only avoids REJECTING a conforming plain CONNECT's
+// pseudo-header shape, it doesn't implement CONNECT tunneling itself
+// (h2_server.v has no Handler-visible CONNECT semantics yet either).
+// Missed in an earlier version: EVERY request, CONNECT included, was
+// required to carry :path and :scheme, so a conforming CONNECT request
+// was unconditionally classified malformed and answered 400 instead of
+// ever reaching the Handler -- the same bug independently found and fixed
+// in h3_server.v's h3_validate_request_pseudo (Codex review, PR #28164
+// pullrequestreview-5044139767); this file had the identical gap.
 fn h2_validate_request_pseudo(headers []H2HeaderField) ! {
 	mut seen_regular := false
 	mut has_method := false
 	mut has_path := false
 	mut has_scheme := false
 	mut has_authority := false
+	mut method := ''
+	mut authority := ''
 	for f in headers {
 		if f.name.starts_with(':') {
 			if seen_regular {
@@ -114,6 +133,7 @@ fn h2_validate_request_pseudo(headers []H2HeaderField) ! {
 						return error('empty :method pseudo-header')
 					}
 					has_method = true
+					method = f.value
 				}
 				':path' {
 					if has_path {
@@ -139,6 +159,7 @@ fn h2_validate_request_pseudo(headers []H2HeaderField) ! {
 						return error('duplicate :authority pseudo-header')
 					}
 					has_authority = true
+					authority = f.value
 				}
 				else {
 					return error('unknown request pseudo-header "${f.name}"')
@@ -151,6 +172,15 @@ fn h2_validate_request_pseudo(headers []H2HeaderField) ! {
 				return error(reason)
 			}
 		}
+	}
+	if method == 'CONNECT' {
+		if has_scheme || has_path {
+			return error('CONNECT request must omit :scheme and :path (RFC 9113 §8.5)')
+		}
+		if !has_authority || authority == '' {
+			return error('CONNECT request omits mandatory :authority pseudo-header (RFC 9113 §8.5)')
+		}
+		return
 	}
 	if !has_method || !has_path || !has_scheme {
 		return error('request omits a mandatory pseudo-header (:method/:path/:scheme)')

--- a/vlib/net/http/h2_server_pseudo_test.v
+++ b/vlib/net/http/h2_server_pseudo_test.v
@@ -1,0 +1,129 @@
+// Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
+// Use of this source code is governed by an MIT license
+// that can be found in the LICENSE file.
+module http
+
+import net
+
+// h2_validate_request_pseudo's own doc comment covers the full RFC 9113
+// §8.1.2/§8.3/§8.5 shape it enforces; these are pure, fast unit tests for
+// it directly, independent of h2_server_test.v's own connection-level
+// coverage -- in particular the CONNECT-specific branch, which nothing
+// else in this module exercises. Mirrors h3_server_pseudo_test.v's shape
+// exactly (RFC 9114 §4.1.1/§4.4 mirror RFC 9113 §8.1.2.2/§8.5 almost
+// verbatim -- the same precedent h3_validate_request_pseudo's own doc
+// comment already states for the outgoing side).
+fn test_h2_validate_request_pseudo_accepts_an_ordinary_get() {
+	h2_validate_request_pseudo([
+		H2HeaderField{':method', 'GET'},
+		H2HeaderField{':path', '/'},
+		H2HeaderField{':scheme', 'https'},
+		H2HeaderField{':authority', 'example.com'},
+	])!
+}
+
+fn test_h2_validate_request_pseudo_rejects_ordinary_request_missing_scheme() {
+	h2_validate_request_pseudo([
+		H2HeaderField{':method', 'GET'},
+		H2HeaderField{':path', '/'},
+	]) or { return }
+	assert false, 'expected an error for a GET request missing :scheme'
+}
+
+// A conforming CONNECT request (RFC 9113 §8.5): :method=CONNECT,
+// :authority present, :scheme and :path both OMITTED. Regression test for
+// a real bug: h2_validate_request_pseudo required :path/:scheme
+// unconditionally, so this exact conforming shape was rejected as
+// malformed (400) and never reached the Handler -- the same bug already
+// found and fixed in h3_server.v's h3_validate_request_pseudo (Codex
+// review, PR #28164 pullrequestreview-5044139767); h2_server.v had the
+// identical gap, left as an explicitly out-of-scope follow-up in that
+// same round.
+fn test_h2_validate_request_pseudo_accepts_a_conforming_connect() {
+	h2_validate_request_pseudo([
+		H2HeaderField{':method', 'CONNECT'},
+		H2HeaderField{':authority', 'example.com:443'},
+	])!
+}
+
+fn test_h2_validate_request_pseudo_rejects_connect_with_scheme() {
+	h2_validate_request_pseudo([
+		H2HeaderField{':method', 'CONNECT'},
+		H2HeaderField{':scheme', 'https'},
+		H2HeaderField{':authority', 'example.com:443'},
+	]) or { return }
+	assert false, 'expected an error for a CONNECT request carrying :scheme'
+}
+
+fn test_h2_validate_request_pseudo_rejects_connect_with_path() {
+	h2_validate_request_pseudo([
+		H2HeaderField{':method', 'CONNECT'},
+		H2HeaderField{':path', '/'},
+		H2HeaderField{':authority', 'example.com:443'},
+	]) or { return }
+	assert false, 'expected an error for a CONNECT request carrying :path'
+}
+
+fn test_h2_validate_request_pseudo_rejects_connect_missing_authority() {
+	h2_validate_request_pseudo([
+		H2HeaderField{':method', 'CONNECT'},
+	]) or { return }
+	assert false, 'expected an error for a CONNECT request missing :authority'
+}
+
+// :authority's own match arm (above) only checks for duplication, never
+// emptiness -- unlike :method/:path/:scheme, which all reject an empty
+// value inline. That is fine for an ORDINARY request (RFC 9113 doesn't
+// mandate a non-empty :authority when present at all), but RFC 9113 §8.5
+// says a CONNECT request's :authority "MUST be provided" and "contains
+// the host and port to connect to" -- an empty string satisfies neither.
+// Found while reviewing this same diff's own CONNECT branch (Angle D,
+// full-file read): a CONNECT request with a present-but-empty :authority
+// would have set has_authority=true and slipped past the new
+// !has_authority check.
+fn test_h2_validate_request_pseudo_rejects_connect_with_empty_authority() {
+	h2_validate_request_pseudo([
+		H2HeaderField{':method', 'CONNECT'},
+		H2HeaderField{':authority', ''},
+	]) or { return }
+	assert false, 'expected an error for a CONNECT request with an empty :authority'
+}
+
+// H2NoopPseudoTestTransport is a minimal, do-nothing H2Transport stand-in
+// -- build_request (below) never touches c.transport at all (only
+// s.headers/s.body), so no real pipe/socket is needed, just something
+// satisfying the interface. A local, file-scoped fake rather than reusing
+// h2_server_test.v's own new_pipe()/PipeEnd: each _test.v file compiles as
+// its own independent unit (confirmed while writing this test -- a first
+// attempt to reuse new_pipe() here failed with "unknown function", the
+// same isolation h3_server_pseudo_test.v's own module doc comment already
+// notes for its file), so a cross-file helper isn't visible here.
+struct H2NoopPseudoTestTransport {}
+
+fn (mut t H2NoopPseudoTestTransport) read(mut buf []u8) !int {
+	return error_with_code('unused in this test', net.err_timed_out_code)
+}
+
+fn (mut t H2NoopPseudoTestTransport) write(buf []u8) !int {
+	return buf.len
+}
+
+// build_request end-to-end for CONNECT: method decodes correctly and url
+// stays empty (there is no :path to populate it from) -- the Handler, not
+// this layer, is responsible for CONNECT-specific behavior. Mirrors
+// test_h3_build_request_connect_yields_connect_method_and_empty_url
+// (h3_server_pseudo_test.v).
+fn test_h2_build_request_connect_yields_connect_method_and_empty_url() {
+	mut c := &H2ServerConn{
+		transport: H2Transport(&H2NoopPseudoTestTransport{})
+	}
+	s := &H2ServerStream{
+		headers: [
+			H2HeaderField{':method', 'CONNECT'},
+			H2HeaderField{':authority', 'example.com:443'},
+		]
+	}
+	req := c.build_request(s)!
+	assert req.method == .connect
+	assert req.url == ''
+}


### PR DESCRIPTION
## Summary

`h2_validate_request_pseudo` (`h2_server.v`) required `:method`/`:path`/`:scheme`
unconditionally, so every conforming CONNECT request — RFC 9113 §8.5 requires a
CONNECT request to **omit** `:scheme` and `:path`, and instead carry `:authority`
— was rejected as malformed (400) before ever reaching the `Handler`.

This is the same bug independently found and fixed in `h3_server.v`'s
`h3_validate_request_pseudo` (Codex review, [PR #28164](https://github.com/vlang/v/pull/28164),
[pullrequestreview-5044139767](https://github.com/vlang/v/pull/28164#pullrequestreview-5044139767)).
That fix's own commit message noted `h2_server.v` had the identical gap, left as
an explicitly out-of-scope follow-up — this PR closes it.

## Fix

Mirrors the `h3_server.v` reference exactly: track `:method` during validation;
when it's `CONNECT`, require `:authority` (non-empty) and forbid `:scheme`/`:path`;
otherwise keep the existing `:method`/`:path`/`:scheme` requirement. Extended
CONNECT (RFC 8441's `:protocol`, WebSockets-over-HTTP/2) stays out of scope, same
as the H3 side — this only stops a conforming plain CONNECT from being rejected,
it doesn't implement CONNECT tunneling itself.

**A second, related gap found and fixed while reviewing this same diff
full-file:** the `:authority` match arm only ever checked for duplication, never
emptiness — unlike `:method`/`:path`/`:scheme`, which all reject an empty value
inline. A CONNECT request with a present-but-empty `:authority` would have
slipped past the new check, violating RFC 9113 §8.5's "MUST be provided...
contains the host and port to connect to". Fixed by capturing the value and
checking it specifically in the CONNECT branch — the ordinary-request arm is
left alone, since RFC 9113 doesn't mandate a non-empty `:authority` there.

## Test plan

- [x] Regression tests mirroring `h3_server_pseudo_test.v`'s shape (new file,
      `h2_server_pseudo_test.v`): accepts a conforming CONNECT, rejects
      CONNECT+`:scheme`, rejects CONNECT+`:path`, rejects CONNECT missing
      `:authority`, rejects CONNECT with an empty `:authority`, and an
      end-to-end `build_request` test asserting `.connect` method with an
      empty `url` (there is no `:path` to populate it from)
- [x] Both fixes Phase-R'd: each regression test confirmed failing against the
      pre-fix code, then passing after
- [x] `./vnew -no-memory-limit -silent test vlib/net/http/` green (30 passed,
      4 pre-existing platform skips, 0 failed)
- [x] `/vreview high-risk` — full-file read of `h2_server.v` (1192 lines); 1
      finding (the empty-`:authority` gap above), fixed

## Note: an unrelated `v fmt` bug hit along the way

While formatting this change I found `v fmt -w` silently strips `mut` from
`if mut x := map[...] { ... }` and reorders comments around `or {}` blocks —
filed separately as [#28226](https://github.com/vlang/v/issues/28226), with a
minimal repro. I reverted its output on this file and hand-applied only this
PR's intended change instead of trusting `fmt -w` on it.

## Not done here, flagged rather than silently skipped

The H2 conformance matrix (a maintained local reviewer artifact, not part of
this repo) should get a CONFORMS row for RFC 9113 §8.5 here, mirroring the
QUIC matrix's own update for the H3 fix — not done in this PR.
