### PR TITLE
v3: fix the bootstrap build broken by the `int` 64-bit change

### DIFF
--- a/vlib/v3/gen/fastc/fastc.v
+++ b/vlib/v3/gen/fastc/fastc.v
@@ -1479,6 +1479,9 @@ fn generate_source_files(input_sources []FastcSourceFile, module_aliases map[str
 // per-file bodies are referenced, not copied, so the multi-megabyte output is
 // never assembled into one buffer here.
 fn generate_source_pieces(input_sources []FastcSourceFile, module_aliases map[string]string, prefs &pref.Preferences) !([]string, bool, []string) {
+	// The `int` C spelling is fixed before any source is generated, so the
+	// generation workers below all read the same width.
+	fastc_set_platform_int_bits(prefs.target.pointer_bits)
 	// Source-level generic monomorphization runs first; it is a no-op when the
 	// program has no generic function definitions (so the self-host is untouched).
 	mut timer := fastc_new_phase_timer()

--- a/vlib/v3/gen/fastc/platform_int.v
+++ b/vlib/v3/gen/fastc/platform_int.v
@@ -4,6 +4,16 @@ module fastc
 // fastc_platform_int_c_type is the C spelling FastC emits for V's
 // platform-width `int`. Keep the state in its own module file so FastC's
 // generation entry point can follow upstream refactors without carrying a
-// conflict-prone module-header edit. FastC self-hosts for the current machine,
-// so default this from the compiler's pointer width.
-__global fastc_platform_int_c_type = $if x64 { 'i64' } $else { 'i32' }
+// conflict-prone module-header edit. It defaults to the 64-bit spelling so the
+// generator is usable before a target is configured; generation calls
+// `fastc_set_platform_int_bits` with the target pointer width first.
+__global fastc_platform_int_c_type = 'i64'
+
+// fastc_set_platform_int_bits selects the C spelling for the platform `int`
+// from the target pointer width. Generation calls this once, before any worker
+// reads the spelling, so every emitted declaration agrees on the width. Taking
+// the width from the target rather than the compiler host keeps cross builds
+// correct, and matches `types.set_platform_int_bits` in the C backend.
+fn fastc_set_platform_int_bits(bits int) {
+	fastc_platform_int_c_type = if bits == 32 { 'i32' } else { 'i64' }
+}


### PR DESCRIPTION
`make` and `v up` fail on master: every use of `fastc_platform_int_c_type` reports `undefined ident`, so `v1` (built from `vc/v.c`) cannot compile `cmd/v` and the bootstrap chain stops.

```
vlib/v3/gen/fastc/fn.v:1269:10: error: undefined ident: `fastc_platform_int_c_type`
vlib/v3/gen/fastc/stmt.v:1889:19: error: undefined ident: `fastc_platform_int_c_type`
make: *** [GNUmakefile:216: all] Error 1
```

Reported after #28293; still present at `e009ef9e27` (i.e. #28301 does not fix it).

## Cause

The global's initializer, added in #28293:

```v
__global fastc_platform_int_c_type = $if x64 { 'i64' } $else { 'i32' }
```

V1 does not register a `__global` whose initializer is a comptime-if expression. It parses without an error but never enters scope, so `fn.v` and `stmt.v` fail to resolve it. Minimal reproduction against a `vc/v.c` build:

```v
@[has_globals]
module m

__global mg = $if x64 { 'i64' } $else { 'i32' }   // undefined ident at every use
__global mg = 'i64'                              // fine
```

Nothing caught this locally because `v test` and the FastC self-host both run through the *new* compiler, which accepts the form; only the V1 bootstrap stage rejects it.

## Fix

Default the global to the 64-bit spelling, and set it from the target pointer width at the start of `generate_source_pieces` — the single funnel that `generate`, `generate_files` and `generate_files_with_source_paths` all pass through, so the spelling is fixed before any generation worker reads it.

That also removes the last place where the compiler *host's* width decided a *target* property; it now reads `prefs.target.pointer_bits`, matching `types.set_platform_int_bits` in the C backend.

## Validation

- Full bootstrap chain green (fails without this patch): `cc -std=c99 -w -o v1 vc/v.c -lm -lpthread` → `./v1 -no-parallel -o v2 -gc none cmd/v` → `./v2 -nocache -o v -gc none cmd/v`. The reported `-gc none -prealloc` self-compile succeeds too.
- Emitted C unchanged on 64-bit hosts: `int` fields still spell `i64 n;`, `int` locals `i64 y = (100000);`, and `100000 * 100000 + 7` prints `10000000007` (no 32-bit overflow).
- FastC self-host chain reaches a fixpoint: gen1 → gen2 → gen3 with `v5.c` byte-identical to `v6.c`.
- `vlib/v3/tests/fastc_backend_test.v` passes; `-d v3_no_parallel` builds; `v fmt -verify` clean.
- `fastc_test.v`'s `test_real_builtin_path_map_and_filter_lower_to_array_loops` failure ("fastc parser does not support `.map` closure type" on an enum-array literal) is pre-existing — confirmed identical on a baseline build of `origin/master` carrying only the minimal edit needed to make V1 compile it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)