### PR TITLE
v3: further speed up FastC self-host generation

### DIFF
--- a/vlib/v3/gen/fastc/decl.v
+++ b/vlib/v3/gen/fastc/decl.v
@@ -5,7 +5,7 @@ import v3.pref
 import v3.scanner
 import v3.token
 
-fn collect_declared_types(source string, path string, module_name string, prefs &pref.Preferences, mut declared_types map[string]bool, mut declared_kinds map[string]FastcDeclaredTypeKind, mut enum_flags map[string]bool, mut params_structs map[string]bool, mut declaration_paths map[string]string, mut declaration_modules map[string]string) ! {
+fn collect_declared_types(source string, path string, module_name string, prefs &pref.Preferences, mut declared_types map[string]bool, mut declared_kinds map[string]FastcDeclaredTypeKind, mut enum_flags map[string]bool, mut params_structs map[string]bool, mut declaration_paths map[string]string, mut declaration_modules map[string]string) !bool {
 	mut file_set := token.FileSet.new()
 	mut file := file_set.add_file(path, source.len)
 	file.index_lines_without_digest(source)
@@ -16,6 +16,7 @@ fn collect_declared_types(source string, path string, module_name string, prefs 
 	mut next_enum_is_flag := false
 	mut next_struct_is_params := false
 	mut next_type_is_enabled := true
+	mut has_type_declarations := false
 	mut previous_tok := token.Token.unknown
 	mut tok := scan.scan()
 	for tok != .eof {
@@ -24,9 +25,10 @@ fn collect_declared_types(source string, path string, module_name string, prefs 
 			if lookahead.scan() == .key_if {
 				selected := fastc_scan_selected_comptime_branch(mut scan, scan.scan(), path, prefs)!
 				if selected.source != '' {
-					collect_declared_types(selected.source, path, module_name, prefs, mut
-						declared_types, mut declared_kinds, mut enum_flags, mut params_structs, mut
-						declaration_paths, mut declaration_modules)!
+					selected_has_types := collect_declared_types(selected.source, path, module_name,
+						prefs, mut declared_types, mut declared_kinds, mut enum_flags, mut params_structs,
+						mut declaration_paths, mut declaration_modules)!
+					has_type_declarations = has_type_declarations || selected_has_types
 				}
 				tok = selected.tok
 				previous_tok = .unknown
@@ -50,6 +52,7 @@ fn collect_declared_types(source string, path string, module_name string, prefs 
 		}
 		if brace_depth == 0
 			&& tok in [.key_struct, .key_enum, .key_interface, .key_type, .key_union] {
+			has_type_declarations = true
 			is_public := previous_tok == .key_pub
 			kind := match tok {
 				.key_enum { FastcDeclaredTypeKind.enum_ }
@@ -104,6 +107,7 @@ fn collect_declared_types(source string, path string, module_name string, prefs 
 		previous_tok = tok
 		tok = scan.scan()
 	}
+	return has_type_declarations
 }
 
 fn collect_constant_names(source string, path string, module_name string, prefs &pref.Preferences, mut constants map[string]string, mut public_constants map[string]bool, mut constant_paths map[string]string) ! {
@@ -278,6 +282,7 @@ mut:
 	declared_kinds      map[string]FastcDeclaredTypeKind
 	enum_flags          map[string]bool
 	params_structs      map[string]bool
+	type_source_paths   map[string]bool
 	declaration_paths   map[string]string
 	declaration_modules map[string]string
 	constants           map[string]string
@@ -296,6 +301,7 @@ fn fastc_collect_declaration_chunk(sources []FastcSourceFile, prefs &pref.Prefer
 		declared_kinds:      map[string]FastcDeclaredTypeKind{}
 		enum_flags:          map[string]bool{}
 		params_structs:      map[string]bool{}
+		type_source_paths:   map[string]bool{}
 		declaration_paths:   map[string]string{}
 		declaration_modules: map[string]string{}
 		constants:           map[string]string{}
@@ -307,7 +313,7 @@ fn fastc_collect_declaration_chunk(sources []FastcSourceFile, prefs &pref.Prefer
 	}
 	for idx in start .. end {
 		source_file := sources[idx]
-		collect_declared_types(source_file.source, source_file.path,
+		has_type_declarations := collect_declared_types(source_file.source, source_file.path,
 			source_file.header.module_name, prefs, mut partial.declared_types, mut
 			partial.declared_kinds, mut partial.enum_flags, mut partial.params_structs, mut
 			partial.declaration_paths, mut partial.declaration_modules) or {
@@ -315,24 +321,31 @@ fn fastc_collect_declaration_chunk(sources []FastcSourceFile, prefs &pref.Prefer
 			partial.error_message = err.msg()
 			return partial
 		}
-		collect_constant_names(source_file.source, source_file.path,
-			source_file.header.module_name, prefs, mut partial.constants, mut
-			partial.public_constants, mut partial.constant_paths) or {
-			partial.failed = true
-			partial.error_message = err.msg()
-			return partial
+		if has_type_declarations {
+			partial.type_source_paths[source_file.path] = true
 		}
-		collect_global_names(source_file.source, source_file.path, source_file.header, prefs, mut
-			partial.globals, mut partial.public_globals, mut partial.global_paths) or {
-			partial.failed = true
-			partial.error_message = err.msg()
-			return partial
+		if source_file.header.has_constants {
+			collect_constant_names(source_file.source, source_file.path,
+				source_file.header.module_name, prefs, mut partial.constants, mut
+				partial.public_constants, mut partial.constant_paths) or {
+				partial.failed = true
+				partial.error_message = err.msg()
+				return partial
+			}
+		}
+		if source_file.header.has_global_declarations {
+			collect_global_names(source_file.source, source_file.path, source_file.header, prefs, mut
+				partial.globals, mut partial.public_globals, mut partial.global_paths) or {
+				partial.failed = true
+				partial.error_message = err.msg()
+				return partial
+			}
 		}
 	}
 	return partial
 }
 
-fn fastc_merge_declaration_partial(partial FastcDeclarationPartial, mut declared_types map[string]bool, mut declared_kinds map[string]FastcDeclaredTypeKind, mut enum_flags map[string]bool, mut params_structs map[string]bool, mut constants map[string]string, mut public_constants map[string]bool, mut globals map[string]string, mut public_globals map[string]bool) ! {
+fn fastc_merge_declaration_partial(partial FastcDeclarationPartial, mut declared_types map[string]bool, mut declared_kinds map[string]FastcDeclaredTypeKind, mut enum_flags map[string]bool, mut params_structs map[string]bool, mut type_source_paths map[string]bool, mut constants map[string]string, mut public_constants map[string]bool, mut globals map[string]string, mut public_globals map[string]bool) ! {
 	if partial.failed {
 		return error(partial.error_message)
 	}
@@ -350,6 +363,9 @@ fn fastc_merge_declaration_partial(partial FastcDeclarationPartial, mut declared
 	}
 	for key, _ in partial.params_structs {
 		params_structs[key] = true
+	}
+	for path, _ in partial.type_source_paths {
+		type_source_paths[path] = true
 	}
 	for key, c_name in partial.constants {
 		if key in constants {
@@ -379,6 +395,9 @@ fn fastc_generate_global_declarations(sources []FastcSourceFile, prefs &pref.Pre
 	helper_has_c_functions := fastc_functions_declare_c(functions)
 	ordered_sources := fastc_sources_in_dependency_order(sources)!
 	for source_file in ordered_sources {
+		if !source_file.header.has_global_declarations {
+			continue
+		}
 		mut initializers := strings.new_builder(256)
 		mut file_set := token.FileSet.new()
 		mut file := file_set.add_file(source_file.path, source_file.source.len)
@@ -691,6 +710,9 @@ fn fastc_generate_constant_declarations(sources []FastcSourceFile, prefs &pref.P
 	helper_has_c_functions := fastc_functions_declare_c(functions)
 	ordered_sources := fastc_sources_in_dependency_order(sources)!
 	for source_file in ordered_sources {
+		if !source_file.header.has_constants {
+			continue
+		}
 		mut file_set := token.FileSet.new()
 		mut file := file_set.add_file(source_file.path, source_file.source.len)
 		file.index_lines_without_digest(source_file.source)
@@ -1017,7 +1039,7 @@ fn (g &Parser) constant_expression_requires_runtime_storage(tokens []FastcExpres
 	return false
 }
 
-fn fastc_generate_type_declarations(sources []FastcSourceFile, prefs &pref.Preferences, declared_types map[string]bool, declared_kinds map[string]FastcDeclaredTypeKind, enum_flags map[string]bool, constants map[string]string, public_constants map[string]bool, mut struct_fields map[string]map[string]string, mut struct_field_info map[string][]FastcStructField, mut composite_types map[string]bool) !FastcTypeDeclarations {
+fn fastc_generate_type_declarations(sources []FastcSourceFile, prefs &pref.Preferences, type_source_paths map[string]bool, declared_types map[string]bool, declared_kinds map[string]FastcDeclaredTypeKind, enum_flags map[string]bool, constants map[string]string, public_constants map[string]bool, mut struct_fields map[string]map[string]string, mut struct_field_info map[string][]FastcStructField, mut composite_types map[string]bool) !FastcTypeDeclarations {
 	mut out := strings.new_builder(4096)
 	mut bodies := strings.new_builder(4096)
 	mut enum_infos := []FastcEnumInfo{}
@@ -1045,6 +1067,9 @@ fn fastc_generate_type_declarations(sources []FastcSourceFile, prefs &pref.Prefe
 	}
 	out.writeln('')
 	for source_file in sources {
+		if source_file.path !in type_source_paths {
+			continue
+		}
 		fastc_emit_source_type_declarations(source_file, prefs, declared_types, declared_kinds,
 			constants, public_constants, mut struct_fields, mut struct_field_info, mut
 			composite_types, mut alias_base_types, mut sum_types, mut enum_infos, mut bodies)!

--- a/vlib/v3/gen/fastc/fastc.v
+++ b/vlib/v3/gen/fastc/fastc.v
@@ -670,11 +670,13 @@ struct FastcInterfaceField {
 }
 
 struct FastcSourceHeader {
-	module_name   string
-	imports       map[string]string
-	import_order  []string
-	blank_imports []string
-	has_globals   bool
+	module_name             string
+	imports                 map[string]string
+	import_order            []string
+	blank_imports           []string
+	has_globals             bool
+	has_constants           bool
+	has_global_declarations bool
 }
 
 struct FastcSourceFile {
@@ -1110,9 +1112,10 @@ fn generate_source_files(input_sources []FastcSourceFile, module_aliases map[str
 	mut public_constants := map[string]bool{}
 	mut globals := map[string]string{}
 	mut public_globals := map[string]bool{}
+	mut type_source_paths := map[string]bool{}
 	fastc_collect_declaration_indexes(sources, prefs, mut declared_types, mut declared_kinds, mut
-		enum_flags, mut params_structs, mut constants, mut public_constants, mut globals, mut
-		public_globals)!
+		enum_flags, mut params_structs, mut type_source_paths, mut constants, mut public_constants, mut
+		globals, mut public_globals)!
 	declared_type_c_names := fastc_declared_type_c_names(declared_types)
 	mut functions := map[string]FastcFunctionSignature{}
 	mut interface_methods := map[string]bool{}
@@ -1145,7 +1148,7 @@ fn generate_source_files(input_sources []FastcSourceFile, module_aliases map[str
 			fastc_register_composite_type(parameter_type, mut composite_types)
 		}
 	}
-	type_output := fastc_generate_type_declarations(sources, prefs, declared_types, declared_kinds, enum_flags, constants, public_constants, mut struct_fields, mut struct_field_info, mut composite_types)!
+	type_output := fastc_generate_type_declarations(sources, prefs, type_source_paths, declared_types, declared_kinds, enum_flags, constants, public_constants, mut struct_fields, mut struct_field_info, mut composite_types)!
 	declared_composite_types := composite_types.clone()
 	type_declarations := type_output.declarations
 	enum_field_types := type_output.enum_field_types.clone()

--- a/vlib/v3/gen/fastc/fastc_test.v
+++ b/vlib/v3/gen/fastc/fastc_test.v
@@ -24,6 +24,54 @@ fn test_fastc_chunk_bounds_reserve_files_for_later_workers() {
 	assert fastc_chunk_bounds(sources, 2) == [0, 3, 3, 4]
 }
 
+fn test_fastc_source_contains_word_respects_identifier_boundaries() {
+	assert fastc_source_contains_word('module main\nconst answer = 42\n', 'const')
+	assert fastc_source_contains_word('module main\n__global count int\n', '__global')
+	assert !fastc_source_contains_word('module main\nfn key_const() {}\n', 'const')
+	assert !fastc_source_contains_word('module main\nfn use__global_value() {}\n', '__global')
+}
+
+fn test_fastc_generic_source_collection_matches_serial_scan() {
+	mut prefs := pref.new_preferences()
+	sources := [
+		FastcSourceFile{
+			path: 'first.v'
+			source: 'module sample\nfn pick[T](value T) T { return value }\n'
+			header: FastcSourceHeader{
+				module_name: 'sample'
+			}
+		},
+		FastcSourceFile{
+			path: 'second.v'
+			source: 'module sample\nfn keep[T](value T) T { return value }\n'
+			header: FastcSourceHeader{
+				module_name: 'sample'
+			}
+		},
+		FastcSourceFile{
+			path: 'plain.v'
+			source: 'module sample\nfn plain() {}\n'
+			header: FastcSourceHeader{
+				module_name: 'sample'
+			}
+		},
+		FastcSourceFile{
+			path: 'last.v'
+			source: 'module sample\nfn pick[T](other T) T { return other }\n'
+			header: FastcSourceHeader{
+				module_name: 'sample'
+			}
+		},
+	]
+	serial := fastc_collect_generic_method_source_chunk(sources, prefs, 0, sources.len)
+	collected := fastc_collect_generic_method_sources(sources, prefs)
+	assert collected.keys().len == serial.keys().len
+	for key, expected in serial {
+		assert key in collected
+		assert collected[key].source == expected.source
+	}
+}
+
 fn test_selfhost_spawn_nested_wait_statement_and_helper_names() {
 	$if windows {
 		return

--- a/vlib/v3/gen/fastc/monomorphize.v
+++ b/vlib/v3/gen/fastc/monomorphize.v
@@ -43,14 +43,13 @@ struct FastcGenericMethodSource {
 	source                     string
 }
 
-// fastc_collect_generic_method_sources indexes every generic method (own type param) AND
-// generic FREE FUNCTION remaining in the post-monomorphization sources, so the parser can
-// instantiate them on demand. Methods are keyed `<receiver_type>.<name>`; functions are
-// keyed `<module>.<name>` (module-qualified, for aliased cross-module calls like
-// `json.encode`). Fully source-monomorphized entries are already blanked and absent here.
-fn fastc_collect_generic_method_sources(sources []FastcSourceFile, prefs &pref.Preferences) map[string]FastcGenericMethodSource {
+// fastc_collect_generic_method_source_chunk indexes the generic methods and free
+// functions in one contiguous source range. The parallel wrapper merges ranges in
+// source order so duplicate keys retain the serial scan's last-definition behavior.
+fn fastc_collect_generic_method_source_chunk(sources []FastcSourceFile, prefs &pref.Preferences, start int, end int) map[string]FastcGenericMethodSource {
 	mut result := map[string]FastcGenericMethodSource{}
-	for i, source_file in sources {
+	for i in start .. end {
+		source_file := sources[i]
 		module_name := source_file.header.module_name
 		for generic in fastc_scan_generic_fns(source_file.source, source_file.path, prefs, i) {
 			receiver_type := if generic.receiver_type != '' {

--- a/vlib/v3/gen/fastc/parallel_d_v3_no_parallel.v
+++ b/vlib/v3/gen/fastc/parallel_d_v3_no_parallel.v
@@ -5,6 +5,10 @@ import v3.pref
 // A `-no-parallel` (v3_no_parallel) FastC build omits threaded generation
 // entirely, mirroring the AST pipeline's _d_v3_no_parallel variants: both
 // phases run serially and no spawn helpers are referenced.
+fn fastc_collect_generic_method_sources(sources []FastcSourceFile, prefs &pref.Preferences) map[string]FastcGenericMethodSource {
+	return fastc_collect_generic_method_source_chunk(sources, prefs, 0, sources.len)
+}
+
 fn fastc_generate_file_outputs(ctx &FastcFileGenContext, sources []FastcSourceFile) []FastcFileGenOutput {
 	mut outputs := []FastcFileGenOutput{cap: sources.len}
 	for source_file in sources {
@@ -20,11 +24,11 @@ fn fastc_collect_reference_partials(sources []FastcSourceFile, prefs &pref.Prefe
 	}
 }
 
-fn fastc_collect_declaration_indexes(sources []FastcSourceFile, prefs &pref.Preferences, mut declared_types map[string]bool, mut declared_kinds map[string]FastcDeclaredTypeKind, mut enum_flags map[string]bool, mut params_structs map[string]bool, mut constants map[string]string, mut public_constants map[string]bool, mut globals map[string]string, mut public_globals map[string]bool) ! {
+fn fastc_collect_declaration_indexes(sources []FastcSourceFile, prefs &pref.Preferences, mut declared_types map[string]bool, mut declared_kinds map[string]FastcDeclaredTypeKind, mut enum_flags map[string]bool, mut params_structs map[string]bool, mut type_source_paths map[string]bool, mut constants map[string]string, mut public_constants map[string]bool, mut globals map[string]string, mut public_globals map[string]bool) ! {
 	partial := fastc_collect_declaration_chunk(sources, prefs, 0, sources.len)
 	fastc_merge_declaration_partial(partial, mut declared_types, mut declared_kinds, mut
-		enum_flags, mut params_structs, mut constants, mut public_constants, mut globals, mut
-		public_globals)!
+		enum_flags, mut params_structs, mut type_source_paths, mut constants, mut public_constants, mut
+		globals, mut public_globals)!
 }
 
 fn fastc_collect_signatures(sources []FastcSourceFile, prefs &pref.Preferences, declared_types map[string]bool, declared_type_c_names map[string]string, params_structs map[string]bool, mut functions map[string]FastcFunctionSignature, mut interface_methods map[string]bool, mut interface_fields map[string]FastcInterfaceField, mut embed_embedders []string, mut embed_embeddeds []string) ! {

--- a/vlib/v3/gen/fastc/parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/fastc/parallel_notd_v3_no_parallel.v
@@ -55,6 +55,33 @@ fn fastc_chunk_bounds(sources []FastcSourceFile, jobs int) []int {
 	return bounds
 }
 
+// fastc_collect_generic_method_sources indexes every generic method and free
+// function remaining after source monomorphization. Scanning is independent per
+// file, and chunk maps are merged in source order for deterministic duplicates.
+fn fastc_collect_generic_method_sources(sources []FastcSourceFile, prefs &pref.Preferences) map[string]FastcGenericMethodSource {
+	jobs := fastc_parallel_jobs(sources, prefs)
+	if jobs <= 1 {
+		return fastc_collect_generic_method_source_chunk(sources, prefs, 0, sources.len)
+	}
+	bounds := fastc_chunk_bounds(sources, jobs)
+	first_thread := spawn fastc_collect_generic_method_source_chunk(sources, prefs, bounds[0],
+		bounds[1])
+	mut chunk_threads := [first_thread]
+	for chunk_idx in 1 .. bounds.len / 2 {
+		chunk_thread := spawn fastc_collect_generic_method_source_chunk(sources, prefs,
+			bounds[chunk_idx * 2], bounds[chunk_idx * 2 + 1])
+		chunk_threads << chunk_thread
+	}
+	mut result := map[string]FastcGenericMethodSource{}
+	for chunk_idx in 0 .. chunk_threads.len {
+		chunk := chunk_threads[chunk_idx].wait()
+		for key, generic in chunk {
+			result[key] = generic
+		}
+	}
+	return result
+}
+
 // fastc_generate_file_chunk generates a contiguous file range on its own
 // thread. The array header is passed by value; the backing file data is
 // shared and read-only. It runs as a value-returning spawn: under -prealloc,
@@ -158,13 +185,13 @@ fn fastc_collect_reference_partials(sources []FastcSourceFile, prefs &pref.Prefe
 	}
 }
 
-fn fastc_collect_declaration_indexes(sources []FastcSourceFile, prefs &pref.Preferences, mut declared_types map[string]bool, mut declared_kinds map[string]FastcDeclaredTypeKind, mut enum_flags map[string]bool, mut params_structs map[string]bool, mut constants map[string]string, mut public_constants map[string]bool, mut globals map[string]string, mut public_globals map[string]bool) ! {
+fn fastc_collect_declaration_indexes(sources []FastcSourceFile, prefs &pref.Preferences, mut declared_types map[string]bool, mut declared_kinds map[string]FastcDeclaredTypeKind, mut enum_flags map[string]bool, mut params_structs map[string]bool, mut type_source_paths map[string]bool, mut constants map[string]string, mut public_constants map[string]bool, mut globals map[string]string, mut public_globals map[string]bool) ! {
 	jobs := fastc_parallel_jobs(sources, prefs)
 	if jobs <= 1 {
 		partial := fastc_collect_declaration_chunk(sources, prefs, 0, sources.len)
 		fastc_merge_declaration_partial(partial, mut declared_types, mut declared_kinds, mut
-			enum_flags, mut params_structs, mut constants, mut public_constants, mut globals, mut
-			public_globals)!
+			enum_flags, mut params_structs, mut type_source_paths, mut constants, mut public_constants,
+			mut globals, mut public_globals)!
 		return
 	}
 	bounds := fastc_chunk_bounds(sources, jobs)
@@ -178,8 +205,8 @@ fn fastc_collect_declaration_indexes(sources []FastcSourceFile, prefs &pref.Pref
 	for chunk_idx in 0 .. chunk_threads.len {
 		partial := chunk_threads[chunk_idx].wait()
 		fastc_merge_declaration_partial(partial, mut declared_types, mut declared_kinds, mut
-			enum_flags, mut params_structs, mut constants, mut public_constants, mut globals, mut
-			public_globals)!
+			enum_flags, mut params_structs, mut type_source_paths, mut constants, mut public_constants,
+			mut globals, mut public_globals)!
 	}
 }
 

--- a/vlib/v3/gen/fastc/source.v
+++ b/vlib/v3/gen/fastc/source.v
@@ -135,11 +135,13 @@ fn fastc_resolve_source_files(paths []string, prefs &pref.Preferences) !([]Fastc
 				return error('fastc imported source `${path}` declares module `${header.module_name}` instead of `${expected_module_name}`')
 			}
 			header = FastcSourceHeader{
-				module_name:   queued.module_name
-				imports:       header.imports
-				import_order:  header.import_order
-				blank_imports: header.blank_imports
-				has_globals:   header.has_globals
+				module_name:             queued.module_name
+				imports:                 header.imports
+				import_order:            header.import_order
+				blank_imports:           header.blank_imports
+				has_globals:             header.has_globals
+				has_constants:           header.has_constants
+				has_global_declarations: header.has_global_declarations
 			}
 		}
 		sources << FastcSourceFile{
@@ -476,12 +478,37 @@ fn fastc_scan_source_header(source string, path string, prefs &pref.Preferences)
 		}
 	}
 	return FastcSourceHeader{
-		module_name:   module_name
-		imports:       imports
-		import_order:  import_order
-		blank_imports: blank_imports
-		has_globals:   has_globals
+		module_name:             module_name
+		imports:                 imports
+		import_order:            import_order
+		blank_imports:           blank_imports
+		has_globals:             has_globals
+		has_constants:           fastc_source_contains_word(source, 'const')
+		has_global_declarations: fastc_source_contains_word(source, '__global')
 	}
+}
+
+fn fastc_source_contains_word(source string, word string) bool {
+	mut start := 0
+	for start < source.len {
+		index := source.index_after_(word, start)
+		if index < 0 {
+			return false
+		}
+		end := index + word.len
+		before_is_identifier := index > 0 && fastc_identifier_byte(source[index - 1])
+		after_is_identifier := end < source.len && fastc_identifier_byte(source[end])
+		if !before_is_identifier && !after_is_identifier {
+			return true
+		}
+		start = end
+	}
+	return false
+}
+
+fn fastc_identifier_byte(value u8) bool {
+	return value == `_` || (value >= `a` && value <= `z`) || (value >= `A` && value <= `Z`)
+		|| (value >= `0` && value <= `9`)
 }
 
 // fastc_source_uses_sql reports whether a file contains a `sql <conn> { ... }` ORM


### PR DESCRIPTION
## Summary

- parallelize generic method and free-function source discovery using the existing size-balanced worker chunks
- skip constant and global declaration scans for source files that cannot contain them
- reuse declaration indexing to skip type emission scans for files without type declarations
- preserve deterministic source-order merging and the serial `v3_no_parallel` implementation

## Performance

Production-built FastC compiler, same source tree, quiet machine, best of 100 generations:

| Version | Generation time | Throughput |
| --- | ---: | ---: |
| merged baseline | 75.08 ms | 855,697 loc/s |
| this PR | 63.32 ms | 1,014,719 loc/s |

This is an 11.76 ms / 15.7% reduction and puts self-host generation below the 70 ms target.
The benchmark covers 170 files and 64,250 lines. The existing descendant TinyCC operand error occurs after the measured generation phase and is unchanged.

## Validation

- rebuilt `./vnew` with `./v -g -keepc -o ./vnew cmd/v`
- focused FastC tests, including header word boundaries, parallel generic collection, and C directives
- `./vnew -silent vlib/v/compiler_errors_test.v` — 1,619 passed, 1 skipped
- direct `v3_no_parallel` self-host compiler build
- byte comparison of default parallel and forced-serial generated C — identical, 3,987,858 bytes
- `git diff --check`

The broad test suite was not run.