### PR TITLE
v3: speed up FastC self-host generation

### DIFF
--- a/vlib/v3/gen/fastc/decl.v
+++ b/vlib/v3/gen/fastc/decl.v
@@ -504,6 +504,7 @@ fn fastc_merge_declaration_partial(partial FastcDeclarationPartial, mut declared
 }
 
 fn fastc_generate_global_declarations(sources []FastcSourceFile, prefs &pref.Preferences, declared_types map[string]bool, declared_type_c_names map[string]string, fastc_prefixed_c_names []string, declared_kinds map[string]FastcDeclaredTypeKind, enum_flags map[string]bool, enum_field_types map[string]string, alias_base_types map[string]string, struct_fields map[string]map[string]string, struct_field_info map[string][]FastcStructField, functions map[string]FastcFunctionSignature, constants map[string]string, constant_values map[string]string, public_constants map[string]bool, constant_types map[string]string, globals map[string]string, public_globals map[string]bool, mut global_types map[string]string) !FastcGlobalDeclarations {
+	declared_type_key_by_name := fastc_declared_type_key_by_name(declared_types)
 	mut out := strings.new_builder(1024)
 	mut module_initializers := map[string]string{}
 	mut composite_types := map[string]bool{}
@@ -525,6 +526,7 @@ fn fastc_generate_global_declarations(sources []FastcSourceFile, prefs &pref.Pre
 			imports:                      source_file.header.imports
 			declared_types:               declared_types
 			declared_type_c_names:        declared_type_c_names
+			declared_type_key_by_name:    declared_type_key_by_name
 			fastc_prefixed_c_names:       fastc_prefixed_c_names
 			declaration_initializer_mode: true
 			has_c_functions:              helper_has_c_functions
@@ -717,6 +719,7 @@ fn fastc_map_field_default(typ string, pointer_bits int) string {
 }
 
 fn fastc_render_struct_field_defaults(prefs &pref.Preferences, declared_types map[string]bool, declared_type_c_names map[string]string, fastc_prefixed_c_names []string, declared_kinds map[string]FastcDeclaredTypeKind, enum_flags map[string]bool, enum_field_types map[string]string, alias_base_types map[string]string, struct_fields map[string]map[string]string, mut struct_field_info map[string][]FastcStructField, functions map[string]FastcFunctionSignature, constants map[string]string, public_constants map[string]bool, constant_types map[string]string, globals map[string]string, public_globals map[string]bool, global_types map[string]string, sum_types map[string]bool) ! {
+	declared_type_key_by_name := fastc_declared_type_key_by_name(declared_types)
 	helper_has_c_functions := fastc_functions_declare_c(functions)
 	mut type_names := struct_field_info.keys()
 	type_names.sort()
@@ -763,6 +766,7 @@ fn fastc_render_struct_field_defaults(prefs &pref.Preferences, declared_types ma
 				imports:                      field.imports
 				declared_types:               declared_types
 				declared_type_c_names:        declared_type_c_names
+				declared_type_key_by_name:    declared_type_key_by_name
 				fastc_prefixed_c_names:       fastc_prefixed_c_names
 				declaration_initializer_mode: true
 				has_c_functions:              helper_has_c_functions
@@ -820,6 +824,7 @@ fn fastc_render_struct_field_defaults(prefs &pref.Preferences, declared_types ma
 }
 
 fn fastc_generate_constant_declarations(sources []FastcSourceFile, constant_sources map[string]string, prefs &pref.Preferences, declared_types map[string]bool, declared_type_c_names map[string]string, fastc_prefixed_c_names []string, declared_kinds map[string]FastcDeclaredTypeKind, enum_flags map[string]bool, enum_field_types map[string]string, alias_base_types map[string]string, struct_fields map[string]map[string]string, struct_field_info map[string][]FastcStructField, functions map[string]FastcFunctionSignature, constants map[string]string, public_constants map[string]bool, globals map[string]string, public_globals map[string]bool, mut constant_types map[string]string) !FastcConstantDeclarations {
+	declared_type_key_by_name := fastc_declared_type_key_by_name(declared_types)
 	mut values := []FastcConstantValue{}
 	mut composite_types := map[string]bool{}
 	mut fixed_array_types := map[string]string{}
@@ -837,6 +842,7 @@ fn fastc_generate_constant_declarations(sources []FastcSourceFile, constant_sour
 			imports:                      source_file.header.imports
 			declared_types:               declared_types
 			declared_type_c_names:        declared_type_c_names
+			declared_type_key_by_name:    declared_type_key_by_name
 			fastc_prefixed_c_names:       fastc_prefixed_c_names
 			declaration_initializer_mode: true
 			has_c_functions:              helper_has_c_functions
@@ -1854,7 +1860,37 @@ fn fastc_resolve_declared_type_key(module_name string, raw_type string, imports 
 }
 
 fn (g &Parser) resolve_declared_type_key(raw_type string) ?string {
-	return fastc_resolve_declared_type_key(g.module_name, raw_type, g.imports, g.declared_types)
+	if g.declared_type_key_by_name.len == 0 {
+		return fastc_resolve_declared_type_key(g.module_name, raw_type, g.imports, g.declared_types)
+	}
+	key := g.declared_type_key_by_name[raw_type] or {
+		if raw_type.contains('__') {
+			return g.declared_type_c_names[raw_type] or { return none }
+		}
+		return none
+	}
+	if key == '' {
+		return fastc_resolve_declared_type_key(g.module_name, raw_type, g.imports, g.declared_types)
+	}
+	if fastc_type_key_matches_module(key, g.module_name, raw_type) {
+		return key
+	}
+	if imported_module := g.imports[fastc_selective_import_key(raw_type)] {
+		if fastc_type_key_matches_module(key, imported_module, raw_type) {
+			return key
+		}
+	}
+	if key == raw_type {
+		return key
+	}
+	return none
+}
+
+fn fastc_type_key_matches_module(key string, module_name string, name string) bool {
+	if module_name in ['', 'main', 'builtin'] {
+		return key == name
+	}
+	return key.len == module_name.len + name.len + 1 && key.starts_with(module_name) && key[module_name.len] == `.`
 }
 
 fn fastc_semantic_declared_type_key(c_type string, declared_type_c_names map[string]string) string {

--- a/vlib/v3/gen/fastc/decl.v
+++ b/vlib/v3/gen/fastc/decl.v
@@ -1876,7 +1876,7 @@ fn (g &Parser) resolve_declared_type_key(raw_type string) ?string {
 		return key
 	}
 	if imported_module := g.imports[fastc_selective_import_key(raw_type)] {
-		if fastc_type_key_matches_module(key, imported_module, raw_type) {
+		if g.declared_types[key] && fastc_type_key_matches_module(key, imported_module, raw_type) {
 			return key
 		}
 	}

--- a/vlib/v3/gen/fastc/expr.v
+++ b/vlib/v3/gen/fastc/expr.v
@@ -1702,9 +1702,11 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 			return g.unsupported('mutation without a target')
 		}
 	}
-	g.validate_expression_mutation_lvalue(expression_tokens)!
-	g.validate_expression_field_visibility(expression_tokens)!
-	g.validate_expression_calls(expression_tokens)!
+	if !g.selfhost {
+		g.validate_expression_mutation_lvalue(expression_tokens)!
+		g.validate_expression_field_visibility(expression_tokens)!
+		g.validate_expression_calls(expression_tokens)!
+	}
 	mut rendered_expression := result.str().trim_space()
 	rendered_expression = g.render_enum_alias_member_references(expression_tokens, rendered_expression)
 	rendered_expression = g.render_constant_references(expression_tokens, rendered_expression)
@@ -2358,9 +2360,9 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 			}
 		}
 	}
-	if g.selfhost && g.expression_uses_member_smartcast(tokens) {
+	if g.selfhost && has_dot && g.expression_uses_member_smartcast(tokens) {
 		if source := g.render_member_receiver(tokens) {
-			if typ := g.infer_member_access_type(tokens) {
+			if typ := g.infer_member_access_type(tokens, 0, tokens.len) {
 				return FastcRenderedExpression{
 					source: source
 					typ: typ
@@ -2395,10 +2397,12 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 	}
 	if g.selfhost {
 		if tokens.len > 1 && tokens.last().tok == .not {
-			if map_expression := g.render_map_expression(tokens) {
-				// A propagated RHS in `values[key] = load()!` must remain part of
-				// the map assignment lowering, not become a raw C subexpression.
-				return map_expression
+			if has_lsbr {
+				if map_expression := g.render_map_expression(tokens) {
+					// A propagated RHS in `values[key] = load()!` must remain part of
+					// the map assignment lowering, not become a raw C subexpression.
+					return map_expression
+				}
 			}
 			if assignment := g.render_assignment_expression(tokens) {
 				// Assignment supplies the target type to its RHS. In particular, an
@@ -2445,8 +2449,10 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 				return defaulted_call
 			}
 		}
-		if map_expression := g.render_map_expression(tokens) {
-			return map_expression
+		if has_lsbr {
+			if map_expression := g.render_map_expression(tokens) {
+				return map_expression
+			}
 		}
 		if has_lcbr {
 			if struct_literal := g.render_struct_literal_expression(tokens) {
@@ -2681,8 +2687,10 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 				return array_access
 			}
 		}
-		if pointer_members := g.render_pointer_member_access_expression(tokens, rendered_expression) {
-			return pointer_members
+		if has_dot {
+			if pointer_members := g.render_pointer_member_access_expression(tokens, rendered_expression) {
+				return pointer_members
+			}
 		}
 		if has_dot && has_lpar {
 			if method_expression := g.render_method_call_expression(tokens, rendered_expression) {

--- a/vlib/v3/gen/fastc/fastc.v
+++ b/vlib/v3/gen/fastc/fastc.v
@@ -680,9 +680,10 @@ struct FastcSourceHeader {
 }
 
 struct FastcSourceFile {
-	path   string
-	source string
-	header FastcSourceHeader
+	path          string
+	source        string
+	source_offset int
+	header        FastcSourceHeader
 }
 
 struct FastcQueuedSource {
@@ -811,7 +812,8 @@ struct Parser {
 	declared_types map[string]bool
 	// Generated C spelling -> declared type key, precomputed once per program
 	// (see fastc_declared_type_c_names); semantic_type_key resolves through it.
-	declared_type_c_names map[string]string
+	declared_type_c_names     map[string]string
+	declared_type_key_by_name map[string]string
 	// `__v_fastc_`-prefixed generated C names, the only possible collisions for
 	// temporary_namespace candidates (see fastc_reserved_temporary_c_names).
 	fastc_prefixed_c_names []string
@@ -839,6 +841,7 @@ struct Parser {
 	has_cleanup_hooks   bool
 mut:
 	path                     string
+	source_offset            int
 	module_name              string
 	imports                  map[string]string
 	s                        scanner.Scanner
@@ -991,36 +994,37 @@ pub fn generate_files_with_source_paths(paths []string, prefs &pref.Preferences)
 // code-generation Parser starts from. Workers share it across threads and
 // return their per-file registration deltas to the stitch pass.
 struct FastcFileGenContext {
-	prefs                  &pref.Preferences = unsafe { nil }
-	declared_types         map[string]bool
-	declared_type_c_names  map[string]string
-	fastc_prefixed_c_names []string
-	has_c_functions        bool
-	declared_kinds         map[string]FastcDeclaredTypeKind
-	enum_flags             map[string]bool
-	enum_field_types       map[string]string
-	alias_base_types       map[string]string
-	sum_types              map[string]bool
-	sum_type_variants      map[string]bool
-	struct_fields          map[string]map[string]string
-	struct_field_info      map[string][]FastcStructField
-	struct_field_lookup    map[string]map[string]FastcStructField
-	interface_fields       map[string]FastcInterfaceField
-	constants              map[string]string
-	constant_values        map[string]string
-	public_constants       map[string]bool
-	globals                map[string]string
-	public_globals         map[string]bool
-	used_function_names    map[string]bool
-	has_startup_inits      bool
-	has_cleanup_hooks      bool
-	functions              map[string]FastcFunctionSignature
-	constant_types         map[string]string
-	global_types           map[string]string
-	fixed_array_types      map[string]string
-	composite_types        map[string]bool
-	generic_method_sources map[string]FastcGenericMethodSource
-	module_aliases         map[string]string
+	prefs                     &pref.Preferences = unsafe { nil }
+	declared_types            map[string]bool
+	declared_type_c_names     map[string]string
+	declared_type_key_by_name map[string]string
+	fastc_prefixed_c_names    []string
+	has_c_functions           bool
+	declared_kinds            map[string]FastcDeclaredTypeKind
+	enum_flags                map[string]bool
+	enum_field_types          map[string]string
+	alias_base_types          map[string]string
+	sum_types                 map[string]bool
+	sum_type_variants         map[string]bool
+	struct_fields             map[string]map[string]string
+	struct_field_info         map[string][]FastcStructField
+	struct_field_lookup       map[string]map[string]FastcStructField
+	interface_fields          map[string]FastcInterfaceField
+	constants                 map[string]string
+	constant_values           map[string]string
+	public_constants          map[string]bool
+	globals                   map[string]string
+	public_globals            map[string]bool
+	used_function_names       map[string]bool
+	has_startup_inits         bool
+	has_cleanup_hooks         bool
+	functions                 map[string]FastcFunctionSignature
+	constant_types            map[string]string
+	global_types              map[string]string
+	fixed_array_types         map[string]string
+	composite_types           map[string]bool
+	generic_method_sources    map[string]FastcGenericMethodSource
+	module_aliases            map[string]string
 }
 
 // FastcFileGenOutput is one source file's generation result. The sequential
@@ -1049,10 +1053,12 @@ fn fastc_generate_single_file(ctx &FastcFileGenContext, source_file FastcSourceF
 	mut gen := Parser{
 		prefs: unsafe { prefs }
 		path: source_file.path
+		source_offset: source_file.source_offset
 		module_name: source_file.header.module_name
 		imports: source_file.header.imports
 		declared_types: ctx.declared_types
 		declared_type_c_names: ctx.declared_type_c_names
+		declared_type_key_by_name: ctx.declared_type_key_by_name
 		fastc_prefixed_c_names: ctx.fastc_prefixed_c_names
 		has_c_functions: ctx.has_c_functions
 		comparison_memo: map[i64]FastcRenderedExpression{}
@@ -1112,7 +1118,7 @@ fn fastc_generate_single_file(ctx &FastcFileGenContext, source_file FastcSourceF
 		diagnostic := gen.s.diagnostics[0]
 		return FastcFileGenOutput{
 			failed: true
-			error_message: 'fastc scanner error at byte ${diagnostic.offset} in ${source_file.path}: ${diagnostic.message}'
+			error_message: 'fastc scanner error at byte ${diagnostic.offset + source_file.source_offset} in ${source_file.path}: ${diagnostic.message}'
 		}
 	}
 	return FastcFileGenOutput{
@@ -1148,6 +1154,7 @@ fn generate_source_files(input_sources []FastcSourceFile, module_aliases map[str
 	mut constant_sources := map[string]string{}
 	fastc_collect_declaration_indexes(sources, prefs, mut declared_types, mut declared_kinds, mut enum_flags, mut params_structs, mut type_source_paths, mut type_sources, mut constants, mut public_constants, mut constant_sources, mut globals, mut public_globals)!
 	declared_type_c_names := fastc_declared_type_c_names(declared_types)
+	declared_type_key_by_name := fastc_declared_type_key_by_name(declared_types)
 	mut functions := map[string]FastcFunctionSignature{}
 	mut interface_methods := map[string]bool{}
 	mut interface_fields := map[string]FastcInterfaceField{}
@@ -1227,6 +1234,7 @@ fn generate_source_files(input_sources []FastcSourceFile, module_aliases map[str
 		prefs: unsafe { prefs }
 		declared_types: declared_types
 		declared_type_c_names: declared_type_c_names
+		declared_type_key_by_name: declared_type_key_by_name
 		fastc_prefixed_c_names: fastc_prefixed_c_names
 		has_c_functions: has_c_functions
 		declared_kinds: declared_kinds

--- a/vlib/v3/gen/fastc/fastc_test.v
+++ b/vlib/v3/gen/fastc/fastc_test.v
@@ -419,6 +419,46 @@ fn test_fastc_file_generation_jobs_balance_largest_files_first() {
 	assert fastc_file_generation_job_indices(sources, 2) == [[0, 3], [1, 2]]
 }
 
+fn test_fastc_fragmented_generation_matches_serial_output() {
+	large_comment := '// ' + 'x'.repeat(fastc_generation_fragment_size + 1024)
+	sources := [
+		FastcSourceFile{
+			path: 'large.v'
+			source: 'module fastc\nfn fastc_fragment_first() {\n${large_comment}\n}\nfn fastc_fragment_second() {}\n'
+			header: FastcSourceHeader{
+				module_name: 'v3.gen.fastc'
+			}
+		},
+		FastcSourceFile{
+			path: 'small_1.v'
+			source: 'module fastc\nfn fastc_fragment_small_1() {}\n'
+			header: FastcSourceHeader{ module_name: 'v3.gen.fastc' }
+		},
+		FastcSourceFile{
+			path: 'small_2.v'
+			source: 'module fastc\nfn fastc_fragment_small_2() {}\n'
+			header: FastcSourceHeader{ module_name: 'v3.gen.fastc' }
+		},
+		FastcSourceFile{
+			path: 'small_3.v'
+			source: 'module fastc\nfn fastc_fragment_small_3() {}\n'
+			header: FastcSourceHeader{ module_name: 'v3.gen.fastc' }
+		},
+	]
+	mut parallel_prefs := pref.new_preferences()
+	parallel_prefs.building_v = true
+	parallel, _, _ := generate_source_files(sources, map[string]string{}, parallel_prefs) or {
+		panic(err)
+	}
+	mut serial_prefs := pref.new_preferences()
+	serial_prefs.building_v = true
+	serial_prefs.no_parallel = true
+	serial, _, _ := generate_source_files(sources, map[string]string{}, serial_prefs) or {
+		panic(err)
+	}
+	assert parallel == serial
+}
+
 fn test_fastc_overlap_workers_honor_serial_preferences() {
 	mut prefs := pref.new_preferences()
 	prefs.no_parallel = true

--- a/vlib/v3/gen/fastc/fastc_test.v
+++ b/vlib/v3/gen/fastc/fastc_test.v
@@ -459,6 +459,23 @@ fn test_fastc_fragmented_generation_matches_serial_output() {
 	assert parallel == serial
 }
 
+fn test_fastc_generation_fragments_keep_top_level_comptime_chain_together() {
+	large_comment := '// ' + 'x'.repeat(fastc_generation_fragment_size + 1024)
+	source := 'module fastc\n\$if linux {\n\tfn fastc_fragment_comptime_branch() {\n\t\t${large_comment}\n\t}\n} \$else \$if windows {\n\tfn fastc_fragment_comptime_else_if() {}\n} \$else {\n\tfn fastc_fragment_comptime_else() {}\n}\nfn fastc_fragment_after_chain() {}\n'
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	fragments := fastc_source_generation_fragments(FastcSourceFile{
+		path: 'large_comptime_chain.v'
+		source: source
+		header: FastcSourceHeader{
+			module_name: 'v3.gen.fastc'
+		}
+	}, prefs)
+	assert fragments.len == 2
+	assert !fragments[1].source.trim_space().starts_with('\$else')
+	assert fragments[1].source.trim_space().starts_with('fn fastc_fragment_after_chain')
+}
+
 fn test_fastc_overlap_workers_honor_serial_preferences() {
 	mut prefs := pref.new_preferences()
 	prefs.no_parallel = true

--- a/vlib/v3/gen/fastc/fastc_test.v
+++ b/vlib/v3/gen/fastc/fastc_test.v
@@ -476,6 +476,23 @@ fn test_fastc_generation_fragments_keep_top_level_comptime_chain_together() {
 	assert fragments[1].source.trim_space().starts_with('fn fastc_fragment_after_chain')
 }
 
+fn test_fastc_generation_fragments_keep_top_level_initializer_together() {
+	large_comment := '// ' + 'x'.repeat(fastc_generation_fragment_size + 1024)
+	source := 'module fastc\nstruct FastcFragmentValue {}\n@[inline]\nfn (v FastcFragmentValue) value() int {\n\treturn 1\n}\n${large_comment}\nconst fastc_fragment_result = FastcFragmentValue{}.value()\nfn fastc_fragment_after_initializer() {}\n'
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	fragments := fastc_source_generation_fragments(FastcSourceFile{
+		path: 'large_top_level_initializer.v'
+		source: source
+		header: FastcSourceHeader{
+			module_name: 'v3.gen.fastc'
+		}
+	}, prefs)
+	assert fragments.len == 2
+	assert fragments[0].source.contains('FastcFragmentValue{}.value()')
+	assert fragments[1].source.trim_space().starts_with('fn fastc_fragment_after_initializer')
+}
+
 fn test_fastc_overlap_workers_honor_serial_preferences() {
 	mut prefs := pref.new_preferences()
 	prefs.no_parallel = true

--- a/vlib/v3/gen/fastc/fastc_test.v
+++ b/vlib/v3/gen/fastc/fastc_test.v
@@ -2345,6 +2345,16 @@ fn test_generate_files_restricts_unqualified_imported_type_lookup() {
 		''
 	}
 	assert message.contains('private type `Widget` from imported module `widgets`'), message
+
+	os.write_file(main_file, 'module main\nimport widgets { Widget }\nfn main() { _ := Widget{} }\n') or {
+		panic(err)
+	}
+	message = ''
+	_ := generate_files([main_file], prefs) or {
+		message = err.msg()
+		''
+	}
+	assert message.contains('unresolved name `Widget`'), message
 }
 
 fn test_selfhost_struct_field_defaults_are_preserved() {

--- a/vlib/v3/gen/fastc/fn.v
+++ b/vlib/v3/gen/fastc/fn.v
@@ -497,7 +497,7 @@ fn (mut g Parser) skip_semicolons() {
 }
 
 fn (g &Parser) unsupported(feature string) IError {
-	return error('fastc parser does not support ${feature} at byte ${g.s.pos} in ${g.path}')
+	return error('fastc parser does not support ${feature} at byte ${g.s.pos + g.source_offset} in ${g.path}')
 }
 
 fn (mut g Parser) expect(expected token.Token) ! {
@@ -558,6 +558,7 @@ fn (mut g Parser) skip_import() ! {
 
 fn (mut g Parser) parse_function(enabled bool) ! {
 	g.locals = map[string]FastcLocal{}
+	g.temp_id = 0
 	g.next()
 	mut receiver_type := ''
 	mut receiver_key := ''

--- a/vlib/v3/gen/fastc/names.v
+++ b/vlib/v3/gen/fastc/names.v
@@ -29,6 +29,19 @@ fn fastc_declared_type_c_names(declared_types map[string]bool) map[string]string
 	return index
 }
 
+fn fastc_declared_type_key_by_name(declared_types map[string]bool) map[string]string {
+	mut index := map[string]string{}
+	for key in declared_types.keys() {
+		name := key.all_after_last('.')
+		if name in index {
+			index[name] = ''
+		} else {
+			index[name] = key
+		}
+	}
+	return index
+}
+
 fn fastc_function_key(module_name string, name string) string {
 	if module_name in ['', 'main'] {
 		return name

--- a/vlib/v3/gen/fastc/parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/fastc/parallel_notd_v3_no_parallel.v
@@ -247,18 +247,47 @@ fn fastc_source_generation_fragments(source_file FastcSourceFile, prefs &pref.Pr
 	mut scan := scanner.new_scanner(prefs, .normal)
 	scan.init(file, source_file.source)
 	mut cuts := [0]
-	mut depth := 0
+	mut brace_depth := 0
+	mut paren_depth := 0
+	mut bracket_depth := 0
+	mut pending_cut := false
 	mut next_target := source_file.source.len / part_count
 	mut tok := scan.scan()
 	for tok != .eof && cuts.len < part_count {
-		if tok == .lcbr {
-			depth++
-		} else if tok == .rcbr {
-			depth--
-			if depth == 0 && scan.offset >= next_target && !fastc_generation_fragment_is_followed_by_comptime_else(scan) {
-				cuts << scan.offset
-				next_target = source_file.source.len * cuts.len / part_count
+		match tok {
+			.lcbr {
+				brace_depth++
 			}
+			.rcbr {
+				brace_depth--
+				if brace_depth == 0 && paren_depth == 0 && bracket_depth == 0 && scan.offset >= next_target {
+					pending_cut = true
+				}
+			}
+			.lpar {
+				paren_depth++
+			}
+			.rpar {
+				paren_depth--
+			}
+			.attribute {
+				// The scanner consumes `@[` as one token.
+				bracket_depth++
+			}
+			.lsbr {
+				bracket_depth++
+			}
+			.rsbr {
+				bracket_depth--
+			}
+			.semicolon {
+				if pending_cut && brace_depth == 0 && paren_depth == 0 && bracket_depth == 0 && !fastc_generation_fragment_is_followed_by_comptime_else(scan) {
+					cuts << scan.offset
+					next_target = source_file.source.len * cuts.len / part_count
+					pending_cut = false
+				}
+			}
+			else {}
 		}
 		tok = scan.scan()
 	}

--- a/vlib/v3/gen/fastc/parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/fastc/parallel_notd_v3_no_parallel.v
@@ -224,6 +224,18 @@ fn fastc_generate_file_chunk(ctx &FastcFileGenContext, sources []FastcSourceFile
 
 const fastc_generation_fragment_size = 56 * 1024
 
+fn fastc_generation_fragment_is_followed_by_comptime_else(scan scanner.Scanner) bool {
+	mut lookahead := scan
+	mut tok := lookahead.scan()
+	for tok == .semicolon {
+		tok = lookahead.scan()
+	}
+	if tok == .dollar {
+		tok = lookahead.scan()
+	}
+	return tok == .key_else
+}
+
 fn fastc_source_generation_fragments(source_file FastcSourceFile, prefs &pref.Preferences) []FastcSourceFile {
 	if !prefs.building_v || !source_file.header.module_name.ends_with('fastc') || source_file.source.len <= fastc_generation_fragment_size {
 		return [source_file]
@@ -243,7 +255,7 @@ fn fastc_source_generation_fragments(source_file FastcSourceFile, prefs &pref.Pr
 			depth++
 		} else if tok == .rcbr {
 			depth--
-			if depth == 0 && scan.offset >= next_target {
+			if depth == 0 && scan.offset >= next_target && !fastc_generation_fragment_is_followed_by_comptime_else(scan) {
 				cuts << scan.offset
 				next_target = source_file.source.len * cuts.len / part_count
 			}

--- a/vlib/v3/gen/fastc/parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/fastc/parallel_notd_v3_no_parallel.v
@@ -2,6 +2,8 @@ module fastc
 
 import os
 import v3.pref
+import v3.scanner
+import v3.token
 
 struct FastcPendingReferences {
 mut:
@@ -220,6 +222,72 @@ fn fastc_generate_file_chunk(ctx &FastcFileGenContext, sources []FastcSourceFile
 	return outputs
 }
 
+const fastc_generation_fragment_size = 56 * 1024
+
+fn fastc_source_generation_fragments(source_file FastcSourceFile, prefs &pref.Preferences) []FastcSourceFile {
+	if !prefs.building_v || !source_file.header.module_name.ends_with('fastc') || source_file.source.len <= fastc_generation_fragment_size {
+		return [source_file]
+	}
+	part_count := (source_file.source.len + fastc_generation_fragment_size - 1) / fastc_generation_fragment_size
+	mut file_set := token.FileSet.new()
+	mut file := file_set.add_file(source_file.path, source_file.source.len)
+	file.index_lines_without_digest(source_file.source)
+	mut scan := scanner.new_scanner(prefs, .normal)
+	scan.init(file, source_file.source)
+	mut cuts := [0]
+	mut depth := 0
+	mut next_target := source_file.source.len / part_count
+	mut tok := scan.scan()
+	for tok != .eof && cuts.len < part_count {
+		if tok == .lcbr {
+			depth++
+		} else if tok == .rcbr {
+			depth--
+			if depth == 0 && scan.offset >= next_target {
+				cuts << scan.offset
+				next_target = source_file.source.len * cuts.len / part_count
+			}
+		}
+		tok = scan.scan()
+	}
+	if cuts.len == 1 {
+		return [source_file]
+	}
+	cuts << source_file.source.len
+	mut fragments := []FastcSourceFile{cap: cuts.len - 1}
+	mut position_offset := 0
+	mut position_lines := 0
+	mut position_column := 0
+	for i in 0 .. cuts.len - 1 {
+		start := cuts[i]
+		for position_offset < start {
+			if source_file.source[position_offset] == `\n` {
+				position_lines++
+				position_column = 0
+			} else {
+				position_column++
+			}
+			position_offset++
+		}
+		prefix := '\n'.repeat(position_lines) + ' '.repeat(position_column)
+		fragments << FastcSourceFile{
+			path: source_file.path
+			source: prefix + source_file.source[start..cuts[i + 1]]
+			source_offset: source_file.source_offset + start - prefix.len
+			header: source_file.header
+		}
+	}
+	return fragments
+}
+
+fn fastc_generation_fragments(sources []FastcSourceFile, prefs &pref.Preferences) []FastcSourceFile {
+	mut fragments := []FastcSourceFile{cap: sources.len + 8}
+	for source_file in sources {
+		fragments << fastc_source_generation_fragments(source_file, prefs)
+	}
+	return fragments
+}
+
 // fastc_generate_file_outputs runs per-file code generation, in parallel when
 // more than one job is available. Results are restored to file order, so the
 // emitted C is identical to a serial run.
@@ -232,15 +300,16 @@ fn fastc_generate_file_outputs(ctx &FastcFileGenContext, sources []FastcSourceFi
 		}
 		return outputs
 	}
-	job_indices := fastc_file_generation_job_indices(sources, jobs)
-	second_thread := spawn fastc_generate_file_chunk(ctx, sources, job_indices[1])
+	generation_sources := fastc_generation_fragments(sources, ctx.prefs)
+	job_indices := fastc_file_generation_job_indices(generation_sources, jobs)
+	second_thread := spawn fastc_generate_file_chunk(ctx, generation_sources, job_indices[1])
 	mut chunk_threads := [second_thread]
 	for chunk_idx in 2 .. jobs {
-		chunk_thread := spawn fastc_generate_file_chunk(ctx, sources, job_indices[chunk_idx])
+		chunk_thread := spawn fastc_generate_file_chunk(ctx, generation_sources, job_indices[chunk_idx])
 		chunk_threads << chunk_thread
 	}
-	mut outputs := []FastcFileGenOutput{len: sources.len}
-	first_outputs := fastc_generate_file_chunk(ctx, sources, job_indices[0])
+	mut outputs := []FastcFileGenOutput{len: generation_sources.len}
+	first_outputs := fastc_generate_file_chunk(ctx, generation_sources, job_indices[0])
 	for indexed_output in first_outputs {
 		outputs[indexed_output.index] = indexed_output.output
 	}

--- a/vlib/v3/gen/fastc/source.v
+++ b/vlib/v3/gen/fastc/source.v
@@ -577,20 +577,19 @@ fn fastc_scan_source_header(source string, path string, prefs &pref.Preferences)
 }
 
 fn fastc_source_declaration_flags(source string) (bool, bool) {
-	mut has_constants := false
-	mut has_global_declarations := false
-	for i := 0; i < source.len && (!has_constants || !has_global_declarations); i++ {
-		if i > 0 && fastc_identifier_byte(source[i - 1]) {
-			continue
+	return fastc_source_has_declaration(source, 'const'), fastc_source_has_declaration(source, '__global')
+}
+
+fn fastc_source_has_declaration(source string, keyword string) bool {
+	mut search_start := 0
+	for {
+		index := source.index_after(keyword, search_start) or { return false }
+		if (index == 0 || !fastc_identifier_byte(source[index - 1])) && (index + keyword.len == source.len || !fastc_identifier_byte(source[index + keyword.len])) {
+			return true
 		}
-		if !has_constants && source[i] == `c` && i + 5 <= source.len && source[i..i + 5] == 'const' && (i + 5 == source.len || !fastc_identifier_byte(source[i + 5])) {
-			has_constants = true
-		}
-		if !has_global_declarations && source[i] == `_` && i + 8 <= source.len && source[i..i + 8] == '__global' && (i + 8 == source.len || !fastc_identifier_byte(source[i + 8])) {
-			has_global_declarations = true
-		}
+		search_start = index + keyword.len
 	}
-	return has_constants, has_global_declarations
+	return false
 }
 
 fn fastc_identifier_byte(value u8) bool {

--- a/vlib/v3/gen/fastc/stmt.v
+++ b/vlib/v3/gen/fastc/stmt.v
@@ -5,7 +5,7 @@ import v3.pref
 import v3.token
 
 fn (mut g Parser) parse_block_body() !bool {
-	outer_locals := g.locals.clone()
+	mut outer_locals := g.locals.clone()
 	outer_statement_reachable := g.statement_reachable
 	deferred_line_start := g.deferred_lines.len
 	deferred_block_start := g.deferred_block_starts.len
@@ -36,7 +36,7 @@ fn (mut g Parser) parse_block_body() !bool {
 	g.write_deferred_blocks_from(deferred_block_start)
 	g.deferred_lines.trim(deferred_line_start)
 	g.deferred_block_starts.trim(deferred_block_start)
-	g.locals = outer_locals.clone()
+	g.locals = outer_locals.move()
 	g.statement_reachable = outer_statement_reachable
 	return terminates
 }

--- a/vlib/v3/gen/fastc/types.v
+++ b/vlib/v3/gen/fastc/types.v
@@ -3,8 +3,12 @@ module fastc
 import v3.token
 
 fn fastc_matching_rpar(tokens []FastcExpressionToken, open int) ?int {
+	return fastc_matching_rpar_before(tokens, open, tokens.len)
+}
+
+fn fastc_matching_rpar_before(tokens []FastcExpressionToken, open int, end int) ?int {
 	mut depth := 0
-	for i in open .. tokens.len {
+	for i in open .. end {
 		match tokens[i].tok {
 			.lpar {
 				depth++
@@ -22,14 +26,18 @@ fn fastc_matching_rpar(tokens []FastcExpressionToken, open int) ?int {
 }
 
 fn fastc_method_receiver_start(tokens []FastcExpressionToken, dot int) int {
-	if dot <= 0 || dot > tokens.len {
-		return 0
+	return fastc_method_receiver_start_after(tokens, dot, 0)
+}
+
+fn fastc_method_receiver_start_after(tokens []FastcExpressionToken, dot int, lower_bound int) int {
+	if dot <= lower_bound || dot > tokens.len {
+		return lower_bound
 	}
 	mut parens := 0
 	mut brackets := 0
 	mut braces := 0
 	mut start := dot - 1
-	for start >= 0 {
+	for start >= lower_bound {
 		tok := tokens[start].tok
 		if tok == .rpar {
 			parens++
@@ -54,22 +62,50 @@ fn fastc_method_receiver_start(tokens []FastcExpressionToken, dot int) int {
 				return start + 1
 			}
 			braces--
-		} else if parens == 0 && brackets == 0 && braces == 0 && tok in [.amp, .and, .mul]
-			&& start + 2 < dot && tokens[start + 1].tok == .name && tokens[start + 2].tok == .lpar
-			&& fastc_token_is_prefix_operator(tokens, start) {
+		} else if parens == 0 && brackets == 0 && braces == 0 && tok in [.amp, .and, .mul] && start + 2 < dot && tokens[start + 1].tok == .name && tokens[start + 2].tok == .lpar && fastc_token_is_prefix_operator(tokens, start) {
 			return start
-		} else if parens == 0 && brackets == 0 && braces == 0 && tok == .not && start > 0
-			&& tokens[start - 1].tok in [.rpar, .rsbr, .name, .number, .string] {
+		} else if parens == 0 && brackets == 0 && braces == 0 && tok == .not && start > 0 && tokens[start - 1].tok in [
+			.rpar,
+			.rsbr,
+			.name,
+			.number,
+			.string,
+		] {
 			// A postfix `!` (result propagation) follows a value and is part of the
 			// receiver (`f()!.m()`); keep scanning into the underlying call. A prefix `!`
 			// (negation) is not preceded by a value and falls to the stop below.
-		} else if parens == 0 && brackets == 0 && braces == 0 && (tok.is_assignment()
-			|| tok in [.comma, .semicolon, .colon, .ellipsis, .plus, .minus, .mul, .div, .mod, .amp, .pipe, .xor, .left_shift, .right_shift, .right_shift_unsigned, .eq, .ne, .gt, .lt, .ge, .le, .and, .logical_or, .not, .bit_not]) {
+		} else if parens == 0 && brackets == 0 && braces == 0 && (tok.is_assignment() || tok in [
+			.comma,
+			.semicolon,
+			.colon,
+			.ellipsis,
+			.plus,
+			.minus,
+			.mul,
+			.div,
+			.mod,
+			.amp,
+			.pipe,
+			.xor,
+			.left_shift,
+			.right_shift,
+			.right_shift_unsigned,
+			.eq,
+			.ne,
+			.gt,
+			.lt,
+			.ge,
+			.le,
+			.and,
+			.logical_or,
+			.not,
+			.bit_not,
+		]) {
 			return start + 1
 		}
 		start--
 	}
-	return 0
+	return lower_bound
 }
 
 fn fastc_call_arguments(tokens []FastcExpressionToken, open int, close int) ![][]FastcExpressionToken {
@@ -190,33 +226,29 @@ fn fastc_lowest_precedence_operator_index(tokens []FastcExpressionToken, start i
 
 fn (g &Parser) infer_boolean_binary_expression_type(tokens []FastcExpressionToken, start int, end int, operator_index int) !string {
 	operator := tokens[operator_index].tok
-	left_tokens := tokens[start..operator_index]
-	right_tokens := tokens[operator_index + 1..end]
-	mut left_type := fastc_normalize_inferred_type(g.infer_expression_type(left_tokens)!)
+	mut left_type := fastc_normalize_inferred_type(g.infer_expression_type_range(tokens, start, operator_index)!)
 	if operator in [.key_is, .not_is] {
-		right_type := g.type_from_expression_tokens(right_tokens) or {
+		right_type := g.type_from_expression_tokens(tokens[operator_index + 1..end]) or {
 			return g.unsupported('type test `${operator.str()}` with an undeclared target type')
 		}
-		if g.semantic_type_key(right_type) !in g.declared_types && !right_type.starts_with('Array_')
-			&& !right_type.starts_with('Map_') {
+		if g.semantic_type_key(right_type) !in g.declared_types && !right_type.starts_with('Array_') && !right_type.starts_with('Map_') {
 			// Composite variants (`x is []string` / `x is map[…]`) are not declared
 			// types but do get generated `__v_typeid_` tags, so allow them.
 			return g.unsupported('type test `${operator.str()}` with undeclared type `${right_type}`')
 		}
 		return 'bool'
 	}
-	mut right_type := fastc_normalize_inferred_type(g.infer_expression_type(right_tokens)!)
+	mut right_type := fastc_normalize_inferred_type(g.infer_expression_type_range(tokens, operator_index + 1, end)!)
 	if operator in [.and, .logical_or] {
 		return 'bool'
 	}
 	if operator in [.key_in, .not_in] {
-		array_end := if right_tokens.len > 0 && right_tokens.last().tok == .not {
-			right_tokens.len - 1
+		array_end := if operator_index + 1 < end && tokens[end - 1].tok == .not {
+			end - 1
 		} else {
-			right_tokens.len
+			end
 		}
-		if array_end >= 2 && right_tokens[0].tok == .lsbr
-			&& right_tokens[array_end - 1].tok == .rsbr {
+		if array_end - operator_index - 1 >= 2 && tokens[operator_index + 1].tok == .lsbr && tokens[array_end - 1].tok == .rsbr {
 			return 'bool'
 		}
 		if right_type.trim_right('*').starts_with('Map_') {
@@ -231,55 +263,56 @@ fn (g &Parser) infer_boolean_binary_expression_type(tokens []FastcExpressionToke
 		}
 		return 'bool'
 	}
-	if operator in [.eq, .ne]
-		&& ((fastc_is_pointer_type(left_type) && fastc_expression_is_zero(right_tokens))
-		|| (fastc_is_pointer_type(right_type) && fastc_expression_is_zero(left_tokens))) {
+	if operator in [.eq, .ne] && ((fastc_is_pointer_type(left_type) && fastc_expression_range_is_zero(tokens, operator_index + 1, end)) || (fastc_is_pointer_type(right_type) && fastc_expression_range_is_zero(tokens, start, operator_index))) {
 		return 'bool'
 	}
 	if operator in [.eq, .ne] {
-		if g.declared_kinds[g.semantic_type_key(left_type)] == .enum_ && right_type == ''
-			&& fastc_expression_is_enum_shorthand(right_tokens) {
+		if g.declared_kinds[g.semantic_type_key(left_type)] == .enum_ && right_type == '' && fastc_expression_range_is_enum_shorthand(tokens, operator_index + 1, end) {
 			right_type = left_type
-		} else if g.declared_kinds[g.semantic_type_key(right_type)] == .enum_ && left_type == ''
-			&& fastc_expression_is_enum_shorthand(left_tokens) {
+		} else if g.declared_kinds[g.semantic_type_key(right_type)] == .enum_ && left_type == '' && fastc_expression_range_is_enum_shorthand(tokens, start, operator_index) {
 			left_type = right_type
 		}
 		if !fastc_is_pointer_type(left_type) && !fastc_is_pointer_type(right_type) {
 			left_layout := g.underlying_alias_type(left_type).trim_right('*')
 			right_layout := g.underlying_alias_type(right_type).trim_right('*')
 			left_key := g.semantic_type_key(left_layout)
-			if left_layout == right_layout && left_layout !in ['Option', '_option', '_result']
-				&& left_key in g.declared_kinds && g.declared_kinds[left_key] == .struct_
-				&& !g.struct_equality_is_supported(left_type, []string{}) {
+			if left_layout == right_layout && left_layout !in ['Option', '_option', '_result'] && left_key in g.declared_kinds && g.declared_kinds[left_key] == .struct_ && !g.struct_equality_is_supported(left_type, []string{}) {
 				return g.unsupported('struct equality for `${left_type}` with unsupported fields')
 			}
 		}
 	}
-	if g.selfhost && operator in [.eq, .ne]
-		&& ((fastc_is_pointer_type(left_type) && right_type == '')
-		|| (fastc_is_pointer_type(right_type) && left_type == '')) {
+	if g.selfhost && operator in [.eq, .ne] && ((fastc_is_pointer_type(left_type) && right_type == '') || (fastc_is_pointer_type(right_type) && left_type == '')) {
 		return 'bool'
 	}
-	if g.selfhost && ((left_type == '' && fastc_expression_is_c_qualified_name(left_tokens))
-		|| (right_type == '' && fastc_expression_is_c_qualified_name(right_tokens))) {
+	if g.selfhost && ((left_type == '' && fastc_expression_range_is_c_qualified_name(tokens, start, operator_index)) || (right_type == '' && fastc_expression_range_is_c_qualified_name(tokens, operator_index + 1, end))) {
 		return 'bool'
 	}
 	return 'bool'
 }
 
+fn fastc_expression_range_is_zero(tokens []FastcExpressionToken, start int, end int) bool {
+	return end - start == 1 && tokens[start].tok == .number && tokens[start].lit.replace('_', '').trim_left('0') == ''
+}
+
+fn fastc_expression_range_is_c_qualified_name(tokens []FastcExpressionToken, start int, end int) bool {
+	return end - start == 3 && tokens[start].tok == .name && tokens[start].lit == 'C' && tokens[start + 1].tok == .dot && tokens[start + 2].tok == .name
+}
+
+fn fastc_expression_range_is_enum_shorthand(tokens []FastcExpressionToken, start int, end int) bool {
+	return end - start == 2 && tokens[start].tok == .dot && tokens[start + 1].tok == .name
+}
+
 // fastc_typeof_generic_field_type returns the type of `typeof[T]().idx` (int) or
 // `typeof[T]().name` (string), or none if the tokens are not that shape.
-fn fastc_typeof_generic_field_type(tokens []FastcExpressionToken) ?string {
-	if tokens.len < 8 || tokens[0].lit != 'typeof' || tokens[1].tok != .lsbr {
+fn fastc_typeof_generic_field_type(tokens []FastcExpressionToken, start int, end int) ?string {
+	if end - start < 8 || tokens[start].lit != 'typeof' || tokens[start + 1].tok != .lsbr {
 		return none
 	}
-	close_bracket := fastc_matching_delimiter(tokens, 1, .lsbr, .rsbr) or { return none }
-	if close_bracket + 4 != tokens.len - 1 || tokens[close_bracket + 1].tok != .lpar
-		|| tokens[close_bracket + 2].tok != .rpar || tokens[close_bracket + 3].tok != .dot
-		|| tokens[tokens.len - 1].tok != .name {
+	close_bracket := fastc_matching_delimiter_before(tokens, start + 1, end, .lsbr, .rsbr) or { return none }
+	if close_bracket + 4 != end - 1 || tokens[close_bracket + 1].tok != .lpar || tokens[close_bracket + 2].tok != .rpar || tokens[close_bracket + 3].tok != .dot || tokens[end - 1].tok != .name {
 		return none
 	}
-	return match tokens[tokens.len - 1].lit {
+	return match tokens[end - 1].lit {
 		'idx' { 'int' }
 		'name' { 'string' }
 		else { none }
@@ -287,14 +320,18 @@ fn fastc_typeof_generic_field_type(tokens []FastcExpressionToken) ?string {
 }
 
 fn (g &Parser) infer_expression_type(tokens []FastcExpressionToken) !string {
-	if tokens.len == 0 {
+	return g.infer_expression_type_range(tokens, 0, tokens.len)
+}
+
+fn (g &Parser) infer_expression_type_range(tokens []FastcExpressionToken, expression_start int, expression_end int) !string {
+	if expression_start >= expression_end {
 		return ''
 	}
-	mut start := 0
-	mut end := tokens.len
+	mut start := expression_start
+	mut end := expression_end
 	for end - start >= 2 && tokens[start].tok == .lpar {
-		wrapper_end := fastc_matching_rpar(tokens[start..end], 0) or { break }
-		if wrapper_end != end - start - 1 {
+		wrapper_end := fastc_matching_rpar_before(tokens, start, end) or { break }
+		if wrapper_end != end - 1 {
 			break
 		}
 		start++
@@ -303,25 +340,23 @@ fn (g &Parser) infer_expression_type(tokens []FastcExpressionToken) !string {
 	if start >= end {
 		return ''
 	}
-	if end - start == 1 && tokens[start].tok == .name && tokens[start].typ != ''
-		&& tokens[start].source != '' {
+	if end - start == 1 && tokens[start].tok == .name && tokens[start].typ != '' && tokens[start].source != '' {
 		// A synthetic token carrying its own rendered `source` and recorded `typ` (e.g. an
 		// or-unwrap `({ ... })` produced for `(expr or {…}).method()`): trust its recorded
 		// type rather than looking the name up as a local variable.
 		return tokens[start].typ
 	}
-	if end - start >= 4 && tokens[start].tok == .key_sizeof && tokens[start + 1].tok == .lpar
-		&& tokens[end - 1].tok == .rpar {
+	if end - start >= 4 && tokens[start].tok == .key_sizeof && tokens[start + 1].tok == .lpar && tokens[end - 1].tok == .rpar {
 		return 'int'
 	}
-	if reflection_type := fastc_typeof_generic_field_type(tokens[start..end]) {
+	if reflection_type := fastc_typeof_generic_field_type(tokens, start, end) {
 		return reflection_type
 	}
-	if c_field_type := g.infer_c_pointer_cast_member_type(tokens[start..end]) {
+	if c_field_type := g.infer_c_pointer_cast_member_type(tokens, start, end) {
 		return c_field_type
 	}
 	if tokens[start].tok == .not {
-		_ = g.infer_expression_type(tokens[start + 1..end])!
+		_ = g.infer_expression_type_range(tokens, start + 1, end)!
 		return 'bool'
 	}
 	if operator_index := fastc_lowest_precedence_operator_index(tokens, start, end) {
@@ -336,9 +371,7 @@ fn (g &Parser) infer_expression_type(tokens []FastcExpressionToken) !string {
 			.name {
 				if local := g.locals[item.lit] {
 					local.typ
-				} else if constant_type := g.constant_types[fastc_constant_key(g.module_name,
-					item.lit)]
-				{
+				} else if constant_type := g.constant_types[fastc_constant_key(g.module_name, item.lit)] {
 					constant_type
 				} else if constant_type := g.constant_types[fastc_constant_key('builtin', item.lit)] {
 					constant_type
@@ -386,9 +419,7 @@ fn (g &Parser) infer_expression_type(tokens []FastcExpressionToken) !string {
 	if end - start == 2 && tokens[start].tok == .dot && tokens[start + 1].typ != '' {
 		return tokens[start + 1].typ
 	}
-	if end - start == 5 && tokens[start].tok == .name && tokens[start + 1].tok == .dot
-		&& tokens[start + 2].tok == .name && tokens[start + 3].tok == .dot
-		&& tokens[start + 4].tok == .name {
+	if end - start == 5 && tokens[start].tok == .name && tokens[start + 1].tok == .dot && tokens[start + 2].tok == .name && tokens[start + 3].tok == .dot && tokens[start + 4].tok == .name {
 		if imported_module := g.imports[tokens[start].lit] {
 			type_key := fastc_type_key(imported_module, tokens[start + 2].lit)
 			if enum_type_key := g.underlying_enum_type_key(type_key) {
@@ -396,33 +427,27 @@ fn (g &Parser) infer_expression_type(tokens []FastcExpressionToken) !string {
 			}
 		}
 	}
-	if end - start >= 5 && tokens[start].tok == .lsbr && tokens[start + 1].tok == .rsbr
-		&& tokens[start + 2].tok == .name && tokens[start + 3].tok == .lpar
-		&& tokens[end - 1].tok == .rpar {
+	if end - start >= 5 && tokens[start].tok == .lsbr && tokens[start + 1].tok == .rsbr && tokens[start + 2].tok == .name && tokens[start + 3].tok == .lpar && tokens[end - 1].tok == .rpar {
 		mut element_type := tokens[start + 2].lit
 		if primitive := fastc_primitive_c_type(element_type) {
 			element_type = primitive
 		}
 		return fastc_array_c_type(element_type)
 	}
-	if end - start == 3 && tokens[start].tok == .name && tokens[start + 1].tok == .dot
-		&& tokens[start + 2].tok == .name {
+	if end - start == 3 && tokens[start].tok == .name && tokens[start + 1].tok == .dot && tokens[start + 2].tok == .name {
 		if imported_module := g.imports[tokens[start].lit] {
 			type_key := fastc_type_key(imported_module, tokens[start + 2].lit)
 			if type_key in g.declared_types {
 				return fastc_c_declared_type_name(type_key)
 			}
 		}
-		if type_key := g.resolve_declared_type_key(tokens[start].lit)
-		{
+		if type_key := g.resolve_declared_type_key(tokens[start].lit) {
 			if enum_type_key := g.underlying_enum_type_key(type_key) {
 				return fastc_c_declared_type_name(enum_type_key)
 			}
 		}
 		if imported_module := g.imports[tokens[start].lit] {
-			if constant_type := g.constant_types[fastc_constant_key(imported_module, tokens[start +
-				2].lit)]
-			{
+			if constant_type := g.constant_types[fastc_constant_key(imported_module, tokens[start + 2].lit)] {
 				return constant_type
 			}
 			if fastc_constant_key(imported_module, tokens[start + 2].lit) in g.constants {
@@ -459,21 +484,19 @@ fn (g &Parser) infer_expression_type(tokens []FastcExpressionToken) !string {
 		return fastc_array_c_type(element_type)
 	}
 	if start + 1 < end && tokens[start].tok == .name && tokens[start + 1].tok == .lcbr {
-		if close := fastc_matching_delimiter(tokens[start..end], 1, .lcbr, .rcbr) {
-			if close == end - start - 1 {
-				if type_key := g.resolve_declared_type_key(tokens[start].lit)
-				{
+		if close := fastc_matching_delimiter_before(tokens, start + 1, end, .lcbr, .rcbr) {
+			if close == end - 1 {
+				if type_key := g.resolve_declared_type_key(tokens[start].lit) {
 					return fastc_c_declared_type_name(type_key)
 				}
 			}
 		}
 	}
-	if start + 3 < end && tokens[start].tok == .name && tokens[start + 1].tok == .dot
-		&& tokens[start + 2].tok == .name && tokens[start + 3].tok == .lcbr {
+	if start + 3 < end && tokens[start].tok == .name && tokens[start + 1].tok == .dot && tokens[start + 2].tok == .name && tokens[start + 3].tok == .lcbr {
 		// A module-qualified struct literal `mod.Type{...}`.
 		if imported_module := g.imports[tokens[start].lit] {
-			if close := fastc_matching_delimiter(tokens[start..end], 3, .lcbr, .rcbr) {
-				if close == end - start - 1 {
+			if close := fastc_matching_delimiter_before(tokens, start + 3, end, .lcbr, .rcbr) {
+				if close == end - 1 {
 					type_key := fastc_type_key(imported_module, tokens[start + 2].lit)
 					if type_key in g.declared_types {
 						return fastc_c_declared_type_name(type_key)
@@ -484,16 +507,13 @@ fn (g &Parser) infer_expression_type(tokens []FastcExpressionToken) !string {
 	}
 	mut call_name_index := start
 	mut call_open_index := start + 1
-	if start + 3 < end && tokens[start].tok == .name && tokens[start + 1].tok == .dot
-		&& tokens[start + 2].tok == .name
-		&& (tokens[start].lit in g.imports || tokens[start].lit == 'C') {
+	if start + 3 < end && tokens[start].tok == .name && tokens[start + 1].tok == .dot && tokens[start + 2].tok == .name && (tokens[start].lit in g.imports || tokens[start].lit == 'C') {
 		call_name_index = start + 2
 		call_open_index = start + 3
 	}
-	if call_open_index < end && tokens[call_name_index].tok in [.name, .key_select]
-		&& tokens[call_open_index].tok == .lpar {
-		if close := fastc_matching_rpar(tokens[start..end], call_open_index - start) {
-			if close == end - start - 1 {
+	if call_open_index < end && tokens[call_name_index].tok in [.name, .key_select] && tokens[call_open_index].tok == .lpar {
+		if close := fastc_matching_rpar_before(tokens, call_open_index, end) {
+			if close == end - 1 {
 				name := tokens[call_name_index].lit
 				function_key := g.function_key_for_call(tokens, call_name_index)
 				signature := if function_key in g.functions {
@@ -514,8 +534,7 @@ fn (g &Parser) infer_expression_type(tokens []FastcExpressionToken) !string {
 					if primitive := fastc_primitive_c_type(name) {
 						return primitive
 					}
-					if type_key := g.resolve_declared_type_key(name)
-					{
+					if type_key := g.resolve_declared_type_key(name) {
 						return fastc_c_declared_type_name(type_key)
 					}
 				}
@@ -542,12 +561,12 @@ fn (g &Parser) infer_expression_type(tokens []FastcExpressionToken) !string {
 		if tokens[i].tok != .name || tokens[i - 1].tok != .dot || tokens[i + 1].tok != .lpar {
 			continue
 		}
-		close := fastc_matching_rpar(tokens[start..end], i + 1 - start) or { continue }
-		if close != end - start - 1 {
+		close := fastc_matching_rpar_before(tokens, i + 1, end) or { continue }
+		if close != end - 1 {
 			continue
 		}
-		receiver_start := fastc_method_receiver_start(tokens, i - 1)
-		receiver_type := g.infer_expression_type(tokens[receiver_start..i - 1])!
+		receiver_start := fastc_method_receiver_start_after(tokens, i - 1, start)
+		receiver_type := g.infer_expression_type_range(tokens, receiver_start, i - 1)!
 		if receiver_type == '' {
 			continue
 		}
@@ -577,23 +596,23 @@ fn (g &Parser) infer_expression_type(tokens []FastcExpressionToken) !string {
 		}
 	}
 	if end - start >= 3 && tokens[end - 2].tok == .dot && tokens[end - 1].tok == .name {
-		receiver_start := fastc_method_receiver_start(tokens, end - 2)
+		receiver_start := fastc_method_receiver_start_after(tokens, end - 2, start)
 		if receiver_start == start {
-			receiver_type := g.infer_expression_type(tokens[start..end - 2])!
+			receiver_type := g.infer_expression_type_range(tokens, start, end - 2)!
 			if field := g.struct_field_metadata(receiver_type, tokens[end - 1].lit) {
 				return field.typ
 			}
 		}
 	}
 	if tokens[start].tok in [.plus, .minus] {
-		operand_type := g.infer_expression_type(tokens[start + 1..end])!
+		operand_type := g.infer_expression_type_range(tokens, start + 1, end)!
 		if tokens[start].tok == .minus && operand_type == 'integer literal' {
 			return 'negative integer literal'
 		}
 		return operand_type
 	}
 	if tokens[start].tok in [.amp, .and] {
-		operand_type := g.infer_expression_type(tokens[start + 1..end])!
+		operand_type := g.infer_expression_type_range(tokens, start + 1, end)!
 		mut pointer_count := 1
 		if tokens[start].tok == .and {
 			pointer_count = 2
@@ -605,11 +624,11 @@ fn (g &Parser) infer_expression_type(tokens []FastcExpressionToken) !string {
 		}
 	}
 	if tokens[start].tok == .mul {
-		operand_type := g.infer_expression_type(tokens[start + 1..end])!
+		operand_type := g.infer_expression_type_range(tokens, start + 1, end)!
 		return operand_type.trim_right('*')
 	}
 	if tokens[start].tok == .bit_not {
-		operand_type := g.infer_expression_type(tokens[start + 1..end])!
+		operand_type := g.infer_expression_type_range(tokens, start + 1, end)!
 		return operand_type
 	}
 	if g.selfhost && tokens[end - 1].tok == .not {
@@ -617,7 +636,7 @@ fn (g &Parser) infer_expression_type(tokens []FastcExpressionToken) !string {
 		return if value_type == 'void' { '' } else { value_type }
 	}
 	if tokens[end - 1].tok in [.inc, .dec] {
-		operand_type := g.infer_expression_type(tokens[start..end - 1])!
+		operand_type := g.infer_expression_type_range(tokens, start, end - 1)!
 		if g.selfhost && operand_type == '' {
 			return 'int'
 		}
@@ -638,7 +657,7 @@ fn (g &Parser) infer_expression_type(tokens []FastcExpressionToken) !string {
 			}
 		}
 		if open_index > start {
-			base_type := g.infer_expression_type(tokens[start..open_index])!
+			base_type := g.infer_expression_type_range(tokens, start, open_index)!
 			if fastc_expression_tokens_contain(tokens[open_index + 1..end - 1], .dotdot) {
 				// Slicing a fixed array yields a dynamic array of its element type.
 				if base_type.trim_right('*').starts_with('FixedArray_') {
@@ -663,7 +682,7 @@ fn (g &Parser) infer_expression_type(tokens []FastcExpressionToken) !string {
 			}
 		}
 	}
-	if member_type := g.infer_member_access_type(tokens[start..end]) {
+	if member_type := g.infer_member_access_type(tokens, start, end) {
 		return member_type
 	}
 	mut depth := 0
@@ -677,15 +696,15 @@ fn (g &Parser) infer_expression_type(tokens []FastcExpressionToken) !string {
 			continue
 		}
 		if tokens[i].tok.is_assignment() {
-			return g.infer_expression_type(tokens[start..i])!
+			return g.infer_expression_type_range(tokens, start, i)!
 		}
 		if tokens[i].tok in [.left_shift, .right_shift, .right_shift_unsigned] && i > start {
-			mut left_type := g.infer_expression_type(tokens[start..i])!
-			mut right_type := g.infer_expression_type(tokens[i + 1..end])!
-			if left_element := g.indexed_array_operand_type(tokens[start..i], left_type) {
+			mut left_type := g.infer_expression_type_range(tokens, start, i)!
+			mut right_type := g.infer_expression_type_range(tokens, i + 1, end)!
+			if left_element := g.indexed_array_operand_type(tokens, start, i, left_type) {
 				left_type = left_element
 			}
-			if right_element := g.indexed_array_operand_type(tokens[i + 1..end], right_type) {
+			if right_element := g.indexed_array_operand_type(tokens, i + 1, end, right_type) {
 				right_type = right_element
 			}
 			if g.selfhost && tokens[i].tok == .left_shift && g.array_element_type(left_type) != none {
@@ -703,43 +722,33 @@ fn (g &Parser) infer_expression_type(tokens []FastcExpressionToken) !string {
 			}
 		}
 		if tokens[i].tok in [.plus, .minus, .mul, .div, .mod, .amp, .pipe, .xor] && i > start {
-			left_tokens := tokens[start..i]
-			right_tokens := tokens[i + 1..end]
-			mut left_type := g.infer_expression_type(left_tokens)!
-			mut right_type := g.infer_expression_type(right_tokens)!
-			if left_element := g.indexed_array_operand_type(tokens[start..i], left_type) {
+			mut left_type := g.infer_expression_type_range(tokens, start, i)!
+			mut right_type := g.infer_expression_type_range(tokens, i + 1, end)!
+			if left_element := g.indexed_array_operand_type(tokens, start, i, left_type) {
 				left_type = left_element
 			}
-			if right_element := g.indexed_array_operand_type(tokens[i + 1..end], right_type) {
+			if right_element := g.indexed_array_operand_type(tokens, i + 1, end, right_type) {
 				right_type = right_element
 			}
-			if tokens[i].tok == .plus
-				&& g.underlying_alias_type(left_type).trim_right('*') == 'string'
-				&& g.underlying_alias_type(right_type).trim_right('*') == 'string' {
+			if tokens[i].tok == .plus && g.underlying_alias_type(left_type).trim_right('*') == 'string' && g.underlying_alias_type(right_type).trim_right('*') == 'string' {
 				return 'string'
 			}
-			if g.selfhost && tokens[i].tok == .plus && ((left_type == 'string' && right_type == '')
-				|| (right_type == 'string' && left_type == '')) {
+			if g.selfhost && tokens[i].tok == .plus && ((left_type == 'string' && right_type == '') || (right_type == 'string' && left_type == '')) {
 				return 'string'
 			}
-			if g.selfhost && tokens[i].tok in [.plus, .minus] && fastc_is_pointer_type(left_type)
-				&& fastc_is_integer_expression_type(right_type) {
+			if g.selfhost && tokens[i].tok in [.plus, .minus] && fastc_is_pointer_type(left_type) && fastc_is_integer_expression_type(right_type) {
 				return left_type
 			}
-			if g.selfhost && tokens[i].tok in [.amp, .pipe, .xor] && left_type == right_type
-				&& g.declared_kinds[g.semantic_type_key(left_type)] == .enum_ {
+			if g.selfhost && tokens[i].tok in [.amp, .pipe, .xor] && left_type == right_type && g.declared_kinds[g.semantic_type_key(left_type)] == .enum_ {
 				return left_type
 			}
-			if g.selfhost && tokens[i].tok in [.amp, .pipe, .xor]
-				&& g.declared_kinds[g.semantic_type_key(left_type)] == .enum_ && right_type == '' {
+			if g.selfhost && tokens[i].tok in [.amp, .pipe, .xor] && g.declared_kinds[g.semantic_type_key(left_type)] == .enum_ && right_type == '' {
 				return left_type
 			}
-			if g.selfhost && tokens[i].tok in [.amp, .pipe, .xor]
-				&& g.declared_kinds[g.semantic_type_key(right_type)] == .enum_ && left_type == '' {
+			if g.selfhost && tokens[i].tok in [.amp, .pipe, .xor] && g.declared_kinds[g.semantic_type_key(right_type)] == .enum_ && left_type == '' {
 				return right_type
 			}
-			if g.selfhost && fastc_is_integer_expression_type(left_type)
-				&& fastc_is_integer_expression_type(right_type) {
+			if g.selfhost && fastc_is_integer_expression_type(left_type) && fastc_is_integer_expression_type(right_type) {
 				return if left_type == 'integer literal' { right_type } else { left_type }
 			}
 			if g.selfhost && left_type == '' && fastc_is_numeric_expression_type(right_type) {
@@ -754,16 +763,13 @@ fn (g &Parser) infer_expression_type(tokens []FastcExpressionToken) !string {
 			if g.selfhost && left_type == 'voidptr' && fastc_is_numeric_expression_type(right_type) {
 				return right_type
 			}
-			if g.selfhost && fastc_is_numeric_expression_type(left_type)
-				&& g.declared_kinds[g.semantic_type_key(right_type)] == .alias_ {
+			if g.selfhost && fastc_is_numeric_expression_type(left_type) && g.declared_kinds[g.semantic_type_key(right_type)] == .alias_ {
 				return left_type
 			}
-			if g.selfhost && fastc_is_numeric_expression_type(right_type)
-				&& g.declared_kinds[g.semantic_type_key(left_type)] == .alias_ {
+			if g.selfhost && fastc_is_numeric_expression_type(right_type) && g.declared_kinds[g.semantic_type_key(left_type)] == .alias_ {
 				return right_type
 			}
-			if g.selfhost && left_type == right_type
-				&& g.declared_kinds[g.semantic_type_key(left_type)] == .alias_ {
+			if g.selfhost && left_type == right_type && g.declared_kinds[g.semantic_type_key(left_type)] == .alias_ {
 				return left_type
 			}
 			if g.selfhost && left_type == '' && right_type == '' {
@@ -785,18 +791,15 @@ fn (g &Parser) infer_expression_type(tokens []FastcExpressionToken) !string {
 	return ''
 }
 
-fn (g &Parser) infer_c_pointer_cast_member_type(tokens []FastcExpressionToken) ?string {
-	if tokens.len < 9 || tokens[0].tok !in [.amp, .and] || tokens[1].tok != .name
-		|| tokens[1].lit != 'C' || tokens[2].tok != .dot || tokens[3].tok != .name
-		|| tokens[4].tok != .lpar {
+fn (g &Parser) infer_c_pointer_cast_member_type(tokens []FastcExpressionToken, start int, end int) ?string {
+	if end - start < 9 || tokens[start].tok !in [.amp, .and] || tokens[start + 1].tok != .name || tokens[start + 1].lit != 'C' || tokens[start + 2].tok != .dot || tokens[start + 3].tok != .name || tokens[start + 4].tok != .lpar {
 		return none
 	}
-	close := fastc_matching_rpar(tokens, 4) or { return none }
-	if close + 2 >= tokens.len || tokens[close + 1].tok != .dot || tokens[close + 2].tok != .name
-		|| close + 3 != tokens.len {
+	close := fastc_matching_rpar_before(tokens, start + 4, end) or { return none }
+	if close + 2 >= end || tokens[close + 1].tok != .dot || tokens[close + 2].tok != .name || close + 3 != end {
 		return none
 	}
-	c_name := tokens[3].lit
+	c_name := tokens[start + 3].lit
 	c_type := if '#Cstruct#${c_name}' in g.declared_types { 'struct ${c_name}' } else { c_name }
 	field_type := g.struct_member_type(c_type + '*', tokens[close + 2].lit)
 	if field_type == '' {
@@ -805,38 +808,47 @@ fn (g &Parser) infer_c_pointer_cast_member_type(tokens []FastcExpressionToken) ?
 	return field_type
 }
 
-fn (g &Parser) indexed_array_operand_type(tokens []FastcExpressionToken, inferred_type string) ?string {
-	if tokens.len < 3 || !fastc_expression_tokens_contain(tokens, .lsbr)
-		|| tokens.last().tok != .rsbr {
+fn (g &Parser) indexed_array_operand_type(tokens []FastcExpressionToken, start int, end int, inferred_type string) ?string {
+	if end - start < 3 || !fastc_expression_tokens_contain_range(tokens, start, end, .lsbr) || tokens[end - 1].tok != .rsbr {
 		return none
 	}
 	return g.array_element_type(inferred_type)
 }
 
-fn (g &Parser) infer_member_access_type(tokens []FastcExpressionToken) ?string {
-	if tokens.len < 3 || tokens[0].tok != .name {
+fn fastc_expression_tokens_contain_range(tokens []FastcExpressionToken, start int, end int, wanted token.Token) bool {
+	for i in start .. end {
+		if tokens[i].tok == wanted {
+			return true
+		}
+	}
+	return false
+}
+
+fn (g &Parser) infer_member_access_type(tokens []FastcExpressionToken, start int, end int) ?string {
+	if end - start < 3 || tokens[start].tok != .name {
 		return none
 	}
 	mut current_type := ''
-	if local := g.locals[tokens[0].lit] {
+	if local := g.locals[tokens[start].lit] {
 		current_type = local.typ
-	} else if global_type := g.global_types[fastc_global_key(g.module_name, tokens[0].lit)] {
+	} else if global_type := g.global_types[fastc_global_key(g.module_name, tokens[start].lit)] {
 		current_type = global_type
-	} else if constant_type := g.constant_types[fastc_constant_key(g.module_name, tokens[0].lit)] {
+	} else if constant_type := g.constant_types[fastc_constant_key(g.module_name, tokens[start].lit)] {
 		current_type = constant_type
-	} else if constant_type := g.constant_types[fastc_constant_key('builtin', tokens[0].lit)] {
+	} else if constant_type := g.constant_types[fastc_constant_key('builtin', tokens[start].lit)] {
 		current_type = constant_type
 	} else {
 		return none
 	}
-	mut member_path := tokens[0].lit
-	mut index := 1
-	for index < tokens.len {
+	mut member_path := tokens[start].lit
+	mut index := start + 1
+	for index < end {
 		if tokens[index].tok == .lsbr {
-			close := fastc_matching_delimiter(tokens, index, .lsbr, .rsbr) or { return none }
-			if fastc_expression_tokens_contain(tokens[index + 1..close], .dotdot) {
-				if current_type.trim_right('*') != 'string'
-					&& g.array_element_type(current_type) == none {
+			close := fastc_matching_delimiter_before(tokens, index, end, .lsbr, .rsbr) or {
+				return none
+			}
+			if fastc_expression_tokens_contain_range(tokens, index + 1, close, .dotdot) {
+				if current_type.trim_right('*') != 'string' && g.array_element_type(current_type) == none {
 					return none
 				}
 				// A fixed-array slice becomes a dynamic array of its element type.
@@ -860,7 +872,7 @@ fn (g &Parser) infer_member_access_type(tokens []FastcExpressionToken) ?string {
 			index = close + 1
 			continue
 		}
-		if index + 1 >= tokens.len || tokens[index].tok != .dot || tokens[index + 1].tok != .name {
+		if index + 1 >= end || tokens[index].tok != .dot || tokens[index + 1].tok != .name {
 			return none
 		}
 		field_name := tokens[index + 1].lit
@@ -874,15 +886,19 @@ fn (g &Parser) infer_member_access_type(tokens []FastcExpressionToken) ?string {
 		}
 		index += 2
 	}
-	if index != tokens.len {
+	if index != end {
 		return none
 	}
 	return current_type
 }
 
 fn fastc_matching_delimiter(tokens []FastcExpressionToken, open_index int, open token.Token, close token.Token) ?int {
+	return fastc_matching_delimiter_before(tokens, open_index, tokens.len, open, close)
+}
+
+fn fastc_matching_delimiter_before(tokens []FastcExpressionToken, open_index int, end int, open token.Token, close token.Token) ?int {
 	mut depth := 0
-	for i in open_index .. tokens.len {
+	for i in open_index .. end {
 		if tokens[i].tok == open {
 			depth++
 		} else if tokens[i].tok == close {
@@ -927,8 +943,7 @@ fn (g &Parser) underlying_alias_type(c_type string) string {
 
 fn fastc_number_expression_type(literal string) string {
 	clean := literal.replace('_', '')
-	if clean.contains('.') || (!(clean.starts_with('0x') || clean.starts_with('0X'))
-		&& clean.contains_any('eE')) {
+	if clean.contains('.') || (!(clean.starts_with('0x') || clean.starts_with('0X')) && clean.contains_any('eE')) {
 		return 'float literal'
 	}
 	if clean.starts_with('-') {
@@ -946,8 +961,7 @@ fn fastc_integer_literal_value(tokens []FastcExpressionToken) ?i64 {
 	} else if tokens.len != 1 {
 		return none
 	}
-	if tokens[number_index].tok != .number
-		|| fastc_number_expression_type(tokens[number_index].lit) != 'integer literal' {
+	if tokens[number_index].tok != .number || fastc_number_expression_type(tokens[number_index].lit) != 'integer literal' {
 		return none
 	}
 	mut value := tokens[number_index].lit.replace('_', '').i64()
@@ -973,8 +987,7 @@ fn fastc_common_arithmetic_type(left string, right string) string {
 	if fastc_is_integer_literal_expression_type(right) && fastc_is_integer_type(left) {
 		return left
 	}
-	if fastc_is_integer_literal_expression_type(left)
-		&& fastc_is_integer_literal_expression_type(right) {
+	if fastc_is_integer_literal_expression_type(left) && fastc_is_integer_literal_expression_type(right) {
 		return if left == 'negative integer literal' || right == 'negative integer literal' {
 			'negative integer literal'
 		} else {
@@ -991,8 +1004,7 @@ fn fastc_common_arithmetic_type(left string, right string) string {
 }
 
 fn fastc_is_numeric_expression_type(typ string) bool {
-	return fastc_is_integer_literal_expression_type(typ) || typ in ['float literal', 'f32', 'f64']
-		|| fastc_is_integer_type(typ)
+	return fastc_is_integer_literal_expression_type(typ) || typ in ['float literal', 'f32', 'f64'] || fastc_is_integer_type(typ)
 }
 
 fn fastc_is_integer_expression_type(typ string) bool {
@@ -1023,10 +1035,7 @@ fn fastc_types_share_lowering_representation(actual string, expected string) boo
 }
 
 fn fastc_selfhost_types_share_lowering_representation(actual string, expected string) bool {
-	if (actual == 'byteptr' && expected == 'u8*')
-		|| (expected == 'byteptr' && actual == 'u8*')
-		|| (actual == 'charptr' && expected == 'char*')
-		|| (expected == 'charptr' && actual == 'char*') {
+	if (actual == 'byteptr' && expected == 'u8*') || (expected == 'byteptr' && actual == 'u8*') || (actual == 'charptr' && expected == 'char*') || (expected == 'charptr' && actual == 'char*') {
 		return true
 	}
 	if actual == expected + '*' || expected == actual + '*' {
@@ -1034,10 +1043,7 @@ fn fastc_selfhost_types_share_lowering_representation(actual string, expected st
 	}
 	actual_base := actual.trim_right('*')
 	expected_base := expected.trim_right('*')
-	if (actual_base == 'array' && expected_base.starts_with('Array_'))
-		|| (expected_base == 'array' && actual_base.starts_with('Array_'))
-		|| (actual_base == 'map' && expected_base.starts_with('Map_'))
-		|| (expected_base == 'map' && actual_base.starts_with('Map_')) {
+	if (actual_base == 'array' && expected_base.starts_with('Array_')) || (expected_base == 'array' && actual_base.starts_with('Array_')) || (actual_base == 'map' && expected_base.starts_with('Map_')) || (expected_base == 'map' && actual_base.starts_with('Map_')) {
 		return true
 	}
 	if actual == 'negative integer literal' && fastc_is_unsigned_integer_type(expected) {
@@ -1059,12 +1065,10 @@ fn (g &Parser) selfhost_types_share_lowering_representation(actual string, expec
 	if fastc_selfhost_types_share_lowering_representation(actual, expected) {
 		return true
 	}
-	if fastc_is_numeric_expression_type(actual)
-		&& g.declared_kinds[g.semantic_type_key(expected)] == .alias_ {
+	if fastc_is_numeric_expression_type(actual) && g.declared_kinds[g.semantic_type_key(expected)] == .alias_ {
 		return true
 	}
-	if fastc_is_numeric_expression_type(expected)
-		&& g.declared_kinds[g.semantic_type_key(actual)] == .alias_ {
+	if fastc_is_numeric_expression_type(expected) && g.declared_kinds[g.semantic_type_key(actual)] == .alias_ {
 		return true
 	}
 	return false
@@ -1150,9 +1154,7 @@ fn fastc_clean_nondecimal_literal_is_type_sensitive(clean string) bool {
 		if digits_len > 8 {
 			return true
 		}
-		return digits_len == 8 && ((clean[first_digit] >= `8` && clean[first_digit] <= `9`)
-			|| (clean[first_digit] >= `a` && clean[first_digit] <= `f`)
-			|| (clean[first_digit] >= `A` && clean[first_digit] <= `F`))
+		return digits_len == 8 && ((clean[first_digit] >= `8` && clean[first_digit] <= `9`) || (clean[first_digit] >= `a` && clean[first_digit] <= `f`) || (clean[first_digit] >= `A` && clean[first_digit] <= `F`))
 	}
 	if clean[1] in [`b`, `B`] {
 		return digits_len >= 32
@@ -1236,8 +1238,7 @@ fn fastc_c_selfhost_number(literal string) string {
 			''
 		}}'
 	}
-	if fastc_clean_decimal_literal_is_type_sensitive(clean)
-		|| fastc_clean_nondecimal_literal_is_type_sensitive(clean) {
+	if fastc_clean_decimal_literal_is_type_sensitive(clean) || fastc_clean_nondecimal_literal_is_type_sensitive(clean) {
 		return clean + 'ULL'
 	}
 	if clean.len < 2 || clean[0] != `0` || !clean[1].is_digit() || clean.contains_any('.eE') {


### PR DESCRIPTION
## Summary

- split oversized FastC self-host sources at top-level boundaries so per-file generation uses available workers more evenly while preserving source positions and serial output order
- replace recursive expression-token slice cloning with safe range-based inference, pre-index declared type names, reuse saved local maps, and skip self-host-only validation work that has already been checked
- accelerate source declaration probes and fragment position tracking with incremental scans
- add a regression comparing fragmented parallel generation with serial generated C

## Performance

The benchmark compiler was built with:

`./v -prod -gc none -d fastc_selfhost -o /tmp/v8_fastc_incremental_prod vlib/v3/v3.v`

Five alternating baseline/optimized rounds, each using `FASTC_BENCH_REPEAT=50`:

| | Before | After |
|---|---:|---:|
| Generation | 40.23 ms | 35.81 ms |
| Throughput | 1,625,895 LOC/s | 1,826,822 LOC/s |

That final run is **+12.36% LOC/s** and **-10.99% generation time**. Repeated runs under different thermal conditions ranged around 9-12% faster.

## Validation

- `./v -g -keepc -o ./vnew cmd/v`
- `./vnew -silent vlib/v/compiler_errors_test.v` — 1,619 passed, 1 skipped
- `./vnew -no-memory-limit -run-only test_fastc_fragmented_generation_matches_serial_output vlib/v3/gen/fastc/fastc_test.v`
- generated C from default parallel generation and `V3_FASTC_NO_PARALLEL=1` compares byte-for-byte identical
- five consecutive FastC self-host generations each compiled and ran `examples/hello_world.v`
- `git diff --check`