### PR TITLE
v3: further speed up FastC self-hosting

### DIFF
--- a/vlib/v3/gen/fastc/array.v
+++ b/vlib/v3/gen/fastc/array.v
@@ -149,7 +149,7 @@ fn (g &Parser) render_array_access_expression(tokens []FastcExpressionToken) ?Fa
 		}
 		return FastcRenderedExpression{
 			source: slice_source
-			typ:    slice_type
+			typ: slice_type
 		}
 	}
 	is_array_pointer := base_type.ends_with('*') && g.array_element_type(base_type) != none
@@ -166,41 +166,40 @@ fn (g &Parser) render_array_access_expression(tokens []FastcExpressionToken) ?Fa
 	if base_layout_type == 'string' {
 		return FastcRenderedExpression{
 			source: 'builtin__string_at(${base_source}, ${index_source})'
-			typ:    element_type
+			typ: element_type
 		}
 	}
-	is_raw_fixed_array := base_type.starts_with('FixedArray_')
-		&& g.fixed_array_uses_raw_storage(base_tokens)
+	is_raw_fixed_array := base_type.starts_with('FixedArray_') && g.fixed_array_uses_raw_storage(base_tokens)
 	if fixed_length := fastc_fixed_array_length(base_type.trim_right('*')) {
 		checked_index := 'builtin__v_fixed_index(${index_source}, ${fixed_length})'
 		if is_raw_fixed_array {
 			return FastcRenderedExpression{
 				source: '((${base_source})[${checked_index}])'
-				typ:    element_type
+				typ: element_type
 			}
 		}
 		access := if base_type.ends_with('*') { '->' } else { '.' }
 		return FastcRenderedExpression{
 			source: '((${base_source})${access}data[${checked_index}])'
-			typ:    element_type
+			typ: element_type
 		}
 	}
 	if is_raw_fixed_array {
 		return FastcRenderedExpression{
 			source: '((${base_source})[${index_source}])'
-			typ:    element_type
+			typ: element_type
 		}
 	}
 	if base_type.ends_with('*') && !is_array_pointer {
 		return FastcRenderedExpression{
 			source: '((${base_source})[${index_source}])'
-			typ:    element_type
+			typ: element_type
 		}
 	}
 	array_value := if base_type.ends_with('*') { '*(${base_source})' } else { base_source }
 	return FastcRenderedExpression{
 		source: '(*(${element_type} *)builtin__array_get(${array_value}, ${index_source}))'
-		typ:    element_type
+		typ: element_type
 	}
 }
 
@@ -293,7 +292,7 @@ fn (g &Parser) render_nested_array_access_expression(tokens []FastcExpressionTok
 	inferred_type := g.infer_expression_type(tokens) or { '' }
 	return FastcRenderedExpression{
 		source: rendered
-		typ:    inferred_type
+		typ: inferred_type
 	}
 }
 
@@ -311,8 +310,7 @@ fn (g &Parser) resolved_root_expression_name(name string) string {
 }
 
 fn (g &Parser) render_membership_candidate(tokens []FastcExpressionToken, expected_type string) ?string {
-	if tokens.len == 2 && tokens[0].tok == .dot && tokens[1].tok == .name
-		&& g.declared_kinds[g.semantic_type_key(expected_type)] == .enum_ {
+	if tokens.len == 2 && tokens[0].tok == .dot && tokens[1].tok == .name && g.declared_kinds[g.semantic_type_key(expected_type)] == .enum_ {
 		return '${expected_type.trim_right('*')}__${tokens[1].lit}'
 	}
 	if array_access := g.render_array_access_expression(tokens) {
@@ -337,8 +335,7 @@ fn (g &Parser) render_membership_candidate(tokens []FastcExpressionToken, expect
 	if member_source := g.render_member_receiver(tokens) {
 		return member_source
 	}
-	if tokens.len >= 4 && tokens[0].tok == .name && tokens[1].tok == .lpar
-		&& tokens.last().tok == .rpar {
+	if tokens.len >= 4 && tokens[0].tok == .name && tokens[1].tok == .lpar && tokens.last().tok == .rpar {
 		if cast_type := fastc_primitive_c_type(tokens[0].lit) {
 			close := fastc_matching_rpar(tokens, 1) or { return none }
 			if close == tokens.len - 1 {
@@ -364,8 +361,7 @@ fn (g &Parser) render_leading_member_chain_promotion(tokens []FastcExpressionTok
 		return none
 	}
 	mut chain_end := 1
-	for chain_end + 1 < tokens.len && tokens[chain_end].tok == .dot
-		&& tokens[chain_end + 1].tok == .name {
+	for chain_end + 1 < tokens.len && tokens[chain_end].tok == .dot && tokens[chain_end + 1].tok == .name {
 		chain_end += 2
 	}
 	// Need `root.field` (chain_end >= 3) followed by an arithmetic operator; a pure
@@ -390,20 +386,14 @@ fn (g &Parser) render_leading_member_chain_promotion(tokens []FastcExpressionTok
 
 fn (g &Parser) render_raw_expression_tokens(tokens []FastcExpressionToken) ?string {
 	mut result := strings.new_builder(32)
-	mut cast_closes := map[int]bool{}
-	mut cast_opens := map[int]bool{}
+	mut cast_closes := []int{}
+	mut cast_open := -1
+	mut previous_module_separator := false
 	for i, item in tokens {
 		mut piece := item.lit
 		module_separator := g.expression_dot_is_module_separator(tokens, i)
-		previous_module_separator := g.expression_dot_is_module_separator(tokens, i - 1)
-		is_direct_pointer_cast := item.tok in [.amp, .and]
-			&& fastc_token_is_prefix_operator(tokens, i) && i + 2 < tokens.len
-			&& tokens[i + 1].tok == .name && tokens[i + 2].tok == .lpar
-			&& (fastc_primitive_c_type(tokens[i + 1].lit) != none
-			|| g.resolve_declared_type_key(tokens[i + 1].lit) != none)
-		is_c_pointer_cast := item.tok in [.amp, .and] && fastc_token_is_prefix_operator(tokens, i)
-			&& i + 4 < tokens.len && tokens[i + 1].tok == .name && tokens[i + 1].lit == 'C'
-			&& tokens[i + 2].tok == .dot && tokens[i + 3].tok == .name && tokens[i + 4].tok == .lpar
+		is_direct_pointer_cast := item.tok in [.amp, .and] && fastc_token_is_prefix_operator(tokens, i) && i + 2 < tokens.len && tokens[i + 1].tok == .name && tokens[i + 2].tok == .lpar && (fastc_primitive_c_type(tokens[i + 1].lit) != none || g.resolve_declared_type_key(tokens[i + 1].lit) != none)
+		is_c_pointer_cast := item.tok in [.amp, .and] && fastc_token_is_prefix_operator(tokens, i) && i + 4 < tokens.len && tokens[i + 1].tok == .name && tokens[i + 1].lit == 'C' && tokens[i + 2].tok == .dot && tokens[i + 3].tok == .name && tokens[i + 4].tok == .lpar
 		if item.source != '' {
 			// Synthetic expression atoms (an `or` unwrap, interpolation, anonymous
 			// function, etc.) carry their complete C spelling in `source`. Preserve it
@@ -418,10 +408,7 @@ fn (g &Parser) render_raw_expression_tokens(tokens []FastcExpressionToken) ?stri
 			} else {
 				fastc_primitive_c_type(item.lit) or { '' }
 			}
-			is_c_cast := i >= 2 && tokens[i - 2].tok == .name && tokens[i - 2].lit == 'C'
-				&& tokens[i - 1].tok == .dot && item.lit.len > 0 && 'C.${item.lit}' !in g.functions
-				&& fastc_call_has_one_argument(tokens, i + 1)
-				&& (item.lit[0].is_capital() || '#Cstruct#${item.lit}' in g.declared_types)
+			is_c_cast := i >= 2 && tokens[i - 2].tok == .name && tokens[i - 2].lit == 'C' && tokens[i - 1].tok == .dot && item.lit.len > 0 && 'C.${item.lit}' !in g.functions && fastc_call_has_one_argument(tokens, i + 1) && (item.lit[0].is_capital() || '#Cstruct#${item.lit}' in g.declared_types)
 			if is_c_cast {
 				cast_type = if '#Cstruct#${item.lit}' in g.declared_types {
 					'struct ${item.lit}'
@@ -430,17 +417,14 @@ fn (g &Parser) render_raw_expression_tokens(tokens []FastcExpressionToken) ?stri
 				}
 			}
 			if cast_type == '' && !is_member_call {
-				if type_key := g.resolve_declared_type_key(item.lit)
-				{
+				if type_key := g.resolve_declared_type_key(item.lit) {
 					cast_type = fastc_c_declared_type_name(type_key)
 				}
 			}
 			if cast_type != '' {
-				pointer_token := if i > 0 && tokens[i - 1].tok in [.amp, .and]
-					&& fastc_token_is_prefix_operator(tokens, i - 1) {
+				pointer_token := if i > 0 && tokens[i - 1].tok in [.amp, .and] && fastc_token_is_prefix_operator(tokens, i - 1) {
 					tokens[i - 1].tok
-				} else if is_c_cast && i >= 3 && tokens[i - 3].tok in [.amp, .and]
-					&& fastc_token_is_prefix_operator(tokens, i - 3) {
+				} else if is_c_cast && i >= 3 && tokens[i - 3].tok in [.amp, .and] && fastc_token_is_prefix_operator(tokens, i - 3) {
 					tokens[i - 3].tok
 				} else {
 					token.Token.unknown
@@ -454,8 +438,8 @@ fn (g &Parser) render_raw_expression_tokens(tokens []FastcExpressionToken) ?stri
 				})
 				piece = '((${cast_type}${pointer_suffix})('
 				close := fastc_matching_rpar(tokens, i + 1) or { return none }
-				cast_opens[i + 1] = true
-				cast_closes[close] = true
+				cast_open = i + 1
+				cast_closes << close
 			} else {
 				previous := if i == 0 { token.Token.unknown } else { tokens[i - 1].tok }
 				piece = if previous == .dot {
@@ -464,7 +448,7 @@ fn (g &Parser) render_raw_expression_tokens(tokens []FastcExpressionToken) ?stri
 					g.resolved_expression_name(item.lit, previous)
 				}
 			}
-		} else if item.tok == .lpar && i in cast_opens {
+		} else if item.tok == .lpar && i == cast_open {
 			piece = ''
 		} else if item.tok == .rpar && i in cast_closes {
 			piece = '))'
@@ -503,56 +487,47 @@ fn (g &Parser) render_raw_expression_tokens(tokens []FastcExpressionToken) ?stri
 				// The module prefix already makes a qualified keyword-named constant safe
 				// (`orm.float` -> `orm__float`), so do not sanitize the member by itself.
 				item.lit
-			} else if i >= 2 && previous == .dot && tokens[i - 2].tok == .name
-				&& g.is_enum_type_name(tokens[i - 2].lit) {
+			} else if i >= 2 && previous == .dot && tokens[i - 2].tok == .name && g.is_enum_type_name(tokens[i - 2].lit) {
 				// An enum type prefix likewise makes keyword-named fields safe
 				// (`TokenKind.float` -> `TokenKind__float`).
 				item.lit
-			} else if i >= 2 && previous == .dot && tokens[i - 2].tok == .name
-				&& tokens[i - 2].lit == 'C' {
+			} else if i >= 2 && previous == .dot && tokens[i - 2].tok == .name && tokens[i - 2].lit == 'C' {
 				item.lit
 			} else if previous == .dot {
 				fastc_c_identifier(item.lit)
 			} else {
 				g.resolved_expression_name(item.lit, previous)
 			}
-		} else if item.tok == .dot && i > 0 && tokens[i - 1].tok == .name
-			&& tokens[i - 1].lit in g.imports {
+		} else if item.tok == .dot && i > 0 && tokens[i - 1].tok == .name && tokens[i - 1].lit in g.imports {
 			piece = '__'
-		} else if item.tok == .dot && i > 0 && tokens[i - 1].tok == .name
-			&& tokens[i - 1].lit == 'C' {
+		} else if item.tok == .dot && i > 0 && tokens[i - 1].tok == .name && tokens[i - 1].lit == 'C' {
 			piece = ''
-		} else if item.tok == .dot && i > 0 && tokens[i - 1].tok == .name
-			&& g.local_is_pointer(tokens[i - 1].lit) {
+		} else if item.tok == .dot && i > 0 && tokens[i - 1].tok == .name && g.local_is_pointer(tokens[i - 1].lit) {
 			piece = '->'
-		} else if item.tok == .dot && i > 0 && tokens[i - 1].tok == .name
-			&& tokens[i - 1].lit !in g.locals && g.is_enum_type_name(tokens[i - 1].lit) {
+		} else if item.tok == .dot && i > 0 && tokens[i - 1].tok == .name && tokens[i - 1].lit !in g.locals && g.is_enum_type_name(tokens[i - 1].lit) {
 			piece = '__'
 		} else if item.tok == .dot && module_separator {
 			piece = '__'
 		} else if piece == '' {
 			piece = item.tok.str()
 		}
-		if result.len > 0 && fastc_needs_space(result.last(), piece) && !module_separator
-			&& !previous_module_separator {
+		if result.len > 0 && fastc_needs_space(result.last(), piece) && !module_separator && !previous_module_separator {
 			result.write_u8(` `)
 		}
 		result.write_string(piece)
+		previous_module_separator = module_separator
 	}
 	return g.render_enum_alias_member_references(tokens, result.str())
 }
 
 fn (g &Parser) expression_dot_is_module_separator(tokens []FastcExpressionToken, index int) bool {
-	if index <= 0 || index >= tokens.len || tokens[index].tok != .dot
-		|| tokens[index - 1].tok != .name {
+	if index <= 0 || index >= tokens.len || tokens[index].tok != .dot || tokens[index - 1].tok != .name {
 		return false
 	}
 	previous_name := tokens[index - 1].lit
 	// An imported module name is only a qualifier at the start of a member chain.
 	// In `app.config.value`, `config` is a field even when the file imports `config`.
-	if (index < 2 || tokens[index - 2].tok != .dot) && (previous_name in g.imports
-		|| previous_name == 'C' || (previous_name !in g.locals
-		&& g.is_enum_type_name(previous_name))) {
+	if (index < 2 || tokens[index - 2].tok != .dot) && (previous_name in g.imports || previous_name == 'C' || (previous_name !in g.locals && g.is_enum_type_name(previous_name))) {
 		return true
 	}
 	if index < 3 || tokens[index - 2].tok != .dot || tokens[index - 3].tok != .name {
@@ -578,8 +553,7 @@ fn (g &Parser) array_initializer_type(tokens []FastcExpressionToken) ?string {
 	mut index := 0
 	mut dimensions := 0
 	mut fixed_length := ''
-	if tokens.len >= 4 && tokens[0].tok == .lsbr && tokens[1].tok in [.name, .number]
-		&& tokens[2].tok == .rsbr {
+	if tokens.len >= 4 && tokens[0].tok == .lsbr && tokens[1].tok in [.name, .number] && tokens[2].tok == .rsbr {
 		fixed_length = if tokens[1].tok == .name {
 			constant_key := fastc_constant_key(g.module_name, tokens[1].lit)
 			g.constants[constant_key] or { fastc_c_constant_name(g.module_name, tokens[1].lit) }
@@ -597,8 +571,7 @@ fn (g &Parser) array_initializer_type(tokens []FastcExpressionToken) ?string {
 		return none
 	}
 	mut element_type := g.type_from_expression_tokens(tokens[index..]) or { '' }
-	if element_type == '' && index + 1 == tokens.len && tokens[index].tok == .name
-		&& tokens[index].lit == 'thread' {
+	if element_type == '' && index + 1 == tokens.len && tokens[index].tok == .name && tokens[index].lit == 'thread' {
 		// `[]thread` is an array of spawned-thread handles (all handles share one
 		// C layout, keyed as the void-thread type).
 		element_type = fastc_thread_type_name('')
@@ -653,8 +626,7 @@ fn (g &Parser) type_from_expression_tokens(tokens []FastcExpressionToken) ?strin
 		element_type := g.type_from_expression_tokens(remaining[2..]) or { return none }
 		return fastc_array_c_type(element_type) + '*'.repeat(pointers)
 	}
-	if remaining.len >= 5 && remaining[0].tok == .name && remaining[0].lit == 'map'
-		&& remaining[1].tok == .lsbr {
+	if remaining.len >= 5 && remaining[0].tok == .name && remaining[0].lit == 'map' && remaining[1].tok == .lsbr {
 		close := fastc_matching_delimiter(remaining, 1, .lsbr, .rsbr) or { return none }
 		if close <= 2 || close + 1 >= remaining.len {
 			return none
@@ -677,8 +649,7 @@ fn (g &Parser) type_from_expression_tokens(tokens []FastcExpressionToken) ?strin
 		}
 		return base + '*'.repeat(pointers)
 	}
-	if remaining.len == 3 && remaining[0].tok == .name && remaining[1].tok == .dot
-		&& remaining[2].tok == .name {
+	if remaining.len == 3 && remaining[0].tok == .name && remaining[1].tok == .dot && remaining[2].tok == .name {
 		if remaining[0].lit == 'C' {
 			raw_type := remaining[2].lit
 			if '#Cstruct#${raw_type}' in g.declared_types {

--- a/vlib/v3/gen/fastc/expr.v
+++ b/vlib/v3/gen/fastc/expr.v
@@ -1075,7 +1075,10 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 			g.locals['err'] = FastcLocal{
 				typ: 'IError'
 			}
-			mut fallback := g.read_expression([token.Token.rcbr])!
+			// A multiline final expression gets a scanner-inserted semicolon before
+			// the block's `}`. Keep it out of the expression tokens so composite
+			// literals retain their inferred type.
+			mut fallback := g.read_expression([token.Token.semicolon, token.Token.rcbr])!
 			fallback_type := fastc_normalize_inferred_type(g.last_expression_type)
 			if fallback == '' {
 				fallback = '0'
@@ -1091,6 +1094,7 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 			} else {
 				g.locals.delete('err')
 			}
+			g.skip_semicolons()
 			g.expect(.rcbr)!
 			if fallback.contains('err') {
 				fallback = '({ IError err = ${temporary}.err; ${fallback}; })'
@@ -2239,35 +2243,110 @@ fn (g &Parser) expected_call_argument_type(tokens []FastcExpressionToken) string
 }
 
 fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered_expression string) ?FastcRenderedExpression {
-	if c_sizeof := g.render_c_struct_sizeof(tokens) {
-		return c_sizeof
+	if tokens.len == 6 && tokens[0].tok == .key_sizeof {
+		if c_sizeof := g.render_c_struct_sizeof(tokens) {
+			return c_sizeof
+		}
 	}
-	if interface_object := g.render_c_interface_object_address(tokens) {
-		return interface_object
+	if tokens.len == 9 && tokens[0].tok == .amp {
+		if interface_object := g.render_c_interface_object_address(tokens) {
+			return interface_object
+		}
 	}
-	if type_name := g.render_typeof_name_expression(tokens) {
-		return type_name
+	mut has_typeof := false
+	mut has_lpar := false
+	mut has_binary := false
+	mut has_comparison := false
+	mut has_plus := false
+	mut has_dot := false
+	mut has_lsbr := false
+	mut has_lcbr := false
+	mut has_left_shift := false
+	mut has_logical := false
+	mut has_as := false
+	mut has_assignment := false
+	mut has_membership := false
+	for item in tokens {
+		if item.tok.is_assignment() {
+			has_assignment = true
+		}
+		if item.lit == 'typeof' {
+			has_typeof = true
+		}
+		match item.tok {
+			.dot {
+				has_dot = true
+			}
+			.lpar {
+				has_lpar = true
+			}
+			.lsbr {
+				has_lsbr = true
+			}
+			.lcbr {
+				has_lcbr = true
+			}
+			.plus {
+				has_plus = true
+				has_binary = true
+			}
+			.left_shift {
+				has_left_shift = true
+				has_binary = true
+			}
+			.minus, .mul, .div, .mod, .amp, .pipe, .xor, .right_shift {
+				has_binary = true
+			}
+			.and, .logical_or {
+				has_binary = true
+				has_comparison = true
+				has_logical = true
+			}
+			.eq, .ne, .gt, .lt, .ge, .le, .key_is, .not_is {
+				has_binary = true
+				has_comparison = true
+			}
+			.key_in, .not_in {
+				has_binary = true
+				has_comparison = true
+				has_membership = true
+			}
+			.key_as {
+				has_as = true
+			}
+			else {}
+		}
 	}
-	if type_reflection := g.render_typeof_generic_expression(tokens) {
-		return type_reflection
+	if has_typeof {
+		if type_name := g.render_typeof_name_expression(tokens) {
+			return type_name
+		}
+		if type_reflection := g.render_typeof_generic_expression(tokens) {
+			return type_reflection
+		}
+		if type_comparison := g.render_typeof_generic_comparison_expression(tokens) {
+			return type_comparison
+		}
 	}
-	if type_comparison := g.render_typeof_generic_comparison_expression(tokens) {
-		return type_comparison
+	if has_lpar && tokens.len > 0 && tokens.last().tok == .rpar {
+		if disabled_call := g.render_disabled_call_expression(tokens) {
+			return disabled_call
+		}
 	}
-	if disabled_call := g.render_disabled_call_expression(tokens) {
-		return disabled_call
-	}
-	if enum_print := g.render_enum_print_expression(tokens) {
-		return enum_print
-	}
-	if selfhost_print := g.render_selfhost_print_expression(tokens) {
-		return selfhost_print
-	}
-	if bool_print := g.render_bool_print_expression(tokens) {
-		return bool_print
-	}
-	if string_print := g.render_ordinary_string_print_expression(tokens) {
-		return string_print
+	is_print := tokens.len >= 4 && tokens[0].tok == .name && tokens[0].lit in ['print', 'println']
+	if is_print {
+		if enum_print := g.render_enum_print_expression(tokens) {
+			return enum_print
+		}
+		if selfhost_print := g.render_selfhost_print_expression(tokens) {
+			return selfhost_print
+		}
+		if bool_print := g.render_bool_print_expression(tokens) {
+			return bool_print
+		}
+		if string_print := g.render_ordinary_string_print_expression(tokens) {
+			return string_print
+		}
 	}
 	if tokens.len == 1 && tokens[0].tok == .name {
 		if local := g.locals[tokens[0].lit] {
@@ -2289,21 +2368,29 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 			}
 		}
 	}
-	if overloaded_binary := g.render_overloaded_binary_expression(tokens) {
-		return overloaded_binary
+	if has_binary {
+		if overloaded_binary := g.render_overloaded_binary_expression(tokens) {
+			return overloaded_binary
+		}
 	}
-	if struct_comparison := g.render_struct_comparison_expression(tokens) {
-		return struct_comparison
-	}
-	if integer_comparison := g.render_mixed_integer_comparison_expression(tokens) {
-		return integer_comparison
+	if has_comparison {
+		if struct_comparison := g.render_struct_comparison_expression(tokens) {
+			return struct_comparison
+		}
+		if integer_comparison := g.render_mixed_integer_comparison_expression(tokens) {
+			return integer_comparison
+		}
 	}
 	if !g.selfhost {
-		if string_comparison := g.render_string_comparison_expression(tokens) {
-			return string_comparison
+		if has_comparison {
+			if string_comparison := g.render_string_comparison_expression(tokens) {
+				return string_comparison
+			}
 		}
-		if concatenation := g.render_composed_string_concatenation(tokens) {
-			return concatenation
+		if has_plus {
+			if concatenation := g.render_composed_string_concatenation(tokens) {
+				return concatenation
+			}
 		}
 	}
 	if g.selfhost {
@@ -2320,57 +2407,79 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 				return assignment
 			}
 		}
-		if interface_cast := g.render_interface_cast_expression(tokens, rendered_expression) {
-			return interface_cast
+		if has_lpar {
+			if interface_cast := g.render_interface_cast_expression(tokens, rendered_expression) {
+				return interface_cast
+			}
 		}
 		// An append RHS may itself use result propagation (`items << load()!`). Lower
 		// the append first so nested propagation is applied to the RHS call rather than
 		// returning a raw C expression that still contains V's `<<` operator.
-		if append_expression := g.render_append_expression(tokens, rendered_expression) {
-			return append_expression
+		if has_left_shift {
+			if append_expression := g.render_append_expression(tokens, rendered_expression) {
+				return append_expression
+			}
 		}
-		if nested_propagation := g.render_nested_option_propagation(tokens, rendered_expression) {
-			return nested_propagation
+		if tokens.len > 1 && tokens.last().tok == .not {
+			if nested_propagation := g.render_nested_option_propagation(tokens, rendered_expression) {
+				return nested_propagation
+			}
 		}
 	}
-	if cast_expression := g.render_cast_expression(tokens) {
-		if pointer_members := g.render_pointer_member_access_expression(tokens, cast_expression.source) {
-			return pointer_members
+	if has_lpar {
+		if cast_expression := g.render_cast_expression(tokens) {
+			if pointer_members := g.render_pointer_member_access_expression(tokens, cast_expression.source) {
+				return pointer_members
+			}
+			return cast_expression
 		}
-		return cast_expression
 	}
 	if g.selfhost {
-		if explicit_generic := g.render_explicit_generic_call_expression(tokens) {
-			return explicit_generic
+		if has_lsbr && has_lpar {
+			if explicit_generic := g.render_explicit_generic_call_expression(tokens) {
+				return explicit_generic
+			}
 		}
-		if defaulted_call := g.render_missing_call_arguments(tokens) {
-			return defaulted_call
+		if has_lpar {
+			if defaulted_call := g.render_missing_call_arguments(tokens) {
+				return defaulted_call
+			}
 		}
 		if map_expression := g.render_map_expression(tokens) {
 			return map_expression
 		}
-		if struct_literal := g.render_struct_literal_expression(tokens) {
-			return struct_literal
+		if has_lcbr {
+			if struct_literal := g.render_struct_literal_expression(tokens) {
+				return struct_literal
+			}
+			if struct_literal := g.render_struct_literal_field_names(tokens, rendered_expression) {
+				return struct_literal
+			}
 		}
-		if struct_literal := g.render_struct_literal_field_names(tokens, rendered_expression) {
-			return struct_literal
+		if has_assignment && has_lcbr {
+			if initializer_assignment := g.render_initializer_assignment_expression(tokens) {
+				return initializer_assignment
+			}
 		}
-		if initializer_assignment := g.render_initializer_assignment_expression(tokens) {
-			return initializer_assignment
+		if has_assignment {
+			if has_lsbr {
+				if array_assignment := g.render_array_assignment_expression(tokens) {
+					return array_assignment
+				}
+			}
+			if assignment := g.render_assignment_expression(tokens) {
+				return assignment
+			}
 		}
-		if array_assignment := g.render_array_assignment_expression(tokens) {
-			return array_assignment
-		}
-		if assignment := g.render_assignment_expression(tokens) {
-			return assignment
-		}
-		if tokens.len == 0 || tokens.last().tok != .not {
+		if has_dot && has_lpar && (tokens.len == 0 || tokens.last().tok != .not) {
 			if static_call := g.render_static_call_expression(tokens, rendered_expression) {
 				return static_call
 			}
 		}
-		if logical := g.render_logical_expression(tokens) {
-			return logical
+		if has_logical {
+			if logical := g.render_logical_expression(tokens) {
+				return logical
+			}
 		}
 		if tokens.len > 1 && tokens[0].tok == .not {
 			inner := g.render_call_argument_expression(tokens[1..], 'bool') or { return none }
@@ -2379,17 +2488,21 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 				typ: 'bool'
 			}
 		}
-		if option_comparison := g.render_option_none_comparison(tokens) {
-			return option_comparison
+		if has_comparison {
+			if option_comparison := g.render_option_none_comparison(tokens) {
+				return option_comparison
+			}
+			if enum_comparison := g.render_enum_comparison_expression(tokens) {
+				return enum_comparison
+			}
+			if string_comparison := g.render_string_comparison_expression(tokens) {
+				return string_comparison
+			}
 		}
-		if enum_comparison := g.render_enum_comparison_expression(tokens) {
-			return enum_comparison
-		}
-		if string_comparison := g.render_string_comparison_expression(tokens) {
-			return string_comparison
-		}
-		if concatenation := g.render_composed_string_concatenation(tokens) {
-			return concatenation
+		if has_plus {
+			if concatenation := g.render_composed_string_concatenation(tokens) {
+				return concatenation
+			}
 		}
 		if tokens.len > 1 && tokens.last().tok == .not && rendered_expression.ends_with('!') && !fastc_trailing_not_marks_fixed_array_literal(tokens) {
 			inner_tokens := tokens[..tokens.len - 1]
@@ -2425,164 +2538,180 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 				typ: value_type
 			}
 		}
-		mut depth := 0
-		for i, item in tokens {
-			if item.tok in [.lpar, .lsbr, .lcbr] {
-				depth++
-			} else if item.tok in [.rpar, .rsbr, .rcbr] {
-				depth--
-			} else if depth == 0 && item.tok in [.key_in, .not_in] && i > 0 && i + 1 < tokens.len {
-				temporary_namespace := g.temporary_namespace('membership')
-				right_tokens := tokens[i + 1..]
-				right_type := g.infer_expression_type(right_tokens) or { return none }
-				if g.underlying_alias_type(right_type) == 'string' {
-					left_type := g.infer_expression_type(tokens[..i]) or { return none }
-					if g.underlying_alias_type(left_type) != 'string' {
+		if has_membership {
+			mut depth := 0
+			for i, item in tokens {
+				if item.tok in [.lpar, .lsbr, .lcbr] {
+					depth++
+				} else if item.tok in [.rpar, .rsbr, .rcbr] {
+					depth--
+				} else if depth == 0 && item.tok in [.key_in, .not_in] && i > 0 && i + 1 < tokens.len {
+					temporary_namespace := g.temporary_namespace('membership')
+					right_tokens := tokens[i + 1..]
+					right_type := g.infer_expression_type(right_tokens) or { return none }
+					if g.underlying_alias_type(right_type) == 'string' {
+						left_type := g.infer_expression_type(tokens[..i]) or { return none }
+						if g.underlying_alias_type(left_type) != 'string' {
+							return none
+						}
+						substring := g.render_membership_candidate(tokens[..i], 'string') or {
+							return none
+						}
+						value := g.render_call_argument_expression(right_tokens, right_type) or {
+							return none
+						}
+						substring_name := '${temporary_namespace}_substring'
+						value_name := '${temporary_namespace}_value'
+						found := 'v_fastc_string_contains(${value_name}, ${substring_name})'
+						predicate := if item.tok == .not_in { '!(${found})' } else { found }
+						return FastcRenderedExpression{
+							source: '({ string ${substring_name} = (${substring}); string ${value_name} = (${value}); ${predicate}; })'
+							typ: 'bool'
+						}
+					}
+					if right_type.trim_right('*').starts_with('Map_') {
+						key_type, _ := g.map_key_value_types(right_type) or { return none }
+						key_source := g.render_membership_candidate(tokens[..i], key_type) or {
+							return none
+						}
+						map_source := g.render_member_receiver(right_tokens) or { return none }
+						map_expression := if right_type.ends_with('*') {
+							map_source
+						} else {
+							'&(${map_source})'
+						}
+						key_name := '${temporary_namespace}_map_key'
+						found := 'builtin__map_get_check((map *)${map_expression}, &${key_name}) != NULL'
+						predicate := if item.tok == .not_in { '!(${found})' } else { found }
+						return FastcRenderedExpression{
+							source: '({ ${fastc_runtime_c_type(key_type)} ${key_name} = (${key_source}); ${predicate}; })'
+							typ: 'bool'
+						}
+					}
+					right_layout := right_type.trim_right('*')
+					if right_layout.starts_with('Array_') || right_layout.starts_with('FixedArray_') {
+						element_type := g.array_element_type(right_type) or { return none }
+						candidate := g.render_membership_candidate(tokens[..i], element_type) or {
+							return none
+						}
+						collection := g.render_call_argument_expression(right_tokens, right_type) or {
+							return none
+						}
+						item_name := '${temporary_namespace}_item'
+						collection_name := '${temporary_namespace}_collection'
+						found_name := '${temporary_namespace}_found'
+						index_name := '${temporary_namespace}_index'
+						access := if right_type.ends_with('*') { '->' } else { '.' }
+						collection_length := if fixed_length := fastc_fixed_array_length(right_layout) {
+							fixed_length
+						} else {
+							'${collection_name}${access}len'
+						}
+						comparison := if g.underlying_alias_type(element_type).trim_right('*') == 'string' {
+							'builtin__string_eq(${item_name}, ((${element_type} *)${collection_name}${access}data)[${index_name}])'
+						} else {
+							'(${item_name} == ((${element_type} *)${collection_name}${access}data)[${index_name}])'
+						}
+						// A hoisted predicate keeps this interpolation flat: the FastC
+						// selfhost parser renders nested `${if ... { '${...}' }}` blocks
+						// literally, corrupting the emitted membership expression.
+						predicate := if item.tok == .not_in { '!${found_name}' } else { found_name }
+						return FastcRenderedExpression{
+							source: '({ ${element_type} ${item_name} = (${candidate}); __typeof__((${collection})) ${collection_name} = (${collection}); bool ${found_name} = false; for (int ${index_name} = 0; ${index_name} < ${collection_length}; ${index_name}++) { if (${comparison}) { ${found_name} = true; break; } } ${predicate}; })'
+							typ: 'bool'
+						}
+					}
+					array_end := if tokens.last().tok == .not { tokens.len - 1 } else { tokens.len }
+					if i + 2 >= array_end || tokens[i + 1].tok != .lsbr || tokens[array_end - 1].tok != .rsbr {
+						continue
+					}
+					lhs_type := g.infer_expression_type(tokens[..i]) or { return none }
+					items := fastc_expression_list_items(tokens, i + 2, array_end - 1) or {
 						return none
 					}
-					substring := g.render_membership_candidate(tokens[..i], 'string') or {
+					if items.len == 0 {
+						return FastcRenderedExpression{
+							source: if item.tok == .key_in { 'false' } else { 'true' }
+							typ: 'bool'
+						}
+					}
+					lhs_source := g.render_membership_candidate(tokens[..i], lhs_type) or {
 						return none
 					}
-					value := g.render_call_argument_expression(right_tokens, right_type) or {
-						return none
+					lhs_name := '${temporary_namespace}_subject'
+					value_type := fastc_runtime_c_type(fastc_normalize_inferred_type(lhs_type))
+					mut initializers := []string{cap: items.len}
+					mut comparisons := []string{cap: items.len}
+					for candidate_index, candidate in items {
+						candidate_source := g.render_membership_candidate(candidate, lhs_type) or {
+							return none
+						}
+						candidate_name := '${temporary_namespace}_candidate_${candidate_index}'
+						initializers << '${value_type} ${candidate_name} = (${candidate_source});'
+						comparison := if g.underlying_alias_type(lhs_type).trim_right('*') == 'string' {
+							'builtin__string_eq(${lhs_name}, ${candidate_name})'
+						} else {
+							'((${lhs_name}) == (${candidate_name}))'
+						}
+						comparisons << if item.tok == .key_in {
+							comparison
+						} else {
+							'!${comparison}'
+						}
 					}
-					substring_name := '${temporary_namespace}_substring'
-					value_name := '${temporary_namespace}_value'
-					found := 'v_fastc_string_contains(${value_name}, ${substring_name})'
-					predicate := if item.tok == .not_in { '!(${found})' } else { found }
+					joiner := if item.tok == .key_in { ' || ' } else { ' && ' }
 					return FastcRenderedExpression{
-						source: '({ string ${substring_name} = (${substring}); string ${value_name} = (${value}); ${predicate}; })'
+						source: '({ ${value_type} ${lhs_name} = (${lhs_source}); ${initializers.join(' ')} (${comparisons.join(joiner)}); })'
 						typ: 'bool'
 					}
-				}
-				if right_type.trim_right('*').starts_with('Map_') {
-					key_type, _ := g.map_key_value_types(right_type) or { return none }
-					key_source := g.render_membership_candidate(tokens[..i], key_type) or {
-						return none
-					}
-					map_source := g.render_member_receiver(right_tokens) or { return none }
-					map_expression := if right_type.ends_with('*') {
-						map_source
-					} else {
-						'&(${map_source})'
-					}
-					key_name := '${temporary_namespace}_map_key'
-					found := 'builtin__map_get_check((map *)${map_expression}, &${key_name}) != NULL'
-					predicate := if item.tok == .not_in { '!(${found})' } else { found }
-					return FastcRenderedExpression{
-						source: '({ ${fastc_runtime_c_type(key_type)} ${key_name} = (${key_source}); ${predicate}; })'
-						typ: 'bool'
-					}
-				}
-				right_layout := right_type.trim_right('*')
-				if right_layout.starts_with('Array_') || right_layout.starts_with('FixedArray_') {
-					element_type := g.array_element_type(right_type) or { return none }
-					candidate := g.render_membership_candidate(tokens[..i], element_type) or {
-						return none
-					}
-					collection := g.render_call_argument_expression(right_tokens, right_type) or {
-						return none
-					}
-					item_name := '${temporary_namespace}_item'
-					collection_name := '${temporary_namespace}_collection'
-					found_name := '${temporary_namespace}_found'
-					index_name := '${temporary_namespace}_index'
-					access := if right_type.ends_with('*') { '->' } else { '.' }
-					collection_length := if fixed_length := fastc_fixed_array_length(right_layout) {
-						fixed_length
-					} else {
-						'${collection_name}${access}len'
-					}
-					comparison := if g.underlying_alias_type(element_type).trim_right('*') == 'string' {
-						'builtin__string_eq(${item_name}, ((${element_type} *)${collection_name}${access}data)[${index_name}])'
-					} else {
-						'(${item_name} == ((${element_type} *)${collection_name}${access}data)[${index_name}])'
-					}
-					// A hoisted predicate keeps this interpolation flat: the FastC
-					// selfhost parser renders nested `${if ... { '${...}' }}` blocks
-					// literally, corrupting the emitted membership expression.
-					predicate := if item.tok == .not_in { '!${found_name}' } else { found_name }
-					return FastcRenderedExpression{
-						source: '({ ${element_type} ${item_name} = (${candidate}); __typeof__((${collection})) ${collection_name} = (${collection}); bool ${found_name} = false; for (int ${index_name} = 0; ${index_name} < ${collection_length}; ${index_name}++) { if (${comparison}) { ${found_name} = true; break; } } ${predicate}; })'
-						typ: 'bool'
-					}
-				}
-				array_end := if tokens.last().tok == .not { tokens.len - 1 } else { tokens.len }
-				if i + 2 >= array_end || tokens[i + 1].tok != .lsbr || tokens[array_end - 1].tok != .rsbr {
-					continue
-				}
-				lhs_type := g.infer_expression_type(tokens[..i]) or { return none }
-				items := fastc_expression_list_items(tokens, i + 2, array_end - 1) or {
-					return none
-				}
-				if items.len == 0 {
-					return FastcRenderedExpression{
-						source: if item.tok == .key_in { 'false' } else { 'true' }
-						typ: 'bool'
-					}
-				}
-				lhs_source := g.render_membership_candidate(tokens[..i], lhs_type) or {
-					return none
-				}
-				lhs_name := '${temporary_namespace}_subject'
-				value_type := fastc_runtime_c_type(fastc_normalize_inferred_type(lhs_type))
-				mut initializers := []string{cap: items.len}
-				mut comparisons := []string{cap: items.len}
-				for candidate_index, candidate in items {
-					candidate_source := g.render_membership_candidate(candidate, lhs_type) or {
-						return none
-					}
-					candidate_name := '${temporary_namespace}_candidate_${candidate_index}'
-					initializers << '${value_type} ${candidate_name} = (${candidate_source});'
-					comparison := if g.underlying_alias_type(lhs_type).trim_right('*') == 'string' {
-						'builtin__string_eq(${lhs_name}, ${candidate_name})'
-					} else {
-						'((${lhs_name}) == (${candidate_name}))'
-					}
-					comparisons << if item.tok == .key_in { comparison } else { '!${comparison}' }
-				}
-				joiner := if item.tok == .key_in { ' || ' } else { ' && ' }
-				return FastcRenderedExpression{
-					source: '({ ${value_type} ${lhs_name} = (${lhs_source}); ${initializers.join(' ')} (${comparisons.join(joiner)}); })'
-					typ: 'bool'
 				}
 			}
 		}
-		if array_type := g.infer_expression_type(tokens) {
-			if array_literal := g.render_array_literal_argument(tokens, array_type) {
-				return array_literal
-			}
-		}
-		// Resolve a complete index expression before the generic pointer/member
-		// rewriter gets a chance to treat its base as part of a longer chain.
-		if array_access := g.render_array_access_expression(tokens) {
-			return array_access
-		}
-		if pointer_members := g.render_pointer_member_access_expression(tokens, rendered_expression) {
-			return pointer_members
-		}
-		if method_expression := g.render_method_call_expression(tokens, rendered_expression) {
-			if array_expression := g.render_nested_array_access_expression(tokens, method_expression.source) {
-				return FastcRenderedExpression{
-					source: array_expression.source
-					typ: method_expression.typ
-				}
-			}
+		if has_lsbr {
 			if array_type := g.infer_expression_type(tokens) {
 				if array_literal := g.render_array_literal_argument(tokens, array_type) {
 					return array_literal
 				}
 			}
-			if pointer_members := g.render_pointer_member_access_expression(tokens, method_expression.source) {
-				return pointer_members
+		}
+		// Resolve a complete index expression before the generic pointer/member
+		// rewriter gets a chance to treat its base as part of a longer chain.
+		if has_lsbr {
+			if array_access := g.render_array_access_expression(tokens) {
+				return array_access
 			}
-			return method_expression
 		}
-		if defaulted_call := g.render_missing_call_arguments(tokens) {
-			return defaulted_call
+		if pointer_members := g.render_pointer_member_access_expression(tokens, rendered_expression) {
+			return pointer_members
 		}
-		if array_expression := g.render_nested_array_access_expression(tokens, rendered_expression) {
-			return array_expression
+		if has_dot && has_lpar {
+			if method_expression := g.render_method_call_expression(tokens, rendered_expression) {
+				if array_expression := g.render_nested_array_access_expression(tokens, method_expression.source) {
+					return FastcRenderedExpression{
+						source: array_expression.source
+						typ: method_expression.typ
+					}
+				}
+				if array_type := g.infer_expression_type(tokens) {
+					if array_literal := g.render_array_literal_argument(tokens, array_type) {
+						return array_literal
+					}
+				}
+				if pointer_members := g.render_pointer_member_access_expression(tokens, method_expression.source) {
+					return pointer_members
+				}
+				return method_expression
+			}
+		}
+		if has_lpar {
+			if defaulted_call := g.render_missing_call_arguments(tokens) {
+				return defaulted_call
+			}
+		}
+		if has_lsbr {
+			if array_expression := g.render_nested_array_access_expression(tokens, rendered_expression) {
+				return array_expression
+			}
 		}
 	}
 	if g.selfhost && tokens.len >= 3 && tokens[0].tok == .name && tokens[1].tok in [
@@ -2611,7 +2740,7 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 			typ: 'bool'
 		}
 	}
-	if g.selfhost {
+	if g.selfhost && has_as {
 		if as_expression := g.render_as_cast_expression(tokens) {
 			return as_expression
 		}
@@ -2631,7 +2760,7 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 			}
 		}
 	}
-	if g.selfhost {
+	if g.selfhost && has_lcbr {
 		mut init_open := -1
 		for i, item in tokens {
 			if item.tok == .lcbr {
@@ -2692,7 +2821,7 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 			typ: array_type
 		}
 	}
-	if g.selfhost && tokens.len > 0 && tokens.len % 2 == 1 {
+	if g.selfhost && tokens.len > 0 && tokens.len % 2 == 1 && (has_plus || (tokens.len == 1 && tokens[0].tok == .string)) {
 		mut is_literal_concat := true
 		mut literals := strings.new_builder(rendered_expression.len)
 		for i, item in tokens {
@@ -2718,7 +2847,7 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 			}
 		}
 	}
-	if g.selfhost {
+	if g.selfhost && has_plus {
 		mut depth := 0
 		mut operand_start := 0
 		mut string_operands := []bool{}
@@ -2760,7 +2889,10 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 			}
 		}
 	}
-	return g.render_flag_method_expression(tokens, rendered_expression)
+	if has_dot && has_lpar {
+		return g.render_flag_method_expression(tokens, rendered_expression)
+	}
+	return none
 }
 
 fn (g &Parser) expression_uses_member_smartcast(tokens []FastcExpressionToken) bool {

--- a/vlib/v3/gen/fastc/fastc.v
+++ b/vlib/v3/gen/fastc/fastc.v
@@ -1190,7 +1190,7 @@ fn generate_source_files(input_sources []FastcSourceFile, module_aliases map[str
 	}
 	startup_initializers := fastc_generate_startup_initializers(sources, constant_output.module_initializers, global_output.module_initializers, module_init_calls)!
 	used_function_names := fastc_wait_referenced_function_names(mut pending_references)
-	mut pending_interface_dispatches := fastc_start_interface_dispatches(declared_kinds, functions, interface_methods, used_function_names, prefs.building_v)
+	mut pending_interface_dispatches := fastc_start_interface_dispatches(declared_kinds, functions, interface_methods, used_function_names, prefs.building_v, prefs)
 	mut struct_field_lookup := map[string]map[string]FastcStructField{}
 	for layout_type, fields in struct_field_info {
 		mut fields_by_name := map[string]FastcStructField{}

--- a/vlib/v3/gen/fastc/fastc.v
+++ b/vlib/v3/gen/fastc/fastc.v
@@ -686,8 +686,9 @@ struct FastcSourceFile {
 }
 
 struct FastcQueuedSource {
-	path        string
-	module_name string
+	path         string
+	module_name  string
+	is_canonical bool
 }
 
 struct FastcLoadedSource {
@@ -814,20 +815,20 @@ struct Parser {
 	// Declared variants of each sum type, keyed `"${sum_type_c_name}|${variant_c_name}"`.
 	// Lets an append distinguish push-many (`[]T << []T`) from boxing an array-valued
 	// variant of a recursive sum type as one element (see sumtype_has_variant).
-	sum_type_variants      map[string]bool
-	struct_fields          map[string]map[string]string
-	struct_field_info      map[string][]FastcStructField
-	struct_field_lookup    map[string]map[string]FastcStructField
-	interface_fields       map[string]FastcInterfaceField
-	constants              map[string]string
-	constant_values        map[string]string
-	public_constants       map[string]bool
-	globals                map[string]string
-	public_globals         map[string]bool
-	used_function_names    map[string]bool
-	selfhost               bool
-	has_startup_inits      bool
-	has_cleanup_hooks      bool
+	sum_type_variants   map[string]bool
+	struct_fields       map[string]map[string]string
+	struct_field_info   map[string][]FastcStructField
+	struct_field_lookup map[string]map[string]FastcStructField
+	interface_fields    map[string]FastcInterfaceField
+	constants           map[string]string
+	constant_values     map[string]string
+	public_constants    map[string]bool
+	globals             map[string]string
+	public_globals      map[string]bool
+	used_function_names map[string]bool
+	selfhost            bool
+	has_startup_inits   bool
+	has_cleanup_hooks   bool
 mut:
 	path                     string
 	module_name              string
@@ -1135,9 +1136,7 @@ fn generate_source_files(input_sources []FastcSourceFile, module_aliases map[str
 	mut globals := map[string]string{}
 	mut public_globals := map[string]bool{}
 	mut type_source_paths := map[string]bool{}
-	fastc_collect_declaration_indexes(sources, prefs, mut declared_types, mut declared_kinds, mut
-		enum_flags, mut params_structs, mut type_source_paths, mut constants, mut public_constants, mut
-		globals, mut public_globals)!
+	fastc_collect_declaration_indexes(sources, prefs, mut declared_types, mut declared_kinds, mut enum_flags, mut params_structs, mut type_source_paths, mut constants, mut public_constants, mut globals, mut public_globals)!
 	declared_type_c_names := fastc_declared_type_c_names(declared_types)
 	mut functions := map[string]FastcFunctionSignature{}
 	mut interface_methods := map[string]bool{}
@@ -1146,14 +1145,12 @@ fn generate_source_files(input_sources []FastcSourceFile, module_aliases map[str
 	// interface it embeds), kept flat to stay in FastC's self-hostable subset.
 	mut embed_embedders := []string{}
 	mut embed_embeddeds := []string{}
-	fastc_collect_signatures(sources, prefs, declared_types, declared_type_c_names, params_structs, mut
-		functions, mut interface_methods, mut interface_fields, mut embed_embedders, mut
-		embed_embeddeds)!
+	fastc_collect_signatures(sources, prefs, declared_types, declared_type_c_names, params_structs, mut functions, mut interface_methods, mut interface_fields, mut embed_embedders, mut embed_embeddeds)!
 	// An interface that embeds another (`interface B { A; ... }`) inherits A's
 	// methods. Copy them onto B (with the receiver re-keyed to B) so calls on a B
 	// value resolve and B gets its own dispatch table entries.
 	fastc_promote_embedded_interface_methods(embed_embedders, embed_embeddeds, mut functions, mut interface_methods)
-	used_function_names := fastc_collect_referenced_function_names(sources, prefs, functions)
+	mut pending_references := fastc_start_referenced_function_names(sources, prefs, functions)
 	has_c_functions := fastc_functions_declare_c(functions)
 	fastc_prefixed_c_names := fastc_reserved_temporary_c_names(functions, globals)
 	module_init_calls := fastc_module_init_calls(sources, functions)!
@@ -1192,6 +1189,8 @@ fn generate_source_files(input_sources []FastcSourceFile, module_aliases map[str
 		fastc_register_composite_type(global_type, mut composite_types)
 	}
 	startup_initializers := fastc_generate_startup_initializers(sources, constant_output.module_initializers, global_output.module_initializers, module_init_calls)!
+	used_function_names := fastc_wait_referenced_function_names(mut pending_references)
+	mut pending_interface_dispatches := fastc_start_interface_dispatches(declared_kinds, functions, interface_methods, used_function_names, prefs.building_v)
 	mut struct_field_lookup := map[string]map[string]FastcStructField{}
 	for layout_type, fields in struct_field_info {
 		mut fields_by_name := map[string]FastcStructField{}
@@ -1312,7 +1311,7 @@ fn generate_source_files(input_sources []FastcSourceFile, module_aliases map[str
 	if late_composite_declarations.len > 0 {
 		late_composite_declarations.writeln('')
 	}
-	interface_dispatches := fastc_generate_interface_dispatches(declared_kinds, functions, interface_methods, used_function_names, prefs.building_v)
+	interface_dispatches := fastc_wait_interface_dispatches(mut pending_interface_dispatches)
 	fixed_array_declarations := fastc_generate_fixed_array_declarations(fixed_array_types)
 	preamble := if prefs.building_v { c_selfhost_preamble } else { c_preamble }
 	hoisted_body := fastc_hoist_c_directives(body.str())
@@ -1511,8 +1510,7 @@ fn fastc_generate_interface_dispatches(declared_kinds map[string]FastcDeclaredTy
 			}
 			for candidate_index in 0 .. candidate_count {
 				candidate_key := function_keys[candidate_index]
-				if candidate_key == interface_method_key
-					|| function_method_names[candidate_index] != method_name {
+				if candidate_key == interface_method_key || function_method_names[candidate_index] != method_name {
 					continue
 				}
 				receiver_key := candidate_key.all_before_last('.')
@@ -1560,22 +1558,58 @@ fn fastc_hoist_c_directives(source string) FastcHoistedCSource {
 	mut conditional_code := strings.new_builder(256)
 	mut body := strings.new_builder(source.len)
 	mut conditional_depth := 0
-	for line in source.split('\n') {
-		directive_name := fastc_c_directive_name(line)
+	mut line_start := 0
+	mut run_start := 0
+	mut run_kind := -1
+	for line_end := 0; line_end <= source.len; line_end++ {
+		if line_end < source.len && source[line_end] != `\n` {
+			continue
+		}
+		directive_kind := fastc_c_directive_kind(source, line_start, line_end)
+		mut line_kind := 0
 		if conditional_depth > 0 {
-			conditional_code.writeln(line)
-			if directive_name in ['if', 'ifdef', 'ifndef'] {
+			line_kind = 2
+			if directive_kind == 2 {
 				conditional_depth++
-			} else if directive_name == 'endif' {
+			} else if directive_kind == 3 {
 				conditional_depth--
 			}
-		} else if directive_name in ['if', 'ifdef', 'ifndef'] {
-			conditional_code.writeln(line)
+		} else if directive_kind == 2 {
+			line_kind = 2
 			conditional_depth = 1
-		} else if directive_name != '' {
-			directives.writeln(line)
-		} else {
-			body.writeln(line)
+		} else if directive_kind != 0 {
+			line_kind = 1
+		}
+		if run_kind == -1 {
+			run_kind = line_kind
+		} else if line_kind != run_kind {
+			segment := source[run_start..line_start]
+			match run_kind {
+				1 { directives.write_string(segment) }
+				2 { conditional_code.write_string(segment) }
+				else { body.write_string(segment) }
+			}
+			run_start = line_start
+			run_kind = line_kind
+		}
+		if line_end == source.len {
+			break
+		}
+		line_start = line_end + 1
+	}
+	segment := source[run_start..]
+	match run_kind {
+		1 {
+			directives.write_string(segment)
+			directives.write_u8(`\n`)
+		}
+		2 {
+			conditional_code.write_string(segment)
+			conditional_code.write_u8(`\n`)
+		}
+		else {
+			body.write_string(segment)
+			body.write_u8(`\n`)
 		}
 	}
 	if directives.len > 0 {
@@ -1591,9 +1625,36 @@ fn fastc_hoist_c_directives(source string) FastcHoistedCSource {
 	}
 }
 
-fn fastc_c_directive_name(line string) string {
-	if !line.starts_with('#') {
-		return ''
+// fastc_c_directive_kind classifies a source line without allocating a
+// substring: 0 is ordinary code, 1 a plain directive, 2 a conditional opener,
+// and 3 `#endif`.
+fn fastc_c_directive_kind(source string, start int, end int) int {
+	if start >= end || source[start] != `#` {
+		return 0
 	}
-	return line[1..].trim_space().fields()[0] or { '' }
+	mut name_start := start + 1
+	for name_start < end && source[name_start] in [` `, `\t`, `\r`, `\v`, `\f`] {
+		name_start++
+	}
+	if name_start == end {
+		return 0
+	}
+	mut name_end := name_start
+	for name_end < end && source[name_end] !in [` `, `\t`, `\r`, `\v`, `\f`] {
+		name_end++
+	}
+	name_len := name_end - name_start
+	if name_len == 2 && source[name_start] == `i` && source[name_start + 1] == `f` {
+		return 2
+	}
+	if name_len == 5 && source[name_start] == `i` && source[name_start + 1] == `f` && source[name_start + 2] == `d` && source[name_start + 3] == `e` && source[name_start + 4] == `f` {
+		return 2
+	}
+	if name_len == 6 && source[name_start] == `i` && source[name_start + 1] == `f` && source[name_start + 2] == `n` && source[name_start + 3] == `d` && source[name_start + 4] == `e` && source[name_start + 5] == `f` {
+		return 2
+	}
+	if name_len == 5 && source[name_start] == `e` && source[name_start + 1] == `n` && source[name_start + 2] == `d` && source[name_start + 3] == `i` && source[name_start + 4] == `f` {
+		return 3
+	}
+	return 1
 }

--- a/vlib/v3/gen/fastc/fastc_test.v
+++ b/vlib/v3/gen/fastc/fastc_test.v
@@ -419,6 +419,28 @@ fn test_fastc_file_generation_jobs_balance_largest_files_first() {
 	assert fastc_file_generation_job_indices(sources, 2) == [[0, 3], [1, 2]]
 }
 
+fn test_fastc_overlap_workers_honor_serial_preferences() {
+	mut prefs := pref.new_preferences()
+	prefs.no_parallel = true
+	sources := [
+		FastcSourceFile{ source: 'module main\nfn a() {}\n' },
+		FastcSourceFile{ source: 'module main\nfn b() {}\n' },
+		FastcSourceFile{ source: 'module main\nfn c() {}\n' },
+		FastcSourceFile{ source: 'module main\nfn d() {}\n' },
+	]
+	mut pending_references := fastc_start_referenced_function_names(sources, prefs, map[string]FastcFunctionSignature{})
+	assert pending_references.workers.len == 0
+	assert fastc_wait_referenced_function_names(mut pending_references).len > 0
+
+	mut functions := map[string]FastcFunctionSignature{}
+	for name in ['a', 'b', 'c', 'd'] {
+		functions[name] = FastcFunctionSignature{}
+	}
+	mut pending_dispatches := fastc_start_interface_dispatches(map[string]FastcDeclaredTypeKind{}, functions, map[string]bool{}, map[string]bool{}, false, prefs)
+	assert pending_dispatches.workers.len == 0
+	assert fastc_wait_interface_dispatches(mut pending_dispatches) == ''
+}
+
 fn test_fastc_source_declaration_flags_respect_identifier_boundaries() {
 	has_constants, has_global_declarations := fastc_source_declaration_flags('module main\nconst answer = 42\n__global count int\n')
 	assert has_constants

--- a/vlib/v3/gen/fastc/fastc_test.v
+++ b/vlib/v3/gen/fastc/fastc_test.v
@@ -6265,6 +6265,40 @@ fn main() {
 	assert !c_source.contains('groups[index]'), c_source
 }
 
+fn test_selfhost_fixed_array_elements_skip_dynamic_inner_array_initialization() {
+	prefs := pref.new_preferences()
+	g := Parser{
+		prefs: &prefs
+		s: scanner.new_scanner(prefs, .normal)
+		struct_fields: {
+			'array': {
+				'len': 'int'
+			}
+		}
+	}
+	mut tokens := [
+		FastcExpressionToken{
+			tok: .name
+			lit: 'array'
+			typ: 'Array_FixedArray_2_int'
+		},
+		fastc_test_expression_token(.lcbr, '{'),
+		fastc_test_expression_token(.name, 'len'),
+		fastc_test_expression_token(.colon, ':'),
+		fastc_test_expression_token(.number, '1'),
+		fastc_test_expression_token(.rcbr, '}'),
+	]
+	fixed := g.render_struct_literal_expression(tokens) or { panic('fixed array literal was not rendered') }
+	assert fixed.source.contains('sizeof(' + 'FixedArray_2_int' + ')'), fixed.source
+	assert !fixed.source.contains('builtin____new_array(0,0,sizeof(int))'), fixed.source
+	assert !fixed.source.contains('((FixedArray_2_int *)__v_fastc_array_init.data)'), fixed.source
+
+	tokens[0].typ = 'Array_Array_int'
+	dynamic := g.render_struct_literal_expression(tokens) or { panic('dynamic array literal was not rendered') }
+	assert dynamic.source.contains('builtin____new_array(0,0,sizeof(int))'), dynamic.source
+	assert dynamic.source.contains('((Array_int *)__v_fastc_array_init.data)'), dynamic.source
+}
+
 fn test_selfhost_append_array_result_to_struct_field() {
 	mut prefs := pref.new_preferences()
 	prefs.building_v = true

--- a/vlib/v3/gen/fastc/fastc_test.v
+++ b/vlib/v3/gen/fastc/fastc_test.v
@@ -411,10 +411,10 @@ fn test_fastc_chunk_bounds_reserve_files_for_later_workers() {
 
 fn test_fastc_file_generation_jobs_balance_largest_files_first() {
 	sources := [
-		FastcSourceFile{source: 'a'.repeat(60)},
-		FastcSourceFile{source: 'b'.repeat(50)},
-		FastcSourceFile{source: 'c'.repeat(40)},
-		FastcSourceFile{source: 'd'.repeat(30)},
+		FastcSourceFile{ source: 'a'.repeat(60) },
+		FastcSourceFile{ source: 'b'.repeat(50) },
+		FastcSourceFile{ source: 'c'.repeat(40) },
+		FastcSourceFile{ source: 'd'.repeat(30) },
 	]
 	assert fastc_file_generation_job_indices(sources, 2) == [[0, 3], [1, 2]]
 }
@@ -1346,8 +1346,7 @@ fn test_source_resolver_preserves_aliases_for_scheduled_files() {
 	os.write_file(os.join_path(canonical_dir, 'canonical.v'), 'module canonical\n') or {
 		panic(err)
 	}
-	os.write_file(os.join_path(root, 'legacy', 'alias.v'),
-		"@[alias: '${canonical_dir}'] module legacy\n") or {
+	os.write_file(os.join_path(root, 'legacy', 'alias.v'), "@[alias: '${canonical_dir}'] module legacy\n") or {
 		panic(err)
 	}
 	mut prefs := pref.new_preferences()
@@ -1371,8 +1370,7 @@ fn test_source_resolver_preserves_aliases_for_symlinked_module_dirs() {
 	os.write_file(main_file, 'module main\nimport canonical\nimport legacy\nfn main() { canonical.ping(); legacy.ping() }\n') or {
 		panic(err)
 	}
-	os.write_file(os.join_path(canonical_dir, 'canonical.v'),
-		'module canonical\npub fn ping() {}\n') or {
+	os.write_file(os.join_path(canonical_dir, 'canonical.v'), 'module canonical\npub fn ping() {}\n') or {
 		panic(err)
 	}
 	mut prefs := pref.new_preferences()
@@ -1380,6 +1378,25 @@ fn test_source_resolver_preserves_aliases_for_symlinked_module_dirs() {
 	sources, aliases := fastc_resolve_source_files([main_file], prefs) or { panic(err) }
 	assert sources.len == 2
 	assert aliases['legacy'] == 'canonical'
+}
+
+fn test_source_resolver_canonicalizes_building_v_entry_path() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	prefs.vroot = os.real_path(@VEXEROOT)
+	canonical_entry := os.join_path(prefs.vroot, 'vlib', 'v3', 'v3.v')
+	// The regular V3 driver can pass a relative or otherwise non-canonical entry,
+	// while entry-module enumeration returns canonical absolute paths. Both spellings
+	// must resolve to one source or FastC reports a duplicate `main` during self-host.
+	noncanonical_entry := os.dir(canonical_entry) + '/../v3/v3.v'
+	sources, _ := fastc_resolve_source_files([noncanonical_entry], prefs) or { panic(err) }
+	mut entry_count := 0
+	for source in sources {
+		if source.path == canonical_entry {
+			entry_count++
+		}
+	}
+	assert entry_count == 1
 }
 
 fn test_header_discovers_imports_only_from_selected_comptime_branches() {
@@ -5961,6 +5978,14 @@ fn test_selfhost_type_aliases_are_hoisted_before_composite_fields() {
 	assert handle_index < alias_index && alias_index < request_index, ordered
 }
 
+fn test_c_directive_hoisting_preserves_source_order() {
+	source := 'one\n#include <x.h>\ntwo\n# if FLAG\nthree\n#ifdef INNER\nfour\n#endif\n#else\nfive\n#endif\nsix'
+	hoisted := fastc_hoist_c_directives(source)
+	assert hoisted.directives == '#include <x.h>\n\n'
+	assert hoisted.conditional_code == '# if FLAG\nthree\n#ifdef INNER\nfour\n#endif\n#else\nfive\n#endif\n\n'
+	assert hoisted.body == 'one\ntwo\nsix\n'
+}
+
 fn test_nested_fixed_array_struct_field_uses_native_c_dimensions() {
 	typ := fastc_fixed_array_type('4', fastc_fixed_array_type('256', 'u32'))
 	assert fastc_fixed_array_field_declaration(typ, 'values')? == 'u32 values[4][256]'
@@ -6235,6 +6260,8 @@ fn main() {
 ', 'selfhost_append_to_nested_array.v', prefs) or { panic(err) }
 	assert c_source.contains('__v_fastc_append_array_target'), c_source
 	assert c_source.contains('builtin__array_get(*(groups), index)'), c_source
+	assert c_source.contains('builtin____new_array(0,0,sizeof(int))'), c_source
+	assert c_source.contains('((Array_int *)__v_fastc_array_init.data)[__v_fastc_array_index]'), c_source
 	assert !c_source.contains('groups[index]'), c_source
 }
 
@@ -8177,6 +8204,27 @@ fn main() {
 	assert c_source.contains('__v_fastc_or_result'), c_source
 	assert c_source.contains('flag=9'), c_source
 	assert c_source.contains(' = (42)'), c_source
+}
+
+fn test_selfhost_or_block_with_multiline_struct_fallback_is_a_value() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Item {}
+
+fn get(items map[string]Item) Item {
+	return items[\'missing\'] or {
+		Item{}
+	}
+}
+
+fn main() {
+	_ := get(map[string]Item{})
+}
+', 'selfhost_multiline_struct_fallback.v', prefs) or { panic(err) }
+	assert c_source.contains('? ((Item){}) : *((Item *)'), c_source
+	assert !c_source.contains('if (__v_fastc_option_'), c_source
 }
 
 fn test_veb_template_compiles_to_builder() {
@@ -10405,6 +10453,33 @@ fn main() {
 	assert c_source.contains('builtin__map_get_check'), c_source
 	assert c_source.contains('builtin__map_set'), c_source
 	assert !c_source.contains('counts[key]+amount'), c_source
+}
+
+fn test_selfhost_map_assignment_keeps_overloaded_operation_in_value() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Text {
+	value string
+}
+
+fn (left Text) + (right Text) Text {
+	return Text{ value: left.value + right.value }
+}
+
+fn append_value(mut values map[string]Text, key string, suffix Text) {
+	previous := values[key] or { Text{} }
+	values[key] = previous + suffix
+}
+
+fn main() {
+	mut values := map[string]Text{}
+	append_value(mut values, "compiler", Text{ value: " initializer" })
+}
+', 'selfhost_map_assignment_overloaded_operation.v', prefs) or { panic(err) }
+	assert c_source.contains('Text __v_fastc_map_value = (Text_plus(previous,suffix))'), c_source
+	assert !c_source.contains('Text_plus(({ string __v_fastc_map_key'), c_source
 }
 
 fn test_selfhost_map_assignment_with_propagated_result() {

--- a/vlib/v3/gen/fastc/parallel_d_v3_no_parallel.v
+++ b/vlib/v3/gen/fastc/parallel_d_v3_no_parallel.v
@@ -2,6 +2,34 @@ module fastc
 
 import v3.pref
 
+struct FastcPendingReferences {
+	references map[string]bool
+}
+
+struct FastcPendingInterfaceDispatches {
+	dispatches string
+}
+
+fn fastc_start_referenced_function_names(sources []FastcSourceFile, prefs &pref.Preferences, functions map[string]FastcFunctionSignature) FastcPendingReferences {
+	return FastcPendingReferences{
+		references: fastc_collect_referenced_function_names(sources, prefs, functions)
+	}
+}
+
+fn fastc_wait_referenced_function_names(mut pending FastcPendingReferences) map[string]bool {
+	return pending.references
+}
+
+fn fastc_start_interface_dispatches(declared_kinds map[string]FastcDeclaredTypeKind, functions map[string]FastcFunctionSignature, interface_methods map[string]bool, used_function_names map[string]bool, selfhost bool) FastcPendingInterfaceDispatches {
+	return FastcPendingInterfaceDispatches{
+		dispatches: fastc_generate_interface_dispatches(declared_kinds, functions, interface_methods, used_function_names, selfhost)
+	}
+}
+
+fn fastc_wait_interface_dispatches(mut pending FastcPendingInterfaceDispatches) string {
+	return pending.dispatches
+}
+
 fn fastc_load_source_headers(paths []string, prefs &pref.Preferences) []FastcLoadedSource {
 	mut loaded := []FastcLoadedSource{cap: paths.len}
 	for path in paths {
@@ -27,21 +55,16 @@ fn fastc_generate_file_outputs(ctx &FastcFileGenContext, sources []FastcSourceFi
 
 fn fastc_collect_reference_partials(sources []FastcSourceFile, prefs &pref.Preferences, available_names map[string]bool, mut references map[string]map[string]bool, mut top_level_references map[string]bool) {
 	for source_file in sources {
-		fastc_collect_file_references(source_file, prefs, available_names, mut references, mut
-			top_level_references)
+		fastc_collect_file_references(source_file, prefs, available_names, mut references, mut top_level_references)
 	}
 }
 
 fn fastc_collect_declaration_indexes(sources []FastcSourceFile, prefs &pref.Preferences, mut declared_types map[string]bool, mut declared_kinds map[string]FastcDeclaredTypeKind, mut enum_flags map[string]bool, mut params_structs map[string]bool, mut type_source_paths map[string]bool, mut constants map[string]string, mut public_constants map[string]bool, mut globals map[string]string, mut public_globals map[string]bool) ! {
 	partial := fastc_collect_declaration_chunk(sources, prefs, 0, sources.len)
-	fastc_merge_declaration_partial(partial, mut declared_types, mut declared_kinds, mut
-		enum_flags, mut params_structs, mut type_source_paths, mut constants, mut public_constants, mut
-		globals, mut public_globals)!
+	fastc_merge_declaration_partial(partial, mut declared_types, mut declared_kinds, mut enum_flags, mut params_structs, mut type_source_paths, mut constants, mut public_constants, mut globals, mut public_globals)!
 }
 
 fn fastc_collect_signatures(sources []FastcSourceFile, prefs &pref.Preferences, declared_types map[string]bool, declared_type_c_names map[string]string, params_structs map[string]bool, mut functions map[string]FastcFunctionSignature, mut interface_methods map[string]bool, mut interface_fields map[string]FastcInterfaceField, mut embed_embedders []string, mut embed_embeddeds []string) ! {
-	partial := fastc_collect_signature_chunk(sources, prefs, declared_types, declared_type_c_names,
-		params_structs, 0, sources.len)
-	fastc_merge_signature_partial(partial, mut functions, mut interface_methods, mut
-		interface_fields, mut embed_embedders, mut embed_embeddeds)!
+	partial := fastc_collect_signature_chunk(sources, prefs, declared_types, declared_type_c_names, params_structs, 0, sources.len)
+	fastc_merge_signature_partial(partial, mut functions, mut interface_methods, mut interface_fields, mut embed_embedders, mut embed_embeddeds)!
 }

--- a/vlib/v3/gen/fastc/parallel_d_v3_no_parallel.v
+++ b/vlib/v3/gen/fastc/parallel_d_v3_no_parallel.v
@@ -20,7 +20,7 @@ fn fastc_wait_referenced_function_names(mut pending FastcPendingReferences) map[
 	return pending.references
 }
 
-fn fastc_start_interface_dispatches(declared_kinds map[string]FastcDeclaredTypeKind, functions map[string]FastcFunctionSignature, interface_methods map[string]bool, used_function_names map[string]bool, selfhost bool) FastcPendingInterfaceDispatches {
+fn fastc_start_interface_dispatches(declared_kinds map[string]FastcDeclaredTypeKind, functions map[string]FastcFunctionSignature, interface_methods map[string]bool, used_function_names map[string]bool, selfhost bool, _prefs &pref.Preferences) FastcPendingInterfaceDispatches {
 	return FastcPendingInterfaceDispatches{
 		dispatches: fastc_generate_interface_dispatches(declared_kinds, functions, interface_methods, used_function_names, selfhost)
 	}

--- a/vlib/v3/gen/fastc/parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/fastc/parallel_notd_v3_no_parallel.v
@@ -5,25 +5,40 @@ import v3.pref
 
 struct FastcPendingReferences {
 mut:
-	workers []thread map[string]bool
+	workers    []thread map[string]bool
+	references map[string]bool
 }
 
 struct FastcPendingInterfaceDispatches {
 mut:
-	workers []thread string
+	workers    []thread string
+	dispatches string
 }
 
 fn fastc_start_referenced_function_names(sources []FastcSourceFile, prefs &pref.Preferences, functions map[string]FastcFunctionSignature) FastcPendingReferences {
+	if fastc_parallel_job_count(sources.len, prefs) <= 1 {
+		return FastcPendingReferences{
+			references: fastc_collect_referenced_function_names(sources, prefs, functions)
+		}
+	}
 	return FastcPendingReferences{
 		workers: [spawn fastc_collect_referenced_function_names(sources, prefs, functions)]
 	}
 }
 
 fn fastc_wait_referenced_function_names(mut pending FastcPendingReferences) map[string]bool {
+	if pending.workers.len == 0 {
+		return pending.references
+	}
 	return pending.workers[0].wait()
 }
 
-fn fastc_start_interface_dispatches(declared_kinds map[string]FastcDeclaredTypeKind, functions map[string]FastcFunctionSignature, interface_methods map[string]bool, used_function_names map[string]bool, selfhost bool) FastcPendingInterfaceDispatches {
+fn fastc_start_interface_dispatches(declared_kinds map[string]FastcDeclaredTypeKind, functions map[string]FastcFunctionSignature, interface_methods map[string]bool, used_function_names map[string]bool, selfhost bool, prefs &pref.Preferences) FastcPendingInterfaceDispatches {
+	if fastc_parallel_job_count(functions.len, prefs) <= 1 {
+		return FastcPendingInterfaceDispatches{
+			dispatches: fastc_generate_interface_dispatches(declared_kinds, functions, interface_methods, used_function_names, selfhost)
+		}
+	}
 	return FastcPendingInterfaceDispatches{
 		workers: [
 			spawn fastc_generate_interface_dispatches(declared_kinds, functions, interface_methods, used_function_names, selfhost),
@@ -32,6 +47,9 @@ fn fastc_start_interface_dispatches(declared_kinds map[string]FastcDeclaredTypeK
 }
 
 fn fastc_wait_interface_dispatches(mut pending FastcPendingInterfaceDispatches) string {
+	if pending.workers.len == 0 {
+		return pending.dispatches
+	}
 	return pending.workers[0].wait()
 }
 

--- a/vlib/v3/gen/fastc/parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/fastc/parallel_notd_v3_no_parallel.v
@@ -3,6 +3,38 @@ module fastc
 import os
 import v3.pref
 
+struct FastcPendingReferences {
+mut:
+	workers []thread map[string]bool
+}
+
+struct FastcPendingInterfaceDispatches {
+mut:
+	workers []thread string
+}
+
+fn fastc_start_referenced_function_names(sources []FastcSourceFile, prefs &pref.Preferences, functions map[string]FastcFunctionSignature) FastcPendingReferences {
+	return FastcPendingReferences{
+		workers: [spawn fastc_collect_referenced_function_names(sources, prefs, functions)]
+	}
+}
+
+fn fastc_wait_referenced_function_names(mut pending FastcPendingReferences) map[string]bool {
+	return pending.workers[0].wait()
+}
+
+fn fastc_start_interface_dispatches(declared_kinds map[string]FastcDeclaredTypeKind, functions map[string]FastcFunctionSignature, interface_methods map[string]bool, used_function_names map[string]bool, selfhost bool) FastcPendingInterfaceDispatches {
+	return FastcPendingInterfaceDispatches{
+		workers: [
+			spawn fastc_generate_interface_dispatches(declared_kinds, functions, interface_methods, used_function_names, selfhost),
+		]
+	}
+}
+
+fn fastc_wait_interface_dispatches(mut pending FastcPendingInterfaceDispatches) string {
+	return pending.workers[0].wait()
+}
+
 fn fastc_parallel_job_count(item_count int, prefs &pref.Preferences) int {
 	if prefs.no_parallel {
 		return 1
@@ -46,14 +78,17 @@ fn fastc_load_source_headers(paths []string, prefs &pref.Preferences) []FastcLoa
 		return fastc_load_source_chunk(paths, prefs, 0, paths.len)
 	}
 	first_end := paths.len / jobs
-	first_thread := spawn fastc_load_source_chunk(paths, prefs, 0, first_end)
-	mut chunk_threads := [first_thread]
-	for chunk_idx in 1 .. jobs {
+	second_start := paths.len / jobs
+	second_end := paths.len * 2 / jobs
+	second_thread := spawn fastc_load_source_chunk(paths, prefs, second_start, second_end)
+	mut chunk_threads := [second_thread]
+	for chunk_idx in 2 .. jobs {
 		start := paths.len * chunk_idx / jobs
 		end := paths.len * (chunk_idx + 1) / jobs
 		chunk_threads << spawn fastc_load_source_chunk(paths, prefs, start, end)
 	}
 	mut loaded := []FastcLoadedSource{cap: paths.len}
+	loaded << fastc_load_source_chunk(paths, prefs, 0, first_end)
 	for chunk_thread in chunk_threads {
 		loaded << chunk_thread.wait()
 	}
@@ -96,17 +131,15 @@ fn fastc_collect_generic_method_sources(sources []FastcSourceFile, prefs &pref.P
 		return fastc_collect_generic_method_source_chunk(sources, prefs, 0, sources.len)
 	}
 	bounds := fastc_chunk_bounds(sources, jobs)
-	first_thread := spawn fastc_collect_generic_method_source_chunk(sources, prefs, bounds[0],
-		bounds[1])
-	mut chunk_threads := [first_thread]
-	for chunk_idx in 1 .. bounds.len / 2 {
-		chunk_thread := spawn fastc_collect_generic_method_source_chunk(sources, prefs,
-			bounds[chunk_idx * 2], bounds[chunk_idx * 2 + 1])
+	second_thread := spawn fastc_collect_generic_method_source_chunk(sources, prefs, bounds[2], bounds[3])
+	mut chunk_threads := [second_thread]
+	for chunk_idx in 2 .. bounds.len / 2 {
+		chunk_thread := spawn fastc_collect_generic_method_source_chunk(sources, prefs, bounds[chunk_idx * 2], bounds[chunk_idx * 2 + 1])
 		chunk_threads << chunk_thread
 	}
-	mut result := map[string]FastcGenericMethodSource{}
-	for chunk_idx in 0 .. chunk_threads.len {
-		chunk := chunk_threads[chunk_idx].wait()
+	mut result := fastc_collect_generic_method_source_chunk(sources, prefs, bounds[0], bounds[1])
+	for chunk_thread in chunk_threads {
+		chunk := chunk_thread.wait()
 		for key, generic in chunk {
 			result[key] = generic
 		}
@@ -182,15 +215,19 @@ fn fastc_generate_file_outputs(ctx &FastcFileGenContext, sources []FastcSourceFi
 		return outputs
 	}
 	job_indices := fastc_file_generation_job_indices(sources, jobs)
-	first_thread := spawn fastc_generate_file_chunk(ctx, sources, job_indices[0])
-	mut chunk_threads := [first_thread]
-	for chunk_idx in 1 .. jobs {
+	second_thread := spawn fastc_generate_file_chunk(ctx, sources, job_indices[1])
+	mut chunk_threads := [second_thread]
+	for chunk_idx in 2 .. jobs {
 		chunk_thread := spawn fastc_generate_file_chunk(ctx, sources, job_indices[chunk_idx])
 		chunk_threads << chunk_thread
 	}
 	mut outputs := []FastcFileGenOutput{len: sources.len}
-	for chunk_idx in 0 .. chunk_threads.len {
-		chunk_outputs := chunk_threads[chunk_idx].wait()
+	first_outputs := fastc_generate_file_chunk(ctx, sources, job_indices[0])
+	for indexed_output in first_outputs {
+		outputs[indexed_output.index] = indexed_output.output
+	}
+	for chunk_thread in chunk_threads {
+		chunk_outputs := chunk_thread.wait()
 		for indexed_output in chunk_outputs {
 			outputs[indexed_output.index] = indexed_output.output
 		}
@@ -210,12 +247,27 @@ fn fastc_collect_reference_chunk(sources []FastcSourceFile, prefs &pref.Preferen
 	mut references := map[string]map[string]bool{}
 	mut top_level_references := map[string]bool{}
 	for idx in start .. end {
-		fastc_collect_file_references(sources[idx], prefs, available_names, mut references, mut
-			top_level_references)
+		fastc_collect_file_references(sources[idx], prefs, available_names, mut references, mut top_level_references)
 	}
 	return FastcReferencePartial{
-		references:           references
+		references: references
 		top_level_references: top_level_references
+	}
+}
+
+fn fastc_merge_reference_partial(chunk FastcReferencePartial, mut references map[string]map[string]bool, mut top_level_references map[string]bool) {
+	for function_name in chunk.references.keys() {
+		mut combined := map[string]bool{}
+		if function_name in references {
+			combined = references[function_name].clone()
+		}
+		for referenced_name, _ in chunk.references[function_name] {
+			combined[referenced_name] = true
+		}
+		references[function_name] = combined.clone()
+	}
+	for referenced_name, _ in chunk.top_level_references {
+		top_level_references[referenced_name] = true
 	}
 }
 
@@ -226,35 +278,22 @@ fn fastc_collect_reference_partials(sources []FastcSourceFile, prefs &pref.Prefe
 	jobs := fastc_parallel_jobs(sources, prefs)
 	if jobs <= 1 {
 		for source_file in sources {
-			fastc_collect_file_references(source_file, prefs, available_names, mut references, mut
-				top_level_references)
+			fastc_collect_file_references(source_file, prefs, available_names, mut references, mut top_level_references)
 		}
 		return
 	}
 	bounds := fastc_chunk_bounds(sources, jobs)
-	first_thread := spawn fastc_collect_reference_chunk(sources, prefs, available_names, bounds[0],
-		bounds[1])
-	mut chunk_threads := [first_thread]
-	for chunk_idx in 1 .. bounds.len / 2 {
-		chunk_thread := spawn fastc_collect_reference_chunk(sources, prefs, available_names,
-			bounds[chunk_idx * 2], bounds[chunk_idx * 2 + 1])
+	second_thread := spawn fastc_collect_reference_chunk(sources, prefs, available_names, bounds[2], bounds[3])
+	mut chunk_threads := [second_thread]
+	for chunk_idx in 2 .. bounds.len / 2 {
+		chunk_thread := spawn fastc_collect_reference_chunk(sources, prefs, available_names, bounds[chunk_idx * 2], bounds[chunk_idx * 2 + 1])
 		chunk_threads << chunk_thread
 	}
-	for chunk_idx in 0 .. chunk_threads.len {
-		chunk := chunk_threads[chunk_idx].wait()
-		for function_name in chunk.references.keys() {
-			mut combined := map[string]bool{}
-			if function_name in references {
-				combined = references[function_name].clone()
-			}
-			for referenced_name, _ in chunk.references[function_name] {
-				combined[referenced_name] = true
-			}
-			references[function_name] = combined.clone()
-		}
-		for referenced_name, _ in chunk.top_level_references {
-			top_level_references[referenced_name] = true
-		}
+	first := fastc_collect_reference_chunk(sources, prefs, available_names, bounds[0], bounds[1])
+	fastc_merge_reference_partial(first, mut references, mut top_level_references)
+	for chunk_thread in chunk_threads {
+		chunk := chunk_thread.wait()
+		fastc_merge_reference_partial(chunk, mut references, mut top_level_references)
 	}
 }
 
@@ -262,49 +301,42 @@ fn fastc_collect_declaration_indexes(sources []FastcSourceFile, prefs &pref.Pref
 	jobs := fastc_parallel_jobs(sources, prefs)
 	if jobs <= 1 {
 		partial := fastc_collect_declaration_chunk(sources, prefs, 0, sources.len)
-		fastc_merge_declaration_partial(partial, mut declared_types, mut declared_kinds, mut
-			enum_flags, mut params_structs, mut type_source_paths, mut constants, mut public_constants,
-			mut globals, mut public_globals)!
+		fastc_merge_declaration_partial(partial, mut declared_types, mut declared_kinds, mut enum_flags, mut params_structs, mut type_source_paths, mut constants, mut public_constants, mut globals, mut public_globals)!
 		return
 	}
 	bounds := fastc_chunk_bounds(sources, jobs)
-	first_thread := spawn fastc_collect_declaration_chunk(sources, prefs, bounds[0], bounds[1])
-	mut chunk_threads := [first_thread]
-	for chunk_idx in 1 .. bounds.len / 2 {
-		chunk_thread := spawn fastc_collect_declaration_chunk(sources, prefs,
-			bounds[chunk_idx * 2], bounds[chunk_idx * 2 + 1])
+	second_thread := spawn fastc_collect_declaration_chunk(sources, prefs, bounds[2], bounds[3])
+	mut chunk_threads := [second_thread]
+	for chunk_idx in 2 .. bounds.len / 2 {
+		chunk_thread := spawn fastc_collect_declaration_chunk(sources, prefs, bounds[chunk_idx * 2], bounds[chunk_idx * 2 + 1])
 		chunk_threads << chunk_thread
 	}
-	for chunk_idx in 0 .. chunk_threads.len {
-		partial := chunk_threads[chunk_idx].wait()
-		fastc_merge_declaration_partial(partial, mut declared_types, mut declared_kinds, mut
-			enum_flags, mut params_structs, mut type_source_paths, mut constants, mut public_constants,
-			mut globals, mut public_globals)!
+	first := fastc_collect_declaration_chunk(sources, prefs, bounds[0], bounds[1])
+	fastc_merge_declaration_partial(first, mut declared_types, mut declared_kinds, mut enum_flags, mut params_structs, mut type_source_paths, mut constants, mut public_constants, mut globals, mut public_globals)!
+	for chunk_thread in chunk_threads {
+		partial := chunk_thread.wait()
+		fastc_merge_declaration_partial(partial, mut declared_types, mut declared_kinds, mut enum_flags, mut params_structs, mut type_source_paths, mut constants, mut public_constants, mut globals, mut public_globals)!
 	}
 }
 
 fn fastc_collect_signatures(sources []FastcSourceFile, prefs &pref.Preferences, declared_types map[string]bool, declared_type_c_names map[string]string, params_structs map[string]bool, mut functions map[string]FastcFunctionSignature, mut interface_methods map[string]bool, mut interface_fields map[string]FastcInterfaceField, mut embed_embedders []string, mut embed_embeddeds []string) ! {
 	jobs := fastc_parallel_jobs(sources, prefs)
 	if jobs <= 1 {
-		partial := fastc_collect_signature_chunk(sources, prefs, declared_types,
-			declared_type_c_names, params_structs, 0, sources.len)
-		fastc_merge_signature_partial(partial, mut functions, mut interface_methods, mut
-			interface_fields, mut embed_embedders, mut embed_embeddeds)!
+		partial := fastc_collect_signature_chunk(sources, prefs, declared_types, declared_type_c_names, params_structs, 0, sources.len)
+		fastc_merge_signature_partial(partial, mut functions, mut interface_methods, mut interface_fields, mut embed_embedders, mut embed_embeddeds)!
 		return
 	}
 	bounds := fastc_chunk_bounds(sources, jobs)
-	first_thread := spawn fastc_collect_signature_chunk(sources, prefs, declared_types,
-		declared_type_c_names, params_structs, bounds[0], bounds[1])
-	mut chunk_threads := [first_thread]
-	for chunk_idx in 1 .. bounds.len / 2 {
-		chunk_thread := spawn fastc_collect_signature_chunk(sources, prefs, declared_types,
-			declared_type_c_names, params_structs, bounds[chunk_idx * 2],
-			bounds[chunk_idx * 2 + 1])
+	second_thread := spawn fastc_collect_signature_chunk(sources, prefs, declared_types, declared_type_c_names, params_structs, bounds[2], bounds[3])
+	mut chunk_threads := [second_thread]
+	for chunk_idx in 2 .. bounds.len / 2 {
+		chunk_thread := spawn fastc_collect_signature_chunk(sources, prefs, declared_types, declared_type_c_names, params_structs, bounds[chunk_idx * 2], bounds[chunk_idx * 2 + 1])
 		chunk_threads << chunk_thread
 	}
-	for chunk_idx in 0 .. chunk_threads.len {
-		partial := chunk_threads[chunk_idx].wait()
-		fastc_merge_signature_partial(partial, mut functions, mut interface_methods, mut
-			interface_fields, mut embed_embedders, mut embed_embeddeds)!
+	first := fastc_collect_signature_chunk(sources, prefs, declared_types, declared_type_c_names, params_structs, bounds[0], bounds[1])
+	fastc_merge_signature_partial(first, mut functions, mut interface_methods, mut interface_fields, mut embed_embedders, mut embed_embeddeds)!
+	for chunk_thread in chunk_threads {
+		partial := chunk_thread.wait()
+		fastc_merge_signature_partial(partial, mut functions, mut interface_methods, mut interface_fields, mut embed_embedders, mut embed_embeddeds)!
 	}
 }

--- a/vlib/v3/gen/fastc/render.v
+++ b/vlib/v3/gen/fastc/render.v
@@ -42,7 +42,7 @@ fn (g &Parser) render_map_expression(tokens []FastcExpressionToken) ?FastcRender
 	if lookup := g.render_map_lookup_option_expression(tokens) {
 		return FastcRenderedExpression{
 			source: '({ Option lookup = (${lookup.source}); lookup.state ? (${lookup.typ}){0} : *((${lookup.typ} *)lookup.data); })'
-			typ:    lookup.typ
+			typ: lookup.typ
 		}
 	}
 	mut literal_open := -1
@@ -58,7 +58,7 @@ fn (g &Parser) render_map_expression(tokens []FastcExpressionToken) ?FastcRender
 			hash_fn, eq_fn, clone_fn, free_fn := g.map_runtime_functions(key_type)
 			return FastcRenderedExpression{
 				source: '(builtin__new_map(sizeof(${fastc_runtime_c_type(key_type)}), sizeof(${fastc_runtime_c_type(value_type)}), &${hash_fn}, &${eq_fn}, &${clone_fn}, &${free_fn}))'
-				typ:    map_type
+				typ: map_type
 			}
 		}
 	}
@@ -105,8 +105,7 @@ fn (g &Parser) render_map_expression(tokens []FastcExpressionToken) ?FastcRender
 		key_source := g.render_call_argument_expression(tokens[open + 1..close], key_type) or {
 			return none
 		}
-		value_source := g.render_call_argument_expression(tokens[assignment_index + 1..],
-			value_type) or { return none }
+		value_source := g.render_call_argument_expression(tokens[assignment_index + 1..], value_type) or { return none }
 		mut map_address := ''
 		if nested := g.render_mutable_map_value_pointer(base_tokens) {
 			if nested.typ != map_type.trim_right('*') {
@@ -121,11 +120,10 @@ fn (g &Parser) render_map_expression(tokens []FastcExpressionToken) ?FastcRender
 		}
 		return FastcRenderedExpression{
 			source: '({ ${key_type} __v_fastc_map_key = (${key_source}); ${value_type} __v_fastc_map_value = (${value_source}); builtin__map_set((map *)${map_address}, &__v_fastc_map_key, &__v_fastc_map_value); __v_fastc_map_value; })'
-			typ:    value_type
+			typ: value_type
 		}
 	}
-	if tokens.len >= 4 && tokens[0].tok == .name && tokens[1].tok == .lsbr
-		&& tokens.last().tok == .rsbr {
+	if tokens.len >= 4 && tokens[0].tok == .name && tokens[1].tok == .lsbr && tokens.last().tok == .rsbr {
 		close := fastc_matching_delimiter(tokens, 1, .lsbr, .rsbr) or { return none }
 		if close != tokens.len - 1 {
 			return none
@@ -140,16 +138,17 @@ fn (g &Parser) render_map_expression(tokens []FastcExpressionToken) ?FastcRender
 		map_address := if map_type.ends_with('*') { map_source } else { '&${map_source}' }
 		return FastcRenderedExpression{
 			source: '({ ${key_type} __v_fastc_map_key = (${key_source}); ${value_type} __v_fastc_map_zero = (${value_type}){0}; *((${value_type} *)builtin__map_get((map *)${map_address}, &__v_fastc_map_key, &__v_fastc_map_zero)); })'
-			typ:    value_type
+			typ: value_type
 		}
 	}
 	return none
 }
 
 fn (g &Parser) render_bool_print_expression(tokens []FastcExpressionToken) ?FastcRenderedExpression {
-	if g.selfhost || tokens.len < 4 || tokens[0].tok != .name
-		|| tokens[0].lit !in ['print', 'println'] || tokens[1].tok != .lpar
-		|| tokens.last().tok != .rpar {
+	if g.selfhost || tokens.len < 4 || tokens[0].tok != .name || tokens[0].lit !in [
+		'print',
+		'println',
+	] || tokens[1].tok != .lpar || tokens.last().tok != .rpar {
 		return none
 	}
 	call_end := fastc_matching_rpar(tokens, 1) or { return none }
@@ -175,14 +174,15 @@ fn (g &Parser) render_bool_print_expression(tokens []FastcExpressionToken) ?Fast
 	}
 	return FastcRenderedExpression{
 		source: '${function_name}((bool)(${argument}))'
-		typ:    'void'
+		typ: 'void'
 	}
 }
 
 fn (g &Parser) render_ordinary_string_print_expression(tokens []FastcExpressionToken) ?FastcRenderedExpression {
-	if g.selfhost || tokens.len < 4 || tokens[0].tok != .name
-		|| tokens[0].lit !in ['print', 'println'] || tokens[1].tok != .lpar
-		|| tokens.last().tok != .rpar {
+	if g.selfhost || tokens.len < 4 || tokens[0].tok != .name || tokens[0].lit !in [
+		'print',
+		'println',
+	] || tokens[1].tok != .lpar || tokens.last().tok != .rpar {
 		return none
 	}
 	call_end := fastc_matching_rpar(tokens, 1) or { return none }
@@ -200,13 +200,12 @@ fn (g &Parser) render_ordinary_string_print_expression(tokens []FastcExpressionT
 	argument := g.render_call_argument_expression(call_arguments[0], 'string') or { return none }
 	return FastcRenderedExpression{
 		source: '${tokens[0].lit}(${argument})'
-		typ:    'void'
+		typ: 'void'
 	}
 }
 
 fn (g &Parser) render_enum_print_expression(tokens []FastcExpressionToken) ?FastcRenderedExpression {
-	if tokens.len < 4 || tokens[0].tok != .name || tokens[0].lit !in ['print', 'println']
-		|| tokens[1].tok != .lpar || tokens.last().tok != .rpar {
+	if tokens.len < 4 || tokens[0].tok != .name || tokens[0].lit !in ['print', 'println'] || tokens[1].tok != .lpar || tokens.last().tok != .rpar {
 		return none
 	}
 	call_end := fastc_matching_rpar(tokens, 1) or { return none }
@@ -224,18 +223,17 @@ fn (g &Parser) render_enum_print_expression(tokens []FastcExpressionToken) ?Fast
 	argument := g.render_call_argument_expression(call_arguments[0], c_type) or { return none }
 	return FastcRenderedExpression{
 		source: 'v_fastc_print_enum_${c_type}(${argument}, ${if tokens[0].lit == 'println' {
-			'true'
-		} else {
-			'false'
-		}})'
-		typ:    'void'
+			'true'} else {
+			'false'}})'
+		typ: 'void'
 	}
 }
 
 fn (g &Parser) render_selfhost_print_expression(tokens []FastcExpressionToken) ?FastcRenderedExpression {
-	if !g.selfhost || tokens.len < 4 || tokens[0].tok != .name
-		|| tokens[0].lit !in ['print', 'println'] || tokens[1].tok != .lpar
-		|| tokens.last().tok != .rpar {
+	if !g.selfhost || tokens.len < 4 || tokens[0].tok != .name || tokens[0].lit !in [
+		'print',
+		'println',
+	] || tokens[1].tok != .lpar || tokens.last().tok != .rpar {
 		return none
 	}
 	call_end := fastc_matching_rpar(tokens, 1) or { return none }
@@ -274,7 +272,7 @@ fn (g &Parser) render_selfhost_print_expression(tokens []FastcExpressionToken) ?
 	string_value := '${fastc_method_c_name(signature.module_name, expected_receiver, 'str')}(${receiver_argument})'
 	return FastcRenderedExpression{
 		source: 'builtin__${tokens[0].lit}(${string_value})'
-		typ:    'void'
+		typ: 'void'
 	}
 }
 
@@ -310,7 +308,7 @@ fn (g &Parser) render_struct_literal_with_defaults(c_type string, layout_type st
 	}
 	return FastcRenderedExpression{
 		source: '({ ${explicit_initializers.join(' ')} ${base_type} __v_fastc_struct_default = ${initializer}; ${assignments.join(' ')} ${result}; })'
-		typ:    c_type
+		typ: c_type
 	}
 }
 
@@ -333,8 +331,7 @@ fn (g &Parser) render_empty_struct_initializer(c_type string) string {
 		return '(${c_type}){0}'
 	}
 	empty_initializers := []string{}
-	return g.render_struct_literal_with_defaults(c_type, layout_type, empty_initializers,
-		rendered_fields, rendered_fields_by_name).source
+	return g.render_struct_literal_with_defaults(c_type, layout_type, empty_initializers, rendered_fields, rendered_fields_by_name).source
 }
 
 // fastc_type_is_declared_struct reports whether `c_type` names a declared struct/union.
@@ -385,38 +382,36 @@ fn (g &Parser) render_struct_literal_field_names(tokens []FastcExpressionToken, 
 		return none
 	}
 	c_type := g.type_from_expression_tokens(tokens[..open]) or { return none }
-	mut field_names := []string{}
-	if fields := g.struct_fields[c_type.trim_right('*')] {
-		field_names = fields.keys()
-	} else {
-		return none
-	}
 	mut rendered := rendered_expression
 	mut changed := false
-	for field_name in field_names {
-		for module_name in [g.module_name, 'builtin'] {
-			constant_name := g.constants[fastc_constant_key(module_name, field_name)] or { '' }
-			mut resolved_names := []string{}
-			if constant_name != '' {
-				resolved_names << constant_name
-			}
-			function_key := fastc_function_key(module_name, field_name)
-			if function_key in g.functions || function_key in g.mono_functions {
-				resolved_names << fastc_c_function_name_for_key(function_key)
-			}
-			for resolved_name in resolved_names {
-				needle := '.${resolved_name}='
-				if rendered.contains(needle) {
-					rendered = rendered.replace(needle, '.${fastc_c_identifier(field_name)}=')
-					changed = true
+	if fields := g.struct_fields[c_type.trim_right('*')] {
+		for field_name, _ in fields {
+			for module_name in [g.module_name, 'builtin'] {
+				constant_name := g.constants[fastc_constant_key(module_name, field_name)] or { '' }
+				mut resolved_names := []string{}
+				if constant_name != '' {
+					resolved_names << constant_name
+				}
+				function_key := fastc_function_key(module_name, field_name)
+				if function_key in g.functions || function_key in g.mono_functions {
+					resolved_names << fastc_c_function_name_for_key(function_key)
+				}
+				for resolved_name in resolved_names {
+					needle := '.${resolved_name}='
+					if rendered.contains(needle) {
+						rendered = rendered.replace(needle, '.${fastc_c_identifier(field_name)}=')
+						changed = true
+					}
 				}
 			}
 		}
+	} else {
+		return none
 	}
 	return if changed {
 		FastcRenderedExpression{
 			source: rendered
-			typ:    c_type
+			typ: c_type
 		}
 	} else {
 		none
@@ -436,8 +431,7 @@ fn (g &Parser) render_array_assignment_expression(tokens []FastcExpressionToken)
 			break
 		}
 	}
-	if assignment_index <= 0 || assignment_index + 1 >= tokens.len
-		|| tokens[assignment_index - 1].tok != .rsbr {
+	if assignment_index <= 0 || assignment_index + 1 >= tokens.len || tokens[assignment_index - 1].tok != .rsbr {
 		return none
 	}
 	left := g.render_array_access_expression(tokens[..assignment_index]) or { return none }
@@ -445,9 +439,7 @@ fn (g &Parser) render_array_assignment_expression(tokens []FastcExpressionToken)
 		return none
 	}
 	operator := tokens[assignment_index].tok
-	source := if overloaded := g.render_overloaded_assignment(left.source, right, left.typ,
-		operator)
-	{
+	source := if overloaded := g.render_overloaded_assignment(left.source, right, left.typ, operator) {
 		overloaded
 	} else if operator == .right_shift_unsigned_assign {
 		g.render_unsigned_right_shift_assignment(left.source, right, left.typ) or { return none }
@@ -456,7 +448,7 @@ fn (g &Parser) render_array_assignment_expression(tokens []FastcExpressionToken)
 	}
 	return FastcRenderedExpression{
 		source: source
-		typ:    left.typ
+		typ: left.typ
 	}
 }
 
@@ -476,8 +468,7 @@ fn (g &Parser) render_initializer_assignment_expression(tokens []FastcExpression
 		return none
 	}
 	initializer_type_tokens := tokens[initializer_start..initializer_open]
-	if g.array_initializer_type(initializer_type_tokens) == none
-		&& g.map_initializer_type(initializer_type_tokens) == none {
+	if g.array_initializer_type(initializer_type_tokens) == none && g.map_initializer_type(initializer_type_tokens) == none {
 		return none
 	}
 	return g.render_assignment_expression(tokens)
@@ -519,8 +510,7 @@ fn (g &Parser) render_assignment_expression(tokens []FastcExpressionToken) ?Fast
 	}
 	rhs_tokens := tokens[assignment_index + 1..]
 	mut right := ''
-	if rhs_tokens.len == 2 && rhs_tokens[0].tok == .lsbr && rhs_tokens[1].tok == .rsbr
-		&& left_type.trim_right('*').starts_with('Array_') {
+	if rhs_tokens.len == 2 && rhs_tokens[0].tok == .lsbr && rhs_tokens[1].tok == .rsbr && left_type.trim_right('*').starts_with('Array_') {
 		// An empty array literal `[]` has no element type of its own; assigned to an
 		// array target it lowers to a typed empty array from the target's type (the
 		// standalone `x = []` case is handled where `expected_expression_type` is set).
@@ -554,7 +544,7 @@ fn (g &Parser) render_assignment_expression(tokens []FastcExpressionToken) ?Fast
 	}
 	return FastcRenderedExpression{
 		source: source
-		typ:    left_type
+		typ: left_type
 	}
 }
 
@@ -568,7 +558,9 @@ fn (g &Parser) render_overloaded_assignment(target string, value string, target_
 		.power_assign { '**' }
 		.or_assign { '|' }
 		.xor_assign { '^' }
-		else { return none }
+		else {
+			return none
+		}
 	}
 	method_key := g.method_function_key(target_type, operator)
 	signature := g.functions[method_key] or { return none }
@@ -588,7 +580,9 @@ fn (g &Parser) render_unsigned_right_shift_assignment(target string, value strin
 		'i32', 'int', 'rune', 'u32', 'unsigned int' { 'u32', '32' }
 		'i64', 'u64' { 'u64', '64' }
 		'isize', 'usize' { 'usize', '${g.prefs.target.pointer_bits}' }
-		else { return none }
+		else {
+			return none
+		}
 	}
 	return '({ ${target_type} *__v_fastc_unsigned_shift_target = &(${target}); ${unsigned_type} __v_fastc_unsigned_shift_value = (${unsigned_type})(*__v_fastc_unsigned_shift_target); u64 __v_fastc_unsigned_shift_count = (u64)(${value}); *__v_fastc_unsigned_shift_target = (${target_type})(__v_fastc_unsigned_shift_count >= ${bits} ? (${unsigned_type})0 : (__v_fastc_unsigned_shift_value >> __v_fastc_unsigned_shift_count)); })'
 }
@@ -603,6 +597,20 @@ fn fastc_overloaded_binary_precedence(tok token.Token) int {
 		.mul, .div, .mod { 6 }
 		else { 0 }
 	}
+}
+
+fn fastc_has_top_level_assignment(tokens []FastcExpressionToken) bool {
+	mut depth := 0
+	for item in tokens {
+		if item.tok in [.lpar, .lsbr, .lcbr] {
+			depth++
+		} else if item.tok in [.rpar, .rsbr, .rcbr] {
+			depth--
+		} else if depth == 0 && item.tok.is_assignment() {
+			return true
+		}
+	}
+	return false
 }
 
 fn (g &Parser) render_overloaded_comparison_expression(left_tokens []FastcExpressionToken, right_tokens []FastcExpressionToken, operator token.Token) ?FastcRenderedExpression {
@@ -655,11 +663,10 @@ fn (g &Parser) render_overloaded_comparison_expression(left_tokens []FastcExpres
 	argument := g.render_call_argument_expression(argument_tokens, signature.parameter_types[1]) or {
 		return none
 	}
-	call := '${fastc_method_c_name(signature.module_name, signature.parameter_types[0],
-		method_operator)}(${receiver},${argument})'
+	call := '${fastc_method_c_name(signature.module_name, signature.parameter_types[0], method_operator)}(${receiver},${argument})'
 	return FastcRenderedExpression{
 		source: if negate { '!(${call})' } else { call }
-		typ:    'bool'
+		typ: 'bool'
 	}
 }
 
@@ -674,15 +681,12 @@ fn (g &Parser) render_array_equality_comparison(left_tokens []FastcExpressionTok
 		return none
 	})
 	left_layout := left_type.trim_right('*')
-	if left_type != right_type
-		|| (!left_layout.starts_with('Array_') && !left_layout.starts_with('FixedArray_')) {
+	if left_type != right_type || (!left_layout.starts_with('Array_') && !left_layout.starts_with('FixedArray_')) {
 		return none
 	}
 	element_type := g.array_element_type(left_type) or { return none }
 	resolved_element := g.underlying_alias_type(element_type).trim_right('*')
-	is_scalar := fastc_is_numeric_expression_type(resolved_element) || resolved_element == 'bool'
-		|| fastc_is_pointer_type(element_type)
-		|| g.underlying_enum_type_key(g.semantic_type_key(element_type)) != none
+	is_scalar := fastc_is_numeric_expression_type(resolved_element) || resolved_element == 'bool' || fastc_is_pointer_type(element_type) || g.underlying_enum_type_key(g.semantic_type_key(element_type)) != none
 	if resolved_element != 'string' && !is_scalar {
 		return none
 	}
@@ -700,7 +704,7 @@ fn (g &Parser) render_array_equality_comparison(left_tokens []FastcExpressionTok
 		result := if operator == .ne { '!__v_fastc_array_equal' } else { '__v_fastc_array_equal' }
 		return FastcRenderedExpression{
 			source: '({ ${element_type} *__v_fastc_array_eq_left = (${element_type} *)(${left_data}); ${element_type} *__v_fastc_array_eq_right = (${element_type} *)(${right_data}); bool __v_fastc_array_equal = true; for (int __v_fastc_array_eq_index = 0; __v_fastc_array_eq_index < ${length}; __v_fastc_array_eq_index++) { if (!(${element_comparison})) { __v_fastc_array_equal = false; break; } } ${result}; })'
-			typ:    'bool'
+			typ: 'bool'
 		}
 	}
 	left := g.render_call_argument_expression(left_tokens, left_type) or { return none }
@@ -713,7 +717,7 @@ fn (g &Parser) render_array_equality_comparison(left_tokens []FastcExpressionTok
 	result := if operator == .ne { '!__v_fastc_array_equal' } else { '__v_fastc_array_equal' }
 	return FastcRenderedExpression{
 		source: '({ ${left_type} __v_fastc_array_eq_left = (${left}); ${right_type} __v_fastc_array_eq_right = (${right}); bool __v_fastc_array_equal = __v_fastc_array_eq_left.len == __v_fastc_array_eq_right.len; if (__v_fastc_array_equal) { for (int __v_fastc_array_eq_index = 0; __v_fastc_array_eq_index < __v_fastc_array_eq_left.len; __v_fastc_array_eq_index++) { if (!(${element_comparison})) { __v_fastc_array_equal = false; break; } } } ${result}; })'
-		typ:    'bool'
+		typ: 'bool'
 	}
 }
 
@@ -757,17 +761,21 @@ fn (g &Parser) render_overloaded_binary_expression(tokens []FastcExpressionToken
 			}
 			return FastcRenderedExpression{
 				source: '((${inner.source}))'
-				typ:    inner.typ
+				typ: inner.typ
 			}
 		}
+	}
+	// Assignment has lower precedence than every binary operator. Its RHS is
+	// rendered recursively by the assignment lowering, so do not split the full
+	// expression at an overloaded operator that appears after `=`.
+	if fastc_has_top_level_assignment(tokens) {
+		return none
 	}
 	if boolean_index := fastc_lowest_precedence_operator_index(tokens, 0, tokens.len) {
 		left_tokens := tokens[..boolean_index]
 		right_tokens := tokens[boolean_index + 1..]
 		operator := tokens[boolean_index].tok
-		if comparison := g.render_overloaded_comparison_expression(left_tokens, right_tokens,
-			operator)
-		{
+		if comparison := g.render_overloaded_comparison_expression(left_tokens, right_tokens, operator) {
 			return comparison
 		}
 		mut left_special := FastcRenderedExpression{}
@@ -805,7 +813,7 @@ fn (g &Parser) render_overloaded_binary_expression(tokens []FastcExpressionToken
 			}
 			return FastcRenderedExpression{
 				source: '((${left})${operator.str()}(${right}))'
-				typ:    'bool'
+				typ: 'bool'
 			}
 		}
 		return none
@@ -859,7 +867,7 @@ fn (g &Parser) render_overloaded_binary_expression(tokens []FastcExpressionToken
 		}
 		return FastcRenderedExpression{
 			source: '((${left})${operator}(${right}))'
-			typ:    g.infer_expression_type(tokens) or { left_type }
+			typ: g.infer_expression_type(tokens) or { left_type }
 		}
 	}
 	signature := g.functions[method_key]
@@ -873,9 +881,8 @@ fn (g &Parser) render_overloaded_binary_expression(tokens []FastcExpressionToken
 		return none
 	}
 	return FastcRenderedExpression{
-		source: '${fastc_method_c_name(signature.module_name, signature.parameter_types[0],
-			operator)}(${left},${right})'
-		typ:    signature.return_type
+		source: '${fastc_method_c_name(signature.module_name, signature.parameter_types[0], operator)}(${left},${right})'
+		typ: signature.return_type
 	}
 }
 
@@ -884,20 +891,16 @@ fn (g &Parser) render_pointer_member_access_expression(tokens []FastcExpressionT
 		return none
 	}
 	for i in 1 .. tokens.len - 1 {
-		if tokens[i].tok != .dot || tokens[i + 1].tok != .name || i + 2 >= tokens.len
-			|| tokens[i + 2].tok != .lpar {
+		if tokens[i].tok != .dot || tokens[i + 1].tok != .name || i + 2 >= tokens.len || tokens[i + 2].tok != .lpar {
 			continue
 		}
 		// A qualified function call can contain an embedded-field argument that
 		// still needs promotion here. A real method call is rendered later with
 		// its receiver and arguments, so preserve the old early exit for it.
-		is_qualified_call := tokens[i - 1].tok == .name
-			&& (tokens[i - 1].lit in g.imports || tokens[i - 1].lit == 'C')
-			&& (i < 2 || tokens[i - 2].tok != .dot)
+		is_qualified_call := tokens[i - 1].tok == .name && (tokens[i - 1].lit in g.imports || tokens[i - 1].lit == 'C') && (i < 2 || tokens[i - 2].tok != .dot)
 		method_marker := '.${tokens[i + 1].lit}('
 		pointer_method_marker := '->${tokens[i + 1].lit}('
-		if !is_qualified_call && (rendered_expression.contains(method_marker)
-			|| rendered_expression.contains(pointer_method_marker)) {
+		if !is_qualified_call && (rendered_expression.contains(method_marker) || rendered_expression.contains(pointer_method_marker)) {
 			return none
 		}
 	}
@@ -973,8 +976,7 @@ fn (g &Parser) render_pointer_member_access_expression(tokens []FastcExpressionT
 			g.render_membership_candidate(receiver_tokens, '') or { continue }
 		}
 		needle := '${receiver_source}.${tokens[i + 1].lit}'
-		replaced := fastc_replace_c_identifier(rendered, needle,
-			'${receiver_source}->${tokens[i + 1].lit}')
+		replaced := fastc_replace_c_identifier(rendered, needle, '${receiver_source}->${tokens[i + 1].lit}')
 		if replaced != rendered {
 			rendered = replaced
 			changed = true
@@ -982,8 +984,7 @@ fn (g &Parser) render_pointer_member_access_expression(tokens []FastcExpressionT
 		}
 		raw_receiver := g.render_raw_expression_tokens(receiver_tokens) or { '' }
 		raw_needle := '${raw_receiver}.${tokens[i + 1].lit}'
-		raw_replaced := fastc_replace_c_identifier(rendered, raw_needle, '${raw_receiver}->${tokens[
-			i + 1].lit}')
+		raw_replaced := fastc_replace_c_identifier(rendered, raw_needle, '${raw_receiver}->${tokens[i + 1].lit}')
 		if raw_receiver != '' && raw_replaced != rendered {
 			rendered = raw_replaced
 			changed = true
@@ -1005,7 +1006,7 @@ fn (g &Parser) render_pointer_member_access_expression(tokens []FastcExpressionT
 	inferred_type := g.infer_expression_type(tokens) or { '' }
 	return FastcRenderedExpression{
 		source: rendered
-		typ:    inferred_type
+		typ: inferred_type
 	}
 }
 
@@ -1048,10 +1049,7 @@ fn (g &Parser) render_chained_array_access_expression(tokens []FastcExpressionTo
 			g.array_element_type(base_type) or { continue }
 		}
 		raw_base := g.render_raw_expression_tokens(base_tokens) or { continue }
-		base_is_global_or_constant := base_tokens.len == 1
-			&& (fastc_global_key(g.module_name, base_tokens[0].lit) in g.globals
-			|| fastc_constant_key(g.module_name, base_tokens[0].lit) in g.constants
-			|| base_tokens[0].lit in g.constants)
+		base_is_global_or_constant := base_tokens.len == 1 && (fastc_global_key(g.module_name, base_tokens[0].lit) in g.globals || fastc_constant_key(g.module_name, base_tokens[0].lit) in g.constants || base_tokens[0].lit in g.constants)
 		base_source := if base_is_global_or_constant {
 			raw_base
 		} else {
@@ -1060,9 +1058,7 @@ fn (g &Parser) render_chained_array_access_expression(tokens []FastcExpressionTo
 		index_source := g.render_membership_candidate(tokens[open + 1..close], 'int') or {
 			continue
 		}
-		is_raw_fixed_array := base_type.trim_right('*').starts_with('FixedArray_')
-			&& (base_tokens.len > 1 || (base_tokens.len == 1
-			&& fastc_global_key(g.module_name, base_tokens[0].lit) in g.globals))
+		is_raw_fixed_array := base_type.trim_right('*').starts_with('FixedArray_') && (base_tokens.len > 1 || (base_tokens.len == 1 && fastc_global_key(g.module_name, base_tokens[0].lit) in g.globals))
 		replacement := if checked_access := g.render_array_access_expression(tokens[start..close + 1]) {
 			checked_access.source
 		} else if is_raw_fixed_array {
@@ -1086,49 +1082,64 @@ fn (g &Parser) render_chained_array_access_expression(tokens []FastcExpressionTo
 	return if changed {
 		FastcRenderedExpression{
 			source: rendered
-			typ:    inferred_type
+			typ: inferred_type
 		}
 	} else {
 		none
 	}
 }
 
-fn fastc_trim_expression_parentheses(tokens []FastcExpressionToken) []FastcExpressionToken {
+fn fastc_trim_expression_parentheses_bounds(tokens []FastcExpressionToken) (int, int) {
 	mut start := 0
 	mut end := tokens.len
 	for end - start >= 2 && tokens[start].tok == .lpar && tokens[end - 1].tok == .rpar {
-		trimmed := tokens[start..end]
-		close := fastc_matching_delimiter(trimmed, 0, .lpar, .rpar) or { break }
-		if close != trimmed.len - 1 {
+		mut depth := 0
+		mut close := -1
+		for i := start; i < end; i++ {
+			if tokens[i].tok == .lpar {
+				depth++
+			} else if tokens[i].tok == .rpar {
+				depth--
+				if depth == 0 {
+					close = i
+					break
+				}
+			}
+		}
+		if close != end - 1 {
 			break
 		}
 		start++
 		end--
 	}
-	return tokens[start..end].clone()
+	return start, end
 }
 
 // render_refined_enum_logical_expression lowers `x is Enum && x == .value`.
 // The right side is safe to unbox because C's `&&` preserves V's short-circuit
 // refinement semantics.
 fn (g &Parser) render_refined_enum_logical_expression(left_tokens []FastcExpressionToken, right_tokens []FastcExpressionToken) ?FastcRenderedExpression {
-	left := fastc_trim_expression_parentheses(left_tokens)
-	if left.len < 3 || left[0].tok != .name || left[1].tok != .key_is {
+	left_start, left_end := fastc_trim_expression_parentheses_bounds(left_tokens)
+	if left_end - left_start < 3 || left_tokens[left_start].tok != .name || left_tokens[left_start + 1].tok != .key_is {
 		return none
 	}
-	local := g.locals[left[0].lit] or { return none }
+	local_name := left_tokens[left_start].lit
+	local := g.locals[local_name] or { return none }
 	boxed_type := fastc_normalize_inferred_type(local.typ)
 	if !g.is_boxed_type(boxed_type) {
 		return none
 	}
-	target_type := g.type_from_expression_tokens(left[2..]) or { return none }
+	target_type := g.type_from_expression_tokens(left_tokens[left_start + 2..left_end]) or {
+		return none
+	}
 	enum_type := fastc_normalize_inferred_type(target_type).trim_right('*')
 	if g.declared_kinds[g.semantic_type_key(enum_type)] != .enum_ {
 		return none
 	}
-	right := fastc_trim_expression_parentheses(right_tokens)
+	right_start, right_end := fastc_trim_expression_parentheses_bounds(right_tokens)
 	mut comparison_index := -1
-	for i, item in right {
+	for i := right_start; i < right_end; i++ {
+		item := right_tokens[i]
 		if item.tok in [.eq, .ne, .lt, .gt, .le, .ge] {
 			if comparison_index != -1 {
 				return none
@@ -1139,24 +1150,20 @@ fn (g &Parser) render_refined_enum_logical_expression(left_tokens []FastcExpress
 	if comparison_index == -1 {
 		return none
 	}
-	comparison := right[comparison_index].tok.str()
-	comparison_left := right[..comparison_index]
-	comparison_right := right[comparison_index + 1..]
+	comparison := right_tokens[comparison_index].tok.str()
+	comparison_left_len := comparison_index - right_start
+	comparison_right_len := right_end - comparison_index - 1
 	mut enum_value := ''
 	mut enum_first := false
-	if comparison_left.len == 1 && comparison_left[0].tok == .name
-		&& comparison_left[0].lit == left[0].lit && comparison_right.len == 2
-		&& comparison_right[0].tok == .dot && comparison_right[1].tok == .name {
-		enum_value = comparison_right[1].lit
-	} else if comparison_right.len == 1 && comparison_right[0].tok == .name
-		&& comparison_right[0].lit == left[0].lit && comparison_left.len == 2
-		&& comparison_left[0].tok == .dot && comparison_left[1].tok == .name {
-		enum_value = comparison_left[1].lit
+	if comparison_left_len == 1 && right_tokens[right_start].tok == .name && right_tokens[right_start].lit == local_name && comparison_right_len == 2 && right_tokens[comparison_index + 1].tok == .dot && right_tokens[comparison_index + 2].tok == .name {
+		enum_value = right_tokens[comparison_index + 2].lit
+	} else if comparison_right_len == 1 && right_tokens[comparison_index + 1].tok == .name && right_tokens[comparison_index + 1].lit == local_name && comparison_left_len == 2 && right_tokens[right_start].tok == .dot && right_tokens[right_start + 1].tok == .name {
+		enum_value = right_tokens[right_start + 1].lit
 		enum_first = true
 	} else {
 		return none
 	}
-	subject := fastc_c_identifier(left[0].lit)
+	subject := fastc_c_identifier(local_name)
 	access := if boxed_type.ends_with('*') { '->' } else { '.' }
 	type_test := '((${subject}${access}_typ) == __v_typeid_${enum_type})'
 	concrete := '*((${enum_type} *)${subject}${access}_object)'
@@ -1168,7 +1175,7 @@ fn (g &Parser) render_refined_enum_logical_expression(left_tokens []FastcExpress
 	}
 	return FastcRenderedExpression{
 		source: '((${type_test})&&(${right_source}))'
-		typ:    'bool'
+		typ: 'bool'
 	}
 }
 
@@ -1189,7 +1196,7 @@ fn (g &Parser) render_logical_expression(tokens []FastcExpressionToken) ?FastcRe
 			right := g.render_call_argument_expression(tokens[i + 1..], 'bool') or { return none }
 			return FastcRenderedExpression{
 				source: '((${left})${if item.tok == .and { '&&' } else { '||' }}(${right}))'
-				typ:    'bool'
+				typ: 'bool'
 			}
 		}
 	}
@@ -1201,8 +1208,7 @@ fn (g &Parser) struct_equality_is_supported(typ string, seen []string) bool {
 		return true
 	}
 	layout_type := g.underlying_alias_type(typ).trim_right('*')
-	if layout_type == 'string' || layout_type == 'bool'
-		|| fastc_is_numeric_expression_type(layout_type) {
+	if layout_type == 'string' || layout_type == 'bool' || fastc_is_numeric_expression_type(layout_type) {
 		return true
 	}
 	if element_type := fastc_fixed_array_element_type(layout_type) {
@@ -1220,8 +1226,7 @@ fn (g &Parser) struct_equality_is_supported(typ string, seen []string) bool {
 	if type_key in g.declared_kinds && g.declared_kinds[type_key] == .enum_ {
 		return true
 	}
-	if type_key !in g.declared_kinds || g.declared_kinds[type_key] != .struct_
-		|| layout_type !in g.struct_field_info {
+	if type_key !in g.declared_kinds || g.declared_kinds[type_key] != .struct_ || layout_type !in g.struct_field_info {
 		return false
 	}
 	if layout_type in seen {
@@ -1253,8 +1258,7 @@ fn (g &Parser) struct_equality_source(left string, right string, typ string, see
 		length := g.fixed_array_length_value(length_source) or { return 'false' }
 		mut comparisons := []string{cap: length}
 		for index in 0 .. length {
-			comparisons << g.struct_equality_source('(${left})[${index}]', '(${right})[${index}]',
-				element_type, seen)
+			comparisons << g.struct_equality_source('(${left})[${index}]', '(${right})[${index}]', element_type, seen)
 		}
 		return if comparisons.len == 0 { 'true' } else { '(${comparisons.join(' && ')})' }
 	}
@@ -1265,16 +1269,14 @@ fn (g &Parser) struct_equality_source(left string, right string, typ string, see
 		index := '__v_fastc_array_eq_index'
 		left_element := '((${element_type} *)${left_array}.data)[${index}]'
 		right_element := '((${element_type} *)${right_array}.data)[${index}]'
-		element_equality :=
-			g.struct_equality_source(left_element, right_element, element_type, seen)
+		element_equality := g.struct_equality_source(left_element, right_element, element_type, seen)
 		return '({ ${layout_type} ${left_array} = (${left}); ${layout_type} ${right_array} = (${right}); bool ${equal} = ${left_array}.len == ${right_array}.len; for (int ${index} = 0; ${equal} && ${index} < ${left_array}.len; ${index}++) { if (!(${element_equality})) { ${equal} = false; } } ${equal}; })'
 	}
 	type_key := g.semantic_type_key(layout_type)
 	if type_key in g.declared_kinds && g.declared_kinds[type_key] == .enum_ {
 		return '((${left}) == (${right}))'
 	}
-	if type_key !in g.declared_kinds || g.declared_kinds[type_key] != .struct_
-		|| layout_type in seen {
+	if type_key !in g.declared_kinds || g.declared_kinds[type_key] != .struct_ || layout_type in seen {
 		return '((${left}) == (${right}))'
 	}
 	mut nested_seen := seen.clone()
@@ -1282,8 +1284,7 @@ fn (g &Parser) struct_equality_source(left string, right string, typ string, see
 	mut comparisons := []string{}
 	for field in g.struct_field_info[layout_type] {
 		field_name := fastc_c_identifier(field.name)
-		comparisons << g.struct_equality_source('(${left}).${field_name}',
-			'(${right}).${field_name}', field.typ, nested_seen)
+		comparisons << g.struct_equality_source('(${left}).${field_name}', '(${right}).${field_name}', field.typ, nested_seen)
 	}
 	return if comparisons.len == 0 { 'true' } else { '(${comparisons.join(' && ')})' }
 }
@@ -1321,7 +1322,7 @@ fn (g &Parser) render_struct_comparison_expression_impl(tokens []FastcExpression
 			}
 			return FastcRenderedExpression{
 				source: '((${inner.source}))'
-				typ:    'bool'
+				typ: 'bool'
 			}
 		}
 	}
@@ -1357,7 +1358,7 @@ fn (g &Parser) render_struct_comparison_expression_impl(tokens []FastcExpression
 			}
 			return FastcRenderedExpression{
 				source: '((${left}) ${if item.tok == .and { '&&' } else { '||' }} (${right}))'
-				typ:    'bool'
+				typ: 'bool'
 			}
 		}
 	}
@@ -1365,7 +1366,7 @@ fn (g &Parser) render_struct_comparison_expression_impl(tokens []FastcExpression
 		inner := g.render_struct_comparison_expression(tokens[1..]) or { return none }
 		return FastcRenderedExpression{
 			source: '!(${inner.source})'
-			typ:    'bool'
+			typ: 'bool'
 		}
 	}
 	depth = 0
@@ -1394,25 +1395,22 @@ fn (g &Parser) render_struct_comparison_expression_impl(tokens []FastcExpression
 					source := if item.tok == .ne { '!(${sum_eq})' } else { sum_eq }
 					return FastcRenderedExpression{
 						source: source
-						typ:    'bool'
+						typ: 'bool'
 					}
 				}
 				return none
 			}
 			left_key := g.semantic_type_key(left_layout)
-			if left_layout != right_layout || left_key !in g.declared_kinds
-				|| g.declared_kinds[left_key] != .struct_
-				|| !g.struct_equality_is_supported(left_type, []string{}) {
+			if left_layout != right_layout || left_key !in g.declared_kinds || g.declared_kinds[left_key] != .struct_ || !g.struct_equality_is_supported(left_type, []string{}) {
 				return none
 			}
 			left := g.render_comparison_operand(left_tokens, left_type) or { return none }
 			right := g.render_comparison_operand(right_tokens, right_type) or { return none }
-			equality := g.struct_equality_source('__v_fastc_eq_left', '__v_fastc_eq_right',
-				left_type, []string{})
+			equality := g.struct_equality_source('__v_fastc_eq_left', '__v_fastc_eq_right', left_type, []string{})
 			result := if item.tok == .ne { '!(${equality})' } else { equality }
 			return FastcRenderedExpression{
 				source: '({ ${left_type} __v_fastc_eq_left = (${left}); ${right_type} __v_fastc_eq_right = (${right}); ${result}; })'
-				typ:    'bool'
+				typ: 'bool'
 			}
 		}
 	}
@@ -1429,8 +1427,7 @@ fn (g &Parser) render_sum_type_equality(left_tokens []FastcExpressionToken, righ
 	if right_tokens.len >= 3 && right_tokens[0].tok == .name && right_tokens[1].tok == .lpar {
 		operand_start = 2
 		open_index = 1
-	} else if right_tokens.len >= 5 && right_tokens[0].tok == .name && right_tokens[1].tok == .dot
-		&& right_tokens[2].tok == .name && right_tokens[3].tok == .lpar {
+	} else if right_tokens.len >= 5 && right_tokens[0].tok == .name && right_tokens[1].tok == .dot && right_tokens[2].tok == .name && right_tokens[3].tok == .lpar {
 		operand_start = 4
 		open_index = 3
 	}
@@ -1497,9 +1494,7 @@ fn (g &Parser) render_as_cast_expression(tokens []FastcExpressionToken) ?FastcRe
 	mut type_key := ''
 	if as_index == tokens.len - 2 && tokens[as_index + 1].tok == .name {
 		type_key = g.resolve_declared_type_key(tokens[as_index + 1].lit) or { return none }
-	} else if as_index == tokens.len - 4 && tokens[as_index + 1].tok == .name
-		&& tokens[as_index + 2].tok == .dot && tokens[as_index + 3].tok == .name
-		&& tokens[as_index + 1].lit in g.imports {
+	} else if as_index == tokens.len - 4 && tokens[as_index + 1].tok == .name && tokens[as_index + 2].tok == .dot && tokens[as_index + 3].tok == .name && tokens[as_index + 1].lit in g.imports {
 		type_key = fastc_type_key(g.imports[tokens[as_index + 1].lit], tokens[as_index + 3].lit)
 		if type_key !in g.declared_types {
 			return none
@@ -1519,12 +1514,12 @@ fn (g &Parser) render_as_cast_expression(tokens []FastcExpressionToken) ?FastcRe
 	if g.is_boxed_type(target_c) {
 		return FastcRenderedExpression{
 			source: '({ ${left_type} ${src} = (${left_source}); (${target_c}){._object = ${src}${access}_object, ._typ = ${src}${access}_typ, ._methods = ${src}${access}_methods}; })'
-			typ:    target_c
+			typ: target_c
 		}
 	}
 	return FastcRenderedExpression{
 		source: '({ ${left_type} ${src} = (${left_source}); *((${target_c} *)${src}${access}_object); })'
-		typ:    target_c
+		typ: target_c
 	}
 }
 
@@ -1535,45 +1530,39 @@ fn (g &Parser) render_enum_comparison_expression(tokens []FastcExpressionToken) 
 			depth++
 		} else if item.tok in [.rpar, .rsbr, .rcbr] {
 			depth--
-		} else if depth == 0 && item.tok in [.eq, .ne, .lt, .gt, .le, .ge] && i > 0
-			&& i + 1 < tokens.len {
+		} else if depth == 0 && item.tok in [.eq, .ne, .lt, .gt, .le, .ge] && i > 0 && i + 1 < tokens.len {
 			left_tokens := tokens[..i]
 			right_tokens := tokens[i + 1..]
 			mut left_type := g.infer_expression_type(left_tokens) or { '' }
 			mut right_type := g.infer_expression_type(right_tokens) or { '' }
-			if left_type == '' && left_tokens.len > 2
-				&& left_tokens[left_tokens.len - 2].tok == .dot && left_tokens.last().tok == .name {
+			if left_type == '' && left_tokens.len > 2 && left_tokens[left_tokens.len - 2].tok == .dot && left_tokens.last().tok == .name {
 				receiver_type := g.infer_expression_type(left_tokens[..left_tokens.len - 2]) or {
 					''
 				}
 				left_type = g.struct_member_type(receiver_type, left_tokens.last().lit)
 			}
-			if right_type == '' && right_tokens.len > 2
-				&& right_tokens[right_tokens.len - 2].tok == .dot
-				&& right_tokens.last().tok == .name {
+			if right_type == '' && right_tokens.len > 2 && right_tokens[right_tokens.len - 2].tok == .dot && right_tokens.last().tok == .name {
 				receiver_type := g.infer_expression_type(right_tokens[..right_tokens.len - 2]) or {
 					''
 				}
 				right_type = g.struct_member_type(receiver_type, right_tokens.last().lit)
 			}
-			if g.declared_kinds[g.semantic_type_key(left_type)] == .enum_ && right_tokens.len == 2
-				&& right_tokens[0].tok == .dot && right_tokens[1].tok == .name {
+			if g.declared_kinds[g.semantic_type_key(left_type)] == .enum_ && right_tokens.len == 2 && right_tokens[0].tok == .dot && right_tokens[1].tok == .name {
 				left := g.render_call_argument_expression(left_tokens, left_type) or { return none }
 				enum_type := left_type.trim_right('*')
 				return FastcRenderedExpression{
 					source: '((${left}) ${item.tok.str()} (${enum_type}__${right_tokens[1].lit}))'
-					typ:    'bool'
+					typ: 'bool'
 				}
 			}
-			if g.declared_kinds[g.semantic_type_key(right_type)] == .enum_ && left_tokens.len == 2
-				&& left_tokens[0].tok == .dot && left_tokens[1].tok == .name {
+			if g.declared_kinds[g.semantic_type_key(right_type)] == .enum_ && left_tokens.len == 2 && left_tokens[0].tok == .dot && left_tokens[1].tok == .name {
 				right := g.render_call_argument_expression(right_tokens, right_type) or {
 					return none
 				}
 				enum_type := right_type.trim_right('*')
 				return FastcRenderedExpression{
 					source: '((${enum_type}__${left_tokens[1].lit}) ${item.tok.str()} (${right}))'
-					typ:    'bool'
+					typ: 'bool'
 				}
 			}
 		}
@@ -1601,7 +1590,7 @@ fn (g &Parser) render_option_none_comparison(tokens []FastcExpressionToken) ?Fas
 			operator := if item.tok == .eq { '==' } else { '!=' }
 			return FastcRenderedExpression{
 				source: '((${value}).state ${operator} 2)'
-				typ:    'bool'
+				typ: 'bool'
 			}
 		}
 	}
@@ -1647,7 +1636,7 @@ fn (g &Parser) render_string_comparison_expression(tokens []FastcExpressionToken
 		}
 		return FastcRenderedExpression{
 			source: '(${left_source}${if item.tok == .and { '&&' } else { '||' }}${right_source})'
-			typ:    'bool'
+			typ: 'bool'
 		}
 	}
 	depth = 0
@@ -1660,16 +1649,14 @@ fn (g &Parser) render_string_comparison_expression(tokens []FastcExpressionToken
 			depth--
 			continue
 		}
-		if depth != 0 || item.tok !in [.eq, .ne, .lt, .gt, .le, .ge] || i == 0
-			|| i + 1 >= tokens.len {
+		if depth != 0 || item.tok !in [.eq, .ne, .lt, .gt, .le, .ge] || i == 0 || i + 1 >= tokens.len {
 			continue
 		}
 		left_tokens := tokens[..i]
 		right_tokens := tokens[i + 1..]
 		left_type := g.infer_expression_type(left_tokens) or { return none }
 		right_type := g.infer_expression_type(right_tokens) or { return none }
-		if g.underlying_alias_type(left_type).trim_right('*') != 'string'
-			|| g.underlying_alias_type(right_type).trim_right('*') != 'string' {
+		if g.underlying_alias_type(left_type).trim_right('*') != 'string' || g.underlying_alias_type(right_type).trim_right('*') != 'string' {
 			return none
 		}
 		left_source := g.render_comparison_operand(left_tokens, 'string') or { return none }
@@ -1681,11 +1668,13 @@ fn (g &Parser) render_string_comparison_expression(tokens []FastcExpressionToken
 			.gt { 'builtin__string_lt(${right_source},${left_source})' }
 			.le { '!builtin__string_lt(${right_source},${left_source})' }
 			.ge { '!builtin__string_lt(${left_source},${right_source})' }
-			else { return none }
+			else {
+				return none
+			}
 		}
 		return FastcRenderedExpression{
 			source: source
-			typ:    'bool'
+			typ: 'bool'
 		}
 	}
 	return none
@@ -1724,7 +1713,7 @@ fn (g &Parser) render_mixed_integer_comparison_expression_impl(tokens []FastcExp
 			}
 			return FastcRenderedExpression{
 				source: '((${inner.source}))'
-				typ:    'bool'
+				typ: 'bool'
 			}
 		}
 	}
@@ -1732,7 +1721,7 @@ fn (g &Parser) render_mixed_integer_comparison_expression_impl(tokens []FastcExp
 		inner := g.render_mixed_integer_comparison_expression(tokens[1..]) or { return none }
 		return FastcRenderedExpression{
 			source: '!(${inner.source})'
-			typ:    'bool'
+			typ: 'bool'
 		}
 	}
 	mut depth := 0
@@ -1773,7 +1762,7 @@ fn (g &Parser) render_mixed_integer_comparison_expression_impl(tokens []FastcExp
 		}
 		return FastcRenderedExpression{
 			source: '((${left_source})${if item.tok == .and { '&&' } else { '||' }}(${right_source}))'
-			typ:    'bool'
+			typ: 'bool'
 		}
 	}
 	depth = 0
@@ -1786,8 +1775,7 @@ fn (g &Parser) render_mixed_integer_comparison_expression_impl(tokens []FastcExp
 			depth--
 			continue
 		}
-		if depth != 0 || item.tok !in [.eq, .ne, .lt, .gt, .le, .ge] || i == 0
-			|| i + 1 >= tokens.len {
+		if depth != 0 || item.tok !in [.eq, .ne, .lt, .gt, .le, .ge] || i == 0 || i + 1 >= tokens.len {
 			continue
 		}
 		left_tokens := tokens[..i]
@@ -1812,7 +1800,9 @@ fn (g &Parser) render_mixed_integer_comparison_expression_impl(tokens []FastcExp
 			.lt { 'lt' }
 			.ge { 'ge' }
 			.le { 'le' }
-			else { return none }
+			else {
+				return none
+			}
 		}
 		unsigned_source := if left_is_unsigned { left_source } else { right_source }
 		signed_source := if left_is_signed { left_source } else { right_source }
@@ -1827,15 +1817,14 @@ fn (g &Parser) render_mixed_integer_comparison_expression_impl(tokens []FastcExp
 		}
 		return FastcRenderedExpression{
 			source: 'v_fastc_us_${operation}((u64)(${unsigned_source}), (i64)(${signed_source}))'
-			typ:    'bool'
+			typ: 'bool'
 		}
 	}
 	return none
 }
 
 fn (g &Parser) render_comparison_operand(tokens []FastcExpressionToken, expected_type string) ?string {
-	if g.selfhost && tokens.len > 1 && tokens.last().tok == .not
-		&& !fastc_trailing_not_marks_fixed_array_literal(tokens) {
+	if g.selfhost && tokens.len > 1 && tokens.last().tok == .not && !fastc_trailing_not_marks_fixed_array_literal(tokens) {
 		if propagation := g.render_option_propagation(tokens[..tokens.len - 1]) {
 			return propagation.source
 		}
@@ -1924,8 +1913,7 @@ fn (g &Parser) render_call_argument_expression(tokens []FastcExpressionToken, ex
 	if map_literal := g.render_map_literal_argument(tokens, expected_type) {
 		return map_literal.source
 	}
-	if tokens.len == 2 && tokens[0].tok == .dot && tokens[1].tok == .name
-		&& g.declared_kinds[g.semantic_type_key(expected_type)] == .enum_ {
+	if tokens.len == 2 && tokens[0].tok == .dot && tokens[1].tok == .name && g.declared_kinds[g.semantic_type_key(expected_type)] == .enum_ {
 		return '${expected_type.trim_right('*')}__${tokens[1].lit}'
 	}
 	if function_value := g.render_function_value_expression(tokens) {
@@ -1948,8 +1936,7 @@ fn (g &Parser) render_call_argument_expression(tokens []FastcExpressionToken, ex
 				if fastc_is_pointer_type(expected_type) {
 					return raw
 				}
-				if expected_type != '' && (expected_type == value_type
-					|| fastc_selfhost_types_share_lowering_representation(value_type, expected_type)) {
+				if expected_type != '' && (expected_type == value_type || fastc_selfhost_types_share_lowering_representation(value_type, expected_type)) {
 					return '*(${raw})'
 				}
 			}
@@ -1969,23 +1956,17 @@ fn (g &Parser) render_call_argument_expression(tokens []FastcExpressionToken, ex
 	} else {
 		fastc_normalize_inferred_type(g.infer_expression_type(tokens) or { '' })
 	}
-	if expected_type == 'voidptr' && actual_type !in ['', 'voidptr', 'nil']
-		&& !fastc_expression_is_zero(tokens) && !fastc_is_pointer_type(actual_type) {
+	if expected_type == 'voidptr' && actual_type !in ['', 'voidptr', 'nil'] && !fastc_expression_is_zero(tokens) && !fastc_is_pointer_type(actual_type) {
 		box_value := '__v_fastc_generic_argument'
 		return '({ ${actual_type} ${box_value} = (${rendered}); v_fastc_interface_box(&${box_value}, sizeof(${actual_type})); })'
 	}
-	if actual_type == 'voidptr' && !expected_type.ends_with('*')
-		&& (expected_type.trim_right('*') in g.struct_fields
-		|| expected_type.trim_right('*').starts_with('Array_')
-		|| expected_type.trim_right('*').starts_with('Map_')
-		|| expected_type.trim_right('*').starts_with('FixedArray_')) {
+	if actual_type == 'voidptr' && !expected_type.ends_with('*') && (expected_type.trim_right('*') in g.struct_fields || expected_type.trim_right('*').starts_with('Array_') || expected_type.trim_right('*').starts_with('Map_') || expected_type.trim_right('*').starts_with('FixedArray_')) {
 		return '*((${expected_type} *)(${rendered}))'
 	}
 	if expected_type == 'string' && actual_type.trim_right('*') == 'IError' {
 		return 'builtin__IError_msg(${rendered})'
 	}
-	if actual_type.ends_with('*') && expected_type == actual_type.trim_right('*')
-		&& !fastc_expression_tokens_contain(tokens, .lsbr) {
+	if actual_type.ends_with('*') && expected_type == actual_type.trim_right('*') && !fastc_expression_tokens_contain(tokens, .lsbr) {
 		// V automatically dereferences an explicit reference when a by-value
 		// parameter is expected (`s &string` passed to `log_line(s string)`). A
 		// slice of a mutable array is already a by-value array even though the
@@ -2025,7 +2006,7 @@ fn (g &Parser) render_array_literal_argument(tokens []FastcExpressionToken, expe
 	if items.len == 0 {
 		return FastcRenderedExpression{
 			source: '(${array_type}){0}'
-			typ:    array_type
+			typ: array_type
 		}
 	}
 	mut rendered_items := []string{cap: items.len}
@@ -2042,12 +2023,12 @@ fn (g &Parser) render_array_literal_argument(tokens []FastcExpressionToken, expe
 		w.fixed_array_types[c_array_type] = array_type
 		return FastcRenderedExpression{
 			source: '((${c_array_type}){.data={${rendered_items.join(',')}}})'
-			typ:    array_type
+			typ: array_type
 		}
 	}
 	return FastcRenderedExpression{
 		source: '((${array_type})builtin__new_array_from_c_array(${items.len}, ${items.len}, sizeof(${normalized_element}), (${normalized_element}[]){${rendered_items.join(',')}}))'
-		typ:    array_type
+		typ: array_type
 	}
 }
 
@@ -2055,8 +2036,7 @@ fn (g &Parser) render_selfhost_simple_array_literal_item(tokens []FastcExpressio
 	if !g.selfhost || expected_type in ['Option', 'voidptr'] {
 		return none
 	}
-	if tokens.len == 4 && tokens[0].tok == .name && tokens[1].tok == .lpar
-		&& tokens[3].tok == .rpar && tokens[2].source == '' {
+	if tokens.len == 4 && tokens[0].tok == .name && tokens[1].tok == .lpar && tokens[3].tok == .rpar && tokens[2].source == '' {
 		cast_type := fastc_primitive_c_type(tokens[0].lit) or { return none }
 		if cast_type != expected_type.trim_right('*') || expected_type.ends_with('*') {
 			return none
@@ -2096,7 +2076,9 @@ fn (g &Parser) render_selfhost_simple_array_literal_item(tokens []FastcExpressio
 		.key_true { '((bool)true)' }
 		.key_false { '((bool)false)' }
 		.key_nil { 'NULL' }
-		else { return none }
+		else {
+			return none
+		}
 	}
 }
 
@@ -2107,8 +2089,7 @@ fn (g &Parser) render_function_value_expression(tokens []FastcExpressionToken) ?
 	if tokens.len == 1 && tokens[0].lit in g.locals {
 		return none
 	}
-	if tokens.len != 1 && !(tokens.len == 3 && tokens[0].tok == .name && tokens[1].tok == .dot
-		&& (tokens[0].lit in g.imports || tokens[0].lit == 'C')) {
+	if tokens.len != 1 && !(tokens.len == 3 && tokens[0].tok == .name && tokens[1].tok == .dot && (tokens[0].lit in g.imports || tokens[0].lit == 'C')) {
 		return none
 	}
 	function_key := g.function_key_for_call(tokens, tokens.len - 1)
@@ -2138,8 +2119,7 @@ fn (g &Parser) render_method_value_expression(tokens []FastcExpressionToken) ?st
 	if signature.parameter_types.len == 0 {
 		return none
 	}
-	return '&${fastc_method_c_name(signature.module_name, signature.parameter_types[0],
-		tokens.last().lit)}'
+	return '&${fastc_method_c_name(signature.module_name, signature.parameter_types[0], tokens.last().lit)}'
 }
 
 fn (g &Parser) render_map_literal_argument(tokens []FastcExpressionToken, expected_type string) ?FastcRenderedExpression {
@@ -2206,7 +2186,7 @@ fn (g &Parser) render_map_literal_argument(tokens []FastcExpressionToken, expect
 	}
 	return FastcRenderedExpression{
 		source: '({ ${statements.join(' ')} __v_fastc_argument_map; })'
-		typ:    map_type
+		typ: map_type
 	}
 }
 
@@ -2292,8 +2272,7 @@ fn (g &Parser) should_box_variant(expected_type string, actual_type string) bool
 		// Primitive or composite (`Array_`/`Map_`) value into a sum type. Interfaces
 		// have no primitive/composite implementers, so this is sum-type only.
 		normalized := fastc_normalize_inferred_type(actual_type).trim_right('*')
-		return fastc_primitive_c_type(normalized) != none || normalized.starts_with('Array_')
-			|| normalized.starts_with('Map_')
+		return fastc_primitive_c_type(normalized) != none || normalized.starts_with('Array_') || normalized.starts_with('Map_')
 	}
 	return false
 }
@@ -2334,11 +2313,10 @@ fn (g &Parser) render_map_lookup_option_expression(tokens []FastcExpressionToken
 	if map_type.ends_with('*') {
 		map_source = '*(${map_source})'
 	}
-	key_source := g.render_membership_candidate(lookup_tokens[open + 1..lookup_tokens.len - 1],
-		key_type) or { return none }
+	key_source := g.render_membership_candidate(lookup_tokens[open + 1..lookup_tokens.len - 1], key_type) or { return none }
 	return FastcRenderedExpression{
 		source: '({ ${key_type} __v_fastc_map_key = (${key_source}); ${value_type} *__v_fastc_map_value = (${value_type} *)builtin__map_get_check((map *)&(${map_source}), &__v_fastc_map_key); (Option){.data=__v_fastc_map_value, .state=__v_fastc_map_value == NULL ? 2 : 0}; })'
-		typ:    value_type
+		typ: value_type
 	}
 }
 
@@ -2375,11 +2353,10 @@ fn (g &Parser) render_array_lookup_option_expression(tokens []FastcExpressionTok
 	element_type := g.array_element_type(base_type) or { return none }
 	base_source := g.render_call_argument_expression(base_tokens, base_type) or { return none }
 	array_source := if base_type.ends_with('*') { '*(${base_source})' } else { base_source }
-	index_source := g.render_membership_candidate(lookup_tokens[open + 1..lookup_tokens.len - 1],
-		'int') or { return none }
+	index_source := g.render_membership_candidate(lookup_tokens[open + 1..lookup_tokens.len - 1], 'int') or { return none }
 	return FastcRenderedExpression{
 		source: '({ int __v_fastc_array_index = (${index_source}); ${base_type.trim_right('*')} __v_fastc_array = (${array_source}); bool __v_fastc_array_missing = __v_fastc_array_index < 0 || __v_fastc_array_index >= __v_fastc_array.len; ${element_type} *__v_fastc_array_value = __v_fastc_array_missing ? NULL : (${element_type} *)((byteptr)__v_fastc_array.data + (usize)__v_fastc_array_index * (usize)__v_fastc_array.element_size); (Option){.data=__v_fastc_array_value, .state=__v_fastc_array_missing ? 2 : 0}; })'
-		typ:    element_type
+		typ: element_type
 	}
 }
 
@@ -2462,8 +2439,7 @@ fn (g &Parser) render_append_expression(tokens []FastcExpressionToken, rendered_
 	// `type Value = []Value | int`), the array must be boxed as a single element
 	// instead. This mirrors the `sumtype_has_variant` guard the main C backend applies
 	// before selecting push-many (see vlib/v/gen/c/infix.v).
-	is_array_append := normalized_right == fastc_normalize_inferred_type(left_type)
-		&& !g.sumtype_has_variant(element_type, normalized_right)
+	is_array_append := normalized_right == fastc_normalize_inferred_type(left_type) && !g.sumtype_has_variant(element_type, normalized_right)
 	separator := rendered_expression.index('<<') or { return none }
 	left_tokens := tokens[..operator_index]
 	mut left_source := rendered_expression[..separator]
@@ -2497,8 +2473,7 @@ fn (g &Parser) render_append_expression(tokens []FastcExpressionToken, rendered_
 			map_type := g.infer_expression_type(base_tokens) or { '' }
 			if key_type, value_type := g.map_key_value_types(map_type) {
 				if value_type == left_type {
-					key_source := g.render_call_argument_expression(left_tokens[open + 1..left_tokens.len - 1],
-						key_type) or { return none }
+					key_source := g.render_call_argument_expression(left_tokens[open + 1..left_tokens.len - 1], key_type) or { return none }
 					mut map_source := if base_tokens.len == 1 && base_tokens[0].tok == .name {
 						g.globals[fastc_global_key(g.module_name, base_tokens[0].lit)] or {
 							g.resolved_expression_name(base_tokens[0].lit, .unknown)
@@ -2512,7 +2487,7 @@ fn (g &Parser) render_append_expression(tokens []FastcExpressionToken, rendered_
 					left_source = '({ ${key_type} __v_fastc_append_map_key = (${key_source}); ${value_type} *__v_fastc_append_map_value = (${value_type} *)builtin__map_get_check((map *)&(${map_source}), &__v_fastc_append_map_key); if (__v_fastc_append_map_value == NULL) { ${value_type} __v_fastc_append_map_empty = (${value_type}){0}; builtin__map_set((map *)&(${map_source}), &__v_fastc_append_map_key, &__v_fastc_append_map_empty); __v_fastc_append_map_value = (${value_type} *)builtin__map_get_check((map *)&(${map_source}), &__v_fastc_append_map_key); } __v_fastc_append_map_value; })'
 					return FastcRenderedExpression{
 						source: '({ ${element_type} ${temporary} = (${right_source}); ${value_type} *__v_fastc_append_map_target = ${left_source}; builtin__array_push((array *)__v_fastc_append_map_target, &${temporary}); 0; })'
-						typ:    'void'
+						typ: 'void'
 					}
 				}
 			}
@@ -2521,8 +2496,7 @@ fn (g &Parser) render_append_expression(tokens []FastcExpressionToken, rendered_
 			if base_layout.starts_with('Array_') {
 				outer_element_type := g.array_element_type(base_type) or { '' }
 				if fastc_normalize_inferred_type(outer_element_type) == fastc_normalize_inferred_type(left_type) {
-					index_source := g.render_call_argument_expression(left_tokens[open + 1..left_tokens.len - 1],
-						'int') or { return none }
+					index_source := g.render_call_argument_expression(left_tokens[open + 1..left_tokens.len - 1], 'int') or { return none }
 					base_source := if base_tokens.len == 1 {
 						g.resolved_root_expression_name(base_tokens[0].lit)
 					} else if nested_base := g.render_array_access_expression(base_tokens) {
@@ -2532,17 +2506,21 @@ fn (g &Parser) render_append_expression(tokens []FastcExpressionToken, rendered_
 					} else {
 						return none
 					}
-					array_value := if base_type.ends_with('*') { '*(${base_source})' } else { base_source }
+					array_value := if base_type.ends_with('*') {
+						'*(${base_source})'
+					} else {
+						base_source
+					}
 					target := '(${left_type.trim_right('*')} *)builtin__array_get(${array_value}, ${index_source})'
 					if is_array_append {
 						return FastcRenderedExpression{
 							source: '({ ${left_type.trim_right('*')} ${temporary} = (${right_source}); ${left_type.trim_right('*')} *__v_fastc_append_array_target = ${target}; builtin__array_push_many((array *)__v_fastc_append_array_target, ${temporary}.data, ${temporary}.len); 0; })'
-							typ:    'void'
+							typ: 'void'
 						}
 					}
 					return FastcRenderedExpression{
 						source: '({ ${element_type} ${temporary} = (${right_source}); ${left_type.trim_right('*')} *__v_fastc_append_array_target = ${target}; builtin__array_push((array *)__v_fastc_append_array_target, &${temporary}); 0; })'
-						typ:    'void'
+						typ: 'void'
 					}
 				}
 			}
@@ -2556,12 +2534,12 @@ fn (g &Parser) render_append_expression(tokens []FastcExpressionToken, rendered_
 		}
 		return FastcRenderedExpression{
 			source: '({ ${left_type.trim_right('*')} ${temporary} = (${right_source}); builtin__array_push_many(${array_target}, ${temporary}.data, ${temporary}.len); 0; })'
-			typ:    'void'
+			typ: 'void'
 		}
 	}
 	return FastcRenderedExpression{
 		source: '({ __typeof__((${right_source})) ${temporary} = (${right_source}); builtin__array_push((array *)&(${left_source}), &${temporary}); 0; })'
-		typ:    'void'
+		typ: 'void'
 	}
 }
 
@@ -2633,7 +2611,7 @@ fn (g &Parser) render_composed_string_concatenation(tokens []FastcExpressionToke
 	}
 	return FastcRenderedExpression{
 		source: combined
-		typ:    'string'
+		typ: 'string'
 	}
 }
 
@@ -2682,7 +2660,7 @@ fn (g &Parser) render_option_propagation(inner_tokens []FastcExpressionToken) ?F
 	}
 	return FastcRenderedExpression{
 		source: '({ Option ${temporary} = (${inner_source}); if (${temporary}.state) { ${failure} } ${value}; })'
-		typ:    value_type
+		typ: value_type
 	}
 }
 
@@ -2726,13 +2704,12 @@ fn (g &Parser) render_nested_option_propagation(tokens []FastcExpressionToken, r
 	}
 	return FastcRenderedExpression{
 		source: rendered
-		typ:    g.infer_expression_type(tokens) or { '' }
+		typ: g.infer_expression_type(tokens) or { '' }
 	}
 }
 
 fn (g &Parser) render_method_receiver_expression(tokens []FastcExpressionToken) ?FastcRenderedExpression {
-	if tokens.len > 1 && tokens.last().tok == .not && !(tokens[0].tok == .lsbr
-		&& tokens[tokens.len - 2].tok == .rsbr) {
+	if tokens.len > 1 && tokens.last().tok == .not && !(tokens[0].tok == .lsbr && tokens[tokens.len - 2].tok == .rsbr) {
 		// A `!`-propagated receiver (`f()!.m()`): unwrap the result before the call.
 		if propagation := g.render_option_propagation(tokens[..tokens.len - 1]) {
 			return propagation
@@ -2745,7 +2722,7 @@ fn (g &Parser) render_method_receiver_expression(tokens []FastcExpressionToken) 
 		// use it directly so the method call binds to it.
 		return FastcRenderedExpression{
 			source: tokens[0].source
-			typ:    receiver_type
+			typ: receiver_type
 		}
 	}
 	if source := g.render_map_expression(tokens) {
@@ -2769,7 +2746,7 @@ fn (g &Parser) render_method_receiver_expression(tokens []FastcExpressionToken) 
 	if source := g.render_member_receiver(tokens) {
 		return FastcRenderedExpression{
 			source: source
-			typ:    receiver_type
+			typ: receiver_type
 		}
 	}
 	if raw := g.render_raw_expression_tokens(tokens) {
@@ -2780,7 +2757,7 @@ fn (g &Parser) render_method_receiver_expression(tokens []FastcExpressionToken) 
 	if source := g.render_membership_candidate(tokens, '') {
 		return FastcRenderedExpression{
 			source: source
-			typ:    receiver_type
+			typ: receiver_type
 		}
 	}
 	return none

--- a/vlib/v3/gen/fastc/render_method_calls.v
+++ b/vlib/v3/gen/fastc/render_method_calls.v
@@ -92,16 +92,17 @@ fn (g &Parser) render_missing_call_arguments(tokens []FastcExpressionToken) ?Fas
 		if fixed_arguments < 0 || fixed_arguments > rendered_arguments.len {
 			return none
 		}
-		variadic_arguments := rendered_arguments[fixed_arguments..].clone()
-		packed := if variadic_arguments.len == 0 {
+		variadic_count := rendered_arguments.len - fixed_arguments
+		variadic_values := rendered_arguments[fixed_arguments..].join(',')
+		packed := if variadic_count == 0 {
 			'(${variadic_type}){0}'
 		} else {
-			'((${variadic_type})builtin__new_array_from_c_array(${variadic_arguments.len}, ${variadic_arguments.len}, sizeof(${element_type}), (${element_type}[]){${variadic_arguments.join(',')}}))'
+			'((${variadic_type})builtin__new_array_from_c_array(${variadic_count}, ${variadic_count}, sizeof(${element_type}), (${element_type}[]){${variadic_values}}))'
 		}
-		mut c_arguments := rendered_arguments[..fixed_arguments].clone()
-		c_arguments << packed
+		rendered_arguments.trim(fixed_arguments)
+		rendered_arguments << packed
 		return FastcRenderedExpression{
-			source: '${fastc_c_function_name_for_key(function_key)}(${c_arguments.join(',')})'
+			source: '${fastc_c_function_name_for_key(function_key)}(${rendered_arguments.join(',')})'
 			typ: signature.return_type
 		}
 	}
@@ -431,13 +432,14 @@ fn (g &Parser) render_method_call_expression(tokens []FastcExpressionToken, rend
 			}
 			variadic_type := signature.parameter_types.last()
 			element_type := g.array_element_type(variadic_type) or { continue }
-			variadic_arguments := direct_arguments[fixed_arguments..].clone()
-			packed := if variadic_arguments.len == 0 {
+			variadic_count := direct_arguments.len - fixed_arguments
+			variadic_values := direct_arguments[fixed_arguments..].join(',')
+			packed := if variadic_count == 0 {
 				'(${variadic_type}){0}'
 			} else {
-				'((${variadic_type})builtin__new_array_from_c_array(${variadic_arguments.len}, ${variadic_arguments.len}, sizeof(${element_type}), (${element_type}[]){${variadic_arguments.join(',')}}))'
+				'((${variadic_type})builtin__new_array_from_c_array(${variadic_count}, ${variadic_count}, sizeof(${element_type}), (${element_type}[]){${variadic_values}}))'
 			}
-			direct_arguments = direct_arguments[..fixed_arguments].clone()
+			direct_arguments.trim(fixed_arguments)
 			direct_arguments << packed
 		}
 		if signature.last_parameter_is_params && direct_arguments.len + 1 == signature.parameter_types.len - 1 {

--- a/vlib/v3/gen/fastc/render_struct_literal.v
+++ b/vlib/v3/gen/fastc/render_struct_literal.v
@@ -310,7 +310,11 @@ fn (g &Parser) render_struct_literal_expression(tokens []FastcExpressionToken) ?
 		element_type := g.array_element_type(array_type) or { return none }
 		length := field_values['len'] or { '0' }
 		capacity := field_values['cap'] or { '0' }
-		inner_array_element_type := g.array_element_type(element_type) or { '' }
+		inner_array_element_type := if element_type.starts_with('Array_') {
+			g.array_element_type(element_type) or { '' }
+		} else {
+			''
+		}
 		base := '((${array_type})builtin____new_array(${length},${capacity},sizeof(${element_type})))'
 		mut value_source := base
 		if initial := field_values['init'] {

--- a/vlib/v3/gen/fastc/render_struct_literal.v
+++ b/vlib/v3/gen/fastc/render_struct_literal.v
@@ -1,5 +1,72 @@
 module fastc
 
+struct FastcStructLiteralFieldValue {
+	explicit_initializers []string
+	rendered_field        string
+	field_value           string
+	fixed_array_copy      string
+	is_fixed_array        bool
+}
+
+fn (g &Parser) render_struct_literal_field_value(value_tokens []FastcExpressionToken, expected_type string, c_field_name string, temporary_start int) ?FastcStructLiteralFieldValue {
+	if fixed_element_type := fastc_fixed_array_element_type(expected_type) {
+		array_end := if value_tokens.len > 0 && value_tokens.last().tok == .not {
+			value_tokens.len - 1
+		} else {
+			value_tokens.len
+		}
+		if array_end >= 2 && value_tokens[0].tok == .lsbr && value_tokens[array_end - 1].tok == .rsbr {
+			items := fastc_expression_list_items(value_tokens, 1, array_end - 1) or {
+				return none
+			}
+			mut values := []string{cap: items.len}
+			mut initializers := []string{cap: items.len}
+			for item in items {
+				rendered_item := g.render_call_argument_expression(item, fixed_element_type) or {
+					return none
+				}
+				temporary := '__v_fastc_struct_field_${temporary_start + initializers.len}'
+				initializers << '__typeof__((${rendered_item})) ${temporary} = (${rendered_item});'
+				values << temporary
+			}
+			joined_values := values.join(',')
+			return FastcStructLiteralFieldValue{
+				explicit_initializers: initializers
+				rendered_field: '.${c_field_name}={${joined_values}}'
+				field_value: '{${joined_values}}'
+				is_fixed_array: true
+			}
+		}
+		value := g.render_call_argument_expression(value_tokens, expected_type) or { return none }
+		is_raw_fixed_array := value_tokens.len > 1 || (value_tokens.len == 1 && value_tokens[0].tok == .name && fastc_global_key(g.module_name, value_tokens[0].lit) in g.globals)
+		copy_source := if is_raw_fixed_array {
+			value
+		} else if expected_type.ends_with('*') {
+			'(${value})->data'
+		} else {
+			'(${value}).data'
+		}
+		return FastcStructLiteralFieldValue{
+			field_value: value
+			fixed_array_copy: 'memcpy(__v_fastc_struct_fixed.${c_field_name}, ${copy_source}, sizeof(__v_fastc_struct_fixed.${c_field_name}));'
+			is_fixed_array: true
+		}
+	}
+	value := if value_tokens.len == 1 && value_tokens[0].source != '' {
+		// A field value carried as a pre-rendered `({ ... })` (e.g. an `or`-unwrap) is used
+		// directly so its internal temporaries stay self-contained.
+		value_tokens[0].source
+	} else {
+		g.render_call_argument_expression(value_tokens, expected_type) or { return none }
+	}
+	temporary := '__v_fastc_struct_field_${temporary_start}'
+	return FastcStructLiteralFieldValue{
+		explicit_initializers: ['__typeof__((${value})) ${temporary} = (${value});']
+		rendered_field: '.${c_field_name}=(${temporary})'
+		field_value: temporary
+	}
+}
+
 fn (g &Parser) render_struct_literal_expression(tokens []FastcExpressionToken) ?FastcRenderedExpression {
 	mut open := -1
 	mut delimiter_depth := 0
@@ -112,10 +179,11 @@ fn (g &Parser) render_struct_literal_expression(tokens []FastcExpressionToken) ?
 		}
 		field_name := tokens[index].lit
 		index++
-		mut value_tokens := []FastcExpressionToken{}
+		mut value_start := -1
+		mut value_end := -1
 		if index < close && tokens[index].tok == .colon {
 			index++
-			value_start := index
+			value_start = index
 			mut parens := 0
 			mut brackets := 0
 			mut braces := 0
@@ -151,14 +219,7 @@ fn (g &Parser) render_struct_literal_expression(tokens []FastcExpressionToken) ?
 			if value_start == index {
 				return none
 			}
-			value_tokens = tokens[value_start..index].clone()
-		} else {
-			value_tokens = [
-				FastcExpressionToken{
-					tok: .name
-					lit: field_name
-				},
-			]
+			value_end = index
 		}
 		mut c_field_name := if is_c_struct_literal {
 			field_name
@@ -192,59 +253,28 @@ fn (g &Parser) render_struct_literal_expression(tokens []FastcExpressionToken) ?
 				}
 			}
 		}
-		if fixed_element_type := fastc_fixed_array_element_type(expected_type) {
-			array_end := if value_tokens.len > 0 && value_tokens.last().tok == .not {
-				value_tokens.len - 1
-			} else {
-				value_tokens.len
-			}
-			if array_end >= 2 && value_tokens[0].tok == .lsbr && value_tokens[array_end - 1].tok == .rsbr {
-				items := fastc_expression_list_items(value_tokens, 1, array_end - 1) or {
-					return none
-				}
-				mut values := []string{}
-				for item in items {
-					rendered_item := g.render_call_argument_expression(item, fixed_element_type) or {
-						return none
-					}
-					temporary := '__v_fastc_struct_field_${explicit_initializers.len}'
-					explicit_initializers << '__typeof__((${rendered_item})) ${temporary} = (${rendered_item});'
-					values << temporary
-				}
-				rendered_field := '.${c_field_name}={${values.join(',')}}'
-				rendered_fields << rendered_field
-				rendered_fields_by_name[field_name] = rendered_field
-				field_values[field_name] = '{${values.join(',')}}'
-				continue
-			}
-			value := g.render_call_argument_expression(value_tokens, expected_type) or {
-				return none
-			}
-			is_raw_fixed_array := value_tokens.len > 1 || (value_tokens.len == 1 && value_tokens[0].tok == .name && fastc_global_key(g.module_name, value_tokens[0].lit) in g.globals)
-			copy_source := if is_raw_fixed_array {
-				value
-			} else if expected_type.ends_with('*') {
-				'(${value})->data'
-			} else {
-				'(${value}).data'
-			}
-			fixed_array_copies << 'memcpy(__v_fastc_struct_fixed.${c_field_name}, ${copy_source}, sizeof(__v_fastc_struct_fixed.${c_field_name}));'
-			field_values[field_name] = value
+		field_value := if value_start >= 0 {
+			g.render_struct_literal_field_value(tokens[value_start..value_end], expected_type, c_field_name, explicit_initializers.len) or { return none }
+		} else {
+			g.render_struct_literal_field_value([
+				FastcExpressionToken{
+					tok: .name
+					lit: field_name
+				},
+			], expected_type, c_field_name, explicit_initializers.len) or { return none }
+		}
+		explicit_initializers << field_value.explicit_initializers
+		if field_value.rendered_field != '' {
+			rendered_fields << field_value.rendered_field
+			rendered_fields_by_name[field_name] = field_value.rendered_field
+		}
+		field_values[field_name] = field_value.field_value
+		if field_value.fixed_array_copy != '' {
+			fixed_array_copies << field_value.fixed_array_copy
+		}
+		if field_value.is_fixed_array {
 			continue
 		}
-		value := if value_tokens.len == 1 && value_tokens[0].source != '' {
-			// A field value carried as a pre-rendered `({ ... })` (e.g. an `or`-unwrap) is used
-			// directly so its internal temporaries stay self-contained.
-			value_tokens[0].source
-		} else {
-			g.render_call_argument_expression(value_tokens, expected_type) or { return none }
-		}
-		temporary := '__v_fastc_struct_field_${explicit_initializers.len}'
-		explicit_initializers << '__typeof__((${value})) ${temporary} = (${value});'
-		rendered_field := '.${c_field_name}=(${temporary})'
-		rendered_fields << rendered_field
-		rendered_fields_by_name[field_name] = rendered_field
-		field_values[field_name] = temporary
 	}
 	if update_source == '' {
 		for field in g.struct_field_info[layout_type] {
@@ -280,10 +310,17 @@ fn (g &Parser) render_struct_literal_expression(tokens []FastcExpressionToken) ?
 		element_type := g.array_element_type(array_type) or { return none }
 		length := field_values['len'] or { '0' }
 		capacity := field_values['cap'] or { '0' }
+		inner_array_element_type := g.array_element_type(element_type) or { '' }
 		base := '((${array_type})builtin____new_array(${length},${capacity},sizeof(${element_type})))'
 		mut value_source := base
 		if initial := field_values['init'] {
 			value_source = '({ ${explicit_initializers.join(' ')} ${array_type} __v_fastc_array_init = ${base}; ${element_type} __v_fastc_array_default = (${initial}); for (int __v_fastc_array_index = 0; __v_fastc_array_index < __v_fastc_array_init.len; __v_fastc_array_index++) { ((${element_type} *)__v_fastc_array_init.data)[__v_fastc_array_index] = __v_fastc_array_default; } __v_fastc_array_init; })'
+		} else if inner_array_element_type != '' {
+			// A zeroed inner dynamic array has element_size == 0, so appending to an
+			// element of `[][]T{len: n}` copies no data. Construct a valid empty inner
+			// array for every outer element, as the main C backend does.
+			inner_default := '((${element_type})builtin____new_array(0,0,sizeof(${inner_array_element_type})))'
+			value_source = '({ ${explicit_initializers.join(' ')} ${array_type} __v_fastc_array_init = ${base}; for (int __v_fastc_array_index = 0; __v_fastc_array_index < __v_fastc_array_init.len; __v_fastc_array_index++) { ((${element_type} *)__v_fastc_array_init.data)[__v_fastc_array_index] = ${inner_default}; } __v_fastc_array_init; })'
 		} else if explicit_initializers.len > 0 {
 			value_source = '({ ${explicit_initializers.join(' ')} ${base}; })'
 		}

--- a/vlib/v3/gen/fastc/source.v
+++ b/vlib/v3/gen/fastc/source.v
@@ -63,13 +63,13 @@ fn fastc_resolve_c_pseudo_paths(raw string, vroot string, source_file string) st
 fn fastc_load_source(path string, prefs &pref.Preferences) FastcLoadedSource {
 	source := os.read_file(path) or {
 		return FastcLoadedSource{
-			failed:        true
+			failed: true
 			error_message: err.msg()
 		}
 	}
 	header := fastc_scan_source_header(source, path, prefs) or {
 		return FastcLoadedSource{
-			failed:        true
+			failed: true
 			error_message: err.msg()
 		}
 	}
@@ -82,19 +82,22 @@ fn fastc_load_source(path string, prefs &pref.Preferences) FastcLoadedSource {
 fn fastc_resolve_source_files(paths []string, prefs &pref.Preferences) !([]FastcSourceFile, map[string]string) {
 	mut queue := []FastcQueuedSource{}
 	if prefs.building_v {
-		builtin_dir := prefs.get_vlib_module_path('builtin')
+		builtin_dir := os.real_path(prefs.get_vlib_module_path('builtin'))
 		for builtin_file in pref.get_v_files_from_dir_for_target(builtin_dir, prefs.user_defines, prefs.target) {
 			if fastc_source_file_matches_backend(builtin_file) {
 				queue << FastcQueuedSource{
 					path: builtin_file
 					module_name: 'builtin'
+					is_canonical: true
 				}
 			}
 		}
 	}
 	for path in paths {
+		entry_path := if prefs.building_v { os.real_path(path) } else { path }
 		queue << FastcQueuedSource{
-			path: path
+			path: entry_path
+			is_canonical: prefs.building_v
 		}
 		// A V module spans every source file in its directory, plus any `subdirs`
 		// its v.mod lists that belong to the same module (e.g. gitly's `ssh/`,
@@ -103,10 +106,11 @@ fn fastc_resolve_source_files(paths []string, prefs &pref.Preferences) !([]Fastc
 		// path does this: the bootstrap runtime compiles single entry files, and its
 		// tests place several independent programs in one scratch directory.
 		if prefs.building_v {
-			for module_file in fastc_entry_module_files(path, prefs) {
+			for module_file in fastc_entry_module_files(entry_path, prefs) {
 				if fastc_source_file_matches_backend(module_file) {
 					queue << FastcQueuedSource{
 						path: module_file
+						is_canonical: true
 					}
 				}
 			}
@@ -139,9 +143,7 @@ fn fastc_resolve_source_files(paths []string, prefs &pref.Preferences) !([]Fastc
 			queued := queue[queue_index]
 			queue_index++
 			mut path := ''
-			if prefs.building_v {
-				// The self-host driver canonicalizes its entry path and derives vroot
-				// from it, so every queued vlib path is already absolute and canonical.
+			if queued.is_canonical {
 				path = queued.path
 			} else if cached := real_path_cache[queued.path] {
 				path = cached
@@ -228,14 +230,16 @@ fn fastc_resolve_source_files(paths []string, prefs &pref.Preferences) !([]Fastc
 					if prefs.building_v {
 						vlib_module_dir := prefs.get_vlib_module_path(imported_module)
 						// Alias modules need the generic resolver to follow `alias.v`.
-						if os.is_dir(vlib_module_dir)
-							&& !os.is_file(os.join_path_single(vlib_module_dir, 'alias.v')) {
+						if os.is_dir(vlib_module_dir) && !os.is_file(os.join_path_single(vlib_module_dir, 'alias.v')) {
 							module_dir = vlib_module_dir
 						} else {
 							module_dir = prefs.get_module_path(imported_module, source_file.path)
 						}
 					} else {
 						module_dir = prefs.get_module_path(imported_module, source_file.path)
+					}
+					if prefs.building_v {
+						module_dir = os.real_path(module_dir)
 					}
 					module_path_cache[module_cache_key] = module_dir
 				}
@@ -254,14 +258,14 @@ fn fastc_resolve_source_files(paths []string, prefs &pref.Preferences) !([]Fastc
 					module_dir_files[module_dir] = module_files
 				}
 				for module_file in module_files {
-					mut module_file_real := ''
-					if prefs.building_v {
-						module_file_real = module_file
-					} else if cached := real_path_cache[module_file] {
-						module_file_real = cached
-					} else {
-						module_file_real = os.real_path(module_file)
-						real_path_cache[module_file] = module_file_real
+					mut module_file_real := module_file
+					if !prefs.building_v {
+						if cached := real_path_cache[module_file] {
+							module_file_real = cached
+						} else {
+							module_file_real = os.real_path(module_file)
+							real_path_cache[module_file] = module_file_real
+						}
 					}
 					if scheduled_module := scheduled_path_modules[module_file_real] {
 						loaded_module := path_module[module_file_real] or { scheduled_module }
@@ -272,8 +276,9 @@ fn fastc_resolve_source_files(paths []string, prefs &pref.Preferences) !([]Fastc
 					}
 					scheduled_path_modules[module_file_real] = imported_module
 					queue << FastcQueuedSource{
-						path: module_file
+						path: module_file_real
 						module_name: imported_module
+						is_canonical: prefs.building_v
 					}
 				}
 			}
@@ -299,8 +304,7 @@ fn fastc_entry_module_files(entry_path string, prefs &pref.Preferences) []string
 		for subdir in fastc_vmod_subdirs(vmod_root) {
 			subdir_path := os.join_path(vmod_root, subdir)
 			if os.is_dir(subdir_path) {
-				files << pref.get_v_files_from_dir_for_target(subdir_path, prefs.user_defines,
-					prefs.target)
+				files << pref.get_v_files_from_dir_for_target(subdir_path, prefs.user_defines, prefs.target)
 			}
 		}
 	}
@@ -441,9 +445,7 @@ fn fastc_append_module_sources(module_name string, sources []FastcSourceFile, mu
 }
 
 fn fastc_source_file_matches_backend(path string) bool {
-	return !path.ends_with('.arm64.v') && !path.ends_with('.amd64.v')
-		&& !path.ends_with('.native.v') && !path.ends_with('.wasm.v') && !path.ends_with('.rv64.v')
-		&& !path.ends_with('.js.v')
+	return !path.ends_with('.arm64.v') && !path.ends_with('.amd64.v') && !path.ends_with('.native.v') && !path.ends_with('.wasm.v') && !path.ends_with('.rv64.v') && !path.ends_with('.js.v')
 }
 
 fn fastc_scan_source_header(source string, path string, prefs &pref.Preferences) !FastcSourceHeader {
@@ -491,16 +493,15 @@ fn fastc_scan_source_header(source string, path string, prefs &pref.Preferences)
 				selected := fastc_scan_selected_comptime_branch(mut scan, scan.scan(), path, prefs)!
 				if selected.source != '' {
 					selected_header := fastc_scan_source_header(selected.source, path, prefs)!
-					fastc_merge_source_header_imports(selected_header, path, mut imports, mut
-						import_order, mut blank_imports)!
+					fastc_merge_source_header_imports(selected_header, path, mut imports, mut import_order, mut blank_imports)!
 					has_globals = has_globals || selected_header.has_globals
 				}
 				tok = selected.tok
 				continue
 			}
 		}
-		if brace_depth == 0
-			&& tok in [.key_fn, .key_struct, .key_enum, .key_interface, .key_type, .key_const, .key_global] {
+		if brace_depth == 0 && tok in [.key_fn, .key_struct, .key_enum, .key_interface, .key_type,
+			.key_const, .key_global] {
 			break
 		}
 		if tok != .key_import || brace_depth > 0 {
@@ -520,10 +521,8 @@ fn fastc_scan_source_header(source string, path string, prefs &pref.Preferences)
 					tok = scan.scan()
 					continue
 				}
-				import_path, alias, selected_names, next_token :=
-					fastc_scan_import(mut scan, tok, path)!
-				fastc_register_import_alias(import_path, alias, path, mut imports, mut
-					blank_imports)!
+				import_path, alias, selected_names, next_token := fastc_scan_import(mut scan, tok, path)!
+				fastc_register_import_alias(import_path, alias, path, mut imports, mut blank_imports)!
 				fastc_register_selective_imports(import_path, selected_names, path, mut imports)!
 				if import_path !in import_order {
 					import_order << import_path
@@ -550,15 +549,13 @@ fn fastc_scan_source_header(source string, path string, prefs &pref.Preferences)
 	// Mirror that so the ORM lowering resolves `orm.Table`/`orm.QueryData`/... and the
 	// `orm` module is pulled into the source set. Only the real-builtin path has the
 	// runtime the ORM needs; the toy runtime cannot compile `orm`.
-	if prefs.building_v && module_name != 'orm' && 'orm' !in imports
-		&& fastc_source_uses_sql(source, prefs) {
+	if prefs.building_v && module_name != 'orm' && 'orm' !in imports && fastc_source_uses_sql(source, prefs) {
 		imports['orm'] = 'orm'
 		if 'orm' !in import_order {
 			import_order << 'orm'
 		}
 	}
-	if prefs.building_v && prefs.backend == 'fastc' && imports['driver'] == 'v3.driver'
-		&& 'fastcdriver' in imports {
+	if prefs.building_v && prefs.backend == 'fastc' && imports['driver'] == 'v3.driver' && 'fastcdriver' in imports {
 		fastcdriver_module := imports['fastcdriver']
 		imports['driver'] = fastcdriver_module
 		for i, imported_module in import_order {
@@ -569,12 +566,12 @@ fn fastc_scan_source_header(source string, path string, prefs &pref.Preferences)
 	}
 	has_constants, has_global_declarations := fastc_source_declaration_flags(source)
 	return FastcSourceHeader{
-		module_name:             module_name
-		imports:                 imports
-		import_order:            import_order
-		blank_imports:           blank_imports
-		has_globals:             has_globals
-		has_constants:           has_constants
+		module_name: module_name
+		imports: imports
+		import_order: import_order
+		blank_imports: blank_imports
+		has_globals: has_globals
+		has_constants: has_constants
 		has_global_declarations: has_global_declarations
 	}
 }
@@ -586,14 +583,10 @@ fn fastc_source_declaration_flags(source string) (bool, bool) {
 		if i > 0 && fastc_identifier_byte(source[i - 1]) {
 			continue
 		}
-		if !has_constants && source[i] == `c` && i + 5 <= source.len
-			&& source[i..i + 5] == 'const'
-			&& (i + 5 == source.len || !fastc_identifier_byte(source[i + 5])) {
+		if !has_constants && source[i] == `c` && i + 5 <= source.len && source[i..i + 5] == 'const' && (i + 5 == source.len || !fastc_identifier_byte(source[i + 5])) {
 			has_constants = true
 		}
-		if !has_global_declarations && source[i] == `_` && i + 8 <= source.len
-			&& source[i..i + 8] == '__global'
-			&& (i + 8 == source.len || !fastc_identifier_byte(source[i + 8])) {
+		if !has_global_declarations && source[i] == `_` && i + 8 <= source.len && source[i..i + 8] == '__global' && (i + 8 == source.len || !fastc_identifier_byte(source[i + 8])) {
 			has_global_declarations = true
 		}
 	}
@@ -601,8 +594,7 @@ fn fastc_source_declaration_flags(source string) (bool, bool) {
 }
 
 fn fastc_identifier_byte(value u8) bool {
-	return value == `_` || (value >= `a` && value <= `z`) || (value >= `A` && value <= `Z`)
-		|| (value >= `0` && value <= `9`)
+	return value == `_` || (value >= `a` && value <= `z`) || (value >= `A` && value <= `Z`) || (value >= `0` && value <= `9`)
 }
 
 // fastc_source_uses_sql reports whether a file contains a `sql <conn> { ... }` ORM
@@ -642,16 +634,15 @@ fn fastc_source_uses_sql(source string, prefs &pref.Preferences) bool {
 fn fastc_merge_source_header_imports(header FastcSourceHeader, path string, mut destination_imports map[string]string, mut destination_import_order []string, mut destination_blank_imports []string) ! {
 	for alias, imported_module in header.imports {
 		if alias.starts_with('#select#') {
-			fastc_register_selective_imports(imported_module, [alias['#select#'.len..]], path, mut
-				destination_imports)!
+			fastc_register_selective_imports(imported_module, [
+				alias['#select#'.len..],
+			], path, mut destination_imports)!
 		} else {
-			fastc_register_import_alias(imported_module, alias, path, mut destination_imports, mut
-				destination_blank_imports)!
+			fastc_register_import_alias(imported_module, alias, path, mut destination_imports, mut destination_blank_imports)!
 		}
 	}
 	for imported_module in header.blank_imports {
-		fastc_register_import_alias(imported_module, '_', path, mut destination_imports, mut
-			destination_blank_imports)!
+		fastc_register_import_alias(imported_module, '_', path, mut destination_imports, mut destination_blank_imports)!
 	}
 	for imported_module in header.import_order {
 		if imported_module !in destination_import_order {


### PR DESCRIPTION
## Summary

- avoid repeated failed renderer probes and allocation-heavy token bookkeeping in hot FastC expression paths
- overlap independent reference/interface work with generation and run the first parallel chunk on the caller
- canonicalize and cache self-host source paths to prevent duplicate loading through aliases/symlinks
- preserve self-host lowering for option fallbacks, map assignments, recursive sum-array appends, and related render paths

## Performance

Production-built benchmark over 101 self-host generation repeats:

- before: 42.60 ms
- after: 35.62 ms
- improvement: 16.4%
- throughput: approximately 1.83M LOC/s

Compiler build: `./vnew -prod -gc none -d fastc_selfhost -o <output> vlib/v3/v3.v`

## Validation

- FastC self-hosted successfully for five consecutive generations
- the fifth-generation compiler compiled and ran `examples/hello_world.v`
- the `-d v3_no_parallel` compiler self-hosted successfully
- parallel and serial generated C output was byte-identical
- 17 focused FastC regression tests passed
- `git diff --check` passed
- full test suite not run
