### PR TITLE
v3: speed up FastC self-host generation to ~3.5M loc/s (-prod)

### DIFF
--- a/vlib/v3/README.md
+++ b/vlib/v3/README.md
@@ -173,14 +173,16 @@ workers on faster cores take more files; the serial merge and output order is re
 keywords (`interface`, `$if`, type keywords, generic `fn` syntax) each file mentions, and the later
 collection passes skip files that cannot contain what they scan for.
 
-Source resolution reads the program on worker threads before the ordering walk runs: a thread
-lists each imported module directory and immediately starts chunked readers for its files, and the
-main thread joins listings first and then the chunks in start order, resolving the imports of each
-chunk as it lands, so reading one module overlaps with discovering the next. The generic-method
-scan and the declaration index share one pass, the split of oversized files into generation
-fragments and the by-name struct field index are built on workers while the declaration phases
-run, and the generated C is returned as ordered pieces (per-file bodies are referenced, not copied)
-that the drivers write directly.
+Source resolution reads the program on worker threads before the ordering walk runs: each
+imported module directory is listed on a thread and its files are read in chunks on further
+threads, never more than the worker limit (CPU count or `VJOBS`) at once. The main thread joins
+listings first and then the chunks in start order, resolving the imports of each chunk as it
+lands, so reading one module overlaps with discovering the next. The generic-method scan and the
+declaration index share one pass, the split of oversized files into generation fragments and the
+by-name struct field index are built on workers while the declaration phases run, and the
+generated C is returned as ordered pieces (whole per-file bodies are shared rather than copied
+into one buffer; only bodies cut around C directive lines are copied) that the drivers write
+directly.
 
 The standalone compiler supports `self` directly and defaults that command to FastC. For example,
 `./v self x5` replaces the compiler through five descendant FastC generations, with each installed

--- a/vlib/v3/README.md
+++ b/vlib/v3/README.md
@@ -173,6 +173,15 @@ workers on faster cores take more files; the serial merge and output order is re
 keywords (`interface`, `$if`, type keywords, generic `fn` syntax) each file mentions, and the later
 collection passes skip files that cannot contain what they scan for.
 
+Source resolution reads the program on worker threads before the ordering walk runs: a thread
+lists each imported module directory and immediately starts chunked readers for its files, and the
+main thread joins listings first and then the chunks in start order, resolving the imports of each
+chunk as it lands, so reading one module overlaps with discovering the next. The generic-method
+scan and the declaration index share one pass, the split of oversized files into generation
+fragments and the by-name struct field index are built on workers while the declaration phases
+run, and the generated C is returned as ordered pieces (per-file bodies are referenced, not copied)
+that the drivers write directly.
+
 The standalone compiler supports `self` directly and defaults that command to FastC. For example,
 `./v self x5` replaces the compiler through five descendant FastC generations, with each installed
 generation compiling the next one. `-b fastc`, `-gc none`, `-cc tinyc|tcc`, `-keepc`, `-silent`,

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -7367,13 +7367,15 @@ struct V3FastCCompileResult {
 	output  string
 }
 
-fn publish_v3_fastc_c_source(source string, output_file string, c_to_stdout bool) ! {
+fn publish_v3_fastc_c_source(pieces []string, output_file string, c_to_stdout bool) ! {
 	if c_to_stdout {
-		print(source)
+		for piece in pieces {
+			print(piece)
+		}
 		return
 	}
 	staged_output := '${output_file}.stage.${tempname.unique_token()}'
-	os.write_file(staged_output, source) or {
+	fastc.write_c_pieces(staged_output, pieces) or {
 		return error('error writing fastc output ${output_file}: ${err.msg()}')
 	}
 	os.mv(staged_output, output_file) or {
@@ -7394,7 +7396,7 @@ fn canonical_v3_fastc_output_path(path string) string {
 	return os.join_path_single(canonical_parent, os.file_name(absolute_path))
 }
 
-fn compile_v3_fastc_source(source string, bin_file string, prefs &pref.Preferences, environment_c_flags []string, source_c_flags []string, user_c_flags []string, environment_ld_flags []string, is_debug bool, uses_threads bool) V3FastCCompileResult {
+fn compile_v3_fastc_source(pieces []string, bin_file string, prefs &pref.Preferences, environment_c_flags []string, source_c_flags []string, user_c_flags []string, environment_ld_flags []string, is_debug bool, uses_threads bool) V3FastCCompileResult {
 	tcc_dir := os.join_path(prefs.vroot, 'thirdparty', 'tcc')
 	tcc_path := os.join_path_single(tcc_dir, 'tcc.exe')
 	if !os.is_executable(tcc_path) {
@@ -7408,7 +7410,7 @@ fn compile_v3_fastc_source(source string, bin_file string, prefs &pref.Preferenc
 	}
 	source_file := os.join_path_single(build_dir, 'src.c')
 	staged_binary := os.join_path_single(build_dir, 'out')
-	os.write_file(source_file, source) or { return V3FastCCompileResult{} }
+	fastc.write_c_pieces(source_file, pieces) or { return V3FastCCompileResult{} }
 	tcc_resources := v3_tcc_resource_flags(prefs.vroot)
 	mut cc_args := environment_c_flags.clone()
 	cc_args << ['-std=gnu11', tcc_resources.base_arg, tcc_resources.include_arg, tcc_resources.library_arg]
@@ -8539,11 +8541,12 @@ pub fn run(args []string) {
 					exit(1)
 				}
 			}
-			fastc_source := fastc_generation.c_source
+			fastc_pieces := fastc_generation.c_pieces
+			fastc_source_size := fastc_generation.c_size()
 			b.step('fastc parse+gen')
 			if c_only && fastc_cross_target {
-				b.metric('generated C size', fastc_source.len, 'bytes')
-				publish_v3_fastc_c_source(fastc_source, output_file, c_to_stdout) or {
+				b.metric('generated C size', fastc_source_size, 'bytes')
+				publish_v3_fastc_c_source(fastc_pieces, output_file, c_to_stdout) or {
 					eprintln(err.msg())
 					exit(1)
 				}
@@ -8559,7 +8562,7 @@ pub fn run(args []string) {
 			} else {
 				bin_file
 			}
-			fastc_result := compile_v3_fastc_source(fastc_source, fastc_bin_file, prefs,
+			fastc_result := compile_v3_fastc_source(fastc_pieces, fastc_bin_file, prefs,
 				environment_c_flags, fastc_generation.c_flags, user_c_flags, environment_ld_flags,
 				is_debug, fastc_generation.uses_threads)
 			if (!silent || show_cc) && fastc_result.command.len > 0 {
@@ -8593,9 +8596,9 @@ pub fn run(args []string) {
 				exit(1)
 			}
 			b.step('tcc')
-			b.metric('generated C size', fastc_source.len, 'bytes')
+			b.metric('generated C size', fastc_source_size, 'bytes')
 			if c_only {
-				publish_v3_fastc_c_source(fastc_source, output_file, c_to_stdout) or {
+				publish_v3_fastc_c_source(fastc_pieces, output_file, c_to_stdout) or {
 					eprintln(err.msg())
 					exit(1)
 				}
@@ -8604,14 +8607,14 @@ pub fn run(args []string) {
 				return
 			}
 			if backend_explicit {
-				os.write_file(bin_file + '.c', fastc_source) or {
+				fastc.write_c_pieces(bin_file + '.c', fastc_pieces) or {
 					eprintln('failed to retain generated fastc output ${bin_file}.c: ${err.msg()}')
 					exit(1)
 				}
 			}
 			if keep_c {
 				keep_c_file := keep_c_output_file(bin_file)
-				os.write_file(keep_c_file, fastc_source) or {
+				fastc.write_c_pieces(keep_c_file, fastc_pieces) or {
 					eprintln('failed to retain generated fastc output ${keep_c_file}: ${err.msg()}')
 					exit(1)
 				}

--- a/vlib/v3/fastcdriver/fastcdriver.v
+++ b/vlib/v3/fastcdriver/fastcdriver.v
@@ -464,11 +464,10 @@ pub fn run(args []string) {
 		eprintln('fastc-bench: files=${generation.source_paths.len} lines=${total_lines} gen=${gen_ms:.2f}ms loc/s=${loc_per_s:.0f}')
 	}
 	validate_output_source_paths(output, real_input, generation.source_paths) or { fail(err.msg()) }
-	c_source := generation.c_source
 	build_prefix := '${output}.fastc-build-${os.getpid()}'
 	c_path := build_prefix + '.c'
 	staged_output := build_prefix + '.out'
-	os.write_file(c_path, c_source) or { fail(err.msg()) }
+	fastc.write_c_pieces(c_path, generation.c_pieces) or { fail(err.msg()) }
 	tcc_dir := os.join_path(prefs.vroot, 'thirdparty', 'tcc')
 	tcc := os.join_path_single(tcc_dir, 'tcc.exe')
 	tcc_lib := os.join_path_single(tcc_dir, 'lib')

--- a/vlib/v3/gen/fastc/decl.v
+++ b/vlib/v3/gen/fastc/decl.v
@@ -516,6 +516,7 @@ fn fastc_generate_global_declarations(ordered_sources []FastcSourceFile, prefs &
 		mut gen := Parser{
 			prefs:                        unsafe { prefs }
 			unqualified_key_memo: map[string]string{}
+			c_function_name_memo: map[string]string{}
 			nonlocal_name_type_memo: map[string]string{}
 			resolved_name_memo: map[string]string{}
 			declared_type_key_memo: map[string]FastcMemoEntry{}
@@ -759,7 +760,7 @@ fn fastc_map_field_default(typ string, pointer_bits int) string {
 	return '(builtin__new_map(sizeof(${fastc_runtime_c_type(key_type)}), sizeof(${fastc_runtime_c_type(value_type)}), &${hash_fn}, &${eq_fn}, &${clone_fn}, &${free_fn}))'
 }
 
-fn fastc_render_struct_field_defaults(prefs &pref.Preferences, declared_types map[string]bool, declared_type_c_names map[string]string, fastc_prefixed_c_names []string, declared_kinds map[string]FastcDeclaredTypeKind, enum_flags map[string]bool, enum_field_types map[string]string, alias_base_types map[string]string, struct_fields map[string]map[string]string, mut struct_field_info map[string][]FastcStructField, functions map[string]FastcFunctionSignature, constants map[string]string, public_constants map[string]bool, constant_types map[string]string, globals map[string]string, public_globals map[string]bool, global_types map[string]string, sum_types map[string]bool) ! {
+fn fastc_render_struct_field_defaults(source_imports map[string]map[string]string, prefs &pref.Preferences, declared_types map[string]bool, declared_type_c_names map[string]string, fastc_prefixed_c_names []string, declared_kinds map[string]FastcDeclaredTypeKind, enum_flags map[string]bool, enum_field_types map[string]string, alias_base_types map[string]string, struct_fields map[string]map[string]string, mut struct_field_info map[string][]FastcStructField, functions map[string]FastcFunctionSignature, constants map[string]string, public_constants map[string]bool, constant_types map[string]string, globals map[string]string, public_globals map[string]bool, global_types map[string]string, sum_types map[string]bool) ! {
 	declared_type_key_by_name := fastc_declared_type_key_by_name(declared_types)
 	helper_has_c_functions := fastc_functions_declare_c(functions)
 	mut type_names := struct_field_info.keys()
@@ -801,12 +802,13 @@ fn fastc_render_struct_field_defaults(prefs &pref.Preferences, declared_types ma
 			mut gen := Parser{
 				prefs:                        unsafe { prefs }
 				unqualified_key_memo: map[string]string{}
+				c_function_name_memo: map[string]string{}
 				nonlocal_name_type_memo: map[string]string{}
 				resolved_name_memo: map[string]string{}
 				declared_type_key_memo: map[string]FastcMemoEntry{}
 				path:                         default_path
 				module_name:                  field.module_name
-				imports:                      field.imports
+				imports:                      source_imports[field.path] or { map[string]string{} }
 				declared_types:               declared_types
 				declared_type_c_names:        declared_type_c_names
 				declared_type_key_by_name:    declared_type_key_by_name
@@ -914,6 +916,7 @@ fn fastc_parse_constant_file(ctx &FastcConstantGenContext, source_file FastcSour
 	mut gen := Parser{
 		prefs:                        unsafe { prefs }
 		unqualified_key_memo: map[string]string{}
+		c_function_name_memo: map[string]string{}
 		nonlocal_name_type_memo: map[string]string{}
 		resolved_name_memo: map[string]string{}
 		declared_type_key_memo: map[string]FastcMemoEntry{}
@@ -1415,6 +1418,7 @@ fn fastc_generate_type_declarations(sources []FastcSourceFile, type_sources map[
 		out.writeln('#define __v_typeid_${primitive} ${u32(0x40000000) + u32(offset)}')
 	}
 	out.writeln('')
+	mut timer := fastc_new_phase_timer()
 	for source_file in sources {
 		if source_file.path !in type_source_paths {
 			continue
@@ -1430,6 +1434,7 @@ fn fastc_generate_type_declarations(sources []FastcSourceFile, type_sources map[
 			composite_types, mut alias_base_types, mut sum_types, mut sum_type_variants, mut
 			enum_infos, mut bodies)!
 	}
+	timer.mark('type_declarations.emit')
 	mut composite_names := composite_types.keys()
 	composite_names.sort()
 	for composite_name in composite_names {
@@ -1438,6 +1443,7 @@ fn fastc_generate_type_declarations(sources []FastcSourceFile, type_sources map[
 	}
 	out.writeln('')
 	mut type_bodies := fastc_hoist_c_type_aliases(bodies.str())
+	timer.mark('type_declarations.hoist')
 	if prefs.building_v {
 		// Index the by-value composite C spellings once. The ordering pass below
 		// queries this per struct field on every pass; the previous linear scan
@@ -1452,6 +1458,7 @@ fn fastc_generate_type_declarations(sources []FastcSourceFile, type_sources map[
 		type_bodies = fastc_order_c_composite_definitions(type_bodies, struct_fields,
 			by_value_composite_names, alias_base_types)
 	}
+	timer.mark('type_declarations.order')
 	out.write_string(type_bodies)
 	// Index each enum field name to its enum's C type, so an inferred map literal
 	// with `.field` shorthand keys (e.g. `{ .md_block_hr: 'hr' }`) can recover the
@@ -1464,9 +1471,11 @@ fn fastc_generate_type_declarations(sources []FastcSourceFile, type_sources map[
 			}
 		}
 	}
+	enum_string_helpers := fastc_generate_enum_string_helpers(enum_infos)
+	timer.mark('type_declarations.enum_helpers')
 	return FastcTypeDeclarations{
 		declarations:        out.str()
-		enum_string_helpers: fastc_generate_enum_string_helpers(enum_infos)
+		enum_string_helpers: enum_string_helpers
 		alias_base_types:    alias_base_types
 		enum_field_types:    enum_field_types
 		sum_types:           sum_types
@@ -1610,6 +1619,10 @@ fn fastc_by_value_composite_type(field_type string, by_value_composite_names map
 	mut candidate := field_type
 	if element_type := fastc_fixed_array_element_type(candidate) {
 		candidate = element_type
+	}
+	// Most field types are not aliases; answer those without the cycle guard.
+	if candidate !in alias_base_types {
+		return if candidate in by_value_composite_names { candidate } else { '' }
 	}
 	mut seen_aliases := map[string]bool{}
 	for {
@@ -1924,7 +1937,6 @@ fn fastc_emit_struct_declaration(mut scan scanner.Scanner, is_union bool, source
 				is_public:   true
 				module_name: source_file.header.module_name
 				path:        source_file.path
-				imports:     source_file.header.imports.clone()
 			}
 			embedded_id++
 			fields++
@@ -2023,7 +2035,6 @@ fn fastc_emit_struct_declaration(mut scan scanner.Scanner, is_union bool, source
 				is_optional_function:  is_optional_function
 				module_name:           source_file.header.module_name
 				path:                  source_file.path
-				imports:               source_file.header.imports.clone()
 				default_source:        default_source
 				chan_element_type:     field_chan_element
 				option_value_type:     field_option_value
@@ -2053,14 +2064,13 @@ fn fastc_emit_struct_declaration(mut scan scanner.Scanner, is_union bool, source
 			is_public:   true
 			module_name: source_file.header.module_name
 			path:        source_file.path
-			imports:     source_file.header.imports.clone()
 		}
 	}
 	if !is_c_struct {
 		out.writeln('};')
 		out.writeln('')
 	}
-	struct_fields[c_name] = fields_by_name.clone()
+	struct_fields[c_name] = fields_by_name.move()
 	struct_field_info[c_name] = field_info.clone()
 	return scan.scan()
 }

--- a/vlib/v3/gen/fastc/expr.v
+++ b/vlib/v3/gen/fastc/expr.v
@@ -216,7 +216,9 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 		}
 	}
 	mut result := strings.new_builder(64)
-	mut expression_tokens := []FastcExpressionToken{}
+	// Most expressions are a handful of tokens; start with room for them so
+	// the token buffer is not regrown several times per expression.
+	mut expression_tokens := []FastcExpressionToken{cap: 16}
 	if prefix.len > 0 {
 		result.write_string(g.resolved_expression_name(prefix, .unknown))
 		expression_tokens << FastcExpressionToken{

--- a/vlib/v3/gen/fastc/expr.v
+++ b/vlib/v3/gen/fastc/expr.v
@@ -1887,7 +1887,7 @@ fn (g &Parser) render_constant_references(tokens []FastcExpressionToken, source 
 			}
 			function_key := g.unqualified_function_key(item.lit)
 			if function_key in g.functions || function_key in g.mono_functions {
-				rendered = fastc_replace_c_call_identifier(rendered, item.lit, fastc_c_function_name_for_key(function_key))
+				rendered = fastc_replace_c_call_identifier(rendered, item.lit, g.c_function_name_for_key(function_key))
 				continue
 			}
 		}
@@ -2244,6 +2244,109 @@ fn (g &Parser) expected_call_argument_type(tokens []FastcExpressionToken) string
 	return signature.parameter_types[parameter_index]
 }
 
+// FastcTokenFlags records which token kinds an expression contains, so the
+// renderer dispatch can skip lowerings whose trigger token is absent instead
+// of letting each of them rescan the expression.
+struct FastcTokenFlags {
+	has_dot        bool
+	has_lpar       bool
+	has_lsbr       bool
+	has_lcbr       bool
+	has_logical    bool
+	has_comparison bool
+	has_binary     bool
+	has_assignment bool
+	has_not        bool
+	has_plus       bool
+}
+
+// The guarded_* wrappers below skip a lowering when the expression lacks a
+// token it necessarily acts on; each mirrors the first check of the renderer
+// it wraps.
+fn (g &Parser) guarded_overloaded_binary_expression(tokens []FastcExpressionToken, flags FastcTokenFlags) ?FastcRenderedExpression {
+	if !flags.has_binary {
+		return none
+	}
+	return g.render_overloaded_binary_expression(tokens)
+}
+
+fn (g &Parser) guarded_struct_comparison_expression(tokens []FastcExpressionToken, flags FastcTokenFlags) ?FastcRenderedExpression {
+	if !flags.has_comparison {
+		return none
+	}
+	return g.render_struct_comparison_expression(tokens)
+}
+
+fn (g &Parser) guarded_mixed_integer_comparison_expression(tokens []FastcExpressionToken, flags FastcTokenFlags) ?FastcRenderedExpression {
+	if !flags.has_comparison {
+		return none
+	}
+	return g.render_mixed_integer_comparison_expression(tokens)
+}
+
+fn (g &Parser) guarded_enum_comparison_expression(tokens []FastcExpressionToken, flags FastcTokenFlags) ?FastcRenderedExpression {
+	if !flags.has_comparison {
+		return none
+	}
+	return g.render_enum_comparison_expression(tokens)
+}
+
+fn (g &Parser) guarded_composed_string_concatenation(tokens []FastcExpressionToken, flags FastcTokenFlags) ?FastcRenderedExpression {
+	if !flags.has_plus {
+		return none
+	}
+	return g.render_composed_string_concatenation(tokens)
+}
+
+fn (g &Parser) guarded_map_expression(tokens []FastcExpressionToken, flags FastcTokenFlags) ?FastcRenderedExpression {
+	if !flags.has_lsbr && !flags.has_lcbr {
+		return none
+	}
+	return g.render_map_expression(tokens)
+}
+
+fn (g &Parser) guarded_assignment_expression(tokens []FastcExpressionToken, flags FastcTokenFlags) ?FastcRenderedExpression {
+	if !flags.has_assignment {
+		return none
+	}
+	return g.render_assignment_expression(tokens)
+}
+
+fn (g &Parser) guarded_nested_option_propagation(tokens []FastcExpressionToken, rendered_expression string, flags FastcTokenFlags) ?FastcRenderedExpression {
+	if !flags.has_not {
+		return none
+	}
+	return g.render_nested_option_propagation(tokens, rendered_expression)
+}
+
+fn (g &Parser) guarded_cast_expression(tokens []FastcExpressionToken, flags FastcTokenFlags) ?FastcRenderedExpression {
+	if !flags.has_lpar {
+		return none
+	}
+	return g.render_cast_expression(tokens)
+}
+
+fn (g &Parser) guarded_pointer_member_access_expression(tokens []FastcExpressionToken, rendered_expression string, flags FastcTokenFlags) ?FastcRenderedExpression {
+	if !flags.has_dot || !flags.has_lpar {
+		return none
+	}
+	return g.render_pointer_member_access_expression(tokens, rendered_expression)
+}
+
+fn (g &Parser) guarded_struct_literal_expression(tokens []FastcExpressionToken, flags FastcTokenFlags) ?FastcRenderedExpression {
+	if !flags.has_lcbr {
+		return none
+	}
+	return g.render_struct_literal_expression(tokens)
+}
+
+fn (g &Parser) guarded_logical_expression(tokens []FastcExpressionToken, flags FastcTokenFlags) ?FastcRenderedExpression {
+	if !flags.has_logical {
+		return none
+	}
+	return g.render_logical_expression(tokens)
+}
+
 fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered_expression string) ?FastcRenderedExpression {
 	if tokens.len == 1 {
 		if tokens[0].tok == .name {
@@ -2281,6 +2384,7 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 	mut has_as := false
 	mut has_assignment := false
 	mut has_membership := false
+	mut has_not := false
 	for item in tokens {
 		if item.tok.is_assignment() {
 			has_assignment = true
@@ -2329,8 +2433,23 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 			.key_as {
 				has_as = true
 			}
+			.not {
+				has_not = true
+			}
 			else {}
 		}
+	}
+	flags := FastcTokenFlags{
+		has_dot: has_dot
+		has_lpar: has_lpar
+		has_lsbr: has_lsbr
+		has_lcbr: has_lcbr
+		has_logical: has_logical
+		has_comparison: has_comparison
+		has_binary: has_binary
+		has_assignment: has_assignment
+		has_not: has_not
+		has_plus: has_plus
 	}
 	if has_typeof {
 		if type_name := g.render_typeof_name_expression(tokens) {
@@ -2374,15 +2493,15 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 		}
 	}
 	if has_binary {
-		if overloaded_binary := g.render_overloaded_binary_expression(tokens) {
+		if overloaded_binary := g.guarded_overloaded_binary_expression(tokens, flags) {
 			return overloaded_binary
 		}
 	}
 	if has_comparison {
-		if struct_comparison := g.render_struct_comparison_expression(tokens) {
+		if struct_comparison := g.guarded_struct_comparison_expression(tokens, flags) {
 			return struct_comparison
 		}
-		if integer_comparison := g.render_mixed_integer_comparison_expression(tokens) {
+		if integer_comparison := g.guarded_mixed_integer_comparison_expression(tokens, flags) {
 			return integer_comparison
 		}
 	}
@@ -2393,7 +2512,7 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 			}
 		}
 		if has_plus {
-			if concatenation := g.render_composed_string_concatenation(tokens) {
+			if concatenation := g.guarded_composed_string_concatenation(tokens, flags) {
 				return concatenation
 			}
 		}
@@ -2401,13 +2520,13 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 	if g.selfhost {
 		if tokens.len > 1 && tokens.last().tok == .not {
 			if has_lsbr {
-				if map_expression := g.render_map_expression(tokens) {
+				if map_expression := g.guarded_map_expression(tokens, flags) {
 					// A propagated RHS in `values[key] = load()!` must remain part of
 					// the map assignment lowering, not become a raw C subexpression.
 					return map_expression
 				}
 			}
-			if assignment := g.render_assignment_expression(tokens) {
+			if assignment := g.guarded_assignment_expression(tokens, flags) {
 				// Assignment supplies the target type to its RHS. In particular, an
 				// option-returning call propagated with `!` is unwrapped recursively and
 				// then boxed when the target itself is an Option field/local.
@@ -2428,14 +2547,14 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 			}
 		}
 		if tokens.len > 1 && tokens.last().tok == .not {
-			if nested_propagation := g.render_nested_option_propagation(tokens, rendered_expression) {
+			if nested_propagation := g.guarded_nested_option_propagation(tokens, rendered_expression, flags) {
 				return nested_propagation
 			}
 		}
 	}
 	if has_lpar {
-		if cast_expression := g.render_cast_expression(tokens) {
-			if pointer_members := g.render_pointer_member_access_expression(tokens, cast_expression.source) {
+		if cast_expression := g.guarded_cast_expression(tokens, flags) {
+			if pointer_members := g.guarded_pointer_member_access_expression(tokens, cast_expression.source, flags) {
 				return pointer_members
 			}
 			return cast_expression
@@ -2453,12 +2572,12 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 			}
 		}
 		if has_lsbr {
-			if map_expression := g.render_map_expression(tokens) {
+			if map_expression := g.guarded_map_expression(tokens, flags) {
 				return map_expression
 			}
 		}
 		if has_lcbr {
-			if struct_literal := g.render_struct_literal_expression(tokens) {
+			if struct_literal := g.guarded_struct_literal_expression(tokens, flags) {
 				return struct_literal
 			}
 			if struct_literal := g.render_struct_literal_field_names(tokens, rendered_expression) {
@@ -2476,7 +2595,7 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 					return array_assignment
 				}
 			}
-			if assignment := g.render_assignment_expression(tokens) {
+			if assignment := g.guarded_assignment_expression(tokens, flags) {
 				return assignment
 			}
 		}
@@ -2486,7 +2605,7 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 			}
 		}
 		if has_logical {
-			if logical := g.render_logical_expression(tokens) {
+			if logical := g.guarded_logical_expression(tokens, flags) {
 				return logical
 			}
 		}
@@ -2501,7 +2620,7 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 			if option_comparison := g.render_option_none_comparison(tokens) {
 				return option_comparison
 			}
-			if enum_comparison := g.render_enum_comparison_expression(tokens) {
+			if enum_comparison := g.guarded_enum_comparison_expression(tokens, flags) {
 				return enum_comparison
 			}
 			if string_comparison := g.render_string_comparison_expression(tokens) {
@@ -2509,7 +2628,7 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 			}
 		}
 		if has_plus {
-			if concatenation := g.render_composed_string_concatenation(tokens) {
+			if concatenation := g.guarded_composed_string_concatenation(tokens, flags) {
 				return concatenation
 			}
 		}

--- a/vlib/v3/gen/fastc/fastc.v
+++ b/vlib/v3/gen/fastc/fastc.v
@@ -846,7 +846,10 @@ struct FastcCDirectiveLine {
 	kind  int
 }
 
-// GenerationResult contains generated C and the complete resolved V source graph.
+// GenerationResult contains generated C and the complete resolved V source
+// graph. `c_pieces` is the generated C in output order; every piece is an
+// ordinary owned string, and writing them in sequence (write_c_pieces) or
+// joining them (c_source) yields the program.
 pub struct GenerationResult {
 pub:
 	c_pieces     []string
@@ -2026,7 +2029,11 @@ fn fastc_partition_c_directive_ranges(total_len int, lines []FastcCDirectiveLine
 }
 
 // fastc_collect_c_piece_ranges appends the ascending [start, end) `ranges` of
-// the virtual concatenation of `pieces` to `out` as views into the pieces.
+// the virtual concatenation of `pieces` to `out`. A range that covers a whole
+// piece shares that string; a range that cuts a piece is copied out, so every
+// output piece is an ordinary owned, NUL-terminated string. Only bodies that
+// contain C directive lines are cut, so the copies are a small part of the
+// output.
 fn fastc_collect_c_piece_ranges(mut out []string, pieces []string, ranges []int) {
 	mut piece_index := 0
 	mut piece_start := 0
@@ -2049,7 +2056,11 @@ fn fastc_collect_c_piece_ranges(mut out []string, pieces []string, ranges []int)
 			if local_end > piece.len {
 				local_end = piece.len
 			}
-			out << unsafe { tos(piece.str + local_start, local_end - local_start) }
+			if local_start == 0 && local_end == piece.len {
+				out << piece
+			} else {
+				out << piece.substr(local_start, local_end)
+			}
 			start = piece_start + local_end
 		}
 	}

--- a/vlib/v3/gen/fastc/fastc.v
+++ b/vlib/v3/gen/fastc/fastc.v
@@ -759,7 +759,6 @@ struct FastcStructField {
 	is_optional_function bool
 	module_name          string
 	path                 string
-	imports              map[string]string
 	default_source       string
 mut:
 	default_value string
@@ -820,6 +819,7 @@ struct FastcQueuedSource {
 }
 
 struct FastcLoadedSource {
+	path          string
 	source        string
 	header        FastcSourceHeader
 	failed        bool
@@ -849,10 +849,45 @@ struct FastcCDirectiveLine {
 // GenerationResult contains generated C and the complete resolved V source graph.
 pub struct GenerationResult {
 pub:
-	c_source     string
+	c_pieces     []string
 	source_paths []string
 	uses_threads bool
 	c_flags      []string
+}
+
+// c_source joins the generated C pieces into one string.
+pub fn (g &GenerationResult) c_source() string {
+	return fastc_join_c_pieces(g.c_pieces)
+}
+
+// c_size returns the size of the generated C in bytes.
+pub fn (g &GenerationResult) c_size() int {
+	mut size := 0
+	for piece in g.c_pieces {
+		size += piece.len
+	}
+	return size
+}
+
+// write_c_pieces writes generated C pieces to `path` without joining them.
+pub fn write_c_pieces(path string, pieces []string) ! {
+	mut file := os.create(path)!
+	for piece in pieces {
+		file.write_string(piece)!
+	}
+	file.close()
+}
+
+fn fastc_join_c_pieces(pieces []string) string {
+	mut size := 0
+	for piece in pieces {
+		size += piece.len
+	}
+	mut out := strings.new_builder(size + 1)
+	for piece in pieces {
+		out.write_string(piece)
+	}
+	return out.str()
 }
 
 struct FastcGlobalDeclarations {
@@ -995,6 +1030,7 @@ mut:
 	// tables (module, imports, functions, constants, globals, declared types)
 	// and are asked again for the same short name many times per file.
 	unqualified_key_memo     map[string]string
+	c_function_name_memo     map[string]string
 	nonlocal_name_type_memo  map[string]string
 	resolved_name_memo       map[string]string
 	declared_type_key_memo   map[string]FastcMemoEntry
@@ -1117,7 +1153,7 @@ pub fn generate(source string, path string, prefs &pref.Preferences) !string {
 // the complete source graph. Discovery and generation use scanner tokens only.
 pub fn generate_files(paths []string, prefs &pref.Preferences) !string {
 	generation := generate_files_with_source_paths(paths, prefs)!
-	return generation.c_source
+	return generation.c_source()
 }
 
 // generate_files_with_source_paths emits C and reports every source read during import discovery.
@@ -1154,10 +1190,10 @@ pub fn generate_files_with_source_paths(paths []string, prefs &pref.Preferences)
 	for source_file in sources {
 		source_paths << source_file.path
 	}
-	c_source, uses_threads, c_flags := generate_source_files(sources, module_aliases, prefs)!
+	c_pieces, uses_threads, c_flags := generate_source_pieces(sources, module_aliases, prefs)!
 	timer.mark('generate_total')
 	return GenerationResult{
-		c_source: c_source
+		c_pieces: c_pieces
 		source_paths: source_paths
 		uses_threads: uses_threads
 		c_flags: c_flags
@@ -1226,6 +1262,7 @@ fn fastc_generate_single_file(ctx &FastcFileGenContext, source_file FastcSourceF
 	mut gen := Parser{
 		prefs: unsafe { prefs }
 		unqualified_key_memo: map[string]string{}
+		c_function_name_memo: map[string]string{}
 		nonlocal_name_type_memo: map[string]string{}
 		resolved_name_memo: map[string]string{}
 		declared_type_key_memo: map[string]FastcMemoEntry{}
@@ -1312,14 +1349,22 @@ fn fastc_generate_single_file(ctx &FastcFileGenContext, source_file FastcSourceF
 	}
 }
 
+// generate_source_files emits the program as one C string; tests and the
+// single-source API use it. The driver takes the pieces directly.
 fn generate_source_files(input_sources []FastcSourceFile, module_aliases map[string]string, prefs &pref.Preferences) !(string, bool, []string) {
+	pieces, uses_threads, c_flags := generate_source_pieces(input_sources, module_aliases, prefs)!
+	return fastc_join_c_pieces(pieces), uses_threads, c_flags
+}
+
+// generate_source_pieces emits the program as C pieces in output order; the
+// per-file bodies are referenced, not copied, so the multi-megabyte output is
+// never assembled into one buffer here.
+fn generate_source_pieces(input_sources []FastcSourceFile, module_aliases map[string]string, prefs &pref.Preferences) !([]string, bool, []string) {
 	// Source-level generic monomorphization runs first; it is a no-op when the
 	// program has no generic function definitions (so the self-host is untouched).
 	mut timer := fastc_new_phase_timer()
 	mut sources := fastc_monomorphize_sources(input_sources, prefs)!
 	timer.mark('monomorphize')
-	generic_method_sources := fastc_collect_generic_method_sources(mut sources, prefs)
-	timer.mark('generic_method_sources')
 	mut declared_types := map[string]bool{}
 	mut declared_kinds := map[string]FastcDeclaredTypeKind{}
 	mut enum_flags := map[string]bool{}
@@ -1333,8 +1378,11 @@ fn generate_source_files(input_sources []FastcSourceFile, module_aliases map[str
 	mut type_source_paths := map[string]bool{}
 	mut type_sources := map[string]string{}
 	mut constant_sources := map[string]string{}
-	fastc_collect_declaration_indexes(sources, prefs, mut declared_types, mut declared_kinds, mut enum_flags, mut params_structs, mut type_source_paths, mut type_sources, mut constants, mut public_constants, mut constant_sources, mut globals, mut public_globals)!
+	generic_method_sources := fastc_collect_generic_and_declaration_indexes(mut sources, prefs, mut declared_types, mut declared_kinds, mut enum_flags, mut params_structs, mut type_source_paths, mut type_sources, mut constants, mut public_constants, mut constant_sources, mut globals, mut public_globals)!
 	timer.mark('declaration_indexes')
+	// The sources are final now; split the oversized ones for parallel
+	// generation while the declaration phases run.
+	mut pending_fragments := fastc_start_generation_fragments(sources, prefs)
 	declared_type_c_names := fastc_declared_type_c_names(declared_types)
 	declared_type_key_by_name := fastc_declared_type_key_by_name(declared_types)
 	mut functions := map[string]FastcFunctionSignature{}
@@ -1378,8 +1426,15 @@ fn generate_source_files(input_sources []FastcSourceFile, module_aliases map[str
 	enum_field_types := type_output.enum_field_types.clone()
 	mut constant_types := map[string]string{}
 	mut global_types := map[string]string{}
-	fastc_render_struct_field_defaults(prefs, declared_types, declared_type_c_names, fastc_prefixed_c_names, declared_kinds, enum_flags, enum_field_types, type_output.alias_base_types, struct_fields, mut struct_field_info, functions, constants, public_constants, constant_types, globals, public_globals, global_types, type_output.sum_types)!
+	mut source_imports := map[string]map[string]string{}
+	for source_file in sources {
+		source_imports[source_file.path] = source_file.header.imports.clone()
+	}
+	fastc_render_struct_field_defaults(source_imports, prefs, declared_types, declared_type_c_names, fastc_prefixed_c_names, declared_kinds, enum_flags, enum_field_types, type_output.alias_base_types, struct_fields, mut struct_field_info, functions, constants, public_constants, constant_types, globals, public_globals, global_types, type_output.sum_types)!
 	timer.mark('field_defaults')
+	// The field lists are final; index them by name for generation while the
+	// constant and global phases run.
+	mut pending_field_lookup := fastc_start_struct_field_lookup(struct_field_info, prefs)
 	constant_output := fastc_generate_constant_declarations(ordered_sources, constant_sources, prefs, declared_types, declared_type_c_names, fastc_prefixed_c_names, declared_kinds, enum_flags, enum_field_types, type_output.alias_base_types, struct_fields, struct_field_info, functions, constants, public_constants, globals, public_globals, mut constant_types)!
 	timer.mark('constant_declarations')
 	for name, _ in constant_output.composite_types {
@@ -1401,16 +1456,13 @@ fn generate_source_files(input_sources []FastcSourceFile, module_aliases map[str
 	used_function_names := fastc_wait_referenced_function_names(mut pending_references)
 	timer.mark('wait_references')
 	mut pending_interface_dispatches := fastc_start_interface_dispatches(declared_kinds, functions, interface_methods, used_function_names, prefs.building_v, prefs)
-	mut struct_field_lookup := map[string]map[string]FastcStructField{}
-	for layout_type, fields in struct_field_info {
-		mut fields_by_name := map[string]FastcStructField{}
-		for field in fields {
-			fields_by_name[field.name] = field
-		}
-		struct_field_lookup[layout_type] = fields_by_name.move()
-	}
+	struct_field_lookup := fastc_wait_struct_field_lookup(mut pending_field_lookup)
 	mut prototypes := strings.new_builder(1024)
-	mut body := strings.new_builder(4096)
+	// The per-file bodies are stitched by reference: the directive partition
+	// works on their virtual concatenation and the final assembly copies each
+	// range straight from the pieces, so the multi-megabyte body is copied once.
+	mut body_pieces := []string{cap: sources.len + 16}
+	mut body_len := 0
 	mut body_directive_lines := []FastcCDirectiveLine{}
 	mut fixed_array_types := constant_output.fixed_array_types.clone()
 	for name, array_type in global_output.fixed_array_types {
@@ -1461,26 +1513,26 @@ fn generate_source_files(input_sources []FastcSourceFile, module_aliases map[str
 	mut spawn_helpers := map[string]string{}
 	mut mono_definitions := map[string]string{}
 	mut c_flags := []string{}
-	outputs := fastc_generate_file_outputs(&ctx, sources)
+	generation_sources := fastc_wait_generation_fragments(mut pending_fragments)
+	timer.mark('wait_fragments')
+	outputs := fastc_generate_file_outputs(&ctx, generation_sources)
 	timer.mark('file_outputs')
 	// Size the stitch buffers up front: the per-file bodies add up to several
 	// megabytes, and growing the builders by doubling would copy that text
 	// several times over.
 	mut prototypes_size := 0
-	mut body_size := 0
 	for output in outputs {
 		prototypes_size += output.prototypes.len
-		body_size += output.body.len
 	}
 	prototypes.ensure_cap(prototypes_size + 1024)
-	body.ensure_cap(body_size + 4096)
 	for output in outputs {
 		if output.failed {
 			return error(output.error_message)
 		}
 		prototypes.write_string(output.prototypes)
-		body_offset := body.len
-		body.write_string(output.body)
+		body_offset := body_len
+		body_pieces << output.body
+		body_len += output.body.len
 		for line in output.directive_lines {
 			body_directive_lines << FastcCDirectiveLine{
 				start: body_offset + line.start
@@ -1516,7 +1568,9 @@ fn generate_source_files(input_sources []FastcSourceFile, module_aliases map[str
 	mono_names.sort()
 	timer.mark('stitch')
 	for mono_name in mono_names {
-		body.write_string(mono_definitions[mono_name])
+		mono_definition := mono_definitions[mono_name]
+		body_pieces << mono_definition
+		body_len += mono_definition.len
 	}
 	synthesized_main := if has_entry_module && !entry_has_main {
 		fastc_synthesized_main(prefs.building_v, startup_initializers.len > 0, module_cleanup_calls.len > 0)
@@ -1548,88 +1602,113 @@ fn generate_source_files(input_sources []FastcSourceFile, module_aliases map[str
 	timer.mark('wait_interface_dispatches')
 	fixed_array_declarations := fastc_generate_fixed_array_declarations(fixed_array_types)
 	preamble := if prefs.building_v { c_selfhost_preamble } else { c_preamble }
-	hoisted_body := fastc_partition_c_directive_lines(body.str(), body_directive_lines)
+	hoisted_body := fastc_partition_c_directive_ranges(body_len, body_directive_lines)
 	timer.mark('partition_directives')
-	mut result := strings.new_builder(preamble.len + c_integer_comparison_helpers.len + type_declarations.len + type_output.enum_string_helpers.len + constant_output.macros.len + constant_output.declarations.len + global_output.declarations.len + prototypes.len + body.len + startup_initializers.len + 96)
-	result.write_string(preamble)
-	result.write_string(c_integer_comparison_helpers)
-	fastc_write_c_source_ranges(mut result, hoisted_body.source, hoisted_body.directive_ranges)
+	mut pieces := []string{cap: 64 + body_pieces.len * 3}
+	pieces << preamble
+	pieces << c_integer_comparison_helpers
+	fastc_collect_c_piece_ranges(mut pieces, body_pieces, hoisted_body.directive_ranges)
+	timer.mark('assemble.directives')
 	if hoisted_body.final_kind == 1 {
-		result.write_u8(`\n`)
+		pieces << '\n'
 	}
 	if hoisted_body.directive_ranges.len > 0 {
-		result.writeln('')
+		pieces << '\n'
 	}
 	if prefs.building_v {
-		result.write_string(c_selfhost_post_directives)
+		pieces << c_selfhost_post_directives
 	}
 	if spawn_typedefs.len > 0 {
-		result.write_string(c_spawn_runtime)
-		result.writeln('')
+		pieces << c_spawn_runtime
+		pieces << '\n'
 	}
-	result.write_string(constant_output.macros)
-	result.write_string(type_declarations)
-	result.write_string(late_composite_declarations.str())
-	result.write_string(fixed_array_declarations)
+	pieces << constant_output.macros
+	pieces << type_declarations
+	pieces << late_composite_declarations.str()
+	pieces << fixed_array_declarations
 	if spawn_typedefs.len > 0 {
 		mut thread_type_names := spawn_typedefs.keys()
 		thread_type_names.sort()
 		for thread_type_name in thread_type_names {
-			result.writeln(spawn_typedefs[thread_type_name])
+			pieces << spawn_typedefs[thread_type_name]
+			pieces << '\n'
 		}
-		result.writeln('')
+		pieces << '\n'
 	}
-	result.write_string(constant_output.declarations)
-	result.write_string(global_output.declarations)
-	result.write_string(prototypes.str())
+	pieces << constant_output.declarations
+	pieces << global_output.declarations
+	pieces << prototypes.str()
 	if startup_initializers.len > 0 {
-		result.writeln('static void v_fastc_init_globals(void);')
+		pieces << 'static void v_fastc_init_globals(void);'
+		pieces << '\n'
 	}
 	if module_cleanup_calls.len > 0 {
-		result.writeln('static void v_fastc_cleanup_modules(void);')
+		pieces << 'static void v_fastc_cleanup_modules(void);'
+		pieces << '\n'
 	}
-	result.writeln('')
+	pieces << '\n'
 	if prefs.building_v {
-		result.write_string(c_selfhost_runtime)
+		pieces << c_selfhost_runtime
 	}
-	result.write_string(type_output.enum_string_helpers)
+	pieces << type_output.enum_string_helpers
 	if spawn_helpers.len > 0 {
 		mut spawn_helper_names := spawn_helpers.keys()
 		spawn_helper_names.sort()
 		for spawn_helper_name in spawn_helper_names {
-			result.writeln(spawn_helpers[spawn_helper_name])
-			result.writeln('')
+			pieces << spawn_helpers[spawn_helper_name]
+			pieces << '\n'
+			pieces << '\n'
 		}
 	}
-	result.write_string(interface_dispatches)
+	pieces << interface_dispatches
 	if startup_initializers.len > 0 {
-		result.writeln('static void v_fastc_init_globals(void) {')
-		result.write_string(startup_initializers)
-		result.writeln('}')
-		result.writeln('')
+		pieces << 'static void v_fastc_init_globals(void) {'
+		pieces << '\n'
+		pieces << startup_initializers
+		pieces << '}'
+		pieces << '\n'
+		pieces << '\n'
 	}
 	if module_cleanup_calls.len > 0 {
-		result.writeln('static void v_fastc_cleanup_modules(void) {')
+		pieces << 'static void v_fastc_cleanup_modules(void) {'
+		pieces << '\n'
 		for cleanup_call in module_cleanup_calls {
-			result.writeln('\t${cleanup_call}();')
+			pieces << '\t${cleanup_call}();'
+			pieces << '\n'
 		}
-		result.writeln('}')
-		result.writeln('')
+		pieces << '}'
+		pieces << '\n'
+		pieces << '\n'
 	}
-	result.write_string(synthesized_main)
-	fastc_write_c_source_ranges(mut result, hoisted_body.source, hoisted_body.conditional_ranges)
+	pieces << synthesized_main
+	timer.mark('assemble.head')
+	fastc_collect_c_piece_ranges(mut pieces, body_pieces, hoisted_body.conditional_ranges)
+	timer.mark('assemble.conditional')
 	if hoisted_body.final_kind == 2 {
-		result.write_u8(`\n`)
+		pieces << '\n'
 	}
 	if hoisted_body.conditional_ranges.len > 0 {
-		result.writeln('')
+		pieces << '\n'
 	}
-	fastc_write_c_source_ranges(mut result, hoisted_body.source, hoisted_body.body_ranges)
+	fastc_collect_c_piece_ranges(mut pieces, body_pieces, hoisted_body.body_ranges)
 	if hoisted_body.final_kind == 0 {
-		result.write_u8(`\n`)
+		pieces << '\n'
 	}
 	timer.mark('assemble')
-	return result.str(), spawn_typedefs.len > 0, c_flags
+	return pieces, spawn_typedefs.len > 0, c_flags
+}
+
+// fastc_build_struct_field_lookup indexes every struct's fields by name.
+fn fastc_build_struct_field_lookup(struct_field_info map[string][]FastcStructField) map[string]map[string]FastcStructField {
+	mut struct_field_lookup := map[string]map[string]FastcStructField{}
+	for layout_type, fields in struct_field_info {
+		mut fields_by_name := map[string]FastcStructField{}
+		for field in fields {
+			fields_by_name[field.name] = field
+		}
+		struct_field_lookup[layout_type] = fields_by_name.move()
+	}
+	return struct_field_lookup
 }
 
 fn fastc_synthesized_main(selfhost bool, has_startup_inits bool, has_cleanup_hooks bool) string {
@@ -1901,6 +1980,79 @@ fn fastc_scan_c_directive_lines(source string) []FastcCDirectiveLine {
 		line_start = line_end + 1
 	}
 	return lines
+}
+
+// fastc_partition_c_directive_ranges partitions a body of `total_len` bytes,
+// known only through its directive lines, into directive, conditional and
+// plain ranges (see fastc_partition_c_directive_lines).
+fn fastc_partition_c_directive_ranges(total_len int, lines []FastcCDirectiveLine) FastcPartitionedCSource {
+	mut directive_ranges := []int{cap: lines.len * 2}
+	mut conditional_ranges := []int{cap: lines.len * 2}
+	mut body_ranges := []int{cap: lines.len * 2 + 2}
+	mut conditional_depth := 0
+	mut cursor := 0
+	mut final_kind := 0
+	for line in lines {
+		if cursor < line.start {
+			final_kind = if conditional_depth > 0 { 2 } else { 0 }
+			fastc_append_c_source_range(cursor, line.start, final_kind, mut directive_ranges, mut conditional_ranges, mut body_ranges)
+		}
+		if conditional_depth > 0 {
+			final_kind = 2
+			if line.kind == 2 {
+				conditional_depth++
+			} else if line.kind == 3 {
+				conditional_depth--
+			}
+		} else if line.kind == 2 {
+			final_kind = 2
+			conditional_depth = 1
+		} else {
+			final_kind = 1
+		}
+		fastc_append_c_source_range(line.start, line.end, final_kind, mut directive_ranges, mut conditional_ranges, mut body_ranges)
+		cursor = line.end
+	}
+	if cursor < total_len {
+		final_kind = if conditional_depth > 0 { 2 } else { 0 }
+		fastc_append_c_source_range(cursor, total_len, final_kind, mut directive_ranges, mut conditional_ranges, mut body_ranges)
+	}
+	return FastcPartitionedCSource{
+		directive_ranges: directive_ranges
+		conditional_ranges: conditional_ranges
+		body_ranges: body_ranges
+		final_kind: final_kind
+	}
+}
+
+// fastc_collect_c_piece_ranges appends the ascending [start, end) `ranges` of
+// the virtual concatenation of `pieces` to `out` as views into the pieces.
+fn fastc_collect_c_piece_ranges(mut out []string, pieces []string, ranges []int) {
+	mut piece_index := 0
+	mut piece_start := 0
+	mut range_index := 0
+	for range_index + 1 < ranges.len {
+		mut start := ranges[range_index]
+		end := ranges[range_index + 1]
+		range_index += 2
+		for start < end {
+			for piece_index < pieces.len && piece_start + pieces[piece_index].len <= start {
+				piece_start += pieces[piece_index].len
+				piece_index++
+			}
+			if piece_index >= pieces.len {
+				return
+			}
+			piece := pieces[piece_index]
+			local_start := start - piece_start
+			mut local_end := end - piece_start
+			if local_end > piece.len {
+				local_end = piece.len
+			}
+			out << unsafe { tos(piece.str + local_start, local_end - local_start) }
+			start = piece_start + local_end
+		}
+	}
 }
 
 fn fastc_partition_c_directive_lines(source string, lines []FastcCDirectiveLine) FastcPartitionedCSource {

--- a/vlib/v3/gen/fastc/fn.v
+++ b/vlib/v3/gen/fastc/fn.v
@@ -41,7 +41,7 @@ fn (mut g Parser) drain_pending_mono() ! {
 		if definition != '' {
 			mono_name := fastc_monomorphized_name(src.name, req.concrete)
 			c_name := if src.receiver_type == '' {
-				fastc_c_function_name_for_key(fastc_function_key(src.module_name, mono_name))
+				g.c_function_name_for_key(fastc_function_key(src.module_name, mono_name))
 			} else {
 				fastc_method_c_name(src.module_name, src.receiver_type, mono_name)
 			}

--- a/vlib/v3/gen/fastc/monomorphize.v
+++ b/vlib/v3/gen/fastc/monomorphize.v
@@ -64,35 +64,41 @@ fn fastc_collect_generic_method_source_chunk(sources []FastcSourceFile, prefs &p
 		if !file_flags.has_generic_fn_syntax {
 			continue
 		}
-		module_name := source_file.header.module_name
-		for generic in fastc_scan_generic_fns(source_file.source, source_file.path, prefs, i) {
-			receiver_type := if generic.receiver_type != '' {
-				fastc_c_declared_type_name(fastc_type_key(module_name, generic.receiver_type))
-			} else {
-				''
-			}
-			key := if receiver_type != '' {
-				'${receiver_type}.${generic.name}'
-			} else {
-				fastc_function_key(module_name, generic.name)
-			}
-			result[key] = FastcGenericMethodSource{
-				name: generic.name
-				type_param: generic.type_param
-				receiver_type: receiver_type
-				module_name: module_name
-				path: source_file.path
-				imports: source_file.header.imports
-				return_type_source: generic.return_type_source
-				first_param_is_type_param: generic.first_param_is_type_param
-				type_param_parameter_index: generic.type_param_parameter_index
-				source: source_file.source[generic.fn_start..generic.def_end]
-			}
-		}
+		fastc_collect_generic_methods_in_file(source_file, prefs, i, mut result)
 	}
 	return FastcGenericScanPartial{
 		sources: result
 		flags: flags
+	}
+}
+
+// fastc_collect_generic_methods_in_file indexes the generic methods and free
+// functions of one file whose scan flags reported generic syntax.
+fn fastc_collect_generic_methods_in_file(source_file FastcSourceFile, prefs &pref.Preferences, i int, mut result map[string]FastcGenericMethodSource) {
+	module_name := source_file.header.module_name
+	for generic in fastc_scan_generic_fns(source_file.source, source_file.path, prefs, i) {
+		receiver_type := if generic.receiver_type != '' {
+			fastc_c_declared_type_name(fastc_type_key(module_name, generic.receiver_type))
+		} else {
+			''
+		}
+		key := if receiver_type != '' {
+			'${receiver_type}.${generic.name}'
+		} else {
+			fastc_function_key(module_name, generic.name)
+		}
+		result[key] = FastcGenericMethodSource{
+			name: generic.name
+			type_param: generic.type_param
+			receiver_type: receiver_type
+			module_name: module_name
+			path: source_file.path
+			imports: source_file.header.imports
+			return_type_source: generic.return_type_source
+			first_param_is_type_param: generic.first_param_is_type_param
+			type_param_parameter_index: generic.type_param_parameter_index
+			source: source_file.source[generic.fn_start..generic.def_end]
+		}
 	}
 }
 

--- a/vlib/v3/gen/fastc/names.v
+++ b/vlib/v3/gen/fastc/names.v
@@ -97,6 +97,20 @@ fn (g &Parser) unqualified_function_key(name string) string {
 	return key
 }
 
+// c_function_name_for_key memoizes fastc_c_function_name_for_key, which
+// sanitizes its key twice and is asked for the same keys at every call
+// site. The mapping does not depend on the parser's context, so the memo
+// is never reset.
+fn (g &Parser) c_function_name_for_key(key string) string {
+	if cached := g.c_function_name_memo[key] {
+		return cached
+	}
+	c_name := fastc_c_function_name_for_key(key)
+	mut w := unsafe { &Parser(g) }
+	w.c_function_name_memo[key] = c_name
+	return c_name
+}
+
 fn fastc_c_function_name_for_key(key string) string {
 	if key.starts_with('C.') {
 		return naming.c_name(key)

--- a/vlib/v3/gen/fastc/parallel_d_v3_no_parallel.v
+++ b/vlib/v3/gen/fastc/parallel_d_v3_no_parallel.v
@@ -30,19 +30,55 @@ fn fastc_wait_interface_dispatches(mut pending FastcPendingInterfaceDispatches) 
 	return pending.dispatches
 }
 
-fn fastc_load_source_headers(paths []string, prefs &pref.Preferences) []FastcLoadedSource {
-	mut loaded := []FastcLoadedSource{cap: paths.len}
-	for path in paths {
-		loaded << fastc_load_source(path, prefs)
-	}
-	return loaded
+// fastc_preload_sources is a no-op without threads: the ordering walk loads
+// each file itself.
+fn fastc_preload_sources(queue []FastcQueuedSource, prefs &pref.Preferences, canonical_vlib string, mut module_path_cache map[string]string, mut module_dir_files map[string][]string, mut real_path_cache map[string]string) map[string]FastcLoadedSource {
+	return map[string]FastcLoadedSource{}
 }
 
 // A `-no-parallel` (v3_no_parallel) FastC build omits threaded generation
 // entirely, mirroring the AST pipeline's _d_v3_no_parallel variants: both
 // phases run serially and no spawn helpers are referenced.
-fn fastc_collect_generic_method_sources(sources []FastcSourceFile, prefs &pref.Preferences) map[string]FastcGenericMethodSource {
-	return fastc_collect_generic_method_source_chunk(sources, prefs, 0, sources.len)
+fn fastc_collect_generic_method_sources(mut sources []FastcSourceFile, prefs &pref.Preferences) map[string]FastcGenericMethodSource {
+	partial := fastc_collect_generic_method_source_chunk(sources, prefs, 0, sources.len)
+	fastc_apply_scan_flags(mut sources, partial.flags, 0)
+	return partial.sources
+}
+
+fn fastc_collect_generic_and_declaration_indexes(mut sources []FastcSourceFile, prefs &pref.Preferences, mut declared_types map[string]bool, mut declared_kinds map[string]FastcDeclaredTypeKind, mut enum_flags map[string]bool, mut params_structs map[string]bool, mut type_source_paths map[string]bool, mut type_sources map[string]string, mut constants map[string]string, mut public_constants map[string]bool, mut constant_sources map[string]string, mut globals map[string]string, mut public_globals map[string]bool) !map[string]FastcGenericMethodSource {
+	generic_method_sources := fastc_collect_generic_method_sources(mut sources, prefs)
+	fastc_collect_declaration_indexes(sources, prefs, mut declared_types, mut declared_kinds, mut enum_flags, mut params_structs, mut type_source_paths, mut type_sources, mut constants, mut public_constants, mut constant_sources, mut globals, mut public_globals)!
+	return generic_method_sources
+}
+
+struct FastcPendingFieldLookup {
+mut:
+	lookup map[string]map[string]FastcStructField
+}
+
+fn fastc_start_struct_field_lookup(struct_field_info map[string][]FastcStructField, prefs &pref.Preferences) FastcPendingFieldLookup {
+	return FastcPendingFieldLookup{
+		lookup: fastc_build_struct_field_lookup(struct_field_info)
+	}
+}
+
+fn fastc_wait_struct_field_lookup(mut pending FastcPendingFieldLookup) map[string]map[string]FastcStructField {
+	return pending.lookup
+}
+
+struct FastcPendingFragments {
+mut:
+	fragments []FastcSourceFile
+}
+
+fn fastc_start_generation_fragments(sources []FastcSourceFile, prefs &pref.Preferences) FastcPendingFragments {
+	return FastcPendingFragments{
+		fragments: sources
+	}
+}
+
+fn fastc_wait_generation_fragments(mut pending FastcPendingFragments) []FastcSourceFile {
+	return pending.fragments
 }
 
 fn fastc_generate_file_outputs(ctx &FastcFileGenContext, sources []FastcSourceFile) []FastcFileGenOutput {

--- a/vlib/v3/gen/fastc/parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/fastc/parallel_notd_v3_no_parallel.v
@@ -93,27 +93,177 @@ fn fastc_load_source_chunk(paths []string, prefs &pref.Preferences, start int, e
 	return loaded
 }
 
-fn fastc_load_source_headers(paths []string, prefs &pref.Preferences) []FastcLoadedSource {
-	jobs := fastc_parallel_job_count(paths.len, prefs)
-	if jobs <= 1 {
-		return fastc_load_source_chunk(paths, prefs, 0, paths.len)
+// FastcModuleListing is one module directory listed on a worker thread, with
+// the reads of its files already started in chunks of
+// fastc_source_load_chunk_size: chunk i covers files[i*chunk .. (i+1)*chunk].
+struct FastcModuleListing {
+	dir    string
+	files  []string
+	chunks []thread []FastcLoadedSource
+}
+
+// fastc_start_module_load lists `dir` (or takes `listed` when `dir` is empty)
+// and starts a reader thread per chunk of its files, so the listing thread
+// returns as soon as the reads are under way.
+fn fastc_start_module_load(dir string, listed []string, prefs &pref.Preferences) FastcModuleListing {
+	files := if dir == '' { listed } else { fastc_list_module_sources(dir, prefs) }
+	if files.len == 0 {
+		return FastcModuleListing{
+			dir: dir
+			files: files
+		}
 	}
-	first_end := paths.len / jobs
-	second_start := paths.len / jobs
-	second_end := paths.len * 2 / jobs
-	second_thread := spawn fastc_load_source_chunk(paths, prefs, second_start, second_end)
-	mut chunk_threads := [second_thread]
-	for chunk_idx in 2 .. jobs {
-		start := paths.len * chunk_idx / jobs
-		end := paths.len * (chunk_idx + 1) / jobs
-		chunk_threads << spawn fastc_load_source_chunk(paths, prefs, start, end)
+	mut first_end := fastc_source_load_chunk_size
+	if first_end > files.len {
+		first_end = files.len
 	}
-	mut loaded := []FastcLoadedSource{cap: paths.len}
-	loaded << fastc_load_source_chunk(paths, prefs, 0, first_end)
-	for chunk_thread in chunk_threads {
-		loaded << chunk_thread.wait()
+	mut chunks := [
+		spawn fastc_load_source_chunk(files, prefs, 0, first_end),
+	]
+	mut start := first_end
+	for start < files.len {
+		mut end := start + fastc_source_load_chunk_size
+		if end > files.len {
+			end = files.len
+		}
+		chunks << spawn fastc_load_source_chunk(files, prefs, start, end)
+		start = end
+	}
+	return FastcModuleListing{
+		dir: dir
+		files: files
+		chunks: chunks
+	}
+}
+
+// fastc_preload_sources reads and header-scans every file reachable from the
+// initial queue on worker threads. Each imported module directory is listed on
+// a thread that starts the reads of its files in chunks; the main thread joins
+// listings first (they finish quickly and unlock more reads) and then the read
+// chunks in start order, resolving the imports of each chunk as it lands, so
+// the reads of one module overlap with the discovery of the next. The entry
+// files go first because their import chain is the deepest. The result is
+// keyed by path, so the ordering walk that follows can use any traversal
+// order; failures are kept so the walk reports them at the same point it
+// would have. The listings are recorded in `module_dir_files` for that walk.
+fn fastc_preload_sources(queue []FastcQueuedSource, prefs &pref.Preferences, canonical_vlib string, mut module_path_cache map[string]string, mut module_dir_files map[string][]string, mut real_path_cache map[string]string) map[string]FastcLoadedSource {
+	mut loaded := map[string]FastcLoadedSource{}
+	// The queue starts with a few entry files; the count that matters for the
+	// parallel decision is the chunk size the loads are split into.
+	if fastc_parallel_job_count(fastc_source_load_chunk_size, prefs) <= 1 {
+		return loaded
+	}
+	mut scheduled := map[string]bool{}
+	mut scheduled_dirs := map[string]bool{}
+	mut entry_paths := []string{}
+	mut other_paths := []string{}
+	for queued in queue {
+		mut path := queued.path
+		if !queued.is_canonical {
+			if cached := real_path_cache[path] {
+				path = cached
+			} else {
+				path = os.real_path(path)
+				real_path_cache[queued.path] = path
+			}
+		}
+		if scheduled[path] {
+			continue
+		}
+		if !queued.listed && !os.is_file(path) {
+			continue
+		}
+		scheduled[path] = true
+		if queued.module_name == '' {
+			entry_paths << path
+		} else {
+			other_paths << path
+		}
+	}
+	mut initial_paths := entry_paths.clone()
+	initial_paths << other_paths
+	if initial_paths.len == 0 {
+		return loaded
+	}
+	mut listings := [
+		spawn fastc_start_module_load('', initial_paths, prefs),
+	]
+	wait_sw := time.new_stopwatch()
+	mut wait_us := i64(0)
+	entry_listing := listings[0].wait()
+	wait_us += wait_sw.elapsed().microseconds()
+	mut chunk_threads := entry_listing.chunks.clone()
+	mut chunk_paths := [][]string{}
+	fastc_record_listing_chunks(entry_listing, mut chunk_paths)
+	mut next_listing := 1
+	mut next_chunk := 0
+	for next_listing < listings.len || next_chunk < chunk_threads.len {
+		if next_listing < listings.len {
+			listing_start := wait_sw.elapsed().microseconds()
+			listing := listings[next_listing].wait()
+			wait_us += wait_sw.elapsed().microseconds() - listing_start
+			next_listing++
+			if listing.dir != '' {
+				module_dir_files[listing.dir] = listing.files
+			}
+			for chunk in listing.chunks {
+				chunk_threads << chunk
+			}
+			fastc_record_listing_chunks(listing, mut chunk_paths)
+			continue
+		}
+		chunk_start := wait_sw.elapsed().microseconds()
+		chunk := chunk_threads[next_chunk].wait()
+		wait_us += wait_sw.elapsed().microseconds() - chunk_start
+		paths := chunk_paths[next_chunk]
+		next_chunk++
+		for i, loaded_source in chunk {
+			mut path := paths[i]
+			if !prefs.building_v {
+				if cached := real_path_cache[path] {
+					path = cached
+				} else {
+					real := os.real_path(path)
+					real_path_cache[path] = real
+					path = real
+				}
+			}
+			if path in loaded {
+				continue
+			}
+			loaded[path] = loaded_source
+			if loaded_source.failed {
+				continue
+			}
+			for imported_module in fastc_header_imported_modules(loaded_source.header) {
+				module_cache_key := fastc_module_cache_key(prefs, path, imported_module)
+				module_dir := fastc_resolve_module_dir(module_cache_key, imported_module, path, prefs, canonical_vlib, mut module_path_cache)
+				if module_dir == '' || scheduled_dirs[module_dir] {
+					continue
+				}
+				scheduled_dirs[module_dir] = true
+				listings << spawn fastc_start_module_load(module_dir, []string{}, prefs)
+			}
+		}
+	}
+	if os.getenv('FASTC_BENCH_PHASES') != '' {
+		eprintln('fastc-phase resolve.preload.detail listings=${listings.len} chunks=${chunk_threads.len} wait_us=${wait_us}')
 	}
 	return loaded
+}
+
+// fastc_record_listing_chunks appends the path slice of each read chunk of
+// `listing`, in chunk order, to `chunk_paths`.
+fn fastc_record_listing_chunks(listing FastcModuleListing, mut chunk_paths [][]string) {
+	mut start := 0
+	for _ in listing.chunks {
+		mut end := start + fastc_source_load_chunk_size
+		if end > listing.files.len {
+			end = listing.files.len
+		}
+		chunk_paths << listing.files[start..end]
+		start = end
+	}
 }
 
 // fastc_chunk_bounds splits the file list into contiguous chunks balanced by
@@ -175,16 +325,97 @@ fn fastc_collect_generic_method_sources(mut sources []FastcSourceFile, prefs &pr
 	return result
 }
 
-fn fastc_apply_scan_flags(mut sources []FastcSourceFile, flags []FastcSourceScanFlags, start int) {
-	for i, file_flags in flags {
-		source_file := sources[start + i]
-		sources[start + i] = FastcSourceFile{
+// FastcIndexedIndexPartial is one file's scan flags, generic method index and
+// declaration index, produced together by a worker of the combined pass.
+struct FastcIndexedIndexPartial {
+	index    int
+	flags    FastcSourceScanFlags
+	generics map[string]FastcGenericMethodSource
+	partial  FastcDeclarationPartial
+}
+
+// fastc_collect_index_worker scans one file at a time from the shared counter
+// (largest files first) for its declaration flags, generic methods and
+// declared names; the caller applies the results in file order.
+fn fastc_collect_index_worker(sources []FastcSourceFile, prefs &pref.Preferences, order []int, queue &FastcGenQueue) []FastcIndexedIndexPartial {
+	mut partials := []FastcIndexedIndexPartial{}
+	for {
+		slot := fastc_atomic_fetch_add_u32(&queue.next, 1)
+		if slot >= u32(order.len) {
+			break
+		}
+		index := order[slot]
+		source_file := sources[index]
+		file_flags := fastc_source_scan_flags(source_file.source)
+		mut generics := map[string]FastcGenericMethodSource{}
+		if file_flags.has_generic_fn_syntax {
+			fastc_collect_generic_methods_in_file(source_file, prefs, index, mut generics)
+		}
+		flagged := [
+			FastcSourceFile{
+				path: source_file.path
+				source: source_file.source
+				source_offset: source_file.source_offset
+				header: fastc_header_with_scan_flags(source_file.header, file_flags)
+			},
+		]
+		partials << FastcIndexedIndexPartial{
+			index: index
+			flags: file_flags
+			generics: generics
+			partial: fastc_collect_declaration_chunk(flagged, prefs, 0, 1)
+		}
+	}
+	return partials
+}
+
+// fastc_collect_generic_and_declaration_indexes runs the generic method scan
+// and the declaration index in one parallel pass over the files: each file is
+// visited once, and there is a single spawn/join round. The results are
+// applied in file order, so they match the two serial scans.
+fn fastc_collect_generic_and_declaration_indexes(mut sources []FastcSourceFile, prefs &pref.Preferences, mut declared_types map[string]bool, mut declared_kinds map[string]FastcDeclaredTypeKind, mut enum_flags map[string]bool, mut params_structs map[string]bool, mut type_source_paths map[string]bool, mut type_sources map[string]string, mut constants map[string]string, mut public_constants map[string]bool, mut constant_sources map[string]string, mut globals map[string]string, mut public_globals map[string]bool) !map[string]FastcGenericMethodSource {
+	jobs := fastc_parallel_jobs(sources, prefs)
+	if jobs <= 1 {
+		generic_method_sources := fastc_collect_generic_method_sources(mut sources, prefs)
+		fastc_collect_declaration_indexes(sources, prefs, mut declared_types, mut declared_kinds, mut enum_flags, mut params_structs, mut type_source_paths, mut type_sources, mut constants, mut public_constants, mut constant_sources, mut globals, mut public_globals)!
+		return generic_method_sources
+	}
+	order := fastc_file_generation_order(sources)
+	mut queue := &FastcGenQueue{
+		next: 0
+	}
+	second_thread := spawn fastc_collect_index_worker(sources, prefs, order, queue)
+	mut chunk_threads := [second_thread]
+	for _ in 2 .. jobs {
+		chunk_thread := spawn fastc_collect_index_worker(sources, prefs, order, queue)
+		chunk_threads << chunk_thread
+	}
+	mut partials := []FastcIndexedIndexPartial{len: sources.len}
+	first := fastc_collect_index_worker(sources, prefs, order, queue)
+	for indexed in first {
+		partials[indexed.index] = indexed
+	}
+	for chunk_thread in chunk_threads {
+		worker_partials := chunk_thread.wait()
+		for indexed in worker_partials {
+			partials[indexed.index] = indexed
+		}
+	}
+	mut generic_method_sources := map[string]FastcGenericMethodSource{}
+	for index, indexed in partials {
+		source_file := sources[index]
+		sources[index] = FastcSourceFile{
 			path: source_file.path
 			source: source_file.source
 			source_offset: source_file.source_offset
-			header: fastc_header_with_scan_flags(source_file.header, file_flags)
+			header: fastc_header_with_scan_flags(source_file.header, indexed.flags)
 		}
+		for key, generic in indexed.generics {
+			generic_method_sources[key] = generic
+		}
+		fastc_merge_declaration_partial(indexed.partial, mut declared_types, mut declared_kinds, mut enum_flags, mut params_structs, mut type_source_paths, mut type_sources, mut constants, mut public_constants, mut constant_sources, mut globals, mut public_globals)!
 	}
+	return generic_method_sources
 }
 
 struct FastcIndexedFileGenOutput {
@@ -419,8 +650,64 @@ fn fastc_generation_fragments(sources []FastcSourceFile, prefs &pref.Preferences
 	return fragments
 }
 
+// FastcPendingFieldLookup is the by-name index of struct fields, built on a
+// worker while the constant and global phases run.
+struct FastcPendingFieldLookup {
+mut:
+	workers []thread map[string]map[string]FastcStructField
+	lookup  map[string]map[string]FastcStructField
+}
+
+fn fastc_start_struct_field_lookup(struct_field_info map[string][]FastcStructField, prefs &pref.Preferences) FastcPendingFieldLookup {
+	if fastc_parallel_job_count(fastc_source_load_chunk_size, prefs) <= 1 {
+		return FastcPendingFieldLookup{
+			lookup: fastc_build_struct_field_lookup(struct_field_info)
+		}
+	}
+	return FastcPendingFieldLookup{
+		workers: [spawn fastc_build_struct_field_lookup(struct_field_info)]
+	}
+}
+
+fn fastc_wait_struct_field_lookup(mut pending FastcPendingFieldLookup) map[string]map[string]FastcStructField {
+	if pending.workers.len == 0 {
+		return pending.lookup
+	}
+	return pending.workers[0].wait()
+}
+
+// FastcPendingFragments is the fragmentation of the sources for parallel
+// generation, running on a worker while the declaration phases proceed.
+struct FastcPendingFragments {
+mut:
+	workers   []thread []FastcSourceFile
+	fragments []FastcSourceFile
+}
+
+// fastc_start_generation_fragments starts splitting oversized sources into
+// generation fragments in the background; a serial run generates whole files,
+// so it gets the sources back unchanged.
+fn fastc_start_generation_fragments(sources []FastcSourceFile, prefs &pref.Preferences) FastcPendingFragments {
+	if fastc_parallel_job_count(sources.len, prefs) <= 1 {
+		return FastcPendingFragments{
+			fragments: sources
+		}
+	}
+	return FastcPendingFragments{
+		workers: [spawn fastc_generation_fragments(sources, prefs)]
+	}
+}
+
+fn fastc_wait_generation_fragments(mut pending FastcPendingFragments) []FastcSourceFile {
+	if pending.workers.len == 0 {
+		return pending.fragments
+	}
+	return pending.workers[0].wait()
+}
+
 // fastc_generate_file_outputs runs per-file code generation, in parallel when
-// more than one job is available. Results are restored to file order, so the
+// more than one job is available. `sources` are the generation fragments from
+// fastc_wait_generation_fragments. Results are restored to file order, so the
 // emitted C is identical to a serial run.
 fn fastc_generate_file_outputs(ctx &FastcFileGenContext, sources []FastcSourceFile) []FastcFileGenOutput {
 	jobs := fastc_parallel_jobs(sources, ctx.prefs)
@@ -432,8 +719,7 @@ fn fastc_generate_file_outputs(ctx &FastcFileGenContext, sources []FastcSourceFi
 		return outputs
 	}
 	mut timer := fastc_new_phase_timer()
-	generation_sources := fastc_generation_fragments(sources, ctx.prefs)
-	timer.mark('file_outputs.fragments')
+	generation_sources := sources
 	order := fastc_file_generation_order(generation_sources)
 	mut queue := &FastcGenQueue{
 		next: 0
@@ -630,6 +916,9 @@ fn fastc_collect_signatures(sources []FastcSourceFile, prefs &pref.Preferences, 
 			partials[indexed.index] = indexed.partial
 		}
 	}
+	// Size the program map once: growing it by doubling while thousands of
+	// signatures are merged would rehash every key several times.
+	functions.reserve(u32(functions.len + fastc_signature_partial_count(partials)))
 	for partial in partials {
 		fastc_merge_signature_partial(partial, mut functions, mut interface_methods, mut interface_fields, mut embed_embedders, mut embed_embeddeds)!
 	}

--- a/vlib/v3/gen/fastc/parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/fastc/parallel_notd_v3_no_parallel.v
@@ -56,7 +56,10 @@ fn fastc_wait_interface_dispatches(mut pending FastcPendingInterfaceDispatches) 
 	return pending.workers[0].wait()
 }
 
-fn fastc_parallel_job_count(item_count int, prefs &pref.Preferences) int {
+// fastc_parallel_worker_limit is the number of worker threads a parallel
+// phase may run at once: the CPU count, overridden by VJOBS, and 1 when
+// parallelism is disabled.
+fn fastc_parallel_worker_limit(prefs &pref.Preferences) int {
 	if prefs.no_parallel {
 		return 1
 	}
@@ -68,6 +71,11 @@ fn fastc_parallel_job_count(item_count int, prefs &pref.Preferences) int {
 	if os.getenv('V3_FASTC_NO_PARALLEL') != '' {
 		jobs = 1
 	}
+	return jobs
+}
+
+fn fastc_parallel_job_count(item_count int, prefs &pref.Preferences) int {
+	mut jobs := fastc_parallel_worker_limit(prefs)
 	if jobs > item_count {
 		jobs = item_count
 	}
@@ -93,64 +101,51 @@ fn fastc_load_source_chunk(paths []string, prefs &pref.Preferences, start int, e
 	return loaded
 }
 
-// FastcModuleListing is one module directory listed on a worker thread, with
-// the reads of its files already started in chunks of
-// fastc_source_load_chunk_size: chunk i covers files[i*chunk .. (i+1)*chunk].
+// FastcModuleListing is one module directory listed on a worker thread.
 struct FastcModuleListing {
-	dir    string
-	files  []string
-	chunks []thread []FastcLoadedSource
+	dir   string
+	files []string
 }
 
-// fastc_start_module_load lists `dir` (or takes `listed` when `dir` is empty)
-// and starts a reader thread per chunk of its files, so the listing thread
-// returns as soon as the reads are under way.
-fn fastc_start_module_load(dir string, listed []string, prefs &pref.Preferences) FastcModuleListing {
+// fastc_list_module_load lists `dir`, or takes `listed` when `dir` is empty.
+fn fastc_list_module_load(dir string, listed []string, prefs &pref.Preferences) FastcModuleListing {
 	files := if dir == '' { listed } else { fastc_list_module_sources(dir, prefs) }
-	if files.len == 0 {
-		return FastcModuleListing{
-			dir: dir
-			files: files
-		}
+	return FastcModuleListing{
+		dir: dir
+		files: files
 	}
-	mut first_end := fastc_source_load_chunk_size
-	if first_end > files.len {
-		first_end = files.len
-	}
-	mut chunks := [
-		spawn fastc_load_source_chunk(files, prefs, 0, first_end),
-	]
-	mut start := first_end
+}
+
+// fastc_queue_source_chunks appends `files` to `pending` in read chunks of
+// fastc_source_load_chunk_size paths.
+fn fastc_queue_source_chunks(files []string, mut pending [][]string) {
+	mut start := 0
 	for start < files.len {
 		mut end := start + fastc_source_load_chunk_size
 		if end > files.len {
 			end = files.len
 		}
-		chunks << spawn fastc_load_source_chunk(files, prefs, start, end)
+		pending << files[start..end]
 		start = end
-	}
-	return FastcModuleListing{
-		dir: dir
-		files: files
-		chunks: chunks
 	}
 }
 
 // fastc_preload_sources reads and header-scans every file reachable from the
-// initial queue on worker threads. Each imported module directory is listed on
-// a thread that starts the reads of its files in chunks; the main thread joins
-// listings first (they finish quickly and unlock more reads) and then the read
-// chunks in start order, resolving the imports of each chunk as it lands, so
-// the reads of one module overlap with the discovery of the next. The entry
-// files go first because their import chain is the deepest. The result is
-// keyed by path, so the ordering walk that follows can use any traversal
-// order; failures are kept so the walk reports them at the same point it
-// would have. The listings are recorded in `module_dir_files` for that walk.
+// initial queue on worker threads. Each imported module directory is listed
+// on a thread and its files are read in chunks on further threads; the main
+// thread schedules that work, keeping at most the phase's worker limit of
+// threads running, and joins listings first (they unlock more reads) and
+// then the read chunks in start order, resolving the imports of each chunk
+// as it lands, so the reads of one module overlap with the discovery of the
+// next. The entry files go first because their import chain is the deepest.
+// The result is keyed by path, so the ordering walk that follows can use any
+// traversal order; failures are kept so the walk reports them at the same
+// point it would have. The listings are recorded in `module_dir_files` for
+// that walk.
 fn fastc_preload_sources(queue []FastcQueuedSource, prefs &pref.Preferences, canonical_vlib string, mut module_path_cache map[string]string, mut module_dir_files map[string][]string, mut real_path_cache map[string]string) map[string]FastcLoadedSource {
 	mut loaded := map[string]FastcLoadedSource{}
-	// The queue starts with a few entry files; the count that matters for the
-	// parallel decision is the chunk size the loads are split into.
-	if fastc_parallel_job_count(fastc_source_load_chunk_size, prefs) <= 1 {
+	jobs := fastc_parallel_worker_limit(prefs)
+	if jobs <= 1 {
 		return loaded
 	}
 	mut scheduled := map[string]bool{}
@@ -185,31 +180,56 @@ fn fastc_preload_sources(queue []FastcQueuedSource, prefs &pref.Preferences, can
 	if initial_paths.len == 0 {
 		return loaded
 	}
-	mut listings := [
-		spawn fastc_start_module_load('', initial_paths, prefs),
-	]
 	wait_sw := time.new_stopwatch()
 	mut wait_us := i64(0)
+	// The entry files form the first listing; its first chunk starts the
+	// reader queue. (Both thread arrays start from a spawn: the self-hosted
+	// generator has no empty thread-array literal.)
+	mut listings := [
+		spawn fastc_list_module_load('', initial_paths, prefs),
+	]
+	mut listing_count := 1
+	mut next_listing := 1
 	entry_listing := listings[0].wait()
 	wait_us += wait_sw.elapsed().microseconds()
-	mut chunk_threads := entry_listing.chunks.clone()
-	mut chunk_paths := [][]string{}
-	fastc_record_listing_chunks(entry_listing, mut chunk_paths)
-	mut next_listing := 1
+	mut pending_chunks := [][]string{}
+	fastc_queue_source_chunks(entry_listing.files, mut pending_chunks)
+	first_chunk := pending_chunks[0]
+	mut chunk_threads := [
+		spawn fastc_load_source_chunk(first_chunk, prefs, 0, first_chunk.len),
+	]
+	mut chunk_paths := [first_chunk]
+	mut next_pending_chunk := 1
 	mut next_chunk := 0
-	for next_listing < listings.len || next_chunk < chunk_threads.len {
-		if next_listing < listings.len {
+	mut pending_dirs := []string{}
+	mut next_pending_dir := 0
+	mut in_flight := 1
+	for next_listing < listing_count || next_chunk < chunk_threads.len || next_pending_dir < pending_dirs.len || next_pending_chunk < pending_chunks.len {
+		// Start queued work up to the worker limit, listings first.
+		for in_flight < jobs && next_pending_dir < pending_dirs.len {
+			listings << spawn fastc_list_module_load(pending_dirs[next_pending_dir], []string{}, prefs)
+			listing_count++
+			next_pending_dir++
+			in_flight++
+		}
+		for in_flight < jobs && next_pending_chunk < pending_chunks.len {
+			chunk := pending_chunks[next_pending_chunk]
+			chunk_threads << spawn fastc_load_source_chunk(chunk, prefs, 0, chunk.len)
+			chunk_paths << chunk
+			next_pending_chunk++
+			in_flight++
+		}
+		if next_listing < listing_count {
 			listing_start := wait_sw.elapsed().microseconds()
 			listing := listings[next_listing].wait()
 			wait_us += wait_sw.elapsed().microseconds() - listing_start
 			next_listing++
-			if listing.dir != '' {
-				module_dir_files[listing.dir] = listing.files
-			}
-			for chunk in listing.chunks {
-				chunk_threads << chunk
-			}
-			fastc_record_listing_chunks(listing, mut chunk_paths)
+			in_flight--
+			module_dir_files[listing.dir] = listing.files
+			fastc_queue_source_chunks(listing.files, mut pending_chunks)
+			continue
+		}
+		if next_chunk >= chunk_threads.len {
 			continue
 		}
 		chunk_start := wait_sw.elapsed().microseconds()
@@ -217,6 +237,7 @@ fn fastc_preload_sources(queue []FastcQueuedSource, prefs &pref.Preferences, can
 		wait_us += wait_sw.elapsed().microseconds() - chunk_start
 		paths := chunk_paths[next_chunk]
 		next_chunk++
+		in_flight--
 		for i, loaded_source in chunk {
 			mut path := paths[i]
 			if !prefs.building_v {
@@ -242,28 +263,14 @@ fn fastc_preload_sources(queue []FastcQueuedSource, prefs &pref.Preferences, can
 					continue
 				}
 				scheduled_dirs[module_dir] = true
-				listings << spawn fastc_start_module_load(module_dir, []string{}, prefs)
+				pending_dirs << module_dir
 			}
 		}
 	}
 	if os.getenv('FASTC_BENCH_PHASES') != '' {
-		eprintln('fastc-phase resolve.preload.detail listings=${listings.len} chunks=${chunk_threads.len} wait_us=${wait_us}')
+		eprintln('fastc-phase resolve.preload.detail jobs=${jobs} listings=${listing_count} chunks=${chunk_threads.len} wait_us=${wait_us}')
 	}
 	return loaded
-}
-
-// fastc_record_listing_chunks appends the path slice of each read chunk of
-// `listing`, in chunk order, to `chunk_paths`.
-fn fastc_record_listing_chunks(listing FastcModuleListing, mut chunk_paths [][]string) {
-	mut start := 0
-	for _ in listing.chunks {
-		mut end := start + fastc_source_load_chunk_size
-		if end > listing.files.len {
-			end = listing.files.len
-		}
-		chunk_paths << listing.files[start..end]
-		start = end
-	}
 }
 
 // fastc_chunk_bounds splits the file list into contiguous chunks balanced by

--- a/vlib/v3/gen/fastc/render.v
+++ b/vlib/v3/gen/fastc/render.v
@@ -394,7 +394,7 @@ fn (g &Parser) render_struct_literal_field_names(tokens []FastcExpressionToken, 
 				}
 				function_key := fastc_function_key(module_name, field_name)
 				if function_key in g.functions || function_key in g.mono_functions {
-					resolved_names << fastc_c_function_name_for_key(function_key)
+					resolved_names << g.c_function_name_for_key(function_key)
 				}
 				for resolved_name in resolved_names {
 					needle := '.${resolved_name}='
@@ -2096,7 +2096,7 @@ fn (g &Parser) render_function_value_expression(tokens []FastcExpressionToken) ?
 	if function_key !in g.functions && function_key !in g.mono_functions {
 		return none
 	}
-	return '&${fastc_c_function_name_for_key(function_key)}'
+	return '&${g.c_function_name_for_key(function_key)}'
 }
 
 fn (g &Parser) render_method_value_expression(tokens []FastcExpressionToken) ?string {

--- a/vlib/v3/gen/fastc/render_method_calls.v
+++ b/vlib/v3/gen/fastc/render_method_calls.v
@@ -54,7 +54,7 @@ fn (g &Parser) render_missing_call_arguments(tokens []FastcExpressionToken) ?Fas
 		named_initializer := g.render_named_struct_initializer(parameter_type, call_args[named_start..]) or { return none }
 		rendered_arguments << named_initializer
 		return FastcRenderedExpression{
-			source: '${fastc_c_function_name_for_key(function_key)}(${rendered_arguments.join(',')})'
+			source: '${g.c_function_name_for_key(function_key)}(${rendered_arguments.join(',')})'
 			typ: signature.return_type
 		}
 	}
@@ -73,7 +73,7 @@ fn (g &Parser) render_missing_call_arguments(tokens []FastcExpressionToken) ?Fas
 			named_initializer := g.render_named_struct_initializer(element_type, call_args[named_start..]) or { return none }
 			c_arguments << '((${variadic_type})builtin__new_array_from_c_array(1, 1, sizeof(${element_type}), (${element_type}[]){${named_initializer}}))'
 			return FastcRenderedExpression{
-				source: '${fastc_c_function_name_for_key(function_key)}(${c_arguments.join(',')})'
+				source: '${g.c_function_name_for_key(function_key)}(${c_arguments.join(',')})'
 				typ: signature.return_type
 			}
 		}
@@ -102,7 +102,7 @@ fn (g &Parser) render_missing_call_arguments(tokens []FastcExpressionToken) ?Fas
 		rendered_arguments.trim(fixed_arguments)
 		rendered_arguments << packed
 		return FastcRenderedExpression{
-			source: '${fastc_c_function_name_for_key(function_key)}(${rendered_arguments.join(',')})'
+			source: '${g.c_function_name_for_key(function_key)}(${rendered_arguments.join(',')})'
 			typ: signature.return_type
 		}
 	}
@@ -130,7 +130,7 @@ fn (g &Parser) render_missing_call_arguments(tokens []FastcExpressionToken) ?Fas
 	call_name := if function_key.starts_with('C.') {
 		function_key.all_after_last('.')
 	} else {
-		fastc_c_function_name_for_key(function_key)
+		g.c_function_name_for_key(function_key)
 	}
 	return FastcRenderedExpression{
 		source: '${call_name}(${rendered_arguments.join(',')})'

--- a/vlib/v3/gen/fastc/signatures.v
+++ b/vlib/v3/gen/fastc/signatures.v
@@ -857,21 +857,31 @@ fn fastc_collect_signature_chunk(sources []FastcSourceFile, prefs &pref.Preferen
 	return partial
 }
 
+// fastc_signature_partial_count sums the function signatures of `partials`.
+fn fastc_signature_partial_count(partials []FastcSignaturePartial) int {
+	mut count := 0
+	for partial in partials {
+		count += partial.functions.len
+	}
+	return count
+}
+
 fn fastc_merge_signature_partial(partial FastcSignaturePartial, mut functions map[string]FastcFunctionSignature, mut interface_methods map[string]bool, mut interface_fields map[string]FastcInterfaceField, mut embed_embedders []string, mut embed_embeddeds []string) ! {
 	if partial.failed {
 		return error(partial.error_message)
 	}
 	for key, signature in partial.functions {
-		if key !in partial.interface_methods {
-			if previous := functions[key] {
-				if !key.starts_with('C.') {
-					is_c_override := previous.path.ends_with('.c.v') || signature.path.ends_with('.c.v')
-					if previous.path == signature.path || !is_c_override || !fastc_string_types_equal(previous.parameter_types, signature.parameter_types) || !fastc_bool_types_equal(previous.parameter_mutability, signature.parameter_mutability) || previous.last_parameter_is_params != signature.last_parameter_is_params || previous.return_type != signature.return_type {
-						return error('fastc parser does not support duplicate function `${key.all_after_last('.')}` in ${signature.path}')
-					}
-					if previous.path.ends_with('.c.v') {
-						continue
-					}
+		// Duplicates are rare, so test membership first and only then copy
+		// the previous signature out for the override checks.
+		if key !in partial.interface_methods && key in functions {
+			previous := functions[key]
+			if !key.starts_with('C.') {
+				is_c_override := previous.path.ends_with('.c.v') || signature.path.ends_with('.c.v')
+				if previous.path == signature.path || !is_c_override || !fastc_string_types_equal(previous.parameter_types, signature.parameter_types) || !fastc_bool_types_equal(previous.parameter_mutability, signature.parameter_mutability) || previous.last_parameter_is_params != signature.last_parameter_is_params || previous.return_type != signature.return_type {
+					return error('fastc parser does not support duplicate function `${key.all_after_last('.')}` in ${signature.path}')
+				}
+				if previous.path.ends_with('.c.v') {
+					continue
 				}
 			}
 		}

--- a/vlib/v3/gen/fastc/source.v
+++ b/vlib/v3/gen/fastc/source.v
@@ -63,17 +63,20 @@ fn fastc_resolve_c_pseudo_paths(raw string, vroot string, source_file string) st
 fn fastc_load_source(path string, prefs &pref.Preferences) FastcLoadedSource {
 	source := os.read_file(path) or {
 		return FastcLoadedSource{
+			path: path
 			failed: true
 			error_message: err.msg()
 		}
 	}
 	header := fastc_scan_source_header(source, path, prefs) or {
 		return FastcLoadedSource{
+			path: path
 			failed: true
 			error_message: err.msg()
 		}
 	}
 	return FastcLoadedSource{
+		path: path
 		source: source
 		header: header
 	}
@@ -120,6 +123,25 @@ fn fastc_resolve_source_files(paths []string, prefs &pref.Preferences) !([]Fastc
 		}
 	}
 	timer.mark('resolve.queue_init')
+	// vroot is canonical, so a module directory found below its vlib is too and
+	// needs no realpath call of its own.
+	canonical_vlib := if prefs.building_v {
+		os.dir(os.real_path(prefs.get_vlib_module_path('builtin')))
+	} else {
+		''
+	}
+	// Modules are re-discovered once per importing file; canonicalization and
+	// directory enumeration are syscalls, so both are memoized for the walk and
+	// shared with the preload below.
+	mut real_path_cache := map[string]string{}
+	mut module_dir_files := map[string][]string{}
+	mut module_path_cache := map[string]string{}
+	// Every reachable file is read and header-scanned up front on worker
+	// threads, following imports as soon as they are known. The wave walk below
+	// then only orders and validates what was preloaded, so its dependency
+	// depth no longer serializes the file reads.
+	preloaded := fastc_preload_sources(queue, prefs, canonical_vlib, mut module_path_cache, mut module_dir_files, mut real_path_cache)
+	timer.mark('resolve.preload')
 	mut seen := map[string]bool{}
 	mut sources := []FastcSourceFile{}
 	// path -> the module_name a file was first loaded under, and the resulting alias map:
@@ -128,11 +150,6 @@ fn fastc_resolve_source_files(paths []string, prefs &pref.Preferences) !([]Fastc
 	// an alias of the first, so `<second>.<sym>` references resolve to the loaded `<first>`.
 	mut path_module := map[string]string{}
 	mut module_aliases := map[string]string{}
-	// Modules are re-discovered once per importing file; canonicalization and
-	// directory enumeration are syscalls, so both are memoized for the walk.
-	mut real_path_cache := map[string]string{}
-	mut module_dir_files := map[string][]string{}
-	mut module_path_cache := map[string]string{}
 	mut scheduled_path_modules := map[string]string{}
 	mut queue_index := 0
 	for queue_index < queue.len {
@@ -178,7 +195,7 @@ fn fastc_resolve_source_files(paths []string, prefs &pref.Preferences) !([]Fastc
 			wave_modules << queued.module_name
 		}
 		timer.mark('resolve.wave_scan')
-		loaded_sources := fastc_load_source_headers(wave_paths, prefs)
+		loaded_sources := fastc_preloaded_source_headers(wave_paths, prefs, preloaded)
 		timer.mark('resolve.wave_load(${wave_paths.len})')
 		wave_source_start := sources.len
 		for i, loaded_source in loaded_sources {
@@ -228,45 +245,12 @@ fn fastc_resolve_source_files(paths []string, prefs &pref.Preferences) !([]Fastc
 					continue
 				}
 				discovered_imports[imported_module] = true
-				module_cache_key := if prefs.building_v {
-					imported_module
-				} else {
-					os.dir(source_file.path) + '\x00' + imported_module
-				}
-				mut module_dir := ''
-				if module_cache_key in module_path_cache {
-					module_dir = module_path_cache[module_cache_key]
-				} else {
-					if prefs.building_v {
-						vlib_module_dir := prefs.get_vlib_module_path(imported_module)
-						// Alias modules need the generic resolver to follow `alias.v`.
-						if os.is_dir(vlib_module_dir) && !os.is_file(os.join_path_single(vlib_module_dir, 'alias.v')) {
-							module_dir = vlib_module_dir
-						} else {
-							module_dir = prefs.get_module_path(imported_module, source_file.path)
-						}
-					} else {
-						module_dir = prefs.get_module_path(imported_module, source_file.path)
-					}
-					if prefs.building_v {
-						module_dir = os.real_path(module_dir)
-					}
-					module_path_cache[module_cache_key] = module_dir
-				}
+				module_cache_key := fastc_module_cache_key(prefs, source_file.path, imported_module)
+				module_dir := fastc_resolve_module_dir(module_cache_key, imported_module, source_file.path, prefs, canonical_vlib, mut module_path_cache)
 				if module_dir == '' {
 					return error('fastc cannot resolve imported module `${imported_module}` from `${source_file.path}`')
 				}
-				mut module_files := []string{}
-				if cached := module_dir_files[module_dir] {
-					module_files = cached.clone()
-				} else {
-					for module_file in pref.get_v_files_from_dir_for_target(module_dir, prefs.user_defines, prefs.target) {
-						if fastc_source_file_matches_backend(module_file) {
-							module_files << module_file
-						}
-					}
-					module_dir_files[module_dir] = module_files
-				}
+				module_files := fastc_module_source_files(module_dir, prefs, mut module_dir_files)
 				for module_file in module_files {
 					mut module_file_real := module_file
 					if !prefs.building_v {
@@ -297,6 +281,84 @@ fn fastc_resolve_source_files(paths []string, prefs &pref.Preferences) !([]Fastc
 	}
 	timer.mark('resolve.imports')
 	return sources, module_aliases
+}
+
+// fastc_source_load_chunk_size is the number of files one loader thread reads;
+// reads are short syscalls, so a few per spawn amortize the thread start.
+const fastc_source_load_chunk_size = 4
+
+// fastc_resolve_module_dir resolves and memoizes the directory of an imported
+// module. A directory below the canonical vlib root is canonical already.
+// fastc_module_cache_key keys the module directory cache by importing
+// directory and module name; when building V the vlib lookup is global.
+// (vfmt rewrites '\x00' as '\0', which the FastC parser rejects, so this
+// helper stays in a file vfmt does not verify.)
+fn fastc_module_cache_key(prefs &pref.Preferences, source_path string, imported_module string) string {
+	if prefs.building_v {
+		return imported_module
+	}
+	return os.dir(source_path) + '\x00' + imported_module
+}
+
+fn fastc_resolve_module_dir(module_cache_key string, imported_module string, source_path string, prefs &pref.Preferences, canonical_vlib string, mut module_path_cache map[string]string) string {
+	if cached := module_path_cache[module_cache_key] {
+		return cached
+	}
+	mut module_dir := ''
+	mut canonical := false
+	if prefs.building_v {
+		vlib_module_dir := prefs.get_vlib_module_path(imported_module)
+		// Alias modules need the generic resolver to follow `alias.v`.
+		if os.is_dir(vlib_module_dir) && !os.is_file(os.join_path_single(vlib_module_dir, 'alias.v')) {
+			module_dir = vlib_module_dir
+			canonical = canonical_vlib != '' && module_dir.starts_with(canonical_vlib + '/')
+		} else {
+			module_dir = prefs.get_module_path(imported_module, source_path)
+		}
+	} else {
+		module_dir = prefs.get_module_path(imported_module, source_path)
+	}
+	if prefs.building_v && !canonical {
+		module_dir = os.real_path(module_dir)
+	}
+	module_path_cache[module_cache_key] = module_dir
+	return module_dir
+}
+
+// fastc_module_source_files lists and memoizes the backend-compatible source
+// files of a module directory.
+fn fastc_module_source_files(module_dir string, prefs &pref.Preferences, mut module_dir_files map[string][]string) []string {
+	if cached := module_dir_files[module_dir] {
+		return cached.clone()
+	}
+	module_files := fastc_list_module_sources(module_dir, prefs)
+	module_dir_files[module_dir] = module_files
+	return module_files
+}
+
+// fastc_list_module_sources lists the backend-relevant .v files of `dir`.
+fn fastc_list_module_sources(dir string, prefs &pref.Preferences) []string {
+	mut module_files := []string{}
+	for module_file in pref.get_v_files_from_dir_for_target(dir, prefs.user_defines, prefs.target) {
+		if fastc_source_file_matches_backend(module_file) {
+			module_files << module_file
+		}
+	}
+	return module_files
+}
+
+// fastc_preloaded_source_headers returns the preloaded sources for `paths`,
+// reading any that the preload did not reach synchronously.
+fn fastc_preloaded_source_headers(paths []string, prefs &pref.Preferences, preloaded map[string]FastcLoadedSource) []FastcLoadedSource {
+	mut result := []FastcLoadedSource{cap: paths.len}
+	for path in paths {
+		if source := preloaded[path] {
+			result << source
+		} else {
+			result << fastc_load_source(path, prefs)
+		}
+	}
+	return result
 }
 
 // fastc_entry_module_files returns the other source files of the entry file's
@@ -590,6 +652,20 @@ fn fastc_scan_source_header(source string, path string, prefs &pref.Preferences)
 
 // fastc_header_with_scan_flags copies a header with the declaration keyword
 // flags of its source filled in.
+// fastc_apply_scan_flags stores per-file scan flags into the source headers
+// starting at `start`.
+fn fastc_apply_scan_flags(mut sources []FastcSourceFile, flags []FastcSourceScanFlags, start int) {
+	for i, file_flags in flags {
+		source_file := sources[start + i]
+		sources[start + i] = FastcSourceFile{
+			path: source_file.path
+			source: source_file.source
+			source_offset: source_file.source_offset
+			header: fastc_header_with_scan_flags(source_file.header, file_flags)
+		}
+	}
+}
+
 fn fastc_header_with_scan_flags(header FastcSourceHeader, flags FastcSourceScanFlags) FastcSourceHeader {
 	return FastcSourceHeader{
 		module_name: header.module_name
@@ -722,51 +798,69 @@ fn fastc_source_scan_flags(source string) FastcSourceScanFlags {
 	mut flags := FastcSourceScanFlags{}
 	for i := 0; i < source.len; i++ {
 		c := source[i]
-		// Only a word start can begin a keyword; most bytes are rejected here.
-		if i > 0 && fastc_identifier_byte(source[i - 1]) {
+		// Only a word start can begin a keyword, so after checking one, skip
+		// the rest of the identifier; the byte that ends it cannot start a
+		// keyword either, since its previous byte is part of the word.
+		if fastc_identifier_byte(c) {
+			mut end := i + 1
+			for end < source.len && fastc_identifier_byte(source[end]) {
+				end++
+			}
+			if !flags.has_constants || !flags.has_type_keywords || !flags.has_global_declarations
+				|| !flags.has_interfaces || !flags.has_generic_fn_syntax {
+				fastc_source_scan_word_flags(source, i, c, mut flags)
+			}
+			i = end
 			continue
 		}
-		if c == `c` {
-			if !flags.has_constants && fastc_source_word_at(source, i, 'const') {
-				flags.has_constants = true
-			}
-		} else if c == `_` {
-			if !flags.has_global_declarations && fastc_source_word_at(source, i, '__global') {
-				flags.has_global_declarations = true
-			}
-		} else if c == `i` {
-			if !flags.has_interfaces && fastc_source_word_at(source, i, 'interface') {
-				flags.has_interfaces = true
-				flags.has_type_keywords = true
-			}
-		} else if c == `$` {
+		if c == `$` {
 			if !flags.has_comptime_if && fastc_source_comptime_if_at(source, i) {
 				flags.has_comptime_if = true
-			}
-		} else if c == `s` {
-			if !flags.has_type_keywords && fastc_source_word_at(source, i, 'struct') {
-				flags.has_type_keywords = true
-			}
-		} else if c == `e` {
-			if !flags.has_type_keywords && fastc_source_word_at(source, i, 'enum') {
-				flags.has_type_keywords = true
-			}
-		} else if c == `t` {
-			if !flags.has_type_keywords && fastc_source_word_at(source, i, 'type') {
-				flags.has_type_keywords = true
-			}
-		} else if c == `u` {
-			if !flags.has_type_keywords && fastc_source_word_at(source, i, 'union') {
-				flags.has_type_keywords = true
-			}
-		} else if c == `f` {
-			if !flags.has_generic_fn_syntax && fastc_source_word_at(source, i, 'fn')
-				&& fastc_source_generic_fn_at(source, i + 2) {
-				flags.has_generic_fn_syntax = true
 			}
 		}
 	}
 	return flags
+}
+
+// fastc_source_scan_word_flags checks the identifier starting at `i` (whose
+// first byte is `c`) for the declaration keywords the flags track.
+@[direct_array_access]
+fn fastc_source_scan_word_flags(source string, i int, c u8, mut flags FastcSourceScanFlags) {
+	if c == `c` {
+		if !flags.has_constants && fastc_source_word_at(source, i, 'const') {
+			flags.has_constants = true
+		}
+	} else if c == `_` {
+		if !flags.has_global_declarations && fastc_source_word_at(source, i, '__global') {
+			flags.has_global_declarations = true
+		}
+	} else if c == `i` {
+		if !flags.has_interfaces && fastc_source_word_at(source, i, 'interface') {
+			flags.has_interfaces = true
+			flags.has_type_keywords = true
+		}
+	} else if c == `s` {
+		if !flags.has_type_keywords && fastc_source_word_at(source, i, 'struct') {
+			flags.has_type_keywords = true
+		}
+	} else if c == `e` {
+		if !flags.has_type_keywords && fastc_source_word_at(source, i, 'enum') {
+			flags.has_type_keywords = true
+		}
+	} else if c == `t` {
+		if !flags.has_type_keywords && fastc_source_word_at(source, i, 'type') {
+			flags.has_type_keywords = true
+		}
+	} else if c == `u` {
+		if !flags.has_type_keywords && fastc_source_word_at(source, i, 'union') {
+			flags.has_type_keywords = true
+		}
+	} else if c == `f` {
+		if !flags.has_generic_fn_syntax && fastc_source_word_at(source, i, 'fn')
+			&& fastc_source_generic_fn_at(source, i + 2) {
+			flags.has_generic_fn_syntax = true
+		}
+	}
 }
 
 fn fastc_identifier_byte(value u8) bool {

--- a/vlib/v3/gen/fastc/spawn.v
+++ b/vlib/v3/gen/fastc/spawn.v
@@ -364,7 +364,7 @@ fn (mut g Parser) register_spawn_helpers(function_key string, thread_type string
 	target := if target_c_name != '' {
 		target_c_name
 	} else {
-		fastc_c_function_name_for_key(function_key)
+		g.c_function_name_for_key(function_key)
 	}
 	target_stem := fastc_spawn_target_stem(function_key)
 	args_struct := g.fastc_unclaimed_generated_name('__v_fastc_spawn_args_${target_stem}')

--- a/vlib/v3/gen/fastc/validate.v
+++ b/vlib/v3/gen/fastc/validate.v
@@ -132,7 +132,7 @@ fn (g &Parser) resolved_nonlocal_expression_name(name string) string {
 	}
 	function_key := g.unqualified_function_key(name)
 	if function_key in g.functions {
-		return fastc_c_function_name_for_key(function_key)
+		return g.c_function_name_for_key(function_key)
 	}
 	if type_key := g.resolve_declared_type_key(name) {
 		return fastc_c_declared_type_name(type_key)


### PR DESCRIPTION
Second round of FastC generation speedups (follow-up to #28291). Measured on the self-host input (`vlib/v3/v3.v`, 173 files, ~66.4K lines) with the standalone driver built with `-prod -gc none -prealloc`, interleaving master and branch runs on the same machine (M5 Max, other sessions running tests, load ≈ 4):

| build | min | median | loc/s (median) |
|---|---|---|---|
| master `-prod` | 21.46 ms | 22.75 ms | ~2.9M |
| this PR `-prod` | 18.98 ms | 20.23 ms | ~3.3M |

On a quiet machine the `-O2` builds measured master 21.1 / 21.3 ms → branch 18.4 / 19.0 ms (min / median), i.e. ~3.5-3.6M loc/s; single quiet `-prod` runs print 18.4-19.1 ms for the `fastc parse+gen` row.

The generated C is byte-identical to master's generator on this input (`cmp` of the master `-O2`/`-prod` reference against the branch's `-O2` and `-prod` output; the only difference between the two `-prod` binaries is the embedded git hash constant, which depends on where the binary was built). The TCC self-host chain still reproduces itself (`v4 → v5 → v6` C identical) and `V3_FASTC_NO_PARALLEL=1` output matches the parallel output.

### Changes

- **Piecewise C output.** `GenerationResult.c_pieces` returns the generated C as ordered pieces; per-file bodies are referenced rather than copied into a single multi-megabyte buffer, and the drivers (`v3.driver`, `v3.fastcdriver`) write the pieces directly. The string APIs (`generate`, `generate_files`, `c_source()`) remain for tests.
- **Source preload before the ordering walk.** A thread lists each imported module directory and immediately starts chunked readers for its files; the main thread joins listings first and then chunks in start order, resolving the imports of each chunk as it lands, so reading one module overlaps with discovering the next. The ordering walk itself is unchanged: it replays over the preloaded files (same order, same errors), and `-d v3_no_parallel` gets serial stubs.
- **One pass for the generic-method scan and the declaration index** on the shared work counter (one spawn/join round, no static chunk split).
- **Background workers** for splitting oversized files into generation fragments and for the by-name struct field index, both built while the declaration phases run.
- **Smaller serial merges.** The program signature map is pre-sized before the merge, the duplicate check no longer copies every signature out of the map, the C function name of a key is memoized per parser, and the per-file declaration flag scan skips whole identifiers.
- The token-dependent expression lowerings are skipped when the expression lacks the token they act on, and the per-field import map copies are gone (defaults look the field's file up in a per-source map).

### Phase profile (`FASTC_BENCH_PHASES=1`, `-O2`, ms)

resolve 3.7 → 3.2, generic+declarations 1.5 → 1.1, signatures 1.6 → 1.4, fragments/field index wait 0.4 → 0.02, stitch+assemble 1.1 → 0.6.

### Tests

- `v test vlib/v3/scanner vlib/v3/token vlib/v3/pref vlib/v3/fastcdriver/fastcdriver_test.v`: all pass except `scanner_test.v`, which fails to compile on master too (checker error on an untyped enum array literal).
- `vlib/v3/gen/fastc/fastc_test.v` (built with a pre-#28277 V binary, since V3 cannot build it on macOS): the same four `test_selfhost_*` assertion failures and the known `enum_literal_map_lowering` panic occur on untouched master; no new failures.
- `-d v3_no_parallel` fails on master and on this branch for the same reason (decl.v references `FastcGenQueue` without the parallel helpers).

### Review follow-up

- **Owned output pieces.** `fastc_collect_c_piece_ranges` no longer hands out `tos` views into the per-file bodies: a range that covers a whole body shares that string, and a range that cuts a body (around hoisted C directive lines) is copied out with `substr`, so every entry of `GenerationResult.c_pieces` is an ordinary owned, NUL-terminated string. The copies are a small part of the output (about 0.2 ms in the `-O2` assemble step).
- **Bounded preload readers.** The listing threads no longer spawn one reader per four files. The main thread schedules listings and read chunks from pending queues and keeps at most `fastc_parallel_worker_limit` (CPU count or `VJOBS`) threads running, listings first. Join order and the resolved import graph are unchanged; the output is identical, also with `VJOBS=2`. This costs about 0.2 ms of resolve time compared to the unbounded version.
- **API note.** `GenerationResult.c_source` became `c_pieces` plus the `c_source()` method. `v3.gen.fastc` is part of the in-development V3 compiler and has no external users in the repository; keeping a `c_source` field would require joining the pieces on every generation, which is the copy this PR removes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

