### PR TITLE
v3: bound native-input scan RSS so cold builds don't hit the memory ceiling

### DIFF
--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -2681,8 +2681,14 @@ fn register_headerless_c_types(mut tc types.TypeChecker) {
 fn c_typedef_is_function_pointer(source string, name string) bool {
 	mut offset := 0
 	for offset < source.len {
-		relative := source[offset..].index(name) or { return false }
-		start := offset + relative
+		// index_after scans in place from `offset`. `source[offset..].index(name)`
+		// allocated a fresh copy of the whole remaining tail of `source` on every
+		// iteration; this function runs once per typedef name per native header, so
+		// under -prealloc (allocations in a stage scope are not freed until the
+		// scope ends) those tail copies accumulated to multiple GB of transient
+		// RSS on a build pulling large native headers (sokol, stb, mbedtls,
+		// openssl) — enough to trip v3's memory ceiling and fall back to V1.
+		start := source.index_after(name, offset) or { return false }
 		end := start + name.len
 		if (start == 0 || (!source[start - 1].is_alnum() && source[start - 1] != `_`))
 			&& (end == source.len || (!source[end].is_alnum() && source[end] != `_`)) {

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -1860,6 +1860,14 @@ pub fn cache_native_inputs_language(a &flat.FlatAst, vroot string, c_flags []str
 	mut need_objc := false
 	mut need_cpp := false
 	mut cur_file := ''
+	// A header's Objective-C classification depends only on the resolved header
+	// plus c_flags/c99_mode/target, all constant across this loop, so memoize it:
+	// a system `<...>` argument resolves identically no matter which file
+	// included it; a quoted argument is keyed with its including file since it
+	// resolves relative to that file. Without this a header pulled by N modules
+	// is fully inlined N times. Values: 1 = needs Objective-C, 2 = checked and
+	// does not (0 / absent = not yet checked).
+	mut header_objc_cache := map[string]int{}
 	for node in a.nodes {
 		if node.kind == .file {
 			cur_file = node.value
@@ -1890,10 +1898,41 @@ pub fn cache_native_inputs_language(a &flat.FlatAst, vroot string, c_flags []str
 			}
 			continue
 		}
-		if header := c_inline_header_text(include_arg, vroot, cur_file, include_dirs, false) {
-			if c_header_text_needs_objective_c_for_target(header.text, c_flags, c99_mode, target) {
+		// This branch can only ever set need_objc (never need_cpp), so once
+		// need_objc is known there is nothing left for it to discover.
+		if need_objc {
+			continue
+		}
+		memo_key := if include_arg.starts_with('<') {
+			include_arg
+		} else {
+			cur_file + '\x00' + include_arg
+		}
+		if cached := header_objc_cache[memo_key] {
+			if cached == 1 {
 				need_objc = true
 			}
+			continue
+		}
+		// Inlining a header expands its whole transitive #include closure into a
+		// builder just to text-scan it. Under -prealloc that scratch is retained
+		// until the enclosing stage scope ends; a disposable scope here frees
+		// each header's closure as soon as the boolean is read, bounding peak
+		// RSS to one closure at a time instead of the sum of all of them.
+		mut this_objc := false
+		lang_scope := cgen_worker_scope_begin(true)
+		if header := c_inline_header_text(include_arg, vroot, cur_file, include_dirs, false) {
+			if c_header_text_needs_objective_c_for_target(header.text, c_flags, c99_mode,
+				target)
+			{
+				this_objc = true
+			}
+		}
+		cgen_worker_scope_leave(lang_scope)
+		cgen_worker_scope_free(lang_scope)
+		header_objc_cache[memo_key] = if this_objc { 1 } else { 2 }
+		if this_objc {
+			need_objc = true
 		}
 	}
 	return c_native_language_from_features(need_objc, need_cpp)
@@ -2060,7 +2099,17 @@ fn c_collect_external_input_tree(path string, vroot string, include_dirs []strin
 		}
 	}
 	mut has_untracked_include := false
-	mut possible_source := strings.new_builder(text.len)
+	// Collect active (non-`#if`-excluded) lines as cheap string references while
+	// this scan and any nested-include recursion it triggers are in flight,
+	// instead of copying each line's bytes into a growing builder immediately.
+	// The single byte-copying pass that builds `possible_text` for the
+	// static-storage check runs once, after this file's own recursion finishes,
+	// so a deeply nested include chain never keeps a second full-size copy of
+	// this file's active content alive for the whole descent. Under -prealloc
+	// (nothing in the stage scope is freed until it exits) this trims real
+	// transient RSS, though it is not the dominant cost of a heavy-native-header
+	// build — see c_typedef_is_function_pointer for that.
+	mut kept_lines := []string{}
 	mut in_block_comment := false
 	mut conditionals := []CCacheConditional{}
 	defer {
@@ -2116,7 +2165,7 @@ fn c_collect_external_input_tree(path string, vroot string, include_dirs []strin
 		if conditionals.any(it.inactive) {
 			continue
 		}
-		possible_source.writeln(line)
+		kept_lines << line
 		if directive_name !in ['include', 'import'] {
 			mutation_is_ambiguous := ambient_ambiguous || conditionals.any(it.ambiguous)
 			c_record_include_macro_definition(clean, mutation_is_ambiguous, mut include_macros, mut
@@ -2176,6 +2225,11 @@ fn c_collect_external_input_tree(path string, vroot string, include_dirs []strin
 			}
 		}
 	}
+	mut possible_source := strings.new_builder(text.len)
+	for kept in kept_lines {
+		possible_source.writeln(kept)
+	}
+	unsafe { kept_lines.free() }
 	possible_text := possible_source.str()
 	if modulecache.c_source_has_static_storage(possible_text) {
 		active_static_storage_paths[collection_key] = true

--- a/vlib/v3/gen/c/target_test.v
+++ b/vlib/v3/gen/c/target_test.v
@@ -1062,6 +1062,58 @@ fn test_cache_native_input_language_reports_source_language() {
 	assert cache_native_inputs_language(a, '', []string{}, false, prefs.target) == 'objective-c++'
 }
 
+// cache_native_inputs_language memoizes each header include's Objective-C
+// classification, keyed on the include argument alone for `<...>` (which
+// resolves independently of the including file) and on including-file + argument
+// for a quoted include (which resolves relative to that file). This exercises
+// the header-include branch directly -- the only other test that reaches
+// cache_native_inputs_language passes an `.mm` SOURCE file, which takes the
+// unrelated source-file branch -- and pins the quoted-include key: two
+// same-named headers in different module directories with different
+// Objective-C-ness must not share a cache entry.
+fn test_cache_native_inputs_language_header_branch_and_memo_key() {
+	dir := os.join_path(os.vtmp_dir(), 'v3_native_language_header_${os.getpid()}')
+	os.rmdir_all(dir) or {}
+	os.mkdir_all(dir) or { panic(err) }
+	defer {
+		os.rmdir_all(dir) or {}
+	}
+	mut prefs := pref.new_preferences()
+	prefs.target = pref.host_target()
+
+	// A quoted `.h` header carrying `@interface` reaches the header-include
+	// branch (a `.h` is not a native source file) and must classify as
+	// objective-c.
+	objc_dir := os.join_path(dir, 'objc_mod')
+	os.mkdir_all(objc_dir) or { panic(err) }
+	os.write_file(os.join_path(objc_dir, 'shared.h'), '@interface V3HeaderBranch\n@end\n')!
+	objc_program := os.join_path(objc_dir, 'prog.v')
+	os.write_file(objc_program, 'module objc_mod\n#include "shared.h"\n')!
+	mut p1 := parser.Parser.new(prefs)
+	a1 := p1.parse_file(objc_program)
+	assert cache_native_inputs_language(a1, '', []string{}, false, prefs.target) == 'objective-c'
+
+	// A plain header in the same shape stays c.
+	plain_dir := os.join_path(dir, 'plain_mod')
+	os.mkdir_all(plain_dir) or { panic(err) }
+	os.write_file(os.join_path(plain_dir, 'shared.h'), 'int plain_decl(void);\n')!
+	plain_program := os.join_path(plain_dir, 'prog.v')
+	os.write_file(plain_program, 'module plain_mod\n#include "shared.h"\n')!
+	mut p2 := parser.Parser.new(prefs)
+	a2 := p2.parse_file(plain_program)
+	assert cache_native_inputs_language(a2, '', []string{}, false, prefs.target) == 'c'
+
+	// Both modules in one AST, the plain one walked first, each including its
+	// own directory-local `"shared.h"`. If the quoted-include memo key dropped
+	// the including-file component, the plain module's entry (`shared.h` ->
+	// clean) would shadow the objc module's header, and the whole probe would
+	// be misclassified as c -- silently dropping __OBJC__ from the shared
+	// compiler-macro probe. Correct keying keeps them distinct.
+	mut p3 := parser.Parser.new(prefs)
+	a3 := p3.parse_files([plain_program, objc_program])
+	assert cache_native_inputs_language(a3, '', []string{}, false, prefs.target) == 'objective-c'
+}
+
 fn test_cache_input_scan_rejects_ambiguous_include_macro_literal() {
 	dir := os.join_path(os.vtmp_dir(), 'v3_ambiguous_include_macro_${os.getpid()}')
 	os.rmdir_all(dir) or {}


### PR DESCRIPTION
## Problem

On a **cold** V3 module cache, the `check` stage's native-input scan drives peak RSS to ~9 GB when building a project with a large combined native surface (OpenSSL via `crypto.ecdsa`, Cocoa/AppKit, and `sokol`/`stb`/`mbedtls` single-header C libs together). That trips v3's 10 GiB memory ceiling and forces a silent fallback to the V1 compiler. Warm builds are unaffected (~750 MB), which is why it's intermittent.

Root cause is two transient allocations in the native-input path, both retained for the whole stage because v3 `-prealloc` builds run `-gc none` — nothing is freed until the enclosing stage scope exits:

### 1. `c_typedef_is_function_pointer` (dominant, ~8 GB)

```v
relative := source[offset..].index(name) or { return false }
```

`string[offset..]` allocates a fresh copy of the entire remaining tail of `source` on **every loop iteration**. This runs once per typedef name per native header, so large headers (`sokol_gfx.h`, `stb_truetype.h`, mbedtls, openssl) × hundreds of typedef names accumulate gigabytes of tail copies. Replaced with `source.index_after(name, offset)`, which scans in place — same first-match semantics, no allocation.

### 2. `cache_native_inputs_language` (~2.2 GB)

For every header `#include` in the AST it recursively inlined the header's entire transitive `#include` closure into a builder — once per include site, no cross-site dedup, no size cap — purely to decide whether the native inputs need Objective-C. Now: memoize the result per include argument (`<...>` keyed on the argument, quoted keyed on including-file + argument), stop once Objective-C is known, and run each remaining inline inside a disposable prealloc scope so its closure is freed as soon as the boolean is read.

### 3. `c_collect_external_input_tree` (minor, ~200 MB)

It built a second full-size line-buffer copy of each file and held it across the nested-include recursion. Now it collects cheap string refs during the scan and does the one byte-copy after the recursion returns.

## Result

Cold `check` stage peak on the affected project: **~9058 MB → ~980 MB**; the whole cold build now peaks at cgen (~1.9 GB), well under the ceiling. Warm builds unchanged.

**No behavior change:** the scan produces the same native-input set, the same C-language classification, and the same static-storage flags — only less transient memory.

## Tests

- `vlib/v3/gen/c/target_test.v` and `vlib/v3/modulecache/` pass.
- Added `test_cache_native_inputs_language_header_branch_and_memo_key` covering the previously-untested header-include branch, including a regression guard for the quoted-include memo key (two same-named headers in different module dirs with different Objective-C-ness must not share a cache entry — verified this assertion fails if the key's including-file component is dropped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)