### PR TITLE
v3: fix self-host segfault in transform call-operand re-dispatch

### DIFF
--- a/vlib/v3/tests/selfhost_transform_regression_test.v
+++ b/vlib/v3/tests/selfhost_transform_regression_test.v
@@ -43,7 +43,38 @@ fn selfhost_regression_run(name string, source string) string {
 // `transform_expr`, which rebuilds the branch unchanged in shape. The re-dispatch used to see a
 // changed-but-still-a-branch operand and recurse forever, overflowing the stack.
 fn test_untyped_enum_branch_argument_in_generic_clone_terminates() {
-	out := selfhost_regression_run('untyped_enum_branch_arg', '\nenum Op {\n\tdot\n\tarrow\n}\n\nstruct Sel {\nmut:\n\tn int\n}\n\nfn (mut s Sel) make_selector_op(base int, field string, typ string, op Op) string {\n\ts.n++\n\treturn "${base}-${field}-${typ}-${op}"\n}\n\nfn (mut s Sel) wrap[U](v U, expr_type string) string {\n\tbase := s.n + 1\n\tfield := "${v}"\n\tfield_typ := "x${field}"\n\treturn s.make_selector_op(base, field, field_typ, if expr_type.starts_with("&") {\n\t\t.arrow\n\t} else {\n\t\t.dot\n\t})\n}\n\nfn main() {\n\tmut s := Sel{}\n\tprintln(s.wrap(1, "&int"))\n\tprintln(s.wrap("s", "int"))\n}\n')
+	out := selfhost_regression_run('untyped_enum_branch_arg', 'enum Op {
+	dot
+	arrow
+}
+
+struct Sel {
+mut:
+	n int
+}
+
+fn (mut s Sel) make_selector_op(base int, field string, typ string, op Op) string {
+	s.n++
+	return "\${base}-\${field}-\${typ}-\${op}"
+}
+
+fn (mut s Sel) wrap[U](v U, expr_type string) string {
+	base := s.n + 1
+	field := "\${v}"
+	field_typ := "x\${field}"
+	return s.make_selector_op(base, field, field_typ, if expr_type.starts_with("&") {
+		.arrow
+	} else {
+		.dot
+	})
+}
+
+fn main() {
+	mut s := Sel{}
+	println(s.wrap(1, "&int"))
+	println(s.wrap("s", "int"))
+}
+')
 	assert out.split_into_lines() == ['1-1-x1-arrow', '2-s-xs-dot']
 }
 
@@ -51,8 +82,7 @@ fn test_untyped_enum_branch_argument_in_generic_clone_terminates() {
 // value. When a later argument hoists a value branch, the source-order guards used to snapshot
 // that base into a temp, emitting `unknown __order_snapshot_0 = os;`.
 fn test_module_qualified_call_with_branch_argument() {
-	out := selfhost_regression_run('module_qualified_branch_arg', '
-import os
+	out := selfhost_regression_run('module_qualified_branch_arg', 'import os
 
 fn pick(name string) !string {
 	if name.len == 0 {
@@ -83,8 +113,7 @@ fn main() {
 // reference (`m &map[string]bool`) still binds a plain value copy, so the binding must not be
 // typed `&V` — that made every use of it emit a dereference of a non-pointer local.
 fn test_for_in_over_map_reference_binds_value() {
-	out := selfhost_regression_run('for_in_map_reference', '
-fn count_used(used &map[string]bool) int {
+	out := selfhost_regression_run('for_in_map_reference', 'fn count_used(used &map[string]bool) int {
 	mut n := 0
 	for name, is_used in used {
 		if !is_used || name.len == 0 {
@@ -118,4 +147,70 @@ fn main() {
 }
 ')
 	assert out.split_into_lines() == ['2', '2', '4']
+}
+
+// `mod.Type.make(...)` is a static associated call: its callee base is the *selector* `mod.Type`,
+// which names a type, not a value. `static_assoc_fn_name` recognizes that selector shape, so the
+// namespace guard must consult it for selector bases too — otherwise the call is classified as a
+// method and a value-branch argument makes the ordering guards snapshot the type name as a
+// receiver (`void __order_snapshot_0 = shapes__Box;`).
+fn test_module_qualified_static_assoc_call_with_branch_argument() {
+	v3_bin := selfhost_regression_build_v3()
+	root := os.join_path(os.temp_dir(), 'v3_selfhost_regression_static_assoc_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(os.join_path(root, 'shapes')) or { panic(err) }
+	os.write_file(os.join_path(root, 'v.mod'), "Module { name: 'selfhost_regression_static_assoc' }\n") or {
+		panic(err)
+	}
+	os.write_file(os.join_path(root, 'shapes/shapes.v'), 'module shapes
+
+pub struct Box {
+pub:
+	w int
+	h int
+}
+
+pub fn Box.make(w int) Box {
+	return Box{
+		w: w
+		h: w * 2
+	}
+}
+') or { panic(err) }
+	main_path := os.join_path(root, 'main.v')
+	os.write_file(main_path, 'module main
+
+import shapes
+
+fn pick(n int) !int {
+	if n < 0 {
+		return error("neg")
+	}
+	return n
+}
+
+fn build(n int) shapes.Box {
+	return shapes.Box.make(pick(n) or {
+		if n == -1 {
+			7
+		} else {
+			9
+		}
+	})
+}
+
+fn main() {
+	b := build(3)
+	println("\${b.w}-\${b.h}")
+	c := build(-1)
+	println("\${c.w}-\${c.h}")
+}
+') or { panic(err) }
+	bin := os.join_path(os.temp_dir(), 'v3_selfhost_regression_static_assoc_bin_${os.getpid()}')
+	compile := os.execute('${v3_bin} -nocache -b c -o ${bin} ${main_path}')
+	assert compile.exit_code == 0, compile.output
+	assert !compile.output.contains('C compilation failed'), compile.output
+	run := os.execute(bin)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space().split_into_lines() == ['3-6', '7-14']
 }

--- a/vlib/v3/tests/selfhost_transform_regression_test.v
+++ b/vlib/v3/tests/selfhost_transform_regression_test.v
@@ -1,0 +1,121 @@
+import os
+
+const selfhost_regression_vexe = @VEXE
+const selfhost_regression_tests_dir = os.dir(@FILE)
+const selfhost_regression_v3_dir = os.dir(selfhost_regression_tests_dir)
+const selfhost_regression_vlib_dir = os.dir(selfhost_regression_v3_dir)
+const selfhost_regression_v3_src = os.join_path(selfhost_regression_v3_dir, 'v3.v')
+
+fn selfhost_regression_v3_bin_path() string {
+	return os.join_path(os.temp_dir(), 'v3_selfhost_transform_regression_test')
+}
+
+fn testsuite_begin() {
+	os.rm(selfhost_regression_v3_bin_path()) or {}
+}
+
+fn selfhost_regression_build_v3() string {
+	v3_bin := selfhost_regression_v3_bin_path()
+	if os.exists(v3_bin) {
+		return v3_bin
+	}
+	build := os.execute('${selfhost_regression_vexe} -gc none -path "${selfhost_regression_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${selfhost_regression_v3_src}')
+	assert build.exit_code == 0, build.output
+	return v3_bin
+}
+
+fn selfhost_regression_run(name string, source string) string {
+	v3_bin := selfhost_regression_build_v3()
+	src := os.join_path(os.temp_dir(), 'v3_selfhost_regression_${name}.v')
+	bin := os.join_path(os.temp_dir(), 'v3_selfhost_regression_${name}')
+	os.write_file(src, source) or { panic(err) }
+	compile := os.execute('${v3_bin} -nocache -b c -o ${bin} ${src}')
+	assert compile.exit_code == 0, compile.output
+	assert !compile.output.contains('C compilation failed'), compile.output
+	run := os.execute(bin)
+	assert run.exit_code == 0, run.output
+	return run.output.trim_space()
+}
+
+// A value `if`/`match` call argument is materialized into a value temp, and the call is rebuilt
+// over the materialized operands and re-dispatched. In a generic clone the checker has no
+// recorded type for an enum-shorthand `if`, so the materialization falls back to plain
+// `transform_expr`, which rebuilds the branch unchanged in shape. The re-dispatch used to see a
+// changed-but-still-a-branch operand and recurse forever, overflowing the stack.
+fn test_untyped_enum_branch_argument_in_generic_clone_terminates() {
+	out := selfhost_regression_run('untyped_enum_branch_arg', '\nenum Op {\n\tdot\n\tarrow\n}\n\nstruct Sel {\nmut:\n\tn int\n}\n\nfn (mut s Sel) make_selector_op(base int, field string, typ string, op Op) string {\n\ts.n++\n\treturn "${base}-${field}-${typ}-${op}"\n}\n\nfn (mut s Sel) wrap[U](v U, expr_type string) string {\n\tbase := s.n + 1\n\tfield := "${v}"\n\tfield_typ := "x${field}"\n\treturn s.make_selector_op(base, field, field_typ, if expr_type.starts_with("&") {\n\t\t.arrow\n\t} else {\n\t\t.dot\n\t})\n}\n\nfn main() {\n\tmut s := Sel{}\n\tprintln(s.wrap(1, "&int"))\n\tprintln(s.wrap("s", "int"))\n}\n')
+	assert out.split_into_lines() == ['1-1-x1-arrow', '2-s-xs-dot']
+}
+
+// A module-qualified callee (`os.abs_path(...)`) is a selector whose base names an import, not a
+// value. When a later argument hoists a value branch, the source-order guards used to snapshot
+// that base into a temp, emitting `unknown __order_snapshot_0 = os;`.
+fn test_module_qualified_call_with_branch_argument() {
+	out := selfhost_regression_run('module_qualified_branch_arg', '
+import os
+
+fn pick(name string) !string {
+	if name.len == 0 {
+		return error("empty")
+	}
+	return name
+}
+
+fn base_dir(name string) string {
+	return os.abs_path(pick(name) or {
+		if os.getenv("V3_SELFHOST_REGRESSION_UNSET") == "1" {
+			"/tmp/a"
+		} else {
+			"/tmp/b"
+		}
+	})
+}
+
+fn main() {
+	println(base_dir("") == os.abs_path("/tmp/b"))
+	println(base_dir("/tmp/c") == os.abs_path("/tmp/c"))
+}
+')
+	assert out.split_into_lines() == ['true', 'true']
+}
+
+// Only `for k, mut v in m` binds the map value by reference. A container that is merely a map
+// reference (`m &map[string]bool`) still binds a plain value copy, so the binding must not be
+// typed `&V` — that made every use of it emit a dereference of a non-pointer local.
+fn test_for_in_over_map_reference_binds_value() {
+	out := selfhost_regression_run('for_in_map_reference', '
+fn count_used(used &map[string]bool) int {
+	mut n := 0
+	for name, is_used in used {
+		if !is_used || name.len == 0 {
+			continue
+		}
+		n++
+	}
+	return n
+}
+
+fn double_values(mut m map[string]int) {
+	for _, mut v in m {
+		v = v * 2
+	}
+}
+
+fn main() {
+	flags := {
+		"a": true
+		"b": false
+		"c": true
+	}
+	println(count_used(&flags))
+	mut counts := {
+		"a": 1
+		"b": 2
+	}
+	double_values(mut counts)
+	println(counts["a"])
+	println(counts["b"])
+}
+')
+	assert out.split_into_lines() == ['2', '2', '4']
+}

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -2231,6 +2231,30 @@ fn (t &Transformer) selector_is_lexical_module_call(base_id flat.NodeId, method 
 	return call_name == '${module_name}.${method}'
 }
 
+// call_selector_base_is_namespace reports whether the base of a selector callee names a
+// compile-time namespace rather than a runtime value: the `C` pseudo-module, an imported module
+// (`os.abs_path(...)`, `flat.node_payload(...)`), or a type in a static associated call
+// (`Type.make(...)`). Such a base has no storage, so the call-operand ordering guards must not
+// stabilize or snapshot it — spilling it emits a declaration of an undeclared identifier at an
+// `unknown` type (`unknown __order_snapshot_0 = os;`) — and treat only the arguments as operands.
+fn (t &Transformer) call_selector_base_is_namespace(base_id flat.NodeId, method string, call_name string) bool {
+	if int(base_id) < 0 || int(base_id) >= t.a.nodes.len {
+		return false
+	}
+	base := t.a.nodes[int(base_id)]
+	if base.kind != .ident {
+		return false
+	}
+	if base.value == 'C' || t.selector_is_lexical_module_call(base_id, method, call_name)
+		|| t.is_import_alias_ident(base_id) {
+		return true
+	}
+	if _ := t.static_assoc_fn_name(base_id, method) {
+		return true
+	}
+	return false
+}
+
 fn (t &Transformer) is_import_alias_ident(id flat.NodeId) bool {
 	if int(id) < 0 || isnil(t.tc) {
 		return false

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -2234,20 +2234,22 @@ fn (t &Transformer) selector_is_lexical_module_call(base_id flat.NodeId, method 
 // call_selector_base_is_namespace reports whether the base of a selector callee names a
 // compile-time namespace rather than a runtime value: the `C` pseudo-module, an imported module
 // (`os.abs_path(...)`, `flat.node_payload(...)`), or a type in a static associated call
-// (`Type.make(...)`). Such a base has no storage, so the call-operand ordering guards must not
-// stabilize or snapshot it — spilling it emits a declaration of an undeclared identifier at an
-// `unknown` type (`unknown __order_snapshot_0 = os;`) — and treat only the arguments as operands.
+// (`Type.make(...)`, `mod.Type.make(...)`). Such a base has no storage, so the call-operand
+// ordering guards must not stabilize or snapshot it — spilling it declares an undeclared
+// identifier at an unusable type (`unknown __order_snapshot_0 = os;`,
+// `void __order_snapshot_0 = mod__Type;`) — and must treat only the arguments as operands.
 fn (t &Transformer) call_selector_base_is_namespace(base_id flat.NodeId, method string, call_name string) bool {
 	if int(base_id) < 0 || int(base_id) >= t.a.nodes.len {
 		return false
 	}
 	base := t.a.nodes[int(base_id)]
-	if base.kind != .ident {
-		return false
-	}
-	if base.value == 'C' || t.selector_is_lexical_module_call(base_id, method, call_name)
-		|| t.is_import_alias_ident(base_id) {
-		return true
+	// The module and `C` spellings are single identifiers, but a static associated call also
+	// reaches its type through a selector (`mod.Type.make(...)`), so that check must see both.
+	if base.kind == .ident {
+		if base.value == 'C' || t.selector_is_lexical_module_call(base_id, method, call_name)
+			|| t.is_import_alias_ident(base_id) {
+			return true
+		}
 	}
 	if _ := t.static_assoc_fn_name(base_id, method) {
 		return true

--- a/vlib/v3/transform/for.v
+++ b/vlib/v3/transform/for.v
@@ -541,7 +541,12 @@ fn (mut t Transformer) rebuild_for_in_stmt(_id flat.NodeId, node flat.Node) []fl
 				t.infer_for_in_elem_type(iter_type, node)
 			}
 			if elem_type.len > 0 {
-				val_type := if node.op == .amp || iter_type.starts_with('&map[') {
+				// Only `for k, mut v in m` (`.amp`) binds the value by reference, and C
+				// generation declares the binding by reference on that same condition. A
+				// container that is merely a map *reference* (`m &map[string]bool`) still binds
+				// a plain value copy, so typing it `&V` here makes every use of the binding
+				// emit a dereference of a non-pointer local.
+				val_type := if node.op == .amp {
 					'&${elem_type}'
 				} else {
 					elem_type
@@ -560,7 +565,7 @@ fn (mut t Transformer) rebuild_for_in_stmt(_id flat.NodeId, node flat.Node) []fl
 					t.infer_for_in_elem_type(iter_type, node)
 				}
 				if elem_type.len > 0 {
-					value_type := if node.op == .amp || iter_type.starts_with('&map[') {
+					value_type := if node.op == .amp {
 						'&${elem_type}'
 					} else {
 						elem_type

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -17065,6 +17065,27 @@ fn (mut t Transformer) transform_value_operand(id flat.NodeId) flat.NodeId {
 	return t.transform_expr(id)
 }
 
+// materialize_value_branch_operand is transform_value_operand for a caller that rebuilds its
+// node over the materialized operands and re-dispatches over the rebuilt node. That protocol
+// needs the rewrite to make progress: `transform_value_operand` only materializes a branch when
+// it has a usable value type, and otherwise falls back to plain `transform_expr`, which rebuilds
+// the branch with the same shape under a fresh id (e.g. `f(a, b, c, if cond { .arrow } else {
+// .dot })`, whose enum-shorthand arms leave the `if` untyped). The caller would then see a
+// changed operand that is still a branch and re-dispatch forever, overflowing the stack. Detect
+// that, drop the prelude the failed attempt queued, and return the operand unchanged so the
+// caller leaves it to its ordinary operand lowering.
+fn (mut t Transformer) materialize_value_branch_operand(id flat.NodeId) flat.NodeId {
+	pending_mark := t.pending_stmts.len
+	value := t.transform_value_operand(id)
+	if value != id && t.operand_hoists_value_branch(value) {
+		if t.pending_stmts.len > pending_mark {
+			t.pending_stmts = t.pending_stmts[..pending_mark].clone()
+		}
+		return id
+	}
+	return value
+}
+
 // transform_infix_expr transforms transform infix expr data for transform.
 fn (mut t Transformer) transform_infix_expr(id flat.NodeId, node flat.Node) flat.NodeId {
 	if node.children_count < 2 {
@@ -17241,7 +17262,7 @@ fn (mut t Transformer) transform_infix_expr(id flat.NodeId, node flat.Node) flat
 		// (idents/literals) are left untouched for the re-dispatch to transform once.
 		pending_start := t.pending_stmts.len
 		new_lhs := if lhs_is_value_branch {
-			t.transform_value_operand(infix_lhs_id)
+			t.materialize_value_branch_operand(infix_lhs_id)
 		} else if rhs_is_value_branch && t.operand_needs_ordering_snapshot(infix_lhs_id) {
 			t.snapshot_expr_for_reuse(infix_lhs_id)
 		} else {
@@ -17253,7 +17274,7 @@ fn (mut t Transformer) transform_infix_expr(id flat.NodeId, node flat.Node) flat
 			t.pending_stmts = t.pending_stmts[..pending_start].clone()
 		}
 		new_rhs := if rhs_is_value_branch {
-			t.transform_value_operand(infix_rhs_id)
+			t.materialize_value_branch_operand(infix_rhs_id)
 		} else if lhs_is_value_branch && !t.is_stable_expr_for_reuse(infix_rhs_id) {
 			t.stable_expr_for_reuse(infix_rhs_id)
 		} else {
@@ -17393,13 +17414,18 @@ fn (mut t Transformer) transform_call_expr(id flat.NodeId, node flat.Node) flat.
 		} else {
 			flat.empty_node
 		}
+		// A module/type-qualified callee (`os.abs_path(...)`, `Type.make(...)`) is a selector
+		// whose base names a compile-time namespace, not a value: it has no runtime storage to
+		// stabilize or snapshot, so only its arguments take ordering treatment.
+		is_namespace_call := is_selector_call
+			&& t.call_selector_base_is_namespace(recv_sel_base_id, recv_fn.value, node.value)
 		// A function-valued field callee (`p.callback(...)`) is a selector but not a method call:
 		// the field holds a function value that an argument prelude can replace (via a
 		// reference-backed holder), so it must be snapshotted whole like any other runtime callee
 		// rather than treated as a method that only stabilizes its receiver.
-		is_fn_field_callee := is_selector_call
+		is_fn_field_callee := is_selector_call && !is_namespace_call
 			&& t.receiver_selector_is_fn_field(t.normalize_type_alias(t.trim_pointer_type(t.lvalue_type(recv_sel_base_id))), recv_fn.value)
-		is_method := is_selector_call && !is_fn_field_callee
+		is_method := is_selector_call && !is_fn_field_callee && !is_namespace_call
 		recv_id := if is_method { recv_sel_base_id } else { flat.empty_node }
 		// A plain (non-method) call whose callee is itself a value branch —
 		// `(match node { ... make_cb(node)! ... })()` — must materialize operand 0 too;
@@ -17435,7 +17461,7 @@ fn (mut t Transformer) transform_call_expr(id flat.NodeId, node flat.Node) flat.
 			mut new_fn_id := recv_fn_id
 			if is_method {
 				new_recv := if t.is_value_match_or_if_operand(recv_id) {
-					r := t.transform_value_operand(recv_id)
+					r := t.materialize_value_branch_operand(recv_id)
 					if r != recv_id {
 						changed = true
 					}
@@ -17478,12 +17504,13 @@ fn (mut t Transformer) transform_call_expr(id flat.NodeId, node flat.Node) flat.
 					pos:            recv_fn.pos
 				})
 			} else if callee_is_value_branch {
-				r := t.transform_value_operand(recv_fn_id)
+				r := t.materialize_value_branch_operand(recv_fn_id)
 				if r != recv_fn_id {
 					new_fn_id = r
 					changed = true
 				}
-			} else if last_branch > 0 && t.callee_needs_ordering_snapshot(recv_fn_id) {
+			} else if last_branch > 0 && !is_namespace_call
+				&& t.callee_needs_ordering_snapshot(recv_fn_id) {
 				// A non-method runtime callee (make_cb(mut trace)(match ...), or a function-valued
 				// variable a branch could reassign) must evaluate before a later branch argument's
 				// hoisted prelude, so snapshot it in source order.
@@ -17497,7 +17524,7 @@ fn (mut t Transformer) transform_call_expr(id flat.NodeId, node flat.Node) flat.
 			for i in 1 .. node.children_count {
 				arg_id := t.a.child(&node, i)
 				na := if t.is_value_match_or_if_operand(arg_id) {
-					t.transform_value_operand(arg_id)
+					t.materialize_value_branch_operand(arg_id)
 				} else if i < last_branch && t.operand_needs_ordering_snapshot(arg_id) {
 					// A `mut` argument keeps its lvalue identity (only its dynamic base/index
 					// components are spilled) so it still mutates through. An ordinary argument is
@@ -20322,7 +20349,7 @@ fn (mut t Transformer) transform_cast_expr(id flat.NodeId, node flat.Node) flat.
 	if node.children_count == 1 {
 		match_cast_child := t.a.child(&node, 0)
 		if t.is_value_match_or_if_operand(match_cast_child) {
-			value := t.transform_value_operand(match_cast_child)
+			value := t.materialize_value_branch_operand(match_cast_child)
 			if value != match_cast_child {
 				start := t.a.children.len
 				t.a.children << value


### PR DESCRIPTION
## Problem

```
$ ../../v -gc none -prealloc -prod -o v3 v3.v && ./v3 -nocache -building-v -o v4 v3.v
  markused                37.16 ms     1256 MB RSS ...
zsh: segmentation fault  ./v3 -nocache -building-v -o v4 v3.v
```

The crash is a stack overflow from an unbounded `transform_call_expr` self-recursion (~6300 frames):

```
frame #1: v3__types__TypeChecker_resolve_type_uncached
...
frame #9:  v3__transform__Transformer_transform_call_expr + 2848
frame #10: v3__transform__Transformer_transform_call_expr + 3168
frame #11: v3__transform__Transformer_transform_call_expr + 3168   <- x6276
```

## Cause

A call with a value `match`/`if` operand is rebuilt over the materialized operands and re-dispatched over the rebuilt node. `transform_value_operand` only materializes a branch when it has a usable value type; otherwise it falls back to plain `transform_expr`, which rebuilds the branch with the same shape under a fresh id. The re-dispatch then saw a *changed but still a branch* operand, rebuilt the call again, and recursed forever.

The self-host trigger is in `vlib/v3/transform/sum.v`:

```v
field_sel := t.make_selector_op(new_expr, field, field_typ, if expr_type.starts_with('&') {
    .arrow
} else {
    .dot
})
```

Inside a clone the checker has no recorded type for the enum-shorthand `if`, so it never materializes.

## Fix

`materialize_value_branch_operand` makes the re-dispatch protocol require progress: when the lowering leaves a branch behind, it drops the prelude the failed attempt queued and returns the operand unchanged, so the caller falls back to its ordinary operand lowering. Applied at every rebuild-and-re-dispatch site — call receiver, callee, arguments, infix operands and cast operand.

Two pre-existing bugs sat behind the crash and also blocked the self-host build (they are only reachable once transform completes):

- **Module qualifier snapshotted as a value.** A module/type-qualified callee (`os.abs_path(...)`, `flat.node_payload(...)`) is a selector whose base names a compile-time namespace, not a value. When a later argument hoisted a value branch, the source-order guards snapshotted that base into a temp and emitted `unknown __order_snapshot_0 = os;`.
- **`for k, v in <&map>` bound the value by reference.** Only `for k, mut v in m` binds by reference, and C generation declares the binding by reference on that same condition. A container that is merely a map reference (`m &map[string]bool`) still binds a plain value copy, so typing it `&V` made every use emit a dereference of a non-pointer local (`if (!*is_used)`).

## Verification

With all three fixed:

- `v3 -nocache -building-v -o v4 v3.v` completes, and the following `v4 -> v5` generation completes too.
- `v3 -nocache -selfhost -o v4 v3.v` completes (on master it segfaults in transform in this mode as well).

`vlib/v3/tests/selfhost_transform_regression_test.v` adds a minimal repro for each of the three, all of which segfault or fail C compilation on master:

- an untyped enum-shorthand `if` argument in a generic clone (segfault),
- `os.abs_path(pick(name) or { if ... })` (`use of undeclared identifier 'os'`),
- `for name, is_used in used` over `used &map[string]bool` (`indirection requires pointer operand ('int' invalid)`).

## Known remaining, not addressed here

`-selfhost` with the module cache enabled (i.e. without `-nocache`) still crashes later, in cgen: `parse_type_cache_put` -> `map_set` writes through a corrupt map, so `pre_tc.type_cache` is dangling on that path. It is pre-existing and unreachable on master (transform crashes first), and independent of these changes — `-nocache` builds are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)