### PR TITLE
tools: cap automatic v test parallelism

### DIFF
--- a/TESTS.md
+++ b/TESTS.md
@@ -47,6 +47,10 @@ recursively.
 `v -stats test folder` - same, but will also produce timing reports
 about how fast each test_ function in each _test.v file ran.
 
+By default, `v test` uses at most four parallel workers and budgets one worker per 8 GiB
+of physical memory. Set `VJOBS` to a positive value to explicitly choose a different worker
+count when your test workload and machine capacity are known.
+
 ## `v test vlib/v/tests`:
 
 This folder contains _test.v files, testing the different features of the V

--- a/TESTS.md
+++ b/TESTS.md
@@ -48,8 +48,9 @@ recursively.
 about how fast each test_ function in each _test.v file ran.
 
 By default, `v test` uses at most four parallel workers and budgets one worker per 8 GiB
-of physical memory. Set `VJOBS` to a positive value to explicitly choose a different worker
-count when your test workload and machine capacity are known.
+of memory. On Linux it uses the lower of physical memory and the active cgroup memory limit.
+Set `VJOBS` to a positive value to explicitly choose a different worker count when your test
+workload and machine capacity are known.
 
 ## `v test vlib/v/tests`:
 

--- a/cmd/tools/modules/testing/common.v
+++ b/cmd/tools/modules/testing/common.v
@@ -119,6 +119,19 @@ fn cgroup_memory_limit_from_contents(cgroups string, mountinfo string) !u64 {
 			v1_memory_path = parts[2]
 		}
 	}
+	if v1_memory_path != '' {
+		if limit := cgroup_memory_limit_for_hierarchy(mountinfo, v1_memory_path, 'cgroup',
+			'memory.limit_in_bytes') {
+			return limit
+		}
+	}
+	if v2_path != '' {
+		return cgroup_memory_limit_for_hierarchy(mountinfo, v2_path, 'cgroup2', 'memory.max')
+	}
+	return error('no cgroup memory limit found')
+}
+
+fn cgroup_memory_limit_for_hierarchy(mountinfo string, cgroup_path string, fs_type string, limit_file string) !u64 {
 	for line in mountinfo.split_into_lines() {
 		parts := line.split(' - ')
 		if parts.len != 2 {
@@ -131,13 +144,11 @@ fn cgroup_memory_limit_from_contents(cgroups string, mountinfo string) !u64 {
 		}
 		mount_root := mount_parts[3]
 		mount_point := mount_parts[4]
-		if fs_parts[0] == 'cgroup2' && v2_path != '' {
-			return cgroup_memory_limit_in_hierarchy(mount_root, mount_point, v2_path,
-				'memory.max')
+		if fs_parts[0] != fs_type || (fs_type == 'cgroup' && 'memory' !in fs_parts[2].split(',')) {
+			continue
 		}
-		if fs_parts[0] == 'cgroup' && 'memory' in fs_parts[2].split(',') && v1_memory_path != '' {
-			return cgroup_memory_limit_in_hierarchy(mount_root, mount_point, v1_memory_path,
-				'memory.limit_in_bytes')
+		if limit := cgroup_memory_limit_in_hierarchy(mount_root, mount_point, cgroup_path, limit_file) {
+			return limit
 		}
 	}
 	return error('no cgroup memory limit found')

--- a/cmd/tools/modules/testing/common.v
+++ b/cmd/tools/modules/testing/common.v
@@ -78,9 +78,39 @@ pub const separator = '-'.repeat(max_header_len) + '\n'
 pub const max_compilation_retries = get_max_compilation_retries()
 
 const c_error_bug_report_disabled_env = 'V_C_ERROR_BUG_REPORT_DISABLED'
+// Each worker compiles a separate test program, so bound automatic parallelism
+// by a conservative memory budget. VJOBS remains an explicit override.
+const test_job_memory_budget = u64(8) * 1024 * 1024 * 1024
+const max_automatic_test_jobs = 4
 
 fn get_max_compilation_retries() int {
 	return os.getenv_opt('VTEST_MAX_COMPILATION_RETRIES') or { '3' }.int()
+}
+
+fn automatic_test_jobs(cpu_jobs int, total_memory u64, configured_jobs int) int {
+	if configured_jobs > 0 {
+		return configured_jobs
+	}
+	mut jobs := if cpu_jobs > 0 { cpu_jobs } else { 1 }
+	mut memory_jobs := int(total_memory / test_job_memory_budget)
+	if memory_jobs < 1 {
+		memory_jobs = 1
+	}
+	if jobs > memory_jobs {
+		jobs = memory_jobs
+	}
+	if jobs > max_automatic_test_jobs {
+		jobs = max_automatic_test_jobs
+	}
+	return jobs
+}
+
+fn test_runner_jobs() int {
+	configured_jobs := os.getenv('VJOBS').int()
+	total_memory := runtime.total_memory() or {
+		return automatic_test_jobs(runtime.nr_jobs(), 0, configured_jobs)
+	}
+	return automatic_test_jobs(runtime.nr_jobs(), u64(total_memory), configured_jobs)
 }
 
 fn get_fail_retry_delay_ms() time.Duration {
@@ -505,7 +535,7 @@ pub fn (mut ts TestSession) test() {
 	remaining_files = vtest.filter_vtest_only(remaining_files, fix_slashes: false)
 	ts.files = remaining_files
 	ts.benchmark.set_total_expected_steps(remaining_files.len)
-	mut njobs := runtime.nr_jobs()
+	mut njobs := test_runner_jobs()
 	if remaining_files.len < njobs {
 		njobs = remaining_files.len
 	}

--- a/cmd/tools/modules/testing/common.v
+++ b/cmd/tools/modules/testing/common.v
@@ -540,7 +540,10 @@ pub fn (mut ts TestSession) test() {
 		njobs = remaining_files.len
 	}
 	ts.benchmark.njobs = njobs
-	mut pool_of_test_runners := pool.new_pool_processor(callback: worker_trunner)
+	mut pool_of_test_runners := pool.new_pool_processor(
+		callback: worker_trunner
+		maxjobs:  njobs
+	)
 	// ensure that the nmessages queue/channel, has enough capacity for handling many messages across threads, without blocking
 	ts.nmessages = chan LogMessage{cap: 10000}
 	ts.nmessage_idx = 0

--- a/cmd/tools/modules/testing/common.v
+++ b/cmd/tools/modules/testing/common.v
@@ -109,14 +109,14 @@ fn cgroup_memory_limit_from_contents(cgroups string, mountinfo string) !u64 {
 	mut v2_path := ''
 	mut v1_memory_path := ''
 	for line in cgroups.split_into_lines() {
-		parts := line.split(':')
-		if parts.len != 3 {
-			continue
-		}
-		if parts[1] == '' {
-			v2_path = parts[2]
-		} else if 'memory' in parts[1].split(',') {
-			v1_memory_path = parts[2]
+		first_separator := line.index(':') or { continue }
+		second_separator := line.index_after(':', first_separator + 1) or { continue }
+		controllers := line[first_separator + 1..second_separator]
+		cgroup_path := line[second_separator + 1..]
+		if controllers == '' {
+			v2_path = cgroup_path
+		} else if 'memory' in controllers.split(',') {
+			v1_memory_path = cgroup_path
 		}
 	}
 	if v1_memory_path != '' {

--- a/cmd/tools/modules/testing/common.v
+++ b/cmd/tools/modules/testing/common.v
@@ -162,9 +162,9 @@ fn cgroup_memory_limit_in_hierarchy(mount_root string, mount_point string, cgrou
 			relative_path = ''
 		} else if cgroup_path.starts_with(trimmed_root + '/') {
 			relative_path = cgroup_path[trimmed_root.len..].trim_left('/')
-		} else {
-			return error('cgroup path is outside its mount')
 		}
+		// Otherwise cgroup_path is relative to a cgroup namespace rooted at
+		// mount_root, so relative_path already maps from the visible mount point.
 	}
 	mut current_path := os.join_path(mount_point, relative_path)
 	mut memory_limit := u64(0)

--- a/cmd/tools/modules/testing/common.v
+++ b/cmd/tools/modules/testing/common.v
@@ -142,8 +142,8 @@ fn cgroup_memory_limit_for_hierarchy(mountinfo string, cgroup_path string, fs_ty
 		if mount_parts.len < 5 || fs_parts.len < 3 {
 			continue
 		}
-		mount_root := mount_parts[3]
-		mount_point := mount_parts[4]
+		mount_root := decode_mountinfo_path(mount_parts[3])
+		mount_point := decode_mountinfo_path(mount_parts[4])
 		if fs_parts[0] != fs_type || (fs_type == 'cgroup' && 'memory' !in fs_parts[2].split(',')) {
 			continue
 		}
@@ -152,6 +152,23 @@ fn cgroup_memory_limit_for_hierarchy(mountinfo string, cgroup_path string, fs_ty
 		}
 	}
 	return error('no cgroup memory limit found')
+}
+
+fn decode_mountinfo_path(path string) string {
+	mut result := strings.new_builder(path.len)
+	mut i := 0
+	for i < path.len {
+		if path[i] == `\\` && i + 3 < path.len && path[i + 1] >= `0` && path[i + 1] <= `7`
+			&& path[i + 2] >= `0` && path[i + 2] <= `7` && path[i + 3] >= `0` && path[i + 3] <= `7` {
+			value := (path[i + 1] - `0`) * 64 + (path[i + 2] - `0`) * 8 + path[i + 3] - `0`
+			result.write_u8(value)
+			i += 4
+			continue
+		}
+		result.write_u8(path[i])
+		i++
+	}
+	return result.str()
 }
 
 fn cgroup_memory_limit_in_hierarchy(mount_root string, mount_point string, cgroup_path string, limit_file string) !u64 {
@@ -221,12 +238,23 @@ fn test_runner_memory() !u64 {
 	return physical_memory
 }
 
-fn test_runner_jobs() int {
+fn test_session_jobs(will_compile bool, cpu_jobs int, total_memory u64, configured_jobs int) int {
+	if !will_compile {
+		return cpu_jobs
+	}
+	return automatic_test_jobs(cpu_jobs, total_memory, configured_jobs)
+}
+
+fn test_runner_jobs(will_compile bool) int {
+	cpu_jobs := runtime.nr_jobs()
+	if !will_compile {
+		return test_session_jobs(false, cpu_jobs, 0, 0)
+	}
 	configured_jobs := os.getenv('VJOBS').int()
 	total_memory := test_runner_memory() or {
-		return automatic_test_jobs(runtime.nr_jobs(), 0, configured_jobs)
+		return test_session_jobs(true, cpu_jobs, 0, configured_jobs)
 	}
-	return automatic_test_jobs(runtime.nr_jobs(), total_memory, configured_jobs)
+	return test_session_jobs(true, cpu_jobs, total_memory, configured_jobs)
 }
 
 fn get_fail_retry_delay_ms() time.Duration {
@@ -268,6 +296,7 @@ pub struct TestSession {
 pub mut:
 	files         []string
 	skip_files    []string
+	will_compile  bool
 	vexe          string
 	vroot         string
 	vtmp_dir      string
@@ -534,6 +563,7 @@ pub fn new_test_session(_vargs string, will_compile bool) TestSession {
 		os.setenv('VCOLORS', 'always', true)
 	}
 	mut ts := TestSession{
+		will_compile:  will_compile
 		vexe:          vexe
 		vroot:         vroot
 		skip_files:    skip_files
@@ -651,7 +681,7 @@ pub fn (mut ts TestSession) test() {
 	remaining_files = vtest.filter_vtest_only(remaining_files, fix_slashes: false)
 	ts.files = remaining_files
 	ts.benchmark.set_total_expected_steps(remaining_files.len)
-	mut njobs := test_runner_jobs()
+	mut njobs := test_runner_jobs(ts.will_compile)
 	if remaining_files.len < njobs {
 		njobs = remaining_files.len
 	}

--- a/cmd/tools/modules/testing/common.v
+++ b/cmd/tools/modules/testing/common.v
@@ -105,12 +105,117 @@ fn automatic_test_jobs(cpu_jobs int, total_memory u64, configured_jobs int) int 
 	return jobs
 }
 
+fn cgroup_memory_limit_from_contents(cgroups string, mountinfo string) !u64 {
+	mut v2_path := ''
+	mut v1_memory_path := ''
+	for line in cgroups.split_into_lines() {
+		parts := line.split(':')
+		if parts.len != 3 {
+			continue
+		}
+		if parts[1] == '' {
+			v2_path = parts[2]
+		} else if 'memory' in parts[1].split(',') {
+			v1_memory_path = parts[2]
+		}
+	}
+	for line in mountinfo.split_into_lines() {
+		parts := line.split(' - ')
+		if parts.len != 2 {
+			continue
+		}
+		mount_parts := parts[0].fields()
+		fs_parts := parts[1].fields()
+		if mount_parts.len < 5 || fs_parts.len < 3 {
+			continue
+		}
+		mount_root := mount_parts[3]
+		mount_point := mount_parts[4]
+		if fs_parts[0] == 'cgroup2' && v2_path != '' {
+			return cgroup_memory_limit_in_hierarchy(mount_root, mount_point, v2_path,
+				'memory.max')
+		}
+		if fs_parts[0] == 'cgroup' && 'memory' in fs_parts[2].split(',') && v1_memory_path != '' {
+			return cgroup_memory_limit_in_hierarchy(mount_root, mount_point, v1_memory_path,
+				'memory.limit_in_bytes')
+		}
+	}
+	return error('no cgroup memory limit found')
+}
+
+fn cgroup_memory_limit_in_hierarchy(mount_root string, mount_point string, cgroup_path string, limit_file string) !u64 {
+	mut relative_path := cgroup_path.trim_left('/')
+	trimmed_root := mount_root.trim_right('/')
+	if trimmed_root != '' {
+		if cgroup_path == trimmed_root {
+			relative_path = ''
+		} else if cgroup_path.starts_with(trimmed_root + '/') {
+			relative_path = cgroup_path[trimmed_root.len..].trim_left('/')
+		} else {
+			return error('cgroup path is outside its mount')
+		}
+	}
+	mut current_path := os.join_path(mount_point, relative_path)
+	mut memory_limit := u64(0)
+	for {
+		if content := os.read_file(os.join_path(current_path, limit_file)) {
+			if limit := cgroup_memory_limit_value(content) {
+				if memory_limit == 0 || limit < memory_limit {
+					memory_limit = limit
+				}
+			}
+		}
+		if current_path == mount_point {
+			break
+		}
+		parent_path := os.dir(current_path)
+		if parent_path == current_path || !parent_path.starts_with(mount_point) {
+			break
+		}
+		current_path = parent_path
+	}
+	if memory_limit == 0 {
+		return error('cgroup memory limit is unlimited')
+	}
+	return memory_limit
+}
+
+fn cgroup_memory_limit_value(content string) !u64 {
+	value := content.trim_space()
+	if value == '' || value == 'max' {
+		return error('cgroup memory limit is unlimited')
+	}
+	limit := value.u64()
+	if limit == 0 {
+		return error('invalid cgroup memory limit')
+	}
+	return limit
+}
+
+fn effective_test_memory(physical_memory u64, cgroup_memory_limit u64) u64 {
+	if cgroup_memory_limit > 0 && cgroup_memory_limit < physical_memory {
+		return cgroup_memory_limit
+	}
+	return physical_memory
+}
+
+fn test_runner_memory() !u64 {
+	physical_memory := u64(runtime.total_memory()!)
+	$if linux {
+		cgroup_memory_limit := cgroup_memory_limit_from_contents(os.read_file('/proc/self/cgroup')!, os.read_file('/proc/self/mountinfo')!) or {
+			return physical_memory
+		}
+		return effective_test_memory(physical_memory, cgroup_memory_limit)
+	}
+	return physical_memory
+}
+
 fn test_runner_jobs() int {
 	configured_jobs := os.getenv('VJOBS').int()
-	total_memory := runtime.total_memory() or {
+	total_memory := test_runner_memory() or {
 		return automatic_test_jobs(runtime.nr_jobs(), 0, configured_jobs)
 	}
-	return automatic_test_jobs(runtime.nr_jobs(), u64(total_memory), configured_jobs)
+	return automatic_test_jobs(runtime.nr_jobs(), total_memory, configured_jobs)
 }
 
 fn get_fail_retry_delay_ms() time.Duration {

--- a/cmd/tools/modules/testing/common_test.v
+++ b/cmd/tools/modules/testing/common_test.v
@@ -53,6 +53,17 @@ fn test_automatic_test_jobs_preserves_vjobs_override() {
 	assert automatic_test_jobs(18, u64(16) * 1024 * 1024 * 1024, 7) == 7
 }
 
+fn test_noncompiling_test_sessions_use_cpu_jobs() {
+	assert test_session_jobs(false, 18, u64(8) * 1024 * 1024 * 1024, 0) == 18
+	assert test_session_jobs(false, 7, u64(8) * 1024 * 1024 * 1024, 7) == 7
+	assert test_session_jobs(true, 18, u64(8) * 1024 * 1024 * 1024, 0) == 1
+}
+
+fn test_decode_mountinfo_path() {
+	assert decode_mountinfo_path(r'/docker/my\040container') == '/docker/my container'
+	assert decode_mountinfo_path(r'/docker/my\134container') == r'/docker/my\container'
+}
+
 fn test_cgroup_v2_memory_limit_uses_parent_limit() {
 	mount_point := os.join_path(os.vtmp_dir(), 'testing_cgroup_memory_limit_${os.getpid()}')
 	defer {
@@ -102,6 +113,20 @@ fn test_cgroup_namespace_relative_path_uses_non_root_mount() {
 	os.write_file(os.join_path(mount_point, 'memory.max'), '8589934592')!
 	cgroups := '0::/'
 	mountinfo := '36 25 0:32 /docker/container ${mount_point} rw,nosuid,nodev,noexec,relatime - cgroup2 cgroup rw'
+	assert cgroup_memory_limit_from_contents(cgroups, mountinfo)! == u64(8) * 1024 * 1024 * 1024
+}
+
+fn test_cgroup_memory_limit_decodes_mountinfo_paths() {
+	mount_point := os.join_path(os.vtmp_dir(), 'testing cgroup memory limit ${os.getpid()}')
+	defer {
+		os.rmdir_all(mount_point) or {}
+	}
+	os.mkdir_all(os.join_path(mount_point, 'work'))!
+	os.write_file(os.join_path(mount_point, 'work', 'memory.max'), '8589934592')!
+	cgroups := '0::/docker container/work'
+	escaped_mount_root := r'/docker\040container'
+	escaped_mount_point := mount_point.replace(' ', r'\040')
+	mountinfo := '36 25 0:32 ${escaped_mount_root} ${escaped_mount_point} rw,nosuid,nodev,noexec,relatime - cgroup2 cgroup rw'
 	assert cgroup_memory_limit_from_contents(cgroups, mountinfo)! == u64(8) * 1024 * 1024 * 1024
 }
 

--- a/cmd/tools/modules/testing/common_test.v
+++ b/cmd/tools/modules/testing/common_test.v
@@ -93,6 +93,18 @@ fn test_cgroup_v1_memory_limit_is_preferred_on_hybrid_hosts() {
 	assert cgroup_memory_limit_from_contents(cgroups, mountinfo)! == u64(8) * 1024 * 1024 * 1024
 }
 
+fn test_cgroup_namespace_relative_path_uses_non_root_mount() {
+	mount_point := os.join_path(os.vtmp_dir(), 'testing_cgroup_memory_limit_${os.getpid()}')
+	defer {
+		os.rmdir_all(mount_point) or {}
+	}
+	os.mkdir_all(mount_point)!
+	os.write_file(os.join_path(mount_point, 'memory.max'), '8589934592')!
+	cgroups := '0::/'
+	mountinfo := '36 25 0:32 /docker/container ${mount_point} rw,nosuid,nodev,noexec,relatime - cgroup2 cgroup rw'
+	assert cgroup_memory_limit_from_contents(cgroups, mountinfo)! == u64(8) * 1024 * 1024 * 1024
+}
+
 fn test_effective_test_memory_uses_lower_cgroup_limit() {
 	physical_memory := u64(32) * 1024 * 1024 * 1024
 	cgroup_memory_limit := u64(8) * 1024 * 1024 * 1024

--- a/cmd/tools/modules/testing/common_test.v
+++ b/cmd/tools/modules/testing/common_test.v
@@ -39,3 +39,16 @@ fn test_add_automatic_execution_retry() {
 	})
 	assert details.retry == 3
 }
+
+fn test_automatic_test_jobs_respects_memory_and_cpu_limits() {
+	assert automatic_test_jobs(18, u64(128) * 1024 * 1024 * 1024, 0) == 4
+	assert automatic_test_jobs(18, u64(32) * 1024 * 1024 * 1024, 0) == 4
+	assert automatic_test_jobs(18, u64(16) * 1024 * 1024 * 1024, 0) == 2
+	assert automatic_test_jobs(18, u64(8) * 1024 * 1024 * 1024, 0) == 1
+	assert automatic_test_jobs(2, u64(128) * 1024 * 1024 * 1024, 0) == 2
+	assert automatic_test_jobs(0, 0, 0) == 1
+}
+
+fn test_automatic_test_jobs_preserves_vjobs_override() {
+	assert automatic_test_jobs(18, u64(16) * 1024 * 1024 * 1024, 7) == 7
+}

--- a/cmd/tools/modules/testing/common_test.v
+++ b/cmd/tools/modules/testing/common_test.v
@@ -52,3 +52,35 @@ fn test_automatic_test_jobs_respects_memory_and_cpu_limits() {
 fn test_automatic_test_jobs_preserves_vjobs_override() {
 	assert automatic_test_jobs(18, u64(16) * 1024 * 1024 * 1024, 7) == 7
 }
+
+fn test_cgroup_v2_memory_limit_uses_parent_limit() {
+	mount_point := os.join_path(os.vtmp_dir(), 'testing_cgroup_memory_limit_${os.getpid()}')
+	defer {
+		os.rmdir_all(mount_point) or {}
+	}
+	os.mkdir_all(os.join_path(mount_point, 'container', 'work'))!
+	os.write_file(os.join_path(mount_point, 'container', 'memory.max'), '8589934592')!
+	os.write_file(os.join_path(mount_point, 'container', 'work', 'memory.max'), 'max')!
+	cgroups := '0::/container/work'
+	mountinfo := '36 25 0:32 / ${mount_point} rw,nosuid,nodev,noexec,relatime - cgroup2 cgroup rw'
+	assert cgroup_memory_limit_from_contents(cgroups, mountinfo)! == u64(8) * 1024 * 1024 * 1024
+}
+
+fn test_cgroup_v1_memory_limit_is_used() {
+	mount_point := os.join_path(os.vtmp_dir(), 'testing_cgroup_memory_limit_${os.getpid()}')
+	defer {
+		os.rmdir_all(mount_point) or {}
+	}
+	os.mkdir_all(os.join_path(mount_point, 'docker', 'container'))!
+	os.write_file(os.join_path(mount_point, 'docker', 'container', 'memory.limit_in_bytes'), '8589934592')!
+	cgroups := '5:memory:/docker/container'
+	mountinfo := '29 23 0:26 / ${mount_point} rw,relatime - cgroup cgroup rw,memory'
+	assert cgroup_memory_limit_from_contents(cgroups, mountinfo)! == u64(8) * 1024 * 1024 * 1024
+}
+
+fn test_effective_test_memory_uses_lower_cgroup_limit() {
+	physical_memory := u64(32) * 1024 * 1024 * 1024
+	cgroup_memory_limit := u64(8) * 1024 * 1024 * 1024
+	assert effective_test_memory(physical_memory, cgroup_memory_limit) == cgroup_memory_limit
+	assert effective_test_memory(cgroup_memory_limit, physical_memory) == cgroup_memory_limit
+}

--- a/cmd/tools/modules/testing/common_test.v
+++ b/cmd/tools/modules/testing/common_test.v
@@ -78,6 +78,21 @@ fn test_cgroup_v1_memory_limit_is_used() {
 	assert cgroup_memory_limit_from_contents(cgroups, mountinfo)! == u64(8) * 1024 * 1024 * 1024
 }
 
+fn test_cgroup_v1_memory_limit_is_preferred_on_hybrid_hosts() {
+	test_root := os.join_path(os.vtmp_dir(), 'testing_cgroup_memory_limit_${os.getpid()}')
+	v1_mount_point := os.join_path(test_root, 'v1')
+	v2_mount_point := os.join_path(test_root, 'v2')
+	defer {
+		os.rmdir_all(test_root) or {}
+	}
+	os.mkdir_all(os.join_path(v1_mount_point, 'container'))!
+	os.mkdir_all(os.join_path(v2_mount_point, 'container'))!
+	os.write_file(os.join_path(v1_mount_point, 'container', 'memory.limit_in_bytes'), '8589934592')!
+	cgroups := '0::/container\n5:memory:/container'
+	mountinfo := '36 25 0:32 / ${v2_mount_point} rw,nosuid,nodev,noexec,relatime - cgroup2 cgroup rw\n' + '29 23 0:26 / ${v1_mount_point} rw,relatime - cgroup cgroup rw,memory'
+	assert cgroup_memory_limit_from_contents(cgroups, mountinfo)! == u64(8) * 1024 * 1024 * 1024
+}
+
 fn test_effective_test_memory_uses_lower_cgroup_limit() {
 	physical_memory := u64(32) * 1024 * 1024 * 1024
 	cgroup_memory_limit := u64(8) * 1024 * 1024 * 1024

--- a/cmd/tools/modules/testing/common_test.v
+++ b/cmd/tools/modules/testing/common_test.v
@@ -77,6 +77,18 @@ fn test_cgroup_v2_memory_limit_uses_parent_limit() {
 	assert cgroup_memory_limit_from_contents(cgroups, mountinfo)! == u64(8) * 1024 * 1024 * 1024
 }
 
+fn test_cgroup_memory_limit_preserves_colons_in_paths() {
+	mount_point := os.join_path(os.vtmp_dir(), 'testing_cgroup_memory_limit_${os.getpid()}')
+	defer {
+		os.rmdir_all(mount_point) or {}
+	}
+	os.mkdir_all(os.join_path(mount_point, 'container:team'))!
+	os.write_file(os.join_path(mount_point, 'container:team', 'memory.max'), '8589934592')!
+	cgroups := '0::/container:team'
+	mountinfo := '36 25 0:32 / ${mount_point} rw,nosuid,nodev,noexec,relatime - cgroup2 cgroup rw'
+	assert cgroup_memory_limit_from_contents(cgroups, mountinfo)! == u64(8) * 1024 * 1024 * 1024
+}
+
 fn test_cgroup_v1_memory_limit_is_used() {
 	mount_point := os.join_path(os.vtmp_dir(), 'testing_cgroup_memory_limit_${os.getpid()}')
 	defer {


### PR DESCRIPTION
## What

- Cap automatic `v test` worker count by physical memory (one worker per 16 GiB) and at four workers.
- Preserve `VJOBS` as an explicit override.
- Document the default and cover the job-selection policy.

## Why

`v test .` previously used the CPU count directly. On high-core machines, that launches many whole compiler builds at once and can exhaust memory.

## Tests

- `./vnew -silent cmd/tools/modules/testing/common_test.v`
- `./vnew -silent cmd/tools/vtest_test.v`
- `VJOBS=1 ./vnew -silent test cmd/tools/modules/testing`
- `./vnew check-md TESTS.md`