### PR TITLE
builder: upload the full failing file in automatic C-error bug reports

### DIFF
--- a/cmd/tools/modules/vbugreport/c_error_storage.v
+++ b/cmd/tools/modules/vbugreport/c_error_storage.v
@@ -20,8 +20,8 @@ pub:
 // The generated C context is stored in `lines`, while the corresponding V source
 // context (the V line that caused the C error and its surrounding lines) is stored
 // separately in `v_lines`. `v_version` (the reporting compiler's version), `arch`,
-// `build_options` (the codegen-affecting `v` flags) and `v_source` (the failing file's leading
-// declarations plus the block around the error line) are stored so a report can be reproduced,
+// `build_options` (the codegen-affecting `v` flags) and `v_source` (the full failing file,
+// bounded only when larger than the byte budget) are stored so a report can be reproduced,
 // and so reports from V versions predating a fix can be filtered out during triage.
 pub fn new_stored_c_error_report(c_file string, target_os string, ccompiler string, v_version string, arch string, build_options string, c_error string, c_lines []string, v_lines []string, v_source string) StoredCErrorReport {
 	return StoredCErrorReport{

--- a/cmd/v/macos_v3_dispatch.c.v
+++ b/cmd/v/macos_v3_dispatch.c.v
@@ -47,11 +47,12 @@ const macos_v3_c_error_kind_file = 'kind'
 const macos_v3_compiler_error_message_base = 'error: the experimental V3 compiler hit an internal compiler error building this program'
 
 struct MacosV3InputSnapshot {
-	path     string
-	digest   string
-	v_file   string
-	v_source string
-	focus    int // 1-based failing line within v_source (0 = none); export bounds once, centered here
+	path               string
+	digest             string
+	v_file             string
+	v_source           string
+	v_source_truncated bool
+	focus              int // 1-based failing line within v_source (0 = none)
 }
 
 struct MacosV3RetryState {
@@ -351,7 +352,8 @@ fn retry_macos_v3_with_old_compiler(caller_environment map[string]string, fallba
 		// digest; otherwise send metadata only, never bytes that V3 did not parse. Once the
 		// retry succeeds it prints the fallback notice and files the report. A directory
 		// build (`v .`) or non-V input also remains metadata-only, but never silent.
-		v_file, v_source, v_source_focus := input_snapshot.current_report_source()
+		v_file, v_source, v_source_focus, v_source_truncated :=
+			input_snapshot.current_report_source()
 		// Post-parse V3 stages write exact parser and resolved-native digests into the
 		// owned staging directory. If that complete manifest is unavailable (for example,
 		// after an early parser crash), the retry still runs but its report is not submitted
@@ -361,7 +363,7 @@ fn retry_macos_v3_with_old_compiler(caller_environment map[string]string, fallba
 		}
 		export_macos_v3_bounded_report_content(macos_v3_compiler_error_fallback, 'v3',
 			macos_v3_compiler_error_message(fallback_stage), v_file, v_source, v_source_focus,
-			input_digests, input_digests.len > 0)
+			v_source_truncated, input_digests, input_digests.len > 0)
 		os.rmdir_all(c_error_dir) or {}
 		if should_report {
 			eprintln('V3 compilation failed; retrying with `-old-compiler`.')
@@ -415,11 +417,11 @@ fn take_macos_v3_report_content() ?MacosV3CErrorReport {
 fn export_macos_v3_report_content(kind string, ccompiler string, c_output string, c_file string, v_sources map[string]string, input_digests_complete bool) {
 	v_file, v_source, v_source_focus := builder.bounded_v3_fallback_source(kind, c_output, c_file,
 		v_sources)
-	export_macos_v3_bounded_report_content(kind, ccompiler, c_output, v_file, v_source, v_source_focus,
-		v_sources, input_digests_complete)
+	export_macos_v3_bounded_report_content(kind, ccompiler, c_output, v_file, v_source,
+		v_source_focus, false, v_sources, input_digests_complete)
 }
 
-fn export_macos_v3_bounded_report_content(kind string, ccompiler string, c_output string, v_file string, v_source string, v_source_focus int, input_digests map[string]string, input_digests_complete bool) {
+fn export_macos_v3_bounded_report_content(kind string, ccompiler string, c_output string, v_file string, v_source string, v_source_focus int, v_source_truncated bool, input_digests map[string]string, input_digests_complete bool) {
 	builder.export_external_v3_report_to_env(builder.ExternalCErrorBugReport{
 		kind:                   kind
 		ccompiler:              ccompiler
@@ -427,6 +429,7 @@ fn export_macos_v3_bounded_report_content(kind string, ccompiler string, c_outpu
 		v_file:                 v_file
 		v_source:               v_source
 		v_source_focus:         v_source_focus
+		v_source_truncated:     v_source_truncated
 		source_inline:          true
 		input_digests:          input_digests
 		input_digests_complete: input_digests_complete
@@ -443,26 +446,26 @@ fn macos_v3_compiler_error_input_snapshot(input_path string) MacosV3InputSnapsho
 	// working-directory changes inside V3.
 	v_path := os.abs_path(candidate)
 	source := os.read_file(v_path) or { return MacosV3InputSnapshot{} }
-	v_file, v_source, v_source_focus := builder.bounded_v3_internal_fallback_source(v_path,
-		source)
+	v_file, v_source, v_source_focus := builder.bounded_v3_internal_fallback_source(v_path, source)
 	return MacosV3InputSnapshot{
-		path:     v_path
-		digest:   sha256.hexhash(source)
-		v_file:   v_file
-		v_source: v_source
-		focus:    v_source_focus
+		path:               v_path
+		digest:             sha256.hexhash(source)
+		v_file:             v_file
+		v_source:           v_source
+		v_source_truncated: v_source.len < source.len
+		focus:              v_source_focus
 	}
 }
 
-fn (snapshot MacosV3InputSnapshot) current_report_source() (string, string, int) {
+fn (snapshot MacosV3InputSnapshot) current_report_source() (string, string, int, bool) {
 	if snapshot.path == '' || snapshot.digest == '' {
-		return '', '', 0
+		return '', '', 0, false
 	}
-	current := os.read_file(snapshot.path) or { return '', '', 0 }
+	current := os.read_file(snapshot.path) or { return '', '', 0, false }
 	if sha256.hexhash(current) != snapshot.digest {
-		return '', '', 0
+		return '', '', 0, false
 	}
-	return snapshot.v_file, snapshot.v_source, snapshot.focus
+	return snapshot.v_file, snapshot.v_source, snapshot.focus, snapshot.v_source_truncated
 }
 
 // macos_v3_compiler_error_input_source returns `input_path` when it is a single V source

--- a/cmd/v/macos_v3_dispatch.c.v
+++ b/cmd/v/macos_v3_dispatch.c.v
@@ -403,6 +403,7 @@ fn take_macos_v3_report_content() ?MacosV3CErrorReport {
 		v_file:                 report.v_file
 		v_source:               report.v_source
 		v_source_truncated:     report.v_source_truncated
+		v_source_focus:         report.v_source_focus
 		input_digests:          report.input_digests
 		input_digests_complete: report.input_digests_complete
 	}

--- a/cmd/v/macos_v3_dispatch.c.v
+++ b/cmd/v/macos_v3_dispatch.c.v
@@ -51,6 +51,7 @@ struct MacosV3InputSnapshot {
 	digest   string
 	v_file   string
 	v_source string
+	focus    int // 1-based failing line within v_source (0 = none); export bounds once, centered here
 }
 
 struct MacosV3RetryState {
@@ -350,7 +351,7 @@ fn retry_macos_v3_with_old_compiler(caller_environment map[string]string, fallba
 		// digest; otherwise send metadata only, never bytes that V3 did not parse. Once the
 		// retry succeeds it prints the fallback notice and files the report. A directory
 		// build (`v .`) or non-V input also remains metadata-only, but never silent.
-		v_file, v_source := input_snapshot.current_report_source()
+		v_file, v_source, v_source_focus := input_snapshot.current_report_source()
 		// Post-parse V3 stages write exact parser and resolved-native digests into the
 		// owned staging directory. If that complete manifest is unavailable (for example,
 		// after an early parser crash), the retry still runs but its report is not submitted
@@ -359,8 +360,8 @@ fn retry_macos_v3_with_old_compiler(caller_environment map[string]string, fallba
 			map[string]string{}
 		}
 		export_macos_v3_bounded_report_content(macos_v3_compiler_error_fallback, 'v3',
-			macos_v3_compiler_error_message(fallback_stage), v_file, v_source, input_digests,
-			input_digests.len > 0)
+			macos_v3_compiler_error_message(fallback_stage), v_file, v_source, v_source_focus,
+			input_digests, input_digests.len > 0)
 		os.rmdir_all(c_error_dir) or {}
 		if should_report {
 			eprintln('V3 compilation failed; retrying with `-old-compiler`.')
@@ -410,18 +411,20 @@ fn take_macos_v3_report_content() ?MacosV3CErrorReport {
 // the report and therefore trusts `c_file` — and forwards only that content to the V1
 // retry through the environment.
 fn export_macos_v3_report_content(kind string, ccompiler string, c_output string, c_file string, v_sources map[string]string, input_digests_complete bool) {
-	v_file, v_source := builder.bounded_v3_fallback_source(kind, c_output, c_file, v_sources)
-	export_macos_v3_bounded_report_content(kind, ccompiler, c_output, v_file, v_source, v_sources,
-		input_digests_complete)
+	v_file, v_source, v_source_focus := builder.bounded_v3_fallback_source(kind, c_output, c_file,
+		v_sources)
+	export_macos_v3_bounded_report_content(kind, ccompiler, c_output, v_file, v_source, v_source_focus,
+		v_sources, input_digests_complete)
 }
 
-fn export_macos_v3_bounded_report_content(kind string, ccompiler string, c_output string, v_file string, v_source string, input_digests map[string]string, input_digests_complete bool) {
+fn export_macos_v3_bounded_report_content(kind string, ccompiler string, c_output string, v_file string, v_source string, v_source_focus int, input_digests map[string]string, input_digests_complete bool) {
 	builder.export_external_v3_report_to_env(builder.ExternalCErrorBugReport{
 		kind:                   kind
 		ccompiler:              ccompiler
 		c_output:               c_output
 		v_file:                 v_file
 		v_source:               v_source
+		v_source_focus:         v_source_focus
 		source_inline:          true
 		input_digests:          input_digests
 		input_digests_complete: input_digests_complete
@@ -438,24 +441,26 @@ fn macos_v3_compiler_error_input_snapshot(input_path string) MacosV3InputSnapsho
 	// working-directory changes inside V3.
 	v_path := os.abs_path(candidate)
 	source := os.read_file(v_path) or { return MacosV3InputSnapshot{} }
-	v_file, v_source := builder.bounded_v3_internal_fallback_source(v_path, source)
+	v_file, v_source, v_source_focus := builder.bounded_v3_internal_fallback_source(v_path,
+		source)
 	return MacosV3InputSnapshot{
 		path:     v_path
 		digest:   sha256.hexhash(source)
 		v_file:   v_file
 		v_source: v_source
+		focus:    v_source_focus
 	}
 }
 
-fn (snapshot MacosV3InputSnapshot) current_report_source() (string, string) {
+fn (snapshot MacosV3InputSnapshot) current_report_source() (string, string, int) {
 	if snapshot.path == '' || snapshot.digest == '' {
-		return '', ''
+		return '', '', 0
 	}
-	current := os.read_file(snapshot.path) or { return '', '' }
+	current := os.read_file(snapshot.path) or { return '', '', 0 }
 	if sha256.hexhash(current) != snapshot.digest {
-		return '', ''
+		return '', '', 0
 	}
-	return snapshot.v_file, snapshot.v_source
+	return snapshot.v_file, snapshot.v_source, snapshot.focus
 }
 
 // macos_v3_compiler_error_input_source returns `input_path` when it is a single V source

--- a/cmd/v/macos_v3_dispatch.c.v
+++ b/cmd/v/macos_v3_dispatch.c.v
@@ -402,6 +402,7 @@ fn take_macos_v3_report_content() ?MacosV3CErrorReport {
 		c_output:               report.c_output
 		v_file:                 report.v_file
 		v_source:               report.v_source
+		v_source_truncated:     report.v_source_truncated
 		input_digests:          report.input_digests
 		input_digests_complete: report.input_digests_complete
 	}

--- a/cmd/v/macos_v3_test.v
+++ b/cmd/v/macos_v3_test.v
@@ -1757,10 +1757,10 @@ fn main() {}
 }
 
 // The compiler-error fallback captures the input V source into content in the trusted
-// process, uploading the full file (so the report is reproducible) for a single source
-// file and nothing (a metadata-only report) for a directory build or a non-V / missing
-// input. Runs wherever the dispatcher is embedded (macOS and Linux) without triggering a
-// real V3 failure (PR #28131 review).
+// process, uploading the full file when it fits the byte budget (so the report is reproducible)
+// and a bounded snapshot otherwise. A directory build or a non-V / missing input uploads nothing
+// (a metadata-only report). Runs wherever the dispatcher is embedded (macOS and Linux) without
+// triggering a real V3 failure (PR #28131 review).
 fn test_macos_v3_compiler_error_content_extraction() {
 	$if macos || linux {
 		root := os.join_path(os.real_path(os.vtmp_dir()), 'macos_v3_ce_content_${os.getpid()}')
@@ -1779,17 +1779,27 @@ fn test_macos_v3_compiler_error_content_extraction() {
 		os.write_file(source, whole)!
 		compiler_error := macos_v3_compiler_error_message('source parsing')
 		snapshot := macos_v3_compiler_error_input_snapshot(source)
-		v_file, v_source, v_source_focus := snapshot.current_report_source()
+		v_file, v_source, v_source_focus, v_source_truncated := snapshot.current_report_source()
 		assert v_file == 'prog.v'
 		assert compiler_error.contains('during source parsing')
 		// The full file is captured (it fits the byte budget), so the report reproduces. An
 		// internal error has no mapped failing line, so its focus is 0 (head+tail if bounded).
 		assert v_source == whole
 		assert v_source_focus == 0
+		assert !v_source_truncated
+		// A large input keeps only a payload-sized snapshot in the at-exit retry state, so a
+		// successful V3 build does not retain an unbounded second copy until process exit.
+		large_source := ('fn large() { println("' + 'x'.repeat(1000) + '") }\n').repeat(100)
+		os.write_file(source, large_source)!
+		large_snapshot := macos_v3_compiler_error_input_snapshot(source)
+		_, large_report_source, _, large_source_truncated := large_snapshot.current_report_source()
+		assert large_report_source.len <= 64 * 1024
+		assert large_report_source.len < large_source.len
+		assert large_source_truncated
 		// Rewriting the file after the pre-V3 snapshot suppresses source completely: the
 		// fallback must not upload bytes that V3 never parsed.
 		os.write_file(source, whole + '\nfn changed_after_snapshot() {}')!
-		changed_file, changed_source, _ := snapshot.current_report_source()
+		changed_file, changed_source, _, _ := snapshot.current_report_source()
 		assert changed_file == ''
 		assert changed_source == ''
 		// A directory build, a non-V file, or a missing input yields no source, so the
@@ -1798,7 +1808,7 @@ fn test_macos_v3_compiler_error_content_extraction() {
 		os.write_file(note, 'not v source')!
 		for empty in [root, note, os.join_path(root, 'missing.v'), ''] {
 			empty_snapshot := macos_v3_compiler_error_input_snapshot(empty)
-			ef, es, _ := empty_snapshot.current_report_source()
+			ef, es, _, _ := empty_snapshot.current_report_source()
 			assert ef == '', empty
 			assert es == '', empty
 		}

--- a/cmd/v/macos_v3_test.v
+++ b/cmd/v/macos_v3_test.v
@@ -1779,15 +1779,17 @@ fn test_macos_v3_compiler_error_content_extraction() {
 		os.write_file(source, whole)!
 		compiler_error := macos_v3_compiler_error_message('source parsing')
 		snapshot := macos_v3_compiler_error_input_snapshot(source)
-		v_file, v_source := snapshot.current_report_source()
+		v_file, v_source, v_source_focus := snapshot.current_report_source()
 		assert v_file == 'prog.v'
 		assert compiler_error.contains('during source parsing')
-		// The full file is captured (it fits the byte budget), so the report reproduces.
+		// The full file is captured (it fits the byte budget), so the report reproduces. An
+		// internal error has no mapped failing line, so its focus is 0 (head+tail if bounded).
 		assert v_source == whole
+		assert v_source_focus == 0
 		// Rewriting the file after the pre-V3 snapshot suppresses source completely: the
 		// fallback must not upload bytes that V3 never parsed.
 		os.write_file(source, whole + '\nfn changed_after_snapshot() {}')!
-		changed_file, changed_source := snapshot.current_report_source()
+		changed_file, changed_source, _ := snapshot.current_report_source()
 		assert changed_file == ''
 		assert changed_source == ''
 		// A directory build, a non-V file, or a missing input yields no source, so the
@@ -1796,7 +1798,7 @@ fn test_macos_v3_compiler_error_content_extraction() {
 		os.write_file(note, 'not v source')!
 		for empty in [root, note, os.join_path(root, 'missing.v'), ''] {
 			empty_snapshot := macos_v3_compiler_error_input_snapshot(empty)
-			ef, es := empty_snapshot.current_report_source()
+			ef, es, _ := empty_snapshot.current_report_source()
 			assert ef == '', empty
 			assert es == '', empty
 		}

--- a/cmd/v/macos_v3_test.v
+++ b/cmd/v/macos_v3_test.v
@@ -1756,11 +1756,11 @@ fn main() {}
 	}
 }
 
-// The compiler-error fallback bounds the input V source into content in the trusted
-// process, uploading a bounded strict subset for a single source file and nothing (a
-// metadata-only report) for a directory build or a non-V / missing input. Runs wherever
-// the dispatcher is embedded (macOS and Linux) without triggering a real V3 failure
-// (PR #28131 review).
+// The compiler-error fallback captures the input V source into content in the trusted
+// process, uploading the full file (so the report is reproducible) for a single source
+// file and nothing (a metadata-only report) for a directory build or a non-V / missing
+// input. Runs wherever the dispatcher is embedded (macOS and Linux) without triggering a
+// real V3 failure (PR #28131 review).
 fn test_macos_v3_compiler_error_content_extraction() {
 	$if macos || linux {
 		root := os.join_path(os.real_path(os.vtmp_dir()), 'macos_v3_ce_content_${os.getpid()}')
@@ -1769,7 +1769,7 @@ fn test_macos_v3_compiler_error_content_extraction() {
 		defer {
 			os.rmdir_all(root) or {}
 		}
-		// A single V source file is uploaded as a bounded snippet.
+		// A single V source file is uploaded in full so the report is reproducible.
 		source := os.join_path(root, 'prog.v')
 		mut lines := []string{}
 		for i in 0 .. 200 {
@@ -1781,10 +1781,9 @@ fn test_macos_v3_compiler_error_content_extraction() {
 		snapshot := macos_v3_compiler_error_input_snapshot(source)
 		v_file, v_source := snapshot.current_report_source()
 		assert v_file == 'prog.v'
-		assert v_source != ''
 		assert compiler_error.contains('during source parsing')
-		// A bounded strict subset — never the whole file.
-		assert v_source.len < whole.len
+		// The full file is captured (it fits the byte budget), so the report reproduces.
+		assert v_source == whole
 		// Rewriting the file after the pre-V3 snapshot suppresses source completely: the
 		// fallback must not upload bytes that V3 never parsed.
 		os.write_file(source, whole + '\nfn changed_after_snapshot() {}')!

--- a/cmd/v/v.v
+++ b/cmd/v/v.v
@@ -75,6 +75,7 @@ struct MacosV3CErrorReport {
 	// named by the (inheritable, forgeable) environment.
 	v_file                 string // informational base filename (no directory)
 	v_source               string // the full failing file (bounded only when larger than the byte budget)
+	v_source_truncated     bool   // true when v_source is a bounded excerpt rather than the whole file
 	input_digests          map[string]string
 	input_digests_complete bool
 }
@@ -442,6 +443,7 @@ fn rebuild(prefs &pref.Preferences, macos_v3_c_error_report ?MacosV3CErrorReport
 					c_output:               failed.c_output
 					v_file:                 failed.v_file
 					v_source:               failed.v_source
+					v_source_truncated:     failed.v_source_truncated
 					source_inline:          true
 					input_digests:          failed.input_digests
 					input_digests_complete: failed.input_digests_complete
@@ -475,6 +477,7 @@ fn rebuild(prefs &pref.Preferences, macos_v3_c_error_report ?MacosV3CErrorReport
 					c_output:               failed.c_output
 					v_file:                 failed.v_file
 					v_source:               failed.v_source
+					v_source_truncated:     failed.v_source_truncated
 					source_inline:          true
 					input_digests:          failed.input_digests
 					input_digests_complete: failed.input_digests_complete

--- a/cmd/v/v.v
+++ b/cmd/v/v.v
@@ -74,7 +74,7 @@ struct MacosV3CErrorReport {
 	// and deleted the directory, so the retry never reads a path or deletes a directory
 	// named by the (inheritable, forgeable) environment.
 	v_file                 string // informational base filename (no directory)
-	v_source               string // already-bounded source snippet; never a whole file
+	v_source               string // the full failing file (bounded only when larger than the byte budget)
 	input_digests          map[string]string
 	input_digests_complete bool
 }

--- a/cmd/v/v.v
+++ b/cmd/v/v.v
@@ -76,6 +76,7 @@ struct MacosV3CErrorReport {
 	v_file                 string // informational base filename (no directory)
 	v_source               string // the full failing file (bounded only when larger than the byte budget)
 	v_source_truncated     bool   // true when v_source is a bounded excerpt rather than the whole file
+	v_source_focus         int    // failing line's 1-based position within v_source (0 = none)
 	input_digests          map[string]string
 	input_digests_complete bool
 }
@@ -444,6 +445,7 @@ fn rebuild(prefs &pref.Preferences, macos_v3_c_error_report ?MacosV3CErrorReport
 					v_file:                 failed.v_file
 					v_source:               failed.v_source
 					v_source_truncated:     failed.v_source_truncated
+					v_source_focus:         failed.v_source_focus
 					source_inline:          true
 					input_digests:          failed.input_digests
 					input_digests_complete: failed.input_digests_complete
@@ -478,6 +480,7 @@ fn rebuild(prefs &pref.Preferences, macos_v3_c_error_report ?MacosV3CErrorReport
 					v_file:                 failed.v_file
 					v_source:               failed.v_source
 					v_source_truncated:     failed.v_source_truncated
+					v_source_focus:         failed.v_source_focus
 					source_inline:          true
 					input_digests:          failed.input_digests
 					input_digests_complete: failed.input_digests_complete

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -112,18 +112,15 @@ embedded in your `v`).
 
 To help close the remaining gaps, a successful fallback (V3 fails to build a
 program that the established compiler then builds) normally submits the V
-version, target OS/arch, and build options to `https://bugs.vlang.io`. When a
-source excerpt is included it is always a **bounded strict subset** of the failing
-file — a window around the failure, or a head+tail window — and the whole file is
-never uploaded.
-An internal V3 compiler error on a short program (and any directory build such as
-`v .`) submits metadata only. If the input selected for a source excerpt changes
-after V3 parses it, that report also submits metadata only rather than source V3
-did not parse. Before submitting any report, the stable compiler also verifies
-that it parsed the same bytes for every captured project input; if it did not, no
-fallback report is submitted. An unchanged input mapped from a generated-C error
-can still upload a strict-subset excerpt of that file plus a few lines of context
-around the failing line, even when the file is short. Inline-assembly fallbacks
+version, target OS/arch, and build options to `https://bugs.vlang.io`. The
+**full failing source file** is included so the report is reproducible; it is
+bounded to a window around the failure only when the file is larger than the
+upload byte budget.
+A directory build (such as `v .`) submits metadata only. If the input selected
+for the source changes after V3 parses it, that report also submits metadata only
+rather than source V3 did not parse. Before submitting any report, the stable
+compiler also verifies that it parsed the same bytes for every captured project
+input; if it did not, no fallback report is submitted. Inline-assembly fallbacks
 and reports that cannot fit safely through the retry's process environment are
 notice-only and do not submit a report. Reporting is also skipped for test
 compilations and to the default endpoint in GitHub CI. A custom fallback endpoint

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -122,6 +122,10 @@ single-module `main` program, a smaller **self-contained reproducer** — the
 failing declaration plus the closure of declarations it references, which may be
 assembled from several files in that module — is preferred over the whole file
 and is reported as a bounded excerpt rather than the complete source.
+This full-file selection applies only to verified V3 fallback reports. When the
+established compiler is used directly, its automatic C-error reports retain a
+bounded strict subset of mapped source and omit source when no strict subset is
+possible.
 A directory build (such as `v .`) submits metadata only for an **internal V3
 compiler error**: that path uploads a snapshot of the single input file, which a
 directory build does not have. A **generated-C compilation error** is instead

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -116,9 +116,14 @@ version, target OS/arch, and build options to `https://bugs.vlang.io`. The
 **full failing source file** is included so the report is reproducible; it is
 bounded to a window around the failure only when the file is larger than the
 upload byte budget.
-A directory build (such as `v .`) submits metadata only. If the input selected
-for the source changes after V3 parses it, that report also submits metadata only
-rather than source V3 did not parse. Before submitting any report, the stable
+A directory build (such as `v .`) submits metadata only for an **internal V3
+compiler error**: that path uploads a snapshot of the single input file, which a
+directory build does not have. A **generated-C compilation error** is instead
+mapped back to the specific failing file through the staged C's `#line`
+directives, so even a directory build can upload that one failing file (still
+only when its current bytes match what V3 parsed). If the input selected for the
+source changes after V3 parses it, that report submits metadata only rather than
+source V3 did not parse. Before submitting any report, the stable
 compiler also verifies that it parsed the same bytes for every captured project
 input; if it did not, no fallback report is submitted. Inline-assembly fallbacks
 and reports that cannot fit safely through the retry's process environment are

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -115,7 +115,11 @@ program that the established compiler then builds) normally submits the V
 version, target OS/arch, and build options to `https://bugs.vlang.io`. The
 **full failing source file** is included so the report is reproducible; it is
 bounded to a window around the failure only when the file is larger than the
-upload byte budget.
+upload byte budget. One exception: when the failure is inside an ordinary
+single-module `main` program, a smaller **self-contained reproducer** — the
+failing declaration plus the closure of declarations it references, which may be
+assembled from several files in that module — is preferred over the whole file
+and is reported as a bounded excerpt rather than the complete source.
 A directory build (such as `v .`) submits metadata only for an **internal V3
 compiler error**: that path uploads a snapshot of the single input file, which a
 directory build does not have. A **generated-C compilation error** is instead

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -116,12 +116,7 @@ version, target OS/arch, and build options to `https://bugs.vlang.io`. When a
 generated-C diagnostic maps to a verified V source, the **full mapped source
 file** is included so the report is reproducible; a failure without such a
 mapping submits metadata only. The source is bounded to a window around the
-failure only when the file is larger than the upload byte budget. One exception:
-when the failure is inside an ordinary
-single-module `main` program, a smaller **self-contained reproducer** — the
-failing declaration plus the closure of declarations it references, which may be
-assembled from several files in that module — is preferred over the whole file
-and is reported as a bounded excerpt rather than the complete source.
+failure only when the file is larger than the upload byte budget.
 This full-file selection applies only to verified V3 fallback reports. When the
 established compiler is used directly, its automatic C-error reports retain a
 bounded strict subset of mapped source and omit source when no strict subset is

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -112,10 +112,12 @@ embedded in your `v`).
 
 To help close the remaining gaps, a successful fallback (V3 fails to build a
 program that the established compiler then builds) normally submits the V
-version, target OS/arch, and build options to `https://bugs.vlang.io`. The
-**full failing source file** is included so the report is reproducible; it is
-bounded to a window around the failure only when the file is larger than the
-upload byte budget. One exception: when the failure is inside an ordinary
+version, target OS/arch, and build options to `https://bugs.vlang.io`. When a
+generated-C diagnostic maps to a verified V source, the **full mapped source
+file** is included so the report is reproducible; a failure without such a
+mapping submits metadata only. The source is bounded to a window around the
+failure only when the file is larger than the upload byte budget. One exception:
+when the failure is inside an ordinary
 single-module `main` program, a smaller **self-contained reproducer** — the
 failing declaration plus the closure of declarations it references, which may be
 assembled from several files in that module — is preferred over the whole file

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -121,10 +121,13 @@ This full-file selection applies only to verified V3 fallback reports. When the
 established compiler is used directly, its automatic C-error reports retain a
 bounded strict subset of mapped source and omit source when no strict subset is
 possible.
-A directory build (such as `v .`) submits metadata only for an **internal V3
-compiler error**: that path uploads a snapshot of the single input file, which a
-directory build does not have. A **generated-C compilation error** is instead
-mapped back to the specific failing file through the staged C's `#line`
+A single-file build that hits an **internal V3 compiler error** uploads the
+complete captured input when it fits the 64 KiB source and process-environment
+transport budgets. Larger snapshots are truncated to a bounded head-and-tail
+window, and source is omitted when the transport cannot safely carry an excerpt.
+A directory build (such as `v .`) submits metadata only for this failure type
+because it has no single input snapshot. A **generated-C compilation error** is
+instead mapped back to the specific failing file through the staged C's `#line`
 directives, so even a directory build can upload that one failing file (still
 only when its current bytes match what V3 parsed). If the input selected for the
 source changes after V3 parses it, that report submits metadata only rather than

--- a/vlib/v/builder/c_error_report.v
+++ b/vlib/v/builder/c_error_report.v
@@ -229,8 +229,11 @@ fn (mut v Builder) send_prepared_c_error_bug_report(raw_report CErrorBugReport, 
 	// `-o -` output for exactly the programs that needed the fallback.
 	eprintln('================== C compiler bug report ==============')
 	if is_v3_fallback {
+		// A report can carry source as the full `v_source` OR only a few `v_context` lines (a
+		// context-only upload for a mapped non-V file / legacy external report). Only a nonempty,
+		// non-truncated `v_source` is the complete file; context-only is a bounded excerpt.
 		print_v3_fallback_notice(report_url, true, report_includes_v_source(report),
-			!report.v_source_truncated)
+			report_uploaded_complete_source(report))
 	}
 	if tool_output != '' {
 		eprintln(tool_output)
@@ -438,6 +441,19 @@ fn v3_transport_limited_notice_payload() map[string]string {
 // it only hashes tagged native dependencies after constraining them to roots selected by
 // its own successful build. A forged handoff therefore cannot disclose a victim's file
 // or recursively delete a victim's directory.
+// env_c_output_budget caps the diagnostic's environment budget at both the per-variable value
+// limit and the fixed maximum, so a single V_MACOS_V3_REPORT_COUTPUT value never risks E2BIG.
+fn env_c_output_budget(available int, value_limit int) int {
+	mut b := available
+	if b > c_error_bug_report_max_env_c_output_bytes {
+		b = c_error_bug_report_max_env_c_output_bytes
+	}
+	if b > value_limit {
+		b = value_limit
+	}
+	return b
+}
+
 pub fn export_external_v3_report_to_env(report ExternalCErrorBugReport) {
 	// `report` is already content-only: its v_source was bounded by the process that owns
 	// the staged directory (bounded_v3_fallback_source), and that process deletes the
@@ -478,16 +494,13 @@ pub fn export_external_v3_report_to_env(report ExternalCErrorBugReport) {
 	// Share the remaining aggregate capacity when both fields are present. A short
 	// missing-library/libatomic diagnostic remains intact, keeping the receiver's filter
 	// accurate, while large diagnostics and excerpts are both bounded.
+	// The full capacity the diagnostic may use when no source is forwarded.
+	full_c_output_budget := env_c_output_budget(content_budget, value_limit)
 	mut c_output_budget := content_budget
 	if report.v_source != '' {
 		c_output_budget /= 2
 	}
-	if c_output_budget > c_error_bug_report_max_env_c_output_bytes {
-		c_output_budget = c_error_bug_report_max_env_c_output_bytes
-	}
-	if c_output_budget > value_limit {
-		c_output_budget = value_limit
-	}
+	c_output_budget = env_c_output_budget(c_output_budget, value_limit)
 	payload['COUTPUT'] = truncated_report_text(report.c_output, c_output_budget)
 	content_budget = budget - v3_report_env_payload_bytes(payload)
 	v_source_budget := if content_budget < value_limit { content_budget } else { value_limit }
@@ -498,9 +511,12 @@ pub fn export_external_v3_report_to_env(report ExternalCErrorBugReport) {
 	// prefix that both drops the failing line and misreports the excerpt as complete.
 	v_source_marker_min := c_error_v_source_truncation_notice.len + 2
 	mut v_source_truncated := false
+	mut source_omitted := false
 	payload['VSOURCE'] = if v_source_budget <= 0 {
+		source_omitted = report.v_source != ''
 		''
 	} else if report.v_source.len > v_source_budget && v_source_budget <= v_source_marker_min {
+		source_omitted = true
 		''
 	} else if report.v_source.len > v_source_budget {
 		// Larger than the budget: a bounded excerpt centered on the failing line.
@@ -509,6 +525,13 @@ pub fn export_external_v3_report_to_env(report ExternalCErrorBugReport) {
 	} else {
 		// Fits whole: the complete file is forwarded.
 		report.v_source
+	}
+	// The report had source, but the budget could not hold even the marker, so it was omitted.
+	// The half of the content budget that was reserved for it is now free: recompute COUTPUT with
+	// the full capacity so a short missing-library/libatomic diagnostic is not truncated past the
+	// receiver's recognizable form (which would misclassify it as a compiler bug).
+	if source_omitted && c_output_budget < full_c_output_budget {
+		payload['COUTPUT'] = truncated_report_text(report.c_output, full_c_output_budget)
 	}
 	// Carry the truncation state explicitly through the handoff, computed from the byte budget
 	// rather than from (user-controlled) source content, so the retry's notice is accurate even
@@ -889,7 +912,7 @@ fn (mut v Builder) submit_v3_compiler_error_bug_report(v3_stage string, v3_outpu
 	// C is already on stdout, so appending this banner there would corrupt the documented
 	// `-o -` output for exactly the programs that needed the fallback.
 	eprintln('================== V3 compiler bug report ==============')
-	print_v3_fallback_notice(report_url, true, report.v_source != '', !report.v_source_truncated)
+	print_v3_fallback_notice(report_url, true, report.v_source != '', report_uploaded_complete_source(report))
 	if tool_output != '' {
 		eprintln(tool_output)
 	}
@@ -963,6 +986,14 @@ fn v_source_and_context_expose_whole_file(v_source string, context []CErrorRepor
 // metadata-only report carries neither.
 fn report_includes_v_source(report CErrorBugReport) bool {
 	return report.v_source != '' || report.v_context.len > 0
+}
+
+// report_uploaded_complete_source reports whether the report's uploaded source is the complete
+// failing file, as opposed to a bounded excerpt or a context-only upload (v_source empty while
+// v_context still carries a few mapped lines). Used to pick the disclosure notice so a
+// context-only or truncated upload is never announced as the complete source.
+fn report_uploaded_complete_source(report CErrorBugReport) bool {
+	return report.v_source != '' && !report.v_source_truncated
 }
 
 // print_v3_fallback_notice explains, in plain language, that V3 could not build the

--- a/vlib/v/builder/c_error_report.v
+++ b/vlib/v/builder/c_error_report.v
@@ -175,7 +175,7 @@ fn (mut v Builder) submit_c_error_bug_report_with_tag(ccompiler string, c_output
 	is_v3_fallback := tag != ''
 	if !should_submit_c_error_bug_report(v.pref.c_error_bug_report_url) {
 		if is_v3_fallback {
-			print_v3_fallback_notice('', false, false)
+			print_v3_fallback_notice('', false, false, false)
 		}
 		return
 	}
@@ -207,7 +207,7 @@ fn (mut v Builder) send_prepared_c_error_bug_report(raw_report CErrorBugReport, 
 	tool_output := send_c_error_bug_report(report, report_url) or {
 		eprintln('C compiler bug report was not sent to ${report_url}: ${err}')
 		if is_v3_fallback {
-			print_v3_fallback_notice('', false, false)
+			print_v3_fallback_notice('', false, false, false)
 		}
 		return
 	}
@@ -216,7 +216,8 @@ fn (mut v Builder) send_prepared_c_error_bug_report(raw_report CErrorBugReport, 
 	// `-o -` output for exactly the programs that needed the fallback.
 	eprintln('================== C compiler bug report ==============')
 	if is_v3_fallback {
-		print_v3_fallback_notice(report_url, true, report_includes_v_source(report))
+		print_v3_fallback_notice(report_url, true, report_includes_v_source(report),
+			v_source_upload_is_complete(report.v_source))
 	}
 	if tool_output != '' {
 		eprintln(tool_output)
@@ -236,7 +237,7 @@ pub fn submit_external_c_error_bug_report(prefs &pref.Preferences, ccompiler str
 		// `submit_c_error_bug_report_with_tag` would normally emit this, but the
 		// filter returns before reaching it. A non-empty tag marks the V3 fallback.
 		if tag != '' {
-			print_v3_fallback_notice('', false, false)
+			print_v3_fallback_notice('', false, false, false)
 		}
 		return
 	}
@@ -262,7 +263,7 @@ fn consume_external_c_error_bug_report(prefs &pref.Preferences, report ExternalC
 			// A known V3 limitation or a report omitted to keep the retry transport safe:
 			// the stable build has just succeeded, so tell the user V3 fell back — matching
 			// the documented notice (doc/docs.md) — but file no bug report.
-			print_v3_fallback_notice('', false, false)
+			print_v3_fallback_notice('', false, false, false)
 			return
 		}
 		if report.kind == external_v3_compiler_error_kind {
@@ -800,14 +801,14 @@ fn submit_inline_c_error_bug_report(prefs &pref.Preferences, ccompiler string, c
 		// Not eligible for automatic submission (e.g. a missing library), but V3 still
 		// fell back to the stable compiler, so the user is told about the fallback.
 		if is_v3_fallback {
-			print_v3_fallback_notice('', false, false)
+			print_v3_fallback_notice('', false, false, false)
 		}
 		return
 	}
 	mut b := new_builder(prefs)
 	if !should_submit_c_error_bug_report(b.pref.c_error_bug_report_url) {
 		if is_v3_fallback {
-			print_v3_fallback_notice('', false, false)
+			print_v3_fallback_notice('', false, false, false)
 		}
 		return
 	}
@@ -816,7 +817,7 @@ fn submit_inline_c_error_bug_report(prefs &pref.Preferences, ccompiler string, c
 
 fn (mut v Builder) submit_v3_compiler_error_bug_report(v3_stage string, v3_output string, v_file string, v_source string, tag string) {
 	if !should_submit_c_error_bug_report(v.pref.c_error_bug_report_url) {
-		print_v3_fallback_notice('', false, false)
+		print_v3_fallback_notice('', false, false, false)
 		return
 	}
 	build_options := c_error_report_build_options(v.pref, tag)
@@ -842,14 +843,14 @@ fn (mut v Builder) submit_v3_compiler_error_bug_report(v3_stage string, v3_outpu
 	report_url := c_error_bug_report_url(v.pref.c_error_bug_report_url)
 	tool_output := send_c_error_bug_report(report, report_url) or {
 		eprintln('V3 compiler bug report was not sent to ${report_url}: ${err}')
-		print_v3_fallback_notice('', false, false)
+		print_v3_fallback_notice('', false, false, false)
 		return
 	}
 	// Report diagnostics go to stderr, never stdout: with `v -o - source.v` the generated
 	// C is already on stdout, so appending this banner there would corrupt the documented
 	// `-o -` output for exactly the programs that needed the fallback.
 	eprintln('================== V3 compiler bug report ==============')
-	print_v3_fallback_notice(report_url, true, report.v_source != '')
+	print_v3_fallback_notice(report_url, true, report.v_source != '', v_source_upload_is_complete(report.v_source))
 	if tool_output != '' {
 		eprintln(tool_output)
 	}
@@ -934,16 +935,31 @@ fn report_includes_v_source(report CErrorBugReport) bool {
 	return report.v_source != '' || report.v_context.len > 0
 }
 
+// v_source_upload_is_complete reports whether the uploaded `v_source` is the complete
+// failing source rather than a bounded excerpt. The whole file is uploaded when it fits
+// the byte budget; only a larger file (or the head+tail internal-error window) carries the
+// truncation marker, and an empty `v_source` means nothing but context lines were sent.
+// Used so the fallback notice states accurately how much source reached the report service.
+fn v_source_upload_is_complete(v_source string) bool {
+	return v_source != '' && !v_source.contains(c_error_v_source_truncation_notice)
+}
+
 // print_v3_fallback_notice explains, in plain language, that V3 could not build the
 // program so the stable compiler was used instead. `submitted` selects whether a bug
 // report was actually filed; `report_url` is where it went (empty when not filed).
-fn print_v3_fallback_notice(report_url string, submitted bool, source_uploaded bool) {
+// `complete_source` distinguishes a full-file upload from a bounded excerpt so users are
+// told accurately how much source was disclosed.
+fn print_v3_fallback_notice(report_url string, submitted bool, source_uploaded bool, complete_source bool) {
 	eprintln('note: V3 could not build this program, so V used the stable compiler instead.')
 	if !submitted {
 		return
 	}
 	if source_uploaded {
-		eprintln('A bug report with a bounded excerpt of the failing V source was submitted to ${report_url} so this can be fixed.')
+		if complete_source {
+			eprintln('A bug report with the complete failing V source was submitted to ${report_url} so this can be fixed.')
+		} else {
+			eprintln('A bug report with a bounded excerpt of the failing V source was submitted to ${report_url} so this can be fixed.')
+		}
 	} else {
 		eprintln('A metadata-only bug report (no source) was submitted to ${report_url} so this can be fixed.')
 	}

--- a/vlib/v/builder/c_error_report.v
+++ b/vlib/v/builder/c_error_report.v
@@ -74,6 +74,10 @@ pub:
 	v_line         int
 	v_context      []CErrorReportLine
 	v_source       string // the full failing V file, so the report is reproducible (bounded only when larger than the byte budget)
+	// v_source_truncated records, explicitly, whether v_source is a bounded excerpt rather than
+	// the complete file, so the fallback notice states accurately how much source was uploaded
+	// without having to sniff for the in-band truncation marker.
+	v_source_truncated bool
 }
 
 // external_v3_compiler_error_kind marks an ExternalCErrorBugReport that describes a
@@ -217,7 +221,7 @@ fn (mut v Builder) send_prepared_c_error_bug_report(raw_report CErrorBugReport, 
 	eprintln('================== C compiler bug report ==============')
 	if is_v3_fallback {
 		print_v3_fallback_notice(report_url, true, report_includes_v_source(report),
-			v_source_upload_is_complete(report.v_source))
+			!report.v_source_truncated)
 	}
 	if tool_output != '' {
 		eprintln(tool_output)
@@ -786,6 +790,7 @@ fn build_inline_c_error_report(prefs &pref.Preferences, ccompiler string, c_outp
 		c_error:        c_output
 		v_file:         v_file
 		v_source:       v_source
+		v_source_truncated: bounded_v_source_content_is_truncated(v_source)
 	}
 }
 
@@ -838,6 +843,7 @@ fn (mut v Builder) submit_v3_compiler_error_bug_report(v3_stage string, v3_outpu
 		c_error:        v3_output
 		v_file:         v_file
 		v_source:       v_source
+		v_source_truncated: bounded_v_source_content_is_truncated(v_source)
 	}
 	report := bounded_c_error_bug_report(raw_report, c_error_bug_report_max_body_bytes)
 	report_url := c_error_bug_report_url(v.pref.c_error_bug_report_url)
@@ -850,7 +856,7 @@ fn (mut v Builder) submit_v3_compiler_error_bug_report(v3_stage string, v3_outpu
 	// C is already on stdout, so appending this banner there would corrupt the documented
 	// `-o -` output for exactly the programs that needed the fallback.
 	eprintln('================== V3 compiler bug report ==============')
-	print_v3_fallback_notice(report_url, true, report.v_source != '', v_source_upload_is_complete(report.v_source))
+	print_v3_fallback_notice(report_url, true, report.v_source != '', !report.v_source_truncated)
 	if tool_output != '' {
 		eprintln(tool_output)
 	}
@@ -935,13 +941,16 @@ fn report_includes_v_source(report CErrorBugReport) bool {
 	return report.v_source != '' || report.v_context.len > 0
 }
 
-// v_source_upload_is_complete reports whether the uploaded `v_source` is the complete
-// failing source rather than a bounded excerpt. The whole file is uploaded when it fits
-// the byte budget; only a larger file (or the head+tail internal-error window) carries the
-// truncation marker, and an empty `v_source` means nothing but context lines were sent.
-// Used so the fallback notice states accurately how much source reached the report service.
-fn v_source_upload_is_complete(v_source string) bool {
-	return v_source != '' && !v_source.contains(c_error_v_source_truncation_notice)
+// bounded_v_source_content_is_truncated reports whether already-bounded source *content* is a
+// bounded excerpt rather than the complete file. It is used only where the original source is
+// no longer available — reconstructing a report from bytes forwarded across the V3->V1 retry —
+// so truncation cannot be recomputed from the byte budget. bounded_v_source guarantees the
+// truncation marker on every truncation (including the single-oversized-line hard clamp), so
+// its presence is a reliable record there. In-process construction records truncation directly
+// from the byte budget instead (see new_c_error_bug_report), and the notice reads the resulting
+// explicit `CErrorBugReport.v_source_truncated` field rather than sniffing the bytes itself.
+fn bounded_v_source_content_is_truncated(v_source string) bool {
+	return v_source.contains(c_error_v_source_truncation_notice)
 }
 
 // print_v3_fallback_notice explains, in plain language, that V3 could not build the
@@ -1017,6 +1026,10 @@ fn (mut v Builder) new_c_error_bug_report(ccompiler string, c_output string) CEr
 	} else {
 		''
 	}
+	// The reproducer already fits the byte budget; the full-file branch is truncated only when
+	// the mapped file is larger than the budget. Record that explicitly for the notice.
+	v_source_truncated := repro == '' && is_v_source_file(v_file)
+		&& mapped_source.len > c_error_bug_report_max_v_source_bytes
 	// v_context is a separate uploaded payload; for a short mapped file its radius
 	// window can also span every line, so apply the same strict-subset rule to it.
 	mut v_context := numbered_context_lines(mapped_lines, v_line, c_error_context_radius)
@@ -1045,6 +1058,7 @@ fn (mut v Builder) new_c_error_bug_report(ccompiler string, c_output string) CEr
 		v_line:         v_line
 		v_context:      v_context
 		v_source:       v_source
+		v_source_truncated: v_source_truncated
 	}
 }
 
@@ -1348,8 +1362,16 @@ fn bounded_v_source(source string, max_bytes int, focus_line int) string {
 		parts << c_error_v_source_truncation_notice
 	}
 	result := parts.join('\n')
-	// safety clamp in case a single very long line still exceeds the budget
-	return if result.len > max_bytes { result[..max_bytes] } else { result }
+	if result.len <= max_bytes {
+		return result
+	}
+	// A single line longer than the whole budget still overflows the window. Hard-clamp it,
+	// but keep the truncation marker so a truncated upload is never a silently complete-looking
+	// prefix (the notice's truncation state is tracked explicitly, and this keeps the uploaded
+	// bytes self-describing too).
+	marker_tail := '\n${c_error_v_source_truncation_notice}'
+	clamp := if max_bytes > marker_tail.len { max_bytes - marker_tail.len } else { 0 }
+	return result[..clamp] + marker_tail
 }
 
 // new_c_error_bug_report_with_vlines regenerates the program's C source with `#line`

--- a/vlib/v/builder/c_error_report.v
+++ b/vlib/v/builder/c_error_report.v
@@ -1082,17 +1082,18 @@ fn (mut v Builder) new_c_error_bug_report(ccompiler string, c_output string, inc
 	// included header, not V source).
 	mapped_source := if v_file != '' { os.read_file(v_file) or { '' } } else { '' }
 	mapped_lines := mapped_source.split_into_lines()
-	// Prefer a self-contained reproducer (the failing declaration plus the closure of the user
-	// declarations it references). It already keeps itself within the byte budget, returning ''
-	// when it cannot, so it is uploaded verbatim; otherwise fall back to a plain source window.
-	repro := v.v_source_reproducer(v_file, v_line, c_error_bug_report_max_v_source_bytes)
-	mut v_source := if repro != '' {
-		repro
-	} else if include_full_source && is_v_source_file(v_file) {
-		// No self-contained reproducer (multi-module or non-`main` program): upload the full
-		// failing file so the report is reproducible, bounding only a file larger than the
-		// byte budget to a window around the failing line.
+	// Tagged V3 fallbacks always upload the verified mapped file, matching the normal inline
+	// handoff path. Direct stable-compiler reports retain their prior strict-subset selection:
+	// prefer a self-contained reproducer, then fall back to a local source window.
+	repro := if include_full_source {
+		''
+	} else {
+		v.v_source_reproducer(v_file, v_line, c_error_bug_report_max_v_source_bytes)
+	}
+	mut v_source := if include_full_source && is_v_source_file(v_file) {
 		bounded_v_source(mapped_source, c_error_bug_report_max_v_source_bytes, v_line)
+	} else if repro != '' {
+		repro
 	} else {
 		// Direct stable-compiler reports retain their established privacy boundary: select only
 		// a local window, and below drop it if that window would expose the complete file.
@@ -1102,12 +1103,10 @@ fn (mut v Builder) new_c_error_bug_report(ccompiler string, c_output string, inc
 	if !include_full_source && v_source_exposes_whole_file(v_source, mapped_source, mapped_lines) {
 		v_source = ''
 	}
-	// A reproducer is a synthesized subset of the module's declarations (possibly assembled from
-	// several files), not the whole file, so it is a bounded excerpt. The full-file branch is
-	// truncated only when the mapped file is larger than the byte budget. Record that explicitly
-	// for the notice.
-	v_source_truncated := v_source != '' && (repro != '' || !include_full_source
-		|| (is_v_source_file(v_file) && mapped_source.len > c_error_bug_report_max_v_source_bytes))
+	// Direct stable-compiler payloads are always strict subsets. A tagged V3 source is truncated
+	// only when the mapped file is larger than the byte budget.
+	v_source_truncated := v_source != ''
+		&& (!include_full_source || mapped_source.len > c_error_bug_report_max_v_source_bytes)
 	// v_context is a separate uploaded payload; for a short mapped file its radius
 	// window can also span every line, so apply the same strict-subset rule to it.
 	mut v_context := numbered_context_lines(mapped_lines, v_line, c_error_context_radius)

--- a/vlib/v/builder/c_error_report.v
+++ b/vlib/v/builder/c_error_report.v
@@ -490,57 +490,69 @@ pub fn export_external_v3_report_to_env(report ExternalCErrorBugReport) {
 		set_v3_report_env_payload(payload)
 		return
 	}
-	mut content_budget := budget - v3_report_env_payload_bytes(payload)
-	// Share the remaining aggregate capacity when both fields are present. A short
-	// missing-library/libatomic diagnostic remains intact, keeping the receiver's filter
-	// accurate, while large diagnostics and excerpts are both bounded.
-	// The full capacity the diagnostic may use when no source is forwarded.
+	// The aggregate capacity left after the base payload, split between the diagnostic and source.
+	content_budget := budget - v3_report_env_payload_bytes(payload)
+	plan := plan_env_report_content(report, content_budget, value_limit)
+	payload['COUTPUT'] = plan.c_output
+	payload['VSOURCE'] = plan.v_source
+	// Carry the truncation state explicitly through the handoff, computed from the byte budget
+	// rather than from (user-controlled) source content, so the retry's notice is accurate even
+	// when a complete file legitimately contains the truncation marker text.
+	payload['VSOURCE_TRUNCATED'] = if plan.v_source_truncated { '1' } else { '0' }
+	set_v3_report_env_payload(payload)
+}
+
+struct EnvContentPlan {
+	c_output           string
+	v_source           string
+	v_source_truncated bool
+}
+
+// plan_env_report_content splits `content_budget` (the aggregate environment capacity left after
+// the base payload) between the C diagnostic and the V source, each capped by `value_limit`. The
+// env payload counts value bytes, so the diagnostic and source consume exactly their lengths.
+//
+// When both are present it halves the capacity so a short missing-library/libatomic diagnostic
+// stays intact and the receiver's filter stays accurate. Source is bounded once, centered on the
+// failing line, or omitted when the budget cannot even hold the truncation marker (a markerless
+// prefix would drop the failing line and misreport the excerpt as complete). When source is
+// omitted the half reserved for it is reclaimed for the diagnostic, so the linker failure remains
+// recognizable rather than being misclassified as a compiler bug. Any truncation recorded upstream
+// (e.g. the first handoff before a wasm re-export) is preserved; further bounding only sets it.
+fn plan_env_report_content(report ExternalCErrorBugReport, content_budget int, value_limit int) EnvContentPlan {
 	full_c_output_budget := env_c_output_budget(content_budget, value_limit)
 	mut c_output_budget := content_budget
 	if report.v_source != '' {
 		c_output_budget /= 2
 	}
 	c_output_budget = env_c_output_budget(c_output_budget, value_limit)
-	payload['COUTPUT'] = truncated_report_text(report.c_output, c_output_budget)
-	content_budget = budget - v3_report_env_payload_bytes(payload)
-	v_source_budget := if content_budget < value_limit { content_budget } else { value_limit }
-	// Apply the byte bound once, here, centered on the failing line the producer identified, so a
-	// file larger than the environment budget still keeps the exact failing code instead of
-	// losing it to a second head+tail truncation. Omit source when the budget cannot hold real
-	// content plus a truncation marker: bounded_v_source would otherwise return a markerless
-	// prefix that both drops the failing line and misreports the excerpt as complete.
+	mut c_output := truncated_report_text(report.c_output, c_output_budget)
+	remaining := content_budget - c_output.len
+	v_source_budget := if remaining < value_limit { remaining } else { value_limit }
 	v_source_marker_min := c_error_v_source_truncation_notice.len + 2
-	// Preserve any truncation already recorded upstream (e.g. the first handoff bounded the source
-	// before the wasm re-export in cmd/v). Further bounding below only sets it, never clears it, so
-	// an already-bounded excerpt that fits this budget is not re-announced as the complete file.
 	mut v_source_truncated := report.v_source_truncated
 	mut source_omitted := false
-	payload['VSOURCE'] = if v_source_budget <= 0 {
+	v_source := if v_source_budget <= 0 {
 		source_omitted = report.v_source != ''
 		''
 	} else if report.v_source.len > v_source_budget && v_source_budget <= v_source_marker_min {
 		source_omitted = true
 		''
 	} else if report.v_source.len > v_source_budget {
-		// Larger than the budget: a bounded excerpt centered on the failing line.
 		v_source_truncated = true
 		bounded_v_source(report.v_source, v_source_budget, report.v_source_focus)
 	} else {
-		// Fits whole: the complete file is forwarded.
 		report.v_source
 	}
-	// The report had source, but the budget could not hold even the marker, so it was omitted.
-	// The half of the content budget that was reserved for it is now free: recompute COUTPUT with
-	// the full capacity so a short missing-library/libatomic diagnostic is not truncated past the
-	// receiver's recognizable form (which would misclassify it as a compiler bug).
 	if source_omitted && c_output_budget < full_c_output_budget {
-		payload['COUTPUT'] = truncated_report_text(report.c_output, full_c_output_budget)
+		// The half reserved for the omitted source is now free; give it back to the diagnostic.
+		c_output = truncated_report_text(report.c_output, full_c_output_budget)
 	}
-	// Carry the truncation state explicitly through the handoff, computed from the byte budget
-	// rather than from (user-controlled) source content, so the retry's notice is accurate even
-	// when a complete file legitimately contains the truncation marker text.
-	payload['VSOURCE_TRUNCATED'] = if v_source_truncated { '1' } else { '0' }
-	set_v3_report_env_payload(payload)
+	return EnvContentPlan{
+		c_output:           c_output
+		v_source:           v_source
+		v_source_truncated: v_source_truncated
+	}
 }
 
 // bounded_v3_fallback_source extracts the bounded V source snippet to upload for a V3->V1

--- a/vlib/v/builder/c_error_report.v
+++ b/vlib/v/builder/c_error_report.v
@@ -113,16 +113,14 @@ pub:
 	// a directory to delete — both of which would be forgeable by an inherited or hostile
 	// environment. When source_inline is set, v_file/v_source are used verbatim and no
 	// path from the report is ever read or removed.
-	v_file        string // informational base filename of the failing source (no directory)
-	v_source      string // the full failing file; the byte bound is applied once, at export
-	// v_source_focus is the 1-based failing line within v_source (0 for none). export applies
-	// the byte bound once, centered on it, so a file larger than the environment budget keeps
-	// the exact failing code instead of losing it to a second head+tail truncation.
+	v_file   string // informational base filename of the failing source (no directory)
+	v_source string // the full failing file, or an already bounded internal-error snapshot
+	// v_source_focus is the 1-based failing line within v_source (0 for none). export applies or
+	// tightens the byte bound centered on it, so a generated-C failure keeps the exact failing code.
 	v_source_focus int
-	// v_source_truncated records, explicitly, whether the forwarded v_source is a bounded
-	// excerpt rather than the complete file. export sets it from the byte-budget comparison it
-	// performs, and it rides through the environment so the retry states truncation accurately
-	// without ever inferring it from (user-controlled) source content.
+	// v_source_truncated records, explicitly, whether v_source is already a bounded excerpt.
+	// Export preserves it and also sets it when tightening the byte bound; it rides through the
+	// environment so the retry states truncation accurately without sniffing source content.
 	v_source_truncated bool
 	source_inline      bool // true: use v_file/v_source as-is and touch no filesystem path
 	// Untagged path/digest pairs below describe source bytes V3 actually parsed. The
@@ -455,10 +453,9 @@ fn env_c_output_budget(available int, value_limit int) int {
 }
 
 pub fn export_external_v3_report_to_env(report ExternalCErrorBugReport) {
-	// `report` is already content-only: its v_source was bounded by the process that owns
-	// the staged directory (bounded_v3_fallback_source), and that process deletes the
-	// directory itself. This function only forwards that content, so nothing here reads a
-	// path or deletes a directory named by the (inheritable, forgeable) environment.
+	// `report` is already content-only: its source was captured by the process that owns the staged
+	// directory, and that process deletes the directory itself. This function bounds and forwards
+	// that content, so nothing here reads a path or deletes a directory named by the environment.
 	mut encoded_digests := ''
 	mut input_digests_complete := false
 	if encoded := encode_v3_report_input_digests(report.input_digests) {
@@ -520,10 +517,9 @@ struct EnvContentPlan {
 // env payload counts value bytes, so the diagnostic and source consume exactly their lengths.
 //
 // When both are present it halves the capacity so a short missing-library/libatomic diagnostic
-// stays intact and the receiver's filter stays accurate. Source is bounded once, centered on the
-// failing line, or omitted when the budget cannot even hold the truncation marker (a markerless
-// prefix would drop the failing line and misreport the excerpt as complete). When source is
-// omitted the half reserved for it is reclaimed for the diagnostic, so the linker failure remains
+// stays intact and the receiver's filter stays accurate. Source is bounded around the failing line,
+// or omitted when the budget cannot hold the required marker(s) plus actual source content. When
+// source is omitted, its half is reclaimed for the diagnostic so the linker failure remains
 // recognizable rather than being misclassified as a compiler bug. Any truncation recorded upstream
 // (e.g. the first handoff before a wasm re-export) is preserved; further bounding only sets it.
 fn plan_env_report_content(report ExternalCErrorBugReport, content_budget int, value_limit int) EnvContentPlan {
@@ -536,22 +532,23 @@ fn plan_env_report_content(report ExternalCErrorBugReport, content_budget int, v
 	mut c_output := truncated_report_text(report.c_output, c_output_budget)
 	remaining := content_budget - c_output.len
 	v_source_budget := if remaining < value_limit { remaining } else { value_limit }
-	v_source_marker_min := c_error_v_source_truncation_notice.len + 2
 	mut v_source_truncated := report.v_source_truncated
 	mut source_omitted := false
 	mut v_source_focus := 0
 	v_source := if v_source_budget <= 0 {
 		source_omitted = report.v_source != ''
 		''
-	} else if report.v_source.len > v_source_budget && v_source_budget <= v_source_marker_min {
-		source_omitted = true
-		''
 	} else if report.v_source.len > v_source_budget {
-		v_source_truncated = true
 		bounded, focus := bounded_v_source_with_focus(report.v_source, v_source_budget,
 			report.v_source_focus)
-		v_source_focus = focus
-		bounded
+		if bounded == '' {
+			source_omitted = true
+			''
+		} else {
+			v_source_truncated = true
+			v_source_focus = focus
+			bounded
+		}
 	} else {
 		// Fits whole: the complete file is forwarded, with the failing line unchanged.
 		v_source_focus = report.v_source_focus
@@ -594,15 +591,15 @@ pub fn bounded_v3_fallback_source(kind string, c_output string, c_file string, a
 }
 
 // bounded_v3_internal_fallback_source returns the source CONTENT captured before V3 starts,
-// with focus 0 (a head+tail window is kept if it must be bounded at export). It never opens
-// `source_name`; the dispatcher separately verifies that the input still has the captured
-// digest before forwarding this content to the stable retry. The byte bound is applied once,
-// at the handoff, rather than here.
+// with focus 0. It never opens `source_name`; the dispatcher separately verifies that the input
+// still has the captured digest before forwarding this content to the stable retry. The snapshot
+// is bounded here so a successful V3 compile does not retain an unbounded source copy until exit;
+// export may tighten the bound further to fit the process environment.
 pub fn bounded_v3_internal_fallback_source(source_name string, source string) (string, string, int) {
 	if source_name == '' {
 		return '', '', 0
 	}
-	return os.base(source_name), source, 0
+	return os.base(source_name), bounded_v_source(source, c_error_bug_report_max_v_source_bytes, 0), 0
 }
 
 // bounded_v_source_for_generated_c maps a generated-C compilation error back to the V
@@ -1394,11 +1391,12 @@ fn bounded_v_source_with_focus(source string, max_bytes int, focus_line int) (st
 		return source, focus_line
 	}
 	marker := '\n${c_error_v_source_truncation_notice}\n'
-	if max_bytes <= marker.len {
-		// no room for both content and the marker: fall back to a hard prefix cut
-		return source[..max_bytes], 0
-	}
 	if focus_line <= 0 {
+		// A head+tail excerpt needs the marker plus at least two retained bytes: the split can
+		// assign one byte to each side, and line-boundary clamping may discard one side.
+		if max_bytes < marker.len + 2 {
+			return '', 0
+		}
 		kept_bytes := max_bytes - marker.len
 		head_budget := kept_bytes / 2
 		tail_budget := kept_bytes - head_budget
@@ -1453,13 +1451,16 @@ fn bounded_v_source_with_focus(source string, max_bytes int, focus_line int) (st
 	if result.len <= max_bytes {
 		return result, adjusted_focus
 	}
-	// A single line longer than the whole budget still overflows the window. Hard-clamp it,
-	// but keep the truncation marker so a truncated upload is never a silently complete-looking
-	// prefix (the notice's truncation state is tracked explicitly, and this keeps the uploaded
-	// bytes self-describing too).
+	// A single focused line longer than the whole budget still overflows the window. Build the
+	// clamp explicitly from its markers and line prefix, rather than slicing `result`: when there
+	// is a leading marker, slicing can spend the entire budget on marker text and retain no source.
+	leading_marker := if lo > 0 { '${c_error_v_source_truncation_notice}\n' } else { '' }
 	marker_tail := '\n${c_error_v_source_truncation_notice}'
-	clamp := if max_bytes > marker_tail.len { max_bytes - marker_tail.len } else { 0 }
-	return result[..clamp] + marker_tail, adjusted_focus
+	clamp := max_bytes - leading_marker.len - marker_tail.len
+	if clamp <= 0 {
+		return '', 0
+	}
+	return leading_marker + lines[fi][..clamp] + marker_tail, adjusted_focus
 }
 
 // new_c_error_bug_report_with_vlines regenerates the program's C source with `#line`

--- a/vlib/v/builder/c_error_report.v
+++ b/vlib/v/builder/c_error_report.v
@@ -510,7 +510,10 @@ pub fn export_external_v3_report_to_env(report ExternalCErrorBugReport) {
 	// content plus a truncation marker: bounded_v_source would otherwise return a markerless
 	// prefix that both drops the failing line and misreports the excerpt as complete.
 	v_source_marker_min := c_error_v_source_truncation_notice.len + 2
-	mut v_source_truncated := false
+	// Preserve any truncation already recorded upstream (e.g. the first handoff bounded the source
+	// before the wasm re-export in cmd/v). Further bounding below only sets it, never clears it, so
+	// an already-bounded excerpt that fits this budget is not re-announced as the complete file.
+	mut v_source_truncated := report.v_source_truncated
 	mut source_omitted := false
 	payload['VSOURCE'] = if v_source_budget <= 0 {
 		source_omitted = report.v_source != ''
@@ -1069,10 +1072,12 @@ fn (mut v Builder) new_c_error_bug_report(ccompiler string, c_output string) CEr
 	} else {
 		''
 	}
-	// The reproducer already fits the byte budget; the full-file branch is truncated only when
-	// the mapped file is larger than the budget. Record that explicitly for the notice.
-	v_source_truncated := repro == '' && is_v_source_file(v_file)
-		&& mapped_source.len > c_error_bug_report_max_v_source_bytes
+	// A reproducer is a synthesized subset of the module's declarations (possibly assembled from
+	// several files), not the whole file, so it is a bounded excerpt. The full-file branch is
+	// truncated only when the mapped file is larger than the byte budget. Record that explicitly
+	// for the notice.
+	v_source_truncated := repro != ''
+		|| (is_v_source_file(v_file) && mapped_source.len > c_error_bug_report_max_v_source_bytes)
 	// v_context is a separate uploaded payload; for a short mapped file its radius
 	// window can also span every line, so apply the same strict-subset rule to it.
 	mut v_context := numbered_context_lines(mapped_lines, v_line, c_error_context_radius)

--- a/vlib/v/builder/c_error_report.v
+++ b/vlib/v/builder/c_error_report.v
@@ -73,7 +73,7 @@ pub:
 	v_file         string
 	v_line         int
 	v_context      []CErrorReportLine
-	v_source       string // the full failing V file, so the report is reproducible (bounded only when larger than the byte budget)
+	v_source       string // full mapped source for a V3 fallback, or a bounded excerpt for a direct stable-compiler report
 	// v_source_truncated records, explicitly, whether v_source is a bounded excerpt rather than
 	// the complete file, so the fallback notice states accurately how much source was uploaded
 	// without having to sniff for the in-band truncation marker.
@@ -193,12 +193,12 @@ fn (mut v Builder) submit_c_error_bug_report_with_tag(ccompiler string, c_output
 	// Snapshot the user's real flags now: the vlines fallback below temporarily flips
 	// `pref.is_vlines`, so computing this after it would misreport `vlines` for plain builds.
 	build_options := c_error_report_build_options(v.pref, tag)
-	mut raw_report := v.new_c_error_bug_report(ccompiler, c_output)
+	mut raw_report := v.new_c_error_bug_report(ccompiler, c_output, is_v3_fallback)
 	if retry_with_vlines && raw_report.v_file == '' {
 		// The default `.tmp.c` has no `#line` directives, so the C error could not be
 		// traced back to a V line. Regenerate the C with `#line` info (as `-g` would),
 		// recompile, and reuse the richer report when it does map to a V source line.
-		if vlines_report := v.new_c_error_bug_report_with_vlines(ccompiler) {
+		if vlines_report := v.new_c_error_bug_report_with_vlines(ccompiler, is_v3_fallback) {
 			raw_report = vlines_report
 		}
 	}
@@ -1057,7 +1057,7 @@ fn c_error_report_build_options(prefs &pref.Preferences, tag string) string {
 	return '${trimmed_tag} ${options}'
 }
 
-fn (mut v Builder) new_c_error_bug_report(ccompiler string, c_output string) CErrorBugReport {
+fn (mut v Builder) new_c_error_bug_report(ccompiler string, c_output string, include_full_source bool) CErrorBugReport {
 	c_source := os.read_file(v.out_name_c) or { '' }
 	c_lines := c_source.split_into_lines()
 	mut c_file := v.out_name_c
@@ -1086,22 +1086,28 @@ fn (mut v Builder) new_c_error_bug_report(ccompiler string, c_output string) CEr
 	// declarations it references). It already keeps itself within the byte budget, returning ''
 	// when it cannot, so it is uploaded verbatim; otherwise fall back to a plain source window.
 	repro := v.v_source_reproducer(v_file, v_line, c_error_bug_report_max_v_source_bytes)
-	v_source := if repro != '' {
+	mut v_source := if repro != '' {
 		repro
-	} else if is_v_source_file(v_file) {
+	} else if include_full_source && is_v_source_file(v_file) {
 		// No self-contained reproducer (multi-module or non-`main` program): upload the full
 		// failing file so the report is reproducible, bounding only a file larger than the
 		// byte budget to a window around the failing line.
 		bounded_v_source(mapped_source, c_error_bug_report_max_v_source_bytes, v_line)
 	} else {
-		''
+		// Direct stable-compiler reports retain their established privacy boundary: select only
+		// a local window, and below drop it if that window would expose the complete file.
+		v_chunk := selected_v_source(v_file, mapped_lines, v_line)
+		bounded_v_source(v_chunk.text, c_error_bug_report_max_v_source_bytes, v_chunk.focus)
+	}
+	if !include_full_source && v_source_exposes_whole_file(v_source, mapped_source, mapped_lines) {
+		v_source = ''
 	}
 	// A reproducer is a synthesized subset of the module's declarations (possibly assembled from
 	// several files), not the whole file, so it is a bounded excerpt. The full-file branch is
 	// truncated only when the mapped file is larger than the byte budget. Record that explicitly
 	// for the notice.
-	v_source_truncated := repro != ''
-		|| (is_v_source_file(v_file) && mapped_source.len > c_error_bug_report_max_v_source_bytes)
+	v_source_truncated := v_source != '' && (repro != '' || !include_full_source
+		|| (is_v_source_file(v_file) && mapped_source.len > c_error_bug_report_max_v_source_bytes))
 	// v_context is a separate uploaded payload; for a short mapped file its radius
 	// window can also span every line, so apply the same strict-subset rule to it.
 	mut v_context := numbered_context_lines(mapped_lines, v_line, c_error_context_radius)
@@ -1115,21 +1121,21 @@ fn (mut v Builder) new_c_error_bug_report(ccompiler string, c_output string) CEr
 		v_context = []CErrorReportLine{}
 	}
 	return CErrorBugReport{
-		kind:           'v-c-compiler-error'
-		v_version:      version.full_v_version(true)
-		target_os:      v.pref.os.str()
-		target_backend: v.pref.backend.str()
-		arch:           v.pref.arch.str()
-		ccompiler:      ccompiler
-		build_options:  codegen_build_options(v.pref)
-		c_error:        c_output
-		c_file:         c_file
-		c_line:         c_line
-		c_context:      numbered_context_lines(c_lines, c_line, c_error_context_radius)
-		v_file:         v_file
-		v_line:         v_line
-		v_context:      v_context
-		v_source:       v_source
+		kind:               'v-c-compiler-error'
+		v_version:          version.full_v_version(true)
+		target_os:          v.pref.os.str()
+		target_backend:     v.pref.backend.str()
+		arch:               v.pref.arch.str()
+		ccompiler:          ccompiler
+		build_options:      codegen_build_options(v.pref)
+		c_error:            c_output
+		c_file:             c_file
+		c_line:             c_line
+		c_context:          numbered_context_lines(c_lines, c_line, c_error_context_radius)
+		v_file:             v_file
+		v_line:             v_line
+		v_context:          v_context
+		v_source:           v_source
 		v_source_truncated: v_source_truncated
 	}
 }
@@ -1469,7 +1475,7 @@ fn bounded_v_source_with_focus(source string, max_bytes int, focus_line int) (st
 // Because the regenerated C carries `#line` annotations, the C error can be mapped back
 // to the exact V source line that produced it. It returns none when the V mapping still
 // cannot be produced, so the caller keeps the original, C-only report.
-fn (mut v Builder) new_c_error_bug_report_with_vlines(ccompiler string) ?CErrorBugReport {
+fn (mut v Builder) new_c_error_bug_report_with_vlines(ccompiler string, include_full_source bool) ?CErrorBugReport {
 	if v.pref.is_vlines || v.pref.parallel_cc || v.pref.generate_c_project != ''
 		|| v.last_cc_cmd == '' || v.parsed_files.len == 0 || v.out_name_c == '' {
 		return none
@@ -1492,7 +1498,7 @@ fn (mut v Builder) new_c_error_bug_report_with_vlines(ccompiler string) ?CErrorB
 	os.chdir(vdir) or {}
 	recompiled := os.execute(v.last_cc_cmd)
 	os.chdir(original_pwd) or {}
-	report := v.new_c_error_bug_report(ccompiler, recompiled.output)
+	report := v.new_c_error_bug_report(ccompiler, recompiled.output, include_full_source)
 	// Restore the C source that the user actually compiled, now that the report is built.
 	os.write_file(v.out_name_c, original_c) or {}
 	if report.v_file == '' {

--- a/vlib/v/builder/c_error_report.v
+++ b/vlib/v/builder/c_error_report.v
@@ -119,7 +119,12 @@ pub:
 	// the byte bound once, centered on it, so a file larger than the environment budget keeps
 	// the exact failing code instead of losing it to a second head+tail truncation.
 	v_source_focus int
-	source_inline  bool // true: use v_file/v_source as-is and touch no filesystem path
+	// v_source_truncated records, explicitly, whether the forwarded v_source is a bounded
+	// excerpt rather than the complete file. export sets it from the byte-budget comparison it
+	// performs, and it rides through the environment so the retry states truncation accurately
+	// without ever inferring it from (user-controlled) source content.
+	v_source_truncated bool
+	source_inline      bool // true: use v_file/v_source as-is and touch no filesystem path
 	// Untagged path/digest pairs below describe source bytes V3 actually parsed. The
 	// stable parser compares them only with its own parsed-file paths and scanner
 	// digests. Tagged native inputs describe resolved #include/#insert dependencies;
@@ -276,10 +281,10 @@ fn consume_external_c_error_bug_report(prefs &pref.Preferences, report ExternalC
 		}
 		if report.kind == external_v3_compiler_error_kind {
 			submit_inline_v3_compiler_error_bug_report(prefs, report.ccompiler, report.c_output,
-				report.v_file, report.v_source, report.tag)
+				report.v_file, report.v_source, report.v_source_truncated, report.tag)
 		} else {
 			submit_inline_c_error_bug_report(prefs, report.ccompiler, report.c_output,
-				report.v_file, report.v_source, report.tag)
+				report.v_file, report.v_source, report.v_source_truncated, report.tag)
 		}
 		return
 	}
@@ -305,7 +310,7 @@ const v3_report_env_prefix = 'V_MACOS_V3_REPORT_'
 // only and no directory path is accepted. Tagged native paths can only be hashed after
 // the receiver constrains them to roots selected by its own successful build.
 const v3_report_env_suffixes = ['PRESENT', 'KIND', 'CCOMPILER', 'COUTPUT', 'TAG', 'VFILE', 'VSOURCE',
-	'INPUT_DIGESTS', 'INPUT_DIGESTS_COMPLETE']
+	'VSOURCE_TRUNCATED', 'INPUT_DIGESTS', 'INPUT_DIGESTS_COMPLETE']
 
 // encode_v3_report_input_digests serializes arbitrary input paths without allowing a
 // newline or separator in a filename to corrupt the manifest. Untagged paths are matched
@@ -452,6 +457,7 @@ pub fn export_external_v3_report_to_env(report ExternalCErrorBugReport) {
 		'TAG':                    report.tag
 		'VFILE':                  report.v_file
 		'VSOURCE':                ''
+		'VSOURCE_TRUNCATED':      '0'
 		'INPUT_DIGESTS':          encoded_digests
 		'INPUT_DIGESTS_COMPLETE': if input_digests_complete { '1' } else { '0' }
 	}
@@ -491,13 +497,23 @@ pub fn export_external_v3_report_to_env(report ExternalCErrorBugReport) {
 	// content plus a truncation marker: bounded_v_source would otherwise return a markerless
 	// prefix that both drops the failing line and misreports the excerpt as complete.
 	v_source_marker_min := c_error_v_source_truncation_notice.len + 2
+	mut v_source_truncated := false
 	payload['VSOURCE'] = if v_source_budget <= 0 {
 		''
 	} else if report.v_source.len > v_source_budget && v_source_budget <= v_source_marker_min {
 		''
-	} else {
+	} else if report.v_source.len > v_source_budget {
+		// Larger than the budget: a bounded excerpt centered on the failing line.
+		v_source_truncated = true
 		bounded_v_source(report.v_source, v_source_budget, report.v_source_focus)
+	} else {
+		// Fits whole: the complete file is forwarded.
+		report.v_source
 	}
+	// Carry the truncation state explicitly through the handoff, computed from the byte budget
+	// rather than from (user-controlled) source content, so the retry's notice is accurate even
+	// when a complete file legitimately contains the truncation marker text.
+	payload['VSOURCE_TRUNCATED'] = if v_source_truncated { '1' } else { '0' }
 	set_v3_report_env_payload(payload)
 }
 
@@ -607,6 +623,7 @@ pub fn take_external_v3_report_from_env() ?ExternalCErrorBugReport {
 		tag:                    os.getenv('${v3_report_env_prefix}TAG')
 		v_file:                 os.getenv('${v3_report_env_prefix}VFILE')
 		v_source:               os.getenv('${v3_report_env_prefix}VSOURCE')
+		v_source_truncated:     os.getenv('${v3_report_env_prefix}VSOURCE_TRUNCATED') == '1'
 		source_inline:          true
 		input_digests:          input_digests
 		input_digests_complete: os.getenv('${v3_report_env_prefix}INPUT_DIGESTS_COMPLETE') == '1'
@@ -772,7 +789,7 @@ pub fn submit_external_v3_compiler_error_bug_report(prefs &pref.Preferences, v3_
 		''
 	} else {
 		os.base(v_file)
-	}, '', tag)
+	}, '', false, tag)
 }
 
 // submit_inline_v3_compiler_error_bug_report reports a V3 internal compiler error whose
@@ -780,9 +797,10 @@ pub fn submit_external_v3_compiler_error_bug_report(prefs &pref.Preferences, v3_
 // file is identified only by the base name `v_file_label`. It reads no filesystem path,
 // so it is safe to drive from the environment handoff, where every value is caller-
 // controlled (a forged handoff can therefore only submit attacker-supplied text).
-fn submit_inline_v3_compiler_error_bug_report(prefs &pref.Preferences, v3_stage string, v3_output string, v_file_label string, v_source string, tag string) {
+fn submit_inline_v3_compiler_error_bug_report(prefs &pref.Preferences, v3_stage string, v3_output string, v_file_label string, v_source string, v_source_truncated bool, tag string) {
 	mut b := new_builder(prefs)
-	b.submit_v3_compiler_error_bug_report(v3_stage, v3_output, v_file_label, v_source, tag)
+	b.submit_v3_compiler_error_bug_report(v3_stage, v3_output, v_file_label, v_source, v_source_truncated,
+		tag)
 }
 
 // build_inline_c_error_report constructs the generated-C fallback report to upload from
@@ -790,7 +808,7 @@ fn submit_inline_v3_compiler_error_bug_report(prefs &pref.Preferences, v3_stage 
 // submission (an expected missing-library / missing-libatomic error). No generated C is
 // available inline, so there is no C context or C/V line mapping — only the bounded V
 // source snippet — but the `v-c-compiler-error` classification matches the in-process path.
-fn build_inline_c_error_report(prefs &pref.Preferences, ccompiler string, c_output string, v_file string, v_source string, tag string) ?CErrorBugReport {
+fn build_inline_c_error_report(prefs &pref.Preferences, ccompiler string, c_output string, v_file string, v_source string, v_source_truncated bool, tag string) ?CErrorBugReport {
 	if !c_error_should_send_bug_report(c_output) {
 		return none
 	}
@@ -805,7 +823,7 @@ fn build_inline_c_error_report(prefs &pref.Preferences, ccompiler string, c_outp
 		c_error:        c_output
 		v_file:         v_file
 		v_source:       v_source
-		v_source_truncated: bounded_v_source_content_is_truncated(v_source)
+		v_source_truncated: v_source_truncated
 	}
 }
 
@@ -815,9 +833,10 @@ fn build_inline_c_error_report(prefs &pref.Preferences, ccompiler string, c_outp
 // c_error_should_send_bug_report filter (so expected missing-library / missing-libatomic
 // diagnostics are not uploaded) and the `v-c-compiler-error` classification. It reads no
 // filesystem path, so it is safe to drive from the environment handoff.
-fn submit_inline_c_error_bug_report(prefs &pref.Preferences, ccompiler string, c_output string, v_file_label string, v_source string, tag string) {
+fn submit_inline_c_error_bug_report(prefs &pref.Preferences, ccompiler string, c_output string, v_file_label string, v_source string, v_source_truncated bool, tag string) {
 	is_v3_fallback := tag != ''
-	raw_report := build_inline_c_error_report(prefs, ccompiler, c_output, v_file_label, v_source, tag) or {
+	raw_report := build_inline_c_error_report(prefs, ccompiler, c_output, v_file_label, v_source,
+		v_source_truncated, tag) or {
 		// Not eligible for automatic submission (e.g. a missing library), but V3 still
 		// fell back to the stable compiler, so the user is told about the fallback.
 		if is_v3_fallback {
@@ -835,18 +854,17 @@ fn submit_inline_c_error_bug_report(prefs &pref.Preferences, ccompiler string, c
 	b.send_prepared_c_error_bug_report(raw_report, tag)
 }
 
-fn (mut v Builder) submit_v3_compiler_error_bug_report(v3_stage string, v3_output string, v_file string, v_source string, tag string) {
+fn (mut v Builder) submit_v3_compiler_error_bug_report(v3_stage string, v3_output string, v_file string, v_source string, v_source_truncated bool, tag string) {
 	if !should_submit_c_error_bug_report(v.pref.c_error_bug_report_url) {
 		print_v3_fallback_notice('', false, false, false)
 		return
 	}
 	build_options := c_error_report_build_options(v.pref, tag)
-	// A V3 internal failure has no mapped failing line to center a window on, so
-	// only a bounded head+tail window of the source is uploaded (never the whole
-	// file, which could hold unrelated proprietary code or secrets), mirroring the
-	// C-error report path. A directory build (`v .`) stages an empty source and so
-	// contributes no source at all — but the version/target/build-option metadata is
-	// still reported rather than dropped entirely. See the privacy note in doc/docs.md.
+	// A V3 internal failure has no mapped failing line, so the whole captured input is uploaded
+	// (bounded to a head+tail window at the handoff only when larger than the byte budget); the
+	// dispatcher forwards it and its explicit truncation state through the environment. A
+	// directory build (`v .`) stages an empty source and so contributes no source at all — but
+	// the version/target/build-option metadata is still reported. See doc/docs.md.
 	raw_report := CErrorBugReport{
 		kind:           'v3-compiler-error'
 		v_version:      version.full_v_version(true)
@@ -858,7 +876,7 @@ fn (mut v Builder) submit_v3_compiler_error_bug_report(v3_stage string, v3_outpu
 		c_error:        v3_output
 		v_file:         v_file
 		v_source:       v_source
-		v_source_truncated: bounded_v_source_content_is_truncated(v_source)
+		v_source_truncated: v_source_truncated
 	}
 	report := bounded_c_error_bug_report(raw_report, c_error_bug_report_max_body_bytes)
 	report_url := c_error_bug_report_url(v.pref.c_error_bug_report_url)
@@ -945,18 +963,6 @@ fn v_source_and_context_expose_whole_file(v_source string, context []CErrorRepor
 // metadata-only report carries neither.
 fn report_includes_v_source(report CErrorBugReport) bool {
 	return report.v_source != '' || report.v_context.len > 0
-}
-
-// bounded_v_source_content_is_truncated reports whether already-bounded source *content* is a
-// bounded excerpt rather than the complete file. It is used only where the original source is
-// no longer available — reconstructing a report from bytes forwarded across the V3->V1 retry —
-// so truncation cannot be recomputed from the byte budget. bounded_v_source guarantees the
-// truncation marker on every truncation (including the single-oversized-line hard clamp), so
-// its presence is a reliable record there. In-process construction records truncation directly
-// from the byte budget instead (see new_c_error_bug_report), and the notice reads the resulting
-// explicit `CErrorBugReport.v_source_truncated` field rather than sniffing the bytes itself.
-fn bounded_v_source_content_is_truncated(v_source string) bool {
-	return v_source.contains(c_error_v_source_truncation_notice)
 }
 
 // print_v3_fallback_notice explains, in plain language, that V3 could not build the

--- a/vlib/v/builder/c_error_report.v
+++ b/vlib/v/builder/c_error_report.v
@@ -114,8 +114,12 @@ pub:
 	// environment. When source_inline is set, v_file/v_source are used verbatim and no
 	// path from the report is ever read or removed.
 	v_file        string // informational base filename of the failing source (no directory)
-	v_source      string // the full failing file (bounded only when larger than the byte budget)
-	source_inline bool   // true: use v_file/v_source as-is and touch no filesystem path
+	v_source      string // the full failing file; the byte bound is applied once, at export
+	// v_source_focus is the 1-based failing line within v_source (0 for none). export applies
+	// the byte bound once, centered on it, so a file larger than the environment budget keeps
+	// the exact failing code instead of losing it to a second head+tail truncation.
+	v_source_focus int
+	source_inline  bool // true: use v_file/v_source as-is and touch no filesystem path
 	// Untagged path/digest pairs below describe source bytes V3 actually parsed. The
 	// stable parser compares them only with its own parsed-file paths and scanner
 	// digests. Tagged native inputs describe resolved #include/#insert dependencies;
@@ -481,10 +485,18 @@ pub fn export_external_v3_report_to_env(report ExternalCErrorBugReport) {
 	payload['COUTPUT'] = truncated_report_text(report.c_output, c_output_budget)
 	content_budget = budget - v3_report_env_payload_bytes(payload)
 	v_source_budget := if content_budget < value_limit { content_budget } else { value_limit }
-	payload['VSOURCE'] = if v_source_budget > 0 {
-		bounded_v_source(report.v_source, v_source_budget, 0)
-	} else {
+	// Apply the byte bound once, here, centered on the failing line the producer identified, so a
+	// file larger than the environment budget still keeps the exact failing code instead of
+	// losing it to a second head+tail truncation. Omit source when the budget cannot hold real
+	// content plus a truncation marker: bounded_v_source would otherwise return a markerless
+	// prefix that both drops the failing line and misreports the excerpt as complete.
+	v_source_marker_min := c_error_v_source_truncation_notice.len + 2
+	payload['VSOURCE'] = if v_source_budget <= 0 {
 		''
+	} else if report.v_source.len > v_source_budget && v_source_budget <= v_source_marker_min {
+		''
+	} else {
+		bounded_v_source(report.v_source, v_source_budget, report.v_source_focus)
 	}
 	set_v3_report_env_payload(payload)
 }
@@ -499,27 +511,30 @@ pub fn export_external_v3_report_to_env(report ExternalCErrorBugReport) {
 // `allowed_v_sources` maps every source file V3 actually parsed to the SHA-256 digest
 // captured from those exact parser bytes. Generated-C mappings outside that set, or
 // files whose current contents no longer match the captured digest, contribute no
-// source. The returned source is the full mapped file, so the report is reproducible
-// (bounded to a window only when the file is larger than the byte budget); ('', '')
-// means no source is available, so the report stays metadata-only.
-pub fn bounded_v3_fallback_source(kind string, c_output string, c_file string, allowed_v_sources map[string]string) (string, string) {
+// source. The returned source is the full mapped file plus the 1-based failing line to focus
+// on; the byte bound is applied once, at the handoff, centered on that line, so it is never
+// dropped by a second truncation. ('', '', 0) means no source is available, so the report
+// stays metadata-only.
+pub fn bounded_v3_fallback_source(kind string, c_output string, c_file string, allowed_v_sources map[string]string) (string, string, int) {
 	if kind == external_v3_compiler_error_kind {
-		return '', ''
+		return '', '', 0
 	}
 	if c_file == '' || !os.is_file(c_file) {
-		return '', ''
+		return '', '', 0
 	}
 	return bounded_v_source_for_generated_c(c_output, c_file, allowed_v_sources)
 }
 
-// bounded_v3_internal_fallback_source bounds source CONTENT captured before V3 starts.
-// It never opens `source_name`; the dispatcher separately verifies that the input still
-// has the captured digest before forwarding this snippet to the stable retry.
-pub fn bounded_v3_internal_fallback_source(source_name string, source string) (string, string) {
+// bounded_v3_internal_fallback_source returns the source CONTENT captured before V3 starts,
+// with focus 0 (a head+tail window is kept if it must be bounded at export). It never opens
+// `source_name`; the dispatcher separately verifies that the input still has the captured
+// digest before forwarding this content to the stable retry. The byte bound is applied once,
+// at the handoff, rather than here.
+pub fn bounded_v3_internal_fallback_source(source_name string, source string) (string, string, int) {
 	if source_name == '' {
-		return '', ''
+		return '', '', 0
 	}
-	return os.base(source_name), v3_report_v_source(source)
+	return os.base(source_name), source, 0
 }
 
 // bounded_v_source_for_generated_c maps a generated-C compilation error back to the V
@@ -528,8 +543,8 @@ pub fn bounded_v3_internal_fallback_source(source_name string, source string) (s
 // is larger than the byte budget), so the report is reproducible. The generated C was
 // staged by this process's own V3 run, while its mapped V path is trusted only when it
 // matches a parsed compiler input.
-fn bounded_v_source_for_generated_c(c_output string, generated_c_file string, allowed_v_sources map[string]string) (string, string) {
-	c_source := os.read_file(generated_c_file) or { return '', '' }
+fn bounded_v_source_for_generated_c(c_output string, generated_c_file string, allowed_v_sources map[string]string) (string, string, int) {
+	c_source := os.read_file(generated_c_file) or { return '', '', 0 }
 	c_lines := c_source.split_into_lines()
 	mut v_file := ''
 	mut v_line := 0
@@ -543,7 +558,7 @@ fn bounded_v_source_for_generated_c(c_output string, generated_c_file string, al
 		v_line = source_loc.line
 	}
 	if v_file == '' || !os.is_file(v_file) {
-		return '', ''
+		return '', '', 0
 	}
 	mut parsed_digest := ''
 	for parsed_file, digest in allowed_v_sources {
@@ -553,23 +568,23 @@ fn bounded_v_source_for_generated_c(c_output string, generated_c_file string, al
 		}
 	}
 	if parsed_digest == '' {
-		return '', ''
+		return '', '', 0
 	}
-	mapped_source := os.read_file(v_file) or { return '', '' }
+	mapped_source := os.read_file(v_file) or { return '', '', 0 }
 	if sha256.hexhash(mapped_source) != parsed_digest {
 		// An editor/build watcher rewrote this input after V3 parsed it. Keep the
 		// report metadata-only rather than uploading bytes unrelated to the failure.
-		return os.base(v_file), ''
+		return os.base(v_file), '', 0
 	}
-	// Upload the full failing file so the report is reproducible. The digest check above
-	// guarantees these are exactly the bytes V3 parsed, and only files V3 actually parsed
-	// (always V source, never a mapped header) reach this point. A file larger than the byte
-	// budget is reduced to a window around the failing line so the report still fits.
+	// Return the full failing file plus the failing line so the report is reproducible. The
+	// digest check above guarantees these are exactly the bytes V3 parsed, and only files V3
+	// actually parsed (always V source, never a mapped header) reach this point. The byte bound
+	// is applied once, at the handoff (export_external_v3_report_to_env), centered on this line,
+	// so a file larger than the environment budget still keeps the exact failing code.
 	if !is_v_source_file(v_file) {
-		return os.base(v_file), ''
+		return os.base(v_file), '', 0
 	}
-	v_source := bounded_v_source(mapped_source, c_error_bug_report_max_v_source_bytes, v_line)
-	return os.base(v_file), v_source
+	return os.base(v_file), mapped_source, v_line
 }
 
 // take_external_v3_report_from_env returns the content-only fallback report exported by
@@ -862,15 +877,6 @@ fn (mut v Builder) submit_v3_compiler_error_bug_report(v3_stage string, v3_outpu
 	}
 	eprintln('V ${report.v_version}, ${report.target_os}/${report.arch}, build options: ${report.build_options}')
 	eprintln('='.repeat('================== V3 compiler bug report =============='.len))
-}
-
-// v3_report_v_source returns the V source uploaded for an internal V3 failure. An
-// internal failure has no mapped failing line, so the whole captured input is uploaded
-// to make the report reproducible; the dispatcher only forwards it when the input still
-// has the exact digest V3 parsed. Only an input larger than the byte budget is reduced
-// to a bounded head+tail window.
-fn v3_report_v_source(source string) string {
-	return bounded_v_source(source, c_error_bug_report_max_v_source_bytes, 0)
 }
 
 // v_source_is_whole_file reports whether the selected excerpt is the entire mapped

--- a/vlib/v/builder/c_error_report.v
+++ b/vlib/v/builder/c_error_report.v
@@ -313,7 +313,7 @@ const v3_report_env_prefix = 'V_MACOS_V3_REPORT_'
 // only and no directory path is accepted. Tagged native paths can only be hashed after
 // the receiver constrains them to roots selected by its own successful build.
 const v3_report_env_suffixes = ['PRESENT', 'KIND', 'CCOMPILER', 'COUTPUT', 'TAG', 'VFILE', 'VSOURCE',
-	'VSOURCE_TRUNCATED', 'INPUT_DIGESTS', 'INPUT_DIGESTS_COMPLETE']
+	'VSOURCE_TRUNCATED', 'VSOURCE_FOCUS', 'INPUT_DIGESTS', 'INPUT_DIGESTS_COMPLETE']
 
 // encode_v3_report_input_digests serializes arbitrary input paths without allowing a
 // newline or separator in a filename to corrupt the manifest. Untagged paths are matched
@@ -474,6 +474,7 @@ pub fn export_external_v3_report_to_env(report ExternalCErrorBugReport) {
 		'VFILE':                  report.v_file
 		'VSOURCE':                ''
 		'VSOURCE_TRUNCATED':      '0'
+		'VSOURCE_FOCUS':          '0'
 		'INPUT_DIGESTS':          encoded_digests
 		'INPUT_DIGESTS_COMPLETE': if input_digests_complete { '1' } else { '0' }
 	}
@@ -499,6 +500,9 @@ pub fn export_external_v3_report_to_env(report ExternalCErrorBugReport) {
 	// rather than from (user-controlled) source content, so the retry's notice is accurate even
 	// when a complete file legitimately contains the truncation marker text.
 	payload['VSOURCE_TRUNCATED'] = if plan.v_source_truncated { '1' } else { '0' }
+	// Carry the failing line's position within the forwarded excerpt so a later re-bound (the wasm
+	// re-export) centers on it instead of dropping it with a head+tail window.
+	payload['VSOURCE_FOCUS'] = plan.v_source_focus.str()
 	set_v3_report_env_payload(payload)
 }
 
@@ -506,6 +510,9 @@ struct EnvContentPlan {
 	c_output           string
 	v_source           string
 	v_source_truncated bool
+	// v_source_focus is the failing line's 1-based position within the produced v_source, carried
+	// through the handoff so a further re-bound (e.g. the wasm re-export) keeps the failing line.
+	v_source_focus int
 }
 
 // plan_env_report_content splits `content_budget` (the aggregate environment capacity left after
@@ -532,6 +539,7 @@ fn plan_env_report_content(report ExternalCErrorBugReport, content_budget int, v
 	v_source_marker_min := c_error_v_source_truncation_notice.len + 2
 	mut v_source_truncated := report.v_source_truncated
 	mut source_omitted := false
+	mut v_source_focus := 0
 	v_source := if v_source_budget <= 0 {
 		source_omitted = report.v_source != ''
 		''
@@ -540,8 +548,13 @@ fn plan_env_report_content(report ExternalCErrorBugReport, content_budget int, v
 		''
 	} else if report.v_source.len > v_source_budget {
 		v_source_truncated = true
-		bounded_v_source(report.v_source, v_source_budget, report.v_source_focus)
+		bounded, focus := bounded_v_source_with_focus(report.v_source, v_source_budget,
+			report.v_source_focus)
+		v_source_focus = focus
+		bounded
 	} else {
+		// Fits whole: the complete file is forwarded, with the failing line unchanged.
+		v_source_focus = report.v_source_focus
 		report.v_source
 	}
 	if source_omitted && c_output_budget < full_c_output_budget {
@@ -552,6 +565,7 @@ fn plan_env_report_content(report ExternalCErrorBugReport, content_budget int, v
 		c_output:           c_output
 		v_source:           v_source
 		v_source_truncated: v_source_truncated
+		v_source_focus:     v_source_focus
 	}
 }
 
@@ -662,6 +676,7 @@ pub fn take_external_v3_report_from_env() ?ExternalCErrorBugReport {
 		v_file:                 os.getenv('${v3_report_env_prefix}VFILE')
 		v_source:               os.getenv('${v3_report_env_prefix}VSOURCE')
 		v_source_truncated:     os.getenv('${v3_report_env_prefix}VSOURCE_TRUNCATED') == '1'
+		v_source_focus:         os.getenv('${v3_report_env_prefix}VSOURCE_FOCUS').int()
 		source_inline:          true
 		input_digests:          input_digests
 		input_digests_complete: os.getenv('${v3_report_env_prefix}INPUT_DIGESTS_COMPLETE') == '1'
@@ -1363,16 +1378,25 @@ fn v_source_for_report(lines []string, center int, radius int) VSourceChunk {
 // failing line is never dropped even inside a declaration larger than `max_bytes`. Otherwise it
 // keeps the start (declarations/imports) and the end (usually where the failing code lives).
 fn bounded_v_source(source string, max_bytes int, focus_line int) string {
+	result, _ := bounded_v_source_with_focus(source, max_bytes, focus_line)
+	return result
+}
+
+// bounded_v_source_with_focus bounds `source` to `max_bytes` and also returns the 1-based line of
+// `focus_line` within the produced excerpt (0 when there is no meaningful focus). A later handoff
+// that must re-bound the excerpt (e.g. the wasm re-export with a smaller budget) uses that focus
+// to keep centering on the failing line instead of dropping it with a head+tail window.
+fn bounded_v_source_with_focus(source string, max_bytes int, focus_line int) (string, int) {
 	if max_bytes <= 0 {
-		return ''
+		return '', 0
 	}
 	if source.len <= max_bytes {
-		return source
+		return source, focus_line
 	}
 	marker := '\n${c_error_v_source_truncation_notice}\n'
 	if max_bytes <= marker.len {
 		// no room for both content and the marker: fall back to a hard prefix cut
-		return source[..max_bytes]
+		return source[..max_bytes], 0
 	}
 	if focus_line <= 0 {
 		kept_bytes := max_bytes - marker.len
@@ -1387,7 +1411,7 @@ fn bounded_v_source(source string, max_bytes int, focus_line int) string {
 		tail_region_start := source.len - tail_budget
 		next_nl := source[tail_region_start..].index_u8(`\n`)
 		tail_start := if next_nl >= 0 { tail_region_start + next_nl + 1 } else { source.len }
-		return source[..head_end] + marker + source[tail_start..]
+		return source[..head_end] + marker + source[tail_start..], 0
 	}
 	// keep a window of whole lines centered on the failing line, growing outward until the budget
 	// (minus room for a marker on each dropped side) is exhausted.
@@ -1413,6 +1437,10 @@ fn bounded_v_source(source string, max_bytes int, focus_line int) string {
 			break
 		}
 	}
+	// The failing line's 1-based position in the excerpt: a leading truncation-marker line (present
+	// when the window does not reach the file start) shifts it down by one.
+	leading_marker_lines := if lo > 0 { 1 } else { 0 }
+	adjusted_focus := leading_marker_lines + (fi - lo) + 1
 	mut parts := []string{}
 	if lo > 0 {
 		parts << c_error_v_source_truncation_notice
@@ -1423,7 +1451,7 @@ fn bounded_v_source(source string, max_bytes int, focus_line int) string {
 	}
 	result := parts.join('\n')
 	if result.len <= max_bytes {
-		return result
+		return result, adjusted_focus
 	}
 	// A single line longer than the whole budget still overflows the window. Hard-clamp it,
 	// but keep the truncation marker so a truncated upload is never a silently complete-looking
@@ -1431,7 +1459,7 @@ fn bounded_v_source(source string, max_bytes int, focus_line int) string {
 	// bytes self-describing too).
 	marker_tail := '\n${c_error_v_source_truncation_notice}'
 	clamp := if max_bytes > marker_tail.len { max_bytes - marker_tail.len } else { 0 }
-	return result[..clamp] + marker_tail
+	return result[..clamp] + marker_tail, adjusted_focus
 }
 
 // new_c_error_bug_report_with_vlines regenerates the program's C source with `#line`

--- a/vlib/v/builder/c_error_report.v
+++ b/vlib/v/builder/c_error_report.v
@@ -73,7 +73,7 @@ pub:
 	v_file         string
 	v_line         int
 	v_context      []CErrorReportLine
-	v_source       string // a small chunk of V source around the failing line (bounded), never the whole file
+	v_source       string // the full failing V file, so the report is reproducible (bounded only when larger than the byte budget)
 }
 
 // external_v3_compiler_error_kind marks an ExternalCErrorBugReport that describes a
@@ -110,7 +110,7 @@ pub:
 	// environment. When source_inline is set, v_file/v_source are used verbatim and no
 	// path from the report is ever read or removed.
 	v_file        string // informational base filename of the failing source (no directory)
-	v_source      string // already-bounded source snippet; never a whole file
+	v_source      string // the full failing file (bounded only when larger than the byte budget)
 	source_inline bool   // true: use v_file/v_source as-is and touch no filesystem path
 	// Untagged path/digest pairs below describe source bytes V3 actually parsed. The
 	// stable parser compares them only with its own parsed-file paths and scanner
@@ -494,8 +494,9 @@ pub fn export_external_v3_report_to_env(report ExternalCErrorBugReport) {
 // `allowed_v_sources` maps every source file V3 actually parsed to the SHA-256 digest
 // captured from those exact parser bytes. Generated-C mappings outside that set, or
 // files whose current contents no longer match the captured digest, contribute no
-// source. The returned snippet is always a bounded strict subset (never a whole file);
-// ('', '') means no source is available, so the report stays metadata-only.
+// source. The returned source is the full mapped file, so the report is reproducible
+// (bounded to a window only when the file is larger than the byte budget); ('', '')
+// means no source is available, so the report stays metadata-only.
 pub fn bounded_v3_fallback_source(kind string, c_output string, c_file string, allowed_v_sources map[string]string) (string, string) {
 	if kind == external_v3_compiler_error_kind {
 		return '', ''
@@ -518,8 +519,10 @@ pub fn bounded_v3_internal_fallback_source(source_name string, source string) (s
 
 // bounded_v_source_for_generated_c maps a generated-C compilation error back to the V
 // source line it came from (via the #line directives in the trusted staged C) and returns
-// a bounded window of that V file. The generated C was staged by this process's own V3
-// run, while its mapped V path is trusted only when it matches a parsed compiler input.
+// the full mapped V file (bounded to a window around the failing line only when the file
+// is larger than the byte budget), so the report is reproducible. The generated C was
+// staged by this process's own V3 run, while its mapped V path is trusted only when it
+// matches a parsed compiler input.
 fn bounded_v_source_for_generated_c(c_output string, generated_c_file string, allowed_v_sources map[string]string) (string, string) {
 	c_source := os.read_file(generated_c_file) or { return '', '' }
 	c_lines := c_source.split_into_lines()
@@ -553,17 +556,14 @@ fn bounded_v_source_for_generated_c(c_output string, generated_c_file string, al
 		// report metadata-only rather than uploading bytes unrelated to the failure.
 		return os.base(v_file), ''
 	}
-	mapped_lines := mapped_source.split_into_lines()
-	chunk := selected_v_source(v_file, mapped_lines, v_line)
-	mut v_source := bounded_v_source(chunk.text, c_error_bug_report_max_v_source_bytes, chunk.focus)
-	if v_source_exposes_whole_file(v_source, mapped_source, mapped_lines) {
-		// Strict-subset rule (doc/docs.md): a short mapped file makes the window cover the
-		// whole file. Exact line-array equality misses a window that omits only
-		// whitespace-only lines yet still exposes every nonblank source line, so apply the
-		// nonblank-line coverage check as well and drop the excerpt rather than upload the
-		// whole program.
-		v_source = ''
+	// Upload the full failing file so the report is reproducible. The digest check above
+	// guarantees these are exactly the bytes V3 parsed, and only files V3 actually parsed
+	// (always V source, never a mapped header) reach this point. A file larger than the byte
+	// budget is reduced to a window around the failing line so the report still fits.
+	if !is_v_source_file(v_file) {
+		return os.base(v_file), ''
 	}
+	v_source := bounded_v_source(mapped_source, c_error_bug_report_max_v_source_bytes, v_line)
 	return os.base(v_file), v_source
 }
 
@@ -857,35 +857,13 @@ fn (mut v Builder) submit_v3_compiler_error_bug_report(v3_stage string, v3_outpu
 	eprintln('='.repeat('================== V3 compiler bug report =============='.len))
 }
 
-// v3_report_v_source returns the bounded V source snippet uploaded for an internal
-// V3 failure. A C error maps to a failing line, so its window is centered there
-// (see selected_v_source); a V3 internal failure has no such line, so a bounded
-// head+tail window of whole lines is kept instead — the leading declarations plus
-// the trailing code, where the failure usually is. A program larger than the
-// window (2 * c_error_v_source_radius lines) is therefore never uploaded whole
-// (see the privacy note in doc/docs.md).
+// v3_report_v_source returns the V source uploaded for an internal V3 failure. An
+// internal failure has no mapped failing line, so the whole captured input is uploaded
+// to make the report reproducible; the dispatcher only forwards it when the input still
+// has the exact digest V3 parsed. Only an input larger than the byte budget is reduced
+// to a bounded head+tail window.
 fn v3_report_v_source(source string) string {
-	lines := source.split_into_lines()
-	if lines.len <= 2 * c_error_v_source_radius {
-		// A program this short cannot be reduced to a strict subset — any head+tail
-		// window would cover the whole file. The privacy guarantee in doc/docs.md is
-		// that the whole file is never auto-uploaded, so upload no source for it at
-		// all rather than disclose it in full. Larger programs still yield the
-		// bounded window below.
-		return ''
-	}
-	head := lines[..c_error_v_source_radius].join('\n')
-	tail := lines[lines.len - c_error_v_source_radius..].join('\n')
-	snippet := '${head}\n${c_error_v_source_truncation_notice}\n${tail}'
-	bounded := bounded_v_source(snippet, c_error_bug_report_max_v_source_bytes, 0)
-	if v_source_and_context_expose_whole_file(bounded, []CErrorReportLine{}, lines) {
-		// The dropped middle lines were all blank, so head+tail together still expose
-		// every nonblank source line and reconstruct the file. Apply the same
-		// nonblank-line coverage check as the combined C-error payload and send no
-		// source rather than the whole program (doc/docs.md).
-		return ''
-	}
-	return bounded
+	return bounded_v_source(source, c_error_bug_report_max_v_source_bytes, 0)
 }
 
 // v_source_is_whole_file reports whether the selected excerpt is the entire mapped
@@ -1013,17 +991,15 @@ fn (mut v Builder) new_c_error_bug_report(ccompiler string, c_output string) CEr
 	// declarations it references). It already keeps itself within the byte budget, returning ''
 	// when it cannot, so it is uploaded verbatim; otherwise fall back to a plain source window.
 	repro := v.v_source_reproducer(v_file, v_line, c_error_bug_report_max_v_source_bytes)
-	mut v_source := if repro != '' {
+	v_source := if repro != '' {
 		repro
+	} else if is_v_source_file(v_file) {
+		// No self-contained reproducer (multi-module or non-`main` program): upload the full
+		// failing file so the report is reproducible, bounding only a file larger than the
+		// byte budget to a window around the failing line.
+		bounded_v_source(mapped_source, c_error_bug_report_max_v_source_bytes, v_line)
 	} else {
-		v_chunk := selected_v_source(v_file, mapped_lines, v_line)
-		bounded_v_source(v_chunk.text, c_error_bug_report_max_v_source_bytes, v_chunk.focus)
-	}
-	if v_source_exposes_whole_file(v_source, mapped_source, mapped_lines) {
-		// Strict-subset rule (doc/docs.md): a short mapped file, or a window that
-		// omits only whitespace, exposes the entire substantive file. Drop the
-		// excerpt rather than upload it whole.
-		v_source = ''
+		''
 	}
 	// v_context is a separate uploaded payload; for a short mapped file its radius
 	// window can also span every line, so apply the same strict-subset rule to it.

--- a/vlib/v/builder/c_error_report_test.v
+++ b/vlib/v/builder/c_error_report_test.v
@@ -304,6 +304,39 @@ fn test_report_includes_v_source_counts_v_context() {
 	})
 }
 
+fn test_report_uploaded_complete_source_distinguishes_context_only() {
+	// A context-only upload (v_source empty, v_context present) is a bounded excerpt, not the
+	// complete file, even though report_includes_v_source is true — so the notice must not claim
+	// the complete source was submitted (PR #28234 review).
+	context_only := CErrorBugReport{
+		v_context: [CErrorReportLine{
+			line: 6
+			text: 'x := 1'
+		}]
+	}
+	assert report_includes_v_source(context_only)
+	assert !report_uploaded_complete_source(context_only)
+	// A nonempty, non-truncated v_source is the complete file.
+	assert report_uploaded_complete_source(CErrorBugReport{
+		v_source: 'fn main() {}'
+	})
+	// A truncated v_source is a bounded excerpt, not complete.
+	assert !report_uploaded_complete_source(CErrorBugReport{
+		v_source:           'fn main() {}'
+		v_source_truncated: true
+	})
+	assert !report_uploaded_complete_source(CErrorBugReport{})
+}
+
+fn test_env_c_output_budget_caps_at_value_limit_and_max() {
+	// The diagnostic budget is capped at both the per-variable value limit and the fixed maximum.
+	assert env_c_output_budget(1000, 500) == 500 // value limit binds
+	assert env_c_output_budget(500, 1000) == 500 // available binds
+	// The fixed maximum binds when both are larger.
+	big := 4 * c_error_bug_report_max_env_c_output_bytes
+	assert env_c_output_budget(big, big) == c_error_bug_report_max_env_c_output_bytes
+}
+
 fn test_bounded_v_source_marks_single_oversized_line_hard_clamp() {
 	// The failing V line is the whole file and is longer than the byte budget. The safety
 	// hard-clamp used to drop a markerless prefix (PR #28234 review); it must now carry the

--- a/vlib/v/builder/c_error_report_test.v
+++ b/vlib/v/builder/c_error_report_test.v
@@ -318,18 +318,17 @@ fn test_external_v3_report_env_round_trip() {
 		os.rmdir_all(dir) or {}
 	}
 	c_file := os.join_path(dir, 'main.v')
-	// A program large enough to yield a bounded head+tail snippet (short files upload no
-	// source at all, per the no-whole-file guarantee).
+	// The full failing file is captured as content so the report is reproducible.
 	mut lines := []string{}
 	for i in 0 .. 4 * c_error_v_source_radius {
 		lines << 'fn f${i}() { println(${i}) }'
 	}
-	os.write_file(c_file, lines.join('\n'))!
-	// The owning process bounds the source into content...
-	v_file, v_source := bounded_v3_internal_fallback_source(c_file, lines.join('\n'))
+	source := lines.join('\n')
+	os.write_file(c_file, source)!
+	// The owning process captures the source as content...
+	v_file, v_source := bounded_v3_internal_fallback_source(c_file, source)
 	assert v_file == 'main.v'
-	assert v_source != ''
-	assert v_source.contains(c_error_v_source_truncation_notice)
+	assert v_source == source
 	// The path-based extractor must never reopen an internal-error input after V3 fails.
 	late_file, late_source := bounded_v3_fallback_source(external_v3_compiler_error_kind,
 		'error: v3 failed', c_file, map[string]string{})
@@ -722,35 +721,32 @@ fn test_v_source_and_context_expose_whole_file_checks_the_union() {
 	assert !v_source_and_context_expose_whole_file('', [], mapped)
 }
 
-fn test_v3_report_v_source_bounds_large_files() {
-	// A program at or below the window (2 * c_error_v_source_radius lines) cannot be
-	// reduced to a strict subset, so no source is uploaded for it at all — the whole
-	// file is never sent.
+fn test_v3_report_v_source_returns_full_source_and_bounds_oversized() {
+	// An internal V3 failure has no mapped failing line, so the whole captured input is
+	// uploaded to make the report reproducible. A short program is uploaded verbatim.
 	small := 'fn main() {\n\tprintln(1)\n}\n'
-	assert v3_report_v_source(small) == ''
-	// A larger program is reduced to a bounded head+tail window; the middle (which
-	// could hold unrelated proprietary code) is dropped and never uploaded.
+	assert v3_report_v_source(small) == small
+	// A larger program that still fits the byte budget is uploaded whole.
 	mut lines := []string{}
 	for i in 0 .. 4 * c_error_v_source_radius {
 		lines << 'fn f${i}() { println(${i}) }'
 	}
-	big := lines.join('\n')
+	medium := lines.join('\n')
+	assert medium.len < c_error_bug_report_max_v_source_bytes
+	assert v3_report_v_source(medium) == medium
+	// Only a program larger than the byte budget is reduced to a bounded head+tail window.
+	mut big_lines := []string{}
+	for i in 0 .. 4000 {
+		big_lines << 'fn f${i}() { println(${i}) }'
+	}
+	big := big_lines.join('\n')
+	assert big.len > c_error_bug_report_max_v_source_bytes
 	snippet := v3_report_v_source(big)
-	assert snippet != ''
+	assert snippet.len <= c_error_bug_report_max_v_source_bytes
 	assert snippet.len < big.len
 	assert snippet.contains(c_error_v_source_truncation_notice)
 	assert snippet.contains('fn f0() ') // head kept
-	assert snippet.contains('fn f${4 * c_error_v_source_radius - 1}() ') // tail kept
-	assert !snippet.contains('fn f${2 * c_error_v_source_radius}() ') // middle dropped
-	assert snippet.split_into_lines().len <= 2 * c_error_v_source_radius + 3
-	// A program just over the window whose only dropped (middle) line is blank still
-	// exposes every nonblank line via head+tail, so no source is uploaded even though
-	// the file is over 80 lines (PR #28131 review).
-	mut blank_middle := []string{}
-	for i in 0 .. 2 * c_error_v_source_radius + 1 {
-		blank_middle << if i == c_error_v_source_radius { '' } else { 'fn g${i}() {}' }
-	}
-	assert v3_report_v_source(blank_middle.join('\n')) == ''
+	assert snippet.contains('fn f3999() ') // tail kept
 }
 
 fn test_selected_v_source_only_uploads_mapped_v_source_chunk() {
@@ -859,9 +855,9 @@ fn test_v_source_location_mapping_from_line_directives() {
 }
 
 fn test_bounded_v3_fallback_source_maps_generated_c_error() {
-	// A generated-C compilation error is mapped back to its V source line (via the #line
-	// directives in the trusted staged C) and a bounded window of that V file is returned
-	// — a strict subset, never the whole file (PR #28131 review).
+	// A generated-C compilation error is mapped back to its V source file (via the #line
+	// directives in the trusted staged C) and the full file is returned, so the report is
+	// reproducible.
 	dir := os.join_path(os.vtmp_dir(), 'v3_gen_c_map_${os.getpid()}')
 	os.rmdir_all(dir) or {}
 	os.mkdir_all(dir) or { panic(err) }
@@ -883,18 +879,15 @@ fn test_bounded_v3_fallback_source_maps_generated_c_error() {
 		v_path: sha256.hexhash(whole)
 	})
 	assert v_file == 'source.v'
-	assert v_source != ''
-	// A bounded strict subset centered on the mapped V line (~100), never the whole file.
-	assert v_source.len < whole.len
+	// The full mapped file is uploaded (it fits the byte budget), so the report reproduces.
+	assert v_source == whole
 	assert v_source.contains('fn f100()')
 }
 
-fn test_bounded_v3_fallback_source_rejects_nonblank_whole_file_generated_c() {
-	// A generated-C error mapping near line 40 of an 81-line file whose omitted final line
-	// is only whitespace: the window (lines 1..80) covers every nonblank line, so exact
-	// line-array equality misses it but the nonblank coverage check must still drop the
-	// excerpt rather than upload the whole program (doc/docs.md, PR #28131 review).
-	dir := os.join_path(os.vtmp_dir(), 'v3_gen_c_nonblank_${os.getpid()}')
+fn test_bounded_v3_fallback_source_uploads_whole_mapped_file_generated_c() {
+	// A generated-C error mapping into a small file uploads the whole file (it is the
+	// reproducer), so the report reproduces rather than dropping to metadata-only.
+	dir := os.join_path(os.vtmp_dir(), 'v3_gen_c_wholefile_${os.getpid()}')
 	os.rmdir_all(dir) or {}
 	os.mkdir_all(dir) or { panic(err) }
 	defer {
@@ -915,8 +908,8 @@ fn test_bounded_v3_fallback_source_rejects_nonblank_whole_file_generated_c() {
 		v_path: sha256.hexhash(whole)
 	})
 	assert v_file == 'source.v'
-	// The mapped window exposes every nonblank line, so no source is uploaded.
-	assert v_source == '', v_source
+	// The full file is uploaded so the failure can be reproduced from the report.
+	assert v_source == whole, v_source
 }
 
 fn test_bounded_v3_fallback_source_rejects_unparsed_mapped_file() {

--- a/vlib/v/builder/c_error_report_test.v
+++ b/vlib/v/builder/c_error_report_test.v
@@ -1441,7 +1441,7 @@ fn test_new_c_error_bug_report_with_vlines_is_skipped_when_already_vlines() {
 			is_vlines: true
 		}
 	}
-	if _ := b.new_c_error_bug_report_with_vlines('cc') {
+	if _ := b.new_c_error_bug_report_with_vlines('cc', false) {
 		assert false, 'expected none when the C source is already #line annotated'
 	}
 }
@@ -1453,9 +1453,40 @@ fn test_new_c_error_bug_report_with_vlines_is_skipped_without_a_recorded_command
 		pref:        &pref.Preferences{}
 		last_cc_cmd: ''
 	}
-	if _ := b.new_c_error_bug_report_with_vlines('cc') {
+	if _ := b.new_c_error_bug_report_with_vlines('cc', false) {
 		assert false, 'expected none when no C compiler command was recorded'
 	}
+}
+
+fn test_new_c_error_bug_report_limits_full_source_to_v3_fallbacks() {
+	dir := os.join_path(os.vtmp_dir(), 'c_error_source_scope_${os.getpid()}')
+	os.rmdir_all(dir) or {}
+	os.mkdir_all(dir) or { panic(err) }
+	defer {
+		os.rmdir_all(dir) or {}
+	}
+	mut lines := []string{}
+	for i in 1 .. 201 {
+		lines << 'fn source_${i}() { println(${i}) }'
+	}
+	source := lines.join('\n')
+	v_path := os.join_path(dir, 'source.v')
+	os.write_file(v_path, source)!
+	generated_c := os.join_path(dir, 'program.tmp.c')
+	os.write_file(generated_c, '#line 100 "${v_path}"\nint b = missing;\n')!
+	c_output := '${generated_c}:2:9: error: use of undeclared identifier missing'
+	mut b := Builder{
+		pref:       &pref.Preferences{}
+		out_name_c: generated_c
+	}
+	direct_report := b.new_c_error_bug_report('clang', c_output, false)
+	assert direct_report.v_source != ''
+	assert direct_report.v_source != source
+	assert direct_report.v_source_truncated
+	assert direct_report.v_source.contains('fn source_100()')
+	fallback_report := b.new_c_error_bug_report('clang', c_output, true)
+	assert fallback_report.v_source == source
+	assert !fallback_report.v_source_truncated
 }
 
 fn clear_v3_report_env() {

--- a/vlib/v/builder/c_error_report_test.v
+++ b/vlib/v/builder/c_error_report_test.v
@@ -304,27 +304,16 @@ fn test_report_includes_v_source_counts_v_context() {
 	})
 }
 
-fn test_bounded_v_source_content_is_truncated_detects_marked_excerpts() {
-	// A whole file that fit the byte budget carries no truncation marker: complete upload.
-	assert !bounded_v_source_content_is_truncated('module main\nfn main() {\n\tprintln(1)\n}')
-	// A bounded excerpt carries the marker.
-	truncated := 'module main\n${c_error_v_source_truncation_notice}\nfn main() {}'
-	assert bounded_v_source_content_is_truncated(truncated)
-	assert !bounded_v_source_content_is_truncated('')
-}
-
 fn test_bounded_v_source_marks_single_oversized_line_hard_clamp() {
 	// The failing V line is the whole file and is longer than the byte budget. The safety
-	// hard-clamp used to drop a markerless prefix, so a truncated upload was reported as the
-	// complete source (PR #28234 review). It must now carry the truncation marker, and
-	// bounded_v_source_content_is_truncated must therefore report it as an excerpt.
+	// hard-clamp used to drop a markerless prefix (PR #28234 review); it must now carry the
+	// truncation marker so a truncated upload is never a silently complete-looking prefix.
 	long_line := 'const x = "' + 'a'.repeat(200) + '"'
 	budget := 64
 	out := bounded_v_source(long_line, budget, 1) // focus on line 1 (the only line)
 	assert out.len <= budget
 	assert out.len < long_line.len
 	assert out.contains(c_error_v_source_truncation_notice)
-	assert bounded_v_source_content_is_truncated(out)
 }
 
 fn test_external_v3_report_env_round_trip() {
@@ -388,6 +377,8 @@ fn test_external_v3_report_env_round_trip() {
 	assert got.cleanup_dir == ''
 	assert got.v_file == 'main.v'
 	assert got.v_source == v_source
+	// The small source fit the budget, so it round-trips complete and untruncated.
+	assert !got.v_source_truncated
 	assert got.input_digests_complete
 	assert got.input_digests == {
 		parsed_path: parsed_digest
@@ -619,6 +610,8 @@ fn test_export_external_v3_report_bounds_combined_exec_payload() {
 	assert got.v_source.len < huge_source.len
 	assert got.c_output.contains(c_error_bug_report_truncation_notice)
 	assert got.v_source.contains(c_error_v_source_truncation_notice)
+	// The excerpt is flagged truncated explicitly through the handoff.
+	assert got.v_source_truncated
 }
 
 fn test_export_external_v3_report_preserves_failing_line_through_handoff() {
@@ -663,6 +656,35 @@ fn test_export_external_v3_report_preserves_failing_line_through_handoff() {
 		assert got.v_source.contains(c_error_v_source_truncation_notice)
 		assert got.v_source.contains('the_unique_failing_line_marker')
 	}
+}
+
+fn test_export_external_v3_report_marks_complete_file_containing_marker_text_as_untruncated() {
+	// A complete file that legitimately contains the truncation-marker comment text must NOT be
+	// classified as truncated. Truncation is carried explicitly through the handoff, computed
+	// from the byte budget, not inferred from (user-controlled) source content (PR #28234 review).
+	clear_v3_report_env()
+	source := 'fn main() {\n\t${c_error_v_source_truncation_notice}\n\tprintln(1)\n}'
+	assert source.contains(c_error_v_source_truncation_notice)
+	export_external_v3_report_to_env(ExternalCErrorBugReport{
+		kind:          '' // generated-C compilation error
+		ccompiler:     'clang'
+		c_output:      'error: use of undeclared identifier missing'
+		v_file:        'main.v'
+		v_source:      source
+		source_inline: true
+		tag:           'V3'
+	})
+	got := take_external_v3_report_from_env() or {
+		assert false, 'no report round-tripped'
+		return
+	}
+	if got.kind == external_v3_transport_limited_kind {
+		return // environment too small to forward the manifest; nothing to assert
+	}
+	// The whole file fit the budget, so it was forwarded complete and reported as untruncated,
+	// even though its content contains the marker text.
+	assert got.v_source == source
+	assert !got.v_source_truncated
 }
 
 fn test_v3_report_env_budget_reserves_existing_argv_and_environment() {
@@ -711,7 +733,8 @@ fn test_build_inline_c_error_report_classifies_and_filters() {
 	// (`v-c-compiler-error`) report carrying the bounded content — not misreported as an
 	// internal V3 error (which would emit `v3-compiler-error`) (PR #28131 review).
 	report := build_inline_c_error_report(&prefs, 'clang',
-		'main.tmp.c:3:9: error: use of undeclared identifier x', 'main.v', 'fn main() {}', 'V3') or {
+		'main.tmp.c:3:9: error: use of undeclared identifier x', 'main.v', 'fn main() {}',
+		false, 'V3') or {
 		assert false, 'an ordinary generated-C diagnostic must be reportable'
 		return
 	}
@@ -719,11 +742,13 @@ fn test_build_inline_c_error_report_classifies_and_filters() {
 	assert report.c_error.contains('undeclared identifier')
 	assert report.v_file == 'main.v'
 	assert report.v_source == 'fn main() {}'
+	// The explicit truncation flag is carried through, not inferred from source content.
+	assert !report.v_source_truncated
 	assert report.build_options.split(' ').first() == 'V3'
 	// An expected missing-library diagnostic is filtered out (not uploaded), exactly as
 	// the in-process generated-C path already does.
 	if _ := build_inline_c_error_report(&prefs, 'clang', "ld: library 'macos_v3_absent' not found",
-		'main.v', 'fn main() {}', 'V3')
+		'main.v', 'fn main() {}', false, 'V3')
 	{
 		assert false, 'a missing-library diagnostic must not be reported'
 	}

--- a/vlib/v/builder/c_error_report_test.v
+++ b/vlib/v/builder/c_error_report_test.v
@@ -720,6 +720,35 @@ fn test_export_external_v3_report_marks_complete_file_containing_marker_text_as_
 	assert !got.v_source_truncated
 }
 
+fn test_export_external_v3_report_preserves_incoming_truncation_flag() {
+	// A wasm re-export forwards a report whose source was already bounded by the first handoff.
+	// If that excerpt fits the second budget (no further bounding), the exporter must still mark
+	// it truncated rather than re-announce it as the complete file (PR #28234 review).
+	clear_v3_report_env()
+	excerpt := 'module main\n${c_error_v_source_truncation_notice}\nfn main() {}'
+	export_external_v3_report_to_env(ExternalCErrorBugReport{
+		kind:               '' // generated-C compilation error
+		ccompiler:          'clang'
+		c_output:           'error: use of undeclared identifier missing'
+		v_file:             'main.v'
+		v_source:           excerpt
+		v_source_truncated: true
+		source_inline:      true
+		tag:                'V3'
+	})
+	got := take_external_v3_report_from_env() or {
+		assert false, 'no report round-tripped'
+		return
+	}
+	if got.kind == external_v3_transport_limited_kind {
+		return // environment too small to forward the manifest; nothing to assert
+	}
+	// The small excerpt fits the budget (forwarded whole), but its incoming truncation flag is
+	// preserved through the re-export.
+	assert got.v_source == excerpt
+	assert got.v_source_truncated
+}
+
 fn test_v3_report_env_budget_reserves_existing_argv_and_environment() {
 	assert v3_report_env_budget({
 		'EXISTING': 'x'.repeat(v3_report_conservative_exec_bytes)

--- a/vlib/v/builder/c_error_report_test.v
+++ b/vlib/v/builder/c_error_report_test.v
@@ -348,12 +348,13 @@ fn test_external_v3_report_env_round_trip() {
 	}
 	source := lines.join('\n')
 	os.write_file(c_file, source)!
-	// The owning process captures the source as content...
-	v_file, v_source := bounded_v3_internal_fallback_source(c_file, source)
+	// The owning process captures the source as content, with focus 0 (head+tail if bounded)...
+	v_file, v_source, v_source_focus := bounded_v3_internal_fallback_source(c_file, source)
 	assert v_file == 'main.v'
 	assert v_source == source
+	assert v_source_focus == 0
 	// The path-based extractor must never reopen an internal-error input after V3 fails.
-	late_file, late_source := bounded_v3_fallback_source(external_v3_compiler_error_kind,
+	late_file, late_source, _ := bounded_v3_fallback_source(external_v3_compiler_error_kind,
 		'error: v3 failed', c_file, map[string]string{})
 	assert late_file == ''
 	assert late_source == ''
@@ -620,6 +621,50 @@ fn test_export_external_v3_report_bounds_combined_exec_payload() {
 	assert got.v_source.contains(c_error_v_source_truncation_notice)
 }
 
+fn test_export_external_v3_report_preserves_failing_line_through_handoff() {
+	// A generated-C failure into a file larger than the environment budget must keep the exact
+	// failing line. The byte bound is applied once, at the handoff, centered on it, instead of a
+	// second head+tail truncation that would drop the middle — including the failing line
+	// (PR #28234 review). It is also never forwarded as a silent markerless prefix.
+	clear_v3_report_env()
+	mut lines := []string{}
+	for i in 0 .. 3000 {
+		lines << 'fn head_${i}() { println(${i}) }'
+	}
+	failing_line := lines.len + 1 // 1-based line of the unique failing marker inserted next
+	lines << 'fn the_unique_failing_line_marker() {}'
+	for i in 0 .. 3000 {
+		lines << 'fn tail_${i}() { println(${i}) }'
+	}
+	source := lines.join('\n')
+	// Far larger than the environment value limit, so export must truncate it.
+	assert source.len > c_error_bug_report_max_v_source_bytes
+	export_external_v3_report_to_env(ExternalCErrorBugReport{
+		kind:           '' // generated-C compilation error
+		ccompiler:      'clang'
+		c_output:       'error: use of undeclared identifier missing'
+		v_file:         'main.v'
+		v_source:       source
+		v_source_focus: failing_line
+		source_inline:  true
+		tag:            'V3'
+	})
+	got := take_external_v3_report_from_env() or {
+		assert false, 'no report round-tripped'
+		return
+	}
+	if got.kind == external_v3_transport_limited_kind {
+		return // environment too small to forward any manifest; nothing to assert
+	}
+	// Either source was omitted (a budget too small to hold even the marker) or it was
+	// truncated with the marker present, keeping the failing line — never a markerless prefix.
+	if got.v_source != '' {
+		assert got.v_source.len < source.len
+		assert got.v_source.contains(c_error_v_source_truncation_notice)
+		assert got.v_source.contains('the_unique_failing_line_marker')
+	}
+}
+
 fn test_v3_report_env_budget_reserves_existing_argv_and_environment() {
 	assert v3_report_env_budget({
 		'EXISTING': 'x'.repeat(v3_report_conservative_exec_bytes)
@@ -744,33 +789,6 @@ fn test_v_source_and_context_expose_whole_file_checks_the_union() {
 	assert !v_source_and_context_expose_whole_file('', [], mapped)
 }
 
-fn test_v3_report_v_source_returns_full_source_and_bounds_oversized() {
-	// An internal V3 failure has no mapped failing line, so the whole captured input is
-	// uploaded to make the report reproducible. A short program is uploaded verbatim.
-	small := 'fn main() {\n\tprintln(1)\n}\n'
-	assert v3_report_v_source(small) == small
-	// A larger program that still fits the byte budget is uploaded whole.
-	mut lines := []string{}
-	for i in 0 .. 4 * c_error_v_source_radius {
-		lines << 'fn f${i}() { println(${i}) }'
-	}
-	medium := lines.join('\n')
-	assert medium.len < c_error_bug_report_max_v_source_bytes
-	assert v3_report_v_source(medium) == medium
-	// Only a program larger than the byte budget is reduced to a bounded head+tail window.
-	mut big_lines := []string{}
-	for i in 0 .. 4000 {
-		big_lines << 'fn f${i}() { println(${i}) }'
-	}
-	big := big_lines.join('\n')
-	assert big.len > c_error_bug_report_max_v_source_bytes
-	snippet := v3_report_v_source(big)
-	assert snippet.len <= c_error_bug_report_max_v_source_bytes
-	assert snippet.len < big.len
-	assert snippet.contains(c_error_v_source_truncation_notice)
-	assert snippet.contains('fn f0() ') // head kept
-	assert snippet.contains('fn f3999() ') // tail kept
-}
 
 fn test_selected_v_source_only_uploads_mapped_v_source_chunk() {
 	// a mapped V file yields a small chunk around the failing line
@@ -898,13 +916,16 @@ fn test_bounded_v3_fallback_source_maps_generated_c_error() {
 	os.write_file(generated_c, '#line 100 "${v_path}"\nint a = 1;\nint b = missing;\n')!
 	c_output := '${generated_c}:3:9: error: use of undeclared identifier missing'
 	// kind '' selects the generated-C mapping path.
-	v_file, v_source := bounded_v3_fallback_source('', c_output, generated_c, {
+	v_file, v_source, focus := bounded_v3_fallback_source('', c_output, generated_c, {
 		v_path: sha256.hexhash(whole)
 	})
 	assert v_file == 'source.v'
-	// The full mapped file is uploaded (it fits the byte budget), so the report reproduces.
+	// The full mapped file is returned, plus the failing line to focus on, so the byte bound is
+	// applied once at the handoff without dropping the failing code.
 	assert v_source == whole
 	assert v_source.contains('fn f100()')
+	// `#line 100` makes the next C line map to V line 100, so the error one line later is 101.
+	assert focus == 101
 }
 
 fn test_bounded_v3_fallback_source_uploads_whole_mapped_file_generated_c() {
@@ -927,7 +948,7 @@ fn test_bounded_v3_fallback_source_uploads_whole_mapped_file_generated_c() {
 	generated_c := os.join_path(dir, 'program.tmp.c')
 	os.write_file(generated_c, '#line 40 "${v_path}"\nint b = missing;\n')!
 	c_output := '${generated_c}:2:9: error: use of undeclared identifier missing'
-	v_file, v_source := bounded_v3_fallback_source('', c_output, generated_c, {
+	v_file, v_source, _ := bounded_v3_fallback_source('', c_output, generated_c, {
 		v_path: sha256.hexhash(whole)
 	})
 	assert v_file == 'source.v'
@@ -952,7 +973,7 @@ fn test_bounded_v3_fallback_source_rejects_unparsed_mapped_file() {
 	generated_c := os.join_path(dir, 'program.tmp.c')
 	os.write_file(generated_c, '#line 1 "${unrelated_path}"\nint exposed = missing;\n')!
 	c_output := '${generated_c}:2:15: error: use of undeclared identifier missing'
-	v_file, v_source := bounded_v3_fallback_source('', c_output, generated_c, {
+	v_file, v_source, _ := bounded_v3_fallback_source('', c_output, generated_c, {
 		parsed_path: sha256.hexhash(os.read_file(parsed_path)!)
 	})
 	assert v_file == ''
@@ -979,7 +1000,7 @@ fn test_bounded_v3_fallback_source_rejects_changed_parsed_source() {
 	// Simulate an editor/build watcher replacing the mapped input after V3 parsed it.
 	os.write_file(v_path, original.replace('original_', 'new_private_'))!
 	c_output := '${generated_c}:2:9: error: use of undeclared identifier missing'
-	v_file, v_source := bounded_v3_fallback_source('', c_output, generated_c, {
+	v_file, v_source, _ := bounded_v3_fallback_source('', c_output, generated_c, {
 		v_path: parsed_digest
 	})
 	assert v_file == 'source.v'

--- a/vlib/v/builder/c_error_report_test.v
+++ b/vlib/v/builder/c_error_report_test.v
@@ -427,6 +427,27 @@ fn test_plan_env_report_content_reports_excerpt_focus_for_rebound() {
 	assert plan_lines[plan.v_source_focus - 1] == 'fn the_failing_line() {}'
 }
 
+fn test_plan_env_report_content_omits_focused_source_until_code_fits() {
+	// A focused middle excerpt needs two markers and at least one byte from the failing line.
+	// Smaller budgets must omit source instead of forwarding marker-only text whose focus points
+	// at a marker (PR #28234 review).
+	minimum := 2 * c_error_v_source_truncation_notice.len + 3
+	source := 'a'.repeat(100) + '\nX\n' + 'b'.repeat(100)
+	omitted := plan_env_report_content(ExternalCErrorBugReport{
+		v_source:       source
+		v_source_focus: 2
+	}, minimum - 1, v3_report_max_env_payload_bytes)
+	assert omitted.v_source == ''
+	assert omitted.v_source_focus == 0
+	kept := plan_env_report_content(ExternalCErrorBugReport{
+		v_source:       source
+		v_source_focus: 2
+	}, minimum, v3_report_max_env_payload_bytes)
+	assert kept.v_source_truncated
+	assert kept.v_source_focus > 0
+	assert kept.v_source.split_into_lines()[kept.v_source_focus - 1] == 'X'
+}
+
 fn test_export_external_v3_report_round_trips_v_source_focus() {
 	// The failing-line focus is carried through the environment handoff (PR #28234 review).
 	clear_v3_report_env()
@@ -461,6 +482,20 @@ fn test_bounded_v_source_marks_single_oversized_line_hard_clamp() {
 	assert out.len <= budget
 	assert out.len < long_line.len
 	assert out.contains(c_error_v_source_truncation_notice)
+}
+
+fn test_bounded_v_source_focused_hard_clamp_keeps_code_between_markers() {
+	// A long focused line in the middle needs both markers plus actual source. A smaller budget
+	// must omit it, while the smallest useful budget keeps one source byte at the reported focus.
+	long_line := 'const x = "' + 'a'.repeat(200) + '"'
+	source := 'module main\n${long_line}\nfn main() {}'
+	minimum := 2 * c_error_v_source_truncation_notice.len + 3
+	too_small, too_small_focus := bounded_v_source_with_focus(source, minimum - 1, 2)
+	assert too_small == ''
+	assert too_small_focus == 0
+	out, focus := bounded_v_source_with_focus(source, minimum, 2)
+	assert out.len == minimum
+	assert out.split_into_lines()[focus - 1] == 'c'
 }
 
 fn test_external_v3_report_env_round_trip() {

--- a/vlib/v/builder/c_error_report_test.v
+++ b/vlib/v/builder/c_error_report_test.v
@@ -4,6 +4,7 @@ import os
 import crypto.sha256
 import v.ast
 import v.gen.c as cgen
+import v.parser
 import v.pref
 
 fn restore_env_var(name string, old_value ?string) {
@@ -1465,25 +1466,25 @@ fn test_new_c_error_bug_report_limits_full_source_to_v3_fallbacks() {
 	defer {
 		os.rmdir_all(dir) or {}
 	}
-	mut lines := []string{}
-	for i in 1 .. 201 {
-		lines << 'fn source_${i}() { println(${i}) }'
-	}
-	source := lines.join('\n')
+	source := "module main\n\nfn helper() {\n\tprintln('needed')\n}\n\nfn main() {\n\thelper()\n}\n\nfn unrelated() {\n\tprintln('private')\n}"
 	v_path := os.join_path(dir, 'source.v')
 	os.write_file(v_path, source)!
 	generated_c := os.join_path(dir, 'program.tmp.c')
-	os.write_file(generated_c, '#line 100 "${v_path}"\nint b = missing;\n')!
+	os.write_file(generated_c, '#line 8 "${v_path}"\nint b = missing;\n')!
 	c_output := '${generated_c}:2:9: error: use of undeclared identifier missing'
 	mut b := Builder{
 		pref:       &pref.Preferences{}
 		out_name_c: generated_c
+		table:      ast.new_table()
 	}
+	b.parsed_files = [parser.parse_file(v_path, mut b.table, .skip_comments, b.pref)]
+	repro := b.v_source_reproducer(v_path, 8, c_error_bug_report_max_v_source_bytes)
+	assert repro != ''
+	assert repro.contains('fn helper()')
+	assert !repro.contains('fn unrelated()')
 	direct_report := b.new_c_error_bug_report('clang', c_output, false)
-	assert direct_report.v_source != ''
-	assert direct_report.v_source != source
+	assert direct_report.v_source == repro
 	assert direct_report.v_source_truncated
-	assert direct_report.v_source.contains('fn source_100()')
 	fallback_report := b.new_c_error_bug_report('clang', c_output, true)
 	assert fallback_report.v_source == source
 	assert !fallback_report.v_source_truncated

--- a/vlib/v/builder/c_error_report_test.v
+++ b/vlib/v/builder/c_error_report_test.v
@@ -304,6 +304,18 @@ fn test_report_includes_v_source_counts_v_context() {
 	})
 }
 
+fn test_v_source_upload_is_complete_distinguishes_full_file_from_excerpt() {
+	// A whole file that fit the byte budget carries no truncation marker, so the notice
+	// must report it as the complete source rather than a bounded excerpt (PR #28234 review).
+	assert v_source_upload_is_complete('module main\nfn main() {\n\tprintln(1)\n}')
+	// A file larger than the budget (or an internal-error head+tail window) carries the
+	// truncation marker, so it is a bounded excerpt.
+	truncated := 'module main\n${c_error_v_source_truncation_notice}\nfn main() {}'
+	assert !v_source_upload_is_complete(truncated)
+	// No source at all (context-only or metadata-only) is not a complete upload.
+	assert !v_source_upload_is_complete('')
+}
+
 fn test_external_v3_report_env_round_trip() {
 	// The fallback report is handed to the external builder as self-contained content
 	// through the environment: the owning process bounds the source (reading its own

--- a/vlib/v/builder/c_error_report_test.v
+++ b/vlib/v/builder/c_error_report_test.v
@@ -304,16 +304,27 @@ fn test_report_includes_v_source_counts_v_context() {
 	})
 }
 
-fn test_v_source_upload_is_complete_distinguishes_full_file_from_excerpt() {
-	// A whole file that fit the byte budget carries no truncation marker, so the notice
-	// must report it as the complete source rather than a bounded excerpt (PR #28234 review).
-	assert v_source_upload_is_complete('module main\nfn main() {\n\tprintln(1)\n}')
-	// A file larger than the budget (or an internal-error head+tail window) carries the
-	// truncation marker, so it is a bounded excerpt.
+fn test_bounded_v_source_content_is_truncated_detects_marked_excerpts() {
+	// A whole file that fit the byte budget carries no truncation marker: complete upload.
+	assert !bounded_v_source_content_is_truncated('module main\nfn main() {\n\tprintln(1)\n}')
+	// A bounded excerpt carries the marker.
 	truncated := 'module main\n${c_error_v_source_truncation_notice}\nfn main() {}'
-	assert !v_source_upload_is_complete(truncated)
-	// No source at all (context-only or metadata-only) is not a complete upload.
-	assert !v_source_upload_is_complete('')
+	assert bounded_v_source_content_is_truncated(truncated)
+	assert !bounded_v_source_content_is_truncated('')
+}
+
+fn test_bounded_v_source_marks_single_oversized_line_hard_clamp() {
+	// The failing V line is the whole file and is longer than the byte budget. The safety
+	// hard-clamp used to drop a markerless prefix, so a truncated upload was reported as the
+	// complete source (PR #28234 review). It must now carry the truncation marker, and
+	// bounded_v_source_content_is_truncated must therefore report it as an excerpt.
+	long_line := 'const x = "' + 'a'.repeat(200) + '"'
+	budget := 64
+	out := bounded_v_source(long_line, budget, 1) // focus on line 1 (the only line)
+	assert out.len <= budget
+	assert out.len < long_line.len
+	assert out.contains(c_error_v_source_truncation_notice)
+	assert bounded_v_source_content_is_truncated(out)
 }
 
 fn test_external_v3_report_env_round_trip() {

--- a/vlib/v/builder/c_error_report_test.v
+++ b/vlib/v/builder/c_error_report_test.v
@@ -337,6 +337,49 @@ fn test_env_c_output_budget_caps_at_value_limit_and_max() {
 	assert env_c_output_budget(big, big) == c_error_bug_report_max_env_c_output_bytes
 }
 
+fn test_plan_env_report_content_reclaims_omitted_source_budget_for_diagnostic() {
+	// A tiny content budget that cannot hold even the truncation marker omits the source; the half
+	// that was reserved for it must be reclaimed so a short missing-library diagnostic survives
+	// intact, staying recognizable to the receiver's filter instead of being reported as a compiler
+	// bug (PR #28234 review).
+	marker_min := c_error_v_source_truncation_notice.len + 2
+	short_diagnostic := "ld: library 'macos_v3_absent' not found"
+	value_limit := v3_report_max_env_payload_bytes
+	// A budget below marker_min forces omission; the source is larger than the budget.
+	tiny_budget := marker_min - 2
+	plan := plan_env_report_content(ExternalCErrorBugReport{
+		c_output: short_diagnostic
+		v_source: 'module main\nfn main() {}\n' + 'x'.repeat(1000)
+	}, tiny_budget, value_limit)
+	// Source is omitted (the budget cannot hold the marker)...
+	assert plan.v_source == ''
+	assert !plan.v_source_truncated
+	// ...and the reclaimed capacity keeps the whole short diagnostic (no truncation notice).
+	assert plan.c_output == short_diagnostic
+	assert !plan.c_output.contains(c_error_bug_report_truncation_notice)
+}
+
+fn test_plan_env_report_content_bounds_source_and_diagnostic_when_both_fit() {
+	// With ample budget both are forwarded whole; a source larger than its half-share is bounded
+	// (marked truncated) while the diagnostic stays intact.
+	value_limit := v3_report_max_env_payload_bytes
+	small := plan_env_report_content(ExternalCErrorBugReport{
+		c_output: 'error: use of undeclared identifier missing'
+		v_source: 'module main\nfn main() {}'
+	}, 4096, value_limit)
+	assert small.v_source == 'module main\nfn main() {}'
+	assert !small.v_source_truncated
+	assert small.c_output == 'error: use of undeclared identifier missing'
+	// A source that overflows its half-share is bounded and flagged truncated.
+	big_source := 'module main\n' + 'fn f() {}\n'.repeat(400)
+	bounded := plan_env_report_content(ExternalCErrorBugReport{
+		c_output: 'error: x'
+		v_source: big_source
+	}, 512, value_limit)
+	assert bounded.v_source.len < big_source.len
+	assert bounded.v_source_truncated
+}
+
 fn test_bounded_v_source_marks_single_oversized_line_hard_clamp() {
 	// The failing V line is the whole file and is longer than the byte budget. The safety
 	// hard-clamp used to drop a markerless prefix (PR #28234 review); it must now carry the

--- a/vlib/v/builder/c_error_report_test.v
+++ b/vlib/v/builder/c_error_report_test.v
@@ -380,6 +380,77 @@ fn test_plan_env_report_content_bounds_source_and_diagnostic_when_both_fit() {
 	assert bounded.v_source_truncated
 }
 
+fn test_bounded_v_source_with_focus_reports_failing_line_in_excerpt() {
+	// A large file bounded around a middle failing line keeps that line and reports its new 1-based
+	// position within the excerpt, so a later re-bound can stay centered on it (PR #28234 review).
+	mut lines := []string{}
+	for i in 0 .. 4000 {
+		lines << 'fn f${i}() { println(${i}) }'
+	}
+	failing := 2000 // 1-based
+	lines[failing - 1] = 'fn the_failing_line() {}'
+	source := lines.join('\n')
+	excerpt, focus := bounded_v_source_with_focus(source, 4096, failing)
+	assert excerpt.len < source.len
+	assert excerpt.contains('fn the_failing_line() {}')
+	assert focus > 0
+	excerpt_lines := excerpt.split_into_lines()
+	assert excerpt_lines[focus - 1] == 'fn the_failing_line() {}'
+	// A whole file that fits keeps the focus unchanged; a head+tail window reports no focus.
+	whole, whole_focus := bounded_v_source_with_focus('module main\nfn main() {}', 4096, 2)
+	assert whole == 'module main\nfn main() {}'
+	assert whole_focus == 2
+	_, headtail_focus := bounded_v_source_with_focus(source, 4096, 0)
+	assert headtail_focus == 0
+}
+
+fn test_plan_env_report_content_reports_excerpt_focus_for_rebound() {
+	// When source is bounded, the plan reports the failing line's position within the excerpt so
+	// the wasm re-export re-bounds around it instead of dropping it (PR #28234 review).
+	value_limit := v3_report_max_env_payload_bytes
+	mut lines := []string{}
+	for i in 0 .. 400 {
+		lines << 'fn f${i}() {}'
+	}
+	failing := 200
+	lines[failing - 1] = 'fn the_failing_line() {}'
+	source := lines.join('\n')
+	plan := plan_env_report_content(ExternalCErrorBugReport{
+		c_output:       'error: x'
+		v_source:       source
+		v_source_focus: failing
+	}, 512, value_limit)
+	assert plan.v_source_truncated
+	assert plan.v_source.contains('fn the_failing_line() {}')
+	assert plan.v_source_focus > 0
+	plan_lines := plan.v_source.split_into_lines()
+	assert plan_lines[plan.v_source_focus - 1] == 'fn the_failing_line() {}'
+}
+
+fn test_export_external_v3_report_round_trips_v_source_focus() {
+	// The failing-line focus is carried through the environment handoff (PR #28234 review).
+	clear_v3_report_env()
+	export_external_v3_report_to_env(ExternalCErrorBugReport{
+		kind:           '' // generated-C compilation error
+		ccompiler:      'clang'
+		c_output:       'error: use of undeclared identifier missing'
+		v_file:         'main.v'
+		v_source:       'module main\nfn main() {}'
+		v_source_focus: 2
+		source_inline:  true
+		tag:            'V3'
+	})
+	got := take_external_v3_report_from_env() or {
+		assert false, 'no report round-tripped'
+		return
+	}
+	if got.kind == external_v3_transport_limited_kind {
+		return
+	}
+	assert got.v_source == 'module main\nfn main() {}'
+	assert got.v_source_focus == 2
+}
+
 fn test_bounded_v_source_marks_single_oversized_line_hard_clamp() {
 	// The failing V line is the whole file and is longer than the byte budget. The safety
 	// hard-clamp used to drop a markerless prefix (PR #28234 review); it must now carry the

--- a/vlib/v/builder/compile.v
+++ b/vlib/v/builder/compile.v
@@ -80,7 +80,7 @@ fn compile_with_optional_external_c_error_report(pref_ &pref.Preferences, backen
 				// V3 failed before it could stage a complete parser manifest. The stable
 				// build succeeded, so preserve the documented fallback notice, but do not
 				// submit an unverified V3-only failure report.
-				print_v3_fallback_notice('', false, false)
+				print_v3_fallback_notice('', false, false, false)
 			}
 			.changed {
 				// The stable compiler succeeded, but not from the exact source snapshot V3


### PR DESCRIPTION
## Problem

Automatic V3→V1 fallback bug reports (submitted when V3's generated C fails to compile but the established compiler then builds the program) uploaded only a **bounded strict subset** of the failing source — a ~40-line window around the error, or a head+tail window — and dropped the excerpt entirely when it would cover the whole file.

Triage of the live report database showed this makes reports **non-reproducible**: multi-file fragments begin with a stray `}` (`unexpected token \`}\``), and even self-contained programs lose the surrounding declarations needed to replay the failure.

## Fix

Upload the **full failing file** so reports reproduce. The change is limited to source *selection*:

- `bounded_v_source_for_generated_c` (generated-C errors) → returns the full mapped file
- `v3_report_v_source` (internal V3 errors) → returns the full captured source
- `new_c_error_bug_report` (in-process path) → keeps the flattened reproducer when available, else the full file

The **SHA-256 digest check** (only ever upload bytes V3 actually parsed, and only when the on-disk file still matches) is kept as the security anchor — only the anti-whole-file drops and the line-window are removed. A file larger than `c_error_bug_report_max_v_source_bytes` (64 KiB) is still reduced to a window around the failing line, and the env-handoff transport still degrades oversized sources gracefully.

Doc comments, `doc/docs.md`, and the affected tests are updated to match the new behavior.

## Testing

- `v test vlib/v/builder/c_error_report_test.v` — passes (assertions updated to expect the full file)
- macOS dispatch content-extraction / env-round-trip assertions updated and passing
- End-to-end: a real V3→V1 fallback against a local `vbug-report` server now stores the full source in the reports DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)