### PR TITLE
vfmt: preserve mut guards and or-block comments

### DIFF
--- a/vlib/v3/gen/v/gen.v
+++ b/vlib/v3/gen/v/gen.v
@@ -2006,6 +2006,9 @@ fn (mut g Gen) assign_stmt(id flat.NodeId) {
 		g.write('mut ')
 	}
 	if count <= 1 {
+		if is_decl && !n.is_mut && g.a.node(children[0]).is_mut && !g.suppress_mut {
+			g.write('mut ')
+		}
 		g.expr(children[0])
 		g.write(' ${opstr} ')
 		g.expr_list(children[1..], ', ')
@@ -2025,7 +2028,15 @@ fn (mut g Gen) assign_stmt(id flat.NodeId) {
 				child_index++
 			}
 		}
-		g.expr_list(lhs, ', ')
+		for i, lhs_id in lhs {
+			if is_decl && !n.is_mut && g.a.node(lhs_id).is_mut && !g.suppress_mut {
+				g.write('mut ')
+			}
+			g.expr(lhs_id)
+			if i < lhs.len - 1 {
+				g.write(', ')
+			}
+		}
 		g.write(' ${opstr} ')
 		g.expr_list(rhs, ', ')
 	}

--- a/vlib/v3/gen/v/gen_test.v
+++ b/vlib/v3/gen/v/gen_test.v
@@ -633,7 +633,7 @@ fn test_formatter_preserves_three_value_if_guard_bindings() {
 }
 
 fn check() {
-	if r1, r2, r3 := create() {
+	if mut r1, mut r2, r3 := create() {
 		_ = r1
 		_ = r2
 		_ = r3
@@ -643,6 +643,46 @@ fn check() {
 	out := vfmt('three_value_if_guard', source)
 	assert out == source, out
 	assert vfmt('three_value_if_guard_twice', out) == out
+}
+
+fn test_formatter_preserves_mut_if_guard_binding() {
+	source := 'struct Item {
+mut:
+	value int
+}
+
+struct Holder {
+mut:
+	items map[u32]&Item
+}
+
+fn (mut holder Holder) update(id u32) {
+	if mut item := holder.items[id] {
+		item.value++
+	}
+}
+'
+	out := vfmt('mut_if_guard_binding', source)
+	assert out == source, out
+	assert vfmt('mut_if_guard_binding_twice', out) == out
+}
+
+fn test_formatter_keeps_or_block_leading_comment_inside_block() {
+	source := 'fn read_frame() ?int {
+	return 1
+}
+
+fn process() {
+	frame := read_frame() or {
+		// Treat a clean transport close as end of session.
+		return
+	}
+	println(frame)
+}
+'
+	out := vfmt('or_block_leading_comment', source)
+	assert out == source, out
+	assert vfmt('or_block_leading_comment_twice', out) == out
 }
 
 fn test_formatter_retains_expanded_call_argument_layout() {

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -8323,11 +8323,11 @@ fn (mut p Parser) expr_with_lhs_context(first flat.NodeId, min_bp token.BindingP
 			p.next()
 			or_body := p.block_stmt()
 			ostart := p.add_children2(lhs, or_body)
-			lhs = p.add_node(flat.Node{
+			lhs = p.add_node_from(flat.Node{
 				kind:           .or_expr
 				children_start: ostart
 				children_count: 2
-			})
+			}, lhs)
 			continue
 		}
 		// selector / method call


### PR DESCRIPTION
## Summary

- preserve per-binding `mut` qualifiers when formatting if guards
- keep comments at the start of `or {}` handlers inside the handler block
- add idempotence regressions for single- and multi-value mutable guards

Fixes #28226

## Testing

- `./vnew -old-compiler -silent vlib/v3/gen/v/gen_test.v`
- `./vnew -silent vlib/v3/gen/v/gen_test.v`
- `./vnew -old-compiler -silent test vlib/v3/parser/`
- `./vnew -old-compiler -silent cmd/tools/vfmt_test.v`
- `./vnew -silent vlib/v/compiler_errors_test.v` (1619 passed, 1 skipped)
- exact `v fmt` CLI reproduction for the reported guard and comment cases

The broad default-V3 `./vnew -silent test vlib/v/` run was stopped at 736/2370 after accumulating unrelated existing runtime/codegen failures; all issue-specific and stable-compiler checks above pass.