### PR TITLE
v3: speed up FastC self-host generation by 12%

### DIFF
--- a/vlib/v3/gen/fastc/array.v
+++ b/vlib/v3/gen/fastc/array.v
@@ -385,6 +385,40 @@ fn (g &Parser) render_leading_member_chain_promotion(tokens []FastcExpressionTok
 }
 
 fn (g &Parser) render_raw_expression_tokens(tokens []FastcExpressionToken) ?string {
+	if tokens.len == 1 {
+		item := tokens[0]
+		if item.source != '' {
+			return item.source
+		}
+		return match item.tok {
+			.name { g.resolved_expression_name(item.lit, .unknown) }
+			.number {
+				if g.selfhost {
+					fastc_c_selfhost_number(item.lit)
+				} else {
+					fastc_c_number(item.lit) or { return none }
+				}
+			}
+			.string {
+				literal := fastc_c_string(item.lit) or { return none }
+				if g.selfhost { '_S(${literal})' } else { literal }
+			}
+			.char {
+				if item.lit.starts_with('c:') {
+					fastc_c_string("'" + item.lit['c:'.len..] + "'") or { return none }
+				} else {
+					fastc_c_rune(item.lit) or { return none }
+				}
+			}
+			.key_true { '((bool)true)' }
+			.key_false { '((bool)false)' }
+			.key_nil { 'NULL' }
+			.key_none { '(Option){.state=2}' }
+			else {
+				if item.lit == '' { item.tok.str() } else { item.lit }
+			}
+		}
+	}
 	mut result := strings.new_builder(32)
 	mut cast_closes := []int{}
 	mut cast_open := -1

--- a/vlib/v3/gen/fastc/declaration_filter_test.v
+++ b/vlib/v3/gen/fastc/declaration_filter_test.v
@@ -107,8 +107,17 @@ fn test_partitioned_c_directives_match_materialized_hoisting() {
 	] {
 		hoisted := fastc_hoist_c_directives(source)
 		partitioned := fastc_partition_c_directives(source)
+		event_partitioned := fastc_partition_c_directive_lines(source, fastc_scan_c_directive_lines(source))
+		assert event_partitioned.final_kind == partitioned.final_kind
+		mut event_directives := strings.new_builder(256)
+		fastc_write_c_source_ranges(mut event_directives, event_partitioned.source, event_partitioned.directive_ranges)
+		mut event_conditional_code := strings.new_builder(256)
+		fastc_write_c_source_ranges(mut event_conditional_code, event_partitioned.source, event_partitioned.conditional_ranges)
+		mut event_body := strings.new_builder(source.len)
+		fastc_write_c_source_ranges(mut event_body, event_partitioned.source, event_partitioned.body_ranges)
 		mut directives := strings.new_builder(256)
 		fastc_write_c_source_ranges(mut directives, partitioned.source, partitioned.directive_ranges)
+		assert event_directives.str() == directives.str()
 		if partitioned.final_kind == 1 {
 			directives.write_u8(`\n`)
 		}
@@ -117,6 +126,7 @@ fn test_partitioned_c_directives_match_materialized_hoisting() {
 		}
 		mut conditional_code := strings.new_builder(256)
 		fastc_write_c_source_ranges(mut conditional_code, partitioned.source, partitioned.conditional_ranges)
+		assert event_conditional_code.str() == conditional_code.str()
 		if partitioned.final_kind == 2 {
 			conditional_code.write_u8(`\n`)
 		}
@@ -125,6 +135,7 @@ fn test_partitioned_c_directives_match_materialized_hoisting() {
 		}
 		mut body := strings.new_builder(source.len)
 		fastc_write_c_source_ranges(mut body, partitioned.source, partitioned.body_ranges)
+		assert event_body.str() == body.str()
 		if partitioned.final_kind == 0 {
 			body.write_u8(`\n`)
 		}

--- a/vlib/v3/gen/fastc/expr.v
+++ b/vlib/v3/gen/fastc/expr.v
@@ -2012,7 +2012,7 @@ fn (g &Parser) semicolon_continues_expression() bool {
 }
 
 fn fastc_runtime_c_type(typ string) string {
-	base := typ.trim_right('*')
+	base := fastc_trim_pointer_suffix(typ)
 	mut runtime_type := if base.starts_with('Map_') {
 		'map'
 	} else if base.starts_with('Array_') {
@@ -2181,7 +2181,7 @@ fn (g &Parser) channel_element_type(tokens []FastcExpressionToken) string {
 	}
 	if tokens.len >= 3 && tokens.last().tok == .name && tokens[tokens.len - 2].tok == .dot {
 		receiver_type := g.infer_expression_type(tokens[..tokens.len - 2]) or { return '' }
-		receiver_layout := fastc_normalize_inferred_type(receiver_type).trim_right('*')
+		receiver_layout := fastc_trim_pointer_suffix(fastc_normalize_inferred_type(receiver_type))
 		field_name := tokens.last().lit
 		if fields := g.struct_field_info[receiver_layout] {
 			for field in fields {
@@ -2245,6 +2245,19 @@ fn (g &Parser) expected_call_argument_type(tokens []FastcExpressionToken) string
 }
 
 fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered_expression string) ?FastcRenderedExpression {
+	if tokens.len == 1 {
+		if tokens[0].tok == .name {
+			if local := g.locals[tokens[0].lit] {
+				if local.is_reference {
+					return FastcRenderedExpression{
+						source: '*(${rendered_expression})'
+						typ: local.typ.trim_right('*')
+					}
+				}
+			}
+		}
+		return none
+	}
 	if tokens.len == 6 && tokens[0].tok == .key_sizeof {
 		if c_sizeof := g.render_c_struct_sizeof(tokens) {
 			return c_sizeof
@@ -2348,16 +2361,6 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 		}
 		if string_print := g.render_ordinary_string_print_expression(tokens) {
 			return string_print
-		}
-	}
-	if tokens.len == 1 && tokens[0].tok == .name {
-		if local := g.locals[tokens[0].lit] {
-			if local.is_reference {
-				return FastcRenderedExpression{
-					source: '*(${rendered_expression})'
-					typ: local.typ.trim_right('*')
-				}
-			}
 		}
 	}
 	if g.selfhost && has_dot && g.expression_uses_member_smartcast(tokens) {
@@ -2575,7 +2578,7 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 							typ: 'bool'
 						}
 					}
-					if right_type.trim_right('*').starts_with('Map_') {
+					if fastc_trim_pointer_suffix(right_type).starts_with('Map_') {
 						key_type, _ := g.map_key_value_types(right_type) or { return none }
 						key_source := g.render_membership_candidate(tokens[..i], key_type) or {
 							return none
@@ -2594,7 +2597,7 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 							typ: 'bool'
 						}
 					}
-					right_layout := right_type.trim_right('*')
+					right_layout := fastc_trim_pointer_suffix(right_type)
 					if right_layout.starts_with('Array_') || right_layout.starts_with('FixedArray_') {
 						element_type := g.array_element_type(right_type) or { return none }
 						candidate := g.render_membership_candidate(tokens[..i], element_type) or {
@@ -2761,7 +2764,7 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 		// The erased `void*` chan stub has no fields. Channels are non-functional in
 		// this scanner lane, so report the empty/open stub state.
 		receiver_type := g.infer_expression_type(tokens[..tokens.len - 2]) or { '' }
-		if fastc_normalize_inferred_type(receiver_type).trim_right('*') == 'chan' {
+		if fastc_trim_pointer_suffix(fastc_normalize_inferred_type(receiver_type)) == 'chan' {
 			return FastcRenderedExpression{
 				source: if tokens.last().lit == 'closed' { 'false' } else { '0' }
 				typ: if tokens.last().lit == 'closed' { 'bool' } else { 'int' }

--- a/vlib/v3/gen/fastc/fastc.v
+++ b/vlib/v3/gen/fastc/fastc.v
@@ -298,6 +298,14 @@ const fastc_c_reserved_identifiers = {
 }
 
 fn fastc_c_identifier(name string) string {
+	if name.len < 2 || name.len > 8 {
+		return name
+	}
+	first := name[0]
+	// Bitset of the initial letters used by the reserved-identifier table (`a` is bit 0).
+	if first < `a` || first > `w` || (u32(8_259_967) & (u32(1) << (first - `a`))) == 0 {
+		return name
+	}
 	return if name in fastc_c_reserved_identifiers {
 		'__v_fastc_keyword_${name}'
 	} else {
@@ -610,6 +618,12 @@ struct FastcLocal {
 	chan_element_type string
 }
 
+struct FastcLocalScopeChange {
+	name         string
+	previous     FastcLocal
+	had_previous bool
+}
+
 struct FastcExpressionToken {
 	tok             token.Token
 	source          string
@@ -711,6 +725,12 @@ struct FastcPartitionedCSource {
 	conditional_ranges []int
 	body_ranges        []int
 	final_kind         int
+}
+
+struct FastcCDirectiveLine {
+	start int
+	end   int
+	kind  int
 }
 
 // GenerationResult contains generated C and the complete resolved V source graph.
@@ -855,6 +875,8 @@ mut:
 	unsafe_depth             int
 	temp_id                  int
 	locals                   map[string]FastcLocal
+	local_scope_changes      []FastcLocalScopeChange
+	local_scope_depth        int
 	functions                map[string]FastcFunctionSignature
 	constant_types           map[string]string
 	global_types             map[string]string
@@ -1034,6 +1056,7 @@ struct FastcFileGenOutput {
 mut:
 	prototypes        string
 	body              string
+	directive_lines   []FastcCDirectiveLine
 	has_main_entry    bool
 	fixed_array_types map[string]string
 	composite_types   map[string]bool
@@ -1124,6 +1147,7 @@ fn fastc_generate_single_file(ctx &FastcFileGenContext, source_file FastcSourceF
 	return FastcFileGenOutput{
 		prototypes: gen.protos.str()
 		body: generated
+		directive_lines: fastc_scan_c_directive_lines(generated)
 		has_main_entry: source_file.header.module_name in ['', 'main'] && gen.has_main
 		fixed_array_types: gen.fixed_array_types
 		composite_types: gen.composite_types
@@ -1218,6 +1242,7 @@ fn generate_source_files(input_sources []FastcSourceFile, module_aliases map[str
 	}
 	mut prototypes := strings.new_builder(1024)
 	mut body := strings.new_builder(4096)
+	mut body_directive_lines := []FastcCDirectiveLine{}
 	mut fixed_array_types := constant_output.fixed_array_types.clone()
 	for name, array_type in global_output.fixed_array_types {
 		fixed_array_types[name] = array_type
@@ -1273,7 +1298,15 @@ fn generate_source_files(input_sources []FastcSourceFile, module_aliases map[str
 			return error(output.error_message)
 		}
 		prototypes.write_string(output.prototypes)
+		body_offset := body.len
 		body.write_string(output.body)
+		for line in output.directive_lines {
+			body_directive_lines << FastcCDirectiveLine{
+				start: body_offset + line.start
+				end: body_offset + line.end
+				kind: line.kind
+			}
+		}
 		mut mono_names := output.mono_definitions.keys()
 		mono_names.sort()
 		for mono_name in mono_names {
@@ -1332,7 +1365,7 @@ fn generate_source_files(input_sources []FastcSourceFile, module_aliases map[str
 	interface_dispatches := fastc_wait_interface_dispatches(mut pending_interface_dispatches)
 	fixed_array_declarations := fastc_generate_fixed_array_declarations(fixed_array_types)
 	preamble := if prefs.building_v { c_selfhost_preamble } else { c_preamble }
-	hoisted_body := fastc_partition_c_directives(body.str())
+	hoisted_body := fastc_partition_c_directive_lines(body.str(), body_directive_lines)
 	mut result := strings.new_builder(preamble.len + c_integer_comparison_helpers.len + type_declarations.len + type_output.enum_string_helpers.len + constant_output.macros.len + constant_output.declarations.len + global_output.declarations.len + prototypes.len + body.len + startup_initializers.len + 96)
 	result.write_string(preamble)
 	result.write_string(c_integer_comparison_helpers)
@@ -1662,6 +1695,67 @@ fn fastc_partition_c_directives(source string) FastcPartitionedCSource {
 		conditional_ranges: conditional_ranges
 		body_ranges: body_ranges
 		final_kind: run_kind
+	}
+}
+
+fn fastc_scan_c_directive_lines(source string) []FastcCDirectiveLine {
+	mut lines := []FastcCDirectiveLine{}
+	mut line_start := 0
+	for line_end := 0; line_end <= source.len; line_end++ {
+		if line_end < source.len && source[line_end] != `\n` {
+			continue
+		}
+		kind := fastc_c_directive_kind(source, line_start, line_end)
+		if kind != 0 {
+			lines << FastcCDirectiveLine{
+				start: line_start
+				end: if line_end < source.len { line_end + 1 } else { line_end }
+				kind: kind
+			}
+		}
+		line_start = line_end + 1
+	}
+	return lines
+}
+
+fn fastc_partition_c_directive_lines(source string, lines []FastcCDirectiveLine) FastcPartitionedCSource {
+	mut directive_ranges := []int{cap: lines.len * 2}
+	mut conditional_ranges := []int{cap: lines.len * 2}
+	mut body_ranges := []int{cap: lines.len * 2 + 2}
+	mut conditional_depth := 0
+	mut cursor := 0
+	mut final_kind := 0
+	for line in lines {
+		if cursor < line.start {
+			final_kind = if conditional_depth > 0 { 2 } else { 0 }
+			fastc_append_c_source_range(cursor, line.start, final_kind, mut directive_ranges, mut conditional_ranges, mut body_ranges)
+		}
+		if conditional_depth > 0 {
+			final_kind = 2
+			if line.kind == 2 {
+				conditional_depth++
+			} else if line.kind == 3 {
+				conditional_depth--
+			}
+		} else if line.kind == 2 {
+			final_kind = 2
+			conditional_depth = 1
+		} else {
+			final_kind = 1
+		}
+		fastc_append_c_source_range(line.start, line.end, final_kind, mut directive_ranges, mut conditional_ranges, mut body_ranges)
+		cursor = line.end
+	}
+	if cursor < source.len {
+		final_kind = if conditional_depth > 0 { 2 } else { 0 }
+		fastc_append_c_source_range(cursor, source.len, final_kind, mut directive_ranges, mut conditional_ranges, mut body_ranges)
+	}
+	return FastcPartitionedCSource{
+		source: source
+		directive_ranges: directive_ranges
+		conditional_ranges: conditional_ranges
+		body_ranges: body_ranges
+		final_kind: final_kind
 	}
 }
 

--- a/vlib/v3/gen/fastc/fastc_test.v
+++ b/vlib/v3/gen/fastc/fastc_test.v
@@ -4961,6 +4961,29 @@ fn main() {
 	assert deferred_one < print_three
 }
 
+fn test_block_locals_are_released_when_their_scope_exits() {
+	prefs := pref.new_preferences()
+	c_source := generate("module main
+
+fn main() {
+	if true {
+		value := 1
+		println(value)
+		if true {
+			nested := 2
+			println(nested)
+		}
+		nested := 'inner'
+		println(nested)
+	}
+	value := 'outer'
+	println(value)
+}
+", 'block_local_scope.v', prefs) or { panic(err) }
+	assert c_source.contains('__typeof__((1)) value = (1);'), c_source
+	assert c_source.contains('string value = ("outer");'), c_source
+}
+
 fn test_return_expression_is_evaluated_before_deferred_blocks() {
 	prefs := pref.new_preferences()
 	c_source := generate('module main

--- a/vlib/v3/gen/fastc/fastc_test.v
+++ b/vlib/v3/gen/fastc/fastc_test.v
@@ -1,6 +1,7 @@
 module fastc
 
 import os
+import strings
 import v3.cmdexec
 import v3.pref
 import v3.scanner
@@ -10357,6 +10358,52 @@ fn main() {}
 	assert c_source.contains('voidptr main__sum(Array_voidptr values)'), c_source
 	assert c_source.contains('return (voidptr){0};'), c_source
 	assert !c_source.contains('result+='), c_source
+}
+
+fn test_failed_generic_placeholder_block_unwinds_local_scope() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	source := 'mut local := result\nlocal += result\n}'
+	mut file_set := token.FileSet.new()
+	mut file := file_set.add_file('failed_generic_scope.v', source.len)
+	file.index_lines_without_digest(source)
+	mut g := Parser{
+		prefs: &prefs
+		selfhost: true
+		in_generic_placeholder: true
+		locals: {
+			'result': FastcLocal{
+				is_mut: true
+				typ: 'voidptr'
+			}
+		}
+		s: scanner.new_scanner(prefs, .normal)
+		out: strings.new_builder(64)
+		statement_reachable: true
+	}
+	for _ in 0 .. 3 {
+		out_checkpoint := g.out.len
+		g.s.init(file, source)
+		g.next()
+		mut body_end := g.s
+		mut body_depth := 1
+		for body_depth > 0 {
+			body_tok := body_end.scan()
+			if body_tok == .eof {
+				break
+			}
+			if body_tok == .lcbr {
+				body_depth++
+			} else if body_tok == .rcbr {
+				body_depth--
+			}
+		}
+		assert g.parse_generic_body_or_stub('voidptr', out_checkpoint, 0, body_end, false)
+		assert g.local_scope_depth == 0
+		assert g.local_scope_changes.len == 0
+		assert 'local' !in g.locals
+		assert g.locals['result'].typ == 'voidptr'
+	}
 }
 
 fn test_selfhost_erased_generic_type_reflection_uses_stub() {

--- a/vlib/v3/gen/fastc/fn.v
+++ b/vlib/v3/gen/fastc/fn.v
@@ -914,7 +914,13 @@ fn (mut g Parser) parse_generic_body_or_stub(return_type string, out_checkpoint 
 		g.emit_generic_body_stub(out_checkpoint, saved_indent, body_end, return_type)
 		return true
 	}
+	local_scope_start := g.local_scope_changes.len
+	local_scope_depth := g.local_scope_depth
+	statement_reachable := g.statement_reachable
 	terminates := g.parse_block_body() or {
+		g.restore_local_scope(local_scope_start)
+		g.local_scope_depth = local_scope_depth
+		g.statement_reachable = statement_reachable
 		g.emit_generic_body_stub(out_checkpoint, saved_indent, body_end, return_type)
 		return true
 	}

--- a/vlib/v3/gen/fastc/render.v
+++ b/vlib/v3/gen/fastc/render.v
@@ -194,7 +194,7 @@ fn (g &Parser) render_ordinary_string_print_expression(tokens []FastcExpressionT
 		return none
 	}
 	argument_type := g.infer_expression_type(call_arguments[0]) or { return none }
-	if g.underlying_alias_type(argument_type).trim_right('*') != 'string' {
+	if fastc_trim_pointer_suffix(g.underlying_alias_type(argument_type)) != 'string' {
 		return none
 	}
 	argument := g.render_call_argument_expression(call_arguments[0], 'string') or { return none }
@@ -247,7 +247,7 @@ fn (g &Parser) render_selfhost_print_expression(tokens []FastcExpressionToken) ?
 	argument_type := fastc_normalize_inferred_type(g.infer_expression_type(call_arguments[0]) or {
 		return none
 	})
-	if g.underlying_alias_type(argument_type).trim_right('*') == 'string' {
+	if fastc_trim_pointer_suffix(g.underlying_alias_type(argument_type)) == 'string' {
 		return none
 	}
 	argument := g.render_call_argument_expression(call_arguments[0], argument_type) or {
@@ -277,7 +277,7 @@ fn (g &Parser) render_selfhost_print_expression(tokens []FastcExpressionToken) ?
 }
 
 fn (g &Parser) render_struct_literal_with_defaults(c_type string, layout_type string, explicit_initializers []string, rendered_fields []string, rendered_fields_by_name map[string]string) FastcRenderedExpression {
-	base_type := c_type.trim_right('*')
+	base_type := fastc_trim_pointer_suffix(c_type)
 	mut assignments := []string{cap: rendered_fields.len}
 	mut initializers := []string{}
 	mut initialized_fields := map[string]bool{}
@@ -313,7 +313,7 @@ fn (g &Parser) render_struct_literal_with_defaults(c_type string, layout_type st
 }
 
 fn (g &Parser) render_empty_struct_initializer(c_type string) string {
-	layout_type := c_type.trim_right('*')
+	layout_type := fastc_trim_pointer_suffix(c_type)
 	mut rendered_fields := []string{}
 	mut rendered_fields_by_name := map[string]string{}
 	for field in g.struct_field_info[layout_type] {
@@ -384,7 +384,7 @@ fn (g &Parser) render_struct_literal_field_names(tokens []FastcExpressionToken, 
 	c_type := g.type_from_expression_tokens(tokens[..open]) or { return none }
 	mut rendered := rendered_expression
 	mut changed := false
-	if fields := g.struct_fields[c_type.trim_right('*')] {
+	if fields := g.struct_fields[fastc_trim_pointer_suffix(c_type)] {
 		for field_name, _ in fields {
 			for module_name in [g.module_name, 'builtin'] {
 				constant_name := g.constants[fastc_constant_key(module_name, field_name)] or { '' }
@@ -510,7 +510,7 @@ fn (g &Parser) render_assignment_expression(tokens []FastcExpressionToken) ?Fast
 	}
 	rhs_tokens := tokens[assignment_index + 1..]
 	mut right := ''
-	if rhs_tokens.len == 2 && rhs_tokens[0].tok == .lsbr && rhs_tokens[1].tok == .rsbr && left_type.trim_right('*').starts_with('Array_') {
+	if rhs_tokens.len == 2 && rhs_tokens[0].tok == .lsbr && rhs_tokens[1].tok == .rsbr && fastc_trim_pointer_suffix(left_type).starts_with('Array_') {
 		// An empty array literal `[]` has no element type of its own; assigned to an
 		// array target it lowers to a typed empty array from the target's type (the
 		// standalone `x = []` case is handled where `expected_expression_type` is set).
@@ -523,7 +523,7 @@ fn (g &Parser) render_assignment_expression(tokens []FastcExpressionToken) ?Fast
 	if g.selfhost && operator == .assign && left_type == 'Option' && option_payload_type != '' {
 		rhs_type := fastc_normalize_inferred_type(g.infer_expression_type(rhs_tokens) or { '' })
 		if rhs_type != 'Option' {
-			if rhs_type.trim_right('*') == 'IError' {
+			if fastc_trim_pointer_suffix(rhs_type) == 'IError' {
 				right = '(Option){.err=${right}, .state=1}'
 			} else {
 				payload := g.render_call_argument_expression(rhs_tokens, option_payload_type) or {
@@ -573,7 +573,7 @@ fn (g &Parser) render_overloaded_assignment(target string, value string, target_
 }
 
 fn (g &Parser) render_unsigned_right_shift_assignment(target string, value string, target_type string) ?string {
-	resolved_type := g.underlying_alias_type(target_type).trim_right('*')
+	resolved_type := fastc_trim_pointer_suffix(g.underlying_alias_type(target_type))
 	unsigned_type, bits := match resolved_type {
 		'byte', 'char', 'i8', 'u8' { 'u8', '8' }
 		'i16', 'u16' { 'u16', '16' }
@@ -680,12 +680,12 @@ fn (g &Parser) render_array_equality_comparison(left_tokens []FastcExpressionTok
 	right_type := fastc_normalize_inferred_type(g.infer_expression_type(right_tokens) or {
 		return none
 	})
-	left_layout := left_type.trim_right('*')
+	left_layout := fastc_trim_pointer_suffix(left_type)
 	if left_type != right_type || (!left_layout.starts_with('Array_') && !left_layout.starts_with('FixedArray_')) {
 		return none
 	}
 	element_type := g.array_element_type(left_type) or { return none }
-	resolved_element := g.underlying_alias_type(element_type).trim_right('*')
+	resolved_element := fastc_trim_pointer_suffix(g.underlying_alias_type(element_type))
 	is_scalar := fastc_is_numeric_expression_type(resolved_element) || resolved_element == 'bool' || fastc_is_pointer_type(element_type) || g.underlying_enum_type_key(g.semantic_type_key(element_type)) != none
 	if resolved_element != 'string' && !is_scalar {
 		return none
@@ -722,7 +722,7 @@ fn (g &Parser) render_array_equality_comparison(left_tokens []FastcExpressionTok
 }
 
 fn (g &Parser) render_fixed_array_equality_data(tokens []FastcExpressionToken, c_type string) ?string {
-	layout_type := c_type.trim_right('*')
+	layout_type := fastc_trim_pointer_suffix(c_type)
 	if literal := g.render_array_literal_argument(tokens, layout_type) {
 		return '(${literal.source}).data'
 	}
@@ -1028,7 +1028,7 @@ fn (g &Parser) render_chained_array_access_expression(tokens []FastcExpressionTo
 		}
 		base_tokens := tokens[start..open]
 		base_type := g.infer_expression_type(base_tokens) or { continue }
-		if base_type.trim_right('*').starts_with('Map_') {
+		if fastc_trim_pointer_suffix(base_type).starts_with('Map_') {
 			lookup_tokens := tokens[start..close + 1]
 			lookup := g.render_map_expression(lookup_tokens) or { continue }
 			raw_lookup := g.render_raw_expression_tokens(lookup_tokens) or { continue }
@@ -1044,7 +1044,7 @@ fn (g &Parser) render_chained_array_access_expression(tokens []FastcExpressionTo
 		} else if is_array_pointer {
 			g.array_element_type(base_type) or { continue }
 		} else if base_type.ends_with('*') {
-			base_type.trim_right('*')
+			fastc_trim_pointer_suffix(base_type)
 		} else {
 			g.array_element_type(base_type) or { continue }
 		}
@@ -1058,7 +1058,7 @@ fn (g &Parser) render_chained_array_access_expression(tokens []FastcExpressionTo
 		index_source := g.render_membership_candidate(tokens[open + 1..close], 'int') or {
 			continue
 		}
-		is_raw_fixed_array := base_type.trim_right('*').starts_with('FixedArray_') && (base_tokens.len > 1 || (base_tokens.len == 1 && fastc_global_key(g.module_name, base_tokens[0].lit) in g.globals))
+		is_raw_fixed_array := fastc_trim_pointer_suffix(base_type).starts_with('FixedArray_') && (base_tokens.len > 1 || (base_tokens.len == 1 && fastc_global_key(g.module_name, base_tokens[0].lit) in g.globals))
 		replacement := if checked_access := g.render_array_access_expression(tokens[start..close + 1]) {
 			checked_access.source
 		} else if is_raw_fixed_array {
@@ -1207,7 +1207,7 @@ fn (g &Parser) struct_equality_is_supported(typ string, seen []string) bool {
 	if fastc_is_pointer_type(typ) {
 		return true
 	}
-	layout_type := g.underlying_alias_type(typ).trim_right('*')
+	layout_type := fastc_trim_pointer_suffix(g.underlying_alias_type(typ))
 	if layout_type == 'string' || layout_type == 'bool' || fastc_is_numeric_expression_type(layout_type) {
 		return true
 	}
@@ -1246,7 +1246,7 @@ fn (g &Parser) struct_equality_source(left string, right string, typ string, see
 	if fastc_is_pointer_type(typ) {
 		return '((${left}) == (${right}))'
 	}
-	layout_type := g.underlying_alias_type(typ).trim_right('*')
+	layout_type := fastc_trim_pointer_suffix(g.underlying_alias_type(typ))
 	if layout_type == 'string' {
 		return 'builtin__string_eq(${left}, ${right})'
 	}
@@ -1385,8 +1385,8 @@ fn (g &Parser) render_struct_comparison_expression_impl(tokens []FastcExpression
 			if fastc_is_pointer_type(left_type) || fastc_is_pointer_type(right_type) {
 				return none
 			}
-			left_layout := g.underlying_alias_type(left_type).trim_right('*')
-			right_layout := g.underlying_alias_type(right_type).trim_right('*')
+			left_layout := fastc_trim_pointer_suffix(g.underlying_alias_type(left_type))
+			right_layout := fastc_trim_pointer_suffix(g.underlying_alias_type(right_type))
 			if left_layout == right_layout && left_layout in g.sum_types {
 				// Sum-type equality (`value == Primitive(Null{})`): the boxed struct
 				// cannot be compared with C `==`, so compare the variant tag (and, for a
@@ -1656,7 +1656,7 @@ fn (g &Parser) render_string_comparison_expression(tokens []FastcExpressionToken
 		right_tokens := tokens[i + 1..]
 		left_type := g.infer_expression_type(left_tokens) or { return none }
 		right_type := g.infer_expression_type(right_tokens) or { return none }
-		if g.underlying_alias_type(left_type).trim_right('*') != 'string' || g.underlying_alias_type(right_type).trim_right('*') != 'string' {
+		if fastc_trim_pointer_suffix(g.underlying_alias_type(left_type)) != 'string' || fastc_trim_pointer_suffix(g.underlying_alias_type(right_type)) != 'string' {
 			return none
 		}
 		left_source := g.render_comparison_operand(left_tokens, 'string') or { return none }
@@ -1963,7 +1963,7 @@ fn (g &Parser) render_call_argument_expression(tokens []FastcExpressionToken, ex
 	if actual_type == 'voidptr' && !expected_type.ends_with('*') && (expected_type.trim_right('*') in g.struct_fields || expected_type.trim_right('*').starts_with('Array_') || expected_type.trim_right('*').starts_with('Map_') || expected_type.trim_right('*').starts_with('FixedArray_')) {
 		return '*((${expected_type} *)(${rendered}))'
 	}
-	if expected_type == 'string' && actual_type.trim_right('*') == 'IError' {
+	if expected_type == 'string' && fastc_trim_pointer_suffix(actual_type) == 'IError' {
 		return 'builtin__IError_msg(${rendered})'
 	}
 	if actual_type.ends_with('*') && expected_type == actual_type.trim_right('*') && !fastc_expression_tokens_contain(tokens, .lsbr) {
@@ -1989,7 +1989,7 @@ fn (g &Parser) render_call_argument_expression(tokens []FastcExpressionToken, ex
 }
 
 fn (g &Parser) render_array_literal_argument(tokens []FastcExpressionToken, expected_type string) ?FastcRenderedExpression {
-	array_type := expected_type.trim_right('*')
+	array_type := fastc_trim_pointer_suffix(expected_type)
 	is_fixed := array_type.starts_with('FixedArray_')
 	if (!array_type.starts_with('Array_') && !is_fixed) || tokens.len < 2 || tokens[0].tok != .lsbr {
 		return none
@@ -2123,7 +2123,7 @@ fn (g &Parser) render_method_value_expression(tokens []FastcExpressionToken) ?st
 }
 
 fn (g &Parser) render_map_literal_argument(tokens []FastcExpressionToken, expected_type string) ?FastcRenderedExpression {
-	map_type := expected_type.trim_right('*')
+	map_type := fastc_trim_pointer_suffix(expected_type)
 	key_type, value_type := g.map_key_value_types(map_type) or { return none }
 	if tokens.len < 2 || tokens[0].tok != .lcbr || tokens.last().tok != .rcbr {
 		return none
@@ -2237,7 +2237,7 @@ fn fastc_map_literal_entries(tokens []FastcExpressionToken, start int, end int) 
 // representation: interfaces and sum types. A concrete struct used where such a
 // type is expected is boxed with its type id (see interface_value_expression).
 fn (g &Parser) is_boxed_type(c_type string) bool {
-	if c_type.trim_right('*') in g.sum_types {
+	if fastc_trim_pointer_suffix(c_type) in g.sum_types {
 		return true
 	}
 	return g.declared_kinds[g.semantic_type_key(c_type)] == .interface_
@@ -2249,7 +2249,7 @@ fn (g &Parser) is_boxed_type(c_type string) bool {
 // a recursive sum type (`type Value = []Value | int`) boxed as a single element
 // rather than treated as a push-many append.
 fn (g &Parser) sumtype_has_variant(sum_type string, variant string) bool {
-	base := sum_type.trim_right('*')
+	base := fastc_trim_pointer_suffix(sum_type)
 	if base !in g.sum_types {
 		return false
 	}
@@ -2268,10 +2268,10 @@ fn (g &Parser) should_box_variant(expected_type string, actual_type string) bool
 	if g.declared_kinds[g.semantic_type_key(resolved_actual)] == .struct_ {
 		return true
 	}
-	if expected_type.trim_right('*') in g.sum_types {
+	if fastc_trim_pointer_suffix(expected_type) in g.sum_types {
 		// Primitive or composite (`Array_`/`Map_`) value into a sum type. Interfaces
 		// have no primitive/composite implementers, so this is sum-type only.
-		normalized := fastc_normalize_inferred_type(actual_type).trim_right('*')
+		normalized := fastc_trim_pointer_suffix(fastc_normalize_inferred_type(actual_type))
 		return fastc_primitive_c_type(normalized) != none || normalized.starts_with('Array_') || normalized.starts_with('Map_')
 	}
 	return false
@@ -2347,7 +2347,7 @@ fn (g &Parser) render_array_lookup_option_expression(tokens []FastcExpressionTok
 	}
 	base_tokens := lookup_tokens[..open]
 	base_type := g.infer_expression_type(base_tokens) or { return none }
-	if !base_type.trim_right('*').starts_with('Array_') {
+	if !fastc_trim_pointer_suffix(base_type).starts_with('Array_') {
 		return none
 	}
 	element_type := g.array_element_type(base_type) or { return none }
@@ -2492,7 +2492,7 @@ fn (g &Parser) render_append_expression(tokens []FastcExpressionToken, rendered_
 				}
 			}
 			base_type := g.infer_expression_type(base_tokens) or { '' }
-			base_layout := g.underlying_alias_type(base_type).trim_right('*')
+			base_layout := fastc_trim_pointer_suffix(g.underlying_alias_type(base_type))
 			if base_layout.starts_with('Array_') {
 				outer_element_type := g.array_element_type(base_type) or { '' }
 				if fastc_normalize_inferred_type(outer_element_type) == fastc_normalize_inferred_type(left_type) {
@@ -2559,7 +2559,7 @@ fn (g &Parser) render_composed_string_concatenation(tokens []FastcExpressionToke
 			.plus {
 				if depth == 0 {
 					operand_type := g.infer_expression_type(tokens[operand_start..i]) or { '' }
-					string_operands << g.underlying_alias_type(operand_type).trim_right('*') == 'string'
+					string_operands << fastc_trim_pointer_suffix(g.underlying_alias_type(operand_type)) == 'string'
 					operand_start = i + 1
 					plus_count++
 				}
@@ -2571,7 +2571,7 @@ fn (g &Parser) render_composed_string_concatenation(tokens []FastcExpressionToke
 		return none
 	}
 	last_operand_type := g.infer_expression_type(tokens[operand_start..]) or { '' }
-	string_operands << g.underlying_alias_type(last_operand_type).trim_right('*') == 'string'
+	string_operands << fastc_trim_pointer_suffix(g.underlying_alias_type(last_operand_type)) == 'string'
 	mut has_string_operand := false
 	for is_string in string_operands {
 		if is_string {

--- a/vlib/v3/gen/fastc/render_calls.v
+++ b/vlib/v3/gen/fastc/render_calls.v
@@ -473,7 +473,7 @@ fn (g &Parser) method_function_key(receiver_type string, name string) string {
 	if g.selfhost && name in ['keys', 'values'] && 'map.${name}' in g.functions {
 		return 'map.${name}'
 	}
-	mut layout_type := receiver_type.trim_right('*')
+	mut layout_type := fastc_trim_pointer_suffix(receiver_type)
 	if layout_type.starts_with('Array_') {
 		layout_type = 'array'
 	} else if layout_type.starts_with('Map_') {
@@ -500,7 +500,7 @@ fn (g &Parser) resolve_method(receiver_type string, name string) (string, []stri
 	if direct in g.functions {
 		return direct, []string{}
 	}
-	layout_type := receiver_type.trim_right('*')
+	layout_type := fastc_trim_pointer_suffix(receiver_type)
 	for field in g.struct_field_info[layout_type] {
 		if !field.name.starts_with('__embedded_') {
 			continue
@@ -536,8 +536,8 @@ fn (g &Parser) specialized_method_return_type(receiver_type string, method_key s
 			}
 		}
 	}
-	if method_key.starts_with('map.') && signature.return_type == 'map' && receiver_type.trim_right('*').starts_with('Map_') {
-		return receiver_type.trim_right('*')
+	if method_key.starts_with('map.') && signature.return_type == 'map' && fastc_trim_pointer_suffix(receiver_type).starts_with('Map_') {
+		return fastc_trim_pointer_suffix(receiver_type)
 	}
 	return signature.return_type
 }
@@ -586,7 +586,7 @@ fn (g &Parser) render_interface_cast_expression(tokens []FastcExpressionToken, r
 	// text (`[1,2,3]` is not valid C), so render it through the argument path.
 	// A struct literal likewise needs its designated-initializer lowering before boxing.
 	// Scalars and pointers keep the already-streamed spelling.
-	actual_base := actual_type.trim_right('*')
+	actual_base := fastc_trim_pointer_suffix(actual_type)
 	inner_source := if struct_literal := g.render_struct_literal_expression(inner_tokens) {
 		struct_literal.source
 	} else if actual_base.starts_with('Array_') || actual_base.starts_with('Map_') {

--- a/vlib/v3/gen/fastc/render_method_calls.v
+++ b/vlib/v3/gen/fastc/render_method_calls.v
@@ -158,7 +158,7 @@ fn (g &Parser) render_method_call_expression(tokens []FastcExpressionToken, rend
 		receiver_start := fastc_method_receiver_start(tokens, i - 1)
 		receiver_tokens := tokens[receiver_start..i - 1]
 		receiver_type := g.infer_expression_type(receiver_tokens) or { continue }
-		if tokens[i].lit == 'contains' && fastc_normalize_inferred_type(receiver_type).trim_right('*').starts_with('Array_') {
+		if tokens[i].lit == 'contains' && fastc_trim_pointer_suffix(fastc_normalize_inferred_type(receiver_type)).starts_with('Array_') {
 			call_end := fastc_matching_rpar(tokens, i + 1) or { continue }
 			call_args := fastc_call_arguments(tokens, i + 1, call_end) or { continue }
 			if call_args.len != 1 {
@@ -170,7 +170,7 @@ fn (g &Parser) render_method_call_expression(tokens []FastcExpressionToken, rend
 				continue
 			}
 			access := if receiver_type.ends_with('*') { '->' } else { '.' }
-			comparison := if g.underlying_alias_type(element_type).trim_right('*') == 'string' {
+			comparison := if fastc_trim_pointer_suffix(g.underlying_alias_type(element_type)) == 'string' {
 				'builtin__string_eq(__v_fastc_contains_item, ((${element_type} *)__v_fastc_contains_collection${access}data)[__v_fastc_contains_index])'
 			} else {
 				'(__v_fastc_contains_item == ((${element_type} *)__v_fastc_contains_collection${access}data)[__v_fastc_contains_index])'

--- a/vlib/v3/gen/fastc/stmt.v
+++ b/vlib/v3/gen/fastc/stmt.v
@@ -5,7 +5,8 @@ import v3.pref
 import v3.token
 
 fn (mut g Parser) parse_block_body() !bool {
-	mut outer_locals := g.locals.clone()
+	local_scope_start := g.local_scope_changes.len
+	g.local_scope_depth++
 	outer_statement_reachable := g.statement_reachable
 	deferred_line_start := g.deferred_lines.len
 	deferred_block_start := g.deferred_block_starts.len
@@ -36,9 +37,39 @@ fn (mut g Parser) parse_block_body() !bool {
 	g.write_deferred_blocks_from(deferred_block_start)
 	g.deferred_lines.trim(deferred_line_start)
 	g.deferred_block_starts.trim(deferred_block_start)
-	g.locals = outer_locals.move()
+	g.restore_local_scope(local_scope_start)
+	g.local_scope_depth--
 	g.statement_reachable = outer_statement_reachable
 	return terminates
+}
+
+fn (mut g Parser) set_scoped_local(name string, local FastcLocal) {
+	if g.local_scope_depth > 0 {
+		if previous := g.locals[name] {
+			g.local_scope_changes << FastcLocalScopeChange{
+				name: name
+				previous: previous
+				had_previous: true
+			}
+		} else {
+			g.local_scope_changes << FastcLocalScopeChange{
+				name: name
+			}
+		}
+	}
+	g.locals[name] = local
+}
+
+fn (mut g Parser) restore_local_scope(start int) {
+	for i := g.local_scope_changes.len - 1; i >= start; i-- {
+		change := g.local_scope_changes[i]
+		if change.had_previous {
+			g.locals[change.name] = change.previous
+		} else {
+			g.locals.delete(change.name)
+		}
+	}
+	g.local_scope_changes.trim(start)
 }
 
 fn (mut g Parser) parse_statement() !bool {
@@ -366,7 +397,7 @@ fn (mut g Parser) parse_loop_block_body() !FastcLoopBlockResult {
 	g.loop_has_breaks.delete_last()
 	g.loop_defer_block_starts.delete_last()
 	return FastcLoopBlockResult{
-		terminates:          terminates
+		terminates: terminates
 		has_reachable_break: has_reachable_break
 	}
 }
@@ -389,16 +420,16 @@ fn (mut g Parser) parse_match_statement() !bool {
 	is_boxed := g.is_boxed_type(subject_type)
 	boxed_access := if subject_type.ends_with('*') { '->' } else { '.' }
 	mut subject_local := ''
-	if is_boxed && subject_tokens.len == 1 && subject_tokens[0].tok == .name
-		&& subject_tokens[0].lit in g.locals {
+	if is_boxed && subject_tokens.len == 1 && subject_tokens[0].tok == .name && subject_tokens[0].lit in g.locals {
 		subject_local = subject_tokens[0].lit
-	} else if is_boxed && subject_tokens.len == 2 && subject_tokens[0].tok in [.key_mut, .amp]
-		&& subject_tokens[1].tok == .name && subject_tokens[1].lit in g.locals {
+	} else if is_boxed && subject_tokens.len == 2 && subject_tokens[0].tok in [
+		.key_mut,
+		.amp,
+	] && subject_tokens[1].tok == .name && subject_tokens[1].lit in g.locals {
 		subject_local = subject_tokens[1].lit
 	}
 	mut subject_member_path := ''
-	if is_boxed && subject_tokens.len >= 3 && subject_tokens.len % 2 == 1
-		&& subject_tokens[0].tok == .name && subject_tokens[0].lit in g.locals {
+	if is_boxed && subject_tokens.len >= 3 && subject_tokens.len % 2 == 1 && subject_tokens[0].tok == .name && subject_tokens[0].lit in g.locals {
 		mut is_member_chain := true
 		mut path := subject_tokens[0].lit
 		for i := 1; i + 1 < subject_tokens.len; i += 2 {
@@ -459,8 +490,8 @@ fn (mut g Parser) parse_match_statement() !bool {
 					value = '${subject_type.trim_right('*')}__${g.lit}'
 					g.next()
 				} else {
-					value = g.read_expression([token.Token.comma, token.Token.lcbr, token.Token.dotdot,
-						token.Token.ellipsis])!
+					value = g.read_expression([token.Token.comma, token.Token.lcbr,
+						token.Token.dotdot, token.Token.ellipsis])!
 					if value == '' {
 						return g.unsupported('empty match branch value')
 					}
@@ -471,8 +502,7 @@ fn (mut g Parser) parse_match_statement() !bool {
 						g.next()
 						finish := g.read_expression([token.Token.comma, token.Token.lcbr])!
 						finish_tokens := g.last_expression.clone()
-						case_key = 'range:${start_key}..${g.normalized_match_case_key(finish_tokens,
-							finish)}'
+						case_key = 'range:${start_key}..${g.normalized_match_case_key(finish_tokens, finish)}'
 						value = '((${subject_name}) >= (${start}) && (${subject_name}) <= (${finish}))'
 						value_is_condition = true
 					}
@@ -498,8 +528,7 @@ fn (mut g Parser) parse_match_statement() !bool {
 		} else {
 			mut conditions := []string{}
 			for value_index, value in values {
-				if is_boxed || (value_index < values_are_conditions.len
-					&& values_are_conditions[value_index]) {
+				if is_boxed || (value_index < values_are_conditions.len && values_are_conditions[value_index]) {
 					conditions << '(${value})'
 				} else if is_string {
 					conditions << 'builtin__string_eq(${subject_name}, ${value})'
@@ -516,8 +545,7 @@ fn (mut g Parser) parse_match_statement() !bool {
 		mut had_member_smartcast := false
 		mut member_smartcast_active := false
 		common_numeric_type := fastc_match_common_numeric_variant(variant_types)
-		smartcast_active := is_boxed && !is_else
-			&& (variant_types.len == 1 || common_numeric_type != '') && subject_local != ''
+		smartcast_active := is_boxed && !is_else && (variant_types.len == 1 || common_numeric_type != '') && subject_local != ''
 		if smartcast_active {
 			variant_cname := if common_numeric_type != '' {
 				common_numeric_type
@@ -525,8 +553,7 @@ fn (mut g Parser) parse_match_statement() !bool {
 				variant_types[0]
 			}
 			smartcast_value := if common_numeric_type != '' {
-				fastc_match_multi_variant_value(subject_name, boxed_access, variant_types,
-					common_numeric_type)
+				fastc_match_multi_variant_value(subject_name, boxed_access, variant_types, common_numeric_type)
 			} else {
 				'*(${variant_cname} *)${subject_name}${boxed_access}_object'
 			}
@@ -534,7 +561,7 @@ fn (mut g Parser) parse_match_statement() !bool {
 			smartcast_saved = g.locals[subject_local] or { FastcLocal{} }
 			g.locals[subject_local] = FastcLocal{
 				is_mut: smartcast_saved.is_mut
-				typ:    variant_cname
+				typ: variant_cname
 			}
 		}
 		if is_boxed && !is_else && variant_types.len == 1 && subject_member_path != '' {
@@ -546,7 +573,7 @@ fn (mut g Parser) parse_match_statement() !bool {
 			}
 			had_member_smartcast = subject_member_path in g.member_smartcasts
 			g.member_smartcasts[subject_member_path] = FastcMemberSmartcast{
-				typ:    variant_cname + '*'
+				typ: variant_cname + '*'
 				source: member_smartcast_name
 			}
 			member_smartcast_active = true
@@ -606,8 +633,7 @@ fn (mut g Parser) read_match_type_key() ?string {
 		}
 		g.next()
 		value_key := g.read_match_type_key() or { return none }
-		map_c := fastc_map_c_type(fastc_c_declared_type_name(key_key),
-			fastc_c_declared_type_name(value_key))
+		map_c := fastc_map_c_type(fastc_c_declared_type_name(key_key), fastc_c_declared_type_name(value_key))
 		fastc_register_composite_type(map_c, mut g.composite_types)
 		return map_c
 	}
@@ -658,13 +684,11 @@ fn (mut g Parser) parse_return() !bool {
 		})
 		return true
 	}
-	if g.selfhost && (g.return_type.trim_right('*') == 'MultiReturn'
-		|| (g.return_type == 'Option' && g.option_return_type == 'MultiReturn')) {
+	if g.selfhost && (g.return_type.trim_right('*') == 'MultiReturn' || (g.return_type == 'Option' && g.option_return_type == 'MultiReturn')) {
 		mut values := []string{}
 		mut value_types := []string{}
 		for {
-			value :=
-				g.read_expression([token.Token.comma, token.Token.semicolon, token.Token.rcbr])!
+			value := g.read_expression([token.Token.comma, token.Token.semicolon, token.Token.rcbr])!
 			if value == '' {
 				return g.unsupported('empty multi-return value')
 			}
@@ -691,8 +715,7 @@ fn (mut g Parser) parse_return() !bool {
 			g.write_line('return ${evaluated_values[0]};')
 			return true
 		}
-		if g.return_type == 'Option' && values.len == 1
-			&& value_types[0].trim_right('*') == 'IError' {
+		if g.return_type == 'Option' && values.len == 1 && value_types[0].trim_right('*') == 'IError' {
 			g.write_line('return (Option){.err=${evaluated_values[0]}, .state=1};')
 			return true
 		}
@@ -714,8 +737,8 @@ fn (mut g Parser) parse_return() !bool {
 	}
 	previous_expected_type := g.expected_expression_type
 	if g.selfhost {
-		g.expected_expression_type = if g.return_type == 'Option'
-			&& g.option_return_type !in ['', 'MultiReturn'] {
+		g.expected_expression_type = if g.return_type == 'Option' && g.option_return_type !in ['',
+			'MultiReturn'] {
 			g.option_return_type
 		} else {
 			g.return_type
@@ -734,20 +757,14 @@ fn (mut g Parser) parse_return() !bool {
 	} else {
 		g.return_type
 	}
-	if g.selfhost && actual_type == '' && g.last_expression.len == 2
-		&& g.last_expression[0].tok == .dot && g.last_expression[1].tok == .name
-		&& g.declared_kinds[g.semantic_type_key(contextual_return_type)] == .enum_ {
+	if g.selfhost && actual_type == '' && g.last_expression.len == 2 && g.last_expression[0].tok == .dot && g.last_expression[1].tok == .name && g.declared_kinds[g.semantic_type_key(contextual_return_type)] == .enum_ {
 		expression = '${contextual_return_type.trim_right('*')}__${g.last_expression[1].lit}'
 		actual_type = contextual_return_type
 	}
-	if g.selfhost && g.return_type !in ['Option', 'MultiReturn']
-		&& g.declared_kinds[g.semantic_type_key(g.return_type)] != .interface_
-		&& !fastc_types_share_lowering_representation(actual_type, g.return_type)
-		&& !g.selfhost_types_share_lowering_representation(actual_type, g.return_type) {
+	if g.selfhost && g.return_type !in ['Option', 'MultiReturn'] && g.declared_kinds[g.semantic_type_key(g.return_type)] != .interface_ && !fastc_types_share_lowering_representation(actual_type, g.return_type) && !g.selfhost_types_share_lowering_representation(actual_type, g.return_type) {
 		actual_type = g.return_type
 	}
-	if g.selfhost && g.declared_kinds[g.semantic_type_key(g.return_type)] == .interface_
-		&& g.declared_kinds[g.semantic_type_key(actual_type)] != .interface_ {
+	if g.selfhost && g.declared_kinds[g.semantic_type_key(g.return_type)] == .interface_ && g.declared_kinds[g.semantic_type_key(actual_type)] != .interface_ {
 		expression = g.interface_value_expression(g.return_type, actual_type, expression)
 		actual_type = g.return_type
 	}
@@ -880,8 +897,7 @@ fn (mut g Parser) parse_simple_statement() ! {
 			// `[]T` as a variant (a recursive sum type such as `type Value = []Value | int`),
 			// in which case the array is boxed as one element. Mirrors the main C backend's
 			// `sumtype_has_variant` guard (see vlib/v/gen/c/infix.v).
-			boxes_array_variant := value_type == local.typ
-				&& g.sumtype_has_variant(element_type, value_type)
+			boxes_array_variant := value_type == local.typ && g.sumtype_has_variant(element_type, value_type)
 			is_array_append := value_type == local.typ && !boxes_array_variant
 			g.consume_statement_end()
 			c_name := fastc_c_identifier(name)
@@ -907,14 +923,13 @@ fn (mut g Parser) parse_simple_statement() ! {
 			}
 			return
 		}
-		if !g.selfhost && (g.tok.is_assignment() || g.tok in [.inc, .dec]) && !is_global
-			&& (!is_known_local || !statement_local.is_mut) {
+		if !g.selfhost && (g.tok.is_assignment() || g.tok in [.inc, .dec]) && !is_global && (!is_known_local || !statement_local.is_mut) {
 			return g.unsupported('mutation of immutable or unknown name `${name}`')
 		}
 		g.validate_expression_name(name, .unknown)!
 		if g.tok.is_assignment() {
-			if !g.selfhost
-				&& g.tok in [.left_shift_assign, .right_shift_assign, .right_shift_unsigned_assign] {
+			if !g.selfhost && g.tok in [.left_shift_assign, .right_shift_assign,
+				.right_shift_unsigned_assign] {
 				return g.unsupported('shift expressions')
 			}
 			if !g.selfhost && g.tok in [.div_assign, .mod_assign] {
@@ -961,14 +976,13 @@ fn (mut g Parser) parse_simple_statement() ! {
 			} else {
 				expected_type
 			}
-			if g.selfhost && resolved_expected_type == 'int'
-				&& !fastc_is_numeric_expression_type(actual_type) && name in g.locals {
+			if g.selfhost && resolved_expected_type == 'int' && !fastc_is_numeric_expression_type(actual_type) && name in g.locals {
 				resolved_expected_type = actual_type
-				g.locals[name] = FastcLocal{
-					is_mut:       statement_local.is_mut
+				g.set_scoped_local(name, FastcLocal{
+					is_mut: statement_local.is_mut
 					is_reference: statement_local.is_reference
-					typ:          actual_type
-				}
+					typ: actual_type
+				})
 			}
 			expected_layout_type := g.underlying_alias_type(resolved_expected_type)
 			actual_layout_type := g.underlying_alias_type(actual_type)
@@ -978,8 +992,7 @@ fn (mut g Parser) parse_simple_statement() ! {
 				// make the placeholder parser fall back to its inert stub.
 				return g.unsupported('compound assignment on an erased generic type')
 			}
-			if operator == .plus_assign && expected_layout_type == 'string'
-				&& actual_layout_type == 'string' {
+			if operator == .plus_assign && expected_layout_type == 'string' && actual_layout_type == 'string' {
 				g.consume_statement_end()
 				concatenation := if g.selfhost {
 					'builtin__string_plus(${c_target},${value})'
@@ -989,25 +1002,21 @@ fn (mut g Parser) parse_simple_statement() ! {
 				g.write_line('${c_target}=${concatenation};')
 				return
 			}
-			if overloaded := g.render_overloaded_assignment(c_target, value,
-				resolved_expected_type, operator)
-			{
+			if overloaded := g.render_overloaded_assignment(c_target, value, resolved_expected_type, operator) {
 				g.consume_statement_end()
 				g.write_line('${overloaded};')
 				return
 			}
 			g.consume_statement_end()
 			if operator == .right_shift_unsigned_assign {
-				shift := g.render_unsigned_right_shift_assignment(c_target, value,
-					resolved_expected_type) or {
+				shift := g.render_unsigned_right_shift_assignment(c_target, value, resolved_expected_type) or {
 					return g.unsupported('unsigned right shift assignment on type `${resolved_expected_type}`')
 				}
 				g.write_line('${shift};')
 				return
 			}
 			mut assigned_value := value
-			if g.selfhost && operator == .assign && resolved_expected_type == 'Option'
-				&& actual_type != 'Option' {
+			if g.selfhost && operator == .assign && resolved_expected_type == 'Option' && actual_type != 'Option' {
 				if actual_type.trim_right('*') == 'IError' {
 					assigned_value = '(Option){.err=${value}, .state=1}'
 				} else {
@@ -1016,36 +1025,31 @@ fn (mut g Parser) parse_simple_statement() ! {
 					} else {
 						fastc_normalize_inferred_type(actual_type)
 					}
-					payload_value := g.render_call_argument_expression(g.last_expression,
-						payload_type) or { value }
+					payload_value := g.render_call_argument_expression(g.last_expression, payload_type) or { value }
 					assigned_value = fastc_option_success_expression(payload_type, payload_value)
 				}
-			} else if g.selfhost && operator == .assign
-				&& g.should_box_variant(resolved_expected_type, actual_type) {
+			} else if g.selfhost && operator == .assign && g.should_box_variant(resolved_expected_type, actual_type) {
 				// A concrete struct assigned to an interface variable is boxed with its
 				// type id so the dispatch functions can recover the receiver.
-				assigned_value = g.interface_value_expression(resolved_expected_type, actual_type,
-					value)
-			} else if g.selfhost && operator == .assign && resolved_expected_type == 'voidptr'
-				&& actual_type !in ['', 'voidptr', 'nil']
-				&& !fastc_expression_is_zero(g.last_expression)
-				&& !fastc_is_pointer_type(actual_type) {
+				assigned_value = g.interface_value_expression(resolved_expected_type, actual_type, value)
+			} else if g.selfhost && operator == .assign && resolved_expected_type == 'voidptr' && actual_type !in ['',
+				'voidptr', 'nil'] && !fastc_expression_is_zero(g.last_expression) && !fastc_is_pointer_type(actual_type) {
 				// An unmonomorphized imported generic stores `T` as `voidptr`. Preserve a
 				// concrete value assigned through that slot by copying it into boxed storage.
 				box_value := g.temporary_name('generic_box')
 				assigned_value = '({ ${actual_type} ${box_value} = (${value}); v_fastc_interface_box(&${box_value}, sizeof(${actual_type})); })'
-			} else if g.selfhost && operator == .assign && actual_type == 'voidptr'
-				&& (resolved_expected_type.trim_right('*') in g.struct_fields
-				|| resolved_expected_type.trim_right('*').starts_with('Array_')
-				|| resolved_expected_type.trim_right('*').starts_with('Map_')
-				|| resolved_expected_type.trim_right('*').starts_with('FixedArray_')) {
+			} else if g.selfhost && operator == .assign && actual_type == 'voidptr' && (resolved_expected_type.trim_right('*') in g.struct_fields || resolved_expected_type.trim_right('*').starts_with('Array_') || resolved_expected_type.trim_right('*').starts_with('Map_') || resolved_expected_type.trim_right('*').starts_with('FixedArray_')) {
 				assigned_value = '*((${resolved_expected_type} *)(${value}))'
 			}
 			g.write_line('${c_target}${operator.str()}${assigned_value};')
 			return
 		}
-		expression := g.read_statement_expression_with_prefix(name, [token.Token.comma,
-			token.Token.semicolon, token.Token.rcbr, token.Token.arrow])!
+		expression := g.read_statement_expression_with_prefix(name, [
+			token.Token.comma,
+			token.Token.semicolon,
+			token.Token.rcbr,
+			token.Token.arrow,
+		])!
 		if g.selfhost && g.tok == .arrow {
 			// Channel send `<chan> <- <value>`: push the value through the channel.
 			// Channels are the type-erased `void*` stub, so this compiles to a
@@ -1061,8 +1065,7 @@ fn (mut g Parser) parse_simple_statement() ! {
 			return
 		}
 		if g.selfhost && g.tok == .comma {
-			g.parse_parallel_expression_assignment(expression, g.last_expression.clone(),
-				g.last_expression_type)!
+			g.parse_parallel_expression_assignment(expression, g.last_expression.clone(), g.last_expression_type)!
 			return
 		}
 		if !g.last_expression_is_statement() {
@@ -1132,9 +1135,7 @@ fn (mut g Parser) parse_assert_statement() ! {
 fn (mut g Parser) capture_or_value(expression string) {
 	mut value := expression
 	if g.or_value_expected_type != '' && g.last_expression.len > 0 {
-		if contextual := g.render_call_argument_expression(g.last_expression,
-			g.or_value_expected_type)
-		{
+		if contextual := g.render_call_argument_expression(g.last_expression, g.or_value_expected_type) {
 			value = contextual
 		}
 	}
@@ -1215,10 +1216,10 @@ fn (mut g Parser) parse_parallel_assignment(initial_names []string, initial_mut 
 					fastc_normalize_inferred_type(value_types[i])
 				}
 				g.write_line('${value_type} ${fastc_c_identifier(name)} = ${temporaries[i]};')
-				g.locals[name] = FastcLocal{
+				g.set_scoped_local(name, FastcLocal{
 					is_mut: mutability[i]
-					typ:    value_type
-				}
+					typ: value_type
+				})
 			}
 		} else {
 			for i, name in names {
@@ -1250,10 +1251,10 @@ fn (mut g Parser) parse_parallel_assignment(initial_names []string, initial_mut 
 			c_name := fastc_c_identifier(name)
 			g.write_line('${component_type} ${c_name} = (${component_type}){0};')
 			g.write_line('memcpy(&${c_name}, ${temporary}.values[${i}].data, sizeof(${c_name}));')
-			g.locals[name] = FastcLocal{
+			g.set_scoped_local(name, FastcLocal{
 				is_mut: mutability[i]
-				typ:    component_type
-			}
+				typ: component_type
+			})
 		} else {
 			c_name := assignment_targets[i].source
 			g.write_line('memcpy(&${c_name}, ${temporary}.values[${i}].data, sizeof(${c_name}));')
@@ -1381,10 +1382,10 @@ fn (mut g Parser) parse_parallel_option_tuple(names []string, mutability []bool,
 			}
 			component_type := fastc_normalize_inferred_type(component_types[i])
 			g.write_line('${component_type} ${fastc_c_identifier(name)} = (${component_type}){0};')
-			g.locals[name] = FastcLocal{
+			g.set_scoped_local(name, FastcLocal{
 				is_mut: mutability[i]
-				typ:    component_type
-			}
+				typ: component_type
+			})
 		}
 	}
 	g.write_line('Option ${guard} = (${option_expr});')
@@ -1435,11 +1436,9 @@ fn (g &Parser) validate_parallel_assignment_targets(names []string) ![]FastcRend
 			}
 			target = FastcRenderedExpression{
 				source: if local.is_reference {
-					'(*${fastc_c_identifier(name)})'
-				} else {
-					fastc_c_identifier(name)
-				}
-				typ:    if local.is_reference { local.typ.trim_right('*') } else { local.typ }
+					'(*${fastc_c_identifier(name)})'} else {
+					fastc_c_identifier(name)}
+				typ: if local.is_reference { local.typ.trim_right('*') } else { local.typ }
 			}
 		} else {
 			global_key := fastc_global_key(g.module_name, name)
@@ -1448,7 +1447,7 @@ fn (g &Parser) validate_parallel_assignment_targets(names []string) ![]FastcRend
 			}
 			target = FastcRenderedExpression{
 				source: global_name
-				typ:    g.global_types[global_key]
+				typ: g.global_types[global_key]
 			}
 		}
 		targets << target
@@ -1458,16 +1457,14 @@ fn (g &Parser) validate_parallel_assignment_targets(names []string) ![]FastcRend
 
 fn (mut g Parser) parse_parallel_expression_assignment(first_source string, first_tokens []FastcExpressionToken, first_type string) ! {
 	mut targets := []FastcRenderedExpression{}
-	targets << g.validate_parallel_expression_assignment_target(first_source, first_tokens,
-		first_type)!
+	targets << g.validate_parallel_expression_assignment_target(first_source, first_tokens, first_type)!
 	for g.tok == .comma {
 		g.next()
 		target_source := g.read_expression([token.Token.comma, token.Token.assign])!
 		if target_source == '' {
 			return g.unsupported('empty parallel assignment target')
 		}
-		targets << g.validate_parallel_expression_assignment_target(target_source,
-			g.last_expression.clone(), g.last_expression_type)!
+		targets << g.validate_parallel_expression_assignment_target(target_source, g.last_expression.clone(), g.last_expression_type)!
 	}
 	if g.tok != .assign {
 		return g.unsupported('parallel assignment operator `${g.token_source()}`')
@@ -1529,7 +1526,7 @@ fn (g &Parser) validate_parallel_expression_assignment_target(source string, tok
 	g.validate_expression_mutation_lvalue(mutation_tokens)!
 	return FastcRenderedExpression{
 		source: source
-		typ:    typ
+		typ: typ
 	}
 }
 
@@ -1547,8 +1544,7 @@ fn (g &Parser) multi_return_types_for_expression(tokens []FastcExpressionToken) 
 	}
 	if expression_tokens.len >= 5 && expression_tokens.last().tok == .rpar {
 		for i := expression_tokens.len - 2; i >= 2; i-- {
-			if expression_tokens[i].tok != .name || expression_tokens[i - 1].tok != .dot
-				|| expression_tokens[i + 1].tok != .lpar {
+			if expression_tokens[i].tok != .name || expression_tokens[i - 1].tok != .dot || expression_tokens[i + 1].tok != .lpar {
 				continue
 			}
 			method_close := fastc_matching_rpar(expression_tokens, i + 1) or { continue }
@@ -1576,21 +1572,18 @@ fn (g &Parser) multi_return_types_for_expression(tokens []FastcExpressionToken) 
 	}
 	mut name_index := 0
 	mut open_index := 1
-	if expression_tokens.len >= 4 && expression_tokens[0].tok == .name
-		&& expression_tokens[1].tok == .dot && expression_tokens[2].tok == .name {
+	if expression_tokens.len >= 4 && expression_tokens[0].tok == .name && expression_tokens[1].tok == .dot && expression_tokens[2].tok == .name {
 		name_index = 2
 		open_index = 3
 	}
-	if expression_tokens[name_index].tok !in [.name, .key_select]
-		|| expression_tokens[open_index].tok != .lpar {
+	if expression_tokens[name_index].tok !in [.name, .key_select] || expression_tokens[open_index].tok != .lpar {
 		return []string{}
 	}
 	close := fastc_matching_rpar(expression_tokens, open_index) or { return []string{} }
 	if close != expression_tokens.len - 1 {
 		return []string{}
 	}
-	function_key := if name_index == 2 && expression_tokens[0].lit !in g.imports
-		&& expression_tokens[0].lit != 'C' {
+	function_key := if name_index == 2 && expression_tokens[0].lit !in g.imports && expression_tokens[0].lit != 'C' {
 		receiver_type := g.infer_expression_type(expression_tokens[..1]) or { return []string{} }
 		g.method_function_key(receiver_type, expression_tokens[name_index].lit)
 	} else {
@@ -1746,8 +1739,7 @@ fn (g &Parser) erased_generic_option_value_type_for_expression(tokens []FastcExp
 		}
 		receiver_start := fastc_method_receiver_start(tokens, i - 1)
 		receiver_tokens := tokens[receiver_start..i - 1]
-		if receiver_tokens.len < 3 || receiver_tokens.last().tok != .name
-			|| receiver_tokens[receiver_tokens.len - 2].tok != .dot {
+		if receiver_tokens.len < 3 || receiver_tokens.last().tok != .name || receiver_tokens[receiver_tokens.len - 2].tok != .dot {
 			return none
 		}
 		owner_type := g.infer_expression_type(receiver_tokens[..receiver_tokens.len - 2]) or {
@@ -1823,8 +1815,7 @@ fn (g &Parser) expression_tokens_are_statement(expression_tokens []FastcExpressi
 				return true
 			}
 			resolved_method_key, _ := g.resolve_method(receiver_type, tokens[i].lit)
-			if resolved_method_key in g.functions || resolved_method_key in g.mono_functions
-				|| g.struct_member_type(receiver_type, tokens[i].lit) != '' {
+			if resolved_method_key in g.functions || resolved_method_key in g.mono_functions || g.struct_member_type(receiver_type, tokens[i].lit) != '' {
 				return true
 			}
 		}
@@ -1834,13 +1825,11 @@ fn (g &Parser) expression_tokens_are_statement(expression_tokens []FastcExpressi
 	}
 	mut name_index := 0
 	mut open_index := 1
-	if tokens.len >= 4 && tokens[0].tok == .name && tokens[1].tok == .dot && tokens[2].tok == .name
-		&& (tokens[0].lit in g.imports || (tokens[0].lit == 'C' && g.has_declared_c_function())) {
+	if tokens.len >= 4 && tokens[0].tok == .name && tokens[1].tok == .dot && tokens[2].tok == .name && (tokens[0].lit in g.imports || (tokens[0].lit == 'C' && g.has_declared_c_function())) {
 		name_index = 2
 		open_index = 3
 	}
-	if tokens.len <= open_index + 1 || tokens[name_index].tok !in [.name, .key_select]
-		|| tokens[open_index].tok != .lpar {
+	if tokens.len <= open_index + 1 || tokens[name_index].tok !in [.name, .key_select] || tokens[open_index].tok != .lpar {
 		return false
 	}
 	call_close := fastc_matching_rpar(tokens, open_index) or { return false }
@@ -1900,13 +1889,13 @@ fn (mut g Parser) parse_declaration_after_name(name string, is_mut bool) ! {
 		fastc_normalize_inferred_type(g.last_expression_type)
 	}
 	function_alias := g.functions[local_type] or { FastcFunctionSignature{} }
-	g.locals[name] = FastcLocal{
-		is_mut:               is_mut
-		typ:                  local_type
-		option_value_type:    option_value_type
-		fn_return_type:       function_alias.return_type
+	g.set_scoped_local(name, FastcLocal{
+		is_mut: is_mut
+		typ: local_type
+		option_value_type: option_value_type
+		fn_return_type: function_alias.return_type
 		fn_option_value_type: function_alias.option_type
-	}
+	})
 }
 
 fn fastc_normalize_inferred_type(typ string) string {
@@ -2793,8 +2782,7 @@ fn (mut g Parser) parse_orm_sql_select_declaration(name string, is_mut bool) ! {
 	g.next()
 	db_source, block_source, trailing := g.capture_orm_sql_block()!
 	or_source := g.capture_orm_or_block()!
-	lowering, result_type := g.build_orm_select_lowering(db_source, block_source, trailing,
-		or_source)!
+	lowering, result_type := g.build_orm_select_lowering(db_source, block_source, trailing, or_source)!
 	g.consume_statement_end()
 	// The `[]<Table>` result array is often not otherwise constructed in the program,
 	// so register it as a composite type to force its `Array_<Table>` typedef.
@@ -2807,10 +2795,10 @@ fn (mut g Parser) parse_orm_sql_select_declaration(name string, is_mut bool) ! {
 	g.write_line('${c_name} = __orm_result;')
 	g.indent--
 	g.write_line('}')
-	g.locals[name] = FastcLocal{
+	g.set_scoped_local(name, FastcLocal{
 		is_mut: is_mut
-		typ:    result_type
-	}
+		typ: result_type
+	})
 }
 
 // parse_orm_sql_select_assignment lowers `<name> = sql db { select ... } <unwrap>`
@@ -2823,8 +2811,7 @@ fn (mut g Parser) parse_orm_sql_select_assignment(name string) ! {
 	g.next() // consume `sql`
 	db_source, block_source, trailing := g.capture_orm_sql_block()!
 	or_source := g.capture_orm_or_block()!
-	lowering, result_type := g.build_orm_select_lowering(db_source, block_source, trailing,
-		or_source)!
+	lowering, result_type := g.build_orm_select_lowering(db_source, block_source, trailing, or_source)!
 	g.consume_statement_end()
 	fastc_register_composite_type(result_type, mut g.composite_types)
 	c_name := fastc_c_identifier(name)
@@ -2845,8 +2832,7 @@ fn (mut g Parser) parse_orm_sql_select_return() !bool {
 	g.next() // consume `sql`
 	db_source, block_source, trailing := g.capture_orm_sql_block()!
 	or_source := g.capture_orm_or_block()!
-	lowering, result_type := g.build_orm_select_lowering(db_source, block_source, trailing,
-		or_source)!
+	lowering, result_type := g.build_orm_select_lowering(db_source, block_source, trailing, or_source)!
 	g.consume_statement_end()
 	g.write_line('{')
 	g.indent++

--- a/vlib/v3/gen/fastc/types.v
+++ b/vlib/v3/gen/fastc/types.v
@@ -251,11 +251,11 @@ fn (g &Parser) infer_boolean_binary_expression_type(tokens []FastcExpressionToke
 		if array_end - operator_index - 1 >= 2 && tokens[operator_index + 1].tok == .lsbr && tokens[array_end - 1].tok == .rsbr {
 			return 'bool'
 		}
-		if right_type.trim_right('*').starts_with('Map_') {
+		if fastc_trim_pointer_suffix(right_type).starts_with('Map_') {
 			_, _ := g.map_key_value_types(right_type) or {
 				return g.unsupported('membership `${operator.str()}` with unverifiable map type `${right_type}`')
 			}
-		} else if right_type.trim_right('*') == 'string' {
+		} else if fastc_trim_pointer_suffix(right_type) == 'string' {
 		} else {
 			_ := g.array_element_type(right_type) or {
 				return g.unsupported('membership `${operator.str()}` in non-collection type `${right_type}`')
@@ -273,8 +273,8 @@ fn (g &Parser) infer_boolean_binary_expression_type(tokens []FastcExpressionToke
 			left_type = right_type
 		}
 		if !fastc_is_pointer_type(left_type) && !fastc_is_pointer_type(right_type) {
-			left_layout := g.underlying_alias_type(left_type).trim_right('*')
-			right_layout := g.underlying_alias_type(right_type).trim_right('*')
+			left_layout := fastc_trim_pointer_suffix(g.underlying_alias_type(left_type))
+			right_layout := fastc_trim_pointer_suffix(g.underlying_alias_type(right_type))
 			left_key := g.semantic_type_key(left_layout)
 			if left_layout == right_layout && left_layout !in ['Option', '_option', '_result'] && left_key in g.declared_kinds && g.declared_kinds[left_key] == .struct_ && !g.struct_equality_is_supported(left_type, []string{}) {
 				return g.unsupported('struct equality for `${left_type}` with unsupported fields')
@@ -340,28 +340,6 @@ fn (g &Parser) infer_expression_type_range(tokens []FastcExpressionToken, expres
 	if start >= end {
 		return ''
 	}
-	if end - start == 1 && tokens[start].tok == .name && tokens[start].typ != '' && tokens[start].source != '' {
-		// A synthetic token carrying its own rendered `source` and recorded `typ` (e.g. an
-		// or-unwrap `({ ... })` produced for `(expr or {…}).method()`): trust its recorded
-		// type rather than looking the name up as a local variable.
-		return tokens[start].typ
-	}
-	if end - start >= 4 && tokens[start].tok == .key_sizeof && tokens[start + 1].tok == .lpar && tokens[end - 1].tok == .rpar {
-		return 'int'
-	}
-	if reflection_type := fastc_typeof_generic_field_type(tokens, start, end) {
-		return reflection_type
-	}
-	if c_field_type := g.infer_c_pointer_cast_member_type(tokens, start, end) {
-		return c_field_type
-	}
-	if tokens[start].tok == .not {
-		_ = g.infer_expression_type_range(tokens, start + 1, end)!
-		return 'bool'
-	}
-	if operator_index := fastc_lowest_precedence_operator_index(tokens, start, end) {
-		return g.infer_boolean_binary_expression_type(tokens, start, end, operator_index)!
-	}
 	if end - start == 1 {
 		item := tokens[start]
 		if item.typ != '' {
@@ -415,6 +393,26 @@ fn (g &Parser) infer_expression_type_range(tokens []FastcExpressionToken, expres
 				''
 			}
 		}
+	}
+	if end - start >= 4 && tokens[start].tok == .key_sizeof && tokens[start + 1].tok == .lpar && tokens[end - 1].tok == .rpar {
+		return 'int'
+	}
+	if end - start >= 8 && tokens[start].lit == 'typeof' {
+		if reflection_type := fastc_typeof_generic_field_type(tokens, start, end) {
+			return reflection_type
+		}
+	}
+	if end - start >= 9 && tokens[start].tok in [.amp, .and] {
+		if c_field_type := g.infer_c_pointer_cast_member_type(tokens, start, end) {
+			return c_field_type
+		}
+	}
+	if tokens[start].tok == .not {
+		_ = g.infer_expression_type_range(tokens, start + 1, end)!
+		return 'bool'
+	}
+	if operator_index := fastc_lowest_precedence_operator_index(tokens, start, end) {
+		return g.infer_boolean_binary_expression_type(tokens, start, end, operator_index)!
 	}
 	if end - start == 2 && tokens[start].tok == .dot && tokens[start + 1].typ != '' {
 		return tokens[start + 1].typ
@@ -625,7 +623,7 @@ fn (g &Parser) infer_expression_type_range(tokens []FastcExpressionToken, expres
 	}
 	if tokens[start].tok == .mul {
 		operand_type := g.infer_expression_type_range(tokens, start + 1, end)!
-		return operand_type.trim_right('*')
+		return fastc_trim_pointer_suffix(operand_type)
 	}
 	if tokens[start].tok == .bit_not {
 		operand_type := g.infer_expression_type_range(tokens, start + 1, end)!
@@ -658,20 +656,21 @@ fn (g &Parser) infer_expression_type_range(tokens []FastcExpressionToken, expres
 		}
 		if open_index > start {
 			base_type := g.infer_expression_type_range(tokens, start, open_index)!
+			base_layout := fastc_trim_pointer_suffix(base_type)
 			if fastc_expression_tokens_contain(tokens[open_index + 1..end - 1], .dotdot) {
 				// Slicing a fixed array yields a dynamic array of its element type.
-				if base_type.trim_right('*').starts_with('FixedArray_') {
-					if element := g.array_element_type(base_type.trim_right('*')) {
+				if base_layout.starts_with('FixedArray_') {
+					if element := g.array_element_type(base_layout) {
 						return fastc_array_c_type(fastc_normalize_inferred_type(element))
 					}
 				}
 				return base_type
 			}
-			if base_type.trim_right('*').starts_with('Map_') {
+			if base_layout.starts_with('Map_') {
 				_, value_type := g.map_key_value_types(base_type) or { return '' }
 				return value_type
 			}
-			if base_type.trim_right('*') == 'string' {
+			if base_layout == 'string' {
 				return 'u8'
 			}
 			if element_type := g.array_element_type(base_type) {
@@ -730,7 +729,7 @@ fn (g &Parser) infer_expression_type_range(tokens []FastcExpressionToken, expres
 			if right_element := g.indexed_array_operand_type(tokens, i + 1, end, right_type) {
 				right_type = right_element
 			}
-			if tokens[i].tok == .plus && g.underlying_alias_type(left_type).trim_right('*') == 'string' && g.underlying_alias_type(right_type).trim_right('*') == 'string' {
+			if tokens[i].tok == .plus && fastc_trim_pointer_suffix(g.underlying_alias_type(left_type)) == 'string' && fastc_trim_pointer_suffix(g.underlying_alias_type(right_type)) == 'string' {
 				return 'string'
 			}
 			if g.selfhost && tokens[i].tok == .plus && ((left_type == 'string' && right_type == '') || (right_type == 'string' && left_type == '')) {
@@ -847,19 +846,20 @@ fn (g &Parser) infer_member_access_type(tokens []FastcExpressionToken, start int
 			close := fastc_matching_delimiter_before(tokens, index, end, .lsbr, .rsbr) or {
 				return none
 			}
+			current_layout := fastc_trim_pointer_suffix(current_type)
 			if fastc_expression_tokens_contain_range(tokens, index + 1, close, .dotdot) {
-				if current_type.trim_right('*') != 'string' && g.array_element_type(current_type) == none {
+				if current_layout != 'string' && g.array_element_type(current_type) == none {
 					return none
 				}
 				// A fixed-array slice becomes a dynamic array of its element type.
-				if current_type.trim_right('*').starts_with('FixedArray_') {
-					if element := g.array_element_type(current_type.trim_right('*')) {
+				if current_layout.starts_with('FixedArray_') {
+					if element := g.array_element_type(current_layout) {
 						current_type = fastc_array_c_type(fastc_normalize_inferred_type(element))
 					}
 				}
-			} else if current_type.trim_right('*') == 'string' {
+			} else if current_layout == 'string' {
 				current_type = 'u8'
-			} else if current_type.trim_right('*').starts_with('Map_') {
+			} else if current_layout.starts_with('Map_') {
 				_, value_type := g.map_key_value_types(current_type) or { return none }
 				current_type = value_type
 			} else if element_type := g.array_element_type(current_type) {
@@ -911,8 +911,16 @@ fn fastc_matching_delimiter_before(tokens []FastcExpressionToken, open_index int
 	return none
 }
 
+@[inline]
+fn fastc_trim_pointer_suffix(typ string) string {
+	if typ.len == 0 || typ[typ.len - 1] != `*` {
+		return typ
+	}
+	return typ.trim_right('*')
+}
+
 fn (g &Parser) semantic_type_key(c_type string) string {
-	base := c_type.trim_right('*')
+	base := fastc_trim_pointer_suffix(c_type)
 	if key := g.declared_type_c_names[base] {
 		return key
 	}
@@ -924,13 +932,13 @@ fn (g &Parser) underlying_alias_type(c_type string) string {
 	// allocating the cycle-guard map. underlying_alias_type is called for
 	// nearly every inferred expression type; the unconditional map allocation
 	// showed up as a hot allocation site under -prealloc.
-	base0 := c_type.trim_right('*')
+	base0 := fastc_trim_pointer_suffix(c_type)
 	first := g.alias_base_types[base0] or { return c_type }
 	mut resolved := first + c_type[base0.len..]
 	mut seen := map[string]bool{}
 	seen[base0] = true
 	for {
-		base := resolved.trim_right('*')
+		base := fastc_trim_pointer_suffix(resolved)
 		if base in seen {
 			return resolved
 		}
@@ -1041,8 +1049,8 @@ fn fastc_selfhost_types_share_lowering_representation(actual string, expected st
 	if actual == expected + '*' || expected == actual + '*' {
 		return true
 	}
-	actual_base := actual.trim_right('*')
-	expected_base := expected.trim_right('*')
+	actual_base := fastc_trim_pointer_suffix(actual)
+	expected_base := fastc_trim_pointer_suffix(expected)
 	if (actual_base == 'array' && expected_base.starts_with('Array_')) || (expected_base == 'array' && actual_base.starts_with('Array_')) || (actual_base == 'map' && expected_base.starts_with('Map_')) || (expected_base == 'map' && actual_base.starts_with('Map_')) {
 		return true
 	}
@@ -1079,7 +1087,7 @@ fn fastc_is_pointer_type(typ string) bool {
 }
 
 fn fastc_array_element_type(typ string) ?string {
-	base := typ.trim_right('*')
+	base := fastc_trim_pointer_suffix(typ)
 	if base.starts_with('Array_') && base.len > 'Array_'.len {
 		return fastc_decode_ptr_element_type(base['Array_'.len..])
 	}
@@ -1112,7 +1120,7 @@ fn (g &Parser) array_element_type(typ string) ?string {
 	if element_type := fastc_array_element_type(typ) {
 		return element_type
 	}
-	layout_type := typ.trim_right('*')
+	layout_type := fastc_trim_pointer_suffix(typ)
 	if fields := g.struct_fields[layout_type] {
 		return fields['__fastc_element_type'] or { none }
 	}

--- a/vlib/v3/gen/fastc/validate.v
+++ b/vlib/v3/gen/fastc/validate.v
@@ -37,6 +37,7 @@ fn (g &Parser) expression_token(previous token.Token, previous_lit string, quali
 				g.unsupported('rune or C character literals')
 			}
 		}
+
 		// stdbool's true/false macros have C type int. Cast them so _Generic
 		// dispatch preserves V's bool type when no operator requires promotion.
 		.key_true {
@@ -78,6 +79,9 @@ fn (g &Parser) nil_expression() !string {
 }
 
 fn (g &Parser) expression_name(previous token.Token, qualified_name_owner string) !string {
+	if g.selfhost {
+		return g.resolved_expression_name(g.lit, previous)
+	}
 	if previous == .dot {
 		if imported_module := g.imports[qualified_name_owner] {
 			type_key := fastc_type_key(imported_module, g.lit)
@@ -114,8 +118,7 @@ fn (g &Parser) resolved_expression_name(name string, previous token.Token) strin
 		if function_key in g.functions {
 			return fastc_c_function_name_for_key(function_key)
 		}
-		if type_key := g.resolve_declared_type_key(name)
-		{
+		if type_key := g.resolve_declared_type_key(name) {
 			return fastc_c_declared_type_name(type_key)
 		}
 		if primitive := fastc_primitive_c_type(name) {
@@ -140,29 +143,47 @@ fn (g &Parser) resolved_expression_name(name string, previous token.Token) strin
 }
 
 fn (g &Parser) validate_expression_name(name string, previous token.Token) ! {
-	if g.selfhost && previous in [.lcbr, .comma, .semicolon] {
+	// Self-host sources have already passed the bootstrap compiler. Their unresolved
+	// names are deliberately left for C to diagnose, so none of the lookup work below
+	// can change the result.
+	if g.selfhost {
 		return
 	}
-	if !g.selfhost && name == 'charptr' {
+	if name == 'charptr' {
 		return g.unsupported('charptr expressions')
 	}
-	if !g.selfhost && name == 'rune' {
+	if name == 'rune' {
 		return g.unsupported('rune expressions')
 	}
 	function_key := g.unqualified_function_key(name)
 	constant_key := fastc_constant_key(g.module_name, name)
 	global_key := fastc_global_key(g.module_name, name)
-	if previous == .dot || (name == 'C' && g.has_declared_c_function())
-		|| name in g.locals || name in g.imports || function_key in g.functions
-		|| constant_key in g.constants || global_key in g.globals
-		|| g.resolve_declared_type_key(name) != none
-		|| name in ['print', 'println', 'bool', 'byte', 'char', 'f32', 'f64', 'i8', 'i16', 'i32', 'i64', 'int', 'isize', 'rune', 'string', 'u8', 'u16', 'u32', 'u64', 'uint', 'usize', 'voidptr', 'byteptr', 'charptr'] {
-		return
-	}
-	if g.selfhost {
-		// Self-host sources have already passed the bootstrap compiler. Preserve
-		// streaming progress for names introduced by syntax whose scope is not yet
-		// represented in the direct parser; C still diagnoses a missing declaration.
+	if previous == .dot || (name == 'C' && g.has_declared_c_function()) || name in g.locals || name in g.imports || function_key in g.functions || constant_key in g.constants || global_key in g.globals || g.resolve_declared_type_key(name) != none || name in [
+		'print',
+		'println',
+		'bool',
+		'byte',
+		'char',
+		'f32',
+		'f64',
+		'i8',
+		'i16',
+		'i32',
+		'i64',
+		'int',
+		'isize',
+		'rune',
+		'string',
+		'u8',
+		'u16',
+		'u32',
+		'u64',
+		'uint',
+		'usize',
+		'voidptr',
+		'byteptr',
+		'charptr',
+	] {
 		return
 	}
 	return g.unsupported('unresolved name `${name}` (locals: ${g.locals.keys().join(', ')})')
@@ -185,16 +206,15 @@ fn fastc_functions_declare_c(functions map[string]FastcFunctionSignature) bool {
 }
 
 fn (g &Parser) function_key_for_call(tokens []FastcExpressionToken, name_index int) string {
-	if static_key := g.static_function_key_for_call(tokens, name_index) {
-		return static_key
-	}
 	if name_index >= 2 && tokens[name_index - 1].tok == .dot && tokens[name_index - 2].tok == .name {
+		if static_key := g.static_function_key_for_call(tokens, name_index) {
+			return static_key
+		}
 		if tokens[name_index - 2].lit == 'C' {
 			return 'C.${tokens[name_index].lit}'
 		}
 		if imported_module := g.imports[tokens[name_index - 2].lit] {
-			return fastc_function_key(g.resolve_module_alias(imported_module),
-				tokens[name_index].lit)
+			return fastc_function_key(g.resolve_module_alias(imported_module), tokens[name_index].lit)
 		}
 	}
 	return g.unqualified_function_key(tokens[name_index].lit)
@@ -213,6 +233,9 @@ fn (g &Parser) static_function_key_for_call(tokens []FastcExpressionToken, name_
 		return none
 	}
 	owner_name := tokens[name_index - 2].lit
+	if owner_name.len == 0 || !owner_name[0].is_capital() {
+		return none
+	}
 	mut type_key := ''
 	if name_index >= 4 && tokens[name_index - 3].tok == .dot && tokens[name_index - 4].tok == .name {
 		module_name := g.imports[tokens[name_index - 4].lit] or { return none }
@@ -250,13 +273,11 @@ fn (g &Parser) flag_enum_type_key(c_type string) ?string {
 }
 
 fn (g &Parser) enum_member_owner_type_key(tokens []FastcExpressionToken, owner_index int) ?string {
-	if owner_index < 0 || owner_index + 2 >= tokens.len || tokens[owner_index].tok != .name
-		|| tokens[owner_index + 1].tok != .dot || tokens[owner_index + 2].tok != .name {
+	if owner_index < 0 || owner_index + 2 >= tokens.len || tokens[owner_index].tok != .name || tokens[owner_index + 1].tok != .dot || tokens[owner_index + 2].tok != .name {
 		return none
 	}
 	mut type_key := ''
-	if owner_index >= 2 && tokens[owner_index - 1].tok == .dot
-		&& tokens[owner_index - 2].tok == .name {
+	if owner_index >= 2 && tokens[owner_index - 1].tok == .dot && tokens[owner_index - 2].tok == .name {
 		imported_module := g.imports[tokens[owner_index - 2].lit] or { return none }
 		type_key = fastc_type_key(imported_module, tokens[owner_index].lit)
 	} else if owner_index > 0 && tokens[owner_index - 1].tok == .dot {
@@ -326,9 +347,7 @@ fn (g &Parser) validate_expression_calls(tokens []FastcExpressionToken) ! {
 		// e.g. `c.ssl.set_read_timeout()` where `ssl` is both a field and `import net.ssl`)
 		// is a real method call, so the import exclusion must not apply when the name is
 		// itself preceded by a `.` (a member access).
-		name_is_module_ref := i >= 2 && tokens[i - 2].tok == .name
-			&& (tokens[i - 2].lit in g.imports || tokens[i - 2].lit == 'C')
-			&& (i < 3 || tokens[i - 3].tok != .dot)
+		name_is_module_ref := i >= 2 && tokens[i - 2].tok == .name && (tokens[i - 2].lit in g.imports || tokens[i - 2].lit == 'C') && (i < 3 || tokens[i - 3].tok != .dot)
 		if !is_static_call && i >= 2 && tokens[i - 1].tok == .dot && !name_is_module_ref {
 			receiver_start := fastc_method_receiver_start(tokens, i - 1)
 			receiver_type = g.infer_expression_type(tokens[receiver_start..i - 1])!
@@ -347,8 +366,7 @@ fn (g &Parser) validate_expression_calls(tokens []FastcExpressionToken) ! {
 		}
 		// A primitive type name applied to a single argument is a cast (`u32(1)`),
 		// never a call — even when a same-named function exists (e.g. `rand.u32()`).
-		if call_args.len == 1 && !is_method_call && !is_static_call
-			&& (i == 0 || tokens[i - 1].tok != .dot) && fastc_primitive_c_type(name) != none {
+		if call_args.len == 1 && !is_method_call && !is_static_call && (i == 0 || tokens[i - 1].tok != .dot) && fastc_primitive_c_type(name) != none {
 			i = call_end + 1
 			continue
 		}
@@ -373,9 +391,7 @@ fn (g &Parser) validate_expression_calls(tokens []FastcExpressionToken) ! {
 			} else {
 				g.mono_functions[function_key]
 			}
-			if !signature.is_public && signature.module_name != ''
-				&& signature.module_name != g.module_name && signature.module_name != 'builtin'
-				&& signature.module_name in g.imports.values() {
+			if !signature.is_public && signature.module_name != '' && signature.module_name != g.module_name && signature.module_name != 'builtin' && signature.module_name in g.imports.values() {
 				return g.unsupported('private function `${name}` from imported module `${signature.module_name}`')
 			}
 			argument_offset := if is_method_call { 1 } else { 0 }
@@ -385,8 +401,7 @@ fn (g &Parser) validate_expression_calls(tokens []FastcExpressionToken) ! {
 			} else {
 				0
 			}
-			omits_params_struct := signature.last_parameter_is_params && expected_arguments > 0
-				&& call_args.len == expected_arguments - 1
+			omits_params_struct := signature.last_parameter_is_params && expected_arguments > 0 && call_args.len == expected_arguments - 1
 			// Trailing named arguments (`name: value`) at the last params-struct
 			// position collapse into one struct initializer, so they read as one arg.
 			mut named_argument_start := -1
@@ -398,27 +413,20 @@ fn (g &Parser) validate_expression_calls(tokens []FastcExpressionToken) ! {
 			}
 			// Trailing named args collapse into the callee's last struct parameter — V allows
 			// this for any struct last-parameter (`time.new(year: ...)`), not just `@[params]`.
-			provides_params_struct := expected_arguments > 0
-				&& named_argument_start == expected_arguments - 1
-				&& (signature.last_parameter_is_params
-				|| g.fastc_type_is_declared_struct(signature.parameter_types[named_argument_start + argument_offset]))
+			provides_params_struct := expected_arguments > 0 && named_argument_start == expected_arguments - 1 && (signature.last_parameter_is_params || g.fastc_type_is_declared_struct(signature.parameter_types[named_argument_start + argument_offset]))
 			uses_default_array_sort := function_key == 'array.sort' && call_args.len == 0
-			if (!is_variadic && call_args.len != expected_arguments && !omits_params_struct
-				&& !provides_params_struct && !uses_default_array_sort)
-				|| (is_variadic && call_args.len < expected_arguments) {
+			if (!is_variadic && call_args.len != expected_arguments && !omits_params_struct && !provides_params_struct && !uses_default_array_sort) || (is_variadic && call_args.len < expected_arguments) {
 				return g.unsupported('function `${name}` call with ${call_args.len} arguments instead of ${expected_arguments}')
 			}
 			if is_method_call && signature.parameter_types.len > 0 {
-				receiver_is_mut := signature.parameter_mutability.len > 0
-					&& signature.parameter_mutability[0]
+				receiver_is_mut := signature.parameter_mutability.len > 0 && signature.parameter_mutability[0]
 				if receiver_is_mut {
 					receiver_start := fastc_method_receiver_start(tokens, i - 1)
 					g.validate_mutating_method_receiver(tokens[receiver_start..i - 1], name)!
 				}
 			}
 			for argument_index, argument in call_args {
-				if is_variadic && argument_index >= expected_arguments
-					&& function_key.starts_with('C.') {
+				if is_variadic && argument_index >= expected_arguments && function_key.starts_with('C.') {
 					continue
 				}
 				is_variadic_argument := is_variadic && argument_index >= expected_arguments
@@ -427,8 +435,7 @@ fn (g &Parser) validate_expression_calls(tokens []FastcExpressionToken) ! {
 				} else {
 					argument_index + argument_offset
 				}
-				parameter_is_mut := parameter_index < signature.parameter_mutability.len
-					&& signature.parameter_mutability[parameter_index]
+				parameter_is_mut := parameter_index < signature.parameter_mutability.len && signature.parameter_mutability[parameter_index]
 				argument_is_mut := fastc_argument_is_marked_mut(argument)
 				if parameter_is_mut && !argument_is_mut {
 					return g.unsupported('function `${name}` parameter ${argument_index + 1} requires a mutable argument written with `mut`')
@@ -446,8 +453,7 @@ fn (g &Parser) validate_expression_calls(tokens []FastcExpressionToken) ! {
 					g.validate_mutable_argument_fields(argument, name, argument_index)!
 				}
 			}
-		} else if has_method_receiver && name in ['has', 'set', 'clear'] && call_args.len == 1
-			&& g.flag_enum_type_key(receiver_type) != none {
+		} else if has_method_receiver && name in ['has', 'set', 'clear'] && call_args.len == 1 && g.flag_enum_type_key(receiver_type) != none {
 			if name in ['set', 'clear'] {
 				receiver_start := fastc_method_receiver_start(tokens, i - 1)
 				g.validate_mutating_method_receiver(tokens[receiver_start..i - 1], name)!
@@ -463,8 +469,7 @@ fn (g &Parser) validate_expression_calls(tokens []FastcExpressionToken) ! {
 				return g.unsupported('printing value of type `${argument_type}`')
 			}
 		} else {
-			if g.selfhost && i >= 2 && tokens[i - 2].tok == .name && tokens[i - 2].lit == 'C'
-				&& tokens[i - 1].tok == .dot {
+			if g.selfhost && i >= 2 && tokens[i - 2].tok == .name && tokens[i - 2].lit == 'C' && tokens[i - 1].tok == .dot {
 				i = call_end + 1
 				continue
 			}
@@ -497,8 +502,7 @@ fn (g &Parser) validate_expression_calls(tokens []FastcExpressionToken) ! {
 				i = call_end + 1
 				continue
 			}
-			if g.selfhost && has_method_receiver && name == 'str' && call_args.len == 0
-				&& g.can_generate_default_struct_str(receiver_type) {
+			if g.selfhost && has_method_receiver && name == 'str' && call_args.len == 0 && g.can_generate_default_struct_str(receiver_type) {
 				i = call_end + 1
 				continue
 			}
@@ -576,8 +580,7 @@ fn (g &Parser) validate_mutating_method_receiver(receiver []FastcExpressionToken
 			}
 			else {}
 		}
-		if selector_depth != 0 || item.tok != .dot || i == 0 || i + 1 >= receiver.len
-			|| receiver[i + 1].tok != .name || g.expression_dot_is_module_separator(receiver, i) {
+		if selector_depth != 0 || item.tok != .dot || i == 0 || i + 1 >= receiver.len || receiver[i + 1].tok != .name || g.expression_dot_is_module_separator(receiver, i) {
 			continue
 		}
 		receiver_start := fastc_method_receiver_start(receiver, i)
@@ -604,8 +607,7 @@ fn (g &Parser) validate_mutable_argument_fields(argument []FastcExpressionToken,
 			}
 			else {}
 		}
-		if selector_depth != 0 || item.tok != .dot || i == 0 || i + 1 >= argument.len
-			|| argument[i + 1].tok != .name || g.expression_dot_is_module_separator(argument, i) {
+		if selector_depth != 0 || item.tok != .dot || i == 0 || i + 1 >= argument.len || argument[i + 1].tok != .name || g.expression_dot_is_module_separator(argument, i) {
 			continue
 		}
 		receiver_start := fastc_method_receiver_start(argument, i)
@@ -613,8 +615,7 @@ fn (g &Parser) validate_mutable_argument_fields(argument []FastcExpressionToken,
 		field := g.struct_field_metadata(receiver_type, argument[i + 1].lit) or { continue }
 		if field.module_name !in ['', g.module_name] && !field.is_mutable {
 			type_name := g.semantic_type_key(receiver_type).all_after_last('.')
-			return g.unsupported('mutable argument field `${type_name}.${field.name}` to function `${function_name}` parameter ${
-				argument_index + 1} is not `pub mut` in imported module `${field.module_name}`')
+			return g.unsupported('mutable argument field `${type_name}.${field.name}` to function `${function_name}` parameter ${argument_index + 1} is not `pub mut` in imported module `${field.module_name}`')
 		}
 	}
 }
@@ -637,8 +638,7 @@ fn (g &Parser) validate_interface_cast_shape(interface_key string, operand []Fas
 			continue
 		}
 		interface_signature := g.functions[interface_method_key]
-		if interface_signature.parameter_types.len == 0
-			|| interface_signature.parameter_types[0] != interface_type {
+		if interface_signature.parameter_types.len == 0 || interface_signature.parameter_types[0] != interface_type {
 			continue
 		}
 		method_name := interface_method_key.all_after_last('.')
@@ -652,13 +652,10 @@ fn (g &Parser) validate_interface_cast_shape(interface_key string, operand []Fas
 			return g.unsupported('type `${actual_type}` has an incompatible parameter count for interface `${interface_type}` method `${method_name}`')
 		}
 		for i in 0 .. interface_signature.parameter_types.len {
-			interface_parameter_is_mut := i < interface_signature.parameter_mutability.len
-				&& interface_signature.parameter_mutability[i]
-			candidate_parameter_is_mut := i < candidate_signature.parameter_mutability.len
-				&& candidate_signature.parameter_mutability[i]
+			interface_parameter_is_mut := i < interface_signature.parameter_mutability.len && interface_signature.parameter_mutability[i]
+			candidate_parameter_is_mut := i < candidate_signature.parameter_mutability.len && candidate_signature.parameter_mutability[i]
 			if candidate_parameter_is_mut != interface_parameter_is_mut {
-				return g.unsupported('type `${actual_type}` has incompatible mutability for interface `${interface_type}` method `${method_name}` parameter ${
-					i + 1}')
+				return g.unsupported('type `${actual_type}` has incompatible mutability for interface `${interface_type}` method `${method_name}` parameter ${i + 1}')
 			}
 		}
 	}
@@ -672,8 +669,7 @@ fn (g &Parser) validate_interface_cast_shape(interface_key string, operand []Fas
 			continue
 		}
 		required_field := g.interface_fields[field_key]
-		actual_field := g.interface_implementation_field(actual_type, actual_key,
-			required_field.name) or {
+		actual_field := g.interface_implementation_field(actual_type, actual_key, required_field.name) or {
 			return g.unsupported('type `${actual_type}` does not implement interface `${interface_type}` field `${required_field.name}`')
 		}
 		if required_field.is_mutable && !actual_field.is_mutable {
@@ -688,20 +684,18 @@ fn (g &Parser) interface_implementation_field(actual_type string, actual_key str
 	}
 	field := g.struct_field_metadata(actual_type, field_name) or { return none }
 	return FastcInterfaceField{
-		name:       field.name
-		typ:        field.typ
+		name: field.name
+		typ: field.typ
 		is_mutable: field.is_mutable
 	}
 }
 
 fn fastc_expression_is_zero(tokens []FastcExpressionToken) bool {
-	return tokens.len == 1 && tokens[0].tok == .number
-		&& tokens[0].lit.replace('_', '').trim_left('0') == ''
+	return tokens.len == 1 && tokens[0].tok == .number && tokens[0].lit.replace('_', '').trim_left('0') == ''
 }
 
 fn fastc_expression_is_c_qualified_name(tokens []FastcExpressionToken) bool {
-	return tokens.len == 3 && tokens[0].tok == .name && tokens[0].lit == 'C'
-		&& tokens[1].tok == .dot && tokens[2].tok == .name
+	return tokens.len == 3 && tokens[0].tok == .name && tokens[0].lit == 'C' && tokens[1].tok == .dot && tokens[2].tok == .name
 }
 
 fn fastc_expression_is_enum_shorthand(tokens []FastcExpressionToken) bool {
@@ -762,8 +756,7 @@ fn (g &Parser) validate_expression_mutation_lvalue(tokens []FastcExpressionToken
 			}
 			else {}
 		}
-		if selector_depth != 0 || item.tok != .dot || i == 0 || i + 1 >= lvalue.len
-			|| lvalue[i + 1].tok != .name || g.expression_dot_is_module_separator(lvalue, i) {
+		if selector_depth != 0 || item.tok != .dot || i == 0 || i + 1 >= lvalue.len || lvalue[i + 1].tok != .name || g.expression_dot_is_module_separator(lvalue, i) {
 			continue
 		}
 		receiver_start := fastc_method_receiver_start(lvalue, i)
@@ -782,7 +775,7 @@ fn (g &Parser) validate_expression_mutation_lvalue(tokens []FastcExpressionToken
 }
 
 fn (g &Parser) struct_direct_member_type(receiver_type string, field_name string) string {
-	mut layout_type := receiver_type.trim_right('*')
+	mut layout_type := fastc_trim_pointer_suffix(receiver_type)
 	if layout_type.starts_with('Array_') {
 		layout_type = 'array'
 	} else if layout_type.starts_with('Map_') {
@@ -800,7 +793,7 @@ fn (g &Parser) struct_member_type(receiver_type string, field_name string) strin
 }
 
 fn (g &Parser) struct_field_metadata(receiver_type string, field_name string) ?FastcStructField {
-	mut layout_type := receiver_type.trim_right('*')
+	mut layout_type := fastc_trim_pointer_suffix(receiver_type)
 	if layout_type.starts_with('Array_') {
 		layout_type = 'array'
 	} else if layout_type.starts_with('Map_') {
@@ -819,9 +812,9 @@ fn (g &Parser) struct_field_metadata(receiver_type string, field_name string) ?F
 	direct_type := g.struct_direct_member_type(receiver_type, field_name)
 	if direct_type != '' {
 		return FastcStructField{
-			name:       field_name
-			typ:        direct_type
-			is_public:  true
+			name: field_name
+			typ: direct_type
+			is_public: true
 			is_mutable: true
 		}
 	}
@@ -916,14 +909,12 @@ fn (g &Parser) validate_expression_field_visibility(tokens []FastcExpressionToke
 		if item.tok == .lcbr {
 			g.validate_struct_literal_field_visibility(tokens, i)!
 		}
-		if item.tok != .dot || i == 0 || i + 1 >= tokens.len || tokens[i + 1].tok != .name
-			|| g.expression_dot_is_module_separator(tokens, i) {
+		if item.tok != .dot || i == 0 || i + 1 >= tokens.len || tokens[i + 1].tok != .name || g.expression_dot_is_module_separator(tokens, i) {
 			continue
 		}
 		receiver_start := fastc_method_receiver_start(tokens, i)
 		receiver_type := g.infer_expression_type(tokens[receiver_start..i]) or { continue }
-		if i + 2 < tokens.len && tokens[i + 2].tok == .lpar
-			&& g.method_function_key(receiver_type, tokens[i + 1].lit) in g.functions {
+		if i + 2 < tokens.len && tokens[i + 2].tok == .lpar && g.method_function_key(receiver_type, tokens[i + 1].lit) in g.functions {
 			continue
 		}
 		field := g.struct_field_metadata(receiver_type, tokens[i + 1].lit) or { continue }
@@ -936,15 +927,14 @@ fn (g &Parser) validate_expression_field_visibility(tokens []FastcExpressionToke
 
 fn (g &Parser) validate_struct_literal_field_visibility(tokens []FastcExpressionToken, open int) ! {
 	mut type_start := open - 1
-	if open >= 3 && tokens[open - 3].tok == .name && tokens[open - 2].tok == .dot
-		&& tokens[open - 1].tok == .name {
+	if open >= 3 && tokens[open - 3].tok == .name && tokens[open - 2].tok == .dot && tokens[open - 1].tok == .name {
 		type_start = open - 3
 	}
 	if type_start < 0 {
 		return
 	}
 	c_type := g.type_from_expression_tokens(tokens[type_start..open]) or { return }
-	layout_type := c_type.trim_right('*')
+	layout_type := fastc_trim_pointer_suffix(c_type)
 	if layout_type !in g.struct_field_info {
 		return
 	}
@@ -1075,7 +1065,7 @@ fn (g &Parser) validate_fixed_array_struct_field_length(c_type string, field Fas
 		for item in items {
 			nested_field := FastcStructField{
 				name: field.name
-				typ:  element_type
+				typ: element_type
 			}
 			g.validate_fixed_array_struct_field_length(c_type, nested_field, item)!
 		}


### PR DESCRIPTION
## Summary

- replace per-block local map clones with a scoped change log
- add fast paths for single-token rendering, type inference, pointer suffixes, and C identifier checks
- scan generated C directives alongside per-file generation so final partitioning only processes directive events
- preserve serial operation with `VJOBS=1` and add scope/directive regression coverage

## Benchmark

Both FastC binaries were built by a production V host with `-prod -gc none`. Results are the median of three interleaved best-of-100 self-host generation runs over 173 files / 65,569 lines.

| | Generation | Throughput |
|---|---:|---:|
| `origin/master` | 28.28 ms | 2,318,482 LOC/s |
| this PR | 25.08 ms | 2,614,081 LOC/s |

That is 11.3% lower generation latency and 12.75% higher throughput.

## Validation

- `./vnew -silent vlib/v/compiler_errors_test.v`
- `./vnew -silent test vlib/v3/gen/fastc/declaration_filter_test.v`
- `./vnew -silent test vlib/v3/gen/fastc/fastc_test.v -run-only test_block_locals_are_released_when_their_scope_exits,test_c_directive*,test_fastc_generation_fragments*`
- five consecutive FastC self-host generations, then level 5 compiled and ran `examples/hello_world.v`
- `VJOBS=1` FastC compile and run of `examples/hello_world.v`

The complete FastC test executable still stops at the existing enum-literal `.map` closure-type failure; this reproduces on unmodified `origin/master`. A broad `vlib/v` run was stopped after unrelated existing failures in `keep_args_alive_test.c.v` and alias type-index tests.