### PR TITLE
v3: fix `or { panic(...) }` tail codegen in const initializers

### DIFF
--- a/vlib/v3/gen/c/stmt.v
+++ b/vlib/v3/gen/c/stmt.v
@@ -7893,7 +7893,12 @@ fn (mut g FlatGen) gen_or_body_value(or_body flat.Node, value_name string, value
 				g.write('return ')
 				g.gen_optional_error_from_call(fn_opt_ct, g.a.nodes[int(expr_id)])
 				g.write(';')
-			} else if g.stmt_tail_exits(expr_id) {
+			} else if g.stmt_tail_exits(expr_id) && !g.is_noreturn_call(expr_id) {
+				// A control-flow tail that always exits (e.g. a lowered exhaustive
+				// match rendered as an if/else chain) is emitted as a statement.
+				// A bare noreturn call (`panic(..)`/`exit(..)`) is not a statement
+				// node, so it is left to the branch below, which emits it as an
+				// expression statement; gen_node cannot render a bare `.call`.
 				g.gen_node(expr_id)
 			} else if g.is_noreturn_call(expr_id) || g.tc.resolve_type(expr_id) is types.Void {
 				// A diverging/void or-body tail (e.g. `panic(..)`/`exit(..)`) yields no

--- a/vlib/v3/tests/const_or_panic_codegen_test.v
+++ b/vlib/v3/tests/const_or_panic_codegen_test.v
@@ -1,0 +1,55 @@
+import os
+
+const vexe = @VEXE
+const tests_dir = os.dir(@FILE)
+const v3_dir = os.dir(tests_dir)
+const vlib_dir = os.dir(v3_dir)
+const v3_src = os.join_path(v3_dir, 'v3.v')
+
+fn tmp_const_or_panic_path(name string) string {
+	return os.join_path(os.temp_dir(), 'v3_${name}_${os.getpid()}')
+}
+
+fn build_v3_const_or_panic() string {
+	v3_bin := tmp_const_or_panic_path('const_or_panic')
+	build :=
+		os.execute('${os.quoted_path(vexe)} -gc none -path "${vlib_dir}|@vlib|@vmodules" -o ${os.quoted_path(v3_bin)} ${os.quoted_path(v3_src)}')
+	assert build.exit_code == 0, build.output
+	return v3_bin
+}
+
+fn run_v3_const_or_panic_program(v3_bin string, name string, src string) string {
+	src_path := '${tmp_const_or_panic_path(name)}.v'
+	bin_path := tmp_const_or_panic_path('${name}_bin')
+	os.write_file(src_path, src) or { panic(err) }
+	compile :=
+		os.execute('${os.quoted_path(v3_bin)} ${os.quoted_path(src_path)} -b c -o ${os.quoted_path(bin_path)}')
+	assert compile.exit_code == 0, compile.output
+	// The regressed path emitted `gen_node: unsupported node kind: call` to stderr
+	// while still producing a binary, so assert the diagnostic is absent too.
+	assert !compile.output.contains('unsupported node kind'), compile.output
+	assert !compile.output.contains('C compilation failed'), compile.output
+	run := os.execute(os.quoted_path(bin_path))
+	assert run.exit_code == 0, run.output
+	return run.output.trim_space()
+}
+
+// A const initialized by a Result-returning call guarded with `or { panic(..) }`
+// used to reach the C backend as a bare `.call` node in the or-body tail, which
+// gen_node could not render (it printed `unsupported node kind: call`). The
+// noreturn call must instead be emitted as an expression statement.
+fn test_const_or_panic_tail_and_related_positions() {
+	v3_bin := build_v3_const_or_panic()
+
+	const_or := run_v3_const_or_panic_program(v3_bin, 'const_or_panic',
+		"fn decode(x int) !int {\n\tif x == 0 {\n\t\treturn error('zero')\n\t}\n\treturn x * 2\n}\n\nconst decoded = decode(3) or { panic('bad: \${err}') }\n\nfn main() {\n\tprintln(int_str(decoded))\n}\n")
+	assert const_or == '6'
+
+	return_or := run_v3_const_or_panic_program(v3_bin, 'return_or_panic',
+		"fn decode(x int) !int {\n\tif x == 0 {\n\t\treturn error('zero')\n\t}\n\treturn x * 2\n}\n\nfn via(x int) int {\n\treturn decode(x) or { panic('bad: \${err}') }\n}\n\nfn main() {\n\tprintln(int_str(via(5)))\n}\n")
+	assert return_or == '10'
+
+	value_or := run_v3_const_or_panic_program(v3_bin, 'value_or_default',
+		"fn decode(x int) !int {\n\tif x == 0 {\n\t\treturn error('zero')\n\t}\n\treturn x * 2\n}\n\nfn via(x int) int {\n\treturn decode(x) or { -1 }\n}\n\nfn main() {\n\tprintln(int_str(via(0)) + ':' + int_str(via(4)))\n}\n")
+	assert value_or == '-1:8'
+}


### PR DESCRIPTION
## Problem

Building a program that imports `net.http` with the V3 backend printed:

```
gen_node: unsupported node kind: call; ...
```

for the HPACK/QPACK Huffman const tables in `net.http`/`net.quic`, both of the form:

```v
const h2_huffman_decode_map = h2_huffman_table.decode_map() or { panic('hpack: ${err}') }
```

i.e. a `const` initialized by a `Result`-returning call guarded with `or { panic(..) }`. The stable compiler still produced a binary, so the diagnostic only leaked to stderr — which is what surfaced for users as e.g.:

```
v -prod -o bombardier .
```

Minimal reproducer:

```v
fn decode(x int) !int {
	if x == 0 { return error('zero') }
	return x * 2
}
const decoded = decode(3) or { panic('bad: ${err}') }
fn main() { println(decoded) }
```

## Root cause

In `gen_or_body_value` (`vlib/v3/gen/c/stmt.v`), when an `or {}` body's tail is an `expr_stmt`, the inner expression is unwrapped and checked with `stmt_tail_exits()`. For a `panic(..)`/`exit(..)` call, `stmt_tail_exits()` returns `true` (via its `.call → is_noreturn_call` case), so that branch called `gen_node()` on a **bare `.call`** node. `gen_node` is a statement generator with no `.call` case, so it fell through to the "unsupported node kind" branch.

The dedicated branch right below already handles this correctly by emitting the call as an expression statement (`v_panic(...);`).

## Fix

Exclude noreturn calls from the `stmt_tail_exits` branch so they fall through to the branch that renders them properly:

```v
} else if g.stmt_tail_exits(expr_id) && !g.is_noreturn_call(expr_id) {
```

Since `stmt_tail_exits(.call) ⟺ is_noreturn_call(.call)`, this only redirects bare noreturn calls; the `.if_expr`/`.block` tail-exit paths (where `is_noreturn_call` is `false`) are byte-for-byte unchanged.

## Testing

- Added `vlib/v3/tests/const_or_panic_codegen_test.v`, covering the const, return, and value `or`-block positions. It passes with the fix and **fails** without it.
- Verified the original directory build and `-new-compiler -prod` build of the reproducing program now compile with no `gen_node` errors, and the panic path still fires with `err` bound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
