### PR TITLE
json2: share cached field metadata parsing

### DIFF
--- a/vlib/json2/decode.v
+++ b/vlib/json2/decode.v
@@ -47,6 +47,37 @@ struct StructFieldInfo {
 	is_raw        bool
 }
 
+// Keep runtime attribute parsing outside the compile-time field loop. This is called only while
+// a struct type's field metadata cache is initialized.
+@[noinline]
+fn struct_field_info(field_name string, attrs []string) StructFieldInfo {
+	mut json_name_str := field_name.str
+	mut json_name_len := field_name.len
+	mut is_json_skip := false
+	for attr in attrs {
+		if start, end := json_attr_value_range(attr) {
+			if end <= start {
+				continue
+			}
+			if end == start + 1 && attr[start] == `-` {
+				is_json_skip = true
+				break
+			}
+			json_name_str = unsafe { attr.str + start }
+			json_name_len = end - start
+			break
+		}
+	}
+	return StructFieldInfo{
+		json_name_ptr: voidptr(json_name_str)
+		json_name_len: json_name_len
+		is_omitempty:  attrs.contains('omitempty')
+		is_skip:       attrs.contains('skip') || is_json_skip
+		is_required:   attrs.contains('required')
+		is_raw:        attrs.contains('raw')
+	}
+}
+
 struct StructKeyDecodeResult[T] {
 	matched bool
 	value   T
@@ -370,31 +401,7 @@ fn (mut decoder Decoder) cached_struct_field_infos[T]() []StructFieldInfo {
 	if field_infos == nil {
 		field_infos = &[]StructFieldInfo{}
 		$for field in T.fields {
-			mut json_name_str := field.name.str
-			mut json_name_len := field.name.len
-			mut is_json_skip := false
-			for attr in field.attrs {
-				if start, end := json_attr_value_range(attr) {
-					if end <= start {
-						continue
-					}
-					if end == start + 1 && attr[start] == `-` {
-						is_json_skip = true
-						break
-					}
-					json_name_str = unsafe { attr.str + start }
-					json_name_len = end - start
-					break
-				}
-			}
-			field_infos << StructFieldInfo{
-				json_name_ptr: voidptr(json_name_str)
-				json_name_len: json_name_len
-				is_omitempty:  field.attrs.contains('omitempty')
-				is_skip:       field.attrs.contains('skip') || is_json_skip
-				is_required:   field.attrs.contains('required')
-				is_raw:        field.attrs.contains('raw')
-			}
+			field_infos << struct_field_info(field.name, field.attrs)
 		}
 	}
 	return *field_infos

--- a/vlib/json2/decode.v
+++ b/vlib/json2/decode.v
@@ -395,16 +395,21 @@ fn decoder_field_infos[T]() []DecoderFieldInfo {
 	return field_infos
 }
 
+struct StructFieldInfoCache {
+mut:
+	field_infos []StructFieldInfo
+}
+
 @[manualfree; unsafe]
-fn (mut decoder Decoder) cached_struct_field_infos[T]() []StructFieldInfo {
-	static field_infos := &[]StructFieldInfo(nil)
-	if field_infos == nil {
-		field_infos = &[]StructFieldInfo{}
+fn (mut decoder Decoder) cached_struct_field_infos[T]() &StructFieldInfoCache {
+	static cache := &StructFieldInfoCache(nil)
+	if cache == nil {
+		cache = &StructFieldInfoCache{}
 		$for field in T.fields {
-			field_infos << struct_field_info(field.name, field.attrs)
+			cache.field_infos << struct_field_info(field.name, field.attrs)
 		}
 	}
-	return *field_infos
+	return cache
 }
 
 @[inline; markused]
@@ -877,11 +882,11 @@ fn (mut decoder Decoder) decode_value[T](mut val T) ! {
 
 					check_required_struct_fields(mut decoder, val, seen_required, '')!
 				} else {
-					field_infos := unsafe { decoder.cached_struct_field_infos[T]() }
+					field_info_cache := unsafe { decoder.cached_struct_field_infos[T]() }
 					mut decoded_mask := u64(0)
 					mut decoded_fields := []bool{}
-					if field_infos.len > 64 {
-						decoded_fields = []bool{len: field_infos.len}
+					if field_info_cache.field_infos.len > 64 {
+						decoded_fields = []bool{len: field_info_cache.field_infos.len}
 					}
 
 					mut field_idx := 0
@@ -906,7 +911,7 @@ fn (mut decoder Decoder) decode_value[T](mut val T) ! {
 							key_len = unescaped_key.len
 						}
 
-						matched_field_idx := decoder.find_struct_field(field_infos, key_ptr, key_len)
+						matched_field_idx := decoder.find_struct_field(field_info_cache.field_infos, key_ptr, key_len)
 						mut matched := false
 						field_idx = 0
 						$for field in T.fields {
@@ -921,7 +926,7 @@ fn (mut decoder Decoder) decode_value[T](mut val T) ! {
 										matched = true
 								}
 							} else if !matched && field_idx == matched_field_idx {
-								field_info := field_infos[field_idx]
+								field_info := field_info_cache.field_infos[field_idx]
 									// value node
 									decoder.current_node = decoder.current_node.next
 
@@ -1064,7 +1069,7 @@ fn (mut decoder Decoder) decode_value[T](mut val T) ! {
 					// check if all required fields are present
 					field_idx = 0
 					$for field in T.fields {
-						field_info := field_infos[field_idx]
+						field_info := field_info_cache.field_infos[field_idx]
 						if field_info.is_required
 							&& !struct_field_is_decoded(decoded_mask, decoded_fields, field_idx) {
 							decoder.decode_error('missing required field `${field.name}`')!

--- a/vlib/json2/encode.v
+++ b/vlib/json2/encode.v
@@ -575,6 +575,51 @@ struct EncoderFieldInfo {
 	is_json_null bool
 }
 
+// Keep runtime attribute parsing outside the compile-time field loop. This is called only while
+// a struct type's field metadata cache is initialized.
+@[noinline]
+fn encoder_field_info(field_name string, attrs []string) EncoderFieldInfo {
+	mut is_skip := false
+	mut key_name := ''
+	mut is_omitempty := false
+	mut is_required := false
+	mut is_json_null := false
+	for attr in attrs {
+		match attr {
+			'skip' {
+				is_skip = true
+				break
+			}
+			'omitempty' {
+				is_omitempty = true
+			}
+			'required' {
+				is_required = true
+			}
+			'json_null' {
+				is_json_null = true
+			}
+			else {}
+		}
+
+		if attr.starts_with('json:') {
+			json_attr := json_attr_value(attr) or { continue }
+			if json_attr == '-' {
+				is_skip = true
+				break
+			}
+			key_name = json_attr
+		}
+	}
+	return EncoderFieldInfo{
+		key_name:     if key_name == '' { field_name } else { key_name }
+		is_skip:      is_skip
+		is_omitempty: is_omitempty
+		is_required:  is_required
+		is_json_null: is_json_null
+	}
+}
+
 fn get_value_from_optional[T](val ?T) T {
 	return val or { T{} }
 }
@@ -629,45 +674,7 @@ fn (mut encoder Encoder) cached_field_infos[T]() []EncoderFieldInfo {
 	if field_infos == nil {
 		field_infos = &[]EncoderFieldInfo{}
 		$for field in T.fields {
-			mut is_skip := false
-			mut key_name := ''
-			mut is_omitempty := false
-			mut is_required := false
-			mut is_json_null := false
-			for attr in field.attrs {
-				match attr {
-					'skip' {
-						is_skip = true
-						break
-					}
-					'omitempty' {
-						is_omitempty = true
-					}
-					'required' {
-						is_required = true
-					}
-					'json_null' {
-						is_json_null = true
-					}
-					else {}
-				}
-
-				if attr.starts_with('json:') {
-					json_attr := json_attr_value(attr) or { continue }
-					if json_attr == '-' {
-						is_skip = true
-						break
-					}
-					key_name = json_attr
-				}
-			}
-			field_infos << EncoderFieldInfo{
-				key_name:     if key_name == '' { field.name } else { key_name }
-				is_skip:      is_skip
-				is_omitempty: is_omitempty
-				is_required:  is_required
-				is_json_null: is_json_null
-			}
+			field_infos << encoder_field_info(field.name, field.attrs)
 		}
 	}
 	return *field_infos

--- a/vlib/json2/encode.v
+++ b/vlib/json2/encode.v
@@ -575,9 +575,14 @@ struct EncoderFieldInfo {
 	is_json_null bool
 }
 
+struct EncoderFieldInfoCache {
+mut:
+	field_infos []EncoderFieldInfo
+}
+
 // Keep runtime attribute parsing outside the compile-time field loop. This is called only while
 // a struct type's field metadata cache is initialized.
-@[noinline]
+@[manualfree; noinline]
 fn encoder_field_info(field_name string, attrs []string) EncoderFieldInfo {
 	mut is_skip := false
 	mut key_name := ''
@@ -612,7 +617,7 @@ fn encoder_field_info(field_name string, attrs []string) EncoderFieldInfo {
 		}
 	}
 	return EncoderFieldInfo{
-		key_name:     if key_name == '' { field_name } else { key_name }
+		key_name:     if key_name == '' { field_name } else { key_name.clone() }
 		is_skip:      is_skip
 		is_omitempty: is_omitempty
 		is_required:  is_required
@@ -669,15 +674,15 @@ fn check_not_empty[T](val T) ?bool {
 
 // TODO: fix compilation with -autofree, and remove the tag @[manualfree] here:
 @[manualfree; unsafe]
-fn (mut encoder Encoder) cached_field_infos[T]() []EncoderFieldInfo {
-	static field_infos := &[]EncoderFieldInfo(nil)
-	if field_infos == nil {
-		field_infos = &[]EncoderFieldInfo{}
+fn (mut encoder Encoder) cached_field_infos[T]() &EncoderFieldInfoCache {
+	static cache := &EncoderFieldInfoCache(nil)
+	if cache == nil {
+		cache = &EncoderFieldInfoCache{}
 		$for field in T.fields {
-			field_infos << encoder_field_info(field.name, field.attrs)
+			cache.field_infos << encoder_field_info(field.name, field.attrs)
 		}
 	}
-	return *field_infos
+	return cache
 }
 
 fn (mut encoder Encoder) encode_struct_field_value[T](val T) {
@@ -784,7 +789,7 @@ fn (mut encoder Encoder) encode_sumtype_struct_variant_with_embeds[T](val T, var
 
 @[unsafe]
 fn (mut encoder Encoder) encode_struct_fields[T](val T, was_first bool, old_used_keys []string, prefix string) bool {
-	field_infos := encoder.cached_field_infos[T]()
+	field_info_cache := encoder.cached_field_infos[T]()
 	mut is_first := was_first
 	mut used_keys := old_used_keys
 	mut i := 0
@@ -792,7 +797,7 @@ fn (mut encoder Encoder) encode_struct_fields[T](val T, was_first bool, old_used
 	$for field in T.fields {
 		$if !field.is_embed {
 			if !field.attrs.contains('skip') {
-				field_info := field_infos[i]
+				field_info := field_info_cache.field_infos[i]
 				mut write_field := true
 
 				$if field.typ is $shared {
@@ -839,7 +844,7 @@ fn (mut encoder Encoder) encode_struct_fields[T](val T, was_first bool, old_used
 
 @[unsafe]
 fn (mut encoder Encoder) encode_embedded_struct_fields[T](val T, was_first bool, old_used_keys []string, reserved_keys []string, prefix string) bool {
-	field_infos := encoder.cached_field_infos[T]()
+	field_info_cache := encoder.cached_field_infos[T]()
 	mut is_first := was_first
 	mut used_keys := old_used_keys.clone()
 	mut i := 0
@@ -849,7 +854,7 @@ fn (mut encoder Encoder) encode_embedded_struct_fields[T](val T, was_first bool,
 			mut child_reserved_keys := reserved_keys.clone()
 			mut reserved_i := 0
 			$for reserved_field in T.fields {
-				reserved_field_info := field_infos[reserved_i]
+				reserved_field_info := field_info_cache.field_infos[reserved_i]
 				$if !reserved_field.is_embed {
 					if !reserved_field_info.is_skip {
 						child_reserved_keys << reserved_field_info.key_name
@@ -870,7 +875,7 @@ fn (mut encoder Encoder) encode_embedded_struct_fields[T](val T, was_first bool,
 			}
 		} $else {
 			if !field.attrs.contains('skip') {
-				field_info := field_infos[i]
+				field_info := field_info_cache.field_infos[i]
 				mut write_field := true
 				$if field.typ is $shared {
 					shared field_value := unsafe { val.$(field.name) }

--- a/vlib/json2/tests/autofree_json_test.v
+++ b/vlib/json2/tests/autofree_json_test.v
@@ -6,8 +6,19 @@ struct Config {
 	bbb bool
 }
 
+struct RenamedConfig {
+	renamed bool @[json: 'renamed_key']
+}
+
 fn test_compilation_with_autofree() {
 	cfg := Config{}
 	s := json2.encode(cfg, prettify: true)
 	assert s == '{\n    "bbb": false\n}'
+}
+
+fn test_autofree_preserves_json_renamed_key() {
+	assert json2.encode(RenamedConfig{}) == '{"renamed_key":false}'
+	assert json2.encode(RenamedConfig{}) == '{"renamed_key":false}'
+	assert json2.decode[RenamedConfig]('{"renamed_key":true}')!.renamed
+	assert json2.decode[RenamedConfig]('{"renamed_key":true}')!.renamed
 }


### PR DESCRIPTION
## Summary

- move encoder and decoder field-attribute parsing out of comptime field expansion
- share the runtime parsing across all fields and concrete struct types
- keep the shared helpers out of line so the work is emitted only once

The cached metadata builders currently parse `json`, `skip`, `omitempty`, `required`, `raw`, and `json_null` attributes inside `$for field in T.fields`. That duplicates the same runtime parsing logic for every field of every concrete struct type. The helpers are called only while each struct type metadata cache is initialized, so steady-state encode and decode paths are unchanged.

## Size impact

Measured on arm64 macOS using the current FuseCode working tree and identical `-prod -gc none` builds:

- executable: 3,716,040 -> 3,633,256 bytes (-82,784, 2.23%)
- Mach-O `__text`: 3,029,960 -> 2,947,804 bytes (-82,156, 2.71%)
- estimated json2 text from `nm`: 357,708 -> 271,416 bytes (-86,292, 24.12%)

Linker dead stripping did not remove any additional machine code, confirming that the reduction comes from avoiding duplicated generated code rather than removing unreachable functions.

## Performance

Five alternating runs with 2,000,000 attribute-heavy struct operations per encode/decode phase showed no regression:

- median decode: 1,712 ms -> 1,622 ms
- median encode: 1,149 ms -> 1,145 ms

The small differences are within normal benchmark variance; the relevant result is that steady-state throughput did not decline.

## Testing

- JSON2 test suite: 74 passed
- focused JSON2 attribute test passed with the production compiler
- V3 production smoke test covering `json`, `skip`, `omitempty`, and `required` attributes passed
- built and inspected the FuseCode production binary with `nm`, `size`, `file`, and `otool`
