### PR TITLE
v3: reduce FastC self-host generation to 50 ms

### DIFF
--- a/vlib/v3/fastcdriver/fastcdriver.v
+++ b/vlib/v3/fastcdriver/fastcdriver.v
@@ -271,6 +271,13 @@ fn canonical_output_path(path string) string {
 	return os.join_path_single(canonical_parent, os.file_name(absolute_path))
 }
 
+fn fastc_canonical_vroot(vroot string) string {
+	if vroot == '' {
+		return ''
+	}
+	return os.real_path(vroot)
+}
+
 fn fastc_tcc_backtrace_enabled(target_os string, target_arch string) bool {
 	return !(target_os == 'macos' && target_arch == 'arm64')
 }
@@ -372,6 +379,7 @@ pub fn run(args []string) {
 	if prefs.vroot == '' && real_input.ends_with('/vlib/v3/v3.v') {
 		prefs.vroot = os.dir(os.dir(os.dir(real_input)))
 	}
+	prefs.vroot = fastc_canonical_vroot(prefs.vroot)
 	prefs.backend = 'fastc'
 	prefs.ccompiler = 'tinyc'
 	prefs.building_v = real_input.ends_with('/vlib/v3/v3.v')

--- a/vlib/v3/fastcdriver/fastcdriver.v
+++ b/vlib/v3/fastcdriver/fastcdriver.v
@@ -296,6 +296,63 @@ fn tcc_host_system_flags(target_os string) []string {
 	return flags
 }
 
+struct FastcBenchSample {
+	gen_us i64
+	files  int
+	lines  int
+}
+
+fn fastc_bench_source_line_count(paths []string) int {
+	mut total_lines := 0
+	for source_path in paths {
+		content := os.read_file(source_path) or { '' }
+		for ch in content {
+			if ch == `\n` {
+				total_lines++
+			}
+		}
+	}
+	return total_lines
+}
+
+fn fastc_measure_generation(real_input string, prefs &pref.Preferences) !FastcBenchSample {
+	mut sw := time.new_stopwatch()
+	generation := fastc.generate_files_with_source_paths([real_input], prefs)!
+	return FastcBenchSample{
+		gen_us: sw.elapsed().microseconds()
+		files: generation.source_paths.len
+		lines: fastc_bench_source_line_count(generation.source_paths)
+	}
+}
+
+fn fastc_parse_bench_child_output(output string) ?FastcBenchSample {
+	for line in output.split_into_lines() {
+		if !line.starts_with('fastc-bench-child ') {
+			continue
+		}
+		parts := line.split(' ')
+		if parts.len != 4 {
+			return none
+		}
+		return FastcBenchSample{
+			gen_us: parts[1].i64()
+			files: parts[2].int()
+			lines: parts[3].int()
+		}
+	}
+	return none
+}
+
+fn fastc_run_bench_child(args []string) FastcBenchSample {
+	result := cmdexec.run(os.executable(), args)
+	if result.exit_code != 0 {
+		fail(result.output)
+	}
+	return fastc_parse_bench_child_output(result.output) or {
+		fail('fastc benchmark child returned no timing sample:\n${result.output}')
+	}
+}
+
 // run invokes the standalone FastC compiler or its self-build command.
 pub fn run(args []string) {
 	command_index := self_command_index(args)
@@ -334,47 +391,36 @@ pub fn run(args []string) {
 	if repeat < 1 {
 		repeat = 1
 	}
+	if bench && os.getenv('FASTC_BENCH_CHILD') != '' {
+		sample := fastc_measure_generation(real_input, prefs) or { fail(err.msg()) }
+		println('fastc-bench-child ${sample.gen_us} ${sample.files} ${sample.lines}')
+		return
+	}
 	if bench && repeat > 1 {
-		mut warm := fastc.generate_files_with_source_paths([real_input], prefs) or {
-			fail(err.msg())
-		}
-		warm = warm
+		old_child_marker := os.getenv_opt('FASTC_BENCH_CHILD')
+		os.setenv('FASTC_BENCH_CHILD', '1', true)
+		warm := fastc_run_bench_child(args)
 		mut best_us := i64(0)
-		mut sw2 := time.new_stopwatch()
 		for iteration in 0 .. repeat {
-			sw2.restart()
-			fastc.generate_files_with_source_paths([real_input], prefs) or { fail(err.msg()) }
-			iter_us := sw2.elapsed().microseconds()
-			if iteration == 0 || iter_us < best_us {
-				best_us = iter_us
+			sample := fastc_run_bench_child(args)
+			if iteration == 0 || sample.gen_us < best_us {
+				best_us = sample.gen_us
 			}
 		}
-		mut total_lines := 0
-		for source_path in warm.source_paths {
-			content := os.read_file(source_path) or { '' }
-			for ch in content {
-				if ch == `\n` {
-					total_lines++
-				}
-			}
+		if old_child_marker_value := old_child_marker {
+			os.setenv('FASTC_BENCH_CHILD', old_child_marker_value, true)
+		} else {
+			os.unsetenv('FASTC_BENCH_CHILD')
 		}
 		gen_ms := f64(best_us) / 1000.0
-		loc_per_s := f64(total_lines) * 1_000_000.0 / f64(best_us)
-		eprintln('fastc-bench: files=${warm.source_paths.len} lines=${total_lines} best_gen=${gen_ms:.2f}ms loc/s=${loc_per_s:.0f} (repeat=${repeat})')
+		loc_per_s := f64(warm.lines) * 1_000_000.0 / f64(best_us)
+		eprintln('fastc-bench: files=${warm.files} lines=${warm.lines} best_gen=${gen_ms:.2f}ms loc/s=${loc_per_s:.0f} (repeat=${repeat})')
 	}
 	mut sw := time.new_stopwatch()
 	generation := fastc.generate_files_with_source_paths([real_input], prefs) or { fail(err.msg()) }
 	if bench && repeat == 1 {
 		gen_us := sw.elapsed().microseconds()
-		mut total_lines := 0
-		for source_path in generation.source_paths {
-			content := os.read_file(source_path) or { '' }
-			for ch in content {
-				if ch == `\n` {
-					total_lines++
-				}
-			}
-		}
+		total_lines := fastc_bench_source_line_count(generation.source_paths)
 		gen_ms := f64(gen_us) / 1000.0
 		loc_per_s := f64(total_lines) * 1_000_000.0 / f64(gen_us)
 		eprintln('fastc-bench: files=${generation.source_paths.len} lines=${total_lines} gen=${gen_ms:.2f}ms loc/s=${loc_per_s:.0f}')

--- a/vlib/v3/fastcdriver/fastcdriver_test.v
+++ b/vlib/v3/fastcdriver/fastcdriver_test.v
@@ -9,6 +9,16 @@ fn test_fastc_tcc_backtrace_enabled() {
 	assert fastc_tcc_backtrace_enabled('linux', 'amd64')
 }
 
+fn test_fastc_parse_bench_child_output() {
+	sample := fastc_parse_bench_child_output('notice\nfastc-bench-child 50123 170 64516\n') or {
+		assert false, 'expected benchmark sample'
+		return
+	}
+	assert sample.gen_us == 50123
+	assert sample.files == 170
+	assert sample.lines == 64516
+}
+
 fn assert_in_place_self_chain_survives(compiler_name string) {
 	dir := os.join_path(os.temp_dir(), 'fastc_self_${compiler_name}_chain_${os.getpid()}')
 	os.rmdir_all(dir) or {}

--- a/vlib/v3/fastcdriver/fastcdriver_test.v
+++ b/vlib/v3/fastcdriver/fastcdriver_test.v
@@ -9,6 +9,19 @@ fn test_fastc_tcc_backtrace_enabled() {
 	assert fastc_tcc_backtrace_enabled('linux', 'amd64')
 }
 
+fn test_fastc_canonical_vroot_resolves_symlinked_checkout() {
+	root := os.join_path(os.temp_dir(), 'fastc_canonical_vroot_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	real_root := os.join_path(root, 'real')
+	linked_root := os.join_path(root, 'linked')
+	os.mkdir_all(os.join_path(real_root, 'vlib', 'builtin')) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	os.symlink(real_root, linked_root) or { return }
+	assert fastc_canonical_vroot(linked_root) == os.real_path(real_root)
+}
+
 fn test_fastc_parse_bench_child_output() {
 	sample := fastc_parse_bench_child_output('notice\nfastc-bench-child 50123 170 64516\n') or {
 		assert false, 'expected benchmark sample'

--- a/vlib/v3/gen/fastc/array.v
+++ b/vlib/v3/gen/fastc/array.v
@@ -768,7 +768,9 @@ fn fastc_expression_list_items(tokens []FastcExpressionToken, start int, end int
 					if item_start == i {
 						return error('empty expression-list item')
 					}
-					result << tokens[item_start..i]
+					// Items are consumed while `tokens` is alive and never mutated, so views are safe.
+					item := unsafe { tokens[item_start..i] }
+					result << item
 					item_start = i + 1
 				}
 			}
@@ -778,6 +780,7 @@ fn fastc_expression_list_items(tokens []FastcExpressionToken, start int, end int
 	if item_start == end {
 		return result
 	}
-	result << tokens[item_start..end]
+	item := unsafe { tokens[item_start..end] }
+	result << item
 	return result
 }

--- a/vlib/v3/gen/fastc/decl.v
+++ b/vlib/v3/gen/fastc/decl.v
@@ -993,6 +993,10 @@ fn (g &Parser) constant_expression_dependencies(tokens []FastcExpressionToken) [
 		if item.tok != .name || (i > 0 && tokens[i - 1].tok == .dot) {
 			continue
 		}
+		if i + 1 < tokens.len && tokens[i + 1].tok == .lpar
+			&& fastc_primitive_c_type(item.lit) != none {
+			continue
+		}
 		mut key := ''
 		if i + 2 < tokens.len && tokens[i + 1].tok == .dot && tokens[i + 2].tok == .name {
 			if imported_module := g.imports[item.lit] {
@@ -1170,7 +1174,7 @@ fn fastc_order_c_composite_definitions(source string, struct_fields map[string]m
 				if dependency_start < dependent_start {
 					continue
 				}
-				next := fastc_move_c_composite_before(ordered, dependency, dependent)
+				next := fastc_move_c_composite_before(ordered, dependency_start, dependent_start)
 				if next != ordered {
 					ordered = next
 					changed = true
@@ -1183,8 +1187,7 @@ fn fastc_order_c_composite_definitions(source string, struct_fields map[string]m
 }
 
 // fastc_composite_definition_positions maps each C composite name to the start
-// offset of its `struct NAME {` / `union NAME {` definition, matching the first
-// occurrence that fastc_c_composite_definition_start would find via `.index`.
+// offset of the first `struct NAME {` / `union NAME {` definition.
 @[direct_array_access]
 fn fastc_composite_definition_positions(source string) map[string]int {
 	mut positions := map[string]int{}
@@ -1246,9 +1249,7 @@ fn fastc_by_value_composite_type(field_type string, by_value_composite_names map
 	return ''
 }
 
-fn fastc_move_c_composite_before(source string, dependency string, dependent string) string {
-	dependency_start := fastc_c_composite_definition_start(source, dependency) or { return source }
-	dependent_start := fastc_c_composite_definition_start(source, dependent) or { return source }
+fn fastc_move_c_composite_before(source string, dependency_start int, dependent_start int) string {
 	if dependency_start < dependent_start {
 		return source
 	}
@@ -1260,19 +1261,7 @@ fn fastc_move_c_composite_before(source string, dependency string, dependent str
 		end++
 	}
 	block := source[dependency_start..end]
-	without := source[..dependency_start] + source[end..]
-	insert_at := fastc_c_composite_definition_start(without, dependent) or { return source }
-	return without[..insert_at] + block + without[insert_at..]
-}
-
-fn fastc_c_composite_definition_start(source string, name string) ?int {
-	if start := source.index('struct ${name} {') {
-		return int(start)
-	}
-	if start := source.index('union ${name} {') {
-		return int(start)
-	}
-	return none
+	return source[..dependent_start] + block + source[dependent_start..dependency_start] + source[end..]
 }
 
 fn fastc_c_composite_definition_end(source string, start int) ?int {

--- a/vlib/v3/gen/fastc/fastc.v
+++ b/vlib/v3/gen/fastc/fastc.v
@@ -690,6 +690,13 @@ struct FastcQueuedSource {
 	module_name string
 }
 
+struct FastcLoadedSource {
+	source        string
+	header        FastcSourceHeader
+	failed        bool
+	error_message string
+}
+
 struct FastcHoistedCSource {
 	directives       string
 	conditional_code string
@@ -964,8 +971,8 @@ pub fn generate_files_with_source_paths(paths []string, prefs &pref.Preferences)
 }
 
 // FastcFileGenContext bundles the read-only program tables every per-file
-// code-generation Parser starts from. Workers share it across threads; the
-// two seed maps are cloned per file, never mutated through the context.
+// code-generation Parser starts from. Workers share it across threads and
+// return their per-file registration deltas to the stitch pass.
 struct FastcFileGenContext {
 	prefs                  &pref.Preferences = unsafe { nil }
 	declared_types         map[string]bool
@@ -1062,8 +1069,11 @@ fn fastc_generate_single_file(ctx &FastcFileGenContext, source_file FastcSourceF
 		functions: ctx.functions
 		constant_types: ctx.constant_types
 		global_types: ctx.global_types
-		fixed_array_types: ctx.fixed_array_types.clone()
-		composite_types: ctx.composite_types.clone()
+		// These maps are per-file registration deltas. The stitch pass already owns
+		// the declarations collected before file generation, so copying that shared
+		// seed into every parser only adds allocation and hashing work.
+		fixed_array_types: map[string]string{}
+		composite_types: map[string]bool{}
 		deferred_lines: []string{}
 		deferred_block_starts: []int{}
 		loop_defer_block_starts: []int{}
@@ -1439,6 +1449,10 @@ fn fastc_generate_interface_dispatches(declared_kinds map[string]FastcDeclaredTy
 	mut out := strings.new_builder(1024)
 	mut function_keys := functions.keys()
 	function_keys.sort()
+	mut function_method_names := []string{cap: function_keys.len}
+	for function_key in function_keys {
+		function_method_names << function_key.all_after_last('.')
+	}
 	mut interface_method_keys := interface_methods.keys()
 	interface_method_keys.sort()
 	for interface_key, kind in declared_kinds {
@@ -1468,11 +1482,15 @@ fn fastc_generate_interface_dispatches(declared_kinds map[string]FastcDeclaredTy
 			c_name := fastc_method_c_name(interface_signature.module_name, interface_type, method_name)
 			out.writeln('${interface_signature.return_type} ${c_name}(${parameters.join(', ')}) {')
 			out.writeln('\tswitch (value._typ) {')
-			for candidate_key in function_keys {
-				if selfhost && method_name !in used_function_names {
-					continue
-				}
-				if candidate_key == interface_method_key || candidate_key.all_after_last('.') != method_name {
+			candidate_count := if selfhost && method_name !in used_function_names {
+				0
+			} else {
+				function_keys.len
+			}
+			for candidate_index in 0 .. candidate_count {
+				candidate_key := function_keys[candidate_index]
+				if candidate_key == interface_method_key
+					|| function_method_names[candidate_index] != method_name {
 					continue
 				}
 				receiver_key := candidate_key.all_before_last('.')

--- a/vlib/v3/gen/fastc/fastc_test.v
+++ b/vlib/v3/gen/fastc/fastc_test.v
@@ -947,6 +947,31 @@ fn test_source_resolver_preserves_aliases_for_scheduled_files() {
 	assert aliases['legacy'] == 'canonical'
 }
 
+fn test_source_resolver_preserves_aliases_for_symlinked_module_dirs() {
+	root := os.join_path(os.vtmp_dir(), 'v3_fastc_symlinked_alias_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	canonical_dir := os.join_path(root, 'canonical')
+	legacy_dir := os.join_path(root, 'legacy')
+	os.mkdir_all(canonical_dir) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	os.symlink(canonical_dir, legacy_dir) or { return }
+	main_file := os.join_path(root, 'main.v')
+	os.write_file(main_file, 'module main\nimport canonical\nimport legacy\nfn main() { canonical.ping(); legacy.ping() }\n') or {
+		panic(err)
+	}
+	os.write_file(os.join_path(canonical_dir, 'canonical.v'),
+		'module canonical\npub fn ping() {}\n') or {
+		panic(err)
+	}
+	mut prefs := pref.new_preferences()
+	prefs.module_search_paths = [root]
+	sources, aliases := fastc_resolve_source_files([main_file], prefs) or { panic(err) }
+	assert sources.len == 2
+	assert aliases['legacy'] == 'canonical'
+}
+
 fn test_header_discovers_imports_only_from_selected_comptime_branches() {
 	root := os.join_path(os.vtmp_dir(), 'v3_fastc_comptime_imports_${os.getpid()}')
 	os.rmdir_all(root) or {}

--- a/vlib/v3/gen/fastc/fastc_test.v
+++ b/vlib/v3/gen/fastc/fastc_test.v
@@ -24,11 +24,23 @@ fn test_fastc_chunk_bounds_reserve_files_for_later_workers() {
 	assert fastc_chunk_bounds(sources, 2) == [0, 3, 3, 4]
 }
 
-fn test_fastc_source_contains_word_respects_identifier_boundaries() {
-	assert fastc_source_contains_word('module main\nconst answer = 42\n', 'const')
-	assert fastc_source_contains_word('module main\n__global count int\n', '__global')
-	assert !fastc_source_contains_word('module main\nfn key_const() {}\n', 'const')
-	assert !fastc_source_contains_word('module main\nfn use__global_value() {}\n', '__global')
+fn test_fastc_file_generation_jobs_balance_largest_files_first() {
+	sources := [
+		FastcSourceFile{source: 'a'.repeat(60)},
+		FastcSourceFile{source: 'b'.repeat(50)},
+		FastcSourceFile{source: 'c'.repeat(40)},
+		FastcSourceFile{source: 'd'.repeat(30)},
+	]
+	assert fastc_file_generation_job_indices(sources, 2) == [[0, 3], [1, 2]]
+}
+
+fn test_fastc_source_declaration_flags_respect_identifier_boundaries() {
+	has_constants, has_global_declarations := fastc_source_declaration_flags('module main\nconst answer = 42\n__global count int\n')
+	assert has_constants
+	assert has_global_declarations
+	identifier_constants, identifier_globals := fastc_source_declaration_flags('module main\nfn key_const() {}\nfn use__global_value() {}\n')
+	assert !identifier_constants
+	assert !identifier_globals
 }
 
 fn test_fastc_generic_source_collection_matches_serial_scan() {
@@ -908,6 +920,33 @@ fn test_generate_files_resolves_modules_without_an_ast() {
 	assert run_result.output.trim_space() == '42'
 }
 
+fn test_source_resolver_preserves_aliases_for_scheduled_files() {
+	root := os.join_path(os.vtmp_dir(), 'v3_fastc_scheduled_alias_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	canonical_dir := os.join_path(root, 'canonical')
+	os.mkdir_all(canonical_dir) or { panic(err) }
+	os.mkdir_all(os.join_path(root, 'legacy')) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	main_file := os.join_path(root, 'main.v')
+	os.write_file(main_file, 'module main\nimport canonical\nimport legacy\nfn main() {}\n') or {
+		panic(err)
+	}
+	os.write_file(os.join_path(canonical_dir, 'canonical.v'), 'module canonical\n') or {
+		panic(err)
+	}
+	os.write_file(os.join_path(root, 'legacy', 'alias.v'),
+		"@[alias: '${canonical_dir}'] module legacy\n") or {
+		panic(err)
+	}
+	mut prefs := pref.new_preferences()
+	prefs.module_search_paths = [root]
+	sources, aliases := fastc_resolve_source_files([main_file], prefs) or { panic(err) }
+	assert sources.len == 2
+	assert aliases['legacy'] == 'canonical'
+}
+
 fn test_header_discovers_imports_only_from_selected_comptime_branches() {
 	root := os.join_path(os.vtmp_dir(), 'v3_fastc_comptime_imports_${os.getpid()}')
 	os.rmdir_all(root) or {}
@@ -1106,6 +1145,21 @@ fn main() {
 ', 'static_array_argument.v', prefs) or { panic(err) }
 	assert c_source.contains('Tool_run(((Array_string)builtin__new_array_from_c_array'), c_source
 	assert !c_source.contains('Tool_run(['), c_source
+}
+
+fn test_selfhost_primitive_cast_array_literal_argument_is_lowered() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+fn take(values []u64) {}
+
+fn main() {
+	take([u64(0x8000000000000000), u64(1)])
+}
+', 'selfhost_primitive_cast_array_argument.v', prefs) or { panic(err) }
+	assert c_source.contains('0x8000000000000000ULL'), c_source
+	assert !c_source.contains('take(['), c_source
 }
 
 fn test_selfhost_static_method_named_options_argument_is_lowered() {

--- a/vlib/v3/gen/fastc/parallel_d_v3_no_parallel.v
+++ b/vlib/v3/gen/fastc/parallel_d_v3_no_parallel.v
@@ -2,6 +2,14 @@ module fastc
 
 import v3.pref
 
+fn fastc_load_source_headers(paths []string, prefs &pref.Preferences) []FastcLoadedSource {
+	mut loaded := []FastcLoadedSource{cap: paths.len}
+	for path in paths {
+		loaded << fastc_load_source(path, prefs)
+	}
+	return loaded
+}
+
 // A `-no-parallel` (v3_no_parallel) FastC build omits threaded generation
 // entirely, mirroring the AST pipeline's _d_v3_no_parallel variants: both
 // phases run serially and no spawn helpers are referenced.

--- a/vlib/v3/gen/fastc/parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/fastc/parallel_notd_v3_no_parallel.v
@@ -3,11 +3,7 @@ module fastc
 import os
 import v3.pref
 
-// fastc_parallel_jobs picks the worker count for a parallel phase; 1 selects
-// the serial path. `-no-parallel` and VJOBS mirror the AST pipeline's
-// behavior, and V3_FASTC_NO_PARALLEL forces serial for debugging and for
-// byte-comparing parallel output against a serial run.
-fn fastc_parallel_jobs(sources []FastcSourceFile, prefs &pref.Preferences) int {
+fn fastc_parallel_job_count(item_count int, prefs &pref.Preferences) int {
 	if prefs.no_parallel {
 		return 1
 	}
@@ -19,13 +15,49 @@ fn fastc_parallel_jobs(sources []FastcSourceFile, prefs &pref.Preferences) int {
 	if os.getenv('V3_FASTC_NO_PARALLEL') != '' {
 		jobs = 1
 	}
-	if jobs > sources.len {
-		jobs = sources.len
+	if jobs > item_count {
+		jobs = item_count
 	}
-	if sources.len < 4 {
+	if item_count < 4 {
 		jobs = 1
 	}
 	return jobs
+}
+
+// fastc_parallel_jobs picks the worker count for a parallel phase; 1 selects
+// the serial path. `-no-parallel` and VJOBS mirror the AST pipeline's
+// behavior, and V3_FASTC_NO_PARALLEL forces serial for debugging and for
+// byte-comparing parallel output against a serial run.
+fn fastc_parallel_jobs(sources []FastcSourceFile, prefs &pref.Preferences) int {
+	return fastc_parallel_job_count(sources.len, prefs)
+}
+
+fn fastc_load_source_chunk(paths []string, prefs &pref.Preferences, start int, end int) []FastcLoadedSource {
+	mut loaded := []FastcLoadedSource{cap: end - start}
+	for i in start .. end {
+		loaded << fastc_load_source(paths[i], prefs)
+	}
+	return loaded
+}
+
+fn fastc_load_source_headers(paths []string, prefs &pref.Preferences) []FastcLoadedSource {
+	jobs := fastc_parallel_job_count(paths.len, prefs)
+	if jobs <= 1 {
+		return fastc_load_source_chunk(paths, prefs, 0, paths.len)
+	}
+	first_end := paths.len / jobs
+	first_thread := spawn fastc_load_source_chunk(paths, prefs, 0, first_end)
+	mut chunk_threads := [first_thread]
+	for chunk_idx in 1 .. jobs {
+		start := paths.len * chunk_idx / jobs
+		end := paths.len * (chunk_idx + 1) / jobs
+		chunk_threads << spawn fastc_load_source_chunk(paths, prefs, start, end)
+	}
+	mut loaded := []FastcLoadedSource{cap: paths.len}
+	for chunk_thread in chunk_threads {
+		loaded << chunk_thread.wait()
+	}
+	return loaded
 }
 
 // fastc_chunk_bounds splits the file list into contiguous chunks balanced by
@@ -82,44 +114,85 @@ fn fastc_collect_generic_method_sources(sources []FastcSourceFile, prefs &pref.P
 	return result
 }
 
-// fastc_generate_file_chunk generates a contiguous file range on its own
-// thread. The array header is passed by value; the backing file data is
-// shared and read-only. It runs as a value-returning spawn: under -prealloc,
-// V frees a void thread's arena when the thread exits, so the outputs must
-// travel through the thread result.
-fn fastc_generate_file_chunk(ctx &FastcFileGenContext, sources []FastcSourceFile, start int, end int) []FastcFileGenOutput {
-	mut outputs := []FastcFileGenOutput{cap: end - start}
-	for idx in start .. end {
-		outputs << fastc_generate_single_file(ctx, sources[idx])
+struct FastcIndexedFileGenOutput {
+	index  int
+	output FastcFileGenOutput
+}
+
+// fastc_file_generation_job_indices assigns the largest files first to the
+// currently lightest worker. This avoids clustering the generator's largest
+// source files at the end of the dependency-ordered source list.
+fn fastc_file_generation_job_indices(sources []FastcSourceFile, jobs int) [][]int {
+	mut order := []int{len: sources.len}
+	for i in 0 .. sources.len {
+		order[i] = i
+	}
+	// There are normally only a few hundred files; insertion sort avoids a
+	// closure and keeps this scheduling helper in FastC's self-hostable subset.
+	for i in 1 .. order.len {
+		index := order[i]
+		weight := sources[index].source.len
+		mut insert_at := i
+		for insert_at > 0 && sources[order[insert_at - 1]].source.len < weight {
+			order[insert_at] = order[insert_at - 1]
+			insert_at--
+		}
+		order[insert_at] = index
+	}
+	mut job_indices := [][]int{len: jobs}
+	mut job_weights := []i64{len: jobs}
+	for index in order {
+		mut lightest := 0
+		for job in 1 .. jobs {
+			if job_weights[job] < job_weights[lightest] {
+				lightest = job
+			}
+		}
+		job_indices[lightest] << index
+		job_weights[lightest] += i64(sources[index].source.len) + 1
+	}
+	return job_indices
+}
+
+// fastc_generate_file_chunk generates one worker's files. The backing source
+// data is shared and read-only. It runs as a value-returning spawn: under
+// -prealloc, V frees a void thread's arena when the thread exits, so outputs
+// must travel through the thread result.
+fn fastc_generate_file_chunk(ctx &FastcFileGenContext, sources []FastcSourceFile, indices []int) []FastcIndexedFileGenOutput {
+	mut outputs := []FastcIndexedFileGenOutput{cap: indices.len}
+	for index in indices {
+		outputs << FastcIndexedFileGenOutput{
+			index: index
+			output: fastc_generate_single_file(ctx, sources[index])
+		}
 	}
 	return outputs
 }
 
 // fastc_generate_file_outputs runs per-file code generation, in parallel when
-// more than one job is available. Files are split into contiguous chunks
-// balanced by source size, and results are stitched back in file order, so
-// the emitted C is identical to a serial run.
+// more than one job is available. Results are restored to file order, so the
+// emitted C is identical to a serial run.
 fn fastc_generate_file_outputs(ctx &FastcFileGenContext, sources []FastcSourceFile) []FastcFileGenOutput {
 	jobs := fastc_parallel_jobs(sources, ctx.prefs)
-	mut outputs := []FastcFileGenOutput{cap: sources.len}
 	if jobs <= 1 {
+		mut outputs := []FastcFileGenOutput{cap: sources.len}
 		for source_file in sources {
 			outputs << fastc_generate_single_file(ctx, source_file)
 		}
 		return outputs
 	}
-	bounds := fastc_chunk_bounds(sources, jobs)
-	first_thread := spawn fastc_generate_file_chunk(ctx, sources, bounds[0], bounds[1])
+	job_indices := fastc_file_generation_job_indices(sources, jobs)
+	first_thread := spawn fastc_generate_file_chunk(ctx, sources, job_indices[0])
 	mut chunk_threads := [first_thread]
-	for chunk_idx in 1 .. bounds.len / 2 {
-		chunk_thread := spawn fastc_generate_file_chunk(ctx, sources, bounds[chunk_idx * 2], bounds[
-			chunk_idx * 2 + 1])
+	for chunk_idx in 1 .. jobs {
+		chunk_thread := spawn fastc_generate_file_chunk(ctx, sources, job_indices[chunk_idx])
 		chunk_threads << chunk_thread
 	}
+	mut outputs := []FastcFileGenOutput{len: sources.len}
 	for chunk_idx in 0 .. chunk_threads.len {
 		chunk_outputs := chunk_threads[chunk_idx].wait()
-		for output in chunk_outputs {
-			outputs << output
+		for indexed_output in chunk_outputs {
+			outputs[indexed_output.index] = indexed_output.output
 		}
 	}
 	return outputs

--- a/vlib/v3/gen/fastc/render.v
+++ b/vlib/v3/gen/fastc/render.v
@@ -3085,7 +3085,11 @@ fn (g &Parser) render_array_literal_argument(tokens []FastcExpressionToken, expe
 	}
 	mut rendered_items := []string{cap: items.len}
 	for item in items {
-		rendered_items << g.render_call_argument_expression(item, element_type) or { return none }
+		if simple := g.render_selfhost_simple_array_literal_item(item, element_type) {
+			rendered_items << simple
+		} else {
+			rendered_items << g.render_call_argument_expression(item, element_type) or { return none }
+		}
 	}
 	normalized_element := fastc_normalize_inferred_type(element_type)
 	if is_fixed {
@@ -3099,6 +3103,55 @@ fn (g &Parser) render_array_literal_argument(tokens []FastcExpressionToken, expe
 	return FastcRenderedExpression{
 		source: '((${array_type})builtin__new_array_from_c_array(${items.len}, ${items.len}, sizeof(${normalized_element}), (${normalized_element}[]){${rendered_items.join(',')}}))'
 		typ:    array_type
+	}
+}
+
+fn (g &Parser) render_selfhost_simple_array_literal_item(tokens []FastcExpressionToken, expected_type string) ?string {
+	if !g.selfhost || expected_type in ['Option', 'voidptr'] {
+		return none
+	}
+	if tokens.len == 4 && tokens[0].tok == .name && tokens[1].tok == .lpar
+		&& tokens[3].tok == .rpar && tokens[2].source == '' {
+		cast_type := fastc_primitive_c_type(tokens[0].lit) or { return none }
+		if cast_type != expected_type.trim_right('*') || expected_type.ends_with('*') {
+			return none
+		}
+		inner := g.render_selfhost_simple_array_literal_item(tokens[2..3], cast_type) or {
+			return none
+		}
+		return '((${cast_type})(${inner}))'
+	}
+	if tokens.len != 1 || tokens[0].source != '' {
+		return none
+	}
+	item := tokens[0]
+	return match item.tok {
+		.number {
+			if expected_type.ends_with('*') {
+				if item.lit == '0' {
+					'NULL'
+				} else {
+					return none
+				}
+			} else {
+				fastc_c_selfhost_number(item.lit)
+			}
+		}
+		.string {
+			literal := fastc_c_string(item.lit) or { return none }
+			'_S(${literal})'
+		}
+		.char {
+			if item.lit.starts_with('c:') {
+				fastc_c_string("'" + item.lit['c:'.len..] + "'") or { return none }
+			} else {
+				fastc_c_rune(item.lit) or { return none }
+			}
+		}
+		.key_true { '((bool)true)' }
+		.key_false { '((bool)false)' }
+		.key_nil { 'NULL' }
+		else { return none }
 	}
 }
 

--- a/vlib/v3/gen/fastc/source.v
+++ b/vlib/v3/gen/fastc/source.v
@@ -60,15 +60,33 @@ fn fastc_resolve_c_pseudo_paths(raw string, vroot string, source_file string) st
 	return result
 }
 
+fn fastc_load_source(path string, prefs &pref.Preferences) FastcLoadedSource {
+	source := os.read_file(path) or {
+		return FastcLoadedSource{
+			failed:        true
+			error_message: err.msg()
+		}
+	}
+	header := fastc_scan_source_header(source, path, prefs) or {
+		return FastcLoadedSource{
+			failed:        true
+			error_message: err.msg()
+		}
+	}
+	return FastcLoadedSource{
+		source: source
+		header: header
+	}
+}
+
 fn fastc_resolve_source_files(paths []string, prefs &pref.Preferences) !([]FastcSourceFile, map[string]string) {
 	mut queue := []FastcQueuedSource{}
 	if prefs.building_v {
 		builtin_dir := prefs.get_vlib_module_path('builtin')
-		for builtin_file in pref.get_v_files_from_dir_for_target(builtin_dir, prefs.user_defines,
-			prefs.target) {
+		for builtin_file in pref.get_v_files_from_dir_for_target(builtin_dir, prefs.user_defines, prefs.target) {
 			if fastc_source_file_matches_backend(builtin_file) {
 				queue << FastcQueuedSource{
-					path:        builtin_file
+					path: builtin_file
 					module_name: 'builtin'
 				}
 			}
@@ -106,84 +124,163 @@ fn fastc_resolve_source_files(paths []string, prefs &pref.Preferences) !([]Fastc
 	// directory enumeration are syscalls, so both are memoized for the walk.
 	mut real_path_cache := map[string]string{}
 	mut module_dir_files := map[string][]string{}
-	for queue.len > 0 {
-		queued := queue[0]
-		queue.delete(0)
-		mut path := ''
-		if cached := real_path_cache[queued.path] {
-			path = cached
-		} else {
-			path = os.real_path(queued.path)
-			real_path_cache[queued.path] = path
-		}
-		if seen[path] {
-			loaded := path_module[path] or { '' }
-			if queued.module_name != '' && loaded != '' && loaded != queued.module_name {
-				module_aliases[queued.module_name] = loaded
-			}
-			continue
-		}
-		if !os.is_file(path) {
-			return error('fastc source file `${path}` does not exist')
-		}
-		seen[path] = true
-		source := os.read_file(path)!
-		mut header := fastc_scan_source_header(source, path, prefs)!
-		if queued.module_name != '' {
-			expected_module_name := queued.module_name.all_after_last('.')
-			if header.module_name != expected_module_name {
-				return error('fastc imported source `${path}` declares module `${header.module_name}` instead of `${expected_module_name}`')
-			}
-			header = FastcSourceHeader{
-				module_name:             queued.module_name
-				imports:                 header.imports
-				import_order:            header.import_order
-				blank_imports:           header.blank_imports
-				has_globals:             header.has_globals
-				has_constants:           header.has_constants
-				has_global_declarations: header.has_global_declarations
-			}
-		}
-		sources << FastcSourceFile{
-			path:   path
-			source: source
-			header: header
-		}
-		path_module[path] = header.module_name
-		mut discovered_imports := map[string]bool{}
-		for imported_module in fastc_header_imported_modules(header) {
-			if discovered_imports[imported_module] {
-				continue
-			}
-			discovered_imports[imported_module] = true
-			module_dir := prefs.get_module_path(imported_module, path)
-			if module_dir == '' {
-				return error('fastc cannot resolve imported module `${imported_module}` from `${path}`')
-			}
-			mut module_files := []string{}
-			if cached := module_dir_files[module_dir] {
-				module_files = cached.clone()
+	mut module_path_cache := map[string]string{}
+	mut module_dir_modules := map[string]string{}
+	mut scheduled_paths := map[string]bool{}
+	mut queue_index := 0
+	for queue_index < queue.len {
+		// Freeze the current discovery wave. Its files are independent until their
+		// headers have been scanned, so load them concurrently and merge in queue order.
+		wave_end := queue.len
+		mut wave_paths := []string{cap: wave_end - queue_index}
+		mut wave_modules := []string{cap: wave_end - queue_index}
+		mut pending_alias_paths := []string{}
+		mut pending_alias_modules := []string{}
+		for queue_index < wave_end {
+			queued := queue[queue_index]
+			queue_index++
+			mut path := ''
+			if prefs.building_v {
+				// The self-host driver canonicalizes its entry path and derives vroot
+				// from it, so every queued vlib path is already absolute and canonical.
+				path = queued.path
+			} else if cached := real_path_cache[queued.path] {
+				path = cached
 			} else {
-				for module_file in pref.get_v_files_from_dir_for_target(module_dir,
-					prefs.user_defines, prefs.target) {
-					if fastc_source_file_matches_backend(module_file) {
-						module_files << module_file
+				path = os.real_path(queued.path)
+				real_path_cache[queued.path] = path
+			}
+			if seen[path] {
+				loaded := path_module[path] or { '' }
+				if queued.module_name != '' && loaded != queued.module_name {
+					if loaded != '' {
+						module_aliases[queued.module_name] = loaded
+					} else {
+						// The duplicate belongs to this same wave; resolve its alias after
+						// the first occurrence's header has supplied the canonical module.
+						pending_alias_paths << path
+						pending_alias_modules << queued.module_name
 					}
 				}
-				module_dir_files[module_dir] = module_files
+				continue
 			}
-			for module_file in module_files {
-				mut module_file_real := ''
-				if cached := real_path_cache[module_file] {
-					module_file_real = cached
-				} else {
-					module_file_real = os.real_path(module_file)
-					real_path_cache[module_file] = module_file_real
+			if !os.is_file(path) {
+				return error('fastc source file `${path}` does not exist')
+			}
+			seen[path] = true
+			scheduled_paths[path] = true
+			wave_paths << path
+			wave_modules << queued.module_name
+		}
+		loaded_sources := fastc_load_source_headers(wave_paths, prefs)
+		wave_source_start := sources.len
+		for i, loaded_source in loaded_sources {
+			if loaded_source.failed {
+				return error(loaded_source.error_message)
+			}
+			path := wave_paths[i]
+			queued_module := wave_modules[i]
+			mut header := loaded_source.header
+			if queued_module != '' {
+				expected_module_name := queued_module.all_after_last('.')
+				if header.module_name != expected_module_name {
+					return error('fastc imported source `${path}` declares module `${header.module_name}` instead of `${expected_module_name}`')
 				}
-				if !seen[module_file_real] {
-					queue << FastcQueuedSource{
-						path:        module_file
-						module_name: imported_module
+				header = FastcSourceHeader{
+					module_name: queued_module
+					imports: header.imports
+					import_order: header.import_order
+					blank_imports: header.blank_imports
+					has_globals: header.has_globals
+					has_constants: header.has_constants
+					has_global_declarations: header.has_global_declarations
+				}
+			}
+			sources << FastcSourceFile{
+				path: path
+				source: loaded_source.source
+				header: header
+			}
+			path_module[path] = header.module_name
+		}
+		for i, alias_path in pending_alias_paths {
+			loaded := path_module[alias_path] or { '' }
+			alias_module := pending_alias_modules[i]
+			if loaded != '' && loaded != alias_module {
+				module_aliases[alias_module] = loaded
+			}
+		}
+		for source_file in sources[wave_source_start..] {
+			mut discovered_imports := map[string]bool{}
+			for imported_module in fastc_header_imported_modules(source_file.header) {
+				if discovered_imports[imported_module] {
+					continue
+				}
+				discovered_imports[imported_module] = true
+				module_cache_key := if prefs.building_v {
+					imported_module
+				} else {
+					os.dir(source_file.path) + '\x00' + imported_module
+				}
+				mut module_dir := ''
+				mut newly_resolved_module := false
+				if module_cache_key in module_path_cache {
+					module_dir = module_path_cache[module_cache_key]
+				} else {
+					if prefs.building_v {
+						vlib_module_dir := prefs.get_vlib_module_path(imported_module)
+						// Alias modules need the generic resolver to follow `alias.v`.
+						if os.is_dir(vlib_module_dir)
+							&& !os.is_file(os.join_path_single(vlib_module_dir, 'alias.v')) {
+							module_dir = vlib_module_dir
+						} else {
+							module_dir = prefs.get_module_path(imported_module, source_file.path)
+						}
+					} else {
+						module_dir = prefs.get_module_path(imported_module, source_file.path)
+					}
+					module_path_cache[module_cache_key] = module_dir
+					newly_resolved_module = true
+				}
+				if module_dir == '' {
+					return error('fastc cannot resolve imported module `${imported_module}` from `${source_file.path}`')
+				}
+				if newly_resolved_module {
+					if loaded_module := module_dir_modules[module_dir] {
+						if loaded_module != imported_module {
+							module_aliases[imported_module] = loaded_module
+						}
+					} else {
+						module_dir_modules[module_dir] = imported_module
+					}
+				}
+				mut module_files := []string{}
+				if cached := module_dir_files[module_dir] {
+					module_files = cached.clone()
+				} else {
+					for module_file in pref.get_v_files_from_dir_for_target(module_dir, prefs.user_defines, prefs.target) {
+						if fastc_source_file_matches_backend(module_file) {
+							module_files << module_file
+						}
+					}
+					module_dir_files[module_dir] = module_files
+				}
+				for module_file in module_files {
+					mut module_file_real := ''
+					if prefs.building_v {
+						module_file_real = module_file
+					} else if cached := real_path_cache[module_file] {
+						module_file_real = cached
+					} else {
+						module_file_real = os.real_path(module_file)
+						real_path_cache[module_file] = module_file_real
+					}
+					if !scheduled_paths[module_file_real] {
+						scheduled_paths[module_file_real] = true
+						queue << FastcQueuedSource{
+							path: module_file
+							module_name: imported_module
+						}
 					}
 				}
 			}
@@ -477,33 +574,37 @@ fn fastc_scan_source_header(source string, path string, prefs &pref.Preferences)
 			}
 		}
 	}
+	has_constants, has_global_declarations := fastc_source_declaration_flags(source)
 	return FastcSourceHeader{
 		module_name:             module_name
 		imports:                 imports
 		import_order:            import_order
 		blank_imports:           blank_imports
 		has_globals:             has_globals
-		has_constants:           fastc_source_contains_word(source, 'const')
-		has_global_declarations: fastc_source_contains_word(source, '__global')
+		has_constants:           has_constants
+		has_global_declarations: has_global_declarations
 	}
 }
 
-fn fastc_source_contains_word(source string, word string) bool {
-	mut start := 0
-	for start < source.len {
-		index := source.index_after_(word, start)
-		if index < 0 {
-			return false
+fn fastc_source_declaration_flags(source string) (bool, bool) {
+	mut has_constants := false
+	mut has_global_declarations := false
+	for i := 0; i < source.len && (!has_constants || !has_global_declarations); i++ {
+		if i > 0 && fastc_identifier_byte(source[i - 1]) {
+			continue
 		}
-		end := index + word.len
-		before_is_identifier := index > 0 && fastc_identifier_byte(source[index - 1])
-		after_is_identifier := end < source.len && fastc_identifier_byte(source[end])
-		if !before_is_identifier && !after_is_identifier {
-			return true
+		if !has_constants && source[i] == `c` && i + 5 <= source.len
+			&& source[i..i + 5] == 'const'
+			&& (i + 5 == source.len || !fastc_identifier_byte(source[i + 5])) {
+			has_constants = true
 		}
-		start = end
+		if !has_global_declarations && source[i] == `_` && i + 8 <= source.len
+			&& source[i..i + 8] == '__global'
+			&& (i + 8 == source.len || !fastc_identifier_byte(source[i + 8])) {
+			has_global_declarations = true
+		}
 	}
-	return false
+	return has_constants, has_global_declarations
 }
 
 fn fastc_identifier_byte(value u8) bool {

--- a/vlib/v3/gen/fastc/source.v
+++ b/vlib/v3/gen/fastc/source.v
@@ -125,8 +125,7 @@ fn fastc_resolve_source_files(paths []string, prefs &pref.Preferences) !([]Fastc
 	mut real_path_cache := map[string]string{}
 	mut module_dir_files := map[string][]string{}
 	mut module_path_cache := map[string]string{}
-	mut module_dir_modules := map[string]string{}
-	mut scheduled_paths := map[string]bool{}
+	mut scheduled_path_modules := map[string]string{}
 	mut queue_index := 0
 	for queue_index < queue.len {
 		// Freeze the current discovery wave. Its files are independent until their
@@ -168,7 +167,7 @@ fn fastc_resolve_source_files(paths []string, prefs &pref.Preferences) !([]Fastc
 				return error('fastc source file `${path}` does not exist')
 			}
 			seen[path] = true
-			scheduled_paths[path] = true
+			scheduled_path_modules[path] = queued.module_name
 			wave_paths << path
 			wave_modules << queued.module_name
 		}
@@ -223,7 +222,6 @@ fn fastc_resolve_source_files(paths []string, prefs &pref.Preferences) !([]Fastc
 					os.dir(source_file.path) + '\x00' + imported_module
 				}
 				mut module_dir := ''
-				mut newly_resolved_module := false
 				if module_cache_key in module_path_cache {
 					module_dir = module_path_cache[module_cache_key]
 				} else {
@@ -240,19 +238,9 @@ fn fastc_resolve_source_files(paths []string, prefs &pref.Preferences) !([]Fastc
 						module_dir = prefs.get_module_path(imported_module, source_file.path)
 					}
 					module_path_cache[module_cache_key] = module_dir
-					newly_resolved_module = true
 				}
 				if module_dir == '' {
 					return error('fastc cannot resolve imported module `${imported_module}` from `${source_file.path}`')
-				}
-				if newly_resolved_module {
-					if loaded_module := module_dir_modules[module_dir] {
-						if loaded_module != imported_module {
-							module_aliases[imported_module] = loaded_module
-						}
-					} else {
-						module_dir_modules[module_dir] = imported_module
-					}
 				}
 				mut module_files := []string{}
 				if cached := module_dir_files[module_dir] {
@@ -275,12 +263,17 @@ fn fastc_resolve_source_files(paths []string, prefs &pref.Preferences) !([]Fastc
 						module_file_real = os.real_path(module_file)
 						real_path_cache[module_file] = module_file_real
 					}
-					if !scheduled_paths[module_file_real] {
-						scheduled_paths[module_file_real] = true
-						queue << FastcQueuedSource{
-							path: module_file
-							module_name: imported_module
+					if scheduled_module := scheduled_path_modules[module_file_real] {
+						loaded_module := path_module[module_file_real] or { scheduled_module }
+						if loaded_module != '' && loaded_module != imported_module {
+							module_aliases[imported_module] = loaded_module
 						}
+						continue
+					}
+					scheduled_path_modules[module_file_real] = imported_module
+					queue << FastcQueuedSource{
+						path: module_file
+						module_name: imported_module
 					}
 				}
 			}

--- a/vlib/v3/gen/fastc/types.v
+++ b/vlib/v3/gen/fastc/types.v
@@ -1136,30 +1136,42 @@ fn fastc_is_signed_integer_type(typ string) bool {
 }
 
 fn fastc_nondecimal_literal_is_type_sensitive(literal string) bool {
-	clean := literal.replace('_', '')
+	clean := fastc_number_without_separators(literal)
+	return fastc_clean_nondecimal_literal_is_type_sensitive(clean)
+}
+
+fn fastc_clean_nondecimal_literal_is_type_sensitive(clean string) bool {
 	if clean.len <= 2 || clean[0] != `0` {
 		return false
 	}
-	digits := clean[2..].trim_left('0')
+	mut first_digit := 2
+	for first_digit < clean.len && clean[first_digit] == `0` {
+		first_digit++
+	}
+	digits_len := clean.len - first_digit
 	if clean[1] in [`x`, `X`] {
-		if digits.len > 8 {
+		if digits_len > 8 {
 			return true
 		}
-		return digits.len == 8 && ((digits[0] >= `8` && digits[0] <= `9`)
-			|| (digits[0] >= `a` && digits[0] <= `f`)
-			|| (digits[0] >= `A` && digits[0] <= `F`))
+		return digits_len == 8 && ((clean[first_digit] >= `8` && clean[first_digit] <= `9`)
+			|| (clean[first_digit] >= `a` && clean[first_digit] <= `f`)
+			|| (clean[first_digit] >= `A` && clean[first_digit] <= `F`))
 	}
 	if clean[1] in [`b`, `B`] {
-		return digits.len >= 32
+		return digits_len >= 32
 	}
 	if clean[1] in [`o`, `O`] {
-		return digits.len > 11 || (digits.len == 11 && digits[0] >= `2`)
+		return digits_len > 11 || (digits_len == 11 && clean[first_digit] >= `2`)
 	}
 	return false
 }
 
 fn fastc_decimal_literal_is_type_sensitive(literal string) bool {
-	clean := literal.replace('_', '')
+	clean := fastc_number_without_separators(literal)
+	return fastc_clean_decimal_literal_is_type_sensitive(clean)
+}
+
+fn fastc_clean_decimal_literal_is_type_sensitive(clean string) bool {
 	if clean.len == 0 || clean.contains_any('.eE') {
 		return false
 	}
@@ -1168,27 +1180,39 @@ fn fastc_decimal_literal_is_type_sensitive(literal string) bool {
 			return false
 		}
 	}
-	digits := clean.trim_left('0')
-	int_max_literal := '2147483647'
-	if digits.len != int_max_literal.len {
-		return digits.len > int_max_literal.len
+	mut first_digit := 0
+	for first_digit < clean.len && clean[first_digit] == `0` {
+		first_digit++
 	}
-	for i in 0 .. digits.len {
-		if digits[i] != int_max_literal[i] {
-			return digits[i] > int_max_literal[i]
+	digits_len := clean.len - first_digit
+	int_max_literal := '2147483647'
+	if digits_len != int_max_literal.len {
+		return digits_len > int_max_literal.len
+	}
+	for i in 0 .. digits_len {
+		if clean[first_digit + i] != int_max_literal[i] {
+			return clean[first_digit + i] > int_max_literal[i]
 		}
 	}
 	return false
 }
 
+@[inline]
+fn fastc_number_without_separators(literal string) string {
+	if literal.index_u8(`_`) < 0 {
+		return literal
+	}
+	return literal.replace('_', '')
+}
+
 fn fastc_c_number(literal string) !string {
-	clean := literal.replace('_', '')
-	if fastc_decimal_literal_is_type_sensitive(literal) {
+	clean := fastc_number_without_separators(literal)
+	if fastc_clean_decimal_literal_is_type_sensitive(clean) {
 		// C assigns oversized decimal tokens a wider type before any surrounding
 		// operation. Reject them until the direct parser can preserve V inference.
 		return error('fastc parser does not support oversized decimal literal expressions')
 	}
-	if fastc_nondecimal_literal_is_type_sensitive(literal) {
+	if fastc_clean_nondecimal_literal_is_type_sensitive(clean) {
 		return error('fastc parser does not support high-bit nondecimal literals')
 	}
 	if clean.len > 2 && clean[0] == `0` && clean[1] in [`o`, `O`] {
@@ -1207,16 +1231,16 @@ fn fastc_c_number(literal string) !string {
 }
 
 fn fastc_c_selfhost_number(literal string) string {
-	clean := literal.replace('_', '')
+	clean := fastc_number_without_separators(literal)
 	if clean.len > 2 && clean[0] == `0` && clean[1] in [`o`, `O`] {
-		return '0${clean[2..]}${if fastc_nondecimal_literal_is_type_sensitive(literal) {
+		return '0${clean[2..]}${if fastc_clean_nondecimal_literal_is_type_sensitive(clean) {
 			'ULL'
 		} else {
 			''
 		}}'
 	}
-	if fastc_decimal_literal_is_type_sensitive(literal)
-		|| fastc_nondecimal_literal_is_type_sensitive(literal) {
+	if fastc_clean_decimal_literal_is_type_sensitive(clean)
+		|| fastc_clean_nondecimal_literal_is_type_sensitive(clean) {
 		return clean + 'ULL'
 	}
 	if clean.len < 2 || clean[0] != `0` || !clean[1].is_digit() || clean.contains_any('.eE') {


### PR DESCRIPTION
## Summary

- batch and parallelize source discovery, then balance per-file generation with largest-first scheduling
- avoid repeated map clones, expression-slice copies, numeric normalization allocations, and redundant rendering/scans
- preserve deterministic source ordering and module alias resolution
- isolate repeated `FASTC_BENCH` samples in child processes so the `-gc none` self-host compiler does not retain every generation

## Performance

Measured with a production-built FastC compiler generating `vlib/v3/v3.v`:

- merged baseline: 69.12 ms
- this PR: 49.50 ms best, about 28% faster
- repeated benchmark peak RSS before: 1.47 GB at repeat 2 and linear growth
- repeated benchmark peak RSS after: 371 MB at repeat 2 and repeat 10

The benchmark stopwatch remains inside the child, so process startup is excluded.

## Validation

- rebuilt `./vnew` with `./v -g -keepc -o ./vnew cmd/v`
- `./vnew -silent test vlib/v3/fastcdriver/`
- focused FastC scheduler, source resolver, declaration scan, literal rendering, and numeric literal tests
- production FastC build with `-prod`
- parallel and forced-serial generation produced identical SHA-256 hashes
- `git diff --check`

The broad compiler suite was not run. The benchmark still reaches the existing post-generation TinyCC operand-type failure; generation completes and is the measured phase.