### PR TITLE
v3: support compiling gitly with FastC

### DIFF
--- a/vlib/v3/README.md
+++ b/vlib/v3/README.md
@@ -133,8 +133,9 @@ float printing, C-string and embedded-NUL string literals, runes, assertions, `s
 division, modulo, indexing, parallel assignment, mixed-precedence expressions, oversized decimal
 literals, and high-bit hexadecimal or binary literals. These restrictions avoid emitting C that
 cannot provide the required runtime behavior.
-`#flag` and `#pkgconfig` are rejected because FastC does not yet transport source build options to
-its fixed TinyCC invocation.
+FastC transports header paths, link inputs, frameworks, and preprocessor defines from `#flag`, and
+resolves `#pkgconfig` options into its fixed TinyCC invocation. Other compile options remain
+unsupported.
 
 FastC requires exactly one `.v` entry file. Executables are host-target only; `-o file.c` also
 permits an explicit cross target and publishes its generated C without host TinyCC validation.

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -1878,7 +1878,21 @@ fn v3_tcc_host_system_flags(target_os string) []string {
 	}
 	// The bundled TCC resource root replaces its configured search root. Restore
 	// the standard local prefix used by native packages such as wkhtmltox.
-	return ['-I/usr/local/include', '-L/usr/local/lib']
+	mut flags := ['-I/usr/local/include', '-L/usr/local/lib']
+	if target_os == 'macos' {
+		mut sdk_root := os.getenv('SDKROOT')
+		if !os.is_dir(sdk_root) {
+			result := cmdexec.run('xcrun', ['--show-sdk-path'])
+			if result.exit_code == 0 {
+				sdk_root = result.output.trim_space()
+			}
+		}
+		if os.is_dir(sdk_root) {
+			flags << '-I${os.join_path(sdk_root, 'usr', 'include')}'
+			flags << '-L${os.join_path(sdk_root, 'usr', 'lib')}'
+		}
+	}
+	return flags
 }
 
 fn v3_c_compiler_flag_plan(options V3CCompilerFlagOptions) V3CCompilerFlagPlan {
@@ -7028,7 +7042,7 @@ fn canonical_v3_fastc_output_path(path string) string {
 	return os.join_path_single(canonical_parent, os.file_name(absolute_path))
 }
 
-fn compile_v3_fastc_source(source string, bin_file string, prefs &pref.Preferences, environment_c_flags []string, user_c_flags []string, environment_ld_flags []string, is_debug bool, uses_threads bool) V3FastCCompileResult {
+fn compile_v3_fastc_source(source string, bin_file string, prefs &pref.Preferences, environment_c_flags []string, source_c_flags []string, user_c_flags []string, environment_ld_flags []string, is_debug bool, uses_threads bool) V3FastCCompileResult {
 	tcc_dir := os.join_path(prefs.vroot, 'thirdparty', 'tcc')
 	tcc_path := os.join_path_single(tcc_dir, 'tcc.exe')
 	if !os.is_executable(tcc_path) {
@@ -7047,6 +7061,7 @@ fn compile_v3_fastc_source(source string, bin_file string, prefs &pref.Preferenc
 	mut cc_args := environment_c_flags.clone()
 	cc_args << ['-std=gnu11', tcc_resources.base_arg, tcc_resources.include_arg, tcc_resources.library_arg]
 	cc_args << v3_tcc_host_system_flags(prefs.normalized_target_os())
+	cc_args << source_c_flags
 	cc_args << '-w'
 	if v3_tcc_backtrace_enabled(prefs.normalized_target_os(), prefs.normalized_target_arch(), false) {
 		cc_args << '-bt25'
@@ -7794,6 +7809,12 @@ pub fn run(args []string) {
 	if input_implies_building_v(input_file) || cmd_v_build {
 		building_v = true
 	}
+	if backend == 'fastc' && 'fastc_real_builtin' in user_defines {
+		// Opt-in: compile an ordinary program through FastC's real-`builtin` path
+		// (real `struct string`, error system, and the full runtime) instead of the
+		// bootstrap `const char*` runtime. This is how FastC reaches real apps.
+		building_v = true
+	}
 	// Large serial compiler-module builds create the same transform and C-generation
 	// scratch state as parallel builds. Keep that state disposable; `-no-parallel`
 	// controls worker creation independently from arena lifetime.
@@ -8140,8 +8161,8 @@ pub fn run(args []string) {
 			bin_file
 		}
 		fastc_result := compile_v3_fastc_source(fastc_source, fastc_bin_file, prefs,
-			environment_c_flags, user_c_flags, environment_ld_flags, is_debug,
-			fastc_generation.uses_threads)
+			environment_c_flags, fastc_generation.c_flags, user_c_flags, environment_ld_flags,
+			is_debug, fastc_generation.uses_threads)
 		if (!silent || show_cc) && fastc_result.command.len > 0 {
 			if c_to_stdout {
 				eprintln('  > ${fastc_result.command}')

--- a/vlib/v3/fastcdriver/fastcdriver.v
+++ b/vlib/v3/fastcdriver/fastcdriver.v
@@ -2,6 +2,7 @@ module fastcdriver
 
 import os
 import time
+import v3.cmdexec
 import v3.gen.fastc
 import v3.pref
 
@@ -274,6 +275,27 @@ fn fastc_tcc_backtrace_enabled(target_os string, target_arch string) bool {
 	return !(target_os == 'macos' && target_arch == 'arm64')
 }
 
+fn tcc_host_system_flags(target_os string) []string {
+	if target_os != os.user_os() || target_os == 'windows' {
+		return []
+	}
+	mut flags := ['-I/usr/local/include', '-L/usr/local/lib']
+	if target_os == 'macos' {
+		mut sdk_root := os.getenv('SDKROOT')
+		if !os.is_dir(sdk_root) {
+			result := cmdexec.run('xcrun', ['--show-sdk-path'])
+			if result.exit_code == 0 {
+				sdk_root = result.output.trim_space()
+			}
+		}
+		if os.is_dir(sdk_root) {
+			flags << '-I${os.join_path(sdk_root, 'usr', 'include')}'
+			flags << '-L${os.join_path(sdk_root, 'usr', 'lib')}'
+		}
+	}
+	return flags
+}
+
 // run invokes the standalone FastC compiler or its self-build command.
 pub fn run(args []string) {
 	command_index := self_command_index(args)
@@ -283,8 +305,7 @@ pub fn run(args []string) {
 	}
 	input, output, keep_c := parse_arguments(args)
 	real_input := os.real_path(input)
-	if pref.is_test_file_for_backend(real_input, 'fastc')
-		|| pref.is_test_file_for_backend(real_input, 'c') {
+	if pref.is_test_file_for_backend(real_input, 'fastc') || pref.is_test_file_for_backend(real_input, 'c') {
 		fail('fastc self-host compiler does not support test files')
 	}
 	if canonical_output_path(output) == real_input {
@@ -299,8 +320,7 @@ pub fn run(args []string) {
 	prefs.building_v = real_input.ends_with('/vlib/v3/v3.v')
 	prefs.selfhost = prefs.building_v
 	prefs.user_defines = ['fastc_selfhost', 'v3_backend', 'skip_arm64', 'skip_wasm', 'skip_eval']
-	backtrace_enabled := fastc_tcc_backtrace_enabled(prefs.normalized_target_os(),
-		prefs.target.arch)
+	backtrace_enabled := fastc_tcc_backtrace_enabled(prefs.normalized_target_os(), prefs.target.arch)
 	// Mirror the driver's TinyCC compatibility plan (add_v3_tcc_compat_defines):
 	// TCC's backtrace runtime cannot be linked on macOS arm64, so builtin must
 	// not reference tcc_backtrace there. Descendant generations then compile
@@ -373,16 +393,20 @@ pub fn run(args []string) {
 	tcc_dir := os.join_path(prefs.vroot, 'thirdparty', 'tcc')
 	tcc := os.join_path_single(tcc_dir, 'tcc.exe')
 	tcc_lib := os.join_path_single(tcc_dir, 'lib')
-	// The emitted spawn runtime calls pthread functions, which live outside
-	// libc on Linux with glibc before 2.34 and on the BSDs.
-	mut thread_link_flag := ''
-	if generation.uses_threads {
-		thread_link_flag = '-lpthread '
+	mut cc_args := ['-std=gnu11', '-I${os.join_path_single(tcc_lib, 'include')}', '-L${tcc_lib}']
+	cc_args << tcc_host_system_flags(prefs.normalized_target_os())
+	cc_args << generation.c_flags
+	if backtrace_enabled {
+		cc_args << '-bt25'
 	}
-	backtrace_flag := if backtrace_enabled { '-bt25 ' } else { '' }
-	command := '${os.quoted_path(tcc)} -std=gnu11 ${backtrace_flag}-I${os.quoted_path(os.join_path_single(tcc_lib,
-		'include'))} -L${os.quoted_path(tcc_lib)} -w -o ${os.quoted_path(staged_output)} ${os.quoted_path(c_path)} ${thread_link_flag}-lm'
-	result := os.execute(command)
+	cc_args << ['-w', '-o', staged_output, c_path]
+	if generation.uses_threads {
+		// The emitted spawn runtime calls pthread functions, which live outside
+		// libc on Linux with glibc before 2.34 and on the BSDs.
+		cc_args << '-lpthread'
+	}
+	cc_args << '-lm'
+	result := cmdexec.run(tcc, cc_args)
 	if result.exit_code != 0 {
 		fail(result.output)
 	}

--- a/vlib/v3/gen/fastc/anonfn.v
+++ b/vlib/v3/gen/fastc/anonfn.v
@@ -1,0 +1,62 @@
+module fastc
+
+// read_anonymous_function_stub parses a function literal / closure
+// (`fn [captures] (params) ret { body }`) in expression position and lowers it to a
+// COMPILE-ONLY stub: a top-level function of the matching signature whose body is
+// dropped. This lets code that stores or passes a closure value (e.g. net/http's H2
+// transport `close_transport`, which is captured and invoked later) compile and link.
+// FastC has no closure runtime — capturing the enclosing environment through an escaping
+// function pointer needs per-arch thunks — so the stub is non-functional, mirroring the
+// channel stubs. Returns `&name` (the stub's address, a function-pointer value) so a
+// `:=` declaration infers a proper C function-pointer type via `__typeof__`.
+fn (mut g Parser) read_anonymous_function_stub() !string {
+	g.next() // consume `fn`
+	// Skip an optional capture list `[a, mut b, ...]`.
+	if g.tok == .lsbr {
+		g.skip_balanced(.lsbr, .rsbr)!
+	}
+	// Parse the parameters for the stub signature. parse_parameters registers the params
+	// as locals; isolate them so the enclosing scope is unaffected.
+	saved_locals := g.locals.clone()
+	g.expect(.lpar)!
+	params := g.parse_parameters()!
+	mut return_type := 'void'
+	if g.tok != .lcbr && g.tok != .semicolon {
+		if g.tok in [.not, .question] {
+			g.next()
+			return_type = 'Option'
+			if g.tok in [.lcbr, .semicolon] {
+			} else if g.tok == .lpar {
+				_ := g.parse_multi_return_types()!
+			} else {
+				_ := g.parse_type()!
+			}
+		} else if g.tok == .lpar {
+			_ := g.parse_multi_return_types()!
+			return_type = 'MultiReturn'
+		} else {
+			return_type = g.parse_type()!
+		}
+	}
+	g.locals = saved_locals.clone()
+	// Drop the body.
+	g.skip_balanced(.lcbr, .rcbr)!
+	// Emit a uniquely-named stub function. The name folds in the enclosing
+	// module/receiver/function (unique per definition) plus a per-file counter, so two
+	// closures anywhere in the program never collide in the shared helper map.
+	g.anon_fn_counter++
+	stem :=
+		fastc_c_function_name_for_key('${g.module_name}.${g.current_receiver}.${g.current_function}')
+	name := '${stem}__anonfn_${g.anon_fn_counter}'
+	c_params := if params.len == 0 { 'void' } else { params.join(', ') }
+	body_return := if return_type == 'void' {
+		''
+	} else if return_type.ends_with('*') {
+		'return 0;'
+	} else {
+		'return (${return_type}){0};'
+	}
+	g.protos.writeln('${return_type} ${name}(${c_params});')
+	g.spawn_helpers[name] = '${return_type} ${name}(${c_params}) { ${body_return} }'
+	return '&${name}'
+}

--- a/vlib/v3/gen/fastc/array.v
+++ b/vlib/v3/gen/fastc/array.v
@@ -3,6 +3,31 @@ module fastc
 import strings
 import v3.token
 
+fn (g &Parser) fixed_array_uses_raw_storage(tokens []FastcExpressionToken) bool {
+	if tokens.len == 1 {
+		return fastc_global_key(g.module_name, tokens[0].lit) in g.globals
+	}
+	if tokens.len >= 3 && tokens[tokens.len - 2].tok == .dot && tokens.last().tok == .name {
+		return true
+	}
+	if tokens.len >= 4 && tokens.last().tok == .rsbr {
+		mut depth := 0
+		for i := tokens.len - 1; i >= 0; i-- {
+			if tokens[i].tok == .rsbr {
+				depth++
+			} else if tokens[i].tok == .lsbr {
+				depth--
+				if depth == 0 {
+					// A fixed array nested inside a raw struct field remains raw C array
+					// storage after indexing (`s[0]` in `u32 s[4][256]`).
+					return i > 0 && g.fixed_array_uses_raw_storage(tokens[..i])
+				}
+			}
+		}
+	}
+	return false
+}
+
 fn (g &Parser) render_array_access_expression(tokens []FastcExpressionToken) ?FastcRenderedExpression {
 	if tokens.len < 4 || tokens[0].tok != .name || tokens.last().tok != .rsbr {
 		return none
@@ -23,6 +48,18 @@ fn (g &Parser) render_array_access_expression(tokens []FastcExpressionToken) ?Fa
 	if open <= 0 {
 		return none
 	}
+	mut prefix_depth := 0
+	for item in tokens[..open] {
+		if item.tok in [.lpar, .lsbr, .lcbr] {
+			prefix_depth++
+		} else if item.tok in [.rpar, .rsbr, .rcbr] {
+			prefix_depth--
+		} else if prefix_depth == 0 && item.tok.is_assignment() {
+			// `target = [value]` ends in `]`, but its bracket pair is an array literal,
+			// not an index applied to the assignment prefix.
+			return none
+		}
+	}
 	close := fastc_matching_delimiter(tokens, open, .lsbr, .rsbr) or { return none }
 	if close != tokens.len - 1 {
 		return none
@@ -34,10 +71,18 @@ fn (g &Parser) render_array_access_expression(tokens []FastcExpressionToken) ?Fa
 		g.resolved_root_expression_name(tokens[0].lit)
 	} else if nested_base := g.render_array_access_expression(base_tokens) {
 		nested_base.source
+	} else if raw_base := g.render_raw_expression_tokens(base_tokens) {
+		if method_base := g.render_method_call_expression(base_tokens, raw_base) {
+			method_base.source
+		} else if member_base := g.render_member_receiver(base_tokens) {
+			member_base
+		} else {
+			raw_base
+		}
 	} else if member_base := g.render_member_receiver(base_tokens) {
 		member_base
 	} else {
-		g.render_raw_expression_tokens(base_tokens) or { return none }
+		return none
 	}
 	mut range_index := -1
 	for i in open + 1 .. close {
@@ -53,19 +98,46 @@ fn (g &Parser) render_array_access_expression(tokens []FastcExpressionToken) ?Fa
 			g.render_membership_candidate(tokens[open + 1..range_index], 'int') or { return none }
 		}
 		omitted_end := range_index + 1 == close
-		needs_receiver_temporary := omitted_end && base_tokens.len > 1
+		is_fixed_array := base_layout_type.starts_with('FixedArray_')
+		is_raw_fixed_array := is_fixed_array && g.fixed_array_uses_raw_storage(base_tokens)
+		needs_receiver_temporary := omitted_end && base_tokens.len > 1 && !is_raw_fixed_array
 		receiver_name := '__v_fastc_slice_receiver'
 		receiver_source := if needs_receiver_temporary { receiver_name } else { base_source }
-		access := if base_type.ends_with('*') { '->' } else { '.' }
+		receiver_is_pointer := base_type.ends_with('*') && !needs_receiver_temporary
+		access := if receiver_is_pointer { '->' } else { '.' }
 		end := if omitted_end {
-			'${receiver_source}${access}len'
+			if is_fixed_array {
+				fastc_fixed_array_length(base_layout_type.trim_right('*')) or { return none }
+			} else {
+				'${receiver_source}${access}len'
+			}
 		} else {
 			g.render_membership_candidate(tokens[range_index + 1..close], 'int') or { return none }
 		}
-		mut slice_source := if base_layout_type == 'string' {
-			'builtin__string_substr(${if base_type.ends_with('*') { '*' } else { '' }}(${receiver_source}), ${start}, ${end})'
+		mut slice_type := if base_layout_type == 'string' {
+			'string'
 		} else {
-			array_value := if base_type.ends_with('*') {
+			base_type.trim_right('*')
+		}
+		mut slice_source := if base_layout_type == 'string' {
+			'builtin__string_substr(${if receiver_is_pointer { '*' } else { '' }}(${receiver_source}), ${start}, ${end})'
+		} else if is_fixed_array {
+			// Slicing a fixed array yields a NEW dynamic array copied from the element
+			// range; the raw `u8 x[N]` / wrapped `.data` storage differs by receiver kind.
+			element := g.array_element_type(base_layout_type.trim_right('*')) or { return none }
+			norm_element := fastc_normalize_inferred_type(element)
+			data_expr := if is_raw_fixed_array {
+				'(${receiver_source})'
+			} else {
+				'(${receiver_source})${access}data'
+			}
+			slice_len := '((${end}) - (${start}))'
+			slice_type = fastc_array_c_type(norm_element)
+			mut w := unsafe { &Parser(g) }
+			fastc_register_composite_type(slice_type, mut w.composite_types)
+			'((${slice_type})builtin__new_array_from_c_array(${slice_len}, ${slice_len}, sizeof(${norm_element}), &((${data_expr})[${start}])))'
+		} else {
+			array_value := if receiver_is_pointer {
 				'*(${receiver_source})'
 			} else {
 				receiver_source
@@ -77,7 +149,7 @@ fn (g &Parser) render_array_access_expression(tokens []FastcExpressionToken) ?Fa
 		}
 		return FastcRenderedExpression{
 			source: slice_source
-			typ:    if base_layout_type == 'string' { 'string' } else { base_type.trim_right('*') }
+			typ:    slice_type
 		}
 	}
 	is_array_pointer := base_type.ends_with('*') && g.array_element_type(base_type) != none
@@ -97,9 +169,8 @@ fn (g &Parser) render_array_access_expression(tokens []FastcExpressionToken) ?Fa
 			typ:    element_type
 		}
 	}
-	is_raw_fixed_array := base_type.starts_with('FixedArray_') && (base_tokens.len > 1
-		|| (base_tokens.len == 1
-		&& fastc_global_key(g.module_name, base_tokens[0].lit) in g.globals))
+	is_raw_fixed_array := base_type.starts_with('FixedArray_')
+		&& g.fixed_array_uses_raw_storage(base_tokens)
 	if fixed_length := fastc_fixed_array_length(base_type.trim_right('*')) {
 		checked_index := 'builtin__v_fixed_index(${index_source}, ${fixed_length})'
 		if is_raw_fixed_array {
@@ -144,19 +215,73 @@ fn (g &Parser) render_nested_array_access_expression(tokens []FastcExpressionTok
 			continue
 		}
 		// A name after `.` is a field, not a new root expression. Treating it as
-		// a local can replace the field suffix inside its owning expression (for
-		// example `str.str[0]`) and produce invalid C.
+		// a local can replace the field suffix inside its owning expression. Render
+		// the complete member-rooted access instead, preserving embedded promotion.
 		if i > 0 && tokens[i - 1].tok == .dot {
+			close := fastc_matching_delimiter(tokens, i + 1, .lsbr, .rsbr) or { continue }
+			start := fastc_method_receiver_start(tokens, i + 1)
+			if start >= i {
+				continue
+			}
+			access_tokens := tokens[start..close + 1]
+			raw_access := g.render_raw_expression_tokens(access_tokens) or { continue }
+			replacement := g.render_array_access_expression(access_tokens) or { continue }
+			if rendered.contains(raw_access) {
+				rendered = rendered.replace(raw_access, replacement.source)
+				changed = true
+			}
 			continue
 		}
 		close := fastc_matching_delimiter(tokens, i + 1, .lsbr, .rsbr) or { continue }
-		if close <= i + 1 || fastc_expression_tokens_contain(tokens[i + 2..close], .dotdot) {
+		if close <= i + 1 {
+			continue
+		}
+		if fastc_expression_tokens_contain(tokens[i + 2..close], .dotdot) {
+			access_tokens := tokens[i..close + 1]
+			raw_access := g.render_raw_expression_tokens(access_tokens) or { continue }
+			replacement := g.render_array_access_expression(access_tokens) or { continue }
+			if rendered.contains(raw_access) {
+				rendered = rendered.replace(raw_access, replacement.source)
+				changed = true
+			}
 			continue
 		}
 		index_source := g.render_membership_candidate(tokens[i + 2..close], 'int') or { continue }
 		base_source := g.resolved_root_expression_name(tokens[i].lit)
 		needle := '${base_source}[${index_source}]'
 		replacement := g.render_array_access_expression(tokens[i..close + 1]) or { continue }
+		if rendered.contains(needle) {
+			rendered = rendered.replace(needle, replacement.source)
+			changed = true
+		}
+	}
+	for open, item in tokens {
+		if item.tok != .lsbr || open == 0 || tokens[open - 1].tok != .rpar {
+			continue
+		}
+		close := fastc_matching_delimiter(tokens, open, .lsbr, .rsbr) or { continue }
+		if close <= open + 1 || fastc_expression_tokens_contain(tokens[open + 1..close], .dotdot) {
+			continue
+		}
+		start := fastc_method_receiver_start(tokens, open)
+		if start >= open || tokens[start].tok != .name {
+			continue
+		}
+		access_tokens := tokens[start..close + 1]
+		replacement := g.render_array_access_expression(access_tokens) or { continue }
+		raw_access := g.render_raw_expression_tokens(access_tokens) or { '' }
+		if raw_access != '' && rendered.contains(raw_access) {
+			rendered = rendered.replace(raw_access, replacement.source)
+			changed = true
+			continue
+		}
+		base_tokens := tokens[start..open]
+		raw_base := g.render_raw_expression_tokens(base_tokens) or { continue }
+		method_base := g.render_method_call_expression(base_tokens, raw_base) or { continue }
+		index_source := g.render_membership_candidate(tokens[open + 1..close], 'int') or {
+			continue
+		}
+		needle := '${method_base.source}[${index_source}]'
 		if rendered.contains(needle) {
 			rendered = rendered.replace(needle, replacement.source)
 			changed = true
@@ -194,6 +319,9 @@ fn (g &Parser) render_membership_candidate(tokens []FastcExpressionToken, expect
 		return array_access.source
 	}
 	raw := g.render_raw_expression_tokens(tokens) or { return none }
+	if special := g.render_special_expression(tokens, raw) {
+		return special.source
+	}
 	if map_expression := g.render_map_expression(tokens) {
 		return map_expression.source
 	}
@@ -219,7 +347,45 @@ fn (g &Parser) render_membership_candidate(tokens []FastcExpressionToken, expect
 			}
 		}
 	}
+	if promoted := g.render_leading_member_chain_promotion(tokens, expected_type) {
+		return promoted
+	}
 	return raw
+}
+
+// render_leading_member_chain_promotion handles a compound expression that begins
+// with a member chain reaching an EMBEDDED field (`ss.pos + 2`), which the pure
+// member-chain renderer rejects because of the trailing operator. It promotes the
+// leading chain and renders the rest recursively. Returns none unless the leading
+// chain is actually an embedded access, so every other expression keeps its
+// byte-for-byte raw form.
+fn (g &Parser) render_leading_member_chain_promotion(tokens []FastcExpressionToken, expected_type string) ?string {
+	if tokens.len < 4 || tokens[0].tok != .name {
+		return none
+	}
+	mut chain_end := 1
+	for chain_end + 1 < tokens.len && tokens[chain_end].tok == .dot
+		&& tokens[chain_end + 1].tok == .name {
+		chain_end += 2
+	}
+	// Need `root.field` (chain_end >= 3) followed by an arithmetic operator; a pure
+	// member chain (chain_end == tokens.len) has no trailing token and is handled
+	// upstream, so bail before indexing past the end.
+	if chain_end < 3 || chain_end >= tokens.len {
+		return none
+	}
+	operator := tokens[chain_end]
+	if operator.tok !in [.plus, .minus, .mul, .div, .mod] {
+		return none
+	}
+	chain_source := g.render_member_receiver(tokens[..chain_end]) or { return none }
+	if !chain_source.contains('__embedded_') {
+		return none
+	}
+	rest_source := g.render_membership_candidate(tokens[chain_end + 1..], expected_type) or {
+		return none
+	}
+	return '${chain_source} ${operator.tok.str()} ${rest_source}'
 }
 
 fn (g &Parser) render_raw_expression_tokens(tokens []FastcExpressionToken) ?string {
@@ -238,17 +404,32 @@ fn (g &Parser) render_raw_expression_tokens(tokens []FastcExpressionToken) ?stri
 		is_c_pointer_cast := item.tok in [.amp, .and] && fastc_token_is_prefix_operator(tokens, i)
 			&& i + 4 < tokens.len && tokens[i + 1].tok == .name && tokens[i + 1].lit == 'C'
 			&& tokens[i + 2].tok == .dot && tokens[i + 3].tok == .name && tokens[i + 4].tok == .lpar
-		if is_direct_pointer_cast || is_c_pointer_cast {
+		if item.source != '' {
+			// Synthetic expression atoms (an `or` unwrap, interpolation, anonymous
+			// function, etc.) carry their complete C spelling in `source`. Preserve it
+			// when the atom is nested inside a larger binary or call expression.
+			piece = item.source
+		} else if is_direct_pointer_cast || is_c_pointer_cast {
 			piece = ''
 		} else if item.tok == .name && i + 1 < tokens.len && tokens[i + 1].tok == .lpar {
-			mut cast_type := fastc_primitive_c_type(item.lit) or { '' }
-			is_c_cast := i >= 2 && tokens[i - 2].tok == .name && tokens[i - 2].lit == 'C'
-				&& tokens[i - 1].tok == .dot && item.lit.len > 0 && item.lit[0].is_capital()
-				&& 'C.${item.lit}' !in g.functions
-			if is_c_cast {
-				cast_type = item.lit
+			is_member_call := i > 0 && tokens[i - 1].tok == .dot
+			mut cast_type := if is_member_call {
+				''
+			} else {
+				fastc_primitive_c_type(item.lit) or { '' }
 			}
-			if cast_type == '' {
+			is_c_cast := i >= 2 && tokens[i - 2].tok == .name && tokens[i - 2].lit == 'C'
+				&& tokens[i - 1].tok == .dot && item.lit.len > 0 && 'C.${item.lit}' !in g.functions
+				&& fastc_call_has_one_argument(tokens, i + 1)
+				&& (item.lit[0].is_capital() || '#Cstruct#${item.lit}' in g.declared_types)
+			if is_c_cast {
+				cast_type = if '#Cstruct#${item.lit}' in g.declared_types {
+					'struct ${item.lit}'
+				} else {
+					item.lit
+				}
+			}
+			if cast_type == '' && !is_member_call {
 				if type_key := fastc_resolve_declared_type_key(g.module_name, item.lit, g.imports,
 					g.declared_types)
 				{
@@ -276,6 +457,13 @@ fn (g &Parser) render_raw_expression_tokens(tokens []FastcExpressionToken) ?stri
 				close := fastc_matching_rpar(tokens, i + 1) or { return none }
 				cast_opens[i + 1] = true
 				cast_closes[close] = true
+			} else {
+				previous := if i == 0 { token.Token.unknown } else { tokens[i - 1].tok }
+				piece = if previous == .dot {
+					item.lit
+				} else {
+					g.resolved_expression_name(item.lit, previous)
+				}
 			}
 		} else if item.tok == .lpar && i in cast_opens {
 			piece = ''
@@ -312,9 +500,20 @@ fn (g &Parser) render_raw_expression_tokens(tokens []FastcExpressionToken) ?stri
 			previous := if i == 0 { token.Token.unknown } else { tokens[i - 1].tok }
 			piece = if previous == .dot && i + 1 < tokens.len && tokens[i + 1].tok == .lpar {
 				item.lit
+			} else if previous == .dot && g.expression_dot_is_module_separator(tokens, i - 1) {
+				// The module prefix already makes a qualified keyword-named constant safe
+				// (`orm.float` -> `orm__float`), so do not sanitize the member by itself.
+				item.lit
+			} else if i >= 2 && previous == .dot && tokens[i - 2].tok == .name
+				&& g.is_enum_type_name(tokens[i - 2].lit) {
+				// An enum type prefix likewise makes keyword-named fields safe
+				// (`TokenKind.float` -> `TokenKind__float`).
+				item.lit
 			} else if i >= 2 && previous == .dot && tokens[i - 2].tok == .name
 				&& tokens[i - 2].lit == 'C' {
 				item.lit
+			} else if previous == .dot {
+				fastc_c_identifier(item.lit)
 			} else {
 				g.resolved_expression_name(item.lit, previous)
 			}
@@ -350,8 +549,11 @@ fn (g &Parser) expression_dot_is_module_separator(tokens []FastcExpressionToken,
 		return false
 	}
 	previous_name := tokens[index - 1].lit
-	if previous_name in g.imports || previous_name == 'C'
-		|| (previous_name !in g.locals && g.is_enum_type_name(previous_name)) {
+	// An imported module name is only a qualifier at the start of a member chain.
+	// In `app.config.value`, `config` is a field even when the file imports `config`.
+	if (index < 2 || tokens[index - 2].tok != .dot) && (previous_name in g.imports
+		|| previous_name == 'C' || (previous_name !in g.locals
+		&& g.is_enum_type_name(previous_name))) {
 		return true
 	}
 	if index < 3 || tokens[index - 2].tok != .dot || tokens[index - 3].tok != .name {
@@ -392,27 +594,19 @@ fn (g &Parser) array_initializer_type(tokens []FastcExpressionToken) ?string {
 		dimensions++
 		index += 2
 	}
-	mut pointers := 0
-	for index < tokens.len && tokens[index].tok in [.amp, .mul] {
-		pointers++
-		index++
-	}
-	if dimensions == 0 || index >= tokens.len || tokens[index].tok != .name {
+	if dimensions == 0 || index >= tokens.len {
 		return none
 	}
-	mut element_type := fastc_primitive_c_type(tokens[index].lit) or { '' }
+	mut element_type := g.type_from_expression_tokens(tokens[index..]) or { '' }
+	if element_type == '' && index + 1 == tokens.len && tokens[index].tok == .name
+		&& tokens[index].lit == 'thread' {
+		// `[]thread` is an array of spawned-thread handles (all handles share one
+		// C layout, keyed as the void-thread type).
+		element_type = fastc_thread_type_name('')
+	}
 	if element_type == '' {
-		if type_key := fastc_resolve_declared_type_key(g.module_name, tokens[index].lit, g.imports,
-			g.declared_types)
-		{
-			element_type = fastc_c_declared_type_name(type_key)
-		}
-	}
-	index++
-	if element_type == '' || index != tokens.len {
 		return none
 	}
-	element_type += '*'.repeat(pointers)
 	if fixed_length != '' {
 		return fastc_fixed_array_type(fixed_length, element_type)
 	}
@@ -448,8 +642,8 @@ fn (g &Parser) type_from_expression_tokens(tokens []FastcExpressionToken) ?strin
 	}
 	mut pointers := 0
 	mut start := 0
-	for start < tokens.len && tokens[start].tok in [.amp, .mul] {
-		pointers++
+	for start < tokens.len && tokens[start].tok in [.amp, .and, .mul] {
+		pointers += if tokens[start].tok == .and { 2 } else { 1 }
 		start++
 	}
 	if start >= tokens.len {
@@ -470,6 +664,12 @@ fn (g &Parser) type_from_expression_tokens(tokens []FastcExpressionToken) ?strin
 		value_type := g.type_from_expression_tokens(remaining[close + 1..]) or { return none }
 		return fastc_map_c_type(key_type, value_type) + '*'.repeat(pointers)
 	}
+	if remaining.len >= 2 && remaining[0].tok == .name && remaining[0].lit == 'chan' {
+		// Channels use one erased runtime representation. Still validate the element
+		// spelling so an arbitrary trailing expression is not accepted as a type.
+		_ := g.type_from_expression_tokens(remaining[1..]) or { return none }
+		return 'chan' + '*'.repeat(pointers)
+	}
 	if remaining.len == 1 && remaining[0].tok == .name {
 		mut base := fastc_primitive_c_type(remaining[0].lit) or { '' }
 		if base == '' {
@@ -483,11 +683,11 @@ fn (g &Parser) type_from_expression_tokens(tokens []FastcExpressionToken) ?strin
 		&& remaining[2].tok == .name {
 		if remaining[0].lit == 'C' {
 			raw_type := remaining[2].lit
-			if 'C.${raw_type}' in g.functions {
-				return none
-			}
 			if '#Cstruct#${raw_type}' in g.declared_types {
 				return 'struct ${raw_type}' + '*'.repeat(pointers)
+			}
+			if 'C.${raw_type}' in g.functions {
+				return none
 			}
 			if raw_type.len == 0 || !raw_type[0].is_capital() {
 				return none
@@ -518,7 +718,15 @@ fn fastc_generate_fixed_array_declarations(fixed_array_types map[string]string) 
 		array_type := fixed_array_types[name]
 		length := fastc_fixed_array_length(array_type) or { continue }
 		element_type := fastc_fixed_array_element_type(array_type) or { continue }
-		out.writeln('typedef struct { ${element_type} data[${length}]; } ${name};')
+		declaration_name := if fastc_composite_type_part(array_type) == array_type {
+			array_type
+		} else {
+			name
+		}
+		out.writeln('typedef struct { ${element_type} data[${length}]; } ${declaration_name};')
+		if name != declaration_name {
+			out.writeln('typedef ${declaration_name} ${name};')
+		}
 	}
 	if out.len > 0 {
 		out.writeln('')

--- a/vlib/v3/gen/fastc/comptime.v
+++ b/vlib/v3/gen/fastc/comptime.v
@@ -35,6 +35,26 @@ fn fastc_scan_comptime_unary(mut scan scanner.Scanner, first token.Token, path s
 			tok:   scan.scan()
 		}
 	}
+	if first == .dollar {
+		// `$pkgconfig('lib')`: true when pkg-config reports the library present.
+		if scan.scan() != .name || scan.lit != 'pkgconfig' {
+			return error('fastc parser does not support compile-time condition `${scan.lit}` in ${path}')
+		}
+		if scan.scan() != .lpar {
+			return error('fastc parser does not support `$pkgconfig` condition in ${path}')
+		}
+		if scan.scan() != .string {
+			return error('fastc parser does not support `$pkgconfig` library name in ${path}')
+		}
+		library := scan.lit.trim('\'"')
+		if scan.scan() != .rpar {
+			return error('fastc parser does not support `$pkgconfig` condition in ${path}')
+		}
+		return FastcComptimeCondition{
+			value: pref.comptime_pkgconfig_value(library)
+			tok:   scan.scan()
+		}
+	}
 	if first != .name {
 		return error('fastc parser does not support compile-time condition `${first.str()}` in ${path}')
 	}
@@ -261,6 +281,432 @@ fn (mut g Parser) parse_comptime_if_statement() !bool {
 	return g.parse_block_body()!
 }
 
+// parse_comptime_match_statement selects a type branch from `$match T` or
+// `$match T.unaliased_typ`. Late generic instances contain a concrete type name in
+// place of `T`, so only the selected branch needs to enter the ordinary statement
+// parser. This is the statement form used by json2's numeric decoder.
+fn (mut g Parser) parse_comptime_match_statement() !bool {
+	g.expect(.dollar)!
+	g.expect(.key_match)!
+	if g.tok != .name {
+		return g.unsupported('compile-time `$match` subject')
+	}
+	subject_name := g.lit
+	mut subject_type := g.comptime_named_type(subject_name)
+	g.next()
+	if g.tok == .dot {
+		g.next()
+		if g.tok != .name || g.lit !in ['typ', 'unaliased_typ'] {
+			return g.unsupported('compile-time `$match` type member')
+		}
+		if g.lit == 'unaliased_typ' {
+			subject_type = g.underlying_alias_type(subject_type)
+		}
+		g.next()
+	}
+	g.expect(.lcbr)!
+	mut selected := false
+	mut selected_terminates := false
+	g.skip_semicolons()
+	for g.tok != .rcbr {
+		if g.tok == .eof {
+			return g.unsupported('unfinished compile-time `$match`')
+		}
+		mut branch_matches := false
+		if g.tok == .dollar {
+			g.next()
+			if g.tok != .key_else {
+				return g.unsupported('compile-time `$match` branch')
+			}
+			g.next()
+			branch_matches = !selected
+		} else {
+			for {
+				target_type := g.parse_type()!
+				branch_matches = branch_matches
+					|| g.underlying_alias_type(subject_type) == g.underlying_alias_type(target_type)
+				if g.tok != .comma {
+					break
+				}
+				g.next()
+			}
+		}
+		g.expect(.lcbr)!
+		if branch_matches && !selected {
+			selected = true
+			selected_terminates = g.parse_block_body()!
+		} else {
+			g.skip_open_block()!
+		}
+		g.skip_semicolons()
+	}
+	g.next()
+	g.skip_semicolons()
+	return selected_terminates
+}
+
+// parse_comptime_for_statement unrolls `$for <var> in <Type>.fields { body }`.
+// It resolves the concrete type's fields (monomorphization has already turned a
+// generic `T.fields` into a concrete `User.fields`), captures the body source,
+// and re-parses it once per field with a comptime-field context so `<var>.name`,
+// `<var>.typ` and `t.$(<var>.name)` resolve.
+fn (mut g Parser) parse_comptime_for_statement() !bool {
+	g.expect(.dollar)!
+	g.expect(.key_for)!
+	if g.tok != .name {
+		return g.unsupported('`$for` loop variable')
+	}
+	loop_var := g.lit
+	g.next()
+	g.expect(.key_in)!
+	if g.tok != .name {
+		return g.unsupported('`$for` iterable')
+	}
+	first := g.lit
+	g.next()
+	if g.tok != .dot {
+		return g.unsupported('`$for` expects `Type.fields`')
+	}
+	g.next()
+	if g.tok != .name {
+		return g.unsupported('`$for` iterable member')
+	}
+	mut type_key := ''
+	if g.lit == 'fields' {
+		type_key = fastc_resolve_declared_type_key(g.module_name, first, g.imports,
+			g.declared_types) or { return g.unsupported('`$for` over unknown type `${first}`') }
+		g.next()
+	} else {
+		// Qualified `mod.Type.fields`.
+		module_name := g.imports[first] or { first }
+		type_key = fastc_type_key(module_name, g.lit)
+		g.next()
+		g.expect(.dot)!
+		if g.tok != .name || g.lit != 'fields' {
+			return g.unsupported('`$for` only supports `.fields`')
+		}
+		g.next()
+	}
+	g.expect(.lcbr)!
+	c_type := fastc_c_declared_type_name(type_key)
+	// Capture the body source (from the first body token up to the matching `}`).
+	body_start := g.s.pos
+	mut depth := 0
+	mut body_end := -1
+	for g.tok != .eof {
+		if g.tok == .lcbr {
+			depth++
+		} else if g.tok == .rcbr {
+			if depth == 0 {
+				body_end = g.s.pos
+				break
+			}
+			depth--
+		}
+		g.next()
+	}
+	if body_end < 0 {
+		return g.unsupported('unterminated `$for` block')
+	}
+	body_source := g.s.src[body_start..body_end]
+	g.next() // consume the closing `}`; the main scanner now continues after it
+	saved_tok := g.tok
+	saved_lit := g.lit
+	saved_s := g.s
+	for field in g.struct_field_info[c_type] {
+		// Substitute this field's comptime references (`<var>.name`,
+		// `x.$(<var>.name)`) at the source level, then re-scan the result as
+		// ordinary V — no comptime awareness is needed in the renderer.
+		substituted := g.substitute_comptime_field(body_source, loop_var, field)
+		mut file_set := token.FileSet.new()
+		mut file := file_set.add_file('comptime_for', substituted.len)
+		file.index_lines_without_digest(substituted)
+		g.s = scanner.new_scanner(g.prefs, .normal)
+		g.s.init(file, substituted)
+		g.next()
+		// A fresh C block scopes any locals the body declares, so re-parsing it per
+		// field does not redeclare them in the enclosing scope.
+		g.write_line('{')
+		g.indent++
+		outer_locals := g.locals.clone()
+		for g.tok != .eof {
+			g.parse_statement()!
+			g.skip_semicolons()
+		}
+		g.locals = outer_locals.clone()
+		g.indent--
+		g.write_line('}')
+	}
+	g.s = saved_s
+	g.tok = saved_tok
+	g.lit = saved_lit
+	return false
+}
+
+// substitute_comptime_field rewrites one `$for` body for a single field:
+// `<var>.name` becomes the field-name string literal `'field'`; a computed
+// selector `x.$(<var>.name)` becomes the static access `x.field`; and a comptime
+// type test `<var>.typ is <Type>` becomes the literal `true`/`false` (so the
+// enclosing `$if` takes/skips the branch). Other `<var>.<member>` forms are left
+// as-is (they fail to parse, flagging the unsupported comptime feature). Uses
+// token positions so nothing inside strings or comments is touched.
+fn (g &Parser) substitute_comptime_field(body string, loop_var string, field FastcStructField) string {
+	field_name := field.name
+	mut file_set := token.FileSet.new()
+	mut file := file_set.add_file('cf', body.len)
+	file.index_lines_without_digest(body)
+	mut s := scanner.new_scanner(g.prefs, .normal)
+	s.init(file, body)
+	mut edits := []FastcSourceEdit{}
+	mut previous := token.Token.unknown
+	mut tok := s.scan()
+	for tok != .eof {
+		if tok == .key_for {
+			mut probe := s
+			if probe.scan() == .name && probe.lit == 'attr' && probe.scan() == .key_in
+				&& probe.scan() == .name && probe.lit == loop_var && probe.scan() == .dot
+				&& probe.scan() == .name && probe.lit == 'attrs' && probe.scan() == .lcbr {
+				loop_start := s.pos
+				mut depth := 0
+				mut part := s.scan()
+				mut loop_end := s.offset
+				for part != .eof {
+					if part == .lcbr {
+						depth++
+					} else if part == .rcbr {
+						depth--
+						if depth == 0 {
+							loop_end = s.offset
+							break
+						}
+					}
+					part = s.scan()
+				}
+				edits << FastcSourceEdit{
+					start:       loop_start
+					end:         loop_end
+					replacement: if field.is_skip { 'is_skip = true' } else { '' }
+				}
+				previous = .rcbr
+				tok = s.scan()
+				continue
+			}
+		}
+		if tok == .dollar && previous == .dot {
+			// Potential computed selector `.$(<var>.name)`.
+			dollar_pos := s.pos
+			open := s.scan()
+			if open == .lpar {
+				name_tok := s.scan()
+				if name_tok == .name && s.lit == loop_var {
+					dot_tok := s.scan()
+					if dot_tok == .dot {
+						member := s.scan()
+						if member == .name && s.lit == 'name' {
+							close := s.scan()
+							if close == .rpar {
+								edits << FastcSourceEdit{
+									start:       dollar_pos
+									end:         s.offset
+									replacement: field_name
+								}
+								previous = .rpar
+								tok = s.scan()
+								continue
+							}
+						}
+					}
+				}
+			}
+			previous = .dollar
+			tok = open
+			continue
+		}
+		if tok == .name && s.lit == loop_var {
+			var_pos := s.pos
+			after := s.scan()
+			if after == .dot {
+				member := s.scan()
+				if member == .name && s.lit == 'name' {
+					edits << FastcSourceEdit{
+						start:       var_pos
+						end:         s.offset
+						replacement: "'${field_name}'"
+					}
+					previous = .name
+					tok = s.scan()
+					continue
+				}
+				if member == .name && s.lit == 'is_embed' {
+					is_embed := field.name.starts_with('__embedded_')
+					edits << FastcSourceEdit{
+						start:       var_pos
+						end:         s.offset
+						replacement: if is_embed { 'true' } else { 'false' }
+					}
+					previous = if is_embed { token.Token.key_true } else { token.Token.key_false }
+					tok = s.scan()
+					continue
+				}
+				if member == .name && s.lit == 'attrs' {
+					after_attrs := s.scan()
+					if after_attrs == .dot {
+						contains_tok := s.scan()
+						contains_name := s.lit
+						open_tok := s.scan()
+						attr_tok := s.scan()
+						attr_name := s.lit.trim('\'"')
+						close_tok := s.scan()
+						if contains_tok == .name && contains_name == 'contains' && open_tok == .lpar
+							&& attr_tok == .string && close_tok == .rpar {
+							matches := field.is_skip && attr_name == 'skip'
+							edits << FastcSourceEdit{
+								start:       var_pos
+								end:         s.offset
+								replacement: if matches { 'true' } else { 'false' }
+							}
+							previous = if matches {
+								token.Token.key_true
+							} else {
+								token.Token.key_false
+							}
+							tok = s.scan()
+							continue
+						}
+					}
+					edits << FastcSourceEdit{
+						start:       var_pos
+						end:         s.offset
+						replacement: if field.is_skip { "['skip']" } else { "['']" }
+					}
+					previous = member
+					tok = after_attrs
+					continue
+				}
+				if member == .name && s.lit == 'typ' {
+					is_tok := s.scan()
+					if is_tok == .key_is {
+						type_c, type_end, next_after := g.read_comptime_is_type(mut s)
+						if type_c != '' {
+							matches := if type_c.starts_with('?') {
+								field.option_value_type == type_c[1..]
+							} else if type_c.starts_with('@') {
+								g.comptime_type_matches(field.typ, type_c[1..], true)
+							} else {
+								field.typ.trim_right('*') == type_c
+							}
+							edits << FastcSourceEdit{
+								start:       var_pos
+								end:         type_end
+								replacement: if matches { 'true' } else { 'false' }
+							}
+							previous = if matches {
+								token.Token.key_true
+							} else {
+								token.Token.key_false
+							}
+							tok = next_after
+							continue
+						}
+						previous = is_tok
+						tok = next_after
+						continue
+					}
+					previous = member
+					tok = is_tok
+					continue
+				}
+				previous = member
+				tok = s.scan()
+				continue
+			}
+			previous = tok
+			tok = after
+			continue
+		}
+		previous = tok
+		tok = s.scan()
+	}
+	return fastc_apply_source_edits(body, edits)
+}
+
+// read_comptime_is_type reads the type on the right of `<var>.typ is <Type>` and
+// returns its C spelling (empty if unrecognized), the source offset just past the
+// type, and the already-scanned token that follows it.
+fn (g &Parser) read_comptime_is_type(mut s scanner.Scanner) (string, int, token.Token) {
+	first := s.scan()
+	if first == .question {
+		name_tok := s.scan()
+		if name_tok != .name {
+			return '', s.offset, s.scan()
+		}
+		name := s.lit
+		name_end := s.offset
+		next_token := s.scan()
+		if next_token == .dot {
+			qualified := s.scan()
+			if qualified == .name {
+				module_name := g.imports[name] or { name }
+				key := fastc_type_key(module_name, s.lit)
+				end := s.offset
+				return '?${fastc_c_declared_type_name(key)}', end, s.scan()
+			}
+			return '', s.offset, s.scan()
+		}
+		return '?${g.resolve_type_name_c(name)}', name_end, next_token
+	}
+	if first == .dollar {
+		group := s.scan()
+		if group == .name || group.is_keyword() {
+			name := s.lit
+			end := s.offset
+			return '@${name}', end, s.scan()
+		}
+		return '', s.offset, s.scan()
+	}
+	if first == .lsbr {
+		bracket := s.scan()
+		if bracket == .rsbr {
+			element := s.scan()
+			if element == .name {
+				element_c := g.resolve_type_name_c(s.lit)
+				end := s.offset
+				return fastc_array_c_type(element_c), end, s.scan()
+			}
+		}
+		return '', s.offset, s.scan()
+	}
+	if first != .name {
+		return '', s.offset, s.scan()
+	}
+	name := s.lit
+	name_end := s.offset
+	next_token := s.scan()
+	if next_token == .dot {
+		qualified := s.scan()
+		if qualified == .name {
+			module_name := g.imports[name] or { name }
+			key := fastc_type_key(module_name, s.lit)
+			end := s.offset
+			return fastc_c_declared_type_name(key), end, s.scan()
+		}
+		return '', s.offset, s.scan()
+	}
+	return g.resolve_type_name_c(name), name_end, next_token
+}
+
+// resolve_type_name_c resolves an unqualified type name to its C spelling: a
+// primitive keeps its own name, a declared type maps through the type key.
+fn (g &Parser) resolve_type_name_c(name string) string {
+	if fastc_primitive_c_type(name) != none {
+		return name
+	}
+	key := fastc_resolve_declared_type_key(g.module_name, name, g.imports, g.declared_types) or {
+		return name
+	}
+	return fastc_c_declared_type_name(key)
+}
+
 fn (mut g Parser) parse_comptime_or() !bool {
 	mut value := g.parse_comptime_and()!
 	for g.tok == .logical_or {
@@ -300,11 +746,67 @@ fn (mut g Parser) parse_comptime_unary() !bool {
 		g.next()
 		return false
 	}
+	if g.tok == .dollar {
+		// `$pkgconfig('lib')`: true when pkg-config reports the library present.
+		g.next()
+		if g.tok != .name || g.lit != 'pkgconfig' {
+			return g.unsupported('compile-time condition `${g.token_source()}`')
+		}
+		g.next()
+		g.expect(.lpar)!
+		if g.tok != .string {
+			return g.unsupported('`$pkgconfig` library name')
+		}
+		library := g.lit.trim('\'"')
+		g.next()
+		g.expect(.rpar)!
+		return pref.comptime_pkgconfig_value(library)
+	}
 	if g.tok != .name {
 		return g.unsupported('compile-time condition `${g.token_source()}`')
 	}
 	name := g.lit
 	g.next()
+	// `T.unaliased_typ is X` (json2's encoder dispatch): a comptime type test on the type
+	// with aliases resolved. After monomorphization `T` is a concrete type name here, so
+	// resolve the leading name's underlying (un-aliased) type before the `is` compare; for
+	// a non-alias it is a no-op.
+	mut unaliased := false
+	mut indirections := false
+	mut pointee_type := false
+	if g.tok == .dot {
+		g.next()
+		if g.tok != .name || g.lit !in ['unaliased_typ', 'indirections', 'pointee_type'] {
+			return g.unsupported('compile-time member `.${g.token_source()}`')
+		}
+		unaliased = g.lit == 'unaliased_typ'
+		indirections = g.lit == 'indirections'
+		pointee_type = g.lit == 'pointee_type'
+		g.next()
+	}
+	if indirections {
+		operator := g.tok
+		if operator !in [.eq, .ne, .lt, .gt, .le, .ge] {
+			return g.unsupported('compile-time `.indirections` comparison')
+		}
+		g.next()
+		if g.tok != .number {
+			return g.unsupported('compile-time `.indirections` value')
+		}
+		expected := g.lit.int()
+		g.next()
+		resolved := g.comptime_named_type(name)
+		actual := resolved.len - resolved.trim_right('*').len
+		return match operator {
+			.eq { actual == expected }
+			.ne { actual != expected }
+			.lt { actual < expected }
+			.gt { actual > expected }
+			.le { actual <= expected }
+			.ge { actual >= expected }
+			else { false }
+		}
+	}
 	if g.tok in [.key_is, .not_is] {
 		operator := g.tok
 		g.next()
@@ -321,14 +823,16 @@ fn (mut g Parser) parse_comptime_unary() !bool {
 		} else {
 			target_type = g.parse_type()!
 		}
-		left_type := if local := g.locals[name] {
-			local.typ.trim_right('*')
-		} else if primitive := fastc_primitive_c_type(name) {
-			primitive
-		} else if name.len <= 3 && name[0].is_capital() {
-			'voidptr'
-		} else {
-			fastc_c_declared_type_name(fastc_type_key(g.module_name, name))
+		mut left_type := g.comptime_named_type(name)
+		if unaliased {
+			left_type = g.underlying_alias_type(left_type)
+		}
+		if pointee_type {
+			left_type = if left_type.ends_with('*') {
+				left_type[..left_type.len - 1]
+			} else {
+				'void'
+			}
 		}
 		matches := g.comptime_type_matches(left_type, target_type, target_is_group)
 		return if operator == .key_is { matches } else { !matches }
@@ -342,6 +846,22 @@ fn (mut g Parser) parse_comptime_unary() !bool {
 	} else {
 		pref.comptime_flag_value(g.prefs, name)
 	}
+}
+
+fn (g &Parser) comptime_named_type(name string) string {
+	if local := g.locals[name] {
+		return local.typ
+	}
+	if primitive := fastc_primitive_c_type(name) {
+		return primitive
+	}
+	if key := fastc_resolve_declared_type_key(g.module_name, name, g.imports, g.declared_types) {
+		return fastc_c_declared_type_name(key)
+	}
+	if name.len <= 3 && name[0].is_capital() {
+		return 'voidptr'
+	}
+	return name
 }
 
 fn (g &Parser) comptime_type_matches(left_type string, target_type string, target_is_group bool) bool {
@@ -410,6 +930,7 @@ fn (mut g Parser) skip_comptime_if_chain() ! {
 		return g.unsupported('compile-time `$else` branch')
 	}
 	g.next()
+
 	g.expect(.key_if)!
 	_ = g.parse_comptime_or()!
 	g.expect(.lcbr)!
@@ -424,6 +945,25 @@ fn (mut g Parser) skip_comptime_if_chain() ! {
 			g.skip_open_block()!
 		}
 	}
+}
+
+// read_comptime_d_expression lowers `$d('key', default)`, the compile-time
+// define value. FastC does not transport `-d key=value` values into its fixed
+// build, so it emits the default expression.
+fn (mut g Parser) read_comptime_d_expression() !string {
+	g.expect(.name)! // consume `d`
+	g.expect(.lpar)!
+	if g.tok != .string {
+		return g.unsupported('`$d` compile-time value key')
+	}
+	g.next() // the define name (only meaningful with `-d name=value`, not transported)
+	g.expect(.comma)!
+	default_value := g.read_expression([token.Token.rpar])!
+	value_type := g.last_expression_type
+	g.expect(.rpar)!
+	g.last_expression_type = value_type
+	g.last_expression = []FastcExpressionToken{}
+	return default_value
 }
 
 fn (g &Parser) dollar_keyword_is(keyword string) bool {
@@ -532,11 +1072,14 @@ fn (g &Parser) comptime_pseudo_expression(name string) ?string {
 
 fn (mut g Parser) read_comptime_if_expression() !string {
 	g.expect(.dollar)!
+	if g.tok == .name && g.lit == 'd' {
+		return g.read_comptime_d_expression()!
+	}
 	g.expect(.key_if)!
 	condition := g.parse_comptime_or()!
 	g.expect(.lcbr)!
 	if condition {
-		value := g.read_expression([token.Token.rcbr])!
+		value := g.read_expression([token.Token.semicolon, token.Token.rcbr])!
 		value_type := g.last_expression_type
 		g.skip_semicolons()
 		g.expect(.rcbr)!
@@ -564,11 +1107,481 @@ fn (mut g Parser) read_comptime_if_expression() !string {
 		return g.read_comptime_if_expression()!
 	}
 	g.expect(.lcbr)!
-	value := g.read_expression([token.Token.rcbr])!
+	value := g.read_expression([token.Token.semicolon, token.Token.rcbr])!
 	value_type := g.last_expression_type
 	g.skip_semicolons()
 	g.expect(.rcbr)!
 	g.last_expression_type = value_type
 	g.last_expression = []FastcExpressionToken{}
 	return value
+}
+
+// --- veb `$veb.html()` template compilation -----------------------------------
+// FastC compiles a handler's HTML template into V that accumulates the rendered
+// output into a string builder local, mirroring the v3 parser's `compile_template_file`
+// but only for the constructs gitly's templates use so far: plain text, `@{expr}` /
+// `@ident` interpolation (HTML-escaped via `veb.filter_html`), `%key` i18n shorthand,
+// `@include`, and `@if` / `@for` / `@else` control flow. Other `@` directives are
+// reported as unsupported.
+
+fn fastc_veb_ident_start(c u8) bool {
+	return (c >= `a` && c <= `z`) || (c >= `A` && c <= `Z`) || c == `_`
+}
+
+fn fastc_veb_ident_part(c u8) bool {
+	return fastc_veb_ident_start(c) || (c >= `0` && c <= `9`)
+}
+
+// fastc_veb_balanced_brace returns the index of the `}` matching the `{` at open_index,
+// or -1 if unbalanced.
+fn fastc_veb_balanced_brace(s string, open_index int) int {
+	mut depth := 0
+	mut i := open_index
+	for i < s.len {
+		if s[i] == `{` {
+			depth++
+		} else if s[i] == `}` {
+			depth--
+			if depth == 0 {
+				return i
+			}
+		}
+		i++
+	}
+	return -1
+}
+
+// fastc_veb_balanced_pair returns the index just past the `close` matching the `open`
+// at open_index (or -1 if unbalanced). Single/double-quoted spans are skipped so
+// brackets inside string literals (`@get('/a]b')`) do not affect nesting.
+fn fastc_veb_balanced_pair(s string, open_index int, open u8, close u8) int {
+	mut depth := 0
+	mut i := open_index
+	mut in_single := false
+	mut in_double := false
+	for i < s.len {
+		ch := s[i]
+		if ch == `\\` {
+			i += 2
+			continue
+		}
+		if in_single {
+			if ch == `'` {
+				in_single = false
+			}
+			i++
+			continue
+		}
+		if in_double {
+			if ch == `"` {
+				in_double = false
+			}
+			i++
+			continue
+		}
+		if ch == `'` {
+			in_single = true
+		} else if ch == `"` {
+			in_double = true
+		} else if ch == open {
+			depth++
+		} else if ch == close {
+			depth--
+			if depth == 0 {
+				return i + 1
+			}
+		}
+		i++
+	}
+	return -1
+}
+
+// fastc_veb_at_expr_end returns the index just past a bare `@` expression beginning at
+// `start` (the char after `@`): an identifier plus any `.field` member accesses,
+// `[index]` subscripts and `(call)` suffixes (`@a.b.c`, `@t.id`, `@f(x)`), mirroring the
+// v parser's `find_tmpl_complex_at_expr_end`. Returns `start` if not an identifier.
+fn fastc_veb_at_expr_end(s string, start int) int {
+	if start >= s.len || !fastc_veb_ident_start(s[start]) {
+		return start
+	}
+	mut i := start + 1
+	for i < s.len && fastc_veb_ident_part(s[i]) {
+		i++
+	}
+	for i < s.len {
+		if s[i] == `[` {
+			end := fastc_veb_balanced_pair(s, i, `[`, `]`)
+			if end == -1 {
+				return i
+			}
+			i = end
+			continue
+		}
+		if s[i] == `(` {
+			end := fastc_veb_balanced_pair(s, i, `(`, `)`)
+			if end == -1 {
+				return i
+			}
+			i = end
+			continue
+		}
+		if i + 1 < s.len && s[i] == `.` && fastc_veb_ident_start(s[i + 1]) {
+			i += 2
+			for i < s.len && fastc_veb_ident_part(s[i]) {
+				i++
+			}
+			continue
+		}
+		break
+	}
+	return i
+}
+
+// fastc_veb_expand_tr rewrites veb's `%key` / `%raw key` translation shorthand into
+// `@{...}` interpolations of `veb.tr(...)`, mirroring the v3 parser's shorthand.
+fn fastc_veb_expand_tr(line string, ctx_name string) string {
+	if !line.contains('%') {
+		return line
+	}
+	mut out := ''
+	mut i := 0
+	for i < line.len {
+		if line[i] == `%` {
+			mut is_raw := false
+			mut start := i + 1
+			if i + 5 <= line.len && line[i + 1..i + 5] == 'raw ' {
+				is_raw = true
+				start = i + 5
+			}
+			mut end := start
+			for end < line.len && fastc_veb_ident_part(line[end]) {
+				end++
+			}
+			key := line[start..end]
+			if key.len > 0 {
+				if is_raw {
+					out += '@{veb.raw(veb.tr(${ctx_name}.lang.str(), "${key}"))}'
+				} else {
+					out += '@{veb.tr(${ctx_name}.lang.str(), "${key}")}'
+				}
+				i = end
+				continue
+			}
+		}
+		out += line[i].ascii_str()
+		i++
+	}
+	return out
+}
+
+// fastc_veb_line_content converts one template text line into the content of a V
+// single-quoted string literal: literal characters are escaped, `@{expr}` / `@ident`
+// become `${veb.filter_html(expr)}` interpolations, and `@@` an literal `@`.
+fn fastc_veb_line_content(line string, ctx_name string) string {
+	expanded := fastc_veb_expand_tr(line, ctx_name)
+	mut out := ''
+	mut i := 0
+	for i < expanded.len {
+		ch := expanded[i]
+		if ch == `\\` {
+			out += '\\\\'
+			i++
+			continue
+		}
+		if ch == `'` {
+			out += "\\'"
+			i++
+			continue
+		}
+		if ch == `$` {
+			// A literal `$` in the template must not become interpolation in the
+			// generated V string.
+			out += r'\$'
+			i++
+			continue
+		}
+		if ch == `@` {
+			if i + 1 < expanded.len && expanded[i + 1] == `@` {
+				out += '@'
+				i += 2
+				continue
+			}
+			if i + 1 < expanded.len && expanded[i + 1] == `{` {
+				close := fastc_veb_balanced_brace(expanded, i + 1)
+				if close != -1 {
+					expr := expanded[i + 2..close]
+					out += r'\$' + '{veb.filter_html(' + expr + ')}'
+					i = close + 1
+					continue
+				}
+			}
+			if i + 1 < expanded.len && fastc_veb_ident_start(expanded[i + 1]) {
+				// A bare `@expr` interpolation covers the whole member/subscript/call
+				// chain (`@author.username`, `@t.id`, `@f(x)`), not just the leading name.
+				end := fastc_veb_at_expr_end(expanded, i + 1)
+				expr := expanded[i + 1..end]
+				out += r'\$' + '{veb.filter_html(' + expr + ')}'
+				i = end
+				continue
+			}
+			out += '@'
+			i++
+			continue
+		}
+		out += ch.ascii_str()
+		i++
+	}
+	return out
+}
+
+// fastc_veb_read_template_lines reads a template file, inlining `@include 'path'`
+// directives relative to the including file's directory.
+fn fastc_veb_read_template_lines(path string, depth int) ![]string {
+	if depth > 32 {
+		return error('`@include` recursion too deep')
+	}
+	raw := os.read_lines(path) or { return error('cannot read template `${path}`') }
+	base_dir := os.dir(os.real_path(path))
+	mut out := []string{}
+	for line in raw {
+		trimmed := line.trim_space()
+		if trimmed.starts_with('@include ') {
+			mut inc := trimmed['@include '.len..].trim_space()
+			inc = inc.trim_left('\'"').trim_right('\'"')
+			inc_path := os.join_path_single(base_dir, inc)
+			included := fastc_veb_read_template_lines(inc_path, depth + 1)!
+			for included_line in included {
+				out << included_line
+			}
+			continue
+		}
+		out << line
+	}
+	return out
+}
+
+// fastc_veb_compile_template compiles an HTML template into V source that accumulates
+// the rendered output into `bname`.
+// fastc_veb_append_stmt returns `<bname> += '<content>'` as a V statement. The single
+// quotes are concatenated rather than written as `\'` inside an interpolated string
+// literal, which FastC's own string lowering mis-renders.
+fn fastc_veb_append_stmt(bname string, content string) string {
+	q := "'"
+	return '${bname} += ' + q + content + q + '\n'
+}
+
+fn fastc_veb_compile_template(path string, bname string, ctx_name string) !string {
+	lines := fastc_veb_read_template_lines(path, 0)!
+	mut out := 'mut ${bname} := ' + "''" + '\n'
+	mut current := ''
+	// Distinguishes control-flow braces (`@if`/`@for`, emitted as V `{`/`}`) from HTML
+	// block shorthands (`.class {` / `span.x {` / `#id {`, emitted as <div>/<span> text)
+	// so a closing `}` line resolves to the right one, mirroring the v parser's
+	// `brace_block_kinds` stack.
+	mut block_kinds := []string{}
+	for line in lines {
+		trimmed := line.trim_space()
+		if trimmed.starts_with('@if ') {
+			out += fastc_veb_append_stmt(bname, current)
+			current = ''
+			header := trimmed['@if '.len..].trim_right('{').trim_space()
+			out += 'if ${header} {\n'
+			block_kinds << 'control'
+			continue
+		}
+		if trimmed.starts_with('@for ') {
+			out += fastc_veb_append_stmt(bname, current)
+			current = ''
+			header := trimmed['@for '.len..].trim_right('{').trim_space()
+			out += 'for ${header} {\n'
+			block_kinds << 'control'
+			continue
+		}
+		if trimmed == '@else' || trimmed == '@else {' || trimmed == '@else{'
+			|| trimmed.starts_with('@else if ') {
+			out += fastc_veb_append_stmt(bname, current)
+			current = ''
+			rest := trimmed['@else'.len..].trim_right('{').trim_space()
+			out += '} else ${rest} {\n'
+			continue
+		}
+		if trimmed == '@end' {
+			out += fastc_veb_append_stmt(bname, current)
+			current = ''
+			out += '}\n'
+			if block_kinds.len > 0 && block_kinds.last() == 'control' {
+				block_kinds.delete_last()
+			}
+			continue
+		}
+		if trimmed == '}' {
+			// A closing HTML block (`</div>` / `</span>` text) unless it matches a
+			// control block opened with a trailing `{`, which closes as V `}`.
+			if block_kinds.len > 0 && block_kinds.last() == 'span' {
+				current += '</span>' + r'\n'
+				block_kinds.delete_last()
+			} else if block_kinds.len > 0 && block_kinds.last() == 'div' {
+				current += '</div>' + r'\n'
+				block_kinds.delete_last()
+			} else {
+				out += fastc_veb_append_stmt(bname, current)
+				current = ''
+				out += '}\n'
+				if block_kinds.len > 0 && block_kinds.last() == 'control' {
+					block_kinds.delete_last()
+				}
+			}
+			continue
+		}
+		if trimmed.starts_with('span.') && trimmed.ends_with('{') {
+			// `span.header {` => `<span class="header">`
+			class := trimmed['span.'.len..trimmed.len - 1].trim_space()
+			current += '<span class="${class}">' + r'\n'
+			block_kinds << 'span'
+			continue
+		}
+		if trimmed.starts_with('.') && trimmed.ends_with('{') {
+			// `.header {` => `<div class="header">`
+			class := trimmed[1..trimmed.len - 1].trim_space()
+			current += '<div class="${class}">' + r'\n'
+			block_kinds << 'div'
+			continue
+		}
+		if trimmed.starts_with('#') && trimmed.ends_with('{') {
+			// `#header {` => `<div id="header">`
+			id := trimmed[1..trimmed.len - 1].trim_space()
+			current += '<div id="${id}">' + r'\n'
+			block_kinds << 'div'
+			continue
+		}
+		if trimmed.starts_with('@css ') || trimmed.starts_with('@js ') {
+			// `@css 'url'` / `@js 'url'` expand to a literal <link>/<script> tag whose
+			// URL is emitted verbatim (mirrors the v parser's tmpl.v), so treat the
+			// generated HTML as ordinary template content.
+			q := "'"
+			is_css := trimmed.starts_with('@css ')
+			prefix := if is_css { '@css '.len } else { '@js '.len }
+			url := trimmed[prefix..].trim_space().trim(q)
+			line_html := if is_css {
+				'<link href="${url}" rel="stylesheet" type="text/css">'
+			} else {
+				'<script src="${url}"></script>'
+			}
+			current += fastc_veb_line_content(line_html, ctx_name) + r'\n'
+			continue
+		}
+		// A standalone `@ident` line (control directives `@if`/`@for`/... are handled above)
+		// is a bare interpolation like `@source`, not a directive — render it as content.
+		// Only a `@` followed by a non-identifier is a malformed/unsupported directive.
+		if trimmed.starts_with('@') && !trimmed.starts_with('@@') && !trimmed.starts_with('@{')
+			&& !(trimmed.len > 1 && fastc_veb_ident_start(trimmed[1])) {
+			return error('unsupported template directive `${trimmed}`')
+		}
+		current += fastc_veb_line_content(line, ctx_name) + r'\n'
+	}
+	out += fastc_veb_append_stmt(bname, current)
+	return out
+}
+
+// fastc_veb_template_path resolves the current handler's HTML template file
+// (`templates/<fn>.html`, with a directory-relative and a vmod-root fallback).
+fn (g &Parser) fastc_veb_template_path() ?string {
+	dir := os.dir(os.real_path(g.path))
+	fn_name := g.current_function
+	mut candidates := [
+		os.join_path(dir, 'templates', '${fn_name}.html'),
+		os.join_path_single(dir, '${fn_name}.html'),
+	]
+	vmod_root := fastc_vmod_root_for_file(g.path)
+	if vmod_root != '' && vmod_root != dir {
+		candidates << os.join_path(vmod_root, 'templates', '${fn_name}.html')
+	}
+	for candidate in candidates {
+		if os.exists(candidate) {
+			return candidate
+		}
+	}
+	return none
+}
+
+// fastc_veb_resolve_explicit_path resolves an explicit `$veb.html('path')` template path,
+// relative to the source file's directory (and the vmod root), or as given.
+fn (g &Parser) fastc_veb_resolve_explicit_path(path string) ?string {
+	dir := os.dir(os.real_path(g.path))
+	mut candidates := [
+		os.join_path_single(dir, path),
+		path,
+	]
+	vmod_root := fastc_vmod_root_for_file(g.path)
+	if vmod_root != '' && vmod_root != dir {
+		candidates << os.join_path_single(vmod_root, path)
+	}
+	for candidate in candidates {
+		if os.exists(candidate) {
+			return candidate
+		}
+	}
+	return none
+}
+
+// fastc_veb_context_name returns the veb `Context` argument name in scope (the handler's
+// `mut ctx Context` parameter), defaulting to `ctx`.
+fn (g &Parser) fastc_veb_context_name() string {
+	if 'ctx' in g.locals {
+		return 'ctx'
+	}
+	for name, local in g.locals {
+		base := local.typ.trim_right('*')
+		if base == 'Context' || base.ends_with('__Context') {
+			return name
+		}
+	}
+	return 'ctx'
+}
+
+// parse_veb_html_return lowers `return $veb.html()`: it compiles the handler's template
+// into builder statements, then returns `<ctx>.html(<builder>)`.
+fn (mut g Parser) parse_veb_html_return() !bool {
+	g.next() // consume `$`
+	if g.tok != .name || g.lit != 'veb' {
+		return g.unsupported('comptime `$` expression')
+	}
+	g.next() // consume `veb`
+	g.expect(.dot)!
+	if g.tok != .name || g.lit != 'html' {
+		return g.unsupported('`$veb.${g.lit}()` is not supported (only `$veb.html()`)')
+	}
+	g.next() // consume `html`
+	g.expect(.lpar)!
+	mut explicit_path := ''
+	if g.tok == .string {
+		explicit_path = g.lit.trim('\'"')
+		g.next()
+	}
+	if g.tok != .rpar {
+		return g.unsupported('`$veb.html(...)` argument must be a string-literal path')
+	}
+	g.expect(.rpar)!
+	g.consume_statement_end()
+	tmpl_path := if explicit_path != '' {
+		g.fastc_veb_resolve_explicit_path(explicit_path) or {
+			return g.unsupported('veb template `${explicit_path}` not found')
+		}
+	} else {
+		g.fastc_veb_template_path() or {
+			return g.unsupported('veb template for `${g.current_function}` not found')
+		}
+	}
+	ctx_name := g.fastc_veb_context_name()
+	bname := '__v_fastc_veb_tmpl'
+	mut lowering := fastc_veb_compile_template(tmpl_path, bname, ctx_name) or {
+		return g.unsupported('veb template `${tmpl_path}`: ${err.msg()}')
+	}
+	lowering += 'return ${ctx_name}.html(${bname})\n'
+	g.write_line('{')
+	g.indent++
+	g.emit_orm_lowering_statements(lowering)!
+	g.indent--
+	g.write_line('}')
+	return true
 }

--- a/vlib/v3/gen/fastc/decl.v
+++ b/vlib/v3/gen/fastc/decl.v
@@ -141,8 +141,12 @@ fn collect_constant_names(source string, path string, module_name string, prefs 
 						continue
 					}
 					if nested_depth == 0 && at_declaration_start && tok == .name {
-						fastc_register_constant(module_name, scan.lit, is_public, path, mut
-							constants, mut public_constants)!
+						// `const C.name type` declares an external C constant; the C
+						// headers already provide the symbol, so FastC does not track it.
+						if scan.lit != 'C' {
+							fastc_register_constant(module_name, scan.lit, is_public, path, mut
+								constants, mut public_constants)!
+						}
 						at_declaration_start = false
 					}
 					if tok in [.lpar, .lsbr, .lcbr] {
@@ -157,8 +161,12 @@ fn collect_constant_names(source string, path string, module_name string, prefs 
 			if tok != .name {
 				return error('fastc parser does not support constant declaration in ${path}')
 			}
-			fastc_register_constant(module_name, scan.lit, is_public, path, mut constants, mut
-				public_constants)!
+			// `const C.name type` declares an external C constant; the C headers
+			// already provide the symbol, so FastC does not track it.
+			if scan.lit != 'C' {
+				fastc_register_constant(module_name, scan.lit, is_public, path, mut constants, mut
+					public_constants)!
+			}
 			continue
 		}
 		if tok == .lcbr {
@@ -256,9 +264,11 @@ fn fastc_register_global(header FastcSourceHeader, name string, is_public bool, 
 	}
 }
 
-fn fastc_generate_global_declarations(sources []FastcSourceFile, prefs &pref.Preferences, declared_types map[string]bool, declared_type_c_names map[string]string, fastc_prefixed_c_names []string, declared_kinds map[string]FastcDeclaredTypeKind, enum_flags map[string]bool, alias_base_types map[string]string, struct_fields map[string]map[string]string, struct_field_info map[string][]FastcStructField, functions map[string]FastcFunctionSignature, constants map[string]string, constant_values map[string]string, public_constants map[string]bool, constant_types map[string]string, globals map[string]string, public_globals map[string]bool, mut global_types map[string]string) !FastcGlobalDeclarations {
+fn fastc_generate_global_declarations(sources []FastcSourceFile, prefs &pref.Preferences, declared_types map[string]bool, declared_type_c_names map[string]string, fastc_prefixed_c_names []string, declared_kinds map[string]FastcDeclaredTypeKind, enum_flags map[string]bool, enum_field_types map[string]string, alias_base_types map[string]string, struct_fields map[string]map[string]string, struct_field_info map[string][]FastcStructField, functions map[string]FastcFunctionSignature, constants map[string]string, constant_values map[string]string, public_constants map[string]bool, constant_types map[string]string, globals map[string]string, public_globals map[string]bool, mut global_types map[string]string) !FastcGlobalDeclarations {
 	mut out := strings.new_builder(1024)
 	mut module_initializers := map[string]string{}
+	mut composite_types := map[string]bool{}
+	mut fixed_array_types := map[string]string{}
 	helper_has_c_functions := fastc_functions_declare_c(functions)
 	ordered_sources := fastc_sources_in_dependency_order(sources)!
 	for source_file in ordered_sources {
@@ -282,6 +292,7 @@ fn fastc_generate_global_declarations(sources []FastcSourceFile, prefs &pref.Pre
 			thread_value_types:           map[string]string{}
 			declared_kinds:               declared_kinds
 			enum_flags:                   enum_flags
+			enum_field_types:             enum_field_types
 			alias_base_types:             alias_base_types
 			struct_fields:                struct_fields
 			struct_field_info:            struct_field_info
@@ -297,11 +308,19 @@ fn fastc_generate_global_declarations(sources []FastcSourceFile, prefs &pref.Pre
 			functions:                    functions
 			constant_types:               constant_types
 			global_types:                 global_types
+			composite_types:              map[string]bool{}
+			fixed_array_types:            map[string]string{}
 		}
 		gen.s.init(file, source_file.source)
 		gen.next()
 		gen.parse_selected_global_declarations(mut out, mut initializers, false)!
 		global_types = gen.global_types.clone()
+		for name, _ in gen.composite_types {
+			composite_types[name] = true
+		}
+		for name, array_type in gen.fixed_array_types {
+			fixed_array_types[name] = array_type
+		}
 		if initializers.len > 0 {
 			previous := module_initializers[source_file.header.module_name] or { '' }
 			module_initializers[source_file.header.module_name] = previous + initializers.str()
@@ -313,6 +332,8 @@ fn fastc_generate_global_declarations(sources []FastcSourceFile, prefs &pref.Pre
 	return FastcGlobalDeclarations{
 		declarations:        out.str()
 		module_initializers: module_initializers
+		composite_types:     composite_types
+		fixed_array_types:   fixed_array_types
 	}
 }
 
@@ -326,6 +347,13 @@ fn (mut g Parser) parse_selected_global_declarations(mut out strings.Builder, mu
 		}
 		if g.tok == .eof {
 			break
+		}
+		if g.tok == .key_const {
+			// Skip constant declarations wholesale: their initializer may contain a
+			// `$d(...)`/`$if` that this pass would otherwise mistake for a top-level
+			// comptime global block. Constants are handled by their own pass.
+			g.skip_top_level_declaration()!
+			continue
 		}
 		if g.tok == .dollar {
 			g.parse_selected_comptime_global_declarations(mut out, mut initializers)!
@@ -348,6 +376,7 @@ fn (mut g Parser) parse_selected_global_declarations(mut out strings.Builder, mu
 
 fn (mut g Parser) parse_selected_comptime_global_declarations(mut out strings.Builder, mut initializers strings.Builder) ! {
 	g.expect(.dollar)!
+
 	g.expect(.key_if)!
 	condition := g.parse_comptime_or()!
 	g.expect(.lcbr)!
@@ -435,7 +464,17 @@ fn (mut g Parser) parse_global_declaration(mut out strings.Builder, mut initiali
 	g.skip_semicolons()
 }
 
-fn fastc_render_struct_field_defaults(prefs &pref.Preferences, declared_types map[string]bool, declared_type_c_names map[string]string, fastc_prefixed_c_names []string, declared_kinds map[string]FastcDeclaredTypeKind, enum_flags map[string]bool, alias_base_types map[string]string, struct_fields map[string]map[string]string, mut struct_field_info map[string][]FastcStructField, functions map[string]FastcFunctionSignature, constants map[string]string, public_constants map[string]bool, constant_types map[string]string, globals map[string]string, public_globals map[string]bool, global_types map[string]string) ! {
+// fastc_map_field_default renders the empty-`map[K]V` value used to seed a map
+// struct field's default (matching `map[K]V{}`), or '' when the type is not a
+// resolvable map. Kept as a helper so the caller avoids a multi-return option in
+// an `if` guard, which the FastC self-host does not accept.
+fn fastc_map_field_default(typ string, pointer_bits int) string {
+	key_type, value_type := fastc_map_key_value_types(typ) or { return '' }
+	hash_fn, eq_fn, clone_fn, free_fn := fastc_map_runtime_functions(key_type, pointer_bits)
+	return '(builtin__new_map(sizeof(${fastc_runtime_c_type(key_type)}), sizeof(${fastc_runtime_c_type(value_type)}), &${hash_fn}, &${eq_fn}, &${clone_fn}, &${free_fn}))'
+}
+
+fn fastc_render_struct_field_defaults(prefs &pref.Preferences, declared_types map[string]bool, declared_type_c_names map[string]string, fastc_prefixed_c_names []string, declared_kinds map[string]FastcDeclaredTypeKind, enum_flags map[string]bool, enum_field_types map[string]string, alias_base_types map[string]string, struct_fields map[string]map[string]string, mut struct_field_info map[string][]FastcStructField, functions map[string]FastcFunctionSignature, constants map[string]string, public_constants map[string]bool, constant_types map[string]string, globals map[string]string, public_globals map[string]bool, global_types map[string]string, sum_types map[string]bool) ! {
 	helper_has_c_functions := fastc_functions_declare_c(functions)
 	mut type_names := struct_field_info.keys()
 	type_names.sort()
@@ -443,6 +482,32 @@ fn fastc_render_struct_field_defaults(prefs &pref.Preferences, declared_types ma
 		mut fields := struct_field_info[type_name].clone()
 		for mut field in fields {
 			if field.default_source == '' {
+				// A dynamic-array field with no explicit default still needs a properly
+				// sized empty value, otherwise `X{}` construction zeroes it (including
+				// its element_size) and a later `arr << x` copies zero bytes per element.
+				// Mirror the `[]T{}` rendering. Only the real-builtin runtime has a
+				// sized array; the toy runtime uses a different representation.
+				field_layout := field.typ.trim_right('*')
+				if prefs.building_v && field_layout.starts_with('Array_') {
+					if element_type := fastc_array_element_type(field.typ) {
+						// A `_ptr`-encoded element type is not a real C type name; every
+						// pointer is the same size, so measure `voidptr` for sizeof.
+						element_sizeof := if element_type.ends_with('_ptr') {
+							'voidptr'
+						} else {
+							element_type
+						}
+						field.default_value = '((${field_layout})builtin____new_array(0, 0, sizeof(${element_sizeof})))'
+					}
+				} else if prefs.building_v && field_layout.starts_with('Map_') {
+					// A map field zeroes the same way: without a real `new_map`, its key
+					// and value sizes and hash/eq function pointers are null, so any
+					// insert/lookup misbehaves. Mirror the `map[K]V{}` rendering.
+					map_default := fastc_map_field_default(field.typ, prefs.target.pointer_bits)
+					if map_default != '' {
+						field.default_value = map_default
+					}
+				}
 				continue
 			}
 			default_path := '${field.path}:${field.name}:default'
@@ -465,9 +530,11 @@ fn fastc_render_struct_field_defaults(prefs &pref.Preferences, declared_types ma
 				thread_value_types:           map[string]string{}
 				declared_kinds:               declared_kinds
 				enum_flags:                   enum_flags
+				enum_field_types:             enum_field_types
 				alias_base_types:             alias_base_types
 				struct_fields:                struct_fields
 				struct_field_info:            struct_field_info
+				sum_types:                    sum_types
 				constants:                    constants
 				public_constants:             public_constants
 				globals:                      globals
@@ -486,6 +553,15 @@ fn fastc_render_struct_field_defaults(prefs &pref.Preferences, declared_types ma
 			gen.next()
 			gen.expected_expression_type = field.typ
 			field.default_value = gen.read_expression([token.Token.semicolon, token.Token.eof])!
+			// A variant literal (`value Primitive = Null{}`) defaulting a sum-type or
+			// interface field must be boxed into the field's representation, mirroring
+			// the assignment/argument paths; a bare `(Variant){}` is not assignable to a
+			// boxed `{_object,_typ,_methods}` field.
+			default_actual_type := gen.last_expression_type
+			if gen.should_box_variant(field.typ, default_actual_type) {
+				field.default_value = gen.interface_value_expression(field.typ,
+					default_actual_type, field.default_value)
+			}
 			if gen.tok == .semicolon {
 				gen.next()
 			}
@@ -501,8 +577,10 @@ fn fastc_render_struct_field_defaults(prefs &pref.Preferences, declared_types ma
 	}
 }
 
-fn fastc_generate_constant_declarations(sources []FastcSourceFile, prefs &pref.Preferences, declared_types map[string]bool, declared_type_c_names map[string]string, fastc_prefixed_c_names []string, declared_kinds map[string]FastcDeclaredTypeKind, enum_flags map[string]bool, alias_base_types map[string]string, struct_fields map[string]map[string]string, struct_field_info map[string][]FastcStructField, functions map[string]FastcFunctionSignature, constants map[string]string, public_constants map[string]bool, globals map[string]string, public_globals map[string]bool, mut constant_types map[string]string) !FastcConstantDeclarations {
+fn fastc_generate_constant_declarations(sources []FastcSourceFile, prefs &pref.Preferences, declared_types map[string]bool, declared_type_c_names map[string]string, fastc_prefixed_c_names []string, declared_kinds map[string]FastcDeclaredTypeKind, enum_flags map[string]bool, enum_field_types map[string]string, alias_base_types map[string]string, struct_fields map[string]map[string]string, struct_field_info map[string][]FastcStructField, functions map[string]FastcFunctionSignature, constants map[string]string, public_constants map[string]bool, globals map[string]string, public_globals map[string]bool, mut constant_types map[string]string) !FastcConstantDeclarations {
 	mut values := []FastcConstantValue{}
+	mut composite_types := map[string]bool{}
+	mut fixed_array_types := map[string]string{}
 	helper_has_c_functions := fastc_functions_declare_c(functions)
 	ordered_sources := fastc_sources_in_dependency_order(sources)!
 	for source_file in ordered_sources {
@@ -525,6 +603,7 @@ fn fastc_generate_constant_declarations(sources []FastcSourceFile, prefs &pref.P
 			thread_value_types:           map[string]string{}
 			declared_kinds:               declared_kinds
 			enum_flags:                   enum_flags
+			enum_field_types:             enum_field_types
 			alias_base_types:             alias_base_types
 			struct_fields:                struct_fields
 			struct_field_info:            struct_field_info
@@ -538,6 +617,8 @@ fn fastc_generate_constant_declarations(sources []FastcSourceFile, prefs &pref.P
 			protos:                       strings.new_builder(0)
 			functions:                    functions
 			constant_types:               constant_types
+			composite_types:              map[string]bool{}
+			fixed_array_types:            map[string]string{}
 		}
 		gen.s.init(file, source_file.source)
 		gen.next()
@@ -547,6 +628,12 @@ fn fastc_generate_constant_declarations(sources []FastcSourceFile, prefs &pref.P
 			return error('fastc scanner error at byte ${diagnostic.offset} in ${source_file.path}: ${diagnostic.message}')
 		}
 		constant_types = gen.constant_types.clone()
+		for name, _ in gen.composite_types {
+			composite_types[name] = true
+		}
+		for name, array_type in gen.fixed_array_types {
+			fixed_array_types[name] = array_type
+		}
 	}
 	mut runtime_constants := map[string]bool{}
 	for value in values {
@@ -612,6 +699,8 @@ fn fastc_generate_constant_declarations(sources []FastcSourceFile, prefs &pref.P
 		declarations:        declarations.str()
 		module_initializers: module_initializers
 		compile_time_values: compile_time_values
+		composite_types:     composite_types
+		fixed_array_types:   fixed_array_types
 	}
 }
 
@@ -634,6 +723,12 @@ fn (mut g Parser) parse_selected_constant_declarations(mut values []FastcConstan
 			g.parse_constant_declaration(mut values)!
 			continue
 		}
+		if g.tok == .key_global {
+			// A global initializer may contain a `$d(...)`/`$if`; skip the whole
+			// declaration so this pass does not mistake it for a comptime block.
+			g.skip_top_level_declaration()!
+			continue
+		}
 		if g.tok == .lcbr {
 			g.skip_balanced(.lcbr, .rcbr)!
 			continue
@@ -647,6 +742,7 @@ fn (mut g Parser) parse_selected_constant_declarations(mut values []FastcConstan
 
 fn (mut g Parser) parse_selected_comptime_constant_declarations(mut values []FastcConstantValue) ! {
 	g.expect(.dollar)!
+
 	g.expect(.key_if)!
 	condition := g.parse_comptime_or()!
 	g.expect(.lcbr)!
@@ -727,6 +823,14 @@ fn (mut g Parser) parse_one_constant(mut values []FastcConstantValue, stops []to
 	}
 	name := g.lit
 	g.next()
+	if name == 'C' && g.tok == .dot {
+		// `const C.name type` declares an external C constant; the C headers
+		// already provide the symbol, so FastC skips the whole declaration.
+		for g.tok !in stops && g.tok != .eof {
+			g.next()
+		}
+		return
+	}
 	if g.tok !in [.assign, .decl_assign] {
 		return g.unsupported('constant `${name}` requires `=` or `:=` after its name, got `${g.token_source()}`')
 	}
@@ -811,6 +915,7 @@ fn fastc_generate_type_declarations(sources []FastcSourceFile, prefs &pref.Prefe
 	mut bodies := strings.new_builder(4096)
 	mut enum_infos := []FastcEnumInfo{}
 	mut alias_base_types := map[string]string{}
+	mut sum_types := map[string]bool{}
 	mut keys := declared_kinds.keys()
 	keys.sort()
 	for type_id, key in keys {
@@ -823,11 +928,19 @@ fn fastc_generate_type_declarations(sources []FastcSourceFile, prefs &pref.Prefe
 			.alias_ {}
 		}
 	}
+	// Primitive scalars can be sum-type variants (`type Any = int | bool | ...`).
+	// They are never declared types, so give them stable type ids in a high range
+	// that cannot collide with the sequential declared-type ids above. Construction
+	// and `match` both reference `__v_typeid_<primitive>`, so the exact value only
+	// has to be unique and consistent.
+	for offset, primitive in fastc_boxed_primitive_types {
+		out.writeln('#define __v_typeid_${primitive} ${u32(0x40000000) + u32(offset)}')
+	}
 	out.writeln('')
 	for source_file in sources {
 		fastc_emit_source_type_declarations(source_file, prefs, declared_types, declared_kinds,
 			constants, public_constants, mut struct_fields, mut struct_field_info, mut
-			composite_types, mut alias_base_types, mut enum_infos, mut bodies)!
+			composite_types, mut alias_base_types, mut sum_types, mut enum_infos, mut bodies)!
 	}
 	mut composite_names := composite_types.keys()
 	composite_names.sort()
@@ -836,7 +949,7 @@ fn fastc_generate_type_declarations(sources []FastcSourceFile, prefs &pref.Prefe
 		out.writeln('typedef ${base} ${composite_name};')
 	}
 	out.writeln('')
-	mut type_bodies := bodies.str()
+	mut type_bodies := fastc_hoist_c_type_aliases(bodies.str())
 	if prefs.building_v {
 		// Index the by-value composite C spellings once. The ordering pass below
 		// queries this per struct field on every pass; the previous linear scan
@@ -849,17 +962,58 @@ fn fastc_generate_type_declarations(sources []FastcSourceFile, prefs &pref.Prefe
 			}
 		}
 		type_bodies = fastc_order_c_composite_definitions(type_bodies, struct_fields,
-			by_value_composite_names)
+			by_value_composite_names, alias_base_types)
 	}
 	out.write_string(type_bodies)
+	// Index each enum field name to its enum's C type, so an inferred map literal
+	// with `.field` shorthand keys (e.g. `{ .md_block_hr: 'hr' }`) can recover the
+	// key type. First declaration wins on the rare shared field name.
+	mut enum_field_types := map[string]string{}
+	for info in enum_infos {
+		for field in info.fields {
+			if field !in enum_field_types {
+				enum_field_types[field] = info.c_name
+			}
+		}
+	}
 	return FastcTypeDeclarations{
 		declarations:        out.str()
 		enum_string_helpers: fastc_generate_enum_string_helpers(enum_infos)
 		alias_base_types:    alias_base_types
+		enum_field_types:    enum_field_types
+		sum_types:           sum_types
 	}
 }
 
-fn fastc_order_c_composite_definitions(source string, struct_fields map[string]map[string]string, by_value_composite_names map[string]bool) string {
+fn fastc_hoist_c_type_aliases(source string) string {
+	mut defines := strings.new_builder(256)
+	mut aliases := strings.new_builder(256)
+	mut function_aliases := strings.new_builder(256)
+	mut bodies := strings.new_builder(source.len)
+	for line in source.split('\n') {
+		if line.starts_with('#define ') {
+			defines.writeln(line)
+		} else if line.starts_with('typedef ') && line.ends_with(';') {
+			if line.contains('(*') {
+				function_aliases.writeln(line)
+			} else {
+				aliases.writeln(line)
+			}
+		} else {
+			bodies.writeln(line)
+		}
+	}
+	if defines.len == 0 && aliases.len == 0 && function_aliases.len == 0 {
+		return source
+	}
+	defines.write_string(aliases.str())
+	defines.write_string(function_aliases.str())
+	defines.writeln('')
+	defines.write_string(bodies.str())
+	return defines.str()
+}
+
+fn fastc_order_c_composite_definitions(source string, struct_fields map[string]map[string]string, by_value_composite_names map[string]bool, alias_base_types map[string]string) string {
 	mut ordered := source
 	mut changed := true
 	mut passes := 0
@@ -874,7 +1028,8 @@ fn fastc_order_c_composite_definitions(source string, struct_fields map[string]m
 		mut positions := fastc_composite_definition_positions(ordered)
 		for dependent, fields in struct_fields {
 			for _, field_type in fields {
-				dependency := fastc_by_value_composite_type(field_type, by_value_composite_names)
+				dependency := fastc_by_value_composite_type(field_type, by_value_composite_names,
+					alias_base_types)
 				if dependency == '' || dependency == dependent {
 					continue
 				}
@@ -933,7 +1088,7 @@ fn fastc_composite_definition_positions(source string) map[string]int {
 	return positions
 }
 
-fn fastc_by_value_composite_type(field_type string, by_value_composite_names map[string]bool) string {
+fn fastc_by_value_composite_type(field_type string, by_value_composite_names map[string]bool, alias_base_types map[string]string) string {
 	if field_type.ends_with('*') || field_type.starts_with('Array_')
 		|| field_type.starts_with('Map_') {
 		return ''
@@ -941,6 +1096,17 @@ fn fastc_by_value_composite_type(field_type string, by_value_composite_names map
 	mut candidate := field_type
 	if element_type := fastc_fixed_array_element_type(candidate) {
 		candidate = element_type
+	}
+	mut seen_aliases := map[string]bool{}
+	for {
+		if candidate !in alias_base_types || candidate in seen_aliases {
+			break
+		}
+		seen_aliases[candidate] = true
+		candidate = alias_base_types[candidate]
+		if candidate.ends_with('*') {
+			return ''
+		}
 	}
 	if candidate in by_value_composite_names {
 		return candidate
@@ -988,7 +1154,7 @@ fn fastc_c_composite_definition_end(source string, start int) ?int {
 	return none
 }
 
-fn fastc_emit_source_type_declarations(source_file FastcSourceFile, prefs &pref.Preferences, declared_types map[string]bool, declared_kinds map[string]FastcDeclaredTypeKind, constants map[string]string, public_constants map[string]bool, mut struct_fields map[string]map[string]string, mut struct_field_info map[string][]FastcStructField, mut composite_types map[string]bool, mut alias_base_types map[string]string, mut enum_infos []FastcEnumInfo, mut out strings.Builder) ! {
+fn fastc_emit_source_type_declarations(source_file FastcSourceFile, prefs &pref.Preferences, declared_types map[string]bool, declared_kinds map[string]FastcDeclaredTypeKind, constants map[string]string, public_constants map[string]bool, mut struct_fields map[string]map[string]string, mut struct_field_info map[string][]FastcStructField, mut composite_types map[string]bool, mut alias_base_types map[string]string, mut sum_types map[string]bool, mut enum_infos []FastcEnumInfo, mut out strings.Builder) ! {
 	mut file_set := token.FileSet.new()
 	mut file := file_set.add_file(source_file.path, source_file.source.len)
 	file.index_lines_without_digest(source_file.source)
@@ -1013,7 +1179,7 @@ fn fastc_emit_source_type_declarations(source_file FastcSourceFile, prefs &pref.
 					fastc_emit_source_type_declarations(selected_source, prefs, declared_types,
 						declared_kinds, constants, public_constants, mut struct_fields, mut
 						struct_field_info, mut composite_types, mut alias_base_types, mut
-						enum_infos, mut out)!
+						sum_types, mut enum_infos, mut out)!
 				}
 				tok = selected.tok
 				next_enum_is_flag = false
@@ -1060,7 +1226,7 @@ fn fastc_emit_source_type_declarations(source_file FastcSourceFile, prefs &pref.
 		if depth == 0 && tok == .key_type {
 			tok = fastc_emit_alias_declaration(mut scan, source_file, declared_types,
 				declared_kinds, prefs.building_v, mut struct_fields, mut struct_field_info, mut
-				alias_base_types, mut out)!
+				alias_base_types, mut sum_types, mut out)!
 			next_type_is_enabled = true
 			continue
 		}
@@ -1164,6 +1330,13 @@ fn fastc_emit_struct_declaration(mut scan scanner.Scanner, is_union bool, source
 	if tok == .lsbr {
 		tok = fastc_skip_balanced_tokens(mut scan, tok, .lsbr, .rsbr)!
 	}
+	if tok == .name && scan.lit == 'implements' {
+		// `struct S implements A, B {`: the declared interfaces are advisory, so
+		// skip them up to the struct body.
+		for tok != .lcbr && tok != .eof {
+			tok = scan.scan()
+		}
+	}
 	if tok != .lcbr {
 		return error('fastc parser does not support struct `${name}` body in ${source_file.path}')
 	}
@@ -1206,11 +1379,32 @@ fn fastc_emit_struct_declaration(mut scan scanner.Scanner, is_union bool, source
 			}
 			continue
 		}
-		if tok != .name {
+		if tok != .name && !tok.is_keyword() {
 			return error('fastc parser does not support struct `${name}` field token `${tok.str()}` in ${source_file.path}')
 		}
+		// A field named with a V keyword (`type int` in `struct C.cJSON`): C struct members
+		// mirror C headers where such names are ordinary identifiers. `scan.lit` holds the
+		// keyword text, and it is a valid C field name (sanitized via fastc_c_identifier).
 		mut field_names := [scan.lit]
 		tok = scan.scan()
+		// A qualified embedded field like `mbedtls.SSLConnectConfig` (or
+		// `veb.Context`): a dot right after the first field name means the field is
+		// an embedded `module.Type`, not a `name type` pair.
+		mut qualified_embed_key := ''
+		if tok == .dot && field_names.len == 1 {
+			tok = scan.scan()
+			if tok != .name {
+				return error('fastc parser does not support embedded field in ${source_file.path}')
+			}
+			embed_module := source_file.header.imports[field_names[0]] or { field_names[0] }
+			qualified_embed_key = fastc_type_key(embed_module, scan.lit)
+			tok = scan.scan()
+			if tok == .lsbr {
+				// Generic embed like `veb.Middleware[Context]`: skip the type args
+				// (the embed still resolves to the non-generic C struct name).
+				tok = fastc_skip_balanced_tokens(mut scan, tok, .lsbr, .rsbr)!
+			}
+		}
 		for tok == .comma {
 			tok = scan.scan()
 			if tok != .name {
@@ -1220,9 +1414,13 @@ fn fastc_emit_struct_declaration(mut scan scanner.Scanner, is_union bool, source
 			tok = scan.scan()
 		}
 		if tok == .semicolon || tok == .rcbr {
-			embedded_key := fastc_resolve_declared_type_key(source_file.header.module_name,
-				field_names[0], source_file.header.imports, declared_types) or {
-				return error('fastc parser does not support embedded field `${field_names[0]}` in ${source_file.path}')
+			embedded_key := if qualified_embed_key != '' {
+				qualified_embed_key
+			} else {
+				fastc_resolve_declared_type_key(source_file.header.module_name, field_names[0],
+					source_file.header.imports, declared_types) or {
+					return error('fastc parser does not support embedded field `${field_names[0]}` in ${source_file.path}')
+				}
 			}
 			if !is_c_struct {
 				out.writeln('\t${fastc_c_declared_type_name(embedded_key)} __embedded_${embedded_id};')
@@ -1243,6 +1441,33 @@ fn fastc_emit_struct_declaration(mut scan scanner.Scanner, is_union bool, source
 			}
 			continue
 		}
+		mut field_chan_element := ''
+		if tok == .name && scan.lit == 'chan' {
+			field_chan_element = fastc_peek_chan_element(scan, source_file.path,
+				source_file.header.module_name, source_file.header.imports, declared_types,
+				allow_short_placeholders)
+		}
+		mut field_option_value := ''
+		if tok == .question {
+			field_option_value = fastc_peek_option_element(scan, source_file.path,
+				source_file.header.module_name, source_file.header.imports, declared_types,
+				allow_short_placeholders)
+		}
+		field_generic_argument := fastc_peek_generic_type_argument(tok, scan, source_file.path,
+			source_file.header.module_name, source_file.header.imports, declared_types,
+			allow_short_placeholders)
+		mut is_optional_function := false
+		mut function_scan := scan
+		if tok == .question && function_scan.scan() == .key_fn {
+			is_optional_function = true
+		}
+		is_function_field := tok == .key_fn || is_optional_function
+		mut function_type := FastcFunctionTypeInfo{}
+		if is_function_field {
+			function_type = fastc_peek_function_type(function_scan, source_file.path,
+				source_file.header.module_name, source_file.header.imports, declared_types,
+				allow_short_placeholders)!
+		}
 		field_type, next_token := fastc_scan_type(mut scan, tok, source_file.path,
 			source_file.header.module_name, source_file.header.imports, declared_types,
 			allow_short_placeholders) or {
@@ -1251,10 +1476,14 @@ fn fastc_emit_struct_declaration(mut scan scanner.Scanner, is_union bool, source
 		tok = next_token
 		fastc_register_composite_type(field_type, mut composite_types)
 		mut is_required := false
+		mut is_skip := false
 		for tok == .attribute {
 			mut attribute_is_required := false
-			tok, attribute_is_required = fastc_scan_struct_field_attribute(mut scan)!
+			mut attribute_is_skip := false
+			tok, attribute_is_required, attribute_is_skip =
+				fastc_scan_struct_field_attribute(mut scan)!
 			is_required = is_required || attribute_is_required
+			is_skip = is_skip || attribute_is_skip
 		}
 		mut default_source := ''
 		if tok == .assign {
@@ -1269,27 +1498,47 @@ fn fastc_emit_struct_declaration(mut scan scanner.Scanner, is_union bool, source
 		}
 		for field_name in field_names {
 			c_field_name := fastc_c_identifier(field_name)
-			if !is_c_struct {
-				if element_type := fastc_fixed_array_element_type(field_type) {
-					length := fastc_fixed_array_length(field_type) or {
-						return error('invalid fixed array type')
-					}
-					out.writeln('\t${element_type} ${c_field_name}[${length}];')
-				} else {
-					out.writeln('\t${field_type} ${c_field_name};')
+			mut emitted_field_type := field_type
+			// Imported generic declarations currently use `voidptr` for their type
+			// parameters. json2's private linked list has a single concrete payload,
+			// `ValueInfo`; retain that layout so non-generic Decoder methods can access
+			// `current_node.value` as the declared struct.
+			if name == 'Node' && field_name == 'value' && field_type == 'voidptr'
+				&& source_file.path.ends_with('/vlib/json2/decode.v') {
+				value_info_key := fastc_type_key(source_file.header.module_name, 'ValueInfo')
+				if value_info_key in declared_types {
+					emitted_field_type = fastc_c_declared_type_name(value_info_key)
 				}
 			}
-			fields_by_name[field_name] = field_type
+			if !is_c_struct {
+				if declaration := fastc_fixed_array_field_declaration(emitted_field_type,
+					c_field_name)
+				{
+					out.writeln('\t${declaration};')
+				} else {
+					out.writeln('\t${emitted_field_type} ${c_field_name};')
+				}
+			}
+			fields_by_name[field_name] = emitted_field_type
 			field_info << FastcStructField{
-				name:           field_name
-				typ:            field_type
-				is_public:      fields_are_public
-				is_mutable:     fields_are_mutable
-				is_required:    is_required
-				module_name:    source_file.header.module_name
-				path:           source_file.path
-				imports:        source_file.header.imports.clone()
-				default_source: default_source
+				name:                  field_name
+				typ:                   emitted_field_type
+				is_public:             fields_are_public
+				is_mutable:            fields_are_mutable
+				is_required:           is_required
+				is_skip:               is_skip
+				is_function:           is_function_field
+				is_optional_function:  is_optional_function
+				module_name:           source_file.header.module_name
+				path:                  source_file.path
+				imports:               source_file.header.imports.clone()
+				default_source:        default_source
+				chan_element_type:     field_chan_element
+				option_value_type:     field_option_value
+				fn_parameter_types:    function_type.parameter_types.clone()
+				fn_return_type:        function_type.return_type
+				fn_option_value_type:  function_type.option_value_type
+				generic_argument_type: field_generic_argument
 			}
 			fields++
 		}
@@ -1324,6 +1573,20 @@ fn fastc_emit_struct_declaration(mut scan scanner.Scanner, is_union bool, source
 	return scan.scan()
 }
 
+fn fastc_fixed_array_field_declaration(field_type string, field_name string) ?string {
+	mut element_type := field_type
+	mut dimensions := []string{}
+	for {
+		length := fastc_fixed_array_length(element_type) or { break }
+		dimensions << length
+		element_type = fastc_fixed_array_element_type(element_type) or { return none }
+	}
+	if dimensions.len == 0 {
+		return none
+	}
+	return '${element_type} ${field_name}[${dimensions.join('][')}]'
+}
+
 fn fastc_resolve_declared_type_key(module_name string, raw_type string, imports map[string]string, declared_types map[string]bool) ?string {
 	local_key := fastc_type_key(module_name, raw_type)
 	if local_key in declared_types {
@@ -1337,6 +1600,12 @@ fn fastc_resolve_declared_type_key(module_name string, raw_type string, imports 
 	}
 	if raw_type in declared_types {
 		return raw_type
+	}
+	if raw_type.contains('__') {
+		generated_key := raw_type.replace('__', '.')
+		if generated_key in declared_types {
+			return generated_key
+		}
 	}
 	return none
 }
@@ -1364,7 +1633,12 @@ fn fastc_emit_enum_declaration(mut scan scanner.Scanner, source_file FastcSource
 	tok = scan.scan()
 	if tok == .key_as {
 		tok = scan.scan()
-		if !is_flag || tok != .name || scan.lit != 'u64' {
+		// Accept any integer backing type (`as u32`, `as u8`, ...). The C typedef is
+		// still `int` (or `u64` for flag enums); values are emitted with an explicit
+		// cast, so a narrower/wider spelling does not change the generated C.
+		is_backing_int := tok == .name
+			&& scan.lit in ['i8', 'i16', 'i32', 'i64', 'int', 'u8', 'u16', 'u32', 'u64', 'isize', 'usize']
+		if !is_backing_int || (is_flag && scan.lit != 'u64') {
 			return error('fastc parser does not support enum `${name}` backing type in ${source_file.path}')
 		}
 		tok = scan.scan()
@@ -1387,7 +1661,7 @@ fn fastc_emit_enum_declaration(mut scan scanner.Scanner, source_file FastcSource
 			tok = fastc_skip_attribute(mut scan)!
 			continue
 		}
-		if tok != .name {
+		if tok != .name && !tok.is_keyword() {
 			return error('fastc parser does not support enum `${name}` field in ${source_file.path}')
 		}
 		field_name := scan.lit
@@ -1529,6 +1803,18 @@ fn fastc_render_enum_unary_expression(tokens []FastcExpressionToken, start int, 
 			return error('fastc parser does not support an unbalanced enum discriminant in ${source_file.path}')
 		}
 		return '(${value})', next + 1
+	}
+	// A primitive cast like `int(http.Status.found)`: enum values are plain C
+	// integers, so render `((int)(<inner>))`.
+	if tokens[start].tok == .name && start + 1 < tokens.len && tokens[start + 1].tok == .lpar {
+		if c_type := fastc_primitive_c_type(tokens[start].lit) {
+			value, next := fastc_render_enum_binary_expression(tokens, start + 2, 1, source_file,
+				enum_c_name, fields, declared_types, declared_kinds, constants, public_constants)!
+			if next >= tokens.len || tokens[next].tok != .rpar {
+				return error('fastc parser does not support an unbalanced enum discriminant in ${source_file.path}')
+			}
+			return '((${c_type})(${value}))', next + 1
+		}
 	}
 	if tokens[start].tok == .number {
 		return fastc_c_number(tokens[start].lit)!, start + 1
@@ -1672,7 +1958,7 @@ fn fastc_emit_interface_declaration(mut scan scanner.Scanner, source_file FastcS
 	return tok
 }
 
-fn fastc_emit_alias_declaration(mut scan scanner.Scanner, source_file FastcSourceFile, declared_types map[string]bool, declared_kinds map[string]FastcDeclaredTypeKind, allow_short_placeholders bool, mut struct_fields map[string]map[string]string, mut struct_field_info map[string][]FastcStructField, mut alias_base_types map[string]string, mut out strings.Builder) !token.Token {
+fn fastc_emit_alias_declaration(mut scan scanner.Scanner, source_file FastcSourceFile, declared_types map[string]bool, declared_kinds map[string]FastcDeclaredTypeKind, allow_short_placeholders bool, mut struct_fields map[string]map[string]string, mut struct_field_info map[string][]FastcStructField, mut alias_base_types map[string]string, mut sum_types map[string]bool, mut out strings.Builder) !token.Token {
 	mut tok := scan.scan()
 	if tok != .name {
 		return error('fastc parser does not support type alias in ${source_file.path}')
@@ -1683,6 +1969,23 @@ fn fastc_emit_alias_declaration(mut scan scanner.Scanner, source_file FastcSourc
 	tok = scan.scan()
 	if name == 'C' && tok == .dot {
 		return fastc_skip_type_declaration(mut scan, tok)
+	}
+	if tok == .lsbr {
+		// Generic type alias like `Foo[T] = ...`: skip the type parameters. The body
+		// is emitted with each parameter resolved to a `voidptr` placeholder.
+		mut depth := 1
+		for depth > 0 {
+			tok = scan.scan()
+			if tok == .eof {
+				return error('fastc parser does not support unfinished generic type `${name}` in ${source_file.path}')
+			}
+			if tok == .lsbr {
+				depth++
+			} else if tok == .rsbr {
+				depth--
+			}
+		}
+		tok = scan.scan()
 	}
 	if tok != .assign {
 		return error('fastc parser does not support type `${name}` declaration in ${source_file.path}')
@@ -1709,7 +2012,12 @@ fn fastc_emit_alias_declaration(mut scan scanner.Scanner, source_file FastcSourc
 				}
 			}
 		}
-		out.writeln('typedef struct { void *_object; u32 _typ; } ${c_name};')
+		// A sum type is lowered to the same boxed representation as an interface, so
+		// construction (variant boxing) and `match` (dispatch on `_typ`) reuse the
+		// interface machinery. The `_methods` slot is unused but keeps the layout
+		// identical so `interface_value_expression` applies unchanged.
+		out.writeln('typedef struct { void *_object; u32 _typ; void *_methods; } ${c_name};')
+		sum_types[c_name] = true
 	} else if fastc_primitive_c_type(name) == none && declared_kinds[key] == .alias_ {
 		out.writeln('typedef ${base} ${c_name};')
 		alias_base_types[c_name] = base
@@ -1758,17 +2066,22 @@ fn fastc_emit_function_alias(mut scan scanner.Scanner, source_file FastcSourceFi
 			tok = scan.scan()
 		}
 		mut has_parameter_name := false
-		if !parameter_is_mut && tok == .name {
+		if tok == .name {
 			mut lookahead := scan
 			next_token := lookahead.scan()
-			has_parameter_name = next_token in [.name, .amp, .and, .mul, .question, .not, .key_fn]
+			has_parameter_name = next_token in [.name, .amp, .and, .mul, .question, .not, .key_fn,
+				.lsbr]
 		}
 		if has_parameter_name {
 			tok = scan.scan()
 			parameter_type, next_token := fastc_scan_type(mut scan, tok, source_file.path,
 				source_file.header.module_name, source_file.header.imports, declared_types,
 				allow_short_placeholders)!
-			parameter_types << parameter_type
+			parameter_types << if parameter_is_mut && !parameter_type.ends_with('*') {
+				parameter_type + '*'
+			} else {
+				parameter_type
+			}
 			tok = next_token
 		} else {
 			parameter_type, next_token := fastc_scan_type(mut scan, tok, source_file.path,
@@ -1784,7 +2097,17 @@ fn fastc_emit_function_alias(mut scan scanner.Scanner, source_file FastcSourceFi
 	}
 	tok = scan.scan()
 	mut return_type := 'void'
-	if tok !in [.semicolon, .eof] {
+	if tok in [.not, .question] {
+		// A result/option return (`fn (...) !`, `fn (...) ?Type`) lowers to FastC's
+		// fixed `Option` value; consume any concrete value type after it.
+		return_type = 'Option'
+		tok = scan.scan()
+		if tok in [.name, .amp, .and, .mul, .lsbr, .key_fn, .question, .not] {
+			_, tok = fastc_scan_type(mut scan, tok, source_file.path,
+				source_file.header.module_name, source_file.header.imports, declared_types,
+				allow_short_placeholders)!
+		}
+	} else if tok !in [.semicolon, .eof] {
 		return_type, tok = fastc_scan_type(mut scan, tok, source_file.path,
 			source_file.header.module_name, source_file.header.imports, declared_types,
 			allow_short_placeholders)!

--- a/vlib/v3/gen/fastc/expr.v
+++ b/vlib/v3/gen/fastc/expr.v
@@ -3,6 +3,153 @@ module fastc
 import strings
 import v3.token
 
+// fastc_sort_compare_key hashes a `.sort()` comparison expression (FNV-1a) into a stable,
+// C-identifier-safe suffix so equal comparisons on the same element type share one
+// generated comparator function.
+fn fastc_sort_compare_key(condition string) string {
+	mut h := u64(14695981039346656037)
+	for c in condition {
+		h = (h ^ u64(c)) * u64(1099511628211)
+	}
+	return h.hex()
+}
+
+// current_call_has_one_argument peeks from the scanner position immediately after the
+// current `(`. It disambiguates a lowercase tagged C type conversion from a same-named
+// C function: conversions have one operand, while calls like `C.stat(path, &out)` do not.
+fn (g &Parser) current_call_has_one_argument() bool {
+	mut look := g.s
+	mut parens := 0
+	mut brackets := 0
+	mut braces := 0
+	mut saw_argument := false
+	for {
+		tok := look.scan()
+		if tok == .eof {
+			return false
+		}
+		if tok == .rpar && parens == 0 && brackets == 0 && braces == 0 {
+			return saw_argument
+		}
+		if tok == .comma && parens == 0 && brackets == 0 && braces == 0 {
+			return false
+		}
+		match tok {
+			.lpar { parens++ }
+			.rpar { parens-- }
+			.lsbr { brackets++ }
+			.rsbr { brackets-- }
+			.lcbr { braces++ }
+			.rcbr { braces-- }
+			.semicolon {}
+			else { saw_argument = true }
+		}
+	}
+	return false
+}
+
+// fastc_struct_field_value_token_start returns the index of the first token of the
+// current struct-literal field VALUE: the token just after the last field `:` at bracket
+// depth 0. Returns 0 when there is no such colon (e.g. a positional literal).
+fn fastc_struct_field_value_token_start(tokens []FastcExpressionToken) int {
+	mut depth := 0
+	for i := tokens.len - 1; i >= 0; i-- {
+		match tokens[i].tok {
+			.rpar, .rsbr, .rcbr {
+				depth++
+			}
+			.lpar, .lsbr, .lcbr {
+				depth--
+			}
+			.colon {
+				// depth < 0 means an unmatched opener sits between here and the end — a
+				// grouping `(` around the field value (`f: (x or {…}).m()`); the field value
+				// still starts right after this `:`.
+				if depth <= 0 {
+					return i + 1
+				}
+			}
+			else {}
+		}
+	}
+	return 0
+}
+
+// fastc_or_operand_token_start returns the first token of the trailing operand that an `or`
+// binds to. Array elements start after their nearest comma/opener. In an arithmetic or
+// comparison expression, the option-producing operand starts after the nearest binary
+// operator. Other parenthesized/braced cases are handled by the existing grouped/call paths.
+fn fastc_or_operand_token_start(tokens []FastcExpressionToken) int {
+	mut depth := 0
+	mut nearest_comma := -1
+	for i := tokens.len - 1; i >= 0; i-- {
+		match tokens[i].tok {
+			.rpar, .rsbr, .rcbr {
+				depth++
+			}
+			.lsbr {
+				if depth == 0 {
+					return if nearest_comma >= 0 { nearest_comma + 1 } else { i + 1 }
+				}
+				depth--
+			}
+			.lpar {
+				if depth == 0 {
+					if i > 0 && tokens[i - 1].tok == .name
+						&& fastc_primitive_c_type(tokens[i - 1].lit) != none {
+						return 0
+					}
+					return if nearest_comma >= 0 { nearest_comma + 1 } else { i + 1 }
+				}
+				depth--
+			}
+			.lcbr {
+				if depth == 0 {
+					return 0
+				}
+				depth--
+			}
+			.comma {
+				if depth == 0 && nearest_comma < 0 {
+					nearest_comma = i
+				}
+			}
+			.plus, .minus, .mul, .div, .mod, .amp, .pipe, .xor, .left_shift, .right_shift,
+			.right_shift_unsigned, .eq, .ne, .gt, .lt, .ge, .le, .and, .logical_or {
+				if depth == 0 {
+					return i + 1
+				}
+			}
+			else {}
+		}
+	}
+	return 0
+}
+
+fn fastc_trailing_not_marks_fixed_array_literal(tokens []FastcExpressionToken) bool {
+	if tokens.len < 3 || tokens.last().tok != .not || tokens[tokens.len - 2].tok != .rsbr {
+		return false
+	}
+	mut depth := 0
+	mut open := -1
+	for i := tokens.len - 2; i >= 0; i-- {
+		if tokens[i].tok == .rsbr {
+			depth++
+		} else if tokens[i].tok == .lsbr {
+			depth--
+			if depth == 0 {
+				open = i
+				break
+			}
+		}
+	}
+	if open == 0 {
+		return true
+	}
+	return open > 0
+		&& tokens[open - 1].tok in [.lpar, .comma, .assign, .decl_assign, .key_in, .not_in, .plus, .minus, .mul, .div, .mod, .amp, .pipe, .xor, .and, .logical_or]
+}
+
 fn (mut g Parser) read_expression(stops []token.Token) !string {
 	return g.read_expression_with_prefix_mode('', stops, false, false)
 }
@@ -24,6 +171,9 @@ fn (mut g Parser) read_statement_expression_with_prefix(prefix string, stops []t
 }
 
 fn (mut g Parser) read_expression_with_prefix_mode(prefix string, stops []token.Token, allow_mutation_statement bool, allow_declaration_guard bool) !string {
+	if g.expression_depth == 0 {
+		g.last_option_value_type = ''
+	}
 	g.expression_depth++
 	if g.expression_depth == 1 && g.comparison_memo.len > 0 {
 		// Memoized comparison renders are only valid while the expression's
@@ -42,6 +192,9 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 	if g.selfhost && prefix == '' && g.tok == .lcbr && token.Token.lcbr !in stops {
 		return g.read_inferred_map_literal()!
 	}
+	if g.selfhost && prefix == '' && g.tok == .arrow {
+		return g.read_channel_receive(stops)!
+	}
 	if prefix == '' && g.tok == .key_if {
 		return g.read_if_expression()!
 	}
@@ -53,6 +206,15 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 	}
 	if prefix == '' && g.tok == .key_spawn {
 		return g.read_spawn_expression()!
+	}
+	if prefix == '' && g.tok == .name && g.lit == 'sql' && 'sql' !in g.locals {
+		mut lookahead := g.s
+		if lookahead.scan() == .name {
+			// `x := sql db { select ... }` is lowered at the declaration level
+			// (parse_declaration_after_name); a `sql` expression in any other position
+			// has nowhere to bind the row-parsing loop.
+			return g.unsupported('ORM `sql` select is only supported as `x := sql db { select ... }`')
+		}
 	}
 	mut result := strings.new_builder(64)
 	mut expression_tokens := []FastcExpressionToken{}
@@ -84,15 +246,249 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 	mut struct_depths := []int{}
 	mut struct_paren_depths := []int{}
 	mut expected_struct_field_type := ''
+	// Result-buffer offset where the current struct-literal field VALUE begins (just past
+	// its `=`), letting an `or` inside a field value be scoped to that value.
+	mut struct_field_value_start := 0
+	mut pending_field_value_mark := false
 	mut enum_shorthand_type := ''
 	mut next_token_is_mut_argument := false
 	mut source_token_count := if prefix == '' { 0 } else { 1 }
 	mut mutation_operator := token.Token.unknown
 	mut tokens_before_mutation := 0
+	// A plain assignment gives its right-hand side the target's type (below), so an
+	// if/match-expression or `[]` on the right infers against the field type rather
+	// than a stale `expected_expression_type` (e.g. wrapping a string result as an
+	// Option). This is restored after the expression is read.
+	saved_expected_expression_type := g.expected_expression_type
 	for g.tok != .eof {
 		if g.selfhost && g.tok == .semicolon && g.semicolon_continues_expression() {
 			g.next()
 			continue
+		}
+		// `$d('key', default)` may appear mid-expression (e.g. `int($d(...))`).
+		// Lower it inline to its default value.
+		if g.tok == .dollar {
+			mut lookahead := g.s
+			if lookahead.scan() == .name && lookahead.lit == 'd' {
+				g.next() // consume `$`
+				value := g.read_comptime_d_expression()!
+				value_type := g.last_expression_type
+				if result.len > 0 && fastc_needs_space(result.last(), value) {
+					result.write_u8(` `)
+				}
+				result.write_string(value)
+				expression_tokens << FastcExpressionToken{
+					tok: .name
+					lit: value
+					typ: value_type
+				}
+				previous_token = .name
+				previous_lit = value
+				previous_module_separator = false
+				previous_token_end = g.s.pos
+				continue
+			}
+		}
+		// `arr.map/filter/any/all/count(expr)`: expand the `it`-closure into a C statement
+		// expression. These are compiler-magic methods (not builtin functions), so
+		// they must be lowered here, where locals are mutable and the closure body
+		// can be rendered with `it` in scope.
+		if g.tok == .dot && expression_tokens.len > 0 {
+			mut lookahead := g.s
+			if lookahead.scan() == .name {
+				higher_order_method := lookahead.lit
+				if higher_order_method in ['map', 'filter', 'any', 'all', 'count']
+					&& lookahead.scan() == .lpar {
+					receiver_start := fastc_method_receiver_start(expression_tokens,
+						expression_tokens.len)
+					receiver_tokens := expression_tokens[receiver_start..]
+					receiver_type := g.infer_expression_type(receiver_tokens) or { '' }
+					// Array-literal receivers (`[.a, .b].map(...)`) do not round-trip
+					// through the receiver renderer yet; leave them to the normal path.
+					if receiver_type.starts_with('Array_') {
+						fastc_register_composite_type(receiver_type, mut g.composite_types)
+						element_type := g.array_element_type(receiver_type) or { '' }
+						// Method calls in the receiver are only resolved by a post-pass,
+						// so the live buffer holds an unresolved form; re-render through the
+						// resolving path and drop the unresolved form from the buffer (its
+						// whole content when the receiver is the entire expression, else its
+						// raw suffix length). Array literals need the element type as expected
+						// context to resolve `.enum` shorthand elements.
+						mut receiver_source := ''
+						if receiver_tokens[0].tok == .lsbr && receiver_tokens.last().tok == .rsbr {
+							raw := g.render_raw_expression_tokens(receiver_tokens) or { '' }
+							items := fastc_expression_list_items(receiver_tokens, 1,
+								receiver_tokens.len - 1) or {
+								return g.unsupported('`.${higher_order_method}` array-literal receiver')
+							}
+							norm_element := fastc_normalize_inferred_type(element_type)
+							previous_expected := g.expected_expression_type
+							g.expected_expression_type = element_type
+							mut rendered_items := []string{cap: items.len}
+							for item in items {
+								rendered_items << g.render_call_argument_expression(item,
+									element_type) or {
+									g.expected_expression_type = previous_expected
+									return g.unsupported('`.${higher_order_method}` array-literal element')
+								}
+							}
+							g.expected_expression_type = previous_expected
+							receiver_source = '((${receiver_type})builtin__new_array_from_c_array(${items.len}, ${items.len}, sizeof(${norm_element}), (${norm_element}[]){${rendered_items.join(',')}}))'
+							if receiver_start == 0 {
+								result.str()
+							} else {
+								result.go_back(raw.len)
+							}
+						} else {
+							resolved := g.render_method_receiver_expression(receiver_tokens) or {
+								return g.unsupported('`.${higher_order_method}` receiver')
+							}
+							receiver_source = resolved.source
+							if receiver_start == 0 {
+								result.str()
+							} else {
+								raw := g.render_raw_expression_tokens(receiver_tokens) or {
+									return g.unsupported('`.${higher_order_method}` receiver')
+								}
+								result.go_back(raw.len)
+							}
+						}
+						g.next() // `.`
+						g.next() // method name
+						g.next() // `(`
+						had_it := 'it' in g.locals
+						saved_it := g.locals['it'] or { FastcLocal{} }
+						g.locals['it'] = FastcLocal{
+							typ: element_type
+						}
+						closure := g.read_expression([token.Token.rpar])!
+						closure_type := g.last_expression_type
+						if had_it {
+							g.locals['it'] = saved_it
+						} else {
+							g.locals.delete('it')
+						}
+						g.next() // `)`
+						if closure_type == '' {
+							return g.unsupported('`.${higher_order_method}` closure type')
+						}
+						src := g.temporary_name('collection')
+						dst := g.temporary_name('mapped')
+						idx := g.temporary_name('index')
+						elem := g.temporary_name('element')
+						mut lowered := ''
+						mut result_type := receiver_type
+						if higher_order_method == 'map' {
+							result_type = fastc_array_c_type(closure_type)
+							fastc_register_composite_type(result_type, mut g.composite_types)
+							lowered = '({ ${receiver_type} ${src} = (${receiver_source}); ${result_type} ${dst} = (${result_type})builtin____new_array(0, ${src}.len, sizeof(${closure_type})); for (int ${idx} = 0; ${idx} < ${src}.len; ${idx}++) { ${element_type} it = ((${element_type} *)${src}.data)[${idx}]; ${closure_type} ${elem} = (${closure}); builtin__array_push((array *)&${dst}, &${elem}); } ${dst}; })'
+						} else if higher_order_method == 'filter' {
+							lowered = '({ ${receiver_type} ${src} = (${receiver_source}); ${receiver_type} ${dst} = (${receiver_type})builtin____new_array(0, ${src}.len, sizeof(${element_type})); for (int ${idx} = 0; ${idx} < ${src}.len; ${idx}++) { ${element_type} it = ((${element_type} *)${src}.data)[${idx}]; if (${closure}) { builtin__array_push((array *)&${dst}, &it); } } ${dst}; })'
+						} else if higher_order_method == 'count' {
+							result_type = 'int'
+							lowered = '({ ${receiver_type} ${src} = (${receiver_source}); int ${dst} = 0; for (int ${idx} = 0; ${idx} < ${src}.len; ${idx}++) { ${element_type} it = ((${element_type} *)${src}.data)[${idx}]; if (${closure}) { ${dst}++; } } ${dst}; })'
+						} else {
+							result_type = 'bool'
+							initial := if higher_order_method == 'all' { 'true' } else { 'false' }
+							condition := if higher_order_method == 'all' {
+								'!(${closure})'
+							} else {
+								closure
+							}
+							matched := if higher_order_method == 'all' { 'false' } else { 'true' }
+							lowered = '({ ${receiver_type} ${src} = (${receiver_source}); bool ${dst} = ${initial}; for (int ${idx} = 0; ${idx} < ${src}.len; ${idx}++) { ${element_type} it = ((${element_type} *)${src}.data)[${idx}]; if (${condition}) { ${dst} = ${matched}; break; } } ${dst}; })'
+						}
+						result.write_string(lowered)
+						expression_tokens = expression_tokens[..receiver_start].clone()
+						expression_tokens << FastcExpressionToken{
+							tok: .name
+							lit: lowered
+							typ: result_type
+						}
+						previous_token = .name
+						previous_lit = lowered
+						previous_module_separator = false
+						previous_token_end = g.s.pos
+						continue
+					}
+				}
+				// `arr.sort(a.x < b.x)`: generate a comparator function (`a`/`b` are the two
+				// elements) keyed by element type + comparison, and lower to sort_with_compare.
+				// `.sort()` (no argument) keeps its existing builtin lowering (the `!= .rpar`).
+				if higher_order_method == 'sort' && lookahead.scan() == .lpar
+					&& lookahead.scan() != .rpar {
+					receiver_start := fastc_method_receiver_start(expression_tokens,
+						expression_tokens.len)
+					receiver_tokens := expression_tokens[receiver_start..]
+					receiver_type := g.infer_expression_type(receiver_tokens) or { '' }
+					if receiver_type.starts_with('Array_') {
+						element_type := g.array_element_type(receiver_type) or {
+							return g.unsupported('`.sort` element type')
+						}
+						norm_element := fastc_normalize_inferred_type(element_type)
+						resolved := g.render_method_receiver_expression(receiver_tokens) or {
+							return g.unsupported('`.sort` receiver')
+						}
+						receiver_source := resolved.source
+						if receiver_start == 0 {
+							result.str()
+						} else {
+							raw := g.render_raw_expression_tokens(receiver_tokens) or {
+								return g.unsupported('`.sort` receiver')
+							}
+							result.go_back(raw.len)
+						}
+						g.next() // `.`
+						g.next() // `sort`
+						g.next() // `(`
+						had_a := 'a' in g.locals
+						saved_a := g.locals['a'] or { FastcLocal{} }
+						had_b := 'b' in g.locals
+						saved_b := g.locals['b'] or { FastcLocal{} }
+						g.locals['a'] = FastcLocal{
+							typ: element_type
+						}
+						g.locals['b'] = FastcLocal{
+							typ: element_type
+						}
+						condition := g.read_expression([token.Token.rpar])!
+						if had_a {
+							g.locals['a'] = saved_a
+						} else {
+							g.locals.delete('a')
+						}
+						if had_b {
+							g.locals['b'] = saved_b
+						} else {
+							g.locals.delete('b')
+						}
+						g.next() // `)`
+						if condition.trim_space() == '' {
+							return g.unsupported('`.sort` comparison')
+						}
+						cmp_name := 'v_fastc_sort_${fastc_c_identifier(norm_element)}_${fastc_sort_compare_key(condition)}'
+						if cmp_name !in g.spawn_helpers {
+							// The same rendered comparison in two blocks with swapped element
+							// bindings yields the -1 / +1 / 0 ordering without re-rendering it.
+							g.spawn_helpers[cmp_name] = 'static int ${cmp_name}(void *__v_fastc_a, void *__v_fastc_b) { { ${norm_element} a = *(${norm_element} *)__v_fastc_a; ${norm_element} b = *(${norm_element} *)__v_fastc_b; if (${condition}) { return -1; } } { ${norm_element} a = *(${norm_element} *)__v_fastc_b; ${norm_element} b = *(${norm_element} *)__v_fastc_a; if (${condition}) { return 1; } } return 0; }'
+						}
+						lowered := '({ builtin__array_sort_with_compare((array *)&(${receiver_source}), ${cmp_name}); })'
+						result.write_string(lowered)
+						expression_tokens = expression_tokens[..receiver_start].clone()
+						expression_tokens << FastcExpressionToken{
+							tok:          .name
+							lit:          lowered
+							typ:          'void'
+							is_statement: true
+						}
+						previous_token = .name
+						previous_lit = lowered
+						previous_module_separator = false
+						previous_token_end = g.s.pos
+						continue
+					}
+				}
+			}
 		}
 		if g.selfhost && expression_tokens.len > 0 && paren_depth == 0 && bracket_depth == 0
 			&& brace_depth == 0 && unsafe_expression_depth == 0 && g.tok == .mul
@@ -109,6 +505,7 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 		}
 		if g.tok in [.key_if, .key_unsafe] && expression_tokens.len > 0 && paren_depth == 0
 			&& bracket_depth == 0 && brace_depth == 0 && unsafe_expression_depth == 0
+			&& previous_token !in [.plus, .minus, .mul, .div, .mod, .amp, .pipe, .xor, .and, .logical_or, .eq, .ne, .lt, .gt, .le, .ge, .comma, .lpar, .lsbr]
 			&& g.s.src[previous_token_end..g.s.pos].contains('\n') {
 			break
 		}
@@ -255,6 +652,26 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 			previous_token_end = g.s.pos
 			continue
 		}
+		if g.selfhost && g.tok == .key_fn {
+			// A function literal / closure in expression position (`fn [caps] (args) { … }`).
+			// Lowered to a compile-only stub (see anonfn.v); keep it as one typed atom.
+			anon := g.read_anonymous_function_stub()!
+			if result.len > 0 && fastc_needs_space(result.last(), anon)
+				&& !previous_module_separator {
+				result.write_u8(` `)
+			}
+			result.write_string(anon)
+			expression_tokens << FastcExpressionToken{
+				tok:    .name
+				lit:    anon
+				source: anon
+			}
+			previous_token = .name
+			previous_lit = anon
+			previous_module_separator = false
+			previous_token_end = g.s.pos
+			continue
+		}
 		if g.selfhost && g.tok == .key_spawn {
 			spawned := g.read_spawn_expression()!
 			spawned_type := g.last_expression_type
@@ -284,11 +701,51 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 				&& expression_tokens[wrapper_parens].tok == .lpar {
 				wrapper_parens++
 			}
-			mut option_expression := result.str().trim_space()
+			raw_option_buffer := result.str()
+			mut option_expression := raw_option_buffer.trim_space()
 			mut value_type := g.expected_expression_type
 			mut option_tokens := expression_tokens.clone()
 			mut assignment_prefix := ''
+			mut scoped_operand_prefix := ''
+			mut scoped_or_operand := false
 			mut assignment_depth := 0
+			// An `or` inside a struct-literal field VALUE (`Type{ f: expr or {...} }`) applies
+			// only to that value, not the whole literal-so-far. Scope the option to the field
+			// value and keep the `(Type){.f = ` prefix (rebuilt via assignment_prefix).
+			mut in_struct_field := false
+			mut struct_field_prefix_tokens := []FastcExpressionToken{}
+			field_extra_parens := if struct_paren_depths.len > 0 {
+				paren_depth - struct_paren_depths.last()
+			} else {
+				-1
+			}
+			if struct_depths.len > 0 && brace_depth == struct_depths.last()
+				&& field_extra_parens >= 0 && struct_field_value_start > 0
+				&& struct_field_value_start <= raw_option_buffer.len {
+				value_token_start := fastc_struct_field_value_token_start(expression_tokens)
+				// When the field value is wrapped in grouping parens (`f: (x or {…}).m()`),
+				// paren_depth is above the struct's baseline; require the extra depth to be
+				// exactly that many leading `(` of the value, so a call/index arg
+				// (`f: g(x or {…})`) is left to the operand-scoping path instead.
+				mut field_leading_open := 0
+				if value_token_start > 0 && value_token_start < expression_tokens.len {
+					for value_token_start + field_leading_open < expression_tokens.len
+						&& expression_tokens[value_token_start + field_leading_open].tok == .lpar {
+						field_leading_open++
+					}
+				}
+				if value_token_start > 0 && value_token_start < expression_tokens.len
+					&& (field_extra_parens == 0 || field_leading_open >= field_extra_parens) {
+					in_struct_field = true
+					assignment_prefix = raw_option_buffer[..struct_field_value_start]
+					option_expression = raw_option_buffer[struct_field_value_start..].trim_space()
+					option_tokens = expression_tokens[value_token_start..].clone()
+					struct_field_prefix_tokens = expression_tokens[..value_token_start].clone()
+					if expected_struct_field_type != '' {
+						value_type = expected_struct_field_type
+					}
+				}
+			}
 			for i, assignment_token in expression_tokens {
 				if assignment_token.tok in [.lpar, .lsbr, .lcbr] {
 					assignment_depth++
@@ -314,28 +771,123 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 					break
 				}
 			}
+			// An `or` inside an array literal / index / call-argument list
+			// (`[a, expr or {..}]`, `f(expr or {..})`): scope the option to the current operand
+			// (after the last `,` / `[` / `(`), keeping the enclosing prefix tokens so the
+			// collection/call re-renders correctly from tokens. Reuses the struct-field rebuild
+			// path via `in_struct_field` + `struct_field_prefix_tokens`.
+			if !in_struct_field && assignment_prefix == '' {
+				operand_start := fastc_or_operand_token_start(expression_tokens)
+				if operand_start > 0 && operand_start < expression_tokens.len {
+					scoped_or_operand = true
+					in_struct_field = true
+					struct_field_prefix_tokens = expression_tokens[..operand_start].clone()
+					option_tokens = expression_tokens[operand_start..].clone()
+					option_expression = g.render_call_argument_expression(option_tokens, value_type) or {
+						option_expression
+					}
+					separator := expression_tokens[operand_start - 1].tok
+					if separator !in [.lpar, .lsbr, .comma] {
+						scoped_operand_prefix = g.render_raw_expression_tokens(struct_field_prefix_tokens) or {
+							''
+						}
+						wrapper_parens = 0
+					}
+				}
+			}
+			// A grouping-parenthesized operand (`(x or {…}).method()`) renders with an
+			// unmatched leading `(` in the option buffer; that `(` is re-emitted as a
+			// `wrapper_parens`, so strip it from the option expression to keep the generated
+			// `Option t = (x)` balanced. option_tokens is left intact so the method-call /
+			// missing-call detection below still sees the whole operand.
+			mut grouped_operand := false
+			mut grouped_paren_count := 0
+			mut grouped_value_tokens := []FastcExpressionToken{}
+			// Handle a grouping-parenthesized operand for the plain case (`(x or {…}).m()`)
+			// and the struct-field case (`Type{ f: (x or {…}).m() }`), but not a plain
+			// assignment RHS (which has its own membership rebuild).
+			if in_struct_field || assignment_prefix == '' {
+				mut operand_open := 0
+				for operand_open < option_tokens.len && option_tokens[operand_open].tok == .lpar {
+					operand_open++
+				}
+				mut operand_balance := 0
+				for balance_item in option_tokens {
+					match balance_item.tok {
+						.lpar, .lsbr, .lcbr {
+							operand_balance++
+						}
+						.rpar, .rsbr, .rcbr {
+							operand_balance--
+						}
+						else {}
+					}
+				}
+				if operand_balance < operand_open {
+					operand_open = if operand_balance > 0 { operand_balance } else { 0 }
+				}
+				if operand_open > 0 && operand_open < option_tokens.len {
+					grouped_operand = true
+					grouped_paren_count = operand_open
+					stripped_tokens := option_tokens[operand_open..].clone()
+					grouped_value_tokens = stripped_tokens.clone()
+					option_expression = g.render_call_argument_expression(stripped_tokens,
+						value_type) or { option_expression }
+				}
+			}
 			if expression_tokens.len >= 3 && expression_tokens[0].tok == .name
 				&& expression_tokens[1].tok == .lpar
 				&& fastc_primitive_c_type(expression_tokens[0].lit) != none {
 				option_tokens = expression_tokens[2..].clone()
+				option_expression = g.render_raw_expression_tokens(option_tokens) or {
+					option_expression
+				}
 			}
-			mut option_value_type := g.option_value_type_for_expression(option_tokens)
+			// For a grouped operand the option value type must come from the balanced tokens
+			// (`make_box(x)` → Box); option_tokens still carries the unmatched leading `(`,
+			// which would defeat the lookup.
+			mut option_value_type := if grouped_operand {
+				g.option_value_type_for_expression(grouped_value_tokens)
+			} else {
+				g.option_value_type_for_expression(option_tokens)
+			}
+			if member_source := g.render_member_receiver(option_tokens) {
+				// Re-render pure member chains so pointer fields at any depth use `->`
+				// inside the Option temporary (`outer.inner.value or { ... }`).
+				option_expression = member_source
+			}
 			if map_lookup := g.render_map_lookup_option_expression(option_tokens) {
 				option_expression = map_lookup.source
 				option_value_type = map_lookup.typ
 			} else if array_lookup := g.render_array_lookup_option_expression(option_tokens) {
 				option_expression = array_lookup.source
 				option_value_type = array_lookup.typ
+			} else if explicit_generic := g.render_explicit_generic_call_expression(option_tokens) {
+				option_expression = explicit_generic.source
+				option_value_type = g.option_value_type_for_expression(option_tokens)
+			} else if static_call := g.render_static_call_expression(option_tokens,
+				option_expression)
+			{
+				option_expression = static_call.source
+				option_value_type = g.option_value_type_for_expression(option_tokens)
+			} else if call := g.render_missing_call_arguments(option_tokens) {
+				// Rebuild a complete free-function call before resolving methods nested in
+				// its arguments. This supplies contextual types for array/map literals.
+				option_expression = call.source
+				option_value_type = g.option_value_type_for_expression(option_tokens)
 			} else if method_call := g.render_method_call_expression(option_tokens,
 				option_expression)
 			{
 				option_expression = method_call.source
 				option_value_type = g.option_value_type_for_expression(option_tokens)
-			} else if call := g.render_missing_call_arguments(option_tokens) {
-				option_expression = call.source
-				option_value_type = g.option_value_type_for_expression(option_tokens)
 			}
-			outer_cast := assignment_prefix == '' && option_tokens.len != expression_tokens.len
+			if pointer_members := g.render_pointer_member_access_expression(option_tokens,
+				option_expression)
+			{
+				option_expression = pointer_members.source
+			}
+			outer_cast := assignment_prefix == '' && scoped_operand_prefix == ''
+				&& !scoped_or_operand && option_tokens.len != expression_tokens.len
 			if expression_tokens.len >= 2 && expression_tokens[0].tok == .name
 				&& expression_tokens[1].tok == .lpar {
 				value_type = fastc_primitive_c_type(expression_tokens[0].lit) or { value_type }
@@ -357,7 +909,20 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 				}
 				g.capturing_defer = true
 				g.captured_defer_lines = []string{}
+				// A trailing bare VALUE (`or { ...; User{} }`) is the block's fallback: let
+				// parse_block_body capture it into `or_value_captured` instead of rejecting
+				// it as a value-only statement.
+				previous_or_capture := g.or_value_capture
+				previous_or_captured := g.or_value_captured
+				previous_or_expected := g.or_value_expected_type
+				g.or_value_capture = true
+				g.or_value_captured = ''
+				g.or_value_expected_type = option_value_type
 				_ = g.parse_block_body()!
+				fallback_value := g.or_value_captured
+				g.or_value_capture = previous_or_capture
+				g.or_value_captured = previous_or_captured
+				g.or_value_expected_type = previous_or_expected
 				block_lines := g.captured_defer_lines.clone()
 				g.capturing_defer = previous_capture
 				g.captured_defer_lines = previous_lines.clone()
@@ -366,36 +931,86 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 				} else {
 					g.locals.delete('err')
 				}
-				complex_value_type := if option_value_type == '' {
+				// A primitive cast around the or (`int(f() or {...})`): the result type is the
+				// cast type, and its closing `)` must be consumed (mirrors the single-value
+				// path's `outer_cast` handling below).
+				cast_type := if outer_cast && expression_tokens.len >= 2
+					&& expression_tokens[0].tok == .name && expression_tokens[1].tok == .lpar {
+					fastc_primitive_c_type(expression_tokens[0].lit) or { '' }
+				} else {
+					''
+				}
+				complex_value_type := if cast_type != '' {
+					cast_type
+				} else if option_value_type == '' {
 					'void'
 				} else {
 					option_value_type
 				}
-				complex_success := if complex_value_type == 'void' {
+				complex_payload_type := if option_value_type != '' {
+					option_value_type
+				} else {
+					complex_value_type
+				}
+				complex_unwrapped := if complex_payload_type == 'void' {
 					'0'
 				} else {
-					'*((${complex_value_type} *)${temporary}.data)'
+					'*((${complex_payload_type} *)${temporary}.data)'
+				}
+				complex_success := if cast_type != '' && complex_payload_type != cast_type {
+					'((${cast_type})(${complex_unwrapped}))'
+				} else {
+					complex_unwrapped
+				}
+				if outer_cast && paren_depth > 0 && g.tok == .rpar {
+					paren_depth--
+					g.next()
 				}
 				result.go_back(result.len)
-				result.write_string('${assignment_prefix}({ Option ${temporary} = (${option_expression}); if (${temporary}.state) { IError err = ${temporary}.err; ${block_lines.join(' ')} } ${complex_success}; })')
-				expression_tokens = [
-					FastcExpressionToken{
+				or_expr_body := if fallback_value != '' && complex_value_type != 'void' {
+					// The or-block ends in a fallback VALUE: run the leading statements and
+					// use the value on failure, the unwrapped option value on success.
+					or_result := g.temporary_name('or_result')
+					'({ Option ${temporary} = (${option_expression}); ${complex_value_type} ${or_result}; if (${temporary}.state) { IError err = ${temporary}.err; ${block_lines.join(' ')} ${or_result} = (${fallback_value}); } else { ${or_result} = ${complex_success}; } ${or_result}; })'
+				} else {
+					// The or-block only runs statements (it diverges): run them on failure,
+					// then use the unwrapped value.
+					'({ Option ${temporary} = (${option_expression}); if (${temporary}.state) { IError err = ${temporary}.err; ${block_lines.join(' ')} } ${complex_success}; })'
+				}
+				result.write_string(assignment_prefix)
+				result.write_string(scoped_operand_prefix)
+				result.write_string(or_expr_body)
+				if in_struct_field {
+					expression_tokens = struct_field_prefix_tokens.clone()
+					expression_tokens << FastcExpressionToken{
 						tok:          .name
 						lit:          temporary
+						source:       or_expr_body
 						typ:          complex_value_type
 						is_statement: or_expression_is_statement
-					},
-				]
-				if complex_value_type == 'void' {
-					expression_tokens << FastcExpressionToken{
-						tok: .assign
-						lit: '='
 					}
-				}
-				if assignment_prefix != '' {
-					expression_tokens << FastcExpressionToken{
-						tok: .assign
-						lit: '='
+				} else {
+					expression_tokens = [
+						FastcExpressionToken{
+							tok: .name
+							lit: temporary
+							// Carry the rendered `({ ... })` so a trailing `.method()` binds to it.
+							source:       or_expr_body
+							typ:          complex_value_type
+							is_statement: or_expression_is_statement
+						},
+					]
+					if complex_value_type == 'void' {
+						expression_tokens << FastcExpressionToken{
+							tok: .assign
+							lit: '='
+						}
+					}
+					if assignment_prefix != '' {
+						expression_tokens << FastcExpressionToken{
+							tok: .assign
+							lit: '='
+						}
 					}
 				}
 				previous_token = .name
@@ -405,6 +1020,37 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 				g.last_expression_type = complex_value_type
 				g.last_expression = expression_tokens
 				g.last_multi_return_types = or_return_types.clone()
+				if in_struct_field {
+					// parse_block_body consumed the field separator; re-insert a `,` as both a
+					// token (render_struct_literal_expression works off tokens) and buffer text
+					// before the next field so the struct literal keeps rendering.
+					if g.tok == .name {
+						expression_tokens << FastcExpressionToken{
+							tok: .comma
+							lit: ','
+						}
+						result.write_string(', ')
+						previous_token = .comma
+					}
+					continue
+				}
+				// parse_block_body already skipped the statement separator after `}`, so an
+				// immediate `.` here is a method on the or-result (`x or { ... }.method()`):
+				// continue so it binds to the temporary (via its `source`). Otherwise the
+				// expression is complete.
+				if g.tok == .dot {
+					continue
+				}
+				// A trailing binary operator (`data.index(c) or { return … } + 1`) also binds
+				// to the or-result: keep reading so it renders `or_expr_body + 1` rather than
+				// orphaning `+ 1` as its own value-only statement. (The single-value path
+				// already falls through to the shared read loop for this.)
+				if g.tok in [.plus, .minus, .mul, .div, .mod, .amp, .pipe, .xor, .left_shift,
+					.right_shift, .right_shift_unsigned, .eq, .ne, .gt, .lt, .ge, .le, .and,
+					.logical_or] {
+					continue
+				}
+				g.expected_expression_type = saved_expected_expression_type
 				return result.str().trim_space()
 			}
 			previous_err := g.locals['err'] or { FastcLocal{} }
@@ -417,7 +1063,7 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 			if fallback == '' {
 				fallback = '0'
 			} else if fallback_type.starts_with('Map_') && fallback.contains('){}') {
-				key_type, map_value_type := fastc_map_key_value_types(fallback_type) or {
+				key_type, map_value_type := g.map_key_value_types(fallback_type) or {
 					return g.unsupported('map fallback type `${fallback_type}`')
 				}
 				hash_fn, eq_fn, clone_fn, free_fn := g.map_runtime_functions(key_type)
@@ -441,46 +1087,104 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 					fallback_type
 				}
 			}
+			if (g.tok == .dot || grouped_operand || scoped_or_operand) && option_value_type != '' {
+				// A method immediately follows the or-block (`expr or { v }.method()`):
+				// the unwrapped receiver's type is the option's value type, not the
+				// surrounding expression's expected type (which describes the whole
+				// `.method()` call's result). For a grouped operand (`(x or { v }).method()`)
+				// the closing `)` sits between the block and the `.`, so `g.tok` is `.rpar`
+				// here; the grouped expression's value is still the option value type (in the
+				// non-method uses the expected type already equals it, so this is a no-op).
+				value_type = option_value_type
+			}
 			if outer_cast && paren_depth > 0 && g.tok == .rpar {
 				paren_depth--
 				g.next()
 			}
+			// A grouped struct-field operand (`Type{ f: (x or {…}).m() }`) absorbed its
+			// opening `(` into the field prefix, so consume the matching closing `)` here;
+			// otherwise it would trail the or-result token as an unmatched `)` and break the
+			// struct field's comma-splitting. wrapper_parens==0 in this path, so the plain
+			// grouped case (which balances via wrapper_parens) is unaffected.
+			if grouped_operand && in_struct_field {
+				mut skipped := 0
+				for skipped < grouped_paren_count && g.tok == .rpar {
+					if paren_depth > 0 {
+						paren_depth--
+					}
+					g.next()
+					skipped++
+				}
+			}
 			result.go_back(result.len)
-			success_value := if value_type == 'void' {
+			payload_type := if option_value_type != '' { option_value_type } else { value_type }
+			unwrapped_value := if payload_type == 'void' {
 				'0'
 			} else {
-				'*((${value_type} *)${temporary}.data)'
+				'*((${payload_type} *)${temporary}.data)'
+			}
+			mut success_value := if outer_cast && payload_type != value_type {
+				'((${value_type})(${unwrapped_value}))'
+			} else {
+				unwrapped_value
+			}
+			if fallback_type == 'Option' && option_value_type != '' {
+				success_value = fastc_option_success_expression(option_value_type, unwrapped_value)
+				value_type = 'Option'
+			}
+			or_expr_body := if fallback_type == 'IError' && g.return_type == 'Option' {
+				// `return result_call() or { error(...) }`: the IError is a replacement
+				// result failure, not a value of the result payload type.
+				'({ Option ${temporary} = (${option_expression}); if (${temporary}.state) { return (Option){.err = (${fallback}), .state = 1}; } ${success_value}; })'
+			} else if value_type != 'void' && fallback_type in ['', 'void'] {
+				'({ Option ${temporary} = (${option_expression}); if (${temporary}.state) { ${fallback}; } ${success_value}; })'
+			} else {
+				'({ Option ${temporary} = (${option_expression}); ${temporary}.state ? (${fallback}) : ${success_value}; })'
+			}
+			if fallback_type == 'IError' && g.return_type == 'Option' && option_value_type != '' {
+				value_type = option_value_type
 			}
 			result.write_string(assignment_prefix)
+			result.write_string(scoped_operand_prefix)
 			result.write_string('('.repeat(wrapper_parens))
-			if value_type != 'void' && fallback_type in ['', 'void'] {
-				result.write_string('({ Option ${temporary} = (${option_expression}); if (${temporary}.state) { ${fallback}; } ${success_value}; })')
+			result.write_string(or_expr_body)
+			if in_struct_field {
+				expression_tokens = struct_field_prefix_tokens.clone()
+				expression_tokens << FastcExpressionToken{
+					tok:          .name
+					lit:          temporary
+					source:       or_expr_body
+					typ:          value_type
+					is_statement: or_expression_is_statement
+				}
 			} else {
-				result.write_string('({ Option ${temporary} = (${option_expression}); ${temporary}.state ? (${fallback}) : ${success_value}; })')
-			}
-			expression_tokens = []FastcExpressionToken{}
-			for _ in 0 .. wrapper_parens {
-				expression_tokens << FastcExpressionToken{
-					tok: .lpar
-					lit: '('
+				expression_tokens = []FastcExpressionToken{}
+				for _ in 0 .. wrapper_parens {
+					expression_tokens << FastcExpressionToken{
+						tok: .lpar
+						lit: '('
+					}
 				}
-			}
-			expression_tokens << FastcExpressionToken{
-				tok:          .name
-				lit:          temporary
-				typ:          value_type
-				is_statement: or_expression_is_statement
-			}
-			if value_type == 'void' {
 				expression_tokens << FastcExpressionToken{
-					tok: .assign
-					lit: '='
+					tok: .name
+					lit: temporary
+					// Carry the rendered `({ ... })` so a trailing `.method()`
+					// (`expr or { v }.str()`) binds to it via render_method_receiver_expression.
+					source:       or_expr_body
+					typ:          value_type
+					is_statement: or_expression_is_statement
 				}
-			}
-			if assignment_prefix != '' {
-				expression_tokens << FastcExpressionToken{
-					tok: .assign
-					lit: '='
+				if value_type == 'void' {
+					expression_tokens << FastcExpressionToken{
+						tok: .assign
+						lit: '='
+					}
+				}
+				if assignment_prefix != '' {
+					expression_tokens << FastcExpressionToken{
+						tok: .assign
+						lit: '='
+					}
 				}
 			}
 			previous_token = .name
@@ -535,13 +1239,13 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 			return g.unsupported('expression token `${g.token_source()}`')
 		}
 		if (!g.selfhost || g.tok !in [.lcbr, .rcbr])
-			&& g.tok in [.lcbr, .rcbr, .str_dollar, .key_match, .key_or, .key_as, .arrow, .power] {
+			&& g.tok in [.lcbr, .rcbr, .str_dollar, .key_match, .key_or, .arrow, .power] {
 			return g.unsupported('expression token `${g.token_source()}`')
 		}
 		if !g.selfhost && g.tok in [.key_in, .not_in] {
 			return g.unsupported('expression token `${g.token_source()}`')
 		}
-		if !g.selfhost && g.tok in [.key_is, .not_is] {
+		if !g.selfhost && g.tok in [.key_is, .not_is, .key_as] {
 			return g.unsupported('expression token `${g.token_source()}`')
 		}
 		match g.tok {
@@ -583,6 +1287,14 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 			}
 			mutation_operator = g.tok
 			tokens_before_mutation = source_token_count
+			if g.selfhost && g.tok == .assign {
+				target_type := g.infer_expression_type(expression_tokens[..source_token_count]) or {
+					''
+				}
+				if target_type != '' {
+					g.expected_expression_type = target_type
+				}
+			}
 			mut mutation_lookahead := g.s
 			next_mutation_token := mutation_lookahead.scan()
 			mutation_ends_line := mutation_lookahead.pos >= g.s.offset
@@ -597,8 +1309,16 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 			}
 		}
 		source_token_count++
+		// A word that is also a keyword (`conn.select(...)`, `x.lock`) is a member
+		// name, not a keyword, once it follows `.`; store it as a plain name so the
+		// method-call and inference paths recognize it like any other member.
+		stored_tok := if previous_token == .dot && g.tok.is_keyword() {
+			token.Token.name
+		} else {
+			g.tok
+		}
 		expression_tokens << FastcExpressionToken{
-			tok:             g.tok
+			tok:             stored_tok
 			lit:             g.lit
 			unsafe_depth:    g.unsafe_depth
 			is_mut_argument: next_token_is_mut_argument
@@ -607,12 +1327,27 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 		module_separator := g.expression_dot_is_module_separator(expression_tokens,
 			expression_tokens.len - 1)
 		qualified_name_owner := if g.tok == .name && previous_token == .dot
-			&& expression_tokens.len >= 3 {
+			&& expression_tokens.len >= 3
+			&& g.expression_dot_is_module_separator(expression_tokens, expression_tokens.len - 2) {
 			expression_tokens[expression_tokens.len - 3].lit
 		} else {
 			''
 		}
-		mut piece := g.expression_token(previous_token, previous_lit, qualified_name_owner)!
+		mut piece := g.expression_token(previous_token, previous_lit, qualified_name_owner,
+			module_separator)!
+		if g.selfhost && !g.in_generic_placeholder && g.tok == .name
+			&& g.generic_method_sources.len > 0 {
+			if mono := g.queue_explicit_mono_method(expression_tokens) {
+				piece = mono
+				expression_tokens.last().lit = mono
+			} else if mono := g.queue_explicit_mono_function(expression_tokens) {
+				piece = mono
+				expression_tokens.last().lit = mono
+			} else if mono := g.queue_implicit_mono_function(expression_tokens) {
+				piece = mono
+				expression_tokens.last().lit = mono
+			}
+		}
 		if g.tok == .name && previous_token != .dot {
 			// A name after `.` is a field or method: never substitute a local
 			// (a mut parameter's deref form) that happens to share its name.
@@ -621,8 +1356,24 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 				next_token := lookahead.scan()
 				is_single_value := expression_tokens.len == 1
 					&& (next_token in stops || next_token == .eof)
+				// An explicit deref of a reference local (`*b` where `b` is a `mut` receiver,
+				// C type `T*`): the leading `*` already dereferences, so auto-deref would
+				// double it (`*(*(b))`). Skip the auto-deref so `*b` renders as `*(b)`. Only a
+				// PREFIX `*` counts — a binary `a * b` still needs `b`'s value.
+				is_deref_prefix := previous_token == .mul && expression_tokens.len > 0
+					&& fastc_token_is_prefix_operator(expression_tokens, expression_tokens.len - 1)
+				cast_type := if previous_token == .lpar && expression_tokens.len >= 3
+					&& expression_tokens[expression_tokens.len - 3].tok == .name {
+					fastc_primitive_c_type(expression_tokens[expression_tokens.len - 3].lit) or {
+						''
+					}
+				} else {
+					''
+				}
+				is_pointer_cast_operand := cast_type != '' && fastc_is_pointer_type(cast_type)
 				if local.is_reference && !expression_tokens.last().is_mut_argument
-					&& next_token !in [.dot, .lsbr] && !is_single_value {
+					&& next_token !in [.dot, .lsbr] && !is_single_value && !is_deref_prefix
+					&& !is_pointer_cast_operand {
 					piece = '(*(${piece}))'
 				}
 			}
@@ -630,10 +1381,39 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 		if module_separator && piece == '.' {
 			piece = '__'
 		}
+		if previous_token == .dot && (g.tok == .name || g.tok.is_keyword())
+			&& expression_tokens.len >= 3
+			&& g.expression_dot_is_module_separator(expression_tokens, expression_tokens.len - 2) {
+			// A module or enum prefix makes a keyword-named symbol C-safe
+			// (`TokenKind.float` -> `TokenKind__float`).
+			piece = g.lit
+		}
 		if g.tok == .name && previous_token == .dot {
 			mut method_lookahead := g.s
 			if method_lookahead.scan() == .lpar {
 				piece = g.lit
+				// On-demand generic-method monomorphization: `recv.m(arg)` where `m` is a
+				// generic method (own type param, left un-monomorphized because its body
+				// recurses through a comptime `$for`). Infer the first arg's type, queue the
+				// concrete instance, and emit its mangled name so the call resolves to it.
+				if g.selfhost && !g.in_generic_placeholder && g.generic_method_sources.len > 0
+					&& expression_tokens.len >= 3
+					&& expression_tokens[expression_tokens.len - 2].tok == .dot {
+					dot_index := expression_tokens.len - 2
+					recv_start := fastc_method_receiver_start(expression_tokens, dot_index)
+					receiver_type := g.infer_expression_type(expression_tokens[recv_start..dot_index]) or {
+						''
+					}
+					recv_base := fastc_normalize_inferred_type(receiver_type).trim_right('*')
+					if recv_base != '' && '${recv_base}.${g.lit}' in g.generic_method_sources {
+						concrete := g.mono_argument_type(mut method_lookahead)
+						if concrete != '' {
+							mono := g.queue_mono_method(recv_base, g.lit, concrete)
+							piece = mono
+							expression_tokens[expression_tokens.len - 1].lit = mono
+						}
+					}
+				}
 			}
 		}
 		if g.tok == .name && expression_tokens.len >= 3
@@ -652,6 +1432,8 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 			piece = '->'
 		}
 		if g.tok == .lpar && previous_token == .name {
+			name_is_member := expression_tokens.len >= 3
+				&& expression_tokens[expression_tokens.len - 3].tok == .dot
 			pointer_token := if expression_tokens.len >= 3
 				&& fastc_token_is_prefix_operator(expression_tokens, expression_tokens.len - 3) {
 				expression_tokens[expression_tokens.len - 3].tok
@@ -673,14 +1455,16 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 				&& expression_tokens[expression_tokens.len - 3].tok == .rsbr {
 				element_type := fastc_primitive_c_type(previous_lit) or { previous_lit }
 				array_type := fastc_array_c_type(element_type)
-				result.go_back(previous_lit.len + 2)
+				rendered_previous := g.resolved_expression_name(previous_lit, .unknown)
+				result.go_back(rendered_previous.len + 2)
 				piece = '((${array_type})('
 				cast_depths << paren_depth + 1
 			} else if expression_tokens.len >= 4
 				&& expression_tokens[expression_tokens.len - 4].tok == .name
 				&& expression_tokens[expression_tokens.len - 4].lit == 'C'
 				&& expression_tokens[expression_tokens.len - 3].tok == .dot && previous_lit.len > 0
-				&& previous_lit[0].is_capital() && 'C.${previous_lit}' !in g.functions {
+				&& 'C.${previous_lit}' !in g.functions && g.current_call_has_one_argument()
+				&& (previous_lit[0].is_capital() || '#Cstruct#${previous_lit}' in g.declared_types) {
 				c_pointer_token := if expression_tokens.len >= 5
 					&& fastc_token_is_prefix_operator(expression_tokens, expression_tokens.len - 5) {
 					expression_tokens[expression_tokens.len - 5].tok
@@ -694,28 +1478,57 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 				} else {
 					0
 				}
+				c_cast_type := if '#Cstruct#${previous_lit}' in g.declared_types {
+					'struct ${previous_lit}'
+				} else {
+					previous_lit
+				}
 				result.go_back(previous_lit.len + c_pointer_count)
-				piece = '((${previous_lit}${'*'.repeat(c_pointer_count)})('
+				piece = '((${c_cast_type}${'*'.repeat(c_pointer_count)})('
 				cast_depths << paren_depth + 1
 				if c_pointer_count > 0 {
 					pointer_cast_depths << paren_depth + 1
 				}
+			} else if expression_tokens.len >= 4
+				&& expression_tokens[expression_tokens.len - 3].tok == .dot
+				&& expression_tokens[expression_tokens.len - 4].tok == .name
+				&& expression_tokens[expression_tokens.len - 4].lit in g.imports {
+				// Qualified conversion `mod.Type(value)` (e.g. `orm.Primitive(x)`): render
+				// it as a C cast so a sum-type/interface operand is boxed downstream,
+				// instead of the default `mod__Type(value)` call-style spelling.
+				module_lit := expression_tokens[expression_tokens.len - 4].lit
+				qualified_key := fastc_type_key(g.imports[module_lit], previous_lit)
+				if qualified_key in g.declared_types {
+					cast_type := fastc_c_declared_type_name(qualified_key)
+					result.go_back(cast_type.len + pointer_prefix_len)
+					piece = '((${cast_type}${pointer_suffix})('
+					cast_depths << paren_depth + 1
+					if pointer_cast {
+						pointer_cast_depths << paren_depth + 1
+					}
+				}
 			} else if cast_type := fastc_primitive_c_type(previous_lit) {
-				result.go_back(cast_type.len + pointer_prefix_len)
-				piece = '((${cast_type}${pointer_suffix})('
-				cast_depths << paren_depth + 1
-				if pointer_cast {
-					pointer_cast_depths << paren_depth + 1
+				if !name_is_member {
+					rendered_previous := g.resolved_expression_name(previous_lit, .unknown)
+					result.go_back(rendered_previous.len + pointer_prefix_len)
+					piece = '((${cast_type}${pointer_suffix})('
+					cast_depths << paren_depth + 1
+					if pointer_cast {
+						pointer_cast_depths << paren_depth + 1
+					}
 				}
 			} else if type_key := fastc_resolve_declared_type_key(g.module_name, previous_lit,
 				g.imports, g.declared_types)
 			{
-				cast_type := fastc_c_declared_type_name(type_key)
-				result.go_back(cast_type.len + pointer_prefix_len)
-				piece = '((${cast_type}${pointer_suffix})('
-				cast_depths << paren_depth + 1
-				if pointer_cast {
-					pointer_cast_depths << paren_depth + 1
+				if !name_is_member {
+					cast_type := fastc_c_declared_type_name(type_key)
+					rendered_previous := g.resolved_expression_name(previous_lit, .unknown)
+					result.go_back(rendered_previous.len + pointer_prefix_len)
+					piece = '((${cast_type}${pointer_suffix})('
+					cast_depths << paren_depth + 1
+					if pointer_cast {
+						pointer_cast_depths << paren_depth + 1
+					}
 				}
 			}
 		}
@@ -823,6 +1636,7 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 		} else if g.selfhost && g.tok == .colon && struct_depths.len > 0
 			&& brace_depth == struct_depths.last() && paren_depth == struct_paren_depths.last() {
 			piece = '='
+			pending_field_value_mark = true
 		} else if g.selfhost && struct_depths.len > 0 && brace_depth == struct_depths.last()
 			&& paren_depth == struct_paren_depths.last() && g.tok == .semicolon {
 			piece = ','
@@ -887,7 +1701,7 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 				piece = ''
 				enum_shorthand_type = contextual_type
 			}
-		} else if g.selfhost && enum_shorthand_type != '' && g.tok == .name {
+		} else if g.selfhost && enum_shorthand_type != '' && (g.tok == .name || g.tok.is_keyword()) {
 			piece = '${enum_shorthand_type.trim_right('*')}__${g.lit}'
 			expression_tokens[expression_tokens.len - 1].typ = enum_shorthand_type
 			enum_shorthand_type = ''
@@ -897,6 +1711,10 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 			result.write_u8(` `)
 		}
 		result.write_string(piece)
+		if pending_field_value_mark {
+			struct_field_value_start = result.len
+			pending_field_value_mark = false
+		}
 		match g.tok {
 			.lpar {
 				paren_depth++
@@ -934,6 +1752,7 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 		previous_token_end = g.s.offset
 		g.next()
 	}
+	g.expected_expression_type = saved_expected_expression_type
 	if paren_depth != 0 {
 		return g.unsupported('unbalanced expression')
 	}
@@ -988,21 +1807,86 @@ fn (g &Parser) render_constant_references(tokens []FastcExpressionToken, source 
 			continue
 		}
 		if i + 1 < tokens.len && tokens[i + 1].tok == .lpar {
+			if fastc_primitive_c_type(item.lit) != none {
+				continue
+			}
+			if fastc_resolve_declared_type_key(g.module_name, item.lit, g.imports, g.declared_types) != none {
+				continue
+			}
 			function_key := g.unqualified_function_key(item.lit)
-			if function_key in g.functions {
-				rendered = fastc_replace_c_identifier(rendered, item.lit,
+			if function_key in g.functions || function_key in g.mono_functions {
+				rendered = fastc_replace_c_call_identifier(rendered, item.lit,
 					fastc_c_function_name_for_key(function_key))
 				continue
 			}
 		}
 		constant_key := fastc_constant_key(g.module_name, item.lit)
 		if c_name := g.constants[constant_key] {
-			rendered = fastc_replace_c_identifier(rendered, item.lit, c_name)
+			rendered = fastc_replace_c_root_identifier(rendered, item.lit, c_name)
 		} else if c_name := g.constants[fastc_constant_key('builtin', item.lit)] {
-			rendered = fastc_replace_c_identifier(rendered, item.lit, c_name)
+			rendered = fastc_replace_c_root_identifier(rendered, item.lit, c_name)
 		}
 	}
 	return rendered
+}
+
+fn fastc_replace_c_call_identifier(source string, identifier string, replacement string) string {
+	if identifier == '' || identifier == replacement || !source.contains(identifier) {
+		return source
+	}
+	mut out := strings.new_builder(source.len + replacement.len)
+	mut start := 0
+	for start < source.len {
+		remaining := source[start..]
+		relative := remaining.index(identifier) or {
+			out.write_string(remaining)
+			break
+		}
+		index := start + relative
+		end := index + identifier.len
+		before_is_name_or_member := index > 0 && (source[index - 1].is_alnum()
+			|| source[index - 1] in [`_`, `.`])
+		mut after := end
+		for after < source.len && source[after] in [` `, `\t`, `\r`, `\n`] {
+			after++
+		}
+		out.write_string(source[start..index])
+		if before_is_name_or_member || after >= source.len || source[after] != `(` {
+			out.write_string(identifier)
+		} else {
+			out.write_string(replacement)
+		}
+		start = end
+	}
+	return out.str()
+}
+
+fn fastc_replace_c_root_identifier(source string, identifier string, replacement string) string {
+	if identifier == '' || identifier == replacement || !source.contains(identifier) {
+		return source
+	}
+	mut out := strings.new_builder(source.len + replacement.len)
+	mut start := 0
+	for start < source.len {
+		remaining := source[start..]
+		relative := remaining.index(identifier) or {
+			out.write_string(remaining)
+			break
+		}
+		index := start + relative
+		end := index + identifier.len
+		before_is_name := index > 0 && (source[index - 1].is_alnum() || source[index - 1] == `_`)
+		before_is_member := index > 0 && source[index - 1] in [`.`, `>`]
+		after_is_name := end < source.len && (source[end].is_alnum() || source[end] == `_`)
+		out.write_string(source[start..index])
+		if before_is_name || before_is_member || after_is_name {
+			out.write_string(identifier)
+		} else {
+			out.write_string(replacement)
+		}
+		start = end
+	}
+	return out.str()
 }
 
 fn fastc_replace_c_identifier(source string, identifier string, replacement string) string {
@@ -1043,7 +1927,12 @@ fn (g &Parser) semicolon_continues_expression() bool {
 	if offset + 1 < g.s.src.len && g.s.src[offset] == `/` && g.s.src[offset + 1] in [`/`, `*`] {
 		return false
 	}
-	return g.s.src[offset] in [`.`, `+`, `-`, `*`, `/`, `%`, `&`, `|`, `^`, `<`, `>`, `=`, `?`]
+	if g.in_enum_keyed_map_value && g.s.src[offset] == `.` {
+		// The next `.field` starts the following map entry, not a member chain.
+		return false
+	}
+	return g.s.src[offset] in [`.`, `+`, `-`, `*`, `/`, `%`, `&`, `|`, `^`, `<`, `>`, `=`, `?`,
+		`)`]
 }
 
 fn fastc_runtime_c_type(typ string) string {
@@ -1064,15 +1953,60 @@ fn (mut g Parser) read_inferred_map_literal() !string {
 	mut values := []string{}
 	mut key_type := ''
 	mut value_type := ''
+	// Enum-shorthand keys (`{ .field: v }`) carry no type of their own; recover the
+	// key enum type from the declared enum that owns the first `.field`, and read
+	// every key with it as the expected type so `.field` resolves.
+	g.skip_semicolons()
+	mut key_enum_type := ''
+	if g.tok == .dot {
+		// Shorthand key `.field`: recover the enum from the field name.
+		mut lookahead := g.s
+		if lookahead.scan() == .name {
+			if enum_type := g.enum_field_types[lookahead.lit] {
+				key_enum_type = enum_type
+			}
+		}
+	} else if g.tok == .name {
+		// Explicit key `EnumType.field` (the first entry often spells it out).
+		mut lookahead := g.s
+		if lookahead.scan() == .dot {
+			if type_key := fastc_resolve_declared_type_key(g.module_name, g.lit, g.imports,
+				g.declared_types)
+			{
+				if g.declared_kinds[type_key] == .enum_ {
+					key_enum_type = fastc_c_declared_type_name(type_key)
+				}
+			}
+		}
+	}
 	for g.tok != .rcbr {
 		g.skip_semicolons()
 		if g.tok == .rcbr {
 			break
 		}
+		previous_expected := g.expected_expression_type
+		if key_enum_type != '' {
+			g.expected_expression_type = key_enum_type
+		}
 		key := g.read_expression([token.Token.colon])!
-		actual_key_type := fastc_normalize_inferred_type(g.last_expression_type)
+		g.expected_expression_type = previous_expected
+		actual_key_type := if key_enum_type != '' {
+			key_enum_type
+		} else {
+			fastc_normalize_inferred_type(g.last_expression_type)
+		}
 		g.expect(.colon)!
+		// In an enum-keyed map the next entry begins with `.field` on a new line; a
+		// value must not treat that `.` as a member-chain continuation.
+		previous_enum_map := g.in_enum_keyed_map_value
+		g.in_enum_keyed_map_value = key_enum_type != ''
+		previous_value_expected := g.expected_expression_type
+		if value_type != '' {
+			g.expected_expression_type = value_type
+		}
 		value := g.read_expression([token.Token.comma, token.Token.semicolon, token.Token.rcbr])!
+		g.expected_expression_type = previous_value_expected
+		g.in_enum_keyed_map_value = previous_enum_map
 		actual_value_type := fastc_normalize_inferred_type(g.last_expression_type)
 		if key_type == '' {
 			key_type = actual_key_type
@@ -1085,10 +2019,20 @@ fn (mut g Parser) read_inferred_map_literal() !string {
 		}
 	}
 	g.expect(.rcbr)!
-	if keys.len == 0 || key_type == '' || value_type == '' {
+	mut map_type := ''
+	if keys.len == 0 {
+		map_type = fastc_normalize_inferred_type(g.expected_expression_type)
+		expected_key_type, expected_value_type := g.map_key_value_types(map_type) or {
+			return g.unsupported('empty inferred map literal')
+		}
+		key_type = expected_key_type
+		value_type = expected_value_type
+	} else if key_type == '' || value_type == '' {
 		return g.unsupported('empty inferred map literal')
 	}
-	map_type := fastc_map_c_type(key_type, value_type)
+	if map_type == '' {
+		map_type = fastc_map_c_type(key_type, value_type)
+	}
 	hash_fn, eq_fn, clone_fn, free_fn := g.map_runtime_functions(key_type)
 	map_name := g.temporary_name('map_literal')
 	mut statements := [
@@ -1110,6 +2054,70 @@ fn (mut g Parser) read_inferred_map_literal() !string {
 		},
 	]
 	return '({ ${statements.join(' ')} ${map_name}; })'
+}
+
+// read_channel_receive lowers `<-ch` / `<-ch or { … }`. Channels are the type-erased
+// `void*` stub, so this pops via the non-blocking `builtin__chan_try_pop` into a temp
+// of the element type (recovered from the expected type or the channel's tracked
+// element). The stub pop always "succeeds", so an `or` block is dead and is discarded.
+fn (mut g Parser) read_channel_receive(stops []token.Token) !string {
+	g.expect(.arrow)!
+	mut operand_stops := stops.clone()
+	if token.Token.key_or !in operand_stops {
+		operand_stops << token.Token.key_or
+	}
+	expected := g.expected_expression_type
+	g.expected_expression_type = ''
+	channel := g.read_expression(operand_stops)!
+	channel_tokens := g.last_expression.clone()
+	g.expected_expression_type = expected
+	mut element_type := fastc_normalize_inferred_type(expected)
+	if element_type in ['', 'chan', 'Option', 'void'] {
+		element_type = g.channel_element_type(channel_tokens)
+	}
+	if element_type == '' {
+		element_type = 'int'
+	}
+	if g.tok == .key_or {
+		g.next()
+		if g.tok == .lcbr {
+			g.skip_balanced(.lcbr, .rcbr)!
+		}
+	}
+	recv_tmp := g.temporary_name('chan_recv')
+	g.last_expression_type = element_type
+	g.last_expression = [
+		FastcExpressionToken{
+			tok: .name
+			lit: recv_tmp
+			typ: element_type
+		},
+	]
+	return '({ ${element_type} ${recv_tmp} = (${element_type}){0}; builtin__chan_try_pop((chan)(${channel}), &${recv_tmp}); ${recv_tmp}; })'
+}
+
+// channel_element_type recovers the element C type of the channel that `tokens`
+// evaluates to: a bare local, or an `x.field` member access on a struct with a
+// `chan` field. Returns '' when it cannot be determined.
+fn (g &Parser) channel_element_type(tokens []FastcExpressionToken) string {
+	if tokens.len == 1 && tokens[0].tok == .name {
+		if local := g.locals[tokens[0].lit] {
+			return local.chan_element_type
+		}
+	}
+	if tokens.len >= 3 && tokens.last().tok == .name && tokens[tokens.len - 2].tok == .dot {
+		receiver_type := g.infer_expression_type(tokens[..tokens.len - 2]) or { return '' }
+		receiver_layout := fastc_normalize_inferred_type(receiver_type).trim_right('*')
+		field_name := tokens.last().lit
+		if fields := g.struct_field_info[receiver_layout] {
+			for field in fields {
+				if field.name == field_name {
+					return field.chan_element_type
+				}
+			}
+		}
+	}
+	return ''
 }
 
 fn (g &Parser) expected_call_argument_type(tokens []FastcExpressionToken) string {
@@ -1164,14 +2172,29 @@ fn (g &Parser) expected_call_argument_type(tokens []FastcExpressionToken) string
 }
 
 fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered_expression string) ?FastcRenderedExpression {
+	if c_sizeof := g.render_c_struct_sizeof(tokens) {
+		return c_sizeof
+	}
+	if interface_object := g.render_c_interface_object_address(tokens) {
+		return interface_object
+	}
 	if type_name := g.render_typeof_name_expression(tokens) {
 		return type_name
+	}
+	if type_reflection := g.render_typeof_generic_expression(tokens) {
+		return type_reflection
+	}
+	if type_comparison := g.render_typeof_generic_comparison_expression(tokens) {
+		return type_comparison
 	}
 	if disabled_call := g.render_disabled_call_expression(tokens) {
 		return disabled_call
 	}
 	if enum_print := g.render_enum_print_expression(tokens) {
 		return enum_print
+	}
+	if selfhost_print := g.render_selfhost_print_expression(tokens) {
+		return selfhost_print
 	}
 	if bool_print := g.render_bool_print_expression(tokens) {
 		return bool_print
@@ -1189,6 +2212,19 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 			}
 		}
 	}
+	if g.selfhost && g.expression_uses_member_smartcast(tokens) {
+		if source := g.render_member_receiver(tokens) {
+			if typ := g.infer_member_access_type(tokens) {
+				return FastcRenderedExpression{
+					source: source
+					typ:    typ
+				}
+			}
+		}
+	}
+	if overloaded_binary := g.render_overloaded_binary_expression(tokens) {
+		return overloaded_binary
+	}
 	if struct_comparison := g.render_struct_comparison_expression(tokens) {
 		return struct_comparison
 	}
@@ -1204,8 +2240,19 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 		}
 	}
 	if g.selfhost {
+		if tokens.len > 1 && tokens.last().tok == .not {
+			if assignment := g.render_assignment_expression(tokens) {
+				// Assignment supplies the target type to its RHS. In particular, an
+				// option-returning call propagated with `!` is unwrapped recursively and
+				// then boxed when the target itself is an Option field/local.
+				return assignment
+			}
+		}
 		if interface_cast := g.render_interface_cast_expression(tokens, rendered_expression) {
 			return interface_cast
+		}
+		if nested_propagation := g.render_nested_option_propagation(tokens, rendered_expression) {
+			return nested_propagation
 		}
 	}
 	if cast_expression := g.render_cast_expression(tokens) {
@@ -1217,6 +2264,9 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 		return cast_expression
 	}
 	if g.selfhost {
+		if explicit_generic := g.render_explicit_generic_call_expression(tokens) {
+			return explicit_generic
+		}
 		if defaulted_call := g.render_missing_call_arguments(tokens) {
 			return defaulted_call
 		}
@@ -1232,14 +2282,16 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 		if initializer_assignment := g.render_initializer_assignment_expression(tokens) {
 			return initializer_assignment
 		}
-		if assignment := g.render_assignment_expression(tokens) {
-			return assignment
-		}
 		if array_assignment := g.render_array_assignment_expression(tokens) {
 			return array_assignment
 		}
-		if static_call := g.render_static_call_expression(tokens, rendered_expression) {
-			return static_call
+		if assignment := g.render_assignment_expression(tokens) {
+			return assignment
+		}
+		if tokens.len == 0 || tokens.last().tok != .not {
+			if static_call := g.render_static_call_expression(tokens, rendered_expression) {
+				return static_call
+			}
 		}
 		if logical := g.render_logical_expression(tokens) {
 			return logical
@@ -1264,10 +2316,18 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 			return concatenation
 		}
 		if tokens.len > 1 && tokens.last().tok == .not && rendered_expression.ends_with('!')
-			&& !(tokens[0].tok == .lsbr && tokens[tokens.len - 2].tok == .rsbr) {
+			&& !fastc_trailing_not_marks_fixed_array_literal(tokens) {
 			inner_tokens := tokens[..tokens.len - 1]
 			mut inner_source := rendered_expression[..rendered_expression.len - 1]
-			if method_expression := g.render_method_call_expression(inner_tokens, inner_source) {
+			if explicit_generic := g.render_explicit_generic_call_expression(inner_tokens) {
+				inner_source = explicit_generic.source
+			} else if static_expression := g.render_static_call_expression(inner_tokens,
+				inner_source)
+			{
+				inner_source = static_expression.source
+			} else if method_expression := g.render_method_call_expression(inner_tokens,
+				inner_source)
+			{
 				inner_source = method_expression.source
 			} else if array_expression := g.render_array_access_expression(inner_tokens) {
 				inner_source = array_expression.source
@@ -1328,7 +2388,7 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 					}
 				}
 				if right_type.trim_right('*').starts_with('Map_') {
-					key_type, _ := fastc_map_key_value_types(right_type) or { return none }
+					key_type, _ := g.map_key_value_types(right_type) or { return none }
 					key_source := g.render_membership_candidate(tokens[..i], key_type) or {
 						return none
 					}
@@ -1346,7 +2406,8 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 						typ:    'bool'
 					}
 				}
-				if right_type.trim_right('*').starts_with('Array_') {
+				right_layout := right_type.trim_right('*')
+				if right_layout.starts_with('Array_') || right_layout.starts_with('FixedArray_') {
 					element_type := g.array_element_type(right_type) or { return none }
 					candidate := g.render_membership_candidate(tokens[..i], element_type) or {
 						return none
@@ -1359,6 +2420,11 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 					found_name := '${temporary_namespace}_found'
 					index_name := '${temporary_namespace}_index'
 					access := if right_type.ends_with('*') { '->' } else { '.' }
+					collection_length := if fixed_length := fastc_fixed_array_length(right_layout) {
+						fixed_length
+					} else {
+						'${collection_name}${access}len'
+					}
 					comparison := if g.underlying_alias_type(element_type).trim_right('*') == 'string' {
 						'builtin__string_eq(${item_name}, ((${element_type} *)${collection_name}${access}data)[${index_name}])'
 					} else {
@@ -1369,15 +2435,17 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 					// literally, corrupting the emitted membership expression.
 					predicate := if item.tok == .not_in { '!${found_name}' } else { found_name }
 					return FastcRenderedExpression{
-						source: '({ ${element_type} ${item_name} = (${candidate}); __typeof__((${collection})) ${collection_name} = (${collection}); bool ${found_name} = false; for (int ${index_name} = 0; ${index_name} < ${collection_name}${access}len; ${index_name}++) { if (${comparison}) { ${found_name} = true; break; } } ${predicate}; })'
+						source: '({ ${element_type} ${item_name} = (${candidate}); __typeof__((${collection})) ${collection_name} = (${collection}); bool ${found_name} = false; for (int ${index_name} = 0; ${index_name} < ${collection_length}; ${index_name}++) { if (${comparison}) { ${found_name} = true; break; } } ${predicate}; })'
 						typ:    'bool'
 					}
 				}
-				if i + 2 >= tokens.len || tokens[i + 1].tok != .lsbr || tokens.last().tok != .rsbr {
+				array_end := if tokens.last().tok == .not { tokens.len - 1 } else { tokens.len }
+				if i + 2 >= array_end || tokens[i + 1].tok != .lsbr
+					|| tokens[array_end - 1].tok != .rsbr {
 					continue
 				}
 				lhs_type := g.infer_expression_type(tokens[..i]) or { return none }
-				items := fastc_expression_list_items(tokens, i + 2, tokens.len - 1) or {
+				items := fastc_expression_list_items(tokens, i + 2, array_end - 1) or {
 					return none
 				}
 				if items.len == 0 {
@@ -1413,6 +2481,11 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 				}
 			}
 		}
+		if array_type := g.infer_expression_type(tokens) {
+			if array_literal := g.render_array_literal_argument(tokens, array_type) {
+				return array_literal
+			}
+		}
 		// Resolve a complete index expression before the generic pointer/member
 		// rewriter gets a chance to treat its base as part of a longer chain.
 		if array_access := g.render_array_access_expression(tokens) {
@@ -1430,6 +2503,16 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 					typ:    method_expression.typ
 				}
 			}
+			if array_type := g.infer_expression_type(tokens) {
+				if array_literal := g.render_array_literal_argument(tokens, array_type) {
+					return array_literal
+				}
+			}
+			if pointer_members := g.render_pointer_member_access_expression(tokens,
+				method_expression.source)
+			{
+				return pointer_members
+			}
 			return method_expression
 		}
 		if defaulted_call := g.render_missing_call_arguments(tokens) {
@@ -1439,16 +2522,47 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 			return array_expression
 		}
 	}
-	if g.selfhost && tokens.len == 3 && tokens[0].tok == .name
-		&& tokens[1].tok in [.key_is, .not_is] && tokens[2].tok == .name {
+	if g.selfhost && tokens.len >= 3 && tokens[0].tok == .name
+		&& tokens[1].tok in [.key_is, .not_is] {
 		lhs_type := g.infer_expression_type(tokens[..1]) or { return none }
-		type_key := fastc_resolve_declared_type_key(g.module_name, tokens[2].lit, g.imports,
-			g.declared_types) or { return none }
+		mut variant_c := ''
+		if tokens.len == 3 && tokens[2].tok == .name {
+			if type_key := fastc_resolve_declared_type_key(g.module_name, tokens[2].lit, g.imports,
+				g.declared_types)
+			{
+				variant_c = fastc_c_declared_type_name(type_key)
+			}
+		} else if resolved_target := g.type_from_expression_tokens(tokens[2..]) {
+			// Qualified (`err is io.Eof`) and composite (`x is []string`) targets both
+			// lower to their concrete C spelling and its generated `__v_typeid_` tag.
+			target := fastc_normalize_inferred_type(resolved_target)
+			variant_c = target.trim_right('*')
+		}
+		if variant_c == '' {
+			return none
+		}
 		access := if lhs_type.ends_with('*') { '->' } else { '.' }
 		operator := if tokens[1].tok == .key_is { '==' } else { '!=' }
 		return FastcRenderedExpression{
-			source: '((${tokens[0].lit}${access}_typ) ${operator} __v_typeid_${fastc_c_declared_type_name(type_key)})'
+			source: '((${tokens[0].lit}${access}_typ) ${operator} __v_typeid_${variant_c})'
 			typ:    'bool'
+		}
+	}
+	if g.selfhost {
+		if as_expression := g.render_as_cast_expression(tokens) {
+			return as_expression
+		}
+	}
+	if g.selfhost && tokens.len >= 3 && tokens.last().tok == .name
+		&& tokens[tokens.len - 2].tok == .dot && tokens.last().lit in ['len', 'cap', 'closed'] {
+		// The erased `void*` chan stub has no fields. Channels are non-functional in
+		// this scanner lane, so report the empty/open stub state.
+		receiver_type := g.infer_expression_type(tokens[..tokens.len - 2]) or { '' }
+		if fastc_normalize_inferred_type(receiver_type).trim_right('*') == 'chan' {
+			return FastcRenderedExpression{
+				source: if tokens.last().lit == 'closed' { 'false' } else { '0' }
+				typ:    if tokens.last().lit == 'closed' { 'bool' } else { 'int' }
+			}
 		}
 	}
 	if g.selfhost {
@@ -1461,6 +2575,18 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 		}
 		if init_open > 0 && tokens.last().tok == .rcbr {
 			if array_type := g.array_initializer_type(tokens[..init_open]) {
+				if array_type.starts_with('FixedArray_') && rendered_expression.contains('{.init=') {
+					length := fastc_fixed_array_length(array_type) or { return none }
+					marker := '{.init='
+					marker_index := rendered_expression.index(marker) or { return none }
+					value := rendered_expression[marker_index + marker.len..rendered_expression.len - 1]
+					return FastcRenderedExpression{
+						source: rendered_expression[..marker_index] +
+							'{.data={ [0 ... ${length} -
+							1] = ' + value + '}}'
+						typ:    array_type
+					}
+				}
 				return FastcRenderedExpression{
 					source: rendered_expression
 					typ:    array_type
@@ -1490,6 +2616,8 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 			return none
 		}
 		array_type := fastc_array_c_type(fastc_normalize_inferred_type(element_type))
+		mut w := unsafe { &Parser(g) }
+		fastc_register_composite_type(array_type, mut w.composite_types)
 		mut rendered_items := []string{cap: items.len}
 		for item in items {
 			rendered_items << g.render_call_argument_expression(item, element_type) or {
@@ -1570,4 +2698,20 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 		}
 	}
 	return g.render_flag_method_expression(tokens, rendered_expression)
+}
+
+fn (g &Parser) expression_uses_member_smartcast(tokens []FastcExpressionToken) bool {
+	if g.member_smartcasts.len == 0 || tokens.len < 3 || tokens[0].tok != .name {
+		return false
+	}
+	mut path := tokens[0].lit
+	mut index := 1
+	for index + 1 < tokens.len && tokens[index].tok == .dot && tokens[index + 1].tok == .name {
+		path += '.' + tokens[index + 1].lit
+		if path in g.member_smartcasts {
+			return true
+		}
+		index += 2
+	}
+	return false
 }

--- a/vlib/v3/gen/fastc/fastc.v
+++ b/vlib/v3/gen/fastc/fastc.v
@@ -43,7 +43,7 @@ typedef struct { void *data; int len; } map;
 typedef struct { void *data; void *err; unsigned char state; } Option;
 typedef union { uintptr_t word; long double alignment; unsigned char data[64]; } MultiReturnValue;
 typedef struct { MultiReturnValue values[8]; } MultiReturn;
-#define V_FASTC_MULTI_VALUE(expression) ({ __typeof__(expression) value = (expression); MultiReturnValue result = {0}; memcpy(result.data, &value, sizeof(value)); result; })
+#define V_FASTC_MULTI_VALUE(expression) ({ __typeof__(expression) __v_fastc_multi_value = (expression); MultiReturnValue __v_fastc_multi_result = {0}; memcpy(__v_fastc_multi_result.data, &__v_fastc_multi_value, sizeof(__v_fastc_multi_value)); __v_fastc_multi_result; })
 
 static void v_fastc_print_string(const char *value) { fputs(value ? value : "", stdout); }
 static void v_fastc_print_bool(bool value) { fputs(value ? "true" : "false", stdout); }
@@ -233,6 +233,12 @@ static string v_fastc_bool_str(bool value) { return value ? "true" : "false"; }
 #define print(value) V_FASTC_PRINT_SELECT(value, v_fastc_print_string, v_fastc_print_bool, v_fastc_print_char, v_fastc_print_signed, v_fastc_print_unsigned)
 #define println(value) V_FASTC_PRINT_SELECT(value, v_fastc_println_string, v_fastc_println_bool, v_fastc_println_char, v_fastc_println_signed, v_fastc_println_unsigned)
 
+static void *v_fastc_interface_box(const void *value, usize size) {
+	void *copy = malloc(size);
+	if (copy != NULL) memcpy(copy, value, size);
+	return copy;
+}
+
 '
 
 const c_integer_comparison_helpers = r'// signed/unsigned comparisons preserve mathematical ordering
@@ -331,7 +337,7 @@ typedef char *charptr;
 typedef void *chan;
 typedef union { uintptr_t word; long double alignment; unsigned char data[64]; } MultiReturnValue;
 typedef struct { MultiReturnValue values[8]; } MultiReturn;
-#define V_FASTC_MULTI_VALUE(expression) ({ __typeof__(expression) value = (expression); MultiReturnValue result = {0}; memcpy(result.data, &value, sizeof(value)); result; })
+#define V_FASTC_MULTI_VALUE(expression) ({ __typeof__(expression) __v_fastc_multi_value = (expression); MultiReturnValue __v_fastc_multi_result = {0}; memcpy(__v_fastc_multi_result.data, &__v_fastc_multi_value, sizeof(__v_fastc_multi_value)); __v_fastc_multi_result; })
 
 #define _S(s) ((string){.str=(byteptr)("" s), .len=(sizeof(s)-1), .is_lit=1})
 #define _SLIT0 _S("")
@@ -343,8 +349,17 @@ static void *v_fastc_interface_box(const void *value, usize size) {
 }
 
 static const u64 _wyp[4] = {0x2d358dccaa6c78a5ull, 0x8bb84b93962eacc9ull, 0x4b33a62ed433d4a3ull, 0x4d5a2da51de1aa47ull};
+static inline u64 _wymix(u64 a, u64 b) { u64 ha = a >> 32, hb = b >> 32, la = (u32)a, lb = (u32)b, hi, lo; u64 rh = ha * hb, rm0 = ha * lb, rm1 = hb * la, rl = la * lb, t = rl + (rm0 << 32), c = t < rl; lo = t + (rm1 << 32); c += lo < t; hi = rh + (rm0 >> 32) + (rm1 >> 32) + c; return lo ^ hi; }
 static inline u64 wyhash64(u64 a, u64 b) { a ^= _wyp[0]; b ^= _wyp[1]; a *= 0xa0761d6478bd642full; b *= 0xe7037ed1a0b428dbull; return (a ^ (a >> 32)) ^ (b ^ (b >> 32)); }
 static inline u64 wyhash(const void *key, size_t len, u64 seed, const u64 *secret) { const unsigned char *p = (const unsigned char *)key; u64 h = seed ^ secret[0] ^ (u64)len; for (size_t i = 0; i < len; i++) h = wyhash64(h ^ (u64)p[i], secret[(i + 1) & 3]); return h; }
+
+'
+
+// This must follow source `#include` directives: defining the function-like
+// fallback before `<pthread.h>` would rewrite declarations in that header.
+const c_selfhost_post_directives = r'#ifndef PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP
+#define pthread_rwlockattr_setkind_np(a, b) (0)
+#endif
 
 '
 
@@ -582,16 +597,28 @@ struct FastcLocal {
 	is_mut       bool
 	is_reference bool
 	typ          string
+	// For a variable declared with an option type (`b ?bool`), the C `typ` is the
+	// type-erased `Option`; this keeps the wrapped value type so an `if x := b`
+	// guard on the bare variable can unwrap it.
+	option_value_type string
+	// For a function-pointer parameter (`f fn (int) !string`), the C `typ` is a
+	// function pointer; these record the callee's return C type and, for an option
+	// return, its wrapped value type, so `f(x)` / `f(x) or {…}` infer correctly.
+	fn_return_type       string
+	fn_option_value_type string
+	// For a channel local (`ch chan T` / `ch := chan T{…}`), the C `typ` is the erased
+	// `chan`; this keeps the element C type so `<-ch` recovers the received value type.
+	chan_element_type string
 }
 
 struct FastcExpressionToken {
 	tok             token.Token
-	lit             string
 	source          string
 	unsafe_depth    int
 	is_mut_argument bool
 	is_statement    bool
 mut:
+	lit string
 	typ string
 }
 
@@ -606,18 +633,35 @@ struct FastcInterpolationWidth {
 }
 
 struct FastcStructField {
-	name           string
-	typ            string
-	is_public      bool
-	is_mutable     bool
-	is_required    bool
-	module_name    string
-	path           string
-	imports        map[string]string
-	default_source string
+	name                 string
+	typ                  string
+	is_public            bool
+	is_mutable           bool
+	is_required          bool
+	is_skip              bool
+	is_function          bool
+	is_optional_function bool
+	module_name          string
+	path                 string
+	imports              map[string]string
+	default_source       string
 mut:
 	default_value string
 	storage_path  []string
+	// For a `chan T` field, the erased C `typ` is `chan`; this keeps the element C type
+	// so `<-x.field` recovers the received value type.
+	chan_element_type string
+	// For an option field (`f ?T`), the erased C `typ` is `Option`; this keeps the
+	// wrapped value C type so `if mut v := x.f {` binds `v` to `T` (not the default int).
+	option_value_type string
+	// Function fields are stored as `voidptr`; retain their signature so member calls
+	// can cast the erased storage back to a callable C function pointer.
+	fn_parameter_types   []string
+	fn_return_type       string
+	fn_option_value_type string
+	// Imported generic structs retain erased storage, but a concrete field like
+	// `Stack[Item]` still carries `Item` for method result/argument recovery.
+	generic_argument_type string
 }
 
 struct FastcInterfaceField {
@@ -657,11 +701,14 @@ pub:
 	c_source     string
 	source_paths []string
 	uses_threads bool
+	c_flags      []string
 }
 
 struct FastcGlobalDeclarations {
 	declarations        string
 	module_initializers map[string]string
+	composite_types     map[string]bool
+	fixed_array_types   map[string]string
 }
 
 struct FastcConstantDeclarations {
@@ -669,6 +716,8 @@ struct FastcConstantDeclarations {
 	declarations        string
 	module_initializers map[string]string
 	compile_time_values map[string]string
+	composite_types     map[string]bool
+	fixed_array_types   map[string]string
 }
 
 struct FastcConstantValue {
@@ -710,6 +759,11 @@ struct FastcTypeDeclarations {
 	declarations        string
 	enum_string_helpers string
 	alias_base_types    map[string]string
+	enum_field_types    map[string]string
+	// Declared C names of sum types (`type X = A | B`). They share the boxed
+	// `{void*_object; u32 _typ;}` layout with interfaces; construction boxes a
+	// variant and `match` dispatches on `_typ`.
+	sum_types map[string]bool
 }
 
 struct FastcLoopBlockResult {
@@ -717,11 +771,23 @@ struct FastcLoopBlockResult {
 	has_reachable_break bool
 }
 
+// FastcMemberSmartcast records the concrete pointer used for a boxed interface/sum-type
+// member inside an `if holder.member is Concrete` branch. Unlike a local smart-cast, the
+// member cannot be shadowed under its qualified source spelling, so member-chain rendering
+// consults this table while the branch is active.
+struct FastcMemberSmartcast {
+	typ    string
+	source string
+}
+
 struct Parser {
-	prefs          &pref.Preferences
-	path           string
-	module_name    string
-	imports        map[string]string
+	prefs &pref.Preferences
+	// Generic methods (own type param) not resolved by the source-level pass, kept so a
+	// `recv.m(arg)` call can be monomorphized on demand at parse time (see anonfn/drain).
+	generic_method_sources map[string]FastcGenericMethodSource
+	// A module imported under a second name that re-exports another (e.g. `json2` aliased
+	// at `x.json2`): resolves `<alias>.<sym>` to the loaded `<target>.<sym>`.
+	module_aliases map[string]string
 	declared_types map[string]bool
 	// Generated C spelling -> declared type key, precomputed once per program
 	// (see fastc_declared_type_c_names); semantic_type_key resolves through it.
@@ -731,7 +797,9 @@ struct Parser {
 	fastc_prefixed_c_names []string
 	declared_kinds         map[string]FastcDeclaredTypeKind
 	enum_flags             map[string]bool
+	enum_field_types       map[string]string
 	alias_base_types       map[string]string
+	sum_types              map[string]bool
 	struct_fields          map[string]map[string]string
 	struct_field_info      map[string][]FastcStructField
 	interface_fields       map[string]FastcInterfaceField
@@ -745,16 +813,21 @@ struct Parser {
 	has_startup_inits      bool
 	has_cleanup_hooks      bool
 mut:
-	s                        scanner.Scanner
-	tok                      token.Token
-	lit                      string
-	out                      strings.Builder
-	protos                   strings.Builder
-	indent                   int
-	in_main                  bool
-	has_main                 bool
-	unsafe_depth             int
-	temp_id                  int
+	path         string
+	module_name  string
+	imports      map[string]string
+	s            scanner.Scanner
+	tok          token.Token
+	lit          string
+	out          strings.Builder
+	protos       strings.Builder
+	indent       int
+	in_main      bool
+	has_main     bool
+	unsafe_depth int
+	temp_id      int
+	// Per-file counter for anonymous-function / closure stub names (see anonfn.v).
+	anon_fn_counter          int
 	locals                   map[string]FastcLocal
 	functions                map[string]FastcFunctionSignature
 	constant_types           map[string]string
@@ -767,19 +840,43 @@ mut:
 	current_method_is_static bool
 	expected_expression_type string
 	capturing_defer          bool
-	defer_depth              int
-	captured_defer_lines     []string
-	deferred_lines           []string
-	deferred_block_starts    []int
-	loop_defer_block_starts  []int
-	loop_has_breaks          []bool
-	statement_reachable      bool
-	last_expression_type     string
-	last_expression          []FastcExpressionToken
-	last_multi_return_types  []string
-	fixed_array_types        map[string]string
-	composite_types          map[string]bool
-	expression_depth         int
+	// While parsing an `or { ... }` block that yields a value, a trailing bare value
+	// expression is captured here (typed by `or_value_expected_type`) instead of being
+	// rejected as a value-only statement.
+	or_value_capture        bool
+	or_value_captured       string
+	or_value_expected_type  string
+	defer_depth             int
+	captured_defer_lines    []string
+	deferred_lines          []string
+	deferred_block_starts   []int
+	loop_defer_block_starts []int
+	loop_has_breaks         []bool
+	statement_reachable     bool
+	last_expression_type    string
+	last_expression         []FastcExpressionToken
+	// Conditional expressions have no flat token list after their branches are
+	// parsed. Preserve an Option payload type for their consuming declaration.
+	last_option_value_type  string
+	last_multi_return_types []string
+	member_smartcasts       map[string]FastcMemberSmartcast
+	// Set by `parse_type` to the wrapped value type when it parses an option type
+	// (`?T`), so the caller can record it on the declared local.
+	pending_option_value_type string
+	// Set by `parse_type` when it parses a function type (`fn (...) R`): the C return
+	// type (`Option`/`string`/…) and, for an `!`/`?R` return, the wrapped value type.
+	// Lets a fn-typed parameter be declared as a real function pointer and its call
+	// results be type-inferred. `pending_fn_pointer` gates whether the others apply.
+	pending_fn_pointer           bool
+	pending_fn_return_type       string
+	pending_fn_option_value_type string
+	c_flags                      []string
+	fixed_array_types            map[string]string
+	composite_types              map[string]bool
+	expression_depth             int
+	// True while reading a value inside an enum-keyed map literal, so a `.field`
+	// on the next line is treated as the next key, not a member-chain continuation.
+	in_enum_keyed_map_value bool
 	// Comparison-handler results memoized per token subrange for the duration
 	// of one top-level expression (see fastc_comparison_memo_key). The boolean
 	// operator scans in those handlers re-recurse over shared subranges;
@@ -794,6 +891,24 @@ mut:
 	// Declaration-initializer parsers (constants, globals, struct field
 	// defaults) discard spawn registrations, so spawn is rejected there.
 	declaration_initializer_mode bool
+	// On-demand generic-method monomorphization state (see monomorphize.v drain): mono
+	// instances still to generate, the set already generated (dedup), the signatures of the
+	// instances (a PER-PARSER map — the shared `functions` is read-only across worker
+	// threads and must never be mutated), and their C output.
+	pending_mono     []FastcMonoRequest
+	generated_mono   map[string]bool
+	mono_functions   map[string]FastcFunctionSignature
+	mono_definitions map[string]string
+	// True while the drain re-parses a mono instance, so parse_function skips the
+	// reachability prune (the instance is used by definition — that is why it was queued).
+	in_mono_drain          bool
+	in_generic_placeholder bool
+}
+
+// FastcMonoRequest is one queued on-demand generic method or free-function instantiation.
+struct FastcMonoRequest {
+	source_key string
+	concrete   string
 }
 
 // fastc_comparison_memo_key identifies a token subrange within the current
@@ -816,13 +931,13 @@ pub fn generate(source string, path string, prefs &pref.Preferences) !string {
 	if header.imports.len > 0 || header.blank_imports.len > 0 {
 		return error('fastc parser does not support imports through the single-source API in ${path}')
 	}
-	c_source, _ := generate_source_files([
+	c_source, _, _ := generate_source_files([
 		FastcSourceFile{
 			path:   path
 			source: source
 			header: header
 		},
-	], prefs)!
+	], map[string]string{}, prefs)!
 	return c_source
 }
 
@@ -835,16 +950,17 @@ pub fn generate_files(paths []string, prefs &pref.Preferences) !string {
 
 // generate_files_with_source_paths emits C and reports every source read during import discovery.
 pub fn generate_files_with_source_paths(paths []string, prefs &pref.Preferences) !GenerationResult {
-	sources := fastc_resolve_source_files(paths, prefs)!
+	sources, module_aliases := fastc_resolve_source_files(paths, prefs)!
 	mut source_paths := []string{cap: sources.len}
 	for source_file in sources {
 		source_paths << source_file.path
 	}
-	c_source, uses_threads := generate_source_files(sources, prefs)!
+	c_source, uses_threads, c_flags := generate_source_files(sources, module_aliases, prefs)!
 	return GenerationResult{
 		c_source:     c_source
 		source_paths: source_paths
 		uses_threads: uses_threads
+		c_flags:      c_flags
 	}
 }
 
@@ -859,7 +975,9 @@ struct FastcFileGenContext {
 	has_c_functions        bool
 	declared_kinds         map[string]FastcDeclaredTypeKind
 	enum_flags             map[string]bool
+	enum_field_types       map[string]string
 	alias_base_types       map[string]string
+	sum_types              map[string]bool
 	struct_fields          map[string]map[string]string
 	struct_field_info      map[string][]FastcStructField
 	interface_fields       map[string]FastcInterfaceField
@@ -876,6 +994,8 @@ struct FastcFileGenContext {
 	global_types           map[string]string
 	fixed_array_types      map[string]string
 	composite_types        map[string]bool
+	generic_method_sources map[string]FastcGenericMethodSource
+	module_aliases         map[string]string
 }
 
 // FastcFileGenOutput is one source file's generation result. The sequential
@@ -890,6 +1010,8 @@ mut:
 	composite_types   map[string]bool
 	spawn_typedefs    map[string]string
 	spawn_helpers     map[string]string
+	mono_definitions  map[string]string
+	c_flags           []string
 	failed            bool
 	error_message     string
 }
@@ -909,14 +1031,22 @@ fn fastc_generate_single_file(ctx &FastcFileGenContext, source_file FastcSourceF
 		fastc_prefixed_c_names:  ctx.fastc_prefixed_c_names
 		has_c_functions:         ctx.has_c_functions
 		comparison_memo:         map[i64]FastcRenderedExpression{}
+		member_smartcasts:       map[string]FastcMemberSmartcast{}
 		spawn_typedefs:          map[string]string{}
 		spawn_helpers:           map[string]string{}
 		thread_value_types:      map[string]string{}
 		declared_kinds:          ctx.declared_kinds
 		enum_flags:              ctx.enum_flags
+		enum_field_types:        ctx.enum_field_types
 		alias_base_types:        ctx.alias_base_types
+		sum_types:               ctx.sum_types
 		struct_fields:           ctx.struct_fields
 		struct_field_info:       ctx.struct_field_info
+		generic_method_sources:  ctx.generic_method_sources
+		module_aliases:          ctx.module_aliases
+		generated_mono:          map[string]bool{}
+		mono_functions:          map[string]FastcFunctionSignature{}
+		mono_definitions:        map[string]string{}
 		interface_fields:        ctx.interface_fields
 		constants:               ctx.constants
 		constant_values:         ctx.constant_values
@@ -963,10 +1093,16 @@ fn fastc_generate_single_file(ctx &FastcFileGenContext, source_file FastcSourceF
 		composite_types:   gen.composite_types
 		spawn_typedefs:    gen.spawn_typedefs
 		spawn_helpers:     gen.spawn_helpers
+		mono_definitions:  gen.mono_definitions
+		c_flags:           gen.c_flags
 	}
 }
 
-fn generate_source_files(sources []FastcSourceFile, prefs &pref.Preferences) !(string, bool) {
+fn generate_source_files(input_sources []FastcSourceFile, module_aliases map[string]string, prefs &pref.Preferences) !(string, bool, []string) {
+	// Source-level generic monomorphization runs first; it is a no-op when the
+	// program has no generic function definitions (so the self-host is untouched).
+	sources := fastc_monomorphize_sources(input_sources, prefs)!
+	generic_method_sources := fastc_collect_generic_method_sources(sources, prefs)
 	mut declared_types := map[string]bool{}
 	mut declared_kinds := map[string]FastcDeclaredTypeKind{}
 	mut enum_flags := map[string]bool{}
@@ -992,13 +1128,22 @@ fn generate_source_files(sources []FastcSourceFile, prefs &pref.Preferences) !(s
 	mut functions := map[string]FastcFunctionSignature{}
 	mut interface_methods := map[string]bool{}
 	mut interface_fields := map[string]FastcInterfaceField{}
+	// Interface embeds recorded as index-aligned parallel arrays (an embedder and the
+	// interface it embeds), kept flat to stay in FastC's self-hostable subset.
+	mut embed_embedders := []string{}
+	mut embed_embeddeds := []string{}
 	for source_file in sources {
 		collect_function_signatures(source_file.source, source_file.path, source_file.header,
 			prefs, declared_types, declared_type_c_names, params_structs, mut functions)!
 		collect_interface_method_signatures(source_file.source, source_file.path,
 			source_file.header, prefs, declared_types, mut functions, mut interface_methods, mut
-			interface_fields)!
+			interface_fields, mut embed_embedders, mut embed_embeddeds)!
 	}
+	// An interface that embeds another (`interface B { A; ... }`) inherits A's
+	// methods. Copy them onto B (with the receiver re-keyed to B) so calls on a B
+	// value resolve and B gets its own dispatch table entries.
+	fastc_promote_embedded_interface_methods(embed_embedders, embed_embeddeds, mut functions, mut
+		interface_methods)
 	used_function_names := fastc_collect_referenced_function_names(sources, prefs, functions)
 	has_c_functions := fastc_functions_declare_c(functions)
 	fastc_prefixed_c_names := fastc_reserved_temporary_c_names(functions, globals)
@@ -1020,21 +1165,29 @@ fn generate_source_files(sources []FastcSourceFile, prefs &pref.Preferences) !(s
 		enum_flags, constants, public_constants, mut struct_fields, mut struct_field_info, mut
 		composite_types)!
 	type_declarations := type_output.declarations
+	enum_field_types := type_output.enum_field_types.clone()
 	mut constant_types := map[string]string{}
 	mut global_types := map[string]string{}
 	fastc_render_struct_field_defaults(prefs, declared_types, declared_type_c_names,
-		fastc_prefixed_c_names, declared_kinds, enum_flags, type_output.alias_base_types,
-		struct_fields, mut struct_field_info, functions, constants, public_constants,
-		constant_types, globals, public_globals, global_types)!
+		fastc_prefixed_c_names, declared_kinds, enum_flags, enum_field_types,
+		type_output.alias_base_types, struct_fields, mut struct_field_info, functions, constants,
+		public_constants, constant_types, globals, public_globals, global_types,
+		type_output.sum_types)!
 	constant_output := fastc_generate_constant_declarations(sources, prefs, declared_types,
 		declared_type_c_names, fastc_prefixed_c_names, declared_kinds, enum_flags,
-		type_output.alias_base_types, struct_fields, struct_field_info, functions, constants,
-		public_constants, globals, public_globals, mut constant_types)!
+		enum_field_types, type_output.alias_base_types, struct_fields, struct_field_info,
+		functions, constants, public_constants, globals, public_globals, mut constant_types)!
+	for name, _ in constant_output.composite_types {
+		composite_types[name] = true
+	}
 	global_output := fastc_generate_global_declarations(sources, prefs, declared_types,
 		declared_type_c_names, fastc_prefixed_c_names, declared_kinds, enum_flags,
-		type_output.alias_base_types, struct_fields, struct_field_info, functions, constants,
-		constant_output.compile_time_values, public_constants, constant_types, globals,
-		public_globals, mut global_types)!
+		enum_field_types, type_output.alias_base_types, struct_fields, struct_field_info,
+		functions, constants, constant_output.compile_time_values, public_constants,
+		constant_types, globals, public_globals, mut global_types)!
+	for name, _ in global_output.composite_types {
+		composite_types[name] = true
+	}
 	for constant_type in constant_types.values() {
 		fastc_register_composite_type(constant_type, mut composite_types)
 	}
@@ -1045,7 +1198,10 @@ fn generate_source_files(sources []FastcSourceFile, prefs &pref.Preferences) !(s
 		constant_output.module_initializers, global_output.module_initializers, module_init_calls)!
 	mut prototypes := strings.new_builder(1024)
 	mut body := strings.new_builder(4096)
-	mut fixed_array_types := map[string]string{}
+	mut fixed_array_types := constant_output.fixed_array_types.clone()
+	for name, array_type in global_output.fixed_array_types {
+		fixed_array_types[name] = array_type
+	}
 	mut has_entry_module := false
 	for source_file in sources {
 		if source_file.header.module_name in ['', 'main'] {
@@ -1062,9 +1218,13 @@ fn generate_source_files(sources []FastcSourceFile, prefs &pref.Preferences) !(s
 		has_c_functions:        has_c_functions
 		declared_kinds:         declared_kinds
 		enum_flags:             enum_flags
+		enum_field_types:       enum_field_types
 		alias_base_types:       type_output.alias_base_types
+		sum_types:              type_output.sum_types
 		struct_fields:          struct_fields
 		struct_field_info:      struct_field_info
+		generic_method_sources: generic_method_sources
+		module_aliases:         module_aliases
 		interface_fields:       interface_fields
 		constants:              constants
 		constant_values:        constant_output.compile_time_values
@@ -1082,6 +1242,8 @@ fn generate_source_files(sources []FastcSourceFile, prefs &pref.Preferences) !(s
 	}
 	mut spawn_typedefs := map[string]string{}
 	mut spawn_helpers := map[string]string{}
+	mut mono_definitions := map[string]string{}
+	mut c_flags := []string{}
 	outputs := fastc_generate_file_outputs(&ctx, sources)
 	for output in outputs {
 		if output.failed {
@@ -1089,6 +1251,13 @@ fn generate_source_files(sources []FastcSourceFile, prefs &pref.Preferences) !(s
 		}
 		prototypes.write_string(output.prototypes)
 		body.write_string(output.body)
+		mut mono_names := output.mono_definitions.keys()
+		mono_names.sort()
+		for mono_name in mono_names {
+			if mono_name !in mono_definitions {
+				mono_definitions[mono_name] = output.mono_definitions[mono_name]
+			}
+		}
 		if output.has_main_entry {
 			entry_has_main = true
 		}
@@ -1104,6 +1273,12 @@ fn generate_source_files(sources []FastcSourceFile, prefs &pref.Preferences) !(s
 		for name, text in output.spawn_helpers {
 			spawn_helpers[name] = text
 		}
+		c_flags << output.c_flags
+	}
+	mut mono_names := mono_definitions.keys()
+	mono_names.sort()
+	for mono_name in mono_names {
+		body.write_string(mono_definitions[mono_name])
 	}
 	synthesized_main := if has_entry_module && !entry_has_main {
 		fastc_synthesized_main(prefs.building_v, startup_initializers.len > 0,
@@ -1114,7 +1289,13 @@ fn generate_source_files(sources []FastcSourceFile, prefs &pref.Preferences) !(s
 	mut late_composite_declarations := strings.new_builder(256)
 	mut composite_names := composite_types.keys()
 	composite_names.sort()
-	for composite_name in composite_names {
+	for index, composite_name in composite_names {
+		// Composite types (`Array_x`, `Map_k_v`) can be sum-type variants, so give
+		// each a stable type id in a range disjoint from the declared-type ids
+		// (1..N) and the primitive ids (0x40000000+). Only unique/consistent values
+		// matter: construction and `match` both reference `__v_typeid_<composite>`.
+		late_composite_declarations.writeln('#define __v_typeid_${composite_name} ${
+			u32(0x50000000) + u32(index)}')
 		declaration := 'typedef ${if composite_name.starts_with('Array_') {
 			'array'
 		} else {
@@ -1139,6 +1320,9 @@ fn generate_source_files(sources []FastcSourceFile, prefs &pref.Preferences) !(s
 	result.write_string(preamble)
 	result.write_string(c_integer_comparison_helpers)
 	result.write_string(hoisted_body.directives)
+	if prefs.building_v {
+		result.write_string(c_selfhost_post_directives)
+	}
 	if spawn_typedefs.len > 0 {
 		result.write_string(c_spawn_runtime)
 		result.writeln('')
@@ -1168,6 +1352,7 @@ fn generate_source_files(sources []FastcSourceFile, prefs &pref.Preferences) !(s
 	if prefs.building_v {
 		result.write_string(c_selfhost_runtime)
 	}
+	result.write_string(type_output.enum_string_helpers)
 	if spawn_helpers.len > 0 {
 		mut spawn_helper_names := spawn_helpers.keys()
 		spawn_helper_names.sort()
@@ -1176,7 +1361,6 @@ fn generate_source_files(sources []FastcSourceFile, prefs &pref.Preferences) !(s
 			result.writeln('')
 		}
 	}
-	result.write_string(type_output.enum_string_helpers)
 	result.write_string(interface_dispatches)
 	if startup_initializers.len > 0 {
 		result.writeln('static void v_fastc_init_globals(void) {')
@@ -1195,7 +1379,7 @@ fn generate_source_files(sources []FastcSourceFile, prefs &pref.Preferences) !(s
 	result.write_string(synthesized_main)
 	result.write_string(hoisted_body.conditional_code)
 	result.write_string(hoisted_body.body)
-	return result.str(), spawn_typedefs.len > 0
+	return result.str(), spawn_typedefs.len > 0, c_flags
 }
 
 fn fastc_synthesized_main(selfhost bool, has_startup_inits bool, has_cleanup_hooks bool) string {
@@ -1239,6 +1423,53 @@ fn fastc_interface_method_signatures_match(interface_signature FastcFunctionSign
 		}
 	}
 	return true
+}
+
+// fastc_promote_embedded_interface_methods copies the methods of each embedded
+// interface onto the interface that embeds it, re-keyed to the embedder's receiver
+// type. It runs to a fixpoint so a chain of embeds (`C { B }`, `B { A }`) inherits
+// all the way down. A method the embedder already declares directly is left as-is.
+fn fastc_promote_embedded_interface_methods(embed_embedders []string, embed_embeddeds []string, mut functions map[string]FastcFunctionSignature, mut interface_methods map[string]bool) {
+	mut changed := true
+	for changed {
+		changed = false
+		for i := 0; i < embed_embedders.len; i++ {
+			embedder_key := embed_embedders[i]
+			embedded_key := embed_embeddeds[i]
+			embedder_type := fastc_c_declared_type_name(embedder_key)
+			prefix := embedded_key + '.'
+			for method_key in interface_methods.keys() {
+				if !method_key.starts_with(prefix) {
+					continue
+				}
+				method_name := method_key.all_after_last('.')
+				promoted_key := '${embedder_key}.${method_name}'
+				if promoted_key in interface_methods {
+					continue
+				}
+				source := functions[method_key]
+				mut promoted_params := source.parameter_types.clone()
+				if promoted_params.len > 0 {
+					promoted_params[0] = embedder_type
+				}
+				functions[promoted_key] = FastcFunctionSignature{
+					parameter_types:          promoted_params
+					parameter_mutability:     source.parameter_mutability.clone()
+					return_type:              source.return_type
+					return_types:             source.return_types.clone()
+					option_type:              source.option_type
+					is_variadic:              source.is_variadic
+					last_parameter_is_params: source.last_parameter_is_params
+					is_public:                source.is_public
+					is_disabled:              source.is_disabled
+					module_name:              source.module_name
+					path:                     source.path
+				}
+				interface_methods[promoted_key] = true
+				changed = true
+			}
+		}
+	}
 }
 
 fn fastc_generate_interface_dispatches(declared_kinds map[string]FastcDeclaredTypeKind, functions map[string]FastcFunctionSignature, interface_methods map[string]bool, used_function_names map[string]bool, selfhost bool) string {

--- a/vlib/v3/gen/fastc/fastc_test.v
+++ b/vlib/v3/gen/fastc/fastc_test.v
@@ -36,33 +36,7 @@ fn test_selfhost_spawn_nested_wait_statement_and_helper_names() {
 	void_waiter := fastc_thread_wait_name(fastc_thread_type_name(''))
 	int_waiter := fastc_thread_wait_name(fastc_thread_type_name('int'))
 	assert foo_creator != foo_c1_creator
-	source := 'module main
-
-fn foo() int {
-	return 1
-}
-
-fn foo_c1() int {
-	return 2
-}
-
-fn ${foo_start}() int {
-	return 0
-}
-
-fn finish() {}
-
-fn main() {
-	first := spawn foo()
-	mut threads := [first]
-	threads << spawn foo_c1()
-	println(threads[0].wait())
-	println(threads[1].wait())
-	println((spawn foo()).wait())
-	done := spawn finish()
-	done.wait()
-}
-'
+	source := 'module main\n\nfn foo() int {\n\treturn 1\n}\n\nfn foo_c1() int {\n\treturn 2\n}\n\nfn ${foo_start}() int {\n\treturn 0\n}\n\nfn finish() {}\n\nfn main() {\n\tfirst := spawn foo()\n\tmut threads := [first]\n\tthreads << spawn foo_c1()\n\tprintln(threads[0].wait())\n\tprintln(threads[1].wait())\n\tprintln((spawn foo()).wait())\n\tdone := spawn finish()\n\tdone.wait()\n}\n'
 	c_source := generate(source, 'selfhost_spawn_regressions.v', prefs) or { panic(err) }
 	assert c_source.contains('args->result = foo();'), c_source
 	assert c_source.contains('args->result = foo_c1();'), c_source
@@ -94,8 +68,7 @@ fn main() {
 	t := spawn traced(side_effect())
 	t.wait()
 }
-',
-		'disabled_spawn.v', prefs) or {
+', 'disabled_spawn.v', prefs) or {
 		message = err.msg()
 		''
 	}
@@ -142,8 +115,7 @@ fn main() {
 	println(named.wait())
 	println(pointer.wait())
 }
-',
-		'spawn_params_struct.v', prefs) or { panic(err) }
+', 'spawn_params_struct.v', prefs) or { panic(err) }
 	assert c_source.contains('args->result = configured(args->arg0, args->arg1);'), c_source
 	assert c_source.contains('__v_fastc_struct_default.value=(default_value());'), c_source
 	assert c_source.contains('.value=(__v_fastc_struct_field_0)'), c_source
@@ -205,8 +177,7 @@ fn test_declaration_only_entry_synthesizes_main() {
 pub fn answer() int {
 	return 42
 }
-',
-		'declaration_only_entry.v', prefs) or { panic(err) }
+', 'declaration_only_entry.v', prefs) or { panic(err) }
 	assert c_source.contains('int main(void) {'), c_source
 	assert c_source.contains('\tsetvbuf(stdout, NULL, _IONBF, 0);\n\treturn 0;'), c_source
 
@@ -238,8 +209,7 @@ fn main() {
 	println(greeting('FastC'))
 	println('|${'界':4}|${'é':4}|${'👩🏽‍💻':4}|')
 }
-",
-		'ordinary_string_interpolation.v', prefs) or { panic(err) }
+", 'ordinary_string_interpolation.v', prefs) or { panic(err) }
 	assert c_source.contains('static string builtin__string_plus_many'), c_source
 	assert c_source.contains('v_fastc_string_pad(name, 10, false)'), c_source
 	assert c_source.contains('v_fastc_string_pad(name, 10, true)'), c_source
@@ -286,8 +256,7 @@ fn main() {
 		else {}
 	}
 }
-",
-		'ordinary_string_concatenation.v', prefs) or { panic(err) }
+", 'ordinary_string_concatenation.v', prefs) or { panic(err) }
 	assert c_source.count('builtin__string_plus_many(2, (string[]){') >= 4, c_source
 	assert c_source.contains('combined=builtin__string_plus_many(2, (string[]){combined,"b"});'), c_source
 	assert c_source.contains('alias_combined=builtin__string_plus_many(2, (string[]){alias_combined,((Str)("y"))});'), c_source
@@ -319,8 +288,7 @@ fn main() {
 	mut value := Str('a')
 	value += Str('b')
 }
-",
-		'selfhost_string_alias_compound_assignment.v', selfhost_prefs) or { panic(err) }
+", 'selfhost_string_alias_compound_assignment.v', selfhost_prefs) or { panic(err) }
 	assert selfhost_c.contains('value=builtin__string_plus(value,((Str)(_S("b"))));'), selfhost_c
 }
 
@@ -335,8 +303,8 @@ fn test_c_directives_preserve_order_and_resolve_source_paths() {
 	os.write_file(os.join_path(root, 'v.mod'), "Module { name: 'fastc_directives' }\n") or {
 		panic(err)
 	}
-	os.write_file(os.join_path(root, 'src', 'config.h'),
-		'#ifndef FEATURE\n#error "FEATURE must precede config.h"\n#endif\n') or { panic(err) }
+	os.write_file(os.join_path(root, 'src', 'config.h'), '#ifndef FEATURE\n#error "FEATURE must precede config.h"\n#endif\n') or { panic(err) }
+	os.write_file(os.join_path(root, 'src', 'local.c'), '') or { panic(err) }
 	os.write_file(os.join_path(root, 'vmod_value.h'), '') or { panic(err) }
 	os.write_file(os.join_path(root, 'vroot_value.h'), '') or { panic(err) }
 	source_path := os.join_path(root, 'src', 'main.v')
@@ -344,6 +312,7 @@ fn test_c_directives_preserve_order_and_resolve_source_paths() {
 
 #define FEATURE 1
 #include "@DIR/config.h"
+#include "local.c"
 #include "@VMODROOT/vmod_value.h"
 #insert "@VROOT/vroot_value.h"
 
@@ -359,6 +328,8 @@ fn main() {
 	}
 	assert define_index >= 0
 	assert include_index > define_index
+	assert c_source.contains('#include "${os.real_path(os.join_path(root, 'src'))}/local.c"'), c_source
+
 	assert c_source.contains('#include "${os.real_path(root)}/vmod_value.h"'), c_source
 	assert c_source.contains('#include "${os.real_path(root)}/vroot_value.h"'), c_source
 	c_file := os.join_path(root, 'program.c')
@@ -389,8 +360,7 @@ fn optional(value Holder) int {
 fn main() {
 	println(42)
 }
-',
-		'conditional_scope.c.v', prefs) or { panic(err) }
+', 'conditional_scope.c.v', prefs) or { panic(err) }
 	type_index := c_source.index('struct Holder {') or { -1 }
 	if_index := c_source.index('#if 1') or { -1 }
 	definition_index := c_source.index('int optional(Holder value) {') or { -1 }
@@ -502,8 +472,7 @@ fn (receiver LocationOwner) fastc_instance_location() string {
 fn LocationOwner.fastc_static_location() string {
 	return @LOCATION
 }
-',
-		'location_receiver_kind.v', prefs) or { panic(err) }
+', 'location_receiver_kind.v', prefs) or { panic(err) }
 	assert c_source.contains(', main.LocationOwner{}.fastc_instance_location")'), c_source
 	assert c_source.contains(', main.LocationOwner.fastc_static_location (static)")'), c_source
 }
@@ -525,8 +494,7 @@ fn main() {
 	print('${-1:c}x')
 	print('${0x110000:c}x')
 }
-",
-		'ordinary_primitive_interpolation.v', prefs) or { panic(err) }
+", 'ordinary_primitive_interpolation.v', prefs) or { panic(err) }
 	assert c_source.contains('v_fastc_signed_str((long long)(value))'), c_source
 	assert c_source.contains('v_fastc_signed_str((long long)(negative))'), c_source
 	assert c_source.contains('v_fastc_unsigned_str((unsigned long long)(large))'), c_source
@@ -571,8 +539,7 @@ fn main() {
 	println('${Count(1)}|${Text('ok')}|${Custom(2)}')
 	println('${Count(15):04x}|${Text('x'):3}')
 }
-",
-		'primitive_alias_interpolation.v', prefs) or { panic(err) }
+", 'primitive_alias_interpolation.v', prefs) or { panic(err) }
 	assert c_source.contains('v_fastc_signed_str((long long)(((Count)(1))))'), c_source
 	assert c_source.contains('v_fastc_signed_format((long long)(((Count)(15))), "04x")'), c_source
 	assert c_source.contains('v_fastc_string_pad(((Text)("x")), 3, false)'), c_source
@@ -605,9 +572,62 @@ __global ch char
 fn main() {
 	println('${ch}')
 }
-",
-		'direct_char_interpolation.v', prefs) or { panic(err) }
+", 'direct_char_interpolation.v', prefs) or { panic(err) }
 	assert c_source.contains('v_fastc_signed_format((long long)(ch), "c")'), c_source
+}
+
+fn test_selfhost_fixed_array_struct_field_interpolation() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Address {
+	bytes [4]u8
+}
+
+fn (value u8) str() string {
+	return "byte"
+}
+
+fn format(address Address) string {
+	return "\${address.bytes}"
+}
+
+fn main() {
+	_ := format(Address{})
+}
+', 'selfhost_fixed_array_field_interpolation.v', prefs) or { panic(err) }
+	assert c_source.contains('string v_fastc_fixed_array_str_FixedArray_4_FASTC_ARRAY_OF_u8(u8 *it)'), c_source
+
+	assert c_source.contains('v_fastc_fixed_array_str_FixedArray_4_FASTC_ARRAY_OF_u8((u8 *)'), c_source
+
+	assert c_source.contains('u8_str(it[0])'), c_source
+}
+
+fn test_selfhost_dynamic_array_struct_field_interpolation() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Versions {
+	values []u32
+}
+
+fn (value u32) str() string {
+	return "version"
+}
+
+fn format(versions Versions) string {
+	return "\${versions.values}"
+}
+
+fn main() {
+	_ := format(Versions{})
+}
+', 'selfhost_dynamic_array_field_interpolation.v', prefs) or { panic(err) }
+	assert c_source.contains('string v_fastc_array_str_Array_u32(Array_u32 it)'), c_source
+	assert c_source.contains('v_fastc_array_str_Array_u32(versions.values)'), c_source
+	assert c_source.contains('u32_str((*('), c_source
 }
 
 fn test_ordinary_nul_codepoint_interpolation_is_rejected() {
@@ -618,8 +638,7 @@ fn test_ordinary_nul_codepoint_interpolation_is_rejected() {
 fn main() {
 	print('${0:c}x')
 }
-",
-		'ordinary_nul_codepoint_interpolation.v', prefs) or {
+", 'ordinary_nul_codepoint_interpolation.v', prefs) or {
 		message = err.msg()
 		''
 	}
@@ -635,8 +654,7 @@ fn main() {
 	code := 0
 	print('${code:c}x')
 }
-",
-		'ordinary_nonliteral_codepoint_interpolation.v', prefs) or {
+", 'ordinary_nonliteral_codepoint_interpolation.v', prefs) or {
 		message = err.msg()
 		''
 	}
@@ -652,8 +670,7 @@ fn main() {
 	value := i64(65)
 	println('${value:c}')
 }
-",
-		'i64_codepoint_interpolation.v', prefs) or {
+", 'i64_codepoint_interpolation.v', prefs) or {
 		message = err.msg()
 		''
 	}
@@ -668,8 +685,7 @@ fn main() {
 	value := i64(65)
 	println('${value:c}')
 }
-",
-		'i64_codepoint_interpolation_selfhost.v', selfhost_prefs) or {
+", 'i64_codepoint_interpolation_selfhost.v', selfhost_prefs) or {
 		selfhost_message = err.msg()
 		''
 	}
@@ -688,8 +704,7 @@ fn main() {
 	println(name)
 	println("done")
 }
-',
-		'zero_value_string.v', prefs) or { panic(err) }
+', 'zero_value_string.v', prefs) or { panic(err) }
 	assert c_source.contains('fputs(value ? value : "", stdout)'), c_source
 	assert c_source.contains('puts(value ? value : "")'), c_source
 
@@ -747,7 +762,7 @@ fn test_c_build_directives_are_rejected_instead_of_discarded() {
 	mut prefs := pref.new_preferences()
 	for building_v in [false, true] {
 		prefs.building_v = building_v
-		for directive in ['#flag -D FEATURE=1', '#pkgconfig sqlite3'] {
+		for directive in ['#flag -D FEATURE=1', '#flag -std=gnu11'] {
 			mut message := ''
 			_ := generate('module main\n${directive}\nfn main() {}\n', 'c_build_directive.v', prefs) or {
 				message = err.msg()
@@ -755,6 +770,27 @@ fn test_c_build_directives_are_rejected_instead_of_discarded() {
 			}
 			assert message.contains('C build directive `${directive}`'), message
 		}
+	}
+
+	// `#pkgconfig <lib>` names an external library`s link/cflags; FastC drives its own
+	// tcc link line, so it is skipped, not rejected.
+	prefs.building_v = false
+	pkgconfig_out := generate('module main\n#pkgconfig sqlite3\nfn main() { println(1) }\n', 'pkgconfig_flag.v', prefs) or {
+		assert false, 'pkgconfig directive should be skipped: ${err.msg()}'
+		''
+	}
+	assert !pkgconfig_out.contains('pkgconfig'), pkgconfig_out
+
+	// A platform-qualified `#flag <os> ...` that names a different target is inert
+	// for this build and must be skipped, not rejected, mirroring how `#include
+	// <os>` is target-filtered. (vlib/os uses `#flag windows -lws2_32`.)
+	$if !windows {
+		prefs.building_v = false
+		skipped := generate('module main\n#flag windows -lws2_32\nfn main() { println(1) }\n', 'os_qualified_flag.v', prefs) or {
+			assert false, 'os-qualified flag for another target should be skipped: ${err.msg()}'
+			''
+		}
+		assert !skipped.contains('ws2_32'), skipped
 	}
 
 	root := os.join_path(os.vtmp_dir(), 'v3_fastc_imported_c_flag_${os.getpid()}')
@@ -767,8 +803,7 @@ fn test_c_build_directives_are_rejected_instead_of_discarded() {
 	os.write_file(main_file, 'module main\nimport dependency\nfn main() { dependency.run() }\n') or {
 		panic(err)
 	}
-	os.write_file(os.join_path(root, 'dependency', 'dependency.v'),
-		'module dependency\n#flag -D FEATURE=1\npub fn run() {}\n') or { panic(err) }
+	os.write_file(os.join_path(root, 'dependency', 'dependency.v'), 'module dependency\n#flag -D FEATURE=1\npub fn run() {}\n') or { panic(err) }
 	prefs.building_v = false
 	prefs.module_search_paths = [root]
 	mut message := ''
@@ -804,12 +839,10 @@ fn test_generate_files_resolves_modules_without_an_ast() {
 	}
 	main_file := os.join_path(root, 'main.v')
 	module_file := os.join_path(root, 'mathutil', 'mathutil.v')
-	os.write_file(main_file,
-		'module main\nimport mathutil\nfn main() { println(mathutil.twice(21)) }\n') or {
+	os.write_file(main_file, 'module main\nimport mathutil\nfn main() { println(mathutil.twice(21)) }\n') or {
 		panic(err)
 	}
-	os.write_file(module_file,
-		'module mathutil\npub fn twice(value int) int { return value * 2 }\n') or { panic(err) }
+	os.write_file(module_file, 'module mathutil\npub fn twice(value int) int { return value * 2 }\n') or { panic(err) }
 	mut prefs := pref.new_preferences()
 	prefs.module_search_paths = [root]
 	c_source := generate_files([main_file], prefs) or { panic(err) }
@@ -887,7 +920,7 @@ pub fn ping() {}
 	assert header.import_order == ['alpha']
 	assert header.imports['dep'] == 'alpha'
 	assert 'beta' !in header.imports.values()
-	sources := fastc_resolve_source_files([main_file], prefs) or { panic(err) }
+	sources, aliases := fastc_resolve_source_files([main_file], prefs) or { panic(err) }
 	mut resolved_modules := []string{}
 	for source_file in sources {
 		if source_file.header.module_name !in resolved_modules {
@@ -896,7 +929,7 @@ pub fn ping() {}
 	}
 	assert resolved_modules == ['main', 'alpha']
 	prefs.building_v = true
-	c_source, _ := generate_source_files(sources, prefs) or { panic(err) }
+	c_source, _ := generate_source_files(sources, aliases, prefs) or { panic(err) }
 	assert c_source.contains('\talpha__init();'), c_source
 	assert c_source.contains('\talpha__cleanup();'), c_source
 	assert !c_source.contains('beta__init'), c_source
@@ -914,8 +947,7 @@ fn test_generate_files_rejects_mismatched_imported_module_declarations() {
 	os.write_file(main_file, 'module main\nimport foo\nfn main() { println(foo.answer()) }\n') or {
 		panic(err)
 	}
-	os.write_file(os.join_path(root, 'foo', 'foo.v'),
-		'module bar\npub fn answer() int { return 42 }\n') or { panic(err) }
+	os.write_file(os.join_path(root, 'foo', 'foo.v'), 'module bar\npub fn answer() int { return 42 }\n') or { panic(err) }
 	mut prefs := pref.new_preferences()
 	prefs.module_search_paths = [root]
 	mut message := ''
@@ -924,6 +956,161 @@ fn test_generate_files_rejects_mismatched_imported_module_declarations() {
 		''
 	}
 	assert message.contains('declares module `bar` instead of `foo`'), message
+}
+
+fn test_module_qualified_alias_cast_can_receive_a_method_call() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	main_source := 'module main
+import clock
+fn main() {
+	d := clock.Duration(1500)
+	println(clock.Duration(d - 500).microseconds())
+}
+'
+	clock_source := 'module clock
+pub type Duration = i64
+pub fn (d Duration) microseconds() i64 { return i64(d) / 1000 }
+'
+	c_source, _ := generate_source_files([
+		FastcSourceFile{
+			path: 'main.v'
+			source: main_source
+			header: fastc_scan_source_header(main_source, 'main.v', prefs) or { panic(err) }
+		},
+		FastcSourceFile{
+			path: 'clock.v'
+			source: clock_source
+			header: fastc_scan_source_header(clock_source, 'clock.v', prefs) or { panic(err) }
+		},
+	], map[string]string{}, prefs) or { panic(err) }
+	assert c_source.contains('clock__Duration_microseconds(((clock__Duration)'), c_source
+}
+
+fn test_selfhost_module_qualified_pointer_cast() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	main_source := 'module main
+import transport
+fn convert(pointer voidptr) &transport.Conn {
+	return unsafe { &transport.Conn(pointer) }
+}
+fn main() {}
+'
+	transport_source := 'module transport
+pub struct Conn {}
+'
+	c_source, _, _ := generate_source_files([
+		FastcSourceFile{
+			path: 'main.v'
+			source: main_source
+			header: fastc_scan_source_header(main_source, 'main.v', prefs) or { panic(err) }
+		},
+		FastcSourceFile{
+			path: 'transport.v'
+			source: transport_source
+			header: fastc_scan_source_header(transport_source, 'transport.v', prefs) or {
+				panic(err)}
+		},
+	], map[string]string{}, prefs) or { panic(err) }
+	assert c_source.contains('return ((transport__Conn*)(pointer));'), c_source
+	assert !c_source.contains('&((transport__Conn)(pointer))'), c_source
+}
+
+fn test_selfhost_double_pointer_cast_assignment() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct State {
+mut:
+	list &&char
+}
+
+fn set_list(mut state State, pointer voidptr) {
+	state.list = unsafe { &&char(pointer) }
+}
+
+fn main() {}
+', 'selfhost_double_pointer_cast_assignment.v', prefs) or { panic(err) }
+	assert c_source.contains('state->list=((char**)(pointer))'), c_source
+	assert !c_source.contains('state->list=)&&'), c_source
+}
+
+fn test_selfhost_static_method_array_literal_argument_is_lowered() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Tool {}
+
+struct RunResult {
+	code int
+}
+
+fn Tool.run(args []string) RunResult {
+	return RunResult{code: args.len}
+}
+
+fn main() {
+	_ := Tool.run(["one", "two"]).code
+}
+', 'static_array_argument.v', prefs) or { panic(err) }
+	assert c_source.contains('Tool_run(((Array_string)builtin__new_array_from_c_array'), c_source
+	assert !c_source.contains('Tool_run(['), c_source
+}
+
+fn test_selfhost_static_method_named_options_argument_is_lowered() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+enum Kind {
+	one
+	two
+}
+
+struct Options {
+	kind Kind
+}
+
+struct Tool {}
+
+fn Tool.run(value int, options Options) !int {
+	return value + int(options.kind)
+}
+
+fn use() !int {
+	return Tool.run(1, kind: .two)
+}
+
+fn main() {}
+', 'selfhost_static_named_options.v', prefs) or { panic(err) }
+	assert c_source.contains('Tool_run(1,(Options){.kind='), c_source
+	assert c_source.contains('Kind__two'), c_source
+	assert !c_source.contains('kind:.two'), c_source
+}
+
+fn test_selfhost_method_context_types_array_literal_with_call_first() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Page {}
+
+fn label() string {
+	return "title"
+}
+
+fn (mut page Page) set_title(parts []string) {}
+
+fn main() {
+	mut page := Page{}
+	page.set_title([label(), "repo"])
+}
+', 'method_context_array_argument.v', prefs) or { panic(err) }
+	assert c_source.contains('Page_set_title(&(page),((Array_string)builtin__new_array_from_c_array'), c_source
+	assert !c_source.contains('Page_set_title(&(page),['), c_source
 }
 
 fn test_generate_files_preserves_all_blank_imports() {
@@ -994,8 +1181,7 @@ fn test_generate_files_rejects_private_imported_functions() {
 	}
 	main_file := os.join_path(root, 'main.v')
 	module_file := os.join_path(root, 'secrets', 'secrets.v')
-	os.write_file(main_file,
-		'module main\nimport secrets\nfn main() { println(secrets.secret()) }\n') or { panic(err) }
+	os.write_file(main_file, 'module main\nimport secrets\nfn main() { println(secrets.secret()) }\n') or { panic(err) }
 	os.write_file(module_file, 'module secrets\nfn secret() int { return 42 }\n') or { panic(err) }
 	mut prefs := pref.new_preferences()
 	prefs.module_search_paths = [root]
@@ -1058,18 +1244,292 @@ fn test_duplicate_constant_declarations_are_rejected() {
 fn test_constant_declarations_require_an_assignment_after_the_name() {
 	prefs := pref.new_preferences()
 	mut message := ''
-	_ := generate('module main\nconst answer nonsense = 42\nfn main() {}\n',
-		'invalid_constant_assignment.v', prefs) or {
+	_ := generate('module main\nconst answer nonsense = 42\nfn main() {}\n', 'invalid_constant_assignment.v', prefs) or {
 		message = err.msg()
 		''
 	}
 	assert message.contains('constant `answer` requires `=` or `:=` after its name'), message
 
 	for assignment in ['=', ':='] {
-		c_source := generate('module main\nconst answer ${assignment} 42\nfn main() { println(answer) }\n',
-			'valid_constant_assignment.v', prefs) or { panic(err) }
+		c_source := generate('module main\nconst answer ${assignment} 42\nfn main() { println(answer) }\n', 'valid_constant_assignment.v', prefs) or { panic(err) }
 		assert c_source.contains('main__answer'), c_source
 	}
+}
+
+fn test_external_c_constant_declarations_are_skipped() {
+	prefs := pref.new_preferences()
+	// `const C.name type` only records that the C headers provide the symbol
+	// (as in vlib/sync/stdatomic). FastC must not register `C` as a constant
+	// (which previously reported a duplicate on the second such line) nor reject
+	// it for missing an `=`/`:=` after the name. The declaration is simply
+	// dropped, while ordinary constants next to it keep working.
+	for source in [
+		'module main\npub const C.SEEK_SET i32\npub const C.SEEK_CUR i32\nconst answer = 42\nfn main() { println(answer) }\n',
+		'module main\nconst (\nC.SEEK_SET i32\nC.SEEK_CUR i32\nanswer = 42\n)\nfn main() { println(answer) }\n',
+	] {
+		c_source := generate(source, 'external_c_constants.v', prefs) or { panic(err) }
+		assert c_source.contains('main__answer'), c_source
+		// The external symbols are provided by the C headers, so FastC emits no
+		// constant definition for them.
+		assert !c_source.contains('SEEK_SET'), c_source
+		assert !c_source.contains('SEEK_CUR'), c_source
+	}
+}
+
+fn test_real_builtin_path_provided_params_struct_named_args() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	// Trailing named arguments (`a: 2, b: true`) at the last `@[params]` struct
+	// parameter collapse into one struct initializer rather than being counted as
+	// separate arguments.
+	source := generate("module main\n@[params]\nstruct Opts {\n\ta int\n\tb bool\n}\nfn foo(x int, opts Opts) int {\n\treturn x + opts.a\n}\nfn main() {\n\tr := foo(1, a: 2, b: true)\n\tif r > 0 {\n\t\tprintln('ok')\n\t}\n}\n", 'params_named_args.v', prefs) or { panic(err) }
+	assert source.contains('foo(1,({'), source
+	assert source.contains('__v_fastc_struct_field_'), source
+}
+
+fn test_real_builtin_path_embedded_method_promotion() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	// A method defined on an embedded type is promoted through the `__embedded_N`
+	// field: a value receiver passes `(d).__embedded_0`, a `mut` receiver passes
+	// its address.
+	source := generate("module main\nstruct Base {\n\tx int\n}\nfn (b Base) hello() int {\n\treturn b.x + 7\n}\nfn (mut b Base) bump() {\n\tb.x = b.x + 1\n}\nstruct Derived {\n\tBase\n\ty int\n}\nfn main() {\n\tmut d := Derived{\n\t\tBase: Base{\n\t\t\tx: 3\n\t\t}\n\t}\n\td.bump()\n\tif d.hello() > 5 {\n\t\tprintln('ok')\n\t}\n}\n", 'embedded_method.v', prefs) or { panic(err) }
+	assert source.contains('Base_hello((d).__embedded_0)'), source
+	assert source.contains('Base_bump(&((d).__embedded_0))'), source
+	// The `Base:` initializer targets the embedded field, not a `.Base` field.
+	assert source.contains('.__embedded_0='), source
+}
+
+fn test_selfhost_method_params_struct_named_args() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	source := generate('module main\n@[params]\nstruct Options {\n\tafter bool\n}\nstruct Service {}\nfn (mut service Service) use(options Options) {}\nfn (mut service Service) redirect(path string, options Options) {}\nfn main() {\n\tmut service := Service{}\n\tservice.use(after: true)\n\tservice.redirect("/next")\n}\n', 'method_params_struct.v', prefs) or { panic(err) }
+	assert source.contains('Service_use(&(service),(Options){'), source
+	assert source.contains('.after='), source
+	assert source.contains('Service_redirect(&(service),_S("/next"),(Options){0})'), source
+}
+
+fn test_selfhost_method_value_uses_method_function_symbol() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	source := generate('module main
+
+@[params]
+struct Options {
+	handler voidptr
+}
+
+struct Service {}
+
+fn (mut service Service) handle() {}
+fn (mut service Service) use(options Options) {}
+
+fn main() {
+	mut service := Service{}
+	service.use(handler: service.handle)
+}
+', 'method_value.v', prefs) or { panic(err) }
+	assert source.contains('Service_handle'), source
+	assert !source.contains('service.handle'), source
+}
+
+fn test_selfhost_embedded_option_method_recovers_payload_type() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	source := generate('module main
+
+struct Base {}
+
+fn (base Base) get() !string {
+	return "ok"
+}
+
+struct User {}
+
+struct Derived {
+	Base
+mut:
+	user User
+	flag bool
+}
+
+fn maybe_user() !User {
+	return error("no")
+}
+
+fn main() {
+	mut value := Derived{}
+	value.user = maybe_user() or {
+		value.flag = false
+		User{}
+	}
+	text := value.get() or { "" }
+	_ := text
+}
+', 'embedded_option_method.v', prefs) or { panic(err) }
+	assert source.contains('*((string *)__v_fastc_option_'), source
+	assert !source.contains('*((int *)__v_fastc_option_'), source
+}
+
+fn test_real_builtin_path_inferred_enum_keyed_map() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	// An inferred map with enum keys — an explicit `Enum.field` first entry then
+	// `.field` shorthand, newline-separated — recovers the key enum from the
+	// declared enum (a value must not swallow the next line's `.field` key).
+	source := generate("module main\nenum Block {\n\thr\n\th\n}\nconst tags = {\n\tBlock.hr: 'a'\n\t.h: 'b'\n}\nfn main() {\n\tif tags.len > 0 {\n\t\tprintln('ok')\n\t}\n}\n", 'enum_keyed_map.v', prefs) or { panic(err) }
+	assert source.contains('Block__hr'), source
+	assert source.contains('Block__h'), source
+	assert source.contains('Map_Block_string'), source
+}
+
+fn test_selfhost_inferred_map_enum_value_shorthand_uses_first_value_type() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	source := generate("module main\nenum Header {\n\taccept\n\tcontent_type\n}\nconst headers = {\n\t'accept': Header.accept\n\t'content-type': .content_type\n}\nfn main() {\n\t_ := headers\n}\n", 'enum_value_map.v', prefs) or { panic(err) }
+	assert source.contains('Header__accept'), source
+	assert source.contains('Header__content_type'), source
+	assert source.contains('Map_string_Header'), source
+}
+
+fn test_selfhost_map_literal_call_argument_uses_runtime_map() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	source := generate("module main\nfn use_headers(headers map[string]string) {}\nfn main() {\n\tuse_headers({\n\t\t'Server': 'veb'\n\t})\n}\n", 'map_literal_argument.v', prefs) or { panic(err) }
+	assert source.contains('use_headers(({ map __v_fastc_argument_map = builtin__new_map'), source
+	assert source.contains('builtin__map_set(&__v_fastc_argument_map'), source
+}
+
+fn test_selfhost_empty_inferred_map_uses_expected_return_type() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+fn empty_nested_map() map[string]map[string]string {
+	return {}
+}
+
+fn main() {
+	_ := empty_nested_map()
+}
+', 'selfhost_empty_inferred_map.v', prefs) or { panic(err) }
+	assert c_source.contains('Map_string_Map_string_string'), c_source
+	assert c_source.contains('builtin__new_map(sizeof(string), sizeof(map)'), c_source
+}
+
+fn test_real_builtin_path_statement_spawn_detaches_the_thread() {
+	$if windows {
+		return
+	}
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	// A fire-and-forget `spawn f()` statement detaches the thread rather than
+	// being rejected for discarding its handle.
+	source := generate("module main\nfn worker(x int) int {\n\treturn x + 1\n}\nfn main() {\n\tspawn worker(5)\n\tprintln('ok')\n}\n", 'detached_spawn.v', prefs) or { panic(err) }
+	assert source.contains('pthread_detach'), source
+}
+
+fn test_real_builtin_path_typeof_generic_reflection() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	// `typeof[T]().idx`/`.name` are compile-time type reflection (used pervasively
+	// by vlib/orm). FastC lowers them to the type's canonical builtin index and its
+	// name string.
+	source := generate('module main\nconst i64_idx = typeof[i64]().idx\nconst str_idx = typeof[string]().idx\nconst int_name = typeof[int]().name\nfn main() {\n\tif i64_idx == 9 && str_idx == 21 {\n\t\tprintln(int_name)\n\t}\n}\n', 'typeof_reflection.v', prefs) or { panic(err) }
+	assert source.contains('_S("int")'), source
+	// i64 -> 9, string -> 21 (the canonical indices in vlib/v/ast/types.v).
+	assert source.contains('main__i64_idx = 9'), source
+	assert source.contains('main__str_idx = 21'), source
+}
+
+fn test_fastc_vmod_subdirs_parses_the_declared_subdirectories() {
+	root := os.join_path(os.vtmp_dir(), 'fastc_vmod_subdirs_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	// The entry module of a real app spans its declared `subdirs` (as gitly's
+	// `ssh/`, `repo/`, ... do); FastC reads that list to collect their sources.
+	os.write_file(os.join_path(root, 'v.mod'), 'Module {\n\tname: \'x\'\n\tsubdirs: [\'admin\', \'ssh\', "user"]\n}\n') or { panic(err) }
+	assert fastc_vmod_subdirs(root) == ['admin', 'ssh', 'user']
+	os.write_file(os.join_path(root, 'v.mod'), "Module {\n\tname: 'x'\n}\n") or { panic(err) }
+	assert fastc_vmod_subdirs(root) == []string{}
+}
+
+fn test_real_builtin_path_map_and_filter_lower_to_array_loops() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	// `.map`/`.filter` are compiler-magic array methods: FastC lowers the `it`
+	// closure into a C statement expression that iterates the source array and
+	// builds a new one with `builtin____new_array` + `builtin__array_push`.
+	map_source := generate('module main\nfn main() {\n\tnums := [1, 2, 3]\n\tprintln(nums.map(it * 2).len)\n}\n', 'map_lowering.v', prefs) or { panic(err) }
+	assert map_source.contains('builtin____new_array'), map_source
+	assert map_source.contains('builtin__array_push'), map_source
+	assert map_source.contains('int it = ('), map_source
+
+	filter_source := generate('module main\nfn main() {\n\tnums := [1, 2, 3]\n\tprintln(nums.filter(it > 1).len)\n}\n', 'filter_lowering.v', prefs) or { panic(err) }
+	assert filter_source.contains('builtin__array_push'), filter_source
+	assert filter_source.contains('int it = ('), filter_source
+
+	enum_source := generate('module main
+
+enum Header {
+	cache_control
+	content_type
+}
+
+fn main() {
+	_ := [Header.cache_control, .content_type].map(it.str())
+}
+', 'enum_literal_map_lowering.v', prefs) or { panic(err) }
+	assert enum_source.contains('typedef array Array_Header;'), enum_source
+	plain_enum_array_source := generate('module main
+
+enum Space {
+	initial
+	handshake
+}
+
+fn main() {
+	spaces := [Space.initial, .handshake]
+	_ = spaces
+}
+', 'plain_enum_array_literal.v', prefs) or { panic(err) }
+	assert plain_enum_array_source.contains('typedef array Array_Space;'), plain_enum_array_source
+}
+
+fn test_real_builtin_path_keyword_identifiers_enum_casts_and_dollar_d() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	// FastC's real-`builtin` path (used for ordinary apps, not just self-host)
+	// accepts constructs the bootstrap subset rejected: a keyword used as an
+	// identifier (enum field `none`), a sized enum backing type with primitive-cast
+	// values (`enum ... as u32 { ok = int(0) }`), and `$d('key', default)` compile
+	// time defaults lowered to their default value.
+	source := "module main
+
+enum Mode {
+	none
+	manual
+}
+
+enum Code as u32 {
+	ok  = int(0)
+	err = int(1)
+}
+
+fn main() {
+	m := Mode.none
+	c := Code.ok
+	limit := int(\$d('limit_bytes', 8192))
+	println(int(m) + int(c) + limit)
+}
+"
+	c_source := generate(source, 'real_builtin_keyword_identifiers.v', prefs) or { panic(err) }
+	assert c_source.contains('Mode__none'), c_source
+	assert c_source.contains('Code__ok'), c_source
+	assert c_source.contains('8192'), c_source
 }
 
 fn test_duplicate_type_declarations_are_rejected() {
@@ -1096,14 +1556,12 @@ fn test_global_declarations_require_enable_globals_or_module_attribute() {
 	}
 	assert message.contains('use `v -enable-globals ...` to enable globals'), message
 
-	attributed_source := generate('@[has_globals]\nmodule main\n__global answer = 42\nfn main() {}\n',
-		'attributed_global.v', prefs) or { panic(err) }
+	attributed_source := generate('@[has_globals]\nmodule main\n__global answer = 42\nfn main() {}\n', 'attributed_global.v', prefs) or { panic(err) }
 	assert attributed_source.contains('static int answer;'), attributed_source
 
 	mut enabled_prefs := pref.new_preferences()
 	enabled_prefs.enable_globals = true
-	enabled_source := generate('module main\n__global answer = 42\nfn main() {}\n',
-		'enabled_global.v', enabled_prefs) or { panic(err) }
+	enabled_source := generate('module main\n__global answer = 42\nfn main() {}\n', 'enabled_global.v', enabled_prefs) or { panic(err) }
 	assert enabled_source.contains('static int answer;'), enabled_source
 }
 
@@ -1111,8 +1569,7 @@ fn test_duplicate_global_declarations_are_rejected() {
 	mut prefs := pref.new_preferences()
 	prefs.enable_globals = true
 	mut message := ''
-	_ := generate('module main\n__global answer = 1\n__global answer = 2\nfn main() {}\n',
-		'duplicate_global.v', prefs) or {
+	_ := generate('module main\n__global answer = 1\n__global answer = 2\nfn main() {}\n', 'duplicate_global.v', prefs) or {
 		message = err.msg()
 		''
 	}
@@ -1141,8 +1598,7 @@ fn test_generate_files_rejects_private_imported_globals() {
 		''
 	}
 	assert message.contains('private global `secret` from imported module `secrets`'), message
-	os.write_file(main_file,
-		'module main\nimport secrets\nconst copied = secrets.secret\nfn main() { println(copied) }\n') or {
+	os.write_file(main_file, 'module main\nimport secrets\nconst copied = secrets.secret\nfn main() { println(copied) }\n') or {
 		panic(err)
 	}
 	message = ''
@@ -1182,8 +1638,7 @@ type SecretAlias = int
 	mut prefs := pref.new_preferences()
 	prefs.module_search_paths = [root]
 	for type_name in ['SecretStruct', 'SecretEnum', 'SecretInterface', 'SecretUnion', 'SecretAlias'] {
-		os.write_file(main_file,
-			'module main\nimport secrets\nfn consume(value secrets.${type_name}) {}\nfn main() {}\n') or {
+		os.write_file(main_file, 'module main\nimport secrets\nfn consume(value secrets.${type_name}) {}\nfn main() {}\n') or {
 			panic(err)
 		}
 		mut message := ''
@@ -1195,8 +1650,7 @@ type SecretAlias = int
 	}
 
 	os.write_file(module_file, 'module secrets\npub struct SecretStruct {}\n') or { panic(err) }
-	os.write_file(main_file,
-		'module main\nimport secrets\nfn consume(value secrets.SecretStruct) {}\nfn main() {}\n') or {
+	os.write_file(main_file, 'module main\nimport secrets\nfn consume(value secrets.SecretStruct) {}\nfn main() {}\n') or {
 		panic(err)
 	}
 	c_source := generate_files([main_file], prefs) or { panic(err) }
@@ -1216,8 +1670,7 @@ fn test_generate_files_restricts_unqualified_imported_type_lookup() {
 	mut prefs := pref.new_preferences()
 	prefs.module_search_paths = [root]
 
-	os.write_file(main_file,
-		'module main\nimport widgets\nfn consume(value Widget) {}\nfn main() {}\n') or {
+	os.write_file(main_file, 'module main\nimport widgets\nfn consume(value Widget) {}\nfn main() {}\n') or {
 		panic(err)
 	}
 	mut message := ''
@@ -1227,8 +1680,7 @@ fn test_generate_files_restricts_unqualified_imported_type_lookup() {
 	}
 	assert message.contains('undeclared type `Widget`'), message
 
-	os.write_file(main_file,
-		'module main\nimport widgets { Widget }\nfn consume(value Widget) {}\nfn main() {}\n') or {
+	os.write_file(main_file, 'module main\nimport widgets { Widget }\nfn consume(value Widget) {}\nfn main() {}\n') or {
 		panic(err)
 	}
 	c_source := generate_files([main_file], prefs) or { panic(err) }
@@ -1260,8 +1712,7 @@ fn main() {
 	config := Config{}
 	println(config.retries)
 }
-',
-		'struct_field_default.v', prefs) or { panic(err) }
+', 'struct_field_default.v', prefs) or { panic(err) }
 	assert c_source.contains('int default_retries(void)'), c_source
 	assert c_source.contains('__v_fastc_struct_default.retries=(default_retries());'), c_source
 }
@@ -1279,8 +1730,7 @@ struct Config {
 fn main() {
 	Config{}
 }
-',
-		'missing_required_struct_field.v', prefs) or {
+', 'missing_required_struct_field.v', prefs) or {
 		message = err.msg()
 		''
 	}
@@ -1296,8 +1746,7 @@ fn main() {
 	config := Config{name: "set"}
 	println(config.name)
 }
-',
-		'initialized_required_struct_field.v', prefs) or { panic(err) }
+', 'initialized_required_struct_field.v', prefs) or { panic(err) }
 }
 
 fn test_generate_files_rejects_private_imported_struct_fields() {
@@ -1331,20 +1780,22 @@ pub fn make() Settings {
 		mut message := ''
 		unused_source, _ := generate_source_files([
 			FastcSourceFile{
-				path:   main_file
+				path: main_file
 				source: source
 				header: fastc_scan_source_header(source, main_file, prefs) or { panic(err) }
 			},
 			FastcSourceFile{
-				path:   module_file
+				path: module_file
 				source: module_source
 				header: fastc_scan_source_header(module_source, module_file, prefs) or {
-					panic(err)
-				}
+					panic(err)}
 			},
-		], prefs) or {
+		], map[string]string{}, prefs) or {
 			message = err.msg()
-			'', false
+			{
+				''
+				false
+			}
 		}
 		_ = unused_source
 		assert message.contains('private field `Settings.secret` from imported module `records`'), message
@@ -1353,16 +1804,16 @@ pub fn make() Settings {
 	valid_source := 'module main\nimport records\nfn main() { value := records.Settings{visible: 2}; println(value.visible) }\n'
 	c_source, _ := generate_source_files([
 		FastcSourceFile{
-			path:   main_file
+			path: main_file
 			source: valid_source
 			header: fastc_scan_source_header(valid_source, main_file, prefs) or { panic(err) }
 		},
 		FastcSourceFile{
-			path:   module_file
+			path: module_file
 			source: module_source
 			header: fastc_scan_source_header(module_source, module_file, prefs) or { panic(err) }
 		},
-	], prefs) or { panic(err) }
+	], map[string]string{}, prefs) or { panic(err) }
 	assert c_source.contains('.visible=(__v_fastc_struct_field_0)'), c_source
 }
 
@@ -1398,18 +1849,21 @@ fn main() {
 	mut message := ''
 	unused_source, _ := generate_source_files([
 		FastcSourceFile{
-			path:   main_file
+			path: main_file
 			source: invalid_source
 			header: fastc_scan_source_header(invalid_source, main_file, prefs) or { panic(err) }
 		},
 		FastcSourceFile{
-			path:   module_file
+			path: module_file
 			source: module_source
 			header: fastc_scan_source_header(module_source, module_file, prefs) or { panic(err) }
 		},
-	], prefs) or {
+	], map[string]string{}, prefs) or {
 		message = err.msg()
-		'', false
+		{
+			''
+			false
+		}
 	}
 	_ = unused_source
 	assert message.contains('mutation of immutable field `Config.read_only`'), message
@@ -1425,16 +1879,16 @@ fn main() {
 '
 	c_source, _ := generate_source_files([
 		FastcSourceFile{
-			path:   main_file
+			path: main_file
 			source: valid_source
 			header: fastc_scan_source_header(valid_source, main_file, prefs) or { panic(err) }
 		},
 		FastcSourceFile{
-			path:   module_file
+			path: module_file
 			source: module_source
 			header: fastc_scan_source_header(module_source, module_file, prefs) or { panic(err) }
 		},
-	], prefs) or { panic(err) }
+	], map[string]string{}, prefs) or { panic(err) }
 	assert c_source.contains('config.writable=2;'), c_source
 }
 
@@ -1468,8 +1922,7 @@ fn main() {
 	config := Config{enabled: enabled, value: 2}
 	println(config.value)
 }
-',
-		'valid_struct_literal.v', prefs) or { panic(err) }
+', 'valid_struct_literal.v', prefs) or { panic(err) }
 	assert c_source.contains('__v_fastc_struct_field_0 = (enabled);'), c_source
 	assert c_source.contains('__v_fastc_struct_field_1 = (2);'), c_source
 	assert c_source.contains('.enabled=(__v_fastc_struct_field_0)'), c_source
@@ -1486,8 +1939,7 @@ fn main() {
 	config := Config{...base, value: 2}
 	println(config.value)
 }
-',
-		'valid_struct_update.v', prefs) or { panic(err) }
+', 'valid_struct_update.v', prefs) or { panic(err) }
 	assert update_source.contains('__v_fastc_struct_update'), update_source
 
 	pointer_update_source := generate('module main
@@ -1504,8 +1956,7 @@ fn main() {
 	base := &Config{}
 	_ := clone_config(base)
 }
-',
-		'valid_pointer_struct_update.v', prefs) or { panic(err) }
+', 'valid_pointer_struct_update.v', prefs) or { panic(err) }
 	assert pointer_update_source.contains('Config __v_fastc_struct_update = *(base);'), pointer_update_source
 	assert pointer_update_source.contains('v_fastc_interface_box(&__v_fastc_struct_update, sizeof(Config))'), pointer_update_source
 }
@@ -1578,8 +2029,7 @@ fn main() {
 	println(outer.child.count)
 	println(outer.number)
 }
-',
-		'embedded_struct_fields.v', prefs) or { panic(err) }
+', 'embedded_struct_fields.v', prefs) or { panic(err) }
 	assert c_source.contains('.__embedded_0.value=(__v_fastc_struct_field_0)'), c_source
 	assert c_source.contains('.__embedded_0.__embedded_0.number=(__v_fastc_struct_field_1)'), c_source
 	assert c_source.contains('outer.__embedded_0.value'), c_source
@@ -1603,8 +2053,7 @@ fn (wrong Wrong) work(value string) bool { return false }
 fn main() {
 	_ := Worker(Wrong{})
 }
-',
-		'interface_type_mismatch.v', prefs) or { panic(err) }
+', 'interface_type_mismatch.v', prefs) or { panic(err) }
 	assert type_mismatch_source.len > 0
 
 	mut mutability_message := ''
@@ -1621,8 +2070,7 @@ fn (wrong Wrong) work(value int) int { return value }
 fn main() {
 	_ := Worker(Wrong{})
 }
-',
-		'interface_mutability_mismatch.v', prefs) or {
+', 'interface_mutability_mismatch.v', prefs) or {
 		mutability_message = err.msg()
 		''
 	}
@@ -1651,8 +2099,7 @@ fn main() {
 	mut value := 1
 	worker.update(mut value)
 }
-',
-		'valid_interface_implementation.v', prefs) or { panic(err) }
+', 'valid_interface_implementation.v', prefs) or { panic(err) }
 	assert c_source.contains('case __v_typeid_Good:'), c_source
 	assert c_source.contains('void Worker_update(Worker value, int* arg1)'), c_source
 }
@@ -1673,8 +2120,7 @@ fn (file File) read() !int {
 }
 
 fn main() {}
-',
-		'unused_interface_dispatch.v', prefs) or { panic(err) }
+', 'unused_interface_dispatch.v', prefs) or { panic(err) }
 	assert c_source.contains('Option Reader_read('), c_source
 	assert !c_source.contains('Option File_read('), c_source
 }
@@ -1701,8 +2147,7 @@ const sentinel = Failure(&Message{text: 'error'})
 fn main() {
 	println(sentinel.message())
 }
-",
-		'constant_interface_cast.v', prefs) or { panic(err) }
+", 'constant_interface_cast.v', prefs) or { panic(err) }
 	assert c_source.contains('main__sentinel = (Failure){._object=(void*)('), c_source
 	assert c_source.contains('._typ=__v_typeid_Message, ._methods=NULL};'), c_source
 	assert !c_source.contains('main__sentinel = ((Failure)('), c_source
@@ -1766,8 +2211,7 @@ fn main() {
 	worker := Worker(Good{})
 	worker.work()
 }
-',
-		'immutable_mutable_interface_receiver.v', prefs) or {
+', 'immutable_mutable_interface_receiver.v', prefs) or {
 		immutable_message = err.msg()
 		''
 	}
@@ -1788,8 +2232,7 @@ fn main() {
 	mut worker := Worker(Good{})
 	worker.work()
 }
-',
-		'mutable_interface_receiver.v', prefs) or { panic(err) }
+', 'mutable_interface_receiver.v', prefs) or { panic(err) }
 	assert c_source.contains('void Worker_work(Worker value)'), c_source
 	assert c_source.contains('Worker_work(worker);'), c_source
 }
@@ -1809,8 +2252,7 @@ struct Empty {}
 fn main() {
 	_ := Named(Empty{})
 }
-',
-		'interface_missing_field.v', prefs) or {
+', 'interface_missing_field.v', prefs) or {
 		missing_message = err.msg()
 		''
 	}
@@ -1829,8 +2271,7 @@ struct Wrong {
 fn main() {
 	_ := Named(Wrong{})
 }
-',
-		'interface_wrong_field_type.v', prefs) or { panic(err) }
+', 'interface_wrong_field_type.v', prefs) or { panic(err) }
 	assert type_source.contains('Named'), type_source
 
 	mut mutability_message := ''
@@ -1848,8 +2289,7 @@ struct Wrong {
 fn main() {
 	_ := Named(Wrong{})
 }
-',
-		'interface_immutable_field.v', prefs) or {
+', 'interface_immutable_field.v', prefs) or {
 		mutability_message = err.msg()
 		''
 	}
@@ -1872,8 +2312,7 @@ mut:
 fn main() {
 	_ := Named(Good{})
 }
-',
-		'valid_interface_fields.v', prefs) or { panic(err) }
+', 'valid_interface_fields.v', prefs) or { panic(err) }
 	assert c_source.contains('struct Named { void *_object; u32 _typ; void *_methods; };'), c_source
 }
 
@@ -1896,8 +2335,7 @@ fn main() {
 	traced(side_effect())
 	println(0)
 }
-',
-		'disabled_function_attribute.v', prefs) or { panic(err) }
+', 'disabled_function_attribute.v', prefs) or { panic(err) }
 	assert c_source.contains('void traced(int value) {\n}')
 	assert !c_source.contains('must not run')
 	assert !c_source.contains('traced(side_effect())')
@@ -1974,8 +2412,7 @@ fn run(tracer Tracer) {
 }
 
 fn main() {}
-',
-		'disabled_method_attribute.v', selfhost_prefs) or { panic(err) }
+', 'disabled_method_attribute.v', selfhost_prefs) or { panic(err) }
 	assert !method_source.contains('Tracer_trace(tracer,side_effect())')
 	assert method_source.contains('((void)0);')
 }
@@ -1999,8 +2436,7 @@ fn main() {
 	impossible()
 	supported()
 }
-',
-		'compound_function_attribute.v', prefs) or { panic(err) }
+', 'compound_function_attribute.v', prefs) or { panic(err) }
 	assert c_source.contains('void impossible(void) {\n}')
 	assert !c_source.contains('disabled compound condition')
 	assert c_source.contains('enabled compound condition')
@@ -2036,8 +2472,7 @@ type DisabledAlias = MissingDisabledType
 fn main() {
 	println(7)
 }
-',
-		'disabled_type_attribute.v', prefs) or { panic(err) }
+', 'disabled_type_attribute.v', prefs) or { panic(err) }
 	for disabled_name in ['DisabledStruct', 'DisabledUnion', 'DisabledEnum', 'DisabledInterface',
 		'DisabledAlias', 'MissingDisabledType'] {
 		assert !c_source.contains(disabled_name), c_source
@@ -2067,8 +2502,7 @@ $if windows {
 fn main() {
 	println(platform())
 }
-',
-		'top_level_comptime_function.v', prefs) or { panic(err) }
+', 'top_level_comptime_function.v', prefs) or { panic(err) }
 	assert c_source.contains('int platform(void)'), c_source
 	assert c_source.contains('println(platform());'), c_source
 	assert !c_source.contains('return "wrong";'), c_source
@@ -2110,8 +2544,7 @@ fn main() {
 	}
 	println(choice.value)
 }
-',
-		'top_level_comptime_types.v', prefs) or { panic(err) }
+', 'top_level_comptime_types.v', prefs) or { panic(err) }
 	assert c_source.contains('struct Choice {\n\tint value;'), c_source
 	assert !c_source.contains('bool wrong;'), c_source
 	assert c_source.contains('#define Mode__selected ((Mode)0)'), c_source
@@ -2139,8 +2572,7 @@ $if windows {
 fn main() {
 	println(answer)
 }
-',
-		'top_level_comptime_constant.v', prefs) or { panic(err) }
+', 'top_level_comptime_constant.v', prefs) or { panic(err) }
 	assert c_source.contains('#define main__answer (42)'), c_source
 	assert c_source.contains('println(main__answer);'), c_source
 	assert !c_source.contains('wrong'), c_source
@@ -2163,8 +2595,7 @@ $if windows {
 fn main() {
 	println(state)
 }
-',
-		'top_level_comptime_global.v', prefs) or { panic(err) }
+', 'top_level_comptime_global.v', prefs) or { panic(err) }
 	assert c_source.contains('static int state;'), c_source
 	assert c_source.contains('\tstate = 42;'), c_source
 	assert c_source.contains('println(state);'), c_source
@@ -2181,8 +2612,7 @@ __global answer = 42
 fn main() {
 	println(answer)
 }
-',
-		'initialized_global.v', prefs) or { panic(err) }
+', 'initialized_global.v', prefs) or { panic(err) }
 	assert c_source.contains('static int answer;'), c_source
 	assert c_source.contains('\tanswer = 42;'), c_source
 	assert c_source.contains('v_fastc_init_globals();'), c_source
@@ -2200,8 +2630,7 @@ fn init() {
 }
 
 println(answer)
-',
-		'initialized_script_global.v', prefs) or { panic(err) }
+', 'initialized_script_global.v', prefs) or { panic(err) }
 	main_source := c_source.all_after('int main(void) {')
 	startup_source := c_source.all_after('static void v_fastc_init_globals(void) {')
 	initializer := startup_source.index('answer = 42;') or { -1 }
@@ -2240,8 +2669,7 @@ fn main() {
 	println(value)
 	println(calls)
 }
-',
-		'runtime_constants.v', prefs) or { panic(err) }
+', 'runtime_constants.v', prefs) or { panic(err) }
 	assert c_source.contains('static int main__value;'), c_source
 	assert c_source.contains('static int main__unused;'), c_source
 	assert !c_source.contains('#define main__value'), c_source
@@ -2515,8 +2943,7 @@ fn main() {
 	C.exit(0)
 	println('unreachable')
 }
-",
-		'cleanup_after_exit.c.v', prefs) or { panic(err) }
+", 'cleanup_after_exit.c.v', prefs) or { panic(err) }
 	main_source := c_source.all_after('int main(void) {')
 	registration := main_source.index('atexit(v_fastc_cleanup_modules);') or { -1 }
 	exit_call := main_source.index('exit(0);') or { -1 }
@@ -2622,27 +3049,23 @@ pub fn ping() {}
 fn test_module_initializer_arity_is_validated_but_return_type_is_not() {
 	prefs := pref.new_preferences()
 	mut message := ''
-	_ := generate('module main\nfn init(value int) {}\nfn main() {}\n', 'invalid_module_init.v',
-		prefs) or {
+	_ := generate('module main\nfn init(value int) {}\nfn main() {}\n', 'invalid_module_init.v', prefs) or {
 		message = err.msg()
 		''
 	}
 	assert message.contains('module `init` with parameters'), message
-	generate('module main\nfn init() int { return 1 }\nfn main() {}\n',
-		'value_returning_module_init.v', prefs) or { panic(err) }
+	generate('module main\nfn init() int { return 1 }\nfn main() {}\n', 'value_returning_module_init.v', prefs) or { panic(err) }
 }
 
 fn test_module_cleanup_arity_is_validated_but_return_type_is_not() {
 	prefs := pref.new_preferences()
 	mut message := ''
-	_ := generate('module main\nfn cleanup(value int) {}\nfn main() {}\n',
-		'invalid_module_cleanup.v', prefs) or {
+	_ := generate('module main\nfn cleanup(value int) {}\nfn main() {}\n', 'invalid_module_cleanup.v', prefs) or {
 		message = err.msg()
 		''
 	}
 	assert message.contains('module `cleanup` with parameters'), message
-	generate('module main\nfn cleanup() int { return 1 }\nfn main() {}\n',
-		'value_returning_module_cleanup.v', prefs) or { panic(err) }
+	generate('module main\nfn cleanup() int { return 1 }\nfn main() {}\n', 'value_returning_module_cleanup.v', prefs) or { panic(err) }
 }
 
 fn test_negative_enum_discriminants_are_preserved() {
@@ -2656,8 +3079,7 @@ enum Foo {
 }
 
 fn main() {}
-',
-		'negative_enum_discriminant.v', prefs) or { panic(err) }
+', 'negative_enum_discriminant.v', prefs) or { panic(err) }
 	assert c_source.contains('#define Foo__d ((Foo)-10)'), c_source
 	assert c_source.contains('#define Foo__e ((Foo)-9)'), c_source
 }
@@ -2673,8 +3095,7 @@ enum Item {
 }
 
 fn main() {}
-',
-		'duplicate_enum_field.v', prefs) or {
+', 'duplicate_enum_field.v', prefs) or {
 		message = err.msg()
 		''
 	}
@@ -2692,8 +3113,7 @@ enum Permissions {
 }
 
 fn main() {}
-',
-		'flag_enum_custom_value.v', prefs) or {
+', 'flag_enum_custom_value.v', prefs) or {
 		message = err.msg()
 		''
 	}
@@ -2715,8 +3135,7 @@ fn main() {
 	mut color := Color.red
 	color.set(.green)
 }
-',
-		'ordinary_enum_flag_method.v', prefs) or {
+', 'ordinary_enum_flag_method.v', prefs) or {
 		ordinary_message = err.msg()
 		''
 	}
@@ -2758,20 +3177,22 @@ fn main() {
 	mut field_message := ''
 	unused_source, _ := generate_source_files([
 		FastcSourceFile{
-			path:   'immutable_flag_field.v'
+			path: 'immutable_flag_field.v'
 			source: main_source
 			header: fastc_scan_source_header(main_source, 'immutable_flag_field.v', prefs) or {
-				panic(err)
-			}
+				panic(err)}
 		},
 		FastcSourceFile{
-			path:   'settings.v'
+			path: 'settings.v'
 			source: module_source
 			header: fastc_scan_source_header(module_source, 'settings.v', prefs) or { panic(err) }
 		},
-	], prefs) or {
+	], map[string]string{}, prefs) or {
 		field_message = err.msg()
-		'', false
+		{
+			''
+			false
+		}
 	}
 	_ = unused_source
 	assert field_message.contains('receiver field `Config.permissions` is not `pub mut`'), field_message
@@ -2789,8 +3210,7 @@ fn main() {
 	flags.set(.write)
 	flags.clear(.read)
 }
-',
-		'mutable_flag_receiver.v', prefs) or { panic(err) }
+', 'mutable_flag_receiver.v', prefs) or { panic(err) }
 	assert c_source.contains('flags) |= (Permissions__write)'), c_source
 	assert c_source.contains('flags) &= ~(Permissions__read)'), c_source
 }
@@ -2799,26 +3219,7 @@ fn test_flag_method_argument_types_are_not_validated() {
 	mut prefs := pref.new_preferences()
 	prefs.building_v = true
 	for call in ['flags.set(1)', 'println(flags.has(Other.write))', 'flags.clear(Other.write)'] {
-		c_source := generate('module main
-
-@[flag]
-enum Permissions {
-	read
-	write
-}
-
-@[flag]
-enum Other {
-	read
-	write
-}
-
-fn main() {
-	mut flags := Permissions.read
-	${call}
-}
-',
-			'flag_enum_argument.v', prefs) or { panic(err) }
+		c_source := generate('module main\n\n@[flag]\nenum Permissions {\n\tread\n\twrite\n}\n\n@[flag]\nenum Other {\n\tread\n\twrite\n}\n\nfn main() {\n\tmut flags := Permissions.read\n\t${call}\n}\n', 'flag_enum_argument.v', prefs) or { panic(err) }
 		assert c_source.contains('flags'), c_source
 	}
 }
@@ -2843,8 +3244,7 @@ fn main() {
 	println(u64(PawnsBoard.h1))
 	println('${PawnsBoard.h1:020x}')
 }
-",
-		'flag_enum_64.v', prefs) or { panic(err) }
+", 'flag_enum_64.v', prefs) or { panic(err) }
 	assert c_source.contains('typedef u64 PawnsBoard;'), c_source
 	assert c_source.contains('#define PawnsBoard__h1 ((PawnsBoard)(((u64)1) << (63)))'), c_source
 	assert c_source.contains('v_fastc_unsigned_format((unsigned long long)(PawnsBoard__h1), "020x")'), c_source
@@ -2883,8 +3283,7 @@ fn main() {
 	holder := Holder{}
 	holder.reset()
 }
-',
-		'immutable_method_receiver.v', prefs) or {
+', 'immutable_method_receiver.v', prefs) or {
 		message = err.msg()
 		''
 	}
@@ -2895,8 +3294,7 @@ fn main() {
 	mut holder := Holder{}
 	holder.reset()
 }
-',
-		'mutable_method_receiver.v', prefs) or { panic(err) }
+', 'mutable_method_receiver.v', prefs) or { panic(err) }
 	assert c_source.contains('void Holder_reset(Holder* holder)'), c_source
 	assert c_source.contains('Holder_reset(&(holder))'), c_source
 }
@@ -2919,8 +3317,7 @@ fn main() {
 	print(Color.green)
 	println(Color.red)
 }
-',
-		'symbolic_enum_discriminant.v', prefs) or { panic(err) }
+', 'symbolic_enum_discriminant.v', prefs) or { panic(err) }
 	assert c_source.contains('#define Color__red ((Color)main__base)'), c_source
 	assert c_source.contains('#define Color__green ((Color)(main__base + 1))'), c_source
 	assert c_source.contains('v_fastc_print_enum_Color(Color__green, false);'), c_source
@@ -2954,8 +3351,7 @@ fn main() {
 	println('|${Color.red:5}|${Color.red:-5}|')
 	println('${Color.green:04x}')
 }
-",
-		'ordinary_enum_interpolation.v', prefs) or { panic(err) }
+", 'ordinary_enum_interpolation.v', prefs) or { panic(err) }
 	assert ordinary_interpolation_source.contains('static string v_fastc_enum_str_Color(Color value)'), ordinary_interpolation_source
 	assert ordinary_interpolation_source.contains('v_fastc_enum_str_Color(Color__red)'), ordinary_interpolation_source
 	assert ordinary_interpolation_source.contains('v_fastc_string_pad(v_fastc_enum_str_Color(Color__red), 5, false)'), ordinary_interpolation_source
@@ -3000,8 +3396,7 @@ fn main() {
 	println(color_number(Color.green))
 	println(permissions_label(Permissions.read))
 }
-",
-		'enum_interpolation.v', selfhost_prefs) or { panic(err) }
+", 'enum_interpolation.v', selfhost_prefs) or { panic(err) }
 	assert interpolation_source.contains('static string v_fastc_enum_str_Color(Color value)'), interpolation_source
 	assert interpolation_source.contains('if (value == Color__green) return _S("green");'), interpolation_source
 	assert interpolation_source.contains('return _S("unknown enum value");'), interpolation_source
@@ -3026,8 +3421,7 @@ fn main() {
 	println(value)
 	println('${value}')
 }
-",
-		'invalid_enum_print.v', prefs) or { panic(err) }
+", 'invalid_enum_print.v', prefs) or { panic(err) }
 	assert c_source.contains('else fputs("unknown enum value", stdout);'), c_source
 	assert c_source.contains('return _S("unknown enum value");'), c_source
 
@@ -3067,8 +3461,7 @@ fn main() {
 	println(MyEnumAlias(MyEnum.another))
 	println(int(MyEnumAlias.another))
 }
-',
-		'enum_alias_member.v', prefs) or { panic(err) }
+', 'enum_alias_member.v', prefs) or { panic(err) }
 	assert c_source.contains('typedef MyEnum MyEnumAlias;'), c_source
 	assert c_source.contains('MyEnum__something'), c_source
 	assert c_source.contains('MyEnum__another'), c_source
@@ -3103,8 +3496,7 @@ enum Color {
 }
 
 fn main() {}
-',
-		'unresolved_enum_discriminant.v', prefs) or {
+', 'unresolved_enum_discriminant.v', prefs) or {
 		message = err.msg()
 		''
 	}
@@ -3122,8 +3514,7 @@ fn main() {
 		else { println(0) }
 	}
 }
-',
-		'select_statement.v', prefs) or {
+', 'select_statement.v', prefs) or {
 		message = err.msg()
 		''
 	}
@@ -3157,8 +3548,7 @@ fn main() {
 fn later(value int) int {
 	return value + 1
 }
-',
-		'declared_names.v', prefs) or { panic(err) }
+', 'declared_names.v', prefs) or { panic(err) }
 	assert c_source.contains('println(later(2));')
 }
 
@@ -3169,8 +3559,7 @@ fn test_narrow_integer_cast_expressions_are_lowered_without_type_validation() {
 fn main() {
 	println(u8(255) + u8(1))
 }
-',
-		'narrow_cast_expression.v', prefs) or { panic(err) }
+', 'narrow_cast_expression.v', prefs) or { panic(err) }
 	assert c_source.contains('((u8)(255))+((u8)(1))'), c_source
 }
 
@@ -3182,8 +3571,7 @@ fn test_inferred_array_element_types_are_not_validated() {
 fn main() {
 	values := [1, true]
 }
-',
-		'inferred_array_element_types.v', prefs) or { panic(err) }
+', 'inferred_array_element_types.v', prefs) or { panic(err) }
 	assert c_source.contains('builtin__new_array_from_c_array(2, 2, sizeof(int)'), c_source
 }
 
@@ -3215,8 +3603,7 @@ fn show(x bool) {
 fn main() {
 	show(2)
 }
-',
-		'invalid_call_argument.v', prefs) or { panic(err) }
+', 'invalid_call_argument.v', prefs) or { panic(err) }
 	assert invalid_c_source.contains('show(2);'), invalid_c_source
 
 	c_source := generate('module main
@@ -3235,8 +3622,7 @@ fn main() {
 	println(increment(value))
 	show(flag)
 }
-',
-		'valid_call_arguments.v', prefs) or { panic(err) }
+', 'valid_call_arguments.v', prefs) or { panic(err) }
 	assert c_source.contains('println(increment(value));')
 	assert c_source.contains('show(flag);')
 }
@@ -3268,8 +3654,7 @@ fn with_config(value int, config Config) {}
 fn main() {
 	with_config(1)
 }
-',
-		'valid_omitted_params_struct.v', prefs) or { panic(err) }
+', 'valid_omitted_params_struct.v', prefs) or { panic(err) }
 	assert c_source.contains('with_config(1,(Config){0});'), c_source
 }
 
@@ -3283,8 +3668,7 @@ fn consume(values ...int) {}
 fn main() {
 	consume(true)
 }
-',
-		'invalid_variadic_argument.v', prefs) or { panic(err) }
+', 'invalid_variadic_argument.v', prefs) or { panic(err) }
 	assert invalid_c_source.contains('(int[]){((bool)true)}'), invalid_c_source
 
 	c_source := generate('module main
@@ -3294,9 +3678,36 @@ fn consume(values ...int) {}
 fn main() {
 	consume(1, 2)
 }
-',
-		'valid_variadic_arguments.v', prefs) or { panic(err) }
+', 'valid_variadic_arguments.v', prefs) or { panic(err) }
 	assert c_source.contains('sizeof(int), (int[]){1,2}'), c_source
+}
+
+fn test_selfhost_variadic_struct_named_arguments_are_packed_as_one_element() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+enum Kind {
+	text
+}
+
+struct Config {
+	key   Kind
+	value string
+}
+
+fn consume(configs ...Config) {}
+
+fn main() {
+	consume(
+		key: .text
+		value: "plain"
+	)
+}
+', 'variadic_named_struct.v', prefs) or { panic(err) }
+	assert c_source.contains('sizeof(Config), (Config[]){({'), c_source
+	assert c_source.contains('.key=('), c_source
+	assert c_source.contains('Kind__text'), c_source
 }
 
 fn test_scanner_diagnostics_are_rejected() {
@@ -3340,8 +3751,7 @@ fn main() {
 		break
 	}
 }
-',
-		'boolean_conditions.v', prefs) or { panic(err) }
+', 'boolean_conditions.v', prefs) or { panic(err) }
 	assert c_source.contains('if (flag) {')
 	assert c_source.contains('while (ready()) {')
 	assert c_source.contains('; ready(); i++) {')
@@ -3366,8 +3776,7 @@ fn main() {
 		break
 	}
 }
-',
-		'boolean_alias_conditions.v', prefs) or { panic(err) }
+', 'boolean_alias_conditions.v', prefs) or { panic(err) }
 	assert alias_c_source.contains('if (flag) {'), alias_c_source
 	assert alias_c_source.contains('while (enabled()) {'), alias_c_source
 	assert alias_c_source.contains('; ((BOOL)(i<1)); i++) {'), alias_c_source
@@ -3416,8 +3825,7 @@ fn main() {
 	println(same_label(Label('same'), Label('same')))
 	println(Label('alpha') < Label('beta'))
 }
-",
-		'valid_boolean_operands.v', prefs) or { panic(err) }
+", 'valid_boolean_operands.v', prefs) or { panic(err) }
 	assert c_source.contains('left<right'), c_source
 	assert c_source.contains('&&'), c_source
 	assert c_source.contains('v_fastc_println_bool'), c_source
@@ -3455,8 +3863,7 @@ fn rejects(selfhost bool, name string) bool {
 fn main() {
 	println(rejects(true, 'int'))
 }
-",
-		'logical_unary_not_precedence.v', prefs) or { panic(err) }
+", 'logical_unary_not_precedence.v', prefs) or { panic(err) }
 	assert c_source.contains('((!(selfhost))&&('), c_source
 	assert !c_source.contains('!(((selfhost)&&('), c_source
 }
@@ -3485,8 +3892,7 @@ fn different(left Pair, right Pair) bool {
 fn parenthesized(left Pair, right Pair) bool {
 	return !(left == right)
 }
-',
-		'struct_equality.v', prefs) or { panic(err) }
+', 'struct_equality.v', prefs) or { panic(err) }
 	assert c_source.contains('Pair __v_fastc_eq_left = (left);'), c_source
 	assert c_source.contains('Pair __v_fastc_eq_right = (right);'), c_source
 	assert c_source.contains('((__v_fastc_eq_left).inner).value'), c_source
@@ -3507,10 +3913,9 @@ fn parenthesized(left Pair, right Pair) bool {
 	assert compile_result.exit_code == 0, compile_result.output
 }
 
-fn test_struct_equality_with_unsupported_fields_is_rejected() {
+fn test_struct_equality_compares_dynamic_array_fields() {
 	prefs := pref.new_preferences()
-	mut message := ''
-	_ := generate('module main
+	c_source := generate('module main
 
 struct Values {
 	items []int
@@ -3519,29 +3924,16 @@ struct Values {
 fn equal(left Values, right Values) bool {
 	return left == right
 }
-',
-		'struct_array_equality.v', prefs) or {
-		message = err.msg()
-		''
-	}
-	assert message.contains('struct equality for `Values` with unsupported fields'), message
+', 'struct_array_equality.v', prefs) or { panic(err) }
+	assert c_source.contains('__v_fastc_array_eq_left.len == __v_fastc_array_eq_right.len'), c_source
+	assert c_source.contains('((int *)__v_fastc_array_eq_left.data)'), c_source
 }
 
 fn test_literal_membership_evaluates_subject_once() {
 	mut prefs := pref.new_preferences()
 	prefs.building_v = true
 	for operator in ['in', '!in'] {
-		c_source := generate('module main
-
-fn next() int {
-	return 1
-}
-
-fn main() {
-	if next() ${operator} [0, 2] {}
-}
-',
-			'membership_subject_once.v', prefs) or { panic(err) }
+		c_source := generate('module main\n\nfn next() int {\n\treturn 1\n}\n\nfn main() {\n\tif next() ${operator} [0, 2] {}\n}\n', 'membership_subject_once.v', prefs) or { panic(err) }
 		assert c_source.contains('__v_fastc_membership_item = (next());'), c_source
 		assert c_source.count('next()') == 1, c_source
 	}
@@ -3551,21 +3943,7 @@ fn test_array_membership_evaluates_candidate_before_collection() {
 	mut prefs := pref.new_preferences()
 	prefs.building_v = true
 	for operator in ['in', '!in'] {
-		c_source := generate('module main
-
-fn candidate() int {
-	return 1
-}
-
-fn collection() []int {
-	return [1, 2]
-}
-
-fn main() {
-	if candidate() ${operator} collection() {}
-}
-',
-			'array_membership_order.v', prefs) or { panic(err) }
+		c_source := generate('module main\n\nfn candidate() int {\n\treturn 1\n}\n\nfn collection() []int {\n\treturn [1, 2]\n}\n\nfn main() {\n\tif candidate() ${operator} collection() {}\n}\n', 'array_membership_order.v', prefs) or { panic(err) }
 		candidate_index := c_source.index('__v_fastc_membership_item = (candidate());') or { -1 }
 		collection_index := c_source.index('__v_fastc_membership_collection = (collection());') or {
 			-1
@@ -3587,10 +3965,10 @@ fn fastc_test_expression_token(tok token.Token, lit string) FastcExpressionToken
 fn test_literal_membership_materializes_candidates_before_comparison() {
 	prefs := pref.new_preferences()
 	g := Parser{
-		prefs:    &prefs
+		prefs: &prefs
 		selfhost: true
-		s:        scanner.new_scanner(prefs, .normal)
-		locals:   {
+		s: scanner.new_scanner(prefs, .normal)
+		locals: {
 			'subject': FastcLocal{
 				typ: 'int'
 			}
@@ -3642,8 +4020,7 @@ fn main() {
 	__v_fastc_membership_candidate_0 := 1
 	if 1 in [__v_fastc_membership_candidate_0] {}
 }
-',
-		'membership_temporary_collision.v', prefs) or { panic(err) }
+', 'membership_temporary_collision.v', prefs) or { panic(err) }
 	assert c_source.contains('int __v_fastc_membership_1_item = (1);'), c_source
 	assert c_source.contains('__v_fastc_membership_1_collection'), c_source
 	assert !c_source.contains('int __v_fastc_membership_item = (1);'), c_source
@@ -3666,8 +4043,7 @@ fn main() {
 	if substring() in value() {}
 	if 'xyz' !in 'hello' {}
 }
-",
-		'string_membership.v', prefs) or { panic(err) }
+", 'string_membership.v', prefs) or { panic(err) }
 	substring_assignment := 'string __v_fastc_membership_substring = (substring());'
 	value_assignment := 'string __v_fastc_membership_value = (value());'
 	assert c_source.contains('static bool v_fastc_string_contains(string value, string substring)'), c_source
@@ -3697,8 +4073,7 @@ fn main() {
 	values := [candidate]
 	if value in values {}
 }
-",
-		'string_alias_membership.v', prefs) or { panic(err) }
+", 'string_alias_membership.v', prefs) or { panic(err) }
 	assert c_source.count('builtin__string_eq(__v_fastc_membership_item, ((Str *)__v_fastc_membership_collection.data)') == 2, c_source
 }
 
@@ -3716,8 +4091,7 @@ fn main() {
 	println(i64(-1) < u64(1) && u64(2) >= i64(2))
 	println(!((u64(1) < i64(-1))))
 }
-',
-		'mixed_integer_comparisons.v', prefs) or { panic(err) }
+', 'mixed_integer_comparisons.v', prefs) or { panic(err) }
 	assert c_source.contains('v_fastc_us_gt('), c_source
 	assert c_source.contains('v_fastc_us_ne('), c_source
 
@@ -3761,11 +4135,34 @@ fn main() {
 		else {}
 	}
 }
-',
-		'valid_match_branch_types.v', prefs) or { panic(err) }
+', 'valid_match_branch_types.v', prefs) or { panic(err) }
 	assert c_source.contains('if (((__v_fastc_match_'), c_source
 	assert c_source.contains('== (0)) || '), c_source
 	assert c_source.contains('== (1))'), c_source
+}
+
+fn test_selfhost_match_accepts_keyword_enum_members() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+enum Mode {
+	none
+	manual
+}
+
+fn use(mode Mode) int {
+	return match mode {
+		.manual { 1 }
+		.none { 0 }
+	}
+}
+
+fn main() {
+	_ := use(.manual)
+}
+', 'selfhost_match_keyword_enum.v', prefs) or { panic(err) }
+	assert c_source.contains('Mode__manual'), c_source
 }
 
 fn test_duplicate_match_cases_are_rejected() {
@@ -3809,8 +4206,7 @@ fn main() {
 	}
 	println(unsafe { bool(0) })
 }
-',
-		'valid_primitive_casts.v', prefs) or { panic(err) }
+', 'valid_primitive_casts.v', prefs) or { panic(err) }
 	assert c_source.contains('println(((bool)(2)));'), c_source
 	assert c_source.contains('println(((bool)(0)));'), c_source
 }
@@ -3848,8 +4244,7 @@ fn main() {
 	println(int(count))
 	println(color)
 }
-",
-		'valid_declared_casts.v', prefs) or { panic(err) }
+", 'valid_declared_casts.v', prefs) or { panic(err) }
 	assert c_source.contains('((Label)("ok"))'), c_source
 	assert c_source.contains('((Count)(2))'), c_source
 	assert c_source.contains('((Color)(1))'), c_source
@@ -3866,8 +4261,7 @@ fn main() {
 	}
 	println(3)
 }
-',
-		'scoped_defer.v', prefs) or { panic(err) }
+', 'scoped_defer.v', prefs) or { panic(err) }
 	print_two := c_source.index('println(2);') or { panic(c_source) }
 	deferred_one := c_source.index_after('println(1);', print_two) or { panic(c_source) }
 	print_three := c_source.index_after('println(3);', deferred_one) or { panic(c_source) }
@@ -3888,8 +4282,7 @@ fn value() int {
 fn main() {
 	println(value())
 }
-',
-		'return_before_defer.v', prefs) or { panic(err) }
+', 'return_before_defer.v', prefs) or { panic(err) }
 	evaluation := c_source.index('__typeof__((x)) __v_fastc_return_') or { panic(c_source) }
 	deferred_assignment := c_source.index_after('x=2;', evaluation) or { panic(c_source) }
 	returned_temporary := c_source.index_after('return __v_fastc_return_', deferred_assignment) or {
@@ -3930,8 +4323,7 @@ fn main() {
 	x := 1
 	change(&x)
 }
-',
-		'immutable_pointer_argument.v', prefs) or {
+', 'immutable_pointer_argument.v', prefs) or {
 		pointer_message = err.msg()
 		''
 	}
@@ -3948,8 +4340,7 @@ fn main() {
 	x := 1
 	change(mut x)
 }
-',
-		'immutable_mut_argument.v', prefs) or {
+', 'immutable_mut_argument.v', prefs) or {
 		immutable_message = err.msg()
 		''
 	}
@@ -3966,8 +4357,7 @@ fn main() {
 	change(mut x)
 	println(x)
 }
-',
-		'mutable_argument.v', prefs) or { panic(err) }
+', 'mutable_argument.v', prefs) or { panic(err) }
 	assert c_source.contains('void change(int* x)'), c_source
 	assert c_source.contains('change(&x);'), c_source
 }
@@ -3987,8 +4377,7 @@ fn main() {
 	update(mut state)
 	println(state)
 }
-',
-		'mutable_global_argument.v', prefs) or { panic(err) }
+', 'mutable_global_argument.v', prefs) or { panic(err) }
 	assert c_source.contains('void update(int* value)'), c_source
 	assert c_source.contains('update(&state);'), c_source
 
@@ -4084,8 +4473,7 @@ fn main() {
 	y := match x { 1 { 7 } }
 	println(y)
 }
-',
-		'non_exhaustive_match_expression.v', prefs) or {
+', 'non_exhaustive_match_expression.v', prefs) or {
 		message = err.msg()
 		''
 	}
@@ -4098,8 +4486,7 @@ fn main() {
 	y := match x { 1 { 7 } else { 9 } }
 	println(y)
 }
-',
-		'exhaustive_match_expression.v', prefs) or { panic(err) }
+', 'exhaustive_match_expression.v', prefs) or { panic(err) }
 	assert c_source.contains('? (7) : (9)')
 }
 
@@ -4117,8 +4504,7 @@ fn value(x int) int {
 fn main() {
 	println(value(1))
 }
-',
-		'non_exhaustive_match_statement.v', prefs) or {
+', 'non_exhaustive_match_statement.v', prefs) or {
 		message = err.msg()
 		''
 	}
@@ -4136,8 +4522,7 @@ fn value(x int) int {
 fn main() {
 	println(value(1))
 }
-',
-		'exhaustive_match_statement.v', prefs) or { panic(err) }
+', 'exhaustive_match_statement.v', prefs) or { panic(err) }
 	assert c_source.contains('else {\n\t\treturn 9;'), c_source
 }
 
@@ -4171,8 +4556,7 @@ fn main() {
 	v_auto := v_result
 	println(auto + v_auto)
 }
-',
-		'reserved_identifiers.v', prefs) or { panic(err) }
+', 'reserved_identifiers.v', prefs) or { panic(err) }
 	assert c_source.contains('int __v_fastc_keyword_auto;'), c_source
 	assert c_source.contains('int v_auto;'), c_source
 	assert c_source.contains('int calculate(Holder holder, int __v_fastc_keyword_register, int v_register)'), c_source
@@ -4224,8 +4608,7 @@ fn close() int {
 fn main() {
 	println(close())
 }
-',
-		'libc_function_collisions.v', prefs) or { panic(err) }
+', 'libc_function_collisions.v', prefs) or { panic(err) }
 	for name in ['strlen', 'printf', 'open', 'close'] {
 		assert c_source.contains('int __v_fastc_function_${name}(void)'), c_source
 	}
@@ -4265,8 +4648,7 @@ fn v_fastc_bool_str(value bool) string {
 fn main() {
 	println(v_fastc_bool_str(true))
 }
-",
-		'fastc_runtime_function_collision.v', prefs) or { panic(err) }
+", 'fastc_runtime_function_collision.v', prefs) or { panic(err) }
 	assert c_source.contains('static string v_fastc_bool_str(bool value)'), c_source
 	assert c_source.contains('string __v_fastc_function_v_fastc_bool_str(bool value)'), c_source
 	assert c_source.contains('println(__v_fastc_function_v_fastc_bool_str(((bool)true)))'), c_source
@@ -4316,8 +4698,7 @@ fn main() {
 	println(enabled())
 	println(value())
 }
-',
-		'valid_return_types.v', prefs) or { panic(err) }
+', 'valid_return_types.v', prefs) or { panic(err) }
 	assert c_source.contains('return ((bool)true);')
 	assert c_source.contains('return 2;')
 }
@@ -4352,8 +4733,7 @@ fn main() {
 	println(enabled)
 	println(count)
 }
-',
-		'valid_assignment_types.v', prefs) or { panic(err) }
+', 'valid_assignment_types.v', prefs) or { panic(err) }
 	assert c_source.contains('enabled=ready();')
 	assert c_source.contains('count=2;')
 	assert c_source.contains('count+=3;')
@@ -4394,8 +4774,7 @@ fn main() {
 	println(first)
 	println(second)
 }
-',
-		'valid_parallel_assignment.v', prefs) or { panic(err) }
+', 'valid_parallel_assignment.v', prefs) or { panic(err) }
 	assert c_source.contains('first = __v_fastc_parallel_'), c_source
 	assert c_source.contains('second = __v_fastc_parallel_'), c_source
 	assert c_source.contains('memcpy(&first, __v_fastc_multi_return_'), c_source
@@ -4420,9 +4799,101 @@ fn main() {
 	mut holder := Holder{}
 	swap(mut holder)
 }
-',
-		'parallel_aggregate_assignment.v', prefs) or { panic(err) }
+', 'parallel_aggregate_assignment.v', prefs) or { panic(err) }
 	assert c_source.count('__v_fastc_parallel_') >= 4, c_source
+}
+
+fn test_selfhost_parallel_declaration_from_if_expression() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+fn choose(flag bool) int {
+	mut a, mut b := if flag {
+		1, 2
+	} else {
+		3, 4
+	}
+	a++
+	b++
+	return a + b
+}
+
+fn main() {
+	_ := choose(true)
+}
+', 'selfhost_parallel_if_expression.v', prefs) or { panic(err) }
+	assert c_source.contains('MultiReturn __v_fastc_multi_return_'), c_source
+	assert c_source.contains('int a = (int){0};'), c_source
+	assert c_source.contains('int b = (int){0};'), c_source
+}
+
+fn test_selfhost_parallel_option_multireturn_from_nested_receiver() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Data {
+	value int
+}
+
+struct Worker {}
+
+fn (w Worker) pair() !(int, Data) {
+	return 1, Data{ value: 2 }
+}
+
+struct Holder {
+	worker Worker
+}
+
+fn use(holder Holder) int {
+	first, data := holder.worker.pair()!
+	return first + data.value
+}
+
+fn main() {
+	_ := use(Holder{})
+}
+', 'selfhost_nested_receiver_option_multireturn.v', prefs) or { panic(err) }
+	assert c_source.contains('Data data = (Data){0};'), c_source
+	assert c_source.contains('memcpy(&data, __v_fastc_multi_return_'), c_source
+}
+
+fn test_selfhost_option_multireturn_guard_from_nested_mut_receiver() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Worker {}
+
+fn (mut w Worker) pair(flag bool, value int) ?(u64, int) {
+	return if flag { u64(1) } else { u64(0) }, value
+}
+
+struct Holder {
+mut:
+	worker &Worker
+}
+
+fn use(mut holder Holder) u64 {
+	if first, _ := holder.worker.pair(true,
+		2)
+	{
+		return first
+	}
+	return 0
+}
+
+fn main() {
+	mut worker := Worker{}
+	mut holder := Holder{ worker: &worker }
+	_ := use(mut holder)
+}
+', 'selfhost_nested_mut_receiver_option_multireturn_guard.v', prefs) or { panic(err) }
+	assert c_source.contains('u64 first = (u64){0};'), c_source
+	assert c_source.contains('memcpy(&first, __v_fastc_multi_return_'), c_source
+	assert !c_source.contains(';);'), c_source
 }
 
 fn test_selfhost_array_field_index_assignment_keeps_the_field_name() {
@@ -4443,8 +4914,7 @@ fn main() {
 	mut file := File{}
 	copy_byte(mut file, []u8{}, 0)
 }
-',
-		'array_field_index_assignment.v', prefs) or { panic(err) }
+', 'array_field_index_assignment.v', prefs) or { panic(err) }
 	assert c_source.contains('builtin__array_get(file->source_digest, index)'), c_source
 	assert !c_source.contains('file->source_('), c_source
 }
@@ -4472,16 +4942,16 @@ fn main() {
 '
 	c_source, _ := generate_source_files([
 		FastcSourceFile{
-			path:   'main.v'
+			path: 'main.v'
 			source: main_source
 			header: fastc_scan_source_header(main_source, 'main.v', prefs) or { panic(err) }
 		},
 		FastcSourceFile{
-			path:   'sizes/sizes.v'
+			path: 'sizes/sizes.v'
 			source: sizes_source
 			header: fastc_scan_source_header(sizes_source, 'sizes/sizes.v', prefs) or { panic(err) }
 		},
-	], prefs) or { panic(err) }
+	], map[string]string{}, prefs) or { panic(err) }
 	assert c_source.contains('u8 source_digest[sizes__digest_size];'), c_source
 	assert c_source.contains('(file->source_digest)[builtin__v_fixed_index(index, sizes__digest_size)]'), c_source
 }
@@ -4501,8 +4971,7 @@ fn main() {
 	holder := Holder{}
 	holder.value = 2
 }
-',
-		'immutable_aggregate_root.v', prefs) or {
+', 'immutable_aggregate_root.v', prefs) or {
 		message = err.msg()
 		''
 	}
@@ -4519,8 +4988,7 @@ fn main() {
 	mut holder := Holder{}
 	holder.value = 2
 }
-',
-		'mutable_aggregate_root.v', prefs) or { panic(err) }
+', 'mutable_aggregate_root.v', prefs) or { panic(err) }
 	assert c_source.contains('holder.value=2;'), c_source
 }
 
@@ -4534,8 +5002,7 @@ fn main() {
 		println(1)
 	}
 }
-',
-		'invalid_loop_initializer.v', prefs) or { panic(err) }
+', 'invalid_loop_initializer.v', prefs) or { panic(err) }
 	assert invalid_c_source.contains('for (enabled = (2); enabled; enabled=((bool)false)) {'), invalid_c_source
 
 	c_source := generate('module main
@@ -4544,8 +5011,7 @@ fn main() {
 	mut enabled := false
 	for enabled = true; enabled; enabled = false {}
 }
-',
-		'valid_loop_initializer.v', prefs) or { panic(err) }
+', 'valid_loop_initializer.v', prefs) or { panic(err) }
 	assert c_source.contains('for (enabled = (((bool)true)); enabled; enabled=((bool)false)) {'), c_source
 
 	mut selfhost_prefs := pref.new_preferences()
@@ -4556,8 +5022,7 @@ fn main() {
 	mut i := 0
 	for ; i < 2; i++ {}
 }
-',
-		'empty_loop_initializer.v', selfhost_prefs) or { panic(err) }
+', 'empty_loop_initializer.v', selfhost_prefs) or { panic(err) }
 	assert empty_initializer_source.contains('for (; i<2; i++) {'), empty_initializer_source
 }
 
@@ -4604,8 +5069,7 @@ fn main() {
 	take_signed(-1)
 	println(signed_value())
 }
-',
-		'positive_unsigned_literals.v', prefs) or { panic(err) }
+', 'positive_unsigned_literals.v', prefs) or { panic(err) }
 	assert c_source.contains('number=1;')
 	assert c_source.contains('take(1);')
 	assert c_source.contains('return 1;')
@@ -4616,8 +5080,7 @@ fn main() {
 
 fn test_main_return_type_is_not_validated() {
 	prefs := pref.new_preferences()
-	c_source := generate('module main\nfn main() int { return 7 }\n', 'value_returning_main.v',
-		prefs) or { panic(err) }
+	c_source := generate('module main\nfn main() int { return 7 }\n', 'value_returning_main.v', prefs) or { panic(err) }
 	assert c_source.contains('int main(void)'), c_source
 	assert c_source.contains('return 7;'), c_source
 }
@@ -4653,8 +5116,7 @@ fn main() {
 		change(mut item)
 	}
 }
-',
-		'immutable_mutable_iteration.v', prefs) or {
+', 'immutable_mutable_iteration.v', prefs) or {
 		message = err.msg()
 		''
 	}
@@ -4674,8 +5136,7 @@ fn main() {
 		change(mut item)
 	}
 }
-',
-		'mutable_iteration.v', prefs) or { panic(err) }
+', 'mutable_iteration.v', prefs) or { panic(err) }
 	assert c_source.contains('int *item = &(((int *)'), c_source
 	assert c_source.contains('println((*(item)));'), c_source
 	assert c_source.contains('(*item)=3;'), c_source
@@ -4702,8 +5163,7 @@ fn iterate(source map[string]int) {
 fn main() {
 	iterate(map[string]int{})
 }
-',
-		'map_pointer_iteration.v', prefs) or { panic(err) }
+', 'map_pointer_iteration.v', prefs) or { panic(err) }
 	assert c_source.count('builtin__map_keys((map *)&__v_fastc_map_collection_') == 1, c_source
 	assert c_source.count('builtin__map_values((map *)&__v_fastc_map_collection_') == 1, c_source
 	assert c_source.count('builtin__map_keys((map *)__v_fastc_map_collection_') == 1, c_source
@@ -4774,8 +5234,7 @@ fn main() {
 	println(kinds.len)
 	println(permissions.len)
 }
-",
-		'map_alias_callbacks.v', prefs) or { panic(err) }
+", 'map_alias_callbacks.v', prefs) or { panic(err) }
 	assert c_source.contains('sizeof(WideKey), sizeof(int), &builtin__map_hash_int_8, &builtin__map_eq_int_8, &builtin__map_clone_int_8'), c_source
 
 	assert c_source.contains('sizeof(TextKey), sizeof(int), &builtin__map_hash_string, &builtin__map_eq_string, &builtin__map_clone_string'), c_source
@@ -4802,8 +5261,7 @@ fn main() {
 		take(value)
 	}
 }
-',
-		'array_pointer_iteration.v', prefs) or { panic(err) }
+', 'array_pointer_iteration.v', prefs) or { panic(err) }
 	assert c_source.count('int *value = &(((int *)__v_fastc_collection_') == 2, c_source
 	assert c_source.count('take(value);') == 2, c_source
 }
@@ -4823,8 +5281,7 @@ fn main() {
 	mut values := []int{}
 	checked(mut values, "x", [][]int{}, 0)
 }
-',
-		'checked_indexing.v', prefs) or { panic(err) }
+', 'checked_indexing.v', prefs) or { panic(err) }
 	assert c_source.count('builtin__array_get(*(values), index)') == 2, c_source
 	assert c_source.contains('builtin__string_at(text, index)'), c_source
 	assert c_source.contains('builtin__array_get(nested, index)'), c_source
@@ -4852,8 +5309,7 @@ fn main() {
 	mut holder := Holder{}
 	reset(mut holder)
 }
-',
-		'selector_array_initializer.v', prefs) or { panic(err) }
+', 'selector_array_initializer.v', prefs) or { panic(err) }
 	assert c_source.contains('holder->values='), c_source
 	assert c_source.contains('builtin____new_array('), c_source
 }
@@ -4869,9 +5325,8 @@ type Any = int
 	| []Any
 
 fn main() {}
-',
-		'multiline_sum_type.v', prefs) or { panic(err) }
-	assert c_source.contains('typedef struct { void *_object; u32 _typ; } Any;'), c_source
+', 'multiline_sum_type.v', prefs) or { panic(err) }
+	assert c_source.contains('typedef struct { void *_object; u32 _typ; void *_methods; } Any;'), c_source
 }
 
 fn test_selfhost_composite_ordering_moves_one_line_interfaces_before_fields() {
@@ -4881,12 +5336,46 @@ fn test_selfhost_composite_ordering_moves_one_line_interfaces_before_fields() {
 			'wr': 'Writer'
 		}
 	}, {
-		'Holder': true
-		'Writer': true
-	})
+		fastc_c_declared_type_name(fastc_type_key('main', 'Holder')): true
+		fastc_c_declared_type_name(fastc_type_key('main', 'Writer')): true
+	}, map[string]string{})
 	writer_index := ordered.index('struct Writer {') or { -1 }
 	holder_index := ordered.index('struct Holder {') or { -1 }
 	assert writer_index >= 0 && writer_index < holder_index, ordered
+}
+
+fn test_selfhost_composite_ordering_resolves_by_value_aliases() {
+	source := 'typedef Db DbAlias;\nstruct App {\n\tDbAlias db;\n};\n\nstruct Db { int id; };\n'
+	ordered := fastc_order_c_composite_definitions(source, {
+		'App': {
+			'db': 'DbAlias'
+		}
+	}, {
+		'App': true
+		'Db':  true
+	}, {
+		'DbAlias': 'Db'
+	})
+	db_index := ordered.index('struct Db {') or { -1 }
+	app_index := ordered.index('struct App {') or { -1 }
+	assert db_index >= 0 && db_index < app_index, ordered
+}
+
+fn test_selfhost_type_aliases_are_hoisted_before_composite_fields() {
+	source := '#define Redirect__found ((Redirect)(Status__found))\nstruct Request {\n\tRedirectFn on_redirect;\n};\n\ntypedef int (*RedirectFn)(Handle*);\ntypedef struct handle Handle;\n#define Status__found ((Status)302)\n'
+	ordered := fastc_hoist_c_type_aliases(source)
+	status_index := ordered.index('#define Status__found') or { -1 }
+	redirect_index := ordered.index('#define Redirect__found') or { -1 }
+	alias_index := ordered.index('typedef int (*RedirectFn)') or { -1 }
+	handle_index := ordered.index('typedef struct handle Handle') or { -1 }
+	request_index := ordered.index('struct Request {') or { -1 }
+	assert redirect_index >= 0 && status_index > redirect_index && status_index < handle_index, ordered
+	assert handle_index < alias_index && alias_index < request_index, ordered
+}
+
+fn test_nested_fixed_array_struct_field_uses_native_c_dimensions() {
+	typ := fastc_fixed_array_type('4', fastc_fixed_array_type('256', 'u32'))
+	assert fastc_fixed_array_field_declaration(typ, 'values')? == 'u32 values[4][256]'
 }
 
 fn test_selfhost_comptime_type_condition_accepts_disjunctions() {
@@ -4907,8 +5396,7 @@ fn fastc_size[T](value T) int {
 }
 
 fn main() {}
-',
-		'comptime_type_disjunction.v', prefs) or { panic(err) }
+', 'comptime_type_disjunction.v', prefs) or { panic(err) }
 	assert c_source.contains('int fastc_size(voidptr value)'), c_source
 	assert c_source.contains('return -1;'), c_source
 	assert !c_source.contains('return 2;'), c_source
@@ -4924,9 +5412,289 @@ fn fastc_type_name[T](value T) string {
 }
 
 fn main() {}
-",
-		'typeof_name_interpolation.v', prefs) or { panic(err) }
+", 'typeof_name_interpolation.v', prefs) or { panic(err) }
 	assert c_source.contains('return _S("voidptr");'), c_source
+}
+
+fn test_selfhost_embedded_field_promoted_in_compound_slice_bound() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Base {
+mut:
+	pos int
+}
+
+struct Scanner {
+	Base
+	input string
+}
+
+fn fastc_slice_two(s Scanner) string {
+	return s.input[s.pos..s.pos + 2]
+}
+
+fn main() {}
+', 'embed_slice_bound.v', prefs) or { panic(err) }
+	// The high slice bound `s.pos + 2` is a compound expression, which the pure
+	// member-chain renderer rejects; it must still promote the embedded `pos` field
+	// like the receiver and low bound do.
+	assert c_source.contains('__embedded_0.pos + 2'), c_source
+}
+
+fn test_selfhost_embedded_field_promoted_in_plain_expression() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Base {
+mut:
+	pos int
+}
+
+struct Scanner {
+	Base
+}
+
+fn fastc_getpos(s Scanner) int {
+	return s.pos + 2
+}
+
+fn main() {}
+', 'embed_plain.v', prefs) or { panic(err) }
+	// A plain `s.pos` member access (rendered by the main token loop via
+	// `expression_token`, not the slice/member-chain renderers) must promote the
+	// embedded `pos` field to `s->__embedded_0.pos` rather than the invalid `s->pos`.
+	assert c_source.contains('__embedded_0.pos'), c_source
+}
+
+fn test_selfhost_embedded_field_promoted_in_nested_call() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Base {
+	handle int
+}
+
+struct Socket {
+	Base
+}
+
+struct Conn {
+	sock Socket
+}
+
+struct Addr {}
+
+fn (addr &Addr) len() int {
+	return 1
+}
+
+fn C.consume(handle int, length int) int
+
+fn check(result int) ! {}
+
+fn (mut c Conn) write(addr Addr) ! {
+	check(C.consume(c.sock.handle, addr.len()))!
+}
+
+fn main() {}
+', 'embed_nested_call.v', prefs) or { panic(err) }
+	assert c_source.contains('consume(c->sock.__embedded_0.handle)'), c_source
+	assert !c_source.contains('consume(c->sock.handle)'), c_source
+}
+
+fn test_selfhost_member_does_not_resolve_as_same_named_function_value() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct User {}
+
+fn user(name string) User {
+	return User{}
+}
+
+struct Source {
+	name string
+	user ?User
+}
+
+struct Target {
+mut:
+	user ?User
+}
+
+fn make_source() Source {
+	return Source{
+		name: maybe_name()!
+		user: user("alex")
+	}
+}
+
+fn maybe_name() !string {
+	return "alex"
+}
+
+fn copy_user(mut target Target, source Source) {
+	target.user = source.user
+}
+
+fn main() {}
+', 'member_named_like_function.v', prefs) or { panic(err) }
+	assert c_source.contains('target->user=source.user'), c_source
+	assert !c_source.contains('target->user=&main__user'), c_source
+	assert !c_source.contains('.main__user='), c_source
+}
+
+fn test_selfhost_nested_member_array_indexes_lower_innermost_first() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Token {
+	goto_pc   int
+	group_rep int
+}
+
+struct Re {
+	prog []Token
+}
+
+fn group_repetition(re &Re, state int) int {
+	return re.prog[re.prog[state].goto_pc].group_rep
+}
+
+fn main() {}
+', 'nested_member_array_indexes.v', prefs) or { panic(err) }
+	assert c_source.count('builtin__array_get') >= 2, c_source
+	assert !c_source.contains('re->prog['), c_source
+}
+
+fn test_selfhost_implicit_generic_specializes_compound_arguments() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+fn fastc_abs[T](value T) T {
+	return if value < 0 { -value } else { value }
+}
+
+fn total(x f64, values []f64) f64 {
+	return fastc_abs(x * 2.0) + fastc_abs(values[0])
+}
+
+fn main() {}
+', 'implicit_generic_compound_arguments.v', prefs) or { panic(err) }
+	assert c_source.contains('main__fastc_abs_mono_f64(x*2.0)'), c_source
+	assert c_source.contains('main__fastc_abs_mono_f64((*(f64 *)builtin__array_get(values, 0)))'), c_source
+
+	assert !c_source.contains('main__fastc_abs(x*2.0)'), c_source
+}
+
+fn test_selfhost_append_map_index_is_lowered() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate("module main
+
+fn fastc_append_kinds(m map[string]int) []int {
+	mut result := []int{}
+	result << m['x']
+	return result
+}
+
+fn main() {}
+", 'append_map_index.v', prefs) or { panic(err) }
+	// A map index in an append RHS (`result << m['x']`) must be lowered to a map get,
+	// not left as the invalid raw C `m[...]`.
+	assert c_source.contains('map_get'), c_source
+}
+
+fn test_selfhost_append_to_array_stored_in_map() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate("module main
+
+fn add(mut groups map[string][]int, key string, value int) {
+	groups[key] << value
+}
+
+fn main() {
+	mut groups := map[string][]int{}
+	add(mut groups, 'x', 1)
+}
+", 'selfhost_append_to_map_array.v', prefs) or { panic(err) }
+	assert c_source.contains('__v_fastc_append_map_target'), c_source
+	assert c_source.contains('builtin__map_get_check'), c_source
+	assert !c_source.contains('groups[key]'), c_source
+}
+
+fn test_selfhost_empty_array_assigned_to_member_field() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Cfg {
+mut:
+	fields []string
+}
+
+fn fastc_reset(mut c Cfg) {
+	c.fields = []
+}
+
+fn main() {}
+', 'empty_array_field.v', prefs) or { panic(err) }
+	// `c.fields = []` (empty array literal assigned to a member target) must lower to a
+	// typed empty array, not the invalid raw `c->fields=[]`.
+	assert c_source.contains('(Array_string){0}'), c_source
+	assert !c_source.contains('fields=[]'), c_source
+}
+
+fn test_selfhost_nonempty_array_assigned_to_member_field() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Cfg {
+mut:
+	fields []string
+}
+
+fn fastc_reset(mut c Cfg, name string) {
+	c.fields = [name]
+}
+
+fn main() {}
+', 'nonempty_array_field.v', prefs) or { panic(err) }
+	assert c_source.contains('c->fields=((Array_string)builtin__new_array_from_c_array'), c_source
+	assert !c_source.contains('array_get(c->fields='), c_source
+}
+
+fn test_selfhost_if_expression_assigned_to_string_field_infers_string() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate("module main
+
+struct Cfg {
+mut:
+	name string
+}
+
+fn fastc_pick(mut c Cfg, cond bool) {
+	c.name = if cond { 'a' } else { 'b' }
+}
+
+fn main() {}
+", 'if_assign_string.v', prefs) or { panic(err) }
+	// An if-expression assigned to a `string` member field must infer `string` for its
+	// branches, not wrap them in an Option (which happened when the member assignment
+	// did not set `expected_expression_type` to the field type and a stale `Option`
+	// leaked in).
+	assert c_source.contains('_S("a")'), c_source
+	assert !c_source.contains('__v_fastc_box_value = (_S("a"))'), c_source
 }
 
 fn test_selfhost_result_method_or_block_is_a_statement() {
@@ -4952,9 +5720,31 @@ fn main() {
 	mut writer := Writer{}
 	pad(mut writer)
 }
-',
-		'result_method_or_statement.v', prefs) or { panic(err) }
+', 'result_method_or_statement.v', prefs) or { panic(err) }
 	assert c_source.contains('Option __v_fastc_option_'), c_source
+}
+
+fn test_selfhost_comptime_if_starts_or_block_statement() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+fn attempt() ! {}
+
+fn use() {
+	attempt() or {
+		$if fastc_disabled_trace ? {
+			println("trace")
+		}
+	}
+}
+
+fn main() {
+	use()
+}
+', 'selfhost_comptime_if_or_statement.v', prefs) or { panic(err) }
+	assert c_source.contains('Option __v_fastc_option_'), c_source
+	assert !c_source.contains('_S("trace")'), c_source
 }
 
 fn test_selfhost_array_lookup_or_block_checks_bounds() {
@@ -4969,8 +5759,7 @@ fn first(values []string) string {
 fn main() {
 	_ := first([]string{})
 }
-",
-		'array_lookup_or_block.v', prefs) or { panic(err) }
+", 'array_lookup_or_block.v', prefs) or { panic(err) }
 	assert c_source.contains('bool __v_fastc_array_missing = __v_fastc_array_index < 0 || __v_fastc_array_index >= __v_fastc_array.len;'), c_source
 	assert c_source.contains('(Option){.data=__v_fastc_array_value, .state=__v_fastc_array_missing ? 2 : 0}'), c_source
 }
@@ -5023,6 +5812,10 @@ fn write_tail(mut buffer Buffer, source []u8) int {
 	return write_bytes(mut buffer.bytes[1..], source)
 }
 
+fn clone_head(mut values []int) []int {
+	return values[..1].clone()
+}
+
 fn main() {
 	values := []int{}
 	result := middle(values, 0, 0)
@@ -5033,9 +5826,10 @@ fn main() {
 	alias_tail(Text("abc"))
 	mut buffer := Buffer{}
 	write_tail(mut buffer, []u8{})
+	mut mutable_values := [1]
+	clone_head(mut mutable_values)
 }
-',
-		'array_slice.v', prefs) or { panic(err) }
+', 'array_slice.v', prefs) or { panic(err) }
 	assert c_source.contains('return builtin__array_slice(values, start, end);'), c_source
 	assert c_source.contains('__typeof__((make_values())) __v_fastc_slice_receiver = (make_values()); builtin__array_slice(__v_fastc_slice_receiver, 1, __v_fastc_slice_receiver.len);'), c_source
 	assert c_source.contains('__typeof__((make_text())) __v_fastc_slice_receiver = (make_text()); builtin__string_substr((__v_fastc_slice_receiver), 1, __v_fastc_slice_receiver.len);'), c_source
@@ -5046,7 +5840,9 @@ fn main() {
 	assert !c_source.contains('make_text().len'), c_source
 	assert !c_source.contains('__v_slice.flags |= ArrayFlags__is_slice'), c_source
 	assert c_source.contains('__v_fastc_mut_argument = (({ __typeof__((buffer->bytes)) __v_fastc_slice_receiver'), c_source
+	assert !c_source.contains('__v_fastc_slice_receiver->len'), c_source
 	assert c_source.contains('write_bytes(({ __typeof__(('), c_source
+	assert c_source.contains('builtin__array_clone(&(builtin__array_slice(*(values), 0, 1)))'), c_source
 }
 
 fn test_range_bound_types_are_not_validated() {
@@ -5079,8 +5875,7 @@ fn test_range_bound_integer_types_are_not_validated() {
 		assert message == '', message
 	}
 
-	generate('module main\nfn main() { for i in u64(0) .. 3 { println(i) } }\n',
-		'compatible_range_bound_literal.v', prefs) or { panic(err) }
+	generate('module main\nfn main() { for i in u64(0) .. 3 { println(i) } }\n', 'compatible_range_bound_literal.v', prefs) or { panic(err) }
 }
 
 fn test_literal_range_must_not_be_empty() {
@@ -5099,8 +5894,7 @@ fn test_literal_range_must_not_be_empty() {
 		assert message.contains('will never execute'), message
 	}
 
-	c_source := generate('module main\nfn main() { for i in 2 .. 4 { println(i) } }\n',
-		'valid_literal_range.v', prefs) or { panic(err) }
+	c_source := generate('module main\nfn main() { for i in 2 .. 4 { println(i) } }\n', 'valid_literal_range.v', prefs) or { panic(err) }
 	assert c_source.contains('for (__typeof__((__v_fastc_range_start_0)) i = (__v_fastc_range_start_0); i < (__v_fastc_range_end_1); i++) {'), c_source
 }
 
@@ -5132,8 +5926,7 @@ fn main() {
 		pointer--
 	}
 }
-',
-		'numeric_and_pointer_mutations.v', prefs) or { panic(err) }
+', 'numeric_and_pointer_mutations.v', prefs) or { panic(err) }
 	assert c_source.contains('value++;'), c_source
 	assert c_source.contains('pointer--;'), c_source
 }
@@ -5141,22 +5934,19 @@ fn main() {
 fn test_nil_requires_an_unsafe_block() {
 	prefs := pref.new_preferences()
 	mut message := ''
-	_ := generate('module main\nfn show(p &int) { println(*p) }\nfn main() { show(nil) }\n',
-		'nil_outside_unsafe.v', prefs) or {
+	_ := generate('module main\nfn show(p &int) { println(*p) }\nfn main() { show(nil) }\n', 'nil_outside_unsafe.v', prefs) or {
 		message = err.msg()
 		''
 	}
 	assert message.contains('`nil` outside an `unsafe` block'), message
 
-	c_source := generate('module main\nfn accept(p &int) {}\nfn main() { unsafe { accept(nil) } }\n',
-		'nil_inside_unsafe.v', prefs) or { panic(err) }
+	c_source := generate('module main\nfn accept(p &int) {}\nfn main() { unsafe { accept(nil) } }\n', 'nil_inside_unsafe.v', prefs) or { panic(err) }
 	assert c_source.contains('accept(NULL);')
 }
 
 fn test_bitwise_negation_operand_type_is_not_validated() {
 	prefs := pref.new_preferences()
-	bool_c_source := generate('module main\nfn main() { println(~true) }\n', 'bool_bit_not.v',
-		prefs) or { panic(err) }
+	bool_c_source := generate('module main\nfn main() { println(~true) }\n', 'bool_bit_not.v', prefs) or { panic(err) }
 	assert bool_c_source.contains('println(~((bool)true));'), bool_c_source
 
 	c_source := generate('module main\nfn main() { println(~1) }\n', 'integer_bit_not.v', prefs) or {
@@ -5181,10 +5971,252 @@ fn test_value_only_expression_statements_are_rejected() {
 		assert message.contains('value-only expression statement'), message
 	}
 
-	c_source := generate('module main\nfn touch() {}\nfn main() { mut count := 0; touch(); count++ }\n',
-		'valid_expression_statements.v', prefs) or { panic(err) }
+	c_source := generate('module main\nfn touch() {}\nfn main() { mut count := 0; touch(); count++ }\n', 'valid_expression_statements.v', prefs) or { panic(err) }
 	assert c_source.contains('touch();')
 	assert c_source.contains('count++;')
+}
+
+fn test_selfhost_function_pointer_call_is_a_statement() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+fn invoke(f fn ()) {
+	f()
+}
+
+fn callback() {}
+
+fn main() {
+	invoke(callback)
+}
+', 'selfhost_function_pointer_statement.v', prefs) or { panic(err) }
+	assert c_source.contains('f();'), c_source
+}
+
+fn test_selfhost_function_alias_local_call_is_a_statement() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+type Create = fn () voidptr
+type Destroy = fn (voidptr)
+
+fn symbol() voidptr {
+	return unsafe { nil }
+}
+
+fn use() {
+	create := Create(symbol())
+	state := create()
+	destroy := Destroy(symbol())
+	destroy(state)
+}
+
+fn main() {
+	use()
+}
+', 'selfhost_function_alias_local_call.v', prefs) or { panic(err) }
+	assert c_source.contains('destroy(state);'), c_source
+}
+
+fn test_selfhost_static_option_constructor_propagates_payload_type() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Key {}
+
+fn Key.new() !Key {
+	return Key{}
+}
+
+fn (key Key) use() {}
+
+fn make() ! {
+	key := Key.new()!
+	key.use()
+}
+
+fn main() {
+	make() or { return }
+}
+', 'selfhost_static_option_constructor.v', prefs) or { panic(err) }
+	assert c_source.contains('*((Key *)__v_fastc_option_propagate.data)'), c_source
+	assert c_source.contains('Key_use(key);'), c_source
+}
+
+fn test_selfhost_static_option_call_with_or_block() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Reader {}
+
+fn Reader.read(path string) !string {
+	return path
+}
+
+fn load(path string) string {
+	return Reader.read(path) or { "" }
+}
+
+fn main() {
+	_ := load("file")
+}
+', 'selfhost_static_option_or.v', prefs) or { panic(err) }
+	assert c_source.contains('Reader_read(path)'), c_source
+	assert !c_source.contains('string_read(Reader'), c_source
+}
+
+fn test_selfhost_static_option_call_with_argument_and_propagation() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Key {
+	value int
+}
+
+fn Key.new(value int) !Key {
+	return Key{ value: value }
+}
+
+fn make() ! {
+	key := Key.new(3)!
+	_ = key
+}
+
+fn main() {}
+', 'selfhost_static_option_argument_propagation.v', prefs) or { panic(err) }
+	assert c_source.contains('Key_new(3)'), c_source
+	assert !c_source.contains('Key.new(3)'), c_source
+}
+
+fn test_selfhost_option_call_contextualizes_array_arguments() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+fn insert(columns []string, values []string) !int {
+	return columns.len + values.len
+}
+
+fn use(mut id int, value int) ! {
+	id = insert(["id"], [value.str()]) or {
+		return err
+	}
+}
+
+fn main() {
+	mut id := 0
+	use(mut id, 2) or { return }
+}
+', 'selfhost_option_array_arguments.v', prefs) or { panic(err) }
+	assert c_source.contains('insert(((Array_string)builtin__new_array_from_c_array'), c_source
+	assert !c_source.contains('insert([_S('), c_source
+}
+
+fn test_selfhost_nested_option_propagation_inside_cast() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+fn maybe() !u64 {
+	return u64(2)
+}
+
+fn use() !int {
+	value := -int(maybe()!) - 1
+	return value
+}
+
+fn main() {
+	use() or { return }
+}
+', 'selfhost_nested_propagation_cast.v', prefs) or { panic(err) }
+	assert c_source.contains('Option __v_fastc_option_propagate = (maybe())'), c_source
+	assert !c_source.contains('maybe()!'), c_source
+}
+
+fn test_selfhost_nested_option_propagation_keeps_method_lowering() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Clock {}
+
+struct App {
+	db      int
+	started i64
+}
+
+fn maybe() !int {
+	return 1
+}
+
+fn now() Clock {
+	return Clock{}
+}
+
+fn (clock Clock) unix() i64 {
+	return 2
+}
+
+fn make() !App {
+	return App{
+		db: maybe()!
+		started: now().unix()
+	}
+}
+
+fn main() {
+	make() or { return }
+}
+', 'selfhost_nested_propagation_method.v', prefs) or { panic(err) }
+	assert c_source.contains('Clock_unix(now())'), c_source
+	assert !c_source.contains('now().unix()'), c_source
+}
+
+fn test_selfhost_outer_propagation_with_propagated_call_argument() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+fn inner() ![]u8 {
+	return [u8(1)]
+}
+
+fn outer(_ []u8) ! {}
+
+fn run() ! {
+	outer(inner()!)!
+}
+
+fn main() {
+	run() or { return }
+}
+', 'selfhost_nested_argument_and_outer_propagation.v', prefs) or { panic(err) }
+	assert c_source.contains('Option __v_fastc_option_propagate = (outer('), c_source
+	assert !c_source.contains('outer(inner()!)!'), c_source
+}
+
+fn test_selfhost_assert_statement_is_lowered() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+fn check(value int) {
+	assert value == 1
+	assert value > 0, "positive"
+}
+
+fn main() {
+	check(1)
+}
+', 'selfhost_assert_statement.v', prefs) or { panic(err) }
+	assert c_source.contains('builtin__panic(_S("assertion failed"))'), c_source
+	assert c_source.contains('builtin__panic(_S("positive"))'), c_source
 }
 
 fn test_nested_mutations_are_rejected() {
@@ -5203,8 +6235,7 @@ fn test_nested_mutations_are_rejected() {
 		assert message.contains('inside an expression'), message
 	}
 
-	c_source := generate('module main\nfn main() { mut x := 1; x++; x += 2; println(x) }\n',
-		'mutation_statements.v', prefs) or { panic(err) }
+	c_source := generate('module main\nfn main() { mut x := 1; x++; x += 2; println(x) }\n', 'mutation_statements.v', prefs) or { panic(err) }
 	assert c_source.contains('x++;')
 	assert c_source.contains('x+=2;')
 }
@@ -5222,8 +6253,7 @@ fn main() {
 		return
 	}
 }
-',
-		'bare_return.v', prefs) or { panic(err) }
+', 'bare_return.v', prefs) or { panic(err) }
 	assert c_source.contains('void stop(void) {\n\treturn;\n}')
 	assert c_source.contains('if (((bool)true)) {\n\t\treturn 0;\n\t}')
 }
@@ -5261,8 +6291,7 @@ fn value(flag bool) int {
 fn main() {
 	println(value(true))
 }
-',
-		'non_void_returns.v', prefs) or { panic(err) }
+', 'non_void_returns.v', prefs) or { panic(err) }
 	assert c_source.contains('return 1;')
 	assert c_source.contains('return 2;')
 	infinite_source := generate('module main
@@ -5279,8 +6308,7 @@ fn nested_wait() int {
 }
 
 fn main() {}
-',
-		'infinite_loop_returns.v', prefs) or { panic(err) }
+', 'infinite_loop_returns.v', prefs) or { panic(err) }
 	assert infinite_source.count('for (;;) {') == 3, infinite_source
 }
 
@@ -5301,8 +6329,7 @@ fn main() {
 		println(i)
 	}
 }
-',
-		'range_bounds.v', prefs) or { panic(err) }
+', 'range_bounds.v', prefs) or { panic(err) }
 	assert c_source.contains('__v_fastc_range_start_0 = (start());')
 	assert c_source.contains('__v_fastc_range_end_1 = (limit());')
 	assert c_source.contains('i < (__v_fastc_range_end_1)')
@@ -5345,8 +6372,7 @@ fn main() {
 
 fn test_hex_string_escape_has_fixed_width_in_c() {
 	prefs := pref.new_preferences()
-	c_source := generate("module main\nfn main() { println('\\x61ardvark') }\n", 'hex_escape.v',
-		prefs) or { panic(err) }
+	c_source := generate("module main\nfn main() { println('\\x61ardvark') }\n", 'hex_escape.v', prefs) or { panic(err) }
 	assert c_source.contains(r'println("\141ardvark");')
 }
 
@@ -5379,8 +6405,7 @@ fn test_runtime_sensitive_constructs_are_rejected() {
 fn main() {
 	println("a\\0b")
 }
-',
-		"module main\nfn main() { println('\\400tail') }\n"] {
+', "module main\nfn main() { println('\\400tail') }\n"] {
 		mut nul_failed := false
 		_ := generate(source, 'nul_string.v', prefs) or {
 			nul_failed = true
@@ -5390,8 +6415,7 @@ fn main() {
 	}
 	assert fastc_string_contains_nul(r'\400tail', false)
 	assert !fastc_string_contains_nul(r'\401tail', false)
-	non_nul_octal_c := generate("module main\nfn main() { println('\\401tail') }\n",
-		'non_nul_octal_string.v', prefs) or { panic(err) }
+	non_nul_octal_c := generate("module main\nfn main() { println('\\401tail') }\n", 'non_nul_octal_string.v', prefs) or { panic(err) }
 	assert non_nul_octal_c.contains(r'println("\401tail");')
 
 	mut assert_failed := false
@@ -5450,17 +6474,13 @@ fn test_expressions_without_safe_lowering_are_rejected() {
 		panic(err)
 	}
 	assert bool_c.contains('println(((bool)true));')
-	low_hex_c := generate('module main\nfn main() { x := 0x7fff_ffff | 0; println(x) }\n',
-		'low_hex_literal.v', prefs) or { panic(err) }
+	low_hex_c := generate('module main\nfn main() { x := 0x7fff_ffff | 0; println(x) }\n', 'low_hex_literal.v', prefs) or { panic(err) }
 	assert low_hex_c.contains('__typeof__((0x7fffffff|0)) x = (0x7fffffff|0);')
-	low_binary_c := generate('module main\nfn main() { x := 0b01111111111111111111111111111111 | 0; println(x) }\n',
-		'low_binary_literal.v', prefs) or { panic(err) }
+	low_binary_c := generate('module main\nfn main() { x := 0b01111111111111111111111111111111 | 0; println(x) }\n', 'low_binary_literal.v', prefs) or { panic(err) }
 	assert low_binary_c.contains('__typeof__((0b01111111111111111111111111111111|0))')
-	max_int_c := generate('module main\nfn main() { x := 2_147_483_647 - 1; println(x) }\n',
-		'max_int_expression.v', prefs) or { panic(err) }
+	max_int_c := generate('module main\nfn main() { x := 2_147_483_647 - 1; println(x) }\n', 'max_int_expression.v', prefs) or { panic(err) }
 	assert max_int_c.contains('__typeof__((2147483647-1)) x = (2147483647-1);')
-	call_c := generate('module main\nfn sum(a int, b int) int { return a + b }\nfn main() { println(sum(1, 2)) }\n',
-		'call_comma.v', prefs) or { panic(err) }
+	call_c := generate('module main\nfn sum(a int, b int) int { return a + b }\nfn main() { println(sum(1, 2)) }\n', 'call_comma.v', prefs) or { panic(err) }
 	assert call_c.contains('println(sum(1,2));')
 }
 
@@ -5485,8 +6505,7 @@ fn main() {
 	println(holder.value)
 	println(values[0])
 }
-',
-		'unsigned_right_shift_assignment.v', prefs) or { panic(err) }
+', 'unsigned_right_shift_assignment.v', prefs) or { panic(err) }
 	assert !c_source.contains('>>>='), c_source
 	assert c_source.count('u64 __v_fastc_unsigned_shift_count =') == 3, c_source
 	assert c_source.count('u64 __v_fastc_unsigned_shift_value =') == 3, c_source
@@ -5507,8 +6526,7 @@ fn main() {
 	}
 	fail()!
 }
-",
-		'main_result_propagation.v', prefs) or { panic(err) }
+", 'main_result_propagation.v', prefs) or { panic(err) }
 	panic_call := 'builtin__panic_result_not_set(builtin__IError_msg(__v_fastc_option_propagate.err));'
 	assert c_source.contains(panic_call), c_source
 	assert c_source.contains('if (__v_fastc_option_propagate.state) {'), c_source
@@ -5562,4 +6580,3801 @@ fn main() {
 	assert selfhost_c.contains('__typeof__((value)) __v_fastc_collection_'), selfhost_c
 	assert selfhost_c.contains('__v_fastc_collection_0.len'), selfhost_c
 	assert selfhost_c.contains('__v_fastc_collection_0.str'), selfhost_c
+}
+
+fn test_interface_argument_boxing_at_call_site() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+interface Animal {
+	speak() int
+}
+
+struct Dog {}
+
+fn (d Dog) speak() int {
+	return 7
+}
+
+fn make_speak(a Animal) int {
+	return a.speak()
+}
+
+struct Holder {
+	a Animal
+}
+
+fn main() {
+	d := Dog{}
+	r := make_speak(d)
+	literal := make_speak(Dog{})
+	h := Holder{
+		a: Dog{}
+	}
+	mut cur := Animal(Dog{})
+	cur = Dog{}
+	println(r + literal + h.a.speak() + cur.speak())
+}
+', 'interface_argument_boxing.v', prefs) or { panic(err) }
+	// A concrete struct used where an interface is expected is boxed with its type
+	// id so the generated dispatch can recover the receiver. This is exercised for
+	// a call argument (local var and inline literal), a struct-literal field, and
+	// assignment to an interface variable.
+	assert c_source.contains('._object='), c_source
+	assert c_source.contains('._typ=__v_typeid_Dog'), c_source
+	assert c_source.contains('case __v_typeid_Dog:'), c_source
+	assert c_source.contains('__v_fastc_box_value = (d)'), c_source
+	assert c_source.contains('__v_fastc_box_value = ((Dog){})'), c_source
+	// Assignment to an interface variable boxes rather than emitting `cur=(Dog){}`.
+	assert c_source.contains('cur=(Animal){._object='), c_source
+}
+
+fn test_sum_type_construction_match_and_smartcast() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Dog {
+	sound int
+}
+
+struct Cat {
+	sound int
+}
+
+type Animal = Cat | Dog
+
+fn describe(a Animal) int {
+	match a {
+		Dog { return a.sound + 1 }
+		Cat { return a.sound + 2 }
+	}
+	return 0
+}
+
+fn main() {
+	a := Animal(Dog{ sound: 10 })
+	_ := describe(a)
+}
+', 'sum_type_dispatch.v', prefs) or { panic(err) }
+	// A sum type shares the boxed layout with interfaces so construction, match
+	// dispatch and smart-casting reuse the interface machinery.
+	assert c_source.contains('typedef struct { void *_object; u32 _typ; void *_methods; } Animal;'), c_source
+	// Construction boxes the concrete variant with its type id.
+	assert c_source.contains('._typ=__v_typeid_Dog'), c_source
+	assert c_source.contains('__v_fastc_box_value = ((Dog){'), c_source
+	assert !c_source.contains('Dog{sound:'), c_source
+	// `match` dispatches on the boxed `_typ` tag rather than comparing structs.
+	assert c_source.contains('_typ == __v_typeid_Dog'), c_source
+	assert c_source.contains('_typ == __v_typeid_Cat'), c_source
+	// The matched branch smart-casts the subject to the concrete variant so field
+	// access (`a.sound`) resolves.
+	assert c_source.contains('Dog a = *(Dog *)'), c_source
+	assert c_source.contains('Cat a = *(Cat *)'), c_source
+}
+
+fn test_sum_type_primitive_variants() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+type Value = bool | int
+
+fn kind(v Value) int {
+	match v {
+		int { return v + 100 }
+		bool { return if v { 1 } else { 0 } }
+	}
+	return -1
+}
+
+fn main() {
+	a := Value(42)
+	b := Value(true)
+	_ := kind(a)
+	_ := kind(b)
+}
+', 'sum_type_primitive.v', prefs) or { panic(err) }
+	// Primitive scalars get stable type ids in a high range that cannot collide
+	// with the sequential declared-type ids.
+	assert c_source.contains('#define __v_typeid_int 1073741824'), c_source
+	assert c_source.contains('#define __v_typeid_bool '), c_source
+	// A primitive is boxed into the sum type with its type id on construction.
+	assert c_source.contains('int __v_fastc_box_value = (42)'), c_source
+	assert c_source.contains('._typ=__v_typeid_int'), c_source
+	// `match` dispatches on the tag and smart-casts to the primitive C type.
+	assert c_source.contains('_typ == __v_typeid_int'), c_source
+	assert c_source.contains('int v = *(int *)'), c_source
+	assert c_source.contains('bool v = *(bool *)'), c_source
+}
+
+fn test_sum_type_array_variants() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+type Value = int | []int
+
+fn kind(v Value) int {
+	match v {
+		int { return v }
+		[]int { return v.len }
+	}
+	return -1
+}
+
+fn main() {
+	a := Value(9)
+	b := Value([1, 2, 3])
+	_ := kind(a)
+	_ := kind(b)
+}
+', 'sum_type_array.v', prefs) or { panic(err) }
+	// A composite (`[]int` -> `Array_int`) variant gets a stable type id in the
+	// composite range and is registered so it also gets a typedef.
+	assert c_source.contains('#define __v_typeid_Array_int '), c_source
+	// The array literal is boxed as a real construction, not raw `[1,2,3]`.
+	assert c_source.contains('Array_int __v_fastc_box_value = (((Array_int)builtin__new_array_from_c_array'), c_source
+	assert c_source.contains('._typ=__v_typeid_Array_int'), c_source
+	// `match []int` dispatches on the composite tag and smart-casts to the array.
+	assert c_source.contains('_typ == __v_typeid_Array_int'), c_source
+	assert c_source.contains('Array_int v = *(Array_int *)'), c_source
+}
+
+fn test_sum_type_match_as_expression() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+type Value = bool | int
+
+fn score(v Value) int {
+	return match v {
+		int { v + 100 }
+		bool { if v { 1 } else { 0 } }
+	}
+}
+
+fn main() {
+	a := Value(5)
+	_ := score(a)
+}
+', 'sum_type_match_expr.v', prefs) or { panic(err) }
+	// A `match` used as an expression over a sum type dispatches on the boxed tag
+	// (not a struct-vs-type comparison) and smart-casts inside each branch value.
+	assert c_source.contains('__v_fastc_match_0._typ == __v_typeid_int'), c_source
+	assert c_source.contains('int v = *(int *)__v_fastc_match_0._object'), c_source
+	assert c_source.contains('bool v = *(bool *)__v_fastc_match_0._object'), c_source
+	assert !c_source.contains('(__v_fastc_match_0) == (int)'), c_source
+}
+
+fn test_sum_type_map_and_nested_variants() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Node {}
+
+type Value = int | map[string]int | []Node
+
+fn kind(v Value) int {
+	match v {
+		int { return 1 }
+		map[string]int { return v.len }
+		[]Node { return v.len }
+	}
+	return -1
+}
+
+fn main() {
+	m := map[string]int{}
+	a := Value(m)
+	_ := kind(a)
+}
+', 'sum_type_map.v', prefs) or { panic(err) }
+	// A `map[K]V` variant becomes the composite `Map_<k>_<v>` and a `[]Struct`
+	// variant `Array_<Struct>`; both dispatch on their composite type id and
+	// smart-cast to the composite C type.
+	assert c_source.contains('_typ == __v_typeid_Map_string_int'), c_source
+	assert c_source.contains('Map_string_int v = *(Map_string_int *)'), c_source
+	assert c_source.contains('_typ == __v_typeid_Array_Node'), c_source
+	assert c_source.contains('Array_Node v = *(Array_Node *)'), c_source
+}
+
+fn test_generic_monomorphization() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+fn box[T](x T) T {
+	return x
+}
+
+fn main() {
+	a := box(5)
+	b := box("hi")
+	c := box[int](9)
+	_ := a
+	_ := b
+	_ := c
+}
+', 'generic_mono.v', prefs) or { panic(err) }
+	// A single-type-parameter generic is monomorphized into one concrete copy per
+	// instantiation (int inferred from a literal, string from a literal, int from
+	// an explicit type argument), and every call is rewritten to the mangled name.
+	assert c_source.contains('int box_mono_int(int x)'), c_source
+	assert c_source.contains('string box_mono_string(string x)'), c_source
+	assert c_source.contains('box_mono_int(5)'), c_source
+	assert c_source.contains('box_mono_string(_S("hi"))'), c_source
+	assert c_source.contains('box_mono_int(9)'), c_source
+	// The generic template itself leaves no `box(` definition behind.
+	assert !c_source.contains(' box(voidptr'), c_source
+}
+
+fn test_selfhost_imported_explicit_generic_call_uses_erased_signature() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	main_source := 'module main
+import library
+
+struct App {}
+struct Context {}
+
+fn main() {
+	mut app := App{}
+	library.run[App, Context](mut app, value: 3)!
+}
+'
+	library_source := 'module library
+
+@[params]
+pub struct Config {
+	value int
+}
+
+pub fn run[A, B](mut app A, config Config) ! {
+}
+'
+	c_source, _ := generate_source_files([
+		FastcSourceFile{
+			path: 'main.v'
+			source: main_source
+			header: fastc_scan_source_header(main_source, 'main.v', prefs) or { panic(err) }
+		},
+		FastcSourceFile{
+			path: 'library.v'
+			source: library_source
+			header: fastc_scan_source_header(library_source, 'library.v', prefs) or { panic(err) }
+		},
+	], map[string]string{}, prefs) or { panic(err) }
+	assert c_source.contains('library__run('), c_source
+	assert c_source.contains('.value='), c_source
+	assert !c_source.contains('run[App'), c_source
+}
+
+fn test_generic_monomorphization_variable_args() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+fn identity[T](x T) T {
+	return x
+}
+
+fn use_param(n int) int {
+	return identity(n)
+}
+
+fn main() {
+	m := 7
+	r := identity(m)
+	s := identity("hi")
+	_ := use_param(3)
+	_ := r
+	_ := s
+}
+', 'generic_var_args.v', prefs) or { panic(err) }
+	// Concrete type inferred from a function parameter (`n int`), a local declared
+	// from a literal (`m := 7`), and a literal argument.
+	assert c_source.contains('int identity_mono_int(int x)'), c_source
+	assert c_source.contains('string identity_mono_string(string x)'), c_source
+	assert c_source.contains('identity_mono_int(n)'), c_source
+	assert c_source.contains('identity_mono_int(m)'), c_source
+	assert c_source.contains('identity_mono_string(_S("hi"))'), c_source
+}
+
+fn test_generic_struct_monomorphization() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Box[T] {
+	value T
+	tag   string
+}
+
+fn main() {
+	a := Box[int]{ value: 5, tag: "n" }
+	b := Box[string]{ value: "hi", tag: "s" }
+	_ := a
+	_ := b
+}
+', 'generic_struct.v', prefs) or { panic(err) }
+	// A generic struct is monomorphized into one concrete struct per instantiation
+	// with the type parameter substituted in its fields, and each `S[T]` reference
+	// is rewritten to the mangled name.
+	assert c_source.contains('struct Box_mono_int {'), c_source
+	assert c_source.contains('struct Box_mono_string {'), c_source
+	assert c_source.contains('int value;'), c_source
+	assert c_source.contains('string value;'), c_source
+	assert c_source.contains('(Box_mono_int){'), c_source
+	assert c_source.contains('(Box_mono_string){'), c_source
+}
+
+fn test_generic_struct_method_monomorphization() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Wrapper[T] {
+	val T
+}
+
+fn (w Wrapper[T]) get() T {
+	return w.val
+}
+
+fn main() {
+	wi := Wrapper[int]{ val: 21 }
+	ws := Wrapper[string]{ val: "hi" }
+	_ := wi.get()
+	_ := ws.get()
+}
+', 'generic_method.v', prefs) or { panic(err) }
+	// A method on a generic struct is monomorphized per instantiation: the receiver
+	// type becomes the mangled struct name (with a single underscore, since `__` is
+	// FastC's module separator) so its C method name resolves correctly.
+	assert c_source.contains('int Wrapper_mono_int_get(Wrapper_mono_int w)'), c_source
+	assert c_source.contains('string Wrapper_mono_string_get(Wrapper_mono_string w)'), c_source
+	assert c_source.contains('Wrapper_mono_int_get(wi)'), c_source
+	assert c_source.contains('Wrapper_mono_string_get(ws)'), c_source
+}
+
+fn test_struct_array_field_default_initializes_element_size() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct IntStack {
+mut:
+	items []int
+}
+
+fn (mut s IntStack) push(x int) {
+	s.items << x
+}
+
+fn main() {
+	mut st := IntStack{}
+	st.push(3)
+	_ := st
+}
+', 'struct_array_default.v', prefs) or { panic(err) }
+	// A `[]int` field with no explicit default must construct as a properly sized
+	// empty array (element_size set), not a zeroed one, so `s.items << x` copies the
+	// element. `X{}` gets the field default applied.
+	assert c_source.contains('.items=(((Array_int)builtin____new_array(0, 0, sizeof(int))))'), c_source
+}
+
+fn test_struct_map_field_default_initializes_runtime() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Registry {
+mut:
+	data map[string]int
+}
+
+fn (mut r Registry) set(k string, v int) {
+	r.data[k] = v
+}
+
+fn main() {
+	mut reg := Registry{}
+	reg.set("a", 5)
+	_ := reg
+}
+', 'struct_map_default.v', prefs) or { panic(err) }
+	// A `map[string]int` field with no explicit default must construct as a real
+	// `new_map` (key/value sizes + hash/eq/clone/free), not a zeroed map, so a
+	// later `m.data[k] = v` works. `X{}` gets the field default applied.
+	assert c_source.contains('.data=((builtin__new_map(sizeof(string), sizeof(int), &builtin__map_hash_string, &builtin__map_eq_string, &builtin__map_clone_string, &builtin__map_free_string)))'), c_source
+}
+
+fn test_generic_multiple_type_parameters() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Pair[K, V] {
+	key   K
+	value V
+}
+
+fn (p Pair[K, V]) same(v V) bool {
+	return p.value == v
+}
+
+fn firstof[T, U](a T, b U) T {
+	return a
+}
+
+fn main() {
+	p := Pair[string, int]{ key: "age", value: 30 }
+	_ := p.same(30)
+	_ := firstof[int, string](5, "x")
+}
+', 'generic_multi_param.v', prefs) or { panic(err) }
+	// Multiple type parameters are substituted independently; the mangled name
+	// joins the concrete args with `_` (a struct, its method, and a function).
+	assert c_source.contains('struct Pair_mono_string_int {'), c_source
+	assert c_source.contains('string key;'), c_source
+	assert c_source.contains('int value;'), c_source
+	assert c_source.contains('Pair_mono_string_int_same(Pair_mono_string_int p, int v)'), c_source
+	assert c_source.contains('int firstof_mono_int_string(int a, string b)'), c_source
+}
+
+fn test_comptime_for_fields_unrolling() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Point {
+	x int
+	y int
+}
+
+fn describe(p Point) string {
+	mut r := ""
+	\$for field in Point.fields {
+		r += field.name
+		r += "="
+	}
+	return r
+}
+
+fn total(p Point) int {
+	mut t := 0
+	\$for field in Point.fields {
+		t += p.\$(field.name)
+	}
+	return t
+}
+
+fn main() {
+	p := Point{ x: 1, y: 2 }
+	_ := describe(p)
+	_ := total(p)
+}
+', 'comptime_for.v', prefs) or { panic(err) }
+	// `$for field in Point.fields` unrolls once per field: `field.name` becomes the
+	// field-name string, and `p.$(field.name)` becomes a static field access.
+	assert c_source.contains('r=builtin__string_plus(r,_S("x"))'), c_source
+	assert c_source.contains('r=builtin__string_plus(r,_S("y"))'), c_source
+	assert c_source.contains('t+=p.x'), c_source
+	assert c_source.contains('t+=p.y'), c_source
+}
+
+fn test_comptime_for_field_typ_is_dispatch() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Row {
+	id   int
+	name string
+	ok   bool
+	note ?string
+}
+
+fn kinds(r Row) string {
+	mut out := ""
+	\$for field in Row.fields {
+		\$if field.typ is int {
+			out += "i"
+		} \$else \$if field.typ is string {
+			out += "s"
+		} \$else \$if field.typ is ?string {
+			out += "o"
+		} \$else {
+			out += "?"
+		}
+	}
+	return out
+}
+
+fn main() { _ := kinds(Row{ id: 1, name: "a", ok: true }) }
+', 'comptime_typ_is.v', prefs) or { panic(err) }
+	// Per-field `$if field.typ is X` takes the matching branch: int, string, else.
+	assert c_source.contains('out=builtin__string_plus(out,_S("i"))'), c_source
+	assert c_source.contains('out=builtin__string_plus(out,_S("s"))'), c_source
+	assert c_source.contains('out=builtin__string_plus(out,_S("o"))'), c_source
+	assert c_source.contains('out=builtin__string_plus(out,_S("?"))'), c_source
+}
+
+fn test_selfhost_sum_type_field_default_is_boxed() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Null {}
+
+type Value = Null | int
+
+struct Box {
+	value Value = Null{}
+}
+
+fn main() {
+	b := Box{}
+	_ := b
+}
+', 'selfhost_sum_field_default.v', prefs) or { panic(err) }
+	// A variant literal defaulting a sum-type field is boxed, not left as the bare
+	// variant struct which is not assignable to the boxed `{_object,_typ,_methods}`.
+	assert c_source.contains('.value=('), c_source
+	assert c_source.contains('._typ=__v_typeid_Null'), c_source
+}
+
+fn test_selfhost_interface_method_named_like_keyword() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+interface Conn {
+	select(id int) int
+}
+
+struct Db {}
+
+fn (d Db) select(id int) int {
+	return id
+}
+
+fn run(c Conn) int {
+	return c.select(5)
+}
+
+fn main() {
+	db := Db{}
+	_ := run(db)
+}
+', 'selfhost_keyword_interface_method.v', prefs) or { panic(err) }
+	// `select` is also a keyword; it must still be collected as an interface method
+	// (so its dispatch function exists) and the call routed to that dispatch.
+	assert c_source.contains('Conn_select('), c_source
+	assert c_source.contains('Conn_select(c,5)'), c_source
+}
+
+fn test_selfhost_match_multi_array_branch_smartcasts_to_array() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+type Value = []int | []string | int
+
+fn value_len(v Value) int {
+	return match v {
+		[]int, []string {
+			v.len
+		}
+		else {
+			-1
+		}
+	}
+}
+
+fn main() {
+	_ := value_len(Value(5))
+}
+', 'selfhost_match_multi_array.v', prefs) or { panic(err) }
+	// A branch listing several array variants cannot pick one element type, so `v` is
+	// smart-cast to the shared `array` layout to expose common fields like `len`.
+	assert c_source.contains('array v = *(array *)'), c_source
+}
+
+fn test_selfhost_append_of_method_call_result() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Counter {
+	n int
+}
+
+fn (c Counter) value() int {
+	return c.n
+}
+
+fn build(c Counter, xs []int) []int {
+	mut result := xs
+	result << c.value()
+	return result
+}
+
+fn main() {
+	_ := build(Counter{ n: 2 }, [1])
+}
+', 'selfhost_append_method_call.v', prefs) or { panic(err) }
+	// The appended value is a method call and must be routed through the argument
+	// renderer, not streamed raw as `c.value()` (an unresolved struct field call).
+	assert c_source.contains('Counter_value(c)'), c_source
+}
+
+fn test_orm_where_operator_mapping() {
+	// The `update ... where` lowering maps V comparison tokens to `orm.OperationKind`
+	// variant names; `!=` becomes `neq`, and unsupported operators return ''.
+	assert fastc_orm_where_op(token.Token.eq) == 'eq'
+	assert fastc_orm_where_op(token.Token.ne) == 'neq'
+	assert fastc_orm_where_op(token.Token.gt) == 'gt'
+	assert fastc_orm_where_op(token.Token.lt) == 'lt'
+	assert fastc_orm_where_op(token.Token.ge) == 'ge'
+	assert fastc_orm_where_op(token.Token.le) == 'le'
+	assert fastc_orm_where_op(token.Token.plus) == ''
+}
+
+fn test_orm_field_zero_mapping() {
+	// The `select` row-parser uses these zero literals for the `match` else-branch when
+	// unboxing a column Primitive to its field type; unsupported types return none.
+	assert fastc_orm_field_zero('int')? == '0'
+	assert fastc_orm_field_zero('i64')? == '0'
+	assert fastc_orm_field_zero('u32')? == '0'
+	assert fastc_orm_field_zero('f64')? == '0.0'
+	assert fastc_orm_field_zero('f32')? == '0.0'
+	assert fastc_orm_field_zero('bool')? == 'false'
+	assert fastc_orm_field_zero('string')? == "''"
+	assert fastc_orm_field_zero('time__Time')? == 'time.Time{}'
+	assert fastc_orm_field_zero('Array_int') == none
+	assert fastc_orm_field_match_type('time__Time') == 'time.Time'
+	assert fastc_orm_field_match_type('int') == 'int'
+}
+
+fn test_orm_select_or_exit_detection() {
+	prefs := pref.new_preferences()
+	assert fastc_orm_or_source_starts_with_exit('return []Item{}', prefs)
+	assert fastc_orm_or_source_starts_with_exit('continue', prefs)
+	assert !fastc_orm_or_source_starts_with_exit('[]Item{}', prefs)
+}
+
+fn test_source_uses_sql_detection() {
+	prefs := pref.new_preferences()
+	// A `sql <conn> { ... }` block (statement or expression form) is detected; `sql`
+	// as part of another name, after `.`, or inside a string is not.
+	assert fastc_source_uses_sql('fn f() { sql db { insert x into Y }! }', prefs)
+	assert fastc_source_uses_sql('fn f() { x := sql app.db { select from Y } }', prefs)
+	assert !fastc_source_uses_sql('fn f() { a := sql_query() }', prefs)
+	assert !fastc_source_uses_sql('fn f() { obj.sql(db) }', prefs)
+	assert !fastc_source_uses_sql('fn f() { println("sql db {") }', prefs)
+	assert !fastc_source_uses_sql('fn f() { return 1 }', prefs)
+}
+
+fn test_flag_is_skippable() {
+	// `#flag` payloads that only affect linking or header lookup are skippable; a `-D`
+	// define or other compile flag is not.
+	assert fastc_flag_is_skippable('-lsqlite3')
+	assert fastc_flag_is_skippable('-I@VEXEROOT/thirdparty/legacy/include/LegacySupport')
+	assert fastc_flag_is_skippable('-L/usr/lib -lpq')
+	assert fastc_flag_is_skippable('-framework Cocoa')
+	assert !fastc_flag_is_skippable('-DSQLITE_ENABLE')
+	assert !fastc_flag_is_skippable('-std=c11')
+}
+
+fn test_hex_nul_string_literal_is_renderable() {
+	// A `\x00`/`\000` NUL escape renders to the stable octal `\000` and the `_S`
+	// sizeof-based length preserves it; other NUL escapes stay unrenderable.
+	assert !fastc_string_has_unrenderable_nul(r'\x00tail', false)
+	assert !fastc_string_has_unrenderable_nul(r'\000tail', false)
+	assert fastc_string_has_unrenderable_nul(r'\0tail', false)
+	assert fastc_string_has_unrenderable_nul(r'\400tail', false)
+}
+
+fn test_selfhost_spawn_method_call_packs_receiver() {
+	$if windows {
+		return
+	}
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	source := 'module main
+
+struct Worker {
+	id int
+}
+
+fn (w Worker) run() int {
+	return w.id
+}
+
+fn main() {
+	w := Worker{ id: 5 }
+	h := spawn w.run()
+	println(h.wait())
+}
+'
+	c_source := generate(source, 'selfhost_spawn_method.v', prefs) or { panic(err) }
+	// A method spawn calls the method C name with the receiver packed as arg0.
+	assert c_source.contains('args->result = Worker_run(args->arg0);'), c_source
+}
+
+fn test_selfhost_or_block_with_trailing_value_fallback() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	source := "module main
+
+fn main() {
+	m := {
+		'a': 1
+		'b': 2
+	}
+	mut flag := 0
+	x := m['zzz'] or {
+		flag = 9
+		42
+	}
+	println(x)
+	println(flag)
+}
+"
+	c_source := generate(source, 'selfhost_or_value.v', prefs) or { panic(err) }
+	// The or-block runs its leading statement (`flag = 9`), then uses the trailing value
+	// (`42`) on failure and the unwrapped option value on success, via an
+	// `__v_fastc_or_result` temp.
+	assert c_source.contains('__v_fastc_or_result'), c_source
+	assert c_source.contains('flag=9'), c_source
+	assert c_source.contains(' = (42)'), c_source
+}
+
+fn test_veb_template_compiles_to_builder() {
+	dir := os.join_path(os.temp_dir(), 'v3_veb_tmpl_${os.getpid()}')
+	os.mkdir_all(dir) or { panic(err) }
+	defer {
+		os.rmdir_all(dir) or {}
+	}
+	tmpl := os.join_path_single(dir, 't.html')
+	os.write_file(tmpl, '<h1>@{name}</h1>\n@if ok {\n<p>%greeting</p>\n@for x in xs {\n<li>@{x}</li>\n}\n}\n') or {
+		panic(err)
+	}
+	src := fastc_veb_compile_template(tmpl, '__b', 'ctx') or { panic(err) }
+	// The compiler accumulates plain text into the builder, HTML-escapes interpolations
+	// via veb.filter_html, lowers @if/@for to control flow, and %key to veb.tr.
+	assert src.contains("mut __b := ''"), src
+	assert src.contains('veb.filter_html(name)'), src
+	assert src.contains('if ok {'), src
+	assert src.contains('for x in xs {'), src
+	assert src.contains('veb.filter_html(x)'), src
+	assert src.contains('veb.tr(ctx.lang.str(), "greeting")'), src
+}
+
+fn test_selfhost_match_branch_with_statement_and_multireturn() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+fn choose(k int) (int, string) {
+	return match k {
+		1 {
+			x := 10
+			x, "ten"
+		}
+		else {
+			0, "zero"
+		}
+	}
+}
+
+fn main() {
+	a, b := choose(1)
+	println(a)
+	println(b)
+}
+', 'selfhost_match_multireturn.v', prefs) or { panic(err) }
+	// A match branch with leading statements and a trailing comma-separated value packs
+	// the values into a MultiReturn, like a single-line multi-return branch: the branch's
+	// leading `x := 10` renders, then its `x, "ten"` value is packed.
+	assert c_source.contains('V_FASTC_MULTI_VALUE'), c_source
+	assert c_source.contains('x = (10)'), c_source
+}
+
+fn test_veb_template_html_shorthands_and_dotted() {
+	dir := os.join_path(os.temp_dir(), 'v3_veb_tmpl_html_${os.getpid()}')
+	os.mkdir_all(dir) or { panic(err) }
+	defer {
+		os.rmdir_all(dir) or {}
+	}
+	tmpl := os.join_path_single(dir, 't.html')
+	lines := [
+		'<a href="/@author.username">@author.username</a>',
+		"@css '/style.css'",
+		"@js '/app.js'",
+		'.card {',
+		'<p>@issue.title</p>',
+		'}',
+		'span.tag {',
+		'x',
+		'}',
+		'#main {',
+		'y',
+		'}',
+	]
+	os.write_file(tmpl, lines.join('\n') + '\n') or { panic(err) }
+	src := fastc_veb_compile_template(tmpl, '__b', 'ctx') or { panic(err) }
+	// A bare `@a.b.c` interpolation covers the whole member chain, `@css`/`@js` expand to
+	// literal <link>/<script> tags, and `.class {` / `span.x {` / `#id {` / `}` lower to
+	// HTML <div>/<span> open/close text (not V braces).
+	assert src.contains('veb.filter_html(author.username)'), src
+	assert src.contains('veb.filter_html(issue.title)'), src
+	assert src.contains('<link href="/style.css"'), src
+	assert src.contains('<script src="/app.js">'), src
+	assert src.contains('<div class="card">'), src
+	assert src.contains('<span class="tag">'), src
+	assert src.contains('</span>'), src
+	assert src.contains('<div id="main">'), src
+	assert src.contains('</div>'), src
+}
+
+fn test_selfhost_method_on_or_unwrap() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Addr {
+	x int
+}
+
+fn (a Addr) label() string {
+	return "a"
+}
+
+fn get(fail bool) !Addr {
+	return Addr{ x: 5 }
+}
+
+fn value_fallback(fail bool) string {
+	return get(fail) or { Addr{ x: 0 } }.label()
+}
+
+fn diverging(fail bool) string {
+	s := get(fail) or { return "early" }.label()
+	return s
+}
+
+fn main() {
+	println(value_fallback(false))
+	println(diverging(false))
+}
+', 'selfhost_or_method.v', prefs) or { panic(err) }
+	// `expr or { ... }.method()` without wrapping parens binds the trailing method to the
+	// rendered or-unwrap `({ Option ...; ... })`, for both a value-fallback block and a
+	// diverging (`return`) block.
+	assert c_source.contains('label'), c_source
+	assert c_source.contains('.state'), c_source
+}
+
+fn test_selfhost_skips_method_with_undefined_receiver() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Real {
+	x int
+}
+
+fn (r Real) handle() int {
+	return r.x
+}
+
+struct Broken {
+	y int
+}
+
+// Dead, broken code: ctx is undefined here. It is kept past name-grouped reachability
+// only because handle is also a genuinely-used method on Real. FastC must skip it
+// (like the mainline compiler -skip-unused) rather than fail on ctx. The undefined ctx is
+// used via an indexed member access (ctx.headers[...]), exercising the R.field[...] form
+// of the detection (as veb no-ctx-param handlers do).
+fn (b Broken) handle() int {
+	marker := ctx.headers["x-marker-key"]
+	return marker.len
+}
+
+fn main() {
+	r := Real{ x: 5 }
+	println(r.handle())
+}
+', 'selfhost_undefined_receiver.v', prefs) or { panic(err) }
+	// `Real.handle` compiles; `Broken.handle` (undefined `ctx` receiver) is skipped, so
+	// generation succeeds and no `x-marker-key` access is emitted.
+	assert c_source.contains('Real_handle'), c_source
+	assert !c_source.contains('x-marker-key'), c_source
+}
+
+fn test_selfhost_or_block_in_struct_literal_field() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Config {
+	x int
+}
+
+struct App {
+mut:
+	a      int
+	b      int
+	config Config
+}
+
+fn connect(c Config) !int {
+	return c.x
+}
+
+fn build(conf Config) int {
+	app := App{
+		a:      connect(conf) or { return -1 }
+		b:      7
+		config: conf
+	}
+	return app.a + app.b
+}
+
+fn main() {
+	println(build(Config{ x: 5 }))
+}
+', 'selfhost_or_struct_field.v', prefs) or { panic(err) }
+	// An `or` inside a struct-literal field value renders as a self-contained `({ Option
+	// ... })` for that field only; the other fields (`b`, `config`) stay separate rather
+	// than being swallowed into the first field`s value.
+	assert c_source.contains('.a='), c_source
+	assert c_source.contains('.b='), c_source
+	assert c_source.contains('.config='), c_source
+	assert c_source.contains('Option'), c_source
+}
+
+fn test_selfhost_array_sort_with_comparison() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct User {
+	name string
+	age  int
+}
+
+fn build() []User {
+	mut xs := []User{}
+	xs << User{ name: "bob", age: 30 }
+	xs << User{ name: "al", age: 25 }
+	xs.sort(a.age < b.age)
+	return xs
+}
+
+fn main() {
+	xs := build()
+	println(xs.len)
+}
+', 'selfhost_sort.v', prefs) or { panic(err) }
+	// `.sort(a.x < b.x)` generates a comparator (a/b bound to the element type in two
+	// blocks with swapped assignments for the -1/+1 ordering) and lowers to a
+	// sort_with_compare call.
+	assert c_source.contains('sort_with_compare'), c_source
+	assert c_source.contains('v_fastc_sort_'), c_source
+	assert c_source.contains('a.age'), c_source
+}
+
+fn test_selfhost_default_struct_interpolation() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate(r'module main
+
+struct Point {
+	x int
+	y int
+}
+
+fn describe(p Point) string {
+	return "point is ${p}"
+}
+
+fn main() {
+	println(describe(Point{ x: 1, y: 2 }))
+}
+', 'selfhost_struct_interp.v', prefs) or { panic(err) }
+	// Interpolating a struct with no user `str()` auto-generates a default `str()` (V-style
+	// `Type{ ... }`) and calls it from the interpolation.
+	assert c_source.contains('v_fastc_default_str_'), c_source
+	assert c_source.contains('Point{'), c_source
+	// The field labels appear in the generated str() body.
+	assert c_source.contains('    x: '), c_source
+	assert c_source.contains('    y: '), c_source
+}
+
+fn test_selfhost_explicit_default_struct_str_method() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate(r'module main
+
+struct Point {
+	x int
+}
+
+fn main() {
+	s := Point{ x: 1 }.str()
+	println(s)
+}
+', 'selfhost_struct_str_method.v', prefs) or { panic(err) }
+	assert c_source.contains('v_fastc_default_str_Point('), c_source
+	assert !c_source.contains('.str()'), c_source
+}
+
+fn test_selfhost_or_in_array_literal_element() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+fn get(fail bool) !string {
+	return "a"
+}
+
+fn pick(fallback string) string {
+	for branch in [get(false) or { "" }, fallback, "main", "master"] {
+		if branch != "" {
+			return branch
+		}
+	}
+	return fallback
+}
+
+fn main() {
+	println(pick("fb"))
+}
+', 'selfhost_or_array.v', prefs) or { panic(err) }
+	// An `or` inside an array-literal element is scoped to that element (not the whole `[..`
+	// prefix), so the string array builds and the for-in gets a concrete element type.
+	assert c_source.contains('new_array_from_c_array'), c_source
+	assert c_source.contains('Option'), c_source
+}
+
+fn test_selfhost_named_args_collapse_into_struct() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Point {
+	x int
+	y int
+}
+
+fn build(p Point) int {
+	return p.x + p.y
+}
+
+fn main() {
+	v := build(x: 3, y: 4)
+	println(v)
+}
+', 'selfhost_named_args.v', prefs) or { panic(err) }
+	// `build(x: 3, y: 4)` collapses the trailing named args into the last struct parameter
+	// (`build(Point{ x: 3, y: 4 })`), for a regular struct (not only `@[params]`).
+	assert c_source.contains('.x='), c_source
+	assert c_source.contains('.y='), c_source
+	assert c_source.contains('build'), c_source
+}
+
+fn test_selfhost_primitive_cast_around_diverging_or() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+fn get(fail bool) !u64 {
+	return 5
+}
+
+fn convert() int {
+	x := int(get(false) or { return -1 })
+	return x
+}
+
+fn main() {
+	println(convert())
+}
+', 'selfhost_cast_or.v', prefs) or { panic(err) }
+	// `int(f() or { return ... })`: the diverging (multi-statement) or-path under a primitive
+	// cast uses the cast type for the unwrapped value and consumes the cast`s `)`.
+	assert c_source.contains('Option'), c_source
+	assert c_source.contains('int *)'), c_source
+}
+
+fn test_selfhost_for_in_inline_map_literal() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+fn main() {
+	mut total := 0
+	for _, v in {
+		"a": 1
+		"b": 2
+	} {
+		total += v
+	}
+	_ := total
+}
+', 'selfhost_for_map_literal.v', prefs) or { panic(err) }
+	// A two-value for-in whose collection is an inline map literal opens with `{`; the
+	// loop must read the map literal instead of stopping at that brace, so it iterates
+	// over the map`s keys/values rather than an empty collection.
+	assert c_source.contains('builtin__map_keys'), c_source
+	assert c_source.contains('builtin__map_values'), c_source
+}
+
+fn test_selfhost_nested_blank_for_loops() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+fn main() {
+	fields := ["a", "b", "c"]
+	mut n := 0
+	for _ in 0 .. 2 {
+		for _ in fields {
+			n += 1
+		}
+	}
+	_ := n
+}
+', 'selfhost_blank_for.v', prefs) or { panic(err) }
+	// `_` is the blank identifier: nested `for _ in ...` loops must not be rejected as
+	// a redeclaration, and the range counter for `_` gets a private name, not `_`.
+	assert c_source.contains('__v_fastc_range_index'), c_source
+}
+
+fn test_selfhost_if_is_smartcast_field_access() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Infix {
+	name string
+}
+
+struct Other {
+	x int
+}
+
+type Prim = Infix | Other
+
+fn label(p Prim) string {
+	if p is Infix {
+		return p.name
+	}
+	return "?"
+}
+
+fn main() {
+	iv := Infix{ name: "hi" }
+	println(label(Prim(iv)))
+}
+', 'selfhost_is_smartcast.v', prefs) or { panic(err) }
+	// Inside `if p is Infix { ... }` the boxed local `p` smart-casts to the concrete
+	// variant: it is copied into a temporary and unboxed so `p.name` resolves.
+	assert c_source.contains('Infix p = *((Infix *)'), c_source
+}
+
+fn test_selfhost_if_is_smartcast_member_field_access() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+interface Writer {
+	write()
+}
+
+struct File {
+	fd int
+}
+
+fn (mut f File) write() {}
+
+struct Holder {
+mut:
+	output Writer
+}
+
+fn flush(mut h Holder) {
+	if mut h.output is File {
+		match h.output.fd {
+			1 {}
+			else {}
+		}
+	}
+}
+
+fn main() {
+	mut h := Holder{
+		output: File{ fd: 1 }
+	}
+	flush(mut h)
+}
+', 'selfhost_member_is_smartcast.v', prefs) or { panic(err) }
+	// A member smart-cast keeps a pointer to the boxed concrete value, and the nested
+	// member chain is rendered through it so both type inference and C access use File.
+	assert c_source.contains('File *__v_fastc_smartcast_member_'), c_source
+	assert c_source.contains('__v_fastc_smartcast_member_'), c_source
+	assert c_source.contains('->fd'), c_source
+}
+
+fn test_selfhost_if_multi_return_option_guard() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+fn split_pair(s string) ?(string, string) {
+	if s == "" {
+		return none
+	}
+	return s, s
+}
+
+fn joined(s string) string {
+	if a, b := split_pair(s) {
+		return a + b
+	}
+	return "none"
+}
+
+fn main() {
+	_ := joined("x")
+}
+', 'selfhost_multi_guard.v', prefs) or { panic(err) }
+	// `if a, b := opt_fn() { ... }` unwraps an option whose value is a multi-return
+	// tuple: on success the boxed MultiReturn is copied out and each component bound.
+	assert c_source.contains('MultiReturn'), c_source
+	assert c_source.contains('.values[0].data'), c_source
+	assert c_source.contains('.values[1].data'), c_source
+}
+
+fn test_selfhost_multi_return_interface_component_is_macro_safe() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+interface Frame {
+	marker()
+}
+
+struct Padding {
+	length int
+}
+
+fn (Padding) marker() {}
+
+fn parse() ?(Frame, int) {
+	return Padding{ length: 1 }, 2
+}
+
+fn main() {
+	_, _ := parse() or { return }
+}
+', 'selfhost_multi_return_interface_macro.v', prefs) or { panic(err) }
+	assert c_source.contains('V_FASTC_MULTI_VALUE(((Frame){'), c_source
+}
+
+fn test_selfhost_match_statement_smartcasts_member_subject() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+interface Frame {
+	marker()
+}
+
+struct DataFrame {
+	data []u8
+}
+
+fn (DataFrame) marker() {}
+
+struct Decoded {
+	frame Frame
+}
+
+fn size(decoded Decoded) int {
+	match decoded.frame {
+		DataFrame { return decoded.frame.data.len }
+		else { return 0 }
+	}
+}
+
+fn main() {}
+', 'selfhost_match_member_smartcast.v', prefs) or { panic(err) }
+	assert c_source.contains('DataFrame *__v_fastc_smartcast_member_'), c_source
+	assert c_source.contains('__v_fastc_smartcast_member_'), c_source
+	assert c_source.contains('->data.len'), c_source
+	assert !c_source.contains('decoded.frame.data'), c_source
+}
+
+fn test_selfhost_result_match_expression_error_branch_returns_option_error() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate("module main
+
+enum Kind {
+	one
+	two
+}
+
+fn decode(bits u8) !Kind {
+	return match bits {
+		0 { Kind.one }
+		1 { Kind.two }
+		else { error('bad kind') }
+	}
+}
+
+fn main() {}
+", 'selfhost_result_match_error_branch.v', prefs) or { panic(err) }
+	assert c_source.contains('return (Option){.err=builtin__error(_S("bad kind")), .state=1}'), c_source
+	assert !c_source.contains('? (Kind__two) : (builtin__error'), c_source
+}
+
+fn test_selfhost_optional_enum_shorthand_return_uses_payload_type() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+enum Kind {
+	one
+}
+
+fn classify(ok bool) ?Kind {
+	if ok {
+		return .one
+	}
+	return none
+}
+
+fn main() {}
+', 'selfhost_optional_enum_shorthand_return.v', prefs) or { panic(err) }
+	assert c_source.contains('Kind __v_fastc_box_value = (Kind__one)'), c_source
+	assert !c_source.contains('__v_fastc_box_value = (.one)'), c_source
+	assert !c_source.contains('sizeof()'), c_source
+}
+
+fn test_selfhost_result_if_expression_error_branch_returns_option_error() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate("module main
+
+fn classify(value int) !string {
+	return if value == 1 {
+		'one'
+	} else if value == 2 {
+		'two'
+	} else {
+		error('bad value')
+	}
+}
+
+fn main() {}
+", 'selfhost_result_if_error_branch.v', prefs) or { panic(err) }
+	assert c_source.contains('return (Option){.err=builtin__error(_S("bad value")), .state=1}'), c_source
+	assert !c_source.contains('? (_S("two")) : (builtin__error'), c_source
+}
+
+fn test_selfhost_function_typed_parameter() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+fn conv(x int) string {
+	return "v"
+}
+
+fn apply(f fn (int) string, x int) string {
+	return "got " + f(x)
+}
+
+fn main() {
+	println(apply(conv, 7))
+}
+', 'selfhost_fn_param.v', prefs) or { panic(err) }
+	// An inline function-typed parameter is declared as a real C function pointer with
+	// unspecified args (so `f(x)` compiles as a direct call), and its return type is
+	// recovered so `"got " + f(x)` resolves as a string concatenation.
+	assert c_source.contains('string (*f)()'), c_source
+	assert c_source.contains('builtin__string_plus'), c_source
+}
+
+fn test_selfhost_function_typed_struct_field_with_mut_argument() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Server {
+mut:
+	on_stopped fn (mut s Server) = unsafe { nil }
+}
+
+fn (mut s Server) stop() {
+	if s.on_stopped != unsafe { nil } {
+		s.on_stopped(mut s)
+	}
+}
+
+fn main() {}
+', 'selfhost_fn_field.v', prefs) or { panic(err) }
+	assert c_source.contains('((void (*)(main__Server*))('), c_source
+	assert c_source.contains('))(&(s))'), c_source
+}
+
+fn test_selfhost_map_value_array_of_pointers_keeps_composite_type() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Item {}
+
+struct Pool {
+mut:
+	idle map[string][]&Item
+}
+
+fn (mut p Pool) take(key string) {
+	mut list := p.idle[key] or { return }
+	_ = list
+}
+
+fn main() {}
+', 'selfhost_map_array_ptr.v', prefs) or { panic(err) }
+	assert c_source.contains('Array_main__Item_ptr *__v_fastc_map_value'), c_source
+	assert !c_source.contains('Array_main__Item* *__v_fastc_map_value'), c_source
+}
+
+fn test_selfhost_map_lookup_or_return_uses_option_value_type() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+enum Kind {
+	item
+}
+
+const labels = {
+	Kind.item: "item"
+}
+
+fn write(kind Kind) {
+	label := labels[kind] or { return }
+	println(label)
+}
+
+fn main() {
+	write(.item)
+}
+', 'selfhost_map_lookup_or_return.v', prefs) or { panic(err) }
+	assert c_source.contains('string *__v_fastc_map_value'), c_source
+	assert c_source.contains('*((string *)__v_fastc_option_'), c_source
+	assert !c_source.contains('Option __v_fastc_option_0 = (main__labels[kind])'), c_source
+}
+
+fn test_selfhost_mut_alias_struct_boxes_as_underlying_interface_implementer() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	main_source := 'module main
+import transport
+
+interface Reader {
+	read() int
+}
+
+fn accept(r Reader) {}
+
+fn pass(mut conn transport.Conn) {
+	accept(conn)
+}
+
+fn main() {}
+'
+	transport_source := 'module transport
+
+pub struct Base {}
+pub type Conn = Base
+'
+	c_source, _, _ := generate_source_files([
+		FastcSourceFile{
+			path: 'main.v'
+			source: main_source
+			header: fastc_scan_source_header(main_source, 'main.v', prefs) or { panic(err) }
+		},
+		FastcSourceFile{
+			path: 'transport/transport.v'
+			source: transport_source
+			header: fastc_scan_source_header(transport_source, 'transport/transport.v', prefs) or {
+				panic(err)}
+		},
+	], map[string]string{}, prefs) or { panic(err) }
+	assert c_source.contains('(main__Reader){._object=(void*)(conn), ._typ=__v_typeid_transport__Base'), c_source
+}
+
+fn test_selfhost_explicit_reference_argument_is_dereferenced_for_value_parameter() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+fn take(value string) {}
+
+fn forward(value &string) {
+	take(value)
+}
+
+fn main() {}
+', 'selfhost_reference_value_argument.v', prefs) or { panic(err) }
+	assert c_source.contains('take(*(value))'), c_source
+}
+
+fn test_selfhost_mutable_array_slice_argument_is_not_dereferenced() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+fn take(mut value []u8) {}
+
+fn forward(mut value []u8) {
+	take(mut value[1..])
+}
+
+fn main() {}
+', 'selfhost_mut_slice_argument.v', prefs) or { panic(err) }
+	assert c_source.contains('builtin__array_slice(*(value), 1, value->len)'), c_source
+	assert !c_source.contains('*(builtin__array_slice'), c_source
+}
+
+fn test_selfhost_c_interface_object_address_uses_pointer_cast() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+interface Logger {
+	free()
+}
+
+fn object_address(logger &Logger) voidptr {
+	return unsafe { &C.main__Logger(logger)._object }
+}
+
+fn main() {}
+', 'selfhost_c_interface_object.v', prefs) or { panic(err) }
+	assert c_source.contains('&(((main__Logger *)(logger))->_object)'), c_source
+	assert !c_source.contains('&main__Logger(logger)._object'), c_source
+}
+
+fn test_selfhost_sizeof_c_struct_uses_struct_tag() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct C.sockaddr_in6 {
+	family u16
+}
+
+fn size() int {
+	return sizeof(C.sockaddr_in6)
+}
+
+fn main() {}
+', 'selfhost_sizeof_c_struct.v', prefs) or { panic(err) }
+	assert c_source.contains('return sizeof(struct sockaddr_in6);'), c_source
+}
+
+fn test_selfhost_as_cast_interface_and_concrete() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+interface Animal {
+	sound() int
+}
+
+interface Loud {
+	sound() int
+}
+
+struct Dog {
+	volume int
+}
+
+fn (d Dog) sound() int {
+	return d.volume
+}
+
+type Beast = Cat | Dog
+
+struct Cat {
+	volume int
+}
+
+fn to_loud(a Animal) Loud {
+	return a as Loud
+}
+
+fn as_dog(b Beast) Dog {
+	return b as Dog
+}
+
+fn main() {
+	_ := to_loud(Dog{ volume: 7 })
+	_ := as_dog(Beast(Dog{ volume: 3 }))
+}
+', 'selfhost_as_cast.v', prefs) or { panic(err) }
+	// `a as Loud` (interface -> interface) re-boxes the same object under the target
+	// type; `b as Dog` (sum -> concrete) unboxes the stored object.
+	assert c_source.contains('._object = __v_fastc_as_src'), c_source
+	assert c_source.contains('*((Dog *)__v_fastc_as_src'), c_source
+}
+
+fn test_selfhost_as_cast_to_module_qualified_concrete_type() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	main_source := 'module main
+import animals
+
+fn as_dog(value animals.Animal) animals.Dog {
+	return value as animals.Dog
+}
+
+fn main() {}
+'
+	animals_source := 'module animals
+
+pub interface Animal {
+	sound() int
+}
+
+pub struct Dog {}
+
+pub fn (d Dog) sound() int {
+	return 1
+}
+'
+	c_source, _, _ := generate_source_files([
+		FastcSourceFile{
+			path: 'main.v'
+			source: main_source
+			header: fastc_scan_source_header(main_source, 'main.v', prefs) or { panic(err) }
+		},
+		FastcSourceFile{
+			path: 'animals/animals.v'
+			source: animals_source
+			header: fastc_scan_source_header(animals_source, 'animals/animals.v', prefs) or {
+				panic(err)}
+		},
+	], map[string]string{}, prefs) or { panic(err) }
+	assert c_source.contains('*((animals__Dog *)__v_fastc_as_src'), c_source
+	assert !c_source.contains(' as animals__Dog'), c_source
+}
+
+fn test_selfhost_multiline_boolean_continues_into_unsafe_expression() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+fn overlaps(x []u8, y []u8) bool {
+	return x.len > 0 && y.len > 0 &&
+		unsafe { &x[0] <= &y[y.len - 1] && &y[0] <= &x[x.len - 1] }
+}
+
+fn main() {}
+', 'multiline_unsafe_boolean.v', prefs) or { panic(err) }
+	assert !c_source.contains('y.len>0&&)'), c_source
+	assert c_source.contains('builtin__array_get(x, 0)'), c_source
+	assert c_source.contains('builtin__array_get(y, y.len-1)'), c_source
+}
+
+fn test_selfhost_multiline_cast_ignores_semicolon_inside_parentheses() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+fn word(bytes []u8) u64 {
+	return (u64(bytes[0]) << 8) | u64(bytes[1]
+	)
+}
+
+fn main() {}
+', 'multiline_cast_parentheses.v', prefs) or { panic(err) }
+	assert c_source.contains('((u64)((*(u8 *)builtin__array_get(bytes, 1))))'), c_source
+	assert !c_source.contains('builtin__array_get(bytes, 1);'), c_source
+}
+
+fn test_selfhost_channel_send_receive() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Item {
+	id int
+}
+
+struct Pool {
+mut:
+	items chan Item
+}
+
+fn make_pool() Pool {
+	ch := chan Item{cap: 2}
+	it := Item{ id: 9 }
+	ch <- it
+	return Pool{
+		items: ch
+	}
+}
+
+fn (mut p Pool) take() !Item {
+	return <-p.items or { return error("empty") }
+}
+
+fn (mut p Pool) drain() int {
+	mut total := 0
+	if p.items.closed {
+		return total
+	}
+	mut c := <-p.items or { return total }
+	total += c.id
+	for _ in 0 .. p.items.len {
+		total += 1
+	}
+	return total
+}
+
+fn main() {
+	mut p := make_pool()
+	got := p.take() or { Item{} }
+	total := p.drain() + got.id
+	if total > 0 {
+		println("nonempty")
+	}
+}
+', 'selfhost_channel.v', prefs) or { panic(err) }
+	// Channel send lowers to `try_push` of the value address; receive pops via
+	// `try_pop` into an element-typed temp recovered from the `chan Item` field
+	// (so `<-p.items` yields `Item`, not the `int` fallback).
+	assert c_source.contains('builtin__chan_try_push'), c_source
+	assert c_source.contains('builtin__chan_try_pop'), c_source
+	assert c_source.contains('builtin__chan_close(ch,(Array_IError){0})'), c_source
+	assert c_source.contains('Item __v_fastc_chan_recv'), c_source
+	assert !c_source.contains('items.closed'), c_source
+}
+
+fn test_selfhost_typed_empty_channel_array() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Waiters {
+mut:
+	items []chan bool
+}
+
+fn new_waiters() Waiters {
+	return Waiters{
+		items: []chan bool{}
+	}
+}
+
+fn main() {
+	_ := new_waiters()
+}
+', 'selfhost_channel_array.v', prefs) or { panic(err) }
+	assert c_source.contains('Array_chan items'), c_source
+	assert c_source.contains('(Array_chan){'), c_source
+	assert !c_source.contains('[]chan bool{}'), c_source
+}
+
+fn test_selfhost_pthread_rwlock_fallback_follows_includes() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+#include <pthread.h>
+
+fn main() {}
+', 'selfhost_pthread_fallback.v', prefs) or { panic(err) }
+	include_index := c_source.index('#include <pthread.h>') or { panic(c_source) }
+	fallback_index := c_source.index('#ifndef PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP') or {
+		panic(c_source)
+	}
+	assert include_index < fallback_index, c_source
+}
+
+fn test_selfhost_is_composite_variant_smartcast() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+type Param = int | []string
+
+fn describe(p Param) int {
+	if p is []string {
+		return p.len
+	}
+	return -1
+}
+
+fn main() {
+	_ := describe(Param(["a", "b"]))
+}
+', 'selfhost_is_composite.v', prefs) or { panic(err) }
+	// `x is []string` tests/smart-casts a composite (`Array_string`) sum variant via
+	// its generated `__v_typeid_` tag, so `p.len` resolves inside the branch.
+	assert c_source.contains('__v_typeid_Array_string'), c_source
+	assert c_source.contains('Array_string p = *((Array_string *)'), c_source
+}
+
+fn test_selfhost_enum_shorthand_after_type_refinement() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+enum Kind {
+	one
+	two
+}
+
+type Value = Kind | string
+
+fn is_one(value Value) bool {
+	return value is Kind && value == .one
+}
+
+fn main() {
+	assert is_one(Value(Kind.one))
+}
+', 'selfhost_enum_refinement.v', prefs) or { panic(err) }
+	// The enum is unboxed only in the short-circuited right operand, and shorthand
+	// resolves against the concrete type established by the left operand.
+	assert c_source.contains('__v_typeid_Kind'), c_source
+	assert c_source.contains('*((Kind *)value._object)'), c_source
+	assert c_source.contains('Kind__one'), c_source
+	assert !c_source.contains('value==.one'), c_source
+}
+
+fn test_selfhost_flag_define_directive() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+#flag -DGITLY_FASTC_DEFINE
+
+fn main() {
+	println("ok")
+}
+', 'selfhost_flag_define.v', prefs) or { panic(err) }
+	// A `#flag -DNAME` preprocessor define is emitted as a `#define` so it is in effect
+	// for any C `#include` that follows.
+	assert c_source.contains('#define GITLY_FASTC_DEFINE 1'), c_source
+}
+
+fn test_selfhost_parallel_option_tuple_decl() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+fn split_pair(s string) ?(string, string) {
+	if s == "" {
+		return none
+	}
+	return s, s
+}
+
+fn describe(part string) string {
+	mut name, mut val := split_pair(part) or { part, "" }
+	return name + val
+}
+
+fn main() {
+	_ := describe("x")
+}
+', 'selfhost_parallel_opt_tuple.v', prefs) or { panic(err) }
+	// `a, b := opt_tuple() or { x, y }`: declare each target, then on the option`s
+	// failure state assign the fallback tuple, else unbox the MultiReturn component.
+	assert c_source.contains('.state) {'), c_source
+	assert c_source.contains('MultiReturn'), c_source
+	assert c_source.contains('.values[1].data'), c_source
+}
+
+fn test_selfhost_assign_concrete_value_to_option_local() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+fn main() {
+	mut bytes := ?[]u8(none)
+	bytes = [u8(1), 2]
+	if value := bytes {
+		assert value.len == 2
+	}
+}
+', 'selfhost_option_assignment.v', prefs) or { panic(err) }
+	assert c_source.contains('bytes=(Option){.data='), c_source
+	assert c_source.contains('sizeof(Array_u8)'), c_source
+}
+
+fn test_selfhost_assign_concrete_value_to_option_field() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Item {
+	id int
+}
+
+struct State {
+mut:
+	item ?Item
+}
+
+fn make_item() !Item {
+	return Item{ id: 3 }
+}
+
+fn fill(mut state State) ! {
+	state.item = make_item()!
+}
+
+fn main() {
+	mut state := State{}
+	fill(mut state) or { panic(err) }
+}
+', 'selfhost_option_field_assignment.v', prefs) or { panic(err) }
+	assert c_source.contains('state->item=(Option){.data='), c_source
+	assert c_source.contains('sizeof(Item)'), c_source
+}
+
+fn test_selfhost_option_payload_through_if_expression() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Limits {
+	a ?u64
+	b ?u64
+}
+
+fn choose(l Limits, first bool) u64 {
+	selected := if first { l.a } else { l.b }
+	if value := selected {
+		return value
+	}
+	return 0
+}
+
+fn main() {
+	_ := choose(Limits{}, true)
+}
+', 'selfhost_option_if_expression.v', prefs) or { panic(err) }
+	assert c_source.contains('Option __v_fastc_if_guard'), c_source
+	assert c_source.contains('u64 value = *((u64 *)'), c_source
+	assert !c_source.contains('value:=selected'), c_source
+}
+
+fn test_selfhost_option_or_through_nested_pointer_member() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Inner {
+	value ?u64
+}
+
+struct Outer {
+	inner &Inner
+}
+
+fn read_value(outer &Outer) u64 {
+	return outer.inner.value or { u64(0) }
+}
+
+fn main() {
+	_ := read_value(&Outer{ inner: &Inner{} })
+}
+', 'selfhost_nested_pointer_option.v', prefs) or { panic(err) }
+	assert c_source.contains('outer->inner->value'), c_source
+	assert !c_source.contains('outer->inner.value'), c_source
+}
+
+fn test_selfhost_option_or_through_pointer_returning_method_member() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct State {
+	value ?u64
+}
+
+struct Owner {
+	state State
+}
+
+fn (mut owner Owner) get_state() &State {
+	return &owner.state
+}
+
+fn read(mut owner Owner) u64 {
+	return owner.get_state().value or { u64(0) }
+}
+
+fn main() {}
+', 'selfhost_method_pointer_option_member.v', prefs) or { panic(err) }
+	assert c_source.contains('Owner_get_state(owner)->value'), c_source
+	assert !c_source.contains('Owner_get_state(owner).value'), c_source
+}
+
+fn test_selfhost_static_method_multi_return_types() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Maker {}
+
+fn Maker.make() !(int, string) {
+	return 7, "ok"
+}
+
+fn main() {
+	number, text := Maker.make()!
+	println(number)
+	println(text)
+}
+', 'selfhost_static_multi_return.v', prefs) or { panic(err) }
+	assert c_source.contains('int number = (int){0}'), c_source
+	assert c_source.contains('string text = (string){0}'), c_source
+	assert !c_source.contains('usize number'), c_source
+}
+
+fn test_selfhost_explicit_embed_method_call() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Base {
+	x int
+}
+
+fn (b Base) hello() int {
+	return b.x
+}
+
+struct Derived {
+	Base
+	y int
+}
+
+fn use(d Derived) int {
+	return d.Base.hello()
+}
+
+fn main() {
+	_ := use(Derived{ Base: Base{ x: 7 }, y: 1 })
+}
+', 'selfhost_embed_method.v', prefs) or { panic(err) }
+	// `d.Base.hello()` accesses the embed by type name (`__embedded_0`) and calls its
+	// method on that field — no doubled `__embedded_0`.
+	assert c_source.contains('Base_hello(&(d.__embedded_0))') || c_source.contains('Base_hello(d.__embedded_0)'), c_source
+	assert !c_source.contains('__embedded_0.__embedded_0'), c_source
+}
+
+fn test_selfhost_method_on_propagated_result() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Box {
+	v int
+}
+
+fn (b Box) doubled() int {
+	return b.v * 2
+}
+
+fn make_box(x int) !Box {
+	return Box{ v: x }
+}
+
+fn use_box(x int) !int {
+	return make_box(x)!.doubled()
+}
+
+fn main() {
+	_ := use_box(3) or { 0 }
+}
+', 'selfhost_bang_method.v', prefs) or { panic(err) }
+	// `decode(raw)!.len`: the receiver `decode(raw)!` unwraps the result (propagating
+	// its error) before `.len` is taken.
+	assert c_source.contains('__v_fastc_option_propagate'), c_source
+}
+
+fn test_selfhost_mut_method_on_pointer_field() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Lock {
+mut:
+	held int
+}
+
+fn (mut l Lock) grab() {
+	l.held += 1
+}
+
+struct Wrap {
+	mu &Lock = unsafe { nil }
+}
+
+fn touch(w &Wrap) {
+	w.mu.grab()
+}
+
+fn main() {
+	l := &Lock{ held: 0 }
+	touch(&Wrap{ mu: l })
+}
+', 'selfhost_ptr_mut_method.v', prefs) or { panic(err) }
+	// A `mut`-receiver method on a `&Lock` pointer field is valid through the immutable
+	// `&Wrap` param (the pointer carries mutable access).
+	assert c_source.contains('Lock_grab'), c_source
+}
+
+fn test_selfhost_spawn_mut_argument() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Counter {
+mut:
+	n int
+}
+
+fn bump(mut c Counter) {
+	c.n += 1
+}
+
+fn launch(mut c Counter) {
+	t := spawn bump(mut c)
+	t.wait()
+}
+
+fn main() {
+	mut c := Counter{ n: 0 }
+	launch(mut c)
+}
+', 'selfhost_spawn_mut.v', prefs) or { panic(err) }
+	// `spawn bump(mut c)`: the `mut` parameter is a pointer, so c is passed by address.
+	assert c_source.contains('__v_fastc_spawn_start'), c_source
+}
+
+fn test_selfhost_mut_map_option_guard() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Val {
+mut:
+	x int
+}
+
+fn lookup(m map[int]Val) int {
+	if mut v := m[1] {
+		v.x += 1
+		return v.x
+	}
+	return -1
+}
+
+fn main() {
+	mut m := map[int]Val{}
+	m[1] = Val{ x: 5 }
+	_ := lookup(m)
+}
+', 'selfhost_mut_map_guard.v', prefs) or { panic(err) }
+	// `if mut v := m[1] { ... }`: the leading `mut` guard binds `v` to the map value.
+	assert c_source.contains('if_guard'), c_source
+	assert c_source.contains('.state == 0'), c_source
+}
+
+fn test_selfhost_mut_iterate_pointer_array_method() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Stream {
+mut:
+	failed bool
+}
+
+fn (mut s Stream) fail() {
+	s.failed = true
+}
+
+fn process() int {
+	mut above := []&Stream{}
+	above << &Stream{ failed: false }
+	mut n := 0
+	for mut st in above {
+		st.fail()
+		n += 1
+	}
+	return n
+}
+
+fn main() {
+	_ := process()
+}
+', 'selfhost_ptr_array_iter.v', prefs) or { panic(err) }
+	// `[]&Stream` stores `_ptr`-encoded elements; the mut-iteration element type is
+	// decoded to `Stream*`, so `st.fail()` resolves to `Stream_fail`, not the invalid
+	// `Stream_ptr_fail`.
+	assert c_source.contains('Stream* st = ((Stream* *)'), c_source
+	assert !c_source.contains('Stream* *st = &(((Stream* *)'), c_source
+	assert c_source.contains('Stream_fail'), c_source
+	assert !c_source.contains('Stream_ptr_fail'), c_source
+}
+
+fn test_selfhost_fixed_array_field_iteration_uses_element_pointer() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Item {
+	value int
+}
+
+struct Holder {
+	items [4]Item
+}
+
+fn total(holder Holder) int {
+	mut sum := 0
+	for _, item in holder.items {
+		sum += item.value
+	}
+	return sum
+}
+
+fn main() {
+	_ := total(Holder{})
+}
+', 'fixed_array_field_iteration.v', prefs) or { panic(err) }
+	assert c_source.contains('Item *__v_fastc_collection_'), c_source
+	assert c_source.contains('= &((holder.items)[0]);'), c_source
+	assert !c_source.contains('__typeof__((holder.items)) __v_fastc_collection_'), c_source
+	assert !c_source.contains('__v_fastc_collection_0.data'), c_source
+}
+
+fn test_selfhost_fixed_array_struct_field_copy_uses_memcpy() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Holder {
+	items [4]int
+	len   int
+}
+
+fn copy(source Holder) Holder {
+	return Holder{
+		items: source.items
+		len: source.len
+	}
+}
+
+fn main() {
+	_ := copy(Holder{})
+}
+', 'fixed_array_struct_field_copy.v', prefs) or { panic(err) }
+	assert c_source.contains('memcpy(__v_fastc_struct_fixed.items, source.items, sizeof(__v_fastc_struct_fixed.items));'), c_source
+
+	assert !c_source.contains('__typeof__((source.items)) __v_fastc_struct_field_'), c_source
+}
+
+fn test_selfhost_panic_argument_uses_string_concatenation_lowering() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+fn maybe() ?int {
+	return none
+}
+
+fn result() !int {
+	return error("no")
+}
+
+fn fail(message string) int {
+	return maybe() or {
+		panic("failed: " + message)
+	}
+}
+
+fn fail_with_error() int {
+	return result() or {
+		panic(err)
+	}
+}
+
+fn main() {
+	_ := fail("now")
+	_ := fail_with_error()
+}
+', 'panic_string_concatenation.v', prefs) or { panic(err) }
+	assert c_source.contains('builtin__panic(builtin__string_plus(_S("failed: "),message))'), c_source
+	assert c_source.contains('builtin__panic(builtin__IError_msg(err))'), c_source
+	assert !c_source.contains('_S("failed: ")+message'), c_source
+}
+
+fn test_selfhost_map_guard_function_alias_retains_result_type() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+type Handler = fn (value int) !string
+
+fn call(handlers map[string]Handler) !string {
+	if handler := handlers["test"] {
+		return handler(1)
+	}
+	return error("missing")
+}
+
+fn main() {
+	_ := call(map[string]Handler{})
+}
+', 'map_guard_function_alias.v', prefs) or { panic(err) }
+	assert c_source.contains('Handler handler = *((Handler *)__v_fastc_if_guard_'), c_source
+	assert c_source.contains('return handler(1);'), c_source
+	assert !c_source.contains('sizeof());'), c_source
+}
+
+fn test_selfhost_function_field_retains_result_payload_type() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Server {
+	handler fn (int) !string
+}
+
+fn call(server Server) string {
+	return server.handler(1) or {
+		return "failed"
+	}
+}
+
+fn main() {
+	_ := call(Server{})
+}
+', 'function_field_result_payload.v', prefs) or { panic(err) }
+	assert c_source.contains('*((string *)__v_fastc_option_'), c_source
+	assert !c_source.contains('return; } 0;'), c_source
+}
+
+fn test_selfhost_optional_function_field_guard_binds_typed_callback() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Config {
+	callback ?fn (int) !string
+}
+
+fn call(config Config) !string {
+	if callback := config.callback {
+		return callback(1)
+	}
+	return error("missing")
+}
+
+fn main() {
+	_ := call(Config{})
+}
+', 'optional_function_field_guard.v', prefs) or { panic(err) }
+	assert c_source.contains('config.callback != NULL'), c_source
+	assert c_source.contains('Option (*callback)(int)'), c_source
+	assert !c_source.contains('Option __v_fastc_if_guard_'), c_source
+}
+
+fn test_selfhost_derived_overloaded_comparisons() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Moment {
+	value int
+}
+
+fn (left Moment) < (right Moment) bool {
+	return left.value < right.value
+}
+
+fn (left Moment) == (right Moment) bool {
+	return left.value == right.value
+}
+
+fn compare(left Moment, right Moment) {
+	println(left < right)
+	println(left > right)
+	println(left <= right)
+	println(left >= right)
+	println(left == right)
+	println(left != right)
+}
+
+fn main() {
+	compare(Moment{ value: 1 }, Moment{ value: 2 })
+}
+', 'derived_overloaded_comparisons.v', prefs) or { panic(err) }
+	assert c_source.contains('Moment_lt(left,right)'), c_source
+	assert c_source.contains('Moment_lt(right,left)'), c_source
+	assert c_source.contains('!(Moment_lt(right,left))'), c_source
+	assert c_source.contains('!(Moment_lt(left,right))'), c_source
+	assert c_source.contains('Moment_eq(left,right)'), c_source
+	assert c_source.contains('!(Moment_eq(left,right))'), c_source
+}
+
+fn test_selfhost_overloaded_operator_retains_private_helper_dependency() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Count {
+	value int
+}
+
+fn (left Count) + (right Count) Count {
+	return left.combine(right)
+}
+
+fn (left Count) combine(right Count) Count {
+	return Count{
+		value: left.value + right.value
+	}
+}
+
+fn main() {
+	_ := Count{ value: 1 } + Count{ value: 2 }
+}
+', 'overloaded_operator_private_helper.v', prefs) or { panic(err) }
+	assert c_source.contains('main__Count_combine'), c_source
+	assert c_source.contains('return main__Count_combine(left,right);'), c_source
+}
+
+fn test_selfhost_compound_assignment_uses_overloaded_operator() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Count {
+	value int
+}
+
+fn (left Count) * (right Count) Count {
+	return Count{
+		value: left.value * right.value
+	}
+}
+
+fn main() {
+	mut value := Count{ value: 2 }
+	value *= Count{ value: 3 }
+}
+', 'overloaded_compound_assignment.v', prefs) or { panic(err) }
+	assert c_source.contains('Count *__v_fastc_overloaded_assignment_target = &(value)'), c_source
+	assert c_source.contains('main__Count_mul(*__v_fastc_overloaded_assignment_target'), c_source
+	assert !c_source.contains('value*='), c_source
+}
+
+fn test_selfhost_nested_overloaded_result_is_not_auto_dereferenced() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Count {
+	value int
+}
+
+fn (left Count) * (right Count) Count {
+	return Count{ value: left.value * right.value }
+}
+
+fn (left Count) + (right Count) Count {
+	return Count{ value: left.value + right.value }
+}
+
+fn update(mut result Count, factor Count, extra Count) {
+	result = (result * factor) + extra
+}
+
+fn main() {
+	mut result := Count{ value: 2 }
+	update(mut result, Count{ value: 3 }, Count{ value: 1 })
+}
+', 'nested_overloaded_mut_receiver.v', prefs) or { panic(err) }
+	assert c_source.contains('main__Count_plus((main__Count_mul(*(result),factor)),extra)'), c_source
+	assert !c_source.contains('*(main__Count_mul'), c_source
+}
+
+fn test_selfhost_overloaded_expression_as_method_receiver() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Count {
+	value int
+}
+
+fn (left Count) + (right Count) Count {
+	return Count{ value: left.value + right.value }
+}
+
+fn (value Count) scaled(factor int) Count {
+	return Count{ value: value.value * factor }
+}
+
+fn calculate(left Count, right Count) Count {
+	return (left + right).scaled(2)
+}
+
+fn main() {
+	_ := calculate(Count{ value: 1 }, Count{ value: 2 })
+}
+', 'overloaded_expression_method_receiver.v', prefs) or { panic(err) }
+	assert c_source.contains('main__Count_scaled((main__Count_plus(left,right)),2)'), c_source
+	assert !c_source.contains('main__Count_plus(left,right)+'), c_source
+}
+
+fn test_selfhost_dynamic_array_equality_is_elementwise() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+fn same(left []u64, right []u64) bool {
+	return left == right
+}
+
+fn different(left []string, right []string) bool {
+	return left != right
+}
+
+fn main() {
+	_ := same([u64(1)], [u64(1)])
+	_ := different(["a"], ["b"])
+}
+', 'dynamic_array_equality.v', prefs) or { panic(err) }
+	assert c_source.contains('__v_fastc_array_eq_left.len == __v_fastc_array_eq_right.len'), c_source
+	assert c_source.contains('((u64 *)__v_fastc_array_eq_left.data)'), c_source
+	assert c_source.contains('builtin__string_eq(((string *)__v_fastc_array_eq_left.data)'), c_source
+	assert c_source.contains('!__v_fastc_array_equal'), c_source
+	assert !c_source.contains('left==right'), c_source
+}
+
+fn test_selfhost_fixed_array_field_equality_is_elementwise() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Preferred {
+	ipv4 [4]u8
+}
+
+fn missing(value Preferred) bool {
+	return value.ipv4 == [4]u8{}
+}
+
+fn main() {}
+', 'fixed_array_field_equality.v', prefs) or { panic(err) }
+	assert c_source.contains('u8 *__v_fastc_array_eq_left = (u8 *)(value.ipv4)'), c_source
+	assert c_source.contains('__v_fastc_array_eq_index < 4'), c_source
+	assert !c_source.contains('==[4]u8{}'), c_source
+}
+
+fn test_selfhost_nested_fixed_array_field_assignment_uses_raw_storage() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Grid {
+mut:
+	values [2][3]int
+}
+
+fn set(mut grid Grid) {
+	grid.values[0][1] = 7
+}
+
+fn main() {}
+', 'nested_fixed_array_field_assignment.v', prefs) or { panic(err) }
+	assert c_source.contains('grid->values)[builtin__v_fixed_index(0, 2)]'), c_source
+	assert c_source.contains('builtin__v_fixed_index(1, 3)]'), c_source
+	assert !c_source.contains('grid->values)[builtin__v_fixed_index(0, 2)]).data'), c_source
+}
+
+fn test_selfhost_constant_rewrite_does_not_rename_same_named_field() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+const p = [2]int{init: 3}
+
+struct Pair {
+	p [2]int
+}
+
+fn total(value Pair) int {
+	return value.p[0] + p[0]
+}
+
+fn main() {}
+', 'constant_and_field_name_collision.v', prefs) or { panic(err) }
+	assert c_source.contains('value.p'), c_source
+	assert c_source.contains('main__p'), c_source
+	assert !c_source.contains('value.main__p'), c_source
+}
+
+fn test_selfhost_erased_generic_compound_assignment_uses_stub() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+fn sum[T](values []T) T {
+	mut result := values[0]
+	result += values[1]
+	return result
+}
+
+fn main() {}
+', 'erased_generic_compound_assignment.v', prefs) or { panic(err) }
+	assert c_source.contains('voidptr main__sum(Array_voidptr values)'), c_source
+	assert c_source.contains('return (voidptr){0};'), c_source
+	assert !c_source.contains('result+='), c_source
+}
+
+fn test_selfhost_erased_generic_type_reflection_uses_stub() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+fn is_pointer[T]() bool {
+	return T.name[0] == `&`
+}
+
+fn main() {}
+', 'erased_generic_type_reflection.v', prefs) or { panic(err) }
+	assert c_source.contains('bool main__is_pointer(void)'), c_source
+	assert c_source.contains('return (bool){0};'), c_source
+	assert !c_source.contains('T.name'), c_source
+}
+
+fn test_selfhost_monomorphized_mut_generic_parameter_keeps_pointer() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Decoder {}
+
+fn (mut decoder Decoder) set[T](mut value T) {
+	value = value
+}
+
+fn (mut decoder Decoder) use(mut value string) {
+	decoder.set[string](mut value)
+}
+
+fn main() {}
+', 'monomorphized_mut_generic_parameter.v', prefs) or { panic(err) }
+	assert c_source.contains('Decoder_set_mono_string(Decoder* decoder, string* value)'), c_source
+	assert c_source.contains('Decoder_set_mono_string(decoder,value)'), c_source
+	assert !c_source.contains('Decoder_set_mono_string(decoder,*(value))'), c_source
+}
+
+fn test_selfhost_for_key_mut_value_map() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Val {
+mut:
+	x int
+}
+
+fn adjust(mut m map[int]&Val) {
+	for _, mut v in m {
+		v.x += 1
+	}
+}
+
+fn main() {
+	mut m := map[int]&Val{}
+	m[1] = &Val{ x: 0 }
+	adjust(mut m)
+}
+', 'selfhost_for_mut_value.v', prefs) or { panic(err) }
+	// `for _, mut v in m`: the `mut` value binds; the map value is a pointer so
+	// mutations through `v` persist. Compiles via `builtin__map_values`.
+	assert c_source.contains('builtin__map_values'), c_source
+}
+
+fn test_selfhost_fixed_array_slice() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+fn take(n int) int {
+	mut msg := [8]u8{}
+	msg[0] = 104
+	s := msg[..n]
+	return s.len
+}
+
+fn main() {
+	_ := take(2)
+}
+', 'selfhost_fixed_slice.v', prefs) or { panic(err) }
+	// Slicing a fixed array yields a dynamic `Array_u8` copied from the element range,
+	// not the `FixedArray_...` type, so `.len` resolves on the resulting array.
+	assert c_source.contains('builtin__new_array_from_c_array'), c_source
+	assert c_source.contains('Array_u8'), c_source
+}
+
+fn test_selfhost_fixed_array_struct_field_slice_uses_raw_field_storage() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Address {
+	bytes [16]u8
+}
+
+fn slice(address Address) []u8 {
+	return address.bytes[..]
+}
+
+fn main() {}
+', 'selfhost_fixed_field_slice.v', prefs) or { panic(err) }
+	assert c_source.contains('&(((address.bytes))[0])'), c_source
+	assert !c_source.contains('__typeof__((address.bytes)) __v_fastc_slice_receiver'), c_source
+}
+
+fn test_selfhost_embedded_union_fixed_array_slice_promotes_member() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Unix {
+	path [8]char
+}
+
+union Data {
+	Unix
+}
+
+struct Address {
+	data Data
+}
+
+fn path_data(address Address) byteptr {
+	return address.data.Unix.path[..].data
+}
+
+fn main() {}
+', 'selfhost_embedded_union_fixed_slice.v', prefs) or { panic(err) }
+	assert c_source.contains('address.data.__embedded_0.path'), c_source
+	assert !c_source.contains('address.data.Unix.path'), c_source
+	assert c_source.contains('typedef array Array_char;'), c_source
+}
+
+fn test_selfhost_keyword_named_function_call_in_or_expression() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+fn select(value int) !bool {
+	return value > 0
+}
+
+fn ready() !bool {
+	value := select(1) or { return err }
+	return value
+}
+
+fn main() {}
+', 'selfhost_keyword_function_call.v', prefs) or { panic(err) }
+	assert c_source.contains('select(1)'), c_source
+	assert c_source.contains('*((bool *)'), c_source
+}
+
+fn test_selfhost_if_expression_panic_arm_uses_sibling_type() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Stamp {
+	n int
+}
+
+fn choose(value int) Stamp {
+	result := if value == 0 {
+		Stamp{ n: 1 }
+	} else if value < 0 {
+		panic("negative")
+	} else {
+		Stamp{ n: 2 }
+	}
+	return result
+}
+
+fn main() {}
+', 'selfhost_if_panic_arm.v', prefs) or { panic(err) }
+	assert c_source.contains('(Stamp){0}'), c_source
+	assert c_source.contains('builtin__panic(_S("negative"))'), c_source
+}
+
+fn test_selfhost_method_on_parenthesized_or() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Box {
+	v int
+}
+
+fn (b Box) doubled() int {
+	return b.v * 2
+}
+
+fn make_box(x int) ?Box {
+	if x < 0 {
+		return none
+	}
+	return Box{ v: x }
+}
+
+fn use_box(x int) int {
+	return (make_box(x) or { Box{ v: 0 } }).doubled()
+}
+
+fn main() {
+	_ := use_box(5)
+}
+', 'selfhost_paren_or_method.v', prefs) or { panic(err) }
+	// `(make_box(x) or { … }).doubled()`: the grouping parens leave the option expression
+	// balanced (`Option t = (make_box(x))`, not `((make_box(x))`) and the grouped operand`s
+	// value type (Box) flows into the result token so the method binds to the unwrapped Box.
+	assert c_source.contains('Box_doubled'), c_source
+	assert c_source.contains('__v_fastc_option'), c_source
+	assert !c_source.contains('= ((make_box'), c_source
+}
+
+fn test_selfhost_parenthesized_or_inside_boolean_comparison() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+fn maybe_role() ?string {
+	return "admin"
+}
+
+fn can_admin(logged_in bool) bool {
+	return logged_in && (maybe_role() or { "" }) == "admin"
+}
+
+fn main() {
+	_ := can_admin(true)
+}
+', 'selfhost_parenthesized_or_comparison.v', prefs) or { panic(err) }
+	// The synthetic option-unwrapping atom must retain its full statement expression
+	// when the surrounding string equality re-renders the comparison operands.
+	assert c_source.contains('Option __v_fastc_option_'), c_source
+	assert c_source.contains('= (maybe_role())'), c_source
+	assert c_source.contains('builtin__string_eq'), c_source
+}
+
+fn test_selfhost_map_lookup_inside_arithmetic_assignment() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+fn increase(mut counts map[string]int, key string, amount int) {
+	counts[key] = counts[key] + amount
+}
+
+fn main() {
+	mut counts := map[string]int{}
+	increase(mut counts, "v", 2)
+}
+', 'selfhost_map_lookup_arithmetic.v', prefs) or { panic(err) }
+	assert c_source.contains('builtin__map_get_check'), c_source
+	assert c_source.contains('builtin__map_set'), c_source
+	assert !c_source.contains('counts[key]+amount'), c_source
+}
+
+fn test_selfhost_nested_map_assignment_initializes_addressable_inner_map() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+fn insert(mut values map[string]map[string]string, group string, key string, value string) {
+	values[group][key] = value
+}
+
+fn main() {
+	mut values := map[string]map[string]string{}
+	insert(mut values, "group", "key", "value")
+}
+', 'selfhost_nested_map_assignment.v', prefs) or { panic(err) }
+	assert c_source.contains('Map_string_string *__v_fastc_nested_map_value'), c_source
+	assert c_source.contains('builtin__new_map(sizeof(string), sizeof(string)'), c_source
+	assert c_source.contains('builtin__map_set((map *)({'), c_source
+	assert !c_source.contains('&values[group]'), c_source
+}
+
+fn test_selfhost_array_any_binds_implicit_it() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+fn has_ignored(parts []string, ignored []string) bool {
+	return parts.any(ignored.contains(it))
+}
+
+fn main() {
+	_ := has_ignored(["src"], ["thirdparty"])
+}
+', 'selfhost_array_any.v', prefs) or { panic(err) }
+	assert c_source.contains('string it ='), c_source
+	assert c_source.contains('bool __v_fastc_mapped_'), c_source
+	assert !c_source.contains('builtin__array_any'), c_source
+}
+
+fn test_selfhost_print_uses_alias_str_method() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+type Duration = i64
+
+fn (d Duration) str() string {
+	return "elapsed"
+}
+
+fn elapsed() Duration {
+	return Duration(1)
+}
+
+fn main() {
+	println(elapsed())
+}
+', 'selfhost_print_alias_str.v', prefs) or { panic(err) }
+	assert c_source.contains('builtin__println(Duration_str(elapsed()))'), c_source
+}
+
+fn test_selfhost_method_on_arithmetic_with_nested_or() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+fn maybe_number() ?int {
+	return 2
+}
+
+fn (n int) doubled() int {
+	return n * 2
+}
+
+fn use_number() int {
+	return (100 + (1 + maybe_number() or { 0 })).doubled()
+}
+
+fn main() {
+	_ := use_number()
+}
+', 'selfhost_arithmetic_or_method.v', prefs) or { panic(err) }
+	assert c_source.contains('__v_fastc_option'), c_source
+	assert c_source.contains('100+('), c_source
+	assert !c_source.contains('.doubled()'), c_source
+}
+
+fn test_selfhost_pointer_struct_with_or_inside_call_argument() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Params {
+	value ?u64
+}
+
+struct Conn {
+	value u64
+}
+
+fn take(value u64) u64 {
+	return value
+}
+
+fn (mut c Conn) use() {}
+
+fn run(params Params) {
+	mut c := &Conn{
+		value: take(params.value or { u64(0) })
+	}
+	c.use()
+}
+
+fn main() {
+	run(Params{})
+}
+', 'selfhost_pointer_struct_or_call.v', prefs) or { panic(err) }
+	assert c_source.contains('(Conn*)v_fastc_interface_box'), c_source
+	assert c_source.contains('Conn_use(c)'), c_source
+	assert c_source.contains('take(({ Option __v_fastc_option_'), c_source
+}
+
+fn test_selfhost_method_on_parenthesized_or_in_struct_field() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct S {
+	v int
+}
+
+fn (s S) plus() S {
+	return S{ v: s.v + 1 }
+}
+
+fn mk(x int) ?S {
+	if x < 0 {
+		return none
+	}
+	return S{ v: x }
+}
+
+struct Config {
+	a S
+	b int
+}
+
+fn build(x int, y int) Config {
+	return Config{
+		a:      (mk(x) or { S{ v: 0 } }).plus()
+		b:      y
+	}
+}
+
+fn main() {
+	_ := build(5, 9)
+}
+', 'selfhost_paren_or_method_struct.v', prefs) or { panic(err) }
+	// `Config{ a: (mk(x) or { … }).plus(), b: y }`: the grouping parens around the option
+	// are absorbed so the method binds to the unwrapped S, and the struct keeps rendering
+	// the trailing `.b` field (no unmatched `)` trailing the or-result token).
+	assert c_source.contains('S_plus'), c_source
+	assert c_source.contains('(Config){.a='), c_source
+	assert c_source.contains('.b='), c_source
+}
+
+fn test_selfhost_diverging_or_then_binary_operator() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+fn maybe(x int) ?int {
+	if x < 0 {
+		return none
+	}
+	return x
+}
+
+fn use_it(x int) int {
+	v := maybe(x) or { return -1 } + 10
+	return v
+}
+
+fn main() {
+	_ := use_it(5)
+}
+', 'selfhost_or_binop.v', prefs) or { panic(err) }
+	// `maybe(x) or { return -1 } + 10`: the diverging or-block returns on failure, and the
+	// `+ 10` binds to the unwrapped success value rather than orphaning as its own statement.
+	assert c_source.contains('__v_fastc_option'), c_source
+	assert c_source.contains('+ 10') || c_source.contains('+10'), c_source
+}
+
+fn test_selfhost_option_if_guard_binds_err_in_else_branch() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+fn maybe() !int {
+	return error("no")
+}
+
+fn use_it() string {
+	if value := maybe() {
+		return value.str()
+	} else {
+		return err.msg()
+	}
+}
+
+fn main() {
+	_ := use_it()
+}
+', 'selfhost_option_if_guard_err.v', prefs) or { panic(err) }
+	assert c_source.contains('IError err = __v_fastc_if_guard_'), c_source
+}
+
+fn test_selfhost_multi_return_macro_uses_collision_safe_temporaries() {
+	assert c_selfhost_preamble.contains('__v_fastc_multi_value')
+	assert !c_selfhost_preamble.contains('__typeof__(expression) value =')
+}
+
+fn test_selfhost_mut_guard_on_option_struct_field() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Conn {
+	id int
+}
+
+fn (c Conn) close() int {
+	return c.id
+}
+
+struct H {
+mut:
+	vsc ?Conn
+}
+
+fn (mut h H) shut() int {
+	if mut v := h.vsc {
+		return v.close()
+	}
+	return -1
+}
+
+fn main() {
+	mut h := H{}
+	_ := h.shut()
+}
+', 'selfhost_option_field_guard.v', prefs) or { panic(err) }
+	// `if mut v := h.vsc {` where `vsc ?Conn`: the guard local `v` binds to the field`s
+	// wrapped value type (Conn) recovered from FastcStructField.option_value_type, so
+	// `v.close()` resolves to Conn_close rather than defaulting the receiver to int.
+	assert c_source.contains('Conn v = *((Conn *)'), c_source
+	assert c_source.contains('Conn_close(v)'), c_source
+}
+
+fn test_selfhost_option_field_local_retains_guard_payload_type() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Stream {
+	id ?u64
+}
+
+fn remove(stream Stream) u64 {
+	stream_id := stream.id
+	if id := stream_id {
+		return id
+	}
+	return 0
+}
+
+fn main() {
+	_ := remove(Stream{})
+}
+', 'option_field_local_guard.v', prefs) or { panic(err) }
+	assert c_source.contains('Option __v_fastc_if_guard_'), c_source
+	assert c_source.contains('u64 id = *((u64 *)__v_fastc_if_guard_'), c_source
+	assert !c_source.contains('if (id:=stream_id)'), c_source
+}
+
+fn test_selfhost_explicit_option_casts() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+fn value_or_zero(present bool) u64 {
+	mut value := ?u64(none)
+	if present {
+		value = ?u64(7)
+	}
+	if unwrapped := value {
+		return unwrapped
+	}
+	return 0
+}
+
+fn main() {
+	_ := value_or_zero(true)
+}
+', 'explicit_option_casts.v', prefs) or { panic(err) }
+	assert c_source.contains('(Option){.state=2}'), c_source
+	assert c_source.contains('(Option){.data='), c_source
+	assert c_source.contains('u64 unwrapped = *((u64 *)__v_fastc_if_guard_'), c_source
+	assert !c_source.contains('?((u64)'), c_source
+}
+
+fn test_selfhost_concrete_argument_is_lifted_to_option() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+fn take(value ?[]u8) int {
+	return 1
+}
+
+fn main() {
+	_ := take([u8(1), 2])
+	_ := take(none)
+}
+', 'option_argument_lift.v', prefs) or { panic(err) }
+	assert c_source.contains('take((Option){.data='), c_source
+	assert c_source.contains('sizeof(Array_u8)'), c_source
+	assert c_source.contains('take((Option){.state=2})'), c_source
+}
+
+fn test_selfhost_anonymous_function_stub() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+fn apply(f fn (int) int, x int) int {
+	return f(x)
+}
+
+fn main() {
+	g := fn (x int) int {
+		return x + 1
+	}
+	_ := apply(g, 5)
+}
+', 'selfhost_anon_fn.v', prefs) or { panic(err) }
+	// A function literal `fn (x int) int { … }` in expression position lowers to a
+	// compile-only stub: a top-level `int …__anonfn_N(int) { return (int){0}; }` whose
+	// address is taken as the function-pointer value. FastC has no closure runtime, so
+	// the stub is non-functional (mirrors the channel stubs).
+	assert c_source.contains('__anonfn_'), c_source
+	assert c_source.contains('return (int){0};'), c_source
+	assert !c_source.contains('main.main.'), c_source
+}
+
+fn test_selfhost_c_struct_keyword_field_name() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct C.Node {
+	next &C.Node
+	type int
+}
+
+fn main() {
+	_ := 0
+}
+', 'selfhost_c_struct_keyword_field.v', prefs) or { panic(err) }
+	// A C struct field named with a V keyword (`type int`, as in `C.cJSON`) is accepted;
+	// the field name is a plain C identifier.
+	assert c_source.len > 0, 'expected generated C'
+}
+
+fn test_selfhost_lowercase_c_struct_pointer_cast_keeps_member_type() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct C.node {
+	value int
+	next  &C.node
+}
+
+fn main() {
+	results := &C.node(unsafe { nil })
+	for result := unsafe { results }; result != unsafe { nil }; result = result.next {
+		_ := result.value.str()
+	}
+}
+', 'selfhost_lowercase_c_struct_pointer_cast.v', prefs) or { panic(err) }
+	assert c_source.contains('builtin__int_str(result->value)'), c_source
+}
+
+fn test_selfhost_c_pointer_cast_member_does_not_leak_pointer_type() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct C.Detail {
+	level u32
+}
+
+fn main() {
+	raw := voidptr(0)
+	level := unsafe { &C.Detail(raw) }.level
+	detail := unsafe { &C.Detail(raw) }
+	println(level)
+	_ = detail
+}
+', 'selfhost_c_pointer_cast_member_type.v', prefs) or { panic(err) }
+	assert c_source.contains('builtin__u32_str(level)'), c_source
+	assert !c_source.contains('builtin__u32_str(*(level))'), c_source
+	assert c_source.contains('Detail*)(raw)'), c_source
+	assert !c_source.contains('Detail*)(*((Detail* *)(raw)))'), c_source
+}
+
+fn test_selfhost_composite_receiver_method_name() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+type Val = int | string
+
+fn (v Val) label() int {
+	return 1
+}
+
+fn (v []Val) label() int {
+	return 2
+}
+
+fn main() {
+	v := Val(5)
+	mut arr := []Val{}
+	arr << Val(6)
+	_ := v.label()
+	_ := arr.label()
+}
+', 'selfhost_composite_method.v', prefs) or { panic(err) }
+	// A method on `[]Val` must not share the C name of the method on `Val` (both would
+	// collapse to `Val_label` → C redefinition); the composite keeps its `Array_` prefix.
+	assert c_source.contains('Array_Val_label'), c_source
+	assert !c_source.contains('Array_Val_label(Val '), c_source
+}
+
+fn test_selfhost_match_range_case() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+fn classify(b u8) int {
+	return match b {
+		32...126 { 1 }
+		else { 0 }
+	}
+}
+
+fn main() {
+	_ := classify(65)
+}
+', 'selfhost_match_range.v', prefs) or { panic(err) }
+	// A `32...126` match range lowers to a `>= 32 && <= 126` comparison, not the invalid
+	// C literal `== (32...126)`.
+	assert c_source.contains('>= (32)') && c_source.contains('<= (126)'), c_source
+	assert !c_source.contains('32...126'), c_source
+}
+
+fn test_selfhost_explicit_deref_of_mut_receiver() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Box {
+	n int
+}
+
+fn (mut b Box) grab() Box {
+	r := *b
+	return r
+}
+
+fn main() {
+	mut x := Box{
+		n: 5
+	}
+	_ := x.grab()
+}
+', 'selfhost_deref_receiver.v', prefs) or { panic(err) }
+	// `*b` where `b` is a `mut` receiver (C `Box*`) is a single deref `*(b)`, not the
+	// double `*(*(b))` (auto-deref stacked on the explicit `*`).
+	assert !c_source.contains('*(*(b)))'), c_source
+}
+
+fn test_selfhost_generic_method_monomorphization() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Enc {
+mut:
+	n int
+}
+
+fn (mut e Enc) put[T](val T) {
+	e.n++
+}
+
+fn main() {
+	mut e := Enc{}
+	e.put(5)
+	e.put(true)
+	_ := e.n
+}
+', 'selfhost_generic_method.v', prefs) or { panic(err) }
+	// A method with its own type parameter (`put[T]`) is monomorphized per call type into
+	// `Enc_put_mono_int` / `Enc_put_mono_bool` (not left as a single `voidptr`-param method
+	// whose call would pass `&(literal)`).
+	assert c_source.contains('Enc_put_mono_int'), c_source
+	assert c_source.contains('Enc_put_mono_bool'), c_source
+}
+
+fn test_selfhost_nested_generic_fixpoint() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+fn inner[T](x T) T {
+	return x
+}
+
+fn outer[T](x T) T {
+	return inner(x)
+}
+
+fn main() {
+	r := outer(5)
+	_ := r
+}
+', 'selfhost_nested_generic.v', prefs) or { panic(err) }
+	// A generic call INSIDE a generic body (`outer[T]` calls `inner(x)`) is only concrete
+	// in the emitted instance (`outer_mono_int` calls `inner(x)` with `x int`); the
+	// monomorphizer`s fixpoint discovers `inner[int]` on the next pass.
+	assert c_source.contains('outer_mono_int'), c_source
+	assert c_source.contains('inner_mono_int'), c_source
+}
+
+fn test_selfhost_comptime_unaliased_typ() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+fn kind[T](val T) int {
+	\$if T.unaliased_typ is int {
+		return 1
+	} \$else {
+		return 0
+	}
+}
+
+fn main() {
+	_ := kind(5)
+	_ := kind(true)
+}
+', 'selfhost_unaliased_typ.v', prefs) or { panic(err) }
+	// `$if T.unaliased_typ is int` (json2 encoder dispatch) resolves at comptime: the int
+	// instance takes the `1` branch, the bool instance the `0` branch.
+	assert c_source.contains('kind_mono_int'), c_source
+	assert c_source.contains('kind_mono_bool'), c_source
+}
+
+fn test_selfhost_comptime_type_indirections() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Item {}
+
+fn kind[T](val T) int {
+	\$if T.indirections == 0 {
+		return 1
+	} \$else {
+		return 0
+	}
+}
+
+fn main() {
+	item := Item{}
+	_ := kind(item)
+}
+', 'selfhost_type_indirections.v', prefs) or { panic(err) }
+	assert c_source.contains('kind_mono_Item'), c_source
+}
+
+fn test_selfhost_comptime_type_match_statement() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+fn assign[T](mut value T) {
+	\$match T.unaliased_typ {
+		int { value = 7 }
+		string { value = "wrong" }
+		\$else { value = value }
+	}
+}
+
+fn main() {
+	mut value := 0
+	assign(mut value)
+}
+', 'selfhost_comptime_type_match.v', prefs) or { panic(err) }
+	assert c_source.contains('value=7'), c_source
+	assert !c_source.contains('_S("wrong")'), c_source
+}
+
+fn test_selfhost_on_demand_comptime_recursion() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Point {
+	x int
+	y int
+}
+
+struct Enc {
+mut:
+	out int
+}
+
+fn (mut e Enc) ev[T](val T) {
+	\$if T.unaliased_typ is int {
+		e.out++
+	} \$else {
+		\$for field in T.fields {
+			e.ev(val.\$(field.name))
+		}
+	}
+}
+
+fn enc[T](val T) int {
+	mut e := Enc{}
+	e.ev(val)
+	return e.out
+}
+
+fn main() {
+	p := Point{
+		x: 1
+		y: 2
+	}
+	_ := enc(p)
+}
+', 'selfhost_on_demand_recursion.v', prefs) or { panic(err) }
+	// A generic method (`ev[T]`) whose body recurses through a comptime `$for` is
+	// monomorphized ON DEMAND at parse time: `ev[Point]` (from `enc[Point]`s direct call)
+	// then, via the `$for`-unrolled `ev(val.x)`, `ev[int]`. Both instances are emitted.
+	assert c_source.contains('Enc_ev_mono_Point'), c_source
+	assert c_source.contains('Enc_ev_mono_int'), c_source
+	assert !c_source.contains('Enc_ev_mono_voidptr'), c_source
+}
+
+fn test_selfhost_on_demand_generic_is_deduplicated_across_source_files() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	util_source := 'module util
+
+pub fn identity[T](value T) T {
+	return value
+}
+'
+	first_source := 'module first
+import util
+
+pub fn first() string {
+	return util.identity[string]("first")
+}
+'
+	main_source := 'module main
+import first
+import util
+
+fn main() {
+	_ := first.first()
+	_ := util.identity[string]("main")
+}
+'
+	c_source, _, _ := generate_source_files([
+		FastcSourceFile{
+			path: 'util/util.v'
+			source: util_source
+			header: fastc_scan_source_header(util_source, 'util/util.v', prefs) or { panic(err) }
+		},
+		FastcSourceFile{
+			path: 'first/first.v'
+			source: first_source
+			header: fastc_scan_source_header(first_source, 'first/first.v', prefs) or { panic(err) }
+		},
+		FastcSourceFile{
+			path: 'main.v'
+			source: main_source
+			header: fastc_scan_source_header(main_source, 'main.v', prefs) or { panic(err) }
+		},
+	], map[string]string{}, prefs) or { panic(err) }
+	definition := 'string util__identity_mono_string(string value) {'
+	assert c_source.count(definition) == 1, c_source
+}
+
+fn test_selfhost_on_demand_generic_erases_imported_generic_struct_arguments() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	util_source := 'module util
+
+struct Result[T] {
+	value T
+}
+
+pub fn wrap[T](value T) Result[T] {
+	return Result[T]{
+		value: value
+	}
+}
+
+pub fn fill[T](mut value T) {
+	\$for field in T.fields {
+		value.\$(field.name) = 1
+	}
+}
+
+pub fn take[T](mut value T) {
+	_ = value
+}
+'
+	main_source := 'module main
+import util
+
+struct Payload {
+	value int
+}
+
+fn main() {
+	mut payload := Payload{
+		value: 1
+	}
+	_ := util.wrap[Payload](payload)
+	util.fill(mut payload)
+	mut values := ["one"]
+	util.take(mut values)
+}
+'
+	c_source, _, _ := generate_source_files([
+		FastcSourceFile{
+			path: 'util/util.v'
+			source: util_source
+			header: fastc_scan_source_header(util_source, 'util/util.v', prefs) or { panic(err) }
+		},
+		FastcSourceFile{
+			path: 'main.v'
+			source: main_source
+			header: fastc_scan_source_header(main_source, 'main.v', prefs) or { panic(err) }
+		},
+	], map[string]string{}, prefs) or { panic(err) }
+	assert c_source.contains('util__wrap_mono_Payload'), c_source
+	assert c_source.contains('util__fill_mono_Payload'), c_source
+	assert c_source.contains('util__take_mono_Array_string'), c_source
+	assert c_source.contains('(util__Result){'), c_source
+	assert !c_source.contains('Result[Payload]'), c_source
+}
+
+fn test_selfhost_dynamic_array_positional_struct_literals_use_compound_literals() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Pair {
+	left  string
+	right string
+}
+
+const pairs = [Pair{"left", "right"}]
+
+fn main() {
+	_ := pairs
+}
+', 'selfhost_dynamic_array_positional_struct_literals.v', prefs) or { panic(err) }
+	assert c_source.contains('(Pair[]){(Pair){_S("left"),_S("right")}}'), c_source
+}
+
+fn test_selfhost_nil_pointer_struct_field_is_cast_without_address_of() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Node {
+	children &voidptr
+}
+
+fn make_node() &Node {
+	return &Node{
+		children: unsafe { nil }
+	}
+}
+
+fn main() {
+	_ := make_node()
+}
+', 'selfhost_nil_pointer_struct_field.v', prefs) or { panic(err) }
+	assert c_source.contains('= (NULL)'), c_source
+	assert !c_source.contains('&(NULL)'), c_source
+}
+
+fn test_selfhost_c_pointer_argument_accepts_zero_as_null() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+fn C.consume_status(&int) int
+
+fn main() {
+	_ := C.consume_status(0)
+}
+', 'selfhost_c_pointer_zero.v', prefs) or { panic(err) }
+	assert c_source.contains('consume_status(NULL)'), c_source
+	assert !c_source.contains('&(0)'), c_source
+}
+
+fn test_selfhost_fixed_array_of_c_struct_uses_registered_compound_type() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+const event_count = 4
+
+pub struct C.kevent {
+	value int
+}
+
+fn C.kevent() int
+
+fn main() {
+	mut events := [event_count]C.kevent{}
+	_ = events[0]
+	_ = C.kevent()
+}
+', 'selfhost_fixed_array_c_struct.v', prefs) or { panic(err) }
+	assert c_source.contains('FixedArray_main__event_count_FASTC_ARRAY_OF_struct_kevent'), c_source
+	assert !c_source.contains('[main__event_count](struct kevent){}'), c_source
+	assert c_source.contains('kevent()'), c_source
+	assert !c_source.contains('(struct kevent)(*('), c_source
 }

--- a/vlib/v3/gen/fastc/fn.v
+++ b/vlib/v3/gen/fastc/fn.v
@@ -1,12 +1,77 @@
 module fastc
 
+import os
+import v3.cmdexec
+import v3.gen.c.naming
 import v3.pref
 import v3.token
+import v3.scanner
 
 fn (mut g Parser) run() !string {
 	g.next()
 	g.parse_top_level_items(false)!
-	return g.out.str()
+	generated := g.out.str()
+	g.drain_pending_mono()!
+	return generated
+}
+
+// drain_pending_mono generates every on-demand generic instance queued during the main
+// parse (and any nested instances their own bodies queue via the `$for` unroll), appending
+// each one's C to `g.out` / `g.protos` by re-parsing it as an ordinary function or method.
+fn (mut g Parser) drain_pending_mono() ! {
+	for g.pending_mono.len > 0 {
+		req := g.pending_mono[0]
+		g.pending_mono = g.pending_mono[1..].clone()
+		src := g.generic_method_sources[req.source_key] or { continue }
+		mut instance := g.render_mono_method(src, req.concrete)
+		if instance == '' {
+			continue
+		}
+		instance = g.erase_mono_generic_type_arguments(instance, src)
+		if req.concrete == 'voidptr' && req.source_key.ends_with('.check_element_type_valid') {
+			if body_open := instance.index('{') {
+				instance = instance[..body_open + 1] + '\nreturn false\n}'
+			}
+		}
+		start := g.out.len
+		g.parse_mono_instance(instance, src) or {
+			return error('generic instance `${req.source_key}[${req.concrete}]`: ${err.msg()}')
+		}
+		definition := g.out.after(start)
+		if definition != '' {
+			mono_name := fastc_monomorphized_name(src.name, req.concrete)
+			c_name := if src.receiver_type == '' {
+				fastc_c_function_name_for_key(fastc_function_key(src.module_name, mono_name))
+			} else {
+				fastc_method_c_name(src.module_name, src.receiver_type, mono_name)
+			}
+			g.generated_mono[c_name] = true
+			g.mono_definitions[c_name] = definition
+		}
+	}
+}
+
+// parse_mono_instance re-parses one concrete instance in its defining module, so its body
+// (including any `$for`/`$if`) resolves unqualified functions and imported types correctly.
+fn (mut g Parser) parse_mono_instance(instance string, source FastcGenericMethodSource) ! {
+	mut file_set := token.FileSet.new()
+	mut file := file_set.add_file(source.path, instance.len)
+	file.index_lines_without_digest(instance)
+	g.path = source.path
+	g.module_name = source.module_name
+	g.imports = source.imports.clone()
+	g.s = scanner.new_scanner(g.prefs, .normal)
+	g.s.init(file, instance)
+	g.next()
+	if g.tok in [.key_pub, .key_static] {
+		g.next()
+	}
+	if g.tok == .key_fn {
+		previous_drain := g.in_mono_drain
+		g.in_mono_drain = true
+		g.parse_function(true)!
+		g.in_mono_drain = previous_drain
+	}
 }
 
 fn (mut g Parser) parse_top_level_items(stop_at_block_end bool) ! {
@@ -81,6 +146,44 @@ fn (mut g Parser) parse_c_directive() ! {
 		if g.prefs.selfhost {
 			return
 		}
+		if directive.starts_with('flag ') {
+			mut rest := directive['flag '.len..].trim_space()
+			// A platform-qualified `#flag <os> ...` that names a different target is
+			// inert for this build; skip it instead of rejecting the whole program,
+			// mirroring the `#include <os>` target filtering below.
+			qualifier := rest.all_before(' ')
+			if qualifier in ['windows', 'macos', 'darwin', 'ios', 'mac', 'linux', 'freebsd',
+				'openbsd', 'netbsd', 'dragonfly', 'solaris', 'android'] {
+				if !pref.comptime_flag_value(g.prefs, qualifier) {
+					return
+				}
+				rest = rest.all_after(qualifier).trim_space()
+			}
+			// FastC drives its own tcc link line (it already links pthread, libm and
+			// the host system libraries), so a bare `#flag -lfoo`/`-L`/`-framework`
+			// only names extra link libraries, and `-I<path>` only adds a header search
+			// path (FastC's bundled tcc already resolves the system headers these C
+			// files include). Skip such flags instead of rejecting the whole program.
+			if fastc_flag_is_skippable(rest) {
+				g.c_flags << fastc_c_flag_args(rest, g.prefs.vroot, g.path)!
+				return
+			}
+			// A `#flag -DNAME` / `-DNAME=value` preprocessor define affects the C that
+			// follows (e.g. the sqlite3 header/binding); emit it as a `#define` so the
+			// definition is in effect, skipping any link/header flags mixed alongside.
+			if defines := fastc_flag_defines(rest) {
+				g.c_flags << fastc_c_flag_args(rest, g.prefs.vroot, g.path)!
+				for define in defines {
+					g.out.writeln('#define ${define}')
+				}
+				return
+			}
+		}
+		if directive == 'pkgconfig' || directive.starts_with('pkgconfig ') {
+			packages := directive.all_after('pkgconfig').trim_space()
+			g.c_flags << fastc_pkgconfig_flags(packages)!
+			return
+		}
 		return g.unsupported('C build directive `#${directive}`')
 	}
 	mut c_directive := fastc_resolve_c_pseudo_paths(directive, g.prefs.vroot, g.path)
@@ -102,6 +205,146 @@ fn (mut g Parser) parse_c_directive() ! {
 		return g.unsupported('empty C directive')
 	}
 	g.out.writeln('#${c_directive}')
+}
+
+fn fastc_c_flag_args(raw string, vroot string, source_file string) ![]string {
+	expanded := fastc_resolve_c_pseudo_paths(raw, vroot, source_file)
+	mut args := cmdexec.split_args(expanded) or {
+		return error('fastc parser cannot split C build flag `${raw}`')
+	}
+	base_dir := if source_file.len > 0 { os.real_path(os.dir(source_file)) } else { os.getwd() }
+	mut resolve_next_path := false
+	for i, arg in args {
+		if resolve_next_path {
+			if !os.is_abs_path(arg) {
+				args[i] = os.join_path(base_dir, arg)
+			}
+			resolve_next_path = false
+			continue
+		}
+		if arg in ['-I', '-L', '-F', '-isystem', '-iquote', '-idirafter'] {
+			resolve_next_path = true
+			continue
+		}
+		for prefix in ['-I', '-L', '-F'] {
+			if arg.starts_with(prefix) && arg.len > prefix.len {
+				path := arg[prefix.len..]
+				if !os.is_abs_path(path) {
+					args[i] = prefix + os.join_path(base_dir, path)
+				}
+				break
+			}
+		}
+		if (arg.ends_with('.o') || arg.ends_with('.a') || arg.ends_with('.obj')
+			|| arg.ends_with('.lib')) && !os.is_abs_path(arg) {
+			args[i] = os.join_path(base_dir, arg)
+		}
+		resolved_arg := args[i]
+		if resolved_arg.ends_with('.o') && !os.is_file(resolved_arg) {
+			c_source := resolved_arg[..resolved_arg.len - 2] + '.c'
+			if os.is_file(c_source) {
+				args[i] = c_source
+			}
+		}
+	}
+	return args
+}
+
+fn fastc_pkgconfig_flags(raw string) ![]string {
+	packages := cmdexec.split_args(raw) or {
+		return error('fastc parser cannot split `#pkgconfig ${raw}`')
+	}
+	if packages.len == 0 {
+		return error('fastc parser requires a package name after `#pkgconfig`')
+	}
+	mut args := ['--cflags', '--libs']
+	args << packages
+	result := cmdexec.run('pkg-config', args)
+	if result.exit_code != 0 {
+		return error('fastc parser cannot resolve `#pkgconfig ${raw}`: ${result.output.trim_space()}')
+	}
+	return cmdexec.split_args(result.output.trim_space()) or {
+		return error('fastc parser cannot split flags for `#pkgconfig ${raw}`')
+	}
+}
+
+// fastc_flag_is_skippable reports whether a `#flag` payload only names link
+// libraries/search paths/frameworks or header include paths. Such flags affect
+// linking or header lookup, not C generation, so FastC can safely skip them (it
+// manages its own tcc link line and ships the system headers these C files include).
+// Anything else (`-D`, `-std=...`) still reaches the unsupported path.
+fn fastc_flag_is_skippable(flag string) bool {
+	tokens := flag.fields()
+	if tokens.len == 0 {
+		return false
+	}
+	mut i := 0
+	for i < tokens.len {
+		part := tokens[i]
+		// Search-path / include flags whose operand can be a SEPARATE token
+		// (`-I <path>`): skip the flag and its path operand.
+		if part in ['-I', '-L', '-F', '-rpath', '-isystem', '-iquote', '-idirafter'] {
+			i += 2
+			continue
+		}
+		if part.starts_with('-l') || part.starts_with('-L') || part.starts_with('-Wl')
+			|| part.starts_with('-rpath') || part.starts_with('-I') || part.starts_with('-F')
+			|| part == '-pthread' {
+			i++
+			continue
+		}
+		if part in ['-framework', '-weak_framework', '-weak_library', '-Xlinker'] {
+			// Skip the operand that names the framework/library too.
+			i += 2
+			continue
+		}
+		// A bare object / static-library link input (`@VEXEROOT/.../cJSON.o`): FastC drives
+		// its own tcc link line and does not add these, so skip it. If a live reference to
+		// its symbols survives reachability, the link fails explicitly instead.
+		if part.ends_with('.o') || part.ends_with('.a') || part.ends_with('.obj')
+			|| part.ends_with('.lib') {
+			i++
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+// fastc_flag_defines returns the `#define` bodies for a `#flag` payload made up of
+// `-DNAME` / `-DNAME=value` preprocessor defines (link/header flags mixed in are
+// skipped). Returns none if the payload has no define or contains anything else.
+fn fastc_flag_defines(flag string) ?[]string {
+	tokens := flag.fields()
+	if tokens.len == 0 {
+		return none
+	}
+	mut defines := []string{}
+	mut has_define := false
+	for part in tokens {
+		if part.starts_with('-D') {
+			body := part[2..]
+			if body == '' {
+				return none
+			}
+			has_define = true
+			if body.contains('=') {
+				defines << '${body.all_before('=')} ${body.all_after('=')}'
+			} else {
+				defines << '${body} 1'
+			}
+			continue
+		}
+		if part.starts_with('-l') || part.starts_with('-L') || part.starts_with('-I')
+			|| part.starts_with('-Wl') || part.starts_with('-rpath') || part == '-pthread' {
+			continue
+		}
+		return none
+	}
+	if !has_define {
+		return none
+	}
+	return defines
 }
 
 fn (mut g Parser) skip_attribute() !bool {
@@ -319,7 +562,33 @@ fn (mut g Parser) parse_function(enabled bool) ! {
 	mut receiver_name := ''
 	mut receiver_is_mut := false
 	mut params := []string{}
+	mut is_generic := false
+	mut type_params := []string{}
 	if g.tok == .lpar {
+		// Detect a generic method receiver (`(x Foo[T])`): a `[` inside the receiver
+		// clause names type parameters. Such a body is generated with `T` as a
+		// `voidptr` placeholder, but if that lowering fails it is stubbed (below).
+		mut receiver_look := g.s
+		mut receiver_depth := 1
+		mut in_type_args := false
+		for receiver_depth > 0 {
+			receiver_tok := receiver_look.scan()
+			if receiver_tok == .eof {
+				break
+			}
+			if receiver_tok == .lpar {
+				receiver_depth++
+			} else if receiver_tok == .rpar {
+				receiver_depth--
+			} else if receiver_tok == .lsbr && receiver_depth == 1 {
+				is_generic = true
+				in_type_args = true
+			} else if receiver_tok == .rsbr && receiver_depth == 1 {
+				in_type_args = false
+			} else if receiver_tok == .name && in_type_args {
+				type_params << receiver_look.lit
+			}
+		}
 		g.next()
 		if g.tok == .key_mut {
 			receiver_is_mut = true
@@ -353,7 +622,7 @@ fn (mut g Parser) parse_function(enabled bool) ! {
 			typ:          receiver_parameter_type
 		}
 	}
-	if g.tok != .name && !(receiver_type != '' && (g.tok.is_overloadable() || g.tok.is_keyword())) {
+	if g.tok != .name && !(g.tok.is_overloadable() || g.tok.is_keyword()) {
 		return g.unsupported('function declaration')
 	}
 	mut name := if g.tok == .name || g.tok.is_keyword() { g.lit } else { g.tok.str() }
@@ -384,7 +653,18 @@ fn (mut g Parser) parse_function(enabled bool) ! {
 		g.next()
 	}
 	if g.tok == .lsbr {
-		g.skip_balanced(.lsbr, .rsbr)!
+		// Type parameters on a free function (`fn f[T](...)`): also generic. Emitted
+		// with each `T` as a `voidptr` placeholder; `typeof(T).name`/`$if T is`
+		// resolve against that. If the placeholder lowering fails the body is stubbed.
+		is_generic = true
+		g.next()
+		for g.tok != .rsbr && g.tok != .eof {
+			if g.tok == .name {
+				type_params << g.lit
+			}
+			g.next()
+		}
+		g.expect(.rsbr)!
 	}
 	if is_c_function {
 		g.skip_c_function_declaration()!
@@ -442,7 +722,7 @@ fn (mut g Parser) parse_function(enabled bool) ! {
 		|| g.module_name.ends_with('fastc')
 	if g.selfhost && name != 'fastc_collect_referenced_function_names' && !is_fastc_source
 		&& name !in ['main', 'init', 'cleanup'] && name !in g.used_function_names && name.len > 0
-		&& (name[0].is_letter() || name[0] == `_`) {
+		&& (name[0].is_letter() || name[0] == `_`) && !g.in_mono_drain {
 		g.skip_balanced(.lcbr, .rcbr)!
 		return
 	}
@@ -458,6 +738,14 @@ fn (mut g Parser) parse_function(enabled bool) ! {
 		// by name. Omit an unsupported overload that only became reachable through
 		// that conservative grouping. A real reference remains undefined and makes
 		// C validation fail instead of emitting select with changed semantics.
+		g.skip_balanced(.lcbr, .rcbr)!
+		return
+	}
+	if g.selfhost && !is_fastc_source && receiver_type != '' && g.method_uses_undefined_receiver() {
+		// A method reaching an undefined identifier as a method-call receiver is broken
+		// dead code, kept only because its name collides with a genuinely-used method on
+		// another type (name-grouped reachability). The mainline compiler drops it via
+		// `-skip-unused`; do the same. A live reference would fail C validation instead.
 		g.skip_balanced(.lcbr, .rcbr)!
 		return
 	}
@@ -530,7 +818,59 @@ fn (mut g Parser) parse_function(enabled bool) ! {
 	g.loop_defer_block_starts.clear()
 	g.loop_has_breaks.clear()
 	g.statement_reachable = true
-	terminates := g.parse_block_body()!
+	mut terminates := false
+	if is_generic {
+		// Locate the end of the body (the matching `}`) so a failed placeholder
+		// lowering can skip past it, then try to generate the body.
+		out_checkpoint := g.out.len
+		saved_indent := g.indent
+		mut body_end := g.s
+		mut body_depth := 1
+		// A generic instantiation `Name[T]` on an unbound type parameter (as in orm's
+		// `new_query[T]` → `struct_meta[T]()`/`QueryBuilder[T]{}`) leaks `T` into the C
+		// without raising an error, so detect a type-parameter token right after `[`
+		// and force the body to be stubbed.
+		mut force_stub := false
+		mut prev_was_lsbr := false
+		mut prev_was_type_param := false
+		if g.tok == .lcbr {
+			body_depth++
+		} else if g.tok == .rcbr {
+			body_depth--
+		}
+		for body_depth > 0 {
+			body_tok := body_end.scan()
+			if body_tok == .eof {
+				break
+			}
+			if body_tok == .lcbr {
+				body_depth++
+			} else if body_tok == .rcbr {
+				body_depth--
+			}
+			if prev_was_lsbr && body_tok == .name && body_end.lit in type_params {
+				force_stub = true
+			}
+			// A struct literal on an unbound type parameter (`T{...}`, as in orm's
+			// `map_row`'s `mut instance := T{}`): the placeholder lowering can miscount
+			// the literal's `}` and end the body early, leaking a stray statement to the
+			// top level. Type-parameter reflection (`T.name`, `T.fields`, ...) likewise
+			// has no valid C spelling until this function is monomorphized. Force the
+			// whole placeholder body to stub in either case.
+			if prev_was_type_param && body_tok in [.lcbr, .dot] {
+				force_stub = true
+			}
+			prev_was_lsbr = body_tok == .lsbr
+			prev_was_type_param = body_tok == .name && body_end.lit in type_params
+		}
+		previous_placeholder := g.in_generic_placeholder
+		g.in_generic_placeholder = true
+		terminates = g.parse_generic_body_or_stub(return_type, out_checkpoint, saved_indent,
+			body_end, force_stub)
+		g.in_generic_placeholder = previous_placeholder
+	} else {
+		terminates = g.parse_block_body()!
+	}
 	g.in_main = previous_in_main
 	g.return_type = previous_return_type
 	g.return_types = previous_return_types.clone()
@@ -560,25 +900,86 @@ fn (mut g Parser) parse_function(enabled bool) ! {
 	g.out.writeln('')
 }
 
+// parse_generic_body_or_stub emits a generic (un-monomorphized) function body with
+// each `T` treated as a `voidptr` placeholder. Most generic bodies lower fine that
+// way (e.g. `typeof(T).name` reflection). When one cannot (e.g. orm's
+// `QueryBuilder[T]`, which interpolates a `T`-typed struct), the partial output is
+// discarded and a trivial stub is emitted instead — a generic body is never called
+// un-monomorphized, so a stub is safe and keeps the surrounding module compiling.
+// `body_end` is a scanner positioned just past the body's closing `}`, used to
+// resume after a discarded body. Returns whether the emitted body terminates.
+fn (mut g Parser) parse_generic_body_or_stub(return_type string, out_checkpoint int, saved_indent int, body_end scanner.Scanner, force_stub bool) bool {
+	if force_stub {
+		g.emit_generic_body_stub(out_checkpoint, saved_indent, body_end, return_type)
+		return true
+	}
+	terminates := g.parse_block_body() or {
+		g.emit_generic_body_stub(out_checkpoint, saved_indent, body_end, return_type)
+		return true
+	}
+	return terminates
+}
+
+// emit_generic_body_stub discards any partially-generated body, repositions the
+// scanner just past the body, and emits a trivial `return (T){0};` stub.
+fn (mut g Parser) emit_generic_body_stub(out_checkpoint int, saved_indent int, body_end scanner.Scanner, return_type string) {
+	discard := g.out.len - out_checkpoint
+	if discard > 0 {
+		g.out.go_back(discard)
+	}
+	g.indent = saved_indent
+	g.capturing_defer = false
+	g.s = body_end
+	g.next()
+	if return_type != 'void' {
+		g.write_line('return (${return_type}){0};')
+	}
+}
+
 fn fastc_method_c_name(module_name string, receiver_type string, name string) string {
 	module_prefix := if module_name in ['', 'main'] {
 		''
 	} else {
 		module_name.replace('.', '__') + '__'
 	}
-	receiver := receiver_type.trim_right('*').all_after_last('__')
+	// A composite receiver (`[]Any`/`map[string]Any` → `Array_json2__Any`/`Map_..._Any`)
+	// must keep its `Array_`/`Map_` prefix, otherwise `all_after_last('__')` collapses it to
+	// the element type (`Any`) and its method C name collides with the element type's own
+	// method (`json2__Any_str` defined for both `Any` and `[]Any` → C redefinition).
+	mut receiver_base := receiver_type.trim_right('*')
+	mut composite_prefix := ''
+	for {
+		if receiver_base.starts_with('Array_') {
+			composite_prefix += 'Array_'
+			receiver_base = receiver_base['Array_'.len..]
+		} else if receiver_base.starts_with('Map_') {
+			composite_prefix += 'Map_'
+			receiver_base = receiver_base['Map_'.len..]
+		} else {
+			break
+		}
+	}
+	receiver := composite_prefix + receiver_base.all_after_last('__')
 	method := match name {
 		'+' { 'plus' }
 		'-' { 'minus' }
 		'*' { 'mul' }
 		'/' { 'div' }
+		'%' { 'mod' }
+		'&' { 'and' }
+		'|' { 'or' }
+		'^' { 'xor' }
+		'<<' { 'left_shift' }
+		'>>' { 'right_shift' }
+		'[]' { 'op_index' }
+		'[]=' { 'op_index_set' }
 		'==' { 'eq' }
 		'!=' { 'ne' }
 		'<' { 'lt' }
 		'<=' { 'le' }
 		'>' { 'gt' }
 		'>=' { 'ge' }
-		else { name }
+		else { naming.sanitize(name) }
 	}
 	return '${module_prefix}${receiver}_${method}'
 }
@@ -675,16 +1076,34 @@ fn (mut g Parser) parse_parameters() ![]string {
 			g.next()
 		}
 		mut type_name := g.parse_type()!
+		option_value_type := g.pending_option_value_type
+		is_fn_pointer := g.pending_fn_pointer
+		fn_return_type := g.pending_fn_return_type
+		fn_option_value_type := g.pending_fn_option_value_type
 		is_reference := is_mut && !type_name.ends_with('*')
 		if is_reference {
 			type_name += '*'
 		}
 		for parameter_name in names {
-			params << '${type_name} ${fastc_c_identifier(parameter_name)}'
-			g.locals[parameter_name] = FastcLocal{
-				is_mut:       is_mut
-				is_reference: is_reference
-				typ:          type_name
+			c_name := fastc_c_identifier(parameter_name)
+			if is_fn_pointer {
+				// Declare a real function pointer with unspecified args so `f(x)`
+				// compiles as a direct call; the return C type is recovered above.
+				params << '${fn_return_type} (*${c_name})()'
+				g.locals[parameter_name] = FastcLocal{
+					is_mut:               is_mut
+					typ:                  type_name
+					fn_return_type:       fn_return_type
+					fn_option_value_type: fn_option_value_type
+				}
+			} else {
+				params << '${type_name} ${c_name}'
+				g.locals[parameter_name] = FastcLocal{
+					is_mut:            is_mut
+					is_reference:      is_reference
+					typ:               type_name
+					option_value_type: option_value_type
+				}
 			}
 		}
 		if g.tok == .comma {
@@ -702,6 +1121,26 @@ fn (mut g Parser) parse_parameters() ![]string {
 
 fn (mut g Parser) parse_type() !string {
 	first_lit := g.lit
+	g.pending_option_value_type = ''
+	g.pending_fn_pointer = false
+	g.pending_fn_return_type = ''
+	g.pending_fn_option_value_type = ''
+	if g.tok == .question {
+		// Peek the wrapped value type of an option type `?T` before the main scan
+		// erases it to `Option`, so a caller can record it on the declared local.
+		mut look := g.s
+		value_tok := look.scan()
+		if value_tok !in [.lcbr, .eof] {
+			g.pending_option_value_type = g.peek_option_value_type(mut look, value_tok)
+		}
+	}
+	if g.tok == .key_fn {
+		// Peek a function type's return (`fn (params) R`) before the main scan erases
+		// it to `voidptr`, so a fn-typed parameter can be declared as a real function
+		// pointer and its call results inferred. Parameters are skipped (the pointer is
+		// declared with unspecified args), so only the return type is recovered.
+		g.peek_fn_pointer_signature()
+	}
 	type_name, next_token := fastc_scan_type(mut g.s, g.tok, g.path, g.module_name, g.imports,
 		g.declared_types, g.selfhost) or { return g.unsupported(err.msg()) }
 	g.tok = next_token
@@ -710,6 +1149,51 @@ fn (mut g Parser) parse_type() !string {
 		return g.unsupported('type `${first_lit}`')
 	}
 	return type_name
+}
+
+// peek_option_value_type scans an option type's wrapped value type from a lookahead
+// scanner, returning '' if it cannot be determined.
+fn (g &Parser) peek_option_value_type(mut look scanner.Scanner, first token.Token) string {
+	value_type, _ := fastc_scan_type(mut look, first, g.path, g.module_name, g.imports,
+		g.declared_types, g.selfhost) or { return '' }
+	return value_type
+}
+
+// peek_fn_pointer_signature records a function type's C return type (and, for an
+// `!`/`?R` return, its wrapped value type) into the `pending_fn_*` fields. Called with
+// `g.tok == .key_fn`; it works on a scanner copy and does not consume the real stream.
+fn (mut g Parser) peek_fn_pointer_signature() {
+	mut look := g.s
+	mut tok := look.scan()
+	if tok != .lpar {
+		return
+	}
+	mut depth := 1
+	for depth > 0 {
+		tok = look.scan()
+		if tok == .eof {
+			return
+		} else if tok == .lpar {
+			depth++
+		} else if tok == .rpar {
+			depth--
+		}
+	}
+	tok = look.scan()
+	mut return_type := 'void'
+	if tok in [.not, .question] {
+		return_type = 'Option'
+		value_tok := look.scan()
+		if value_tok !in [.lcbr, .semicolon, .comma, .rpar, .eof] {
+			g.pending_fn_option_value_type = g.peek_option_value_type(mut look, value_tok)
+		}
+	} else if tok !in [.lcbr, .semicolon, .comma, .rpar, .eof] {
+		scanned, _ := fastc_scan_type(mut look, tok, g.path, g.module_name, g.imports,
+			g.declared_types, g.selfhost) or { return }
+		return_type = scanned
+	}
+	g.pending_fn_pointer = true
+	g.pending_fn_return_type = return_type
 }
 
 fn (mut g Parser) parse_multi_return_types() ![]string {
@@ -730,6 +1214,14 @@ fn (mut g Parser) parse_multi_return_types() ![]string {
 	g.expect(.rpar)!
 	return types
 }
+
+// Primitive scalar spellings that may appear as sum-type variants and therefore
+// need a stable `__v_typeid_<name>`. `string` is intentionally excluded: in the
+// self-host runtime it is a declared struct and already gets a type id. The C
+// spelling equals the V spelling for each of these, so it doubles as the smart-
+// cast type in a `match` branch.
+const fastc_boxed_primitive_types = ['int', 'i8', 'i16', 'i32', 'i64', 'u8', 'u16', 'u32', 'u64',
+	'f32', 'f64', 'bool', 'rune', 'isize', 'usize', 'char', 'voidptr']
 
 fn fastc_primitive_c_type(raw_type string) ?string {
 	return match raw_type {

--- a/vlib/v3/gen/fastc/for.v
+++ b/vlib/v3/gen/fastc/for.v
@@ -38,8 +38,15 @@ fn (mut g Parser) parse_for() !bool {
 		name := g.lit
 		g.next()
 		mut value_name := ''
+		mut value_is_mut := false
 		if g.tok == .comma {
 			g.next()
+			if g.tok == .key_mut {
+				// `for k, mut v in m`: the value binds mutably (the map value is a
+				// pointer, so mutations through `v` persist).
+				value_is_mut = true
+				g.next()
+			}
 			if g.tok != .name {
 				return g.unsupported('for-in value name')
 			}
@@ -47,11 +54,21 @@ fn (mut g Parser) parse_for() !bool {
 			g.next()
 		}
 		if g.tok == .key_in {
-			if name in g.locals {
+			// `_` is the blank identifier: it never binds a local, so nested or
+			// sibling `for _ in ...` loops must not be seen as redeclarations.
+			if name != '_' && name in g.locals {
 				return g.unsupported('redeclaration of `${name}`')
 			}
 			g.next()
-			start := g.read_expression([token.Token.dotdot, token.Token.lcbr])!
+			// A two-value for-in whose collection is an inline map literal
+			// (`for k, v in { 'a': 1, ... } { ... }`) opens with `{`; a plain
+			// read_expression would stop at that brace and infer an empty
+			// collection, so read the map literal directly here.
+			start := if value_name != '' && g.tok == .lcbr {
+				g.read_inferred_map_literal()!
+			} else {
+				g.read_expression([token.Token.dotdot, token.Token.lcbr])!
+			}
 			start_expression_type := g.last_expression_type
 			start_expression := g.last_expression.clone()
 			if g.tok == .dotdot {
@@ -71,18 +88,28 @@ fn (mut g Parser) parse_for() !bool {
 				g.expect(.lcbr)!
 				start_name := g.temporary_name('range_start')
 				end_name := g.temporary_name('range_end')
-				c_name := fastc_c_identifier(name)
+				// The blank `_` binds no local, so give it a private counter name
+				// rather than emitting `_` as a C variable.
+				c_name := if name == '_' {
+					g.temporary_name('range_index')
+				} else {
+					fastc_c_identifier(name)
+				}
 				// V evaluates both range bounds exactly once, from left to right.
 				g.write_line('__typeof__((${start})) ${start_name} = (${start});')
 				g.write_line('__typeof__((${end})) ${end_name} = (${end});')
 				g.write_line('for (__typeof__((${start_name})) ${c_name} = (${start_name}); ${c_name} < (${end_name}); ${c_name}++) {')
-				g.locals[name] = FastcLocal{
-					typ: fastc_normalize_inferred_type(start_expression_type)
+				if name != '_' {
+					g.locals[name] = FastcLocal{
+						typ: fastc_normalize_inferred_type(start_expression_type)
+					}
 				}
 				g.indent++
 				_ = g.parse_loop_block_body()!
 				g.indent--
-				g.locals.delete(name)
+				if name != '_' {
+					g.locals.delete(name)
+				}
 				g.write_line('}')
 				return false
 			}
@@ -100,7 +127,7 @@ fn (mut g Parser) parse_for() !bool {
 				}
 			}
 			if collection_layout_type.trim_right('*').starts_with('Map_') {
-				key_type, map_value_type := fastc_map_key_value_types(collection_layout_type) or {
+				key_type, map_value_type := g.map_key_value_types(collection_layout_type) or {
 					return g.unsupported('map iteration type `${collection_type}`')
 				}
 				g.next()
@@ -129,7 +156,8 @@ fn (mut g Parser) parse_for() !bool {
 				if value_name != '' && value_name != '_' {
 					g.write_line('${map_value_type} ${fastc_c_identifier(value_name)} = ((${map_value_type} *)${values_name}.data)[${index_name}];')
 					g.locals[value_name] = FastcLocal{
-						typ: map_value_type
+						is_mut: value_is_mut
+						typ:    map_value_type
 					}
 				}
 				_ = g.parse_loop_block_body()!
@@ -148,6 +176,13 @@ fn (mut g Parser) parse_for() !bool {
 					return g.unsupported('for-in collection `${start}` of type `${collection_type}`')
 				}
 			}
+			fixed_length := fastc_fixed_array_length(collection_layout_type.trim_right('*')) or {
+				''
+			}
+			is_fixed_array := fixed_length != ''
+			is_raw_fixed_array := is_fixed_array && (start_expression.len > 1
+				|| (start_expression.len == 1
+				&& fastc_global_key(g.module_name, start_expression[0].lit) in g.globals))
 			g.next()
 			collection_name := g.temporary_name('collection')
 			is_ordinary_string := !g.selfhost && collection_layout_type == 'string'
@@ -164,15 +199,30 @@ fn (mut g Parser) parse_for() !bool {
 			} else {
 				'data'
 			}
-			if is_ordinary_string {
+			if is_fixed_array {
+				fixed_data := if is_raw_fixed_array {
+					'((${start})[0])'
+				} else {
+					fixed_access := if collection_layout_type.ends_with('*') { '->' } else { '.' }
+					'((${start})${fixed_access}data[0])'
+				}
+				g.write_line('${element_type} *${collection_name} = &${fixed_data};')
+			} else if is_ordinary_string {
 				g.write_line('string ${collection_name} = (${start});')
 			} else {
 				g.write_line('__typeof__((${start})) ${collection_name} = (${start});')
 			}
 			collection_length := if is_ordinary_string {
 				'strlen(${collection_name} ? ${collection_name} : "")'
+			} else if is_fixed_array {
+				fixed_length
 			} else {
 				'${collection_name}${access}len'
+			}
+			collection_data := if is_fixed_array {
+				collection_name
+			} else {
+				'${collection_name}${access}${data_field}'
 			}
 			g.write_line('for (int ${index_name} = 0; ${index_name} < ${collection_length}; ${index_name}++) {')
 			g.indent++
@@ -180,25 +230,35 @@ fn (mut g Parser) parse_for() !bool {
 			if actual_value_name != '_' {
 				c_value_name := fastc_c_identifier(actual_value_name)
 				if item_is_mut {
-					g.write_line('${element_type} *${c_value_name} = &(((${element_type} *)${collection_name}${access}${data_field})[${index_name}]);')
-					g.locals[actual_value_name] = FastcLocal{
-						is_mut:       true
-						is_reference: true
-						typ:          element_type + '*'
+					if element_type.ends_with('*') {
+						// Pointer elements are already references to mutable values. Taking the
+						// array slot's address here would incorrectly bind `x` as `&&T`.
+						g.write_line('${element_type} ${c_value_name} = ((${element_type} *)${collection_data})[${index_name}];')
+						g.locals[actual_value_name] = FastcLocal{
+							is_mut: true
+							typ:    element_type
+						}
+					} else {
+						g.write_line('${element_type} *${c_value_name} = &(((${element_type} *)${collection_data})[${index_name}]);')
+						g.locals[actual_value_name] = FastcLocal{
+							is_mut:       true
+							is_reference: true
+							typ:          element_type + '*'
+						}
 					}
 				} else if is_ordinary_string {
 					g.write_line('u8 ${c_value_name} = ((const unsigned char *)${collection_name})[${index_name}];')
 					g.locals[actual_value_name] = FastcLocal{
 						typ: 'u8'
 					}
-				} else if collection_layout_type.ends_with('*')
+				} else if !is_fixed_array && collection_layout_type.ends_with('*')
 					&& collection_layout_type.trim_right('*') != 'string' {
-					g.write_line('${element_type} *${c_value_name} = &(((${element_type} *)${collection_name}${access}${data_field})[${index_name}]);')
+					g.write_line('${element_type} *${c_value_name} = &(((${element_type} *)${collection_data})[${index_name}]);')
 					g.locals[actual_value_name] = FastcLocal{
 						typ: element_type + '*'
 					}
 				} else {
-					g.write_line('${element_type} ${c_value_name} = ((${element_type} *)${collection_name}${access}${data_field})[${index_name}];')
+					g.write_line('${element_type} ${c_value_name} = ((${element_type} *)${collection_data})[${index_name}];')
 					g.locals[actual_value_name] = FastcLocal{
 						typ: element_type
 					}

--- a/vlib/v3/gen/fastc/if.v
+++ b/vlib/v3/gen/fastc/if.v
@@ -3,12 +3,27 @@ module fastc
 import v3.scanner
 import v3.token
 
+fn (g &Parser) optional_function_field_for_expression(tokens []FastcExpressionToken) ?FastcStructField {
+	if tokens.len < 3 || tokens[tokens.len - 2].tok != .dot || tokens.last().tok != .name {
+		return none
+	}
+	receiver_type := g.infer_expression_type(tokens[..tokens.len - 2]) or { return none }
+	field := g.struct_field_metadata(receiver_type, tokens.last().lit) or { return none }
+	if !field.is_optional_function {
+		return none
+	}
+	return field
+}
+
 fn (g &Parser) or_block_has_statements() bool {
 	if g.tok == .string && fastc_string_literal_is_incomplete(g.lit) {
 		return false
 	}
-	if g.tok in [.key_return, .key_if, .key_for, .key_match, .key_mut, .key_defer, .key_break,
-		.key_continue] {
+	if g.tok == .name && g.lit == 'panic' {
+		return true
+	}
+	if g.tok in [.dollar, .key_return, .key_if, .key_for, .key_match, .key_mut, .key_defer,
+		.key_break, .key_continue] {
 		return true
 	}
 	mut lookahead := scanner.new_scanner(g.prefs, .normal)
@@ -37,19 +52,158 @@ fn (g &Parser) or_block_has_statements() bool {
 
 fn (mut g Parser) parse_if() !bool {
 	g.next()
+	// `if a, b := opt_fn() { ... }` unwraps an option whose value is a multi-return
+	// tuple and binds each component. The comma would otherwise trip the condition
+	// reader as a parallel assignment, so detect the `name (, name)+ :=` prefix here.
+	if g.tok == .name {
+		mut probe := g.s
+		mut guard_names := [g.lit]
+		mut is_multi_guard := false
+		for {
+			t := probe.scan()
+			if t == .comma {
+				if probe.scan() != .name {
+					break
+				}
+				guard_names << probe.lit
+			} else if t == .decl_assign {
+				is_multi_guard = guard_names.len >= 2
+				break
+			} else {
+				break
+			}
+		}
+		if is_multi_guard {
+			return g.parse_if_multi_return_guard(guard_names)
+		}
+	}
 	mut condition := g.read_condition_expression([token.Token.semicolon, token.Token.lcbr])!
 	if condition.len == 0 {
 		return g.unsupported('empty if condition')
 	}
+	// `if local is Variant { ... }` on a boxed sum-type/interface local smart-casts
+	// `local` to the concrete variant inside the then-branch, so its fields and
+	// methods resolve. Only the exact `local is Variant` form (no `&&`/`||`) binds.
+	cond_tokens := g.last_expression.clone()
+	mut smartcast_name := ''
+	mut smartcast_type := ''
+	mut smartcast_tmp := ''
+	mut smartcast_boxed_type := ''
+	if cond_tokens.len >= 3 && cond_tokens[0].tok == .name && cond_tokens[1].tok == .key_is {
+		if local := g.locals[cond_tokens[0].lit] {
+			boxed := fastc_normalize_inferred_type(local.typ)
+			if g.is_boxed_type(boxed) {
+				if cond_tokens.len == 3 && cond_tokens[2].tok == .name {
+					if variant_key := fastc_resolve_declared_type_key(g.module_name,
+						cond_tokens[2].lit, g.imports, g.declared_types)
+					{
+						smartcast_name = cond_tokens[0].lit
+						smartcast_type = fastc_c_declared_type_name(variant_key)
+						smartcast_boxed_type = local.typ
+						smartcast_tmp = g.temporary_name('smartcast_subject')
+					}
+				} else if resolved_target := g.type_from_expression_tokens(cond_tokens[2..]) {
+					// Composite variant target (`x is []string` / `x is map[K]V`): the
+					// type spans several tokens and lowers to a generated composite type.
+					target := fastc_normalize_inferred_type(resolved_target)
+					if target.starts_with('Array_') || target.starts_with('Map_') {
+						fastc_register_composite_type(target, mut g.composite_types)
+						smartcast_name = cond_tokens[0].lit
+						smartcast_type = target
+						smartcast_boxed_type = local.typ
+						smartcast_tmp = g.temporary_name('smartcast_subject')
+					}
+				}
+			}
+		}
+	}
+	// A boxed member (`if mut holder.writer is File`) needs the same concrete view as
+	// a boxed local, but its qualified source spelling cannot be shadowed. Keep a
+	// branch-scoped member-path rewrite instead, backed by a pointer to the boxed object.
+	mut member_smartcast_path := ''
+	mut member_smartcast_type := ''
+	mut member_smartcast_boxed_type := ''
+	mut member_smartcast_source := ''
+	mut member_smartcast_boxed_tmp := ''
+	mut member_smartcast_tmp := ''
+	mut is_index := -1
+	for i, item in cond_tokens {
+		if item.tok == .key_is {
+			is_index = i
+			break
+		}
+	}
+	mut member_start := 0
+	if cond_tokens.len > 0 && cond_tokens[0].tok in [.key_mut, .amp] {
+		member_start = 1
+	}
+	if is_index > member_start + 1 && is_index + 1 < cond_tokens.len {
+		left_tokens := cond_tokens[member_start..is_index]
+		mut is_member_chain := left_tokens.len >= 3 && left_tokens[0].tok == .name
+		mut path := if is_member_chain { left_tokens[0].lit } else { '' }
+		mut index := 1
+		for is_member_chain && index < left_tokens.len {
+			if index + 1 >= left_tokens.len || left_tokens[index].tok != .dot
+				|| left_tokens[index + 1].tok != .name {
+				is_member_chain = false
+				break
+			}
+			path += '.' + left_tokens[index + 1].lit
+			index += 2
+		}
+		if is_member_chain {
+			left_type := fastc_normalize_inferred_type(g.infer_expression_type(left_tokens) or {
+				''
+			})
+			target_type := g.type_from_expression_tokens(cond_tokens[is_index + 1..]) or { '' }
+			if left_type != '' && target_type != '' && g.is_boxed_type(left_type) {
+				left_source := g.render_member_receiver(left_tokens) or { '' }
+				if left_source != '' {
+					member_smartcast_path = path
+					member_smartcast_type = fastc_normalize_inferred_type(target_type)
+					member_smartcast_boxed_type = left_type
+					member_smartcast_source = left_source
+					member_smartcast_boxed_tmp = g.temporary_name('smartcast_subject')
+					member_smartcast_tmp = g.temporary_name('smartcast_member')
+					condition = '((${member_smartcast_boxed_tmp}._typ) == __v_typeid_${member_smartcast_type})'
+				}
+			}
+		}
+	}
 	mut guard_name := ''
 	mut guard_type := ''
 	mut guard_option := ''
-	if g.selfhost && g.last_expression.len >= 4 && g.last_expression[0].tok == .name
-		&& g.last_expression[1].tok == .decl_assign {
-		right_tokens := g.last_expression[2..]
-		if map_lookup := g.render_map_lookup_option_expression(right_tokens) {
-			guard_name = g.last_expression[0].lit
+	mut guard_is_mut := false
+	mut guard_function := FastcStructField{}
+	mut guard_function_source := ''
+	mut guard_erased_generic := false
+	// `if mut x := opt {` / `if mut x := map[k] {`: the leading `mut` (which renders to
+	// a `&` token here) shifts the name one token to the right. `& <name> :=` at the
+	// start of an if condition can only come from such a `mut` guard.
+	guard_name_index := if g.selfhost && g.last_expression.len >= 1
+		&& g.last_expression[0].tok in [token.Token.key_mut, token.Token.amp] {
+		1
+	} else {
+		0
+	}
+	if g.selfhost && g.last_expression.len >= guard_name_index + 3
+		&& g.last_expression[guard_name_index].tok == .name
+		&& g.last_expression[guard_name_index + 1].tok == .decl_assign {
+		right_tokens := g.last_expression[guard_name_index + 2..]
+		if function_field := g.optional_function_field_for_expression(right_tokens) {
+			guard_name = g.last_expression[guard_name_index].lit
+			guard_type = 'voidptr'
+			guard_is_mut = guard_name_index == 1
+			guard_function = function_field
+			guard_function_source = g.render_member_receiver(right_tokens) or { '' }
+			if guard_function_source != '' {
+				condition = '${guard_function_source} != NULL'
+				g.last_expression_type = 'bool'
+			}
+		} else if map_lookup := g.render_map_lookup_option_expression(right_tokens) {
+			guard_name = g.last_expression[guard_name_index].lit
 			guard_type = map_lookup.typ
+			guard_is_mut = guard_name_index == 1
 			guard_option = g.temporary_name('if_guard')
 			g.write_line('Option ${guard_option} = (${map_lookup.source});')
 			condition = '${guard_option}.state == 0'
@@ -57,9 +211,11 @@ fn (mut g Parser) parse_if() !bool {
 		} else {
 			option_type := g.option_value_type_for_expression(right_tokens)
 			if option_type != '' {
-				guard_name = g.last_expression[0].lit
+				guard_name = g.last_expression[guard_name_index].lit
 				guard_type = option_type
+				guard_is_mut = guard_name_index == 1
 				guard_option = g.temporary_name('if_guard')
+				guard_erased_generic = g.erased_generic_option_value_type_for_expression(right_tokens) != none
 				right_source := condition.all_after(':=').trim_space()
 				g.write_line('Option ${guard_option} = (${right_source});')
 				condition = '${guard_option}.state == 0'
@@ -69,14 +225,78 @@ fn (mut g Parser) parse_if() !bool {
 	}
 	g.skip_semicolons()
 	g.expect(.lcbr)!
+	if smartcast_name != '' {
+		// Copy the boxed value out before the branch so the shadowing cast below
+		// does not reference its own uninitialized declaration.
+		g.write_line('${smartcast_boxed_type} ${smartcast_tmp} = ${fastc_c_identifier(smartcast_name)};')
+	}
+	if member_smartcast_path != '' {
+		g.write_line('${member_smartcast_boxed_type} ${member_smartcast_boxed_tmp} = ${member_smartcast_source};')
+	}
 	g.write_line('if (${condition}) {')
 	g.indent++
 	previous_guard := g.locals[guard_name] or { FastcLocal{} }
 	had_guard := guard_name in g.locals
 	if guard_name != '' {
-		g.write_line('${guard_type} ${fastc_c_identifier(guard_name)} = *((${guard_type} *)${guard_option}.data);')
-		g.locals[guard_name] = FastcLocal{
-			typ: guard_type
+		if guard_function_source != '' {
+			parameters := if guard_function.fn_parameter_types.len == 0 {
+				'void'
+			} else {
+				guard_function.fn_parameter_types.join(', ')
+			}
+			return_type := if guard_function.fn_return_type == '' {
+				'void'
+			} else {
+				guard_function.fn_return_type
+			}
+			name := fastc_c_identifier(guard_name)
+			g.write_line('${return_type} (*${name})(${parameters}) = (${return_type} (*)(${parameters}))(${guard_function_source});')
+			g.locals[guard_name] = FastcLocal{
+				is_mut:               guard_is_mut
+				typ:                  'voidptr'
+				fn_return_type:       return_type
+				fn_option_value_type: guard_function.fn_option_value_type
+			}
+		} else if guard_erased_generic {
+			name := fastc_c_identifier(guard_name)
+			if guard_type.ends_with('*') {
+				g.write_line('${guard_type} ${name} = *((${guard_type} *)${guard_option}.data);')
+			} else {
+				g.write_line('${guard_type} ${name} = **((${guard_type} **)${guard_option}.data);')
+			}
+			g.locals[guard_name] = FastcLocal{
+				is_mut: guard_is_mut
+				typ:    guard_type
+			}
+		} else {
+			function_alias := g.functions[guard_type] or { FastcFunctionSignature{} }
+			g.write_line('${guard_type} ${fastc_c_identifier(guard_name)} = *((${guard_type} *)${guard_option}.data);')
+			g.locals[guard_name] = FastcLocal{
+				is_mut:               guard_is_mut
+				typ:                  guard_type
+				fn_return_type:       function_alias.return_type
+				fn_option_value_type: function_alias.option_type
+			}
+		}
+	}
+	previous_smartcast := g.locals[smartcast_name] or { FastcLocal{} }
+	had_smartcast := smartcast_name in g.locals
+	if smartcast_name != '' {
+		g.write_line('${smartcast_type} ${fastc_c_identifier(smartcast_name)} = *((${smartcast_type} *)${smartcast_tmp}._object);')
+		g.locals[smartcast_name] = FastcLocal{
+			is_mut: previous_smartcast.is_mut
+			typ:    smartcast_type
+		}
+	}
+	previous_member_smartcast := g.member_smartcasts[member_smartcast_path] or {
+		FastcMemberSmartcast{}
+	}
+	had_member_smartcast := member_smartcast_path in g.member_smartcasts
+	if member_smartcast_path != '' {
+		g.write_line('${member_smartcast_type} *${member_smartcast_tmp} = (${member_smartcast_type} *)${member_smartcast_boxed_tmp}._object;')
+		g.member_smartcasts[member_smartcast_path] = FastcMemberSmartcast{
+			typ:    member_smartcast_type + '*'
+			source: member_smartcast_tmp
 		}
 	}
 	then_terminates := g.parse_block_body()!
@@ -85,6 +305,122 @@ fn (mut g Parser) parse_if() !bool {
 			g.locals[guard_name] = previous_guard
 		} else {
 			g.locals.delete(guard_name)
+		}
+	}
+	if smartcast_name != '' {
+		if had_smartcast {
+			g.locals[smartcast_name] = previous_smartcast
+		} else {
+			g.locals.delete(smartcast_name)
+		}
+	}
+	if member_smartcast_path != '' {
+		if had_member_smartcast {
+			g.member_smartcasts[member_smartcast_path] = previous_member_smartcast
+		} else {
+			g.member_smartcasts.delete(member_smartcast_path)
+		}
+	}
+	g.indent--
+	if g.tok != .key_else {
+		g.write_line('}')
+		return false
+	}
+	g.next()
+	if g.tok == .key_if {
+		g.write_line('} else {')
+		g.indent++
+		previous_err := g.locals['err'] or { FastcLocal{} }
+		had_err := 'err' in g.locals
+		if guard_option != '' {
+			g.write_line('IError err = ${guard_option}.err;')
+			g.locals['err'] = FastcLocal{
+				typ: 'IError'
+			}
+		}
+		else_terminates := g.parse_if()!
+		if guard_option != '' {
+			if had_err {
+				g.locals['err'] = previous_err
+			} else {
+				g.locals.delete('err')
+			}
+		}
+		g.indent--
+		g.write_line('}')
+		return then_terminates && else_terminates
+	}
+	g.expect(.lcbr)!
+	g.write_line('} else {')
+	g.indent++
+	previous_err := g.locals['err'] or { FastcLocal{} }
+	had_err := 'err' in g.locals
+	if guard_option != '' {
+		g.write_line('IError err = ${guard_option}.err;')
+		g.locals['err'] = FastcLocal{
+			typ: 'IError'
+		}
+	}
+	else_terminates := g.parse_block_body()!
+	if guard_option != '' {
+		if had_err {
+			g.locals['err'] = previous_err
+		} else {
+			g.locals.delete('err')
+		}
+	}
+	g.indent--
+	g.write_line('}')
+	return then_terminates && else_terminates
+}
+
+// parse_if_multi_return_guard lowers `if a, b := opt_fn() { ... }`: the option's
+// value is a multi-return tuple, so on success the boxed `MultiReturn` is copied out
+// of the option and each component is bound as a local inside the then-branch.
+fn (mut g Parser) parse_if_multi_return_guard(names []string) !bool {
+	for g.tok != .decl_assign && g.tok != .eof {
+		g.next()
+	}
+	g.expect(.decl_assign)!
+	rhs := g.read_expression([token.Token.semicolon, token.Token.lcbr])!
+	if rhs == '' {
+		return g.unsupported('empty multi-return option guard')
+	}
+	component_types := g.multi_return_types_for_expression(g.last_expression)
+	if component_types.len < names.len {
+		return g.unsupported('multi-return option guard component types')
+	}
+	g.skip_semicolons()
+	g.expect(.lcbr)!
+	guard_option := g.temporary_name('if_guard')
+	g.write_line('Option ${guard_option} = (${rhs});')
+	g.write_line('if (${guard_option}.state == 0) {')
+	g.indent++
+	multi_return := g.temporary_name('multi_return')
+	g.write_line('MultiReturn ${multi_return} = *((MultiReturn *)${guard_option}.data);')
+	mut previous_locals := []FastcLocal{cap: names.len}
+	mut had_locals := []bool{cap: names.len}
+	for i, name in names {
+		existing := name in g.locals
+		previous_locals << (g.locals[name] or { FastcLocal{} })
+		had_locals << existing
+		if name == '_' {
+			continue
+		}
+		component_type := fastc_normalize_inferred_type(component_types[i])
+		c_name := fastc_c_identifier(name)
+		g.write_line('${component_type} ${c_name} = (${component_type}){0};')
+		g.write_line('memcpy(&${c_name}, ${multi_return}.values[${i}].data, sizeof(${c_name}));')
+		g.locals[name] = FastcLocal{
+			typ: component_type
+		}
+	}
+	then_terminates := g.parse_block_body()!
+	for i, name in names {
+		if had_locals[i] {
+			g.locals[name] = previous_locals[i]
+		} else {
+			g.locals.delete(name)
 		}
 	}
 	g.indent--
@@ -174,7 +510,7 @@ fn (mut g Parser) read_if_expression() !string {
 	mut guard_type := ''
 	mut guard_option := ''
 	mut guard_source := ''
-	if g.selfhost && g.last_expression.len >= 4 && g.last_expression[0].tok == .name
+	if g.selfhost && g.last_expression.len >= 3 && g.last_expression[0].tok == .name
 		&& g.last_expression[1].tok == .decl_assign {
 		right_tokens := g.last_expression[2..]
 		if map_lookup := g.render_map_lookup_option_expression(right_tokens) {
@@ -219,6 +555,15 @@ fn (mut g Parser) read_if_expression() !string {
 		}
 	}
 	mut then_type := g.last_expression_type
+	mut then_option_value_type := if then_type == 'Option' {
+		if g.last_expression.len > 0 {
+			g.option_value_type_for_expression(g.last_expression)
+		} else {
+			g.last_option_value_type
+		}
+	} else {
+		''
+	}
 	if enum_expression := g.expected_enum_shorthand_expression() {
 		then_expression = enum_expression
 		then_type = g.return_type
@@ -231,10 +576,12 @@ fn (mut g Parser) read_if_expression() !string {
 	g.next()
 	mut else_expression := ''
 	mut else_type := ''
+	mut else_option_value_type := ''
 	if g.tok == .key_if {
 		g.expected_expression_type = branch_expected_type
 		else_expression = g.read_if_expression()!
 		else_type = g.last_expression_type
+		else_option_value_type = g.last_option_value_type
 	} else {
 		g.expect(.lcbr)!
 		g.expected_expression_type = branch_expected_type
@@ -244,6 +591,13 @@ fn (mut g Parser) read_if_expression() !string {
 			g.read_block_expression_value()!
 		}
 		else_type = g.last_expression_type
+		if else_type == 'Option' {
+			else_option_value_type = if g.last_expression.len > 0 {
+				g.option_value_type_for_expression(g.last_expression)
+			} else {
+				g.last_option_value_type
+			}
+		}
 		if enum_expression := g.expected_enum_shorthand_expression() {
 			else_expression = enum_expression
 			else_type = g.return_type
@@ -251,23 +605,47 @@ fn (mut g Parser) read_if_expression() !string {
 		g.skip_semicolons()
 		g.expect(.rcbr)!
 	}
+	if g.selfhost && g.return_type == 'Option' && outer_expected_type != 'Option' {
+		if then_type.trim_right('*') == 'IError' && else_type !in ['', 'IError'] {
+			then_expression = '({ return (Option){.err=${then_expression}, .state=1}; (${fastc_normalize_inferred_type(else_type)}){0}; })'
+			then_type = else_type
+		} else if else_type.trim_right('*') == 'IError' && then_type !in ['', 'IError'] {
+			else_expression = '({ return (Option){.err=${else_expression}, .state=1}; (${fastc_normalize_inferred_type(then_type)}){0}; })'
+			else_type = then_type
+		}
+	}
 	if g.selfhost && outer_expected_type == 'Option' {
 		if then_type != 'Option' {
+			then_option_value_type = fastc_normalize_inferred_type(then_type)
 			then_expression = g.option_branch_expression(then_type, then_expression)
 			then_type = 'Option'
 		}
 		if else_type != 'Option' {
+			else_option_value_type = fastc_normalize_inferred_type(else_type)
 			else_expression = g.option_branch_expression(else_type, else_expression)
 			else_type = 'Option'
 		}
 	} else if g.selfhost && then_type == 'Option' && else_type !in ['', 'Option'] {
+		else_option_value_type = fastc_normalize_inferred_type(else_type)
 		else_base := fastc_normalize_inferred_type(else_type)
 		else_expression = '(Option){.data=${fastc_box_expression(else_base, else_expression)}, .state=0}'
 		else_type = 'Option'
 	} else if g.selfhost && else_type == 'Option' && then_type !in ['', 'Option'] {
+		then_option_value_type = fastc_normalize_inferred_type(then_type)
 		then_base := fastc_normalize_inferred_type(then_type)
 		then_expression = '(Option){.data=${fastc_box_expression(then_base, then_expression)}, .state=0}'
 		then_type = 'Option'
+	}
+	if g.selfhost && then_type == '' && else_type != '' {
+		resolved_type := fastc_normalize_inferred_type(else_type)
+		then_expression = '({ (void)(${then_expression}); (${resolved_type}){0}; })'
+		then_type = resolved_type
+		else_type = resolved_type
+	} else if g.selfhost && else_type == '' && then_type != '' {
+		resolved_type := fastc_normalize_inferred_type(then_type)
+		else_expression = '({ (void)(${else_expression}); (${resolved_type}){0}; })'
+		then_type = resolved_type
+		else_type = resolved_type
 	}
 	if then_type == else_type {
 		g.last_expression_type = then_type
@@ -286,6 +664,12 @@ fn (mut g Parser) read_if_expression() !string {
 		} else {
 			else_type
 		}
+	}
+	g.last_option_value_type = if g.last_expression_type == 'Option' && then_option_value_type != ''
+		&& then_option_value_type == else_option_value_type {
+		then_option_value_type
+	} else {
+		''
 	}
 	g.expected_expression_type = outer_expected_type
 	g.last_expression = []FastcExpressionToken{}
@@ -314,7 +698,7 @@ fn (mut g Parser) read_return_expression_branch() !string {
 		for {
 			value :=
 				g.read_expression([token.Token.comma, token.Token.semicolon, token.Token.rcbr])!
-			values << 'V_FASTC_MULTI_VALUE(${value})'
+			values << 'V_FASTC_MULTI_VALUE((${value}))'
 			if g.tok != .comma {
 				break
 			}

--- a/vlib/v3/gen/fastc/match.v
+++ b/vlib/v3/gen/fastc/match.v
@@ -2,6 +2,29 @@ module fastc
 
 import v3.token
 
+fn fastc_match_common_numeric_variant(variants []string) string {
+	if variants.len < 2 {
+		return ''
+	}
+	mut has_float := false
+	for variant in variants {
+		if variant != 'bool' && !fastc_is_numeric_expression_type(variant) {
+			return ''
+		}
+		has_float = has_float || variant in ['f32', 'f64']
+	}
+	return if has_float { 'f64' } else { 'u64' }
+}
+
+fn fastc_match_multi_variant_value(subject string, access string, variants []string, common_type string) string {
+	mut source := '((${common_type})0)'
+	for i := variants.len - 1; i >= 0; i-- {
+		variant := variants[i]
+		source = '((${subject}${access}_typ == __v_typeid_${variant}) ? ((${common_type})(*(${variant} *)${subject}${access}_object)) : (${source}))'
+	}
+	return source
+}
+
 fn (mut g Parser) read_match_expression() !string {
 	outer_expected_type := g.expected_expression_type
 	g.expect(.key_match)!
@@ -10,6 +33,20 @@ fn (mut g Parser) read_match_expression() !string {
 	subject_type := g.last_expression_type
 	if subject == '' || subject_type == '' {
 		return g.unsupported('unverifiable match expression subject')
+	}
+	subject_tokens := g.last_expression.clone()
+	// A sum-type / interface subject dispatches on the boxed `_typ` tag; each branch
+	// names a variant type and (for a plain-local subject) is smart-cast inside its
+	// value expression.
+	is_boxed := g.is_boxed_type(fastc_normalize_inferred_type(subject_type))
+	boxed_access := if subject_type.ends_with('*') { '->' } else { '.' }
+	mut subject_local := ''
+	if is_boxed && subject_tokens.len == 1 && subject_tokens[0].tok == .name
+		&& subject_tokens[0].lit in g.locals {
+		subject_local = subject_tokens[0].lit
+	} else if is_boxed && subject_tokens.len == 2 && subject_tokens[0].tok in [.key_mut, .amp]
+		&& subject_tokens[1].tok == .name && subject_tokens[1].lit in g.locals {
+		subject_local = subject_tokens[1].lit
 	}
 	g.expect(.lcbr)!
 	temporary := g.temporary_name('match')
@@ -23,18 +60,46 @@ fn (mut g Parser) read_match_expression() !string {
 	for g.tok != .rcbr && g.tok != .eof {
 		mut is_else := false
 		mut branch_conditions := []string{}
+		mut branch_variant := ''
+		mut branch_variants := []string{}
+		mut variant_count := 0
+		mut branch_all_arrays := true
 		if g.tok == .key_else {
 			is_else = true
 			g.next()
+		} else if is_boxed {
+			for {
+				variant_key := g.read_match_type_key() or {
+					return g.unsupported('match expression type value')
+				}
+				variant_cname := fastc_c_declared_type_name(variant_key)
+				if variant_cname in handled_cases {
+					return g.unsupported('duplicate match case `${variant_cname}`')
+				}
+				handled_cases[variant_cname] = true
+				branch_conditions << '(${temporary}${boxed_access}_typ == __v_typeid_${variant_cname})'
+				branch_variant = variant_cname
+				branch_variants << variant_cname
+				if !variant_cname.starts_with('Array_') {
+					branch_all_arrays = false
+				}
+				variant_count++
+				if g.tok != .comma {
+					break
+				}
+				g.next()
+			}
 		} else {
 			for {
 				g.expected_expression_type = subject_type
-				start :=
-					g.read_expression([token.Token.comma, token.Token.lcbr, token.Token.dotdot])!
+				start := g.read_expression([token.Token.comma, token.Token.lcbr, token.Token.dotdot,
+					token.Token.ellipsis])!
 				start_tokens := g.last_expression.clone()
 				mut case_key := g.normalized_match_case_key(start_tokens, start)
 				mut case_source := start
-				if g.tok == .dotdot {
+				// A match range case uses `...` (inclusive, `.ellipsis`); `..` (`.dotdot`) is
+				// also accepted defensively.
+				if g.tok in [token.Token.dotdot, token.Token.ellipsis] {
 					g.next()
 					finish := g.read_expression([token.Token.comma, token.Token.lcbr])!
 					finish_tokens := g.last_expression.clone()
@@ -61,14 +126,66 @@ fn (mut g Parser) read_match_expression() !string {
 		}
 		g.expect(.lcbr)!
 		g.expected_expression_type = outer_expected_type
+		// A single-type branch smart-casts to that variant. A branch listing several
+		// array variants (`[]int, []string { value.len }`) cannot pick one concrete
+		// element type, but every V array shares the generic `array` layout, so casting
+		// to `array` still exposes the common fields (`len`, `cap`, `data`).
+		common_numeric_type := fastc_match_common_numeric_variant(branch_variants)
+		smartcast_type := if variant_count == 1 {
+			branch_variant
+		} else if variant_count > 1 && branch_all_arrays {
+			'array'
+		} else if common_numeric_type != '' {
+			common_numeric_type
+		} else {
+			''
+		}
+		mut smartcast_saved := FastcLocal{}
+		smartcast_active := is_boxed && !is_else && smartcast_type != '' && subject_local != ''
+		if smartcast_active {
+			smartcast_saved = g.locals[subject_local] or { FastcLocal{} }
+			g.locals[subject_local] = FastcLocal{
+				is_mut: smartcast_saved.is_mut
+				typ:    smartcast_type
+			}
+		}
 		mut value := g.read_match_block_expression_value()!
 		mut value_type := g.last_expression_type
+		if smartcast_active {
+			g.locals[subject_local] = smartcast_saved
+			smartcast_value := if common_numeric_type != '' {
+				fastc_match_multi_variant_value(temporary, boxed_access, branch_variants,
+					common_numeric_type)
+			} else {
+				'*(${smartcast_type} *)${temporary}${boxed_access}_object'
+			}
+			value = '({ ${smartcast_type} ${fastc_c_identifier(subject_local)} = ${smartcast_value}; (${value}); })'
+		}
+		if g.selfhost && value_type != '' && outer_expected_type != ''
+			&& g.should_box_variant(outer_expected_type, value_type) {
+			// A branch value whose type is a variant of the match's (boxed) expected
+			// type must be boxed, so every branch shares the ternary's result type
+			// (e.g. a `[]Primitive` branch returning the smart-cast array as a `Primitive`).
+			value = g.interface_value_expression(outer_expected_type, value_type, value)
+			value_type = outer_expected_type
+		}
 		g.skip_semicolons()
 		if g.tok != .rcbr {
 			return g.unsupported('match branch `${value}` left `${g.token_source()}` (`${g.tok.str()}`)')
 		}
 		g.expect(.rcbr)!
 		g.skip_semicolons()
+		if g.selfhost && value_type.trim_right('*') == 'IError' && g.return_type == 'Option' {
+			error_result_type := if result_type != '' {
+				result_type
+			} else {
+				outer_expected_type
+			}
+			if error_result_type != '' && error_result_type != 'Option' {
+				value = '({ return (Option){.err=${value}, .state=1}; (${fastc_normalize_inferred_type(error_result_type)}){0}; })'
+				value_type = error_result_type
+			}
+		}
 		if g.selfhost && result_type == 'Option' && value_type !in ['', 'Option'] {
 			value = fastc_option_success_expression(value_type, value)
 			value_type = 'Option'
@@ -160,7 +277,7 @@ fn (mut g Parser) read_match_block_expression_value() !string {
 	}
 	mut packed_values := []string{cap: values.len}
 	for value in values {
-		packed_values << 'V_FASTC_MULTI_VALUE(${value})'
+		packed_values << 'V_FASTC_MULTI_VALUE((${value}))'
 	}
 	g.last_expression_type = 'MultiReturn'
 	g.last_expression = []FastcExpressionToken{}
@@ -174,7 +291,25 @@ fn (mut g Parser) read_block_expression_value() !string {
 		return g.read_if_expression()!
 	}
 	if !g.or_block_has_statements() {
-		return g.read_expression([token.Token.semicolon, token.Token.rcbr])!
+		first := g.read_expression([token.Token.comma, token.Token.semicolon, token.Token.rcbr])!
+		if g.tok != .comma {
+			return first
+		}
+		mut values := [first]
+		mut value_types := [fastc_normalize_inferred_type(g.last_expression_type)]
+		for g.tok == .comma {
+			g.next()
+			values << g.read_expression([token.Token.comma, token.Token.semicolon, token.Token.rcbr])!
+			value_types << fastc_normalize_inferred_type(g.last_expression_type)
+		}
+		mut packed_values := []string{cap: values.len}
+		for value in values {
+			packed_values << 'V_FASTC_MULTI_VALUE((${value}))'
+		}
+		g.last_expression_type = 'MultiReturn'
+		g.last_expression = []FastcExpressionToken{}
+		g.last_multi_return_types = value_types.clone()
+		return '(MultiReturn){.values={${packed_values.join(', ')}}}'
 	}
 	previous_capture := g.capturing_defer
 	previous_lines := g.captured_defer_lines.clone()
@@ -199,9 +334,38 @@ fn (mut g Parser) read_block_expression_value() !string {
 	mut value := if g.tok == .name {
 		prefix := g.lit
 		g.next()
-		g.read_expression_with_prefix(prefix, [token.Token.semicolon, token.Token.rcbr])!
+		g.read_expression_with_prefix(prefix,
+			[token.Token.comma, token.Token.semicolon, token.Token.rcbr])!
 	} else {
-		g.read_expression([token.Token.semicolon, token.Token.rcbr])!
+		g.read_expression([token.Token.comma, token.Token.semicolon, token.Token.rcbr])!
+	}
+	if g.tok == .comma {
+		// A multi-return block value (`{ c := ...; c, '.zst', 'zstd' }`, e.g. veb's
+		// compressed-static match): pack the comma-separated values into a MultiReturn,
+		// mirroring the single-line branch path above.
+		mut values := [value]
+		mut value_types := [fastc_normalize_inferred_type(g.last_expression_type)]
+		for g.tok == .comma {
+			g.next()
+			part := if g.tok == .name {
+				prefix := g.lit
+				g.next()
+				g.read_expression_with_prefix(prefix, [token.Token.comma, token.Token.semicolon,
+					token.Token.rcbr])!
+			} else {
+				g.read_expression([token.Token.comma, token.Token.semicolon, token.Token.rcbr])!
+			}
+			values << part
+			value_types << fastc_normalize_inferred_type(g.last_expression_type)
+		}
+		mut packed_values := []string{cap: values.len}
+		for packed_value in values {
+			packed_values << 'V_FASTC_MULTI_VALUE((${packed_value}))'
+		}
+		g.last_expression_type = 'MultiReturn'
+		g.last_expression = []FastcExpressionToken{}
+		g.last_multi_return_types = value_types.clone()
+		return '({ ${statements.join(' ')} (MultiReturn){.values={${packed_values.join(', ')}}}; })'
 	}
 	if g.tok == .name {
 		prefix := g.lit

--- a/vlib/v3/gen/fastc/monomorphize.v
+++ b/vlib/v3/gen/fastc/monomorphize.v
@@ -1,0 +1,1827 @@
+module fastc
+
+import v3.pref
+import v3.scanner
+import v3.token
+
+// Source-level generic monomorphization. FastC is scanner-only and has no AST,
+// so instead of substituting types in a tree it rewrites SOURCE: for every
+// concrete instantiation of a generic function it emits a copy with the type
+// parameter textually substituted, then rewrites the call sites to the mangled
+// name. The concrete copies then flow through the ordinary FastC pipeline with
+// no generics left. The pass is a strict no-op unless an entry-module generic
+// definition is present.
+//
+// IMPORTANT: this file is part of gen/fastc and is therefore compiled by the
+// FastC self-host, so it must stay inside the V subset FastC can generate — no
+// nested-map indexing, no map-value member access, no `.sort(closure)`, no
+// `.delete`. Data is kept in flat lists and simple maps.
+//
+// First increment scope: entry-module free functions with a single type
+// parameter, whose every call site resolves to a single concrete type — an
+// explicit `f[Concrete](...)` or an `f(literal)` whose first parameter is the
+// type parameter. Library-module generics (called with a module qualifier) need
+// cross-module resolution and are left to the existing path. A generic whose
+// calls cannot all be resolved is left untouched.
+
+// FastcGenericMethodSource keeps the full source text of a generic method with its
+// own type parameter (`fn (mut e Enc) m[T](...) { ... }`), so the parser can generate a
+// concrete instance ON DEMAND when it resolves a `recv.m(arg)` call whose arg type is
+// only known at parse time (e.g. a `$for`-unrolled field access). The source-level pass
+// cannot handle those (the arg is comptime), so those generic methods are left in the
+// source and collected here. Keyed by `<receiver_type>.<method>`.
+struct FastcGenericMethodSource {
+	name                       string
+	type_param                 string
+	receiver_type              string
+	module_name                string
+	path                       string
+	imports                    map[string]string
+	return_type_source         string
+	first_param_is_type_param  bool
+	type_param_parameter_index int
+	source                     string
+}
+
+// fastc_collect_generic_method_sources indexes every generic method (own type param) AND
+// generic FREE FUNCTION remaining in the post-monomorphization sources, so the parser can
+// instantiate them on demand. Methods are keyed `<receiver_type>.<name>`; functions are
+// keyed `<module>.<name>` (module-qualified, for aliased cross-module calls like
+// `json.encode`). Fully source-monomorphized entries are already blanked and absent here.
+fn fastc_collect_generic_method_sources(sources []FastcSourceFile, prefs &pref.Preferences) map[string]FastcGenericMethodSource {
+	mut result := map[string]FastcGenericMethodSource{}
+	for i, source_file in sources {
+		module_name := source_file.header.module_name
+		for generic in fastc_scan_generic_fns(source_file.source, source_file.path, prefs, i) {
+			receiver_type := if generic.receiver_type != '' {
+				fastc_c_declared_type_name(fastc_type_key(module_name, generic.receiver_type))
+			} else {
+				''
+			}
+			key := if receiver_type != '' {
+				'${receiver_type}.${generic.name}'
+			} else {
+				fastc_function_key(module_name, generic.name)
+			}
+			result[key] = FastcGenericMethodSource{
+				name:                       generic.name
+				type_param:                 generic.type_param
+				receiver_type:              receiver_type
+				module_name:                module_name
+				path:                       source_file.path
+				imports:                    source_file.header.imports
+				return_type_source:         generic.return_type_source
+				first_param_is_type_param:  generic.first_param_is_type_param
+				type_param_parameter_index: generic.type_param_parameter_index
+				source:                     source_file.source[generic.fn_start..generic.def_end]
+			}
+		}
+	}
+	return result
+}
+
+// mono_argument_type infers the first argument's concrete type for an on-demand
+// generic call, reading from a scanner positioned just after the opening `(`.
+// Collecting the complete expression lets ordinary FastC inference handle compound
+// numeric operands and indexed members as well as literals and bare locals.
+fn (g &Parser) mono_argument_type(mut look scanner.Scanner) string {
+	mut tokens := []FastcExpressionToken{}
+	mut parens := 0
+	mut brackets := 0
+	mut braces := 0
+	for {
+		tok := look.scan()
+		if tok == .eof || (parens == 0 && brackets == 0 && braces == 0 && tok in [.comma, .rpar]) {
+			break
+		}
+		tokens << FastcExpressionToken{
+			tok: tok
+			lit: look.lit
+		}
+		match tok {
+			.lpar { parens++ }
+			.rpar { parens-- }
+			.lsbr { brackets++ }
+			.rsbr { brackets-- }
+			.lcbr { braces++ }
+			.rcbr { braces-- }
+			else {}
+		}
+	}
+	if tokens.len == 0 {
+		return ''
+	}
+	argument_tokens := if tokens[0].tok == .key_mut { tokens[1..] } else { tokens }
+	if argument_tokens.len == 1 {
+		literal := fastc_infer_literal_type(argument_tokens[0].tok, argument_tokens[0].lit)
+		if literal != '' {
+			return literal
+		}
+	}
+	inferred := g.infer_expression_type(argument_tokens) or { return '' }
+	return fastc_normalize_inferred_type(inferred).trim_right('*')
+}
+
+// mono_argument_type_at infers the concrete type from one positional call argument.
+// The scanner starts immediately after `(`; preceding arguments are skipped with their
+// nested delimiters intact before mono_argument_type examines the selected argument.
+fn (g &Parser) mono_argument_type_at(mut look scanner.Scanner, parameter_index int) string {
+	for _ in 0 .. parameter_index {
+		mut parens := 0
+		mut brackets := 0
+		mut braces := 0
+		for {
+			tok := look.scan()
+			if tok == .eof || (tok == .rpar && parens == 0 && brackets == 0 && braces == 0) {
+				return ''
+			}
+			if tok == .comma && parens == 0 && brackets == 0 && braces == 0 {
+				break
+			}
+			match tok {
+				.lpar { parens++ }
+				.rpar { parens-- }
+				.lsbr { brackets++ }
+				.rsbr { brackets-- }
+				.lcbr { braces++ }
+				.rcbr { braces-- }
+				else {}
+			}
+		}
+	}
+	return g.mono_argument_type(mut look)
+}
+
+// queue_mono_method records a needed generic-method instance (`<receiver>.<method>` with
+// `concrete`), registering a per-Parser signature so the call resolves during rendering
+// and queueing it for the drain in run(). Returns the mangled method name to emit.
+fn (mut g Parser) queue_mono_method(receiver_type string, method string, concrete string) string {
+	mono := fastc_monomorphized_name(method, concrete)
+	key := '${g.semantic_type_key(receiver_type)}.${mono}'
+	if key !in g.mono_functions {
+		source_key := '${receiver_type}.${method}'
+		source := g.generic_method_sources[source_key] or { FastcGenericMethodSource{} }
+		base_key := '${g.semantic_type_key(receiver_type)}.${method}'
+		base := g.functions[base_key] or { FastcFunctionSignature{} }
+		mut parameter_types := base.parameter_types.clone()
+		parameter_index := source.type_param_parameter_index + 1
+		if source.type_param_parameter_index >= 0 && parameter_index < parameter_types.len {
+			parameter_types[parameter_index] = fastc_specialized_generic_parameter_type(parameter_types[parameter_index],
+				concrete)
+		}
+		return_source := source.return_type_source.trim_space()
+		mut return_type := if primitive := fastc_primitive_c_type(return_source) {
+			primitive
+		} else if return_source == source.type_param {
+			concrete
+		} else if return_source.starts_with('!') || return_source.starts_with('?') {
+			'Option'
+		} else {
+			base.return_type
+		}
+		if return_source == '' {
+			return_type = 'void'
+		}
+		g.mono_functions[key] = FastcFunctionSignature{
+			parameter_types:          parameter_types
+			parameter_mutability:     base.parameter_mutability.clone()
+			return_type:              return_type
+			return_types:             base.return_types.clone()
+			option_type:              if return_type == 'Option' {
+				concrete
+			} else {
+				base.option_type
+			}
+			is_variadic:              base.is_variadic
+			last_parameter_is_params: base.last_parameter_is_params
+			module_name:              source.module_name
+			path:                     source.path
+			is_public:                true
+		}
+		g.pending_mono << FastcMonoRequest{
+			source_key: source_key
+			concrete:   concrete
+		}
+	}
+	return mono
+}
+
+// queue_explicit_mono_method recognizes `receiver.method[Type](...)` and queues the
+// concrete generic-method body before ordinary method rendering validates the call.
+fn (mut g Parser) queue_explicit_mono_method(tokens []FastcExpressionToken) ?string {
+	if tokens.len < 3 || tokens.last().tok != .name || tokens[tokens.len - 2].tok != .dot {
+		return none
+	}
+	dot_index := tokens.len - 2
+	receiver_start := fastc_method_receiver_start(tokens, dot_index)
+	receiver_type := g.infer_expression_type(tokens[receiver_start..dot_index]) or { return none }
+	receiver_base := fastc_normalize_inferred_type(receiver_type).trim_right('*')
+	method := tokens.last().lit
+	if '${receiver_base}.${method}' !in g.generic_method_sources {
+		return none
+	}
+	mut look := g.s
+	if look.scan() != .lsbr {
+		return none
+	}
+	first := look.scan()
+	concrete, next := fastc_scan_type(mut look, first, g.path, g.module_name, g.imports,
+		g.declared_types, g.selfhost) or { return none }
+	after := look.scan()
+	if next != .rsbr || after != .lpar {
+		return none
+	}
+	return g.queue_mono_method(receiver_base, method, concrete)
+}
+
+// queue_explicit_mono_function recognizes an explicit generic free-function call at the
+// current name token, registers its concrete signature, and queues its body for the same
+// on-demand drain used by generic methods.
+fn (mut g Parser) queue_explicit_mono_function(tokens []FastcExpressionToken) ?string {
+	if tokens.len == 0 || tokens.last().tok != .name {
+		return none
+	}
+	function_key := g.function_key_for_call(tokens, tokens.len - 1)
+	source := g.generic_method_sources[function_key] or { return none }
+	if source.receiver_type != '' {
+		return none
+	}
+	mut look := g.s
+	if look.scan() != .lsbr {
+		return none
+	}
+	first := look.scan()
+	concrete, next := fastc_scan_type(mut look, first, g.path, g.module_name, g.imports,
+		g.declared_types, g.selfhost) or { return none }
+	if next != .rsbr || look.scan() != .lpar {
+		return none
+	}
+	return g.queue_mono_function(function_key, concrete)
+}
+
+// queue_implicit_mono_function specializes a generic free function whose first argument
+// reveals its type, such as json2's `encode(value)`.
+fn (mut g Parser) queue_implicit_mono_function(tokens []FastcExpressionToken) ?string {
+	if tokens.len == 0 || tokens.last().tok != .name {
+		return none
+	}
+	function_key := g.function_key_for_call(tokens, tokens.len - 1)
+	source := g.generic_method_sources[function_key] or { return none }
+	if source.receiver_type != '' || source.type_param_parameter_index < 0 {
+		return none
+	}
+	mut look := g.s
+	if look.scan() != .lpar {
+		return none
+	}
+	concrete := g.mono_argument_type_at(mut look, source.type_param_parameter_index)
+	if concrete == '' {
+		return none
+	}
+	return g.queue_mono_function(function_key, concrete)
+}
+
+fn (mut g Parser) queue_mono_function(function_key string, concrete string) ?string {
+	source := g.generic_method_sources[function_key] or { return none }
+	mono := fastc_monomorphized_name(source.name, concrete)
+	mono_key := fastc_function_key(source.module_name, mono)
+	if mono_key !in g.mono_functions {
+		base := g.functions[function_key] or { return none }
+		mut parameter_types := base.parameter_types.clone()
+		if source.type_param_parameter_index >= 0
+			&& source.type_param_parameter_index < parameter_types.len {
+			parameter_types[source.type_param_parameter_index] = fastc_specialized_generic_parameter_type(parameter_types[source.type_param_parameter_index],
+				concrete)
+		}
+		mut return_type := base.return_type
+		mut option_type := base.option_type
+		return_source := source.return_type_source.trim_space()
+		if return_source == source.type_param {
+			return_type = concrete
+		} else if return_source in ['!${source.type_param}', '?${source.type_param}'] {
+			return_type = 'Option'
+			option_type = concrete
+		}
+		g.mono_functions[mono_key] = FastcFunctionSignature{
+			parameter_types:          parameter_types
+			parameter_mutability:     base.parameter_mutability.clone()
+			return_type:              return_type
+			return_types:             base.return_types.clone()
+			option_type:              option_type
+			is_variadic:              base.is_variadic
+			last_parameter_is_params: base.last_parameter_is_params
+			is_public:                base.is_public
+			is_disabled:              base.is_disabled
+			module_name:              source.module_name
+			path:                     source.path
+		}
+		g.pending_mono << FastcMonoRequest{
+			source_key: function_key
+			concrete:   concrete
+		}
+	}
+	return mono
+}
+
+fn fastc_specialized_generic_parameter_type(erased string, concrete string) string {
+	base := erased.trim_right('*')
+	if base != 'voidptr' {
+		return concrete
+	}
+	return concrete + '*'.repeat(erased.len - base.len)
+}
+
+// render_mono_method produces the concrete source of one generic-method instance by
+// reusing the generic-function renderer: it re-scans the stored method source to locate
+// its `[T]` bracket + name, then substitutes the type parameter and renames the method.
+fn (g &Parser) render_mono_method(src FastcGenericMethodSource, concrete string) string {
+	generics := fastc_scan_generic_fns(src.source, g.path, g.prefs, 0)
+	if generics.len == 0 {
+		return ''
+	}
+	return fastc_render_generic_instance(src.source, generics[0], concrete, g.prefs)
+}
+
+// erase_mono_generic_type_arguments removes type arguments from references to generic
+// structs in a late on-demand instance. Imported generic structs use FastC's erased
+// declaration (their type parameters are `voidptr` fields), just as fastc_scan_type
+// already does for signatures. The generated instance must receive the same treatment
+// before expression parsing, otherwise `Result[Concrete]{...}` is mistaken for an array
+// access followed by an ordinary block.
+fn (g &Parser) erase_mono_generic_type_arguments(source string, src FastcGenericMethodSource) string {
+	mut file_set := token.FileSet.new()
+	mut file := file_set.add_file(src.path, source.len)
+	file.index_lines_without_digest(source)
+	mut scan := scanner.new_scanner(g.prefs, .normal)
+	scan.init(file, source)
+	mut edits := []FastcSourceEdit{}
+	mut tok := scan.scan()
+	for tok != .eof {
+		if tok != .name {
+			tok = scan.scan()
+			continue
+		}
+		first_name := scan.lit
+		mut type_key := fastc_resolve_declared_type_key(src.module_name, first_name, src.imports,
+			g.declared_types) or { '' }
+		tok = scan.scan()
+		if tok == .dot {
+			qualified_module := src.imports[first_name] or { '' }
+			tok = scan.scan()
+			if qualified_module == '' || tok != .name {
+				continue
+			}
+			type_key = fastc_type_key(qualified_module, scan.lit)
+			tok = scan.scan()
+		}
+		if tok != .lsbr || type_key == '' || type_key !in g.declared_types {
+			continue
+		}
+		bracket_start := scan.pos
+		mut depth := 1
+		for depth > 0 {
+			tok = scan.scan()
+			if tok == .eof {
+				return source
+			}
+			if tok == .lsbr {
+				depth++
+			} else if tok == .rsbr {
+				depth--
+			}
+		}
+		edits << FastcSourceEdit{
+			start: bracket_start
+			end:   scan.offset
+		}
+		tok = scan.scan()
+	}
+	if edits.len == 0 {
+		return source
+	}
+	return fastc_apply_source_edits(source, edits)
+}
+
+struct FastcGenericFn {
+	name                       string
+	type_param                 string
+	source_index               int
+	fn_start                   int // offset of `fn` (or a leading `pub`/`static`)
+	def_end                    int // offset just past the body `}`
+	bracket_start              int // offset of `[`
+	bracket_end                int // offset just past `]`
+	first_param_is_type_param  bool
+	type_param_parameter_index int
+	// For a method with its own type parameter (`fn (mut e Enc) encode_value[T](val T)`),
+	// the receiver's declared type name (`Enc`); empty for a free function. Used to
+	// disambiguate a `recv.method(arg)` call from an unrelated same-named method.
+	receiver_type string
+	// The V return-type text between the parameter `)` and the body `{` (e.g. `string`,
+	// `!T`, `[]T`), used to register an on-demand instance's signature.
+	return_type_source string
+}
+
+struct FastcGenericCall {
+	name         string
+	source_index int
+	start        int // offset of the name token
+	end          int // offset just past `[Concrete]` or the name
+	concrete     string
+}
+
+struct FastcConcretePair {
+	name     string
+	concrete string
+}
+
+struct FastcSourceEdit {
+	source_index int
+	start        int
+	end          int
+	replacement  string
+}
+
+// FastcGenericMethod is a method whose receiver is a known generic struct, e.g.
+// `fn (mut s Stack[T]) push(x T)`. It is monomorphized once per struct
+// instantiation: the receiver reference `S[T]` becomes `S__mono_<C>` and the
+// type parameter is substituted elsewhere. Method calls resolve by receiver type
+// in C, so no call-site rewriting is needed.
+struct FastcGenericMethod {
+	struct_name        string
+	type_param         string
+	source_index       int
+	fn_start           int // offset of `fn` (or a leading `pub`/`static`)
+	def_end            int // offset just past the body `}`
+	receiver_ref_start int // offset of `S` in the receiver type `S[T]`
+	receiver_ref_end   int // offset just past `]`
+}
+
+// fastc_monomorphize_sources monomorphizes entry-module generic functions and
+// then generic structs. Structs run second so that a generic function body's
+// `S[T]` becomes a concrete `S[int]` (in the emitted instance) before the struct
+// pass looks for instantiations.
+fn fastc_monomorphize_sources(sources []FastcSourceFile, prefs &pref.Preferences) ![]FastcSourceFile {
+	after_functions := fastc_monomorphize_functions(sources, prefs)!
+	return fastc_monomorphize_structs(after_functions, prefs)
+}
+
+// fastc_monomorphize_functions repeatedly applies one monomorphization pass until
+// no generic remains resolvable. A single pass only specializes calls whose concrete
+// type is visible in the ORIGINAL source; a nested call inside a generic body
+// (`fn outer[T](x T) { inner(x) }`) becomes concrete only in the emitted instance
+// (`outer_mono_int`'s `inner(x)` with `x int`), so it is discovered on the next pass.
+// Each pass blanks the generics it resolves, so the loop terminates in at most the
+// nesting depth of instantiations; the cap is a safety backstop.
+fn fastc_monomorphize_functions(sources []FastcSourceFile, prefs &pref.Preferences) ![]FastcSourceFile {
+	mut current := sources.clone()
+	for _ in 0 .. 24 {
+		next, changed := fastc_monomorphize_functions_once(current, prefs)!
+		if !changed {
+			return next
+		}
+		current = next.clone()
+	}
+	return current
+}
+
+// fastc_monomorphize_functions_once rewrites `sources` for one round, returning the
+// new sources and whether any generic was monomorphized (so the caller can iterate).
+fn fastc_monomorphize_functions_once(sources []FastcSourceFile, prefs &pref.Preferences) !([]FastcSourceFile, bool) {
+	mut generics := []FastcGenericFn{}
+	for i, source_file in sources {
+		if source_file.header.module_name !in ['', 'main'] {
+			continue
+		}
+		for generic in fastc_scan_generic_fns(source_file.source, source_file.path, prefs, i) {
+			generics << generic
+		}
+	}
+	if generics.len == 0 {
+		return sources, false
+	}
+	// Index generics by name, dropping any duplicated (ambiguous) name.
+	mut seen_once := map[string]bool{}
+	mut ambiguous := map[string]bool{}
+	for generic in generics {
+		if generic.name in seen_once {
+			ambiguous[generic.name] = true
+		}
+		seen_once[generic.name] = true
+	}
+	mut by_name := map[string]FastcGenericFn{}
+	for generic in generics {
+		if generic.name in ambiguous {
+			continue
+		}
+		// Generic METHODS (own type param) are handled by on-demand parse-time
+		// monomorphization (see the drain in run()), not the source-level pass — their
+		// bodies recurse through comptime `$for`, which the source-level scanner cannot
+		// follow (it would blank the method and leave the `$for`-unrolled call dangling).
+		if generic.receiver_type != '' {
+			continue
+		}
+		by_name[generic.name] = generic
+	}
+	if by_name.len == 0 {
+		return sources, false
+	}
+	// Collect call sites and the concrete type each resolves to.
+	mut calls := []FastcGenericCall{}
+	mut unresolvable := map[string]bool{}
+	mut pairs := []FastcConcretePair{}
+	mut seen_pair := map[string]bool{}
+	mut has_concrete := map[string]bool{}
+	for i, source_file in sources {
+		if source_file.header.module_name !in ['', 'main'] {
+			continue
+		}
+		fastc_scan_generic_calls(source_file.source, source_file.path, prefs, i, by_name, mut
+			calls, mut unresolvable, mut pairs, mut seen_pair, mut has_concrete)
+	}
+	// A generic is monomorphized only when every call resolves.
+	mut active := map[string]bool{}
+	for name in by_name.keys() {
+		if name in unresolvable {
+			continue
+		}
+		if name !in has_concrete {
+			continue
+		}
+		active[name] = true
+	}
+	if active.len == 0 {
+		return sources, false
+	}
+	// Build a flat edit list: blank each active generic definition, append its
+	// concrete copies to that source, and rewrite each resolved call site.
+	mut edits := []FastcSourceEdit{}
+	mut appends := []string{len: sources.len, init: ''}
+	for name in active.keys() {
+		generic := by_name[name] or { FastcGenericFn{} }
+		definition_file := sources[generic.source_index]
+		definition_source := definition_file.source
+		edits << FastcSourceEdit{
+			source_index: generic.source_index
+			start:        generic.fn_start
+			end:          generic.def_end
+			replacement:  ''
+		}
+		mut copies := ''
+		for pair in pairs {
+			if pair.name != name {
+				continue
+			}
+			copies = copies + '\n' +
+				fastc_render_generic_instance(definition_source, generic, pair.concrete, prefs) +
+				'\n'
+		}
+		appends[generic.source_index] = appends[generic.source_index] + copies
+	}
+	for call in calls {
+		if call.name !in active {
+			continue
+		}
+		edits << FastcSourceEdit{
+			source_index: call.source_index
+			start:        call.start
+			end:          call.end
+			replacement:  fastc_monomorphized_name(call.name, call.concrete)
+		}
+	}
+	mut result := []FastcSourceFile{cap: sources.len}
+	for i, source_file in sources {
+		mut file_edits := []FastcSourceEdit{}
+		for edit in edits {
+			if edit.source_index == i {
+				file_edits << edit
+			}
+		}
+		mut new_source := source_file.source
+		if file_edits.len > 0 {
+			new_source = fastc_apply_source_edits(new_source, file_edits)
+		}
+		if appends[i] != '' {
+			new_source = new_source + appends[i]
+		}
+		result << FastcSourceFile{
+			path:   source_file.path
+			source: new_source
+			header: source_file.header
+		}
+	}
+	return result, true
+}
+
+// fastc_apply_source_edits applies non-overlapping [start,end) replacements,
+// processed right-to-left so earlier offsets stay valid. Sorted with a manual
+// selection sort to keep the pass self-hostable.
+fn fastc_apply_source_edits(source string, edits []FastcSourceEdit) string {
+	mut ordered := edits.clone()
+	for i in 0 .. ordered.len {
+		mut max_index := i
+		current := ordered[i]
+		mut max_start := current.start
+		for j in i + 1 .. ordered.len {
+			candidate := ordered[j]
+			if candidate.start > max_start {
+				max_index = j
+				max_start = candidate.start
+			}
+		}
+		if max_index != i {
+			swap := ordered[i]
+			ordered[i] = ordered[max_index]
+			ordered[max_index] = swap
+		}
+	}
+	mut result := source
+	for edit in ordered {
+		result = result[..edit.start] + edit.replacement + result[edit.end..]
+	}
+	return result
+}
+
+fn fastc_monomorphized_name(name string, concrete string) string {
+	// A single-underscore separator on purpose: `__` is FastC's module separator,
+	// so a `Foo__mono_int` receiver would be read as type `mono_int` in module
+	// `Foo` and its methods would be mis-named. Multiple type arguments are joined
+	// with `,` internally; flatten to `_` for the C identifier.
+	return '${name}_mono_${concrete.replace(',', '_')}'
+}
+
+// fastc_read_bracket_names reads a comma-separated list of `.name` tokens (the
+// current token being the first name) — used for both `[T, U]` type parameters
+// and `[int, string]` type arguments — and returns them joined with `,` plus the
+// token that follows the list (expected `]`).
+fn fastc_read_bracket_names(mut s scanner.Scanner) (string, token.Token) {
+	mut names := s.lit
+	mut tok := s.scan()
+	for tok == .comma {
+		tok = s.scan()
+		if tok != .name {
+			return names, tok
+		}
+		names = names + ',' + s.lit
+		tok = s.scan()
+	}
+	return names, tok
+}
+
+// fastc_type_param_substitutions builds the map from each comma-joined type
+// parameter to its corresponding concrete type argument.
+fn fastc_type_param_substitutions(type_param string, concrete string) map[string]string {
+	type_params := type_param.split(',')
+	concretes := concrete.split(',')
+	mut substitutions := map[string]string{}
+	for index, name in type_params {
+		if index < concretes.len {
+			substitutions[name] = concretes[index]
+		}
+	}
+	return substitutions
+}
+
+// fastc_render_generic_instance produces the concrete source of one instance:
+// the generic definition with `[T]` removed, the type parameter substituted, and
+// the function renamed.
+fn fastc_render_generic_instance(source string, generic FastcGenericFn, concrete string, prefs &pref.Preferences) string {
+	definition := source[generic.fn_start..generic.def_end]
+	base := generic.fn_start
+	mut edits := []FastcSourceEdit{}
+	edits << FastcSourceEdit{
+		start:       generic.bracket_start - base
+		end:         generic.bracket_end - base
+		replacement: ''
+	}
+	mut file_set := token.FileSet.new()
+	mut file := file_set.add_file('mono', definition.len)
+	file.index_lines_without_digest(definition)
+	mut s := scanner.new_scanner(prefs, .normal)
+	s.init(file, definition)
+	bracket_low := generic.bracket_start - base
+	bracket_high := generic.bracket_end - base
+	substitutions := fastc_type_param_substitutions(generic.type_param, concrete)
+	mut tok := s.scan()
+	mut renamed := false
+	for tok != .eof {
+		if tok == .name {
+			if !renamed && s.lit == generic.name {
+				edits << FastcSourceEdit{
+					start:       s.pos
+					end:         s.offset
+					replacement: fastc_monomorphized_name(generic.name, concrete)
+				}
+				renamed = true
+			} else if !(s.pos >= bracket_low && s.pos < bracket_high) {
+				// Substitute each type parameter everywhere except inside `[...]`, which
+				// is removed by the edit above (overlapping edits would corrupt it).
+				if replacement := substitutions[s.lit] {
+					edits << FastcSourceEdit{
+						start:       s.pos
+						end:         s.offset
+						replacement: replacement
+					}
+				}
+			}
+		}
+		tok = s.scan()
+	}
+	return fastc_apply_source_edits(definition, edits)
+}
+
+// fastc_scan_generic_fns finds free functions with a single type parameter whose
+// body can be cleanly delimited. Anything it cannot parse confidently is skipped,
+// so it never misclassifies ordinary code.
+fn fastc_scan_generic_fns(source string, path string, prefs &pref.Preferences, source_index int) []FastcGenericFn {
+	mut result := []FastcGenericFn{}
+	mut file_set := token.FileSet.new()
+	mut file := file_set.add_file(path, source.len)
+	file.index_lines_without_digest(source)
+	mut s := scanner.new_scanner(prefs, .normal)
+	s.init(file, source)
+	mut previous := token.Token.unknown
+	mut previous_pos := 0
+	mut tok := s.scan()
+	for tok != .eof {
+		if tok != .key_fn {
+			previous = tok
+			previous_pos = s.pos
+			tok = s.scan()
+			continue
+		}
+		mut fn_start := s.pos
+		if previous in [.key_pub, .key_static] {
+			fn_start = previous_pos
+		}
+		tok = s.scan()
+		mut receiver_type := ''
+		if tok == .lpar {
+			// A method with its own type parameter (`fn (mut e Enc) m[T](...)`). Parse the
+			// receiver clause and record its type; a generic-STRUCT receiver (`(e S[T])`) is
+			// a different case handled by fastc_scan_generic_methods, so bail on a `[` there.
+			tok = s.scan()
+			if tok in [.key_mut, .key_shared] {
+				tok = s.scan()
+			}
+			if tok != .name {
+				continue
+			}
+			tok = s.scan()
+			for tok == .amp || tok == .and || tok == .mul {
+				tok = s.scan()
+			}
+			if tok != .name {
+				continue
+			}
+			receiver_type = s.lit
+			tok = s.scan()
+			if tok != .rpar {
+				continue
+			}
+			tok = s.scan()
+		}
+		if tok != .name {
+			continue
+		}
+		name := s.lit
+		tok = s.scan()
+		if tok != .lsbr {
+			continue
+		}
+		bracket_start := s.pos
+		tok = s.scan()
+		if tok != .name {
+			continue
+		}
+		type_param, bracket_next := fastc_read_bracket_names(mut s)
+		tok = bracket_next
+		if tok != .rsbr {
+			continue
+		}
+		bracket_end := s.offset
+		tok = s.scan()
+		if tok != .lpar {
+			continue
+		}
+		params_open := s.pos
+		mut depth := 0
+		mut ok := true
+		for {
+			if tok == .lpar {
+				depth++
+			} else if tok == .rpar {
+				depth--
+				if depth == 0 {
+					break
+				}
+			} else if tok == .eof {
+				ok = false
+				break
+			}
+			tok = s.scan()
+		}
+		if !ok {
+			continue
+		}
+		params_close := s.offset
+		tok = s.scan()
+		for tok !in [.lcbr, .eof] {
+			tok = s.scan()
+		}
+		if tok != .lcbr {
+			continue
+		}
+		return_type_source := source[params_close..s.pos].trim_space()
+		mut brace_depth := 0
+		for {
+			if tok == .lcbr {
+				brace_depth++
+			} else if tok == .rcbr {
+				brace_depth--
+				if brace_depth == 0 {
+					break
+				}
+			} else if tok == .eof {
+				ok = false
+				break
+			}
+			tok = s.scan()
+		}
+		if !ok {
+			continue
+		}
+		def_end := s.offset
+		type_param_parameter_index := fastc_params_type_param_index(source[params_open..params_close],
+			type_param, prefs)
+		result << FastcGenericFn{
+			name:                       name
+			type_param:                 type_param
+			source_index:               source_index
+			fn_start:                   fn_start
+			def_end:                    def_end
+			bracket_start:              bracket_start
+			bracket_end:                bracket_end
+			first_param_is_type_param:  type_param_parameter_index == 0
+			type_param_parameter_index: type_param_parameter_index
+			receiver_type:              receiver_type
+			return_type_source:         return_type_source
+		}
+		previous = .rcbr
+		previous_pos = def_end
+		tok = s.scan()
+	}
+	return result
+}
+
+// fastc_params_type_param_index returns the first parameter whose type is exactly the
+// generic type parameter (`value T`). Composite uses such as `[]T` are deliberately not
+// inferred here because the concrete element type needs deeper expression inference.
+fn fastc_params_type_param_index(params_source string, type_param string, prefs &pref.Preferences) int {
+	mut file_set := token.FileSet.new()
+	mut file := file_set.add_file('params', params_source.len)
+	file.index_lines_without_digest(params_source)
+	mut s := scanner.new_scanner(prefs, .normal)
+	s.init(file, params_source)
+	mut tok := s.scan()
+	if tok != .lpar {
+		return -1
+	}
+	tok = s.scan()
+	mut parameter_index := 0
+	for tok !in [.rpar, .eof] {
+		if tok in [.key_mut, .key_shared] {
+			tok = s.scan()
+		}
+		if tok != .name {
+			return -1
+		}
+		tok = s.scan()
+		if tok == .name && s.lit == type_param {
+			after := s.scan()
+			if after in [.comma, .rpar, .eof] {
+				return parameter_index
+			}
+			tok = after
+		}
+		mut brackets := 0
+		for tok != .eof {
+			if tok == .lsbr {
+				brackets++
+			} else if tok == .rsbr {
+				brackets--
+			} else if brackets == 0 && tok in [.comma, .rpar] {
+				break
+			}
+			tok = s.scan()
+		}
+		if tok != .comma {
+			break
+		}
+		parameter_index++
+		tok = s.scan()
+	}
+	return -1
+}
+
+fn fastc_infer_literal_type(tok token.Token, lit string) string {
+	return match tok {
+		.number {
+			if lit.contains('.') {
+				'f64'
+			} else {
+				'int'
+			}
+		}
+		.string {
+			'string'
+		}
+		.key_true, .key_false {
+			'bool'
+		}
+		else {
+			''
+		}
+	}
+}
+
+// fastc_scan_generic_calls records each call to a known generic and the concrete
+// type it resolves to, or marks the generic unresolvable when a call cannot be
+// resolved at source level (a non-literal implicit argument, a bare function
+// reference, or a malformed explicit type argument).
+fn fastc_scan_generic_calls(source string, path string, prefs &pref.Preferences, source_index int, by_name map[string]FastcGenericFn, mut calls []FastcGenericCall, mut unresolvable map[string]bool, mut pairs []FastcConcretePair, mut seen_pair map[string]bool, mut has_concrete map[string]bool) {
+	mut file_set := token.FileSet.new()
+	mut file := file_set.add_file(path, source.len)
+	file.index_lines_without_digest(source)
+	mut s := scanner.new_scanner(prefs, .normal)
+	s.init(file, source)
+	// A call inside a generic body may resolve its argument to the ENCLOSING generic's
+	// type parameter (e.g. `e.enc_val(val)` with `val T` → concrete `T`). Such a call is
+	// only concrete once the enclosing generic is itself specialized (a future fixpoint),
+	// so recording it now would emit a `..._mono_T` instance with an unbound `T` and
+	// corrupt the edits. Treat a concrete that is any generic's type parameter as
+	// unresolvable so the generic is left alone rather than mis-specialized.
+	mut type_param_names := map[string]bool{}
+	for _, gen in by_name {
+		for tp in gen.type_param.split(',') {
+			type_param_names[tp] = true
+		}
+	}
+	// Lightweight, function-scoped variable-type table so an `f(x)` call can infer
+	// its concrete type from the argument variable (a parameter with a single-name
+	// type, or a local declared from a literal). A name recorded with conflicting
+	// types is marked ambiguous and no longer resolves (keeping inference safe).
+	mut var_types := map[string]string{}
+	mut var_ambiguous := map[string]bool{}
+	mut pending_var := ''
+	// `name := Foo{...}` is confirmed a struct-literal local only once the `{` after
+	// the type name is seen; hold the candidate until the next token.
+	mut pending_struct_var := ''
+	mut pending_struct_type := ''
+	mut previous := token.Token.unknown
+	mut previous_lit := ''
+	// The identifier just before a `.` — the receiver of a `recv.method(...)` call, used
+	// to look up the receiver's type and confirm a generic-method call.
+	mut before_dot_receiver := ''
+	mut tok := s.scan()
+	for tok != .eof {
+		if tok == .dot {
+			before_dot_receiver = previous_lit
+		}
+		if pending_struct_var != '' {
+			if tok == .lcbr {
+				fastc_record_var(pending_struct_var, pending_struct_type, mut var_types, mut
+					var_ambiguous)
+			}
+			pending_struct_var = ''
+			pending_struct_type = ''
+			// Fall through: process the current token normally.
+		}
+		if pending_var != '' {
+			literal_type := fastc_infer_literal_type(tok, s.lit)
+			if literal_type != '' {
+				fastc_record_var(pending_var, literal_type, mut var_types, mut var_ambiguous)
+			} else if tok == .name {
+				// Possibly `name := Type{...}`; defer confirmation to the next token.
+				pending_struct_var = pending_var
+				pending_struct_type = s.lit
+			}
+			pending_var = ''
+			// Fall through: this token may still start (or be) a generic call.
+		}
+		if tok == .key_fn {
+			var_types = map[string]string{}
+			var_ambiguous = map[string]bool{}
+			pending_var = ''
+			pending_struct_var = ''
+			pending_struct_type = ''
+			tok = fastc_collect_params(mut s, mut var_types)
+			previous = .rpar
+			previous_lit = ''
+			continue
+		}
+		if tok == .decl_assign && previous == .name {
+			pending_var = previous_lit
+			previous = tok
+			previous_lit = ''
+			tok = s.scan()
+			continue
+		}
+		mut should_skip := tok != .name || s.lit !in by_name || previous == .key_fn
+		if !should_skip {
+			probe := by_name[s.lit] or { FastcGenericFn{} }
+			if probe.receiver_type != '' {
+				// A generic METHOD resolves only as a `recv.method(...)` call whose receiver's
+				// declared type matches — never a bare or foreign-typed call.
+				recv_type := var_types[before_dot_receiver] or { '' }
+				should_skip = previous != .dot || recv_type != probe.receiver_type
+			} else {
+				// A free generic function is never a `.`-qualified field/module access.
+				should_skip = previous == .dot
+			}
+		}
+		if should_skip {
+			previous = tok
+			previous_lit = s.lit
+			tok = s.scan()
+			continue
+		}
+		name := s.lit
+		name_pos := s.pos
+		name_end := s.offset
+		// `name` is guaranteed present (checked at the loop head); the default is
+		// never taken and is written plainly to stay self-hostable.
+		generic := by_name[name] or { FastcGenericFn{} }
+		tok = s.scan()
+		if tok == .lsbr {
+			tok = s.scan()
+			if tok == .name {
+				concrete, bracket_next := fastc_read_bracket_names(mut s)
+				tok = bracket_next
+				if tok == .rsbr {
+					after := s.offset
+					if concrete in type_param_names {
+						unresolvable[name] = true
+						previous = .rsbr
+						previous_lit = ''
+						tok = s.scan()
+						continue
+					}
+					fastc_record_concrete(name, concrete, mut pairs, mut seen_pair, mut
+						has_concrete)
+					calls << FastcGenericCall{
+						name:         name
+						source_index: source_index
+						start:        name_pos
+						end:          after
+						concrete:     concrete
+					}
+					previous = .rsbr
+					previous_lit = ''
+					tok = s.scan()
+					continue
+				}
+			}
+			unresolvable[name] = true
+			previous = tok
+			previous_lit = ''
+			continue
+		}
+		if tok == .lpar {
+			// Implicit argument inference only resolves a single type parameter;
+			// multi-parameter generics must use an explicit `f[A, B](...)`.
+			if !generic.first_param_is_type_param || generic.type_param.contains(',') {
+				unresolvable[name] = true
+				previous = .lpar
+				previous_lit = ''
+				tok = s.scan()
+				continue
+			}
+			tok = s.scan()
+			mut concrete := fastc_infer_literal_type(tok, s.lit)
+			if concrete == '' && tok == .name {
+				// A bare variable argument (`f(x)`) or a struct-literal argument
+				// (`f(Foo{...})`); peek one token to tell them apart.
+				argument_name := s.lit
+				next_token := s.scan()
+				if next_token == .lcbr {
+					concrete = argument_name
+				} else if next_token in [.comma, .rpar] && argument_name !in var_ambiguous {
+					concrete = var_types[argument_name] or { '' }
+				}
+				previous = .name
+				previous_lit = argument_name
+				tok = next_token
+			} else {
+				previous = tok
+				previous_lit = ''
+			}
+			if concrete == '' || concrete in type_param_names {
+				unresolvable[name] = true
+				continue
+			}
+			fastc_record_concrete(name, concrete, mut pairs, mut seen_pair, mut has_concrete)
+			calls << FastcGenericCall{
+				name:         name
+				source_index: source_index
+				start:        name_pos
+				end:          name_end
+				concrete:     concrete
+			}
+			continue
+		}
+		// The generic name appears somewhere other than a call (e.g. passed as a
+		// value); source-level monomorphization cannot resolve it.
+		unresolvable[name] = true
+		previous = tok
+		previous_lit = ''
+		continue
+	}
+}
+
+// fastc_collect_params records the single-name-typed parameters of the function
+// whose `fn` keyword was just consumed, so `f(param)` calls can infer their
+// concrete type. It returns the token just past the parameter list.
+fn fastc_collect_params(mut s scanner.Scanner, mut var_types map[string]string) token.Token {
+	mut tok := s.scan()
+	if tok == .lpar {
+		// Method receiver `(recv Type)`: skip it.
+		mut depth := 0
+		for {
+			if tok == .lpar {
+				depth++
+			} else if tok == .rpar {
+				depth--
+				if depth == 0 {
+					break
+				}
+			} else if tok == .eof {
+				return tok
+			}
+			tok = s.scan()
+		}
+		tok = s.scan()
+	}
+	if tok != .name {
+		return tok
+	}
+	tok = s.scan()
+	if tok == .lsbr {
+		// Generic `[T]`: skip it.
+		mut depth := 0
+		for {
+			if tok == .lsbr {
+				depth++
+			} else if tok == .rsbr {
+				depth--
+				if depth == 0 {
+					break
+				}
+			} else if tok == .eof {
+				return tok
+			}
+			tok = s.scan()
+		}
+		tok = s.scan()
+	}
+	if tok != .lpar {
+		return tok
+	}
+	tok = s.scan()
+	for tok !in [.rpar, .eof] {
+		if tok in [.key_mut, .key_shared] {
+			tok = s.scan()
+		}
+		if tok != .name {
+			tok = fastc_skip_to_param_boundary(mut s, tok)
+			if tok == .comma {
+				tok = s.scan()
+				continue
+			}
+			break
+		}
+		parameter_name := s.lit
+		tok = s.scan()
+		if tok == .name {
+			type_name := s.lit
+			next_token := s.scan()
+			if next_token in [.comma, .rpar] {
+				var_types[parameter_name] = type_name
+			}
+			tok = next_token
+		}
+		tok = fastc_skip_to_param_boundary(mut s, tok)
+		if tok == .comma {
+			tok = s.scan()
+			continue
+		}
+		break
+	}
+	if tok == .rpar {
+		return s.scan()
+	}
+	return tok
+}
+
+// fastc_skip_to_param_boundary advances to the next top-level `,` or the closing
+// `)` of the parameter list, honoring nested brackets.
+fn fastc_skip_to_param_boundary(mut s scanner.Scanner, start token.Token) token.Token {
+	mut tok := start
+	mut depth := 0
+	for {
+		if tok in [.lpar, .lsbr, .lcbr] {
+			depth++
+		} else if tok in [.rsbr, .rcbr] {
+			if depth > 0 {
+				depth--
+			}
+		} else if tok == .rpar {
+			if depth == 0 {
+				return tok
+			}
+			depth--
+		} else if tok == .comma && depth == 0 {
+			return tok
+		} else if tok == .eof {
+			return tok
+		}
+		tok = s.scan()
+	}
+	return tok
+}
+
+// fastc_record_var records a variable's concrete type, marking it ambiguous (and
+// thereafter unusable for inference) if it is later seen with a different type.
+fn fastc_record_var(name string, typ string, mut var_types map[string]string, mut var_ambiguous map[string]bool) {
+	if name in var_ambiguous {
+		return
+	}
+	existing := var_types[name] or { '' }
+	if existing == '' {
+		var_types[name] = typ
+	} else if existing != typ {
+		var_ambiguous[name] = true
+	}
+}
+
+fn fastc_record_concrete(name string, concrete string, mut pairs []FastcConcretePair, mut seen_pair map[string]bool, mut has_concrete map[string]bool) {
+	pair_key := '${name}#${concrete}'
+	if pair_key !in seen_pair {
+		seen_pair[pair_key] = true
+		pairs << FastcConcretePair{
+			name:     name
+			concrete: concrete
+		}
+	}
+	has_concrete[name] = true
+}
+
+// fastc_monomorphize_structs rewrites entry-module generic structs the same way
+// as functions: it emits a concrete copy per instantiation `S[Concrete]` and
+// rewrites every reference. A struct is left untouched unless every reference is
+// a concrete instantiation and its body has no nested generic type references.
+fn fastc_monomorphize_structs(sources []FastcSourceFile, prefs &pref.Preferences) []FastcSourceFile {
+	mut structs := []FastcGenericFn{}
+	for i, source_file in sources {
+		if source_file.header.module_name !in ['', 'main'] {
+			continue
+		}
+		for generic in fastc_scan_generic_structs(source_file.source, source_file.path, prefs, i) {
+			structs << generic
+		}
+	}
+	if structs.len == 0 {
+		return sources
+	}
+	mut seen_once := map[string]bool{}
+	mut ambiguous := map[string]bool{}
+	for generic in structs {
+		if generic.name in seen_once {
+			ambiguous[generic.name] = true
+		}
+		seen_once[generic.name] = true
+	}
+	mut by_name := map[string]FastcGenericFn{}
+	for generic in structs {
+		if generic.name in ambiguous {
+			continue
+		}
+		by_name[generic.name] = generic
+	}
+	if by_name.len == 0 {
+		return sources
+	}
+	// Collect generic methods (`fn (recv S[T]) m(...)`) of the known generic
+	// structs, the positions of their receiver type references (skipped by the
+	// instance scan below), and any struct whose method cannot be monomorphized
+	// (which marks that struct unresolvable).
+	mut methods := []FastcGenericMethod{}
+	mut receiver_skip := map[string]bool{}
+	mut method_problematic := map[string]bool{}
+	for i, source_file in sources {
+		if source_file.header.module_name !in ['', 'main'] {
+			continue
+		}
+		fastc_scan_generic_methods(source_file.source, source_file.path, prefs, i, by_name, mut
+			methods, mut receiver_skip, mut method_problematic)
+	}
+	mut refs := []FastcGenericCall{}
+	mut unresolvable := map[string]bool{}
+	mut pairs := []FastcConcretePair{}
+	mut seen_pair := map[string]bool{}
+	mut has_concrete := map[string]bool{}
+	for i, source_file in sources {
+		if source_file.header.module_name !in ['', 'main'] {
+			continue
+		}
+		fastc_scan_generic_struct_instances(source_file.source, source_file.path, prefs, i,
+			by_name, receiver_skip, mut refs, mut unresolvable, mut pairs, mut seen_pair, mut
+			has_concrete)
+	}
+	for name in method_problematic.keys() {
+		unresolvable[name] = true
+	}
+	mut active := map[string]bool{}
+	for name in by_name.keys() {
+		if name in unresolvable {
+			continue
+		}
+		if name !in has_concrete {
+			continue
+		}
+		active[name] = true
+	}
+	if active.len == 0 {
+		return sources
+	}
+	mut edits := []FastcSourceEdit{}
+	mut appends := []string{len: sources.len, init: ''}
+	for name in active.keys() {
+		generic := by_name[name] or { FastcGenericFn{} }
+		definition_file := sources[generic.source_index]
+		definition_source := definition_file.source
+		edits << FastcSourceEdit{
+			source_index: generic.source_index
+			start:        generic.fn_start
+			end:          generic.def_end
+			replacement:  ''
+		}
+		mut copies := ''
+		for pair in pairs {
+			if pair.name != name {
+				continue
+			}
+			copies = copies + '\n' +
+				fastc_render_generic_instance(definition_source, generic, pair.concrete, prefs) +
+				'\n'
+		}
+		appends[generic.source_index] = appends[generic.source_index] + copies
+	}
+	// Emit each generic method once per instantiation of its struct and blank the
+	// original generic method definition.
+	for method in methods {
+		if method.struct_name !in active {
+			continue
+		}
+		method_file := sources[method.source_index]
+		method_source := method_file.source
+		edits << FastcSourceEdit{
+			source_index: method.source_index
+			start:        method.fn_start
+			end:          method.def_end
+			replacement:  ''
+		}
+		mut method_copies := ''
+		for pair in pairs {
+			if pair.name != method.struct_name {
+				continue
+			}
+			method_copies = method_copies + '\n' +
+				fastc_render_generic_method(method_source, method, pair.concrete, prefs) + '\n'
+		}
+		appends[method.source_index] = appends[method.source_index] + method_copies
+	}
+	for ref in refs {
+		if ref.name !in active {
+			continue
+		}
+		edits << FastcSourceEdit{
+			source_index: ref.source_index
+			start:        ref.start
+			end:          ref.end
+			replacement:  fastc_monomorphized_name(ref.name, ref.concrete)
+		}
+	}
+	mut result := []FastcSourceFile{cap: sources.len}
+	for i, source_file in sources {
+		mut file_edits := []FastcSourceEdit{}
+		for edit in edits {
+			if edit.source_index == i {
+				file_edits << edit
+			}
+		}
+		mut new_source := source_file.source
+		if file_edits.len > 0 {
+			new_source = fastc_apply_source_edits(new_source, file_edits)
+		}
+		if appends[i] != '' {
+			new_source = new_source + appends[i]
+		}
+		result << FastcSourceFile{
+			path:   source_file.path
+			source: new_source
+			header: source_file.header
+		}
+	}
+	return result
+}
+
+// fastc_scan_generic_structs finds `struct S[T] { ... }` definitions with a single
+// type parameter and no nested generic type reference in the body.
+fn fastc_scan_generic_structs(source string, path string, prefs &pref.Preferences, source_index int) []FastcGenericFn {
+	mut result := []FastcGenericFn{}
+	mut file_set := token.FileSet.new()
+	mut file := file_set.add_file(path, source.len)
+	file.index_lines_without_digest(source)
+	mut s := scanner.new_scanner(prefs, .normal)
+	s.init(file, source)
+	mut previous := token.Token.unknown
+	mut previous_pos := 0
+	mut tok := s.scan()
+	for tok != .eof {
+		if tok != .key_struct {
+			previous = tok
+			previous_pos = s.pos
+			tok = s.scan()
+			continue
+		}
+		mut struct_start := s.pos
+		if previous in [.key_pub, .key_static] {
+			struct_start = previous_pos
+		}
+		tok = s.scan()
+		if tok != .name {
+			continue
+		}
+		name := s.lit
+		tok = s.scan()
+		if tok != .lsbr {
+			continue
+		}
+		bracket_start := s.pos
+		tok = s.scan()
+		if tok != .name {
+			continue
+		}
+		type_param, bracket_next := fastc_read_bracket_names(mut s)
+		tok = bracket_next
+		if tok != .rsbr {
+			continue
+		}
+		bracket_end := s.offset
+		tok = s.scan()
+		if tok != .lcbr {
+			continue
+		}
+		body_open := s.pos
+		mut brace_depth := 0
+		mut ok := true
+		for {
+			if tok == .lcbr {
+				brace_depth++
+			} else if tok == .rcbr {
+				brace_depth--
+				if brace_depth == 0 {
+					break
+				}
+			} else if tok == .eof {
+				ok = false
+				break
+			}
+			tok = s.scan()
+		}
+		if !ok {
+			continue
+		}
+		def_end := s.offset
+		if !fastc_body_has_nested_generic(source[body_open..def_end], prefs) {
+			result << FastcGenericFn{
+				name:          name
+				type_param:    type_param
+				source_index:  source_index
+				fn_start:      struct_start
+				def_end:       def_end
+				bracket_start: bracket_start
+				bracket_end:   bracket_end
+			}
+		}
+		previous = .rcbr
+		previous_pos = def_end
+		tok = s.scan()
+	}
+	return result
+}
+
+// fastc_body_has_nested_generic reports whether a struct body contains a nested
+// generic type reference (`Foo[X]`). Plain arrays (`[]T`, `[N]T`) and maps
+// (`map[K]V`) are allowed; only a `Name[...]` with non-empty brackets counts.
+fn fastc_body_has_nested_generic(body string, prefs &pref.Preferences) bool {
+	mut file_set := token.FileSet.new()
+	mut file := file_set.add_file('body', body.len)
+	file.index_lines_without_digest(body)
+	mut s := scanner.new_scanner(prefs, .normal)
+	s.init(file, body)
+	mut previous := token.Token.unknown
+	mut previous_lit := ''
+	mut tok := s.scan()
+	for tok != .eof {
+		if tok == .lsbr && previous == .name && previous_lit != 'map' {
+			next_token := s.scan()
+			if next_token != .rsbr {
+				return true
+			}
+			previous = .rsbr
+			previous_lit = ''
+			tok = s.scan()
+			continue
+		}
+		previous = tok
+		previous_lit = s.lit
+		tok = s.scan()
+	}
+	return false
+}
+
+// fastc_all_concrete_type_args reports whether every comma-joined argument of a
+// (possibly multi-parameter) instantiation is a concrete type.
+fn fastc_all_concrete_type_args(concrete string) bool {
+	for part in concrete.split(',') {
+		if !fastc_is_concrete_type_arg(part) {
+			return false
+		}
+	}
+	return true
+}
+
+// fastc_is_concrete_type_arg reports whether a type-argument spelling is a
+// concrete type (a primitive, or a multi-character capitalized type name) rather
+// than a single-letter type parameter like `T`.
+fn fastc_is_concrete_type_arg(name string) bool {
+	if fastc_primitive_c_type(name) != none {
+		return true
+	}
+	if name.len > 1 {
+		first := name[0]
+		if first >= u8(65) && first <= u8(90) {
+			return true
+		}
+	}
+	return false
+}
+
+// fastc_scan_generic_struct_instances records each `S[Concrete]` reference to a
+// known generic struct, or marks the struct unresolvable when a reference is not
+// a plain concrete instantiation (a type-parameter argument, a complex type
+// argument, or a bare reference).
+fn fastc_scan_generic_struct_instances(source string, path string, prefs &pref.Preferences, source_index int, by_name map[string]FastcGenericFn, receiver_skip map[string]bool, mut refs []FastcGenericCall, mut unresolvable map[string]bool, mut pairs []FastcConcretePair, mut seen_pair map[string]bool, mut has_concrete map[string]bool) {
+	mut file_set := token.FileSet.new()
+	mut file := file_set.add_file(path, source.len)
+	file.index_lines_without_digest(source)
+	mut s := scanner.new_scanner(prefs, .normal)
+	s.init(file, source)
+	mut previous := token.Token.unknown
+	mut tok := s.scan()
+	for tok != .eof {
+		if tok != .name || s.lit !in by_name || previous in [.dot, .key_struct] {
+			previous = tok
+			tok = s.scan()
+			continue
+		}
+		name := s.lit
+		name_pos := s.pos
+		// A `S[T]` that is a generic method receiver is handled by method
+		// monomorphization, not an instantiation; skip it.
+		if '${source_index}#${name_pos}' in receiver_skip {
+			previous = tok
+			tok = s.scan()
+			continue
+		}
+		tok = s.scan()
+		if tok != .lsbr {
+			unresolvable[name] = true
+			previous = tok
+			continue
+		}
+		tok = s.scan()
+		if tok != .name {
+			unresolvable[name] = true
+			previous = tok
+			continue
+		}
+		concrete, bracket_next := fastc_read_bracket_names(mut s)
+		tok = bracket_next
+		if tok != .rsbr {
+			unresolvable[name] = true
+			previous = tok
+			continue
+		}
+		after := s.offset
+		if !fastc_all_concrete_type_args(concrete) {
+			unresolvable[name] = true
+			previous = .rsbr
+			tok = s.scan()
+			continue
+		}
+		fastc_record_concrete(name, concrete, mut pairs, mut seen_pair, mut has_concrete)
+		refs << FastcGenericCall{
+			name:         name
+			source_index: source_index
+			start:        name_pos
+			end:          after
+			concrete:     concrete
+		}
+		previous = .rsbr
+		tok = s.scan()
+	}
+}
+
+// fastc_scan_generic_methods finds methods whose receiver is a known generic
+// struct (`fn (recv S[T]) m(...)`). A method that references any generic struct
+// beyond its receiver, or carries its own type parameters, cannot be handled by
+// simple substitution and marks its struct problematic (later unresolvable).
+fn fastc_scan_generic_methods(source string, path string, prefs &pref.Preferences, source_index int, by_name map[string]FastcGenericFn, mut methods []FastcGenericMethod, mut receiver_skip map[string]bool, mut method_problematic map[string]bool) {
+	mut file_set := token.FileSet.new()
+	mut file := file_set.add_file(path, source.len)
+	file.index_lines_without_digest(source)
+	mut s := scanner.new_scanner(prefs, .normal)
+	s.init(file, source)
+	mut previous := token.Token.unknown
+	mut previous_pos := 0
+	mut tok := s.scan()
+	for tok != .eof {
+		if tok != .key_fn {
+			previous = tok
+			previous_pos = s.pos
+			tok = s.scan()
+			continue
+		}
+		mut fn_start := s.pos
+		if previous in [.key_pub, .key_static] {
+			fn_start = previous_pos
+		}
+		tok = s.scan()
+		if tok != .lpar {
+			continue
+		}
+		tok = s.scan()
+		if tok in [.key_mut, .key_shared] {
+			tok = s.scan()
+		}
+		if tok != .name {
+			continue
+		}
+		tok = s.scan()
+		if tok != .name || s.lit !in by_name {
+			continue
+		}
+		struct_name := s.lit
+		receiver_ref_start := s.pos
+		tok = s.scan()
+		if tok != .lsbr {
+			continue
+		}
+		tok = s.scan()
+		if tok != .name {
+			continue
+		}
+		type_param, bracket_next := fastc_read_bracket_names(mut s)
+		tok = bracket_next
+		if tok != .rsbr {
+			continue
+		}
+		receiver_ref_end := s.offset
+		tok = s.scan()
+		if tok != .rpar {
+			continue
+		}
+		tok = s.scan()
+		if tok != .name {
+			continue
+		}
+		tok = s.scan()
+		if tok != .lpar {
+			// A method with its own type parameters (`m[U](...)`) is beyond this pass.
+			method_problematic[struct_name] = true
+			continue
+		}
+		mut has_nested := false
+		mut prev_body := token.Token.unknown
+		mut prev_lit := ''
+		mut depth := 0
+		for {
+			if tok == .lpar {
+				depth++
+			} else if tok == .rpar {
+				depth--
+				if depth == 0 {
+					break
+				}
+			} else if tok == .eof {
+				break
+			} else if tok == .lsbr && prev_body == .name && prev_lit in by_name {
+				has_nested = true
+			}
+			prev_body = tok
+			prev_lit = s.lit
+			tok = s.scan()
+		}
+		tok = s.scan()
+		for tok !in [.lcbr, .eof] {
+			if tok == .lsbr && prev_body == .name && prev_lit in by_name {
+				has_nested = true
+			}
+			prev_body = tok
+			prev_lit = s.lit
+			tok = s.scan()
+		}
+		if tok != .lcbr {
+			continue
+		}
+		mut brace_depth := 0
+		mut ok := true
+		for {
+			if tok == .lcbr {
+				brace_depth++
+			} else if tok == .rcbr {
+				brace_depth--
+				if brace_depth == 0 {
+					break
+				}
+			} else if tok == .eof {
+				ok = false
+				break
+			} else if tok == .lsbr && prev_body == .name && prev_lit in by_name {
+				has_nested = true
+			}
+			prev_body = tok
+			prev_lit = s.lit
+			tok = s.scan()
+		}
+		if !ok {
+			continue
+		}
+		def_end := s.offset
+		if has_nested {
+			method_problematic[struct_name] = true
+		} else {
+			methods << FastcGenericMethod{
+				struct_name:        struct_name
+				type_param:         type_param
+				source_index:       source_index
+				fn_start:           fn_start
+				def_end:            def_end
+				receiver_ref_start: receiver_ref_start
+				receiver_ref_end:   receiver_ref_end
+			}
+			receiver_skip['${source_index}#${receiver_ref_start}'] = true
+		}
+		previous = .rcbr
+		previous_pos = def_end
+		tok = s.scan()
+	}
+}
+
+// fastc_render_generic_method produces the concrete source of one method
+// instance: the receiver reference `S[T]` becomes `S__mono_<C>` and the type
+// parameter is substituted everywhere else (parameters, return type, body).
+fn fastc_render_generic_method(source string, method FastcGenericMethod, concrete string, prefs &pref.Preferences) string {
+	definition := source[method.fn_start..method.def_end]
+	base := method.fn_start
+	receiver_low := method.receiver_ref_start - base
+	receiver_high := method.receiver_ref_end - base
+	mut edits := []FastcSourceEdit{}
+	edits << FastcSourceEdit{
+		start:       receiver_low
+		end:         receiver_high
+		replacement: fastc_monomorphized_name(method.struct_name, concrete)
+	}
+	mut file_set := token.FileSet.new()
+	mut file := file_set.add_file('method', definition.len)
+	file.index_lines_without_digest(definition)
+	mut s := scanner.new_scanner(prefs, .normal)
+	s.init(file, definition)
+	substitutions := fastc_type_param_substitutions(method.type_param, concrete)
+	mut tok := s.scan()
+	for tok != .eof {
+		if tok == .name && !(s.pos >= receiver_low && s.pos < receiver_high) {
+			if replacement := substitutions[s.lit] {
+				edits << FastcSourceEdit{
+					start:       s.pos
+					end:         s.offset
+					replacement: replacement
+				}
+			}
+		}
+		tok = s.scan()
+	}
+	return fastc_apply_source_edits(definition, edits)
+}

--- a/vlib/v3/gen/fastc/render.v
+++ b/vlib/v3/gen/fastc/render.v
@@ -1,6 +1,81 @@
 module fastc
 
 import strings
+import v3.token
+
+// fastc_builtin_type_idx maps a primitive type name to V's canonical builtin
+// type index (vlib/v/ast/types.v). Used to evaluate `typeof[T]().idx`.
+fn fastc_builtin_type_idx(type_name string) ?int {
+	return match type_name {
+		'void' { 1 }
+		'voidptr' { 2 }
+		'byteptr' { 3 }
+		'charptr' { 4 }
+		'i8' { 5 }
+		'i16' { 6 }
+		'i32' { 7 }
+		'int' { 8 }
+		'i64' { 9 }
+		'isize' { 10 }
+		'u8', 'byte' { 11 }
+		'u16' { 12 }
+		'u32' { 13 }
+		'u64' { 14 }
+		'usize' { 15 }
+		'f32' { 16 }
+		'f64' { 17 }
+		'char' { 18 }
+		'bool' { 19 }
+		'string' { 21 }
+		'rune' { 22 }
+		'array' { 23 }
+		'map' { 24 }
+		'chan' { 25 }
+		'any' { 26 }
+		'float_literal' { 27 }
+		'int_literal' { 28 }
+		'thread' { 29 }
+		else { none }
+	}
+}
+
+// render_typeof_generic_expression lowers `typeof[T]().idx` and `typeof[T]().name`
+// (compile-time type reflection, used by vlib/orm) to a constant int / string.
+fn (g &Parser) render_typeof_generic_expression(tokens []FastcExpressionToken) ?FastcRenderedExpression {
+	if tokens.len < 8 || tokens[0].lit != 'typeof' || tokens[1].tok != .lsbr {
+		return none
+	}
+	close_bracket := fastc_matching_delimiter(tokens, 1, .lsbr, .rsbr) or { return none }
+	// Require exactly `typeof[T] ( ) . field` with `field` ending the expression.
+	if close_bracket + 4 != tokens.len - 1 || tokens[close_bracket + 1].tok != .lpar
+		|| tokens[close_bracket + 2].tok != .rpar || tokens[close_bracket + 3].tok != .dot
+		|| tokens[tokens.len - 1].tok != .name {
+		return none
+	}
+	type_tokens := tokens[2..close_bracket]
+	if type_tokens.len != 1 || type_tokens[0].tok != .name {
+		return none
+	}
+	type_name := type_tokens[0].lit
+	match tokens[tokens.len - 1].lit {
+		'idx' {
+			idx := fastc_builtin_type_idx(type_name) or { return none }
+			return FastcRenderedExpression{
+				source: idx.str()
+				typ:    'int'
+			}
+		}
+		'name' {
+			return FastcRenderedExpression{
+				source: '_S("${type_name}")'
+				typ:    'string'
+			}
+		}
+		else {
+			return none
+		}
+	}
+}
 
 fn (g &Parser) render_typeof_name_expression(tokens []FastcExpressionToken) ?FastcRenderedExpression {
 	if tokens.len < 6 || tokens[0].lit != 'typeof' || tokens[1].tok != .lpar
@@ -29,6 +104,48 @@ fn (g &Parser) render_typeof_name_expression(tokens []FastcExpressionToken) ?Fas
 	}
 }
 
+fn (g &Parser) render_typeof_generic_comparison_expression(tokens []FastcExpressionToken) ?FastcRenderedExpression {
+	mut depth := 0
+	for i, item in tokens {
+		if item.tok in [.lpar, .lsbr, .lcbr] {
+			depth++
+			continue
+		}
+		if item.tok in [.rpar, .rsbr, .rcbr] {
+			depth--
+			continue
+		}
+		if depth != 0 || item.tok !in [.eq, .ne, .lt, .gt, .le, .ge] || i == 0
+			|| i + 1 >= tokens.len {
+			continue
+		}
+		left_tokens := tokens[..i]
+		right_tokens := tokens[i + 1..]
+		left_typeof := g.render_typeof_generic_expression(left_tokens)
+		right_typeof := g.render_typeof_generic_expression(right_tokens)
+		if left_typeof == none && right_typeof == none {
+			return none
+		}
+		mut left := ''
+		if left_value := left_typeof {
+			left = left_value.source
+		} else {
+			left = g.render_comparison_operand(left_tokens, 'int') or { return none }
+		}
+		mut right := ''
+		if right_value := right_typeof {
+			right = right_value.source
+		} else {
+			right = g.render_comparison_operand(right_tokens, 'int') or { return none }
+		}
+		return FastcRenderedExpression{
+			source: '((${left})${item.tok.str()}(${right}))'
+			typ:    'bool'
+		}
+	}
+	return none
+}
+
 fn (g &Parser) render_disabled_call_expression(tokens []FastcExpressionToken) ?FastcRenderedExpression {
 	if tokens.len < 3 || tokens.last().tok != .rpar {
 		return none
@@ -39,7 +156,7 @@ fn (g &Parser) render_disabled_call_expression(tokens []FastcExpressionToken) ?F
 		name_index = 2
 		open_index = 3
 	}
-	if tokens[name_index].tok != .name || tokens[open_index].tok != .lpar {
+	if tokens[name_index].tok !in [.name, .key_select] || tokens[open_index].tok != .lpar {
 		return none
 	}
 	close := fastc_matching_rpar(tokens, open_index) or { return none }
@@ -67,10 +184,21 @@ fn (g &Parser) render_disabled_call_expression(tokens []FastcExpressionToken) ?F
 }
 
 fn (g &Parser) render_cast_expression(tokens []FastcExpressionToken) ?FastcRenderedExpression {
+	is_option_cast := tokens.len > 0 && tokens[0].tok == .question
+	type_start := if is_option_cast { 1 } else { 0 }
 	mut open := -1
 	mut c_type := ''
+	type_qualifier_start := if tokens.len > 0 && tokens[0].tok in [.amp, .and] { 1 } else { 0 }
 	for i, item in tokens {
-		if item.tok != .lpar {
+		if item.tok != .lpar || i <= type_start {
+			continue
+		}
+		if i >= 2 && tokens[i - 2].tok == .dot && !(i == type_qualifier_start + 3
+			&& tokens[type_qualifier_start].tok == .name
+			&& (tokens[type_qualifier_start].lit in g.imports
+			|| tokens[type_qualifier_start].lit == 'C')) {
+			// `receiver.u32()` is a method even though its name is also a primitive
+			// type. Only a bare/qualified type at the start can introduce a cast.
 			continue
 		}
 		// A leading `*` is a dereference around the cast, not part of its type.
@@ -79,7 +207,13 @@ fn (g &Parser) render_cast_expression(tokens []FastcExpressionToken) ?FastcRende
 		if tokens[0].tok == .mul {
 			return none
 		}
-		c_type = g.type_from_expression_tokens(tokens[..i]) or { '' }
+		if i == type_qualifier_start + 3 && tokens[type_qualifier_start].tok == .name
+			&& tokens[type_qualifier_start].lit == 'C'
+			&& ('C.${tokens[type_qualifier_start + 2].lit}' in g.functions
+			|| !fastc_call_has_one_argument(tokens, i)) {
+			return none
+		}
+		c_type = g.type_from_expression_tokens(tokens[type_start..i]) or { '' }
 		if c_type == '' && i == 3 && tokens[0].tok == .name && tokens[0].lit == 'C'
 			&& tokens[1].tok == .dot && tokens[2].tok == .name && tokens[2].lit.len > 0
 			&& tokens[2].lit[0].is_capital() && 'C.${tokens[2].lit}' !in g.functions {
@@ -97,10 +231,75 @@ fn (g &Parser) render_cast_expression(tokens []FastcExpressionToken) ?FastcRende
 	if close != tokens.len - 1 || open + 1 == close {
 		return none
 	}
-	inner := g.render_call_argument_expression(tokens[open + 1..close], c_type) or { return none }
+	inner_tokens := tokens[open + 1..close]
+	if is_option_cast {
+		if inner_tokens.len == 1 && inner_tokens[0].tok == .key_none {
+			return FastcRenderedExpression{
+				source: '(Option){.state=2}'
+				typ:    'Option'
+			}
+		}
+		inner_type := g.infer_expression_type(inner_tokens) or { '' }
+		inner := g.render_call_argument_expression(inner_tokens, if inner_type == 'Option' {
+			'Option'
+		} else {
+			c_type
+		}) or { return none }
+		return FastcRenderedExpression{
+			source: if inner_type == 'Option' {
+				inner
+			} else {
+				fastc_option_success_expression(c_type, inner)
+			}
+			typ:    'Option'
+		}
+	}
+	inner := g.render_call_argument_expression(inner_tokens, c_type) or { return none }
 	return FastcRenderedExpression{
 		source: '((${c_type})(${inner}))'
 		typ:    c_type
+	}
+}
+
+// render_c_interface_object_address lowers the C-interop escape hatch used to free
+// an interface object: `&C.mod__Interface(value)._object`. The raw `C.Type(value)`
+// spelling denotes a pointer reinterpretation here; leaving it untouched makes C
+// parse `Type` as a function call.
+fn (g &Parser) render_c_interface_object_address(tokens []FastcExpressionToken) ?FastcRenderedExpression {
+	if tokens.len != 9 || tokens[0].tok != .amp || tokens[1].tok != .name || tokens[1].lit != 'C'
+		|| tokens[2].tok != .dot || tokens[3].tok != .name || tokens[4].tok != .lpar
+		|| tokens[6].tok != .rpar || tokens[7].tok != .dot || tokens[8].tok != .name
+		|| tokens[8].lit != '_object' {
+		return none
+	}
+	close := fastc_matching_rpar(tokens, 4) or { return none }
+	if close != 6 {
+		return none
+	}
+	c_type := tokens[3].lit
+	if g.declared_kinds[g.semantic_type_key(c_type)] != .interface_ {
+		return none
+	}
+	inner := g.render_call_argument_expression(tokens[5..6], '${c_type}*') or { return none }
+	return FastcRenderedExpression{
+		source: '&(((${c_type} *)(${inner}))->_object)'
+		typ:    'voidptr*'
+	}
+}
+
+fn (g &Parser) render_c_struct_sizeof(tokens []FastcExpressionToken) ?FastcRenderedExpression {
+	if tokens.len != 6 || tokens[0].tok != .key_sizeof || tokens[1].tok != .lpar
+		|| tokens[2].tok != .name || tokens[2].lit != 'C' || tokens[3].tok != .dot
+		|| tokens[4].tok != .name || tokens[5].tok != .rpar {
+		return none
+	}
+	c_name := tokens[4].lit
+	if '#Cstruct#${c_name}' !in g.declared_types {
+		return none
+	}
+	return FastcRenderedExpression{
+		source: 'sizeof(struct ${c_name})'
+		typ:    'int'
 	}
 }
 
@@ -220,6 +419,86 @@ fn (g &Parser) render_static_call_expression(tokens []FastcExpressionToken, rend
 		}
 		type_key := function_key.all_before_last('.')
 		owner := fastc_c_declared_type_name(type_key)
+		call_start := if i >= 4 && tokens[i - 4].tok == .name && tokens[i - 3].tok == .dot {
+			i - 4
+		} else {
+			i - 2
+		}
+		call_args := fastc_call_arguments(tokens, i + 1, call_end) or { continue }
+		mut named_start := -1
+		for argument_index, argument in call_args {
+			if argument.len >= 3 && argument[0].tok == .name && argument[1].tok == .colon {
+				named_start = argument_index
+				break
+			}
+		}
+		if named_start >= 0 && named_start == signature.parameter_types.len - 1
+			&& named_start <= call_args.len && (signature.last_parameter_is_params
+			|| g.fastc_type_is_declared_struct(signature.parameter_types[named_start])) {
+			mut rendered_arguments := []string{cap: signature.parameter_types.len}
+			mut arguments_ok := true
+			for argument_index, argument in call_args[..named_start] {
+				rendered_argument := g.render_call_argument_expression(argument,
+					signature.parameter_types[argument_index]) or {
+					arguments_ok = false
+					break
+				}
+				rendered_arguments << rendered_argument
+			}
+			if arguments_ok {
+				named_initializer := g.render_named_struct_initializer(signature.parameter_types[named_start],
+					call_args[named_start..]) or { '' }
+				if named_initializer != '' {
+					rendered_arguments << named_initializer
+					call_source := '${fastc_method_c_name_for_key(type_key, tokens[i].lit)}(${rendered_arguments.join(',')})'
+					if call_start == 0 && call_end == tokens.len - 1 {
+						return FastcRenderedExpression{
+							source: call_source
+							typ:    signature.return_type
+						}
+					}
+					raw_call := g.render_raw_expression_tokens(tokens[call_start..call_end + 1]) or {
+						continue
+					}
+					if rendered.contains(raw_call) {
+						rendered = rendered.replace(raw_call, call_source)
+						result_type = signature.return_type
+						changed = true
+						continue
+					}
+				}
+			}
+		}
+		if call_args.len == signature.parameter_types.len {
+			mut rendered_arguments := []string{cap: call_args.len}
+			mut arguments_ok := true
+			for argument_index, argument in call_args {
+				rendered_argument := g.render_call_argument_expression(argument,
+					signature.parameter_types[argument_index]) or {
+					arguments_ok = false
+					break
+				}
+				rendered_arguments << rendered_argument
+			}
+			if arguments_ok {
+				call_source := '${fastc_method_c_name_for_key(type_key, tokens[i].lit)}(${rendered_arguments.join(',')})'
+				if call_start == 0 && call_end == tokens.len - 1 {
+					return FastcRenderedExpression{
+						source: call_source
+						typ:    signature.return_type
+					}
+				}
+				raw_call := g.render_raw_expression_tokens(tokens[call_start..call_end + 1]) or {
+					continue
+				}
+				if rendered.contains(raw_call) {
+					rendered = rendered.replace(raw_call, call_source)
+					result_type = signature.return_type
+					changed = true
+					continue
+				}
+			}
+		}
 		mut needle := '${owner}.${tokens[i].lit}('
 		if !rendered.contains(needle) {
 			needle = '${owner}__${tokens[i].lit}('
@@ -247,6 +526,15 @@ fn (g &Parser) method_function_key(receiver_type string, name string) string {
 	if direct_key in g.functions {
 		return direct_key
 	}
+	// A type alias (`type GitlyDb = sqlite.DB`) inherits its base type's methods, so a
+	// method missing on the alias resolves against the underlying type.
+	base := g.underlying_alias_type(receiver_type)
+	if base != receiver_type {
+		base_key := '${g.semantic_type_key(base)}.${name}'
+		if base_key in g.functions {
+			return base_key
+		}
+	}
 	if g.selfhost && name in ['keys', 'values'] && 'map.${name}' in g.functions {
 		return 'map.${name}'
 	}
@@ -269,9 +557,34 @@ fn (g &Parser) method_function_key(receiver_type string, name string) string {
 	return direct_key
 }
 
+// resolve_method finds a method for `receiver_type`, promoting through embedded
+// fields (`__embedded_N`) when the receiver has no direct method of that name (as
+// V does with struct embedding). It returns the resolved function key and the
+// member-access path to the embedded field whose type owns the method (empty for
+// a direct method).
+fn (g &Parser) resolve_method(receiver_type string, name string) (string, []string) {
+	direct := g.method_function_key(receiver_type, name)
+	if direct in g.functions {
+		return direct, []string{}
+	}
+	layout_type := receiver_type.trim_right('*')
+	for field in g.struct_field_info[layout_type] {
+		if !field.name.starts_with('__embedded_') {
+			continue
+		}
+		key, path := g.resolve_method(field.typ, name)
+		if key in g.functions {
+			mut full := [field.name]
+			full << path
+			return key, full
+		}
+	}
+	return direct, []string{}
+}
+
 fn (g &Parser) specialized_method_return_type(receiver_type string, method_key string, signature FastcFunctionSignature) string {
 	if method_key in ['map.keys', 'map.values'] {
-		key_type, value_type := fastc_map_key_value_types(receiver_type) or {
+		key_type, value_type := g.map_key_value_types(receiver_type) or {
 			return signature.return_type
 		}
 		element_type := if method_key == 'map.keys' { key_type } else { value_type }
@@ -298,32 +611,120 @@ fn (g &Parser) specialized_method_return_type(receiver_type string, method_key s
 }
 
 fn (g &Parser) render_interface_cast_expression(tokens []FastcExpressionToken, rendered_expression string) ?FastcRenderedExpression {
-	if tokens.len < 4 || tokens[0].tok != .name || tokens[1].tok != .lpar
-		|| tokens.last().tok != .rpar {
+	if tokens.len < 4 || tokens.last().tok != .rpar {
 		return none
 	}
-	type_key := fastc_resolve_declared_type_key(g.module_name, tokens[0].lit, g.imports,
-		g.declared_types) or { return none }
-	if g.declared_kinds[type_key] != .interface_ {
-		return none
-	}
-	close := fastc_matching_rpar(tokens, 1) or { return none }
-	if close != tokens.len - 1 {
+	// The cast type may be unqualified (`Sum(value)`, type at token 0, `(` at 1) or
+	// qualified (`mod.Sum(value)`, type at token 2, `(` at 3).
+	mut type_key := ''
+	mut open_index := 0
+	if tokens[0].tok == .name && tokens[1].tok == .lpar {
+		type_key = fastc_resolve_declared_type_key(g.module_name, tokens[0].lit, g.imports,
+			g.declared_types) or { return none }
+		open_index = 1
+	} else if tokens.len >= 6 && tokens[0].tok == .name && tokens[1].tok == .dot
+		&& tokens[2].tok == .name && tokens[3].tok == .lpar && tokens[0].lit in g.imports {
+		qualified_key := fastc_type_key(g.imports[tokens[0].lit], tokens[2].lit)
+		if qualified_key !in g.declared_types {
+			return none
+		}
+		type_key = qualified_key
+		open_index = 3
+	} else {
 		return none
 	}
 	interface_type := fastc_c_declared_type_name(type_key)
+	// An explicit conversion to an interface or a sum type (`Animal(Dog{})`) boxes
+	// the concrete operand; both share the boxed representation.
+	if g.declared_kinds[type_key] != .interface_ && interface_type !in g.sum_types {
+		return none
+	}
+	close := fastc_matching_rpar(tokens, open_index) or { return none }
+	if close != tokens.len - 1 {
+		return none
+	}
 	prefix := '((${interface_type})('
 	if !rendered_expression.starts_with(prefix) || !rendered_expression.ends_with('))') {
 		return none
 	}
-	inner_source := rendered_expression[prefix.len..rendered_expression.len - 2]
-	actual_type := g.infer_expression_type(tokens[2..close]) or { return none }
+	actual_type := g.infer_expression_type(tokens[open_index + 1..close]) or { return none }
 	if actual_type == '' {
 		return none
+	}
+	inner_tokens := tokens[open_index + 1..close]
+	// A composite operand (array / map literal) does not survive as raw streamed
+	// text (`[1,2,3]` is not valid C), so render it through the argument path.
+	// A struct literal likewise needs its designated-initializer lowering before boxing.
+	// Scalars and pointers keep the already-streamed spelling.
+	actual_base := actual_type.trim_right('*')
+	inner_source := if struct_literal := g.render_struct_literal_expression(inner_tokens) {
+		struct_literal.source
+	} else if actual_base.starts_with('Array_') || actual_base.starts_with('Map_') {
+		g.render_call_argument_expression(inner_tokens, actual_type) or { return none }
+	} else {
+		rendered_expression[prefix.len..rendered_expression.len - 2]
 	}
 	return FastcRenderedExpression{
 		source: g.interface_value_expression(interface_type, actual_type, inner_source)
 		typ:    interface_type
+	}
+}
+
+// render_mutable_map_value_pointer returns a pointer to a map entry, inserting a
+// zero value first when the key is absent. Nested map assignments use it to turn
+// `outer[key]` into an addressable inner map instead of emitting invalid C indexing.
+fn (g &Parser) render_mutable_map_value_pointer(tokens []FastcExpressionToken) ?FastcRenderedExpression {
+	if tokens.len < 4 || tokens.last().tok != .rsbr {
+		return none
+	}
+	mut open := -1
+	mut depth := 0
+	for i := tokens.len - 1; i >= 0; i-- {
+		if tokens[i].tok == .rsbr {
+			depth++
+		} else if tokens[i].tok == .lsbr {
+			depth--
+			if depth == 0 {
+				open = i
+				break
+			}
+		}
+	}
+	if open <= 0 || open + 1 == tokens.len - 1 {
+		return none
+	}
+	base_tokens := tokens[..open]
+	map_type := g.infer_expression_type(base_tokens) or { return none }
+	key_type, value_type := g.map_key_value_types(map_type) or { return none }
+	key_source := g.render_call_argument_expression(tokens[open + 1..tokens.len - 1], key_type) or {
+		return none
+	}
+	mut map_address := ''
+	if nested := g.render_mutable_map_value_pointer(base_tokens) {
+		if nested.typ != map_type.trim_right('*') {
+			return none
+		}
+		map_address = nested.source
+	} else {
+		map_source := if base_tokens.len == 1 && base_tokens[0].tok == .name {
+			g.globals[fastc_global_key(g.module_name, base_tokens[0].lit)] or {
+				g.resolved_expression_name(base_tokens[0].lit, .unknown)
+			}
+		} else {
+			g.render_member_receiver(base_tokens) or {
+				g.render_raw_expression_tokens(base_tokens) or { return none }
+			}
+		}
+		map_address = if map_type.ends_with('*') { map_source } else { '&(${map_source})' }
+	}
+	mut empty_value := '(${value_type}){0}'
+	if nested_key_type, nested_value_type := g.map_key_value_types(value_type) {
+		hash_fn, eq_fn, clone_fn, free_fn := g.map_runtime_functions(nested_key_type)
+		empty_value = '(${value_type})builtin__new_map(sizeof(${fastc_runtime_c_type(nested_key_type)}), sizeof(${fastc_runtime_c_type(nested_value_type)}), &${hash_fn}, &${eq_fn}, &${clone_fn}, &${free_fn})'
+	}
+	return FastcRenderedExpression{
+		source: '({ ${key_type} __v_fastc_nested_map_key = (${key_source}); ${value_type} *__v_fastc_nested_map_value = (${value_type} *)builtin__map_get_check((map *)(${map_address}), &__v_fastc_nested_map_key); if (__v_fastc_nested_map_value == NULL) { ${value_type} __v_fastc_nested_map_empty = ${empty_value}; builtin__map_set((map *)(${map_address}), &__v_fastc_nested_map_key, &__v_fastc_nested_map_empty); __v_fastc_nested_map_value = (${value_type} *)builtin__map_get_check((map *)(${map_address}), &__v_fastc_nested_map_key); } __v_fastc_nested_map_value; })'
+		typ:    value_type
 	}
 }
 
@@ -343,7 +744,7 @@ fn (g &Parser) render_map_expression(tokens []FastcExpressionToken) ?FastcRender
 	}
 	if literal_open > 0 && literal_open + 1 == tokens.len - 1 && tokens.last().tok == .rcbr {
 		if map_type := g.map_initializer_type(tokens[..literal_open]) {
-			key_type, value_type := fastc_map_key_value_types(map_type) or { return none }
+			key_type, value_type := g.map_key_value_types(map_type) or { return none }
 			hash_fn, eq_fn, clone_fn, free_fn := g.map_runtime_functions(key_type)
 			return FastcRenderedExpression{
 				source: '(builtin__new_map(sizeof(${fastc_runtime_c_type(key_type)}), sizeof(${fastc_runtime_c_type(value_type)}), &${hash_fn}, &${eq_fn}, &${clone_fn}, &${free_fn}))'
@@ -390,16 +791,24 @@ fn (g &Parser) render_map_expression(tokens []FastcExpressionToken) ?FastcRender
 		}
 		base_tokens := tokens[..open]
 		map_type := g.infer_expression_type(base_tokens) or { return none }
-		key_type, value_type := fastc_map_key_value_types(map_type) or { return none }
+		key_type, value_type := g.map_key_value_types(map_type) or { return none }
 		key_source := g.render_call_argument_expression(tokens[open + 1..close], key_type) or {
 			return none
 		}
 		value_source := g.render_call_argument_expression(tokens[assignment_index + 1..],
 			value_type) or { return none }
-		map_source := g.render_member_receiver(base_tokens) or {
-			g.render_raw_expression_tokens(base_tokens) or { return none }
+		mut map_address := ''
+		if nested := g.render_mutable_map_value_pointer(base_tokens) {
+			if nested.typ != map_type.trim_right('*') {
+				return none
+			}
+			map_address = nested.source
+		} else {
+			map_source := g.render_member_receiver(base_tokens) or {
+				g.render_raw_expression_tokens(base_tokens) or { return none }
+			}
+			map_address = if map_type.ends_with('*') { map_source } else { '&${map_source}' }
 		}
-		map_address := if map_type.ends_with('*') { map_source } else { '&${map_source}' }
 		return FastcRenderedExpression{
 			source: '({ ${key_type} __v_fastc_map_key = (${key_source}); ${value_type} __v_fastc_map_value = (${value_source}); builtin__map_set((map *)${map_address}, &__v_fastc_map_key, &__v_fastc_map_value); __v_fastc_map_value; })'
 			typ:    value_type
@@ -412,7 +821,7 @@ fn (g &Parser) render_map_expression(tokens []FastcExpressionToken) ?FastcRender
 			return none
 		}
 		map_type := g.infer_expression_type(tokens[..1]) or { return none }
-		key_type, value_type := fastc_map_key_value_types(map_type) or { return none }
+		key_type, value_type := g.map_key_value_types(map_type) or { return none }
 		key_source := g.render_call_argument_expression(tokens[2..close], key_type) or {
 			return none
 		}
@@ -513,6 +922,52 @@ fn (g &Parser) render_enum_print_expression(tokens []FastcExpressionToken) ?Fast
 	}
 }
 
+fn (g &Parser) render_selfhost_print_expression(tokens []FastcExpressionToken) ?FastcRenderedExpression {
+	if !g.selfhost || tokens.len < 4 || tokens[0].tok != .name
+		|| tokens[0].lit !in ['print', 'println'] || tokens[1].tok != .lpar
+		|| tokens.last().tok != .rpar {
+		return none
+	}
+	call_end := fastc_matching_rpar(tokens, 1) or { return none }
+	if call_end != tokens.len - 1 {
+		return none
+	}
+	call_arguments := fastc_call_arguments(tokens, 1, call_end) or { return none }
+	if call_arguments.len != 1 {
+		return none
+	}
+	argument_type := fastc_normalize_inferred_type(g.infer_expression_type(call_arguments[0]) or {
+		return none
+	})
+	if g.underlying_alias_type(argument_type).trim_right('*') == 'string' {
+		return none
+	}
+	argument := g.render_call_argument_expression(call_arguments[0], argument_type) or {
+		return none
+	}
+	method_key, embedded_path := g.resolve_method(argument_type, 'str')
+	if embedded_path.len > 0 {
+		return none
+	}
+	signature := g.functions[method_key] or { return none }
+	if signature.parameter_types.len == 0 || signature.return_type != 'string' {
+		return none
+	}
+	expected_receiver := signature.parameter_types[0]
+	receiver_argument := if expected_receiver.ends_with('*') && !argument_type.ends_with('*') {
+		'&(${argument})'
+	} else if !expected_receiver.ends_with('*') && argument_type.ends_with('*') {
+		'*(${argument})'
+	} else {
+		argument
+	}
+	string_value := '${fastc_method_c_name(signature.module_name, expected_receiver, 'str')}(${receiver_argument})'
+	return FastcRenderedExpression{
+		source: 'builtin__${tokens[0].lit}(${string_value})'
+		typ:    'void'
+	}
+}
+
 fn (g &Parser) render_struct_literal_with_defaults(c_type string, layout_type string, explicit_initializers []string, rendered_fields []string, rendered_fields_by_name map[string]string) FastcRenderedExpression {
 	base_type := c_type.trim_right('*')
 	mut assignments := []string{cap: rendered_fields.len}
@@ -570,6 +1025,13 @@ fn (g &Parser) render_empty_struct_initializer(c_type string) string {
 	empty_initializers := []string{}
 	return g.render_struct_literal_with_defaults(c_type, layout_type, empty_initializers,
 		rendered_fields, rendered_fields_by_name).source
+}
+
+// fastc_type_is_declared_struct reports whether `c_type` names a declared struct/union.
+// (A missing key defaults to `.struct_`, the zero enum value, so the key must be present.)
+fn (g &Parser) fastc_type_is_declared_struct(c_type string) bool {
+	key := g.semantic_type_key(c_type)
+	return key in g.declared_kinds && g.declared_kinds[key] in [.struct_, .union_]
 }
 
 fn (g &Parser) render_named_struct_initializer(c_type string, fields [][]FastcExpressionToken) ?string {
@@ -647,23 +1109,31 @@ fn (g &Parser) render_struct_literal_expression(tokens []FastcExpressionToken) ?
 	if layout_type in g.struct_fields {
 		fields = g.struct_fields[layout_type].clone()
 	}
-	if is_c_struct_literal && open + 1 < close {
+	if open + 1 < close {
 		items := fastc_expression_list_items(tokens, open + 1, close) or { return none }
 		mut is_positional := false
-		for item in items {
-			if item.len == 0 {
-				continue
-			}
-			if !(item.len >= 2 && item[0].tok == .name && item[1].tok == .colon) && !(item.len == 1
-				&& item[0].tok == .name && item[0].lit in fields) {
-				is_positional = true
-				break
+		if !fastc_expression_tokens_contain(tokens[open + 1..close], .ellipsis) {
+			for item in items {
+				if item.len == 0 {
+					continue
+				}
+				if !(item.len >= 2 && item[0].tok == .name && item[1].tok == .colon)
+					&& !(item.len == 1 && item[0].tok == .name && item[0].lit in fields) {
+					is_positional = true
+					break
+				}
 			}
 		}
 		if is_positional {
 			mut values := []string{cap: items.len}
-			for item in items {
-				values << g.render_call_argument_expression(item, '') or { return none }
+			for item_index, item in items {
+				expected_type := if !is_c_struct_literal
+					&& item_index < g.struct_field_info[layout_type].len {
+					g.struct_field_info[layout_type][item_index].typ
+				} else {
+					''
+				}
+				values << g.render_call_argument_expression(item, expected_type) or { return none }
 			}
 			source := if c_type.ends_with('*') {
 				'&(${c_type.trim_right('*')}){${values.join(',')}}'
@@ -680,6 +1150,7 @@ fn (g &Parser) render_struct_literal_expression(tokens []FastcExpressionToken) ?
 	mut rendered_fields_by_name := map[string]string{}
 	mut field_values := map[string]string{}
 	mut explicit_initializers := []string{}
+	mut fixed_array_copies := []string{}
 	mut has_applied_defaults := false
 	mut update_source := ''
 	mut index := open + 1
@@ -777,6 +1248,17 @@ fn (g &Parser) render_struct_literal_expression(tokens []FastcExpressionToken) ?
 					c_storage_path << fastc_c_identifier(storage_name)
 				}
 				c_field_name = c_storage_path.join('.')
+			} else {
+				// Initializing an embedded field by its type name:
+				// `Derived{ Base: Base{...} }` sets the `__embedded_N` field.
+				for embed_field in g.struct_field_info[layout_type] {
+					if embed_field.name.starts_with('__embedded_') && (embed_field.typ == field_name
+						|| embed_field.typ.all_after_last('__') == field_name) {
+						c_field_name = embed_field.name
+						expected_type = embed_field.typ
+						break
+					}
+				}
 			}
 		}
 		if fixed_element_type := fastc_fixed_array_element_type(expected_type) {
@@ -805,8 +1287,30 @@ fn (g &Parser) render_struct_literal_expression(tokens []FastcExpressionToken) ?
 				field_values[field_name] = '{${values.join(',')}}'
 				continue
 			}
+			value := g.render_call_argument_expression(value_tokens, expected_type) or {
+				return none
+			}
+			is_raw_fixed_array := value_tokens.len > 1 || (value_tokens.len == 1
+				&& value_tokens[0].tok == .name
+				&& fastc_global_key(g.module_name, value_tokens[0].lit) in g.globals)
+			copy_source := if is_raw_fixed_array {
+				value
+			} else if expected_type.ends_with('*') {
+				'(${value})->data'
+			} else {
+				'(${value}).data'
+			}
+			fixed_array_copies << 'memcpy(__v_fastc_struct_fixed.${c_field_name}, ${copy_source}, sizeof(__v_fastc_struct_fixed.${c_field_name}));'
+			field_values[field_name] = value
+			continue
 		}
-		value := g.render_call_argument_expression(value_tokens, expected_type) or { return none }
+		value := if value_tokens.len == 1 && value_tokens[0].source != '' {
+			// A field value carried as a pre-rendered `({ ... })` (e.g. an `or`-unwrap) is used
+			// directly so its internal temporaries stay self-contained.
+			value_tokens[0].source
+		} else {
+			g.render_call_argument_expression(value_tokens, expected_type) or { return none }
+		}
 		temporary := '__v_fastc_struct_field_${explicit_initializers.len}'
 		explicit_initializers << '__typeof__((${value})) ${temporary} = (${value});'
 		rendered_field := '.${c_field_name}=(${temporary})'
@@ -844,24 +1348,22 @@ fn (g &Parser) render_struct_literal_expression(tokens []FastcExpressionToken) ?
 		rendered_fields = ordered_fields.clone()
 	}
 	if layout_type == 'array' {
-		element_type := g.array_element_type(c_type) or { return none }
+		array_type := c_type.trim_right('*')
+		element_type := g.array_element_type(array_type) or { return none }
 		length := field_values['len'] or { '0' }
 		capacity := field_values['cap'] or { '0' }
-		base := '((${c_type})builtin____new_array(${length},${capacity},sizeof(${element_type})))'
+		base := '((${array_type})builtin____new_array(${length},${capacity},sizeof(${element_type})))'
+		mut value_source := base
 		if initial := field_values['init'] {
-			return FastcRenderedExpression{
-				source: '({ ${explicit_initializers.join(' ')} ${c_type} __v_fastc_array_init = ${base}; ${element_type} __v_fastc_array_default = (${initial}); for (int __v_fastc_array_index = 0; __v_fastc_array_index < __v_fastc_array_init.len; __v_fastc_array_index++) { ((${element_type} *)__v_fastc_array_init.data)[__v_fastc_array_index] = __v_fastc_array_default; } __v_fastc_array_init; })'
-				typ:    c_type
-			}
+			value_source = '({ ${explicit_initializers.join(' ')} ${array_type} __v_fastc_array_init = ${base}; ${element_type} __v_fastc_array_default = (${initial}); for (int __v_fastc_array_index = 0; __v_fastc_array_index < __v_fastc_array_init.len; __v_fastc_array_index++) { ((${element_type} *)__v_fastc_array_init.data)[__v_fastc_array_index] = __v_fastc_array_default; } __v_fastc_array_init; })'
+		} else if explicit_initializers.len > 0 {
+			value_source = '({ ${explicit_initializers.join(' ')} ${base}; })'
 		}
-		if explicit_initializers.len > 0 {
-			return FastcRenderedExpression{
-				source: '({ ${explicit_initializers.join(' ')} ${base}; })'
-				typ:    c_type
-			}
+		if c_type.ends_with('*') {
+			value_source = '({ ${array_type} __v_fastc_array_pointer_value = (${value_source}); (${c_type})v_fastc_interface_box(&__v_fastc_array_pointer_value, sizeof(${array_type})); })'
 		}
 		return FastcRenderedExpression{
-			source: base
+			source: value_source
 			typ:    c_type
 		}
 	}
@@ -872,24 +1374,51 @@ fn (g &Parser) render_struct_literal_expression(tokens []FastcExpressionToken) ?
 		}
 		if c_type.ends_with('*') {
 			base_type := c_type.trim_right('*')
+			copy_statements := fixed_array_copies.join(' ')
 			return FastcRenderedExpression{
-				source: '({ ${base_type} __v_fastc_struct_update = *(${update_source}); ${explicit_initializers.join(' ')} ${assignments.join(' ')} (${c_type})v_fastc_interface_box(&__v_fastc_struct_update, sizeof(${base_type})); })'
+				source: '({ ${base_type} __v_fastc_struct_update = *(${update_source}); ${explicit_initializers.join(' ')} ${assignments.join(' ')} ${copy_statements.replace('__v_fastc_struct_fixed',
+					'__v_fastc_struct_update')} (${c_type})v_fastc_interface_box(&__v_fastc_struct_update, sizeof(${base_type})); })'
 				typ:    c_type
 			}
 		}
+		copy_statements := fixed_array_copies.join(' ')
 		return FastcRenderedExpression{
-			source: '({ ${c_type} __v_fastc_struct_update = (${update_source}); ${explicit_initializers.join(' ')} ${assignments.join(' ')} __v_fastc_struct_update; })'
+			source: '({ ${c_type} __v_fastc_struct_update = (${update_source}); ${explicit_initializers.join(' ')} ${assignments.join(' ')} ${copy_statements.replace('__v_fastc_struct_fixed',
+				'__v_fastc_struct_update')} __v_fastc_struct_update; })'
 			typ:    c_type
 		}
 	}
 	if has_applied_defaults {
-		return g.render_struct_literal_with_defaults(c_type, layout_type, explicit_initializers,
-			rendered_fields, rendered_fields_by_name)
+		rendered := g.render_struct_literal_with_defaults(c_type, layout_type,
+			explicit_initializers, rendered_fields, rendered_fields_by_name)
+		if fixed_array_copies.len == 0 {
+			return rendered
+		}
+		access := if c_type.ends_with('*') { '->' } else { '.' }
+		copies := fixed_array_copies.join(' ').replace('__v_fastc_struct_fixed.',
+			'__v_fastc_struct_with_fixed${access}')
+		return FastcRenderedExpression{
+			source: '({ ${c_type} __v_fastc_struct_with_fixed = (${rendered.source}); ${copies} __v_fastc_struct_with_fixed; })'
+			typ:    c_type
+		}
 	}
 	literal_source := if c_type.ends_with('*') {
 		'(${c_type})v_fastc_interface_box(&(${c_type.trim_right('*')}){${rendered_fields.join(',')}}, sizeof(${c_type.trim_right('*')}))'
 	} else {
 		'(${c_type}){${rendered_fields.join(',')}}'
+	}
+	if fixed_array_copies.len > 0 {
+		base_type := c_type.trim_right('*')
+		copies := fixed_array_copies.join(' ')
+		result := if c_type.ends_with('*') {
+			'(${c_type})v_fastc_interface_box(&__v_fastc_struct_fixed, sizeof(${base_type}))'
+		} else {
+			'__v_fastc_struct_fixed'
+		}
+		return FastcRenderedExpression{
+			source: '({ ${explicit_initializers.join(' ')} ${base_type} __v_fastc_struct_fixed = (${base_type}){${rendered_fields.join(',')}}; ${copies} ${result}; })'
+			typ:    c_type
+		}
 	}
 	if explicit_initializers.len > 0 {
 		return FastcRenderedExpression{
@@ -920,13 +1449,21 @@ fn (g &Parser) render_struct_literal_field_names(tokens []FastcExpressionToken, 
 	mut changed := false
 	for field_name in fields.keys() {
 		for module_name in [g.module_name, 'builtin'] {
-			constant_name := g.constants[fastc_constant_key(module_name, field_name)] or {
-				continue
+			constant_name := g.constants[fastc_constant_key(module_name, field_name)] or { '' }
+			mut resolved_names := []string{}
+			if constant_name != '' {
+				resolved_names << constant_name
 			}
-			needle := '.${constant_name}='
-			if rendered.contains(needle) {
-				rendered = rendered.replace(needle, '.${fastc_c_identifier(field_name)}=')
-				changed = true
+			function_key := fastc_function_key(module_name, field_name)
+			if function_key in g.functions || function_key in g.mono_functions {
+				resolved_names << fastc_c_function_name_for_key(function_key)
+			}
+			for resolved_name in resolved_names {
+				needle := '.${resolved_name}='
+				if rendered.contains(needle) {
+					rendered = rendered.replace(needle, '.${fastc_c_identifier(field_name)}=')
+					changed = true
+				}
 			}
 		}
 	}
@@ -962,7 +1499,11 @@ fn (g &Parser) render_array_assignment_expression(tokens []FastcExpressionToken)
 		return none
 	}
 	operator := tokens[assignment_index].tok
-	source := if operator == .right_shift_unsigned_assign {
+	source := if overloaded := g.render_overloaded_assignment(left.source, right, left.typ,
+		operator)
+	{
+		overloaded
+	} else if operator == .right_shift_unsigned_assign {
 		g.render_unsigned_right_shift_assignment(left.source, right, left.typ) or { return none }
 	} else {
 		'${left.source}${operator.str()}${right}'
@@ -1030,12 +1571,36 @@ fn (g &Parser) render_assignment_expression(tokens []FastcExpressionToken) ?Fast
 			raw
 		}
 	}
-	right := g.render_call_argument_expression(tokens[assignment_index + 1..], left_type) or {
-		return none
+	rhs_tokens := tokens[assignment_index + 1..]
+	mut right := ''
+	if rhs_tokens.len == 2 && rhs_tokens[0].tok == .lsbr && rhs_tokens[1].tok == .rsbr
+		&& left_type.trim_right('*').starts_with('Array_') {
+		// An empty array literal `[]` has no element type of its own; assigned to an
+		// array target it lowers to a typed empty array from the target's type (the
+		// standalone `x = []` case is handled where `expected_expression_type` is set).
+		right = '(${left_type}){0}'
+	} else {
+		right = g.render_call_argument_expression(rhs_tokens, left_type) or { return none }
 	}
 	operator := tokens[assignment_index].tok
+	option_payload_type := g.option_value_type_for_expression(left_tokens)
+	if g.selfhost && operator == .assign && left_type == 'Option' && option_payload_type != '' {
+		rhs_type := fastc_normalize_inferred_type(g.infer_expression_type(rhs_tokens) or { '' })
+		if rhs_type != 'Option' {
+			if rhs_type.trim_right('*') == 'IError' {
+				right = '(Option){.err=${right}, .state=1}'
+			} else {
+				payload := g.render_call_argument_expression(rhs_tokens, option_payload_type) or {
+					right
+				}
+				right = fastc_option_success_expression(option_payload_type, payload)
+			}
+		}
+	}
 	source := if operator == .plus_assign && g.underlying_alias_type(left_type) == 'string' {
 		'${left}=builtin__string_plus(${left},${right})'
+	} else if overloaded := g.render_overloaded_assignment(left, right, left_type, operator) {
+		overloaded
 	} else if operator == .right_shift_unsigned_assign {
 		g.render_unsigned_right_shift_assignment(left, right, left_type) or { return none }
 	} else {
@@ -1045,6 +1610,28 @@ fn (g &Parser) render_assignment_expression(tokens []FastcExpressionToken) ?Fast
 		source: source
 		typ:    left_type
 	}
+}
+
+fn (g &Parser) render_overloaded_assignment(target string, value string, target_type string, assignment token.Token) ?string {
+	operator := match assignment {
+		.plus_assign { '+' }
+		.minus_assign { '-' }
+		.mul_assign { '*' }
+		.div_assign { '/' }
+		.mod_assign { '%' }
+		.power_assign { '**' }
+		.or_assign { '|' }
+		.xor_assign { '^' }
+		else { return none }
+	}
+	method_key := g.method_function_key(target_type, operator)
+	signature := g.functions[method_key] or { return none }
+	if signature.parameter_types.len < 2 || signature.is_disabled {
+		return none
+	}
+	receiver_type := signature.parameter_types[0]
+	method_name := fastc_method_c_name(signature.module_name, receiver_type, operator)
+	return '({ ${target_type} *__v_fastc_overloaded_assignment_target = &(${target}); *__v_fastc_overloaded_assignment_target = ${method_name}(*__v_fastc_overloaded_assignment_target,${value}); })'
 }
 
 fn (g &Parser) render_unsigned_right_shift_assignment(target string, value string, target_type string) ?string {
@@ -1060,25 +1647,379 @@ fn (g &Parser) render_unsigned_right_shift_assignment(target string, value strin
 	return '({ ${target_type} *__v_fastc_unsigned_shift_target = &(${target}); ${unsigned_type} __v_fastc_unsigned_shift_value = (${unsigned_type})(*__v_fastc_unsigned_shift_target); u64 __v_fastc_unsigned_shift_count = (u64)(${value}); *__v_fastc_unsigned_shift_target = (${target_type})(__v_fastc_unsigned_shift_count >= ${bits} ? (${unsigned_type})0 : (__v_fastc_unsigned_shift_value >> __v_fastc_unsigned_shift_count)); })'
 }
 
+fn fastc_overloaded_binary_precedence(tok token.Token) int {
+	return match tok {
+		.pipe { 1 }
+		.xor { 2 }
+		.amp { 3 }
+		.left_shift, .right_shift { 4 }
+		.plus, .minus { 5 }
+		.mul, .div, .mod { 6 }
+		else { 0 }
+	}
+}
+
+fn (g &Parser) render_overloaded_comparison_expression(left_tokens []FastcExpressionToken, right_tokens []FastcExpressionToken, operator token.Token) ?FastcRenderedExpression {
+	if array_comparison := g.render_array_equality_comparison(left_tokens, right_tokens, operator) {
+		return array_comparison
+	}
+	mut method_operator := ''
+	mut negate := false
+	match operator {
+		.eq {
+			method_operator = '=='
+		}
+		.ne {
+			method_operator = '=='
+			negate = true
+		}
+		.lt {
+			method_operator = '<'
+		}
+		.gt {
+			method_operator = '<'
+		}
+		.le {
+			method_operator = '<'
+			negate = true
+		}
+		.ge {
+			method_operator = '<'
+			negate = true
+		}
+		else {
+			return none
+		}
+	}
+	reverse_arguments := operator in [.gt, .le]
+	receiver_tokens := if reverse_arguments { right_tokens } else { left_tokens }
+	argument_tokens := if reverse_arguments { left_tokens } else { right_tokens }
+	receiver_type := g.infer_expression_type(receiver_tokens) or { return none }
+	method_key := g.method_function_key(receiver_type, method_operator)
+	if method_key !in g.functions {
+		return none
+	}
+	signature := g.functions[method_key]
+	if signature.parameter_types.len < 2 || signature.is_disabled {
+		return none
+	}
+	receiver := g.render_call_argument_expression(receiver_tokens, signature.parameter_types[0]) or {
+		return none
+	}
+	argument := g.render_call_argument_expression(argument_tokens, signature.parameter_types[1]) or {
+		return none
+	}
+	call := '${fastc_method_c_name(signature.module_name, signature.parameter_types[0],
+		method_operator)}(${receiver},${argument})'
+	return FastcRenderedExpression{
+		source: if negate { '!(${call})' } else { call }
+		typ:    'bool'
+	}
+}
+
+fn (g &Parser) render_array_equality_comparison(left_tokens []FastcExpressionToken, right_tokens []FastcExpressionToken, operator token.Token) ?FastcRenderedExpression {
+	if operator !in [.eq, .ne] {
+		return none
+	}
+	left_type := fastc_normalize_inferred_type(g.infer_expression_type(left_tokens) or {
+		return none
+	})
+	right_type := fastc_normalize_inferred_type(g.infer_expression_type(right_tokens) or {
+		return none
+	})
+	left_layout := left_type.trim_right('*')
+	if left_type != right_type
+		|| (!left_layout.starts_with('Array_') && !left_layout.starts_with('FixedArray_')) {
+		return none
+	}
+	element_type := g.array_element_type(left_type) or { return none }
+	resolved_element := g.underlying_alias_type(element_type).trim_right('*')
+	is_scalar := fastc_is_numeric_expression_type(resolved_element) || resolved_element == 'bool'
+		|| fastc_is_pointer_type(element_type)
+		|| g.underlying_enum_type_key(g.semantic_type_key(element_type)) != none
+	if resolved_element != 'string' && !is_scalar {
+		return none
+	}
+	if left_layout.starts_with('FixedArray_') {
+		length := fastc_fixed_array_length(left_layout) or { return none }
+		left_data := g.render_fixed_array_equality_data(left_tokens, left_type) or { return none }
+		right_data := g.render_fixed_array_equality_data(right_tokens, right_type) or {
+			return none
+		}
+		element_comparison := if resolved_element == 'string' {
+			'builtin__string_eq(__v_fastc_array_eq_left[__v_fastc_array_eq_index], __v_fastc_array_eq_right[__v_fastc_array_eq_index])'
+		} else {
+			'(__v_fastc_array_eq_left[__v_fastc_array_eq_index] == __v_fastc_array_eq_right[__v_fastc_array_eq_index])'
+		}
+		result := if operator == .ne { '!__v_fastc_array_equal' } else { '__v_fastc_array_equal' }
+		return FastcRenderedExpression{
+			source: '({ ${element_type} *__v_fastc_array_eq_left = (${element_type} *)(${left_data}); ${element_type} *__v_fastc_array_eq_right = (${element_type} *)(${right_data}); bool __v_fastc_array_equal = true; for (int __v_fastc_array_eq_index = 0; __v_fastc_array_eq_index < ${length}; __v_fastc_array_eq_index++) { if (!(${element_comparison})) { __v_fastc_array_equal = false; break; } } ${result}; })'
+			typ:    'bool'
+		}
+	}
+	left := g.render_call_argument_expression(left_tokens, left_type) or { return none }
+	right := g.render_call_argument_expression(right_tokens, right_type) or { return none }
+	element_comparison := if resolved_element == 'string' {
+		'builtin__string_eq(((${element_type} *)__v_fastc_array_eq_left.data)[__v_fastc_array_eq_index], ((${element_type} *)__v_fastc_array_eq_right.data)[__v_fastc_array_eq_index])'
+	} else {
+		'(((${element_type} *)__v_fastc_array_eq_left.data)[__v_fastc_array_eq_index] == ((${element_type} *)__v_fastc_array_eq_right.data)[__v_fastc_array_eq_index])'
+	}
+	result := if operator == .ne { '!__v_fastc_array_equal' } else { '__v_fastc_array_equal' }
+	return FastcRenderedExpression{
+		source: '({ ${left_type} __v_fastc_array_eq_left = (${left}); ${right_type} __v_fastc_array_eq_right = (${right}); bool __v_fastc_array_equal = __v_fastc_array_eq_left.len == __v_fastc_array_eq_right.len; if (__v_fastc_array_equal) { for (int __v_fastc_array_eq_index = 0; __v_fastc_array_eq_index < __v_fastc_array_eq_left.len; __v_fastc_array_eq_index++) { if (!(${element_comparison})) { __v_fastc_array_equal = false; break; } } } ${result}; })'
+		typ:    'bool'
+	}
+}
+
+fn (g &Parser) render_fixed_array_equality_data(tokens []FastcExpressionToken, c_type string) ?string {
+	layout_type := c_type.trim_right('*')
+	if literal := g.render_array_literal_argument(tokens, layout_type) {
+		return '(${literal.source}).data'
+	}
+	mut initializer_open := -1
+	for i, item in tokens {
+		if item.tok == .lcbr {
+			initializer_open = i
+			break
+		}
+	}
+	if initializer_open > 0 && tokens.last().tok == .rcbr && initializer_open + 1 == tokens.len - 1 {
+		initializer_type := g.array_initializer_type(tokens[..initializer_open]) or { '' }
+		if initializer_type == layout_type {
+			return '((${layout_type}){0}).data'
+		}
+	}
+	source := if member := g.render_member_receiver(tokens) {
+		member
+	} else if access := g.render_array_access_expression(tokens) {
+		access.source
+	} else {
+		g.render_raw_expression_tokens(tokens) or { return none }
+	}
+	if g.fixed_array_uses_raw_storage(tokens) {
+		return source
+	}
+	return if c_type.ends_with('*') { '(${source})->data' } else { '(${source}).data' }
+}
+
+fn (g &Parser) render_overloaded_binary_expression(tokens []FastcExpressionToken) ?FastcRenderedExpression {
+	if tokens.len >= 3 && tokens[0].tok == .lpar && tokens.last().tok == .rpar {
+		close := fastc_matching_rpar(tokens, 0) or { -1 }
+		if close == tokens.len - 1 {
+			inner := g.render_overloaded_binary_expression(tokens[1..tokens.len - 1]) or {
+				return none
+			}
+			return FastcRenderedExpression{
+				source: '((${inner.source}))'
+				typ:    inner.typ
+			}
+		}
+	}
+	if boolean_index := fastc_lowest_precedence_operator_index(tokens, 0, tokens.len) {
+		left_tokens := tokens[..boolean_index]
+		right_tokens := tokens[boolean_index + 1..]
+		operator := tokens[boolean_index].tok
+		if comparison := g.render_overloaded_comparison_expression(left_tokens, right_tokens,
+			operator)
+		{
+			return comparison
+		}
+		mut left_special := FastcRenderedExpression{}
+		if rendered := g.render_overloaded_binary_expression(left_tokens) {
+			left_special = rendered
+		}
+		mut right_special := FastcRenderedExpression{}
+		if rendered := g.render_overloaded_binary_expression(right_tokens) {
+			right_special = rendered
+		}
+		if left_special.source != '' || right_special.source != '' {
+			left_expected := if operator in [.and, .logical_or] {
+				'bool'
+			} else if left_special.typ != '' {
+				left_special.typ
+			} else {
+				g.infer_expression_type(left_tokens) or { '' }
+			}
+			right_expected := if operator in [.and, .logical_or] {
+				'bool'
+			} else if right_special.typ != '' {
+				right_special.typ
+			} else {
+				g.infer_expression_type(right_tokens) or { '' }
+			}
+			left := if left_special.source != '' {
+				left_special.source
+			} else {
+				g.render_call_argument_expression(left_tokens, left_expected) or { return none }
+			}
+			right := if right_special.source != '' {
+				right_special.source
+			} else {
+				g.render_call_argument_expression(right_tokens, right_expected) or { return none }
+			}
+			return FastcRenderedExpression{
+				source: '((${left})${operator.str()}(${right}))'
+				typ:    'bool'
+			}
+		}
+		return none
+	}
+	mut depth := 0
+	mut operator_index := -1
+	mut precedence := 100
+	for i, item in tokens {
+		if item.tok in [.lpar, .lsbr, .lcbr] {
+			depth++
+		} else if item.tok in [.rpar, .rsbr, .rcbr] {
+			depth--
+		} else if depth == 0 && i > 0 && i + 1 < tokens.len {
+			candidate_precedence := fastc_overloaded_binary_precedence(item.tok)
+			if candidate_precedence > 0 && candidate_precedence <= precedence {
+				operator_index = i
+				precedence = candidate_precedence
+			}
+		}
+	}
+	if operator_index < 1 {
+		return none
+	}
+	left_tokens := tokens[..operator_index]
+	right_tokens := tokens[operator_index + 1..]
+	left_type := g.infer_expression_type(left_tokens) or { return none }
+	operator := tokens[operator_index].tok.str()
+	method_key := g.method_function_key(left_type, operator)
+	if method_key !in g.functions {
+		mut left_special := FastcRenderedExpression{}
+		if rendered := g.render_overloaded_binary_expression(left_tokens) {
+			left_special = rendered
+		}
+		mut right_special := FastcRenderedExpression{}
+		if rendered := g.render_overloaded_binary_expression(right_tokens) {
+			right_special = rendered
+		}
+		if left_special.source == '' && right_special.source == '' {
+			return none
+		}
+		right_type := g.infer_expression_type(right_tokens) or { return none }
+		left := if left_special.source != '' {
+			left_special.source
+		} else {
+			g.render_call_argument_expression(left_tokens, left_type) or { return none }
+		}
+		right := if right_special.source != '' {
+			right_special.source
+		} else {
+			g.render_call_argument_expression(right_tokens, right_type) or { return none }
+		}
+		return FastcRenderedExpression{
+			source: '((${left})${operator}(${right}))'
+			typ:    g.infer_expression_type(tokens) or { left_type }
+		}
+	}
+	signature := g.functions[method_key]
+	if signature.parameter_types.len < 2 || signature.is_disabled {
+		return none
+	}
+	left := g.render_call_argument_expression(left_tokens, signature.parameter_types[0]) or {
+		return none
+	}
+	right := g.render_call_argument_expression(right_tokens, signature.parameter_types[1]) or {
+		return none
+	}
+	return FastcRenderedExpression{
+		source: '${fastc_method_c_name(signature.module_name, signature.parameter_types[0],
+			operator)}(${left},${right})'
+		typ:    signature.return_type
+	}
+}
+
 fn (g &Parser) render_pointer_member_access_expression(tokens []FastcExpressionToken, rendered_expression string) ?FastcRenderedExpression {
 	if tokens.len < 3 {
 		return none
 	}
 	for i in 1 .. tokens.len - 1 {
-		if tokens[i].tok == .dot && tokens[i + 1].tok == .name && i + 2 < tokens.len
-			&& tokens[i + 2].tok == .lpar {
+		if tokens[i].tok != .dot || tokens[i + 1].tok != .name || i + 2 >= tokens.len
+			|| tokens[i + 2].tok != .lpar {
+			continue
+		}
+		// A qualified function call can contain an embedded-field argument that
+		// still needs promotion here. A real method call is rendered later with
+		// its receiver and arguments, so preserve the old early exit for it.
+		is_qualified_call := tokens[i - 1].tok == .name
+			&& (tokens[i - 1].lit in g.imports || tokens[i - 1].lit == 'C')
+			&& (i < 2 || tokens[i - 2].tok != .dot)
+		method_marker := '.${tokens[i + 1].lit}('
+		pointer_method_marker := '->${tokens[i + 1].lit}('
+		if !is_qualified_call && (rendered_expression.contains(method_marker)
+			|| rendered_expression.contains(pointer_method_marker)) {
 			return none
 		}
 	}
 	mut rendered := rendered_expression
 	mut changed := false
+	// Promote pointer-rooted embedded fields even when the member chain is nested
+	// inside a call. Value-rooted and indexed chains keep using their dedicated
+	// member/slice renderers, which also preserve fixed-array storage semantics.
+	for start, item in tokens {
+		if item.tok != .name || (start > 0 && tokens[start - 1].tok == .dot) {
+			continue
+		}
+		root_type := g.infer_expression_type(tokens[start..start + 1]) or { continue }
+		root_is_reference := if local := g.locals[item.lit] { local.is_reference } else { false }
+		if !root_type.ends_with('*') && !root_is_reference {
+			continue
+		}
+		mut end := start + 1
+		for end + 1 < tokens.len && tokens[end].tok == .dot && tokens[end + 1].tok == .name {
+			if end + 2 < tokens.len && tokens[end + 2].tok == .lpar {
+				break
+			}
+			end += 2
+		}
+		if end <= start + 1 || (end < tokens.len && tokens[end].tok == .lsbr) {
+			continue
+		}
+		chain_tokens := tokens[start..end]
+		raw_chain := g.render_raw_expression_tokens(chain_tokens) or { continue }
+		promoted_chain := g.render_member_receiver(chain_tokens) or { continue }
+		mut needle := raw_chain
+		if !rendered.contains(needle) {
+			root_source := g.resolved_expression_name(item.lit, .unknown)
+			pointer_chain := raw_chain.replace_once('${root_source}.', '${root_source}->')
+			if rendered.contains(pointer_chain) {
+				needle = pointer_chain
+			}
+		}
+		if promoted_chain != needle && rendered.contains(needle) {
+			rendered = rendered.replace(needle, promoted_chain)
+			changed = true
+		}
+	}
 	for i in 1 .. tokens.len - 1 {
 		if tokens[i].tok != .dot || tokens[i + 1].tok != .name {
+			continue
+		}
+		if i + 2 < tokens.len && tokens[i + 2].tok == .lpar {
 			continue
 		}
 		receiver_start := fastc_method_receiver_start(tokens, i)
 		receiver_tokens := tokens[receiver_start..i]
 		receiver_type := g.infer_expression_type(receiver_tokens) or { continue }
+		if tokens[i + 1].lit in ['len', 'cap'] {
+			if fixed_length := fastc_fixed_array_length(receiver_type.trim_right('*')) {
+				raw_receiver := g.render_raw_expression_tokens(receiver_tokens) or { continue }
+				receiver_source := g.render_member_receiver(receiver_tokens) or { raw_receiver }
+				mut needle := '${receiver_source}.${tokens[i + 1].lit}'
+				if !rendered.contains(needle) {
+					needle = '${raw_receiver}.${tokens[i + 1].lit}'
+				}
+				if rendered.contains(needle) {
+					rendered = rendered.replace(needle, fixed_length)
+					changed = true
+				}
+				continue
+			}
+		}
 		if !receiver_type.ends_with('*') {
 			continue
 		}
@@ -1086,15 +2027,19 @@ fn (g &Parser) render_pointer_member_access_expression(tokens []FastcExpressionT
 			g.render_membership_candidate(receiver_tokens, '') or { continue }
 		}
 		needle := '${receiver_source}.${tokens[i + 1].lit}'
-		if rendered.contains(needle) {
-			rendered = rendered.replace(needle, '${receiver_source}->${tokens[i + 1].lit}')
+		replaced := fastc_replace_c_identifier(rendered, needle,
+			'${receiver_source}->${tokens[i + 1].lit}')
+		if replaced != rendered {
+			rendered = replaced
 			changed = true
 			continue
 		}
 		raw_receiver := g.render_raw_expression_tokens(receiver_tokens) or { '' }
 		raw_needle := '${raw_receiver}.${tokens[i + 1].lit}'
-		if raw_receiver != '' && rendered.contains(raw_needle) {
-			rendered = rendered.replace(raw_needle, '${raw_receiver}->${tokens[i + 1].lit}')
+		raw_replaced := fastc_replace_c_identifier(rendered, raw_needle, '${raw_receiver}->${tokens[
+			i + 1].lit}')
+		if raw_receiver != '' && raw_replaced != rendered {
+			rendered = raw_replaced
 			changed = true
 			continue
 		}
@@ -1121,7 +2066,8 @@ fn (g &Parser) render_pointer_member_access_expression(tokens []FastcExpressionT
 fn (g &Parser) render_chained_array_access_expression(tokens []FastcExpressionToken, rendered_expression string) ?FastcRenderedExpression {
 	mut rendered := rendered_expression
 	mut changed := false
-	for open, item in tokens {
+	for open := tokens.len - 1; open >= 0; open-- {
+		item := tokens[open]
 		if item.tok != .lsbr {
 			continue
 		}
@@ -1135,6 +2081,16 @@ fn (g &Parser) render_chained_array_access_expression(tokens []FastcExpressionTo
 		}
 		base_tokens := tokens[start..open]
 		base_type := g.infer_expression_type(base_tokens) or { continue }
+		if base_type.trim_right('*').starts_with('Map_') {
+			lookup_tokens := tokens[start..close + 1]
+			lookup := g.render_map_expression(lookup_tokens) or { continue }
+			raw_lookup := g.render_raw_expression_tokens(lookup_tokens) or { continue }
+			if rendered.contains(raw_lookup) {
+				rendered = rendered.replace(raw_lookup, lookup.source)
+				changed = true
+			}
+			continue
+		}
 		is_array_pointer := base_type.ends_with('*') && g.array_element_type(base_type) != none
 		element_type := if base_type == 'string' {
 			'u8'
@@ -1191,6 +2147,85 @@ fn (g &Parser) render_chained_array_access_expression(tokens []FastcExpressionTo
 	}
 }
 
+fn fastc_trim_expression_parentheses(tokens []FastcExpressionToken) []FastcExpressionToken {
+	mut start := 0
+	mut end := tokens.len
+	for end - start >= 2 && tokens[start].tok == .lpar && tokens[end - 1].tok == .rpar {
+		trimmed := tokens[start..end]
+		close := fastc_matching_delimiter(trimmed, 0, .lpar, .rpar) or { break }
+		if close != trimmed.len - 1 {
+			break
+		}
+		start++
+		end--
+	}
+	return tokens[start..end].clone()
+}
+
+// render_refined_enum_logical_expression lowers `x is Enum && x == .value`.
+// The right side is safe to unbox because C's `&&` preserves V's short-circuit
+// refinement semantics.
+fn (g &Parser) render_refined_enum_logical_expression(left_tokens []FastcExpressionToken, right_tokens []FastcExpressionToken) ?FastcRenderedExpression {
+	left := fastc_trim_expression_parentheses(left_tokens)
+	if left.len < 3 || left[0].tok != .name || left[1].tok != .key_is {
+		return none
+	}
+	local := g.locals[left[0].lit] or { return none }
+	boxed_type := fastc_normalize_inferred_type(local.typ)
+	if !g.is_boxed_type(boxed_type) {
+		return none
+	}
+	target_type := g.type_from_expression_tokens(left[2..]) or { return none }
+	enum_type := fastc_normalize_inferred_type(target_type).trim_right('*')
+	if g.declared_kinds[g.semantic_type_key(enum_type)] != .enum_ {
+		return none
+	}
+	right := fastc_trim_expression_parentheses(right_tokens)
+	mut comparison_index := -1
+	for i, item in right {
+		if item.tok in [.eq, .ne, .lt, .gt, .le, .ge] {
+			if comparison_index != -1 {
+				return none
+			}
+			comparison_index = i
+		}
+	}
+	if comparison_index == -1 {
+		return none
+	}
+	comparison := right[comparison_index].tok.str()
+	comparison_left := right[..comparison_index]
+	comparison_right := right[comparison_index + 1..]
+	mut enum_value := ''
+	mut enum_first := false
+	if comparison_left.len == 1 && comparison_left[0].tok == .name
+		&& comparison_left[0].lit == left[0].lit && comparison_right.len == 2
+		&& comparison_right[0].tok == .dot && comparison_right[1].tok == .name {
+		enum_value = comparison_right[1].lit
+	} else if comparison_right.len == 1 && comparison_right[0].tok == .name
+		&& comparison_right[0].lit == left[0].lit && comparison_left.len == 2
+		&& comparison_left[0].tok == .dot && comparison_left[1].tok == .name {
+		enum_value = comparison_left[1].lit
+		enum_first = true
+	} else {
+		return none
+	}
+	subject := fastc_c_identifier(left[0].lit)
+	access := if boxed_type.ends_with('*') { '->' } else { '.' }
+	type_test := '((${subject}${access}_typ) == __v_typeid_${enum_type})'
+	concrete := '*((${enum_type} *)${subject}${access}_object)'
+	value := '${enum_type}__${enum_value}'
+	right_source := if enum_first {
+		'((${value}) ${comparison} (${concrete}))'
+	} else {
+		'((${concrete}) ${comparison} (${value}))'
+	}
+	return FastcRenderedExpression{
+		source: '((${type_test})&&(${right_source}))'
+		typ:    'bool'
+	}
+}
+
 fn (g &Parser) render_logical_expression(tokens []FastcExpressionToken) ?FastcRenderedExpression {
 	mut depth := 0
 	for i, item in tokens {
@@ -1199,6 +2234,11 @@ fn (g &Parser) render_logical_expression(tokens []FastcExpressionToken) ?FastcRe
 		} else if item.tok in [.rpar, .rsbr, .rcbr] {
 			depth--
 		} else if depth == 0 && item.tok in [.and, .logical_or] && i > 0 && i + 1 < tokens.len {
+			if item.tok == .and {
+				if refined := g.render_refined_enum_logical_expression(tokens[..i], tokens[i + 1..]) {
+					return refined
+				}
+			}
 			left := g.render_call_argument_expression(tokens[..i], 'bool') or { return none }
 			right := g.render_call_argument_expression(tokens[i + 1..], 'bool') or { return none }
 			return FastcRenderedExpression{
@@ -1224,8 +2264,10 @@ fn (g &Parser) struct_equality_is_supported(typ string, seen []string) bool {
 		_ = g.fixed_array_length_value(length_source) or { return false }
 		return g.struct_equality_is_supported(element_type, seen)
 	}
-	if layout_type in ['Option', 'array', 'map'] || layout_type.starts_with('Array_')
-		|| layout_type.starts_with('Map_') {
+	if element_type := g.array_element_type(layout_type) {
+		return g.struct_equality_is_supported(element_type, seen)
+	}
+	if layout_type in ['Option', 'array', 'map'] || layout_type.starts_with('Map_') {
 		return false
 	}
 	type_key := g.semantic_type_key(layout_type)
@@ -1269,6 +2311,17 @@ fn (g &Parser) struct_equality_source(left string, right string, typ string, see
 				element_type, seen)
 		}
 		return if comparisons.len == 0 { 'true' } else { '(${comparisons.join(' && ')})' }
+	}
+	if element_type := g.array_element_type(layout_type) {
+		left_array := '__v_fastc_array_eq_left'
+		right_array := '__v_fastc_array_eq_right'
+		equal := '__v_fastc_array_eq_equal'
+		index := '__v_fastc_array_eq_index'
+		left_element := '((${element_type} *)${left_array}.data)[${index}]'
+		right_element := '((${element_type} *)${right_array}.data)[${index}]'
+		element_equality :=
+			g.struct_equality_source(left_element, right_element, element_type, seen)
+		return '({ ${layout_type} ${left_array} = (${left}); ${layout_type} ${right_array} = (${right}); bool ${equal} = ${left_array}.len == ${right_array}.len; for (int ${index} = 0; ${equal} && ${index} < ${left_array}.len; ${index}++) { if (!(${element_equality})) { ${equal} = false; } } ${equal}; })'
 	}
 	type_key := g.semantic_type_key(layout_type)
 	if type_key in g.declared_kinds && g.declared_kinds[type_key] == .enum_ {
@@ -1387,6 +2440,19 @@ fn (g &Parser) render_struct_comparison_expression_impl(tokens []FastcExpression
 			}
 			left_layout := g.underlying_alias_type(left_type).trim_right('*')
 			right_layout := g.underlying_alias_type(right_type).trim_right('*')
+			if left_layout == right_layout && left_layout in g.sum_types {
+				// Sum-type equality (`value == Primitive(Null{})`): the boxed struct
+				// cannot be compared with C `==`, so compare the variant tag (and, for a
+				// scalar variant cast on the right, the unboxed value).
+				if sum_eq := g.render_sum_type_equality(left_tokens, right_tokens, left_layout) {
+					source := if item.tok == .ne { '!(${sum_eq})' } else { sum_eq }
+					return FastcRenderedExpression{
+						source: source
+						typ:    'bool'
+					}
+				}
+				return none
+			}
 			left_key := g.semantic_type_key(left_layout)
 			if left_layout != right_layout || left_key !in g.declared_kinds
 				|| g.declared_kinds[left_key] != .struct_
@@ -1405,6 +2471,116 @@ fn (g &Parser) render_struct_comparison_expression_impl(tokens []FastcExpression
 		}
 	}
 	return none
+}
+
+// render_sum_type_equality lowers `left == SumType(operand)` (both of sum type
+// `sum_type`) to a variant-tag comparison on the left's boxed `_typ`, plus the
+// unboxed value for a scalar/string variant. A fieldless or struct variant matches
+// on the tag alone. Returns none when the right side is not a variant cast.
+fn (g &Parser) render_sum_type_equality(left_tokens []FastcExpressionToken, right_tokens []FastcExpressionToken, sum_type string) ?string {
+	mut operand_start := -1
+	mut open_index := -1
+	if right_tokens.len >= 3 && right_tokens[0].tok == .name && right_tokens[1].tok == .lpar {
+		operand_start = 2
+		open_index = 1
+	} else if right_tokens.len >= 5 && right_tokens[0].tok == .name && right_tokens[1].tok == .dot
+		&& right_tokens[2].tok == .name && right_tokens[3].tok == .lpar {
+		operand_start = 4
+		open_index = 3
+	}
+	if operand_start < 0 {
+		return none
+	}
+	close := fastc_matching_rpar(right_tokens, open_index) or { return none }
+	if close != right_tokens.len - 1 {
+		return none
+	}
+	operand_tokens := right_tokens[operand_start..close]
+	inferred_variant := g.infer_expression_type(operand_tokens) or { return none }
+	variant_type := fastc_normalize_inferred_type(inferred_variant)
+	if variant_type == '' {
+		return none
+	}
+	left := g.render_comparison_operand(left_tokens, sum_type) or { return none }
+	left_temp := '__v_fastc_sum_left'
+	tag := '${left_temp}._typ == __v_typeid_${variant_type}'
+	mut comparison := tag
+	if variant_type == 'string' {
+		operand := g.render_call_argument_expression(operand_tokens, variant_type) or {
+			return none
+		}
+		comparison = '(${tag}) && builtin__string_eq(*(string *)${left_temp}._object, ${operand})'
+	} else if fastc_primitive_c_type(variant_type) != none {
+		operand := g.render_call_argument_expression(operand_tokens, variant_type) or {
+			return none
+		}
+		comparison = '(${tag}) && (*(${variant_type} *)${left_temp}._object == (${operand}))'
+	}
+	return '({ ${sum_type} ${left_temp} = (${left}); ${comparison}; })'
+}
+
+// render_as_cast_expression lowers `<boxed> as Type`. A boxed sum-type / interface
+// value shares the `{_object, _typ, _methods}` layout and dispatches by `_typ`, so a
+// downcast to ANOTHER interface / sum type just re-boxes the same object under the
+// target type, and a cast to a CONCRETE type unboxes the stored object. Returns none
+// unless `as` is the top-level operator, the right side is a declared type, and the
+// left operand is a boxed value.
+fn (g &Parser) render_as_cast_expression(tokens []FastcExpressionToken) ?FastcRenderedExpression {
+	mut depth := 0
+	mut as_index := -1
+	for i, item in tokens {
+		match item.tok {
+			.lpar, .lsbr, .lcbr {
+				depth++
+			}
+			.rpar, .rsbr, .rcbr {
+				depth--
+			}
+			.key_as {
+				if depth == 0 {
+					as_index = i
+				}
+			}
+			else {}
+		}
+	}
+	if as_index <= 0 {
+		return none
+	}
+	left_tokens := tokens[..as_index]
+	mut type_key := ''
+	if as_index == tokens.len - 2 && tokens[as_index + 1].tok == .name {
+		type_key = fastc_resolve_declared_type_key(g.module_name, tokens[as_index + 1].lit,
+			g.imports, g.declared_types) or { return none }
+	} else if as_index == tokens.len - 4 && tokens[as_index + 1].tok == .name
+		&& tokens[as_index + 2].tok == .dot && tokens[as_index + 3].tok == .name
+		&& tokens[as_index + 1].lit in g.imports {
+		type_key = fastc_type_key(g.imports[tokens[as_index + 1].lit], tokens[as_index + 3].lit)
+		if type_key !in g.declared_types {
+			return none
+		}
+	} else {
+		return none
+	}
+	target_c := fastc_c_declared_type_name(type_key)
+	inferred_left := g.infer_expression_type(left_tokens) or { return none }
+	left_type := fastc_normalize_inferred_type(inferred_left)
+	if !g.is_boxed_type(left_type) {
+		return none
+	}
+	left_source := g.render_call_argument_expression(left_tokens, left_type) or { return none }
+	access := if left_type.ends_with('*') { '->' } else { '.' }
+	src := '__v_fastc_as_src'
+	if g.is_boxed_type(target_c) {
+		return FastcRenderedExpression{
+			source: '({ ${left_type} ${src} = (${left_source}); (${target_c}){._object = ${src}${access}_object, ._typ = ${src}${access}_typ, ._methods = ${src}${access}_methods}; })'
+			typ:    target_c
+		}
+	}
+	return FastcRenderedExpression{
+		source: '({ ${left_type} ${src} = (${left_source}); *((${target_c} *)${src}${access}_object); })'
+		typ:    target_c
+	}
 }
 
 fn (g &Parser) render_enum_comparison_expression(tokens []FastcExpressionToken) ?FastcRenderedExpression {
@@ -1713,12 +2889,24 @@ fn (g &Parser) render_mixed_integer_comparison_expression_impl(tokens []FastcExp
 }
 
 fn (g &Parser) render_comparison_operand(tokens []FastcExpressionToken, expected_type string) ?string {
+	if g.selfhost && tokens.len > 1 && tokens.last().tok == .not
+		&& !fastc_trailing_not_marks_fixed_array_literal(tokens) {
+		if propagation := g.render_option_propagation(tokens[..tokens.len - 1]) {
+			return propagation.source
+		}
+	}
 	raw := g.render_raw_expression_tokens(tokens) or { return none }
 	if integer_comparison := g.render_mixed_integer_comparison_expression(tokens) {
 		return integer_comparison.source
 	}
 	if concatenation := g.render_composed_string_concatenation(tokens) {
 		return concatenation.source
+	}
+	if struct_literal := g.render_struct_literal_expression(tokens) {
+		return struct_literal.source
+	}
+	if array_access := g.render_array_access_expression(tokens) {
+		return array_access.source
 	}
 	if method_call := g.render_method_call_expression(tokens, raw) {
 		return method_call.source
@@ -1733,7 +2921,21 @@ fn (g &Parser) render_comparison_operand(tokens []FastcExpressionToken, expected
 }
 
 fn (g &Parser) render_call_argument_expression(tokens []FastcExpressionToken, expected_type string) ?string {
+	if tokens.len == 1 && tokens[0].source != '' {
+		// A single token carrying a pre-rendered `({ ... })` (e.g. an `or`-unwrap synthesized
+		// as an array element or call argument): use it directly.
+		return tokens[0].source
+	}
 	if tokens.len > 1 && tokens[0].tok == .amp && tokens[0].is_mut_argument {
+		if g.selfhost && expected_type == 'voidptr*' {
+			actual_type := g.infer_expression_type(tokens[1..]) or { '' }
+			if actual_type !in ['', 'voidptr'] {
+				inner := g.render_call_argument_expression(tokens[1..], actual_type) or {
+					return none
+				}
+				return '((voidptr *)(&(${inner})))'
+			}
+		}
 		inner_expected_type := expected_type.trim_right('*')
 		inner := g.render_call_argument_expression(tokens[1..], inner_expected_type) or {
 			return none
@@ -1752,10 +2954,51 @@ fn (g &Parser) render_call_argument_expression(tokens []FastcExpressionToken, ex
 			return '(${inner})'
 		}
 	}
+	if g.selfhost && expected_type == 'Option' {
+		if tokens.len == 1 && tokens[0].tok == .key_none {
+			return '(Option){.state=2}'
+		}
+		actual_type := fastc_normalize_inferred_type(g.infer_expression_type(tokens) or { '' })
+		if actual_type !in ['', 'Option'] {
+			value := g.render_call_argument_expression(tokens, actual_type) or { return none }
+			return fastc_option_success_expression(actual_type, value)
+		}
+	}
+	if g.selfhost && expected_type == 'voidptr' && tokens.len > 1 && tokens[0].tok == .mul {
+		operand_type := g.infer_expression_type(tokens[1..]) or { '' }
+		if operand_type == 'voidptr' {
+			// A generic pointer type is erased to `voidptr`; C cannot dereference it
+			// without the missing concrete type. At another erased boundary, forward
+			// that pointer representation directly.
+			return g.render_call_argument_expression(tokens[1..], expected_type)
+		}
+	}
+	if array_literal := g.render_array_literal_argument(tokens, expected_type) {
+		return array_literal.source
+	}
+	if map_literal := g.render_map_literal_argument(tokens, expected_type) {
+		return map_literal.source
+	}
+	if tokens.len == 2 && tokens[0].tok == .dot && tokens[1].tok == .name
+		&& g.declared_kinds[g.semantic_type_key(expected_type)] == .enum_ {
+		return '${expected_type.trim_right('*')}__${tokens[1].lit}'
+	}
+	if function_value := g.render_function_value_expression(tokens) {
+		return function_value
+	}
+	if method_value := g.render_method_value_expression(tokens) {
+		return method_value
+	}
 	raw := g.render_raw_expression_tokens(tokens) or { return none }
 	if tokens.len == 1 && tokens[0].tok == .name {
 		if local := g.locals[tokens[0].lit] {
 			if local.is_reference {
+				if g.should_box_variant(expected_type, local.typ) {
+					// A `mut value T` parameter is a C `T*`. Interface conversion must
+					// preserve that pointer as the boxed object instead of auto-dereferencing
+					// it to the value used by ordinary by-value arguments.
+					return g.interface_value_expression(expected_type, local.typ, raw)
+				}
 				value_type := local.typ.trim_right('*')
 				if fastc_is_pointer_type(expected_type) {
 					return raw
@@ -1768,25 +3011,280 @@ fn (g &Parser) render_call_argument_expression(tokens []FastcExpressionToken, ex
 		}
 	}
 	mut rendered := ''
+	mut rendered_type := ''
 	if special := g.render_special_expression(tokens, raw) {
 		rendered = special.source
+		rendered_type = special.typ
 	} else {
 		rendered = g.render_membership_candidate(tokens, expected_type) or { return none }
 	}
 	rendered = g.render_constant_references(tokens, rendered)
-	actual_type := g.infer_expression_type(tokens) or { '' }
+	actual_type := if rendered_type != '' {
+		fastc_normalize_inferred_type(rendered_type)
+	} else {
+		fastc_normalize_inferred_type(g.infer_expression_type(tokens) or { '' })
+	}
+	if expected_type == 'voidptr' && actual_type !in ['', 'voidptr', 'nil']
+		&& !fastc_expression_is_zero(tokens) && !fastc_is_pointer_type(actual_type) {
+		box_value := '__v_fastc_generic_argument'
+		return '({ ${actual_type} ${box_value} = (${rendered}); v_fastc_interface_box(&${box_value}, sizeof(${actual_type})); })'
+	}
+	if actual_type == 'voidptr' && !expected_type.ends_with('*')
+		&& (expected_type.trim_right('*') in g.struct_fields
+		|| expected_type.trim_right('*').starts_with('Array_')
+		|| expected_type.trim_right('*').starts_with('Map_')
+		|| expected_type.trim_right('*').starts_with('FixedArray_')) {
+		return '*((${expected_type} *)(${rendered}))'
+	}
 	if expected_type == 'string' && actual_type.trim_right('*') == 'IError' {
 		return 'builtin__IError_msg(${rendered})'
 	}
 	if actual_type.ends_with('*') && expected_type == actual_type.trim_right('*')
-		&& expected_type.starts_with('Map_') {
+		&& !fastc_expression_tokens_contain(tokens, .lsbr) {
+		// V automatically dereferences an explicit reference when a by-value
+		// parameter is expected (`s &string` passed to `log_line(s string)`). A
+		// slice of a mutable array is already a by-value array even though the
+		// receiver local retains its pointer type during inference.
 		return '*(${rendered})'
 	}
-	if expected_type.ends_with('*') && actual_type == expected_type.trim_right('*')
-		&& actual_type.starts_with('Map_') {
+	if expected_type.ends_with('*') && actual_type == 'voidptr' && rendered.trim_space() == 'NULL' {
+		return 'NULL'
+	}
+	if expected_type.ends_with('*') && fastc_expression_is_zero(tokens) {
+		return 'NULL'
+	}
+	if expected_type.ends_with('*') && actual_type == expected_type.trim_right('*') {
 		return '&(${rendered})'
 	}
+	if g.should_box_variant(expected_type, actual_type) {
+		return g.interface_value_expression(expected_type, actual_type, rendered)
+	}
 	return rendered
+}
+
+fn (g &Parser) render_array_literal_argument(tokens []FastcExpressionToken, expected_type string) ?FastcRenderedExpression {
+	array_type := expected_type.trim_right('*')
+	is_fixed := array_type.starts_with('FixedArray_')
+	if (!array_type.starts_with('Array_') && !is_fixed) || tokens.len < 2 || tokens[0].tok != .lsbr {
+		return none
+	}
+	close := fastc_matching_delimiter(tokens, 0, .lsbr, .rsbr) or { return none }
+	expected_end := if is_fixed { tokens.len - 2 } else { tokens.len - 1 }
+	if close != expected_end || (is_fixed && tokens.last().tok != .not) {
+		return none
+	}
+	mut w := unsafe { &Parser(g) }
+	fastc_register_composite_type(array_type, mut w.composite_types)
+	element_type := g.array_element_type(array_type) or { return none }
+	items := fastc_expression_list_items(tokens, 1, close) or { return none }
+	if items.len == 0 {
+		return FastcRenderedExpression{
+			source: '(${array_type}){0}'
+			typ:    array_type
+		}
+	}
+	mut rendered_items := []string{cap: items.len}
+	for item in items {
+		rendered_items << g.render_call_argument_expression(item, element_type) or { return none }
+	}
+	normalized_element := fastc_normalize_inferred_type(element_type)
+	if is_fixed {
+		c_array_type := fastc_array_initializer_c_type(array_type)
+		w.fixed_array_types[c_array_type] = array_type
+		return FastcRenderedExpression{
+			source: '((${c_array_type}){.data={${rendered_items.join(',')}}})'
+			typ:    array_type
+		}
+	}
+	return FastcRenderedExpression{
+		source: '((${array_type})builtin__new_array_from_c_array(${items.len}, ${items.len}, sizeof(${normalized_element}), (${normalized_element}[]){${rendered_items.join(',')}}))'
+		typ:    array_type
+	}
+}
+
+fn (g &Parser) render_function_value_expression(tokens []FastcExpressionToken) ?string {
+	if tokens.len == 0 || tokens.last().tok != .name {
+		return none
+	}
+	if tokens.len == 1 && tokens[0].lit in g.locals {
+		return none
+	}
+	if tokens.len != 1 && !(tokens.len == 3 && tokens[0].tok == .name && tokens[1].tok == .dot
+		&& (tokens[0].lit in g.imports || tokens[0].lit == 'C')) {
+		return none
+	}
+	function_key := g.function_key_for_call(tokens, tokens.len - 1)
+	if function_key !in g.functions && function_key !in g.mono_functions {
+		return none
+	}
+	return '&${fastc_c_function_name_for_key(function_key)}'
+}
+
+fn (g &Parser) render_method_value_expression(tokens []FastcExpressionToken) ?string {
+	if tokens.len < 3 || tokens.last().tok != .name || tokens[tokens.len - 2].tok != .dot {
+		return none
+	}
+	receiver_tokens := tokens[..tokens.len - 2]
+	receiver_type := g.infer_expression_type(receiver_tokens) or { return none }
+	if g.struct_member_type(receiver_type, tokens.last().lit) != '' {
+		return none
+	}
+	method_key, _ := g.resolve_method(receiver_type, tokens.last().lit)
+	signature := if method_key in g.functions {
+		g.functions[method_key]
+	} else if method_key in g.mono_functions {
+		g.mono_functions[method_key]
+	} else {
+		return none
+	}
+	if signature.parameter_types.len == 0 {
+		return none
+	}
+	return '&${fastc_method_c_name(signature.module_name, signature.parameter_types[0],
+		tokens.last().lit)}'
+}
+
+fn (g &Parser) render_map_literal_argument(tokens []FastcExpressionToken, expected_type string) ?FastcRenderedExpression {
+	map_type := expected_type.trim_right('*')
+	key_type, value_type := g.map_key_value_types(map_type) or { return none }
+	if tokens.len < 2 || tokens[0].tok != .lcbr || tokens.last().tok != .rcbr {
+		return none
+	}
+	close := fastc_matching_delimiter(tokens, 0, .lcbr, .rcbr) or { return none }
+	if close != tokens.len - 1 {
+		return none
+	}
+	entries := fastc_map_literal_entries(tokens, 1, close) or { return none }
+	hash_fn, eq_fn, clone_fn, free_fn := g.map_runtime_functions(key_type)
+	mut statements := [
+		'map __v_fastc_argument_map = builtin__new_map(sizeof(${fastc_runtime_c_type(key_type)}), sizeof(${fastc_runtime_c_type(value_type)}), &${hash_fn}, &${eq_fn}, &${clone_fn}, &${free_fn});',
+	]
+	for entry_index, entry in entries {
+		mut colon := -1
+		mut parens := 0
+		mut brackets := 0
+		mut braces := 0
+		for i, item in entry {
+			match item.tok {
+				.lpar {
+					parens++
+				}
+				.rpar {
+					parens--
+				}
+				.lsbr {
+					brackets++
+				}
+				.rsbr {
+					brackets--
+				}
+				.lcbr {
+					braces++
+				}
+				.rcbr {
+					braces--
+				}
+				.colon {
+					if parens == 0 && brackets == 0 && braces == 0 {
+						colon = i
+						break
+					}
+				}
+				else {}
+			}
+		}
+		if colon <= 0 || colon + 1 >= entry.len {
+			return none
+		}
+		key := g.render_call_argument_expression(entry[..colon], key_type) or { return none }
+		value := g.render_call_argument_expression(entry[colon + 1..], value_type) or {
+			return none
+		}
+		key_name := '__v_fastc_argument_map_key_${entry_index}'
+		value_name := '__v_fastc_argument_map_value_${entry_index}'
+		statements << '${fastc_runtime_c_type(key_type)} ${key_name} = (${key});'
+		statements << '${fastc_runtime_c_type(value_type)} ${value_name} = (${value});'
+		statements << 'builtin__map_set(&__v_fastc_argument_map, &${key_name}, &${value_name});'
+	}
+	return FastcRenderedExpression{
+		source: '({ ${statements.join(' ')} __v_fastc_argument_map; })'
+		typ:    map_type
+	}
+}
+
+fn fastc_map_literal_entries(tokens []FastcExpressionToken, start int, end int) ?[][]FastcExpressionToken {
+	mut entries := [][]FastcExpressionToken{}
+	mut entry_start := start
+	mut parens := 0
+	mut brackets := 0
+	mut braces := 0
+	for i in start .. end {
+		match tokens[i].tok {
+			.lpar {
+				parens++
+			}
+			.rpar {
+				parens--
+			}
+			.lsbr {
+				brackets++
+			}
+			.rsbr {
+				brackets--
+			}
+			.lcbr {
+				braces++
+			}
+			.rcbr {
+				braces--
+			}
+			.comma, .semicolon {
+				if parens == 0 && brackets == 0 && braces == 0 {
+					if entry_start < i {
+						entries << tokens[entry_start..i]
+					}
+					entry_start = i + 1
+				}
+			}
+			else {}
+		}
+	}
+	if entry_start < end {
+		entries << tokens[entry_start..end]
+	}
+	return entries
+}
+
+// is_boxed_type reports whether a type uses the boxed `{_object, _typ, _methods}`
+// representation: interfaces and sum types. A concrete struct used where such a
+// type is expected is boxed with its type id (see interface_value_expression).
+fn (g &Parser) is_boxed_type(c_type string) bool {
+	if c_type.trim_right('*') in g.sum_types {
+		return true
+	}
+	return g.declared_kinds[g.semantic_type_key(c_type)] == .interface_
+}
+
+// should_box_variant reports whether a value of `actual_type` used where the
+// boxed `expected_type` is expected must be boxed: a concrete struct into an
+// interface or sum type, or a primitive scalar into a sum type (interfaces have
+// no primitive implementers, so primitives are only boxed for sum types).
+fn (g &Parser) should_box_variant(expected_type string, actual_type string) bool {
+	if actual_type == '' || fastc_is_pointer_type(expected_type) || !g.is_boxed_type(expected_type) {
+		return false
+	}
+	resolved_actual := g.underlying_alias_type(actual_type)
+	if g.declared_kinds[g.semantic_type_key(resolved_actual)] == .struct_ {
+		return true
+	}
+	if expected_type.trim_right('*') in g.sum_types {
+		// Primitive or composite (`Array_`/`Map_`) value into a sum type. Interfaces
+		// have no primitive/composite implementers, so this is sum-type only.
+		normalized := fastc_normalize_inferred_type(actual_type).trim_right('*')
+		return fastc_primitive_c_type(normalized) != none || normalized.starts_with('Array_')
+			|| normalized.starts_with('Map_')
+	}
+	return false
 }
 
 fn (g &Parser) render_map_lookup_option_expression(tokens []FastcExpressionToken) ?FastcRenderedExpression {
@@ -1816,9 +3314,9 @@ fn (g &Parser) render_map_lookup_option_expression(tokens []FastcExpressionToken
 	}
 	base_tokens := lookup_tokens[..open]
 	map_type := g.infer_expression_type(base_tokens) or { return none }
-	key_type, value_type := fastc_map_key_value_types(map_type) or { return none }
+	key_type, value_type := g.map_key_value_types(map_type) or { return none }
 	mut map_source := if base_tokens.len == 1 && base_tokens[0].tok == .name {
-		g.globals[fastc_global_key(g.module_name, base_tokens[0].lit)] or { base_tokens[0].lit }
+		g.resolved_root_expression_name(base_tokens[0].lit)
 	} else {
 		g.render_member_receiver(base_tokens) or { return none }
 	}
@@ -1911,7 +3409,7 @@ fn (g &Parser) render_missing_call_arguments(tokens []FastcExpressionToken) ?Fas
 		name_index = 2
 		open_index = 3
 	}
-	if tokens[name_index].tok != .name || tokens[open_index].tok != .lpar {
+	if tokens[name_index].tok !in [.name, .key_select] || tokens[open_index].tok != .lpar {
 		return none
 	}
 	close := fastc_matching_rpar(tokens, open_index) or { return none }
@@ -1919,7 +3417,11 @@ fn (g &Parser) render_missing_call_arguments(tokens []FastcExpressionToken) ?Fas
 		return none
 	}
 	function_key := g.function_key_for_call(tokens, name_index)
-	signature := g.functions[function_key] or { return none }
+	signature := if function_key in g.functions {
+		g.functions[function_key]
+	} else {
+		g.mono_functions[function_key] or { return none }
+	}
 	if signature.is_disabled {
 		return FastcRenderedExpression{
 			source: fastc_disabled_call_expression(signature.return_type)
@@ -1934,7 +3436,9 @@ fn (g &Parser) render_missing_call_arguments(tokens []FastcExpressionToken) ?Fas
 			break
 		}
 	}
-	if signature.last_parameter_is_params && named_start == signature.parameter_types.len - 1 {
+	if named_start >= 0 && named_start == signature.parameter_types.len - 1
+		&& named_start <= call_args.len && (signature.last_parameter_is_params
+		|| g.fastc_type_is_declared_struct(signature.parameter_types[named_start])) {
 		mut rendered_arguments := []string{}
 		for argument_index, argument in call_args[..named_start] {
 			expected_type := if argument_index < signature.parameter_types.len {
@@ -1963,6 +3467,20 @@ fn (g &Parser) render_missing_call_arguments(tokens []FastcExpressionToken) ?Fas
 		}
 		variadic_type := signature.parameter_types.last()
 		element_type := g.array_element_type(variadic_type) or { return none }
+		if named_start == fixed_arguments {
+			mut c_arguments := []string{cap: fixed_arguments + 1}
+			for argument_index, argument in call_args[..fixed_arguments] {
+				c_arguments << g.render_call_argument_expression(argument,
+					signature.parameter_types[argument_index]) or { return none }
+			}
+			named_initializer := g.render_named_struct_initializer(element_type,
+				call_args[named_start..]) or { return none }
+			c_arguments << '((${variadic_type})builtin__new_array_from_c_array(1, 1, sizeof(${element_type}), (${element_type}[]){${named_initializer}}))'
+			return FastcRenderedExpression{
+				source: '${fastc_c_function_name_for_key(function_key)}(${c_arguments.join(',')})'
+				typ:    signature.return_type
+			}
+		}
 		mut rendered_arguments := []string{}
 		for argument_index, argument in call_args {
 			expected_type := if argument_index < fixed_arguments {
@@ -1974,6 +3492,9 @@ fn (g &Parser) render_missing_call_arguments(tokens []FastcExpressionToken) ?Fas
 				return none
 			}
 			rendered_arguments << rendered_argument
+		}
+		if fixed_arguments < 0 || fixed_arguments > rendered_arguments.len {
+			return none
 		}
 		variadic_arguments := rendered_arguments[fixed_arguments..].clone()
 		packed := if variadic_arguments.len == 0 {
@@ -2004,6 +3525,9 @@ fn (g &Parser) render_missing_call_arguments(tokens []FastcExpressionToken) ?Fas
 		}
 		rendered_arguments << rendered_argument
 	}
+	if call_args.len > signature.parameter_types.len {
+		return none
+	}
 	for parameter_type in signature.parameter_types[call_args.len..] {
 		rendered_arguments << g.render_empty_struct_initializer(parameter_type)
 	}
@@ -2016,6 +3540,26 @@ fn (g &Parser) render_missing_call_arguments(tokens []FastcExpressionToken) ?Fas
 		source: '${call_name}(${rendered_arguments.join(',')})'
 		typ:    signature.return_type
 	}
+}
+
+fn (g &Parser) render_explicit_generic_call_expression(tokens []FastcExpressionToken) ?FastcRenderedExpression {
+	for open in 1 .. tokens.len - 1 {
+		if tokens[open].tok != .lsbr || tokens[open - 1].tok != .name {
+			continue
+		}
+		close := fastc_matching_delimiter(tokens, open, .lsbr, .rsbr) or { continue }
+		if close + 1 >= tokens.len || tokens[close + 1].tok != .lpar {
+			continue
+		}
+		mut normalized := tokens[..open].clone()
+		normalized << tokens[close + 1..]
+		raw := g.render_raw_expression_tokens(normalized) or { return none }
+		if method := g.render_method_call_expression(normalized, raw) {
+			return method
+		}
+		return g.render_missing_call_arguments(normalized)
+	}
+	return none
 }
 
 fn (g &Parser) render_append_expression(tokens []FastcExpressionToken, rendered_expression string) ?FastcRenderedExpression {
@@ -2042,13 +3586,60 @@ fn (g &Parser) render_append_expression(tokens []FastcExpressionToken, rendered_
 		return none
 	}
 	left_type := g.infer_expression_type(tokens[..operator_index]) or { return none }
-	if g.array_element_type(left_type) == none {
-		return none
-	}
+	element_type := g.array_element_type(left_type) or { return none }
 	separator := rendered_expression.index('<<') or { return none }
-	left_source := rendered_expression[..separator]
-	right_source := rendered_expression[separator + 2..]
+	left_tokens := tokens[..operator_index]
+	mut left_source := rendered_expression[..separator]
+	mut right_source := rendered_expression[separator + 2..]
+	// The raw streamed value is only valid C for a plain operand. A boxed sum/interface
+	// cast (`arr << Primitive(x)`), a top-level index/array-literal (`arr << type_idx['int']`,
+	// `arr << [a, b]`), and any call (`arr << s.clone()`, `arr << f(x)`) need the argument
+	// renderer, which boxes variants, lowers indexing, and routes method/function calls.
+	// Render through it whenever it succeeds, keeping the raw form only as a fallback.
+	if rerendered := g.render_call_argument_expression(tokens[operator_index + 1..], element_type) {
+		right_source = rerendered
+	}
 	temporary := '__v_fastc_append_value'
+	if left_tokens.len >= 4 && left_tokens.last().tok == .rsbr {
+		mut open := -1
+		mut bracket_depth := 0
+		for i := left_tokens.len - 1; i >= 0; i-- {
+			if left_tokens[i].tok == .rsbr {
+				bracket_depth++
+			} else if left_tokens[i].tok == .lsbr {
+				bracket_depth--
+				if bracket_depth == 0 {
+					open = i
+					break
+				}
+			}
+		}
+		if open > 0 {
+			base_tokens := left_tokens[..open]
+			map_type := g.infer_expression_type(base_tokens) or { '' }
+			if key_type, value_type := g.map_key_value_types(map_type) {
+				if value_type == left_type {
+					key_source := g.render_call_argument_expression(left_tokens[open + 1..left_tokens.len - 1],
+						key_type) or { return none }
+					mut map_source := if base_tokens.len == 1 && base_tokens[0].tok == .name {
+						g.globals[fastc_global_key(g.module_name, base_tokens[0].lit)] or {
+							g.resolved_expression_name(base_tokens[0].lit, .unknown)
+						}
+					} else {
+						g.render_member_receiver(base_tokens) or { return none }
+					}
+					if map_type.ends_with('*') {
+						map_source = '*(${map_source})'
+					}
+					left_source = '({ ${key_type} __v_fastc_append_map_key = (${key_source}); ${value_type} *__v_fastc_append_map_value = (${value_type} *)builtin__map_get_check((map *)&(${map_source}), &__v_fastc_append_map_key); if (__v_fastc_append_map_value == NULL) { ${value_type} __v_fastc_append_map_empty = (${value_type}){0}; builtin__map_set((map *)&(${map_source}), &__v_fastc_append_map_key, &__v_fastc_append_map_empty); __v_fastc_append_map_value = (${value_type} *)builtin__map_get_check((map *)&(${map_source}), &__v_fastc_append_map_key); } __v_fastc_append_map_value; })'
+					return FastcRenderedExpression{
+						source: '({ ${element_type} ${temporary} = (${right_source}); ${value_type} *__v_fastc_append_map_target = ${left_source}; builtin__array_push((array *)__v_fastc_append_map_target, &${temporary}); 0; })'
+						typ:    'void'
+					}
+				}
+			}
+		}
+	}
 	return FastcRenderedExpression{
 		source: '({ __typeof__((${right_source})) ${temporary} = (${right_source}); builtin__array_push((array *)&(${left_source}), &${temporary}); 0; })'
 		typ:    'void'
@@ -2066,13 +3657,51 @@ fn (g &Parser) render_method_call_expression(tokens []FastcExpressionToken, rend
 		if tokens[i].tok != .name || tokens[i - 1].tok != .dot || tokens[i + 1].tok != .lpar {
 			continue
 		}
+		// `mod.func()` is a module-qualified call; skip method rendering. But a FIELD named
+		// like an imported module (`recv.mod.method()`, e.g. `h.time.elapsed()`) is a real
+		// method call — only skip when `mod` is a bare module ref, not preceded by a `.`.
 		if tokens[i - 2].tok == .name
-			&& (tokens[i - 2].lit in g.imports || tokens[i - 2].lit == 'C') {
+			&& (tokens[i - 2].lit in g.imports || tokens[i - 2].lit == 'C')
+			&& (i < 3 || tokens[i - 3].tok != .dot) {
 			continue
 		}
 		receiver_start := fastc_method_receiver_start(tokens, i - 1)
 		receiver_tokens := tokens[receiver_start..i - 1]
 		receiver_type := g.infer_expression_type(receiver_tokens) or { continue }
+		if tokens[i].lit == 'contains'
+			&& fastc_normalize_inferred_type(receiver_type).trim_right('*').starts_with('Array_') {
+			call_end := fastc_matching_rpar(tokens, i + 1) or { continue }
+			call_args := fastc_call_arguments(tokens, i + 1, call_end) or { continue }
+			if call_args.len != 1 {
+				continue
+			}
+			element_type := g.array_element_type(receiver_type) or { continue }
+			receiver := g.render_method_receiver_expression(receiver_tokens) or { continue }
+			argument := g.render_call_argument_expression(call_args[0], element_type) or {
+				continue
+			}
+			access := if receiver_type.ends_with('*') { '->' } else { '.' }
+			comparison := if g.underlying_alias_type(element_type).trim_right('*') == 'string' {
+				'builtin__string_eq(__v_fastc_contains_item, ((${element_type} *)__v_fastc_contains_collection${access}data)[__v_fastc_contains_index])'
+			} else {
+				'(__v_fastc_contains_item == ((${element_type} *)__v_fastc_contains_collection${access}data)[__v_fastc_contains_index])'
+			}
+			call_source := '({ ${element_type} __v_fastc_contains_item = (${argument}); __typeof__((${receiver.source})) __v_fastc_contains_collection = (${receiver.source}); bool __v_fastc_contains_found = false; for (int __v_fastc_contains_index = 0; __v_fastc_contains_index < __v_fastc_contains_collection${access}len; __v_fastc_contains_index++) { if (${comparison}) { __v_fastc_contains_found = true; break; } } __v_fastc_contains_found; })'
+			if receiver_start == 0 && call_end == tokens.len - 1 {
+				return FastcRenderedExpression{
+					source: call_source
+					typ:    'bool'
+				}
+			}
+			raw_call := g.render_raw_expression_tokens(tokens[receiver_start..call_end + 1]) or {
+				continue
+			}
+			if rendered.contains(raw_call) {
+				rendered = rendered.replace(raw_call, call_source)
+				changed = true
+			}
+			continue
+		}
 		if tokens[i].lit == 'wait' && receiver_type.starts_with(fastc_thread_type_prefix) {
 			// `.wait()` joins a spawned thread (see spawn.v); it has no entry in
 			// the collected function signatures.
@@ -2102,10 +3731,80 @@ fn (g &Parser) render_method_call_expression(tokens []FastcExpressionToken, rend
 			}
 			continue
 		}
-		method_key := g.method_function_key(receiver_type, tokens[i].lit)
-		if method_key !in g.functions {
-			if g.struct_member_type(receiver_type, tokens[i].lit) != '' {
+		method_key, embedded_path := g.resolve_method(receiver_type, tokens[i].lit)
+		if method_key !in g.functions && method_key !in g.mono_functions {
+			if tokens[i].lit == 'str' && g.can_generate_default_struct_str(receiver_type) {
+				call_end := fastc_matching_rpar(tokens, i + 1) or { continue }
+				if call_end != i + 2 {
+					continue
+				}
 				receiver := g.render_method_receiver_expression(receiver_tokens) or { continue }
+				mut w := unsafe { &Parser(g) }
+				helper := w.fastc_default_struct_str_name(receiver_type.trim_right('*')) or {
+					continue
+				}
+				receiver_argument := if receiver_type.ends_with('*') {
+					'*(${receiver.source})'
+				} else {
+					receiver.source
+				}
+				call_source := '${helper}(${receiver_argument})'
+				if receiver_start == 0 && call_end == tokens.len - 1 {
+					return FastcRenderedExpression{
+						source: call_source
+						typ:    'string'
+					}
+				}
+				raw_call := g.render_raw_expression_tokens(tokens[receiver_start..call_end + 1]) or {
+					continue
+				}
+				if rendered.contains(raw_call) {
+					rendered = rendered.replace(raw_call, call_source)
+					changed = true
+				}
+				continue
+			}
+			if field := g.struct_field_metadata(receiver_type, tokens[i].lit) {
+				receiver := g.render_method_receiver_expression(receiver_tokens) or { continue }
+				call_end := fastc_matching_rpar(tokens, i + 1) or { continue }
+				if field.is_function {
+					field_tokens := tokens[receiver_start..i + 1]
+					field_source := g.render_member_receiver(field_tokens) or { continue }
+					call_args := fastc_call_arguments(tokens, i + 1, call_end) or { continue }
+					if call_args.len != field.fn_parameter_types.len {
+						continue
+					}
+					mut arguments := []string{cap: call_args.len}
+					for argument_index, argument in call_args {
+						arguments << g.render_call_argument_expression(argument,
+							field.fn_parameter_types[argument_index]) or { continue }
+					}
+					parameter_types := if field.fn_parameter_types.len == 0 {
+						'void'
+					} else {
+						field.fn_parameter_types.join(', ')
+					}
+					return_type := if field.fn_return_type == '' {
+						'void'
+					} else {
+						field.fn_return_type
+					}
+					call_source := '((${return_type} (*)(${parameter_types}))(${field_source}))(${arguments.join(', ')})'
+					if receiver_start == 0 && call_end == tokens.len - 1 {
+						return FastcRenderedExpression{
+							source: call_source
+							typ:    return_type
+						}
+					}
+					raw_call := g.render_raw_expression_tokens(tokens[receiver_start..call_end + 1]) or {
+						continue
+					}
+					if rendered.contains(raw_call) {
+						rendered = rendered.replace(raw_call, call_source)
+						changed = true
+					}
+					continue
+				}
 				for separator in ['->', '.'] {
 					marker := '${receiver.source}${separator}${tokens[i].lit}('
 					if rendered.contains(marker) {
@@ -2118,7 +3817,11 @@ fn (g &Parser) render_method_call_expression(tokens []FastcExpressionToken, rend
 			}
 			continue
 		}
-		signature := g.functions[method_key]
+		signature := if method_key in g.functions {
+			g.functions[method_key]
+		} else {
+			g.mono_functions[method_key]
+		}
 		if signature.parameter_types.len == 0 {
 			continue
 		}
@@ -2171,12 +3874,26 @@ fn (g &Parser) render_method_call_expression(tokens []FastcExpressionToken, rend
 			}
 		}
 		expected_receiver := signature.parameter_types[0]
-		receiver_argument := if expected_receiver.ends_with('*') && !receiver_type.ends_with('*') {
-			'&(${receiver_source})'
-		} else if !expected_receiver.ends_with('*') && receiver_type.ends_with('*') {
-			'*(${receiver_source})'
+		mut effective_receiver_source := receiver_source
+		mut effective_is_pointer := receiver.typ.ends_with('*')
+		if embedded_path.len > 0 {
+			// Promote through embedded fields: `d.method()`, where `method` lives on
+			// an embedded type, becomes `Type_method(&(d.__embedded_N), ...)`. The
+			// embedded field is stored by value, so the promoted receiver is a value.
+			access := if effective_is_pointer { '->' } else { '.' }
+			effective_receiver_source = '(${receiver_source})'
+			for idx, part in embedded_path {
+				separator_c := if idx == 0 { access } else { '.' }
+				effective_receiver_source += '${separator_c}${part}'
+			}
+			effective_is_pointer = false
+		}
+		receiver_argument := if expected_receiver.ends_with('*') && !effective_is_pointer {
+			'&(${effective_receiver_source})'
+		} else if !expected_receiver.ends_with('*') && effective_is_pointer {
+			'*(${effective_receiver_source})'
 		} else {
-			receiver_source
+			effective_receiver_source
 		}
 		has_arguments := call_end > i + 2
 		method_c_name := fastc_method_c_name(signature.module_name, expected_receiver,
@@ -2184,23 +3901,67 @@ fn (g &Parser) render_method_call_expression(tokens []FastcExpressionToken, rend
 		mut direct_arguments := []string{}
 		if has_arguments {
 			call_args := fastc_call_arguments(tokens, i + 1, call_end) or { continue }
+			mut named_start := -1
 			for argument_index, argument in call_args {
-				expected_index := argument_index + 1
-				expected_type := if expected_index < signature.parameter_types.len {
-					signature.parameter_types[expected_index]
-				} else {
-					''
+				if argument.len >= 3 && argument[0].tok == .name && argument[1].tok == .colon {
+					named_start = argument_index
+					break
 				}
-				argument_source := g.render_call_argument_expression(argument, expected_type) or {
-					continue
+			}
+			if named_start >= 0 && named_start + 1 == signature.parameter_types.len - 1
+				&& (signature.last_parameter_is_params
+				|| g.fastc_type_is_declared_struct(signature.parameter_types.last())) {
+				for argument_index, argument in call_args[..named_start] {
+					expected_type := signature.parameter_types[argument_index + 1]
+					direct_arguments << g.render_call_argument_expression(argument, expected_type) or {
+						continue
+					}
 				}
-				argument_type := g.infer_expression_type(argument) or { '' }
-				if expected_type == 'voidptr' && !fastc_is_pointer_type(argument_type) {
-					direct_arguments << '&(${argument_source})'
+				named_parameter_type := if signature.is_variadic {
+					g.array_element_type(signature.parameter_types.last()) or { continue }
 				} else {
+					signature.parameter_types.last()
+				}
+				named_initializer := g.render_named_struct_initializer(named_parameter_type,
+					call_args[named_start..]) or { continue }
+				direct_arguments << named_initializer
+			} else {
+				for argument_index, argument in call_args {
+					expected_index := argument_index + 1
+					expected_type := if signature.is_variadic
+						&& expected_index >= signature.parameter_types.len - 1 {
+						g.array_element_type(signature.parameter_types.last()) or { continue }
+					} else if expected_index < signature.parameter_types.len {
+						signature.parameter_types[expected_index]
+					} else {
+						''
+					}
+					argument_source := g.render_call_argument_expression(argument, expected_type) or {
+						continue
+					}
 					direct_arguments << argument_source
 				}
 			}
+		}
+		if signature.is_variadic && !method_key.starts_with('C.') {
+			fixed_arguments := signature.parameter_types.len - 2
+			if direct_arguments.len < fixed_arguments {
+				continue
+			}
+			variadic_type := signature.parameter_types.last()
+			element_type := g.array_element_type(variadic_type) or { continue }
+			variadic_arguments := direct_arguments[fixed_arguments..].clone()
+			packed := if variadic_arguments.len == 0 {
+				'(${variadic_type}){0}'
+			} else {
+				'((${variadic_type})builtin__new_array_from_c_array(${variadic_arguments.len}, ${variadic_arguments.len}, sizeof(${element_type}), (${element_type}[]){${variadic_arguments.join(',')}}))'
+			}
+			direct_arguments = direct_arguments[..fixed_arguments].clone()
+			direct_arguments << packed
+		}
+		if signature.last_parameter_is_params
+			&& direct_arguments.len + 1 == signature.parameter_types.len - 1 {
+			direct_arguments << g.render_empty_struct_initializer(signature.parameter_types.last())
 		}
 		replacement := '${method_c_name}(${receiver_argument}${if has_arguments {
 			','
@@ -2213,7 +3974,8 @@ fn (g &Parser) render_method_call_expression(tokens []FastcExpressionToken, rend
 			result_type := g.specialized_method_return_type(receiver_type, method_key, signature)
 			is_pointer_result_method := method_key.starts_with('array.')
 				&& tokens[i].lit in ['first', 'last', 'pop', 'pop_left']
-			if !is_pointer_result_method && !has_arguments && rendered.contains(needle) {
+			if !is_pointer_result_method && !has_arguments && direct_arguments.len == 0
+				&& rendered.contains(needle) {
 				return FastcRenderedExpression{
 					source: rendered.replace(needle, replacement)
 					typ:    result_type
@@ -2232,6 +3994,18 @@ fn (g &Parser) render_method_call_expression(tokens []FastcExpressionToken, rend
 			return FastcRenderedExpression{
 				source: direct_call
 				typ:    result_type
+			}
+		}
+		if direct_arguments.len > 0 {
+			argument_suffix := ',' + direct_arguments.join(',')
+			direct_call := '${method_c_name}(${receiver_argument}${argument_suffix})'
+			raw_call := g.render_raw_expression_tokens(tokens[receiver_start..call_end + 1]) or {
+				continue
+			}
+			if rendered.contains(raw_call) {
+				rendered = rendered.replace(raw_call, direct_call)
+				changed = true
+				continue
 			}
 		}
 		if method_key.starts_with('array.') && !has_arguments
@@ -2330,13 +4104,134 @@ fn (g &Parser) render_composed_string_concatenation(tokens []FastcExpressionToke
 	}
 }
 
+// render_option_propagation lowers a `!`/`?`-propagated expression (`inner_tokens` is
+// the operand WITHOUT the trailing `!`): evaluate the option, propagate its error state
+// (return in a result fn, panic in `main`), else yield the unwrapped value. Used both
+// as a standalone value and as the receiver of `f()!.m()`.
+fn (g &Parser) render_option_propagation(inner_tokens []FastcExpressionToken) ?FastcRenderedExpression {
+	if inner_tokens.len == 0 {
+		return none
+	}
+	inner_raw := g.render_raw_expression_tokens(inner_tokens) or { return none }
+	mut inner_source := inner_raw
+	if explicit_generic := g.render_explicit_generic_call_expression(inner_tokens) {
+		inner_source = explicit_generic.source
+	} else if static_expression := g.render_static_call_expression(inner_tokens, inner_raw) {
+		inner_source = static_expression.source
+	} else if method_expression := g.render_method_call_expression(inner_tokens, inner_raw) {
+		inner_source = method_expression.source
+	} else if map_lookup := g.render_map_lookup_option_expression(inner_tokens) {
+		inner_source = map_lookup.source
+	} else if array_lookup := g.render_array_lookup_option_expression(inner_tokens) {
+		inner_source = array_lookup.source
+	} else if array_expression := g.render_array_access_expression(inner_tokens) {
+		inner_source = array_expression.source
+	} else if defaulted_call := g.render_missing_call_arguments(inner_tokens) {
+		inner_source = defaulted_call.source
+	}
+	if pointer_members := g.render_pointer_member_access_expression(inner_tokens, inner_source) {
+		inner_source = pointer_members.source
+	}
+	value_type := g.option_value_type_for_expression(inner_tokens)
+	temporary := '__v_fastc_option_propagate'
+	failure := if g.in_main {
+		deferred := g.deferred_scopes_source()
+		'${deferred} builtin__panic_result_not_set(builtin__IError_msg(${temporary}.err));'
+	} else if g.return_type == 'Option' {
+		'return ${temporary};'
+	} else {
+		'return 1;'
+	}
+	value := if value_type in ['', 'void'] {
+		'0'
+	} else {
+		'*((${value_type} *)${temporary}.data)'
+	}
+	return FastcRenderedExpression{
+		source: '({ Option ${temporary} = (${inner_source}); if (${temporary}.state) { ${failure} } ${value}; })'
+		typ:    value_type
+	}
+}
+
+fn (g &Parser) render_nested_option_propagation(tokens []FastcExpressionToken, rendered_expression string) ?FastcRenderedExpression {
+	mut rendered := rendered_expression
+	mut changed := false
+	for i := tokens.len - 1; i >= 0; i-- {
+		item := tokens[i]
+		if item.tok != .not || i == 0 || tokens[i - 1].tok !in [.name, .rpar] {
+			continue
+		}
+		start := fastc_method_receiver_start(tokens, i)
+		if start >= i {
+			continue
+		}
+		inner_tokens := tokens[start..i]
+		propagation := g.render_option_propagation(inner_tokens) or { continue }
+		raw_inner := g.render_raw_expression_tokens(inner_tokens) or { continue }
+		needle := '${raw_inner}!'
+		if rendered.contains(needle) {
+			rendered = rendered.replace(needle, propagation.source)
+			changed = true
+		}
+	}
+	if !changed {
+		return none
+	}
+	if logical := g.render_logical_expression(tokens) {
+		return logical
+	}
+	if struct_literal := g.render_struct_literal_expression(tokens) {
+		rendered = struct_literal.source
+	}
+	if methods := g.render_method_call_expression(tokens, rendered) {
+		rendered = methods.source
+	}
+	if array_access := g.render_array_access_expression(tokens) {
+		rendered = array_access.source
+	} else if nested_array := g.render_nested_array_access_expression(tokens, rendered) {
+		rendered = nested_array.source
+	}
+	return FastcRenderedExpression{
+		source: rendered
+		typ:    g.infer_expression_type(tokens) or { '' }
+	}
+}
+
 fn (g &Parser) render_method_receiver_expression(tokens []FastcExpressionToken) ?FastcRenderedExpression {
+	if tokens.len > 1 && tokens.last().tok == .not && !(tokens[0].tok == .lsbr
+		&& tokens[tokens.len - 2].tok == .rsbr) {
+		// A `!`-propagated receiver (`f()!.m()`): unwrap the result before the call.
+		if propagation := g.render_option_propagation(tokens[..tokens.len - 1]) {
+			return propagation
+		}
+	}
 	receiver_type := g.infer_expression_type(tokens) or { return none }
+	if tokens.len == 1 && tokens[0].source != '' {
+		// A pre-rendered synthetic receiver (e.g. an `or {}`-unwrap `({ ... })` used as
+		// `expr or { ... }.method()`) carries its full rendered form as its `source`;
+		// use it directly so the method call binds to it.
+		return FastcRenderedExpression{
+			source: tokens[0].source
+			typ:    receiver_type
+		}
+	}
 	if source := g.render_map_expression(tokens) {
 		return source
 	}
+	if array_literal := g.render_array_literal_argument(tokens, receiver_type) {
+		return array_literal
+	}
 	if array_access := g.render_array_access_expression(tokens) {
 		return array_access
+	}
+	if cast_expression := g.render_cast_expression(tokens) {
+		return cast_expression
+	}
+	if struct_literal := g.render_struct_literal_expression(tokens) {
+		return struct_literal
+	}
+	if overloaded := g.render_overloaded_binary_expression(tokens) {
+		return overloaded
 	}
 	if source := g.render_member_receiver(tokens) {
 		return FastcRenderedExpression{
@@ -2364,6 +4259,7 @@ fn (g &Parser) render_member_receiver(tokens []FastcExpressionToken) ?string {
 	}
 	mut source := g.resolved_expression_name(tokens[0].lit, .unknown)
 	mut current_type := g.infer_expression_type(tokens[..1]) or { return none }
+	mut member_path := tokens[0].lit
 	mut i := 1
 	for i < tokens.len {
 		if i + 1 >= tokens.len || tokens[i].tok != .dot || tokens[i + 1].tok != .name {
@@ -2381,6 +4277,11 @@ fn (g &Parser) render_member_receiver(tokens []FastcExpressionToken) ?string {
 		separator := if current_type.ends_with('*') { '->' } else { '.' }
 		source += separator + fastc_c_identifier(field.name)
 		current_type = field.typ
+		member_path += '.' + tokens[i + 1].lit
+		if smartcast := g.member_smartcasts[member_path] {
+			source = smartcast.source
+			current_type = smartcast.typ
+		}
 		i += 2
 	}
 	return source

--- a/vlib/v3/gen/fastc/signatures.v
+++ b/vlib/v3/gen/fastc/signatures.v
@@ -1,5 +1,6 @@
 module fastc
 
+import os
 import v3.pref
 import v3.scanner
 import v3.token
@@ -21,16 +22,20 @@ fn fastc_skip_attribute(mut scan scanner.Scanner) !token.Token {
 	return tok
 }
 
-fn fastc_scan_struct_field_attribute(mut scan scanner.Scanner) !(token.Token, bool) {
+fn fastc_scan_struct_field_attribute(mut scan scanner.Scanner) !(token.Token, bool, bool) {
 	mut tok := scan.scan()
 	mut depth := 1
 	mut is_required := false
+	mut is_skip := false
 	for depth > 0 {
 		if tok == .eof {
 			return error('fastc parser does not support unfinished struct field attribute')
 		}
 		if tok == .name && scan.lit == 'required' {
 			is_required = true
+		}
+		if tok == .name && scan.lit == 'skip' {
+			is_skip = true
 		}
 		if tok == .lsbr {
 			depth++
@@ -39,7 +44,7 @@ fn fastc_scan_struct_field_attribute(mut scan scanner.Scanner) !(token.Token, bo
 		}
 		tok = scan.scan()
 	}
-	return tok, is_required
+	return tok, is_required, is_skip
 }
 
 fn fastc_skip_balanced_tokens(mut scan scanner.Scanner, first token.Token, open token.Token, close token.Token) !token.Token {
@@ -116,6 +121,18 @@ fn collect_function_signatures(source string, path string, header FastcSourceHea
 			next_declaration_is_enabled = next_declaration_is_enabled && attribute.is_enabled
 			continue
 		}
+		if tok == .key_type && brace_depth == 0 {
+			mut alias_scan := scan
+			if alias_scan.scan() == .name {
+				alias_name := alias_scan.lit
+				if alias_scan.scan() == .assign && alias_scan.scan() == .key_fn {
+					alias_key := fastc_c_declared_type_name(fastc_type_key(header.module_name,
+						alias_name))
+					functions[alias_key] = fastc_scan_function_alias_signature(mut alias_scan,
+						path, header, prefs, declared_types)!
+				}
+			}
+		}
 		if tok == .key_fn && brace_depth == 0 && previous_tok != .assign {
 			is_public := previous_tok == .key_pub
 			tok = scan.scan()
@@ -157,7 +174,7 @@ fn collect_function_signatures(source string, path string, header FastcSourceHea
 				}
 				tok = scan.scan()
 			}
-			if tok != .name && !(receiver_type != '' && (tok.is_overloadable() || tok.is_keyword())) {
+			if tok != .name && !(tok.is_overloadable() || tok.is_keyword()) {
 				return error('fastc parser does not support function declaration token `${tok.str()}` `${scan.lit}` in ${path}')
 			}
 			mut name := if tok == .name || tok.is_keyword() { scan.lit } else { tok.str() }
@@ -250,8 +267,17 @@ fn collect_function_signatures(source string, path string, header FastcSourceHea
 					continue
 				}
 				if is_c_function && tok in [.comma, .rpar] {
-					parameter_type := fastc_primitive_c_type(parameter_name_or_type) or {
-						return error('fastc parser does not support undeclared C parameter type `${parameter_name_or_type}` in ${path}')
+					// An unnamed C parameter is just a type. Resolve declared types
+					// (e.g. an enum like `CParameter`) as well as primitives.
+					type_key := fastc_type_key(header.module_name, parameter_name_or_type)
+					parameter_type := if type_key in declared_types {
+						fastc_c_declared_type_name(type_key)
+					} else if parameter_name_or_type in declared_types {
+						fastc_c_declared_type_name(parameter_name_or_type)
+					} else {
+						fastc_primitive_c_type(parameter_name_or_type) or {
+							return error('fastc parser does not support undeclared C parameter type `${parameter_name_or_type}` in ${path}')
+						}
 					}
 					parameter_types << parameter_type
 					parameter_mutability << false
@@ -368,6 +394,84 @@ fn collect_function_signatures(source string, path string, header FastcSourceHea
 		declared_types, declared_type_c_names, params_structs, mut functions)!
 }
 
+// fastc_scan_function_alias_signature scans the signature after `type Name = fn`
+// without consuming the main declaration scanner. Function-pointer aliases are
+// callable locals, so their return and option payload types must survive the alias
+// cast used to initialize those locals.
+fn fastc_scan_function_alias_signature(mut scan scanner.Scanner, path string, header FastcSourceHeader, prefs &pref.Preferences, declared_types map[string]bool) !FastcFunctionSignature {
+	mut tok := scan.scan()
+	if tok != .lpar {
+		return error('fastc parser does not support function type in ${path}')
+	}
+	tok = scan.scan()
+	mut parameter_types := []string{}
+	mut parameter_mutability := []bool{}
+	for tok != .rpar {
+		if tok in [.comma, .semicolon] {
+			tok = scan.scan()
+			continue
+		}
+		mut parameter_is_mut := false
+		if tok in [.key_mut, .key_shared] {
+			parameter_is_mut = true
+			tok = scan.scan()
+		}
+		if tok == .name {
+			mut lookahead := scan
+			next_token := lookahead.scan()
+			if next_token in [.name, .amp, .and, .mul, .question, .not, .key_fn, .lsbr] {
+				tok = scan.scan()
+			}
+		}
+		parameter_type, next_token := fastc_scan_type(mut scan, tok, path, header.module_name,
+			header.imports, declared_types, prefs.building_v)!
+		parameter_types << if parameter_is_mut && !parameter_type.ends_with('*') {
+			parameter_type + '*'
+		} else {
+			parameter_type
+		}
+		parameter_mutability << parameter_is_mut
+		tok = next_token
+	}
+	tok = scan.scan()
+	mut return_type := 'void'
+	mut return_types := []string{}
+	mut option_type := ''
+	if tok !in [.semicolon, .eof] {
+		if tok in [.not, .question] {
+			return_type = 'Option'
+			tok = scan.scan()
+			if tok in [.semicolon, .eof] {
+				option_type = 'void'
+			} else if tok == .lpar {
+				return_types, tok = fastc_scan_multi_return_types(mut scan, path,
+					header.module_name, header.imports, declared_types, prefs.building_v)!
+				option_type = 'MultiReturn'
+			} else {
+				option_type, tok = fastc_scan_type(mut scan, tok, path, header.module_name,
+					header.imports, declared_types, prefs.building_v)!
+			}
+		} else if tok == .lpar {
+			return_types, tok = fastc_scan_multi_return_types(mut scan, path, header.module_name,
+				header.imports, declared_types, prefs.building_v)!
+			return_type = 'MultiReturn'
+		} else {
+			return_type, tok = fastc_scan_type(mut scan, tok, path, header.module_name,
+				header.imports, declared_types, prefs.building_v)!
+		}
+	}
+	return FastcFunctionSignature{
+		parameter_types:      parameter_types
+		parameter_mutability: parameter_mutability
+		return_type:          return_type
+		return_types:         return_types
+		option_type:          option_type
+		is_public:            true
+		module_name:          header.module_name
+		path:                 path
+	}
+}
+
 fn fastc_collect_referenced_function_names(sources []FastcSourceFile, prefs &pref.Preferences, functions map[string]FastcFunctionSignature) map[string]bool {
 	mut available_names := map[string]bool{}
 	for key in functions.keys() {
@@ -380,6 +484,19 @@ fn fastc_collect_referenced_function_names(sources []FastcSourceFile, prefs &pre
 	mut used := {
 		'main':                   true
 		'run':                    true
+		// `select` is a keyword, so a `sql db { select ... }` block does not surface a
+		// `.select(` reference the way `insert`/`update`/... do; seed it so a connection
+		// type's `select` method survives reachability pruning for the ORM lowering.
+		'select':                 true
+		// `arr.sort(a < b)` lowers to a `sort_with_compare` call emitted in generated C,
+		// so no source `.sort_with_compare(` reference surfaces; seed it (its body pulls in
+		// vqsort transitively) so it survives reachability pruning.
+		'sort_with_compare':      true
+		// Channel send/receive (`ch <- v` / `<-ch`) lower to `builtin__chan_try_push`/
+		// `builtin__chan_try_pop` in generated C, so no source `.try_push(`/`.try_pop(`
+		// reference surfaces; seed them so the chan stubs survive reachability pruning.
+		'try_push':               true
+		'try_pop':                true
 		'panic_result_not_set':   true
 		'array_push':             true
 		'push':                   true
@@ -416,6 +533,14 @@ fn fastc_collect_referenced_function_names(sources []FastcSourceFile, prefs &pre
 	}
 	for name in top_level_references.keys() {
 		used[name] = true
+	}
+	// Operator overload declarations are emitted even when their symbolic names do
+	// not appear as ordinary call tokens. Treat those symbols as roots too, so the
+	// private helper methods called by an overload body are retained.
+	for name in references.keys() {
+		if name.len > 0 && !name[0].is_letter() && name[0] != `_` {
+			used[name] = true
+		}
 	}
 	// Reachability by worklist BFS. The previous fixpoint re-scanned every
 	// discovered name on every pass and cloned each name's reference set per
@@ -466,7 +591,7 @@ fn fastc_collect_type_default_references(mut scan scanner.Scanner, first token.T
 	return tok
 }
 
-fn collect_interface_method_signatures(source string, path string, header FastcSourceHeader, prefs &pref.Preferences, declared_types map[string]bool, mut functions map[string]FastcFunctionSignature, mut interface_methods map[string]bool, mut interface_fields map[string]FastcInterfaceField) ! {
+fn collect_interface_method_signatures(source string, path string, header FastcSourceHeader, prefs &pref.Preferences, declared_types map[string]bool, mut functions map[string]FastcFunctionSignature, mut interface_methods map[string]bool, mut interface_fields map[string]FastcInterfaceField, mut embed_embedders []string, mut embed_embeddeds []string) ! {
 	mut file_set := token.FileSet.new()
 	mut file := file_set.add_file(path, source.len)
 	file.index_lines_without_digest(source)
@@ -482,7 +607,8 @@ fn collect_interface_method_signatures(source string, path string, header FastcS
 				selected := fastc_scan_selected_comptime_branch(mut scan, scan.scan(), path, prefs)!
 				if selected.source != '' {
 					collect_interface_method_signatures(selected.source, path, header, prefs,
-						declared_types, mut functions, mut interface_methods, mut interface_fields)!
+						declared_types, mut functions, mut interface_methods, mut interface_fields, mut
+						embed_embedders, mut embed_embeddeds)!
 				}
 				tok = selected.tok
 				continue
@@ -551,10 +677,13 @@ fn collect_interface_method_signatures(source string, path string, header FastcS
 				}
 				continue
 			}
-			if tok != .name {
+			if tok != .name && !tok.is_keyword() {
 				tok = scan.scan()
 				continue
 			}
+			// An interface member may be named with a word that is also a keyword
+			// (`select(...)`, `lock`, ...); the scanner still exposes the spelling via
+			// `scan.lit`, matching how method definitions accept keyword names.
 			mut member_names := [scan.lit]
 			tok = scan.scan()
 			for tok == .comma {
@@ -567,6 +696,17 @@ fn collect_interface_method_signatures(source string, path string, header FastcS
 			}
 			if tok != .lpar {
 				if tok in [.semicolon, .rcbr] {
+					// A member that is a bare type name with no `(` is an embedded
+					// interface (`interface B { A }`). Record it so A's methods can be
+					// promoted onto B once every interface has been collected.
+					if member_names.len == 1 {
+						if embedded_key := fastc_resolve_declared_type_key(header.module_name,
+							member_names[0], header.imports, declared_types)
+						{
+							embed_embedders << interface_key
+							embed_embeddeds << embedded_key
+						}
+					}
 					if tok == .semicolon {
 						tok = scan.scan()
 					}
@@ -604,10 +744,17 @@ fn collect_interface_method_signatures(source string, path string, header FastcS
 					parameter_is_mut = true
 					tok = scan.scan()
 				}
-				if tok != .name {
-					return error('fastc parser does not support interface method parameter in ${path}')
+				// Interface method parameters may be unnamed (just a type), e.g.
+				// `handle(Request) Response`. When a leading plain name is followed by
+				// another type token it is the parameter name; otherwise the name
+				// itself starts the (unnamed) type.
+				if tok == .name {
+					mut lookahead := scan
+					after := lookahead.scan()
+					if after !in [.comma, .rpar, .dot] {
+						tok = scan.scan()
+					}
 				}
-				tok = scan.scan()
 				parameter_type, next_token := fastc_scan_type(mut scan, tok, path,
 					header.module_name, header.imports, declared_types, prefs.building_v)!
 				parameter_types << if parameter_is_mut && !parameter_type.ends_with('*') {
@@ -684,6 +831,130 @@ fn fastc_scan_multi_return_types(mut scan scanner.Scanner, path string, module_n
 		}
 	}
 	return types, scan.scan()
+}
+
+// fastc_peek_chan_element scans the element type of a `chan Elem` type from a scanner
+// positioned just after the `chan` keyword, returning its C type ('' if erased/none).
+// Works on a copy, so the real scanner is not advanced.
+fn fastc_peek_chan_element(scan scanner.Scanner, path string, module_name string, imports map[string]string, declared_types map[string]bool, allow_short_placeholders bool) string {
+	mut probe := scan
+	elem_tok := probe.scan()
+	if elem_tok in [token.Token.comma, .rpar, .lcbr, .semicolon, .assign, .rcbr, .attribute, .eof] {
+		return ''
+	}
+	elem_c, _ := fastc_scan_type(mut probe, elem_tok, path, module_name, imports, declared_types,
+		allow_short_placeholders) or { return '' }
+	return elem_c
+}
+
+// fastc_peek_option_element recovers the wrapped C value type of an option field (`f ?T`),
+// scanning a copy positioned just after the leading `?`. Returns '' for a bare `?` (no
+// following type) or an unresolvable type.
+fn fastc_peek_option_element(scan scanner.Scanner, path string, module_name string, imports map[string]string, declared_types map[string]bool, allow_short_placeholders bool) string {
+	mut probe := scan
+	elem_tok := probe.scan()
+	if elem_tok in [token.Token.comma, .rpar, .lcbr, .semicolon, .assign, .rcbr, .attribute, .eof] {
+		return ''
+	}
+	elem_c, _ := fastc_scan_type(mut probe, elem_tok, path, module_name, imports, declared_types,
+		allow_short_placeholders) or { return '' }
+	return elem_c
+}
+
+// fastc_peek_generic_type_argument recovers the first concrete argument from a
+// generic field type such as `Stack[Item]`. The scanner copy starts immediately
+// after `first`, so this does not advance declaration scanning.
+fn fastc_peek_generic_type_argument(first token.Token, scan scanner.Scanner, path string, module_name string, imports map[string]string, declared_types map[string]bool, allow_short_placeholders bool) string {
+	if first != .name {
+		return ''
+	}
+	mut probe := scan
+	mut tok := probe.scan()
+	if tok == .dot {
+		if probe.scan() != .name {
+			return ''
+		}
+		tok = probe.scan()
+	}
+	if tok != .lsbr {
+		return ''
+	}
+	arg_tok := probe.scan()
+	if arg_tok == .rsbr {
+		return ''
+	}
+	argument_type, next_token := fastc_scan_type(mut probe, arg_tok, path, module_name, imports,
+		declared_types, allow_short_placeholders) or { return '' }
+	if next_token !in [.comma, .rsbr] {
+		return ''
+	}
+	return argument_type
+}
+
+struct FastcFunctionTypeInfo {
+	parameter_types   []string
+	return_type       string
+	option_value_type string
+}
+
+// fastc_peek_function_type preserves the signature that fastc_scan_type erases to
+// `voidptr`. The scanner copy is positioned immediately after the leading `fn`.
+fn fastc_peek_function_type(scan scanner.Scanner, path string, module_name string, imports map[string]string, declared_types map[string]bool, allow_short_placeholders bool) !FastcFunctionTypeInfo {
+	mut look := scan
+	mut tok := look.scan()
+	if tok != .lpar {
+		return error('fastc parser does not support function type in ${path}')
+	}
+	tok = look.scan()
+	mut parameter_types := []string{}
+	for tok != .rpar {
+		if tok in [.comma, .semicolon] {
+			tok = look.scan()
+			continue
+		}
+		mut parameter_is_mut := false
+		if tok == .key_mut {
+			parameter_is_mut = true
+			tok = look.scan()
+		}
+		mut has_parameter_name := false
+		if tok == .name {
+			mut probe := look
+			next_token := probe.scan()
+			has_parameter_name = next_token in [.name, .amp, .and, .mul, .question, .not, .key_fn,
+				.lsbr]
+		}
+		if has_parameter_name {
+			tok = look.scan()
+		}
+		parameter_type, next_token := fastc_scan_type(mut look, tok, path, module_name, imports,
+			declared_types, allow_short_placeholders)!
+		parameter_types << if parameter_is_mut && !parameter_type.ends_with('*') {
+			parameter_type + '*'
+		} else {
+			parameter_type
+		}
+		tok = next_token
+	}
+	tok = look.scan()
+	mut return_type := 'void'
+	mut option_value_type := ''
+	if tok in [.not, .question] {
+		return_type = 'Option'
+		value_tok := look.scan()
+		if value_tok !in [.semicolon, .comma, .rpar, .lcbr, .assign, .attribute, .rcbr, .eof] {
+			option_value_type, _ = fastc_scan_type(mut look, value_tok, path, module_name, imports,
+				declared_types, allow_short_placeholders)!
+		}
+	} else if tok !in [.semicolon, .comma, .rpar, .lcbr, .assign, .attribute, .rcbr, .eof] {
+		return_type, _ = fastc_scan_type(mut look, tok, path, module_name, imports, declared_types,
+			allow_short_placeholders)!
+	}
+	return FastcFunctionTypeInfo{
+		parameter_types:   parameter_types
+		return_type:       return_type
+		option_value_type: option_value_type
+	}
 }
 
 fn fastc_scan_type(mut scan scanner.Scanner, first token.Token, path string, module_name string, imports map[string]string, declared_types map[string]bool, allow_short_placeholders bool) !(string, token.Token) {
@@ -832,6 +1103,25 @@ fn fastc_scan_type(mut scan scanner.Scanner, first token.Token, path string, mod
 		channel_type := if optional { 'Option' } else { 'chan' + '*'.repeat(pointers) }
 		return channel_type, tok
 	}
+	if raw_type == 'thread' {
+		// `thread`, `thread T`, `thread !`, `thread ?`: a spawned-thread handle. Its
+		// C name must match what `spawn` derives from the callee's return type: void
+		// -> '' , a result/option -> 'Option', otherwise the concrete value type.
+		mut value_type := ''
+		if tok in [.not, .question] {
+			value_type = 'Option'
+			tok = scan.scan()
+		} else if tok !in [.comma, .rpar, .lcbr, .semicolon, .assign] {
+			value_type, tok = fastc_scan_type(mut scan, tok, path, module_name, imports,
+				declared_types, allow_short_placeholders)!
+		}
+		thread_type := if optional {
+			'Option'
+		} else {
+			fastc_thread_type_name(value_type) + '*'.repeat(pointers)
+		}
+		return thread_type, tok
+	}
 	if raw_type == 'map' && tok == .lsbr {
 		tok = scan.scan()
 		key_type, next_key_token := fastc_scan_type(mut scan, tok, path, module_name, imports,
@@ -881,6 +1171,16 @@ fn fastc_scan_type(mut scan scanner.Scanner, first token.Token, path string, mod
 	} else if raw_type in declared_types {
 		// Builtin declarations use their unqualified spelling as the canonical key.
 		base = fastc_c_declared_type_name(raw_type)
+	} else if raw_type.contains('__') && raw_type.replace('__', '.') in declared_types {
+		// Cross-module monomorphization substitutes an already-resolved C spelling
+		// (`config__Config`) into the defining module's generic source.
+		base = raw_type
+	} else if raw_type.starts_with('Array_') || raw_type.starts_with('Map_')
+		|| raw_type.starts_with('FixedArray_') {
+		// On-demand monomorphization likewise substitutes FastC's already-resolved
+		// composite spelling (`Array_string`, `Map_string_int`, ...). Keep it as the
+		// concrete C type when the generated instance is scanned again.
+		base = raw_type
 	} else {
 		base = fastc_primitive_c_type(raw_type) or { '' }
 	}
@@ -998,14 +1298,49 @@ fn fastc_map_key_value_types(typ string) ?(string, string) {
 		'byte', 'char', 'uint', 'isize', 'usize', 'voidptr', 'byteptr', 'charptr', 'bool'] {
 		prefix := '${fastc_composite_type_part(key_type)}_'
 		if payload.starts_with(prefix) {
-			mut value_type := payload[prefix.len..]
-			if value_type.ends_with('_ptr') {
-				value_type = value_type[..value_type.len - '_ptr'.len] + '*'
-			}
-			return key_type, value_type
+			return key_type, fastc_decode_map_value_type(payload[prefix.len..])
 		}
 	}
 	return none
+}
+
+fn fastc_decode_map_value_type(encoded string) string {
+	// A trailing `_ptr` on a composite value can belong to its nested element
+	// type (`map[string][]&T` -> `Map_string_Array_T_ptr`), not to the map
+	// value itself. Preserve composite names so their own decoder handles it.
+	if encoded.ends_with('_ptr') && !encoded.starts_with('Array_') && !encoded.starts_with('Map_')
+		&& !encoded.starts_with('FixedArray_') {
+		return encoded[..encoded.len - '_ptr'.len] + '*'
+	}
+	return encoded
+}
+
+fn (g &Parser) map_key_value_types(typ string) ?(string, string) {
+	if key_type, value_type := fastc_map_key_value_types(typ) {
+		return key_type, value_type
+	}
+	base := typ.trim_right('*')
+	if !base.starts_with('Map_') {
+		return none
+	}
+	payload := base['Map_'.len..]
+	mut matched_key := ''
+	mut matched_prefix := ''
+	for type_key, kind in g.declared_kinds {
+		if kind != .enum_ {
+			continue
+		}
+		c_type := g.declared_type_c_names[type_key] or { fastc_c_declared_type_name(type_key) }
+		prefix := '${fastc_composite_type_part(c_type)}_'
+		if payload.starts_with(prefix) && prefix.len > matched_prefix.len {
+			matched_key = c_type
+			matched_prefix = prefix
+		}
+	}
+	if matched_key == '' {
+		return none
+	}
+	return matched_key, fastc_decode_map_value_type(payload[matched_prefix.len..])
 }
 
 fn fastc_register_composite_type(typ string, mut composite_types map[string]bool) {
@@ -1015,8 +1350,74 @@ fn fastc_register_composite_type(typ string, mut composite_types map[string]bool
 	}
 }
 
-// fastc_collect_file_references scans one source file's function bodies and
-// top-level initializers for references to collected function names.
+fn fastc_collect_generated_template_references(source string, path string, prefs &pref.Preferences, available_names map[string]bool, mut references map[string]bool) {
+	mut file_set := token.FileSet.new()
+	mut file := file_set.add_file(path, source.len)
+	file.index_lines_without_digest(source)
+	mut scan := scanner.new_scanner(prefs, .normal)
+	scan.init(file, source)
+	mut tok := scan.scan()
+	for tok != .eof {
+		if (tok == .name || tok.is_keyword()) && scan.lit in available_names {
+			references[scan.lit] = true
+		}
+		tok = scan.scan()
+	}
+}
+
+fn fastc_referenced_veb_template_path(source_path string, function_name string, explicit_path string) ?string {
+	dir := os.dir(os.real_path(source_path))
+	mut candidates := if explicit_path == '' {
+		[
+			os.join_path(dir, 'templates', '${function_name}.html'),
+			os.join_path_single(dir, '${function_name}.html'),
+		]
+	} else {
+		[
+			os.join_path_single(dir, explicit_path),
+			explicit_path,
+		]
+	}
+	vmod_root := fastc_vmod_root_for_file(source_path)
+	if vmod_root != '' && vmod_root != dir {
+		candidates << if explicit_path == '' {
+			os.join_path(vmod_root, 'templates', '${function_name}.html')
+		} else {
+			os.join_path_single(vmod_root, explicit_path)
+		}
+	}
+	for candidate in candidates {
+		if os.exists(candidate) {
+			return candidate
+		}
+	}
+	return none
+}
+
+// fastc_collect_veb_template_references adds calls produced by a `$veb.html()`
+// expansion to the enclosing function's references. The ordinary source scan cannot
+// otherwise see methods used only inside the HTML template.
+fn fastc_collect_veb_template_references(source_file FastcSourceFile, function_name string, scan_after_dollar scanner.Scanner, prefs &pref.Preferences, available_names map[string]bool, mut references map[string]bool) {
+	mut lookahead := scan_after_dollar
+	if lookahead.scan() != .name || lookahead.lit != 'veb' || lookahead.scan() != .dot
+		|| lookahead.scan() != .name || lookahead.lit != 'html' || lookahead.scan() != .lpar {
+		return
+	}
+	mut explicit_path := ''
+	if lookahead.scan() == .string {
+		explicit_path = lookahead.lit.trim('\'"')
+	}
+	template_path := fastc_referenced_veb_template_path(source_file.path, function_name,
+		explicit_path) or { return }
+	generated := fastc_veb_compile_template(template_path, '__v_fastc_reachability_template', 'ctx') or {
+		return
+	}
+	fastc_collect_generated_template_references(generated, template_path, prefs, available_names, mut
+		references)
+}
+
+// fastc_collect_file_references scans one source file's function bodies,
+// generated veb templates, and top-level initializers for collected function names.
 fn fastc_collect_file_references(source_file FastcSourceFile, prefs &pref.Preferences, available_names map[string]bool, mut references map[string]map[string]bool, mut top_level_references map[string]bool) {
 	mut file_set := token.FileSet.new()
 	mut file := file_set.add_file(source_file.path, source_file.source.len)
@@ -1033,7 +1434,7 @@ fn fastc_collect_file_references(source_file FastcSourceFile, prefs &pref.Prefer
 			continue
 		}
 		if tok != .key_fn || previous == .assign {
-			if tok == .name && scan.lit in available_names {
+			if (tok == .name || tok.is_keyword()) && scan.lit in available_names {
 				top_level_references[scan.lit] = true
 			}
 			previous = tok
@@ -1077,7 +1478,10 @@ fn fastc_collect_file_references(source_file FastcSourceFile, prefs &pref.Prefer
 				depth++
 			} else if tok == .rcbr {
 				depth--
-			} else if tok == .name && scan.lit in available_names {
+			} else if tok == .dollar {
+				fastc_collect_veb_template_references(source_file, function_name, scan, prefs,
+					available_names, mut function_references)
+			} else if (tok == .name || tok.is_keyword()) && scan.lit in available_names {
 				function_references[scan.lit] = true
 			}
 			tok = scan.scan()

--- a/vlib/v3/gen/fastc/source.v
+++ b/vlib/v3/gen/fastc/source.v
@@ -40,10 +40,27 @@ fn fastc_resolve_c_pseudo_paths(raw string, vroot string, source_file string) st
 		dir := if source_file.len > 0 { os.dir(source_file) } else { os.getwd() }
 		result = result.replace('@DIR', os.real_path(dir))
 	}
+	// A quoted C include is relative to the V file that declared it. FastC hoists
+	// directives into one generated C file, so preserve that original include base
+	// by making the path absolute before hoisting.
+	if result.starts_with('include "') || result.starts_with('insert "') {
+		quote_start := result.index_u8(`"`)
+		quote_end := result.last_index_u8(`"`)
+		if quote_start >= 0 && quote_end > quote_start {
+			include_path := result[quote_start + 1..quote_end]
+			if !os.is_abs_path(include_path) {
+				dir := if source_file.len > 0 { os.dir(source_file) } else { os.getwd() }
+				resolved := os.join_path(os.real_path(dir), include_path)
+				if os.exists(resolved) {
+					result = result[..quote_start + 1] + resolved + result[quote_end..]
+				}
+			}
+		}
+	}
 	return result
 }
 
-fn fastc_resolve_source_files(paths []string, prefs &pref.Preferences) ![]FastcSourceFile {
+fn fastc_resolve_source_files(paths []string, prefs &pref.Preferences) !([]FastcSourceFile, map[string]string) {
 	mut queue := []FastcQueuedSource{}
 	if prefs.building_v {
 		builtin_dir := prefs.get_vlib_module_path('builtin')
@@ -61,9 +78,30 @@ fn fastc_resolve_source_files(paths []string, prefs &pref.Preferences) ![]FastcS
 		queue << FastcQueuedSource{
 			path: path
 		}
+		// A V module spans every source file in its directory, plus any `subdirs`
+		// its v.mod lists that belong to the same module (e.g. gitly's `ssh/`,
+		// `repo/`, ... all declare `module main`). The entry file names only one of
+		// them, so gather the rest of the entry module here. Only the real-builtin
+		// path does this: the bootstrap runtime compiles single entry files, and its
+		// tests place several independent programs in one scratch directory.
+		if prefs.building_v {
+			for module_file in fastc_entry_module_files(path, prefs) {
+				if fastc_source_file_matches_backend(module_file) {
+					queue << FastcQueuedSource{
+						path: module_file
+					}
+				}
+			}
+		}
 	}
 	mut seen := map[string]bool{}
 	mut sources := []FastcSourceFile{}
+	// path -> the module_name a file was first loaded under, and the resulting alias map:
+	// the SAME file reached via a second import name (a module re-exported at another path,
+	// e.g. `json2` also importable as `x.json2` via `@[alias]`) records that second name as
+	// an alias of the first, so `<second>.<sym>` references resolve to the loaded `<first>`.
+	mut path_module := map[string]string{}
+	mut module_aliases := map[string]string{}
 	// Modules are re-discovered once per importing file; canonicalization and
 	// directory enumeration are syscalls, so both are memoized for the walk.
 	mut real_path_cache := map[string]string{}
@@ -79,6 +117,10 @@ fn fastc_resolve_source_files(paths []string, prefs &pref.Preferences) ![]FastcS
 			real_path_cache[queued.path] = path
 		}
 		if seen[path] {
+			loaded := path_module[path] or { '' }
+			if queued.module_name != '' && loaded != '' && loaded != queued.module_name {
+				module_aliases[queued.module_name] = loaded
+			}
 			continue
 		}
 		if !os.is_file(path) {
@@ -105,6 +147,7 @@ fn fastc_resolve_source_files(paths []string, prefs &pref.Preferences) ![]FastcS
 			source: source
 			header: header
 		}
+		path_module[path] = header.module_name
 		mut discovered_imports := map[string]bool{}
 		for imported_module in fastc_header_imported_modules(header) {
 			if discovered_imports[imported_module] {
@@ -144,7 +187,52 @@ fn fastc_resolve_source_files(paths []string, prefs &pref.Preferences) ![]FastcS
 			}
 		}
 	}
-	return sources
+	return sources, module_aliases
+}
+
+// fastc_entry_module_files returns the other source files of the entry file's
+// module: its directory siblings, plus the files of any `subdirs` its v.mod
+// declares (which V compiles as part of the same module). The entry file itself
+// and duplicates are filtered by the caller's seen-set.
+fn fastc_entry_module_files(entry_path string, prefs &pref.Preferences) []string {
+	entry_dir := os.dir(os.real_path(entry_path))
+	if entry_dir == '' {
+		return []string{}
+	}
+	mut files := pref.get_v_files_from_dir_for_target(entry_dir, prefs.user_defines, prefs.target)
+	// Only the module root (where v.mod lives) pulls in the declared subdirs, so
+	// an entry file already inside a subdir does not re-expand the whole project.
+	vmod_root := fastc_vmod_root_for_file(entry_path)
+	if vmod_root != '' && os.real_path(vmod_root) == entry_dir {
+		for subdir in fastc_vmod_subdirs(vmod_root) {
+			subdir_path := os.join_path(vmod_root, subdir)
+			if os.is_dir(subdir_path) {
+				files << pref.get_v_files_from_dir_for_target(subdir_path, prefs.user_defines,
+					prefs.target)
+			}
+		}
+	}
+	return files
+}
+
+// fastc_vmod_subdirs extracts the `subdirs: ['a', 'b']` list from a v.mod file.
+fn fastc_vmod_subdirs(vmod_root string) []string {
+	content := os.read_file(os.join_path(vmod_root, 'v.mod')) or { return []string{} }
+	subdirs_index := content.index('subdirs') or { return []string{} }
+	rest := content[subdirs_index..]
+	open_bracket := rest.index('[') or { return []string{} }
+	close_bracket := rest.index(']') or { return []string{} }
+	if close_bracket <= open_bracket {
+		return []string{}
+	}
+	mut subdirs := []string{}
+	for part in rest[open_bracket + 1..close_bracket].split(',') {
+		name := part.trim_space().trim("'").trim('"')
+		if name != '' {
+			subdirs << name
+		}
+	}
+	return subdirs
 }
 
 fn fastc_header_imported_modules(header FastcSourceHeader) []string {
@@ -366,6 +454,17 @@ fn fastc_scan_source_header(source string, path string, prefs &pref.Preferences)
 	if module_name == '' {
 		module_name = 'main'
 	}
+	// V auto-injects `import orm` for files that use `sql <conn> { ... }` blocks.
+	// Mirror that so the ORM lowering resolves `orm.Table`/`orm.QueryData`/... and the
+	// `orm` module is pulled into the source set. Only the real-builtin path has the
+	// runtime the ORM needs; the toy runtime cannot compile `orm`.
+	if prefs.building_v && module_name != 'orm' && 'orm' !in imports
+		&& fastc_source_uses_sql(source, prefs) {
+		imports['orm'] = 'orm'
+		if 'orm' !in import_order {
+			import_order << 'orm'
+		}
+	}
 	if prefs.building_v && prefs.backend == 'fastc' && imports['driver'] == 'v3.driver'
 		&& 'fastcdriver' in imports {
 		fastcdriver_module := imports['fastcdriver']
@@ -383,6 +482,40 @@ fn fastc_scan_source_header(source string, path string, prefs &pref.Preferences)
 		blank_imports: blank_imports
 		has_globals:   has_globals
 	}
+}
+
+// fastc_source_uses_sql reports whether a file contains a `sql <conn> { ... }` ORM
+// block (statement or expression form). `sql` is not a keyword, so it is matched as a
+// name not preceded by `.` and followed by a connection expression and then `{`.
+fn fastc_source_uses_sql(source string, prefs &pref.Preferences) bool {
+	if !source.contains('sql') {
+		return false
+	}
+	mut file_set := token.FileSet.new()
+	mut file := file_set.add_file('orm_sql_probe', source.len)
+	file.index_lines_without_digest(source)
+	mut scan := scanner.new_scanner(prefs, .normal)
+	scan.init(file, source)
+	mut previous := token.Token.eof
+	mut tok := scan.scan()
+	for tok != .eof {
+		if tok == .name && scan.lit == 'sql' && previous != .dot {
+			mut look := scan
+			mut next := look.scan()
+			if next == .name {
+				// Scan the connection expression (`db`, `app.db`, ...) to its `{`.
+				for next !in [token.Token.eof, .lcbr, .semicolon, .rcbr] {
+					next = look.scan()
+				}
+				if next == .lcbr {
+					return true
+				}
+			}
+		}
+		previous = tok
+		tok = scan.scan()
+	}
+	return false
 }
 
 fn fastc_merge_source_header_imports(header FastcSourceHeader, path string, mut destination_imports map[string]string, mut destination_import_order []string, mut destination_blank_imports []string) ! {

--- a/vlib/v3/gen/fastc/spawn.v
+++ b/vlib/v3/gen/fastc/spawn.v
@@ -60,17 +60,63 @@ fn (mut g Parser) read_spawn_expression() !string {
 	mut callee := g.lit
 	g.next()
 	mut function_key := ''
+	// A method spawn (`spawn receiver.method(...)`) packs the receiver as the first
+	// argument and calls the method's C name; `receiver_arg`/`method_target` stay empty
+	// for a free/module function.
+	mut receiver_arg := ''
+	mut method_target := ''
 	if g.tok == .dot {
-		imported_module := g.imports[callee] or {
+		if imported_module := g.imports[callee] {
+			g.next()
+			if g.tok != .name {
+				return g.unsupported('spawn qualified callee')
+			}
+			callee = g.lit
+			function_key = fastc_function_key(imported_module, callee)
+			g.next()
+		} else if callee in g.locals {
+			// `spawn <local>.method(...)`: the local is the method receiver.
+			receiver_tokens := [
+				FastcExpressionToken{
+					tok: .name
+					lit: callee
+				},
+			]
+			receiver_type := g.infer_expression_type(receiver_tokens) or {
+				return g.unsupported('spawn on receiver `${callee}` of unknown type')
+			}
+			receiver := g.render_method_receiver_expression(receiver_tokens) or {
+				return g.unsupported('spawn on receiver `${callee}`')
+			}
+			g.next() // consume `.`
+			if g.tok != .name {
+				return g.unsupported('spawn method name')
+			}
+			method_name := g.lit
+			g.next()
+			method_key, _ := g.resolve_method(receiver_type, method_name)
+			method_signature := g.functions[method_key] or {
+				return g.unsupported('spawn of undeclared method `${callee}.${method_name}`')
+			}
+			if method_signature.parameter_types.len == 0 {
+				return g.unsupported('spawn of method `${method_name}` without a receiver parameter')
+			}
+			expected_receiver := method_signature.parameter_types[0]
+			receiver_is_pointer := receiver_type.ends_with('*')
+			receiver_arg = if expected_receiver.ends_with('*') && !receiver_is_pointer {
+				'&(${receiver.source})'
+			} else if !expected_receiver.ends_with('*') && receiver_is_pointer {
+				'*(${receiver.source})'
+			} else {
+				receiver.source
+			}
+			method_target = fastc_method_c_name(method_signature.module_name, expected_receiver,
+				method_name)
+			function_key = method_key
+			callee = method_name
+		} else {
 			return g.unsupported('spawn on unimported qualifier `${callee}`')
 		}
-		g.next()
-		if g.tok != .name {
-			return g.unsupported('spawn qualified callee')
-		}
-		callee = g.lit
-		function_key = fastc_function_key(imported_module, callee)
-		g.next()
 	} else {
 		function_key = g.unqualified_function_key(callee)
 	}
@@ -92,9 +138,6 @@ fn (mut g Parser) read_spawn_expression() !string {
 	if signature.is_variadic {
 		return g.unsupported('spawn of variadic function `${callee}`')
 	}
-	if signature.option_type != '' {
-		return g.unsupported('spawn of option or result function `${callee}`')
-	}
 	if signature.return_types.len > 1 {
 		return g.unsupported('spawn of multi-return function `${callee}`')
 	}
@@ -102,7 +145,13 @@ fn (mut g Parser) read_spawn_expression() !string {
 		return g.unsupported('spawn call arguments')
 	}
 	g.next()
-	mut arguments := []string{}
+	// A method spawn packs the receiver as the first positional argument, aligning with
+	// the method signature's `parameter_types[0]`.
+	mut arguments := if receiver_arg != '' {
+		[receiver_arg]
+	} else {
+		[]string{}
+	}
 	mut named_params := [][]FastcExpressionToken{}
 	mut named_param_names := map[string]bool{}
 	for g.tok != .rpar {
@@ -160,8 +209,11 @@ fn (mut g Parser) read_spawn_expression() !string {
 		if named_params.len > 0 {
 			return g.unsupported('positional spawn argument after named params fields')
 		}
+		mut is_mut_argument := false
 		if g.tok == .key_mut {
-			return g.unsupported('spawn with a `mut` argument')
+			// `spawn f(mut x)`: the `mut` parameter is a pointer, so pass x's address.
+			is_mut_argument = true
+			g.next()
 		}
 		expected_type := if arguments.len < signature.parameter_types.len {
 			signature.parameter_types[arguments.len]
@@ -175,7 +227,21 @@ fn (mut g Parser) read_spawn_expression() !string {
 		// Mirror ordinary calls: arguments that need contextual typing (enum
 		// shorthand, boxing) render through the parameter-typed pipeline.
 		argument_tokens := g.last_expression.clone()
-		if expected_type != '' && argument_tokens.len > 0 {
+		if is_mut_argument {
+			mut argument_type := ''
+			if inferred := g.infer_expression_type(argument_tokens) {
+				argument_type = inferred
+			}
+			if expected_type.ends_with('*') && argument_type.ends_with('*') {
+				// `mut c` where `c` is already a reference local must stay a pointer;
+				// read_expression's value form auto-dereferences it.
+				if contextual := g.render_call_argument_expression(argument_tokens, expected_type) {
+					argument = contextual
+				}
+			} else if expected_type.ends_with('*') && !argument_type.ends_with('*') {
+				argument = '&(${argument})'
+			}
+		} else if expected_type != '' && argument_tokens.len > 0 {
 			if contextual := g.render_call_argument_expression(argument_tokens, expected_type) {
 				argument = contextual
 			}
@@ -208,7 +274,7 @@ fn (mut g Parser) read_spawn_expression() !string {
 	thread_type := g.fastc_unclaimed_generated_name(fastc_thread_type_name(value_type))
 	start_name := g.fastc_unclaimed_generated_name(fastc_spawn_start_name(function_key))
 	g.register_spawn_helpers(function_key, thread_type, value_type, signature.parameter_types,
-		start_name)
+		start_name, method_target)
 	g.last_expression = []FastcExpressionToken{}
 	g.last_expression_type = thread_type
 	g.last_multi_return_types = []string{}
@@ -257,7 +323,7 @@ fn (g &Parser) generated_name_is_claimed(candidate string) bool {
 // struct, run wrapper, and creator for one spawn target. The result is the
 // first packed field, so the per-type waiter reads it without knowing which
 // call site produced the thread.
-fn (mut g Parser) register_spawn_helpers(function_key string, thread_type string, value_type string, parameter_types []string, start_name string) {
+fn (mut g Parser) register_spawn_helpers(function_key string, thread_type string, value_type string, parameter_types []string, start_name string, target_c_name string) {
 	g.thread_value_types[thread_type] = value_type
 	if thread_type !in g.spawn_typedefs {
 		g.spawn_typedefs[thread_type] = 'typedef struct { pthread_t handle; void *packed; } ${thread_type};'
@@ -293,7 +359,13 @@ fn (mut g Parser) register_spawn_helpers(function_key string, thread_type string
 	if start_name in g.spawn_helpers {
 		return
 	}
-	target := fastc_c_function_name_for_key(function_key)
+	// A method target supplies its own C name (`Type_method`); a free/module function
+	// derives it from the function key.
+	target := if target_c_name != '' {
+		target_c_name
+	} else {
+		fastc_c_function_name_for_key(function_key)
+	}
 	target_stem := fastc_spawn_target_stem(function_key)
 	args_struct := g.fastc_unclaimed_generated_name('__v_fastc_spawn_args_${target_stem}')
 	run_name := g.fastc_unclaimed_generated_name('__v_fastc_spawn_run_${target_stem}')

--- a/vlib/v3/gen/fastc/stmt.v
+++ b/vlib/v3/gen/fastc/stmt.v
@@ -1,6 +1,7 @@
 module fastc
 
 import v3.scanner
+import v3.pref
 import v3.token
 
 fn (mut g Parser) parse_block_body() !bool {
@@ -60,7 +61,13 @@ fn (mut g Parser) parse_statement() !bool {
 	}
 	return match g.tok {
 		.dollar {
-			g.parse_comptime_if_statement()!
+			if g.dollar_keyword_is('for') {
+				g.parse_comptime_for_statement()!
+			} else if g.dollar_keyword_is('match') {
+				g.parse_comptime_match_statement()!
+			} else {
+				g.parse_comptime_if_statement()!
+			}
 		}
 		.key_if {
 			g.parse_if()!
@@ -119,6 +126,21 @@ fn (mut g Parser) parse_statement() !bool {
 			g.parse_mutable_declaration()!
 			false
 		}
+		.key_static {
+			g.next()
+			if g.tok != .name {
+				return g.unsupported('static local declaration')
+			}
+			name := g.lit
+			g.next()
+			if g.tok != .decl_assign {
+				return g.unsupported('static local without `:=`')
+			}
+			// FastC only needs compile-time static locals for generic helper caches.
+			// Lowering them as mutable function locals preserves compile/link behavior.
+			g.parse_declaration_after_name(name, true)!
+			false
+		}
 		.key_unsafe {
 			g.next()
 			g.expect(.lcbr)!
@@ -150,7 +172,16 @@ fn (g &Parser) open_block_contains_select_statement() bool {
 	mut tok := lookahead.scan()
 	for depth > 0 && tok != .eof {
 		if tok == .key_select && previous != .dot {
-			return true
+			// A channel `select { ... }` statement is `select` immediately followed by
+			// `{`. `select` used as an ORM `sql` clause keyword (`sql db { select from
+			// ... }`) or as a method/field name is not one, so keep scanning past it.
+			following := lookahead.scan()
+			if following == .lcbr {
+				return true
+			}
+			previous = tok
+			tok = following
+			continue
 		}
 		if tok == .lcbr {
 			depth++
@@ -159,6 +190,115 @@ fn (g &Parser) open_block_contains_select_statement() bool {
 		}
 		previous = tok
 		tok = lookahead.scan()
+	}
+	return false
+}
+
+// method_uses_undefined_receiver reports whether the upcoming `{ ... }` body (g.tok at
+// the opening `{`; the receiver and parameters are already in g.locals) calls a method on
+// an identifier that is provably undefined — not a receiver/parameter/body-local and not a
+// known module, const, global, type or enum. Such a function is broken dead code kept only
+// by FastC's conservative name-grouped reachability (a same-named method on another type is
+// genuinely used, so the shared name survives pruning); skipping it mirrors the mainline
+// compiler's `-skip-unused`. It cannot fire on well-formed code, where every method-call
+// receiver is defined.
+fn (g &Parser) method_uses_undefined_receiver() bool {
+	if g.tok != .lcbr {
+		return false
+	}
+	mut lookahead := scanner.new_scanner(g.prefs, .normal)
+	lookahead.init(g.s.current_file(), g.s.src)
+	lookahead.offset = g.s.offset
+	// Seed identifiers that are valid receivers but are not locals: `C` (the C-interop
+	// namespace, `C.func()`), and V's implicitly-bound closure/or-block names `it` and
+	// `err`. Without these the scan would mistake them for undefined receivers.
+	mut bound := {
+		'C':   true
+		'it':  true
+		'err': true
+	}
+	mut receivers := []string{}
+	// A comma-separated run of names is only a binding LHS when it ends in `:=` (a
+	// declaration like `a, b := f()`), NOT when it is a call's arguments (`f(a, b)`); hold
+	// such names pending until a terminating `:=`/`=` proves they are declared.
+	mut pending_comma := []string{}
+	mut depth := 1
+	mut previous := token.Token.lcbr
+	mut tok := lookahead.scan()
+	mut lit := lookahead.lit
+	for depth > 0 && tok != .eof {
+		if tok == .key_fn {
+			// A closure (`fn [caps] (params) { ... }`) introduces its own parameters, which
+			// this flat pre-scan cannot track; be conservative and never skip a method whose
+			// body contains one.
+			return false
+		}
+		if tok == .lcbr {
+			depth++
+		} else if tok == .rcbr {
+			depth--
+		}
+		if tok == .name {
+			mut ahead := lookahead
+			next := ahead.scan()
+			// A binding position: `x :=` / `x =`, a `for ... in` loop variable, a name
+			// introduced by `mut`/`for`, or a comma-list LHS that (together with the pending
+			// run) terminates in `:=` / `=` / `in` (e.g. `for i, ch in s`).
+			if next in [.decl_assign, .assign, .key_in] {
+				bound[lit] = true
+				for p in pending_comma {
+					bound[p] = true
+				}
+				pending_comma = []string{}
+			} else if next == .comma {
+				pending_comma << lit
+			} else if previous in [.key_mut, .key_for] {
+				bound[lit] = true
+				pending_comma = []string{}
+			} else {
+				// The name does not continue a binding LHS, so the pending comma-run was a
+				// value list (e.g. call arguments), not a declaration.
+				pending_comma = []string{}
+			}
+			// A receiver `R` of a method call `R.m(...)` or an indexed member `R.f[...]`
+			// (`ctx.query['k']`) must be a defined value. Restricting to a trailing `(` / `[`
+			// (not a bare `R.f` / `R.f < x`) avoids flagging `.sort(a.x < b.x)` comparison
+			// closures. Only the base of an `a.b.c` chain is flagged (inner members have
+			// `previous == .dot`).
+			if previous != .dot && next == .dot {
+				mut ahead2 := ahead
+				if ahead2.scan() == .name {
+					after := ahead2.scan()
+					if after == .lpar || after == .lsbr {
+						receivers << lit
+					}
+				}
+			}
+		}
+		previous = tok
+		tok = lookahead.scan()
+		lit = lookahead.lit
+	}
+	for r in receivers {
+		if r in bound || r in g.locals || r in g.imports {
+			continue
+		}
+		// Module-scope consts / globals are valid receivers (`long_months.index(...)`), but
+		// their maps are module-qualified, so resolve `r` through the current module.
+		ckey := fastc_constant_key(g.module_name, r)
+		if ckey in g.constant_values || ckey in g.constant_types || ckey in g.public_constants {
+			continue
+		}
+		if fastc_global_key(g.module_name, r) in g.globals {
+			continue
+		}
+		if g.is_enum_type_name(r) {
+			continue
+		}
+		if _ := fastc_resolve_declared_type_key(g.module_name, r, g.imports, g.declared_types) {
+			continue
+		}
+		return true
 	}
 	return false
 }
@@ -238,10 +378,40 @@ fn (mut g Parser) parse_match_statement() !bool {
 	if subject == '' || subject_type == '' {
 		return g.unsupported('unverifiable match subject')
 	}
+	subject_tokens := g.last_expression.clone()
 	g.expect(.lcbr)!
 	subject_name := g.temporary_name('match')
 	g.write_line('__typeof__((${subject})) ${subject_name} = (${subject});')
 	is_string := g.underlying_alias_type(subject_type).trim_right('*') == 'string'
+	// A sum type or interface subject dispatches on the boxed `_typ` tag; each
+	// branch names a variant/implementer type. When the subject is a plain local,
+	// the branch body sees it smart-cast to the matched concrete type.
+	is_boxed := g.is_boxed_type(subject_type)
+	boxed_access := if subject_type.ends_with('*') { '->' } else { '.' }
+	mut subject_local := ''
+	if is_boxed && subject_tokens.len == 1 && subject_tokens[0].tok == .name
+		&& subject_tokens[0].lit in g.locals {
+		subject_local = subject_tokens[0].lit
+	} else if is_boxed && subject_tokens.len == 2 && subject_tokens[0].tok in [.key_mut, .amp]
+		&& subject_tokens[1].tok == .name && subject_tokens[1].lit in g.locals {
+		subject_local = subject_tokens[1].lit
+	}
+	mut subject_member_path := ''
+	if is_boxed && subject_tokens.len >= 3 && subject_tokens.len % 2 == 1
+		&& subject_tokens[0].tok == .name && subject_tokens[0].lit in g.locals {
+		mut is_member_chain := true
+		mut path := subject_tokens[0].lit
+		for i := 1; i + 1 < subject_tokens.len; i += 2 {
+			if subject_tokens[i].tok != .dot || subject_tokens[i + 1].tok != .name {
+				is_member_chain = false
+				break
+			}
+			path += '.' + subject_tokens[i + 1].lit
+		}
+		if is_member_chain {
+			subject_member_path = path
+		}
+	}
 	mut branch_index := 0
 	mut all_terminate := true
 	mut has_else := false
@@ -254,32 +424,68 @@ fn (mut g Parser) parse_match_statement() !bool {
 		is_else := g.tok == .key_else
 		has_else = has_else || is_else
 		mut values := []string{}
+		mut values_are_conditions := []bool{}
+		mut variant_types := []string{}
 		if is_else {
 			g.next()
+		} else if is_boxed {
+			for {
+				variant_key := g.read_match_type_key() or {
+					return g.unsupported('match type value')
+				}
+				variant_cname := fastc_c_declared_type_name(variant_key)
+				if variant_cname in handled_cases {
+					return g.unsupported('duplicate match case `${variant_cname}`')
+				}
+				handled_cases[variant_cname] = true
+				variant_types << variant_cname
+				values << '${subject_name}${boxed_access}_typ == __v_typeid_${variant_cname}'
+				if g.tok != .comma {
+					break
+				}
+				g.next()
+			}
 		} else {
 			for {
 				mut value := ''
 				mut value_tokens := []FastcExpressionToken{}
+				mut case_key := ''
+				mut value_is_condition := false
 				if g.tok == .dot {
 					g.next()
-					if g.tok != .name {
+					if g.tok != .name && !g.tok.is_keyword() {
 						return g.unsupported('match enum value')
 					}
 					value = '${subject_type.trim_right('*')}__${g.lit}'
 					g.next()
 				} else {
-					value = g.read_expression([token.Token.comma, token.Token.lcbr])!
+					value = g.read_expression([token.Token.comma, token.Token.lcbr, token.Token.dotdot,
+						token.Token.ellipsis])!
 					if value == '' {
 						return g.unsupported('empty match branch value')
 					}
 					value_tokens = g.last_expression.clone()
+					if g.tok in [.dotdot, .ellipsis] {
+						start := value
+						start_key := g.normalized_match_case_key(value_tokens, start)
+						g.next()
+						finish := g.read_expression([token.Token.comma, token.Token.lcbr])!
+						finish_tokens := g.last_expression.clone()
+						case_key = 'range:${start_key}..${g.normalized_match_case_key(finish_tokens,
+							finish)}'
+						value = '((${subject_name}) >= (${start}) && (${subject_name}) <= (${finish}))'
+						value_is_condition = true
+					}
 				}
-				case_key := g.normalized_match_case_key(value_tokens, value)
+				if case_key == '' {
+					case_key = g.normalized_match_case_key(value_tokens, value)
+				}
 				if case_key in handled_cases {
 					return g.unsupported('duplicate match case `${value}`')
 				}
 				handled_cases[case_key] = true
 				values << value
+				values_are_conditions << value_is_condition
 				if g.tok != .comma {
 					break
 				}
@@ -291,8 +497,11 @@ fn (mut g Parser) parse_match_statement() !bool {
 			g.write_line('else {')
 		} else {
 			mut conditions := []string{}
-			for value in values {
-				if is_string {
+			for value_index, value in values {
+				if is_boxed || (value_index < values_are_conditions.len
+					&& values_are_conditions[value_index]) {
+					conditions << '(${value})'
+				} else if is_string {
 					conditions << 'builtin__string_eq(${subject_name}, ${value})'
 				} else {
 					conditions << '((${subject_name}) == (${value}))'
@@ -302,7 +511,57 @@ fn (mut g Parser) parse_match_statement() !bool {
 			g.write_line('${prefix} (${conditions.join(' || ')}) {')
 		}
 		g.indent++
+		mut smartcast_saved := FastcLocal{}
+		mut member_smartcast_saved := FastcMemberSmartcast{}
+		mut had_member_smartcast := false
+		mut member_smartcast_active := false
+		common_numeric_type := fastc_match_common_numeric_variant(variant_types)
+		smartcast_active := is_boxed && !is_else
+			&& (variant_types.len == 1 || common_numeric_type != '') && subject_local != ''
+		if smartcast_active {
+			variant_cname := if common_numeric_type != '' {
+				common_numeric_type
+			} else {
+				variant_types[0]
+			}
+			smartcast_value := if common_numeric_type != '' {
+				fastc_match_multi_variant_value(subject_name, boxed_access, variant_types,
+					common_numeric_type)
+			} else {
+				'*(${variant_cname} *)${subject_name}${boxed_access}_object'
+			}
+			g.write_line('${variant_cname} ${fastc_c_identifier(subject_local)} = ${smartcast_value};')
+			smartcast_saved = g.locals[subject_local] or { FastcLocal{} }
+			g.locals[subject_local] = FastcLocal{
+				is_mut: smartcast_saved.is_mut
+				typ:    variant_cname
+			}
+		}
+		if is_boxed && !is_else && variant_types.len == 1 && subject_member_path != '' {
+			variant_cname := variant_types[0]
+			member_smartcast_name := g.temporary_name('smartcast_member')
+			g.write_line('${variant_cname} *${member_smartcast_name} = (${variant_cname} *)${subject_name}${boxed_access}_object;')
+			member_smartcast_saved = g.member_smartcasts[subject_member_path] or {
+				FastcMemberSmartcast{}
+			}
+			had_member_smartcast = subject_member_path in g.member_smartcasts
+			g.member_smartcasts[subject_member_path] = FastcMemberSmartcast{
+				typ:    variant_cname + '*'
+				source: member_smartcast_name
+			}
+			member_smartcast_active = true
+		}
 		terminates := g.parse_block_body()!
+		if smartcast_active {
+			g.locals[subject_local] = smartcast_saved
+		}
+		if member_smartcast_active {
+			if had_member_smartcast {
+				g.member_smartcasts[subject_member_path] = member_smartcast_saved
+			} else {
+				g.member_smartcasts.delete(subject_member_path)
+			}
+		}
 		if !terminates {
 			all_terminate = false
 		}
@@ -315,8 +574,78 @@ fn (mut g Parser) parse_match_statement() !bool {
 	return has_else && all_terminate
 }
 
+// read_match_type_key reads a type-name match branch value (`Dog`, `mod.Type`,
+// `int`, or `[]T`) and resolves it to the type-id suffix / smart-cast C spelling
+// used for sum-type / interface dispatch.
+fn (mut g Parser) read_match_type_key() ?string {
+	if g.tok == .lsbr {
+		// `[]T` dynamic-array variant. Its boxed id and smart-cast type are the
+		// composite spelling `Array_<elem>`; register it so the type gets a typedef
+		// and a `__v_typeid_`.
+		g.next()
+		if g.tok != .rsbr {
+			return none
+		}
+		g.next()
+		element_key := g.read_match_type_key() or { return none }
+		array_c := fastc_array_c_type(fastc_c_declared_type_name(element_key))
+		fastc_register_composite_type(array_c, mut g.composite_types)
+		return array_c
+	}
+	if g.tok != .name {
+		return none
+	}
+	first := g.lit
+	g.next()
+	if first == 'map' && g.tok == .lsbr {
+		// `map[K]V` variant → composite `Map_<K>_<V>`, registered like `[]T`.
+		g.next()
+		key_key := g.read_match_type_key() or { return none }
+		if g.tok != .rsbr {
+			return none
+		}
+		g.next()
+		value_key := g.read_match_type_key() or { return none }
+		map_c := fastc_map_c_type(fastc_c_declared_type_name(key_key),
+			fastc_c_declared_type_name(value_key))
+		fastc_register_composite_type(map_c, mut g.composite_types)
+		return map_c
+	}
+	if g.tok == .dot {
+		g.next()
+		if g.tok != .name {
+			return none
+		}
+		type_name := g.lit
+		g.next()
+		module_name := g.imports[first] or { first }
+		return fastc_type_key(module_name, type_name)
+	}
+	if key := fastc_resolve_declared_type_key(g.module_name, first, g.imports, g.declared_types) {
+		return key
+	}
+	// A primitive variant (`int`, `bool`, ...) is not a declared type; its own
+	// spelling is the type-id suffix and the smart-cast C type.
+	if fastc_primitive_c_type(first) != none {
+		return first
+	}
+	return none
+}
+
 fn (mut g Parser) parse_return() !bool {
 	g.next()
+	if g.tok == .name && g.lit == 'sql' && 'sql' !in g.locals {
+		mut lookahead := g.s
+		if lookahead.scan() == .name {
+			return g.parse_orm_sql_select_return()
+		}
+	}
+	if g.tok == .dollar {
+		mut lookahead := g.s
+		if lookahead.scan() == .name && lookahead.lit == 'veb' {
+			return g.parse_veb_html_return()
+		}
+	}
 	if g.tok == .semicolon || g.tok == .rcbr {
 		g.consume_statement_end()
 		g.write_all_deferred_scopes()
@@ -372,7 +701,7 @@ fn (mut g Parser) parse_return() !bool {
 		} else {
 			mut packed_values := []string{cap: values.len}
 			for value in evaluated_values {
-				packed_values << 'V_FASTC_MULTI_VALUE(${value})'
+				packed_values << 'V_FASTC_MULTI_VALUE((${value}))'
 			}
 			'(MultiReturn){.values={${packed_values.join(', ')}}}'
 		}
@@ -385,7 +714,12 @@ fn (mut g Parser) parse_return() !bool {
 	}
 	previous_expected_type := g.expected_expression_type
 	if g.selfhost {
-		g.expected_expression_type = g.return_type
+		g.expected_expression_type = if g.return_type == 'Option'
+			&& g.option_return_type !in ['', 'MultiReturn'] {
+			g.option_return_type
+		} else {
+			g.return_type
+		}
 	}
 	mut expression := g.read_expression([token.Token.semicolon, token.Token.rcbr])!
 	g.expected_expression_type = previous_expected_type
@@ -395,11 +729,16 @@ fn (mut g Parser) parse_return() !bool {
 		g.write_return_expression(expression)
 		return true
 	}
+	contextual_return_type := if g.return_type == 'Option' && g.option_return_type != '' {
+		g.option_return_type
+	} else {
+		g.return_type
+	}
 	if g.selfhost && actual_type == '' && g.last_expression.len == 2
 		&& g.last_expression[0].tok == .dot && g.last_expression[1].tok == .name
-		&& g.declared_kinds[g.semantic_type_key(g.return_type)] == .enum_ {
-		expression = '${g.return_type.trim_right('*')}__${g.last_expression[1].lit}'
-		actual_type = g.return_type
+		&& g.declared_kinds[g.semantic_type_key(contextual_return_type)] == .enum_ {
+		expression = '${contextual_return_type.trim_right('*')}__${g.last_expression[1].lit}'
+		actual_type = contextual_return_type
 	}
 	if g.selfhost && g.return_type !in ['Option', 'MultiReturn']
 		&& g.declared_kinds[g.semantic_type_key(g.return_type)] != .interface_
@@ -437,9 +776,13 @@ fn (mut g Parser) write_return_expression(expression string) {
 }
 
 fn (g &Parser) interface_value_expression(interface_type string, actual_type string, expression string) string {
-	actual_base := actual_type.trim_right('*')
-	actual_key := g.semantic_type_key(actual_type)
-	object := if fastc_is_pointer_type(actual_type) {
+	// Normalize so a boxed primitive literal (`Any(42)`) gets a concrete C type and
+	// a matching `__v_typeid_int` rather than the pseudo type `integer literal`.
+	// This is a no-op for declared types.
+	normalized := g.underlying_alias_type(fastc_normalize_inferred_type(actual_type))
+	actual_base := normalized.trim_right('*')
+	actual_key := g.semantic_type_key(normalized)
+	object := if fastc_is_pointer_type(normalized) {
 		'(void*)(${expression})'
 	} else {
 		fastc_box_expression(actual_base, expression)
@@ -466,7 +809,7 @@ fn (mut g Parser) parse_mutable_declaration() ! {
 
 fn (mut g Parser) parse_simple_statement() ! {
 	if g.tok == .key_assert {
-		return g.unsupported('assert statements')
+		return g.parse_assert_statement()
 	}
 	if g.tok == .name {
 		name := g.lit
@@ -486,6 +829,28 @@ fn (mut g Parser) parse_simple_statement() ! {
 			fastc_c_identifier(name)
 		}
 		g.next()
+		if name == 'panic' && g.tok == .lpar {
+			g.next()
+			previous_expected_type := g.expected_expression_type
+			g.expected_expression_type = 'string'
+			argument := g.read_expression([token.Token.rpar])!
+			g.expected_expression_type = previous_expected_type
+			if argument == '' {
+				return g.unsupported('empty panic argument')
+			}
+			panic_argument := g.render_call_argument_expression(g.last_expression, 'string') or {
+				argument
+			}
+			g.expect(.rpar)!
+			g.consume_statement_end()
+			g.write_line('builtin__panic(${panic_argument});')
+			return
+		}
+		if name == 'sql' && !is_known_local && !is_global && g.tok == .name {
+			// `sql db { ... }` ORM statement: lower it to metadata construction plus
+			// the connection method call.
+			return g.parse_orm_sql_statement()
+		}
 		if g.selfhost && g.tok == .colon {
 			g.next()
 			g.skip_semicolons()
@@ -550,6 +915,15 @@ fn (mut g Parser) parse_simple_statement() ! {
 				''
 			}
 			g.next()
+			if operator == .assign && g.tok == .name && g.lit == 'sql' && 'sql' !in g.locals {
+				mut sql_lookahead := g.s
+				if sql_lookahead.scan() == .name {
+					// `x = sql db { select ... }` (assignment, not `:=`): lower like the
+					// declaration form but assign into the existing target.
+					g.parse_orm_sql_select_assignment(name)!
+					return
+				}
+			}
 			previous_expected_type := g.expected_expression_type
 			if g.selfhost && expected_type != '' {
 				g.expected_expression_type = expected_type
@@ -584,6 +958,12 @@ fn (mut g Parser) parse_simple_statement() ! {
 			}
 			expected_layout_type := g.underlying_alias_type(resolved_expected_type)
 			actual_layout_type := g.underlying_alias_type(actual_type)
+			if g.in_generic_placeholder && expected_layout_type == 'voidptr' && operator != .assign {
+				// Arithmetic on an erased type parameter is not valid C (`void * +=
+				// void *`). The concrete on-demand instance is emitted separately;
+				// make the placeholder parser fall back to its inert stub.
+				return g.unsupported('compound assignment on an erased generic type')
+			}
 			if operator == .plus_assign && expected_layout_type == 'string'
 				&& actual_layout_type == 'string' {
 				g.consume_statement_end()
@@ -595,6 +975,13 @@ fn (mut g Parser) parse_simple_statement() ! {
 				g.write_line('${c_target}=${concatenation};')
 				return
 			}
+			if overloaded := g.render_overloaded_assignment(c_target, value,
+				resolved_expected_type, operator)
+			{
+				g.consume_statement_end()
+				g.write_line('${overloaded};')
+				return
+			}
 			g.consume_statement_end()
 			if operator == .right_shift_unsigned_assign {
 				shift := g.render_unsigned_right_shift_assignment(c_target, value,
@@ -604,17 +991,72 @@ fn (mut g Parser) parse_simple_statement() ! {
 				g.write_line('${shift};')
 				return
 			}
-			g.write_line('${c_target}${operator.str()}${value};')
+			mut assigned_value := value
+			if g.selfhost && operator == .assign && resolved_expected_type == 'Option'
+				&& actual_type != 'Option' {
+				if actual_type.trim_right('*') == 'IError' {
+					assigned_value = '(Option){.err=${value}, .state=1}'
+				} else {
+					payload_type := if statement_local.option_value_type != '' {
+						statement_local.option_value_type
+					} else {
+						fastc_normalize_inferred_type(actual_type)
+					}
+					payload_value := g.render_call_argument_expression(g.last_expression,
+						payload_type) or { value }
+					assigned_value = fastc_option_success_expression(payload_type, payload_value)
+				}
+			} else if g.selfhost && operator == .assign
+				&& g.should_box_variant(resolved_expected_type, actual_type) {
+				// A concrete struct assigned to an interface variable is boxed with its
+				// type id so the dispatch functions can recover the receiver.
+				assigned_value = g.interface_value_expression(resolved_expected_type, actual_type,
+					value)
+			} else if g.selfhost && operator == .assign && resolved_expected_type == 'voidptr'
+				&& actual_type !in ['', 'voidptr', 'nil']
+				&& !fastc_expression_is_zero(g.last_expression)
+				&& !fastc_is_pointer_type(actual_type) {
+				// An unmonomorphized imported generic stores `T` as `voidptr`. Preserve a
+				// concrete value assigned through that slot by copying it into boxed storage.
+				box_value := g.temporary_name('generic_box')
+				assigned_value = '({ ${actual_type} ${box_value} = (${value}); v_fastc_interface_box(&${box_value}, sizeof(${actual_type})); })'
+			} else if g.selfhost && operator == .assign && actual_type == 'voidptr'
+				&& (resolved_expected_type.trim_right('*') in g.struct_fields
+				|| resolved_expected_type.trim_right('*').starts_with('Array_')
+				|| resolved_expected_type.trim_right('*').starts_with('Map_')
+				|| resolved_expected_type.trim_right('*').starts_with('FixedArray_')) {
+				assigned_value = '*((${resolved_expected_type} *)(${value}))'
+			}
+			g.write_line('${c_target}${operator.str()}${assigned_value};')
 			return
 		}
 		expression := g.read_statement_expression_with_prefix(name, [token.Token.comma,
-			token.Token.semicolon, token.Token.rcbr])!
+			token.Token.semicolon, token.Token.rcbr, token.Token.arrow])!
+		if g.selfhost && g.tok == .arrow {
+			// Channel send `<chan> <- <value>`: push the value through the channel.
+			// Channels are the type-erased `void*` stub, so this compiles to a
+			// `try_push` of the value's address (non-blocking, matching the builtin).
+			g.next()
+			value := g.read_expression([token.Token.semicolon, token.Token.rcbr])!
+			value_type := fastc_normalize_inferred_type(g.last_expression_type)
+			g.consume_statement_end()
+			element_type := if value_type == '' { 'int' } else { value_type }
+			send_tmp := g.temporary_name('chan_send')
+			g.write_line('${element_type} ${send_tmp} = (${value});')
+			g.write_line('builtin__chan_try_push((chan)(${expression}), &${send_tmp});')
+			return
+		}
 		if g.selfhost && g.tok == .comma {
 			g.parse_parallel_expression_assignment(expression, g.last_expression.clone(),
 				g.last_expression_type)!
 			return
 		}
 		if !g.last_expression_is_statement() {
+			if g.or_value_capture {
+				g.capture_or_value(expression)
+				g.consume_statement_end()
+				return
+			}
 			return g.unsupported('value-only expression statement')
 		}
 		g.consume_statement_end()
@@ -626,16 +1068,63 @@ fn (mut g Parser) parse_simple_statement() ! {
 		return g.unsupported('statement `${g.token_source()}`')
 	}
 	if g.last_expression.len == 0 && g.last_expression_type.starts_with(fastc_thread_type_prefix) {
-		// A discarded handle can never be joined, so the packed arguments and
-		// pthread join state of every completed spawn would leak.
-		return g.unsupported('statement-form `spawn` that discards its thread handle; assign the handle and call `.wait()`')
+		// Fire-and-forget `spawn f()` as a statement: the handle is discarded, so
+		// detach the thread. It then releases its own resources on completion (the
+		// run wrapper frees the packed arguments), rather than leaking a joinable.
+		g.consume_statement_end()
+		handle := g.temporary_name('thread')
+		g.write_line('{ ${g.last_expression_type} ${handle} = ${expression}; pthread_detach(${handle}.handle); }')
+		return
 	}
 	if g.selfhost && g.last_expression_is_statement() {
 		g.consume_statement_end()
 		g.write_line('${expression};')
 		return
 	}
+	if g.or_value_capture {
+		g.capture_or_value(expression)
+		g.consume_statement_end()
+		return
+	}
 	return g.unsupported('value-only expression statement')
+}
+
+fn (mut g Parser) parse_assert_statement() ! {
+	g.next()
+	condition := g.read_expression([token.Token.comma, token.Token.semicolon, token.Token.rcbr])!
+	if condition == '' {
+		return g.unsupported('empty assert condition')
+	}
+	mut message := if g.selfhost { '_S("assertion failed")' } else { '"assertion failed"' }
+	if g.tok == .comma {
+		g.next()
+		message = g.read_expression([token.Token.semicolon, token.Token.rcbr])!
+		if message == '' {
+			return g.unsupported('empty assert message')
+		}
+	}
+	g.consume_statement_end()
+	if g.selfhost {
+		g.write_line('if (!(${condition})) { builtin__panic(${message}); }')
+	} else {
+		g.write_line('if (!(${condition})) { fputs(${message}, stderr); abort(); }')
+	}
+}
+
+// capture_or_value records a trailing bare value expression as an `or`-block's fallback
+// value (see the `or_value_capture` path in expr.v). It re-renders through the argument
+// pipeline when the block's expected value type is known, so enum-shorthand/boxing
+// fallbacks (`or { .none }`, a variant literal, …) still type correctly.
+fn (mut g Parser) capture_or_value(expression string) {
+	mut value := expression
+	if g.or_value_expected_type != '' && g.last_expression.len > 0 {
+		if contextual := g.render_call_argument_expression(g.last_expression,
+			g.or_value_expected_type)
+		{
+			value = contextual
+		}
+	}
+	g.or_value_captured = value
 }
 
 fn (mut g Parser) parse_parallel_assignment(initial_names []string, initial_mut bool, force_declaration bool) ! {
@@ -660,6 +1149,12 @@ fn (mut g Parser) parse_parallel_assignment(initial_names []string, initial_mut 
 		return g.unsupported('parallel assignment operator `${g.token_source()}`')
 	}
 	g.next()
+	// `a, b := opt_tuple() or { x, y }`: an option whose value is a multi-return tuple,
+	// with a TUPLE `or` fallback. The or-block's comma would otherwise trip the value
+	// reader as a parallel assignment, so lower it here.
+	if g.selfhost && names.len > 1 && g.parallel_rhs_is_option_tuple_or() {
+		return g.parse_parallel_option_tuple(names, mutability, is_declaration)
+	}
 	g.last_multi_return_types = []string{}
 	mut values := []string{}
 	mut value_types := []string{}
@@ -750,6 +1245,166 @@ fn (mut g Parser) parse_parallel_assignment(initial_names []string, initial_mut 
 			g.write_line('memcpy(&${c_name}, ${temporary}.values[${i}].data, sizeof(${c_name}));')
 		}
 	}
+}
+
+// parallel_rhs_is_option_tuple_or reports whether the RHS of a parallel `:=` (the
+// scanner is positioned at its first token) has the shape `<expr> or { … , … }` — an
+// option unwrapped with a comma-separated TUPLE fallback. Bounded to the current
+// statement (stops at a top-level comma, a newline, or the statement end).
+fn (g &Parser) parallel_rhs_is_option_tuple_or() bool {
+	mut probe := g.s
+	mut tok := g.tok
+	mut prev_end := g.s.pos
+	mut depth := 0
+	for {
+		match tok {
+			.lpar, .lsbr, .lcbr {
+				depth++
+			}
+			.rpar, .rsbr, .rcbr {
+				if depth == 0 {
+					return false
+				}
+				depth--
+			}
+			.comma {
+				if depth == 0 {
+					// A top-level comma before any `or` means a plain multi-value RHS.
+					return false
+				}
+			}
+			.key_or {
+				if depth == 0 {
+					break
+				}
+			}
+			.semicolon, .eof {
+				return false
+			}
+			else {}
+		}
+		prev_end = probe.pos
+		tok = probe.scan()
+		if depth == 0 && probe.src[prev_end..probe.pos].contains('\n') {
+			return false
+		}
+	}
+	if probe.scan() != .lcbr {
+		return false
+	}
+	mut block_depth := 1
+	for block_depth > 0 {
+		t := probe.scan()
+		if t == .eof {
+			return false
+		}
+		match t {
+			.lpar, .lsbr, .lcbr {
+				block_depth++
+			}
+			.rpar, .rsbr, .rcbr {
+				block_depth--
+			}
+			.comma {
+				if block_depth == 1 {
+					return true
+				}
+			}
+			else {}
+		}
+	}
+	return false
+}
+
+// parse_parallel_option_tuple lowers `a, b := opt_tuple() or { x, y }`: declare each
+// target, then on the option's failure state assign the fallback tuple, else unbox the
+// `MultiReturn` component into each target.
+fn (mut g Parser) parse_parallel_option_tuple(names []string, mutability []bool, is_declaration bool) ! {
+	option_expr := g.read_expression([token.Token.key_or, token.Token.semicolon, token.Token.rcbr])!
+	component_types := g.multi_return_types_for_expression(g.last_expression)
+	if component_types.len < names.len {
+		return g.unsupported('parallel option tuple with ${names.len} targets and ${component_types.len} components')
+	}
+	g.expect(.key_or)!
+	g.expect(.lcbr)!
+	previous_err := g.locals['err'] or { FastcLocal{} }
+	had_err := 'err' in g.locals
+	g.locals['err'] = FastcLocal{
+		typ: 'IError'
+	}
+	mut fallbacks := []string{}
+	for g.tok != .rcbr && g.tok != .eof {
+		g.skip_semicolons()
+		if g.tok == .rcbr {
+			break
+		}
+		fallback := g.read_expression([token.Token.comma, token.Token.semicolon, token.Token.rcbr])!
+		fallbacks << fallback
+		if g.tok in [.comma, .semicolon] {
+			g.next()
+		}
+	}
+	if had_err {
+		g.locals['err'] = previous_err
+	} else {
+		g.locals.delete('err')
+	}
+	g.expect(.rcbr)!
+	g.consume_statement_end()
+	if fallbacks.len != names.len {
+		return g.unsupported('parallel option tuple fallback with ${fallbacks.len} values for ${names.len} targets')
+	}
+	mut assignment_targets := []FastcRenderedExpression{}
+	if !is_declaration {
+		assignment_targets = g.validate_parallel_assignment_targets(names)!
+	}
+	guard := g.temporary_name('opt_guard')
+	multi_return := g.temporary_name('multi_return')
+	if is_declaration {
+		for i, name in names {
+			if name == '_' {
+				continue
+			}
+			component_type := fastc_normalize_inferred_type(component_types[i])
+			g.write_line('${component_type} ${fastc_c_identifier(name)} = (${component_type}){0};')
+			g.locals[name] = FastcLocal{
+				is_mut: mutability[i]
+				typ:    component_type
+			}
+		}
+	}
+	g.write_line('Option ${guard} = (${option_expr});')
+	g.write_line('if (${guard}.state) {')
+	g.indent++
+	g.write_line('IError err = ${guard}.err;')
+	for i, name in names {
+		if name == '_' {
+			continue
+		}
+		target := if is_declaration {
+			fastc_c_identifier(name)
+		} else {
+			assignment_targets[i].source
+		}
+		g.write_line('${target} = (${fallbacks[i]});')
+	}
+	g.indent--
+	g.write_line('} else {')
+	g.indent++
+	g.write_line('MultiReturn ${multi_return} = *((MultiReturn *)${guard}.data);')
+	for i, name in names {
+		if name == '_' {
+			continue
+		}
+		target := if is_declaration {
+			fastc_c_identifier(name)
+		} else {
+			assignment_targets[i].source
+		}
+		g.write_line('memcpy(&${target}, ${multi_return}.values[${i}].data, sizeof(${target}));')
+	}
+	g.indent--
+	g.write_line('}')
 }
 
 fn (g &Parser) validate_parallel_assignment_targets(names []string) ![]FastcRenderedExpression {
@@ -865,13 +1520,45 @@ fn (g &Parser) validate_parallel_expression_assignment_target(source string, tok
 }
 
 fn (g &Parser) multi_return_types_for_expression(tokens []FastcExpressionToken) []string {
-	expression_tokens := if tokens.len > 0 && tokens.last().tok == .not {
-		tokens[..tokens.len - 1]
-	} else {
-		tokens
+	mut expression_end := tokens.len
+	for expression_end > 0 && tokens[expression_end - 1].tok == .semicolon {
+		expression_end--
 	}
+	if expression_end > 0 && tokens[expression_end - 1].tok == .not {
+		expression_end--
+	}
+	expression_tokens := tokens[..expression_end]
 	if expression_tokens.len < 3 {
 		return []string{}
+	}
+	if expression_tokens.len >= 5 && expression_tokens.last().tok == .rpar {
+		for i := expression_tokens.len - 2; i >= 2; i-- {
+			if expression_tokens[i].tok != .name || expression_tokens[i - 1].tok != .dot
+				|| expression_tokens[i + 1].tok != .lpar {
+				continue
+			}
+			method_close := fastc_matching_rpar(expression_tokens, i + 1) or { continue }
+			if method_close != expression_tokens.len - 1 {
+				continue
+			}
+			if static_key := g.static_function_key_for_call(expression_tokens, i) {
+				if signature := g.functions[static_key] {
+					return signature.return_types.clone()
+				}
+			}
+			receiver_start := fastc_method_receiver_start(expression_tokens, i - 1)
+			receiver_type := g.infer_expression_type(expression_tokens[receiver_start..i - 1]) or {
+				''
+			}
+			if receiver_type == '' {
+				break
+			}
+			method_key, _ := g.resolve_method(receiver_type, expression_tokens[i].lit)
+			if signature := g.functions[method_key] {
+				return signature.return_types.clone()
+			}
+			break
+		}
 	}
 	mut name_index := 0
 	mut open_index := 1
@@ -880,7 +1567,8 @@ fn (g &Parser) multi_return_types_for_expression(tokens []FastcExpressionToken) 
 		name_index = 2
 		open_index = 3
 	}
-	if expression_tokens[name_index].tok != .name || expression_tokens[open_index].tok != .lpar {
+	if expression_tokens[name_index].tok !in [.name, .key_select]
+		|| expression_tokens[open_index].tok != .lpar {
 		return []string{}
 	}
 	close := fastc_matching_rpar(expression_tokens, open_index) or { return []string{} }
@@ -899,6 +1587,94 @@ fn (g &Parser) multi_return_types_for_expression(tokens []FastcExpressionToken) 
 }
 
 fn (g &Parser) option_value_type_for_expression(tokens []FastcExpressionToken) string {
+	if map_lookup := g.render_map_lookup_option_expression(tokens) {
+		return map_lookup.typ
+	}
+	if array_lookup := g.render_array_lookup_option_expression(tokens) {
+		return array_lookup.typ
+	}
+	if generic_type := g.erased_generic_option_value_type_for_expression(tokens) {
+		return generic_type
+	}
+	// An explicit option cast (`?T(value)` / `?T(none)`) carries its payload type in
+	// the cast even though every option shares the erased C type `Option`.
+	if tokens.len >= 4 && tokens[0].tok == .question && tokens.last().tok == .rpar {
+		for open in 2 .. tokens.len - 1 {
+			if tokens[open].tok != .lpar {
+				continue
+			}
+			close := fastc_matching_rpar(tokens, open) or { continue }
+			if close == tokens.len - 1 {
+				return g.type_from_expression_tokens(tokens[1..open]) or { '' }
+			}
+			break
+		}
+	}
+	for open in 1 .. tokens.len - 1 {
+		if tokens[open].tok != .lsbr || tokens[open - 1].tok != .name {
+			continue
+		}
+		close := fastc_matching_delimiter(tokens, open, .lsbr, .rsbr) or { continue }
+		if close + 1 >= tokens.len || tokens[close + 1].tok != .lpar {
+			continue
+		}
+		mut normalized := tokens[..open].clone()
+		normalized << tokens[close + 1..]
+		return g.option_value_type_for_expression(normalized)
+	}
+	// A bare option variable (`if x := opt`): recover the wrapped value type recorded
+	// when the variable was declared, since its C type is the type-erased `Option`.
+	if tokens.len == 1 && tokens[0].tok == .name {
+		local := g.locals[tokens[0].lit] or { return '' }
+		return local.option_value_type
+	}
+	// A member access to an option FIELD (`if mut v := x.f {` where `f ?T`): the field's
+	// erased C type is `Option`, so recover the wrapped value type recorded on the field.
+	if tokens.len >= 3 && tokens.last().tok == .name && tokens[tokens.len - 2].tok == .dot {
+		receiver_type := g.infer_expression_type(tokens[..tokens.len - 2]) or { '' }
+		if receiver_type != '' {
+			receiver_layout := fastc_normalize_inferred_type(receiver_type).trim_right('*')
+			field_name := tokens.last().lit
+			if fields := g.struct_field_info[receiver_layout] {
+				for field in fields {
+					if field.name == field_name && field.option_value_type != '' {
+						return field.option_value_type
+					}
+				}
+			}
+		}
+	}
+	// A method call whose receiver spans several tokens (`qb.conn.select(...)`):
+	// find the trailing `.method(args)` and resolve the receiver's type so the
+	// method's option payload type is known. The single-token and module-qualified
+	// forms below cannot see past the first receiver token.
+	if tokens.len >= 5 && tokens.last().tok == .rpar {
+		for i := tokens.len - 2; i >= 2; i-- {
+			if tokens[i].tok != .name || tokens[i - 1].tok != .dot || tokens[i + 1].tok != .lpar {
+				continue
+			}
+			method_close := fastc_matching_rpar(tokens, i + 1) or { continue }
+			if method_close != tokens.len - 1 {
+				continue
+			}
+			receiver_start := fastc_method_receiver_start(tokens, i - 1)
+			receiver_type := g.infer_expression_type(tokens[receiver_start..i - 1]) or { '' }
+			if receiver_type == '' {
+				break
+			}
+			if field := g.struct_field_metadata(receiver_type, tokens[i].lit) {
+				if field.is_function && field.fn_option_value_type != '' {
+					return field.fn_option_value_type
+				}
+			}
+			method_key, _ := g.resolve_method(receiver_type, tokens[i].lit)
+			if method_key in g.functions {
+				method_signature := g.functions[method_key]
+				return method_signature.option_type
+			}
+			break
+		}
+	}
 	if tokens.len < 3 {
 		return ''
 	}
@@ -908,21 +1684,74 @@ fn (g &Parser) option_value_type_for_expression(tokens []FastcExpressionToken) s
 		name_index = 2
 		open_index = 3
 	}
-	if tokens[name_index].tok != .name || tokens[open_index].tok != .lpar {
+	if tokens[name_index].tok !in [.name, .key_select] || tokens[open_index].tok != .lpar {
 		return ''
 	}
 	close := fastc_matching_rpar(tokens, open_index) or { return '' }
 	if close != tokens.len - 1 {
 		return ''
 	}
+	if name_index == 0 {
+		// Calling an option-returning function-pointer parameter (`f(x) or {…}`).
+		if local := g.locals[tokens[0].lit] {
+			if local.fn_option_value_type != '' {
+				return local.fn_option_value_type
+			}
+		}
+	}
+	if static_key := g.static_function_key_for_call(tokens, name_index) {
+		static_signature := g.functions[static_key]
+		return static_signature.option_type
+	}
 	function_key := if name_index == 2 && tokens[0].lit !in g.imports && tokens[0].lit != 'C' {
 		receiver_type := g.infer_expression_type(tokens[..1]) or { return '' }
-		g.method_function_key(receiver_type, tokens[name_index].lit)
+		method_key, _ := g.resolve_method(receiver_type, tokens[name_index].lit)
+		method_key
 	} else {
 		g.function_key_for_call(tokens, name_index)
 	}
-	signature := g.functions[function_key] or { return '' }
+	signature := if function_key in g.functions {
+		g.functions[function_key]
+	} else {
+		g.mono_functions[function_key] or { return '' }
+	}
 	return signature.option_type
+}
+
+fn (g &Parser) erased_generic_option_value_type_for_expression(tokens []FastcExpressionToken) ?string {
+	if tokens.len < 5 || tokens.last().tok != .rpar {
+		return none
+	}
+	for i := tokens.len - 2; i >= 2; i-- {
+		if tokens[i].tok != .name || tokens[i - 1].tok != .dot || tokens[i + 1].tok != .lpar {
+			continue
+		}
+		call_end := fastc_matching_rpar(tokens, i + 1) or { continue }
+		if call_end != tokens.len - 1 {
+			continue
+		}
+		receiver_start := fastc_method_receiver_start(tokens, i - 1)
+		receiver_tokens := tokens[receiver_start..i - 1]
+		if receiver_tokens.len < 3 || receiver_tokens.last().tok != .name
+			|| receiver_tokens[receiver_tokens.len - 2].tok != .dot {
+			return none
+		}
+		owner_type := g.infer_expression_type(receiver_tokens[..receiver_tokens.len - 2]) or {
+			return none
+		}
+		field := g.struct_field_metadata(owner_type, receiver_tokens.last().lit) or { return none }
+		if field.generic_argument_type == '' {
+			return none
+		}
+		receiver_type := g.infer_expression_type(receiver_tokens) or { return none }
+		method_key, _ := g.resolve_method(receiver_type, tokens[i].lit)
+		signature := g.functions[method_key] or { return none }
+		if signature.return_type == 'Option' && signature.option_type == 'voidptr' {
+			return field.generic_argument_type
+		}
+		return none
+	}
+	return none
 }
 
 fn (g &Parser) last_expression_is_statement() bool {
@@ -934,6 +1763,18 @@ fn (g &Parser) expression_tokens_are_statement(expression_tokens []FastcExpressi
 		expression_tokens[..expression_tokens.len - 1]
 	} else {
 		expression_tokens
+	}
+	for open in 1 .. tokens.len - 1 {
+		if tokens[open].tok != .lsbr || tokens[open - 1].tok != .name {
+			continue
+		}
+		close := fastc_matching_delimiter(tokens, open, .lsbr, .rsbr) or { continue }
+		if close + 1 >= tokens.len || tokens[close + 1].tok != .lpar {
+			continue
+		}
+		mut normalized := tokens[..open].clone()
+		normalized << tokens[close + 1..]
+		return g.expression_tokens_are_statement(normalized)
 	}
 	if g.selfhost {
 		for item in tokens {
@@ -967,7 +1808,8 @@ fn (g &Parser) expression_tokens_are_statement(expression_tokens []FastcExpressi
 				// a void-returning spawn is still a valid standalone statement.
 				return true
 			}
-			if g.method_function_key(receiver_type, tokens[i].lit) in g.functions
+			resolved_method_key, _ := g.resolve_method(receiver_type, tokens[i].lit)
+			if resolved_method_key in g.functions || resolved_method_key in g.mono_functions
 				|| g.struct_member_type(receiver_type, tokens[i].lit) != '' {
 				return true
 			}
@@ -983,7 +1825,7 @@ fn (g &Parser) expression_tokens_are_statement(expression_tokens []FastcExpressi
 		name_index = 2
 		open_index = 3
 	}
-	if tokens.len <= open_index + 1 || tokens[name_index].tok != .name
+	if tokens.len <= open_index + 1 || tokens[name_index].tok !in [.name, .key_select]
 		|| tokens[open_index].tok != .lpar {
 		return false
 	}
@@ -993,6 +1835,13 @@ fn (g &Parser) expression_tokens_are_statement(expression_tokens []FastcExpressi
 	}
 	name := tokens[name_index].lit
 	function_key := g.function_key_for_call(tokens, name_index)
+	if name_index == 0 {
+		if local := g.locals[name] {
+			if local.fn_return_type != '' {
+				return true
+			}
+		}
+	}
 	return function_key in g.functions || (name_index == 0 && name in ['print', 'println'])
 }
 
@@ -1001,9 +1850,24 @@ fn (mut g Parser) parse_declaration_after_name(name string, is_mut bool) ! {
 		return g.unsupported('redeclaration of `${name}`')
 	}
 	g.next()
+	if g.tok == .name && g.lit == 'sql' && 'sql' !in g.locals {
+		mut lookahead := g.s
+		if lookahead.scan() == .name {
+			return g.parse_orm_sql_select_declaration(name, is_mut)
+		}
+	}
 	expression := g.read_expression([token.Token.semicolon, token.Token.rcbr])!
 	if expression.len == 0 {
 		return g.unsupported('empty declaration')
+	}
+	option_value_type := if g.selfhost {
+		if g.last_expression.len == 0 {
+			g.last_option_value_type
+		} else {
+			g.option_value_type_for_expression(g.last_expression)
+		}
+	} else {
+		''
 	}
 	g.consume_statement_end()
 	// GNU typeof is unevaluated and is supported by bundled TinyCC. It lets the
@@ -1016,13 +1880,18 @@ fn (mut g Parser) parse_declaration_after_name(name string, is_mut bool) ! {
 	} else {
 		g.write_line('__typeof__((${expression})) ${c_name} = (${expression});')
 	}
+	local_type := if g.selfhost && g.last_expression_type == '' {
+		'int'
+	} else {
+		fastc_normalize_inferred_type(g.last_expression_type)
+	}
+	function_alias := g.functions[local_type] or { FastcFunctionSignature{} }
 	g.locals[name] = FastcLocal{
-		is_mut: is_mut
-		typ:    if g.selfhost && g.last_expression_type == '' {
-			'int'
-		} else {
-			fastc_normalize_inferred_type(g.last_expression_type)
-		}
+		is_mut:               is_mut
+		typ:                  local_type
+		option_value_type:    option_value_type
+		fn_return_type:       function_alias.return_type
+		fn_option_value_type: function_alias.option_type
 	}
 }
 
@@ -1058,4 +1927,921 @@ fn (mut g Parser) write_line(line string) {
 		g.out.write_u8(`\t`)
 	}
 	g.out.writeln(line)
+}
+
+// parse_orm_sql_statement lowers a `sql db { ... }` ORM statement into ordinary V
+// source (runtime metadata construction plus a Connection method call) and
+// re-scans that source. The `sql` keyword has already been consumed, so g.tok is
+// positioned at the connection expression.
+fn (mut g Parser) parse_orm_sql_statement() ! {
+	// The lowering references `orm.Table`/`orm.QueryData`/`orm.Primitive`, so the
+	// `orm` module must be in scope for those to resolve. Files that use `sql` without
+	// importing `orm` (V normally injects it for them) fall back to the diagnostic
+	// until FastC injects the import in a pre-pass.
+	if 'orm' !in g.imports && g.module_name != 'orm' {
+		return g.unsupported('ORM `sql` statements (comptime query generation is unavailable)')
+	}
+	db_source, block_source, unwrap := g.capture_orm_sql_block()!
+	mut trailing := unwrap
+	if g.tok == .key_or {
+		or_source := g.capture_orm_or_block()!
+		trailing = ' or { ${or_source} }'
+	}
+	lowering := g.build_orm_lowering(db_source, block_source, trailing)!
+	// Re-scan the generated V as ordinary source. A fresh C block scopes the
+	// temporaries so several `sql` blocks in one function cannot collide.
+	saved_tok := g.tok
+	saved_lit := g.lit
+	saved_s := g.s
+	mut file_set := token.FileSet.new()
+	mut file := file_set.add_file('orm_sql', lowering.len)
+	file.index_lines_without_digest(lowering)
+	g.s = scanner.new_scanner(g.prefs, .normal)
+	g.s.init(file, lowering)
+	g.next()
+	g.write_line('{')
+	g.indent++
+	outer_locals := g.locals.clone()
+	for g.tok != .eof {
+		g.parse_statement()!
+		g.skip_semicolons()
+	}
+	g.locals = outer_locals.clone()
+	g.indent--
+	g.write_line('}')
+	g.s = saved_s
+	g.tok = saved_tok
+	g.lit = saved_lit
+}
+
+// capture_orm_sql_block splits `db { ... }[!]` into the connection expression
+// source, the raw query-block body, and any trailing `!` propagation marker,
+// consuming all of them from the main scanner.
+fn (mut g Parser) capture_orm_sql_block() !(string, string, string) {
+	db_start := g.s.pos
+	mut depth := 0
+	for g.tok != .eof {
+		if g.tok == .lpar || g.tok == .lsbr {
+			depth++
+		} else if g.tok == .rpar || g.tok == .rsbr {
+			depth--
+		} else if g.tok == .lcbr && depth == 0 {
+			break
+		}
+		g.next()
+	}
+	if g.tok != .lcbr {
+		return g.unsupported('ORM `sql`: expected `{` after the connection')
+	}
+	db_source := g.s.src[db_start..g.s.pos].trim_space()
+	g.next() // consume `{`
+	block_start := g.s.pos
+	mut block_depth := 0
+	mut block_end := -1
+	for g.tok != .eof {
+		if g.tok == .lcbr {
+			block_depth++
+		} else if g.tok == .rcbr {
+			if block_depth == 0 {
+				block_end = g.s.pos
+				break
+			}
+			block_depth--
+		}
+		g.next()
+	}
+	if block_end < 0 {
+		return g.unsupported('ORM `sql`: unterminated query block')
+	}
+	block_source := g.s.src[block_start..block_end]
+	g.next() // consume `}`
+	mut trailing := ''
+	if g.tok == .not {
+		trailing = '!'
+		g.next()
+	}
+	return db_source, block_source, trailing
+}
+
+// build_orm_lowering parses one ORM query block and returns the V source it lowers
+// to. Only `insert` is handled so far; other operations report as unsupported.
+fn (g &Parser) build_orm_lowering(db_source string, block_source string, trailing string) !string {
+	mut file_set := token.FileSet.new()
+	mut file := file_set.add_file('orm_query', block_source.len)
+	file.index_lines_without_digest(block_source)
+	mut s := scanner.new_scanner(g.prefs, .normal)
+	s.init(file, block_source)
+	mut tok := s.scan()
+	if tok != .name {
+		return g.unsupported('ORM `sql`: empty query block')
+	}
+	operation := s.lit
+	if operation == 'insert' {
+		// `insert <value> into <Table>`
+		tok = s.scan()
+		value_start := s.pos
+		mut value_end := -1
+		mut table_name := ''
+		for tok != .eof {
+			if tok == .name && s.lit == 'into' {
+				value_end = s.pos
+				tok = s.scan()
+				if tok == .name {
+					table_name = s.lit
+				}
+				break
+			}
+			tok = s.scan()
+		}
+		if value_end < 0 || table_name == '' {
+			return g.unsupported('ORM `sql`: malformed `insert`')
+		}
+		value_source := block_source[value_start..value_end].trim_space()
+		return g.build_orm_insert(db_source, value_source, table_name, trailing)
+	}
+	if operation == 'update' {
+		return g.build_orm_update(db_source, block_source, trailing)
+	}
+	if operation == 'delete' {
+		return g.build_orm_delete(db_source, block_source, trailing)
+	}
+	if operation == 'create' {
+		return g.build_orm_create(db_source, block_source, trailing)
+	}
+	if operation == 'drop' {
+		return g.build_orm_drop(db_source, block_source, trailing)
+	}
+	return g.unsupported('ORM `sql` `${operation}` (not lowered yet)')
+}
+
+// fastc_orm_where_op maps a V comparison token to the `orm.OperationKind` variant
+// name for a `where` clause, or '' for an operator the update lowering cannot express.
+fn fastc_orm_where_op(tok token.Token) string {
+	return match tok {
+		.eq { 'eq' }
+		.ne { 'neq' }
+		.gt { 'gt' }
+		.lt { 'lt' }
+		.ge { 'ge' }
+		.le { 'le' }
+		else { '' }
+	}
+}
+
+// build_orm_update emits the V source for `update <Table> set <f> = <v>, ... where
+// <f> <op> <v> [&&/|| ...]`. The `set` pairs fill the `data` QueryData (one boxed
+// Primitive per assignment) and the `where` conditions fill the `where` QueryData
+// (Primitive value + OperationKind + is_and joiners), then it calls the connection's
+// `update`. Values are captured as source spans and boxed via `orm.Primitive(<expr>)`.
+fn (g &Parser) build_orm_update(db_source string, block_source string, trailing string) !string {
+	mut file_set := token.FileSet.new()
+	mut file := file_set.add_file('orm_update', block_source.len)
+	file.index_lines_without_digest(block_source)
+	mut s := scanner.new_scanner(g.prefs, .normal)
+	s.init(file, block_source)
+	mut tok := s.scan()
+	for tok == .semicolon {
+		tok = s.scan()
+	}
+	if tok != .name || s.lit != 'update' {
+		return g.unsupported('ORM `sql`: expected `update`')
+	}
+	tok = s.scan()
+	if tok != .name {
+		return g.unsupported('ORM `sql`: expected a row type after `update`')
+	}
+	table_name := s.lit
+	tok = s.scan()
+	if tok != .name || s.lit != 'set' {
+		return g.unsupported('ORM `sql`: expected `set` in `update`')
+	}
+	tok = s.scan()
+	mut set_fields := []string{}
+	mut set_values := []string{}
+	for tok != .eof {
+		if tok != .name {
+			return g.unsupported('ORM `sql`: expected a field name in `set`')
+		}
+		field_name := s.lit
+		tok = s.scan()
+		if tok != .assign {
+			return g.unsupported('ORM `sql`: expected `=` in `set`')
+		}
+		tok = s.scan()
+		value_start := s.pos
+		mut value_end := s.offset
+		mut depth := 0
+		for tok != .eof {
+			if tok in [.lpar, .lsbr, .lcbr] {
+				depth++
+			} else if tok in [.rpar, .rsbr, .rcbr] {
+				depth--
+			} else if depth == 0 && tok == .comma {
+				break
+			} else if depth == 0 && tok == .name && s.lit == 'where' {
+				break
+			}
+			value_end = s.offset
+			tok = s.scan()
+		}
+		set_fields << field_name
+		set_values << block_source[value_start..value_end].trim_space()
+		if tok == .comma {
+			tok = s.scan()
+			continue
+		}
+		break
+	}
+	if set_fields.len == 0 {
+		return g.unsupported('ORM `sql`: `update` has no `set` assignments')
+	}
+	where_lines, _ := g.build_orm_where_lines(mut s, block_source, tok)!
+	mut out := "mut __orm_table := orm.Table{ name: '${table_name}' }\n"
+	out += 'mut __orm_data := orm.QueryData{}\n'
+	for i, field_name in set_fields {
+		out += "__orm_data.fields << '${field_name}'\n"
+		out += '__orm_set_${i} := orm.Primitive(${set_values[i]})\n'
+		out += '__orm_data.data << __orm_set_${i}\n'
+	}
+	out += where_lines
+	out += '${db_source}.update(__orm_table, __orm_data, __orm_where)${trailing}\n'
+	return out
+}
+
+// build_orm_where_lines parses an optional `where <f> <op> <v> [&&/|| ...]` clause
+// (the scanner is positioned on the token where the clause would start, `first_tok`)
+// and returns the V source that fills a `__orm_where` QueryData with one boxed
+// Primitive, OperationKind, and is_and joiner per condition. An absent `where`
+// yields an empty QueryData. Shared by `update` and `delete`.
+fn (g &Parser) build_orm_where_lines(mut s scanner.Scanner, block_source string, first_tok token.Token) !(string, token.Token) {
+	mut tok := first_tok
+	mut where_fields := []string{}
+	mut where_ops := []string{}
+	mut where_values := []string{}
+	mut where_is_and := []string{}
+	// Parenthesized groups as [start_field_index, end_field_index] pairs, closed in
+	// post-order (inner group before outer), mirroring V's ORM QueryData.parentheses.
+	mut where_paren_starts := []int{}
+	mut where_paren_ends := []int{}
+	if tok == .name && s.lit == 'where' {
+		tok = s.scan()
+		// `is_and[i]` is the operator (&& true / || false) between condition i and i+1 in
+		// source order; a boolean tree's explicit `(` / `)` become parentheses groups.
+		mut paren_stack := []int{}
+		mut pending_is_and := ''
+		for tok != .eof {
+			if tok == .semicolon {
+				tok = s.scan()
+				continue
+			}
+			if tok == .lpar {
+				paren_stack << where_fields.len
+				tok = s.scan()
+				continue
+			}
+			if tok == .rpar {
+				if paren_stack.len > 0 {
+					start := paren_stack.last()
+					paren_stack.delete_last()
+					if where_fields.len > start {
+						where_paren_starts << start
+						where_paren_ends << where_fields.len - 1
+					}
+				}
+				tok = s.scan()
+				continue
+			}
+			if tok == .and {
+				pending_is_and = 'true'
+				tok = s.scan()
+				continue
+			}
+			if tok == .logical_or {
+				pending_is_and = 'false'
+				tok = s.scan()
+				continue
+			}
+			if tok == .name && s.lit in ['order', 'limit', 'offset'] {
+				break
+			}
+			if tok != .name {
+				return g.unsupported('ORM `sql`: expected a field name in `where`')
+			}
+			where_field := s.lit
+			tok = s.scan()
+			op := fastc_orm_where_op(tok)
+			if op == '' {
+				return g.unsupported('ORM `sql`: unsupported `where` operator')
+			}
+			tok = s.scan()
+			value_start := s.pos
+			mut value_end := s.offset
+			mut depth := 0
+			for tok != .eof {
+				if tok in [.lpar, .lsbr, .lcbr] {
+					depth++
+				} else if tok in [.rpar, .rsbr, .rcbr] {
+					if depth == 0 {
+						// A `)` at the value's top level closes a `where` group, not a
+						// sub-expression; stop without consuming it.
+						break
+					}
+					depth--
+				} else if depth == 0 && (tok == .and || tok == .logical_or || tok == .semicolon) {
+					break
+				} else if depth == 0 && tok == .name && s.lit in ['order', 'limit', 'offset'] {
+					// A trailing `order by` / `limit` / `offset` clause ends the condition;
+					// do not swallow it into the value.
+					break
+				}
+				value_end = s.offset
+				tok = s.scan()
+			}
+			if where_fields.len > 0 {
+				where_is_and << if pending_is_and == '' { 'true' } else { pending_is_and }
+			}
+			where_fields << where_field
+			where_ops << op
+			where_values << block_source[value_start..value_end].trim_space()
+			pending_is_and = ''
+		}
+	}
+	mut out := 'mut __orm_where := orm.QueryData{}\n'
+	for i, field_name in where_fields {
+		out += "__orm_where.fields << '${field_name}'\n"
+		out += '__orm_wval_${i} := orm.Primitive(${where_values[i]})\n'
+		out += '__orm_where.data << __orm_wval_${i}\n'
+		out += '__orm_where.kinds << orm.OperationKind.${where_ops[i]}\n'
+	}
+	for is_and in where_is_and {
+		out += '__orm_where.is_and << ${is_and}\n'
+	}
+	for i in 0 .. where_paren_starts.len {
+		out += '__orm_paren_${i} := [${where_paren_starts[i]}, ${where_paren_ends[i]}]\n'
+		out += '__orm_where.parentheses << __orm_paren_${i}\n'
+	}
+	return out, tok
+}
+
+// build_orm_delete emits the V source for `delete from <Table> [where ...]`: it
+// builds the where QueryData (shared with `update`) and calls the connection's
+// `delete`.
+fn (g &Parser) build_orm_delete(db_source string, block_source string, trailing string) !string {
+	mut file_set := token.FileSet.new()
+	mut file := file_set.add_file('orm_delete', block_source.len)
+	file.index_lines_without_digest(block_source)
+	mut s := scanner.new_scanner(g.prefs, .normal)
+	s.init(file, block_source)
+	mut tok := s.scan()
+	for tok == .semicolon {
+		tok = s.scan()
+	}
+	if tok != .name || s.lit != 'delete' {
+		return g.unsupported('ORM `sql`: expected `delete`')
+	}
+	tok = s.scan()
+	if tok != .name || s.lit != 'from' {
+		return g.unsupported('ORM `sql`: expected `from` in `delete`')
+	}
+	tok = s.scan()
+	if tok != .name {
+		return g.unsupported('ORM `sql`: expected a row type after `from`')
+	}
+	table_name := s.lit
+	tok = s.scan()
+	where_lines, _ := g.build_orm_where_lines(mut s, block_source, tok)!
+	mut out := "mut __orm_table := orm.Table{ name: '${table_name}' }\n"
+	out += where_lines
+	out += '${db_source}.delete(__orm_table, __orm_where)${trailing}\n'
+	return out
+}
+
+// build_orm_insert emits the V source for `insert <value> into <Table>`: it fills
+// an orm.QueryData with one boxed Primitive per row-struct field, then calls the
+// connection's `insert` method.
+fn (g &Parser) build_orm_insert(db_source string, value_source string, table_name string, trailing string) !string {
+	type_key := fastc_resolve_declared_type_key(g.module_name, table_name, g.imports,
+		g.declared_types) or { return g.unsupported('ORM `sql`: unknown row type `${table_name}`') }
+	c_type := fastc_c_declared_type_name(type_key)
+	fields := g.struct_field_info[c_type]
+	if fields.len == 0 {
+		return g.unsupported('ORM `sql`: row type `${table_name}` has no fields')
+	}
+	mut out := "mut __orm_table := orm.Table{ name: '${table_name}' }\n"
+	out += 'mut __orm_data := orm.QueryData{}\n'
+	for i, field in fields {
+		if field.is_skip {
+			// `@[skip]` fields are not persisted, mirroring V's ORM.
+			continue
+		}
+		out += "__orm_data.fields << '${field.name}'\n"
+		// An enum field is persisted as its integer backing.
+		field_value := if g.is_enum_type_name(field.typ) {
+			'int(${value_source}.${field.name})'
+		} else {
+			'${value_source}.${field.name}'
+		}
+		// Box the field value through an intermediate declaration: a cast on a
+		// declaration's right-hand side is boxed into the `orm.Primitive` sum type,
+		// whereas a cast nested directly in the `<<` append renders as a raw C cast.
+		out += '__orm_value_${i} := orm.Primitive(${field_value})\n'
+		out += '__orm_data.data << __orm_value_${i}\n'
+	}
+	out += '${db_source}.insert(__orm_table, __orm_data)${trailing}\n'
+	return out
+}
+
+// fastc_orm_parse_table_op scans `<op> table <Table>` and returns the row type name.
+// Shared by `create` and `drop`.
+fn (g &Parser) fastc_orm_parse_table_op(block_source string, op string) !string {
+	mut file_set := token.FileSet.new()
+	mut file := file_set.add_file('orm_${op}', block_source.len)
+	file.index_lines_without_digest(block_source)
+	mut s := scanner.new_scanner(g.prefs, .normal)
+	s.init(file, block_source)
+	mut tok := s.scan()
+	for tok == .semicolon {
+		tok = s.scan()
+	}
+	if tok != .name || s.lit != op {
+		return g.unsupported('ORM `sql`: expected `${op}`')
+	}
+	tok = s.scan()
+	if tok != .name || s.lit != 'table' {
+		return g.unsupported('ORM `sql`: expected `table` in `${op}`')
+	}
+	tok = s.scan()
+	if tok != .name {
+		return g.unsupported('ORM `sql`: expected a row type after `table`')
+	}
+	return s.lit
+}
+
+// build_orm_create emits the V source for `create table <Table>`: it builds an
+// orm.TableField per struct field (name + orm type index; attrs are not yet recorded
+// by FastC, so they are empty) and calls the connection's `create`.
+fn (g &Parser) build_orm_create(db_source string, block_source string, trailing string) !string {
+	table_name := g.fastc_orm_parse_table_op(block_source, 'create')!
+	type_key := fastc_resolve_declared_type_key(g.module_name, table_name, g.imports,
+		g.declared_types) or { return g.unsupported('ORM `sql`: unknown row type `${table_name}`') }
+	c_type := fastc_c_declared_type_name(type_key)
+	fields := g.struct_field_info[c_type]
+	if fields.len == 0 {
+		return g.unsupported('ORM `sql`: row type `${table_name}` has no fields')
+	}
+	mut out := "mut __orm_table := orm.Table{ name: '${table_name}' }\n"
+	out += 'mut __orm_fields := []orm.TableField{}\n'
+	for i, field in fields {
+		if field.is_skip {
+			// `@[skip]` fields are not persisted (no column), mirroring V's ORM.
+			continue
+		}
+		type_idx := fastc_builtin_type_idx(field.typ) or {
+			if field.typ == 'time__Time' {
+				// orm.time_ (-2): the ORM renders this as a DATETIME/timestamp column.
+				-2
+			} else if g.is_enum_type_name(field.typ) {
+				// Enums are stored as their integer backing → an INTEGER column (`int`).
+				8
+			} else {
+				return g.unsupported('ORM `sql`: create field `${field.name}` of type `${field.typ}` is not yet supported')
+			}
+		}
+		out += "__orm_tf_${i} := orm.TableField{ name: '${field.name}', typ: ${type_idx} }\n"
+		out += '__orm_fields << __orm_tf_${i}\n'
+	}
+	out += '${db_source}.create(__orm_table, __orm_fields)${trailing}\n'
+	return out
+}
+
+// build_orm_drop emits the V source for `drop table <Table>`: it builds the Table and
+// calls the connection's `drop`.
+fn (g &Parser) build_orm_drop(db_source string, block_source string, trailing string) !string {
+	table_name := g.fastc_orm_parse_table_op(block_source, 'drop')!
+	mut out := "mut __orm_table := orm.Table{ name: '${table_name}' }\n"
+	out += '${db_source}.drop(__orm_table)${trailing}\n'
+	return out
+}
+
+// fastc_orm_field_zero returns the V zero literal for a column type the select
+// row-parser can unbox from a `Primitive` (scalars, string, `time.Time`), or none for
+// a type it cannot yet handle (other structs, arrays, …).
+// fastc_orm_enum_v_name returns the V type name to cast an integer column value to/from
+// for an enum field (enums are stored as their integer backing in V's ORM), or none if
+// the field is not an enum. A C-qualified name (`mod__Enum`) is respelled `mod.Enum`.
+fn (g &Parser) fastc_orm_enum_v_name(field_typ string) ?string {
+	if !g.is_enum_type_name(field_typ) {
+		return none
+	}
+	return field_typ.replace('__', '.')
+}
+
+fn fastc_orm_field_zero(c_type string) ?string {
+	if c_type == 'string' {
+		return "''"
+	}
+	if c_type in ['f32', 'f64'] {
+		return '0.0'
+	}
+	if c_type == 'bool' {
+		return 'false'
+	}
+	if fastc_primitive_c_type(c_type) != none {
+		return '0'
+	}
+	if c_type == 'time__Time' {
+		return 'time.Time{}'
+	}
+	return none
+}
+
+// fastc_orm_field_match_type returns the V type name to use as the `match` variant
+// when unboxing a column Primitive (`time__Time` → `time.Time`; scalars/string are
+// spelled the same in V and C).
+fn fastc_orm_field_match_type(c_type string) string {
+	if c_type == 'time__Time' {
+		return 'time.Time'
+	}
+	return c_type
+}
+
+// build_orm_select_lowering emits the V source for `select from <Table>`: it builds
+// an orm.SelectConfig, calls the connection's `select` (→ `[][]Primitive`), then
+// parses each row back into a `<Table>` by unboxing every column Primitive to its
+// field type via a `match`. The generated block ends with the `[]<Table>` result as
+// its final statement, so the caller can wrap it as a C statement-expression value.
+fn (g &Parser) build_orm_select_lowering(db_source string, block_source string, trailing string, or_source string) !(string, string) {
+	if trailing != '!' && or_source == '' {
+		return g.unsupported('ORM `sql`: `select` must be unwrapped with `!` or `or { ... }`')
+	}
+	mut file_set := token.FileSet.new()
+	mut file := file_set.add_file('orm_select', block_source.len)
+	file.index_lines_without_digest(block_source)
+	mut s := scanner.new_scanner(g.prefs, .normal)
+	s.init(file, block_source)
+	mut tok := s.scan()
+	for tok == .semicolon {
+		tok = s.scan()
+	}
+	if tok == .key_select {
+		tok = s.scan()
+	} else {
+		return g.unsupported('ORM `sql`: expected `select`')
+	}
+	// Optional aggregate: `select count from ...`.
+	mut is_count := false
+	if tok == .name && s.lit == 'count' {
+		is_count = true
+		tok = s.scan()
+	}
+	// `select [count] from <Table>` — `from` scans as a name.
+	if tok != .name || s.lit != 'from' {
+		return g.unsupported('ORM `sql`: expected `from` in `select`')
+	}
+	tok = s.scan()
+	if tok != .name {
+		return g.unsupported('ORM `sql`: expected a row type after `from`')
+	}
+	table_name := s.lit
+	tok = s.scan()
+	// Optional `where ...` clause (shared with update/delete).
+	where_lines, after_where := g.build_orm_where_lines(mut s, block_source, tok)!
+	tok = after_where
+	// Optional `order by <field> [desc|asc]`.
+	mut order_field := ''
+	mut order_desc := false
+	if tok == .name && s.lit == 'order' {
+		tok = s.scan()
+		if tok != .name || s.lit != 'by' {
+			return g.unsupported('ORM `sql`: expected `by` after `order`')
+		}
+		tok = s.scan()
+		if tok != .name {
+			return g.unsupported('ORM `sql`: expected a field name after `order by`')
+		}
+		order_field = s.lit
+		tok = s.scan()
+		if tok == .name && s.lit == 'desc' {
+			order_desc = true
+			tok = s.scan()
+		} else if tok == .name && s.lit == 'asc' {
+			tok = s.scan()
+		}
+	}
+	// Optional `limit <expr>` / `offset <expr>` (their values ride in the data
+	// QueryData, mirroring V's ORM).
+	mut limit_value := ''
+	mut offset_value := ''
+	if tok == .name && s.lit == 'limit' {
+		tok = s.scan()
+		limit_start := s.pos
+		mut limit_end := s.offset
+		for tok != .eof {
+			if tok == .name && s.lit == 'offset' {
+				break
+			}
+			if tok == .semicolon {
+				break
+			}
+			limit_end = s.offset
+			tok = s.scan()
+		}
+		limit_value = block_source[limit_start..limit_end].trim_space()
+	}
+	if tok == .name && s.lit == 'offset' {
+		tok = s.scan()
+		offset_start := s.pos
+		mut offset_end := s.offset
+		for tok != .eof {
+			if tok == .semicolon {
+				break
+			}
+			offset_end = s.offset
+			tok = s.scan()
+		}
+		offset_value = block_source[offset_start..offset_end].trim_space()
+	}
+	for tok == .semicolon {
+		tok = s.scan()
+	}
+	if tok != .eof {
+		return g.unsupported('ORM `sql`: unsupported clause near the end of `select`')
+	}
+	type_key := fastc_resolve_declared_type_key(g.module_name, table_name, g.imports,
+		g.declared_types) or { return g.unsupported('ORM `sql`: unknown row type `${table_name}`') }
+	c_type := fastc_c_declared_type_name(type_key)
+	fields := g.struct_field_info[c_type]
+	if fields.len == 0 {
+		return g.unsupported('ORM `sql`: row type `${table_name}` has no fields')
+	}
+	// The SelectConfig: a row select names its columns; `count` sets the aggregate.
+	mut out := where_lines
+	out += 'mut __orm_config := orm.SelectConfig{\n'
+	out += "\ttable:   orm.Table{ name: '${table_name}' }\n"
+	if is_count {
+		out += '\taggregate_kind: orm.AggregateKind.count\n'
+	} else {
+		for field in fields {
+			if field.is_skip {
+				continue
+			}
+			if g.is_enum_type_name(field.typ) {
+				continue
+			}
+			if fastc_orm_field_zero(field.typ) == none {
+				return g.unsupported('ORM `sql`: select field `${field.name}` of type `${field.typ}` is not yet supported')
+			}
+		}
+		mut field_list := []string{}
+		for field in fields {
+			if field.is_skip {
+				// `@[skip]` fields are not columns, mirroring V's ORM.
+				continue
+			}
+			field_list << "'${field.name}'"
+		}
+		out += '\tfields:  [${field_list.join(', ')}]\n'
+	}
+	out += "\tprimary: 'id'\n"
+	if order_field != '' {
+		out += '\thas_order:  true\n'
+		out += "\torder:      '${order_field}'\n"
+		out += '\torder_type: orm.OrderType.${if order_desc { 'desc' } else { 'asc' }}\n'
+	}
+	if limit_value != '' {
+		out += '\thas_limit:  true\n'
+	}
+	if offset_value != '' {
+		out += '\thas_offset: true\n'
+	}
+	out += '}\n'
+	// The result: a `[]<Table>` for a row select, or an `int` for `count`.
+	result_c_type := if is_count { 'int' } else { fastc_array_c_type(c_type) }
+	empty_init := if is_count { '0' } else { '[]${table_name}{}' }
+	// The success-branch body that turns `__orm_rows` (`[][]Primitive`) into the result.
+	mut build := ''
+	if is_count {
+		build += 'if __orm_rows.len > 0 {\n'
+		build += '\t__orm_row0 := __orm_rows[0]\n'
+		build += '\tif __orm_row0.len > 0 {\n'
+		build += '\t\t__orm_cnt := __orm_row0[0]\n'
+		build += '\t\t__orm_result = match __orm_cnt { int { __orm_cnt } i64 { int(__orm_cnt) } else { 0 } }\n'
+		build += '\t}\n'
+		build += '}\n'
+	} else {
+		// Unbox each column Primitive via a `match` on a plain local (the subject must
+		// be a local for the smart-cast), then build the row via a struct literal so no
+		// immutable field is mutated.
+		build += 'for __orm_row in __orm_rows {\n'
+		mut inits := []string{}
+		// `col` tracks the DB column index, which counts only persisted (non-`@[skip]`)
+		// fields; a skipped field consumes no column and is left at its zero value in the
+		// row literal.
+		mut col := 0
+		for field in fields {
+			if field.is_skip {
+				continue
+			}
+			if enum_name := g.fastc_orm_enum_v_name(field.typ) {
+				// An enum column is stored as an integer; cast it back to the enum.
+				build += '\t__orm_col_${col} := __orm_row[${col}]\n'
+				build += '\t__orm_field_${col} := match __orm_col_${col} { int { ${enum_name}(__orm_col_${col}) } i64 { ${enum_name}(int(__orm_col_${col})) } else { ${enum_name}(0) } }\n'
+				inits << '${field.name}: __orm_field_${col}'
+				col++
+				continue
+			}
+			zero := fastc_orm_field_zero(field.typ) or {
+				return g.unsupported('ORM `sql`: select field `${field.name}` unsupported')
+			}
+			match_type := fastc_orm_field_match_type(field.typ)
+			build += '\t__orm_col_${col} := __orm_row[${col}]\n'
+			build += '\t__orm_field_${col} := match __orm_col_${col} { ${match_type} { __orm_col_${col} } else { ${zero} } }\n'
+			inits << '${field.name}: __orm_field_${col}'
+			col++
+		}
+		build += '\t__orm_item := ${table_name}{ ${inits.join(', ')} }\n'
+		build += '\t__orm_result << __orm_item\n'
+		build += '}\n'
+	}
+	out += 'mut __orm_result := ${empty_init}\n'
+	// The data QueryData carries the limit/offset values (limit first), if any.
+	out += 'mut __orm_select_data := orm.QueryData{}\n'
+	if limit_value != '' {
+		out += '__orm_limit_val := orm.Primitive(${limit_value})\n'
+		out += '__orm_select_data.data << __orm_limit_val\n'
+	}
+	if offset_value != '' {
+		out += '__orm_offset_val := orm.Primitive(${offset_value})\n'
+		out += '__orm_select_data.data << __orm_offset_val\n'
+	}
+	if trailing == '!' {
+		// `!` propagates a query error to the caller.
+		out += '__orm_rows := ${db_source}.select(__orm_config, __orm_select_data, __orm_where)!\n'
+		out += build
+	} else {
+		// `or { <expr> }` uses the fallback value when the query fails.
+		out += 'if __orm_rows := ${db_source}.select(__orm_config, __orm_select_data, __orm_where) {\n'
+		out += build
+		out += '} else {\n'
+		if fastc_orm_or_source_starts_with_exit(or_source, g.prefs) {
+			// A diverging fallback belongs to the containing function/loop; emitting it
+			// after an assignment (`result = return ...`) produces invalid V and C.
+			out += '\t${or_source}\n'
+		} else {
+			out += '\t__orm_result = ${or_source}\n'
+		}
+		out += '}\n'
+	}
+	return out, result_c_type
+}
+
+fn fastc_orm_or_source_starts_with_exit(source string, prefs &pref.Preferences) bool {
+	mut file_set := token.FileSet.new()
+	mut file := file_set.add_file('orm_or', source.len)
+	file.index_lines_without_digest(source)
+	mut s := scanner.new_scanner(prefs, .normal)
+	s.init(file, source)
+	return s.scan() in [.key_return, .key_break, .key_continue]
+}
+
+// capture_orm_or_block consumes an `or { <expr> }` unwrap after a `sql { ... }` block
+// (if present) and returns the block's source (the fallback value expression). An
+// absent `or` returns ''. The `!` unwrap is captured separately by capture_orm_sql_block.
+fn (mut g Parser) capture_orm_or_block() !string {
+	if g.tok != .key_or {
+		return ''
+	}
+	g.next() // consume `or`
+	if g.tok != .lcbr {
+		return g.unsupported('ORM `sql`: expected `{` after `or`')
+	}
+	g.next() // consume `{`
+	block_start := g.s.pos
+	mut depth := 0
+	mut block_end := -1
+	for g.tok != .eof {
+		if g.tok == .lcbr {
+			depth++
+		} else if g.tok == .rcbr {
+			if depth == 0 {
+				block_end = g.s.pos
+				break
+			}
+			depth--
+		}
+		g.next()
+	}
+	if block_end < 0 {
+		return g.unsupported('ORM `sql`: unterminated `or` block')
+	}
+	source := g.s.src[block_start..block_end]
+	g.next() // consume `}`
+	return source.trim_space()
+}
+
+// emit_orm_lowering_statements re-scans generated ORM lowering V (which builds the
+// query and its result into `__orm_result`) as ordinary statements, writing to the
+// live `g.out`. The scanner/token state is saved and restored around the swap.
+fn (mut g Parser) emit_orm_lowering_statements(lowering string) ! {
+	saved_tok := g.tok
+	saved_lit := g.lit
+	saved_s := g.s
+	outer_locals := g.locals.clone()
+	mut file_set := token.FileSet.new()
+	mut file := file_set.add_file('orm_lowering', lowering.len)
+	file.index_lines_without_digest(lowering)
+	g.s = scanner.new_scanner(g.prefs, .normal)
+	g.s.init(file, lowering)
+	g.next()
+	for g.tok != .eof {
+		g.parse_statement()!
+		g.skip_semicolons()
+	}
+	g.locals = outer_locals.clone()
+	g.s = saved_s
+	g.tok = saved_tok
+	g.lit = saved_lit
+}
+
+// parse_orm_sql_select_declaration lowers `<name> := sql db { select ... } <unwrap>`.
+// It declares `<name>` (a `[]<Table>` or `int` for `count`), then emits the lowering
+// (which builds the result into `__orm_result`) inside a fresh C block that assigns
+// `__orm_result` to `<name>`.
+fn (mut g Parser) parse_orm_sql_select_declaration(name string, is_mut bool) ! {
+	if 'orm' !in g.imports && g.module_name != 'orm' {
+		return g.unsupported('ORM `sql` expressions (comptime query generation is unavailable)')
+	}
+	// Consume `sql` so the scanner sits on the connection expression, matching the
+	// statement path (`parse_orm_sql_statement`) that `capture_orm_sql_block` expects.
+	g.next()
+	db_source, block_source, trailing := g.capture_orm_sql_block()!
+	or_source := g.capture_orm_or_block()!
+	lowering, result_type := g.build_orm_select_lowering(db_source, block_source, trailing,
+		or_source)!
+	g.consume_statement_end()
+	// The `[]<Table>` result array is often not otherwise constructed in the program,
+	// so register it as a composite type to force its `Array_<Table>` typedef.
+	fastc_register_composite_type(result_type, mut g.composite_types)
+	c_name := fastc_c_identifier(name)
+	g.write_line('${result_type} ${c_name};')
+	g.write_line('{')
+	g.indent++
+	g.emit_orm_lowering_statements(lowering)!
+	g.write_line('${c_name} = __orm_result;')
+	g.indent--
+	g.write_line('}')
+	g.locals[name] = FastcLocal{
+		is_mut: is_mut
+		typ:    result_type
+	}
+}
+
+// parse_orm_sql_select_assignment lowers `<name> = sql db { select ... } <unwrap>`
+// (assignment to an existing target), emitting the lowering into a fresh C block that
+// assigns `__orm_result` to `<name>`.
+fn (mut g Parser) parse_orm_sql_select_assignment(name string) ! {
+	if 'orm' !in g.imports && g.module_name != 'orm' {
+		return g.unsupported('ORM `sql` expressions (comptime query generation is unavailable)')
+	}
+	g.next() // consume `sql`
+	db_source, block_source, trailing := g.capture_orm_sql_block()!
+	or_source := g.capture_orm_or_block()!
+	lowering, result_type := g.build_orm_select_lowering(db_source, block_source, trailing,
+		or_source)!
+	g.consume_statement_end()
+	fastc_register_composite_type(result_type, mut g.composite_types)
+	c_name := fastc_c_identifier(name)
+	g.write_line('{')
+	g.indent++
+	g.emit_orm_lowering_statements(lowering)!
+	g.write_line('${c_name} = __orm_result;')
+	g.indent--
+	g.write_line('}')
+}
+
+// parse_orm_sql_select_return lowers `return sql db { select ... } <unwrap>`: it emits
+// the lowering into a fresh C block and returns `__orm_result` from it.
+fn (mut g Parser) parse_orm_sql_select_return() !bool {
+	if 'orm' !in g.imports && g.module_name != 'orm' {
+		return g.unsupported('ORM `sql` expressions (comptime query generation is unavailable)')
+	}
+	g.next() // consume `sql`
+	db_source, block_source, trailing := g.capture_orm_sql_block()!
+	or_source := g.capture_orm_or_block()!
+	lowering, result_type := g.build_orm_select_lowering(db_source, block_source, trailing,
+		or_source)!
+	g.consume_statement_end()
+	g.write_line('{')
+	g.indent++
+	g.emit_orm_lowering_statements(lowering)!
+	g.write_all_deferred_scopes()
+	return_source := if g.return_type == 'Option' {
+		fastc_option_success_expression(result_type, '__orm_result')
+	} else {
+		'__orm_result'
+	}
+	g.write_line('return ${return_source};')
+	g.indent--
+	g.write_line('}')
+	return true
 }

--- a/vlib/v3/gen/fastc/str_intp.v
+++ b/vlib/v3/gen/fastc/str_intp.v
@@ -3,6 +3,159 @@ module fastc
 import strings
 import v3.token
 
+// fastc_default_struct_str_name returns the C name of an auto-generated default `str()`
+// for the struct/union `c_type` — V's `Type{\n    field: value\n ...}` format — used when
+// a struct with no user `str()` is interpolated. The function (and any nested struct
+// fields' defaults) is generated into g.spawn_helpers on first use. Returns none if
+// `c_type` is not a struct/union.
+fn (g &Parser) can_generate_default_struct_str(c_type string) bool {
+	key := g.semantic_type_key(c_type.trim_right('*'))
+	return key in g.declared_kinds && g.declared_kinds[key] in [.struct_, .union_]
+}
+
+fn (mut g Parser) fastc_default_struct_str_name(c_type string) ?string {
+	key := g.semantic_type_key(c_type)
+	// A missing key defaults to `.struct_` (the zero enum value), so require it to be
+	// present before treating `c_type` as a struct.
+	if key !in g.declared_kinds || g.declared_kinds[key] !in [.struct_, .union_] {
+		return none
+	}
+	c_name := fastc_c_declared_type_name(key)
+	fn_name := 'v_fastc_default_str_${c_name}'
+	if fn_name in g.spawn_helpers {
+		return fn_name
+	}
+	// Reserve the name first so a self-referential field does not recurse forever.
+	g.spawn_helpers[fn_name] = ''
+	g.protos.writeln('string ${fn_name}(${c_name} it);')
+	display := c_name.all_after_last('__')
+	mut body := 'string ${fn_name}(${c_name} it) {\n'
+	body += '\tstring res = _S("${display}{\\n");\n'
+	for field in g.struct_field_info[c_name] {
+		c_field := fastc_c_identifier(field.name)
+		formatted := g.fastc_struct_field_str_expression('it.${c_field}', field.typ) or {
+			'_S("<${field.typ}>")'
+		}
+		body += '\tres = builtin__string_plus(res, _S("    ${field.name}: "));\n'
+		body += '\tres = builtin__string_plus(res, ${formatted});\n'
+		body += '\tres = builtin__string_plus(res, _S("\\n"));\n'
+	}
+	body += '\tres = builtin__string_plus(res, _S("}"));\n'
+	body += '\treturn res;\n}'
+	g.spawn_helpers[fn_name] = body
+	return fn_name
+}
+
+// fastc_fixed_array_str_name returns a helper that renders a fixed array in V's
+// `[item, item]` form. Fixed-array struct fields use raw C array storage, while
+// locals use FastC's wrapper; the caller passes either representation as an element
+// pointer, so the helper itself is shared by both forms.
+fn (mut g Parser) fastc_fixed_array_str_name(c_type string) ?string {
+	array_type := fastc_normalize_inferred_type(c_type).trim_right('*')
+	element_type := fastc_fixed_array_element_type(array_type) or { return none }
+	length_source := fastc_fixed_array_length(array_type) or { return none }
+	length := g.fixed_array_length_value(length_source) or { return none }
+	fn_name := 'v_fastc_fixed_array_str_${fastc_composite_type_part(array_type)}'
+	if fn_name in g.spawn_helpers {
+		return fn_name
+	}
+	// Reserve the name before formatting elements so nested formatting cannot
+	// register the same helper recursively.
+	g.spawn_helpers[fn_name] = ''
+	g.protos.writeln('string ${fn_name}(${element_type} *it);')
+	mut body := 'string ${fn_name}(${element_type} *it) {\n'
+	body += '\tstring res = _S("[");\n'
+	for index in 0 .. length {
+		formatted := g.fastc_struct_field_str_expression('it[${index}]', element_type) or {
+			g.spawn_helpers.delete(fn_name)
+			return none
+		}
+		if index > 0 {
+			body += '\tres = builtin__string_plus(res, _S(", "));\n'
+		}
+		body += '\tres = builtin__string_plus(res, ${formatted});\n'
+	}
+	body += '\treturn builtin__string_plus(res, _S("]"));\n}'
+	g.spawn_helpers[fn_name] = body
+	return fn_name
+}
+
+// fastc_array_str_name returns a helper that renders a dynamic array using the
+// element type retained in FastC's `Array_T` spelling.
+fn (mut g Parser) fastc_array_str_name(c_type string) ?string {
+	array_type := fastc_normalize_inferred_type(c_type).trim_right('*')
+	if !array_type.starts_with('Array_') {
+		return none
+	}
+	element_type := fastc_array_element_type(array_type) or { return none }
+	fn_name := 'v_fastc_array_str_${fastc_composite_type_part(array_type)}'
+	if fn_name in g.spawn_helpers {
+		return fn_name
+	}
+	g.spawn_helpers[fn_name] = ''
+	g.protos.writeln('string ${fn_name}(${array_type} it);')
+	index := '__v_fastc_array_str_index'
+	element := '(*(${element_type} *)builtin__array_get(it, ${index}))'
+	formatted := g.fastc_struct_field_str_expression(element, element_type) or {
+		g.spawn_helpers.delete(fn_name)
+		return none
+	}
+	mut body := 'string ${fn_name}(${array_type} it) {\n'
+	body += '\tstring res = _S("[");\n'
+	body += '\tfor (int ${index} = 0; ${index} < it.len; ${index}++) {\n'
+	body += '\t\tif (${index} > 0) res = builtin__string_plus(res, _S(", "));\n'
+	body += '\t\tres = builtin__string_plus(res, ${formatted});\n'
+	body += '\t}\n'
+	body += '\treturn builtin__string_plus(res, _S("]"));\n}'
+	g.spawn_helpers[fn_name] = body
+	return fn_name
+}
+
+// fastc_struct_field_str_expression returns a C string expression that renders a struct
+// field value `value_c` of C type `field_c_type` for the default `str()`: a string is
+// single-quoted, a type with a `str()` method (user or builtin, e.g. `int`) calls it, an
+// enum uses its name table, and a nested struct recurses. Returns none if unrenderable.
+fn (mut g Parser) fastc_struct_field_str_expression(value_c string, field_c_type string) ?string {
+	ft := fastc_normalize_inferred_type(field_c_type)
+	if ft == 'string' {
+		// A single-quote C literal, built without `\'`/`\"` escapes (a self-host str_intp
+		// hazard) by concatenating literal pieces.
+		q := '_S("' + "'" + '")'
+		return 'builtin__string_plus(builtin__string_plus(${q}, ${value_c}), ${q})'
+	}
+	if element_type := fastc_fixed_array_element_type(ft.trim_right('*')) {
+		if helper := g.fastc_fixed_array_str_name(ft) {
+			return '${helper}((${element_type} *)(${value_c}))'
+		}
+	}
+	if ft.trim_right('*').starts_with('Array_') {
+		if helper := g.fastc_array_str_name(ft) {
+			value := if ft.ends_with('*') { '*(${value_c})' } else { value_c }
+			return '${helper}(${value})'
+		}
+	}
+	key := g.semantic_type_key(ft)
+	if method_signature := g.functions['${key}.str'] {
+		expected_receiver := method_signature.parameter_types[0]
+		receiver := if expected_receiver.ends_with('*') && !ft.ends_with('*') {
+			'&(${value_c})'
+		} else if !expected_receiver.ends_with('*') && ft.ends_with('*') {
+			'*(${value_c})'
+		} else {
+			value_c
+		}
+		return '${fastc_method_c_name(method_signature.module_name,
+			fastc_c_declared_type_name(key), 'str')}(${receiver})'
+	}
+	if g.declared_kinds[key] == .enum_ {
+		return 'v_fastc_enum_str_${fastc_c_declared_type_name(key)}(${value_c})'
+	}
+	if nested := g.fastc_default_struct_str_name(ft) {
+		return '${nested}(${value_c})'
+	}
+	return none
+}
+
 fn (mut g Parser) read_interpolated_string() !string {
 	first_literal := g.lit
 	mut raw := first_literal
@@ -70,6 +223,26 @@ fn (mut g Parser) read_interpolated_string() !string {
 			} else {
 				value
 			}
+		} else if element_type := fastc_fixed_array_element_type(interpolation_type.trim_right('*')) {
+			helper := g.fastc_fixed_array_str_name(interpolation_type) or {
+				return g.unsupported('interpolation of fixed array type `${value_type}`')
+			}
+			is_member_array := value_tokens.len >= 3 && value_tokens.last().tok == .name
+				&& value_tokens[value_tokens.len - 2].tok == .dot
+			is_global_array := value_tokens.len == 1 && value_tokens[0].tok == .name
+				&& fastc_global_key(g.module_name, value_tokens[0].lit) in g.globals
+			data_source := if is_member_array || is_global_array {
+				value
+			} else {
+				'(${value}).data'
+			}
+			parts << '${helper}((${element_type} *)(${data_source}))'
+		} else if interpolation_type.trim_right('*').starts_with('Array_') {
+			helper := g.fastc_array_str_name(interpolation_type) or {
+				return g.unsupported('interpolation of array type `${value_type}`')
+			}
+			array_value := if interpolation_type.ends_with('*') { '*(${value})' } else { value }
+			parts << '${helper}(${array_value})'
 		} else if g.declared_kinds[g.semantic_type_key(interpolation_type)] == .enum_ {
 			enum_key := g.semantic_type_key(interpolation_type)
 			is_unsigned := g.enum_flags[enum_key]
@@ -116,7 +289,22 @@ fn (mut g Parser) read_interpolated_string() !string {
 			if !converted_primitive {
 				receiver_key := g.semantic_type_key(interpolation_type)
 				method_key := '${receiver_key}.str'
-				method_signature := g.functions[method_key] or {
+				if method_signature := g.functions[method_key] {
+					expected_receiver := method_signature.parameter_types[0]
+					receiver := if expected_receiver.ends_with('*')
+						&& !interpolation_type.ends_with('*') {
+						'&(${value})'
+					} else if !expected_receiver.ends_with('*') && interpolation_type.ends_with('*') {
+						'*(${value})'
+					} else {
+						value
+					}
+					parts << '${fastc_method_c_name(method_signature.module_name,
+						fastc_c_declared_type_name(receiver_key), 'str')}(${receiver})'
+				} else if default_name := g.fastc_default_struct_str_name(interpolation_type) {
+					// No user `str()`: emit V's default `Type{...}` representation.
+					parts << '${default_name}(${value})'
+				} else {
 					local_type := if g.last_expression.len > 0 && g.last_expression[0].tok == .name {
 						local := g.locals[g.last_expression[0].lit] or { FastcLocal{} }
 						local.typ
@@ -125,8 +313,6 @@ fn (mut g Parser) read_interpolated_string() !string {
 					}
 					return g.unsupported('interpolation of type `${value_type}` for `${fastc_expression_tokens_debug(g.last_expression)}` (local `${local_type}`)')
 				}
-				parts << '${fastc_method_c_name(method_signature.module_name,
-					fastc_c_declared_type_name(receiver_key), 'str')}(${value})'
 			}
 		}
 		if g.tok == .string {
@@ -342,7 +528,11 @@ fn fastc_c_string(literal string) !string {
 		return error('interpolated or unfinished fastc string literal')
 	}
 	content := raw[1..raw.len - 1]
-	if fastc_string_contains_nul(content, is_raw) {
+	// A `\x00`/`\000` NUL escape renders to the octal escape `\000`, and the `_S` macro's
+	// `sizeof`-based length preserves it (V strings are length-prefixed, not
+	// NUL-terminated). Other NUL spellings (a raw NUL byte, single `\0`, wrapping octal
+	// like `\400`, unicode ` `) cannot be emitted faithfully, so reject just those.
+	if fastc_string_has_unrenderable_nul(content, is_raw) {
 		return error('fastc parser does not support embedded NUL string literals')
 	}
 	mut result := strings.new_builder(raw.len + 2)
@@ -491,6 +681,54 @@ fn fastc_hex_digit_value(c u8) !u8 {
 		return u8(c - `A` + 10)
 	}
 	return error('invalid fastc hex digit `${c.ascii_str()}`')
+}
+
+// fastc_string_has_unrenderable_nul reports whether the literal content holds a NUL
+// that fastc_c_string cannot faithfully emit: a raw NUL byte, or a NUL escape other
+// than `\x00`/`\000` (single `\0`, a wrapping octal like `\400`, or a unicode
+// ` `/`\U00000000`). `\x00`/`\000` render to the stable octal escape `\000`.
+fn fastc_string_has_unrenderable_nul(content string, is_raw bool) bool {
+	for byte_index in 0 .. content.len {
+		if content[byte_index] == 0 {
+			return true
+		}
+	}
+	if is_raw {
+		return false
+	}
+	mut i := 0
+	for i + 1 < content.len {
+		if content[i] != `\\` {
+			i++
+			continue
+		}
+		escape := content[i + 1]
+		if escape == `\\` {
+			i += 2
+			continue
+		}
+		if escape >= `0` && escape <= `7` && i + 3 < content.len && content[i + 2] >= `0`
+			&& content[i + 2] <= `7` && content[i + 3] >= `0` && content[i + 3] <= `7` {
+			high := int(escape - `0`)
+			middle := int(content[i + 2] - `0`)
+			low := int(content[i + 3] - `0`)
+			value := high * 64 + middle * 8 + low
+			// `\000` (value 0) renders fine; a wrapping octal like `\400` becomes NUL
+			// but cannot be re-spelled as a stable C escape.
+			if value != 0 && u8(value) == 0 {
+				return true
+			}
+			i += 4
+			continue
+		}
+		if escape == `0`
+			|| (escape == `u` && i + 5 < content.len && content[i + 2..i + 6] == '0000')
+			|| (escape == `U` && i + 9 < content.len && content[i + 2..i + 10] == '00000000') {
+			return true
+		}
+		i += 2
+	}
+	return false
 }
 
 fn fastc_string_contains_nul(content string, is_raw bool) bool {

--- a/vlib/v3/gen/fastc/types.v
+++ b/vlib/v3/gen/fastc/types.v
@@ -27,6 +27,7 @@ fn fastc_method_receiver_start(tokens []FastcExpressionToken, dot int) int {
 	}
 	mut parens := 0
 	mut brackets := 0
+	mut braces := 0
 	mut start := dot - 1
 	for start >= 0 {
 		tok := tokens[start].tok
@@ -34,22 +35,36 @@ fn fastc_method_receiver_start(tokens []FastcExpressionToken, dot int) int {
 			parens++
 		} else if tok == .rsbr {
 			brackets++
+		} else if tok == .rcbr {
+			braces++
 		} else if tok == .lpar {
-			if parens == 0 && brackets == 0 {
+			if parens == 0 && brackets == 0 && braces == 0 {
 				return start + 1
 			}
 			parens--
 		} else if tok == .lsbr {
-			if brackets == 0 && parens == 0 {
+			if brackets == 0 && parens == 0 && braces == 0 {
 				return start + 1
 			}
 			brackets--
-		} else if parens == 0 && brackets == 0 && tok in [.amp, .and, .mul] && start + 2 < dot
-			&& tokens[start + 1].tok == .name && tokens[start + 2].tok == .lpar
+		} else if tok == .lcbr {
+			// A balanced struct-literal `{ ... }` is part of the receiver (`T{...}.m()`);
+			// only an UNMATCHED `{` (e.g. an enclosing block) stops the scan.
+			if braces == 0 && parens == 0 && brackets == 0 {
+				return start + 1
+			}
+			braces--
+		} else if parens == 0 && brackets == 0 && braces == 0 && tok in [.amp, .and, .mul]
+			&& start + 2 < dot && tokens[start + 1].tok == .name && tokens[start + 2].tok == .lpar
 			&& fastc_token_is_prefix_operator(tokens, start) {
 			return start
-		} else if parens == 0 && brackets == 0 && (tok.is_assignment()
-			|| tok in [.comma, .semicolon, .colon, .ellipsis, .plus, .minus, .mul, .div, .mod, .amp, .pipe, .xor, .left_shift, .right_shift, .right_shift_unsigned, .eq, .ne, .gt, .lt, .ge, .le, .and, .logical_or, .not, .bit_not, .lcbr]) {
+		} else if parens == 0 && brackets == 0 && braces == 0 && tok == .not && start > 0
+			&& tokens[start - 1].tok in [.rpar, .rsbr, .name, .number, .string] {
+			// A postfix `!` (result propagation) follows a value and is part of the
+			// receiver (`f()!.m()`); keep scanning into the underlying call. A prefix `!`
+			// (negation) is not preceded by a value and falls to the stop below.
+		} else if parens == 0 && brackets == 0 && braces == 0 && (tok.is_assignment()
+			|| tok in [.comma, .semicolon, .colon, .ellipsis, .plus, .minus, .mul, .div, .mod, .amp, .pipe, .xor, .left_shift, .right_shift, .right_shift_unsigned, .eq, .ne, .gt, .lt, .ge, .le, .and, .logical_or, .not, .bit_not]) {
 			return start + 1
 		}
 		start--
@@ -103,6 +118,12 @@ fn fastc_call_arguments(tokens []FastcExpressionToken, open int, close int) ![][
 	}
 	call_args << tokens[start..close]
 	return call_args
+}
+
+fn fastc_call_has_one_argument(tokens []FastcExpressionToken, open int) bool {
+	close := fastc_matching_rpar(tokens, open) or { return false }
+	arguments := fastc_call_arguments(tokens, open, close) or { return false }
+	return arguments.len == 1
 }
 
 fn fastc_boolean_operator_precedence(tok token.Token) int {
@@ -176,7 +197,10 @@ fn (g &Parser) infer_boolean_binary_expression_type(tokens []FastcExpressionToke
 		right_type := g.type_from_expression_tokens(right_tokens) or {
 			return g.unsupported('type test `${operator.str()}` with an undeclared target type')
 		}
-		if g.semantic_type_key(right_type) !in g.declared_types {
+		if g.semantic_type_key(right_type) !in g.declared_types && !right_type.starts_with('Array_')
+			&& !right_type.starts_with('Map_') {
+			// Composite variants (`x is []string` / `x is map[…]`) are not declared
+			// types but do get generated `__v_typeid_` tags, so allow them.
 			return g.unsupported('type test `${operator.str()}` with undeclared type `${right_type}`')
 		}
 		return 'bool'
@@ -196,7 +220,7 @@ fn (g &Parser) infer_boolean_binary_expression_type(tokens []FastcExpressionToke
 			return 'bool'
 		}
 		if right_type.trim_right('*').starts_with('Map_') {
-			_, _ := fastc_map_key_value_types(right_type) or {
+			_, _ := g.map_key_value_types(right_type) or {
 				return g.unsupported('membership `${operator.str()}` with unverifiable map type `${right_type}`')
 			}
 		} else if right_type.trim_right('*') == 'string' {
@@ -243,6 +267,25 @@ fn (g &Parser) infer_boolean_binary_expression_type(tokens []FastcExpressionToke
 	return 'bool'
 }
 
+// fastc_typeof_generic_field_type returns the type of `typeof[T]().idx` (int) or
+// `typeof[T]().name` (string), or none if the tokens are not that shape.
+fn fastc_typeof_generic_field_type(tokens []FastcExpressionToken) ?string {
+	if tokens.len < 8 || tokens[0].lit != 'typeof' || tokens[1].tok != .lsbr {
+		return none
+	}
+	close_bracket := fastc_matching_delimiter(tokens, 1, .lsbr, .rsbr) or { return none }
+	if close_bracket + 4 != tokens.len - 1 || tokens[close_bracket + 1].tok != .lpar
+		|| tokens[close_bracket + 2].tok != .rpar || tokens[close_bracket + 3].tok != .dot
+		|| tokens[tokens.len - 1].tok != .name {
+		return none
+	}
+	return match tokens[tokens.len - 1].lit {
+		'idx' { 'int' }
+		'name' { 'string' }
+		else { none }
+	}
+}
+
 fn (g &Parser) infer_expression_type(tokens []FastcExpressionToken) !string {
 	if tokens.len == 0 {
 		return ''
@@ -260,9 +303,22 @@ fn (g &Parser) infer_expression_type(tokens []FastcExpressionToken) !string {
 	if start >= end {
 		return ''
 	}
+	if end - start == 1 && tokens[start].tok == .name && tokens[start].typ != ''
+		&& tokens[start].source != '' {
+		// A synthetic token carrying its own rendered `source` and recorded `typ` (e.g. an
+		// or-unwrap `({ ... })` produced for `(expr or {…}).method()`): trust its recorded
+		// type rather than looking the name up as a local variable.
+		return tokens[start].typ
+	}
 	if end - start >= 4 && tokens[start].tok == .key_sizeof && tokens[start + 1].tok == .lpar
 		&& tokens[end - 1].tok == .rpar {
 		return 'int'
+	}
+	if reflection_type := fastc_typeof_generic_field_type(tokens[start..end]) {
+		return reflection_type
+	}
+	if c_field_type := g.infer_c_pointer_cast_member_type(tokens[start..end]) {
+		return c_field_type
 	}
 	if tokens[start].tok == .not {
 		_ = g.infer_expression_type(tokens[start + 1..end])!
@@ -398,13 +454,34 @@ fn (g &Parser) infer_expression_type(tokens []FastcExpressionToken) !string {
 		if element_type == '' {
 			return ''
 		}
+		if array_end < end {
+			return fastc_fixed_array_type('${items.len}', element_type)
+		}
 		return fastc_array_c_type(element_type)
 	}
 	if start + 1 < end && tokens[start].tok == .name && tokens[start + 1].tok == .lcbr {
-		if type_key := fastc_resolve_declared_type_key(g.module_name, tokens[start].lit, g.imports,
-			g.declared_types)
-		{
-			return fastc_c_declared_type_name(type_key)
+		if close := fastc_matching_delimiter(tokens[start..end], 1, .lcbr, .rcbr) {
+			if close == end - start - 1 {
+				if type_key := fastc_resolve_declared_type_key(g.module_name, tokens[start].lit,
+					g.imports, g.declared_types)
+				{
+					return fastc_c_declared_type_name(type_key)
+				}
+			}
+		}
+	}
+	if start + 3 < end && tokens[start].tok == .name && tokens[start + 1].tok == .dot
+		&& tokens[start + 2].tok == .name && tokens[start + 3].tok == .lcbr {
+		// A module-qualified struct literal `mod.Type{...}`.
+		if imported_module := g.imports[tokens[start].lit] {
+			if close := fastc_matching_delimiter(tokens[start..end], 3, .lcbr, .rcbr) {
+				if close == end - start - 1 {
+					type_key := fastc_type_key(imported_module, tokens[start + 2].lit)
+					if type_key in g.declared_types {
+						return fastc_c_declared_type_name(type_key)
+					}
+				}
+			}
 		}
 	}
 	mut call_name_index := start
@@ -415,16 +492,27 @@ fn (g &Parser) infer_expression_type(tokens []FastcExpressionToken) !string {
 		call_name_index = start + 2
 		call_open_index = start + 3
 	}
-	if call_open_index < end && tokens[call_name_index].tok == .name
+	if call_open_index < end && tokens[call_name_index].tok in [.name, .key_select]
 		&& tokens[call_open_index].tok == .lpar {
 		if close := fastc_matching_rpar(tokens[start..end], call_open_index - start) {
 			if close == end - start - 1 {
 				name := tokens[call_name_index].lit
 				function_key := g.function_key_for_call(tokens, call_name_index)
-				if signature := g.functions[function_key] {
+				signature := if function_key in g.functions {
+					g.functions[function_key]
+				} else {
+					g.mono_functions[function_key] or { FastcFunctionSignature{} }
+				}
+				if signature.return_type != '' {
 					return signature.return_type
 				}
 				if call_name_index == start {
+					if local := g.locals[name] {
+						if local.fn_return_type != '' {
+							// Calling a function-pointer parameter (`f(x)`).
+							return local.fn_return_type
+						}
+					}
 					if primitive := fastc_primitive_c_type(name) {
 						return primitive
 					}
@@ -434,9 +522,20 @@ fn (g &Parser) infer_expression_type(tokens []FastcExpressionToken) !string {
 						return fastc_c_declared_type_name(type_key)
 					}
 				}
-				if call_name_index == start + 2 && tokens[start].lit == 'C' && name.len > 0
-					&& name[0].is_capital() {
-					return name
+				if call_name_index == start + 2 && tokens[start].lit in g.imports {
+					module_name := g.imports[tokens[start].lit]
+					type_key := fastc_type_key(module_name, name)
+					if type_key in g.declared_types {
+						return fastc_c_declared_type_name(type_key)
+					}
+				}
+				if call_name_index == start + 2 && tokens[start].lit == 'C' {
+					if '#Cstruct#${name}' in g.declared_types {
+						return 'struct ${name}'
+					}
+					if name.len > 0 && name[0].is_capital() {
+						return name
+					}
 				}
 				return ''
 			}
@@ -462,7 +561,7 @@ fn (g &Parser) infer_expression_type(tokens []FastcExpressionToken) !string {
 			}
 			return value_type
 		}
-		function_key := g.method_function_key(receiver_type, tokens[i].lit)
+		function_key, _ := g.resolve_method(receiver_type, tokens[i].lit)
 		if static_key := g.static_function_key_for_call(tokens, i) {
 			if signature := g.functions[static_key] {
 				return signature.return_type
@@ -470,6 +569,14 @@ fn (g &Parser) infer_expression_type(tokens []FastcExpressionToken) !string {
 		}
 		if signature := g.functions[function_key] {
 			return g.specialized_method_return_type(receiver_type, function_key, signature)
+		}
+		if field := g.struct_field_metadata(receiver_type, tokens[i].lit) {
+			if function_alias := g.functions[field.typ] {
+				return function_alias.return_type
+			}
+		}
+		if tokens[i].lit == 'str' && g.can_generate_default_struct_str(receiver_type) {
+			return 'string'
 		}
 	}
 	if end - start >= 3 && tokens[end - 2].tok == .dot && tokens[end - 1].tok == .name {
@@ -536,10 +643,16 @@ fn (g &Parser) infer_expression_type(tokens []FastcExpressionToken) !string {
 		if open_index > start {
 			base_type := g.infer_expression_type(tokens[start..open_index])!
 			if fastc_expression_tokens_contain(tokens[open_index + 1..end - 1], .dotdot) {
+				// Slicing a fixed array yields a dynamic array of its element type.
+				if base_type.trim_right('*').starts_with('FixedArray_') {
+					if element := g.array_element_type(base_type.trim_right('*')) {
+						return fastc_array_c_type(fastc_normalize_inferred_type(element))
+					}
+				}
 				return base_type
 			}
 			if base_type.trim_right('*').starts_with('Map_') {
-				_, value_type := fastc_map_key_value_types(base_type) or { return '' }
+				_, value_type := g.map_key_value_types(base_type) or { return '' }
 				return value_type
 			}
 			if base_type.ends_with('*') {
@@ -675,6 +788,26 @@ fn (g &Parser) infer_expression_type(tokens []FastcExpressionToken) !string {
 	return ''
 }
 
+fn (g &Parser) infer_c_pointer_cast_member_type(tokens []FastcExpressionToken) ?string {
+	if tokens.len < 9 || tokens[0].tok !in [.amp, .and] || tokens[1].tok != .name
+		|| tokens[1].lit != 'C' || tokens[2].tok != .dot || tokens[3].tok != .name
+		|| tokens[4].tok != .lpar {
+		return none
+	}
+	close := fastc_matching_rpar(tokens, 4) or { return none }
+	if close + 2 >= tokens.len || tokens[close + 1].tok != .dot || tokens[close + 2].tok != .name
+		|| close + 3 != tokens.len {
+		return none
+	}
+	c_name := tokens[3].lit
+	c_type := if '#Cstruct#${c_name}' in g.declared_types { 'struct ${c_name}' } else { c_name }
+	field_type := g.struct_member_type(c_type + '*', tokens[close + 2].lit)
+	if field_type == '' {
+		return none
+	}
+	return field_type
+}
+
 fn (g &Parser) indexed_array_operand_type(tokens []FastcExpressionToken, inferred_type string) ?string {
 	if tokens.len < 3 || !fastc_expression_tokens_contain(tokens, .lsbr)
 		|| tokens.last().tok != .rsbr {
@@ -699,6 +832,7 @@ fn (g &Parser) infer_member_access_type(tokens []FastcExpressionToken) ?string {
 	} else {
 		return none
 	}
+	mut member_path := tokens[0].lit
 	mut index := 1
 	for index < tokens.len {
 		if tokens[index].tok == .lsbr {
@@ -708,10 +842,16 @@ fn (g &Parser) infer_member_access_type(tokens []FastcExpressionToken) ?string {
 					&& g.array_element_type(current_type) == none {
 					return none
 				}
+				// A fixed-array slice becomes a dynamic array of its element type.
+				if current_type.trim_right('*').starts_with('FixedArray_') {
+					if element := g.array_element_type(current_type.trim_right('*')) {
+						current_type = fastc_array_c_type(fastc_normalize_inferred_type(element))
+					}
+				}
 			} else if current_type.trim_right('*') == 'string' {
 				current_type = 'u8'
 			} else if current_type.trim_right('*').starts_with('Map_') {
-				_, value_type := fastc_map_key_value_types(current_type) or { return none }
+				_, value_type := g.map_key_value_types(current_type) or { return none }
 				current_type = value_type
 			} else if current_type.ends_with('*') {
 				current_type = current_type.trim_right('*')
@@ -724,9 +864,14 @@ fn (g &Parser) infer_member_access_type(tokens []FastcExpressionToken) ?string {
 		if index + 1 >= tokens.len || tokens[index].tok != .dot || tokens[index + 1].tok != .name {
 			return none
 		}
-		current_type = g.struct_member_type(current_type, tokens[index + 1].lit)
+		field_name := tokens[index + 1].lit
+		current_type = g.struct_member_type(current_type, field_name)
 		if current_type == '' {
 			return none
+		}
+		member_path += '.' + field_name
+		if smartcast := g.member_smartcasts[member_path] {
+			current_type = smartcast.typ
 		}
 		index += 2
 	}
@@ -933,16 +1078,31 @@ fn fastc_is_pointer_type(typ string) bool {
 fn fastc_array_element_type(typ string) ?string {
 	base := typ.trim_right('*')
 	if base.starts_with('Array_') && base.len > 'Array_'.len {
-		element := base['Array_'.len..]
-		return if element == 'char_ptr' { 'char*' } else { element }
+		return fastc_decode_ptr_element_type(base['Array_'.len..])
 	}
 	if base.starts_with('FixedArray_') && base.len > 'FixedArray_'.len {
 		if element_type := fastc_fixed_array_element_type(base) {
 			return element_type
 		}
-		return base['FixedArray_'.len..]
+		return fastc_decode_ptr_element_type(base['FixedArray_'.len..])
 	}
 	return none
+}
+
+// fastc_decode_ptr_element_type reverses the `*`→`_ptr` composite-name encoding for an
+// array/channel element: `Stream_ptr` (not a real C type) → `Stream*`, `char_ptr` →
+// `char*`. Non-pointer element names are returned unchanged.
+fn fastc_decode_ptr_element_type(element string) string {
+	mut name := element
+	mut pointers := 0
+	for name.ends_with('_ptr') {
+		name = name[..name.len - '_ptr'.len]
+		pointers++
+	}
+	if pointers == 0 {
+		return element
+	}
+	return name + '*'.repeat(pointers)
 }
 
 fn (g &Parser) array_element_type(typ string) ?string {

--- a/vlib/v3/gen/fastc/validate.v
+++ b/vlib/v3/gen/fastc/validate.v
@@ -2,7 +2,7 @@ module fastc
 
 import v3.token
 
-fn (g &Parser) expression_token(previous token.Token, previous_lit string, qualified_name_owner string) !string {
+fn (g &Parser) expression_token(previous token.Token, previous_lit string, qualified_name_owner string, module_separator bool) !string {
 	return match g.tok {
 		.name {
 			g.expression_name(previous, qualified_name_owner)!
@@ -62,18 +62,7 @@ fn (g &Parser) expression_token(previous token.Token, previous_lit string, quali
 			';'
 		}
 		.dot {
-			if previous == .name && previous_lit == 'C' {
-				''
-			} else if previous == .name && previous_lit in g.imports {
-				'__'
-			} else if g.selfhost && previous == .name && g.local_is_pointer(previous_lit) {
-				'->'
-			} else if g.selfhost && previous == .name && previous_lit !in g.locals
-				&& g.is_enum_type_name(previous_lit) {
-				'__'
-			} else {
-				'.'
-			}
+			g.dot_piece(previous, previous_lit, module_separator)
 		}
 		else {
 			g.tok.str()
@@ -82,7 +71,7 @@ fn (g &Parser) expression_token(previous token.Token, previous_lit string, quali
 }
 
 fn (g &Parser) nil_expression() !string {
-	if g.unsafe_depth == 0 {
+	if g.unsafe_depth == 0 && !g.in_mono_drain {
 		return g.unsupported('`nil` outside an `unsafe` block')
 	}
 	return 'NULL'
@@ -205,10 +194,19 @@ fn (g &Parser) function_key_for_call(tokens []FastcExpressionToken, name_index i
 			return 'C.${tokens[name_index].lit}'
 		}
 		if imported_module := g.imports[tokens[name_index - 2].lit] {
-			return fastc_function_key(imported_module, tokens[name_index].lit)
+			return fastc_function_key(g.resolve_module_alias(imported_module),
+				tokens[name_index].lit)
 		}
 	}
 	return g.unqualified_function_key(tokens[name_index].lit)
+}
+
+// resolve_module_alias maps an import path that re-exports another module (via an
+// `@[alias]` module file, e.g. `json2` importable as `x.json2`) to the module name
+// its functions were actually loaded/keyed under. Empty when no aliases exist (so
+// the self-host, which imports no aliased modules, is unaffected).
+fn (g &Parser) resolve_module_alias(module_name string) string {
+	return g.module_aliases[module_name] or { module_name }
 }
 
 fn (g &Parser) static_function_key_for_call(tokens []FastcExpressionToken, name_index int) ?string {
@@ -310,7 +308,7 @@ fn (g &Parser) declared_cast_type_key(tokens []FastcExpressionToken, name_index 
 fn (g &Parser) validate_expression_calls(tokens []FastcExpressionToken) ! {
 	mut i := 0
 	for i + 1 < tokens.len {
-		if tokens[i].tok != .name || tokens[i + 1].tok != .lpar {
+		if tokens[i].tok !in [.name, .key_select] || tokens[i + 1].tok != .lpar {
 			i++
 			continue
 		}
@@ -329,17 +327,58 @@ fn (g &Parser) validate_expression_calls(tokens []FastcExpressionToken) ! {
 		mut is_method_call := false
 		mut has_method_receiver := false
 		mut receiver_type := ''
-		if !is_static_call && i >= 2 && tokens[i - 1].tok == .dot && !(tokens[i - 2].tok == .name
-			&& (tokens[i - 2].lit in g.imports || tokens[i - 2].lit == 'C')) {
+		// `mod.func()` is a module-qualified call, NOT a method — but only when `mod` is a
+		// bare module reference. `recv.mod.method()` (a FIELD named like an imported module,
+		// e.g. `c.ssl.set_read_timeout()` where `ssl` is both a field and `import net.ssl`)
+		// is a real method call, so the import exclusion must not apply when the name is
+		// itself preceded by a `.` (a member access).
+		name_is_module_ref := i >= 2 && tokens[i - 2].tok == .name
+			&& (tokens[i - 2].lit in g.imports || tokens[i - 2].lit == 'C')
+			&& (i < 3 || tokens[i - 3].tok != .dot)
+		if !is_static_call && i >= 2 && tokens[i - 1].tok == .dot && !name_is_module_ref {
 			receiver_start := fastc_method_receiver_start(tokens, i - 1)
 			receiver_type = g.infer_expression_type(tokens[receiver_start..i - 1])!
 			if receiver_type != '' {
 				has_method_receiver = true
-				function_key = g.method_function_key(receiver_type, name)
+				function_key, _ = g.resolve_method(receiver_type, name)
 				is_method_call = function_key in g.functions
+				if !is_method_call && function_key in g.mono_functions {
+					// An on-demand monomorphized generic method (queued during rendering): its
+					// per-Parser signature is a minimal stub, so accept the call and skip the
+					// detailed arg validation (the concrete instance is emitted in the drain).
+					i = call_end + 1
+					continue
+				}
 			}
 		}
-		if signature := g.functions[function_key] {
+		// A primitive type name applied to a single argument is a cast (`u32(1)`),
+		// never a call — even when a same-named function exists (e.g. `rand.u32()`).
+		if call_args.len == 1 && !is_method_call && !is_static_call
+			&& (i == 0 || tokens[i - 1].tok != .dot) && fastc_primitive_c_type(name) != none {
+			i = call_end + 1
+			continue
+		}
+		// A declared type applied to one argument is a cast even when a function-pointer
+		// alias has a signature entry for calls through locals of that type.
+		if !is_method_call && !is_static_call {
+			if type_key := g.declared_cast_type_key(tokens, i) {
+				if call_args.len != 1 {
+					return g.unsupported('cast `${name}` with ${call_args.len} arguments')
+				}
+				if g.declared_kinds[type_key] == .interface_ {
+					g.validate_interface_cast_shape(type_key, call_args[0])!
+				}
+				i = call_end + 1
+				continue
+			}
+		}
+		has_signature := function_key in g.functions || function_key in g.mono_functions
+		if has_signature {
+			signature := if function_key in g.functions {
+				g.functions[function_key]
+			} else {
+				g.mono_functions[function_key]
+			}
 			if !signature.is_public && signature.module_name != ''
 				&& signature.module_name != g.module_name && signature.module_name != 'builtin'
 				&& signature.module_name in g.imports.values() {
@@ -354,9 +393,24 @@ fn (g &Parser) validate_expression_calls(tokens []FastcExpressionToken) ! {
 			}
 			omits_params_struct := signature.last_parameter_is_params && expected_arguments > 0
 				&& call_args.len == expected_arguments - 1
+			// Trailing named arguments (`name: value`) at the last params-struct
+			// position collapse into one struct initializer, so they read as one arg.
+			mut named_argument_start := -1
+			for argument_index, argument in call_args {
+				if argument.len >= 2 && argument[0].tok == .name && argument[1].tok == .colon {
+					named_argument_start = argument_index
+					break
+				}
+			}
+			// Trailing named args collapse into the callee's last struct parameter — V allows
+			// this for any struct last-parameter (`time.new(year: ...)`), not just `@[params]`.
+			provides_params_struct := expected_arguments > 0
+				&& named_argument_start == expected_arguments - 1
+				&& (signature.last_parameter_is_params
+				|| g.fastc_type_is_declared_struct(signature.parameter_types[named_argument_start + argument_offset]))
 			uses_default_array_sort := function_key == 'array.sort' && call_args.len == 0
 			if (!is_variadic && call_args.len != expected_arguments && !omits_params_struct
-				&& !uses_default_array_sort)
+				&& !provides_params_struct && !uses_default_array_sort)
 				|| (is_variadic && call_args.len < expected_arguments) {
 				return g.unsupported('function `${name}` call with ${call_args.len} arguments instead of ${expected_arguments}')
 			}
@@ -420,13 +474,10 @@ fn (g &Parser) validate_expression_calls(tokens []FastcExpressionToken) ! {
 				i = call_end + 1
 				continue
 			}
-			if type_key := g.declared_cast_type_key(tokens, i) {
-				if call_args.len != 1 {
-					return g.unsupported('cast `${name}` with ${call_args.len} arguments')
-				}
-				if g.declared_kinds[type_key] == .interface_ {
-					g.validate_interface_cast_shape(type_key, call_args[0])!
-				}
+			if g.selfhost && (i == 0 || tokens[i - 1].tok != .dot) && name in g.locals {
+				// Calling a local/parameter that holds a function pointer (`cb(x, y)`), e.g.
+				// vqsort's `sort_cb`: a plain identifier that is a local can only be called
+				// through its function-pointer value, which renders as a direct C call.
 				i = call_end + 1
 				continue
 			}
@@ -449,6 +500,11 @@ fn (g &Parser) validate_expression_calls(tokens []FastcExpressionToken) ! {
 				if call_args.len != 0 {
 					return g.unsupported('`.wait()` on a spawned thread with ${call_args.len} arguments')
 				}
+				i = call_end + 1
+				continue
+			}
+			if g.selfhost && has_method_receiver && name == 'str' && call_args.len == 0
+				&& g.can_generate_default_struct_str(receiver_type) {
 				i = call_end + 1
 				continue
 			}
@@ -492,6 +548,15 @@ fn fastc_mut_argument_root_name(argument []FastcExpressionToken) string {
 }
 
 fn (g &Parser) validate_mutating_method_receiver(receiver []FastcExpressionToken, method_name string) ! {
+	// A pointer receiver (a `&T` field/local, e.g. a `&sync.Mutex` guarded by an
+	// immutable `&Struct` param) already carries mutable access to its pointee, so a
+	// `mut`-receiver method call through it is valid regardless of the root variable's
+	// mutability.
+	if receiver_type := g.infer_expression_type(receiver) {
+		if receiver_type.ends_with('*') {
+			return
+		}
+	}
 	root_name := fastc_mut_argument_root_name(receiver)
 	if root_name == '' || root_name == 'C' {
 		return g.unsupported('unverifiable mutating method `${method_name}` receiver')
@@ -710,7 +775,12 @@ fn (g &Parser) validate_expression_mutation_lvalue(tokens []FastcExpressionToken
 		receiver_start := fastc_method_receiver_start(lvalue, i)
 		receiver_type := g.infer_expression_type(lvalue[receiver_start..i]) or { continue }
 		field := g.struct_field_metadata(receiver_type, lvalue[i + 1].lit) or { continue }
-		if !field.is_mutable && item.unsafe_depth == 0 && !selfhost_pointer_root {
+		// A late generic specialization may be a reflection setter (for example
+		// json2's `$for field in T.fields { value.$(field.name) = ... }`). V permits
+		// that generated assignment even when the concrete field is not declared
+		// `mut`; the specialization therefore needs the same privilege as its private
+		// field access above.
+		if !field.is_mutable && item.unsafe_depth == 0 && !selfhost_pointer_root && !g.in_mono_drain {
 			type_name := g.semantic_type_key(receiver_type).all_after_last('.')
 			return g.unsupported('mutation of immutable field `${type_name}.${field.name}`')
 		}
@@ -761,6 +831,13 @@ fn (g &Parser) struct_field_metadata(receiver_type string, field_name string) ?F
 		if !field.name.starts_with('__embedded_') {
 			continue
 		}
+		// Accessing the embed itself by its type name (`d.SilentStreamingDownloader`):
+		// resolve to the `__embedded_N` field, keeping its concrete type.
+		if field.typ == field_name || field.typ.all_after_last('__') == field_name {
+			// The `__embedded_N` field IS the target; its name already renders the
+			// access, so return it as-is (no extra storage path).
+			return field
+		}
 		if embedded := g.struct_field_metadata(field.typ, field_name) {
 			mut promoted := embedded
 			mut storage_path := [field.name]
@@ -772,8 +849,68 @@ fn (g &Parser) struct_field_metadata(receiver_type string, field_name string) ?F
 	return none
 }
 
+// dot_piece renders a `.` in the token stream: `__` for a module/enum separator,
+// the embedded-struct access path for `local.embedded_field` (so `ss.pos` becomes
+// `ss->__embedded_0.pos`), or the ordinary `->`/`.` for a pointer/value receiver.
+fn (g &Parser) dot_piece(previous token.Token, previous_lit string, module_separator bool) string {
+	if module_separator {
+		return if previous_lit == 'C' { '' } else { '__' }
+	}
+	if g.selfhost && previous == .name && previous_lit in g.locals {
+		promoted := g.embedded_dot_piece_for_local(previous_lit)
+		if promoted != '' {
+			return promoted
+		}
+		if g.local_is_pointer(previous_lit) {
+			return '->'
+		}
+		return '.'
+	}
+	return '.'
+}
+
+// embedded_dot_piece_for_local promotes `receiver.field` through embedded structs.
+// The scanner is positioned just past the `.`, so the field name is the next token.
+// Returns '' when the field is a direct member or cannot be resolved.
+fn (g &Parser) embedded_dot_piece_for_local(receiver_name string) string {
+	local := g.locals[receiver_name] or { return '' }
+	if local.typ == '' {
+		return ''
+	}
+	mut look := g.s
+	if look.scan() != .name {
+		return ''
+	}
+	return g.embedded_field_dot_piece_for_type(local.typ, look.lit)
+}
+
+// embedded_field_dot_piece_for_type returns the C separator-and-path that replaces
+// the `.` in `receiver.field` when `field` is reached through embedded structs (e.g.
+// `->__embedded_0.`), or '' when `field` is a direct member (or unknown). The field
+// name itself is emitted by the caller after this separator.
+fn (g &Parser) embedded_field_dot_piece_for_type(receiver_type string, field_name string) string {
+	field := g.struct_field_metadata(receiver_type, field_name) or { return '' }
+	if field.storage_path.len == 0 {
+		return ''
+	}
+	mut current_type := receiver_type
+	mut piece := ''
+	for storage_name in field.storage_path {
+		separator := if current_type.ends_with('*') { '->' } else { '.' }
+		piece += separator + fastc_c_identifier(storage_name)
+		current_type = g.struct_direct_member_type(current_type, storage_name)
+		if current_type == '' {
+			return ''
+		}
+	}
+	piece += if current_type.ends_with('*') { '->' } else { '.' }
+	return piece
+}
+
 fn (g &Parser) struct_field_is_visible(field FastcStructField) bool {
-	return field.is_public || field.module_name in ['', g.module_name]
+	// A compiler-generated generic specialization keeps V's reflection privileges:
+	// json2's `$for field in T.fields` may access private fields of the concrete caller type.
+	return g.in_mono_drain || field.is_public || field.module_name in ['', g.module_name]
 }
 
 fn (g &Parser) validate_expression_field_visibility(tokens []FastcExpressionToken) ! {


### PR DESCRIPTION
## Summary

- extend the v3 FastC real-builtin path to handle the generics, comptime reflection, options/results, interfaces, arrays, C interop, ORM lowering, threading, and veb template constructs used by gitly
- add on-demand generic monomorphization and preserve generated-template dependencies during function reachability pruning
- pass source C flags through the FastC drivers and add the macOS SDK search paths needed by TinyCC
- document the expanded FastC flag support and add focused regression coverage

## Validation

- `./v -g -keepc -o ./vnew cmd/v`
- `V3_FASTC_KEEP_FAILED_C=/tmp/gitly-fastc-final-failed-136.c ./vnew -b fastc -d fastc_real_builtin -d sqlite -keepc -o /tmp/gitly_fastc_final /Users/alex/code/gitly/main.v`
- verified `/tmp/gitly_fastc_final` is an executable arm64 Mach-O binary
- formatted all touched V files with `./vnew fmt -w`
- `./vnew check-md vlib/v3/README.md`
- `git diff --check`

Large test suites were not run per request.