### PR TITLE
v3: speed up FastC self-host generation

### DIFF
--- a/vlib/v3/gen/fastc/decl.v
+++ b/vlib/v3/gen/fastc/decl.v
@@ -5,7 +5,7 @@ import v3.pref
 import v3.scanner
 import v3.token
 
-fn collect_declared_types(source string, path string, module_name string, prefs &pref.Preferences, mut declared_types map[string]bool, mut declared_kinds map[string]FastcDeclaredTypeKind, mut enum_flags map[string]bool, mut params_structs map[string]bool) ! {
+fn collect_declared_types(source string, path string, module_name string, prefs &pref.Preferences, mut declared_types map[string]bool, mut declared_kinds map[string]FastcDeclaredTypeKind, mut enum_flags map[string]bool, mut params_structs map[string]bool, mut declaration_paths map[string]string, mut declaration_modules map[string]string) ! {
 	mut file_set := token.FileSet.new()
 	mut file := file_set.add_file(path, source.len)
 	file.index_lines_without_digest(source)
@@ -25,7 +25,8 @@ fn collect_declared_types(source string, path string, module_name string, prefs 
 				selected := fastc_scan_selected_comptime_branch(mut scan, scan.scan(), path, prefs)!
 				if selected.source != '' {
 					collect_declared_types(selected.source, path, module_name, prefs, mut
-						declared_types, mut declared_kinds, mut enum_flags, mut params_structs)!
+						declared_types, mut declared_kinds, mut enum_flags, mut params_structs, mut
+						declaration_paths, mut declaration_modules)!
 				}
 				tok = selected.tok
 				previous_tok = .unknown
@@ -64,7 +65,10 @@ fn collect_declared_types(source string, path string, module_name string, prefs 
 				if name == 'C' && tok == .dot {
 					tok = scan.scan()
 					if tok == .name && !next_c_struct_is_typedef {
-						declared_types['#Cstruct#${scan.lit}'] = true
+						key := '#Cstruct#${scan.lit}'
+						declared_types[key] = true
+						declaration_paths[key] = path
+						declaration_modules[key] = module_name
 					}
 					next_c_struct_is_typedef = false
 					next_enum_is_flag = false
@@ -77,6 +81,8 @@ fn collect_declared_types(source string, path string, module_name string, prefs 
 				}
 				declared_types[key] = is_public
 				declared_kinds[key] = kind
+				declaration_paths[key] = path
+				declaration_modules[key] = module_name
 				if kind == .enum_ && next_enum_is_flag {
 					enum_flags[key] = true
 				}
@@ -100,7 +106,7 @@ fn collect_declared_types(source string, path string, module_name string, prefs 
 	}
 }
 
-fn collect_constant_names(source string, path string, module_name string, prefs &pref.Preferences, mut constants map[string]string, mut public_constants map[string]bool) ! {
+fn collect_constant_names(source string, path string, module_name string, prefs &pref.Preferences, mut constants map[string]string, mut public_constants map[string]bool, mut constant_paths map[string]string) ! {
 	mut file_set := token.FileSet.new()
 	mut file := file_set.add_file(path, source.len)
 	file.index_lines_without_digest(source)
@@ -116,7 +122,7 @@ fn collect_constant_names(source string, path string, module_name string, prefs 
 				selected := fastc_scan_selected_comptime_branch(mut scan, scan.scan(), path, prefs)!
 				if selected.source != '' {
 					collect_constant_names(selected.source, path, module_name, prefs, mut
-						constants, mut public_constants)!
+						constants, mut public_constants, mut constant_paths)!
 				}
 				tok = selected.tok
 				previous_tok = .unknown
@@ -145,7 +151,7 @@ fn collect_constant_names(source string, path string, module_name string, prefs 
 						// headers already provide the symbol, so FastC does not track it.
 						if scan.lit != 'C' {
 							fastc_register_constant(module_name, scan.lit, is_public, path, mut
-								constants, mut public_constants)!
+								constants, mut public_constants, mut constant_paths)!
 						}
 						at_declaration_start = false
 					}
@@ -165,7 +171,7 @@ fn collect_constant_names(source string, path string, module_name string, prefs 
 			// already provide the symbol, so FastC does not track it.
 			if scan.lit != 'C' {
 				fastc_register_constant(module_name, scan.lit, is_public, path, mut constants, mut
-					public_constants)!
+					public_constants, mut constant_paths)!
 			}
 			continue
 		}
@@ -179,18 +185,19 @@ fn collect_constant_names(source string, path string, module_name string, prefs 
 	}
 }
 
-fn fastc_register_constant(module_name string, name string, is_public bool, path string, mut constants map[string]string, mut public_constants map[string]bool) ! {
+fn fastc_register_constant(module_name string, name string, is_public bool, path string, mut constants map[string]string, mut public_constants map[string]bool, mut constant_paths map[string]string) ! {
 	key := fastc_constant_key(module_name, name)
 	if key in constants {
 		return error('fastc parser does not support duplicate constant `${name}` in ${path}')
 	}
 	constants[key] = fastc_c_constant_name(module_name, name)
+	constant_paths[key] = path
 	if is_public {
 		public_constants[key] = true
 	}
 }
 
-fn collect_global_names(source string, path string, header FastcSourceHeader, prefs &pref.Preferences, mut globals map[string]string, mut public_globals map[string]bool) ! {
+fn collect_global_names(source string, path string, header FastcSourceHeader, prefs &pref.Preferences, mut globals map[string]string, mut public_globals map[string]bool, mut global_paths map[string]string) ! {
 	mut file_set := token.FileSet.new()
 	mut file := file_set.add_file(path, source.len)
 	file.index_lines_without_digest(source)
@@ -206,7 +213,7 @@ fn collect_global_names(source string, path string, header FastcSourceHeader, pr
 				selected := fastc_scan_selected_comptime_branch(mut scan, scan.scan(), path, prefs)!
 				if selected.source != '' {
 					collect_global_names(selected.source, path, header, prefs, mut globals, mut
-						public_globals)!
+						public_globals, mut global_paths)!
 				}
 				tok = selected.tok
 				previous_tok = .unknown
@@ -225,7 +232,7 @@ fn collect_global_names(source string, path string, header FastcSourceHeader, pr
 					} else if at_start && tok == .name {
 						if scan.lit != 'C' {
 							fastc_register_global(header, scan.lit, is_public, path, prefs, mut
-								globals, mut public_globals)!
+								globals, mut public_globals, mut global_paths)!
 						}
 						at_start = false
 					}
@@ -235,7 +242,7 @@ fn collect_global_names(source string, path string, header FastcSourceHeader, pr
 			}
 			if tok == .name && scan.lit != 'C' {
 				fastc_register_global(header, scan.lit, is_public, path, prefs, mut globals, mut
-					public_globals)!
+					public_globals, mut global_paths)!
 			}
 			continue
 		}
@@ -249,7 +256,7 @@ fn collect_global_names(source string, path string, header FastcSourceHeader, pr
 	}
 }
 
-fn fastc_register_global(header FastcSourceHeader, name string, is_public bool, path string, prefs &pref.Preferences, mut globals map[string]string, mut public_globals map[string]bool) ! {
+fn fastc_register_global(header FastcSourceHeader, name string, is_public bool, path string, prefs &pref.Preferences, mut globals map[string]string, mut public_globals map[string]bool, mut global_paths map[string]string) ! {
 	if !prefs.enable_globals && !prefs.building_v && header.module_name != 'builtin'
 		&& !header.has_globals {
 		return error('use `v -enable-globals ...` to enable globals in ${path}')
@@ -259,7 +266,107 @@ fn fastc_register_global(header FastcSourceHeader, name string, is_public bool, 
 		return error('fastc parser does not support duplicate global `${name}` in ${path}')
 	}
 	globals[key] = fastc_c_global_name(key)
+	global_paths[key] = path
 	if is_public {
+		public_globals[key] = true
+	}
+}
+
+struct FastcDeclarationPartial {
+mut:
+	declared_types      map[string]bool
+	declared_kinds      map[string]FastcDeclaredTypeKind
+	enum_flags          map[string]bool
+	params_structs      map[string]bool
+	declaration_paths   map[string]string
+	declaration_modules map[string]string
+	constants           map[string]string
+	public_constants    map[string]bool
+	constant_paths      map[string]string
+	globals             map[string]string
+	public_globals      map[string]bool
+	global_paths        map[string]string
+	failed              bool
+	error_message       string
+}
+
+fn fastc_collect_declaration_chunk(sources []FastcSourceFile, prefs &pref.Preferences, start int, end int) FastcDeclarationPartial {
+	mut partial := FastcDeclarationPartial{
+		declared_types:      map[string]bool{}
+		declared_kinds:      map[string]FastcDeclaredTypeKind{}
+		enum_flags:          map[string]bool{}
+		params_structs:      map[string]bool{}
+		declaration_paths:   map[string]string{}
+		declaration_modules: map[string]string{}
+		constants:           map[string]string{}
+		public_constants:    map[string]bool{}
+		constant_paths:      map[string]string{}
+		globals:             map[string]string{}
+		public_globals:      map[string]bool{}
+		global_paths:        map[string]string{}
+	}
+	for idx in start .. end {
+		source_file := sources[idx]
+		collect_declared_types(source_file.source, source_file.path,
+			source_file.header.module_name, prefs, mut partial.declared_types, mut
+			partial.declared_kinds, mut partial.enum_flags, mut partial.params_structs, mut
+			partial.declaration_paths, mut partial.declaration_modules) or {
+			partial.failed = true
+			partial.error_message = err.msg()
+			return partial
+		}
+		collect_constant_names(source_file.source, source_file.path,
+			source_file.header.module_name, prefs, mut partial.constants, mut
+			partial.public_constants, mut partial.constant_paths) or {
+			partial.failed = true
+			partial.error_message = err.msg()
+			return partial
+		}
+		collect_global_names(source_file.source, source_file.path, source_file.header, prefs, mut
+			partial.globals, mut partial.public_globals, mut partial.global_paths) or {
+			partial.failed = true
+			partial.error_message = err.msg()
+			return partial
+		}
+	}
+	return partial
+}
+
+fn fastc_merge_declaration_partial(partial FastcDeclarationPartial, mut declared_types map[string]bool, mut declared_kinds map[string]FastcDeclaredTypeKind, mut enum_flags map[string]bool, mut params_structs map[string]bool, mut constants map[string]string, mut public_constants map[string]bool, mut globals map[string]string, mut public_globals map[string]bool) ! {
+	if partial.failed {
+		return error(partial.error_message)
+	}
+	for key, is_public in partial.declared_types {
+		if key in declared_types && !key.starts_with('#Cstruct#') {
+			return error('fastc parser does not support duplicate type declaration `${key.all_after_last('.')}` in module `${partial.declaration_modules[key]}` in ${partial.declaration_paths[key]}')
+		}
+		declared_types[key] = is_public
+	}
+	for key, kind in partial.declared_kinds {
+		declared_kinds[key] = kind
+	}
+	for key, _ in partial.enum_flags {
+		enum_flags[key] = true
+	}
+	for key, _ in partial.params_structs {
+		params_structs[key] = true
+	}
+	for key, c_name in partial.constants {
+		if key in constants {
+			return error('fastc parser does not support duplicate constant `${key.all_after_last('.')}` in ${partial.constant_paths[key]}')
+		}
+		constants[key] = c_name
+	}
+	for key, _ in partial.public_constants {
+		public_constants[key] = true
+	}
+	for key, c_name in partial.globals {
+		if key in globals {
+			return error('fastc parser does not support duplicate global `${key.all_after_last('.')}` in ${partial.global_paths[key]}')
+		}
+		globals[key] = c_name
+	}
+	for key, _ in partial.public_globals {
 		public_globals[key] = true
 	}
 }

--- a/vlib/v3/gen/fastc/fastc.v
+++ b/vlib/v3/gen/fastc/fastc.v
@@ -1110,14 +1110,10 @@ fn generate_source_files(input_sources []FastcSourceFile, module_aliases map[str
 	mut public_constants := map[string]bool{}
 	mut globals := map[string]string{}
 	mut public_globals := map[string]bool{}
-	for source_file in sources {
-		collect_declared_types(source_file.source, source_file.path, source_file.header.module_name, prefs, mut declared_types, mut declared_kinds, mut enum_flags, mut params_structs)!
-	}
+	fastc_collect_declaration_indexes(sources, prefs, mut declared_types, mut declared_kinds, mut
+		enum_flags, mut params_structs, mut constants, mut public_constants, mut globals, mut
+		public_globals)!
 	declared_type_c_names := fastc_declared_type_c_names(declared_types)
-	for source_file in sources {
-		collect_constant_names(source_file.source, source_file.path, source_file.header.module_name, prefs, mut constants, mut public_constants)!
-		collect_global_names(source_file.source, source_file.path, source_file.header, prefs, mut globals, mut public_globals)!
-	}
 	mut functions := map[string]FastcFunctionSignature{}
 	mut interface_methods := map[string]bool{}
 	mut interface_fields := map[string]FastcInterfaceField{}
@@ -1125,10 +1121,9 @@ fn generate_source_files(input_sources []FastcSourceFile, module_aliases map[str
 	// interface it embeds), kept flat to stay in FastC's self-hostable subset.
 	mut embed_embedders := []string{}
 	mut embed_embeddeds := []string{}
-	for source_file in sources {
-		collect_function_signatures(source_file.source, source_file.path, source_file.header, prefs, declared_types, declared_type_c_names, params_structs, mut functions)!
-		collect_interface_method_signatures(source_file.source, source_file.path, source_file.header, prefs, declared_types, mut functions, mut interface_methods, mut interface_fields, mut embed_embedders, mut embed_embeddeds)!
-	}
+	fastc_collect_signatures(sources, prefs, declared_types, declared_type_c_names, params_structs, mut
+		functions, mut interface_methods, mut interface_fields, mut embed_embedders, mut
+		embed_embeddeds)!
 	// An interface that embeds another (`interface B { A; ... }`) inherits A's
 	// methods. Copy them onto B (with the receiver re-keyed to B) so calls on a B
 	// value resolve and B gets its own dispatch table entries.
@@ -1151,6 +1146,7 @@ fn generate_source_files(input_sources []FastcSourceFile, module_aliases map[str
 		}
 	}
 	type_output := fastc_generate_type_declarations(sources, prefs, declared_types, declared_kinds, enum_flags, constants, public_constants, mut struct_fields, mut struct_field_info, mut composite_types)!
+	declared_composite_types := composite_types.clone()
 	type_declarations := type_output.declarations
 	enum_field_types := type_output.enum_field_types.clone()
 	mut constant_types := map[string]string{}
@@ -1269,12 +1265,12 @@ fn generate_source_files(input_sources []FastcSourceFile, module_aliases map[str
 		// (1..N) and the primitive ids (0x40000000+). Only unique/consistent values
 		// matter: construction and `match` both reference `__v_typeid_<composite>`.
 		late_composite_declarations.writeln('#define __v_typeid_${composite_name} ${u32(0x50000000) + u32(index)}')
-		declaration := 'typedef ${if composite_name.starts_with('Array_') {
-			'array'
-		} else {
-			'map'
-		}} ${composite_name};'
-		if !type_declarations.contains(declaration) {
+		if composite_name !in declared_composite_types {
+			declaration := 'typedef ${if composite_name.starts_with('Array_') {
+				'array'
+			} else {
+				'map'
+			}} ${composite_name};'
 			late_composite_declarations.writeln(declaration)
 		}
 	}

--- a/vlib/v3/gen/fastc/fastc_test.v
+++ b/vlib/v3/gen/fastc/fastc_test.v
@@ -10365,6 +10365,38 @@ fn main() {
 	assert fastc_infer_generic_type_from_parameter('Map_string_Array_voidptr', 'Map_string_Array_example__Item_ptr') == 'example__Item*'
 }
 
+fn test_selfhost_on_demand_generic_does_not_partially_infer_multiple_type_parameters() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	util_source := 'module util
+
+pub fn pair[T, U](left T, right U) T {
+	_ = right
+	return left
+}
+'
+	main_source := 'module main
+import util
+
+fn main() {
+	_ := util.pair(1, "right")
+}
+'
+	c_source, _, _ := generate_source_files([
+		FastcSourceFile{
+			path: 'util/util.v'
+			source: util_source
+			header: fastc_scan_source_header(util_source, 'util/util.v', prefs) or { panic(err) }
+		},
+		FastcSourceFile{
+			path: 'main.v'
+			source: main_source
+			header: fastc_scan_source_header(main_source, 'main.v', prefs) or { panic(err) }
+		},
+	], map[string]string{}, prefs) or { panic(err) }
+	assert !c_source.contains('util__pair_mono_'), c_source
+}
+
 fn test_selfhost_user_voidptr_generic_method_named_check_element_type_valid_keeps_body() {
 	mut prefs := pref.new_preferences()
 	prefs.building_v = true

--- a/vlib/v3/gen/fastc/monomorphize.v
+++ b/vlib/v3/gen/fastc/monomorphize.v
@@ -254,15 +254,15 @@ fn (mut g Parser) queue_explicit_mono_function(tokens []FastcExpressionToken) ?s
 	return g.queue_mono_function(function_key, concrete)
 }
 
-// queue_implicit_mono_function specializes a generic free function whose first argument
-// reveals its type, such as json2's `encode(value)`.
+// queue_implicit_mono_function specializes a single-parameter generic free function whose
+// argument reveals its type, such as json2's `encode(value)`.
 fn (mut g Parser) queue_implicit_mono_function(tokens []FastcExpressionToken) ?string {
 	if tokens.len == 0 || tokens.last().tok != .name {
 		return none
 	}
 	function_key := g.function_key_for_call(tokens, tokens.len - 1)
 	source := g.generic_method_sources[function_key] or { return none }
-	if source.receiver_type != '' || source.type_param_parameter_index < 0 {
+	if source.receiver_type != '' || source.type_param.contains(',') || source.type_param_parameter_index < 0 {
 		return none
 	}
 	mut look := g.s

--- a/vlib/v3/gen/fastc/parallel_d_v3_no_parallel.v
+++ b/vlib/v3/gen/fastc/parallel_d_v3_no_parallel.v
@@ -19,3 +19,17 @@ fn fastc_collect_reference_partials(sources []FastcSourceFile, prefs &pref.Prefe
 			top_level_references)
 	}
 }
+
+fn fastc_collect_declaration_indexes(sources []FastcSourceFile, prefs &pref.Preferences, mut declared_types map[string]bool, mut declared_kinds map[string]FastcDeclaredTypeKind, mut enum_flags map[string]bool, mut params_structs map[string]bool, mut constants map[string]string, mut public_constants map[string]bool, mut globals map[string]string, mut public_globals map[string]bool) ! {
+	partial := fastc_collect_declaration_chunk(sources, prefs, 0, sources.len)
+	fastc_merge_declaration_partial(partial, mut declared_types, mut declared_kinds, mut
+		enum_flags, mut params_structs, mut constants, mut public_constants, mut globals, mut
+		public_globals)!
+}
+
+fn fastc_collect_signatures(sources []FastcSourceFile, prefs &pref.Preferences, declared_types map[string]bool, declared_type_c_names map[string]string, params_structs map[string]bool, mut functions map[string]FastcFunctionSignature, mut interface_methods map[string]bool, mut interface_fields map[string]FastcInterfaceField, mut embed_embedders []string, mut embed_embeddeds []string) ! {
+	partial := fastc_collect_signature_chunk(sources, prefs, declared_types, declared_type_c_names,
+		params_structs, 0, sources.len)
+	fastc_merge_signature_partial(partial, mut functions, mut interface_methods, mut
+		interface_fields, mut embed_embedders, mut embed_embeddeds)!
+}

--- a/vlib/v3/gen/fastc/parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/fastc/parallel_notd_v3_no_parallel.v
@@ -157,3 +157,54 @@ fn fastc_collect_reference_partials(sources []FastcSourceFile, prefs &pref.Prefe
 		}
 	}
 }
+
+fn fastc_collect_declaration_indexes(sources []FastcSourceFile, prefs &pref.Preferences, mut declared_types map[string]bool, mut declared_kinds map[string]FastcDeclaredTypeKind, mut enum_flags map[string]bool, mut params_structs map[string]bool, mut constants map[string]string, mut public_constants map[string]bool, mut globals map[string]string, mut public_globals map[string]bool) ! {
+	jobs := fastc_parallel_jobs(sources, prefs)
+	if jobs <= 1 {
+		partial := fastc_collect_declaration_chunk(sources, prefs, 0, sources.len)
+		fastc_merge_declaration_partial(partial, mut declared_types, mut declared_kinds, mut
+			enum_flags, mut params_structs, mut constants, mut public_constants, mut globals, mut
+			public_globals)!
+		return
+	}
+	bounds := fastc_chunk_bounds(sources, jobs)
+	first_thread := spawn fastc_collect_declaration_chunk(sources, prefs, bounds[0], bounds[1])
+	mut chunk_threads := [first_thread]
+	for chunk_idx in 1 .. bounds.len / 2 {
+		chunk_thread := spawn fastc_collect_declaration_chunk(sources, prefs,
+			bounds[chunk_idx * 2], bounds[chunk_idx * 2 + 1])
+		chunk_threads << chunk_thread
+	}
+	for chunk_idx in 0 .. chunk_threads.len {
+		partial := chunk_threads[chunk_idx].wait()
+		fastc_merge_declaration_partial(partial, mut declared_types, mut declared_kinds, mut
+			enum_flags, mut params_structs, mut constants, mut public_constants, mut globals, mut
+			public_globals)!
+	}
+}
+
+fn fastc_collect_signatures(sources []FastcSourceFile, prefs &pref.Preferences, declared_types map[string]bool, declared_type_c_names map[string]string, params_structs map[string]bool, mut functions map[string]FastcFunctionSignature, mut interface_methods map[string]bool, mut interface_fields map[string]FastcInterfaceField, mut embed_embedders []string, mut embed_embeddeds []string) ! {
+	jobs := fastc_parallel_jobs(sources, prefs)
+	if jobs <= 1 {
+		partial := fastc_collect_signature_chunk(sources, prefs, declared_types,
+			declared_type_c_names, params_structs, 0, sources.len)
+		fastc_merge_signature_partial(partial, mut functions, mut interface_methods, mut
+			interface_fields, mut embed_embedders, mut embed_embeddeds)!
+		return
+	}
+	bounds := fastc_chunk_bounds(sources, jobs)
+	first_thread := spawn fastc_collect_signature_chunk(sources, prefs, declared_types,
+		declared_type_c_names, params_structs, bounds[0], bounds[1])
+	mut chunk_threads := [first_thread]
+	for chunk_idx in 1 .. bounds.len / 2 {
+		chunk_thread := spawn fastc_collect_signature_chunk(sources, prefs, declared_types,
+			declared_type_c_names, params_structs, bounds[chunk_idx * 2],
+			bounds[chunk_idx * 2 + 1])
+		chunk_threads << chunk_thread
+	}
+	for chunk_idx in 0 .. chunk_threads.len {
+		partial := chunk_threads[chunk_idx].wait()
+		fastc_merge_signature_partial(partial, mut functions, mut interface_methods, mut
+			interface_fields, mut embed_embedders, mut embed_embeddeds)!
+	}
+}

--- a/vlib/v3/gen/fastc/signatures.v
+++ b/vlib/v3/gen/fastc/signatures.v
@@ -591,7 +591,7 @@ fn fastc_collect_type_default_references(mut scan scanner.Scanner, first token.T
 	return tok
 }
 
-fn collect_interface_method_signatures(source string, path string, header FastcSourceHeader, prefs &pref.Preferences, declared_types map[string]bool, mut functions map[string]FastcFunctionSignature, mut interface_methods map[string]bool, mut interface_fields map[string]FastcInterfaceField, mut embed_embedders []string, mut embed_embeddeds []string) ! {
+fn collect_interface_method_signatures(source string, path string, header FastcSourceHeader, prefs &pref.Preferences, declared_types map[string]bool, mut functions map[string]FastcFunctionSignature, mut interface_methods map[string]bool, mut interface_fields map[string]FastcInterfaceField, mut interface_field_paths map[string]string, mut embed_embedders []string, mut embed_embeddeds []string) ! {
 	mut file_set := token.FileSet.new()
 	mut file := file_set.add_file(path, source.len)
 	file.index_lines_without_digest(source)
@@ -608,7 +608,7 @@ fn collect_interface_method_signatures(source string, path string, header FastcS
 				if selected.source != '' {
 					collect_interface_method_signatures(selected.source, path, header, prefs,
 						declared_types, mut functions, mut interface_methods, mut interface_fields, mut
-						embed_embedders, mut embed_embeddeds)!
+						interface_field_paths, mut embed_embedders, mut embed_embeddeds)!
 				}
 				tok = selected.tok
 				continue
@@ -724,6 +724,7 @@ fn collect_interface_method_signatures(source string, path string, header FastcS
 						typ:        field_type
 						is_mutable: members_are_mutable
 					}
+					interface_field_paths[field_key] = path
 				}
 				tok = next_token
 				if tok == .semicolon {
@@ -808,6 +809,91 @@ fn collect_interface_method_signatures(source string, path string, header FastcS
 			tok = scan.scan()
 		}
 		next_declaration_is_enabled = true
+	}
+}
+
+struct FastcSignaturePartial {
+mut:
+	functions             map[string]FastcFunctionSignature
+	interface_methods     map[string]bool
+	interface_fields      map[string]FastcInterfaceField
+	interface_field_paths map[string]string
+	embed_embedders       []string
+	embed_embeddeds       []string
+	failed                bool
+	error_message         string
+}
+
+fn fastc_collect_signature_chunk(sources []FastcSourceFile, prefs &pref.Preferences, declared_types map[string]bool, declared_type_c_names map[string]string, params_structs map[string]bool, start int, end int) FastcSignaturePartial {
+	mut partial := FastcSignaturePartial{
+		functions:             map[string]FastcFunctionSignature{}
+		interface_methods:     map[string]bool{}
+		interface_fields:      map[string]FastcInterfaceField{}
+		interface_field_paths: map[string]string{}
+		embed_embedders:       []string{}
+		embed_embeddeds:       []string{}
+	}
+	for idx in start .. end {
+		source_file := sources[idx]
+		collect_function_signatures(source_file.source, source_file.path, source_file.header,
+			prefs, declared_types, declared_type_c_names, params_structs, mut partial.functions) or {
+			partial.failed = true
+			partial.error_message = err.msg()
+			return partial
+		}
+		collect_interface_method_signatures(source_file.source, source_file.path,
+			source_file.header, prefs, declared_types, mut partial.functions, mut
+			partial.interface_methods, mut partial.interface_fields, mut
+			partial.interface_field_paths, mut partial.embed_embedders, mut
+			partial.embed_embeddeds) or {
+			partial.failed = true
+			partial.error_message = err.msg()
+			return partial
+		}
+	}
+	return partial
+}
+
+fn fastc_merge_signature_partial(partial FastcSignaturePartial, mut functions map[string]FastcFunctionSignature, mut interface_methods map[string]bool, mut interface_fields map[string]FastcInterfaceField, mut embed_embedders []string, mut embed_embeddeds []string) ! {
+	if partial.failed {
+		return error(partial.error_message)
+	}
+	for key, signature in partial.functions {
+		if key !in partial.interface_methods {
+			if previous := functions[key] {
+				if !key.starts_with('C.') {
+					is_c_override := previous.path.ends_with('.c.v') || signature.path.ends_with('.c.v')
+					if previous.path == signature.path || !is_c_override
+						|| !fastc_string_types_equal(previous.parameter_types,
+							signature.parameter_types)
+						|| !fastc_bool_types_equal(previous.parameter_mutability,
+							signature.parameter_mutability)
+						|| previous.last_parameter_is_params != signature.last_parameter_is_params
+						|| previous.return_type != signature.return_type {
+						return error('fastc parser does not support duplicate function `${key.all_after_last('.')}` in ${signature.path}')
+					}
+					if previous.path.ends_with('.c.v') {
+						continue
+					}
+				}
+			}
+		}
+		functions[key] = signature
+	}
+	for key, _ in partial.interface_methods {
+		interface_methods[key] = true
+	}
+	for key, field in partial.interface_fields {
+		if key in interface_fields {
+			return error('fastc parser does not support duplicate interface field `${field.name}` in ${partial.interface_field_paths[key]}')
+		}
+		interface_fields[key] = field
+	}
+	for embedder in partial.embed_embedders {
+		embed_embedders << embedder
+	}
+	for embedded in partial.embed_embeddeds {
+		embed_embeddeds << embedded
 	}
 }
 


### PR DESCRIPTION
## Summary

- parallelize FastC declaration, constant/global name, and function/interface signature scans while merging results in deterministic source order
- avoid repeated full generated-declaration string searches for late composite types
- reject partial implicit inference for generic functions with multiple type parameters

## Benchmark

Apple M5 Max, 18 cores, with the benchmark compiler built using `-prod`.

`FASTC_BENCH=1 FASTC_BENCH_REPEAT=20 fastc -silent -b fastc -o descendant vlib/v3/v3.v`

- baseline on the same 64,169-line source: 110.54 ms, 580,494 loc/s
- optimized: 82.65 ms, 776,432 loc/s
- improvement: 25.2% lower generation time
- against the original pre-change baseline of 107.45 ms: 23.1% lower generation time

Parallel and forced-serial generation produced byte-identical C output (SHA-256 `94e7766132b81910fd68d84e8f3a2a0fd38c815c1ca4a4133233700cfa0f7edf`).

## Tests

- `./vnew -silent vlib/v/compiler_errors_test.v` (1,619 passed, 1 skipped)
- focused FastC tests for chunking, duplicate declarations, and multi-parameter generic inference
- normal and `-d v3_no_parallel` FastC self-host builds

The broad `./vnew -silent test vlib/v/` run was stopped after the existing macOS `vlib/v/slow_tests/keep_args_alive_test.c.v` crash (exit 11 on all retries). The benchmark reaches FastC C generation; the descendant TCC compile still encounters the pre-existing generated-C binary-operation error.