### PR TITLE
v3: fix pointer return and alias typeof regressions

### DIFF
--- a/vlib/v3/tests/pointer_voidptr_compat_test.v
+++ b/vlib/v3/tests/pointer_voidptr_compat_test.v
@@ -232,3 +232,27 @@ fn main() {
 	assert run.exit_code == 0, run.output
 	assert run.output.trim_space() == '17'
 }
+
+fn test_pointer_to_voidptr_return_keeps_pointer_value() {
+	v3_bin := pointer_voidptr_build_v3()
+	source := 'fn make_values() voidptr {
+	unsafe {
+		values := &voidptr(malloc(64))
+		values[1] = voidptr(17)
+		return values
+	}
+}
+
+fn main() {
+	unsafe {
+		values := &voidptr(make_values())
+		println(usize(values[1]))
+		free(values)
+	}
+}
+'
+	out := pointer_voidptr_run_good(v3_bin, 'pointer_to_voidptr_return', source)
+	assert out == '17'
+	c_source := pointer_voidptr_gen_c(v3_bin, 'pointer_to_voidptr_return_c', source)
+	assert !c_source.contains('return *values;'), c_source
+}

--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -9683,11 +9683,6 @@ fn (mut t Transformer) generic_comptime_typeof_target(node flat.Node, args []str
 		}
 	}
 	target := t.generic_comptime_base_type(child_id, args) or { return none }
-	if child.kind == .ident && t.mut_param_values[child.value] && !target.starts_with('&') {
-		// A `mut value T` parameter is stored indirectly. `typeof(value)` observes
-		// that pointer shape even though ordinary value uses infer T itself.
-		return '&${target}'
-	}
 	return target
 }
 

--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -9097,7 +9097,7 @@ fn (mut t Transformer) clone_generic_node_from(node flat.Node, args []string, is
 		}
 		if node.value in ['idx', 'typ', 'key_type', 'value_type', 'element_type', 'payload_type', 'pointee_type', 'indirections']
 			&& t.selector_base_is_comptime_type_value(base_id) {
-			if concrete := t.generic_comptime_type_expr(base_id, args) {
+			if concrete := t.generic_comptime_type_expr_for_member(base_id, node.value, args) {
 				if node.value == 'indirections' {
 					return t.make_int_literal(generic_type_indirections(concrete))
 				}
@@ -9624,6 +9624,20 @@ fn (t &Transformer) generic_comptime_base_type(id flat.NodeId, args []string) ?s
 	return none
 }
 
+fn (mut t Transformer) generic_comptime_type_expr_for_member(id flat.NodeId, member string, args []string) ?string {
+	if member in ['idx', 'typ'] && int(id) >= 0 && int(id) < t.a.nodes.len {
+		node := t.a.nodes[int(id)]
+		if node.kind == .typeof_expr && node.children_count > 0 {
+			child_id := t.a.child(&node, 0)
+			child := t.a.nodes[int(child_id)]
+			if child.kind == .ident && t.mut_param_values[child.value] {
+				return t.generic_comptime_base_type(child_id, args)
+			}
+		}
+	}
+	return t.generic_comptime_type_expr(id, args)
+}
+
 fn (mut t Transformer) generic_comptime_type_expr(id flat.NodeId, args []string) ?string {
 	if int(id) < 0 || int(id) >= t.a.nodes.len {
 		return none
@@ -9683,6 +9697,11 @@ fn (mut t Transformer) generic_comptime_typeof_target(node flat.Node, args []str
 		}
 	}
 	target := t.generic_comptime_base_type(child_id, args) or { return none }
+	if child.kind == .ident && t.mut_param_values[child.value] && !target.starts_with('&') {
+		// A `mut value T` parameter is stored indirectly. `typeof(value)` observes
+		// that pointer shape even though ordinary value uses infer T itself.
+		return '&${target}'
+	}
 	return target
 }
 

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -13084,6 +13084,10 @@ fn (mut t Transformer) coerce_transformed_expr_to_type(expr flat.NodeId, source_
 		}
 		return expr
 	}
+	// `voidptr` receives the pointer value itself, even when its pointee is also `voidptr`.
+	if target == 'voidptr' && expr_type.starts_with('&') {
+		return t.make_cast(target, expr, target)
+	}
 	if expr_type.starts_with('&') {
 		expr_value_type := t.normalize_type_alias(expr_type[1..])
 		if expr_value_type == target || t.type_alias_targets_type(expr_type[1..], target) {


### PR DESCRIPTION
## Summary

- keep typed pointer values intact when coercing them to `voidptr`, instead of dereferencing pointers whose pointee is also `voidptr`
- keep `typeof(mut_generic_parameter)` based on the source-level generic type rather than its indirect runtime storage
- add focused V3 coverage for the pointer-to-`voidptr` return path

This fixes the master failures in `keep_args_alive_test.c.v` and the three generic alias/mutable-reference issue tests.

## Validation

- `V_MACOS_V3_NO_FALLBACK=1 ./vnew -silent test vlib/v3/tests/pointer_voidptr_compat_test.v`
- `V_MACOS_V3_NO_FALLBACK=1 ./vnew -silent test vlib/v/slow_tests/keep_args_alive_test.c.v`
- `V_MACOS_V3_NO_FALLBACK=1 ./vnew -silent test vlib/v/tests/aliases/alias_generic_mut_method_reference_issue_24012_test.v vlib/v/tests/aliases/alias_generic_mut_reference_issue_24010_test.v vlib/v/tests/aliases/alias_generic_mut_reference_issue_24011_test.v`
- `./vnew -silent vlib/v/compiler_errors_test.v`
- `./vnew -silent vlib/v/gen/c/coutput_test.v`
- bootstrap-built `vfmt -verify` on all touched V files
