### PR TITLE
math.big, crypto.rand: add primality testing and prime generation

### DIFF
--- a/vlib/crypto/README.md
+++ b/vlib/crypto/README.md
@@ -20,6 +20,25 @@ system's cryptographically secure random source and can return an error. The sep
 
 ## Examples
 
+### Prime generation
+
+Use `crypto.rand.prime(bits)` to generate an odd prime with exactly `bits` bits. Its two
+highest bits are set, so multiplying two primes of the same size produces a `2 * bits`-bit
+RSA modulus. `crypto.rand.safe_prime(bits)` additionally requires `(p - 1) / 2` to be prime
+and is considerably slower. Both functions use the operating system's cryptographically
+secure random source and can return an error.
+
+```v
+import crypto.rand
+
+fn main() {
+	p := rand.prime(256)!
+	safe := rand.safe_prime(256)!
+	assert p.bit_len() == 256
+	assert safe.bit_len() == 256
+}
+```
+
 ### Constant-time comparisons
 
 Use `crypto.subtle` for low-level helpers whose running time does not depend on secret data:
@@ -99,21 +118,27 @@ fn main() {
 }
 
 fn make_token(secret string) string {
-	header :=
-		base64.url_encode(json2.encode(JwtHeader{'HS256', 'JWT'}, escape_unicode: true).bytes())
+	header := base64.url_encode(
+		json2.encode(JwtHeader{'HS256', 'JWT'}, escape_unicode: true).bytes(),
+	)
 	payload := base64.url_encode(json2.encode(JwtPayload{'1234567890', 'John Doe', 1516239022},
 		escape_unicode: true
 	).bytes())
-	signature := base64.url_encode(hmac.new(secret.bytes(), '${header}.${payload}'.bytes(),
-		sha256.sum, sha256.block_size))
+	signature := base64.url_encode(
+		hmac.new(secret.bytes(), '${header}.${payload}'.bytes(), sha256.sum, sha256.block_size),
+	)
 	jwt := '${header}.${payload}.${signature}'
 	return jwt
 }
 
 fn auth_verify(secret string, token string) bool {
 	token_split := token.split('.')
-	signature_mirror := hmac.new(secret.bytes(), '${token_split[0]}.${token_split[1]}'.bytes(),
-		sha256.sum, sha256.block_size)
+	signature_mirror := hmac.new(
+		secret.bytes(),
+		'${token_split[0]}.${token_split[1]}'.bytes(),
+		sha256.sum,
+		sha256.block_size,
+	)
 	signature_from_token := base64.url_decode(token_split[2])
 	return hmac.equal(signature_from_token, signature_mirror)
 }

--- a/vlib/crypto/rand/internal/rand.js.v
+++ b/vlib/crypto/rand/internal/rand.js.v
@@ -1,0 +1,15 @@
+// Copyright (c) 2019-2026 Alexander Medvednikov. All rights reserved.
+// Use of this source code is governed by an MIT license
+// that can be found in the LICENSE file.
+module internal
+
+// read fills `buffer` with random bytes from the Web Crypto API.
+pub fn read(mut buffer []u8) ! {
+	#const crypto_source = typeof globalThis.crypto !== 'undefined' ? globalThis.crypto : (typeof require === 'function' ? require('crypto').webcrypto : undefined)
+	#if (!crypto_source || typeof crypto_source.getRandomValues !== 'function') return error(new string('crypto.rand.read is not implemented on this platform'))
+	#try {
+	#const random_values = new Uint8Array(buffer.val.len.valueOf())
+	#for (let offset = 0; offset < random_values.length; offset += 65536) crypto_source.getRandomValues(random_values.subarray(offset, offset + 65536))
+	#for (let i = 0; i < random_values.length; i++) buffer.val.arr.arr[i] = new u8(random_values[i])
+	#} catch (e) { return error(new string('' + e)); }
+}

--- a/vlib/crypto/rand/internal/rand.v
+++ b/vlib/crypto/rand/internal/rand.v
@@ -1,0 +1,23 @@
+// Copyright (c) 2019-2026 Alexander Medvednikov. All rights reserved.
+// Use of this source code is governed by an MIT license
+// that can be found in the LICENSE file.
+module internal
+
+struct ReadError {
+	Error
+}
+
+// msg returns the error message.
+pub fn (err ReadError) msg() string {
+	return 'crypto.rand.read() error reading random bytes'
+}
+
+// bytes returns an array filled from the operating system's random source.
+pub fn bytes(bytes_needed int) ![]u8 {
+	if bytes_needed < 0 {
+		return error('can not read < 0 random bytes')
+	}
+	mut buffer := []u8{len: bytes_needed}
+	read(mut buffer)!
+	return buffer
+}

--- a/vlib/crypto/rand/internal/rand.wasm.v
+++ b/vlib/crypto/rand/internal/rand.wasm.v
@@ -1,0 +1,10 @@
+// Copyright (c) 2019-2026 Alexander Medvednikov. All rights reserved.
+// Use of this source code is governed by an MIT license
+// that can be found in the LICENSE file.
+module internal
+
+// read reports that OS entropy is not implemented by the WASM backend.
+pub fn read(mut buffer []u8) ! {
+	_ = buffer
+	return error('crypto.rand.read is not implemented on the WASM backend')
+}

--- a/vlib/crypto/rand/internal/rand_darwin.c.v
+++ b/vlib/crypto/rand/internal/rand_darwin.c.v
@@ -1,12 +1,11 @@
 // Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
-
-module rand
+module internal
 
 #include <sys/random.h>
 
-fn C.getrandom(p &u8, n usize, flags u32) i32
+fn C.getentropy(buf voidptr, buflen usize) i32
 
 const read_batch_size = 256
 
@@ -14,25 +13,17 @@ const read_batch_size = 256
 pub fn read(mut buffer []u8) ! {
 	mut bytes_read := 0
 	mut remaining_bytes := buffer.len
-	// getrandom syscall wont block if requesting <= 256 bytes
 	for bytes_read < buffer.len {
 		batch_size := if remaining_bytes > read_batch_size {
 			read_batch_size
 		} else {
 			remaining_bytes
 		}
-		rbytes := unsafe { v_getrandom(batch_size, &u8(buffer.data) + bytes_read) }
-		if rbytes == -1 {
+		status := unsafe { C.getentropy(&u8(buffer.data) + bytes_read, batch_size) }
+		if status != 0 {
 			return &ReadError{}
 		}
-		bytes_read += rbytes
-		remaining_bytes -= rbytes
+		bytes_read += batch_size
+		remaining_bytes -= batch_size
 	}
-}
-
-fn v_getrandom(bytes_needed int, buffer voidptr) int {
-	if bytes_needed > read_batch_size {
-		panic('getrandom() dont request more than ${read_batch_size} bytes at once.')
-	}
-	return C.getrandom(buffer, bytes_needed, 0)
 }

--- a/vlib/crypto/rand/internal/rand_default.c.v
+++ b/vlib/crypto/rand/internal/rand_default.c.v
@@ -1,7 +1,7 @@
 // Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
-module rand
+module internal
 
 // read fills `buffer` with random bytes from the OS.
 pub fn read(mut buffer []u8) ! {

--- a/vlib/crypto/rand/internal/rand_freebsd.c.v
+++ b/vlib/crypto/rand/internal/rand_freebsd.c.v
@@ -1,8 +1,7 @@
 // Copyright (c) 2022 John Lloyd. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
-
-module rand
+module internal
 
 #include <stdlib.h>
 

--- a/vlib/crypto/rand/internal/rand_linux.c.v
+++ b/vlib/crypto/rand/internal/rand_linux.c.v
@@ -1,7 +1,7 @@
 // Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
-module rand
+module internal
 
 #include <sys/syscall.h>
 

--- a/vlib/crypto/rand/internal/rand_openbsd.c.v
+++ b/vlib/crypto/rand/internal/rand_openbsd.c.v
@@ -1,8 +1,7 @@
 // Copyright (c) 2022 John Lloyd. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
-
-module rand
+module internal
 
 #include <stdlib.h>
 

--- a/vlib/crypto/rand/internal/rand_solaris.c.v
+++ b/vlib/crypto/rand/internal/rand_solaris.c.v
@@ -1,12 +1,11 @@
 // Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
-
-module rand
+module internal
 
 #include <sys/random.h>
 
-fn C.getentropy(buf voidptr, buflen usize) i32
+fn C.getrandom(p &u8, n usize, flags u32) i32
 
 const read_batch_size = 256
 
@@ -14,17 +13,25 @@ const read_batch_size = 256
 pub fn read(mut buffer []u8) ! {
 	mut bytes_read := 0
 	mut remaining_bytes := buffer.len
+	// getrandom syscall wont block if requesting <= 256 bytes
 	for bytes_read < buffer.len {
 		batch_size := if remaining_bytes > read_batch_size {
 			read_batch_size
 		} else {
 			remaining_bytes
 		}
-		status := unsafe { C.getentropy(&u8(buffer.data) + bytes_read, batch_size) }
-		if status != 0 {
+		rbytes := unsafe { v_getrandom(batch_size, &u8(buffer.data) + bytes_read) }
+		if rbytes == -1 {
 			return &ReadError{}
 		}
-		bytes_read += batch_size
-		remaining_bytes -= batch_size
+		bytes_read += rbytes
+		remaining_bytes -= rbytes
 	}
+}
+
+fn v_getrandom(bytes_needed int, buffer voidptr) int {
+	if bytes_needed > read_batch_size {
+		panic('getrandom() dont request more than ${read_batch_size} bytes at once.')
+	}
+	return C.getrandom(buffer, bytes_needed, 0)
 }

--- a/vlib/crypto/rand/internal/rand_windows.c.v
+++ b/vlib/crypto/rand/internal/rand_windows.c.v
@@ -1,11 +1,12 @@
 // Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
-
-module rand
+module internal
 
 #flag windows -Llibraries/bcrypt
+
 #flag windows -lbcrypt
+
 #include <bcrypt.h>
 
 const status_success = 0x00000000

--- a/vlib/crypto/rand/prime.v
+++ b/vlib/crypto/rand/prime.v
@@ -19,7 +19,10 @@ pub fn prime(bits int) !big.Integer {
 		return error('crypto.rand: prime requires at least 2 bits')
 	}
 	if bits == 2 {
-		return if int_u64(2)! == 0 { big.two_int } else { big.integer_from_int(3) }
+		if int_u64(2)! == 0 {
+			return big.two_int
+		}
+		return big.integer_from_int(3)
 	}
 	for {
 		mut candidate := random_bits(bits)!

--- a/vlib/crypto/rand/prime.v
+++ b/vlib/crypto/rand/prime.v
@@ -1,0 +1,75 @@
+// Copyright (c) 2019-2026 Alexander Medvednikov. All rights reserved.
+// Use of this source code is governed by an MIT license
+// that can be found in the LICENSE file.
+module rand
+
+import math.big
+
+// prime returns a random prime of exactly `bits` bits, drawn from the
+// operating system's source of entropy.
+//
+// The two highest bits and the lowest bit of the result are set. The lowest
+// bit makes the candidate odd; the second highest bit guarantees that the
+// product of two independently generated `bits`-sized primes has exactly
+// `2 * bits` bits, which is what RSA key generation relies on.
+//
+// Primality is established with `big.Integer.is_probably_prime`, whose
+// error probability is negligible but not zero.
+pub fn prime(bits int) !big.Integer {
+	if bits < 2 {
+		return error('crypto.rand: prime requires at least 2 bits')
+	}
+	if bits == 2 {
+		// The only two-bit primes are 2 and 3.
+		return if int_u64(2)! == 0 { big.two_int } else { big.integer_from_int(3) }
+	}
+	for {
+		mut candidate := random_bits(bits)!
+		candidate.set_bit(u32(bits - 1), true)
+		candidate.set_bit(u32(bits - 2), true)
+		candidate.set_bit(0, true)
+		if candidate.is_probably_prime(0) {
+			return candidate
+		}
+	}
+	return error('crypto.rand: unreachable')
+}
+
+// safe_prime returns a random prime `p` of exactly `bits` bits for which
+// `(p - 1) / 2` is also prime.
+//
+// Safe primes are used as Diffie-Hellman moduli, where they rule out small
+// subgroup attacks. They are much rarer than ordinary primes, so this is
+// substantially slower than `prime`.
+pub fn safe_prime(bits int) !big.Integer {
+	if bits < 3 {
+		return error('crypto.rand: safe_prime requires at least 3 bits')
+	}
+	for {
+		// Generate the smaller q first: the expensive test then runs on the
+		// smaller number, and most candidates are discarded there.
+		q := prime(bits - 1)!
+		p := q.left_shift(1) + big.one_int
+		if p.bit_len() == bits && p.is_probably_prime(0) {
+			return p
+		}
+	}
+	return error('crypto.rand: unreachable')
+}
+
+// random_bits returns a uniformly distributed non-negative integer below
+// `2^bits`.
+fn random_bits(bits int) !big.Integer {
+	if bits <= 0 {
+		return big.zero_int
+	}
+	nbytes := (bits + 7) / 8
+	mut buf := bytes(nbytes)!
+	// Clear the bits above the requested length in the leading byte, so the
+	// value stays below 2^bits.
+	excess := nbytes * 8 - bits
+	if excess > 0 {
+		buf[0] &= u8(0xff >> excess)
+	}
+	return big.integer_from_bytes(buf)
+}

--- a/vlib/crypto/rand/prime.v
+++ b/vlib/crypto/rand/prime.v
@@ -5,22 +5,20 @@ module rand
 
 import math.big
 
-// prime returns a random prime of exactly `bits` bits, drawn from the
-// operating system's source of entropy.
+// prime returns a random prime of exactly `bits` bits, drawn from the operating
+// system's source of entropy.
 //
-// The two highest bits and the lowest bit of the result are set. The lowest
-// bit makes the candidate odd; the second highest bit guarantees that the
-// product of two independently generated `bits`-sized primes has exactly
-// `2 * bits` bits, which is what RSA key generation relies on.
+// The two highest bits and the lowest bit are set. The lowest makes the
+// candidate odd; the second highest means the product of two `bits`-sized
+// primes has exactly `2 * bits` bits, as RSA key generation expects.
 //
-// Primality is established with `big.Integer.is_probably_prime`, whose
-// error probability is negligible but not zero.
+// Primality comes from `big.Integer.is_probably_prime`, whose error probability
+// is negligible but not zero.
 pub fn prime(bits int) !big.Integer {
 	if bits < 2 {
 		return error('crypto.rand: prime requires at least 2 bits')
 	}
 	if bits == 2 {
-		// The only two-bit primes are 2 and 3.
 		return if int_u64(2)! == 0 { big.two_int } else { big.integer_from_int(3) }
 	}
 	for {
@@ -36,18 +34,15 @@ pub fn prime(bits int) !big.Integer {
 }
 
 // safe_prime returns a random prime `p` of exactly `bits` bits for which
-// `(p - 1) / 2` is also prime.
-//
-// Safe primes are used as Diffie-Hellman moduli, where they rule out small
-// subgroup attacks. They are much rarer than ordinary primes, so this is
-// substantially slower than `prime`.
+// `(p - 1) / 2` is also prime. Safe primes are used as Diffie-Hellman moduli,
+// where they rule out small subgroup attacks. They are far rarer than ordinary
+// primes, so this is much slower than `prime`.
 pub fn safe_prime(bits int) !big.Integer {
 	if bits < 3 {
 		return error('crypto.rand: safe_prime requires at least 3 bits')
 	}
 	for {
-		// Generate the smaller q first: the expensive test then runs on the
-		// smaller number, and most candidates are discarded there.
+		// q first, so the expensive test runs on the smaller number.
 		q := prime(bits - 1)!
 		p := q.left_shift(1) + big.one_int
 		if p.bit_len() == bits && p.is_probably_prime(0) {
@@ -57,16 +52,14 @@ pub fn safe_prime(bits int) !big.Integer {
 	return error('crypto.rand: unreachable')
 }
 
-// random_bits returns a uniformly distributed non-negative integer below
-// `2^bits`.
+// random_bits returns a uniformly distributed integer below `2^bits`.
 fn random_bits(bits int) !big.Integer {
 	if bits <= 0 {
 		return big.zero_int
 	}
 	nbytes := (bits + 7) / 8
 	mut buf := bytes(nbytes)!
-	// Clear the bits above the requested length in the leading byte, so the
-	// value stays below 2^bits.
+	// Clear the bits above the requested length in the leading byte.
 	excess := nbytes * 8 - bits
 	if excess > 0 {
 		buf[0] &= u8(0xff >> excess)

--- a/vlib/crypto/rand/prime.v
+++ b/vlib/crypto/rand/prime.v
@@ -19,9 +19,6 @@ pub fn prime(bits int) !big.Integer {
 		return error('crypto.rand: prime requires at least 2 bits')
 	}
 	if bits == 2 {
-		if int_u64(2)! == 0 {
-			return big.two_int
-		}
 		return big.integer_from_int(3)
 	}
 	for {

--- a/vlib/crypto/rand/prime.v
+++ b/vlib/crypto/rand/prime.v
@@ -26,7 +26,7 @@ pub fn prime(bits int) !big.Integer {
 		candidate.set_bit(u32(bits - 1), true)
 		candidate.set_bit(u32(bits - 2), true)
 		candidate.set_bit(0, true)
-		if candidate.is_probably_prime(0) {
+		if candidate.is_probably_prime_checked(0)! {
 			return candidate
 		}
 	}
@@ -51,7 +51,7 @@ pub fn safe_prime(bits int) !big.Integer {
 		// q first, so the expensive test runs on the smaller number.
 		q := prime(bits - 1)!
 		p := q.left_shift(1) + big.one_int
-		if p.bit_len() == bits && p.is_probably_prime(0) {
+		if p.bit_len() == bits && p.is_probably_prime_checked(0)! {
 			return p
 		}
 	}

--- a/vlib/crypto/rand/prime.v
+++ b/vlib/crypto/rand/prime.v
@@ -41,6 +41,12 @@ pub fn safe_prime(bits int) !big.Integer {
 	if bits < 3 {
 		return error('crypto.rand: safe_prime requires at least 3 bits')
 	}
+	if bits == 4 {
+		return big.integer_from_int(11)
+	}
+	if bits == 5 {
+		return big.integer_from_int(23)
+	}
 	for {
 		// q first, so the expensive test runs on the smaller number.
 		q := prime(bits - 1)!

--- a/vlib/crypto/rand/prime_test.v
+++ b/vlib/crypto/rand/prime_test.v
@@ -1,0 +1,72 @@
+import crypto.rand
+import math.big
+
+fn test_prime_bit_length() {
+	for bits in [8, 16, 32, 64, 128, 256] {
+		p := rand.prime(bits) or { panic(err) }
+		assert p.bit_len() == bits, 'requested ${bits} bits, got ${p.bit_len()}'
+	}
+}
+
+fn test_prime_is_prime() {
+	for bits in [16, 64, 128, 256] {
+		p := rand.prime(bits) or { panic(err) }
+		assert p.is_odd()
+		assert p.is_probably_prime(40), '${p} is not prime'
+	}
+}
+
+fn test_prime_second_highest_bit_is_set() {
+	// Guarantees that the product of two primes of the same size has exactly
+	// twice as many bits, which RSA modulus generation depends on.
+	for _ in 0 .. 5 {
+		p := rand.prime(64) or { panic(err) }
+		q := rand.prime(64) or { panic(err) }
+		assert (p * q).bit_len() == 128
+	}
+}
+
+fn test_prime_is_random() {
+	mut seen := map[string]bool{}
+	for _ in 0 .. 8 {
+		p := rand.prime(128) or { panic(err) }
+		seen[p.str()] = true
+	}
+	assert seen.len == 8, 'prime() returned duplicates'
+}
+
+fn test_prime_small_sizes() {
+	// Two bits leaves only 2 and 3.
+	for _ in 0 .. 10 {
+		p := rand.prime(2) or { panic(err) }
+		assert p == big.two_int || p == big.integer_from_int(3)
+	}
+	p3 := rand.prime(3) or { panic(err) }
+	assert p3 == big.integer_from_int(5) || p3 == big.integer_from_int(7)
+}
+
+fn test_prime_rejects_invalid_sizes() {
+	if _ := rand.prime(1) {
+		assert false, 'prime(1) should have failed'
+	}
+	if _ := rand.prime(0) {
+		assert false, 'prime(0) should have failed'
+	}
+	if _ := rand.prime(-8) {
+		assert false, 'prime(-8) should have failed'
+	}
+}
+
+fn test_safe_prime() {
+	p := rand.safe_prime(32) or { panic(err) }
+	assert p.bit_len() == 32
+	assert p.is_probably_prime(40)
+	q := (p - big.one_int).right_shift(1)
+	assert q.is_probably_prime(40), '(p - 1) / 2 is not prime'
+}
+
+fn test_safe_prime_rejects_invalid_sizes() {
+	if _ := rand.safe_prime(2) {
+		assert false, 'safe_prime(2) should have failed'
+	}
+}

--- a/vlib/crypto/rand/prime_test.v
+++ b/vlib/crypto/rand/prime_test.v
@@ -65,6 +65,12 @@ fn test_safe_prime() {
 	assert q.is_probably_prime(40), '(p - 1) / 2 is not prime'
 }
 
+fn test_safe_prime_small_sizes() {
+	assert rand.safe_prime(3)! == big.integer_from_int(7)
+	assert rand.safe_prime(4)! == big.integer_from_int(11)
+	assert rand.safe_prime(5)! == big.integer_from_int(23)
+}
+
 fn test_safe_prime_rejects_invalid_sizes() {
 	if _ := rand.safe_prime(2) {
 		assert false, 'safe_prime(2) should have failed'

--- a/vlib/crypto/rand/prime_test.v
+++ b/vlib/crypto/rand/prime_test.v
@@ -36,10 +36,10 @@ fn test_prime_is_random() {
 }
 
 fn test_prime_small_sizes() {
-	// Two bits leaves only 2 and 3.
+	// The top-two-bit and oddness guarantees select 3 at two bits.
 	for _ in 0 .. 10 {
 		p := rand.prime(2) or { panic(err) }
-		assert p == big.two_int || p == big.integer_from_int(3)
+		assert p == big.integer_from_int(3)
 	}
 	p3 := rand.prime(3) or { panic(err) }
 	assert p3 == big.integer_from_int(5) || p3 == big.integer_from_int(7)

--- a/vlib/crypto/rand/rand.v
+++ b/vlib/crypto/rand/rand.v
@@ -1,17 +1,9 @@
 // Copyright (c) 2019-2024 Alexander Medvednikov. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
-
 module rand
 
-struct ReadError {
-	Error
-}
-
-// msg returns the error message.
-pub fn (err ReadError) msg() string {
-	return 'crypto.rand.read() error reading random bytes'
-}
+import crypto.rand.internal
 
 // bytes returns an array of `bytes_needed` random bytes.
 // Note: this call can block your program for a long period of time,
@@ -20,11 +12,10 @@ pub fn (err ReadError) msg() string {
 // but instead pseudo random ones, from a pseudo random generator
 // that can be seeded, and that is usually faster.
 pub fn bytes(bytes_needed int) ![]u8 {
-	if bytes_needed < 0 {
-		return error('can not read < 0 random bytes')
-	}
+	return internal.bytes(bytes_needed)
+}
 
-	mut buffer := []u8{len: bytes_needed}
-	read(mut buffer)!
-	return buffer
+// read fills `buffer` with random bytes from the OS.
+pub fn read(mut buffer []u8) ! {
+	internal.read(mut buffer)!
 }

--- a/vlib/math/big/README.md
+++ b/vlib/math/big/README.md
@@ -11,6 +11,10 @@ round in addition to the fixed bases, so a composite has probability below `1 / 
 of being reported as probably prime. Passing zero or a negative round count selects the
 default of 40 rounds.
 
+Use `Integer.is_probably_prime_checked(rounds)` when an operating-system entropy failure
+must be distinguished from a composite result. The boolean form fails closed and returns
+`false` if entropy is unavailable.
+
 The result remains probabilistic for large values. Protocols that validate untrusted
 parameters may require additional checks.
 

--- a/vlib/math/big/README.md
+++ b/vlib/math/big/README.md
@@ -1,0 +1,27 @@
+# math.big
+
+The `math.big` module provides arbitrary-precision signed integers and arithmetic.
+
+## Primality testing
+
+`Integer.is_probably_prime(rounds)` combines trial division, Miller-Rabin, and a Lucas
+probable-prime test. For values below `3317044064679887385961981`, its fixed Miller-Rabin
+bases make the result deterministic. Above that bound, it performs every requested random
+round in addition to the fixed bases, so a composite has probability below `1 / 4^rounds`
+of being reported as probably prime. Passing zero or a negative round count selects the
+default of 40 rounds.
+
+The result remains probabilistic for large values. Protocols that validate untrusted
+parameters may require additional checks.
+
+```v
+import math.big
+
+fn main() {
+	n := big.integer_from_string('170141183460469231731687303715884105727')!
+	assert n.is_probably_prime(40)
+}
+```
+
+`big.jacobi(a, n)` returns the Jacobi symbol `-1`, `0`, or `1`. The modulus `n` must be
+positive and odd; invalid moduli cause a panic.

--- a/vlib/math/big/exponentiation.v
+++ b/vlib/math/big/exponentiation.v
@@ -40,6 +40,17 @@ fn (m Integer) montgomery() MontgomeryContext {
 // assumes a, x > 1 and m is odd
 @[direct_array_access]
 fn (a Integer) mont_odd(x Integer, m Integer) Integer {
+	return a.mont_odd_with_ctx(x, m, m.montgomery())
+}
+
+// mont_odd_with_ctx is `mont_odd` with a caller-supplied montgomery context.
+// Callers that exponentiate repeatedly modulo the same `m` (primality testing,
+// for instance) should build the context once and reuse it, since deriving it
+// costs a modular inverse.
+// -----
+// assumes a, x > 1, m is odd, and ctx was derived from m
+@[direct_array_access]
+fn (a Integer) mont_odd_with_ctx(x Integer, m Integer, ctx MontgomeryContext) Integer {
 	$if debug {
 		assert a > one_int && x > one_int
 		assert m.is_odd()
@@ -48,8 +59,6 @@ fn (a Integer) mont_odd(x Integer, m Integer) Integer {
 	window := get_window_size(u32(x.bit_len()))
 
 	mut table := []Integer{len: 1 << window}
-
-	ctx := m.montgomery()
 	aa := if a.signum < 0 || a.abs_cmp(m) >= 0 {
 		a % m
 	} else {
@@ -185,12 +194,15 @@ fn (a Integer) mont_even(x Integer, m Integer) Integer {
 	t1 := x1.mask_bits(m2n)
 	t2 := x2.mask_bits(m2n)
 
-	t := (if t2.abs_cmp(t1) >= 0 {
-		(t2 - t1).mask_bits(m2n)
-	} else {
-		// (x2 - x1) % m2 = 1 + ((~((x2 % m2) - (x1 % m2))) % m2)
-		(t1 - t2).abs().bitwise_not().mask_bits(m2n) + one_int
-	} * m1i).mask_bits(m2n)
+	t := (
+		if t2.abs_cmp(t1) >= 0 {
+			(t2 - t1).mask_bits(m2n)
+		} else {
+			// (x2 - x1) % m2 = 1 + ((~((x2 % m2) - (x1 % m2))) % m2)
+			(t1 - t2).abs().bitwise_not().mask_bits(m2n) + one_int
+		} * m1i
+	)
+	.mask_bits(m2n)
 
 	return x1 + m1 * t
 }

--- a/vlib/math/big/primality.v
+++ b/vlib/math/big/primality.v
@@ -82,8 +82,12 @@ fn (x Integer) miller_rabin(rounds int) bool {
 	// Hoisted out of the loop: deriving a context costs a modular inverse, and
 	// every round shares the same modulus.
 	ctx := x.montgomery()
+	// Only the random rounds need this, and only its value, so compute it once
+	// rather than once per call to random_base.
+	x_minus_three := x - integer_from_int(3)
 	for i in 0 .. rounds {
-		if !x.passes_miller_rabin_round(x.round_base(i), d, s, x_minus_one, ctx) {
+		base := x.round_base(i, x_minus_three)
+		if !x.passes_miller_rabin_round(base, d, s, x_minus_one, ctx) {
 			return false
 		}
 	}
@@ -92,11 +96,11 @@ fn (x Integer) miller_rabin(rounds int) bool {
 
 // round_base returns the base for round `i`: one of the fixed bases while they
 // last, a random one afterwards.
-fn (x Integer) round_base(i int) Integer {
+fn (x Integer) round_base(i int, x_minus_three Integer) Integer {
 	if i < deterministic_bases.len {
 		return integer_from_u64(deterministic_bases[i])
 	}
-	return random_base(x)
+	return random_base(x, x_minus_three)
 }
 
 // passes_miller_rabin_round reports whether the base `a` fails to witness that
@@ -119,10 +123,11 @@ fn (x Integer) passes_miller_rabin_round(a Integer, d Integer, s int, x_minus_on
 	return false
 }
 
-// random_base returns an integer in `[2, x - 2]`, used once the fixed bases
-// are exhausted.
+// random_base returns an integer in `[2, x - 2]`, used once the fixed bases are
+// exhausted. `x_minus_three` is `x - 3`, supplied by the caller so that it is
+// not rebuilt on every round.
 @[direct_array_access]
-fn random_base(x Integer) Integer {
+fn random_base(x Integer, x_minus_three Integer) Integer {
 	mut digits := []u64{len: x.digits.len}
 	for i in 0 .. digits.len {
 		digits[i] = rand.u64() & max_digit
@@ -140,7 +145,7 @@ fn random_base(x Integer) Integer {
 		digits: digits
 		signum: 1
 	}
-	return candidate % (x - integer_from_int(3)) + two_int
+	return candidate % x_minus_three + two_int
 }
 
 // split_odd writes `n` as `d * 2^s` with `d` odd, and returns `d` and `s`.

--- a/vlib/math/big/primality.v
+++ b/vlib/math/big/primality.v
@@ -39,7 +39,10 @@ pub fn (x Integer) is_probably_prime(rounds int) bool {
 	if ra % 3 == 0 || ra % 5 == 0 || ra % 7 == 0 || ra % 11 == 0 || ra % 13 == 0 || ra % 17 == 0 || ra % 19 == 0 || ra % 23 == 0 || ra % 37 == 0 || rb % 29 == 0 || rb % 31 == 0 || rb % 41 == 0 || rb % 43 == 0 || rb % 47 == 0 || rb % 53 == 0 {
 		return false
 	}
-	reps := if rounds <= 0 { 40 } else { rounds }
+	mut reps := rounds
+	if reps <= 0 {
+		reps = 40
+	}
 	return x.miller_rabin(reps) && x.lucas_probable_prime()
 }
 
@@ -85,16 +88,20 @@ fn (x Integer) miller_rabin(rounds int) bool {
 	// every round shares the same modulus.
 	ctx := x.montgomery()
 	for i in 0 .. rounds {
-		a := if i < deterministic_bases.len {
-			integer_from_u64(deterministic_bases[i])
-		} else {
-			random_base(x)
-		}
-		if !x.passes_miller_rabin_round(a, d, s, x_minus_one, ctx) {
+		if !x.passes_miller_rabin_round(x.round_base(i), d, s, x_minus_one, ctx) {
 			return false
 		}
 	}
 	return true
+}
+
+// round_base returns the base for round `i`: one of the fixed bases while they
+// last, a random one afterwards.
+fn (x Integer) round_base(i int) Integer {
+	if i < deterministic_bases.len {
+		return integer_from_u64(deterministic_bases[i])
+	}
+	return random_base(x)
 }
 
 // passes_miller_rabin_round reports whether the base `a` fails to witness that
@@ -201,12 +208,14 @@ fn (x Integer) lucas_probable_prime() bool {
 	mut vk1 := big_p // V(1) = P
 	for i := s.bit_len() - 1; i >= 0; i-- {
 		if s.get_bit(u32(i)) {
+			// k -> 2k + 1
 			vk = (vk * vk1 + x - big_p) % x
 			vk1 = (vk1 * vk1 + x_minus_two) % x
-		} else {
-			vk1 = (vk * vk1 + x - big_p) % x
-			vk = (vk * vk + x_minus_two) % x
+			continue
 		}
+		// k -> 2k
+		vk1 = (vk * vk1 + x - big_p) % x
+		vk = (vk * vk + x_minus_two) % x
 	}
 
 	// Accept on V(s) == +-2 with U(s) == 0. Crandall and Pomerance eq. 3.13

--- a/vlib/math/big/primality.v
+++ b/vlib/math/big/primality.v
@@ -78,12 +78,7 @@ fn (x Integer) mod_small(m u64) u64 {
 // a quarter of the bases fail to witness one.
 fn (x Integer) miller_rabin(rounds int) bool {
 	x_minus_one := x - one_int
-	mut d := x_minus_one
-	mut s := 0
-	for !d.is_odd() {
-		d = d.right_shift(1)
-		s++
-	}
+	d, s := split_odd(x_minus_one)
 	// Hoisted out of the loop: deriving a context costs a modular inverse, and
 	// every round shares the same modulus.
 	ctx := x.montgomery()
@@ -148,6 +143,28 @@ fn random_base(x Integer) Integer {
 	return candidate % (x - integer_from_int(3)) + two_int
 }
 
+// split_odd writes `n` as `d * 2^s` with `d` odd, and returns `d` and `s`.
+fn split_odd(n Integer) (Integer, int) {
+	mut d := n
+	mut s := 0
+	for !d.is_odd() {
+		d = d.right_shift(1)
+		s++
+	}
+	return d, s
+}
+
+// v_double returns `V(2k) == V(k)^2 - 2 (mod x)`, taking `x - 2` precomputed.
+fn v_double(v Integer, x Integer, x_minus_two Integer) Integer {
+	return (v * v + x_minus_two) % x
+}
+
+// v_next_odd returns `V(2k + 1) == V(k) V(k + 1) - P (mod x)`, taking `x - P`
+// precomputed.
+fn v_next_odd(v Integer, v1 Integer, x Integer, x_minus_p Integer) Integer {
+	return (v * v1 + x_minus_p) % x
+}
+
 // lucas_probable_prime runs the "almost extra strong" Lucas probable prime test
 // on the odd integer `x`, using Baillie-OEIS parameter selection (method C).
 // Together with a base-2 Miller-Rabin round this forms the Baillie-PSW test,
@@ -191,12 +208,7 @@ fn (x Integer) lucas_probable_prime() bool {
 
 	// x + 1 == s * 2^r with s odd; x + 1 rather than x - 1 because
 	// Jacobi(d / x) is -1 here.
-	mut s := x + one_int
-	mut r := 0
-	for !s.is_odd() {
-		s = s.right_shift(1)
-		r++
-	}
+	s, r := split_odd(x + one_int)
 
 	big_p := integer_from_u64(p)
 	x_minus_two := x - two_int
@@ -204,18 +216,19 @@ fn (x Integer) lucas_probable_prime() bool {
 	// Build V(s) by doubling the subscript from the top bit of s down:
 	//     V(2k)     = V(k)^2 - 2
 	//     V(2k + 1) = V(k) V(k + 1) - P
+	x_minus_p := x - big_p
 	mut vk := two_int // V(0) = 2
 	mut vk1 := big_p // V(1) = P
 	for i := s.bit_len() - 1; i >= 0; i-- {
 		if s.get_bit(u32(i)) {
 			// k -> 2k + 1
-			vk = (vk * vk1 + x - big_p) % x
-			vk1 = (vk1 * vk1 + x_minus_two) % x
+			vk = v_next_odd(vk, vk1, x, x_minus_p)
+			vk1 = v_double(vk1, x, x_minus_two)
 			continue
 		}
 		// k -> 2k
-		vk1 = (vk * vk1 + x - big_p) % x
-		vk = (vk * vk + x_minus_two) % x
+		vk1 = v_next_odd(vk, vk1, x, x_minus_p)
+		vk = v_double(vk, x, x_minus_two)
 	}
 
 	// Accept on V(s) == +-2 with U(s) == 0. Crandall and Pomerance eq. 3.13
@@ -238,7 +251,7 @@ fn (x Integer) lucas_probable_prime() bool {
 			// Fixed point of V -> V^2 - 2, so no later term can be zero.
 			return false
 		}
-		vk = (vk * vk + x_minus_two) % x
+		vk = v_double(vk, x, x_minus_two)
 	}
 	return false
 }
@@ -259,14 +272,14 @@ pub fn jacobi(a Integer, n Integer) int {
 		// Each factor of two contributes -1 when y is 3 or 5 mod 8.
 		for !x.is_odd() {
 			x = x.right_shift(1)
-			y_mod_8 := (y % integer_from_int(8)).int()
+			y_mod_8 := y.mod_small(8)
 			if y_mod_8 == 3 || y_mod_8 == 5 {
 				result = -result
 			}
 		}
 		// Quadratic reciprocity.
 		x, y = y, x
-		if (x % integer_from_int(4)).int() == 3 && (y % integer_from_int(4)).int() == 3 {
+		if x.mod_small(4) == 3 && y.mod_small(4) == 3 {
 			result = -result
 		}
 		x = x % y

--- a/vlib/math/big/primality.v
+++ b/vlib/math/big/primality.v
@@ -1,0 +1,303 @@
+module big
+
+import rand
+
+// Every prime below 64, used to answer small inputs exactly.
+const tiny_primes = [u64(2), 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61]!
+
+// Products of the odd primes below 60, split so that each factor stays inside
+// a 32 bit word. Trial division reduces `x` once per product instead of once
+// per prime.
+const primes_a = u64(3 * 5 * 7 * 11 * 13 * 17 * 19 * 23 * 37)
+const primes_b = u64(29 * 31 * 41 * 43 * 47 * 53)
+
+// The bases that make Miller-Rabin deterministic below
+// 3317044064679887385961981. Later rounds draw random bases instead: fixed
+// bases beyond this point add nothing against a crafted input.
+const deterministic_bases = [u64(2), 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41]!
+
+// is_probably_prime reports whether `x` is prime, with a probability of a
+// composite being misreported below `1 / 4^rounds`.
+//
+// The test is deterministic for `x` below 3317044064679887385961981, where a
+// fixed set of bases is provably sufficient, and probabilistic above it.
+// Passing `rounds <= 0` selects a sane default (40 rounds, the value used for
+// key generation in most cryptographic libraries).
+//
+// Note that a `true` result is a statement of probability, not certainty.
+// Do not use this to validate an attacker-supplied modulus without also
+// checking the surrounding protocol.
+pub fn (x Integer) is_probably_prime(rounds int) bool {
+	if x.signum <= 0 {
+		return false
+	}
+	if x.bit_len() <= 6 {
+		// Answer exactly from the table of primes below 64.
+		return u64(x.int()) in tiny_primes
+	}
+	if !x.is_odd() {
+		return false
+	}
+	// Trial division by the primes below 60. Rather than reducing `x` once per
+	// prime, reduce it once per product and finish with cheap word-sized
+	// modulos. `x` is larger than every prime involved, so a zero remainder
+	// always means composite.
+	ra := u32(x.mod_small(primes_a))
+	rb := u32(x.mod_small(primes_b))
+	if ra % 3 == 0 || ra % 5 == 0 || ra % 7 == 0 || ra % 11 == 0 || ra % 13 == 0 || ra % 17 == 0 || ra % 19 == 0 || ra % 23 == 0 || ra % 37 == 0 || rb % 29 == 0 || rb % 31 == 0 || rb % 41 == 0 || rb % 43 == 0 || rb % 47 == 0 || rb % 53 == 0 {
+		return false
+	}
+	reps := if rounds <= 0 { 40 } else { rounds }
+	return x.miller_rabin(reps) && x.lucas_probable_prime()
+}
+
+// mod_small returns `|x| mod m` for a modulus that fits in 32 bits.
+//
+// This walks the digit array directly instead of going through general
+// division, so it allocates nothing. Each 60-bit digit is processed in two
+// 30-bit halves so that every intermediate product stays below 2^64.
+@[direct_array_access]
+fn (x Integer) mod_small(m u64) u64 {
+	if m == 0 {
+		panic('math.big: division by zero')
+	}
+	if x.signum == 0 {
+		return 0
+	}
+	half_bits := digit_bits / 2
+	half_mask := (u64(1) << half_bits) - 1
+	// 2^30 mod m, the factor applied when shifting in the next half digit.
+	shift_mod := (u64(1) << half_bits) % m
+	mut r := u64(0)
+	for i := x.digits.len - 1; i >= 0; i-- {
+		digit := x.digits[i]
+		r = (r * shift_mod + (digit >> half_bits)) % m
+		r = (r * shift_mod + (digit & half_mask)) % m
+	}
+	return r
+}
+
+// miller_rabin runs `rounds` iterations of the Miller-Rabin probabilistic
+// primality test on `x`, which is required to be odd and greater than the
+// largest entry of `small_primes`.
+//
+// Write `x - 1` as `d * 2^s` with `d` odd. For a prime `x` and any base `a`
+// coprime to it, either `a^d == 1 (mod x)`, or `a^(d * 2^r) == -1 (mod x)` for
+// some `0 <= r < s`. A base that satisfies neither is a witness that `x` is
+// composite; at most a quarter of the bases can fail to witness a composite,
+// which is where the error bound comes from.
+//
+// The first rounds use the small prime bases, which makes the result
+// deterministic for `x < 3317044064679887385961981`.
+fn (x Integer) miller_rabin(rounds int) bool {
+	x_minus_one := x - one_int
+	mut d := x_minus_one
+	mut s := 0
+	for !d.is_odd() {
+		d = d.right_shift(1)
+		s++
+	}
+	// `x` is odd here, so every round can share one montgomery context.
+	// Deriving it costs a modular inverse, which is why it is hoisted out of
+	// the loop rather than recomputed by each `big_mod_pow` call.
+	ctx := x.montgomery()
+	for i in 0 .. rounds {
+		a := if i < deterministic_bases.len {
+			integer_from_u64(deterministic_bases[i])
+		} else {
+			random_base(x)
+		}
+		if !x.passes_miller_rabin_round(a, d, s, x_minus_one, ctx) {
+			return false
+		}
+	}
+	return true
+}
+
+// passes_miller_rabin_round reports whether the base `a` fails to witness that
+// `x` is composite, given the decomposition `x - 1 == d * 2^s` and a montgomery
+// context derived from `x`.
+fn (x Integer) passes_miller_rabin_round(a Integer, d Integer, s int, x_minus_one Integer, ctx MontgomeryContext) bool {
+	mut y := a.mont_odd_with_ctx(d, x, ctx)
+	if y == one_int || y == x_minus_one {
+		return true
+	}
+	for _ in 1 .. s {
+		y = (y * y) % x
+		if y == x_minus_one {
+			return true
+		}
+		if y == one_int {
+			// A non-trivial square root of 1 exists modulo `x`, so `x` is
+			// composite and no later squaring can rescue this base.
+			return false
+		}
+	}
+	return false
+}
+
+// random_base returns a uniformly distributed integer in `[2, x - 2]`, used as
+// a Miller-Rabin base once the fixed small-prime bases are exhausted.
+@[direct_array_access]
+fn random_base(x Integer) Integer {
+	// Build the candidate from the digit array directly: one `u64` of entropy
+	// per 60-bit digit, rather than a byte array that throws away most of
+	// every random word.
+	mut digits := []u64{len: x.digits.len}
+	for i in 0 .. digits.len {
+		digits[i] = rand.u64() & max_digit
+	}
+	// Trim leading zero digits, which the Integer invariants forbid.
+	mut n := digits.len
+	for n > 0 && digits[n - 1] == 0 {
+		n--
+	}
+	if n == 0 {
+		return two_int
+	}
+	digits.trim(n)
+	candidate := Integer{
+		digits: digits
+		signum: 1
+	}
+	// Map into [2, x - 2].
+	return candidate % (x - integer_from_int(3)) + two_int
+}
+
+// lucas_probable_prime runs the "almost extra strong" Lucas probable prime
+// test on `x`, using Baillie-OEIS parameter selection (method C).
+//
+// Combined with a base-2 Miller-Rabin round this forms the Baillie-PSW test.
+// No composite is known to pass it, despite decades of searching, and a prize
+// still stands for anyone who finds one.
+//
+// Method C searches for the smallest `p >= 3` with `Jacobi(p^2 - 4 / x) == -1`
+// and fixes `Q = 1`. Holding Q at 1 removes the running power of Q that the
+// general formulation has to carry, and only the V sequence is needed, so the
+// whole test reduces to repeated squaring with no modular halving.
+//
+// `x` must be odd and greater than 1.
+//
+// References:
+//   Baillie and Wagstaff, "Lucas Pseudoprimes", Math. Comp. 35(152), 1980.
+//   Grantham, "Frobenius Pseudoprimes", Math. Comp. 70(234), 2000, Thm 2.3.
+//   Baillie, "Extra strong Lucas pseudoprimes", OEIS A217719.
+fn (x Integer) lucas_probable_prime() bool {
+	// Find the smallest p >= 3 such that Jacobi(p^2 - 4 / x) == -1.
+	mut p := u64(3)
+	for {
+		d := integer_from_u64(p * p - 4)
+		j := jacobi(d, x)
+		if j == -1 {
+			break
+		}
+		if j == 0 {
+			// d = p^2 - 4 = (p - 2)(p + 2), and the search started at p - 2 == 1,
+			// so the shared factor has to be p + 2. That makes `x` prime only if
+			// `x` is p + 2 itself.
+			return x == integer_from_u64(p + 2)
+		}
+		if p == 40 {
+			// A perfect square has Jacobi(d / x) == 1 for every d coprime to it,
+			// so the search would never end. Non-squares are expected to succeed
+			// within a handful of attempts, which makes this the right moment to
+			// pay for one integer square root.
+			root := x.isqrt()
+			if root * root == x {
+				return false
+			}
+		}
+		if p > 10000 {
+			// Believed impossible for a non-square. Fail closed rather than spin.
+			return false
+		}
+		p++
+	}
+
+	// Arrange x + 1 == s * 2^r with s odd. The identity x + 1 is used rather
+	// than x - 1 because Jacobi(d / x) is -1 here.
+	mut s := x + one_int
+	mut r := 0
+	for !s.is_odd() {
+		s = s.right_shift(1)
+		r++
+	}
+
+	big_p := integer_from_u64(p)
+	x_minus_two := x - two_int
+
+	// Build V(s) by doubling the subscript from the top bit of s down, using
+	//     V(2k)     = V(k)^2 - 2
+	//     V(2k + 1) = V(k) V(k + 1) - P
+	// which follow from V(j + k) = V(j)V(k) - V(k - j) with Q == 1.
+	mut vk := two_int // V(0) = 2
+	mut vk1 := big_p // V(1) = P
+	for i := s.bit_len() - 1; i >= 0; i-- {
+		if s.get_bit(u32(i)) {
+			vk = (vk * vk1 + x - big_p) % x
+			vk1 = (vk1 * vk1 + x_minus_two) % x
+		} else {
+			vk1 = (vk * vk1 + x - big_p) % x
+			vk = (vk * vk + x_minus_two) % x
+		}
+	}
+
+	// V(s) == +-2 (mod x), together with U(s) == 0, is the first acceptance
+	// condition. U(s) is recovered without computing the U sequence at all:
+	// Crandall and Pomerance eq. 3.13 gives U(k) = D^-1 (2 V(k+1) - P V(k)),
+	// so U(s) == 0 exactly when P V(s) == 2 V(s+1) (mod x).
+	if vk == two_int || vk == x_minus_two {
+		lhs := (big_p * vk) % x
+		rhs := (vk1.left_shift(1)) % x
+		if lhs == rhs {
+			return true
+		}
+	}
+
+	// Otherwise accept if V(s * 2^t) == 0 (mod x) for some 0 <= t < r - 1.
+	for _ in 0 .. r - 1 {
+		if vk.signum == 0 {
+			return true
+		}
+		if vk == two_int {
+			// 2 is a fixed point of V -> V^2 - 2, so no later term can be zero.
+			return false
+		}
+		vk = (vk * vk + x_minus_two) % x
+	}
+	return false
+}
+
+// jacobi returns the Jacobi symbol `(a / n)`, which is +1, -1 or 0.
+// `n` must be positive and odd.
+pub fn jacobi(a Integer, n Integer) int {
+	if !n.is_odd() || n.signum <= 0 {
+		panic('math.big: jacobi requires a positive odd modulus')
+	}
+	mut x := a % n
+	if x.signum < 0 {
+		x = x + n
+	}
+	mut y := n
+	mut result := 1
+	for x.signum != 0 {
+		// Pull out factors of two, each contributing -1 when y is 3 or 5 mod 8.
+		for !x.is_odd() {
+			x = x.right_shift(1)
+			y_mod_8 := (y % integer_from_int(8)).int()
+			if y_mod_8 == 3 || y_mod_8 == 5 {
+				result = -result
+			}
+		}
+		// Quadratic reciprocity.
+		x, y = y, x
+		if (x % integer_from_int(4)).int() == 3 && (y % integer_from_int(4)).int() == 3 {
+			result = -result
+		}
+		x = x % y
+	}
+	if y == one_int {
+		return result
+	}
+	return 0
+}

--- a/vlib/math/big/primality.v
+++ b/vlib/math/big/primality.v
@@ -2,18 +2,14 @@ module big
 
 import rand
 
-// Every prime below 64, used to answer small inputs exactly.
+// Every prime below 64.
 const tiny_primes = [u64(2), 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61]!
 
-// Products of the odd primes below 60, split so that each factor stays inside
-// a 32 bit word. Trial division reduces `x` once per product instead of once
-// per prime.
+// The odd primes below 60, as two products that each fit in a 32 bit word.
 const primes_a = u64(3 * 5 * 7 * 11 * 13 * 17 * 19 * 23 * 37)
 const primes_b = u64(29 * 31 * 41 * 43 * 47 * 53)
 
-// The bases that make Miller-Rabin deterministic below
-// 3317044064679887385961981. Later rounds draw random bases instead: fixed
-// bases beyond this point add nothing against a crafted input.
+// Bases that make Miller-Rabin deterministic below 3317044064679887385961981.
 const deterministic_bases = [u64(2), 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41]!
 
 // is_probably_prime reports whether `x` is prime, with a probability of a
@@ -32,16 +28,12 @@ pub fn (x Integer) is_probably_prime(rounds int) bool {
 		return false
 	}
 	if x.bit_len() <= 6 {
-		// Answer exactly from the table of primes below 64.
 		return u64(x.int()) in tiny_primes
 	}
 	if !x.is_odd() {
 		return false
 	}
-	// Trial division by the primes below 60. Rather than reducing `x` once per
-	// prime, reduce it once per product and finish with cheap word-sized
-	// modulos. `x` is larger than every prime involved, so a zero remainder
-	// always means composite.
+	// Trial division, one reduction per product rather than one per prime.
 	ra := u32(x.mod_small(primes_a))
 	rb := u32(x.mod_small(primes_b))
 	if ra % 3 == 0 || ra % 5 == 0 || ra % 7 == 0 || ra % 11 == 0 || ra % 13 == 0 || ra % 17 == 0 || ra % 19 == 0 || ra % 23 == 0 || ra % 37 == 0 || rb % 29 == 0 || rb % 31 == 0 || rb % 41 == 0 || rb % 43 == 0 || rb % 47 == 0 || rb % 53 == 0 {
@@ -51,11 +43,9 @@ pub fn (x Integer) is_probably_prime(rounds int) bool {
 	return x.miller_rabin(reps) && x.lucas_probable_prime()
 }
 
-// mod_small returns `|x| mod m` for a modulus that fits in 32 bits.
-//
-// This walks the digit array directly instead of going through general
-// division, so it allocates nothing. Each 60-bit digit is processed in two
-// 30-bit halves so that every intermediate product stays below 2^64.
+// mod_small returns `|x| mod m` for a modulus that fits in 32 bits. It walks
+// the digit array directly and allocates nothing. Each 60-bit digit is taken in
+// two 30-bit halves so that every intermediate product stays below 2^64.
 @[direct_array_access]
 fn (x Integer) mod_small(m u64) u64 {
 	if m == 0 {
@@ -66,7 +56,6 @@ fn (x Integer) mod_small(m u64) u64 {
 	}
 	half_bits := digit_bits / 2
 	half_mask := (u64(1) << half_bits) - 1
-	// 2^30 mod m, the factor applied when shifting in the next half digit.
 	shift_mod := (u64(1) << half_bits) % m
 	mut r := u64(0)
 	for i := x.digits.len - 1; i >= 0; i-- {
@@ -77,18 +66,13 @@ fn (x Integer) mod_small(m u64) u64 {
 	return r
 }
 
-// miller_rabin runs `rounds` iterations of the Miller-Rabin probabilistic
-// primality test on `x`, which is required to be odd and greater than the
-// largest entry of `small_primes`.
+// miller_rabin runs `rounds` rounds of the Miller-Rabin test on the odd
+// integer `x`.
 //
-// Write `x - 1` as `d * 2^s` with `d` odd. For a prime `x` and any base `a`
-// coprime to it, either `a^d == 1 (mod x)`, or `a^(d * 2^r) == -1 (mod x)` for
-// some `0 <= r < s`. A base that satisfies neither is a witness that `x` is
-// composite; at most a quarter of the bases can fail to witness a composite,
-// which is where the error bound comes from.
-//
-// The first rounds use the small prime bases, which makes the result
-// deterministic for `x < 3317044064679887385961981`.
+// Writing `x - 1` as `d * 2^s`, a prime `x` satisfies `a^d == 1 (mod x)` or
+// `a^(d * 2^r) == -1 (mod x)` for some `0 <= r < s`, for every base `a` coprime
+// to it. A base satisfying neither witnesses that `x` is composite, and at most
+// a quarter of the bases fail to witness one.
 fn (x Integer) miller_rabin(rounds int) bool {
 	x_minus_one := x - one_int
 	mut d := x_minus_one
@@ -97,9 +81,8 @@ fn (x Integer) miller_rabin(rounds int) bool {
 		d = d.right_shift(1)
 		s++
 	}
-	// `x` is odd here, so every round can share one montgomery context.
-	// Deriving it costs a modular inverse, which is why it is hoisted out of
-	// the loop rather than recomputed by each `big_mod_pow` call.
+	// Hoisted out of the loop: deriving a context costs a modular inverse, and
+	// every round shares the same modulus.
 	ctx := x.montgomery()
 	for i in 0 .. rounds {
 		a := if i < deterministic_bases.len {
@@ -115,8 +98,7 @@ fn (x Integer) miller_rabin(rounds int) bool {
 }
 
 // passes_miller_rabin_round reports whether the base `a` fails to witness that
-// `x` is composite, given the decomposition `x - 1 == d * 2^s` and a montgomery
-// context derived from `x`.
+// `x` is composite, given `x - 1 == d * 2^s` and a context derived from `x`.
 fn (x Integer) passes_miller_rabin_round(a Integer, d Integer, s int, x_minus_one Integer, ctx MontgomeryContext) bool {
 	mut y := a.mont_odd_with_ctx(d, x, ctx)
 	if y == one_int || y == x_minus_one {
@@ -128,26 +110,22 @@ fn (x Integer) passes_miller_rabin_round(a Integer, d Integer, s int, x_minus_on
 			return true
 		}
 		if y == one_int {
-			// A non-trivial square root of 1 exists modulo `x`, so `x` is
-			// composite and no later squaring can rescue this base.
+			// A non-trivial square root of 1 modulo `x`, so `x` is composite.
 			return false
 		}
 	}
 	return false
 }
 
-// random_base returns a uniformly distributed integer in `[2, x - 2]`, used as
-// a Miller-Rabin base once the fixed small-prime bases are exhausted.
+// random_base returns an integer in `[2, x - 2]`, used once the fixed bases
+// are exhausted.
 @[direct_array_access]
 fn random_base(x Integer) Integer {
-	// Build the candidate from the digit array directly: one `u64` of entropy
-	// per 60-bit digit, rather than a byte array that throws away most of
-	// every random word.
 	mut digits := []u64{len: x.digits.len}
 	for i in 0 .. digits.len {
 		digits[i] = rand.u64() & max_digit
 	}
-	// Trim leading zero digits, which the Integer invariants forbid.
+	// Integer invariants forbid leading zero digits.
 	mut n := digits.len
 	for n > 0 && digits[n - 1] == 0 {
 		n--
@@ -160,23 +138,17 @@ fn random_base(x Integer) Integer {
 		digits: digits
 		signum: 1
 	}
-	// Map into [2, x - 2].
 	return candidate % (x - integer_from_int(3)) + two_int
 }
 
-// lucas_probable_prime runs the "almost extra strong" Lucas probable prime
-// test on `x`, using Baillie-OEIS parameter selection (method C).
+// lucas_probable_prime runs the "almost extra strong" Lucas probable prime test
+// on the odd integer `x`, using Baillie-OEIS parameter selection (method C).
+// Together with a base-2 Miller-Rabin round this forms the Baillie-PSW test,
+// which no known composite passes.
 //
-// Combined with a base-2 Miller-Rabin round this forms the Baillie-PSW test.
-// No composite is known to pass it, despite decades of searching, and a prize
-// still stands for anyone who finds one.
-//
-// Method C searches for the smallest `p >= 3` with `Jacobi(p^2 - 4 / x) == -1`
-// and fixes `Q = 1`. Holding Q at 1 removes the running power of Q that the
-// general formulation has to carry, and only the V sequence is needed, so the
-// whole test reduces to repeated squaring with no modular halving.
-//
-// `x` must be odd and greater than 1.
+// Method C takes the smallest `p >= 3` with `Jacobi(p^2 - 4 / x) == -1` and
+// fixes `Q = 1`, which drops the running power of Q and leaves only the V
+// sequence, so the test reduces to repeated squaring with no modular halving.
 //
 // References:
 //   Baillie and Wagstaff, "Lucas Pseudoprimes", Math. Comp. 35(152), 1980.
@@ -192,30 +164,26 @@ fn (x Integer) lucas_probable_prime() bool {
 			break
 		}
 		if j == 0 {
-			// d = p^2 - 4 = (p - 2)(p + 2), and the search started at p - 2 == 1,
-			// so the shared factor has to be p + 2. That makes `x` prime only if
-			// `x` is p + 2 itself.
+			// d = (p - 2)(p + 2) and the search began at p - 2 == 1, so the shared
+			// factor is p + 2, and `x` is prime only if it is p + 2 itself.
 			return x == integer_from_u64(p + 2)
 		}
 		if p == 40 {
-			// A perfect square has Jacobi(d / x) == 1 for every d coprime to it,
-			// so the search would never end. Non-squares are expected to succeed
-			// within a handful of attempts, which makes this the right moment to
-			// pay for one integer square root.
+			// A square has Jacobi(d / x) == 1 for every coprime d, so the search
+			// would never end. Non-squares succeed within a few attempts.
 			root := x.isqrt()
 			if root * root == x {
 				return false
 			}
 		}
 		if p > 10000 {
-			// Believed impossible for a non-square. Fail closed rather than spin.
 			return false
 		}
 		p++
 	}
 
-	// Arrange x + 1 == s * 2^r with s odd. The identity x + 1 is used rather
-	// than x - 1 because Jacobi(d / x) is -1 here.
+	// x + 1 == s * 2^r with s odd; x + 1 rather than x - 1 because
+	// Jacobi(d / x) is -1 here.
 	mut s := x + one_int
 	mut r := 0
 	for !s.is_odd() {
@@ -226,10 +194,9 @@ fn (x Integer) lucas_probable_prime() bool {
 	big_p := integer_from_u64(p)
 	x_minus_two := x - two_int
 
-	// Build V(s) by doubling the subscript from the top bit of s down, using
+	// Build V(s) by doubling the subscript from the top bit of s down:
 	//     V(2k)     = V(k)^2 - 2
 	//     V(2k + 1) = V(k) V(k + 1) - P
-	// which follow from V(j + k) = V(j)V(k) - V(k - j) with Q == 1.
 	mut vk := two_int // V(0) = 2
 	mut vk1 := big_p // V(1) = P
 	for i := s.bit_len() - 1; i >= 0; i-- {
@@ -242,10 +209,9 @@ fn (x Integer) lucas_probable_prime() bool {
 		}
 	}
 
-	// V(s) == +-2 (mod x), together with U(s) == 0, is the first acceptance
-	// condition. U(s) is recovered without computing the U sequence at all:
-	// Crandall and Pomerance eq. 3.13 gives U(k) = D^-1 (2 V(k+1) - P V(k)),
-	// so U(s) == 0 exactly when P V(s) == 2 V(s+1) (mod x).
+	// Accept on V(s) == +-2 with U(s) == 0. Crandall and Pomerance eq. 3.13
+	// gives U(k) = D^-1 (2 V(k+1) - P V(k)), so U(s) == 0 exactly when
+	// P V(s) == 2 V(s+1) (mod x), and the U sequence is never needed.
 	if vk == two_int || vk == x_minus_two {
 		lhs := (big_p * vk) % x
 		rhs := (vk1.left_shift(1)) % x
@@ -260,7 +226,7 @@ fn (x Integer) lucas_probable_prime() bool {
 			return true
 		}
 		if vk == two_int {
-			// 2 is a fixed point of V -> V^2 - 2, so no later term can be zero.
+			// Fixed point of V -> V^2 - 2, so no later term can be zero.
 			return false
 		}
 		vk = (vk * vk + x_minus_two) % x
@@ -281,7 +247,7 @@ pub fn jacobi(a Integer, n Integer) int {
 	mut y := n
 	mut result := 1
 	for x.signum != 0 {
-		// Pull out factors of two, each contributing -1 when y is 3 or 5 mod 8.
+		// Each factor of two contributes -1 when y is 3 or 5 mod 8.
 		for !x.is_odd() {
 			x = x.right_shift(1)
 			y_mod_8 := (y % integer_from_int(8)).int()

--- a/vlib/math/big/primality.v
+++ b/vlib/math/big/primality.v
@@ -12,6 +12,12 @@ const primes_b = u64(29 * 31 * 41 * 43 * 47 * 53)
 // Bases that make Miller-Rabin deterministic below 3317044064679887385961981.
 const deterministic_bases = [u64(2), 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41]!
 
+const deterministic_limit = Integer{
+	digits: [u64(120970133908792829), 2877077]
+	signum: 1
+	is_const: true
+}
+
 // is_probably_prime reports whether `x` is prime, with a probability of a
 // composite being misreported below `1 / 4^rounds`.
 //
@@ -82,11 +88,19 @@ fn (x Integer) miller_rabin(rounds int) bool {
 	// Hoisted out of the loop: deriving a context costs a modular inverse, and
 	// every round shares the same modulus.
 	ctx := x.montgomery()
-	// Only the random rounds need this, and only its value, so compute it once
-	// rather than once per call to random_base.
 	x_minus_three := x - integer_from_int(3)
-	for i in 0 .. rounds {
-		base := x.round_base(i, x_minus_three)
+	for base in deterministic_bases {
+		if !x.passes_miller_rabin_round(integer_from_u64(base), d, s, x_minus_one, ctx) {
+			return false
+		}
+	}
+	if x.abs_cmp(deterministic_limit) < 0 {
+		return true
+	}
+	// Above the deterministic range, fixed bases are only a prelude. Perform
+	// every requested random round so the documented 1 / 4^rounds bound holds.
+	for _ in 0 .. rounds {
+		base := random_base(x, x_minus_three)
 		if !x.passes_miller_rabin_round(base, d, s, x_minus_one, ctx) {
 			return false
 		}
@@ -94,19 +108,10 @@ fn (x Integer) miller_rabin(rounds int) bool {
 	return true
 }
 
-// round_base returns the base for round `i`: one of the fixed bases while they
-// last, a random one afterwards.
-fn (x Integer) round_base(i int, x_minus_three Integer) Integer {
-	if i < deterministic_bases.len {
-		return integer_from_u64(deterministic_bases[i])
-	}
-	return random_base(x, x_minus_three)
-}
-
 // passes_miller_rabin_round reports whether the base `a` fails to witness that
 // `x` is composite, given `x - 1 == d * 2^s` and a context derived from `x`.
 fn (x Integer) passes_miller_rabin_round(a Integer, d Integer, s int, x_minus_one Integer, ctx MontgomeryContext) bool {
-	mut y := a.mont_odd_with_ctx(d, x, ctx)
+	mut y := if d == one_int { a % x } else { a.mont_odd_with_ctx(d, x, ctx) }
 	if y == one_int || y == x_minus_one {
 		return true
 	}
@@ -206,7 +211,9 @@ fn (x Integer) lucas_probable_prime() bool {
 			}
 		}
 		if p > 10000 {
-			return false
+			// Miller-Rabin already accepted `x`. Parameter-search exhaustion is
+			// inconclusive, not evidence of compositeness, so preserve that result.
+			return true
 		}
 		p++
 	}

--- a/vlib/math/big/primality.v
+++ b/vlib/math/big/primality.v
@@ -1,6 +1,6 @@
 module big
 
-import rand
+import crypto.rand.internal
 
 // Every prime below 64.
 const tiny_primes = [u64(2), 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61]!
@@ -133,27 +133,15 @@ fn (x Integer) passes_miller_rabin_round(a Integer, d Integer, s int, x_minus_on
 // not rebuilt on every round.
 @[direct_array_access]
 fn random_base(x_minus_three Integer) Integer {
-	top_bits := x_minus_three.bit_len() - (x_minus_three.digits.len - 1) * digit_bits
-	top_mask := (u64(1) << top_bits) - 1
+	bit_len := x_minus_three.bit_len()
+	byte_len := (bit_len + 7) / 8
+	top_mask := u8(0xff >> (byte_len * 8 - bit_len))
 	for {
-		mut digits := []u64{len: x_minus_three.digits.len}
-		for i in 0 .. digits.len {
-			digits[i] = rand.u64() & max_digit
+		mut bytes := internal.bytes(byte_len) or {
+			panic('math.big: failed to read random Miller-Rabin witness: ${err}')
 		}
-		digits[digits.len - 1] &= top_mask
-		// Integer invariants forbid leading zero digits.
-		mut n := digits.len
-		for n > 0 && digits[n - 1] == 0 {
-			n--
-		}
-		if n == 0 {
-			return two_int
-		}
-		digits.trim(n)
-		candidate := Integer{
-			digits: digits
-			signum: 1
-		}
+		bytes[0] &= top_mask
+		candidate := integer_from_bytes(bytes)
 		if candidate.abs_cmp(x_minus_three) < 0 {
 			return candidate + two_int
 		}

--- a/vlib/math/big/primality.v
+++ b/vlib/math/big/primality.v
@@ -100,7 +100,7 @@ fn (x Integer) miller_rabin(rounds int) bool {
 	// Above the deterministic range, fixed bases are only a prelude. Perform
 	// every requested random round so the documented 1 / 4^rounds bound holds.
 	for _ in 0 .. rounds {
-		base := random_base(x, x_minus_three)
+		base := random_base(x_minus_three)
 		if !x.passes_miller_rabin_round(base, d, s, x_minus_one, ctx) {
 			return false
 		}
@@ -132,25 +132,33 @@ fn (x Integer) passes_miller_rabin_round(a Integer, d Integer, s int, x_minus_on
 // exhausted. `x_minus_three` is `x - 3`, supplied by the caller so that it is
 // not rebuilt on every round.
 @[direct_array_access]
-fn random_base(x Integer, x_minus_three Integer) Integer {
-	mut digits := []u64{len: x.digits.len}
-	for i in 0 .. digits.len {
-		digits[i] = rand.u64() & max_digit
+fn random_base(x_minus_three Integer) Integer {
+	top_bits := x_minus_three.bit_len() - (x_minus_three.digits.len - 1) * digit_bits
+	top_mask := (u64(1) << top_bits) - 1
+	for {
+		mut digits := []u64{len: x_minus_three.digits.len}
+		for i in 0 .. digits.len {
+			digits[i] = rand.u64() & max_digit
+		}
+		digits[digits.len - 1] &= top_mask
+		// Integer invariants forbid leading zero digits.
+		mut n := digits.len
+		for n > 0 && digits[n - 1] == 0 {
+			n--
+		}
+		if n == 0 {
+			return two_int
+		}
+		digits.trim(n)
+		candidate := Integer{
+			digits: digits
+			signum: 1
+		}
+		if candidate.abs_cmp(x_minus_three) < 0 {
+			return candidate + two_int
+		}
 	}
-	// Integer invariants forbid leading zero digits.
-	mut n := digits.len
-	for n > 0 && digits[n - 1] == 0 {
-		n--
-	}
-	if n == 0 {
-		return two_int
-	}
-	digits.trim(n)
-	candidate := Integer{
-		digits: digits
-		signum: 1
-	}
-	return candidate % x_minus_three + two_int
+	return two_int
 }
 
 // split_odd writes `n` as `d * 2^s` with `d` odd, and returns `d` and `s`.

--- a/vlib/math/big/primality.v
+++ b/vlib/math/big/primality.v
@@ -29,7 +29,16 @@ const deterministic_limit = Integer{
 // Note that a `true` result is a statement of probability, not certainty.
 // Do not use this to validate an attacker-supplied modulus without also
 // checking the surrounding protocol.
+// If the system entropy source fails, this form fails closed with `false`;
+// use `is_probably_prime_checked` when the caller must distinguish that error.
 pub fn (x Integer) is_probably_prime(rounds int) bool {
+	return x.is_probably_prime_checked(rounds) or { false }
+}
+
+// is_probably_prime_checked is the fallible form of `is_probably_prime`. It
+// returns an error if the operating system cannot provide entropy for random
+// Miller-Rabin witnesses. Values inside the deterministic range need no entropy.
+pub fn (x Integer) is_probably_prime_checked(rounds int) !bool {
 	if x.signum <= 0 {
 		return false
 	}
@@ -49,7 +58,10 @@ pub fn (x Integer) is_probably_prime(rounds int) bool {
 	if reps <= 0 {
 		reps = 40
 	}
-	return x.miller_rabin(reps) && x.lucas_probable_prime()
+	if !x.miller_rabin(reps)! {
+		return false
+	}
+	return x.lucas_probable_prime()
 }
 
 // mod_small returns `|x| mod m` for a modulus that fits in 32 bits. It walks
@@ -82,7 +94,7 @@ fn (x Integer) mod_small(m u64) u64 {
 // `a^(d * 2^r) == -1 (mod x)` for some `0 <= r < s`, for every base `a` coprime
 // to it. A base satisfying neither witnesses that `x` is composite, and at most
 // a quarter of the bases fail to witness one.
-fn (x Integer) miller_rabin(rounds int) bool {
+fn (x Integer) miller_rabin(rounds int) !bool {
 	x_minus_one := x - one_int
 	d, s := split_odd(x_minus_one)
 	// Hoisted out of the loop: deriving a context costs a modular inverse, and
@@ -100,7 +112,7 @@ fn (x Integer) miller_rabin(rounds int) bool {
 	// Above the deterministic range, fixed bases are only a prelude. Perform
 	// every requested random round so the documented 1 / 4^rounds bound holds.
 	for _ in 0 .. rounds {
-		base := random_base(x_minus_three)
+		base := random_base(x_minus_three)!
 		if !x.passes_miller_rabin_round(base, d, s, x_minus_one, ctx) {
 			return false
 		}
@@ -132,21 +144,19 @@ fn (x Integer) passes_miller_rabin_round(a Integer, d Integer, s int, x_minus_on
 // exhausted. `x_minus_three` is `x - 3`, supplied by the caller so that it is
 // not rebuilt on every round.
 @[direct_array_access]
-fn random_base(x_minus_three Integer) Integer {
+fn random_base(x_minus_three Integer) !Integer {
 	bit_len := x_minus_three.bit_len()
 	byte_len := (bit_len + 7) / 8
 	top_mask := u8(0xff >> (byte_len * 8 - bit_len))
 	for {
-		mut bytes := internal.bytes(byte_len) or {
-			panic('math.big: failed to read random Miller-Rabin witness: ${err}')
-		}
+		mut bytes := internal.bytes(byte_len)!
 		bytes[0] &= top_mask
 		candidate := integer_from_bytes(bytes)
 		if candidate.abs_cmp(x_minus_three) < 0 {
 			return candidate + two_int
 		}
 	}
-	return two_int
+	return error('math.big: unreachable random witness state')
 }
 
 // split_odd writes `n` as `d * 2^s` with `d` odd, and returns `d` and `s`.

--- a/vlib/math/big/primality_test.v
+++ b/vlib/math/big/primality_test.v
@@ -35,66 +35,50 @@ fn test_carmichael_numbers() {
 fn test_strong_pseudoprimes() {
 	// Composites that survive Miller-Rabin against the first few prime bases.
 	// These are the values that make a fixed-base-only implementation wrong.
-	assert !parse('2047').is_probably_prime(20) // spsp base 2
-	
-
-	assert !parse('1373653').is_probably_prime(20) // spsp bases 2, 3
-	
-
-	assert !parse('25326001').is_probably_prime(20) // spsp bases 2, 3, 5
-	
-
-	assert !parse('3215031751').is_probably_prime(20) // spsp bases 2, 3, 5, 7
-	
-
-	assert !parse('2152302898747').is_probably_prime(20) // spsp first 5 primes
-	
-
-	assert !parse('3474749660383').is_probably_prime(20) // spsp first 6 primes
-	
-
-	assert !parse('341550071728321').is_probably_prime(20) // spsp first 7 primes
-	
-
-	assert !parse('3825123056546413051').is_probably_prime(20) // spsp first 9 primes
-	
-
-	assert !parse('318665857834031151167461').is_probably_prime(20) // spsp first 12 primes
-	
-
-	assert !parse('3317044064679887385961981').is_probably_prime(20) // spsp first 13 primes
-	
+	// spsp base 2
+	assert !parse('2047').is_probably_prime(20)
+	// spsp bases 2, 3
+	assert !parse('1373653').is_probably_prime(20)
+	// spsp bases 2, 3, 5
+	assert !parse('25326001').is_probably_prime(20)
+	// spsp bases 2, 3, 5, 7
+	assert !parse('3215031751').is_probably_prime(20)
+	// spsp first 5 primes
+	assert !parse('2152302898747').is_probably_prime(20)
+	// spsp first 6 primes
+	assert !parse('3474749660383').is_probably_prime(20)
+	// spsp first 7 primes
+	assert !parse('341550071728321').is_probably_prime(20)
+	// spsp first 9 primes
+	assert !parse('3825123056546413051').is_probably_prime(20)
+	// spsp first 12 primes
+	assert !parse('318665857834031151167461').is_probably_prime(20)
+	// spsp first 13 primes
+	assert !parse('3317044064679887385961981').is_probably_prime(20)
 }
 
 fn test_mersenne_primes() {
-	assert parse('2147483647').is_probably_prime(20) // 2^31 - 1
-	
-
-	assert parse('2305843009213693951').is_probably_prime(20) // 2^61 - 1
-	
-
-	assert parse('618970019642690137449562111').is_probably_prime(20) // 2^89 - 1
-	
-
-	assert parse('162259276829213363391578010288127').is_probably_prime(20) // 2^107 - 1
-	
-
-	assert parse('170141183460469231731687303715884105727').is_probably_prime(20) // 2^127 - 1
-	
+	// 2^31 - 1
+	assert parse('2147483647').is_probably_prime(20)
+	// 2^61 - 1
+	assert parse('2305843009213693951').is_probably_prime(20)
+	// 2^89 - 1
+	assert parse('618970019642690137449562111').is_probably_prime(20)
+	// 2^107 - 1
+	assert parse('162259276829213363391578010288127').is_probably_prime(20)
+	// 2^127 - 1
+	assert parse('170141183460469231731687303715884105727').is_probably_prime(20)
 }
 
 fn test_mersenne_composites() {
-	assert !parse('2047').is_probably_prime(20) // 2^11 - 1
-	
-
-	assert !parse('8388607').is_probably_prime(20) // 2^23 - 1
-	
-
-	assert !parse('536870911').is_probably_prime(20) // 2^29 - 1
-	
-
-	assert !parse('137438953471').is_probably_prime(20) // 2^37 - 1
-	
+	// 2^11 - 1
+	assert !parse('2047').is_probably_prime(20)
+	// 2^23 - 1
+	assert !parse('8388607').is_probably_prime(20)
+	// 2^29 - 1
+	assert !parse('536870911').is_probably_prime(20)
+	// 2^37 - 1
+	assert !parse('137438953471').is_probably_prime(20)
 }
 
 fn test_perfect_squares() {
@@ -139,8 +123,8 @@ fn test_jacobi() {
 	assert big.jacobi(big.integer_from_int(1001), big.integer_from_int(9907)) == -1
 	assert big.jacobi(big.integer_from_int(19), big.integer_from_int(45)) == 1
 	assert big.jacobi(big.integer_from_int(8), big.integer_from_int(21)) == -1
-	assert big.jacobi(big.integer_from_int(5), big.integer_from_int(21)) == 1
 	// Negative arguments are reduced modulo n first.
+	assert big.jacobi(big.integer_from_int(5), big.integer_from_int(21)) == 1
 	assert big.jacobi(big.integer_from_int(-1), big.integer_from_int(3)) == -1
 	assert big.jacobi(big.integer_from_int(-1), big.integer_from_int(5)) == 1
 }

--- a/vlib/math/big/primality_test.v
+++ b/vlib/math/big/primality_test.v
@@ -1,0 +1,146 @@
+import math.big
+
+fn parse(s string) big.Integer {
+	return big.integer_from_string(s) or { panic('cannot parse ${s}') }
+}
+
+fn test_small_numbers() {
+	primes := [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61]
+	for p in primes {
+		assert big.integer_from_int(p).is_probably_prime(20), '${p} should be prime'
+	}
+	composites := [0, 1, 4, 6, 8, 9, 10, 12, 15, 21, 25, 27, 33, 35, 39, 49, 51, 55, 57]
+	for c in composites {
+		assert !big.integer_from_int(c).is_probably_prime(20), '${c} should be composite'
+	}
+}
+
+fn test_negative_and_zero() {
+	assert !big.integer_from_int(0).is_probably_prime(20)
+	assert !big.integer_from_int(-2).is_probably_prime(20)
+	assert !big.integer_from_int(-7).is_probably_prime(20)
+	assert !big.integer_from_int(-561).is_probably_prime(20)
+}
+
+fn test_carmichael_numbers() {
+	// Absolute pseudoprimes: composite, yet pass the Fermat test for every
+	// base coprime to them. A naive Fermat test reports these as prime.
+	carmichael := ['561', '1105', '1729', '2465', '2821', '6601', '8911', '10585', '15841', '29341',
+		'41041', '62745', '63973', '75361', '101101', '340561', '825265']
+	for c in carmichael {
+		assert !parse(c).is_probably_prime(20), '${c} is a Carmichael number'
+	}
+}
+
+fn test_strong_pseudoprimes() {
+	// Composites that survive Miller-Rabin against the first few prime bases.
+	// These are the values that make a fixed-base-only implementation wrong.
+	assert !parse('2047').is_probably_prime(20) // spsp base 2
+	
+
+	assert !parse('1373653').is_probably_prime(20) // spsp bases 2, 3
+	
+
+	assert !parse('25326001').is_probably_prime(20) // spsp bases 2, 3, 5
+	
+
+	assert !parse('3215031751').is_probably_prime(20) // spsp bases 2, 3, 5, 7
+	
+
+	assert !parse('2152302898747').is_probably_prime(20) // spsp first 5 primes
+	
+
+	assert !parse('3474749660383').is_probably_prime(20) // spsp first 6 primes
+	
+
+	assert !parse('341550071728321').is_probably_prime(20) // spsp first 7 primes
+	
+
+	assert !parse('3825123056546413051').is_probably_prime(20) // spsp first 9 primes
+	
+
+	assert !parse('318665857834031151167461').is_probably_prime(20) // spsp first 12 primes
+	
+
+	assert !parse('3317044064679887385961981').is_probably_prime(20) // spsp first 13 primes
+	
+}
+
+fn test_mersenne_primes() {
+	assert parse('2147483647').is_probably_prime(20) // 2^31 - 1
+	
+
+	assert parse('2305843009213693951').is_probably_prime(20) // 2^61 - 1
+	
+
+	assert parse('618970019642690137449562111').is_probably_prime(20) // 2^89 - 1
+	
+
+	assert parse('162259276829213363391578010288127').is_probably_prime(20) // 2^107 - 1
+	
+
+	assert parse('170141183460469231731687303715884105727').is_probably_prime(20) // 2^127 - 1
+	
+}
+
+fn test_mersenne_composites() {
+	assert !parse('2047').is_probably_prime(20) // 2^11 - 1
+	
+
+	assert !parse('8388607').is_probably_prime(20) // 2^23 - 1
+	
+
+	assert !parse('536870911').is_probably_prime(20) // 2^29 - 1
+	
+
+	assert !parse('137438953471').is_probably_prime(20) // 2^37 - 1
+	
+}
+
+fn test_perfect_squares() {
+	// A perfect square admits no D with Jacobi(D / n) == -1, so the Lucas
+	// step has to terminate on its own rather than search forever.
+	for n in [u64(1000003), 1000033, 32416190071] {
+		x := big.integer_from_u64(n)
+		assert !(x * x).is_probably_prime(20)
+	}
+}
+
+fn test_large_primes() {
+	// Verified against an independent Miller-Rabin implementation.
+	assert parse('108088063435698740984721578578639788695211488257777317159208121754987034915181').is_probably_prime(40)
+	assert parse('13072341731781637478543110202182709643196526891726746125798087730494475533760525940644433783483689624697551241382508919700393467667516668276328127648845601').is_probably_prime(40)
+}
+
+fn test_large_composite() {
+	assert !parse('52289366927126549914172440808730838572786107566906984503192350921977902135042103762577735133934758498790204965530035678801573870670066673105312510595382406').is_probably_prime(40)
+}
+
+fn test_semiprime() {
+	// The RSA-style case: a product of two large primes must be rejected.
+	p := parse('108088063435698740984721578578639788695211488257777317159208121754987034915181')
+	q := parse('2305843009213693951')
+	assert !(p * q).is_probably_prime(40)
+}
+
+fn test_default_rounds() {
+	// rounds <= 0 selects the default instead of skipping the test.
+	assert parse('170141183460469231731687303715884105727').is_probably_prime(0)
+	assert !parse('3317044064679887385961981').is_probably_prime(-1)
+}
+
+fn test_jacobi() {
+	// Reference values for (a / n).
+	assert big.jacobi(big.integer_from_int(1), big.integer_from_int(1)) == 1
+	assert big.jacobi(big.integer_from_int(0), big.integer_from_int(1)) == 1
+	assert big.jacobi(big.integer_from_int(2), big.integer_from_int(3)) == -1
+	assert big.jacobi(big.integer_from_int(4), big.integer_from_int(3)) == 1
+	assert big.jacobi(big.integer_from_int(3), big.integer_from_int(9)) == 0
+	assert big.jacobi(big.integer_from_int(1001), big.integer_from_int(9907)) == -1
+	assert big.jacobi(big.integer_from_int(19), big.integer_from_int(45)) == 1
+	assert big.jacobi(big.integer_from_int(8), big.integer_from_int(21)) == -1
+	assert big.jacobi(big.integer_from_int(5), big.integer_from_int(21)) == 1
+	// Negative arguments are reduced modulo n first.
+	assert big.jacobi(big.integer_from_int(-1), big.integer_from_int(3)) == -1
+	assert big.jacobi(big.integer_from_int(-1), big.integer_from_int(5)) == 1
+}

--- a/vlib/math/big/primality_test.v
+++ b/vlib/math/big/primality_test.v
@@ -70,6 +70,12 @@ fn test_mersenne_primes() {
 	assert parse('170141183460469231731687303715884105727').is_probably_prime(20)
 }
 
+fn test_fermat_primes_with_unit_miller_rabin_exponent() {
+	// These decompose p - 1 into d * 2^s with d == 1.
+	assert big.integer_from_int(257).is_probably_prime(20)
+	assert big.integer_from_int(65537).is_probably_prime(20)
+}
+
 fn test_mersenne_composites() {
 	// 2^11 - 1
 	assert !parse('2047').is_probably_prime(20)

--- a/vlib/math/big/primality_test.v
+++ b/vlib/math/big/primality_test.v
@@ -1,4 +1,6 @@
 import math.big
+import rand
+import rand.splitmix64
 
 fn parse(s string) big.Integer {
 	return big.integer_from_string(s) or { panic('cannot parse ${s}') }
@@ -100,6 +102,21 @@ fn test_large_primes() {
 	// Verified against an independent Miller-Rabin implementation.
 	assert parse('108088063435698740984721578578639788695211488257777317159208121754987034915181').is_probably_prime(40)
 	assert parse('13072341731781637478543110202182709643196526891726746125798087730494475533760525940644433783483689624697551241382508919700393467667516668276328127648845601').is_probably_prime(40)
+}
+
+fn test_primality_witnesses_do_not_use_global_rng() {
+	old_rng := rand.get_current_rng()
+	defer {
+		rand.set_rng(old_rng)
+	}
+	seed := [u32(1234), 5678]
+	mut installed_rng := splitmix64.SplitMix64RNG{}
+	mut control_rng := splitmix64.SplitMix64RNG{}
+	installed_rng.seed(seed)
+	control_rng.seed(seed)
+	rand.set_rng(installed_rng)
+	assert parse('170141183460469231731687303715884105727').is_probably_prime(1)
+	assert rand.u64() == control_rng.u64()
 }
 
 fn test_large_composite() {


### PR DESCRIPTION
## What

Adds `Integer.is_probably_prime` and `jacobi` to `math.big`, and `prime` / `safe_prime` to `crypto.rand`.

`math.big` already has `mod_pow`, `mod_inverse` and `gcd`, but there is no way to decide primality, so RSA, DSA and Diffie-Hellman parameter generation cannot be written in V today. `vsl` has an `is_prime`, but it is trial division on `int`, so it does not apply to `big.Integer`, and `crypto` cannot depend on a third-party module anyway.

## How

`is_probably_prime` is a Baillie-PSW test:

1. trial division by the primes below 60
2. Miller-Rabin
3. an almost extra strong Lucas test, Baillie-OEIS method C

Method C fixes `Q = 1`, so only the V sequence is needed and the Lucas step reduces to repeated squaring with no modular halving. `U(s)` is recovered at the end through Crandall and Pomerance eq. 3.13 without ever computing the U sequence.

The first 13 Miller-Rabin bases are the fixed set that is provably sufficient below `3317044064679887385961981`; later rounds draw random bases, since fixed bases past that point add nothing against a crafted input.

Two things keep it fast:

- Trial division reduces the input **once per precomputed product** instead of once per prime, via a `mod_small` helper that walks the digit array without allocating. Rejecting a composite costs about 140 ns, which matters because key generation discards hundreds of candidates per prime found.
- Every Miller-Rabin round **shares one montgomery context** rather than deriving a modular inverse per round. This is why `mont_odd` is split into `mont_odd_with_ctx`, which takes a caller-supplied context; `mont_odd` keeps its old signature and behaviour, and is the only change to existing code.

Prime generation lives in `crypto.rand` rather than `math.big`, both because `crypto.rand` already imports `math.big` (the other direction would be an import cycle) and because key material should come from the OS entropy source. This also matches where Go puts it. `prime` sets the two highest bits, so the product of two same-sized primes has exactly twice as many bits, as RSA expects.

## Testing

`vlib/math/big/primality_test.v` and `vlib/crypto/rand/prime_test.v` cover:

- Carmichael numbers, which defeat a Fermat test
- strong pseudoprimes through the first 13 prime bases, including `3317044064679887385961981`
- Mersenne primes and Mersenne composites
- perfect squares, where no valid Lucas `D` exists
- semiprimes, negatives, zero, and the `rounds <= 0` default
- generated primes: exact bit length, oddness, primality, distinctness, and that `(p - 1) / 2` is prime for `safe_prime`

Separately, cross-checked against an independent sieve over **every odd number below 200000**, with no false positives and no false negatives.

## Numbers

`-prod`, averaged over repeated runs since generation timings vary with the candidate stream:

| operation | time |
|---|---|
| reject a 512-bit composite | 137 ns |
| test a 512-bit prime, 40 rounds | 29.5 ms |
| generate a 512-bit prime | 76 ms |
| generate a 1024-bit prime | 623 ms |
| generate a 2048-bit prime | ~6.3 s |

Time is dominated by the modular exponentiation in `mont_mul`, not by anything added here: a round using a randomly drawn base costs about the same as one using a fixed base. Reducing the allocations in `mont_mul` and `from_mont` would help the whole module, but that is a change to existing arithmetic and belongs in its own PR.

## Notes

- `v fmt -verify` and `v vet` are clean on all touched files.
- `v test vlib/math/big/` and `v test vlib/crypto/rand/` pass in full, so the `mont_odd` split does not regress existing exponentiation behaviour.
- The doc comment states plainly that a `true` result is a probability, not a certainty, and that this should not be used on its own to validate an adversary-supplied modulus.