### PR TITLE
v3: speed up FastC self-host generation to ~4M loc/s

### DIFF
--- a/vlib/v3/README.md
+++ b/vlib/v3/README.md
@@ -177,12 +177,20 @@ Source resolution reads the program on worker threads before the ordering walk r
 imported module directory is listed on a thread and its files are read in chunks on further
 threads, never more than the worker limit (CPU count or `VJOBS`) at once. The main thread joins
 listings first and then the chunks in start order, resolving the imports of each chunk as it
-lands, so reading one module overlaps with discovering the next. The generic-method scan and the
-declaration index share one pass, the split of oversized files into generation fragments and the
-by-name struct field index are built on workers while the declaration phases run, and the
-generated C is returned as ordered pieces (whole per-file bodies are shared rather than copied
-into one buffer; only bodies cut around C directive lines are copied) that the drivers write
-directly.
+lands, so reading one module overlaps with discovering the next. A resolve memo in `os.vtmp_dir()`
+(`fastc_resolve_<hash>.memo`, keyed by the entry files, vroot, target and defines) records what
+the previous resolution of the same entry touched, so the next run lists every directory, looks
+up every module and stats every file in one batch instead of level by level along the import
+chain; a file's content is taken from the memo's blob only when its size, mtime, ctime and inode
+still match and it was last modified at least two seconds before the memo was written, and it is
+read again otherwise. The ordering walk itself is unchanged and replays over that data, so the
+output is identical with and without the memo (`V3_FASTC_NO_RESOLVE_MEMO=1` disables it). The
+type declarations are rendered on a worker while the signatures are collected, the generic-method
+scan and the declaration index share one pass, the split of oversized files into generation
+fragments and the by-name struct field index are built on workers while the declaration phases
+run, and the generated C is returned as ordered pieces (whole per-file bodies are shared rather
+than copied into one buffer; only bodies cut around C directive lines are copied) that the drivers
+write directly.
 
 The standalone compiler supports `self` directly and defaults that command to FastC. For example,
 `./v self x5` replaces the compiler through five descendant FastC generations, with each installed

--- a/vlib/v3/README.md
+++ b/vlib/v3/README.md
@@ -190,7 +190,10 @@ scan and the declaration index share one pass, the split of oversized files into
 fragments and the by-name struct field index are built on workers while the declaration phases
 run, and the generated C is returned as ordered pieces (whole per-file bodies are shared rather
 than copied into one buffer; only bodies cut around C directive lines are copied) that the drivers
-write directly.
+write directly. The declaration index records the text spans of each file's constant and global
+declarations: a large file's constants are parsed as separate parallel candidates (merged in
+source order), and the global phase parses only the recorded global declarations instead of
+whole files.
 
 The standalone compiler supports `self` directly and defaults that command to FastC. For example,
 `./v self x5` replaces the compiler through five descendant FastC generations, with each installed

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -8365,6 +8365,9 @@ pub fn run(args []string) {
 
 	// Parse directly to flat AST
 	mut prefs := pref.new_preferences()
+	if os.getenv('FASTC_BENCH_PHASES') != '' {
+		eprintln('fastc-phase driver.prefs ${driver_sw.elapsed().microseconds()}us')
+	}
 	prefs.target = target
 	prefs.thread_stack_size = if thread_stack_size_set {
 		thread_stack_size
@@ -8397,6 +8400,9 @@ pub fn run(args []string) {
 	}
 	explicit_tcc = c_compiler_explicit && effective_c_compiler == 'tinyc'
 	add_v3_tcc_compat_defines(mut user_defines, target.os, target.arch, is_shared, explicit_tcc)
+	if os.getenv('FASTC_BENCH_PHASES') != '' {
+		eprintln('fastc-phase driver.defines ${driver_sw.elapsed().microseconds()}us')
+	}
 	prefs.ccompiler = effective_c_compiler
 	prefs.no_parallel = current_no_parallel
 	prefs.c99 = c99
@@ -8454,6 +8460,9 @@ pub fn run(args []string) {
 				&& canonical_v3_fastc_output_path(fastc_artifact_file) == os.real_path(input_file) {
 				eprintln('fastc output path `${fastc_artifact_file}` aliases input source `${input_file}`')
 				exit(1)
+			}
+			if os.getenv('FASTC_BENCH_PHASES') != '' {
+				eprintln('fastc-phase driver.entry_checks ${driver_sw.elapsed().microseconds()}us')
 			}
 			fastc_host := pref.host_target()
 			fastc_cross_target := target.os != fastc_host.os || target.arch != fastc_host.arch

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -8339,6 +8339,7 @@ pub fn run(args []string) {
 	}
 
 	mut b := bench.new()
+	driver_sw := time.new_stopwatch()
 	if silent || c_to_stdout {
 		b.set_quiet()
 	}
@@ -8528,10 +8529,16 @@ pub fn run(args []string) {
 					return
 				}
 			}
+			if os.getenv('FASTC_BENCH_PHASES') != '' {
+				eprintln('fastc-phase driver.setup ${driver_sw.elapsed().microseconds()}us')
+			}
 			fastc_generation := fastc.generate_files_with_source_paths([input_file], prefs) or {
 				eprintln(err.msg())
 				exit(1)
 				return
+			}
+			if os.getenv('FASTC_BENCH_PHASES') != '' {
+				eprintln('fastc-phase driver.generated ${driver_sw.elapsed().microseconds()}us')
 			}
 			fastc_artifact_path := canonical_v3_fastc_output_path(fastc_artifact_file)
 			for source_path in fastc_generation.source_paths {

--- a/vlib/v3/gen/fastc/decl.v
+++ b/vlib/v3/gen/fastc/decl.v
@@ -1,6 +1,8 @@
 module fastc
 
+import os
 import strings
+import time
 import v3.pref
 import v3.scanner
 import v3.token
@@ -980,15 +982,20 @@ fn fastc_parse_constant_file(ctx &FastcConstantGenContext, source_file FastcSour
 // counter runs past the end of `order` (largest files first).
 fn fastc_parse_constant_file_worker(ctx &FastcConstantGenContext, candidates []FastcSourceFile, seed map[string]string, order []int, queue &FastcGenQueue) []FastcIndexedConstantFileResult {
 	mut results := []FastcIndexedConstantFileResult{}
+	bench_files := os.getenv('FASTC_BENCH_FILES') != ''
 	for {
 		slot := fastc_atomic_fetch_add_u32(&queue.next, 1)
 		if slot >= u32(order.len) {
 			break
 		}
 		index := order[slot]
+		file_sw := time.new_stopwatch()
 		results << FastcIndexedConstantFileResult{
 			index:  index
 			result: fastc_parse_constant_file(ctx, candidates[index], seed.clone())
+		}
+		if bench_files {
+			eprintln('fastc-constants-file ${file_sw.elapsed().microseconds()}us ${candidates[index].source.len} bytes ${candidates[index].path}')
 		}
 	}
 	return results
@@ -1081,7 +1088,10 @@ fn fastc_generate_constant_declarations(ordered_sources []FastcSourceFile, const
 			header: source_file.header
 		}
 	}
+	sw := time.new_stopwatch()
 	parallel_results := fastc_parse_constant_files_parallel(&ctx, candidates, constant_types)
+	parallel_us := sw.elapsed().microseconds()
+	mut serial_count := 0
 	for index, candidate in candidates {
 		if index < parallel_results.len {
 			result := parallel_results[index]
@@ -1099,6 +1109,7 @@ fn fastc_generate_constant_declarations(ordered_sources []FastcSourceFile, const
 				continue
 			}
 		}
+		serial_count++
 		mut serial := fastc_parse_constant_file(&ctx, candidate, constant_types)
 		if serial.failed {
 			return error(serial.error_message)
@@ -1111,6 +1122,9 @@ fn fastc_generate_constant_declarations(ordered_sources []FastcSourceFile, const
 		for name, array_type in serial.fixed_array_types {
 			fixed_array_types[name] = array_type
 		}
+	}
+	if os.getenv('FASTC_BENCH_PHASES') != '' {
+		eprintln('fastc-phase constants.detail candidates=${candidates.len} parallel_us=${parallel_us} serial=${serial_count} merge_us=${sw.elapsed().microseconds() - parallel_us}')
 	}
 	mut runtime_constants := map[string]bool{}
 	for value in values {
@@ -1390,6 +1404,49 @@ fn (g &Parser) constant_expression_requires_runtime_storage(tokens []FastcExpres
 	return false
 }
 
+// fastc_composite_typedefs renders the typedefs of the composite (`Array_x`,
+// `Map_k_v`) types named by signatures and struct fields. It precedes the
+// type declarations in the output; it is rendered after the type phase and
+// the signature phase have both contributed their names.
+fn fastc_composite_typedefs(composite_types map[string]bool) string {
+	mut out := strings.new_builder(1024)
+	mut composite_names := composite_types.keys()
+	composite_names.sort()
+	for composite_name in composite_names {
+		base := if composite_name.starts_with('Array_') { 'array' } else { 'map' }
+		out.writeln('typedef ${base} ${composite_name};')
+	}
+	out.writeln('')
+	return out.str()
+}
+
+// FastcTypeDeclarationResult is the type phase's output with the tables it
+// fills, so the phase can run on a worker and hand them back.
+struct FastcTypeDeclarationResult {
+mut:
+	output            FastcTypeDeclarations
+	struct_fields     map[string]map[string]string
+	struct_field_info map[string][]FastcStructField
+	composite_types   map[string]bool
+	failed            bool
+	error_message     string
+}
+
+// fastc_run_type_declarations runs the type phase into fresh tables.
+fn fastc_run_type_declarations(sources []FastcSourceFile, type_sources map[string]string, prefs &pref.Preferences, type_source_paths map[string]bool, declared_types map[string]bool, declared_kinds map[string]FastcDeclaredTypeKind, enum_flags map[string]bool, constants map[string]string, public_constants map[string]bool) FastcTypeDeclarationResult {
+	mut result := FastcTypeDeclarationResult{
+		struct_fields:     map[string]map[string]string{}
+		struct_field_info: map[string][]FastcStructField{}
+		composite_types:   map[string]bool{}
+	}
+	result.output = fastc_generate_type_declarations(sources, type_sources, prefs, type_source_paths, declared_types, declared_kinds, enum_flags, constants, public_constants, mut result.struct_fields, mut result.struct_field_info, mut result.composite_types) or {
+		result.failed = true
+		result.error_message = err.msg()
+		return result
+	}
+	return result
+}
+
 fn fastc_generate_type_declarations(sources []FastcSourceFile, type_sources map[string]string, prefs &pref.Preferences, type_source_paths map[string]bool, declared_types map[string]bool, declared_kinds map[string]FastcDeclaredTypeKind, enum_flags map[string]bool, constants map[string]string, public_constants map[string]bool, mut struct_fields map[string]map[string]string, mut struct_field_info map[string][]FastcStructField, mut composite_types map[string]bool) !FastcTypeDeclarations {
 	mut out := strings.new_builder(4096)
 	mut bodies := strings.new_builder(4096)
@@ -1435,13 +1492,9 @@ fn fastc_generate_type_declarations(sources []FastcSourceFile, type_sources map[
 			enum_infos, mut bodies)!
 	}
 	timer.mark('type_declarations.emit')
-	mut composite_names := composite_types.keys()
-	composite_names.sort()
-	for composite_name in composite_names {
-		base := if composite_name.starts_with('Array_') { 'array' } else { 'map' }
-		out.writeln('typedef ${base} ${composite_name};')
-	}
-	out.writeln('')
+	// The composite typedefs go here in the output; they are rendered by the
+	// caller once the signature phase has contributed its names too.
+	declarations_head := out.str()
 	mut type_bodies := fastc_hoist_c_type_aliases(bodies.str())
 	timer.mark('type_declarations.hoist')
 	if prefs.building_v {
@@ -1474,6 +1527,7 @@ fn fastc_generate_type_declarations(sources []FastcSourceFile, type_sources map[
 	enum_string_helpers := fastc_generate_enum_string_helpers(enum_infos)
 	timer.mark('type_declarations.enum_helpers')
 	return FastcTypeDeclarations{
+		declarations_head:   declarations_head
 		declarations:        out.str()
 		enum_string_helpers: enum_string_helpers
 		alias_base_types:    alias_base_types

--- a/vlib/v3/gen/fastc/decl.v
+++ b/vlib/v3/gen/fastc/decl.v
@@ -316,21 +316,38 @@ fn fastc_register_constant(module_name string, name string, is_public bool, path
 	}
 }
 
-fn collect_global_names(source string, path string, header FastcSourceHeader, prefs &pref.Preferences, mut globals map[string]string, mut public_globals map[string]bool, mut global_paths map[string]string) ! {
+// collect_global_names registers a file's globals and appends the text of
+// their declarations (and of the comptime blocks that select them) to
+// `global_source`, so the global phase parses only that text.
+fn collect_global_names(source string, path string, header FastcSourceHeader, prefs &pref.Preferences, mut globals map[string]string, mut public_globals map[string]bool, mut global_paths map[string]string, mut global_source strings.Builder) ! {
 	file := token.File.unindexed(path, source.len)
 	mut scan := scanner.new_scanner(prefs, .normal)
 	scan.init(file, source)
 	mut depth := 0
 	mut previous_tok := token.Token.unknown
+	mut previous_pos := 0
+	mut emitted_end := 0
+	// A single `__global name = value` declaration runs to the next top-level
+	// statement end; its span is closed there.
+	mut pending_start := -1
 	mut tok := scan.scan()
 	for tok != .eof {
 		if depth == 0 && tok == .dollar {
+			comptime_start := scan.pos
 			mut lookahead := scan
 			if lookahead.scan() == .key_if {
+				globals_before := globals.len
 				selected := fastc_scan_selected_comptime_branch(mut scan, scan.scan(), path, prefs)!
+				comptime_end := if selected.tok == .eof { scan.offset } else { scan.pos }
 				if selected.source != '' {
+					mut selected_source := strings.new_builder(64)
 					collect_global_names(selected.source, path, header, prefs, mut globals, mut
-						public_globals, mut global_paths)!
+						public_globals, mut global_paths, mut selected_source)!
+				}
+				if globals.len > globals_before {
+					fastc_append_filtered_source_span(source, emitted_end, comptime_start,
+						comptime_end, mut global_source)
+					emitted_end = comptime_end
 				}
 				tok = selected.tok
 				previous_tok = .unknown
@@ -339,6 +356,7 @@ fn collect_global_names(source string, path string, header FastcSourceHeader, pr
 		}
 		if depth == 0 && tok == .key_global {
 			is_public := previous_tok == .key_pub
+			declaration_start := if is_public { previous_pos } else { scan.pos }
 			tok = scan.scan()
 			if tok == .lpar {
 				tok = scan.scan()
@@ -355,13 +373,24 @@ fn collect_global_names(source string, path string, header FastcSourceHeader, pr
 					}
 					tok = scan.scan()
 				}
+				declaration_end := if tok == .rpar { scan.offset } else { scan.pos }
+				fastc_append_filtered_source_span(source, emitted_end, declaration_start,
+					declaration_end, mut global_source)
+				emitted_end = declaration_end
 				continue
 			}
 			if tok == .name && scan.lit != 'C' {
 				fastc_register_global(header, scan.lit, is_public, path, prefs, mut globals, mut
 					public_globals, mut global_paths)!
 			}
+			pending_start = declaration_start
 			continue
+		}
+		if pending_start >= 0 && depth == 0 && tok == .semicolon {
+			fastc_append_filtered_source_span(source, emitted_end, pending_start, scan.pos, mut
+				global_source)
+			emitted_end = scan.pos
+			pending_start = -1
 		}
 		if tok == .lcbr {
 			depth++
@@ -369,7 +398,12 @@ fn collect_global_names(source string, path string, header FastcSourceHeader, pr
 			depth--
 		}
 		previous_tok = tok
+		previous_pos = scan.pos
 		tok = scan.scan()
+	}
+	if pending_start >= 0 {
+		fastc_append_filtered_source_span(source, emitted_end, pending_start, source.len, mut
+			global_source)
 	}
 }
 
@@ -404,6 +438,7 @@ mut:
 	constant_paths      map[string]string
 	constant_sources    map[string]string
 	constant_spans      map[string][]int
+	global_sources      map[string]string
 	globals             map[string]string
 	public_globals      map[string]bool
 	global_paths        map[string]string
@@ -464,18 +499,23 @@ fn fastc_collect_declaration_chunk(sources []FastcSourceFile, prefs &pref.Prefer
 			}
 		}
 		if source_file.header.has_global_declarations {
+			mut global_source := strings.new_builder(256)
 			collect_global_names(source_file.source, source_file.path, source_file.header, prefs, mut
-				partial.globals, mut partial.public_globals, mut partial.global_paths) or {
+				partial.globals, mut partial.public_globals, mut partial.global_paths, mut
+				global_source) or {
 				partial.failed = true
 				partial.error_message = err.msg()
 				return partial
+			}
+			if global_source.len > 0 {
+				partial.global_sources[source_file.path] = global_source.str()
 			}
 		}
 	}
 	return partial
 }
 
-fn fastc_merge_declaration_partial(partial FastcDeclarationPartial, mut declared_types map[string]bool, mut declared_kinds map[string]FastcDeclaredTypeKind, mut enum_flags map[string]bool, mut params_structs map[string]bool, mut type_source_paths map[string]bool, mut type_sources map[string]string, mut constants map[string]string, mut public_constants map[string]bool, mut constant_sources map[string]string, mut constant_spans map[string][]int, mut globals map[string]string, mut public_globals map[string]bool) ! {
+fn fastc_merge_declaration_partial(partial FastcDeclarationPartial, mut declared_types map[string]bool, mut declared_kinds map[string]FastcDeclaredTypeKind, mut enum_flags map[string]bool, mut params_structs map[string]bool, mut type_source_paths map[string]bool, mut type_sources map[string]string, mut constants map[string]string, mut public_constants map[string]bool, mut constant_sources map[string]string, mut constant_spans map[string][]int, mut global_sources map[string]string, mut globals map[string]string, mut public_globals map[string]bool) ! {
 	if partial.failed {
 		return error(partial.error_message)
 	}
@@ -515,6 +555,9 @@ fn fastc_merge_declaration_partial(partial FastcDeclarationPartial, mut declared
 	for path, spans in partial.constant_spans {
 		constant_spans[path] = spans
 	}
+	for path, source in partial.global_sources {
+		global_sources[path] = source
+	}
 	for key, c_name in partial.globals {
 		if key in globals {
 			return error('fastc parser does not support duplicate global `${key.all_after_last('.')}` in ${partial.global_paths[key]}')
@@ -526,7 +569,7 @@ fn fastc_merge_declaration_partial(partial FastcDeclarationPartial, mut declared
 	}
 }
 
-fn fastc_generate_global_declarations(ordered_sources []FastcSourceFile, prefs &pref.Preferences, declared_types map[string]bool, declared_type_c_names map[string]string, fastc_prefixed_c_names []string, declared_kinds map[string]FastcDeclaredTypeKind, enum_flags map[string]bool, enum_field_types map[string]string, alias_base_types map[string]string, struct_fields map[string]map[string]string, struct_field_info map[string][]FastcStructField, functions map[string]FastcFunctionSignature, constants map[string]string, constant_values map[string]string, public_constants map[string]bool, constant_types map[string]string, globals map[string]string, public_globals map[string]bool, mut global_types map[string]string) !FastcGlobalDeclarations {
+fn fastc_generate_global_declarations(ordered_sources []FastcSourceFile, global_sources map[string]string, prefs &pref.Preferences, declared_types map[string]bool, declared_type_c_names map[string]string, fastc_prefixed_c_names []string, declared_kinds map[string]FastcDeclaredTypeKind, enum_flags map[string]bool, enum_field_types map[string]string, alias_base_types map[string]string, struct_fields map[string]map[string]string, struct_field_info map[string][]FastcStructField, functions map[string]FastcFunctionSignature, constants map[string]string, constant_values map[string]string, public_constants map[string]bool, constant_types map[string]string, globals map[string]string, public_globals map[string]bool, mut global_types map[string]string) !FastcGlobalDeclarations {
 	declared_type_key_by_name := fastc_declared_type_key_by_name(declared_types)
 	mut out := strings.new_builder(1024)
 	mut module_initializers := map[string]string{}
@@ -534,11 +577,9 @@ fn fastc_generate_global_declarations(ordered_sources []FastcSourceFile, prefs &
 	mut fixed_array_types := map[string]string{}
 	helper_has_c_functions := fastc_functions_declare_c(functions)
 	for source_file in ordered_sources {
-		if !source_file.header.has_global_declarations {
-			continue
-		}
+		global_source := global_sources[source_file.path] or { continue }
 		mut initializers := strings.new_builder(256)
-		file := token.File.unindexed(source_file.path, source_file.source.len)
+		file := token.File.unindexed(source_file.path, global_source.len)
 		mut gen := Parser{
 			prefs:                        unsafe { prefs }
 			unqualified_key_memo: map[string]string{}
@@ -580,7 +621,7 @@ fn fastc_generate_global_declarations(ordered_sources []FastcSourceFile, prefs &
 			composite_types:              map[string]bool{}
 			fixed_array_types:            map[string]string{}
 		}
-		gen.s.init(file, source_file.source)
+		gen.s.init(file, global_source)
 		gen.next()
 		gen.parse_selected_global_declarations(mut out, mut initializers, false)!
 		global_types = gen.global_types.move()

--- a/vlib/v3/gen/fastc/decl.v
+++ b/vlib/v3/gen/fastc/decl.v
@@ -155,7 +155,7 @@ fn collect_declared_types(source string, path string, module_name string, prefs 
 	return has_type_declarations
 }
 
-fn collect_constant_names(source string, path string, module_name string, prefs &pref.Preferences, mut constants map[string]string, mut public_constants map[string]bool, mut constant_paths map[string]string, mut constant_source strings.Builder) ! {
+fn collect_constant_names(source string, path string, module_name string, prefs &pref.Preferences, mut constants map[string]string, mut public_constants map[string]bool, mut constant_paths map[string]string, mut constant_source strings.Builder, mut constant_spans []int) ! {
 	file := token.File.unindexed(path, source.len)
 	mut scan := scanner.new_scanner(prefs, .normal)
 	scan.init(file, source)
@@ -172,11 +172,16 @@ fn collect_constant_names(source string, path string, module_name string, prefs 
 				comptime_end := if selected.tok == .eof { scan.offset } else { scan.pos }
 				if selected.source != '' {
 					mut selected_constants := strings.new_builder(256)
+					mut selected_spans := []int{}
 					collect_constant_names(selected.source, path, module_name, prefs, mut
-						constants, mut public_constants, mut constant_paths, mut selected_constants)!
+						constants, mut public_constants, mut constant_paths, mut selected_constants, mut selected_spans)!
 					if selected_constants.len > 0 {
+						constant_spans << constant_source.len
+
 						fastc_append_filtered_source_span(source, emitted_end, comptime_start,
 							comptime_end, mut constant_source)
+
+						constant_spans << constant_source.len
 						emitted_end = comptime_end
 					}
 				}
@@ -195,8 +200,12 @@ fn collect_constant_names(source string, path string, module_name string, prefs 
 				mut nested_depth := 0
 				for tok != .eof {
 					if nested_depth == 0 && tok == .rpar {
+						constant_spans << constant_source.len
+
 						fastc_append_filtered_source_span(source, emitted_end, declaration_start,
 							scan.offset, mut constant_source)
+
+						constant_spans << constant_source.len
 						emitted_end = scan.offset
 						tok = scan.scan()
 						break
@@ -240,8 +249,12 @@ fn collect_constant_names(source string, path string, module_name string, prefs 
 			for tok != .eof {
 				if nested_depth == 0 && tok == .semicolon {
 					declaration_end := if scan.offset > scan.pos { scan.offset } else { scan.pos }
+					constant_spans << constant_source.len
+
 					fastc_append_filtered_source_span(source, emitted_end, declaration_start,
 						declaration_end, mut constant_source)
+
+					constant_spans << constant_source.len
 					emitted_end = declaration_end
 					emitted = true
 					tok = scan.scan()
@@ -255,8 +268,12 @@ fn collect_constant_names(source string, path string, module_name string, prefs 
 				tok = scan.scan()
 			}
 			if tok == .eof && !emitted {
+				constant_spans << constant_source.len
+
 				fastc_append_filtered_source_span(source, emitted_end, declaration_start,
 					source.len, mut constant_source)
+
+				constant_spans << constant_source.len
 				emitted_end = source.len
 			}
 			previous_tok = .unknown
@@ -386,6 +403,7 @@ mut:
 	public_constants    map[string]bool
 	constant_paths      map[string]string
 	constant_sources    map[string]string
+	constant_spans      map[string][]int
 	globals             map[string]string
 	public_globals      map[string]bool
 	global_paths        map[string]string
@@ -431,15 +449,18 @@ fn fastc_collect_declaration_chunk(sources []FastcSourceFile, prefs &pref.Prefer
 		}
 		if source_file.header.has_constants {
 			mut constant_source := strings.new_builder(256)
+			mut constant_spans := []int{}
 			collect_constant_names(source_file.source, source_file.path,
 				source_file.header.module_name, prefs, mut partial.constants, mut
-				partial.public_constants, mut partial.constant_paths, mut constant_source) or {
+				partial.public_constants, mut partial.constant_paths, mut constant_source, mut
+				constant_spans) or {
 				partial.failed = true
 				partial.error_message = err.msg()
 				return partial
 			}
 			if constant_source.len > 0 {
 				partial.constant_sources[source_file.path] = constant_source.str()
+				partial.constant_spans[source_file.path] = constant_spans
 			}
 		}
 		if source_file.header.has_global_declarations {
@@ -454,7 +475,7 @@ fn fastc_collect_declaration_chunk(sources []FastcSourceFile, prefs &pref.Prefer
 	return partial
 }
 
-fn fastc_merge_declaration_partial(partial FastcDeclarationPartial, mut declared_types map[string]bool, mut declared_kinds map[string]FastcDeclaredTypeKind, mut enum_flags map[string]bool, mut params_structs map[string]bool, mut type_source_paths map[string]bool, mut type_sources map[string]string, mut constants map[string]string, mut public_constants map[string]bool, mut constant_sources map[string]string, mut globals map[string]string, mut public_globals map[string]bool) ! {
+fn fastc_merge_declaration_partial(partial FastcDeclarationPartial, mut declared_types map[string]bool, mut declared_kinds map[string]FastcDeclaredTypeKind, mut enum_flags map[string]bool, mut params_structs map[string]bool, mut type_source_paths map[string]bool, mut type_sources map[string]string, mut constants map[string]string, mut public_constants map[string]bool, mut constant_sources map[string]string, mut constant_spans map[string][]int, mut globals map[string]string, mut public_globals map[string]bool) ! {
 	if partial.failed {
 		return error(partial.error_message)
 	}
@@ -490,6 +511,9 @@ fn fastc_merge_declaration_partial(partial FastcDeclarationPartial, mut declared
 	}
 	for path, source in partial.constant_sources {
 		constant_sources[path] = source
+	}
+	for path, spans in partial.constant_spans {
+		constant_spans[path] = spans
 	}
 	for key, c_name in partial.globals {
 		if key in globals {
@@ -1053,7 +1077,11 @@ fn fastc_constant_file_is_independent(result FastcConstantFileResult) bool {
 	return true
 }
 
-fn fastc_generate_constant_declarations(ordered_sources []FastcSourceFile, constant_sources map[string]string, prefs &pref.Preferences, declared_types map[string]bool, declared_type_c_names map[string]string, fastc_prefixed_c_names []string, declared_kinds map[string]FastcDeclaredTypeKind, enum_flags map[string]bool, enum_field_types map[string]string, alias_base_types map[string]string, struct_fields map[string]map[string]string, struct_field_info map[string][]FastcStructField, functions map[string]FastcFunctionSignature, constants map[string]string, public_constants map[string]bool, globals map[string]string, public_globals map[string]bool, mut constant_types map[string]string) !FastcConstantDeclarations {
+// fastc_constant_split_size is the constant source size from which a file's
+// declarations are parsed as separate parallel candidates.
+const fastc_constant_split_size = 16 * 1024
+
+fn fastc_generate_constant_declarations(ordered_sources []FastcSourceFile, constant_sources map[string]string, constant_spans map[string][]int, prefs &pref.Preferences, declared_types map[string]bool, declared_type_c_names map[string]string, fastc_prefixed_c_names []string, declared_kinds map[string]FastcDeclaredTypeKind, enum_flags map[string]bool, enum_field_types map[string]string, alias_base_types map[string]string, struct_fields map[string]map[string]string, struct_field_info map[string][]FastcStructField, functions map[string]FastcFunctionSignature, constants map[string]string, public_constants map[string]bool, globals map[string]string, public_globals map[string]bool, mut constant_types map[string]string) !FastcConstantDeclarations {
 	mut values := []FastcConstantValue{}
 	mut composite_types := map[string]bool{}
 	mut fixed_array_types := map[string]string{}
@@ -1082,6 +1110,20 @@ fn fastc_generate_constant_declarations(ordered_sources []FastcSourceFile, const
 	mut candidates := []FastcSourceFile{cap: ordered_sources.len}
 	for source_file in ordered_sources {
 		constant_source := constant_sources[source_file.path] or { continue }
+		spans := constant_spans[source_file.path] or { []int{} }
+		if constant_source.len >= fastc_constant_split_size && spans.len > 2 {
+			// A large file's declarations parse as separate candidates, so its
+			// tables no longer bound the parallel pre-pass; the in-order merge
+			// sees them in source order, as it would within one file.
+			for i := 0; i + 1 < spans.len; i += 2 {
+				candidates << FastcSourceFile{
+					path:   source_file.path
+					source: constant_source[spans[i]..spans[i + 1]]
+					header: source_file.header
+				}
+			}
+			continue
+		}
 		candidates << FastcSourceFile{
 			path:   source_file.path
 			source: constant_source

--- a/vlib/v3/gen/fastc/expr.v
+++ b/vlib/v3/gen/fastc/expr.v
@@ -1910,12 +1910,11 @@ fn fastc_replace_c_call_identifier(source string, identifier string, replacement
 	mut out := strings.new_builder(source.len + replacement.len)
 	mut start := 0
 	for start < source.len {
-		remaining := source[start..]
-		relative := remaining.index(identifier) or {
-			out.write_string(remaining)
+		index := source.index_after_(identifier, start)
+		if index < 0 {
+			unsafe { out.write_ptr(source.str + start, source.len - start) }
 			break
 		}
-		index := start + relative
 		end := index + identifier.len
 		before_is_name_or_member := index > 0 && (source[index - 1].is_alnum() || source[index - 1] in [
 			`_`,
@@ -1925,7 +1924,7 @@ fn fastc_replace_c_call_identifier(source string, identifier string, replacement
 		for after < source.len && source[after] in [` `, `\t`, `\r`, `\n`] {
 			after++
 		}
-		out.write_string(source[start..index])
+		unsafe { out.write_ptr(source.str + start, index - start) }
 		if before_is_name_or_member || after >= source.len || source[after] != `(` {
 			out.write_string(identifier)
 		} else {
@@ -1943,17 +1942,16 @@ fn fastc_replace_c_root_identifier(source string, identifier string, replacement
 	mut out := strings.new_builder(source.len + replacement.len)
 	mut start := 0
 	for start < source.len {
-		remaining := source[start..]
-		relative := remaining.index(identifier) or {
-			out.write_string(remaining)
+		index := source.index_after_(identifier, start)
+		if index < 0 {
+			unsafe { out.write_ptr(source.str + start, source.len - start) }
 			break
 		}
-		index := start + relative
 		end := index + identifier.len
 		before_is_name := index > 0 && (source[index - 1].is_alnum() || source[index - 1] == `_`)
 		before_is_member := index > 0 && source[index - 1] in [`.`, `>`]
 		after_is_name := end < source.len && (source[end].is_alnum() || source[end] == `_`)
-		out.write_string(source[start..index])
+		unsafe { out.write_ptr(source.str + start, index - start) }
 		if before_is_name || before_is_member || after_is_name {
 			out.write_string(identifier)
 		} else {
@@ -1971,16 +1969,15 @@ fn fastc_replace_c_identifier(source string, identifier string, replacement stri
 	mut out := strings.new_builder(source.len + replacement.len)
 	mut start := 0
 	for start < source.len {
-		remaining := source[start..]
-		relative := remaining.index(identifier) or {
-			out.write_string(remaining)
+		index := source.index_after_(identifier, start)
+		if index < 0 {
+			unsafe { out.write_ptr(source.str + start, source.len - start) }
 			break
 		}
-		index := start + relative
 		end := index + identifier.len
 		before_is_name := index > 0 && (source[index - 1].is_alnum() || source[index - 1] == `_`)
 		after_is_name := end < source.len && (source[end].is_alnum() || source[end] == `_`)
-		out.write_string(source[start..index])
+		unsafe { out.write_ptr(source.str + start, index - start) }
 		if before_is_name || after_is_name {
 			out.write_string(identifier)
 		} else {

--- a/vlib/v3/gen/fastc/fastc.v
+++ b/vlib/v3/gen/fastc/fastc.v
@@ -1253,6 +1253,34 @@ struct FastcFileGenContext {
 // FastcFileGenOutput is one source file's generation result. The sequential
 // stitch loop consumes them in file order, so parallel workers never touch
 // the shared output builders or the merged registration maps.
+// FastcFileGenResult is every file's generation output in file order with the
+// union of the composite and fixed-array types they registered.
+struct FastcFileGenResult {
+	outputs           []FastcFileGenOutput
+	composite_types   map[string]bool
+	fixed_array_types map[string]string
+}
+
+// fastc_file_gen_result wraps serially generated outputs with their type
+// registrations.
+fn fastc_file_gen_result(outputs []FastcFileGenOutput) FastcFileGenResult {
+	mut composite_types := map[string]bool{}
+	mut fixed_array_types := map[string]string{}
+	for output in outputs {
+		for name, _ in output.composite_types {
+			composite_types[name] = true
+		}
+		for name, array_type in output.fixed_array_types {
+			fixed_array_types[name] = array_type
+		}
+	}
+	return FastcFileGenResult{
+		outputs: outputs
+		composite_types: composite_types
+		fixed_array_types: fixed_array_types
+	}
+}
+
 struct FastcFileGenOutput {
 mut:
 	prototypes        string
@@ -1548,7 +1576,8 @@ fn generate_source_pieces(input_sources []FastcSourceFile, module_aliases map[st
 	mut c_flags := []string{}
 	generation_sources := fastc_wait_generation_fragments(mut pending_fragments)
 	timer.mark('wait_fragments')
-	outputs := fastc_generate_file_outputs(&ctx, generation_sources)
+	generation := fastc_generate_file_outputs(&ctx, generation_sources)
+	outputs := generation.outputs
 	timer.mark('file_outputs')
 	// Size the stitch buffers up front: the per-file bodies add up to several
 	// megabytes, and growing the builders by doubling would copy that text
@@ -1558,6 +1587,7 @@ fn generate_source_pieces(input_sources []FastcSourceFile, module_aliases map[st
 		prototypes_size += output.prototypes.len
 	}
 	prototypes.ensure_cap(prototypes_size + 1024)
+	timer.mark('stitch.size')
 	for output in outputs {
 		if output.failed {
 			return error(output.error_message)
@@ -1573,21 +1603,17 @@ fn generate_source_pieces(input_sources []FastcSourceFile, module_aliases map[st
 				kind: line.kind
 			}
 		}
-		mut mono_names := output.mono_definitions.keys()
-		mono_names.sort()
-		for mono_name in mono_names {
-			if mono_name !in mono_definitions {
-				mono_definitions[mono_name] = output.mono_definitions[mono_name]
+		if output.mono_definitions.len > 0 {
+			mut mono_names := output.mono_definitions.keys()
+			mono_names.sort()
+			for mono_name in mono_names {
+				if mono_name !in mono_definitions {
+					mono_definitions[mono_name] = output.mono_definitions[mono_name]
+				}
 			}
 		}
 		if output.has_main_entry {
 			entry_has_main = true
-		}
-		for name, array_type in output.fixed_array_types {
-			fixed_array_types[name] = array_type
-		}
-		for name, _ in output.composite_types {
-			composite_types[name] = true
 		}
 		for name, text in output.spawn_typedefs {
 			spawn_typedefs[name] = text
@@ -1597,6 +1623,13 @@ fn generate_source_pieces(input_sources []FastcSourceFile, module_aliases map[st
 		}
 		c_flags << output.c_flags
 	}
+	for name, array_type in generation.fixed_array_types {
+		fixed_array_types[name] = array_type
+	}
+	for name, _ in generation.composite_types {
+		composite_types[name] = true
+	}
+	timer.mark('stitch.outputs')
 	mut mono_names := mono_definitions.keys()
 	mono_names.sort()
 	timer.mark('stitch')

--- a/vlib/v3/gen/fastc/fastc.v
+++ b/vlib/v3/gen/fastc/fastc.v
@@ -824,6 +824,8 @@ struct FastcLoadedSource {
 	header        FastcSourceHeader
 	failed        bool
 	error_message string
+	// stamp is the file version the memo preload observed (zero when unknown).
+	stamp FastcFileStamp
 }
 
 struct FastcHoistedCSource {
@@ -945,6 +947,9 @@ struct FastcEnumInfo {
 }
 
 struct FastcTypeDeclarations {
+	// declarations_head precedes the composite typedefs (type ids and forward
+	// typedefs) and declarations follows them (the type bodies).
+	declarations_head   string
 	declarations        string
 	enum_string_helpers string
 	alias_base_types    map[string]string
@@ -977,6 +982,10 @@ struct Parser {
 	// Generic methods (own type param) not resolved by the source-level pass, kept so a
 	// `recv.m(arg)` call can be monomorphized on demand at parse time (see anonfn/drain).
 	generic_method_sources map[string]FastcGenericMethodSource
+	// generic_method_names holds the bare names of the generic methods and
+	// functions, so an expression can skip the monomorphization scan unless
+	// its last name could be one.
+	generic_method_names map[string]bool
 	// A module imported under a second name that re-exports another (e.g. `json2` aliased
 	// at `x.json2`): resolves `<alias>.<sym>` to the loaded `<target>.<sym>`.
 	module_aliases map[string]string
@@ -1237,6 +1246,7 @@ struct FastcFileGenContext {
 	fixed_array_types         map[string]string
 	composite_types           map[string]bool
 	generic_method_sources    map[string]FastcGenericMethodSource
+	generic_method_names      map[string]bool
 	module_aliases            map[string]string
 }
 
@@ -1293,6 +1303,7 @@ fn fastc_generate_single_file(ctx &FastcFileGenContext, source_file FastcSourceF
 		struct_field_info: ctx.struct_field_info
 		struct_field_lookup: ctx.struct_field_lookup
 		generic_method_sources: ctx.generic_method_sources
+		generic_method_names: ctx.generic_method_names
 		module_aliases: ctx.module_aliases
 		generated_mono: map[string]bool{}
 		mono_functions: map[string]FastcFunctionSignature{}
@@ -1324,6 +1335,14 @@ fn fastc_generate_single_file(ctx &FastcFileGenContext, source_file FastcSourceF
 		loop_has_breaks: []bool{}
 		statement_reachable: true
 	}
+	// The per-file lookup memos fill up quickly; size them once instead of
+	// rehashing through the small capacities.
+	gen.unqualified_key_memo.reserve(128)
+	gen.c_function_name_memo.reserve(128)
+	gen.nonlocal_name_type_memo.reserve(128)
+	gen.resolved_name_memo.reserve(128)
+	gen.declared_type_key_memo.reserve(128)
+	gen.comparison_memo.reserve(64)
 	gen.s.init(file, source_file.source)
 	generated := gen.run() or {
 		return FastcFileGenOutput{
@@ -1372,8 +1391,6 @@ fn generate_source_pieces(input_sources []FastcSourceFile, module_aliases map[st
 	mut declared_kinds := map[string]FastcDeclaredTypeKind{}
 	mut enum_flags := map[string]bool{}
 	mut params_structs := map[string]bool{}
-	mut struct_fields := map[string]map[string]string{}
-	mut struct_field_info := map[string][]FastcStructField{}
 	mut constants := map[string]string{}
 	mut public_constants := map[string]bool{}
 	mut globals := map[string]string{}
@@ -1383,6 +1400,10 @@ fn generate_source_pieces(input_sources []FastcSourceFile, module_aliases map[st
 	mut constant_sources := map[string]string{}
 	generic_method_sources := fastc_collect_generic_and_declaration_indexes(mut sources, prefs, mut declared_types, mut declared_kinds, mut enum_flags, mut params_structs, mut type_source_paths, mut type_sources, mut constants, mut public_constants, mut constant_sources, mut globals, mut public_globals)!
 	timer.mark('declaration_indexes')
+	// The type declarations depend only on the declaration index, so they are
+	// rendered on a worker while the signatures are collected below; the
+	// composite typedefs that precede them need both and are rendered after.
+	mut pending_types := fastc_start_type_declarations(sources, type_sources, prefs, type_source_paths, declared_types, declared_kinds, enum_flags, constants, public_constants)
 	// The sources are final now; split the oversized ones for parallel
 	// generation while the declaration phases run.
 	mut pending_fragments := fastc_start_generation_fragments(sources, prefs)
@@ -1422,7 +1443,14 @@ fn generate_source_pieces(input_sources []FastcSourceFile, module_aliases map[st
 			fastc_register_composite_type(parameter_type, mut composite_types)
 		}
 	}
-	type_output := fastc_generate_type_declarations(sources, type_sources, prefs, type_source_paths, declared_types, declared_kinds, enum_flags, constants, public_constants, mut struct_fields, mut struct_field_info, mut composite_types)!
+	mut type_result := fastc_wait_type_declarations(mut pending_types)!
+	for name, _ in type_result.composite_types {
+		composite_types[name] = true
+	}
+	composite_typedefs := fastc_composite_typedefs(composite_types)
+	type_output := type_result.output
+	struct_fields := type_result.struct_fields.move()
+	mut struct_field_info := type_result.struct_field_info.move()
 	timer.mark('type_declarations')
 	declared_composite_types := composite_types.clone()
 	type_declarations := type_output.declarations
@@ -1496,6 +1524,7 @@ fn generate_source_pieces(input_sources []FastcSourceFile, module_aliases map[st
 		struct_field_info: struct_field_info
 		struct_field_lookup: struct_field_lookup
 		generic_method_sources: generic_method_sources
+		generic_method_names: fastc_generic_method_names(generic_method_sources)
 		module_aliases: module_aliases
 		interface_fields: interface_fields
 		constants: constants
@@ -1626,6 +1655,8 @@ fn generate_source_pieces(input_sources []FastcSourceFile, module_aliases map[st
 		pieces << '\n'
 	}
 	pieces << constant_output.macros
+	pieces << type_output.declarations_head
+	pieces << composite_typedefs
 	pieces << type_declarations
 	pieces << late_composite_declarations.str()
 	pieces << fixed_array_declarations
@@ -1699,6 +1730,16 @@ fn generate_source_pieces(input_sources []FastcSourceFile, module_aliases map[st
 	}
 	timer.mark('assemble')
 	return pieces, spawn_typedefs.len > 0, c_flags
+}
+
+// fastc_generic_method_names collects the bare method and function names of
+// the generic sources, the last dotted component of their keys.
+fn fastc_generic_method_names(generic_method_sources map[string]FastcGenericMethodSource) map[string]bool {
+	mut names := map[string]bool{}
+	for key, _ in generic_method_sources {
+		names[key.all_after_last('.')] = true
+	}
+	return names
 }
 
 // fastc_build_struct_field_lookup indexes every struct's fields by name.

--- a/vlib/v3/gen/fastc/fastc.v
+++ b/vlib/v3/gen/fastc/fastc.v
@@ -1427,7 +1427,8 @@ fn generate_source_pieces(input_sources []FastcSourceFile, module_aliases map[st
 	mut type_sources := map[string]string{}
 	mut constant_sources := map[string]string{}
 	mut constant_spans := map[string][]int{}
-	generic_method_sources := fastc_collect_generic_and_declaration_indexes(mut sources, prefs, mut declared_types, mut declared_kinds, mut enum_flags, mut params_structs, mut type_source_paths, mut type_sources, mut constants, mut public_constants, mut constant_sources, mut constant_spans, mut globals, mut public_globals)!
+	mut global_sources := map[string]string{}
+	generic_method_sources := fastc_collect_generic_and_declaration_indexes(mut sources, prefs, mut declared_types, mut declared_kinds, mut enum_flags, mut params_structs, mut type_source_paths, mut type_sources, mut constants, mut public_constants, mut constant_sources, mut constant_spans, mut global_sources, mut globals, mut public_globals)!
 	timer.mark('declaration_indexes')
 	// The type declarations depend only on the declaration index, so they are
 	// rendered on a worker while the signatures are collected below; the
@@ -1500,7 +1501,7 @@ fn generate_source_pieces(input_sources []FastcSourceFile, module_aliases map[st
 	for name, _ in constant_output.composite_types {
 		composite_types[name] = true
 	}
-	global_output := fastc_generate_global_declarations(ordered_sources, prefs, declared_types, declared_type_c_names, fastc_prefixed_c_names, declared_kinds, enum_flags, enum_field_types, type_output.alias_base_types, struct_fields, struct_field_info, functions, constants, constant_output.compile_time_values, public_constants, constant_types, globals, public_globals, mut global_types)!
+	global_output := fastc_generate_global_declarations(ordered_sources, global_sources, prefs, declared_types, declared_type_c_names, fastc_prefixed_c_names, declared_kinds, enum_flags, enum_field_types, type_output.alias_base_types, struct_fields, struct_field_info, functions, constants, constant_output.compile_time_values, public_constants, constant_types, globals, public_globals, mut global_types)!
 	timer.mark('global_declarations')
 	for name, _ in global_output.composite_types {
 		composite_types[name] = true

--- a/vlib/v3/gen/fastc/fastc.v
+++ b/vlib/v3/gen/fastc/fastc.v
@@ -1398,7 +1398,8 @@ fn generate_source_pieces(input_sources []FastcSourceFile, module_aliases map[st
 	mut type_source_paths := map[string]bool{}
 	mut type_sources := map[string]string{}
 	mut constant_sources := map[string]string{}
-	generic_method_sources := fastc_collect_generic_and_declaration_indexes(mut sources, prefs, mut declared_types, mut declared_kinds, mut enum_flags, mut params_structs, mut type_source_paths, mut type_sources, mut constants, mut public_constants, mut constant_sources, mut globals, mut public_globals)!
+	mut constant_spans := map[string][]int{}
+	generic_method_sources := fastc_collect_generic_and_declaration_indexes(mut sources, prefs, mut declared_types, mut declared_kinds, mut enum_flags, mut params_structs, mut type_source_paths, mut type_sources, mut constants, mut public_constants, mut constant_sources, mut constant_spans, mut globals, mut public_globals)!
 	timer.mark('declaration_indexes')
 	// The type declarations depend only on the declaration index, so they are
 	// rendered on a worker while the signatures are collected below; the
@@ -1466,7 +1467,7 @@ fn generate_source_pieces(input_sources []FastcSourceFile, module_aliases map[st
 	// The field lists are final; index them by name for generation while the
 	// constant and global phases run.
 	mut pending_field_lookup := fastc_start_struct_field_lookup(struct_field_info, prefs)
-	constant_output := fastc_generate_constant_declarations(ordered_sources, constant_sources, prefs, declared_types, declared_type_c_names, fastc_prefixed_c_names, declared_kinds, enum_flags, enum_field_types, type_output.alias_base_types, struct_fields, struct_field_info, functions, constants, public_constants, globals, public_globals, mut constant_types)!
+	constant_output := fastc_generate_constant_declarations(ordered_sources, constant_sources, constant_spans, prefs, declared_types, declared_type_c_names, fastc_prefixed_c_names, declared_kinds, enum_flags, enum_field_types, type_output.alias_base_types, struct_fields, struct_field_info, functions, constants, public_constants, globals, public_globals, mut constant_types)!
 	timer.mark('constant_declarations')
 	for name, _ in constant_output.composite_types {
 		composite_types[name] = true

--- a/vlib/v3/gen/fastc/fastc_test.v
+++ b/vlib/v3/gen/fastc/fastc_test.v
@@ -7,6 +7,23 @@ import v3.pref
 import v3.scanner
 import v3.token
 
+fn test_contains_method_marker() {
+	// A leading occurrence of the name is not a call; the scan must go on to
+	// a later `.name(` or `->name(`.
+	assert fastc_contains_method_marker('foo + ptr.foo(1)', 'foo')
+	assert fastc_contains_method_marker('foo + ptr->foo(1)', 'foo')
+	assert fastc_contains_method_marker('foo(1) + x.foo(2)', 'foo')
+	assert fastc_contains_method_marker('bar.foo()', 'foo')
+	assert fastc_contains_method_marker('a->foo()', 'foo')
+	assert !fastc_contains_method_marker('foo(1)', 'foo')
+	assert !fastc_contains_method_marker('foo + foo', 'foo')
+	assert !fastc_contains_method_marker('x.foobar(1)', 'foo')
+	assert !fastc_contains_method_marker('x.foo', 'foo')
+	assert !fastc_contains_method_marker('xfoo(1)', 'foo')
+	assert !fastc_contains_method_marker('', 'foo')
+	assert !fastc_contains_method_marker('x.foo(1)', '')
+}
+
 fn test_selfhost_shared_keyword_local_is_preserved() {
 	mut prefs := pref.new_preferences()
 	prefs.building_v = true

--- a/vlib/v3/gen/fastc/monomorphize.v
+++ b/vlib/v3/gen/fastc/monomorphize.v
@@ -230,6 +230,11 @@ fn (mut g Parser) queue_expression_monomorphization(tokens []FastcExpressionToke
 	if !g.selfhost || g.in_generic_placeholder || g.generic_method_sources.len == 0 {
 		return none
 	}
+	// Every recognizer below keys the generic source by the expression's last
+	// name, so an expression ending in any other name cannot queue anything.
+	if tokens.len == 0 || tokens.last().tok != .name || tokens.last().lit !in g.generic_method_names {
+		return none
+	}
 	if mono := g.queue_explicit_mono_method(tokens) {
 		return mono
 	}

--- a/vlib/v3/gen/fastc/parallel_d_v3_no_parallel.v
+++ b/vlib/v3/gen/fastc/parallel_d_v3_no_parallel.v
@@ -30,6 +30,15 @@ fn fastc_wait_interface_dispatches(mut pending FastcPendingInterfaceDispatches) 
 	return pending.dispatches
 }
 
+fn fastc_preload_memo(memo FastcResolveMemo, prefs &pref.Preferences, canonical_vlib string, mut module_path_cache map[string]string, mut module_dir_files map[string][]string) map[string]FastcLoadedSource {
+	tasks := fastc_memo_tasks(memo)
+	mut results := []FastcMemoResult{len: tasks.len}
+	for index, task in tasks {
+		results[index] = fastc_run_memo_task(task, index, prefs, canonical_vlib)
+	}
+	return fastc_apply_memo_results(tasks, results, prefs, mut module_path_cache, mut module_dir_files)
+}
+
 // fastc_preload_sources is a no-op without threads: the ordering walk loads
 // each file itself.
 fn fastc_preload_sources(queue []FastcQueuedSource, prefs &pref.Preferences, canonical_vlib string, mut module_path_cache map[string]string, mut module_dir_files map[string][]string, mut real_path_cache map[string]string) map[string]FastcLoadedSource {
@@ -49,6 +58,24 @@ fn fastc_collect_generic_and_declaration_indexes(mut sources []FastcSourceFile, 
 	generic_method_sources := fastc_collect_generic_method_sources(mut sources, prefs)
 	fastc_collect_declaration_indexes(sources, prefs, mut declared_types, mut declared_kinds, mut enum_flags, mut params_structs, mut type_source_paths, mut type_sources, mut constants, mut public_constants, mut constant_sources, mut globals, mut public_globals)!
 	return generic_method_sources
+}
+
+struct FastcPendingTypeDeclarations {
+mut:
+	result FastcTypeDeclarationResult
+}
+
+fn fastc_start_type_declarations(sources []FastcSourceFile, type_sources map[string]string, prefs &pref.Preferences, type_source_paths map[string]bool, declared_types map[string]bool, declared_kinds map[string]FastcDeclaredTypeKind, enum_flags map[string]bool, constants map[string]string, public_constants map[string]bool) FastcPendingTypeDeclarations {
+	return FastcPendingTypeDeclarations{
+		result: fastc_run_type_declarations(sources, type_sources, prefs, type_source_paths, declared_types, declared_kinds, enum_flags, constants, public_constants)
+	}
+}
+
+fn fastc_wait_type_declarations(mut pending FastcPendingTypeDeclarations) !FastcTypeDeclarationResult {
+	if pending.result.failed {
+		return error(pending.result.error_message)
+	}
+	return pending.result
 }
 
 struct FastcPendingFieldLookup {

--- a/vlib/v3/gen/fastc/parallel_d_v3_no_parallel.v
+++ b/vlib/v3/gen/fastc/parallel_d_v3_no_parallel.v
@@ -65,9 +65,9 @@ fn fastc_collect_generic_method_sources(mut sources []FastcSourceFile, prefs &pr
 	return partial.sources
 }
 
-fn fastc_collect_generic_and_declaration_indexes(mut sources []FastcSourceFile, prefs &pref.Preferences, mut declared_types map[string]bool, mut declared_kinds map[string]FastcDeclaredTypeKind, mut enum_flags map[string]bool, mut params_structs map[string]bool, mut type_source_paths map[string]bool, mut type_sources map[string]string, mut constants map[string]string, mut public_constants map[string]bool, mut constant_sources map[string]string, mut constant_spans map[string][]int, mut globals map[string]string, mut public_globals map[string]bool) !map[string]FastcGenericMethodSource {
+fn fastc_collect_generic_and_declaration_indexes(mut sources []FastcSourceFile, prefs &pref.Preferences, mut declared_types map[string]bool, mut declared_kinds map[string]FastcDeclaredTypeKind, mut enum_flags map[string]bool, mut params_structs map[string]bool, mut type_source_paths map[string]bool, mut type_sources map[string]string, mut constants map[string]string, mut public_constants map[string]bool, mut constant_sources map[string]string, mut constant_spans map[string][]int, mut global_sources map[string]string, mut globals map[string]string, mut public_globals map[string]bool) !map[string]FastcGenericMethodSource {
 	generic_method_sources := fastc_collect_generic_method_sources(mut sources, prefs)
-	fastc_collect_declaration_indexes(sources, prefs, mut declared_types, mut declared_kinds, mut enum_flags, mut params_structs, mut type_source_paths, mut type_sources, mut constants, mut public_constants, mut constant_sources, mut constant_spans, mut globals, mut public_globals)!
+	fastc_collect_declaration_indexes(sources, prefs, mut declared_types, mut declared_kinds, mut enum_flags, mut params_structs, mut type_source_paths, mut type_sources, mut constants, mut public_constants, mut constant_sources, mut constant_spans, mut global_sources, mut globals, mut public_globals)!
 	return generic_method_sources
 }
 
@@ -133,9 +133,9 @@ fn fastc_collect_reference_partials(sources []FastcSourceFile, prefs &pref.Prefe
 	}
 }
 
-fn fastc_collect_declaration_indexes(sources []FastcSourceFile, prefs &pref.Preferences, mut declared_types map[string]bool, mut declared_kinds map[string]FastcDeclaredTypeKind, mut enum_flags map[string]bool, mut params_structs map[string]bool, mut type_source_paths map[string]bool, mut type_sources map[string]string, mut constants map[string]string, mut public_constants map[string]bool, mut constant_sources map[string]string, mut constant_spans map[string][]int, mut globals map[string]string, mut public_globals map[string]bool) ! {
+fn fastc_collect_declaration_indexes(sources []FastcSourceFile, prefs &pref.Preferences, mut declared_types map[string]bool, mut declared_kinds map[string]FastcDeclaredTypeKind, mut enum_flags map[string]bool, mut params_structs map[string]bool, mut type_source_paths map[string]bool, mut type_sources map[string]string, mut constants map[string]string, mut public_constants map[string]bool, mut constant_sources map[string]string, mut constant_spans map[string][]int, mut global_sources map[string]string, mut globals map[string]string, mut public_globals map[string]bool) ! {
 	partial := fastc_collect_declaration_chunk(sources, prefs, 0, sources.len)
-	fastc_merge_declaration_partial(partial, mut declared_types, mut declared_kinds, mut enum_flags, mut params_structs, mut type_source_paths, mut type_sources, mut constants, mut public_constants, mut constant_sources, mut constant_spans, mut globals, mut public_globals)!
+	fastc_merge_declaration_partial(partial, mut declared_types, mut declared_kinds, mut enum_flags, mut params_structs, mut type_source_paths, mut type_sources, mut constants, mut public_constants, mut constant_sources, mut constant_spans, mut global_sources, mut globals, mut public_globals)!
 }
 
 fn fastc_collect_signatures(sources []FastcSourceFile, prefs &pref.Preferences, declared_types map[string]bool, declared_type_c_names map[string]string, params_structs map[string]bool, mut functions map[string]FastcFunctionSignature, mut interface_methods map[string]bool, mut interface_fields map[string]FastcInterfaceField, mut embed_embedders []string, mut embed_embeddeds []string) ! {

--- a/vlib/v3/gen/fastc/parallel_d_v3_no_parallel.v
+++ b/vlib/v3/gen/fastc/parallel_d_v3_no_parallel.v
@@ -30,13 +30,24 @@ fn fastc_wait_interface_dispatches(mut pending FastcPendingInterfaceDispatches) 
 	return pending.dispatches
 }
 
-fn fastc_preload_memo(memo FastcResolveMemo, prefs &pref.Preferences, canonical_vlib string, mut module_path_cache map[string]string, mut module_dir_files map[string][]string) map[string]FastcLoadedSource {
-	tasks := fastc_memo_tasks(memo)
-	mut results := []FastcMemoResult{len: tasks.len}
-	for index, task in tasks {
-		results[index] = fastc_run_memo_task(task, index, prefs, canonical_vlib)
+fn fastc_preload_memo(memo_path string, memo FastcResolveMemo, prefs &pref.Preferences, canonical_vlib string, mut module_path_cache map[string]string, mut module_dir_files map[string][]string) map[string]FastcLoadedSource {
+	probe_tasks := fastc_memo_probe_tasks(memo)
+	mut probe_results := []FastcMemoResult{len: probe_tasks.len}
+	for index, task in probe_tasks {
+		probe_results[index] = fastc_run_memo_task(task, index, prefs, canonical_vlib)
 	}
-	return fastc_apply_memo_results(tasks, results, prefs, mut module_path_cache, mut module_dir_files)
+	mut loaded := fastc_apply_memo_results(probe_tasks, probe_results, prefs, mut module_path_cache, mut module_dir_files)
+	blob := fastc_read_memo_blob(memo_path, memo)
+	current_stamps := fastc_memo_current_stamps(probe_tasks, probe_results, memo.files.len)
+	read_tasks := fastc_memo_read_tasks(memo, current_stamps, blob)
+	mut read_results := []FastcMemoResult{len: read_tasks.len}
+	for index, task in read_tasks {
+		read_results[index] = fastc_run_memo_task(task, index, prefs, canonical_vlib)
+	}
+	for path, source in fastc_apply_memo_results(read_tasks, read_results, prefs, mut module_path_cache, mut module_dir_files) {
+		loaded[path] = source
+	}
+	return loaded
 }
 
 // fastc_preload_sources is a no-op without threads: the ordering walk loads

--- a/vlib/v3/gen/fastc/parallel_d_v3_no_parallel.v
+++ b/vlib/v3/gen/fastc/parallel_d_v3_no_parallel.v
@@ -119,12 +119,12 @@ fn fastc_wait_generation_fragments(mut pending FastcPendingFragments) []FastcSou
 	return pending.fragments
 }
 
-fn fastc_generate_file_outputs(ctx &FastcFileGenContext, sources []FastcSourceFile) []FastcFileGenOutput {
+fn fastc_generate_file_outputs(ctx &FastcFileGenContext, sources []FastcSourceFile) FastcFileGenResult {
 	mut outputs := []FastcFileGenOutput{cap: sources.len}
 	for source_file in sources {
 		outputs << fastc_generate_single_file(ctx, source_file)
 	}
-	return outputs
+	return fastc_file_gen_result(outputs)
 }
 
 fn fastc_collect_reference_partials(sources []FastcSourceFile, prefs &pref.Preferences, available_names map[string]bool, mut references map[string]map[string]bool, mut top_level_references map[string]bool) {

--- a/vlib/v3/gen/fastc/parallel_d_v3_no_parallel.v
+++ b/vlib/v3/gen/fastc/parallel_d_v3_no_parallel.v
@@ -54,9 +54,9 @@ fn fastc_collect_generic_method_sources(mut sources []FastcSourceFile, prefs &pr
 	return partial.sources
 }
 
-fn fastc_collect_generic_and_declaration_indexes(mut sources []FastcSourceFile, prefs &pref.Preferences, mut declared_types map[string]bool, mut declared_kinds map[string]FastcDeclaredTypeKind, mut enum_flags map[string]bool, mut params_structs map[string]bool, mut type_source_paths map[string]bool, mut type_sources map[string]string, mut constants map[string]string, mut public_constants map[string]bool, mut constant_sources map[string]string, mut globals map[string]string, mut public_globals map[string]bool) !map[string]FastcGenericMethodSource {
+fn fastc_collect_generic_and_declaration_indexes(mut sources []FastcSourceFile, prefs &pref.Preferences, mut declared_types map[string]bool, mut declared_kinds map[string]FastcDeclaredTypeKind, mut enum_flags map[string]bool, mut params_structs map[string]bool, mut type_source_paths map[string]bool, mut type_sources map[string]string, mut constants map[string]string, mut public_constants map[string]bool, mut constant_sources map[string]string, mut constant_spans map[string][]int, mut globals map[string]string, mut public_globals map[string]bool) !map[string]FastcGenericMethodSource {
 	generic_method_sources := fastc_collect_generic_method_sources(mut sources, prefs)
-	fastc_collect_declaration_indexes(sources, prefs, mut declared_types, mut declared_kinds, mut enum_flags, mut params_structs, mut type_source_paths, mut type_sources, mut constants, mut public_constants, mut constant_sources, mut globals, mut public_globals)!
+	fastc_collect_declaration_indexes(sources, prefs, mut declared_types, mut declared_kinds, mut enum_flags, mut params_structs, mut type_source_paths, mut type_sources, mut constants, mut public_constants, mut constant_sources, mut constant_spans, mut globals, mut public_globals)!
 	return generic_method_sources
 }
 
@@ -122,9 +122,9 @@ fn fastc_collect_reference_partials(sources []FastcSourceFile, prefs &pref.Prefe
 	}
 }
 
-fn fastc_collect_declaration_indexes(sources []FastcSourceFile, prefs &pref.Preferences, mut declared_types map[string]bool, mut declared_kinds map[string]FastcDeclaredTypeKind, mut enum_flags map[string]bool, mut params_structs map[string]bool, mut type_source_paths map[string]bool, mut type_sources map[string]string, mut constants map[string]string, mut public_constants map[string]bool, mut constant_sources map[string]string, mut globals map[string]string, mut public_globals map[string]bool) ! {
+fn fastc_collect_declaration_indexes(sources []FastcSourceFile, prefs &pref.Preferences, mut declared_types map[string]bool, mut declared_kinds map[string]FastcDeclaredTypeKind, mut enum_flags map[string]bool, mut params_structs map[string]bool, mut type_source_paths map[string]bool, mut type_sources map[string]string, mut constants map[string]string, mut public_constants map[string]bool, mut constant_sources map[string]string, mut constant_spans map[string][]int, mut globals map[string]string, mut public_globals map[string]bool) ! {
 	partial := fastc_collect_declaration_chunk(sources, prefs, 0, sources.len)
-	fastc_merge_declaration_partial(partial, mut declared_types, mut declared_kinds, mut enum_flags, mut params_structs, mut type_source_paths, mut type_sources, mut constants, mut public_constants, mut constant_sources, mut globals, mut public_globals)!
+	fastc_merge_declaration_partial(partial, mut declared_types, mut declared_kinds, mut enum_flags, mut params_structs, mut type_source_paths, mut type_sources, mut constants, mut public_constants, mut constant_sources, mut constant_spans, mut globals, mut public_globals)!
 }
 
 fn fastc_collect_signatures(sources []FastcSourceFile, prefs &pref.Preferences, declared_types map[string]bool, declared_type_c_names map[string]string, params_structs map[string]bool, mut functions map[string]FastcFunctionSignature, mut interface_methods map[string]bool, mut interface_fields map[string]FastcInterfaceField, mut embed_embedders []string, mut embed_embeddeds []string) ! {

--- a/vlib/v3/gen/fastc/parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/fastc/parallel_notd_v3_no_parallel.v
@@ -541,6 +541,15 @@ struct FastcIndexedFileGenOutput {
 	output FastcFileGenOutput
 }
 
+// FastcFileGenWorkerResult is one worker's outputs together with the union
+// of their composite and fixed-array type registrations, so the stitch pass
+// merges one set per worker instead of one per file.
+struct FastcFileGenWorkerResult {
+	outputs           []FastcIndexedFileGenOutput
+	composite_types   map[string]bool
+	fixed_array_types map[string]string
+}
+
 // FastcGenQueue is a shared work-stealing counter for per-file generation. On a
 // heterogeneous CPU (Apple Silicon's performance + efficiency cores) a static
 // byte-weighted chunk per worker leaves the slowest efficiency core setting the
@@ -577,8 +586,10 @@ fn fastc_file_generation_order(sources []FastcSourceFile) []int {
 // claims the next order slot until the queue empties. The backing source data is
 // shared and read-only. It runs as a value-returning spawn: under -prealloc, V
 // frees a void thread's arena on exit, so outputs travel through the return value.
-fn fastc_generate_file_steal(ctx &FastcFileGenContext, sources []FastcSourceFile, order []int, queue &FastcGenQueue) []FastcIndexedFileGenOutput {
+fn fastc_generate_file_steal(ctx &FastcFileGenContext, sources []FastcSourceFile, order []int, queue &FastcGenQueue) FastcFileGenWorkerResult {
 	mut outputs := []FastcIndexedFileGenOutput{}
+	mut composite_types := map[string]bool{}
+	mut fixed_array_types := map[string]string{}
 	limit := u32(order.len)
 	bench_files := os.getenv('FASTC_BENCH_FILES') != ''
 	mut sw := time.new_stopwatch()
@@ -593,15 +604,26 @@ fn fastc_generate_file_steal(ctx &FastcFileGenContext, sources []FastcSourceFile
 		}
 		file_index := order[claimed]
 		start_us := sw.elapsed().microseconds()
+		output := fastc_generate_single_file(ctx, sources[file_index])
+		for name, _ in output.composite_types {
+			composite_types[name] = true
+		}
+		for name, array_type in output.fixed_array_types {
+			fixed_array_types[name] = array_type
+		}
 		outputs << FastcIndexedFileGenOutput{
 			index: file_index
-			output: fastc_generate_single_file(ctx, sources[file_index])
+			output: output
 		}
 		if bench_files {
 			eprintln('fastc-file ${sw.elapsed().microseconds() - start_us} ${sources[file_index].source.len} ${sources[file_index].path}')
 		}
 	}
-	return outputs
+	return FastcFileGenWorkerResult{
+		outputs: outputs
+		composite_types: composite_types
+		fixed_array_types: fixed_array_types
+	}
 }
 
 const fastc_generation_fragment_size = 28 * 1024
@@ -859,14 +881,14 @@ fn fastc_wait_generation_fragments(mut pending FastcPendingFragments) []FastcSou
 // more than one job is available. `sources` are the generation fragments from
 // fastc_wait_generation_fragments. Results are restored to file order, so the
 // emitted C is identical to a serial run.
-fn fastc_generate_file_outputs(ctx &FastcFileGenContext, sources []FastcSourceFile) []FastcFileGenOutput {
+fn fastc_generate_file_outputs(ctx &FastcFileGenContext, sources []FastcSourceFile) FastcFileGenResult {
 	jobs := fastc_parallel_jobs(sources, ctx.prefs)
 	if jobs <= 1 {
 		mut outputs := []FastcFileGenOutput{cap: sources.len}
 		for source_file in sources {
 			outputs << fastc_generate_single_file(ctx, source_file)
 		}
-		return outputs
+		return fastc_file_gen_result(outputs)
 	}
 	mut timer := fastc_new_phase_timer()
 	generation_sources := sources
@@ -881,19 +903,36 @@ fn fastc_generate_file_outputs(ctx &FastcFileGenContext, sources []FastcSourceFi
 		worker_threads << spawn fastc_generate_file_steal(ctx, generation_sources, order, queue)
 	}
 	mut outputs := []FastcFileGenOutput{len: generation_sources.len}
-	first_outputs := fastc_generate_file_steal(ctx, generation_sources, order, queue)
-	for indexed_output in first_outputs {
+	mut composite_types := map[string]bool{}
+	mut fixed_array_types := map[string]string{}
+	first := fastc_generate_file_steal(ctx, generation_sources, order, queue)
+	for indexed_output in first.outputs {
 		outputs[indexed_output.index] = indexed_output.output
 	}
+	fastc_merge_worker_types(first, mut composite_types, mut fixed_array_types)
 	timer.mark('file_outputs.first_chunk')
 	for worker_thread in worker_threads {
-		worker_outputs := worker_thread.wait()
-		for indexed_output in worker_outputs {
+		worker := worker_thread.wait()
+		for indexed_output in worker.outputs {
 			outputs[indexed_output.index] = indexed_output.output
 		}
+		fastc_merge_worker_types(worker, mut composite_types, mut fixed_array_types)
 	}
 	timer.mark('file_outputs.wait_chunks')
-	return outputs
+	return FastcFileGenResult{
+		outputs: outputs
+		composite_types: composite_types
+		fixed_array_types: fixed_array_types
+	}
+}
+
+fn fastc_merge_worker_types(worker FastcFileGenWorkerResult, mut composite_types map[string]bool, mut fixed_array_types map[string]string) {
+	for name, _ in worker.composite_types {
+		composite_types[name] = true
+	}
+	for name, array_type in worker.fixed_array_types {
+		fixed_array_types[name] = array_type
+	}
 }
 
 // FastcReferencePartial carries one chunk's function-reference scan across

--- a/vlib/v3/gen/fastc/parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/fastc/parallel_notd_v3_no_parallel.v
@@ -445,11 +445,11 @@ fn fastc_collect_index_worker(sources []FastcSourceFile, prefs &pref.Preferences
 // and the declaration index in one parallel pass over the files: each file is
 // visited once, and there is a single spawn/join round. The results are
 // applied in file order, so they match the two serial scans.
-fn fastc_collect_generic_and_declaration_indexes(mut sources []FastcSourceFile, prefs &pref.Preferences, mut declared_types map[string]bool, mut declared_kinds map[string]FastcDeclaredTypeKind, mut enum_flags map[string]bool, mut params_structs map[string]bool, mut type_source_paths map[string]bool, mut type_sources map[string]string, mut constants map[string]string, mut public_constants map[string]bool, mut constant_sources map[string]string, mut globals map[string]string, mut public_globals map[string]bool) !map[string]FastcGenericMethodSource {
+fn fastc_collect_generic_and_declaration_indexes(mut sources []FastcSourceFile, prefs &pref.Preferences, mut declared_types map[string]bool, mut declared_kinds map[string]FastcDeclaredTypeKind, mut enum_flags map[string]bool, mut params_structs map[string]bool, mut type_source_paths map[string]bool, mut type_sources map[string]string, mut constants map[string]string, mut public_constants map[string]bool, mut constant_sources map[string]string, mut constant_spans map[string][]int, mut globals map[string]string, mut public_globals map[string]bool) !map[string]FastcGenericMethodSource {
 	jobs := fastc_parallel_jobs(sources, prefs)
 	if jobs <= 1 {
 		generic_method_sources := fastc_collect_generic_method_sources(mut sources, prefs)
-		fastc_collect_declaration_indexes(sources, prefs, mut declared_types, mut declared_kinds, mut enum_flags, mut params_structs, mut type_source_paths, mut type_sources, mut constants, mut public_constants, mut constant_sources, mut globals, mut public_globals)!
+		fastc_collect_declaration_indexes(sources, prefs, mut declared_types, mut declared_kinds, mut enum_flags, mut params_structs, mut type_source_paths, mut type_sources, mut constants, mut public_constants, mut constant_sources, mut constant_spans, mut globals, mut public_globals)!
 		return generic_method_sources
 	}
 	order := fastc_file_generation_order(sources)
@@ -485,7 +485,7 @@ fn fastc_collect_generic_and_declaration_indexes(mut sources []FastcSourceFile, 
 		for key, generic in indexed.generics {
 			generic_method_sources[key] = generic
 		}
-		fastc_merge_declaration_partial(indexed.partial, mut declared_types, mut declared_kinds, mut enum_flags, mut params_structs, mut type_source_paths, mut type_sources, mut constants, mut public_constants, mut constant_sources, mut globals, mut public_globals)!
+		fastc_merge_declaration_partial(indexed.partial, mut declared_types, mut declared_kinds, mut enum_flags, mut params_structs, mut type_source_paths, mut type_sources, mut constants, mut public_constants, mut constant_sources, mut constant_spans, mut globals, mut public_globals)!
 	}
 	return generic_method_sources
 }
@@ -936,11 +936,11 @@ fn fastc_collect_declaration_worker(sources []FastcSourceFile, prefs &pref.Prefe
 	return partials
 }
 
-fn fastc_collect_declaration_indexes(sources []FastcSourceFile, prefs &pref.Preferences, mut declared_types map[string]bool, mut declared_kinds map[string]FastcDeclaredTypeKind, mut enum_flags map[string]bool, mut params_structs map[string]bool, mut type_source_paths map[string]bool, mut type_sources map[string]string, mut constants map[string]string, mut public_constants map[string]bool, mut constant_sources map[string]string, mut globals map[string]string, mut public_globals map[string]bool) ! {
+fn fastc_collect_declaration_indexes(sources []FastcSourceFile, prefs &pref.Preferences, mut declared_types map[string]bool, mut declared_kinds map[string]FastcDeclaredTypeKind, mut enum_flags map[string]bool, mut params_structs map[string]bool, mut type_source_paths map[string]bool, mut type_sources map[string]string, mut constants map[string]string, mut public_constants map[string]bool, mut constant_sources map[string]string, mut constant_spans map[string][]int, mut globals map[string]string, mut public_globals map[string]bool) ! {
 	jobs := fastc_parallel_jobs(sources, prefs)
 	if jobs <= 1 {
 		partial := fastc_collect_declaration_chunk(sources, prefs, 0, sources.len)
-		fastc_merge_declaration_partial(partial, mut declared_types, mut declared_kinds, mut enum_flags, mut params_structs, mut type_source_paths, mut type_sources, mut constants, mut public_constants, mut constant_sources, mut globals, mut public_globals)!
+		fastc_merge_declaration_partial(partial, mut declared_types, mut declared_kinds, mut enum_flags, mut params_structs, mut type_source_paths, mut type_sources, mut constants, mut public_constants, mut constant_sources, mut constant_spans, mut globals, mut public_globals)!
 		return
 	}
 	order := fastc_file_generation_order(sources)
@@ -965,7 +965,7 @@ fn fastc_collect_declaration_indexes(sources []FastcSourceFile, prefs &pref.Pref
 		}
 	}
 	for partial in partials {
-		fastc_merge_declaration_partial(partial, mut declared_types, mut declared_kinds, mut enum_flags, mut params_structs, mut type_source_paths, mut type_sources, mut constants, mut public_constants, mut constant_sources, mut globals, mut public_globals)!
+		fastc_merge_declaration_partial(partial, mut declared_types, mut declared_kinds, mut enum_flags, mut params_structs, mut type_source_paths, mut type_sources, mut constants, mut public_constants, mut constant_sources, mut constant_spans, mut globals, mut public_globals)!
 	}
 }
 

--- a/vlib/v3/gen/fastc/parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/fastc/parallel_notd_v3_no_parallel.v
@@ -101,6 +101,64 @@ fn fastc_load_source_chunk(paths []string, prefs &pref.Preferences, start int, e
 	return loaded
 }
 
+// fastc_memo_reader_limit caps the memo preload workers: file reads are the
+// bulk of the batch and they do not scale past a few concurrent readers.
+const fastc_memo_reader_limit = 6
+
+// fastc_memo_worker runs memo preload tasks from the shared counter.
+fn fastc_memo_worker(tasks []FastcMemoTask, prefs &pref.Preferences, canonical_vlib string, queue &FastcGenQueue) []FastcMemoResult {
+	mut results := []FastcMemoResult{}
+	for {
+		slot := fastc_atomic_fetch_add_u32(&queue.next, 1)
+		if slot >= u32(tasks.len) {
+			break
+		}
+		index := int(slot)
+		results << fastc_run_memo_task(tasks[index], index, prefs, canonical_vlib)
+	}
+	return results
+}
+
+// fastc_preload_memo lists, reads and looks up everything a resolve memo
+// names in one parallel batch bounded by the worker limit.
+fn fastc_preload_memo(memo FastcResolveMemo, prefs &pref.Preferences, canonical_vlib string, mut module_path_cache map[string]string, mut module_dir_files map[string][]string) map[string]FastcLoadedSource {
+	tasks := fastc_memo_tasks(memo)
+	mut jobs := fastc_parallel_job_count(tasks.len, prefs)
+	// Small-file reads and stats stop scaling after a few concurrent callers
+	// (the kernel serializes them), and extra workers only land on slower
+	// cores.
+	if jobs > fastc_memo_reader_limit {
+		jobs = fastc_memo_reader_limit
+	}
+	mut results := []FastcMemoResult{len: tasks.len}
+	if jobs <= 1 {
+		for index, task in tasks {
+			results[index] = fastc_run_memo_task(task, index, prefs, canonical_vlib)
+		}
+		return fastc_apply_memo_results(tasks, results, prefs, mut module_path_cache, mut module_dir_files)
+	}
+	mut queue := &FastcGenQueue{
+		next: 0
+	}
+	mut workers := [
+		spawn fastc_memo_worker(tasks, prefs, canonical_vlib, queue),
+	]
+	for _ in 2 .. jobs {
+		workers << spawn fastc_memo_worker(tasks, prefs, canonical_vlib, queue)
+	}
+	first := fastc_memo_worker(tasks, prefs, canonical_vlib, queue)
+	for result in first {
+		results[result.index] = result
+	}
+	for worker in workers {
+		worker_results := worker.wait()
+		for result in worker_results {
+			results[result.index] = result
+		}
+	}
+	return fastc_apply_memo_results(tasks, results, prefs, mut module_path_cache, mut module_dir_files)
+}
+
 // FastcModuleListing is one module directory listed on a worker thread.
 struct FastcModuleListing {
 	dir   string
@@ -182,6 +240,7 @@ fn fastc_preload_sources(queue []FastcQueuedSource, prefs &pref.Preferences, can
 	}
 	wait_sw := time.new_stopwatch()
 	mut wait_us := i64(0)
+	trace := os.getenv('FASTC_BENCH_PRELOAD') != ''
 	// The entry files form the first listing; its first chunk starts the
 	// reader queue. (Both thread arrays start from a spawn: the self-hosted
 	// generator has no empty thread-array literal.)
@@ -223,6 +282,9 @@ fn fastc_preload_sources(queue []FastcQueuedSource, prefs &pref.Preferences, can
 			listing_start := wait_sw.elapsed().microseconds()
 			listing := listings[next_listing].wait()
 			wait_us += wait_sw.elapsed().microseconds() - listing_start
+			if trace {
+				eprintln('preload listing join ${wait_sw.elapsed().microseconds()} waited ${wait_sw.elapsed().microseconds() - listing_start} ${listing.dir.all_after_last('/')} files=${listing.files.len}')
+			}
 			next_listing++
 			in_flight--
 			module_dir_files[listing.dir] = listing.files
@@ -235,6 +297,9 @@ fn fastc_preload_sources(queue []FastcQueuedSource, prefs &pref.Preferences, can
 		chunk_start := wait_sw.elapsed().microseconds()
 		chunk := chunk_threads[next_chunk].wait()
 		wait_us += wait_sw.elapsed().microseconds() - chunk_start
+		if trace {
+			eprintln('preload chunk join ${wait_sw.elapsed().microseconds()} waited ${wait_sw.elapsed().microseconds() - chunk_start}')
+		}
 		paths := chunk_paths[next_chunk]
 		next_chunk++
 		in_flight--
@@ -655,6 +720,38 @@ fn fastc_generation_fragments(sources []FastcSourceFile, prefs &pref.Preferences
 		}
 	}
 	return fragments
+}
+
+// FastcPendingTypeDeclarations is the type phase running on a worker while
+// the signatures are collected; the two only share read-only tables.
+struct FastcPendingTypeDeclarations {
+mut:
+	workers []thread FastcTypeDeclarationResult
+	result  FastcTypeDeclarationResult
+}
+
+fn fastc_start_type_declarations(sources []FastcSourceFile, type_sources map[string]string, prefs &pref.Preferences, type_source_paths map[string]bool, declared_types map[string]bool, declared_kinds map[string]FastcDeclaredTypeKind, enum_flags map[string]bool, constants map[string]string, public_constants map[string]bool) FastcPendingTypeDeclarations {
+	if fastc_parallel_worker_limit(prefs) <= 1 {
+		return FastcPendingTypeDeclarations{
+			result: fastc_run_type_declarations(sources, type_sources, prefs, type_source_paths, declared_types, declared_kinds, enum_flags, constants, public_constants)
+		}
+	}
+	return FastcPendingTypeDeclarations{
+		workers: [
+			spawn fastc_run_type_declarations(sources, type_sources, prefs, type_source_paths, declared_types, declared_kinds, enum_flags, constants, public_constants),
+		]
+	}
+}
+
+fn fastc_wait_type_declarations(mut pending FastcPendingTypeDeclarations) !FastcTypeDeclarationResult {
+	mut result := pending.result
+	if pending.workers.len > 0 {
+		result = pending.workers[0].wait()
+	}
+	if result.failed {
+		return error(result.error_message)
+	}
+	return result
 }
 
 // FastcPendingFieldLookup is the by-name index of struct fields, built on a

--- a/vlib/v3/gen/fastc/parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/fastc/parallel_notd_v3_no_parallel.v
@@ -119,10 +119,9 @@ fn fastc_memo_worker(tasks []FastcMemoTask, prefs &pref.Preferences, canonical_v
 	return results
 }
 
-// fastc_preload_memo lists, reads and looks up everything a resolve memo
-// names in one parallel batch bounded by the worker limit.
-fn fastc_preload_memo(memo FastcResolveMemo, prefs &pref.Preferences, canonical_vlib string, mut module_path_cache map[string]string, mut module_dir_files map[string][]string) map[string]FastcLoadedSource {
-	tasks := fastc_memo_tasks(memo)
+// fastc_run_memo_tasks runs a batch of memo tasks on at most the memo worker
+// limit of threads and returns the results in task order.
+fn fastc_run_memo_tasks(tasks []FastcMemoTask, prefs &pref.Preferences, canonical_vlib string) []FastcMemoResult {
 	mut jobs := fastc_parallel_job_count(tasks.len, prefs)
 	// Small-file reads and stats stop scaling after a few concurrent callers
 	// (the kernel serializes them), and extra workers only land on slower
@@ -135,7 +134,7 @@ fn fastc_preload_memo(memo FastcResolveMemo, prefs &pref.Preferences, canonical_
 		for index, task in tasks {
 			results[index] = fastc_run_memo_task(task, index, prefs, canonical_vlib)
 		}
-		return fastc_apply_memo_results(tasks, results, prefs, mut module_path_cache, mut module_dir_files)
+		return results
 	}
 	mut queue := &FastcGenQueue{
 		next: 0
@@ -156,7 +155,54 @@ fn fastc_preload_memo(memo FastcResolveMemo, prefs &pref.Preferences, canonical_
 			results[result.index] = result
 		}
 	}
-	return fastc_apply_memo_results(tasks, results, prefs, mut module_path_cache, mut module_dir_files)
+	return results
+}
+
+// fastc_preload_memo lists, looks up and stats everything a resolve memo
+// names in one bounded parallel batch while the main thread reads the memo's
+// content blob, then materializes the files in a second batch: from the blob
+// when a file's stamp still matches, by reading it otherwise.
+fn fastc_preload_memo(memo_path string, memo FastcResolveMemo, prefs &pref.Preferences, canonical_vlib string, mut module_path_cache map[string]string, mut module_dir_files map[string][]string) map[string]FastcLoadedSource {
+	probe_tasks := fastc_memo_probe_tasks(memo)
+	mut jobs := fastc_parallel_job_count(probe_tasks.len, prefs)
+	if jobs > fastc_memo_reader_limit {
+		jobs = fastc_memo_reader_limit
+	}
+	mut probe_results := []FastcMemoResult{len: probe_tasks.len}
+	mut blob := ''
+	if jobs <= 1 {
+		probe_results = fastc_run_memo_tasks(probe_tasks, prefs, canonical_vlib)
+		blob = fastc_read_memo_blob(memo_path, memo)
+	} else {
+		mut queue := &FastcGenQueue{
+			next: 0
+		}
+		mut workers := [
+			spawn fastc_memo_worker(probe_tasks, prefs, canonical_vlib, queue),
+		]
+		for _ in 2 .. jobs {
+			workers << spawn fastc_memo_worker(probe_tasks, prefs, canonical_vlib, queue)
+		}
+		blob = fastc_read_memo_blob(memo_path, memo)
+		first := fastc_memo_worker(probe_tasks, prefs, canonical_vlib, queue)
+		for result in first {
+			probe_results[result.index] = result
+		}
+		for worker in workers {
+			worker_results := worker.wait()
+			for result in worker_results {
+				probe_results[result.index] = result
+			}
+		}
+	}
+	mut loaded := fastc_apply_memo_results(probe_tasks, probe_results, prefs, mut module_path_cache, mut module_dir_files)
+	current_stamps := fastc_memo_current_stamps(probe_tasks, probe_results, memo.files.len)
+	read_tasks := fastc_memo_read_tasks(memo, current_stamps, blob)
+	read_results := fastc_run_memo_tasks(read_tasks, prefs, canonical_vlib)
+	for path, source in fastc_apply_memo_results(read_tasks, read_results, prefs, mut module_path_cache, mut module_dir_files) {
+		loaded[path] = source
+	}
+	return loaded
 }
 
 // FastcModuleListing is one module directory listed on a worker thread.

--- a/vlib/v3/gen/fastc/parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/fastc/parallel_notd_v3_no_parallel.v
@@ -491,11 +491,11 @@ fn fastc_collect_index_worker(sources []FastcSourceFile, prefs &pref.Preferences
 // and the declaration index in one parallel pass over the files: each file is
 // visited once, and there is a single spawn/join round. The results are
 // applied in file order, so they match the two serial scans.
-fn fastc_collect_generic_and_declaration_indexes(mut sources []FastcSourceFile, prefs &pref.Preferences, mut declared_types map[string]bool, mut declared_kinds map[string]FastcDeclaredTypeKind, mut enum_flags map[string]bool, mut params_structs map[string]bool, mut type_source_paths map[string]bool, mut type_sources map[string]string, mut constants map[string]string, mut public_constants map[string]bool, mut constant_sources map[string]string, mut constant_spans map[string][]int, mut globals map[string]string, mut public_globals map[string]bool) !map[string]FastcGenericMethodSource {
+fn fastc_collect_generic_and_declaration_indexes(mut sources []FastcSourceFile, prefs &pref.Preferences, mut declared_types map[string]bool, mut declared_kinds map[string]FastcDeclaredTypeKind, mut enum_flags map[string]bool, mut params_structs map[string]bool, mut type_source_paths map[string]bool, mut type_sources map[string]string, mut constants map[string]string, mut public_constants map[string]bool, mut constant_sources map[string]string, mut constant_spans map[string][]int, mut global_sources map[string]string, mut globals map[string]string, mut public_globals map[string]bool) !map[string]FastcGenericMethodSource {
 	jobs := fastc_parallel_jobs(sources, prefs)
 	if jobs <= 1 {
 		generic_method_sources := fastc_collect_generic_method_sources(mut sources, prefs)
-		fastc_collect_declaration_indexes(sources, prefs, mut declared_types, mut declared_kinds, mut enum_flags, mut params_structs, mut type_source_paths, mut type_sources, mut constants, mut public_constants, mut constant_sources, mut constant_spans, mut globals, mut public_globals)!
+		fastc_collect_declaration_indexes(sources, prefs, mut declared_types, mut declared_kinds, mut enum_flags, mut params_structs, mut type_source_paths, mut type_sources, mut constants, mut public_constants, mut constant_sources, mut constant_spans, mut global_sources, mut globals, mut public_globals)!
 		return generic_method_sources
 	}
 	order := fastc_file_generation_order(sources)
@@ -531,7 +531,7 @@ fn fastc_collect_generic_and_declaration_indexes(mut sources []FastcSourceFile, 
 		for key, generic in indexed.generics {
 			generic_method_sources[key] = generic
 		}
-		fastc_merge_declaration_partial(indexed.partial, mut declared_types, mut declared_kinds, mut enum_flags, mut params_structs, mut type_source_paths, mut type_sources, mut constants, mut public_constants, mut constant_sources, mut constant_spans, mut globals, mut public_globals)!
+		fastc_merge_declaration_partial(indexed.partial, mut declared_types, mut declared_kinds, mut enum_flags, mut params_structs, mut type_source_paths, mut type_sources, mut constants, mut public_constants, mut constant_sources, mut constant_spans, mut global_sources, mut globals, mut public_globals)!
 	}
 	return generic_method_sources
 }
@@ -1021,11 +1021,11 @@ fn fastc_collect_declaration_worker(sources []FastcSourceFile, prefs &pref.Prefe
 	return partials
 }
 
-fn fastc_collect_declaration_indexes(sources []FastcSourceFile, prefs &pref.Preferences, mut declared_types map[string]bool, mut declared_kinds map[string]FastcDeclaredTypeKind, mut enum_flags map[string]bool, mut params_structs map[string]bool, mut type_source_paths map[string]bool, mut type_sources map[string]string, mut constants map[string]string, mut public_constants map[string]bool, mut constant_sources map[string]string, mut constant_spans map[string][]int, mut globals map[string]string, mut public_globals map[string]bool) ! {
+fn fastc_collect_declaration_indexes(sources []FastcSourceFile, prefs &pref.Preferences, mut declared_types map[string]bool, mut declared_kinds map[string]FastcDeclaredTypeKind, mut enum_flags map[string]bool, mut params_structs map[string]bool, mut type_source_paths map[string]bool, mut type_sources map[string]string, mut constants map[string]string, mut public_constants map[string]bool, mut constant_sources map[string]string, mut constant_spans map[string][]int, mut global_sources map[string]string, mut globals map[string]string, mut public_globals map[string]bool) ! {
 	jobs := fastc_parallel_jobs(sources, prefs)
 	if jobs <= 1 {
 		partial := fastc_collect_declaration_chunk(sources, prefs, 0, sources.len)
-		fastc_merge_declaration_partial(partial, mut declared_types, mut declared_kinds, mut enum_flags, mut params_structs, mut type_source_paths, mut type_sources, mut constants, mut public_constants, mut constant_sources, mut constant_spans, mut globals, mut public_globals)!
+		fastc_merge_declaration_partial(partial, mut declared_types, mut declared_kinds, mut enum_flags, mut params_structs, mut type_source_paths, mut type_sources, mut constants, mut public_constants, mut constant_sources, mut constant_spans, mut global_sources, mut globals, mut public_globals)!
 		return
 	}
 	order := fastc_file_generation_order(sources)
@@ -1050,7 +1050,7 @@ fn fastc_collect_declaration_indexes(sources []FastcSourceFile, prefs &pref.Pref
 		}
 	}
 	for partial in partials {
-		fastc_merge_declaration_partial(partial, mut declared_types, mut declared_kinds, mut enum_flags, mut params_structs, mut type_source_paths, mut type_sources, mut constants, mut public_constants, mut constant_sources, mut constant_spans, mut globals, mut public_globals)!
+		fastc_merge_declaration_partial(partial, mut declared_types, mut declared_kinds, mut enum_flags, mut params_structs, mut type_source_paths, mut type_sources, mut constants, mut public_constants, mut constant_sources, mut constant_spans, mut global_sources, mut globals, mut public_globals)!
 	}
 }
 

--- a/vlib/v3/gen/fastc/render.v
+++ b/vlib/v3/gen/fastc/render.v
@@ -886,6 +886,32 @@ fn (g &Parser) render_overloaded_binary_expression(tokens []FastcExpressionToken
 	}
 }
 
+// fastc_contains_method_marker reports whether `rendered` contains a call of
+// `name` on a receiver, i.e. `.name(` or `->name(`, without building the
+// marker strings.
+@[direct_array_access]
+fn fastc_contains_method_marker(rendered string, name string) bool {
+	if name.len == 0 {
+		return false
+	}
+	mut from := 0
+	for from + name.len < rendered.len {
+		index := rendered.index_after_(name, from)
+		if index < 1 {
+			return false
+		}
+		end := index + name.len
+		if end < rendered.len && rendered[end] == `(` {
+			previous := rendered[index - 1]
+			if previous == `.` || (previous == `>` && index > 1 && rendered[index - 2] == `-`) {
+				return true
+			}
+		}
+		from = index + 1
+	}
+	return false
+}
+
 fn (g &Parser) render_pointer_member_access_expression(tokens []FastcExpressionToken, rendered_expression string) ?FastcRenderedExpression {
 	if tokens.len < 3 {
 		return none
@@ -898,9 +924,7 @@ fn (g &Parser) render_pointer_member_access_expression(tokens []FastcExpressionT
 		// still needs promotion here. A real method call is rendered later with
 		// its receiver and arguments, so preserve the old early exit for it.
 		is_qualified_call := tokens[i - 1].tok == .name && (tokens[i - 1].lit in g.imports || tokens[i - 1].lit == 'C') && (i < 2 || tokens[i - 2].tok != .dot)
-		method_marker := '.${tokens[i + 1].lit}('
-		pointer_method_marker := '->${tokens[i + 1].lit}('
-		if !is_qualified_call && (rendered_expression.contains(method_marker) || rendered_expression.contains(pointer_method_marker)) {
+		if !is_qualified_call && fastc_contains_method_marker(rendered_expression, tokens[i + 1].lit) {
 			return none
 		}
 	}

--- a/vlib/v3/gen/fastc/render.v
+++ b/vlib/v3/gen/fastc/render.v
@@ -897,11 +897,13 @@ fn fastc_contains_method_marker(rendered string, name string) bool {
 	mut from := 0
 	for from + name.len < rendered.len {
 		index := rendered.index_after_(name, from)
-		if index < 1 {
+		if index < 0 {
 			return false
 		}
+		// An occurrence at the start has no receiver before it; keep scanning
+		// past it (and past any other non-call occurrence).
 		end := index + name.len
-		if end < rendered.len && rendered[end] == `(` {
+		if index > 0 && end < rendered.len && rendered[end] == `(` {
 			previous := rendered[index - 1]
 			if previous == `.` || (previous == `>` && index > 1 && rendered[index - 2] == `-`) {
 				return true

--- a/vlib/v3/gen/fastc/source.v
+++ b/vlib/v3/gen/fastc/source.v
@@ -87,10 +87,7 @@ fn fastc_resolve_source_files(paths []string, prefs &pref.Preferences) !([]Fastc
 	mut timer := fastc_new_phase_timer()
 	memo_path := fastc_resolve_memo_path(paths, prefs)
 	memo_text := if memo_path != '' { os.read_file(memo_path) or { '' } } else { '' }
-	mut memo := fastc_parse_resolve_memo(memo_text)
-	if memo.files.len > 0 {
-		memo.blob = fastc_read_memo_blob(memo_path, memo)
-	}
+	memo := fastc_parse_resolve_memo(memo_text)
 	builtin_dir := if prefs.building_v {
 		os.real_path(prefs.get_vlib_module_path('builtin'))
 	} else {
@@ -109,7 +106,7 @@ fn fastc_resolve_source_files(paths []string, prefs &pref.Preferences) !([]Fastc
 	if memo.files.len > 0 {
 		// A memo from an earlier run names everything this entry touched, so
 		// all of it is listed, read and looked up in one parallel batch.
-		preloaded = fastc_preload_memo(memo, prefs, canonical_vlib, mut module_path_cache, mut module_dir_files)
+		preloaded = fastc_preload_memo(memo_path, memo, prefs, canonical_vlib, mut module_path_cache, mut module_dir_files)
 		timer.mark('resolve.memo_preload')
 	}
 	mut queue := []FastcQueuedSource{}
@@ -324,9 +321,6 @@ mut:
 	// are trusted only for files modified at least two seconds before it.
 	written i64
 	blob_token string
-	// blob holds every memoized file's content, each followed by a NUL, when
-	// the companion blob file matched the memo; empty otherwise.
-	blob string
 }
 
 // FastcFileStamp identifies a file version: a cached content is reused only
@@ -386,11 +380,12 @@ struct FastcMemoTask {
 	source      string
 	dir         string
 	files       []string
-	// For read tasks: the memoized stamps and blob offsets of `files`, and
-	// the memo they came from (its blob and trust window).
-	stamps  []FastcFileStamp
-	offsets []int
-	blob    string
+	// For read tasks: the memoized and the current stamps of `files`, the
+	// blob offsets, and the memo's blob and trust window.
+	stamps         []FastcFileStamp
+	current_stamps []FastcFileStamp
+	offsets        []int
+	blob           string
 	trusted_before i64
 }
 
@@ -469,15 +464,19 @@ fn fastc_parse_resolve_memo(text string) FastcResolveMemo {
 	return memo
 }
 
-// fastc_memo_tasks turns a memo into preload tasks: lookups and listings
-// first, then the file reads in chunks.
-fn fastc_memo_tasks(memo FastcResolveMemo) []FastcMemoTask {
-	mut tasks := []FastcMemoTask{cap: memo.dirs.len + memo.lookup_modules.len + memo.files.len / fastc_source_load_chunk_size + 1}
+// fastc_memo_stat_chunk_size is the number of files one probe task stats.
+const fastc_memo_stat_chunk_size = 12
+
+// fastc_memo_probe_tasks turns a memo into the first batch of preload tasks:
+// the module lookups, the directory listings and the file stats. They need
+// no file content, so they overlap with reading the memo's content blob.
+fn fastc_memo_probe_tasks(memo FastcResolveMemo) []FastcMemoTask {
+	mut tasks := []FastcMemoTask{cap: memo.dirs.len + memo.lookup_modules.len + memo.files.len / fastc_memo_stat_chunk_size + 1}
 	for i, module_name in memo.lookup_modules {
 		tasks << FastcMemoTask{
-			kind:   0
+			kind:        0
 			module_name: module_name
-			source: memo.lookup_sources[i]
+			source:      memo.lookup_sources[i]
 		}
 	}
 	for dir in memo.dirs {
@@ -486,9 +485,27 @@ fn fastc_memo_tasks(memo FastcResolveMemo) []FastcMemoTask {
 			dir:  dir
 		}
 	}
-	with_blob := memo.blob.len > 0
-	// Files whose content is in the blob only need a stat each, so those
-	// chunks are larger.
+	mut start := 0
+	for start < memo.files.len {
+		mut end := start + fastc_memo_stat_chunk_size
+		if end > memo.files.len {
+			end = memo.files.len
+		}
+		tasks << FastcMemoTask{
+			kind:  3
+			files: memo.files[start..end]
+		}
+		start = end
+	}
+	return tasks
+}
+
+// fastc_memo_read_tasks turns the stat results into the second batch: each
+// chunk materializes its files, from the blob when a file's stamp still
+// matches the memo's and is old enough to trust, by reading it otherwise.
+fn fastc_memo_read_tasks(memo FastcResolveMemo, current_stamps []FastcFileStamp, blob string) []FastcMemoTask {
+	mut tasks := []FastcMemoTask{cap: memo.files.len / fastc_source_load_chunk_size + 1}
+	with_blob := blob.len > 0 && current_stamps.len == memo.files.len
 	chunk := if with_blob { fastc_source_load_chunk_size * 2 } else { fastc_source_load_chunk_size }
 	mut start := 0
 	for start < memo.files.len {
@@ -505,8 +522,9 @@ fn fastc_memo_tasks(memo FastcResolveMemo) []FastcMemoTask {
 				kind:           2
 				files:          memo.files[start..end]
 				stamps:         memo.stamps[start..end]
+				current_stamps: current_stamps[start..end]
 				offsets:        memo.offsets[start..end]
-				blob:           memo.blob
+				blob:           blob
 				trusted_before: memo.written - 1
 			}
 		}
@@ -534,21 +552,28 @@ fn fastc_run_memo_task(task FastcMemoTask, index int, prefs &pref.Preferences, c
 			files: fastc_list_module_sources(task.dir, prefs)
 		}
 	}
-	mut sources := []FastcLoadedSource{cap: task.files.len}
-	mut stamps := []FastcFileStamp{cap: task.files.len}
-	for i, path in task.files {
-		stamp := fastc_file_stamp(path) or {
-			sources << fastc_load_source(path, prefs)
-			stamps << FastcFileStamp{}
-			continue
+	if task.kind == 3 {
+		mut stamps := []FastcFileStamp{cap: task.files.len}
+		for path in task.files {
+			stamps << fastc_file_stamp(path) or { FastcFileStamp{} }
 		}
-		stamps << stamp
-		if task.blob.len > 0 && fastc_same_stamp(stamp, task.stamps[i]) && stamp.mtime < task.trusted_before {
-			// The file is the memoized version: its content is in the blob.
-			offset := task.offsets[i]
-			text := unsafe { tos(task.blob.str + offset, int(stamp.size)) }.clone()
-			sources << fastc_load_source_text(path, text, prefs)
-			continue
+		return FastcMemoResult{
+			index:  index
+			files:  task.files
+			stamps: stamps
+		}
+	}
+	mut sources := []FastcLoadedSource{cap: task.files.len}
+	for i, path in task.files {
+		if task.blob.len > 0 {
+			stamp := task.current_stamps[i]
+			if stamp.size != 0 && fastc_same_stamp(stamp, task.stamps[i]) && stamp.mtime < task.trusted_before {
+				// The file is the memoized version: its content is in the blob.
+				offset := task.offsets[i]
+				text := unsafe { tos(task.blob.str + offset, int(stamp.size)) }.clone()
+				sources << fastc_load_source_text(path, text, prefs)
+				continue
+			}
 		}
 		sources << fastc_load_source(path, prefs)
 	}
@@ -556,7 +581,7 @@ fn fastc_run_memo_task(task FastcMemoTask, index int, prefs &pref.Preferences, c
 		index:   index
 		files:   task.files
 		sources: sources
-		stamps:  stamps
+		stamps:  task.current_stamps
 	}
 }
 
@@ -586,7 +611,7 @@ fn fastc_apply_memo_results(tasks []FastcMemoTask, results []FastcMemoResult, pr
 			module_path_cache[fastc_module_cache_key(prefs, task.source, task.module_name)] = result.dir
 		} else if task.kind == 1 {
 			module_dir_files[task.dir] = result.files
-		} else {
+		} else if task.kind == 2 {
 			for i, source in result.sources {
 				stamp := if i < result.stamps.len { result.stamps[i] } else { FastcFileStamp{} }
 				loaded[task.files[i]] = FastcLoadedSource{
@@ -601,6 +626,22 @@ fn fastc_apply_memo_results(tasks []FastcMemoTask, results []FastcMemoResult, pr
 		}
 	}
 	return loaded
+}
+
+// fastc_memo_current_stamps gathers the stats of the probe batch in memo
+// file order (a zero stamp where a stat failed).
+fn fastc_memo_current_stamps(tasks []FastcMemoTask, results []FastcMemoResult, file_count int) []FastcFileStamp {
+	mut stamps := []FastcFileStamp{cap: file_count}
+	for index, task in tasks {
+		if task.kind != 3 {
+			continue
+		}
+		result := results[index]
+		for i, _ in task.files {
+			stamps << if i < result.stamps.len { result.stamps[i] } else { FastcFileStamp{} }
+		}
+	}
+	return stamps
 }
 
 // fastc_store_resolve_memo writes the memo of this resolution when it differs

--- a/vlib/v3/gen/fastc/source.v
+++ b/vlib/v3/gen/fastc/source.v
@@ -2,6 +2,7 @@ module fastc
 
 import os
 import strings
+import time
 import v3.pref
 import v3.scanner
 import v3.token
@@ -84,17 +85,41 @@ fn fastc_load_source(path string, prefs &pref.Preferences) FastcLoadedSource {
 
 fn fastc_resolve_source_files(paths []string, prefs &pref.Preferences) !([]FastcSourceFile, map[string]string) {
 	mut timer := fastc_new_phase_timer()
+	memo_path := fastc_resolve_memo_path(paths, prefs)
+	memo_text := if memo_path != '' { os.read_file(memo_path) or { '' } } else { '' }
+	mut memo := fastc_parse_resolve_memo(memo_text)
+	if memo.files.len > 0 {
+		memo.blob = fastc_read_memo_blob(memo_path, memo)
+	}
+	builtin_dir := if prefs.building_v {
+		os.real_path(prefs.get_vlib_module_path('builtin'))
+	} else {
+		''
+	}
+	// vroot is canonical, so a module directory found below its vlib is too and
+	// needs no realpath call of its own.
+	canonical_vlib := if prefs.building_v { os.dir(builtin_dir) } else { '' }
+	// Modules are re-discovered once per importing file; canonicalization and
+	// directory enumeration are syscalls, so both are memoized for the walk and
+	// shared with the preload below.
+	mut real_path_cache := map[string]string{}
+	mut module_dir_files := map[string][]string{}
+	mut module_path_cache := map[string]string{}
+	mut preloaded := map[string]FastcLoadedSource{}
+	if memo.files.len > 0 {
+		// A memo from an earlier run names everything this entry touched, so
+		// all of it is listed, read and looked up in one parallel batch.
+		preloaded = fastc_preload_memo(memo, prefs, canonical_vlib, mut module_path_cache, mut module_dir_files)
+		timer.mark('resolve.memo_preload')
+	}
 	mut queue := []FastcQueuedSource{}
 	if prefs.building_v {
-		builtin_dir := os.real_path(prefs.get_vlib_module_path('builtin'))
-		for builtin_file in pref.get_v_files_from_dir_for_target(builtin_dir, prefs.user_defines, prefs.target) {
-			if fastc_source_file_matches_backend(builtin_file) {
-				queue << FastcQueuedSource{
-					path: builtin_file
-					module_name: 'builtin'
-					is_canonical: true
-					listed: true
-				}
+		for builtin_file in fastc_module_source_files(builtin_dir, prefs, mut module_dir_files) {
+			queue << FastcQueuedSource{
+				path: builtin_file
+				module_name: 'builtin'
+				is_canonical: true
+				listed: true
 			}
 		}
 	}
@@ -123,25 +148,16 @@ fn fastc_resolve_source_files(paths []string, prefs &pref.Preferences) !([]Fastc
 		}
 	}
 	timer.mark('resolve.queue_init')
-	// vroot is canonical, so a module directory found below its vlib is too and
-	// needs no realpath call of its own.
-	canonical_vlib := if prefs.building_v {
-		os.dir(os.real_path(prefs.get_vlib_module_path('builtin')))
-	} else {
-		''
+	if memo.files.len == 0 {
+		// Every reachable file is read and header-scanned up front on worker
+		// threads, following imports as soon as they are known. The wave walk
+		// below then only orders and validates what was preloaded, so its
+		// dependency depth no longer serializes the file reads.
+		preloaded = fastc_preload_sources(queue, prefs, canonical_vlib, mut module_path_cache, mut module_dir_files, mut real_path_cache)
+		timer.mark('resolve.preload')
 	}
-	// Modules are re-discovered once per importing file; canonicalization and
-	// directory enumeration are syscalls, so both are memoized for the walk and
-	// shared with the preload below.
-	mut real_path_cache := map[string]string{}
-	mut module_dir_files := map[string][]string{}
-	mut module_path_cache := map[string]string{}
-	// Every reachable file is read and header-scanned up front on worker
-	// threads, following imports as soon as they are known. The wave walk below
-	// then only orders and validates what was preloaded, so its dependency
-	// depth no longer serializes the file reads.
-	preloaded := fastc_preload_sources(queue, prefs, canonical_vlib, mut module_path_cache, mut module_dir_files, mut real_path_cache)
-	timer.mark('resolve.preload')
+	mut memo_lookup_modules := []string{}
+	mut memo_lookup_sources := []string{}
 	mut seen := map[string]bool{}
 	mut sources := []FastcSourceFile{}
 	// path -> the module_name a file was first loaded under, and the resulting alias map:
@@ -247,6 +263,8 @@ fn fastc_resolve_source_files(paths []string, prefs &pref.Preferences) !([]Fastc
 				discovered_imports[imported_module] = true
 				module_cache_key := fastc_module_cache_key(prefs, source_file.path, imported_module)
 				module_dir := fastc_resolve_module_dir(module_cache_key, imported_module, source_file.path, prefs, canonical_vlib, mut module_path_cache)
+				memo_lookup_modules << imported_module
+				memo_lookup_sources << source_file.path
 				if module_dir == '' {
 					return error('fastc cannot resolve imported module `${imported_module}` from `${source_file.path}`')
 				}
@@ -280,7 +298,392 @@ fn fastc_resolve_source_files(paths []string, prefs &pref.Preferences) !([]Fastc
 		}
 	}
 	timer.mark('resolve.imports')
+	if memo_path != '' {
+		fastc_store_resolve_memo(memo_path, memo_text, sources, builtin_dir, memo_lookup_modules, memo_lookup_sources, prefs, module_path_cache, preloaded)
+		timer.mark('resolve.memo_store')
+	}
 	return sources, module_aliases
+}
+
+// FastcResolveMemo records what an earlier resolution of the same entry
+// touched: the module directories it listed, the files it loaded and the
+// module lookups it made. Only the names are reused: the directories are
+// listed and the files read again and the lookups are recomputed, all in one
+// parallel batch instead of level by level along the import chain, and the
+// ordering walk then replays over that data exactly as it would have without
+// the memo (anything it needs that the memo missed is loaded on demand).
+struct FastcResolveMemo {
+mut:
+	dirs           []string
+	files          []string
+	stamps         []FastcFileStamp
+	offsets        []int
+	lookup_modules []string
+	lookup_sources []string
+	// written is the memo's own write time (unix seconds); cached contents
+	// are trusted only for files modified at least two seconds before it.
+	written i64
+	blob_token string
+	// blob holds every memoized file's content, each followed by a NUL, when
+	// the companion blob file matched the memo; empty otherwise.
+	blob string
+}
+
+// FastcFileStamp identifies a file version: a cached content is reused only
+// when the file's current stamp equals the memoized one.
+struct FastcFileStamp {
+	size  i64
+	mtime i64
+	ctime i64
+	inode u64
+}
+
+fn fastc_same_stamp(a FastcFileStamp, b FastcFileStamp) bool {
+	return a.size == b.size && a.mtime == b.mtime && a.ctime == b.ctime && a.inode == b.inode
+}
+
+fn fastc_file_stamp(path string) ?FastcFileStamp {
+	st := os.stat(path) or { return none }
+	return FastcFileStamp{
+		size:  i64(st.size)
+		mtime: st.mtime
+		ctime: st.ctime
+		inode: st.inode
+	}
+}
+
+// fastc_memo_token_width is the fixed width of the token line that starts a
+// memo blob, so the file offsets recorded in the memo are absolute and stable.
+const fastc_memo_token_width = 40
+
+// fastc_memo_blob_path names the content file that accompanies a memo.
+fn fastc_memo_blob_path(memo_path string) string {
+	return memo_path + '.src'
+}
+
+// fastc_read_memo_blob reads the memo's content blob and returns it when it
+// belongs to this memo (same token) and has the expected size.
+fn fastc_read_memo_blob(memo_path string, memo FastcResolveMemo) string {
+	if memo.blob_token == '' || memo.stamps.len != memo.files.len || memo.offsets.len != memo.files.len {
+		return ''
+	}
+	blob := os.read_file(fastc_memo_blob_path(memo_path)) or { return '' }
+	mut expected := fastc_memo_token_width + 1
+	for stamp in memo.stamps {
+		expected += int(stamp.size) + 1
+	}
+	if blob.len != expected || !blob.starts_with(memo.blob_token) || blob[fastc_memo_token_width] != `\n` {
+		return ''
+	}
+	return blob
+}
+
+// FastcMemoTask is one unit of the memo preload: a module lookup, a directory
+// listing or a chunk of file reads.
+struct FastcMemoTask {
+	kind        int
+	module_name string
+	source      string
+	dir         string
+	files       []string
+	// For read tasks: the memoized stamps and blob offsets of `files`, and
+	// the memo they came from (its blob and trust window).
+	stamps  []FastcFileStamp
+	offsets []int
+	blob    string
+	trusted_before i64
+}
+
+struct FastcMemoResult {
+	index   int
+	dir     string
+	files   []string
+	sources []FastcLoadedSource
+	stamps  []FastcFileStamp
+}
+
+fn fastc_fnv_hash(seed u64, text string) u64 {
+	mut hash := seed
+	for i in 0 .. text.len {
+		hash ^= u64(text[i])
+		hash *= u64(1099511628211)
+	}
+	hash ^= u64(0xff)
+	hash *= u64(1099511628211)
+	return hash
+}
+
+// fastc_resolve_memo_path names the memo file of an entry set and build
+// configuration; it is empty when the memo is disabled.
+fn fastc_resolve_memo_path(paths []string, prefs &pref.Preferences) string {
+	if os.getenv('V3_FASTC_NO_RESOLVE_MEMO') != '' {
+		return ''
+	}
+	mut hash := u64(14695981039346656037)
+	// The format version keeps compilers that write different memo layouts
+	// from overwriting each other's memo.
+	hash = fastc_fnv_hash(hash, 'fastc-resolve-memo-2')
+	hash = fastc_fnv_hash(hash, prefs.vroot)
+	hash = fastc_fnv_hash(hash, prefs.target.os)
+	hash = fastc_fnv_hash(hash, prefs.target.arch)
+	hash = fastc_fnv_hash(hash, if prefs.building_v { 'v' } else { '' })
+	for define in prefs.user_defines {
+		hash = fastc_fnv_hash(hash, define)
+	}
+	for path in paths {
+		hash = fastc_fnv_hash(hash, os.real_path(path))
+	}
+	return os.join_path_single(os.vtmp_dir(), 'fastc_resolve_${hash.hex()}.memo')
+}
+
+fn fastc_parse_resolve_memo(text string) FastcResolveMemo {
+	mut memo := FastcResolveMemo{}
+	for line in text.split_into_lines() {
+		if line.len < 3 {
+			continue
+		}
+		fields := line[2..].split('\t')
+		kind := line[0]
+		if kind == `D` {
+			memo.dirs << fields[0]
+		} else if kind == `F` {
+			memo.files << fields[0]
+			if fields.len == 6 {
+				memo.stamps << FastcFileStamp{
+					size:  fields[1].i64()
+					mtime: fields[2].i64()
+					ctime: fields[3].i64()
+					inode: fields[4].u64()
+				}
+				memo.offsets << fields[5].int()
+			}
+		} else if kind == `M` && fields.len == 2 {
+			memo.lookup_modules << fields[0]
+			memo.lookup_sources << fields[1]
+		} else if kind == `T` {
+			memo.written = fields[0].i64()
+		} else if kind == `B` {
+			memo.blob_token = fields[0]
+		}
+	}
+	return memo
+}
+
+// fastc_memo_tasks turns a memo into preload tasks: lookups and listings
+// first, then the file reads in chunks.
+fn fastc_memo_tasks(memo FastcResolveMemo) []FastcMemoTask {
+	mut tasks := []FastcMemoTask{cap: memo.dirs.len + memo.lookup_modules.len + memo.files.len / fastc_source_load_chunk_size + 1}
+	for i, module_name in memo.lookup_modules {
+		tasks << FastcMemoTask{
+			kind:   0
+			module_name: module_name
+			source: memo.lookup_sources[i]
+		}
+	}
+	for dir in memo.dirs {
+		tasks << FastcMemoTask{
+			kind: 1
+			dir:  dir
+		}
+	}
+	with_blob := memo.blob.len > 0
+	// Files whose content is in the blob only need a stat each, so those
+	// chunks are larger.
+	chunk := if with_blob { fastc_source_load_chunk_size * 2 } else { fastc_source_load_chunk_size }
+	mut start := 0
+	for start < memo.files.len {
+		mut end := start + chunk
+		if end > memo.files.len {
+			end = memo.files.len
+		}
+		mut task := FastcMemoTask{
+			kind:  2
+			files: memo.files[start..end]
+		}
+		if with_blob {
+			task = FastcMemoTask{
+				kind:           2
+				files:          memo.files[start..end]
+				stamps:         memo.stamps[start..end]
+				offsets:        memo.offsets[start..end]
+				blob:           memo.blob
+				trusted_before: memo.written - 1
+			}
+		}
+		tasks << task
+		start = end
+	}
+	return tasks
+}
+
+// fastc_run_memo_task performs one memo preload task with the same helpers
+// the ordering walk uses, so the results are what the walk would compute.
+fn fastc_run_memo_task(task FastcMemoTask, index int, prefs &pref.Preferences, canonical_vlib string) FastcMemoResult {
+	if task.kind == 0 {
+		mut local_cache := map[string]string{}
+		key := fastc_module_cache_key(prefs, task.source, task.module_name)
+		return FastcMemoResult{
+			index: index
+			dir:   fastc_resolve_module_dir(key, task.module_name, task.source, prefs, canonical_vlib, mut local_cache)
+		}
+	}
+	if task.kind == 1 {
+		return FastcMemoResult{
+			index: index
+			dir:   task.dir
+			files: fastc_list_module_sources(task.dir, prefs)
+		}
+	}
+	mut sources := []FastcLoadedSource{cap: task.files.len}
+	mut stamps := []FastcFileStamp{cap: task.files.len}
+	for i, path in task.files {
+		stamp := fastc_file_stamp(path) or {
+			sources << fastc_load_source(path, prefs)
+			stamps << FastcFileStamp{}
+			continue
+		}
+		stamps << stamp
+		if task.blob.len > 0 && fastc_same_stamp(stamp, task.stamps[i]) && stamp.mtime < task.trusted_before {
+			// The file is the memoized version: its content is in the blob.
+			offset := task.offsets[i]
+			text := unsafe { tos(task.blob.str + offset, int(stamp.size)) }.clone()
+			sources << fastc_load_source_text(path, text, prefs)
+			continue
+		}
+		sources << fastc_load_source(path, prefs)
+	}
+	return FastcMemoResult{
+		index:   index
+		files:   task.files
+		sources: sources
+		stamps:  stamps
+	}
+}
+
+// fastc_load_source_text header-scans already read source text.
+fn fastc_load_source_text(path string, source string, prefs &pref.Preferences) FastcLoadedSource {
+	header := fastc_scan_source_header(source, path, prefs) or {
+		return FastcLoadedSource{
+			path:          path
+			failed:        true
+			error_message: err.msg()
+		}
+	}
+	return FastcLoadedSource{
+		path:   path
+		source: source
+		header: header
+	}
+}
+
+// fastc_apply_memo_results stores the preload results in the walk's caches
+// and returns the loaded files keyed by path.
+fn fastc_apply_memo_results(tasks []FastcMemoTask, results []FastcMemoResult, prefs &pref.Preferences, mut module_path_cache map[string]string, mut module_dir_files map[string][]string) map[string]FastcLoadedSource {
+	mut loaded := map[string]FastcLoadedSource{}
+	for index, task in tasks {
+		result := results[index]
+		if task.kind == 0 {
+			module_path_cache[fastc_module_cache_key(prefs, task.source, task.module_name)] = result.dir
+		} else if task.kind == 1 {
+			module_dir_files[task.dir] = result.files
+		} else {
+			for i, source in result.sources {
+				stamp := if i < result.stamps.len { result.stamps[i] } else { FastcFileStamp{} }
+				loaded[task.files[i]] = FastcLoadedSource{
+					path:          source.path
+					source:        source.source
+					header:        source.header
+					failed:        source.failed
+					error_message: source.error_message
+					stamp:         stamp
+				}
+			}
+		}
+	}
+	return loaded
+}
+
+// fastc_store_resolve_memo writes the memo of this resolution when it differs
+// from the one read at the start, atomically, so a concurrent compiler sees
+// either version.
+fn fastc_store_resolve_memo(memo_path string, previous_text string, sources []FastcSourceFile, builtin_dir string, lookup_modules []string, lookup_sources []string, prefs &pref.Preferences, module_path_cache map[string]string, preloaded map[string]FastcLoadedSource) {
+	mut out := strings.new_builder(4096)
+	mut seen_dirs := map[string]bool{}
+	if builtin_dir != '' {
+		seen_dirs[builtin_dir] = true
+		out.writeln('D\t' + builtin_dir)
+	}
+	for i, module_name in lookup_modules {
+		dir := module_path_cache[fastc_module_cache_key(prefs, lookup_sources[i], module_name)] or { '' }
+		if dir == '' || seen_dirs[dir] {
+			continue
+		}
+		seen_dirs[dir] = true
+		out.writeln('D\t' + dir)
+	}
+	// The stamps and the blob layout: the previous memo's token and time are
+	// not part of the comparison, so an unchanged program rewrites nothing.
+	mut stamp_lines := strings.new_builder(8192)
+	mut blob_size := fastc_memo_token_width + 1
+	mut stamps := []FastcFileStamp{cap: sources.len}
+	for source_file in sources {
+		mut stamp := FastcFileStamp{}
+		if loaded := preloaded[source_file.path] {
+			stamp = loaded.stamp
+		}
+		if stamp.size == 0 && stamp.mtime == 0 {
+			stamp = fastc_file_stamp(source_file.path) or { FastcFileStamp{} }
+		}
+		stamps << stamp
+		stamp_lines.writeln('F\t' + source_file.path + '\t${stamp.size}\t${stamp.mtime}\t${stamp.ctime}\t${stamp.inode}\t${blob_size}')
+		blob_size += source_file.source.len + 1
+	}
+	out.write_string(stamp_lines.str())
+	for i, module_name in lookup_modules {
+		out.writeln('M\t' + module_name + '\t' + lookup_sources[i])
+	}
+	body := out.str()
+	if body == fastc_memo_body(previous_text) {
+		return
+	}
+	mut blob_token := '${os.getpid()}.${time.now().unix_nano()}'
+	for blob_token.len < fastc_memo_token_width {
+		blob_token += '.'
+	}
+	blob_token = blob_token[..fastc_memo_token_width]
+	mut blob := strings.new_builder(blob_size)
+	blob.writeln(blob_token)
+	for source_file in sources {
+		blob.write_string(source_file.source)
+		blob.write_u8(0)
+	}
+	blob_path := fastc_memo_blob_path(memo_path)
+	staged_blob := '${blob_path}.${os.getpid()}.tmp'
+	os.write_file(staged_blob, blob.str()) or { return }
+	os.mv(staged_blob, blob_path) or {
+		os.rm(staged_blob) or {}
+		return
+	}
+	text := body + 'T\t${time.now().unix()}\nB\t' + blob_token + '\n'
+	staged := '${memo_path}.${os.getpid()}.tmp'
+	os.write_file(staged, text) or { return }
+	os.mv(staged, memo_path) or {
+		os.rm(staged) or {}
+		return
+	}
+}
+
+// fastc_memo_body strips the write time and token lines from a memo text, so
+// two memos of the same program compare equal.
+fn fastc_memo_body(text string) string {
+	mut out := strings.new_builder(text.len)
+	for line in text.split_into_lines() {
+		if line.len >= 2 && (line[0] == `T` || line[0] == `B`) && line[1] == `\t` {
+			continue
+		}
+		out.writeln(line)
+	}
+	return out.str()
 }
 
 // fastc_source_load_chunk_size is the number of files one loader thread reads;

--- a/vlib/v3/pref/pref.v
+++ b/vlib/v3/pref/pref.v
@@ -639,6 +639,20 @@ pub fn get_v_files_from_dir_for_target(dir string, user_defines []string, target
 	all_files := os.ls(dir) or { return []string{} }
 	mut sorted_files := all_files.clone()
 	sorted_files.sort()
+	// The target-dependent parts of the per-file checks are computed once per
+	// directory: the architectures a file suffix may name that are not the
+	// target's, and the OS-specific suffixes of the target OS.
+	mut incompatible_archs := []string{}
+	for arch in ['amd64', 'x64', 'x86_64', 'arm64', 'aarch64', 'x86', 'i386', 'i486', 'i586', 'i686',
+		'x32', 'x86_32', 'ia-32', 'ia32', 'arm32', 'rv64', 'riscv64', 'ppc', 'ppc64', 'ppc64le',
+		's390x', 'loongarch64', 'wasm32'] {
+		if normalized_arch(arch) != target.arch {
+			incompatible_archs << arch
+		}
+	}
+	os_suffixes := os_specific_suffixes(target.os)
+	// Each file is classified once; both emission groups below reuse the result.
+	mut candidates := []VFileCandidate{cap: sorted_files.len}
 	mut has_os_specific := map[string]bool{}
 	for file in sorted_files {
 		if !file.ends_with('.v') || file.ends_with('.js.v')
@@ -646,27 +660,34 @@ pub fn get_v_files_from_dir_for_target(dir string, user_defines []string, target
 			&& !file_name_has_marker(file, '_notd_test.')) {
 			continue
 		}
-		if file_has_incompatible_target_suffix(file, target) {
+		if file_has_incompatible_os_only_suffix(file, target.os) {
 			continue
 		}
-		if base := os_specific_base(file, target.os) {
+		mut incompatible := false
+		for arch in incompatible_archs {
+			if file_name_has_arch_marker(file, arch) {
+				incompatible = true
+				break
+			}
+		}
+		if incompatible {
+			continue
+		}
+		if base := os_specific_base_for(file, os_suffixes) {
 			has_os_specific[base] = true
+		}
+		candidates << VFileCandidate{
+			file: file
+			is_c: file.ends_with('.c.v')
 		}
 	}
 	mut v_files := []string{}
 	for backend_specific in [false, true] {
-		for file in sorted_files {
-			if file.ends_with('.c.v') != backend_specific {
+		for candidate in candidates {
+			if candidate.is_c != backend_specific {
 				continue
 			}
-			if !file.ends_with('.v') || file.ends_with('.js.v')
-				|| (file_name_has_marker(file, '_test.') && !file_name_has_marker(file, '_d_test.')
-				&& !file_name_has_marker(file, '_notd_test.')) {
-				continue
-			}
-			if file_has_incompatible_target_suffix(file, target) {
-				continue
-			}
+			file := candidate.file
 			if base := default_file_base(file) {
 				if has_os_specific[base] {
 					continue
@@ -687,6 +708,13 @@ pub fn get_v_files_from_dir_for_target(dir string, user_defines []string, target
 		}
 	}
 	return v_files
+}
+
+// VFileCandidate is a source file of a directory that passed the
+// target-independent and target-suffix filters, with its backend group.
+struct VFileCandidate {
+	file string
+	is_c bool
 }
 
 // get_test_v_files_from_dir returns backend/target/define-compatible test files in dir.
@@ -809,9 +837,12 @@ fn default_file_base(file string) ?string {
 
 // os_specific_base supports os specific base handling for pref.
 fn os_specific_base(file string, target_os string) ?string {
-	if _ := default_file_base(file) {
-		return none
-	}
+	return os_specific_base_for(file, os_specific_suffixes(target_os))
+}
+
+// os_specific_suffixes lists the file name suffixes (`_nix`, `_macos`, ...)
+// that mark a file as specific to `target_os`.
+fn os_specific_suffixes(target_os string) []string {
 	mut suffixes := []string{}
 	os_name := normalized_os(target_os)
 	if os_name != 'windows' {
@@ -867,6 +898,15 @@ fn os_specific_base(file string, target_os string) ?string {
 		else {}
 	}
 
+	return suffixes
+}
+
+// os_specific_base_for returns the base name of an OS-specific file whose
+// suffix is one of `suffixes` (see os_specific_suffixes).
+fn os_specific_base_for(file string, suffixes []string) ?string {
+	if _ := default_file_base(file) {
+		return none
+	}
 	for suffix in suffixes {
 		for ext in ['.c.v', '.v'] {
 			marker := suffix + ext

--- a/vlib/v3/pref/pref.v
+++ b/vlib/v3/pref/pref.v
@@ -168,11 +168,20 @@ pub fn target_from(os_name string, arch_name string) !Target {
 // new_preferences supports new preferences handling for pref.
 pub fn new_preferences() &Preferences {
 	build_time := target_build_time()
+	// Formatted by hand: the first C strftime call of a process initializes
+	// the timezone data, which costs about half a millisecond per compile.
 	return &Preferences{
-		build_date:      build_time.strftime('%Y-%m-%d')
-		build_time:      build_time.strftime('%H:%M:%S')
+		build_date:      '${build_time.year}-${two_digits(build_time.month)}-${two_digits(build_time.day)}'
+		build_time:      '${two_digits(build_time.hour)}:${two_digits(build_time.minute)}:${two_digits(build_time.second)}'
 		build_timestamp: build_time.unix().str()
 	}
+}
+
+fn two_digits(value int) string {
+	if value < 10 {
+		return '0' + value.str()
+	}
+	return value.str()
 }
 
 // has_macos_v3_caller_environment reports whether the macOS driver transported


### PR DESCRIPTION
Third round of FastC generation speedups (after #28291 and #28294), measured on the self-host input (`vlib/v3/v3.v`, 173 files, ~66.4K lines) with the standalone driver built with `-cflags -O2 -gc none -prealloc`, interleaving the merged master and this branch on the same loaded machine (M5 Max, other sessions running tests, load ≈ 4.5):

| build | min | median | loc/s (median) |
|---|---|---|---|
| master `-O2` | 20.27 ms | 21.23 ms | ~3.1M |
| this PR `-O2` | 16.28 ms | 16.95 ms | ~3.9M |

On a quiet machine the same master build measured 18.9 / 19.3 ms, so this branch lands around 15.5-16 ms there (~4.2M loc/s). Phase profile (`FASTC_BENCH_PHASES=1`, ms): resolve 3.3 → 1.3, type declarations 1.4 → 0.2 of main-thread time, the rest within noise.

The generated C is byte-identical to the merged master's on this input, checked with the memo cold, warm (blob trusted), disabled, and with `VJOBS=2`; the TCC self-host chain reproduces itself in each mode and serial output matches parallel output.

### Resolve memo

`os.vtmp_dir()/fastc_resolve_<hash>.memo` (keyed by entry files, vroot, target, defines and a format version) records what the previous resolution of the same entry touched: the module directories it listed, the module lookups it made, and the files it loaded with their size/mtime/ctime/inode; a companion `.memo.src` blob holds the contents. The next run lists every directory, recomputes every lookup and stats every file in one bounded parallel batch (at most 6 workers: small-file `open`/`read` and `stat` stop scaling past a few concurrent callers in one process) instead of discovering them level by level along the import chain. A file's content is taken from the blob only when its stamp still matches **and** it was last modified at least two seconds before the memo was written; otherwise it is read again. The ordering walk itself is unchanged and replays over that data, so anything the memo missed is loaded on demand and the resolved graph, order and errors are what they would be without it. The memo and blob are rewritten atomically only when the program (paths or stamps) changed; `V3_FASTC_NO_RESOLVE_MEMO=1` disables the memo. An edit test (real code change, same-size edit inside the trust window, restore) produced the same C as with the memo disabled at every step.

### Other changes

- The type declarations are rendered on a worker while the signatures are collected; the composite typedef list, which needs both phases' names, is rendered afterwards and emitted at its original position.
- `pref.get_v_files_from_dir_for_target` classifies each file once and hoists the target-dependent checks out of the per-file loop; a one-off test compared it with the original over 26,752 directory/target/define combinations (identical).
- Per-file generation: the monomorphization scan is skipped unless the expression's last name is a generic method or function name; the C identifier replacement helpers search from an offset instead of copying the remainder per match; the pointer-member method marker check scans instead of building marker strings; the per-file lookup memos are pre-sized; the expression token buffer starts with room for 16 tokens.
- Env-gated diagnostics: `FASTC_BENCH_PHASES` also reports the driver's setup time and the memo phases, `FASTC_BENCH_FILES` the constant files' parse times, `FASTC_BENCH_PRELOAD` the preload's listing and chunk waits.

Tried and dropped (measured slower or no gain): parallel field-default rendering, reading a module's first chunk on its listing thread, a one-file first chunk per module.

### Tests

- `v test vlib/v3/pref vlib/v3/token vlib/v3/fastcdriver/fastcdriver_test.v`: all pass.
- `vlib/v3/gen/fastc/fastc_test.v` (built with a pre-#28277 V binary, since V3 cannot build it on macOS): the same four `test_selfhost_*` assertion failures and the known `enum_literal_map_lowering` panic as on master, no new failures.

### Follow-up commits

- The constants pre-pass parses a large file's top-level declarations as separate parallel candidates (the declaration index records their spans), so `strconv/tables.v` no longer bounds the phase: 1.1 ms → 0.8 ms. The in-order merge sees the spans in source order, as it did within the file.
- `pref.new_preferences` formats the build date and time by hand: the first C `strftime` call of a process initializes the timezone data, which cost about 0.45 ms per compile; the driver's setup before generation is now about 0.2 ms.
- The memo preload runs the module lookups, directory listings and file stats while the main thread reads the content blob, then materializes the files in a second batch (resolve ~1.4 → ~1.3 ms).
- Each generation worker unions the composite and fixed-array types its files registered, so the stitch pass merges one set per worker instead of one per file.
- The declaration index records the spans of each file's `__global` declarations and the global phase parses only that text instead of scanning every file that mentions a global: ~0.4 ms → ~0.1 ms.
- `FASTC_BENCH_PHASES` also reports the driver's preference, define and entry-check timings and the stitch sub-steps.

Every commit was checked byte-identical against the merged master's generator on the self-host input with the memo cold, warm, disabled, and with `VJOBS=2`; the TCC self-host chain reproduces itself in each mode and serial output matches parallel output.

The v3 CI job's `declaration_filter_test.v` failures (directive hoisting and type-source assertions) reproduce on untouched master with the same three assertions; the clang-linux failure is a V1 test parse error unrelated to this branch; tcc-linux is the known `-cg -cstrict cmd/v` error.

### Review follow-up

- `fastc_contains_method_marker` stopped scanning when the name occurred at offset 0 (a valid `index_after_` result), so `foo + ptr.foo(...)` was not recognized as a method call and the pointer-member promotion no longer bailed out as the old `contains('.foo(')` check did. Only a missing occurrence ends the scan now; a leading occurrence is skipped. `test_contains_method_marker` covers the leading-occurrence cases for `.name(` and `->name(`; the self-host output is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



