### PR TITLE
v3: fix `arr.first()/last().field` borrow codegen for owned elements

### DIFF
--- a/vlib/v3/tests/array_accessor_field_borrow_codegen_test.v
+++ b/vlib/v3/tests/array_accessor_field_borrow_codegen_test.v
@@ -85,3 +85,71 @@ fn test_first_last_field_borrow_in_imported_module() {
 		"module main\n\nimport mymod\n\nfn main() {\n\tmut t := mymod.Tbl{}\n\tt.add('a', 'b')\n\tt.add('c', 'd')\n\tprintln(int_str(t.total()))\n}\n")
 	assert out == '68'
 }
+
+// The in-place borrow only fires with the ownership checker (`-d ownership`); it is where
+// the accessor would otherwise take its independent-clone path. These cases exercise that
+// path directly. The build compiler must itself embed the ownership checker.
+fn build_v3_array_accessor_borrow_ownership() ?string {
+	v3_bin := tmp_array_accessor_borrow_path('array_accessor_borrow_ownership')
+	build :=
+		os.execute('${os.quoted_path(array_accessor_borrow_vexe)} -gc none -d ownership -path "${array_accessor_borrow_vlib_dir}|@vlib|@vmodules" -o ${os.quoted_path(v3_bin)} ${os.quoted_path(array_accessor_borrow_v3_src)}')
+	if build.output.contains('ownership support is not compiled into this v3 executable') {
+		// The bootstrap compiler running this test lacks the ownership checker, so it
+		// cannot build an ownership-enabled v3. Skip rather than fail on such a host.
+		return none
+	}
+	assert build.exit_code == 0, build.output
+	return v3_bin
+}
+
+fn compile_v3_ownership_program(v3_bin string, name string, src string, extra_args string) os.Result {
+	src_path := '${tmp_array_accessor_borrow_path(name)}.v'
+	bin_path := tmp_array_accessor_borrow_path('${name}_bin')
+	os.write_file(src_path, src) or { panic(err) }
+	return os.execute('${os.quoted_path(v3_bin)} -ownership -d ownership -no-parallel ${extra_args} -o ${os.quoted_path(bin_path)} ${os.quoted_path(src_path)}')
+}
+
+// Concern: `last()` reads its receiver twice (`arr[arr.len - 1]`), so a non-lvalue receiver
+// such as `make_entries()` must be evaluated exactly once. The borrow lowering binds it to a
+// temp instead of duplicating the call.
+fn test_owned_first_last_receiver_evaluated_once() {
+	v3_bin := build_v3_array_accessor_borrow_ownership() or { return }
+	compile := compile_v3_ownership_program(v3_bin, 'owned_eval_once',
+		"struct E {\n\tname string\n\tsize int\n}\n\n__global (\n\tmake_calls = 0\n)\n\nfn make_entries() []E {\n\tmake_calls++\n\treturn [E{ name: 'a', size: 5 }, E{ name: 'b', size: 9 }]\n}\n\nfn main() {\n\ts := make_entries().last().size\n\tprintln(int_str(s) + ':' + int_str(make_calls))\n}\n",
+		'-enable-globals')
+	assert compile.exit_code == 0, compile.output
+	assert !compile.output.contains('unsupported node kind'), compile.output
+	bin_path := tmp_array_accessor_borrow_path('owned_eval_once_bin')
+	run := os.execute(os.quoted_path(bin_path))
+	assert run.exit_code == 0, run.output
+	// size == 9 (last element), make_entries() invoked once (not twice).
+	assert run.output.trim_space() == '9:1', run.output
+}
+
+// Concern: a bound method value (`arr.last().method`) is not a field read. Closure
+// generation shallow-copies the receiver, so it must keep the copying accessor semantics
+// instead of borrowing the array element. For an owned element with no `clone()` method the
+// accessor is genuinely impossible, so this must be rejected rather than silently miscompiled.
+fn test_owned_method_value_receiver_is_rejected() {
+	v3_bin := build_v3_array_accessor_borrow_ownership() or { return }
+	compile := compile_v3_ownership_program(v3_bin, 'owned_method_value',
+		"struct E {\n\tname string\n\tsize int\n}\n\nfn (e E) describe() string {\n\treturn e.name\n}\n\nfn main() {\n\tarr := [E{ name: 'a', size: 1 }, E{ name: 'b', size: 2 }]\n\tf := arr.last().describe\n\tprintln(f())\n}\n",
+		'')
+	assert compile.exit_code != 0, compile.output
+	assert compile.output.contains('cannot return an independent array element'), compile.output
+}
+
+// A method value whose element type does provide `clone()` keeps working: the receiver is
+// cloned (an independent copy), never an alias of the live array element.
+fn test_owned_method_value_with_clone_runs() {
+	v3_bin := build_v3_array_accessor_borrow_ownership() or { return }
+	compile := compile_v3_ownership_program(v3_bin, 'owned_method_value_clone',
+		"struct E {\n\tname string\n\tsize int\n}\n\nfn (e E) clone() E {\n\treturn E{ name: e.name.clone(), size: e.size }\n}\n\nfn (e E) describe() string {\n\treturn e.name\n}\n\nfn main() {\n\tarr := [E{ name: 'a', size: 1 }, E{ name: 'bb', size: 2 }]\n\tf := arr.last().describe\n\tprintln(f())\n}\n",
+		'')
+	assert compile.exit_code == 0, compile.output
+	assert !compile.output.contains('unsupported node kind'), compile.output
+	bin_path := tmp_array_accessor_borrow_path('owned_method_value_clone_bin')
+	run := os.execute(os.quoted_path(bin_path))
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == 'bb', run.output
+}

--- a/vlib/v3/tests/array_accessor_field_borrow_codegen_test.v
+++ b/vlib/v3/tests/array_accessor_field_borrow_codegen_test.v
@@ -126,6 +126,24 @@ fn test_owned_first_last_receiver_evaluated_once() {
 	assert run.output.trim_space() == '9:1', run.output
 }
 
+// Concern: `(arr.last()).field` must lower to the same in-place borrow as `arr.last().field`.
+// The checker's borrowed-field predicate sees through transparent parentheses to suppress the
+// diagnostic, so the transformer must unwrap them too; otherwise the accessor follows its
+// independent-copy path and emits an empty `(0)` placeholder that fails C compilation.
+fn test_owned_parenthesized_field_borrow() {
+	v3_bin := build_v3_array_accessor_borrow_ownership() or { return }
+	compile := compile_v3_ownership_program(v3_bin, 'owned_paren_borrow',
+		"struct E {\n\tname string\n\tsize int\n}\n\nstruct T {\nmut:\n\tentries []E\n\ttotal   int\n}\n\nfn (mut t T) shrink() {\n\tfor t.entries.len > 0 {\n\t\tt.total -= (t.entries.last()).size\n\t\tt.entries.delete_last()\n\t}\n}\n\nfn main() {\n\tmut t := T{}\n\tt.entries << E{ name: 'a', size: 5 }\n\tt.entries << E{ name: 'b', size: 7 }\n\tt.total = 12\n\tt.shrink()\n\tprintln(int_str(t.total))\n}\n",
+		'')
+	assert compile.exit_code == 0, compile.output
+	assert !compile.output.contains('unsupported node kind'), compile.output
+	assert !compile.output.contains('C compilation failed'), compile.output
+	bin_path := tmp_array_accessor_borrow_path('owned_paren_borrow_bin')
+	run := os.execute(os.quoted_path(bin_path))
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == '0', run.output
+}
+
 // Concern: a bound method value (`arr.last().method`) is not a field read. Closure
 // generation shallow-copies the receiver, so it must keep the copying accessor semantics
 // instead of borrowing the array element. For an owned element with no `clone()` method the

--- a/vlib/v3/tests/array_accessor_field_borrow_codegen_test.v
+++ b/vlib/v3/tests/array_accessor_field_borrow_codegen_test.v
@@ -1,0 +1,87 @@
+import os
+
+const array_accessor_borrow_vexe = @VEXE
+const array_accessor_borrow_tests_dir = os.dir(@FILE)
+const array_accessor_borrow_v3_dir = os.dir(array_accessor_borrow_tests_dir)
+const array_accessor_borrow_vlib_dir = os.dir(array_accessor_borrow_v3_dir)
+const array_accessor_borrow_v3_src = os.join_path(array_accessor_borrow_v3_dir, 'v3.v')
+
+fn tmp_array_accessor_borrow_path(name string) string {
+	return os.join_path(os.temp_dir(), 'v3_${name}_${os.getpid()}')
+}
+
+fn build_v3_array_accessor_borrow() string {
+	v3_bin := tmp_array_accessor_borrow_path('array_accessor_borrow')
+	build :=
+		os.execute('${os.quoted_path(array_accessor_borrow_vexe)} -gc none -path "${array_accessor_borrow_vlib_dir}|@vlib|@vmodules" -o ${os.quoted_path(v3_bin)} ${os.quoted_path(array_accessor_borrow_v3_src)}')
+	assert build.exit_code == 0, build.output
+	return v3_bin
+}
+
+fn assert_clean_borrow_build(compile os.Result) {
+	assert compile.exit_code == 0, compile.output
+	// The regressed transform lowered `arr.last().field` to an empty placeholder that
+	// the C backend printed as `(0)`, so the borrow read reached cc as `(0).field`
+	// ("member reference base type 'int' is not a structure or union"). In a directly
+	// compiled module the ownership checker instead rejected the accessor outright.
+	assert !compile.output.contains('unsupported node kind'), compile.output
+	assert !compile.output.contains('cannot return an independent array element'), compile.output
+	assert !compile.output.contains('C compilation failed'), compile.output
+}
+
+fn run_v3_array_accessor_borrow_program(v3_bin string, name string, src string) string {
+	src_path := '${tmp_array_accessor_borrow_path(name)}.v'
+	bin_path := tmp_array_accessor_borrow_path('${name}_bin')
+	os.write_file(src_path, src) or { panic(err) }
+	compile :=
+		os.execute('${os.quoted_path(v3_bin)} ${os.quoted_path(src_path)} -b c -o ${os.quoted_path(bin_path)}')
+	assert_clean_borrow_build(compile)
+	run := os.execute(os.quoted_path(bin_path))
+	assert run.exit_code == 0, run.output
+	return run.output.trim_space()
+}
+
+fn run_v3_array_accessor_borrow_module(name string, module_src string, main_src string) string {
+	proj_dir := tmp_array_accessor_borrow_path(name)
+	mod_dir := os.join_path(proj_dir, 'mymod')
+	os.mkdir_all(mod_dir) or { panic(err) }
+	os.write_file(os.join_path(mod_dir, 'mymod.v'), module_src) or { panic(err) }
+	os.write_file(os.join_path(proj_dir, 'main.v'), main_src) or { panic(err) }
+	bin_path := tmp_array_accessor_borrow_path('${name}_bin')
+	v3_bin := build_v3_array_accessor_borrow()
+	compile :=
+		os.execute('${os.quoted_path(v3_bin)} ${os.quoted_path(proj_dir)} -b c -o ${os.quoted_path(bin_path)}')
+	assert_clean_borrow_build(compile)
+	run := os.execute(os.quoted_path(bin_path))
+	assert run.exit_code == 0, run.output
+	return run.output.trim_space()
+}
+
+// Reading a field of `arr.first()`/`arr.last()` is a borrow of the stored element,
+// not an independent copy, so it must lower to an in-place `arr[..]` access even when
+// the element type owns heap data and has no `clone()` method. This mirrors the HPACK
+// dynamic table (`net.http` / `net.quic`) that `v new --web` pulls in via `veb`.
+fn test_first_last_field_borrow_on_owned_elements() {
+	v3_bin := build_v3_array_accessor_borrow()
+
+	// The exact evict-loop shape: read the last element's scalar field, then remove it.
+	last_field := run_v3_array_accessor_borrow_program(v3_bin, 'last_field',
+		"struct Entry {\n\tname  string\n\tvalue string\n\tsize  int\n}\n\nstruct Tbl {\nmut:\n\tentries []Entry\n\ttotal   int\n}\n\nfn (mut t Tbl) shrink() {\n\tfor t.entries.len > 0 {\n\t\tt.total -= t.entries.last().size\n\t\tt.entries.delete_last()\n\t}\n}\n\nfn main() {\n\tmut t := Tbl{}\n\tt.entries << Entry{ name: 'a', value: 'b', size: 5 }\n\tt.entries << Entry{ name: 'c', value: 'd', size: 7 }\n\tt.total = 12\n\tt.shrink()\n\tprintln(int_str(t.total))\n}\n")
+	assert last_field == '0'
+
+	// first()/last() field reads through both value and ref receivers, incl. a chained
+	// field access (`last().name.len`).
+	mixed := run_v3_array_accessor_borrow_program(v3_bin, 'mixed_field',
+		"struct Entry {\n\tname string\n\tn    int\n}\n\nstruct Box {\nmut:\n\tentries []Entry\n}\n\nfn (b &Box) probe() int {\n\treturn b.entries.first().n + b.entries.last().n + b.entries.last().name.len\n}\n\nfn main() {\n\tmut b := Box{}\n\tb.entries << Entry{ name: 'ab', n: 10 }\n\tb.entries << Entry{ name: 'cdef', n: 20 }\n\tprintln(int_str(b.probe()))\n}\n")
+	assert mixed == '34'
+}
+
+// The same borrow read inside an imported module: the ownership checker does not
+// diagnose non-user modules, so the regressed transform silently produced `(0)` there,
+// which is precisely why `v .` on a fresh `--web` project failed to compile.
+fn test_first_last_field_borrow_in_imported_module() {
+	out := run_v3_array_accessor_borrow_module('borrow_mod',
+		"module mymod\n\nstruct Entry {\n\tname  string\n\tvalue string\n\tsize  int\n}\n\npub struct Tbl {\nmut:\n\tentries []Entry\n\ttotal   int\n}\n\npub fn (mut t Tbl) add(name string, value string) {\n\tsz := name.len + value.len + 32\n\tfor t.entries.len > 0 && t.total + sz > 100 {\n\t\tt.total -= t.entries.last().size\n\t\tt.entries.delete_last()\n\t}\n\tt.entries.insert(0, Entry{ name: name, value: value, size: sz })\n\tt.total += sz\n}\n\npub fn (t &Tbl) total() int {\n\treturn t.total\n}\n",
+		"module main\n\nimport mymod\n\nfn main() {\n\tmut t := mymod.Tbl{}\n\tt.add('a', 'b')\n\tt.add('c', 'd')\n\tprintln(int_str(t.total()))\n}\n")
+	assert out == '68'
+}

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -17745,7 +17745,61 @@ fn stringify_type_has_generic_placeholder(typ string) bool {
 	return false
 }
 
+// borrow_first_last_accessor lowers a `first()`/`last()` array accessor used as a borrow
+// (e.g. the base of a field selector `arr.last().field`) into an in-place element access
+// `arr[0]` / `arr[len - 1]`. The stored element stays owned by the array, so this avoids
+// the independent-clone path `first()`/`last()` otherwise takes for ownership-bearing
+// element types — a path that has no valid lowering when the element has no `clone()`
+// method and would otherwise emit an empty placeholder (`(0)`). Restricted to that owned
+// case so non-owned elements keep their existing accessor lowering. Applied unconditionally
+// for owned elements so it stays in lock-step with the checker, which likewise treats every
+// `first()`/`last()` field read as a borrow. Returns none when the base is not such an
+// accessor.
+fn (mut t Transformer) borrow_first_last_accessor(call_id flat.NodeId) ?flat.NodeId {
+	if int(call_id) < 0 || int(call_id) >= t.a.nodes.len || isnil(t.tc) {
+		return none
+	}
+	node := t.a.nodes[int(call_id)]
+	if node.kind != .call || node.children_count == 0 {
+		return none
+	}
+	callee := t.a.child_node(&node, 0)
+	if callee.kind != .selector || callee.value !in ['first', 'last'] || callee.children_count == 0 {
+		return none
+	}
+	base_id := t.a.child(callee, 0)
+	base_type := t.normalize_type_alias(t.lvalue_type(base_id))
+	clean_base_type := base_type.trim_left('&')
+	if !clean_base_type.starts_with('[]') {
+		return none
+	}
+	elem_type := clean_base_type[2..]
+	if !t.tc.ownership_type_requires_destruction(t.tc.parse_type(elem_type)) {
+		return none
+	}
+	mut base := t.transform_lvalue(base_id)
+	if base_type.starts_with('&') {
+		base = t.make_prefix(.mul, base)
+		t.set_node_typ(int(base), clean_base_type)
+	}
+	if callee.value == 'last' {
+		base = t.stabilize_transformed_lvalue_for_reuse(base)
+	}
+	index := if callee.value == 'first' {
+		t.make_int_literal(0)
+	} else {
+		t.make_infix(.minus, t.make_selector(base, 'len', 'int'), t.make_int_literal(1))
+	}
+	return t.make_index(base, index, elem_type)
+}
+
 fn (mut t Transformer) transform_selector_base_expr(id flat.NodeId) flat.NodeId {
+	// A `first()`/`last()` accessor used as a selector base (`arr.last().field`) borrows
+	// the stored element rather than returning an independent copy; lower it in place so
+	// ownership-bearing element types without a `clone()` method still resolve.
+	if borrowed := t.borrow_first_last_accessor(id) {
+		return borrowed
+	}
 	// `in_selector_base` suppresses the pointer-value rvalue deref in
 	// transform_ident_expr, but that must apply only to the *direct* receiver ident of
 	// a selector (`x.field`, where `x` stays `&T` so the selector emits arrow access).

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -17767,7 +17767,14 @@ fn (mut t Transformer) borrow_first_last_accessor(call_id flat.NodeId) ?flat.Nod
 		|| t.suppress_first_last_accessor_borrow {
 		return none
 	}
-	node := t.a.nodes[int(call_id)]
+	mut node := t.a.nodes[int(call_id)]
+	// `(arr.last()).field` is the same borrow as `arr.last().field`; the checker's
+	// borrowed-field predicate (array_accessor_result_is_borrowed) looks through
+	// transparent parentheses, so this must too — otherwise the suppressed diagnostic
+	// leaks an empty `(0)` placeholder and the C compilation fails.
+	for node.kind == .paren && node.children_count > 0 {
+		node = t.a.nodes[int(t.a.child(&node, 0))]
+	}
 	if node.kind != .call || node.children_count == 0 {
 		return none
 	}

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -206,6 +206,11 @@ mut:
 	expected_expr_node              int = -1
 	expected_expr_type              string
 	in_selector_base                bool
+	// Set while transforming the base of a bound-method-value selector, where a
+	// `first()`/`last()` accessor base must keep its copying semantics instead of being
+	// borrowed in place (see borrow_first_last_accessor / transform_selector_expr).
+	suppress_first_last_accessor_borrow bool
+
 	autolock_depth                  int
 	alias_cache                     &AliasCache              = unsafe { nil }
 	sum_cache                       &AliasCache              = unsafe { nil }
@@ -17751,12 +17756,15 @@ fn stringify_type_has_generic_placeholder(typ string) bool {
 // the independent-clone path `first()`/`last()` otherwise takes for ownership-bearing
 // element types — a path that has no valid lowering when the element has no `clone()`
 // method and would otherwise emit an empty placeholder (`(0)`). Restricted to that owned
-// case so non-owned elements keep their existing accessor lowering. Applied unconditionally
-// for owned elements so it stays in lock-step with the checker, which likewise treats every
-// `first()`/`last()` field read as a borrow. Returns none when the base is not such an
-// accessor.
+// case so non-owned elements keep their existing accessor lowering. Applied for every owned
+// field read so it stays in lock-step with the checker, which likewise treats such a read as
+// a borrow — but NOT for a bound-method-value receiver (`suppress_first_last_accessor_borrow`):
+// there closure generation shallow-copies the receiver, so an aliased array element would
+// share heap fields with the array and double-free. Returns none when the base is not such
+// an accessor.
 fn (mut t Transformer) borrow_first_last_accessor(call_id flat.NodeId) ?flat.NodeId {
-	if int(call_id) < 0 || int(call_id) >= t.a.nodes.len || isnil(t.tc) {
+	if int(call_id) < 0 || int(call_id) >= t.a.nodes.len || isnil(t.tc)
+		|| t.suppress_first_last_accessor_borrow {
 		return none
 	}
 	node := t.a.nodes[int(call_id)]
@@ -17783,7 +17791,10 @@ fn (mut t Transformer) borrow_first_last_accessor(call_id flat.NodeId) ?flat.Nod
 		t.set_node_typ(int(base), clean_base_type)
 	}
 	if callee.value == 'last' {
-		base = t.stabilize_transformed_lvalue_for_reuse(base)
+		// `last()` reads the base twice (`arr[arr.len - 1]`), so it must evaluate once.
+		// A plain lvalue (`t.entries`) is left untouched; a non-lvalue receiver such as
+		// `make_entries()` is bound to a temp instead of being duplicated.
+		base = t.stable_transformed_expr_for_reuse(base, clean_base_type, 'first_last_borrow_base')
 	}
 	index := if callee.value == 'first' {
 		t.make_int_literal(0)
@@ -18154,9 +18165,16 @@ fn (mut t Transformer) transform_selector_expr(id flat.NodeId, node flat.Node) f
 		new_base := t.selector_base_for_field(transformed_base, base_type0)
 		return t.lower_sum_shared_field_selector(new_base, base_type0, node.value, shared_typ)
 	}
+	// A bound method value keeps the copying `first()`/`last()` accessor semantics for its
+	// receiver; only a field read borrows the element in place. The field-specific branches
+	// above never reach here for a method value, so gating this one call site suffices.
+	is_method_value := !isnil(t.tc) && t.tc.expr_is_method_value(id)
+	old_suppress_borrow := t.suppress_first_last_accessor_borrow
+	t.suppress_first_last_accessor_borrow = is_method_value
 	mut new_base := t.transform_selector_base_expr(base_id)
+	t.suppress_first_last_accessor_borrow = old_suppress_borrow
 	mut selector_generic_params := node.generic_params().clone()
-	if !isnil(t.tc) && t.tc.expr_is_method_value(id) {
+	if is_method_value {
 		method_value_name := t.resolve_receiver_method_name(new_base, node.value)
 		method_params := t.call_param_types(method_value_name)
 		if method_params.len > 0 && method_params[0] !is types.Pointer {

--- a/vlib/v3/types/checker_tail.v
+++ b/vlib/v3/types/checker_tail.v
@@ -6024,6 +6024,30 @@ fn (tc &TypeChecker) known_sum_constructor_name(name string) ?string {
 	return none
 }
 
+// array_accessor_result_is_borrowed reports whether a `first()`/`last()` call result is
+// consumed as a borrow — the base of a field selector (`arr.last().field`) — rather than
+// escaping as an independent value. A borrowed field read keeps the element owned by the
+// array, so it needs no `clone()` even when the element type has no clone method; the
+// transformer lowers such a base to an in-place `arr[..]` access.
+fn (tc &TypeChecker) array_accessor_result_is_borrowed(id flat.NodeId) bool {
+	mut current := id
+	for {
+		parent_id := tc.direct_parent_id(current)
+		if parent_id == flat.empty_node || int(parent_id) < 0 || int(parent_id) >= tc.a.nodes.len {
+			return false
+		}
+		parent := tc.a.node(parent_id)
+		// See through transparent parens: `(arr.last()).field`.
+		if parent.kind == .paren {
+			current = parent_id
+			continue
+		}
+		return parent.kind == .selector && parent.children_count > 0
+			&& tc.a.child(parent, 0) == current
+	}
+	return false
+}
+
 // should_diagnose reports whether should diagnose applies in types.
 fn (tc &TypeChecker) should_diagnose(id flat.NodeId) bool {
 	if tc.valid_diagnostic_fast {
@@ -6843,7 +6867,8 @@ fn (mut tc TypeChecker) resolve_call_info_uncached(id flat.NodeId, node flat.Nod
 		if clean_array := array_like_type_for_method(clean, fn_node.value) {
 			match fn_node.value {
 				'first', 'last', 'pop', 'pop_left' {
-					if fn_node.value in ['first', 'last'] {
+					if fn_node.value in ['first', 'last']
+						&& !tc.array_accessor_result_is_borrowed(id) {
 						if bad_type := tc.ownership_default_clone_missing_method(clean_array.elem_type) {
 							tc.record_error(.call_arg_mismatch,
 								'cannot return an independent array element: `${bad_type}` requires ownership destruction but has no `clone()` method',

--- a/vlib/v3/types/checker_tail.v
+++ b/vlib/v3/types/checker_tail.v
@@ -6028,7 +6028,9 @@ fn (tc &TypeChecker) known_sum_constructor_name(name string) ?string {
 // consumed as a borrow — the base of a field selector (`arr.last().field`) — rather than
 // escaping as an independent value. A borrowed field read keeps the element owned by the
 // array, so it needs no `clone()` even when the element type has no clone method; the
-// transformer lowers such a base to an in-place `arr[..]` access.
+// transformer lowers such a base to an in-place `arr[..]` access. A bound method value
+// (`arr.last().method`) is excluded: it is not a field read, and closure generation
+// shallow-copies the receiver, so it must keep the copying accessor semantics.
 fn (tc &TypeChecker) array_accessor_result_is_borrowed(id flat.NodeId) bool {
 	mut current := id
 	for {
@@ -6043,7 +6045,7 @@ fn (tc &TypeChecker) array_accessor_result_is_borrowed(id flat.NodeId) bool {
 			continue
 		}
 		return parent.kind == .selector && parent.children_count > 0
-			&& tc.a.child(parent, 0) == current
+			&& tc.a.child(parent, 0) == current && !tc.expr_is_method_value(parent_id)
 	}
 	return false
 }


### PR DESCRIPTION
## Problem

`v .` on a fresh `v new --web` project failed to compile in the V3 backend. The web template pulls in `veb` → `net.http` / `net.quic`, whose HPACK dynamic table reads a field of the last array element while evicting entries (`vlib/net/http/h2_hpack.v`):

```v
struct H2DynEntry {
	name  string
	value string
	size  int
}
...
for t.entries.len > 0 && t.cur_size + sz > t.max_size {
	t.cur_size -= t.entries.last().size
	t.entries.delete_last()
}
```

`t.entries.last().size` is a **borrow** of the stored element (it only reads the scalar `.size`), but V3 treated it as an escaping independent copy. Because `H2DynEntry` owns heap data and has no `clone()` method:

- In an **imported module**, the transformer lowered the accessor to an empty placeholder, so the field read reached the C compiler as `t->cur_size -= (0).size;` → *"member reference base type 'int' is not a structure or union"*, failing **both** tcc and cc.
- In a **directly compiled module**, the ownership checker rejected it outright: *"cannot return an independent array element: `Entry` requires ownership destruction but has no `clone()` method"*.

(The related `or { panic(...) }`-in-const codegen bug on the same files, which printed `gen_node: unsupported node kind: call`, was already fixed by #28235.)

## Fix

- **`transform/transform.v`** — new `borrow_first_last_accessor`, called from `transform_selector_base_expr`: a `first()`/`last()` accessor on an owned-element array used as a field-selector base is lowered in place to `arr[len - 1]` / `arr[0]` — the same borrow the lvalue path already uses — instead of the copying accessor path that has no valid lowering for a clone-less owned element.
- **`types/checker_tail.v`** — new `array_accessor_result_is_borrowed`: don't flag the accessor when its result is a field-selector base (a borrow), kept in lock-step with the transformer.

Escape cases (`x := arr.last()`, `return arr.last()`) and `pop`/`pop_left` are unchanged. Non-owned elements keep their existing accessor lowering, so generated C is byte-identical for programs that don't hit the broken pattern (verified across a range of examples and tools).

## Result

`v .` on a fresh `--web` project now compiles cleanly (no tcc→cc fallback, no `(0).` placeholders, no C errors) and the app serves `/health` → `ok` and `/` → the rendered template.

Adds `vlib/v3/tests/array_accessor_field_borrow_codegen_test.v` covering the borrow in both the main module and an imported module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)