### PR TITLE
net.websocket: close the socket when the TLS connect in dial_socket fails

### DIFF
--- a/vlib/net/websocket/io.v
+++ b/vlib/net/websocket/io.v
@@ -84,7 +84,12 @@ fn (mut ws Client) dial_socket() !&net.TcpConn {
 	t.set_read_timeout(ws.read_timeout)
 	t.set_write_timeout(ws.write_timeout)
 	if ws.is_ssl {
-		ws.ssl_conn.connect(mut t, ws.uri.hostname)!
+		ws.ssl_conn.connect(mut t, ws.uri.hostname) or {
+			// The TcpConn is not the client's yet, so nothing else can close it: a failed TLS
+			// handshake would otherwise leak the connected socket, and the peer's half of it.
+			t.close() or {}
+			return err
+		}
 	}
 	return t
 }


### PR DESCRIPTION
`Client.dial_socket` dials the `TcpConn`, then runs `ws.ssl_conn.connect(mut t, …)!`. On failure the error propagates with `t` never closed — and since `ws.conn` is only assigned after `dial_socket` returns, nothing downstream can close it either. Against a small embedded TLS server (a CSS Electronics CANsub, reached over `wss://`) that meant every failed connect kept a half-open session on the peer until its own timeout, and a few failures in a row exhausted its pool so that later connects timed out. Close it there.

(This PR originally also carried a retry loop for `SSLConn.connect` on `WANT_READ`/`WANT_WRITE`; master has since gained exactly that, so it is now only the websocket half, rebased.)

Tests: `v test vlib/net/websocket/` passes.
