### PR TITLE
v3: speed up FastC self-host generation ~1.8x (TCC) and ~1.3x (-prod)

### DIFF
--- a/vlib/builtin/map.c.v
+++ b/vlib/builtin/map.c.v
@@ -18,7 +18,7 @@ fn fast_string_eq(a string, b string) bool {
 }
 
 fn map_hash_string(pkey voidptr) u64 {
-	key := *unsafe { &string(pkey) }
+	key := unsafe { &string(pkey) }
 	// XTODO remove voidptr cast once virtual C.consts can be declared
 	return C.wyhash(key.str, u64(key.len), 0, &u64(voidptr(C._wyp)))
 }

--- a/vlib/v3/README.md
+++ b/vlib/v3/README.md
@@ -154,6 +154,25 @@ compiler uses the small `v3.fastcdriver` entry point and can build further FastC
 the flat AST or conventional C backend. Set `V_MACOS_V3_NO_FALLBACK=1` while validating a chain to
 turn any attempted compatibility fallback into a hard failure.
 
+Set `FASTC_BENCH=1` when running a FastC self-host compiler to print the generation time and
+`loc/s` for its input (`FASTC_BENCH_REPEAT=N` reports the best of N child runs). `FASTC_BENCH_PHASES=1`
+prints the time of every generation phase, `FASTC_BENCH_FILES=1` the generation time of every source
+file, and `FASTC_BENCH=1 FASTC_BENCH_LOOP=N` repeats generation N times in-process so an external
+sampler can profile it. The compiler's own C preamble and runtime (hashing, option boxing, tuple
+slots) are emitted by the generator that built it, so such changes take effect one generation later:
+measure the compiler built by the modified compiler, not the modified compiler itself.
+
+Self-host generations box `?`/`!` payloads out of a per-thread bump chunk rather than `malloc`, keep
+one file record per scanner pass, and honor `@[direct_array_access]` for string and array indexing.
+Multi-return components larger than 32 bytes are boxed instead of copied into the tuple slot, so a
+returned `map` or large struct can no longer overflow it.
+
+Per-file generation, constant parsing, and the declaration and signature collection passes claim
+their work items from a shared atomic counter (largest files first) instead of a static split, so
+workers on faster cores take more files; the serial merge and output order is restored by index. The first parallel pass also records which declaration
+keywords (`interface`, `$if`, type keywords, generic `fn` syntax) each file mentions, and the later
+collection passes skip files that cannot contain what they scan for.
+
 The standalone compiler supports `self` directly and defaults that command to FastC. For example,
 `./v self x5` replaces the compiler through five descendant FastC generations, with each installed
 generation compiling the next one. `-b fastc`, `-gc none`, `-cc tinyc|tcc`, `-keepc`, `-silent`,

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -8517,6 +8517,15 @@ pub fn run(args []string) {
 				add_v3_tcc_compat_defines(mut prefs.user_defines, target.os, target.arch, false,
 					true)
 			}
+			// FASTC_BENCH_LOOP=N repeats generation in-process so an external
+			// sampler can profile it (see the FastC section of the v3 README).
+			for _ in 0 .. os.getenv('FASTC_BENCH_LOOP').int() {
+				fastc.generate_files_with_source_paths([input_file], prefs) or {
+					eprintln(err.msg())
+					exit(1)
+					return
+				}
+			}
 			fastc_generation := fastc.generate_files_with_source_paths([input_file], prefs) or {
 				eprintln(err.msg())
 				exit(1)

--- a/vlib/v3/fastcdriver/fastcdriver.v
+++ b/vlib/v3/fastcdriver/fastcdriver.v
@@ -447,6 +447,13 @@ pub fn run(args []string) {
 		loc_per_s := f64(warm.lines) * 1_000_000.0 / f64(best_us)
 		eprintln('fastc-bench: files=${warm.files} lines=${warm.lines} best_gen=${gen_ms:.2f}ms loc/s=${loc_per_s:.0f} (repeat=${repeat})')
 	}
+	loop := os.getenv('FASTC_BENCH_LOOP').int()
+	if bench && loop > 0 {
+		// Repeat generation in-process so an external sampler can profile it.
+		for _ in 0 .. loop {
+			fastc.generate_files_with_source_paths([real_input], prefs) or { fail(err.msg()) }
+		}
+	}
 	mut sw := time.new_stopwatch()
 	generation := fastc.generate_files_with_source_paths([real_input], prefs) or { fail(err.msg()) }
 	if bench && repeat == 1 {

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -16727,6 +16727,11 @@ fn (g &FlatGen) should_emit_c_extern_decl(cfn string) bool {
 	if cfn in ['va_arg', 'va_start', 'va_end', 'va_copy'] {
 		return false
 	}
+	// Compiler builtins (`__atomic_fetch_add`, `__builtin_expect`, `__sync_*`)
+	// are provided by the C compiler itself; clang rejects a prototype for them.
+	if cfn.starts_with('__atomic_') || cfn.starts_with('__builtin_') || cfn.starts_with('__sync_') {
+		return false
+	}
 	if cfn in ['sem_destroy', 'sem_init', 'sem_post', 'sem_timedwait', 'sem_trywait', 'sem_wait']
 		&& g.target.os in ['linux', 'android', 'termux'] && g.c_directives_use_system_libc() {
 		return false

--- a/vlib/v3/gen/c/preamble_test.v
+++ b/vlib/v3/gen/c/preamble_test.v
@@ -139,6 +139,9 @@ fn test_headerless_libc_preamble_suppresses_its_mach_timebase_declaration() {
 	mut g := FlatGen.new()
 	g.headerless_libc_preamble()
 	assert !g.should_emit_c_extern_decl('mach_timebase_info')
+	// Compiler builtins never get a prototype; clang rejects redeclaring them.
+	assert !g.should_emit_c_extern_decl('__atomic_fetch_add')
+	assert !g.should_emit_c_extern_decl('__builtin_expect')
 }
 
 fn test_headerless_platform_constants_include_process_errno_values() {

--- a/vlib/v3/gen/fastc/arm64_d_arm64.v
+++ b/vlib/v3/gen/fastc/arm64_d_arm64.v
@@ -298,9 +298,7 @@ fn fast_arm64_validate_unsupported_calls(sources []FastcSourceFile, prefs &pref.
 		if source_file.header.module_name == 'os' {
 			continue
 		}
-		mut file_set := token.FileSet.new()
-		mut file := file_set.add_file(source_file.path, source_file.source.len)
-		file.index_lines_without_digest(source_file.source)
+		file := token.File.unindexed(source_file.path, source_file.source.len)
 		mut scan := scanner.new_scanner(prefs, .normal)
 		scan.init(file, source_file.source)
 		mut previous_3 := token.Token.unknown
@@ -526,9 +524,7 @@ fn fast_arm64_collect_constant_sources(sources []FastcSourceFile, prefs &pref.Pr
 		if !source_file.header.has_constants {
 			continue
 		}
-		mut file_set := token.FileSet.new()
-		mut file := file_set.add_file(source_file.path, source_file.source.len)
-		file.index_lines_without_digest(source_file.source)
+		file := token.File.unindexed(source_file.path, source_file.source.len)
 		mut scan := scanner.new_scanner(prefs, .normal)
 		scan.init(file, source_file.source)
 		mut tok := scan.scan()
@@ -555,9 +551,7 @@ fn fast_arm64_collect_enum_values(sources []FastcSourceFile, prefs &pref.Prefere
 		if source_file.path !in type_source_paths {
 			continue
 		}
-		mut file_set := token.FileSet.new()
-		mut file := file_set.add_file(source_file.path, source_file.source.len)
-		file.index_lines_without_digest(source_file.source)
+		file := token.File.unindexed(source_file.path, source_file.source.len)
 		mut scan := scanner.new_scanner(prefs, .normal)
 		scan.init(file, source_file.source)
 		mut tok := scan.scan()
@@ -770,9 +764,7 @@ fn fast_arm64_scan_layout_attribute(mut scan scanner.Scanner, path string, prefs
 }
 
 fn fast_arm64_collect_source_declarations(source_file FastcSourceFile, prefs &pref.Preferences, declared_types map[string]bool, enum_flags map[string]bool, mut declarations map[string]FastArm64TypeDecl, mut constants map[string]FastArm64ConstantDecl, mut enum_values map[string]FastArm64ConstantDecl) ! {
-	mut file_set := token.FileSet.new()
-	mut file := file_set.add_file(source_file.path, source_file.source.len)
-	file.index_lines_without_digest(source_file.source)
+	file := token.File.unindexed(source_file.path, source_file.source.len)
 	mut scan := scanner.new_scanner(prefs, .normal)
 	scan.init(file, source_file.source)
 	mut tok := scan.scan()
@@ -3779,9 +3771,7 @@ fn (mut p FastArm64Program) register_string_sort_runtime() {
 }
 
 fn FastArm64Parser.new(mut program FastArm64Program, source_file FastcSourceFile) &FastArm64Parser {
-	mut file_set := token.FileSet.new()
-	mut file := file_set.add_file(source_file.path, source_file.source.len)
-	file.index_lines_without_digest(source_file.source)
+	file := token.File.unindexed(source_file.path, source_file.source.len)
 	mut scan := scanner.new_scanner(program.prefs, .normal)
 	scan.init(file, source_file.source)
 	return &FastArm64Parser{
@@ -3907,9 +3897,7 @@ fn (mut p FastArm64Parser) skip_value_declaration() {
 }
 
 fn (mut p FastArm64Parser) enter_source(source string) {
-	mut file_set := token.FileSet.new()
-	mut file := file_set.add_file(p.source_file.path, source.len)
-	file.index_lines_without_digest(source)
+	file := token.File.unindexed(p.source_file.path, source.len)
 	mut scan := scanner.new_scanner(p.program.prefs, .normal)
 	scan.init(file, source)
 	p.s = scan

--- a/vlib/v3/gen/fastc/array.v
+++ b/vlib/v3/gen/fastc/array.v
@@ -164,6 +164,12 @@ fn (g &Parser) render_array_access_expression(tokens []FastcExpressionToken) ?Fa
 	}
 	index_source := g.render_membership_candidate(tokens[open + 1..close], 'int') or { return none }
 	if base_layout_type == 'string' {
+		if g.direct_array_access && !base_type.ends_with('*') {
+			return FastcRenderedExpression{
+				source: '((${base_source}).str[${index_source}])'
+				typ: element_type
+			}
+		}
 		return FastcRenderedExpression{
 			source: 'builtin__string_at(${base_source}, ${index_source})'
 			typ: element_type
@@ -197,6 +203,12 @@ fn (g &Parser) render_array_access_expression(tokens []FastcExpressionToken) ?Fa
 		}
 	}
 	array_value := if base_type.ends_with('*') { '*(${base_source})' } else { base_source }
+	if g.direct_array_access {
+		return FastcRenderedExpression{
+			source: '(((${element_type} *)(${array_value}).data)[${index_source}])'
+			typ: element_type
+		}
+	}
 	return FastcRenderedExpression{
 		source: '(*(${element_type} *)builtin__array_get(${array_value}, ${index_source}))'
 		typ: element_type

--- a/vlib/v3/gen/fastc/comptime.v
+++ b/vlib/v3/gen/fastc/comptime.v
@@ -187,9 +187,7 @@ fn fastc_scan_selected_comptime_branch(mut scan scanner.Scanner, first token.Tok
 }
 
 fn fastc_collect_selected_comptime_function_signatures(source string, path string, header FastcSourceHeader, prefs &pref.Preferences, declared_types map[string]bool, declared_type_c_names map[string]string, params_structs map[string]bool, mut functions map[string]FastcFunctionSignature) ! {
-	mut file_set := token.FileSet.new()
-	mut file := file_set.add_file(path, source.len)
-	file.index_lines_without_digest(source)
+	file := token.File.unindexed(path, source.len)
 	mut scan := scanner.new_scanner(prefs, .normal)
 	scan.init(file, source)
 	mut brace_depth := 0
@@ -419,9 +417,7 @@ fn (mut g Parser) parse_comptime_for_statement() !bool {
 		// `x.$(<var>.name)`) at the source level, then re-scan the result as
 		// ordinary V — no comptime awareness is needed in the renderer.
 		substituted := g.substitute_comptime_field(body_source, loop_var, field)
-		mut file_set := token.FileSet.new()
-		mut file := file_set.add_file('comptime_for', substituted.len)
-		file.index_lines_without_digest(substituted)
+		file := token.File.unindexed('comptime_for', substituted.len)
 		g.s = scanner.new_scanner(g.prefs, .normal)
 		g.s.init(file, substituted)
 		g.next()
@@ -457,9 +453,7 @@ fn fastc_comptime_loop_var_token(tok token.Token) bool {
 
 fn (g &Parser) substitute_comptime_field(body string, loop_var string, field FastcStructField) string {
 	field_name := field.name
-	mut file_set := token.FileSet.new()
-	mut file := file_set.add_file('cf', body.len)
-	file.index_lines_without_digest(body)
+	file := token.File.unindexed('cf', body.len)
 	mut s := scanner.new_scanner(g.prefs, .normal)
 	s.init(file, body)
 	mut edits := []FastcSourceEdit{}

--- a/vlib/v3/gen/fastc/decl.v
+++ b/vlib/v3/gen/fastc/decl.v
@@ -6,9 +6,7 @@ import v3.scanner
 import v3.token
 
 fn collect_declared_types(source string, path string, module_name string, prefs &pref.Preferences, mut declared_types map[string]bool, mut declared_kinds map[string]FastcDeclaredTypeKind, mut enum_flags map[string]bool, mut params_structs map[string]bool, mut declaration_paths map[string]string, mut declaration_modules map[string]string, mut type_source strings.Builder) !bool {
-	mut file_set := token.FileSet.new()
-	mut file := file_set.add_file(path, source.len)
-	file.index_lines_without_digest(source)
+	file := token.File.unindexed(path, source.len)
 	mut scan := scanner.new_scanner(prefs, .normal)
 	scan.init(file, source)
 	mut brace_depth := 0
@@ -156,9 +154,7 @@ fn collect_declared_types(source string, path string, module_name string, prefs 
 }
 
 fn collect_constant_names(source string, path string, module_name string, prefs &pref.Preferences, mut constants map[string]string, mut public_constants map[string]bool, mut constant_paths map[string]string, mut constant_source strings.Builder) ! {
-	mut file_set := token.FileSet.new()
-	mut file := file_set.add_file(path, source.len)
-	file.index_lines_without_digest(source)
+	file := token.File.unindexed(path, source.len)
 	mut scan := scanner.new_scanner(prefs, .normal)
 	scan.init(file, source)
 	mut brace_depth := 0
@@ -302,9 +298,7 @@ fn fastc_register_constant(module_name string, name string, is_public bool, path
 }
 
 fn collect_global_names(source string, path string, header FastcSourceHeader, prefs &pref.Preferences, mut globals map[string]string, mut public_globals map[string]bool, mut global_paths map[string]string) ! {
-	mut file_set := token.FileSet.new()
-	mut file := file_set.add_file(path, source.len)
-	file.index_lines_without_digest(source)
+	file := token.File.unindexed(path, source.len)
 	mut scan := scanner.new_scanner(prefs, .normal)
 	scan.init(file, source)
 	mut depth := 0
@@ -418,13 +412,16 @@ fn fastc_collect_declaration_chunk(sources []FastcSourceFile, prefs &pref.Prefer
 	for idx in start .. end {
 		source_file := sources[idx]
 		mut type_source := strings.new_builder(256)
-		has_type_declarations := collect_declared_types(source_file.source, source_file.path,
-			source_file.header.module_name, prefs, mut partial.declared_types, mut
-			partial.declared_kinds, mut partial.enum_flags, mut partial.params_structs, mut
-			partial.declaration_paths, mut partial.declaration_modules, mut type_source) or {
-			partial.failed = true
-			partial.error_message = err.msg()
-			return partial
+		mut has_type_declarations := false
+		if source_file.header.has_type_keywords {
+			has_type_declarations = collect_declared_types(source_file.source, source_file.path,
+				source_file.header.module_name, prefs, mut partial.declared_types, mut
+				partial.declared_kinds, mut partial.enum_flags, mut partial.params_structs, mut
+				partial.declaration_paths, mut partial.declaration_modules, mut type_source) or {
+				partial.failed = true
+				partial.error_message = err.msg()
+				return partial
+			}
 		}
 		if has_type_declarations {
 			partial.type_source_paths[source_file.path] = true
@@ -503,24 +500,25 @@ fn fastc_merge_declaration_partial(partial FastcDeclarationPartial, mut declared
 	}
 }
 
-fn fastc_generate_global_declarations(sources []FastcSourceFile, prefs &pref.Preferences, declared_types map[string]bool, declared_type_c_names map[string]string, fastc_prefixed_c_names []string, declared_kinds map[string]FastcDeclaredTypeKind, enum_flags map[string]bool, enum_field_types map[string]string, alias_base_types map[string]string, struct_fields map[string]map[string]string, struct_field_info map[string][]FastcStructField, functions map[string]FastcFunctionSignature, constants map[string]string, constant_values map[string]string, public_constants map[string]bool, constant_types map[string]string, globals map[string]string, public_globals map[string]bool, mut global_types map[string]string) !FastcGlobalDeclarations {
+fn fastc_generate_global_declarations(ordered_sources []FastcSourceFile, prefs &pref.Preferences, declared_types map[string]bool, declared_type_c_names map[string]string, fastc_prefixed_c_names []string, declared_kinds map[string]FastcDeclaredTypeKind, enum_flags map[string]bool, enum_field_types map[string]string, alias_base_types map[string]string, struct_fields map[string]map[string]string, struct_field_info map[string][]FastcStructField, functions map[string]FastcFunctionSignature, constants map[string]string, constant_values map[string]string, public_constants map[string]bool, constant_types map[string]string, globals map[string]string, public_globals map[string]bool, mut global_types map[string]string) !FastcGlobalDeclarations {
 	declared_type_key_by_name := fastc_declared_type_key_by_name(declared_types)
 	mut out := strings.new_builder(1024)
 	mut module_initializers := map[string]string{}
 	mut composite_types := map[string]bool{}
 	mut fixed_array_types := map[string]string{}
 	helper_has_c_functions := fastc_functions_declare_c(functions)
-	ordered_sources := fastc_sources_in_dependency_order(sources)!
 	for source_file in ordered_sources {
 		if !source_file.header.has_global_declarations {
 			continue
 		}
 		mut initializers := strings.new_builder(256)
-		mut file_set := token.FileSet.new()
-		mut file := file_set.add_file(source_file.path, source_file.source.len)
-		file.index_lines_without_digest(source_file.source)
+		file := token.File.unindexed(source_file.path, source_file.source.len)
 		mut gen := Parser{
 			prefs:                        unsafe { prefs }
+			unqualified_key_memo: map[string]string{}
+			nonlocal_name_type_memo: map[string]string{}
+			resolved_name_memo: map[string]string{}
+			declared_type_key_memo: map[string]FastcMemoEntry{}
 			path:                         source_file.path
 			module_name:                  source_file.header.module_name
 			imports:                      source_file.header.imports
@@ -799,11 +797,13 @@ fn fastc_render_struct_field_defaults(prefs &pref.Preferences, declared_types ma
 				continue
 			}
 			default_path := '${field.path}:${field.name}:default'
-			mut file_set := token.FileSet.new()
-			mut file := file_set.add_file(default_path, field.default_source.len)
-			file.index_lines_without_digest(field.default_source)
+			file := token.File.unindexed(default_path, field.default_source.len)
 			mut gen := Parser{
 				prefs:                        unsafe { prefs }
+				unqualified_key_memo: map[string]string{}
+				nonlocal_name_type_memo: map[string]string{}
+				resolved_name_memo: map[string]string{}
+				declared_type_key_memo: map[string]FastcMemoEntry{}
 				path:                         default_path
 				module_name:                  field.module_name
 				imports:                      field.imports
@@ -866,64 +866,246 @@ fn fastc_render_struct_field_defaults(prefs &pref.Preferences, declared_types ma
 	}
 }
 
-fn fastc_generate_constant_declarations(sources []FastcSourceFile, constant_sources map[string]string, prefs &pref.Preferences, declared_types map[string]bool, declared_type_c_names map[string]string, fastc_prefixed_c_names []string, declared_kinds map[string]FastcDeclaredTypeKind, enum_flags map[string]bool, enum_field_types map[string]string, alias_base_types map[string]string, struct_fields map[string]map[string]string, struct_field_info map[string][]FastcStructField, functions map[string]FastcFunctionSignature, constants map[string]string, public_constants map[string]bool, globals map[string]string, public_globals map[string]bool, mut constant_types map[string]string) !FastcConstantDeclarations {
-	declared_type_key_by_name := fastc_declared_type_key_by_name(declared_types)
+// FastcConstantGenContext bundles the read-only program tables every
+// constant-initializer Parser starts from, so parallel workers share them.
+struct FastcConstantGenContext {
+	prefs                     &pref.Preferences = unsafe { nil }
+	declared_types            map[string]bool
+	declared_type_c_names     map[string]string
+	declared_type_key_by_name map[string]string
+	fastc_prefixed_c_names    []string
+	has_c_functions           bool
+	declared_kinds            map[string]FastcDeclaredTypeKind
+	enum_flags                map[string]bool
+	enum_field_types          map[string]string
+	alias_base_types          map[string]string
+	struct_fields             map[string]map[string]string
+	struct_field_info         map[string][]FastcStructField
+	functions                 map[string]FastcFunctionSignature
+	constants                 map[string]string
+	public_constants          map[string]bool
+	globals                   map[string]string
+	public_globals            map[string]bool
+}
+
+// FastcConstantFileResult is one file's parsed constant initializers.
+struct FastcConstantFileResult {
+mut:
+	values            []FastcConstantValue
+	constant_types    map[string]string
+	composite_types   map[string]bool
+	fixed_array_types map[string]string
+	failed            bool
+	error_message     string
+}
+
+struct FastcIndexedConstantFileResult {
+	index  int
+	result FastcConstantFileResult
+}
+
+// fastc_parse_constant_file parses the filtered constant source of one file
+// (`source_file.source`), starting from `constant_types`, the constant types
+// known before it.
+fn fastc_parse_constant_file(ctx &FastcConstantGenContext, source_file FastcSourceFile, constant_types map[string]string) FastcConstantFileResult {
+	constant_source := source_file.source
+	file := token.File.unindexed(source_file.path, constant_source.len)
+	prefs := ctx.prefs
+	mut gen := Parser{
+		prefs:                        unsafe { prefs }
+		unqualified_key_memo: map[string]string{}
+		nonlocal_name_type_memo: map[string]string{}
+		resolved_name_memo: map[string]string{}
+		declared_type_key_memo: map[string]FastcMemoEntry{}
+		path:                         source_file.path
+		module_name:                  source_file.header.module_name
+		imports:                      source_file.header.imports
+		declared_types:               ctx.declared_types
+		declared_type_c_names:        ctx.declared_type_c_names
+		declared_type_key_by_name:    ctx.declared_type_key_by_name
+		fastc_prefixed_c_names:       ctx.fastc_prefixed_c_names
+		declaration_initializer_mode: true
+		has_c_functions:              ctx.has_c_functions
+		comparison_memo:              map[i64]FastcRenderedExpression{}
+		spawn_typedefs:               map[string]string{}
+		spawn_helpers:                map[string]string{}
+		thread_value_types:           map[string]string{}
+		declared_kinds:               ctx.declared_kinds
+		enum_flags:                   ctx.enum_flags
+		enum_field_types:             ctx.enum_field_types
+		alias_base_types:             ctx.alias_base_types
+		struct_fields:                ctx.struct_fields
+		struct_field_info:            ctx.struct_field_info
+		constants:                    ctx.constants
+		public_constants:             ctx.public_constants
+		globals:                      ctx.globals
+		public_globals:               ctx.public_globals
+		selfhost:                     prefs.building_v
+		s:                            scanner.new_scanner(prefs, .normal)
+		out:                          strings.new_builder(256)
+		protos:                       strings.new_builder(0)
+		functions:                    ctx.functions
+		constant_types:               constant_types
+		composite_types:              map[string]bool{}
+		fixed_array_types:            map[string]string{}
+	}
+	gen.s.init(file, constant_source)
+	gen.next()
+	mut values := []FastcConstantValue{}
+	gen.parse_selected_constant_declarations(mut values, false) or {
+		return FastcConstantFileResult{
+			failed:        true
+			error_message: err.msg()
+		}
+	}
+	if gen.s.diagnostics.len > 0 {
+		diagnostic := gen.s.diagnostics[0]
+		return FastcConstantFileResult{
+			failed:        true
+			error_message: 'fastc scanner error at byte ${diagnostic.offset} in ${source_file.path}: ${diagnostic.message}'
+		}
+	}
+	return FastcConstantFileResult{
+		values:            values
+		constant_types:    gen.constant_types.move()
+		composite_types:   gen.composite_types
+		fixed_array_types: gen.fixed_array_types
+	}
+}
+
+// fastc_parse_constant_file_worker parses candidate files until the shared
+// counter runs past the end of `order` (largest files first).
+fn fastc_parse_constant_file_worker(ctx &FastcConstantGenContext, candidates []FastcSourceFile, seed map[string]string, order []int, queue &FastcGenQueue) []FastcIndexedConstantFileResult {
+	mut results := []FastcIndexedConstantFileResult{}
+	for {
+		slot := fastc_atomic_fetch_add_u32(&queue.next, 1)
+		if slot >= u32(order.len) {
+			break
+		}
+		index := order[slot]
+		results << FastcIndexedConstantFileResult{
+			index:  index
+			result: fastc_parse_constant_file(ctx, candidates[index], seed.clone())
+		}
+	}
+	return results
+}
+
+// fastc_parse_constant_files_parallel parses every candidate file's constants
+// on parallel workers, each starting from the phase's initial constant types.
+// It returns an empty list when the phase runs serially.
+fn fastc_parse_constant_files_parallel(ctx &FastcConstantGenContext, candidates []FastcSourceFile, seed map[string]string) []FastcConstantFileResult {
+	jobs := fastc_parallel_job_count(candidates.len, ctx.prefs)
+	if jobs <= 1 {
+		return []FastcConstantFileResult{}
+	}
+	order := fastc_file_generation_order(candidates)
+	mut queue := &FastcGenQueue{
+		next: 0
+	}
+	second_thread := spawn fastc_parse_constant_file_worker(ctx, candidates, seed, order, queue)
+	mut chunk_threads := [second_thread]
+	for _ in 2 .. jobs {
+		chunk_thread := spawn fastc_parse_constant_file_worker(ctx, candidates, seed, order, queue)
+		chunk_threads << chunk_thread
+	}
+	mut results := []FastcConstantFileResult{len: candidates.len}
+	first_results := fastc_parse_constant_file_worker(ctx, candidates, seed, order, queue)
+	for indexed in first_results {
+		results[indexed.index] = indexed.result
+	}
+	for chunk_thread in chunk_threads {
+		chunk_results := chunk_thread.wait()
+		for indexed in chunk_results {
+			results[indexed.index] = indexed.result
+		}
+	}
+	return results
+}
+
+// fastc_constant_file_is_independent reports whether every constant that the
+// file's initializers depend on is declared in that same file. Type inference
+// of an initializer consults only the types of the constants it references, so
+// such a file parsed from the phase's initial constant types yields exactly
+// what an in-order parse would; any other file is re-parsed in order.
+fn fastc_constant_file_is_independent(result FastcConstantFileResult) bool {
+	mut declared := map[string]bool{}
+	for value in result.values {
+		declared[value.key] = true
+	}
+	for value in result.values {
+		for dependency in value.dependencies {
+			if dependency !in declared {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+fn fastc_generate_constant_declarations(ordered_sources []FastcSourceFile, constant_sources map[string]string, prefs &pref.Preferences, declared_types map[string]bool, declared_type_c_names map[string]string, fastc_prefixed_c_names []string, declared_kinds map[string]FastcDeclaredTypeKind, enum_flags map[string]bool, enum_field_types map[string]string, alias_base_types map[string]string, struct_fields map[string]map[string]string, struct_field_info map[string][]FastcStructField, functions map[string]FastcFunctionSignature, constants map[string]string, public_constants map[string]bool, globals map[string]string, public_globals map[string]bool, mut constant_types map[string]string) !FastcConstantDeclarations {
 	mut values := []FastcConstantValue{}
 	mut composite_types := map[string]bool{}
 	mut fixed_array_types := map[string]string{}
-	helper_has_c_functions := fastc_functions_declare_c(functions)
-	ordered_sources := fastc_sources_in_dependency_order(sources)!
+	ctx := FastcConstantGenContext{
+		prefs:                     unsafe { prefs }
+		declared_types:            declared_types
+		declared_type_c_names:     declared_type_c_names
+		declared_type_key_by_name: fastc_declared_type_key_by_name(declared_types)
+		fastc_prefixed_c_names:    fastc_prefixed_c_names
+		has_c_functions:           fastc_functions_declare_c(functions)
+		declared_kinds:            declared_kinds
+		enum_flags:                enum_flags
+		enum_field_types:          enum_field_types
+		alias_base_types:          alias_base_types
+		struct_fields:             struct_fields
+		struct_field_info:         struct_field_info
+		functions:                 functions
+		constants:                 constants
+		public_constants:          public_constants
+		globals:                   globals
+		public_globals:            public_globals
+	}
+	// Candidates carry their filtered constant source as `source`, in module
+	// dependency order, so both the parallel pre-pass and the in-order merge
+	// below see the same files.
+	mut candidates := []FastcSourceFile{cap: ordered_sources.len}
 	for source_file in ordered_sources {
 		constant_source := constant_sources[source_file.path] or { continue }
-		mut file_set := token.FileSet.new()
-		mut file := file_set.add_file(source_file.path, constant_source.len)
-		file.index_lines_without_digest(constant_source)
-		mut gen := Parser{
-			prefs:                        unsafe { prefs }
-			path:                         source_file.path
-			module_name:                  source_file.header.module_name
-			imports:                      source_file.header.imports
-			declared_types:               declared_types
-			declared_type_c_names:        declared_type_c_names
-			declared_type_key_by_name:    declared_type_key_by_name
-			fastc_prefixed_c_names:       fastc_prefixed_c_names
-			declaration_initializer_mode: true
-			has_c_functions:              helper_has_c_functions
-			comparison_memo:              map[i64]FastcRenderedExpression{}
-			spawn_typedefs:               map[string]string{}
-			spawn_helpers:                map[string]string{}
-			thread_value_types:           map[string]string{}
-			declared_kinds:               declared_kinds
-			enum_flags:                   enum_flags
-			enum_field_types:             enum_field_types
-			alias_base_types:             alias_base_types
-			struct_fields:                struct_fields
-			struct_field_info:            struct_field_info
-			constants:                    constants
-			public_constants:             public_constants
-			globals:                      globals
-			public_globals:               public_globals
-			selfhost:                     prefs.building_v
-			s:                            scanner.new_scanner(prefs, .normal)
-			out:                          strings.new_builder(256)
-			protos:                       strings.new_builder(0)
-			functions:                    functions
-			constant_types:               constant_types
-			composite_types:              map[string]bool{}
-			fixed_array_types:            map[string]string{}
+		candidates << FastcSourceFile{
+			path:   source_file.path
+			source: constant_source
+			header: source_file.header
 		}
-		gen.s.init(file, constant_source)
-		gen.next()
-		gen.parse_selected_constant_declarations(mut values, false)!
-		if gen.s.diagnostics.len > 0 {
-			diagnostic := gen.s.diagnostics[0]
-			return error('fastc scanner error at byte ${diagnostic.offset} in ${source_file.path}: ${diagnostic.message}')
+	}
+	parallel_results := fastc_parse_constant_files_parallel(&ctx, candidates, constant_types)
+	for index, candidate in candidates {
+		if index < parallel_results.len {
+			result := parallel_results[index]
+			if !result.failed && fastc_constant_file_is_independent(result) {
+				for value in result.values {
+					constant_types[value.key] = value.typ
+				}
+				values << result.values
+				for name, _ in result.composite_types {
+					composite_types[name] = true
+				}
+				for name, array_type in result.fixed_array_types {
+					fixed_array_types[name] = array_type
+				}
+				continue
+			}
 		}
-		constant_types = gen.constant_types.move()
-		for name, _ in gen.composite_types {
+		mut serial := fastc_parse_constant_file(&ctx, candidate, constant_types)
+		if serial.failed {
+			return error(serial.error_message)
+		}
+		constant_types = serial.constant_types.move()
+		values << serial.values
+		for name, _ in serial.composite_types {
 			composite_types[name] = true
 		}
-		for name, array_type in gen.fixed_array_types {
+		for name, array_type in serial.fixed_array_types {
 			fixed_array_types[name] = array_type
 		}
 	}
@@ -1324,15 +1506,14 @@ fn fastc_order_c_composite_definitions(source string, struct_fields map[string]m
 	mut ordered := source
 	mut changed := true
 	mut passes := 0
+	// Index every `struct/union NAME {` definition start once. The
+	// dependency-already-before-dependent test is the overwhelmingly common
+	// case, and a splice only moves one definition block, so the index is
+	// updated arithmetically instead of rescanning the text after each move.
+	mut positions := fastc_composite_definition_positions(ordered)
 	for changed && passes < struct_fields.len {
 		changed = false
 		passes++
-		// Index every `struct/union NAME {` definition start once per pass.
-		// The dependency-already-before-dependent test is the overwhelmingly
-		// common case; the previous code re-scanned `ordered` twice per struct
-		// field to decide it. Positions only shift when a move happens, so the
-		// map is rebuilt after each actual splice.
-		mut positions := fastc_composite_definition_positions(ordered)
 		for dependent, fields in struct_fields {
 			for _, field_type in fields {
 				dependency := fastc_by_value_composite_type(field_type, by_value_composite_names,
@@ -1345,16 +1526,43 @@ fn fastc_order_c_composite_definitions(source string, struct_fields map[string]m
 				if dependency_start < dependent_start {
 					continue
 				}
+				block_end := fastc_c_composite_block_end(ordered, dependency_start) or { continue }
 				next := fastc_move_c_composite_before(ordered, dependency_start, dependent_start)
 				if next != ordered {
 					ordered = next
 					changed = true
-					positions = fastc_composite_definition_positions(ordered)
+					fastc_shift_composite_positions(mut positions, dependency_start, block_end,
+						dependent_start)
 				}
 			}
 		}
 	}
 	return ordered
+}
+
+// fastc_shift_composite_positions updates definition starts after the block
+// [block_start, block_end) was spliced in front of the definition at
+// insert_at: the moved block now starts there, and every definition that was
+// between the insertion point and the block moved down by the block's length.
+fn fastc_shift_composite_positions(mut positions map[string]int, block_start int, block_end int, insert_at int) {
+	block_len := block_end - block_start
+	for name, start in positions {
+		if start == block_start {
+			positions[name] = insert_at
+		} else if start >= insert_at && start < block_start {
+			positions[name] = start + block_len
+		}
+	}
+}
+
+// fastc_c_composite_block_end returns the end of the definition block that
+// starts at `start`, including the newlines that follow its `};`.
+fn fastc_c_composite_block_end(source string, start int) ?int {
+	mut end := fastc_c_composite_definition_end(source, start) or { return none }
+	for end < source.len && source[end] == `\n` {
+		end++
+	}
+	return end
 }
 
 // fastc_composite_definition_positions maps each C composite name to the start
@@ -1424,13 +1632,7 @@ fn fastc_move_c_composite_before(source string, dependency_start int, dependent_
 	if dependency_start < dependent_start {
 		return source
 	}
-	dependency_end := fastc_c_composite_definition_end(source, dependency_start) or {
-		return source
-	}
-	mut end := dependency_end
-	for end < source.len && source[end] == `\n` {
-		end++
-	}
+	end := fastc_c_composite_block_end(source, dependency_start) or { return source }
 	block := source[dependency_start..end]
 	return source[..dependent_start] + block + source[dependent_start..dependency_start] + source[end..]
 }
@@ -1447,9 +1649,7 @@ fn fastc_c_composite_definition_end(source string, start int) ?int {
 }
 
 fn fastc_emit_source_type_declarations(source_file FastcSourceFile, prefs &pref.Preferences, declared_types map[string]bool, declared_kinds map[string]FastcDeclaredTypeKind, constants map[string]string, public_constants map[string]bool, mut struct_fields map[string]map[string]string, mut struct_field_info map[string][]FastcStructField, mut composite_types map[string]bool, mut alias_base_types map[string]string, mut sum_types map[string]bool, mut sum_type_variants map[string]bool, mut enum_infos []FastcEnumInfo, mut out strings.Builder) ! {
-	mut file_set := token.FileSet.new()
-	mut file := file_set.add_file(source_file.path, source_file.source.len)
-	file.index_lines_without_digest(source_file.source)
+	file := token.File.unindexed(source_file.path, source_file.source.len)
 	mut scan := scanner.new_scanner(prefs, .normal)
 	scan.init(file, source_file.source)
 	mut depth := 0
@@ -1903,6 +2103,25 @@ fn fastc_resolve_declared_type_key(module_name string, raw_type string, imports 
 }
 
 fn (g &Parser) resolve_declared_type_key(raw_type string) ?string {
+	if entry := g.declared_type_key_memo[raw_type] {
+		if entry.found {
+			return entry.value
+		}
+		return none
+	}
+	mut w := unsafe { &Parser(g) }
+	if key := g.resolve_declared_type_key_uncached(raw_type) {
+		w.declared_type_key_memo[raw_type] = FastcMemoEntry{
+			found: true
+			value: key
+		}
+		return key
+	}
+	w.declared_type_key_memo[raw_type] = FastcMemoEntry{}
+	return none
+}
+
+fn (g &Parser) resolve_declared_type_key_uncached(raw_type string) ?string {
 	if g.declared_type_key_by_name.len == 0 {
 		return fastc_resolve_declared_type_key(g.module_name, raw_type, g.imports, g.declared_types)
 	}

--- a/vlib/v3/gen/fastc/fastc.v
+++ b/vlib/v3/gen/fastc/fastc.v
@@ -1,6 +1,8 @@
 module fastc
 
+import os
 import strings
+import time
 import v3.pref
 import v3.scanner
 import v3.token
@@ -40,9 +42,13 @@ typedef void *chan;
 typedef struct { void *data; int offset; int len; int cap; int flags; } array;
 typedef struct { void *data; int len; } map;
 typedef struct { void *data; void *err; unsigned char state; } Option;
-typedef union { uintptr_t word; long double alignment; unsigned char data[64]; } MultiReturnValue;
+/* One multi-return component. Values up to 32 bytes are stored inline; larger
+   ones are boxed and referenced through `ptr`, so no component size can
+   overflow the slot. */
+typedef union { uintptr_t word; long double alignment; void *ptr; unsigned char data[32]; } MultiReturnValue;
 typedef struct { MultiReturnValue values[8]; } MultiReturn;
-#define V_FASTC_MULTI_VALUE(expression) ({ __typeof__(expression) __v_fastc_multi_value = (expression); MultiReturnValue __v_fastc_multi_result = {0}; memcpy(__v_fastc_multi_result.data, &__v_fastc_multi_value, sizeof(__v_fastc_multi_value)); __v_fastc_multi_result; })
+#define V_FASTC_MULTI_VALUE(expression) ({ __typeof__(expression) __v_fastc_multi_value = (expression); MultiReturnValue __v_fastc_multi_result; if (sizeof(__v_fastc_multi_value) <= sizeof(__v_fastc_multi_result.data)) memcpy(__v_fastc_multi_result.data, &__v_fastc_multi_value, sizeof(__v_fastc_multi_value)); else __v_fastc_multi_result.ptr = v_fastc_interface_box(&__v_fastc_multi_value, sizeof(__v_fastc_multi_value)); __v_fastc_multi_result; })
+#define V_FASTC_MULTI_SOURCE(slot, size) (((size) <= sizeof((slot).data)) ? (const void *)(slot).data : (const void *)(slot).ptr)
 
 static void v_fastc_print_string(const char *value) { fputs(value ? value : "", stdout); }
 static void v_fastc_print_bool(bool value) { fputs(value ? "true" : "false", stdout); }
@@ -323,6 +329,9 @@ typedef _Bool bool;
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#ifndef _WIN32
+#include <pthread.h>
+#endif
 
 typedef int8_t i8;
 typedef int16_t i16;
@@ -342,23 +351,99 @@ typedef void *voidptr;
 typedef unsigned char *byteptr;
 typedef char *charptr;
 typedef void *chan;
-typedef union { uintptr_t word; long double alignment; unsigned char data[64]; } MultiReturnValue;
+/* One multi-return component. Values up to 32 bytes are stored inline; larger
+   ones are boxed and referenced through `ptr`, so no component size can
+   overflow the slot. */
+typedef union { uintptr_t word; long double alignment; void *ptr; unsigned char data[32]; } MultiReturnValue;
 typedef struct { MultiReturnValue values[8]; } MultiReturn;
-#define V_FASTC_MULTI_VALUE(expression) ({ __typeof__(expression) __v_fastc_multi_value = (expression); MultiReturnValue __v_fastc_multi_result = {0}; memcpy(__v_fastc_multi_result.data, &__v_fastc_multi_value, sizeof(__v_fastc_multi_value)); __v_fastc_multi_result; })
+#define V_FASTC_MULTI_VALUE(expression) ({ __typeof__(expression) __v_fastc_multi_value = (expression); MultiReturnValue __v_fastc_multi_result; if (sizeof(__v_fastc_multi_value) <= sizeof(__v_fastc_multi_result.data)) memcpy(__v_fastc_multi_result.data, &__v_fastc_multi_value, sizeof(__v_fastc_multi_value)); else __v_fastc_multi_result.ptr = v_fastc_interface_box(&__v_fastc_multi_value, sizeof(__v_fastc_multi_value)); __v_fastc_multi_result; })
+#define V_FASTC_MULTI_SOURCE(slot, size) (((size) <= sizeof((slot).data)) ? (const void *)(slot).data : (const void *)(slot).ptr)
 
 #define _S(s) ((string){.str=(byteptr)("" s), .len=(sizeof(s)-1), .is_lit=1})
 #define _SLIT0 _S("")
 
+/* Option, result, and interface payloads are boxed on the heap and never
+   freed. Boxing through malloc made every option-returning call pay for a
+   locked, zero-filling allocation, so each thread bumps its boxes out of a
+   private chunk instead; only oversized payloads still go through malloc. */
+#ifndef _WIN32
+typedef struct { unsigned char *cursor; unsigned char *end; } v_fastc_box_arena;
+static pthread_key_t v_fastc_box_arena_key;
+static pthread_once_t v_fastc_box_arena_once = PTHREAD_ONCE_INIT;
+static void v_fastc_box_arena_create_key(void) { pthread_key_create(&v_fastc_box_arena_key, NULL); }
+static void *v_fastc_interface_box(const void *value, usize size) {
+	usize aligned = (size + 15) & ~(usize)15;
+	usize chunk = 262144;
+	v_fastc_box_arena *arena;
+	void *copy;
+	if (aligned > 65536) {
+		copy = malloc(size);
+		if (copy != NULL) memcpy(copy, value, size);
+		return copy;
+	}
+	pthread_once(&v_fastc_box_arena_once, v_fastc_box_arena_create_key);
+	arena = (v_fastc_box_arena *)pthread_getspecific(v_fastc_box_arena_key);
+	if (arena == NULL || (usize)(arena->end - arena->cursor) < aligned) {
+		unsigned char *block = (unsigned char *)malloc(sizeof(v_fastc_box_arena) + chunk);
+		if (block == NULL) return NULL;
+		arena = (v_fastc_box_arena *)block;
+		arena->cursor = block + sizeof(v_fastc_box_arena);
+		arena->end = arena->cursor + chunk;
+		pthread_setspecific(v_fastc_box_arena_key, arena);
+	}
+	copy = arena->cursor;
+	arena->cursor += aligned;
+	memcpy(copy, value, size);
+	return copy;
+}
+#else
 static void *v_fastc_interface_box(const void *value, usize size) {
 	void *copy = malloc(size);
 	if (copy != NULL) memcpy(copy, value, size);
 	return copy;
 }
+#endif
 
 static const u64 _wyp[4] = {0x2d358dccaa6c78a5ull, 0x8bb84b93962eacc9ull, 0x4b33a62ed433d4a3ull, 0x4d5a2da51de1aa47ull};
 static inline u64 _wymix(u64 a, u64 b) { u64 ha = a >> 32, hb = b >> 32, la = (u32)a, lb = (u32)b, hi, lo; u64 rh = ha * hb, rm0 = ha * lb, rm1 = hb * la, rl = la * lb, t = rl + (rm0 << 32), c = t < rl; lo = t + (rm1 << 32); c += lo < t; hi = rh + (rm0 >> 32) + (rm1 >> 32) + c; return lo ^ hi; }
 static inline u64 wyhash64(u64 a, u64 b) { a ^= _wyp[0]; b ^= _wyp[1]; a *= 0xa0761d6478bd642full; b *= 0xe7037ed1a0b428dbull; return (a ^ (a >> 32)) ^ (b ^ (b >> 32)); }
-static inline u64 wyhash(const void *key, size_t len, u64 seed, const u64 *secret) { const unsigned char *p = (const unsigned char *)key; u64 h = seed ^ secret[0] ^ (u64)len; for (size_t i = 0; i < len; i++) h = wyhash64(h ^ (u64)p[i], secret[(i + 1) & 3]); return h; }
+#if defined(__aarch64__) || defined(__x86_64__) || defined(__i386__)
+#define V_FASTC_LOAD_U64(p) (*(const u64 *)(p))
+#else
+#define V_FASTC_LOAD_U64(p) ({ u64 __v_fastc_word; memcpy(&__v_fastc_word, (p), 8); __v_fastc_word; })
+#endif
+/* Map keys are hashed by this function on every lookup. It mixes one 64-bit
+   word per step and has no helper calls, since TinyCC does not inline. */
+static inline u64 wyhash(const void *key, size_t len, u64 seed, const u64 *secret) {
+	const unsigned char *p = (const unsigned char *)key;
+	size_t n = len;
+	u64 h = seed ^ secret[0] ^ ((u64)len * 0x9e3779b97f4a7c15ull);
+	while (n >= 8) {
+		h = (h ^ V_FASTC_LOAD_U64(p)) * 0xa0761d6478bd642full;
+		h ^= h >> 29;
+		p += 8;
+		n -= 8;
+	}
+	if (n > 0) {
+		u64 v = 0;
+		switch (n) {
+			case 7: v |= (u64)p[6] << 48;
+			case 6: v |= (u64)p[5] << 40;
+			case 5: v |= (u64)p[4] << 32;
+			case 4: v |= (u64)p[3] << 24;
+			case 3: v |= (u64)p[2] << 16;
+			case 2: v |= (u64)p[1] << 8;
+			default: v |= (u64)p[0];
+		}
+		h = (h ^ v) * 0xe7037ed1a0b428dbull;
+		h ^= h >> 29;
+	}
+	h *= 0x8ebc6af09c88c6e3ull;
+	h ^= h >> 32;
+	h *= 0x589965cc75374cc3ull;
+	h ^= h >> 29;
+	return h;
+}
 
 '
 
@@ -576,6 +661,19 @@ struct FastcFunctionSignature {
 	path                     string
 }
 
+// fastc_multi_return_literal packs already-boxed components into a MultiReturn.
+// Filling an uninitialized local slot by slot avoids the zero-fill a partially
+// designated compound literal would perform on the whole aggregate.
+fn fastc_multi_return_literal(packed_values []string) string {
+	mut out := strings.new_builder(64)
+	out.write_string('({ MultiReturn __v_fastc_multi; ')
+	for i, value in packed_values {
+		out.write_string('__v_fastc_multi.values[${i}] = ${value}; ')
+	}
+	out.write_string('__v_fastc_multi; })')
+	return out.str()
+}
+
 fn fastc_string_types_equal(left []string, right []string) bool {
 	if left.len != right.len {
 		return false
@@ -640,6 +738,12 @@ struct FastcRenderedExpression {
 	typ    string
 }
 
+// FastcMemoEntry caches an optional lookup result, including a negative one.
+struct FastcMemoEntry {
+	found bool
+	value string
+}
+
 struct FastcInterpolationWidth {
 	width      int
 	left_align bool
@@ -691,6 +795,13 @@ struct FastcSourceHeader {
 	has_globals             bool
 	has_constants           bool
 	has_global_declarations bool
+	// Byte-level superset tests over the whole file (see fastc_source_scan_flags):
+	// a false flag proves the file cannot hold that kind of declaration, so the
+	// matching collection pass skips its scan.
+	has_interfaces        bool
+	has_comptime_if       bool
+	has_type_keywords     bool
+	has_generic_fn_syntax bool
 }
 
 struct FastcSourceFile {
@@ -704,6 +815,9 @@ struct FastcQueuedSource {
 	path         string
 	module_name  string
 	is_canonical bool
+	// listed sources came from a directory listing moments ago, so their
+	// existence check is skipped.
+	listed bool
 }
 
 struct FastcLoadedSource {
@@ -860,20 +974,31 @@ struct Parser {
 	has_startup_inits   bool
 	has_cleanup_hooks   bool
 mut:
-	path                     string
-	source_offset            int
-	module_name              string
-	imports                  map[string]string
-	s                        scanner.Scanner
-	tok                      token.Token
-	lit                      string
-	out                      strings.Builder
-	protos                   strings.Builder
-	indent                   int
-	in_main                  bool
-	has_main                 bool
-	unsafe_depth             int
-	temp_id                  int
+	path          string
+	source_offset int
+	module_name   string
+	imports       map[string]string
+	s             scanner.Scanner
+	tok           token.Token
+	lit           string
+	out           strings.Builder
+	protos        strings.Builder
+	indent        int
+	in_main       bool
+	has_main      bool
+	unsafe_depth  int
+	// Set while generating a `@[direct_array_access]` function body, so string
+	// and array indexing skip the bounds-checked runtime accessors.
+	direct_array_access         bool
+	pending_direct_array_access bool
+	temp_id                     int
+	// Per-file memos for name lookups whose answers depend only on file-level
+	// tables (module, imports, functions, constants, globals, declared types)
+	// and are asked again for the same short name many times per file.
+	unqualified_key_memo     map[string]string
+	nonlocal_name_type_memo  map[string]string
+	resolved_name_memo       map[string]string
+	declared_type_key_memo   map[string]FastcMemoEntry
 	locals                   map[string]FastcLocal
 	local_scope_changes      []FastcLocalScopeChange
 	local_scope_depth        int
@@ -997,13 +1122,41 @@ pub fn generate_files(paths []string, prefs &pref.Preferences) !string {
 }
 
 // generate_files_with_source_paths emits C and reports every source read during import discovery.
+// FastcPhaseTimer reports per-phase generation timings to stderr when
+// FASTC_BENCH_PHASES is set; it is a no-op otherwise.
+struct FastcPhaseTimer {
+mut:
+	enabled bool
+	sw      time.StopWatch
+	last_us i64
+}
+
+fn fastc_new_phase_timer() FastcPhaseTimer {
+	return FastcPhaseTimer{
+		enabled: os.getenv('FASTC_BENCH_PHASES') != ''
+		sw: time.new_stopwatch()
+	}
+}
+
+fn (mut timer FastcPhaseTimer) mark(name string) {
+	if !timer.enabled {
+		return
+	}
+	now_us := timer.sw.elapsed().microseconds()
+	eprintln('fastc-phase ${name} ${now_us - timer.last_us}us')
+	timer.last_us = now_us
+}
+
 pub fn generate_files_with_source_paths(paths []string, prefs &pref.Preferences) !GenerationResult {
+	mut timer := fastc_new_phase_timer()
 	sources, module_aliases := fastc_resolve_source_files(paths, prefs)!
+	timer.mark('resolve')
 	mut source_paths := []string{cap: sources.len}
 	for source_file in sources {
 		source_paths << source_file.path
 	}
 	c_source, uses_threads, c_flags := generate_source_files(sources, module_aliases, prefs)!
+	timer.mark('generate_total')
 	return GenerationResult{
 		c_source: c_source
 		source_paths: source_paths
@@ -1069,12 +1222,14 @@ mut:
 }
 
 fn fastc_generate_single_file(ctx &FastcFileGenContext, source_file FastcSourceFile) FastcFileGenOutput {
-	mut file_set := token.FileSet.new()
-	mut file := file_set.add_file(source_file.path, source_file.source.len)
-	file.index_lines_without_digest(source_file.source)
+	file := token.File.unindexed(source_file.path, source_file.source.len)
 	prefs := ctx.prefs
 	mut gen := Parser{
 		prefs: unsafe { prefs }
+		unqualified_key_memo: map[string]string{}
+		nonlocal_name_type_memo: map[string]string{}
+		resolved_name_memo: map[string]string{}
+		declared_type_key_memo: map[string]FastcMemoEntry{}
 		path: source_file.path
 		source_offset: source_file.source_offset
 		module_name: source_file.header.module_name
@@ -1161,8 +1316,11 @@ fn fastc_generate_single_file(ctx &FastcFileGenContext, source_file FastcSourceF
 fn generate_source_files(input_sources []FastcSourceFile, module_aliases map[string]string, prefs &pref.Preferences) !(string, bool, []string) {
 	// Source-level generic monomorphization runs first; it is a no-op when the
 	// program has no generic function definitions (so the self-host is untouched).
-	sources := fastc_monomorphize_sources(input_sources, prefs)!
-	generic_method_sources := fastc_collect_generic_method_sources(sources, prefs)
+	mut timer := fastc_new_phase_timer()
+	mut sources := fastc_monomorphize_sources(input_sources, prefs)!
+	timer.mark('monomorphize')
+	generic_method_sources := fastc_collect_generic_method_sources(mut sources, prefs)
+	timer.mark('generic_method_sources')
 	mut declared_types := map[string]bool{}
 	mut declared_kinds := map[string]FastcDeclaredTypeKind{}
 	mut enum_flags := map[string]bool{}
@@ -1177,6 +1335,7 @@ fn generate_source_files(input_sources []FastcSourceFile, module_aliases map[str
 	mut type_sources := map[string]string{}
 	mut constant_sources := map[string]string{}
 	fastc_collect_declaration_indexes(sources, prefs, mut declared_types, mut declared_kinds, mut enum_flags, mut params_structs, mut type_source_paths, mut type_sources, mut constants, mut public_constants, mut constant_sources, mut globals, mut public_globals)!
+	timer.mark('declaration_indexes')
 	declared_type_c_names := fastc_declared_type_c_names(declared_types)
 	declared_type_key_by_name := fastc_declared_type_key_by_name(declared_types)
 	mut functions := map[string]FastcFunctionSignature{}
@@ -1187,6 +1346,7 @@ fn generate_source_files(input_sources []FastcSourceFile, module_aliases map[str
 	mut embed_embedders := []string{}
 	mut embed_embeddeds := []string{}
 	fastc_collect_signatures(sources, prefs, declared_types, declared_type_c_names, params_structs, mut functions, mut interface_methods, mut interface_fields, mut embed_embedders, mut embed_embeddeds)!
+	timer.mark('signatures')
 	// An interface that embeds another (`interface B { A; ... }`) inherits A's
 	// methods. Copy them onto B (with the receiver re-keyed to B) so calls on a B
 	// value resolve and B gets its own dispatch table entries.
@@ -1194,8 +1354,12 @@ fn generate_source_files(input_sources []FastcSourceFile, module_aliases map[str
 	mut pending_references := fastc_start_referenced_function_names(sources, prefs, functions)
 	has_c_functions := fastc_functions_declare_c(functions)
 	fastc_prefixed_c_names := fastc_reserved_temporary_c_names(functions, globals)
-	module_init_calls := fastc_module_init_calls(sources, functions)!
-	module_cleanup_calls := fastc_module_cleanup_calls(sources, functions)!
+	// Module dependency order is shared by the lifecycle, constant, global, and
+	// startup-initializer passes below.
+	ordered_sources := fastc_sources_in_dependency_order(sources)!
+	module_init_calls := fastc_module_init_calls(ordered_sources, functions)!
+	module_cleanup_calls := fastc_module_cleanup_calls(ordered_sources, functions)!
+	timer.mark('lifecycle_calls')
 	mut composite_types := map[string]bool{}
 	if prefs.building_v {
 		// The OS exec helpers build their native argv arrays locally, so this
@@ -1209,17 +1373,21 @@ fn generate_source_files(input_sources []FastcSourceFile, module_aliases map[str
 		}
 	}
 	type_output := fastc_generate_type_declarations(sources, type_sources, prefs, type_source_paths, declared_types, declared_kinds, enum_flags, constants, public_constants, mut struct_fields, mut struct_field_info, mut composite_types)!
+	timer.mark('type_declarations')
 	declared_composite_types := composite_types.clone()
 	type_declarations := type_output.declarations
 	enum_field_types := type_output.enum_field_types.clone()
 	mut constant_types := map[string]string{}
 	mut global_types := map[string]string{}
 	fastc_render_struct_field_defaults(prefs, declared_types, declared_type_c_names, fastc_prefixed_c_names, declared_kinds, enum_flags, enum_field_types, type_output.alias_base_types, struct_fields, mut struct_field_info, functions, constants, public_constants, constant_types, globals, public_globals, global_types, type_output.sum_types)!
-	constant_output := fastc_generate_constant_declarations(sources, constant_sources, prefs, declared_types, declared_type_c_names, fastc_prefixed_c_names, declared_kinds, enum_flags, enum_field_types, type_output.alias_base_types, struct_fields, struct_field_info, functions, constants, public_constants, globals, public_globals, mut constant_types)!
+	timer.mark('field_defaults')
+	constant_output := fastc_generate_constant_declarations(ordered_sources, constant_sources, prefs, declared_types, declared_type_c_names, fastc_prefixed_c_names, declared_kinds, enum_flags, enum_field_types, type_output.alias_base_types, struct_fields, struct_field_info, functions, constants, public_constants, globals, public_globals, mut constant_types)!
+	timer.mark('constant_declarations')
 	for name, _ in constant_output.composite_types {
 		composite_types[name] = true
 	}
-	global_output := fastc_generate_global_declarations(sources, prefs, declared_types, declared_type_c_names, fastc_prefixed_c_names, declared_kinds, enum_flags, enum_field_types, type_output.alias_base_types, struct_fields, struct_field_info, functions, constants, constant_output.compile_time_values, public_constants, constant_types, globals, public_globals, mut global_types)!
+	global_output := fastc_generate_global_declarations(ordered_sources, prefs, declared_types, declared_type_c_names, fastc_prefixed_c_names, declared_kinds, enum_flags, enum_field_types, type_output.alias_base_types, struct_fields, struct_field_info, functions, constants, constant_output.compile_time_values, public_constants, constant_types, globals, public_globals, mut global_types)!
+	timer.mark('global_declarations')
 	for name, _ in global_output.composite_types {
 		composite_types[name] = true
 	}
@@ -1229,8 +1397,10 @@ fn generate_source_files(input_sources []FastcSourceFile, module_aliases map[str
 	for global_type in global_types.values() {
 		fastc_register_composite_type(global_type, mut composite_types)
 	}
-	startup_initializers := fastc_generate_startup_initializers(sources, constant_output.module_initializers, global_output.module_initializers, module_init_calls)!
+	startup_initializers := fastc_generate_startup_initializers(ordered_sources, constant_output.module_initializers, global_output.module_initializers, module_init_calls)!
+	timer.mark('startup_initializers')
 	used_function_names := fastc_wait_referenced_function_names(mut pending_references)
+	timer.mark('wait_references')
 	mut pending_interface_dispatches := fastc_start_interface_dispatches(declared_kinds, functions, interface_methods, used_function_names, prefs.building_v, prefs)
 	mut struct_field_lookup := map[string]map[string]FastcStructField{}
 	for layout_type, fields in struct_field_info {
@@ -1293,6 +1463,18 @@ fn generate_source_files(input_sources []FastcSourceFile, module_aliases map[str
 	mut mono_definitions := map[string]string{}
 	mut c_flags := []string{}
 	outputs := fastc_generate_file_outputs(&ctx, sources)
+	timer.mark('file_outputs')
+	// Size the stitch buffers up front: the per-file bodies add up to several
+	// megabytes, and growing the builders by doubling would copy that text
+	// several times over.
+	mut prototypes_size := 0
+	mut body_size := 0
+	for output in outputs {
+		prototypes_size += output.prototypes.len
+		body_size += output.body.len
+	}
+	prototypes.ensure_cap(prototypes_size + 1024)
+	body.ensure_cap(body_size + 4096)
 	for output in outputs {
 		if output.failed {
 			return error(output.error_message)
@@ -1333,6 +1515,7 @@ fn generate_source_files(input_sources []FastcSourceFile, module_aliases map[str
 	}
 	mut mono_names := mono_definitions.keys()
 	mono_names.sort()
+	timer.mark('stitch')
 	for mono_name in mono_names {
 		body.write_string(mono_definitions[mono_name])
 	}
@@ -1363,9 +1546,11 @@ fn generate_source_files(input_sources []FastcSourceFile, module_aliases map[str
 		late_composite_declarations.writeln('')
 	}
 	interface_dispatches := fastc_wait_interface_dispatches(mut pending_interface_dispatches)
+	timer.mark('wait_interface_dispatches')
 	fixed_array_declarations := fastc_generate_fixed_array_declarations(fixed_array_types)
 	preamble := if prefs.building_v { c_selfhost_preamble } else { c_preamble }
 	hoisted_body := fastc_partition_c_directive_lines(body.str(), body_directive_lines)
+	timer.mark('partition_directives')
 	mut result := strings.new_builder(preamble.len + c_integer_comparison_helpers.len + type_declarations.len + type_output.enum_string_helpers.len + constant_output.macros.len + constant_output.declarations.len + global_output.declarations.len + prototypes.len + body.len + startup_initializers.len + 96)
 	result.write_string(preamble)
 	result.write_string(c_integer_comparison_helpers)
@@ -1444,6 +1629,7 @@ fn generate_source_files(input_sources []FastcSourceFile, module_aliases map[str
 	if hoisted_body.final_kind == 0 {
 		result.write_u8(`\n`)
 	}
+	timer.mark('assemble')
 	return result.str(), spawn_typedefs.len > 0, c_flags
 }
 

--- a/vlib/v3/gen/fastc/fastc.v
+++ b/vlib/v3/gen/fastc/fastc.v
@@ -407,11 +407,10 @@ static void *v_fastc_interface_box(const void *value, usize size) {
 static const u64 _wyp[4] = {0x2d358dccaa6c78a5ull, 0x8bb84b93962eacc9ull, 0x4b33a62ed433d4a3ull, 0x4d5a2da51de1aa47ull};
 static inline u64 _wymix(u64 a, u64 b) { u64 ha = a >> 32, hb = b >> 32, la = (u32)a, lb = (u32)b, hi, lo; u64 rh = ha * hb, rm0 = ha * lb, rm1 = hb * la, rl = la * lb, t = rl + (rm0 << 32), c = t < rl; lo = t + (rm1 << 32); c += lo < t; hi = rh + (rm0 >> 32) + (rm1 >> 32) + c; return lo ^ hi; }
 static inline u64 wyhash64(u64 a, u64 b) { a ^= _wyp[0]; b ^= _wyp[1]; a *= 0xa0761d6478bd642full; b *= 0xe7037ed1a0b428dbull; return (a ^ (a >> 32)) ^ (b ^ (b >> 32)); }
-#if defined(__aarch64__) || defined(__x86_64__) || defined(__i386__)
-#define V_FASTC_LOAD_U64(p) (*(const u64 *)(p))
-#else
-#define V_FASTC_LOAD_U64(p) ({ u64 __v_fastc_word; memcpy(&__v_fastc_word, (p), 8); __v_fastc_word; })
-#endif
+/* Assembling the word from its bytes is defined for any alignment and any
+   effective type of the key storage; optimizing compilers fold it into one
+   load, and the hash stays identical across byte orders. */
+#define V_FASTC_LOAD_U64(p) ((u64)(p)[0] | ((u64)(p)[1] << 8) | ((u64)(p)[2] << 16) | ((u64)(p)[3] << 24) | ((u64)(p)[4] << 32) | ((u64)(p)[5] << 40) | ((u64)(p)[6] << 48) | ((u64)(p)[7] << 56))
 /* Map keys are hashed by this function on every lookup. It mixes one 64-bit
    word per step and has no helper calls, since TinyCC does not inline. */
 static inline u64 wyhash(const void *key, size_t len, u64 seed, const u64 *secret) {

--- a/vlib/v3/gen/fastc/fastc_test.v
+++ b/vlib/v3/gen/fastc/fastc_test.v
@@ -580,13 +580,36 @@ fn test_fastc_overlap_workers_honor_serial_preferences() {
 	assert fastc_wait_interface_dispatches(mut pending_dispatches) == ''
 }
 
-fn test_fastc_source_declaration_flags_respect_identifier_boundaries() {
-	has_constants, has_global_declarations := fastc_source_declaration_flags('module main\nconst answer = 42\n__global count int\n')
-	assert has_constants
-	assert has_global_declarations
-	identifier_constants, identifier_globals := fastc_source_declaration_flags('module main\nfn key_const() {}\nfn use__global_value() {}\n')
-	assert !identifier_constants
-	assert !identifier_globals
+fn test_fastc_source_scan_flags_respect_identifier_boundaries() {
+	flags := fastc_source_scan_flags('module main\nconst answer = 42\n__global count int\n')
+	assert flags.has_constants
+	assert flags.has_global_declarations
+	assert !flags.has_interfaces
+	assert !flags.has_comptime_if
+	assert !flags.has_type_keywords
+	assert !flags.has_generic_fn_syntax
+	identifier_flags := fastc_source_scan_flags('module main\nfn key_const() {}\nfn use__global_value() {}\nfn interfaces() {}\nfn structure() {}\n')
+	assert !identifier_flags.has_constants
+	assert !identifier_flags.has_global_declarations
+	assert !identifier_flags.has_interfaces
+	assert !identifier_flags.has_type_keywords
+}
+
+fn test_fastc_source_scan_flags_detect_declaration_keywords() {
+	assert fastc_source_scan_flags('module main\ninterface Shape { area() int }\n').has_interfaces
+	assert fastc_source_scan_flags('module main\ninterface Shape {}\n').has_type_keywords
+	assert fastc_source_scan_flags('module main\nstruct Point { x int }\n').has_type_keywords
+	assert fastc_source_scan_flags('module main\nenum Color { red }\n').has_type_keywords
+	assert fastc_source_scan_flags('module main\ntype Id = int\n').has_type_keywords
+	assert fastc_source_scan_flags('module main\nunion Bits { a int }\n').has_type_keywords
+	dollar := '$'
+	assert fastc_source_scan_flags('module main\n' + dollar + 'if linux {\nfn only_linux() {}\n}\n').has_comptime_if
+	assert fastc_source_scan_flags('module main\n' + dollar + ' if linux {\nfn only_linux() {}\n}\n').has_comptime_if
+	assert !fastc_source_scan_flags('module main\nfn main() { println("' + dollar + '{1}") }\n').has_comptime_if
+	assert fastc_source_scan_flags('module main\nfn pick[T](value T) T { return value }\n').has_generic_fn_syntax
+	assert fastc_source_scan_flags('module main\nfn (s Stack) push[T](value T) {}\n').has_generic_fn_syntax
+	assert fastc_source_scan_flags('module main\nfn Stack.make[T]() Stack {}\n').has_generic_fn_syntax
+	assert !fastc_source_scan_flags('module main\nfn plain(values []int) int { return values[0] }\n').has_generic_fn_syntax
 }
 
 fn test_fastc_generic_source_collection_matches_serial_scan() {
@@ -621,8 +644,9 @@ fn test_fastc_generic_source_collection_matches_serial_scan() {
 			}
 		},
 	]
-	serial := fastc_collect_generic_method_source_chunk(sources, prefs, 0, sources.len)
-	collected := fastc_collect_generic_method_sources(sources, prefs)
+	serial := fastc_collect_generic_method_source_chunk(sources, prefs, 0, sources.len).sources
+	mut flagged_sources := sources.clone()
+	collected := fastc_collect_generic_method_sources(mut flagged_sources, prefs)
 	assert collected.keys().len == serial.keys().len
 	for key, expected in serial {
 		assert key in collected
@@ -8960,8 +8984,8 @@ fn main() {
 	// `if a, b := opt_fn() { ... }` unwraps an option whose value is a multi-return
 	// tuple: on success the boxed MultiReturn is copied out and each component bound.
 	assert c_source.contains('MultiReturn'), c_source
-	assert c_source.contains('.values[0].data'), c_source
-	assert c_source.contains('.values[1].data'), c_source
+	assert c_source.contains('.values[0], sizeof('), c_source
+	assert c_source.contains('.values[1], sizeof('), c_source
 }
 
 fn test_selfhost_if_multi_return_option_guard_with_shared_bindings() {
@@ -9665,7 +9689,7 @@ fn main() {
 	// failure state assign the fallback tuple, else unbox the MultiReturn component.
 	assert c_source.contains('.state) {'), c_source
 	assert c_source.contains('MultiReturn'), c_source
-	assert c_source.contains('.values[1].data'), c_source
+	assert c_source.contains('.values[1], sizeof('), c_source
 }
 
 fn test_selfhost_assign_concrete_value_to_option_local() {

--- a/vlib/v3/gen/fastc/fastc_test.v
+++ b/vlib/v3/gen/fastc/fastc_test.v
@@ -612,6 +612,20 @@ fn test_fastc_source_scan_flags_detect_declaration_keywords() {
 	assert !fastc_source_scan_flags('module main\nfn plain(values []int) int { return values[0] }\n').has_generic_fn_syntax
 }
 
+fn test_fastc_source_scan_flags_skip_comments_between_tokens() {
+	// The scanner treats comments as whitespace, so the byte probes must not
+	// let one hide a `$if` or a generic declaration.
+	dollar := '$'
+	assert fastc_source_scan_flags('module main\n' + dollar + '/* c */if linux {\nfn only_linux() {}\n}\n').has_comptime_if
+	assert fastc_source_scan_flags('module main\n' + dollar + '// c\nif linux {\nfn only_linux() {}\n}\n').has_comptime_if
+	assert fastc_source_scan_flags('module main\n' + dollar + '/* outer /* nested */ */ if linux {\n}\n').has_comptime_if
+	assert fastc_source_scan_flags('module main\nfn /* c */ pick[T](x T) T { return x }\n').has_generic_fn_syntax
+	assert fastc_source_scan_flags('module main\nfn pick /* c */ [T](x T) T { return x }\n').has_generic_fn_syntax
+	assert fastc_source_scan_flags('module main\nfn (s /* ) */ Stack) push[T](v T) {}\n').has_generic_fn_syntax
+	assert fastc_source_scan_flags('module main\nfn (s Stack) // c\n push[T](v T) {}\n').has_generic_fn_syntax
+	assert !fastc_source_scan_flags('module main\nfn plain() { x := 1 // [T]\n }\n').has_generic_fn_syntax
+}
+
 fn test_fastc_generic_source_collection_matches_serial_scan() {
 	mut prefs := pref.new_preferences()
 	sources := [

--- a/vlib/v3/gen/fastc/fn.v
+++ b/vlib/v3/gen/fastc/fn.v
@@ -62,9 +62,7 @@ fn fastc_is_json2_voidptr_element_check(req FastcMonoRequest, src FastcGenericMe
 // parse_mono_instance re-parses one concrete instance in its defining module, so its body
 // (including any `$for`/`$if`) resolves unqualified functions and imported types correctly.
 fn (mut g Parser) parse_mono_instance(instance string, source FastcGenericMethodSource) ! {
-	mut file_set := token.FileSet.new()
-	mut file := file_set.add_file(source.path, instance.len)
-	file.index_lines_without_digest(instance)
+	file := token.File.unindexed(source.path, instance.len)
 	g.path = source.path
 	g.module_name = source.module_name
 	g.imports = source.imports.clone()
@@ -98,6 +96,7 @@ fn (mut g Parser) parse_top_level_items(stop_at_block_end bool) ! {
 			continue
 		}
 		mut item_enabled := true
+		g.pending_direct_array_access = false
 		for g.tok == .attribute {
 			item_enabled = g.skip_attribute()! && item_enabled
 			g.skip_semicolons()
@@ -374,6 +373,9 @@ fn (mut g Parser) skip_attribute() !bool {
 			}
 			continue
 		}
+		if depth == 1 && g.tok == .name && g.lit == 'direct_array_access' {
+			g.pending_direct_array_access = true
+		}
 		if depth == 1 && g.tok == .semicolon {
 			at_item_start = true
 		} else if depth == 1 {
@@ -477,6 +479,12 @@ fn (g &Parser) temporary_namespace(kind string) string {
 fn fastc_reserved_temporary_c_names(functions map[string]FastcFunctionSignature, globals map[string]string) []string {
 	mut names := []string{}
 	for function_key in functions.keys() {
+		// Only an unqualified key can collide with a C keyword or libc name and
+		// so be renamed into the `__v_fastc_` namespace: a module-qualified key
+		// keeps its `module__name` spelling, and `C.` keys are emitted verbatim.
+		if function_key.contains('.') {
+			continue
+		}
 		function_c_name := fastc_c_function_name_for_key(function_key)
 		if function_c_name.starts_with('__v_fastc_') {
 			names << function_c_name
@@ -559,6 +567,8 @@ fn (mut g Parser) skip_import() ! {
 fn (mut g Parser) parse_function(enabled bool) ! {
 	g.locals = map[string]FastcLocal{}
 	g.temp_id = 0
+	g.direct_array_access = g.pending_direct_array_access
+	g.pending_direct_array_access = false
 	g.next()
 	mut receiver_type := ''
 	mut receiver_key := ''

--- a/vlib/v3/gen/fastc/fn.v
+++ b/vlib/v3/gen/fastc/fn.v
@@ -59,6 +59,16 @@ fn fastc_is_json2_voidptr_element_check(req FastcMonoRequest, src FastcGenericMe
 	return req.concrete == 'voidptr' && src.name == 'check_element_type_valid' && (src.receiver_type == 'json2__Decoder' || src.receiver_type.ends_with('__json2__Decoder')) && normalized_path.ends_with('/vlib/json2/decode_sumtype.v')
 }
 
+// reset_lookup_memos discards the per-file name lookup memos. They are keyed
+// by the bare name only, so they are valid for exactly one module and import
+// context and must be reset whenever the parser switches to another one.
+fn (mut g Parser) reset_lookup_memos() {
+	g.unqualified_key_memo = map[string]string{}
+	g.nonlocal_name_type_memo = map[string]string{}
+	g.resolved_name_memo = map[string]string{}
+	g.declared_type_key_memo = map[string]FastcMemoEntry{}
+}
+
 // parse_mono_instance re-parses one concrete instance in its defining module, so its body
 // (including any `$for`/`$if`) resolves unqualified functions and imported types correctly.
 fn (mut g Parser) parse_mono_instance(instance string, source FastcGenericMethodSource) ! {
@@ -66,6 +76,9 @@ fn (mut g Parser) parse_mono_instance(instance string, source FastcGenericMethod
 	g.path = source.path
 	g.module_name = source.module_name
 	g.imports = source.imports.clone()
+	// The lookup memos are keyed by bare name and answer for the current
+	// module and imports, so they must not carry over into another module.
+	g.reset_lookup_memos()
 	g.s = scanner.new_scanner(g.prefs, .normal)
 	g.s.init(file, instance)
 	g.next()

--- a/vlib/v3/gen/fastc/if.v
+++ b/vlib/v3/gen/fastc/if.v
@@ -409,7 +409,7 @@ fn (mut g Parser) parse_if_multi_return_guard(names []string) !bool {
 		component_type := fastc_normalize_inferred_type(component_types[i])
 		c_name := fastc_c_identifier(name)
 		g.write_line('${component_type} ${c_name} = (${component_type}){0};')
-		g.write_line('memcpy(&${c_name}, ${multi_return}.values[${i}].data, sizeof(${c_name}));')
+		g.write_line('memcpy(&${c_name}, V_FASTC_MULTI_SOURCE(${multi_return}.values[${i}], sizeof(${c_name})), sizeof(${c_name}));')
 		g.locals[name] = FastcLocal{
 			typ: component_type
 		}
@@ -706,7 +706,7 @@ fn (mut g Parser) read_return_expression_branch() !string {
 		g.consume_statement_end()
 		g.last_expression_type = ''
 		g.last_expression = []FastcExpressionToken{}
-		return '({ return (MultiReturn){.values={${values.join(', ')}}}; 0; })'
+		return '({ return ${fastc_multi_return_literal(values)}; 0; })'
 	}
 	value := g.read_expression([token.Token.semicolon, token.Token.rcbr])!
 	g.consume_statement_end()

--- a/vlib/v3/gen/fastc/match.v
+++ b/vlib/v3/gen/fastc/match.v
@@ -282,7 +282,7 @@ fn (mut g Parser) read_match_block_expression_value() !string {
 	g.last_expression_type = 'MultiReturn'
 	g.last_expression = []FastcExpressionToken{}
 	g.last_multi_return_types = value_types.clone()
-	return '(MultiReturn){.values={${packed_values.join(', ')}}}'
+	return fastc_multi_return_literal(packed_values)
 }
 
 fn (mut g Parser) read_block_expression_value() !string {
@@ -309,7 +309,7 @@ fn (mut g Parser) read_block_expression_value() !string {
 		g.last_expression_type = 'MultiReturn'
 		g.last_expression = []FastcExpressionToken{}
 		g.last_multi_return_types = value_types.clone()
-		return '(MultiReturn){.values={${packed_values.join(', ')}}}'
+		return fastc_multi_return_literal(packed_values)
 	}
 	previous_capture := g.capturing_defer
 	previous_lines := g.captured_defer_lines.clone()
@@ -365,7 +365,7 @@ fn (mut g Parser) read_block_expression_value() !string {
 		g.last_expression_type = 'MultiReturn'
 		g.last_expression = []FastcExpressionToken{}
 		g.last_multi_return_types = value_types.clone()
-		return '({ ${statements.join(' ')} (MultiReturn){.values={${packed_values.join(', ')}}}; })'
+		return '({ ${statements.join(' ')} ${fastc_multi_return_literal(packed_values)}; })'
 	}
 	if g.tok == .name {
 		prefix := g.lit

--- a/vlib/v3/gen/fastc/monomorphize.v
+++ b/vlib/v3/gen/fastc/monomorphize.v
@@ -46,10 +46,24 @@ struct FastcGenericMethodSource {
 // fastc_collect_generic_method_source_chunk indexes the generic methods and free
 // functions in one contiguous source range. The parallel wrapper merges ranges in
 // source order so duplicate keys retain the serial scan's last-definition behavior.
-fn fastc_collect_generic_method_source_chunk(sources []FastcSourceFile, prefs &pref.Preferences, start int, end int) map[string]FastcGenericMethodSource {
+// FastcGenericScanPartial is one chunk's generic method index plus the
+// declaration keyword flags of every file in the chunk, in chunk order.
+struct FastcGenericScanPartial {
+mut:
+	sources map[string]FastcGenericMethodSource
+	flags   []FastcSourceScanFlags
+}
+
+fn fastc_collect_generic_method_source_chunk(sources []FastcSourceFile, prefs &pref.Preferences, start int, end int) FastcGenericScanPartial {
 	mut result := map[string]FastcGenericMethodSource{}
+	mut flags := []FastcSourceScanFlags{cap: end - start}
 	for i in start .. end {
 		source_file := sources[i]
+		file_flags := fastc_source_scan_flags(source_file.source)
+		flags << file_flags
+		if !file_flags.has_generic_fn_syntax {
+			continue
+		}
 		module_name := source_file.header.module_name
 		for generic in fastc_scan_generic_fns(source_file.source, source_file.path, prefs, i) {
 			receiver_type := if generic.receiver_type != '' {
@@ -76,7 +90,10 @@ fn fastc_collect_generic_method_source_chunk(sources []FastcSourceFile, prefs &p
 			}
 		}
 	}
-	return result
+	return FastcGenericScanPartial{
+		sources: result
+		flags: flags
+	}
 }
 
 // mono_argument_type infers the first argument's concrete type for an on-demand
@@ -437,9 +454,7 @@ fn fastc_generic_type_source_uses_parameter(source string, type_params string, p
 	for type_param in type_params.split(',') {
 		parameters[type_param] = true
 	}
-	mut file_set := token.FileSet.new()
-	mut file := file_set.add_file('generic_return_type', source.len)
-	file.index_lines_without_digest(source)
+	file := token.File.unindexed('generic_return_type', source.len)
 	mut scan := scanner.new_scanner(prefs, .normal)
 	scan.init(file, source)
 	mut tok := scan.scan()
@@ -470,9 +485,7 @@ fn (g &Parser) render_mono_method(src FastcGenericMethodSource, concrete string)
 // before expression parsing, otherwise `Result[Concrete]{...}` is mistaken for an array
 // access followed by an ordinary block.
 fn (g &Parser) erase_mono_generic_type_arguments(source string, src FastcGenericMethodSource) string {
-	mut file_set := token.FileSet.new()
-	mut file := file_set.add_file(src.path, source.len)
-	file.index_lines_without_digest(source)
+	file := token.File.unindexed(src.path, source.len)
 	mut scan := scanner.new_scanner(g.prefs, .normal)
 	scan.init(file, source)
 	mut edits := []FastcSourceEdit{}
@@ -839,9 +852,7 @@ fn fastc_render_generic_instance_with_call_rewrites(source string, generic Fastc
 			}
 		}
 	}
-	mut file_set := token.FileSet.new()
-	mut file := file_set.add_file('mono', definition.len)
-	file.index_lines_without_digest(definition)
+	file := token.File.unindexed('mono', definition.len)
 	mut s := scanner.new_scanner(prefs, .normal)
 	s.init(file, definition)
 	bracket_low := generic.bracket_start - base
@@ -878,9 +889,7 @@ fn fastc_render_generic_instance_with_call_rewrites(source string, generic Fastc
 // so it never misclassifies ordinary code.
 fn fastc_scan_generic_fns(source string, path string, prefs &pref.Preferences, source_index int) []FastcGenericFn {
 	mut result := []FastcGenericFn{}
-	mut file_set := token.FileSet.new()
-	mut file := file_set.add_file(path, source.len)
-	file.index_lines_without_digest(source)
+	file := token.File.unindexed(path, source.len)
 	mut s := scanner.new_scanner(prefs, .normal)
 	s.init(file, source)
 	mut previous := token.Token.unknown
@@ -1024,9 +1033,7 @@ fn fastc_params_type_param_index(params_source string, type_param string, prefs 
 		type_params[name] = true
 	}
 	no_imports := map[string]string{}
-	mut file_set := token.FileSet.new()
-	mut file := file_set.add_file('params', params_source.len)
-	file.index_lines_without_digest(params_source)
+	file := token.File.unindexed('params', params_source.len)
 	mut s := scanner.new_scanner(prefs, .normal)
 	s.init(file, params_source)
 	mut tok := s.scan()
@@ -1102,9 +1109,7 @@ fn fastc_infer_literal_type(tok token.Token, lit string) string {
 // resolved at source level (a non-literal implicit argument, a bare function
 // reference, or a malformed explicit type argument).
 fn fastc_scan_generic_calls(source string, path string, prefs &pref.Preferences, source_index int, by_name map[string]FastcGenericFn, mut calls []FastcGenericCall, mut unresolvable map[string]bool, mut pairs []FastcConcretePair, mut seen_pair map[string]bool, mut has_concrete map[string]bool) {
-	mut file_set := token.FileSet.new()
-	mut file := file_set.add_file(path, source.len)
-	file.index_lines_without_digest(source)
+	file := token.File.unindexed(path, source.len)
 	mut s := scanner.new_scanner(prefs, .normal)
 	s.init(file, source)
 	// A call inside a generic body may resolve its argument to the ENCLOSING generic's
@@ -1587,9 +1592,7 @@ fn fastc_monomorphize_structs(sources []FastcSourceFile, prefs &pref.Preferences
 // type parameter and no nested generic type reference in the body.
 fn fastc_scan_generic_structs(source string, path string, prefs &pref.Preferences, source_index int) []FastcGenericFn {
 	mut result := []FastcGenericFn{}
-	mut file_set := token.FileSet.new()
-	mut file := file_set.add_file(path, source.len)
-	file.index_lines_without_digest(source)
+	file := token.File.unindexed(path, source.len)
 	mut s := scanner.new_scanner(prefs, .normal)
 	s.init(file, source)
 	mut previous := token.Token.unknown
@@ -1673,9 +1676,7 @@ fn fastc_scan_generic_structs(source string, path string, prefs &pref.Preference
 // generic type reference (`Foo[X]`). Plain arrays (`[]T`, `[N]T`) and maps
 // (`map[K]V`) are allowed; only a `Name[...]` with non-empty brackets counts.
 fn fastc_body_has_nested_generic(body string, prefs &pref.Preferences) bool {
-	mut file_set := token.FileSet.new()
-	mut file := file_set.add_file('body', body.len)
-	file.index_lines_without_digest(body)
+	file := token.File.unindexed('body', body.len)
 	mut s := scanner.new_scanner(prefs, .normal)
 	s.init(file, body)
 	mut previous := token.Token.unknown
@@ -1731,9 +1732,7 @@ fn fastc_is_concrete_type_arg(name string) bool {
 // a plain concrete instantiation (a type-parameter argument, a complex type
 // argument, or a bare reference).
 fn fastc_scan_generic_struct_instances(source string, path string, prefs &pref.Preferences, source_index int, by_name map[string]FastcGenericFn, receiver_skip map[string]bool, mut refs []FastcGenericCall, mut unresolvable map[string]bool, mut pairs []FastcConcretePair, mut seen_pair map[string]bool, mut has_concrete map[string]bool) {
-	mut file_set := token.FileSet.new()
-	mut file := file_set.add_file(path, source.len)
-	file.index_lines_without_digest(source)
+	file := token.File.unindexed(path, source.len)
 	mut s := scanner.new_scanner(prefs, .normal)
 	s.init(file, source)
 	mut previous := token.Token.unknown
@@ -1797,9 +1796,7 @@ fn fastc_scan_generic_struct_instances(source string, path string, prefs &pref.P
 // beyond its receiver, or carries its own type parameters, cannot be handled by
 // simple substitution and marks its struct problematic (later unresolvable).
 fn fastc_scan_generic_methods(source string, path string, prefs &pref.Preferences, source_index int, by_name map[string]FastcGenericFn, mut methods []FastcGenericMethod, mut receiver_skip map[string]bool, mut method_problematic map[string]bool) {
-	mut file_set := token.FileSet.new()
-	mut file := file_set.add_file(path, source.len)
-	file.index_lines_without_digest(source)
+	file := token.File.unindexed(path, source.len)
 	mut s := scanner.new_scanner(prefs, .normal)
 	s.init(file, source)
 	mut previous := token.Token.unknown
@@ -1952,9 +1949,7 @@ fn fastc_render_generic_method(source string, method FastcGenericMethod, concret
 		end: receiver_high
 		replacement: fastc_monomorphized_name(method.struct_name, concrete)
 	}
-	mut file_set := token.FileSet.new()
-	mut file := file_set.add_file('method', definition.len)
-	file.index_lines_without_digest(definition)
+	file := token.File.unindexed('method', definition.len)
 	mut s := scanner.new_scanner(prefs, .normal)
 	s.init(file, definition)
 	substitutions := fastc_type_param_substitutions(method.type_param, concrete)

--- a/vlib/v3/gen/fastc/names.v
+++ b/vlib/v3/gen/fastc/names.v
@@ -81,15 +81,20 @@ fn fastc_c_function_name(module_name string, name string) string {
 }
 
 fn (g &Parser) unqualified_function_key(name string) string {
+	if cached := g.unqualified_key_memo[name] {
+		return cached
+	}
 	local_key := fastc_function_key(g.module_name, name)
-	if local_key in g.functions {
-		return local_key
+	mut key := local_key
+	if local_key !in g.functions {
+		builtin_key := fastc_function_key('builtin', name)
+		if builtin_key in g.functions {
+			key = builtin_key
+		}
 	}
-	builtin_key := fastc_function_key('builtin', name)
-	if builtin_key in g.functions {
-		return builtin_key
-	}
-	return local_key
+	mut w := unsafe { &Parser(g) }
+	w.unqualified_key_memo[name] = key
+	return key
 }
 
 fn fastc_c_function_name_for_key(key string) string {

--- a/vlib/v3/gen/fastc/parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/fastc/parallel_notd_v3_no_parallel.v
@@ -1,6 +1,7 @@
 module fastc
 
 import os
+import time
 import v3.pref
 import v3.scanner
 import v3.token
@@ -145,10 +146,14 @@ fn fastc_chunk_bounds(sources []FastcSourceFile, jobs int) []int {
 // fastc_collect_generic_method_sources indexes every generic method and free
 // function remaining after source monomorphization. Scanning is independent per
 // file, and chunk maps are merged in source order for deterministic duplicates.
-fn fastc_collect_generic_method_sources(sources []FastcSourceFile, prefs &pref.Preferences) map[string]FastcGenericMethodSource {
+// It also computes every file's declaration keyword flags, since this is the
+// first pass over the sources, and stores them in the returned headers.
+fn fastc_collect_generic_method_sources(mut sources []FastcSourceFile, prefs &pref.Preferences) map[string]FastcGenericMethodSource {
 	jobs := fastc_parallel_jobs(sources, prefs)
 	if jobs <= 1 {
-		return fastc_collect_generic_method_source_chunk(sources, prefs, 0, sources.len)
+		partial := fastc_collect_generic_method_source_chunk(sources, prefs, 0, sources.len)
+		fastc_apply_scan_flags(mut sources, partial.flags, 0)
+		return partial.sources
 	}
 	bounds := fastc_chunk_bounds(sources, jobs)
 	second_thread := spawn fastc_collect_generic_method_source_chunk(sources, prefs, bounds[2], bounds[3])
@@ -157,14 +162,29 @@ fn fastc_collect_generic_method_sources(sources []FastcSourceFile, prefs &pref.P
 		chunk_thread := spawn fastc_collect_generic_method_source_chunk(sources, prefs, bounds[chunk_idx * 2], bounds[chunk_idx * 2 + 1])
 		chunk_threads << chunk_thread
 	}
-	mut result := fastc_collect_generic_method_source_chunk(sources, prefs, bounds[0], bounds[1])
-	for chunk_thread in chunk_threads {
+	mut first := fastc_collect_generic_method_source_chunk(sources, prefs, bounds[0], bounds[1])
+	mut result := first.sources.move()
+	fastc_apply_scan_flags(mut sources, first.flags, bounds[0])
+	for chunk_idx, chunk_thread in chunk_threads {
 		chunk := chunk_thread.wait()
-		for key, generic in chunk {
+		for key, generic in chunk.sources {
 			result[key] = generic
 		}
+		fastc_apply_scan_flags(mut sources, chunk.flags, bounds[(chunk_idx + 1) * 2])
 	}
 	return result
+}
+
+fn fastc_apply_scan_flags(mut sources []FastcSourceFile, flags []FastcSourceScanFlags, start int) {
+	for i, file_flags in flags {
+		source_file := sources[start + i]
+		sources[start + i] = FastcSourceFile{
+			path: source_file.path
+			source: source_file.source
+			source_offset: source_file.source_offset
+			header: fastc_header_with_scan_flags(source_file.header, file_flags)
+		}
+	}
 }
 
 struct FastcIndexedFileGenOutput {
@@ -211,6 +231,8 @@ fn fastc_file_generation_order(sources []FastcSourceFile) []int {
 fn fastc_generate_file_steal(ctx &FastcFileGenContext, sources []FastcSourceFile, order []int, queue &FastcGenQueue) []FastcIndexedFileGenOutput {
 	mut outputs := []FastcIndexedFileGenOutput{}
 	limit := u32(order.len)
+	bench_files := os.getenv('FASTC_BENCH_FILES') != ''
+	mut sw := time.new_stopwatch()
 	for {
 		// Relaxed ordering is enough: the counter only hands out unique indices,
 		// and `order`/`sources` are fully initialized and read-only before the
@@ -221,15 +243,19 @@ fn fastc_generate_file_steal(ctx &FastcFileGenContext, sources []FastcSourceFile
 			break
 		}
 		file_index := order[claimed]
+		start_us := sw.elapsed().microseconds()
 		outputs << FastcIndexedFileGenOutput{
 			index: file_index
 			output: fastc_generate_single_file(ctx, sources[file_index])
+		}
+		if bench_files {
+			eprintln('fastc-file ${sw.elapsed().microseconds() - start_us} ${sources[file_index].source.len} ${sources[file_index].path}')
 		}
 	}
 	return outputs
 }
 
-const fastc_generation_fragment_size = 56 * 1024
+const fastc_generation_fragment_size = 28 * 1024
 
 fn fastc_generation_fragment_is_followed_by_comptime_else(scan scanner.Scanner) bool {
 	mut lookahead := scan
@@ -244,13 +270,11 @@ fn fastc_generation_fragment_is_followed_by_comptime_else(scan scanner.Scanner) 
 }
 
 fn fastc_source_generation_fragments(source_file FastcSourceFile, prefs &pref.Preferences) []FastcSourceFile {
-	if !prefs.building_v || !source_file.header.module_name.ends_with('fastc') || source_file.source.len <= fastc_generation_fragment_size {
+	if !fastc_source_needs_fragmentation(source_file, prefs) {
 		return [source_file]
 	}
 	part_count := (source_file.source.len + fastc_generation_fragment_size - 1) / fastc_generation_fragment_size
-	mut file_set := token.FileSet.new()
-	mut file := file_set.add_file(source_file.path, source_file.source.len)
-	file.index_lines_without_digest(source_file.source)
+	file := token.File.unindexed(source_file.path, source_file.source.len)
 	mut scan := scanner.new_scanner(prefs, .normal)
 	scan.init(file, source_file.source)
 	mut cuts := [0]
@@ -328,10 +352,69 @@ fn fastc_source_generation_fragments(source_file FastcSourceFile, prefs &pref.Pr
 	return fragments
 }
 
+fn fastc_source_needs_fragmentation(source_file FastcSourceFile, prefs &pref.Preferences) bool {
+	return prefs.building_v && source_file.header.module_name.ends_with('fastc') && source_file.source.len > fastc_generation_fragment_size
+}
+
+struct FastcFragmentedSource {
+	index     int
+	fragments []FastcSourceFile
+}
+
+fn fastc_generation_fragment_chunk(candidates []FastcSourceFile, candidate_indices []int, prefs &pref.Preferences, start int, end int) []FastcFragmentedSource {
+	mut result := []FastcFragmentedSource{cap: end - start}
+	for i in start .. end {
+		result << FastcFragmentedSource{
+			index: candidate_indices[i]
+			fragments: fastc_source_generation_fragments(candidates[i], prefs)
+		}
+	}
+	return result
+}
+
+// fastc_generation_fragments splits oversized self-host sources into
+// top-level fragments. Finding the cut points scans each candidate with the
+// scanner, so candidates are scanned on parallel workers; the fragments are
+// then spliced back in source order.
 fn fastc_generation_fragments(sources []FastcSourceFile, prefs &pref.Preferences) []FastcSourceFile {
-	mut fragments := []FastcSourceFile{cap: sources.len + 8}
-	for source_file in sources {
-		fragments << fastc_source_generation_fragments(source_file, prefs)
+	mut candidates := []FastcSourceFile{}
+	mut candidate_indices := []int{}
+	for index, source_file in sources {
+		if fastc_source_needs_fragmentation(source_file, prefs) {
+			candidates << source_file
+			candidate_indices << index
+		}
+	}
+	mut fragments := []FastcSourceFile{cap: sources.len + candidates.len * 4}
+	if candidates.len == 0 {
+		fragments << sources
+		return fragments
+	}
+	jobs := fastc_parallel_job_count(candidates.len, prefs)
+	mut fragmented := []FastcFragmentedSource{cap: candidates.len}
+	if jobs <= 1 {
+		fragmented = fastc_generation_fragment_chunk(candidates, candidate_indices, prefs, 0, candidates.len)
+	} else {
+		bounds := fastc_chunk_bounds(candidates, jobs)
+		second_thread := spawn fastc_generation_fragment_chunk(candidates, candidate_indices, prefs, bounds[2], bounds[3])
+		mut chunk_threads := [second_thread]
+		for chunk_idx in 2 .. bounds.len / 2 {
+			chunk_thread := spawn fastc_generation_fragment_chunk(candidates, candidate_indices, prefs, bounds[chunk_idx * 2], bounds[chunk_idx * 2 + 1])
+			chunk_threads << chunk_thread
+		}
+		fragmented << fastc_generation_fragment_chunk(candidates, candidate_indices, prefs, bounds[0], bounds[1])
+		for chunk_thread in chunk_threads {
+			fragmented << chunk_thread.wait()
+		}
+	}
+	mut next_fragmented := 0
+	for index, source_file in sources {
+		if next_fragmented < fragmented.len && fragmented[next_fragmented].index == index {
+			fragments << fragmented[next_fragmented].fragments
+			next_fragmented++
+		} else {
+			fragments << source_file
+		}
 	}
 	return fragments
 }
@@ -348,11 +431,14 @@ fn fastc_generate_file_outputs(ctx &FastcFileGenContext, sources []FastcSourceFi
 		}
 		return outputs
 	}
+	mut timer := fastc_new_phase_timer()
 	generation_sources := fastc_generation_fragments(sources, ctx.prefs)
+	timer.mark('file_outputs.fragments')
 	order := fastc_file_generation_order(generation_sources)
 	mut queue := &FastcGenQueue{
 		next: 0
 	}
+	timer.mark('file_outputs.order')
 	second_thread := spawn fastc_generate_file_steal(ctx, generation_sources, order, queue)
 	mut worker_threads := [second_thread]
 	for _ in 2 .. jobs {
@@ -363,12 +449,14 @@ fn fastc_generate_file_outputs(ctx &FastcFileGenContext, sources []FastcSourceFi
 	for indexed_output in first_outputs {
 		outputs[indexed_output.index] = indexed_output.output
 	}
+	timer.mark('file_outputs.first_chunk')
 	for worker_thread in worker_threads {
 		worker_outputs := worker_thread.wait()
 		for indexed_output in worker_outputs {
 			outputs[indexed_output.index] = indexed_output.output
 		}
 	}
+	timer.mark('file_outputs.wait_chunks')
 	return outputs
 }
 
@@ -434,6 +522,30 @@ fn fastc_collect_reference_partials(sources []FastcSourceFile, prefs &pref.Prefe
 	}
 }
 
+struct FastcIndexedDeclarationPartial {
+	index   int
+	partial FastcDeclarationPartial
+}
+
+// fastc_collect_declaration_worker collects one file at a time from the shared
+// counter (largest files first); the caller merges the partials in file order,
+// so the result matches a serial pass exactly.
+fn fastc_collect_declaration_worker(sources []FastcSourceFile, prefs &pref.Preferences, order []int, queue &FastcGenQueue) []FastcIndexedDeclarationPartial {
+	mut partials := []FastcIndexedDeclarationPartial{}
+	for {
+		slot := fastc_atomic_fetch_add_u32(&queue.next, 1)
+		if slot >= u32(order.len) {
+			break
+		}
+		index := order[slot]
+		partials << FastcIndexedDeclarationPartial{
+			index: index
+			partial: fastc_collect_declaration_chunk(sources, prefs, index, index + 1)
+		}
+	}
+	return partials
+}
+
 fn fastc_collect_declaration_indexes(sources []FastcSourceFile, prefs &pref.Preferences, mut declared_types map[string]bool, mut declared_kinds map[string]FastcDeclaredTypeKind, mut enum_flags map[string]bool, mut params_structs map[string]bool, mut type_source_paths map[string]bool, mut type_sources map[string]string, mut constants map[string]string, mut public_constants map[string]bool, mut constant_sources map[string]string, mut globals map[string]string, mut public_globals map[string]bool) ! {
 	jobs := fastc_parallel_jobs(sources, prefs)
 	if jobs <= 1 {
@@ -441,19 +553,53 @@ fn fastc_collect_declaration_indexes(sources []FastcSourceFile, prefs &pref.Pref
 		fastc_merge_declaration_partial(partial, mut declared_types, mut declared_kinds, mut enum_flags, mut params_structs, mut type_source_paths, mut type_sources, mut constants, mut public_constants, mut constant_sources, mut globals, mut public_globals)!
 		return
 	}
-	bounds := fastc_chunk_bounds(sources, jobs)
-	second_thread := spawn fastc_collect_declaration_chunk(sources, prefs, bounds[2], bounds[3])
+	order := fastc_file_generation_order(sources)
+	mut queue := &FastcGenQueue{
+		next: 0
+	}
+	second_thread := spawn fastc_collect_declaration_worker(sources, prefs, order, queue)
 	mut chunk_threads := [second_thread]
-	for chunk_idx in 2 .. bounds.len / 2 {
-		chunk_thread := spawn fastc_collect_declaration_chunk(sources, prefs, bounds[chunk_idx * 2], bounds[chunk_idx * 2 + 1])
+	for _ in 2 .. jobs {
+		chunk_thread := spawn fastc_collect_declaration_worker(sources, prefs, order, queue)
 		chunk_threads << chunk_thread
 	}
-	first := fastc_collect_declaration_chunk(sources, prefs, bounds[0], bounds[1])
-	fastc_merge_declaration_partial(first, mut declared_types, mut declared_kinds, mut enum_flags, mut params_structs, mut type_source_paths, mut type_sources, mut constants, mut public_constants, mut constant_sources, mut globals, mut public_globals)!
+	mut partials := []FastcDeclarationPartial{len: sources.len}
+	first := fastc_collect_declaration_worker(sources, prefs, order, queue)
+	for indexed in first {
+		partials[indexed.index] = indexed.partial
+	}
 	for chunk_thread in chunk_threads {
-		partial := chunk_thread.wait()
+		worker_partials := chunk_thread.wait()
+		for indexed in worker_partials {
+			partials[indexed.index] = indexed.partial
+		}
+	}
+	for partial in partials {
 		fastc_merge_declaration_partial(partial, mut declared_types, mut declared_kinds, mut enum_flags, mut params_structs, mut type_source_paths, mut type_sources, mut constants, mut public_constants, mut constant_sources, mut globals, mut public_globals)!
 	}
+}
+
+struct FastcIndexedSignaturePartial {
+	index   int
+	partial FastcSignaturePartial
+}
+
+// fastc_collect_signature_worker collects one file at a time from the shared
+// counter (largest files first); the caller merges the partials in file order.
+fn fastc_collect_signature_worker(sources []FastcSourceFile, prefs &pref.Preferences, declared_types map[string]bool, declared_type_c_names map[string]string, params_structs map[string]bool, order []int, queue &FastcGenQueue) []FastcIndexedSignaturePartial {
+	mut partials := []FastcIndexedSignaturePartial{}
+	for {
+		slot := fastc_atomic_fetch_add_u32(&queue.next, 1)
+		if slot >= u32(order.len) {
+			break
+		}
+		index := order[slot]
+		partials << FastcIndexedSignaturePartial{
+			index: index
+			partial: fastc_collect_signature_chunk(sources, prefs, declared_types, declared_type_c_names, params_structs, index, index + 1)
+		}
+	}
+	return partials
 }
 
 fn fastc_collect_signatures(sources []FastcSourceFile, prefs &pref.Preferences, declared_types map[string]bool, declared_type_c_names map[string]string, params_structs map[string]bool, mut functions map[string]FastcFunctionSignature, mut interface_methods map[string]bool, mut interface_fields map[string]FastcInterfaceField, mut embed_embedders []string, mut embed_embeddeds []string) ! {
@@ -463,17 +609,28 @@ fn fastc_collect_signatures(sources []FastcSourceFile, prefs &pref.Preferences, 
 		fastc_merge_signature_partial(partial, mut functions, mut interface_methods, mut interface_fields, mut embed_embedders, mut embed_embeddeds)!
 		return
 	}
-	bounds := fastc_chunk_bounds(sources, jobs)
-	second_thread := spawn fastc_collect_signature_chunk(sources, prefs, declared_types, declared_type_c_names, params_structs, bounds[2], bounds[3])
+	order := fastc_file_generation_order(sources)
+	mut queue := &FastcGenQueue{
+		next: 0
+	}
+	second_thread := spawn fastc_collect_signature_worker(sources, prefs, declared_types, declared_type_c_names, params_structs, order, queue)
 	mut chunk_threads := [second_thread]
-	for chunk_idx in 2 .. bounds.len / 2 {
-		chunk_thread := spawn fastc_collect_signature_chunk(sources, prefs, declared_types, declared_type_c_names, params_structs, bounds[chunk_idx * 2], bounds[chunk_idx * 2 + 1])
+	for _ in 2 .. jobs {
+		chunk_thread := spawn fastc_collect_signature_worker(sources, prefs, declared_types, declared_type_c_names, params_structs, order, queue)
 		chunk_threads << chunk_thread
 	}
-	first := fastc_collect_signature_chunk(sources, prefs, declared_types, declared_type_c_names, params_structs, bounds[0], bounds[1])
-	fastc_merge_signature_partial(first, mut functions, mut interface_methods, mut interface_fields, mut embed_embedders, mut embed_embeddeds)!
+	mut partials := []FastcSignaturePartial{len: sources.len}
+	first := fastc_collect_signature_worker(sources, prefs, declared_types, declared_type_c_names, params_structs, order, queue)
+	for indexed in first {
+		partials[indexed.index] = indexed.partial
+	}
 	for chunk_thread in chunk_threads {
-		partial := chunk_thread.wait()
+		worker_partials := chunk_thread.wait()
+		for indexed in worker_partials {
+			partials[indexed.index] = indexed.partial
+		}
+	}
+	for partial in partials {
 		fastc_merge_signature_partial(partial, mut functions, mut interface_methods, mut interface_fields, mut embed_embedders, mut embed_embeddeds)!
 	}
 }

--- a/vlib/v3/gen/fastc/signatures.v
+++ b/vlib/v3/gen/fastc/signatures.v
@@ -122,9 +122,7 @@ fn fastc_parameter_is_params_struct(parameter_type string, params_structs map[st
 }
 
 fn collect_function_signatures(source string, path string, header FastcSourceHeader, prefs &pref.Preferences, declared_types map[string]bool, declared_type_c_names map[string]string, params_structs map[string]bool, mut functions map[string]FastcFunctionSignature) ! {
-	mut file_set := token.FileSet.new()
-	mut file := file_set.add_file(path, source.len)
-	file.index_lines_without_digest(source)
+	file := token.File.unindexed(path, source.len)
 	mut scan := scanner.new_scanner(prefs, .normal)
 	scan.init(file, source)
 	mut brace_depth := 0
@@ -409,7 +407,9 @@ fn collect_function_signatures(source string, path string, header FastcSourceHea
 		previous_tok = tok
 		tok = scan.scan()
 	}
-	fastc_collect_selected_comptime_function_signatures(source, path, header, prefs, declared_types, declared_type_c_names, params_structs, mut functions)!
+	if header.has_comptime_if {
+		fastc_collect_selected_comptime_function_signatures(source, path, header, prefs, declared_types, declared_type_c_names, params_structs, mut functions)!
+	}
 }
 
 // fastc_scan_function_alias_signature scans the signature after `type Name = fn`
@@ -606,9 +606,7 @@ fn fastc_collect_type_default_references(mut scan scanner.Scanner, first token.T
 }
 
 fn collect_interface_method_signatures(source string, path string, header FastcSourceHeader, prefs &pref.Preferences, declared_types map[string]bool, mut functions map[string]FastcFunctionSignature, mut interface_methods map[string]bool, mut interface_fields map[string]FastcInterfaceField, mut interface_field_paths map[string]string, mut embed_embedders []string, mut embed_embeddeds []string) ! {
-	mut file_set := token.FileSet.new()
-	mut file := file_set.add_file(path, source.len)
-	file.index_lines_without_digest(source)
+	file := token.File.unindexed(path, source.len)
 	mut scan := scanner.new_scanner(prefs, .normal)
 	scan.init(file, source)
 	mut tok := scan.scan()
@@ -846,6 +844,9 @@ fn fastc_collect_signature_chunk(sources []FastcSourceFile, prefs &pref.Preferen
 			partial.failed = true
 			partial.error_message = err.msg()
 			return partial
+		}
+		if !source_file.header.has_interfaces {
+			continue
 		}
 		collect_interface_method_signatures(source_file.source, source_file.path, source_file.header, prefs, declared_types, mut partial.functions, mut partial.interface_methods, mut partial.interface_fields, mut partial.interface_field_paths, mut partial.embed_embedders, mut partial.embed_embeddeds) or {
 			partial.failed = true
@@ -1419,9 +1420,7 @@ fn fastc_register_composite_type(typ string, mut composite_types map[string]bool
 }
 
 fn fastc_collect_generated_template_references(source string, path string, prefs &pref.Preferences, available_names map[string]bool, mut references map[string]bool) {
-	mut file_set := token.FileSet.new()
-	mut file := file_set.add_file(path, source.len)
-	file.index_lines_without_digest(source)
+	file := token.File.unindexed(path, source.len)
 	mut scan := scanner.new_scanner(prefs, .normal)
 	scan.init(file, source)
 	mut tok := scan.scan()
@@ -1484,9 +1483,7 @@ fn fastc_collect_veb_template_references(source_file FastcSourceFile, function_n
 // fastc_collect_file_references scans one source file's function bodies,
 // generated veb templates, and top-level initializers for collected function names.
 fn fastc_collect_file_references(source_file FastcSourceFile, prefs &pref.Preferences, available_names map[string]bool, mut references map[string]map[string]bool, mut top_level_references map[string]bool) {
-	mut file_set := token.FileSet.new()
-	mut file := file_set.add_file(source_file.path, source_file.source.len)
-	file.index_lines_without_digest(source_file.source)
+	file := token.File.unindexed(source_file.path, source_file.source.len)
 	mut scan := scanner.new_scanner(prefs, .normal)
 	scan.init(file, source_file.source)
 	mut previous := token.Token.unknown

--- a/vlib/v3/gen/fastc/source.v
+++ b/vlib/v3/gen/fastc/source.v
@@ -640,14 +640,47 @@ fn fastc_source_space_byte(c u8) bool {
 	return c == ` ` || c == `\t` || c == `\r` || c == `\n`
 }
 
+// fastc_source_skip_blank returns the offset of the first byte at or after
+// `start` that is neither whitespace nor part of a comment. The scanner treats
+// comments as whitespace between tokens, so the byte probes must too, or a
+// comment between two tokens would turn a superset test into a false negative.
+@[direct_array_access]
+fn fastc_source_skip_blank(source string, start int) int {
+	mut j := start
+	for j < source.len {
+		c := source[j]
+		if fastc_source_space_byte(c) {
+			j++
+		} else if c == `/` && j + 1 < source.len && source[j + 1] == `/` {
+			for j < source.len && source[j] != `\n` {
+				j++
+			}
+		} else if c == `/` && j + 1 < source.len && source[j + 1] == `*` {
+			// Block comments nest, as in the scanner.
+			mut depth := 1
+			j += 2
+			for j < source.len && depth > 0 {
+				if source[j] == `/` && j + 1 < source.len && source[j + 1] == `*` {
+					depth++
+					j += 2
+				} else if source[j] == `*` && j + 1 < source.len && source[j + 1] == `/` {
+					depth--
+					j += 2
+				} else {
+					j++
+				}
+			}
+		} else {
+			break
+		}
+	}
+	return j
+}
+
 // fastc_source_comptime_if_at reports whether `$` at `i` starts a `$if`.
 @[direct_array_access]
 fn fastc_source_comptime_if_at(source string, i int) bool {
-	mut j := i + 1
-	for j < source.len && fastc_source_space_byte(source[j]) {
-		j++
-	}
-	return fastc_source_word_at(source, j, 'if')
+	return fastc_source_word_at(source, fastc_source_skip_blank(source, i + 1), 'if')
 }
 
 // fastc_source_generic_fn_at reports whether the `fn` keyword ending at `i`
@@ -655,18 +688,20 @@ fn fastc_source_comptime_if_at(source string, i int) bool {
 // followed by an optional receiver clause and a name that a `[` follows.
 @[direct_array_access]
 fn fastc_source_generic_fn_at(source string, i int) bool {
-	mut j := i
-	for j < source.len && fastc_source_space_byte(source[j]) {
-		j++
-	}
+	mut j := fastc_source_skip_blank(source, i)
 	if j < source.len && source[j] == `(` {
-		for j < source.len && source[j] != `)` {
-			j++
-		}
 		j++
-		for j < source.len && fastc_source_space_byte(source[j]) {
+		for {
+			j = fastc_source_skip_blank(source, j)
+			if j >= source.len {
+				return false
+			}
+			if source[j] == `)` {
+				break
+			}
 			j++
 		}
+		j = fastc_source_skip_blank(source, j + 1)
 	}
 	name_start := j
 	for j < source.len && (fastc_identifier_byte(source[j]) || source[j] == `.`) {
@@ -675,9 +710,7 @@ fn fastc_source_generic_fn_at(source string, i int) bool {
 	if j == name_start {
 		return false
 	}
-	for j < source.len && fastc_source_space_byte(source[j]) {
-		j++
-	}
+	j = fastc_source_skip_blank(source, j)
 	return j < source.len && source[j] == `[`
 }
 

--- a/vlib/v3/gen/fastc/source.v
+++ b/vlib/v3/gen/fastc/source.v
@@ -80,6 +80,7 @@ fn fastc_load_source(path string, prefs &pref.Preferences) FastcLoadedSource {
 }
 
 fn fastc_resolve_source_files(paths []string, prefs &pref.Preferences) !([]FastcSourceFile, map[string]string) {
+	mut timer := fastc_new_phase_timer()
 	mut queue := []FastcQueuedSource{}
 	if prefs.building_v {
 		builtin_dir := os.real_path(prefs.get_vlib_module_path('builtin'))
@@ -89,6 +90,7 @@ fn fastc_resolve_source_files(paths []string, prefs &pref.Preferences) !([]Fastc
 					path: builtin_file
 					module_name: 'builtin'
 					is_canonical: true
+					listed: true
 				}
 			}
 		}
@@ -111,11 +113,13 @@ fn fastc_resolve_source_files(paths []string, prefs &pref.Preferences) !([]Fastc
 					queue << FastcQueuedSource{
 						path: module_file
 						is_canonical: true
+						listed: true
 					}
 				}
 			}
 		}
 	}
+	timer.mark('resolve.queue_init')
 	mut seen := map[string]bool{}
 	mut sources := []FastcSourceFile{}
 	// path -> the module_name a file was first loaded under, and the resulting alias map:
@@ -165,7 +169,7 @@ fn fastc_resolve_source_files(paths []string, prefs &pref.Preferences) !([]Fastc
 				}
 				continue
 			}
-			if !os.is_file(path) {
+			if !queued.listed && !os.is_file(path) {
 				return error('fastc source file `${path}` does not exist')
 			}
 			seen[path] = true
@@ -173,7 +177,9 @@ fn fastc_resolve_source_files(paths []string, prefs &pref.Preferences) !([]Fastc
 			wave_paths << path
 			wave_modules << queued.module_name
 		}
+		timer.mark('resolve.wave_scan')
 		loaded_sources := fastc_load_source_headers(wave_paths, prefs)
+		timer.mark('resolve.wave_load(${wave_paths.len})')
 		wave_source_start := sources.len
 		for i, loaded_source in loaded_sources {
 			if loaded_source.failed {
@@ -195,6 +201,10 @@ fn fastc_resolve_source_files(paths []string, prefs &pref.Preferences) !([]Fastc
 					has_globals: header.has_globals
 					has_constants: header.has_constants
 					has_global_declarations: header.has_global_declarations
+					has_interfaces: header.has_interfaces
+					has_comptime_if: header.has_comptime_if
+					has_type_keywords: header.has_type_keywords
+					has_generic_fn_syntax: header.has_generic_fn_syntax
 				}
 			}
 			sources << FastcSourceFile{
@@ -279,11 +289,13 @@ fn fastc_resolve_source_files(paths []string, prefs &pref.Preferences) !([]Fastc
 						path: module_file_real
 						module_name: imported_module
 						is_canonical: prefs.building_v
+						listed: true
 					}
 				}
 			}
 		}
 	}
+	timer.mark('resolve.imports')
 	return sources, module_aliases
 }
 
@@ -357,16 +369,17 @@ fn fastc_sources_in_dependency_order(sources []FastcSourceFile) ![]FastcSourceFi
 	return ordered
 }
 
-fn fastc_module_init_calls(sources []FastcSourceFile, functions map[string]FastcFunctionSignature) ![]string {
-	return fastc_module_lifecycle_calls(sources, functions, 'init', false)
+// fastc_module_init_calls lists the `init` hooks of `ordered_sources`, which
+// must already be in module dependency order.
+fn fastc_module_init_calls(ordered_sources []FastcSourceFile, functions map[string]FastcFunctionSignature) ![]string {
+	return fastc_module_lifecycle_calls(ordered_sources, functions, 'init', false)
 }
 
-fn fastc_module_cleanup_calls(sources []FastcSourceFile, functions map[string]FastcFunctionSignature) ![]string {
-	return fastc_module_lifecycle_calls(sources, functions, 'cleanup', true)
+fn fastc_module_cleanup_calls(ordered_sources []FastcSourceFile, functions map[string]FastcFunctionSignature) ![]string {
+	return fastc_module_lifecycle_calls(ordered_sources, functions, 'cleanup', true)
 }
 
-fn fastc_module_lifecycle_calls(sources []FastcSourceFile, functions map[string]FastcFunctionSignature, hook_name string, reverse bool) ![]string {
-	ordered_sources := fastc_sources_in_dependency_order(sources)!
+fn fastc_module_lifecycle_calls(ordered_sources []FastcSourceFile, functions map[string]FastcFunctionSignature, hook_name string, reverse bool) ![]string {
 	mut seen_modules := map[string]bool{}
 	mut ordered_modules := []string{}
 	for source_file in ordered_sources {
@@ -391,8 +404,7 @@ fn fastc_module_lifecycle_calls(sources []FastcSourceFile, functions map[string]
 	return calls
 }
 
-fn fastc_generate_startup_initializers(sources []FastcSourceFile, constant_initializers map[string]string, global_initializers map[string]string, module_init_calls []string) !string {
-	ordered_sources := fastc_sources_in_dependency_order(sources)!
+fn fastc_generate_startup_initializers(ordered_sources []FastcSourceFile, constant_initializers map[string]string, global_initializers map[string]string, module_init_calls []string) !string {
 	mut seen_modules := map[string]bool{}
 	mut out := strings.new_builder(1024)
 	for source_file in ordered_sources {
@@ -449,9 +461,7 @@ fn fastc_source_file_matches_backend(path string) bool {
 }
 
 fn fastc_scan_source_header(source string, path string, prefs &pref.Preferences) !FastcSourceHeader {
-	mut file_set := token.FileSet.new()
-	mut file := file_set.add_file(path, source.len)
-	file.index_lines_without_digest(source)
+	file := token.File.unindexed(path, source.len)
 	mut scan := scanner.new_scanner(prefs, .normal)
 	scan.init(file, source)
 	mut module_name := ''
@@ -549,7 +559,10 @@ fn fastc_scan_source_header(source string, path string, prefs &pref.Preferences)
 	// Mirror that so the ORM lowering resolves `orm.Table`/`orm.QueryData`/... and the
 	// `orm` module is pulled into the source set. Only the real-builtin path has the
 	// runtime the ORM needs; the toy runtime cannot compile `orm`.
-	if prefs.building_v && module_name != 'orm' && 'orm' !in imports && fastc_source_uses_sql(source, prefs) {
+	// The compiler's own sources never use the ORM, and the probe rescans every
+	// file that mentions `sql` anywhere (FastC's ORM lowering does), so self-host
+	// builds skip it.
+	if prefs.building_v && !prefs.selfhost && module_name != 'orm' && 'orm' !in imports && fastc_source_uses_sql(source, prefs) {
 		imports['orm'] = 'orm'
 		if 'orm' !in import_order {
 			import_order << 'orm'
@@ -564,32 +577,163 @@ fn fastc_scan_source_header(source string, path string, prefs &pref.Preferences)
 			}
 		}
 	}
-	has_constants, has_global_declarations := fastc_source_declaration_flags(source)
+	// The declaration keyword flags are filled in by fastc_collect_generic_method_sources,
+	// the first parallel pass, so discovery waves only scan imports.
 	return FastcSourceHeader{
 		module_name: module_name
 		imports: imports
 		import_order: import_order
 		blank_imports: blank_imports
 		has_globals: has_globals
-		has_constants: has_constants
-		has_global_declarations: has_global_declarations
 	}
 }
 
-fn fastc_source_declaration_flags(source string) (bool, bool) {
-	return fastc_source_has_declaration(source, 'const'), fastc_source_has_declaration(source, '__global')
+// fastc_header_with_scan_flags copies a header with the declaration keyword
+// flags of its source filled in.
+fn fastc_header_with_scan_flags(header FastcSourceHeader, flags FastcSourceScanFlags) FastcSourceHeader {
+	return FastcSourceHeader{
+		module_name: header.module_name
+		imports: header.imports
+		import_order: header.import_order
+		blank_imports: header.blank_imports
+		has_globals: header.has_globals
+		has_constants: flags.has_constants
+		has_global_declarations: flags.has_global_declarations
+		has_interfaces: flags.has_interfaces
+		has_comptime_if: flags.has_comptime_if
+		has_type_keywords: flags.has_type_keywords
+		has_generic_fn_syntax: flags.has_generic_fn_syntax
+	}
 }
 
-fn fastc_source_has_declaration(source string, keyword string) bool {
-	mut search_start := 0
-	for {
-		index := source.index_after(keyword, search_start) or { return false }
-		if (index == 0 || !fastc_identifier_byte(source[index - 1])) && (index + keyword.len == source.len || !fastc_identifier_byte(source[index + keyword.len])) {
-			return true
+// FastcSourceScanFlags records which declaration keywords a source mentions
+// anywhere in its bytes (comments and strings included), so later collection
+// passes can skip files that cannot contain the declarations they look for.
+struct FastcSourceScanFlags {
+mut:
+	has_constants           bool
+	has_global_declarations bool
+	has_interfaces          bool
+	has_comptime_if         bool
+	has_type_keywords       bool
+	has_generic_fn_syntax   bool
+}
+
+@[direct_array_access]
+fn fastc_source_word_at(source string, i int, word string) bool {
+	if i + word.len > source.len {
+		return false
+	}
+	for j := 0; j < word.len; j++ {
+		if source[i + j] != word[j] {
+			return false
 		}
-		search_start = index + keyword.len
 	}
-	return false
+	if i > 0 && fastc_identifier_byte(source[i - 1]) {
+		return false
+	}
+	return i + word.len == source.len || !fastc_identifier_byte(source[i + word.len])
+}
+
+@[direct_array_access]
+fn fastc_source_space_byte(c u8) bool {
+	return c == ` ` || c == `\t` || c == `\r` || c == `\n`
+}
+
+// fastc_source_comptime_if_at reports whether `$` at `i` starts a `$if`.
+@[direct_array_access]
+fn fastc_source_comptime_if_at(source string, i int) bool {
+	mut j := i + 1
+	for j < source.len && fastc_source_space_byte(source[j]) {
+		j++
+	}
+	return fastc_source_word_at(source, j, 'if')
+}
+
+// fastc_source_generic_fn_at reports whether the `fn` keyword ending at `i`
+// could declare a function or method with its own type parameter, i.e. is
+// followed by an optional receiver clause and a name that a `[` follows.
+@[direct_array_access]
+fn fastc_source_generic_fn_at(source string, i int) bool {
+	mut j := i
+	for j < source.len && fastc_source_space_byte(source[j]) {
+		j++
+	}
+	if j < source.len && source[j] == `(` {
+		for j < source.len && source[j] != `)` {
+			j++
+		}
+		j++
+		for j < source.len && fastc_source_space_byte(source[j]) {
+			j++
+		}
+	}
+	name_start := j
+	for j < source.len && (fastc_identifier_byte(source[j]) || source[j] == `.`) {
+		j++
+	}
+	if j == name_start {
+		return false
+	}
+	for j < source.len && fastc_source_space_byte(source[j]) {
+		j++
+	}
+	return j < source.len && source[j] == `[`
+}
+
+// fastc_source_scan_flags computes every header flag in one pass over the
+// bytes. It runs on every file of every discovery wave, so it must stay cheap
+// for large files.
+@[direct_array_access]
+fn fastc_source_scan_flags(source string) FastcSourceScanFlags {
+	mut flags := FastcSourceScanFlags{}
+	for i := 0; i < source.len; i++ {
+		c := source[i]
+		// Only a word start can begin a keyword; most bytes are rejected here.
+		if i > 0 && fastc_identifier_byte(source[i - 1]) {
+			continue
+		}
+		if c == `c` {
+			if !flags.has_constants && fastc_source_word_at(source, i, 'const') {
+				flags.has_constants = true
+			}
+		} else if c == `_` {
+			if !flags.has_global_declarations && fastc_source_word_at(source, i, '__global') {
+				flags.has_global_declarations = true
+			}
+		} else if c == `i` {
+			if !flags.has_interfaces && fastc_source_word_at(source, i, 'interface') {
+				flags.has_interfaces = true
+				flags.has_type_keywords = true
+			}
+		} else if c == `$` {
+			if !flags.has_comptime_if && fastc_source_comptime_if_at(source, i) {
+				flags.has_comptime_if = true
+			}
+		} else if c == `s` {
+			if !flags.has_type_keywords && fastc_source_word_at(source, i, 'struct') {
+				flags.has_type_keywords = true
+			}
+		} else if c == `e` {
+			if !flags.has_type_keywords && fastc_source_word_at(source, i, 'enum') {
+				flags.has_type_keywords = true
+			}
+		} else if c == `t` {
+			if !flags.has_type_keywords && fastc_source_word_at(source, i, 'type') {
+				flags.has_type_keywords = true
+			}
+		} else if c == `u` {
+			if !flags.has_type_keywords && fastc_source_word_at(source, i, 'union') {
+				flags.has_type_keywords = true
+			}
+		} else if c == `f` {
+			if !flags.has_generic_fn_syntax && fastc_source_word_at(source, i, 'fn')
+				&& fastc_source_generic_fn_at(source, i + 2) {
+				flags.has_generic_fn_syntax = true
+			}
+		}
+	}
+	return flags
 }
 
 fn fastc_identifier_byte(value u8) bool {
@@ -603,9 +747,7 @@ fn fastc_source_uses_sql(source string, prefs &pref.Preferences) bool {
 	if !source.contains('sql') {
 		return false
 	}
-	mut file_set := token.FileSet.new()
-	mut file := file_set.add_file('orm_sql_probe', source.len)
-	file.index_lines_without_digest(source)
+	file := token.File.unindexed('orm_sql_probe', source.len)
 	mut scan := scanner.new_scanner(prefs, .normal)
 	scan.init(file, source)
 	mut previous := token.Token.eof

--- a/vlib/v3/gen/fastc/stmt.v
+++ b/vlib/v3/gen/fastc/stmt.v
@@ -726,7 +726,7 @@ fn (mut g Parser) parse_return() !bool {
 			for value in evaluated_values {
 				packed_values << 'V_FASTC_MULTI_VALUE((${value}))'
 			}
-			'(MultiReturn){.values={${packed_values.join(', ')}}}'
+			'${fastc_multi_return_literal(packed_values)}'
 		}
 		if g.return_type == 'Option' {
 			g.write_line('return (Option){.data=v_fastc_interface_box(&${multi_value}, sizeof(MultiReturn)), .state=0};')
@@ -1250,14 +1250,14 @@ fn (mut g Parser) parse_parallel_assignment(initial_names []string, initial_mut 
 			component_type := if i < component_types.len { component_types[i] } else { 'usize' }
 			c_name := fastc_c_identifier(name)
 			g.write_line('${component_type} ${c_name} = (${component_type}){0};')
-			g.write_line('memcpy(&${c_name}, ${temporary}.values[${i}].data, sizeof(${c_name}));')
+			g.write_line('memcpy(&${c_name}, V_FASTC_MULTI_SOURCE(${temporary}.values[${i}], sizeof(${c_name})), sizeof(${c_name}));')
 			g.set_scoped_local(name, FastcLocal{
 				is_mut: mutability[i]
 				typ: component_type
 			})
 		} else {
 			c_name := assignment_targets[i].source
-			g.write_line('memcpy(&${c_name}, ${temporary}.values[${i}].data, sizeof(${c_name}));')
+			g.write_line('memcpy(&${c_name}, V_FASTC_MULTI_SOURCE(${temporary}.values[${i}], sizeof(${c_name})), sizeof(${c_name}));')
 		}
 	}
 }
@@ -1416,7 +1416,7 @@ fn (mut g Parser) parse_parallel_option_tuple(names []string, mutability []bool,
 		} else {
 			assignment_targets[i].source
 		}
-		g.write_line('memcpy(&${target}, ${multi_return}.values[${i}].data, sizeof(${target}));')
+		g.write_line('memcpy(&${target}, V_FASTC_MULTI_SOURCE(${multi_return}.values[${i}], sizeof(${target})), sizeof(${target}));')
 	}
 	g.indent--
 	g.write_line('}')
@@ -1507,7 +1507,7 @@ fn (mut g Parser) parse_parallel_expression_assignment(first_source string, firs
 		if target.source == '' {
 			continue
 		}
-		g.write_line('memcpy(&${target.source}, ${temporary}.values[${i}].data, sizeof(${target.source}));')
+		g.write_line('memcpy(&${target.source}, V_FASTC_MULTI_SOURCE(${temporary}.values[${i}], sizeof(${target.source})), sizeof(${target.source}));')
 	}
 }
 
@@ -1956,9 +1956,7 @@ fn (mut g Parser) parse_orm_sql_statement() ! {
 	saved_tok := g.tok
 	saved_lit := g.lit
 	saved_s := g.s
-	mut file_set := token.FileSet.new()
-	mut file := file_set.add_file('orm_sql', lowering.len)
-	file.index_lines_without_digest(lowering)
+	file := token.File.unindexed('orm_sql', lowering.len)
 	g.s = scanner.new_scanner(g.prefs, .normal)
 	g.s.init(file, lowering)
 	g.next()
@@ -2029,9 +2027,7 @@ fn (mut g Parser) capture_orm_sql_block() !(string, string, string) {
 // build_orm_lowering parses one ORM query block and returns the V source it lowers
 // to. Only `insert` is handled so far; other operations report as unsupported.
 fn (g &Parser) build_orm_lowering(db_source string, block_source string, trailing string) !string {
-	mut file_set := token.FileSet.new()
-	mut file := file_set.add_file('orm_query', block_source.len)
-	file.index_lines_without_digest(block_source)
+	file := token.File.unindexed('orm_query', block_source.len)
 	mut s := scanner.new_scanner(g.prefs, .normal)
 	s.init(file, block_source)
 	mut tok := s.scan()
@@ -2097,9 +2093,7 @@ fn fastc_orm_where_op(tok token.Token) string {
 // (Primitive value + OperationKind + is_and joiners), then it calls the connection's
 // `update`. Values are captured as source spans and boxed via `orm.Primitive(<expr>)`.
 fn (g &Parser) build_orm_update(db_source string, block_source string, trailing string) !string {
-	mut file_set := token.FileSet.new()
-	mut file := file_set.add_file('orm_update', block_source.len)
-	file.index_lines_without_digest(block_source)
+	file := token.File.unindexed('orm_update', block_source.len)
 	mut s := scanner.new_scanner(g.prefs, .normal)
 	s.init(file, block_source)
 	mut tok := s.scan()
@@ -2290,9 +2284,7 @@ fn (g &Parser) build_orm_where_lines(mut s scanner.Scanner, block_source string,
 // builds the where QueryData (shared with `update`) and calls the connection's
 // `delete`.
 fn (g &Parser) build_orm_delete(db_source string, block_source string, trailing string) !string {
-	mut file_set := token.FileSet.new()
-	mut file := file_set.add_file('orm_delete', block_source.len)
-	file.index_lines_without_digest(block_source)
+	file := token.File.unindexed('orm_delete', block_source.len)
 	mut s := scanner.new_scanner(g.prefs, .normal)
 	s.init(file, block_source)
 	mut tok := s.scan()
@@ -2358,9 +2350,7 @@ fn (g &Parser) build_orm_insert(db_source string, value_source string, table_nam
 // fastc_orm_parse_table_op scans `<op> table <Table>` and returns the row type name.
 // Shared by `create` and `drop`.
 fn (g &Parser) fastc_orm_parse_table_op(block_source string, op string) !string {
-	mut file_set := token.FileSet.new()
-	mut file := file_set.add_file('orm_${op}', block_source.len)
-	file.index_lines_without_digest(block_source)
+	file := token.File.unindexed('orm_${op}', block_source.len)
 	mut s := scanner.new_scanner(g.prefs, .normal)
 	s.init(file, block_source)
 	mut tok := s.scan()
@@ -2479,9 +2469,7 @@ fn (g &Parser) build_orm_select_lowering(db_source string, block_source string, 
 	if trailing != '!' && or_source == '' {
 		return g.unsupported('ORM `sql`: `select` must be unwrapped with `!` or `or { ... }`')
 	}
-	mut file_set := token.FileSet.new()
-	mut file := file_set.add_file('orm_select', block_source.len)
-	file.index_lines_without_digest(block_source)
+	file := token.File.unindexed('orm_select', block_source.len)
 	mut s := scanner.new_scanner(g.prefs, .normal)
 	s.init(file, block_source)
 	mut tok := s.scan()
@@ -2702,9 +2690,7 @@ fn (g &Parser) build_orm_select_lowering(db_source string, block_source string, 
 }
 
 fn fastc_orm_or_source_starts_with_exit(source string, prefs &pref.Preferences) bool {
-	mut file_set := token.FileSet.new()
-	mut file := file_set.add_file('orm_or', source.len)
-	file.index_lines_without_digest(source)
+	file := token.File.unindexed('orm_or', source.len)
 	mut s := scanner.new_scanner(prefs, .normal)
 	s.init(file, source)
 	return s.scan() in [.key_return, .key_break, .key_continue]
@@ -2753,9 +2739,7 @@ fn (mut g Parser) emit_orm_lowering_statements(lowering string) ! {
 	saved_lit := g.lit
 	saved_s := g.s
 	outer_locals := g.locals.clone()
-	mut file_set := token.FileSet.new()
-	mut file := file_set.add_file('orm_lowering', lowering.len)
-	file.index_lines_without_digest(lowering)
+	file := token.File.unindexed('orm_lowering', lowering.len)
 	g.s = scanner.new_scanner(g.prefs, .normal)
 	g.s.init(file, lowering)
 	g.next()

--- a/vlib/v3/gen/fastc/types.v
+++ b/vlib/v3/gen/fastc/types.v
@@ -319,6 +319,40 @@ fn fastc_typeof_generic_field_type(tokens []FastcExpressionToken, start int, end
 	}
 }
 
+// nonlocal_name_type infers the type of a bare name that is not a local from
+// the constant and global tables. File generation parsers see fixed tables, so
+// the answer is memoized per name there; declaration initializer parsers
+// extend those tables while parsing, so they always recompute.
+fn (g &Parser) nonlocal_name_type(name string) string {
+	if !g.declaration_initializer_mode {
+		if cached := g.nonlocal_name_type_memo[name] {
+			return cached
+		}
+	}
+	typ := if constant_type := g.constant_types[fastc_constant_key(g.module_name, name)] {
+		constant_type
+	} else if constant_type := g.constant_types[fastc_constant_key('builtin', name)] {
+		constant_type
+	} else if fastc_constant_key(g.module_name, name) in g.constants {
+		'integer literal'
+	} else if fastc_constant_key('builtin', name) in g.constants {
+		'integer literal'
+	} else if global_type := g.global_types[fastc_global_key(g.module_name, name)] {
+		global_type
+	} else if global_type := g.global_types[fastc_global_key('builtin', name)] {
+		global_type
+	} else if g.selfhost {
+		'int'
+	} else {
+		''
+	}
+	if !g.declaration_initializer_mode {
+		mut w := unsafe { &Parser(g) }
+		w.nonlocal_name_type_memo[name] = typ
+	}
+	return typ
+}
+
 fn (g &Parser) infer_expression_type(tokens []FastcExpressionToken) !string {
 	return g.infer_expression_type_range(tokens, 0, tokens.len)
 }
@@ -349,22 +383,8 @@ fn (g &Parser) infer_expression_type_range(tokens []FastcExpressionToken, expres
 			.name {
 				if local := g.locals[item.lit] {
 					local.typ
-				} else if constant_type := g.constant_types[fastc_constant_key(g.module_name, item.lit)] {
-					constant_type
-				} else if constant_type := g.constant_types[fastc_constant_key('builtin', item.lit)] {
-					constant_type
-				} else if fastc_constant_key(g.module_name, item.lit) in g.constants {
-					'integer literal'
-				} else if fastc_constant_key('builtin', item.lit) in g.constants {
-					'integer literal'
-				} else if global_type := g.global_types[fastc_global_key(g.module_name, item.lit)] {
-					global_type
-				} else if global_type := g.global_types[fastc_global_key('builtin', item.lit)] {
-					global_type
-				} else if g.selfhost {
-					'int'
 				} else {
-					''
+					g.nonlocal_name_type(item.lit)
 				}
 			}
 			.number {

--- a/vlib/v3/gen/fastc/validate.v
+++ b/vlib/v3/gen/fastc/validate.v
@@ -111,33 +111,48 @@ fn (g &Parser) resolved_expression_name(name string, previous token.Token) strin
 		return ''
 	}
 	if previous != .dot && name !in g.locals {
-		if imported_module := g.imports[name] {
-			return imported_module.replace('.', '__')
+		if cached := g.resolved_name_memo[name] {
+			return cached
 		}
-		function_key := g.unqualified_function_key(name)
-		if function_key in g.functions {
-			return fastc_c_function_name_for_key(function_key)
-		}
-		if type_key := g.resolve_declared_type_key(name) {
-			return fastc_c_declared_type_name(type_key)
-		}
-		if primitive := fastc_primitive_c_type(name) {
-			return primitive
-		}
-		constant_key := fastc_constant_key(g.module_name, name)
-		if c_name := g.constants[constant_key] {
-			return c_name
-		}
-		if c_name := g.constants[fastc_constant_key('builtin', name)] {
-			return c_name
-		}
-		global_key := fastc_global_key(g.module_name, name)
-		if c_name := g.globals[global_key] {
-			return c_name
-		}
-		if c_name := g.globals[fastc_global_key('builtin', name)] {
-			return c_name
-		}
+		resolved := g.resolved_nonlocal_expression_name(name)
+		mut w := unsafe { &Parser(g) }
+		w.resolved_name_memo[name] = resolved
+		return resolved
+	}
+	return fastc_c_identifier(name)
+}
+
+// resolved_nonlocal_expression_name renders a bare name that is not a local:
+// an import, function, type, primitive, constant, or global, else the plain
+// C identifier. Every table it consults is fixed for the file, so
+// resolved_expression_name memoizes the answer per name.
+fn (g &Parser) resolved_nonlocal_expression_name(name string) string {
+	if imported_module := g.imports[name] {
+		return imported_module.replace('.', '__')
+	}
+	function_key := g.unqualified_function_key(name)
+	if function_key in g.functions {
+		return fastc_c_function_name_for_key(function_key)
+	}
+	if type_key := g.resolve_declared_type_key(name) {
+		return fastc_c_declared_type_name(type_key)
+	}
+	if primitive := fastc_primitive_c_type(name) {
+		return primitive
+	}
+	constant_key := fastc_constant_key(g.module_name, name)
+	if c_name := g.constants[constant_key] {
+		return c_name
+	}
+	if c_name := g.constants[fastc_constant_key('builtin', name)] {
+		return c_name
+	}
+	global_key := fastc_global_key(g.module_name, name)
+	if c_name := g.globals[global_key] {
+		return c_name
+	}
+	if c_name := g.globals[fastc_global_key('builtin', name)] {
+		return c_name
 	}
 	return fastc_c_identifier(name)
 }

--- a/vlib/v3/pref/pref.v
+++ b/vlib/v3/pref/pref.v
@@ -508,6 +508,50 @@ pub fn file_has_incompatible_os_suffix(file string, current_os string) bool {
 
 // file_has_incompatible_target_suffix reports whether an OS or architecture suffix excludes
 // file from target.
+// file_name_has_marker reports whether `file` contains `marker`. File names
+// are short, so a direct scan beats the general substring search, and it
+// allocates nothing.
+@[direct_array_access]
+fn file_name_has_marker(file string, marker string) bool {
+	if marker.len == 0 || marker.len > file.len {
+		return false
+	}
+	first := marker[0]
+	for i := 0; i + marker.len <= file.len; i++ {
+		if file[i] != first {
+			continue
+		}
+		mut j := 1
+		for j < marker.len && file[i + j] == marker[j] {
+			j++
+		}
+		if j == marker.len {
+			return true
+		}
+	}
+	return false
+}
+
+// file_name_has_arch_marker reports whether `file` contains `.arch.` or
+// `_arch.` without building those marker strings.
+@[direct_array_access]
+fn file_name_has_arch_marker(file string, arch string) bool {
+	for i := 0; i + arch.len + 2 <= file.len; i++ {
+		c := file[i]
+		if (c != `.` && c != `_`) || file[i + arch.len + 1] != `.` {
+			continue
+		}
+		mut j := 0
+		for j < arch.len && file[i + 1 + j] == arch[j] {
+			j++
+		}
+		if j == arch.len {
+			return true
+		}
+	}
+	return false
+}
+
 pub fn file_has_incompatible_target_suffix(file string, target Target) bool {
 	if file_has_incompatible_os_only_suffix(file, target.os) {
 		return true
@@ -515,8 +559,7 @@ pub fn file_has_incompatible_target_suffix(file string, target Target) bool {
 	for arch in ['amd64', 'x64', 'x86_64', 'arm64', 'aarch64', 'x86', 'i386', 'i486', 'i586', 'i686',
 		'x32', 'x86_32', 'ia-32', 'ia32', 'arm32', 'rv64', 'riscv64', 'ppc', 'ppc64', 'ppc64le',
 		's390x', 'loongarch64', 'wasm32'] {
-		if normalized_arch(arch) != target.arch
-			&& (file.contains('.${arch}.') || file.contains('_${arch}.')) {
+		if normalized_arch(arch) != target.arch && file_name_has_arch_marker(file, arch) {
 			return true
 		}
 	}
@@ -525,57 +568,57 @@ pub fn file_has_incompatible_target_suffix(file string, target Target) bool {
 
 fn file_has_incompatible_os_only_suffix(file string, current_os string) bool {
 	os_name := normalized_os(current_os)
-	if os_name == 'windows' && file.contains('_nix.') {
+	if os_name == 'windows' && file_name_has_marker(file, '_nix.') {
 		return true
 	}
-	if os_name != 'windows' && file.contains('_windows.') {
+	if os_name != 'windows' && file_name_has_marker(file, '_windows.') {
 		return true
 	}
-	if os_name != 'linux' && file.contains('_linux.') {
+	if os_name != 'linux' && file_name_has_marker(file, '_linux.') {
 		return true
 	}
-	if os_name != 'macos' && (file.contains('_macos.') || file.contains('_darwin.')) {
+	if os_name != 'macos' && (file_name_has_marker(file, '_macos.') || file_name_has_marker(file, '_darwin.')) {
 		return true
 	}
 	if os_name != 'macos' && os_name != 'freebsd' && os_name != 'openbsd' && os_name != 'netbsd'
-		&& os_name != 'dragonfly' && file.contains('_bsd.') {
+		&& os_name != 'dragonfly' && file_name_has_marker(file, '_bsd.') {
 		return true
 	}
-	if file.contains('_android_outside_termux.') {
+	if file_name_has_marker(file, '_android_outside_termux.') {
 		if os_name != 'android' {
 			return true
 		}
-	} else if file.contains('_termux.') {
+	} else if file_name_has_marker(file, '_termux.') {
 		if os_name != 'termux' {
 			return true
 		}
-	} else if file.contains('_android.') && os_name !in ['android', 'termux'] {
+	} else if file_name_has_marker(file, '_android.') && os_name !in ['android', 'termux'] {
 		return true
 	}
-	if os_name != 'ios' && file.contains('_ios.') {
+	if os_name != 'ios' && file_name_has_marker(file, '_ios.') {
 		return true
 	}
-	if os_name != 'freebsd' && file.contains('_freebsd.') {
+	if os_name != 'freebsd' && file_name_has_marker(file, '_freebsd.') {
 		return true
 	}
-	if os_name != 'openbsd' && file.contains('_openbsd.') {
+	if os_name != 'openbsd' && file_name_has_marker(file, '_openbsd.') {
 		return true
 	}
-	if os_name != 'netbsd' && file.contains('_netbsd.') {
+	if os_name != 'netbsd' && file_name_has_marker(file, '_netbsd.') {
 		return true
 	}
-	if os_name != 'dragonfly' && file.contains('_dragonfly.') {
+	if os_name != 'dragonfly' && file_name_has_marker(file, '_dragonfly.') {
 		return true
 	}
-	if os_name != 'solaris' && file.contains('_solaris.') {
+	if os_name != 'solaris' && file_name_has_marker(file, '_solaris.') {
 		return true
 	}
 	for target_os in ['qnx', 'haiku', 'serenity', 'vinix'] {
-		if os_name != target_os && file.contains('_${target_os}.') {
+		if os_name != target_os && file_name_has_marker(file, '_${target_os}.') {
 			return true
 		}
 	}
-	if os_name != 'wasm32_emscripten' && file.contains('_wasm32_emscripten.') {
+	if os_name != 'wasm32_emscripten' && file_name_has_marker(file, '_wasm32_emscripten.') {
 		return true
 	}
 	return false
@@ -599,8 +642,8 @@ pub fn get_v_files_from_dir_for_target(dir string, user_defines []string, target
 	mut has_os_specific := map[string]bool{}
 	for file in sorted_files {
 		if !file.ends_with('.v') || file.ends_with('.js.v')
-			|| (file.contains('_test.') && !file.contains('_d_test.')
-			&& !file.contains('_notd_test.')) {
+			|| (file_name_has_marker(file, '_test.') && !file_name_has_marker(file, '_d_test.')
+			&& !file_name_has_marker(file, '_notd_test.')) {
 			continue
 		}
 		if file_has_incompatible_target_suffix(file, target) {
@@ -617,8 +660,8 @@ pub fn get_v_files_from_dir_for_target(dir string, user_defines []string, target
 				continue
 			}
 			if !file.ends_with('.v') || file.ends_with('.js.v')
-				|| (file.contains('_test.') && !file.contains('_d_test.')
-				&& !file.contains('_notd_test.')) {
+				|| (file_name_has_marker(file, '_test.') && !file_name_has_marker(file, '_d_test.')
+				&& !file_name_has_marker(file, '_notd_test.')) {
 				continue
 			}
 			if file_has_incompatible_target_suffix(file, target) {
@@ -629,12 +672,12 @@ pub fn get_v_files_from_dir_for_target(dir string, user_defines []string, target
 					continue
 				}
 			}
-			if file.contains('_notd_') {
+			if file_name_has_marker(file, '_notd_') {
 				feature := extract_define_feature(file, '_notd_')
 				if feature.len > 0 && feature in user_defines {
 					continue
 				}
-			} else if file.contains('_d_') {
+			} else if file_name_has_marker(file, '_d_') {
 				feature := extract_define_feature(file, '_d_')
 				if feature.len == 0 || feature !in user_defines {
 					continue

--- a/vlib/v3/scanner/scanner.v
+++ b/vlib/v3/scanner/scanner.v
@@ -864,7 +864,15 @@ fn (mut s Scanner) consume_digits(base int) int {
 	mut previous_underscore := false
 	for s.offset < s.src.len {
 		c := s.src[s.offset]
-		if digit_value(c) < base {
+		// Decimal digits are by far the most common case, so test them inline
+		// instead of paying a digit_value call per byte.
+		mut is_digit := false
+		if c >= `0` && c <= `9` {
+			is_digit = int(c - `0`) < base
+		} else if base == 16 {
+			is_digit = (c >= `a` && c <= `f`) || (c >= `A` && c <= `F`)
+		}
+		if is_digit {
 			digits++
 			previous_underscore = false
 			s.offset++

--- a/vlib/v3/token/position.v
+++ b/vlib/v3/token/position.v
@@ -139,6 +139,18 @@ pub fn (mut fs FileSet) add_file(filename string, size int) &File {
 	return file
 }
 
+// File.unindexed creates a file record for scanners whose diagnostics report
+// raw byte offsets and never resolve line positions (FastC). It allocates only
+// the record itself and leaves the line table empty, so such a file must not
+// be used for position lookups.
+pub fn File.unindexed(name string, size int) &File {
+	return &File{
+		name:         name
+		size:         size
+		line_offsets: []int{}
+	}
+}
+
 // add_line updates add line state for File.
 @[inline]
 pub fn (mut f File) add_line(offset int) {


### PR DESCRIPTION
Speeds up FastC self-host generation of `vlib/v3/v3.v` (173 files, ~66K lines) on an M5 Max (6 fast + 12 slower cores):

| build | master | this PR |
|---|---|---|
| `-prod -gc none -prealloc` standalone driver (`fastc parse+gen`) | 26.5-27.9 ms (~2.5M loc/s) | 20.1-21.4 ms (~3.1-3.3M loc/s) |
| `-prod -gc none -prealloc` `cmd/v` (`-show-timings`) | 28.6-30.9 ms | 21.4-22.2 ms |
| TCC-built self-host generation (`FASTC_BENCH=1`) | 133 ms (~490K loc/s) | 74 ms (~895K loc/s) |

### Parallelism
- Parallel constant-initializer pass with an exactness rule: a file whose constant dependencies are all declared in that same file is accepted from the parallel pass, any other file is re-parsed in order.
- Fragment cut points are scanned in parallel.
- Per-file generation, constant parsing and the declaration/signature collection passes claim work from the shared atomic counter (`FastcGenQueue`, largest files first); partials are merged in file order, so the output is unchanged.

### Less per-file work
- Per-file memos for name, type-key and function-key lookups.
- `@[direct_array_access]` is honored for string and array indexing (scanner hot loops).
- One file record per scanner pass instead of a `FileSet`; shared module dependency order; pre-sized stitch buffers; incremental position tracking when ordering composite definitions.
- The first parallel pass records which declaration keywords (`interface`, `$if`, type keywords, generic `fn` syntax) each file mentions, and later collection scans skip files that cannot contain what they look for. Discovery waves now only scan imports.
- Allocation-free target-suffix checks in `pref`; faster decimal/hex digit loop in the scanner.

### Self-host runtime
- Map keys are hashed one 64-bit word at a time (the preamble hash was one byte per call, and TinyCC does not inline).
- `?`/`!` payload boxes are bump-allocated from a per-thread chunk instead of `malloc` (they were never freed anyway).
- `MultiReturn` slots are no longer zero-filled, and **components larger than 32 bytes are boxed**: a returned `map` (~120 B) used to overflow the 64-byte slot, which the zero-fill had masked. Repeating generation in-process (`FASTC_BENCH_LOOP`) crashed before this fix.

### Other
- The V3 C backend no longer emits prototypes for compiler builtins (`__atomic_*`, `__builtin_*`, `__sync_*`); clang rejects redeclaring `__atomic_fetch_add` (from the work-stealing generator's `fn C.__atomic_fetch_add`). Note that on master a V3 build of `fastc_test.v` on macOS still fails afterwards with unrelated `strconv__unknown` / `__order_snapshot_1` C errors; the test results below were obtained with the pre-#28277 compiler binary, which builds it.
- `FASTC_BENCH_PHASES=1`, `FASTC_BENCH_FILES=1` and `FASTC_BENCH_LOOP=N` diagnostics (documented in the v3 README).

### Verification
- Generation 2 and 3 compilers emit byte-identical C; serial (`V3_FASTC_NO_PARALLEL=1`) and parallel output are identical; the new generator's output matches the old generator's on the same input at every step.
- `fastc_test.v` (built with the pre-#28277 compiler binary, see above): no assertion failures, only the pre-existing panic in `enum_literal_map_lowering.v` that master shows too; scanner, token, pref, fastcdriver and gen/c preamble tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
