### PR TITLE
v3: support self in standalone FastC

### DIFF
--- a/vlib/v3/README.md
+++ b/vlib/v3/README.md
@@ -147,6 +147,11 @@ compiler uses the small `v3.fastcdriver` entry point and can build further FastC
 the flat AST or conventional C backend. Set `V_MACOS_V3_NO_FALLBACK=1` while validating a chain to
 turn any attempted compatibility fallback into a hard failure.
 
+The standalone compiler supports `self` directly and defaults that command to FastC. For example,
+`./v self x5` replaces the compiler through five descendant FastC generations, with each installed
+generation compiling the next one. `-b fastc`, `-gc none`, `-cc tinyc|tcc`, `-keepc`, `-silent`,
+and a single-generation `-o` destination are accepted.
+
 In selfhost mode, `t := spawn f(args)` and `t.wait()` lower to a generated pthread creator, run
 wrapper, and join helper per spawned function: `thread` values are a typed wrapper around
 `pthread_t` plus a heap block that packs the arguments and receives the result. Spawned threads

--- a/vlib/v3/fastcdriver/fastcdriver.v
+++ b/vlib/v3/fastcdriver/fastcdriver.v
@@ -183,6 +183,20 @@ fn run_self_compiler(compiler string, compile_args []string, output string, sour
 	}
 }
 
+// self_replacement_path returns a collision-free sibling where the freshly
+// self-built binary can be written before it is swapped onto the compiler.
+fn self_replacement_path(compiler string) string {
+	dir := os.dir(compiler)
+	base := os.file_name(compiler)
+	for counter := 0; true; counter++ {
+		candidate := os.join_path_single(dir, '.${base}.self-new.${os.getpid()}.${counter}')
+		if !os.exists(candidate) {
+			return candidate
+		}
+	}
+	return compiler
+}
+
 fn replace_self_compiler(compiler string, replacement string) {
 	backup_name := if os.user_os() == 'windows' { 'v_old.exe' } else { 'v_old' }
 	backup := os.join_path_single(os.dir(compiler), backup_name)
@@ -222,8 +236,7 @@ fn run_self(args []string, command_index int) {
 		run_self_compiler(compiler, compile_args, output, source)
 		return
 	}
-	replacement_name := if os.user_os() == 'windows' { 'v2.exe' } else { 'v2' }
-	replacement := os.join_path_single(os.dir(compiler), replacement_name)
+	replacement := self_replacement_path(compiler)
 	for run_index in 0 .. repeat_count {
 		run_label := if repeat_count > 1 { ' [${run_index + 1}/${repeat_count}]' } else { '' }
 		println('V self compiling${run_label} (-b fastc)...')

--- a/vlib/v3/fastcdriver/fastcdriver.v
+++ b/vlib/v3/fastcdriver/fastcdriver.v
@@ -71,6 +71,168 @@ fn parse_arguments(args []string) (string, string, bool) {
 	return input, output, keep_c
 }
 
+fn self_command_index(args []string) int {
+	mut index := 0
+	for index < args.len {
+		arg := args[index]
+		if arg in ['-o', '-output', '-b', '-backend', '-gc', '-cc', '-d'] {
+			index += 2
+			continue
+		}
+		if arg == 'self' {
+			return index
+		}
+		index++
+	}
+	return -1
+}
+
+fn repeat_count_arg(arg string) int {
+	if arg.len < 2 || arg[0] != `x` {
+		return 0
+	}
+	for ch in arg[1..].bytes() {
+		if !ch.is_digit() {
+			return 0
+		}
+	}
+	count := arg[1..].int()
+	return if count > 0 { count } else { 0 }
+}
+
+fn parse_self_arguments(args []string, command_index int) (int, []string, string) {
+	mut repeat_count := 1
+	mut has_repeat_count := false
+	mut compile_args := []string{}
+	mut output := ''
+	mut index := 0
+	for index < args.len {
+		if index == command_index {
+			index++
+			continue
+		}
+		arg := args[index]
+		if arg in ['-o', '-output', '-b', '-backend', '-gc', '-cc', '-d'] {
+			if index + 1 >= args.len {
+				fail('fastc self: missing value after `${arg}`')
+			}
+			value := args[index + 1]
+			match arg {
+				'-o', '-output' {
+					output = value
+				}
+				'-b', '-backend' {
+					if value != 'fastc' {
+						fail('fastc self only supports `-b fastc`')
+					}
+				}
+				'-gc' {
+					if value != 'none' {
+						fail('fastc self only supports `-gc none`')
+					}
+				}
+				'-cc' {
+					if value !in ['tinyc', 'tcc'] {
+						fail('fastc self only supports bundled TinyCC')
+					}
+					compile_args << ['-cc', value]
+				}
+				'-d' {
+					fail('fastc self does not support custom `-d ${value}` defines')
+				}
+				else {}
+			}
+			index += 2
+			continue
+		}
+		if arg in ['-silent', '-keepc'] {
+			compile_args << arg
+			index++
+			continue
+		}
+		if arg == '-selfhost' {
+			index++
+			continue
+		}
+		count := repeat_count_arg(arg)
+		if count > 0 && !has_repeat_count {
+			repeat_count = count
+			has_repeat_count = true
+			index++
+			continue
+		}
+		fail('fastc self does not support `${arg}`')
+	}
+	compile_args << ['-b', 'fastc', '-gc', 'none', '-selfhost']
+	return repeat_count, compile_args, output
+}
+
+fn run_self_compiler(compiler string, compile_args []string, output string, source string) {
+	mut command := []string{cap: compile_args.len + 4}
+	command << os.quoted_path(compiler)
+	for arg in compile_args {
+		command << os.quoted_path(arg)
+	}
+	command << ['-o', os.quoted_path(output), os.quoted_path(source)]
+	result := os.execute(command.join(' '))
+	if result.exit_code != 0 {
+		fail(result.output)
+	}
+	if result.output.len > 0 {
+		println(result.output.trim_space())
+	}
+}
+
+fn replace_self_compiler(compiler string, replacement string) {
+	backup_name := if os.user_os() == 'windows' { 'v_old.exe' } else { 'v_old' }
+	backup := os.join_path_single(os.dir(compiler), backup_name)
+	if os.exists(backup) {
+		os.rm(backup) or { fail(err.msg()) }
+	}
+	os.mv(compiler, backup) or { fail(err.msg()) }
+	os.mv_by_cp(replacement, compiler) or {
+		message := err.msg()
+		os.mv(backup, compiler) or {}
+		fail(message)
+	}
+}
+
+fn run_self(args []string, command_index int) {
+	$if windows {
+		fail('fastc self is not yet supported on Windows')
+	}
+	repeat_count, compile_args, output := parse_self_arguments(args, command_index)
+	if output != '' && repeat_count > 1 {
+		fail('fastc self does not support xN together with `-o`')
+	}
+	prefs := pref.new_preferences()
+	if prefs.vroot == '' {
+		fail('fastc self could not locate the V source tree')
+	}
+	source := os.join_path(prefs.vroot, 'vlib', 'v3', 'v3.v')
+	if !os.is_file(source) {
+		fail('fastc self could not find `${source}`')
+	}
+	compiler := os.real_path(os.executable())
+	if compiler == '' || !os.is_executable(compiler) {
+		fail('fastc self could not locate its compiler executable')
+	}
+	if output != '' {
+		println('V self compiling (-b fastc)...')
+		run_self_compiler(compiler, compile_args, output, source)
+		return
+	}
+	replacement_name := if os.user_os() == 'windows' { 'v2.exe' } else { 'v2' }
+	replacement := os.join_path_single(os.dir(compiler), replacement_name)
+	for run_index in 0 .. repeat_count {
+		run_label := if repeat_count > 1 { ' [${run_index + 1}/${repeat_count}]' } else { '' }
+		println('V self compiling${run_label} (-b fastc)...')
+		run_self_compiler(compiler, compile_args, replacement, source)
+		replace_self_compiler(compiler, replacement)
+	}
+	println('V built successfully as executable "${os.file_name(compiler)}".')
+}
+
 fn canonical_output_path(path string) string {
 	if os.exists(path) {
 		return os.real_path(path)
@@ -84,8 +246,13 @@ fn fastc_tcc_backtrace_enabled(target_os string, target_arch string) bool {
 	return !(target_os == 'macos' && target_arch == 'arm64')
 }
 
-// run builds a program using only FastC's scanner-to-C pipeline.
+// run invokes the standalone FastC compiler or its self-build command.
 pub fn run(args []string) {
+	command_index := self_command_index(args)
+	if command_index >= 0 {
+		run_self(args, command_index)
+		return
+	}
 	input, output, keep_c := parse_arguments(args)
 	real_input := os.real_path(input)
 	if pref.is_test_file_for_backend(real_input, 'fastc')

--- a/vlib/v3/fastcdriver/fastcdriver.v
+++ b/vlib/v3/fastcdriver/fastcdriver.v
@@ -183,13 +183,11 @@ fn run_self_compiler(compiler string, compile_args []string, output string, sour
 	}
 }
 
-// self_replacement_path returns a collision-free sibling where the freshly
-// self-built binary can be written before it is swapped onto the compiler.
-fn self_replacement_path(compiler string) string {
+fn unique_self_sibling_path(compiler string, role string) string {
 	dir := os.dir(compiler)
 	base := os.file_name(compiler)
 	for counter := 0; true; counter++ {
-		candidate := os.join_path_single(dir, '.${base}.self-new.${os.getpid()}.${counter}')
+		candidate := os.join_path_single(dir, '.${base}.${role}.${os.getpid()}.${counter}')
 		if !os.exists(candidate) {
 			return candidate
 		}
@@ -197,9 +195,26 @@ fn self_replacement_path(compiler string) string {
 	return compiler
 }
 
+// self_replacement_path returns a collision-free sibling where the freshly
+// self-built binary can be written before it is swapped onto the compiler.
+fn self_replacement_path(compiler string) string {
+	return unique_self_sibling_path(compiler, 'self-new')
+}
+
 fn replace_self_compiler(compiler string, replacement string) {
 	backup_name := if os.user_os() == 'windows' { 'v_old.exe' } else { 'v_old' }
 	backup := os.join_path_single(os.dir(compiler), backup_name)
+	if backup == compiler {
+		staging := unique_self_sibling_path(compiler, 'self-old')
+		os.mv(compiler, staging) or { fail(err.msg()) }
+		os.mv_by_cp(replacement, compiler) or {
+			message := err.msg()
+			os.mv(staging, compiler) or {}
+			fail(message)
+		}
+		os.rm(staging) or {}
+		return
+	}
 	if os.exists(backup) {
 		os.rm(backup) or { fail(err.msg()) }
 	}

--- a/vlib/v3/fastcdriver/fastcdriver_test.v
+++ b/vlib/v3/fastcdriver/fastcdriver_test.v
@@ -9,14 +9,14 @@ fn test_fastc_tcc_backtrace_enabled() {
 	assert fastc_tcc_backtrace_enabled('linux', 'amd64')
 }
 
-fn test_in_place_self_chain_survives_a_compiler_named_v2() {
-	dir := os.join_path(os.temp_dir(), 'fastc_self_v2_chain_${os.getpid()}')
+fn assert_in_place_self_chain_survives(compiler_name string) {
+	dir := os.join_path(os.temp_dir(), 'fastc_self_${compiler_name}_chain_${os.getpid()}')
 	os.rmdir_all(dir) or {}
 	os.mkdir_all(dir) or { assert false, err.msg() }
 	defer {
 		os.rmdir_all(dir) or {}
 	}
-	compiler := os.join_path_single(dir, 'v2')
+	compiler := os.join_path_single(dir, compiler_name)
 	os.write_file(compiler, 'GEN0') or { assert false, err.msg() }
 	replacement := self_replacement_path(compiler)
 	assert replacement != compiler
@@ -28,8 +28,25 @@ fn test_in_place_self_chain_survives_a_compiler_named_v2() {
 		assert !os.exists(replacement)
 	}
 	assert os.read_file(compiler) or { '' } == 'GEN2'
-	assert os.read_file(os.join_path_single(dir, 'v_old')) or { '' } == 'GEN1'
 	mut entries := os.ls(dir) or { []string{} }
 	entries.sort()
-	assert entries == ['v2', 'v_old'], entries.str()
+	backup_name := if os.user_os() == 'windows' { 'v_old.exe' } else { 'v_old' }
+	if compiler_name == backup_name {
+		assert entries == [compiler_name], entries.str()
+	} else {
+		assert os.read_file(os.join_path_single(dir, backup_name)) or { '' } == 'GEN1'
+		assert entries == [compiler_name, backup_name], entries.str()
+	}
+}
+
+fn test_in_place_self_chain_survives_a_compiler_named_v2() {
+	assert_in_place_self_chain_survives(if os.user_os() == 'windows' { 'v2.exe' } else { 'v2' })
+}
+
+fn test_in_place_self_chain_survives_a_compiler_named_v_old() {
+	assert_in_place_self_chain_survives(if os.user_os() == 'windows' {
+		'v_old.exe'
+	} else {
+		'v_old'
+	})
 }

--- a/vlib/v3/fastcdriver/fastcdriver_test.v
+++ b/vlib/v3/fastcdriver/fastcdriver_test.v
@@ -1,8 +1,35 @@
 module fastcdriver
 
+import os
+
 fn test_fastc_tcc_backtrace_enabled() {
 	assert !fastc_tcc_backtrace_enabled('macos', 'arm64')
 	assert fastc_tcc_backtrace_enabled('macos', 'amd64')
 	assert fastc_tcc_backtrace_enabled('linux', 'arm64')
 	assert fastc_tcc_backtrace_enabled('linux', 'amd64')
+}
+
+fn test_in_place_self_chain_survives_a_compiler_named_v2() {
+	dir := os.join_path(os.temp_dir(), 'fastc_self_v2_chain_${os.getpid()}')
+	os.rmdir_all(dir) or {}
+	os.mkdir_all(dir) or { assert false, err.msg() }
+	defer {
+		os.rmdir_all(dir) or {}
+	}
+	compiler := os.join_path_single(dir, 'v2')
+	os.write_file(compiler, 'GEN0') or { assert false, err.msg() }
+	replacement := self_replacement_path(compiler)
+	assert replacement != compiler
+	assert os.dir(replacement) == dir
+	for generation in 1 .. 3 {
+		os.write_file(replacement, 'GEN${generation}') or { assert false, err.msg() }
+		replace_self_compiler(compiler, replacement)
+		assert os.read_file(compiler) or { '' } == 'GEN${generation}'
+		assert !os.exists(replacement)
+	}
+	assert os.read_file(compiler) or { '' } == 'GEN2'
+	assert os.read_file(os.join_path_single(dir, 'v_old')) or { '' } == 'GEN1'
+	mut entries := os.ls(dir) or { []string{} }
+	entries.sort()
+	assert entries == ['v2', 'v_old'], entries.str()
 }

--- a/vlib/v3/tests/fastc_backend_test.v
+++ b/vlib/v3/tests/fastc_backend_test.v
@@ -133,6 +133,19 @@ fn test_v_self_accepts_fastc_backend() {
 	assert compiling_lines.len == 2, repeated_build.output
 	assert os.is_executable(isolated_vexe)
 
+	deep_self_build := run_with_v_environment(isolated_vexe, ['self', '-silent', 'x5'], '',
+		isolated_vexe)
+	assert deep_self_build.exit_code == 0, deep_self_build.output
+	assert deep_self_build.output.count('V self compiling') == 5, deep_self_build.output
+	assert os.is_executable(isolated_vexe)
+	assert os.is_executable(os.join_path(isolated_vroot, 'v_old'))
+	deep_self_output := os.join_path(root, 'v_fastc_after_five_self_builds')
+	deep_self_output_build := run_with_v_environment(isolated_vexe, ['self', '-silent', '-o',
+		deep_self_output], '', isolated_vexe)
+	assert deep_self_output_build.exit_code == 0, deep_self_output_build.output
+	assert deep_self_output_build.output.count('V self compiling') == 1, deep_self_output_build.output
+	assert os.is_executable(deep_self_output)
+
 	prod_build := cmdexec.run(@VEXE, ['self', '-silent', '-prod', '-b', 'fastc', '-o',
 		os.join_path(root, 'v prod')])
 	assert prod_build.exit_code != 0

--- a/vlib/v3/tests/fastc_backend_test.v
+++ b/vlib/v3/tests/fastc_backend_test.v
@@ -138,7 +138,12 @@ fn test_v_self_accepts_fastc_backend() {
 	assert deep_self_build.exit_code == 0, deep_self_build.output
 	assert deep_self_build.output.count('V self compiling') == 5, deep_self_build.output
 	assert os.is_executable(isolated_vexe)
-	assert os.is_executable(os.join_path(isolated_vroot, 'v_old'))
+	v_old := os.join_path(isolated_vroot, 'v_old')
+	assert os.is_executable(v_old)
+	v_old_repeated_build := run_with_v_environment(v_old, ['self', '-silent', 'x2'], '', v_old)
+	assert v_old_repeated_build.exit_code == 0, v_old_repeated_build.output
+	assert v_old_repeated_build.output.count('V self compiling') == 2, v_old_repeated_build.output
+	assert os.is_executable(v_old)
 	deep_self_output := os.join_path(isolated_vroot, 'v2')
 	deep_self_output_build := run_with_v_environment(isolated_vexe, ['self', '-silent', '-o',
 		deep_self_output], '', isolated_vexe)

--- a/vlib/v3/tests/fastc_backend_test.v
+++ b/vlib/v3/tests/fastc_backend_test.v
@@ -139,11 +139,16 @@ fn test_v_self_accepts_fastc_backend() {
 	assert deep_self_build.output.count('V self compiling') == 5, deep_self_build.output
 	assert os.is_executable(isolated_vexe)
 	assert os.is_executable(os.join_path(isolated_vroot, 'v_old'))
-	deep_self_output := os.join_path(root, 'v_fastc_after_five_self_builds')
+	deep_self_output := os.join_path(isolated_vroot, 'v2')
 	deep_self_output_build := run_with_v_environment(isolated_vexe, ['self', '-silent', '-o',
 		deep_self_output], '', isolated_vexe)
 	assert deep_self_output_build.exit_code == 0, deep_self_output_build.output
 	assert deep_self_output_build.output.count('V self compiling') == 1, deep_self_output_build.output
+	assert os.is_executable(deep_self_output)
+	v2_repeated_build := run_with_v_environment(deep_self_output, ['self', '-silent', 'x2'], '',
+		deep_self_output)
+	assert v2_repeated_build.exit_code == 0, v2_repeated_build.output
+	assert v2_repeated_build.output.count('V self compiling') == 2, v2_repeated_build.output
 	assert os.is_executable(deep_self_output)
 
 	prod_build := cmdexec.run(@VEXE, ['self', '-silent', '-prod', '-b', 'fastc', '-o',


### PR DESCRIPTION
## What

- add a minimal `self` command to the standalone FastC driver
- make `self xN` replace the compiler through descendant FastC generations
- preserve the supported FastC flags and single-generation output mode
- document the command and test an isolated five-generation chain

## Why

`v self -b fastc` installs the small standalone FastC driver. That compiler can compile `vlib/v3/v3.v` recursively, but it previously rejected the `self` command token, so an installed FastC compiler could not initiate its own rebuild.

The replacement test uses an isolated V root and verifies that the fifth descendant still handles another `self -o` build.

## Validation

- `./vnew -silent test vlib/v3/tests/fastc_backend_test.v`
- `./vnew -silent vlib/v/compiler_errors_test.v` (1619 passed, 1 skipped)
- `./vnew check-md vlib/v3/README.md`

Full `test-all` was not run; focused coverage was used.