### PR TITLE
v3: fix vfmt reformatting valid code (#28292)

### DIFF
--- a/vlib/v3/gen/v/gen.v
+++ b/vlib/v3/gen/v/gen.v
@@ -1213,13 +1213,19 @@ fn (mut g Gen) array_literal(id flat.NodeId) {
 		return
 	}
 	g.array_depth++
+	first := g.a.node(children[0])
+	// An array whose source starts on the line below `[` keeps that layout even
+	// when an earlier array at this nesting depth was written on one line.
+	source_break := g.source_line(first.pos.offset) > g.source_line(n.pos.offset)
 	if g.array_depth > g.array_breaks.len {
-		first := g.a.node(children[0])
+		// The width heuristic is decided once per nesting depth, so a row of
+		// small nested arrays stays uniform instead of breaking at whichever
+		// element happens to cross the limit.
 		first_width := g.array_expr_width(children[0])
-		g.array_breaks << g.source_line(first.pos.offset) > g.source_line(n.pos.offset)
+		g.array_breaks << source_break
 			|| (first_width > 0 && g.output_line_len() + first_width > formatter_array_first_break)
 	}
-	line_break := g.array_breaks[g.array_depth - 1]
+	line_break := source_break || g.array_breaks[g.array_depth - 1]
 	mut indented := false
 	for i, child in children {
 		if i == 0 {

--- a/vlib/v3/gen/v/gen.v
+++ b/vlib/v3/gen/v/gen.v
@@ -611,10 +611,47 @@ fn (mut g Gen) emit_blank_line_between(previous flat.NodeId, current flat.NodeId
 	}
 	prev := g.a.node(previous)
 	cur := g.a.node(current)
-	if !prev.pos.is_valid() || !cur.pos.is_valid()
-		|| !g.source_has_blank_line_between(prev.pos.end, cur.pos.offset) {
+	if !prev.pos.is_valid() || !cur.pos.is_valid() {
 		return
 	}
+	mut limit := cur.pos.offset
+	if g.comment_i < g.comments.len {
+		// a comment in the gap keeps the blank lines that follow it, so only the
+		// part of the gap before that comment decides the separator here
+		comment_start := g.comments[g.comment_i].pos.offset
+		if comment_start >= prev.pos.end && comment_start < limit {
+			limit = comment_start
+		}
+	}
+	if !g.source_has_blank_line_between(prev.pos.end, limit) {
+		return
+	}
+	g.write_blank_line()
+}
+
+// emit_blank_line_after_comment writes a blank line when the source kept one
+// between the comment that was just emitted and the code starting at `limit`.
+fn (mut g Gen) emit_blank_line_after_comment(limit int) {
+	gap := g.source_span(g.source_end, limit) or { return }
+	// Only the blank run directly after the comment counts: `limit` is a node
+	// position, which for some statements starts past their first token.
+	mut newlines := 0
+	for c in gap {
+		if c == `\n` {
+			newlines++
+		} else if c !in [` `, `\t`, `\r`] {
+			break
+		}
+	}
+	if newlines < 2 {
+		return
+	}
+	g.write_blank_line()
+}
+
+// write_blank_line ends the current line and adds an empty one, unless the
+// output already ends with a blank line.
+fn (mut g Gen) write_blank_line() {
 	if !g.on_newline {
 		g.writeln('')
 	}
@@ -640,7 +677,13 @@ fn (mut g Gen) stmt(id flat.NodeId) {
 		eprintln('stmt ${n.kind} | pos: ${n.pos.offset}')
 	}
 	stmt_start, stmt_end := g.stmt_source_span(n)
+	comment_i := g.comment_i
 	g.emit_comments_before(stmt_start)
+	if g.comment_i > comment_i {
+		// keep a blank line the source had between the last comment and this
+		// statement (e.g. a file header comment above `module`)
+		g.emit_blank_line_after_comment(stmt_start)
+	}
 	g.source_end = int_max(g.source_end, stmt_start)
 	match n.kind {
 		.module_decl {
@@ -833,9 +876,7 @@ fn (mut g Gen) expr(id flat.NodeId) {
 			g.write('.${n.value}')
 		}
 		.infix {
-			g.expr(g.a.child(n, 0))
-			g.write(' ${op_str(n.op)} ')
-			g.expr(g.a.child(n, 1))
+			g.infix_expr(id)
 		}
 		.prefix {
 			g.prefix_expr(id)
@@ -1018,6 +1059,77 @@ fn (mut g Gen) expr(id flat.NodeId) {
 		g.emit_trailing_comments(n.pos.end)
 	}
 	g.source_end = int_max(g.source_end, n.pos.end)
+}
+
+// infix_expr prints a binary expression, keeping the line break the source had
+// before a `&&`/`||` continuation instead of joining the operands into one long
+// line.
+fn (mut g Gen) infix_expr(id flat.NodeId) {
+	n := g.a.node(id)
+	lhs := g.a.child(n, 0)
+	rhs := g.a.child(n, 1)
+	g.expr(lhs)
+	if g.infix_continues_on_next_line(n, lhs, rhs) {
+		g.indent++
+		g.writeln('')
+		g.write('${op_str(n.op)} ')
+		g.expr(rhs)
+		g.indent--
+		return
+	}
+	g.write(' ${op_str(n.op)} ')
+	g.expr(rhs)
+}
+
+fn (g &Gen) infix_continues_on_next_line(n &flat.Node, lhs flat.NodeId, rhs flat.NodeId) bool {
+	if n.op !in [.logical_and, .logical_or] {
+		return false
+	}
+	lhs_end := g.rightmost_source_end(lhs)
+	rhs_start := g.leftmost_source_start(rhs)
+	if lhs_end < 0 || rhs_start < lhs_end || g.has_comment_between(lhs_end, rhs_start) {
+		return false
+	}
+	return g.source_has_line_break_between(lhs_end, rhs_start)
+}
+
+// leftmost_source_start returns the first source offset covered by `id`, walking
+// down its leading operands. A few nodes are synthesized around their operand
+// (`!in` wraps `in` in a `!`, for instance) and carry the position of a later
+// token, so the node's own span alone is not enough.
+fn (g &Gen) leftmost_source_start(id flat.NodeId) int {
+	mut current := id
+	mut start := -1
+	for int(current) >= 0 {
+		n := g.a.node(current)
+		if n.pos.is_valid() && (start < 0 || n.pos.offset < start) {
+			start = n.pos.offset
+		}
+		if n.children_count == 0 {
+			break
+		}
+		current = g.a.child(n, 0)
+	}
+	return start
+}
+
+// rightmost_source_end returns the last source offset covered by `id`, walking
+// down its trailing operands. See [leftmost_source_start] for why the node's own
+// span is not enough.
+fn (g &Gen) rightmost_source_end(id flat.NodeId) int {
+	mut current := id
+	mut end := -1
+	for int(current) >= 0 {
+		n := g.a.node(current)
+		if n.pos.is_valid() && n.pos.end > end {
+			end = n.pos.end
+		}
+		if n.children_count == 0 {
+			break
+		}
+		current = g.a.child(n, int(n.children_count) - 1)
+	}
+	return end
 }
 
 fn (g &Gen) innermost_parenthesized_expr(id flat.NodeId) flat.NodeId {
@@ -1785,6 +1897,11 @@ fn (mut g Gen) compact_stmt(id flat.NodeId) {
 fn (mut g Gen) block_expr(id flat.NodeId) {
 	n := g.a.node(id)
 	stmts := g.a.children_of(n)
+	if n.value == 'comma_exprs' {
+		// `a, b` in expression position is a comma group, not a `{}` block.
+		g.comma_exprs(n)
+		return
+	}
 	prefix := if n.value == 'unsafe' { 'unsafe ' } else { '' }
 	is_compact := if n.value == 'unsafe' {
 		stmts.len <= 1 && g.source_block_is_compact(n)
@@ -1819,6 +1936,27 @@ fn (mut g Gen) block_expr(id flat.NodeId) {
 	}
 }
 
+// comma_exprs prints the children of a synthetic `comma_exprs` block as the
+// comma separated expression list they were parsed from.
+fn (mut g Gen) comma_exprs(n &flat.Node) {
+	mut first := true
+	for stmt_id in g.a.children_of(n) {
+		stmt := g.a.node(stmt_id)
+		if !first {
+			g.write(', ')
+		}
+		first = false
+		if stmt.kind == .expr_stmt && stmt.children_count == 1 {
+			g.expr(g.a.child(stmt, 0))
+		} else {
+			in_init := g.in_init
+			g.in_init = true
+			g.stmt(stmt_id)
+			g.in_init = in_init
+		}
+	}
+}
+
 fn (g &Gen) source_block_is_compact(n &flat.Node) bool {
 	if source := g.source_span(n.pos.offset, n.pos.end) {
 		return !source.contains('\n') && !source.contains('\r')
@@ -1838,6 +1976,15 @@ fn (mut g Gen) block_stmt(id flat.NodeId) {
 			g.for_stmt_with_init(stmts[1], stmts[0])
 			return
 		}
+	}
+	if n.value == 'comma_exprs' {
+		// The parser groups `a, b` statements (e.g. the value of an `if`
+		// expression branch) in a synthetic block; print the original commas.
+		g.comma_exprs(n)
+		if !g.in_init {
+			g.writeln('')
+		}
+		return
 	}
 	prefix := if n.value == 'unsafe' { 'unsafe ' } else { '' }
 	if n.value == 'unsafe' && stmts.len <= 1 && g.source_block_is_compact(n)
@@ -1948,9 +2095,33 @@ fn (mut g Gen) sql_expr(id flat.NodeId) {
 	g.write('}')
 }
 
+// interp_has_multiline_text reports whether any literal segment of an
+// interpolated string spans physical lines. A line break inside `${...}` is only
+// wrapping of the embedded expression and does not count.
+fn (g &Gen) interp_has_multiline_text(children []flat.NodeId) bool {
+	for cid in children {
+		c := g.a.node(cid)
+		if c.kind == .string_literal && (c.value.contains('\n') || c.value.contains('\r')) {
+			return true
+		}
+	}
+	return false
+}
+
 fn (mut g Gen) string_interp(id flat.NodeId) {
 	n := g.a.node(id)
 	children := g.a.children_of(n)
+	if g.interp_has_multiline_text(children) {
+		if source := g.source_span(n.pos.offset, n.pos.end) {
+			// Physical newlines are part of a multiline literal's value and
+			// layout, so keep such a literal exactly as written instead of
+			// re-escaping them to `\n`.
+			if source.contains('\n') || source.contains('\r') {
+				g.write(source)
+				return
+			}
+		}
+	}
 	// prefer single quotes unless a literal segment contains `'` but no `"`
 	mut has_single := false
 	mut has_double := false
@@ -2019,8 +2190,7 @@ fn (mut g Gen) assign_stmt(id flat.NodeId) {
 			g.write('mut ')
 		}
 		g.expr(children[0])
-		g.write(' ${opstr} ')
-		g.expr_list(children[1..], ', ')
+		g.assign_rhs(opstr, [children[0]], children[1..])
 	} else {
 		mut lhs := []flat.NodeId{}
 		mut rhs := []flat.NodeId{}
@@ -2046,8 +2216,7 @@ fn (mut g Gen) assign_stmt(id flat.NodeId) {
 				g.write(', ')
 			}
 		}
-		g.write(' ${opstr} ')
-		g.expr_list(rhs, ', ')
+		g.assign_rhs(opstr, lhs, rhs)
 	}
 	if attr := g.a.formatter_sources[int(id)] {
 		g.write(' ${attr.trim_space()}')
@@ -2055,6 +2224,33 @@ fn (mut g Gen) assign_stmt(id flat.NodeId) {
 	if !g.in_init && !g.on_newline {
 		g.writeln('')
 	}
+}
+
+// assign_rhs prints the assignment operator and the right hand side, keeping the
+// right hand side on its own line when the source wrapped it there.
+fn (mut g Gen) assign_rhs(opstr string, lhs []flat.NodeId, rhs []flat.NodeId) {
+	if g.assign_rhs_on_next_line(lhs, rhs) {
+		g.write(' ${opstr}')
+		g.indent++
+		g.writeln('')
+		g.expr_list(rhs, ', ')
+		g.indent--
+		return
+	}
+	g.write(' ${opstr} ')
+	g.expr_list(rhs, ', ')
+}
+
+fn (g &Gen) assign_rhs_on_next_line(lhs []flat.NodeId, rhs []flat.NodeId) bool {
+	if g.in_init || lhs.len == 0 || rhs.len == 0 {
+		return false
+	}
+	lhs_end := g.rightmost_source_end(lhs.last())
+	rhs_start := g.leftmost_source_start(rhs[0])
+	if lhs_end < 0 || rhs_start < lhs_end || g.has_comment_between(lhs_end, rhs_start) {
+		return false
+	}
+	return g.source_has_line_break_between(lhs_end, rhs_start)
 }
 
 fn (mut g Gen) flow_control(kw string, label string) {
@@ -2882,10 +3078,10 @@ fn (mut g Gen) struct_fields(fields []flat.NodeId, end int) {
 	for fid in fields {
 		f := g.a.node(fid)
 		g.emit_blank_line_between(previous, fid)
-		g.emit_comments_before(f.pos.offset)
-		g.source_end = int_max(g.source_end, f.pos.offset)
 		if f.kind != .field_decl {
 			// e.g. a `$if` block inside the struct body
+			g.emit_comments_before(f.pos.offset)
+			g.source_end = int_max(g.source_end, f.pos.offset)
 			g.stmt(fid)
 			previous = fid
 			continue
@@ -2894,6 +3090,16 @@ fn (mut g Gen) struct_fields(fields []flat.NodeId, end int) {
 		flags := if gp.len > 0 { gp[0] } else { '' }
 		access := access_label(flags)
 		if access != cur_access {
+			// Doc comments written below `pub:` belong to the field, so only the
+			// comments before the specifier itself are emitted ahead of it.
+			if spec_end := g.access_specifier_end(g.source_end, f.pos.offset) {
+				comment_i := g.comment_i
+				g.emit_comments_before(spec_end)
+				if g.comment_i > comment_i {
+					g.emit_blank_line_after_comment(spec_end)
+				}
+				g.source_end = int_max(g.source_end, spec_end)
+			}
 			// access specifiers sit one level out from the fields they head
 			g.indent--
 			match access {
@@ -2906,6 +3112,8 @@ fn (mut g Gen) struct_fields(fields []flat.NodeId, end int) {
 			g.indent++
 			cur_access = access
 		}
+		g.emit_comments_before(f.pos.offset)
+		g.source_end = int_max(g.source_end, f.pos.offset)
 		is_embed := f.value == f.typ && f.children_count == 0
 		if is_embed {
 			g.write(g.type_text(f.value))
@@ -3177,6 +3385,40 @@ fn (mut g Gen) interface_decl(id flat.NodeId) {
 	g.emit_comments_before(n.pos.end)
 	g.indent--
 	g.writeln('}')
+}
+
+// access_specifier_end returns the offset just past the `:` of the access
+// specifier (`pub:`, `mut:`, ...) that sits between `start` and `end`, ignoring
+// any comments in that gap. Returns none when no specifier is found.
+fn (g &Gen) access_specifier_end(start int, end int) ?int {
+	gap := g.source_span(start, end) or { return none }
+	mut i := 0
+	mut result := -1
+	for i < gap.len {
+		c := gap[i]
+		if c == `/` && i + 1 < gap.len && gap[i + 1] == `/` {
+			for i < gap.len && gap[i] != `\n` {
+				i++
+			}
+			continue
+		}
+		if c == `/` && i + 1 < gap.len && gap[i + 1] == `*` {
+			i += 2
+			for i + 1 < gap.len && !(gap[i] == `*` && gap[i + 1] == `/`) {
+				i++
+			}
+			i += 2
+			continue
+		}
+		if c == `:` {
+			result = i + 1
+		}
+		i++
+	}
+	if result < 0 {
+		return none
+	}
+	return start + result
 }
 
 // aggregate_field_alignments returns the widest field name in each adjacent

--- a/vlib/v3/gen/v/gen.v
+++ b/vlib/v3/gen/v/gen.v
@@ -2095,33 +2095,80 @@ fn (mut g Gen) sql_expr(id flat.NodeId) {
 	g.write('}')
 }
 
-// interp_has_multiline_text reports whether any literal segment of an
-// interpolated string spans physical lines. A line break inside `${...}` is only
-// wrapping of the embedded expression and does not count.
-fn (g &Gen) interp_has_multiline_text(children []flat.NodeId) bool {
-	for cid in children {
-		c := g.a.node(cid)
-		if c.kind == .string_literal && (c.value.contains('\n') || c.value.contains('\r')) {
-			return true
+// interp_text_spans_lines reports whether the literal text of the interpolated
+// string written as `source` contains a physical line break. Segment values are
+// stored decoded, so this has to work on the source: a `\n` escape is not a
+// physical break. Everything inside `${...}` is skipped too, since a break there
+// only wraps the embedded expression.
+fn interp_text_spans_lines(source string) bool {
+	mut i := 0
+	mut depth := 0
+	for i < source.len {
+		c := source[i]
+		if c == `\\` {
+			i += 2
+			continue
 		}
+		if depth == 0 {
+			if c == `\n` || c == `\r` {
+				return true
+			}
+			if c == `$` && i + 1 < source.len && source[i + 1] == `{` {
+				depth = 1
+				i += 2
+				continue
+			}
+			i++
+			continue
+		}
+		// inside `${...}`: step over nested literals so that a brace of their
+		// own does not throw off the depth count
+		if c in [`'`, `"`, `\``] {
+			i = interp_skip_nested_literal(source, i)
+			continue
+		}
+		if c == `{` {
+			depth++
+		} else if c == `}` {
+			depth--
+		}
+		i++
 	}
 	return false
 }
 
+// interp_skip_nested_literal returns the offset just past the string or rune
+// literal opening at `start` inside an interpolated expression.
+fn interp_skip_nested_literal(source string, start int) int {
+	quote := source[start]
+	mut i := start + 1
+	for i < source.len {
+		if source[i] == `\\` {
+			i += 2
+			continue
+		}
+		if source[i] == quote {
+			return i + 1
+		}
+		i++
+	}
+	return source.len
+}
+
 fn (mut g Gen) string_interp(id flat.NodeId) {
 	n := g.a.node(id)
-	children := g.a.children_of(n)
-	if g.interp_has_multiline_text(children) {
-		if source := g.source_span(n.pos.offset, n.pos.end) {
-			// Physical newlines are part of a multiline literal's value and
-			// layout, so keep such a literal exactly as written instead of
-			// re-escaping them to `\n`.
-			if source.contains('\n') || source.contains('\r') {
-				g.write(source)
-				return
-			}
+	if source := g.source_span(n.pos.offset, n.pos.end) {
+		// Physical newlines are part of a multiline literal's value and layout,
+		// so keep such a literal exactly as written instead of re-escaping them
+		// to `\n`. The comments of any embedded expression are copied along with
+		// it, so they must not be emitted a second time later on.
+		if interp_text_spans_lines(source) {
+			g.write(source)
+			g.skip_comments_before(n.pos.end)
+			return
 		}
 	}
+	children := g.a.children_of(n)
 	// prefer single quotes unless a literal segment contains `'` but no `"`
 	mut has_single := false
 	mut has_double := false

--- a/vlib/v3/gen/v/gen_test.v
+++ b/vlib/v3/gen/v/gen_test.v
@@ -1509,3 +1509,44 @@ fn test_formatter_keeps_assignment_value_on_its_own_line() {
 	assert out == source, out
 	assert vfmt('assignment_value_on_own_line_twice', out) == out
 }
+
+fn test_formatter_keeps_comments_inside_multiline_interpolation_once() {
+	source := "fn describe(a int, b int) string {
+	x := 'line1
+line2 \${a + /* keep */ b}
+line3'
+	return x
+}
+"
+	out := vfmt('comments_inside_multiline_interpolation', source)
+	assert out == source, out
+	assert out.count('/* keep */') == 1, out
+	assert vfmt('comments_inside_multiline_interpolation_twice', out) == out
+}
+
+fn test_formatter_keeps_comment_after_multiline_interpolation() {
+	source := "fn describe(table string) string {
+	q := '
+		SELECT *
+		FROM \${table}
+	' // trailing comment
+	return q
+}
+"
+	out := vfmt('comment_after_multiline_interpolation', source)
+	assert out == source, out
+}
+
+fn test_formatter_reflows_interpolation_wrap_when_text_only_has_escaped_newline() {
+	source := "fn describe(a int, b int) string {
+	return 'a\\nb \${add(a,
+		b)}'
+}
+"
+	expected := "fn describe(a int, b int) string {
+	return 'a\\nb \${add(a, b)}'
+}
+"
+	out := vfmt('escaped_newline_interpolation_wrap', source)
+	assert out == expected, out
+}

--- a/vlib/v3/gen/v/gen_test.v
+++ b/vlib/v3/gen/v/gen_test.v
@@ -1389,3 +1389,123 @@ fn test_formatter_demangles_function_local_aggregate_types() {
 	assert !out.contains('@local@'), out
 	assert vfmt('function_local_aggregate_types_twice', out) == out
 }
+
+fn test_formatter_keeps_comma_expression_branches_unbraced() {
+	source := "fn pick(var1 string, var2 string) (int, int) {
+	shorter, longer := if var1.len <= var2.len {
+		var1.len, var2.len
+	} else {
+		var2.len, var1.len
+	}
+	return shorter, longer
+}
+"
+	out := vfmt('comma_expression_branches', source)
+	assert out == source, out
+	assert vfmt('comma_expression_branches_twice', out) == out
+}
+
+fn test_formatter_keeps_comma_expressions_in_or_block() {
+	source := "fn split(attr string) (string, string) {
+	name, value := attr.split_once(':') or { '', '' }
+	return name, value
+}
+"
+	out := vfmt('comma_expressions_or_block', source)
+	assert out == source, out
+}
+
+fn test_formatter_keeps_multiline_interpolated_string() {
+	source := "fn query(table string) string {
+	return '
+		SELECT
+			*
+		FROM
+			\${table}
+		;
+	'
+}
+"
+	out := vfmt('multiline_interpolated_string', source)
+	assert out == source, out
+	assert vfmt('multiline_interpolated_string_twice', out) == out
+}
+
+fn test_formatter_reflows_interpolation_wrapped_across_lines() {
+	source := "fn log(a string, b string, c string) {
+	println('prefix \${join(a,
+		b, c)}')
+}
+"
+	expected := "fn log(a string, b string, c string) {
+	println('prefix \${join(a, b, c)}')
+}
+"
+	out := vfmt('interpolation_wrapped_across_lines', source)
+	assert out == expected, out
+}
+
+fn test_formatter_keeps_blank_line_after_leading_comment() {
+	source := '// Copyright header
+
+module abc
+
+const answer = 42
+'
+	out := vfmt_with_options('blank_line_after_leading_comment', source, FormatOptions{})
+	assert out == source, out
+}
+
+fn test_formatter_keeps_doc_comments_below_access_specifiers() {
+	source := 'pub struct Foo {
+	a int
+	// section comment before the specifier
+
+pub:
+	// docs for b
+	b int
+	c int
+	// docs for d
+mut:
+	d int
+}
+'
+	out := vfmt('doc_comments_below_access_specifiers', source)
+	assert out == source, out
+	assert vfmt('doc_comments_below_access_specifiers_twice', out) == out
+}
+
+fn test_formatter_keeps_logical_operator_line_breaks() {
+	source := 'fn check(found Rec, actual Rec) {
+	assert found.some_long_field_name_lalalala1 == actual.some_long_field_name_lalalala1
+		&& found.some_long_field_name_lalalala2 == actual.some_long_field_name_lalalala2
+}
+'
+	out := vfmt('logical_operator_line_breaks', source)
+	assert out == source, out
+	assert vfmt('logical_operator_line_breaks_twice', out) == out
+}
+
+fn test_formatter_keeps_logical_chain_joined_when_source_is_one_line() {
+	source := "fn check(name string, sel bool) bool {
+	return sel && name !in [
+		'main',
+		'init',
+	] && name.len > 0
+}
+"
+	out := vfmt('logical_chain_joined', source)
+	assert out == source, out
+}
+
+fn test_formatter_keeps_assignment_value_on_its_own_line() {
+	source := 'fn build(a []int) []int {
+	expected :=
+		a.map(it * 2).filter(it > 3).map(it + 1).filter(it < 100).map(it * 3).filter(it != 7)
+	return expected
+}
+'
+	out := vfmt('assignment_value_on_own_line', source)
+	assert out == source, out
+	assert vfmt('assignment_value_on_own_line_twice', out) == out
+}

--- a/vlib/v3/gen/v/gen_test.v
+++ b/vlib/v3/gen/v/gen_test.v
@@ -1550,3 +1550,35 @@ fn test_formatter_reflows_interpolation_wrap_when_text_only_has_escaped_newline(
 	out := vfmt('escaped_newline_interpolation_wrap', source)
 	assert out == expected, out
 }
+
+fn test_formatter_keeps_expanded_array_after_a_single_line_sibling() {
+	source := 'fn build() []Outer {
+	return [
+		Outer{
+			list: [Elem{
+				a: 1
+			}]
+		},
+		Outer{
+			list: [
+				Elem{
+					a: 2
+				},
+			]
+		},
+	]
+}
+'
+	out := vfmt('expanded_array_after_single_line_sibling', source)
+	assert out == source, out
+	assert vfmt('expanded_array_after_single_line_sibling_twice', out) == out
+}
+
+fn test_formatter_keeps_rows_of_small_nested_arrays_on_one_line() {
+	source := 'fn rows() [][]int {
+	return [[1, 2], [3, 4], [5, 6]]
+}
+'
+	out := vfmt('rows_of_small_nested_arrays', source)
+	assert out == source, out
+}


### PR DESCRIPTION
Fixes every item reported in #28292, where `v fmt` rewrote already valid code.

All of these are in the v3 formatter (`vlib/v3/gen/v/gen.v`), which is what `v fmt` runs today.

### 1. `a, b` branch values got wrapped in a `{}` block

The parser groups a comma expression statement into a synthetic `comma_exprs` block. The formatter printed that block's braces:

```v
shorter, longer := if var1.len <= var2.len {
	var1.len, var2.len          // formatted to `{ var1.len \n var2.len }`
} else {
	var2.len, var1.len
}
```

The result does not compile. The same happened for `or { '', '' }`, for `match` branch values and for `rlock a, b, c { x.a, y.a, z.a }`. The block is now printed as the comma list it was parsed from.

### 2. Multiline interpolated strings were escaped onto one line

```v
query_sql := '
	SELECT *
	FROM ${table}
'
// became: query_sql := '\n\tSELECT *\n\tFROM ${table}\n'
```

Plain multiline strings were already kept verbatim; interpolated ones now are too. A line break that only wraps an embedded `${...}` expression is still reflowed, so `println('x ${f(a,\n\tb)}')` still joins.

### 3. Blank line after a leading comment was dropped

```diff
 // Copyright header
-
 module name
```

### 4. Doc comments were hoisted above `pub:` / `mut:`

```diff
 pub struct Foo {
-
-	// docs...
-pub:
+pub:
+	// docs...
 	field_name string
 }
```

Comments that really do sit before the specifier still stay before it.

### 5. An expanded array collapsed after a one-line sibling

```diff
     expected: [
-        SomeStruct2({
-        }),
-    ]
+    expected: [SomeStruct2({
+    })]
```

`array_breaks` caches one layout decision per nesting depth and is only cleared when the depth returns to 0, so every later array at that depth inherited the decision of the first one. The cache is deliberate for the width heuristic — it keeps a row of small nested arrays such as `[[1, 2], [3, 4], [5, 6]]` uniform rather than breaking at whichever element happens to cross the column limit — so only the source-driven half of the decision is now made per literal.

### 6. Line breaks before `&&` / `||` and before an assignment value were joined

```diff
-	assert found.some_long_field_name_1 == actual.some_long_field_name_1
-		&& found.some_long_field_name_2 == actual.some_long_field_name_2
+	assert found.some_long_field_name_1 == actual.some_long_field_name_1 && found.some_long_field_name_2 == actual.some_long_field_name_2
```

The break the source had is now kept, for `&&`/`||` continuations and for an assignment value written on its own line. Breaks are not added where the source had none, so single-line conditions stay single-line.

Finding the operand boundaries needs `leftmost_source_start`/`rightmost_source_end` rather than the node span, because a few nodes (`!in`, `!is`) are synthesized around their operand and carry the position of a later token.

### Validation

Formatting all 6249 `.v` files under `vlib`, `cmd`, `examples` and `tools` with both the `master` and the patched `vfmt`, and comparing against the committed source:

|                                                    | before | after |
| -------------------------------------------------- | -----: | ----: |
| files whose formatting differs from the source      |   3334 |  2959 |
| files where a second `vfmt` pass changes the first  |    362 |   345 |

No file regressed in either column. Diffing old `vfmt` output against new, every difference is one of the fixes above (plus a handful of array literals that no longer get expanded with a trailing comma, because the line now fits once the `&&` break is kept).

`vlib/v3/gen/v/gen_test.v` gets 14 new regression tests, 11 of which fail on `master`. Formatter timing on `vlib/v/gen/c/cgen.v` is unchanged (0.15s before and after).

The two `vlib/v3/gen/fastc` test failures on this branch also fail on `master` and are unrelated.

Fixes #28292

🤖 Generated with [Claude Code](https://claude.com/claude-code)

