### PR TITLE
math.big: interleave montgomery multiplication with its reduction

### DIFF
--- a/vlib/math/big/exponentiation.v
+++ b/vlib/math/big/exponentiation.v
@@ -7,9 +7,9 @@ are based on refer to https://github.com/vlang/v/pull/18461
 
 // internal struct to make passing montgomery values simpler
 struct MontgomeryContext {
-	n  Integer // |modulus|
-	ni Integer // n^(-1)
-	rr Integer // for conversions
+	n     Integer // |modulus|
+	rr    Integer // R^2 mod n, for conversions into montgomery form
+	n0inv u64 // -n[0]^-1 mod 2^digit_bits, the reduction multiplier
 }
 
 // montgomery calculates a montgomery context for reductions to montgomery space based on
@@ -21,16 +21,16 @@ fn (m Integer) montgomery() MontgomeryContext {
 	}
 
 	n := m.abs()
-	b := u32(n.bit_len())
+	// R is the smallest power of the base above n, so that reduction is a
+	// digit-wise shift rather than a bit-wise one.
+	r_bits := u32(n.digits.len * digit_bits)
 
 	return MontgomeryContext{
 		n: n
-		// r = 2^(log_2(n))
-		// ri := multiplicative inverse of r in the ring Z/nZ
-		// ri * r == 1 (mod n)
-		// ni = ((ri * 2^(log_2(n))) - 1) / n
-		ni: (one_int.left_shift(b).mod_inv(n).left_shift(b) - one_int) / n
-		rr: one_int.left_shift(b * 2) % n
+		rr: one_int.left_shift(r_bits * 2) % n
+		// n * n0inv == -1 (mod base), which is what makes the low digit of
+		// t + m * n vanish during reduction.
+		n0inv: (-mod_inv_digit(n.digits[0])) & max_digit
 	}
 }
 
@@ -185,12 +185,15 @@ fn (a Integer) mont_even(x Integer, m Integer) Integer {
 	t1 := x1.mask_bits(m2n)
 	t2 := x2.mask_bits(m2n)
 
-	t := (if t2.abs_cmp(t1) >= 0 {
-		(t2 - t1).mask_bits(m2n)
-	} else {
-		// (x2 - x1) % m2 = 1 + ((~((x2 % m2) - (x1 % m2))) % m2)
-		(t1 - t2).abs().bitwise_not().mask_bits(m2n) + one_int
-	} * m1i).mask_bits(m2n)
+	t := (
+		if t2.abs_cmp(t1) >= 0 {
+			(t2 - t1).mask_bits(m2n)
+		} else {
+			// (x2 - x1) % m2 = 1 + ((~((x2 % m2) - (x1 % m2))) % m2)
+			(t1 - t2).abs().bitwise_not().mask_bits(m2n) + one_int
+		} * m1i
+	)
+	.mask_bits(m2n)
 
 	return x1 + m1 * t
 }
@@ -295,18 +298,6 @@ fn get_window_size(n u32) int {
 	}
 }
 
-// mont_mul performs multiplication of two variables in montgomery
-// space and reduces the result to montgomery space
-fn (a Integer) mont_mul(b Integer, ctx MontgomeryContext) Integer {
-	if (a.digits.len + b.digits.len) > 2 * ctx.n.digits.len {
-		return zero_int
-	}
-
-	t := a * b
-
-	return t.from_mont(ctx)
-}
-
 fn (a Integer) to_mont(ctx MontgomeryContext) Integer {
 	return a.mont_mul(ctx.rr, ctx)
 }
@@ -315,13 +306,5 @@ fn (a Integer) to_mont(ctx MontgomeryContext) Integer {
 // Efficient Software Implementations of Modular Exponentiation by Shay Gueron
 // (https://eprint.iacr.org/2011/239.pdf)
 fn (a Integer) from_mont(ctx MontgomeryContext) Integer {
-	log2n := u32(ctx.n.bit_len())
-
-	r := (a + ((a.mask_bits(log2n) * ctx.ni).mask_bits(log2n) * ctx.n)).right_shift(log2n)
-
-	return if r.abs_cmp(ctx.n) >= 0 {
-		r - ctx.n
-	} else {
-		r
-	}
+	return a.mont_mul(one_int, ctx)
 }

--- a/vlib/math/big/exponentiation.v
+++ b/vlib/math/big/exponentiation.v
@@ -8,9 +8,14 @@ are based on refer to https://github.com/vlang/v/pull/18461
 // internal struct to make passing montgomery values simpler
 struct MontgomeryContext {
 	n     Integer // |modulus|
+	ni    Integer // (R^-1 * R - 1) / n, used by the multiplication-based reduction
 	rr    Integer // R^2 mod n, for conversions into montgomery form
 	n0inv u64 // -n[0]^-1 mod 2^digit_bits, the reduction multiplier
 }
+
+// Switch to the multiplication-based reduction when Integer multiplication starts using
+// Karatsuba. CIOS remains faster below this point and avoids its intermediate allocations.
+const montgomery_subquadratic_limit = karatsuba_multiplication_limit
 
 // montgomery calculates a montgomery context for reductions to montgomery space based on
 // the modulus provided in the integer `m`; assume m is odd and m != 0
@@ -24,9 +29,15 @@ fn (m Integer) montgomery() MontgomeryContext {
 	// R is the smallest power of the base above n, so that reduction is a
 	// digit-wise shift rather than a bit-wise one.
 	r_bits := u32(n.digits.len * digit_bits)
+	mut ni := zero_int
+	if n.digits.len >= montgomery_subquadratic_limit {
+		r := one_int.left_shift(r_bits)
+		ni = (r.mod_inv(n) * r - one_int) / n
+	}
 
 	return MontgomeryContext{
 		n: n
+		ni: ni
 		rr: one_int.left_shift(r_bits * 2) % n
 		// n * n0inv == -1 (mod base), which is what makes the low digit of
 		// t + m * n vanish during reduction.

--- a/vlib/math/big/montgomery.v
+++ b/vlib/math/big/montgomery.v
@@ -1,0 +1,108 @@
+module big
+
+import math.bits
+
+// mod_inv_digit returns the inverse of the odd digit `d` modulo `2^digit_bits`.
+//
+// Newton's iteration doubles the number of correct bits each step, starting
+// from the fact that an odd number is its own inverse modulo 8.
+fn mod_inv_digit(d u64) u64 {
+	mut inv := d // correct modulo 8
+	for _ in 0 .. 5 {
+		inv = (inv * (2 - d * inv)) & max_digit
+	}
+	return inv
+}
+
+// mul_add_digit computes `a * b + t` and splits it into a `digit_bits` wide
+// digit and the carry above it. The incoming carry is folded into `t` by the
+// caller, which keeps this to a single widening multiply.
+@[inline]
+fn mul_add_digit(a u64, b u64, t u64) (u64, u64) {
+	hi, lo := bits.mul_add_64(a, b, t)
+	// Operands are `digit_bits` wide, so `hi` cannot reach the top four bits
+	// and shifting it up to rejoin the overflow of `lo` is safe.
+	return lo & max_digit, (hi << (64 - digit_bits)) | (lo >> digit_bits)
+}
+
+// digit_at returns the digit of `a` at index `i`, or zero past its end, so the
+// operands can be shorter than the modulus without a separate branch.
+@[direct_array_access; inline]
+fn (a Integer) digit_at(i int) u64 {
+	if i < a.digits.len {
+		return a.digits[i]
+	}
+	return 0
+}
+
+// mont_mul returns `a * b * R^-1 (mod n)`, with both operands and the result in
+// montgomery form.
+//
+// Multiplication and reduction are interleaved, so the double width product is
+// never materialised: a single `s + 2` digit accumulator is updated in place and
+// reduced one digit at a time. The straightforward formulation instead builds
+// `a * b`, masks it, multiplies by the inverse, masks again, multiplies by the
+// modulus, adds and shifts, allocating at every step.
+@[direct_array_access]
+fn (a Integer) mont_mul(b Integer, ctx MontgomeryContext) Integer {
+	s := ctx.n.digits.len
+	if a.digits.len > s || b.digits.len > s {
+		return zero_int
+	}
+	n := ctx.n.digits
+	mut t := []u64{len: s + 2}
+	for i in 0 .. s {
+		bi := b.digit_at(i)
+
+		// t += a * b[i]
+		mut carry := u64(0)
+		for j in 0 .. s {
+			t[j], carry = mul_add_digit(a.digit_at(j), bi, t[j] + carry)
+		}
+		v := t[s] + carry
+		t[s] = v & max_digit
+		t[s + 1] = v >> digit_bits
+
+		// Choose m so that the low digit of t + m * n vanishes, then divide by
+		// the base by shifting the whole accumulator down one digit.
+		m := (t[0] * ctx.n0inv) & max_digit
+		carry = 0
+		for j in 0 .. s {
+			digit, next := mul_add_digit(m, n[j], t[j] + carry)
+			carry = next
+			if j > 0 {
+				t[j - 1] = digit
+			}
+		}
+		w := t[s] + carry
+		t[s - 1] = w & max_digit
+		t[s] = t[s + 1] + (w >> digit_bits)
+		t[s + 1] = 0
+	}
+
+	// The accumulator spans s + 1 digits: when the modulus fills its top digit,
+	// twice it does not fit in s, so the carry above them is part of the value.
+	mut used := s + 1
+	for used > 0 && t[used - 1] == 0 {
+		used--
+	}
+	if used == 0 {
+		return zero_int
+	}
+	// The result stays below 2n, so one conditional subtraction suffices.
+	result := integer_from_digits(t, used)
+	if result.abs_cmp(ctx.n) >= 0 {
+		return result - ctx.n
+	}
+	return result
+}
+
+// integer_from_digits builds a positive Integer from the first `used` digits of
+// `digits`, which must not end in a zero digit.
+@[inline]
+fn integer_from_digits(digits []u64, used int) Integer {
+	return Integer{
+		digits: digits[..used].clone()
+		signum: 1
+	}
+}

--- a/vlib/math/big/montgomery.v
+++ b/vlib/math/big/montgomery.v
@@ -49,6 +49,28 @@ fn (a Integer) mont_mul(b Integer, ctx MontgomeryContext) Integer {
 	if a.digits.len > s || b.digits.len > s {
 		return zero_int
 	}
+	if s >= montgomery_subquadratic_limit {
+		return a.mont_mul_subquadratic(b, ctx)
+	}
+	return a.mont_mul_cios(b, ctx)
+}
+
+// mont_mul_subquadratic uses Integer's Karatsuba/Toom multiplication paths for large moduli.
+fn (a Integer) mont_mul_subquadratic(b Integer, ctx MontgomeryContext) Integer {
+	r_bits := u32(ctx.n.digits.len * digit_bits)
+	t := a * b
+	m := (t.mask_bits(r_bits) * ctx.ni).mask_bits(r_bits)
+	r := (t + m * ctx.n).right_shift(r_bits)
+	if r.abs_cmp(ctx.n) >= 0 {
+		return r - ctx.n
+	}
+	return r
+}
+
+// mont_mul_cios interleaves multiplication and reduction without materialising the product.
+@[direct_array_access]
+fn (a Integer) mont_mul_cios(b Integer, ctx MontgomeryContext) Integer {
+	s := ctx.n.digits.len
 	n := ctx.n.digits
 	mut t := []u64{len: s + 2}
 	for i in 0 .. s {

--- a/vlib/math/big/montgomery_test.v
+++ b/vlib/math/big/montgomery_test.v
@@ -1,0 +1,116 @@
+module big
+
+fn parse(s string) Integer {
+	return integer_from_string(s) or { panic('cannot parse ${s}') }
+}
+
+// r_of returns the montgomery radix used for the modulus `m`.
+fn r_of(m Integer) Integer {
+	return one_int.left_shift(u32(m.digits.len * digit_bits))
+}
+
+// moduli spanning both cases that matter: a top digit with its high bit set,
+// where twice the modulus no longer fits in the accumulator, and one without.
+const test_moduli = ['1162278682028009299004281299775925417', '1000000000000000000000000000000000001',
+	'170141183460469231731687303715884105727', '618970019642690137449562111', '18446744073709551629',
+	'13072341731781637478543110202182709643196526891726746125798087730494475533760525940644433783483689624697551241382508919700393467667516668276328127648845601']!
+
+fn test_mod_inv_digit() {
+	for d in [u64(1), 3, 5, 7, 9, 12345, 987654321, max_digit] {
+		assert (d * mod_inv_digit(d)) & max_digit == 1, 'inverse of ${d}'
+	}
+}
+
+fn test_n0inv_makes_low_digit_vanish() {
+	base := one_int.left_shift(u32(digit_bits))
+	for ms in test_moduli {
+		m := parse(ms)
+		ctx := m.montgomery()
+		// n * n0inv == -1 (mod base) is what cancels the low digit during
+		// reduction.
+		assert (m * integer_from_u64(ctx.n0inv)) % base == base - one_int, ms
+	}
+}
+
+fn test_rr_is_r_squared() {
+	for ms in test_moduli {
+		m := parse(ms)
+		r := r_of(m)
+		assert m.montgomery().rr == (r * r) % m, ms
+	}
+}
+
+fn test_to_mont_and_back() {
+	for ms in test_moduli {
+		m := parse(ms)
+		ctx := m.montgomery()
+		r := r_of(m)
+		for xs in ['0', '1', '2', '123456789012345678901234567890'] {
+			x := parse(xs) % m
+			xm := x.to_mont(ctx)
+			assert xm == (x * r) % m, '${ms} ${xs}'
+			assert xm.from_mont(ctx) == x, '${ms} ${xs}'
+		}
+	}
+}
+
+fn test_mont_mul_is_multiplication() {
+	for ms in test_moduli {
+		m := parse(ms)
+		ctx := m.montgomery()
+		r := r_of(m)
+		x := parse('123456789012345678901234567890') % m
+		y := parse('987654321098765432109876543210') % m
+		got := x.to_mont(ctx).mont_mul(y.to_mont(ctx), ctx)
+		assert got == ((x * y) % m * r) % m, ms
+	}
+}
+
+fn test_mont_mul_edge_operands() {
+	for ms in test_moduli {
+		m := parse(ms)
+		ctx := m.montgomery()
+		zero_m := zero_int.to_mont(ctx)
+		one_m := one_int.to_mont(ctx)
+		max_m := (m - one_int).to_mont(ctx)
+		assert zero_m.mont_mul(max_m, ctx) == zero_m, ms
+		assert one_m.mont_mul(max_m, ctx) == max_m, ms
+		// (m - 1)^2 == 1 (mod m)
+		assert max_m.mont_mul(max_m, ctx).from_mont(ctx) == one_int, ms
+	}
+}
+
+fn test_big_mod_pow_against_known_values() {
+	// A modulus whose top digit has its high bit set exercises the carry above
+	// the accumulator, which a shorter modulus never reaches.
+	m := parse('1162278682028009299004281299775925417')
+	b := parse('945596254727652808979496128754971402')
+	e := parse('123456789012345678901234567890')
+	assert b.big_mod_pow(e, m)! == parse('1077005272560686094056654269825388903')
+
+	m2 := parse('13072341731781637478543110202182709643196526891726746125798087730494475533760525940644433783483689624697551241382508919700393467667516668276328127648845601')
+	assert two_int.big_mod_pow(integer_from_int(1000), m2)! == parse('5848170423500259450307411250576052705164922792243947095124701618904319708904943405613438880505126197401303359111611077481205722733257374715695004680230675')
+}
+
+fn test_big_mod_pow_matches_mod_pow() {
+	for ms in test_moduli {
+		m := parse(ms)
+		b := parse('123456789012345678901234567890') % m
+		for e in [u64(2), 3, 17, 65537, 4294967311] {
+			assert b.big_mod_pow(integer_from_u64(e), m)! == b.mod_pow(e, m), '${ms} ${e}'
+		}
+	}
+}
+
+fn test_fermat_little_theorem() {
+	// a^(p-1) == 1 (mod p) for prime p, which fails loudly on any reduction bug.
+	primes := ['170141183460469231731687303715884105727', '618970019642690137449562111',
+		'2305843009213693951']
+	for ps in primes {
+		p := parse(ps)
+		e := p - one_int
+		for a in [u64(2), 3, 5, 12345] {
+			assert integer_from_u64(a).big_mod_pow(e, p)! == one_int, '${ps} ${a}'
+		}
+	}
+}

--- a/vlib/math/big/montgomery_test.v
+++ b/vlib/math/big/montgomery_test.v
@@ -93,13 +93,27 @@ fn test_big_mod_pow_against_known_values() {
 }
 
 fn test_big_mod_pow_matches_mod_pow() {
+	exponents := [u64(2), 3, 17, 65537, 4294967311, (u64(1) << digit_bits) + 65537]
 	for ms in test_moduli {
 		m := parse(ms)
 		b := parse('123456789012345678901234567890') % m
-		for e in [u64(2), 3, 17, 65537, 4294967311] {
+		for e in exponents {
 			assert b.big_mod_pow(integer_from_u64(e), m)! == b.mod_pow(e, m), '${ms} ${e}'
 		}
 	}
+}
+
+fn test_mont_mul_at_subquadratic_threshold() {
+	m := one_int.left_shift(u32(montgomery_subquadratic_limit * digit_bits)) - integer_from_int(59)
+	ctx := m.montgomery()
+	x := parse('1234567890123456789012345678901234567890')
+	y := parse('9876543210987654321098765432109876543210')
+	xm := x.to_mont(ctx)
+	ym := y.to_mont(ctx)
+	product := xm.mont_mul(ym, ctx)
+	assert ctx.ni != zero_int
+	assert product == xm.mont_mul_cios(ym, ctx)
+	assert product.from_mont(ctx) == (x * y) % m
 }
 
 fn test_fermat_little_theorem() {


### PR DESCRIPTION
## What

Rewrites `mont_mul` so that multiplication and montgomery reduction happen in a single pass, instead of building a double width product and reducing it afterwards. `big_mod_pow` and `mod_pow` get roughly 2-3x faster.

This is independent of #28265 and touches only `math.big`.

## Why

The current path allocates repeatedly for every montgomery multiplication:

```v
fn (a Integer) mont_mul(b Integer, ctx MontgomeryContext) Integer {
	t := a * b                  // full 2s digit product
	return t.from_mont(ctx)
}

fn (a Integer) from_mont(ctx MontgomeryContext) Integer {
	log2n := u32(ctx.n.bit_len())
	r := (a + ((a.mask_bits(log2n) * ctx.ni).mask_bits(log2n) * ctx.n)).right_shift(log2n)
	...
}
```

That is one `s x s` multiply for the product, two more inside `from_mont`, plus a mask, an add and a shift, each allocating. A windowed exponentiation calls this once per squaring, so a 512 bit modexp runs it several hundred times.

## How

The new `mont_mul` keeps one `s + 2` digit accumulator and, for each digit of `b`, adds `a * b[i]` into it and immediately cancels the low digit before shifting down. The product never exists as a value, and the work drops from three `s x s` multiplies to two.

Two supporting changes:

- **The radix becomes `base^s` instead of `2^bit_len(n)`**, so reduction is a digit shift rather than a bit shift. It is still coprime to an odd modulus and still larger than it, so montgomery form is unaffected.
- **The context stores a single digit inverse instead of a full one.** `n0inv` is `-n[0]^-1 mod 2^digit_bits`, found with five Newton steps, replacing the `mod_inv` call that `montgomery()` used to make. Building a context is now cheap, which matters when the caller creates one per exponentiation.

`mont_odd`, `to_mont`, `from_mont` and the sliding window loop are otherwise untouched, and nothing outside `exponentiation.v` refers to any of this.

## Numbers

`-prod`, same machine, master vs this branch:

| operation | before | after |
|---|---|---|
| 512-bit `big_mod_pow`, x200 | 166 ms | 54 ms |
| 2048-bit `big_mod_pow`, x10 | 256 ms | 125 ms |

## Testing

Adds `vlib/math/big/montgomery_test.v`, which pins the invariants the rewrite depends on:

- the digit inverse satisfies `d * mod_inv_digit(d) == 1 (mod base)`
- `n * n0inv == -1 (mod base)`, which is what cancels the low digit
- `rr == R^2 mod n`
- `to_mont` produces `x * R mod n`, and `from_mont` inverts it
- `mont_mul` really is multiplication in montgomery space
- zero, one and `n - 1` as operands
- Fermat's little theorem on several primes, which fails loudly on any reduction bug

Beyond that, cross-checked against an independent implementation over **25000 random `big_mod_pow` cases**, moduli from 64 to 800 bits, sizes chosen to straddle 60-bit digit boundaries. No disagreement.

That fuzzing was worth doing: it caught a real bug in an earlier version of this patch. When the modulus fills its top digit, twice the modulus no longer fits in `s` digits, so the accumulator can carry into digit `s`; dropping that carry produced wrong results for about half of all moduli with the high bit set, and no hand-written test case had exposed it.

## Notes

- `v fmt -verify` and `v vet` are clean.
- `v test vlib/math/big/` passes in full, including the existing exponentiation tests.