### PR TITLE
v3: keep FastC ownership-safe and restore self-hosting

### DIFF
--- a/vlib/v3/gen/fastc/array.v
+++ b/vlib/v3/gen/fastc/array.v
@@ -156,7 +156,7 @@ fn (g &Parser) render_array_access_expression(tokens []FastcExpressionToken) ?Fa
 	element_type := if is_array_pointer {
 		g.array_element_type(base_type) or { return none }
 	} else if base_type.ends_with('*') {
-		base_type.trim_right('*')
+		base_type[..base_type.len - 1]
 	} else if base_layout_type == 'string' {
 		'u8'
 	} else {

--- a/vlib/v3/gen/fastc/decl.v
+++ b/vlib/v3/gen/fastc/decl.v
@@ -1048,6 +1048,7 @@ fn fastc_generate_type_declarations(sources []FastcSourceFile, prefs &pref.Prefe
 	mut enum_infos := []FastcEnumInfo{}
 	mut alias_base_types := map[string]string{}
 	mut sum_types := map[string]bool{}
+	mut sum_type_variants := map[string]bool{}
 	mut keys := declared_kinds.keys()
 	keys.sort()
 	for type_id, key in keys {
@@ -1075,7 +1076,8 @@ fn fastc_generate_type_declarations(sources []FastcSourceFile, prefs &pref.Prefe
 		}
 		fastc_emit_source_type_declarations(source_file, prefs, declared_types, declared_kinds,
 			constants, public_constants, mut struct_fields, mut struct_field_info, mut
-			composite_types, mut alias_base_types, mut sum_types, mut enum_infos, mut bodies)!
+			composite_types, mut alias_base_types, mut sum_types, mut sum_type_variants, mut
+			enum_infos, mut bodies)!
 	}
 	mut composite_names := composite_types.keys()
 	composite_names.sort()
@@ -1117,6 +1119,7 @@ fn fastc_generate_type_declarations(sources []FastcSourceFile, prefs &pref.Prefe
 		alias_base_types:    alias_base_types
 		enum_field_types:    enum_field_types
 		sum_types:           sum_types
+		sum_type_variants:   sum_type_variants
 	}
 }
 
@@ -1274,7 +1277,7 @@ fn fastc_c_composite_definition_end(source string, start int) ?int {
 	return none
 }
 
-fn fastc_emit_source_type_declarations(source_file FastcSourceFile, prefs &pref.Preferences, declared_types map[string]bool, declared_kinds map[string]FastcDeclaredTypeKind, constants map[string]string, public_constants map[string]bool, mut struct_fields map[string]map[string]string, mut struct_field_info map[string][]FastcStructField, mut composite_types map[string]bool, mut alias_base_types map[string]string, mut sum_types map[string]bool, mut enum_infos []FastcEnumInfo, mut out strings.Builder) ! {
+fn fastc_emit_source_type_declarations(source_file FastcSourceFile, prefs &pref.Preferences, declared_types map[string]bool, declared_kinds map[string]FastcDeclaredTypeKind, constants map[string]string, public_constants map[string]bool, mut struct_fields map[string]map[string]string, mut struct_field_info map[string][]FastcStructField, mut composite_types map[string]bool, mut alias_base_types map[string]string, mut sum_types map[string]bool, mut sum_type_variants map[string]bool, mut enum_infos []FastcEnumInfo, mut out strings.Builder) ! {
 	mut file_set := token.FileSet.new()
 	mut file := file_set.add_file(source_file.path, source_file.source.len)
 	file.index_lines_without_digest(source_file.source)
@@ -1299,7 +1302,7 @@ fn fastc_emit_source_type_declarations(source_file FastcSourceFile, prefs &pref.
 					fastc_emit_source_type_declarations(selected_source, prefs, declared_types,
 						declared_kinds, constants, public_constants, mut struct_fields, mut
 						struct_field_info, mut composite_types, mut alias_base_types, mut
-						sum_types, mut enum_infos, mut out)!
+						sum_types, mut sum_type_variants, mut enum_infos, mut out)!
 				}
 				tok = selected.tok
 				next_enum_is_flag = false
@@ -1346,7 +1349,7 @@ fn fastc_emit_source_type_declarations(source_file FastcSourceFile, prefs &pref.
 		if depth == 0 && tok == .key_type {
 			tok = fastc_emit_alias_declaration(mut scan, source_file, declared_types,
 				declared_kinds, prefs.building_v, mut struct_fields, mut struct_field_info, mut
-				alias_base_types, mut sum_types, mut out)!
+				alias_base_types, mut sum_types, mut sum_type_variants, mut out)!
 			next_type_is_enabled = true
 			continue
 		}
@@ -2082,7 +2085,7 @@ fn fastc_emit_interface_declaration(mut scan scanner.Scanner, source_file FastcS
 	return tok
 }
 
-fn fastc_emit_alias_declaration(mut scan scanner.Scanner, source_file FastcSourceFile, declared_types map[string]bool, declared_kinds map[string]FastcDeclaredTypeKind, allow_short_placeholders bool, mut struct_fields map[string]map[string]string, mut struct_field_info map[string][]FastcStructField, mut alias_base_types map[string]string, mut sum_types map[string]bool, mut out strings.Builder) !token.Token {
+fn fastc_emit_alias_declaration(mut scan scanner.Scanner, source_file FastcSourceFile, declared_types map[string]bool, declared_kinds map[string]FastcDeclaredTypeKind, allow_short_placeholders bool, mut struct_fields map[string]map[string]string, mut struct_field_info map[string][]FastcStructField, mut alias_base_types map[string]string, mut sum_types map[string]bool, mut sum_type_variants map[string]bool, mut out strings.Builder) !token.Token {
 	mut tok := scan.scan()
 	if tok != .name {
 		return error('fastc parser does not support type alias in ${source_file.path}')
@@ -2127,13 +2130,20 @@ fn fastc_emit_alias_declaration(mut scan scanner.Scanner, source_file FastcSourc
 		tok = scan.scan()
 	}
 	if tok == .pipe {
-		for tok != .eof {
+		// Record each variant's C type (keyed `<sum type>|<variant>`) so an append can
+		// tell push-many (`[]T << []T`) from boxing an array-valued variant of a
+		// recursive sum type (`type Value = []Value | int`) as one element. `base` is
+		// the first variant, already scanned above; the rest follow each `|`.
+		sum_type_variants['${c_name}|${base.trim_right('*')}'] = true
+		for tok == .pipe {
 			tok = scan.scan()
+			variant, variant_next := fastc_scan_type(mut scan, tok, source_file.path,
+				source_file.header.module_name, source_file.header.imports, declared_types,
+				allow_short_placeholders) or { return error('fastc type `${name}`: ${err.msg()}') }
+			sum_type_variants['${c_name}|${variant.trim_right('*')}'] = true
+			tok = variant_next
 			if tok == .semicolon {
 				tok = scan.scan()
-				if tok != .pipe {
-					break
-				}
 			}
 		}
 		// A sum type is lowered to the same boxed representation as an interface, so

--- a/vlib/v3/gen/fastc/decl.v
+++ b/vlib/v3/gen/fastc/decl.v
@@ -1731,20 +1731,7 @@ fn fastc_resolve_declared_type_key(module_name string, raw_type string, imports 
 }
 
 fn (g &Parser) resolve_declared_type_key(raw_type string) ?string {
-	if cached := g.declared_type_key_memo[raw_type] {
-		return if cached == '' { none } else { cached }
-	}
-	mut resolved := ''
-	if type_key := fastc_resolve_declared_type_key(g.module_name, raw_type, g.imports,
-		g.declared_types) {
-		resolved = type_key
-	}
-	mut parser := unsafe { &Parser(g) }
-	if parser.declared_type_key_memo.len == 0 {
-		parser.declared_type_key_memo = map[string]string{}
-	}
-	parser.declared_type_key_memo[raw_type] = resolved
-	return if resolved == '' { none } else { resolved }
+	return fastc_resolve_declared_type_key(g.module_name, raw_type, g.imports, g.declared_types)
 }
 
 fn fastc_semantic_declared_type_key(c_type string, declared_type_c_names map[string]string) string {

--- a/vlib/v3/gen/fastc/expr.v
+++ b/vlib/v3/gen/fastc/expr.v
@@ -298,7 +298,7 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 				higher_order_method := lookahead.lit
 				if higher_order_method in ['map', 'filter', 'any', 'all', 'count'] && lookahead.scan() == .lpar {
 					receiver_start := fastc_method_receiver_start(expression_tokens, expression_tokens.len)
-					receiver_tokens := unsafe { expression_tokens[receiver_start..] }
+					receiver_tokens := expression_tokens[receiver_start..].clone()
 					receiver_type := g.infer_expression_type(receiver_tokens) or { '' }
 					// Array-literal receivers (`[.a, .b].map(...)`) do not round-trip
 					// through the receiver renderer yet; leave them to the normal path.
@@ -412,7 +412,7 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 				// `.sort()` (no argument) keeps its existing builtin lowering (the `!= .rpar`).
 				if higher_order_method == 'sort' && lookahead.scan() == .lpar && lookahead.scan() != .rpar {
 					receiver_start := fastc_method_receiver_start(expression_tokens, expression_tokens.len)
-					receiver_tokens := unsafe { expression_tokens[receiver_start..] }
+					receiver_tokens := expression_tokens[receiver_start..].clone()
 					receiver_type := g.infer_expression_type(receiver_tokens) or { '' }
 					if receiver_type.starts_with('Array_') {
 						element_type := g.array_element_type(receiver_type) or {
@@ -1563,9 +1563,11 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 			.comma,
 			.semicolon,
 		] && struct_types.len > 0 {
-			// The current program's field metadata is immutable while expressions render.
-			fields := unsafe { g.struct_fields[struct_types.last()] }
-			expected_struct_field_type = fields[g.lit] or { '' }
+			if fields := g.struct_fields[struct_types.last()] {
+				expected_struct_field_type = fields[g.lit] or { '' }
+			} else {
+				expected_struct_field_type = ''
+			}
 			piece = '.${piece}'
 		} else if g.selfhost && g.tok == .dot && fastc_token_is_prefix_operator(expression_tokens, expression_tokens.len - 1) {
 			mut contextual_type := if expected_struct_field_type != '' {

--- a/vlib/v3/gen/fastc/expr.v
+++ b/vlib/v3/gen/fastc/expr.v
@@ -2308,6 +2308,11 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 	}
 	if g.selfhost {
 		if tokens.len > 1 && tokens.last().tok == .not {
+			if map_expression := g.render_map_expression(tokens) {
+				// A propagated RHS in `values[key] = load()!` must remain part of
+				// the map assignment lowering, not become a raw C subexpression.
+				return map_expression
+			}
 			if assignment := g.render_assignment_expression(tokens) {
 				// Assignment supplies the target type to its RHS. In particular, an
 				// option-returning call propagated with `!` is unwrapped recursively and
@@ -2317,6 +2322,12 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 		}
 		if interface_cast := g.render_interface_cast_expression(tokens, rendered_expression) {
 			return interface_cast
+		}
+		// An append RHS may itself use result propagation (`items << load()!`). Lower
+		// the append first so nested propagation is applied to the RHS call rather than
+		// returning a raw C expression that still contains V's `<<` operator.
+		if append_expression := g.render_append_expression(tokens, rendered_expression) {
+			return append_expression
 		}
 		if nested_propagation := g.render_nested_option_propagation(tokens, rendered_expression) {
 			return nested_propagation
@@ -2413,9 +2424,6 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 				source: '({ Option ${temporary} = (${inner_source}); if (${temporary}.state) { ${failure} } ${value}; })'
 				typ: value_type
 			}
-		}
-		if append_expression := g.render_append_expression(tokens, rendered_expression) {
-			return append_expression
 		}
 		mut depth := 0
 		for i, item in tokens {

--- a/vlib/v3/gen/fastc/fastc.v
+++ b/vlib/v3/gen/fastc/fastc.v
@@ -772,6 +772,9 @@ struct FastcTypeDeclarations {
 	// `{void*_object; u32 _typ;}` layout with interfaces; construction boxes a
 	// variant and `match` dispatches on `_typ`.
 	sum_types map[string]bool
+	// Declared variants per sum type, keyed `"${sum_type_c_name}|${variant_c_name}"`
+	// (see Parser.sum_type_variants).
+	sum_type_variants map[string]bool
 }
 
 struct FastcLoopBlockResult {
@@ -808,6 +811,10 @@ struct Parser {
 	enum_field_types       map[string]string
 	alias_base_types       map[string]string
 	sum_types              map[string]bool
+	// Declared variants of each sum type, keyed `"${sum_type_c_name}|${variant_c_name}"`.
+	// Lets an append distinguish push-many (`[]T << []T`) from boxing an array-valued
+	// variant of a recursive sum type as one element (see sumtype_has_variant).
+	sum_type_variants      map[string]bool
 	struct_fields          map[string]map[string]string
 	struct_field_info      map[string][]FastcStructField
 	struct_field_lookup    map[string]map[string]FastcStructField
@@ -985,6 +992,7 @@ struct FastcFileGenContext {
 	enum_field_types       map[string]string
 	alias_base_types       map[string]string
 	sum_types              map[string]bool
+	sum_type_variants      map[string]bool
 	struct_fields          map[string]map[string]string
 	struct_field_info      map[string][]FastcStructField
 	struct_field_lookup    map[string]map[string]FastcStructField
@@ -1048,6 +1056,7 @@ fn fastc_generate_single_file(ctx &FastcFileGenContext, source_file FastcSourceF
 		enum_field_types: ctx.enum_field_types
 		alias_base_types: ctx.alias_base_types
 		sum_types: ctx.sum_types
+		sum_type_variants: ctx.sum_type_variants
 		struct_fields: ctx.struct_fields
 		struct_field_info: ctx.struct_field_info
 		struct_field_lookup: ctx.struct_field_lookup
@@ -1216,6 +1225,7 @@ fn generate_source_files(input_sources []FastcSourceFile, module_aliases map[str
 		enum_field_types: enum_field_types
 		alias_base_types: type_output.alias_base_types
 		sum_types: type_output.sum_types
+		sum_type_variants: type_output.sum_type_variants
 		struct_fields: struct_fields
 		struct_field_info: struct_field_info
 		struct_field_lookup: struct_field_lookup

--- a/vlib/v3/gen/fastc/fastc.v
+++ b/vlib/v3/gen/fastc/fastc.v
@@ -889,8 +889,6 @@ mut:
 	// operator scans in those handlers re-recurse over shared subranges;
 	// without the memo that search re-renders the same ranges combinatorially.
 	comparison_memo map[i64]FastcRenderedExpression
-	enum_type_name_memo map[string]bool
-	declared_type_key_memo map[string]string
 	has_c_functions bool
 	// Spawn lowering registrations (see spawn.v): thread struct typedefs,
 	// creator/run/waiter helper definitions, and thread type -> value type.
@@ -1041,8 +1039,6 @@ fn fastc_generate_single_file(ctx &FastcFileGenContext, source_file FastcSourceF
 		fastc_prefixed_c_names: ctx.fastc_prefixed_c_names
 		has_c_functions: ctx.has_c_functions
 		comparison_memo: map[i64]FastcRenderedExpression{}
-		enum_type_name_memo: map[string]bool{}
-		declared_type_key_memo: map[string]string{}
 		member_smartcasts: map[string]FastcMemberSmartcast{}
 		spawn_typedefs: map[string]string{}
 		spawn_helpers: map[string]string{}

--- a/vlib/v3/gen/fastc/fastc_test.v
+++ b/vlib/v3/gen/fastc/fastc_test.v
@@ -7448,6 +7448,47 @@ fn main() {
 	assert c_source.contains('Array_Node v = *(Array_Node *)'), c_source
 }
 
+fn test_sum_type_recursive_array_variant_append_boxes_one_element() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+type Value = int | []Value
+
+fn main() {
+	mut dst := []Value{}
+	src := [Value(1)]
+	dst << src
+	_ := dst
+}
+', 'sum_type_recursive_append.v', prefs) or { panic(err) }
+	// `[]Value` is a variant of `Value`, so `dst << src` boxes the whole `src` array as
+	// one `Value` element instead of copying its elements. The append must use the
+	// single-element push and box `src` with the composite `Array_Value` type id.
+	assert !c_source.contains('builtin__array_push_many'), c_source
+	assert c_source.contains('__v_typeid_Array_Value'), c_source
+	assert c_source.contains('builtin__array_push('), c_source
+}
+
+fn test_sum_type_nonrecursive_array_append_is_push_many() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+type Plain = int | string
+
+fn main() {
+	mut dst := []Plain{}
+	src := [Plain(1)]
+	dst << src
+	_ := dst
+}
+', 'sum_type_nonrecursive_append.v', prefs) or { panic(err) }
+	// `Plain` has no array variant, so `[]Plain << []Plain` stays a push-many append
+	// that copies each element, matching the main C backend.
+	assert c_source.contains('builtin__array_push_many'), c_source
+}
+
 fn test_generic_monomorphization() {
 	mut prefs := pref.new_preferences()
 	prefs.building_v = true

--- a/vlib/v3/gen/fastc/fastc_test.v
+++ b/vlib/v3/gen/fastc/fastc_test.v
@@ -5860,6 +5860,25 @@ fn main() {
 	assert !c_source.contains('text.str[index]'), c_source
 }
 
+fn test_selfhost_double_pointer_index_preserves_one_pointer_level() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+fn take(value &u8) {}
+
+fn pass(values &&u8, index int) {
+	take(values[index])
+}
+
+fn main() {
+	pass(&&u8(0), 0)
+}
+', 'selfhost_double_pointer_index.v', prefs) or { panic(err) }
+	assert c_source.contains('take(((values)[index]))'), c_source
+	assert !c_source.contains('take(&(((values)[index])))'), c_source
+}
+
 fn test_selfhost_selector_assignment_accepts_array_initializer() {
 	mut prefs := pref.new_preferences()
 	prefs.building_v = true
@@ -6198,6 +6217,52 @@ fn main() {
 	assert c_source.contains('__v_fastc_append_map_target'), c_source
 	assert c_source.contains('builtin__map_get_check'), c_source
 	assert !c_source.contains('groups[key]'), c_source
+}
+
+fn test_selfhost_append_to_nested_array() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+fn add(mut groups [][]int, index int, value int) {
+	groups[index] << value
+}
+
+fn main() {
+	mut groups := [][]int{len: 1}
+	add(mut groups, 0, 42)
+}
+', 'selfhost_append_to_nested_array.v', prefs) or { panic(err) }
+	assert c_source.contains('__v_fastc_append_array_target'), c_source
+	assert c_source.contains('builtin__array_get(*(groups), index)'), c_source
+	assert !c_source.contains('groups[index]'), c_source
+}
+
+fn test_selfhost_append_array_result_to_struct_field() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct State {
+mut:
+	values []string
+}
+
+fn load_values() ![]string {
+	return [\'one\', \'two\']
+}
+
+fn add_values(mut state State) ! {
+	state.values << load_values()!
+}
+
+fn main() {
+	mut state := State{}
+	add_values(mut state) or { panic(err) }
+}
+', 'selfhost_append_array_result_to_struct_field.v', prefs) or { panic(err) }
+	assert c_source.contains('builtin__array_push_many'), c_source
+	assert !c_source.contains('state->values<<'), c_source
 }
 
 fn test_selfhost_empty_array_assigned_to_member_field() {
@@ -10299,6 +10364,33 @@ fn main() {
 	assert c_source.contains('builtin__map_get_check'), c_source
 	assert c_source.contains('builtin__map_set'), c_source
 	assert !c_source.contains('counts[key]+amount'), c_source
+}
+
+fn test_selfhost_map_assignment_with_propagated_result() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Item {
+	value int
+}
+
+fn load_item() !Item {
+	return Item{ value: 42 }
+}
+
+fn insert(mut items map[string]Item) ! {
+	items[\'answer\'] = load_item()!
+}
+
+fn main() {
+	mut items := map[string]Item{}
+	insert(mut items) or { panic(err) }
+}
+', 'selfhost_map_assignment_propagated_result.v', prefs) or { panic(err) }
+	assert c_source.contains('builtin__map_set'), c_source
+	assert c_source.contains('__v_fastc_option_propagate'), c_source
+	assert !c_source.contains('items[_S("answer")]'), c_source
 }
 
 fn test_selfhost_nested_map_assignment_initializes_addressable_inner_map() {

--- a/vlib/v3/gen/fastc/render.v
+++ b/vlib/v3/gen/fastc/render.v
@@ -2263,6 +2263,19 @@ fn (g &Parser) is_boxed_type(c_type string) bool {
 	return g.declared_kinds[g.semantic_type_key(c_type)] == .interface_
 }
 
+// sumtype_has_variant reports whether `sum_type` is a sum type that declares
+// `variant` (a normalized C type name) as one of its variants. It mirrors the main
+// C backend's `sumtype_has_variant` and is used to keep an array-valued variant of
+// a recursive sum type (`type Value = []Value | int`) boxed as a single element
+// rather than treated as a push-many append.
+fn (g &Parser) sumtype_has_variant(sum_type string, variant string) bool {
+	base := sum_type.trim_right('*')
+	if base !in g.sum_types {
+		return false
+	}
+	return g.sum_type_variants['${base}|${variant.trim_right('*')}']
+}
+
 // should_box_variant reports whether a value of `actual_type` used where the
 // boxed `expected_type` is expected must be boxed: a concrete struct into an
 // interface or sum type, or a primitive scalar into a sum type (interfaces have
@@ -2443,7 +2456,14 @@ fn (g &Parser) render_append_expression(tokens []FastcExpressionToken, rendered_
 	element_type := g.array_element_type(left_type) or { return none }
 	right_tokens := tokens[operator_index + 1..]
 	right_type := g.infer_expression_type(right_tokens) or { return none }
-	is_array_append := fastc_normalize_inferred_type(right_type) == fastc_normalize_inferred_type(left_type)
+	normalized_right := fastc_normalize_inferred_type(right_type)
+	// `[]T << []T` is push-many (append each element), but when the element type is a
+	// sum type that lists `[]T` as a variant (a recursive sum type such as
+	// `type Value = []Value | int`), the array must be boxed as a single element
+	// instead. This mirrors the `sumtype_has_variant` guard the main C backend applies
+	// before selecting push-many (see vlib/v/gen/c/infix.v).
+	is_array_append := normalized_right == fastc_normalize_inferred_type(left_type)
+		&& !g.sumtype_has_variant(element_type, normalized_right)
 	separator := rendered_expression.index('<<') or { return none }
 	left_tokens := tokens[..operator_index]
 	mut left_source := rendered_expression[..separator]

--- a/vlib/v3/gen/fastc/render.v
+++ b/vlib/v3/gen/fastc/render.v
@@ -385,11 +385,15 @@ fn (g &Parser) render_struct_literal_field_names(tokens []FastcExpressionToken, 
 		return none
 	}
 	c_type := g.type_from_expression_tokens(tokens[..open]) or { return none }
-	// This is a read-only view of program metadata owned by the generation context.
-	fields := unsafe { g.struct_fields[c_type.trim_right('*')] }
+	mut field_names := []string{}
+	if fields := g.struct_fields[c_type.trim_right('*')] {
+		field_names = fields.keys()
+	} else {
+		return none
+	}
 	mut rendered := rendered_expression
 	mut changed := false
-	for field_name in fields.keys() {
+	for field_name in field_names {
 		for module_name in [g.module_name, 'builtin'] {
 			constant_name := g.constants[fastc_constant_key(module_name, field_name)] or { '' }
 			mut resolved_names := []string{}
@@ -1101,8 +1105,7 @@ fn fastc_trim_expression_parentheses(tokens []FastcExpressionToken) []FastcExpre
 		start++
 		end--
 	}
-	// Callers only inspect the trimmed range while the original expression is alive.
-	return unsafe { tokens[start..end] }
+	return tokens[start..end].clone()
 }
 
 // render_refined_enum_logical_expression lowers `x is Enum && x == .value`.

--- a/vlib/v3/gen/fastc/render.v
+++ b/vlib/v3/gen/fastc/render.v
@@ -2441,6 +2441,9 @@ fn (g &Parser) render_append_expression(tokens []FastcExpressionToken, rendered_
 	}
 	left_type := g.infer_expression_type(tokens[..operator_index]) or { return none }
 	element_type := g.array_element_type(left_type) or { return none }
+	right_tokens := tokens[operator_index + 1..]
+	right_type := g.infer_expression_type(right_tokens) or { return none }
+	is_array_append := fastc_normalize_inferred_type(right_type) == fastc_normalize_inferred_type(left_type)
 	separator := rendered_expression.index('<<') or { return none }
 	left_tokens := tokens[..operator_index]
 	mut left_source := rendered_expression[..separator]
@@ -2450,7 +2453,8 @@ fn (g &Parser) render_append_expression(tokens []FastcExpressionToken, rendered_
 	// `arr << [a, b]`), and any call (`arr << s.clone()`, `arr << f(x)`) need the argument
 	// renderer, which boxes variants, lowers indexing, and routes method/function calls.
 	// Render through it whenever it succeeds, keeping the raw form only as a fallback.
-	if rerendered := g.render_call_argument_expression(tokens[operator_index + 1..], element_type) {
+	expected_right_type := if is_array_append { left_type } else { element_type }
+	if rerendered := g.render_call_argument_expression(right_tokens, expected_right_type) {
 		right_source = rerendered
 	}
 	temporary := '__v_fastc_append_value'
@@ -2492,6 +2496,47 @@ fn (g &Parser) render_append_expression(tokens []FastcExpressionToken, rendered_
 					}
 				}
 			}
+			base_type := g.infer_expression_type(base_tokens) or { '' }
+			base_layout := g.underlying_alias_type(base_type).trim_right('*')
+			if base_layout.starts_with('Array_') {
+				outer_element_type := g.array_element_type(base_type) or { '' }
+				if fastc_normalize_inferred_type(outer_element_type) == fastc_normalize_inferred_type(left_type) {
+					index_source := g.render_call_argument_expression(left_tokens[open + 1..left_tokens.len - 1],
+						'int') or { return none }
+					base_source := if base_tokens.len == 1 {
+						g.resolved_root_expression_name(base_tokens[0].lit)
+					} else if nested_base := g.render_array_access_expression(base_tokens) {
+						nested_base.source
+					} else if raw_base := g.render_raw_expression_tokens(base_tokens) {
+						g.render_member_receiver(base_tokens) or { raw_base }
+					} else {
+						return none
+					}
+					array_value := if base_type.ends_with('*') { '*(${base_source})' } else { base_source }
+					target := '(${left_type.trim_right('*')} *)builtin__array_get(${array_value}, ${index_source})'
+					if is_array_append {
+						return FastcRenderedExpression{
+							source: '({ ${left_type.trim_right('*')} ${temporary} = (${right_source}); ${left_type.trim_right('*')} *__v_fastc_append_array_target = ${target}; builtin__array_push_many((array *)__v_fastc_append_array_target, ${temporary}.data, ${temporary}.len); 0; })'
+							typ:    'void'
+						}
+					}
+					return FastcRenderedExpression{
+						source: '({ ${element_type} ${temporary} = (${right_source}); ${left_type.trim_right('*')} *__v_fastc_append_array_target = ${target}; builtin__array_push((array *)__v_fastc_append_array_target, &${temporary}); 0; })'
+						typ:    'void'
+					}
+				}
+			}
+		}
+	}
+	if is_array_append {
+		array_target := if left_type.ends_with('*') {
+			'(array *)(${left_source})'
+		} else {
+			'(array *)&(${left_source})'
+		}
+		return FastcRenderedExpression{
+			source: '({ ${left_type.trim_right('*')} ${temporary} = (${right_source}); builtin__array_push_many(${array_target}, ${temporary}.data, ${temporary}.len); 0; })'
+			typ:    'void'
 		}
 	}
 	return FastcRenderedExpression{

--- a/vlib/v3/gen/fastc/render_calls.v
+++ b/vlib/v3/gen/fastc/render_calls.v
@@ -482,11 +482,10 @@ fn (g &Parser) method_function_key(receiver_type string, name string) string {
 		}
 		layout_type = 'map'
 	}
-	// The program metadata is immutable during per-file generation, so workers
-	// can share the nested field map instead of cloning it for every method lookup.
-	fields := unsafe { g.struct_fields[layout_type] }
-	if 'data' in fields && 'len' in fields && 'cap' in fields && 'array.${name}' in g.functions {
-		return 'array.${name}'
+	if fields := g.struct_fields[layout_type] {
+		if 'data' in fields && 'len' in fields && 'cap' in fields && 'array.${name}' in g.functions {
+			return 'array.${name}'
+		}
 	}
 	return direct_key
 }

--- a/vlib/v3/gen/fastc/render_method_calls.v
+++ b/vlib/v3/gen/fastc/render_method_calls.v
@@ -92,7 +92,7 @@ fn (g &Parser) render_missing_call_arguments(tokens []FastcExpressionToken) ?Fas
 		if fixed_arguments < 0 || fixed_arguments > rendered_arguments.len {
 			return none
 		}
-		variadic_arguments := unsafe { rendered_arguments[fixed_arguments..] }
+		variadic_arguments := rendered_arguments[fixed_arguments..].clone()
 		packed := if variadic_arguments.len == 0 {
 			'(${variadic_type}){0}'
 		} else {
@@ -431,7 +431,7 @@ fn (g &Parser) render_method_call_expression(tokens []FastcExpressionToken, rend
 			}
 			variadic_type := signature.parameter_types.last()
 			element_type := g.array_element_type(variadic_type) or { continue }
-			variadic_arguments := unsafe { direct_arguments[fixed_arguments..] }
+			variadic_arguments := direct_arguments[fixed_arguments..].clone()
 			packed := if variadic_arguments.len == 0 {
 				'(${variadic_type}){0}'
 			} else {

--- a/vlib/v3/gen/fastc/render_struct_literal.v
+++ b/vlib/v3/gen/fastc/render_struct_literal.v
@@ -43,8 +43,6 @@ fn (g &Parser) render_struct_literal_expression(tokens []FastcExpressionToken) ?
 	]) {
 		return none
 	}
-	// This is a read-only view of program metadata owned by the generation context.
-	fields := unsafe { g.struct_fields[layout_type] }
 	if open + 1 < close {
 		items := fastc_expression_list_items(tokens, open + 1, close) or { return none }
 		mut is_positional := false
@@ -53,7 +51,7 @@ fn (g &Parser) render_struct_literal_expression(tokens []FastcExpressionToken) ?
 				if item.len == 0 {
 					continue
 				}
-				if !(item.len >= 2 && item[0].tok == .name && item[1].tok == .colon) && !(item.len == 1 && item[0].tok == .name && item[0].lit in fields) {
+				if !(item.len >= 2 && item[0].tok == .name && item[1].tok == .colon) && !(item.len == 1 && item[0].tok == .name && g.struct_direct_member_type(c_type, item[0].lit) != '') {
 					is_positional = true
 					break
 				}
@@ -153,8 +151,7 @@ fn (g &Parser) render_struct_literal_expression(tokens []FastcExpressionToken) ?
 			if value_start == index {
 				return none
 			}
-			// The enclosing token array outlives this render pass and is never mutated here.
-			value_tokens = unsafe { tokens[value_start..index] }
+			value_tokens = tokens[value_start..index].clone()
 		} else {
 			value_tokens = [
 				FastcExpressionToken{
@@ -171,7 +168,7 @@ fn (g &Parser) render_struct_literal_expression(tokens []FastcExpressionToken) ?
 		mut expected_type := if layout_type == 'array' && field_name == 'init' {
 			g.array_element_type(c_type) or { '' }
 		} else {
-			fields[field_name] or { '' }
+			g.struct_direct_member_type(c_type, field_name)
 		}
 		if expected_type == '' && !is_c_struct_literal {
 			if field := g.struct_field_metadata(c_type, field_name) {

--- a/vlib/v3/gen/fastc/stmt.v
+++ b/vlib/v3/gen/fastc/stmt.v
@@ -870,13 +870,19 @@ fn (mut g Parser) parse_simple_statement() ! {
 			if !local.is_mut {
 				return g.unsupported('append to immutable name `${name}`')
 			}
-			_ := g.array_element_type(local.typ) or {
+			element_type := g.array_element_type(local.typ) or {
 				return g.unsupported('append to non-array `${name}` of type `${local.typ}`')
 			}
 			g.next()
 			value := g.read_expression([token.Token.semicolon, token.Token.rcbr])!
 			value_type := fastc_normalize_inferred_type(g.last_expression_type)
-			is_array_append := value_type == local.typ
+			// `[]T << []T` is push-many, unless the element type is a sum type that lists
+			// `[]T` as a variant (a recursive sum type such as `type Value = []Value | int`),
+			// in which case the array is boxed as one element. Mirrors the main C backend's
+			// `sumtype_has_variant` guard (see vlib/v/gen/c/infix.v).
+			boxes_array_variant := value_type == local.typ
+				&& g.sumtype_has_variant(element_type, value_type)
+			is_array_append := value_type == local.typ && !boxes_array_variant
 			g.consume_statement_end()
 			c_name := fastc_c_identifier(name)
 			array_target := if local.typ.ends_with('*') {
@@ -885,11 +891,19 @@ fn (mut g Parser) parse_simple_statement() ! {
 				'(array *)&${c_name}'
 			}
 			value_name := g.temporary_name('push_value')
-			g.write_line('__typeof__((${value})) ${value_name} = (${value});')
-			if is_array_append {
-				g.write_line('builtin__array_push_many(${array_target}, ${value_name}.data, ${value_name}.len);')
-			} else {
+			if boxes_array_variant {
+				boxed := g.render_call_argument_expression(g.last_expression, element_type) or {
+					value
+				}
+				g.write_line('${element_type} ${value_name} = (${boxed});')
 				g.write_line('builtin__array_push(${array_target}, &${value_name});')
+			} else {
+				g.write_line('__typeof__((${value})) ${value_name} = (${value});')
+				if is_array_append {
+					g.write_line('builtin__array_push_many(${array_target}, ${value_name}.data, ${value_name}.len);')
+				} else {
+					g.write_line('builtin__array_push(${array_target}, &${value_name});')
+				}
 			}
 			return
 		}

--- a/vlib/v3/gen/fastc/types.v
+++ b/vlib/v3/gen/fastc/types.v
@@ -652,14 +652,14 @@ fn (g &Parser) infer_expression_type(tokens []FastcExpressionToken) !string {
 				_, value_type := g.map_key_value_types(base_type) or { return '' }
 				return value_type
 			}
-			if base_type.ends_with('*') {
-				return base_type.trim_right('*')
-			}
 			if base_type.trim_right('*') == 'string' {
 				return 'u8'
 			}
 			if element_type := g.array_element_type(base_type) {
 				return element_type
+			}
+			if base_type.ends_with('*') {
+				return base_type[..base_type.len - 1]
 			}
 		}
 	}
@@ -850,10 +850,12 @@ fn (g &Parser) infer_member_access_type(tokens []FastcExpressionToken) ?string {
 			} else if current_type.trim_right('*').starts_with('Map_') {
 				_, value_type := g.map_key_value_types(current_type) or { return none }
 				current_type = value_type
+			} else if element_type := g.array_element_type(current_type) {
+				current_type = element_type
 			} else if current_type.ends_with('*') {
-				current_type = current_type.trim_right('*')
+				current_type = current_type[..current_type.len - 1]
 			} else {
-				current_type = g.array_element_type(current_type) or { return none }
+				return none
 			}
 			index = close + 1
 			continue

--- a/vlib/v3/gen/fastc/validate.v
+++ b/vlib/v3/gen/fastc/validate.v
@@ -230,19 +230,8 @@ fn (g &Parser) local_is_pointer(name string) bool {
 }
 
 fn (g &Parser) is_enum_type_name(name string) bool {
-	if cached := g.enum_type_name_memo[name] {
-		return cached
-	}
-	mut result := false
-	if type_key := g.resolve_declared_type_key(name) {
-		result = g.underlying_enum_type_key(type_key) != none
-	}
-	mut parser := unsafe { &Parser(g) }
-	if parser.enum_type_name_memo.len == 0 {
-		parser.enum_type_name_memo = map[string]bool{}
-	}
-	parser.enum_type_name_memo[name] = result
-	return result
+	type_key := g.resolve_declared_type_key(name) or { return false }
+	return g.underlying_enum_type_key(type_key) != none
 }
 
 fn (g &Parser) underlying_enum_type_key(type_key string) ?string {


### PR DESCRIPTION
## What changed

Follow-up to #28271, which merged while its final review fix was still being pushed.

- replace newly introduced `unsafe` token subranges with owned clones
- use safe scoped lookups for nested struct metadata maps
- route struct-literal field queries through the existing safe metadata helpers
- remove the per-parser memoization that required unsafe interior mutation
- restore complete FastC self-hosting by lowering propagated map/array appends and assignments
- preserve one pointer level when indexing double pointers such as `argv`

This addresses the ownership feedback in #28271 and leaves no newly introduced `unsafe`
collection access in the diff.

## Performance

The review-safe version was measured with a fresh `-prod` V compiler and isolated child
samples at 42.71 ms / 1.511M LOC/s (`FASTC_BENCH_REPEAT=80`), retaining the 1.5M LOC/s
target. Peak RSS was about 325 MB.

## Self-host validation

- built a stage-1 FastC compiler with a `-prod` V compiler
- used stage 1 to compile and link a stage-2 FastC compiler
- used stage 2 to compile and run a hello program (`fastc self-host ok`)

## Testing

- `./v -g -keepc -o ./vnew cmd/v`
- focused FastC append, map assignment, pointer indexing, and array indexing tests via
  `-run-only`
- focused scheduler, struct-field, struct-literal, embedded-field, and fixed-array tests
  via `-run-only`
- `git diff --check`
