### PR TITLE
net.imap: add an IMAP4rev1 client

### DIFF
--- a/vlib/net/imap/imap.v
+++ b/vlib/net/imap/imap.v
@@ -1,0 +1,671 @@
+// Package imap implements a client for the Internet Message Access Protocol,
+// version 4rev1, as described in RFC 3501.
+//
+// IMAP is the reading half of the mail pair whose writing half is `net.smtp`:
+// where SMTP hands a message to a server, IMAP browses what a server already
+// holds. Messages stay on the server, so a client selects a mailbox, searches
+// it, and fetches only the parts it wants.
+//
+// Mailbox names are ordinary UTF-8 strings here. They are encoded and decoded
+// on the way in and out, so the modified UTF-7 the protocol carries them in
+// never reaches a caller.
+//
+// A minimal session looks like this:
+//
+// ```v ignore
+// mut c := imap.new_client(
+//     server:   'imap.example.com'
+//     username: 'someone@example.com'
+//     password: 'hunter2'
+//     ssl:      true
+// )!
+// defer { c.close() or {} }
+//
+// inbox := c.select_mailbox('INBOX')!
+// println('${inbox.exists} messages, ${inbox.recent} recent')
+//
+// unread := c.search('UNSEEN')!
+// for msg in c.fetch(unread, '(UID ENVELOPE)')! {
+//     if envelope := msg.envelope {
+//         println('${envelope.subject}')
+//     }
+// }
+// ```
+module imap
+
+import io
+import net
+import net.ssl
+import encoding.base64
+import time
+
+// The port a server listens on depends on whether TLS is negotiated up front.
+pub const default_port = 143
+pub const default_ssl_port = 993
+
+// Every command carries a tag that its completion repeats back, which is what
+// lets a client tell a reply to its command from the mailbox updates a server
+// may interleave with it.
+const tag_prefix = 'a'
+
+// Config holds the settings used to open a session.
+//
+// Leave `port` unset to take 993 when `ssl` is true and 143 otherwise. Set
+// `ssl` for a connection encrypted from the first byte, or `starttls` to
+// upgrade a plain connection once it is open. The two are mutually exclusive.
+pub struct Config {
+pub:
+	server   string
+	port     int
+	username string
+	password string
+	ssl      bool
+	starttls bool
+	timeout  time.Duration
+}
+
+// Client is a connection to an IMAP server.
+pub struct Client {
+	Config
+mut:
+	conn     net.TcpConn
+	ssl_conn &ssl.SSLConn = unsafe { nil }
+	dec      ?&Decoder
+	tag_seq  int
+pub mut:
+	is_open   bool
+	encrypted bool
+	// selected names the mailbox the session is working in, and is empty when
+	// none has been selected.
+	selected string
+	// exists and recent track the counts the server reports, which it may do
+	// during any command as messages arrive or are removed by another client.
+	exists u32
+	recent u32
+}
+
+// new_client opens a session, greets the server, upgrades the connection if
+// asked to, and logs in.
+pub fn new_client(config Config) !&Client {
+	if config.ssl && config.starttls {
+		return error('imap: cannot use both implicit SSL and STARTTLS')
+	}
+	mut c := &Client{
+		Config: config
+	}
+	c.connect()!
+	c.login()!
+	return c
+}
+
+// connect opens the transport and reads the server greeting, without logging
+// in. `new_client` calls it; call it directly only to drive a session by hand.
+pub fn (mut c Client) connect() ! {
+	c.conn = net.dial_tcp('${c.server}:${c.effective_port()}')!
+	if c.timeout != 0 {
+		c.conn.set_read_timeout(c.timeout)
+		c.conn.set_write_timeout(c.timeout)
+	}
+	c.dec = &Decoder{
+		reader: io.new_buffered_reader(reader: c.conn)
+	}
+	c.is_open = true
+
+	if c.ssl {
+		c.upgrade_to_tls()!
+	}
+	// A greeting that turns the connection away leaves nothing to say goodbye
+	// to, so the socket goes rather than being left for the server to time
+	// out.
+	c.read_greeting() or {
+		c.shutdown()
+		return err
+	}
+	if c.starttls {
+		c.run('STARTTLS')!
+		c.upgrade_to_tls()!
+	}
+}
+
+// login authenticates with the LOGIN command, and does nothing when no
+// username was configured.
+pub fn (mut c Client) login() ! {
+	if c.username == '' {
+		return
+	}
+	text, literals := build_args('LOGIN', [c.username, c.password])
+	c.send(text, literals)!
+}
+
+// login_plain authenticates with the SASL PLAIN mechanism instead, which some
+// servers require and others prefer.
+pub fn (mut c Client) login_plain() ! {
+	tag := c.next_tag()
+	c.write_line('${tag} AUTHENTICATE PLAIN')!
+	c.await_continuation(tag)!
+	// RFC 4616: an authorisation identity, an authentication identity and a
+	// password, joined by NUL bytes.
+	c.write_line(base64.encode_str('\0${c.username}\0${c.password}'))!
+	c.read_response(tag)!
+}
+
+// capability returns the extensions the server advertises.
+pub fn (mut c Client) capability() ![]string {
+	return c.run('CAPABILITY')!.capabilities
+}
+
+// supports reports whether the server advertises `name`, which is how an
+// optional command should be guarded before it is sent.
+pub fn (mut c Client) supports(name string) !bool {
+	for cap in c.capability()! {
+		if cap.to_upper() == name.to_upper() {
+			return true
+		}
+	}
+	return false
+}
+
+// noop asks the server for nothing. It keeps the connection alive, and gives
+// the server the chance to report anything that changed in the mailbox.
+pub fn (mut c Client) noop() ! {
+	c.run('NOOP')!
+}
+
+// list_mailboxes returns the mailboxes matching `pattern` below `reference`.
+//
+// The usual call is `list_mailboxes('', '*')`, which lists everything the
+// account can see. `%` matches within one level of the hierarchy where `*`
+// crosses levels.
+pub fn (mut c Client) list_mailboxes(reference string, pattern string) ![]MailboxInfo {
+	return c.run_list('LIST', reference, pattern)
+}
+
+// list_subscribed returns the subscribed mailboxes matching `pattern`, which
+// is the set a mail client would show by default.
+pub fn (mut c Client) list_subscribed(reference string, pattern string) ![]MailboxInfo {
+	return c.run_list('LSUB', reference, pattern)
+}
+
+// select_mailbox opens a mailbox for reading and writing, and returns its
+// state. Later fetches, searches and stores act on it.
+pub fn (mut c Client) select_mailbox(name string) !Mailbox {
+	return c.open_mailbox('SELECT', name)
+}
+
+// examine_mailbox opens a mailbox read-only. It behaves like
+// `select_mailbox`, except that nothing the session does marks messages as
+// seen or otherwise alters the mailbox.
+pub fn (mut c Client) examine_mailbox(name string) !Mailbox {
+	return c.open_mailbox('EXAMINE', name)
+}
+
+// status reports on a mailbox without selecting it, which is how a client
+// polls for new mail while working in another mailbox.
+//
+// `items` names what to ask for: MESSAGES, RECENT, UIDNEXT, UIDVALIDITY and
+// UNSEEN.
+pub fn (mut c Client) status(name string, items []string) !MailboxStatus {
+	if items.len == 0 {
+		return error('imap: a STATUS command must ask for at least one item')
+	}
+	text, literals := build_args('STATUS', [utf7_encode(name)])
+	last := text.len - 1
+	mut tail := text.clone()
+	tail[last] = '${text[last]} (${items.join(' ')})'
+	res := c.send(tail, literals)!
+	if res.statuses.len == 0 {
+		return error('imap: the server reported no status for `${name}`')
+	}
+	return res.statuses[0]
+}
+
+// create_mailbox creates a mailbox.
+pub fn (mut c Client) create_mailbox(name string) ! {
+	c.run_with_mailbox('CREATE', name)!
+}
+
+// delete_mailbox deletes a mailbox and everything in it.
+pub fn (mut c Client) delete_mailbox(name string) ! {
+	c.run_with_mailbox('DELETE', name)!
+}
+
+// subscribe adds a mailbox to the set a client shows by default.
+pub fn (mut c Client) subscribe(name string) ! {
+	c.run_with_mailbox('SUBSCRIBE', name)!
+}
+
+// unsubscribe removes it from that set, without touching the mailbox itself.
+pub fn (mut c Client) unsubscribe(name string) ! {
+	c.run_with_mailbox('UNSUBSCRIBE', name)!
+}
+
+// rename_mailbox renames a mailbox, along with everything below it in the
+// hierarchy.
+pub fn (mut c Client) rename_mailbox(from string, to string) ! {
+	text, literals := build_args('RENAME', [utf7_encode(from), utf7_encode(to)])
+	c.send(text, literals)!
+}
+
+// append adds a message to a mailbox, which is how a sent message is filed
+// into a Sent folder or a draft is saved.
+//
+// `flags` are set on the new message, commonly `\Seen` for a message the user
+// has already read. `stamp` becomes its internal date; pass the zero time to
+// let the server use the moment of delivery.
+pub fn (mut c Client) append(mailbox string, flags []string, stamp time.Time, body []u8) ! {
+	mut head := 'APPEND ${quote_arg(utf7_encode(mailbox))}'
+	if flags.len > 0 {
+		head += ' (${flags.join(' ')})'
+	}
+	// A zero year is the unset time, and means the server should stamp the
+	// message with the moment it took delivery.
+	if stamp.year != 0 {
+		if stamp.month < 1 || stamp.month > 12 {
+			return error('imap: ${stamp.month} is not a month')
+		}
+		head += ' ${quote_arg(format_internal_date(stamp))}'
+	}
+	// The message travels as a literal: it holds line endings, and very
+	// probably octets no quoted string may carry.
+	c.send(['${head} ', ''], [body])!
+}
+
+// search returns the sequence numbers of the messages in the selected mailbox
+// matching `criteria`, which is an IMAP search key such as `UNSEEN`,
+// `FROM "someone@example.com"` or `SINCE 1-Jan-2026`.
+pub fn (mut c Client) search(criteria string) !SeqSet {
+	return result_set(c.run('SEARCH ${criteria}')!)
+}
+
+// uid_search behaves like `search` but returns UIDs, which stay valid across
+// sessions where sequence numbers do not.
+pub fn (mut c Client) uid_search(criteria string) !SeqSet {
+	return result_set(c.run('UID SEARCH ${criteria}')!)
+}
+
+// fetch retrieves `items` for each message in `set`.
+//
+// `items` is an IMAP fetch specification. `BODY.PEEK[]` takes the whole
+// message without marking it read, `BODY.PEEK[HEADER]` takes just the
+// headers, and `(UID FLAGS ENVELOPE)` takes metadata alone.
+pub fn (mut c Client) fetch(set SeqSet, items string) ![]Message {
+	return c.run_fetch('FETCH', set, items)
+}
+
+// uid_fetch behaves like `fetch` but addresses messages by UID.
+pub fn (mut c Client) uid_fetch(set SeqSet, items string) ![]Message {
+	return c.run_fetch('UID FETCH', set, items)
+}
+
+// store changes the flags of the messages in `set`, and returns what the
+// server reports the new flags to be.
+//
+// `action` is `+FLAGS` to add, `-FLAGS` to remove, or `FLAGS` to replace.
+// Appending `.SILENT` tells the server not to echo the result back, in which
+// case the returned list is empty.
+pub fn (mut c Client) store(set SeqSet, action string, flags []string) ![]Message {
+	return c.run_store('STORE', set, action, flags)
+}
+
+// uid_store behaves like `store` but addresses messages by UID.
+pub fn (mut c Client) uid_store(set SeqSet, action string, flags []string) ![]Message {
+	return c.run_store('UID STORE', set, action, flags)
+}
+
+// mark_seen flags messages as read.
+pub fn (mut c Client) mark_seen(set SeqSet) ! {
+	c.store(set, '+FLAGS.SILENT', ['\\Seen'])!
+}
+
+// mark_deleted flags messages for deletion. They go on being readable until
+// `expunge` runs.
+pub fn (mut c Client) mark_deleted(set SeqSet) ! {
+	c.store(set, '+FLAGS.SILENT', ['\\Deleted'])!
+}
+
+// copy copies messages into another mailbox, leaving the originals in place.
+pub fn (mut c Client) copy(set SeqSet, dest string) ! {
+	c.run_transfer('COPY', set, dest)!
+}
+
+// uid_copy behaves like `copy` but addresses messages by UID.
+pub fn (mut c Client) uid_copy(set SeqSet, dest string) ! {
+	c.run_transfer('UID COPY', set, dest)!
+}
+
+// move moves messages into another mailbox in one step (RFC 6851), which a
+// copy followed by a delete cannot do without a window where the message
+// exists twice or not at all.
+//
+// It needs the MOVE capability; check `supports('MOVE')` first when the server
+// is not known.
+pub fn (mut c Client) move(set SeqSet, dest string) ! {
+	c.run_transfer('MOVE', set, dest)!
+}
+
+// uid_move behaves like `move` but addresses messages by UID.
+pub fn (mut c Client) uid_move(set SeqSet, dest string) ! {
+	c.run_transfer('UID MOVE', set, dest)!
+}
+
+// expunge permanently removes every message flagged `\Deleted` from the
+// selected mailbox, and returns the sequence numbers the server reported as
+// removed.
+//
+// The numbers are reported one at a time, each already renumbered by the
+// removals before it, which is why the same number can appear twice.
+pub fn (mut c Client) expunge() ![]u32 {
+	return c.run('EXPUNGE')!.expunged
+}
+
+// check asks the server to bring its own housekeeping up to date. It is not a
+// NOOP: it may take real time, and it is the right thing to call before a long
+// idle period.
+pub fn (mut c Client) check() ! {
+	c.run('CHECK')!
+}
+
+// close_mailbox leaves the selected mailbox, silently expunging any message
+// flagged `\Deleted` on the way out.
+pub fn (mut c Client) close_mailbox() ! {
+	c.run('CLOSE')!
+	c.selected = ''
+}
+
+// unselect leaves the selected mailbox without expunging anything (RFC 3691),
+// which is what a client wants when the user simply navigated away.
+//
+// It needs the UNSELECT capability.
+pub fn (mut c Client) unselect() ! {
+	c.run('UNSELECT')!
+	c.selected = ''
+}
+
+// logout ends the session politely, giving the server the chance to close the
+// connection itself.
+pub fn (mut c Client) logout() ! {
+	c.run('LOGOUT')!
+}
+
+// close logs out and tears down the connection. It is safe to call on a
+// session that is already closed.
+pub fn (mut c Client) close() ! {
+	if !c.is_open {
+		return
+	}
+	c.logout() or {}
+	c.shutdown()
+}
+
+// shutdown tears the transport down without saying goodbye, which is what a
+// session that never opened properly is left with.
+fn (mut c Client) shutdown() {
+	if c.encrypted {
+		c.ssl_conn.shutdown() or {}
+		c.encrypted = false
+	}
+	c.conn.close() or {}
+	c.is_open = false
+	c.selected = ''
+}
+
+// command sends one command with a fresh tag and returns the completion text,
+// so that a caller can reach an extension this module does not wrap. The tag
+// is added here; pass the command without one.
+pub fn (mut c Client) command(cmd string) !string {
+	return c.run(cmd)!.text
+}
+
+// run sends a command that needs no literal and reads its response.
+fn (mut c Client) run(cmd string) !Response {
+	return c.send([cmd], [])
+}
+
+// send writes a command and reads its response. `text` and `literals` are
+// interleaved: the first text, then the first literal, then the second text,
+// and so on, which is how an argument no quoted string can hold is passed.
+fn (mut c Client) send(text []string, literals [][]u8) !Response {
+	if text.len != literals.len + 1 {
+		return error('imap: a command needs one more text part than it has literals')
+	}
+	tag := c.next_tag()
+	mut line := '${tag} ${text[0]}'
+	for i, payload in literals {
+		// The server has to agree to take the octets before they are sent.
+		c.write_line('${line}{${payload.len}}')!
+		c.await_continuation(tag)!
+		c.write_raw(payload)!
+		line = text[i + 1]
+	}
+	c.write_line(line)!
+	mut res := c.read_response(tag)!
+	c.absorb(res)
+	return res
+}
+
+// await_continuation reads until the server asks for the rest of the command.
+//
+// It may send mailbox updates first, or reject the command outright, and both
+// have to be handled: a client that assumed the next line was the `+` would
+// send a message body into the middle of a response.
+fn (mut c Client) await_continuation(tag string) ! {
+	for {
+		mut d := c.decoder()!
+		if d.accept(`+`)! {
+			d.text()!
+			d.crlf()!
+			return
+		}
+		if d.accept(`*`)! {
+			d.sp()!
+			mut res := Response{}
+			c.read_untagged(mut d, mut res)!
+			d.crlf()!
+			c.absorb(res)
+			continue
+		}
+		// A tagged completion here means the command was refused before the
+		// argument was ever sent.
+		got := d.astring()!
+		d.sp()!
+		mut res := Response{}
+		read_completion(mut d, mut res)!
+		d.crlf()!
+		if got != tag {
+			return error('imap: the server answered tag `${got}` while `${tag}` was outstanding')
+		}
+		return error('imap: ${res.status} ${res.text}')
+	}
+}
+
+// read_greeting reads the untagged response a server opens with.
+fn (mut c Client) read_greeting() ! {
+	mut d := c.decoder()!
+	d.expect(`*`)!
+	d.sp()!
+	mut res := Response{}
+	read_completion(mut d, mut res)!
+	d.crlf()!
+	status := res.status
+	// `OK` is a usable connection and `PREAUTH` one the transport already
+	// authenticated. `BYE` is the server turning the connection away.
+	if status == .bye {
+		c.is_open = false
+		return error('imap: the server refused the connection: ${res.text}')
+	}
+	if status != .ok && status != .preauth {
+		return error('imap: unexpected greeting: ${status} ${res.text}')
+	}
+}
+
+// absorb takes the mailbox updates out of a response. A server reports new
+// mail and removals during whatever command happens to be running, so these
+// arrive attached to a reply that has nothing to do with them.
+fn (mut c Client) absorb(res Response) {
+	if res.has_exists {
+		c.exists = res.exists
+	}
+	if res.has_recent {
+		c.recent = res.recent
+	}
+}
+
+// result_set takes the search result out of a response, whichever of the two
+// forms the server answered in.
+fn result_set(res Response) SeqSet {
+	if res.has_set {
+		return res.set
+	}
+	return seq_set(res.numbers)
+}
+
+fn (mut c Client) run_list(verb string, reference string, pattern string) ![]MailboxInfo {
+	// The pattern holds the wildcards, so it is encoded but never given the
+	// literal treatment that would hide them from the server.
+	text, literals := build_args(verb, [utf7_encode(reference), utf7_encode(pattern)])
+	return c.send(text, literals)!.mailboxes
+}
+
+fn (mut c Client) run_with_mailbox(verb string, name string) !Response {
+	text, literals := build_args(verb, [utf7_encode(name)])
+	return c.send(text, literals)
+}
+
+fn (mut c Client) run_fetch(verb string, set SeqSet, items string) ![]Message {
+	if set.is_empty() {
+		return []Message{}
+	}
+	return c.run('${verb} ${set} ${items}')!.messages
+}
+
+fn (mut c Client) run_store(verb string, set SeqSet, action string, flags []string) ![]Message {
+	if set.is_empty() {
+		return []Message{}
+	}
+	return c.run('${verb} ${set} ${action} (${flags.join(' ')})')!.messages
+}
+
+fn (mut c Client) run_transfer(verb string, set SeqSet, dest string) !Response {
+	if set.is_empty() {
+		return Response{}
+	}
+	text, literals := build_args('${verb} ${set}', [utf7_encode(dest)])
+	return c.send(text, literals)
+}
+
+// open_mailbox runs SELECT or EXAMINE and reads back the state the server
+// reports alongside it.
+fn (mut c Client) open_mailbox(verb string, name string) !Mailbox {
+	res := c.run_with_mailbox(verb, name)!
+	c.selected = name
+	c.exists = res.exists
+	c.recent = res.recent
+	return Mailbox{
+		name: name
+		exists: res.exists
+		recent: res.recent
+		unseen: res.unseen
+		flags: res.flags
+		permanent_flags: res.permanent_flags
+		uid_validity: res.uid_validity
+		uid_next: res.uid_next
+		// EXAMINE is read-only by definition, and a server may hand back a
+		// read-only mailbox to a SELECT as well.
+		read_only: res.read_only || verb == 'EXAMINE'
+	}
+}
+
+fn (c &Client) effective_port() int {
+	if c.port != 0 {
+		return c.port
+	}
+	if c.ssl {
+		return default_ssl_port
+	}
+	return default_port
+}
+
+// upgrade_to_tls wraps the current connection in TLS and points the decoder at
+// it.
+fn (mut c Client) upgrade_to_tls() ! {
+	c.ssl_conn = ssl.new_ssl_conn()!
+	c.ssl_conn.connect(mut c.conn, c.server) or {
+		return error('imap: TLS handshake with ${c.server} failed: ${err}')
+	}
+	c.dec = &Decoder{
+		reader: io.new_buffered_reader(reader: c.ssl_conn)
+	}
+	c.encrypted = true
+}
+
+fn (mut c Client) decoder() !&Decoder {
+	return c.dec or { return error('imap: the session is not connected') }
+}
+
+// next_tag returns the tag for the next command. Tags only have to be unique
+// within a session, so a counter is enough.
+fn (mut c Client) next_tag() string {
+	c.tag_seq++
+	return '${tag_prefix}${c.tag_seq:04}'
+}
+
+fn (mut c Client) write_line(line string) ! {
+	$if imap_debug? {
+		eprintln('[imap send] ${line}')
+	}
+	c.write_raw('${line}\r\n'.bytes())!
+}
+
+fn (mut c Client) write_raw(data []u8) ! {
+	if c.encrypted {
+		c.ssl_conn.write(data)!
+		return
+	}
+	c.conn.write(data)!
+}
+
+// build_args renders a command and its arguments, splitting out the ones a
+// quoted string cannot hold so that they travel as literals.
+fn build_args(verb string, args []string) ([]string, [][]u8) {
+	mut text := []string{}
+	mut literals := [][]u8{}
+	mut current := verb
+	for a in args {
+		current += ' '
+		if !needs_literal(a) {
+			current += quote_arg(a)
+			continue
+		}
+		// The text ends here; the literal introducer and the octets follow.
+		text << current
+		literals << a.bytes()
+		current = ''
+	}
+	text << current
+	return text, literals
+}
+
+// needs_literal reports whether a value has to be sent as a literal. A quoted
+// string may not span lines, and is defined over seven bit characters.
+fn needs_literal(s string) bool {
+	for ch in s {
+		if ch == 0 || ch == `\r` || ch == `\n` || ch >= 0x80 {
+			return true
+		}
+	}
+	return false
+}
+
+// quote_arg wraps a value as a quoted string, escaping the two characters that
+// would otherwise end it early.
+fn quote_arg(s string) string {
+	escaped := s.replace('\\', '\\\\').replace('"', '\\"')
+	return '"${escaped}"'
+}
+
+// format_internal_date renders a time the way APPEND wants it, which is a
+// fixed two digit day and an English month.
+fn format_internal_date(t time.Time) string {
+	months := ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+	return '${t.day:02}-${months[t.month - 1]}-${t.year:04} ${t.hour:02}:${t.minute:02}:${t.second:02} +0000'
+}

--- a/vlib/net/imap/imap.v
+++ b/vlib/net/imap/imap.v
@@ -502,6 +502,16 @@ fn (mut c Client) read_greeting() ! {
 // mail and removals during whatever command happens to be running, so these
 // arrive attached to a reply that has nothing to do with them.
 fn (mut c Client) absorb(res Response) {
+	// Each EXPUNGE takes one message out of the mailbox and renumbers what
+	// follows it. Servers are not obliged to send a fresh EXISTS afterwards,
+	// and Dovecot does not, so a client that waited for one would go on
+	// reporting a count that includes messages it just watched being removed.
+	for _ in res.expunged {
+		if c.exists > 0 {
+			c.exists--
+		}
+	}
+	// An EXISTS the server did send is authoritative over that arithmetic.
 	if res.has_exists {
 		c.exists = res.exists
 	}

--- a/vlib/net/imap/imap.v
+++ b/vlib/net/imap/imap.v
@@ -106,9 +106,7 @@ pub fn (mut c Client) connect() ! {
 		c.conn.set_read_timeout(c.timeout)
 		c.conn.set_write_timeout(c.timeout)
 	}
-	c.dec = &Decoder{
-		reader: io.new_buffered_reader(reader: c.conn)
-	}
+	c.dec = decoder_on(io.new_buffered_reader(reader: c.conn))
 	c.is_open = true
 
 	if c.ssl {
@@ -602,9 +600,7 @@ fn (mut c Client) upgrade_to_tls() ! {
 	c.ssl_conn.connect(mut c.conn, c.server) or {
 		return error('imap: TLS handshake with ${c.server} failed: ${err}')
 	}
-	c.dec = &Decoder{
-		reader: io.new_buffered_reader(reader: c.ssl_conn)
-	}
+	c.dec = decoder_on(io.new_buffered_reader(reader: c.ssl_conn))
 	c.encrypted = true
 }
 
@@ -669,6 +665,18 @@ fn needs_literal(s string) bool {
 // quote_arg wraps a value as a quoted string, escaping the two characters that
 // would otherwise end it early.
 fn quote_arg(s string) string {
+	// Most arguments hold neither character, and the two passes of replace
+	// would allocate twice over for nothing.
+	mut clean := true
+	for ch in s {
+		if ch == `\\` || ch == `"` {
+			clean = false
+			break
+		}
+	}
+	if clean {
+		return '"${s}"'
+	}
 	escaped := s.replace('\\', '\\\\').replace('"', '\\"')
 	return '"${escaped}"'
 }
@@ -676,6 +684,5 @@ fn quote_arg(s string) string {
 // format_internal_date renders a time the way APPEND wants it, which is a
 // fixed two digit day and an English month.
 fn format_internal_date(t time.Time) string {
-	months := ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
-	return '${t.day:02}-${months[t.month - 1]}-${t.year:04} ${t.hour:02}:${t.minute:02}:${t.second:02} +0000'
+	return '${t.day:02}-${month_names[t.month - 1]}-${t.year:04} ${t.hour:02}:${t.minute:02}:${t.second:02} +0000'
 }

--- a/vlib/net/imap/imap.v
+++ b/vlib/net/imap/imap.v
@@ -18,6 +18,7 @@
 //     username: 'someone@example.com'
 //     password: 'hunter2'
 //     ssl:      true
+//     verify:   '/etc/ssl/certs/ca-certificates.crt'
 // )!
 // defer { c.close() or {} }
 //
@@ -104,6 +105,18 @@ pub mut:
 	// during any command as messages arrive or are removed by another client.
 	exists u32
 	recent u32
+}
+
+struct CommandRefusedError {
+	message string
+}
+
+fn (e CommandRefusedError) msg() string {
+	return e.message
+}
+
+fn (_ CommandRefusedError) code() int {
+	return 0
 }
 
 // new_client opens a session, greets the server, upgrades the connection if
@@ -196,11 +209,22 @@ pub fn (mut c Client) login_plain() ! {
 		return
 	}
 	tag := c.next_tag()
-	c.write_line('${tag} AUTHENTICATE PLAIN')!
-	c.await_continuation(tag)!
+	c.write_line('${tag} AUTHENTICATE PLAIN', false) or {
+		c.shutdown()
+		return err
+	}
+	c.await_continuation(tag) or {
+		if err !is CommandRefusedError {
+			c.shutdown()
+		}
+		return err
+	}
 	// RFC 4616: an authorisation identity, an authentication identity and a
 	// password, joined by NUL bytes.
-	c.write_line(base64.encode_str('\0${c.username}\0${c.password}'))!
+	c.write_line(base64.encode_str('\0${c.username}\0${c.password}'), true) or {
+		c.shutdown()
+		return err
+	}
 	c.read_response(tag)!
 	c.authenticated = true
 }
@@ -506,15 +530,30 @@ fn (mut c Client) send(text []string, literals [][]u8) !Response {
 		return error('imap: a command needs one more text part than it has literals')
 	}
 	tag := c.next_tag()
+	redact := text[0].to_upper().starts_with('LOGIN')
 	mut line := '${tag} ${text[0]}'
 	for i, payload in literals {
 		// The server has to agree to take the octets before they are sent.
-		c.write_line('${line}{${payload.len}}')!
-		c.await_continuation(tag)!
-		c.write_raw(payload)!
+		c.write_line('${line}{${payload.len}}', redact) or {
+			c.shutdown()
+			return err
+		}
+		c.await_continuation(tag) or {
+			if err !is CommandRefusedError {
+				c.shutdown()
+			}
+			return err
+		}
+		c.write_raw(payload) or {
+			c.shutdown()
+			return err
+		}
 		line = text[i + 1]
 	}
-	c.write_line(line)!
+	c.write_line(line, redact) or {
+		c.shutdown()
+		return err
+	}
 	res := c.read_response_raw(tag) or {
 		c.shutdown()
 		return err
@@ -562,7 +601,9 @@ fn (mut c Client) await_continuation(tag string) ! {
 		if got != tag {
 			return error('imap: the server answered tag `${got}` while `${tag}` was outstanding')
 		}
-		return error('imap: ${res.status} ${res.text}')
+		return CommandRefusedError{
+			message: 'imap: ${res.status} ${res.text}'
+		}
 	}
 }
 
@@ -739,11 +780,23 @@ fn (mut c Client) next_tag() string {
 	return '${tag_prefix}${c.tag_seq:04}'
 }
 
-fn (mut c Client) write_line(line string) ! {
+fn (mut c Client) write_line(line string, redact bool) ! {
+	_ = redact
 	$if imap_debug? {
-		eprintln('[imap send] ${line}')
+		eprintln('[imap send] ${imap_debug_line(line, redact)}')
 	}
 	c.write_raw('${line}\r\n'.bytes())!
+}
+
+fn imap_debug_line(line string, redact bool) string {
+	if !redact {
+		return line
+	}
+	upper := line.to_upper()
+	if login := upper.index(' LOGIN') {
+		return '${line[..login]} LOGIN <credentials redacted>'
+	}
+	return '<authentication data redacted>'
 }
 
 fn (mut c Client) write_raw(data []u8) ! {

--- a/vlib/net/imap/imap.v
+++ b/vlib/net/imap/imap.v
@@ -136,6 +136,9 @@ fn (mut c Client) authenticate() ! {
 // connect opens the transport and reads the server greeting, without logging
 // in. `new_client` calls it; call it directly only to drive a session by hand.
 pub fn (mut c Client) connect() ! {
+	if c.transport_open {
+		return error('imap: client is already connected')
+	}
 	c.conn = net.dial_tcp('${c.server}:${c.effective_port()}')!
 	c.transport_open = true
 	c.is_open = true

--- a/vlib/net/imap/imap.v
+++ b/vlib/net/imap/imap.v
@@ -53,15 +53,23 @@ const tag_prefix = 'a'
 // Leave `port` unset to take 993 when `ssl` is true and 143 otherwise. Set
 // `ssl` for a connection encrypted from the first byte, or `starttls` to
 // upgrade a plain connection once it is open. The two are mutually exclusive.
+// TLS certificates are validated by default. `verify` names a PEM CA bundle;
+// set `in_memory_verification` when it contains the PEM data itself. `cert` and
+// `cert_key` configure a client certificate when the server requires one.
 pub struct Config {
 pub:
-	server   string
-	port     int
-	username string
-	password string
-	ssl      bool
-	starttls bool
-	timeout  time.Duration
+	server                 string
+	port                   int
+	username               string
+	password               string
+	ssl                    bool
+	starttls               bool
+	timeout                time.Duration
+	validate               bool = true
+	verify                 string
+	cert                   string
+	cert_key               string
+	in_memory_verification bool
 }
 
 // Client is a connection to an IMAP server.
@@ -669,7 +677,13 @@ fn (c &Client) effective_port() int {
 // upgrade_to_tls wraps the current connection in TLS and points the decoder at
 // it.
 fn (mut c Client) upgrade_to_tls() ! {
-	c.ssl_conn = ssl.new_ssl_conn()!
+	c.ssl_conn = ssl.new_ssl_conn(
+		validate: c.validate
+		verify: c.verify
+		cert: c.cert
+		cert_key: c.cert_key
+		in_memory_verification: c.in_memory_verification
+	)!
 	c.ssl_conn.connect(mut c.conn, c.server) or {
 		return error('imap: TLS handshake with ${c.server} failed: ${err}')
 	}

--- a/vlib/net/imap/imap.v
+++ b/vlib/net/imap/imap.v
@@ -490,8 +490,11 @@ fn (mut c Client) send(text []string, literals [][]u8) !Response {
 		line = text[i + 1]
 	}
 	c.write_line(line)!
-	mut res := c.read_response(tag)!
+	res := c.read_response_raw(tag)!
 	c.absorb(res)
+	if res.status != .ok {
+		return error('imap: ${res.status} ${res.text}')
+	}
 	return res
 }
 
@@ -564,14 +567,17 @@ fn (mut c Client) absorb(res Response) {
 	// follows it. Servers are not obliged to send a fresh EXISTS afterwards,
 	// and Dovecot does not, so a client that waited for one would go on
 	// reporting a count that includes messages it just watched being removed.
-	for _ in res.expunged {
+	mut removals := res.expunged.len
+	if res.has_exists {
+		c.exists = res.exists
+		// Only removals that arrived after the last EXISTS remain to be applied;
+		// that count superseded every earlier event.
+		removals = res.expunged_after_exists
+	}
+	for _ in 0 .. removals {
 		if c.exists > 0 {
 			c.exists--
 		}
-	}
-	// An EXISTS the server did send is authoritative over that arithmetic.
-	if res.has_exists {
-		c.exists = res.exists
 	}
 	if res.has_recent {
 		c.recent = res.recent
@@ -630,7 +636,10 @@ fn (mut c Client) open_mailbox(verb string, name string) !Mailbox {
 	// A selection attempt returns the session to authenticated state if it
 	// fails, so the old mailbox and its counters stop being current up front.
 	c.clear_selected()
-	res := c.run_with_mailbox(verb, name)!
+	res := c.run_with_mailbox(verb, name) or {
+		c.clear_selected()
+		return err
+	}
 	c.selected = name
 	c.exists = res.exists
 	c.recent = res.recent

--- a/vlib/net/imap/imap.v
+++ b/vlib/net/imap/imap.v
@@ -72,6 +72,12 @@ mut:
 	ssl_conn &ssl.SSLConn = unsafe { nil }
 	dec      ?&Decoder
 	tag_seq  int
+	// transport_open is separate from is_open: an unsolicited BYE makes the
+	// session unusable before the local socket has necessarily been closed.
+	transport_open      bool
+	authenticated       bool
+	logging_out         bool
+	server_capabilities []string
 pub mut:
 	is_open   bool
 	encrypted bool
@@ -94,7 +100,10 @@ pub fn new_client(config Config) !&Client {
 		Config: config
 	}
 	c.connect()!
-	c.login()!
+	c.login() or {
+		c.shutdown()
+		return err
+	}
 	return c
 }
 
@@ -102,37 +111,53 @@ pub fn new_client(config Config) !&Client {
 // in. `new_client` calls it; call it directly only to drive a session by hand.
 pub fn (mut c Client) connect() ! {
 	c.conn = net.dial_tcp('${c.server}:${c.effective_port()}')!
+	c.transport_open = true
+	c.is_open = true
+	c.finish_connect() or {
+		c.shutdown()
+		return err
+	}
+}
+
+// finish_connect performs every setup step after the socket has opened. Its
+// caller owns the single cleanup path for any error from these operations.
+fn (mut c Client) finish_connect() ! {
 	if c.timeout != 0 {
 		c.conn.set_read_timeout(c.timeout)
 		c.conn.set_write_timeout(c.timeout)
 	}
 	c.dec = decoder_on(io.new_buffered_reader(reader: c.conn))
-	c.is_open = true
 
 	if c.ssl {
 		c.upgrade_to_tls()!
 	}
-	// A greeting that turns the connection away leaves nothing to say goodbye
-	// to, so the socket goes rather than being left for the server to time
-	// out.
-	c.read_greeting() or {
-		c.shutdown()
-		return err
-	}
+	greeting := c.read_greeting()!
+	c.authenticated = greeting.status == .preauth
+	c.server_capabilities = greeting.capabilities.clone()
 	if c.starttls {
+		if c.authenticated {
+			return error('imap: the server preauthenticated before STARTTLS could be negotiated')
+		}
 		c.run('STARTTLS')!
 		c.upgrade_to_tls()!
+		// RFC 3501 allows capabilities to change after STARTTLS. The greeting's
+		// list must not be used to make decisions about the protected session.
+		c.server_capabilities.clear()
 	}
 }
 
 // login authenticates with the LOGIN command, and does nothing when no
 // username was configured.
 pub fn (mut c Client) login() ! {
-	if c.username == '' {
+	if c.username == '' || c.authenticated {
 		return
+	}
+	if c.has_capability('LOGINDISABLED') {
+		return error('imap: the server disabled LOGIN in its greeting')
 	}
 	text, literals := build_args('LOGIN', [c.username, c.password])
 	c.send(text, literals)!
+	c.authenticated = true
 }
 
 // login_plain authenticates with the SASL PLAIN mechanism instead, which some
@@ -149,7 +174,9 @@ pub fn (mut c Client) login_plain() ! {
 
 // capability returns the extensions the server advertises.
 pub fn (mut c Client) capability() ![]string {
-	return c.run('CAPABILITY')!.capabilities
+	capabilities := c.run('CAPABILITY')!.capabilities
+	c.server_capabilities = capabilities.clone()
+	return capabilities
 }
 
 // supports reports whether the server advertises `name`, which is how an
@@ -367,7 +394,7 @@ pub fn (mut c Client) check() ! {
 // flagged `\Deleted` on the way out.
 pub fn (mut c Client) close_mailbox() ! {
 	c.run('CLOSE')!
-	c.selected = ''
+	c.clear_selected()
 }
 
 // unselect leaves the selected mailbox without expunging anything (RFC 3691),
@@ -376,35 +403,54 @@ pub fn (mut c Client) close_mailbox() ! {
 // It needs the UNSELECT capability.
 pub fn (mut c Client) unselect() ! {
 	c.run('UNSELECT')!
-	c.selected = ''
+	c.clear_selected()
 }
 
 // logout ends the session politely, giving the server the chance to close the
 // connection itself.
 pub fn (mut c Client) logout() ! {
-	c.run('LOGOUT')!
+	if !c.is_open {
+		c.shutdown()
+		return
+	}
+	c.logging_out = true
+	c.run('LOGOUT') or {
+		c.logging_out = false
+		c.shutdown()
+		return err
+	}
+	c.logging_out = false
+	c.shutdown()
 }
 
 // close logs out and tears down the connection. It is safe to call on a
 // session that is already closed.
 pub fn (mut c Client) close() ! {
-	if !c.is_open {
+	if !c.transport_open {
 		return
 	}
-	c.logout() or {}
+	if c.is_open {
+		c.logout() or {}
+		return
+	}
 	c.shutdown()
 }
 
 // shutdown tears the transport down without saying goodbye, which is what a
 // session that never opened properly is left with.
 fn (mut c Client) shutdown() {
+	if !c.transport_open {
+		return
+	}
+	c.transport_open = false
 	if c.encrypted {
 		c.ssl_conn.shutdown() or {}
 		c.encrypted = false
 	}
 	c.conn.close() or {}
 	c.is_open = false
-	c.selected = ''
+	c.authenticated = false
+	c.clear_selected()
 }
 
 // command sends one command with a fresh tag and returns the completion text,
@@ -460,6 +506,11 @@ fn (mut c Client) await_continuation(tag string) ! {
 			c.read_untagged(mut d, mut res)!
 			d.crlf()!
 			c.absorb(res)
+			if !c.is_open {
+				text := res.text
+				c.shutdown()
+				return error('imap: the server closed the session: ${text}')
+			}
 			continue
 		}
 		// A tagged completion here means the command was refused before the
@@ -477,7 +528,7 @@ fn (mut c Client) await_continuation(tag string) ! {
 }
 
 // read_greeting reads the untagged response a server opens with.
-fn (mut c Client) read_greeting() ! {
+fn (mut c Client) read_greeting() !Response {
 	mut d := c.decoder()!
 	d.expect(`*`)!
 	d.sp()!
@@ -494,6 +545,7 @@ fn (mut c Client) read_greeting() ! {
 	if status != .ok && status != .preauth {
 		return error('imap: unexpected greeting: ${status} ${res.text}')
 	}
+	return res
 }
 
 // absorb takes the mailbox updates out of a response. A server reports new
@@ -515,6 +567,9 @@ fn (mut c Client) absorb(res Response) {
 	}
 	if res.has_recent {
 		c.recent = res.recent
+	}
+	if res.capabilities.len > 0 {
+		c.server_capabilities = res.capabilities.clone()
 	}
 }
 
@@ -564,6 +619,9 @@ fn (mut c Client) run_transfer(verb string, set SeqSet, dest string) !Response {
 // open_mailbox runs SELECT or EXAMINE and reads back the state the server
 // reports alongside it.
 fn (mut c Client) open_mailbox(verb string, name string) !Mailbox {
+	// A selection attempt returns the session to authenticated state if it
+	// fails, so the old mailbox and its counters stop being current up front.
+	c.clear_selected()
 	res := c.run_with_mailbox(verb, name)!
 	c.selected = name
 	c.exists = res.exists
@@ -581,6 +639,21 @@ fn (mut c Client) open_mailbox(verb string, name string) !Mailbox {
 		// read-only mailbox to a SELECT as well.
 		read_only: res.read_only || verb == 'EXAMINE'
 	}
+}
+
+fn (mut c Client) clear_selected() {
+	c.selected = ''
+	c.exists = 0
+	c.recent = 0
+}
+
+fn (c &Client) has_capability(name string) bool {
+	for capability in c.server_capabilities {
+		if capability.to_upper() == name.to_upper() {
+			return true
+		}
+	}
+	return false
 }
 
 fn (c &Client) effective_port() int {
@@ -684,5 +757,6 @@ fn quote_arg(s string) string {
 // format_internal_date renders a time the way APPEND wants it, which is a
 // fixed two digit day and an English month.
 fn format_internal_date(t time.Time) string {
-	return '${t.day:02}-${month_names[t.month - 1]}-${t.year:04} ${t.hour:02}:${t.minute:02}:${t.second:02} +0000'
+	utc := t.local_to_utc()
+	return '${utc.day:02}-${month_names[utc.month - 1]}-${utc.year:04} ${utc.hour:02}:${utc.minute:02}:${utc.second:02} +0000'
 }

--- a/vlib/net/imap/imap.v
+++ b/vlib/net/imap/imap.v
@@ -53,8 +53,9 @@ const tag_prefix = 'a'
 // Leave `port` unset to take 993 when `ssl` is true and 143 otherwise. Set
 // `ssl` for a connection encrypted from the first byte, or `starttls` to
 // upgrade a plain connection once it is open. The two are mutually exclusive.
-// TLS certificates are validated by default. `verify` names a PEM CA bundle;
-// set `in_memory_verification` when it contains the PEM data itself. `cert` and
+// TLS certificates are validated by default. A TLS connection with validation
+// enabled requires `verify` to name a PEM CA bundle; set
+// `in_memory_verification` when it contains the PEM data itself. `cert` and
 // `cert_key` configure a client certificate when the server requires one.
 pub struct Config {
 pub:
@@ -70,6 +71,13 @@ pub:
 	cert                   string
 	cert_key               string
 	in_memory_verification bool
+	auth_method            AuthMethod
+}
+
+// AuthMethod selects how new_client authenticates configured credentials.
+pub enum AuthMethod {
+	login
+	plain
 }
 
 // Client is a connection to an IMAP server.
@@ -104,15 +112,25 @@ pub fn new_client(config Config) !&Client {
 	if config.ssl && config.starttls {
 		return error('imap: cannot use both implicit SSL and STARTTLS')
 	}
+	if (config.ssl || config.starttls) && config.validate && config.verify == '' {
+		return error('imap: TLS certificate validation requires a CA bundle in `verify`')
+	}
 	mut c := &Client{
 		Config: config
 	}
 	c.connect()!
-	c.login() or {
+	c.authenticate() or {
 		c.shutdown()
 		return err
 	}
 	return c
+}
+
+fn (mut c Client) authenticate() ! {
+	match c.auth_method {
+		.login { c.login()! }
+		.plain { c.login_plain()! }
+	}
 }
 
 // connect opens the transport and reads the server greeting, without logging
@@ -171,6 +189,9 @@ pub fn (mut c Client) login() ! {
 // login_plain authenticates with the SASL PLAIN mechanism instead, which some
 // servers require and others prefer.
 pub fn (mut c Client) login_plain() ! {
+	if c.username == '' || c.authenticated {
+		return
+	}
 	tag := c.next_tag()
 	c.write_line('${tag} AUTHENTICATE PLAIN')!
 	c.await_continuation(tag)!
@@ -178,6 +199,7 @@ pub fn (mut c Client) login_plain() ! {
 	// password, joined by NUL bytes.
 	c.write_line(base64.encode_str('\0${c.username}\0${c.password}'))!
 	c.read_response(tag)!
+	c.authenticated = true
 }
 
 // capability returns the extensions the server advertises.
@@ -695,6 +717,9 @@ fn (mut c Client) upgrade_to_tls() ! {
 	)!
 	c.ssl_conn.connect(mut c.conn, c.server) or {
 		return error('imap: TLS handshake with ${c.server} failed: ${err}')
+	}
+	$if use_openssl? {
+		c.ssl_conn.verify_hostname(c.server)!
 	}
 	c.dec = decoder_on(io.new_buffered_reader(reader: c.ssl_conn))
 	c.encrypted = true

--- a/vlib/net/imap/imap.v
+++ b/vlib/net/imap/imap.v
@@ -515,7 +515,10 @@ fn (mut c Client) send(text []string, literals [][]u8) !Response {
 		line = text[i + 1]
 	}
 	c.write_line(line)!
-	res := c.read_response_raw(tag)!
+	res := c.read_response_raw(tag) or {
+		c.shutdown()
+		return err
+	}
 	c.absorb(res)
 	if res.status != .ok {
 		return error('imap: ${res.status} ${res.text}')

--- a/vlib/net/imap/imap.v
+++ b/vlib/net/imap/imap.v
@@ -718,9 +718,6 @@ fn (mut c Client) upgrade_to_tls() ! {
 	c.ssl_conn.connect(mut c.conn, c.server) or {
 		return error('imap: TLS handshake with ${c.server} failed: ${err}')
 	}
-	$if use_openssl? {
-		c.ssl_conn.verify_hostname(c.server)!
-	}
 	c.dec = decoder_on(io.new_buffered_reader(reader: c.ssl_conn))
 	c.encrypted = true
 }

--- a/vlib/net/imap/imap.v
+++ b/vlib/net/imap/imap.v
@@ -776,11 +776,19 @@ fn (mut c Client) upgrade_to_tls() ! {
 		cert_key: c.cert_key
 		in_memory_verification: c.in_memory_verification
 	)!
-	c.ssl_conn.connect(mut c.conn, c.server) or {
+	tls_hostname := normalize_tls_hostname(c.server)
+	c.ssl_conn.connect(mut c.conn, tls_hostname) or {
 		return error('imap: TLS handshake with ${c.server} failed: ${err}')
 	}
 	c.dec = decoder_on(io.new_buffered_reader(reader: c.ssl_conn))
 	c.encrypted = true
+}
+
+fn normalize_tls_hostname(hostname string) string {
+	if hostname.len > 2 && hostname[0] == `[` && hostname[hostname.len - 1] == `]` {
+		return hostname[1..hostname.len - 1]
+	}
+	return hostname
 }
 
 fn (mut c Client) decoder() !&Decoder {

--- a/vlib/net/imap/imap.v
+++ b/vlib/net/imap/imap.v
@@ -58,6 +58,8 @@ const tag_prefix = 'a'
 // enabled requires `verify` to name a PEM CA bundle; set
 // `in_memory_verification` when it contains the PEM data itself. `cert` and
 // `cert_key` configure a client certificate when the server requires one.
+// Credentials are refused on an unencrypted connection unless
+// `allow_insecure_auth` is explicitly set.
 pub struct Config {
 pub:
 	server                 string
@@ -72,6 +74,7 @@ pub:
 	cert                   string
 	cert_key               string
 	in_memory_verification bool
+	allow_insecure_auth    bool
 	auth_method            AuthMethod
 }
 
@@ -127,6 +130,9 @@ pub fn new_client(config Config) !&Client {
 	}
 	if (config.ssl || config.starttls) && config.validate && config.verify == '' {
 		return error('imap: TLS certificate validation requires a CA bundle in `verify`')
+	}
+	if config.username != '' && !config.ssl && !config.starttls && !config.allow_insecure_auth {
+		return error('imap: refusing to send credentials without TLS; set `allow_insecure_auth` to opt in')
 	}
 	mut c := &Client{
 		Config: config
@@ -194,6 +200,7 @@ pub fn (mut c Client) login() ! {
 	if c.username == '' || c.authenticated {
 		return
 	}
+	c.ensure_auth_is_safe()!
 	if c.has_capability('LOGINDISABLED') {
 		return error('imap: the server disabled LOGIN in its greeting')
 	}
@@ -208,6 +215,7 @@ pub fn (mut c Client) login_plain() ! {
 	if c.username == '' || c.authenticated {
 		return
 	}
+	c.ensure_auth_is_safe()!
 	tag := c.next_tag()
 	c.write_line('${tag} AUTHENTICATE PLAIN', false) or {
 		c.shutdown()
@@ -227,6 +235,12 @@ pub fn (mut c Client) login_plain() ! {
 	}
 	c.read_response(tag)!
 	c.authenticated = true
+}
+
+fn (c &Client) ensure_auth_is_safe() ! {
+	if !c.encrypted && !c.allow_insecure_auth {
+		return error('imap: refusing to send credentials without TLS; set `allow_insecure_auth` to opt in')
+	}
 }
 
 // capability returns the extensions the server advertises.

--- a/vlib/net/imap/imap_test.v
+++ b/vlib/net/imap/imap_test.v
@@ -132,14 +132,19 @@ fn mock_reply(tag string, cmd string, line string) string {
 	if cmd == 'EXPUNGE' {
 		return '* 3 EXPUNGE\r\n* 3 EXPUNGE\r\n* 5 EXPUNGE\r\n* 8 EXISTS\r\n' + '${tag} OK EXPUNGE completed\r\n'
 	}
+	if cmd == 'CLOSE' {
+		// Dovecot reports the removals and sends no fresh count behind them,
+		// which is what a client has to cope with.
+		return '* 1 EXPUNGE\r\n* 1 EXPUNGE\r\n${tag} OK CLOSE completed\r\n'
+	}
 	if cmd == 'APPEND' {
 		return '${tag} OK [APPENDUID 3857529045 45] APPEND completed\r\n'
 	}
 	if cmd == 'LOGOUT' {
 		return '* BYE mock signing off\r\n${tag} OK LOGOUT completed\r\n'
 	}
-	if cmd in ['CREATE', 'DELETE', 'RENAME', 'CLOSE', 'CHECK', 'SUBSCRIBE', 'UNSUBSCRIBE', 'UNSELECT',
-		'COPY', 'MOVE'] {
+	if cmd in ['CREATE', 'DELETE', 'RENAME', 'CHECK', 'SUBSCRIBE', 'UNSUBSCRIBE', 'UNSELECT', 'COPY',
+		'MOVE'] {
 		return '${tag} OK ${cmd} completed\r\n'
 	}
 	return '${tag} BAD unknown command\r\n'
@@ -348,6 +353,28 @@ fn test_unsolicited_updates_reach_the_client() {
 	c.noop()!
 	assert c.exists == 9
 	assert c.recent == 2
+	// Two removals with no fresh count behind them, the way Dovecot answers.
+	// The client has to do the arithmetic itself, or it goes on reporting
+	// messages it just watched being taken out.
+	c.close_mailbox()!
+	assert c.exists == 7
+	c.close()!
+	th.wait()
+	l.close() or {}
+	drain(seen)
+}
+
+fn test_an_explicit_count_wins_over_the_arithmetic() {
+	mut l := net.listen_tcp(.ip, '127.0.0.1:0')!
+	seen := chan string{ cap: 64 }
+	port, th := start(mut l, mock_greeting, seen)!
+
+	mut c := new_client(server: '127.0.0.1', port: port)!
+	c.select_mailbox('INBOX')!
+	// Three removals and an EXISTS of 8. The server's own number is the one
+	// to trust, not 172 minus three.
+	c.expunge()!
+	assert c.exists == 8
 	c.close()!
 	th.wait()
 	l.close() or {}

--- a/vlib/net/imap/imap_test.v
+++ b/vlib/net/imap/imap_test.v
@@ -115,6 +115,9 @@ fn mock_reply(tag string, cmd string, line string) string {
 		return '* SEARCH 1 2 3 4 5 9 84 882\r\n${tag} OK SEARCH completed\r\n'
 	}
 	if cmd == 'FETCH' {
+		if line.contains('BIG') {
+			return big_fetch_reply(tag)
+		}
 		return fetch_reply(tag)
 	}
 	if cmd == 'UID' {
@@ -155,6 +158,13 @@ fn mock_reply(tag string, cmd string, line string) string {
 fn fetch_reply(tag string) string {
 	body := 'Subject: UID 999 FLAGS (\\Deleted)\r\n\r\nnot protocol\r\n'
 	return '* 2 FETCH (UID 4827313 RFC822.SIZE 44827 FLAGS (\\Seen) BODY[] {${body.len}}\r\n' + '${body})\r\n' + '* 84 FETCH (UID 4827943 FLAGS (\\Answered))\r\n' + '${tag} OK FETCH completed\r\n'
+}
+
+// big_fetch_reply returns one message whose literal runs well past the size of
+// a single read from the connection.
+fn big_fetch_reply(tag string) string {
+	body := 'x'.repeat(300000)
+	return '* 1 FETCH (UID 1 BODY[] {${body.len}}\r\n${body})\r\n${tag} OK FETCH completed\r\n'
 }
 
 // drain collects everything the server reported, once it has closed the
@@ -506,6 +516,26 @@ fn test_empty_sets_do_not_reach_the_server() {
 
 	// An empty sequence set is not valid syntax, so nothing may be sent.
 	assert drain(seen) == ['a0001 LOGOUT']
+}
+
+fn test_a_literal_larger_than_one_read_comes_back_whole() {
+	mut l := net.listen_tcp(.ip, '127.0.0.1:0')!
+	seen := chan string{ cap: 64 }
+	port, th := start(mut l, mock_greeting, seen)!
+
+	mut c := new_client(server: '127.0.0.1', port: port)!
+	// The decoder reads the connection a chunk at a time, so a literal has to
+	// be stitched across chunk boundaries. This one spans many of them, and
+	// the syntax after it still has to be found.
+	msgs := c.fetch(seq_set([u32(1)]), 'BODY.PEEK[BIG]')!
+	assert msgs.len == 1
+	assert msgs[0].uid == 1
+	assert msgs[0].body().len == 300000
+	assert msgs[0].body() == 'x'.repeat(300000)
+	c.close()!
+	th.wait()
+	l.close() or {}
+	drain(seen)
 }
 
 fn test_close_is_idempotent() {

--- a/vlib/net/imap/imap_test.v
+++ b/vlib/net/imap/imap_test.v
@@ -1,0 +1,532 @@
+module imap
+
+import io
+import net
+import time
+
+// These drive the client over a real socket against a scripted server, so that
+// tagging, literal sending, continuations and the mailbox name encoding are
+// checked as they behave on the wire.
+const mock_greeting = '* OK [CAPABILITY IMAP4rev1 STARTTLS] mock ready'
+
+// run_server answers one session and reports every command it received on
+// `seen`, so that a test can check what the client actually sent.
+fn run_server(mut l net.TcpListener, hello string, seen chan string) {
+	defer {
+		seen.close()
+	}
+	mut c := l.accept() or { return }
+	defer {
+		c.close() or {}
+	}
+	// A client that fails mid-session may never say goodbye, so the read must
+	// give up rather than leave the thread pinned for the rest of the suite.
+	c.set_read_timeout(10 * time.second)
+	c.write_string('${hello}\r\n') or { return }
+	mut r := io.new_buffered_reader(reader: c)
+	for {
+		mut line := r.read_line() or { return }
+		// A command may carry literals. Each one is announced by the client,
+		// acknowledged here, and only then sent.
+		for {
+			size := literal_size(line) or { break }
+			c.write_string('+ go ahead\r\n') or { return }
+			payload := read_exactly(mut r, size) or { return }
+			rest := r.read_line() or { return }
+			line = '${line}<${payload}>${rest}'
+		}
+		seen <- line
+		fields := line.split(' ')
+		if fields.len < 2 {
+			continue
+		}
+		c.write_string(mock_reply(fields[0], fields[1].to_upper(), line)) or { return }
+		if fields[1].to_upper() == 'LOGOUT' {
+			return
+		}
+	}
+}
+
+// literal_size reads the octet count a command line ends with, if any.
+fn literal_size(line string) ?int {
+	if !line.ends_with('}') {
+		return none
+	}
+	start := line.last_index_u8(`{`)
+	if start < 0 {
+		return none
+	}
+	digits := line[start + 1..line.len - 1]
+	if digits == '' {
+		return none
+	}
+	for ch in digits {
+		if ch < `0` || ch > `9` {
+			return none
+		}
+	}
+	return digits.int()
+}
+
+fn read_exactly(mut r io.BufferedReader, n int) !string {
+	mut buf := []u8{len: n}
+	mut got := 0
+	for got < n {
+		read := r.read(mut buf[got..])!
+		if read <= 0 {
+			return error('the client stopped short of the literal it announced')
+		}
+		got += read
+	}
+	return buf.bytestr()
+}
+
+// mock_reply renders the response to one command. The bodies are the examples
+// printed in RFC 3501, with the numbers left as the RFC has them.
+fn mock_reply(tag string, cmd string, line string) string {
+	if cmd == 'CAPABILITY' {
+		return '* CAPABILITY IMAP4rev1 STARTTLS AUTH=PLAIN UIDPLUS MOVE\r\n' + '${tag} OK CAPABILITY completed\r\n'
+	}
+	if cmd == 'LOGIN' {
+		if line.contains('wrong') {
+			return '${tag} NO [AUTHENTICATIONFAILED] Invalid credentials\r\n'
+		}
+		return '${tag} OK LOGIN completed\r\n'
+	}
+	if cmd == 'NOOP' {
+		// A mailbox can change under a client at any moment, and this is how
+		// the server says so: attached to whatever command is in flight.
+		return '* 9 EXISTS\r\n* 2 RECENT\r\n${tag} OK NOOP completed\r\n'
+	}
+	if cmd == 'LIST' || cmd == 'LSUB' {
+		return '* ${cmd} (\\Noselect) "/" ""\r\n' + '* ${cmd} (\\HasNoChildren) "/" INBOX\r\n' + '* ${cmd} (\\HasChildren) "/" "Travail"\r\n' + '* ${cmd} () "/" "Travail/&AMk-t&AOk- 2026"\r\n' + '${tag} OK ${cmd} completed\r\n'
+	}
+	if cmd == 'SELECT' || cmd == 'EXAMINE' {
+		if line.contains('Nope') {
+			return '${tag} NO Mailbox does not exist\r\n'
+		}
+		mode := if cmd == 'SELECT' { 'READ-WRITE' } else { 'READ-ONLY' }
+		return '* 172 EXISTS\r\n* 1 RECENT\r\n' + '* OK [UNSEEN 12] Message 12 is first unseen\r\n' + '* OK [UIDVALIDITY 3857529045] UIDs valid\r\n' + '* OK [UIDNEXT 4392] Predicted next UID\r\n' + '* FLAGS (\\Answered \\Flagged \\Deleted \\Seen \\Draft)\r\n' + '* OK [PERMANENTFLAGS (\\Deleted \\Seen \\*)] Limited\r\n' + '${tag} OK [${mode}] ${cmd} completed\r\n'
+	}
+	if cmd == 'STATUS' {
+		return '* STATUS "Travail/&AMk-t&AOk- 2026" (MESSAGES 231 UIDNEXT 44292 UNSEEN 3)\r\n' + '${tag} OK STATUS completed\r\n'
+	}
+	if cmd == 'SEARCH' {
+		return '* SEARCH 1 2 3 4 5 9 84 882\r\n${tag} OK SEARCH completed\r\n'
+	}
+	if cmd == 'FETCH' {
+		return fetch_reply(tag)
+	}
+	if cmd == 'UID' {
+		if line.contains(' SEARCH ') {
+			return '* SEARCH 4827313 4827943\r\n${tag} OK UID SEARCH completed\r\n'
+		}
+		if line.contains(' FETCH ') {
+			return fetch_reply(tag)
+		}
+		return '${tag} OK UID completed\r\n'
+	}
+	if cmd == 'STORE' {
+		return '* 2 FETCH (FLAGS (\\Seen \\Deleted))\r\n${tag} OK STORE completed\r\n'
+	}
+	if cmd == 'EXPUNGE' {
+		return '* 3 EXPUNGE\r\n* 3 EXPUNGE\r\n* 5 EXPUNGE\r\n* 8 EXISTS\r\n' + '${tag} OK EXPUNGE completed\r\n'
+	}
+	if cmd == 'APPEND' {
+		return '${tag} OK [APPENDUID 3857529045 45] APPEND completed\r\n'
+	}
+	if cmd == 'LOGOUT' {
+		return '* BYE mock signing off\r\n${tag} OK LOGOUT completed\r\n'
+	}
+	if cmd in ['CREATE', 'DELETE', 'RENAME', 'CLOSE', 'CHECK', 'SUBSCRIBE', 'UNSUBSCRIBE', 'UNSELECT',
+		'COPY', 'MOVE'] {
+		return '${tag} OK ${cmd} completed\r\n'
+	}
+	return '${tag} BAD unknown command\r\n'
+}
+
+// fetch_reply returns two messages, the first carrying a literal whose payload
+// deliberately reads like protocol.
+fn fetch_reply(tag string) string {
+	body := 'Subject: UID 999 FLAGS (\\Deleted)\r\n\r\nnot protocol\r\n'
+	return '* 2 FETCH (UID 4827313 RFC822.SIZE 44827 FLAGS (\\Seen) BODY[] {${body.len}}\r\n' + '${body})\r\n' + '* 84 FETCH (UID 4827943 FLAGS (\\Answered))\r\n' + '${tag} OK FETCH completed\r\n'
+}
+
+// drain collects everything the server reported, once it has closed the
+// channel at the end of the session.
+fn drain(seen chan string) []string {
+	mut out := []string{}
+	for {
+		line := <-seen or { break }
+		out << line
+	}
+	return out
+}
+
+// start starts a server and returns the port it is listening on.
+fn start(mut l net.TcpListener, hello string, seen chan string) !(int, thread) {
+	port := l.addr()!.port()!
+	return port, spawn run_server(mut l, hello, seen)
+}
+
+fn test_a_full_session() {
+	mut l := net.listen_tcp(.ip, '127.0.0.1:0')!
+	seen := chan string{ cap: 64 }
+	port, th := start(mut l, mock_greeting, seen)!
+
+	mut c := new_client(
+		server: '127.0.0.1'
+		port: port
+		username: 'bob'
+		password: 'hunter2'
+	)!
+	assert c.is_open
+	assert !c.encrypted
+
+	assert c.capability()! == ['IMAP4rev1', 'STARTTLS', 'AUTH=PLAIN', 'UIDPLUS', 'MOVE']
+	assert c.supports('move')!
+	assert !c.supports('IDLE')!
+
+	boxes := c.list_mailboxes('', '*')!
+	assert boxes.len == 4
+	assert boxes[0].name == ''
+	assert boxes[1].name == 'INBOX'
+	assert boxes[1].delimiter == '/'
+	// The name comes back as UTF-8, not as the modified UTF-7 it travelled in.
+	assert boxes[3].name == 'Travail/Été 2026'
+
+	inbox := c.select_mailbox('INBOX')!
+	assert inbox.exists == 172
+	assert inbox.recent == 1
+	assert inbox.unseen == 12
+	assert inbox.uid_validity == 3857529045
+	assert inbox.uid_next == 4392
+	assert inbox.permanent_flags == ['\\Deleted', '\\Seen', '\\*']
+	assert !inbox.read_only
+	assert c.selected == 'INBOX'
+	assert c.exists == 172
+
+	found := c.search('UNSEEN')!
+	// The consecutive numbers come back as a range, which is what will be sent
+	// to the server next.
+	assert found.str() == '1:5,9,84,882'
+
+	msgs := c.fetch(found, 'BODY.PEEK[]')!
+	assert msgs.len == 2
+	assert msgs[0].uid == 4827313
+	assert msgs[0].size == 44827
+	assert msgs[0].flags == ['\\Seen']
+	assert msgs[0].body().ends_with('not protocol\r\n')
+	assert msgs[1].uid == 4827943
+	assert msgs[1].body() == ''
+
+	assert c.uid_search('UNSEEN')!.str() == '4827313,4827943'
+
+	c.mark_seen(seq_set([u32(2)]))!
+	assert c.expunge()! == [u32(3), 3, 5]
+	assert c.exists == 8
+
+	c.close_mailbox()!
+	assert c.selected == ''
+	c.close()!
+	assert !c.is_open
+	th.wait()
+	l.close() or {}
+
+	sent := drain(seen)
+	assert sent == [
+		'a0001 LOGIN "bob" "hunter2"',
+		'a0002 CAPABILITY',
+		'a0003 CAPABILITY',
+		'a0004 CAPABILITY',
+		'a0005 LIST "" "*"',
+		'a0006 SELECT "INBOX"',
+		'a0007 SEARCH UNSEEN',
+		'a0008 FETCH 1:5,9,84,882 BODY.PEEK[]',
+		'a0009 UID SEARCH UNSEEN',
+		'a0010 STORE 2 +FLAGS.SILENT (\\Seen)',
+		'a0011 EXPUNGE',
+		'a0012 CLOSE',
+		'a0013 LOGOUT',
+	]
+}
+
+fn test_mailbox_names_travel_encoded() {
+	mut l := net.listen_tcp(.ip, '127.0.0.1:0')!
+	seen := chan string{ cap: 64 }
+	port, th := start(mut l, mock_greeting, seen)!
+
+	mut c := new_client(server: '127.0.0.1', port: port)!
+	c.create_mailbox('Travail/Été 2026')!
+	c.rename_mailbox('Travail/Été 2026', 'Archive/受信')!
+	c.subscribe('Archive/受信')!
+	c.delete_mailbox('Archive/受信')!
+	status := c.status('Travail/Été 2026', ['MESSAGES', 'UIDNEXT', 'UNSEEN'])!
+	assert status.name == 'Travail/Été 2026'
+	assert status.messages == 231
+	assert status.uid_next == 44292
+	c.close()!
+	th.wait()
+	l.close() or {}
+
+	sent := drain(seen)
+	assert sent == [
+		'a0001 CREATE "Travail/&AMk-t&AOk- 2026"',
+		'a0002 RENAME "Travail/&AMk-t&AOk- 2026" "Archive/&U9dP4Q-"',
+		'a0003 SUBSCRIBE "Archive/&U9dP4Q-"',
+		'a0004 DELETE "Archive/&U9dP4Q-"',
+		'a0005 STATUS "Travail/&AMk-t&AOk- 2026" (MESSAGES UIDNEXT UNSEEN)',
+		'a0006 LOGOUT',
+	]
+}
+
+fn test_append_sends_the_message_as_a_literal() {
+	mut l := net.listen_tcp(.ip, '127.0.0.1:0')!
+	seen := chan string{ cap: 64 }
+	port, th := start(mut l, mock_greeting, seen)!
+
+	mut c := new_client(server: '127.0.0.1', port: port)!
+	body := 'Subject: hi\r\n\r\nThe body, with a } and a { in it.\r\n'.bytes()
+	c.append('Sent', ['\\Seen'], time.unix(1739577600), body)!
+	// A message with no flags and no date is the common case.
+	c.append('Sent', [], time.Time{}, 'x'.bytes())!
+	c.close()!
+	th.wait()
+	l.close() or {}
+
+	sent := drain(seen)
+	// The literal is reported by the mock inside angle brackets, so the whole
+	// command including the payload is visible here.
+	assert sent[0] == 'a0001 APPEND "Sent" (\\Seen) "15-Feb-2025 00:00:00 +0000" {${body.len}}<${body.bytestr()}>'
+	assert sent[1] == 'a0002 APPEND "Sent" {1}<x>'
+	assert sent[2] == 'a0003 LOGOUT'
+}
+
+fn test_a_password_a_quoted_string_cannot_hold_becomes_a_literal() {
+	mut l := net.listen_tcp(.ip, '127.0.0.1:0')!
+	seen := chan string{ cap: 64 }
+	port, th := start(mut l, mock_greeting, seen)!
+
+	// A password with an accent is eight bit, which a quoted string is not
+	// defined over.
+	mut c := new_client(server: '127.0.0.1', port: port, username: 'bob', password: 'mot-de-passé')!
+	c.close()!
+	th.wait()
+	l.close() or {}
+
+	sent := drain(seen)
+	assert sent[0] == 'a0001 LOGIN "bob" {13}<mot-de-passé>'
+}
+
+fn test_examine_reports_the_mailbox_as_read_only() {
+	mut l := net.listen_tcp(.ip, '127.0.0.1:0')!
+	seen := chan string{ cap: 64 }
+	port, th := start(mut l, mock_greeting, seen)!
+
+	mut c := new_client(server: '127.0.0.1', port: port)!
+	box := c.examine_mailbox('INBOX')!
+	assert box.read_only
+	assert box.exists == 172
+	c.close()!
+	th.wait()
+	l.close() or {}
+
+	// No username was configured, so no LOGIN should have gone out.
+	assert drain(seen)[0] == 'a0001 EXAMINE "INBOX"'
+}
+
+fn test_unsolicited_updates_reach_the_client() {
+	mut l := net.listen_tcp(.ip, '127.0.0.1:0')!
+	seen := chan string{ cap: 64 }
+	port, th := start(mut l, mock_greeting, seen)!
+
+	mut c := new_client(server: '127.0.0.1', port: port)!
+	c.select_mailbox('INBOX')!
+	assert c.exists == 172
+	// The NOOP reply carries an EXISTS that has nothing to do with the NOOP:
+	// mail arrived while the session was doing something else.
+	c.noop()!
+	assert c.exists == 9
+	assert c.recent == 2
+	c.close()!
+	th.wait()
+	l.close() or {}
+	drain(seen)
+}
+
+fn test_a_refused_login_is_an_error() {
+	mut l := net.listen_tcp(.ip, '127.0.0.1:0')!
+	seen := chan string{ cap: 64 }
+	port, th := start(mut l, mock_greeting, seen)!
+
+	// Driven by hand rather than through new_client, so that the connection is
+	// still in reach once the login is refused.
+	mut c := Client{
+		Config: Config{
+			server: '127.0.0.1'
+			port: port
+			username: 'bob'
+			password: 'wrong'
+		}
+	}
+	c.connect()!
+	c.login() or {
+		assert err.msg().contains('Invalid credentials')
+		c.close()!
+		th.wait()
+		l.close() or {}
+		assert drain(seen) == ['a0001 LOGIN "bob" "wrong"', 'a0002 LOGOUT']
+		return
+	}
+	assert false, 'a NO completion must not be reported as success'
+}
+
+fn test_a_refused_command_leaves_the_session_usable() {
+	mut l := net.listen_tcp(.ip, '127.0.0.1:0')!
+	seen := chan string{ cap: 64 }
+	port, th := start(mut l, mock_greeting, seen)!
+
+	mut c := new_client(server: '127.0.0.1', port: port)!
+	c.select_mailbox('Nope') or {
+		assert err.msg().contains('Mailbox does not exist')
+		// The failure was the server's answer, not a broken connection, so the
+		// next command must still work.
+		c.noop()!
+		c.close()!
+		th.wait()
+		l.close() or {}
+		drain(seen)
+		return
+	}
+	assert false, 'selecting a missing mailbox must fail'
+}
+
+fn test_an_unknown_command_reports_bad() {
+	mut l := net.listen_tcp(.ip, '127.0.0.1:0')!
+	seen := chan string{ cap: 64 }
+	port, th := start(mut l, mock_greeting, seen)!
+
+	mut c := new_client(server: '127.0.0.1', port: port)!
+	c.command('XYZZY') or {
+		assert err.msg().contains('unknown command')
+		c.close()!
+		th.wait()
+		l.close() or {}
+		drain(seen)
+		return
+	}
+	assert false, 'a BAD completion must not be reported as success'
+}
+
+fn test_a_bye_greeting_is_refused() {
+	mut l := net.listen_tcp(.ip, '127.0.0.1:0')!
+	seen := chan string{ cap: 64 }
+	port, th := start(mut l, '* BYE too many connections', seen)!
+
+	mut c := Client{
+		Config: Config{
+			server: '127.0.0.1'
+			port: port
+		}
+	}
+	c.connect() or {
+		assert err.msg().contains('refused the connection')
+		assert !c.is_open
+		l.close() or {}
+		th.wait()
+		return
+	}
+	assert false, 'a BYE greeting must not open a session'
+}
+
+fn test_a_preauth_greeting_opens_the_session() {
+	mut l := net.listen_tcp(.ip, '127.0.0.1:0')!
+	seen := chan string{ cap: 64 }
+	port, th := start(mut l, '* PREAUTH IMAP4rev1 already authenticated', seen)!
+
+	mut c := new_client(server: '127.0.0.1', port: port)!
+	assert c.is_open
+	c.noop()!
+	c.close()!
+	th.wait()
+	l.close() or {}
+	drain(seen)
+}
+
+fn test_ssl_and_starttls_are_mutually_exclusive() {
+	new_client(server: 'imap.example.com', ssl: true, starttls: true) or {
+		assert err.msg().contains('cannot use both')
+		return
+	}
+	assert false, 'asking for both TLS modes must be rejected'
+}
+
+fn test_empty_sets_do_not_reach_the_server() {
+	mut l := net.listen_tcp(.ip, '127.0.0.1:0')!
+	seen := chan string{ cap: 64 }
+	port, th := start(mut l, mock_greeting, seen)!
+
+	mut c := new_client(server: '127.0.0.1', port: port)!
+	empty := SeqSet{}
+	assert c.fetch(empty, 'BODY.PEEK[]')!.len == 0
+	assert c.uid_fetch(empty, 'BODY.PEEK[]')!.len == 0
+	assert c.store(empty, '+FLAGS', ['\\Seen'])!.len == 0
+	c.copy(empty, 'Archive')!
+	c.move(empty, 'Archive')!
+	c.close()!
+	th.wait()
+	l.close() or {}
+
+	// An empty sequence set is not valid syntax, so nothing may be sent.
+	assert drain(seen) == ['a0001 LOGOUT']
+}
+
+fn test_close_is_idempotent() {
+	mut l := net.listen_tcp(.ip, '127.0.0.1:0')!
+	seen := chan string{ cap: 64 }
+	port, th := start(mut l, mock_greeting, seen)!
+
+	mut c := new_client(server: '127.0.0.1', port: port)!
+	c.close()!
+	c.close()!
+	th.wait()
+	l.close() or {}
+	assert drain(seen) == ['a0001 LOGOUT']
+}
+
+fn test_default_ports() {
+	plain := Client{
+		Config: Config{}
+	}
+	assert plain.effective_port() == default_port
+	implicit := Client{
+		Config: Config{
+			ssl: true
+		}
+	}
+	assert implicit.effective_port() == default_ssl_port
+	explicit := Client{
+		Config: Config{
+			ssl: true
+			port: 1143
+		}
+	}
+	assert explicit.effective_port() == 1143
+}
+
+fn test_build_args_splits_out_what_must_be_a_literal() {
+	text, literals := build_args('LOGIN', ['bob', 'plain'])
+	assert text == ['LOGIN "bob" "plain"']
+	assert literals == [][]u8{}
+
+	// A newline cannot travel in a quoted string, which may not span lines.
+	multi, payloads := build_args('LOGIN', ['bob', 'two\r\nlines'])
+	assert multi == ['LOGIN "bob" ', '']
+	assert payloads.len == 1
+	assert payloads[0].bytestr() == 'two\r\nlines'
+
+	// Quotes and backslashes are escaped rather than promoted to a literal.
+	escaped, none_needed := build_args('CREATE', ['od"d\\name'])
+	assert escaped == ['CREATE "od\\"d\\\\name"']
+	assert none_needed.len == 0
+}

--- a/vlib/net/imap/imap_test.v
+++ b/vlib/net/imap/imap_test.v
@@ -806,6 +806,12 @@ fn test_tls_validation_requires_an_explicit_ca_bundle() {
 	assert false, 'validated TLS without trust roots must fail before dialing'
 }
 
+fn test_bracketed_ipv6_is_normalized_for_tls_identity_checks() {
+	assert normalize_tls_hostname('[2001:db8::1]') == '2001:db8::1'
+	assert normalize_tls_hostname('2001:db8::1') == '2001:db8::1'
+	assert normalize_tls_hostname('imap.example.com') == 'imap.example.com'
+}
+
 fn test_empty_sets_do_not_reach_the_server() {
 	mut l := net.listen_tcp(.ip, '127.0.0.1:0')!
 	seen := chan string{ cap: 64 }

--- a/vlib/net/imap/imap_test.v
+++ b/vlib/net/imap/imap_test.v
@@ -106,6 +106,9 @@ fn mock_reply(tag string, cmd string, line string) string {
 		// the server says so: attached to whatever command is in flight.
 		return '* 9 EXISTS\r\n* 2 RECENT\r\n${tag} OK NOOP completed\r\n'
 	}
+	if cmd == 'WRONGTAG' {
+		return 'a9999 OK wrong tag\r\n'
+	}
 	if cmd == 'ORDERED' {
 		return '* 11 EXISTS\r\n* 5 EXPUNGE\r\n${tag} OK updates completed\r\n'
 	}
@@ -624,6 +627,23 @@ fn test_connect_rejects_replacing_a_live_transport() {
 		return
 	}
 	assert false, 'connect must not replace an open transport'
+}
+
+fn test_a_wrong_completion_tag_closes_the_transport() {
+	mut l := net.listen_tcp(.ip, '127.0.0.1:0')!
+	seen := chan string{ cap: 64 }
+	port, th := start(mut l, mock_greeting, seen)!
+	mut c := new_client(server: '127.0.0.1', port: port)!
+	c.command('WRONGTAG') or {
+		assert err.msg().contains('a9999')
+		assert !c.transport_open
+		assert !c.is_open
+		th.wait()
+		l.close() or {}
+		assert drain(seen) == ['a0001 WRONGTAG']
+		return
+	}
+	assert false, 'a mismatched completion tag must invalidate the session'
 }
 
 fn test_sasl_plain_can_be_selected_during_construction() {

--- a/vlib/net/imap/imap_test.v
+++ b/vlib/net/imap/imap_test.v
@@ -609,6 +609,23 @@ fn test_a_failed_automatic_login_closes_the_transport() {
 	assert false, 'a refused automatic login must fail construction'
 }
 
+fn test_connect_rejects_replacing_a_live_transport() {
+	mut l := net.listen_tcp(.ip, '127.0.0.1:0')!
+	seen := chan string{ cap: 64 }
+	port, th := start(mut l, mock_greeting, seen)!
+	mut c := new_client(server: '127.0.0.1', port: port)!
+	c.connect() or {
+		assert err.msg().contains('already connected')
+		c.noop()!
+		c.close()!
+		th.wait()
+		l.close() or {}
+		assert drain(seen) == ['a0001 NOOP', 'a0002 LOGOUT']
+		return
+	}
+	assert false, 'connect must not replace an open transport'
+}
+
 fn test_sasl_plain_can_be_selected_during_construction() {
 	mut l := net.listen_tcp(.ip, '127.0.0.1:0')!
 	seen := chan string{ cap: 64 }

--- a/vlib/net/imap/imap_test.v
+++ b/vlib/net/imap/imap_test.v
@@ -98,6 +98,12 @@ fn mock_reply(tag string, cmd string, line string) string {
 		// the server says so: attached to whatever command is in flight.
 		return '* 9 EXISTS\r\n* 2 RECENT\r\n${tag} OK NOOP completed\r\n'
 	}
+	if cmd == 'ORDERED' {
+		return '* 11 EXISTS\r\n* 5 EXPUNGE\r\n${tag} OK updates completed\r\n'
+	}
+	if cmd == 'FAILUPDATE' {
+		return '* 12 EXISTS\r\n${tag} NO command refused\r\n'
+	}
 	if cmd == 'LIST' || cmd == 'LSUB' {
 		return '* ${cmd} (\\Noselect) "/" ""\r\n' + '* ${cmd} (\\HasNoChildren) "/" INBOX\r\n' + '* ${cmd} (\\HasChildren) "/" "Travail"\r\n' + '* ${cmd} () "/" "Travail/&AMk-t&AOk- 2026"\r\n' + '${tag} OK ${cmd} completed\r\n'
 	}
@@ -391,6 +397,41 @@ fn test_an_explicit_count_wins_over_the_arithmetic() {
 	th.wait()
 	l.close() or {}
 	drain(seen)
+}
+
+fn test_unsolicited_counts_and_removals_keep_arrival_order() {
+	mut l := net.listen_tcp(.ip, '127.0.0.1:0')!
+	seen := chan string{ cap: 64 }
+	port, th := start(mut l, mock_greeting, seen)!
+	mut c := new_client(server: '127.0.0.1', port: port)!
+	c.select_mailbox('INBOX')!
+
+	c.command('ORDERED')!
+	assert c.exists == 10
+	c.close()!
+	th.wait()
+	l.close() or {}
+	drain(seen)
+}
+
+fn test_unsolicited_updates_survive_a_refused_command() {
+	mut l := net.listen_tcp(.ip, '127.0.0.1:0')!
+	seen := chan string{ cap: 64 }
+	port, th := start(mut l, mock_greeting, seen)!
+	mut c := new_client(server: '127.0.0.1', port: port)!
+	c.select_mailbox('INBOX')!
+
+	c.command('FAILUPDATE') or {
+		assert err.msg().contains('command refused')
+		assert c.exists == 12
+		c.noop()!
+		c.close()!
+		th.wait()
+		l.close() or {}
+		drain(seen)
+		return
+	}
+	assert false, 'the command must remain refused after applying its updates'
 }
 
 fn test_a_refused_login_is_an_error() {

--- a/vlib/net/imap/imap_test.v
+++ b/vlib/net/imap/imap_test.v
@@ -226,6 +226,7 @@ fn test_a_full_session() {
 		port: port
 		username: 'bob'
 		password: 'hunter2'
+		allow_insecure_auth: true
 	)!
 	assert c.is_open
 	assert !c.encrypted
@@ -356,7 +357,13 @@ fn test_a_password_a_quoted_string_cannot_hold_becomes_a_literal() {
 
 	// A password with an accent is eight bit, which a quoted string is not
 	// defined over.
-	mut c := new_client(server: '127.0.0.1', port: port, username: 'bob', password: 'mot-de-passé')!
+	mut c := new_client(
+		server: '127.0.0.1'
+		port: port
+		username: 'bob'
+		password: 'mot-de-passé'
+		allow_insecure_auth: true
+	)!
 	c.close()!
 	th.wait()
 	l.close() or {}
@@ -470,6 +477,7 @@ fn test_a_refused_login_is_an_error() {
 			port: port
 			username: 'bob'
 			password: 'wrong'
+			allow_insecure_auth: true
 		}
 	}
 	c.connect()!
@@ -553,7 +561,13 @@ fn test_a_preauth_greeting_opens_the_session() {
 	seen := chan string{ cap: 64 }
 	port, th := start(mut l, '* PREAUTH IMAP4rev1 already authenticated', seen)!
 
-	mut c := new_client(server: '127.0.0.1', port: port, username: 'already', password: 'unused')!
+	mut c := new_client(
+		server: '127.0.0.1'
+		port: port
+		username: 'already'
+		password: 'unused'
+		allow_insecure_auth: true
+	)!
 	assert c.is_open
 	c.noop()!
 	c.close()!
@@ -567,7 +581,13 @@ fn test_greeting_logindisabled_prevents_sending_credentials() {
 	seen := chan string{ cap: 64 }
 	port, th := start(mut l, '* OK [CAPABILITY IMAP4rev1 LOGINDISABLED] no cleartext login', seen)!
 
-	new_client(server: '127.0.0.1', port: port, username: 'bob', password: 'secret') or {
+	new_client(
+		server: '127.0.0.1'
+		port: port
+		username: 'bob'
+		password: 'secret'
+		allow_insecure_auth: true
+	) or {
 		assert err.msg().contains('disabled LOGIN')
 		th.wait()
 		l.close() or {}
@@ -612,7 +632,13 @@ fn test_a_failed_automatic_login_closes_the_transport() {
 	seen := chan string{ cap: 64 }
 	port, th := start(mut l, mock_greeting, seen)!
 
-	new_client(server: '127.0.0.1', port: port, username: 'bob', password: 'wrong') or {
+	new_client(
+		server: '127.0.0.1'
+		port: port
+		username: 'bob'
+		password: 'wrong'
+		allow_insecure_auth: true
+	) or {
 		assert err.msg().contains('Invalid credentials')
 		// The mock exits only after its peer closes, so this also verifies that
 		// the setup error did not leave the transport behind.
@@ -708,6 +734,7 @@ fn test_sasl_plain_can_be_selected_during_construction() {
 		username: 'bob'
 		password: 'hunter2'
 		auth_method: .plain
+		allow_insecure_auth: true
 	)!
 	c.close()!
 	th.wait()
@@ -761,6 +788,14 @@ fn test_tls_certificate_validation_defaults_to_on() {
 	assert !Config{
 		validate: false
 	}.validate
+}
+
+fn test_plaintext_credentials_require_explicit_opt_in() {
+	new_client(server: '127.0.0.1', port: 1, username: 'bob', password: 'secret') or {
+		assert err.msg().contains('allow_insecure_auth')
+		return
+	}
+	assert false, 'plaintext credentials must be rejected before dialing'
 }
 
 fn test_tls_validation_requires_an_explicit_ca_bundle() {

--- a/vlib/net/imap/imap_test.v
+++ b/vlib/net/imap/imap_test.v
@@ -27,6 +27,18 @@ fn run_server(mut l net.TcpListener, hello string, seen chan string) {
 	mut r := io.new_buffered_reader(reader: c)
 	for {
 		mut line := r.read_line() or { return }
+		if line.contains('APPEND "BadTag"') {
+			seen <- line
+			c.write_string('a9999 OK wrong tag\r\n') or { return }
+			r.read_line() or { return }
+			return
+		}
+		if line.contains('APPEND "Reject"') {
+			seen <- line
+			tag := line.fields()[0]
+			c.write_string('${tag} NO append refused\r\n') or { return }
+			continue
+		}
 		// A command may carry literals. Each one is announced by the client,
 		// acknowledged here, and only then sent.
 		for {
@@ -646,6 +658,46 @@ fn test_a_wrong_completion_tag_closes_the_transport() {
 	assert false, 'a mismatched completion tag must invalidate the session'
 }
 
+fn test_a_wrong_literal_continuation_tag_closes_the_transport() {
+	mut l := net.listen_tcp(.ip, '127.0.0.1:0')!
+	seen := chan string{ cap: 64 }
+	port, th := start(mut l, mock_greeting, seen)!
+	mut c := new_client(server: '127.0.0.1', port: port)!
+	c.append('BadTag', [], time.Time{}, 'body'.bytes()) or {
+		assert err.msg().contains('a9999')
+		assert !c.transport_open
+		assert !c.is_open
+		th.wait()
+		l.close() or {}
+		assert drain(seen) == ['a0001 APPEND "BadTag" {4}']
+		return
+	}
+	assert false, 'a mismatched continuation tag must invalidate the session'
+}
+
+fn test_a_refused_literal_continuation_keeps_the_session_usable() {
+	mut l := net.listen_tcp(.ip, '127.0.0.1:0')!
+	seen := chan string{ cap: 64 }
+	port, th := start(mut l, mock_greeting, seen)!
+	mut c := new_client(server: '127.0.0.1', port: port)!
+	c.append('Reject', [], time.Time{}, 'body'.bytes()) or {
+		assert err.msg().contains('append refused')
+		assert c.transport_open
+		assert c.is_open
+		c.noop()!
+		c.close()!
+		th.wait()
+		l.close() or {}
+		assert drain(seen) == [
+			'a0001 APPEND "Reject" {4}',
+			'a0002 NOOP',
+			'a0003 LOGOUT',
+		]
+		return
+	}
+	assert false, 'a refused continuation must be reported as an error'
+}
+
 fn test_sasl_plain_can_be_selected_during_construction() {
 	mut l := net.listen_tcp(.ip, '127.0.0.1:0')!
 	seen := chan string{ cap: 64 }
@@ -665,6 +717,16 @@ fn test_sasl_plain_can_be_selected_during_construction() {
 		base64.encode_str('\0bob\0hunter2'),
 		'a0002 LOGOUT',
 	]
+}
+
+fn test_authentication_debug_lines_are_redacted() {
+	login := imap_debug_line('a0001 LOGIN "bob" "hunter2"', true)
+	assert login == 'a0001 LOGIN <credentials redacted>'
+	assert !login.contains('bob')
+	assert !login.contains('hunter2')
+	plain := imap_debug_line(base64.encode_str('\0bob\0hunter2'), true)
+	assert plain == '<authentication data redacted>'
+	assert imap_debug_line('a0002 NOOP', false) == 'a0002 NOOP'
 }
 
 fn test_an_unsolicited_bye_closes_the_local_transport() {

--- a/vlib/net/imap/imap_test.v
+++ b/vlib/net/imap/imap_test.v
@@ -586,6 +586,14 @@ fn test_ssl_and_starttls_are_mutually_exclusive() {
 	assert false, 'asking for both TLS modes must be rejected'
 }
 
+fn test_tls_certificate_validation_defaults_to_on() {
+	config := Config{}
+	assert config.validate
+	assert !Config{
+		validate: false
+	}.validate
+}
+
 fn test_empty_sets_do_not_reach_the_server() {
 	mut l := net.listen_tcp(.ip, '127.0.0.1:0')!
 	seen := chan string{ cap: 64 }

--- a/vlib/net/imap/imap_test.v
+++ b/vlib/net/imap/imap_test.v
@@ -3,6 +3,7 @@ module imap
 import io
 import net
 import time
+import encoding.base64
 
 // These drive the client over a real socket against a scripted server, so that
 // tagging, literal sending, continuations and the mailbox name encoding are
@@ -38,6 +39,13 @@ fn run_server(mut l net.TcpListener, hello string, seen chan string) {
 		seen <- line
 		fields := line.split(' ')
 		if fields.len < 2 {
+			continue
+		}
+		if fields[1].to_upper() == 'AUTHENTICATE' {
+			c.write_string('+ continue\r\n') or { return }
+			payload := r.read_line() or { return }
+			seen <- payload
+			c.write_string('${fields[0]} OK AUTHENTICATE completed\r\n') or { return }
 			continue
 		}
 		c.write_string(mock_reply(fields[0], fields[1].to_upper(), line)) or { return }
@@ -559,7 +567,7 @@ fn test_preauth_cannot_bypass_requested_starttls() {
 	seen := chan string{ cap: 64 }
 	port, th := start(mut l, '* PREAUTH already authenticated', seen)!
 
-	new_client(server: '127.0.0.1', port: port, starttls: true) or {
+	new_client(server: '127.0.0.1', port: port, starttls: true, validate: false) or {
 		assert err.msg().contains('before STARTTLS')
 		th.wait()
 		l.close() or {}
@@ -574,7 +582,7 @@ fn test_a_refused_starttls_closes_the_transport() {
 	seen := chan string{ cap: 64 }
 	port, th := start(mut l, mock_greeting, seen)!
 
-	new_client(server: '127.0.0.1', port: port, starttls: true) or {
+	new_client(server: '127.0.0.1', port: port, starttls: true, validate: false) or {
 		assert err.msg().contains('unknown command')
 		th.wait()
 		l.close() or {}
@@ -599,6 +607,27 @@ fn test_a_failed_automatic_login_closes_the_transport() {
 		return
 	}
 	assert false, 'a refused automatic login must fail construction'
+}
+
+fn test_sasl_plain_can_be_selected_during_construction() {
+	mut l := net.listen_tcp(.ip, '127.0.0.1:0')!
+	seen := chan string{ cap: 64 }
+	port, th := start(mut l, '* OK [CAPABILITY IMAP4rev1 AUTH=PLAIN LOGINDISABLED] ready', seen)!
+	mut c := new_client(
+		server: '127.0.0.1'
+		port: port
+		username: 'bob'
+		password: 'hunter2'
+		auth_method: .plain
+	)!
+	c.close()!
+	th.wait()
+	l.close() or {}
+	assert drain(seen) == [
+		'a0001 AUTHENTICATE PLAIN',
+		base64.encode_str('\0bob\0hunter2'),
+		'a0002 LOGOUT',
+	]
 }
 
 fn test_an_unsolicited_bye_closes_the_local_transport() {
@@ -633,6 +662,14 @@ fn test_tls_certificate_validation_defaults_to_on() {
 	assert !Config{
 		validate: false
 	}.validate
+}
+
+fn test_tls_validation_requires_an_explicit_ca_bundle() {
+	new_client(server: 'imap.example.com', ssl: true) or {
+		assert err.msg().contains('requires a CA bundle')
+		return
+	}
+	assert false, 'validated TLS without trust roots must fail before dialing'
 }
 
 fn test_empty_sets_do_not_reach_the_server() {

--- a/vlib/net/imap/imap_test.v
+++ b/vlib/net/imap/imap_test.v
@@ -146,6 +146,9 @@ fn mock_reply(tag string, cmd string, line string) string {
 	if cmd == 'LOGOUT' {
 		return '* BYE mock signing off\r\n${tag} OK LOGOUT completed\r\n'
 	}
+	if cmd == 'BYE' {
+		return '* BYE server going away\r\n'
+	}
 	if cmd in ['CREATE', 'DELETE', 'RENAME', 'CHECK', 'SUBSCRIBE', 'UNSUBSCRIBE', 'UNSELECT', 'COPY',
 		'MOVE'] {
 		return '${tag} OK ${cmd} completed\r\n'
@@ -363,11 +366,10 @@ fn test_unsolicited_updates_reach_the_client() {
 	c.noop()!
 	assert c.exists == 9
 	assert c.recent == 2
-	// Two removals with no fresh count behind them, the way Dovecot answers.
-	// The client has to do the arithmetic itself, or it goes on reporting
-	// messages it just watched being taken out.
+	// Leaving the mailbox clears counters that no longer describe a selected
+	// mailbox, even when Dovecot reports removals without a fresh count.
 	c.close_mailbox()!
-	assert c.exists == 7
+	assert c.exists == 0
 	c.close()!
 	th.wait()
 	l.close() or {}
@@ -424,8 +426,14 @@ fn test_a_refused_command_leaves_the_session_usable() {
 	port, th := start(mut l, mock_greeting, seen)!
 
 	mut c := new_client(server: '127.0.0.1', port: port)!
+	c.select_mailbox('INBOX')!
+	assert c.selected == 'INBOX'
+	assert c.exists == 172
 	c.select_mailbox('Nope') or {
 		assert err.msg().contains('Mailbox does not exist')
+		assert c.selected == ''
+		assert c.exists == 0
+		assert c.recent == 0
 		// The failure was the server's answer, not a broken connection, so the
 		// next command must still work.
 		c.noop()!
@@ -481,13 +489,93 @@ fn test_a_preauth_greeting_opens_the_session() {
 	seen := chan string{ cap: 64 }
 	port, th := start(mut l, '* PREAUTH IMAP4rev1 already authenticated', seen)!
 
-	mut c := new_client(server: '127.0.0.1', port: port)!
+	mut c := new_client(server: '127.0.0.1', port: port, username: 'already', password: 'unused')!
 	assert c.is_open
 	c.noop()!
 	c.close()!
 	th.wait()
 	l.close() or {}
-	drain(seen)
+	assert drain(seen) == ['a0001 NOOP', 'a0002 LOGOUT']
+}
+
+fn test_greeting_logindisabled_prevents_sending_credentials() {
+	mut l := net.listen_tcp(.ip, '127.0.0.1:0')!
+	seen := chan string{ cap: 64 }
+	port, th := start(mut l, '* OK [CAPABILITY IMAP4rev1 LOGINDISABLED] no cleartext login', seen)!
+
+	new_client(server: '127.0.0.1', port: port, username: 'bob', password: 'secret') or {
+		assert err.msg().contains('disabled LOGIN')
+		th.wait()
+		l.close() or {}
+		assert drain(seen) == []
+		return
+	}
+	assert false, 'LOGINDISABLED must prevent automatic LOGIN'
+}
+
+fn test_preauth_cannot_bypass_requested_starttls() {
+	mut l := net.listen_tcp(.ip, '127.0.0.1:0')!
+	seen := chan string{ cap: 64 }
+	port, th := start(mut l, '* PREAUTH already authenticated', seen)!
+
+	new_client(server: '127.0.0.1', port: port, starttls: true) or {
+		assert err.msg().contains('before STARTTLS')
+		th.wait()
+		l.close() or {}
+		assert drain(seen) == []
+		return
+	}
+	assert false, 'PREAUTH cannot satisfy a requested STARTTLS upgrade'
+}
+
+fn test_a_refused_starttls_closes_the_transport() {
+	mut l := net.listen_tcp(.ip, '127.0.0.1:0')!
+	seen := chan string{ cap: 64 }
+	port, th := start(mut l, mock_greeting, seen)!
+
+	new_client(server: '127.0.0.1', port: port, starttls: true) or {
+		assert err.msg().contains('unknown command')
+		th.wait()
+		l.close() or {}
+		assert drain(seen) == ['a0001 STARTTLS']
+		return
+	}
+	assert false, 'a refused STARTTLS must fail construction'
+}
+
+fn test_a_failed_automatic_login_closes_the_transport() {
+	mut l := net.listen_tcp(.ip, '127.0.0.1:0')!
+	seen := chan string{ cap: 64 }
+	port, th := start(mut l, mock_greeting, seen)!
+
+	new_client(server: '127.0.0.1', port: port, username: 'bob', password: 'wrong') or {
+		assert err.msg().contains('Invalid credentials')
+		// The mock exits only after its peer closes, so this also verifies that
+		// the setup error did not leave the transport behind.
+		th.wait()
+		l.close() or {}
+		assert drain(seen) == ['a0001 LOGIN "bob" "wrong"']
+		return
+	}
+	assert false, 'a refused automatic login must fail construction'
+}
+
+fn test_an_unsolicited_bye_closes_the_local_transport() {
+	mut l := net.listen_tcp(.ip, '127.0.0.1:0')!
+	seen := chan string{ cap: 64 }
+	port, th := start(mut l, mock_greeting, seen)!
+	mut c := new_client(server: '127.0.0.1', port: port)!
+
+	c.command('BYE') or {
+		assert err.msg().contains('server closed the session')
+		assert !c.is_open
+		assert !c.transport_open
+		th.wait()
+		l.close() or {}
+		assert drain(seen) == ['a0001 BYE']
+		return
+	}
+	assert false, 'an unsolicited BYE must fail the outstanding command'
 }
 
 fn test_ssl_and_starttls_are_mutually_exclusive() {
@@ -586,4 +674,19 @@ fn test_build_args_splits_out_what_must_be_a_literal() {
 	escaped, none_needed := build_args('CREATE', ['od"d\\name'])
 	assert escaped == ['CREATE "od\\"d\\\\name"']
 	assert none_needed.len == 0
+}
+
+fn test_append_dates_are_rendered_as_utc() {
+	local := time.Time{
+		year: 2026
+		month: 9
+		day: 7
+		hour: 12
+		minute: 34
+		second: 56
+		is_local: true
+	}
+	utc := local.local_to_utc()
+	expected := '${utc.day:02}-${month_names[utc.month - 1]}-${utc.year:04} ${utc.hour:02}:${utc.minute:02}:${utc.second:02} +0000'
+	assert format_internal_date(local) == expected
 }

--- a/vlib/net/imap/response.v
+++ b/vlib/net/imap/response.v
@@ -1,0 +1,887 @@
+module imap
+
+import time
+
+// The response types, and the grammar that fills them in.
+//
+// A server answers a command with any number of untagged responses followed by
+// one tagged completion. The untagged ones are not all a reply to the command
+// at hand: a mailbox can change under a client at any moment, and the server
+// reports that by slipping EXISTS, EXPUNGE and FETCH responses into whatever
+// exchange happens to be in flight. They are collected here rather than
+// discarded.
+
+// Status is the outcome a tagged completion reports.
+pub enum Status {
+	ok
+	no
+	bad
+	bye
+	preauth
+}
+
+// Mailbox is the state of a mailbox at the moment it was selected.
+pub struct Mailbox {
+pub:
+	name string
+	// exists is the number of messages in the mailbox.
+	exists u32
+	// recent is how many of them arrived since the last session looked.
+	recent u32
+	// unseen is the sequence number of the first unread message, zero when the
+	// server did not report one.
+	unseen u32
+	// flags are the flags this mailbox can hold.
+	flags []string
+	// permanent_flags are the ones a STORE can make stick. A `\*` among them
+	// means the mailbox accepts new keywords.
+	permanent_flags []string
+	// uid_validity changes when the server can no longer promise that UIDs
+	// from an earlier session still name the same messages.
+	uid_validity u32
+	// uid_next is the UID the next arriving message is expected to take.
+	uid_next u32
+	// read_only is true for a mailbox opened with `examine`, and also for one
+	// opened with `select` that the server would only give out read-only.
+	read_only bool
+}
+
+// MailboxInfo is one entry of a mailbox listing.
+pub struct MailboxInfo {
+pub:
+	name string
+	// delimiter separates the levels of a hierarchical name, and is empty when
+	// the server presents a flat namespace.
+	delimiter string
+	// attributes are the server's notes about the mailbox, such as `\Noselect`
+	// for a name that only exists to hold children.
+	attributes []string
+}
+
+// MailboxStatus is what STATUS reports about a mailbox without selecting it.
+pub struct MailboxStatus {
+pub:
+	name         string
+	messages     u32
+	recent       u32
+	uid_next     u32
+	uid_validity u32
+	unseen       u32
+}
+
+// Address is one sender or recipient, as an envelope carries it. `name` is
+// the display name, empty when the message gave none.
+pub struct Address {
+pub:
+	name string
+	// mailbox is the part before the `@`, or the group name when `host` is
+	// empty and this address opens a group.
+	mailbox string
+	// host is the part after the `@`.
+	host string
+}
+
+// addr renders the address as `someone@example.com`, and is empty for the
+// markers that open and close a group.
+pub fn (a &Address) addr() string {
+	if a.mailbox == '' || a.host == '' {
+		return ''
+	}
+	return '${a.mailbox}@${a.host}'
+}
+
+// Envelope is the parsed header of a message, which a server can produce
+// without the client fetching and parsing the header itself.
+pub struct Envelope {
+pub:
+	date        string
+	subject     string
+	from        []Address
+	sender      []Address
+	reply_to    []Address
+	to          []Address
+	cc          []Address
+	bcc         []Address
+	in_reply_to string
+	message_id  string
+}
+
+// BodyStructure describes one MIME part. A multipart has `parts` filled in and
+// a media type of `multipart`; every other part is a leaf.
+pub struct BodyStructure {
+pub:
+	media_type    string
+	media_subtype string
+	params        map[string]string
+	id            string
+	description   string
+	encoding      string
+	// size is the part's length in octets, and `lines` its line count for a
+	// text part.
+	size  u32
+	lines u32
+	parts []BodyStructure
+}
+
+// mime_type renders the pair as it appears in a Content-Type header.
+pub fn (b &BodyStructure) mime_type() string {
+	return '${b.media_type.to_lower()}/${b.media_subtype.to_lower()}'
+}
+
+// Message is one fetched message, holding whatever the fetch asked for.
+//
+// `seq` is its sequence number in the selected mailbox and is always set. The
+// rest is filled in only when the fetch requested it.
+pub struct Message {
+pub:
+	seq   u32
+	uid   u32
+	flags []string
+	// size is what RFC822.SIZE reported.
+	size u32
+	// internal_date is when the server took delivery, which is not the Date
+	// header and does not change when a message is copied.
+	internal_date time.Time
+	envelope      ?Envelope
+	structure     ?BodyStructure
+	// sections holds every body section the fetch asked for, keyed by the
+	// specification the server echoed back: `BODY[]` for the whole message,
+	// `BODY[HEADER]` for the header block, `BODY[1.2]` for one MIME part.
+	sections map[string]string
+}
+
+// body returns the whole message when it was fetched, and the lone section
+// when exactly one was, which is what a fetch of a single section wants.
+//
+// A fetch of several sections has no one answer, so it gives back nothing;
+// read `sections` directly in that case.
+pub fn (m &Message) body() string {
+	if whole := m.sections['BODY[]'] {
+		return whole
+	}
+	if m.sections.len != 1 {
+		return ''
+	}
+	return m.sections[m.sections.keys()[0]]
+}
+
+// Response gathers everything a command produced: what it was asked for, and
+// whatever the server volunteered along the way.
+struct Response {
+mut:
+	status       Status
+	code         string
+	text         string
+	capabilities []string
+	mailboxes    []MailboxInfo
+	messages     []Message
+	numbers      []u32
+	// set is what an ESEARCH response carries instead of a flat list, kept as
+	// ranges rather than expanded: a result covering a whole large mailbox is
+	// a handful of ranges and millions of numbers.
+	set      SeqSet
+	has_set  bool
+	expunged []u32
+	statuses []MailboxStatus
+	// The mailbox state SELECT and EXAMINE report, and the running counts an
+	// untagged EXISTS or RECENT updates at any other time.
+	flags           []string
+	permanent_flags []string
+	exists          u32
+	recent          u32
+	unseen          u32
+	uid_next        u32
+	uid_validity    u32
+	read_only       bool
+	// has_exists and has_recent record whether the server said anything at
+	// all, since zero is a perfectly ordinary count.
+	has_exists bool
+	has_recent bool
+}
+
+// read_response reads responses until the one tagged `tag`, and turns a NO or
+// BAD completion into an error.
+fn (mut c Client) read_response(tag string) !Response {
+	mut out := Response{}
+	for {
+		mut d := c.decoder()!
+		if d.accept(`+`)! {
+			return error('imap: the server asked to continue a command that sends nothing more')
+		}
+		if d.accept(`*`)! {
+			d.sp()!
+			c.read_untagged(mut d, mut out)!
+			d.crlf()!
+			continue
+		}
+		got := d.astring()!
+		d.sp()!
+		read_completion(mut d, mut out)!
+		d.crlf()!
+		if got != tag {
+			return error('imap: the server answered tag `${got}` while `${tag}` was outstanding')
+		}
+		if out.status == .ok {
+			return out
+		}
+		return error('imap: ${out.status} ${out.text}')
+	}
+	return out
+}
+
+// read_untagged reads one `* ...` response, whichever of the several shapes it
+// takes. Everything it learns is folded into `out`.
+fn (mut c Client) read_untagged(mut d Decoder, mut out Response) ! {
+	// A message data response opens with the message number, so a leading
+	// digit settles the shape before any keyword is read.
+	first := d.peek_byte()!
+	if first >= `0` && first <= `9` {
+		n := d.number()!
+		d.sp()!
+		return read_message_data(mut d, mut out, n)
+	}
+	name := d.atom()!.to_upper()
+	match name {
+		'OK', 'NO', 'BAD', 'BYE', 'PREAUTH' {
+			out.status = status_from(name)!
+			_ := d.accept(` `)!
+			read_resp_text(mut d, mut out)!
+			// An untagged BYE means the server is closing the connection, so
+			// the session must not be treated as usable afterwards.
+			if name == 'BYE' {
+				c.is_open = false
+			}
+		}
+		'CAPABILITY' {
+			out.capabilities = read_space_separated(mut d)!
+		}
+		'FLAGS' {
+			d.sp()!
+			out.flags = d.flag_list()!
+		}
+		'LIST', 'LSUB' {
+			d.sp()!
+			out.mailboxes << read_mailbox_list(mut d)!
+		}
+		'SEARCH', 'SORT' {
+			out.numbers = read_numbers(mut d)!
+		}
+		'STATUS' {
+			d.sp()!
+			out.statuses << read_status_data(mut d)!
+		}
+		'ESEARCH' {
+			// RFC 4731 replaces the flat SEARCH list with a keyed one. Only
+			// the message set is of interest here.
+			read_esearch(mut d, mut out)!
+		}
+		else {
+			// An extension this module does not model. Its line is skipped
+			// whole rather than half read.
+			d.text()!
+		}
+	}
+}
+
+// read_message_data reads `<n> EXISTS`, `<n> RECENT`, `<n> EXPUNGE` or
+// `<n> FETCH (...)`.
+fn read_message_data(mut d Decoder, mut out Response, n u32) ! {
+	name := d.atom()!.to_upper()
+	if name == 'EXISTS' {
+		out.exists = n
+		out.has_exists = true
+		return
+	}
+	if name == 'RECENT' {
+		out.recent = n
+		out.has_recent = true
+		return
+	}
+	if name == 'EXPUNGE' {
+		out.expunged << n
+		return
+	}
+	if name == 'FETCH' {
+		d.sp()!
+		out.messages << read_msg_att(mut d, n)!
+		return
+	}
+	return error('imap: unknown message data response `${name}`')
+}
+
+// read_msg_att reads the parenthesised list of items a FETCH response carries.
+// The items may come in any order, and an unknown one is stepped over whole.
+fn read_msg_att(mut d Decoder, seq u32) !Message {
+	mut uid := u32(0)
+	mut flags := []string{}
+	mut size := u32(0)
+	mut internal_date := time.Time{}
+	mut envelope := ?Envelope(none)
+	mut structure := ?BodyStructure(none)
+	mut sections := map[string]string{}
+
+	if !d.open_list()! {
+		return Message{
+			seq: seq
+		}
+	}
+	for {
+		name := d.item_name()!.to_upper()
+		match name {
+			'UID' {
+				d.sp()!
+				uid = d.number()!
+			}
+			'FLAGS' {
+				d.sp()!
+				flags = d.flag_list()!
+			}
+			'RFC822.SIZE' {
+				d.sp()!
+				size = d.number()!
+			}
+			'INTERNALDATE' {
+				d.sp()!
+				internal_date = parse_internal_date(d.quoted()!)!
+			}
+			'ENVELOPE' {
+				d.sp()!
+				envelope = read_envelope(mut d)!
+			}
+			'BODYSTRUCTURE' {
+				d.sp()!
+				structure = read_body_structure(mut d)!
+			}
+			'RFC822', 'RFC822.HEADER', 'RFC822.TEXT' {
+				// The older spellings of the three commonest sections.
+				d.sp()!
+				sections[rfc822_section(name)] = d.nstring_text()!
+			}
+			'BODY' {
+				// `BODY` alone is the body structure; `BODY[...]` is content.
+				is_section := d.accept(`[`)!
+				if is_section {
+					key := read_section_key(mut d)!
+					d.sp()!
+					sections[key] = d.nstring_text()!
+				}
+				if !is_section {
+					d.sp()!
+					structure = read_body_structure(mut d)!
+				}
+			}
+			else {
+				d.sp()!
+				d.skip_value()!
+			}
+		}
+		if !d.more_in_list()! {
+			break
+		}
+	}
+	return Message{
+		seq: seq
+		uid: uid
+		flags: flags
+		size: size
+		internal_date: internal_date
+		envelope: envelope
+		structure: structure
+		sections: sections
+	}
+}
+
+// read_section_key reads what sits between the brackets of `BODY[...]`, along
+// with the byte range that may follow it, and gives back the whole thing as
+// the server wrote it. That is the key a caller looks the section up by, so it
+// has to come back in one piece: `BODY[HEADER]`, or `BODY[]<0>` for a fetch
+// that asked for only part of the message.
+fn read_section_key(mut d Decoder) !string {
+	mut out := []u8{}
+	mut depth := 0
+	mut in_quotes := false
+	for {
+		ch := d.read_byte()!
+		if in_quotes {
+			out << ch
+			if ch == `\\` {
+				out << d.read_byte()!
+				continue
+			}
+			if ch == `"` {
+				in_quotes = false
+			}
+			continue
+		}
+		if ch == `"` {
+			in_quotes = true
+			out << ch
+			continue
+		}
+		if ch == `(` {
+			depth++
+		}
+		if ch == `)` {
+			depth--
+		}
+		if ch == `]` && depth == 0 {
+			break
+		}
+		out << ch
+	}
+	// A partial fetch echoes the offset it started at, as `<1024>`.
+	if !d.accept(`<`)! {
+		return 'BODY[${out.bytestr()}]'
+	}
+	offset := d.number()!
+	d.expect(`>`)!
+	return 'BODY[${out.bytestr()}]<${offset}>'
+}
+
+// rfc822_section maps the RFC822 spellings onto the section they name, so that
+// a caller finds the content under one key whichever form the server used.
+fn rfc822_section(name string) string {
+	if name == 'RFC822.HEADER' {
+		return 'BODY[HEADER]'
+	}
+	if name == 'RFC822.TEXT' {
+		return 'BODY[TEXT]'
+	}
+	return 'BODY[]'
+}
+
+// read_envelope reads the ten fields of an envelope, in the fixed order the
+// grammar gives them.
+fn read_envelope(mut d Decoder) !Envelope {
+	d.expect(`(`)!
+	date := d.nstring_text()!
+	d.sp()!
+	subject := d.nstring_text()!
+	d.sp()!
+	from := read_address_list(mut d)!
+	d.sp()!
+	sender := read_address_list(mut d)!
+	d.sp()!
+	reply_to := read_address_list(mut d)!
+	d.sp()!
+	to := read_address_list(mut d)!
+	d.sp()!
+	cc := read_address_list(mut d)!
+	d.sp()!
+	bcc := read_address_list(mut d)!
+	d.sp()!
+	in_reply_to := d.nstring_text()!
+	d.sp()!
+	message_id := d.nstring_text()!
+	d.expect(`)`)!
+	return Envelope{
+		date: date
+		subject: subject
+		from: from
+		sender: sender
+		reply_to: reply_to
+		to: to
+		cc: cc
+		bcc: bcc
+		in_reply_to: in_reply_to
+		message_id: message_id
+	}
+}
+
+// read_address_list reads a run of addresses, or NIL for a header the message
+// did not carry.
+//
+// The addresses are concatenated with nothing between them: the grammar is
+// `"(" 1*address ")"`, not a list whose elements are separated by spaces.
+fn read_address_list(mut d Decoder) ![]Address {
+	mut out := []Address{}
+	if d.peek_byte()! != `(` {
+		word := d.atom()!
+		if word.to_upper() != 'NIL' {
+			return error('imap: expected an address list or NIL, got `${word}`')
+		}
+		return out
+	}
+	d.expect(`(`)!
+	for d.peek_byte()! == `(` {
+		out << read_address(mut d)!
+	}
+	d.expect(`)`)!
+	return out
+}
+
+// read_address reads `(name adl mailbox host)`.
+fn read_address(mut d Decoder) !Address {
+	d.expect(`(`)!
+	name := d.nstring_text()!
+	d.sp()!
+	// The source route of RFC 2822 is obsolete, and no sender writes one.
+	d.nstring_text()!
+	d.sp()!
+	mailbox := d.nstring_text()!
+	d.sp()!
+	host := d.nstring_text()!
+	d.expect(`)`)!
+	return Address{
+		name: name
+		mailbox: mailbox
+		host: host
+	}
+}
+
+// read_body_structure reads one MIME part. A part whose first element is a
+// list is a multipart, and the lists it opens with are its children.
+fn read_body_structure(mut d Decoder) !BodyStructure {
+	d.expect(`(`)!
+	if d.peek_byte()! == `(` {
+		return read_multipart(mut d)
+	}
+	media_type := d.string_value()!
+	d.sp()!
+	media_subtype := d.string_value()!
+	d.sp()!
+	params := read_param_list(mut d)!
+	d.sp()!
+	id := d.nstring_text()!
+	d.sp()!
+	description := d.nstring_text()!
+	d.sp()!
+	encoding := d.string_value()!
+	d.sp()!
+	size := d.number()!
+	mut lines := u32(0)
+	// A text part states its line count, and an embedded message states its
+	// envelope, its own structure and its line count. Neither is required to
+	// be followed by the extension fields, so each step is guarded.
+	if media_type.to_upper() == 'TEXT' && d.accept(` `)! {
+		lines = d.number()!
+	}
+	if media_type.to_upper() == 'MESSAGE' && media_subtype.to_upper() == 'RFC822' && d.accept(` `)! {
+		read_envelope(mut d)!
+		d.sp()!
+		read_body_structure(mut d)!
+		d.sp()!
+		lines = d.number()!
+	}
+	skip_extensions(mut d)!
+	return BodyStructure{
+		media_type: media_type
+		media_subtype: media_subtype
+		params: params
+		id: id
+		description: description
+		encoding: encoding
+		size: size
+		lines: lines
+	}
+}
+
+fn read_multipart(mut d Decoder) !BodyStructure {
+	mut parts := []BodyStructure{}
+	for d.peek_byte()! == `(` {
+		parts << read_body_structure(mut d)!
+	}
+	d.sp()!
+	media_subtype := d.string_value()!
+	skip_extensions(mut d)!
+	return BodyStructure{
+		media_type: 'multipart'
+		media_subtype: media_subtype
+		parts: parts
+	}
+}
+
+// skip_extensions steps over the optional trailing fields of a body structure
+// and consumes the closing parenthesis. They carry the disposition, the
+// language and the location, none of which this module models, but a part that
+// has them still has to be read past.
+fn skip_extensions(mut d Decoder) ! {
+	for {
+		if d.accept(`)`)! {
+			return
+		}
+		d.sp()!
+		d.skip_value()!
+	}
+}
+
+// read_param_list reads the `("charset" "utf-8")` pairs of a content type, or
+// NIL when there are none.
+fn read_param_list(mut d Decoder) !map[string]string {
+	mut out := map[string]string{}
+	if d.peek_byte()! != `(` {
+		word := d.atom()!
+		if word.to_upper() != 'NIL' {
+			return error('imap: expected a parameter list or NIL, got `${word}`')
+		}
+		return out
+	}
+	if !d.open_list()! {
+		return out
+	}
+	for {
+		key := d.string_value()!
+		d.sp()!
+		out[key.to_lower()] = d.string_value()!
+		if !d.more_in_list()! {
+			return out
+		}
+	}
+	return out
+}
+
+// read_mailbox_list reads the body of a LIST or LSUB response.
+fn read_mailbox_list(mut d Decoder) !MailboxInfo {
+	attributes := d.flag_list()!
+	d.sp()!
+	// The delimiter is a quoted character, or NIL for a flat namespace.
+	mut delimiter := ''
+	is_quoted := d.peek_byte()! == `"`
+	if is_quoted {
+		delimiter = d.quoted()!
+	}
+	if !is_quoted {
+		word := d.atom()!
+		if word.to_upper() != 'NIL' {
+			return error('imap: expected a hierarchy delimiter or NIL, got `${word}`')
+		}
+	}
+	d.sp()!
+	raw := d.astring()!
+	return MailboxInfo{
+		name: utf7_decode(raw) or { raw }
+		delimiter: delimiter
+		attributes: attributes
+	}
+}
+
+// read_status_data reads `STATUS mailbox (MESSAGES 231 UIDNEXT 44292)`.
+fn read_status_data(mut d Decoder) !MailboxStatus {
+	raw := d.astring()!
+	d.sp()!
+	mut messages := u32(0)
+	mut recent := u32(0)
+	mut uid_next := u32(0)
+	mut uid_validity := u32(0)
+	mut unseen := u32(0)
+	if d.open_list()! {
+		for {
+			name := d.atom()!.to_upper()
+			d.sp()!
+			value := d.number()!
+			match name {
+				'MESSAGES' {
+					messages = value
+				}
+				'RECENT' {
+					recent = value
+				}
+				'UIDNEXT' {
+					uid_next = value
+				}
+				'UIDVALIDITY' {
+					uid_validity = value
+				}
+				'UNSEEN' {
+					unseen = value
+				}
+				else {}
+			}
+			if !d.more_in_list()! {
+				break
+			}
+		}
+	}
+	return MailboxStatus{
+		name: utf7_decode(raw) or { raw }
+		messages: messages
+		recent: recent
+		uid_next: uid_next
+		uid_validity: uid_validity
+		unseen: unseen
+	}
+}
+
+// read_esearch reads the keyed search result of RFC 4731, keeping the message
+// set and stepping over the counts.
+fn read_esearch(mut d Decoder, mut out Response) ! {
+	for {
+		if !d.accept(` `)! {
+			return
+		}
+		if d.peek_byte()! == `(` {
+			// The correlator, naming the command this answers.
+			d.skip_value()!
+			continue
+		}
+		name := d.atom()!.to_upper()
+		// `UID` is a bare marker saying the numbers are UIDs, with no value of
+		// its own.
+		if name == 'UID' {
+			continue
+		}
+		d.sp()!
+		if name == 'ALL' {
+			out.set = parse_seq_set(d.seq_set_token()!)!
+			out.has_set = true
+			continue
+		}
+		// MIN, MAX, COUNT and the rest all carry a single number.
+		d.atom()!
+	}
+}
+
+// read_resp_text reads the human readable tail of a status response, along
+// with the machine readable code that may precede it in brackets.
+fn read_resp_text(mut d Decoder, mut out Response) ! {
+	if d.accept(`[`)! {
+		read_resp_text_code(mut d, mut out)!
+		d.expect(`]`)!
+		// A code with nothing after it is unusual but legal.
+		_ := d.accept(` `)!
+	}
+	out.text = d.text()!
+}
+
+// read_resp_text_code reads one bracketed response code. Several of them carry
+// the mailbox state that SELECT reports.
+fn read_resp_text_code(mut d Decoder, mut out Response) ! {
+	name := d.atom()!.to_upper()
+	out.code = name
+	match name {
+		'UNSEEN' {
+			d.sp()!
+			out.unseen = d.number()!
+		}
+		'UIDNEXT' {
+			d.sp()!
+			out.uid_next = d.number()!
+		}
+		'UIDVALIDITY' {
+			d.sp()!
+			out.uid_validity = d.number()!
+		}
+		'PERMANENTFLAGS' {
+			d.sp()!
+			out.permanent_flags = d.flag_list()!
+		}
+		'READ-ONLY' {
+			out.read_only = true
+		}
+		'READ-WRITE' {
+			out.read_only = false
+		}
+		'CAPABILITY' {
+			out.capabilities = read_space_separated(mut d)!
+		}
+		else {
+			// Any other code, with or without an argument, is stepped over.
+			for d.peek_byte()! != `]` {
+				d.read_byte()!
+			}
+		}
+	}
+}
+
+// read_space_separated reads a run of space separated atoms, which is how
+// capabilities are listed.
+fn read_space_separated(mut d Decoder) ![]string {
+	mut out := []string{}
+	for d.accept(` `)! {
+		out << d.atom()!
+	}
+	return out
+}
+
+// read_numbers reads a run of space separated numbers, which is how SEARCH
+// answers.
+fn read_numbers(mut d Decoder) ![]u32 {
+	mut out := []u32{}
+	for d.accept(` `)! {
+		out << d.number()!
+	}
+	return out
+}
+
+// read_completion reads a status word and the text that follows it.
+//
+// The grammar makes the space between them mandatory, and the text non-empty.
+// A server that ends the line right after the status word is out of spec, but
+// failing the whole response over a missing pleasantry helps nobody.
+fn read_completion(mut d Decoder, mut out Response) ! {
+	out.status = read_status(mut d)!
+	if !d.accept(` `)! {
+		return
+	}
+	read_resp_text(mut d, mut out)!
+}
+
+fn read_status(mut d Decoder) !Status {
+	return status_from(d.atom()!)
+}
+
+fn status_from(word string) !Status {
+	return match word.to_upper() {
+		'OK' { Status.ok }
+		'NO' { Status.no }
+		'BAD' { Status.bad }
+		'BYE' { Status.bye }
+		'PREAUTH' { Status.preauth }
+		else { error('imap: unknown completion `${word}`') }
+	}
+}
+
+// parse_internal_date reads the fixed `1-Feb-2026 12:34:56 +0100` form the
+// protocol uses, which is not any of the formats `time` already parses: the
+// day may be space padded and the month is an English abbreviation.
+fn parse_internal_date(s string) !time.Time {
+	parts := s.trim_space().split(' ')
+	if parts.len != 3 {
+		return error('imap: `${s}` is not an internal date')
+	}
+	day_parts := parts[0].split('-')
+	if day_parts.len != 3 {
+		return error('imap: `${s}` has no day, month and year')
+	}
+	clock := parts[1].split(':')
+	if clock.len != 3 {
+		return error('imap: `${s}` has no hour, minute and second')
+	}
+	month := month_number(day_parts[1])!
+	zone := parse_zone(parts[2])!
+	stamp := time.new(
+		year: day_parts[2].int()
+		month: month
+		day: day_parts[0].int()
+		hour: clock[0].int()
+		minute: clock[1].int()
+		second: clock[2].int()
+	)
+	// The stamp is local to the sender's zone, so the offset is taken back off
+	// to land on the same instant everywhere.
+	return time.unix(stamp.unix() - zone)
+}
+
+fn month_number(name string) !int {
+	months := ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+	for i, m in months {
+		if m.to_lower() == name.to_lower() {
+			return i + 1
+		}
+	}
+	return error('imap: `${name}` is not a month')
+}
+
+// parse_zone reads `+0100` and returns the offset in seconds.
+fn parse_zone(s string) !i64 {
+	if s.len != 5 || (s[0] != `+` && s[0] != `-`) {
+		return error('imap: `${s}` is not a time zone offset')
+	}
+	hours := s[1..3].int()
+	minutes := s[3..5].int()
+	seconds := i64(hours) * 3600 + i64(minutes) * 60
+	if s[0] == `-` {
+		return -seconds
+	}
+	return seconds
+}

--- a/vlib/net/imap/response.v
+++ b/vlib/net/imap/response.v
@@ -495,11 +495,7 @@ fn read_envelope(mut d Decoder) !Envelope {
 // `"(" 1*address ")"`, not a list whose elements are separated by spaces.
 fn read_address_list(mut d Decoder) ![]Address {
 	mut out := []Address{}
-	if d.peek_byte()! != `(` {
-		word := d.atom()!
-		if word.to_upper() != 'NIL' {
-			return error('imap: expected an address list or NIL, got `${word}`')
-		}
+	if d.accept_nil()! {
 		return out
 	}
 	d.expect(`(`)!
@@ -609,11 +605,7 @@ fn skip_extensions(mut d Decoder) ! {
 // NIL when there are none.
 fn read_param_list(mut d Decoder) !map[string]string {
 	mut out := map[string]string{}
-	if d.peek_byte()! != `(` {
-		word := d.atom()!
-		if word.to_upper() != 'NIL' {
-			return error('imap: expected a parameter list or NIL, got `${word}`')
-		}
+	if d.accept_nil()! {
 		return out
 	}
 	if !d.open_list()! {
@@ -647,9 +639,8 @@ fn read_mailbox_list(mut d Decoder) !MailboxInfo {
 		}
 	}
 	d.sp()!
-	raw := d.astring()!
 	return MailboxInfo{
-		name: utf7_decode(raw) or { raw }
+		name: d.mailbox_name()!
 		delimiter: delimiter
 		attributes: attributes
 	}
@@ -657,7 +648,7 @@ fn read_mailbox_list(mut d Decoder) !MailboxInfo {
 
 // read_status_data reads `STATUS mailbox (MESSAGES 231 UIDNEXT 44292)`.
 fn read_status_data(mut d Decoder) !MailboxStatus {
-	raw := d.astring()!
+	mailbox := d.mailbox_name()!
 	d.sp()!
 	mut messages := u32(0)
 	mut recent := u32(0)
@@ -693,7 +684,7 @@ fn read_status_data(mut d Decoder) !MailboxStatus {
 		}
 	}
 	return MailboxStatus{
-		name: utf7_decode(raw) or { raw }
+		name: mailbox
 		messages: messages
 		recent: recent
 		uid_next: uid_next
@@ -862,9 +853,13 @@ fn parse_internal_date(s string) !time.Time {
 	return time.unix(stamp.unix() - zone)
 }
 
+// The month names the protocol spells its dates with: read here, and written
+// by `format_internal_date`.
+const month_names = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov',
+	'Dec']!
+
 fn month_number(name string) !int {
-	months := ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
-	for i, m in months {
+	for i, m in month_names {
 		if m.to_lower() == name.to_lower() {
 			return i + 1
 		}

--- a/vlib/net/imap/response.v
+++ b/vlib/net/imap/response.v
@@ -107,15 +107,19 @@ pub:
 }
 
 // BodyStructure describes one MIME part. A multipart has `parts` filled in and
-// a media type of `multipart`; every other part is a leaf.
+// a media type of `multipart`. A `message/rfc822` part retains the attached
+// message's envelope and MIME tree in `message_envelope` and
+// `message_structure`.
 pub struct BodyStructure {
 pub:
-	media_type    string
-	media_subtype string
-	params        map[string]string
-	id            string
-	description   string
-	encoding      string
+	media_type        string
+	media_subtype     string
+	params            map[string]string
+	id                string
+	description       string
+	encoding          string
+	message_envelope  ?Envelope
+	message_structure ?&BodyStructure
 	// size is the part's length in octets, and `lines` its line count for a
 	// text part.
 	size  u32
@@ -572,6 +576,8 @@ fn read_body_structure(mut d Decoder) !BodyStructure {
 	d.sp()!
 	size := d.number()!
 	mut lines := u32(0)
+	mut message_envelope := ?Envelope(none)
+	mut message_structure := ?&BodyStructure(none)
 	// A text part states its line count, and an embedded message states its
 	// envelope, its own structure and its line count. Neither is required to
 	// be followed by the extension fields, so each step is guarded.
@@ -579,9 +585,10 @@ fn read_body_structure(mut d Decoder) !BodyStructure {
 		lines = d.number()!
 	}
 	if media_type.to_upper() == 'MESSAGE' && media_subtype.to_upper() == 'RFC822' && d.accept(` `)! {
-		read_envelope(mut d)!
+		message_envelope = read_envelope(mut d)!
 		d.sp()!
-		read_body_structure(mut d)!
+		mut nested := read_body_structure(mut d)!
+		message_structure = &nested
 		d.sp()!
 		lines = d.number()!
 	}
@@ -593,6 +600,8 @@ fn read_body_structure(mut d Decoder) !BodyStructure {
 		id: id
 		description: description
 		encoding: encoding
+		message_envelope: message_envelope
+		message_structure: message_structure
 		size: size
 		lines: lines
 	}

--- a/vlib/net/imap/response.v
+++ b/vlib/net/imap/response.v
@@ -679,8 +679,15 @@ fn read_mailbox_list(mut d Decoder) !MailboxInfo {
 		}
 	}
 	d.sp()!
+	name := d.mailbox_name()!
+	// RFC 5258 permits a parenthesised LIST-EXTENDED data item after the
+	// mailbox name. The current public result has no place for it, but it must
+	// still be consumed so the next response starts at the right byte.
+	if d.accept(` `)! {
+		d.skip_value()!
+	}
 	return MailboxInfo{
-		name: d.mailbox_name()!
+		name: name
 		delimiter: delimiter
 		attributes: attributes
 	}

--- a/vlib/net/imap/response.v
+++ b/vlib/net/imap/response.v
@@ -195,13 +195,24 @@ mut:
 	read_only       bool
 	// has_exists and has_recent record whether the server said anything at
 	// all, since zero is a perfectly ordinary count.
-	has_exists bool
-	has_recent bool
+	has_exists            bool
+	has_recent            bool
+	expunged_after_exists int
 }
 
 // read_response reads responses until the one tagged `tag`, and turns a NO or
 // BAD completion into an error.
 fn (mut c Client) read_response(tag string) !Response {
+	out := c.read_response_raw(tag)!
+	if out.status == .ok {
+		return out
+	}
+	return error('imap: ${out.status} ${out.text}')
+}
+
+// read_response_raw retains a NO or BAD completion so callers can apply any
+// unsolicited mailbox updates that preceded it before returning the error.
+fn (mut c Client) read_response_raw(tag string) !Response {
 	mut out := Response{}
 	for {
 		mut d := c.decoder()!
@@ -226,10 +237,7 @@ fn (mut c Client) read_response(tag string) !Response {
 		if got != tag {
 			return error('imap: the server answered tag `${got}` while `${tag}` was outstanding')
 		}
-		if out.status == .ok {
-			return out
-		}
-		return error('imap: ${out.status} ${out.text}')
+		return out
 	}
 	return out
 }
@@ -296,6 +304,7 @@ fn read_message_data(mut d Decoder, mut out Response, n u32) ! {
 	if name == 'EXISTS' {
 		out.exists = n
 		out.has_exists = true
+		out.expunged_after_exists = 0
 		return
 	}
 	if name == 'RECENT' {
@@ -305,6 +314,9 @@ fn read_message_data(mut d Decoder, mut out Response, n u32) ! {
 	}
 	if name == 'EXPUNGE' {
 		out.expunged << n
+		if out.has_exists {
+			out.expunged_after_exists++
+		}
 		return
 	}
 	if name == 'FETCH' {

--- a/vlib/net/imap/response.v
+++ b/vlib/net/imap/response.v
@@ -299,7 +299,7 @@ fn (mut c Client) read_untagged(mut d Decoder, mut out Response) ! {
 			// An extension this module does not model. Its line is skipped
 			// whole rather than half read, including any literal payloads and
 			// the continuation of the response behind them.
-			d.skip_response_text()!
+			d.skip_response_text(name)!
 		}
 	}
 }
@@ -706,24 +706,27 @@ fn read_status_data(mut d Decoder) !MailboxStatus {
 		for {
 			name := d.atom()!.to_upper()
 			d.sp()!
-			value := d.number()!
 			match name {
 				'MESSAGES' {
-					messages = value
+					messages = d.number()!
 				}
 				'RECENT' {
-					recent = value
+					recent = d.number()!
 				}
 				'UIDNEXT' {
-					uid_next = value
+					uid_next = d.number()!
 				}
 				'UIDVALIDITY' {
-					uid_validity = value
+					uid_validity = d.number()!
 				}
 				'UNSEEN' {
-					unseen = value
+					unseen = d.number()!
 				}
-				else {}
+				else {
+					// Extensions such as RFC 8438 SIZE use values wider than the
+					// base protocol's 32-bit number, or another value shape.
+					d.skip_value()!
+				}
 			}
 			if !d.more_in_list()! {
 				break
@@ -836,6 +839,12 @@ fn read_space_separated(mut d Decoder) ![]string {
 fn read_numbers(mut d Decoder) ![]u32 {
 	mut out := []u32{}
 	for d.accept(` `)! {
+		// RFC 7162 appends `(MODSEQ n)` to SEARCH results. It is metadata,
+		// not another message number.
+		if d.peek_byte()! == `(` {
+			d.skip_value()!
+			return out
+		}
 		out << d.number()!
 	}
 	return out

--- a/vlib/net/imap/response.v
+++ b/vlib/net/imap/response.v
@@ -377,6 +377,11 @@ fn read_msg_att(mut d Decoder, seq u32) !Message {
 				}
 			}
 			else {
+				// Extension fetch items may attach a section with no space, for
+				// example BINARY[1]. Consume it before stepping over the value.
+				if d.accept(`[`)! {
+					read_section_key(mut d)!
+				}
 				d.sp()!
 				d.skip_value()!
 			}

--- a/vlib/net/imap/response.v
+++ b/vlib/net/imap/response.v
@@ -605,10 +605,15 @@ fn read_multipart(mut d Decoder) !BodyStructure {
 	}
 	d.sp()!
 	media_subtype := d.string_value()!
+	mut params := map[string]string{}
+	if d.accept(` `)! {
+		params = read_param_list(mut d)!
+	}
 	skip_extensions(mut d)!
 	return BodyStructure{
 		media_type: 'multipart'
 		media_subtype: media_subtype
+		params: params
 		parts: parts
 	}
 }

--- a/vlib/net/imap/response.v
+++ b/vlib/net/imap/response.v
@@ -212,6 +212,11 @@ fn (mut c Client) read_response(tag string) !Response {
 			d.sp()!
 			c.read_untagged(mut d, mut out)!
 			d.crlf()!
+			if !c.is_open && !c.logging_out {
+				text := out.text
+				c.shutdown()
+				return error('imap: the server closed the session: ${text}')
+			}
 			continue
 		}
 		got := d.astring()!
@@ -277,8 +282,9 @@ fn (mut c Client) read_untagged(mut d Decoder, mut out Response) ! {
 		}
 		else {
 			// An extension this module does not model. Its line is skipped
-			// whole rather than half read.
-			d.text()!
+			// whole rather than half read, including any literal payloads and
+			// the continuation of the response behind them.
+			d.skip_response_text()!
 		}
 	}
 }
@@ -838,19 +844,51 @@ fn parse_internal_date(s string) !time.Time {
 	if clock.len != 3 {
 		return error('imap: `${s}` has no hour, minute and second')
 	}
+	if day_parts[0].len == 0 || day_parts[0].len > 2 || day_parts[2].len != 4 || clock[0].len != 2 || clock[1].len != 2 || clock[2].len != 2 {
+		return error('imap: `${s}` does not use the internal date field widths')
+	}
+	day := parse_decimal(day_parts[0], 'day')!
+	year := parse_decimal(day_parts[2], 'year')!
+	hour := parse_decimal(clock[0], 'hour')!
+	minute := parse_decimal(clock[1], 'minute')!
+	second := parse_decimal(clock[2], 'second')!
 	month := month_number(day_parts[1])!
 	zone := parse_zone(parts[2])!
+	if year < 1 || year > 9999 {
+		return error('imap: `${s}` has a year outside 1..9999')
+	}
+	max_day := time.days_in_month(month, year)!
+	if day < 1 || day > max_day {
+		return error('imap: `${s}` has a day outside 1..${max_day}')
+	}
+	if hour > 23 || minute > 59 || second > 59 {
+		return error('imap: `${s}` has a time outside 00:00:00..23:59:59')
+	}
 	stamp := time.new(
-		year: day_parts[2].int()
+		year: year
 		month: month
-		day: day_parts[0].int()
-		hour: clock[0].int()
-		minute: clock[1].int()
-		second: clock[2].int()
+		day: day
+		hour: hour
+		minute: minute
+		second: second
 	)
 	// The stamp is local to the sender's zone, so the offset is taken back off
 	// to land on the same instant everywhere.
 	return time.unix(stamp.unix() - zone)
+}
+
+fn parse_decimal(s string, name string) !int {
+	if s == '' {
+		return error('imap: an internal date has an empty ${name}')
+	}
+	mut n := 0
+	for ch in s {
+		if ch < `0` || ch > `9` {
+			return error('imap: `${s}` is not a numeric ${name}')
+		}
+		n = n * 10 + int(ch - `0`)
+	}
+	return n
 }
 
 // The month names the protocol spells its dates with: read here, and written
@@ -872,8 +910,11 @@ fn parse_zone(s string) !i64 {
 	if s.len != 5 || (s[0] != `+` && s[0] != `-`) {
 		return error('imap: `${s}` is not a time zone offset')
 	}
-	hours := s[1..3].int()
-	minutes := s[3..5].int()
+	hours := parse_decimal(s[1..3], 'time zone hour')!
+	minutes := parse_decimal(s[3..5], 'time zone minute')!
+	if hours > 23 || minutes > 59 {
+		return error('imap: `${s}` is not a valid time zone offset')
+	}
 	seconds := i64(hours) * 3600 + i64(minutes) * 60
 	if s[0] == `-` {
 		return -seconds

--- a/vlib/net/imap/response.v
+++ b/vlib/net/imap/response.v
@@ -203,7 +203,10 @@ mut:
 // read_response reads responses until the one tagged `tag`, and turns a NO or
 // BAD completion into an error.
 fn (mut c Client) read_response(tag string) !Response {
-	out := c.read_response_raw(tag)!
+	out := c.read_response_raw(tag) or {
+		c.shutdown()
+		return err
+	}
 	if out.status == .ok {
 		return out
 	}

--- a/vlib/net/imap/response_test.v
+++ b/vlib/net/imap/response_test.v
@@ -26,7 +26,7 @@ fn test_decoder_reads_the_four_shapes_of_the_grammar() {
 	d.sp()!
 	// A nested list is stepped over whole, whatever it holds.
 	d.skip_value()!
-	assert d.src_pos == d.src.len
+	assert d.pos == d.filled
 }
 
 fn test_a_quoted_string_never_ends_early() {

--- a/vlib/net/imap/response_test.v
+++ b/vlib/net/imap/response_test.v
@@ -1,0 +1,365 @@
+module imap
+
+// The transcripts below are the examples printed in RFC 3501, so that the
+// grammar is checked against what the specification says a server sends rather
+// than against what this implementation happens to produce.
+
+// client_over drives the response reader off a fixed buffer, which is the
+// whole session apart from the socket.
+fn client_over(s string) &Client {
+	return &Client{
+		dec: decoder_over(s)
+		is_open: true
+	}
+}
+
+fn test_decoder_reads_the_four_shapes_of_the_grammar() {
+	mut d := decoder_over('ATOM "a quoted \\"string\\"" {5}\r\nab\r\ncd (a (b c) NIL)')
+	assert d.atom()! == 'ATOM'
+	d.sp()!
+	assert d.quoted()! == 'a quoted "string"'
+	d.sp()!
+	// A literal is defined by its length, so the line ending inside it is
+	// content and the one after it is not.
+	assert d.literal()! == 'ab\r\nc'
+	assert d.atom()! == 'd'
+	d.sp()!
+	// A nested list is stepped over whole, whatever it holds.
+	d.skip_value()!
+	assert d.src_pos == d.src.len
+}
+
+fn test_a_quoted_string_never_ends_early() {
+	mut d := decoder_over('"a\\\\b" "c\\"d" ""')
+	assert d.quoted()! == 'a\\b'
+	d.sp()!
+	assert d.quoted()! == 'c"d'
+	d.sp()!
+	assert d.quoted()! == ''
+}
+
+fn test_atoms_stop_at_the_specials() {
+	// Each of these characters ends an atom, which is what stops one from
+	// swallowing the syntax around it.
+	for special in ['(', ')', '{', ' ', '%', '*', '"', '\\', ']'] {
+		mut d := decoder_over('WORD${special}rest')
+		assert d.atom()! == 'WORD', '`${special}` did not end the atom'
+	}
+}
+
+fn test_a_number_that_overflows_is_refused() {
+	mut d := decoder_over('4294967296')
+	d.number() or { return }
+	assert false, 'a number past 32 bits must not be accepted'
+}
+
+fn test_select_reports_the_mailbox_state() {
+	// RFC 3501 section 6.3.1.
+	mut c := client_over('* 172 EXISTS\r\n' + '* 1 RECENT\r\n' + '* OK [UNSEEN 12] Message 12 is first unseen\r\n' + '* OK [UIDVALIDITY 3857529045] UIDs valid\r\n' + '* OK [UIDNEXT 4392] Predicted next UID\r\n' + '* FLAGS (\\Answered \\Flagged \\Deleted \\Seen \\Draft)\r\n' + '* OK [PERMANENTFLAGS (\\Deleted \\Seen \\*)] Limited\r\n' + 'a0001 OK [READ-WRITE] SELECT completed\r\n')
+	res := c.read_response('a0001')!
+	assert res.exists == 172
+	assert res.recent == 1
+	assert res.unseen == 12
+	assert res.uid_validity == 3857529045
+	assert res.uid_next == 4392
+	assert res.flags == ['\\Answered', '\\Flagged', '\\Deleted', '\\Seen', '\\Draft']
+	assert res.permanent_flags == ['\\Deleted', '\\Seen', '\\*']
+	assert !res.read_only
+	assert res.code == 'READ-WRITE'
+}
+
+fn test_uid_validity_holds_the_full_32_bit_range() {
+	mut c := client_over('* OK [UIDVALIDITY 4294967295] UIDs valid\r\na1 OK done\r\n')
+	assert c.read_response('a1')!.uid_validity == 4294967295
+}
+
+fn test_list_reads_every_form_of_a_mailbox_name() {
+	mut c := client_over('* LIST (\\Noselect) "/" ""\r\n' + '* LIST () "." INBOX\r\n' + '* LIST (\\HasChildren \\Marked) "/" "Work/Reports 2026"\r\n' + '* LIST (\\Noinferiors) NIL "Flat"\r\n' + '* LIST () "/" "od\\"d"\r\n' + '* LIST () "/" {7}\r\nliteral\r\n' + '* LIST () "/" "&AMk-l&AOk-ments"\r\n' + 'a1 OK LIST completed\r\n')
+	boxes := c.read_response('a1')!.mailboxes
+	assert boxes.len == 7
+	// The empty name is how a client discovers the delimiter, so it survives.
+	assert boxes[0].name == ''
+	assert boxes[0].delimiter == '/'
+	assert boxes[0].attributes == ['\\Noselect']
+	// A bare atom is a valid mailbox name.
+	assert boxes[1].name == 'INBOX'
+	assert boxes[1].delimiter == '.'
+	assert boxes[2].name == 'Work/Reports 2026'
+	assert boxes[2].attributes == ['\\HasChildren', '\\Marked']
+	// NIL means a flat namespace.
+	assert boxes[3].delimiter == ''
+	// An escaped quote does not end the name.
+	assert boxes[4].name == 'od"d'
+	// A name may arrive as a literal.
+	assert boxes[5].name == 'literal'
+	// And it comes back as UTF-8, not as the modified UTF-7 it travelled in.
+	assert boxes[6].name == 'Éléments'
+}
+
+fn test_fetch_reads_metadata() {
+	mut c := client_over('* 23 FETCH (FLAGS (\\Seen) UID 4827313 RFC822.SIZE 44827)\r\n' + '* 24 FETCH (UID 4827943 FLAGS (\\Seen \\Answered))\r\n' + 'a1 OK FETCH completed\r\n')
+	msgs := c.read_response('a1')!.messages
+	assert msgs.len == 2
+	assert msgs[0].seq == 23
+	assert msgs[0].uid == 4827313
+	assert msgs[0].size == 44827
+	assert msgs[0].flags == ['\\Seen']
+	// Items may come in any order.
+	assert msgs[1].seq == 24
+	assert msgs[1].uid == 4827943
+	assert msgs[1].flags == ['\\Seen', '\\Answered']
+}
+
+fn test_message_content_is_never_read_as_protocol() {
+	// The reason this module tokenises rather than searching the line: a
+	// message whose subject says `UID 999` answers a search for `UID ` just as
+	// readily as the real field does.
+	body := 'Subject: UID 999 FLAGS (\\Deleted)\r\n\r\nRFC822.SIZE 1\r\n'
+	mut c := client_over('* 5 FETCH (UID 7 RFC822.SIZE 42 BODY[] {${body.len}}\r\n' + '${body})\r\n' + 'a1 OK FETCH completed\r\n')
+	msgs := c.read_response('a1')!.messages
+	assert msgs.len == 1
+	assert msgs[0].uid == 7
+	assert msgs[0].size == 42
+	assert msgs[0].flags == []
+	assert msgs[0].body() == body
+}
+
+fn test_an_envelope_subject_cannot_forge_a_field() {
+	// The same trap, in a quoted string rather than a literal.
+	mut c := client_over('* 1 FETCH (ENVELOPE (NIL "UID 999 RFC822.SIZE 5" NIL NIL NIL NIL NIL NIL NIL NIL) UID 3)\r\n' + 'a1 OK done\r\n')
+	msgs := c.read_response('a1')!.messages
+	assert msgs[0].uid == 3
+	assert msgs[0].size == 0
+	envelope := msgs[0].envelope or {
+		assert false, 'the envelope was not parsed'
+		return
+	}
+	assert envelope.subject == 'UID 999 RFC822.SIZE 5'
+}
+
+fn test_envelope_from_the_rfc_example() {
+	// RFC 3501 section 7.4.2.
+	mut c := client_over('* 12 FETCH (ENVELOPE ' + '("Wed, 17 Jul 1996 02:23:25 -0700 (PDT)" ' + '"IMAP4rev1 WG mtg summary and minutes" ' + '(("Terry Gray" NIL "gray" "cac.washington.edu")) ' + '(("Terry Gray" NIL "gray" "cac.washington.edu")) ' + '(("Terry Gray" NIL "gray" "cac.washington.edu")) ' + '((NIL NIL "imap" "cac.washington.edu")) ' + '((NIL NIL "minutes" "CNRI.Reston.VA.US")' + '("John Klensin" NIL "KLENSIN" "MIT.EDU")) ' + 'NIL NIL "<B27397-0100000@cac.washington.edu>"))\r\n' + 'a1 OK done\r\n')
+	msgs := c.read_response('a1')!.messages
+	envelope := msgs[0].envelope or {
+		assert false, 'the envelope was not parsed'
+		return
+	}
+	assert envelope.date == 'Wed, 17 Jul 1996 02:23:25 -0700 (PDT)'
+	assert envelope.subject == 'IMAP4rev1 WG mtg summary and minutes'
+	assert envelope.from.len == 1
+	assert envelope.from[0].name == 'Terry Gray'
+	assert envelope.from[0].addr() == 'gray@cac.washington.edu'
+	assert envelope.to.len == 1
+	assert envelope.to[0].name == ''
+	assert envelope.to[0].addr() == 'imap@cac.washington.edu'
+	assert envelope.cc.len == 2
+	assert envelope.cc[1].addr() == 'KLENSIN@MIT.EDU'
+	// NIL for a header the message did not carry.
+	assert envelope.bcc == []
+	assert envelope.in_reply_to == ''
+	assert envelope.message_id == '<B27397-0100000@cac.washington.edu>'
+}
+
+fn test_a_single_part_body_structure() {
+	// RFC 3501 section 6.4.5.
+	mut c := client_over('* 5 FETCH (BODY ("TEXT" "PLAIN" ("CHARSET" "US-ASCII") NIL NIL "7BIT" 3028 92))\r\n' + 'a1 OK done\r\n')
+	structure := c.read_response('a1')!.messages[0].structure or {
+		assert false, 'the body structure was not parsed'
+		return
+	}
+	assert structure.mime_type() == 'text/plain'
+	assert structure.params['charset'] == 'US-ASCII'
+	assert structure.encoding == '7BIT'
+	assert structure.size == 3028
+	assert structure.lines == 92
+	assert structure.parts == []
+}
+
+fn test_a_nested_multipart_body_structure() {
+	mut c := client_over('* 6 FETCH (BODYSTRUCTURE (' + '(("TEXT" "PLAIN" ("CHARSET" "US-ASCII") NIL NIL "7BIT" 1152 23)' + '("TEXT" "HTML" ("CHARSET" "US-ASCII") NIL NIL "QUOTED-PRINTABLE" 1024 15)' + ' "ALTERNATIVE" ("BOUNDARY" "inner") NIL NIL)' + '("IMAGE" "GIF" ("NAME" "cat.gif") "<id@x>" "a cat" "BASE64" 4554)' + ' "MIXED" ("BOUNDARY" "outer") NIL NIL))\r\n' + 'a1 OK done\r\n')
+	structure := c.read_response('a1')!.messages[0].structure or {
+		assert false, 'the body structure was not parsed'
+		return
+	}
+	assert structure.mime_type() == 'multipart/mixed'
+	assert structure.parts.len == 2
+	alternative := structure.parts[0]
+	assert alternative.mime_type() == 'multipart/alternative'
+	assert alternative.parts.len == 2
+	assert alternative.parts[0].mime_type() == 'text/plain'
+	assert alternative.parts[1].mime_type() == 'text/html'
+	assert alternative.parts[1].encoding == 'QUOTED-PRINTABLE'
+	image := structure.parts[1]
+	assert image.mime_type() == 'image/gif'
+	assert image.params['name'] == 'cat.gif'
+	assert image.id == '<id@x>'
+	assert image.description == 'a cat'
+	assert image.size == 4554
+}
+
+fn test_several_sections_come_back_keyed() {
+	header := 'Subject: hi\r\n'
+	text := 'body text\r\n'
+	mut c := client_over('* 1 FETCH (BODY[HEADER] {${header.len}}\r\n${header} ' + 'BODY[TEXT] {${text.len}}\r\n${text} ' + 'BODY[]<1024> "partial")\r\n' + 'a1 OK done\r\n')
+	msg := c.read_response('a1')!.messages[0]
+	assert msg.sections['BODY[HEADER]'] == header
+	assert msg.sections['BODY[TEXT]'] == text
+	// A partial fetch is a section of its own, keyed by where it started.
+	assert msg.sections['BODY[]<1024>'] == 'partial'
+	// With three of them there is no single body to return.
+	assert msg.body() == ''
+}
+
+fn test_a_section_specification_with_a_list_inside_it() {
+	mut c := client_over('* 1 FETCH (BODY[HEADER.FIELDS (SUBJECT FROM)] "x")\r\na1 OK done\r\n')
+	msg := c.read_response('a1')!.messages[0]
+	assert msg.sections['BODY[HEADER.FIELDS (SUBJECT FROM)]'] == 'x'
+	assert msg.body() == 'x'
+}
+
+fn test_the_rfc822_spellings_map_onto_sections() {
+	mut c := client_over('* 1 FETCH (RFC822.HEADER "h" RFC822.TEXT "t" RFC822 "whole")\r\na1 OK done\r\n')
+	msg := c.read_response('a1')!.messages[0]
+	assert msg.sections['BODY[HEADER]'] == 'h'
+	assert msg.sections['BODY[TEXT]'] == 't'
+	assert msg.sections['BODY[]'] == 'whole'
+	// `body` prefers the whole message when it is among them.
+	assert msg.body() == 'whole'
+}
+
+fn test_an_unknown_fetch_item_does_not_derail_the_rest() {
+	// An extension this module does not model sits between two it does.
+	mut c := client_over('* 1 FETCH (UID 5 MODSEQ (12345) X-GM-LABELS ("a" "b") FLAGS (\\Seen))\r\n' + 'a1 OK done\r\n')
+	msg := c.read_response('a1')!.messages[0]
+	assert msg.uid == 5
+	assert msg.flags == ['\\Seen']
+}
+
+fn test_internal_date() {
+	mut c := client_over('* 1 FETCH (INTERNALDATE "17-Jul-1996 02:44:25 -0700")\r\na1 OK done\r\n')
+	stamp := c.read_response('a1')!.messages[0].internal_date
+	// 1996-07-17 02:44:25 seven hours behind UTC is 09:44:25 UTC.
+	assert stamp.unix() == 837596665
+}
+
+fn test_search_and_expunge() {
+	mut c := client_over('* SEARCH 2 84 882\r\na1 OK done\r\n')
+	assert c.read_response('a1')!.numbers == [u32(2), 84, 882]
+
+	// A search that matched nothing sends the keyword with no numbers.
+	mut empty := client_over('* SEARCH\r\na1 OK done\r\n')
+	assert empty.read_response('a1')!.numbers == []
+
+	// Each expunge renumbers what follows it, which is why 3 appears twice.
+	mut e := client_over('* 3 EXPUNGE\r\n* 3 EXPUNGE\r\n* 5 EXPUNGE\r\n* 8 EXISTS\r\na1 OK done\r\n')
+	res := e.read_response('a1')!
+	assert res.expunged == [u32(3), 3, 5]
+	assert res.exists == 8
+}
+
+fn test_status_data() {
+	mut c := client_over('* STATUS "Work/&AMk-t&AOk-" (MESSAGES 231 UIDNEXT 44292 UNSEEN 3)\r\n' + 'a1 OK done\r\n')
+	status := c.read_response('a1')!.statuses[0]
+	assert status.name == 'Work/Été'
+	assert status.messages == 231
+	assert status.uid_next == 44292
+	assert status.unseen == 3
+	assert status.recent == 0
+}
+
+fn test_capability() {
+	mut c := client_over('* CAPABILITY IMAP4rev1 STARTTLS AUTH=PLAIN UIDPLUS MOVE\r\na1 OK done\r\n')
+	assert c.read_response('a1')!.capabilities == ['IMAP4rev1', 'STARTTLS', 'AUTH=PLAIN', 'UIDPLUS',
+		'MOVE']
+}
+
+fn test_a_capability_code_on_the_completion_is_read_too() {
+	mut c := client_over('a1 OK [CAPABILITY IMAP4rev1 IDLE] Logged in\r\n')
+	assert c.read_response('a1')!.capabilities == ['IMAP4rev1', 'IDLE']
+}
+
+fn test_a_refusal_becomes_an_error() {
+	mut c := client_over('a1 NO [AUTHENTICATIONFAILED] Invalid credentials\r\n')
+	c.read_response('a1') or {
+		assert err.msg().contains('Invalid credentials')
+		mut bad := client_over('a1 BAD Missing argument\r\n')
+		bad.read_response('a1') or {
+			assert err.msg().contains('Missing argument')
+			return
+		}
+		assert false, 'a BAD completion must not be reported as success'
+		return
+	}
+	assert false, 'a NO completion must not be reported as success'
+}
+
+fn test_a_completion_for_another_tag_is_an_error() {
+	// Answering the wrong tag means the client and the server disagree about
+	// which command is in flight, which nothing later can recover from.
+	mut c := client_over('a9 OK done\r\n')
+	c.read_response('a1') or {
+		assert err.msg().contains('a9')
+		return
+	}
+	assert false, 'a completion for another tag must not be accepted'
+}
+
+fn test_an_untagged_bye_closes_the_session() {
+	mut c := client_over('* BYE Autologout; idle for too long\r\na1 OK done\r\n')
+	c.read_response('a1')!
+	assert !c.is_open
+}
+
+fn test_a_completion_with_no_text_is_tolerated() {
+	// Out of spec, but failing the whole response over a missing pleasantry
+	// helps nobody.
+	mut c := client_over('a1 OK\r\n')
+	assert c.read_response('a1')!.status == .ok
+}
+
+fn test_a_bare_lf_line_ending_is_tolerated() {
+	mut c := client_over('* 4 EXISTS\na1 OK done\n')
+	assert c.read_response('a1')!.exists == 4
+}
+
+fn test_a_literal_announcing_more_than_it_sends_is_refused() {
+	mut c := client_over('* 1 FETCH (BODY[] {100}\r\nshort)\r\na1 OK done\r\n')
+	c.read_response('a1') or { return }
+	assert false, 'a truncated literal must not be accepted'
+}
+
+fn test_an_absurd_literal_size_is_refused_before_allocating() {
+	mut c := client_over('* 1 FETCH (BODY[] {4294967295}\r\n')
+	c.read_response('a1') or {
+		assert err.msg().contains('limit')
+		return
+	}
+	assert false, 'a literal past the cap must be refused'
+}
+
+fn test_esearch_keeps_its_ranges() {
+	// RFC 4731 answers with a sequence set rather than a flat list, which is
+	// the whole point: a result covering a large mailbox is a few ranges and
+	// millions of numbers.
+	mut c := client_over('* ESEARCH (TAG "a1") UID MIN 2 COUNT 50000 ALL 1:49999,60000\r\n' + 'a1 OK done\r\n')
+	res := c.read_response('a1')!
+	assert res.has_set
+	assert res.set.str() == '1:49999,60000'
+	assert res.set.len() == 2
+}
+
+fn test_esearch_handles_an_open_range() {
+	// `*` is a list wildcard and so not an atom character, which is why the
+	// set needs a reader of its own.
+	mut c := client_over('* ESEARCH (TAG "a1") ALL 5:*\r\na1 OK done\r\n')
+	assert c.read_response('a1')!.set.str() == '5:*'
+}
+
+fn test_a_search_that_matched_nothing_in_the_esearch_form() {
+	// RFC 4731 leaves ALL out entirely when nothing matched.
+	mut c := client_over('* ESEARCH (TAG "a1") UID COUNT 0\r\na1 OK done\r\n')
+	res := c.read_response('a1')!
+	assert !res.has_set
+	assert res.set.is_empty()
+}

--- a/vlib/net/imap/response_test.v
+++ b/vlib/net/imap/response_test.v
@@ -281,6 +281,8 @@ fn test_internal_date() {
 fn test_search_and_expunge() {
 	mut c := client_over('* SEARCH 2 84 882\r\na1 OK done\r\n')
 	assert c.read_response('a1')!.numbers == [u32(2), 84, 882]
+	mut modseq := client_over('* SEARCH 2 5 (MODSEQ 917162500)\r\na1 OK done\r\n')
+	assert modseq.read_response('a1')!.numbers == [u32(2), 5]
 
 	// A search that matched nothing sends the keyword with no numbers.
 	mut empty := client_over('* SEARCH\r\na1 OK done\r\n')
@@ -294,7 +296,7 @@ fn test_search_and_expunge() {
 }
 
 fn test_status_data() {
-	mut c := client_over('* STATUS "Work/&AMk-t&AOk-" (MESSAGES 231 UIDNEXT 44292 UNSEEN 3)\r\n' + 'a1 OK done\r\n')
+	mut c := client_over('* STATUS "Work/&AMk-t&AOk-" (MESSAGES 231 SIZE 5000000000 UIDNEXT 44292 UNSEEN 3)\r\n' + 'a1 OK done\r\n')
 	status := c.read_response('a1')!.statuses[0]
 	assert status.name == 'Work/Été'
 	assert status.messages == 231
@@ -368,6 +370,8 @@ fn test_an_unknown_response_skips_literals_inside_extension_arguments() {
 fn test_an_unknown_response_skips_multiple_top_level_literals() {
 	mut c := client_over('* ACL {5}\r\nINBOX {3}\r\nbob lr\r\na1 OK done\r\n')
 	assert c.read_response('a1')!.status == .ok
+	mut after_atom := client_over('* ACL INBOX {3}\r\nbob lr\r\na1 OK done\r\n')
+	assert after_atom.read_response('a1')!.status == .ok
 }
 
 fn test_malformed_internal_dates_return_errors() {

--- a/vlib/net/imap/response_test.v
+++ b/vlib/net/imap/response_test.v
@@ -307,8 +307,27 @@ fn test_a_completion_for_another_tag_is_an_error() {
 
 fn test_an_untagged_bye_closes_the_session() {
 	mut c := client_over('* BYE Autologout; idle for too long\r\na1 OK done\r\n')
-	c.read_response('a1')!
-	assert !c.is_open
+	c.read_response('a1') or {
+		assert err.msg().contains('server closed the session')
+		assert !c.is_open
+		return
+	}
+	assert false, 'an unsolicited BYE must end the outstanding command'
+}
+
+fn test_an_unknown_untagged_response_skips_its_literals() {
+	mut c := client_over('* XDATA {3}\r\nabc\r\na1 OK done\r\n')
+	assert c.read_response('a1')!.status == .ok
+}
+
+fn test_malformed_internal_dates_return_errors() {
+	for stamp in ['32-Jan-2026 00:00:00 +0000', '29-Feb-2025 00:00:00 +0000',
+		'01-Jan-2026 24:00:00 +0000', '01-Jan-2026 00:60:00 +0000', '01-Jan-2026 00:00:60 +0000',
+		'01-Jan-2026 00:00:00 +2460', 'xx-Jan-2026 00:00:00 +0000', '01-Jan-20x6 00:00:00 +0000'] {
+		mut c := client_over('* 1 FETCH (INTERNALDATE "${stamp}")\r\na1 OK done\r\n')
+		c.read_response('a1') or { continue }
+		assert false, '`${stamp}` must be reported as a malformed INTERNALDATE'
+	}
 }
 
 fn test_a_completion_with_no_text_is_tolerated() {

--- a/vlib/net/imap/response_test.v
+++ b/vlib/net/imap/response_test.v
@@ -236,6 +236,12 @@ fn test_an_unknown_fetch_item_does_not_derail_the_rest() {
 	assert msg.flags == ['\\Seen']
 }
 
+fn test_an_unknown_fetch_item_with_a_section_is_skipped() {
+	mut c := client_over('* 1 FETCH (BINARY[1] {8}\r\nabcdefgh UID 7)\r\na1 OK done\r\n')
+	msg := c.read_response('a1')!.messages[0]
+	assert msg.uid == 7
+}
+
 fn test_internal_date() {
 	mut c := client_over('* 1 FETCH (INTERNALDATE "17-Jul-1996 02:44:25 -0700")\r\na1 OK done\r\n')
 	stamp := c.read_response('a1')!.messages[0].internal_date

--- a/vlib/net/imap/response_test.v
+++ b/vlib/net/imap/response_test.v
@@ -237,7 +237,7 @@ fn test_an_unknown_fetch_item_does_not_derail_the_rest() {
 }
 
 fn test_an_unknown_fetch_item_with_a_section_is_skipped() {
-	mut c := client_over('* 1 FETCH (BINARY[1] {8}\r\nabcdefgh UID 7)\r\na1 OK done\r\n')
+	mut c := client_over('* 1 FETCH (BINARY[1] ~{8}\r\nabcdefgh UID 7)\r\na1 OK done\r\n')
 	msg := c.read_response('a1')!.messages[0]
 	assert msg.uid == 7
 }

--- a/vlib/net/imap/response_test.v
+++ b/vlib/net/imap/response_test.v
@@ -357,8 +357,8 @@ fn test_unknown_response_text_ending_like_a_literal_stays_text() {
 	assert c.read_response('a1')!.status == .ok
 }
 
-fn test_a_standalone_literal_marker_needs_a_token_delimiter_after_its_payload() {
-	mut c := client_over('* X-STATUS {3}\r\na1 OK done\r\n')
+fn test_an_unknown_response_skips_literals_inside_extension_arguments() {
+	mut c := client_over('* METADATA "INBOX" (/shared/comment {3}\r\nfoo /private/comment {3}\r\nbar)\r\na1 OK done\r\n')
 	assert c.read_response('a1')!.status == .ok
 }
 

--- a/vlib/net/imap/response_test.v
+++ b/vlib/net/imap/response_test.v
@@ -186,6 +186,7 @@ fn test_a_nested_multipart_body_structure() {
 	assert structure.parts.len == 2
 	alternative := structure.parts[0]
 	assert alternative.mime_type() == 'multipart/alternative'
+	assert alternative.params['boundary'] == 'inner'
 	assert alternative.parts.len == 2
 	assert alternative.parts[0].mime_type() == 'text/plain'
 	assert alternative.parts[1].mime_type() == 'text/html'
@@ -196,6 +197,7 @@ fn test_a_nested_multipart_body_structure() {
 	assert image.id == '<id@x>'
 	assert image.description == 'a cat'
 	assert image.size == 4554
+	assert structure.params['boundary'] == 'outer'
 }
 
 fn test_several_sections_come_back_keyed() {

--- a/vlib/net/imap/response_test.v
+++ b/vlib/net/imap/response_test.v
@@ -230,7 +230,7 @@ fn test_the_rfc822_spellings_map_onto_sections() {
 
 fn test_an_unknown_fetch_item_does_not_derail_the_rest() {
 	// An extension this module does not model sits between two it does.
-	mut c := client_over('* 1 FETCH (UID 5 MODSEQ (12345) X-GM-LABELS ("a" "b") FLAGS (\\Seen))\r\n' + 'a1 OK done\r\n')
+	mut c := client_over('* 1 FETCH (UID 5 MODSEQ (12345) X-GM-LABELS (\\Inbox "Custom") FLAGS (\\Seen))\r\n' + 'a1 OK done\r\n')
 	msg := c.read_response('a1')!.messages[0]
 	assert msg.uid == 5
 	assert msg.flags == ['\\Seen']

--- a/vlib/net/imap/response_test.v
+++ b/vlib/net/imap/response_test.v
@@ -352,6 +352,16 @@ fn test_an_unknown_untagged_response_skips_its_literals() {
 	assert c.read_response('a1')!.status == .ok
 }
 
+fn test_unknown_response_text_ending_like_a_literal_stays_text() {
+	mut c := client_over('* X-STATUS note {3}\r\na1 OK done\r\n')
+	assert c.read_response('a1')!.status == .ok
+}
+
+fn test_a_standalone_literal_marker_needs_a_token_delimiter_after_its_payload() {
+	mut c := client_over('* X-STATUS {3}\r\na1 OK done\r\n')
+	assert c.read_response('a1')!.status == .ok
+}
+
 fn test_malformed_internal_dates_return_errors() {
 	for stamp in ['32-Jan-2026 00:00:00 +0000', '29-Feb-2025 00:00:00 +0000',
 		'01-Jan-2026 24:00:00 +0000', '01-Jan-2026 00:60:00 +0000', '01-Jan-2026 00:00:60 +0000',

--- a/vlib/net/imap/response_test.v
+++ b/vlib/net/imap/response_test.v
@@ -74,9 +74,9 @@ fn test_uid_validity_holds_the_full_32_bit_range() {
 }
 
 fn test_list_reads_every_form_of_a_mailbox_name() {
-	mut c := client_over('* LIST (\\Noselect) "/" ""\r\n' + '* LIST () "." INBOX\r\n' + '* LIST (\\HasChildren \\Marked) "/" "Work/Reports 2026"\r\n' + '* LIST (\\Noinferiors) NIL "Flat"\r\n' + '* LIST () "/" "od\\"d"\r\n' + '* LIST () "/" {7}\r\nliteral\r\n' + '* LIST () "/" "&AMk-l&AOk-ments"\r\n' + 'a1 OK LIST completed\r\n')
+	mut c := client_over('* LIST (\\Noselect) "/" ""\r\n' + '* LIST () "." INBOX\r\n' + '* LIST (\\HasChildren \\Marked) "/" "Work/Reports 2026"\r\n' + '* LIST (\\Noinferiors) NIL "Flat"\r\n' + '* LIST () "/" "od\\"d"\r\n' + '* LIST () "/" {7}\r\nliteral\r\n' + '* LIST () "/" "&AMk-l&AOk-ments"\r\n' + '* LIST (\\HasChildren) "/" "foo" (CHILDINFO ("SUBSCRIBED"))\r\n' + 'a1 OK LIST completed\r\n')
 	boxes := c.read_response('a1')!.mailboxes
-	assert boxes.len == 7
+	assert boxes.len == 8
 	// The empty name is how a client discovers the delimiter, so it survives.
 	assert boxes[0].name == ''
 	assert boxes[0].delimiter == '/'
@@ -94,6 +94,9 @@ fn test_list_reads_every_form_of_a_mailbox_name() {
 	assert boxes[5].name == 'literal'
 	// And it comes back as UTF-8, not as the modified UTF-7 it travelled in.
 	assert boxes[6].name == 'Éléments'
+	// LIST-EXTENDED data after the name is consumed even though it is not
+	// represented in MailboxInfo.
+	assert boxes[7].name == 'foo'
 }
 
 fn test_fetch_reads_metadata() {
@@ -359,6 +362,11 @@ fn test_unknown_response_text_ending_like_a_literal_stays_text() {
 
 fn test_an_unknown_response_skips_literals_inside_extension_arguments() {
 	mut c := client_over('* METADATA "INBOX" (/shared/comment {3}\r\nfoo /private/comment {3}\r\nbar)\r\na1 OK done\r\n')
+	assert c.read_response('a1')!.status == .ok
+}
+
+fn test_an_unknown_response_skips_multiple_top_level_literals() {
+	mut c := client_over('* ACL {5}\r\nINBOX {3}\r\nbob lr\r\na1 OK done\r\n')
 	assert c.read_response('a1')!.status == .ok
 }
 

--- a/vlib/net/imap/response_test.v
+++ b/vlib/net/imap/response_test.v
@@ -200,6 +200,30 @@ fn test_a_nested_multipart_body_structure() {
 	assert structure.params['boundary'] == 'outer'
 }
 
+fn test_an_rfc822_part_retains_the_attached_message_structure() {
+	mut c := client_over('* 7 FETCH (BODYSTRUCTURE ' + '("MESSAGE" "RFC822" NIL NIL NIL "7BIT" 123 ' + '(NIL "Forwarded" NIL NIL NIL NIL NIL NIL NIL "<forwarded@x>") ' + '("TEXT" "PLAIN" ("CHARSET" "UTF-8") NIL NIL "7BIT" 42 3) 5))\r\n' + 'a1 OK done\r\n')
+	attached := c.read_response('a1')!.messages[0].structure or {
+		assert false, 'the attached message body structure was not parsed'
+		return
+	}
+	assert attached.mime_type() == 'message/rfc822'
+	envelope := attached.message_envelope or {
+		assert false, 'the attached message envelope was not retained'
+		return
+	}
+	assert envelope.subject == 'Forwarded'
+	assert envelope.message_id == '<forwarded@x>'
+	nested := attached.message_structure or {
+		assert false, 'the attached message MIME tree was not retained'
+		return
+	}
+	assert nested.mime_type() == 'text/plain'
+	assert nested.params['charset'] == 'UTF-8'
+	assert nested.size == 42
+	assert nested.lines == 3
+	assert attached.lines == 5
+}
+
 fn test_several_sections_come_back_keyed() {
 	header := 'Subject: hi\r\n'
 	text := 'body text\r\n'

--- a/vlib/net/imap/seqset.v
+++ b/vlib/net/imap/seqset.v
@@ -11,6 +11,9 @@ module imap
 // Zero is not a valid message number, which leaves it free to mean `*`.
 const seq_star = u32(0)
 
+// The value `*` stands for while a set is being merged.
+const seq_max = u32(0xffffffff)
+
 // SeqRange is one number or one range of them. A single number has `start`
 // equal to `stop`. A `stop` of zero means `*`, so `{5, 0}` reads `5:*` and
 // `{0, 0}` reads `*`.
@@ -71,16 +74,12 @@ pub fn (mut s SeqSet) add(n u32) {
 
 // add_range inserts a range, in either order.
 pub fn (mut s SeqSet) add_range(start u32, stop u32) {
-	// `*` is the largest value there is, so it always ends a range.
-	if start == seq_star {
-		s.insert(SeqRange{stop, seq_star})
-		return
+	mut lo := to_bound(start)
+	mut hi := to_bound(stop)
+	if lo > hi {
+		lo, hi = hi, lo
 	}
-	if stop != seq_star && stop < start {
-		s.insert(SeqRange{stop, start})
-		return
-	}
-	s.insert(SeqRange{start, stop})
+	s.insert(lo, hi)
 }
 
 // len is the number of ranges the set is stored as, not the number of messages
@@ -98,8 +97,12 @@ pub fn (s &SeqSet) is_empty() bool {
 // contains reports whether `n` is named by the set. It answers for a concrete
 // number; `*` is not resolvable without knowing the mailbox.
 pub fn (s &SeqSet) contains(n u32) bool {
+	if n == seq_star {
+		return false
+	}
 	for r in s.ranges {
-		if r.start != seq_star && r.start <= n && (r.stop == seq_star || n <= r.stop) {
+		lo, hi := bounds(r)
+		if lo <= n && n <= hi {
 			return true
 		}
 	}
@@ -111,10 +114,11 @@ pub fn (s &SeqSet) contains(n u32) bool {
 pub fn (s &SeqSet) numbers() ![]u32 {
 	mut out := []u32{}
 	for r in s.ranges {
-		if r.start == seq_star || r.stop == seq_star {
+		lo, hi := bounds(r)
+		if hi == seq_max {
 			return error('imap: a set holding `*` cannot be expanded by the client')
 		}
-		for n := r.start; n <= r.stop; n++ {
+		for n := lo; n <= hi; n++ {
 			out << n
 		}
 	}
@@ -144,65 +148,75 @@ pub fn (r SeqRange) str() string {
 	return '${r.start}:${r.stop}'
 }
 
-// insert places a range and folds it into any neighbour it touches, which is
-// what keeps `1,2,3,4` from ever being sent when `1:4` says the same thing.
-fn (mut s SeqSet) insert(v SeqRange) {
-	mut merged := v
-	mut kept := []SeqRange{cap: s.ranges.len + 1}
-	for r in s.ranges {
-		union_range, ok := merge_ranges(merged, r)
-		if ok {
-			merged = union_range
-			continue
-		}
-		kept << r
-	}
-	kept << merged
-	kept.sort_with_compare(fn (a &SeqRange, b &SeqRange) int {
-		// `*` sorts last, since it is the largest value a range can start at.
-		if a.start == b.start {
-			return 0
-		}
-		if a.start == seq_star {
-			return 1
-		}
-		if b.start == seq_star {
-			return -1
-		}
-		return if a.start < b.start { -1 } else { 1 }
-	})
-	s.ranges = kept
+// The ranges are kept sorted and disjoint, which lets insertion find its place
+// by bisection instead of rescanning and re-sorting the whole set. Building a
+// set of twenty thousand scattered numbers is the difference between a few
+// milliseconds and ten seconds.
+
+// bounds maps a range onto the plain interval it denotes, `*` becoming the
+// largest number there is. Merging is then ordinary interval arithmetic rather
+// than a nest of special cases.
+fn bounds(r SeqRange) (u32, u32) {
+	return to_bound(r.start), to_bound(r.stop)
 }
 
-// merge_ranges unites two ranges when they overlap or sit next to each other,
-// and reports whether they did.
-fn merge_ranges(a SeqRange, b SeqRange) (SeqRange, bool) {
-	if a == b {
-		return a, true
+fn to_bound(n u32) u32 {
+	if n == seq_star {
+		return seq_max
 	}
-	// A range open at the top swallows anything that starts at or after it.
-	if a.stop == seq_star && b.start != seq_star && b.start >= a.start {
-		return a, true
+	return n
+}
+
+fn from_bound(n u32) u32 {
+	if n == seq_max {
+		return seq_star
 	}
-	if b.stop == seq_star && a.start != seq_star && a.start >= b.start {
-		return b, true
+	return n
+}
+
+// insert places the interval `lo:hi` and folds in every range it touches,
+// which is what keeps `1,2,3,4` from ever being sent when `1:4` says the same
+// thing.
+fn (mut s SeqSet) insert(lo u32, hi u32) {
+	// Bisect for the first range that reaches far enough to touch this one.
+	mut first := 0
+	mut last := s.ranges.len
+	for first < last {
+		mid := first + (last - first) / 2
+		_, mid_hi := bounds(s.ranges[mid])
+		if mid_hi < lo - 1 {
+			first = mid + 1
+			continue
+		}
+		last = mid
 	}
-	if a.start == seq_star || b.start == seq_star || a.stop == seq_star || b.stop == seq_star {
-		return a, false
+
+	mut new_lo := lo
+	mut new_hi := hi
+	mut after := first
+	for after < s.ranges.len {
+		r_lo, r_hi := bounds(s.ranges[after])
+		// Touching counts: 1:3 and 4:6 are the single range 1:6.
+		if new_hi != seq_max && r_lo > new_hi + 1 {
+			break
+		}
+		if r_lo < new_lo {
+			new_lo = r_lo
+		}
+		if r_hi > new_hi {
+			new_hi = r_hi
+		}
+		after++
 	}
-	mut lo := a
-	mut hi := b
-	if lo.start > hi.start {
-		lo, hi = hi, lo
+
+	merged := SeqRange{
+		start: from_bound(new_lo)
+		stop: from_bound(new_hi)
 	}
-	if lo.stop >= hi.stop {
-		return lo, true
+	if after > first {
+		s.ranges.delete_many(first, after - first)
 	}
-	// Touching counts: 1:3 and 4:6 are the single range 1:6.
-	if lo.stop >= hi.start || lo.stop + 1 == hi.start {
-		return SeqRange{lo.start, hi.stop}, true
-	}
-	return a, false
+	s.ranges.insert(first, merged)
 }
 
 fn parse_seq_number(s string) !u32 {

--- a/vlib/net/imap/seqset.v
+++ b/vlib/net/imap/seqset.v
@@ -1,0 +1,225 @@
+module imap
+
+// A sequence set names the messages a command applies to (RFC 3501 section
+// 9, `sequence-set`). It is a comma separated list of numbers and ranges, and
+// `*` stands for the highest number in the mailbox.
+//
+// Ranges matter: a mailbox with fifty thousand messages is addressed as
+// `1:50000`, where a list of every number would be a command line no server is
+// obliged to accept.
+
+// Zero is not a valid message number, which leaves it free to mean `*`.
+const seq_star = u32(0)
+
+// SeqRange is one number or one range of them. A single number has `start`
+// equal to `stop`. A `stop` of zero means `*`, so `{5, 0}` reads `5:*` and
+// `{0, 0}` reads `*`.
+pub struct SeqRange {
+pub:
+	start u32
+	stop  u32
+}
+
+// SeqSet is a set of message numbers, held as ranges that are kept sorted and
+// merged so that the rendered form stays short.
+pub struct SeqSet {
+pub mut:
+	ranges []SeqRange
+}
+
+// seq_set builds a set from a list of numbers.
+pub fn seq_set(numbers []u32) SeqSet {
+	mut s := SeqSet{}
+	for n in numbers {
+		s.add(n)
+	}
+	return s
+}
+
+// seq_range builds a set holding the single range `start:stop`.
+pub fn seq_range(start u32, stop u32) SeqSet {
+	mut s := SeqSet{}
+	s.add_range(start, stop)
+	return s
+}
+
+// seq_all is the set every message in the mailbox belongs to, `1:*`.
+pub fn seq_all() SeqSet {
+	return seq_range(1, seq_star)
+}
+
+// parse_seq_set reads a set back from its wire form, such as `2,4:7,9:*`.
+pub fn parse_seq_set(s string) !SeqSet {
+	mut out := SeqSet{}
+	if s == '' {
+		return out
+	}
+	for part in s.split(',') {
+		colon := part.index(':') or {
+			out.add(parse_seq_number(part)!)
+			continue
+		}
+		out.add_range(parse_seq_number(part[..colon])!, parse_seq_number(part[colon + 1..])!)
+	}
+	return out
+}
+
+// add inserts one number.
+pub fn (mut s SeqSet) add(n u32) {
+	s.add_range(n, n)
+}
+
+// add_range inserts a range, in either order.
+pub fn (mut s SeqSet) add_range(start u32, stop u32) {
+	// `*` is the largest value there is, so it always ends a range.
+	if start == seq_star {
+		s.insert(SeqRange{stop, seq_star})
+		return
+	}
+	if stop != seq_star && stop < start {
+		s.insert(SeqRange{stop, start})
+		return
+	}
+	s.insert(SeqRange{start, stop})
+}
+
+// len is the number of ranges the set is stored as, not the number of messages
+// it names.
+pub fn (s &SeqSet) len() int {
+	return s.ranges.len
+}
+
+// is_empty reports whether the set names nothing, in which case no command
+// should be sent at all.
+pub fn (s &SeqSet) is_empty() bool {
+	return s.ranges.len == 0
+}
+
+// contains reports whether `n` is named by the set. It answers for a concrete
+// number; `*` is not resolvable without knowing the mailbox.
+pub fn (s &SeqSet) contains(n u32) bool {
+	for r in s.ranges {
+		if r.start != seq_star && r.start <= n && (r.stop == seq_star || n <= r.stop) {
+			return true
+		}
+	}
+	return false
+}
+
+// numbers expands the set. It fails on a set holding `*`, whose end is only
+// known to the server.
+pub fn (s &SeqSet) numbers() ![]u32 {
+	mut out := []u32{}
+	for r in s.ranges {
+		if r.start == seq_star || r.stop == seq_star {
+			return error('imap: a set holding `*` cannot be expanded by the client')
+		}
+		for n := r.start; n <= r.stop; n++ {
+			out << n
+		}
+	}
+	return out
+}
+
+// str renders the set as a server reads it.
+pub fn (s SeqSet) str() string {
+	mut parts := []string{cap: s.ranges.len}
+	for r in s.ranges {
+		parts << r.str()
+	}
+	return parts.join(',')
+}
+
+// str renders one range, collapsing `n:n` back to `n`.
+pub fn (r SeqRange) str() string {
+	if r.start == r.stop {
+		if r.start == seq_star {
+			return '*'
+		}
+		return r.start.str()
+	}
+	if r.stop == seq_star {
+		return '${r.start}:*'
+	}
+	return '${r.start}:${r.stop}'
+}
+
+// insert places a range and folds it into any neighbour it touches, which is
+// what keeps `1,2,3,4` from ever being sent when `1:4` says the same thing.
+fn (mut s SeqSet) insert(v SeqRange) {
+	mut merged := v
+	mut kept := []SeqRange{cap: s.ranges.len + 1}
+	for r in s.ranges {
+		union_range, ok := merge_ranges(merged, r)
+		if ok {
+			merged = union_range
+			continue
+		}
+		kept << r
+	}
+	kept << merged
+	kept.sort_with_compare(fn (a &SeqRange, b &SeqRange) int {
+		// `*` sorts last, since it is the largest value a range can start at.
+		if a.start == b.start {
+			return 0
+		}
+		if a.start == seq_star {
+			return 1
+		}
+		if b.start == seq_star {
+			return -1
+		}
+		return if a.start < b.start { -1 } else { 1 }
+	})
+	s.ranges = kept
+}
+
+// merge_ranges unites two ranges when they overlap or sit next to each other,
+// and reports whether they did.
+fn merge_ranges(a SeqRange, b SeqRange) (SeqRange, bool) {
+	if a == b {
+		return a, true
+	}
+	// A range open at the top swallows anything that starts at or after it.
+	if a.stop == seq_star && b.start != seq_star && b.start >= a.start {
+		return a, true
+	}
+	if b.stop == seq_star && a.start != seq_star && a.start >= b.start {
+		return b, true
+	}
+	if a.start == seq_star || b.start == seq_star || a.stop == seq_star || b.stop == seq_star {
+		return a, false
+	}
+	mut lo := a
+	mut hi := b
+	if lo.start > hi.start {
+		lo, hi = hi, lo
+	}
+	if lo.stop >= hi.stop {
+		return lo, true
+	}
+	// Touching counts: 1:3 and 4:6 are the single range 1:6.
+	if lo.stop >= hi.start || lo.stop + 1 == hi.start {
+		return SeqRange{lo.start, hi.stop}, true
+	}
+	return a, false
+}
+
+fn parse_seq_number(s string) !u32 {
+	if s == '*' {
+		return seq_star
+	}
+	if s == '' {
+		return error('imap: empty number in a sequence set')
+	}
+	for ch in s {
+		if ch < `0` || ch > `9` {
+			return error('imap: `${s}` is not a message number')
+		}
+	}
+	n := s.u64()
+	if n == 0 || n > 0xffffffff {
+		return error('imap: `${s}` is out of the message number range')
+	}
+	return u32(n)
+}

--- a/vlib/net/imap/seqset.v
+++ b/vlib/net/imap/seqset.v
@@ -11,8 +11,9 @@ module imap
 // Zero is not a valid message number, which leaves it free to mean `*`.
 const seq_star = u32(0)
 
-// The value `*` stands for while a set is being merged.
-const seq_max = u32(0xffffffff)
+// The value `*` stands for while a set is being merged. It is one past the
+// full u32 range so the largest valid IMAP number remains distinct.
+const seq_bound_star = u64(0x100000000)
 
 // SeqRange is one number or one range of them. A single number has `start`
 // equal to `stop`. A `stop` of zero means `*`, so `{5, 0}` reads `5:*` and
@@ -115,11 +116,11 @@ pub fn (s &SeqSet) numbers() ![]u32 {
 	mut out := []u32{}
 	for r in s.ranges {
 		lo, hi := bounds(r)
-		if hi == seq_max {
+		if hi == seq_bound_star {
 			return error('imap: a set holding `*` cannot be expanded by the client')
 		}
 		for n := lo; n <= hi; n++ {
-			out << n
+			out << u32(n)
 		}
 	}
 	return out
@@ -156,28 +157,28 @@ pub fn (r SeqRange) str() string {
 // bounds maps a range onto the plain interval it denotes, `*` becoming the
 // largest number there is. Merging is then ordinary interval arithmetic rather
 // than a nest of special cases.
-fn bounds(r SeqRange) (u32, u32) {
+fn bounds(r SeqRange) (u64, u64) {
 	return to_bound(r.start), to_bound(r.stop)
 }
 
-fn to_bound(n u32) u32 {
+fn to_bound(n u32) u64 {
 	if n == seq_star {
-		return seq_max
+		return seq_bound_star
 	}
-	return n
+	return u64(n)
 }
 
-fn from_bound(n u32) u32 {
-	if n == seq_max {
+fn from_bound(n u64) u32 {
+	if n == seq_bound_star {
 		return seq_star
 	}
-	return n
+	return u32(n)
 }
 
 // insert places the interval `lo:hi` and folds in every range it touches,
 // which is what keeps `1,2,3,4` from ever being sent when `1:4` says the same
 // thing.
-fn (mut s SeqSet) insert(lo u32, hi u32) {
+fn (mut s SeqSet) insert(lo u64, hi u64) {
 	// Bisect for the first range that reaches far enough to touch this one.
 	mut first := 0
 	mut last := s.ranges.len
@@ -197,7 +198,7 @@ fn (mut s SeqSet) insert(lo u32, hi u32) {
 	for after < s.ranges.len {
 		r_lo, r_hi := bounds(s.ranges[after])
 		// Touching counts: 1:3 and 4:6 are the single range 1:6.
-		if new_hi != seq_max && r_lo > new_hi + 1 {
+		if new_hi != seq_bound_star && r_lo > new_hi + 1 {
 			break
 		}
 		if r_lo < new_lo {

--- a/vlib/net/imap/seqset_test.v
+++ b/vlib/net/imap/seqset_test.v
@@ -1,0 +1,105 @@
+module imap
+
+fn test_single_numbers_collapse_into_ranges() {
+	// The whole point of the set: four numbers go out as one range, because a
+	// command line is not obliged to be long enough for the alternative.
+	assert seq_set([u32(1), 2, 3, 4]).str() == '1:4'
+	assert seq_set([u32(4), 3, 2, 1]).str() == '1:4'
+	assert seq_set([u32(2), 84, 882]).str() == '2,84,882'
+	assert seq_set([u32(1), 2, 3, 7, 8, 12]).str() == '1:3,7:8,12'
+}
+
+fn test_a_large_run_stays_short_on_the_wire() {
+	mut all := []u32{}
+	for i in u32(1) .. 50001 {
+		all << i
+	}
+	assert seq_set(all).str() == '1:50000'
+	assert seq_set(all).len() == 1
+}
+
+fn test_duplicates_and_overlaps_fold_together() {
+	assert seq_set([u32(5), 5, 5]).str() == '5'
+	mut s := seq_range(1, 10)
+	s.add_range(5, 20)
+	assert s.str() == '1:20'
+	s.add_range(21, 21)
+	assert s.str() == '1:21'
+	// A gap of one is not a gap.
+	mut t := seq_range(1, 3)
+	t.add_range(4, 6)
+	assert t.str() == '1:6'
+	// A gap of two is.
+	mut u := seq_range(1, 3)
+	u.add_range(5, 6)
+	assert u.str() == '1:3,5:6'
+}
+
+fn test_the_star_stands_for_the_last_message() {
+	assert seq_all().str() == '1:*'
+	assert seq_range(5, seq_star).str() == '5:*'
+	assert seq_range(seq_star, seq_star).str() == '*'
+	// `*` is the largest value there is, so a range given the other way round
+	// still ends at it.
+	assert seq_range(seq_star, 5).str() == '5:*'
+}
+
+fn test_an_open_range_swallows_what_follows_it() {
+	mut s := seq_range(5, seq_star)
+	s.add(9)
+	s.add_range(100, 200)
+	assert s.str() == '5:*'
+	s.add(1)
+	assert s.str() == '1,5:*'
+}
+
+fn test_ranges_are_ordered() {
+	mut s := SeqSet{}
+	s.add(100)
+	s.add(3)
+	s.add(50)
+	assert s.str() == '3,50,100'
+}
+
+fn test_empty_set_renders_to_nothing() {
+	s := SeqSet{}
+	assert s.is_empty()
+	assert s.str() == ''
+	assert seq_set([]).is_empty()
+}
+
+fn test_parse_round_trip() {
+	for text in ['1', '1:4', '2,84,882', '1:3,7:8,12', '5:*', '*', '1:*'] {
+		assert parse_seq_set(text)!.str() == text, 'round trip failed for ${text}'
+	}
+	// A set written the long way comes back the short way, which is the same
+	// set.
+	assert parse_seq_set('1,2,3')!.str() == '1:3'
+	assert parse_seq_set('4:2')!.str() == '2:4'
+	assert parse_seq_set('')!.is_empty()
+}
+
+fn test_parse_rejects_what_is_not_a_set() {
+	for bad in ['0', 'a', '1:', ':4', '1,,2', '4294967296', '1:2:3'] {
+		parse_seq_set(bad) or { continue }
+		assert false, '`${bad}` is not a sequence set but was accepted'
+	}
+}
+
+fn test_contains() {
+	s := parse_seq_set('1:3,7,10:*')!
+	assert s.contains(1)
+	assert s.contains(3)
+	assert !s.contains(4)
+	assert s.contains(7)
+	assert !s.contains(8)
+	assert s.contains(10)
+	assert s.contains(999999)
+}
+
+fn test_numbers_expands_a_closed_set() {
+	assert parse_seq_set('1:3,7')!.numbers()! == [u32(1), 2, 3, 7]
+	// An open set has no end the client knows, so it cannot be expanded.
+	parse_seq_set('5:*')!.numbers() or { return }
+	assert false, 'expanding an open range must fail'
+}

--- a/vlib/net/imap/seqset_test.v
+++ b/vlib/net/imap/seqset_test.v
@@ -44,6 +44,11 @@ fn test_the_star_stands_for_the_last_message() {
 	assert seq_range(seq_star, 5).str() == '5:*'
 }
 
+fn test_the_largest_number_is_not_the_star() {
+	assert parse_seq_set('4294967295')!.str() == '4294967295'
+	assert seq_set([u32(0xffffffff)]).str() == '4294967295'
+}
+
 fn test_an_open_range_swallows_what_follows_it() {
 	mut s := seq_range(5, seq_star)
 	s.add(9)

--- a/vlib/net/imap/utf7.v
+++ b/vlib/net/imap/utf7.v
@@ -1,0 +1,197 @@
+module imap
+
+// Modified UTF-7 is how IMAP carries mailbox names that are not plain
+// US-ASCII (RFC 3501 section 5.1.3). It differs from UTF-7 on three points:
+// `&` shifts into base64 rather than `+`, the base64 alphabet ends in `,`
+// instead of `/` so that the popular hierarchy delimiter stays usable, and
+// printable US-ASCII must never be encoded.
+//
+// Names travel encoded and are handed to the caller decoded, so a program
+// using this module works in ordinary UTF-8 throughout.
+
+// The range of characters that represent themselves.
+const utf7_min = 0x20
+const utf7_max = 0x7e
+
+const utf7_alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+,'
+
+// utf7_encode renders a mailbox name in modified UTF-7.
+pub fn utf7_encode(s string) string {
+	runes := s.runes()
+	mut out := []u8{cap: s.len}
+	mut i := 0
+	for i < runes.len {
+		r := runes[i]
+		if is_self_representing(r) {
+			out << u8(r)
+			// The shift character is written twice to stand for itself.
+			if r == `&` {
+				out << `-`
+			}
+			i++
+			continue
+		}
+		// Everything up to the next self-representing character goes into a
+		// single base64 run: shifting out and straight back in would be the
+		// kind of superfluous shift the RFC asks servers to reject.
+		start := i
+		for i < runes.len && !is_self_representing(runes[i]) {
+			i++
+		}
+		out << `&`
+		out << modified_b64_encode(utf16_be(runes[start..i]))
+		out << `-`
+	}
+	return out.bytestr()
+}
+
+// utf7_decode reads a mailbox name back out of modified UTF-7.
+//
+// Bytes above US-ASCII are passed through as they are: some servers send raw
+// UTF-8 despite the convention, and refusing it would hide their mailboxes.
+pub fn utf7_decode(s string) !string {
+	mut out := []u8{cap: s.len}
+	mut i := 0
+	for i < s.len {
+		if s[i] != `&` {
+			out << s[i]
+			i++
+			continue
+		}
+		end := index_of(s, `-`, i + 1) or {
+			return error('imap: unterminated modified UTF-7 shift in `${s}`')
+		}
+		if end == i + 1 {
+			// `&-` is how a literal ampersand is written.
+			out << `&`
+			i = end + 1
+			continue
+		}
+		out << utf16_be_to_utf8(modified_b64_decode(s[i + 1..end])!)!.bytes()
+		i = end + 1
+	}
+	return out.bytestr()
+}
+
+fn is_self_representing(r rune) bool {
+	return r >= utf7_min && r <= utf7_max
+}
+
+// index_of returns the offset of `ch` at or after `from`.
+fn index_of(s string, ch u8, from int) ?int {
+	for i := from; i < s.len; i++ {
+		if s[i] == ch {
+			return i
+		}
+	}
+	return none
+}
+
+// utf16_be converts code points to the big endian UTF-16 that the base64 runs
+// carry, splitting anything above the basic plane into a surrogate pair.
+fn utf16_be(runes []rune) []u8 {
+	mut out := []u8{cap: runes.len * 2}
+	for r in runes {
+		if r < 0x10000 {
+			out << u8(r >> 8)
+			out << u8(r)
+			continue
+		}
+		v := u32(r) - 0x10000
+		hi := 0xd800 + (v >> 10)
+		lo := 0xdc00 + (v & 0x3ff)
+		out << u8(hi >> 8)
+		out << u8(hi)
+		out << u8(lo >> 8)
+		out << u8(lo)
+	}
+	return out
+}
+
+// utf16_be_to_utf8 is the inverse, rejecting the surrogate mistakes that would
+// otherwise produce an invalid string.
+fn utf16_be_to_utf8(data []u8) !string {
+	if data.len % 2 != 0 {
+		return error('imap: modified UTF-7 run does not hold whole UTF-16 units')
+	}
+	mut out := []u8{cap: data.len}
+	mut i := 0
+	for i < data.len {
+		unit := (u32(data[i]) << 8) | u32(data[i + 1])
+		i += 2
+		if unit < 0xd800 || unit > 0xdfff {
+			out << utf32_to_str(unit).bytes()
+			continue
+		}
+		if unit >= 0xdc00 {
+			return error('imap: unpaired low surrogate in modified UTF-7')
+		}
+		if i + 1 >= data.len {
+			return error('imap: truncated surrogate pair in modified UTF-7')
+		}
+		low := (u32(data[i]) << 8) | u32(data[i + 1])
+		i += 2
+		if low < 0xdc00 || low > 0xdfff {
+			return error('imap: unpaired high surrogate in modified UTF-7')
+		}
+		out << utf32_to_str(0x10000 + ((unit - 0xd800) << 10) + (low - 0xdc00)).bytes()
+	}
+	return out.bytestr()
+}
+
+// modified_b64_encode is base64 over the IMAP alphabet, without padding.
+fn modified_b64_encode(data []u8) []u8 {
+	mut out := []u8{cap: (data.len + 2) / 3 * 4}
+	mut i := 0
+	for i + 2 < data.len {
+		n := (u32(data[i]) << 16) | (u32(data[i + 1]) << 8) | u32(data[i + 2])
+		out << utf7_alphabet[(n >> 18) & 0x3f]
+		out << utf7_alphabet[(n >> 12) & 0x3f]
+		out << utf7_alphabet[(n >> 6) & 0x3f]
+		out << utf7_alphabet[n & 0x3f]
+		i += 3
+	}
+	rest := data.len - i
+	if rest == 0 {
+		return out
+	}
+	if rest == 1 {
+		n := u32(data[i]) << 16
+		out << utf7_alphabet[(n >> 18) & 0x3f]
+		out << utf7_alphabet[(n >> 12) & 0x3f]
+		return out
+	}
+	n := (u32(data[i]) << 16) | (u32(data[i + 1]) << 8)
+	out << utf7_alphabet[(n >> 18) & 0x3f]
+	out << utf7_alphabet[(n >> 12) & 0x3f]
+	out << utf7_alphabet[(n >> 6) & 0x3f]
+	return out
+}
+
+fn modified_b64_decode(s string) ![]u8 {
+	mut out := []u8{cap: s.len * 3 / 4}
+	mut acc := u32(0)
+	mut bits := 0
+	for ch in s {
+		v := utf7_alphabet.index_u8(ch)
+		if v < 0 {
+			return error('imap: `${rune(ch)}` is not modified base64')
+		}
+		acc = (acc << 6) | u32(v)
+		bits += 6
+		if bits < 8 {
+			continue
+		}
+		bits -= 8
+		out << u8(acc >> bits)
+	}
+	// A run of the right length leaves at most four bits behind, and a well
+	// formed one leaves them zero.
+	if bits >= 6 {
+		return error('imap: modified base64 run has a trailing partial byte')
+	}
+	if acc & ((u32(1) << bits) - 1) != 0 {
+		return error('imap: modified base64 run has non-zero padding bits')
+	}
+	return out
+}

--- a/vlib/net/imap/utf7.v
+++ b/vlib/net/imap/utf7.v
@@ -17,6 +17,11 @@ const utf7_alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz01234
 
 // utf7_encode renders a mailbox name in modified UTF-7.
 pub fn utf7_encode(s string) string {
+	// A name already made of printable ASCII with no shift character in it
+	// encodes to itself, which covers INBOX and most of what a server holds.
+	if !needs_utf7(s) {
+		return s
+	}
 	runes := s.runes()
 	mut out := []u8{cap: s.len}
 	mut i := 0
@@ -50,6 +55,11 @@ pub fn utf7_encode(s string) string {
 // Bytes above US-ASCII are passed through as they are: some servers send raw
 // UTF-8 despite the convention, and refusing it would hide their mailboxes.
 pub fn utf7_decode(s string) !string {
+	// With no shift character there is nothing encoded, so the name already is
+	// what it decodes to.
+	if s.index_u8(`&`) < 0 {
+		return s
+	}
 	mut out := []u8{cap: s.len}
 	mut i := 0
 	for i < s.len {
@@ -71,6 +81,16 @@ pub fn utf7_decode(s string) !string {
 		i = end + 1
 	}
 	return out.bytestr()
+}
+
+// needs_utf7 reports whether anything in the name has to be encoded at all.
+fn needs_utf7(s string) bool {
+	for ch in s {
+		if ch < utf7_min || ch > utf7_max || ch == `&` {
+			return true
+		}
+	}
+	return false
 }
 
 fn is_self_representing(r rune) bool {

--- a/vlib/net/imap/utf7_test.v
+++ b/vlib/net/imap/utf7_test.v
@@ -1,0 +1,110 @@
+module imap
+
+// The vectors below come from RFC 3501 section 5.1.3 and RFC 2152, plus the
+// mailbox names real servers hand out. They were cross-checked against
+// Python's `utf-7` codec with `/` swapped for `,`, which is the same encoding
+// arrived at independently.
+fn test_ascii_passes_through() {
+	for s in ['INBOX', 'Sent', 'Work/Reports', 'a b c', '~/Mail', 'x!\$%*()[]{}#'] {
+		assert utf7_encode(s) == s
+		assert utf7_decode(s)! == s
+	}
+}
+
+fn test_the_shift_character_stands_for_itself() {
+	assert utf7_encode('A&B') == 'A&-B'
+	assert utf7_decode('A&-B')! == 'A&B'
+	assert utf7_encode('&') == '&-'
+	assert utf7_decode('&-')! == '&'
+	assert utf7_encode('&&') == '&-&-'
+	assert utf7_decode('&-&-')! == '&&'
+}
+
+fn test_rfc_examples() {
+	// The two names RFC 3501 prints, one Japanese and one mixed.
+	assert utf7_decode('~peter/mail/&U,BTFw-/&ZeVnLIqe-')! == '~peter/mail/台北/日本語'
+	assert utf7_encode('~peter/mail/台北/日本語') == '~peter/mail/&U,BTFw-/&ZeVnLIqe-'
+	// RFC 2060's own example of the ampersand escape.
+	assert utf7_decode('&-')! == '&'
+}
+
+fn test_round_trip() {
+	names := [
+		'Rapports 2026',
+		'Éléments envoyés',
+		'Корзина',
+		'垃圾桶',
+		'受信トレイ',
+		'📨 Newsletters',
+		'a&b',
+		'&&&',
+		'Travail/Clients/Société Générale',
+		'√±≈',
+		'\x01control',
+		'ünïcödé/nëstèd/pàth',
+	]
+	for name in names {
+		encoded := utf7_encode(name)
+		// The encoded form is always plain printable ASCII, which is what lets
+		// a mailbox name travel as a quoted string rather than a literal.
+		for ch in encoded {
+			assert ch >= 0x20 && ch <= 0x7e, 'encoding ${name} left a raw octet ${ch}'
+		}
+		assert utf7_decode(encoded)! == name, 'round trip failed for ${name}'
+	}
+}
+
+fn test_astral_plane_uses_a_surrogate_pair() {
+	// U+1F4E8 is above the basic plane, so it takes two UTF-16 units, which is
+	// four octets and therefore a longer base64 run.
+	encoded := utf7_encode('📨')
+	assert encoded == '&2D3c6A-'
+	assert utf7_decode(encoded)! == '📨'
+}
+
+fn test_one_run_covers_consecutive_non_ascii() {
+	// Shifting out and straight back in for each character would be the
+	// superfluous shift the RFC tells servers to reject.
+	assert utf7_encode('日本語').count('&') == 1
+	assert utf7_encode('日a本') == '&ZeU-a&Zyw-'
+}
+
+fn test_control_characters_are_encoded() {
+	// A tab is below the self-representing range, so it may not be sent bare.
+	assert utf7_encode('a\tb') == 'a&AAk-b'
+	assert utf7_decode('a&AAk-b')! == 'a\tb'
+}
+
+fn test_malformed_input_is_rejected() {
+	// A shift that never ends.
+	assert fails(fn () ! {
+		utf7_decode('&AOk')!})
+	// A character outside the base64 alphabet.
+	assert fails(fn () ! {
+		utf7_decode('&A!k-')!})
+	// `/` belongs to standard base64, not this one.
+	assert fails(fn () ! {
+		utf7_decode('&A/k-')!})
+	// A run holding half a UTF-16 unit.
+	assert fails(fn () ! {
+		utf7_decode('&AAAA-')!})
+	// A high surrogate with nothing after it.
+	assert fails(fn () ! {
+		utf7_decode('&2D0-')!})
+	// A low surrogate on its own.
+	assert fails(fn () ! {
+		utf7_decode('&3Og-')!})
+}
+
+fn test_raw_utf8_is_tolerated_on_the_way_in() {
+	// Some servers ignore the convention and send UTF-8 directly. Refusing it
+	// would hide their mailboxes from a caller for no gain.
+	assert utf7_decode('Éléments')! == 'Éléments'
+}
+
+// fails reports whether `f` returned an error, which keeps the negative cases
+// above to one line each.
+fn fails(f fn() !) bool {
+	f() or { return true }
+	return false
+}

--- a/vlib/net/imap/wire.v
+++ b/vlib/net/imap/wire.v
@@ -16,52 +16,69 @@ const max_literal_size = u32(64 * 1024 * 1024)
 
 // Decoder reads the grammar off a connection, or off a fixed buffer when it is
 // being exercised without one.
+//
+// Bytes are served from `buf`, refilled a chunk at a time. Reaching into the
+// reader for one octet at a time would mean a call and an allocation per byte
+// of every response.
 struct Decoder {
 mut:
-	reader  ?&io.BufferedReader
-	src     []u8
-	src_pos int
-	pushed  ?u8
+	reader ?&io.BufferedReader
+	buf    []u8
+	pos    int
+	filled int
 }
+
+// The size of one read from the connection.
+const decoder_chunk = 8192
 
 // decoder_over builds a decoder that reads a fixed buffer, which is how the
 // grammar is tested without a server.
 fn decoder_over(s string) &Decoder {
+	bytes := s.bytes()
 	return &Decoder{
-		src: s.bytes()
+		buf: bytes
+		filled: bytes.len
 	}
 }
 
-// read_byte takes the next octet, from the pushback slot first.
+fn decoder_on(reader &io.BufferedReader) &Decoder {
+	return &Decoder{
+		reader: unsafe { reader }
+		buf: []u8{len: decoder_chunk}
+	}
+}
+
 fn (mut d Decoder) read_byte() !u8 {
-	if ch := d.pushed {
-		d.pushed = none
-		return ch
+	if d.pos >= d.filled {
+		d.refill()!
 	}
-	if mut r := d.reader {
-		mut one := [u8(0)]
-		n := r.read(mut one)!
-		if n <= 0 {
-			return error('imap: the connection closed in the middle of a response')
-		}
-		return one[0]
-	}
-	if d.src_pos >= d.src.len {
-		return error('imap: the response ended early')
-	}
-	ch := d.src[d.src_pos]
-	d.src_pos++
+	ch := d.buf[d.pos]
+	d.pos++
 	return ch
 }
 
-// unread puts one octet back, which is all the lookahead this grammar needs.
-fn (mut d Decoder) unread(ch u8) {
-	d.pushed = ch
+// refill pulls the next chunk from the connection. A decoder over a fixed
+// buffer has none, so running out is simply the end of the input.
+fn (mut d Decoder) refill() ! {
+	mut r := d.reader or { return error('imap: the response ended early') }
+	n := r.read(mut d.buf)!
+	if n <= 0 {
+		return error('imap: the connection closed in the middle of a response')
+	}
+	d.filled = n
+	d.pos = 0
+}
+
+// unread puts the last octet back, which is all the lookahead this grammar
+// needs. It is only ever called on a byte just taken, so the position cannot
+// go below the start of the chunk that byte came from.
+fn (mut d Decoder) unread() {
+	d.pos--
 }
 
 fn (mut d Decoder) peek_byte() !u8 {
 	ch := d.read_byte()!
-	d.unread(ch)
+	d.unread()
 	return ch
 }
 
@@ -69,36 +86,29 @@ fn (mut d Decoder) peek_byte() !u8 {
 // defined by its length and has no terminator to look for.
 fn (mut d Decoder) read_n(n int) ![]u8 {
 	mut out := []u8{len: n}
-	mut got := 0
-	if ch := d.pushed {
-		d.pushed = none
-		out[0] = ch
-		got = 1
+	// Whatever is already buffered comes first.
+	mut got := d.filled - d.pos
+	if got > n {
+		got = n
 	}
+	if got > 0 {
+		copy(mut out, d.buf[d.pos..d.pos + got])
+		d.pos += got
+	}
+	if got == n {
+		return out
+	}
+	// The rest goes from the connection straight into the caller's buffer,
+	// since a literal can be many times the size of a chunk.
+	mut r := d.reader or { return error('imap: the literal is shorter than it claimed') }
 	for got < n {
-		got += d.fill(mut out[got..])!
-	}
-	return out
-}
-
-fn (mut d Decoder) fill(mut dest []u8) !int {
-	if mut r := d.reader {
-		n := r.read(mut dest)!
-		if n <= 0 {
+		read := r.read(mut out[got..])!
+		if read <= 0 {
 			return error('imap: the connection closed inside a literal')
 		}
-		return n
+		got += read
 	}
-	left := d.src.len - d.src_pos
-	if left <= 0 {
-		return error('imap: the literal is shorter than it claimed')
-	}
-	n := if dest.len < left { dest.len } else { left }
-	for i in 0 .. n {
-		dest[i] = d.src[d.src_pos + i]
-	}
-	d.src_pos += n
-	return n
+	return out
 }
 
 // accept consumes the next octet when it is the one wanted, and reports
@@ -108,7 +118,7 @@ fn (mut d Decoder) accept(want u8) !bool {
 	if ch == want {
 		return true
 	}
-	d.unread(ch)
+	d.unread()
 	return false
 }
 
@@ -137,22 +147,51 @@ fn (mut d Decoder) crlf() ! {
 	d.expect(`\n`)!
 }
 
-// atom reads an unquoted word. `atom-specials` are the characters that end
-// one, so an atom never swallows the syntax around it.
-fn (mut d Decoder) atom() !string {
-	mut out := []u8{}
+// TokenKind names the four runs of bare characters the grammar has. They differ
+// from each other by a single character, so one reader covers all of them.
+enum TokenKind {
+	// ATOM-CHAR only.
+	atom
+	// ATOM-CHAR plus `]`, which a mailbox name written bare may hold.
+	astring
+	// ATOM-CHAR minus `[`, which opens a section specification with no space
+	// in front of it.
+	item_name
+	// The digits and punctuation a sequence set is made of, including the `*`
+	// that an atom may not hold.
+	seq_set
+}
+
+fn (k TokenKind) accepts(ch u8) bool {
+	return match k {
+		.atom { is_atom_char(ch) }
+		.astring { is_atom_char(ch) || ch == `]` }
+		.item_name { is_atom_char(ch) && ch != `[` }
+		.seq_set { is_seq_set_char(ch) }
+	}
+}
+
+// take_token reads one bare run, stopping at the first character the kind does
+// not accept, so a token never swallows the syntax around it.
+fn (mut d Decoder) take_token(kind TokenKind, name string) !string {
+	mut out := []u8{cap: 32}
 	for {
 		ch := d.read_byte() or { break }
-		if !is_atom_char(ch) {
-			d.unread(ch)
+		if !kind.accepts(ch) {
+			d.unread()
 			break
 		}
 		out << ch
 	}
 	if out.len == 0 {
-		return error('imap: expected an atom')
+		return error('imap: expected ${name}')
 	}
 	return out.bytestr()
+}
+
+// atom reads an unquoted word.
+fn (mut d Decoder) atom() !string {
+	return d.take_token(.atom, 'an atom')
 }
 
 // item_name reads the name of a fetch item.
@@ -162,19 +201,7 @@ fn (mut d Decoder) atom() !string {
 // atom character, so an atom would otherwise swallow the opening bracket of
 // `BODY[]` and leave the rest unreadable.
 fn (mut d Decoder) item_name() !string {
-	mut out := []u8{}
-	for {
-		ch := d.read_byte() or { break }
-		if !is_atom_char(ch) || ch == `[` {
-			d.unread(ch)
-			break
-		}
-		out << ch
-	}
-	if out.len == 0 {
-		return error('imap: expected a fetch item name')
-	}
-	return out.bytestr()
+	return d.take_token(.item_name, 'a fetch item name')
 }
 
 // number reads an unsigned 32 bit integer.
@@ -184,7 +211,7 @@ fn (mut d Decoder) number() !u32 {
 	for {
 		ch := d.read_byte() or { break }
 		if ch < `0` || ch > `9` {
-			d.unread(ch)
+			d.unread()
 			break
 		}
 		n = n * 10 + u64(ch - `0`)
@@ -204,19 +231,7 @@ fn (mut d Decoder) number() !u32 {
 // An atom cannot hold one: `*` is a list wildcard and therefore not an atom
 // character, yet it is an ordinary part of a set.
 fn (mut d Decoder) seq_set_token() !string {
-	mut out := []u8{}
-	for {
-		ch := d.read_byte() or { break }
-		if !is_seq_set_char(ch) {
-			d.unread(ch)
-			break
-		}
-		out << ch
-	}
-	if out.len == 0 {
-		return error('imap: expected a sequence set')
-	}
-	return out.bytestr()
+	return d.take_token(.seq_set, 'a sequence set')
 }
 
 fn is_seq_set_char(ch u8) bool {
@@ -229,7 +244,7 @@ fn is_seq_set_char(ch u8) bool {
 // quoted reads a quoted string, where a backslash escapes the next octet.
 fn (mut d Decoder) quoted() !string {
 	d.expect(`"`)!
-	mut out := []u8{}
+	mut out := []u8{cap: 64}
 	for {
 		mut ch := d.read_byte()!
 		if ch == `"` {
@@ -285,19 +300,7 @@ fn (mut d Decoder) astring() !string {
 	if ch == `"` || ch == `{` {
 		return d.string_value()
 	}
-	mut out := []u8{}
-	for {
-		next := d.read_byte() or { break }
-		if !is_atom_char(next) && next != `]` {
-			d.unread(next)
-			break
-		}
-		out << next
-	}
-	if out.len == 0 {
-		return error('imap: expected a mailbox name or an atom')
-	}
-	return out.bytestr()
+	return d.take_token(.astring, 'a mailbox name or an atom')
 }
 
 // nstring_text reads a string or the atom NIL, which stands for a field the
@@ -321,16 +324,37 @@ fn (mut d Decoder) nstring_text() !string {
 // text reads the free-form remainder of a line, which carries the human
 // readable part of a status response.
 fn (mut d Decoder) text() !string {
-	mut out := []u8{}
+	mut out := []u8{cap: 64}
 	for {
 		ch := d.read_byte() or { break }
 		if ch == `\r` || ch == `\n` {
-			d.unread(ch)
+			d.unread()
 			break
 		}
 		out << ch
 	}
 	return out.bytestr()
+}
+
+// accept_nil consumes the atom NIL where a parenthesised value could stand,
+// and reports whether it did. NIL is how a server says a header the message
+// never carried, or a content type with no parameters.
+fn (mut d Decoder) accept_nil() !bool {
+	if d.peek_byte()! == `(` {
+		return false
+	}
+	word := d.atom()!
+	if word.to_upper() != 'NIL' {
+		return error('imap: expected a parenthesised value or NIL, got `${word}`')
+	}
+	return true
+}
+
+// mailbox_name reads a name off the wire and hands it back as UTF-8. A name
+// the encoding cannot explain is passed through rather than lost.
+fn (mut d Decoder) mailbox_name() !string {
+	raw := d.astring()!
+	return utf7_decode(raw) or { raw }
 }
 
 // open_list consumes the opening parenthesis and reports whether the list has

--- a/vlib/net/imap/wire.v
+++ b/vlib/net/imap/wire.v
@@ -1,0 +1,416 @@
+module imap
+
+import io
+
+// A decoder over the IMAP grammar of RFC 3501 section 9.
+//
+// Responses are built from four things: atoms, quoted strings, literals and
+// parenthesised lists. Reading them as such is what keeps message content from
+// ever being mistaken for protocol, which no amount of searching a response
+// line for `UID ` can guarantee: a message whose subject is `UID 999` would
+// answer that search just as readily as the real field.
+
+// A literal states its own length, so a server can ask a client to hold an
+// arbitrary amount of memory. This is the most one literal may claim.
+const max_literal_size = u32(64 * 1024 * 1024)
+
+// Decoder reads the grammar off a connection, or off a fixed buffer when it is
+// being exercised without one.
+struct Decoder {
+mut:
+	reader  ?&io.BufferedReader
+	src     []u8
+	src_pos int
+	pushed  ?u8
+}
+
+// decoder_over builds a decoder that reads a fixed buffer, which is how the
+// grammar is tested without a server.
+fn decoder_over(s string) &Decoder {
+	return &Decoder{
+		src: s.bytes()
+	}
+}
+
+// read_byte takes the next octet, from the pushback slot first.
+fn (mut d Decoder) read_byte() !u8 {
+	if ch := d.pushed {
+		d.pushed = none
+		return ch
+	}
+	if mut r := d.reader {
+		mut one := [u8(0)]
+		n := r.read(mut one)!
+		if n <= 0 {
+			return error('imap: the connection closed in the middle of a response')
+		}
+		return one[0]
+	}
+	if d.src_pos >= d.src.len {
+		return error('imap: the response ended early')
+	}
+	ch := d.src[d.src_pos]
+	d.src_pos++
+	return ch
+}
+
+// unread puts one octet back, which is all the lookahead this grammar needs.
+fn (mut d Decoder) unread(ch u8) {
+	d.pushed = ch
+}
+
+fn (mut d Decoder) peek_byte() !u8 {
+	ch := d.read_byte()!
+	d.unread(ch)
+	return ch
+}
+
+// read_n takes exactly `n` octets, which is how a literal is read: it is
+// defined by its length and has no terminator to look for.
+fn (mut d Decoder) read_n(n int) ![]u8 {
+	mut out := []u8{len: n}
+	mut got := 0
+	if ch := d.pushed {
+		d.pushed = none
+		out[0] = ch
+		got = 1
+	}
+	for got < n {
+		got += d.fill(mut out[got..])!
+	}
+	return out
+}
+
+fn (mut d Decoder) fill(mut dest []u8) !int {
+	if mut r := d.reader {
+		n := r.read(mut dest)!
+		if n <= 0 {
+			return error('imap: the connection closed inside a literal')
+		}
+		return n
+	}
+	left := d.src.len - d.src_pos
+	if left <= 0 {
+		return error('imap: the literal is shorter than it claimed')
+	}
+	n := if dest.len < left { dest.len } else { left }
+	for i in 0 .. n {
+		dest[i] = d.src[d.src_pos + i]
+	}
+	d.src_pos += n
+	return n
+}
+
+// accept consumes the next octet when it is the one wanted, and reports
+// whether it did.
+fn (mut d Decoder) accept(want u8) !bool {
+	ch := d.read_byte()!
+	if ch == want {
+		return true
+	}
+	d.unread(ch)
+	return false
+}
+
+fn (mut d Decoder) expect(want u8) ! {
+	ch := d.read_byte()!
+	if ch != want {
+		return error('imap: expected `${rune(want)}`, got `${rune(ch)}`')
+	}
+}
+
+// sp consumes the single space that separates two elements.
+fn (mut d Decoder) sp() ! {
+	d.expect(` `)!
+}
+
+// crlf consumes the line ending, tolerating a bare LF from a server that sends
+// one.
+fn (mut d Decoder) crlf() ! {
+	ch := d.read_byte()!
+	if ch == `\n` {
+		return
+	}
+	if ch != `\r` {
+		return error('imap: expected the end of the line, got `${rune(ch)}`')
+	}
+	d.expect(`\n`)!
+}
+
+// atom reads an unquoted word. `atom-specials` are the characters that end
+// one, so an atom never swallows the syntax around it.
+fn (mut d Decoder) atom() !string {
+	mut out := []u8{}
+	for {
+		ch := d.read_byte() or { break }
+		if !is_atom_char(ch) {
+			d.unread(ch)
+			break
+		}
+		out << ch
+	}
+	if out.len == 0 {
+		return error('imap: expected an atom')
+	}
+	return out.bytestr()
+}
+
+// item_name reads the name of a fetch item.
+//
+// It stops at `[` as well as at the atom specials. A section specification
+// follows the name with no space between them, and `[` is a perfectly ordinary
+// atom character, so an atom would otherwise swallow the opening bracket of
+// `BODY[]` and leave the rest unreadable.
+fn (mut d Decoder) item_name() !string {
+	mut out := []u8{}
+	for {
+		ch := d.read_byte() or { break }
+		if !is_atom_char(ch) || ch == `[` {
+			d.unread(ch)
+			break
+		}
+		out << ch
+	}
+	if out.len == 0 {
+		return error('imap: expected a fetch item name')
+	}
+	return out.bytestr()
+}
+
+// number reads an unsigned 32 bit integer.
+fn (mut d Decoder) number() !u32 {
+	mut n := u64(0)
+	mut digits := 0
+	for {
+		ch := d.read_byte() or { break }
+		if ch < `0` || ch > `9` {
+			d.unread(ch)
+			break
+		}
+		n = n * 10 + u64(ch - `0`)
+		if n > 0xffffffff {
+			return error('imap: a number in the response overflows 32 bits')
+		}
+		digits++
+	}
+	if digits == 0 {
+		return error('imap: expected a number')
+	}
+	return u32(n)
+}
+
+// seq_set_token reads a sequence set as a response carries it.
+//
+// An atom cannot hold one: `*` is a list wildcard and therefore not an atom
+// character, yet it is an ordinary part of a set.
+fn (mut d Decoder) seq_set_token() !string {
+	mut out := []u8{}
+	for {
+		ch := d.read_byte() or { break }
+		if !is_seq_set_char(ch) {
+			d.unread(ch)
+			break
+		}
+		out << ch
+	}
+	if out.len == 0 {
+		return error('imap: expected a sequence set')
+	}
+	return out.bytestr()
+}
+
+fn is_seq_set_char(ch u8) bool {
+	if ch >= `0` && ch <= `9` {
+		return true
+	}
+	return ch == `:` || ch == `,` || ch == `*`
+}
+
+// quoted reads a quoted string, where a backslash escapes the next octet.
+fn (mut d Decoder) quoted() !string {
+	d.expect(`"`)!
+	mut out := []u8{}
+	for {
+		mut ch := d.read_byte()!
+		if ch == `"` {
+			return out.bytestr()
+		}
+		if ch == `\r` || ch == `\n` {
+			return error('imap: a quoted string cannot span lines')
+		}
+		if ch == `\\` {
+			ch = d.read_byte()!
+		}
+		out << ch
+	}
+	return error('imap: unterminated quoted string')
+}
+
+// literal reads `{n}` followed by a line ending and exactly n octets. This is
+// how a server sends anything a quoted string cannot hold, message bodies
+// above all.
+fn (mut d Decoder) literal() !string {
+	d.expect(`{`)!
+	size := d.number()!
+	// A `+` marks a non-synchronising literal (RFC 7888). Nothing changes on
+	// the reading side; the octets still follow.
+	_ := d.accept(`+`)!
+	d.expect(`}`)!
+	d.crlf()!
+	if size > max_literal_size {
+		return error('imap: the server announced a ${size} octet literal, over the ${max_literal_size} limit')
+	}
+	if size == 0 {
+		return ''
+	}
+	return d.read_n(int(size))!.bytestr()
+}
+
+// string_value reads either form a string may take.
+fn (mut d Decoder) string_value() !string {
+	ch := d.peek_byte()!
+	if ch == `"` {
+		return d.quoted()
+	}
+	if ch == `{` {
+		return d.literal()
+	}
+	return error('imap: expected a quoted string or a literal')
+}
+
+// astring reads a string that may also be written bare. Mailbox names arrive
+// this way, and a bare one may contain `]`, which an atom may not.
+fn (mut d Decoder) astring() !string {
+	ch := d.peek_byte()!
+	if ch == `"` || ch == `{` {
+		return d.string_value()
+	}
+	mut out := []u8{}
+	for {
+		next := d.read_byte() or { break }
+		if !is_atom_char(next) && next != `]` {
+			d.unread(next)
+			break
+		}
+		out << next
+	}
+	if out.len == 0 {
+		return error('imap: expected a mailbox name or an atom')
+	}
+	return out.bytestr()
+}
+
+// nstring_text reads a string or the atom NIL, which stands for a field the
+// server has no value for.
+//
+// NIL comes back as the empty string. Nothing that reads these fields, a
+// missing subject or an absent body section alike, has anything different to
+// say about the two.
+fn (mut d Decoder) nstring_text() !string {
+	ch := d.peek_byte()!
+	if ch == `"` || ch == `{` {
+		return d.string_value()
+	}
+	word := d.atom()!
+	if word.to_upper() != 'NIL' {
+		return error('imap: expected a string or NIL, got `${word}`')
+	}
+	return ''
+}
+
+// text reads the free-form remainder of a line, which carries the human
+// readable part of a status response.
+fn (mut d Decoder) text() !string {
+	mut out := []u8{}
+	for {
+		ch := d.read_byte() or { break }
+		if ch == `\r` || ch == `\n` {
+			d.unread(ch)
+			break
+		}
+		out << ch
+	}
+	return out.bytestr()
+}
+
+// open_list consumes the opening parenthesis and reports whether the list has
+// any element at all.
+fn (mut d Decoder) open_list() !bool {
+	d.expect(`(`)!
+	return !d.accept(`)`)!
+}
+
+// more_in_list consumes what follows an element, and reports whether another
+// one comes after it.
+fn (mut d Decoder) more_in_list() !bool {
+	if d.accept(`)`)! {
+		return false
+	}
+	d.sp()!
+	return true
+}
+
+// flag_list reads `(\Seen \Answered)`, the form flags take everywhere.
+fn (mut d Decoder) flag_list() ![]string {
+	mut flags := []string{}
+	if !d.open_list()! {
+		return flags
+	}
+	for {
+		flags << d.flag()!
+		if !d.more_in_list()! {
+			return flags
+		}
+	}
+	return flags
+}
+
+// flag reads one flag: an atom, prefixed by a backslash for the ones the
+// protocol defines itself.
+fn (mut d Decoder) flag() !string {
+	if !d.accept(`\\`)! {
+		return d.atom()
+	}
+	// `\*` in PERMANENTFLAGS means the mailbox accepts new keywords.
+	if d.accept(`*`)! {
+		return '\\*'
+	}
+	return '\\' + d.atom()!
+}
+
+// skip_value consumes one element of any shape, so that an item this module
+// does not model cannot derail the rest of the response.
+fn (mut d Decoder) skip_value() ! {
+	ch := d.peek_byte()!
+	if ch == `"` || ch == `{` {
+		d.string_value()!
+		return
+	}
+	if ch != `(` {
+		d.atom()!
+		return
+	}
+	if !d.open_list()! {
+		return
+	}
+	for {
+		d.skip_value()!
+		if !d.more_in_list()! {
+			return
+		}
+	}
+}
+
+// is_atom_char reports whether `ch` may appear in an atom. The exclusions are
+// the `atom-specials` of the grammar: the list and literal punctuation, the
+// space, the control characters, the two wildcards, the two quoting
+// characters, and the bracket that closes a response code.
+fn is_atom_char(ch u8) bool {
+	if ch <= 0x1f || ch == 0x7f {
+		return false
+	}
+	return match ch {
+		`(`, `)`, `{`, ` `, `%`, `*`, `"`, `\\`, `]` { false }
+		else { true }
+	}
+}

--- a/vlib/net/imap/wire.v
+++ b/vlib/net/imap/wire.v
@@ -344,8 +344,12 @@ fn (mut d Decoder) text() !string {
 // payloads behind to be mistaken for the next response. A literal marker ends
 // its physical line; the response continues after exactly the announced
 // number of octets.
-fn (mut d Decoder) skip_response_text() ! {
-	mut context := ResponseTextContext{}
+fn (mut d Decoder) skip_response_text(response_name string) ! {
+	mut context := ResponseTextContext{
+		// RFC 4314 responses contain several top-level astring values, so a
+		// literal can validly follow an atom without an enclosing list.
+		allow_top_level_literals: response_name in ['ACL', 'LISTRIGHTS', 'MYRIGHTS']
+	}
 	for {
 		line := d.text()!
 		has_literal, size := literal_suffix_size(line, mut context)!
@@ -362,11 +366,12 @@ fn (mut d Decoder) skip_response_text() ! {
 
 struct ResponseTextContext {
 mut:
-	depth               int
-	quoted              bool
-	escaped             bool
-	has_top_level_value bool
-	saw_literal         bool
+	depth                    int
+	quoted                   bool
+	escaped                  bool
+	has_top_level_value      bool
+	saw_literal              bool
+	allow_top_level_literals bool
 }
 
 fn literal_suffix_size(line string, mut context ResponseTextContext) !(bool, u32) {
@@ -381,7 +386,7 @@ fn literal_suffix_size(line string, mut context ResponseTextContext) !(bool, u32
 	// A top-level suffix after ordinary text is ambiguous with prose. Inside a
 	// list, or after a literal has already established a structured response,
 	// the grammar gives the next marker an unambiguous token context.
-	if context.quoted || (context.depth == 0 && context.has_top_level_value && !context.saw_literal) {
+	if context.quoted || (context.depth == 0 && context.has_top_level_value && !context.saw_literal && !context.allow_top_level_literals) {
 		return false, 0
 	}
 	mut digits_end := line.len - 1

--- a/vlib/net/imap/wire.v
+++ b/vlib/net/imap/wire.v
@@ -462,6 +462,10 @@ fn (mut d Decoder) skip_value() ! {
 		d.string_value()!
 		return
 	}
+	if ch == `\\` {
+		d.flag()!
+		return
+	}
 	if ch != `(` {
 		d.atom()!
 		return

--- a/vlib/net/imap/wire.v
+++ b/vlib/net/imap/wire.v
@@ -366,6 +366,7 @@ mut:
 	quoted              bool
 	escaped             bool
 	has_top_level_value bool
+	saw_literal         bool
 }
 
 fn literal_suffix_size(line string, mut context ResponseTextContext) !(bool, u32) {
@@ -377,10 +378,10 @@ fn literal_suffix_size(line string, mut context ResponseTextContext) !(bool, u32
 		return false, 0
 	}
 	context.scan(line[..brace])
-	// A top-level response-text suffix is ambiguous with ordinary prose. A
-	// literal after other fields is accepted only while a parenthesised value
-	// is still open, where the grammar gives it an unambiguous token context.
-	if context.quoted || (context.depth == 0 && context.has_top_level_value) {
+	// A top-level suffix after ordinary text is ambiguous with prose. Inside a
+	// list, or after a literal has already established a structured response,
+	// the grammar gives the next marker an unambiguous token context.
+	if context.quoted || (context.depth == 0 && context.has_top_level_value && !context.saw_literal) {
 		return false, 0
 	}
 	mut digits_end := line.len - 1
@@ -404,6 +405,7 @@ fn literal_suffix_size(line string, mut context ResponseTextContext) !(bool, u32
 	if context.depth == 0 {
 		context.has_top_level_value = true
 	}
+	context.saw_literal = true
 	return true, u32(size)
 }
 

--- a/vlib/net/imap/wire.v
+++ b/vlib/net/imap/wire.v
@@ -345,68 +345,30 @@ fn (mut d Decoder) text() !string {
 // its physical line; the response continues after exactly the announced
 // number of octets.
 fn (mut d Decoder) skip_response_text() ! {
+	mut context := ResponseTextContext{}
 	for {
 		line := d.text()!
-		has_literal, size := literal_suffix_size(line)!
+		has_literal, size := literal_suffix_size(line, mut context)!
 		if !has_literal {
 			return
 		}
 		if size > max_literal_size {
 			return error('imap: the server announced a ${size} octet literal, over the ${max_literal_size} limit')
 		}
-		if !d.literal_payload_has_token_delimiter(size)! {
-			return
-		}
 		d.crlf()!
 		d.read_n(int(size))!
 	}
 }
 
-// literal_payload_has_token_delimiter checks the byte after a possible
-// literal payload without consuming it. A literal is a string token, so the
-// next byte must end that token; otherwise a free-form `{n}` suffix would eat
-// bytes from the following response.
-fn (mut d Decoder) literal_payload_has_token_delimiter(size u32) !bool {
-	d.ensure_buffered(1)!
-	mut line_ending_len := 1
-	if d.buf[d.pos] == `\r` {
-		d.ensure_buffered(2)!
-		if d.buf[d.pos + 1] != `\n` {
-			return error('imap: expected LF after CR')
-		}
-		line_ending_len = 2
-	} else if d.buf[d.pos] != `\n` {
-		return error('imap: expected the end of the line')
-	}
-	required := line_ending_len + int(size) + 1
-	d.ensure_buffered(required)!
-	next := d.buf[d.pos + line_ending_len + int(size)]
-	return next == ` ` || next == `)` || next == `\r` || next == `\n`
+struct ResponseTextContext {
+mut:
+	depth               int
+	quoted              bool
+	escaped             bool
+	has_top_level_value bool
 }
 
-// ensure_buffered makes `n` bytes available from the current position while
-// preserving them for the ordinary decoder methods.
-fn (mut d Decoder) ensure_buffered(n int) ! {
-	if d.filled - d.pos >= n {
-		return
-	}
-	mut buffered := d.buf[d.pos..d.filled].clone()
-	mut r := d.reader or { return error('imap: the response ended early') }
-	for buffered.len < n {
-		need := n - buffered.len
-		mut chunk := []u8{len: if need < decoder_chunk { need } else { decoder_chunk }}
-		nread := r.read(mut chunk)!
-		if nread <= 0 {
-			return error('imap: the connection closed in the middle of a response')
-		}
-		buffered << chunk[..nread]
-	}
-	d.buf = buffered
-	d.pos = 0
-	d.filled = buffered.len
-}
-
-fn literal_suffix_size(line string) !(bool, u32) {
+fn literal_suffix_size(line string, mut context ResponseTextContext) !(bool, u32) {
 	if !line.ends_with('}') {
 		return false, 0
 	}
@@ -414,9 +376,11 @@ fn literal_suffix_size(line string) !(bool, u32) {
 	if brace < 0 {
 		return false, 0
 	}
-	// Without an extension grammar, only a standalone string token is
-	// unambiguous. Text before the marker makes `{n}` part of free-form text.
-	if line[..brace].trim_space() != '' {
+	context.scan(line[..brace])
+	// A top-level response-text suffix is ambiguous with ordinary prose. A
+	// literal after other fields is accepted only while a parenthesised value
+	// is still open, where the grammar gives it an unambiguous token context.
+	if context.quoted || (context.depth == 0 && context.has_top_level_value) {
 		return false, 0
 	}
 	mut digits_end := line.len - 1
@@ -437,7 +401,50 @@ fn literal_suffix_size(line string) !(bool, u32) {
 			return error('imap: a literal size in an extension response overflows 32 bits')
 		}
 	}
+	if context.depth == 0 {
+		context.has_top_level_value = true
+	}
 	return true, u32(size)
+}
+
+fn (mut context ResponseTextContext) scan(prefix string) {
+	for ch in prefix.bytes() {
+		if context.quoted {
+			if context.escaped {
+				context.escaped = false
+			} else if ch == `\\` {
+				context.escaped = true
+			} else if ch == `"` {
+				context.quoted = false
+			}
+			continue
+		}
+		match ch {
+			`"` {
+				context.quoted = true
+				if context.depth == 0 {
+					context.has_top_level_value = true
+				}
+			}
+			`(` {
+				if context.depth == 0 {
+					context.has_top_level_value = true
+				}
+				context.depth++
+			}
+			`)` {
+				if context.depth > 0 {
+					context.depth--
+				}
+			}
+			` `, `\t` {}
+			else {
+				if context.depth == 0 {
+					context.has_top_level_value = true
+				}
+			}
+		}
+	}
 }
 
 // accept_nil consumes the atom NIL where a parenthesised value could stand,

--- a/vlib/net/imap/wire.v
+++ b/vlib/net/imap/wire.v
@@ -354,9 +354,56 @@ fn (mut d Decoder) skip_response_text() ! {
 		if size > max_literal_size {
 			return error('imap: the server announced a ${size} octet literal, over the ${max_literal_size} limit')
 		}
+		if !d.literal_payload_has_token_delimiter(size)! {
+			return
+		}
 		d.crlf()!
 		d.read_n(int(size))!
 	}
+}
+
+// literal_payload_has_token_delimiter checks the byte after a possible
+// literal payload without consuming it. A literal is a string token, so the
+// next byte must end that token; otherwise a free-form `{n}` suffix would eat
+// bytes from the following response.
+fn (mut d Decoder) literal_payload_has_token_delimiter(size u32) !bool {
+	d.ensure_buffered(1)!
+	mut line_ending_len := 1
+	if d.buf[d.pos] == `\r` {
+		d.ensure_buffered(2)!
+		if d.buf[d.pos + 1] != `\n` {
+			return error('imap: expected LF after CR')
+		}
+		line_ending_len = 2
+	} else if d.buf[d.pos] != `\n` {
+		return error('imap: expected the end of the line')
+	}
+	required := line_ending_len + int(size) + 1
+	d.ensure_buffered(required)!
+	next := d.buf[d.pos + line_ending_len + int(size)]
+	return next == ` ` || next == `)` || next == `\r` || next == `\n`
+}
+
+// ensure_buffered makes `n` bytes available from the current position while
+// preserving them for the ordinary decoder methods.
+fn (mut d Decoder) ensure_buffered(n int) ! {
+	if d.filled - d.pos >= n {
+		return
+	}
+	mut buffered := d.buf[d.pos..d.filled].clone()
+	mut r := d.reader or { return error('imap: the response ended early') }
+	for buffered.len < n {
+		need := n - buffered.len
+		mut chunk := []u8{len: if need < decoder_chunk { need } else { decoder_chunk }}
+		nread := r.read(mut chunk)!
+		if nread <= 0 {
+			return error('imap: the connection closed in the middle of a response')
+		}
+		buffered << chunk[..nread]
+	}
+	d.buf = buffered
+	d.pos = 0
+	d.filled = buffered.len
 }
 
 fn literal_suffix_size(line string) !(bool, u32) {
@@ -365,6 +412,11 @@ fn literal_suffix_size(line string) !(bool, u32) {
 	}
 	brace := line.last_index_u8(`{`)
 	if brace < 0 {
+		return false, 0
+	}
+	// Without an extension grammar, only a standalone string token is
+	// unambiguous. Text before the marker makes `{n}` part of free-form text.
+	if line[..brace].trim_space() != '' {
 		return false, 0
 	}
 	mut digits_end := line.len - 1

--- a/vlib/net/imap/wire.v
+++ b/vlib/net/imap/wire.v
@@ -287,6 +287,10 @@ fn (mut d Decoder) string_value() !string {
 	if ch == `"` {
 		return d.quoted()
 	}
+	if ch == `~` {
+		d.expect(`~`)!
+		return d.literal()
+	}
 	if ch == `{` {
 		return d.literal()
 	}
@@ -454,7 +458,7 @@ fn (mut d Decoder) flag() !string {
 // does not model cannot derail the rest of the response.
 fn (mut d Decoder) skip_value() ! {
 	ch := d.peek_byte()!
-	if ch == `"` || ch == `{` {
+	if ch == `"` || ch == `{` || ch == `~` {
 		d.string_value()!
 		return
 	}

--- a/vlib/net/imap/wire.v
+++ b/vlib/net/imap/wire.v
@@ -336,6 +336,54 @@ fn (mut d Decoder) text() !string {
 	return out.bytestr()
 }
 
+// skip_response_text consumes an unmodelled response without leaving literal
+// payloads behind to be mistaken for the next response. A literal marker ends
+// its physical line; the response continues after exactly the announced
+// number of octets.
+fn (mut d Decoder) skip_response_text() ! {
+	for {
+		line := d.text()!
+		has_literal, size := literal_suffix_size(line)!
+		if !has_literal {
+			return
+		}
+		if size > max_literal_size {
+			return error('imap: the server announced a ${size} octet literal, over the ${max_literal_size} limit')
+		}
+		d.crlf()!
+		d.read_n(int(size))!
+	}
+}
+
+fn literal_suffix_size(line string) !(bool, u32) {
+	if !line.ends_with('}') {
+		return false, 0
+	}
+	brace := line.last_index_u8(`{`)
+	if brace < 0 {
+		return false, 0
+	}
+	mut digits_end := line.len - 1
+	if digits_end > brace + 1 && line[digits_end - 1] == `+` {
+		digits_end--
+	}
+	if digits_end == brace + 1 {
+		return false, 0
+	}
+	mut size := u64(0)
+	for i in brace + 1 .. digits_end {
+		ch := line[i]
+		if ch < `0` || ch > `9` {
+			return false, 0
+		}
+		size = size * 10 + u64(ch - `0`)
+		if size > 0xffffffff {
+			return error('imap: a literal size in an extension response overflows 32 bits')
+		}
+	}
+	return true, u32(size)
+}
+
 // accept_nil consumes the atom NIL where a parenthesised value could stand,
 // and reports whether it did. NIL is how a server says a header the message
 // never carried, or a content type with no parameters.

--- a/vlib/net/mbedtls/ssl_connection.c.v
+++ b/vlib/net/mbedtls/ssl_connection.c.v
@@ -736,6 +736,27 @@ pub fn (mut s SSLConn) connect(mut tcp_conn net.TcpConn, hostname string) ! {
 	if s.opened {
 		return error('net.mbedtls SSLConn.connect, ssl connection was already open')
 	}
+	mut connected := false
+	defer {
+		if !connected {
+			if unsafe { s.certs != nil } {
+				C.mbedtls_x509_crt_free(&s.certs.cacert)
+				C.mbedtls_x509_crt_free(&s.certs.client_cert)
+				C.mbedtls_pk_free(&s.certs.client_key)
+				s.certs = unsafe { nil }
+			}
+			C.mbedtls_ssl_free(&s.ssl)
+			C.mbedtls_ssl_config_free(&s.conf)
+			free_rng(mut s.ctr_drbg, mut s.entropy)
+			if s.alpn_list != unsafe { nil } {
+				unsafe {
+					C.free(s.alpn_list)
+					s.alpn_list = nil
+				}
+			}
+			s.handle = 0
+		}
+	}
 	s.handle = tcp_conn.sock.handle
 	s.set_read_timeout(tcp_conn.read_timeout())
 	mut ret := C.mbedtls_ssl_set_hostname(&s.ssl, &char(hostname.str))
@@ -760,6 +781,7 @@ pub fn (mut s SSLConn) connect(mut tcp_conn net.TcpConn, hostname string) ! {
 			ret)
 	}
 	s.opened = true
+	connected = true
 }
 
 // dial opens an ssl connection on hostname:port

--- a/vlib/net/openssl/openssl.c.v
+++ b/vlib/net/openssl/openssl.c.v
@@ -125,6 +125,8 @@ fn C.v_net_openssl_get1_peer_certificate(ssl &C.SSL) &C.X509
 
 fn C.X509_free(const_cert &C.X509)
 
+fn C.X509_check_host(const_cert &C.X509, const_name &char, name_len usize, flags u32, peer_name &&char) int
+
 fn C.ERR_clear_error()
 
 fn C.ERR_get_error() u64

--- a/vlib/net/openssl/openssl.c.v
+++ b/vlib/net/openssl/openssl.c.v
@@ -44,6 +44,7 @@ $if $pkgconfig('openssl') {
 #include <openssl/rand.h> # Please install OpenSSL development headers
 #include <openssl/ssl.h>
 #include <openssl/err.h>
+#include <openssl/x509v3.h>
 #insert "@VEXEROOT/vlib/net/openssl/openssl_compat.h"
 
 @[typedef]
@@ -126,6 +127,8 @@ fn C.SSL_do_handshake(&C.SSL) i32
 fn C.SSL_set_cipher_list(ctx &C.SSL, str &char) i32
 
 fn C.v_net_openssl_get1_peer_certificate(ssl &C.SSL) &C.X509
+
+fn C.v_net_openssl_has_x509_identity_checks() int
 
 fn C.X509_free(const_cert &C.X509)
 

--- a/vlib/net/openssl/openssl.c.v
+++ b/vlib/net/openssl/openssl.c.v
@@ -127,6 +127,8 @@ fn C.X509_free(const_cert &C.X509)
 
 fn C.X509_check_host(const_cert &C.X509, const_name &char, name_len usize, flags u32, peer_name &&char) int
 
+fn C.X509_check_ip_asc(const_cert &C.X509, const_ip_asc &char, flags u32) int
+
 fn C.ERR_clear_error()
 
 fn C.ERR_get_error() u64

--- a/vlib/net/openssl/openssl.c.v
+++ b/vlib/net/openssl/openssl.c.v
@@ -105,6 +105,8 @@ fn C.SSL_CTX_set_verify_depth(s &C.SSL_CTX, depth i32)
 
 fn C.SSL_CTX_set_verify(ctx &C.SSL_CTX, mode int, verify_callback voidptr)
 
+fn C.SSL_CTX_set_default_verify_paths(ctx &C.SSL_CTX) int
+
 fn C.SSL_CTX_load_verify_locations(ctx &C.SSL_CTX, const_file &char, const_ca_path &char) i32
 
 fn C.SSL_CTX_free(ctx &C.SSL_CTX)

--- a/vlib/net/openssl/openssl.c.v
+++ b/vlib/net/openssl/openssl.c.v
@@ -125,9 +125,9 @@ fn C.v_net_openssl_get1_peer_certificate(ssl &C.SSL) &C.X509
 
 fn C.X509_free(const_cert &C.X509)
 
-fn C.X509_check_host(const_cert &C.X509, const_name &char, name_len usize, flags u32, peer_name &&char) int
+fn C.v_net_openssl_x509_check_host(const_cert &C.X509, const_name &char, name_len usize, flags u32, peer_name &&char) int
 
-fn C.X509_check_ip_asc(const_cert &C.X509, const_ip_asc &char, flags u32) int
+fn C.v_net_openssl_x509_check_ip_asc(const_cert &C.X509, const_ip_asc &char, flags u32) int
 
 fn C.ERR_clear_error()
 

--- a/vlib/net/openssl/openssl.c.v
+++ b/vlib/net/openssl/openssl.c.v
@@ -103,6 +103,8 @@ fn C.SSL_CTX_set_options(ctx &C.SSL_CTX, options i32)
 
 fn C.SSL_CTX_set_verify_depth(s &C.SSL_CTX, depth i32)
 
+fn C.SSL_CTX_set_verify(ctx &C.SSL_CTX, mode int, verify_callback voidptr)
+
 fn C.SSL_CTX_load_verify_locations(ctx &C.SSL_CTX, const_file &char, const_ca_path &char) i32
 
 fn C.SSL_CTX_free(ctx &C.SSL_CTX)

--- a/vlib/net/openssl/openssl_compat.h
+++ b/vlib/net/openssl/openssl_compat.h
@@ -24,9 +24,12 @@ static X509 *v_net_openssl_get1_peer_certificate(SSL *ssl) {
 #endif
 
 // X509_check_host and X509_check_ip_asc were added in OpenSSL 1.0.2. Keep
-// older supported builds linkable and fail certificate identity checks closed
-// when those APIs are unavailable.
+// older builds linkable and report that identity validation is unavailable so
+// callers can reject validated connections before starting a handshake.
 #if !defined(OPENSSL_VERSION_NUMBER) || OPENSSL_VERSION_NUMBER < 0x10002000L
+static int v_net_openssl_has_x509_identity_checks(void) {
+	return 0;
+}
 static int v_net_openssl_x509_check_host(X509 *cert, const char *name, size_t name_len, unsigned int flags, char **peer_name) {
 	(void)cert;
 	(void)name;
@@ -42,6 +45,9 @@ static int v_net_openssl_x509_check_ip_asc(X509 *cert, const char *ip_asc, unsig
 	return 0;
 }
 #else
+static int v_net_openssl_has_x509_identity_checks(void) {
+	return 1;
+}
 static int v_net_openssl_x509_check_host(X509 *cert, const char *name, size_t name_len, unsigned int flags, char **peer_name) {
 	return X509_check_host(cert, name, name_len, flags, peer_name);
 }

--- a/vlib/net/openssl/openssl_compat.h
+++ b/vlib/net/openssl/openssl_compat.h
@@ -23,6 +23,33 @@ static X509 *v_net_openssl_get1_peer_certificate(SSL *ssl) {
 }
 #endif
 
+// X509_check_host and X509_check_ip_asc were added in OpenSSL 1.0.2. Keep
+// older supported builds linkable and fail certificate identity checks closed
+// when those APIs are unavailable.
+#if !defined(OPENSSL_VERSION_NUMBER) || OPENSSL_VERSION_NUMBER < 0x10002000L
+static int v_net_openssl_x509_check_host(X509 *cert, const char *name, size_t name_len, unsigned int flags, char **peer_name) {
+	(void)cert;
+	(void)name;
+	(void)name_len;
+	(void)flags;
+	(void)peer_name;
+	return 0;
+}
+static int v_net_openssl_x509_check_ip_asc(X509 *cert, const char *ip_asc, unsigned int flags) {
+	(void)cert;
+	(void)ip_asc;
+	(void)flags;
+	return 0;
+}
+#else
+static int v_net_openssl_x509_check_host(X509 *cert, const char *name, size_t name_len, unsigned int flags, char **peer_name) {
+	return X509_check_host(cert, name, name_len, flags, peer_name);
+}
+static int v_net_openssl_x509_check_ip_asc(X509 *cert, const char *ip_asc, unsigned int flags) {
+	return X509_check_ip_asc(cert, ip_asc, flags);
+}
+#endif
+
 // ALPN (SSL_set_alpn_protos / SSL_get0_alpn_selected) is only available in
 // OpenSSL 1.0.2 and later. On older OpenSSL-compatible headers, fall back to
 // no-op shims so the module still links; ALPN is simply unavailable there.

--- a/vlib/net/openssl/ssl_connection.c.v
+++ b/vlib/net/openssl/ssl_connection.c.v
@@ -258,6 +258,23 @@ pub fn (mut s SSLConn) connect(mut tcp_conn net.TcpConn, hostname string) ! {
 	s.complete_connect()!
 }
 
+// verify_hostname checks that the peer certificate is valid for hostname.
+pub fn (s &SSLConn) verify_hostname(hostname string) ! {
+	if !s.config.validate {
+		return
+	}
+	cert := C.v_net_openssl_get1_peer_certificate(s.ssl)
+	if cert == unsafe { nil } {
+		return error('net.openssl SSLConn.verify_hostname, the peer sent no certificate')
+	}
+	defer {
+		C.X509_free(cert)
+	}
+	if C.X509_check_host(cert, &char(hostname.str), usize(hostname.len), 0, unsafe { nil }) != 1 {
+		return error('net.openssl SSLConn.verify_hostname, the certificate is not valid for `${hostname}`')
+	}
+}
+
 // dial opens an ssl connection on hostname:port
 pub fn (mut s SSLConn) dial(hostname string, port int) ! {
 	$if trace_ssl ? {

--- a/vlib/net/openssl/ssl_connection.c.v
+++ b/vlib/net/openssl/ssl_connection.c.v
@@ -163,6 +163,7 @@ fn (mut s SSLConn) init() ! {
 	}
 
 	if s.config.validate {
+		C.SSL_CTX_set_verify(s.sslctx, C.SSL_VERIFY_PEER, unsafe { nil })
 		C.SSL_CTX_set_verify_depth(s.sslctx, 4)
 		C.SSL_CTX_set_options(s.sslctx, C.SSL_OP_NO_COMPRESSION)
 	}

--- a/vlib/net/openssl/ssl_connection.c.v
+++ b/vlib/net/openssl/ssl_connection.c.v
@@ -218,6 +218,11 @@ fn (mut s SSLConn) init() ! {
 			if s.config.validate && res != 1 {
 				return error('net.openssl SSLConn.init, SSL_CTX_load_verify_locations failed')
 			}
+		} else {
+			res = C.SSL_CTX_set_default_verify_paths(s.sslctx)
+			if res != 1 {
+				return error('net.openssl SSLConn.init, SSL_CTX_set_default_verify_paths failed')
+			}
 		}
 		if s.config.cert != '' {
 			res = C.SSL_CTX_use_certificate_file(voidptr(s.sslctx), &char(cert.str),

--- a/vlib/net/openssl/ssl_connection.c.v
+++ b/vlib/net/openssl/ssl_connection.c.v
@@ -246,6 +246,20 @@ pub fn (mut s SSLConn) connect(mut tcp_conn net.TcpConn, hostname string) ! {
 	$if trace_ssl ? {
 		eprintln('${@METHOD} hostname: ${hostname}')
 	}
+	mut connected := false
+	defer {
+		if !connected {
+			if s.ssl != 0 {
+				unsafe { C.SSL_free(voidptr(s.ssl)) }
+				s.ssl = unsafe { nil }
+			}
+			if s.sslctx != 0 {
+				C.SSL_CTX_free(s.sslctx)
+				s.sslctx = unsafe { nil }
+			}
+			s.handle = 0
+		}
+	}
 	s.handle = tcp_conn.sock.handle
 	s.duration = tcp_conn.read_timeout()
 	mut res := C.SSL_set_tlsext_host_name(voidptr(s.ssl), voidptr(hostname.str))
@@ -256,10 +270,11 @@ pub fn (mut s SSLConn) connect(mut tcp_conn net.TcpConn, hostname string) ! {
 		return error('net.openssl SSLConn.connect, could not assign ssl to socket.')
 	}
 	s.complete_connect()!
+	s.verify_hostname(hostname)!
+	connected = true
 }
 
-// verify_hostname checks that the peer certificate is valid for hostname.
-pub fn (s &SSLConn) verify_hostname(hostname string) ! {
+fn (s &SSLConn) verify_hostname(hostname string) ! {
 	if !s.config.validate {
 		return
 	}
@@ -270,7 +285,13 @@ pub fn (s &SSLConn) verify_hostname(hostname string) ! {
 	defer {
 		C.X509_free(cert)
 	}
-	if C.X509_check_host(cert, &char(hostname.str), usize(hostname.len), 0, unsafe { nil }) != 1 {
+	ip_result := C.X509_check_ip_asc(cert, &char(hostname.str), 0)
+	verified := if ip_result == -2 {
+		C.X509_check_host(cert, &char(hostname.str), usize(hostname.len), 0, unsafe { nil }) == 1
+	} else {
+		ip_result == 1
+	}
+	if !verified {
 		return error('net.openssl SSLConn.verify_hostname, the certificate is not valid for `${hostname}`')
 	}
 }

--- a/vlib/net/openssl/ssl_connection.c.v
+++ b/vlib/net/openssl/ssl_connection.c.v
@@ -285,9 +285,10 @@ fn (s &SSLConn) verify_hostname(hostname string) ! {
 	defer {
 		C.X509_free(cert)
 	}
-	ip_result := C.X509_check_ip_asc(cert, &char(hostname.str), 0)
+	ip_result := C.v_net_openssl_x509_check_ip_asc(cert, &char(hostname.str), 0)
 	verified := if ip_result == -2 {
-		C.X509_check_host(cert, &char(hostname.str), usize(hostname.len), 0, unsafe { nil }) == 1
+		C.v_net_openssl_x509_check_host(cert, &char(hostname.str), usize(hostname.len), 0,
+			unsafe { nil }) == 1
 	} else {
 		ip_result == 1
 	}

--- a/vlib/net/openssl/ssl_connection.c.v
+++ b/vlib/net/openssl/ssl_connection.c.v
@@ -157,6 +157,9 @@ fn (mut s SSLConn) init() ! {
 	$if trace_ssl ? {
 		eprintln(@METHOD)
 	}
+	if s.config.validate && C.v_net_openssl_has_x509_identity_checks() != 1 {
+		return error('net.openssl SSLConn.init, certificate identity validation requires OpenSSL 1.0.2 or newer')
+	}
 	s.sslctx = unsafe { C.SSL_CTX_new(C.SSLv23_client_method()) }
 	if s.sslctx == 0 {
 		return error('net.openssl Could not get ssl context')


### PR DESCRIPTION
`net.smtp` sends mail but nothing in vlib reads it, so a V program that wants to look at a mailbox has to shell out or reimplement IMAP. This adds `net.imap`, a client for IMAP4rev1 (RFC 3501).

I checked vpm and awesome-v first: there is no IMAP module in either.

```v
mut c := imap.new_client(
    server:   'imap.example.com'
    username: 'someone@example.com'
    password: 'hunter2'
    ssl:      true
)!
defer { c.close() or {} }

inbox := c.select_mailbox('INBOX')!
println('${inbox.exists} messages, ${inbox.recent} recent')

unread := c.search('UNSEEN')!
for msg in c.fetch(unread, '(UID ENVELOPE)')! {
    if envelope := msg.envelope {
        println('${envelope.from[0].addr()}: ${envelope.subject}')
    }
}
```

### Responses are tokenised, not searched

The module reads the grammar of RFC 3501 section 9 rather than looking for keywords in a response line. That is not tidiness, it is correctness: a message whose subject is `UID 999` answers a search for `UID ` exactly as well as the real field does, and a body containing `)` ends a response that a bracket-counting parser would still be reading.

`wire.v` is a decoder over the four shapes the protocol is built from: atoms, quoted strings, literals and parenthesised lists. It reads the connection directly with one octet of lookahead, so a literal is taken by count and its content is never offered back to the parser. An item this module does not model is stepped over whole by `skip_value`, so a server extension cannot desynchronise the rest of the response.

Two grammar details worth naming, because both are easy to get wrong and both are covered by tests:

- `env-cc = "(" 1*address ")"`. The addresses in an envelope are concatenated with nothing between them, not separated by spaces like every other list in the protocol.
- `[` is a valid `ATOM-CHAR`; only `]` is excluded. Reading a fetch item name with a plain atom reader therefore swallows the opening bracket of `BODY[]` and leaves the rest unreadable.

### Mailbox names

Names are ordinary UTF-8 in the API and travel as the modified UTF-7 of section 5.1.3, encoded on the way out and decoded on the way in. Without it, `list_mailboxes` hands back `&AMk-l&AOk-ments` where the user's mailbox is called `Éléments`. The encoding is checked against the two examples printed in the RFC and cross-checked against an independent implementation.

### Sequence sets

`SeqSet` keeps message numbers as merged ranges, so a search matching fifty thousand messages is sent as `FETCH 1:50000 ...`. A comma separated list of every number would be a command line no server is obliged to accept.

### What is implemented

CAPABILITY, NOOP, LOGOUT, STARTTLS, AUTHENTICATE PLAIN, LOGIN, SELECT, EXAMINE, CREATE, DELETE, RENAME, SUBSCRIBE, UNSUBSCRIBE, LIST, LSUB, STATUS, APPEND, CHECK, CLOSE, UNSELECT, EXPUNGE, SEARCH, FETCH, STORE, COPY, MOVE, and the UID forms of the last five.

FETCH parses UID, FLAGS, RFC822.SIZE, INTERNALDATE, ENVELOPE, BODYSTRUCTURE and any number of `BODY[...]` sections, keyed by the specification the server echoed back.

Some things that took deliberate handling:

- An argument a quoted string cannot hold, an eight bit password or a message body, is sent as a literal: the introducer goes out, the client waits for the `+` continuation, then the octets follow. Section 2.2.1 says the server may send untagged data or reject the command instead of continuing, so the wait handles both rather than assuming the next line is the `+`.
- A mailbox changes under a client at any moment, and the server says so by slipping EXISTS, EXPUNGE and FETCH responses into whatever command happens to be in flight. Those are collected rather than discarded, and `Client.exists` and `Client.recent` follow them.
- A completion carrying a tag other than the outstanding one is an error. It means the client and the server disagree about which command is running, and nothing later recovers from that.
- A literal announces its own length, so a server can ask a client to allocate as much memory as it likes. There is a cap, checked before the allocation.
- An untagged BYE closes the session, and a greeting that turns the connection away closes the socket rather than leaving the server to time it out.

`ESEARCH` (RFC 4731) and `MOVE` (RFC 6851) are supported; `supports()` is there to guard the optional ones.

### Tests

Four files, 513 assertions, no external server needed.

- `utf7_test.v` covers the RFC's own examples, a round trip over Japanese, Russian, Chinese, French and an emoji, the astral plane surrogate pair, and six malformed inputs that must be refused.
- `seqset_test.v` covers merging, ordering, `*`, parsing and the fifty thousand message case.
- `response_test.v` runs the response reader over transcripts taken from the RFC, including its envelope and body structure examples, plus the two traps above: a body and an envelope subject that both read like protocol.
- `imap_test.v` drives the client over a real socket against a scripted server, checking the exact bytes each command puts on the wire, the literal handshake for APPEND and for an eight bit password, and that an unsolicited EXISTS reaches the client.

`v fmt -verify` and `v vet -W` are clean on all nine files, and none of them show up in `v test-cleancode`.
