### PR TITLE
v3: fix cross-platform CI regressions

### DIFF
--- a/.github/workflows/resolve-pr-28232.yml
+++ b/.github/workflows/resolve-pr-28232.yml
@@ -1,0 +1,37 @@
+name: Diagnose PR 28232 merge conflict
+
+on:
+  push:
+    branches:
+      - fix-master-ci-batch-2-current
+
+permissions:
+  contents: read
+
+jobs:
+  diagnose:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: fix-master-ci-batch-2-current
+          fetch-depth: 0
+      - name: Show exact merge conflicts
+        shell: bash
+        run: |
+          set -uo pipefail
+          git fetch origin master
+          git merge --no-commit --no-ff origin/master
+          merge_status=$?
+          echo "merge_status=${merge_status}"
+          conflicts="$(git diff --name-only --diff-filter=U)"
+          echo '--- conflicted paths ---'
+          printf '%s\n' "$conflicts"
+          echo '--- conflict diffs ---'
+          while IFS= read -r path; do
+            [ -n "$path" ] || continue
+            echo "===== ${path} ====="
+            git diff --cc --unified=80 -- "$path" || true
+          done <<< "$conflicts"
+          git merge --abort || true
+          exit 0

--- a/vlib/v/tests/builtin_arrays/array_ops_create_just_one_closure_test.c.v
+++ b/vlib/v/tests/builtin_arrays/array_ops_create_just_one_closure_test.c.v
@@ -12,13 +12,20 @@ fn setup(fname string) (int, int, []int) {
 	return unsafe { &C.builtin__closure__Closure(voidptr(&C.g_closure)).closure_cap }, 42, []int{len: 5, init: index * 5}
 }
 
+fn assert_at_most_one_new_closure(start_closure_cap int) {
+	closure_cap := unsafe { &C.builtin__closure__Closure(voidptr(&C.g_closure)).closure_cap }
+	// V3 reclaims array callbacks at function exit, so later tests can reuse the
+	// first test's slot without consuming another slot from the current page.
+	assert start_closure_cap - closure_cap in [0, 1]
+}
+
 fn test_array_filter() {
 	start_closure_cap, x, a := setup(@LOCATION)
 	println(a.filter(fn [x] (i int) bool {
 		println('x: ${x} | i: ${i}')
 		return i < 20
 	}))
-	assert start_closure_cap - unsafe { &C.builtin__closure__Closure(voidptr(&C.g_closure)).closure_cap } == 1
+	assert_at_most_one_new_closure(start_closure_cap)
 }
 
 fn test_array_map() {
@@ -27,7 +34,7 @@ fn test_array_map() {
 		println('x: ${x} | i: ${i}')
 		return x + i
 	}))
-	assert start_closure_cap - unsafe { &C.builtin__closure__Closure(voidptr(&C.g_closure)).closure_cap } == 1
+	assert_at_most_one_new_closure(start_closure_cap)
 }
 
 fn test_array_any() {
@@ -36,7 +43,7 @@ fn test_array_any() {
 		println('x: ${x} | i: ${i}')
 		return i < x
 	}))
-	assert start_closure_cap - unsafe { &C.builtin__closure__Closure(voidptr(&C.g_closure)).closure_cap } == 1
+	assert_at_most_one_new_closure(start_closure_cap)
 }
 
 fn test_array_all() {
@@ -45,5 +52,5 @@ fn test_array_all() {
 		println('x: ${x} | i: ${i}')
 		return i < x
 	}))
-	assert start_closure_cap - unsafe { &C.builtin__closure__Closure(voidptr(&C.g_closure)).closure_cap } == 1
+	assert_at_most_one_new_closure(start_closure_cap)
 }

--- a/vlib/v3/driver/c_compiler_flags_test.v
+++ b/vlib/v3/driver/c_compiler_flags_test.v
@@ -1,6 +1,7 @@
 module driver
 
 import os
+import v3.pref
 
 fn test_v3_tcc_backtrace_enabled() {
 	assert !v3_tcc_backtrace_enabled('macos', 'arm64', false)
@@ -71,4 +72,21 @@ fn test_v3_default_linker_flags_do_not_duplicate_existing_flags() {
 	mut flags := ['-lpthread', '-lm']
 	add_v3_default_linker_flags(mut flags, 'linux', false)
 	assert flags == ['-lpthread', '-lm']
+}
+
+fn test_add_c_language_runtime_link_flags() {
+	target := pref.Target{
+		os: 'linux'
+	}
+	mut objective_c := []string{}
+	add_c_language_runtime_link_flags(mut objective_c, [], 'objective-c', target)
+	assert objective_c == ['-lobjc']
+
+	mut objective_cpp := []string{}
+	add_c_language_runtime_link_flags(mut objective_cpp, [], 'objective-c++', target)
+	assert objective_cpp == ['-lstdc++', '-lobjc']
+
+	mut existing := ['-lstdc++', '-lobjc']
+	add_c_language_runtime_link_flags(mut existing, existing.clone(), 'objective-c++', target)
+	assert existing == ['-lstdc++', '-lobjc']
 }

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -274,6 +274,19 @@ fn cpp_runtime_link_flag(target pref.Target) string {
 	return if target.os in ['macos', 'ios'] { '-lc++' } else { '-lstdc++' }
 }
 
+fn add_c_language_runtime_link_flags(mut prepared []string, original []string, language string, target pref.Target) {
+	if language in ['c++', 'objective-c++'] {
+		cpp_runtime := cpp_runtime_link_flag(target)
+		if cpp_runtime !in original && cpp_runtime !in prepared {
+			prepared << cpp_runtime
+		}
+	}
+	if language in ['objective-c', 'objective-c++'] && '-lobjc' !in original
+		&& '-lobjc' !in prepared {
+		prepared << '-lobjc'
+	}
+}
+
 fn prepare_c_flags_for_link(flags []string, environment_c_flags []string, c99 bool, pic_flag string, target_args []string, target pref.Target, c_compiler string, uncached_dir string, mut stats CObjectCacheStats) ![]string {
 	// Nothing to cache: without object-file or native-source flags the link
 	// plan adds no value, and preparing it costs a compiler-identity probe
@@ -289,10 +302,10 @@ fn prepare_c_flags_for_link(flags []string, environment_c_flags []string, c99 bo
 	if !has_cacheable_flag {
 		mut passthrough := flags.clone()
 		if c_link_flags_use_cpp_language(passthrough) {
-			cpp_runtime := cpp_runtime_link_flag(target)
-			if cpp_runtime !in passthrough {
-				passthrough << cpp_runtime
-			}
+			add_c_language_runtime_link_flags(mut passthrough, flags, 'c++', target)
+		}
+		if c_link_flags_use_objective_c_language(passthrough) {
+			add_c_language_runtime_link_flags(mut passthrough, flags, 'objective-c', target)
 		}
 		return passthrough
 	}
@@ -332,24 +345,19 @@ fn prepare_c_flags_for_link(flags []string, environment_c_flags []string, c99 bo
 		}
 		if c_flag_is_object_file(clean) {
 			stats.requests++
-			adjacent_cpp_source := if !os.exists(clean) {
+			adjacent_language := if !os.exists(clean) {
 				if source_file := c_source_from_object_file(clean) {
-					c_source_language(source_file, active_language) in ['c++', 'objective-c++']
+					c_source_language(source_file, active_language)
 				} else {
-					false
+					''
 				}
 			} else {
-				false
+				''
 			}
 			object_path := ensure_c_object_file(clean, active_language, support_flags, c99,
 				pic_flag, target_args, target, c_compiler, uncached_dir, mut stats)!
 			append_c_link_object(mut prepared, object_path, active_language)
-			if adjacent_cpp_source {
-				cpp_runtime := cpp_runtime_link_flag(target)
-				if cpp_runtime !in flags && cpp_runtime !in prepared {
-					prepared << cpp_runtime
-				}
-			}
+			add_c_language_runtime_link_flags(mut prepared, flags, adjacent_language, target)
 		} else if clean.ends_with('.mm') {
 			stats.requests++
 			language := c_source_language(clean, active_language)
@@ -359,12 +367,7 @@ fn prepare_c_flags_for_link(flags []string, environment_c_flags []string, c99 bo
 			if c_generated_native_source_context(clean, uncached_dir) {
 				os.rm(clean) or {}
 			}
-			if language in ['c++', 'objective-c++'] {
-				cpp_runtime := cpp_runtime_link_flag(target)
-				if cpp_runtime !in flags && cpp_runtime !in prepared {
-					prepared << cpp_runtime
-				}
-			}
+			add_c_language_runtime_link_flags(mut prepared, flags, language, target)
 		} else if c_flag_is_c_source_file(clean) {
 			prepared << flag
 		} else {
@@ -373,10 +376,10 @@ fn prepare_c_flags_for_link(flags []string, environment_c_flags []string, c99 bo
 		i++
 	}
 	if c_link_flags_use_cpp_language(prepared) {
-		cpp_runtime := cpp_runtime_link_flag(target)
-		if cpp_runtime !in flags && cpp_runtime !in prepared {
-			prepared << cpp_runtime
-		}
+		add_c_language_runtime_link_flags(mut prepared, flags, 'c++', target)
+	}
+	if c_link_flags_use_objective_c_language(prepared) {
+		add_c_language_runtime_link_flags(mut prepared, flags, 'objective-c', target)
 	}
 	if stats.dependency_scan_fallbacks == 0 && stats.temporary_objects.len == 0 {
 		write_c_link_plan(plan_path, prepared, stats) or {}
@@ -388,7 +391,7 @@ fn prepare_c_flags_for_link(flags []string, environment_c_flags []string, c99 bo
 fn c_link_plan_path(cache_dir string, flags []string, support_flags []string, c99 bool, pic_flag string, target_args []string, target pref.Target, compiler string, mut stats CObjectCacheStats) string {
 	compiler_path, compiler_version := c_object_compiler_identity(compiler, mut stats)
 	mut hash := u64(1469598103934665603)
-	for identity in ['v3-c-link-plan-v2', os.getwd(), flags.join('\x00'),
+	for identity in ['v3-c-link-plan-v3', os.getwd(), flags.join('\x00'),
 		support_flags.join('\x00'), c99.str(), pic_flag, target_args.join('\x00'), compiler_path,
 		compiler_version, target.os, target.arch, target.abi, target.endian, target.pointer_bits.str(),
 		target.object_format] {
@@ -401,7 +404,7 @@ fn c_link_plan_path(cache_dir string, flags []string, support_flags []string, c9
 fn valid_c_link_plan(plan_path string, mut stats CObjectCacheStats) ?CLinkPlan {
 	content := os.read_file(plan_path) or { return none }
 	lines := content.split_into_lines()
-	if lines.len < 5 || lines[0] != 'format=v3-c-link-plan-v2' {
+	if lines.len < 5 || lines[0] != 'format=v3-c-link-plan-v3' {
 		return none
 	}
 	mut plan := CLinkPlan{}
@@ -465,7 +468,7 @@ fn valid_c_link_plan(plan_path string, mut stats CObjectCacheStats) ?CLinkPlan {
 
 fn write_c_link_plan(plan_path string, flags []string, stats &CObjectCacheStats) ! {
 	mut out := strings.new_builder(256 + flags.len * 64 + stats.file_signatures.len * 96)
-	out.writeln('format=v3-c-link-plan-v2')
+	out.writeln('format=v3-c-link-plan-v3')
 	out.writeln('requests=${stats.requests}')
 	out.writeln('direct_objects=${stats.direct_objects}')
 	out.writeln('dependency_files=${stats.dependency_files}')
@@ -512,6 +515,40 @@ fn c_link_flags_use_non_c_language(flags []string) bool {
 
 fn c_link_flags_use_cpp_language(flags []string) bool {
 	return c_link_flags_use_language(flags, false)
+}
+
+fn c_link_flags_use_objective_c_language(flags []string) bool {
+	mut language := ''
+	mut skip_operand := false
+	mut i := 0
+	for i < flags.len {
+		clean := flags[i].trim_space()
+		if skip_operand {
+			skip_operand = false
+			i++
+			continue
+		}
+		if clean == '-x' && i + 1 < flags.len {
+			language = flags[i + 1].trim_space()
+			i += 2
+			continue
+		}
+		if c_flag_consumes_next_operand(clean) {
+			skip_operand = true
+			i++
+			continue
+		}
+		if c_flag_is_c_source_file(clean) || c_flag_is_existing_file(clean) {
+			if language in ['objective-c', 'objective-c++'] {
+				return true
+			}
+			if language in ['', 'none'] && (clean.ends_with('.m') || clean.ends_with('.mm')) {
+				return true
+			}
+		}
+		i++
+	}
+	return false
 }
 
 fn c_link_flags_use_language(flags []string, include_objective_c bool) bool {

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -3513,8 +3513,10 @@ fn (mut g FlatGen) write_type_declaration_block() {
 }
 
 fn (mut g FlatGen) gen_vinit() {
+	needs_closure_init := g.used_fn_contains('closure.closure_init')
+		|| g.used_fn_contains('closure__closure_init')
 	if g.const_runtime_inits.len == 0 && g.runtime_inits.len == 0 && g.module_init_fns.len == 0
-		&& g.global_inits.len == 0 {
+		&& g.global_inits.len == 0 && !needs_closure_init {
 		return
 	}
 	fn_start_pos := g.sb.len
@@ -3530,6 +3532,9 @@ fn (mut g FlatGen) gen_vinit() {
 		}
 	}
 	g.emit_remaining_runtime_inits(mut emitted_const, mut emitted_runtime)
+	if needs_closure_init {
+		g.writeln('\t${g.cname('closure.closure_init')}();')
+	}
 	g.writeln('}')
 	g.writeln('')
 	if '_vinit' in g.print_fn_names {
@@ -19965,6 +19970,7 @@ fn (mut g FlatGen) headerless_darwin_net_constants() {
 	g.writeln('#define IPV6_LEAVE_GROUP 13')
 	g.writeln('#define IPV6_V6ONLY 27')
 	g.writeln('#define AI_PASSIVE 0x00000001')
+	g.writeln('#define SOMAXCONN 128')
 	g.writeln('#define MSG_DONTWAIT 0x80')
 }
 
@@ -20023,6 +20029,7 @@ fn (mut g FlatGen) headerless_bsd_net_constants(af_inet6 string, msg_nosignal st
 	g.writeln('#define IPV6_LEAVE_GROUP 13')
 	g.writeln('#define IPV6_V6ONLY 27')
 	g.writeln('#define AI_PASSIVE 0x00000001')
+	g.writeln('#define SOMAXCONN 128')
 	g.writeln('#define MSG_DONTWAIT 0x80')
 	g.writeln('#define MSG_NOSIGNAL ${msg_nosignal}')
 }
@@ -20075,6 +20082,7 @@ fn (mut g FlatGen) headerless_solaris_net_constants() {
 	g.writeln('#define IPV6_LEAVE_GROUP 0xa')
 	g.writeln('#define IPV6_V6ONLY 0x27')
 	g.writeln('#define AI_PASSIVE 0x0008')
+	g.writeln('#define SOMAXCONN 128')
 	g.writeln('#define MSG_DONTWAIT 0x80')
 	g.writeln('#define MSG_NOSIGNAL 0x200')
 }
@@ -20127,6 +20135,7 @@ fn (mut g FlatGen) headerless_qnx_net_constants() {
 	g.writeln('#define IPV6_LEAVE_GROUP 13')
 	g.writeln('#define IPV6_V6ONLY 27')
 	g.writeln('#define AI_PASSIVE 0x00000001')
+	g.writeln('#define SOMAXCONN 128')
 	g.writeln('#define MSG_DONTWAIT 0x80')
 	g.writeln('#define MSG_NOSIGNAL 0x0800')
 }
@@ -20239,6 +20248,7 @@ fn (mut g FlatGen) headerless_windows_net_constants() {
 	g.writeln('#define IPV6_LEAVE_GROUP 13')
 	g.writeln('#define IPV6_V6ONLY 27')
 	g.writeln('#define AI_PASSIVE 0x00000001')
+	g.writeln('#define SOMAXCONN 0x7fffffff')
 	g.writeln('#define MSG_DONTWAIT 0')
 	g.writeln('#define MSG_NOSIGNAL 0')
 }

--- a/vlib/v3/markused/markused.v
+++ b/vlib/v3/markused/markused.v
@@ -659,6 +659,7 @@ fn mark_used_with_test_files(a &flat.FlatAst, tc &types.TypeChecker, test_files 
 		markused_program_needs_closure_runtime(a, tc)
 	}
 	if !trivial_literal_output && needs_closure_runtime {
+		enqueue('closure.closure_init', mut used, mut queue)
 		enqueue('closure.closure_create_with_data', mut used, mut queue)
 		enqueue('closure.closure_try_destroy', mut used, mut queue)
 	}
@@ -757,6 +758,7 @@ fn mark_used_with_test_files(a &flat.FlatAst, tc &types.TypeChecker, test_files 
 			// the checker per enclosing function) are reachable too -- mark them so they
 			// survive pruning (cgen emits a wrapper that calls them).
 			if mvs := tc.method_values_by_fn[node_key] {
+				enqueue('closure.closure_init', mut used, mut queue)
 				enqueue('closure.closure_create_with_data', mut used, mut queue)
 				enqueue('closure.closure_try_destroy', mut used, mut queue)
 				for mkey in mvs {

--- a/vlib/v3/tests/or_expr_transform_review_test.v
+++ b/vlib/v3/tests/or_expr_transform_review_test.v
@@ -184,6 +184,13 @@ fn test_channel_send_or_binds_error_during_fallback_transform() {
 	assert out == 'channel closed\n7'
 }
 
+fn test_or_storage_preserves_generic_map_value_type() {
+	v3_bin := build_v3_or_review()
+	out := or_review_run(v3_bin, 'or_storage_generic_map_value',
+		'struct Box[T] {\n\tvalue T\n}\n\nfn make_map() ?map[string]Box[int] {\n\treturn {"answer": Box[int]{value: 42}}\n}\n\nfn main() {\n\titems := make_map() or { map[string]Box[int]{} }\n\tprintln(int_str(items["answer"].value))\n}\n')
+	assert out == '42'
+}
+
 fn test_optional_result_pointers_or_are_rejected() {
 	v3_bin := build_v3_or_review()
 	option_output := or_review_compile_bad(v3_bin, 'optional_pointer_or_rejected',

--- a/vlib/v3/tests/posix_wait_header_codegen_test.v
+++ b/vlib/v3/tests/posix_wait_header_codegen_test.v
@@ -269,6 +269,8 @@ fn main() {
 	assert with_os.c_code.contains('#define TCP_DEFER_ACCEPT 9'), with_os.c_code
 	assert with_os.c_code.contains('#define TCP_FASTOPEN 23'), with_os.c_code
 	assert with_os.c_code.contains('#define SOMAXCONN 4096'), with_os.c_code
+	assert with_os.c_code.contains('#define SOMAXCONN 128'), with_os.c_code
+	assert with_os.c_code.contains('#define SOMAXCONN 0x7fffffff'), with_os.c_code
 	assert with_os.c_code.contains('#define MEM_COMMIT 0x00001000U'), with_os.c_code
 	assert with_os.c_code.contains('#define MEM_RESERVE 0x00002000U'), with_os.c_code
 	assert with_os.c_code.contains('#define PAGE_READWRITE 0x04U'), with_os.c_code

--- a/vlib/v3/tests/review_transform_regressions_test.v
+++ b/vlib/v3/tests/review_transform_regressions_test.v
@@ -2869,6 +2869,28 @@ fn test_immediately_invoked_closure_keeps_aliased_slice_result_alive() {
 	assert out == '[41, 42, 43]'
 }
 
+fn test_immediately_invoked_closure_keeps_aliased_string_result_alive() {
+	v3_bin := build_v3_review_transform()
+	source := 'fn main() {
+	mut bytes := [2]u8{}
+	bytes[0] = `O`
+	bytes[1] = `K`
+	text := (fn [bytes] () string {
+		return unsafe { tos(&bytes[0], bytes.len) }
+	})()
+	println(text)
+}
+'
+	c_source := gen_c_from_source(v3_bin, 'immediate_closure_aliased_string_c', source)
+	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
+	println_pos := main_body.index('println') or { -1 }
+	destroy_pos := main_body.index('closure__closure_try_destroy(__immediate_closure_') or { -1 }
+	assert println_pos >= 0, main_body
+	assert destroy_pos > println_pos, main_body
+	out := run_good(v3_bin, 'immediate_closure_aliased_string', source)
+	assert out == 'OK'
+}
+
 fn test_disjoint_same_name_closure_bindings_are_reclaimed() {
 	v3_bin := build_v3_review_transform()
 	source := '@[heap]

--- a/vlib/v3/tests/review_transform_regressions_test.v
+++ b/vlib/v3/tests/review_transform_regressions_test.v
@@ -3026,6 +3026,42 @@ fn main() {
 	assert out == '42'
 }
 
+fn test_immediately_invoked_factory_closure_keeps_side_effect_capture_escape_alive() {
+	v3_bin := build_v3_review_transform()
+	source := 'struct Registry {
+mut:
+	callbacks []fn () int
+}
+
+fn install(mut registry Registry, callback fn () int) {
+	registry.callbacks << callback
+}
+
+fn make_callback(mut registry Registry) fn () {
+	mut value := 42
+	return fn [mut registry, mut value] () {
+		install(mut registry, fn [mut value] () int {
+			return value
+		})
+	}
+}
+
+fn main() {
+	mut registry := Registry{}
+	make_callback(mut registry)()
+	println(int_str(registry.callbacks[0]()))
+}
+'
+	c_source := gen_c_from_source(v3_bin, 'immediate_factory_closure_side_effect_escape_c', source)
+	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
+	println_pos := main_body.index('println') or { -1 }
+	destroy_pos := main_body.index('closure__closure_try_destroy(__immediate_closure_') or { -1 }
+	assert println_pos >= 0, main_body
+	assert destroy_pos > println_pos, main_body
+	out := run_good(v3_bin, 'immediate_factory_closure_side_effect_escape', source)
+	assert out == '42'
+}
+
 fn test_immediately_invoked_closure_keeps_projected_capture_escapes_alive() {
 	v3_bin := build_v3_review_transform()
 	source := 'struct PointerHolder {

--- a/vlib/v3/tests/review_transform_regressions_test.v
+++ b/vlib/v3/tests/review_transform_regressions_test.v
@@ -2968,6 +2968,28 @@ fn main() {
 	assert out == '42'
 }
 
+fn test_immediately_invoked_closure_keeps_channel_sent_capture_alive() {
+	v3_bin := build_v3_review_transform()
+	source := 'fn main() {
+	ch := chan &int{cap: 1}
+	mut value := 42
+	(fn [ch, mut value] () {
+		ch <- unsafe { &value }
+	})()
+	p := <-ch
+	println(int_str(unsafe { *p }))
+}
+'
+	c_source := gen_c_from_source(v3_bin, 'immediate_closure_channel_escape_c', source)
+	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
+	println_pos := main_body.index('println') or { -1 }
+	destroy_pos := main_body.index('closure__closure_try_destroy(__immediate_closure_') or { -1 }
+	assert println_pos >= 0, main_body
+	assert destroy_pos > println_pos, main_body
+	out := run_good(v3_bin, 'immediate_closure_channel_escape', source)
+	assert out == '42'
+}
+
 fn test_disjoint_same_name_closure_bindings_are_reclaimed() {
 	v3_bin := build_v3_review_transform()
 	source := '@[heap]

--- a/vlib/v3/tests/review_transform_regressions_test.v
+++ b/vlib/v3/tests/review_transform_regressions_test.v
@@ -2891,6 +2891,28 @@ fn test_immediately_invoked_closure_keeps_aliased_string_result_alive() {
 	assert out == 'OK'
 }
 
+fn test_immediately_invoked_closure_keeps_spawned_nested_capture_alive() {
+	v3_bin := build_v3_review_transform()
+	source := 'fn main() {
+	mut value := 41
+	worker := (fn [mut value] () thread int {
+		return spawn fn [mut value] () int {
+			return value + 1
+		}()
+	})()
+	println(int_str(worker.wait()))
+}
+'
+	c_source := gen_c_from_source(v3_bin, 'immediate_closure_spawned_capture_c', source)
+	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
+	wait_pos := main_body.index('__v_thread_join') or { -1 }
+	destroy_pos := main_body.index('closure__closure_try_destroy(__immediate_closure_') or { -1 }
+	assert wait_pos >= 0, main_body
+	assert destroy_pos > wait_pos, main_body
+	out := run_good(v3_bin, 'immediate_closure_spawned_capture', source)
+	assert out == '42'
+}
+
 fn test_disjoint_same_name_closure_bindings_are_reclaimed() {
 	v3_bin := build_v3_review_transform()
 	source := '@[heap]

--- a/vlib/v3/tests/review_transform_regressions_test.v
+++ b/vlib/v3/tests/review_transform_regressions_test.v
@@ -2806,6 +2806,26 @@ fn main() {
 	assert out == '1249975000'
 }
 
+fn test_immediately_invoked_closure_keeps_aliased_pointer_result_alive() {
+	v3_bin := build_v3_review_transform()
+	source := 'fn main() {
+	x := 41
+	p := (fn [x] () &int {
+		return unsafe { &x }
+	})()
+	println(int_str(unsafe { *p + 1 }))
+}
+'
+	c_source := gen_c_from_source(v3_bin, 'immediate_closure_aliased_pointer_c', source)
+	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
+	deref_pos := main_body.index('*p') or { -1 }
+	destroy_pos := main_body.index('closure__closure_try_destroy(__immediate_closure_') or { -1 }
+	assert deref_pos >= 0, main_body
+	assert destroy_pos > deref_pos, main_body
+	out := run_good(v3_bin, 'immediate_closure_aliased_pointer', source)
+	assert out == '42'
+}
+
 fn test_disjoint_same_name_closure_bindings_are_reclaimed() {
 	v3_bin := build_v3_review_transform()
 	source := '@[heap]

--- a/vlib/v3/tests/review_transform_regressions_test.v
+++ b/vlib/v3/tests/review_transform_regressions_test.v
@@ -2936,6 +2936,38 @@ fn test_immediately_invoked_closure_keeps_aliased_spawn_capture_alive() {
 	assert out == '42'
 }
 
+fn test_immediately_invoked_closure_keeps_side_effect_capture_escape_alive() {
+	v3_bin := build_v3_review_transform()
+	source := 'struct Registry {
+mut:
+	callbacks []fn () int
+}
+
+fn install(mut registry Registry, callback fn () int) {
+	registry.callbacks << callback
+}
+
+fn main() {
+	mut registry := &Registry{}
+	mut value := 42
+	(fn [mut registry, mut value] () {
+		install(mut registry, fn [mut value] () int {
+			return value
+		})
+	})()
+	println(int_str(registry.callbacks[0]()))
+}
+'
+	c_source := gen_c_from_source(v3_bin, 'immediate_closure_side_effect_escape_c', source)
+	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
+	println_pos := main_body.index('println') or { -1 }
+	destroy_pos := main_body.index('closure__closure_try_destroy(__immediate_closure_') or { -1 }
+	assert println_pos >= 0, main_body
+	assert destroy_pos > println_pos, main_body
+	out := run_good(v3_bin, 'immediate_closure_side_effect_escape', source)
+	assert out == '42'
+}
+
 fn test_disjoint_same_name_closure_bindings_are_reclaimed() {
 	v3_bin := build_v3_review_transform()
 	source := '@[heap]

--- a/vlib/v3/tests/review_transform_regressions_test.v
+++ b/vlib/v3/tests/review_transform_regressions_test.v
@@ -3005,6 +3005,43 @@ fn main() {
 	assert out == '42'
 }
 
+fn test_immediately_invoked_closure_keeps_projected_capture_escapes_alive() {
+	v3_bin := build_v3_review_transform()
+	source := 'struct PointerHolder {
+mut:
+	value &int
+}
+
+fn main() {
+	external := 0
+	mut holder := &PointerHolder{
+		value: unsafe { &external }
+	}
+	mut selector_value := 40
+	(fn [mut holder, mut selector_value] () {
+		holder.value = unsafe { &selector_value }
+	})()
+
+	mut pointers := [unsafe { &external }]!
+	mut index_value := 41
+	(fn [mut pointers, mut index_value] () {
+		pointers[0] = unsafe { &index_value }
+	})()
+
+	println(int_str(unsafe { *holder.value }))
+	println(int_str(unsafe { *pointers[0] }))
+}
+'
+	c_source := gen_c_from_source(v3_bin, 'immediate_closure_projected_escapes_c', source)
+	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
+	println_pos := main_body.last_index('println') or { -1 }
+	destroy_pos := main_body.index('closure__closure_try_destroy(__immediate_closure_') or { -1 }
+	assert println_pos >= 0, main_body
+	assert destroy_pos > println_pos, main_body
+	out := run_good(v3_bin, 'immediate_closure_projected_escapes', source)
+	assert out == '40\n41'
+}
+
 fn test_immediately_invoked_closure_keeps_channel_sent_capture_alive() {
 	v3_bin := build_v3_review_transform()
 	source := 'fn main() {

--- a/vlib/v3/tests/review_transform_regressions_test.v
+++ b/vlib/v3/tests/review_transform_regressions_test.v
@@ -2863,6 +2863,27 @@ fn test_immediately_invoked_closure_keeps_aliased_pointer_result_alive() {
 	assert out == '42'
 }
 
+fn test_immediately_invoked_closure_keeps_integer_encoded_capture_address_alive() {
+	v3_bin := build_v3_review_transform()
+	source := 'fn main() {
+	mut value := 41
+	address := (fn [mut value] () usize {
+		return usize(voidptr(&value))
+	})()
+	p := unsafe { &int(voidptr(address)) }
+	println(int_str(unsafe { *p + 1 }))
+}
+'
+	c_source := gen_c_from_source(v3_bin, 'immediate_closure_integer_capture_address_c', source)
+	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
+	deref_pos := main_body.index('*p') or { -1 }
+	destroy_pos := main_body.index('closure__closure_try_destroy(__immediate_closure_') or { -1 }
+	assert deref_pos >= 0, main_body
+	assert destroy_pos > deref_pos, main_body
+	out := run_good(v3_bin, 'immediate_closure_integer_capture_address', source)
+	assert out == '42'
+}
+
 fn test_immediately_invoked_closure_keeps_aliased_result_error_alive() {
 	v3_bin := build_v3_review_transform()
 	source := 'struct CaptureError {

--- a/vlib/v3/tests/review_transform_regressions_test.v
+++ b/vlib/v3/tests/review_transform_regressions_test.v
@@ -2884,6 +2884,28 @@ fn test_immediately_invoked_closure_keeps_integer_encoded_capture_address_alive(
 	assert out == '42'
 }
 
+fn test_immediately_invoked_closure_keeps_aliased_integer_capture_address_alive() {
+	v3_bin := build_v3_review_transform()
+	source := 'fn main() {
+	mut value := 41
+	address := (fn [mut value] () usize {
+		encoded := usize(voidptr(&value))
+		return encoded
+	})()
+	p := unsafe { &int(voidptr(address)) }
+	println(int_str(unsafe { *p + 1 }))
+}
+'
+	c_source := gen_c_from_source(v3_bin, 'immediate_closure_aliased_integer_capture_address_c', source)
+	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
+	deref_pos := main_body.index('*p') or { -1 }
+	destroy_pos := main_body.index('closure__closure_try_destroy(__immediate_closure_') or { -1 }
+	assert deref_pos >= 0, main_body
+	assert destroy_pos > deref_pos, main_body
+	out := run_good(v3_bin, 'immediate_closure_aliased_integer_capture_address', source)
+	assert out == '42'
+}
+
 fn test_immediately_invoked_closure_keeps_aliased_result_error_alive() {
 	v3_bin := build_v3_review_transform()
 	source := 'struct CaptureError {

--- a/vlib/v3/tests/review_transform_regressions_test.v
+++ b/vlib/v3/tests/review_transform_regressions_test.v
@@ -2855,6 +2855,20 @@ fn main() {
 	assert out == '42'
 }
 
+fn test_immediately_invoked_closure_keeps_aliased_slice_result_alive() {
+	v3_bin := build_v3_review_transform()
+	source := 'fn main() {
+	fixed := [3]int{41, 42, 43}
+	slice := (fn [fixed] () []int {
+		return fixed[..]
+	})()
+	println(slice)
+}
+'
+	out := run_good(v3_bin, 'immediate_closure_aliased_slice', source)
+	assert out == '[41, 42, 43]'
+}
+
 fn test_disjoint_same_name_closure_bindings_are_reclaimed() {
 	v3_bin := build_v3_review_transform()
 	source := '@[heap]

--- a/vlib/v3/tests/review_transform_regressions_test.v
+++ b/vlib/v3/tests/review_transform_regressions_test.v
@@ -2826,6 +2826,35 @@ fn test_immediately_invoked_closure_keeps_aliased_pointer_result_alive() {
 	assert out == '42'
 }
 
+fn test_immediately_invoked_closure_keeps_aliased_result_error_alive() {
+	v3_bin := build_v3_review_transform()
+	source := 'struct CaptureError {
+	ptr &int
+}
+
+fn (err CaptureError) msg() string {
+	return "capture error"
+}
+
+fn main() {
+	x := 41
+	value := (fn [x] () !int {
+		return CaptureError{
+			ptr: unsafe { &x }
+		}
+	})() or {
+		if err is CaptureError {
+			println(int_str(unsafe { *err.ptr + 1 }))
+		}
+		return
+	}
+	println(int_str(value))
+}
+'
+	out := run_good(v3_bin, 'immediate_closure_aliased_result_error', source)
+	assert out == '42'
+}
+
 fn test_disjoint_same_name_closure_bindings_are_reclaimed() {
 	v3_bin := build_v3_review_transform()
 	source := '@[heap]

--- a/vlib/v3/tests/review_transform_regressions_test.v
+++ b/vlib/v3/tests/review_transform_regressions_test.v
@@ -2806,6 +2806,43 @@ fn main() {
 	assert out == '1249975000'
 }
 
+fn test_immediately_invoked_bound_method_keeps_escaped_receiver_alive() {
+	v3_bin := build_v3_review_transform()
+	source := 'struct Registry {
+mut:
+	callbacks []fn () int
+}
+
+struct State {
+	value int
+}
+
+fn (state &State) install(registry &Registry) {
+	unsafe {
+		registry.callbacks << fn [state] () int {
+			return state.value
+		}
+	}
+}
+
+fn main() {
+	registry := &Registry{}
+	(State{
+		value: 42
+	}.install)(registry)
+	println(int_str(registry.callbacks[0]()))
+}
+'
+	c_source := gen_c_from_source(v3_bin, 'immediate_bound_method_escaped_receiver_c', source)
+	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
+	call_pos := main_body.index('println(int__str') or { -1 }
+	destroy_pos := main_body.index('closure__closure_try_destroy(__immediate_closure_') or { -1 }
+	assert call_pos >= 0, main_body
+	assert destroy_pos > call_pos, main_body
+	out := run_good(v3_bin, 'immediate_bound_method_escaped_receiver', source)
+	assert out == '42'
+}
+
 fn test_immediately_invoked_closure_keeps_aliased_pointer_result_alive() {
 	v3_bin := build_v3_review_transform()
 	source := 'fn main() {

--- a/vlib/v3/tests/review_transform_regressions_test.v
+++ b/vlib/v3/tests/review_transform_regressions_test.v
@@ -2913,6 +2913,29 @@ fn test_immediately_invoked_closure_keeps_spawned_nested_capture_alive() {
 	assert out == '42'
 }
 
+fn test_immediately_invoked_closure_keeps_aliased_spawn_capture_alive() {
+	v3_bin := build_v3_review_transform()
+	source := 'fn main() {
+	mut value := 42
+	worker := (fn [value] () thread int {
+		p := unsafe { &value }
+		return spawn fn [p] () int {
+			return unsafe { *p }
+		}()
+	})()
+	println(int_str(worker.wait()))
+}
+'
+	c_source := gen_c_from_source(v3_bin, 'immediate_closure_aliased_spawn_capture_c', source)
+	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
+	wait_pos := main_body.index('__v_thread_join') or { -1 }
+	destroy_pos := main_body.index('closure__closure_try_destroy(__immediate_closure_') or { -1 }
+	assert wait_pos >= 0, main_body
+	assert destroy_pos > wait_pos, main_body
+	out := run_good(v3_bin, 'immediate_closure_aliased_spawn_capture', source)
+	assert out == '42'
+}
+
 fn test_disjoint_same_name_closure_bindings_are_reclaimed() {
 	v3_bin := build_v3_review_transform()
 	source := '@[heap]

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -1407,10 +1407,11 @@ fn (t &Transformer) expr_may_escape_any_named_capture(id flat.NodeId, captures m
 		return false
 	}
 	node := t.a.nodes[int(id)]
-	// Calls can retain arguments in external storage, and assignments can project a
-	// capture-derived value into storage outside the immediate closure. Conservatively
-	// keep the context through the enclosing scope for either escape boundary.
-	if node.kind in [.call, .spawn_expr] && t.expr_mentions_any_name(id, captures) {
+	// Calls and channel sends can retain values outside the immediate closure, and
+	// assignments can project a capture-derived value into external storage.
+	// Conservatively keep the context through the enclosing scope at these boundaries.
+	if (node.kind in [.call, .spawn_expr] || (node.kind == .infix && node.op == .arrow))
+		&& t.expr_mentions_any_name(id, captures) {
 		return true
 	}
 	if node.kind == .assign && node.children_count >= 2 {

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -1390,7 +1390,7 @@ fn (t &Transformer) closure_result_type_may_alias_capture(typ types.Type, mut se
 			} else {
 				seen[typ.name] = true
 				mut may_alias := false
-				for variant in t.tc.sum_types[typ.name] or { []string{} } {
+				for variant in t.concrete_sum_variants_for_candidate(typ.name) {
 					if t.closure_result_type_may_alias_capture(t.tc.parse_type(variant), mut seen) {
 						may_alias = true
 						break

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -1375,7 +1375,7 @@ fn (t &Transformer) closure_result_type_may_alias_capture(typ types.Type, mut se
 			} else {
 				seen[typ.name] = true
 				mut may_alias := false
-				for field in t.tc.structs[typ.name] or { []types.StructField{} } {
+				for field in t.tc.struct_fields_for_type(typ.name) {
 					if t.closure_result_type_may_alias_capture(field.typ, mut seen) {
 						may_alias = true
 						break

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -1356,15 +1356,52 @@ fn (t &Transformer) immediate_fn_literal_spawns_capture(id flat.NodeId) bool {
 	if captures.len == 0 {
 		return false
 	}
+	mut capture_aliases := captures.clone()
+	for {
+		alias_count := capture_aliases.len
+		for i in 0 .. node.children_count {
+			child_id := t.a.child(&node, i)
+			child := t.a.nodes[int(child_id)]
+			if child.kind !in [.ident, .param] {
+				t.collect_capture_derived_names(child_id, mut capture_aliases)
+			}
+		}
+		if capture_aliases.len == alias_count {
+			break
+		}
+	}
 	for i in 0 .. node.children_count {
 		child_id := t.a.child(&node, i)
 		child := t.a.nodes[int(child_id)]
-		if child.kind !in [.ident, .param]
-			&& t.expr_spawns_any_named_capture(child_id, captures) {
+		if child.kind !in [.ident, .param] && t.expr_spawns_any_named_capture(child_id, capture_aliases) {
 			return true
 		}
 	}
 	return false
+}
+
+fn (t &Transformer) collect_capture_derived_names(id flat.NodeId, mut names map[string]bool) {
+	if int(id) < 0 || int(id) >= t.a.nodes.len {
+		return
+	}
+	node := t.a.nodes[int(id)]
+	if node.kind in [.fn_literal, .lambda_expr, .fn_decl] {
+		return
+	}
+	if node.kind in [.decl_assign, .assign] && node.children_count >= 2 {
+		mut i := 0
+		for i + 1 < node.children_count {
+			lhs := t.a.child_node(&node, i)
+			rhs_id := t.a.child(&node, i + 1)
+			if lhs.kind == .ident && lhs.value.len > 0 && t.expr_mentions_any_name(rhs_id, names) {
+				names[lhs.value] = true
+			}
+			i += 2
+		}
+	}
+	for i in 0 .. node.children_count {
+		t.collect_capture_derived_names(t.a.child(&node, i), mut names)
+	}
 }
 
 fn (t &Transformer) expr_spawns_any_named_capture(id flat.NodeId, captures map[string]bool) bool {

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -1338,7 +1338,8 @@ fn (t &Transformer) immediate_closure_result_may_alias_capture(type_name string)
 	}
 	if isnil(t.tc) {
 		clean := t.normalize_type_alias(type_name)
-		return clean.starts_with('&') || clean in ['voidptr', 'byteptr', 'charptr']
+		return clean.starts_with('!') || clean.starts_with('&')
+			|| clean in ['voidptr', 'byteptr', 'charptr']
 	}
 	mut seen := map[string]bool{}
 	return t.closure_result_type_may_alias_capture(t.tc.parse_type(type_name), mut seen)
@@ -1354,7 +1355,9 @@ fn (t &Transformer) closure_result_type_may_alias_capture(typ types.Type, mut se
 			t.closure_result_type_may_alias_capture(typ.base_type, mut seen)
 		}
 		types.ResultType {
-			t.closure_result_type_may_alias_capture(typ.base_type, mut seen)
+			// A custom IError implementation can retain a pointer into the capture even
+			// when the successful payload is scalar.
+			true
 		}
 		types.Array {
 			t.closure_result_type_may_alias_capture(typ.elem_type, mut seen)

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -1095,6 +1095,7 @@ fn (mut t Transformer) transform_call_args(id flat.NodeId, node flat.Node) flat.
 	immediate_fresh_closure := immediate_bound_method || t.call_returns_exclusive_closure(callee_id)
 	mut immediate_closure_type := ''
 	mut immediate_closure_cleanup := ''
+	immediate_closure_spawns_capture := t.immediate_fn_literal_spawns_capture(callee_id)
 	if immediate_fresh_closure {
 		immediate_closure_type = t.fresh_runtime_closure_type(callee_id) or { '' }
 		if immediate_closure_type.len > 0 {
@@ -1272,7 +1273,8 @@ fn (mut t Transformer) transform_call_args(id flat.NodeId, node flat.Node) flat.
 		if typ != t.a.nodes[int(id)].typ {
 			t.set_node_typ(int(id), typ)
 		}
-		return t.finish_immediate_closure_call(id, immediate_closure_cleanup, typ)
+		return t.finish_immediate_closure_call(id, immediate_closure_cleanup, typ,
+			immediate_closure_spawns_capture)
 	}
 	start := t.a.children.len
 	for nc in new_children {
@@ -1307,14 +1309,15 @@ fn (mut t Transformer) transform_call_args(id flat.NodeId, node flat.Node) flat.
 			args:     cached_args
 		}
 	}
-	return t.finish_immediate_closure_call(new_id, immediate_closure_cleanup, typ)
+	return t.finish_immediate_closure_call(new_id, immediate_closure_cleanup, typ,
+		immediate_closure_spawns_capture)
 }
 
-fn (mut t Transformer) finish_immediate_closure_call(call_id flat.NodeId, closure_name string, typ string) flat.NodeId {
+fn (mut t Transformer) finish_immediate_closure_call(call_id flat.NodeId, closure_name string, typ string, spawns_capture bool) flat.NodeId {
 	if closure_name.len == 0 {
 		return call_id
 	}
-	if t.immediate_closure_result_may_alias_capture(typ) {
+	if spawns_capture || t.immediate_closure_result_may_alias_capture(typ) {
 		t.pending_stmts << t.make_local_closure_cleanup_defer(closure_name)
 		return call_id
 	}
@@ -1330,6 +1333,70 @@ fn (mut t Transformer) finish_immediate_closure_call(call_id flat.NodeId, closur
 	result := t.make_ident(result_name)
 	t.set_node_typ(int(result), typ)
 	return result
+}
+
+fn (t &Transformer) immediate_fn_literal_spawns_capture(id flat.NodeId) bool {
+	if int(id) < 0 || int(id) >= t.a.nodes.len {
+		return false
+	}
+	node := t.a.nodes[int(id)]
+	if node.kind in [.paren, .cast_expr] && node.children_count == 1 {
+		return t.immediate_fn_literal_spawns_capture(t.a.child(&node, 0))
+	}
+	if node.kind != .fn_literal {
+		return false
+	}
+	mut captures := map[string]bool{}
+	for i in 0 .. node.children_count {
+		child := t.a.child_node(&node, i)
+		if child.kind == .ident && child.value.len > 0 && child.value !in t.active_generic_params {
+			captures[child.value] = true
+		}
+	}
+	if captures.len == 0 {
+		return false
+	}
+	for i in 0 .. node.children_count {
+		child_id := t.a.child(&node, i)
+		child := t.a.nodes[int(child_id)]
+		if child.kind !in [.ident, .param]
+			&& t.expr_spawns_any_named_capture(child_id, captures) {
+			return true
+		}
+	}
+	return false
+}
+
+fn (t &Transformer) expr_spawns_any_named_capture(id flat.NodeId, captures map[string]bool) bool {
+	if int(id) < 0 || int(id) >= t.a.nodes.len {
+		return false
+	}
+	node := t.a.nodes[int(id)]
+	if node.kind == .spawn_expr && t.expr_mentions_any_name(id, captures) {
+		return true
+	}
+	for i in 0 .. node.children_count {
+		if t.expr_spawns_any_named_capture(t.a.child(&node, i), captures) {
+			return true
+		}
+	}
+	return false
+}
+
+fn (t &Transformer) expr_mentions_any_name(id flat.NodeId, names map[string]bool) bool {
+	if int(id) < 0 || int(id) >= t.a.nodes.len {
+		return false
+	}
+	node := t.a.nodes[int(id)]
+	if node.kind == .ident && node.value in names {
+		return true
+	}
+	for i in 0 .. node.children_count {
+		if t.expr_mentions_any_name(t.a.child(&node, i), names) {
+			return true
+		}
+	}
+	return false
 }
 
 fn (t &Transformer) immediate_closure_result_may_alias_capture(type_name string) bool {

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -1095,7 +1095,7 @@ fn (mut t Transformer) transform_call_args(id flat.NodeId, node flat.Node) flat.
 	immediate_fresh_closure := immediate_bound_method || t.call_returns_exclusive_closure(callee_id)
 	mut immediate_closure_type := ''
 	mut immediate_closure_cleanup := ''
-	immediate_closure_spawns_capture := t.immediate_fn_literal_spawns_capture(callee_id)
+	immediate_closure_capture_may_escape := t.immediate_fn_literal_capture_may_escape(callee_id)
 	if immediate_fresh_closure {
 		immediate_closure_type = t.fresh_runtime_closure_type(callee_id) or { '' }
 		if immediate_closure_type.len > 0 {
@@ -1273,8 +1273,7 @@ fn (mut t Transformer) transform_call_args(id flat.NodeId, node flat.Node) flat.
 		if typ != t.a.nodes[int(id)].typ {
 			t.set_node_typ(int(id), typ)
 		}
-		return t.finish_immediate_closure_call(id, immediate_closure_cleanup, typ,
-			immediate_closure_spawns_capture)
+		return t.finish_immediate_closure_call(id, immediate_closure_cleanup, typ, immediate_closure_capture_may_escape)
 	}
 	start := t.a.children.len
 	for nc in new_children {
@@ -1309,15 +1308,14 @@ fn (mut t Transformer) transform_call_args(id flat.NodeId, node flat.Node) flat.
 			args:     cached_args
 		}
 	}
-	return t.finish_immediate_closure_call(new_id, immediate_closure_cleanup, typ,
-		immediate_closure_spawns_capture)
+	return t.finish_immediate_closure_call(new_id, immediate_closure_cleanup, typ, immediate_closure_capture_may_escape)
 }
 
-fn (mut t Transformer) finish_immediate_closure_call(call_id flat.NodeId, closure_name string, typ string, spawns_capture bool) flat.NodeId {
+fn (mut t Transformer) finish_immediate_closure_call(call_id flat.NodeId, closure_name string, typ string, capture_may_escape bool) flat.NodeId {
 	if closure_name.len == 0 {
 		return call_id
 	}
-	if spawns_capture || t.immediate_closure_result_may_alias_capture(typ) {
+	if capture_may_escape || t.immediate_closure_result_may_alias_capture(typ) {
 		t.pending_stmts << t.make_local_closure_cleanup_defer(closure_name)
 		return call_id
 	}
@@ -1335,13 +1333,13 @@ fn (mut t Transformer) finish_immediate_closure_call(call_id flat.NodeId, closur
 	return result
 }
 
-fn (t &Transformer) immediate_fn_literal_spawns_capture(id flat.NodeId) bool {
+fn (t &Transformer) immediate_fn_literal_capture_may_escape(id flat.NodeId) bool {
 	if int(id) < 0 || int(id) >= t.a.nodes.len {
 		return false
 	}
 	node := t.a.nodes[int(id)]
 	if node.kind in [.paren, .cast_expr] && node.children_count == 1 {
-		return t.immediate_fn_literal_spawns_capture(t.a.child(&node, 0))
+		return t.immediate_fn_literal_capture_may_escape(t.a.child(&node, 0))
 	}
 	if node.kind != .fn_literal {
 		return false
@@ -1373,7 +1371,7 @@ fn (t &Transformer) immediate_fn_literal_spawns_capture(id flat.NodeId) bool {
 	for i in 0 .. node.children_count {
 		child_id := t.a.child(&node, i)
 		child := t.a.nodes[int(child_id)]
-		if child.kind !in [.ident, .param] && t.expr_spawns_any_named_capture(child_id, capture_aliases) {
+		if child.kind !in [.ident, .param] && t.expr_may_escape_any_named_capture(child_id, capture_aliases) {
 			return true
 		}
 	}
@@ -1404,16 +1402,26 @@ fn (t &Transformer) collect_capture_derived_names(id flat.NodeId, mut names map[
 	}
 }
 
-fn (t &Transformer) expr_spawns_any_named_capture(id flat.NodeId, captures map[string]bool) bool {
+fn (t &Transformer) expr_may_escape_any_named_capture(id flat.NodeId, captures map[string]bool) bool {
 	if int(id) < 0 || int(id) >= t.a.nodes.len {
 		return false
 	}
 	node := t.a.nodes[int(id)]
-	if node.kind == .spawn_expr && t.expr_mentions_any_name(id, captures) {
+	// Calls can retain arguments in external storage, and assignments can project a
+	// capture-derived value into storage outside the immediate closure. Conservatively
+	// keep the context through the enclosing scope for either escape boundary.
+	if node.kind in [.call, .spawn_expr] && t.expr_mentions_any_name(id, captures) {
 		return true
 	}
+	if node.kind == .assign && node.children_count >= 2 {
+		for i := 1; i < node.children_count; i += 2 {
+			if t.expr_mentions_any_name(t.a.child(&node, i), captures) {
+				return true
+			}
+		}
+	}
 	for i in 0 .. node.children_count {
-		if t.expr_spawns_any_named_capture(t.a.child(&node, i), captures) {
+		if t.expr_may_escape_any_named_capture(t.a.child(&node, i), captures) {
 			return true
 		}
 	}

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -1314,6 +1314,10 @@ fn (mut t Transformer) finish_immediate_closure_call(call_id flat.NodeId, closur
 	if closure_name.len == 0 {
 		return call_id
 	}
+	if t.immediate_closure_result_may_alias_capture(typ) {
+		t.pending_stmts << t.make_local_closure_cleanup_defer(closure_name)
+		return call_id
+	}
 	if typ.len == 0 || typ == 'void' {
 		t.pending_stmts << t.make_expr_stmt(call_id)
 		t.pending_stmts << t.make_local_closure_destroy_stmt(closure_name)
@@ -1326,6 +1330,88 @@ fn (mut t Transformer) finish_immediate_closure_call(call_id flat.NodeId, closur
 	result := t.make_ident(result_name)
 	t.set_node_typ(int(result), typ)
 	return result
+}
+
+fn (t &Transformer) immediate_closure_result_may_alias_capture(type_name string) bool {
+	if type_name.len == 0 {
+		return false
+	}
+	if isnil(t.tc) {
+		clean := t.normalize_type_alias(type_name)
+		return clean.starts_with('&') || clean in ['voidptr', 'byteptr', 'charptr']
+	}
+	mut seen := map[string]bool{}
+	return t.closure_result_type_may_alias_capture(t.tc.parse_type(type_name), mut seen)
+}
+
+fn (t &Transformer) closure_result_type_may_alias_capture(typ types.Type, mut seen map[string]bool) bool {
+	return match typ {
+		types.Pointer { true }
+		types.Alias {
+			t.closure_result_type_may_alias_capture(typ.base_type, mut seen)
+		}
+		types.OptionType {
+			t.closure_result_type_may_alias_capture(typ.base_type, mut seen)
+		}
+		types.ResultType {
+			t.closure_result_type_may_alias_capture(typ.base_type, mut seen)
+		}
+		types.Array {
+			t.closure_result_type_may_alias_capture(typ.elem_type, mut seen)
+		}
+		types.ArrayFixed {
+			t.closure_result_type_may_alias_capture(typ.elem_type, mut seen)
+		}
+		types.Channel {
+			t.closure_result_type_may_alias_capture(typ.elem_type, mut seen)
+		}
+		types.Map {
+			t.closure_result_type_may_alias_capture(typ.key_type, mut seen)
+				|| t.closure_result_type_may_alias_capture(typ.value_type, mut seen)
+		}
+		types.Struct {
+			if typ.name in seen {
+				false
+			} else {
+				seen[typ.name] = true
+				mut may_alias := false
+				for field in t.tc.structs[typ.name] or { []types.StructField{} } {
+					if t.closure_result_type_may_alias_capture(field.typ, mut seen) {
+						may_alias = true
+						break
+					}
+				}
+				may_alias
+			}
+		}
+		types.SumType {
+			if typ.name in seen {
+				false
+			} else {
+				seen[typ.name] = true
+				mut may_alias := false
+				for variant in t.tc.sum_types[typ.name] or { []string{} } {
+					if t.closure_result_type_may_alias_capture(t.tc.parse_type(variant), mut seen) {
+						may_alias = true
+						break
+					}
+				}
+				may_alias
+			}
+		}
+		types.MultiReturn {
+			mut may_alias := false
+			for item in typ.types {
+				if t.closure_result_type_may_alias_capture(item, mut seen) {
+					may_alias = true
+					break
+				}
+			}
+			may_alias
+		}
+		types.FnType, types.Interface { true }
+		else { false }
+	}
 }
 
 fn (mut t Transformer) transform_cgen_json_encode_call(id flat.NodeId, node flat.Node) flat.NodeId {

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -1339,6 +1339,7 @@ fn (t &Transformer) immediate_closure_result_may_alias_capture(type_name string)
 	if isnil(t.tc) {
 		clean := t.normalize_type_alias(type_name)
 		return clean.starts_with('!') || clean.starts_with('&')
+			|| clean.starts_with('[]') || clean.starts_with('map[') || clean.starts_with('chan ')
 			|| clean in ['voidptr', 'byteptr', 'charptr']
 	}
 	mut seen := map[string]bool{}
@@ -1359,18 +1360,9 @@ fn (t &Transformer) closure_result_type_may_alias_capture(typ types.Type, mut se
 			// when the successful payload is scalar.
 			true
 		}
-		types.Array {
-			t.closure_result_type_may_alias_capture(typ.elem_type, mut seen)
-		}
+		types.Array, types.Channel, types.Map { true }
 		types.ArrayFixed {
 			t.closure_result_type_may_alias_capture(typ.elem_type, mut seen)
-		}
-		types.Channel {
-			t.closure_result_type_may_alias_capture(typ.elem_type, mut seen)
-		}
-		types.Map {
-			t.closure_result_type_may_alias_capture(typ.key_type, mut seen)
-				|| t.closure_result_type_may_alias_capture(typ.value_type, mut seen)
 		}
 		types.Struct {
 			if typ.name in seen {

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -1092,10 +1092,11 @@ fn (mut t Transformer) transform_call_args(id flat.NodeId, node flat.Node) flat.
 	t.in_call_callee = true
 	callee_id := t.a.children[node.children_start]
 	immediate_bound_method := t.immediate_bound_method_value_allocates_runtime_closure(callee_id)
-	immediate_fresh_closure := immediate_bound_method || t.call_returns_exclusive_closure(callee_id)
+	immediate_factory_closure := t.call_returns_exclusive_closure(callee_id)
+	immediate_fresh_closure := immediate_bound_method || immediate_factory_closure
 	mut immediate_closure_type := ''
 	mut immediate_closure_cleanup := ''
-	immediate_closure_capture_may_escape := immediate_bound_method || t.immediate_fn_literal_capture_may_escape(callee_id)
+	immediate_closure_capture_may_escape := immediate_bound_method || immediate_factory_closure || t.immediate_fn_literal_capture_may_escape(callee_id)
 	if immediate_fresh_closure {
 		immediate_closure_type = t.fresh_runtime_closure_type(callee_id) or { '' }
 		if immediate_closure_type.len > 0 {

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -1440,8 +1440,11 @@ fn (t &Transformer) immediate_closure_result_may_alias_capture(type_name string)
 	if type_name.len == 0 {
 		return false
 	}
+	clean := t.normalize_type_alias(type_name)
+	if clean == 'thread' || clean.starts_with('thread ') {
+		return true
+	}
 	if isnil(t.tc) {
-		clean := t.normalize_type_alias(type_name)
 		return clean == 'string' || clean.starts_with('!') || clean.starts_with('?')
 			|| clean.starts_with('&')
 			|| clean.starts_with('[]') || clean.starts_with('map[') || clean.starts_with('chan ')
@@ -1452,6 +1455,10 @@ fn (t &Transformer) immediate_closure_result_may_alias_capture(type_name string)
 }
 
 fn (t &Transformer) closure_result_type_may_alias_capture(typ types.Type, mut seen map[string]bool) bool {
+	type_name := typ.name()
+	if type_name == 'thread' || type_name.starts_with('thread ') {
+		return true
+	}
 	return match typ {
 		types.Pointer { true }
 		types.Alias {

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -1369,10 +1369,24 @@ fn (t &Transformer) immediate_fn_literal_capture_may_escape(id flat.NodeId) bool
 			break
 		}
 	}
+	mut capture_address_aliases := map[string]bool{}
+	for {
+		alias_count := capture_address_aliases.len
+		for i in 0 .. node.children_count {
+			child_id := t.a.child(&node, i)
+			child := t.a.nodes[int(child_id)]
+			if child.kind !in [.ident, .param] {
+				t.collect_capture_address_derived_names(child_id, capture_aliases, mut capture_address_aliases)
+			}
+		}
+		if capture_address_aliases.len == alias_count {
+			break
+		}
+	}
 	for i in 0 .. node.children_count {
 		child_id := t.a.child(&node, i)
 		child := t.a.nodes[int(child_id)]
-		if child.kind !in [.ident, .param] && t.expr_may_escape_any_named_capture(child_id, capture_aliases) {
+		if child.kind !in [.ident, .param] && t.expr_may_escape_any_named_capture(child_id, capture_aliases, capture_address_aliases) {
 			return true
 		}
 	}
@@ -1403,7 +1417,40 @@ fn (t &Transformer) collect_capture_derived_names(id flat.NodeId, mut names map[
 	}
 }
 
-fn (t &Transformer) expr_may_escape_any_named_capture(id flat.NodeId, captures map[string]bool) bool {
+fn (t &Transformer) collect_capture_address_derived_names(id flat.NodeId, captures map[string]bool, mut address_names map[string]bool) {
+	if int(id) < 0 || int(id) >= t.a.nodes.len {
+		return
+	}
+	node := t.a.nodes[int(id)]
+	if node.kind in [.fn_literal, .lambda_expr, .fn_decl] {
+		return
+	}
+	if node.kind in [.decl_assign, .assign] && node.children_count >= 2 {
+		mut i := 0
+		for i + 1 < node.children_count {
+			lhs := t.a.child_node(&node, i)
+			rhs_id := t.a.child(&node, i + 1)
+			mut derives_from_address := t.expr_mentions_any_name(rhs_id, address_names)
+			if !derives_from_address {
+				for name, _ in captures {
+					if t.fn_literal_expr_takes_address_of_capture(rhs_id, name) {
+						derives_from_address = true
+						break
+					}
+				}
+			}
+			if lhs.kind == .ident && lhs.value.len > 0 && derives_from_address {
+				address_names[lhs.value] = true
+			}
+			i += 2
+		}
+	}
+	for i in 0 .. node.children_count {
+		t.collect_capture_address_derived_names(t.a.child(&node, i), captures, mut address_names)
+	}
+}
+
+fn (t &Transformer) expr_may_escape_any_named_capture(id flat.NodeId, captures map[string]bool, capture_address_aliases map[string]bool) bool {
 	if int(id) < 0 || int(id) >= t.a.nodes.len {
 		return false
 	}
@@ -1416,6 +1463,9 @@ fn (t &Transformer) expr_may_escape_any_named_capture(id flat.NodeId, captures m
 		return true
 	}
 	if node.kind == .return_stmt {
+		if t.expr_mentions_any_name(id, capture_address_aliases) {
+			return true
+		}
 		for name, _ in captures {
 			if t.fn_literal_expr_takes_address_of_capture(id, name) {
 				return true
@@ -1430,7 +1480,7 @@ fn (t &Transformer) expr_may_escape_any_named_capture(id flat.NodeId, captures m
 		}
 	}
 	for i in 0 .. node.children_count {
-		if t.expr_may_escape_any_named_capture(t.a.child(&node, i), captures) {
+		if t.expr_may_escape_any_named_capture(t.a.child(&node, i), captures, capture_address_aliases) {
 			return true
 		}
 	}

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -1414,6 +1414,13 @@ fn (t &Transformer) expr_may_escape_any_named_capture(id flat.NodeId, captures m
 		&& t.expr_mentions_any_name(id, captures) {
 		return true
 	}
+	if node.kind == .return_stmt {
+		for name, _ in captures {
+			if t.fn_literal_expr_takes_address_of_capture(id, name) {
+				return true
+			}
+		}
+	}
 	if node.kind in [.assign, .selector_assign, .index_assign] && node.children_count >= 2 {
 		for i := 1; i < node.children_count; i += 2 {
 			if t.expr_mentions_any_name(t.a.child(&node, i), captures) {

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -1094,6 +1094,7 @@ fn (mut t Transformer) transform_call_args(id flat.NodeId, node flat.Node) flat.
 	immediate_bound_method := t.immediate_bound_method_value_allocates_runtime_closure(callee_id)
 	immediate_fresh_closure := immediate_bound_method || t.call_returns_exclusive_closure(callee_id)
 	mut immediate_closure_type := ''
+	mut immediate_closure_cleanup := ''
 	if immediate_fresh_closure {
 		immediate_closure_type = t.fresh_runtime_closure_type(callee_id) or { '' }
 		if immediate_closure_type.len > 0 {
@@ -1137,7 +1138,7 @@ fn (mut t Transformer) transform_call_args(id flat.NodeId, node flat.Node) flat.
 				// has invoked it.
 				t.mark_fn_used_name('closure.closure_try_destroy')
 			} else {
-				t.pending_stmts << t.make_local_closure_cleanup_defer(closure_name)
+				immediate_closure_cleanup = closure_name
 			}
 			transformed_callee = t.make_ident(closure_name)
 			t.set_node_typ(int(transformed_callee), closure_type)
@@ -1264,12 +1265,14 @@ fn (mut t Transformer) transform_call_args(id flat.NodeId, node flat.Node) flat.
 	concrete_ret := t.concrete_generic_call_return_type(id, node)
 	if concrete_ret.len > 0 {
 		typ = concrete_ret
+	} else if typ.len == 0 && immediate_closure_type.len > 0 {
+		typ = fn_type_return_type_text(immediate_closure_type) or { '' }
 	}
 	if t.rewrite_children_in_place(id, new_children) {
 		if typ != t.a.nodes[int(id)].typ {
 			t.set_node_typ(int(id), typ)
 		}
-		return id
+		return t.finish_immediate_closure_call(id, immediate_closure_cleanup, typ)
 	}
 	start := t.a.children.len
 	for nc in new_children {
@@ -1304,7 +1307,25 @@ fn (mut t Transformer) transform_call_args(id flat.NodeId, node flat.Node) flat.
 			args:     cached_args
 		}
 	}
-	return new_id
+	return t.finish_immediate_closure_call(new_id, immediate_closure_cleanup, typ)
+}
+
+fn (mut t Transformer) finish_immediate_closure_call(call_id flat.NodeId, closure_name string, typ string) flat.NodeId {
+	if closure_name.len == 0 {
+		return call_id
+	}
+	if typ.len == 0 || typ == 'void' {
+		t.pending_stmts << t.make_expr_stmt(call_id)
+		t.pending_stmts << t.make_local_closure_destroy_stmt(closure_name)
+		return t.make_int_literal(0)
+	}
+	result_name := t.new_temp('immediate_closure_result')
+	t.set_var_type(result_name, typ)
+	t.pending_stmts << t.make_decl_assign_typed(result_name, call_id, typ)
+	t.pending_stmts << t.make_local_closure_destroy_stmt(closure_name)
+	result := t.make_ident(result_name)
+	t.set_node_typ(int(result), typ)
+	return result
 }
 
 fn (mut t Transformer) transform_cgen_json_encode_call(id flat.NodeId, node flat.Node) flat.NodeId {
@@ -6067,6 +6088,15 @@ fn (t &Transformer) generic_aggregate_base_exists(base string, arg_count int) bo
 	}
 	if params := t.tc.sum_generic_params[base] {
 		return params.len == arg_count
+	}
+	if base.starts_with('main.') {
+		short := base['main.'.len..]
+		if params := t.tc.struct_generic_params[short] {
+			return params.len == arg_count
+		}
+		if params := t.tc.sum_generic_params[short] {
+			return params.len == arg_count
+		}
 	}
 	if !base.contains('.') && t.cur_module.len > 0 && t.cur_module != 'main'
 		&& t.cur_module != 'builtin' {

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -1095,7 +1095,7 @@ fn (mut t Transformer) transform_call_args(id flat.NodeId, node flat.Node) flat.
 	immediate_fresh_closure := immediate_bound_method || t.call_returns_exclusive_closure(callee_id)
 	mut immediate_closure_type := ''
 	mut immediate_closure_cleanup := ''
-	immediate_closure_capture_may_escape := t.immediate_fn_literal_capture_may_escape(callee_id)
+	immediate_closure_capture_may_escape := immediate_bound_method || t.immediate_fn_literal_capture_may_escape(callee_id)
 	if immediate_fresh_closure {
 		immediate_closure_type = t.fresh_runtime_closure_type(callee_id) or { '' }
 		if immediate_closure_type.len > 0 {

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -1414,7 +1414,7 @@ fn (t &Transformer) expr_may_escape_any_named_capture(id flat.NodeId, captures m
 		&& t.expr_mentions_any_name(id, captures) {
 		return true
 	}
-	if node.kind == .assign && node.children_count >= 2 {
+	if node.kind in [.assign, .selector_assign, .index_assign] && node.children_count >= 2 {
 		for i := 1; i < node.children_count; i += 2 {
 			if t.expr_mentions_any_name(t.a.child(&node, i), captures) {
 				return true

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -1338,7 +1338,8 @@ fn (t &Transformer) immediate_closure_result_may_alias_capture(type_name string)
 	}
 	if isnil(t.tc) {
 		clean := t.normalize_type_alias(type_name)
-		return clean.starts_with('!') || clean.starts_with('&')
+		return clean == 'string' || clean.starts_with('!') || clean.starts_with('?')
+			|| clean.starts_with('&')
 			|| clean.starts_with('[]') || clean.starts_with('map[') || clean.starts_with('chan ')
 			|| clean in ['voidptr', 'byteptr', 'charptr']
 	}
@@ -1360,7 +1361,7 @@ fn (t &Transformer) closure_result_type_may_alias_capture(typ types.Type, mut se
 			// when the successful payload is scalar.
 			true
 		}
-		types.Array, types.Channel, types.Map { true }
+		types.String, types.Array, types.Channel, types.Map { true }
 		types.ArrayFixed {
 			t.closure_result_type_may_alias_capture(typ.elem_type, mut seen)
 		}
@@ -10014,9 +10015,48 @@ fn (mut t Transformer) try_lower_move_method_call(call_id flat.NodeId, node flat
 	return none
 }
 
+fn (t &Transformer) fn_literal_expr_takes_address_of_capture(id flat.NodeId, name string) bool {
+	if int(id) < 0 || int(id) >= t.a.nodes.len || name.len == 0 {
+		return false
+	}
+	node := t.a.nodes[int(id)]
+	if node.kind == .prefix && node.op == .amp && node.children_count > 0
+		&& t.fn_literal_lvalue_is_rooted_at_capture(t.a.child(&node, 0), name) {
+		return true
+	}
+	for i in 0 .. node.children_count {
+		if t.fn_literal_expr_takes_address_of_capture(t.a.child(&node, i), name) {
+			return true
+		}
+	}
+	return false
+}
+
+fn (t &Transformer) fn_literal_lvalue_is_rooted_at_capture(id flat.NodeId, name string) bool {
+	if int(id) < 0 || int(id) >= t.a.nodes.len {
+		return false
+	}
+	node := t.a.nodes[int(id)]
+	if node.kind == .ident {
+		return node.value == name
+	}
+	if node.kind in [.selector, .index, .paren] && node.children_count > 0 {
+		return t.fn_literal_lvalue_is_rooted_at_capture(t.a.child(&node, 0), name)
+	}
+	return false
+}
+
 // lift_fn_literal supports lift fn literal handling for Transformer.
 fn (mut t Transformer) lift_fn_literal(_id flat.NodeId, node flat.Node) flat.NodeId {
 	name := t.new_fn_literal_name()
+	// A checked literal can carry its complete function-value type here; the
+	// synthesized declaration itself needs only that signature's return type.
+	ret_type := if node.typ.len > 0 {
+		fn_type_return_type_text(node.typ) or { node.typ }
+	} else {
+		'void'
+	}
+	result_may_alias_capture := t.immediate_closure_result_may_alias_capture(ret_type)
 	mut param_types := []types.Type{}
 	mut param_type_texts := []string{}
 	mut param_ids := []flat.NodeId{}
@@ -10025,6 +10065,7 @@ fn (mut t Transformer) lift_fn_literal(_id flat.NodeId, node flat.Node) flat.Nod
 	mut capture_types := map[string]string{}
 	mut context_field_types := map[string]string{}
 	mut capture_by_ref := map[string]bool{}
+	mut capture_from_context := map[string]bool{}
 	mut capture_from_heap := map[string]bool{}
 	mut body_ids := []flat.NodeId{}
 	for i in 0 .. node.children_count {
@@ -10104,7 +10145,27 @@ fn (mut t Transformer) lift_fn_literal(_id flat.NodeId, node flat.Node) flat.Nod
 			body_ids << child_id
 		}
 	}
-	ret_type := if node.typ.len > 0 { node.typ } else { 'void' }
+	if result_may_alias_capture {
+		for capture_name in capture_names {
+			capture_type := capture_types[capture_name] or { continue }
+			if capture_by_ref[capture_name] or { false } || capture_type.starts_with('&') {
+				continue
+			}
+			mut aliases_capture := t.is_fixed_array_type(capture_type)
+			if !aliases_capture {
+				for body_id in body_ids {
+					if t.fn_literal_expr_takes_address_of_capture(body_id, capture_name) {
+						aliases_capture = true
+						break
+					}
+				}
+			}
+			if aliases_capture {
+				capture_types[capture_name] = '&${capture_type}'
+				capture_from_context[capture_name] = true
+			}
+		}
+	}
 	file_module := t.current_source_module()
 	generated_module := if file_module.len > 0 { file_module } else { 'main' }
 	context_type := '${name}_Ctx'
@@ -10153,14 +10214,15 @@ fn (mut t Transformer) lift_fn_literal(_id flat.NodeId, node flat.Node) flat.Nod
 		}
 		capture_type := capture_types[capture_name] or { continue }
 		is_ref_capture := capture_by_ref[capture_name] or { false }
+		is_context_capture := capture_from_context[capture_name] or { false }
 		t.set_var_type(capture_name, capture_type)
-		// Only captures that were rewritten into a synthetic `&T` pointer-value local
-		// (`capture_by_ref`) need pointer-value lvalue/rvalue lowering. A mut capture
-		// whose original type is already a pointer (`&S`) stays a genuine `&S` local:
+		// Captures rewritten into synthetic `&T` pointer-value locals need pointer-value
+		// lvalue/rvalue lowering. A mut capture whose original type is already a pointer
+		// (`&S`) stays a genuine `&S` local:
 		// dereferencing its rvalue uses would corrupt `&S` -> `S` and break calls that
 		// expect the pointer (e.g. `takes_ptr(p)`), and its assignments must not become
 		// `*p = ...`.
-		if is_ref_capture {
+		if is_ref_capture || is_context_capture {
 			saved_capture_pointer_flags[capture_name] = t.pointer_value_lvalues[capture_name] or {
 				false
 			}
@@ -10174,7 +10236,7 @@ fn (mut t Transformer) lift_fn_literal(_id flat.NodeId, node flat.Node) flat.Nod
 		t.set_node_typ(int(context_ident), '&${context_type}')
 		context_field_type := context_field_types[capture_name] or { capture_type }
 		mut capture_decl_rhs := t.make_selector(context_ident, capture_name, context_field_type)
-		if is_ref_capture && !context_field_type.starts_with('&') {
+		if (is_ref_capture || is_context_capture) && !context_field_type.starts_with('&') {
 			capture_decl_rhs = t.make_prefix(.amp, capture_decl_rhs)
 			t.set_node_typ(int(capture_decl_rhs), capture_type)
 		}
@@ -10193,7 +10255,8 @@ fn (mut t Transformer) lift_fn_literal(_id flat.NodeId, node flat.Node) flat.Nod
 	new_body := t.transform_stmts(lifted_body)
 	t.pending_stmts = outer_pending
 	for capture_name in capture_names {
-		if capture_by_ref[capture_name] or { false } {
+		if (capture_by_ref[capture_name] or { false })
+			|| (capture_from_context[capture_name] or { false }) {
 			if saved_capture_pointer_flags[capture_name] or { false } {
 				t.pointer_value_lvalues[capture_name] = true
 			} else {
@@ -10239,6 +10302,7 @@ fn (mut t Transformer) lift_fn_literal(_id flat.NodeId, node flat.Node) flat.Nod
 	})
 	t.ensure_node_context_map_capacity()
 	t.mark_node_context(fn_decl, generated_module, t.cur_file)
+	t.set_fn_ret_type(name, ret_type)
 	if !isnil(t.tc) {
 		t.tc.ensure_private_transform_signatures()
 		ret := t.tc.parse_type(ret_type)
@@ -10249,6 +10313,7 @@ fn (mut t Transformer) lift_fn_literal(_id flat.NodeId, node flat.Node) flat.Nod
 		t.tc_signature_names_log << name
 		if t.cur_module.len > 0 && t.cur_module != 'main' && t.cur_module != 'builtin' {
 			qname := '${t.cur_module}.${name}'
+			t.set_fn_ret_type(qname, ret_type)
 			t.tc.fn_ret_types[qname] = ret
 			t.tc.register_generated_fn_param_types(qname, param_types.clone())
 			t.tc.fn_variadic[qname] = false

--- a/vlib/v3/transform/fn_test.v
+++ b/vlib/v3/transform/fn_test.v
@@ -31,6 +31,16 @@ fn test_qualify_or_storage_type_resolves_imported_generic_base_only() {
 	assert t.qualify_or_storage_type('(string, []string)') == '(string, []string)'
 }
 
+fn test_immediate_closure_generic_sum_pointer_result_may_alias_capture() {
+	mut a := flat.FlatAst.new()
+	mut tc := types.TypeChecker.new(&a)
+	tc.sum_types['Maybe'] = ['T', 'IError']
+	tc.sum_generic_params['Maybe'] = ['T']
+	t := new_transformer(mut a, &tc, map[string]bool{})
+
+	assert t.immediate_closure_result_may_alias_capture('Maybe[&int]')
+}
+
 fn test_normalize_function_type_preserves_mut_parameter() {
 	t := Transformer{}
 	assert t.normalize_type_in_module('fn (mut Item)', 'main') == 'fn (&Item)'

--- a/vlib/v3/transform/fn_test.v
+++ b/vlib/v3/transform/fn_test.v
@@ -54,6 +54,17 @@ fn test_immediate_closure_generic_struct_pointer_result_may_alias_capture() {
 	assert t.immediate_closure_result_may_alias_capture('Box[&int]')
 }
 
+fn test_immediate_closure_result_error_may_alias_capture() {
+	fallback := Transformer{}
+	assert fallback.immediate_closure_result_may_alias_capture('!int')
+
+	mut a := flat.FlatAst.new()
+	mut tc := types.TypeChecker.new(&a)
+	t := new_transformer(mut a, &tc, map[string]bool{})
+
+	assert t.immediate_closure_result_may_alias_capture('!int')
+}
+
 fn test_normalize_function_type_preserves_mut_parameter() {
 	t := Transformer{}
 	assert t.normalize_type_in_module('fn (mut Item)', 'main') == 'fn (&Item)'

--- a/vlib/v3/transform/fn_test.v
+++ b/vlib/v3/transform/fn_test.v
@@ -138,6 +138,24 @@ fn test_auto_str_helper_call_uses_type_owner_module() {
 	assert t.auto_str_types['v.token.Pos'].helper_module == 'token'
 }
 
+fn test_immediate_closure_thread_result_may_alias_capture() {
+	mut a := flat.FlatAst.new()
+	mut tc := types.TypeChecker.new(&a)
+	tc.structs['Worker'] = [types.StructField{
+		name: 'handle'
+		typ: tc.parse_type('thread int')
+	}]
+	with_checker := Transformer{
+		a: &a
+		tc: &tc
+	}
+	assert with_checker.immediate_closure_result_may_alias_capture('thread int')
+	assert with_checker.immediate_closure_result_may_alias_capture('Worker')
+
+	without_checker := Transformer{}
+	assert without_checker.immediate_closure_result_may_alias_capture('thread int')
+}
+
 fn test_large_recursive_pointer_auto_str_stops_before_expanding_back_edge() {
 	mut a := flat.FlatAst.new()
 	mut tc := types.TypeChecker.new(&a)

--- a/vlib/v3/transform/fn_test.v
+++ b/vlib/v3/transform/fn_test.v
@@ -18,68 +18,6 @@ fn test_generic_app_parts_distinguishes_postfix_fixed_arrays() {
 	assert c_args == ['C.sg_pass_action']
 }
 
-fn test_qualify_or_storage_type_resolves_imported_generic_base_only() {
-	mut a := flat.FlatAst.new()
-	mut tc := types.TypeChecker.new(&a)
-	tc.structs['orm.QueryBuilder'] = []types.StructField{}
-	tc.struct_generic_params['orm.QueryBuilder'] = ['T']
-	tc.struct_generic_params['QueryBuilder'] = ['T']
-	tc.struct_modules['orm.QueryBuilder'] = 'orm'
-	t := new_transformer(mut a, &tc, map[string]bool{})
-
-	assert t.qualify_or_storage_type('&QueryBuilder[main.User]') == '&orm.QueryBuilder[main.User]'
-	assert t.qualify_or_storage_type('(string, []string)') == '(string, []string)'
-}
-
-fn test_immediate_closure_generic_sum_pointer_result_may_alias_capture() {
-	mut a := flat.FlatAst.new()
-	mut tc := types.TypeChecker.new(&a)
-	tc.sum_types['Maybe'] = ['T', 'IError']
-	tc.sum_generic_params['Maybe'] = ['T']
-	t := new_transformer(mut a, &tc, map[string]bool{})
-
-	assert t.immediate_closure_result_may_alias_capture('Maybe[&int]')
-}
-
-fn test_immediate_closure_generic_struct_pointer_result_may_alias_capture() {
-	mut a := flat.FlatAst.new()
-	mut tc := types.TypeChecker.new(&a)
-	tc.structs['Box'] = [types.StructField{
-		name: 'value'
-		typ:  tc.parse_type('T')
-	}]
-	tc.struct_generic_params['Box'] = ['T']
-	t := new_transformer(mut a, &tc, map[string]bool{})
-
-	assert t.immediate_closure_result_may_alias_capture('Box[&int]')
-}
-
-fn test_immediate_closure_result_error_may_alias_capture() {
-	fallback := Transformer{}
-	assert fallback.immediate_closure_result_may_alias_capture('!int')
-	assert fallback.immediate_closure_result_may_alias_capture('[]int')
-	assert fallback.immediate_closure_result_may_alias_capture('map[string]int')
-	assert fallback.immediate_closure_result_may_alias_capture('chan int')
-	assert fallback.immediate_closure_result_may_alias_capture('string')
-	assert fallback.immediate_closure_result_may_alias_capture('?string')
-
-	mut a := flat.FlatAst.new()
-	mut tc := types.TypeChecker.new(&a)
-	tc.structs['TextBox'] = [types.StructField{
-		name: 'text'
-		typ:  types.Type(types.String{})
-	}]
-	t := new_transformer(mut a, &tc, map[string]bool{})
-
-	assert t.immediate_closure_result_may_alias_capture('!int')
-	assert t.immediate_closure_result_may_alias_capture('[]int')
-	assert t.immediate_closure_result_may_alias_capture('map[string]int')
-	assert t.immediate_closure_result_may_alias_capture('chan int')
-	assert t.immediate_closure_result_may_alias_capture('string')
-	assert t.immediate_closure_result_may_alias_capture('?string')
-	assert t.immediate_closure_result_may_alias_capture('TextBox')
-}
-
 fn test_normalize_function_type_preserves_mut_parameter() {
 	t := Transformer{}
 	assert t.normalize_type_in_module('fn (mut Item)', 'main') == 'fn (&Item)'
@@ -136,24 +74,6 @@ fn test_auto_str_helper_call_uses_type_owner_module() {
 
 	assert callee.value == '__v3_autostr_v__token__Pos'
 	assert t.auto_str_types['v.token.Pos'].helper_module == 'token'
-}
-
-fn test_immediate_closure_thread_result_may_alias_capture() {
-	mut a := flat.FlatAst.new()
-	mut tc := types.TypeChecker.new(&a)
-	tc.structs['Worker'] = [types.StructField{
-		name: 'handle'
-		typ: tc.parse_type('thread int')
-	}]
-	with_checker := Transformer{
-		a: &a
-		tc: &tc
-	}
-	assert with_checker.immediate_closure_result_may_alias_capture('thread int')
-	assert with_checker.immediate_closure_result_may_alias_capture('Worker')
-
-	without_checker := Transformer{}
-	assert without_checker.immediate_closure_result_may_alias_capture('thread int')
 }
 
 fn test_large_recursive_pointer_auto_str_stops_before_expanding_back_edge() {
@@ -450,4 +370,84 @@ fn test_multi_return_selector_suffix_does_not_match_free_fn() {
 		return
 	}
 	assert items.len == 2
+}
+
+fn test_qualify_or_storage_type_resolves_imported_generic_base_only() {
+	mut a := flat.FlatAst.new()
+	mut tc := types.TypeChecker.new(&a)
+	tc.structs['orm.QueryBuilder'] = []types.StructField{}
+	tc.struct_generic_params['orm.QueryBuilder'] = ['T']
+	tc.struct_generic_params['QueryBuilder'] = ['T']
+	tc.struct_modules['orm.QueryBuilder'] = 'orm'
+	t := new_transformer(mut a, &tc, map[string]bool{})
+
+	assert t.qualify_or_storage_type('&QueryBuilder[main.User]') == '&orm.QueryBuilder[main.User]'
+	assert t.qualify_or_storage_type('(string, []string)') == '(string, []string)'
+}
+
+fn test_immediate_closure_generic_sum_pointer_result_may_alias_capture() {
+	mut a := flat.FlatAst.new()
+	mut tc := types.TypeChecker.new(&a)
+	tc.sum_types['Maybe'] = ['T', 'IError']
+	tc.sum_generic_params['Maybe'] = ['T']
+	t := new_transformer(mut a, &tc, map[string]bool{})
+
+	assert t.immediate_closure_result_may_alias_capture('Maybe[&int]')
+}
+
+fn test_immediate_closure_generic_struct_pointer_result_may_alias_capture() {
+	mut a := flat.FlatAst.new()
+	mut tc := types.TypeChecker.new(&a)
+	tc.structs['Box'] = [types.StructField{
+		name: 'value'
+		typ:  tc.parse_type('T')
+	}]
+	tc.struct_generic_params['Box'] = ['T']
+	t := new_transformer(mut a, &tc, map[string]bool{})
+
+	assert t.immediate_closure_result_may_alias_capture('Box[&int]')
+}
+
+fn test_immediate_closure_result_error_may_alias_capture() {
+	fallback := Transformer{}
+	assert fallback.immediate_closure_result_may_alias_capture('!int')
+	assert fallback.immediate_closure_result_may_alias_capture('[]int')
+	assert fallback.immediate_closure_result_may_alias_capture('map[string]int')
+	assert fallback.immediate_closure_result_may_alias_capture('chan int')
+	assert fallback.immediate_closure_result_may_alias_capture('string')
+	assert fallback.immediate_closure_result_may_alias_capture('?string')
+
+	mut a := flat.FlatAst.new()
+	mut tc := types.TypeChecker.new(&a)
+	tc.structs['TextBox'] = [types.StructField{
+		name: 'text'
+		typ:  types.Type(types.String{})
+	}]
+	t := new_transformer(mut a, &tc, map[string]bool{})
+
+	assert t.immediate_closure_result_may_alias_capture('!int')
+	assert t.immediate_closure_result_may_alias_capture('[]int')
+	assert t.immediate_closure_result_may_alias_capture('map[string]int')
+	assert t.immediate_closure_result_may_alias_capture('chan int')
+	assert t.immediate_closure_result_may_alias_capture('string')
+	assert t.immediate_closure_result_may_alias_capture('?string')
+	assert t.immediate_closure_result_may_alias_capture('TextBox')
+}
+
+fn test_immediate_closure_thread_result_may_alias_capture() {
+	mut a := flat.FlatAst.new()
+	mut tc := types.TypeChecker.new(&a)
+	tc.structs['Worker'] = [types.StructField{
+		name: 'handle'
+		typ: tc.parse_type('thread int')
+	}]
+	with_checker := Transformer{
+		a: &a
+		tc: &tc
+	}
+	assert with_checker.immediate_closure_result_may_alias_capture('thread int')
+	assert with_checker.immediate_closure_result_may_alias_capture('Worker')
+
+	without_checker := Transformer{}
+	assert without_checker.immediate_closure_result_may_alias_capture('thread int')
 }

--- a/vlib/v3/transform/fn_test.v
+++ b/vlib/v3/transform/fn_test.v
@@ -18,6 +18,19 @@ fn test_generic_app_parts_distinguishes_postfix_fixed_arrays() {
 	assert c_args == ['C.sg_pass_action']
 }
 
+fn test_qualify_or_storage_type_resolves_imported_generic_base_only() {
+	mut a := flat.FlatAst.new()
+	mut tc := types.TypeChecker.new(&a)
+	tc.structs['orm.QueryBuilder'] = []types.StructField{}
+	tc.struct_generic_params['orm.QueryBuilder'] = ['T']
+	tc.struct_generic_params['QueryBuilder'] = ['T']
+	tc.struct_modules['orm.QueryBuilder'] = 'orm'
+	t := new_transformer(mut a, &tc, map[string]bool{})
+
+	assert t.qualify_or_storage_type('&QueryBuilder[main.User]') == '&orm.QueryBuilder[main.User]'
+	assert t.qualify_or_storage_type('(string, []string)') == '(string, []string)'
+}
+
 fn test_normalize_function_type_preserves_mut_parameter() {
 	t := Transformer{}
 	assert t.normalize_type_in_module('fn (mut Item)', 'main') == 'fn (&Item)'

--- a/vlib/v3/transform/fn_test.v
+++ b/vlib/v3/transform/fn_test.v
@@ -60,15 +60,24 @@ fn test_immediate_closure_result_error_may_alias_capture() {
 	assert fallback.immediate_closure_result_may_alias_capture('[]int')
 	assert fallback.immediate_closure_result_may_alias_capture('map[string]int')
 	assert fallback.immediate_closure_result_may_alias_capture('chan int')
+	assert fallback.immediate_closure_result_may_alias_capture('string')
+	assert fallback.immediate_closure_result_may_alias_capture('?string')
 
 	mut a := flat.FlatAst.new()
 	mut tc := types.TypeChecker.new(&a)
+	tc.structs['TextBox'] = [types.StructField{
+		name: 'text'
+		typ:  types.Type(types.String{})
+	}]
 	t := new_transformer(mut a, &tc, map[string]bool{})
 
 	assert t.immediate_closure_result_may_alias_capture('!int')
 	assert t.immediate_closure_result_may_alias_capture('[]int')
 	assert t.immediate_closure_result_may_alias_capture('map[string]int')
 	assert t.immediate_closure_result_may_alias_capture('chan int')
+	assert t.immediate_closure_result_may_alias_capture('string')
+	assert t.immediate_closure_result_may_alias_capture('?string')
+	assert t.immediate_closure_result_may_alias_capture('TextBox')
 }
 
 fn test_normalize_function_type_preserves_mut_parameter() {

--- a/vlib/v3/transform/fn_test.v
+++ b/vlib/v3/transform/fn_test.v
@@ -57,12 +57,18 @@ fn test_immediate_closure_generic_struct_pointer_result_may_alias_capture() {
 fn test_immediate_closure_result_error_may_alias_capture() {
 	fallback := Transformer{}
 	assert fallback.immediate_closure_result_may_alias_capture('!int')
+	assert fallback.immediate_closure_result_may_alias_capture('[]int')
+	assert fallback.immediate_closure_result_may_alias_capture('map[string]int')
+	assert fallback.immediate_closure_result_may_alias_capture('chan int')
 
 	mut a := flat.FlatAst.new()
 	mut tc := types.TypeChecker.new(&a)
 	t := new_transformer(mut a, &tc, map[string]bool{})
 
 	assert t.immediate_closure_result_may_alias_capture('!int')
+	assert t.immediate_closure_result_may_alias_capture('[]int')
+	assert t.immediate_closure_result_may_alias_capture('map[string]int')
+	assert t.immediate_closure_result_may_alias_capture('chan int')
 }
 
 fn test_normalize_function_type_preserves_mut_parameter() {

--- a/vlib/v3/transform/fn_test.v
+++ b/vlib/v3/transform/fn_test.v
@@ -41,6 +41,19 @@ fn test_immediate_closure_generic_sum_pointer_result_may_alias_capture() {
 	assert t.immediate_closure_result_may_alias_capture('Maybe[&int]')
 }
 
+fn test_immediate_closure_generic_struct_pointer_result_may_alias_capture() {
+	mut a := flat.FlatAst.new()
+	mut tc := types.TypeChecker.new(&a)
+	tc.structs['Box'] = [types.StructField{
+		name: 'value'
+		typ:  tc.parse_type('T')
+	}]
+	tc.struct_generic_params['Box'] = ['T']
+	t := new_transformer(mut a, &tc, map[string]bool{})
+
+	assert t.immediate_closure_result_may_alias_capture('Box[&int]')
+}
+
 fn test_normalize_function_type_preserves_mut_parameter() {
 	t := Transformer{}
 	assert t.normalize_type_in_module('fn (mut Item)', 'main') == 'fn (&Item)'

--- a/vlib/v3/transform/or.v
+++ b/vlib/v3/transform/or.v
@@ -1586,6 +1586,12 @@ fn (t &Transformer) qualify_or_storage_type(typ string) string {
 			return prefix + t.qualify_or_storage_type(clean[prefix.len..])
 		}
 	}
+	if clean.starts_with('map[') {
+		key_type, value_type := t.map_type_parts(clean)
+		if key_type.len > 0 && value_type.len > 0 {
+			return 'map[${t.qualify_or_storage_type(key_type)}]${t.qualify_or_storage_type(value_type)}'
+		}
+	}
 	if clean.ends_with(']') {
 		base, args, is_generic_app := generic_app_parts(clean)
 		if is_generic_app {

--- a/vlib/v3/transform/or.v
+++ b/vlib/v3/transform/or.v
@@ -1535,8 +1535,9 @@ fn (mut t Transformer) lower_or_expr_to_temp(id flat.NodeId, node flat.Node) fla
 	} else {
 		t.shared_alias_storage_type(value_type)
 	}
-	mut storage_value_type := storage_value_type0
-	storage_normalized := t.normalize_type_in_module(storage_value_type0, t.cur_module)
+	qualified_storage_type := t.qualify_or_storage_type(storage_value_type0)
+	storage_normalized := t.normalize_type_in_module(qualified_storage_type, t.cur_module)
+	mut storage_value_type := qualified_storage_type
 	if t.is_optional_type_name(t.cur_fn_ret_type) {
 		return_value_type := t.optional_base_type(t.qualify_optional_type(t.cur_fn_ret_type))
 		if return_value_type != storage_value_type0
@@ -1573,6 +1574,35 @@ fn (mut t Transformer) lower_or_expr_to_temp(id flat.NodeId, node flat.Node) fla
 	}
 	t.pending_stmts << if_stmt
 	return t.make_ident(val_tmp)
+}
+
+fn (t &Transformer) qualify_or_storage_type(typ string) string {
+	clean := typ.trim_space()
+	if clean.len == 0 {
+		return clean
+	}
+	for prefix in ['mut ', 'shared ', 'atomic ', '...', '[]', '?', '!', '&'] {
+		if clean.starts_with(prefix) {
+			return prefix + t.qualify_or_storage_type(clean[prefix.len..])
+		}
+	}
+	if clean.ends_with(']') {
+		base, args, is_generic_app := generic_app_parts(clean)
+		if is_generic_app {
+			mut qualified_args := []string{cap: args.len}
+			for arg_type in args {
+				qualified_args << t.qualify_or_storage_type(arg_type)
+			}
+			mut qualified_base := t.qualify_type(base)
+			if qualified_base == base && !t.bare_struct_name_is_local_to_current_module(base) {
+				if imported_base := t.unique_qualified_struct_for_short(base) {
+					qualified_base = imported_base
+				}
+			}
+			return '${qualified_base}[${qualified_args.join(', ')}]'
+		}
+	}
+	return clean
 }
 
 fn (mut t Transformer) preserve_or_expr_for_codegen(id flat.NodeId, node flat.Node) flat.NodeId {

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -13606,9 +13606,9 @@ fn (mut t Transformer) transform_decl_assign_stmt(id flat.NodeId, node flat.Node
 					t.set_node_typ(int(rhs_id), typ)
 				}
 			}
-			if amp_vt := t.mut_param_amp_decl_type(rhs_id) {
-				// `mut t := &table` where table is a `mut` value param: the RHS
-				// IS the caller's pointer, so the local is single-`&`, not `&&`.
+			if amp_vt := t.pointer_storage_amp_decl_type(rhs_id) {
+				// Mut parameters, mutable captures, and heap-promoted value locals use
+				// pointer storage. Their source-level address is that pointer itself.
 				typ = amp_vt
 			}
 			if typ.len > 0 {
@@ -18497,9 +18497,9 @@ fn (mut t Transformer) transform_match_trailing_or_expr(_id flat.NodeId, node fl
 }
 
 // transform_prefix_expr transforms transform prefix expr data for transform.
-// mut_param_amp_decl_type detects `&param` (possibly as an unsafe-block tail)
-// over a `mut` value param and returns the param's pointer type for the decl.
-fn (t &Transformer) mut_param_amp_decl_type(rhs_id flat.NodeId) ?string {
+// pointer_storage_amp_decl_type detects `&value` (possibly as an unsafe-block tail)
+// when `value` is a source-level value backed by pointer storage.
+fn (t &Transformer) pointer_storage_amp_decl_type(rhs_id flat.NodeId) ?string {
 	if int(rhs_id) < 0 {
 		return none
 	}
@@ -18523,7 +18523,7 @@ fn (t &Transformer) mut_param_amp_decl_type(rhs_id flat.NodeId) ?string {
 		return none
 	}
 	child := t.a.child_node(&node, 0)
-	if child.kind != .ident || !t.mut_param_values[child.value] {
+	if child.kind != .ident || (!t.mut_param_values[child.value] && !t.pointer_value_rvalues[child.value]) {
 		return none
 	}
 	mut vt := t.var_type(child.value)
@@ -18626,22 +18626,12 @@ fn (mut t Transformer) transform_prefix_expr(id flat.NodeId, node flat.Node) fla
 				return expr
 			}
 		}
-		// `&param` where `param` is a `mut` value param IS the pointer the
-		// caller passed; adding another `&` would take the address of the
-		// parameter slot (`map** t = table` + `*t = ...` clobbers the caller).
-		if child.kind == .ident && t.mut_param_values[child.value] {
-			mut vt := t.var_type(child.value)
-			if vt.starts_with('mut ') {
-				vt = '&' + vt[4..].trim_space()
-			}
-			if !vt.starts_with('&') && vt.len > 0 {
-				vt = '&${vt}'
-			}
-			if vt.starts_with('&') {
-				new_id := t.transform_expr(child_id)
-				t.set_node_typ(int(new_id), vt)
-				return new_id
-			}
+		// Pointer-backed values already name their storage address. Preserve that
+		// pointer instead of taking the address of the pointer slot and forming `&&T`.
+		if vt := t.pointer_storage_amp_decl_type(id) {
+			new_id := t.transform_expr_preserving_pointer_value(child_id)
+			t.set_node_typ(int(new_id), vt)
+			return new_id
 		}
 		if child.kind == .struct_init {
 			// `&T{...}` (address of a struct literal) is ALWAYS a heap allocation in V,


### PR DESCRIPTION
## Summary

- qualify imported generic storage and main-scoped generic aggregates, fixing the macOS ORM and Linux TCC codegen failures
- initialize and promptly reclaim runtime closures, fixing the riscv64 closure-capacity failures
- supply headerless `SOMAXCONN` values and Objective-C runtime link flags for cached native sources

## Validation

- rebuilt `vnew` from the bootstrap compiler
- strict V3 ORM, Pico, TCC JSON benchmark, Objective-C link, closure-capacity, and immediate-closure canaries
- `vlib/v/compiler_errors_test.v`: 1619 passed, 1 skipped
- `vlib/v/gen/c/coutput_test.v`: 231 passed, 17 skipped across both fixture groups
- `vlib/v3/transform/`: 7 passed
- targeted driver, header-codegen, monomorphization, and closure tests
- `git diff --check`

The touched non-V3 test passes `vfmt`. Each touched `vlib/v3` file also fails `vfmt -verify` unchanged on pristine `origin/master`; applying `vfmt -w` there rewrites unrelated V3 syntax, so those files were kept manually styled.