### PR TITLE
v3: fix vfmt collapsing block bodies nested in initializers

### DIFF
--- a/vlib/v3/gen/v/gen.v
+++ b/vlib/v3/gen/v/gen.v
@@ -526,6 +526,17 @@ fn (mut g Gen) collect_top_level(ids []flat.NodeId, mut out []flat.NodeId) {
 
 // stmt_list_ids renders a list of statements, one indentation level deeper.
 fn (mut g Gen) stmt_list_ids(ids []flat.NodeId) {
+	// A statement list is always emitted as a multi-line braced body, so it opens
+	// a fresh statement scope where every statement must terminate with a newline.
+	// Compact/inline renderings never reach this function; they emit statements
+	// directly with `in_init` set. Reset `in_init` here so that a body nested
+	// inside an initializer (e.g. an anonymous fn used as a struct field value)
+	// does not have its statements collapsed onto a single line.
+	saved_in_init := g.in_init
+	g.in_init = false
+	defer {
+		g.in_init = saved_in_init
+	}
 	mut previous := flat.empty_node
 	mut i := 0
 	for i < ids.len {

--- a/vlib/v3/gen/v/gen_test.v
+++ b/vlib/v3/gen/v/gen_test.v
@@ -115,6 +115,17 @@ fn test_formatter_preserves_unsafe_and_defer_source_layout() {
 	assert vfmt('unsafe_defer_layout_twice', out) == out
 }
 
+fn test_formatter_keeps_anon_fn_body_statements_expanded_inside_init() {
+	// Regression: an anonymous fn used as a struct init field value kept the
+	// `in_init` flag set while emitting its body, collapsing the body statements
+	// (and any nested `or {}` block) onto a single line, e.g.
+	// `c := codem := msg_ = c_ = m}`, which broke compilation.
+	source := "struct Events {\n\ton_error fn(code int, msg string)\n\ton_close fn(id int)\n}\n\nstruct Registry {\nmut:\n\tclosed bool\n}\n\nfn (r &Registry) find(id int) ?int {\n\treturn id\n}\n\nfn handlers() {\n\tmut reg := Registry{}\n\te := Events{\n\t\ton_error: fn (code int, msg string) {\n\t\t\tc := code\n\t\t\tm := msg\n\t\t\t_ = c\n\t\t\t_ = m\n\t\t}\n\t\ton_close: fn (id int) {\n\t\t\tn := reg.find(id) or { return }\n\t\t\t_ = n\n\t\t}\n\t}\n\t_ = e\n\t_ = reg\n}\n"
+	out := vfmt('anon_fn_body_inside_init', source)
+	assert out == source, out
+	assert vfmt('anon_fn_body_inside_init_twice', out) == out
+}
+
 fn test_formatter_preserves_compact_empty_literals_and_declarations() {
 	source := "interface Compact {}\n\nstruct Between {}\n\ninterface Expanded {\n}\n\nenum CompactEnum {}\n\nstruct Between2 {}\n\nenum ExpandedEnum {\n}\n\nfn literal_layouts() {\n\tcompact := fn (_s string) {}\n\texpanded := fn (_s string) {\n\t}\n\t_ = compact\n\t_ = expanded\n}\n"
 	out := vfmt('compact_empty_literals_declarations', source)


### PR DESCRIPTION
## Problem

Running `v fmt` (which now uses the v3 formatter, `v3.gen.v`) on code that
uses an **anonymous function as a struct-init field value** collapses the
function body onto a single line, producing output that no longer compiles.

For example, this valid input:

```v
mut events := WlDisplayEvents[&Display]{
	error: fn (mut ud Display, oid u32, code u32, msg string) {
		ud.error_code = code
		ud.error_msg = msg
	}
}
```

was reformatted to:

```v
mut events := WlDisplayEvents[&Display]{
	error: fn (mut ud Display, oid u32, code u32, msg string) {
		ud.error_code = codeud.error_msg = msg}
}
```

Note `code` and `ud.error_msg` jammed together (`codeud.error_msg`), which
breaks compilation. The same collapse affected `or {}` blocks and
`if`/`match` expression branches nested inside initializers. Reported against
`v fmt -w .` (e.g. on the `dy-tea/wayland` project).

## Cause

`struct_init` (and the array/assoc initializers) set `g.in_init = true` while
emitting field values so that compact single-line field values render without
trailing newlines. `stmt_list_ids` — which renders every *multi-line* braced
body — inherited that flag when a body happened to be nested inside an
initializer, so it suppressed the newline after each statement in the body.

## Fix

`stmt_list_ids` is only ever reached for multi-line braced bodies; compact /
inline renderings emit their statements directly with `in_init` set and never
call it. So the body of a statement list always opens a fresh statement scope
that must terminate each statement with a newline. Reset `in_init` to `false`
at the entry of `stmt_list_ids` and restore it on exit (matching the existing
`in_c_function` save/restore idiom in `fn_decl`).

This keeps nested `fn` / `or` / `if` / `match` bodies expanded while preserving
compact field rendering.

## Impact

Comparing the formatter output before vs. after this change over ~400 real
`vlib` files, only 8 files change — every one of them was previously being
corrupted into non-compiling output (anon-fn bodies, `or {}` blocks, and
`if/else` expression branches used as initializer values), and all now format
correctly.

## Tests

Adds `test_formatter_keeps_anon_fn_body_statements_expanded_inside_init` to
`vlib/v3/gen/v/gen_test.v`. It fails without the fix (the body collapses) and
passes with it; the whole `gen_test.v` suite passes.