### PR TITLE
crypto.aes: return an error from new_cipher instead of panicking

### DIFF
--- a/vlib/crypto/README.md
+++ b/vlib/crypto/README.md
@@ -49,7 +49,7 @@ fn main() {
 	mut data := 'THIS IS THE DATA'.bytes()
 
 	println('generating cipher')
-	cipher := aes.new_cipher(key)
+	cipher := aes.new_cipher(key)!
 
 	println('performing encryption')
 	mut encrypted := []u8{len: aes.block_size}

--- a/vlib/crypto/aes/aes.v
+++ b/vlib/crypto/aes/aes.v
@@ -38,15 +38,15 @@ pub fn (mut c AesCipher) free() {
 // The key argument should be the AES key,
 // either 16, 24, or 32 bytes to select
 // AES-128, AES-192, or AES-256.
-pub fn new_cipher(key []u8) cipher.Block {
+// It returns an error (instead of panicking) when the key size is invalid.
+pub fn new_cipher(key []u8) !cipher.Block {
 	k := key.len
 	match k {
 		16, 24, 32 {
 			// break
 		}
 		else {
-			panic('crypto.aes: invalid key size ' + k.str())
-			// return error('crypto.aes: invalid key size ' + k.str())
+			return error('crypto.aes: invalid key size ${k} (must be 16, 24 or 32 bytes)')
 		}
 	}
 

--- a/vlib/crypto/aes/aes_gcm.v
+++ b/vlib/crypto/aes/aes_gcm.v
@@ -46,7 +46,7 @@ pub fn new_aes_gcm(key []u8) !&AesGcm {
 	if key.len != 16 && key.len != 24 && key.len != 32 {
 		return error('AES-GCM key must be 16, 24 or 32 bytes, got ${key.len}')
 	}
-	block := new_cipher(key)
+	block := new_cipher(key)!
 	mut h := zero_block.clone()
 	block.encrypt(mut h, zero_block)
 	return &AesGcm{

--- a/vlib/crypto/aes/aes_test.v
+++ b/vlib/crypto/aes/aes_test.v
@@ -6,7 +6,7 @@ import crypto.aes
 fn test_aes() {
 	key := '6368616e676520746869732070617373'.bytes()
 	mut ciphertext := '73c86d43a9d700a253a96c85b0f6b03ac9792e0e757f869cca306bd3cba1c62b'.bytes()
-	block := aes.new_cipher(key)
+	block := aes.new_cipher(key)!
 
 	block.encrypt(mut ciphertext, ciphertext.clone())
 	assert ciphertext.hex() == '05d1737fe0a7c12088ff4c94d62ccbd9353361393663383562306636623033616339373932653065373537663836396363613330366264336362613163363262'
@@ -15,4 +15,24 @@ fn test_aes() {
 
 	assert ciphertext.bytestr() == '73c86d43a9d700a253a96c85b0f6b03ac9792e0e757f869cca306bd3cba1c62b'
 	println('test_aes ok')
+}
+
+fn test_new_cipher_invalid_key_returns_error() {
+	// keys must be 16, 24 or 32 bytes; anything else should return an error
+	// (instead of panicking, which is hard to handle by callers).
+	for bad_len in [0, 1, 8, 15, 17, 33] {
+		bad_key := []u8{len: bad_len}
+		if _ := aes.new_cipher(bad_key) {
+			assert false, 'expected an error for key size ${bad_len}'
+		} else {
+			assert err.msg().contains('invalid key size')
+		}
+	}
+}
+
+fn test_new_cipher_valid_key_sizes() {
+	for good_len in [16, 24, 32] {
+		good_key := []u8{len: good_len}
+		aes.new_cipher(good_key) or { assert false, 'unexpected error for key size ${good_len}' }
+	}
 }

--- a/vlib/crypto/aes/block_generic_test.v
+++ b/vlib/crypto/aes/block_generic_test.v
@@ -37,7 +37,7 @@ fn test_aes_known_answer_vectors() {
 		key := hex.decode(tc.key) or { panic(err) }
 		plaintext := hex.decode(tc.plaintext) or { panic(err) }
 		expected_ciphertext := hex.decode(tc.ciphertext) or { panic(err) }
-		block := new_cipher(key)
+		block := new_cipher(key) or { panic(err) }
 		mut ciphertext := []u8{len: block_size}
 		block.encrypt(mut ciphertext, plaintext)
 		assert ciphertext == expected_ciphertext

--- a/vlib/crypto/cipher/aes_cbc_test.v
+++ b/vlib/crypto/cipher/aes_cbc_test.v
@@ -10,14 +10,14 @@ fn test_aes_cbc_double() {
 	key := []u8{len: 16}
 	iv := []u8{len: 16}
 
-	mut block := aes.new_cipher(key)
+	mut block := aes.new_cipher(key) or { panic(err) }
 	mut en_cbc := cipher.new_cbc(block, iv)
 	mut cip1 := []u8{len: orig1.len}
 	mut cip2 := []u8{len: orig2.len}
 	en_cbc.encrypt_blocks(mut cip1, orig1)
 	en_cbc.encrypt_blocks(mut cip2, orig2)
 
-	mut block2 := aes.new_cipher(key)
+	mut block2 := aes.new_cipher(key) or { panic(err) }
 	mut dec_cbc := cipher.new_cbc(block2, iv)
 	mut plain1 := []u8{len: orig1.len}
 	mut plain2 := []u8{len: orig2.len}
@@ -44,13 +44,13 @@ fn test_aes_cbc() {
 }
 
 fn aes_cbc_en(mut src []u8, key []u8, iv []u8) {
-	block := aes.new_cipher(key)
+	block := aes.new_cipher(key) or { panic(err) }
 	mut mode := cipher.new_cbc(block, iv)
 	mode.encrypt_blocks(mut src, src.clone())
 }
 
 fn aes_cbc_de(mut src []u8, key []u8, iv []u8) {
-	block := aes.new_cipher(key)
+	block := aes.new_cipher(key) or { panic(err) }
 	mut mode := cipher.new_cbc(block, iv)
 	mode.decrypt_blocks(mut src, src.clone())
 }

--- a/vlib/crypto/cipher/aes_cfb_test.v
+++ b/vlib/crypto/cipher/aes_cfb_test.v
@@ -17,13 +17,13 @@ fn test_aes_cfb() {
 }
 
 fn aes_cfb_en(mut src []u8, key []u8, iv []u8) {
-	block := aes.new_cipher(key)
+	block := aes.new_cipher(key) or { panic(err) }
 	mut mode := cipher.new_cfb_encrypter(block, iv)
 	mode.xor_key_stream(mut src, src.clone())
 }
 
 fn aes_cfb_de(mut src []u8, key []u8, iv []u8) {
-	block := aes.new_cipher(key)
+	block := aes.new_cipher(key) or { panic(err) }
 	mut mode := cipher.new_cfb_decrypter(block, iv)
 	mode.xor_key_stream(mut src, src.clone())
 }

--- a/vlib/crypto/cipher/aes_ctr_test.v
+++ b/vlib/crypto/cipher/aes_ctr_test.v
@@ -17,13 +17,13 @@ fn test_aes_ctr() {
 }
 
 fn aes_ctr_en(mut src []u8, key []u8, iv []u8) {
-	block := aes.new_cipher(key)
+	block := aes.new_cipher(key) or { panic(err) }
 	mut mode := cipher.new_ctr(block, iv)
 	mode.xor_key_stream(mut src, src.clone())
 }
 
 fn aes_ctr_de(mut src []u8, key []u8, iv []u8) {
-	block := aes.new_cipher(key)
+	block := aes.new_cipher(key) or { panic(err) }
 	mut mode := cipher.new_ctr(block, iv)
 	mode.xor_key_stream(mut src, src.clone())
 }

--- a/vlib/crypto/cipher/aes_ofb_test.v
+++ b/vlib/crypto/cipher/aes_ofb_test.v
@@ -19,13 +19,13 @@ fn test_aes_ofb() {
 }
 
 fn aes_ofb_en(mut src []u8, key []u8, iv []u8) {
-	block := aes.new_cipher(key)
+	block := aes.new_cipher(key) or { panic(err) }
 	mut mode := cipher.new_ofb(block, iv)
 	mode.xor_key_stream(mut src, src.clone())
 }
 
 fn aes_ofb_de(mut src []u8, key []u8, iv []u8) {
-	block := aes.new_cipher(key)
+	block := aes.new_cipher(key) or { panic(err) }
 	mut mode := cipher.new_ofb(block, iv)
 	mode.xor_key_stream(mut src, src.clone())
 }

--- a/vlib/crypto/cipher/ctr_test.v
+++ b/vlib/crypto/cipher/ctr_test.v
@@ -24,7 +24,7 @@ fn test_ctr_byte_by_byte() {
 	txt := []u8{len: 32, init: index}
 	mut out := []u8{len: 32}
 
-	mut ofb := cipher.new_ctr(aes.new_cipher(key), iv)
+	mut ofb := cipher.new_ctr(aes.new_cipher(key) or { panic(err) }, iv)
 	for i in 0 .. 32 {
 		ofb.xor_key_stream(mut out[i..i + 1], txt[i..i + 1])
 	}

--- a/vlib/crypto/cipher/ofb_test.v
+++ b/vlib/crypto/cipher/ofb_test.v
@@ -24,7 +24,7 @@ fn test_ofb_byte_by_byte() {
 	txt := []u8{len: 32, init: index}
 	mut out := []u8{len: 32}
 
-	mut ofb := cipher.new_ofb(aes.new_cipher(key), iv)
+	mut ofb := cipher.new_ofb(aes.new_cipher(key) or { panic(err) }, iv)
 	for i in 0 .. 32 {
 		ofb.xor_key_stream(mut out[i..i + 1], txt[i..i + 1])
 	}

--- a/vlib/net/quic/header_protection.v
+++ b/vlib/net/quic/header_protection.v
@@ -38,7 +38,7 @@ fn header_protection_mask(hp_key []u8, sample []u8) ![]u8 {
 	if sample.len != header_protection_sample_size {
 		return error('quic: header protection sample must be ${header_protection_sample_size} bytes, got ${sample.len}')
 	}
-	block := aes.new_cipher(hp_key)
+	block := aes.new_cipher(hp_key)!
 	mut mask := []u8{len: header_protection_sample_size}
 	block.encrypt(mut mask, sample)
 	return mask


### PR DESCRIPTION
## What / Why

Fixes #28282.

`crypto.aes.new_cipher` previously called `panic()` when given a key whose size was not 16, 24 or 32 bytes. As the issue reports, a hard panic is unpleasant to handle — a caller passing user-supplied key material has no way to recover.

This changes `new_cipher` to return `!cipher.Block` and report an invalid key size through `error()` instead:

```v
pub fn new_cipher(key []u8) !cipher.Block {
	match key.len {
		16, 24, 32 {}
		else {
			return error('crypto.aes: invalid key size ${key.len} (must be 16, 24 or 32 bytes)')
		}
	}
	return new_cipher_generic(key)
}
```

This mirrors:
- Go's `crypto/aes.NewCipher`, which returns `(cipher.Block, error)`, and
- V's own `crypto.rc4.new_cipher`, `crypto.blowfish.new_cipher` and `x.crypto.chacha20.new_cipher`, which already return a result.

## Callers updated

All in-tree callers now propagate or handle the error:
- `crypto.aes` (`new_aes_gcm`)
- `net.quic` header protection
- `crypto.aes` / `crypto.cipher` tests
- the `vlib/crypto/README.md` example

## Tests

Added coverage for both the invalid-key (error is returned, not panicked) and valid-key paths. Existing `crypto.aes`, `crypto.cipher` and `net.quic` test suites all pass.

## On "data longer than the key"

The issue also notes that encrypting data longer than one block appears to "cut off". That is expected: `AesCipher` is a low-level **block** cipher and, like Go's, intentionally processes a single 16-byte block per call. To encrypt arbitrary-length data, use a cipher mode from `crypto.cipher` (CBC/CTR/CFB/OFB) or the authenticated `crypto.aes` AES-GCM API (`new_aes_gcm`). I kept this PR focused on the concrete panic-vs-error fix rather than introducing a new high-level "encrypt any bytes" helper, since a safe default there needs an explicit mode/IV/padding design decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)