### PR TITLE
db.pg: fix garbled connect error message by deep-copying libpq error before PQfinish (#28225)

### DIFF
--- a/vlib/db/pg/pg.c.v
+++ b/vlib/db/pg/pg.c.v
@@ -386,12 +386,16 @@ fn connect_slot(conninfo string) !IdleSlot {
 	}
 	status := unsafe { ConnStatusType(C.PQstatus(conn)) }
 	if status != .ok {
-		// We force the construction of a new string as the
-		// error message will be freed by the next `PQfinish` call
-		c_error_msg := unsafe { C.PQerrorMessage(conn).vstring() }
-		error_msg := '${c_error_msg}'
+		// `PQerrorMessage` returns a pointer to libpq's internal buffer, and
+		// `vstring()` only does a zero-copy wrap (no ownership transfer). The
+		// buffer is freed by the `PQfinish` call below, so we must take a
+		// deep copy now, before the handle is destroyed, otherwise the error
+		// message is a dangling pointer (garbled / null bytes in the output).
+		// Note: a plain `'${msg}'` interpolation is optimized by the compiler
+		// to a no-op assignment, so an explicit `.clone()` is required.
+		c_error_msg := unsafe { C.PQerrorMessage(conn).vstring().clone() }
 		C.PQfinish(conn)
-		return error('Connection to a PG database failed: ${error_msg}')
+		return error('Connection to a PG database failed: ${c_error_msg}')
 	}
 	return IdleSlot{
 		handle:     conn

--- a/vlib/db/pg/pg.c.v
+++ b/vlib/db/pg/pg.c.v
@@ -386,14 +386,7 @@ fn connect_slot(conninfo string) !IdleSlot {
 	}
 	status := unsafe { ConnStatusType(C.PQstatus(conn)) }
 	if status != .ok {
-		// `PQerrorMessage` returns a pointer to libpq's internal buffer, and
-		// `vstring()` only does a zero-copy wrap (no ownership transfer). The
-		// buffer is freed by the `PQfinish` call below, so we must take a
-		// deep copy now, before the handle is destroyed, otherwise the error
-		// message is a dangling pointer (garbled / null bytes in the output).
-		// Note: a plain `'${msg}'` interpolation is optimized by the compiler
-		// to a no-op assignment, so an explicit `.clone()` is required.
-		c_error_msg := unsafe { C.PQerrorMessage(conn).vstring().clone() }
+		c_error_msg := unsafe { cstring_to_vstring(C.PQerrorMessage(conn)) }
 		C.PQfinish(conn)
 		return error('Connection to a PG database failed: ${c_error_msg}')
 	}

--- a/vlib/db/pg/pg_error_test.v
+++ b/vlib/db/pg/pg_error_test.v
@@ -1,0 +1,25 @@
+module main
+
+import db.pg
+
+// Regression test for https://github.com/vlang/v/issues/28225
+//
+// When PostgreSQL is unreachable, `connect_slot` previously returned an error
+// whose message was built from a dangling pointer: `PQerrorMessage` returns a
+// pointer to libpq's internal buffer and `.vstring()` only wraps it zero-copy,
+// then `PQfinish` freed the buffer before the message was interpolated. The
+// result was a garbled error string full of null bytes / binary garbage.
+fn test_connect_failure_error_is_well_formed() {
+	// Port 59999 is deliberately not running a PostgreSQL server, so
+	// `connect_slot` takes the `status != .ok` path that produced the
+	// garbled message. This test does not require a live database.
+	conn := pg.connect_direct_with_conninfo('host=localhost port=59999 user=nobody dbname=nodb') or {
+		err_str := err.str()
+		// The message must contain readable text and no embedded NUL bytes.
+		assert err_str.contains('Connection to a PG database failed'), 'missing prefix: ${err_str}'
+		assert !err_str.contains('\u0000'), 'garbled error message contains NUL bytes: ${err_str}'
+		return
+	}
+	// An unexpected connection to a non-running server succeeded — skip.
+	conn.close() or {}
+}

--- a/vlib/db/pg/pg_error_test.v
+++ b/vlib/db/pg/pg_error_test.v
@@ -1,3 +1,4 @@
+// vtest build: !windows && !musl?
 module main
 
 import db.pg


### PR DESCRIPTION
Fixes #28225

## Root cause

`PQerrorMessage` returns a pointer to **libpq's internal error buffer**, and V's `&char.vstring()` only does a *zero-copy wrap* (`.str` points at the C buffer, no ownership transfer). In `connect_slot`, the message was interpolated **after** `C.PQfinish(conn)` had already freed that buffer, so the error string became a dangling pointer - the reported garbled / null-byte output.

Note that `error_msg := '${c_error_msg}'` is **not** a deep copy - the compiler optimizes an interpolation of a single string variable into a plain assignment, so the original code's intent ("force the construction of a new string") was defeated.

## Fix

Take an explicit `.clone()` of the wrapped string **before** `PQfinish` destroys the handle:

```v
c_error_msg := unsafe { C.PQerrorMessage(conn).vstring().clone() }
C.PQfinish(conn)
return error('Connection to a PG database failed: ${c_error_msg}')
```

## Test

Added `pg_error_test.v` - connects to a non-running PostgreSQL port (no live DB required) and asserts the error message contains readable text and **no** embedded NUL bytes. Verified:
- Without the fix: test FAILS with the garbled message (exactly #28225's symptom).
- With the fix: all 7 `vlib/db/pg` tests pass.
