### PR TITLE
vfmt: fix non-idempotent blank line after a commented const (fix #28305)

### DIFF
--- a/vlib/v3/gen/arm64/linker.v
+++ b/vlib/v3/gen/arm64/linker.v
@@ -43,22 +43,17 @@ const csslot_requirements = u32(2)
 const csslot_cms_signature = u32(0x10000)
 const cs_adhoc = u32(0x2) // Ad-hoc signing flag
 
-
 const cs_hashtype_sha256 = u8(2)
 const cs_hash_size = 32 // SHA256 = 32 bytes
 
-
 const cs_page_size_arm64 = 16384 // Code signing page size for ARM64 macOS
 
-
 const cs_page_shift_arm64 = 14 // log2(16384)
-
 
 const o_wronly_creat_trunc = $if linux { 0x241 } $else { 0x601 }
 
 // ARM64 page size on macOS
 const page_size = 0x4000 // 16KB
-
 
 // Base address for executables
 const base_addr = u64(0x100000000)

--- a/vlib/v3/gen/v/gen.v
+++ b/vlib/v3/gen/v/gen.v
@@ -3265,34 +3265,28 @@ fn (mut g Gen) const_decl(id flat.NodeId) {
 	n := g.a.node(id)
 	g.emit_attrs(id)
 	pub_prefix := if n.op == .arrow { 'pub ' } else { '' }
-	fields := g.a.children_of(n)
-	if fields.len == 1 {
-		f := g.a.node(fields[0])
-		g.emit_comments_before(f.pos.offset)
-		g.write('${pub_prefix}const ${f.value}')
-		if f.children_count > 0 {
-			g.write(' = ')
-			g.expr(g.a.child(f, 0))
-		} else if f.typ.len > 0 {
-			g.write(' ${g.type_text(f.typ)}')
-		}
-		g.writeln('')
-		g.source_end = int_max(g.source_end, f.pos.end)
-		return
+	for fid in g.a.children_of(n) {
+		g.const_field(fid, pub_prefix)
 	}
-	for fid in fields {
-		f := g.a.node(fid)
-		g.emit_comments_before(f.pos.offset)
-		g.write('${pub_prefix}const ${f.value}')
-		if f.children_count > 0 {
-			g.write(' = ')
-			g.expr(g.a.child(f, 0))
-		} else if f.typ.len > 0 {
-			g.write(' ${g.type_text(f.typ)}')
-		}
-		g.writeln('')
-		g.source_end = int_max(g.source_end, f.pos.end)
+}
+
+fn (mut g Gen) const_field(fid flat.NodeId, pub_prefix string) {
+	f := g.a.node(fid)
+	g.emit_comments_before(f.pos.offset)
+	g.write('${pub_prefix}const ${f.value}')
+	if f.children_count > 0 {
+		g.write(' = ')
+		g.expr(g.a.child(f, 0))
+	} else if f.typ.len > 0 {
+		g.write(' ${g.type_text(f.typ)}')
 	}
+	// `g.expr` already terminated the line when it flushed a trailing `//`
+	// comment; a second newline here would add a blank line on every `vfmt`
+	// pass.
+	if !g.on_newline {
+		g.writeln('')
+	}
+	g.source_end = int_max(g.source_end, f.pos.end)
 }
 
 fn (mut g Gen) global_decl(id flat.NodeId) {

--- a/vlib/v3/gen/v/gen_test.v
+++ b/vlib/v3/gen/v/gen_test.v
@@ -230,6 +230,15 @@ fn test_formatter_keeps_trailing_array_initializer_comments_inside() {
 	assert vfmt('trailing_array_initializer_comment_twice', out) == out
 }
 
+// A `const` with a trailing `//` comment used to emit an extra newline after the
+// comment, so every `v fmt -w` pass added one more blank line after it.
+fn test_formatter_keeps_consts_adjacent_after_trailing_comment() {
+	source := 'const first = u64(0x06)\nconst second = u64(0x08) // low 3 bits\nconst third = u64(0x10)\n\nconst fourth = 1 // spaced out\n\nconst fifth = 2\n\nfn main() {}\n'
+	out := vfmt('const_trailing_comment_blank_lines', source)
+	assert out == source, out
+	assert vfmt('const_trailing_comment_blank_lines_twice', out) == out
+}
+
 fn test_formatter_keeps_singleton_grouped_const_comments_before_declaration() {
 	source := 'const (\n\t// only docs\n\tonly = 1\n)\n'
 	expected := '// only docs\nconst only = 1\n'


### PR DESCRIPTION
Fixes #28305.

## Problem

A top-level `const` carrying a trailing `//` comment gained a blank line after it on every `v fmt -w` pass, so the file kept changing for two passes before settling on two consecutive blank lines:

```v
const frame_type_crypto = u64(0x06)
const frame_type_stream_base = u64(0x08) // 0x08-0x0f, OFF/LEN/FIN bits in the low 3 bits
const frame_type_max_data = u64(0x10)
```

## Cause

`expr()` ends with `emit_trailing_comments(n.pos.end)`, which flushes a same-line `//` comment and terminates the line (`write_comment` uses `writeln`). `const_decl` then wrote an unconditional `g.writeln('')` on top of that, producing a blank line.

That blank line then feeds back into `top_level`: it only keeps two consecutive `const`s adjacent when the *source* has no blank line between them, so once pass 1 wrote one, pass 2 added the separator *and* the stray newline — two blank lines.

## Fix

Guard the newline with `g.on_newline`, the same way `global_field` and `named_init_field` already do. The duplicated single-field / loop bodies of `const_decl` are folded into one `const_field` so the guard lives in a single place.

`vlib/v3/gen/arm64/linker.v` had the doubled blank lines committed (it was formatted by the buggy vfmt), so it is reformatted here.

## Validation

- New regression test in `vlib/v3/gen/v/gen_test.v`; it fails on `master` and passes here. `v test vlib/v3/gen/v/gen_test.v` and `v test cmd/tools/vfmt_test.v` pass.
- Whole-tree A/B sweep, two `v fmt` passes over all 6307 `.v` files in the repo with a `master` build and this build:
  - **24** files that were not idempotent under `master` are now stable (296 → 272), **0** newly unstable.
  - **18** more files now match their committed source, **1** newly differs — `vlib/v3/gen/arm64/linker.v`, whose committed content *is* the bug's output; it is reformatted in this PR.
  - 91 files change output, and in every one the only change is a removed blank line.
- The two `vlib/v3/gen/fastc` failures and `vlib/v/fmt/fmt_bin2v_test.v` fail identically on `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)