### PR TITLE
v3: speed up self-host compilation

### DIFF
--- a/cmd/tools/fast/bench.v
+++ b/cmd/tools/fast/bench.v
@@ -244,7 +244,7 @@ fn build_v3_stage_compiler(dir string, date time.Time, args []string) !string {
 	stage_v := os.join_path(dir, exe_name('fastv3'))
 	os.rm(stage_v) or {}
 	prod := if args.contains('-noprod') { '' } else { '-prod' }
-	cmd := '${os.quoted_path(vprod)} -gc none ${prod} -o ${os.quoted_path(stage_v)} vlib/v3/v3.v'
+	cmd := '${os.quoted_path(vprod)} -gc none ${prod} -d skip_fastc -o ${os.quoted_path(stage_v)} vlib/v3/v3.v'
 	elog('  building standalone v3 self-compiler ...')
 	res := os.execute(cmd)
 	if res.exit_code != 0 || !os.is_executable(stage_v) {

--- a/vlib/v3/README.md
+++ b/vlib/v3/README.md
@@ -146,6 +146,9 @@ Production, test, shared/live, ownership/autofree, object-file, profiling/covera
 custom compiler, custom-builtin, `no_main`, `-Wimpure-v`, translated, and REPL modes are currently
 rejected.
 
+A conventional C-backend self-host prunes FastC along with the other optional backends. Pass
+`-compile-backend fastc` or `-all-backends` when the generated compiler should retain `-b fastc`.
+
 `-selfhost -b fastc -o v4 vlib/v3/v3.v` builds V3 using only the scanner-to-C path. The generated
 compiler uses the small `v3.fastcdriver` entry point and can build further FastC generations without
 the flat AST or conventional C backend. Set `V_MACOS_V3_NO_FALLBACK=1` while validating a chain to

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -14,7 +14,6 @@ import v3.flat
 import v3.fixturetest
 import v3.gen.c as cgen
 import v3.gen.c.naming
-import v3.gen.fastc
 import v3.markused
 import v3.modulecache
 import v3.parser
@@ -27,6 +26,9 @@ import v3.workers
 import v.build_constraint
 import v.vmod
 
+$if !skip_fastc ? {
+	import v3.gen.fastc
+}
 $if !skip_eval ? {
 	import v3.eval
 }
@@ -2652,6 +2654,23 @@ fn prepare_v3_checker_native_inputs_scoped(mut state V3ModuleCacheState, a &flat
 	state.external_resolution_dirs = clone_string_list(state.external_resolution_dirs)
 	state.external_missing_paths = clone_string_list(state.external_missing_paths)
 	prealloc_scope_free_for_v3(scope)
+}
+
+struct PrepareV3CheckerNativeInputsArgs {
+	state         voidptr
+	a             &flat.FlatAst
+	prefs         &pref.Preferences
+	user_files    []string
+	user_c_flags  []string
+	scope_enabled bool
+	done          chan bool
+}
+
+fn prepare_v3_checker_native_inputs_thread(args &PrepareV3CheckerNativeInputsArgs) {
+	mut state := unsafe { &V3ModuleCacheState(args.state) }
+	prepare_v3_checker_native_inputs_scoped(mut state, args.a, args.prefs, args.user_files,
+		args.user_c_flags, args.scope_enabled)
+	args.done <- true
 }
 
 fn ast_has_native_source_include(a &flat.FlatAst) bool {
@@ -8060,7 +8079,8 @@ pub fn run(args []string) {
 	}
 	for requested in compile_backends {
 		for name in requested.split(',') {
-			if name.trim_space() !in ['c', 'arm64', 'aarch64', 'wasm', 'wasm32', 'eval'] {
+			if name.trim_space() !in ['c', 'fastc', 'arm64', 'aarch64', 'wasm', 'wasm32',
+				'eval'] {
 				eprintln('unknown compile backend `${name.trim_space()}`')
 				exit(1)
 			}
@@ -8209,7 +8229,7 @@ pub fn run(args []string) {
 		&& !binary_existed_before
 
 	// Decide which backend modules to compile into the output. By default only the C
-	// backend is built; the arm64/wasm/eval backends (and the whole SSA pipeline that the
+	// backend is built; the fastc/arm64/wasm/eval backends (and the whole SSA pipeline that the
 	// arm64 backend pulls in: v3.ssa + v3.ssa.optimize) are skipped entirely. When compiling
 	// the V compiler itself this avoids parsing/checking/transforming/cgen-ing ~30k lines of
 	// unused backend code, which measurably speeds up the self-host build. The `skip_*`
@@ -8218,12 +8238,14 @@ pub fn run(args []string) {
 	// resolve_imports skips parsing the corresponding module directories.
 	// `-all-backends` keeps everything; `-compile-backend <name>` opts a specific backend back
 	// in; the active `-b` target backend is always force-included.
+	mut include_fastc := all_backends
 	mut include_arm64 := all_backends
 	mut include_wasm := all_backends
 	mut include_eval := all_backends
 	for cb in compile_backends {
 		for name in cb.split(',') {
 			match name.trim_space() {
+				'fastc' { include_fastc = true }
 				'arm64', 'aarch64' { include_arm64 = true }
 				'wasm', 'wasm32' { include_wasm = true }
 				'eval' { include_eval = true }
@@ -8233,12 +8255,16 @@ pub fn run(args []string) {
 		}
 	}
 	match backend {
+		'fastc' { include_fastc = true }
 		'arm64' { include_arm64 = true }
 		'wasm' { include_wasm = true }
 		'eval' { include_eval = true }
 		else {}
 	}
 
+	if !include_fastc {
+		user_defines << 'skip_fastc'
+	}
 	if !include_arm64 {
 		user_defines << 'skip_arm64'
 	}
@@ -8344,195 +8370,200 @@ pub fn run(args []string) {
 	}
 	prefs.supports_inline_asm = is_checker_fixture
 	if backend == 'fastc' {
-		// FastC is a standalone parser that emits C while consuming scanner tokens.
-		// Never let an unsupported FastC input continue into the AST frontend below.
-		clear_macos_v3_compiler_error_fallback(macos_v3_fallback_file)
-		if !input_file.ends_with('.v') || !os.is_file(input_file) || file_list.len > 0 {
-			eprintln('fastc requires exactly one `.v` entry file')
+		$if skip_fastc ? {
+			eprintln('fastc support is not compiled into this v3 executable')
 			exit(1)
-		}
-		fastc_artifact_file := if c_only {
-			if c_to_stdout { '' } else { output_file }
-		} else {
-			bin_file
-		}
-		if fastc_artifact_file != ''
-			&& canonical_v3_fastc_output_path(fastc_artifact_file) == os.real_path(input_file) {
-			eprintln('fastc output path `${fastc_artifact_file}` aliases input source `${input_file}`')
-			exit(1)
-		}
-		fastc_host := pref.host_target()
-		fastc_cross_target := target.os != fastc_host.os || target.arch != fastc_host.arch
-		if !c_only && fastc_cross_target {
-			eprintln('fastc can only build executables for the host target; use `-o file.c` for cross-target C output')
-			exit(1)
-		}
-		mut unsupported_modes := []string{}
-		if is_test_command || is_v3_test_file(input_file, backend, target)
-			|| is_v3_test_file(input_file, 'c', target) || is_checker_fixture {
-			unsupported_modes << 'test/checker mode'
-		}
-		if is_prod {
-			unsupported_modes << '`-prod`'
-		}
-		if is_shared || is_livemain || is_liveshared {
-			unsupported_modes << 'shared/live builds'
-		}
-		if is_o {
-			unsupported_modes << 'object-file output'
-		}
-		if is_prof || coverage_dir.len > 0 {
-			unsupported_modes << 'profiling/coverage'
-		}
-		if ownership_mode || 'ownership' in prefs.user_defines {
-			unsupported_modes << 'ownership/autofree'
-		}
-		if only_check_syntax || check_only {
-			unsupported_modes << 'syntax/check-only mode'
-		}
-		if warn_impure_v {
-			unsupported_modes << '`-Wimpure-v`'
-		}
-		if print_fn_names.len > 0 || print_v_files || print_watched_files || dump_c_flags.len > 0
-			|| generate_c_project.len > 0 {
-			unsupported_modes << 'compiler inspection output'
-		}
-		if c99_explicit || is_strict || check_overflow {
-			unsupported_modes << 'strict/checked C modes'
-		}
-		if c_compiler_explicit {
-			unsupported_modes << 'custom C compilers'
-		}
-		if no_builtin || no_preludes {
-			unsupported_modes << 'custom builtin/prelude modes'
-		}
-		if 'no_main' in prefs.user_defines {
-			unsupported_modes << '`-d no_main`'
-		}
-		if translated_mode || is_repl {
-			unsupported_modes << 'translated/REPL mode'
-		}
-		// Bundled TinyCC has no thread-local storage, so the prealloc arena
-		// pointer would become one shared global while FastC compiler
-		// generations spawn worker threads; concurrent bumps corrupt it.
-		if 'prealloc' in prefs.user_defines {
-			unsupported_modes << '`-prealloc` builds'
-		}
-		if unsupported_modes.len > 0 {
-			eprintln('fastc parser does not support ${unsupported_modes.join(', ')}')
-			exit(1)
-		}
-		if 'v3_backend' !in prefs.user_defines {
-			prefs.user_defines << 'v3_backend'
-		}
-		if !fastc_cross_target {
-			// Same-target FastC output is compiled by bundled TinyCC regardless of
-			// the host default, so compile-time compiler branches must see TinyCC.
-			prefs.ccompiler = 'tinyc'
-			add_v3_tcc_compat_defines(mut prefs.user_defines, target.os, target.arch, false, true)
-		}
-		fastc_generation := fastc.generate_files_with_source_paths([input_file], prefs) or {
-			eprintln(err.msg())
-			exit(1)
-			fastc.GenerationResult{}
-		}
-		fastc_artifact_path := canonical_v3_fastc_output_path(fastc_artifact_file)
-		for source_path in fastc_generation.source_paths {
-			if fastc_artifact_path != '' && fastc_artifact_path == source_path
-				&& source_path != os.real_path(input_file) {
-				eprintln('fastc output path `${fastc_artifact_file}` aliases imported source `${source_path}`')
+		} $else {
+			// FastC is a standalone parser that emits C while consuming scanner tokens.
+			// Never let an unsupported FastC input continue into the AST frontend below.
+			clear_macos_v3_compiler_error_fallback(macos_v3_fallback_file)
+			if !input_file.ends_with('.v') || !os.is_file(input_file) || file_list.len > 0 {
+				eprintln('fastc requires exactly one `.v` entry file')
 				exit(1)
 			}
-		}
-		fastc_source := fastc_generation.c_source
-		b.step('fastc parse+gen')
-		if c_only && fastc_cross_target {
+			fastc_artifact_file := if c_only {
+				if c_to_stdout { '' } else { output_file }
+			} else {
+				bin_file
+			}
+			if fastc_artifact_file != ''
+				&& canonical_v3_fastc_output_path(fastc_artifact_file) == os.real_path(input_file) {
+				eprintln('fastc output path `${fastc_artifact_file}` aliases input source `${input_file}`')
+				exit(1)
+			}
+			fastc_host := pref.host_target()
+			fastc_cross_target := target.os != fastc_host.os || target.arch != fastc_host.arch
+			if !c_only && fastc_cross_target {
+				eprintln('fastc can only build executables for the host target; use `-o file.c` for cross-target C output')
+				exit(1)
+			}
+			mut unsupported_modes := []string{}
+			if is_test_command || is_v3_test_file(input_file, backend, target)
+				|| is_v3_test_file(input_file, 'c', target) || is_checker_fixture {
+				unsupported_modes << 'test/checker mode'
+			}
+			if is_prod {
+				unsupported_modes << '`-prod`'
+			}
+			if is_shared || is_livemain || is_liveshared {
+				unsupported_modes << 'shared/live builds'
+			}
+			if is_o {
+				unsupported_modes << 'object-file output'
+			}
+			if is_prof || coverage_dir.len > 0 {
+				unsupported_modes << 'profiling/coverage'
+			}
+			if ownership_mode || 'ownership' in prefs.user_defines {
+				unsupported_modes << 'ownership/autofree'
+			}
+			if only_check_syntax || check_only {
+				unsupported_modes << 'syntax/check-only mode'
+			}
+			if warn_impure_v {
+				unsupported_modes << '`-Wimpure-v`'
+			}
+			if print_fn_names.len > 0 || print_v_files || print_watched_files || dump_c_flags.len > 0
+				|| generate_c_project.len > 0 {
+				unsupported_modes << 'compiler inspection output'
+			}
+			if c99_explicit || is_strict || check_overflow {
+				unsupported_modes << 'strict/checked C modes'
+			}
+			if c_compiler_explicit {
+				unsupported_modes << 'custom C compilers'
+			}
+			if no_builtin || no_preludes {
+				unsupported_modes << 'custom builtin/prelude modes'
+			}
+			if 'no_main' in prefs.user_defines {
+				unsupported_modes << '`-d no_main`'
+			}
+			if translated_mode || is_repl {
+				unsupported_modes << 'translated/REPL mode'
+			}
+			// Bundled TinyCC has no thread-local storage, so the prealloc arena
+			// pointer would become one shared global while FastC compiler
+			// generations spawn worker threads; concurrent bumps corrupt it.
+			if 'prealloc' in prefs.user_defines {
+				unsupported_modes << '`-prealloc` builds'
+			}
+			if unsupported_modes.len > 0 {
+				eprintln('fastc parser does not support ${unsupported_modes.join(', ')}')
+				exit(1)
+			}
+			if 'v3_backend' !in prefs.user_defines {
+				prefs.user_defines << 'v3_backend'
+			}
+			if !fastc_cross_target {
+				// Same-target FastC output is compiled by bundled TinyCC regardless of
+				// the host default, so compile-time compiler branches must see TinyCC.
+				prefs.ccompiler = 'tinyc'
+				add_v3_tcc_compat_defines(mut prefs.user_defines, target.os, target.arch, false, true)
+			}
+			fastc_generation := fastc.generate_files_with_source_paths([input_file], prefs) or {
+				eprintln(err.msg())
+				exit(1)
+				return
+			}
+			fastc_artifact_path := canonical_v3_fastc_output_path(fastc_artifact_file)
+			for source_path in fastc_generation.source_paths {
+				if fastc_artifact_path != '' && fastc_artifact_path == source_path
+					&& source_path != os.real_path(input_file) {
+					eprintln('fastc output path `${fastc_artifact_file}` aliases imported source `${source_path}`')
+					exit(1)
+				}
+			}
+			fastc_source := fastc_generation.c_source
+			b.step('fastc parse+gen')
+			if c_only && fastc_cross_target {
+				b.metric('generated C size', fastc_source.len, 'bytes')
+				publish_v3_fastc_c_source(fastc_source, output_file, c_to_stdout) or {
+					eprintln(err.msg())
+					exit(1)
+				}
+				b.print_report()
+				clear_macos_v3_compiler_error_fallback(macos_v3_fallback_file)
+				return
+			}
+			// Validate same-target generated C before publishing it. C-only builds use a
+			// throwaway executable; normal builds keep the binary produced by bundled TinyCC.
+			fastc_bin_file := if c_only {
+				os.join_path_single(os.vtmp_dir(),
+					'v3_fastc_validate_${os.getpid()}_${tempname.unique_token()}')
+			} else {
+				bin_file
+			}
+			fastc_result := compile_v3_fastc_source(fastc_source, fastc_bin_file, prefs,
+				environment_c_flags, fastc_generation.c_flags, user_c_flags, environment_ld_flags,
+				is_debug, fastc_generation.uses_threads)
+			if (!silent || show_cc) && fastc_result.command.len > 0 {
+				if c_to_stdout {
+					eprintln('  > ${fastc_result.command}')
+				} else {
+					println('  > ${fastc_result.command}')
+				}
+			}
+			if show_c_output && fastc_result.output.len > 0 {
+				header := '======== Output of TinyCC fastc ========'
+				if c_to_stdout {
+					eprintln(header)
+					eprintln(fastc_result.output.trim_space())
+					eprintln('='.repeat(header.len))
+				} else {
+					println(header)
+					println(fastc_result.output.trim_space())
+					println('='.repeat(header.len))
+				}
+			}
+			if c_only {
+				os.rm(fastc_bin_file) or {}
+			}
+			if !fastc_result.success {
+				if fastc_result.command.len == 0 {
+					eprintln('fastc requires the bundled TinyCC executable')
+				} else if !show_c_output && fastc_result.output.len > 0 {
+					eprintln(fastc_result.output.trim_space())
+				}
+				exit(1)
+			}
+			b.step('tcc')
 			b.metric('generated C size', fastc_source.len, 'bytes')
-			publish_v3_fastc_c_source(fastc_source, output_file, c_to_stdout) or {
-				eprintln(err.msg())
-				exit(1)
+			if c_only {
+				publish_v3_fastc_c_source(fastc_source, output_file, c_to_stdout) or {
+					eprintln(err.msg())
+					exit(1)
+				}
+				b.print_report()
+				clear_macos_v3_compiler_error_fallback(macos_v3_fallback_file)
+				return
+			}
+			if backend_explicit {
+				os.write_file(bin_file + '.c', fastc_source) or {
+					eprintln('failed to retain generated fastc output ${bin_file}.c: ${err.msg()}')
+					exit(1)
+				}
+			}
+			if keep_c {
+				keep_c_file := keep_c_output_file(bin_file)
+				os.write_file(keep_c_file, fastc_source) or {
+					eprintln('failed to retain generated fastc output ${keep_c_file}: ${err.msg()}')
+					exit(1)
+				}
+			}
+			if should_run {
+				run_result := run_binary(bin_file, run_args)
+				if remove_binary_after_run {
+					os.rm(bin_file) or {}
+				}
+				if run_result != 0 {
+					exit(run_result)
+				}
+				b.step('run')
 			}
 			b.print_report()
-			clear_macos_v3_compiler_error_fallback(macos_v3_fallback_file)
 			return
 		}
-		// Validate same-target generated C before publishing it. C-only builds use a
-		// throwaway executable; normal builds keep the binary produced by bundled TinyCC.
-		fastc_bin_file := if c_only {
-			os.join_path_single(os.vtmp_dir(),
-				'v3_fastc_validate_${os.getpid()}_${tempname.unique_token()}')
-		} else {
-			bin_file
-		}
-		fastc_result := compile_v3_fastc_source(fastc_source, fastc_bin_file, prefs,
-			environment_c_flags, fastc_generation.c_flags, user_c_flags, environment_ld_flags,
-			is_debug, fastc_generation.uses_threads)
-		if (!silent || show_cc) && fastc_result.command.len > 0 {
-			if c_to_stdout {
-				eprintln('  > ${fastc_result.command}')
-			} else {
-				println('  > ${fastc_result.command}')
-			}
-		}
-		if show_c_output && fastc_result.output.len > 0 {
-			header := '======== Output of TinyCC fastc ========'
-			if c_to_stdout {
-				eprintln(header)
-				eprintln(fastc_result.output.trim_space())
-				eprintln('='.repeat(header.len))
-			} else {
-				println(header)
-				println(fastc_result.output.trim_space())
-				println('='.repeat(header.len))
-			}
-		}
-		if c_only {
-			os.rm(fastc_bin_file) or {}
-		}
-		if !fastc_result.success {
-			if fastc_result.command.len == 0 {
-				eprintln('fastc requires the bundled TinyCC executable')
-			} else if !show_c_output && fastc_result.output.len > 0 {
-				eprintln(fastc_result.output.trim_space())
-			}
-			exit(1)
-		}
-		b.step('tcc')
-		b.metric('generated C size', fastc_source.len, 'bytes')
-		if c_only {
-			publish_v3_fastc_c_source(fastc_source, output_file, c_to_stdout) or {
-				eprintln(err.msg())
-				exit(1)
-			}
-			b.print_report()
-			clear_macos_v3_compiler_error_fallback(macos_v3_fallback_file)
-			return
-		}
-		if backend_explicit {
-			os.write_file(bin_file + '.c', fastc_source) or {
-				eprintln('failed to retain generated fastc output ${bin_file}.c: ${err.msg()}')
-				exit(1)
-			}
-		}
-		if keep_c {
-			keep_c_file := keep_c_output_file(bin_file)
-			os.write_file(keep_c_file, fastc_source) or {
-				eprintln('failed to retain generated fastc output ${keep_c_file}: ${err.msg()}')
-				exit(1)
-			}
-		}
-		if should_run {
-			run_result := run_binary(bin_file, run_args)
-			if remove_binary_after_run {
-				os.rm(bin_file) or {}
-			}
-			if run_result != 0 {
-				exit(run_result)
-			}
-			b.step('run')
-		}
-		b.print_report()
-		return
 	}
 	minimal_literal_output := !is_prof
 		&& input_uses_minimal_literal_output_builtin(input_file, prefs, is_test_command, is_checker_fixture)
@@ -9137,7 +9168,21 @@ pub fn run(args []string) {
 	// literals before Cgen sees the included translation unit. Resolve those rare
 	// inputs before checking so the type is available to semantic lookup.
 	mut ck_stage_sw := time.new_stopwatch()
-	if !cache_state.external_inputs_ready && ast_has_native_source_include(a) {
+	native_inputs_needed := !cache_state.external_inputs_ready && ast_has_native_source_include(a)
+	native_inputs_overlap := native_inputs_needed && building_v && !cache_state.manager.enabled
+	native_inputs_done := chan bool{cap: 1}
+	native_inputs_args := PrepareV3CheckerNativeInputsArgs{
+		state:         voidptr(&cache_state)
+		a:             &a
+		prefs:         prefs
+		user_files:    user_files
+		user_c_flags:  cache_c_flags
+		scope_enabled: scope_prealloc_stages
+		done:          native_inputs_done
+	}
+	if native_inputs_overlap {
+		spawn prepare_v3_checker_native_inputs_thread(&native_inputs_args)
+	} else if native_inputs_needed {
 		if cache_state.manager.enabled {
 			_ = prepare_v3_cache_external_inputs_scoped(mut cache_state, a, prefs, user_files,
 				cache_c_flags, scope_prealloc_stages)
@@ -9149,7 +9194,7 @@ pub fn run(args []string) {
 	if verbose {
 		eprintln('  [ttime]   ck native inputs ${f64(ck_stage_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 	}
-	if backend == 'c' && cache_state.external_inputs_ready {
+	if !native_inputs_overlap && backend == 'c' && cache_state.external_inputs_ready {
 		fallback_report_sources = macos_v3_fallback_report_inputs(fallback_report_sources,
 			&cache_state)
 		_ = stage_macos_v3_fallback_source_digests(macos_v3_c_error_dir, fallback_report_sources)
@@ -9204,6 +9249,15 @@ pub fn run(args []string) {
 		}
 		mut cvsw := time.new_stopwatch()
 		pre_tc.collect(a)
+		if native_inputs_overlap {
+			_ := <-native_inputs_done
+			if backend == 'c' && cache_state.external_inputs_ready {
+				fallback_report_sources = macos_v3_fallback_report_inputs(fallback_report_sources,
+					&cache_state)
+				_ = stage_macos_v3_fallback_source_digests(macos_v3_c_error_dir,
+					fallback_report_sources)
+			}
+		}
 		if has_conflicting_c_declaration_errors(pre_tc.errors) {
 			if !macos_v3_fallback_suppresses_diagnostics(macos_v3_fallback_file) {
 				print_type_diagnostics(a, pre_tc.notices, pre_tc.errors, is_checker_fixture)
@@ -14061,6 +14115,9 @@ fn path_is_in_dir(path string, dir string) bool {
 // with v3.ssa and v3.ssa.optimize.
 fn skipped_backend_module_groups(prefs &pref.Preferences) [][]string {
 	mut skipped := [][]string{}
+	if 'skip_fastc' in prefs.user_defines {
+		skipped << ['v3.gen.fastc', 'v3.fastcdriver']
+	}
 	if 'skip_arm64' in prefs.user_defines {
 		skipped << ['v3.gen.arm64', 'v3.ssa', 'v3.ssa.optimize']
 	}
@@ -15275,7 +15332,9 @@ fn resolve_imports(mut a flat.FlatAst, mut p parser.Parser, prefs &pref.Preferen
 		}
 	}
 	mut was_parallel := false
-	if prefs.building_v && allow_parallel && !cache_state.manager.enabled
+	// Explicit self-hosting is faster through the normal incremental import loop:
+	// eager discovery duplicates import-identity and collision work for this graph.
+	if prefs.building_v && !prefs.selfhost && allow_parallel && !cache_state.manager.enabled
 		&& os.getenv('V3_NO_EAGER_SELFHOST_IMPORTS') == '' {
 		modules := discover_eager_selfhost_modules(a, prefs, first_file, project_root, mut
 			parsed_modules, mut module_path_cache)

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -8532,6 +8532,15 @@ fn json_encode_sum_helper_name(sum_ct string) string {
 	return b.str()
 }
 
+fn (g &FlatGen) has_legacy_json_module() bool {
+	for _, module_name in g.tc.file_modules {
+		if module_name == 'json' {
+			return true
+		}
+	}
+	return false
+}
+
 fn (mut g FlatGen) collect_json_pointer_types(typ types.Type, seen []string, mut pointer_types map[string]types.Pointer) {
 	clean := if typ is types.Alias { typ.base_type } else { typ }
 	if clean is types.Pointer {
@@ -8652,6 +8661,9 @@ fn (mut g FlatGen) collect_json_encode_sum_types(typ types.Type, seen []string, 
 }
 
 fn (mut g FlatGen) prepare_json_encode_pointer_helpers() []JsonEncodePointerHelper {
+	if !g.has_legacy_json_module() {
+		return []JsonEncodePointerHelper{}
+	}
 	mut pointer_types := map[string]types.Pointer{}
 	for idx, node in g.a.nodes {
 		if node.kind != .call || node.children_count < 2 {
@@ -8685,6 +8697,9 @@ fn (mut g FlatGen) prepare_json_encode_pointer_helpers() []JsonEncodePointerHelp
 }
 
 fn (mut g FlatGen) prepare_json_encode_sum_helpers() []JsonEncodeSumHelper {
+	if !g.has_legacy_json_module() {
+		return []JsonEncodeSumHelper{}
+	}
 	mut sum_types := map[string]types.SumType{}
 	for idx, node in g.a.nodes {
 		if node.kind != .call || node.children_count < 2 {
@@ -8769,6 +8784,9 @@ fn json_decode_pointer_helper_name(pointer_ct string) string {
 }
 
 fn (mut g FlatGen) prepare_json_decode_pointer_helpers() []JsonDecodePointerHelper {
+	if !g.has_legacy_json_module() {
+		return []JsonDecodePointerHelper{}
+	}
 	mut pointer_types := map[string]types.Pointer{}
 	for idx, node in g.a.nodes {
 		if node.kind != .call || node.children_count < 2 {

--- a/vlib/v3/gen/c/interface.v
+++ b/vlib/v3/gen/c/interface.v
@@ -698,6 +698,9 @@ fn (g &FlatGen) interface_impl_is_open_generic(name string) bool {
 }
 
 fn (mut g FlatGen) register_specialized_interface_applications() {
+	if g.tc.interface_generic_params.len == 0 {
+		return
+	}
 	mut applications := map[string]string{}
 	for _, implemented_interfaces in g.tc.struct_implements {
 		for iface in implemented_interfaces {

--- a/vlib/v3/gen/c/types_test.v
+++ b/vlib/v3/gen/c/types_test.v
@@ -6,6 +6,17 @@ import v3.parser
 import v3.pref
 import v3.types
 
+fn test_json_helper_scan_requires_legacy_json_module() {
+	mut ast := flat.FlatAst.new()
+	mut tc := types.TypeChecker.new(&ast)
+	mut g := FlatGen.new()
+	g.a = &ast
+	g.tc = &tc
+	assert !g.has_legacy_json_module()
+	tc.file_modules['json_primitives.c.v'] = 'json'
+	assert g.has_legacy_json_module()
+}
+
 fn test_optional_typedef_collection_ignores_incomplete_call_type_text() {
 	mut ast := &flat.FlatAst{}
 	ast.nodes = [flat.Node{

--- a/vlib/v3/tests/selfhost_backend_prune_test.v
+++ b/vlib/v3/tests/selfhost_backend_prune_test.v
@@ -19,7 +19,7 @@ fn selfhost_to_c(v3_bin string, name string, flags string) string {
 	out_c := out_bin + '.c'
 	os.rm(out_bin) or {}
 	os.rm(out_c) or {}
-	cmd := '${os.quoted_path(v3_bin)} --no-parallel -nocache -no-memory-limit -selfhost -b c ${flags} -o ${os.quoted_path(out_bin)} ${os.quoted_path(v3_src)}'
+	cmd := '${os.quoted_path(v3_bin)} --no-parallel -nocache -no-memory-limit -selfhost -b c ${flags} -o ${os.quoted_path(out_c)} ${os.quoted_path(v3_src)}'
 	res := os.execute(cmd)
 	assert res.exit_code == 0, res.output
 	assert os.exists(out_c), 'missing generated C output ${out_c}'
@@ -33,10 +33,22 @@ fn test_selfhost_default_prunes_optional_backends() {
 	assert !c_src.contains('v3__gen__arm64__'), 'default self-host compiled the arm64 backend'
 	assert !c_src.contains('v3__ssa__'), 'default self-host compiled the SSA backend'
 	assert !c_src.contains('v3__eval__'), 'default self-host compiled the eval backend'
+	assert !c_src.contains('fastc__generate_files_with_source_paths'),
+		'default self-host compiled the FastC backend'
 	assert c_src.contains('bool lhs_is_arr = false;'), 'array equality fallback should use an explicit presence flag'
 	assert c_src.contains('bool lhs_is_fixed = false;'), 'fixed-array equality fallback should use an explicit presence flag'
 	assert !c_src.contains('lhs_arr.elem_type; __sum.typ'), 'array equality fallback used zero-value sum-type sentinel'
 	assert !c_src.contains('lhs_fixed.elem_type; __sum.typ'), 'fixed-array equality fallback used zero-value sum-type sentinel'
+}
+
+fn test_selfhost_compile_backend_fastc_opts_fastc_back_in() {
+	v3_bin := build_selfhost_prune_v3()
+	c_src := selfhost_to_c(v3_bin, 'fastc', '-compile-backend fastc')
+	assert c_src.contains('fastc__generate_files_with_source_paths'),
+		'FastC backend was not compiled after opt-in'
+	assert !c_src.contains('v3__gen__arm64__'), 'FastC opt-in compiled the arm64 backend'
+	assert !c_src.contains('v3__ssa__'), 'FastC opt-in compiled the SSA backend'
+	assert !c_src.contains('v3__eval__'), 'FastC opt-in compiled the eval backend'
 }
 
 fn test_selfhost_compile_backend_wasm_opts_wasm_back_in() {

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -316,14 +316,16 @@ mut:
 	decls            map[string]VisibleMutationFnDecl
 	decl_misses      map[string]bool
 	results          map[u64]bool
+	rebind_results   map[u64]bool
 	decl_index_ready bool
 }
 
 fn new_visible_mutation_cache() &VisibleMutationCache {
 	return &VisibleMutationCache{
-		decls:       map[string]VisibleMutationFnDecl{}
-		decl_misses: map[string]bool{}
-		results:     map[u64]bool{}
+		decls:          map[string]VisibleMutationFnDecl{}
+		decl_misses:    map[string]bool{}
+		results:        map[u64]bool{}
+		rebind_results: map[u64]bool{}
 	}
 }
 
@@ -628,6 +630,15 @@ fn clone_pointer_alias_goto_states(states map[string][]map[string][]string) map[
 	return result
 }
 
+fn clone_string_list_map(source map[string][]string) map[string][]string {
+	mut result := map[string][]string{}
+	result.reserve(u32(source.len))
+	for key, values in source {
+		result[key] = values.clone()
+	}
+	return result
+}
+
 pub struct InterfaceImplIndex {
 pub:
 	names []string
@@ -691,6 +702,7 @@ pub mut:
 	c_variadic_fns                   map[string]bool
 	fn_implicit_veb_ctx              map[string]bool
 	receiver_method_suffix_index     map[string]string
+	generic_receiver_method_index    map[string][]string
 	structs                          map[string][]StructField
 	struct_modules                   map[string]string
 	struct_files                     map[string]string
@@ -1004,6 +1016,7 @@ pub fn TypeChecker.new(a &flat.FlatAst) TypeChecker {
 		c_variadic_fns:                        map[string]bool{}
 		fn_implicit_veb_ctx:                   map[string]bool{}
 		receiver_method_suffix_index:          map[string]string{}
+		generic_receiver_method_index:         map[string][]string{}
 		structs:                               map[string][]StructField{}
 		struct_modules:                        map[string]string{}
 		struct_files:                          map[string]string{}
@@ -1164,6 +1177,7 @@ fn (tc &TypeChecker) fork_program_view(ast &flat.FlatAst, direct_dependencies_by
 		c_variadic_fns:                     tc.c_variadic_fns
 		fn_implicit_veb_ctx:                tc.fn_implicit_veb_ctx
 		receiver_method_suffix_index:       tc.receiver_method_suffix_index
+		generic_receiver_method_index:      tc.generic_receiver_method_index
 		structs:                            tc.structs
 		struct_modules:                     tc.struct_modules
 		struct_files:                       tc.struct_files
@@ -1438,6 +1452,7 @@ pub fn (mut tc TypeChecker) ensure_private_transform_signatures() {
 		tc.fn_ret_types = tc.fn_ret_types.clone()
 		tc.fn_param_types = tc.fn_param_types.clone()
 		tc.receiver_method_suffix_index = tc.receiver_method_suffix_index.clone()
+		tc.generic_receiver_method_index = clone_string_list_map(tc.generic_receiver_method_index)
 		tc.fn_variadic = tc.fn_variadic.clone()
 		tc.specialized_generic_fns = tc.specialized_generic_fns.clone()
 		tc.fn_type_modules = tc.fn_type_modules.clone()
@@ -1682,7 +1697,19 @@ fn (mut tc TypeChecker) init_direct_parent_index(a &flat.FlatAst) {
 fn (mut tc TypeChecker) fill_direct_parent_edges(a &flat.FlatAst) {
 	mut fn_cost := 0
 	for parent_idx, node in a.nodes {
-		fn_cost += 1 + int(node.children_count) * 2
+		// Node count alone severely underestimates index-heavy and control-flow
+		// functions, which leaves one parallel checker worker running last.
+		mut node_cost := 1 + int(node.children_count) * 2
+		node_cost += match node.kind {
+			.index { 64 }
+			.call { 8 }
+			.selector { 4 }
+			.infix { 8 }
+			.for_stmt, .for_in_stmt { 64 }
+			.if_expr, .match_stmt { 16 }
+			else { 0 }
+		}
+		fn_cost += node_cost
 		if node.kind == .goto_stmt {
 			tc.has_goto_nodes = true
 		}
@@ -6263,6 +6290,7 @@ pub fn (mut tc TypeChecker) rebuild_fn_param_suffix_index() {
 	// Allocate a new map so callers rebuilding after a disposable prealloc
 	// scope do not retain its keys, values, or backing storage.
 	tc.receiver_method_suffix_index = map[string]string{}
+	tc.generic_receiver_method_index = map[string][]string{}
 	tc.receiver_method_suffix_index.reserve(u32(tc.fn_param_types.len * 3))
 	for name, _ in tc.fn_param_types {
 		tc.add_receiver_method_suffix_index(name)
@@ -6290,9 +6318,17 @@ fn (mut tc TypeChecker) add_receiver_method_suffix_index(name string) {
 	if tc.method_suffix_prescreen && name.index_u8(`.`) < 0 {
 		return
 	}
+	receiver := name.all_before_last('.')
+	if receiver.contains('[') && receiver.ends_with(']') {
+		method := name.all_after_last('.')
+		mut indexed := tc.generic_receiver_method_index[method] or { []string{} }
+		if name !in indexed {
+			indexed << name
+			tc.generic_receiver_method_index[method] = indexed
+		}
+	}
 	tc.set_receiver_method_suffix_index(name, name)
 	if name.contains('.') {
-		receiver := name.all_before_last('.')
 		bracket := receiver.index_u8(`[`)
 		if bracket > 0 {
 			tc.set_receiver_method_suffix_index('${receiver[..bracket]}.${name.all_after_last('.')}',

--- a/vlib/v3/types/checker_parallel.v
+++ b/vlib/v3/types/checker_parallel.v
@@ -24,6 +24,10 @@ const scoped_check_serial_batches = 64
 // (Re-verified 2026-08: oversubscribe=2 costs ~3-5ms here — the extra per-chunk
 // fork/promote overhead outweighs the straggler absorption.)
 const check_chunk_oversubscribe = 1
+// Self-host checking keeps one accumulator per worker, but feeds each one
+// several smaller chunks dynamically so an underestimated function does not
+// leave the rest of the pool idle at the end of the stage.
+const dynamic_check_chunks_per_job = 8
 // The caller also runs the top-level signature pass while workers check bodies.
 // Give its body bucket one fifth less work so it does not become the pool tail.
 const check_master_bias_pct = i64(-20)
@@ -583,10 +587,13 @@ $if !windows {
 	struct CheckChunkArgs {
 		worker        voidptr
 		items_ptr     voidptr
+		dynamic_items voidptr
+		chunk_queue   chan int
 		scope_enabled bool
 		index         int
 	mut:
-		scope voidptr
+		scope     voidptr
+		processed []CheckWorkItem
 	}
 
 	fn check_chunk_thread(arg voidptr) voidptr {
@@ -595,21 +602,35 @@ $if !windows {
 		a.scope = check_worker_scope_begin(a.scope_enabled)
 		mut w := unsafe { &TypeChecker(a.worker) }
 		items := unsafe { &[]CheckWorkItem(a.items_ptr) }
-		if a.scope_enabled {
-			configured_batches := os.getenv('V3_CHECK_WORKER_BATCHES').int()
-			batch_limit := if configured_batches > 0 {
-				configured_batches
-			} else if os.getenv('V3_NO_COARSER_CHECK_BATCHES') != '' {
-				scoped_check_worker_batches
-			} else {
-				scoped_check_worker_batches / 12
+		configured_batches := os.getenv('V3_CHECK_WORKER_BATCHES').int()
+		batch_limit := if configured_batches > 0 {
+			configured_batches
+		} else if os.getenv('V3_NO_COARSER_CHECK_BATCHES') != '' {
+			scoped_check_worker_batches
+		} else {
+			scoped_check_worker_batches / 12
+		}
+		if a.dynamic_items != unsafe { nil } {
+			chunks := unsafe { &[][]CheckWorkItem(a.dynamic_items) }
+			dynamic_batch_limit := int_max(1, batch_limit / dynamic_check_chunks_per_job)
+			for {
+				chunk_idx := <-a.chunk_queue or { break }
+				chunk := unsafe { chunks[chunk_idx] }
+				if a.scope_enabled {
+					w.check_scoped_batches(chunk, dynamic_batch_limit)
+				} else {
+					w.check_fn_items_serial(chunk)
 			}
+				a.processed << chunk
+			}
+		} else if a.scope_enabled {
 			w.check_scoped_batches(*items, batch_limit)
 		} else {
 			w.check_fn_items_serial(*items)
 		}
 		check_worker_scope_leave(a.scope)
-		w.timing_profile('  [ttime]     ck chunk ${a.index:2}  ${f64(cksw.elapsed().microseconds()) / 1000.0:7.2f} ms (items: ${items.len})')
+		item_count := if a.dynamic_items == unsafe { nil } { items.len } else { a.processed.len }
+		w.timing_profile('  [ttime]     ck chunk ${a.index:2}  ${f64(cksw.elapsed().microseconds()) / 1000.0:7.2f} ms (items: ${item_count})')
 		return unsafe { nil }
 	}
 }
@@ -1180,6 +1201,19 @@ fn (mut tc TypeChecker) run_parallel_check(items []CheckWorkItem) bool {
 		}
 		mut chunks := split_check_items(items, chunk_target)
 		chunk_count := chunks.len
+		fail := os.getenv('V3_TEST_PTHREAD_CREATE_FAIL')
+		dynamic_dispatch := tc.scope_parallel_check_workers && tc.building_v_fast && fail.len == 0
+		mut dynamic_chunks := [][]CheckWorkItem{}
+		mut chunk_queue := chan int{cap: 1}
+		if dynamic_dispatch {
+			dynamic_target := int_min(items.len, chunk_count * dynamic_check_chunks_per_job)
+			dynamic_chunks = split_check_items(items, dynamic_target)
+			chunk_queue = chan int{cap: dynamic_chunks.len}
+			for ci in 0 .. dynamic_chunks.len {
+				chunk_queue <- ci
+			}
+			chunk_queue.close()
+		}
 		thread_count := chunk_count - 1
 		setup_scope := check_worker_scope_begin(tc.scope_parallel_check_workers)
 		worker_count := if tc.scope_parallel_check_workers { chunk_count } else { thread_count }
@@ -1192,6 +1226,10 @@ fn (mut tc TypeChecker) run_parallel_check(items []CheckWorkItem) bool {
 		}
 		tc.timing_profile('  [ttime]   ck forks         ${f64(rpsw.elapsed().microseconds()) / 1000.0:7.2f} ms (workers: ${worker_count})')
 		mut args := []CheckChunkArgs{cap: chunk_count}
+		mut dynamic_items_ptr := voidptr(0)
+		if dynamic_dispatch {
+			dynamic_items_ptr = unsafe { voidptr(&dynamic_chunks) }
+		}
 		for ci in 0 .. chunk_count {
 			mut worker := voidptr(tc)
 			if tc.scope_parallel_check_workers {
@@ -1202,6 +1240,8 @@ fn (mut tc TypeChecker) run_parallel_check(items []CheckWorkItem) bool {
 			args << CheckChunkArgs{
 				worker:        worker
 				items_ptr:     unsafe { voidptr(&chunks[ci]) }
+				dynamic_items: dynamic_items_ptr
+				chunk_queue:   chunk_queue
 				scope_enabled: tc.scope_parallel_check_workers
 				index:         ci
 			}
@@ -1216,7 +1256,6 @@ fn (mut tc TypeChecker) run_parallel_check(items []CheckWorkItem) bool {
 		// cache writes out of the worker-owned shared array ranges. The mutating
 		// value checks already ran before any chunk was created.
 		tc.parallel_check_sparse = true
-		fail := os.getenv('V3_TEST_PTHREAD_CREATE_FAIL')
 		mut tasks := []workers.Task{cap: chunk_count + 1}
 		for ci in 0 .. chunk_count {
 			helper_idx := ci - 1
@@ -1234,6 +1273,11 @@ fn (mut tc TypeChecker) run_parallel_check(items []CheckWorkItem) bool {
 		check_worker_scope_leave(setup_scope)
 		rpsw2 := time.new_stopwatch()
 		any_started := ast.worker_pool.run(tasks)
+		if dynamic_dispatch {
+			for ci in 0 .. chunk_count {
+				chunks[ci] = args[ci].processed
+			}
+		}
 		tc.timing_profile('  [ttime]   ck pool.run      ${f64(rpsw2.elapsed().microseconds()) / 1000.0:7.2f} ms (chunks: ${chunk_count})')
 		tc.merge_own_sparse_caches()
 		tc.parallel_check_sparse = false
@@ -1267,7 +1311,9 @@ fn (mut tc TypeChecker) run_parallel_check(items []CheckWorkItem) bool {
 		for ci in merge_start .. chunk_count {
 			worker_idx := if tc.scope_parallel_check_workers { ci } else { ci - 1 }
 			mut w := unsafe { &TypeChecker(checker_workers[worker_idx]) }
-			scoped := args[ci].scope != unsafe { nil }
+			// Scoped-mode forks always own private interners, even when this compiler
+			// was built without the prealloc allocator and therefore has no arena.
+			scoped := tc.scope_parallel_check_workers
 			if scoped {
 				mg_t0 := time.sys_mono_now()
 				if par_clone {
@@ -2641,6 +2687,7 @@ fn (tc &TypeChecker) fork_for_parallel_check() &TypeChecker {
 		decls:            tc.visible_mutation_cache.decls
 		decl_misses:      map[string]bool{}
 		results:          map[u64]bool{}
+		rebind_results:   map[u64]bool{}
 		decl_index_ready: tc.visible_mutation_cache.decl_index_ready
 	}
 	w.scope_parallel_check_workers = tc.scope_parallel_check_workers

--- a/vlib/v3/types/checker_parallel_test.v
+++ b/vlib/v3/types/checker_parallel_test.v
@@ -41,9 +41,11 @@ fn test_parallel_checker_dependencies_are_private_and_merged() {
 	master_dependency, _ := tc.intern_symbol('main.master_dependency')
 	worker_dependency, _ := tc.intern_symbol('main.worker_dependency')
 	tc.direct_dependencies_by_fn[10] = [master_dependency]
+	tc.visible_mutation_cache.rebind_results[1] = true
 
 	mut worker := tc.fork_for_parallel_check()
 	assert voidptr(worker.visible_mutation_cache) != voidptr(tc.visible_mutation_cache)
+	assert 1 !in worker.visible_mutation_cache.rebind_results
 	assert worker.direct_dependencies_by_fn.len == 0
 	worker.direct_dependencies_by_fn[10] = [worker_dependency]
 	worker.direct_dependencies_by_fn[20] = [master_dependency]
@@ -213,6 +215,30 @@ fn test_generated_fn_params_update_method_suffix_index() {
 	assert tc.fn_param_types_for_name('open') == params
 }
 
+fn test_generic_receiver_pattern_index_survives_rebuild_and_worker_fork() {
+	a := flat.FlatAst.new()
+	mut tc := TypeChecker.new(&a)
+	structured_key := 'Box[[]T].flatten'
+	tc.fn_ret_types[structured_key] = Type(int_)
+	tc.register_generated_fn_param_types(structured_key, []Type{})
+	for i in 0 .. 256 {
+		tc.fn_ret_types['irrelevant_${i}'] = Type(int_)
+	}
+
+	matched := tc.generic_receiver_method_pattern_match('Box', ['[]int'], 'flatten') or {
+		assert false
+		return
+	}
+	assert matched.key == structured_key
+	assert matched.params == ['T']
+	assert matched.args == ['int']
+
+	tc.rebuild_fn_param_suffix_index()
+	assert tc.generic_receiver_method_index['flatten'] == [structured_key]
+	worker := tc.fork_for_parallel_check()
+	assert worker.generic_receiver_method_index['flatten'] == [structured_key]
+}
+
 fn test_enclosing_generic_param_uses_the_owning_top_level_declaration() {
 	mut a := flat.FlatAst.new()
 	generic_child := a.add_val(.ident, 'T')
@@ -269,6 +295,8 @@ fn test_parallel_checker_preserves_all_dependency_edges() {
 		mut a := p.parse_file(path)
 		assert p.diagnostics.len == 0, p.diagnostics.str()
 		mut tc := TypeChecker.new(a)
+		tc.building_v_fast = true
+		tc.enable_scoped_parallel_workers()
 		tc.collect(a)
 		assert tc.check_semantics_opt(true)
 		assert tc.errors.len == 0, tc.errors.str()

--- a/vlib/v3/types/checker_tail.v
+++ b/vlib/v3/types/checker_tail.v
@@ -10432,7 +10432,17 @@ fn (tc &TypeChecker) call_mut_param_can_retag(info CallInfo, param_idx int) bool
 			source_param_idx--
 		}
 	}
-	param := tc.visible_mutation_fn_param(decl, source_param_idx) or { return true }
+	cache_id := visible_mutation_cache_id(decl, source_param_idx)
+	if !isnil(tc.visible_mutation_cache) {
+		cache := tc.visible_mutation_cache
+		if cache_id in cache.rebind_results {
+			return cache.rebind_results[cache_id]
+		}
+	}
+	param := tc.visible_mutation_fn_param(decl, source_param_idx) or {
+		tc.cache_mut_param_rebind_result(cache_id, true)
+		return true
+	}
 	mut param_count := 0
 	for i in 0 .. fn_node.children_count {
 		if tc.a.child_node(&fn_node, i).kind != .param {
@@ -10441,16 +10451,26 @@ fn (tc &TypeChecker) call_mut_param_can_retag(info CallInfo, param_idx int) bool
 		param_count++
 	}
 	if param_count == int(fn_node.children_count) {
+		tc.cache_mut_param_rebind_result(cache_id, fn_node.is_mut)
 		return fn_node.is_mut
 	}
 	for i in param_count .. fn_node.children_count {
 		if tc.subtree_can_rebind_mut_parameter(tc.a.child(&fn_node, i), param.value,
 			info.params[param_idx])
 		{
+			tc.cache_mut_param_rebind_result(cache_id, true)
 			return true
 		}
 	}
+	tc.cache_mut_param_rebind_result(cache_id, false)
 	return false
+}
+
+fn (tc &TypeChecker) cache_mut_param_rebind_result(key u64, result bool) {
+	if !isnil(tc.visible_mutation_cache) {
+		mut cache := tc.visible_mutation_cache
+		cache.rebind_results[key] = result
+	}
 }
 
 fn (tc &TypeChecker) subtree_can_rebind_mut_parameter(id flat.NodeId, name string, typ Type) bool {

--- a/vlib/v3/types/checker_tail_stmt.v
+++ b/vlib/v3/types/checker_tail_stmt.v
@@ -16975,51 +16975,50 @@ fn (tc &TypeChecker) generic_struct_method_alias_target(type_name string) string
 fn (tc &TypeChecker) generic_receiver_method_pattern_match(base string, actual_args []string, method string) ?GenericReceiverMethodPatternMatch {
 	mut best := GenericReceiverMethodPatternMatch{}
 	mut found := false
-	for key, _ in tc.fn_ret_types {
-		method_spelling := key.all_after_last('.')
-		if method_spelling !in [method, '@${method}'] {
-			continue
-		}
-		receiver := key.all_before_last('.')
-		pattern_base, patterns, is_generic := generic_type_application_parts(receiver)
-		if !is_generic || patterns.len != actual_args.len
-			|| !tc.generic_type_base_matches(pattern_base, base) {
-			continue
-		}
-		mut is_exact := true
-		for i, pattern in patterns {
-			if tc.parse_type(trimmed_space(pattern)).name() != tc.parse_type(trimmed_space(actual_args[i])).name() {
-				is_exact = false
-				break
-			}
-		}
-		mut params := []string{}
-		mut inferred_args := []string{}
-		mut specificity := 1_000_000
-		if !is_exact {
-			if patterns.all(is_bare_generic_param(trimmed_space(it))) {
+	for method_spelling in [method, '@${method}'] {
+		candidates := tc.generic_receiver_method_index[method_spelling] or { continue }
+		for key in candidates {
+			receiver := key.all_before_last('.')
+			pattern_base, patterns, is_generic := generic_type_application_parts(receiver)
+			if !is_generic || patterns.len != actual_args.len
+				|| !tc.generic_type_base_matches(pattern_base, base) {
 				continue
 			}
-			params, inferred_args = tc.generic_method_receiver_pattern_args(key, actual_args) or {
-				continue
-			}
-			specificity = 0
-			for pattern in patterns {
-				if !is_bare_generic_param(trimmed_space(pattern)) {
-					specificity += 10_000 + pattern.len
+			mut is_exact := true
+			for i, pattern in patterns {
+				if tc.parse_type(trimmed_space(pattern)).name() != tc.parse_type(trimmed_space(actual_args[i])).name() {
+					is_exact = false
+					break
 				}
 			}
-		}
-		if !found || specificity > best.specificity
-			|| (specificity == best.specificity && key < best.key) {
-			best = GenericReceiverMethodPatternMatch{
-				key:         key
-				params:      params
-				args:        inferred_args
-				specificity: specificity
-				is_exact:    is_exact
+			mut params := []string{}
+			mut inferred_args := []string{}
+			mut specificity := 1_000_000
+			if !is_exact {
+				if patterns.all(is_bare_generic_param(trimmed_space(it))) {
+					continue
+				}
+				params, inferred_args = tc.generic_method_receiver_pattern_args(key, actual_args) or {
+					continue
+				}
+				specificity = 0
+				for pattern in patterns {
+					if !is_bare_generic_param(trimmed_space(pattern)) {
+						specificity += 10_000 + pattern.len
+					}
+				}
 			}
-			found = true
+			if !found || specificity > best.specificity
+				|| (specificity == best.specificity && key < best.key) {
+				best = GenericReceiverMethodPatternMatch{
+					key:         key
+					params:      params
+					args:        inferred_args
+					specificity: specificity
+					is_exact:    is_exact
+				}
+				found = true
+			}
 		}
 	}
 	if !found {
@@ -17073,10 +17072,8 @@ fn (tc &TypeChecker) generic_receiver_has_structured_method_pattern(type_name st
 	if !is_generic {
 		return false
 	}
-	for key, _ in tc.fn_ret_types {
-		if key.all_after_last('.') != method {
-			continue
-		}
+	candidates := tc.generic_receiver_method_index[method] or { return false }
+	for key in candidates {
 		receiver := key.all_before_last('.')
 		pattern_base, patterns, is_pattern := generic_type_application_parts(receiver)
 		if !is_pattern || !tc.generic_type_base_matches(pattern_base, base) {
@@ -17094,10 +17091,8 @@ fn (tc &TypeChecker) generic_receiver_method_rejects_voidptr(type_name string, m
 	if !is_generic {
 		return false
 	}
-	for key, _ in tc.fn_ret_types {
-		if key.all_after_last('.') != method {
-			continue
-		}
+	candidates := tc.generic_receiver_method_index[method] or { return false }
+	for key in candidates {
 		receiver := key.all_before_last('.')
 		pattern_base, _, is_pattern := generic_type_application_parts(receiver)
 		if !is_pattern || !tc.generic_type_base_matches(pattern_base, base) {

--- a/vlib/v3/v3.v
+++ b/vlib/v3/v3.v
@@ -1,8 +1,13 @@
 module main
 
 import os
-import v3.driver
-import v3.fastcdriver
+
+$if !fastc_selfhost ? {
+	import v3.driver
+}
+$if fastc_selfhost ? {
+	import v3.fastcdriver
+}
 
 $if gcboehm ? {
 	$compile_error('v3 must be built without a garbage collector; use `-gc none` or `-prealloc`')


### PR DESCRIPTION
## Summary

- prune FastC from conventional C self-host compilers unless it is explicitly requested
- overlap native-input preparation and improve dynamic checker work distribution
- index generic receiver patterns and cache mutable-parameter rebind analysis
- skip generic-interface and legacy-JSON full-program scans when those features are absent

## Performance

Measured with an optimized standalone V3 compiler compiling `vlib/v3/v3.v` to C with `-selfhost`; C compilation is excluded.

- recent baseline: approximately 1.03-1.2s
- stable post-fix runs: 639.10-648.10ms (median 644.58ms)
- final profiled pass after the additional Cgen guards: 662.79ms under background load
- optional-type helper: 51.88ms to approximately 13ms
- JSON postamble: 21.50ms to 4.03ms
- Cgen in the final paired run: 204.59ms to 178.54ms

## Testing

- `./v -g -keepc -o ./vnew cmd/v`
- `./vnew -silent vlib/v3/types/checker_parallel_test.v`
- `./vnew -silent vlib/v3/types/checker_scoped_transform_test.v`
- `./vnew -silent vlib/v3/tests/selfhost_backend_prune_test.v`
- `./vnew -silent cmd/tools/fast/bench_test.v`
- `./vnew -no-memory-limit -silent vlib/v3/gen/c/types_test.v`
- `./vnew -no-memory-limit -silent vlib/v3/gen/c/interface_test.v`
- `./vnew -no-memory-limit -silent vlib/json/tests/json_decode_v3_regression_test.v`
- `./vnew check-md vlib/v3/README.md`
- `git diff --check`
- repeated optimized V3 self-host source-to-C benchmarks

Not run: broad test suites; validation was intentionally limited to V3 self-host performance and focused regression coverage.