### PR TITLE
v3: select the FastC self-host driver automatically

### DIFF
--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -8336,7 +8336,7 @@ pub fn run(args []string) {
 		// A directly invoked host compiler may live outside the checkout (for example,
 		// a production benchmark binary in /tmp). The explicit compiler entry owns
 		// this build, so resolve builtin and vlib beside that input instead of VEXE.
-		resolve_vroot_for_input(prefs.vroot, input_file)
+		resolve_vroot_for_input(prefs.vroot, os.real_path(input_file))
 	} else if pref.has_macos_v3_caller_environment() && prefs.vexe.len > 0 {
 		// The macOS dispatcher sets VEXE to the invoking compiler. Preserve that
 		// checkout instead of selecting another V checkout around the input.

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -1660,6 +1660,11 @@ fn input_implies_building_v(input_file string) bool {
 	return false
 }
 
+fn input_is_v3_compiler_entry(input_file string) bool {
+	normalized := os.real_path(input_file).replace('\\', '/').trim_right('/')
+	return normalized.ends_with('/vlib/v3/v3.v')
+}
+
 fn input_is_cmd_v(input_file string) bool {
 	normalized := input_file.replace('\\', '/').trim_right('/')
 	return normalized == 'cmd/v' || normalized.ends_with('/cmd/v')
@@ -8284,8 +8289,8 @@ pub fn run(args []string) {
 	if !include_eval {
 		user_defines << 'skip_eval'
 	}
-	fastc_selfhost_build := backend == 'fastc'
-		&& (is_selfhost || input_implies_building_v(input_file))
+	fastc_compiler_entry := backend == 'fastc' && input_is_v3_compiler_entry(input_file)
+	fastc_selfhost_build := backend == 'fastc' && (is_selfhost || fastc_compiler_entry)
 	if fastc_selfhost_build {
 		// Select the scanner-to-C driver in the first generated compiler. A direct
 		// `-b fastc vlib/v3/v3.v` build is a self-host build too; do not require the
@@ -8327,7 +8332,7 @@ pub fn run(args []string) {
 		target.default_thread_stack_size()
 	}
 	prefs.backend = backend
-	prefs.vroot = if fastc_selfhost_build && input_implies_building_v(input_file) {
+	prefs.vroot = if fastc_compiler_entry {
 		// A directly invoked host compiler may live outside the checkout (for example,
 		// a production benchmark binary in /tmp). The explicit compiler entry owns
 		// this build, so resolve builtin and vlib beside that input instead of VEXE.

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -8284,9 +8284,13 @@ pub fn run(args []string) {
 	if !include_eval {
 		user_defines << 'skip_eval'
 	}
-	if backend == 'fastc' && is_selfhost {
-		// Select the scanner-to-C driver in the first generated compiler. Descendant
-		// FastC compilers preserve the same define in v3.fastcdriver.
+	fastc_selfhost_build := backend == 'fastc'
+		&& (is_selfhost || input_implies_building_v(input_file))
+	if fastc_selfhost_build {
+		// Select the scanner-to-C driver in the first generated compiler. A direct
+		// `-b fastc vlib/v3/v3.v` build is a self-host build too; do not require the
+		// internal `-d fastc_selfhost` implementation detail at the command line.
+		// Descendant FastC compilers preserve the same define in v3.fastcdriver.
 		record_user_define(mut user_defines, mut compile_values, 'fastc_selfhost')
 	}
 
@@ -8323,7 +8327,12 @@ pub fn run(args []string) {
 		target.default_thread_stack_size()
 	}
 	prefs.backend = backend
-	prefs.vroot = if pref.has_macos_v3_caller_environment() && prefs.vexe.len > 0 {
+	prefs.vroot = if fastc_selfhost_build && input_implies_building_v(input_file) {
+		// A directly invoked host compiler may live outside the checkout (for example,
+		// a production benchmark binary in /tmp). The explicit compiler entry owns
+		// this build, so resolve builtin and vlib beside that input instead of VEXE.
+		resolve_vroot_for_input(prefs.vroot, input_file)
+	} else if pref.has_macos_v3_caller_environment() && prefs.vexe.len > 0 {
 		// The macOS dispatcher sets VEXE to the invoking compiler. Preserve that
 		// checkout instead of selecting another V checkout around the input.
 		os.real_path(os.dir(prefs.vexe))
@@ -8365,7 +8374,7 @@ pub fn run(args []string) {
 	if prefs.vcurrent_hash == '' {
 		prefs.vcurrent_hash = @VCURRENTHASH
 	}
-	prefs.selfhost = is_selfhost
+	prefs.selfhost = is_selfhost || fastc_selfhost_build
 	prefs.building_v = building_v
 	prefs.is_prod = is_prod
 	prefs.is_debug = is_debug

--- a/vlib/v3/tests/fastc_backend_test.v
+++ b/vlib/v3/tests/fastc_backend_test.v
@@ -46,6 +46,31 @@ fn run_with_v_environment(program string, args []string, flags string, vexe stri
 	return cmdexec.run(program, args)
 }
 
+fn test_direct_fastc_compiler_entry_selects_selfhost_driver() {
+	$if !macos && !linux {
+		return
+	}
+	root := os.join_path(os.vtmp_dir(), 'v_direct_fastc_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	host_binary := os.join_path(root, 'v_host')
+	os.cp(@VEXE, host_binary) or { panic(err) }
+	direct_binary := os.join_path(root, 'v_fastc_direct')
+	direct_build := cmdexec.run(host_binary, ['-silent', '-b', 'fastc', '-o', direct_binary,
+		fastc_backend_v3_source])
+	assert direct_build.exit_code == 0, direct_build.output
+	assert os.is_executable(direct_binary)
+
+	self_output := os.join_path(root, 'v_fastc_child')
+	self_build := cmdexec.run(direct_binary, ['self', '-silent', '-o', self_output])
+	assert self_build.exit_code == 0, self_build.output
+	assert self_build.output.contains('V self compiling (-b fastc)...'), self_build.output
+	assert os.is_executable(self_output)
+}
+
 fn test_v_self_accepts_fastc_backend() {
 	$if !macos && !linux {
 		return

--- a/vlib/v3/tests/fastc_backend_test.v
+++ b/vlib/v3/tests/fastc_backend_test.v
@@ -58,9 +58,13 @@ fn test_direct_fastc_compiler_entry_selects_selfhost_driver() {
 	}
 	host_binary := os.join_path(root, 'v_host')
 	os.cp(@VEXE, host_binary) or { panic(err) }
+	linked_entry_dir := os.join_path(root, 'linked_entry')
+	os.mkdir_all(linked_entry_dir) or { panic(err) }
+	linked_entry := os.join_path(linked_entry_dir, 'v3.v')
+	os.symlink(fastc_backend_v3_source, linked_entry) or { panic(err) }
 	direct_binary := os.join_path(root, 'v_fastc_direct')
-	direct_build := cmdexec.run(host_binary, ['-silent', '-b', 'fastc', '-o', direct_binary,
-		fastc_backend_v3_source])
+	direct_build := cmdexec.run_in(host_binary, ['-silent', '-b', 'fastc', '-o', direct_binary,
+		linked_entry], root)
 	assert direct_build.exit_code == 0, direct_build.output
 	assert os.is_executable(direct_binary)
 

--- a/vlib/v3/tests/fastc_backend_test.v
+++ b/vlib/v3/tests/fastc_backend_test.v
@@ -69,6 +69,15 @@ fn test_direct_fastc_compiler_entry_selects_selfhost_driver() {
 	assert self_build.exit_code == 0, self_build.output
 	assert self_build.output.contains('V self compiling (-b fastc)...'), self_build.output
 	assert os.is_executable(self_output)
+
+	ordinary_source := os.join_path(root, 'v3.v')
+	write_fastc_test_source(ordinary_source, 'module main\nfn main() {\n\t\$if fastc_selfhost ? {\n\t\texit(7)\n\t}\n}\n')
+	ordinary_binary := os.join_path(root, 'ordinary_v3')
+	ordinary_build := cmdexec.run(@VEXE, ['-silent', '-b', 'fastc', '-o', ordinary_binary,
+		ordinary_source])
+	assert ordinary_build.exit_code == 0, ordinary_build.output
+	ordinary_run := cmdexec.run(ordinary_binary, [])
+	assert ordinary_run.exit_code == 0, ordinary_run.output
 }
 
 fn test_v_self_accepts_fastc_backend() {


### PR DESCRIPTION
## Summary

- select the scanner-to-C self-host driver automatically for direct `-b fastc vlib/v3/v3.v` builds
- mark direct FastC compiler-entry builds as self-host builds without exposing the internal `fastc_selfhost` define
- resolve `vroot` from the explicit compiler entry so production host binaries outside the checkout still load the correct builtin
- add a regression that copies the host compiler outside the checkout, builds V3 through FastC, and self-builds the result

## Validation

- direct `-b fastc` build without `-d fastc_selfhost`
- five consecutive FastC self-host generations and Hello World
- relocated production V3 driver, parallel and serial, followed by two self-host generations
- existing `test_v_self_accepts_fastc_backend`
- new `test_direct_fastc_compiler_entry_selects_selfhost_driver`
- `vlib/v/compiler_errors_test.v`: 1619 passed, 1 skipped
- `git diff --check`
