### PR TITLE
v3: fix cache, generic, and ownership regressions

### DIFF
--- a/ci/common/runner.v
+++ b/ci/common/runner.v
@@ -19,7 +19,8 @@ pub fn exec(command string) {
 // not a potentially different V found via PATH.
 fn resolve_v_command(command string) string {
 	if command.starts_with('v ') {
-		return os.quoted_path(os.join_path_single(@VEXEROOT, 'v')) + command[1..]
+		vexe := os.getenv_opt('V_CI_VEXE') or { os.join_path_single(@VEXEROOT, 'v') }
+		return os.quoted_path(vexe) + command[1..]
 	}
 	return command
 }
@@ -47,7 +48,10 @@ pub fn file_size_greater_than(fpath string, min_fsize u64) {
 	}
 }
 
-const self_command = os.quoted_path(os.join_path_single(@VEXEROOT, 'v')) + ' ' +
+const self_command =
+	os.quoted_path(os.getenv_opt('V_CI_VEXE') or {
+	os.join_path_single(@VEXEROOT, 'v')
+}) + ' ' +
 	os.real_path(os.executable()).replace_once(os.real_path(@VEXEROOT), '').trim_left('/\\') +
 	'.vsh'
 

--- a/ci/macos_ci.vsh
+++ b/ci/macos_ci.vsh
@@ -55,27 +55,27 @@ fn self_tests() {
 	// The broad compatibility suite still covers V1. The strict V3 canary and
 	// dedicated V3 suites in macos_ci.yml cover the default compiler separately.
 	if common.is_github_job {
-		exec('VJOBS=1 v -old-compiler -silent test-self vlib')
+		exec('VJOBS=1 v -old-compiler -no-memory-limit -silent test-self vlib')
 	} else {
 		vjobs := os.getenv_opt('VJOBS') or { '1' }
-		exec('VJOBS=${vjobs} v -old-compiler -progress test-self vlib')
+		exec('VJOBS=${vjobs} v -old-compiler -no-memory-limit -progress test-self vlib')
 	}
 }
 
 fn build_examples() {
 	if common.is_github_job {
-		exec('v build-examples')
+		exec('v -no-memory-limit build-examples')
 	} else {
-		exec('v -progress build-examples')
+		exec('v -no-memory-limit -progress build-examples')
 	}
 }
 
 fn build_examples_v_compiled_with_tcc() {
 	exec('v -o vtcc -cc tcc cmd/v')
 	if common.is_github_job {
-		exec('./vtcc build-examples')
+		exec('./vtcc -no-memory-limit build-examples')
 	} else {
-		exec('./vtcc -progress build-examples')
+		exec('./vtcc -no-memory-limit -progress build-examples')
 	}
 }
 
@@ -85,11 +85,13 @@ fn build_hello_world_autofree() {
 }
 
 fn build_tetris_autofree() {
-	exec('v -autofree -o tetris examples/tetris/tetris.v')
+	// Autofree remains a V1 compatibility job. V3 ownership is tested separately,
+	// while fastc intentionally performs no ownership analysis.
+	exec('v -old-compiler -autofree -o tetris examples/tetris/tetris.v')
 }
 
 fn build_blog_autofree() {
-	exec('v -autofree -o blog tutorials/building_a_simple_web_blog_with_veb/code/blog')
+	exec('v -old-compiler -autofree -o blog tutorials/building_a_simple_web_blog_with_veb/code/blog')
 }
 
 fn build_examples_prod() {

--- a/cmd/v/macos_v3_test.v
+++ b/cmd/v/macos_v3_test.v
@@ -1573,6 +1573,80 @@ fn main() {
 	}
 }
 
+fn test_macos_v3_cached_generic_keeps_main_type_homonym() {
+	$if macos {
+		root := os.join_path(os.real_path(os.vtmp_dir()),
+			'macos_v3_generic_main_type_${os.getpid()}')
+		os.rmdir_all(root) or {}
+		os.mkdir_all(os.join_path(root, 'mid')) or { panic(err) }
+		defer {
+			os.rmdir_all(root) or {}
+		}
+		main_file := os.join_path(root, 'main.v')
+		os.write_file(os.join_path(root, 'mid', 'mid.v'), 'module mid
+
+pub struct Context {
+pub:
+	name string
+}
+
+pub struct Middleware[T] {
+pub:
+	handler fn (mut T) string
+}
+
+pub fn make[T]() Middleware[T] {
+	return Middleware[T]{
+		handler: fn [T](mut ctx T) string {
+			return ctx.Context.name
+		}
+	}
+}
+')!
+		os.write_file(main_file, 'module main
+
+import mid
+
+struct Context {
+	mid.Context
+}
+
+fn main() {
+	mut context := Context{
+		Context: mid.Context{
+			name: "main context"
+		}
+	}
+	middleware := mid.make[Context]()
+	println(middleware.handler(mut context))
+}
+')!
+		mut environment := os.environ()
+		environment['CFLAGS'] = ''
+		environment['LDFLAGS'] = ''
+		environment['VFLAGS'] = ''
+		environment['VOSARGS'] = ''
+		environment['V3CACHE'] = os.join_path(root, 'cache')
+		environment['V_MACOS_V3_NO_FALLBACK'] = '1'
+		for name in ['first', 'second'] {
+			output := os.join_path(root, name)
+			mut process := os.new_process(@VEXE)
+			process.set_args(['-gc', 'none', '-o', output, main_file])
+			process.set_environment(environment)
+			process.set_redirect_stdio()
+			process.run()
+			process.wait()
+			compiler_output := process.stdout_slurp() + process.stderr_slurp()
+			exit_code := process.code
+			process.close()
+			assert exit_code == 0, compiler_output
+			run := os.execute(os.quoted_path(output))
+			assert run.exit_code == 0, run.output
+			assert run.output.trim_space() == 'main context'
+		}
+	}
+}
+
 fn test_macos_v3_reads_c_error_fallback_report() {
 	$if macos {
 		root := os.join_path(os.vtmp_dir(), 'macos_v3_c_error_report_${os.getpid()}')

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -2968,6 +2968,12 @@ fn prepare_v3_cache_native_type_declarations(mut state V3ModuleCacheState, c_fla
 			if roots.any(c_flag_is_c_source_file(it)) {
 				return false
 			}
+			if roots.len > 1 {
+				// Several implementation headers can share macro state with later
+				// inlined directives. Replaying each header independently after an
+				// uncertain guard would expose definitions in every cache object.
+				return false
+			}
 			mut recovered_functions := map[string]bool{}
 			for root in roots {
 				real_root := os.real_path(root)
@@ -2985,6 +2991,10 @@ fn prepare_v3_cache_native_type_declarations(mut state V3ModuleCacheState, c_fla
 					}
 				}
 				if root_has_recovered_functions {
+					// An unresolved conditional can make declaration extraction lose a
+					// directive that is nested inside a function branch. Replay headers
+					// with their implementation switches disabled instead; the check below
+					// still rejects any external definition that would survive the replay.
 					roots_with_function_declarations[real_root] = true
 				}
 			}
@@ -9431,6 +9441,7 @@ pub fn run(args []string) {
 			return
 		}
 		if cache_state.manager.enabled {
+			const_init_order := cgen.module_const_init_order(a, pre_tc)
 			if !prepare_v3_cache_external_inputs_scoped(mut cache_state, a, prefs, user_files,
 				cache_c_flags, scope_prealloc_stages) {
 				trace_v3_cache_fallback('external C inputs cannot be assigned to cache units')
@@ -9444,8 +9455,8 @@ pub fn run(args []string) {
 				if !parsed {
 					continue
 				}
-				header := modulecache.module_header(a, pre_tc, module_name, prefs.vroot,
-					cache_state.module_import_paths)
+				header := modulecache.module_header_with_const_order(a, pre_tc, module_name,
+					prefs.vroot, cache_state.module_import_paths, const_init_order)
 				if header.len > 0 {
 					cache_state.headers[module_name] = header
 				}
@@ -11691,16 +11702,17 @@ fn prepare_v3_module_cache(generated_source string, cache_used_fns &map[string]b
 	tcc_declarations := tcc_cached_main_source(main_declarations, main_body)
 	tcc_main := '#define V3CACHE_PROGRAM_UNIT 1\n' + tcc_declarations + main_body
 	mut object_paths := state.objects.clone()
-	mut bundle_body := strings.new_builder(4096)
-	mut split_modules := split.modules.keys()
-	split_modules.sort()
-	for module_name in split_modules {
-		if module_is_builtin_bundle(state, module_name) {
-			bundle_body.write_string(split.modules[module_name])
-		}
-	}
 	if !state.bundle_valid {
 		entry := state.manager.object_entry('builtin', state.bundle_sources, compile_signature)
+		bundle_compile_scope := prealloc_scope_begin_for_v3()
+		mut bundle_body := strings.new_builder(4096)
+		mut split_modules := split.modules.keys()
+		split_modules.sort()
+		for module_name in split_modules {
+			if module_is_builtin_bundle(state, module_name) {
+				bundle_body.write_string(split.modules[module_name])
+			}
+		}
 		bundle_roots := cache_builtin_bundle_roots(state)
 		bundle_declarations := prune_cached_native_function_prototypes(raw_declarations, state,
 			bundle_roots)
@@ -11714,7 +11726,15 @@ fn prepare_v3_module_cache(generated_source string, cache_used_fns &map[string]b
 			declarations + bundle_body.str()
 		}
 		compile_v3_cached_object(entry, module_source, c_standard, opt_flag, pic_flag,
-			warning_flags, generated_c_flags, objective_c)!
+			warning_flags, generated_c_flags, objective_c) or {
+			prealloc_scope_leave_for_v3(bundle_compile_scope)
+			message := err.msg().clone()
+			prealloc_scope_free_for_v3(bundle_compile_scope)
+			return error(message)
+		}
+		unsafe { bundle_body.free() }
+		prealloc_scope_leave_for_v3(bundle_compile_scope)
+		prealloc_scope_free_for_v3(bundle_compile_scope)
 		for module_name, header in state.headers {
 			if !module_is_builtin_bundle(state, module_name) {
 				continue
@@ -11735,7 +11755,6 @@ fn prepare_v3_module_cache(generated_source string, cache_used_fns &map[string]b
 			}
 		}
 	}
-	unsafe { bundle_body.free() }
 
 	for module_name in parsed_modules {
 		if module_is_builtin_bundle(state, module_name) {
@@ -11754,6 +11773,7 @@ fn prepare_v3_module_cache(generated_source string, cache_used_fns &map[string]b
 				''
 			}
 		}
+		module_compile_scope := prealloc_scope_begin_for_v3()
 		module_declarations := prune_cached_native_function_prototypes(raw_declarations, state, [
 			module_name,
 		])
@@ -11767,7 +11787,14 @@ fn prepare_v3_module_cache(generated_source string, cache_used_fns &map[string]b
 			declarations + body
 		}
 		compile_v3_cached_object(entry, module_source, c_standard, opt_flag, pic_flag,
-			warning_flags, generated_c_flags, objective_c)!
+			warning_flags, generated_c_flags, objective_c) or {
+			prealloc_scope_leave_for_v3(module_compile_scope)
+			message := err.msg().clone()
+			prealloc_scope_free_for_v3(module_compile_scope)
+			return error(message)
+		}
+		prealloc_scope_leave_for_v3(module_compile_scope)
+		prealloc_scope_free_for_v3(module_compile_scope)
 		if header := state.headers[module_name] {
 			state.manager.write_header(module_name, source_files, header)!
 		}

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -3955,7 +3955,10 @@ fn (mut g FlatGen) compute_collect_gen_fn_prep(node flat.Node, module_name strin
 			pt = shared_alias_ptr
 		} else if raw_pt is types.Pointer && param_idx < typed_params.len {
 			typed_pt := typed_params[param_idx]
-			if typed_pt is types.Pointer && raw_pt.base_type is types.FnType
+			if child.is_mut && child.op == .amp && typed_pt is types.Pointer
+				&& typed_pt.base_type is types.Pointer {
+				pt = typed_pt
+			} else if typed_pt is types.Pointer && raw_pt.base_type is types.FnType
 				&& typed_pt.base_type is types.FnType {
 				// Specialized `mut T` parameters keep a pointer-to-function type in
 				// the flat declaration. The registered signature retains the concrete
@@ -3964,6 +3967,9 @@ fn (mut g FlatGen) compute_collect_gen_fn_prep(node flat.Node, module_name strin
 			}
 		} else if raw_pt !is types.Pointer && param_idx < typed_params.len {
 			pt = typed_params[param_idx]
+		}
+		if child.is_mut && child.op == .amp {
+			pt = g.explicit_mut_pointer_param_type(child, pt)
 		}
 		mut is_shared_param := false
 		if child.typ.len > 0 && child.typ[0] in [`s`, ` `, `\t`, `\n`, `\r`] {
@@ -10092,6 +10098,65 @@ fn (mut g FlatGen) collect_const_init_order_from_files() {
 	}
 }
 
+// module_const_init_order returns the dependency-safe constant initialization
+// order that declaration-only module headers must preserve.
+pub fn module_const_init_order(a &flat.FlatAst, tc &types.TypeChecker) []string {
+	mut g := FlatGen.new()
+	g.a = a
+	g.tc = tc
+	old_module := tc.cur_module
+	old_file := tc.cur_file
+	defer {
+		g.tc.cur_module = old_module
+		g.tc.cur_file = old_file
+	}
+	mut cur_module := 'main'
+	mut cur_file := ''
+	for node_idx, node in a.nodes {
+		match node.kind {
+			.file {
+				cur_file = node.value
+				cur_module = 'main'
+			}
+			.module_decl {
+				cur_module = node.value
+			}
+			.fn_decl {
+				g.register_fn_decl_node(node.value, cur_module, flat.NodeId(node_idx))
+			}
+			.const_decl {
+				for i in 0 .. node.children_count {
+					field := a.child_node(&node, i)
+					if field.kind != .const_field || field.children_count == 0 {
+						continue
+					}
+					qname := g.const_storage_name(cur_module, field.value)
+					g.const_vals[qname] = a.child(field, 0)
+					g.const_modules[qname] = cur_module
+					g.const_files[qname] = cur_file
+					if cur_module in ['', 'main', 'builtin'] && field.value !in g.const_vals {
+						g.const_vals[field.value] = a.child(field, 0)
+						g.const_modules[field.value] = cur_module
+						g.const_files[field.value] = cur_file
+					}
+				}
+			}
+			.import_decl {
+				if node.typ.len > 0 && node.value.len > 0 {
+					g.modules[node.typ] = node.value
+				}
+				if cur_module.len > 0 && node.value.len > 0
+					&& node.value !in g.module_imports[cur_module] {
+					g.module_imports[cur_module] << node.value
+				}
+			}
+			else {}
+		}
+	}
+	g.collect_const_init_order_from_files()
+	return g.const_emission_order()
+}
+
 // ordered_module_init_fns supports ordered module init fns handling for FlatGen.
 fn (g &FlatGen) ordered_module_init_fns() []string {
 	module_to_init := g.module_init_fn_map()
@@ -15803,7 +15868,9 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 					// semantic `&T` value. Synthetic dereferences only read the slot.
 					g.write('(*')
 					if g.source_mut_pointer_param_deref_type(id) != none {
-						g.gen_expr(child_id)
+						g.write('(*')
+						g.gen_mut_pointer_slot_expr(child_id)
+						g.write(')')
 					} else {
 						g.gen_mut_pointer_slot_expr(child_id)
 					}

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -1274,7 +1274,8 @@ fn (mut g FlatGen) direct_call_name_for_call(id flat.NodeId, name string) string
 	// Synthesized helpers carry their complete, globally unique C symbol in the
 	// source name. Their owning module only controls cache-object placement; it
 	// must not be prepended to calls made from that same module.
-	if name.starts_with('__v3_sum_eq_') || name.starts_with('__v3_autostr_') {
+	if name.starts_with('__v3_sum_eq_') || name.starts_with('__v3_autostr_')
+		|| name.starts_with('__v3_default_clone_') {
 		return g.direct_call_name(name)
 	}
 	if !name.contains('.') && g.tc.cur_module.len > 0 && g.tc.cur_module !in ['main', 'builtin'] {
@@ -3089,6 +3090,14 @@ fn (mut g FlatGen) gen_mut_sum_lvalue_arg(arg_id flat.NodeId, expected types.Typ
 	base := if base0 is types.Alias { base0.base_type } else { base0 }
 	if base !is types.SumType {
 		return false
+	}
+	// A `mut value SumType` parameter is already lowered to `SumType* value`.
+	// Forward that pointer directly; taking its address would pass a `SumType**`
+	// and leave the caller's sum value unchanged.
+	lvalue_node := g.a.nodes[int(lvalue_id)]
+	if lvalue_node.kind == .ident && g.current_param_is_mut(lvalue_node.value) {
+		g.write(g.cname(lvalue_node.value))
+		return true
 	}
 	if !g.expr_is_addressable(lvalue_id) {
 		return false
@@ -15934,8 +15943,7 @@ fn (mut g FlatGen) gen_mut_pointer_slot_arg(arg_id flat.NodeId, arg_node flat.No
 	// by the callee, so emitting the lowered dereference would lose one level.
 	if arg_node.kind == .prefix && arg_node.op == .mul && arg_node.children_count == 1 {
 		child := g.a.child_node(&arg_node, 0)
-		if child.kind == .ident && g.current_param_is_mut(child.value)
-			&& !g.current_param_is_mut_pointer(child.value) {
+		if child.kind == .ident && g.current_param_is_mut(child.value) {
 			param_type := g.current_param_type(child.value) or { types.Type(types.void_) }
 			if g.tc.c_type(param_type) == g.tc.c_type(expected) {
 				g.write(g.local_decl_cname(child.value))
@@ -17974,7 +17982,18 @@ fn (mut g FlatGen) fn_node_signature_names(node flat.Node, module_name string) [
 }
 
 fn (mut g FlatGen) fn_node_effective_param_type(param flat.Node, typed types.Type) types.Type {
-	return typed
+	if !param.is_mut || param.op != .amp || typed !is types.Pointer {
+		return typed
+	}
+	declared := g.tc.parse_resolution_type(param.typ)
+	if declared.name() != typed.name() {
+		// Generic specialization already records the mutable caller-slot pointer in
+		// its concrete signature.
+		return typed
+	}
+	return types.Type(types.Pointer{
+		base_type: typed
+	})
 }
 
 // write_fn_node_params writes fn node params output for c.
@@ -18071,7 +18090,28 @@ fn (mut g FlatGen) write_fn_node_params(node flat.Node) {
 }
 
 fn (mut g FlatGen) explicit_mut_pointer_param_type(param flat.Node, typ types.Type) types.Type {
-	return typ
+	if !param.is_mut || param.op != .amp || typ !is types.Pointer {
+		return typ
+	}
+	decl_type := g.tc.parse_resolution_type(param.typ)
+	mut decl_depth := 0
+	mut decl_base := decl_type
+	for decl_base is types.Pointer {
+		decl_depth++
+		decl_base = decl_base.base_type
+	}
+	mut actual_depth := 0
+	mut actual_base := typ
+	for actual_base is types.Pointer {
+		actual_depth++
+		actual_base = actual_base.base_type
+	}
+	if actual_depth > decl_depth {
+		return typ
+	}
+	return types.Type(types.Pointer{
+		base_type: typ
+	})
 }
 
 fn (g &FlatGen) is_specialized_generic_fn_node(node flat.Node) bool {

--- a/vlib/v3/gen/c/for.v
+++ b/vlib/v3/gen/c/for.v
@@ -272,7 +272,10 @@ fn (mut g FlatGen) gen_for_in(node flat.Node) {
 			if clean_container_type is types.Map {
 				c_key := g.map_key_temp_c_type(clean_container_type.key_type)
 				c_val := g.value_c_type(clean_container_type.value_type)
-				map_value_by_ref := node.op == .amp || container_type is types.Pointer
+				// A mutable pointer-valued map element already permits mutation through
+				// the pointee; taking its address again would add a bogus pointer level.
+				map_value_by_ref := node.op == .amp
+					&& cgen_unalias_type(clean_container_type.value_type) !is types.Pointer
 				container_str := g.expr_to_string(g.a.child(&node, 2))
 				storage_container_type := g.usable_expr_type(g.a.child(&node, 2))
 				container_storage_is_pointer := storage_container_type is types.Pointer

--- a/vlib/v3/gen/c/for.v
+++ b/vlib/v3/gen/c/for.v
@@ -272,10 +272,7 @@ fn (mut g FlatGen) gen_for_in(node flat.Node) {
 			if clean_container_type is types.Map {
 				c_key := g.map_key_temp_c_type(clean_container_type.key_type)
 				c_val := g.value_c_type(clean_container_type.value_type)
-				// A mutable pointer-valued map element already permits mutation through
-				// the pointee; taking its address again would add a bogus pointer level.
 				map_value_by_ref := node.op == .amp
-					&& cgen_unalias_type(clean_container_type.value_type) !is types.Pointer
 				container_str := g.expr_to_string(g.a.child(&node, 2))
 				storage_container_type := g.usable_expr_type(g.a.child(&node, 2))
 				container_storage_is_pointer := storage_container_type is types.Pointer

--- a/vlib/v3/gen/c/names_test.v
+++ b/vlib/v3/gen/c/names_test.v
@@ -120,6 +120,7 @@ fn test_direct_call_does_not_prefix_synthetic_helper_with_owner_module() {
 	assert g.direct_call_name_for_call(flat.empty_node, '__v3_autostr_ast__Comment') == '__v3_autostr_ast__Comment'
 	assert g.direct_call_name_for_call(flat.empty_node, 'ast.__v3_autostr_ast__Comment') == '__v3_autostr_ast__Comment'
 	assert g.direct_call_name_for_call(flat.empty_node, '__v3_default_clone_json2__Any') == '__v3_default_clone_json2__Any'
+	assert g.direct_call_name_for_call(flat.empty_node, 'ast.__v3_default_clone_json2__Any') == '__v3_default_clone_json2__Any'
 	assert g.fn_c_name_in_module('main', '__v3_default_clone_json2__Any') == '__v3_default_clone_json2__Any'
 }
 

--- a/vlib/v3/gen/c/stmt.v
+++ b/vlib/v3/gen/c/stmt.v
@@ -1533,8 +1533,15 @@ fn (mut g FlatGen) gen_ownership_drop_result_error(expr string, depth int, mut e
 		concrete_ct := g.value_c_type(concrete_type)
 		g.writeln('case ${id}:')
 		g.indent++
-		g.gen_ownership_drop_value_inner(concrete_type, '*((${concrete_ct}*)${object})', depth + 1, mut
-			expanding)
+		if concrete in ['MessageError', 'builtin.MessageError'] {
+			// MessageError is introduced by generated result/error lowering and can be
+			// absent from markused's source-level call graph in tiny programs.
+			g.writeln('string__free(&(((${concrete_ct}*)${object})->msg));')
+		} else {
+			g.gen_ownership_drop_value_inner(concrete_type, '*((${concrete_ct}*)${object})',
+
+				depth + 1, mut expanding)
+		}
 		g.writeln('break;')
 		g.indent--
 	}
@@ -5284,7 +5291,14 @@ fn (mut g FlatGen) gen_autofree_discarded_owned_call(id flat.NodeId, node flat.N
 	tmp := '__discarded_owned_${g.tmp_count}'
 	g.tmp_count++
 	g.write('${g.value_c_type(typ)} ${tmp} = ')
-	g.gen_expr(id)
+	if g.expr_is_error_call(id) {
+		// A bare `error(...)` expression is typed as IError here. The regular call
+		// generator wraps it in the current function's result type, which is only
+		// correct when the caller expects that result wrapper.
+		g.gen_ierror_from_error_call(node)
+	} else {
+		g.gen_expr(id)
+	}
 	g.writeln(';')
 	g.gen_ownership_drop_value(typ, tmp, 0)
 	return true

--- a/vlib/v3/gen/c/types.v
+++ b/vlib/v3/gen/c/types.v
@@ -349,6 +349,17 @@ fn (mut g FlatGen) optional_payload_c_type(t types.Type) string {
 		ct = ct[..ct.len - 1]
 		pointer_suffix += '*'
 	}
+	if source_name := optional_payload_struct_name(t) {
+		canonical_name := g.canonical_import_alias_type_text(source_name)
+		lookup_name := if canonical_name.starts_with('main.') {
+			canonical_name['main.'.len..]
+		} else {
+			canonical_name
+		}
+		if canonical_name != source_name && lookup_name in g.tc.structs {
+			return g.struct_cname(canonical_name) + pointer_suffix
+		}
+	}
 	// A concrete generic type can reach this collector through a stale bare
 	// specialization spelling while its declaration is module-qualified
 	// (`StructKeyDecodeResult_T` vs `json2__StructKeyDecodeResult_T`). Resolve
@@ -377,6 +388,68 @@ fn optional_payload_may_have_stale_interface_spelling(t types.Type) bool {
 		clean = cgen_unalias_type(clean.base_type)
 	}
 	return clean is types.Interface || (clean is types.Struct && !clean.name.contains('.'))
+}
+
+fn optional_payload_struct_name(t types.Type) ?string {
+	mut clean := t
+	for clean is types.Pointer {
+		clean = clean.base_type
+	}
+	if clean is types.Struct {
+		return clean.name
+	}
+	return none
+}
+
+fn (g &FlatGen) canonical_import_alias_type_text(typ string) string {
+	clean := typ.trim_space()
+	for prefix in ['&', '?', '!', '[]'] {
+		if clean.starts_with(prefix) {
+			return prefix + g.canonical_import_alias_type_text(clean[prefix.len..])
+		}
+	}
+	if clean.starts_with('map[') {
+		bracket_end := shared_generic_matching_bracket(clean, 3)
+		if bracket_end < clean.len - 1 {
+			key := g.canonical_import_alias_type_text(clean[4..bracket_end])
+			value := g.canonical_import_alias_type_text(clean[bracket_end + 1..])
+			return 'map[${key}]${value}'
+		}
+	}
+	base, args, ok := parse_shared_generic_app_parts(clean)
+	if ok {
+		mut canonical_args := []string{cap: args.len}
+		for arg in args {
+			canonical_args << g.canonical_import_alias_type_text(arg)
+		}
+		canonical_base := g.canonical_import_alias_type_text(base)
+		return '${canonical_base}[${canonical_args.join(', ')}]'
+	}
+	if clean.contains('.') {
+		alias := clean.all_before('.')
+		if module_name := g.unique_import_alias_module(alias) {
+			return module_name + clean[alias.len..]
+		}
+	}
+	return clean
+}
+
+fn (g &FlatGen) unique_import_alias_module(alias string) ?string {
+	mut found := ''
+	suffix := '\n${alias}'
+	for key, module_name in g.tc.file_imports {
+		if !key.ends_with(suffix) {
+			continue
+		}
+		if found.len > 0 && found != module_name {
+			return none
+		}
+		found = module_name
+	}
+	if found.len > 0 {
+		return found
+	}
+	return none
 }
 
 fn optional_payload_is_bare_struct(t types.Type) bool {
@@ -498,11 +571,28 @@ fn (mut g FlatGen) collect_declaration_signature_types() {
 			}
 		}
 	}
+	old_module := g.tc.cur_module
+	old_file := g.tc.cur_file
+	defer {
+		g.tc.cur_module = old_module
+		g.tc.cur_file = old_file
+	}
 	// Parallel monomorph workers can append concrete declarations before their
 	// checker signature maps are merged. Read declaration nodes directly too, so
 	// an option/result used only by a worker specialization still gets a typedef.
+	mut cur_module := ''
+	mut cur_file := ''
 	for idx in g.top_level_nodes() {
 		node := g.a.nodes[idx]
+		if node.kind == .file {
+			cur_file = node.value
+			cur_module = g.tc.file_modules[cur_file] or { '' }
+			continue
+		}
+		if node.kind == .module_decl {
+			cur_module = node.value
+			continue
+		}
 		if node.kind != .fn_decl {
 			continue
 		}
@@ -510,6 +600,10 @@ fn (mut g FlatGen) collect_declaration_signature_types() {
 			|| g.name_uses_specialized_generic_abi(node.value)
 		if !concrete_optional {
 			continue
+		}
+		g.tc.cur_module = g.a.specialized_fn_modules[idx] or { cur_module }
+		g.tc.cur_file = g.a.specialized_fn_files[idx] or {
+			g.tc.fn_type_files[node.value] or { cur_file }
 		}
 		if node.typ.len > 0 {
 			g.collect_declaration_signature_type_for_context(g.tc.parse_type(node.typ),

--- a/vlib/v3/gen/c/types.v
+++ b/vlib/v3/gen/c/types.v
@@ -427,29 +427,18 @@ fn (g &FlatGen) canonical_import_alias_type_text(typ string) string {
 	}
 	if clean.contains('.') {
 		alias := clean.all_before('.')
-		if module_name := g.unique_import_alias_module(alias) {
+		if module_name := g.current_file_import_alias_module(alias) {
 			return module_name + clean[alias.len..]
 		}
 	}
 	return clean
 }
 
-fn (g &FlatGen) unique_import_alias_module(alias string) ?string {
-	mut found := ''
-	suffix := '\n${alias}'
-	for key, module_name in g.tc.file_imports {
-		if !key.ends_with(suffix) {
-			continue
-		}
-		if found.len > 0 && found != module_name {
-			return none
-		}
-		found = module_name
+fn (g &FlatGen) current_file_import_alias_module(alias string) ?string {
+	if g.tc.cur_file.len == 0 {
+		return none
 	}
-	if found.len > 0 {
-		return found
-	}
-	return none
+	return g.tc.file_imports['${g.tc.cur_file}\n${alias}'] or { none }
 }
 
 fn optional_payload_is_bare_struct(t types.Type) bool {

--- a/vlib/v3/gen/c/types_test.v
+++ b/vlib/v3/gen/c/types_test.v
@@ -85,6 +85,7 @@ fn test_optional_payload_qualifies_concrete_generic_struct() {
 	tc.structs['async.Task_mcp__Response'] = []types.StructField{}
 	tc.structs['types.Array'] = []types.StructField{}
 	tc.file_imports['main.v\njson'] = 'json2'
+	tc.cur_file = 'main.v'
 	mut g := FlatGen.new()
 	g.a = ast
 	g.tc = &tc
@@ -111,6 +112,25 @@ fn test_optional_payload_qualifies_concrete_generic_struct() {
 	})
 	assert g.concrete_optional_type_name(result_type) == 'Optional_json2__StructKeyDecodeResult_TestEchoArgs'
 	assert g.needed_optional_types['Optional_json2__StructKeyDecodeResult_TestEchoArgs'] == 'json2__StructKeyDecodeResult_TestEchoArgs'
+}
+
+fn test_optional_payload_ignores_import_aliases_from_other_files() {
+	mut ast := &flat.FlatAst{}
+	mut tc := types.TypeChecker.new(ast)
+	tc.cur_file = 'json/any.v'
+	tc.structs['json.Any'] = []types.StructField{}
+	tc.structs['json2.Any'] = []types.StructField{}
+	tc.structs['AnyStruct[json.Any]'] = []types.StructField{}
+	tc.structs['AnyStruct[json2.Any]'] = []types.StructField{}
+	tc.file_imports['unrelated.v\njson'] = 'json2'
+	mut g := FlatGen.new()
+	g.a = ast
+	g.tc = &tc
+
+	alias_payload := g.optional_payload_c_type(types.Type(types.Struct{
+		name: 'main.AnyStruct[json.Any]'
+	}))
+	assert alias_payload == 'main__AnyStruct_json__Any'
 }
 
 fn test_optional_payload_qualifies_interface() {

--- a/vlib/v3/gen/c/types_test.v
+++ b/vlib/v3/gen/c/types_test.v
@@ -80,8 +80,11 @@ fn test_optional_payload_qualifies_concrete_generic_struct() {
 	mut ast := &flat.FlatAst{}
 	mut tc := types.TypeChecker.new(ast)
 	tc.structs['json2.StructKeyDecodeResult_TestEchoArgs'] = []types.StructField{}
+	tc.structs['AnyStruct[json2.Any]'] = []types.StructField{}
+	tc.struct_modules['AnyStruct[json2.Any]'] = 'main'
 	tc.structs['async.Task_mcp__Response'] = []types.StructField{}
 	tc.structs['types.Array'] = []types.StructField{}
+	tc.file_imports['main.v\njson'] = 'json2'
 	mut g := FlatGen.new()
 	g.a = ast
 	g.tc = &tc
@@ -96,6 +99,10 @@ fn test_optional_payload_qualifies_concrete_generic_struct() {
 	})
 	assert g.optional_payload_c_type(value_type) == 'json2__StructKeyDecodeResult_TestEchoArgs'
 	assert g.optional_payload_c_type(pointer_type) == 'async__Task_mcp__Response*'
+	alias_payload := g.optional_payload_c_type(types.Type(types.Struct{
+		name: 'main.AnyStruct[json.Any]'
+	}))
+	assert alias_payload == 'AnyStruct_json2__Any'
 	assert g.optional_payload_c_type(types.Type(types.Array{
 		elem_type: types.Type(types.int_)
 	})) == 'Array'
@@ -192,6 +199,30 @@ fn test_declaration_signature_scan_collects_specialized_fn_nodes() {
 
 	g.collect_declaration_signature_types()
 	assert 'Optional_Data' in g.needed_optional_types
+}
+
+fn test_specialized_signature_scan_uses_declaration_module() {
+	mut ast := flat.FlatAst.new()
+	fn_id := ast.add_node(flat.Node{
+		kind:  .fn_decl
+		value: 'QueryBuilder_Entity_update'
+		typ:   '!&QueryBuilder[Entity]'
+	})
+	ast.specialized_fn_nodes[int(fn_id)] = true
+	ast.specialized_fn_modules[int(fn_id)] = 'orm'
+	mut tc := types.TypeChecker.new(&ast)
+	tc.structs['Entity'] = []types.StructField{}
+	tc.structs['orm.QueryBuilder[Entity]'] = []types.StructField{}
+	tc.struct_modules['orm.QueryBuilder'] = 'orm'
+	tc.struct_modules['orm.QueryBuilder[Entity]'] = 'orm'
+	tc.struct_generic_params['orm.QueryBuilder'] = ['T']
+	mut g := FlatGen.new()
+	g.a = &ast
+	g.tc = &tc
+
+	g.collect_declaration_signature_types()
+	assert 'Optional_orm__QueryBuilder_Entityptr' in g.needed_optional_types
+	assert 'Optional_QueryBuilder_Entityptr' !in g.needed_optional_types
 }
 
 fn test_optional_value_info_preserves_pointer_payload_abi() {

--- a/vlib/v3/modulecache/modulecache.v
+++ b/vlib/v3/modulecache/modulecache.v
@@ -12,7 +12,7 @@ import v3.util
 pub const builtin_bundle_imports = ['strconv', 'strings', 'hash', 'math.bits']
 pub const builtin_bundle_modules = ['builtin', 'strconv', 'strings', 'hash', 'bits', 'math.bits']
 
-const cache_format = 'v3-module-cache-51'
+const cache_format = 'v3-module-cache-52'
 const c_body_begin = '/* V3CACHE_BODY_BEGIN */'
 const c_body_end = '/* V3CACHE_BODY_END */'
 const c_module_prefix = '/* V3CACHE_MODULE '
@@ -4311,6 +4311,85 @@ fn c_line_braces(line string, initial_block_comment bool) (int, bool, bool, u8, 
 
 // module_header serializes the declaration-only interface for one flat-AST module.
 pub fn module_header(a &flat.FlatAst, tc &types.TypeChecker, module_name string, vroot string, import_paths map[string]string) string {
+	return module_header_with_const_order(a, tc, module_name, vroot, import_paths, []string{})
+}
+
+struct ModuleHeaderConstDecl {
+	id      flat.NodeId
+	rank    int
+	ordinal int
+}
+
+fn module_header_const_storage_name(module_name string, name string) string {
+	if module_name.len > 0 && module_name !in ['main', 'builtin'] && !name.contains('.') {
+		return '${module_name}.${name}'
+	}
+	return name
+}
+
+fn module_header_const_replacements(a &flat.FlatAst, module_name string, const_order []string) (map[int]flat.NodeId, map[int]string) {
+	mut replacements := map[int]flat.NodeId{}
+	mut files := map[int]string{}
+	if const_order.len == 0 {
+		return replacements, files
+	}
+	mut ranks := map[string]int{}
+	for i, name in const_order {
+		ranks[name] = i
+	}
+	mut declarations := []ModuleHeaderConstDecl{}
+	for file_node in a.nodes {
+		if file_node.kind != .file || file_node.children_count == 0
+			|| file_module_name(a, file_node) != module_name {
+			continue
+		}
+		for i in 0 .. file_node.children_count {
+			mut decl_ids := []flat.NodeId{}
+			append_declaration_nodes(a, a.child(&file_node, i), mut decl_ids)
+			for id in decl_ids {
+				node := a.nodes[int(id)]
+				if node.kind != .const_decl {
+					continue
+				}
+				mut rank := const_order.len + declarations.len
+				for j in 0 .. node.children_count {
+					field := a.child_node(&node, j)
+					name := module_header_const_storage_name(module_name, field.value)
+					if field_rank := ranks[name] {
+						if field_rank < rank {
+							rank = field_rank
+						}
+					}
+				}
+				files[int(id)] = file_node.value
+				declarations << ModuleHeaderConstDecl{
+					id:      id
+					rank:    rank
+					ordinal: declarations.len
+				}
+			}
+		}
+	}
+	mut ordered := declarations.clone()
+	for i := 1; i < ordered.len; i++ {
+		current := ordered[i]
+		mut j := i
+		for j > 0 && (current.rank < ordered[j - 1].rank
+			|| (current.rank == ordered[j - 1].rank && current.ordinal < ordered[j - 1].ordinal)) {
+			ordered[j] = ordered[j - 1]
+			j--
+		}
+		ordered[j] = current
+	}
+	for i, declaration in declarations {
+		replacements[int(declaration.id)] = ordered[i].id
+	}
+	return replacements, files
+}
+
+// module_header_with_const_order preserves dependency ordering for runtime
+// constants whose helper bodies are intentionally omitted from warm headers.
+pub fn module_header_with_const_order(a &flat.FlatAst, tc &types.TypeChecker, module_name string, vroot string, import_paths map[string]string, const_order []string) string {
 	mut out := strings.new_builder(4096)
 	out.writeln('module ${module_name.all_after_last('.')}')
 	generic_specialization_callees := generic_specialization_callee_names(tc)
@@ -4342,6 +4421,7 @@ pub fn module_header(a &flat.FlatAst, tc &types.TypeChecker, module_name string,
 	}
 	mut seen := map[string]bool{}
 	declaration_attrs := cached_declaration_attrs(a)
+	const_replacements, const_files := module_header_const_replacements(a, module_name, const_order)
 	for file_node in a.nodes {
 		if file_node.kind != .file || file_node.children_count == 0 {
 			continue
@@ -4354,7 +4434,9 @@ pub fn module_header(a &flat.FlatAst, tc &types.TypeChecker, module_name string,
 			mut decl_ids := []flat.NodeId{}
 			append_declaration_nodes(a, a.child(&file_node, i), mut decl_ids)
 			for id in decl_ids {
-				node := a.nodes[int(id)]
+				effective_id := const_replacements[int(id)] or { id }
+				node := a.nodes[int(effective_id)]
+				source_file := const_files[int(effective_id)] or { file_node.value }
 				if node.kind == .module_decl {
 					continue
 				}
@@ -4362,14 +4444,14 @@ pub fn module_header(a &flat.FlatAst, tc &types.TypeChecker, module_name string,
 				if key.len > 0 && seen[key] {
 					continue
 				}
-				attrs := declaration_attrs[int(id)] or { CachedDeclarationAttrs{} }
-				needs_declaration_source := declaration_node_needs_source(a, id)
-					|| node_creates_generic_specialization(a, tc, id, generic_specialization_callees)
+				attrs := declaration_attrs[int(effective_id)] or { CachedDeclarationAttrs{} }
+				needs_declaration_source := declaration_node_needs_source(a, effective_id)
+					|| node_creates_generic_specialization(a, tc, effective_id, generic_specialization_callees)
 				source_embedded := embed_source_bodies && needs_declaration_source
-					&& declaration_node_source_is_embeddable(a, id)
-				source_attrs_text := declaration_source_attrs_text(a, node, file_node.value, mut
+					&& declaration_node_source_is_embeddable(a, effective_id)
+				source_attrs_text := declaration_source_attrs_text(a, node, source_file, mut
 					source_cache)
-				source_is_public := declaration_source_is_public(a, node, file_node.value, mut
+				source_is_public := declaration_source_is_public(a, node, source_file, mut
 					source_cache)
 				mut effective_attrs := attrs.attrs.clone()
 				for source_attr in declaration_source_attr_values(source_attrs_text) {
@@ -4378,12 +4460,12 @@ pub fn module_header(a &flat.FlatAst, tc &types.TypeChecker, module_name string,
 					}
 				}
 				mut text := if source_embedded {
-					raw_source := declaration_source_with_line(a, node, file_node.value, mut
+					raw_source := declaration_source_with_line(a, node, source_file, mut
 						source_cache) or { CachedDeclarationSource{} }
-					cached_embedded_declaration_source(raw_source.text, vroot, file_node.value,
+					cached_embedded_declaration_source(raw_source.text, vroot, source_file,
 						raw_source.line)
 				} else {
-					decl_text(a, tc, module_name, node, vroot, file_node.value, import_paths,
+					decl_text(a, tc, module_name, node, vroot, source_file, import_paths,
 						effective_attrs, source_is_public)
 				}
 				if text.len == 0 {

--- a/vlib/v3/tests/comptime_review_round4_test.v
+++ b/vlib/v3/tests/comptime_review_round4_test.v
@@ -1787,6 +1787,38 @@ fn main() {
 	assert out == 'params:empty|args:one'
 }
 
+fn test_comptime_method_calls_accept_spread_and_variadic_arity() {
+	v3_bin := round4_build_v3()
+	out := round4_run_good(v3_bin, 'method_call_spread_and_variadic_arity', 'struct Calls {}
+
+fn (calls Calls) fixed(value string, count int) string {
+	_ = calls
+	return value.repeat(count)
+}
+
+fn (calls Calls) variadic(values ...string) string {
+	_ = calls
+	return values.join("")
+}
+
+fn main() {
+	calls := Calls{}
+	mut rows := []string{}
+	$for method in Calls.methods {
+		$if method.name == "fixed" {
+			args := ["x", "3"]
+			rows << calls.$method(...args)
+		}
+		$if method.name == "variadic" {
+			rows << calls.$method("a", "b")
+		}
+	}
+	println(rows.join("|"))
+}
+')
+	assert out == 'xxx|ab'
+}
+
 fn test_method_metadata_locations_are_materialized() {
 	v3_bin := round4_build_v3()
 	out := round4_run_good(v3_bin, 'method_metadata_location', 'struct Located {}

--- a/vlib/v3/tests/map_for_mut_snapshot_codegen_test.v
+++ b/vlib/v3/tests/map_for_mut_snapshot_codegen_test.v
@@ -23,7 +23,7 @@ fn map_for_mut_run_good(v3_bin string, name string, source string) string {
 	bin := os.join_path(os.temp_dir(), 'v3_${name}_${os.getpid()}')
 	os.rm(bin) or {}
 	os.rm(bin + '.c') or {}
-	compile := os.execute('${v3_bin} ${src} -b c -o ${bin}')
+	compile := os.execute('${v3_bin} -enable-globals -b c -o ${bin} ${src}')
 	assert compile.exit_code == 0, compile.output
 	assert !compile.output.contains('C compilation failed'), compile.output
 	run := os.execute(bin)
@@ -47,6 +47,31 @@ fn test_mut_map_iteration_snapshot_updates_original_values() {
 	b := m["b"] or { 0 }
 	assert a == 2
 	assert b == 2
+	println("ok")
+}
+')
+	assert out == 'ok'
+}
+
+fn test_mut_pointer_map_iteration_replaces_stored_pointer() {
+	v3_bin := map_for_mut_build_v3()
+	out := map_for_mut_run_good(v3_bin, 'map_for_mut_pointer_replaces_slot', 'struct Item {
+	value int
+}
+
+fn main() {
+	first := &Item{value: 1}
+	replacement := &Item{value: 2}
+	mut values := map[string]&Item{}
+	values["item"] = first
+	for _, mut item in values {
+		assert item.value == 1
+		item = replacement
+		assert item.value == 2
+	}
+	stored := values["item"] or { &Item{} }
+	assert stored == replacement
+	assert stored.value == 2
 	println("ok")
 }
 ')

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -220,6 +220,53 @@ fn main() {
 	assert run_module_cache_binary(second_output) == 'V3_CACHE_SYNC_OK'
 }
 
+fn test_warm_cached_module_preserves_runtime_const_dependency_order() {
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_cached_runtime_const_order_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	write_module_cache_file(root, 'ordered/a_consumer.v', 'module ordered
+
+const value = make_value()
+
+fn make_value() int {
+	return dependency + 1
+}
+
+pub fn result() int {
+	return value
+}
+')
+	write_module_cache_file(root, 'ordered/z_dependency.v', 'module ordered
+
+const dependency = make_dependency()
+
+fn make_dependency() int {
+	return 41
+}
+')
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'module main
+
+import ordered
+
+fn main() {
+	println(ordered.result())
+}
+')
+	cache_dir := os.join_path(root, 'cache')
+	first_output := os.join_path(root, 'first')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, first_output)
+	assert run_module_cache_binary(first_output) == '42'
+
+	second_output := os.join_path(root, 'second')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, second_output)
+	assert run_module_cache_binary(second_output) == '42'
+}
+
 fn test_cached_program_preserves_selective_import_call_target() {
 	v3_bin := build_module_cache_v3()
 	root := os.join_path(os.temp_dir(), 'v3_cached_selective_import_${os.getpid()}')

--- a/vlib/v3/tests/mut_param_reassign_codegen_test.v
+++ b/vlib/v3/tests/mut_param_reassign_codegen_test.v
@@ -471,6 +471,41 @@ fn main() {
 	assert c_source.contains('((*(*value)))++;'), 'missing standalone postfix dereference'
 }
 
+fn test_generic_mut_sum_parameter_forwards_existing_pointer() {
+	v3_bin := mut_param_reassign_build_v3()
+	out, c_source := mut_param_reassign_run_good_with_c(v3_bin, 'generic_mut_sum_forward', 'struct Cat {
+	name string
+}
+
+struct Dog {
+	name string
+}
+
+type Animal = Cat | Dog
+
+fn replace[T](mut value T, replacement T) {
+	value = replacement
+}
+
+fn decode[T](mut value T, replacement T) {
+	replace(mut value, replacement)
+}
+
+fn main() {
+	mut animal := Animal(Dog{
+		name: "Rex"
+	})
+	decode(mut animal, Animal(Cat{
+		name: "Tom"
+	}))
+	println(animal)
+}
+')
+	assert out == "Animal(Cat{\n    name: 'Tom'\n})"
+	assert c_source.contains('replace_T_Animal(value, replacement);')
+	assert !c_source.contains('replace_T_Animal(&value, replacement);')
+}
+
 fn test_mut_param_reassign_keeps_invalid_assignments_rejected() {
 	v3_bin := mut_param_reassign_build_v3()
 	mut_param_reassign_run_bad(v3_bin, 'bad_same_scope_mut_string_param_redeclare', "struct Text {

--- a/vlib/v3/tests/ownership_result_sentinel_codegen_test.v
+++ b/vlib/v3/tests/ownership_result_sentinel_codegen_test.v
@@ -19,4 +19,17 @@ fn test_ownership_generated_result_cleanup_roots_ierror_sentinels() {
 		os.execute('${v3_bin} -ownership -d ownership -no-parallel -macos-v3-compat-c99 run ${source}')
 	assert out.exit_code == 0, out.output
 	assert out.output.contains('\nok\n'), out.output
+
+	os.write_file(source,
+		"fn main() {\n\t\$if ownership ? {\n\t\tprintln('ownership')\n\t} \$else {\n\t\tprintln('standard')\n\t}\n}\n")!
+	autofree := os.execute('${v3_bin} -ownership -autofree -d ownership -no-parallel run ${source}')
+	assert autofree.exit_code == 0, autofree.output
+	assert autofree.output.contains('\nownership\n'), autofree.output
+
+	os.write_file(source,
+		"fn make_value() !string {\n\terror('discarded')\n\treturn 'ok'\n}\n\nfn main() {\n\tprintln(make_value() or { panic(err) })\n}\n")!
+	discarded_error :=
+		os.execute('${v3_bin} -ownership -autofree -d ownership -no-parallel run ${source}')
+	assert discarded_error.exit_code == 0, discarded_error.output
+	assert discarded_error.output.contains('\nok\n'), discarded_error.output
 }

--- a/vlib/v3/tests/transformer_parity_test.v
+++ b/vlib/v3/tests/transformer_parity_test.v
@@ -615,6 +615,31 @@ fn main() {
 	assert if_count == 1
 }
 
+fn test_statement_match_trailing_or_lowers_before_codegen() {
+	a := parse_checked_transform_source('
+fn result_int() !int {
+	return 1
+}
+
+fn main() {
+	match result_int() {
+		0, 1 {}
+		else {}
+	} or { 0 }
+}
+')
+	main_fn := find_fn(a, 'main')
+	mut or_count := 0
+	mut if_count := 0
+	for i in 0 .. main_fn.children_count {
+		child_id := a.child(&main_fn, i)
+		or_count += count_kind(a, child_id, .or_expr)
+		if_count += count_kind(a, child_id, .if_expr)
+	}
+	assert or_count == 0
+	assert if_count > 0
+}
+
 // test_map_index_or_lowers_to_get_check validates this v3 regression case.
 fn test_map_index_or_lowers_to_get_check() {
 	a := parse_transform_source('

--- a/vlib/v3/transform/comptime.v
+++ b/vlib/v3/transform/comptime.v
@@ -1240,6 +1240,19 @@ fn (mut t Transformer) clone_method_subst(id flat.NodeId, var_name string, metho
 	return t.clone_method_subst_scoped(id, var_name, method, []string{})
 }
 
+fn (t &Transformer) comptime_method_call_arity_matches(node flat.Node, method MethodMeta) bool {
+	for i in 1 .. node.children_count {
+		if t.call_arg_is_spread(t.a.child(&node, i)) {
+			return true
+		}
+	}
+	actual_count := int(node.children_count) - 1
+	if method.params.len > 0 && method.params[method.params.len - 1].typ.starts_with('...') {
+		return actual_count >= method.params.len - 1
+	}
+	return actual_count == method.params.len
+}
+
 fn (mut t Transformer) clone_method_subst_scoped(id flat.NodeId, var_name string, method MethodMeta, inner_vars []string) ?flat.NodeId {
 	if int(id) < 0 {
 		return id
@@ -1260,7 +1273,7 @@ fn (mut t Transformer) clone_method_subst_scoped(id flat.NodeId, var_name string
 		callee := t.a.child_node(&node, 0)
 		if callee.kind == .selector && callee.value == '$' && callee.children_count >= 2
 			&& t.comptime_method_name_expr_matches(t.a.child(callee, 1), var_name)
-			&& int(node.children_count) - 1 != method.params.len {
+			&& !t.comptime_method_call_arity_matches(node, method) {
 			// A `$method` call can appear in the runtime branch paired with a
 			// method-metadata condition. V1 leaves that branch in place but skips
 			// specializations whose argument list cannot call the current method.

--- a/vlib/v3/transform/comptime.v
+++ b/vlib/v3/transform/comptime.v
@@ -1256,6 +1256,17 @@ fn (mut t Transformer) clone_method_subst_scoped(id flat.NodeId, var_name string
 			return t.make_param_data_literal_in_module(method.params[idx], method.module_name)
 		}
 	}
+	if node.kind == .call && node.children_count > 0 {
+		callee := t.a.child_node(&node, 0)
+		if callee.kind == .selector && callee.value == '$' && callee.children_count >= 2
+			&& t.comptime_method_name_expr_matches(t.a.child(callee, 1), var_name)
+			&& int(node.children_count) - 1 != method.params.len {
+			// A `$method` call can appear in the runtime branch paired with a
+			// method-metadata condition. V1 leaves that branch in place but skips
+			// specializations whose argument list cannot call the current method.
+			return none
+		}
+	}
 	if node.kind == .selector && node.value == '$' && node.children_count >= 2
 		&& t.comptime_method_name_expr_matches(t.a.child(&node, 1), var_name) {
 		receiver := t.clone_method_subst_scoped(t.a.child(&node, 0), var_name, method, inner_vars) or {
@@ -1371,12 +1382,52 @@ fn (t &Transformer) method_if_condition_value(id flat.NodeId, var_name string, m
 		}
 		return t.method_if_condition_value(t.a.child(&node, 1), var_name, method)
 	}
+	if node.op in [.eq, .ne, .lt, .gt, .le, .ge] {
+		if left := t.method_const_int_value(t.a.child(&node, 0), var_name, method) {
+			if right := t.method_const_int_value(t.a.child(&node, 1), var_name, method) {
+				return match node.op {
+					.eq { left == right }
+					.ne { left != right }
+					.lt { left < right }
+					.gt { left > right }
+					.le { left <= right }
+					.ge { left >= right }
+					else { false }
+				}
+			}
+		}
+	}
 	if node.op !in [.eq, .ne] {
 		return none
 	}
 	left := t.method_const_string_value(t.a.child(&node, 0), var_name, method) or { return none }
 	right := t.method_const_string_value(t.a.child(&node, 1), var_name, method) or { return none }
 	return if node.op == .eq { left == right } else { left != right }
+}
+
+fn (t &Transformer) method_const_int_value(id flat.NodeId, var_name string, method MethodMeta) ?int {
+	if int(id) < 0 || int(id) >= t.a.nodes.len {
+		return none
+	}
+	node := t.a.nodes[int(id)]
+	if node.kind in [.paren, .expr_stmt] && node.children_count > 0 {
+		return t.method_const_int_value(t.a.child(&node, 0), var_name, method)
+	}
+	if node.kind == .int_literal {
+		return node.value.int()
+	}
+	if node.kind != .selector || node.value != 'len' || node.children_count == 0 {
+		return none
+	}
+	params := t.a.child_node(&node, 0)
+	if params.kind != .selector || params.value !in ['args', 'params'] || params.children_count == 0 {
+		return none
+	}
+	owner := t.a.child_node(params, 0)
+	if owner.kind == .ident && owner.value == var_name {
+		return method.params.len
+	}
+	return none
 }
 
 fn (t &Transformer) method_const_string_value(id flat.NodeId, var_name string, method MethodMeta) ?string {

--- a/vlib/v3/transform/expr.v
+++ b/vlib/v3/transform/expr.v
@@ -2715,20 +2715,21 @@ fn (mut t Transformer) make_sum_semantic_eq_expr(lhs flat.NodeId, rhs flat.NodeI
 	if variants.len == 0 {
 		return t.make_memcmp_eq_expr(lhs, rhs, sum_type, 'eq')
 	}
-	helper := sum_eq_helper_name(clean_sum)
-	if clean_sum !in t.sum_eq_types {
-		// A concrete generic specialization is emitted in main even while it is
-		// transformed under its declaring module's type-resolution context.
-		helper_module := if t.sum_eq_helper_module.len > 0 {
-			t.sum_eq_helper_module
-		} else if t.validating_generic_spec {
-			'main'
-		} else if t.cur_module.len > 0 {
-			t.cur_module
-		} else {
-			'main'
-		}
-		t.sum_eq_types[clean_sum] = SumEqRequest{
+	// A concrete generic specialization is emitted in main even while it is
+	// transformed under its declaring module's type-resolution context.
+	helper_module := if t.sum_eq_helper_module.len > 0 {
+		t.sum_eq_helper_module
+	} else if t.validating_generic_spec {
+		'main'
+	} else if t.cur_module.len > 0 {
+		t.cur_module
+	} else {
+		'main'
+	}
+	helper := sum_eq_helper_name_in_module(clean_sum, helper_module)
+	if helper !in t.sum_eq_types {
+		t.sum_eq_types[helper] = SumEqRequest{
+			sum_name:      clean_sum
 			module:        t.cur_module
 			file:          t.cur_file
 			helper_module: helper_module
@@ -2775,6 +2776,16 @@ pub fn sum_eq_helper_name(sum_name string) string {
 	return '__v3_sum_eq_${c_name(sum_name)}'
 }
 
+// sum_eq_helper_name_in_module keeps program-specific helpers distinct from the
+// same stable helper already supplied by an imported module-cache object.
+fn sum_eq_helper_name_in_module(sum_name string, helper_module string) string {
+	base := sum_eq_helper_name(sum_name)
+	if helper_module == 'main' {
+		return '${base}__v3_program'
+	}
+	return base
+}
+
 // synthesize_sum_eq_helpers generates the fn_decl for every sum type whose
 // equality helper was requested during the transform. Building one helper body
 // can request helpers for nested sum types, so this drains a worklist. Runs
@@ -2794,24 +2805,26 @@ pub fn (mut t Transformer) synthesize_sum_eq_helpers() []string {
 	t.used_fns_log_active = true
 	for {
 		mut pending := []string{}
-		for name, _ in t.sum_eq_types {
-			if name in t.sum_eq_synthesized {
+		for helper, req in t.sum_eq_types {
+			if helper in t.sum_eq_synthesized {
 				continue
 			}
-			if sum_eq_helper_name(name) in t.fn_ret_types {
+			if helper in t.fn_ret_types {
 				// already synthesized by an earlier Transformer over this AST
-				t.sum_eq_synthesized[name] = true
+				t.sum_eq_synthesized[helper] = true
 				continue
 			}
-			pending << name
+			if req.sum_name.len > 0 {
+				pending << helper
+			}
 		}
 		if pending.len == 0 {
 			break
 		}
 		pending.sort()
-		for name in pending {
-			t.sum_eq_synthesized[name] = true
-			req := t.sum_eq_types[name] or { SumEqRequest{} }
+		for helper in pending {
+			t.sum_eq_synthesized[helper] = true
+			req := t.sum_eq_types[helper] or { SumEqRequest{} }
 			t.cur_module = req.module
 			t.cur_file = req.file
 			t.sum_eq_helper_module = if req.helper_module.len > 0 {
@@ -2825,7 +2838,7 @@ pub fn (mut t Transformer) synthesize_sum_eq_helpers() []string {
 				t.tc.cur_module = req.module
 				t.tc.cur_file = req.file
 			}
-			t.build_sum_eq_helper_fn(name)
+			t.build_sum_eq_helper_fn(req.sum_name, helper)
 		}
 	}
 	mut new_names := []string{}
@@ -2855,12 +2868,11 @@ pub fn (mut t Transformer) synthesize_sum_eq_helpers() []string {
 // AST: tags must match, then the active variant's payload is unboxed and compared
 // by value (recursing through the usual membership-eq machinery, which routes
 // nested sum types back through their own helpers).
-fn (mut t Transformer) build_sum_eq_helper_fn(clean_sum string) {
+fn (mut t Transformer) build_sum_eq_helper_fn(clean_sum string, helper string) {
 	variants := t.sum_eq_variants(clean_sum) or { return }
 	if variants.len == 0 {
 		return
 	}
-	helper := sum_eq_helper_name(clean_sum)
 	saved_pending := t.pending_stmts
 	t.pending_stmts = []flat.NodeId{}
 	param_a := t.a.add_node(flat.Node{

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -11265,7 +11265,7 @@ fn (mut t Transformer) try_lower_generic_named_type_cast_call(node flat.Node) ?f
 	fn_node := t.a.node(fn_id)
 	// A monomorphized method callee such as `Tree[int].size` contains a generic
 	// type spelling, but it is a function name rather than a named-type cast.
-	if fn_node.kind == .ident && !fn_node.value.trim_space().ends_with(']') {
+	if fn_node.kind == .ident && t.generic_callee_is_specialization(fn_node.value) {
 		return none
 	}
 	target := t.generic_call_type_arg_name(fn_id)
@@ -11294,8 +11294,7 @@ fn (t &Transformer) generic_sum_constructor_call_type(node flat.Node) ?string {
 		return none
 	}
 	fn_node := t.a.nodes[int(fn_id)]
-	if fn_node.kind == .ident && fn_node.value.contains(']')
-		&& !fn_node.value.trim_space().ends_with(']') {
+	if fn_node.kind == .ident && t.generic_callee_is_specialization(fn_node.value) {
 		return none
 	}
 	mut target := ''

--- a/vlib/v3/transform/fn_test.v
+++ b/vlib/v3/transform/fn_test.v
@@ -199,6 +199,30 @@ fn test_auto_str_helper_call_uses_type_owner_module() {
 	assert t.auto_str_types['v.token.Pos'].helper_module == 'token'
 }
 
+fn test_program_sum_equality_helper_does_not_collide_with_cached_module_helper() {
+	mut a := flat.FlatAst.new()
+	mut tc := types.TypeChecker.new(&a)
+	mut t := new_transformer(mut a, &tc, map[string]bool{})
+	t.sum_types['orm.Primitive'] = ['orm.Null', 'bool']
+	t.cur_module = 'orm'
+	t.cur_file = 'orm.v'
+	lhs := t.make_ident('lhs')
+	rhs := t.make_ident('rhs')
+	t.set_node_typ(int(lhs), 'orm.Primitive')
+	t.set_node_typ(int(rhs), 'orm.Primitive')
+	t.make_sum_semantic_eq_expr(lhs, rhs, 'orm.Primitive', []string{})
+
+	t.sum_eq_helper_module = 'main'
+	t.make_sum_semantic_eq_expr(lhs, rhs, 'orm.Primitive', []string{})
+
+	module_helper := sum_eq_helper_name('orm.Primitive')
+	program_helper := '${module_helper}__v3_program'
+	assert module_helper in t.sum_eq_types
+	assert program_helper in t.sum_eq_types
+	assert t.sum_eq_types[module_helper].helper_module == 'orm'
+	assert t.sum_eq_types[program_helper].helper_module == 'main'
+}
+
 fn test_large_recursive_pointer_auto_str_stops_before_expanding_back_edge() {
 	mut a := flat.FlatAst.new()
 	mut tc := types.TypeChecker.new(&a)
@@ -326,6 +350,33 @@ fn test_lowered_generic_operator_call_records_operator_use() {
 		lowered_operator_uses)
 	assert t.used_struct_operator_fns['Box[int].+']
 	assert t.used_struct_operator_fns['Box_int__plus']
+}
+
+fn test_specialized_zero_arg_method_is_not_lowered_as_generic_cast() {
+	mut a := flat.FlatAst.new()
+	callee_id := a.add_node(flat.Node{
+		kind:  .ident
+		value: 'Tree_f64.min'
+	})
+	receiver_id := a.add_node(flat.Node{
+		kind: .ident
+		typ:  'Tree[f64]'
+	})
+	children_start := a.children.len
+	a.children << callee_id
+	a.children << receiver_id
+	call := flat.Node{
+		kind:           .call
+		children_start: children_start
+		children_count: 2
+		value:          'f64'
+	}
+	mut tc := types.TypeChecker.new(&a)
+	tc.specialized_generic_fns['Tree_f64.min'] = true
+	mut t := new_transformer(mut a, &tc, map[string]bool{})
+
+	assert t.try_lower_generic_sum_constructor_call(call) == none
+	assert t.try_lower_generic_named_type_cast_call(call) == none
 }
 
 fn test_typeof_display_canonicalizes_fixed_array_map_values() {

--- a/vlib/v3/transform/for.v
+++ b/vlib/v3/transform/for.v
@@ -597,6 +597,7 @@ fn (mut t Transformer) rebuild_for_in_stmt(_id flat.NodeId, node flat.Node) []fl
 	}
 	mut transformed_body := []flat.NodeId{}
 	mut pointer_value_name := ''
+	mut pointer_value_reads_pointee := true
 	if node.op == .amp {
 		bind_id := if has_index { val_id } else { key_id }
 		if int(bind_id) >= 0 {
@@ -605,6 +606,15 @@ fn (mut t Transformer) rebuild_for_in_stmt(_id flat.NodeId, node flat.Node) []fl
 				bind_type := t.var_type(bind.value)
 				if bind_type.starts_with('&') && !t.is_fixed_array_type(bind_type[1..]) {
 					pointer_value_name = bind.value
+					elem_type := if map_iter_type.starts_with('map[') {
+						t.map_value_type(map_iter_type)
+					} else {
+						t.infer_for_in_elem_type(iter_type, node)
+					}
+					// `for mut value in map[K]&T` stores `&T` directly. Selectors
+					// and pointer-valued RHS uses must therefore keep the pointer;
+					// only assignments to the mutable binding write through it.
+					pointer_value_reads_pointee = !t.normalize_type_alias(elem_type).starts_with('&')
 				}
 			}
 		}
@@ -613,7 +623,11 @@ fn (mut t Transformer) rebuild_for_in_stmt(_id flat.NodeId, node flat.Node) []fl
 		had_pointer_value_lvalue := t.pointer_value_lvalues[pointer_value_name] or { false }
 		had_pointer_value_rvalue := t.pointer_value_rvalues[pointer_value_name] or { false }
 		t.pointer_value_lvalues[pointer_value_name] = true
-		t.pointer_value_rvalues[pointer_value_name] = true
+		if pointer_value_reads_pointee {
+			t.pointer_value_rvalues[pointer_value_name] = true
+		} else {
+			t.pointer_value_rvalues.delete(pointer_value_name)
+		}
 		transformed_body = t.transform_stmts(body_ids)
 		if had_pointer_value_lvalue {
 			t.pointer_value_lvalues[pointer_value_name] = true

--- a/vlib/v3/transform/for.v
+++ b/vlib/v3/transform/for.v
@@ -597,7 +597,6 @@ fn (mut t Transformer) rebuild_for_in_stmt(_id flat.NodeId, node flat.Node) []fl
 	}
 	mut transformed_body := []flat.NodeId{}
 	mut pointer_value_name := ''
-	mut pointer_value_reads_pointee := true
 	if node.op == .amp {
 		bind_id := if has_index { val_id } else { key_id }
 		if int(bind_id) >= 0 {
@@ -606,15 +605,6 @@ fn (mut t Transformer) rebuild_for_in_stmt(_id flat.NodeId, node flat.Node) []fl
 				bind_type := t.var_type(bind.value)
 				if bind_type.starts_with('&') && !t.is_fixed_array_type(bind_type[1..]) {
 					pointer_value_name = bind.value
-					elem_type := if map_iter_type.starts_with('map[') {
-						t.map_value_type(map_iter_type)
-					} else {
-						t.infer_for_in_elem_type(iter_type, node)
-					}
-					// `for mut value in map[K]&T` stores `&T` directly. Selectors
-					// and pointer-valued RHS uses must therefore keep the pointer;
-					// only assignments to the mutable binding write through it.
-					pointer_value_reads_pointee = !t.normalize_type_alias(elem_type).starts_with('&')
 				}
 			}
 		}
@@ -623,11 +613,7 @@ fn (mut t Transformer) rebuild_for_in_stmt(_id flat.NodeId, node flat.Node) []fl
 		had_pointer_value_lvalue := t.pointer_value_lvalues[pointer_value_name] or { false }
 		had_pointer_value_rvalue := t.pointer_value_rvalues[pointer_value_name] or { false }
 		t.pointer_value_lvalues[pointer_value_name] = true
-		if pointer_value_reads_pointee {
-			t.pointer_value_rvalues[pointer_value_name] = true
-		} else {
-			t.pointer_value_rvalues.delete(pointer_value_name)
-		}
+		t.pointer_value_rvalues[pointer_value_name] = true
 		transformed_body = t.transform_stmts(body_ids)
 		if had_pointer_value_lvalue {
 			t.pointer_value_lvalues[pointer_value_name] = true

--- a/vlib/v3/transform/interface.v
+++ b/vlib/v3/transform/interface.v
@@ -713,12 +713,21 @@ fn (mut t Transformer) make_interface_literal_from_expr(id flat.NodeId, iface_na
 	if adjusted := t.mut_param_address_source_type(id) {
 		source_type = adjusted
 	}
+	source_node := t.a.nodes[int(source_id)]
+	source_is_mut_pointer_slot := source_node.kind == .ident
+		&& t.pointer_value_rvalues[source_node.value]
+		&& t.var_type(source_node.value).starts_with('&&')
+	if source_is_mut_pointer_slot {
+		// `mut p &T` has `&&T` storage but its expression value is `&T`.
+		source_type = t.var_type(source_node.value)[1..]
+	}
 	if source_type.len == 0 {
 		return none
 	}
 	source_expr := if source_is_heaped_amp_child || source_type.starts_with('&') {
 		source := t.a.nodes[int(source_id)]
 		had_rvalue := source.kind == .ident && source.value in t.pointer_value_rvalues
+			&& !source_is_mut_pointer_slot
 		if had_rvalue {
 			t.pointer_value_rvalues.delete(source.value)
 		}

--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -356,10 +356,11 @@ fn (mut t Transformer) monomorphize_pass() []string {
 			match node.kind {
 				.call {
 					if t.node_file_or(i, '').len == 0 && i !in t.generic_call_spec_cache
-						&& !t.synthetic_generic_call_has_exact_callee(node) {
+						&& !t.synthetic_generic_call_has_exact_identity(node) {
 						continue
 					}
-					if !t.call_name_can_target_generic(node) && i !in t.generic_call_spec_cache {
+					if !t.call_name_can_target_generic(node) && i !in t.generic_call_spec_cache
+						&& !t.synthetic_generic_call_has_exact_identity(node) {
 						continue
 					}
 					if t.call_is_recorded_struct_operator(node)
@@ -2945,10 +2946,11 @@ fn (mut t Transformer) collect_generic_struct_spec_from_type(typ string, module_
 		t.record_generic_specialization_args_in_module(spec_base, spec_module, scoped_args)
 		return
 	}
-	base, args, ok := generic_app_parts(clean)
+	base, raw_args, ok := generic_app_parts(clean)
 	if !ok {
 		return
 	}
+	args := t.canonical_generic_specialization_args(raw_args)
 	for arg in args {
 		t.collect_generic_struct_spec_from_type(arg, module_name, file_name, decls, mut specs)
 	}
@@ -3537,6 +3539,15 @@ fn (t &Transformer) node_module_or(idx int, fallback string) string {
 		if module_name.len > 0 {
 			return module_name
 		}
+		if !isnil(t.tc) && idx < t.node_file_map_cache.len {
+			file_name := t.node_file_map_cache[idx]
+			if source_module := t.tc.file_modules[file_name] {
+				return source_module
+			}
+			if file_name.len > 0 {
+				return 'main'
+			}
+		}
 	}
 	return fallback
 }
@@ -3781,7 +3792,7 @@ fn (mut t Transformer) transform_specialized_fn_body(clone_id flat.NodeId, modul
 	old_is_generic := t.cur_fn_is_generic
 	old_generic_params := t.active_generic_params
 	old_specialization_args := t.active_specialization_args
-	old_specialization_main_types := t.active_specialization_main_types.clone()
+	mut old_specialization_main_types := t.active_specialization_main_types.clone()
 	t.active_generic_params = params
 	t.active_specialization_args = args
 	t.active_specialization_main_types = t.specialization_main_type_closure(args)
@@ -4326,8 +4337,15 @@ fn (mut t Transformer) register_specialized_fn_signature_value(decl GenericFnDec
 	old_tc_file := if isnil(t.tc) { '' } else { t.tc.cur_file }
 	old_specialization_args := t.active_specialization_args
 	mut old_specialization_main_types := t.active_specialization_main_types.move()
-	t.active_specialization_args = args
-	t.active_specialization_main_types = t.specialization_main_type_closure(args)
+	concrete_args := t.canonical_generic_specialization_args(args)
+	t.active_specialization_args = concrete_args
+	mut caller_main_types := t.specialization_main_type_closure(concrete_args)
+	if old_module in ['', 'main'] {
+		for arg in concrete_args {
+			t.collect_caller_main_type_names(arg, mut caller_main_types)
+		}
+	}
+	t.active_specialization_main_types = caller_main_types.move()
 	t.cur_module = decl.module
 	t.cur_file = decl.file
 	if !isnil(t.tc) {
@@ -4335,7 +4353,8 @@ fn (mut t Transformer) register_specialized_fn_signature_value(decl GenericFnDec
 		t.tc.cur_file = decl.file
 	}
 	generic_params := t.generic_fn_param_names(decl.node, decl.module)
-	ret_name := t.specialized_signature_type_text(decl, t.generic_fn_return_type_text(decl), args,
+	ret_name := t.specialized_signature_type_text(decl, t.generic_fn_return_type_text(decl),
+		concrete_args,
 		generic_params)
 	ret := if !isnil(t.tc) {
 		t.tc.parse_resolution_type(ret_name)
@@ -4353,7 +4372,7 @@ fn (mut t Transformer) register_specialized_fn_signature_value(decl GenericFnDec
 			continue
 		}
 		param_type := explicit_mut_pointer_param_type_text(child, t.specialized_signature_type_text(decl,
-			child.typ, args, generic_params))
+			child.typ, concrete_args, generic_params))
 		if param_type.starts_with('...') {
 			variadic = true
 		}
@@ -4370,8 +4389,8 @@ fn (mut t Transformer) register_specialized_fn_signature_value(decl GenericFnDec
 		t.tc.ensure_private_transform_signatures()
 		mut names := [clone_value, qname, c_name(clone_value),
 			c_name(qname)]
-		names << specialized_generic_fn_signature_aliases(decl, args)
-		t.record_generic_specialization_args_for_names(names, args)
+		names << specialized_generic_fn_signature_aliases(decl, concrete_args)
+		t.record_generic_specialization_args_for_names(names, concrete_args)
 		for name in names {
 			t.tc.fn_ret_types[name] = ret
 			t.tc.register_generated_fn_param_types(name, params.clone())
@@ -4420,8 +4439,7 @@ fn (t &Transformer) generic_fn_return_type_text(decl GenericFnDecl) string {
 
 fn (mut t Transformer) specialized_signature_type_text(decl GenericFnDecl, typ string, args []string, params []string) string {
 	if direct := t.specialized_direct_generic_type_text(typ, args, params) {
-		pinned := t.pin_direct_main_generic_arg_type_text(direct)
-		return t.lock_colliding_main_generic_type_text(pinned, decl.module)
+		return t.lock_colliding_main_generic_type_text(direct, decl.module)
 	}
 	substituted := substitute_generic_type_text_with_params(typ, args, params)
 	// The scalar `direct` branch above pins a colliding main type to `main.` before it can be
@@ -4471,37 +4489,6 @@ fn (mut t Transformer) specialized_signature_type_text(decl GenericFnDecl, typ s
 		return qualified
 	}
 	return specialized_signature_storage_type_name(parsed)
-}
-
-fn (t &Transformer) pin_direct_main_generic_arg_type_text(typ string) string {
-	clean := typ.trim_space()
-	for prefix in ['mut ', 'shared ', 'atomic ', '...', '[]', '?', '!', '&'] {
-		if clean.starts_with(prefix) {
-			return prefix + t.pin_direct_main_generic_arg_type_text(clean[prefix.len..])
-		}
-	}
-	if clean.starts_with('map[') {
-		bracket_end := generic_matching_bracket(clean, 3)
-		if bracket_end < clean.len - 1 {
-			key := t.pin_direct_main_generic_arg_type_text(clean[4..bracket_end])
-			value := t.pin_direct_main_generic_arg_type_text(clean[bracket_end + 1..])
-			return 'map[${key}]${value}'
-		}
-	}
-	if clean.starts_with('[') {
-		bracket_end := generic_matching_bracket(clean, 0)
-		if bracket_end > 1 && bracket_end < clean.len - 1 {
-			return clean[..bracket_end + 1] +
-				t.pin_direct_main_generic_arg_type_text(clean[bracket_end + 1..])
-		}
-	}
-	if types.is_builtin_type_name(clean) {
-		return clean
-	}
-	if !clean.contains('.') && t.substituted_type_belongs_to_main_generic(clean) {
-		return 'main.' + clean
-	}
-	return clean
 }
 
 fn (t &Transformer) specialized_direct_generic_type_text(typ string, args []string, params []string) ?string {
@@ -5097,18 +5084,33 @@ fn (mut t Transformer) build_generic_receiver_method_index() {
 		if !t.generic_decl_is_receiver_method(decl.node) {
 			for name in [key, decl.node.value, key.all_after_last('.'),
 				decl.node.value.all_after_last('.')] {
-				if name.len > 0 {
-					call_names[name] = true
+				for spelling in generic_call_name_spellings(name) {
+					call_names[spelling] = true
 				}
 			}
 			continue
 		}
 		method := key.all_after_last('.')
-		by_name[method] << key
-		call_names[method] = true
+		for spelling in generic_call_name_spellings(method) {
+			by_name[spelling] << key
+			call_names[spelling] = true
+		}
 	}
 	t.generic_receiver_methods_by_name = by_name.move()
 	t.generic_fn_call_names = call_names.move()
+}
+
+fn generic_call_name_spellings(name string) []string {
+	if name.len == 0 {
+		return []string{}
+	}
+	short := name.all_after_last('.')
+	if short.starts_with('@') {
+		unescaped := name[..name.len - short.len] + short[1..]
+		return [name, unescaped]
+	}
+	escaped := name[..name.len - short.len] + '@' + short
+	return [name, escaped]
 }
 
 // call_name_can_target_generic is an allocation-free superset filter for the
@@ -5137,6 +5139,23 @@ fn (t &Transformer) synthetic_recorded_generic_call(node flat.Node) bool {
 	callee := t.a.child_node(&node, 0)
 	return callee.kind == .ident
 		&& (callee.value.contains('_T_') || t.generic_callee_is_specialization(callee.value))
+}
+
+// synthetic_generic_call_has_exact_identity reports generated calls whose callee
+// encodes its concrete type arguments. Such calls do not have a source-file marker,
+// but unlike unresolved synthetic calls they can be monomorphized without guessing
+// their declaration module or generic arguments.
+fn (t &Transformer) synthetic_generic_call_has_exact_identity(node flat.Node) bool {
+	if node.children_count == 0 {
+		return false
+	}
+	callee := t.a.child_node(&node, 0)
+	if callee.kind != .ident || callee.value.len == 0 {
+		return false
+	}
+	return (callee.value.contains('[') && callee.value.contains(']'))
+		|| callee.value.contains('_T_')
+		|| t.generic_callee_is_specialization(callee.value)
 }
 
 fn (mut t Transformer) infer_generic_call_args_from_params(decl GenericFnDecl, call_id flat.NodeId, node flat.Node, call_module string) ?[]string {
@@ -5173,6 +5192,17 @@ fn (mut t Transformer) infer_generic_call_args_from_params(decl GenericFnDecl, c
 			continue
 		}
 		mut inferred_arg_type := t.generic_call_arg_type_for_inference(arg_id)
+		if is_recv_param {
+			alias_target := t.generic_inference_alias_target(inferred_arg_type, call_module)
+			if alias_target.len > 0 && !t.generic_arg_is_unresolved(alias_target) {
+				inferred_arg_type = alias_target
+			}
+		}
+		if child.is_mut && child.op == .amp && inferred_arg_type.starts_with('&') {
+			// The explicit `mut p &T` marker addresses the caller's pointer slot;
+			// it is ABI indirection, not part of T's inferred source type.
+			inferred_arg_type = inferred_arg_type[1..]
+		}
 		if is_recv_param && t.call_is_selector_form(node)
 			&& t.generic_receiver_needs_decl_type_fallback(child.typ, inferred_arg_type) {
 			recv := t.a.nodes[int(arg_id)]
@@ -5437,6 +5467,9 @@ fn (mut t Transformer) specialized_generic_call_param_type_texts(decl GenericFnD
 }
 
 fn explicit_mut_pointer_param_type_text(param flat.Node, typ string) string {
+	if param.is_mut && param.op == .amp && typ.starts_with('&') {
+		return '&${typ}'
+	}
 	return typ
 }
 
@@ -5916,6 +5949,31 @@ fn (mut t Transformer) unregister_generic_fn_signature(decl GenericFnDecl) {
 
 fn (mut t Transformer) cached_generic_call_specialization(id flat.NodeId, node flat.Node, module_name string, decls map[string]GenericFnDecl) ?(string, []string) {
 	idx := int(id)
+	// Generated calls without source context cannot safely be re-inferred in the
+	// declaration module: a bare caller type in an encoded specialization can bind
+	// to a same-named imported type. The encoded callee is authoritative; it may
+	// request its exact body once, but later scans must not retarget it.
+	if node.children_count > 0 && t.node_file_or(idx, '').len == 0 && !isnil(t.tc) {
+		callee := t.a.child_node(&node, 0)
+		if callee.kind == .ident && t.generic_callee_is_specialization(callee.value) {
+			decl_key := t.generic_call_decl_key(id, node, module_name, decls) or { return none }
+			decl := decls[decl_key] or { return none }
+			if exact := t.exact_generic_specialization_args_from_callee(callee.value) {
+				if exact.len > 0 && !t.generic_args_have_placeholders(exact) {
+					key := t.generic_specialization_progress_key(decl, exact)
+					if key !in t.generic_fn_spec_nodes && !t.generic_fn_specs_in_progress[key]
+						&& !t.pending_generic_fn_spec_keys[key] {
+						t.generic_call_spec_cache[idx] = GenericCallSpec{
+							decl_key: decl_key
+							args:     exact
+						}
+						return decl_key, exact
+					}
+				}
+			}
+			return none
+		}
+	}
 	// A rewritten call records the exact semantic arguments both in its callee
 	// identity and in `node.value`. Preserve that agreement before consulting a
 	// stale cache or re-inferring without the generated function's local scope.
@@ -6786,9 +6844,11 @@ fn (t &Transformer) generic_static_assoc_call_decl_key(base_id flat.NodeId, meth
 		return none
 	}
 	for type_name in t.generic_static_assoc_type_candidates(base_id) {
-		key := generic_fn_decl_base_value('${type_name}.${method}')
-		if key in decls {
-			return key
+		for method_spelling in generic_call_name_spellings(method) {
+			key := generic_fn_decl_base_value('${type_name}.${method_spelling}')
+			if key in decls {
+				return key
+			}
 		}
 	}
 	return none
@@ -6804,14 +6864,16 @@ fn (t &Transformer) generic_call_is_static_assoc_selector(node flat.Node, decl G
 		return false
 	}
 	method := decl.node.value.all_after_last('.')
-	if callee.value != method {
+	if callee.value !in generic_call_name_spellings(method) {
 		return false
 	}
 	base_id := t.a.child(callee, 0)
 	for type_name in t.generic_static_assoc_type_candidates(base_id) {
-		key := generic_fn_decl_base_value('${type_name}.${method}')
-		if key == decl.key || key == generic_fn_decl_base_value(decl.node.value) {
-			return true
+		for method_spelling in generic_call_name_spellings(method) {
+			key := generic_fn_decl_base_value('${type_name}.${method_spelling}')
+			if key == decl.key || key == generic_fn_decl_base_value(decl.node.value) {
+				return true
+			}
 		}
 	}
 	return false
@@ -7050,10 +7112,11 @@ fn generic_flat_receiver_matches(receiver string, decl_receiver string, module_n
 }
 
 fn (t &Transformer) generic_resolved_call_decl_key(resolved string, callee flat.Node, node flat.Node, module_name string, decls map[string]GenericFnDecl) ?string {
-	mut resolved_candidates := [resolved]
+	mut resolved_candidates := []string{}
+	push_generic_call_name_spellings(mut resolved_candidates, resolved)
 	if module_name.len > 0 && module_name !in ['main', 'builtin']
 		&& !resolved.starts_with('${module_name}.') {
-		resolved_candidates << '${module_name}.${resolved}'
+		push_generic_call_name_spellings(mut resolved_candidates, '${module_name}.${resolved}')
 	}
 	for candidate in resolved_candidates {
 		if decl := decls[candidate] {
@@ -7063,11 +7126,13 @@ fn (t &Transformer) generic_resolved_call_decl_key(resolved string, callee flat.
 		}
 	}
 	key := generic_fn_decl_base_value(resolved)
-	if decl := decls[key] {
-		if !t.resolved_generic_decl_matches_callee_receiver(callee, node, decl, module_name) {
-			return none
+	for spelling in generic_call_name_spellings(key) {
+		if decl := decls[spelling] {
+			if !t.resolved_generic_decl_matches_callee_receiver(callee, node, decl, module_name) {
+				continue
+			}
+			return spelling
 		}
-		return key
 	}
 	if flat_key := t.generic_flat_receiver_call_decl_key(key, module_name, decls) {
 		return flat_key
@@ -7083,14 +7148,18 @@ fn (t &Transformer) generic_resolved_call_decl_key(resolved string, callee flat.
 	resolved_mod := if key.contains('.') { key.all_before_last('.') } else { module_name }
 	short := key.all_after_last('.')
 	if resolved_mod.len > 0 {
-		qshort := '${resolved_mod}.${short}'
-		if qshort in decls {
-			return qshort
+		for short_spelling in generic_call_name_spellings(short) {
+			qshort := '${resolved_mod}.${short_spelling}'
+			if qshort in decls {
+				return qshort
+			}
 		}
 	}
-	if decl := decls[short] {
-		if decl.module == resolved_mod || decl.module == module_name {
-			return short
+	for short_spelling in generic_call_name_spellings(short) {
+		if decl := decls[short_spelling] {
+			if decl.module == resolved_mod || decl.module == module_name {
+				return short_spelling
+			}
 		}
 	}
 	if callee.kind == .ident
@@ -7381,35 +7450,43 @@ fn generic_decl_module_matches_call_module(decl_module string, call_module strin
 fn (t &Transformer) generic_plain_call_candidates(name string, module_name string) []string {
 	mut candidates := []string{}
 	if module_name.len > 0 && module_name != 'main' && module_name != 'builtin' {
-		candidates << '${module_name}.${name}'
+		push_generic_call_name_spellings(mut candidates, '${module_name}.${name}')
 	}
-	candidates << name
+	push_generic_call_name_spellings(mut candidates, name)
 	if !isnil(t.tc) {
 		qname := t.tc.qualify_fn_name(name)
-		if qname !in candidates {
-			candidates << qname
-		}
+		push_generic_call_name_spellings(mut candidates, qname)
 		if selected := t.tc.resolve_any_selective_import_fn(name) {
-			if selected !in candidates {
-				candidates << selected
-			}
+			push_generic_call_name_spellings(mut candidates, selected)
 		}
 	}
 	return candidates
 }
 
-fn (t &Transformer) generic_receiver_decl_key(base_name string, method string, decls map[string]GenericFnDecl) string {
-	direct := '${base_name}.${method}'
-	if direct in decls {
-		return direct
-	}
-	short := base_name.all_after_last('.')
-	for key, _ in decls {
-		if key == '${short}.${method}' || key.ends_with('.${short}.${method}') {
-			return key
+fn push_generic_call_name_spellings(mut names []string, name string) {
+	for spelling in generic_call_name_spellings(name) {
+		if spelling !in names {
+			names << spelling
 		}
 	}
-	return direct
+}
+
+fn (t &Transformer) generic_receiver_decl_key(base_name string, method string, decls map[string]GenericFnDecl) string {
+	for method_spelling in generic_call_name_spellings(method) {
+		direct := '${base_name}.${method_spelling}'
+		if direct in decls {
+			return direct
+		}
+	}
+	short := base_name.all_after_last('.')
+	for method_spelling in generic_call_name_spellings(method) {
+		for key, _ in decls {
+			if key == '${short}.${method_spelling}' || key.ends_with('.${short}.${method_spelling}') {
+				return key
+			}
+		}
+	}
+	return '${base_name}.${method}'
 }
 
 fn (t &Transformer) explicit_generic_call_args(node flat.Node, module_name string) ?[]string {
@@ -7537,6 +7614,17 @@ fn (mut t Transformer) infer_generic_call_args_seeded(decl GenericFnDecl, _id fl
 			continue
 		}
 		mut inferred_arg_type := t.generic_call_arg_type_for_inference(arg_id)
+		if is_recv_param {
+			alias_target := t.generic_inference_alias_target(inferred_arg_type, call_module)
+			if alias_target.len > 0 && !t.generic_arg_is_unresolved(alias_target) {
+				inferred_arg_type = alias_target
+			}
+		}
+		if child.is_mut && child.op == .amp && inferred_arg_type.starts_with('&') {
+			// The explicit `mut p &T` marker addresses the caller's pointer slot;
+			// it is ABI indirection, not part of T's inferred source type.
+			inferred_arg_type = inferred_arg_type[1..]
+		}
 		if is_recv_param && t.call_is_selector_form(node)
 			&& t.generic_receiver_needs_decl_type_fallback(child.typ, inferred_arg_type) {
 			recv := t.a.nodes[int(arg_id)]
@@ -7871,6 +7959,13 @@ fn (mut t Transformer) infer_generic_sum_literal_args(param_type string, arg_id 
 }
 
 fn (t &Transformer) generic_arg_for_call_and_decl_module(arg string, call_module string, decl_module string) string {
+	if call_module in ['', 'main'] && !arg.contains('.') {
+		if info := t.structs[arg.trim_space()] {
+			if info.module in ['', 'main'] {
+				return t.lock_colliding_main_generic_type_text(arg, decl_module)
+			}
+		}
+	}
 	if t.substituted_type_belongs_to_main_generic(arg)
 		&& (call_module in ['', 'main'] || t.current_specialization_has_generic_arg(arg)) {
 		return arg
@@ -7943,6 +8038,66 @@ fn (mut t Transformer) specialization_main_type_closure(args []string) map[strin
 	}
 	t.specialization_main_type_closures[key] = types_in_scope.clone()
 	return types_in_scope
+}
+
+// collect_caller_main_type_names preserves the provenance of bare concrete types
+// while a specialization is still in the program module. Once signature
+// registration enters the imported declaration module, the same spelling may
+// resolve to an unrelated homonym.
+fn (t &Transformer) collect_caller_main_type_names(typ string, mut types_in_scope map[string]bool) {
+	mut clean := typ.trim_space()
+	if clean.len == 0 {
+		return
+	}
+	if clean.starts_with('main.') && !t.ident_is_import_alias('main') {
+		clean = clean['main.'.len..]
+	}
+	for prefix in ['mut ', 'shared ', 'atomic ', '...', '[]', '?', '!', '&', 'chan ', 'thread '] {
+		if clean.starts_with(prefix) {
+			t.collect_caller_main_type_names(clean[prefix.len..], mut types_in_scope)
+			return
+		}
+	}
+	if clean.starts_with('fn(') || clean.starts_with('fn (') {
+		if params, ret := fn_type_text_parts(clean) {
+			for param in params {
+				t.collect_caller_main_type_names(param, mut types_in_scope)
+			}
+			t.collect_caller_main_type_names(ret, mut types_in_scope)
+		}
+		return
+	}
+	if clean.starts_with('map[') {
+		end := generic_matching_bracket(clean, 3)
+		if end > 3 && end + 1 < clean.len {
+			t.collect_caller_main_type_names(clean[4..end], mut types_in_scope)
+			t.collect_caller_main_type_names(clean[end + 1..], mut types_in_scope)
+		}
+		return
+	}
+	if clean.starts_with('[') {
+		end := generic_matching_bracket(clean, 0)
+		if end > 0 && end + 1 < clean.len {
+			t.collect_caller_main_type_names(clean[end + 1..], mut types_in_scope)
+		}
+		return
+	}
+	if clean.starts_with('(') && clean.ends_with(')') && clean.contains(',') {
+		for part in split_generic_args(clean[1..clean.len - 1]) {
+			t.collect_caller_main_type_names(part, mut types_in_scope)
+		}
+		return
+	}
+	base, generic_args, is_generic := generic_app_parts(clean)
+	if is_generic {
+		for generic_arg in generic_args {
+			t.collect_caller_main_type_names(generic_arg, mut types_in_scope)
+		}
+		clean = base
+	}
+	if !clean.contains('.') && t.type_name_is_declared(clean) {
+		types_in_scope[clean] = true
+	}
 }
 
 fn (t &Transformer) collect_specialization_main_types(typ string, mut types_in_scope map[string]bool, mut seen map[string]bool) {
@@ -12212,7 +12367,20 @@ fn (t &Transformer) lock_colliding_main_generic_type_text(typ string, module_nam
 	// identity too. Source-owned generic bases are preserved by
 	// lock_colliding_main_substitution_type_text without reaching this branch.
 	if t.active_specialization_main_types[clean] {
-		return 'main.' + clean
+		qname := '${module_name}.${clean}'
+		mut alias_target_needs_lock := false
+		if !isnil(t.tc) {
+			if alias_target := t.tc.type_aliases[clean] {
+				alias_target_needs_lock = alias_target != clean
+					&& t.lock_colliding_main_generic_type_text(alias_target, module_name) != alias_target
+			}
+		}
+		if qname in t.structs || qname in t.sum_types || qname in t.enum_types
+			|| (!isnil(t.tc) && (qname in t.tc.struct_generic_params
+			|| qname in t.tc.sum_generic_params)) || t.type_short_name_has_non_main_owner(clean)
+			|| alias_target_needs_lock {
+			return 'main.' + clean
+		}
 	}
 	if !(clean in t.structs || clean in t.sum_types || clean in t.enum_types) {
 		return clean
@@ -12223,7 +12391,12 @@ fn (t &Transformer) lock_colliding_main_generic_type_text(typ string, module_nam
 				&& '${module_name}.${clean}' in t.tc.struct_generic_params {
 				return clean
 			}
-			return 'main.' + clean
+			qname := '${module_name}.${clean}'
+			if qname in t.structs || qname in t.sum_types || qname in t.enum_types
+				|| t.type_short_name_has_non_main_owner(clean) {
+				return 'main.' + clean
+			}
+			return clean
 		}
 	}
 	// A main-module type substituted into an imported specialization needs an
@@ -12245,6 +12418,29 @@ fn (t &Transformer) lock_colliding_main_generic_type_text(typ string, module_nam
 		return 'main.' + clean
 	}
 	return clean
+}
+
+fn (t &Transformer) type_short_name_has_non_main_owner(name string) bool {
+	for candidate, info in t.structs {
+		owner := if info.module.len > 0 { info.module } else { candidate.all_before_last('.') }
+		if candidate.contains('.') && candidate.all_after_last('.') == name
+			&& owner !in ['', 'main', 'builtin'] {
+			return true
+		}
+	}
+	for candidate, _ in t.sum_types {
+		if candidate.contains('.') && candidate.all_after_last('.') == name
+			&& candidate.all_before_last('.') !in ['', 'main', 'builtin'] {
+			return true
+		}
+	}
+	for candidate, _ in t.enum_types {
+		if candidate.contains('.') && candidate.all_after_last('.') == name
+			&& candidate.all_before_last('.') !in ['', 'main', 'builtin'] {
+			return true
+		}
+	}
+	return false
 }
 
 fn (t &Transformer) substituted_type_belongs_to_main_generic(typ string) bool {
@@ -12911,11 +13107,10 @@ fn (t &Transformer) canonical_generic_specialization_arg(arg string) string {
 	// generic body. Generic specialization keys use the program module's normal
 	// bare spelling; leaving the lock qualified here lets import resolution rebind
 	// it to an unrelated same-named type.
-	if clean.starts_with('main.') && !clean['main.'.len..].contains('.')
-		&& !t.ident_is_import_alias('main') {
-		bare := clean['main.'.len..]
-		if t.type_name_is_declared(bare) {
-			return bare
+	if !t.ident_is_import_alias('main') && clean.contains('main.') {
+		unlocked := strip_main_type_locks(clean)
+		if unlocked != clean {
+			return t.canonical_generic_specialization_arg(unlocked)
 		}
 	}
 	// Inference inside an already-specialized body can observe the materialized
@@ -12990,6 +13185,11 @@ fn (t &Transformer) canonical_generic_specialization_arg(arg string) string {
 		bracket_end := generic_matching_bracket(clean, 0)
 		if bracket_end > 1 && bracket_end < clean.len - 1 {
 			len_text := clean[1..bracket_end].trim_space()
+			elem_text := clean[bracket_end + 1..].trim_space()
+			if !is_decimal_text(len_text) && t.generic_type_base_requires_args(elem_text) {
+				return '${t.canonical_generic_specialization_arg(elem_text)}[${
+					t.canonical_generic_specialization_arg(len_text)}]'
+			}
 			mut clean_len := len_text
 			if !isnil(t.tc) {
 				if value := t.tc.const_int_value(len_text, []string{}) {
@@ -13002,6 +13202,11 @@ fn (t &Transformer) canonical_generic_specialization_arg(arg string) string {
 	}
 	if fixed := t.canonical_suffix_fixed_array_arg(clean) {
 		return fixed
+	}
+	if !t.type_name_is_declared(clean) {
+		if fixed := generic_fixed_array_type_arg_from_short_suffix(clean) {
+			return fixed
+		}
 	}
 	if clean.starts_with('map[') {
 		bracket_end := generic_matching_bracket(clean, 3)
@@ -13064,6 +13269,65 @@ fn (t &Transformer) canonical_generic_specialization_arg(arg string) string {
 		return decoded_array
 	}
 	return clean
+}
+
+fn generic_fixed_array_type_arg_from_short_suffix(suffix string) ?string {
+	clean := suffix.trim_space()
+	split := clean.last_index_u8(`_`)
+	if split <= 0 || split + 1 >= clean.len {
+		return none
+	}
+	len_text := clean[split + 1..]
+	if !is_decimal_text(len_text) {
+		return none
+	}
+	elem := generic_type_arg_from_suffix_with_containers(clean[..split])
+	if elem.len == 0 {
+		return none
+	}
+	candidate := '[${len_text}]${elem}'
+	if generic_type_arg_short(candidate) == clean {
+		return candidate
+	}
+	return none
+}
+
+fn (t &Transformer) generic_type_base_requires_args(typ string) bool {
+	clean := typ.trim_space()
+	if clean.len == 0 || clean.contains('[') || isnil(t.tc) {
+		return false
+	}
+	return clean in t.tc.struct_generic_params || clean in t.tc.sum_generic_params
+		|| clean in t.tc.type_alias_generic_params
+		|| clean.all_after_last('.') in t.tc.struct_generic_params
+		|| clean.all_after_last('.') in t.tc.sum_generic_params
+		|| clean.all_after_last('.') in t.tc.type_alias_generic_params
+}
+
+fn strip_main_type_locks(typ string) string {
+	if !typ.contains('main.') {
+		return typ
+	}
+	mut out := strings.new_builder(typ.len)
+	mut start := 0
+	mut i := 0
+	for i + 'main.'.len <= typ.len {
+		if typ[i..].starts_with('main.')
+			&& (i == 0 || !is_type_identifier_byte(typ[i - 1])) {
+			out.write_string(typ[start..i])
+			i += 'main.'.len
+			start = i
+			continue
+		}
+		i++
+	}
+	out.write_string(typ[start..])
+	return out.str()
+}
+
+fn is_type_identifier_byte(ch u8) bool {
+	return (ch >= `a` && ch <= `z`) || (ch >= `A` && ch <= `Z`)
+		|| (ch >= `0` && ch <= `9`) || ch in [`_`, `.`]
 }
 
 fn (t &Transformer) source_composite_type_from_c_name(encoded string) ?string {

--- a/vlib/v3/transform/monomorphize_test.v
+++ b/vlib/v3/transform/monomorphize_test.v
@@ -132,6 +132,42 @@ fn test_materialized_generic_struct_fields_preserve_plain_alias_arguments() {
 	assert fields[1].typ.name() == '[]int'
 }
 
+fn test_materialized_imported_generic_struct_preserves_locked_main_generic_argument() {
+	mut a := flat.FlatAst.new()
+	value_field := a.add_node(flat.Node{
+		kind:  .field_decl
+		value: 'value'
+		typ:   'T'
+	})
+	children_start := a.children.len
+	a.children << value_field
+	mut result_decl := flat.Node{
+		kind:           .struct_decl
+		value:          'StructKeyDecodeResult'
+		children_start: children_start
+		children_count: 1
+	}
+	result_decl.set_generic_params(['T'])
+	result_id := a.add_node(result_decl)
+
+	mut tc := types.TypeChecker.new(&a)
+	tc.struct_generic_params['StructType'] = ['T']
+	mut t := new_transformer(mut a, &tc, map[string]bool{})
+	t.materialize_generic_struct_spec('json2.StructKeyDecodeResult[main.StructType[main.string]]',
+		GenericStructDecl{
+			id:     result_id
+			node:   result_decl
+			module: 'json2'
+			key:    'json2.StructKeyDecodeResult'
+		})
+
+	fields := tc.structs['json2.StructKeyDecodeResult[main.StructType[main.string]]'] or {
+		assert false, 'missing materialized result fields'
+		return
+	}
+	assert fields[0].typ.name() == 'StructType[string]'
+}
+
 fn test_flattened_generic_struct_types_materialize_from_recorded_args() {
 	mut a := flat.FlatAst.new()
 	mut arc_decl := flat.Node{
@@ -329,7 +365,13 @@ fn test_lock_colliding_main_generic_type_text_locks_args_behind_qualified_base()
 	t.active_specialization_main_types['Context'] = true
 	assert t.lock_colliding_main_substitution_type_text('fn (mut T) bool', 'fn (mut Context) bool',
 		'callee', ['T']) == 'fn (mut main.Context) bool'
+	t.structs['Unique'] = StructInfo{}
+	assert t.lock_colliding_main_generic_type_text('Unique', 'callee') == 'Unique'
 	assert t.canonical_generic_specialization_arg('[]main.Event') == '[]Event'
+	assert t.canonical_generic_specialization_arg('main.Box[main.Event]') == 'Box[Event]'
+	assert t.canonical_generic_specialization_arg('[main.string]Box') == 'Box[string]'
+	assert t.canonical_generic_specialization_arg('u8_3') == '[3]u8'
+	assert strip_main_type_locks('domain.Type[main.Event]') == 'domain.Type[Event]'
 	assert t.specialization_main_type_closure(['map[string]Event']) == {
 		'Event': true
 	}
@@ -462,6 +504,56 @@ fn test_generic_method_decl_matches_embedded_receiver() {
 	}
 	mut seen := map[string]bool{}
 	assert t.generic_decl_matches_embedded_receiver('Outer', decl, 'main', mut seen)
+}
+
+fn test_escaped_generic_method_indexes_unescaped_call_spelling() {
+	mut a := flat.FlatAst.new()
+	receiver_id := a.add_node(flat.Node{
+		kind: .param
+		typ:  '&Box[T]'
+	})
+	children_start := a.children.len
+	a.children << receiver_id
+	mut fn_decl := flat.Node{
+		kind:           .fn_decl
+		value:          'Box[T].@union'
+		children_start: children_start
+		children_count: 1
+	}
+	fn_decl.set_generic_params(['T'])
+	mut tc := types.TypeChecker.new(&a)
+	mut t := new_transformer(mut a, &tc, map[string]bool{})
+	t.generic_fn_decls_cache['Box.@union'] = GenericFnDecl{
+		node: fn_decl
+		key:  'Box.@union'
+	}
+	t.build_generic_receiver_method_index()
+
+	assert t.generic_fn_call_names['union']
+	assert t.generic_receiver_methods_by_name['union'] == ['Box.@union']
+	assert t.generic_receiver_decl_key('Box', 'union', t.generic_fn_decls_cache) == 'Box.@union'
+	assert t.generic_plain_call_candidates('type', 'main') == ['type', '@type']
+}
+
+fn test_synthetic_generic_call_with_exact_identity_is_scannable() {
+	mut a := flat.FlatAst.new()
+	callee_id := a.add_node(flat.Node{
+		kind:  .ident
+		value: 'datatypes.LinkedList[map[string]int].str'
+	})
+	children_start := a.children.len
+	a.children << callee_id
+	call := flat.Node{
+		kind:           .call
+		children_start: children_start
+		children_count: 1
+	}
+	mut tc := types.TypeChecker.new(&a)
+	t := new_transformer(mut a, &tc, map[string]bool{})
+
+	assert t.synthetic_generic_call_has_exact_identity(call)
+	a.nodes[int(callee_id)].value = 'orm.v_sql_create_table_T_Demo'
+	assert t.synthetic_generic_call_has_exact_identity(call)
 }
 
 fn test_specialized_plain_generic_call_args_decode_top_level_array_suffix() {

--- a/vlib/v3/transform/or.v
+++ b/vlib/v3/transform/or.v
@@ -2064,6 +2064,16 @@ fn (mut t Transformer) lower_or_expr_to_stmt(node flat.Node) {
 	t.pending_stmts << if_stmt
 }
 
+fn (mut t Transformer) make_or_lowered_if(mode string, cond flat.NodeId, then_block flat.NodeId, else_block flat.NodeId) flat.NodeId {
+	if mode in ['!', '?'] {
+		// Propagation has no source-level fallback scope. The ownership checker
+		// records its early-return cleanup separately, so this synthetic branch
+		// must not consume the next lexical scope's destructor slot.
+		return t.make_if_with_skip_ownership_drops(cond, then_block, else_block)
+	}
+	return t.make_if(cond, then_block, else_block)
+}
+
 fn (mut t Transformer) mark_optional_source_expr_type(expr flat.NodeId, typ string) {
 	if !t.is_optional_type_name(typ) || int(expr) < 0 || int(expr) >= t.a.nodes.len {
 		return

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -59,6 +59,7 @@ const stack_value_decl_marker = '__v3_stack_value_decl'
 // generated functions and helpers must stay in the main cache segment.
 pub struct SumEqRequest {
 pub:
+	sum_name      string
 	module        string
 	file          string
 	helper_module string
@@ -250,7 +251,7 @@ mut:
 	used_fns_root                 &map[string]bool = unsafe { nil }
 	comptime_reflected_params     map[string][]ParamMeta
 	// sum_eq_types records sum types whose deep-equality helper fn
-	// (__v3_sum_eq_<name>) is called somewhere, keyed by sum name with the
+	// (__v3_sum_eq_<name>) is called somewhere, keyed by the concrete helper name with the
 	// module/file context of the requesting call site (type resolution inside
 	// the helper body needs that context). The helpers are synthesized
 	// serially after the (possibly parallel) transform completes.
@@ -4014,6 +4015,7 @@ fn (mut t Transformer) merge_worker_used_fns(w &Transformer) {
 		if name !in t.sum_eq_types {
 			if scoped {
 				t.sum_eq_types[name.clone()] = SumEqRequest{
+					sum_name:      req.sum_name.clone()
 					module:        req.module.clone()
 					file:          req.file.clone()
 					helper_module: req.helper_module.clone()
@@ -4173,6 +4175,7 @@ fn (mut t Transformer) clone_sum_eq_types_owned() {
 	mut cloned := map[string]SumEqRequest{}
 	for name, req in t.sum_eq_types {
 		cloned[name.clone()] = SumEqRequest{
+			sum_name:      req.sum_name.clone()
 			module:        req.module.clone()
 			file:          req.file.clone()
 			helper_module: req.helper_module.clone()
@@ -8618,6 +8621,9 @@ fn (mut t Transformer) transform_fn_body(fn_idx int) {
 		} else {
 			''
 		}
+		if child.is_mut && child.op == .amp && typ.starts_with('&') {
+			typ = '&${typ}'
+		}
 		if child.is_mut {
 			typ = mut_optional_param_value_type(typ)
 			raw_source_typ = mut_optional_param_value_type(raw_source_typ)
@@ -9093,6 +9099,14 @@ pub fn (mut t Transformer) transform_stmt(id flat.NodeId) []flat.NodeId {
 	if kind_id == 56 {
 		return t.transform_select_stmt(id, node)
 	}
+	if kind_id == 22 {
+		transformed := t.transform_or_expr(id, node)
+		transformed_node := t.a.nodes[int(transformed)]
+		if t.is_stmt_kind_id(int(transformed_node.kind)) {
+			return [transformed]
+		}
+		return [t.make_expr_stmt(transformed)]
+	}
 	match node.kind {
 		.return_stmt {
 			return t.transform_return_stmt(id, node)
@@ -9135,6 +9149,14 @@ pub fn (mut t Transformer) transform_stmt(id flat.NodeId) []flat.NodeId {
 		}
 		.select_stmt {
 			return t.transform_select_stmt(id, node)
+		}
+		.or_expr {
+			transformed := t.transform_or_expr(id, node)
+			transformed_node := t.a.nodes[int(transformed)]
+			if t.is_stmt_kind_id(int(transformed_node.kind)) {
+				return [transformed]
+			}
+			return [t.make_expr_stmt(transformed)]
 		}
 		else {
 			return [id]
@@ -11196,7 +11218,7 @@ fn (mut t Transformer) transform_assign_stmt(id flat.NodeId, node flat.Node) []f
 			// A `mut val T` value param resolves to `&T`; cgen writes assignments
 			// through the pointer (`*val = ...`), so coerce the RHS to `T`, not `&T`.
 			if lhs.kind == .ident && lhs_type.starts_with('&') && t.mut_param_values[lhs.value]
-				&& !lhs_type.starts_with('&&') {
+				&& !t.pointer_value_rvalues[lhs.value] && !lhs_type.starts_with('&&') {
 				lhs_type = lhs_type[1..]
 			}
 			sum_target := t.assignment_sum_target(lhs_id, child_id, lhs_type)

--- a/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
@@ -1835,6 +1835,7 @@ fn (mut t Transformer) absorb_scoped_batch(batch &Transformer, scope voidptr, ne
 	for name, req in batch.sum_eq_types {
 		if name !in t.sum_eq_types {
 			t.sum_eq_types[t.promote_scoped_result_text(name)] = SumEqRequest{
+				sum_name:      t.promote_scoped_result_text(req.sum_name)
 				module:        t.promote_scoped_result_text(req.module)
 				file:          t.promote_scoped_result_text(req.file)
 				helper_module: t.promote_scoped_result_text(req.helper_module)

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -1172,6 +1172,7 @@ fn (tc &TypeChecker) fork_program_view(ast &flat.FlatAst, direct_dependencies_by
 		fn_type_files:                      tc.fn_type_files
 		fn_type_modules:                    tc.fn_type_modules
 		fn_generic_params:                  tc.fn_generic_params
+		transform_signature_names_log:      []string{}
 		specialized_generic_fns:            tc.specialized_generic_fns
 		fn_variadic:                        tc.fn_variadic
 		c_variadic_fns:                     tc.c_variadic_fns
@@ -6071,7 +6072,8 @@ fn (tc &TypeChecker) resolve_imported_type_text(typ string) string {
 			// `main.<name>` for C codegen; the post-transform re-check must still
 			// resolve them against the bare-keyed program symbol tables.
 			if !rest.contains('.') {
-				if tc.qualify_candidate_type_exists(rest) || rest in tc.const_types {
+				if is_builtin_type_name(rest) || tc.qualify_candidate_type_exists(rest)
+					|| rest in tc.const_types {
 					return rest
 				}
 				if _ := tc.file_scope.lookup(rest) {

--- a/vlib/v3/types/checker_scoped_transform_test.v
+++ b/vlib/v3/types/checker_scoped_transform_test.v
@@ -119,6 +119,7 @@ fn test_rebuild_scoped_transform_signatures_and_suffix_index_after_growth() {
 	$if prealloc {
 		a := flat.FlatAst.new()
 		mut tc := TypeChecker.new(&a)
+		tc.ensure_private_transform_signatures()
 		scope := unsafe { prealloc_scope_begin() }
 		// Model a transform that leaves enough scoped map capacity for the
 		// subsequent suffix rebuild to reuse unless it explicitly replaces the map.
@@ -150,6 +151,7 @@ fn test_rebuild_scoped_transform_signatures_and_suffix_index_after_growth() {
 		unsafe { prealloc_scope_leave(scope) }
 		tc.rebuild_scoped_transform_signature_maps()
 		tc.rebuild_fn_param_suffix_index()
+		assert tc.transform_signature_names_log.len == 0
 		ret_rebuilt := unsafe { &SignatureMapLayoutForTest(&tc.fn_ret_types) }
 		params_rebuilt := unsafe { &SignatureMapLayoutForTest(&tc.fn_param_types) }
 		variadic_rebuilt := unsafe { &SignatureMapLayoutForTest(&tc.fn_variadic) }
@@ -161,6 +163,8 @@ fn test_rebuild_scoped_transform_signatures_and_suffix_index_after_growth() {
 		assert !signature_map_storage_owned_by_scope(scope, specialized_rebuilt)
 		assert !signature_map_storage_owned_by_scope(scope, suffix_rebuilt)
 		unsafe { prealloc_scope_free_after(scope) }
+		tc.register_generated_fn_param_types('generated.after_scope', [Type(int_)])
+		assert tc.transform_signature_names_log == ['generated.after_scope']
 
 		for idx in [0, 2048, 4095] {
 			name := 'generated.Box_${idx}.open'
@@ -190,9 +194,10 @@ fn test_parallel_transform_fork_owns_mutable_signature_maps() {
 	mut transform_fork := tc.fork_for_parallel_transform(&a)
 	transform_fork.ensure_private_transform_signatures()
 	transform_fork.fn_ret_types['generated'] = Type(bool_)
-	transform_fork.fn_param_types['generated'] = [Type(int_)]
+	transform_fork.register_generated_fn_param_types('generated', [Type(int_)])
 	transform_fork.fn_variadic['generated'] = false
 	transform_fork.specialized_generic_fns['generated'] = true
+	assert transform_fork.transform_signature_names_log == ['generated']
 
 	assert 'generated' !in tc.fn_ret_types
 	assert 'generated' !in tc.fn_param_types

--- a/vlib/v3/types/checker_tail.v
+++ b/vlib/v3/types/checker_tail.v
@@ -9202,7 +9202,8 @@ fn (tc &TypeChecker) visible_call_param(info CallInfo, param_idx int) ?flat.Node
 }
 
 fn (tc &TypeChecker) call_param_requires_mut_pointer_slot(info CallInfo, param_idx int) bool {
-	return false
+	param := tc.visible_call_param(info, param_idx) or { return false }
+	return param.is_mut && param.op == .amp && param.typ.starts_with('&')
 }
 
 fn (tc &TypeChecker) explicit_generic_source_param_is_mut(call flat.Node, info CallInfo, param_idx int) bool {
@@ -11437,6 +11438,7 @@ fn (mut tc TypeChecker) check_call_arg_types(id flat.NodeId, node flat.Node, inf
 			mut_param_base_depth, _ := type_pointer_depth_and_base(mut_param_base)
 			is_implicit_mut_param_pointer := mut_arg_node.kind == .ident
 				&& mut_arg_node.value in tc.fn_context.mut_param_base_types
+				&& !tc.current_fn_param_is_explicit_mut_pointer(mut_arg_node.value)
 				&& actual_mut_depth > mut_param_base_depth
 			if is_implicit_mut_param_pointer
 				|| !tc.mut_pointer_slot_arg_compatible(actual_mut_type, expected) {

--- a/vlib/v3/types/checker_tail_stmt.v
+++ b/vlib/v3/types/checker_tail_stmt.v
@@ -13826,8 +13826,38 @@ fn (tc &TypeChecker) parse_type_uncached(typ string) Type {
 	// unless `main` is an actual import alias in this file.
 	if typ.starts_with('main.') && !typ['main.'.len..].contains('.') {
 		if _ := tc.resolve_import_alias('main') {
-		} else if known := tc.type_from_known_symbol(typ['main.'.len..]) {
-			return known
+		} else {
+			rest := typ['main.'.len..]
+			if is_builtin_type_name(rest) {
+				return builtin_type_value(rest)
+			}
+			if known := tc.type_from_known_symbol(rest) {
+				return known
+			}
+			if generic_type_application(rest) {
+				base, args, _ := generic_type_application_parts(rest)
+				if !base.contains('.') {
+					suffix := tc.qualified_generic_suffix(args)
+					if base in tc.struct_generic_params || base in tc.structs {
+						return Type(Struct{
+							name: base + suffix
+						})
+					}
+					if base in tc.sum_generic_params || base in tc.sum_types {
+						return Type(SumType{
+							name: base + suffix
+						})
+					}
+					if base in tc.interface_names {
+						return Type(Interface{
+							name: base + suffix
+						})
+					}
+					if base in tc.type_aliases {
+						return tc.parse_generic_alias_application(base, args, suffix)
+					}
+				}
+			}
 		}
 	}
 	if typ.starts_with('&') {

--- a/vlib/v3/types/type_cache_test.v
+++ b/vlib/v3/types/type_cache_test.v
@@ -139,6 +139,18 @@ fn test_receiver_embeds_through_alias() {
 	assert tc.receiver_embeds(actual, expected)
 }
 
+fn test_parse_resolution_type_handles_locked_main_generic_application() {
+	a := flat.FlatAst.new()
+	mut tc := TypeChecker.new(&a)
+	tc.struct_generic_params['StructType'] = ['T']
+	tc.cur_file = 'decode.v'
+	tc.cur_module = 'json2'
+
+	assert tc.parse_resolution_type('main.StructType[string]').name() == 'StructType[string]'
+	assert tc.parse_resolution_type('main.StructType[main.string]').name() == 'StructType[string]'
+	assert tc.parse_type('main.StructType[string]').name() == 'StructType[string]'
+}
+
 fn test_type_cache_overlay_rebinds_resolution_type_views() {
 	a := flat.FlatAst.new()
 	mut tc := TypeChecker.new(&a)


### PR DESCRIPTION
## Summary

- preserve V3 module-cache inputs, initialization order, and cached specialization context
- fix generic monomorphization identity, alias locking, helper ownership, and transformer parity
- restore explicit mutable-pointer ABI and value semantics through calls, dereferences, indexing, and interfaces
- extend ownership/codegen regression coverage and macOS V3 CI coverage

## Tests

- `VFLAGS="-gc none" ./vnew11 -silent test vlib/v3/transform/`
- `VFLAGS="-gc none" ./vnew11 -silent test vlib/v3/types/`
- `VFLAGS="-gc none" ./vnew11 -silent test vlib/v3/gen/c/`
- `VFLAGS="-gc none" ./vnew11 -silent test vlib/v3/modulecache/`
- `VFLAGS="-gc none" ./vnew11 -silent vlib/v3/tests/mut_param_reassign_codegen_test.v`
- `VFLAGS="-gc none" ./vnew11 -silent vlib/v3/tests/ownership_result_sentinel_codegen_test.v`
- `VFLAGS="-gc none" ./vnew11 -silent vlib/v3/tests/transformer_parity_test.v`
- `VFLAGS="-gc none" ./vnew11 -silent test -run-only test_warm_cached_module_preserves_runtime_const_dependency_order vlib/v3/tests/module_cache_test.v`
- `VFLAGS="-gc none" ./vnew11 -silent vlib/v/compiler_errors_test.v`

The complete `module_cache_test.v` run reaches the existing `test_cached_generic_body_resolves_relative_embed_file` raw-string failure; the same failure reproduces from detached `origin/master`. `cmd/v/macos_v3_test.v` reaches the cross-iOS case but cannot complete on this machine because the iPhoneOS SDK is unavailable.