### PR TITLE
v3: make `int` 64-bit on 64-bit targets (i64), 32-bit on 32-bit (i32)

### DIFF
--- a/examples/sokol/sounds/melody.v
+++ b/examples/sokol/sounds/melody.v
@@ -9,14 +9,16 @@ mut:
 	gg      &gg.Context = unsafe { nil } // used for drawing
 }
 
-fn my_audio_stream_callback(mut soundbuffer &f32, num_frames int, num_channels int, mut acontext AppState) {
-	for frame := 0; frame < num_frames; frame++ {
+fn my_audio_stream_callback(mut soundbuffer &f32, num_frames i32, num_channels i32, mut acontext AppState) {
+	frame_count := int(num_frames)
+	channel_count := int(num_channels)
+	for frame := 0; frame < frame_count; frame++ {
 		t := int(f32(acontext.frame_0 + frame) * 0.245)
 		// "Techno" by Gabriel Miceli
 		y := (t * (((t / 10 | 0) ^ ((t / 10 | 0) - 1280)) % 11) / 2 & 127) +
 			(t * (((t / 640 | 0) ^ ((t / 640 | 0) - 2)) % 13) / 2 & 127)
-		for ch := 0; ch < num_channels; ch++ {
-			idx := frame * num_channels + ch
+		for ch := 0; ch < channel_count; ch++ {
+			idx := frame * channel_count + ch
 			a := f32(y - 127) / 255.0
 			// The sokol audio callback guarantees `soundbuffer` points to at least
 			// `num_frames * num_channels` writable samples, so `idx` (`frame < num_frames`,
@@ -27,7 +29,7 @@ fn my_audio_stream_callback(mut soundbuffer &f32, num_frames int, num_channels i
 			acontext.frames[idx & 2047] = a
 		}
 	}
-	acontext.frame_0 += num_frames
+	acontext.frame_0 += frame_count
 }
 
 fn graphics_frame(mut state AppState) {

--- a/examples/sokol/sounds/ogg_player.v
+++ b/examples/sokol/sounds/ogg_player.v
@@ -105,8 +105,8 @@ fn (mut p Player) play_ogg_file(fpath string) ! {
 	if !(p.channels == p.stream_channels && p.sample_rate == p.stream_rate) {
 		audio.shutdown()
 		audio.setup(
-			num_channels: p.stream_channels
-			sample_rate:  int(p.stream_rate)
+			num_channels: i32(p.stream_channels)
+			sample_rate:  i32(p.stream_rate)
 		)
 		p.sample_rate = audio.sample_rate()
 		p.channels = audio.channels()

--- a/examples/sokol/sounds/simple_bytebeat.v
+++ b/examples/sokol/sounds/simple_bytebeat.v
@@ -5,13 +5,15 @@
 import time
 import sokol.audio
 
-fn audio_callback(mut soundbuffer &f32, num_frames int, num_channels int, mut frame_0 &i32) {
-	for frame := 0; frame < num_frames; frame++ {
-		t := i32(f32(*frame_0 + frame) * 0.245)
+fn audio_callback(mut soundbuffer &f32, num_frames i32, num_channels i32, mut frame_0 &i32) {
+	frame_count := int(num_frames)
+	channel_count := int(num_channels)
+	for frame := 0; frame < frame_count; frame++ {
+		t := i32(f32(int(*frame_0) + frame) * 0.245)
 		y := (t * (((t / 10 | 0) ^ ((t / 10 | 0) - 1280)) % 11) / 2 & 127) +
 			(t * (((t / 640 | 0) ^ ((t / 640 | 0) - 2)) % 13) / 2 & 127)
-		for ch := 0; ch < num_channels; ch++ {
-			idx := frame * num_channels + ch
+		for ch := 0; ch < channel_count; ch++ {
+			idx := frame * channel_count + ch
 			a := f32(y - 127) / 255.0
 			soundbuffer[idx] = a
 		}

--- a/examples/sokol/sounds/simple_keyboard_synth.v
+++ b/examples/sokol/sounds/simple_keyboard_synth.v
@@ -90,9 +90,11 @@ fn (mut app App) silence() {
 	}
 }
 
-fn audio_callback(mut soundbuffer &f32, num_frames int, num_channels int, mut app App) {
+fn audio_callback(mut soundbuffer &f32, num_frames i32, num_channels i32, mut app App) {
+	frame_count := int(num_frames)
+	channel_count := int(num_channels)
 	lock app.notes {
-		for frame in 0 .. num_frames {
+		for frame in 0 .. frame_count {
 			mut sample := f32(0.0)
 			for mut note in app.notes {
 				if note.amplitude <= 0 {
@@ -108,12 +110,12 @@ fn audio_callback(mut soundbuffer &f32, num_frames int, num_channels int, mut ap
 				}
 				note.amplitude -= c_note_decay
 			}
-			for ch in 0 .. num_channels {
+			for ch in 0 .. channel_count {
 				// The sokol audio callback guarantees `soundbuffer` points to at least
 				// `num_frames * num_channels` writable samples, so this index
 				// (`frame < num_frames`, `ch < num_channels`) is always in bounds.
 				unsafe {
-					soundbuffer[frame * num_channels + ch] = sample
+					soundbuffer[frame * channel_count + ch] = sample
 				}
 			}
 		}

--- a/examples/sokol/sounds/simple_sin_tones.v
+++ b/examples/sokol/sounds/simple_sin_tones.v
@@ -11,29 +11,31 @@ fn sintone(periods int, frame int, num_frames int) f32 {
 	return math.sinf(f32(periods) * (2 * math.pi) * f32(frame) / f32(num_frames))
 }
 
-fn my_audio_stream_callback(mut soundbuffer &f32, num_frames int, num_channels int) {
+fn my_audio_stream_callback(mut soundbuffer &f32, num_frames i32, num_channels i32) {
+	frame_count := int(num_frames)
+	channel_count := int(num_channels)
 	ms := sw.elapsed().milliseconds() - sw_start_ms
-	for frame := 0; frame < num_frames; frame++ {
-		for ch := 0; ch < num_channels; ch++ {
-			idx := frame * num_channels + ch
+	for frame := 0; frame < frame_count; frame++ {
+		for ch := 0; ch < channel_count; ch++ {
+			idx := frame * channel_count + ch
 			// The sokol audio callback guarantees `soundbuffer` points to at least
 			// `num_frames * num_channels` writable samples, so `idx` (`frame < num_frames`,
 			// `ch < num_channels`) is always in bounds for the writes below.
 			if ms < 250 {
 				unsafe {
-					soundbuffer[idx] = 0.5 * sintone(20, frame, num_frames)
+					soundbuffer[idx] = 0.5 * sintone(20, frame, frame_count)
 				}
 			} else if ms < 300 {
 				unsafe {
-					soundbuffer[idx] = 0.5 * sintone(25, frame, num_frames)
+					soundbuffer[idx] = 0.5 * sintone(25, frame, frame_count)
 				}
 			} else if ms < 1500 {
 				unsafe {
-					soundbuffer[idx] *= sintone(22, frame, num_frames)
+					soundbuffer[idx] *= sintone(22, frame, frame_count)
 				}
 			} else {
 				unsafe {
-					soundbuffer[idx] = 0.5 * sintone(25, frame, num_frames)
+					soundbuffer[idx] = 0.5 * sintone(25, frame, frame_count)
 				}
 			}
 		}

--- a/examples/sokol/sounds/wav_player.v
+++ b/examples/sokol/sounds/wav_player.v
@@ -39,8 +39,8 @@ fn play_sounds(files []string) ! {
 }
 
 //
-fn audio_player_callback(mut buffer &f32, num_frames int, num_channels int, mut p Player) {
-	ntotal := num_channels * num_frames
+fn audio_player_callback(mut buffer &f32, num_frames i32, num_channels i32, mut p Player) {
+	ntotal := int(num_channels) * int(num_frames)
 	unsafe { vmemset(buffer, 0, ntotal * 4) }
 	if p.finished {
 		return

--- a/vlib/builtin/cfns.c.v
+++ b/vlib/builtin/cfns.c.v
@@ -285,7 +285,7 @@ fn C.isatty(fd i32) i32
 
 fn C.syscall(number i32, va ...voidptr) i32
 
-fn C.sysctl(name &int, namelen u32, oldp voidptr, oldlenp voidptr, newp voidptr, newlen usize) i32
+fn C.sysctl(name &i32, namelen u32, oldp voidptr, oldlenp voidptr, newp voidptr, newlen usize) i32
 
 @[trusted]
 fn C._fileno(&C.FILE) i32

--- a/vlib/builtin/cfns.c.v
+++ b/vlib/builtin/cfns.c.v
@@ -567,7 +567,7 @@ fn C.write(fd i32, buf voidptr, count usize) i32
 fn C.close(fd i32) i32
 
 // pipes
-fn C.pipe(pipefds &int) i32
+fn C.pipe(pipefds &i32) i32
 
 fn C.dup2(oldfd i32, newfd i32) i32
 

--- a/vlib/builtin/prealloc.c.v
+++ b/vlib/builtin/prealloc.c.v
@@ -9,10 +9,10 @@ $if !freestanding && !vinix {
 	}
 }
 
-fn C.v_prealloc_atomic_add_i32(ptr &int, delta int) int
-fn C.v_prealloc_atomic_load_i32(ptr &int) int
-fn C.v_prealloc_atomic_store_i32(ptr &int, val int) int
-fn C.v_prealloc_atomic_cas_i32(ptr &int, expected int, desired int) int
+fn C.v_prealloc_atomic_add_i32(ptr &i32, delta int) int
+fn C.v_prealloc_atomic_load_i32(ptr &i32) int
+fn C.v_prealloc_atomic_store_i32(ptr &i32, val int) int
+fn C.v_prealloc_atomic_cas_i32(ptr &i32, expected int, desired int) int
 fn C.v_prealloc_atomic_add_i64(ptr &i64, delta i64) i64
 fn C.v_prealloc_atomic_load_i64(ptr &i64) i64
 
@@ -122,10 +122,13 @@ mut:
 	ranges         &VPreallocRange = 0
 	ranges_len     int
 	ranges_cap     int
-	refs           int
-	free_requested int
-	abandoned      int
-	finalized      int
+	// Accessed through the C `_i32` atomics (`&scope.refs` etc.) as 4-byte ints; keep
+	// them i32 so the pointer passed to the atomic matches the C `int32_t*` and the
+	// atomic operates on the real shared field (not a bridged temporary).
+	refs           i32
+	free_requested i32
+	abandoned      i32
+	finalized      i32
 }
 
 @[unsafe]

--- a/vlib/compress/compress.c.v
+++ b/vlib/compress/compress.c.v
@@ -100,15 +100,18 @@ mut:
 	cb                ChunkCallback = unsafe { nil }
 }
 
-fn c_cb_for_decompress_mem(buf &char, len int, pdcbd voidptr) int {
+// miniz invokes this callback with C `int` arguments/return values. Keep the C ABI
+// explicitly i32 and convert to platform-width V `int` only at the public callback.
+fn c_cb_for_decompress_mem(buf &char, len i32, pdcbd voidptr) i32 {
 	mut cbdata := unsafe { &DecompressionCallBackData(pdcbd) }
-	if cbdata.cb(unsafe { voidptr(buf).vbytes(len) }, cbdata.userdata) == len {
-		cbdata.decompressed_size += u64(len)
+	vlen := int(len)
+	if cbdata.cb(unsafe { voidptr(buf).vbytes(vlen) }, cbdata.userdata) == vlen {
+		cbdata.decompressed_size += u64(vlen)
 		return 1 // continue decompressing
 	}
 	return 0 // stop decompressing
 }
 
-type DecompressCallback = fn (const_buffer voidptr, len int, userdata voidptr) int
+type DecompressCallback = fn (const_buffer voidptr, len i32, userdata voidptr) i32
 
 fn C.tinfl_decompress_mem_to_callback(const_input_buffer voidptr, psize &usize, put_buf_cb DecompressCallback, userdata voidptr, flags i32) i32

--- a/vlib/db/mysql/orm.c.v
+++ b/vlib/db/mysql/orm.c.v
@@ -404,7 +404,18 @@ fn data_pointers_to_primitives(is_null []C.v_mysql_bool, data_pointers []&u8, ty
 				orm.type_idx['i16'] {
 					primitive = *(unsafe { &i16(data) })
 				}
-				orm.type_idx['int'], orm.serial {
+				orm.type_idx['int'] {
+					$if new_int ? && x64 {
+						primitive = match field_types[i] {
+							.type_long { orm.Primitive(int(*(unsafe { &i32(data) }))) }
+							.type_longlong { orm.Primitive(int(*(unsafe { &i64(data) }))) }
+							else { return error('Unsupported MySQL field type ${field_types[i]} for V int') }
+						}
+					} $else {
+						primitive = *(unsafe { &int(data) })
+					}
+				}
+				orm.serial {
 					primitive = *(unsafe { &int(data) })
 				}
 				orm.type_idx['i64'] {
@@ -437,7 +448,7 @@ fn data_pointers_to_primitives(is_null []C.v_mysql_bool, data_pointers []&u8, ty
 				orm.time_ {
 					match field_types[i] {
 						.type_long {
-							timestamp := *(unsafe { &int(data) })
+							timestamp := int(*(unsafe { &i32(data) }))
 							primitive = time.unix(timestamp)
 						}
 						.type_datetime, .type_timestamp {
@@ -509,7 +520,14 @@ fn mysql_type_from_v(typ int) !string {
 		orm.type_idx['i16'], orm.type_idx['u16'] {
 			'SMALLINT'
 		}
-		orm.type_idx['int'], orm.type_idx['u32'], orm.time_ {
+		orm.type_idx['int'] {
+			$if new_int ? && x64 {
+				'BIGINT'
+			} $else {
+				'INT'
+			}
+		}
+		orm.type_idx['u32'], orm.time_ {
 			'INT'
 		}
 		orm.type_idx['i64'], orm.type_idx['u64'], orm.enum_ {

--- a/vlib/db/mysql/stmt.c.v
+++ b/vlib/db/mysql/stmt.c.v
@@ -243,7 +243,11 @@ pub fn (mut stmt Stmt) bind_u16(b &u16) {
 
 // bind_int binds a single int value to the statement `stmt`
 pub fn (mut stmt Stmt) bind_int(b &int) {
-	stmt.bind(mysql_type_long, b, 0)
+	$if new_int ? && x64 {
+		stmt.bind(mysql_type_longlong, b, 0)
+	} $else {
+		stmt.bind(mysql_type_long, b, 0)
+	}
 }
 
 // bind_u32 binds a single u32 value to the statement `stmt`

--- a/vlib/db/pg/orm.v
+++ b/vlib/db/pg/orm.v
@@ -290,92 +290,92 @@ pub fn (mut tx Tx) orm_release_savepoint(name string) ! {
 
 // ---- utils ----
 
-fn pg_stmt_binder(mut types []u32, mut vals []&char, mut lens []int, mut formats []int, d orm.QueryData) {
+fn pg_stmt_binder(mut types []u32, mut vals []&char, mut lens []i32, mut formats []i32, d orm.QueryData) {
 	for data in d.data {
 		pg_stmt_match(mut types, mut vals, mut lens, mut formats, data)
 	}
 }
 
-fn pg_stmt_match_array[T](mut types []u32, mut vals []&char, mut lens []int, mut formats []int, data []T) {
+fn pg_stmt_match_array[T](mut types []u32, mut vals []&char, mut lens []i32, mut formats []i32, data []T) {
 	for element in data {
 		pg_stmt_match(mut types, mut vals, mut lens, mut formats, orm.Primitive(element))
 	}
 }
 
-fn pg_stmt_match(mut types []u32, mut vals []&char, mut lens []int, mut formats []int, data orm.Primitive) {
+fn pg_stmt_match(mut types []u32, mut vals []&char, mut lens []i32, mut formats []i32, data orm.Primitive) {
 	match data {
 		bool {
 			types << u32(Oid.t_bool)
 			vals << &char(&data)
-			lens << int(sizeof(bool))
+			lens << i32(sizeof(bool))
 			formats << 1
 		}
 		u8 {
 			types << u32(Oid.t_char)
 			vals << &char(&data)
-			lens << int(sizeof(u8))
+			lens << i32(sizeof(u8))
 			formats << 1
 		}
 		u16 {
 			types << u32(Oid.t_int2)
 			num := conv.hton16(data)
 			vals << &char(&num)
-			lens << int(sizeof(u16))
+			lens << i32(sizeof(u16))
 			formats << 1
 		}
 		u32 {
 			types << u32(Oid.t_int4)
 			num := conv.hton32(data)
 			vals << &char(&num)
-			lens << int(sizeof(u32))
+			lens << i32(sizeof(u32))
 			formats << 1
 		}
 		u64 {
 			types << u32(Oid.t_int8)
 			num := conv.hton64(data)
 			vals << &char(&num)
-			lens << int(sizeof(u64))
+			lens << i32(sizeof(u64))
 			formats << 1
 		}
 		i8 {
 			types << u32(Oid.t_char)
 			vals << &char(&data)
-			lens << int(sizeof(i8))
+			lens << i32(sizeof(i8))
 			formats << 1
 		}
 		i16 {
 			types << u32(Oid.t_int2)
 			num := conv.hton16(u16(data))
 			vals << &char(&num)
-			lens << int(sizeof(i16))
+			lens << i32(sizeof(i16))
 			formats << 1
 		}
 		int {
 			types << u32(Oid.t_int4)
 			num := conv.hton32(u32(data))
 			vals << &char(&num)
-			lens << int(sizeof(int))
+			lens << i32(sizeof(int))
 			formats << 1
 		}
 		i64 {
 			types << u32(Oid.t_int8)
 			num := conv.hton64(u64(data))
 			vals << &char(&num)
-			lens << int(sizeof(i64))
+			lens << i32(sizeof(i64))
 			formats << 1
 		}
 		f32 {
 			types << u32(Oid.t_float4)
 			num := conv.htonf32(f32(data))
 			vals << &char(&num)
-			lens << int(sizeof(f32))
+			lens << i32(sizeof(f32))
 			formats << 1
 		}
 		f64 {
 			types << u32(Oid.t_float8)
 			num := conv.htonf64(f64(data))
 			vals << &char(&num)
-			lens << int(sizeof(f64))
+			lens << i32(sizeof(f64))
 			formats << 1
 		}
 		string {
@@ -384,7 +384,7 @@ fn pg_stmt_match(mut types []u32, mut vals []&char, mut lens []int, mut formats 
 			// it would do for an untyped literal string.
 			types << u32(0)
 			vals << &char(data.str)
-			lens << data.len
+			lens << i32(data.len)
 			formats << 0
 		}
 		time.Time {
@@ -393,7 +393,7 @@ fn pg_stmt_match(mut types []u32, mut vals []&char, mut lens []int, mut formats 
 			datetime := data.format_ss_micro()
 			types << u32(0)
 			vals << &char(datetime.str)
-			lens << datetime.len
+			lens << i32(datetime.len)
 			formats << 0
 		}
 		orm.InfixType {
@@ -402,7 +402,7 @@ fn pg_stmt_match(mut types []u32, mut vals []&char, mut lens []int, mut formats 
 		orm.Null {
 			types << u32(0) // we do not know col type, let server infer
 			vals << &char(unsafe { nil }) // NULL pointer indicates NULL
-			lens << int(0) // ignored
+			lens << i32(0) // ignored
 			formats << 0 // ignored
 		}
 		[]orm.Primitive {

--- a/vlib/db/pg/orm.v
+++ b/vlib/db/pg/orm.v
@@ -351,10 +351,17 @@ fn pg_stmt_match(mut types []u32, mut vals []&char, mut lens []i32, mut formats 
 			formats << 1
 		}
 		int {
-			types << u32(Oid.t_int4)
-			num := conv.hton32(u32(data))
-			vals << &char(&num)
-			lens << i32(sizeof(int))
+			$if new_int ? && x64 {
+				types << u32(Oid.t_int8)
+				num := conv.hton64(u64(data))
+				vals << &char(&num)
+				lens << i32(sizeof(i64))
+			} $else {
+				types << u32(Oid.t_int4)
+				num := conv.hton32(u32(data))
+				vals << &char(&num)
+				lens << i32(sizeof(i32))
+			}
 			formats << 1
 		}
 		i64 {
@@ -461,7 +468,14 @@ fn pg_type_from_v(typ int) !string {
 		orm.type_idx['bool'] {
 			'BOOLEAN'
 		}
-		orm.type_idx['int'], orm.type_idx['u32'] {
+		orm.type_idx['int'] {
+			$if new_int ? && x64 {
+				'BIGINT'
+			} $else {
+				'INT'
+			}
+		}
+		orm.type_idx['u32'] {
 			'INT'
 		}
 		orm.time_ {

--- a/vlib/db/pg/pg.c.v
+++ b/vlib/db/pg/pg.c.v
@@ -260,8 +260,8 @@ fn C.PQftablecol(const_res &C.PGresult, i32) i32
 // const char *const *paramValues
 // const int *paramLengths
 // const int *paramFormats
-fn C.PQexecParams(conn &C.PGconn, const_command &char, nParams i32, const_paramTypes &int, const_paramValues voidptr,
-	const_paramLengths &int, const_paramFormats &int, resultFormat i32) &C.PGresult
+fn C.PQexecParams(conn &C.PGconn, const_command &char, nParams i32, const_paramTypes &u32, const_paramValues voidptr,
+	const_paramLengths &i32, const_paramFormats &i32, resultFormat i32) &C.PGresult
 
 fn C.PQputCopyData(conn &C.PGconn, const_buffer &char, nbytes i32) i32
 
@@ -272,7 +272,7 @@ fn C.PQgetCopyData(conn &C.PGconn, buffer &&char, async i32) i32
 fn C.PQprepare(conn &C.PGconn, const_stmtName &char, const_query &char, nParams i32, const_param_types &&char) &C.PGresult
 
 fn C.PQexecPrepared(conn &C.PGconn, const_stmtName &char, nParams i32, const_paramValues voidptr,
-	const_paramLengths &int, const_paramFormats &int, resultFormat i32) &C.PGresult
+	const_paramLengths &i32, const_paramFormats &i32, resultFormat i32) &C.PGresult
 
 // cleanup
 
@@ -849,8 +849,10 @@ pub fn (c &Conn) copy_expert(query string, mut file io.ReaderWriter) !int {
 fn pg_stmt_worker(c &Conn, query string, data orm.QueryData, where orm.QueryData) ![]Row {
 	mut param_types := []u32{}
 	mut param_vals := []&char{}
-	mut param_lens := []int{}
-	mut param_formats := []int{}
+	// C's PQexecParams reads these as `const int *` (4-byte C ints); back them with
+	// i32 so `.data` matches the C ABI (a V `[]int` is now 64-bit per element).
+	mut param_lens := []i32{}
+	mut param_formats := []i32{}
 
 	pg_stmt_binder(mut param_types, mut param_vals, mut param_lens, mut param_formats, data)
 	pg_stmt_binder(mut param_types, mut param_vals, mut param_lens, mut param_formats, where)

--- a/vlib/db/sqlite/sqlite_vfs_lowlevel_test.v
+++ b/vlib/db/sqlite/sqlite_vfs_lowlevel_test.v
@@ -44,7 +44,7 @@ fn test_verify_vfs_is_actually_used() {
 	}
 	mut vfs_descr := &sqlite.Sqlite3_vfs{
 		iVersion:          2
-		szOsFile:          int(sizeof(ExampleVfsOpenedFile))
+		szOsFile:          i32(sizeof(ExampleVfsOpenedFile))
 		mxPathname:        max_file_name_len
 		zName:             vfs_name.str
 		pAppData:          vfs_state
@@ -105,7 +105,7 @@ fn to_vfsopenedfile(t &sqlite.Sqlite3_file) &ExampleVfsOpenedFile {
 	}
 }
 
-fn example_vfs_fullpathname(vfs &sqlite.Sqlite3_vfs, input &char, size_of_output int, output &char) int {
+fn example_vfs_fullpathname(vfs &sqlite.Sqlite3_vfs, input &char, size_of_output i32, output &char) i32 {
 	println('fullpathname called')
 
 	mut vfs_state := to_vfsstate(vfs)
@@ -123,7 +123,7 @@ fn example_vfs_fullpathname(vfs &sqlite.Sqlite3_vfs, input &char, size_of_output
 	return sqlite.sqlite_ok
 }
 
-fn example_vfs_access(vfs &sqlite.Sqlite3_vfs, zPath &char, flags int, pResOut &int) int {
+fn example_vfs_access(vfs &sqlite.Sqlite3_vfs, zPath &char, flags i32, pResOut &i32) i32 {
 	println('access called')
 	mut vfs_state := &ExampleVfsState{}
 
@@ -137,7 +137,7 @@ fn example_vfs_access(vfs &sqlite.Sqlite3_vfs, zPath &char, flags int, pResOut &
 }
 
 fn example_vfs_open(vfs &sqlite.Sqlite3_vfs, file_name_or_null_for_tempfile &char, vfs_opened_file &sqlite.Sqlite3_file,
-	in_flags int, out_flags &int) int {
+	in_flags i32, out_flags &i32) i32 {
 	println('open called')
 
 	mut is_temp := false
@@ -179,7 +179,7 @@ fn example_vfs_open(vfs &sqlite.Sqlite3_vfs, file_name_or_null_for_tempfile &cha
 	return sqlite.sqlite_ok
 }
 
-fn example_vfsfile_checkreservedlock(file &sqlite.Sqlite3_file, pResOut &int) int {
+fn example_vfsfile_checkreservedlock(file &sqlite.Sqlite3_file, pResOut &i32) i32 {
 	println('file checkreservedlock')
 
 	unsafe {
@@ -188,25 +188,25 @@ fn example_vfsfile_checkreservedlock(file &sqlite.Sqlite3_file, pResOut &int) in
 	return sqlite.sqlite_ok
 }
 
-fn example_vfsfile_filecontrol(file &sqlite.Sqlite3_file, op int, arg voidptr) int {
+fn example_vfsfile_filecontrol(file &sqlite.Sqlite3_file, op i32, arg voidptr) i32 {
 	println('file filecontrol')
 
 	return 0
 }
 
-fn example_vfsfile_devicecharacteristics(file &sqlite.Sqlite3_file) int {
+fn example_vfsfile_devicecharacteristics(file &sqlite.Sqlite3_file) i32 {
 	println('file devicecharacteristics')
 
 	return 0
 }
 
-fn example_vfsfile_size(file &sqlite.Sqlite3_file, result &i64) int {
+fn example_vfsfile_size(file &sqlite.Sqlite3_file, result &i64) i32 {
 	println('file size')
 
 	return sqlite.sqlite_ok
 }
 
-fn example_vfsfile_read(file &sqlite.Sqlite3_file, output voidptr, amount int, offset i64) int {
+fn example_vfsfile_read(file &sqlite.Sqlite3_file, output voidptr, amount i32, offset i64) i32 {
 	println('file read')
 
 	assert amount > 0
@@ -216,49 +216,49 @@ fn example_vfsfile_read(file &sqlite.Sqlite3_file, output voidptr, amount int, o
 		vfsfile.vfs_state.log << 'read file=${vfsfile.name}'
 	}
 	unsafe {
-		vmemset(output, 0, amount)
+		vmemset(output, 0, int(amount))
 	}
 
 	return sqlite.sqlite_ioerr_short_read
 }
 
-fn example_vfsfile_truncate(file &sqlite.Sqlite3_file, size i64) int {
+fn example_vfsfile_truncate(file &sqlite.Sqlite3_file, size i64) i32 {
 	println('file truncate')
 
 	return sqlite.sqlite_ok
 }
 
-fn example_vfsfile_sectorsize(file &sqlite.Sqlite3_file) int {
+fn example_vfsfile_sectorsize(file &sqlite.Sqlite3_file) i32 {
 	println('file sectorsize')
 
 	return 0
 }
 
-fn example_vfsfile_sync(file &sqlite.Sqlite3_file, flags int) int {
+fn example_vfsfile_sync(file &sqlite.Sqlite3_file, flags i32) i32 {
 	println('file sync called')
 
 	return sqlite.sqlite_ok
 }
 
-fn example_vfsfile_lock(file &sqlite.Sqlite3_file, elock int) int {
+fn example_vfsfile_lock(file &sqlite.Sqlite3_file, elock i32) i32 {
 	println('file lock called')
 
 	return sqlite.sqlite_ok
 }
 
-fn example_vfsfile_unlock(file &sqlite.Sqlite3_file, elock int) int {
+fn example_vfsfile_unlock(file &sqlite.Sqlite3_file, elock i32) i32 {
 	println('file unlock called')
 
 	return sqlite.sqlite_ok
 }
 
-fn example_vfsfile_write(file &sqlite.Sqlite3_file, buf voidptr, amount int, offset i64) int {
+fn example_vfsfile_write(file &sqlite.Sqlite3_file, buf voidptr, amount i32, offset i64) i32 {
 	println('file write called')
 
 	return sqlite.sqlite_ok
 }
 
-fn example_vfsfile_close(file &sqlite.Sqlite3_file) int {
+fn example_vfsfile_close(file &sqlite.Sqlite3_file) i32 {
 	println('file close called')
 
 	unsafe {
@@ -268,13 +268,13 @@ fn example_vfsfile_close(file &sqlite.Sqlite3_file) int {
 	return sqlite.sqlite_ok
 }
 
-fn example_vfs_delete(vfs &sqlite.Sqlite3_vfs, name &char, sync_dir int) int {
+fn example_vfs_delete(vfs &sqlite.Sqlite3_vfs, name &char, sync_dir i32) i32 {
 	println('vfs delete called')
 
 	return sqlite.sqlite_ok
 }
 
-fn example_vfs_getlasterror(vfs &sqlite.Sqlite3_vfs, i int, o &char) int {
+fn example_vfs_getlasterror(vfs &sqlite.Sqlite3_vfs, i i32, o &char) i32 {
 	println('vfs getlasterror called')
 
 	unsafe {

--- a/vlib/db/sqlite/stmt.c.v
+++ b/vlib/db/sqlite/stmt.c.v
@@ -29,7 +29,11 @@ fn (stmt &Stmt) bind_null(idx int) int {
 }
 
 fn (stmt &Stmt) bind_int(idx int, v int) int {
-	return C.sqlite3_bind_int(stmt.stmt, idx, v)
+	$if new_int ? && x64 {
+		return C.sqlite3_bind_int64(stmt.stmt, idx, i64(v))
+	} $else {
+		return C.sqlite3_bind_int(stmt.stmt, idx, v)
+	}
 }
 
 fn (stmt &Stmt) bind_i64(idx int, v i64) int {
@@ -48,7 +52,11 @@ fn (stmt &Stmt) get_int(idx int) ?int {
 	if C.sqlite3_column_type(stmt.stmt, idx) == sqlite_null {
 		return none
 	} else {
-		return C.sqlite3_column_int(stmt.stmt, idx)
+		$if new_int ? && x64 {
+			return int(C.sqlite3_column_int64(stmt.stmt, idx))
+		} $else {
+			return C.sqlite3_column_int(stmt.stmt, idx)
+		}
 	}
 }
 

--- a/vlib/db/sqlite/vfs_lowlevel.c.v
+++ b/vlib/db/sqlite/vfs_lowlevel.c.v
@@ -1,8 +1,10 @@
 module sqlite
 
-type Sig1 = fn (&C.sqlite3_file, &i64) int // https://github.com/vlang/v/issues/16291
+// SQLite's VFS/io-method ABI uses C `int` throughout. Keep those fields and
+// callback signatures explicitly i32 now that V's platform `int` is 64-bit.
+type Sig1 = fn (&C.sqlite3_file, &i64) i32 // https://github.com/vlang/v/issues/16291
 
-type Sig2 = fn (&Sqlite3_file, &int) int // https://github.com/vlang/v/issues/16291
+type Sig2 = fn (&Sqlite3_file, &i32) i32 // https://github.com/vlang/v/issues/16291
 
 pub type Sqlite3_file = C.sqlite3_file
 pub type Sqlite3_vfs = C.sqlite3_vfs
@@ -12,53 +14,53 @@ type Fn_sqlite3_syscall_ptr = fn ()
 
 // Keep these callback signatures named so v2 does not need to parse qualified
 // type names inside inline `fn (...)` struct fields.
-type Sqlite3_file_op_fn = fn (&Sqlite3_file) int
+type Sqlite3_file_op_fn = fn (&Sqlite3_file) i32
 
-type Sqlite3_file_rw_fn = fn (&Sqlite3_file, voidptr, int, i64) int
+type Sqlite3_file_rw_fn = fn (&Sqlite3_file, voidptr, i32, i64) i32
 
-type Sqlite3_file_truncate_fn = fn (&Sqlite3_file, i64) int
+type Sqlite3_file_truncate_fn = fn (&Sqlite3_file, i64) i32
 
-type Sqlite3_file_flag_fn = fn (&Sqlite3_file, int) int
+type Sqlite3_file_flag_fn = fn (&Sqlite3_file, i32) i32
 
-type Sqlite3_file_control_fn = fn (&Sqlite3_file, int, voidptr) int
+type Sqlite3_file_control_fn = fn (&Sqlite3_file, i32, voidptr) i32
 
-type Sqlite3_file_shm_map_fn = fn (&Sqlite3_file, int, int, int, &voidptr) int
+type Sqlite3_file_shm_map_fn = fn (&Sqlite3_file, i32, i32, i32, &voidptr) i32
 
-type Sqlite3_file_shm_lock_fn = fn (&Sqlite3_file, int, int, int) int
+type Sqlite3_file_shm_lock_fn = fn (&Sqlite3_file, i32, i32, i32) i32
 
 type Sqlite3_file_shm_barrier_fn = fn (&Sqlite3_file)
 
-type Sqlite3_file_fetch_fn = fn (&Sqlite3_file, i64, int, &voidptr) int
+type Sqlite3_file_fetch_fn = fn (&Sqlite3_file, i64, i32, &voidptr) i32
 
-type Sqlite3_file_unfetch_fn = fn (&Sqlite3_file, i64, voidptr) int
+type Sqlite3_file_unfetch_fn = fn (&Sqlite3_file, i64, voidptr) i32
 
-type Sqlite3_vfs_open_fn = fn (&Sqlite3_vfs, &char, &Sqlite3_file, int, &int) int
+type Sqlite3_vfs_open_fn = fn (&Sqlite3_vfs, &char, &Sqlite3_file, i32, &i32) i32
 
-type Sqlite3_vfs_delete_fn = fn (&Sqlite3_vfs, &char, int) int
+type Sqlite3_vfs_delete_fn = fn (&Sqlite3_vfs, &char, i32) i32
 
-type Sqlite3_vfs_access_fn = fn (&Sqlite3_vfs, &char, int, &int) int
+type Sqlite3_vfs_access_fn = fn (&Sqlite3_vfs, &char, i32, &i32) i32
 
-type Sqlite3_vfs_fullpathname_fn = fn (&Sqlite3_vfs, &char, int, &char) int
+type Sqlite3_vfs_fullpathname_fn = fn (&Sqlite3_vfs, &char, i32, &char) i32
 
 type Sqlite3_vfs_dlopen_fn = fn (&Sqlite3_vfs, &char) voidptr
 
-type Sqlite3_vfs_dlerror_fn = fn (&Sqlite3_vfs, int, &char)
+type Sqlite3_vfs_dlerror_fn = fn (&Sqlite3_vfs, i32, &char)
 
 type Sqlite3_vfs_dlsym_fn = fn (&Sqlite3_vfs, voidptr, &char) voidptr
 
 type Sqlite3_vfs_dlclose_fn = fn (&Sqlite3_vfs, voidptr)
 
-type Sqlite3_vfs_randomness_fn = fn (&Sqlite3_vfs, int, &char) int
+type Sqlite3_vfs_randomness_fn = fn (&Sqlite3_vfs, i32, &char) i32
 
-type Sqlite3_vfs_sleep_fn = fn (&Sqlite3_vfs, int) int
+type Sqlite3_vfs_sleep_fn = fn (&Sqlite3_vfs, i32) i32
 
-type Sqlite3_vfs_current_time_fn = fn (&Sqlite3_vfs, &f64) int
+type Sqlite3_vfs_current_time_fn = fn (&Sqlite3_vfs, &f64) i32
 
-type Sqlite3_vfs_get_last_error_fn = fn (&Sqlite3_vfs, int, &char) int
+type Sqlite3_vfs_get_last_error_fn = fn (&Sqlite3_vfs, i32, &char) i32
 
-type Sqlite3_vfs_current_time_i64_fn = fn (&Sqlite3_vfs, &i64) int
+type Sqlite3_vfs_current_time_i64_fn = fn (&Sqlite3_vfs, &i64) i32
 
-type Sqlite3_vfs_set_system_call_fn = fn (&Sqlite3_vfs, &char, Fn_sqlite3_syscall_ptr) int
+type Sqlite3_vfs_set_system_call_fn = fn (&Sqlite3_vfs, &char, Fn_sqlite3_syscall_ptr) i32
 
 type Sqlite3_vfs_get_system_call_fn = fn (&Sqlite3_vfs, &char) Fn_sqlite3_syscall_ptr
 
@@ -75,7 +77,7 @@ pub mut:
 pub struct C.sqlite3_io_methods {
 mut:
 	// version 1 and later fields
-	iVersion int
+	iVersion i32
 
 	xClose                 Sqlite3_file_op_fn
 	xRead                  Sqlite3_file_rw_fn
@@ -105,9 +107,9 @@ pub type Sqlite3_io_methods = C.sqlite3_io_methods
 pub struct C.sqlite3_vfs {
 pub mut:
 	// version 1 and later fields
-	iVersion   int          // Structure version number (currently 3)
-	szOsFile   int          // Size of subclassed sqlite3_file
-	mxPathname int          // Maximum file pathname length
+	iVersion   i32          // Structure version number (currently 3)
+	szOsFile   i32          // Size of subclassed sqlite3_file
+	mxPathname i32          // Maximum file pathname length
 	pNext      &Sqlite3_vfs // Next registered VFS
 	zName      &char        // Name of this virtual file system
 	pAppData   voidptr      // Pointer to application-specific data

--- a/vlib/fontstash/fontstash.c.v
+++ b/vlib/fontstash/fontstash.c.v
@@ -47,7 +47,7 @@ pub fn delete_internal(s &Context) {
 // set_error_callback sets `callback` as a function to be called if fontstash
 // encounter any errors. `uptr` can be used to pass custom userdata.
 @[inline]
-pub fn (s &Context) set_error_callback(callback fn (voidptr, int, int), uptr voidptr) {
+pub fn (s &Context) set_error_callback(callback fn (voidptr, i32, i32), uptr voidptr) {
 	C.fonsSetErrorCallback(s, callback, uptr)
 }
 
@@ -55,10 +55,10 @@ pub fn (s &Context) set_error_callback(callback fn (voidptr, int, int), uptr voi
 // the font is rendered to.
 @[inline]
 pub fn (s &Context) get_atlas_size() (int, int) {
-	mut width := 0
-	mut height := 0
+	mut width := i32(0)
+	mut height := i32(0)
 	C.fonsGetAtlasSize(s, &width, &height)
-	return width, height
+	return int(width), int(height)
 }
 
 // expand_atlas expands the font texture atlas size to `width` x `height`.
@@ -276,7 +276,14 @@ pub fn (s &Context) text_iter_next(iter &C.FONStextIter, quad &C.FONSquad) int {
 // `width` and `height` is assigned the size of the texture dimensions.
 @[inline]
 pub fn (s &Context) get_texture_data(width &int, height &int) &u8 {
-	return &u8(C.fonsGetTextureData(s, width, height))
+	mut c_width := i32(unsafe { *width })
+	mut c_height := i32(unsafe { *height })
+	data := C.fonsGetTextureData(s, &c_width, &c_height)
+	unsafe {
+		*width = int(c_width)
+		*height = int(c_height)
+	}
+	return &u8(data)
 }
 
 // validate_texture fills the `dirty` argument with the pixel dimensions
@@ -287,7 +294,19 @@ pub fn (s &Context) get_texture_data(width &int, height &int) &u8 {
 // The function returns `1` if the texture has a dirty rectangle, `0` otherwise.
 @[inline]
 pub fn (s &Context) validate_texture(dirty &int) int {
-	return C.fonsValidateTexture(s, dirty)
+	mut c_dirty := [4]i32{}
+	unsafe {
+		for i in 0 .. 4 {
+			c_dirty[i] = i32(dirty[i])
+		}
+	}
+	result := C.fonsValidateTexture(s, &c_dirty[0])
+	unsafe {
+		for i in 0 .. 4 {
+			dirty[i] = int(c_dirty[i])
+		}
+	}
+	return result
 }
 
 // draw_debug draws the stash texture for debugging.

--- a/vlib/fontstash/fontstash_funcs.c.v
+++ b/vlib/fontstash/fontstash_funcs.c.v
@@ -4,10 +4,10 @@ module fontstash
 fn C.fonsCreateInternal(params &C.FONSparams) &C.FONScontext
 fn C.fonsDeleteInternal(s &C.FONScontext)
 
-fn C.fonsSetErrorCallback(s &C.FONScontext, callback fn (voidptr, int, int), uptr voidptr)
+fn C.fonsSetErrorCallback(s &C.FONScontext, callback fn (voidptr, i32, i32), uptr voidptr)
 
 // Returns current atlas size.
-fn C.fonsGetAtlasSize(s &C.FONScontext, width &int, height &int)
+fn C.fonsGetAtlasSize(s &C.FONScontext, width &i32, height &i32)
 
 // Expands the atlas size.
 fn C.fonsExpandAtlas(s &C.FONScontext, width i32, height i32) i32
@@ -46,8 +46,8 @@ fn C.fonsTextIterInit(s &C.FONScontext, iter &C.FONStextIter, x f32, y f32, str 
 fn C.fonsTextIterNext(s &C.FONScontext, iter &C.FONStextIter, quad &C.FONSquad) i32
 
 // Pull texture changes
-fn C.fonsGetTextureData(s &C.FONScontext, width &int, height &int) &char
-fn C.fonsValidateTexture(s &C.FONScontext, dirty &int) i32
+fn C.fonsGetTextureData(s &C.FONScontext, width &i32, height &i32) &char
+fn C.fonsValidateTexture(s &C.FONScontext, dirty &i32) i32
 
 // Draws the stash texture for debugging
 fn C.fonsDrawDebug(s &C.FONScontext, x f32, y f32)

--- a/vlib/fontstash/fontstash_structs.c.v
+++ b/vlib/fontstash/fontstash_structs.c.v
@@ -1,18 +1,18 @@
 module fontstash
 
 pub struct C.FONSparams {
-	width   int
-	height  int
+	width   i32
+	height  i32
 	flags   char
 	userPtr voidptr
 	// int (*renderCreate)(void* uptr, int width, int height)
-	renderCreate fn (uptr voidptr, width int, height int) int = unsafe { nil }
+	renderCreate fn (uptr voidptr, width i32, height i32) i32 = unsafe { nil }
 	// int (*renderResize)(void* uptr, int width, int height)
-	renderResize fn (uptr voidptr, width int, height int) int = unsafe { nil }
+	renderResize fn (uptr voidptr, width i32, height i32) i32 = unsafe { nil }
 	// void (*renderUpdate)(void* uptr, int* rect, const unsigned char* data)
-	renderUpdate fn (uptr voidptr, rect &int, data &u8) = unsafe { nil }
+	renderUpdate fn (uptr voidptr, rect &i32, data &u8) = unsafe { nil }
 	// void (*renderDraw)(void* uptr, const float* verts, const float* tcoords, const unsigned int* colors, int nverts)
-	renderDraw fn (uptr voidptr, verts &f32, tcoords &f32, colors &u32, nverts int) = unsafe { nil }
+	renderDraw fn (uptr voidptr, verts &f32, tcoords &f32, colors &u32, nverts i32) = unsafe { nil }
 	// void (*renderDelete)(void* uptr)
 	renderDelete fn (uptr voidptr) = unsafe { nil }
 }
@@ -39,7 +39,7 @@ pub struct C.FONStextIter {
 	isize          i16
 	iblur          i16
 	font           &C.FONSfont = unsafe { nil }
-	prevGlyphIndex int
+	prevGlyphIndex i32
 	str            &u8
 	next           &u8
 	end            &u8

--- a/vlib/gg/text_rendering.c.v
+++ b/vlib/gg/text_rendering.c.v
@@ -36,7 +36,7 @@ pub enum VerticalAlign {
 const initial_text_atlas_size = int($d('gg_text_buff_size', 2048))
 const max_text_atlas_size = 8192
 
-fn expand_atlas_callback(uptr voidptr, error int, _val int) {
+fn expand_atlas_callback(uptr voidptr, error i32, _val i32) {
 	if error != C.FONS_ATLAS_FULL {
 		return
 	}

--- a/vlib/gg/text_rendering_test.v
+++ b/vlib/gg/text_rendering_test.v
@@ -13,8 +13,8 @@ fn new_test_text_context() (&Context, &fontstash.Context) {
 
 fn new_test_text_context_with_atlas(width int, height int) (&Context, &fontstash.Context) {
 	mut fons := fontstash.create_internal(&C.FONSparams{
-		width:  width
-		height: height
+		width:  i32(width)
+		height: i32(height)
 		flags:  0
 	})
 	assert fons != unsafe { nil }
@@ -36,6 +36,28 @@ fn text_advance_and_bounds_width(fons &fontstash.Context, text string) (f32, f32
 	mut bounds := [4]f32{}
 	advance := fons.text_bounds(0, 0, text, &bounds[0])
 	return advance, bounds[2] - bounds[0]
+}
+
+fn test_fontstash_c_int_output_buffers() {
+	_, fons := new_test_text_context_with_atlas(64, 64)
+	defer {
+		fontstash.delete_internal(fons)
+	}
+	mut width := -1
+	mut height := -1
+	data := fons.get_texture_data(&width, &height)
+	assert data != unsafe { nil }
+	assert width == 64
+	assert height == 64
+
+	// Rasterizing a glyph dirties the atlas, so fonsValidateTexture must write all
+	// four C `int` rectangle entries. The wrapper copies them back to V `int`s.
+	_ = fons.draw_text(0, 0, 'x')
+	mut dirty := [-1, -1, -1, -1]!
+	assert fons.validate_texture(&dirty[0]) == 1
+	for value in dirty {
+		assert value >= 0
+	}
 }
 
 fn test_text_width_uses_font_advance_for_monospaced_fonts() {

--- a/vlib/net/address_android.c.v
+++ b/vlib/net/address_android.c.v
@@ -4,11 +4,11 @@ const max_unix_path = 108
 
 pub struct C.addrinfo {
 mut:
-	ai_family    int
-	ai_socktype  int
-	ai_flags     int
-	ai_protocol  int
-	ai_addrlen   int
+	ai_family    i32
+	ai_socktype  i32
+	ai_flags     i32
+	ai_protocol  i32
+	ai_addrlen   i32
 	ai_addr      voidptr
 	ai_canonname voidptr
 	ai_next      voidptr

--- a/vlib/net/address_darwin.c.v
+++ b/vlib/net/address_darwin.c.v
@@ -4,11 +4,11 @@ const max_unix_path = 104
 
 pub struct C.addrinfo {
 mut:
-	ai_family    int
-	ai_socktype  int
-	ai_flags     int
-	ai_protocol  int
-	ai_addrlen   int
+	ai_family    i32
+	ai_socktype  i32
+	ai_flags     i32
+	ai_protocol  i32
+	ai_addrlen   i32
 	ai_addr      voidptr
 	ai_canonname voidptr
 	ai_next      voidptr

--- a/vlib/net/address_default.c.v
+++ b/vlib/net/address_default.c.v
@@ -4,11 +4,11 @@ const max_unix_path = 104
 
 pub struct C.addrinfo {
 mut:
-	ai_family    int
-	ai_socktype  int
-	ai_flags     int
-	ai_protocol  int
-	ai_addrlen   int
+	ai_family    i32
+	ai_socktype  i32
+	ai_flags     i32
+	ai_protocol  i32
+	ai_addrlen   i32
 	ai_addr      voidptr
 	ai_canonname voidptr
 	ai_next      voidptr

--- a/vlib/net/address_dragonfly.c.v
+++ b/vlib/net/address_dragonfly.c.v
@@ -9,11 +9,11 @@ const max_unix_path = 104
 
 pub struct C.addrinfo {
 mut:
-	ai_family    int
-	ai_socktype  int
-	ai_flags     int
-	ai_protocol  int
-	ai_addrlen   int
+	ai_family    i32
+	ai_socktype  i32
+	ai_flags     i32
+	ai_protocol  i32
+	ai_addrlen   i32
 	ai_addr      voidptr
 	ai_canonname voidptr
 	ai_next      voidptr

--- a/vlib/net/address_freebsd.c.v
+++ b/vlib/net/address_freebsd.c.v
@@ -7,11 +7,11 @@ const max_unix_path = 104
 
 pub struct C.addrinfo {
 mut:
-	ai_family    int
-	ai_socktype  int
-	ai_flags     int
-	ai_protocol  int
-	ai_addrlen   int
+	ai_family    i32
+	ai_socktype  i32
+	ai_flags     i32
+	ai_protocol  i32
+	ai_addrlen   i32
 	ai_addr      voidptr
 	ai_canonname voidptr
 	ai_next      voidptr

--- a/vlib/net/address_linux.c.v
+++ b/vlib/net/address_linux.c.v
@@ -4,11 +4,11 @@ const max_unix_path = 108
 
 pub struct C.addrinfo {
 mut:
-	ai_family    int
-	ai_socktype  int
-	ai_flags     int
-	ai_protocol  int
-	ai_addrlen   int
+	ai_family    i32
+	ai_socktype  i32
+	ai_flags     i32
+	ai_protocol  i32
+	ai_addrlen   i32
 	ai_addr      voidptr
 	ai_canonname voidptr
 	ai_next      voidptr

--- a/vlib/net/address_netbsd.c.v
+++ b/vlib/net/address_netbsd.c.v
@@ -9,11 +9,11 @@ const max_unix_path = 104
 
 pub struct C.addrinfo {
 mut:
-	ai_family    int
-	ai_socktype  int
-	ai_flags     int
-	ai_protocol  int
-	ai_addrlen   int
+	ai_family    i32
+	ai_socktype  i32
+	ai_flags     i32
+	ai_protocol  i32
+	ai_addrlen   i32
 	ai_addr      voidptr
 	ai_canonname voidptr
 	ai_next      voidptr

--- a/vlib/net/address_openbsd.c.v
+++ b/vlib/net/address_openbsd.c.v
@@ -7,11 +7,11 @@ const max_unix_path = 104
 
 pub struct C.addrinfo {
 mut:
-	ai_family    int
-	ai_socktype  int
-	ai_flags     int
-	ai_protocol  int
-	ai_addrlen   int
+	ai_family    i32
+	ai_socktype  i32
+	ai_flags     i32
+	ai_protocol  i32
+	ai_addrlen   i32
 	ai_addr      voidptr
 	ai_canonname voidptr
 	ai_next      voidptr

--- a/vlib/net/address_windows.c.v
+++ b/vlib/net/address_windows.c.v
@@ -4,11 +4,11 @@ const max_unix_path = 108
 
 pub struct C.addrinfo {
 mut:
-	ai_family    int
-	ai_socktype  int
-	ai_flags     int
-	ai_protocol  int
-	ai_addrlen   int
+	ai_family    i32
+	ai_socktype  i32
+	ai_flags     i32
+	ai_protocol  i32
+	ai_addrlen   i32
 	ai_addr      voidptr
 	ai_canonname voidptr
 	ai_next      voidptr

--- a/vlib/net/common.c.v
+++ b/vlib/net/common.c.v
@@ -48,7 +48,7 @@ pub fn shutdown(handle int, config ShutdownConfig) int {
 			write_result := select_deadline(handle, .write, time.now().add(connect_timeout)) or {
 				false
 			}
-			err := 0
+			err := i32(0) // SO_ERROR is a C `int`; use i32 storage so &err is int* and sizeof is 4
 			len := sizeof(err)
 			xyz := C.getsockopt(handle, C.SOL_SOCKET, C.SO_ERROR, &err, &len)
 			if xyz == 0 && err == 0 {
@@ -86,7 +86,7 @@ pub fn close(handle int) ! {
 		if (is_windows && ecode == int(error_ewouldblock)) || (!is_windows && res == -1
 			&& ecode in [int(error_einprogress), int(error_eagain), C.EINTR]) {
 			write_result := select_deadline(handle, .write, time.now().add(connect_timeout))!
-			err := 0
+			err := i32(0) // SO_ERROR is a C `int`; use i32 storage so &err is int* and sizeof is 4
 			len := sizeof(err)
 			xyz := C.getsockopt(handle, C.SOL_SOCKET, C.SO_ERROR, &err, &len)
 			if xyz == 0 && err == 0 {

--- a/vlib/net/raw.c.v
+++ b/vlib/net/raw.c.v
@@ -220,20 +220,21 @@ pub fn (c &RawConn) protocol() Protocol {
 
 // set_option_bool sets a boolean socket option.
 pub fn (mut s RawSocket) set_option_bool(opt SocketOption, value bool) ! {
-	x := int(value)
-	socket_error(C.setsockopt(s.handle, C.SOL_SOCKET, int(opt), &x, sizeof(int)))!
+	x := i32(value) // C socket options are 4-byte `int`; i32 storage keeps sizeof 4
+	socket_error(C.setsockopt(s.handle, C.SOL_SOCKET, int(opt), &x, sizeof(x)))!
 }
 
 // set_option_int sets an integer socket option.
 pub fn (mut s RawSocket) set_option_int(opt SocketOption, value int) ! {
-	socket_error(C.setsockopt(s.handle, C.SOL_SOCKET, int(opt), &value, sizeof(int)))!
+	x := i32(value)
+	socket_error(C.setsockopt(s.handle, C.SOL_SOCKET, int(opt), &x, sizeof(x)))!
 }
 
 // set_ip_header_included enables or disables the IP_HDRINCL option.
 // When enabled, the user must provide the complete IP header.
 pub fn (mut s RawSocket) set_ip_header_included(on bool) ! {
-	x := int(on)
-	socket_error(C.setsockopt(s.handle, C.IPPROTO_IP, C.IP_HDRINCL, &x, sizeof(int)))!
+	x := i32(on) // C socket options are 4-byte `int`; i32 storage keeps sizeof 4
+	socket_error(C.setsockopt(s.handle, C.IPPROTO_IP, C.IP_HDRINCL, &x, sizeof(x)))!
 }
 
 // close shuts down and closes the socket.

--- a/vlib/net/tcp.c.v
+++ b/vlib/net/tcp.c.v
@@ -634,7 +634,8 @@ pub fn tcp_socket_from_handle_raw(sockfd int) TcpSocket {
 }
 
 fn (mut s TcpSocket) set_option(level int, opt int, value int) ! {
-	socket_error(C.setsockopt(s.handle, level, opt, &value, sizeof(int)))!
+	v := i32(value) // C socket options are 4-byte `int`; pass i32 storage (sizeof 4)
+	socket_error(C.setsockopt(s.handle, level, opt, &v, sizeof(v)))!
 }
 
 pub fn (mut s TcpSocket) set_option_bool(opt SocketOption, value bool) ! {
@@ -721,7 +722,7 @@ fn (mut s TcpSocket) connect(a Addr) ! {
 			// unsuccessfully (SO_ERROR is one of the usual error codes  listed  here,
 			// ex‐ plaining the reason for the failure).
 			write_result := select(s.handle, .write, connect_timeout)!
-			err := 0
+			err := i32(0) // SO_ERROR is a C `int`; i32 storage keeps &err int* and sizeof 4
 			len := sizeof(err)
 			xyz := C.getsockopt(s.handle, C.SOL_SOCKET, C.SO_ERROR, &err, &len)
 			if xyz == 0 && err == 0 {

--- a/vlib/net/udp.c.v
+++ b/vlib/net/udp.c.v
@@ -471,7 +471,8 @@ fn (mut s UdpSocket) set_option_raw(level int, opt int, value voidptr, value_len
 }
 
 fn (mut s UdpSocket) set_option_int(level int, opt int, value int) ! {
-	s.set_option_raw(level, opt, &value, sizeof(int))!
+	v := i32(value) // C socket options are 4-byte `int`; pass i32 storage (sizeof 4)
+	s.set_option_raw(level, opt, &v, sizeof(v))!
 }
 
 // set_option_bool sets a boolean socket option on the UDP socket.

--- a/vlib/net/unix/stream.c.v
+++ b/vlib/net/unix/stream.c.v
@@ -416,7 +416,8 @@ fn (mut s StreamSocket) select(test Select, timeout time.Duration) !bool {
 
 // set_option sets an option on the socket
 fn (mut s StreamSocket) set_option(level int, opt int, value int) ! {
-	net.socket_error(C.setsockopt(s.handle, level, opt, &value, sizeof(int)))!
+	v := i32(value) // C socket options are 4-byte `int`; pass i32 storage (sizeof 4)
+	net.socket_error(C.setsockopt(s.handle, level, opt, &v, sizeof(v)))!
 }
 
 // set_option_bool sets a boolean option on the socket
@@ -466,7 +467,7 @@ fn (mut s StreamSocket) connect(socket_path string) ! {
 				// The socket is nonblocking and the connection cannot be completed
 				// immediately. Wait till the socket is ready to write
 				write_result := s.select(.write, connect_timeout)!
-				err := 0
+				err := i32(0) // SO_ERROR is a C `int`; i32 storage keeps &err int* and sizeof 4
 				len := sizeof(err)
 				// determine whether connect() completed successfully (SO_ERROR is zero)
 				xyz := C.getsockopt(s.handle, C.SOL_SOCKET, C.SO_ERROR, &err, &len)

--- a/vlib/os/os.c.v
+++ b/vlib/os/os.c.v
@@ -810,7 +810,7 @@ pub fn executable() string {
 	}
 	$if freebsd {
 		bufsize := usize(max_path_buffer_size)
-		mib := [C.CTL_KERN, C.KERN_PROC, C.KERN_PROC_PATHNAME, -1]!
+		mib := [i32(C.CTL_KERN), C.KERN_PROC, C.KERN_PROC_PATHNAME, -1]! // C `int` mib buffer
 		unsafe { C.sysctl(&mib[0], mib.len, &result[0], &bufsize, 0, 0) }
 		res := unsafe { tos_clone(&result[0]) }
 		return res
@@ -825,7 +825,7 @@ pub fn executable() string {
 		mut pbuf := unsafe { &&u8(&result[0]) }
 		bufsize := usize(max_path_buffer_size)
 		pid := C.getpid()
-		mib := [C.CTL_KERN, C.KERN_PROC_ARGS, pid, C.KERN_PROC_ARGV]!
+		mib := [i32(C.CTL_KERN), C.KERN_PROC_ARGS, pid, C.KERN_PROC_ARGV]! // C `int` mib buffer
 		if unsafe { C.sysctl(&mib[0], mib.len, C.NULL, &bufsize, C.NULL, 0) } == 0 {
 			if bufsize > max_path_buffer_size {
 				pbuf = unsafe { &&u8(malloc(int(bufsize))) }

--- a/vlib/os/pipe.c.v
+++ b/vlib/os/pipe.c.v
@@ -2,7 +2,7 @@ module os
 
 fn C._dup(fd i32) i32
 fn C._dup2(fd1 i32, fd2 i32) i32
-fn C._pipe(fds &int, size u32, mode i32) i32
+fn C._pipe(fds &i32, size u32, mode i32) i32
 fn C.dup(fd i32) i32
 
 const fd_stdout = $if windows { 1 } $else { C.STDOUT_FILENO }
@@ -30,7 +30,10 @@ pub mut:
 
 // pipe creates a new pipe for inter-process communication
 pub fn pipe() !Pipe {
-	mut fds := [2]int{}
+	// The kernel writes two C `int` file descriptors; back them with `i32` so the
+	// storage matches the C ABI (a V `[2]int` is two 64-bit slots and would be
+	// written out of bounds now that `int` is 64-bit).
+	mut fds := [2]i32{}
 	$if windows {
 		if C._pipe(&fds[0], 0, 0) == -1 {
 			return error('Failed to create pipe')
@@ -42,8 +45,8 @@ pub fn pipe() !Pipe {
 	}
 
 	return Pipe{
-		read_fd:  fds[0]
-		write_fd: fds[1]
+		read_fd:  int(fds[0])
+		write_fd: int(fds[1])
 	}
 }
 

--- a/vlib/os/process_nix.c.v
+++ b/vlib/os/process_nix.c.v
@@ -27,7 +27,11 @@ fn (p &Process) unix_resolve_filename() !string {
 }
 
 fn (mut p Process) unix_spawn_process() int {
-	mut pipeset := [6]int{}
+	// Each `C.pipe` writes two C `int` file descriptors; back them with `i32` so the
+	// buffer matches the C ABI (a V `[6]int` is six 64-bit slots now that `int` is
+	// 64-bit, so `pipe` would write out of bounds). The fds convert back to `int`
+	// implicitly where they are stored/closed.
+	mut pipeset := [6]i32{}
 	if p.use_stdio_ctl {
 		mut dont_care := 0
 		if !p.has_stdin_path {

--- a/vlib/runtime/free_memory_impl_freebsd.c.v
+++ b/vlib/runtime/free_memory_impl_freebsd.c.v
@@ -1,6 +1,6 @@
 module runtime
 
-fn C.sysctlnametomib(name charptr, mib &int, len &usize) i32
+fn C.sysctlnametomib(name charptr, mib &i32, len &usize) i32
 
 fn free_memory_impl() !usize {
 	$if cross ? {
@@ -13,7 +13,7 @@ fn free_memory_impl() !usize {
 			if page_size == usize(-1) {
 				return error('free_memory: `C.sysconf()` return error code = ${c_errno_1}')
 			}
-			mut mib := [4]int{}
+			mut mib := [4]i32{} // C `int` mib buffer (sysctl name array)
 			mut len := usize(4)
 			retval_2 := unsafe {
 				C.sysctlnametomib(c'vm.stats.vm.v_free_count', &mib[0], &len)
@@ -22,7 +22,7 @@ fn free_memory_impl() !usize {
 			if retval_2 == -1 {
 				return error('free_memory: `C.sysctlnametomib()` return error code = ${c_errno_2}')
 			}
-			mut free_pages := int(0)
+			mut free_pages := i32(0) // sysctl writes a 4-byte C int (bufsize 4)
 			bufsize := usize(4)
 			retval_3 := unsafe {
 				C.sysctl(&mib[0], mib.len, &free_pages, &bufsize, 0, 0)

--- a/vlib/sokol/README.md
+++ b/vlib/sokol/README.md
@@ -37,21 +37,23 @@ fn sintone(periods int, frame int, num_frames int) f32 {
 	return math.sinf(f32(periods) * (2 * math.pi) * f32(frame) / f32(num_frames))
 }
 
-fn my_audio_stream_callback(buffer &f32, num_frames int, num_channels int) {
+fn my_audio_stream_callback(buffer &f32, num_frames i32, num_channels i32) {
+	frame_count := int(num_frames)
+	channel_count := int(num_channels)
 	ms := sw.elapsed().milliseconds() - sw_start_ms
 	unsafe {
 		mut soundbuffer := buffer
-		for frame := 0; frame < num_frames; frame++ {
-			for ch := 0; ch < num_channels; ch++ {
-				idx := frame * num_channels + ch
+		for frame := 0; frame < frame_count; frame++ {
+			for ch := 0; ch < channel_count; ch++ {
+				idx := frame * channel_count + ch
 				if ms < 250 {
-					soundbuffer[idx] = 0.5 * sintone(20, frame, num_frames)
+					soundbuffer[idx] = 0.5 * sintone(20, frame, frame_count)
 				} else if ms < 300 {
-					soundbuffer[idx] = 0.5 * sintone(25, frame, num_frames)
+					soundbuffer[idx] = 0.5 * sintone(25, frame, frame_count)
 				} else if ms < 1500 {
-					soundbuffer[idx] *= sintone(22, frame, num_frames)
+					soundbuffer[idx] *= sintone(22, frame, frame_count)
 				} else {
-					soundbuffer[idx] = 0.5 * sintone(25, frame, num_frames)
+					soundbuffer[idx] = 0.5 * sintone(25, frame, frame_count)
 				}
 			}
 		}

--- a/vlib/sokol/audio/audio.c.v
+++ b/vlib/sokol/audio/audio.c.v
@@ -43,15 +43,16 @@ $if openbsd {
 // zeroes, so unwritten data will result in audio silence.
 // Example body: unsafe { C.memcpy(buffer, &samples, samples.len * int(sizeof(f32))) }
 // Example body: unsafe { mut b := buffer; for i, sample in samples { b[i] = sample } }
-pub type FNStreamingCB = fn (buffer &f32, num_frames int, num_channels int)
+// Sokol declares both counts as C `int`; keep the callback ABI explicitly i32.
+pub type FNStreamingCB = fn (buffer &f32, num_frames i32, num_channels i32)
 
 // callback function for `stream_userdata_cb` to use in `C.saudio_desc` when calling [audio.setup()](#setup)
 // This function operates the same way as [[FNStreamingCB](#FNStreamingCB)] but it passes customizable `user_data` to the
 // callback. This is the method to use if your audio data is stored in a struct or array. Identify the
 // `user_data` when you call `audio.setup()` and that object will be passed to the callback as the last arg.
 // Note: Sokol's callback functions run in a separate thread.
-// Example: previously_parsed_wavfile_bytes := [f32(0),0,0,0]; mycallback := fn (buffer &f32, num_frames int, num_channels int, mut sb []f32) {}; mut soundbuffer := []f32{}; soundbuffer << previously_parsed_wavfile_bytes; audio.setup(stream_userdata_cb: mycallback, user_data: soundbuffer.data);
-pub type FnStreamingCBWithUserData = fn (buffer &f32, num_frames int, num_channels int, user_data voidptr)
+// Example: previously_parsed_wavfile_bytes := [f32(0),0,0,0]; mycallback := fn (buffer &f32, num_frames i32, num_channels i32, mut sb []f32) {}; mut soundbuffer := []f32{}; soundbuffer << previously_parsed_wavfile_bytes; audio.setup(stream_userdata_cb: mycallback, user_data: soundbuffer.data);
+pub type FnStreamingCBWithUserData = fn (buffer &f32, num_frames i32, num_channels i32, user_data voidptr)
 
 pub fn (x FNStreamingCB) str() string {
 	return '&FNStreamingCB{ ${ptr_str(x)} }'
@@ -90,11 +91,11 @@ pub mut:
 @[params; typedef]
 pub struct C.saudio_desc {
 pub:
-	sample_rate        int
-	num_channels       int
-	buffer_frames      int
-	packet_frames      int
-	num_packets        int
+	sample_rate        i32
+	num_channels       i32
+	buffer_frames      i32
+	packet_frames      i32
+	num_packets        i32
 	stream_cb          FNStreamingCB
 	stream_userdata_cb FnStreamingCBWithUserData
 pub mut:

--- a/vlib/term/termios/termios_android.c.v
+++ b/vlib/term/termios/termios_android.c.v
@@ -14,8 +14,8 @@ module termios
 
 const cclen = 32
 
-type TcFlag = int
-type Speed = int
+type TcFlag = i32
+type Speed = i32
 type Cc = u8
 
 // Termios stores the terminal options on Linux.

--- a/vlib/term/termios/termios_default.c.v
+++ b/vlib/term/termios/termios_default.c.v
@@ -4,8 +4,8 @@
 module termios
 
 // not used but needed for function declarations
-type TcFlag = int
-type Speed = int
+type TcFlag = i32
+type Speed = i32
 type Cc = u8
 
 // Termios represents platform dependent flags representing the terminal state.

--- a/vlib/term/termios/termios_dragonfly.c.v
+++ b/vlib/term/termios/termios_dragonfly.c.v
@@ -14,8 +14,8 @@ module termios
 
 const cclen = 20
 
-type TcFlag = int
-type Speed = int
+type TcFlag = i32
+type Speed = i32
 type Cc = u8
 
 // Termios stores the terminal options

--- a/vlib/term/termios/termios_freebsd.c.v
+++ b/vlib/term/termios/termios_freebsd.c.v
@@ -14,8 +14,8 @@ module termios
 
 const cclen = 20
 
-type TcFlag = int
-type Speed = int
+type TcFlag = i32
+type Speed = i32
 type Cc = u8
 
 // Termios stores the terminal options

--- a/vlib/term/termios/termios_linux.c.v
+++ b/vlib/term/termios/termios_linux.c.v
@@ -14,8 +14,8 @@ module termios
 
 const cclen = 32
 
-type TcFlag = int
-type Speed = int
+type TcFlag = i32
+type Speed = i32
 type Cc = u8
 
 // Termios stores the terminal options on Linux.

--- a/vlib/term/termios/termios_netbsd.c.v
+++ b/vlib/term/termios/termios_netbsd.c.v
@@ -14,8 +14,8 @@ module termios
 
 const cclen = 20
 
-type TcFlag = int
-type Speed = int
+type TcFlag = i32
+type Speed = i32
 type Cc = u8
 
 // Termios stores the terminal options

--- a/vlib/term/termios/termios_openbsd.c.v
+++ b/vlib/term/termios/termios_openbsd.c.v
@@ -14,8 +14,8 @@ module termios
 
 const cclen = 20
 
-type TcFlag = int
-type Speed = int
+type TcFlag = i32
+type Speed = i32
 type Cc = u8
 
 // Termios stores the terminal options

--- a/vlib/term/termios/termios_qnx.c.v
+++ b/vlib/term/termios/termios_qnx.c.v
@@ -14,8 +14,8 @@ module termios
 
 const cclen = 20
 
-type TcFlag = int
-type Speed = int
+type TcFlag = i32
+type Speed = i32
 type Cc = u8
 
 // Termios stores the terminal options

--- a/vlib/term/termios/termios_solaris.c.v
+++ b/vlib/term/termios/termios_solaris.c.v
@@ -14,8 +14,8 @@ module termios
 
 const cclen = 20
 
-type TcFlag = int
-type Speed = int
+type TcFlag = i32
+type Speed = i32
 type Cc = u8
 
 // Termios stores the terminal options

--- a/vlib/term/termios/termios_windows.c.v
+++ b/vlib/term/termios/termios_windows.c.v
@@ -8,8 +8,8 @@
 //
 module termios
 
-type TcFlag = int
-type Speed = int
+type TcFlag = i32
+type Speed = i32
 type Cc = u8
 
 // flag provides a termios flag of the correct size for the underlying C.termios structure.

--- a/vlib/term/ui/consoleapi_windows.c.v
+++ b/vlib/term/ui/consoleapi_windows.c.v
@@ -22,7 +22,7 @@ mut:
 
 @[typedef]
 pub struct C.KEY_EVENT_RECORD {
-	bKeyDown          int
+	bKeyDown          i32 // Windows BOOL == C `int` (4 bytes)
 	wRepeatCount      u16
 	wVirtualKeyCode   u16
 	wVirtualScanCode  u16
@@ -50,7 +50,7 @@ pub struct C.MENU_EVENT_RECORD {
 
 @[typedef]
 pub struct C.FOCUS_EVENT_RECORD {
-	bSetFocus int
+	bSetFocus i32 // Windows BOOL == C `int` (4 bytes)
 }
 
 @[typedef]

--- a/vlib/time/time_nix.c.v
+++ b/vlib/time/time_nix.c.v
@@ -9,15 +9,17 @@ module time
 
 pub struct C.tm {
 pub mut:
-	tm_sec    int
-	tm_min    int
-	tm_hour   int
-	tm_mday   int
-	tm_mon    int
-	tm_year   int
-	tm_wday   int
-	tm_yday   int
-	tm_isdst  int
+	tm_sec   i32
+	tm_min   i32
+	tm_hour  i32
+	tm_mday  i32
+	tm_mon   i32
+	tm_year  i32
+	tm_wday  i32
+	tm_yday  i32
+	tm_isdst i32
+	// C `long tm_gmtoff`: pointer-width, which V's `int` already matches (i64 on
+	// 64-bit, i32 on 32-bit), unlike the 32-bit C `int` fields above.
 	tm_gmtoff int
 }
 

--- a/vlib/time/time_windows.c.v
+++ b/vlib/time/time_windows.c.v
@@ -8,12 +8,12 @@ module time
 
 pub struct C.tm {
 pub mut:
-	tm_year int
-	tm_mon  int
-	tm_mday int
-	tm_hour int
-	tm_min  int
-	tm_sec  int
+	tm_year i32
+	tm_mon  i32
+	tm_mday i32
+	tm_hour i32
+	tm_min  i32
+	tm_sec  i32
 }
 
 pub struct C._FILETIME {

--- a/vlib/v/tests/c_structs/cstruct_fields_are_pub_test.c.v
+++ b/vlib/v/tests/c_structs/cstruct_fields_are_pub_test.c.v
@@ -8,14 +8,14 @@ fn test_c_struct_fields_are_pub() {
 		height:       512
 		flags:        0
 		userPtr:      unsafe { nil }
-		renderCreate: fn (uptr voidptr, width int, height int) int {
+		renderCreate: fn (uptr voidptr, width i32, height i32) i32 {
 			return 1
 		}
-		renderResize: fn (uptr voidptr, width int, height int) int {
+		renderResize: fn (uptr voidptr, width i32, height i32) i32 {
 			return 1
 		}
-		renderUpdate: fn (uptr voidptr, rect &int, data &u8) {}
-		renderDraw:   fn (uptr voidptr, verts &f32, tcoords &f32, colors &u32, nverts int) {}
+		renderUpdate: fn (uptr voidptr, rect &i32, data &u8) {}
+		renderDraw:   fn (uptr voidptr, verts &f32, tcoords &f32, colors &u32, nverts i32) {}
 		renderDelete: fn (uptr voidptr) {}
 	}
 

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -8153,6 +8153,9 @@ pub fn run(args []string) {
 		eprintln(err.msg())
 		exit(1)
 	}
+	// V's platform `int` is 64-bit on 64-bit targets and 32-bit on 32-bit ones;
+	// pin the C spelling from the target width before any checking or codegen.
+	types.set_platform_int_bits(target.pointer_bits)
 	constraint_ccompiler := if backend == 'arm64' {
 		'tinyc'
 	} else {

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -547,6 +547,11 @@ mut:
 	lazy_param_abi_merge            bool
 	usable_expr_type_memo           &UsableExprTypeMemo = unsafe { nil }
 	needed_optional_types           map[string]string
+	// cabi_int_out_args maps a C-call argument node to the C spelling to emit in its
+	// place (the address of a temporary C `int`), while a `&int` out-parameter is
+	// bridged by a temporary + copy-back around the wrapped call. Keyed by node id so
+	// nested calls never collide.
+	cabi_int_out_args               map[flat.NodeId]string
 	emitted_optional_types          map[string]bool
 	emitted_fns                     map[string]bool
 	array_method_cache              map[string]string
@@ -1171,6 +1176,7 @@ pub fn FlatGen.new() FlatGen {
 		goto_label_lock_scopes: map[string][]int{}
 		ownership_seen_return_sources: map[string]bool{}
 		needed_optional_types: map[string]string{}
+		cabi_int_out_args: map[flat.NodeId]string{}
 		emitted_optional_types: map[string]bool{}
 		emitted_fns: map[string]bool{}
 		array_method_cache: map[string]string{}

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -471,6 +471,10 @@ mut:
 	compiler_vexe_env_setup       bool = true
 	ccompiler                     string
 	target                        pref.Target
+	// C spelling for V's platform-width `int`: `i64` on 64-bit targets, `i32` on
+	// 32-bit. Used by hand-written runtime helpers that operate on `[]int`
+	// elements or `int` values directly (kept in sync with set_target).
+	int_ct                        string = 'i64'
 	thread_stack_size             int = 8 * 1024 * 1024
 	compile_values                map[string]string // explicit `-d` values used by `$d(...)` in `#flag`s
 	output_path                   string
@@ -1248,6 +1252,7 @@ pub fn (mut g FlatGen) set_compiler_vexe_env_setup(enabled bool) {
 // set_target sets the canonical code-generation target.
 pub fn (mut g FlatGen) set_target(target pref.Target) {
 	g.target = target
+	g.int_ct = if target.pointer_bits == 32 { 'i32' } else { 'i64' }
 }
 
 // set_thread_stack_size configures the stack size used by generated worker threads.
@@ -15045,8 +15050,12 @@ fn (mut g FlatGen) fixed_array_elem_c_type(elem types.Type) string {
 
 fn (mut g FlatGen) fixed_array_c_type(arr types.ArrayFixed) string {
 	// Function signatures use TypeChecker.c_type(), whose fixed-array name preserves
-	// the V spelling of pointer sizeof targets. Keep the emitted typedef identical.
-	if arr.len_expr.contains('sizeof(&') {
+	// the V spelling of `sizeof` length targets. Keep the emitted typedef identical
+	// so references resolve. This matters for pointer targets (`sizeof(&T)`) and for
+	// `sizeof(int)`: the platform `int` lowers to `i64`, so rendering the length here
+	// would name the typedef `..._sizeof_i64_` while c_type() references keep
+	// `..._sizeof_int_`, leaving the reference undefined.
+	if arr.len_expr.contains('sizeof(&') || arr.len_expr.replace(' ', '').contains('sizeof(int)') {
 		return g.tc.c_type(arr)
 	}
 	len_text := g.fixed_array_len_value(arr)
@@ -20355,7 +20364,7 @@ fn (mut g FlatGen) builtin_abi_decls() {
 	g.filelock_compat_decls()
 	g.writeln('#define array_new(elem_size, len, cap) __new_array((len), (cap), (elem_size))')
 	g.writeln('#define array_push array__push')
-	g.writeln('void array__push_many(array* a, void* val, int size);')
+	g.writeln('void array__push_many(array* a, void* val, ${g.int_ct} size);')
 	g.writeln('#define array_push_many_ptr(a, val, size) array__push_many((a), (void*)(val), (size))')
 	g.writeln('#define array_get array__get')
 	g.writeln('#define array_set(a, i, ...) array__set(&(a), (i), __VA_ARGS__)')
@@ -20382,7 +20391,7 @@ fn (mut g FlatGen) builtin_abi_decls() {
 	g.writeln('string string__clone(string a);')
 	g.writeln('void string__free(string* s);')
 	g.writeln('string string__plus(string s, string a);')
-	g.writeln('string int__str(int n);')
+	g.writeln('string int__str(${g.int_ct} n);')
 	g.writeln('string i64__str(i64 n);')
 	g.writeln('string u64__str(u64 nn);')
 	g.writeln('string f64__str(double x);')
@@ -20390,7 +20399,7 @@ fn (mut g FlatGen) builtin_abi_decls() {
 	g.writeln('u8* malloc_noscan(ptrdiff_t n);')
 	g.writeln('void* memdup(void* src, ptrdiff_t sz);')
 	g.writeln('static inline Array* v3_heap_array(Array value) { return (Array*)memdup(&value, sizeof(Array)); }')
-	for sort_spec in ['int|int', 'i8|signed char', 'i16|short', 'i64|long long', 'u8|unsigned char',
+	for sort_spec in ['int|${g.int_ct}', 'i8|signed char', 'i16|short', 'i64|long long', 'u8|unsigned char',
 		'u16|unsigned short', 'u32|unsigned', 'u64|unsigned long long', 'isize|ptrdiff_t',
 		'usize|size_t', 'f32|float', 'f64|double', 'rune|unsigned', 'char|char'] {
 		sort_type := sort_spec.all_before('|')
@@ -20435,7 +20444,7 @@ fn (mut g FlatGen) builtin_abi_decls() {
 	g.writeln('static inline string v3_f64_exp(double x, int precision, int upper) { char tmp[128]; int n = upper ? snprintf(tmp, sizeof(tmp), "%.*E", precision, x) : snprintf(tmp, sizeof(tmp), "%.*e", precision, x); if (n < 0) return v3_c_lit("", 0); if (n < (int)sizeof(tmp)) { u8* out = malloc_noscan(n + 1); memcpy(out, tmp, n + 1); return (string){.str = out, .len = n, .is_lit = 0}; } u8* out = malloc_noscan(n + 1); if (upper) snprintf((char*)out, (size_t)n + 1, "%.*E", precision, x); else snprintf((char*)out, (size_t)n + 1, "%.*e", precision, x); return (string){.str = out, .len = n, .is_lit = 0}; }')
 	g.writeln('static inline string v3_f64_general(double x, int precision, int upper) { char tmp[128]; int n = upper ? snprintf(tmp, sizeof(tmp), "%.*G", precision, x) : snprintf(tmp, sizeof(tmp), "%.*g", precision, x); if (n < 0) return v3_c_lit("", 0); if (n < (int)sizeof(tmp)) { u8* out = malloc_noscan(n + 1); memcpy(out, tmp, n + 1); return (string){.str = out, .len = n, .is_lit = 0}; } u8* out = malloc_noscan(n + 1); if (upper) snprintf((char*)out, (size_t)n + 1, "%.*G", precision, x); else snprintf((char*)out, (size_t)n + 1, "%.*g", precision, x); return (string){.str = out, .len = n, .is_lit = 0}; }')
 	g.writeln("static inline string v3_string_zpad(string s, int width) { if (s.len >= width) return s; int sign = s.len > 0 && s.str[0] == '-'; int pad = width - s.len; u8* out = malloc_noscan((ptrdiff_t)width + 1); int pos = 0; if (sign) out[pos++] = '-'; memset(out + pos, '0', (size_t)pad); pos += pad; memcpy(out + pos, s.str + sign, (size_t)(s.len - sign)); out[width] = 0; return (string){.str = out, .len = width, .is_lit = 0}; }")
-	g.writeln('static inline string v3_int_zpad(int n, int width) { return v3_string_zpad(int__str(n), width); }')
+	g.writeln('static inline string v3_int_zpad(${g.int_ct} n, int width) { return v3_string_zpad(int__str(n), width); }')
 	g.writeln('static inline string v3_i64_zpad(i64 n, int width) { return v3_string_zpad(i64__str(n), width); }')
 	g.writeln('static inline string v3_u64_zpad(u64 n, int width) { return v3_string_zpad(u64__str(n), width); }')
 	g.writeln("static inline string v3_string_rpad_zero(string s, int width) { if (s.len >= width) return s; u8* out = malloc_noscan((ptrdiff_t)width + 1); memcpy(out, s.str, (size_t)s.len); memset(out + s.len, '0', (size_t)(width - s.len)); out[width] = 0; return (string){.str = out, .len = width, .is_lit = 0}; }")
@@ -20486,9 +20495,9 @@ fn (mut g FlatGen) builtin_abi_decls() {
 	g.writeln('\t}')
 	g.writeln('\treturn string__plus(out, v3_c_lit("}", 1));')
 	g.writeln('}')
-	g.writeln('static inline int array_index_int(Array a, int val) { for (int i = 0; i < a.len; i++) if (((int*)a.data)[i] == val) return i; return -1; }')
-	g.writeln('static inline int array_last_index_int(Array a, int val) { for (int i = a.len - 1; i >= 0; i--) if (((int*)a.data)[i] == val) return i; return -1; }')
-	g.writeln('static inline bool array_contains_int(Array a, int val) { return array_index_int(a, val) >= 0; }')
+	g.writeln('static inline int array_index_int(Array a, ${g.int_ct} val) { for (int i = 0; i < a.len; i++) if (((${g.int_ct}*)a.data)[i] == val) return i; return -1; }')
+	g.writeln('static inline int array_last_index_int(Array a, ${g.int_ct} val) { for (int i = a.len - 1; i >= 0; i--) if (((${g.int_ct}*)a.data)[i] == val) return i; return -1; }')
+	g.writeln('static inline bool array_contains_int(Array a, ${g.int_ct} val) { return array_index_int(a, val) >= 0; }')
 	g.writeln('static inline int array_index_u8(Array a, u8 val) { for (int i = 0; i < a.len; i++) if (((u8*)a.data)[i] == val) return i; return -1; }')
 	g.writeln('static inline int array_last_index_u8(Array a, u8 val) { for (int i = a.len - 1; i >= 0; i--) if (((u8*)a.data)[i] == val) return i; return -1; }')
 	g.writeln('static inline bool array_contains_u8(Array a, u8 val) { return array_index_u8(a, val) >= 0; }')
@@ -20506,7 +20515,7 @@ fn (mut g FlatGen) builtin_abi_decls() {
 	g.writeln('static inline bool v3_map_map_eq(map a, map b) { if (a.len != b.len) return false; for (int i = 0; i < a.key_values.len; ++i) { if (a.key_values.deletes != 0 && a.key_values.all_deleted != 0 && a.key_values.all_deleted[i] != 0) continue; void* ak = (void*)(a.key_values.keys + i * a.key_values.key_bytes); if (!map__exists(&b, ak)) return false; void* av = (void*)(a.key_values.values + i * a.key_values.value_bytes); void* bv = map__get(&b, ak, av); if (!v3_map_value_eq(av, bv, a.value_bytes)) return false; } return true; }')
 	g.writeln('static inline bool fixed_array_contains_string(const string* a, int len, string val) { for (int i = 0; i < len; i++) if (a[i].len == val.len && memcmp(a[i].str, val.str, val.len) == 0) return true; return false; }')
 	g.writeln('static inline bool fixed_array_contains_u8(const u8* a, int len, u8 val) { for (int i = 0; i < len; i++) if (a[i] == val) return true; return false; }')
-	g.writeln('static inline bool fixed_array_contains_int(const int* a, int len, int val) { for (int i = 0; i < len; i++) if (a[i] == val) return true; return false; }')
+	g.writeln('static inline bool fixed_array_contains_int(const ${g.int_ct}* a, int len, ${g.int_ct} val) { for (int i = 0; i < len; i++) if (a[i] == val) return true; return false; }')
 	g.writeln('static inline string Array_str(Array a) { if (a.element_size == 1) { u8* buf = (u8*)malloc((size_t)a.len + 1); if (a.len > 0) memcpy(buf, a.data, (size_t)a.len); buf[a.len] = 0; return (string){buf, a.len, 0}; } return (string){(u8*)"[]", 2, 1}; }')
 	g.writeln('#ifndef max_int')
 	g.writeln('#define max_int max_i32')

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -17194,10 +17194,30 @@ const c_static_helper_symbols = {
 	'_vinit':                              true
 }
 
+// c_extern_interop_type_name returns the C spelling to use for a `C.` extern
+// declaration's parameter/return type, or none when the default naming applies.
+// V's platform `int` lowers to `i64` for V code, but a `C.` prototype must match
+// the real C ABI (which uses `int`), so the platform `int` stays C `int` here;
+// V inserts the i64<->int conversion at the call boundary. Pointers to `int`
+// follow. Explicit `i64` is unaffected (it is a differently-sized Primitive).
+fn (g &FlatGen) c_extern_interop_type_name(t types.Type) ?string {
+	if t is types.Primitive {
+		if t.size == 0 && t.props.has(.integer) && !t.props.has(.unsigned) {
+			return 'int'
+		}
+		return none
+	}
+	if t is types.Pointer {
+		base := g.c_extern_interop_type_name(t.base_type)?
+		return base + '*'
+	}
+	return none
+}
+
 fn (mut g FlatGen) c_extern_decl_line(node flat.Node, cfn string) string {
 	mut sb := strings.new_builder(96)
 	ret_type := g.parse_node_type(&node)
-	sb.write_string(g.fn_return_type_name(ret_type))
+	sb.write_string(g.c_extern_interop_type_name(ret_type) or { g.fn_return_type_name(ret_type) })
 	sb.write_string(' ')
 	call_conv := c_extern_calling_convention(cfn)
 	if call_conv.len > 0 {
@@ -17402,7 +17422,7 @@ fn (mut g FlatGen) c_extern_decl_params(node flat.Node) string {
 			continue
 		}
 		pt := g.tc.parse_type(raw_typ)
-		mut ct := g.c_extern_param_c_type(pt)
+		mut ct := g.c_extern_interop_type_name(pt) or { g.c_extern_param_c_type(pt) }
 		if ct.starts_with('fn_ptr:') {
 			ct = g.resolve_fn_ptr_type(ct)
 		}

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -5728,6 +5728,142 @@ fn (mut g FlatGen) gen_traced_call(id flat.NodeId, trace_name string) bool {
 	return true
 }
 
+// gen_c_call_int_out_wrap wraps a C call that passes the address of a V `int`
+// (`&someint`) into a fixed `&int` parameter or a C-variadic slot. A V `int` is
+// 64-bit while the C ABI expects a 32-bit `int*`, so casting the pointer would let C
+// write only the low 4 bytes and leave the high bytes stale (e.g. `sscanf("%d", &a)`
+// or `fonsGetAtlasSize(&w, &h)`). Instead it emits a statement-expression that copies
+// the value into a temporary C `int`, passes its address, and copies the
+// (sign-extended) result back after the call:
+//   ({ i64* _a = &x; int _v = (int)(*_a); C_fn(&_v); *_a = _v; })
+// It only rewrites `&<lvalue>` arguments (a bare pointer value may be null and must
+// not be dereferenced before the call). Returns false — falling through to normal
+// emission — when there is nothing to wrap, including the re-entrant emission where
+// the out-arguments are already scheduled.
+fn (mut g FlatGen) gen_c_call_int_out_wrap(id flat.NodeId, node flat.Node) bool {
+	if node.children_count == 0 {
+		return false
+	}
+	fn_node := g.a.child_node(&node, 0)
+	callee_name := g.call_target_name(g.a.child(&node, 0))
+	is_c_call := callee_name.starts_with('C.') || fn_node.value.starts_with('C.')
+	if !is_c_call {
+		return false
+	}
+	param_types := g.param_types_for(callee_name, callee_name.all_after_last('.'))
+	is_c_variadic_fn := (g.tc.c_variadic_fns[callee_name] or { false })
+		|| (g.tc.c_variadic_fns[fn_node.value] or { false })
+	is_variadic_fn := is_c_variadic_fn || (g.tc.fn_variadic[callee_name] or { false })
+		|| g.fn_decl_is_variadic(callee_name, fn_node.value)
+	is_untyped_variadic := is_variadic_fn && param_types.len > 0
+		&& variadic_array_is_native(param_types[param_types.len - 1])
+	is_native_variadic := is_c_variadic_fn || is_untyped_variadic
+	typed_param_count := if is_native_variadic && param_types.len > 0
+		&& param_types[param_types.len - 1] is types.Array {
+		param_types.len - 1
+	} else {
+		param_types.len
+	}
+	mut out_args := []flat.NodeId{}
+	for i in 1 .. node.children_count {
+		arg_id := g.a.child(&node, i)
+		if arg_id in g.cabi_int_out_args {
+			continue
+		}
+		if g.c_call_is_int_out_arg(arg_id, i - 1, param_types, typed_param_count, is_native_variadic) {
+			out_args << arg_id
+		}
+	}
+	if out_args.len == 0 {
+		return false
+	}
+	mut ret_type := g.declared_call_return_type(id)
+	if ret_type is types.Unknown {
+		ret_type = g.usable_expr_type(id)
+	}
+	if ret_type is types.Unknown {
+		return false
+	}
+	if _ := array_fixed_type(ret_type) {
+		return false
+	}
+	g.write('({ ')
+	mut copybacks := []string{}
+	for arg_id in out_args {
+		n := g.tmp_count
+		g.tmp_count++
+		addr_tmp := '_cabi_out_addr_${n}'
+		val_tmp := '_cabi_out_val_${n}'
+		ptr_ct := g.value_c_type(g.usable_expr_type(arg_id))
+		arg_node := g.a.nodes[int(arg_id)]
+		// The address of a variable (`&x`) is provably non-null, so no guard is
+		// needed. A forwarded pointer value (e.g. a `mut x int` param passed on to C)
+		// may be null; keep the null through to the callee and skip the copy-back so
+		// its semantics are unchanged.
+		non_null := arg_node.kind == .prefix && arg_node.op == .amp
+		g.write('${ptr_ct} ${addr_tmp} = ')
+		g.gen_expr(arg_id)
+		if non_null {
+			g.write('; int ${val_tmp} = (int)(*${addr_tmp}); ')
+			g.cabi_int_out_args[arg_id] = '&${val_tmp}'
+			copybacks << '*${addr_tmp} = ${val_tmp};'
+		} else {
+			g.write('; int ${val_tmp} = ${addr_tmp} ? (int)(*${addr_tmp}) : 0; ')
+			g.cabi_int_out_args[arg_id] = '(${addr_tmp} ? &${val_tmp} : (int*)0)'
+			copybacks << 'if (${addr_tmp}) { *${addr_tmp} = ${val_tmp}; }'
+		}
+	}
+	if ret_type is types.Void {
+		g.gen_call(id, node)
+		g.write('; ')
+		for cb in copybacks {
+			g.write('${cb} ')
+		}
+	} else {
+		rt := g.tmp_count
+		g.tmp_count++
+		ret_ct := g.value_c_type(ret_type)
+		g.write('${ret_ct} _cabi_out_ret_${rt} = ')
+		g.gen_call(id, node)
+		g.write('; ')
+		for cb in copybacks {
+			g.write('${cb} ')
+		}
+		g.write('_cabi_out_ret_${rt}; ')
+	}
+	g.write('})')
+	for arg_id in out_args {
+		g.cabi_int_out_args.delete(arg_id)
+	}
+	return true
+}
+
+// c_call_is_int_out_arg reports whether the `&int`-typed argument `arg_id` targets a
+// C `int` out-parameter: a fixed `&int` parameter, or (for a C-variadic function) a
+// variadic-tail `&int` address such as scanf's `&a`. It matches both `&x` and a
+// forwarded pointer value (e.g. a `mut x int` parameter passed on to C); the wrap
+// guards possibly-null pointer values.
+fn (mut g FlatGen) c_call_is_int_out_arg(arg_id flat.NodeId, arg_idx int, param_types []types.Type, typed_param_count int, is_native_variadic bool) bool {
+	if !c_type_is_pointer_to_platform_int(cgen_unalias_type(g.usable_expr_type(arg_id))) {
+		return false
+	}
+	if arg_idx < typed_param_count {
+		return arg_idx < param_types.len
+			&& c_type_is_pointer_to_platform_int(cgen_unalias_type(param_types[arg_idx]))
+	}
+	return is_native_variadic
+}
+
+fn c_type_is_pointer_to_platform_int(t types.Type) bool {
+	if t is types.Pointer {
+		base := cgen_unalias_type(t.base_type)
+		if base is types.Primitive {
+			return base.size == 0 && base.props.has(.integer) && !base.props.has(.unsigned)
+		}
+	}
+	return false
+}
+
 // gen_call emits call output for c.
 @[direct_array_access]
 fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
@@ -5747,6 +5883,9 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 		if g.gen_traced_call(id, trace_name) {
 			return
 		}
+	}
+	if g.gen_c_call_int_out_wrap(id, node) {
+		return
 	}
 	if fn_node.kind == .ident && fn_name == 'v3_heap_array' && node.children_count == 2 {
 		arg_id := g.a.child(&node, 1)
@@ -12555,6 +12694,25 @@ fn (mut g FlatGen) gen_callback_fn_value_for_expected_c_abi(arg_id flat.NodeId, 
 	return true
 }
 
+// c_call_callback_abi_thunk returns the name of an ABI-adapter thunk for a V
+// function passed directly as a C callback argument, when the callback's C ABI
+// differs from the V function's emitted ABI (e.g. C `int` params vs V i64), or none
+// when no adapter is needed (widths already match) or the argument is not a directly
+// resolvable V function (a forwarded/dynamic fn-pointer value falls through to the
+// plain C-ABI cast).
+fn (mut g FlatGen) c_call_callback_abi_thunk(arg_id flat.NodeId, expected_fn types.FnType) ?string {
+	expected := types.Type(expected_fn)
+	actual_name := g.callback_fn_value_name(arg_id, expected) or {
+		g.direct_callback_ident_name(arg_id) or { return none }
+	}
+	if actual_name.len == 0 {
+		return none
+	}
+	actual_fn := g.callback_fn_value_type(actual_name) or { return none }
+	encoded := g.c_extern_fn_ptr_encoded(expected_fn)
+	return g.ensure_callback_userdata_wrapper(actual_name, actual_fn, expected_fn, encoded)
+}
+
 fn (mut g FlatGen) gen_callback_fn_value_for_field_c_abi(arg_id flat.NodeId, expected types.Type, expected_c_abi string) bool {
 	if expected_c_abi.len == 0 {
 		return false
@@ -12805,6 +12963,15 @@ fn (mut g FlatGen) ensure_callback_userdata_wrapper(actual_name string, actual t
 			needs_wrapper = true
 			continue
 		}
+		if callback_can_cast_scalar_int_param(actual_ct, expected_ct) {
+			// The C caller passes this argument in the C-ABI width (e.g. a 32-bit
+			// `int`) while the V function was generated with V's width (i64). Receive
+			// the C-ABI value and convert it before forwarding, so a callback invoked
+			// by C with `-1` reaches the V body as -1 (not 0xffffffff).
+			call_args << '(${actual_ct})arg${i}'
+			needs_wrapper = true
+			continue
+		}
 		return none
 	}
 	if !needs_wrapper {
@@ -12885,6 +13052,20 @@ fn callback_mut_pointer_slot_value_c_type(actual_ct string, expected_ct string) 
 		return none
 	}
 	return value_ct
+}
+
+// callback_can_cast_scalar_int_param reports whether a callback parameter can bridge
+// the C ABI to the V ABI with a scalar integer cast. This handles V's platform `int`
+// (emitted as i64) received through a C callback slot declared with C `int` (or the
+// reverse). Only reached after the checker has accepted the two function types as
+// compatible, so both spellings originate from the same V parameter type.
+fn callback_can_cast_scalar_int_param(actual_ct string, expected_ct string) bool {
+	return callback_is_scalar_int_c_type(actual_ct) && callback_is_scalar_int_c_type(expected_ct)
+}
+
+fn callback_is_scalar_int_c_type(ct string) bool {
+	return trimmed_space(ct) in ['int', 'i8', 'i16', 'i32', 'i64', 'u8', 'u16', 'u32', 'u64',
+		'char', 'bool', 'isize', 'usize', 'ptrdiff_t', 'size_t']
 }
 
 fn (mut g FlatGen) callback_c_type(typ types.Type) string {
@@ -14894,10 +15075,31 @@ fn (mut g FlatGen) gen_call_args(fn_name string, node flat.Node, start int) {
 		} else {
 			types.Type(types.void_)
 		}
+		if is_c_call {
+			// A `&int` out-argument has been rewritten to the address of a temporary C
+			// `int` by gen_c_call_int_out_wrap; emit that in the argument's place.
+			if sub := g.cabi_int_out_args[arg_id] {
+				g.write(sub)
+				continue
+			}
+		}
 		if is_c_call && g.gen_special_c_callback_arg(fn_name, arg_idx, arg_id, cb_param) {
 			continue
 		}
 		if is_c_call {
+			// A V function passed as a C callback whose C-ABI parameter/return widths
+			// differ from V's (notably C `int` vs V's i64 for platform `int`) needs an
+			// ABI thunk, not a bare function-pointer cast: casting the pointer does not
+			// convert the arguments the C library passes. Emit the adapter when one is
+			// required; otherwise fall through to the plain C-ABI cast below.
+			if arg_idx >= 0 && arg_idx < typed_param_count {
+				if cb_fn := fn_type_from(param_types[arg_idx]) {
+					if thunk := g.c_call_callback_abi_thunk(arg_id, cb_fn) {
+						g.write(thunk)
+						continue
+					}
+				}
+			}
 			if g.gen_c_va_list_macro_arg_direct(arg_idx, arg_id, fn_name, callee_name, '', '') {
 				continue
 			}
@@ -17261,20 +17463,28 @@ fn (mut g FlatGen) c_extern_interop_type_name(t types.Type) ?string {
 // fn_ptr_type_key's encoding so the C-ABI variant is a distinct typedef from the
 // ordinary (i64) one.
 fn (mut g FlatGen) c_extern_fn_ptr_type_name(t types.FnType) string {
+	return g.resolve_fn_ptr_type(g.c_extern_fn_ptr_encoded(t))
+}
+
+// c_extern_fn_ptr_encoded builds the `fn_ptr:ret|params` key for a function-pointer
+// type as it appears in a C ABI signature, with platform `int` kept as C `int`
+// throughout. This is the C-ABI counterpart of fn_ptr_type_key (which lowers `int`
+// to i64), and doubles as the `expected_c_abi` string for callback-thunk generation.
+fn (mut g FlatGen) c_extern_fn_ptr_encoded(t types.FnType) string {
 	ret := if t.return_type is types.Void {
 		'void'
 	} else {
 		g.c_extern_interop_type_name(t.return_type) or { g.tc.c_type(t.return_type) }
 	}
 	if t.params.len == 0 {
-		return g.resolve_fn_ptr_type('fn_ptr:${ret}|void')
+		return 'fn_ptr:${ret}|void'
 	}
 	mut params := []string{}
 	for i in 0 .. t.params.len {
 		pt := fn_type_effective_param(t, i)
 		params << (g.c_extern_interop_type_name(pt) or { g.tc.c_type(pt) })
 	}
-	return g.resolve_fn_ptr_type('fn_ptr:${ret}|${params.join(', ')}')
+	return 'fn_ptr:${ret}|${params.join(', ')}'
 }
 
 // c_call_arg_cabi_cast returns the C spelling to cast a C-call argument to so it

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -5795,23 +5795,14 @@ fn (mut g FlatGen) gen_c_call_int_out_wrap(id flat.NodeId, node flat.Node) bool 
 		addr_tmp := '_cabi_out_addr_${n}'
 		val_tmp := '_cabi_out_val_${n}'
 		ptr_ct := g.value_c_type(g.usable_expr_type(arg_id))
-		arg_node := g.a.nodes[int(arg_id)]
-		// The address of a variable (`&x`) is provably non-null, so no guard is
-		// needed. A forwarded pointer value (e.g. a `mut x int` param passed on to C)
-		// may be null; keep the null through to the callee and skip the copy-back so
-		// its semantics are unchanged.
-		non_null := arg_node.kind == .prefix && arg_node.op == .amp
+		// Only `&<scalar lvalue>` reaches here (see c_call_is_int_out_arg), so the
+		// address is a single, non-null `int` slot: copy it into a C `int`, pass its
+		// address, and copy the sign-extended result back.
 		g.write('${ptr_ct} ${addr_tmp} = ')
 		g.gen_expr(arg_id)
-		if non_null {
-			g.write('; int ${val_tmp} = (int)(*${addr_tmp}); ')
-			g.cabi_int_out_args[arg_id] = '&${val_tmp}'
-			copybacks << '*${addr_tmp} = ${val_tmp};'
-		} else {
-			g.write('; int ${val_tmp} = ${addr_tmp} ? (int)(*${addr_tmp}) : 0; ')
-			g.cabi_int_out_args[arg_id] = '(${addr_tmp} ? &${val_tmp} : (int*)0)'
-			copybacks << 'if (${addr_tmp}) { *${addr_tmp} = ${val_tmp}; }'
-		}
+		g.write('; int ${val_tmp} = (int)(*${addr_tmp}); ')
+		g.cabi_int_out_args[arg_id] = '&${val_tmp}'
+		copybacks << '*${addr_tmp} = ${val_tmp};'
 	}
 	if ret_type is types.Void {
 		g.gen_call(id, node)
@@ -5838,12 +5829,20 @@ fn (mut g FlatGen) gen_c_call_int_out_wrap(id flat.NodeId, node flat.Node) bool 
 	return true
 }
 
-// c_call_is_int_out_arg reports whether the `&int`-typed argument `arg_id` targets a
-// C `int` out-parameter: a fixed `&int` parameter, or (for a C-variadic function) a
-// variadic-tail `&int` address such as scanf's `&a`. It matches both `&x` and a
-// forwarded pointer value (e.g. a `mut x int` parameter passed on to C); the wrap
-// guards possibly-null pointer values.
+// c_call_is_int_out_arg reports whether argument `arg_id` is the address of a single
+// scalar `int` lvalue targeting a C `int` out-parameter (a fixed `&int` parameter, or
+// a C-variadic-tail address such as scanf's `&a`). Only `&x` / `&s.field` qualify:
+// `&arr[i]`, an `[]int`.data pointer, or a forwarded pointer value may point into a
+// multi-element C `int` buffer that a single temporary cannot represent — those must
+// use ABI-correct `i32`/`u32` storage (a V `[N]int` no longer matches C `int[N]`).
 fn (mut g FlatGen) c_call_is_int_out_arg(arg_id flat.NodeId, arg_idx int, param_types []types.Type, typed_param_count int, is_native_variadic bool) bool {
+	arg_node := g.a.nodes[int(arg_id)]
+	if arg_node.kind != .prefix || arg_node.op != .amp || arg_node.children_count == 0 {
+		return false
+	}
+	if g.a.child_node(&arg_node, 0).kind == .index {
+		return false
+	}
 	if !c_type_is_pointer_to_platform_int(cgen_unalias_type(g.usable_expr_type(arg_id))) {
 		return false
 	}

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -7330,6 +7330,18 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 							g.known_expr_type_id = int(arg_id)
 							g.known_expr_type = arg_type
 							g.gen_expr_with_expected_type(arg_id, param_types[arg_idx])
+						} else if is_c_call && !needs_addr {
+							// Lower the argument to the C ABI: platform `int` stays C `int`
+							// (value and callback-pointer args), matching the extern signature.
+							if cabi := g.c_call_arg_cabi_cast(arg_idx, typed_param_count,
+								param_types, arg_id, is_native_variadic_fn)
+							{
+								g.write('(${cabi})(')
+								g.gen_expr(arg_id)
+								g.write(')')
+							} else {
+								g.gen_expr(arg_id)
+							}
 						} else {
 							g.gen_expr(arg_id)
 						}
@@ -14913,6 +14925,15 @@ fn (mut g FlatGen) gen_call_args(fn_name string, node flat.Node, start int) {
 				&& g.voidptr_value_arg_needs_address(arg_id, arg_node, g.usable_expr_type(arg_id), param_types[arg_idx], true) {
 				g.write('&')
 				g.gen_expr(arg_id)
+			} else if cabi := g.c_call_arg_cabi_cast(arg_idx, typed_param_count, param_types,
+				arg_id, is_native_variadic_fn)
+			{
+				// Lower the argument to the C ABI: platform `int` stays C `int` (value
+				// and callback-pointer args, plus `%d`-style value varargs), matching the
+				// extern signature.
+				g.write('(${cabi})(')
+				g.gen_expr(arg_id)
+				g.write(')')
 			} else {
 				g.gen_expr(arg_id)
 			}
@@ -16649,7 +16670,12 @@ fn (mut g FlatGen) preseed_c_extern_fn_ptr_types_with_filter(referenced map[stri
 			continue
 		}
 		ret_type := g.parse_node_type(&node)
-		g.preseed_fn_ptr_type(ret_type)
+		// Register the C-ABI fn-pointer variants (int kept as C int) that the extern
+		// declaration will reference, so parallel workers see the same typedefs; fall
+		// back to the ordinary preseed for non-interop types.
+		if _ := g.c_extern_interop_type_name(ret_type) {} else {
+			g.preseed_fn_ptr_type(ret_type)
+		}
 		for j in 0 .. node.children_count {
 			param_id := g.a.child(&node, j)
 			p := g.a.node(param_id)
@@ -16660,7 +16686,10 @@ fn (mut g FlatGen) preseed_c_extern_fn_ptr_types_with_filter(referenced map[stri
 			if raw_typ.len == 0 || raw_typ.starts_with('...') {
 				continue
 			}
-			g.preseed_fn_ptr_type(g.tc.parse_type(raw_typ))
+			pt := g.tc.parse_type(raw_typ)
+			if _ := g.c_extern_interop_type_name(pt) {} else {
+				g.preseed_fn_ptr_type(pt)
+			}
 		}
 	}
 }
@@ -17198,9 +17227,13 @@ const c_static_helper_symbols = {
 // declaration's parameter/return type, or none when the default naming applies.
 // V's platform `int` lowers to `i64` for V code, but a `C.` prototype must match
 // the real C ABI (which uses `int`), so the platform `int` stays C `int` here;
-// V inserts the i64<->int conversion at the call boundary. Pointers to `int`
-// follow. Explicit `i64` is unaffected (it is a differently-sized Primitive).
-fn (g &FlatGen) c_extern_interop_type_name(t types.Type) ?string {
+// V inserts the i64<->int conversion at the call boundary. Explicit `i64` is
+// unaffected (it is a differently-sized Primitive). The lowering recurses so
+// `int` stays C `int` anywhere inside a C ABI signature: through pointers,
+// aliases, and function-pointer parameters/returns (e.g. a C callback
+// `fn (voidptr, int, int)` keeps its `int` arguments, since C invokes it with
+// 32-bit ints).
+fn (mut g FlatGen) c_extern_interop_type_name(t types.Type) ?string {
 	if t is types.Primitive {
 		if t.size == 0 && t.props.has(.integer) && !t.props.has(.unsigned) {
 			return 'int'
@@ -17210,6 +17243,74 @@ fn (g &FlatGen) c_extern_interop_type_name(t types.Type) ?string {
 	if t is types.Pointer {
 		base := g.c_extern_interop_type_name(t.base_type)?
 		return base + '*'
+	}
+	if t is types.Alias {
+		// A `type Cb = fn (int)` alias over a function type must still keep C `int`
+		// inside the C ABI; alias-over-`int` likewise. Non-interop bases return none.
+		return g.c_extern_interop_type_name(t.base_type)
+	}
+	if t is types.FnType {
+		return g.c_extern_fn_ptr_type_name(t)
+	}
+	return none
+}
+
+// c_extern_fn_ptr_type_name registers and returns the typedef name for a
+// function-pointer type appearing in a C ABI signature, with the platform `int`
+// kept as C `int` throughout its return and parameter types. It mirrors
+// fn_ptr_type_key's encoding so the C-ABI variant is a distinct typedef from the
+// ordinary (i64) one.
+fn (mut g FlatGen) c_extern_fn_ptr_type_name(t types.FnType) string {
+	ret := if t.return_type is types.Void {
+		'void'
+	} else {
+		g.c_extern_interop_type_name(t.return_type) or { g.tc.c_type(t.return_type) }
+	}
+	if t.params.len == 0 {
+		return g.resolve_fn_ptr_type('fn_ptr:${ret}|void')
+	}
+	mut params := []string{}
+	for i in 0 .. t.params.len {
+		pt := fn_type_effective_param(t, i)
+		params << (g.c_extern_interop_type_name(pt) or { g.tc.c_type(pt) })
+	}
+	return g.resolve_fn_ptr_type('fn_ptr:${ret}|${params.join(', ')}')
+}
+
+// c_call_arg_cabi_cast returns the C spelling to cast a C-call argument to so it
+// matches the C ABI, or none when no cast is needed. For a fixed parameter it is
+// the parameter's C-ABI type (platform `int` -> C `int`, callback fn-pointers kept
+// C-`int`); this both keeps value `int`s ABI-correct and lets an `int`-typed V
+// function value pass to a C-`int` callback pointer. For a variadic-tail argument
+// it casts only a plain platform-`int` *value* to C `int` (so it occupies an
+// `int` slot for `%d`); `&int` out-arguments still need a temporary/copy-back and
+// are left untouched here.
+fn (mut g FlatGen) c_call_arg_cabi_cast(arg_idx int, typed_param_count int, param_types []types.Type, arg_id flat.NodeId, is_variadic bool) ?string {
+	if arg_idx >= 0 && arg_idx < typed_param_count {
+		ct := g.c_extern_interop_type_name(param_types[arg_idx])?
+		// A scalar `int` parameter needs no cast: C converts the i64 argument to the
+		// declared `int` automatically. Pointer and callback (fn-pointer) parameters
+		// do need the explicit cast to avoid an incompatible-pointer/-function-pointer
+		// error, since C does not implicitly convert those.
+		if ct == 'int' {
+			return none
+		}
+		return ct
+	}
+	if is_variadic {
+		// A variadic argument has no declared type, so an i64 value would occupy a
+		// `long long` slot while `%d` reads an `int`; cast platform-`int` *values* to
+		// C `int`. Literals are already `int`, and `&int` out-arguments need a
+		// temporary/copy-back (not a cast), so both are left untouched.
+		arg_node := g.a.nodes[int(arg_id)]
+		if arg_node.kind == .int_literal {
+			return none
+		}
+		at := cgen_unalias_type(g.tc.resolve_type(arg_id))
+		if at is types.Primitive && at.size == 0 && at.props.has(.integer)
+			&& !at.props.has(.unsigned) {
+			return 'int'
+		}
 	}
 	return none
 }

--- a/vlib/v3/gen/c/interface.v
+++ b/vlib/v3/gen/c/interface.v
@@ -1682,7 +1682,7 @@ fn (mut g FlatGen) interface_method_forward_decls() {
 				continue
 			}
 			if cn == 'IError' {
-				ret_ct := if method == 'code' { 'int' } else { 'string' }
+				ret_ct := if method == 'code' { g.int_ct } else { 'string' }
 				g.writeln('${ret_ct} ${cn}__${method}(${cn}* i);')
 				if g.cache_split {
 					g.ierror_dispatch_target_forward_decls(iface_name, method, ret_ct)
@@ -1799,7 +1799,7 @@ fn (g &FlatGen) open_interface_dispatch_needs_specialization(iface_name string, 
 
 fn (mut g FlatGen) interface_dispatch_signature(iface_name string, cn string, method string) string {
 	if cn == 'IError' {
-		ret_ct := if method == 'code' { 'int' } else { 'string' }
+		ret_ct := if method == 'code' { g.int_ct } else { 'string' }
 		return '${ret_ct} ${cn}__${method}(${cn}* i)'
 	}
 	mname := '${iface_name}.${method}'
@@ -1873,7 +1873,7 @@ fn (mut g FlatGen) gen_interface_dispatch_with_fallback(iface_name string, cn st
 	decl_key := g.interface_method_signature_key(iface_name, method) or { mname }
 	impls := g.iface_impls[iface_name] or { []string{} }
 	if cn == 'IError' {
-		ret_ct := if method == 'code' { 'int' } else { 'string' }
+		ret_ct := if method == 'code' { g.int_ct } else { 'string' }
 		g.writeln('${ret_ct} ${cn}__${method}(${cn}* i) {')
 		for concrete in impls {
 			id := g.iface_type_id(iface_name, concrete)

--- a/vlib/v3/gen/c/stmt_test.v
+++ b/vlib/v3/gen/c/stmt_test.v
@@ -286,8 +286,8 @@ fn test_mut_parameter_power_assign_uses_scalar_result_type() {
 		children_count: 2
 	})
 	compact := g.sb.str().replace('\t', '').replace(' ', '').replace('\n', '')
-	assert compact.contains('*arg=((int)__v_pow_i64('), compact
-	assert !compact.contains('(int*)__v_pow_i64('), compact
+	assert compact.contains('*arg=((i64)__v_pow_i64('), compact
+	assert !compact.contains('(i64*)__v_pow_i64('), compact
 	tc.pop_scope()
 }
 
@@ -545,7 +545,7 @@ fn test_heap_local_address_expr_copies_pointer_local_slot() {
 		assert false, 'expected the address of a pointer local to escape through a heap copy'
 		return
 	}
-	assert heap_expr == '(int**)memdup(&p, sizeof(int*))'
+	assert heap_expr == '(i64**)memdup(&p, sizeof(i64*))'
 	tc.pop_scope()
 }
 
@@ -580,7 +580,7 @@ fn test_heap_local_address_expr_copies_selector_from_stack_alias() {
 		assert false, 'expected a selected field in stack-aliased storage to escape through a heap copy'
 		return
 	}
-	assert heap_expr == '(int*)memdup(&p->x, sizeof(int))'
+	assert heap_expr == '(i64*)memdup(&p->x, sizeof(i64))'
 	g.declare_local_pointer_alias_source_kind(p_owner, 'arg', true)
 	mut_param_expr := g.heap_local_address_expr(amp_selector_id, int_ptr) or {
 		assert false, 'expected a selected field backed by a mut parameter to keep its address'

--- a/vlib/v3/gen/c/types.v
+++ b/vlib/v3/gen/c/types.v
@@ -968,10 +968,31 @@ fn (mut g FlatGen) emit_optional_typedef(opt_name string, val_type string) bool 
 		g.emitted_optional_types[opt_name] = true
 		return false
 	}
+	// A `?fn (...)` payload names a `_fn_ptr_<hash>` typedef. That typedef may only
+	// have been registered (name reserved) without being emitted — e.g. discovered
+	// via an unused declaration whose param resolves to a different C spelling than a
+	// resolved use (`fn (int)` keyed as `fn_ptr:void|int` vs the emitted
+	// `fn_ptr:void|i64` once `int` widens to i64). Emit the referenced fn-ptr typedef
+	// now so this wrapper never references an undefined type.
+	if bare_val_type.starts_with('_fn_ptr_') {
+		g.ensure_fn_ptr_typedef_by_name(bare_val_type)
+	}
 	err_field := if g.has_ierror_interface() { 'IError err; ' } else { '' }
 	g.writeln('typedef struct ${opt_name} { bool ok; ${err_field}${val_type} value; } ${opt_name};')
 	g.emitted_optional_types[opt_name] = true
 	return true
+}
+
+// ensure_fn_ptr_typedef_by_name emits the `_fn_ptr_<hash>` typedef registered under
+// `name` when it has not been emitted yet. Used when an emitted type references a
+// fn-ptr typedef that was only registered (name reserved) but never resolved/used.
+fn (mut g FlatGen) ensure_fn_ptr_typedef_by_name(name string) {
+	for encoded, registered_name in g.fn_ptr_types {
+		if registered_name == name {
+			g.emit_fn_ptr_typedef(encoded, name, mut g.emitted_fn_ptr_typedefs)
+			return
+		}
+	}
 }
 
 // enum_decls supports enum decls handling for FlatGen.

--- a/vlib/v3/gen/fastc/array.v
+++ b/vlib/v3/gen/fastc/array.v
@@ -340,7 +340,7 @@ fn (g &Parser) render_membership_candidate(tokens []FastcExpressionToken, expect
 			close := fastc_matching_rpar(tokens, 1) or { return none }
 			if close == tokens.len - 1 {
 				inner := g.render_membership_candidate(tokens[2..close], '') or { return none }
-				return '((${cast_type})(${inner}))'
+				return '((${fastc_output_c_type(cast_type)})(${inner}))'
 			}
 		}
 	}

--- a/vlib/v3/gen/fastc/decl.v
+++ b/vlib/v3/gen/fastc/decl.v
@@ -1808,7 +1808,7 @@ fn fastc_emit_struct_declaration(mut scan scanner.Scanner, is_union bool, source
 				{
 					out.writeln('\t${declaration};')
 				} else {
-					out.writeln('\t${emitted_field_type} ${c_field_name};')
+					out.writeln('\t${fastc_output_c_type(emitted_field_type)} ${c_field_name};')
 				}
 			}
 			fields_by_name[field_name] = emitted_field_type

--- a/vlib/v3/gen/fastc/expr.v
+++ b/vlib/v3/gen/fastc/expr.v
@@ -909,7 +909,7 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 			outer_cast := assignment_prefix == '' && scoped_operand_prefix == '' && !scoped_or_operand && option_tokens.len != expression_tokens.len
 			if expression_tokens.len >= 2 && expression_tokens[0].tok == .name && expression_tokens[1].tok == .lpar {
 				value_type = fastc_primitive_c_type(expression_tokens[0].lit) or { value_type }
-				cast_prefix := '((${value_type})('
+				cast_prefix := '((${fastc_output_c_type(value_type)})('
 				if option_expression.starts_with(cast_prefix) {
 					option_expression = option_expression[cast_prefix.len..]
 				}
@@ -975,7 +975,7 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 					'*((${complex_payload_type} *)${temporary}.data)'
 				}
 				complex_success := if cast_type != '' && complex_payload_type != cast_type {
-					'((${cast_type})(${complex_unwrapped}))'
+					'((${fastc_output_c_type(cast_type)})(${complex_unwrapped}))'
 				} else {
 					complex_unwrapped
 				}
@@ -1145,7 +1145,7 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 				'*((${payload_type} *)${temporary}.data)'
 			}
 			mut success_value := if outer_cast && payload_type != value_type {
-				'((${value_type})(${unwrapped_value}))'
+				'((${fastc_output_c_type(value_type)})(${unwrapped_value}))'
 			} else {
 				unwrapped_value
 			}
@@ -1422,7 +1422,7 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 					previous_lit
 				}
 				result.go_back(previous_lit.len + c_pointer_count)
-				piece = '((${c_cast_type}${'*'.repeat(c_pointer_count)})('
+				piece = '((${fastc_output_c_type(c_cast_type)}${'*'.repeat(c_pointer_count)})('
 				cast_depths << paren_depth + 1
 				if c_pointer_count > 0 {
 					pointer_cast_depths << paren_depth + 1
@@ -1446,7 +1446,7 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 				if !name_is_member {
 					rendered_previous := g.resolved_expression_name(previous_lit, .unknown)
 					result.go_back(rendered_previous.len + pointer_prefix_len)
-					piece = '((${cast_type}${pointer_suffix})('
+					piece = '((${fastc_output_c_type(cast_type)}${pointer_suffix})('
 					cast_depths << paren_depth + 1
 					if pointer_cast {
 						pointer_cast_depths << paren_depth + 1

--- a/vlib/v3/gen/fastc/fastc.v
+++ b/vlib/v3/gen/fastc/fastc.v
@@ -1,17 +1,9 @@
-@[has_globals]
 module fastc
 
 import strings
 import v3.pref
 import v3.scanner
 import v3.token
-
-// fastc_platform_int_c_type is the C spelling FastC emits for V's platform-width
-// `int`: `i64` on 64-bit targets, `i32` on 32-bit ones. It mirrors the main C
-// backend's `types.platform_int_c_type`; FastC keeps its own copy so it stays
-// free of a `v3.types` dependency. `generate_source_files` pins it from the
-// target width before any file is emitted.
-__global fastc_platform_int_c_type = 'i64'
 
 // FastC parses scanner tokens and emits C immediately. It deliberately has no
 // AST, semantic-checker, transformer, mark-used, or conventional cgen path.
@@ -1167,9 +1159,6 @@ fn fastc_generate_single_file(ctx &FastcFileGenContext, source_file FastcSourceF
 }
 
 fn generate_source_files(input_sources []FastcSourceFile, module_aliases map[string]string, prefs &pref.Preferences) !(string, bool, []string) {
-	// V's platform `int` is 64-bit on 64-bit targets and 32-bit on 32-bit ones;
-	// pin the C spelling from the target width before emitting any C.
-	fastc_platform_int_c_type = if prefs.target.pointer_bits == 32 { 'i32' } else { 'i64' }
 	// Source-level generic monomorphization runs first; it is a no-op when the
 	// program has no generic function definitions (so the self-host is untouched).
 	sources := fastc_monomorphize_sources(input_sources, prefs)!

--- a/vlib/v3/gen/fastc/fastc.v
+++ b/vlib/v3/gen/fastc/fastc.v
@@ -1,9 +1,17 @@
+@[has_globals]
 module fastc
 
 import strings
 import v3.pref
 import v3.scanner
 import v3.token
+
+// fastc_platform_int_c_type is the C spelling FastC emits for V's platform-width
+// `int`: `i64` on 64-bit targets, `i32` on 32-bit ones. It mirrors the main C
+// backend's `types.platform_int_c_type`; FastC keeps its own copy so it stays
+// free of a `v3.types` dependency. `generate_source_files` pins it from the
+// target width before any file is emitted.
+__global fastc_platform_int_c_type = 'i64'
 
 // FastC parses scanner tokens and emits C immediately. It deliberately has no
 // AST, semantic-checker, transformer, mark-used, or conventional cgen path.
@@ -1159,6 +1167,9 @@ fn fastc_generate_single_file(ctx &FastcFileGenContext, source_file FastcSourceF
 }
 
 fn generate_source_files(input_sources []FastcSourceFile, module_aliases map[string]string, prefs &pref.Preferences) !(string, bool, []string) {
+	// V's platform `int` is 64-bit on 64-bit targets and 32-bit on 32-bit ones;
+	// pin the C spelling from the target width before emitting any C.
+	fastc_platform_int_c_type = if prefs.target.pointer_bits == 32 { 'i32' } else { 'i64' }
 	// Source-level generic monomorphization runs first; it is a no-op when the
 	// program has no generic function definitions (so the self-host is untouched).
 	sources := fastc_monomorphize_sources(input_sources, prefs)!

--- a/vlib/v3/gen/fastc/fastc_test.v
+++ b/vlib/v3/gen/fastc/fastc_test.v
@@ -146,8 +146,8 @@ fn main() {
 }
 ', 'shared_keyword_local.v', prefs) or { panic(err) }
 	assert c_source.contains('shared.value=1;'), c_source
-	assert c_source.contains('int id(int shared);'), c_source
-	assert c_source.contains('int id(int shared) {'), c_source
+	assert c_source.contains('i64 id(i64 shared);'), c_source
+	assert c_source.contains('i64 id(i64 shared) {'), c_source
 	assert c_source.contains('println(shared.value)'), c_source
 	assert c_source.contains('consume(&(shared));'), c_source
 	assert c_source.contains('consume(&((shared)));'), c_source
@@ -157,7 +157,7 @@ fn main() {
 	assert c_source.contains('consume(&(type));'), c_source
 	assert c_source.contains('__typeof__(((Box){})) shared = ((Box){});'), c_source
 	assert c_source.contains('return shared;'), c_source
-	assert c_source.contains('int pair(int shared, int other)'), c_source
+	assert c_source.contains('i64 pair(i64 shared, i64 other)'), c_source
 	assert c_source.contains('return shared+other;'), c_source
 	assert c_source.contains('return shared^2;'), c_source
 	assert !c_source.contains('return &shared'), c_source
@@ -780,7 +780,7 @@ fn twice(value int) int {
 	assert c_source.contains('string label = ("total=");')
 	assert c_source.contains('__v_fastc_range_start_0 = (0);')
 	assert c_source.contains('__v_fastc_range_end_1 = (3);')
-	assert c_source.contains('int twice(int value);')
+	assert c_source.contains('i64 twice(i64 value);')
 	assert c_source.contains('setvbuf(stdout, NULL, _IONBF, 0);')
 	assert !c_source.contains('v3.flat')
 
@@ -994,7 +994,7 @@ fn main() {
 ', 'conditional_scope.c.v', prefs) or { panic(err) }
 	type_index := c_source.index('struct Holder {') or { -1 }
 	if_index := c_source.index('#if 1') or { -1 }
-	definition_index := c_source.index('int optional(Holder value) {') or { -1 }
+	definition_index := c_source.index('i64 optional(Holder value) {') or { -1 }
 	endif_index := c_source.index_after('#endif', definition_index) or { -1 }
 	assert type_index >= 0
 	assert if_index > type_index
@@ -1477,7 +1477,7 @@ fn test_generate_files_resolves_modules_without_an_ast() {
 	mut prefs := pref.new_preferences()
 	prefs.module_search_paths = [root]
 	c_source := generate_files([main_file], prefs) or { panic(err) }
-	assert c_source.contains('int mathutil__twice(int value);')
+	assert c_source.contains('i64 mathutil__twice(i64 value);')
 	assert c_source.contains('println(mathutil__twice(21));'), c_source
 
 	c_file := os.join_path(root, 'program.c')
@@ -1775,7 +1775,7 @@ fn main() {
 	_ := Worker.shared()
 }
 ', 'selfhost_static_method_shared.v', prefs) or { panic(err) }
-	assert c_source.contains('int Worker_shared(void)'), c_source
+	assert c_source.contains('i64 Worker_shared(void)'), c_source
 	assert c_source.contains('Worker_shared()'), c_source
 }
 

--- a/vlib/v3/gen/fastc/fastc_test.v
+++ b/vlib/v3/gen/fastc/fastc_test.v
@@ -349,7 +349,7 @@ fn main() {
 	println(shared)
 }
 ', 'selfhost_static_shared_local.v', prefs) or { panic(err) }
-	assert c_source.contains('__typeof__((1)) shared = (1);'), c_source
+	assert c_source.contains('i64 shared = (1);'), c_source
 	assert c_source.contains('println(shared)'), c_source
 }
 
@@ -776,7 +776,7 @@ fn twice(value int) int {
 '
 	prefs := pref.new_preferences()
 	c_source := generate(source, 'fastc_test.v', prefs) or { panic(err) }
-	assert c_source.contains('__typeof__((0)) total = (0);')
+	assert c_source.contains('i64 total = (0);')
 	assert c_source.contains('string label = ("total=");')
 	assert c_source.contains('__v_fastc_range_start_0 = (0);')
 	assert c_source.contains('__v_fastc_range_end_1 = (3);')

--- a/vlib/v3/gen/fastc/fn.v
+++ b/vlib/v3/gen/fastc/fn.v
@@ -10,7 +10,7 @@ import v3.scanner
 fn (mut g Parser) run() !string {
 	g.next()
 	g.parse_top_level_items(false)!
-	generated := g.out.str()
+	generated := fastc_take_string(mut g.out)
 	g.drain_pending_mono()!
 	return generated
 }
@@ -67,6 +67,9 @@ fn (mut g Parser) reset_lookup_memos() {
 	g.nonlocal_name_type_memo = map[string]string{}
 	g.resolved_name_memo = map[string]string{}
 	g.declared_type_key_memo = map[string]FastcMemoEntry{}
+	g.type_memo = map[i64]string{}
+	g.method_key_memo = map[string]map[string]string{}
+	g.field_memo = map[string]map[string]FastcStructField{}
 }
 
 // parse_mono_instance re-parses one concrete instance in its defining module, so its body
@@ -578,6 +581,7 @@ fn (mut g Parser) skip_import() ! {
 }
 
 fn (mut g Parser) parse_function(enabled bool) ! {
+	g.type_memo.clear()
 	g.locals = map[string]FastcLocal{}
 	g.temp_id = 0
 	g.direct_array_access = g.pending_direct_array_access
@@ -642,6 +646,7 @@ fn (mut g Parser) parse_function(enabled bool) ! {
 			receiver_type
 		}
 		params << '${fastc_output_c_type(receiver_parameter_type)} ${fastc_c_identifier(receiver_name)}'
+		g.type_memo.clear()
 		g.locals[receiver_name] = FastcLocal{
 			is_mut: receiver_is_mut
 			is_reference: receiver_is_reference
@@ -1055,6 +1060,7 @@ fn (mut g Parser) skip_c_function_declaration() ! {
 }
 
 fn (mut g Parser) parse_script() ! {
+	g.type_memo.clear()
 	g.locals = map[string]FastcLocal{}
 	g.has_main = true
 	g.protos.writeln('int main(void);')
@@ -1120,6 +1126,7 @@ fn (mut g Parser) parse_parameters() ![]string {
 				// Declare a real function pointer with unspecified args so `f(x)`
 				// compiles as a direct call; the return C type is recovered above.
 				params << '${fastc_output_c_type(fn_return_type)} (*${c_name})()'
+				g.type_memo.clear()
 				g.locals[parameter_name] = FastcLocal{
 					is_mut: is_mut
 					typ: type_name
@@ -1128,6 +1135,7 @@ fn (mut g Parser) parse_parameters() ![]string {
 				}
 			} else {
 				params << '${fastc_output_c_type(type_name)} ${c_name}'
+				g.type_memo.clear()
 				g.locals[parameter_name] = FastcLocal{
 					is_mut: is_mut
 					is_reference: is_reference

--- a/vlib/v3/gen/fastc/fn.v
+++ b/vlib/v3/gen/fastc/fn.v
@@ -618,7 +618,7 @@ fn (mut g Parser) parse_function(enabled bool) ! {
 		} else {
 			receiver_type
 		}
-		params << '${receiver_parameter_type} ${fastc_c_identifier(receiver_name)}'
+		params << '${fastc_output_c_type(receiver_parameter_type)} ${fastc_c_identifier(receiver_name)}'
 		g.locals[receiver_name] = FastcLocal{
 			is_mut: receiver_is_mut
 			is_reference: receiver_is_reference
@@ -756,7 +756,7 @@ fn (mut g Parser) parse_function(enabled bool) ! {
 	} else {
 		fastc_method_c_name(g.module_name, fastc_c_declared_type_name(receiver_key), name)
 	}
-	c_return_type := if is_main { 'int' } else { return_type }
+	c_return_type := if is_main { 'int' } else { fastc_output_c_type(return_type) }
 	c_params := if is_main && g.selfhost {
 		'int argc, char **argv'
 	} else if params.len == 0 {
@@ -769,7 +769,7 @@ fn (mut g Parser) parse_function(enabled bool) ! {
 		g.write_line('${c_return_type} ${c_name}(${c_params}) {')
 		g.indent++
 		if return_type != 'void' {
-			g.write_line('return (${return_type}){0};')
+			g.write_line('return (${fastc_output_c_type(return_type)}){0};')
 		}
 		g.indent--
 		g.write_line('}')
@@ -891,7 +891,7 @@ fn (mut g Parser) parse_function(enabled bool) ! {
 		// Self-host input was already accepted by the bootstrap compiler. Keep C's
 		// control-flow rules satisfied when the streaming parser cannot prove that
 		// every nested source branch terminates.
-		g.write_line('return (${return_type}){0};')
+		g.write_line('return (${fastc_output_c_type(return_type)}){0};')
 	}
 	if is_main {
 		g.write_line('return 0;')
@@ -939,7 +939,7 @@ fn (mut g Parser) emit_generic_body_stub(out_checkpoint int, saved_indent int, b
 	g.s = body_end
 	g.next()
 	if return_type != 'void' {
-		g.write_line('return (${return_type}){0};')
+		g.write_line('return (${fastc_output_c_type(return_type)}){0};')
 	}
 }
 
@@ -1096,7 +1096,7 @@ fn (mut g Parser) parse_parameters() ![]string {
 			if is_fn_pointer {
 				// Declare a real function pointer with unspecified args so `f(x)`
 				// compiles as a direct call; the return C type is recovered above.
-				params << '${fn_return_type} (*${c_name})()'
+				params << '${fastc_output_c_type(fn_return_type)} (*${c_name})()'
 				g.locals[parameter_name] = FastcLocal{
 					is_mut: is_mut
 					typ: type_name
@@ -1104,7 +1104,7 @@ fn (mut g Parser) parse_parameters() ![]string {
 					fn_option_value_type: fn_option_value_type
 				}
 			} else {
-				params << '${type_name} ${c_name}'
+				params << '${fastc_output_c_type(type_name)} ${c_name}'
 				g.locals[parameter_name] = FastcLocal{
 					is_mut: is_mut
 					is_reference: is_reference
@@ -1226,6 +1226,19 @@ fn (mut g Parser) parse_multi_return_types() ![]string {
 // cast type in a `match` branch.
 const fastc_boxed_primitive_types = ['int', 'i8', 'i16', 'i32', 'i64', 'u8', 'u16', 'u32', 'u64',
 	'f32', 'f64', 'bool', 'rune', 'isize', 'usize', 'char', 'voidptr']
+
+// fastc_output_c_type maps a semantic FastC type string to the C spelling that
+// is physically written into a declaration or cast. Only the platform-width
+// `int` differs from its semantic key: it is emitted as `i64`/`i32` per the
+// target, while staying `int` for method-name mangling and type inference (so
+// `int` and `i64` keep distinct methods). Pointer suffixes are preserved.
+fn fastc_output_c_type(t string) string {
+	base := t.trim_right('*')
+	if base == 'int' {
+		return fastc_platform_int_c_type + t[base.len..]
+	}
+	return t
+}
 
 fn fastc_primitive_c_type(raw_type string) ?string {
 	return match raw_type {

--- a/vlib/v3/gen/fastc/platform_int.v
+++ b/vlib/v3/gen/fastc/platform_int.v
@@ -1,0 +1,9 @@
+@[has_globals]
+module fastc
+
+// fastc_platform_int_c_type is the C spelling FastC emits for V's
+// platform-width `int`. Keep the state in its own module file so FastC's
+// generation entry point can follow upstream refactors without carrying a
+// conflict-prone module-header edit. FastC self-hosts for the current machine,
+// so default this from the compiler's pointer width.
+__global fastc_platform_int_c_type = $if x64 { 'i64' } $else { 'i32' }

--- a/vlib/v3/gen/fastc/render.v
+++ b/vlib/v3/gen/fastc/render.v
@@ -2044,7 +2044,7 @@ fn (g &Parser) render_selfhost_simple_array_literal_item(tokens []FastcExpressio
 		inner := g.render_selfhost_simple_array_literal_item(tokens[2..3], cast_type) or {
 			return none
 		}
-		return '((${cast_type})(${inner}))'
+		return '((${fastc_output_c_type(cast_type)})(${inner}))'
 	}
 	if tokens.len != 1 || tokens[0].source != '' {
 		return none

--- a/vlib/v3/gen/fastc/render_calls.v
+++ b/vlib/v3/gen/fastc/render_calls.v
@@ -205,7 +205,7 @@ fn (g &Parser) render_cast_expression(tokens []FastcExpressionToken) ?FastcRende
 	}
 	inner := g.render_call_argument_expression(inner_tokens, c_type) or { return none }
 	return FastcRenderedExpression{
-		source: '((${c_type})(${inner}))'
+		source: '((${fastc_output_c_type(c_type)})(${inner}))'
 		typ: c_type
 	}
 }

--- a/vlib/v3/gen/fastc/stmt.v
+++ b/vlib/v3/gen/fastc/stmt.v
@@ -1876,17 +1876,24 @@ fn (mut g Parser) parse_declaration_after_name(name string, is_mut bool) ! {
 	// GNU typeof is unevaluated and is supported by bundled TinyCC. It lets the
 	// direct path preserve V's `:=` without running any inference or type checker.
 	c_name := fastc_c_identifier(name)
+	normalized_type := fastc_normalize_inferred_type(g.last_expression_type)
 	if expression.starts_with('"') {
 		// C's typeof preserves a literal's array type instead of applying the usual
 		// pointer decay. The spelling alone is enough to lower this case.
 		g.write_line('string ${c_name} = (${expression});')
+	} else if normalized_type == 'int' {
+		// V's platform `int` is i64 (on 64-bit targets); `__typeof__` of an integer
+		// literal or C-`int` expression would give C `int` (32-bit), silently
+		// truncating `int` arithmetic. Spell the platform int type explicitly so the
+		// local matches the width used for `int` params, fields, and the C backend.
+		g.write_line('${fastc_platform_int_c_type} ${c_name} = (${expression});')
 	} else {
 		g.write_line('__typeof__((${expression})) ${c_name} = (${expression});')
 	}
 	local_type := if g.selfhost && g.last_expression_type == '' {
 		'int'
 	} else {
-		fastc_normalize_inferred_type(g.last_expression_type)
+		normalized_type
 	}
 	function_alias := g.functions[local_type] or { FastcFunctionSignature{} }
 	g.set_scoped_local(name, FastcLocal{

--- a/vlib/v3/pref/pref.v
+++ b/vlib/v3/pref/pref.v
@@ -1000,6 +1000,12 @@ pub fn comptime_flag_value(p &Preferences, name string) bool {
 
 // comptime_optional_flag_value supports comptime optional flag value handling for pref.
 pub fn comptime_optional_flag_value(p &Preferences, name string) bool {
+	// `int` is a 64-bit type on 64-bit targets, so the builtin's `$if new_int ?`
+	// guards (max_int/min_int, `int.str`, str_l overflow bounds) must take the
+	// i64 branch there. This mirrors v3's `int` -> `i64` C lowering.
+	if name == 'new_int' {
+		return p.target.pointer_bits == 64 || name in p.user_defines
+	}
 	// Test mode is added internally to `user_defines` so `_d_test.v` source
 	// selection works, but `$if test ?` only asks whether the user supplied
 	// `-d test`. Explicit `-d` values are recorded in `compile_values`.

--- a/vlib/v3/tests/builtin_const_local_collision_codegen_test.v
+++ b/vlib/v3/tests/builtin_const_local_collision_codegen_test.v
@@ -56,5 +56,5 @@ fn main() {
 	assert c_code.contains('builtin__degree'), c_code
 	assert c_code.contains('#define builtin__hashbits ('), c_code
 	assert c_code.contains('map degree ='), c_code
-	assert c_code.contains('int hashbits = 5;'), c_code
+	assert c_code.contains('i64 hashbits = 5;'), c_code
 }

--- a/vlib/v3/tests/c_anonymous_param_codegen_test.v
+++ b/vlib/v3/tests/c_anonymous_param_codegen_test.v
@@ -80,7 +80,7 @@ fn main() {
 	assert generated.contains('take_void((void*)(&ptr))'), generated
 	assert generated.contains('take_multi(pptr)'), generated
 	assert generated.contains('take_mixed(ptr, (void*)(ptr), 3, pptr)'), generated
-	fn_ptr_idx := generated.index('typedef int (*_fn_ptr_') or { -1 }
+	fn_ptr_idx := generated.index('typedef i64 (*_fn_ptr_') or { -1 }
 	take_fn_proto_idx := generated.index('int take_fn(_fn_ptr_') or { -1 }
 	assert fn_ptr_idx >= 0, generated
 	assert take_fn_proto_idx >= 0, generated

--- a/vlib/v3/tests/c_anonymous_param_codegen_test.v
+++ b/vlib/v3/tests/c_anonymous_param_codegen_test.v
@@ -80,7 +80,7 @@ fn main() {
 	assert generated.contains('take_void((void*)(&ptr))'), generated
 	assert generated.contains('take_multi(pptr)'), generated
 	assert generated.contains('take_mixed(ptr, (void*)(ptr), 3, pptr)'), generated
-	fn_ptr_idx := generated.index('typedef i64 (*_fn_ptr_') or { -1 }
+	fn_ptr_idx := generated.index('typedef int (*_fn_ptr_') or { -1 }
 	take_fn_proto_idx := generated.index('int take_fn(_fn_ptr_') or { -1 }
 	assert fn_ptr_idx >= 0, generated
 	assert take_fn_proto_idx >= 0, generated

--- a/vlib/v3/tests/c_global_c_type_storage_codegen_test.v
+++ b/vlib/v3/tests/c_global_c_type_storage_codegen_test.v
@@ -428,9 +428,9 @@ fn main() {
 	_ := sum_entries({1: 2})
 }
 ')
-	assert c_code.contains('int id__local = *(int*)'), c_code
+	assert c_code.contains('i64 id__local = *(i64*)'), c_code
 	assert c_code.contains('total += id__local + value;'), c_code
-	assert !c_code.contains('int id = *(int*)'), c_code
+	assert !c_code.contains('i64 id = *(i64*)'), c_code
 }
 
 fn test_mut_pointer_cast_uses_c_typedef_safe_parameter_name() {
@@ -477,7 +477,7 @@ fn main() {
 	_ := copy_buffer(mut values)
 }
 ')
-	assert c_code.contains('int copy_buffer(Array* buf__local)'), c_code
+	assert c_code.contains('i64 copy_buffer(Array* buf__local)'), c_code
 	assert c_code.contains('return copy(buf__local, '), c_code
 	assert !c_code.contains('return copy(buf, '), c_code
 }
@@ -500,7 +500,7 @@ fn main() {
 }
 ')
 	assert c_code.contains('u8 buf__local[1024]'), c_code
-	assert c_code.contains('return (int)(sizeof(buf__local));'), c_code
+	assert c_code.contains('return (i64)(sizeof(buf__local));'), c_code
 	assert !c_code.contains('return (int)(sizeof(buf));'), c_code
 }
 

--- a/vlib/v3/tests/c_global_static_codegen_test.v
+++ b/vlib/v3/tests/c_global_static_codegen_test.v
@@ -131,7 +131,7 @@ fn main() {
 	_ := next_value()
 }
 ')
-	assert c_code.contains('static int x = 0;')
+	assert c_code.contains('static i64 x = 0;')
 }
 
 // test_aggregate_globals_are_brace_zero_initialized validates this v3 regression case.
@@ -178,8 +178,8 @@ fn main() {}
 	assert c_code.contains('names = array_new(sizeof(string), 0, 0);')
 	assert c_code.contains('lookup = new_map(')
 	assert c_code.contains('Box box = {0};')
-	assert c_code.contains('int empty[0];')
-	assert c_code.contains('int slots[2] = {0};')
+	assert c_code.contains('i64 empty[0];')
+	assert c_code.contains('i64 slots[2] = {0};')
 	assert c_code.contains('\nmain__ZeroLeading zero;\n')
 	assert c_code.contains('\nmain__NestedZeroLeading nested;\n')
 	assert c_code.contains('\nmain__ZeroLeading zero_slots[2];\n')
@@ -189,7 +189,7 @@ fn main() {}
 	assert !c_code.contains('Array names = 0;')
 	assert !c_code.contains('map lookup = 0;')
 	assert !c_code.contains('Box box = 0;')
-	assert !c_code.contains('int empty[0] = {0};')
+	assert !c_code.contains('i64 empty[0] = {0};')
 	assert !c_code.contains('ZeroLeading zero = {0};')
 	assert !c_code.contains('NestedZeroLeading nested = {0};')
 	assert !c_code.contains('ZeroLeading zero_slots[2] = {0};')

--- a/vlib/v3/tests/c_identifier_hygiene_codegen_test.v
+++ b/vlib/v3/tests/c_identifier_hygiene_codegen_test.v
@@ -124,16 +124,16 @@ fn main() {
 	assert !c_code.contains('->unix'), c_code
 	assert !c_code.contains('#define block_size'), c_code
 	assert c_code.contains('i64 v_unix'), c_code
-	assert c_code.contains('int _v_true'), c_code
-	assert c_code.contains('int _v_false'), c_code
-	assert c_code.contains('int v_stdin'), c_code
-	assert c_code.contains('int v_stderr'), c_code
-	assert c_code.contains('int v_stdout'), c_code
-	assert c_code.contains('int v_access(int x)'), c_code
-	assert c_code.contains('int v_read(void)'), c_code
-	assert c_code.contains('int v_close(void)'), c_code
-	assert c_code.contains('int v_fabs(int x)'), c_code
-	assert c_code.contains('int v_typeof'), c_code
+	assert c_code.contains('i64 _v_true'), c_code
+	assert c_code.contains('i64 _v_false'), c_code
+	assert c_code.contains('i64 v_stdin'), c_code
+	assert c_code.contains('i64 v_stderr'), c_code
+	assert c_code.contains('i64 v_stdout'), c_code
+	assert c_code.contains('i64 v_access(i64 x)'), c_code
+	assert c_code.contains('i64 v_read(void)'), c_code
+	assert c_code.contains('i64 v_close(void)'), c_code
+	assert c_code.contains('i64 v_fabs(i64 x)'), c_code
+	assert c_code.contains('i64 v_typeof'), c_code
 	assert c_code.contains('Kind___v_asm'), c_code
 	assert c_code.contains('.v_unix'), c_code
 	assert c_code.contains('->v_unix'), c_code

--- a/vlib/v3/tests/c_variadic_call_codegen_test.v
+++ b/vlib/v3/tests/c_variadic_call_codegen_test.v
@@ -86,7 +86,12 @@ fn main() {
 	assert generated.contains('printf("plain\\n");'), generated
 	assert generated.contains('printf("name=%s count=%d\\n", "ok", 7);'), generated
 	assert generated.contains('fprintf(stderr, "err=%d\\n", 9);'), generated
-	assert generated.contains('sscanf("12 34", "%d %d", &a, &b);'), generated
+	// `&a`/`&b` are addresses of V `int`s (i64). Passing them straight to scanf's
+	// `%d` (which writes only 4 bytes) would leave the high bytes stale, so each is
+	// bridged through a temporary C `int` with copy-back; scanf receives the temp's
+	// address rather than `&a`/`&b` directly.
+	assert generated.contains('sscanf("12 34", "%d %d", &_cabi_out_val_'), generated
+	assert !generated.contains('sscanf("12 34", "%d %d", &a, &b);'), generated
 	assert generated.contains('__varargs_'), generated
 }
 

--- a/vlib/v3/tests/c_variadic_call_codegen_test.v
+++ b/vlib/v3/tests/c_variadic_call_codegen_test.v
@@ -116,7 +116,7 @@ fn main() {
 	assert run.output.trim_space() == '2', run.output
 
 	generated := os.read_file(bin + '.c') or { panic(err) }
-	assert generated.contains('int __vararg_storage_'), generated
+	assert generated.contains('i64 __vararg_storage_'), generated
 	assert generated.contains('double __vararg_storage_'), generated
 	assert !generated.contains('Small __vararg_storage_'), generated
 	assert !generated.contains('Floaty __vararg_storage_'), generated

--- a/vlib/v3/tests/callback_userdata_fn_field_codegen_test.v
+++ b/vlib/v3/tests/callback_userdata_fn_field_codegen_test.v
@@ -321,7 +321,10 @@ fn main() {
 ')
 	primitive_param_compile := callback_compile(v3_bin, wrong_primitive_param,
 		'wrong_primitive_param')
-	assert primitive_param_compile.exit_code != 0, primitive_param_compile.output
+	// With the platform `int` lowered to `i64`, `fn (int)` and `fn (i64)` share the
+	// same width and C spelling, so assigning a `fn (int)` value to a `fn (i64)`
+	// field is accepted rather than rejected.
+	assert primitive_param_compile.exit_code == 0, primitive_param_compile.output
 
 	homonym_root := os.join_path(os.temp_dir(), 'v3_callback_userdata_homonym_${os.getpid()}')
 	os.rmdir_all(homonym_root) or {}

--- a/vlib/v3/tests/callback_userdata_fn_field_codegen_test.v
+++ b/vlib/v3/tests/callback_userdata_fn_field_codegen_test.v
@@ -321,10 +321,11 @@ fn main() {
 ')
 	primitive_param_compile := callback_compile(v3_bin, wrong_primitive_param,
 		'wrong_primitive_param')
-	// With the platform `int` lowered to `i64`, `fn (int)` and `fn (i64)` share the
-	// same width and C spelling, so assigning a `fn (int)` value to a `fn (i64)`
-	// field is accepted rather than rejected.
-	assert primitive_param_compile.exit_code == 0, primitive_param_compile.output
+	// `fn (int)` and `fn (i64)` are distinct source types even though platform `int`
+	// currently shares i64's C width on 64-bit targets; assigning one to the other
+	// stays a type error (function-type identity is independent of the emitted C
+	// spelling and target width).
+	assert primitive_param_compile.exit_code != 0, primitive_param_compile.output
 
 	homonym_root := os.join_path(os.temp_dir(), 'v3_callback_userdata_homonym_${os.getpid()}')
 	os.rmdir_all(homonym_root) or {}

--- a/vlib/v3/tests/comptime_top_level_decl_codegen_test.v
+++ b/vlib/v3/tests/comptime_top_level_decl_codegen_test.v
@@ -110,12 +110,12 @@ fn test_top_level_decls_inside_active_comptime_branch_are_codegen_visible() {
 	else_choice := comptime_decl_struct_body(else_c, 'Choice')
 	assert comptime_decl_count(else_c, 'struct main__Choice {') == 1, else_c
 	assert else_choice.contains('_dummy'), else_c
-	assert !else_choice.contains('int x;'), else_c
+	assert !else_choice.contains('i64 x;'), else_c
 
 	feature_c := comptime_decl_gen_c(v3_bin, 'feature_branch', true)
 	feature_choice := comptime_decl_struct_body(feature_c, 'Choice')
 	assert comptime_decl_count(feature_c, 'struct main__Choice {') == 1, feature_c
-	assert feature_choice.contains('int x;'), feature_c
+	assert feature_choice.contains('i64 x;'), feature_c
 	assert !feature_choice.contains('_dummy'), feature_c
 }
 

--- a/vlib/v3/tests/current_module_call_return_codegen_test.v
+++ b/vlib/v3/tests/current_module_call_return_codegen_test.v
@@ -94,8 +94,8 @@ fn test_plain_call_prefers_current_module_return_authority() {
 	// Cached module bodies are emitted into their own translation units, and markused prunes
 	// their private helpers from the program unit. The exported entry signatures plus the runtime
 	// assertion above verify that each body retained its declaring module's return authority.
-	assert generated.contains('int clock__make(void);'), generated
-	assert generated.contains('zz_other__Other zz_other__new(int seed);'), generated
+	assert generated.contains('i64 clock__make(void);'), generated
+	assert generated.contains('zz_other__Other zz_other__new(i64 seed);'), generated
 	assert !generated.contains('zz_other__Other clock__new'), generated
 	assert !generated.contains('void zz_other__Other__add_seconds(clock__Time*'), generated
 }

--- a/vlib/v3/tests/executable_cleanup_test.v
+++ b/vlib/v3/tests/executable_cleanup_test.v
@@ -148,7 +148,7 @@ pub fn answer() int {
 	assert generate_no_main.exit_code == 0, generate_no_main.output
 	no_main_c := os.read_file(no_main_c_path)!
 	assert no_main_c.contains('static void _vno_main_init_caller(void) {'), no_main_c
-	assert no_main_c.contains('int exported_answer(void)'), no_main_c
+	assert no_main_c.contains('i64 exported_answer(void)'), no_main_c
 	assert_cleanup_registered_after_init(no_main_c)
 
 	// A natural-name export (export name equal to the C symbol) is emitted directly

--- a/vlib/v3/tests/export_attr_codegen_test.v
+++ b/vlib/v3/tests/export_attr_codegen_test.v
@@ -83,8 +83,8 @@ fn helper_unused() int {
 	c_code := os.read_file(bin_path + '.c') or { panic(err) }
 	// Imported module bodies and export wrappers live in the module-cache unit. Their
 	// declarations and the successful calls above prove they were rooted and linked.
-	assert c_code.contains('int expmod__exported_answer(void);'), c_code
-	assert c_code.contains('int raw_exported_answer(void);'), c_code
+	assert c_code.contains('i64 expmod__exported_answer(void);'), c_code
+	assert c_code.contains('i64 raw_exported_answer(void);'), c_code
 	assert c_code.contains('raw_exported_answer()'), c_code
 	assert c_code.contains('take_callback(expmod__exported_answer)'), c_code
 }
@@ -137,7 +137,7 @@ fn main() {
 	assert run.output.trim_space() == '7', run.output
 
 	c_code := os.read_file(bin_path + '.c') or { panic(err) }
-	assert c_code.contains('int raw_enabled_export(void) {'), c_code
+	assert c_code.contains('i64 raw_enabled_export(void) {'), c_code
 	assert !c_code.contains('raw_disabled_export'), c_code
 }
 
@@ -174,7 +174,7 @@ fn main() {}
 	compile := export_attr_compile(v3_bin, os.join_path(root, 'main.v'), bin_path)
 	assert compile.exit_code == 0, compile.output
 	c_code := os.read_file(bin_path + '.c') or { panic(err) }
-	assert c_code.count('int natural_name(void) {') == 1, c_code
+	assert c_code.count('i64 natural_name(void) {') == 1, c_code
 }
 
 fn test_export_name_collision_with_libc_remapped_natural_symbol_is_rejected() {
@@ -441,12 +441,12 @@ fn main() {}
 	compile := export_attr_compile(v3_bin, os.join_path(root, 'main.v'), bin_path)
 	assert compile.exit_code == 0, compile.output
 	c_code := os.read_file(bin_path + '.c') or { panic(err) }
-	assert c_code.contains('_v_ret_Array_fixed_int_3 numbers(void);'), c_code
-	assert c_code.contains('_v_ret_Array_fixed_int_3 raw_numbers(void);'), c_code
-	assert c_code.contains('_v_ret_Array_fixed_int_3 numbers(void) {'), c_code
-	assert c_code.contains('_v_ret_Array_fixed_int_3 raw_numbers(void) {'), c_code
+	assert c_code.contains('_v_ret_Array_fixed_i64_3 numbers(void);'), c_code
+	assert c_code.contains('_v_ret_Array_fixed_i64_3 raw_numbers(void);'), c_code
+	assert c_code.contains('_v_ret_Array_fixed_i64_3 numbers(void) {'), c_code
+	assert c_code.contains('_v_ret_Array_fixed_i64_3 raw_numbers(void) {'), c_code
 	assert c_code.contains('return numbers();'), c_code
-	assert !c_code.contains('\nArray_fixed_int_3 raw_numbers(void)'), c_code
+	assert !c_code.contains('\nArray_fixed_i64_3 raw_numbers(void)'), c_code
 }
 
 fn test_export_wrapper_fn_pointer_return_uses_fn_pointer_typedef() {
@@ -472,7 +472,7 @@ fn main() {}
 	compile := export_attr_compile(v3_bin, os.join_path(root, 'main.v'), bin_path)
 	assert compile.exit_code == 0, compile.output
 	c_code := os.read_file(bin_path + '.c') or { panic(err) }
-	assert c_code.contains('typedef int (*_fn_ptr_'), c_code
+	assert c_code.contains('typedef i64 (*_fn_ptr_'), c_code
 	assert c_code.contains(' callback(void);'), c_code
 	assert c_code.contains(' raw_callback(void);'), c_code
 	assert c_code.contains(' raw_callback(void) {'), c_code
@@ -507,8 +507,8 @@ fn main() {}
 		c_path)
 	assert compile.exit_code == 0, compile.output
 	c_code := os.read_file(c_path) or { panic(err) }
-	assert c_code.contains('veb__Result raw_show(main__App* app, main__Context* ctx, int id);'), c_code
-	assert c_code.contains('veb__Result raw_show(main__App* app, main__Context* ctx, int id) {'), c_code
+	assert c_code.contains('veb__Result raw_show(main__App* app, main__Context* ctx, i64 id);'), c_code
+	assert c_code.contains('veb__Result raw_show(main__App* app, main__Context* ctx, i64 id) {'), c_code
 	assert c_code.contains('return App__show(app, ctx, id);'), c_code
 }
 
@@ -538,8 +538,8 @@ fn main() {}
 		c_path)
 	assert compile.exit_code == 0, compile.output
 	c_code := os.read_file(c_path) or { panic(err) }
-	assert c_code.contains('veb__Result raw_show_underscore(main__App* app, main__Context* ctx, int _2);'), c_code
-	assert c_code.contains('veb__Result raw_show_underscore(main__App* app, main__Context* ctx, int _2) {'), c_code
+	assert c_code.contains('veb__Result raw_show_underscore(main__App* app, main__Context* ctx, i64 _2);'), c_code
+	assert c_code.contains('veb__Result raw_show_underscore(main__App* app, main__Context* ctx, i64 _2) {'), c_code
 	assert c_code.contains('return App__show(app, ctx, _2);'), c_code
 	assert !c_code.contains('return App__show(app, ctx, _1);'), c_code
 }

--- a/vlib/v3/tests/fastc_backend_test.v
+++ b/vlib/v3/tests/fastc_backend_test.v
@@ -259,7 +259,10 @@ fn main() {
 	assert !valid_compile.output.contains(' transform'), valid_compile.output
 	assert !valid_compile.output.contains('markused'), valid_compile.output
 	retained_c := os.read_file(valid_binary + '.c') or { panic(err) }
-	assert retained_c.contains('__typeof__((twice(21))) value = (twice(21));')
+	// A `:=` local whose inferred type is platform `int` is spelled with the explicit
+	// (i64) type rather than `__typeof__`, so `int` locals match the width used for
+	// params/fields and never truncate through C's own `int` inference.
+	assert retained_c.contains('i64 value = (twice(21));')
 	assert retained_c.contains('println(017);')
 	assert retained_c.contains('strlen(__v_fastc_collection_')
 	assert retained_c.contains('((const unsigned char *)__v_fastc_collection_')

--- a/vlib/v3/tests/fixed_array_multi_return_codegen_test.v
+++ b/vlib/v3/tests/fixed_array_multi_return_codegen_test.v
@@ -112,13 +112,13 @@ fn main() {
 	assert run.output.trim_space() == '81'
 	generated := os.read_file(bin + '.c') or { panic(err) }
 	compact := compact_c_whitespace(generated)
-	assert generated.contains('int xs[3];'), generated
-	assert compact.contains('intys[3]={0};')
-		|| compact.contains('intys[3];memmove(ys,(int[3]){0},sizeof(ys));')
-		|| compact.contains('intys[3];memmove(ys,(int[3]){0,0,0},sizeof(ys));'), generated
-	assert generated.contains('int zs[3];'), generated
-	assert generated.contains('int ds[2];'), generated
-	assert generated.contains('int choice[3];'), generated
+	assert generated.contains('i64 xs[3];'), generated
+	assert compact.contains('i64ys[3]={0};')
+		|| compact.contains('i64ys[3];memmove(ys,(i64[3]){0},sizeof(ys));')
+		|| compact.contains('i64ys[3];memmove(ys,(i64[3]){0,0,0},sizeof(ys));'), generated
+	assert generated.contains('i64 zs[3];'), generated
+	assert generated.contains('i64 ds[2];'), generated
+	assert generated.contains('i64 choice[3];'), generated
 	assert has_fixed_array_memmove_copy(compact, 'xs'), generated
 	assert has_fixed_array_memmove_copy(compact, 'ys'), generated
 	assert has_fixed_array_memmove_copy(compact, 'zs'), generated

--- a/vlib/v3/tests/fixed_array_typedef_codegen_test.v
+++ b/vlib/v3/tests/fixed_array_typedef_codegen_test.v
@@ -108,9 +108,9 @@ fn main() {
 	assert !shape_c.contains('[max_items]'), shape_c
 	assert !shape_c.contains('[rows]'), shape_c
 	assert !shape_c.contains('[cols]'), shape_c
-	assert shape_c.contains('typedef int Array_fixed_int_8[8];'), shape_c
-	assert shape_c.contains('typedef int Array_fixed_int_16[16];'), shape_c
-	assert shape_c.contains('typedef Array_fixed_int_16 Array_fixed_Array_fixed_int_16_6[6];'), shape_c
+	assert shape_c.contains('typedef i64 Array_fixed_i64_8[8];'), shape_c
+	assert shape_c.contains('typedef i64 Array_fixed_i64_16[16];'), shape_c
+	assert shape_c.contains('typedef Array_fixed_i64_16 Array_fixed_Array_fixed_i64_16_6[6];'), shape_c
 }
 
 fn test_fixed_array_typedefs_keep_declaring_module_with_unrelated_math_import() {
@@ -265,7 +265,7 @@ fn main() {
 	assert compile.exit_code == 0, compile.output
 	run := os.execute(bin)
 	assert run.exit_code == 0, run.output
-	assert run.output.trim_space() == '13', run.output
+	assert run.output.trim_space() == '17', run.output
 	generated := os.read_file(bin + '.c') or { panic(err) }
 	size_pos := generated.index('struct fixture__ZSize {') or { -1 }
 	typedef_pos := generated.index('typedef u8 Array_fixed_u8_sizeof_fixture__ZSize') or { -1 }

--- a/vlib/v3/tests/fn_value_decl_type_test.v
+++ b/vlib/v3/tests/fn_value_decl_type_test.v
@@ -617,7 +617,7 @@ fn test_local_fn_literal_decl_generates_fn_pointer_locals() {
 	v3_bin := build_v3()
 	optional_c := gen_c(v3_bin, 'fn_value_optional_void_local_c', optional_fn_src)
 	assert !optional_c.contains('Optional f = __anon_fn'), optional_c
-	assert !optional_c.contains('int f = __anon_fn'), optional_c
+	assert !optional_c.contains('i64 f = __anon_fn'), optional_c
 	assert optional_c.contains('typedef struct Optional (*_fn_ptr_'), optional_c
 	assert optional_c.contains(' f = __anon_fn_'), optional_c
 
@@ -628,30 +628,30 @@ fn test_local_fn_literal_decl_generates_fn_pointer_locals() {
 
 	plain_c := gen_c(v3_bin, 'fn_value_plain_int_local_c', plain_fn_src)
 	assert !plain_c.contains('Optional f = __anon_fn'), plain_c
-	assert !plain_c.contains('int f = __anon_fn'), plain_c
-	assert plain_c.contains('typedef int (*_fn_ptr_'), plain_c
+	assert !plain_c.contains('i64 f = __anon_fn'), plain_c
+	assert plain_c.contains('typedef i64 (*_fn_ptr_'), plain_c
 	assert plain_c.contains(' f = __anon_fn_'), plain_c
 
 	shadow_c := gen_c(v3_bin, 'fn_value_local_ident_shadow_c', local_ident_shadow_src)
-	assert shadow_c.contains('int foo = 10'), shadow_c
-	assert shadow_c.contains('int f = foo'), shadow_c
+	assert shadow_c.contains('i64 foo = 10'), shadow_c
+	assert shadow_c.contains('i64 f = foo'), shadow_c
 	call_shadow_c := gen_c(v3_bin, 'fn_value_call_return_shadow_c',
 		local_fn_value_call_return_shadow_src)
 	assert call_shadow_c.contains('string s = f();'), call_shadow_c
-	assert !call_shadow_c.contains('int s = f();'), call_shadow_c
+	assert !call_shadow_c.contains('i64 s = f();'), call_shadow_c
 
 	shadow_call_c := gen_c(v3_bin, 'fn_value_local_call_shadows_global_return_c',
 		local_fn_call_shadow_global_return_src)
-	assert shadow_call_c.contains('int x ='), shadow_call_c
+	assert shadow_call_c.contains('i64 x ='), shadow_call_c
 	assert !shadow_call_c.contains('string x ='), shadow_call_c
 
 	imported_c := gen_project_c(v3_bin, 'fn_value_imported_selector_local_c',
 		imported_fn_value_project_files())
-	assert !imported_c.contains('int f = worker__inc'), imported_c
-	assert !imported_c.contains('int loader = worker__read_ok'), imported_c
+	assert !imported_c.contains('i64 f = worker__inc'), imported_c
+	assert !imported_c.contains('i64 loader = worker__read_ok'), imported_c
 	assert !imported_c.contains(' f = main__inc'), imported_c
-	assert imported_c.contains('int local_f = local_worker.inc'), imported_c
-	assert imported_c.contains('typedef int (*_fn_ptr_'), imported_c
+	assert imported_c.contains('i64 local_f = local_worker.inc'), imported_c
+	assert imported_c.contains('typedef i64 (*_fn_ptr_'), imported_c
 	assert imported_c.contains(' f = worker__inc'), imported_c
 	assert imported_c.contains('f = worker__dec'), imported_c
 	assert imported_c.contains(' loader = worker__read_ok'), imported_c
@@ -666,7 +666,7 @@ fn test_shadowed_fn_value_calls_use_bound_callable_types() {
 
 	optional_c := gen_c(v3_bin, 'fn_value_optional_call_shadow_c',
 		local_fn_value_optional_call_shadow_src)
-	assert optional_c.contains('take((Optional){.ok = true, .value = f()})'), optional_c
+	assert optional_c.contains('take((Optional_i64){.ok = true, .value = f()})'), optional_c
 	assert !optional_c.contains('take(f())'), optional_c
 
 	drop_owned_c := gen_c(v3_bin, 'drop_owned_callback_shadow_c', drop_owned_callback_shadow_src)

--- a/vlib/v3/tests/generic_receiver_nested_call_codegen_test.v
+++ b/vlib/v3/tests/generic_receiver_nested_call_codegen_test.v
@@ -145,5 +145,5 @@ fn test_generic_receiver_nested_calls_use_specialized_receiver_methods() {
 	assert generated.contains('Optional_Array'), generated
 	assert !generated.contains('Inner_T__'), generated
 	assert !generated.contains('Outer_T__'), generated
-	assert !generated.contains('Optional_int __return_opt'), generated
+	assert !generated.contains('Optional_i64 __return_opt'), generated
 }

--- a/vlib/v3/tests/generic_struct_str_string_interp_codegen_test.v
+++ b/vlib/v3/tests/generic_struct_str_string_interp_codegen_test.v
@@ -213,7 +213,7 @@ fn main() {
 
 	assert generated.contains('gr__Inner_Array_string__str'), generated
 	assert generated.contains('Array __arr_str_it_'), generated
-	assert !generated.contains('int __arr_str_it_'), generated
+	assert !generated.contains('i64 __arr_str_it_'), generated
 	assert !generated.contains('Inner_T__str'), generated
 }
 
@@ -271,8 +271,8 @@ fn main() {
 	assert left_body.len > 0, generated
 	assert right_body.len > 0, generated
 	assert left_body.contains('Array __arr_str_it_'), left_body
-	assert !left_body.contains('int __arr_str_it_'), left_body
-	assert right_body.contains('int __arr_str_it_'), right_body
+	assert !left_body.contains('i64 __arr_str_it_'), left_body
+	assert right_body.contains('i64 __arr_str_it_'), right_body
 	assert !right_body.contains('Array __arr_str_it_'), right_body
 	assert !generated.contains('a__Box_int__str'), generated
 	assert !generated.contains('b__Box_Array_string__str'), generated
@@ -360,7 +360,7 @@ fn main() {
 	assert generated.contains('gr__WrapperQueue_Array_string__str'), generated
 	assert body.contains('Array __arr_str_it_'), body
 	assert body.contains('Array_string__str(__arr_str_it_'), body
-	assert !body.contains('int __arr_str_it_'), body
+	assert !body.contains('i64 __arr_str_it_'), body
 	assert !generated.contains('WrapperQueue_T__str'), generated
 	assert !generated.contains('LinkList_T__str'), generated
 }

--- a/vlib/v3/tests/markused_test.v
+++ b/vlib/v3/tests/markused_test.v
@@ -1434,7 +1434,7 @@ fn test_reachable_main_fn_literal_is_emitted_after_used_filter_transform() {
 	tc.annotate_types()
 	mut g := cgen.FlatGen.new()
 	c_code := g.gen_with_used_options(a, used, tc, true)
-	assert c_code.contains('int __anon_fn_')
+	assert c_code.contains('i64 __anon_fn_')
 	assert c_code.contains('callback_value(__anon_fn_')
 }
 
@@ -1761,7 +1761,7 @@ fn main() {
 	tc.annotate_types()
 	mut g := cgen.FlatGen.new()
 	c_code := g.gen_with_used_options(a, used, tc, true)
-	assert c_code.contains('new_map(sizeof(string), sizeof(int)')
+	assert c_code.contains('new_map(sizeof(string), sizeof(i64)')
 }
 
 // test_optional_map_or_lowers_to_new_map_after_used_filter_transform
@@ -1785,7 +1785,7 @@ fn main() {
 	tc.annotate_types()
 	mut g := cgen.FlatGen.new()
 	c_code := g.gen_with_used_options(a, used, tc, true)
-	assert c_code.contains('new_map(sizeof(string), sizeof(int)')
+	assert c_code.contains('new_map(sizeof(string), sizeof(i64)')
 }
 
 // test_string_membership_lowers_to_contains_after_used_filter_transform

--- a/vlib/v3/tests/markused_typed_receiver_codegen_test.v
+++ b/vlib/v3/tests/markused_typed_receiver_codegen_test.v
@@ -294,9 +294,9 @@ fn test_markused_roots_exact_typed_const_receiver_method() {
 	generated := os.read_file(out + '.c') or { panic(err) }
 	// The exact typed receiver methods live in the cached seriesmod object. The program unit
 	// exposes only its rooted entry points; the runtime result above verifies both private calls.
-	assert generated.contains('int seriesmod__run(int x);'), generated
-	assert generated.contains('int seriesmod__local_shadow(void);'), generated
-	assert generated.contains('int othermod__touch(void);'), generated
+	assert generated.contains('i64 seriesmod__run(i64 x);'), generated
+	assert generated.contains('i64 seriesmod__local_shadow(void);'), generated
+	assert generated.contains('i64 othermod__touch(void);'), generated
 	assert !generated.contains('seriesmod__Series__unused'), generated
 	assert !generated.contains('seriesmod__Series__leak'), generated
 	assert !generated.contains('seriesmod__AlternateSeries__measure'), generated

--- a/vlib/v3/tests/module_fn_short_name_collision_codegen_test.v
+++ b/vlib/v3/tests/module_fn_short_name_collision_codegen_test.v
@@ -111,7 +111,7 @@ fn test_imported_module_fn_short_name_does_not_pollute_builtin_return_type() {
 	assert run.output.trim_space() == 'ok'
 
 	generated := os.read_file(out + '.c') or { panic(err) }
-	assert generated.contains('DenseArray new_dense_array(int key_bytes, int value_bytes);'), generated
+	assert generated.contains('DenseArray new_dense_array(i64 key_bytes, i64 value_bytes);'), generated
 	assert generated.contains('.key_values = new_dense_array(key_bytes, value_bytes)'), generated
 	assert generated.contains('collisionmod__new_dense_array_T_v_int'), generated
 	assert generated.contains('localmod__helper()'), generated

--- a/vlib/v3/tests/mut_param_reassign_codegen_test.v
+++ b/vlib/v3/tests/mut_param_reassign_codegen_test.v
@@ -520,8 +520,8 @@ fn main() {
 }
 ')
 	assert out == '62'
-	assert c_source.contains('int read_field(main__Item** item) {'), 'missing main__Item** signature'
-	assert !c_source.contains('int read_field(main__Item*** item) {'), 'found over-indirected main__Item*** signature'
+	assert c_source.contains('i64 read_field(main__Item** item) {'), 'missing main__Item** signature'
+	assert !c_source.contains('i64 read_field(main__Item*** item) {'), 'found over-indirected main__Item*** signature'
 	assert c_source.contains('return ((*item))->value;'), 'missing single slot dereference'
 	assert c_source.contains('return (*(*item));'), 'missing source dereference after slot dereference'
 	assert c_source.contains('copied_value = (*(*item));'), 'missing standalone assignment dereference'

--- a/vlib/v3/tests/numeric_array_literal_type_codegen_test.v
+++ b/vlib/v3/tests/numeric_array_literal_type_codegen_test.v
@@ -139,8 +139,8 @@ fn add_all[T](items []T) T {
 	c_compact := numeric_array_literal_compact_c(c_code)
 	assert c_compact.contains('array_new(sizeof(double),0,6)'), c_code
 	assert c_code.contains('double x = *(double*)(array_get(xs,'), c_code
-	assert c_compact.contains('new_array_from_c_array(3,3,sizeof(int)'), c_code
-	assert !c_code.contains('int x = *(int*)(array_get(xs,'), c_code
+	assert c_compact.contains('new_array_from_c_array(3,3,sizeof(i64)'), c_code
+	assert !c_code.contains('i64 x = *(i64*)(array_get(xs,'), c_code
 	assert c_compact.contains('array_new(sizeof(float),0,2)'), c_code
 	assert c_code.contains('float z = *(float*)(array_get(zs,'), c_code
 	assert c_code.contains('float w = *(float*)(array_get(ws,'), c_code

--- a/vlib/v3/tests/option_arg_codegen_test.v
+++ b/vlib/v3/tests/option_arg_codegen_test.v
@@ -168,14 +168,17 @@ fn test_optional_abi_distinguishes_plain_t_name_from_specialized_generic() {
 	v3_bin := build_v3()
 	c_code := generated_c(v3_bin, 'optional_plain_t_name_abi',
 		'fn plain[T](x T) T {\n\treturn x\n}\n\nfn plain_t_name(x ?int) int {\n\treturn x or { 0 }\n}\n\nfn maybe() ?int {\n\treturn 3\n}\n\nfn use_fn(f fn (?int) int) int {\n\treturn f(maybe())\n}\n\nfn take[T](x ?T, fallback T) T {\n\treturn x or { fallback }\n}\n\nfn main() {\n\tprintln(plain_t_name(maybe()) + use_fn(plain_t_name) + take[int](7, 0) + plain[int](4))\n}\n')
-	assert c_code.contains('int plain_t_name(Optional x)'), c_code
-	assert !c_code.contains('int plain_t_name(Optional_int x)'), c_code
-	assert c_code.contains(')(struct Optional);'), c_code
-	assert !c_code.contains(')(Optional_int);'), c_code
+	// With platform `int` lowered to `i64`, `?int` and `?i64` share the
+	// `Optional_i64` representation, so plain and generic-specialized `?int` uses
+	// converge on it (the fn-pointer ABI stays consistent because every `?int`
+	// site now spells the same optional type).
+	assert c_code.contains('i64 plain_t_name(Optional_i64 x)'), c_code
+	assert !c_code.contains('Optional_int'), c_code
+	assert c_code.contains(')(struct Optional_i64);'), c_code
 	assert c_code.contains('plain_T_v_int(') || c_code.contains('plain_T_int('), c_code
-	assert c_code.contains('int take_T_v_int(Optional_int x, int fallback)')
-		|| c_code.contains('int take_T_int(Optional_int x, int fallback)'), c_code
-	assert c_code.contains('(Optional_int){.ok = true, .value = 7}'), c_code
+	assert c_code.contains('i64 take_T_v_int(Optional_i64 x, i64 fallback)')
+		|| c_code.contains('i64 take_T_int(Optional_i64 x, i64 fallback)'), c_code
+	assert c_code.contains('(Optional_i64){.ok = true, .value = 7}'), c_code
 }
 
 fn test_optional_generic_concrete_abi_converts_optional_args() {
@@ -184,14 +187,15 @@ fn test_optional_generic_concrete_abi_converts_optional_args() {
 	out := run_good(v3_bin, 'optional_generic_concrete_abi_run', source)
 	assert out == 'ok'
 	c_code := generated_c(v3_bin, 'optional_generic_concrete_abi_c', source)
-	assert c_code.contains('int take_T_v_int(Optional_int x, int fallback)')
-		|| c_code.contains('int take_T_int(Optional_int x, int fallback)'), c_code
-	assert c_code.contains('Optional _opt'), c_code
-	assert c_code.contains('(Optional_int){.ok = true, .value = _opt'), c_code
-	assert !c_code.contains('take_T_v_int(maybe(), 0)'), c_code
-	assert !c_code.contains('take_T_int(maybe(), 0)'), c_code
-	assert !c_code.contains('take_T_v_int(x, 0)'), c_code
-	assert !c_code.contains('take_T_int(x, 0)'), c_code
+	assert c_code.contains('i64 take_T_v_int(Optional_i64 x, i64 fallback)')
+		|| c_code.contains('i64 take_T_int(Optional_i64 x, i64 fallback)'), c_code
+	// `int` lowers to `i64`, so a plain `?int` value and the specialized `?T`
+	// (T = int) share `Optional_i64`. The optional arg then passes straight
+	// through, without the generic-`Optional` conversion temp the mismatched
+	// representations used to require.
+	assert !c_code.contains('Optional_int'), c_code
+	assert c_code.contains('take_T_v_int(maybe(), 0)') || c_code.contains('take_T_int(maybe(), 0)'), c_code
+	assert c_code.contains('take_T_v_int(x, 0)') || c_code.contains('take_T_int(x, 0)'), c_code
 }
 
 // test_optional_if_expr_codegen_initializes_optional_temp validates this v3 regression case.

--- a/vlib/v3/tests/parallel_cgen_test.v
+++ b/vlib/v3/tests/parallel_cgen_test.v
@@ -297,7 +297,7 @@ fn test_parallel_cgen_worker_resolves_generic_struct_method_signature() {
 	assert run.output.trim_space() == '550740'
 	c_code := os.read_file(bin_out + '.c') or { panic(err) }
 	assert c_code.contains('Box_int__accept'), c_code
-	assert c_code.contains('Optional_int x'), c_code
+	assert c_code.contains('Optional_i64 x'), c_code
 	assert !c_code.contains('?T'), c_code
 }
 
@@ -312,9 +312,9 @@ fn test_parallel_cgen_generic_optional_method_uses_concrete_optional_abi_in_call
 
 	c_code := os.read_file(c_out) or { panic(err) }
 	assert c_code.contains('Box_int__accept'), c_code
-	assert c_code.contains('Optional_int x'), c_code
-	assert c_code.contains('Box_int__accept(b, (Optional_int){.ok = true, .value = 7})'), c_code
-	assert c_code.contains('Box_int__accept(b, (Optional_int){.ok = true, .value = 8})'), c_code
+	assert c_code.contains('Optional_i64 x'), c_code
+	assert c_code.contains('Box_int__accept(b, (Optional_i64){.ok = true, .value = 7})'), c_code
+	assert c_code.contains('Box_int__accept(b, (Optional_i64){.ok = true, .value = 8})'), c_code
 	assert !c_code.contains('Box_int__accept(b, (Optional){.ok = true, .value = 7})'), c_code
 	assert !c_code.contains('Box_int__accept(b, (Optional){.ok = true, .value = 8})'), c_code
 }

--- a/vlib/v3/tests/review_transform_regressions_test.v
+++ b/vlib/v3/tests/review_transform_regressions_test.v
@@ -6785,7 +6785,7 @@ fn main() {
 		assert body.contains('int* local ='), body
 	}
 	builtin_body := c_fn_body(c_source, 'int* make_builtin_memdup(void) {')
-	assert builtin_body.contains('int local = 44;'), builtin_body
+	assert builtin_body.contains('i64 local = 44;'), builtin_body
 	assert builtin_body.contains('memdup(&local, sizeof(int))'), builtin_body
 }
 

--- a/vlib/v3/tests/selective_import_codegen_test.v
+++ b/vlib/v3/tests/selective_import_codegen_test.v
@@ -513,12 +513,12 @@ pub:
 '
 	})
 	assert output == '10'
-	assert generated.contains('geometry__Point worker__make_point_T_v_int(int x)'), generated
-	assert generated.contains('int worker__take_point_T_v_int(geometry__Point p, int x)'), generated
-	assert !generated.contains('\nPoint worker__make_point_T_v_int(int x)'), generated
-	assert !generated.contains('\npixels__Point worker__make_point_T_v_int(int x)'), generated
-	assert !generated.contains('\nint worker__take_point_T_v_int(Point p, int x)'), generated
-	assert !generated.contains('\nint worker__take_point_T_v_int(pixels__Point p, int x)'), generated
+	assert generated.contains('geometry__Point worker__make_point_T_v_int(i64 x)'), generated
+	assert generated.contains('i64 worker__take_point_T_v_int(geometry__Point p, i64 x)'), generated
+	assert !generated.contains('\nPoint worker__make_point_T_v_int(i64 x)'), generated
+	assert !generated.contains('\npixels__Point worker__make_point_T_v_int(i64 x)'), generated
+	assert !generated.contains('\ni64 worker__take_point_T_v_int(Point p, i64 x)'), generated
+	assert !generated.contains('\ni64 worker__take_point_T_v_int(pixels__Point p, i64 x)'), generated
 }
 
 fn test_selective_import_symbol_can_be_used_as_function_value() {
@@ -535,7 +535,7 @@ fn main() {
 	assert output == '5'
 	assert generated.contains('mymodules__add_xy'), generated
 	assert generated.contains('f(2, 3)'), generated
-	assert !generated.contains('int f = mymodules__add_xy'), generated
+	assert !generated.contains('i64 f = mymodules__add_xy'), generated
 }
 
 fn test_selective_import_function_value_roots_exact_symbol_with_imported_homonym() {
@@ -683,7 +683,7 @@ fn main() {
 }
 ')
 	assert output == '6'
-	assert generated.contains('int add_xy(int x, int y)'), generated
+	assert generated.contains('i64 add_xy(i64 x, i64 y)'), generated
 	assert generated.contains('int__str(add_xy(2, 3))'), generated
 	assert !generated.contains('int__str(mymodules__add_xy(2, 3))'), generated
 }
@@ -712,10 +712,10 @@ pub fn value() string {
 '
 	})
 	assert output == '7\nfoo'
-	assert generated.contains('int value(void);'), generated
+	assert generated.contains('i64 value(void);'), generated
 	assert generated.contains('string foo__value(void);'), generated
 	assert generated.contains('string foo__value(void) {'), generated
-	assert !generated.contains('int foo__value(void);'), generated
+	assert !generated.contains('i64 foo__value(void);'), generated
 }
 
 fn test_module_local_error_method_signature_uses_module_key() {
@@ -906,9 +906,9 @@ fn main() {
 ',
 		extra)
 	assert output == '7'
-	assert generated.contains('int box__Box_int__combine(box__Box_int b, types__Thing thing)'), generated
-	assert !generated.contains('int box__Box_int__combine(box__Box_int b, box__Thing thing)'), generated
-	assert !generated.contains('int box__Box_int__combine(box__Box_int b, other__Thing thing)'), generated
+	assert generated.contains('i64 box__Box_int__combine(box__Box_int b, types__Thing thing)'), generated
+	assert !generated.contains('i64 box__Box_int__combine(box__Box_int b, box__Thing thing)'), generated
+	assert !generated.contains('i64 box__Box_int__combine(box__Box_int b, other__Thing thing)'), generated
 }
 
 fn test_selective_import_resolves_alias_collision() {
@@ -1038,8 +1038,8 @@ fn main() {
 ',
 		selective_import_type_collision_modules())
 	assert output == '3'
-	assert generated.contains('int m = 1 | 2;'), generated
-	assert !generated.contains('int m = 1 | 4;'), generated
+	assert generated.contains('i64 m = 1 | 2;'), generated
+	assert !generated.contains('i64 m = 1 | 4;'), generated
 	assert !generated.contains('Perm.a'), generated
 }
 

--- a/vlib/v3/tests/spawn_args_test.v
+++ b/vlib/v3/tests/spawn_args_test.v
@@ -76,7 +76,7 @@ fn main() {
 	assert c_code.contains('add_thread_args'), c_code
 	assert c_code.contains('pthread_create'), c_code
 	assert_spawn_pthread_decls(c_code)
-	assert c_compact.contains('typedefstruct{main__Counter*a0;inta1;inta2;}add_thread_args;'), c_code
+	assert c_compact.contains('typedefstruct{main__Counter*a0;i64a1;i64a2;}add_thread_args;'), c_code
 	assert c_compact.contains('->a0=c;'), c_code
 	assert c_compact.contains('__v_thread_spawn(add_args_thread_wrapper,(void*)_sa'), c_code
 	assert c_code.contains('add(p->a0, p->a1, p->a2)'), c_code
@@ -104,7 +104,7 @@ fn main() {
 	')
 	c_compact := compact_c(c_code)
 	assert c_code.contains('pthread_create'), c_code
-	assert c_compact.contains('typedefstruct{main__Counter*a0;inta1;}Counter__bump_thread_args;'), c_code
+	assert c_compact.contains('typedefstruct{main__Counter*a0;i64a1;}Counter__bump_thread_args;'), c_code
 	assert c_compact.contains('->a0=c;'), c_code
 	assert c_compact.contains('__v_thread_spawn(Counter__bump_args_thread_wrapper,(void*)_sa'), c_code
 
@@ -180,9 +180,9 @@ fn main() {
 	assert c_compact.contains('typedefstruct{main__Boxa0;}Box__show_thread_args'), c_code
 	assert c_compact.contains('Box__show(&p->a0)'), c_code
 	assert !c_compact.contains('typedefstruct{main__Box*a0;}Box__show_thread_args'), c_code
-	assert c_compact.contains('typedefstruct{inta0;}takes_ptr_thread_args'), c_code
+	assert c_compact.contains('typedefstruct{i64a0;}takes_ptr_thread_args'), c_code
 	assert c_compact.contains('takes_ptr(&p->a0)'), c_code
-	assert !c_compact.contains('typedefstruct{int*a0;}takes_ptr_thread_args'), c_code
+	assert !c_compact.contains('typedefstruct{i64*a0;}takes_ptr_thread_args'), c_code
 }
 
 fn test_spawn_mutable_local_address_preserves_escaping_pointer() {
@@ -202,10 +202,10 @@ fn main() {
 }
 	')
 	c_compact := compact_c(c_code)
-	assert c_compact.contains('typedefstruct{int*a0;}takes_ptr_thread_args'), c_code
+	assert c_compact.contains('typedefstruct{i64*a0;}takes_ptr_thread_args'), c_code
 	assert c_compact.contains('->a0=value;'), c_code
 	assert c_compact.contains('takes_ptr(p->a0)'), c_code
-	assert !c_compact.contains('typedefstruct{inta0;}takes_ptr_thread_args'), c_code
+	assert !c_compact.contains('typedefstruct{i64a0;}takes_ptr_thread_args'), c_code
 }
 
 fn test_spawn_result_uses_checked_allocation_and_typed_join() {
@@ -220,7 +220,7 @@ fn main() {
 	println(t.wait())
 }
 	')
-	assert c_code.contains('(int*)__v_thread_alloc(sizeof(int))'), c_code
+	assert c_code.contains('(i64*)__v_thread_alloc(sizeof(i64))'), c_code
 	assert c_code.contains('__v_thread_join(t)'), c_code
 	assert !c_code.contains('pthread_join((pthread_t)'), c_code
 }

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -4003,11 +4003,11 @@ fn (mut tc TypeChecker) check_c_fn_redeclarations(a &flat.FlatAst) {
 					if child.typ.starts_with('...') {
 						is_variadic = true
 					} else {
-						params << tc.c_type(tc.parse_type(child.typ))
+						params << tc.c_extern_abi_type(tc.parse_type(child.typ))
 					}
 				}
 				signature := CFnDeclSignature{
-					return_type: tc.c_type(tc.parse_type(node.typ))
+					return_type: tc.c_extern_abi_type(tc.parse_type(node.typ))
 					params:      params
 					is_variadic: is_variadic
 				}

--- a/vlib/v3/types/checker_comptime.v
+++ b/vlib/v3/types/checker_comptime.v
@@ -5381,6 +5381,19 @@ fn (tc &TypeChecker) implicit_int_literal_overflows(id flat.NodeId) bool {
 	if magnitude.len == 0 {
 		return false
 	}
+	if platform_int_bits() >= 64 {
+		value, parse_error := strconv.common_parse_uint2(magnitude, 0, 64)
+		if parse_error == -3 {
+			return true
+		}
+		if parse_error != 0 {
+			return false
+		}
+		if is_negative {
+			return value > u64(9_223_372_036_854_775_808)
+		}
+		return value > u64(9_223_372_036_854_775_807)
+	}
 	value, parse_error := strconv.common_parse_uint2(magnitude, 0, 32)
 	if parse_error == -3 {
 		return true
@@ -5407,7 +5420,7 @@ fn integer_type_range(typ Type) ?IntegerTypeRange {
 			return none
 		}
 		return IntegerTypeRange{
-			bits:        if clean.size == 0 { 32 } else { int(clean.size) }
+			bits:        if clean.size == 0 { platform_int_bits() } else { int(clean.size) }
 			is_unsigned: clean.props.has(.unsigned)
 			name:        typ.name()
 		}

--- a/vlib/v3/types/checker_tail.v
+++ b/vlib/v3/types/checker_tail.v
@@ -3912,6 +3912,7 @@ fn (mut tc TypeChecker) check_call(id flat.NodeId, node flat.Node) {
 		}
 		tc.check_call_deprecation(id, node, info)
 		tc.check_call_arg_types(id, node, info)
+		tc.check_c_callback_abi_args(id, node, info)
 		tc.invalidate_smartcasts_after_call(node, info)
 		tc.check_os_file_raw_io_call(id, node, info)
 		tc.check_instantiated_generic_as_casts(node, info)
@@ -10509,6 +10510,53 @@ fn (tc &TypeChecker) subtree_can_rebind_mut_parameter(id flat.NodeId, name strin
 	}
 	for i in 0 .. node.children_count {
 		if tc.subtree_can_rebind_mut_parameter(tc.a.child(node, i), name, typ) {
+			return true
+		}
+	}
+	return false
+}
+
+// check_c_callback_abi_args rejects passing a forwarded/dynamic function value to a
+// C callback parameter whose signature contains platform `int`. A named function is
+// adapted with a generated ABI thunk in the C backend (C `int` <-> V i64), but a
+// dynamic function-pointer value cannot be adapted — a function-pointer cast does not
+// convert the arguments the C library passes — so it would silently miscompile. The
+// caller must pass a named function, or declare the callback with `i32`.
+fn (mut tc TypeChecker) check_c_callback_abi_args(id flat.NodeId, node flat.Node, info CallInfo) {
+	if !info.params_known || !info.name.starts_with('C.') {
+		return
+	}
+	for i in 1 .. node.children_count {
+		param_idx := i - 1
+		if param_idx >= info.params.len {
+			break
+		}
+		param_fn := fn_type_from_type(info.params[param_idx]) or { continue }
+		if !fn_type_has_platform_int(param_fn) {
+			continue
+		}
+		arg_id := tc.call_arg_value(tc.a.child(&node, i))
+		if fn_type_from_type(tc.resolve_type(arg_id)) == none {
+			continue
+		}
+		if tc.fn_value_key(tc.a.node(arg_id)) != none {
+			// A resolvable named function is adapted by a generated thunk.
+			continue
+		}
+		if tc.should_diagnose(id) {
+			tc.record_error(.call_arg_mismatch,
+				'cannot pass a forwarded function value with an `int` parameter/return to the C callback of `${info.name}`: a C callback receives a 32-bit `int` but the V function expects 64-bit, and a function-pointer cast cannot adapt that; pass a named function directly, or declare the callback with `i32`',
+				arg_id)
+		}
+	}
+}
+
+fn fn_type_has_platform_int(t FnType) bool {
+	if fn_param_is_platform_int(t.return_type) {
+		return true
+	}
+	for i in 0 .. t.params.len {
+		if fn_param_is_platform_int(fn_compatible_param_type(t, i)) {
 			return true
 		}
 	}

--- a/vlib/v3/types/checker_tail_stmt.v
+++ b/vlib/v3/types/checker_tail_stmt.v
@@ -8945,10 +8945,28 @@ fn (tc &TypeChecker) fn_param_compatible(actual Type, expected Type) bool {
 			return true
 		}
 	}
+	// V's platform `int` and a fixed-width integer such as `i64`/`i32` may share an
+	// emitted C spelling on a given target, but they remain distinct, target-
+	// independent source types. Function-parameter identity must not depend on the C
+	// width, so never let the c_type shortcut below collapse `int` with `i64`/`i32`
+	// (on 64-bit both spell `i64`; on 32-bit `int`/`i32` both spell `i32`).
+	if fn_param_is_platform_int(actual) != fn_param_is_platform_int(expected)
+		&& fn_param_unalias_type(actual) is Primitive
+		&& fn_param_unalias_type(expected) is Primitive {
+		return false
+	}
 	if tc.c_type(actual) == tc.c_type(expected) {
 		return true
 	}
 	return fn_param_can_cast_userdata_param(actual, expected)
+}
+
+fn fn_param_is_platform_int(typ Type) bool {
+	clean := fn_param_unalias_type(typ)
+	if clean is Primitive {
+		return clean.size == 0 && clean.props.has(.integer) && !clean.props.has(.unsigned)
+	}
+	return false
 }
 
 fn (tc &TypeChecker) fn_return_compatible(actual Type, expected Type) bool {

--- a/vlib/v3/types/checker_tail_stmt.v
+++ b/vlib/v3/types/checker_tail_stmt.v
@@ -16504,6 +16504,14 @@ fn (tc &TypeChecker) c_type_uncached(t Type) string {
 		return 'size_t'
 	}
 	if t is Primitive {
+		// V's platform `int` (a signed integer of unset size) lowers to the
+		// target-width C spelling: `i64` on 64-bit targets, `i32` on 32-bit.
+		// Only the emitted C type changes; `int` stays named `int` for
+		// diagnostics and keeps distinct methods from `i64` (prim_c_type is
+		// still `int`, so method-name mangling never collapses the two).
+		if t.size == 0 && t.props.has(.integer) && !t.props.has(.unsigned) {
+			return platform_int_c_type
+		}
 		return prim_c_type(t)
 	}
 	if t is Array {

--- a/vlib/v3/types/checker_tail_stmt.v
+++ b/vlib/v3/types/checker_tail_stmt.v
@@ -16437,6 +16437,45 @@ fn (tc &TypeChecker) resolve_index_base_value_type(base_type Type) Type {
 }
 
 // c_type supports c type handling for TypeChecker.
+// c_extern_abi_type spells `t` the way a C extern declaration lowers it for ABI
+// comparison: V's platform `int` stays C `int` (via prim_c_type) instead of
+// widening to its value spelling (`i64` on 64-bit). This mirrors the codegen
+// rule that C extern declarations keep C `int`, so two decls of the same C
+// function that mix `int` and `i32` remain ABI-compatible (both are 32-bit C
+// int), while a genuine `int` vs `i64` mismatch is still rejected. It recurses
+// through pointers, aliases, and function types so `int` is treated as C `int`
+// anywhere inside a C ABI signature. For every non-int shape it produces exactly
+// what c_type would, so it never widens the set of "compatible" signatures.
+fn (tc &TypeChecker) c_extern_abi_type(t Type) string {
+	if t is Primitive {
+		return prim_c_type(t)
+	}
+	if t is Pointer {
+		return tc.c_extern_abi_type(t.base_type) + '*'
+	}
+	if t is Alias {
+		return tc.c_extern_abi_type(t.base_type)
+	}
+	if t is FnType {
+		ret := tc.c_extern_abi_type(t.return_type)
+		if t.params.len == 0 {
+			return 'fn_ptr:${ret}|void'
+		}
+		mut params := []string{}
+		for i in 0 .. t.params.len {
+			mut param_type := fn_param_type(t, i)
+			if fn_param_is_mut(t, i) && param_type !is Pointer {
+				param_type = Type(Pointer{
+					base_type: param_type
+				})
+			}
+			params << tc.c_extern_abi_type(param_type)
+		}
+		return 'fn_ptr:${ret}|${params.join(', ')}'
+	}
+	return tc.c_type(t)
+}
+
 pub fn (tc &TypeChecker) c_type(t Type) string {
 	if tc.type_cache == unsafe { nil } || isnil(tc.type_interner) {
 		return tc.c_type_uncached(t)

--- a/vlib/v3/types/type_cache_test.v
+++ b/vlib/v3/types/type_cache_test.v
@@ -301,8 +301,8 @@ fn test_fn_param_mutability_participates_in_type_identity() {
 	immutable_id, _ := tc.intern_type(immutable)
 	mutable_id, _ := tc.intern_type(mutable)
 	assert immutable_id != mutable_id
-	assert tc.c_type(immutable) == 'fn_ptr:void|int'
-	assert tc.c_type(mutable) == 'fn_ptr:void|int*'
+	assert tc.c_type(immutable) == 'fn_ptr:void|i64'
+	assert tc.c_type(mutable) == 'fn_ptr:void|i64*'
 
 	cloned := clone_owned_type(mutable)
 	assert cloned is FnType

--- a/vlib/v3/types/universe.v
+++ b/vlib/v3/types/universe.v
@@ -1,4 +1,25 @@
+@[has_globals]
 module types
+
+// platform_int_c_type is the C spelling emitted for V's platform-width `int`
+// (the `Primitive` with size 0). `int` is 64-bit on 64-bit targets and 32-bit
+// on 32-bit targets, so it lowers to `i64` or `i32` respectively. It defaults to
+// the 64-bit spelling so self-host and the C-backend unit tests work before a
+// target is configured; `set_platform_int_bits` updates it for cross builds.
+__global platform_int_c_type = 'i64'
+
+// set_platform_int_bits selects the C spelling for the platform `int` from the
+// target pointer width. The driver calls this once, before checking or code
+// generation, so every `c_type` lowering agrees on the width.
+pub fn set_platform_int_bits(bits int) {
+	platform_int_c_type = if bits == 32 { 'i32' } else { 'i64' }
+}
+
+// platform_int_bits returns the bit width of V's platform `int` (64 or 32),
+// used for literal-overflow and range checks so they match the emitted width.
+pub fn platform_int_bits() int {
+	return if platform_int_c_type == 'i64' { 64 } else { 32 }
+}
 
 pub const bool_ = Primitive{
 	props: .boolean

--- a/vlib/x/multiwindow/x11_backend.c.v
+++ b/vlib/x/multiwindow/x11_backend.c.v
@@ -321,8 +321,8 @@ $if linux && x_multiwindow_x11 ? {
 	fn C.v_multiwindow_x11_destroy_ic(ic voidptr)
 	fn C.v_multiwindow_x11_set_ic_focus(ic voidptr)
 	fn C.v_multiwindow_x11_unset_ic_focus(ic voidptr)
-	fn C.v_multiwindow_x11_init_keycodes(display &C.Display, keycodes &int, keycodes_len int)
-	fn C.v_multiwindow_x11_key_code(event &C.XEvent, keycodes &int, keycodes_len int) int
+	fn C.v_multiwindow_x11_init_keycodes(display &C.Display, keycodes &i32, keycodes_len int)
+	fn C.v_multiwindow_x11_key_code(event &C.XEvent, keycodes &i32, keycodes_len int) int
 	fn C.v_multiwindow_x11_char_codes(ic voidptr, event &C.XEvent, codes &u32, codes_len int, required_codes &int) int
 	fn C.v_multiwindow_x11_create_cursor_for_shape(display &C.Display, shape int) X11NativeCursor
 	fn C.v_multiwindow_x11_apply_config_hints(display &C.Display, window X11NativeWindow, width int, height int, min_width int, min_height int, resizable int, borderless int, fullscreen int) int
@@ -554,7 +554,7 @@ mut:
 	started                                      bool
 	pending_window                               X11WindowRecord
 	windows                                      []X11WindowRecord
-	keycodes                                     [256]int
+	keycodes                                     [256]i32
 }
 
 fn new_x11_backend() X11Backend {


### PR DESCRIPTION
## What

Makes v3's `int` a platform-width type: it lowers to **`i64` on 64-bit targets** and **`i32` on 32-bit**, chosen from `target.pointer_bits`, across both the **C** and **FastC** backends. Previously `int` was always C `int` (32-bit).

## Design

`int` stays a *distinct* type from `i64` (same source name, its own methods) — only the emitted **C spelling** changes. This keeps `int` and `i64` from collapsing their `str`/`hex`/… method namespaces. The change activates V's existing `$if new_int ?` builtin guards on 64-bit, so `max_int`/`min_int` become i64 bounds and `int.str` formats via i64.

## Changes

- **types**: emission-only lowering in `c_type`; literal-overflow and integer-range checks use the platform width; `platform_int_c_type` + `set_platform_int_bits`.
- **gen/c**: `FlatGen.int_ct` drives the hand-written `[]int` runtime helpers (index/last_index/contains/sort/fixed-array-contains) and the `int__str` / `array__push_many` / `v3_int_zpad` prototypes and the IError `code()` dispatch. **C-extern declarations** (`fn C.foo(x int) int`) keep C `int` for ABI (V converts at the call boundary). `[sizeof(int)]u8` fixed-array typedef names are kept consistent with their references.
- **gen/fastc**: parallel emission-only lowering at the C-write sites.
- **driver / pref**: pins the width from the target before checking and codegen.
- **tests**: codegen expectations updated to `i64` where appropriate; genuine C `int` (libc / pthread / `fn C.*` externs / `int main`) is left unchanged.

## Validation

- **C backend runtime-correct**: `sizeof(int) == 8`, `2e9 + 2e9 == 4e9` (no 32-bit overflow), `int.str`/arrays/`sort`/`Optional`/generics/interfaces all work; a 32-bit target emits `i32`.
- **FastC self-host reaches a gen2 == gen3 fixpoint** and runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)