### PR TITLE
json2: reduce generated struct field code

### DIFF
--- a/vlib/json2/decode.v
+++ b/vlib/json2/decode.v
@@ -417,6 +417,25 @@ fn mark_struct_field_decoded(decoded_mask u64, mut decoded_fields []bool, field_
 	return decoded_mask
 }
 
+// find_struct_field centralizes the runtime part of struct key matching. Keeping
+// this loop outside the comptime field loop avoids emitting the same skip,
+// omitempty, length, and memory-comparison checks once for every struct field.
+@[noinline]
+fn (decoder &Decoder) find_struct_field(field_infos []StructFieldInfo, key_ptr voidptr, key_len int) int {
+	for field_idx, field_info in field_infos {
+		field_can_match := (!field_info.is_skip || field_info.is_required)
+			&& !(field_info.is_omitempty
+			&& decoder.is_empty_value(decoder.current_node.next.value))
+		field_name_matches := key_len == field_info.json_name_len && unsafe {
+			vmemcmp(key_ptr, field_info.json_name_ptr, field_info.json_name_len) == 0
+		}
+		if field_can_match && field_name_matches {
+			return field_idx
+		}
+	}
+	return -1
+}
+
 // key_has_escape reports whether the JSON string key described by `key_info`
 // contains a `\` escape sequence.
 @[direct_array_access; inline]
@@ -880,19 +899,12 @@ fn (mut decoder Decoder) decode_value[T](mut val T) ! {
 							key_len = unescaped_key.len
 						}
 
+						matched_field_idx := decoder.find_struct_field(field_infos, key_ptr, key_len)
 						mut matched := false
 						field_idx = 0
 						$for field in T.fields {
 							if field.attrs.contains('skip') {
-								if !matched {
-									field_info := field_infos[field_idx]
-									field_can_match := field_info.is_required
-										&& !(field_info.is_omitempty
-										&& decoder.is_empty_value(decoder.current_node.next.value))
-									field_name_matches := key_len == field_info.json_name_len && unsafe {
-										vmemcmp(key_ptr, field_info.json_name_ptr, field_info.json_name_len) == 0
-									}
-									if field_can_match && field_name_matches {
+								if !matched && field_idx == matched_field_idx {
 										decoder.current_node = decoder.current_node.next
 										decoded_mask = mark_struct_field_decoded(decoded_mask, mut
 											decoded_fields, field_idx)
@@ -900,17 +912,9 @@ fn (mut decoder Decoder) decode_value[T](mut val T) ! {
 											decoder.current_node = decoder.current_node.next
 										}
 										matched = true
-									}
 								}
-							} else if !matched {
+							} else if !matched && field_idx == matched_field_idx {
 								field_info := field_infos[field_idx]
-								field_can_match := (!field_info.is_skip || field_info.is_required)
-									&& !(field_info.is_omitempty
-									&& decoder.is_empty_value(decoder.current_node.next.value))
-								field_name_matches := key_len == field_info.json_name_len && unsafe {
-									vmemcmp(key_ptr, field_info.json_name_ptr, field_info.json_name_len) == 0
-								}
-								if field_can_match && field_name_matches {
 									// value node
 									decoder.current_node = decoder.current_node.next
 
@@ -1039,7 +1043,6 @@ fn (mut decoder Decoder) decode_value[T](mut val T) ! {
 									decoded_mask = mark_struct_field_decoded(decoded_mask, mut
 										decoded_fields, field_idx)
 									matched = true
-								}
 							}
 							field_idx++
 						}

--- a/vlib/json2/encode.v
+++ b/vlib/json2/encode.v
@@ -729,6 +729,28 @@ fn struct_field_should_encode[T](field_info EncoderFieldInfo, val T) bool {
 	return true
 }
 
+// encode_struct_field_key keeps the non-type-specific part of struct field
+// encoding out of the comptime field loop. Otherwise every field gets its own
+// copy of the key-collision scan and key selection code.
+@[noinline]
+fn (mut encoder Encoder) encode_struct_field_key(mut used_keys []string, old_used_keys []string, prefix string, field_info EncoderFieldInfo, is_first bool) bool {
+	if field_info.key_name in old_used_keys {
+		return encoder.encode_object_key(is_first, prefix + field_info.key_name)
+	}
+	used_keys << field_info.key_name
+	return encoder.encode_object_key(is_first, field_info.key_name)
+}
+
+@[noinline]
+fn (mut encoder Encoder) encode_embedded_struct_field_key(mut used_keys []string, reserved_keys []string, prefix string, field_info EncoderFieldInfo, is_first bool) bool {
+	should_prefix := field_info.key_name in used_keys || field_info.key_name in reserved_keys
+	json_key := if should_prefix { prefix + field_info.key_name } else { field_info.key_name }
+	if !should_prefix {
+		used_keys << field_info.key_name
+	}
+	return encoder.encode_object_key(is_first, json_key)
+}
+
 @[unsafe]
 fn (mut encoder Encoder) encode_struct_with_embeds[T](val T) {
 	encoder.output << `{`
@@ -772,13 +794,8 @@ fn (mut encoder Encoder) encode_struct_fields[T](val T, was_first bool, old_used
 						write_field = struct_field_should_encode(field_info, field_value)
 
 						if write_field {
-							if field_info.key_name in old_used_keys {
-								is_first = encoder.encode_object_key(is_first, prefix +
-									field_info.key_name)
-							} else {
-								is_first = encoder.encode_object_key(is_first, field_info.key_name)
-								used_keys << field_info.key_name
-							}
+							is_first = encoder.encode_struct_field_key(mut used_keys, old_used_keys,
+								prefix, field_info, is_first)
 							encoder.encode_struct_field_value(field_value)
 						}
 					}
@@ -786,13 +803,8 @@ fn (mut encoder Encoder) encode_struct_fields[T](val T, was_first bool, old_used
 					write_field = struct_field_should_encode(field_info, val.$(field.name))
 
 					if write_field {
-						if field_info.key_name in old_used_keys {
-							is_first = encoder.encode_object_key(is_first, prefix +
-								field_info.key_name)
-						} else {
-							is_first = encoder.encode_object_key(is_first, field_info.key_name)
-							used_keys << field_info.key_name
-						}
+						is_first = encoder.encode_struct_field_key(mut used_keys, old_used_keys,
+							prefix, field_info, is_first)
 						encoder.encode_struct_field_value(val.$(field.name))
 					}
 				}
@@ -858,34 +870,16 @@ fn (mut encoder Encoder) encode_embedded_struct_fields[T](val T, was_first bool,
 					rlock field_value {
 						write_field = struct_field_should_encode(field_info, field_value)
 						if write_field {
-							should_prefix := field_info.key_name in used_keys
-								|| field_info.key_name in reserved_keys
-							json_key := if should_prefix {
-								prefix + field_info.key_name
-							} else {
-								field_info.key_name
-							}
-							is_first = encoder.encode_object_key(is_first, json_key)
-							if !should_prefix {
-								used_keys << field_info.key_name
-							}
+							is_first = encoder.encode_embedded_struct_field_key(mut used_keys,
+								reserved_keys, prefix, field_info, is_first)
 							encoder.encode_struct_field_value(field_value)
 						}
 					}
 				} $else {
 					write_field = struct_field_should_encode(field_info, val.$(field.name))
 					if write_field {
-						should_prefix := field_info.key_name in used_keys
-							|| field_info.key_name in reserved_keys
-						json_key := if should_prefix {
-							prefix + field_info.key_name
-						} else {
-							field_info.key_name
-						}
-						is_first = encoder.encode_object_key(is_first, json_key)
-						if !should_prefix {
-							used_keys << field_info.key_name
-						}
+						is_first = encoder.encode_embedded_struct_field_key(mut used_keys,
+							reserved_keys, prefix, field_info, is_first)
 						encoder.encode_struct_field_value(val.$(field.name))
 					}
 				}

--- a/vlib/v3/gen/c/attributes_test.v
+++ b/vlib/v3/gen/c/attributes_test.v
@@ -1,0 +1,42 @@
+module c
+
+import v3.flat
+import v3.token
+import v3.types
+
+fn cgen_attribute_test_gen() &FlatGen {
+	mut ast := &flat.FlatAst{}
+	mut tc := types.TypeChecker.new(ast)
+	mut g := FlatGen.new()
+	g.a = ast
+	g.tc = &tc
+	return &g
+}
+
+fn test_noinline_attribute_is_preserved_for_generic_specialization() {
+	mut g := cgen_attribute_test_gen()
+	g.ccompiler = 'clang'
+	source_pos := token.new_span(1, 20, 40)
+	template_id := g.a.add_node(flat.Node{
+		kind: .fn_decl
+		value: 'helper'
+		pos: source_pos
+	})
+	specialization_id := g.a.add_node(flat.Node{
+		kind: .fn_decl
+		value: 'helper_T_int'
+		pos: source_pos
+	})
+	g.a.specialized_fn_nodes[int(specialization_id)] = true
+	g.decl_attrs[int(template_id)] = ['noinline']
+	g.decl_attrs_by_source_position[flat_fn_source_position_key(g.a.nodes[int(template_id)])] = [
+		'noinline',
+	]
+
+	assert g.fn_decl_c_attribute(template_id) == ' __attribute__((noinline))'
+	assert g.fn_decl_c_attribute(specialization_id) == ' __attribute__((noinline))'
+
+	g.ccompiler = 'msvc'
+	assert g.fn_decl_c_attribute(specialization_id) == ''
+	assert g.fn_decl_msvc_noinline_prefix(specialization_id) == '__declspec(noinline) '
+}

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -458,6 +458,7 @@ mut:
 	struct_decl_infos            map[string]StructDeclInfo
 	struct_decl_short_infos      map[string]StructDeclInfo
 	decl_attrs                   map[int][]string
+	decl_attrs_by_source_position map[u64][]string
 	c_decl_abi_names             map[string]string
 	c_extern_global_names        map[string]string
 	shared_type_names            map[string]SharedTypeInfo // __shared__ wrapper name -> wrapped type metadata
@@ -1132,6 +1133,7 @@ pub fn FlatGen.new() FlatGen {
 		struct_decl_infos:               map[string]StructDeclInfo{}
 		struct_decl_short_infos:         map[string]StructDeclInfo{}
 		decl_attrs:                      map[int][]string{}
+		decl_attrs_by_source_position:   map[u64][]string{}
 		c_decl_abi_names:                map[string]string{}
 		c_extern_global_names:           map[string]string{}
 		shared_type_names:               map[string]SharedTypeInfo{}
@@ -2966,6 +2968,7 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	g.struct_decl_infos.clear()
 	g.struct_decl_short_infos.clear()
 	g.decl_attrs.clear()
+	g.decl_attrs_by_source_position.clear()
 	g.c_decl_abi_names.clear()
 	g.c_extern_global_names.clear()
 	g.shared_type_names.clear()
@@ -4022,6 +4025,14 @@ fn (mut g FlatGen) collect_gen_info(no_parallel bool) {
 			target_idx := node.value['@attributes:'.len..].int()
 			attrs := node.generic_params().clone()
 			g.decl_attrs[target_idx] = attrs
+			if target_idx >= 0 && target_idx < g.a.nodes.len {
+				target := g.a.nodes[target_idx]
+				// Monomorphization erases the generic template node but preserves
+				// its source position, which is also retained by its specializations.
+				if target.pos.is_valid() {
+					g.decl_attrs_by_source_position[flat_fn_source_position_key(target)] = attrs
+				}
+			}
 			g.index_c_decl_attributes(target_idx, cur_module, attrs)
 			continue
 		}

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -1613,16 +1613,35 @@ fn (mut g FlatGen) gen_fn(node flat.Node) {
 	g.gen_fn_in_module(flat.empty_node, node, g.tc.cur_module, false)
 }
 
+fn (g &FlatGen) fn_decl_attributes(node_id flat.NodeId) []string {
+	if int(node_id) < 0 {
+		return []string{}
+	}
+	if attrs := g.decl_attrs[int(node_id)] {
+		return attrs
+	}
+	if g.a.specialized_fn_nodes[int(node_id)] {
+		node := g.a.nodes[int(node_id)]
+		if node.pos.is_valid() {
+			return g.decl_attrs_by_source_position[flat_fn_source_position_key(node)] or {
+				[]string{}
+			}
+		}
+	}
+	return []string{}
+}
+
 fn (g &FlatGen) fn_decl_c_attribute(node_id flat.NodeId) string {
 	if int(node_id) < 0 || g.ccompiler == 'msvc' {
 		return ''
 	}
-	attrs := g.decl_attrs[int(node_id)] or { return '' }
+	attrs := g.fn_decl_attributes(node_id)
 	mut c_attrs := []string{}
 	for raw_attr in attrs {
 		match raw_attr.all_before(':').trim_space() {
 			'_constructor' { c_attrs << 'constructor' }
 			'_destructor' { c_attrs << 'destructor' }
+			'noinline' { c_attrs << 'noinline' }
 			else {}
 		}
 	}
@@ -1630,6 +1649,18 @@ fn (g &FlatGen) fn_decl_c_attribute(node_id flat.NodeId) string {
 		return ''
 	}
 	return ' __attribute__((${c_attrs.join(', ')}))'
+}
+
+fn (g &FlatGen) fn_decl_msvc_noinline_prefix(node_id flat.NodeId) string {
+	if g.ccompiler != 'msvc' {
+		return ''
+	}
+	for raw_attr in g.fn_decl_attributes(node_id) {
+		if raw_attr.all_before(':').trim_space() == 'noinline' {
+			return '__declspec(noinline) '
+		}
+	}
+	return ''
 }
 
 fn (g &FlatGen) fn_decl_noreturn_prefix(node_id flat.NodeId) string {
@@ -4421,6 +4452,7 @@ fn (mut g FlatGen) gen_fn_in_module(node_id flat.NodeId, node flat.Node, module_
 	} else {
 		ret_type := g.fn_node_return_type(node, module_name)
 		g.set_cur_fn_ret(ret_type)
+		g.write(g.fn_decl_msvc_noinline_prefix(node_id))
 		if export_name := g.export_fn_name_in_module(module_name, node.value) {
 			if export_name == generated_fn_name {
 				g.write(g.exported_symbol_attribute())

--- a/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
@@ -2444,6 +2444,7 @@ fn (g &FlatGen) new_parallel_worker_config(worker_id int, result_only bool) &Fla
 		struct_decl_infos:              g.struct_decl_infos
 		struct_decl_short_infos:        g.struct_decl_short_infos
 		decl_attrs:                     g.decl_attrs
+		decl_attrs_by_source_position:  g.decl_attrs_by_source_position
 		shared_type_names:              g.shared_type_names
 		shared_alias_pointer_shorts:    g.shared_alias_pointer_shorts
 		const_runtime_inits:            if result_only {


### PR DESCRIPTION
## Summary

- move runtime JSON struct-field matching out of the comptime field expansion
- share encoder key collision and selection logic across generated struct fields
- teach V3 C generation to preserve `@[noinline]`, including generic specializations and parallel workers

The previous `$for field in T.fields` paths emitted the same runtime key matching and collision logic once per field for every concrete struct type. Large structs consequently produced very large decoder and encoder functions.

## Size impact

Measured with an arm64 macOS FuseCode production build using `-prod -gc none`:

- executable: 3,915,096 -> 3,715,400 bytes (-199,696, 5.10%)
- Mach-O `__text`: 3,224,188 -> 3,025,320 bytes (-198,868, 6.17%)
- generated `JsonTheme` decoder: 56,548 -> 26,492 bytes
- generated `JsonTheme` encoder: 21,152 -> 8,564 bytes

A controlled V3 fixture containing a FuseCode-shaped JSON theme struct went from 173,456 to 141,072 bytes, while `__text` went from 110,336 to 80,400 bytes.

## Testing

- rebuilt V with `./v -g -keepc -o ./vnew cmd/v`
- JSON2 test suite: 74 passed
- V3 C generator unit suite: 17 passed
- compiler error/parser suite: 1,619 passed, 1 skipped
- C output regression suite passed
- verified generated generic C functions contain `__attribute__((noinline))`
- built and inspected the FuseCode production binary with `nm`, `size`, `file`, and `otool`