### PR TITLE
v3: fix the FastC self-host chain and the -d arm64 build

### DIFF
--- a/vlib/v3/README.md
+++ b/vlib/v3/README.md
@@ -187,8 +187,7 @@ read again otherwise. The memo also keeps each listed directory's file list and 
 module's file list together with the directory's own stamp, so an unchanged directory is stat'ed
 instead of listed again (adding, removing or renaming an entry changes that stamp, and the same
 two-second rule applies); module lookups are recorded once per cache key, the memo's blob is read
-in ranges by the same probe workers, and the memo of the current run is written on a worker while
-the program is generated. The ordering walk itself is unchanged and replays over that data, so the
+in ranges by the same probe workers. The ordering walk itself is unchanged and replays over that data, so the
 output is identical with and without the memo (`V3_FASTC_NO_RESOLVE_MEMO=1` disables it). The
 type declarations are rendered on a worker while the signatures are collected, the generic-method
 scan and the declaration index share one pass, the split of oversized files into generation

--- a/vlib/v3/gen/fastc/arm64_d_arm64.v
+++ b/vlib/v3/gen/fastc/arm64_d_arm64.v
@@ -210,7 +210,13 @@ pub fn generate_arm64_files(paths []string, prefs &pref.Preferences, output stri
 	input_sources, _ := fastc_resolve_source_files(paths, prefs)!
 	fast_arm64_validate_output_source_paths(output, input_sources)!
 	fast_arm64_validate_unsupported_calls(input_sources, prefs)!
-	sources := fastc_monomorphize_sources(input_sources, prefs)!
+	mut sources := fastc_monomorphize_sources(input_sources, prefs)!
+	// The declaration and signature passes only scan files whose byte-level
+	// flags (type keywords, interfaces, generic fn syntax) allow the
+	// declaration they look for; the generic-method scan computes those flags,
+	// so run it first as the C path does.
+	flags_partial := fastc_collect_generic_method_source_chunk(sources, prefs, 0, sources.len)
+	fastc_apply_scan_flags(mut sources, flags_partial.flags, 0)
 	mut declared_types := map[string]bool{}
 	mut declared_kinds := map[string]FastcDeclaredTypeKind{}
 	mut enum_flags := map[string]bool{}
@@ -220,7 +226,13 @@ pub fn generate_arm64_files(paths []string, prefs &pref.Preferences, output stri
 	mut public_constants := map[string]bool{}
 	mut globals := map[string]string{}
 	mut public_globals := map[string]bool{}
-	fastc_collect_declaration_indexes(sources, prefs, mut declared_types, mut declared_kinds, mut enum_flags, mut params_structs, mut type_source_paths, mut constants, mut public_constants, mut globals, mut public_globals)!
+	// The C path's per-file declaration texts and spans are not used here: the
+	// native path collects its type and constant declarations itself below.
+	mut index_type_sources := map[string]string{}
+	mut index_constant_sources := map[string]string{}
+	mut index_constant_spans := map[string][]int{}
+	mut index_global_sources := map[string]string{}
+	fastc_collect_declaration_indexes(sources, prefs, mut declared_types, mut declared_kinds, mut enum_flags, mut params_structs, mut type_source_paths, mut index_type_sources, mut constants, mut public_constants, mut index_constant_sources, mut index_constant_spans, mut index_global_sources, mut globals, mut public_globals)!
 	// Non-selfhost programs do not resolve builtin source files, but imported module
 	// signatures can still use V's intrinsic error interface.
 	declared_types['IError'] = true
@@ -244,8 +256,11 @@ pub fn generate_arm64_files(paths []string, prefs &pref.Preferences, output stri
 
 	mut program := FastArm64Program.new(prefs, declared_types, functions, type_decls, constant_sources, enum_values)
 	program.register_functions()
-	module_init_calls := fastc_module_init_calls(sources, functions)!
-	module_cleanup_calls := fastc_module_cleanup_calls(sources, functions)!
+	// The lifecycle hooks run in module dependency order; the resolver returns
+	// discovery order.
+	lifecycle_sources := fastc_sources_in_dependency_order(sources)!
+	module_init_calls := fastc_module_init_calls(lifecycle_sources, functions)!
+	module_cleanup_calls := fastc_module_cleanup_calls(lifecycle_sources, functions)!
 	module_init_function_keys := fast_arm64_lifecycle_function_keys(module_init_calls, 'init', functions)
 	module_cleanup_function_keys := fast_arm64_lifecycle_function_keys(module_cleanup_calls, 'cleanup', functions)
 	program.register_module_lifecycle(module_init_function_keys, module_cleanup_function_keys)
@@ -4433,7 +4448,7 @@ fn (mut p FastArm64Parser) parse_statement() ! {
 			}
 		}
 		else {
-			_ = p.parse_expression(0)!
+			p.parse_expression_statement()!
 		}
 	}
 	if p.tok == .semicolon {
@@ -4769,6 +4784,13 @@ fn (mut p FastArm64Parser) parse_name_statement(after_mut bool) ! {
 	if after_mut {
 		return p.unsupported('mutable declaration without `:=`')
 	}
+	p.parse_expression_statement()!
+}
+
+// parse_expression_statement parses an expression statement, storing into
+// the expression when an assignment follows it (a field of a cast pointer,
+// `(&T(p)).field = v`, an indexed element, a map entry, ...).
+fn (mut p FastArm64Parser) parse_expression_statement() ! {
 	left := p.parse_expression(0)!
 	if p.tok in [.assign, .plus_assign, .minus_assign, .mul_assign, .div_assign, .mod_assign,
 		.left_shift_assign, .right_shift_assign, .right_shift_unsigned_assign, .and_assign,
@@ -5290,6 +5312,10 @@ fn (mut p FastArm64Parser) parse_for_inner() ! {
 			p.parse_c_for()!
 			return
 		}
+		if next_token == .assign {
+			p.parse_c_for_assigning()!
+			return
+		}
 	}
 	preheader := p.cur_block
 	condition_block := p.program.m.add_block(p.func_id, 'for_condition')
@@ -5701,6 +5727,28 @@ fn (mut p FastArm64Parser) parse_c_for() ! {
 		typ_name: initial.typ_name
 	})
 	p.expect(.semicolon)!
+	p.parse_c_for_rest(name, address, initial.typ, initial.typ_name)!
+}
+
+// parse_c_for_assigning lowers `for name = initial; condition; step { ... }`,
+// whose initializer assigns an existing local instead of declaring one.
+fn (mut p FastArm64Parser) parse_c_for_assigning() ! {
+	name := p.lit
+	local := p.locals[name] or { return p.unsupported('C-style loop assigning to unknown `${name}`') }
+	p.next()
+	p.expect(.assign)!
+	mut initial := p.parse_expression(0)!
+	if initial.typ != local.typ {
+		initial = p.convert_value(initial, local.typ, local.typ_name)
+	}
+	p.program.instr2(.store, p.cur_block, p.program.void_type, initial.id, local.addr)
+	p.expect(.semicolon)!
+	p.parse_c_for_rest(name, local.addr, local.typ, local.typ_name)!
+}
+
+// parse_c_for_rest lowers the condition, step and body of a C-style loop whose
+// counter `name` lives at `address`.
+fn (mut p FastArm64Parser) parse_c_for_rest(name string, address ssa.ValueID, typ ssa.TypeID, typ_name string) ! {
 	condition_block := p.program.m.add_block(p.func_id, 'c_for_condition')
 	body_block := p.program.m.add_block(p.func_id, 'c_for_body')
 	increment_block := p.program.m.add_block(p.func_id, 'c_for_increment')
@@ -5722,10 +5770,10 @@ fn (mut p FastArm64Parser) parse_c_for() ! {
 		}
 		p.next()
 		if p.tok in [.inc, .dec] {
-			current := p.program.instr1(.load, increment_block, initial.typ, address)
-			one := p.program.m.get_or_add_const(initial.typ, '1')
+			current := p.program.instr1(.load, increment_block, typ, address)
+			one := p.program.m.get_or_add_const(typ, '1')
 			op := if p.tok == .inc { ssa.OpCode.add } else { ssa.OpCode.sub }
-			next := p.program.instr2(op, increment_block, initial.typ, current, one)
+			next := p.program.instr2(op, increment_block, typ, current, one)
 			p.program.instr2(.store, increment_block, p.program.void_type, next, address)
 			p.next()
 		} else if p.tok in [.plus_assign, .minus_assign, .mul_assign, .div_assign, .mod_assign,
@@ -5734,11 +5782,11 @@ fn (mut p FastArm64Parser) parse_c_for() ! {
 			op := p.tok
 			p.next()
 			mut step := p.parse_expression(0)!
-			if step.typ != initial.typ {
-				step = p.convert_value(step, initial.typ, initial.typ_name)
+			if step.typ != typ {
+				step = p.convert_value(step, typ, typ_name)
 			}
-			current := p.program.instr1(.load, increment_block, initial.typ, address)
-			next := p.program.instr2(fast_arm64_compound_opcode(op, p.program.m.type_store.types[initial.typ].is_unsigned), increment_block, initial.typ, current, step.id)
+			current := p.program.instr1(.load, increment_block, typ, address)
+			next := p.program.instr2(fast_arm64_compound_opcode(op, p.program.m.type_store.types[typ].is_unsigned), increment_block, typ, current, step.id)
 			p.program.instr2(.store, increment_block, p.program.void_type, next, address)
 		} else {
 			return p.unsupported('C-style loop increment operator')
@@ -6103,6 +6151,33 @@ fn (mut p FastArm64Parser) parse_prefix() !FastArm64Value {
 					id: p.program.instr1(.bitcast, p.cur_block, target, value.id)
 					typ: target
 					typ_name: '&C.${c_type_name}'
+				}
+			}
+		}
+		if p.tok == .lsbr {
+			// `&[]T(value)` reinterprets a pointer as a pointer to an array; every
+			// V array shares the runtime array layout, so this is a bitcast.
+			mut array_look := p.s
+			if array_look.scan() == .rsbr && array_look.scan() == .name && array_look.scan() == .lpar {
+				p.next()
+				p.expect(.rsbr)!
+				type_name := '[]' + p.lit
+				p.next()
+				p.expect(.lpar)!
+				value := p.parse_expression(0)!
+				p.expect(.rpar)!
+				target := p.program.m.type_store.get_ptr(p.program.type_id(type_name))
+				// A pointer operand is reinterpreted; an addressable value (such as
+				// a `mut` receiver) contributes its address.
+				mut operand := value.id
+				if p.program.m.type_store.types[value.typ].kind != .ptr_t
+					&& value.address != ssa.ValueID(0) {
+					operand = value.address
+				}
+				return FastArm64Value{
+					id: p.program.instr1(.bitcast, p.cur_block, target, operand)
+					typ: target
+					typ_name: '&${type_name}'
 				}
 			}
 		}
@@ -9265,6 +9340,15 @@ fn (p &FastArm64Program) resolved_type_name(type_name string) string {
 
 fn (mut p FastArm64Parser) resolve_method_key(value FastArm64Value, method string) ?string {
 	receiver_name := value.typ_name.trim_right('*')
+	// An array-typed receiver (`[]T`, `&[]T`) takes the builtin array method:
+	// an alias of `[]T` shares the array layout, so its own methods would
+	// otherwise match a plain array receiver by type.
+	if receiver_name.trim_left('&').starts_with('[]') {
+		array_key := 'array.${method}'
+		if array_key in p.program.functions {
+			return array_key
+		}
+	}
 	for semantic_receiver in [receiver_name, receiver_name.replace('__', '.')] {
 		key := '${semantic_receiver}.${method}'
 		if key in p.program.functions {

--- a/vlib/v3/gen/fastc/arm64_d_arm64.v
+++ b/vlib/v3/gen/fastc/arm64_d_arm64.v
@@ -207,16 +207,13 @@ struct FastArm64Generation {
 // generate_arm64_files parses FastC source tokens directly into SSA and emits a Mach-O binary.
 // It deliberately does not create Flat AST nodes or C source.
 pub fn generate_arm64_files(paths []string, prefs &pref.Preferences, output string) !FastArm64Generation {
+	mut timer := fastc_new_phase_timer()
 	input_sources, _ := fastc_resolve_source_files(paths, prefs)!
+	timer.mark('arm64.resolve')
 	fast_arm64_validate_output_source_paths(output, input_sources)!
 	fast_arm64_validate_unsupported_calls(input_sources, prefs)!
 	mut sources := fastc_monomorphize_sources(input_sources, prefs)!
-	// The declaration and signature passes only scan files whose byte-level
-	// flags (type keywords, interfaces, generic fn syntax) allow the
-	// declaration they look for; the generic-method scan computes those flags,
-	// so run it first as the C path does.
-	flags_partial := fastc_collect_generic_method_source_chunk(sources, prefs, 0, sources.len)
-	fastc_apply_scan_flags(mut sources, flags_partial.flags, 0)
+	timer.mark('arm64.monomorphize')
 	mut declared_types := map[string]bool{}
 	mut declared_kinds := map[string]FastcDeclaredTypeKind{}
 	mut enum_flags := map[string]bool{}
@@ -226,13 +223,17 @@ pub fn generate_arm64_files(paths []string, prefs &pref.Preferences, output stri
 	mut public_constants := map[string]bool{}
 	mut globals := map[string]string{}
 	mut public_globals := map[string]bool{}
-	// The C path's per-file declaration texts and spans are not used here: the
-	// native path collects its type and constant declarations itself below.
+	// The same parallel first pass as the C path: it records the per-file scan
+	// flags and function body spans that the declaration and signature passes
+	// rely on, and indexes the declarations. The generic-method sources and
+	// the per-file declaration texts and spans are not used here: the native
+	// path collects its type and constant declarations itself below.
 	mut index_type_sources := map[string]string{}
 	mut index_constant_sources := map[string]string{}
 	mut index_constant_spans := map[string][]int{}
 	mut index_global_sources := map[string]string{}
-	fastc_collect_declaration_indexes(sources, prefs, mut declared_types, mut declared_kinds, mut enum_flags, mut params_structs, mut type_source_paths, mut index_type_sources, mut constants, mut public_constants, mut index_constant_sources, mut index_constant_spans, mut index_global_sources, mut globals, mut public_globals)!
+	_ = fastc_collect_generic_and_declaration_indexes(mut sources, prefs, mut declared_types, mut declared_kinds, mut enum_flags, mut params_structs, mut type_source_paths, mut index_type_sources, mut constants, mut public_constants, mut index_constant_sources, mut index_constant_spans, mut index_global_sources, mut globals, mut public_globals)!
+	timer.mark('arm64.declaration_indexes')
 	// Non-selfhost programs do not resolve builtin source files, but imported module
 	// signatures can still use V's intrinsic error interface.
 	declared_types['IError'] = true
@@ -252,7 +253,9 @@ pub fn generate_arm64_files(paths []string, prefs &pref.Preferences, output stri
 	mut embed_embedders := []string{}
 	mut embed_embeddeds := []string{}
 	fastc_collect_signatures(sources, prefs, declared_types, declared_type_c_names, params_structs, mut functions, mut interface_methods, mut interface_fields, mut embed_embedders, mut embed_embeddeds)!
+	timer.mark('arm64.signatures')
 	type_decls, constant_sources, enum_values := fast_arm64_collect_declarations(sources, prefs, declared_types, enum_flags, type_source_paths)!
+	timer.mark('arm64.declarations')
 
 	mut program := FastArm64Program.new(prefs, declared_types, functions, type_decls, constant_sources, enum_values)
 	program.register_functions()
@@ -265,6 +268,7 @@ pub fn generate_arm64_files(paths []string, prefs &pref.Preferences, output stri
 	module_cleanup_function_keys := fast_arm64_lifecycle_function_keys(module_cleanup_calls, 'cleanup', functions)
 	program.register_module_lifecycle(module_init_function_keys, module_cleanup_function_keys)
 	program.register_print_runtime()
+	timer.mark('arm64.register')
 	reachable_modules := fast_arm64_reachable_modules(sources)
 	mut pending_paths := fast_arm64_entry_source_paths(functions)
 	for {
@@ -295,10 +299,13 @@ pub fn generate_arm64_files(paths []string, prefs &pref.Preferences, output stri
 	if 'main' !in program.fn_ids || program.m.funcs[program.fn_ids['main']].blocks.len == 0 {
 		return error('fastc arm64 parser did not find a `main` function')
 	}
+	timer.mark('arm64.parse')
 	fast_arm64_hide_unused_prototypes(mut program.m)
 	mut gen := arm64.Gen.new(program.m)
 	gen.gen()
+	timer.mark('arm64.codegen')
 	gen.write_and_link(output)
+	timer.mark('arm64.link')
 	mut source_paths := []string{cap: sources.len}
 	for source_file in sources {
 		source_paths << source_file.path

--- a/vlib/v3/gen/fastc/arm64_d_arm64.v
+++ b/vlib/v3/gen/fastc/arm64_d_arm64.v
@@ -212,6 +212,7 @@ pub fn generate_arm64_files(paths []string, prefs &pref.Preferences, output stri
 	timer.mark('arm64.resolve')
 	fast_arm64_validate_output_source_paths(output, input_sources)!
 	fast_arm64_validate_unsupported_calls(input_sources, prefs)!
+	timer.mark('arm64.validate')
 	mut sources := fastc_monomorphize_sources(input_sources, prefs)!
 	timer.mark('arm64.monomorphize')
 	mut declared_types := map[string]bool{}

--- a/vlib/v3/gen/fastc/arm64_d_arm64.v
+++ b/vlib/v3/gen/fastc/arm64_d_arm64.v
@@ -242,6 +242,10 @@ pub fn generate_arm64_files(paths []string, prefs &pref.Preferences, output stri
 	// instantiated on demand. Treat their parameters as opaque while indexing the
 	// otherwise unreachable signatures in the imported module.
 	for source_index, source_file in sources {
+		// The first pass flags the files that can hold `fn name[T]` syntax.
+		if !source_file.header.has_generic_fn_syntax {
+			continue
+		}
 		for generic in fastc_scan_generic_fns(source_file.source, source_file.path, prefs, source_index) {
 			declared_types[generic.type_param] = true
 		}

--- a/vlib/v3/gen/fastc/arm64_test.v
+++ b/vlib/v3/gen/fastc/arm64_test.v
@@ -2060,6 +2060,39 @@ fn test_fastc_arm64_remaining_pseudo_values() {
 	}
 }
 
+fn test_fastc_arm64_c_style_for_assigning_existing_local() {
+	$if arm64? {
+		test_dir := os.join_path(os.temp_dir(), 'fastc_arm64_c_for_assign_${os.getpid()}')
+		os.rmdir_all(test_dir) or {}
+		os.mkdir_all(test_dir) or { panic(err) }
+		defer {
+			os.rmdir_all(test_dir) or {}
+		}
+		source_path := os.join_path_single(test_dir, 'main.v')
+		output_path := os.join_path_single(test_dir, 'app')
+		os.write_file(source_path, 'fn count_down(n int) int {
+	mut i := 0
+	mut total := 0
+	for i = n - 1; i >= 0; i-- {
+		total += i
+	}
+	return total + i
+}
+
+fn main() {
+	println(count_down(5))
+}
+') or { panic(err) }
+		mut prefs := pref.new_preferences()
+		prefs.backend = 'fastc'
+		prefs.user_defines = ['arm64']
+		generate_arm64_files([source_path], prefs, output_path) or { panic(err) }
+		result := os.execute(output_path)
+		assert result.exit_code == 0
+		assert result.output == '9\n'
+	}
+}
+
 fn test_fastc_arm64_module_lifecycle_hooks() {
 	$if arm64? {
 		test_dir := os.join_path(os.temp_dir(), 'fastc_arm64_lifecycle_${os.getpid()}')

--- a/vlib/v3/gen/fastc/parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/fastc/parallel_notd_v3_no_parallel.v
@@ -227,11 +227,13 @@ fn fastc_finish_memo_preload(memo FastcResolveMemo, probe_tasks []FastcMemoTask,
 	}
 }
 
-// FastcPendingMemoStore keeps the memo-store wait API shared with the serial build.
+// FastcPendingMemoStore keeps the memo-store wait API shared with the serial
+// build. It holds no thread: the self-hosted generator only declares a thread
+// type for functions that are spawned, so a `thread` field without a spawn
+// would leave the generated C referring to an undeclared type.
 struct FastcPendingMemoStore {
 mut:
-	workers []thread bool
-	joined  bool
+	stored bool
 }
 
 fn fastc_start_memo_store(memo_path string, previous_text string, sources []FastcSourceFile, builtin_dir string, lookup_modules []string, lookup_sources []string, prefs &pref.Preferences, module_path_cache map[string]string, module_dir_files map[string][]string, entry_paths []string, real_path_cache map[string]string, entry_files map[string][]string, preloaded map[string]FastcLoadedSource) FastcPendingMemoStore {
@@ -240,17 +242,13 @@ fn fastc_start_memo_store(memo_path string, previous_text string, sources []Fast
 	// generation error returns before the worker is joined. Keep persistence
 	// synchronous until the async store can snapshot the source versions it writes.
 	fastc_store_resolve_memo(memo_path, previous_text, sources, builtin_dir, lookup_modules, lookup_sources, prefs, module_path_cache, module_dir_files, entry_paths, real_path_cache, entry_files, preloaded)
-	return FastcPendingMemoStore{}
+	return FastcPendingMemoStore{
+		stored: true
+	}
 }
 
 fn fastc_wait_memo_store(mut pending FastcPendingMemoStore) {
-	if pending.joined {
-		return
-	}
-	pending.joined = true
-	for worker in pending.workers {
-		worker.wait()
-	}
+	pending.stored = true
 }
 
 // FastcModuleListing is one module directory listed on a worker thread.

--- a/vlib/v3/gen/fastc/source.v
+++ b/vlib/v3/gen/fastc/source.v
@@ -1066,12 +1066,6 @@ fn fastc_write_memo_dir_line(mut out strings.Builder, dir string, module_dir_fil
 	out.write_u8(`\n`)
 }
 
-// fastc_store_resolve_memo_job runs fastc_store_resolve_memo on a worker.
-fn fastc_store_resolve_memo_job(memo_path string, previous_text string, sources []FastcSourceFile, builtin_dir string, lookup_modules []string, lookup_sources []string, prefs &pref.Preferences, module_path_cache map[string]string, module_dir_files map[string][]string, entry_paths []string, real_path_cache map[string]string, entry_files map[string][]string, preloaded map[string]FastcLoadedSource) bool {
-	fastc_store_resolve_memo(memo_path, previous_text, sources, builtin_dir, lookup_modules, lookup_sources, prefs, module_path_cache, module_dir_files, entry_paths, real_path_cache, entry_files, preloaded)
-	return true
-}
-
 // fastc_memo_body strips the write time and token lines from a memo text, so
 // two memos of the same program compare equal.
 fn fastc_memo_body(text string) string {


### PR DESCRIPTION
Checking #28277 on merged master turned up two build breaks and a set of gaps in the native path. This PR fixes what is verified; the native ARM64 self-host chain itself does not complete yet (details below).

## Fixes
- **TinyCC self-host chain was broken on master.** The merge of #28299 kept a `workers []thread bool` field in `FastcPendingMemoStore` with no `spawn` left; the self-hosted generator only declares a thread type for functions that are spawned, so every `./v4 -o v5 vlib/v3/v3.v` failed with `__v_fastc_thread_k626f6f6c_bool undeclared`. The struct now holds no thread (like the serial variant). Verified: five generations `t5..t9`, all with byte-identical C (`t5.c == t9.c`), and `t9` compiles and runs a program.
- **`-d arm64` did not compile**, on master and already at the #28277 merge commit: `arm64_d_arm64.v` called `fastc_collect_declaration_indexes` with the pre-#28258 argument list. Fixed.
- **Native path saw no declarations**: since #28294 the declaration and signature passes only scan files whose byte-level scan flags allow it, and the native path never applied those flags. It now runs the generic-method scan first (as the C path does). Lifecycle hooks are ordered by module dependency (the resolver returns discovery order since #28294), which fixes `test_fastc_arm64_module_lifecycle_hooks`.
- **Native parser additions** needed by the current compiler sources: `for i = expr; cond; step` with an initializer that assigns an existing local (used by `u64_to_hex_no_leading_zeros`), `&[]T(value)` casts (the operand's address for an addressable value, e.g. a `mut` receiver), builtin `array` methods take precedence for `[]T` receivers (`strings.Builder.ensure_cap` resolved `arr.ensure_cap` to itself and recursed until stack overflow), and expression statements accept assignments (`(&ArrayDataHeader(raw)).has_slices = false`). A test for the loop form is added to `arm64_test.v`.

## State of the native chain
`./vnew -d arm64 -d fastc_selfhost -gc none -prealloc -o fd_arm64 vlib/v3/v3.v` builds (gen 0 must be built by V1: the FastC C path cannot compile the arm64-enabled compiler because checker_tail.v's multi-line `return match` branches are outside its subset). `fd_arm64` emits Mach-O for hello world (runs) and for the compiler itself (30 MB, ~1.7 s). That natively compiled compiler builds hello world correctly, but aborts with libmalloc heap corruption after ~6 s of compiling `vlib/v3/v3.v`, with or without the resolve memo. Under `MallocScribble` the first fault is a `memmove` to `0x1000000cc` inside the runtime's `fast_map_set`; the return address resolves to `FastArm64Parser.mark_terminated + 2320`, but that is only the nearest of the ~1000 symbols the native linker emits, so the real caller is an unnamed function. The map runtime itself handles 300k-entry struct-field maps in a natively compiled test program, so the corruption comes from another miscompiled construct in the compiler's code. The native binaries carry no unwind info, so lldb cannot walk past frame 0; `lldb --batch -k "register read lr" -k "image lookup -a \$lr" ...` recovers the caller.

## Timings (clang `-O2 -gc none -prealloc` fastcdriver builds compiling `vlib/v3/v3.v`, load ~2-3, warm memo)
| driver | wall |
|---|---|
| native ARM64 emission | 0.24 s |
| FastC C + TinyCC | 0.13 s |

`FASTC_BENCH_PHASES=1` on the native driver (marks added by this PR): resolve 1.2 ms, unsupported-call validation 13 ms (a serial token scan of every file), monomorphize 0.02 ms, declaration indexes 5 ms, signatures 7 ms, native declarations 14.5 ms (serial rescan of the type files), register 9.7 ms, **parse to SSA 79 ms, ARM64 codegen 85-88 ms**, link 22 ms (0.24 s wall). The C driver: resolve 0.9, declaration indexes 1.2, signatures 1.0, constants 1.2, per-file generation 8.6 ms on all cores, then TinyCC. The native pipeline is serial from the parse loop on: one `ssa.Module` with global value/block/type ids is filled file by file inside a reachability fixpoint, and `arm64.Gen` walks it serially; only the linker's page hashing is threaded. The 8.6% advantage reported in #28277 predates the parallel C-path speedups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


