### PR TITLE
v3: address FastC review feedback

### DIFF
--- a/vlib/v3/gen/fastc/anonfn.v
+++ b/vlib/v3/gen/fastc/anonfn.v
@@ -1,62 +1,8 @@
 module fastc
 
-// read_anonymous_function_stub parses a function literal / closure
-// (`fn [captures] (params) ret { body }`) in expression position and lowers it to a
-// COMPILE-ONLY stub: a top-level function of the matching signature whose body is
-// dropped. This lets code that stores or passes a closure value (e.g. net/http's H2
-// transport `close_transport`, which is captured and invoked later) compile and link.
-// FastC has no closure runtime — capturing the enclosing environment through an escaping
-// function pointer needs per-arch thunks — so the stub is non-functional, mirroring the
-// channel stubs. Returns `&name` (the stub's address, a function-pointer value) so a
-// `:=` declaration infers a proper C function-pointer type via `__typeof__`.
-fn (mut g Parser) read_anonymous_function_stub() !string {
-	g.next() // consume `fn`
-	// Skip an optional capture list `[a, mut b, ...]`.
-	if g.tok == .lsbr {
-		g.skip_balanced(.lsbr, .rsbr)!
-	}
-	// Parse the parameters for the stub signature. parse_parameters registers the params
-	// as locals; isolate them so the enclosing scope is unaffected.
-	saved_locals := g.locals.clone()
-	g.expect(.lpar)!
-	params := g.parse_parameters()!
-	mut return_type := 'void'
-	if g.tok != .lcbr && g.tok != .semicolon {
-		if g.tok in [.not, .question] {
-			g.next()
-			return_type = 'Option'
-			if g.tok in [.lcbr, .semicolon] {
-			} else if g.tok == .lpar {
-				_ := g.parse_multi_return_types()!
-			} else {
-				_ := g.parse_type()!
-			}
-		} else if g.tok == .lpar {
-			_ := g.parse_multi_return_types()!
-			return_type = 'MultiReturn'
-		} else {
-			return_type = g.parse_type()!
-		}
-	}
-	g.locals = saved_locals.clone()
-	// Drop the body.
-	g.skip_balanced(.lcbr, .rcbr)!
-	// Emit a uniquely-named stub function. The name folds in the enclosing
-	// module/receiver/function (unique per definition) plus a per-file counter, so two
-	// closures anywhere in the program never collide in the shared helper map.
-	g.anon_fn_counter++
-	stem :=
-		fastc_c_function_name_for_key('${g.module_name}.${g.current_receiver}.${g.current_function}')
-	name := '${stem}__anonfn_${g.anon_fn_counter}'
-	c_params := if params.len == 0 { 'void' } else { params.join(', ') }
-	body_return := if return_type == 'void' {
-		''
-	} else if return_type.ends_with('*') {
-		'return 0;'
-	} else {
-		'return (${return_type}){0};'
-	}
-	g.protos.writeln('${return_type} ${name}(${c_params});')
-	g.spawn_helpers[name] = '${return_type} ${name}(${c_params}) { ${body_return} }'
-	return '&${name}'
+// reject_anonymous_function rejects a function literal before any of its body is
+// discarded. FastC has no closure runtime, so emitting a callable stub would silently
+// change program behavior.
+fn (mut g Parser) reject_anonymous_function() !string {
+	return g.unsupported('function literals and closures')
 }

--- a/vlib/v3/gen/fastc/expr.v
+++ b/vlib/v3/gen/fastc/expr.v
@@ -42,7 +42,9 @@ fn (g &Parser) current_call_has_one_argument() bool {
 			.lcbr { braces++ }
 			.rcbr { braces-- }
 			.semicolon {}
-			else { saw_argument = true }
+			else {
+				saw_argument = true
+			}
 		}
 	}
 	return false
@@ -95,8 +97,7 @@ fn fastc_or_operand_token_start(tokens []FastcExpressionToken) int {
 			}
 			.lpar {
 				if depth == 0 {
-					if i > 0 && tokens[i - 1].tok == .name
-						&& fastc_primitive_c_type(tokens[i - 1].lit) != none {
+					if i > 0 && tokens[i - 1].tok == .name && fastc_primitive_c_type(tokens[i - 1].lit) != none {
 						return 0
 					}
 					return if nearest_comma >= 0 { nearest_comma + 1 } else { i + 1 }
@@ -114,8 +115,7 @@ fn fastc_or_operand_token_start(tokens []FastcExpressionToken) int {
 					nearest_comma = i
 				}
 			}
-			.plus, .minus, .mul, .div, .mod, .amp, .pipe, .xor, .left_shift, .right_shift,
-			.right_shift_unsigned, .eq, .ne, .gt, .lt, .ge, .le, .and, .logical_or {
+			.plus, .minus, .mul, .div, .mod, .amp, .pipe, .xor, .left_shift, .right_shift, .right_shift_unsigned, .eq, .ne, .gt, .lt, .ge, .le, .and, .logical_or {
 				if depth == 0 {
 					return i + 1
 				}
@@ -146,8 +146,8 @@ fn fastc_trailing_not_marks_fixed_array_literal(tokens []FastcExpressionToken) b
 	if open == 0 {
 		return true
 	}
-	return open > 0
-		&& tokens[open - 1].tok in [.lpar, .comma, .assign, .decl_assign, .key_in, .not_in, .plus, .minus, .mul, .div, .mod, .amp, .pipe, .xor, .and, .logical_or]
+	return open > 0 && tokens[open - 1].tok in [.lpar, .comma, .assign, .decl_assign, .key_in,
+		.not_in, .plus, .minus, .mul, .div, .mod, .amp, .pipe, .xor, .and, .logical_or]
 }
 
 fn (mut g Parser) read_expression(stops []token.Token) !string {
@@ -184,8 +184,7 @@ fn (mut g Parser) read_expression_with_prefix_mode(prefix string, stops []token.
 	defer {
 		g.expression_depth--
 	}
-	return g.read_expression_with_prefix_mode_impl(prefix, stops, allow_mutation_statement,
-		allow_declaration_guard)
+	return g.read_expression_with_prefix_mode_impl(prefix, stops, allow_mutation_statement, allow_declaration_guard)
 }
 
 fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []token.Token, allow_mutation_statement bool, allow_declaration_guard bool) !string {
@@ -221,8 +220,8 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 	if prefix.len > 0 {
 		result.write_string(g.resolved_expression_name(prefix, .unknown))
 		expression_tokens << FastcExpressionToken{
-			tok:          .name
-			lit:          prefix
+			tok: .name
+			lit: prefix
 			unsafe_depth: g.unsafe_depth
 		}
 	}
@@ -297,10 +296,8 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 			mut lookahead := g.s
 			if lookahead.scan() == .name {
 				higher_order_method := lookahead.lit
-				if higher_order_method in ['map', 'filter', 'any', 'all', 'count']
-					&& lookahead.scan() == .lpar {
-					receiver_start := fastc_method_receiver_start(expression_tokens,
-						expression_tokens.len)
+				if higher_order_method in ['map', 'filter', 'any', 'all', 'count'] && lookahead.scan() == .lpar {
+					receiver_start := fastc_method_receiver_start(expression_tokens, expression_tokens.len)
 					receiver_tokens := expression_tokens[receiver_start..]
 					receiver_type := g.infer_expression_type(receiver_tokens) or { '' }
 					// Array-literal receivers (`[.a, .b].map(...)`) do not round-trip
@@ -317,8 +314,7 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 						mut receiver_source := ''
 						if receiver_tokens[0].tok == .lsbr && receiver_tokens.last().tok == .rsbr {
 							raw := g.render_raw_expression_tokens(receiver_tokens) or { '' }
-							items := fastc_expression_list_items(receiver_tokens, 1,
-								receiver_tokens.len - 1) or {
+							items := fastc_expression_list_items(receiver_tokens, 1, receiver_tokens.len - 1) or {
 								return g.unsupported('`.${higher_order_method}` array-literal receiver')
 							}
 							norm_element := fastc_normalize_inferred_type(element_type)
@@ -326,8 +322,7 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 							g.expected_expression_type = element_type
 							mut rendered_items := []string{cap: items.len}
 							for item in items {
-								rendered_items << g.render_call_argument_expression(item,
-									element_type) or {
+								rendered_items << g.render_call_argument_expression(item, element_type) or {
 									g.expected_expression_type = previous_expected
 									return g.unsupported('`.${higher_order_method}` array-literal element')
 								}
@@ -415,10 +410,8 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 				// `arr.sort(a.x < b.x)`: generate a comparator function (`a`/`b` are the two
 				// elements) keyed by element type + comparison, and lower to sort_with_compare.
 				// `.sort()` (no argument) keeps its existing builtin lowering (the `!= .rpar`).
-				if higher_order_method == 'sort' && lookahead.scan() == .lpar
-					&& lookahead.scan() != .rpar {
-					receiver_start := fastc_method_receiver_start(expression_tokens,
-						expression_tokens.len)
+				if higher_order_method == 'sort' && lookahead.scan() == .lpar && lookahead.scan() != .rpar {
+					receiver_start := fastc_method_receiver_start(expression_tokens, expression_tokens.len)
 					receiver_tokens := expression_tokens[receiver_start..]
 					receiver_type := g.infer_expression_type(receiver_tokens) or { '' }
 					if receiver_type.starts_with('Array_') {
@@ -476,9 +469,9 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 						result.write_string(lowered)
 						expression_tokens = expression_tokens[..receiver_start].clone()
 						expression_tokens << FastcExpressionToken{
-							tok:          .name
-							lit:          lowered
-							typ:          'void'
+							tok: .name
+							lit: lowered
+							typ: 'void'
 							is_statement: true
 						}
 						previous_token = .name
@@ -490,23 +483,39 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 				}
 			}
 		}
-		if g.selfhost && expression_tokens.len > 0 && paren_depth == 0 && bracket_depth == 0
-			&& brace_depth == 0 && unsafe_expression_depth == 0 && g.tok == .mul
-			&& g.s.src[previous_token_end..g.s.pos].contains('\n') {
+		if g.selfhost && expression_tokens.len > 0 && paren_depth == 0 && bracket_depth == 0 && brace_depth == 0 && unsafe_expression_depth == 0 && g.tok == .mul && g.s.src[previous_token_end..g.s.pos].contains('\n') {
 			mut lookahead := g.s
 			if lookahead.scan() == .name && lookahead.scan().is_assignment() {
 				break
 			}
 		}
-		if expression_tokens.len > 0 && paren_depth == 0 && bracket_depth == 0 && brace_depth == 0
-			&& unsafe_expression_depth == 0 && previous_token in [.inc, .dec]
-			&& g.s.src[previous_token_end..g.s.pos].contains('\n') {
+		if expression_tokens.len > 0 && paren_depth == 0 && bracket_depth == 0 && brace_depth == 0 && unsafe_expression_depth == 0 && previous_token in [
+			.inc,
+			.dec,
+		] && g.s.src[previous_token_end..g.s.pos].contains('\n') {
 			break
 		}
-		if g.tok in [.key_if, .key_unsafe] && expression_tokens.len > 0 && paren_depth == 0
-			&& bracket_depth == 0 && brace_depth == 0 && unsafe_expression_depth == 0
-			&& previous_token !in [.plus, .minus, .mul, .div, .mod, .amp, .pipe, .xor, .and, .logical_or, .eq, .ne, .lt, .gt, .le, .ge, .comma, .lpar, .lsbr]
-			&& g.s.src[previous_token_end..g.s.pos].contains('\n') {
+		if g.tok in [.key_if, .key_unsafe] && expression_tokens.len > 0 && paren_depth == 0 && bracket_depth == 0 && brace_depth == 0 && unsafe_expression_depth == 0 && previous_token !in [
+			.plus,
+			.minus,
+			.mul,
+			.div,
+			.mod,
+			.amp,
+			.pipe,
+			.xor,
+			.and,
+			.logical_or,
+			.eq,
+			.ne,
+			.lt,
+			.gt,
+			.le,
+			.ge,
+			.comma,
+			.lpar,
+			.lsbr,
+		] && g.s.src[previous_token_end..g.s.pos].contains('\n') {
 			break
 		}
 		if g.tok == .key_unsafe {
@@ -547,14 +556,13 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 			}
 			interpolation := g.read_interpolated_string()!
 			g.expected_expression_type = previous_expected_type
-			if result.len > 0 && fastc_needs_space(result.last(), interpolation)
-				&& !previous_module_separator {
+			if result.len > 0 && fastc_needs_space(result.last(), interpolation) && !previous_module_separator {
 				result.write_u8(` `)
 			}
 			result.write_string(interpolation)
 			expression_tokens << FastcExpressionToken{
-				tok:    .string
-				lit:    literal
+				tok: .string
+				lit: literal
 				source: interpolation
 			}
 			previous_token = .string
@@ -563,8 +571,7 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 			previous_token_end = g.s.pos
 			continue
 		}
-		if g.selfhost && g.tok == .lcbr && expression_tokens.len >= 2
-			&& expression_tokens[0].tok == .name && expression_tokens[0].lit == 'chan' {
+		if g.selfhost && g.tok == .lcbr && expression_tokens.len >= 2 && expression_tokens[0].tok == .name && expression_tokens[0].lit == 'chan' {
 			g.skip_balanced(.lcbr, .rcbr)!
 			result.go_back(result.len)
 			result.write_string('(chan){0}')
@@ -599,8 +606,8 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 			}
 			result.write_u8(`&`)
 			expression_tokens << FastcExpressionToken{
-				tok:             .amp
-				lit:             '&'
+				tok: .amp
+				lit: '&'
 				is_mut_argument: true
 			}
 			previous_token = .amp
@@ -617,8 +624,7 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 			conditional := g.read_if_expression()!
 			conditional_type := g.last_expression_type
 			g.expected_expression_type = previous_expected_type
-			if result.len > 0 && fastc_needs_space(result.last(), conditional)
-				&& !previous_module_separator {
+			if result.len > 0 && fastc_needs_space(result.last(), conditional) && !previous_module_separator {
 				result.write_u8(` `)
 			}
 			result.write_string(conditional)
@@ -636,8 +642,7 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 		if g.selfhost && g.tok == .key_match {
 			matched := g.read_match_expression()!
 			matched_type := g.last_expression_type
-			if result.len > 0 && fastc_needs_space(result.last(), matched)
-				&& !previous_module_separator {
+			if result.len > 0 && fastc_needs_space(result.last(), matched) && !previous_module_separator {
 				result.write_u8(` `)
 			}
 			result.write_string(matched)
@@ -653,17 +658,14 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 			continue
 		}
 		if g.selfhost && g.tok == .key_fn {
-			// A function literal / closure in expression position (`fn [caps] (args) { … }`).
-			// Lowered to a compile-only stub (see anonfn.v); keep it as one typed atom.
-			anon := g.read_anonymous_function_stub()!
-			if result.len > 0 && fastc_needs_space(result.last(), anon)
-				&& !previous_module_separator {
+			anon := g.reject_anonymous_function()!
+			if result.len > 0 && fastc_needs_space(result.last(), anon) && !previous_module_separator {
 				result.write_u8(` `)
 			}
 			result.write_string(anon)
 			expression_tokens << FastcExpressionToken{
-				tok:    .name
-				lit:    anon
+				tok: .name
+				lit: anon
 				source: anon
 			}
 			previous_token = .name
@@ -675,8 +677,7 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 		if g.selfhost && g.tok == .key_spawn {
 			spawned := g.read_spawn_expression()!
 			spawned_type := g.last_expression_type
-			if result.len > 0 && fastc_needs_space(result.last(), spawned)
-				&& !previous_module_separator {
+			if result.len > 0 && fastc_needs_space(result.last(), spawned) && !previous_module_separator {
 				result.write_u8(` `)
 			}
 			result.write_string(spawned)
@@ -697,8 +698,7 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 			or_expression_is_statement := g.expression_tokens_are_statement(expression_tokens)
 			or_return_types := g.multi_return_types_for_expression(expression_tokens)
 			mut wrapper_parens := 0
-			for wrapper_parens < expression_tokens.len
-				&& expression_tokens[wrapper_parens].tok == .lpar {
+			for wrapper_parens < expression_tokens.len && expression_tokens[wrapper_parens].tok == .lpar {
 				wrapper_parens++
 			}
 			raw_option_buffer := result.str()
@@ -719,9 +719,7 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 			} else {
 				-1
 			}
-			if struct_depths.len > 0 && brace_depth == struct_depths.last()
-				&& field_extra_parens >= 0 && struct_field_value_start > 0
-				&& struct_field_value_start <= raw_option_buffer.len {
+			if struct_depths.len > 0 && brace_depth == struct_depths.last() && field_extra_parens >= 0 && struct_field_value_start > 0 && struct_field_value_start <= raw_option_buffer.len {
 				value_token_start := fastc_struct_field_value_token_start(expression_tokens)
 				// When the field value is wrapped in grouping parens (`f: (x or {…}).m()`),
 				// paren_depth is above the struct's baseline; require the extra depth to be
@@ -729,13 +727,11 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 				// (`f: g(x or {…})`) is left to the operand-scoping path instead.
 				mut field_leading_open := 0
 				if value_token_start > 0 && value_token_start < expression_tokens.len {
-					for value_token_start + field_leading_open < expression_tokens.len
-						&& expression_tokens[value_token_start + field_leading_open].tok == .lpar {
+					for value_token_start + field_leading_open < expression_tokens.len && expression_tokens[value_token_start + field_leading_open].tok == .lpar {
 						field_leading_open++
 					}
 				}
-				if value_token_start > 0 && value_token_start < expression_tokens.len
-					&& (field_extra_parens == 0 || field_leading_open >= field_extra_parens) {
+				if value_token_start > 0 && value_token_start < expression_tokens.len && (field_extra_parens == 0 || field_leading_open >= field_extra_parens) {
 					in_struct_field = true
 					assignment_prefix = raw_option_buffer[..struct_field_value_start]
 					option_expression = raw_option_buffer[struct_field_value_start..].trim_space()
@@ -751,8 +747,7 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 					assignment_depth++
 				} else if assignment_token.tok in [.rpar, .rsbr, .rcbr] {
 					assignment_depth--
-				} else if assignment_depth == 0 && assignment_token.tok.is_assignment() && i > 0
-					&& i + 1 < expression_tokens.len {
+				} else if assignment_depth == 0 && assignment_token.tok.is_assignment() && i > 0 && i + 1 < expression_tokens.len {
 					left_tokens := expression_tokens[..i].clone()
 					left_type := g.infer_expression_type(left_tokens) or { '' }
 					if left_type != '' {
@@ -763,8 +758,7 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 							assignment_prefix = '${left_source}${assignment_token.tok.str()}'
 							value_type = left_type
 							option_tokens = expression_tokens[i + 1..].clone()
-							option_expression = g.render_call_argument_expression(option_tokens,
-								left_type) or { '' }
+							option_expression = g.render_call_argument_expression(option_tokens, left_type) or { '' }
 							wrapper_parens = 0
 						}
 					}
@@ -831,13 +825,10 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 					grouped_paren_count = operand_open
 					stripped_tokens := option_tokens[operand_open..].clone()
 					grouped_value_tokens = stripped_tokens.clone()
-					option_expression = g.render_call_argument_expression(stripped_tokens,
-						value_type) or { option_expression }
+					option_expression = g.render_call_argument_expression(stripped_tokens, value_type) or { option_expression }
 				}
 			}
-			if expression_tokens.len >= 3 && expression_tokens[0].tok == .name
-				&& expression_tokens[1].tok == .lpar
-				&& fastc_primitive_c_type(expression_tokens[0].lit) != none {
+			if expression_tokens.len >= 3 && expression_tokens[0].tok == .name && expression_tokens[1].tok == .lpar && fastc_primitive_c_type(expression_tokens[0].lit) != none {
 				option_tokens = expression_tokens[2..].clone()
 				option_expression = g.render_raw_expression_tokens(option_tokens) or {
 					option_expression
@@ -865,9 +856,7 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 			} else if explicit_generic := g.render_explicit_generic_call_expression(option_tokens) {
 				option_expression = explicit_generic.source
 				option_value_type = g.option_value_type_for_expression(option_tokens)
-			} else if static_call := g.render_static_call_expression(option_tokens,
-				option_expression)
-			{
+			} else if static_call := g.render_static_call_expression(option_tokens, option_expression) {
 				option_expression = static_call.source
 				option_value_type = g.option_value_type_for_expression(option_tokens)
 			} else if call := g.render_missing_call_arguments(option_tokens) {
@@ -875,21 +864,15 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 				// its arguments. This supplies contextual types for array/map literals.
 				option_expression = call.source
 				option_value_type = g.option_value_type_for_expression(option_tokens)
-			} else if method_call := g.render_method_call_expression(option_tokens,
-				option_expression)
-			{
+			} else if method_call := g.render_method_call_expression(option_tokens, option_expression) {
 				option_expression = method_call.source
 				option_value_type = g.option_value_type_for_expression(option_tokens)
 			}
-			if pointer_members := g.render_pointer_member_access_expression(option_tokens,
-				option_expression)
-			{
+			if pointer_members := g.render_pointer_member_access_expression(option_tokens, option_expression) {
 				option_expression = pointer_members.source
 			}
-			outer_cast := assignment_prefix == '' && scoped_operand_prefix == ''
-				&& !scoped_or_operand && option_tokens.len != expression_tokens.len
-			if expression_tokens.len >= 2 && expression_tokens[0].tok == .name
-				&& expression_tokens[1].tok == .lpar {
+			outer_cast := assignment_prefix == '' && scoped_operand_prefix == '' && !scoped_or_operand && option_tokens.len != expression_tokens.len
+			if expression_tokens.len >= 2 && expression_tokens[0].tok == .name && expression_tokens[1].tok == .lpar {
 				value_type = fastc_primitive_c_type(expression_tokens[0].lit) or { value_type }
 				cast_prefix := '((${value_type})('
 				if option_expression.starts_with(cast_prefix) {
@@ -934,8 +917,7 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 				// A primitive cast around the or (`int(f() or {...})`): the result type is the
 				// cast type, and its closing `)` must be consumed (mirrors the single-value
 				// path's `outer_cast` handling below).
-				cast_type := if outer_cast && expression_tokens.len >= 2
-					&& expression_tokens[0].tok == .name && expression_tokens[1].tok == .lpar {
+				cast_type := if outer_cast && expression_tokens.len >= 2 && expression_tokens[0].tok == .name && expression_tokens[1].tok == .lpar {
 					fastc_primitive_c_type(expression_tokens[0].lit) or { '' }
 				} else {
 					''
@@ -983,10 +965,10 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 				if in_struct_field {
 					expression_tokens = struct_field_prefix_tokens.clone()
 					expression_tokens << FastcExpressionToken{
-						tok:          .name
-						lit:          temporary
-						source:       or_expr_body
-						typ:          complex_value_type
+						tok: .name
+						lit: temporary
+						source: or_expr_body
+						typ: complex_value_type
 						is_statement: or_expression_is_statement
 					}
 				} else {
@@ -995,8 +977,8 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 							tok: .name
 							lit: temporary
 							// Carry the rendered `({ ... })` so a trailing `.method()` binds to it.
-							source:       or_expr_body
-							typ:          complex_value_type
+							source: or_expr_body
+							typ: complex_value_type
 							is_statement: or_expression_is_statement
 						},
 					]
@@ -1151,10 +1133,10 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 			if in_struct_field {
 				expression_tokens = struct_field_prefix_tokens.clone()
 				expression_tokens << FastcExpressionToken{
-					tok:          .name
-					lit:          temporary
-					source:       or_expr_body
-					typ:          value_type
+					tok: .name
+					lit: temporary
+					source: or_expr_body
+					typ: value_type
 					is_statement: or_expression_is_statement
 				}
 			} else {
@@ -1170,8 +1152,8 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 					lit: temporary
 					// Carry the rendered `({ ... })` so a trailing `.method()`
 					// (`expr or { v }.str()`) binds to it via render_method_receiver_expression.
-					source:       or_expr_body
-					typ:          value_type
+					source: or_expr_body
+					typ: value_type
 					is_statement: or_expression_is_statement
 				}
 				if value_type == 'void' {
@@ -1199,16 +1181,15 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 			pseudo := g.comptime_pseudo_expression(pseudo_name) or {
 				return g.unsupported('compile-time pseudo value `${pseudo_name}`')
 			}
-			if result.len > 0 && fastc_needs_space(result.last(), pseudo)
-				&& !previous_module_separator {
+			if result.len > 0 && fastc_needs_space(result.last(), pseudo) && !previous_module_separator {
 				result.write_u8(` `)
 			}
 			result.write_string(pseudo)
 			expression_tokens << FastcExpressionToken{
-				tok:    .string
-				lit:    pseudo_name
+				tok: .string
+				lit: pseudo_name
 				source: pseudo
-				typ:    'string'
+				typ: 'string'
 			}
 			previous_token = .string
 			previous_lit = pseudo_name
@@ -1217,8 +1198,8 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 			g.next()
 			continue
 		}
-		if !g.selfhost
-			&& g.tok in [.left_shift, .right_shift, .right_shift_unsigned, .left_shift_assign, .right_shift_assign, .right_shift_unsigned_assign] {
+		if !g.selfhost && g.tok in [.left_shift, .right_shift, .right_shift_unsigned,
+			.left_shift_assign, .right_shift_assign, .right_shift_unsigned_assign] {
 			// V defines oversized shifts to produce zero. Raw C shifts are
 			// undefined and may mask the count to the operand width instead.
 			return g.unsupported('shift expressions')
@@ -1238,8 +1219,8 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 			// indexing cannot preserve either in this scanner-only lane.
 			return g.unsupported('expression token `${g.token_source()}`')
 		}
-		if (!g.selfhost || g.tok !in [.lcbr, .rcbr])
-			&& g.tok in [.lcbr, .rcbr, .str_dollar, .key_match, .key_or, .arrow, .power] {
+		if (!g.selfhost || g.tok !in [.lcbr, .rcbr]) && g.tok in [.lcbr, .rcbr, .str_dollar,
+			.key_match, .key_or, .arrow, .power] {
 			return g.unsupported('expression token `${g.token_source()}`')
 		}
 		if !g.selfhost && g.tok in [.key_in, .not_in] {
@@ -1266,20 +1247,14 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 			}
 			else {}
 		}
-		if !g.selfhost && ((has_sum_arithmetic_operator && (has_and_operator
-			|| has_pipe_operator || has_xor_operator))
-			|| (has_multiply_operator && has_and_operator)
-			|| (has_pipe_operator && has_xor_operator)) {
+		if !g.selfhost && ((has_sum_arithmetic_operator && (has_and_operator || has_pipe_operator || has_xor_operator)) || (has_multiply_operator && has_and_operator) || (has_pipe_operator && has_xor_operator)) {
 			// V groups + and - with | and ^, and * with &, while C splits those
 			// levels and also orders + and - above &. Reject ambiguous token streams.
 			return g.unsupported('mixed operator precedence')
 		}
 		if g.tok.is_assignment() || g.tok in [.inc, .dec] {
-			is_declaration_guard := allow_declaration_guard && g.tok == .decl_assign
-				&& source_token_count == 1
-			if (!allow_mutation_statement && !is_declaration_guard)
-				|| paren_depth != 0 || bracket_depth != 0 || brace_depth != 0
-				|| unsafe_expression_depth != 0 {
+			is_declaration_guard := allow_declaration_guard && g.tok == .decl_assign && source_token_count == 1
+			if (!allow_mutation_statement && !is_declaration_guard) || paren_depth != 0 || bracket_depth != 0 || brace_depth != 0 || unsafe_expression_depth != 0 {
 				return g.unsupported('mutation `${g.token_source()}` inside an expression')
 			}
 			if mutation_operator != .unknown {
@@ -1297,14 +1272,11 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 			}
 			mut mutation_lookahead := g.s
 			next_mutation_token := mutation_lookahead.scan()
-			mutation_ends_line := mutation_lookahead.pos >= g.s.offset
-				&& g.s.src[g.s.offset..mutation_lookahead.pos].contains('\n')
-			if mutation_operator in [.inc, .dec] && next_mutation_token !in stops
-				&& next_mutation_token != .eof && !mutation_ends_line {
+			mutation_ends_line := mutation_lookahead.pos >= g.s.offset && g.s.src[g.s.offset..mutation_lookahead.pos].contains('\n')
+			if mutation_operator in [.inc, .dec] && next_mutation_token !in stops && next_mutation_token != .eof && !mutation_ends_line {
 				return g.unsupported('postfix mutation used inside an expression')
 			}
-			if mutation_operator.is_assignment()
-				&& (next_mutation_token in stops || next_mutation_token == .eof) {
+			if mutation_operator.is_assignment() && (next_mutation_token in stops || next_mutation_token == .eof) {
 				return g.unsupported('assignment without a value')
 			}
 		}
@@ -1318,34 +1290,29 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 			g.tok
 		}
 		expression_tokens << FastcExpressionToken{
-			tok:             stored_tok
-			lit:             g.lit
-			unsafe_depth:    g.unsafe_depth
+			tok: stored_tok
+			lit: g.lit
+			unsafe_depth: g.unsafe_depth
 			is_mut_argument: next_token_is_mut_argument
 		}
 		next_token_is_mut_argument = false
-		module_separator := g.expression_dot_is_module_separator(expression_tokens,
-			expression_tokens.len - 1)
-		qualified_name_owner := if g.tok == .name && previous_token == .dot
-			&& expression_tokens.len >= 3
-			&& g.expression_dot_is_module_separator(expression_tokens, expression_tokens.len - 2) {
+		module_separator := g.expression_dot_is_module_separator(expression_tokens, expression_tokens.len - 1)
+		qualified_name_owner := if g.tok == .name && previous_token == .dot && expression_tokens.len >= 3 && g.expression_dot_is_module_separator(expression_tokens, expression_tokens.len - 2) {
 			expression_tokens[expression_tokens.len - 3].lit
 		} else {
 			''
 		}
-		mut piece := g.expression_token(previous_token, previous_lit, qualified_name_owner,
-			module_separator)!
-		if g.selfhost && !g.in_generic_placeholder && g.tok == .name
-			&& g.generic_method_sources.len > 0 {
+		mut piece := g.expression_token(previous_token, previous_lit, qualified_name_owner, module_separator)!
+		if g.selfhost && !g.in_generic_placeholder && g.tok == .name && g.generic_method_sources.len > 0 {
 			if mono := g.queue_explicit_mono_method(expression_tokens) {
 				piece = mono
-				expression_tokens.last().lit = mono
+				expression_tokens[expression_tokens.len - 1].lit = mono
 			} else if mono := g.queue_explicit_mono_function(expression_tokens) {
 				piece = mono
-				expression_tokens.last().lit = mono
+				expression_tokens[expression_tokens.len - 1].lit = mono
 			} else if mono := g.queue_implicit_mono_function(expression_tokens) {
 				piece = mono
-				expression_tokens.last().lit = mono
+				expression_tokens[expression_tokens.len - 1].lit = mono
 			}
 		}
 		if g.tok == .name && previous_token != .dot {
@@ -1354,16 +1321,13 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 			if local := g.locals[g.lit] {
 				mut lookahead := g.s
 				next_token := lookahead.scan()
-				is_single_value := expression_tokens.len == 1
-					&& (next_token in stops || next_token == .eof)
+				is_single_value := expression_tokens.len == 1 && (next_token in stops || next_token == .eof)
 				// An explicit deref of a reference local (`*b` where `b` is a `mut` receiver,
 				// C type `T*`): the leading `*` already dereferences, so auto-deref would
 				// double it (`*(*(b))`). Skip the auto-deref so `*b` renders as `*(b)`. Only a
 				// PREFIX `*` counts — a binary `a * b` still needs `b`'s value.
-				is_deref_prefix := previous_token == .mul && expression_tokens.len > 0
-					&& fastc_token_is_prefix_operator(expression_tokens, expression_tokens.len - 1)
-				cast_type := if previous_token == .lpar && expression_tokens.len >= 3
-					&& expression_tokens[expression_tokens.len - 3].tok == .name {
+				is_deref_prefix := previous_token == .mul && expression_tokens.len > 0 && fastc_token_is_prefix_operator(expression_tokens, expression_tokens.len - 1)
+				cast_type := if previous_token == .lpar && expression_tokens.len >= 3 && expression_tokens[expression_tokens.len - 3].tok == .name {
 					fastc_primitive_c_type(expression_tokens[expression_tokens.len - 3].lit) or {
 						''
 					}
@@ -1371,9 +1335,10 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 					''
 				}
 				is_pointer_cast_operand := cast_type != '' && fastc_is_pointer_type(cast_type)
-				if local.is_reference && !expression_tokens.last().is_mut_argument
-					&& next_token !in [.dot, .lsbr] && !is_single_value && !is_deref_prefix
-					&& !is_pointer_cast_operand {
+				if local.is_reference && !expression_tokens.last().is_mut_argument && next_token !in [
+					.dot,
+					.lsbr,
+				] && !is_single_value && !is_deref_prefix && !is_pointer_cast_operand {
 					piece = '(*(${piece}))'
 				}
 			}
@@ -1381,9 +1346,7 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 		if module_separator && piece == '.' {
 			piece = '__'
 		}
-		if previous_token == .dot && (g.tok == .name || g.tok.is_keyword())
-			&& expression_tokens.len >= 3
-			&& g.expression_dot_is_module_separator(expression_tokens, expression_tokens.len - 2) {
+		if previous_token == .dot && (g.tok == .name || g.tok.is_keyword()) && expression_tokens.len >= 3 && g.expression_dot_is_module_separator(expression_tokens, expression_tokens.len - 2) {
 			// A module or enum prefix makes a keyword-named symbol C-safe
 			// (`TokenKind.float` -> `TokenKind__float`).
 			piece = g.lit
@@ -1396,17 +1359,28 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 				// generic method (own type param, left un-monomorphized because its body
 				// recurses through a comptime `$for`). Infer the first arg's type, queue the
 				// concrete instance, and emit its mangled name so the call resolves to it.
-				if g.selfhost && !g.in_generic_placeholder && g.generic_method_sources.len > 0
-					&& expression_tokens.len >= 3
-					&& expression_tokens[expression_tokens.len - 2].tok == .dot {
+				if g.selfhost && !g.in_generic_placeholder && g.generic_method_sources.len > 0 && expression_tokens.len >= 3 && expression_tokens[expression_tokens.len - 2].tok == .dot {
 					dot_index := expression_tokens.len - 2
 					recv_start := fastc_method_receiver_start(expression_tokens, dot_index)
 					receiver_type := g.infer_expression_type(expression_tokens[recv_start..dot_index]) or {
 						''
 					}
 					recv_base := fastc_normalize_inferred_type(receiver_type).trim_right('*')
-					if recv_base != '' && '${recv_base}.${g.lit}' in g.generic_method_sources {
-						concrete := g.mono_argument_type(mut method_lookahead)
+					source_key := '${recv_base}.${g.lit}'
+					if recv_base != '' && source_key in g.generic_method_sources {
+						source := g.generic_method_sources[source_key] or {
+							FastcGenericMethodSource{}
+						}
+						base_key := '${g.semantic_type_key(recv_base)}.${g.lit}'
+						base := g.functions[base_key] or { FastcFunctionSignature{} }
+						parameter_index := source.type_param_parameter_index
+						signature_index := parameter_index + 1
+						argument_type := g.mono_argument_type_at(mut method_lookahead, parameter_index)
+						concrete := if parameter_index >= 0 && signature_index < base.parameter_types.len {
+							fastc_infer_generic_type_from_parameter(base.parameter_types[signature_index], argument_type)
+						} else {
+							''
+						}
 						if concrete != '' {
 							mono := g.queue_mono_method(recv_base, g.lit, concrete)
 							piece = mono
@@ -1416,10 +1390,7 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 				}
 			}
 		}
-		if g.tok == .name && expression_tokens.len >= 3
-			&& expression_tokens[expression_tokens.len - 2].tok == .dot
-			&& expression_tokens[expression_tokens.len - 3].tok == .name
-			&& expression_tokens[expression_tokens.len - 3].lit == 'C' {
+		if g.tok == .name && expression_tokens.len >= 3 && expression_tokens[expression_tokens.len - 2].tok == .dot && expression_tokens[expression_tokens.len - 3].tok == .name && expression_tokens[expression_tokens.len - 3].lit == 'C' {
 			piece = g.lit
 		}
 		if g.selfhost && brace_depth > 0 && g.tok == .name {
@@ -1432,10 +1403,8 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 			piece = '->'
 		}
 		if g.tok == .lpar && previous_token == .name {
-			name_is_member := expression_tokens.len >= 3
-				&& expression_tokens[expression_tokens.len - 3].tok == .dot
-			pointer_token := if expression_tokens.len >= 3
-				&& fastc_token_is_prefix_operator(expression_tokens, expression_tokens.len - 3) {
+			name_is_member := expression_tokens.len >= 3 && expression_tokens[expression_tokens.len - 3].tok == .dot
+			pointer_token := if expression_tokens.len >= 3 && fastc_token_is_prefix_operator(expression_tokens, expression_tokens.len - 3) {
 				expression_tokens[expression_tokens.len - 3].tok
 			} else {
 				token.Token.unknown
@@ -1450,23 +1419,15 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 			pointer_cast := pointer_count > 0
 			pointer_suffix := '*'.repeat(pointer_count)
 			pointer_prefix_len := pointer_count
-			if expression_tokens.len >= 4
-				&& expression_tokens[expression_tokens.len - 4].tok == .lsbr
-				&& expression_tokens[expression_tokens.len - 3].tok == .rsbr {
+			if expression_tokens.len >= 4 && expression_tokens[expression_tokens.len - 4].tok == .lsbr && expression_tokens[expression_tokens.len - 3].tok == .rsbr {
 				element_type := fastc_primitive_c_type(previous_lit) or { previous_lit }
 				array_type := fastc_array_c_type(element_type)
 				rendered_previous := g.resolved_expression_name(previous_lit, .unknown)
 				result.go_back(rendered_previous.len + 2)
 				piece = '((${array_type})('
 				cast_depths << paren_depth + 1
-			} else if expression_tokens.len >= 4
-				&& expression_tokens[expression_tokens.len - 4].tok == .name
-				&& expression_tokens[expression_tokens.len - 4].lit == 'C'
-				&& expression_tokens[expression_tokens.len - 3].tok == .dot && previous_lit.len > 0
-				&& 'C.${previous_lit}' !in g.functions && g.current_call_has_one_argument()
-				&& (previous_lit[0].is_capital() || '#Cstruct#${previous_lit}' in g.declared_types) {
-				c_pointer_token := if expression_tokens.len >= 5
-					&& fastc_token_is_prefix_operator(expression_tokens, expression_tokens.len - 5) {
+			} else if expression_tokens.len >= 4 && expression_tokens[expression_tokens.len - 4].tok == .name && expression_tokens[expression_tokens.len - 4].lit == 'C' && expression_tokens[expression_tokens.len - 3].tok == .dot && previous_lit.len > 0 && 'C.${previous_lit}' !in g.functions && g.current_call_has_one_argument() && (previous_lit[0].is_capital() || '#Cstruct#${previous_lit}' in g.declared_types) {
+				c_pointer_token := if expression_tokens.len >= 5 && fastc_token_is_prefix_operator(expression_tokens, expression_tokens.len - 5) {
 					expression_tokens[expression_tokens.len - 5].tok
 				} else {
 					token.Token.unknown
@@ -1489,10 +1450,7 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 				if c_pointer_count > 0 {
 					pointer_cast_depths << paren_depth + 1
 				}
-			} else if expression_tokens.len >= 4
-				&& expression_tokens[expression_tokens.len - 3].tok == .dot
-				&& expression_tokens[expression_tokens.len - 4].tok == .name
-				&& expression_tokens[expression_tokens.len - 4].lit in g.imports {
+			} else if expression_tokens.len >= 4 && expression_tokens[expression_tokens.len - 3].tok == .dot && expression_tokens[expression_tokens.len - 4].tok == .name && expression_tokens[expression_tokens.len - 4].lit in g.imports {
 				// Qualified conversion `mod.Type(value)` (e.g. `orm.Primitive(x)`): render
 				// it as a C cast so a sum-type/interface operand is boxed downstream,
 				// instead of the default `mod__Type(value)` call-style spelling.
@@ -1517,9 +1475,7 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 						pointer_cast_depths << paren_depth + 1
 					}
 				}
-			} else if type_key := fastc_resolve_declared_type_key(g.module_name, previous_lit,
-				g.imports, g.declared_types)
-			{
+			} else if type_key := fastc_resolve_declared_type_key(g.module_name, previous_lit, g.imports, g.declared_types) {
 				if !name_is_member {
 					cast_type := fastc_c_declared_type_name(type_key)
 					rendered_previous := g.resolved_expression_name(previous_lit, .unknown)
@@ -1565,11 +1521,7 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 				struct_depths << brace_depth
 				struct_paren_depths << paren_depth
 				is_struct_literal = true
-			} else if expression_tokens.len >= 4
-				&& expression_tokens[expression_tokens.len - 4].tok == .name
-				&& expression_tokens[expression_tokens.len - 4].lit == 'C'
-				&& expression_tokens[expression_tokens.len - 3].tok == .dot
-				&& expression_tokens[expression_tokens.len - 2].tok == .name {
+			} else if expression_tokens.len >= 4 && expression_tokens[expression_tokens.len - 4].tok == .name && expression_tokens[expression_tokens.len - 4].lit == 'C' && expression_tokens[expression_tokens.len - 3].tok == .dot && expression_tokens[expression_tokens.len - 2].tok == .name {
 				raw_c_type := expression_tokens[expression_tokens.len - 2].lit
 				c_type := if '#Cstruct#${raw_c_type}' in g.declared_types {
 					'struct ${raw_c_type}'
@@ -1583,10 +1535,7 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 				struct_depths << brace_depth
 				struct_paren_depths << paren_depth
 				is_struct_literal = true
-			} else if expression_tokens.len >= 4
-				&& expression_tokens[expression_tokens.len - 4].tok == .name
-				&& expression_tokens[expression_tokens.len - 3].tok == .dot
-				&& expression_tokens[expression_tokens.len - 2].tok == .name {
+			} else if expression_tokens.len >= 4 && expression_tokens[expression_tokens.len - 4].tok == .name && expression_tokens[expression_tokens.len - 3].tok == .dot && expression_tokens[expression_tokens.len - 2].tok == .name {
 				module_alias := expression_tokens[expression_tokens.len - 4].lit
 				if imported_module := g.imports[module_alias] {
 					raw_type := expression_tokens[expression_tokens.len - 2].lit
@@ -1603,9 +1552,7 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 					}
 				}
 			} else if previous_token == .name {
-				if type_key := fastc_resolve_declared_type_key(g.module_name, previous_lit,
-					g.imports, g.declared_types)
-				{
+				if type_key := fastc_resolve_declared_type_key(g.module_name, previous_lit, g.imports, g.declared_types) {
 					c_type := fastc_c_declared_type_name(type_key)
 					result.go_back(c_type.len)
 					piece = '(${c_type}){'
@@ -1633,24 +1580,23 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 			}
 			brace_depth--
 			piece = '}'
-		} else if g.selfhost && g.tok == .colon && struct_depths.len > 0
-			&& brace_depth == struct_depths.last() && paren_depth == struct_paren_depths.last() {
+		} else if g.selfhost && g.tok == .colon && struct_depths.len > 0 && brace_depth == struct_depths.last() && paren_depth == struct_paren_depths.last() {
 			piece = '='
 			pending_field_value_mark = true
-		} else if g.selfhost && struct_depths.len > 0 && brace_depth == struct_depths.last()
-			&& paren_depth == struct_paren_depths.last() && g.tok == .semicolon {
+		} else if g.selfhost && struct_depths.len > 0 && brace_depth == struct_depths.last() && paren_depth == struct_paren_depths.last() && g.tok == .semicolon {
 			piece = ','
-		} else if g.selfhost && struct_depths.len > 0 && brace_depth == struct_depths.last()
-			&& paren_depth == struct_paren_depths.last() && g.tok == .name
-			&& previous_token in [.lcbr, .comma, .semicolon] && struct_types.len > 0 {
+		} else if g.selfhost && struct_depths.len > 0 && brace_depth == struct_depths.last() && paren_depth == struct_paren_depths.last() && g.tok == .name && previous_token in [
+			.lcbr,
+			.comma,
+			.semicolon,
+		] && struct_types.len > 0 {
 			mut fields := map[string]string{}
 			if struct_types.last() in g.struct_fields {
 				fields = g.struct_fields[struct_types.last()].clone()
 			}
 			expected_struct_field_type = fields[g.lit] or { '' }
 			piece = '.${piece}'
-		} else if g.selfhost && g.tok == .dot
-			&& fastc_token_is_prefix_operator(expression_tokens, expression_tokens.len - 1) {
+		} else if g.selfhost && g.tok == .dot && fastc_token_is_prefix_operator(expression_tokens, expression_tokens.len - 1) {
 			mut contextual_type := if expected_struct_field_type != '' {
 				expected_struct_field_type
 			} else {
@@ -1675,8 +1621,17 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 			if contextual_type == '' {
 				contextual_type = g.expected_call_argument_type(expression_tokens)
 			}
-			if expression_tokens.len >= 2
-				&& expression_tokens[expression_tokens.len - 2].tok in [.eq, .ne, .gt, .lt, .ge, .le, .pipe, .amp, .xor] {
+			if expression_tokens.len >= 2 && expression_tokens[expression_tokens.len - 2].tok in [
+				.eq,
+				.ne,
+				.gt,
+				.lt,
+				.ge,
+				.le,
+				.pipe,
+				.amp,
+				.xor,
+			] {
 				operator_index := expression_tokens.len - 2
 				mut operand_start := 0
 				mut operand_depth := 0
@@ -1706,8 +1661,7 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 			expression_tokens[expression_tokens.len - 1].typ = enum_shorthand_type
 			enum_shorthand_type = ''
 		}
-		if result.len > 0 && fastc_needs_space(result.last(), piece) && !module_separator
-			&& !previous_module_separator {
+		if result.len > 0 && fastc_needs_space(result.last(), piece) && !module_separator && !previous_module_separator {
 			result.write_u8(` `)
 		}
 		result.write_string(piece)
@@ -1775,8 +1729,7 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 	g.validate_expression_field_visibility(expression_tokens)!
 	g.validate_expression_calls(expression_tokens)!
 	mut rendered_expression := result.str().trim_space()
-	rendered_expression = g.render_enum_alias_member_references(expression_tokens,
-		rendered_expression)
+	rendered_expression = g.render_enum_alias_member_references(expression_tokens, rendered_expression)
 	rendered_expression = g.render_constant_references(expression_tokens, rendered_expression)
 	if special := g.render_special_expression(expression_tokens, rendered_expression) {
 		g.last_expression_type = special.typ
@@ -1789,8 +1742,7 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 	if return_types.len > 0 {
 		g.last_multi_return_types = return_types.clone()
 	}
-	if !g.selfhost && g.last_expression_type == 'bool'
-		&& fastc_expression_tokens_contain_boolean_operator(expression_tokens) {
+	if !g.selfhost && g.last_expression_type == 'bool' && fastc_expression_tokens_contain_boolean_operator(expression_tokens) {
 		// C comparison and logical operators produce int. Preserve V's bool
 		// expression type for inferred declarations and generic dispatch.
 		return '((bool)(${rendered_expression}))'
@@ -1801,9 +1753,7 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 fn (g &Parser) render_constant_references(tokens []FastcExpressionToken, source string) string {
 	mut rendered := source
 	for i, item in tokens {
-		if item.tok != .name || (i > 0 && tokens[i - 1].tok == .dot)
-			|| (i + 1 < tokens.len && tokens[i + 1].tok == .colon)
-			|| item.lit in g.locals {
+		if item.tok != .name || (i > 0 && tokens[i - 1].tok == .dot) || (i + 1 < tokens.len && tokens[i + 1].tok == .colon) || item.lit in g.locals {
 			continue
 		}
 		if i + 1 < tokens.len && tokens[i + 1].tok == .lpar {
@@ -1815,8 +1765,7 @@ fn (g &Parser) render_constant_references(tokens []FastcExpressionToken, source 
 			}
 			function_key := g.unqualified_function_key(item.lit)
 			if function_key in g.functions || function_key in g.mono_functions {
-				rendered = fastc_replace_c_call_identifier(rendered, item.lit,
-					fastc_c_function_name_for_key(function_key))
+				rendered = fastc_replace_c_call_identifier(rendered, item.lit, fastc_c_function_name_for_key(function_key))
 				continue
 			}
 		}
@@ -1844,8 +1793,10 @@ fn fastc_replace_c_call_identifier(source string, identifier string, replacement
 		}
 		index := start + relative
 		end := index + identifier.len
-		before_is_name_or_member := index > 0 && (source[index - 1].is_alnum()
-			|| source[index - 1] in [`_`, `.`])
+		before_is_name_or_member := index > 0 && (source[index - 1].is_alnum() || source[index - 1] in [
+			`_`,
+			`.`,
+		])
 		mut after := end
 		for after < source.len && source[after] in [` `, `\t`, `\r`, `\n`] {
 			after++
@@ -1924,7 +1875,10 @@ fn (g &Parser) semicolon_continues_expression() bool {
 	if offset >= g.s.src.len {
 		return false
 	}
-	if offset + 1 < g.s.src.len && g.s.src[offset] == `/` && g.s.src[offset + 1] in [`/`, `*`] {
+	if offset + 1 < g.s.src.len && g.s.src[offset] == `/` && g.s.src[offset + 1] in [
+		`/`,
+		`*`,
+	] {
 		return false
 	}
 	if g.in_enum_keyed_map_value && g.s.src[offset] == `.` {
@@ -1970,9 +1924,7 @@ fn (mut g Parser) read_inferred_map_literal() !string {
 		// Explicit key `EnumType.field` (the first entry often spells it out).
 		mut lookahead := g.s
 		if lookahead.scan() == .dot {
-			if type_key := fastc_resolve_declared_type_key(g.module_name, g.lit, g.imports,
-				g.declared_types)
-			{
+			if type_key := fastc_resolve_declared_type_key(g.module_name, g.lit, g.imports, g.declared_types) {
 				if g.declared_kinds[type_key] == .enum_ {
 					key_enum_type = fastc_c_declared_type_name(type_key)
 				}
@@ -2143,8 +2095,7 @@ fn (g &Parser) expected_call_argument_type(tokens []FastcExpressionToken) string
 	name_index := open_index - 1
 	mut function_key := g.function_key_for_call(tokens, name_index)
 	mut argument_offset := 0
-	if name_index >= 2 && tokens[name_index - 1].tok == .dot && !(name_index == 2
-		&& tokens[0].tok == .name && (tokens[0].lit in g.imports || tokens[0].lit == 'C')) {
+	if name_index >= 2 && tokens[name_index - 1].tok == .dot && !(name_index == 2 && tokens[0].tok == .name && (tokens[0].lit in g.imports || tokens[0].lit == 'C')) {
 		receiver_start := fastc_method_receiver_start(tokens, name_index - 1)
 		receiver_type := g.infer_expression_type(tokens[receiver_start..name_index - 1]) or {
 			return ''
@@ -2207,7 +2158,7 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 			if local.is_reference {
 				return FastcRenderedExpression{
 					source: '*(${rendered_expression})'
-					typ:    local.typ.trim_right('*')
+					typ: local.typ.trim_right('*')
 				}
 			}
 		}
@@ -2217,7 +2168,7 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 			if typ := g.infer_member_access_type(tokens) {
 				return FastcRenderedExpression{
 					source: source
-					typ:    typ
+					typ: typ
 				}
 			}
 		}
@@ -2256,9 +2207,7 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 		}
 	}
 	if cast_expression := g.render_cast_expression(tokens) {
-		if pointer_members := g.render_pointer_member_access_expression(tokens,
-			cast_expression.source)
-		{
+		if pointer_members := g.render_pointer_member_access_expression(tokens, cast_expression.source) {
 			return pointer_members
 		}
 		return cast_expression
@@ -2300,7 +2249,7 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 			inner := g.render_call_argument_expression(tokens[1..], 'bool') or { return none }
 			return FastcRenderedExpression{
 				source: '!(${inner})'
-				typ:    'bool'
+				typ: 'bool'
 			}
 		}
 		if option_comparison := g.render_option_none_comparison(tokens) {
@@ -2315,19 +2264,14 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 		if concatenation := g.render_composed_string_concatenation(tokens) {
 			return concatenation
 		}
-		if tokens.len > 1 && tokens.last().tok == .not && rendered_expression.ends_with('!')
-			&& !fastc_trailing_not_marks_fixed_array_literal(tokens) {
+		if tokens.len > 1 && tokens.last().tok == .not && rendered_expression.ends_with('!') && !fastc_trailing_not_marks_fixed_array_literal(tokens) {
 			inner_tokens := tokens[..tokens.len - 1]
 			mut inner_source := rendered_expression[..rendered_expression.len - 1]
 			if explicit_generic := g.render_explicit_generic_call_expression(inner_tokens) {
 				inner_source = explicit_generic.source
-			} else if static_expression := g.render_static_call_expression(inner_tokens,
-				inner_source)
-			{
+			} else if static_expression := g.render_static_call_expression(inner_tokens, inner_source) {
 				inner_source = static_expression.source
-			} else if method_expression := g.render_method_call_expression(inner_tokens,
-				inner_source)
-			{
+			} else if method_expression := g.render_method_call_expression(inner_tokens, inner_source) {
 				inner_source = method_expression.source
 			} else if array_expression := g.render_array_access_expression(inner_tokens) {
 				inner_source = array_expression.source
@@ -2351,7 +2295,7 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 			}
 			return FastcRenderedExpression{
 				source: '({ Option ${temporary} = (${inner_source}); if (${temporary}.state) { ${failure} } ${value}; })'
-				typ:    value_type
+				typ: value_type
 			}
 		}
 		if append_expression := g.render_append_expression(tokens, rendered_expression) {
@@ -2384,7 +2328,7 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 					predicate := if item.tok == .not_in { '!(${found})' } else { found }
 					return FastcRenderedExpression{
 						source: '({ string ${substring_name} = (${substring}); string ${value_name} = (${value}); ${predicate}; })'
-						typ:    'bool'
+						typ: 'bool'
 					}
 				}
 				if right_type.trim_right('*').starts_with('Map_') {
@@ -2403,7 +2347,7 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 					predicate := if item.tok == .not_in { '!(${found})' } else { found }
 					return FastcRenderedExpression{
 						source: '({ ${fastc_runtime_c_type(key_type)} ${key_name} = (${key_source}); ${predicate}; })'
-						typ:    'bool'
+						typ: 'bool'
 					}
 				}
 				right_layout := right_type.trim_right('*')
@@ -2436,12 +2380,11 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 					predicate := if item.tok == .not_in { '!${found_name}' } else { found_name }
 					return FastcRenderedExpression{
 						source: '({ ${element_type} ${item_name} = (${candidate}); __typeof__((${collection})) ${collection_name} = (${collection}); bool ${found_name} = false; for (int ${index_name} = 0; ${index_name} < ${collection_length}; ${index_name}++) { if (${comparison}) { ${found_name} = true; break; } } ${predicate}; })'
-						typ:    'bool'
+						typ: 'bool'
 					}
 				}
 				array_end := if tokens.last().tok == .not { tokens.len - 1 } else { tokens.len }
-				if i + 2 >= array_end || tokens[i + 1].tok != .lsbr
-					|| tokens[array_end - 1].tok != .rsbr {
+				if i + 2 >= array_end || tokens[i + 1].tok != .lsbr || tokens[array_end - 1].tok != .rsbr {
 					continue
 				}
 				lhs_type := g.infer_expression_type(tokens[..i]) or { return none }
@@ -2451,7 +2394,7 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 				if items.len == 0 {
 					return FastcRenderedExpression{
 						source: if item.tok == .key_in { 'false' } else { 'true' }
-						typ:    'bool'
+						typ: 'bool'
 					}
 				}
 				lhs_source := g.render_membership_candidate(tokens[..i], lhs_type) or {
@@ -2477,7 +2420,7 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 				joiner := if item.tok == .key_in { ' || ' } else { ' && ' }
 				return FastcRenderedExpression{
 					source: '({ ${value_type} ${lhs_name} = (${lhs_source}); ${initializers.join(' ')} (${comparisons.join(joiner)}); })'
-					typ:    'bool'
+					typ: 'bool'
 				}
 			}
 		}
@@ -2495,12 +2438,10 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 			return pointer_members
 		}
 		if method_expression := g.render_method_call_expression(tokens, rendered_expression) {
-			if array_expression := g.render_nested_array_access_expression(tokens,
-				method_expression.source)
-			{
+			if array_expression := g.render_nested_array_access_expression(tokens, method_expression.source) {
 				return FastcRenderedExpression{
 					source: array_expression.source
-					typ:    method_expression.typ
+					typ: method_expression.typ
 				}
 			}
 			if array_type := g.infer_expression_type(tokens) {
@@ -2508,9 +2449,7 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 					return array_literal
 				}
 			}
-			if pointer_members := g.render_pointer_member_access_expression(tokens,
-				method_expression.source)
-			{
+			if pointer_members := g.render_pointer_member_access_expression(tokens, method_expression.source) {
 				return pointer_members
 			}
 			return method_expression
@@ -2522,14 +2461,14 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 			return array_expression
 		}
 	}
-	if g.selfhost && tokens.len >= 3 && tokens[0].tok == .name
-		&& tokens[1].tok in [.key_is, .not_is] {
+	if g.selfhost && tokens.len >= 3 && tokens[0].tok == .name && tokens[1].tok in [
+		.key_is,
+		.not_is,
+	] {
 		lhs_type := g.infer_expression_type(tokens[..1]) or { return none }
 		mut variant_c := ''
 		if tokens.len == 3 && tokens[2].tok == .name {
-			if type_key := fastc_resolve_declared_type_key(g.module_name, tokens[2].lit, g.imports,
-				g.declared_types)
-			{
+			if type_key := fastc_resolve_declared_type_key(g.module_name, tokens[2].lit, g.imports, g.declared_types) {
 				variant_c = fastc_c_declared_type_name(type_key)
 			}
 		} else if resolved_target := g.type_from_expression_tokens(tokens[2..]) {
@@ -2545,7 +2484,7 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 		operator := if tokens[1].tok == .key_is { '==' } else { '!=' }
 		return FastcRenderedExpression{
 			source: '((${tokens[0].lit}${access}_typ) ${operator} __v_typeid_${variant_c})'
-			typ:    'bool'
+			typ: 'bool'
 		}
 	}
 	if g.selfhost {
@@ -2553,15 +2492,18 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 			return as_expression
 		}
 	}
-	if g.selfhost && tokens.len >= 3 && tokens.last().tok == .name
-		&& tokens[tokens.len - 2].tok == .dot && tokens.last().lit in ['len', 'cap', 'closed'] {
+	if g.selfhost && tokens.len >= 3 && tokens.last().tok == .name && tokens[tokens.len - 2].tok == .dot && tokens.last().lit in [
+		'len',
+		'cap',
+		'closed',
+	] {
 		// The erased `void*` chan stub has no fields. Channels are non-functional in
 		// this scanner lane, so report the empty/open stub state.
 		receiver_type := g.infer_expression_type(tokens[..tokens.len - 2]) or { '' }
 		if fastc_normalize_inferred_type(receiver_type).trim_right('*') == 'chan' {
 			return FastcRenderedExpression{
 				source: if tokens.last().lit == 'closed' { 'false' } else { '0' }
-				typ:    if tokens.last().lit == 'closed' { 'bool' } else { 'int' }
+				typ: if tokens.last().lit == 'closed' { 'bool' } else { 'int' }
 			}
 		}
 	}
@@ -2581,15 +2523,13 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 					marker_index := rendered_expression.index(marker) or { return none }
 					value := rendered_expression[marker_index + marker.len..rendered_expression.len - 1]
 					return FastcRenderedExpression{
-						source: rendered_expression[..marker_index] +
-							'{.data={ [0 ... ${length} -
-							1] = ' + value + '}}'
-						typ:    array_type
+						source: rendered_expression[..marker_index] + '{.data={ [0 ... ${length} -\n\t\t\t\t\t\t\t1] = ' + value + '}}'
+						typ: array_type
 					}
 				}
 				return FastcRenderedExpression{
 					source: rendered_expression
-					typ:    array_type
+					typ: array_type
 				}
 			}
 		}
@@ -2599,11 +2539,10 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 	} else {
 		tokens.len
 	}
-	if g.selfhost && array_end == 2 && tokens[0].tok == .lsbr && tokens[1].tok == .rsbr
-		&& g.expected_expression_type.trim_right('*').starts_with('Array_') {
+	if g.selfhost && array_end == 2 && tokens[0].tok == .lsbr && tokens[1].tok == .rsbr && g.expected_expression_type.trim_right('*').starts_with('Array_') {
 		return FastcRenderedExpression{
 			source: '(${g.expected_expression_type}){0}'
-			typ:    g.expected_expression_type
+			typ: g.expected_expression_type
 		}
 	}
 	if g.selfhost && array_end >= 2 && tokens[0].tok == .lsbr && tokens[array_end - 1].tok == .rsbr {
@@ -2626,7 +2565,7 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 		}
 		return FastcRenderedExpression{
 			source: '((${array_type})builtin__new_array_from_c_array(${items.len}, ${items.len}, sizeof(${fastc_normalize_inferred_type(element_type)}), (${fastc_normalize_inferred_type(element_type)}[]){${rendered_items.join(',')}}))'
-			typ:    array_type
+			typ: array_type
 		}
 	}
 	if g.selfhost && tokens.len > 0 && tokens.len % 2 == 1 {
@@ -2651,7 +2590,7 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 		if is_literal_concat {
 			return FastcRenderedExpression{
 				source: '_S(${literals.str()})'
-				typ:    'string'
+				typ: 'string'
 			}
 		}
 	}
@@ -2691,7 +2630,7 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 					}
 					return FastcRenderedExpression{
 						source: combined
-						typ:    'string'
+						typ: 'string'
 					}
 				}
 			}

--- a/vlib/v3/gen/fastc/fastc.v
+++ b/vlib/v3/gen/fastc/fastc.v
@@ -7,7 +7,6 @@ import v3.token
 
 // FastC parses scanner tokens and emits C immediately. It deliberately has no
 // AST, semantic-checker, transformer, mark-used, or conventional cgen path.
-
 const c_preamble = r'#ifndef __cplusplus
 typedef _Bool bool;
 #define true ((bool)1)
@@ -813,21 +812,19 @@ struct Parser {
 	has_startup_inits      bool
 	has_cleanup_hooks      bool
 mut:
-	path         string
-	module_name  string
-	imports      map[string]string
-	s            scanner.Scanner
-	tok          token.Token
-	lit          string
-	out          strings.Builder
-	protos       strings.Builder
-	indent       int
-	in_main      bool
-	has_main     bool
-	unsafe_depth int
-	temp_id      int
-	// Per-file counter for anonymous-function / closure stub names (see anonfn.v).
-	anon_fn_counter          int
+	path                     string
+	module_name              string
+	imports                  map[string]string
+	s                        scanner.Scanner
+	tok                      token.Token
+	lit                      string
+	out                      strings.Builder
+	protos                   strings.Builder
+	indent                   int
+	in_main                  bool
+	has_main                 bool
+	unsafe_depth             int
+	temp_id                  int
 	locals                   map[string]FastcLocal
 	functions                map[string]FastcFunctionSignature
 	constant_types           map[string]string
@@ -933,7 +930,7 @@ pub fn generate(source string, path string, prefs &pref.Preferences) !string {
 	}
 	c_source, _, _ := generate_source_files([
 		FastcSourceFile{
-			path:   path
+			path: path
 			source: source
 			header: header
 		},
@@ -957,10 +954,10 @@ pub fn generate_files_with_source_paths(paths []string, prefs &pref.Preferences)
 	}
 	c_source, uses_threads, c_flags := generate_source_files(sources, module_aliases, prefs)!
 	return GenerationResult{
-		c_source:     c_source
+		c_source: c_source
 		source_paths: source_paths
 		uses_threads: uses_threads
-		c_flags:      c_flags
+		c_flags: c_flags
 	}
 }
 
@@ -1022,79 +1019,79 @@ fn fastc_generate_single_file(ctx &FastcFileGenContext, source_file FastcSourceF
 	file.index_lines_without_digest(source_file.source)
 	prefs := ctx.prefs
 	mut gen := Parser{
-		prefs:                   unsafe { prefs }
-		path:                    source_file.path
-		module_name:             source_file.header.module_name
-		imports:                 source_file.header.imports
-		declared_types:          ctx.declared_types
-		declared_type_c_names:   ctx.declared_type_c_names
-		fastc_prefixed_c_names:  ctx.fastc_prefixed_c_names
-		has_c_functions:         ctx.has_c_functions
-		comparison_memo:         map[i64]FastcRenderedExpression{}
-		member_smartcasts:       map[string]FastcMemberSmartcast{}
-		spawn_typedefs:          map[string]string{}
-		spawn_helpers:           map[string]string{}
-		thread_value_types:      map[string]string{}
-		declared_kinds:          ctx.declared_kinds
-		enum_flags:              ctx.enum_flags
-		enum_field_types:        ctx.enum_field_types
-		alias_base_types:        ctx.alias_base_types
-		sum_types:               ctx.sum_types
-		struct_fields:           ctx.struct_fields
-		struct_field_info:       ctx.struct_field_info
-		generic_method_sources:  ctx.generic_method_sources
-		module_aliases:          ctx.module_aliases
-		generated_mono:          map[string]bool{}
-		mono_functions:          map[string]FastcFunctionSignature{}
-		mono_definitions:        map[string]string{}
-		interface_fields:        ctx.interface_fields
-		constants:               ctx.constants
-		constant_values:         ctx.constant_values
-		public_constants:        ctx.public_constants
-		globals:                 ctx.globals
-		public_globals:          ctx.public_globals
-		used_function_names:     ctx.used_function_names
-		selfhost:                prefs.building_v
-		has_startup_inits:       ctx.has_startup_inits
-		has_cleanup_hooks:       ctx.has_cleanup_hooks
-		s:                       scanner.new_scanner(prefs, .normal)
-		out:                     strings.new_builder(source_file.source.len)
-		protos:                  strings.new_builder(256)
-		functions:               ctx.functions
-		constant_types:          ctx.constant_types
-		global_types:            ctx.global_types
-		fixed_array_types:       ctx.fixed_array_types.clone()
-		composite_types:         ctx.composite_types.clone()
-		deferred_lines:          []string{}
-		deferred_block_starts:   []int{}
+		prefs: unsafe { prefs }
+		path: source_file.path
+		module_name: source_file.header.module_name
+		imports: source_file.header.imports
+		declared_types: ctx.declared_types
+		declared_type_c_names: ctx.declared_type_c_names
+		fastc_prefixed_c_names: ctx.fastc_prefixed_c_names
+		has_c_functions: ctx.has_c_functions
+		comparison_memo: map[i64]FastcRenderedExpression{}
+		member_smartcasts: map[string]FastcMemberSmartcast{}
+		spawn_typedefs: map[string]string{}
+		spawn_helpers: map[string]string{}
+		thread_value_types: map[string]string{}
+		declared_kinds: ctx.declared_kinds
+		enum_flags: ctx.enum_flags
+		enum_field_types: ctx.enum_field_types
+		alias_base_types: ctx.alias_base_types
+		sum_types: ctx.sum_types
+		struct_fields: ctx.struct_fields
+		struct_field_info: ctx.struct_field_info
+		generic_method_sources: ctx.generic_method_sources
+		module_aliases: ctx.module_aliases
+		generated_mono: map[string]bool{}
+		mono_functions: map[string]FastcFunctionSignature{}
+		mono_definitions: map[string]string{}
+		interface_fields: ctx.interface_fields
+		constants: ctx.constants
+		constant_values: ctx.constant_values
+		public_constants: ctx.public_constants
+		globals: ctx.globals
+		public_globals: ctx.public_globals
+		used_function_names: ctx.used_function_names
+		selfhost: prefs.building_v
+		has_startup_inits: ctx.has_startup_inits
+		has_cleanup_hooks: ctx.has_cleanup_hooks
+		s: scanner.new_scanner(prefs, .normal)
+		out: strings.new_builder(source_file.source.len)
+		protos: strings.new_builder(256)
+		functions: ctx.functions
+		constant_types: ctx.constant_types
+		global_types: ctx.global_types
+		fixed_array_types: ctx.fixed_array_types.clone()
+		composite_types: ctx.composite_types.clone()
+		deferred_lines: []string{}
+		deferred_block_starts: []int{}
 		loop_defer_block_starts: []int{}
-		loop_has_breaks:         []bool{}
-		statement_reachable:     true
+		loop_has_breaks: []bool{}
+		statement_reachable: true
 	}
 	gen.s.init(file, source_file.source)
 	generated := gen.run() or {
 		return FastcFileGenOutput{
-			failed:        true
+			failed: true
 			error_message: err.msg()
 		}
 	}
 	if gen.s.diagnostics.len > 0 {
 		diagnostic := gen.s.diagnostics[0]
 		return FastcFileGenOutput{
-			failed:        true
+			failed: true
 			error_message: 'fastc scanner error at byte ${diagnostic.offset} in ${source_file.path}: ${diagnostic.message}'
 		}
 	}
 	return FastcFileGenOutput{
-		prototypes:        gen.protos.str()
-		body:              generated
-		has_main_entry:    source_file.header.module_name in ['', 'main'] && gen.has_main
+		prototypes: gen.protos.str()
+		body: generated
+		has_main_entry: source_file.header.module_name in ['', 'main'] && gen.has_main
 		fixed_array_types: gen.fixed_array_types
-		composite_types:   gen.composite_types
-		spawn_typedefs:    gen.spawn_typedefs
-		spawn_helpers:     gen.spawn_helpers
-		mono_definitions:  gen.mono_definitions
-		c_flags:           gen.c_flags
+		composite_types: gen.composite_types
+		spawn_typedefs: gen.spawn_typedefs
+		spawn_helpers: gen.spawn_helpers
+		mono_definitions: gen.mono_definitions
+		c_flags: gen.c_flags
 	}
 }
 
@@ -1114,16 +1111,12 @@ fn generate_source_files(input_sources []FastcSourceFile, module_aliases map[str
 	mut globals := map[string]string{}
 	mut public_globals := map[string]bool{}
 	for source_file in sources {
-		collect_declared_types(source_file.source, source_file.path,
-			source_file.header.module_name, prefs, mut declared_types, mut declared_kinds, mut
-			enum_flags, mut params_structs)!
+		collect_declared_types(source_file.source, source_file.path, source_file.header.module_name, prefs, mut declared_types, mut declared_kinds, mut enum_flags, mut params_structs)!
 	}
 	declared_type_c_names := fastc_declared_type_c_names(declared_types)
 	for source_file in sources {
-		collect_constant_names(source_file.source, source_file.path,
-			source_file.header.module_name, prefs, mut constants, mut public_constants)!
-		collect_global_names(source_file.source, source_file.path, source_file.header, prefs, mut
-			globals, mut public_globals)!
+		collect_constant_names(source_file.source, source_file.path, source_file.header.module_name, prefs, mut constants, mut public_constants)!
+		collect_global_names(source_file.source, source_file.path, source_file.header, prefs, mut globals, mut public_globals)!
 	}
 	mut functions := map[string]FastcFunctionSignature{}
 	mut interface_methods := map[string]bool{}
@@ -1133,17 +1126,13 @@ fn generate_source_files(input_sources []FastcSourceFile, module_aliases map[str
 	mut embed_embedders := []string{}
 	mut embed_embeddeds := []string{}
 	for source_file in sources {
-		collect_function_signatures(source_file.source, source_file.path, source_file.header,
-			prefs, declared_types, declared_type_c_names, params_structs, mut functions)!
-		collect_interface_method_signatures(source_file.source, source_file.path,
-			source_file.header, prefs, declared_types, mut functions, mut interface_methods, mut
-			interface_fields, mut embed_embedders, mut embed_embeddeds)!
+		collect_function_signatures(source_file.source, source_file.path, source_file.header, prefs, declared_types, declared_type_c_names, params_structs, mut functions)!
+		collect_interface_method_signatures(source_file.source, source_file.path, source_file.header, prefs, declared_types, mut functions, mut interface_methods, mut interface_fields, mut embed_embedders, mut embed_embeddeds)!
 	}
 	// An interface that embeds another (`interface B { A; ... }`) inherits A's
 	// methods. Copy them onto B (with the receiver re-keyed to B) so calls on a B
 	// value resolve and B gets its own dispatch table entries.
-	fastc_promote_embedded_interface_methods(embed_embedders, embed_embeddeds, mut functions, mut
-		interface_methods)
+	fastc_promote_embedded_interface_methods(embed_embedders, embed_embeddeds, mut functions, mut interface_methods)
 	used_function_names := fastc_collect_referenced_function_names(sources, prefs, functions)
 	has_c_functions := fastc_functions_declare_c(functions)
 	fastc_prefixed_c_names := fastc_reserved_temporary_c_names(functions, globals)
@@ -1161,30 +1150,17 @@ fn generate_source_files(input_sources []FastcSourceFile, module_aliases map[str
 			fastc_register_composite_type(parameter_type, mut composite_types)
 		}
 	}
-	type_output := fastc_generate_type_declarations(sources, prefs, declared_types, declared_kinds,
-		enum_flags, constants, public_constants, mut struct_fields, mut struct_field_info, mut
-		composite_types)!
+	type_output := fastc_generate_type_declarations(sources, prefs, declared_types, declared_kinds, enum_flags, constants, public_constants, mut struct_fields, mut struct_field_info, mut composite_types)!
 	type_declarations := type_output.declarations
 	enum_field_types := type_output.enum_field_types.clone()
 	mut constant_types := map[string]string{}
 	mut global_types := map[string]string{}
-	fastc_render_struct_field_defaults(prefs, declared_types, declared_type_c_names,
-		fastc_prefixed_c_names, declared_kinds, enum_flags, enum_field_types,
-		type_output.alias_base_types, struct_fields, mut struct_field_info, functions, constants,
-		public_constants, constant_types, globals, public_globals, global_types,
-		type_output.sum_types)!
-	constant_output := fastc_generate_constant_declarations(sources, prefs, declared_types,
-		declared_type_c_names, fastc_prefixed_c_names, declared_kinds, enum_flags,
-		enum_field_types, type_output.alias_base_types, struct_fields, struct_field_info,
-		functions, constants, public_constants, globals, public_globals, mut constant_types)!
+	fastc_render_struct_field_defaults(prefs, declared_types, declared_type_c_names, fastc_prefixed_c_names, declared_kinds, enum_flags, enum_field_types, type_output.alias_base_types, struct_fields, mut struct_field_info, functions, constants, public_constants, constant_types, globals, public_globals, global_types, type_output.sum_types)!
+	constant_output := fastc_generate_constant_declarations(sources, prefs, declared_types, declared_type_c_names, fastc_prefixed_c_names, declared_kinds, enum_flags, enum_field_types, type_output.alias_base_types, struct_fields, struct_field_info, functions, constants, public_constants, globals, public_globals, mut constant_types)!
 	for name, _ in constant_output.composite_types {
 		composite_types[name] = true
 	}
-	global_output := fastc_generate_global_declarations(sources, prefs, declared_types,
-		declared_type_c_names, fastc_prefixed_c_names, declared_kinds, enum_flags,
-		enum_field_types, type_output.alias_base_types, struct_fields, struct_field_info,
-		functions, constants, constant_output.compile_time_values, public_constants,
-		constant_types, globals, public_globals, mut global_types)!
+	global_output := fastc_generate_global_declarations(sources, prefs, declared_types, declared_type_c_names, fastc_prefixed_c_names, declared_kinds, enum_flags, enum_field_types, type_output.alias_base_types, struct_fields, struct_field_info, functions, constants, constant_output.compile_time_values, public_constants, constant_types, globals, public_globals, mut global_types)!
 	for name, _ in global_output.composite_types {
 		composite_types[name] = true
 	}
@@ -1194,8 +1170,7 @@ fn generate_source_files(input_sources []FastcSourceFile, module_aliases map[str
 	for global_type in global_types.values() {
 		fastc_register_composite_type(global_type, mut composite_types)
 	}
-	startup_initializers := fastc_generate_startup_initializers(sources,
-		constant_output.module_initializers, global_output.module_initializers, module_init_calls)!
+	startup_initializers := fastc_generate_startup_initializers(sources, constant_output.module_initializers, global_output.module_initializers, module_init_calls)!
 	mut prototypes := strings.new_builder(1024)
 	mut body := strings.new_builder(4096)
 	mut fixed_array_types := constant_output.fixed_array_types.clone()
@@ -1211,34 +1186,34 @@ fn generate_source_files(input_sources []FastcSourceFile, module_aliases map[str
 	}
 	mut entry_has_main := false
 	ctx := FastcFileGenContext{
-		prefs:                  unsafe { prefs }
-		declared_types:         declared_types
-		declared_type_c_names:  declared_type_c_names
+		prefs: unsafe { prefs }
+		declared_types: declared_types
+		declared_type_c_names: declared_type_c_names
 		fastc_prefixed_c_names: fastc_prefixed_c_names
-		has_c_functions:        has_c_functions
-		declared_kinds:         declared_kinds
-		enum_flags:             enum_flags
-		enum_field_types:       enum_field_types
-		alias_base_types:       type_output.alias_base_types
-		sum_types:              type_output.sum_types
-		struct_fields:          struct_fields
-		struct_field_info:      struct_field_info
+		has_c_functions: has_c_functions
+		declared_kinds: declared_kinds
+		enum_flags: enum_flags
+		enum_field_types: enum_field_types
+		alias_base_types: type_output.alias_base_types
+		sum_types: type_output.sum_types
+		struct_fields: struct_fields
+		struct_field_info: struct_field_info
 		generic_method_sources: generic_method_sources
-		module_aliases:         module_aliases
-		interface_fields:       interface_fields
-		constants:              constants
-		constant_values:        constant_output.compile_time_values
-		public_constants:       public_constants
-		globals:                globals
-		public_globals:         public_globals
-		used_function_names:    used_function_names
-		has_startup_inits:      startup_initializers.len > 0
-		has_cleanup_hooks:      module_cleanup_calls.len > 0
-		functions:              functions
-		constant_types:         constant_types
-		global_types:           global_types
-		fixed_array_types:      fixed_array_types
-		composite_types:        composite_types
+		module_aliases: module_aliases
+		interface_fields: interface_fields
+		constants: constants
+		constant_values: constant_output.compile_time_values
+		public_constants: public_constants
+		globals: globals
+		public_globals: public_globals
+		used_function_names: used_function_names
+		has_startup_inits: startup_initializers.len > 0
+		has_cleanup_hooks: module_cleanup_calls.len > 0
+		functions: functions
+		constant_types: constant_types
+		global_types: global_types
+		fixed_array_types: fixed_array_types
+		composite_types: composite_types
 	}
 	mut spawn_typedefs := map[string]string{}
 	mut spawn_helpers := map[string]string{}
@@ -1281,8 +1256,7 @@ fn generate_source_files(input_sources []FastcSourceFile, module_aliases map[str
 		body.write_string(mono_definitions[mono_name])
 	}
 	synthesized_main := if has_entry_module && !entry_has_main {
-		fastc_synthesized_main(prefs.building_v, startup_initializers.len > 0,
-			module_cleanup_calls.len > 0)
+		fastc_synthesized_main(prefs.building_v, startup_initializers.len > 0, module_cleanup_calls.len > 0)
 	} else {
 		''
 	}
@@ -1294,8 +1268,7 @@ fn generate_source_files(input_sources []FastcSourceFile, module_aliases map[str
 		// each a stable type id in a range disjoint from the declared-type ids
 		// (1..N) and the primitive ids (0x40000000+). Only unique/consistent values
 		// matter: construction and `match` both reference `__v_typeid_<composite>`.
-		late_composite_declarations.writeln('#define __v_typeid_${composite_name} ${
-			u32(0x50000000) + u32(index)}')
+		late_composite_declarations.writeln('#define __v_typeid_${composite_name} ${u32(0x50000000) + u32(index)}')
 		declaration := 'typedef ${if composite_name.starts_with('Array_') {
 			'array'
 		} else {
@@ -1308,15 +1281,11 @@ fn generate_source_files(input_sources []FastcSourceFile, module_aliases map[str
 	if late_composite_declarations.len > 0 {
 		late_composite_declarations.writeln('')
 	}
-	interface_dispatches := fastc_generate_interface_dispatches(declared_kinds, functions,
-		interface_methods, used_function_names, prefs.building_v)
+	interface_dispatches := fastc_generate_interface_dispatches(declared_kinds, functions, interface_methods, used_function_names, prefs.building_v)
 	fixed_array_declarations := fastc_generate_fixed_array_declarations(fixed_array_types)
 	preamble := if prefs.building_v { c_selfhost_preamble } else { c_preamble }
 	hoisted_body := fastc_hoist_c_directives(body.str())
-	mut result := strings.new_builder(preamble.len + c_integer_comparison_helpers.len +
-		type_declarations.len + type_output.enum_string_helpers.len + constant_output.macros.len +
-		constant_output.declarations.len + global_output.declarations.len + prototypes.len +
-		body.len + startup_initializers.len + 96)
+	mut result := strings.new_builder(preamble.len + c_integer_comparison_helpers.len + type_declarations.len + type_output.enum_string_helpers.len + constant_output.macros.len + constant_output.declarations.len + global_output.declarations.len + prototypes.len + body.len + startup_initializers.len + 96)
 	result.write_string(preamble)
 	result.write_string(c_integer_comparison_helpers)
 	result.write_string(hoisted_body.directives)
@@ -1404,20 +1373,15 @@ fn fastc_synthesized_main(selfhost bool, has_startup_inits bool, has_cleanup_hoo
 }
 
 fn fastc_interface_method_signatures_match(interface_signature FastcFunctionSignature, candidate_signature FastcFunctionSignature) bool {
-	if candidate_signature.return_type != interface_signature.return_type
-		|| !fastc_string_types_equal(candidate_signature.return_types, interface_signature.return_types)
-		|| candidate_signature.option_type != interface_signature.option_type
-		|| candidate_signature.parameter_types.len != interface_signature.parameter_types.len {
+	if candidate_signature.return_type != interface_signature.return_type || !fastc_string_types_equal(candidate_signature.return_types, interface_signature.return_types) || candidate_signature.option_type != interface_signature.option_type || candidate_signature.parameter_types.len != interface_signature.parameter_types.len {
 		return false
 	}
 	for i in 0 .. interface_signature.parameter_types.len {
 		if i > 0 && candidate_signature.parameter_types[i] != interface_signature.parameter_types[i] {
 			return false
 		}
-		interface_parameter_is_mut := i < interface_signature.parameter_mutability.len
-			&& interface_signature.parameter_mutability[i]
-		candidate_parameter_is_mut := i < candidate_signature.parameter_mutability.len
-			&& candidate_signature.parameter_mutability[i]
+		interface_parameter_is_mut := i < interface_signature.parameter_mutability.len && interface_signature.parameter_mutability[i]
+		candidate_parameter_is_mut := i < candidate_signature.parameter_mutability.len && candidate_signature.parameter_mutability[i]
 		if candidate_parameter_is_mut != interface_parameter_is_mut {
 			return false
 		}
@@ -1453,17 +1417,17 @@ fn fastc_promote_embedded_interface_methods(embed_embedders []string, embed_embe
 					promoted_params[0] = embedder_type
 				}
 				functions[promoted_key] = FastcFunctionSignature{
-					parameter_types:          promoted_params
-					parameter_mutability:     source.parameter_mutability.clone()
-					return_type:              source.return_type
-					return_types:             source.return_types.clone()
-					option_type:              source.option_type
-					is_variadic:              source.is_variadic
+					parameter_types: promoted_params
+					parameter_mutability: source.parameter_mutability.clone()
+					return_type: source.return_type
+					return_types: source.return_types.clone()
+					option_type: source.option_type
+					is_variadic: source.is_variadic
 					last_parameter_is_params: source.last_parameter_is_params
-					is_public:                source.is_public
-					is_disabled:              source.is_disabled
-					module_name:              source.module_name
-					path:                     source.path
+					is_public: source.is_public
+					is_disabled: source.is_disabled
+					module_name: source.module_name
+					path: source.path
 				}
 				interface_methods[promoted_key] = true
 				changed = true
@@ -1502,26 +1466,22 @@ fn fastc_generate_interface_dispatches(declared_kinds map[string]FastcDeclaredTy
 				parameters << '${interface_signature.parameter_types[i]} arg${i}'
 				arguments << 'arg${i}'
 			}
-			c_name := fastc_method_c_name(interface_signature.module_name, interface_type,
-				method_name)
+			c_name := fastc_method_c_name(interface_signature.module_name, interface_type, method_name)
 			out.writeln('${interface_signature.return_type} ${c_name}(${parameters.join(', ')}) {')
 			out.writeln('\tswitch (value._typ) {')
 			for candidate_key in function_keys {
 				if selfhost && method_name !in used_function_names {
 					continue
 				}
-				if candidate_key == interface_method_key
-					|| candidate_key.all_after_last('.') != method_name {
+				if candidate_key == interface_method_key || candidate_key.all_after_last('.') != method_name {
 					continue
 				}
 				receiver_key := candidate_key.all_before_last('.')
-				if declared_kinds[receiver_key] in [.interface_, .enum_, .alias_]
-					|| receiver_key !in declared_kinds {
+				if declared_kinds[receiver_key] in [.interface_, .enum_, .alias_] || receiver_key !in declared_kinds {
 					continue
 				}
 				candidate_signature := functions[candidate_key]
-				if !fastc_interface_method_signatures_match(interface_signature,
-					candidate_signature) {
+				if !fastc_interface_method_signatures_match(interface_signature, candidate_signature) {
 					continue
 				}
 				receiver_type := fastc_c_declared_type_name(receiver_key)
@@ -1536,8 +1496,7 @@ fn fastc_generate_interface_dispatches(declared_kinds map[string]FastcDeclaredTy
 				} else {
 					''
 				}
-				call := '${fastc_method_c_name(candidate_signature.module_name, receiver_type,
-					method_name)}(${receiver_argument}${call_arguments})'
+				call := '${fastc_method_c_name(candidate_signature.module_name, receiver_type, method_name)}(${receiver_argument}${call_arguments})'
 				out.writeln('\tcase __v_typeid_${receiver_type}: ${if interface_signature.return_type == 'void' {
 					call + '; return;'
 				} else {
@@ -1587,9 +1546,9 @@ fn fastc_hoist_c_directives(source string) FastcHoistedCSource {
 		conditional_code.writeln('')
 	}
 	return FastcHoistedCSource{
-		directives:       directives.str()
+		directives: directives.str()
 		conditional_code: conditional_code.str()
-		body:             body.str()
+		body: body.str()
 	}
 }
 

--- a/vlib/v3/gen/fastc/fastc_test.v
+++ b/vlib/v3/gen/fastc/fastc_test.v
@@ -929,7 +929,7 @@ pub fn ping() {}
 	}
 	assert resolved_modules == ['main', 'alpha']
 	prefs.building_v = true
-	c_source, _ := generate_source_files(sources, aliases, prefs) or { panic(err) }
+	c_source, _, _ := generate_source_files(sources, aliases, prefs) or { panic(err) }
 	assert c_source.contains('\talpha__init();'), c_source
 	assert c_source.contains('\talpha__cleanup();'), c_source
 	assert !c_source.contains('beta__init'), c_source
@@ -972,7 +972,7 @@ fn main() {
 pub type Duration = i64
 pub fn (d Duration) microseconds() i64 { return i64(d) / 1000 }
 '
-	c_source, _ := generate_source_files([
+	c_source, _, _ := generate_source_files([
 		FastcSourceFile{
 			path: 'main.v'
 			source: main_source
@@ -1778,7 +1778,7 @@ pub fn make() Settings {
 		'module main\nimport records\nfn main() { value := records.Settings{secret: 1}; println(value.visible) }\n',
 	] {
 		mut message := ''
-		unused_source, _ := generate_source_files([
+		if _, _, _ := generate_source_files([
 			FastcSourceFile{
 				path: main_file
 				source: source
@@ -1790,19 +1790,16 @@ pub fn make() Settings {
 				header: fastc_scan_source_header(module_source, module_file, prefs) or {
 					panic(err)}
 			},
-		], map[string]string{}, prefs) or {
+		], map[string]string{}, prefs) {
+			assert false, 'private field access unexpectedly compiled'
+		} else {
 			message = err.msg()
-			{
-				''
-				false
-			}
 		}
-		_ = unused_source
 		assert message.contains('private field `Settings.secret` from imported module `records`'), message
 	}
 
 	valid_source := 'module main\nimport records\nfn main() { value := records.Settings{visible: 2}; println(value.visible) }\n'
-	c_source, _ := generate_source_files([
+	c_source, _, _ := generate_source_files([
 		FastcSourceFile{
 			path: main_file
 			source: valid_source
@@ -1847,7 +1844,7 @@ fn main() {
 }
 '
 	mut message := ''
-	unused_source, _ := generate_source_files([
+	if _, _, _ := generate_source_files([
 		FastcSourceFile{
 			path: main_file
 			source: invalid_source
@@ -1858,14 +1855,11 @@ fn main() {
 			source: module_source
 			header: fastc_scan_source_header(module_source, module_file, prefs) or { panic(err) }
 		},
-	], map[string]string{}, prefs) or {
+	], map[string]string{}, prefs) {
+		assert false, 'immutable field mutation unexpectedly compiled'
+	} else {
 		message = err.msg()
-		{
-			''
-			false
-		}
 	}
-	_ = unused_source
 	assert message.contains('mutation of immutable field `Config.read_only`'), message
 
 	valid_source := 'module main
@@ -1877,7 +1871,7 @@ fn main() {
 	config.writable = 2
 }
 '
-	c_source, _ := generate_source_files([
+	c_source, _, _ := generate_source_files([
 		FastcSourceFile{
 			path: main_file
 			source: valid_source
@@ -3175,7 +3169,7 @@ fn main() {
 }
 '
 	mut field_message := ''
-	unused_source, _ := generate_source_files([
+	if _, _, _ := generate_source_files([
 		FastcSourceFile{
 			path: 'immutable_flag_field.v'
 			source: main_source
@@ -3187,14 +3181,11 @@ fn main() {
 			source: module_source
 			header: fastc_scan_source_header(module_source, 'settings.v', prefs) or { panic(err) }
 		},
-	], map[string]string{}, prefs) or {
+	], map[string]string{}, prefs) {
+		assert false, 'immutable flag receiver unexpectedly compiled'
+	} else {
 		field_message = err.msg()
-		{
-			''
-			false
-		}
 	}
-	_ = unused_source
 	assert field_message.contains('receiver field `Config.permissions` is not `pub mut`'), field_message
 
 	c_source := generate('module main
@@ -4940,7 +4931,7 @@ fn main() {
 	copy_byte(mut file, []u8{}, 0)
 }
 '
-	c_source, _ := generate_source_files([
+	c_source, _, _ := generate_source_files([
 		FastcSourceFile{
 			path: 'main.v'
 			source: main_source
@@ -6856,7 +6847,7 @@ pub struct Config {
 pub fn run[A, B](mut app A, config Config) ! {
 }
 '
-	c_source, _ := generate_source_files([
+	c_source, _, _ := generate_source_files([
 		FastcSourceFile{
 			path: 'main.v'
 			source: main_source
@@ -9857,10 +9848,11 @@ fn main() {
 	assert c_source.contains('take((Option){.state=2})'), c_source
 }
 
-fn test_selfhost_anonymous_function_stub() {
+fn test_selfhost_anonymous_function_is_rejected() {
 	mut prefs := pref.new_preferences()
 	prefs.building_v = true
-	c_source := generate('module main
+	mut message := ''
+	if _ := generate('module main
 
 fn apply(f fn (int) int, x int) int {
 	return f(x)
@@ -9872,14 +9864,12 @@ fn main() {
 	}
 	_ := apply(g, 5)
 }
-', 'selfhost_anon_fn.v', prefs) or { panic(err) }
-	// A function literal `fn (x int) int { … }` in expression position lowers to a
-	// compile-only stub: a top-level `int …__anonfn_N(int) { return (int){0}; }` whose
-	// address is taken as the function-pointer value. FastC has no closure runtime, so
-	// the stub is non-functional (mirrors the channel stubs).
-	assert c_source.contains('__anonfn_'), c_source
-	assert c_source.contains('return (int){0};'), c_source
-	assert !c_source.contains('main.main.'), c_source
+', 'selfhost_anon_fn.v', prefs) {
+		assert false, 'function literal unexpectedly compiled'
+	} else {
+		message = err.msg()
+	}
+	assert message.contains('function literals and closures'), message
 }
 
 fn test_selfhost_c_struct_keyword_field_name() {
@@ -10074,6 +10064,29 @@ fn main() {
 	assert c_source.contains('inner_mono_int'), c_source
 }
 
+fn test_selfhost_nested_explicit_generic_rewrite_is_emitted_in_outer_copy() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+fn helper[T](value T) T {
+	return value
+}
+
+fn outer[T](value T) int {
+	_ = value
+	return helper[int](1)
+}
+
+fn main() {
+	_ := outer(true)
+}
+', 'selfhost_nested_explicit_generic.v', prefs) or { panic(err) }
+	assert c_source.contains('int helper_mono_int(int value)'), c_source
+	assert c_source.contains('return helper_mono_int(1);'), c_source
+	assert !c_source.contains('helper[int]'), c_source
+}
+
 fn test_selfhost_comptime_unaliased_typ() {
 	mut prefs := pref.new_preferences()
 	prefs.building_v = true
@@ -10234,6 +10247,151 @@ fn main() {
 	], map[string]string{}, prefs) or { panic(err) }
 	definition := 'string util__identity_mono_string(string value) {'
 	assert c_source.count(definition) == 1, c_source
+}
+
+fn test_selfhost_on_demand_generic_specializes_composite_return_type() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	util_source := 'module util
+
+pub fn wrap[T](value T) []T {
+	return [value]
+}
+
+pub fn maybe[T](value T) ?[]T {
+	return [value]
+}
+
+pub fn lookup[T](value T) map[string]T {
+	return {
+		"value": value
+	}
+}
+
+pub fn pair[T](value T) (T, []T) {
+	return value, [value]
+}
+
+pub struct Wrapper {}
+
+pub fn (wrapper Wrapper) wrap_method[T](value T) []T {
+	_ = wrapper
+	return [value]
+}
+'
+	main_source := 'module main
+import util
+
+fn main() {
+	values := util.wrap[int](1)
+	_ := values[0]
+	maybe_values := util.maybe[int](1) or { []int{} }
+	_ := maybe_values[0]
+	mapped := util.lookup[int](1)
+	_ := mapped["value"]
+	left, right := util.pair[int](1)
+	_ = left
+	_ := right[0]
+	wrapper := util.Wrapper{}
+	method_values := wrapper.wrap_method[int](1)
+	_ := method_values[0]
+}
+'
+	c_source, _, _ := generate_source_files([
+		FastcSourceFile{
+			path: 'util/util.v'
+			source: util_source
+			header: fastc_scan_source_header(util_source, 'util/util.v', prefs) or { panic(err) }
+		},
+		FastcSourceFile{
+			path: 'main.v'
+			source: main_source
+			header: fastc_scan_source_header(main_source, 'main.v', prefs) or { panic(err) }
+		},
+	], map[string]string{}, prefs) or { panic(err) }
+	assert c_source.contains('Array_int util__wrap_mono_int(int value)'), c_source
+	assert c_source.contains('Option util__maybe_mono_int(int value)'), c_source
+	assert c_source.contains('Map_string_int util__lookup_mono_int(int value)'), c_source
+	assert c_source.contains('MultiReturn util__pair_mono_int(int value)'), c_source
+	assert c_source.contains('Array_int util__Wrapper_wrap_method_mono_int('), c_source
+	assert c_source.contains('__typeof__((util__wrap_mono_int(1))) values'), c_source
+	assert !c_source.contains('Array_voidptr values'), c_source
+	assert fastc_specialized_generic_result_type('Map_string_Array_voidptr', 'int') == 'Map_string_Array_int'
+	assert fastc_specialized_generic_result_type('voidptr*', 'int') == 'int*'
+}
+
+fn test_selfhost_on_demand_generic_infers_composite_parameter_type() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	util_source := 'module util
+
+pub fn head[T](items []T) T {
+	return items[0]
+}
+
+pub fn lookup[T](items map[string]T) T {
+	return items["value"]
+}
+'
+	main_source := 'module main
+import util
+
+fn main() {
+	items := [11, 22]
+	_ := util.head(items)
+	mapped := {
+		"value": 33
+	}
+	_ := util.lookup(mapped)
+}
+'
+	c_source, _, _ := generate_source_files([
+		FastcSourceFile{
+			path: 'util/util.v'
+			source: util_source
+			header: fastc_scan_source_header(util_source, 'util/util.v', prefs) or { panic(err) }
+		},
+		FastcSourceFile{
+			path: 'main.v'
+			source: main_source
+			header: fastc_scan_source_header(main_source, 'main.v', prefs) or { panic(err) }
+		},
+	], map[string]string{}, prefs) or { panic(err) }
+	assert c_source.contains('int util__head_mono_int(Array_int items)'), c_source
+	assert c_source.contains('int util__lookup_mono_int(Map_string_int items)'), c_source
+	assert c_source.contains('util__head_mono_int(items)'), c_source
+	assert c_source.contains('util__lookup_mono_int(mapped)'), c_source
+	assert fastc_infer_generic_type_from_parameter('Array_voidptr', 'Array_int') == 'int'
+	assert fastc_infer_generic_type_from_parameter('Map_string_Array_voidptr', 'Map_string_Array_example__Item_ptr') == 'example__Item*'
+}
+
+fn test_selfhost_user_voidptr_generic_method_named_check_element_type_valid_keeps_body() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Validator {}
+
+fn (v Validator) check_element_type_valid[T](element T) bool {
+	_ = v
+	_ = element
+	return true
+}
+
+fn validate(value voidptr) bool {
+	validator := Validator{}
+	return validator.check_element_type_valid(value)
+}
+
+fn main() {
+	_ := validate(unsafe { nil })
+}
+', 'selfhost_user_check_element_type_valid.v', prefs) or { panic(err) }
+	marker := '\nbool Validator_check_element_type_valid_mono_voidptr('
+	definition_start := c_source.last_index(marker) or { -1 }
+	assert definition_start >= 0, c_source
+	definition := c_source[definition_start..]
+	assert definition.contains('return ((bool)true);'), definition
 }
 
 fn test_selfhost_on_demand_generic_erases_imported_generic_struct_arguments() {

--- a/vlib/v3/gen/fastc/fn.v
+++ b/vlib/v3/gen/fastc/fn.v
@@ -28,7 +28,7 @@ fn (mut g Parser) drain_pending_mono() ! {
 			continue
 		}
 		instance = g.erase_mono_generic_type_arguments(instance, src)
-		if req.concrete == 'voidptr' && req.source_key.ends_with('.check_element_type_valid') {
+		if fastc_is_json2_voidptr_element_check(req, src) {
 			if body_open := instance.index('{') {
 				instance = instance[..body_open + 1] + '\nreturn false\n}'
 			}
@@ -49,6 +49,14 @@ fn (mut g Parser) drain_pending_mono() ! {
 			g.mono_definitions[c_name] = definition
 		}
 	}
+}
+
+// fastc_is_json2_voidptr_element_check scopes the erased-placeholder fallback to
+// json2's internal decoder helper. A user method with the same ordinary name must
+// retain its specialized body.
+fn fastc_is_json2_voidptr_element_check(req FastcMonoRequest, src FastcGenericMethodSource) bool {
+	normalized_path := src.path.replace('\\', '/')
+	return req.concrete == 'voidptr' && src.name == 'check_element_type_valid' && (src.receiver_type == 'json2__Decoder' || src.receiver_type.ends_with('__json2__Decoder')) && normalized_path.ends_with('/vlib/json2/decode_sumtype.v')
 }
 
 // parse_mono_instance re-parses one concrete instance in its defining module, so its body
@@ -139,8 +147,7 @@ fn (mut g Parser) parse_top_level_items(stop_at_block_end bool) ! {
 fn (mut g Parser) parse_c_directive() ! {
 	directive := g.lit.trim_space()
 	g.next()
-	if directive == 'flag' || directive.starts_with('flag ') || directive == 'pkgconfig'
-		|| directive.starts_with('pkgconfig ') {
+	if directive == 'flag' || directive.starts_with('flag ') || directive == 'pkgconfig' || directive.starts_with('pkgconfig ') {
 		// FastC's compiler invocation supplies its own target flags. The bootstrap
 		// dependency set only uses these directives for optional libraries.
 		if g.prefs.selfhost {
@@ -152,8 +159,8 @@ fn (mut g Parser) parse_c_directive() ! {
 			// inert for this build; skip it instead of rejecting the whole program,
 			// mirroring the `#include <os>` target filtering below.
 			qualifier := rest.all_before(' ')
-			if qualifier in ['windows', 'macos', 'darwin', 'ios', 'mac', 'linux', 'freebsd',
-				'openbsd', 'netbsd', 'dragonfly', 'solaris', 'android'] {
+			if qualifier in ['windows', 'macos', 'darwin', 'ios', 'mac', 'linux', 'freebsd', 'openbsd',
+				'netbsd', 'dragonfly', 'solaris', 'android'] {
 				if !pref.comptime_flag_value(g.prefs, qualifier) {
 					return
 				}
@@ -235,8 +242,7 @@ fn fastc_c_flag_args(raw string, vroot string, source_file string) ![]string {
 				break
 			}
 		}
-		if (arg.ends_with('.o') || arg.ends_with('.a') || arg.ends_with('.obj')
-			|| arg.ends_with('.lib')) && !os.is_abs_path(arg) {
+		if (arg.ends_with('.o') || arg.ends_with('.a') || arg.ends_with('.obj') || arg.ends_with('.lib')) && !os.is_abs_path(arg) {
 			args[i] = os.join_path(base_dir, arg)
 		}
 		resolved_arg := args[i]
@@ -287,9 +293,7 @@ fn fastc_flag_is_skippable(flag string) bool {
 			i += 2
 			continue
 		}
-		if part.starts_with('-l') || part.starts_with('-L') || part.starts_with('-Wl')
-			|| part.starts_with('-rpath') || part.starts_with('-I') || part.starts_with('-F')
-			|| part == '-pthread' {
+		if part.starts_with('-l') || part.starts_with('-L') || part.starts_with('-Wl') || part.starts_with('-rpath') || part.starts_with('-I') || part.starts_with('-F') || part == '-pthread' {
 			i++
 			continue
 		}
@@ -301,8 +305,7 @@ fn fastc_flag_is_skippable(flag string) bool {
 		// A bare object / static-library link input (`@VEXEROOT/.../cJSON.o`): FastC drives
 		// its own tcc link line and does not add these, so skip it. If a live reference to
 		// its symbols survives reachability, the link fails explicitly instead.
-		if part.ends_with('.o') || part.ends_with('.a') || part.ends_with('.obj')
-			|| part.ends_with('.lib') {
+		if part.ends_with('.o') || part.ends_with('.a') || part.ends_with('.obj') || part.ends_with('.lib') {
 			i++
 			continue
 		}
@@ -335,8 +338,7 @@ fn fastc_flag_defines(flag string) ?[]string {
 			}
 			continue
 		}
-		if part.starts_with('-l') || part.starts_with('-L') || part.starts_with('-I')
-			|| part.starts_with('-Wl') || part.starts_with('-rpath') || part == '-pthread' {
+		if part.starts_with('-l') || part.starts_with('-L') || part.starts_with('-I') || part.starts_with('-Wl') || part.starts_with('-rpath') || part == '-pthread' {
 			continue
 		}
 		return none
@@ -617,9 +619,9 @@ fn (mut g Parser) parse_function(enabled bool) ! {
 		}
 		params << '${receiver_parameter_type} ${fastc_c_identifier(receiver_name)}'
 		g.locals[receiver_name] = FastcLocal{
-			is_mut:       receiver_is_mut
+			is_mut: receiver_is_mut
 			is_reference: receiver_is_reference
-			typ:          receiver_parameter_type
+			typ: receiver_parameter_type
 		}
 	}
 	if g.tok != .name && !(g.tok.is_overloadable() || g.tok.is_keyword()) {
@@ -699,8 +701,7 @@ fn (mut g Parser) parse_function(enabled bool) ! {
 	} else {
 		'${receiver_key}.${name}'
 	}
-	is_main := !is_static_method && receiver_type == '' && g.module_name in ['', 'main']
-		&& name == 'main'
+	is_main := !is_static_method && receiver_type == '' && g.module_name in ['', 'main'] && name == 'main'
 	is_module_init := !is_static_method && receiver_type == '' && name == 'init'
 	is_module_cleanup := !is_static_method && receiver_type == '' && name == 'cleanup'
 	if is_main {
@@ -718,17 +719,17 @@ fn (mut g Parser) parse_function(enabled bool) ! {
 		g.next()
 		return
 	}
-	is_fastc_source := name.starts_with('fastc_') || g.path.ends_with('/fastc/fastc.v')
-		|| g.module_name.ends_with('fastc')
-	if g.selfhost && name != 'fastc_collect_referenced_function_names' && !is_fastc_source
-		&& name !in ['main', 'init', 'cleanup'] && name !in g.used_function_names && name.len > 0
-		&& (name[0].is_letter() || name[0] == `_`) && !g.in_mono_drain {
+	is_fastc_source := name.starts_with('fastc_') || g.path.ends_with('/fastc/fastc.v') || g.module_name.ends_with('fastc')
+	if g.selfhost && name != 'fastc_collect_referenced_function_names' && !is_fastc_source && name !in [
+		'main',
+		'init',
+		'cleanup',
+	] && name !in g.used_function_names && name.len > 0 && (name[0].is_letter() || name[0] == `_`) && !g.in_mono_drain {
 		g.skip_balanced(.lcbr, .rcbr)!
 		return
 	}
 	if signature := g.functions[function_key] {
-		if signature.path != g.path && name != 'fastc_collect_referenced_function_names'
-			&& !is_fastc_source {
+		if signature.path != g.path && name != 'fastc_collect_referenced_function_names' && !is_fastc_source {
 			g.skip_balanced(.lcbr, .rcbr)!
 			return
 		}
@@ -865,8 +866,7 @@ fn (mut g Parser) parse_function(enabled bool) ! {
 		}
 		previous_placeholder := g.in_generic_placeholder
 		g.in_generic_placeholder = true
-		terminates = g.parse_generic_body_or_stub(return_type, out_checkpoint, saved_indent,
-			body_end, force_stub)
+		terminates = g.parse_generic_body_or_stub(return_type, out_checkpoint, saved_indent, body_end, force_stub)
 		g.in_generic_placeholder = previous_placeholder
 	} else {
 		terminates = g.parse_block_body()!
@@ -1091,17 +1091,17 @@ fn (mut g Parser) parse_parameters() ![]string {
 				// compiles as a direct call; the return C type is recovered above.
 				params << '${fn_return_type} (*${c_name})()'
 				g.locals[parameter_name] = FastcLocal{
-					is_mut:               is_mut
-					typ:                  type_name
-					fn_return_type:       fn_return_type
+					is_mut: is_mut
+					typ: type_name
+					fn_return_type: fn_return_type
 					fn_option_value_type: fn_option_value_type
 				}
 			} else {
 				params << '${type_name} ${c_name}'
 				g.locals[parameter_name] = FastcLocal{
-					is_mut:            is_mut
-					is_reference:      is_reference
-					typ:               type_name
+					is_mut: is_mut
+					is_reference: is_reference
+					typ: type_name
 					option_value_type: option_value_type
 				}
 			}
@@ -1141,8 +1141,7 @@ fn (mut g Parser) parse_type() !string {
 		// declared with unspecified args), so only the return type is recovered.
 		g.peek_fn_pointer_signature()
 	}
-	type_name, next_token := fastc_scan_type(mut g.s, g.tok, g.path, g.module_name, g.imports,
-		g.declared_types, g.selfhost) or { return g.unsupported(err.msg()) }
+	type_name, next_token := fastc_scan_type(mut g.s, g.tok, g.path, g.module_name, g.imports, g.declared_types, g.selfhost) or { return g.unsupported(err.msg()) }
 	g.tok = next_token
 	g.lit = g.s.lit
 	if !g.selfhost && (first_lit in ['charptr', 'rune'] || type_name == 'char*') {
@@ -1154,8 +1153,7 @@ fn (mut g Parser) parse_type() !string {
 // peek_option_value_type scans an option type's wrapped value type from a lookahead
 // scanner, returning '' if it cannot be determined.
 fn (g &Parser) peek_option_value_type(mut look scanner.Scanner, first token.Token) string {
-	value_type, _ := fastc_scan_type(mut look, first, g.path, g.module_name, g.imports,
-		g.declared_types, g.selfhost) or { return '' }
+	value_type, _ := fastc_scan_type(mut look, first, g.path, g.module_name, g.imports, g.declared_types, g.selfhost) or { return '' }
 	return value_type
 }
 
@@ -1188,8 +1186,7 @@ fn (mut g Parser) peek_fn_pointer_signature() {
 			g.pending_fn_option_value_type = g.peek_option_value_type(mut look, value_tok)
 		}
 	} else if tok !in [.lcbr, .semicolon, .comma, .rpar, .eof] {
-		scanned, _ := fastc_scan_type(mut look, tok, g.path, g.module_name, g.imports,
-			g.declared_types, g.selfhost) or { return }
+		scanned, _ := fastc_scan_type(mut look, tok, g.path, g.module_name, g.imports, g.declared_types, g.selfhost) or { return }
 		return_type = scanned
 	}
 	g.pending_fn_pointer = true

--- a/vlib/v3/gen/fastc/monomorphize.v
+++ b/vlib/v3/gen/fastc/monomorphize.v
@@ -64,16 +64,16 @@ fn fastc_collect_generic_method_sources(sources []FastcSourceFile, prefs &pref.P
 				fastc_function_key(module_name, generic.name)
 			}
 			result[key] = FastcGenericMethodSource{
-				name:                       generic.name
-				type_param:                 generic.type_param
-				receiver_type:              receiver_type
-				module_name:                module_name
-				path:                       source_file.path
-				imports:                    source_file.header.imports
-				return_type_source:         generic.return_type_source
-				first_param_is_type_param:  generic.first_param_is_type_param
+				name: generic.name
+				type_param: generic.type_param
+				receiver_type: receiver_type
+				module_name: module_name
+				path: source_file.path
+				imports: source_file.header.imports
+				return_type_source: generic.return_type_source
+				first_param_is_type_param: generic.first_param_is_type_param
 				type_param_parameter_index: generic.type_param_parameter_index
-				source:                     source_file.source[generic.fn_start..generic.def_end]
+				source: source_file.source[generic.fn_start..generic.def_end]
 			}
 		}
 	}
@@ -91,7 +91,10 @@ fn (g &Parser) mono_argument_type(mut look scanner.Scanner) string {
 	mut braces := 0
 	for {
 		tok := look.scan()
-		if tok == .eof || (parens == 0 && brackets == 0 && braces == 0 && tok in [.comma, .rpar]) {
+		if tok == .eof || (parens == 0 && brackets == 0 && braces == 0 && tok in [
+			.comma,
+			.rpar,
+		]) {
 			break
 		}
 		tokens << FastcExpressionToken{
@@ -166,41 +169,35 @@ fn (mut g Parser) queue_mono_method(receiver_type string, method string, concret
 		mut parameter_types := base.parameter_types.clone()
 		parameter_index := source.type_param_parameter_index + 1
 		if source.type_param_parameter_index >= 0 && parameter_index < parameter_types.len {
-			parameter_types[parameter_index] = fastc_specialized_generic_parameter_type(parameter_types[parameter_index],
-				concrete)
+			parameter_types[parameter_index] = fastc_specialized_generic_parameter_type(parameter_types[parameter_index], concrete)
 		}
 		return_source := source.return_type_source.trim_space()
-		mut return_type := if primitive := fastc_primitive_c_type(return_source) {
-			primitive
-		} else if return_source == source.type_param {
-			concrete
-		} else if return_source.starts_with('!') || return_source.starts_with('?') {
-			'Option'
-		} else {
-			base.return_type
+		mut return_type := base.return_type
+		mut return_types := base.return_types.clone()
+		mut option_type := base.option_type
+		if fastc_generic_type_source_uses_parameter(return_source, source.type_param, g.prefs) {
+			return_type = fastc_specialized_generic_result_type(return_type, concrete)
+			return_types = fastc_specialized_generic_result_types(return_types, concrete)
+			option_type = fastc_specialized_generic_result_type(option_type, concrete)
 		}
 		if return_source == '' {
 			return_type = 'void'
 		}
 		g.mono_functions[key] = FastcFunctionSignature{
-			parameter_types:          parameter_types
-			parameter_mutability:     base.parameter_mutability.clone()
-			return_type:              return_type
-			return_types:             base.return_types.clone()
-			option_type:              if return_type == 'Option' {
-				concrete
-			} else {
-				base.option_type
-			}
-			is_variadic:              base.is_variadic
+			parameter_types: parameter_types
+			parameter_mutability: base.parameter_mutability.clone()
+			return_type: return_type
+			return_types: return_types
+			option_type: option_type
+			is_variadic: base.is_variadic
 			last_parameter_is_params: base.last_parameter_is_params
-			module_name:              source.module_name
-			path:                     source.path
-			is_public:                true
+			module_name: source.module_name
+			path: source.path
+			is_public: true
 		}
 		g.pending_mono << FastcMonoRequest{
 			source_key: source_key
-			concrete:   concrete
+			concrete: concrete
 		}
 	}
 	return mono
@@ -225,8 +222,7 @@ fn (mut g Parser) queue_explicit_mono_method(tokens []FastcExpressionToken) ?str
 		return none
 	}
 	first := look.scan()
-	concrete, next := fastc_scan_type(mut look, first, g.path, g.module_name, g.imports,
-		g.declared_types, g.selfhost) or { return none }
+	concrete, next := fastc_scan_type(mut look, first, g.path, g.module_name, g.imports, g.declared_types, g.selfhost) or { return none }
 	after := look.scan()
 	if next != .rsbr || after != .lpar {
 		return none
@@ -251,8 +247,7 @@ fn (mut g Parser) queue_explicit_mono_function(tokens []FastcExpressionToken) ?s
 		return none
 	}
 	first := look.scan()
-	concrete, next := fastc_scan_type(mut look, first, g.path, g.module_name, g.imports,
-		g.declared_types, g.selfhost) or { return none }
+	concrete, next := fastc_scan_type(mut look, first, g.path, g.module_name, g.imports, g.declared_types, g.selfhost) or { return none }
 	if next != .rsbr || look.scan() != .lpar {
 		return none
 	}
@@ -274,7 +269,13 @@ fn (mut g Parser) queue_implicit_mono_function(tokens []FastcExpressionToken) ?s
 	if look.scan() != .lpar {
 		return none
 	}
-	concrete := g.mono_argument_type_at(mut look, source.type_param_parameter_index)
+	base := g.functions[function_key] or { return none }
+	parameter_index := source.type_param_parameter_index
+	if parameter_index >= base.parameter_types.len {
+		return none
+	}
+	argument_type := g.mono_argument_type_at(mut look, parameter_index)
+	concrete := fastc_infer_generic_type_from_parameter(base.parameter_types[parameter_index], argument_type)
 	if concrete == '' {
 		return none
 	}
@@ -288,47 +289,115 @@ fn (mut g Parser) queue_mono_function(function_key string, concrete string) ?str
 	if mono_key !in g.mono_functions {
 		base := g.functions[function_key] or { return none }
 		mut parameter_types := base.parameter_types.clone()
-		if source.type_param_parameter_index >= 0
-			&& source.type_param_parameter_index < parameter_types.len {
-			parameter_types[source.type_param_parameter_index] = fastc_specialized_generic_parameter_type(parameter_types[source.type_param_parameter_index],
-				concrete)
+		if source.type_param_parameter_index >= 0 && source.type_param_parameter_index < parameter_types.len {
+			parameter_types[source.type_param_parameter_index] = fastc_specialized_generic_parameter_type(parameter_types[source.type_param_parameter_index], concrete)
 		}
-		mut return_type := base.return_type
-		mut option_type := base.option_type
 		return_source := source.return_type_source.trim_space()
-		if return_source == source.type_param {
-			return_type = concrete
-		} else if return_source in ['!${source.type_param}', '?${source.type_param}'] {
-			return_type = 'Option'
-			option_type = concrete
+		mut return_type := base.return_type
+		mut return_types := base.return_types.clone()
+		mut option_type := base.option_type
+		if fastc_generic_type_source_uses_parameter(return_source, source.type_param, g.prefs) {
+			return_type = fastc_specialized_generic_result_type(return_type, concrete)
+			return_types = fastc_specialized_generic_result_types(return_types, concrete)
+			option_type = fastc_specialized_generic_result_type(option_type, concrete)
 		}
 		g.mono_functions[mono_key] = FastcFunctionSignature{
-			parameter_types:          parameter_types
-			parameter_mutability:     base.parameter_mutability.clone()
-			return_type:              return_type
-			return_types:             base.return_types.clone()
-			option_type:              option_type
-			is_variadic:              base.is_variadic
+			parameter_types: parameter_types
+			parameter_mutability: base.parameter_mutability.clone()
+			return_type: return_type
+			return_types: return_types
+			option_type: option_type
+			is_variadic: base.is_variadic
 			last_parameter_is_params: base.last_parameter_is_params
-			is_public:                base.is_public
-			is_disabled:              base.is_disabled
-			module_name:              source.module_name
-			path:                     source.path
+			is_public: base.is_public
+			is_disabled: base.is_disabled
+			module_name: source.module_name
+			path: source.path
 		}
 		g.pending_mono << FastcMonoRequest{
 			source_key: function_key
-			concrete:   concrete
+			concrete: concrete
 		}
 	}
 	return mono
 }
 
 fn fastc_specialized_generic_parameter_type(erased string, concrete string) string {
-	base := erased.trim_right('*')
-	if base != 'voidptr' {
-		return concrete
+	return fastc_specialized_generic_result_type(erased, concrete)
+}
+
+// fastc_infer_generic_type_from_parameter extracts the concrete type argument from
+// an erased parameter spelling. Exact `T` parameters erase to `voidptr`; composite
+// parameters retain that marker inside spellings such as `Array_voidptr` and
+// `Map_string_voidptr`.
+fn fastc_infer_generic_type_from_parameter(erased string, actual string) string {
+	if erased == '' || actual == '' {
+		return ''
 	}
-	return concrete + '*'.repeat(erased.len - base.len)
+	erased_base := erased.trim_right('*')
+	if erased_base == 'voidptr' {
+		return actual.trim_right('*')
+	}
+	marker := 'voidptr'
+	marker_index := erased.index(marker) or { return '' }
+	prefix := erased[..marker_index]
+	suffix := erased[marker_index + marker.len..]
+	if !actual.starts_with(prefix) || !actual.ends_with(suffix) || actual.len < prefix.len + suffix.len {
+		return ''
+	}
+	end := actual.len - suffix.len
+	mut concrete := actual[prefix.len..end]
+	mut pointers := 0
+	for concrete.ends_with('_ptr') {
+		concrete = concrete[..concrete.len - '_ptr'.len]
+		pointers++
+	}
+	return concrete + '*'.repeat(pointers)
+}
+
+// fastc_specialized_generic_result_type replaces an erased generic placeholder at any
+// depth in FastC's composite C spelling. For example, `Array_voidptr` becomes
+// `Array_int`, while a direct `voidptr*` preserves its pointer depth as `int*`.
+fn fastc_specialized_generic_result_type(erased string, concrete string) string {
+	if erased == '' || !erased.contains('voidptr') {
+		return erased
+	}
+	base := erased.trim_right('*')
+	if base == 'voidptr' {
+		return concrete + '*'.repeat(erased.len - base.len)
+	}
+	return erased.replace('voidptr', fastc_composite_type_part(concrete))
+}
+
+fn fastc_specialized_generic_result_types(erased []string, concrete string) []string {
+	mut specialized := []string{cap: erased.len}
+	for typ in erased {
+		specialized << fastc_specialized_generic_result_type(typ, concrete)
+	}
+	return specialized
+}
+
+fn fastc_generic_type_source_uses_parameter(source string, type_params string, prefs &pref.Preferences) bool {
+	if source == '' {
+		return false
+	}
+	mut parameters := map[string]bool{}
+	for type_param in type_params.split(',') {
+		parameters[type_param] = true
+	}
+	mut file_set := token.FileSet.new()
+	mut file := file_set.add_file('generic_return_type', source.len)
+	file.index_lines_without_digest(source)
+	mut scan := scanner.new_scanner(prefs, .normal)
+	scan.init(file, source)
+	mut tok := scan.scan()
+	for tok != .eof {
+		if tok == .name && scan.lit in parameters {
+			return true
+		}
+		tok = scan.scan()
+	}
+	return false
 }
 
 // render_mono_method produces the concrete source of one generic-method instance by
@@ -362,8 +431,7 @@ fn (g &Parser) erase_mono_generic_type_arguments(source string, src FastcGeneric
 			continue
 		}
 		first_name := scan.lit
-		mut type_key := fastc_resolve_declared_type_key(src.module_name, first_name, src.imports,
-			g.declared_types) or { '' }
+		mut type_key := fastc_resolve_declared_type_key(src.module_name, first_name, src.imports, g.declared_types) or { '' }
 		tok = scan.scan()
 		if tok == .dot {
 			qualified_module := src.imports[first_name] or { '' }
@@ -392,7 +460,7 @@ fn (g &Parser) erase_mono_generic_type_arguments(source string, src FastcGeneric
 		}
 		edits << FastcSourceEdit{
 			start: bracket_start
-			end:   scan.offset
+			end: scan.offset
 		}
 		tok = scan.scan()
 	}
@@ -535,8 +603,7 @@ fn fastc_monomorphize_functions_once(sources []FastcSourceFile, prefs &pref.Pref
 		if source_file.header.module_name !in ['', 'main'] {
 			continue
 		}
-		fastc_scan_generic_calls(source_file.source, source_file.path, prefs, i, by_name, mut
-			calls, mut unresolvable, mut pairs, mut seen_pair, mut has_concrete)
+		fastc_scan_generic_calls(source_file.source, source_file.path, prefs, i, by_name, mut calls, mut unresolvable, mut pairs, mut seen_pair, mut has_concrete)
 	}
 	// A generic is monomorphized only when every call resolves.
 	mut active := map[string]bool{}
@@ -562,18 +629,22 @@ fn fastc_monomorphize_functions_once(sources []FastcSourceFile, prefs &pref.Pref
 		definition_source := definition_file.source
 		edits << FastcSourceEdit{
 			source_index: generic.source_index
-			start:        generic.fn_start
-			end:          generic.def_end
-			replacement:  ''
+			start: generic.fn_start
+			end: generic.def_end
+			replacement: ''
+		}
+		mut nested_calls := []FastcGenericCall{}
+		for call in calls {
+			if call.name in active && call.source_index == generic.source_index && call.start >= generic.fn_start && call.end <= generic.def_end {
+				nested_calls << call
+			}
 		}
 		mut copies := ''
 		for pair in pairs {
 			if pair.name != name {
 				continue
 			}
-			copies = copies + '\n' +
-				fastc_render_generic_instance(definition_source, generic, pair.concrete, prefs) +
-				'\n'
+			copies = copies + '\n' + fastc_render_generic_instance_with_call_rewrites(definition_source, generic, pair.concrete, prefs, nested_calls) + '\n'
 		}
 		appends[generic.source_index] = appends[generic.source_index] + copies
 	}
@@ -581,11 +652,21 @@ fn fastc_monomorphize_functions_once(sources []FastcSourceFile, prefs &pref.Pref
 		if call.name !in active {
 			continue
 		}
+		mut inside_removed_generic := false
+		for _, generic in by_name {
+			if generic.name in active && call.source_index == generic.source_index && call.start >= generic.fn_start && call.end <= generic.def_end {
+				inside_removed_generic = true
+				break
+			}
+		}
+		if inside_removed_generic {
+			continue
+		}
 		edits << FastcSourceEdit{
 			source_index: call.source_index
-			start:        call.start
-			end:          call.end
-			replacement:  fastc_monomorphized_name(call.name, call.concrete)
+			start: call.start
+			end: call.end
+			replacement: fastc_monomorphized_name(call.name, call.concrete)
 		}
 	}
 	mut result := []FastcSourceFile{cap: sources.len}
@@ -604,7 +685,7 @@ fn fastc_monomorphize_functions_once(sources []FastcSourceFile, prefs &pref.Pref
 			new_source = new_source + appends[i]
 		}
 		result << FastcSourceFile{
-			path:   source_file.path
+			path: source_file.path
 			source: new_source
 			header: source_file.header
 		}
@@ -685,13 +766,26 @@ fn fastc_type_param_substitutions(type_param string, concrete string) map[string
 // the generic definition with `[T]` removed, the type parameter substituted, and
 // the function renamed.
 fn fastc_render_generic_instance(source string, generic FastcGenericFn, concrete string, prefs &pref.Preferences) string {
+	return fastc_render_generic_instance_with_call_rewrites(source, generic, concrete, prefs, []FastcGenericCall{})
+}
+
+fn fastc_render_generic_instance_with_call_rewrites(source string, generic FastcGenericFn, concrete string, prefs &pref.Preferences, nested_calls []FastcGenericCall) string {
 	definition := source[generic.fn_start..generic.def_end]
 	base := generic.fn_start
 	mut edits := []FastcSourceEdit{}
 	edits << FastcSourceEdit{
-		start:       generic.bracket_start - base
-		end:         generic.bracket_end - base
+		start: generic.bracket_start - base
+		end: generic.bracket_end - base
 		replacement: ''
+	}
+	for call in nested_calls {
+		if call.source_index == generic.source_index && call.start >= generic.fn_start && call.end <= generic.def_end {
+			edits << FastcSourceEdit{
+				start: call.start - base
+				end: call.end - base
+				replacement: fastc_monomorphized_name(call.name, call.concrete)
+			}
+		}
 	}
 	mut file_set := token.FileSet.new()
 	mut file := file_set.add_file('mono', definition.len)
@@ -707,8 +801,8 @@ fn fastc_render_generic_instance(source string, generic FastcGenericFn, concrete
 		if tok == .name {
 			if !renamed && s.lit == generic.name {
 				edits << FastcSourceEdit{
-					start:       s.pos
-					end:         s.offset
+					start: s.pos
+					end: s.offset
 					replacement: fastc_monomorphized_name(generic.name, concrete)
 				}
 				renamed = true
@@ -717,8 +811,8 @@ fn fastc_render_generic_instance(source string, generic FastcGenericFn, concrete
 				// is removed by the edit above (overlapping edits would corrupt it).
 				if replacement := substitutions[s.lit] {
 					edits << FastcSourceEdit{
-						start:       s.pos
-						end:         s.offset
+						start: s.pos
+						end: s.offset
 						replacement: replacement
 					}
 				}
@@ -851,20 +945,19 @@ fn fastc_scan_generic_fns(source string, path string, prefs &pref.Preferences, s
 			continue
 		}
 		def_end := s.offset
-		type_param_parameter_index := fastc_params_type_param_index(source[params_open..params_close],
-			type_param, prefs)
+		type_param_parameter_index := fastc_params_type_param_index(source[params_open..params_close], type_param, prefs)
 		result << FastcGenericFn{
-			name:                       name
-			type_param:                 type_param
-			source_index:               source_index
-			fn_start:                   fn_start
-			def_end:                    def_end
-			bracket_start:              bracket_start
-			bracket_end:                bracket_end
-			first_param_is_type_param:  type_param_parameter_index == 0
+			name: name
+			type_param: type_param
+			source_index: source_index
+			fn_start: fn_start
+			def_end: def_end
+			bracket_start: bracket_start
+			bracket_end: bracket_end
+			first_param_is_type_param: type_param_parameter_index == 0
 			type_param_parameter_index: type_param_parameter_index
-			receiver_type:              receiver_type
-			return_type_source:         return_type_source
+			receiver_type: receiver_type
+			return_type_source: return_type_source
 		}
 		previous = .rcbr
 		previous_pos = def_end
@@ -873,10 +966,13 @@ fn fastc_scan_generic_fns(source string, path string, prefs &pref.Preferences, s
 	return result
 }
 
-// fastc_params_type_param_index returns the first parameter whose type is exactly the
-// generic type parameter (`value T`). Composite uses such as `[]T` are deliberately not
-// inferred here because the concrete element type needs deeper expression inference.
+// fastc_params_type_param_index returns the first parameter whose type contains a
+// generic type parameter, including composite uses such as `[]T` and `map[string]T`.
 fn fastc_params_type_param_index(params_source string, type_param string, prefs &pref.Preferences) int {
+	mut type_params := map[string]bool{}
+	for name in type_param.split(',') {
+		type_params[name] = true
+	}
 	mut file_set := token.FileSet.new()
 	mut file := file_set.add_file('params', params_source.len)
 	file.index_lines_without_digest(params_source)
@@ -896,23 +992,28 @@ fn fastc_params_type_param_index(params_source string, type_param string, prefs 
 			return -1
 		}
 		tok = s.scan()
-		if tok == .name && s.lit == type_param {
-			after := s.scan()
-			if after in [.comma, .rpar, .eof] {
-				return parameter_index
-			}
-			tok = after
-		}
+		mut uses_type_param := false
 		mut brackets := 0
+		mut parens := 0
 		for tok != .eof {
+			if tok == .name && s.lit in type_params {
+				uses_type_param = true
+			}
 			if tok == .lsbr {
 				brackets++
 			} else if tok == .rsbr {
 				brackets--
-			} else if brackets == 0 && tok in [.comma, .rpar] {
+			} else if tok == .lpar {
+				parens++
+			} else if tok == .rpar && parens > 0 {
+				parens--
+			} else if brackets == 0 && parens == 0 && tok in [.comma, .rpar] {
 				break
 			}
 			tok = s.scan()
+		}
+		if uses_type_param {
+			return parameter_index
 		}
 		if tok != .comma {
 			break
@@ -989,8 +1090,7 @@ fn fastc_scan_generic_calls(source string, path string, prefs &pref.Preferences,
 		}
 		if pending_struct_var != '' {
 			if tok == .lcbr {
-				fastc_record_var(pending_struct_var, pending_struct_type, mut var_types, mut
-					var_ambiguous)
+				fastc_record_var(pending_struct_var, pending_struct_type, mut var_types, mut var_ambiguous)
 			}
 			pending_struct_var = ''
 			pending_struct_type = ''
@@ -1066,14 +1166,13 @@ fn fastc_scan_generic_calls(source string, path string, prefs &pref.Preferences,
 						tok = s.scan()
 						continue
 					}
-					fastc_record_concrete(name, concrete, mut pairs, mut seen_pair, mut
-						has_concrete)
+					fastc_record_concrete(name, concrete, mut pairs, mut seen_pair, mut has_concrete)
 					calls << FastcGenericCall{
-						name:         name
+						name: name
 						source_index: source_index
-						start:        name_pos
-						end:          after
-						concrete:     concrete
+						start: name_pos
+						end: after
+						concrete: concrete
 					}
 					previous = .rsbr
 					previous_lit = ''
@@ -1121,11 +1220,11 @@ fn fastc_scan_generic_calls(source string, path string, prefs &pref.Preferences,
 			}
 			fastc_record_concrete(name, concrete, mut pairs, mut seen_pair, mut has_concrete)
 			calls << FastcGenericCall{
-				name:         name
+				name: name
 				source_index: source_index
-				start:        name_pos
-				end:          name_end
-				concrete:     concrete
+				start: name_pos
+				end: name_end
+				concrete: concrete
 			}
 			continue
 		}
@@ -1268,7 +1367,7 @@ fn fastc_record_concrete(name string, concrete string, mut pairs []FastcConcrete
 	if pair_key !in seen_pair {
 		seen_pair[pair_key] = true
 		pairs << FastcConcretePair{
-			name:     name
+			name: name
 			concrete: concrete
 		}
 	}
@@ -1321,8 +1420,7 @@ fn fastc_monomorphize_structs(sources []FastcSourceFile, prefs &pref.Preferences
 		if source_file.header.module_name !in ['', 'main'] {
 			continue
 		}
-		fastc_scan_generic_methods(source_file.source, source_file.path, prefs, i, by_name, mut
-			methods, mut receiver_skip, mut method_problematic)
+		fastc_scan_generic_methods(source_file.source, source_file.path, prefs, i, by_name, mut methods, mut receiver_skip, mut method_problematic)
 	}
 	mut refs := []FastcGenericCall{}
 	mut unresolvable := map[string]bool{}
@@ -1333,9 +1431,7 @@ fn fastc_monomorphize_structs(sources []FastcSourceFile, prefs &pref.Preferences
 		if source_file.header.module_name !in ['', 'main'] {
 			continue
 		}
-		fastc_scan_generic_struct_instances(source_file.source, source_file.path, prefs, i,
-			by_name, receiver_skip, mut refs, mut unresolvable, mut pairs, mut seen_pair, mut
-			has_concrete)
+		fastc_scan_generic_struct_instances(source_file.source, source_file.path, prefs, i, by_name, receiver_skip, mut refs, mut unresolvable, mut pairs, mut seen_pair, mut has_concrete)
 	}
 	for name in method_problematic.keys() {
 		unresolvable[name] = true
@@ -1361,18 +1457,16 @@ fn fastc_monomorphize_structs(sources []FastcSourceFile, prefs &pref.Preferences
 		definition_source := definition_file.source
 		edits << FastcSourceEdit{
 			source_index: generic.source_index
-			start:        generic.fn_start
-			end:          generic.def_end
-			replacement:  ''
+			start: generic.fn_start
+			end: generic.def_end
+			replacement: ''
 		}
 		mut copies := ''
 		for pair in pairs {
 			if pair.name != name {
 				continue
 			}
-			copies = copies + '\n' +
-				fastc_render_generic_instance(definition_source, generic, pair.concrete, prefs) +
-				'\n'
+			copies = copies + '\n' + fastc_render_generic_instance(definition_source, generic, pair.concrete, prefs) + '\n'
 		}
 		appends[generic.source_index] = appends[generic.source_index] + copies
 	}
@@ -1386,17 +1480,16 @@ fn fastc_monomorphize_structs(sources []FastcSourceFile, prefs &pref.Preferences
 		method_source := method_file.source
 		edits << FastcSourceEdit{
 			source_index: method.source_index
-			start:        method.fn_start
-			end:          method.def_end
-			replacement:  ''
+			start: method.fn_start
+			end: method.def_end
+			replacement: ''
 		}
 		mut method_copies := ''
 		for pair in pairs {
 			if pair.name != method.struct_name {
 				continue
 			}
-			method_copies = method_copies + '\n' +
-				fastc_render_generic_method(method_source, method, pair.concrete, prefs) + '\n'
+			method_copies = method_copies + '\n' + fastc_render_generic_method(method_source, method, pair.concrete, prefs) + '\n'
 		}
 		appends[method.source_index] = appends[method.source_index] + method_copies
 	}
@@ -1406,9 +1499,9 @@ fn fastc_monomorphize_structs(sources []FastcSourceFile, prefs &pref.Preferences
 		}
 		edits << FastcSourceEdit{
 			source_index: ref.source_index
-			start:        ref.start
-			end:          ref.end
-			replacement:  fastc_monomorphized_name(ref.name, ref.concrete)
+			start: ref.start
+			end: ref.end
+			replacement: fastc_monomorphized_name(ref.name, ref.concrete)
 		}
 	}
 	mut result := []FastcSourceFile{cap: sources.len}
@@ -1427,7 +1520,7 @@ fn fastc_monomorphize_structs(sources []FastcSourceFile, prefs &pref.Preferences
 			new_source = new_source + appends[i]
 		}
 		result << FastcSourceFile{
-			path:   source_file.path
+			path: source_file.path
 			source: new_source
 			header: source_file.header
 		}
@@ -1505,13 +1598,13 @@ fn fastc_scan_generic_structs(source string, path string, prefs &pref.Preference
 		def_end := s.offset
 		if !fastc_body_has_nested_generic(source[body_open..def_end], prefs) {
 			result << FastcGenericFn{
-				name:          name
-				type_param:    type_param
-				source_index:  source_index
-				fn_start:      struct_start
-				def_end:       def_end
+				name: name
+				type_param: type_param
+				source_index: source_index
+				fn_start: struct_start
+				def_end: def_end
 				bracket_start: bracket_start
-				bracket_end:   bracket_end
+				bracket_end: bracket_end
 			}
 		}
 		previous = .rcbr
@@ -1633,11 +1726,11 @@ fn fastc_scan_generic_struct_instances(source string, path string, prefs &pref.P
 		}
 		fastc_record_concrete(name, concrete, mut pairs, mut seen_pair, mut has_concrete)
 		refs << FastcGenericCall{
-			name:         name
+			name: name
 			source_index: source_index
-			start:        name_pos
-			end:          after
-			concrete:     concrete
+			start: name_pos
+			end: after
+			concrete: concrete
 		}
 		previous = .rsbr
 		tok = s.scan()
@@ -1774,13 +1867,13 @@ fn fastc_scan_generic_methods(source string, path string, prefs &pref.Preference
 			method_problematic[struct_name] = true
 		} else {
 			methods << FastcGenericMethod{
-				struct_name:        struct_name
-				type_param:         type_param
-				source_index:       source_index
-				fn_start:           fn_start
-				def_end:            def_end
+				struct_name: struct_name
+				type_param: type_param
+				source_index: source_index
+				fn_start: fn_start
+				def_end: def_end
 				receiver_ref_start: receiver_ref_start
-				receiver_ref_end:   receiver_ref_end
+				receiver_ref_end: receiver_ref_end
 			}
 			receiver_skip['${source_index}#${receiver_ref_start}'] = true
 		}
@@ -1800,8 +1893,8 @@ fn fastc_render_generic_method(source string, method FastcGenericMethod, concret
 	receiver_high := method.receiver_ref_end - base
 	mut edits := []FastcSourceEdit{}
 	edits << FastcSourceEdit{
-		start:       receiver_low
-		end:         receiver_high
+		start: receiver_low
+		end: receiver_high
 		replacement: fastc_monomorphized_name(method.struct_name, concrete)
 	}
 	mut file_set := token.FileSet.new()
@@ -1815,8 +1908,8 @@ fn fastc_render_generic_method(source string, method FastcGenericMethod, concret
 		if tok == .name && !(s.pos >= receiver_low && s.pos < receiver_high) {
 			if replacement := substitutions[s.lit] {
 				edits << FastcSourceEdit{
-					start:       s.pos
-					end:         s.offset
+					start: s.pos
+					end: s.offset
 					replacement: replacement
 				}
 			}


### PR DESCRIPTION
Follow-up to #28254 for review findings posted after that PR merged.

This change:
- rejects function literals and closures instead of emitting behavior-changing stubs
- preserves nested generic call rewrites in emitted concrete instances
- specializes generic parameters through composite return and option/multi-return types
- infers implicit generic arguments through composite parameters such as `[]T` and `map[string]T`
- scopes the json2 voidptr workaround to the exact internal decoder helper

Focused validation:
- rebuilt `./vnew` with `./v -g -keepc -o ./vnew cmd/v`
- passed seven focused FastC generic/closure regressions in `fastc_test.v`
- verified gitly now rejects its first reached closure explicitly instead of publishing a binary with discarded callback behavior

Large suites were intentionally skipped.