### PR TITLE
v3: speed up fastc declaration generation

### DIFF
--- a/vlib/v3/gen/fastc/decl.v
+++ b/vlib/v3/gen/fastc/decl.v
@@ -29,6 +29,7 @@ fn collect_declared_types(source string, path string, module_name string, prefs 
 			mut lookahead := scan
 			if lookahead.scan() == .key_if {
 				selected := fastc_scan_selected_comptime_branch(mut scan, scan.scan(), path, prefs)!
+				comptime_end := if selected.tok == .eof { scan.offset } else { scan.pos }
 				if selected.source != '' {
 					mut selected_types := strings.new_builder(256)
 					selected_has_types := collect_declared_types(selected.source, path, module_name,
@@ -37,9 +38,9 @@ fn collect_declared_types(source string, path string, module_name string, prefs 
 					has_type_declarations = has_type_declarations || selected_has_types
 					if selected_types.len > 0 {
 						start := if pending_start >= 0 { pending_start } else { comptime_start }
-						fastc_append_filtered_source_span(source, emitted_end, start, scan.pos,
+						fastc_append_filtered_source_span(source, emitted_end, start, comptime_end,
 							mut type_source)
-						emitted_end = scan.pos
+						emitted_end = comptime_end
 					}
 				}
 				pending_start = -1
@@ -170,14 +171,15 @@ fn collect_constant_names(source string, path string, module_name string, prefs 
 			mut lookahead := scan
 			if lookahead.scan() == .key_if {
 				selected := fastc_scan_selected_comptime_branch(mut scan, scan.scan(), path, prefs)!
+				comptime_end := if selected.tok == .eof { scan.offset } else { scan.pos }
 				if selected.source != '' {
 					mut selected_constants := strings.new_builder(256)
 					collect_constant_names(selected.source, path, module_name, prefs, mut
 						constants, mut public_constants, mut constant_paths, mut selected_constants)!
 					if selected_constants.len > 0 {
 						fastc_append_filtered_source_span(source, emitted_end, comptime_start,
-							scan.pos, mut constant_source)
-						emitted_end = scan.pos
+							comptime_end, mut constant_source)
+						emitted_end = comptime_end
 					}
 				}
 				tok = selected.tok

--- a/vlib/v3/gen/fastc/decl.v
+++ b/vlib/v3/gen/fastc/decl.v
@@ -224,6 +224,7 @@ fn collect_constant_names(source string, path string, module_name string, prefs 
 					}
 					tok = scan.scan()
 				}
+				previous_tok = .unknown
 				continue
 			}
 			if tok != .name {
@@ -260,6 +261,7 @@ fn collect_constant_names(source string, path string, module_name string, prefs 
 					source.len, mut constant_source)
 				emitted_end = source.len
 			}
+			previous_tok = .unknown
 			continue
 		}
 		if tok == .lcbr {

--- a/vlib/v3/gen/fastc/decl.v
+++ b/vlib/v3/gen/fastc/decl.v
@@ -5,7 +5,7 @@ import v3.pref
 import v3.scanner
 import v3.token
 
-fn collect_declared_types(source string, path string, module_name string, prefs &pref.Preferences, mut declared_types map[string]bool, mut declared_kinds map[string]FastcDeclaredTypeKind, mut enum_flags map[string]bool, mut params_structs map[string]bool, mut declaration_paths map[string]string, mut declaration_modules map[string]string) !bool {
+fn collect_declared_types(source string, path string, module_name string, prefs &pref.Preferences, mut declared_types map[string]bool, mut declared_kinds map[string]FastcDeclaredTypeKind, mut enum_flags map[string]bool, mut params_structs map[string]bool, mut declaration_paths map[string]string, mut declaration_modules map[string]string, mut type_source strings.Builder) !bool {
 	mut file_set := token.FileSet.new()
 	mut file := file_set.add_file(path, source.len)
 	file.index_lines_without_digest(source)
@@ -18,24 +18,40 @@ fn collect_declared_types(source string, path string, module_name string, prefs 
 	mut next_type_is_enabled := true
 	mut has_type_declarations := false
 	mut previous_tok := token.Token.unknown
+	mut emitted_end := 0
+	mut pending_start := -1
+	mut declaration_start := -1
+	mut declaration_has_block := false
 	mut tok := scan.scan()
 	for tok != .eof {
 		if brace_depth == 0 && tok == .dollar {
+			comptime_start := scan.pos
 			mut lookahead := scan
 			if lookahead.scan() == .key_if {
 				selected := fastc_scan_selected_comptime_branch(mut scan, scan.scan(), path, prefs)!
 				if selected.source != '' {
+					mut selected_types := strings.new_builder(256)
 					selected_has_types := collect_declared_types(selected.source, path, module_name,
 						prefs, mut declared_types, mut declared_kinds, mut enum_flags, mut params_structs,
-						mut declaration_paths, mut declaration_modules)!
+						mut declaration_paths, mut declaration_modules, mut selected_types)!
 					has_type_declarations = has_type_declarations || selected_has_types
+					if selected_types.len > 0 {
+						start := if pending_start >= 0 { pending_start } else { comptime_start }
+						fastc_append_filtered_source_span(source, emitted_end, start, scan.pos,
+							mut type_source)
+						emitted_end = scan.pos
+					}
 				}
+				pending_start = -1
 				tok = selected.tok
 				previous_tok = .unknown
 				continue
 			}
 		}
 		if brace_depth == 0 && tok == .attribute {
+			if pending_start < 0 {
+				pending_start = scan.pos
+			}
 			attribute := fastc_scan_declaration_attribute(mut scan, path, prefs)!
 			tok = attribute.tok
 			next_c_struct_is_typedef = next_c_struct_is_typedef || attribute.is_typedef
@@ -44,15 +60,22 @@ fn collect_declared_types(source string, path string, module_name string, prefs 
 			next_type_is_enabled = next_type_is_enabled && attribute.is_enabled
 			continue
 		}
+		if brace_depth == 0 && tok in [.key_pub, .key_static] && pending_start < 0 {
+			pending_start = scan.pos
+		}
 		if brace_depth == 0 && tok in [.key_fn, .key_const, .key_global] {
 			next_c_struct_is_typedef = false
 			next_enum_is_flag = false
 			next_struct_is_params = false
 			next_type_is_enabled = true
+			pending_start = -1
 		}
 		if brace_depth == 0
 			&& tok in [.key_struct, .key_enum, .key_interface, .key_type, .key_union] {
 			has_type_declarations = true
+			declaration_start = if pending_start >= 0 { pending_start } else { scan.pos }
+			declaration_has_block = false
+			pending_start = -1
 			is_public := previous_tok == .key_pub
 			kind := match tok {
 				.key_enum { FastcDeclaredTypeKind.enum_ }
@@ -101,16 +124,37 @@ fn collect_declared_types(source string, path string, module_name string, prefs 
 		}
 		if tok == .lcbr {
 			brace_depth++
+			if declaration_start >= 0 {
+				declaration_has_block = true
+			}
 		} else if tok == .rcbr && brace_depth > 0 {
 			brace_depth--
+			if declaration_start >= 0 && declaration_has_block && brace_depth == 0 {
+				fastc_append_filtered_source_span(source, emitted_end, declaration_start,
+					scan.offset, mut type_source)
+				emitted_end = scan.offset
+				declaration_start = -1
+				declaration_has_block = false
+			}
+		} else if tok == .semicolon && brace_depth == 0 && declaration_start >= 0
+			&& !declaration_has_block {
+			declaration_end := if scan.offset > scan.pos { scan.offset } else { scan.pos }
+			fastc_append_filtered_source_span(source, emitted_end, declaration_start,
+				declaration_end, mut type_source)
+			emitted_end = declaration_end
+			declaration_start = -1
 		}
 		previous_tok = tok
 		tok = scan.scan()
 	}
+	if declaration_start >= 0 {
+		fastc_append_filtered_source_span(source, emitted_end, declaration_start, source.len,
+			mut type_source)
+	}
 	return has_type_declarations
 }
 
-fn collect_constant_names(source string, path string, module_name string, prefs &pref.Preferences, mut constants map[string]string, mut public_constants map[string]bool, mut constant_paths map[string]string) ! {
+fn collect_constant_names(source string, path string, module_name string, prefs &pref.Preferences, mut constants map[string]string, mut public_constants map[string]bool, mut constant_paths map[string]string, mut constant_source strings.Builder) ! {
 	mut file_set := token.FileSet.new()
 	mut file := file_set.add_file(path, source.len)
 	file.index_lines_without_digest(source)
@@ -118,15 +162,23 @@ fn collect_constant_names(source string, path string, module_name string, prefs 
 	scan.init(file, source)
 	mut brace_depth := 0
 	mut previous_tok := token.Token.unknown
+	mut emitted_end := 0
 	mut tok := scan.scan()
 	for tok != .eof {
 		if brace_depth == 0 && tok == .dollar {
+			comptime_start := scan.pos
 			mut lookahead := scan
 			if lookahead.scan() == .key_if {
 				selected := fastc_scan_selected_comptime_branch(mut scan, scan.scan(), path, prefs)!
 				if selected.source != '' {
+					mut selected_constants := strings.new_builder(256)
 					collect_constant_names(selected.source, path, module_name, prefs, mut
-						constants, mut public_constants, mut constant_paths)!
+						constants, mut public_constants, mut constant_paths, mut selected_constants)!
+					if selected_constants.len > 0 {
+						fastc_append_filtered_source_span(source, emitted_end, comptime_start,
+							scan.pos, mut constant_source)
+						emitted_end = scan.pos
+					}
 				}
 				tok = selected.tok
 				previous_tok = .unknown
@@ -134,6 +186,7 @@ fn collect_constant_names(source string, path string, module_name string, prefs 
 			}
 		}
 		if brace_depth == 0 && tok == .key_const {
+			declaration_start := scan.pos
 			is_public := previous_tok == .key_pub
 			tok = scan.scan()
 			if tok == .lpar {
@@ -142,6 +195,9 @@ fn collect_constant_names(source string, path string, module_name string, prefs 
 				mut nested_depth := 0
 				for tok != .eof {
 					if nested_depth == 0 && tok == .rpar {
+						fastc_append_filtered_source_span(source, emitted_end, declaration_start,
+							scan.offset, mut constant_source)
+						emitted_end = scan.offset
 						tok = scan.scan()
 						break
 					}
@@ -177,6 +233,31 @@ fn collect_constant_names(source string, path string, module_name string, prefs 
 				fastc_register_constant(module_name, scan.lit, is_public, path, mut constants, mut
 					public_constants, mut constant_paths)!
 			}
+			tok = scan.scan()
+			mut nested_depth := 0
+			mut emitted := false
+			for tok != .eof {
+				if nested_depth == 0 && tok == .semicolon {
+					declaration_end := if scan.offset > scan.pos { scan.offset } else { scan.pos }
+					fastc_append_filtered_source_span(source, emitted_end, declaration_start,
+						declaration_end, mut constant_source)
+					emitted_end = declaration_end
+					emitted = true
+					tok = scan.scan()
+					break
+				}
+				if tok in [.lpar, .lsbr, .lcbr] {
+					nested_depth++
+				} else if tok in [.rpar, .rsbr, .rcbr] && nested_depth > 0 {
+					nested_depth--
+				}
+				tok = scan.scan()
+			}
+			if tok == .eof && !emitted {
+				fastc_append_filtered_source_span(source, emitted_end, declaration_start,
+					source.len, mut constant_source)
+				emitted_end = source.len
+			}
 			continue
 		}
 		if tok == .lcbr {
@@ -187,6 +268,21 @@ fn collect_constant_names(source string, path string, module_name string, prefs 
 		previous_tok = tok
 		tok = scan.scan()
 	}
+}
+
+// fastc_append_filtered_source_span preserves declaration pseudo-variable
+// locations while omitting the tokens between declarations.
+fn fastc_append_filtered_source_span(source string, previous_end int, start int, end int, mut out strings.Builder) {
+	mut last_newline := -1
+	for i in previous_end .. start {
+		if source[i] == `\n` {
+			out.write_u8(`\n`)
+			last_newline = i
+		}
+	}
+	column_start := if last_newline >= 0 { last_newline + 1 } else { previous_end }
+	out.write_repeated_rune(` `, start - column_start)
+	out.write_string(source[start..end])
 }
 
 fn fastc_register_constant(module_name string, name string, is_public bool, path string, mut constants map[string]string, mut public_constants map[string]bool, mut constant_paths map[string]string) ! {
@@ -283,11 +379,13 @@ mut:
 	enum_flags          map[string]bool
 	params_structs      map[string]bool
 	type_source_paths   map[string]bool
+	type_sources        map[string]string
 	declaration_paths   map[string]string
 	declaration_modules map[string]string
 	constants           map[string]string
 	public_constants    map[string]bool
 	constant_paths      map[string]string
+	constant_sources    map[string]string
 	globals             map[string]string
 	public_globals      map[string]bool
 	global_paths        map[string]string
@@ -302,35 +400,43 @@ fn fastc_collect_declaration_chunk(sources []FastcSourceFile, prefs &pref.Prefer
 		enum_flags:          map[string]bool{}
 		params_structs:      map[string]bool{}
 		type_source_paths:   map[string]bool{}
+		type_sources:        map[string]string{}
 		declaration_paths:   map[string]string{}
 		declaration_modules: map[string]string{}
 		constants:           map[string]string{}
 		public_constants:    map[string]bool{}
 		constant_paths:      map[string]string{}
+		constant_sources:    map[string]string{}
 		globals:             map[string]string{}
 		public_globals:      map[string]bool{}
 		global_paths:        map[string]string{}
 	}
 	for idx in start .. end {
 		source_file := sources[idx]
+		mut type_source := strings.new_builder(256)
 		has_type_declarations := collect_declared_types(source_file.source, source_file.path,
 			source_file.header.module_name, prefs, mut partial.declared_types, mut
 			partial.declared_kinds, mut partial.enum_flags, mut partial.params_structs, mut
-			partial.declaration_paths, mut partial.declaration_modules) or {
+			partial.declaration_paths, mut partial.declaration_modules, mut type_source) or {
 			partial.failed = true
 			partial.error_message = err.msg()
 			return partial
 		}
 		if has_type_declarations {
 			partial.type_source_paths[source_file.path] = true
+			partial.type_sources[source_file.path] = type_source.str()
 		}
 		if source_file.header.has_constants {
+			mut constant_source := strings.new_builder(256)
 			collect_constant_names(source_file.source, source_file.path,
 				source_file.header.module_name, prefs, mut partial.constants, mut
-				partial.public_constants, mut partial.constant_paths) or {
+				partial.public_constants, mut partial.constant_paths, mut constant_source) or {
 				partial.failed = true
 				partial.error_message = err.msg()
 				return partial
+			}
+			if constant_source.len > 0 {
+				partial.constant_sources[source_file.path] = constant_source.str()
 			}
 		}
 		if source_file.header.has_global_declarations {
@@ -345,7 +451,7 @@ fn fastc_collect_declaration_chunk(sources []FastcSourceFile, prefs &pref.Prefer
 	return partial
 }
 
-fn fastc_merge_declaration_partial(partial FastcDeclarationPartial, mut declared_types map[string]bool, mut declared_kinds map[string]FastcDeclaredTypeKind, mut enum_flags map[string]bool, mut params_structs map[string]bool, mut type_source_paths map[string]bool, mut constants map[string]string, mut public_constants map[string]bool, mut globals map[string]string, mut public_globals map[string]bool) ! {
+fn fastc_merge_declaration_partial(partial FastcDeclarationPartial, mut declared_types map[string]bool, mut declared_kinds map[string]FastcDeclaredTypeKind, mut enum_flags map[string]bool, mut params_structs map[string]bool, mut type_source_paths map[string]bool, mut type_sources map[string]string, mut constants map[string]string, mut public_constants map[string]bool, mut constant_sources map[string]string, mut globals map[string]string, mut public_globals map[string]bool) ! {
 	if partial.failed {
 		return error(partial.error_message)
 	}
@@ -367,6 +473,9 @@ fn fastc_merge_declaration_partial(partial FastcDeclarationPartial, mut declared
 	for path, _ in partial.type_source_paths {
 		type_source_paths[path] = true
 	}
+	for path, source in partial.type_sources {
+		type_sources[path] = source
+	}
 	for key, c_name in partial.constants {
 		if key in constants {
 			return error('fastc parser does not support duplicate constant `${key.all_after_last('.')}` in ${partial.constant_paths[key]}')
@@ -375,6 +484,9 @@ fn fastc_merge_declaration_partial(partial FastcDeclarationPartial, mut declared
 	}
 	for key, _ in partial.public_constants {
 		public_constants[key] = true
+	}
+	for path, source in partial.constant_sources {
+		constant_sources[path] = source
 	}
 	for key, c_name in partial.globals {
 		if key in globals {
@@ -703,19 +815,17 @@ fn fastc_render_struct_field_defaults(prefs &pref.Preferences, declared_types ma
 	}
 }
 
-fn fastc_generate_constant_declarations(sources []FastcSourceFile, prefs &pref.Preferences, declared_types map[string]bool, declared_type_c_names map[string]string, fastc_prefixed_c_names []string, declared_kinds map[string]FastcDeclaredTypeKind, enum_flags map[string]bool, enum_field_types map[string]string, alias_base_types map[string]string, struct_fields map[string]map[string]string, struct_field_info map[string][]FastcStructField, functions map[string]FastcFunctionSignature, constants map[string]string, public_constants map[string]bool, globals map[string]string, public_globals map[string]bool, mut constant_types map[string]string) !FastcConstantDeclarations {
+fn fastc_generate_constant_declarations(sources []FastcSourceFile, constant_sources map[string]string, prefs &pref.Preferences, declared_types map[string]bool, declared_type_c_names map[string]string, fastc_prefixed_c_names []string, declared_kinds map[string]FastcDeclaredTypeKind, enum_flags map[string]bool, enum_field_types map[string]string, alias_base_types map[string]string, struct_fields map[string]map[string]string, struct_field_info map[string][]FastcStructField, functions map[string]FastcFunctionSignature, constants map[string]string, public_constants map[string]bool, globals map[string]string, public_globals map[string]bool, mut constant_types map[string]string) !FastcConstantDeclarations {
 	mut values := []FastcConstantValue{}
 	mut composite_types := map[string]bool{}
 	mut fixed_array_types := map[string]string{}
 	helper_has_c_functions := fastc_functions_declare_c(functions)
 	ordered_sources := fastc_sources_in_dependency_order(sources)!
 	for source_file in ordered_sources {
-		if !source_file.header.has_constants {
-			continue
-		}
+		constant_source := constant_sources[source_file.path] or { continue }
 		mut file_set := token.FileSet.new()
-		mut file := file_set.add_file(source_file.path, source_file.source.len)
-		file.index_lines_without_digest(source_file.source)
+		mut file := file_set.add_file(source_file.path, constant_source.len)
+		file.index_lines_without_digest(constant_source)
 		mut gen := Parser{
 			prefs:                        unsafe { prefs }
 			path:                         source_file.path
@@ -749,7 +859,7 @@ fn fastc_generate_constant_declarations(sources []FastcSourceFile, prefs &pref.P
 			composite_types:              map[string]bool{}
 			fixed_array_types:            map[string]string{}
 		}
-		gen.s.init(file, source_file.source)
+		gen.s.init(file, constant_source)
 		gen.next()
 		gen.parse_selected_constant_declarations(mut values, false)!
 		if gen.s.diagnostics.len > 0 {
@@ -1042,7 +1152,7 @@ fn (g &Parser) constant_expression_requires_runtime_storage(tokens []FastcExpres
 	return false
 }
 
-fn fastc_generate_type_declarations(sources []FastcSourceFile, prefs &pref.Preferences, type_source_paths map[string]bool, declared_types map[string]bool, declared_kinds map[string]FastcDeclaredTypeKind, enum_flags map[string]bool, constants map[string]string, public_constants map[string]bool, mut struct_fields map[string]map[string]string, mut struct_field_info map[string][]FastcStructField, mut composite_types map[string]bool) !FastcTypeDeclarations {
+fn fastc_generate_type_declarations(sources []FastcSourceFile, type_sources map[string]string, prefs &pref.Preferences, type_source_paths map[string]bool, declared_types map[string]bool, declared_kinds map[string]FastcDeclaredTypeKind, enum_flags map[string]bool, constants map[string]string, public_constants map[string]bool, mut struct_fields map[string]map[string]string, mut struct_field_info map[string][]FastcStructField, mut composite_types map[string]bool) !FastcTypeDeclarations {
 	mut out := strings.new_builder(4096)
 	mut bodies := strings.new_builder(4096)
 	mut enum_infos := []FastcEnumInfo{}
@@ -1074,7 +1184,13 @@ fn fastc_generate_type_declarations(sources []FastcSourceFile, prefs &pref.Prefe
 		if source_file.path !in type_source_paths {
 			continue
 		}
-		fastc_emit_source_type_declarations(source_file, prefs, declared_types, declared_kinds,
+		type_source := type_sources[source_file.path] or { continue }
+		type_source_file := FastcSourceFile{
+			path:   source_file.path
+			source: type_source
+			header: source_file.header
+		}
+		fastc_emit_source_type_declarations(type_source_file, prefs, declared_types, declared_kinds,
 			constants, public_constants, mut struct_fields, mut struct_field_info, mut
 			composite_types, mut alias_base_types, mut sum_types, mut sum_type_variants, mut
 			enum_infos, mut bodies)!

--- a/vlib/v3/gen/fastc/declaration_filter_test.v
+++ b/vlib/v3/gen/fastc/declaration_filter_test.v
@@ -78,6 +78,27 @@ fn test_filtered_eof_comptime_spans_include_closing_brace() {
 	assert partial.constant_sources[path].ends_with('}')
 }
 
+fn test_constant_visibility_resets_after_each_declaration() {
+	prefs := pref.new_preferences()
+	path := 'constant_visibility.v'
+	source := 'module example\n\npub const public_one = 1\nconst private_one = 2\npub const (\n\tpublic_group = 3\n)\nconst private_after_group = 4\n'
+	partial := fastc_collect_declaration_chunk([
+		FastcSourceFile{
+			path: path
+			source: source
+			header: FastcSourceHeader{
+				module_name: 'example'
+				has_constants: true
+			}
+		},
+	], prefs, 0, 1)
+	assert !partial.failed, partial.error_message
+	assert 'example.public_one' in partial.public_constants
+	assert 'example.public_group' in partial.public_constants
+	assert 'example.private_one' !in partial.public_constants
+	assert 'example.private_after_group' !in partial.public_constants
+}
+
 fn test_partitioned_c_directives_match_materialized_hoisting() {
 	for source in [
 		'one\n#include <x.h>\ntwo\n# if FLAG\nthree\n#ifdef INNER\nfour\n#endif\n#else\nfive\n#endif\nsix',

--- a/vlib/v3/gen/fastc/declaration_filter_test.v
+++ b/vlib/v3/gen/fastc/declaration_filter_test.v
@@ -1,0 +1,94 @@
+module fastc
+
+import strings
+import v3.pref
+
+fn test_filtered_declaration_sources_preserve_locations() {
+	prefs := pref.new_preferences()
+	path := 'filtered_declarations.v'
+	source := "module main
+
+fn before() {
+	println('const fake = 0')
+}
+
+@[flag]
+enum Mode {
+	one
+	two
+}
+
+struct Box {
+	value int
+}
+
+const answer = @LINE
+const values = [1, 2, 3]
+
+fn after() {}
+"
+	partial := fastc_collect_declaration_chunk([
+		FastcSourceFile{
+			path: path
+			source: source
+			header: FastcSourceHeader{
+				module_name: 'main'
+				has_constants: true
+			}
+		},
+	], prefs, 0, 1)
+	assert !partial.failed, partial.error_message
+	type_source := partial.type_sources[path]
+	constant_source := partial.constant_sources[path]
+	assert type_source.contains('@[flag]\nenum Mode')
+	assert type_source.contains('struct Box')
+	assert !type_source.contains('fn before')
+	assert !type_source.contains('const fake')
+	assert constant_source.contains('const answer = @LINE')
+	assert constant_source.contains('const values = [1, 2, 3]')
+	assert !constant_source.contains('fn before')
+	assert !constant_source.contains('const fake')
+	original_position := source.index('@LINE') or { -1 }
+	filtered_position := constant_source.index('@LINE') or { -1 }
+	assert original_position >= 0
+	assert filtered_position >= 0
+	original_line, original_column := fastc_line_column(source, original_position)
+	filtered_line, filtered_column := fastc_line_column(constant_source, filtered_position)
+	assert filtered_line == original_line
+	assert filtered_column == original_column
+}
+
+fn test_partitioned_c_directives_match_materialized_hoisting() {
+	for source in [
+		'one\n#include <x.h>\ntwo\n# if FLAG\nthree\n#ifdef INNER\nfour\n#endif\n#else\nfive\n#endif\nsix',
+		'one\n#include <x.h>',
+		'one\n#if FLAG\ntwo\n#endif',
+	] {
+		hoisted := fastc_hoist_c_directives(source)
+		partitioned := fastc_partition_c_directives(source)
+		mut directives := strings.new_builder(256)
+		fastc_write_c_source_ranges(mut directives, partitioned.source, partitioned.directive_ranges)
+		if partitioned.final_kind == 1 {
+			directives.write_u8(`\n`)
+		}
+		if partitioned.directive_ranges.len > 0 {
+			directives.writeln('')
+		}
+		mut conditional_code := strings.new_builder(256)
+		fastc_write_c_source_ranges(mut conditional_code, partitioned.source, partitioned.conditional_ranges)
+		if partitioned.final_kind == 2 {
+			conditional_code.write_u8(`\n`)
+		}
+		if partitioned.conditional_ranges.len > 0 {
+			conditional_code.writeln('')
+		}
+		mut body := strings.new_builder(source.len)
+		fastc_write_c_source_ranges(mut body, partitioned.source, partitioned.body_ranges)
+		if partitioned.final_kind == 0 {
+			body.write_u8(`\n`)
+		}
+		assert directives.str() == hoisted.directives
+		assert conditional_code.str() == hoisted.conditional_code
+		assert body.str() == hoisted.body
+	}
+}

--- a/vlib/v3/gen/fastc/declaration_filter_test.v
+++ b/vlib/v3/gen/fastc/declaration_filter_test.v
@@ -58,6 +58,26 @@ fn after() {}
 	assert filtered_column == original_column
 }
 
+fn test_filtered_eof_comptime_spans_include_closing_brace() {
+	prefs := pref.new_preferences()
+	path := 'filtered_eof_comptime.v'
+	source := 'module main\n\n\$if true {\nstruct Tail {}\nconst tail = 1\n}'
+	assert !source.ends_with('\n')
+	partial := fastc_collect_declaration_chunk([
+		FastcSourceFile{
+			path: path
+			source: source
+			header: FastcSourceHeader{
+				module_name: 'main'
+				has_constants: true
+			}
+		},
+	], prefs, 0, 1)
+	assert !partial.failed, partial.error_message
+	assert partial.type_sources[path].ends_with('}')
+	assert partial.constant_sources[path].ends_with('}')
+}
+
 fn test_partitioned_c_directives_match_materialized_hoisting() {
 	for source in [
 		'one\n#include <x.h>\ntwo\n# if FLAG\nthree\n#ifdef INNER\nfour\n#endif\n#else\nfive\n#endif\nsix',

--- a/vlib/v3/gen/fastc/fastc.v
+++ b/vlib/v3/gen/fastc/fastc.v
@@ -704,6 +704,14 @@ struct FastcHoistedCSource {
 	body             string
 }
 
+struct FastcPartitionedCSource {
+	source             string
+	directive_ranges   []int
+	conditional_ranges []int
+	body_ranges        []int
+	final_kind         int
+}
+
 // GenerationResult contains generated C and the complete resolved V source graph.
 pub struct GenerationResult {
 pub:
@@ -1136,7 +1144,9 @@ fn generate_source_files(input_sources []FastcSourceFile, module_aliases map[str
 	mut globals := map[string]string{}
 	mut public_globals := map[string]bool{}
 	mut type_source_paths := map[string]bool{}
-	fastc_collect_declaration_indexes(sources, prefs, mut declared_types, mut declared_kinds, mut enum_flags, mut params_structs, mut type_source_paths, mut constants, mut public_constants, mut globals, mut public_globals)!
+	mut type_sources := map[string]string{}
+	mut constant_sources := map[string]string{}
+	fastc_collect_declaration_indexes(sources, prefs, mut declared_types, mut declared_kinds, mut enum_flags, mut params_structs, mut type_source_paths, mut type_sources, mut constants, mut public_constants, mut constant_sources, mut globals, mut public_globals)!
 	declared_type_c_names := fastc_declared_type_c_names(declared_types)
 	mut functions := map[string]FastcFunctionSignature{}
 	mut interface_methods := map[string]bool{}
@@ -1167,14 +1177,14 @@ fn generate_source_files(input_sources []FastcSourceFile, module_aliases map[str
 			fastc_register_composite_type(parameter_type, mut composite_types)
 		}
 	}
-	type_output := fastc_generate_type_declarations(sources, prefs, type_source_paths, declared_types, declared_kinds, enum_flags, constants, public_constants, mut struct_fields, mut struct_field_info, mut composite_types)!
+	type_output := fastc_generate_type_declarations(sources, type_sources, prefs, type_source_paths, declared_types, declared_kinds, enum_flags, constants, public_constants, mut struct_fields, mut struct_field_info, mut composite_types)!
 	declared_composite_types := composite_types.clone()
 	type_declarations := type_output.declarations
 	enum_field_types := type_output.enum_field_types.clone()
 	mut constant_types := map[string]string{}
 	mut global_types := map[string]string{}
 	fastc_render_struct_field_defaults(prefs, declared_types, declared_type_c_names, fastc_prefixed_c_names, declared_kinds, enum_flags, enum_field_types, type_output.alias_base_types, struct_fields, mut struct_field_info, functions, constants, public_constants, constant_types, globals, public_globals, global_types, type_output.sum_types)!
-	constant_output := fastc_generate_constant_declarations(sources, prefs, declared_types, declared_type_c_names, fastc_prefixed_c_names, declared_kinds, enum_flags, enum_field_types, type_output.alias_base_types, struct_fields, struct_field_info, functions, constants, public_constants, globals, public_globals, mut constant_types)!
+	constant_output := fastc_generate_constant_declarations(sources, constant_sources, prefs, declared_types, declared_type_c_names, fastc_prefixed_c_names, declared_kinds, enum_flags, enum_field_types, type_output.alias_base_types, struct_fields, struct_field_info, functions, constants, public_constants, globals, public_globals, mut constant_types)!
 	for name, _ in constant_output.composite_types {
 		composite_types[name] = true
 	}
@@ -1314,11 +1324,17 @@ fn generate_source_files(input_sources []FastcSourceFile, module_aliases map[str
 	interface_dispatches := fastc_wait_interface_dispatches(mut pending_interface_dispatches)
 	fixed_array_declarations := fastc_generate_fixed_array_declarations(fixed_array_types)
 	preamble := if prefs.building_v { c_selfhost_preamble } else { c_preamble }
-	hoisted_body := fastc_hoist_c_directives(body.str())
+	hoisted_body := fastc_partition_c_directives(body.str())
 	mut result := strings.new_builder(preamble.len + c_integer_comparison_helpers.len + type_declarations.len + type_output.enum_string_helpers.len + constant_output.macros.len + constant_output.declarations.len + global_output.declarations.len + prototypes.len + body.len + startup_initializers.len + 96)
 	result.write_string(preamble)
 	result.write_string(c_integer_comparison_helpers)
-	result.write_string(hoisted_body.directives)
+	fastc_write_c_source_ranges(mut result, hoisted_body.source, hoisted_body.directive_ranges)
+	if hoisted_body.final_kind == 1 {
+		result.write_u8(`\n`)
+	}
+	if hoisted_body.directive_ranges.len > 0 {
+		result.writeln('')
+	}
 	if prefs.building_v {
 		result.write_string(c_selfhost_post_directives)
 	}
@@ -1376,8 +1392,17 @@ fn generate_source_files(input_sources []FastcSourceFile, module_aliases map[str
 		result.writeln('')
 	}
 	result.write_string(synthesized_main)
-	result.write_string(hoisted_body.conditional_code)
-	result.write_string(hoisted_body.body)
+	fastc_write_c_source_ranges(mut result, hoisted_body.source, hoisted_body.conditional_ranges)
+	if hoisted_body.final_kind == 2 {
+		result.write_u8(`\n`)
+	}
+	if hoisted_body.conditional_ranges.len > 0 {
+		result.writeln('')
+	}
+	fastc_write_c_source_ranges(mut result, hoisted_body.source, hoisted_body.body_ranges)
+	if hoisted_body.final_kind == 0 {
+		result.write_u8(`\n`)
+	}
 	return result.str(), spawn_typedefs.len > 0, c_flags
 }
 
@@ -1554,9 +1579,39 @@ fn fastc_generate_interface_dispatches(declared_kinds map[string]FastcDeclaredTy
 }
 
 fn fastc_hoist_c_directives(source string) FastcHoistedCSource {
+	partitioned := fastc_partition_c_directives(source)
 	mut directives := strings.new_builder(256)
+	fastc_write_c_source_ranges(mut directives, partitioned.source, partitioned.directive_ranges)
+	if partitioned.final_kind == 1 {
+		directives.write_u8(`\n`)
+	}
+	if partitioned.directive_ranges.len > 0 {
+		directives.writeln('')
+	}
 	mut conditional_code := strings.new_builder(256)
+	fastc_write_c_source_ranges(mut conditional_code, partitioned.source, partitioned.conditional_ranges)
+	if partitioned.final_kind == 2 {
+		conditional_code.write_u8(`\n`)
+	}
+	if partitioned.conditional_ranges.len > 0 {
+		conditional_code.writeln('')
+	}
 	mut body := strings.new_builder(source.len)
+	fastc_write_c_source_ranges(mut body, partitioned.source, partitioned.body_ranges)
+	if partitioned.final_kind == 0 {
+		body.write_u8(`\n`)
+	}
+	return FastcHoistedCSource{
+		directives: directives.str()
+		conditional_code: conditional_code.str()
+		body: body.str()
+	}
+}
+
+fn fastc_partition_c_directives(source string) FastcPartitionedCSource {
+	mut directive_ranges := []int{}
+	mut conditional_ranges := []int{}
+	mut body_ranges := []int{}
 	mut conditional_depth := 0
 	mut line_start := 0
 	mut run_start := 0
@@ -1583,12 +1638,7 @@ fn fastc_hoist_c_directives(source string) FastcHoistedCSource {
 		if run_kind == -1 {
 			run_kind = line_kind
 		} else if line_kind != run_kind {
-			segment := source[run_start..line_start]
-			match run_kind {
-				1 { directives.write_string(segment) }
-				2 { conditional_code.write_string(segment) }
-				else { body.write_string(segment) }
-			}
+			fastc_append_c_source_range(run_start, line_start, run_kind, mut directive_ranges, mut conditional_ranges, mut body_ranges)
 			run_start = line_start
 			run_kind = line_kind
 		}
@@ -1597,31 +1647,37 @@ fn fastc_hoist_c_directives(source string) FastcHoistedCSource {
 		}
 		line_start = line_end + 1
 	}
-	segment := source[run_start..]
-	match run_kind {
+	fastc_append_c_source_range(run_start, source.len, run_kind, mut directive_ranges, mut conditional_ranges, mut body_ranges)
+	return FastcPartitionedCSource{
+		source: source
+		directive_ranges: directive_ranges
+		conditional_ranges: conditional_ranges
+		body_ranges: body_ranges
+		final_kind: run_kind
+	}
+}
+
+fn fastc_append_c_source_range(start int, end int, kind int, mut directive_ranges []int, mut conditional_ranges []int, mut body_ranges []int) {
+	match kind {
 		1 {
-			directives.write_string(segment)
-			directives.write_u8(`\n`)
+			directive_ranges << start
+			directive_ranges << end
 		}
 		2 {
-			conditional_code.write_string(segment)
-			conditional_code.write_u8(`\n`)
+			conditional_ranges << start
+			conditional_ranges << end
 		}
 		else {
-			body.write_string(segment)
-			body.write_u8(`\n`)
+			body_ranges << start
+			body_ranges << end
 		}
 	}
-	if directives.len > 0 {
-		directives.writeln('')
-	}
-	if conditional_code.len > 0 {
-		conditional_code.writeln('')
-	}
-	return FastcHoistedCSource{
-		directives: directives.str()
-		conditional_code: conditional_code.str()
-		body: body.str()
+}
+
+@[direct_array_access]
+fn fastc_write_c_source_ranges(mut out strings.Builder, source string, ranges []int) {
+	for i := 0; i < ranges.len; i += 2 {
+		out.write_string(source[ranges[i]..ranges[i + 1]])
 	}
 }
 

--- a/vlib/v3/gen/fastc/parallel_d_v3_no_parallel.v
+++ b/vlib/v3/gen/fastc/parallel_d_v3_no_parallel.v
@@ -59,9 +59,9 @@ fn fastc_collect_reference_partials(sources []FastcSourceFile, prefs &pref.Prefe
 	}
 }
 
-fn fastc_collect_declaration_indexes(sources []FastcSourceFile, prefs &pref.Preferences, mut declared_types map[string]bool, mut declared_kinds map[string]FastcDeclaredTypeKind, mut enum_flags map[string]bool, mut params_structs map[string]bool, mut type_source_paths map[string]bool, mut constants map[string]string, mut public_constants map[string]bool, mut globals map[string]string, mut public_globals map[string]bool) ! {
+fn fastc_collect_declaration_indexes(sources []FastcSourceFile, prefs &pref.Preferences, mut declared_types map[string]bool, mut declared_kinds map[string]FastcDeclaredTypeKind, mut enum_flags map[string]bool, mut params_structs map[string]bool, mut type_source_paths map[string]bool, mut type_sources map[string]string, mut constants map[string]string, mut public_constants map[string]bool, mut constant_sources map[string]string, mut globals map[string]string, mut public_globals map[string]bool) ! {
 	partial := fastc_collect_declaration_chunk(sources, prefs, 0, sources.len)
-	fastc_merge_declaration_partial(partial, mut declared_types, mut declared_kinds, mut enum_flags, mut params_structs, mut type_source_paths, mut constants, mut public_constants, mut globals, mut public_globals)!
+	fastc_merge_declaration_partial(partial, mut declared_types, mut declared_kinds, mut enum_flags, mut params_structs, mut type_source_paths, mut type_sources, mut constants, mut public_constants, mut constant_sources, mut globals, mut public_globals)!
 }
 
 fn fastc_collect_signatures(sources []FastcSourceFile, prefs &pref.Preferences, declared_types map[string]bool, declared_type_c_names map[string]string, params_structs map[string]bool, mut functions map[string]FastcFunctionSignature, mut interface_methods map[string]bool, mut interface_fields map[string]FastcInterfaceField, mut embed_embedders []string, mut embed_embeddeds []string) ! {

--- a/vlib/v3/gen/fastc/parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/fastc/parallel_notd_v3_no_parallel.v
@@ -315,11 +315,11 @@ fn fastc_collect_reference_partials(sources []FastcSourceFile, prefs &pref.Prefe
 	}
 }
 
-fn fastc_collect_declaration_indexes(sources []FastcSourceFile, prefs &pref.Preferences, mut declared_types map[string]bool, mut declared_kinds map[string]FastcDeclaredTypeKind, mut enum_flags map[string]bool, mut params_structs map[string]bool, mut type_source_paths map[string]bool, mut constants map[string]string, mut public_constants map[string]bool, mut globals map[string]string, mut public_globals map[string]bool) ! {
+fn fastc_collect_declaration_indexes(sources []FastcSourceFile, prefs &pref.Preferences, mut declared_types map[string]bool, mut declared_kinds map[string]FastcDeclaredTypeKind, mut enum_flags map[string]bool, mut params_structs map[string]bool, mut type_source_paths map[string]bool, mut type_sources map[string]string, mut constants map[string]string, mut public_constants map[string]bool, mut constant_sources map[string]string, mut globals map[string]string, mut public_globals map[string]bool) ! {
 	jobs := fastc_parallel_jobs(sources, prefs)
 	if jobs <= 1 {
 		partial := fastc_collect_declaration_chunk(sources, prefs, 0, sources.len)
-		fastc_merge_declaration_partial(partial, mut declared_types, mut declared_kinds, mut enum_flags, mut params_structs, mut type_source_paths, mut constants, mut public_constants, mut globals, mut public_globals)!
+		fastc_merge_declaration_partial(partial, mut declared_types, mut declared_kinds, mut enum_flags, mut params_structs, mut type_source_paths, mut type_sources, mut constants, mut public_constants, mut constant_sources, mut globals, mut public_globals)!
 		return
 	}
 	bounds := fastc_chunk_bounds(sources, jobs)
@@ -330,10 +330,10 @@ fn fastc_collect_declaration_indexes(sources []FastcSourceFile, prefs &pref.Pref
 		chunk_threads << chunk_thread
 	}
 	first := fastc_collect_declaration_chunk(sources, prefs, bounds[0], bounds[1])
-	fastc_merge_declaration_partial(first, mut declared_types, mut declared_kinds, mut enum_flags, mut params_structs, mut type_source_paths, mut constants, mut public_constants, mut globals, mut public_globals)!
+	fastc_merge_declaration_partial(first, mut declared_types, mut declared_kinds, mut enum_flags, mut params_structs, mut type_source_paths, mut type_sources, mut constants, mut public_constants, mut constant_sources, mut globals, mut public_globals)!
 	for chunk_thread in chunk_threads {
 		partial := chunk_thread.wait()
-		fastc_merge_declaration_partial(partial, mut declared_types, mut declared_kinds, mut enum_flags, mut params_structs, mut type_source_paths, mut constants, mut public_constants, mut globals, mut public_globals)!
+		fastc_merge_declaration_partial(partial, mut declared_types, mut declared_kinds, mut enum_flags, mut params_structs, mut type_source_paths, mut type_sources, mut constants, mut public_constants, mut constant_sources, mut globals, mut public_globals)!
 	}
 }
 


### PR DESCRIPTION
## Summary

- reuse declaration-only type and constant source collected during the existing index scan
- write hoisted C sections directly from source ranges instead of materializing another complete body
- cover filtered declaration locations and range-based directive partitioning

## Benchmark

FastC self-host benchmark on macOS, five samples of 50 runs, with compilers built using ./v -prod:

| | Median LOC/s | Median time |
|---|---:|---:|
| Before | 1,491,318 | 43.65 ms |
| After | 1,673,950 | 38.99 ms |
| Change | +12.2% | -10.7% |

## Validation

- ./vnew -silent test vlib/v3/gen/fastc/declaration_filter_test.v
- ./vnew -silent vlib/v/compiler_errors_test.v
- five successive FastC self-host generations
- serial v3_no_parallel FastC self-host
- git diff --check
