### PR TITLE
builder: drop the "source inputs changed" V3 fallback note

### DIFF
--- a/cmd/v/macos_v3_test.v
+++ b/cmd/v/macos_v3_test.v
@@ -1737,7 +1737,8 @@ exec "\$REAL_CC" "\$@"
 		exit_code := process.code
 		process.close()
 		assert exit_code == 0, compiler_output
-		assert compiler_output.contains('source inputs changed'), compiler_output
+		// The unverified V3 fallback report is dropped silently, without any user-facing note.
+		assert !compiler_output.contains('source inputs changed'), compiler_output
 		assert !compiler_output.contains('V3 could not build this program'), compiler_output
 		assert os.is_executable(output)
 		run := os.execute(os.quoted_path(output))

--- a/vlib/v/builder/c_error_report.v
+++ b/vlib/v/builder/c_error_report.v
@@ -825,10 +825,6 @@ fn v3_fallback_backend_specific_builtin_source(path string, builtin_root string)
 		&& os.file_name(path) in ['ownership_interface_d_v3_backend.v', 'ownership_interface_notd_v3_backend.v', 'prealloc.c.v']
 }
 
-fn discard_unverified_v3_fallback_report() {
-	eprintln('note: source inputs changed before the stable compiler retry completed; the V3 fallback report was not submitted.')
-}
-
 // submit_external_v3_compiler_error_bug_report reports metadata for a V3 internal
 // compiler error after the stable compiler has confirmed the program is buildable.
 // Source may only be supplied through the pre-V3 snapshot/content path, so this legacy

--- a/vlib/v/builder/compile.v
+++ b/vlib/v/builder/compile.v
@@ -84,8 +84,8 @@ fn compile_with_optional_external_c_error_report(pref_ &pref.Preferences, backen
 			}
 			.changed {
 				// The stable compiler succeeded, but not from the exact source snapshot V3
-				// parsed. Do not classify or upload this as a V3-only failure.
-				discard_unverified_v3_fallback_report()
+				// parsed. Do not classify or upload this as a V3-only failure. The staged
+				// report is simply left unconsumed, so the at_exit cleanup drops it silently.
 			}
 		}
 	}


### PR DESCRIPTION
### What

Removes the user-facing note

```
note: source inputs changed before the stable compiler retry completed; the V3 fallback report was not submitted.
```

### Why

When V3 fails and the stable compiler succeeds from a slightly different source snapshot, V discards the unverified V3 fallback report. Previously it also printed the note above, which showed up on ordinary builds (e.g. a plain `v run .` of a hello world program) and was confusing noise for end users.

### How

The staged fallback report is already dropped by the `at_exit` cleanup when it is left unconsumed in the `.changed` branch, so no user-facing note is needed. This removes the `eprintln` (and the now-empty `discard_unverified_v3_fallback_report` helper) and updates `test_macos_v3_discards_fallback_report_when_native_input_changes` to assert the note is no longer emitted (the report is still silently discarded and the build still succeeds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)