### PR TITLE
v3: header-free FastC self-host C, reachability prune, concurrent TinyCC units, in-process signing

### DIFF
--- a/vlib/sync/thread_helper.h
+++ b/vlib/sync/thread_helper.h
@@ -18,8 +18,10 @@ static inline int v_sync_thread_create_detached(void *start, void *arg) {
 	return 0;
 }
 #else
+#ifndef V_FASTC_NO_HEADERS
 #include <pthread.h>
 #include <stdlib.h>
+#endif
 
 static inline int v_sync_thread_create_detached(void *start, void *arg) {
 	pthread_attr_t attr;

--- a/vlib/v3/README.md
+++ b/vlib/v3/README.md
@@ -202,6 +202,20 @@ constant and global declarations: a large file's constants are parsed as separat
 candidates (merged in source order), and the global phase parses only the recorded global
 declarations instead of whole files.
 
+A self-host build (`-selfhost`) for 64-bit macOS or glibc Linux emits C with no `#include`
+at all: `gen/fastc/c_abi.v` holds, per target, the C library types, struct layouts, macros,
+globals and function prototypes the emitted code uses, and that prelude replaces the header block
+of the preamble; V's own C helper headers (`vlib/os/execute_capture_nix.h`, ...) are inlined
+after it, and `#include` lines from V sources are left out. TinyCC then parses about 42K lines
+instead of the 110K that the system headers expanded to. The build passes
+`-Werror=implicit-function-declaration`, so a C function missing from the table fails the build
+instead of being called through an implicit `int` prototype; `c_abi_test.v` compiles the table
+against the host headers and checks every layout, size, value and prototype. The stitch also
+drops the indexed functions (and enum `str`/print helpers) that nothing reachable from `main`,
+the lifecycle hooks or the non-body pieces refers to, which the source-level name-grouped
+reachability keeps: each worker records its definitions and the mangled names they mention, and
+the assembly cuts the unreachable spans out of the pieces (about 9% of the self-host C).
+
 The standalone compiler supports `self` directly and defaults that command to FastC. For example,
 `./v self x5` replaces the compiler through five descendant FastC generations, with each installed
 generation compiling the next one. `-b fastc`, `-gc none`, `-cc tinyc|tcc`, `-keepc`, `-silent`,

--- a/vlib/v3/README.md
+++ b/vlib/v3/README.md
@@ -208,13 +208,26 @@ globals and function prototypes the emitted code uses, and that prelude replaces
 of the preamble; V's own C helper headers (`vlib/os/execute_capture_nix.h`, ...) are inlined
 after it, and `#include` lines from V sources are left out. TinyCC then parses about 42K lines
 instead of the 110K that the system headers expanded to. The build passes
-`-Werror=implicit-function-declaration`, so a C function missing from the table fails the build
-instead of being called through an implicit `int` prototype; `c_abi_test.v` compiles the table
+`-Werror=implicit-function-declaration` (and no `-w`, which would silence it), so a C function
+missing from the table fails the build instead of being called through an implicit `int`
+prototype that truncates pointer results; `c_abi_test.v` compiles the table
 against the host headers and checks every layout, size, value and prototype. The stitch also
 drops the indexed functions (and enum `str`/print helpers) that nothing reachable from `main`,
 the lifecycle hooks or the non-body pieces refers to, which the source-level name-grouped
 reachability keeps: each worker records its definitions and the mangled names they mention, and
 the assembly cuts the unreachable spans out of the pieces (about 9% of the self-host C).
+The TinyCC step itself is split: `fastc_write_c_units` cuts the pieces into up to 8
+translation units (the shared head of typedefs, prototypes and runtime in every unit, the
+dispatch tables, lifecycle functions and `main` only in the first, the file bodies grouped by
+size; the globals are definitions in the first unit and `extern` declarations in the others),
+`fastc_compile_c_units` compiles them with concurrent `tcc -c` processes started through
+`posix_spawn` (forking the large compiler process costs more), and one `tcc` call links the
+objects (`VJOBS=1` keeps the single-file build; both give the same C with `-keepc`). On macOS
+TinyCC runs Apple's `codesign` after linking, which costs ~50 ms per build: the drivers put a
+no-op `codesign` first on its PATH and ad-hoc sign the executable themselves
+(`gen/fastc/macho_sign.v`, SHA-256 page hashes through CommonCrypto, patched into the file in
+place). The SDK path is taken from `SDKROOT` or the known SDK locations before `xcrun` is
+asked (~8 ms per call).
 
 The standalone compiler supports `self` directly and defaults that command to FastC. For example,
 `./v self x5` replaces the compiler through five descendant FastC generations, with each installed

--- a/vlib/v3/README.md
+++ b/vlib/v3/README.md
@@ -216,18 +216,19 @@ drops the indexed functions (and enum `str`/print helpers) that nothing reachabl
 the lifecycle hooks or the non-body pieces refers to, which the source-level name-grouped
 reachability keeps: each worker records its definitions and the mangled names they mention, and
 the assembly cuts the unreachable spans out of the pieces (about 9% of the self-host C).
+
 The TinyCC step itself is split: `fastc_write_c_units` cuts the pieces into up to 8
 translation units (the shared head of typedefs, prototypes and runtime in every unit, the
 dispatch tables, lifecycle functions and `main` only in the first, the file bodies grouped by
 size; the globals are definitions in the first unit and `extern` declarations in the others),
 `fastc_compile_c_units` compiles them with concurrent `tcc -c` processes started through
 `posix_spawn` (forking the large compiler process costs more), and one `tcc` call links the
-objects (`VJOBS=1` keeps the single-file build; both give the same C with `-keepc`). On macOS
-TinyCC runs Apple's `codesign` after linking, which costs ~50 ms per build: the drivers put a
-no-op `codesign` first on its PATH and ad-hoc sign the executable themselves
-(`gen/fastc/macho_sign.v`, SHA-256 page hashes through CommonCrypto, patched into the file in
-place). The SDK path is taken from `SDKROOT` or the known SDK locations before `xcrun` is
-asked (~8 ms per call).
+objects (`VJOBS=1`, `V3_FASTC_NO_PARALLEL=1`, or `-no-parallel` keeps the single-file build; both
+give the same C with `-keepc`). On macOS TinyCC runs Apple's `codesign` after linking, which costs
+~50 ms per build: the drivers put a no-op `codesign` first on its PATH and ad-hoc sign the
+executable themselves (`gen/fastc/macho_sign.v`, SHA-256 page hashes through CommonCrypto,
+patched into the file in place). The SDK path is taken from `SDKROOT` or the toolchain selected by
+`xcrun`; conventional SDK locations are used only as a fallback.
 
 The standalone compiler supports `self` directly and defaults that command to FastC. For example,
 `./v self x5` replaces the compiler through five descendant FastC generations, with each installed

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -1809,6 +1809,7 @@ struct V3CCompilerFlagOptions {
 	vroot                string
 	target_os            string
 	target_arch          string
+	macos_sdk_root       string
 	pic_flag             string
 	is_prod              bool
 	no_prod_options      bool
@@ -1917,7 +1918,7 @@ fn v3_tcc_resource_flags(vroot string) V3TccResourceFlags {
 	}
 }
 
-fn v3_tcc_host_system_flags(target_os string) []string {
+fn v3_tcc_host_system_flags(target_os string, macos_sdk_root string) []string {
 	if target_os != os.user_os() || target_os == 'windows' {
 		return []
 	}
@@ -1925,28 +1926,21 @@ fn v3_tcc_host_system_flags(target_os string) []string {
 	// the standard local prefix used by native packages such as wkhtmltox.
 	mut flags := ['-I/usr/local/include', '-L/usr/local/lib']
 	if target_os == 'macos' {
-		sdk_root := macos_sdk_root()
-		if sdk_root != '' {
-			flags << '-I${os.join_path(sdk_root, 'usr', 'include')}'
-			flags << '-L${os.join_path(sdk_root, 'usr', 'lib')}'
+		if macos_sdk_root != '' {
+			flags << '-I${os.join_path(macos_sdk_root, 'usr', 'include')}'
+			flags << '-L${os.join_path(macos_sdk_root, 'usr', 'lib')}'
 		}
 	}
 	return flags
 }
 
-// macos_sdk_root finds the macOS SDK: `SDKROOT`, then the SDKs of the command
-// line tools and of Xcode, and only then `xcrun`, which costs several
-// milliseconds per compile.
+// macos_sdk_root finds the selected macOS SDK. SDKROOT and xcrun are
+// authoritative; the conventional locations are fallbacks for an unavailable
+// or broken xcrun.
 fn macos_sdk_root() string {
 	env_root := os.getenv('SDKROOT')
 	if os.is_dir(env_root) {
 		return env_root
-	}
-	for candidate in ['/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk',
-		'/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk'] {
-		if os.is_dir(candidate) {
-			return candidate
-		}
 	}
 	result := cmdexec.run('xcrun', ['--show-sdk-path'])
 	if result.exit_code == 0 {
@@ -1955,7 +1949,29 @@ fn macos_sdk_root() string {
 			return found
 		}
 	}
+	for candidate in ['/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk',
+		'/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk'] {
+		if os.is_dir(candidate) {
+			return candidate
+		}
+	}
 	return ''
+}
+
+// V3MacosSdkRootCache avoids repeating xcrun when a TinyCC build constructs
+// both its general flag plan and its final link command.
+struct V3MacosSdkRootCache {
+mut:
+	resolved bool
+	root     string
+}
+
+fn (mut cache V3MacosSdkRootCache) get() string {
+	if !cache.resolved {
+		cache.root = macos_sdk_root()
+		cache.resolved = true
+	}
+	return cache.root
 }
 
 fn v3_c_compiler_flag_plan(options V3CCompilerFlagOptions) V3CCompilerFlagPlan {
@@ -1974,7 +1990,7 @@ fn v3_c_compiler_flag_plan(options V3CCompilerFlagOptions) V3CCompilerFlagPlan {
 		tcc_resources := v3_tcc_resource_flags(options.vroot)
 		tcc_includes = tcc_resources.include_arg
 		before_inputs << [tcc_resources.base_arg, tcc_resources.include_arg, tcc_resources.library_arg]
-		before_inputs << v3_tcc_host_system_flags(options.target_os)
+		before_inputs << v3_tcc_host_system_flags(options.target_os, options.macos_sdk_root)
 		if v3_tcc_backtrace_enabled(options.target_os, options.target_arch, options.is_shared) {
 			before_inputs << '-bt25'
 		}
@@ -7414,7 +7430,7 @@ fn canonical_v3_fastc_output_path(path string) string {
 	return os.join_path_single(canonical_parent, os.file_name(absolute_path))
 }
 
-fn compile_v3_fastc_source(pieces []string, units fastc.FastcUnitLayout, bin_file string, prefs &pref.Preferences, environment_c_flags []string, source_c_flags []string, user_c_flags []string, environment_ld_flags []string, is_debug bool, uses_threads bool) V3FastCCompileResult {
+fn compile_v3_fastc_source(pieces []string, units fastc.FastcUnitLayout, bin_file string, prefs &pref.Preferences, environment_c_flags []string, source_c_flags []string, user_c_flags []string, environment_ld_flags []string, macos_sdk_root string, is_debug bool, uses_threads bool) V3FastCCompileResult {
 	bench_phases := os.getenv('FASTC_BENCH_PHASES') != ''
 	cc_sw := time.new_stopwatch()
 	tcc_dir := os.join_path(prefs.vroot, 'thirdparty', 'tcc')
@@ -7447,7 +7463,7 @@ fn compile_v3_fastc_source(pieces []string, units fastc.FastcUnitLayout, bin_fil
 	tcc_resources := v3_tcc_resource_flags(prefs.vroot)
 	mut cc_args := environment_c_flags.clone()
 	cc_args << ['-std=gnu11', tcc_resources.base_arg, tcc_resources.include_arg, tcc_resources.library_arg]
-	cc_args << v3_tcc_host_system_flags(prefs.normalized_target_os())
+	cc_args << v3_tcc_host_system_flags(prefs.normalized_target_os(), macos_sdk_root)
 	cc_args << source_c_flags
 	// A call without a prototype would silently truncate a pointer result
 	// (the C carries no headers): it is an error, not a warning.
@@ -7461,13 +7477,15 @@ fn compile_v3_fastc_source(pieces []string, units fastc.FastcUnitLayout, bin_fil
 	// TinyCC signs the linked executable through `codesign` on macOS; the
 	// shim makes that call a no-op and the executable is signed below.
 	shim_dir := fastc.fastc_codesign_shim_dir()
+	defer {
+		fastc.fastc_remove_codesign_shim_dir(shim_dir)
+	}
 	mut result := os.Result{}
 	mut command := ''
 	if unit_paths.len > 1 {
 		mut compile_args := cc_args.clone()
 		compile_args << user_c_flags
 		unit_objects := fastc.fastc_compile_c_units(tcc_path, compile_args, unit_paths) or {
-			fastc.fastc_remove_codesign_shim_dir(shim_dir)
 			fastc.write_c_pieces(source_file, pieces) or {}
 			return V3FastCCompileResult{
 				command: cmdexec.display(tcc_path, compile_args)
@@ -7503,7 +7521,6 @@ fn compile_v3_fastc_source(pieces []string, units fastc.FastcUnitLayout, bin_fil
 		command = cmdexec.display(tcc_path, cc_args)
 		result = cmdexec.run_in(tcc_path, cc_args, build_dir)
 	}
-	fastc.fastc_remove_codesign_shim_dir(shim_dir)
 	if result.exit_code != 0 || !os.is_file(staged_binary) {
 		if keep_dir := os.getenv_opt('V3_FASTC_KEEP_FAILED_C') {
 			if keep_dir.len > 0 {
@@ -7515,7 +7532,7 @@ fn compile_v3_fastc_source(pieces []string, units fastc.FastcUnitLayout, bin_fil
 			output:  result.output
 		}
 	}
-	if shim_dir != '' {
+	if shim_dir.dir != '' {
 		fastc.fastc_sign_macho_adhoc(staged_binary) or {
 			return V3FastCCompileResult{
 				command: command
@@ -7666,6 +7683,7 @@ pub fn run(args []string) {
 	mut profile_no_inline := false
 	mut profile_fns := []string{}
 	mut command_seen := false
+	mut macos_sdk_root_cache := V3MacosSdkRootCache{}
 	environment_c_flags := parse_v3_environment_flags('CFLAGS')
 	environment_ld_flags := parse_v3_environment_flags('LDFLAGS')
 	if environment_c_flags.len > 0 || environment_ld_flags.len > 0 {
@@ -8662,9 +8680,14 @@ pub fn run(args []string) {
 			} else {
 				bin_file
 			}
+			fastc_sdk_root := if prefs.normalized_target_os() == 'macos' {
+				macos_sdk_root_cache.get()
+			} else {
+				''
+			}
 			fastc_result := compile_v3_fastc_source(fastc_pieces, fastc_generation.units,
 				fastc_bin_file, prefs, environment_c_flags, fastc_generation.c_flags, user_c_flags,
-				environment_ld_flags, is_debug, fastc_generation.uses_threads)
+				environment_ld_flags, fastc_sdk_root, is_debug, fastc_generation.uses_threads)
 			if (!silent || show_cc) && fastc_result.command.len > 0 {
 				if c_to_stdout {
 					eprintln('  > ${fastc_result.command}')
@@ -10704,6 +10727,11 @@ pub fn run(args []string) {
 			}
 			b.step('C object cache')
 		}
+		flag_plan_sdk_root := if explicit_tcc && prefs.normalized_target_os() == 'macos' {
+			macos_sdk_root_cache.get()
+		} else {
+			''
+		}
 		c_flag_plan := v3_c_compiler_flag_plan(V3CCompilerFlagOptions{
 			environment_c_flags:  environment_c_flags
 			environment_ld_flags: environment_ld_flags
@@ -10714,6 +10742,7 @@ pub fn run(args []string) {
 			vroot:                prefs.vroot
 			target_os:            prefs.normalized_target_os()
 			target_arch:          prefs.normalized_target_arch()
+			macos_sdk_root:       flag_plan_sdk_root
 			pic_flag:             pic_flag
 			is_prod:              is_prod
 			no_prod_options:      no_prod_options
@@ -11227,7 +11256,12 @@ pub fn run(args []string) {
 			tcc_resources := v3_tcc_resource_flags(prefs.vroot)
 			mut tcc_args := [c_standard, tcc_resources.base_arg, tcc_resources.include_arg,
 				tcc_resources.library_arg, '-w', '-Werror=implicit-function-declaration']
-			tcc_args << v3_tcc_host_system_flags(prefs.normalized_target_os())
+			tcc_sdk_root := if prefs.normalized_target_os() == 'macos' {
+				macos_sdk_root_cache.get()
+			} else {
+				''
+			}
+			tcc_args << v3_tcc_host_system_flags(prefs.normalized_target_os(), tcc_sdk_root)
 			if v3_tcc_backtrace_enabled(prefs.normalized_target_os(),
 				prefs.normalized_target_arch(), is_shared)
 			{
@@ -11305,7 +11339,12 @@ pub fn run(args []string) {
 				tcc_args << pic_flag
 			}
 			tcc_args << [tcc_resources.base_arg, tcc_resources.include_arg, tcc_resources.library_arg]
-			tcc_args << v3_tcc_host_system_flags(prefs.normalized_target_os())
+			tcc_sdk_root := if prefs.normalized_target_os() == 'macos' {
+				macos_sdk_root_cache.get()
+			} else {
+				''
+			}
+			tcc_args << v3_tcc_host_system_flags(prefs.normalized_target_os(), tcc_sdk_root)
 			if v3_tcc_backtrace_enabled(prefs.normalized_target_os(),
 				prefs.normalized_target_arch(), is_shared)
 			{

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -1925,19 +1925,37 @@ fn v3_tcc_host_system_flags(target_os string) []string {
 	// the standard local prefix used by native packages such as wkhtmltox.
 	mut flags := ['-I/usr/local/include', '-L/usr/local/lib']
 	if target_os == 'macos' {
-		mut sdk_root := os.getenv('SDKROOT')
-		if !os.is_dir(sdk_root) {
-			result := cmdexec.run('xcrun', ['--show-sdk-path'])
-			if result.exit_code == 0 {
-				sdk_root = result.output.trim_space()
-			}
-		}
-		if os.is_dir(sdk_root) {
+		sdk_root := macos_sdk_root()
+		if sdk_root != '' {
 			flags << '-I${os.join_path(sdk_root, 'usr', 'include')}'
 			flags << '-L${os.join_path(sdk_root, 'usr', 'lib')}'
 		}
 	}
 	return flags
+}
+
+// macos_sdk_root finds the macOS SDK: `SDKROOT`, then the SDKs of the command
+// line tools and of Xcode, and only then `xcrun`, which costs several
+// milliseconds per compile.
+fn macos_sdk_root() string {
+	env_root := os.getenv('SDKROOT')
+	if os.is_dir(env_root) {
+		return env_root
+	}
+	for candidate in ['/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk',
+		'/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk'] {
+		if os.is_dir(candidate) {
+			return candidate
+		}
+	}
+	result := cmdexec.run('xcrun', ['--show-sdk-path'])
+	if result.exit_code == 0 {
+		found := result.output.trim_space()
+		if os.is_dir(found) {
+			return found
+		}
+	}
+	return ''
 }
 
 fn v3_c_compiler_flag_plan(options V3CCompilerFlagOptions) V3CCompilerFlagPlan {
@@ -7396,7 +7414,9 @@ fn canonical_v3_fastc_output_path(path string) string {
 	return os.join_path_single(canonical_parent, os.file_name(absolute_path))
 }
 
-fn compile_v3_fastc_source(pieces []string, bin_file string, prefs &pref.Preferences, environment_c_flags []string, source_c_flags []string, user_c_flags []string, environment_ld_flags []string, is_debug bool, uses_threads bool) V3FastCCompileResult {
+fn compile_v3_fastc_source(pieces []string, units fastc.FastcUnitLayout, bin_file string, prefs &pref.Preferences, environment_c_flags []string, source_c_flags []string, user_c_flags []string, environment_ld_flags []string, is_debug bool, uses_threads bool) V3FastCCompileResult {
+	bench_phases := os.getenv('FASTC_BENCH_PHASES') != ''
+	cc_sw := time.new_stopwatch()
 	tcc_dir := os.join_path(prefs.vroot, 'thirdparty', 'tcc')
 	tcc_path := os.join_path_single(tcc_dir, 'tcc.exe')
 	if !os.is_executable(tcc_path) {
@@ -7410,30 +7430,80 @@ fn compile_v3_fastc_source(pieces []string, bin_file string, prefs &pref.Prefere
 	}
 	source_file := os.join_path_single(build_dir, 'src.c')
 	staged_binary := os.join_path_single(build_dir, 'out')
-	fastc.write_c_pieces(source_file, pieces) or { return V3FastCCompileResult{} }
+	// The program's translation units are compiled by concurrent TinyCC
+	// processes and linked; a program that does not split is compiled as
+	// one file.
+	if bench_phases {
+		eprintln('fastc-phase tcc.setup ${cc_sw.elapsed().microseconds()}us')
+	}
+	unit_paths := fastc.fastc_write_c_units(os.join_path_single(build_dir, 'src'), pieces, units,
+		fastc.fastc_tcc_job_count(prefs)) or { return V3FastCCompileResult{} }
+	if unit_paths.len < 2 {
+		fastc.write_c_pieces(source_file, pieces) or { return V3FastCCompileResult{} }
+	}
+	if bench_phases {
+		eprintln('fastc-phase tcc.units_written ${cc_sw.elapsed().microseconds()}us units=${unit_paths.len}')
+	}
 	tcc_resources := v3_tcc_resource_flags(prefs.vroot)
 	mut cc_args := environment_c_flags.clone()
 	cc_args << ['-std=gnu11', tcc_resources.base_arg, tcc_resources.include_arg, tcc_resources.library_arg]
 	cc_args << v3_tcc_host_system_flags(prefs.normalized_target_os())
 	cc_args << source_c_flags
-	cc_args << '-w'
+	// A call without a prototype would silently truncate a pointer result
+	// (the C carries no headers): it is an error, not a warning.
+	cc_args << '-Werror=implicit-function-declaration'
 	if v3_tcc_backtrace_enabled(prefs.normalized_target_os(), prefs.normalized_target_arch(), false) {
 		cc_args << '-bt25'
 	}
 	if is_debug {
 		cc_args << '-g'
 	}
-	cc_args << ['-o', 'out', 'src.c']
-	cc_args << user_c_flags
-	if uses_threads {
-		// The emitted spawn runtime calls pthread functions, which live
-		// outside libc on Linux with glibc before 2.34 and on the BSDs.
-		cc_args << '-lpthread'
+	// TinyCC signs the linked executable through `codesign` on macOS; the
+	// shim makes that call a no-op and the executable is signed below.
+	shim_dir := fastc.fastc_codesign_shim_dir()
+	mut result := os.Result{}
+	mut command := ''
+	if unit_paths.len > 1 {
+		mut compile_args := cc_args.clone()
+		compile_args << user_c_flags
+		unit_objects := fastc.fastc_compile_c_units(tcc_path, compile_args, unit_paths) or {
+			fastc.fastc_remove_codesign_shim_dir(shim_dir)
+			fastc.write_c_pieces(source_file, pieces) or {}
+			return V3FastCCompileResult{
+				command: cmdexec.display(tcc_path, compile_args)
+				output:  err.msg()
+			}
+		}
+		if bench_phases {
+			eprintln('fastc-phase tcc.units_compiled ${cc_sw.elapsed().microseconds()}us')
+		}
+		cc_args << ['-o', staged_binary]
+		cc_args << unit_objects
+		cc_args << user_c_flags
+		if uses_threads {
+			cc_args << '-lpthread'
+		}
+		cc_args << '-lm'
+		cc_args << environment_ld_flags
+		command = cmdexec.display(tcc_path, cc_args)
+		result = fastc.fastc_run_command(tcc_path, cc_args)
+		if bench_phases {
+			eprintln('fastc-phase tcc.linked ${cc_sw.elapsed().microseconds()}us')
+		}
+	} else {
+		cc_args << ['-o', 'out', 'src.c']
+		cc_args << user_c_flags
+		if uses_threads {
+			// The emitted spawn runtime calls pthread functions, which live
+			// outside libc on Linux with glibc before 2.34 and on the BSDs.
+			cc_args << '-lpthread'
+		}
+		cc_args << '-lm'
+		cc_args << environment_ld_flags
+		command = cmdexec.display(tcc_path, cc_args)
+		result = cmdexec.run_in(tcc_path, cc_args, build_dir)
 	}
-	cc_args << '-lm'
-	cc_args << environment_ld_flags
-	command := cmdexec.display(tcc_path, cc_args)
-	result := cmdexec.run_in(tcc_path, cc_args, build_dir)
+	fastc.fastc_remove_codesign_shim_dir(shim_dir)
 	if result.exit_code != 0 || !os.is_file(staged_binary) {
 		if keep_dir := os.getenv_opt('V3_FASTC_KEEP_FAILED_C') {
 			if keep_dir.len > 0 {
@@ -7444,6 +7514,17 @@ fn compile_v3_fastc_source(pieces []string, bin_file string, prefs &pref.Prefere
 			command: command
 			output:  result.output
 		}
+	}
+	if shim_dir != '' {
+		fastc.fastc_sign_macho_adhoc(staged_binary) or {
+			return V3FastCCompileResult{
+				command: command
+				output:  'could not sign ${staged_binary}: ${err.msg()}'
+			}
+		}
+	}
+	if bench_phases {
+		eprintln('fastc-phase tcc.signed ${cc_sw.elapsed().microseconds()}us')
 	}
 	os.mv(staged_binary, bin_file) or {
 		return V3FastCCompileResult{
@@ -8581,9 +8662,9 @@ pub fn run(args []string) {
 			} else {
 				bin_file
 			}
-			fastc_result := compile_v3_fastc_source(fastc_pieces, fastc_bin_file, prefs,
-				environment_c_flags, fastc_generation.c_flags, user_c_flags, environment_ld_flags,
-				is_debug, fastc_generation.uses_threads)
+			fastc_result := compile_v3_fastc_source(fastc_pieces, fastc_generation.units,
+				fastc_bin_file, prefs, environment_c_flags, fastc_generation.c_flags, user_c_flags,
+				environment_ld_flags, is_debug, fastc_generation.uses_threads)
 			if (!silent || show_cc) && fastc_result.command.len > 0 {
 				if c_to_stdout {
 					eprintln('  > ${fastc_result.command}')

--- a/vlib/v3/fastcdriver/fastcdriver.v
+++ b/vlib/v3/fastcdriver/fastcdriver.v
@@ -306,25 +306,25 @@ fn tcc_host_system_flags(target_os string) []string {
 	return flags
 }
 
-// macos_sdk_root finds the macOS SDK: `SDKROOT`, then the SDKs of the command
-// line tools and of Xcode, and only then `xcrun`, which costs several
-// milliseconds per compile.
+// macos_sdk_root finds the selected macOS SDK. SDKROOT and xcrun are
+// authoritative; the conventional locations are fallbacks for an unavailable
+// or broken xcrun.
 fn macos_sdk_root() string {
 	env_root := os.getenv('SDKROOT')
 	if os.is_dir(env_root) {
 		return env_root
-	}
-	for candidate in ['/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk',
-		'/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk'] {
-		if os.is_dir(candidate) {
-			return candidate
-		}
 	}
 	result := cmdexec.run('xcrun', ['--show-sdk-path'])
 	if result.exit_code == 0 {
 		found := result.output.trim_space()
 		if os.is_dir(found) {
 			return found
+		}
+	}
+	for candidate in ['/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk',
+		'/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk'] {
+		if os.is_dir(candidate) {
+			return candidate
 		}
 	}
 	return ''
@@ -504,9 +504,6 @@ pub fn run(args []string) {
 		link_libs << '-lpthread'
 	}
 	link_libs << '-lm'
-	// TinyCC signs the linked executable through `codesign` on macOS; the
-	// shim makes that call a no-op and the executable is signed below.
-	shim_dir := fastc.fastc_codesign_shim_dir()
 	bench_phases := os.getenv('FASTC_BENCH_PHASES') != ''
 	cc_sw := time.new_stopwatch()
 	// The program's translation units are compiled by concurrent TinyCC
@@ -516,6 +513,9 @@ pub fn run(args []string) {
 	if bench_phases {
 		eprintln('fastc-phase tcc.units_written ${cc_sw.elapsed().microseconds()}us units=${unit_paths.len}')
 	}
+	// TinyCC signs the linked executable through `codesign` on macOS; the
+	// shim makes that call a no-op and the executable is signed below.
+	shim_dir := fastc.fastc_codesign_shim_dir()
 	mut result := os.Result{}
 	mut unit_objects := []string{}
 	if unit_paths.len > 1 {
@@ -538,7 +538,10 @@ pub fn run(args []string) {
 			eprintln('fastc-phase tcc.linked ${cc_sw.elapsed().microseconds()}us')
 		}
 	} else {
-		fastc.write_c_pieces(c_path, generation.c_pieces) or { fail(err.msg()) }
+		fastc.write_c_pieces(c_path, generation.c_pieces) or {
+			fastc.fastc_remove_codesign_shim_dir(shim_dir)
+			fail(err.msg())
+		}
 		mut single_args := cc_args.clone()
 		single_args << ['-o', staged_output, c_path]
 		single_args << link_libs
@@ -549,7 +552,7 @@ pub fn run(args []string) {
 	if result.exit_code != 0 {
 		fail(result.output)
 	}
-	if shim_dir != '' {
+	if shim_dir.dir != '' {
 		fastc.fastc_sign_macho_adhoc(staged_output) or {
 			fail('could not sign ${staged_output}: ${err.msg()}')
 		}

--- a/vlib/v3/fastcdriver/fastcdriver.v
+++ b/vlib/v3/fastcdriver/fastcdriver.v
@@ -297,19 +297,37 @@ fn tcc_host_system_flags(target_os string) []string {
 	}
 	mut flags := ['-I/usr/local/include', '-L/usr/local/lib']
 	if target_os == 'macos' {
-		mut sdk_root := os.getenv('SDKROOT')
-		if !os.is_dir(sdk_root) {
-			result := cmdexec.run('xcrun', ['--show-sdk-path'])
-			if result.exit_code == 0 {
-				sdk_root = result.output.trim_space()
-			}
-		}
-		if os.is_dir(sdk_root) {
+		sdk_root := macos_sdk_root()
+		if sdk_root != '' {
 			flags << '-I${os.join_path(sdk_root, 'usr', 'include')}'
 			flags << '-L${os.join_path(sdk_root, 'usr', 'lib')}'
 		}
 	}
 	return flags
+}
+
+// macos_sdk_root finds the macOS SDK: `SDKROOT`, then the SDKs of the command
+// line tools and of Xcode, and only then `xcrun`, which costs several
+// milliseconds per compile.
+fn macos_sdk_root() string {
+	env_root := os.getenv('SDKROOT')
+	if os.is_dir(env_root) {
+		return env_root
+	}
+	for candidate in ['/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk',
+		'/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk'] {
+		if os.is_dir(candidate) {
+			return candidate
+		}
+	}
+	result := cmdexec.run('xcrun', ['--show-sdk-path'])
+	if result.exit_code == 0 {
+		found := result.output.trim_space()
+		if os.is_dir(found) {
+			return found
+		}
+	}
+	return ''
 }
 
 struct FastcBenchSample {
@@ -467,7 +485,6 @@ pub fn run(args []string) {
 	build_prefix := '${output}.fastc-build-${os.getpid()}'
 	c_path := build_prefix + '.c'
 	staged_output := build_prefix + '.out'
-	fastc.write_c_pieces(c_path, generation.c_pieces) or { fail(err.msg()) }
 	tcc_dir := os.join_path(prefs.vroot, 'thirdparty', 'tcc')
 	tcc := os.join_path_single(tcc_dir, 'tcc.exe')
 	tcc_lib := os.join_path_single(tcc_dir, 'lib')
@@ -477,20 +494,73 @@ pub fn run(args []string) {
 	if backtrace_enabled {
 		cc_args << '-bt25'
 	}
-	cc_args << ['-w', '-o', staged_output, c_path]
+	// A call without a prototype would silently truncate a pointer result
+	// (the C carries no headers): it is an error, not a warning.
+	cc_args << '-Werror=implicit-function-declaration'
+	mut link_libs := []string{}
 	if generation.uses_threads {
 		// The emitted spawn runtime calls pthread functions, which live outside
 		// libc on Linux with glibc before 2.34 and on the BSDs.
-		cc_args << '-lpthread'
+		link_libs << '-lpthread'
 	}
-	cc_args << '-lm'
-	result := cmdexec.run(tcc, cc_args)
+	link_libs << '-lm'
+	// TinyCC signs the linked executable through `codesign` on macOS; the
+	// shim makes that call a no-op and the executable is signed below.
+	shim_dir := fastc.fastc_codesign_shim_dir()
+	bench_phases := os.getenv('FASTC_BENCH_PHASES') != ''
+	cc_sw := time.new_stopwatch()
+	// The program's translation units are compiled by concurrent TinyCC
+	// processes and linked; a program that does not split is compiled as
+	// one file.
+	unit_paths := fastc.fastc_write_c_units(build_prefix, generation.c_pieces, generation.units, fastc.fastc_tcc_job_count(prefs)) or { fail(err.msg()) }
+	if bench_phases {
+		eprintln('fastc-phase tcc.units_written ${cc_sw.elapsed().microseconds()}us units=${unit_paths.len}')
+	}
+	mut result := os.Result{}
+	mut unit_objects := []string{}
+	if unit_paths.len > 1 {
+		unit_objects = fastc.fastc_compile_c_units(tcc, cc_args, unit_paths) or {
+			fastc.fastc_remove_codesign_shim_dir(shim_dir)
+			fastc.fastc_remove_c_units(unit_paths)
+			// The whole program is kept as one file for the error message.
+			fastc.write_c_pieces(c_path, generation.c_pieces) or {}
+			fail(err.msg())
+		}
+		if bench_phases {
+			eprintln('fastc-phase tcc.units_compiled ${cc_sw.elapsed().microseconds()}us')
+		}
+		mut link_args := cc_args.clone()
+		link_args << ['-o', staged_output]
+		link_args << unit_objects
+		link_args << link_libs
+		result = fastc.fastc_run_command(tcc, link_args)
+		if bench_phases {
+			eprintln('fastc-phase tcc.linked ${cc_sw.elapsed().microseconds()}us')
+		}
+	} else {
+		fastc.write_c_pieces(c_path, generation.c_pieces) or { fail(err.msg()) }
+		mut single_args := cc_args.clone()
+		single_args << ['-o', staged_output, c_path]
+		single_args << link_libs
+		result = fastc.fastc_run_command(tcc, single_args)
+	}
+	fastc.fastc_remove_codesign_shim_dir(shim_dir)
+	fastc.fastc_remove_c_units(unit_paths)
 	if result.exit_code != 0 {
 		fail(result.output)
 	}
+	if shim_dir != '' {
+		fastc.fastc_sign_macho_adhoc(staged_output) or {
+			fail('could not sign ${staged_output}: ${err.msg()}')
+		}
+	}
 	os.mv(staged_output, output) or { fail(err.msg()) }
 	if keep_c {
-		os.mv(c_path, output + '.c') or { fail(err.msg()) }
+		if unit_paths.len > 1 {
+			fastc.write_c_pieces(output + '.c', generation.c_pieces) or { fail(err.msg()) }
+		} else {
+			os.mv(c_path, output + '.c') or { fail(err.msg()) }
+		}
 	} else {
 		os.rm(c_path) or {}
 	}

--- a/vlib/v3/gen/fastc/c_abi.v
+++ b/vlib/v3/gen/fastc/c_abi.v
@@ -1,0 +1,386 @@
+module fastc
+
+import strings
+
+// The self-host C is emitted without a single `#include`: everything it takes
+// from the C library is declared here, per target, from a table kept in V.
+// The prelude replaces the header block of the preamble, so the declarations
+// below are exactly what TinyCC otherwise parsed out of the system headers
+// (about 60K preprocessed lines per build), and every C function the emitted
+// code may call gets a prototype with its real C types, which keeps argument
+// conversions identical to a header-based build. `-Werror=implicit-function-
+// declaration` is passed along, so a call to a C function missing from the
+// table fails the build instead of being compiled with an implicit `int`
+// signature. c_abi_test.v checks the table against the host headers.
+
+// fastc_c_abi_supported reports whether the header-free prelude is available
+// for a target (the tables cover 64-bit macOS and glibc Linux).
+fn fastc_c_abi_supported(target_os string, target_arch string) bool {
+	if target_os == 'macos' {
+		return target_arch in ['arm64', 'amd64']
+	}
+	if target_os == 'linux' {
+		return target_arch in ['arm64', 'amd64']
+	}
+	return false
+}
+
+// FastcCAbiFunction is one C library function: its C prototype, with `@`
+// standing for the (possibly prefixed) function name, and the asm label the
+// symbol needs on the target ('' for the plain name).
+struct FastcCAbiFunction {
+	name      string
+	prototype string
+	asm_label string
+}
+
+fn fastc_c_abi_fn(name string, prototype string, asm_label string) FastcCAbiFunction {
+	return FastcCAbiFunction{
+		name: name
+		prototype: prototype
+		asm_label: asm_label
+	}
+}
+
+// fastc_c_abi_functions lists the C functions with their prototypes for a
+// target.
+fn fastc_c_abi_functions(target_os string, target_arch string) []FastcCAbiFunction {
+	macos := target_os == 'macos'
+	inode64 := macos && target_arch == 'amd64'
+	realpath_label := if macos { '_realpath\$DARWIN_EXTSN' } else { '' }
+	stat_label := if inode64 { '_stat\$INODE64' } else { '' }
+	lstat_label := if inode64 { '_lstat\$INODE64' } else { '' }
+	fstat_label := if inode64 { '_fstat\$INODE64' } else { '' }
+	opendir_label := if inode64 { '_opendir\$INODE64' } else { '' }
+	readdir_label := if inode64 { '_readdir\$INODE64' } else { '' }
+	mut fns := [
+		fastc_c_abi_fn('malloc', 'void *@(size_t);', ''),
+		fastc_c_abi_fn('calloc', 'void *@(size_t, size_t);', ''),
+		fastc_c_abi_fn('realloc', 'void *@(void *, size_t);', ''),
+		fastc_c_abi_fn('free', 'void @(void *);', ''),
+		fastc_c_abi_fn('aligned_alloc', 'void *@(size_t, size_t);', ''),
+		fastc_c_abi_fn('memcpy', 'void *@(void *, const void *, size_t);', ''),
+		fastc_c_abi_fn('memmove', 'void *@(void *, const void *, size_t);', ''),
+		fastc_c_abi_fn('memset', 'void *@(void *, int, size_t);', ''),
+		fastc_c_abi_fn('memcmp', 'int @(const void *, const void *, size_t);', ''),
+		fastc_c_abi_fn('memchr', 'void *@(const void *, int, size_t);', ''),
+		fastc_c_abi_fn('strlen', 'size_t @(const char *);', ''),
+		fastc_c_abi_fn('strcmp', 'int @(const char *, const char *);', ''),
+		fastc_c_abi_fn('strerror', 'char *@(int);', ''),
+		fastc_c_abi_fn('bzero', 'void @(void *, size_t);', ''),
+		fastc_c_abi_fn('fopen', 'FILE *@(const char *, const char *);', ''),
+		fastc_c_abi_fn('fclose', 'int @(FILE *);', ''),
+		fastc_c_abi_fn('fread', 'size_t @(void *, size_t, size_t, FILE *);', ''),
+		fastc_c_abi_fn('fwrite', 'size_t @(const void *, size_t, size_t, FILE *);', ''),
+		fastc_c_abi_fn('fseek', 'int @(FILE *, long, int);', ''),
+		fastc_c_abi_fn('ftell', 'long @(FILE *);', ''),
+		fastc_c_abi_fn('rewind', 'void @(FILE *);', ''),
+		fastc_c_abi_fn('fflush', 'int @(FILE *);', ''),
+		fastc_c_abi_fn('feof', 'int @(FILE *);', ''),
+		fastc_c_abi_fn('ferror', 'int @(FILE *);', ''),
+		fastc_c_abi_fn('fileno', 'int @(FILE *);', ''),
+		fastc_c_abi_fn('fgets', 'char *@(char *, int, FILE *);', ''),
+		fastc_c_abi_fn('fgetc', 'int @(FILE *);', ''),
+		fastc_c_abi_fn('fputs', 'int @(const char *, FILE *);', ''),
+		fastc_c_abi_fn('fputc', 'int @(int, FILE *);', ''),
+		fastc_c_abi_fn('getchar', 'int @(void);', ''),
+		fastc_c_abi_fn('fprintf', 'int @(FILE *, const char *, ...);', ''),
+		fastc_c_abi_fn('printf', 'int @(const char *, ...);', ''),
+		fastc_c_abi_fn('snprintf', 'int @(char *, size_t, const char *, ...);', ''),
+		fastc_c_abi_fn('setvbuf', 'int @(FILE *, char *, int, size_t);', ''),
+		fastc_c_abi_fn('getline', 'ssize_t @(char **, size_t *, FILE *);', ''),
+		fastc_c_abi_fn('popen', 'FILE *@(const char *, const char *);', ''),
+		fastc_c_abi_fn('pclose', 'int @(FILE *);', ''),
+		fastc_c_abi_fn('open', 'int @(const char *, int, ...);', ''),
+		fastc_c_abi_fn('close', 'int @(int);', ''),
+		fastc_c_abi_fn('read', 'ssize_t @(int, void *, size_t);', ''),
+		fastc_c_abi_fn('write', 'ssize_t @(int, const void *, size_t);', ''),
+		fastc_c_abi_fn('lseek', 'off_t @(int, off_t, int);', ''),
+		fastc_c_abi_fn('fcntl', 'int @(int, int, ...);', ''),
+		fastc_c_abi_fn('ioctl', 'int @(int, unsigned long, ...);', ''),
+		fastc_c_abi_fn('isatty', 'int @(int);', ''),
+		fastc_c_abi_fn('dup2', 'int @(int, int);', ''),
+		fastc_c_abi_fn('pipe', 'int @(int *);', ''),
+		fastc_c_abi_fn('access', 'int @(const char *, int);', ''),
+		fastc_c_abi_fn('chdir', 'int @(const char *);', ''),
+		fastc_c_abi_fn('getcwd', 'char *@(char *, size_t);', ''),
+		fastc_c_abi_fn('mkdir', 'int @(const char *, mode_t);', ''),
+		fastc_c_abi_fn('rmdir', 'int @(const char *);', ''),
+		fastc_c_abi_fn('unlink', 'int @(const char *);', ''),
+		fastc_c_abi_fn('remove', 'int @(const char *);', ''),
+		fastc_c_abi_fn('rename', 'int @(const char *, const char *);', ''),
+		fastc_c_abi_fn('chmod', 'int @(const char *, mode_t);', ''),
+		fastc_c_abi_fn('readlink', 'ssize_t @(const char *, char *, size_t);', ''),
+		fastc_c_abi_fn('realpath', 'char *@(const char *, char *);', realpath_label),
+		fastc_c_abi_fn('stat', 'int @(const char *, struct stat *);', stat_label),
+		fastc_c_abi_fn('lstat', 'int @(const char *, struct stat *);', lstat_label),
+		fastc_c_abi_fn('fstat', 'int @(int, struct stat *);', fstat_label),
+		fastc_c_abi_fn('opendir', 'DIR *@(const char *);', opendir_label),
+		fastc_c_abi_fn('readdir', 'struct dirent *@(DIR *);', readdir_label),
+		fastc_c_abi_fn('closedir', 'int @(DIR *);', ''),
+		fastc_c_abi_fn('getenv', 'char *@(const char *);', ''),
+		fastc_c_abi_fn('setenv', 'int @(const char *, const char *, int);', ''),
+		fastc_c_abi_fn('unsetenv', 'int @(const char *);', ''),
+		fastc_c_abi_fn('exit', 'void @(int);', ''),
+		fastc_c_abi_fn('abort', 'void @(void);', ''),
+		fastc_c_abi_fn('getpid', 'pid_t @(void);', ''),
+		fastc_c_abi_fn('getuid', 'uid_t @(void);', ''),
+		fastc_c_abi_fn('fork', 'pid_t @(void);', ''),
+		fastc_c_abi_fn('execve', 'int @(const char *, char *const *, char *const *);', ''),
+		fastc_c_abi_fn('wait', 'pid_t @(int *);', ''),
+		fastc_c_abi_fn('waitpid', 'pid_t @(pid_t, int *, int);', ''),
+		fastc_c_abi_fn('setpgid', 'int @(pid_t, pid_t);', ''),
+		fastc_c_abi_fn('sysconf', 'long @(int);', ''),
+		fastc_c_abi_fn('pthread_create', 'int @(pthread_t *, const pthread_attr_t *, void *(*)(void *), void *);', ''),
+		fastc_c_abi_fn('pthread_join', 'int @(pthread_t, void **);', ''),
+		fastc_c_abi_fn('pthread_self', 'pthread_t @(void);', ''),
+		fastc_c_abi_fn('pthread_attr_init', 'int @(pthread_attr_t *);', ''),
+		fastc_c_abi_fn('pthread_attr_destroy', 'int @(pthread_attr_t *);', ''),
+		fastc_c_abi_fn('pthread_attr_setstacksize', 'int @(pthread_attr_t *, size_t);', ''),
+		fastc_c_abi_fn('pthread_attr_setdetachstate', 'int @(pthread_attr_t *, int);', ''),
+		fastc_c_abi_fn('pthread_key_create', 'int @(pthread_key_t *, void (*)(void *));', ''),
+		fastc_c_abi_fn('pthread_getspecific', 'void *@(pthread_key_t);', ''),
+		fastc_c_abi_fn('pthread_setspecific', 'int @(pthread_key_t, const void *);', ''),
+		fastc_c_abi_fn('pthread_once', 'int @(pthread_once_t *, void (*)(void));', ''),
+		fastc_c_abi_fn('pthread_mutex_init', 'int @(pthread_mutex_t *, const pthread_mutexattr_t *);', ''),
+		fastc_c_abi_fn('pthread_mutex_lock', 'int @(pthread_mutex_t *);', ''),
+		fastc_c_abi_fn('pthread_mutex_unlock', 'int @(pthread_mutex_t *);', ''),
+		fastc_c_abi_fn('pthread_mutex_destroy', 'int @(pthread_mutex_t *);', ''),
+		fastc_c_abi_fn('clock_gettime', 'int @(clockid_t, struct timespec *);', ''),
+		fastc_c_abi_fn('nanosleep', 'int @(const struct timespec *, struct timespec *);', ''),
+		fastc_c_abi_fn('localtime_r', 'struct tm *@(const time_t *, struct tm *);', ''),
+		fastc_c_abi_fn('time', 'time_t @(time_t *);', ''),
+		fastc_c_abi_fn('mmap', 'void *@(void *, size_t, int, int, int, off_t);', ''),
+		fastc_c_abi_fn('munmap', 'int @(void *, size_t);', ''),
+		fastc_c_abi_fn('select', 'int @(int, fd_set *, fd_set *, fd_set *, struct timeval *);', ''),
+	]
+	if macos {
+		fns << fastc_c_abi_fn('__error', 'int *@(void);', '')
+		fns << fastc_c_abi_fn('mach_absolute_time', 'uint64_t @(void);', '')
+		fns << fastc_c_abi_fn('mach_timebase_info', 'int @(mach_timebase_info_data_t *);', '')
+		fns << fastc_c_abi_fn('clock_gettime_nsec_np', 'uint64_t @(clockid_t);', '')
+		fns << fastc_c_abi_fn('_dyld_get_image_header', 'const struct mach_header *@(uint32_t);', '')
+		fns << fastc_c_abi_fn('_dyld_get_image_name', 'const char *@(uint32_t);', '')
+	} else {
+		fns << fastc_c_abi_fn('__errno_location', 'int *@(void);', '')
+	}
+	return fns
+}
+
+// fastc_c_abi_prelude renders the header-free prelude for a target. `p`
+// prefixes every name the prelude introduces (types, struct tags, macros,
+// functions, globals); it is '' for generation and lets c_abi_test.v compile
+// the prelude next to the real headers.
+fn fastc_c_abi_prelude(target_os string, target_arch string, p string) string {
+	macos := target_os == 'macos'
+	arm := target_arch == 'arm64'
+	// C symbols carry a leading underscore in Mach-O.
+	symbol_prefix := if macos { '_' } else { '' }
+	mut b := strings.new_builder(8192)
+	b.writeln('/* C library declarations for ${target_os}/${target_arch}, from vlib/v3/gen/fastc/c_abi.v (no headers). */')
+	// V's own C helpers (inlined below the preamble) skip their system
+	// includes under this macro.
+	b.writeln('#define V_FASTC_NO_HEADERS 1')
+	b.writeln('typedef signed char ${p}int8_t; typedef short ${p}int16_t; typedef int ${p}int32_t; typedef long long ${p}int64_t;')
+	b.writeln('typedef unsigned char ${p}uint8_t; typedef unsigned short ${p}uint16_t; typedef unsigned int ${p}uint32_t; typedef unsigned long long ${p}uint64_t;')
+	b.writeln('typedef long ${p}intptr_t; typedef unsigned long ${p}uintptr_t; typedef unsigned long ${p}size_t; typedef long ${p}ssize_t;')
+	b.writeln('typedef long ${p}off_t; typedef int ${p}pid_t; typedef unsigned int ${p}uid_t; typedef unsigned int ${p}gid_t; typedef long ${p}time_t;')
+	b.writeln('#define ${p}NULL ((void *)0)')
+	if macos {
+		b.writeln('typedef unsigned short ${p}mode_t; typedef int ${p}dev_t; typedef unsigned short ${p}nlink_t; typedef unsigned long long ${p}ino_t;')
+		b.writeln('typedef unsigned int ${p}clockid_t; typedef int ${p}suseconds_t;')
+		b.writeln('typedef struct __sFILE ${p}FILE;')
+		b.writeln('typedef struct ${p}v_dir ${p}DIR;')
+		b.writeln('struct ${p}timespec { long tv_sec; long tv_nsec; };')
+		b.writeln('struct ${p}timeval { long tv_sec; ${p}suseconds_t tv_usec; };')
+		b.writeln('struct ${p}stat { ${p}dev_t st_dev; ${p}mode_t st_mode; ${p}nlink_t st_nlink; ${p}ino_t st_ino; ${p}uid_t st_uid; ${p}gid_t st_gid; ${p}dev_t st_rdev; struct ${p}timespec st_atimespec; struct ${p}timespec st_mtimespec; struct ${p}timespec st_ctimespec; struct ${p}timespec st_birthtimespec; ${p}off_t st_size; long long st_blocks; int st_blksize; unsigned int st_flags; unsigned int st_gen; int st_lspare; long long st_qspare[2]; };')
+		b.writeln('#define ${p}st_atime st_atimespec.tv_sec')
+		b.writeln('#define ${p}st_mtime st_mtimespec.tv_sec')
+		b.writeln('#define ${p}st_ctime st_ctimespec.tv_sec')
+		b.writeln('struct ${p}dirent { unsigned long long d_ino; unsigned long long d_seekoff; unsigned short d_reclen; unsigned short d_namlen; unsigned char d_type; char d_name[1024]; };')
+		b.writeln('typedef struct ${p}v_opaque_pthread *${p}pthread_t;')
+		b.writeln('typedef struct { long __sig; char __opaque[56]; } ${p}pthread_attr_t;')
+		b.writeln('typedef struct { long __sig; char __opaque[56]; } ${p}pthread_mutex_t;')
+		b.writeln('typedef struct { long __sig; char __opaque[8]; } ${p}pthread_mutexattr_t;')
+		b.writeln('typedef struct { long __sig; char __opaque[8]; } ${p}pthread_once_t;')
+		b.writeln('#define ${p}PTHREAD_ONCE_INIT {0x30B1BCBA, {0}}')
+		b.writeln('typedef unsigned long ${p}pthread_key_t;')
+		b.writeln('typedef struct { ${p}uint32_t numer; ${p}uint32_t denom; } ${p}mach_timebase_info_data_t;')
+		b.writeln('struct mach_header;')
+		b.writeln('#define ${p}PTHREAD_CREATE_DETACHED 2')
+		b.writeln('typedef struct { ${p}int32_t fds_bits[32]; } ${p}fd_set;')
+		b.writeln('#define ${p}FD_SETSIZE 1024')
+		b.writeln('#define ${p}FD_ZERO(set) ${p}memset((set), 0, sizeof(*(set)))')
+		b.writeln('#define ${p}FD_SET(fd, set) ((set)->fds_bits[(fd) / 32] |= (${p}int32_t)(1U << ((fd) % 32)))')
+		b.writeln('#define ${p}FD_ISSET(fd, set) (((set)->fds_bits[(fd) / 32] & (${p}int32_t)(1U << ((fd) % 32))) != 0)')
+		b.writeln('extern ${p}FILE *__stdinp; extern ${p}FILE *__stdoutp; extern ${p}FILE *__stderrp;')
+		b.writeln('#define ${p}stdin __stdinp')
+		b.writeln('#define ${p}stdout __stdoutp')
+		b.writeln('#define ${p}stderr __stderrp')
+		b.writeln('#define ${p}errno (*${p}__error())')
+		b.writeln('#define ${p}O_RDONLY 0')
+		b.writeln('#define ${p}O_WRONLY 1')
+		b.writeln('#define ${p}O_RDWR 2')
+		b.writeln('#define ${p}O_APPEND 0x8')
+		b.writeln('#define ${p}O_CREAT 0x200')
+		b.writeln('#define ${p}O_TRUNC 0x400')
+		b.writeln('#define ${p}O_EXCL 0x800')
+		b.writeln('#define ${p}O_CLOEXEC 0x1000000')
+		b.writeln('#define ${p}EAGAIN 35')
+		b.writeln('#define ${p}BUFSIZ 1024')
+		b.writeln('#define ${p}MAP_ANONYMOUS 0x1000')
+		b.writeln('#define ${p}CLOCK_MONOTONIC 6')
+		b.writeln('#define ${p}_SC_NPROCESSORS_ONLN 58')
+		b.writeln('#define ${p}FIONREAD 0x4004667fUL')
+	} else {
+		b.writeln('typedef unsigned int ${p}mode_t; typedef unsigned long ${p}dev_t; typedef unsigned long ${p}ino_t;')
+		if arm {
+			b.writeln('typedef unsigned int ${p}nlink_t;')
+		} else {
+			b.writeln('typedef unsigned long ${p}nlink_t;')
+		}
+		b.writeln('typedef int ${p}clockid_t; typedef long ${p}suseconds_t;')
+		b.writeln('typedef struct _IO_FILE ${p}FILE;')
+		b.writeln('typedef struct __dirstream ${p}DIR;')
+		b.writeln('struct ${p}timespec { long tv_sec; long tv_nsec; };')
+		b.writeln('struct ${p}timeval { long tv_sec; ${p}suseconds_t tv_usec; };')
+		if arm {
+			b.writeln('struct ${p}stat { ${p}dev_t st_dev; ${p}ino_t st_ino; ${p}mode_t st_mode; ${p}nlink_t st_nlink; ${p}uid_t st_uid; ${p}gid_t st_gid; ${p}dev_t st_rdev; unsigned long __pad1; ${p}off_t st_size; int st_blksize; int __pad2; long st_blocks; struct ${p}timespec st_atim; struct ${p}timespec st_mtim; struct ${p}timespec st_ctim; unsigned int __unused[2]; };')
+		} else {
+			b.writeln('struct ${p}stat { ${p}dev_t st_dev; ${p}ino_t st_ino; ${p}nlink_t st_nlink; ${p}mode_t st_mode; ${p}uid_t st_uid; ${p}gid_t st_gid; int __pad0; ${p}dev_t st_rdev; ${p}off_t st_size; long st_blksize; long st_blocks; struct ${p}timespec st_atim; struct ${p}timespec st_mtim; struct ${p}timespec st_ctim; long __unused[3]; };')
+		}
+		b.writeln('#define ${p}st_atime st_atim.tv_sec')
+		b.writeln('#define ${p}st_mtime st_mtim.tv_sec')
+		b.writeln('#define ${p}st_ctime st_ctim.tv_sec')
+		b.writeln('struct ${p}dirent { unsigned long d_ino; long d_off; unsigned short d_reclen; unsigned char d_type; char d_name[256]; };')
+		b.writeln('typedef unsigned long ${p}pthread_t;')
+		if arm {
+			b.writeln('typedef union { char __size[64]; long __align; } ${p}pthread_attr_t;')
+			b.writeln('typedef union { char __size[48]; long __align; } ${p}pthread_mutex_t;')
+		} else {
+			b.writeln('typedef union { char __size[56]; long __align; } ${p}pthread_attr_t;')
+			b.writeln('typedef union { char __size[40]; long __align; } ${p}pthread_mutex_t;')
+		}
+		b.writeln('typedef union { char __size[4]; int __align; } ${p}pthread_mutexattr_t;')
+		b.writeln('typedef int ${p}pthread_once_t;')
+		b.writeln('#define ${p}PTHREAD_ONCE_INIT 0')
+		b.writeln('typedef unsigned int ${p}pthread_key_t;')
+		b.writeln('#define ${p}PTHREAD_CREATE_DETACHED 1')
+		b.writeln('typedef struct { long fds_bits[16]; } ${p}fd_set;')
+		b.writeln('#define ${p}FD_SETSIZE 1024')
+		b.writeln('#define ${p}FD_ZERO(set) ${p}memset((set), 0, sizeof(*(set)))')
+		b.writeln('#define ${p}FD_SET(fd, set) ((set)->fds_bits[(fd) / 64] |= (1UL << ((fd) % 64)))')
+		b.writeln('#define ${p}FD_ISSET(fd, set) (((set)->fds_bits[(fd) / 64] & (1UL << ((fd) % 64))) != 0)')
+		b.writeln('extern ${p}FILE *stdin; extern ${p}FILE *stdout; extern ${p}FILE *stderr;')
+		if p != '' {
+			b.writeln('#define ${p}stdin stdin')
+			b.writeln('#define ${p}stdout stdout')
+			b.writeln('#define ${p}stderr stderr')
+		}
+		b.writeln('#define ${p}errno (*${p}__errno_location())')
+		b.writeln('#define ${p}O_RDONLY 0')
+		b.writeln('#define ${p}O_WRONLY 1')
+		b.writeln('#define ${p}O_RDWR 2')
+		b.writeln('#define ${p}O_APPEND 02000')
+		b.writeln('#define ${p}O_CREAT 0100')
+		b.writeln('#define ${p}O_TRUNC 01000')
+		b.writeln('#define ${p}O_EXCL 0200')
+		b.writeln('#define ${p}O_CLOEXEC 02000000')
+		b.writeln('#define ${p}EAGAIN 11')
+		b.writeln('#define ${p}BUFSIZ 8192')
+		b.writeln('#define ${p}MAP_ANONYMOUS 0x20')
+		b.writeln('#define ${p}CLOCK_MONOTONIC 1')
+		b.writeln('#define ${p}_SC_NPROCESSORS_ONLN 84')
+		b.writeln('#define ${p}FIONREAD 0x541B')
+	}
+	b.writeln('struct ${p}tm { int tm_sec; int tm_min; int tm_hour; int tm_mday; int tm_mon; int tm_year; int tm_wday; int tm_yday; int tm_isdst; long tm_gmtoff; char *tm_zone; };')
+	if p == '' {
+		b.writeln('extern char **environ;')
+	} else {
+		b.writeln('extern char **${p}environ __asm__("${symbol_prefix}environ");')
+	}
+	b.writeln('#define ${p}S_IRUSR 0400')
+	b.writeln('#define ${p}S_IWUSR 0200')
+	b.writeln('#define ${p}S_IXUSR 0100')
+	b.writeln('#define ${p}S_IRGRP 040')
+	b.writeln('#define ${p}S_IWGRP 020')
+	b.writeln('#define ${p}S_IXGRP 010')
+	b.writeln('#define ${p}S_IROTH 04')
+	b.writeln('#define ${p}S_IWOTH 02')
+	b.writeln('#define ${p}S_IXOTH 01')
+	b.writeln('#define ${p}S_IFMT 0170000')
+	b.writeln('#define ${p}S_IFDIR 0040000')
+	b.writeln('#define ${p}S_IFREG 0100000')
+	b.writeln('#define ${p}S_IFLNK 0120000')
+	b.writeln('#define ${p}S_IFSOCK 0140000')
+	b.writeln('#define ${p}S_IFIFO 0010000')
+	b.writeln('#define ${p}S_IFCHR 0020000')
+	b.writeln('#define ${p}S_IFBLK 0060000')
+	b.writeln('#define ${p}F_GETFD 1')
+	b.writeln('#define ${p}F_SETFD 2')
+	b.writeln('#define ${p}FD_CLOEXEC 1')
+	b.writeln('#define ${p}EINTR 4')
+	b.writeln('#define ${p}ENOENT 2')
+	b.writeln('#define ${p}EEXIST 17')
+	b.writeln('#define ${p}SEEK_SET 0')
+	b.writeln('#define ${p}SEEK_CUR 1')
+	b.writeln('#define ${p}SEEK_END 2')
+	b.writeln('#define ${p}EOF (-1)')
+	b.writeln('#define ${p}_IOFBF 0')
+	b.writeln('#define ${p}_IOLBF 1')
+	b.writeln('#define ${p}_IONBF 2')
+	b.writeln('#define ${p}PROT_READ 1')
+	b.writeln('#define ${p}PROT_WRITE 2')
+	b.writeln('#define ${p}MAP_PRIVATE 2')
+	b.writeln('#define ${p}MAP_FAILED ((void *)-1)')
+	b.writeln('#define ${p}CLOCK_REALTIME 0')
+	b.writeln('#define ${p}WNOHANG 1')
+	b.writeln('#define ${p}STDIN_FILENO 0')
+	b.writeln('#define ${p}STDOUT_FILENO 1')
+	b.writeln('#define ${p}STDERR_FILENO 2')
+	for f in fastc_c_abi_functions(target_os, target_arch) {
+		// Only the function name takes the prefix: the test compiles these
+		// prototypes against the real headers' types and compares them.
+		mut line := f.prototype.replace('@', p + f.name)
+		mut asm_label := f.asm_label
+		if p != '' && asm_label == '' {
+			// The prefixed prototypes of the test still bind to the real
+			// symbols, so its runtime checks call the C library.
+			asm_label = symbol_prefix + f.name
+		}
+		if asm_label != '' {
+			line = line.trim_right(';') + ' __asm__("${asm_label}");'
+		}
+		b.writeln(line)
+	}
+	b.writeln('')
+	return b.str()
+}
+
+// fastc_c_directive_quoted_include_path returns the path of an
+// `#include "path"` directive line, or none for a system include.
+fn fastc_c_directive_quoted_include_path(source string, start int, end int) ?string {
+	line := source[start..end]
+	open_quote := line.index('"') or { return none }
+	close_quote := line.index_after_('"', open_quote + 1)
+	if close_quote < 0 {
+		return none
+	}
+	return line[open_quote + 1..close_quote]
+}
+
+// fastc_c_directive_is_include reports whether the directive line at
+// source[start..end] is an `#include`.
+@[direct_array_access]
+fn fastc_c_directive_is_include(source string, start int, end int) bool {
+	mut i := start
+	if i >= end || source[i] != `#` {
+		return false
+	}
+	i++
+	for i < end && source[i] in [` `, `\t`] {
+		i++
+	}
+	return end - i >= 7 && source[i] == `i` && source[i + 1] == `n` && source[i + 2] == `c`
+		&& source[i + 3] == `l` && source[i + 4] == `u` && source[i + 5] == `d` && source[i + 6] == `e`
+}

--- a/vlib/v3/gen/fastc/c_abi.v
+++ b/vlib/v3/gen/fastc/c_abi.v
@@ -1,5 +1,6 @@
 module fastc
 
+import os
 import strings
 
 // The self-host C is emitted without a single `#include`: everything it takes
@@ -13,14 +14,35 @@ import strings
 // table fails the build instead of being compiled with an implicit `int`
 // signature. c_abi_test.v checks the table against the host headers.
 
+// fastc_host_uses_glibc reports whether this Linux process has positively
+// identifiable glibc objects loaded. A static process or an unavailable procfs
+// deliberately returns false: retaining the system headers is the safe fallback.
+fn fastc_host_uses_glibc() bool {
+	if os.user_os() != 'linux' {
+		return false
+	}
+	maps := os.read_file('/proc/self/maps') or { return false }
+	for line in maps.split_into_lines() {
+		base := os.file_name(line.all_after_last(' '))
+		if base == 'libc.so.6' || base.starts_with('ld-linux-') {
+			return true
+		}
+		if base.starts_with('libc-') && base.ends_with('.so') && base.len > 'libc-.so'.len
+			&& base['libc-'.len].is_digit() {
+			return true
+		}
+	}
+	return false
+}
+
 // fastc_c_abi_supported reports whether the header-free prelude is available
 // for a target (the tables cover 64-bit macOS and glibc Linux).
-fn fastc_c_abi_supported(target_os string, target_arch string) bool {
+fn fastc_c_abi_supported(target_os string, target_arch string, host_uses_glibc bool) bool {
 	if target_os == 'macos' {
 		return target_arch in ['arm64', 'amd64']
 	}
 	if target_os == 'linux' {
-		return target_arch in ['arm64', 'amd64']
+		return host_uses_glibc && target_arch in ['arm64', 'amd64']
 	}
 	return false
 }

--- a/vlib/v3/gen/fastc/c_abi.v
+++ b/vlib/v3/gen/fastc/c_abi.v
@@ -69,6 +69,7 @@ fn fastc_c_abi_functions(target_os string, target_arch string) []FastcCAbiFuncti
 		fastc_c_abi_fn('strerror', 'char *@(int);', ''),
 		fastc_c_abi_fn('bzero', 'void @(void *, size_t);', ''),
 		fastc_c_abi_fn('fopen', 'FILE *@(const char *, const char *);', ''),
+		fastc_c_abi_fn('fdopen', 'FILE *@(int, const char *);', ''),
 		fastc_c_abi_fn('fclose', 'int @(FILE *);', ''),
 		fastc_c_abi_fn('fread', 'size_t @(void *, size_t, size_t, FILE *);', ''),
 		fastc_c_abi_fn('fwrite', 'size_t @(const void *, size_t, size_t, FILE *);', ''),
@@ -96,6 +97,8 @@ fn fastc_c_abi_functions(target_os string, target_arch string) []FastcCAbiFuncti
 		fastc_c_abi_fn('read', 'ssize_t @(int, void *, size_t);', ''),
 		fastc_c_abi_fn('write', 'ssize_t @(int, const void *, size_t);', ''),
 		fastc_c_abi_fn('lseek', 'off_t @(int, off_t, int);', ''),
+		fastc_c_abi_fn('ftruncate', 'int @(int, off_t);', ''),
+		fastc_c_abi_fn('symlink', 'int @(const char *, const char *);', ''),
 		fastc_c_abi_fn('fcntl', 'int @(int, int, ...);', ''),
 		fastc_c_abi_fn('ioctl', 'int @(int, unsigned long, ...);', ''),
 		fastc_c_abi_fn('isatty', 'int @(int);', ''),
@@ -156,6 +159,7 @@ fn fastc_c_abi_functions(target_os string, target_arch string) []FastcCAbiFuncti
 	]
 	if macos {
 		fns << fastc_c_abi_fn('__error', 'int *@(void);', '')
+		fns << fastc_c_abi_fn('CC_SHA256', 'unsigned char *@(const void *, unsigned int, unsigned char *);', '')
 		fns << fastc_c_abi_fn('mach_absolute_time', 'uint64_t @(void);', '')
 		fns << fastc_c_abi_fn('mach_timebase_info', 'int @(mach_timebase_info_data_t *);', '')
 		fns << fastc_c_abi_fn('clock_gettime_nsec_np', 'uint64_t @(clockid_t);', '')
@@ -226,6 +230,9 @@ fn fastc_c_abi_prelude(target_os string, target_arch string, p string) string {
 		b.writeln('#define ${p}O_TRUNC 0x400')
 		b.writeln('#define ${p}O_EXCL 0x800')
 		b.writeln('#define ${p}O_CLOEXEC 0x1000000')
+		b.writeln('#define ${p}O_SYNC 0x80')
+		b.writeln('#define ${p}O_NONBLOCK 0x4')
+		b.writeln('#define ${p}O_NOCTTY 0x20000')
 		b.writeln('#define ${p}EAGAIN 35')
 		b.writeln('#define ${p}BUFSIZ 1024')
 		b.writeln('#define ${p}MAP_ANONYMOUS 0x1000')
@@ -286,6 +293,9 @@ fn fastc_c_abi_prelude(target_os string, target_arch string, p string) string {
 		b.writeln('#define ${p}O_TRUNC 01000')
 		b.writeln('#define ${p}O_EXCL 0200')
 		b.writeln('#define ${p}O_CLOEXEC 02000000')
+		b.writeln('#define ${p}O_SYNC 04010000')
+		b.writeln('#define ${p}O_NONBLOCK 04000')
+		b.writeln('#define ${p}O_NOCTTY 0400')
 		b.writeln('#define ${p}EAGAIN 11')
 		b.writeln('#define ${p}BUFSIZ 8192')
 		b.writeln('#define ${p}MAP_ANONYMOUS 0x20')

--- a/vlib/v3/gen/fastc/c_abi_test.v
+++ b/vlib/v3/gen/fastc/c_abi_test.v
@@ -9,7 +9,7 @@ import os
 fn test_c_abi_prelude_matches_host_headers() {
 	host_os := os.user_os()
 	host_arch := $if arm64 { 'arm64' } $else $if amd64 { 'amd64' } $else { '' }
-	if !fastc_c_abi_supported(host_os, host_arch) {
+	if !fastc_c_abi_supported(host_os, host_arch, fastc_host_uses_glibc()) {
 		return
 	}
 	tcc := os.join_path(@VEXEROOT, 'thirdparty', 'tcc', 'tcc.exe')
@@ -49,6 +49,15 @@ fn test_c_abi_prelude_matches_host_headers() {
 	run := os.execute(exe_path)
 	assert run.exit_code == 0, run.output
 	assert run.output.trim_space() == 'ok', run.output
+}
+
+fn test_c_abi_prelude_requires_glibc_on_linux() {
+	for arch in ['amd64', 'arm64'] {
+		assert fastc_c_abi_supported('linux', arch, true)
+		assert !fastc_c_abi_supported('linux', arch, false)
+	}
+	assert fastc_c_abi_supported('macos', 'amd64', false)
+	assert !fastc_c_abi_supported('linux', 'x86', true)
 }
 
 // fastc_c_abi_check_source renders the C program that compares the prefixed

--- a/vlib/v3/gen/fastc/c_abi_test.v
+++ b/vlib/v3/gen/fastc/c_abi_test.v
@@ -1,0 +1,162 @@
+module fastc
+
+import os
+
+// The header-free prelude is checked against the host's own headers: every
+// struct layout, type size, macro value and function prototype the table
+// declares must agree with what the system headers say, on the machine
+// running the tests (macOS and glibc Linux tables).
+fn test_c_abi_prelude_matches_host_headers() {
+	host_os := os.user_os()
+	host_arch := $if arm64 { 'arm64' } $else $if amd64 { 'amd64' } $else { '' }
+	if !fastc_c_abi_supported(host_os, host_arch) {
+		return
+	}
+	tcc := os.join_path(@VEXEROOT, 'thirdparty', 'tcc', 'tcc.exe')
+	if !os.is_file(tcc) {
+		return
+	}
+	prelude := fastc_c_abi_prelude(host_os, host_arch, 'v_abi_')
+	assert !prelude.contains('#include')
+	source := fastc_c_abi_check_source(host_os, prelude)
+	test_dir := os.join_path(os.temp_dir(), 'fastc_c_abi_${os.getpid()}')
+	os.mkdir_all(test_dir) or { panic(err) }
+	defer {
+		os.rmdir_all(test_dir) or {}
+	}
+	source_path := os.join_path_single(test_dir, 'abi_check.c')
+	exe_path := os.join_path_single(test_dir, 'abi_check')
+	os.write_file(source_path, source) or { panic(err) }
+	tcc_lib := os.join_path(@VEXEROOT, 'thirdparty', 'tcc', 'lib')
+	mut args := ['-std=gnu11', '-B${tcc_lib}', '-I${os.join_path_single(tcc_lib, 'include')}',
+		'-L${tcc_lib}', '-I/usr/local/include', '-L/usr/local/lib']
+	if host_os == 'macos' {
+		mut sdk_root := os.getenv('SDKROOT')
+		if !os.is_dir(sdk_root) {
+			result := os.execute('xcrun --show-sdk-path')
+			if result.exit_code == 0 {
+				sdk_root = result.output.trim_space()
+			}
+		}
+		if os.is_dir(sdk_root) {
+			args << '-I${os.join_path(sdk_root, 'usr', 'include')}'
+			args << '-L${os.join_path(sdk_root, 'usr', 'lib')}'
+		}
+	}
+	args << ['-w', '-o', exe_path, source_path, '-lpthread', '-lm']
+	compile := os.execute('${tcc} ${args.join(' ')}')
+	assert compile.exit_code == 0, compile.output
+	run := os.execute(exe_path)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == 'ok', run.output
+}
+
+// fastc_c_abi_check_source renders the C program that compares the prefixed
+// prelude with the real headers: static assertions for layouts, values and
+// prototypes, and runtime checks for the initializers and fd_set macros.
+fn fastc_c_abi_check_source(host_os string, prelude string) string {
+	macos := host_os == 'macos'
+	mut out := []string{}
+	out << '#include <stdint.h>'
+	out << '#include <stdio.h>'
+	out << '#include <stdlib.h>'
+	out << '#include <string.h>'
+	out << '#include <strings.h>'
+	out << '#include <stddef.h>'
+	out << '#include <pthread.h>'
+	out << '#include <sys/stat.h>'
+	out << '#include <sys/types.h>'
+	out << '#include <sys/select.h>'
+	out << '#include <sys/ioctl.h>'
+	out << '#include <sys/mman.h>'
+	out << '#include <sys/wait.h>'
+	out << '#include <errno.h>'
+	out << '#include <dirent.h>'
+	out << '#include <unistd.h>'
+	out << '#include <fcntl.h>'
+	out << '#include <time.h>'
+	if macos {
+		out << '#include <mach/mach_time.h>'
+		out << '#include <mach-o/dyld.h>'
+	}
+	// Some libcs spell these as macros; the prototypes are compared as functions.
+	for name in ['feof', 'ferror', 'fileno', 'getchar', 'fgetc', 'fputc', 'stat', 'lstat', 'fstat'] {
+		out << '#undef ${name}'
+	}
+	// unistd.h does not declare environ on macOS; the prelude declares its own.
+	out << 'extern char **environ;'
+	out << prelude
+	out << '#define CHECK_EQ(a, b) _Static_assert((a) == (b), #a " == " #b)'
+	out << '#define CHECK_SIZE(t) _Static_assert(sizeof(v_abi_##t) == sizeof(t), "sizeof " #t)'
+	out << '#define CHECK_STRUCT_SIZE(t) _Static_assert(sizeof(struct v_abi_##t) == sizeof(struct t), "sizeof struct " #t)'
+	out << '#define CHECK_FIELD(t, f) _Static_assert(offsetof(struct v_abi_##t, f) == offsetof(struct t, f), "offset " #t "." #f); _Static_assert(sizeof(((struct v_abi_##t *)0)->f) == sizeof(((struct t *)0)->f), "size " #t "." #f)'
+	out << '#define CHECK_FN(f) _Static_assert(__builtin_types_compatible_p(__typeof__(v_abi_##f), __typeof__(f)), "prototype " #f)'
+	mut macros := ['O_RDONLY', 'O_WRONLY', 'O_RDWR', 'O_APPEND', 'O_CREAT', 'O_TRUNC', 'O_EXCL',
+		'O_CLOEXEC', 'S_IRUSR', 'S_IWUSR', 'S_IXUSR', 'S_IRGRP', 'S_IWGRP', 'S_IXGRP', 'S_IROTH',
+		'S_IWOTH', 'S_IXOTH', 'S_IFMT', 'S_IFDIR', 'S_IFREG', 'S_IFLNK', 'S_IFSOCK', 'S_IFIFO',
+		'S_IFCHR', 'S_IFBLK', 'F_GETFD', 'F_SETFD', 'FD_CLOEXEC', 'EINTR', 'EAGAIN', 'ENOENT',
+		'EEXIST', 'SEEK_SET', 'SEEK_CUR', 'SEEK_END', 'EOF', '_IOFBF', '_IOLBF', '_IONBF', 'BUFSIZ',
+		'PROT_READ', 'PROT_WRITE', 'MAP_PRIVATE', 'MAP_ANONYMOUS', 'CLOCK_REALTIME', 'CLOCK_MONOTONIC',
+		'WNOHANG', '_SC_NPROCESSORS_ONLN', 'STDIN_FILENO', 'STDOUT_FILENO', 'STDERR_FILENO',
+		'FIONREAD', 'FD_SETSIZE', 'PTHREAD_CREATE_DETACHED']
+	for name in macros {
+		out << 'CHECK_EQ(v_abi_${name}, ${name});'
+	}
+	out << 'CHECK_EQ((long)v_abi_MAP_FAILED, (long)MAP_FAILED);'
+	for name in ['int8_t', 'int16_t', 'int32_t', 'int64_t', 'uint8_t', 'uint16_t', 'uint32_t',
+		'uint64_t', 'intptr_t', 'uintptr_t', 'size_t', 'ssize_t', 'off_t', 'pid_t', 'uid_t', 'gid_t',
+		'time_t', 'mode_t', 'dev_t', 'nlink_t', 'ino_t', 'clockid_t', 'suseconds_t', 'pthread_t',
+		'pthread_attr_t', 'pthread_mutex_t', 'pthread_mutexattr_t', 'pthread_once_t', 'pthread_key_t',
+		'fd_set'] {
+		out << 'CHECK_SIZE(${name});'
+	}
+	if macos {
+		out << 'CHECK_SIZE(mach_timebase_info_data_t);'
+		out << 'CHECK_EQ(offsetof(v_abi_mach_timebase_info_data_t, denom), offsetof(mach_timebase_info_data_t, denom));'
+	}
+	for name in ['stat', 'dirent', 'timespec', 'timeval', 'tm'] {
+		out << 'CHECK_STRUCT_SIZE(${name});'
+	}
+	for field in ['st_dev', 'st_mode', 'st_nlink', 'st_ino', 'st_uid', 'st_gid', 'st_rdev', 'st_size',
+		'st_blocks', 'st_blksize'] {
+		out << 'CHECK_FIELD(stat, ${field});'
+	}
+	for field in ['st_atime', 'st_mtime', 'st_ctime'] {
+		out << 'CHECK_EQ(offsetof(struct v_abi_stat, v_abi_${field}), offsetof(struct stat, ${field}));'
+	}
+	for field in ['d_ino', 'd_reclen', 'd_type', 'd_name'] {
+		out << 'CHECK_FIELD(dirent, ${field});'
+	}
+	for field in ['tv_sec', 'tv_nsec'] {
+		out << 'CHECK_FIELD(timespec, ${field});'
+	}
+	for field in ['tv_sec', 'tv_usec'] {
+		out << 'CHECK_FIELD(timeval, ${field});'
+	}
+	for field in ['tm_sec', 'tm_min', 'tm_hour', 'tm_mday', 'tm_mon', 'tm_year', 'tm_wday', 'tm_yday',
+		'tm_isdst', 'tm_gmtoff', 'tm_zone'] {
+		out << 'CHECK_FIELD(tm, ${field});'
+	}
+	for f in fastc_c_abi_functions(host_os, if macos { 'arm64' } else { 'amd64' }) {
+		out << 'CHECK_FN(${f.name});'
+	}
+	out << 'int main(void) {'
+	out << '\tv_abi_pthread_once_t mine = v_abi_PTHREAD_ONCE_INIT;'
+	out << '\tpthread_once_t real = PTHREAD_ONCE_INIT;'
+	out << '\tif (memcmp(&mine, &real, sizeof(real)) != 0) { puts("PTHREAD_ONCE_INIT differs"); return 1; }'
+	out << '\tv_abi_fd_set my_set; fd_set real_set;'
+	out << '\tv_abi_FD_ZERO(&my_set); FD_ZERO(&real_set);'
+	out << '\tv_abi_FD_SET(3, &my_set); FD_SET(3, &real_set);'
+	out << '\tv_abi_FD_SET(63, &my_set); FD_SET(63, &real_set);'
+	out << '\tv_abi_FD_SET(64, &my_set); FD_SET(64, &real_set);'
+	out << '\tv_abi_FD_SET(1000, &my_set); FD_SET(1000, &real_set);'
+	out << '\tif (memcmp(&my_set, &real_set, sizeof(real_set)) != 0) { puts("FD_SET differs"); return 1; }'
+	out << '\tif (!v_abi_FD_ISSET(64, &my_set) || v_abi_FD_ISSET(65, &my_set)) { puts("FD_ISSET differs"); return 1; }'
+	out << '\tif (v_abi_errno != errno) { puts("errno differs"); return 1; }'
+	out << '\tif (v_abi_stdout != stdout || v_abi_stderr != stderr || v_abi_stdin != stdin) { puts("stdio streams differ"); return 1; }'
+	out << '\tif (v_abi_environ != environ) { puts("environ differs"); return 1; }'
+	out << '\tputs("ok");'
+	out << '\treturn 0;'
+	out << '}'
+	return out.join('\n') + '\n'
+}

--- a/vlib/v3/gen/fastc/c_abi_test.v
+++ b/vlib/v3/gen/fastc/c_abi_test.v
@@ -72,6 +72,9 @@ fn fastc_c_abi_check_source(host_os string, prelude string) string {
 	out << '#include <sys/wait.h>'
 	out << '#include <errno.h>'
 	out << '#include <dirent.h>'
+	if macos {
+		out << '#include <CommonCrypto/CommonDigest.h>'
+	}
 	out << '#include <unistd.h>'
 	out << '#include <fcntl.h>'
 	out << '#include <time.h>'
@@ -93,6 +96,9 @@ fn fastc_c_abi_check_source(host_os string, prelude string) string {
 	out << '#define CHECK_FN(f) _Static_assert(__builtin_types_compatible_p(__typeof__(v_abi_##f), __typeof__(f)), "prototype " #f)'
 	mut macros := ['O_RDONLY', 'O_WRONLY', 'O_RDWR', 'O_APPEND', 'O_CREAT', 'O_TRUNC', 'O_EXCL',
 		'O_CLOEXEC', 'S_IRUSR', 'S_IWUSR', 'S_IXUSR', 'S_IRGRP', 'S_IWGRP', 'S_IXGRP', 'S_IROTH',
+		'O_SYNC', 'S_IRUSR', 'S_IWUSR', 'S_IXUSR', 'S_IRGRP', 'S_IWGRP', 'S_IXGRP', 'S_IROTH',
+		'O_NONBLOCK', 'S_IRUSR', 'S_IWUSR', 'S_IXUSR', 'S_IRGRP', 'S_IWGRP', 'S_IXGRP', 'S_IROTH',
+		'O_NOCTTY', 'S_IRUSR', 'S_IWUSR', 'S_IXUSR', 'S_IRGRP', 'S_IWGRP', 'S_IXGRP', 'S_IROTH',
 		'S_IWOTH', 'S_IXOTH', 'S_IFMT', 'S_IFDIR', 'S_IFREG', 'S_IFLNK', 'S_IFSOCK', 'S_IFIFO',
 		'S_IFCHR', 'S_IFBLK', 'F_GETFD', 'F_SETFD', 'FD_CLOEXEC', 'EINTR', 'EAGAIN', 'ENOENT',
 		'EEXIST', 'SEEK_SET', 'SEEK_CUR', 'SEEK_END', 'EOF', '_IOFBF', '_IOLBF', '_IONBF', 'BUFSIZ',

--- a/vlib/v3/gen/fastc/decl.v
+++ b/vlib/v3/gen/fastc/decl.v
@@ -614,7 +614,7 @@ fn fastc_merge_declaration_partial(partial FastcDeclarationPartial, mut declared
 	}
 }
 
-fn fastc_generate_global_declarations(ordered_sources []FastcSourceFile, global_sources map[string]string, prefs &pref.Preferences, declared_types map[string]bool, declared_type_c_names map[string]string, fastc_prefixed_c_names []string, declared_kinds map[string]FastcDeclaredTypeKind, enum_flags map[string]bool, enum_field_types map[string]string, alias_base_types map[string]string, struct_fields map[string]map[string]string, struct_field_info map[string][]FastcStructField, functions map[string]FastcFunctionSignature, constants map[string]string, constant_values map[string]string, public_constants map[string]bool, constant_types map[string]string, globals map[string]string, public_globals map[string]bool, mut global_types map[string]string) !FastcGlobalDeclarations {
+fn fastc_generate_global_declarations(ordered_sources []FastcSourceFile, global_sources map[string]string, prefs &pref.Preferences, header_free bool, declared_types map[string]bool, declared_type_c_names map[string]string, fastc_prefixed_c_names []string, declared_kinds map[string]FastcDeclaredTypeKind, enum_flags map[string]bool, enum_field_types map[string]string, alias_base_types map[string]string, struct_fields map[string]map[string]string, struct_field_info map[string][]FastcStructField, functions map[string]FastcFunctionSignature, constants map[string]string, constant_values map[string]string, public_constants map[string]bool, constant_types map[string]string, globals map[string]string, public_globals map[string]bool, mut global_types map[string]string) !FastcGlobalDeclarations {
 	declared_type_key_by_name := fastc_declared_type_key_by_name(declared_types)
 	mut out := strings.new_builder(1024)
 	mut module_initializers := map[string]string{}
@@ -660,6 +660,7 @@ fn fastc_generate_global_declarations(ordered_sources []FastcSourceFile, global_
 			globals:                      globals
 			public_globals:               public_globals
 			selfhost:                     prefs.building_v
+			header_free:                  header_free
 			s:                            scanner.new_scanner(prefs, .normal)
 			out:                          strings.new_builder(0)
 			protos:                       strings.new_builder(0)
@@ -798,9 +799,9 @@ fn fastc_write_prealloc_tls_global(mut out strings.Builder, styp string, c_name 
 	out.writeln('}')
 	out.writeln('#define ${c_name} (*(${styp} *)v_prealloc_tls_slot())')
 	out.writeln('#elif defined(__cplusplus)')
-	out.writeln('thread_local ${styp} ${c_name};')
+	out.writeln('static thread_local ${styp} ${c_name};')
 	out.writeln('#else')
-	out.writeln('_Thread_local ${styp} ${c_name};')
+	out.writeln('static _Thread_local ${styp} ${c_name};')
 	out.writeln('#endif')
 }
 
@@ -853,8 +854,7 @@ fn (mut g Parser) parse_global_declaration(mut out strings.Builder, mut initiali
 	if g.selfhost && name == 'g_memory_block' && fastc_prealloc_enabled(g.prefs) {
 		// The prealloc arena root must be per-thread; a shared global would be
 		// corrupted by the parallel per-file generator's concurrent bump-allocations.
-		header_free := g.selfhost && fastc_c_abi_supported(g.prefs.target.os, g.prefs.target.arch)
-		fastc_write_prealloc_tls_global(mut out, typ, c_name, header_free)
+		fastc_write_prealloc_tls_global(mut out, typ, c_name, g.header_free)
 	} else {
 		out.writeln('static ${typ} ${c_name};')
 	}

--- a/vlib/v3/gen/fastc/decl.v
+++ b/vlib/v3/gen/fastc/decl.v
@@ -777,9 +777,12 @@ fn fastc_prealloc_enabled(prefs &pref.Preferences) bool {
 // mirrors gen/c's `write_prealloc_tls_global`: bundled TinyCC on macOS has no
 // working thread-local storage, so there the identifier is redirected to a
 // pthread-key slot; every other target uses `_Thread_local`.
-fn fastc_write_prealloc_tls_global(mut out strings.Builder, styp string, c_name string) {
+fn fastc_write_prealloc_tls_global(mut out strings.Builder, styp string, c_name string, header_free bool) {
 	out.writeln('#if defined(__TINYC__) && defined(__APPLE__)')
-	out.writeln('#include <pthread.h>')
+	if !header_free {
+		// A header-free build declares the pthread API in its prelude.
+		out.writeln('#include <pthread.h>')
+	}
 	out.writeln('static pthread_key_t v_prealloc_tls_key;')
 	out.writeln('static pthread_once_t v_prealloc_tls_once = PTHREAD_ONCE_INIT;')
 	out.writeln('static void v_prealloc_tls_slot_free(void *slot) { free(slot); }')
@@ -850,7 +853,8 @@ fn (mut g Parser) parse_global_declaration(mut out strings.Builder, mut initiali
 	if g.selfhost && name == 'g_memory_block' && fastc_prealloc_enabled(g.prefs) {
 		// The prealloc arena root must be per-thread; a shared global would be
 		// corrupted by the parallel per-file generator's concurrent bump-allocations.
-		fastc_write_prealloc_tls_global(mut out, typ, c_name)
+		header_free := g.selfhost && fastc_c_abi_supported(g.prefs.target.os, g.prefs.target.arch)
+		fastc_write_prealloc_tls_global(mut out, typ, c_name, header_free)
 	} else {
 		out.writeln('static ${typ} ${c_name};')
 	}
@@ -1667,12 +1671,13 @@ fn fastc_generate_type_declarations(sources []FastcSourceFile, type_sources map[
 			}
 		}
 	}
-	enum_string_helpers := fastc_generate_enum_string_helpers(enum_infos)
+	enum_helper_names, enum_helper_texts := fastc_generate_enum_string_helpers(enum_infos)
 	timer.mark('type_declarations.enum_helpers')
 	return FastcTypeDeclarations{
 		declarations_head:   declarations_head
 		declarations:        out.str()
-		enum_string_helpers: enum_string_helpers
+		enum_helper_names: enum_helper_names
+		enum_helper_texts: enum_helper_texts
 		alias_base_types:    alias_base_types
 		enum_field_types:    enum_field_types
 		sum_types:           sum_types
@@ -2469,8 +2474,6 @@ fn fastc_emit_enum_declaration(mut scan scanner.Scanner, source_file FastcSource
 		fields:  field_names.clone()
 		is_flag: is_flag
 	}
-	fastc_emit_enum_print_function(c_name, name, field_names, is_flag, mut out)
-	out.writeln('')
 	return scan.scan()
 }
 
@@ -2665,9 +2668,14 @@ fn fastc_emit_enum_print_function(c_name string, name string, fields []string, i
 	out.writeln('}')
 }
 
-fn fastc_generate_enum_string_helpers(infos []FastcEnumInfo) string {
-	mut out := strings.new_builder(infos.len * 256)
+// fastc_generate_enum_string_helpers renders the `str` and print helper of
+// every enum as separate pieces (parallel name and text lists), so the
+// stitch can leave out the helpers nothing reachable calls.
+fn fastc_generate_enum_string_helpers(infos []FastcEnumInfo) ([]string, []string) {
+	mut names := []string{cap: infos.len * 2}
+	mut texts := []string{cap: infos.len * 2}
 	for info in infos {
+		mut out := strings.new_builder(256)
 		out.writeln('static string v_fastc_enum_str_${info.c_name}(${info.c_name} value) {')
 		if info.is_flag {
 			out.writeln('\tstring parts[${info.fields.len * 2 + 2}] = {0};')
@@ -2691,8 +2699,15 @@ fn fastc_generate_enum_string_helpers(infos []FastcEnumInfo) string {
 		}
 		out.writeln('}')
 		out.writeln('')
+		names << 'v_fastc_enum_str_${info.c_name}'
+		texts << out.str()
+		mut print_out := strings.new_builder(256)
+		fastc_emit_enum_print_function(info.c_name, info.name, info.fields, info.is_flag, mut print_out)
+		print_out.writeln('')
+		names << 'v_fastc_print_enum_${info.c_name}'
+		texts << print_out.str()
 	}
-	return out.str()
+	return names, texts
 }
 
 fn fastc_emit_interface_declaration(mut scan scanner.Scanner, source_file FastcSourceFile, mut out strings.Builder) !token.Token {

--- a/vlib/v3/gen/fastc/fastc.v
+++ b/vlib/v3/gen/fastc/fastc.v
@@ -448,6 +448,17 @@ static inline u64 wyhash(const void *key, size_t len, u64 seed, const u64 *secre
 
 // This must follow source `#include` directives: defining the function-like
 // fallback before `<pthread.h>` would rewrite declarations in that header.
+// c_selfhost_preamble_includes is the header block of c_selfhost_preamble;
+// a header-free build replaces it with the target's C ABI prelude.
+const c_selfhost_preamble_includes = r'#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#ifndef _WIN32
+#include <pthread.h>
+#endif
+'
+
 const c_selfhost_post_directives = r'#ifndef PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP
 #define pthread_rwlockattr_setkind_np(a, b) (0)
 #endif
@@ -994,11 +1005,13 @@ struct FastcEnumInfo {
 struct FastcTypeDeclarations {
 	// declarations_head precedes the composite typedefs (type ids and forward
 	// typedefs) and declarations follows them (the type bodies).
-	declarations_head   string
-	declarations        string
-	enum_string_helpers string
-	alias_base_types    map[string]string
-	enum_field_types    map[string]string
+	declarations_head string
+	declarations      string
+	// The enum `str`/print helpers, one piece each (parallel lists).
+	enum_helper_names []string
+	enum_helper_texts []string
+	alias_base_types  map[string]string
+	enum_field_types  map[string]string
 	// Declared C names of sum types (`type X = A | B`). They share the boxed
 	// `{void*_object; u32 _typ;}` layout with interfaces; construction boxes a
 	// variant and `match` dispatches on `_typ`.
@@ -1078,10 +1091,17 @@ mut:
 	lit           string
 	out           strings.Builder
 	protos        strings.Builder
-	indent        int
-	in_main       bool
-	has_main      bool
-	unsafe_depth  int
+	// The function definitions of this file, recorded for the reachability
+	// prune: see FastcFileGenOutput.
+	function_id_table    map[string]int
+	last_function_c_name string
+	function_ids         []int
+	function_spans       []int
+	proto_spans          []int
+	indent               int
+	in_main              bool
+	has_main             bool
+	unsafe_depth         int
 	// Set while generating a `@[direct_array_access]` function body, so string
 	// and array indexing skip the bounds-checked runtime accessors.
 	direct_array_access         bool
@@ -1311,8 +1331,13 @@ struct FastcFileGenContext {
 	fixed_array_types         map[string]string
 	composite_types           map[string]bool
 	generic_method_sources    map[string]FastcGenericMethodSource
-	generic_method_names      map[string]bool
-	module_aliases            map[string]string
+	// function_ids numbers the C names of the indexed functions; a file
+	// output reports its definitions and references by these ids so the
+	// stitch can drop the functions nothing reachable refers to.
+	function_ids         map[string]int
+	prune_unreachable    bool
+	generic_method_names map[string]bool
+	module_aliases       map[string]string
 }
 
 // FastcFileGenOutput is one source file's generation result. The sequential
@@ -1348,9 +1373,20 @@ fn fastc_file_gen_result(outputs []FastcFileGenOutput) FastcFileGenResult {
 
 struct FastcFileGenOutput {
 mut:
-	prototypes        string
-	body              string
-	directive_lines   []FastcCDirectiveLine
+	prototypes      string
+	body            string
+	directive_lines []FastcCDirectiveLine
+	// The functions defined in `body`: their id (-1 when not indexed), their
+	// [start, end) span in `body` and in `prototypes`, and the ids they
+	// reference (CSR: function i references refs[ref_starts[i]..ref_starts[i+1]]).
+	// root_refs are the ids referenced by code that is always emitted (the
+	// generic instances and spawn helpers of this file).
+	function_ids      []int
+	function_spans    []int
+	proto_spans       []int
+	ref_starts        []int
+	refs              []int
+	root_refs         []int
 	has_main_entry    bool
 	fixed_array_types map[string]string
 	composite_types   map[string]bool
@@ -1419,6 +1455,7 @@ fn fastc_generate_single_file(ctx &FastcFileGenContext, source_file FastcSourceF
 		out: strings.new_builder(source_file.source.len * 2 + 1024)
 		protos: strings.new_builder(4096)
 		functions: ctx.functions
+		function_id_table: ctx.function_ids
 		constant_types: ctx.constant_types
 		global_types: ctx.global_types
 		// These maps are per-file registration deltas. The stitch pass already owns
@@ -1454,10 +1491,33 @@ fn fastc_generate_single_file(ctx &FastcFileGenContext, source_file FastcSourceF
 			error_message: 'fastc scanner error at byte ${diagnostic.offset + source_file.source_offset} in ${source_file.path}: ${diagnostic.message}'
 		}
 	}
+	mut ref_starts := []int{}
+	mut refs := []int{}
+	mut root_refs := []int{}
+	if ctx.prune_unreachable {
+		ref_starts = []int{cap: gen.function_ids.len + 1}
+		for i in 0 .. gen.function_ids.len {
+			ref_starts << refs.len
+			fastc_collect_c_name_ids(generated, gen.function_spans[2 * i], gen.function_spans[2 * i + 1], ctx.function_ids, mut refs)
+		}
+		ref_starts << refs.len
+		for _, definition in gen.mono_definitions {
+			fastc_collect_c_name_ids(definition, 0, definition.len, ctx.function_ids, mut root_refs)
+		}
+		for _, helper in gen.spawn_helpers {
+			fastc_collect_c_name_ids(helper, 0, helper.len, ctx.function_ids, mut root_refs)
+		}
+	}
 	return FastcFileGenOutput{
 		prototypes: fastc_take_string(mut gen.protos)
 		body: generated
 		directive_lines: fastc_scan_c_directive_lines(generated)
+		function_ids: gen.function_ids
+		function_spans: gen.function_spans
+		proto_spans: gen.proto_spans
+		ref_starts: ref_starts
+		refs: refs
+		root_refs: root_refs
 		has_main_entry: source_file.header.module_name in ['', 'main'] && gen.has_main
 		fixed_array_types: gen.fixed_array_types
 		composite_types: gen.composite_types
@@ -1591,12 +1651,20 @@ fn generate_source_pieces(input_sources []FastcSourceFile, module_aliases map[st
 	struct_field_lookup := constant_output.struct_field_lookup.clone()
 	// The per-file prototype blocks are emitted as pieces too, so they are
 	// never concatenated into one buffer.
+	// A self-host build for a target with a C ABI table takes no header:
+	// the prelude declares what the emitted C uses, and `#include` lines are
+	// left out of the output.
+	header_free := prefs.building_v && fastc_c_abi_supported(prefs.target.os, prefs.target.arch)
+	mut inlined_header_paths := []string{}
 	mut prototype_pieces := []string{cap: sources.len + 16}
 	// The per-file bodies are stitched by reference: the directive partition
 	// works on their virtual concatenation and the final assembly copies each
 	// range straight from the pieces, so the multi-megabyte body is copied once.
 	mut body_pieces := []string{cap: sources.len + 16}
 	mut body_len := 0
+	mut proto_len := 0
+	mut output_body_offsets := []int{cap: sources.len + 16}
+	mut output_proto_offsets := []int{cap: sources.len + 16}
 	mut body_directive_lines := []FastcCDirectiveLine{}
 	mut fixed_array_types := constant_output.fixed_array_types.clone()
 	for name, array_type in global_output.fixed_array_types {
@@ -1610,8 +1678,18 @@ fn generate_source_pieces(input_sources []FastcSourceFile, module_aliases map[st
 		}
 	}
 	mut entry_has_main := false
+	// Self-host builds drop the functions that nothing reachable refers to:
+	// the source-level reachability keeps every function sharing a used name.
+	prune_unreachable := prefs.building_v
+	function_ids := if prune_unreachable {
+		fastc_function_id_table(functions, declared_kinds)
+	} else {
+		map[string]int{}
+	}
 	ctx := FastcFileGenContext{
 		prefs: unsafe { prefs }
+		function_ids: function_ids
+		prune_unreachable: prune_unreachable
 		declared_types: declared_types
 		declared_type_c_names: declared_type_c_names
 		declared_type_key_by_name: declared_type_key_by_name
@@ -1657,17 +1735,31 @@ fn generate_source_pieces(input_sources []FastcSourceFile, module_aliases map[st
 		if output.failed {
 			return error(output.error_message)
 		}
+		output_proto_offsets << proto_len
 		if output.prototypes.len > 0 {
 			prototype_pieces << fastc_piece(output.prototypes)
+			proto_len += output.prototypes.len
 		}
 		body_offset := body_len
+		output_body_offsets << body_offset
 		body_pieces << fastc_piece(output.body)
 		body_len += output.body.len
 		for line in output.directive_lines {
+			mut kind := line.kind
+			if header_free && kind == 1 && fastc_c_directive_is_include(output.body, line.start, line.end) {
+				// System headers are replaced by the prelude; V's own C helper
+				// headers are inlined after it (see fastc_inlined_c_headers).
+				kind = 4
+				if path := fastc_c_directive_quoted_include_path(output.body, line.start, line.end) {
+					if path !in inlined_header_paths {
+						inlined_header_paths << path
+					}
+				}
+			}
 			body_directive_lines << FastcCDirectiveLine{
 				start: body_offset + line.start
 				end: body_offset + line.end
-				kind: line.kind
+				kind: kind
 			}
 		}
 		if output.mono_definitions.len > 0 {
@@ -1734,11 +1826,104 @@ fn generate_source_pieces(input_sources []FastcSourceFile, module_aliases map[st
 	interface_dispatches := fastc_wait_interface_dispatches(mut pending_interface_dispatches)
 	timer.mark('wait_interface_dispatches')
 	fixed_array_declarations := fastc_generate_fixed_array_declarations(fixed_array_types)
-	preamble := if prefs.building_v { c_selfhost_preamble } else { c_preamble }
+	preamble := if header_free {
+		c_selfhost_preamble.replace(c_selfhost_preamble_includes, fastc_c_abi_prelude(prefs.target.os, prefs.target.arch, ''))
+	} else if prefs.building_v {
+		c_selfhost_preamble
+	} else {
+		c_preamble
+	}
 	hoisted_body := fastc_partition_c_directive_ranges(body_len, body_directive_lines)
 	timer.mark('partition_directives')
+	mut kept_body_ranges := hoisted_body.body_ranges.clone()
+	mut kept_conditional_ranges := hoisted_body.conditional_ranges.clone()
+	mut kept_proto_ranges := [0, proto_len]
+	mut enum_helpers_len := 0
+	for helper_text in type_output.enum_helper_texts {
+		enum_helpers_len += helper_text.len
+	}
+	mut kept_helper_ranges := [0, enum_helpers_len]
+	// A program without `main` (a module generated on its own) has no roots
+	// to walk from, so it keeps every function.
+	if ctx.prune_unreachable && entry_has_main {
+		// Everything outside the function bodies is emitted as is, so the
+		// functions it names are the roots, with `main` and the lifecycle hooks.
+		mut root_ids := []int{}
+		fastc_collect_c_name_ids(preamble, 0, preamble.len, function_ids, mut root_ids)
+		fastc_collect_c_name_ids(c_integer_comparison_helpers, 0, c_integer_comparison_helpers.len, function_ids, mut root_ids)
+		fastc_collect_c_name_ids(c_selfhost_post_directives, 0, c_selfhost_post_directives.len, function_ids, mut root_ids)
+		fastc_collect_c_name_ids(c_spawn_runtime, 0, c_spawn_runtime.len, function_ids, mut root_ids)
+		fastc_collect_c_name_ids(c_selfhost_runtime, 0, c_selfhost_runtime.len, function_ids, mut root_ids)
+		fastc_collect_c_name_ids(constant_output.macros, 0, constant_output.macros.len, function_ids, mut root_ids)
+		fastc_collect_c_name_ids(constant_output.declarations, 0, constant_output.declarations.len, function_ids, mut root_ids)
+		fastc_collect_c_name_ids(global_output.declarations, 0, global_output.declarations.len, function_ids, mut root_ids)
+		fastc_collect_c_name_ids(interface_dispatches, 0, interface_dispatches.len, function_ids, mut root_ids)
+		fastc_collect_c_name_ids(startup_initializers, 0, startup_initializers.len, function_ids, mut root_ids)
+		fastc_collect_c_name_ids(synthesized_main, 0, synthesized_main.len, function_ids, mut root_ids)
+		for _, text in spawn_typedefs {
+			fastc_collect_c_name_ids(text, 0, text.len, function_ids, mut root_ids)
+		}
+		for _, text in spawn_helpers {
+			fastc_collect_c_name_ids(text, 0, text.len, function_ids, mut root_ids)
+		}
+		for call in module_init_calls {
+			if id := function_ids[call] {
+				root_ids << id
+			}
+		}
+		for call in module_cleanup_calls {
+			if id := function_ids[call] {
+				root_ids << id
+			}
+		}
+		if id := function_ids['main'] {
+			root_ids << id
+		}
+		// The enum helpers join the walk as one more output placed after the
+		// bodies, so their unreachable pieces are dropped the same way.
+		mut helper_output := FastcFileGenOutput{}
+		mut helper_len := 0
+		for i, helper_name in type_output.enum_helper_names {
+			helper_text := type_output.enum_helper_texts[i]
+			helper_output.function_ids << function_ids[helper_name] or { -1 }
+			helper_output.function_spans << helper_len
+			helper_output.function_spans << helper_len + helper_text.len
+			helper_output.proto_spans << 0
+			helper_output.proto_spans << 0
+			helper_output.ref_starts << helper_output.refs.len
+			fastc_collect_c_name_ids(helper_text, 0, helper_text.len, function_ids, mut helper_output.refs)
+			helper_len += helper_text.len
+		}
+		helper_output.ref_starts << helper_output.refs.len
+		mut walk_outputs := outputs.clone()
+		walk_outputs << helper_output
+		mut walk_body_offsets := output_body_offsets.clone()
+		walk_body_offsets << body_len
+		mut walk_proto_offsets := output_proto_offsets.clone()
+		walk_proto_offsets << proto_len
+		dead_body_ranges, dead_proto_ranges := fastc_unreachable_function_ranges(walk_outputs, walk_body_offsets, walk_proto_offsets, function_ids.len, root_ids)
+		mut dead_file_ranges := []int{cap: dead_body_ranges.len}
+		mut dead_helper_ranges := []int{}
+		for i := 0; i + 1 < dead_body_ranges.len; i += 2 {
+			if dead_body_ranges[i] >= body_len {
+				dead_helper_ranges << dead_body_ranges[i] - body_len
+				dead_helper_ranges << dead_body_ranges[i + 1] - body_len
+			} else {
+				dead_file_ranges << dead_body_ranges[i]
+				dead_file_ranges << dead_body_ranges[i + 1]
+			}
+		}
+		kept_body_ranges = fastc_subtract_ranges(kept_body_ranges, dead_file_ranges)
+		kept_conditional_ranges = fastc_subtract_ranges(kept_conditional_ranges, dead_file_ranges)
+		kept_proto_ranges = fastc_subtract_ranges(kept_proto_ranges, dead_proto_ranges)
+		kept_helper_ranges = fastc_subtract_ranges(kept_helper_ranges, dead_helper_ranges)
+		timer.mark('prune')
+	}
 	mut pieces := []string{cap: 64 + body_pieces.len * 3}
 	pieces << fastc_piece(preamble)
+	for header_path in inlined_header_paths {
+		pieces << fastc_inlined_c_header(header_path)
+	}
 	pieces << fastc_piece(c_integer_comparison_helpers)
 	fastc_collect_c_piece_ranges(mut pieces, body_pieces, hoisted_body.directive_ranges)
 	timer.mark('assemble.directives')
@@ -1751,7 +1936,7 @@ fn generate_source_pieces(input_sources []FastcSourceFile, module_aliases map[st
 	if prefs.building_v {
 		pieces << fastc_piece(c_selfhost_post_directives)
 	}
-	if spawn_typedefs.len > 0 {
+	if spawn_typedefs.len > 0 && !header_free {
 		pieces << fastc_piece(c_spawn_runtime)
 		pieces << '\n'
 	}
@@ -1772,9 +1957,7 @@ fn generate_source_pieces(input_sources []FastcSourceFile, module_aliases map[st
 	}
 	pieces << fastc_piece(constant_output.declarations)
 	pieces << fastc_piece(global_output.declarations)
-	for prototype_piece in prototype_pieces {
-		pieces << fastc_piece(prototype_piece)
-	}
+	fastc_collect_c_piece_ranges(mut pieces, prototype_pieces, kept_proto_ranges)
 	if startup_initializers.len > 0 {
 		pieces << 'static void v_fastc_init_globals(void);'
 		pieces << '\n'
@@ -1787,7 +1970,7 @@ fn generate_source_pieces(input_sources []FastcSourceFile, module_aliases map[st
 	if prefs.building_v {
 		pieces << fastc_piece(c_selfhost_runtime)
 	}
-	pieces << fastc_piece(type_output.enum_string_helpers)
+	fastc_collect_c_piece_ranges(mut pieces, type_output.enum_helper_texts, kept_helper_ranges)
 	if spawn_helpers.len > 0 {
 		mut spawn_helper_names := spawn_helpers.keys()
 		spawn_helper_names.sort()
@@ -1819,7 +2002,7 @@ fn generate_source_pieces(input_sources []FastcSourceFile, module_aliases map[st
 	}
 	pieces << fastc_piece(synthesized_main)
 	timer.mark('assemble.head')
-	fastc_collect_c_piece_ranges(mut pieces, body_pieces, hoisted_body.conditional_ranges)
+	fastc_collect_c_piece_ranges(mut pieces, body_pieces, kept_conditional_ranges)
 	timer.mark('assemble.conditional')
 	if hoisted_body.final_kind == 2 {
 		pieces << '\n'
@@ -1827,11 +2010,16 @@ fn generate_source_pieces(input_sources []FastcSourceFile, module_aliases map[st
 	if hoisted_body.conditional_ranges.len > 0 {
 		pieces << '\n'
 	}
-	fastc_collect_c_piece_ranges(mut pieces, body_pieces, hoisted_body.body_ranges)
+	fastc_collect_c_piece_ranges(mut pieces, body_pieces, kept_body_ranges)
 	if hoisted_body.final_kind == 0 {
 		pieces << '\n'
 	}
 	timer.mark('assemble')
+	if header_free {
+		// A C function without a prototype in the ABI table must fail the
+		// build rather than compile against an implicit `int` declaration.
+		c_flags << '-Werror=implicit-function-declaration'
+	}
 	return pieces, spawn_typedefs.len > 0, c_flags
 }
 
@@ -2145,6 +2333,11 @@ fn fastc_partition_c_directive_ranges(total_len int, lines []FastcCDirectiveLine
 			final_kind = if conditional_depth > 0 { 2 } else { 0 }
 			fastc_append_c_source_range(cursor, line.start, final_kind, mut directive_ranges, mut conditional_ranges, mut body_ranges)
 		}
+		if line.kind == 4 {
+			// An omitted directive (an `#include` of a header-free build).
+			cursor = line.end
+			continue
+		}
 		if conditional_depth > 0 {
 			final_kind = 2
 			if line.kind == 2 {
@@ -2171,6 +2364,213 @@ fn fastc_partition_c_directive_ranges(total_len int, lines []FastcCDirectiveLine
 		body_ranges: body_ranges
 		final_kind: final_kind
 	}
+}
+
+// fastc_inlined_c_header returns the text a header-free build emits for one
+// of V's own C helper headers: the file itself, or the include directive when
+// it cannot be read (so the C compiler reports the problem).
+fn fastc_inlined_c_header(path string) string {
+	content := os.read_file(path) or { return '#include "${path}"\n' }
+	// The helper headers' own includes (Windows and MSVC branches, or the
+	// system headers the prelude replaces) are left out: the build has none.
+	mut out := strings.new_builder(content.len + 64)
+	out.writeln('/* ${path} */')
+	for line in content.split_into_lines() {
+		if line.trim_left(' \t').starts_with('#include') {
+			out.writeln('')
+			continue
+		}
+		out.writeln(line)
+	}
+	return out.str()
+}
+
+// fastc_function_id_table numbers the C names of the indexed functions and
+// methods (the keys of the signature index), as the emitted definitions and
+// calls spell them.
+fn fastc_function_id_table(functions map[string]FastcFunctionSignature, declared_kinds map[string]FastcDeclaredTypeKind) map[string]int {
+	mut ids := map[string]int{}
+	ids.reserve(u32(functions.len))
+	for key, signature in functions {
+		if key.starts_with('C.') {
+			continue
+		}
+		name := key.all_after_last('.')
+		prefix := key.all_before_last('.')
+		c_name := if prefix == '' || prefix == signature.module_name {
+			fastc_c_function_name(signature.module_name, name)
+		} else {
+			fastc_method_c_name(signature.module_name, fastc_c_declared_type_name(prefix), name)
+		}
+		// Only names the reference scan recognizes (a `__` separator or the
+		// `v_fastc_` prefix) are indexed; a bare main-module name stays out
+		// and its definition is always kept.
+		if !fastc_c_name_is_indexed(c_name) {
+			continue
+		}
+		if c_name !in ids {
+			ids[c_name] = ids.len
+		}
+	}
+	for type_key, kind in declared_kinds {
+		if kind != .enum_ {
+			continue
+		}
+		c_name := fastc_c_declared_type_name(type_key)
+		for helper in ['v_fastc_enum_str_${c_name}', 'v_fastc_print_enum_${c_name}'] {
+			if helper !in ids {
+				ids[helper] = ids.len
+			}
+		}
+	}
+	return ids
+}
+
+// fastc_c_name_is_indexed reports whether a C name carries a module or type
+// separator (`__`) or the helper prefix, the spellings the reference scan
+// looks up.
+fn fastc_c_name_is_indexed(c_name string) bool {
+	return fastc_contains(c_name, '__') || c_name.starts_with('v_fastc_')
+}
+
+fn fastc_c_identifier_start_byte(value u8) bool {
+	return value == `_` || (value >= `a` && value <= `z`) || (value >= `A` && value <= `Z`)
+}
+
+// fastc_collect_c_name_ids appends the ids of the indexed functions named in
+// text[start..end]. Every indexed C name carries a module or type separator
+// (`__`), so only such identifiers are looked up, through a view of the text.
+@[direct_array_access]
+fn fastc_collect_c_name_ids(text string, start int, end int, ids map[string]int, mut out []int) {
+	mut i := start
+	for i < end {
+		if !fastc_c_identifier_start_byte(text[i]) {
+			i++
+			continue
+		}
+		word_start := i
+		mut separated := false
+		i++
+		for i < end && fastc_identifier_byte(text[i]) {
+			if text[i] == `_` && text[i - 1] == `_` {
+				separated = true
+			}
+			i++
+		}
+		if !separated && i - word_start > 8 && text[word_start] == `v` && text[word_start + 1] == `_`
+			&& text[word_start + 2] == `f` && text[word_start + 3] == `a` && text[word_start + 4] == `s`
+			&& text[word_start + 5] == `t` && text[word_start + 6] == `c` && text[word_start + 7] == `_` {
+			// The enum helpers are indexed too.
+			separated = true
+		}
+		if separated {
+			candidate := unsafe { tos(text.str + word_start, i - word_start) }
+			if id := ids[candidate] {
+				out << id
+			}
+		}
+	}
+}
+
+// fastc_unreachable_function_ranges walks the references from `root_ids`
+// through the file outputs and returns the body and prototype ranges (in
+// the outputs' virtual concatenations) of the indexed functions never reached.
+fn fastc_unreachable_function_ranges(outputs []FastcFileGenOutput, body_offsets []int, proto_offsets []int, function_count int, root_ids []int) ([]int, []int) {
+	mut reachable := []bool{len: function_count}
+	mut def_output := []int{len: function_count}
+	mut def_index := []int{len: function_count}
+	for id in 0 .. function_count {
+		def_output[id] = -1
+		def_index[id] = -1
+	}
+	mut work := root_ids.clone()
+	for oi, output in outputs {
+		for id in output.root_refs {
+			work << id
+		}
+		for fi, id in output.function_ids {
+			if id >= 0 {
+				def_output[id] = oi
+				def_index[id] = fi
+			} else {
+				// A definition outside the index is always emitted, so what
+				// it references is reachable too.
+				for k in output.ref_starts[fi] .. output.ref_starts[fi + 1] {
+					work << output.refs[k]
+				}
+			}
+		}
+	}
+	mut cursor := 0
+	for cursor < work.len {
+		id := work[cursor]
+		cursor++
+		if reachable[id] {
+			continue
+		}
+		reachable[id] = true
+		oi := def_output[id]
+		if oi < 0 {
+			continue
+		}
+		fi := def_index[id]
+		output := outputs[oi]
+		for k in output.ref_starts[fi] .. output.ref_starts[fi + 1] {
+			r := output.refs[k]
+			if !reachable[r] {
+				work << r
+			}
+		}
+	}
+	mut dead_body := []int{}
+	mut dead_proto := []int{}
+	for oi, output in outputs {
+		for fi, id in output.function_ids {
+			if id < 0 || reachable[id] {
+				continue
+			}
+			dead_body << body_offsets[oi] + output.function_spans[2 * fi]
+			dead_body << body_offsets[oi] + output.function_spans[2 * fi + 1]
+			dead_proto << proto_offsets[oi] + output.proto_spans[2 * fi]
+			dead_proto << proto_offsets[oi] + output.proto_spans[2 * fi + 1]
+		}
+	}
+	return dead_body, dead_proto
+}
+
+// fastc_subtract_ranges returns the parts of the ascending [start, end)
+// `ranges` not covered by the ascending, disjoint `dead` ranges.
+fn fastc_subtract_ranges(ranges []int, dead []int) []int {
+	if dead.len == 0 {
+		return ranges
+	}
+	mut kept := []int{cap: ranges.len + dead.len}
+	mut d := 0
+	for i := 0; i + 1 < ranges.len; i += 2 {
+		mut start := ranges[i]
+		end := ranges[i + 1]
+		for d + 1 < dead.len && dead[d + 1] <= start {
+			d += 2
+		}
+		mut k := d
+		for k + 1 < dead.len && dead[k] < end {
+			if dead[k + 1] > dead[k] {
+				if dead[k] > start {
+					kept << start
+					kept << dead[k]
+				}
+				if dead[k + 1] > start {
+					start = dead[k + 1]
+				}
+			}
+			k += 2
+		}
+		if start < end {
+			kept << start
+			kept << end
+		}
+	}
+	return kept
 }
 
 // fastc_collect_c_piece_ranges appends the ascending [start, end) `ranges` of

--- a/vlib/v3/gen/fastc/fastc.v
+++ b/vlib/v3/gen/fastc/fastc.v
@@ -1096,6 +1096,7 @@ struct Parser {
 	public_globals      map[string]bool
 	used_function_names map[string]bool
 	selfhost            bool
+	header_free         bool
 	// source_has_select is false only when the file provably holds no `select`
 	// word (see fastc_source_scan_flags), so block pre-scans for channel
 	// select statements can be skipped.
@@ -1659,7 +1660,9 @@ fn generate_source_pieces(input_sources []FastcSourceFile, module_aliases map[st
 	for name, _ in constant_output.composite_types {
 		composite_types[name] = true
 	}
-	global_output := fastc_generate_global_declarations(ordered_sources, global_sources, prefs, declared_types, declared_type_c_names, fastc_prefixed_c_names, declared_kinds, enum_flags, enum_field_types, type_output.alias_base_types, struct_fields, struct_field_info, functions, constants, constant_output.compile_time_values, public_constants, constant_types, globals, public_globals, mut global_types)!
+	header_free := prefs.building_v
+		&& fastc_c_abi_supported(prefs.target.os, prefs.target.arch, fastc_host_uses_glibc())
+	global_output := fastc_generate_global_declarations(ordered_sources, global_sources, prefs, header_free, declared_types, declared_type_c_names, fastc_prefixed_c_names, declared_kinds, enum_flags, enum_field_types, type_output.alias_base_types, struct_fields, struct_field_info, functions, constants, constant_output.compile_time_values, public_constants, constant_types, globals, public_globals, mut global_types)!
 	timer.mark('global_declarations')
 	for name, _ in global_output.composite_types {
 		composite_types[name] = true
@@ -1681,7 +1684,6 @@ fn generate_source_pieces(input_sources []FastcSourceFile, module_aliases map[st
 	// A self-host build for a target with a C ABI table takes no header:
 	// the prelude declares what the emitted C uses, and `#include` lines are
 	// left out of the output.
-	header_free := prefs.building_v && fastc_c_abi_supported(prefs.target.os, prefs.target.arch)
 	mut inlined_header_paths := []string{}
 	mut prototype_pieces := []string{cap: sources.len + 16}
 	// The per-file bodies are stitched by reference: the directive partition
@@ -2152,14 +2154,28 @@ fn fastc_extern_declarations(text string, as_extern bool) string {
 	return out.str()
 }
 
-// fastc_tcc_job_count is the number of TinyCC processes a driver compiles a
-// program's translation units with.
-pub fn fastc_tcc_job_count(prefs &pref.Preferences) int {
+// fastc_parallel_worker_limit is the number of worker threads or compiler
+// processes a parallel phase may run at once: the CPU count, overridden by
+// VJOBS, and 1 when parallelism is disabled.
+fn fastc_parallel_worker_limit(prefs &pref.Preferences) int {
+	if prefs.no_parallel {
+		return 1
+	}
 	mut jobs := fastc_nr_cpus()
 	vjobs := os.getenv('VJOBS').int()
 	if vjobs > 0 {
 		jobs = vjobs
 	}
+	if os.getenv('V3_FASTC_NO_PARALLEL') != '' {
+		jobs = 1
+	}
+	return jobs
+}
+
+// fastc_tcc_job_count is the number of TinyCC processes a driver compiles a
+// program's translation units with.
+pub fn fastc_tcc_job_count(prefs &pref.Preferences) int {
+	mut jobs := fastc_parallel_worker_limit(prefs)
 	if jobs > 8 {
 		jobs = 8
 	}

--- a/vlib/v3/gen/fastc/fastc.v
+++ b/vlib/v3/gen/fastc/fastc.v
@@ -874,6 +874,27 @@ pub:
 	source_paths []string
 	uses_threads bool
 	c_flags      []string
+	// units describes how c_pieces split into translation units that the
+	// drivers can compile in parallel (see fastc_write_c_units).
+	units FastcUnitLayout
+}
+
+// FastcUnitLayout locates, in a generation's pieces, the shared head (types,
+// constants, globals, prototypes, runtime), the pieces that belong to one
+// unit only (the startup initializer, the cleanup hook and the synthesized
+// main) and the per-file body units. extern_indexes name the head pieces
+// whose definitions must become declarations in every unit but the first
+// (the globals), with extern_texts holding those declarations.
+pub struct FastcUnitLayout {
+pub mut:
+	head_end       int
+	solo_end       int
+	unit_starts    []int
+	extern_indexes []int
+	extern_texts   []string
+	// define_texts are the same pieces with `static` dropped, for the first
+	// unit: a static definition would not satisfy the other units' externs.
+	define_texts []string
 }
 
 // c_source joins the generated C pieces into one string.
@@ -1286,7 +1307,11 @@ pub fn generate_files_with_source_paths(paths []string, prefs &pref.Preferences)
 	for source_file in sources {
 		source_paths << source_file.path
 	}
-	c_pieces, uses_threads, c_flags := generate_source_pieces(sources, module_aliases, prefs)!
+	// The layout comes back through a parameter: a struct of arrays as a
+	// multi-return component is not carried correctly by the self-hosted
+	// generator yet.
+	mut units := FastcUnitLayout{}
+	c_pieces, uses_threads, c_flags := generate_source_pieces(sources, module_aliases, prefs, mut units)!
 	fastc_wait_memo_store(mut pending_memo_store)
 	timer.mark('generate_total')
 	return GenerationResult{
@@ -1294,6 +1319,7 @@ pub fn generate_files_with_source_paths(paths []string, prefs &pref.Preferences)
 		source_paths: source_paths
 		uses_threads: uses_threads
 		c_flags: c_flags
+		units: units
 	}
 }
 
@@ -1531,14 +1557,15 @@ fn fastc_generate_single_file(ctx &FastcFileGenContext, source_file FastcSourceF
 // generate_source_files emits the program as one C string; tests and the
 // single-source API use it. The driver takes the pieces directly.
 fn generate_source_files(input_sources []FastcSourceFile, module_aliases map[string]string, prefs &pref.Preferences) !(string, bool, []string) {
-	pieces, uses_threads, c_flags := generate_source_pieces(input_sources, module_aliases, prefs)!
+	mut units := FastcUnitLayout{}
+	pieces, uses_threads, c_flags := generate_source_pieces(input_sources, module_aliases, prefs, mut units)!
 	return fastc_join_c_pieces(pieces), uses_threads, c_flags
 }
 
 // generate_source_pieces emits the program as C pieces in output order; the
 // per-file bodies are referenced, not copied, so the multi-megabyte output is
 // never assembled into one buffer here.
-fn generate_source_pieces(input_sources []FastcSourceFile, module_aliases map[string]string, prefs &pref.Preferences) !([]string, bool, []string) {
+fn generate_source_pieces(input_sources []FastcSourceFile, module_aliases map[string]string, prefs &pref.Preferences, mut units FastcUnitLayout) !([]string, bool, []string) {
 	// The `int` C spelling is fixed before any source is generated, so the
 	// generation workers below all read the same width.
 	fastc_set_platform_int_bits(prefs.target.pointer_bits)
@@ -1955,7 +1982,16 @@ fn generate_source_pieces(input_sources []FastcSourceFile, module_aliases map[st
 		}
 		pieces << '\n'
 	}
+	mut extern_indexes := []int{}
+	mut extern_texts := []string{}
+	mut define_texts := []string{}
+	extern_indexes << pieces.len
+	extern_texts << fastc_extern_declarations(constant_output.declarations, true)
+	define_texts << fastc_extern_declarations(constant_output.declarations, false)
 	pieces << fastc_piece(constant_output.declarations)
+	extern_indexes << pieces.len
+	extern_texts << fastc_extern_declarations(global_output.declarations, true)
+	define_texts << fastc_extern_declarations(global_output.declarations, false)
 	pieces << fastc_piece(global_output.declarations)
 	fastc_collect_c_piece_ranges(mut pieces, prototype_pieces, kept_proto_ranges)
 	if startup_initializers.len > 0 {
@@ -1980,6 +2016,10 @@ fn generate_source_pieces(input_sources []FastcSourceFile, module_aliases map[st
 			pieces << '\n'
 		}
 	}
+	// The interface dispatch functions are definitions, so they belong to
+	// one unit; every unit sees their prototypes.
+	pieces << fastc_definition_prototypes(interface_dispatches)
+	head_end := pieces.len
 	pieces << fastc_piece(interface_dispatches)
 	if startup_initializers.len > 0 {
 		pieces << 'static void v_fastc_init_globals(void) {'
@@ -2001,6 +2041,7 @@ fn generate_source_pieces(input_sources []FastcSourceFile, module_aliases map[st
 		pieces << '\n'
 	}
 	pieces << fastc_piece(synthesized_main)
+	solo_end := pieces.len
 	timer.mark('assemble.head')
 	fastc_collect_c_piece_ranges(mut pieces, body_pieces, kept_conditional_ranges)
 	timer.mark('assemble.conditional')
@@ -2010,10 +2051,31 @@ fn generate_source_pieces(input_sources []FastcSourceFile, module_aliases map[st
 	if hoisted_body.conditional_ranges.len > 0 {
 		pieces << '\n'
 	}
-	fastc_collect_c_piece_ranges(mut pieces, body_pieces, kept_body_ranges)
+	// The bodies are appended file by file, so each file's pieces form a
+	// unit; the generic instances (after the last file) join the last unit.
+	// Conditional blocks would be body text shared by every unit, so a
+	// program with any keeps a single unit.
+	mut unit_starts := []int{cap: outputs.len + 2}
+	if kept_conditional_ranges.len == 0 && outputs.len > 0 {
+		for i, output in outputs {
+			window_start := output_body_offsets[i]
+			window_end := if i + 1 < outputs.len { output_body_offsets[i + 1] } else { body_len }
+			unit_starts << pieces.len
+			fastc_collect_c_piece_ranges(mut pieces, body_pieces, fastc_window_ranges(kept_body_ranges, window_start, window_end, output.body.len == 0))
+		}
+	} else {
+		fastc_collect_c_piece_ranges(mut pieces, body_pieces, kept_body_ranges)
+	}
 	if hoisted_body.final_kind == 0 {
 		pieces << '\n'
 	}
+	unit_starts << pieces.len
+	units.head_end = head_end
+	units.solo_end = solo_end
+	units.unit_starts = unit_starts
+	units.extern_indexes = extern_indexes
+	units.extern_texts = extern_texts
+	units.define_texts = define_texts
 	timer.mark('assemble')
 	if header_free {
 		// A C function without a prototype in the ABI table must fail the
@@ -2021,6 +2083,203 @@ fn generate_source_pieces(input_sources []FastcSourceFile, module_aliases map[st
 		c_flags << '-Werror=implicit-function-declaration'
 	}
 	return pieces, spawn_typedefs.len > 0, c_flags
+}
+
+// fastc_definition_prototypes returns a prototype for every function
+// definition of `text` (a definition starts a line and ends it with `) {`).
+fn fastc_definition_prototypes(text string) string {
+	if text.len == 0 {
+		return ''
+	}
+	mut out := strings.new_builder(text.len / 8 + 64)
+	for line in text.split_into_lines() {
+		if line.len > 4 && !line[0].is_space() && line.ends_with(') {') && !line.starts_with('static ')
+			&& !line.starts_with('#') {
+			out.writeln(line[..line.len - 2] + ';')
+		}
+	}
+	return out.str()
+}
+
+// fastc_window_ranges returns the parts of the ascending [start, end)
+// `ranges` inside [window_start, window_end). An empty body contributes
+// nothing; `empty` short-circuits the search for it.
+fn fastc_window_ranges(ranges []int, window_start int, window_end int, empty bool) []int {
+	mut out := []int{}
+	if empty {
+		return out
+	}
+	for i := 0; i + 1 < ranges.len; i += 2 {
+		start := ranges[i]
+		end := ranges[i + 1]
+		if end <= window_start {
+			continue
+		}
+		if start >= window_end {
+			break
+		}
+		out << if start < window_start { window_start } else { start }
+		out << if end > window_end { window_end } else { end }
+	}
+	return out
+}
+
+// fastc_extern_declarations rewrites the `static` variable definitions of a
+// declaration block for a split build: as `extern` declarations (`as_extern`)
+// for the units that share the globals, or as external definitions (without
+// `static`) for the unit that holds them. Static functions and multi-line
+// initializers are left as they are (they stay per unit).
+fn fastc_extern_declarations(text string, as_extern bool) string {
+	if !fastc_contains(text, 'static ') {
+		return text
+	}
+	mut out := strings.new_builder(text.len)
+	for line in text.split_into_lines() {
+		if line.starts_with('static ') && !fastc_contains(line, '(') && line.ends_with(';') {
+			mut declaration := line['static '.len..]
+			if as_extern {
+				if assign := declaration.index(' = ') {
+					declaration = declaration[..assign] + ';'
+				}
+				out.writeln('extern ' + declaration)
+			} else {
+				out.writeln(declaration)
+			}
+			continue
+		}
+		out.writeln(line)
+	}
+	return out.str()
+}
+
+// fastc_tcc_job_count is the number of TinyCC processes a driver compiles a
+// program's translation units with.
+pub fn fastc_tcc_job_count(prefs &pref.Preferences) int {
+	mut jobs := fastc_nr_cpus()
+	vjobs := os.getenv('VJOBS').int()
+	if vjobs > 0 {
+		jobs = vjobs
+	}
+	if jobs > 8 {
+		jobs = 8
+	}
+	if jobs < 1 {
+		jobs = 1
+	}
+	return jobs
+}
+
+// fastc_write_c_units writes the translation units of a generation for
+// `jobs` parallel TinyCC processes: `prefix.unit<k>.c` files, each with the
+// shared head (the globals as extern declarations after the first), the
+// first also with the startup, cleanup and main pieces, and consecutive body
+// units grouped to balance their sizes. It returns the paths, or none when
+// the program does not split.
+pub fn fastc_write_c_units(prefix string, pieces []string, units FastcUnitLayout, jobs int) ![]string {
+	unit_count := units.unit_starts.len - 1
+	if jobs < 2 || unit_count < 2 || units.head_end <= 0 || units.solo_end > pieces.len {
+		return []string{}
+	}
+	mut total := 0
+	mut unit_sizes := []int{cap: unit_count}
+	for u in 0 .. unit_count {
+		mut size := 0
+		for k in units.unit_starts[u] .. units.unit_starts[u + 1] {
+			size += pieces[k].len
+		}
+		unit_sizes << size
+		total += size
+	}
+	groups := if jobs < unit_count { jobs } else { unit_count }
+	mut paths := []string{cap: groups}
+	mut first_units := []int{cap: groups + 1}
+	mut u := 0
+	mut remaining := total
+	for g in 0 .. groups {
+		// Every group aims at an equal share of what is left, so the last
+		// one does not end up with the remainder of the rounding.
+		target := (remaining + groups - g - 1) / (groups - g)
+		paths << '${prefix}.unit${g}.c'
+		first_units << u
+		mut size := 0
+		remaining_groups := groups - g - 1
+		for u < unit_count {
+			// Leave one unit for every later group; the last group takes the
+			// rest, the others stop at the size target.
+			if unit_count - u <= remaining_groups {
+				break
+			}
+			if size > 0 && remaining_groups > 0 && size + unit_sizes[u] > target {
+				break
+			}
+			size += unit_sizes[u]
+			remaining -= unit_sizes[u]
+			u++
+		}
+	}
+	first_units << unit_count
+	// The files are written concurrently; they add up to several megabytes.
+	mut writers := [
+		spawn fastc_write_c_unit(paths[0], pieces, &units, 0, first_units[0], first_units[1]),
+	]
+	for g in 1 .. groups {
+		writers << spawn fastc_write_c_unit(paths[g], pieces, &units, g, first_units[g], first_units[g + 1])
+	}
+	mut failure := ''
+	for writer in writers {
+		message := writer.wait()
+		if message != '' && failure == '' {
+			failure = message
+		}
+	}
+	if failure != '' {
+		return error(failure)
+	}
+	return paths
+}
+
+// fastc_write_c_unit writes one translation unit: the head (with the shared
+// globals as definitions in the first unit and as externs elsewhere), the
+// pieces every program has once in the first unit, and the bodies of the
+// units `first_unit` to `end_unit`. It returns an error message or ''.
+fn fastc_write_c_unit(path string, pieces []string, units &FastcUnitLayout, g int, first_unit int, end_unit int) string {
+	mut file := os.create(path) or { return 'could not create ${path}: ${err.msg()}' }
+	// One buffered write per unit: piecewise writes cost several times more.
+	mut out := strings.new_builder(1024 * 1024)
+	for k in 0 .. units.head_end {
+		mut text := pieces[k]
+		for e, index in units.extern_indexes {
+			if index == k {
+				text = if g > 0 { units.extern_texts[e] } else { units.define_texts[e] }
+			}
+		}
+		out.write_string(text)
+	}
+	if g == 0 {
+		for k in units.head_end .. units.solo_end {
+			out.write_string(pieces[k])
+		}
+	}
+	out.write_string('\n')
+	for k in units.unit_starts[first_unit] .. units.unit_starts[end_unit] {
+		out.write_string(pieces[k])
+	}
+	file.write(out) or {
+		file.close()
+		return 'could not write ${path}: ${err.msg()}'
+	}
+	file.close()
+	return ''
+}
+
+// FastcUnitCompile is one TinyCC process compiling a translation unit.
+// fastc_remove_c_units deletes the translation unit sources and their
+// objects.
+pub fn fastc_remove_c_units(unit_paths []string) {
+	for unit_path in unit_paths {
+		os.rm(unit_path) or {}
+		os.rm(unit_path[..unit_path.len - 2] + '.o') or {}
+	}
 }
 
 // fastc_generic_method_names collects the bare method and function names of

--- a/vlib/v3/gen/fastc/fastc_test.v
+++ b/vlib/v3/gen/fastc/fastc_test.v
@@ -554,8 +554,40 @@ fn test_fastc_prealloc_arena_root_is_per_thread() {
 	// never be emitted as a plain shared global.
 	assert rendered.contains('#define g_memory_block (*(VMemoryBlock* *)v_prealloc_tls_slot())')
 	assert rendered.contains('pthread_getspecific(v_prealloc_tls_key)')
-	assert rendered.contains('_Thread_local VMemoryBlock* g_memory_block;')
+	assert rendered.contains('static _Thread_local VMemoryBlock* g_memory_block;')
 	assert !rendered.contains('static VMemoryBlock* g_memory_block;')
+}
+
+fn test_fastc_split_rewrites_prealloc_tls_global_linkage() {
+	definition := 'static _Thread_local VMemoryBlock* g_memory_block;\n'
+	assert fastc_extern_declarations(definition, false) == '_Thread_local VMemoryBlock* g_memory_block;\n'
+	assert fastc_extern_declarations(definition, true) == 'extern _Thread_local VMemoryBlock* g_memory_block;\n'
+}
+
+fn test_fastc_tcc_job_count_respects_parallel_controls() {
+	old_vjobs := os.getenv_opt('VJOBS')
+	old_disabled := os.getenv_opt('V3_FASTC_NO_PARALLEL')
+	defer {
+		if value := old_vjobs {
+			os.setenv('VJOBS', value, true)
+		} else {
+			os.unsetenv('VJOBS')
+		}
+		if value := old_disabled {
+			os.setenv('V3_FASTC_NO_PARALLEL', value, true)
+		} else {
+			os.unsetenv('V3_FASTC_NO_PARALLEL')
+		}
+	}
+	os.setenv('VJOBS', '4', true)
+	os.unsetenv('V3_FASTC_NO_PARALLEL')
+	mut prefs := pref.new_preferences()
+	assert fastc_tcc_job_count(prefs) == 4
+	prefs.no_parallel = true
+	assert fastc_tcc_job_count(prefs) == 1
+	prefs.no_parallel = false
+	os.setenv('V3_FASTC_NO_PARALLEL', '1', true)
+	assert fastc_tcc_job_count(prefs) == 1
 }
 
 fn test_fastc_fragmented_generation_matches_serial_output() {

--- a/vlib/v3/gen/fastc/fastc_test.v
+++ b/vlib/v3/gen/fastc/fastc_test.v
@@ -546,7 +546,7 @@ fn test_fastc_prealloc_enabled_reads_user_defines() {
 
 fn test_fastc_prealloc_arena_root_is_per_thread() {
 	mut out := strings.new_builder(256)
-	fastc_write_prealloc_tls_global(mut out, 'VMemoryBlock*', 'g_memory_block')
+	fastc_write_prealloc_tls_global(mut out, 'VMemoryBlock*', 'g_memory_block', false)
 	rendered := out.str()
 	// The arena root must be per-thread so the parallel per-file generator's
 	// workers never share it: a pthread-key slot under bundled TinyCC on macOS

--- a/vlib/v3/gen/fastc/fn.v
+++ b/vlib/v3/gen/fastc/fn.v
@@ -1284,7 +1284,7 @@ const fastc_boxed_primitive_types = ['int', 'i8', 'i16', 'i32', 'i64', 'u8', 'u1
 fn fastc_output_c_type(t string) string {
 	base := t.trim_right('*')
 	if base == 'int' {
-		return fastc_platform_int_c_type() + t[base.len..]
+		return fastc_platform_int_c_type + t[base.len..]
 	}
 	return t
 }

--- a/vlib/v3/gen/fastc/fn.v
+++ b/vlib/v3/gen/fastc/fn.v
@@ -142,7 +142,10 @@ fn (mut g Parser) parse_top_level_items(stop_at_block_end bool) ! {
 			continue
 		}
 		if g.tok == .key_fn {
+			out_start := g.out.len
+			proto_start := g.protos.len
 			g.parse_function(item_enabled)!
+			g.record_function_span(out_start, proto_start)
 			continue
 		}
 		if g.has_main {
@@ -581,6 +584,7 @@ fn (mut g Parser) skip_import() ! {
 }
 
 fn (mut g Parser) parse_function(enabled bool) ! {
+	g.last_function_c_name = ''
 	g.type_memo.clear()
 	g.locals = map[string]FastcLocal{}
 	g.temp_id = 0
@@ -784,6 +788,7 @@ fn (mut g Parser) parse_function(enabled bool) ! {
 	} else {
 		fastc_method_c_name(g.module_name, fastc_c_declared_type_name(receiver_key), name)
 	}
+	g.last_function_c_name = c_name
 	c_return_type := if is_main { 'int' } else { fastc_output_c_type(return_type) }
 	c_params := if is_main && g.selfhost {
 		'int argc, char **argv'
@@ -969,6 +974,19 @@ fn (mut g Parser) emit_generic_body_stub(out_checkpoint int, saved_indent int, b
 	if return_type != 'void' {
 		g.write_line('return (${fastc_output_c_type(return_type)}){0};')
 	}
+}
+
+// record_function_span notes the C definition the last parse_function wrote
+// to `out` (and its prototype in `protos`) for the reachability prune.
+fn (mut g Parser) record_function_span(out_start int, proto_start int) {
+	if g.last_function_c_name == '' || g.in_mono_drain {
+		return
+	}
+	g.function_ids << g.function_id_table[g.last_function_c_name] or { -1 }
+	g.function_spans << out_start
+	g.function_spans << g.out.len
+	g.proto_spans << proto_start
+	g.proto_spans << g.protos.len
 }
 
 fn fastc_method_c_name(module_name string, receiver_type string, name string) string {
@@ -1266,7 +1284,7 @@ const fastc_boxed_primitive_types = ['int', 'i8', 'i16', 'i32', 'i64', 'u8', 'u1
 fn fastc_output_c_type(t string) string {
 	base := t.trim_right('*')
 	if base == 'int' {
-		return fastc_platform_int_c_type + t[base.len..]
+		return fastc_platform_int_c_type() + t[base.len..]
 	}
 	return t
 }

--- a/vlib/v3/gen/fastc/macho_sign.v
+++ b/vlib/v3/gen/fastc/macho_sign.v
@@ -28,36 +28,54 @@ const cs_blob_wrapper_magic = u32(0xfade0b01)
 // fastc_codesign_shim_name is the command name TinyCC runs after linking.
 const fastc_codesign_shim_name = 'codesign'
 
+// FastcCodesignShim owns the temporary codesign shim and the PATH value that
+// must be restored when its use ends.
+pub struct FastcCodesignShim {
+pub:
+	dir string
+mut:
+	previous_path     string
+	previous_path_set bool
+}
+
 // fastc_codesign_shim_dir prepares a directory whose `codesign` is a link to
 // `/usr/bin/true` and puts it first on PATH, so TinyCC's post-link `codesign`
 // call (Apple's tool takes tens of milliseconds) does nothing; the driver
-// then signs the executable itself with fastc_sign_macho_adhoc. It returns
-// the directory (to remove afterwards) or '' when the shim is not used (not
-// macOS, or the link cannot be made), in which case TinyCC's own signing
-// stands.
-pub fn fastc_codesign_shim_dir() string {
+// then signs the executable itself with fastc_sign_macho_adhoc.
+pub fn fastc_codesign_shim_dir() FastcCodesignShim {
 	if os.user_os() != 'macos' || !os.is_executable(fastc_codesign_noop_command) {
-		return ''
+		return FastcCodesignShim{}
 	}
 	dir := os.join_path_single(os.vtmp_dir(), 'fastc_codesign_shim_${os.getpid()}')
-	os.mkdir_all(dir) or { return '' }
+	os.mkdir_all(dir) or { return FastcCodesignShim{} }
 	link := os.join_path_single(dir, fastc_codesign_shim_name)
 	os.rm(link) or {}
 	os.symlink(fastc_codesign_noop_command, link) or {
 		os.rmdir_all(dir) or {}
-		return ''
+		return FastcCodesignShim{}
 	}
-	os.setenv('PATH', dir + ':' + os.getenv('PATH'), true)
-	return dir
+	previous_path := os.getenv_opt('PATH')
+	path := previous_path or { '' }
+	os.setenv('PATH', dir + ':' + path, true)
+	return FastcCodesignShim{
+		dir: dir
+		previous_path: path
+		previous_path_set: previous_path != none
+	}
 }
 
 // fastc_codesign_noop_command stands in for `codesign` while TinyCC links.
 const fastc_codesign_noop_command = '/usr/bin/true'
 
-// fastc_remove_codesign_shim_dir removes the shim directory again.
-pub fn fastc_remove_codesign_shim_dir(dir string) {
-	if dir != '' {
-		os.rmdir_all(dir) or {}
+// fastc_remove_codesign_shim_dir restores PATH and removes the shim directory.
+pub fn fastc_remove_codesign_shim_dir(shim FastcCodesignShim) {
+	if shim.dir != '' {
+		if shim.previous_path_set {
+			os.setenv('PATH', shim.previous_path, true)
+		} else {
+			os.unsetenv('PATH')
+		}
+		os.rmdir_all(shim.dir) or {}
 	}
 }
 

--- a/vlib/v3/gen/fastc/macho_sign.v
+++ b/vlib/v3/gen/fastc/macho_sign.v
@@ -1,0 +1,338 @@
+module fastc
+
+import crypto.sha256
+import os
+
+fn C.ftruncate(i32, u64) i32
+
+// TinyCC signs the executables it links on macOS by running Apple's
+// `codesign -f -s - <file>`, and that tool costs about 50 ms per build,
+// half of TinyCC's own time for the self-host. The drivers therefore put a
+// no-op `codesign` first on TinyCC's PATH (fastc_codesign_shim_dir) and
+// ad-hoc sign the Mach-O themselves (fastc_sign_macho_adhoc), in about a
+// millisecond.
+
+const macho_magic_64 = u32(0xfeedfacf)
+const macho_lc_segment_64 = u32(0x19)
+const macho_lc_code_signature = u32(0x1d)
+const macho_header_size = 32
+const macho_page_size = 16384
+const cs_page_shift = 12
+const cs_page_size = 4096
+const cs_hash_size = 32
+const cs_super_blob_magic = u32(0xfade0cc0)
+const cs_code_directory_magic = u32(0xfade0c02)
+const cs_requirements_magic = u32(0xfade0c01)
+const cs_blob_wrapper_magic = u32(0xfade0b01)
+
+// fastc_codesign_shim_name is the command name TinyCC runs after linking.
+const fastc_codesign_shim_name = 'codesign'
+
+// fastc_codesign_shim_dir prepares a directory whose `codesign` is a link to
+// `/usr/bin/true` and puts it first on PATH, so TinyCC's post-link `codesign`
+// call (Apple's tool takes tens of milliseconds) does nothing; the driver
+// then signs the executable itself with fastc_sign_macho_adhoc. It returns
+// the directory (to remove afterwards) or '' when the shim is not used (not
+// macOS, or the link cannot be made), in which case TinyCC's own signing
+// stands.
+pub fn fastc_codesign_shim_dir() string {
+	if os.user_os() != 'macos' || !os.is_executable(fastc_codesign_noop_command) {
+		return ''
+	}
+	dir := os.join_path_single(os.vtmp_dir(), 'fastc_codesign_shim_${os.getpid()}')
+	os.mkdir_all(dir) or { return '' }
+	link := os.join_path_single(dir, fastc_codesign_shim_name)
+	os.rm(link) or {}
+	os.symlink(fastc_codesign_noop_command, link) or {
+		os.rmdir_all(dir) or {}
+		return ''
+	}
+	os.setenv('PATH', dir + ':' + os.getenv('PATH'), true)
+	return dir
+}
+
+// fastc_codesign_noop_command stands in for `codesign` while TinyCC links.
+const fastc_codesign_noop_command = '/usr/bin/true'
+
+// fastc_remove_codesign_shim_dir removes the shim directory again.
+pub fn fastc_remove_codesign_shim_dir(dir string) {
+	if dir != '' {
+		os.rmdir_all(dir) or {}
+	}
+}
+
+// fastc_sign_macho_adhoc gives the 64-bit Mach-O executable at `path` an
+// ad-hoc code signature (a SHA-256 code directory over 4 KiB pages, an
+// empty requirements blob and an empty CMS wrapper), replacing any signature
+// it has. The identifier is the file name, as `codesign -s -` uses.
+pub fn fastc_sign_macho_adhoc(path string) ! {
+	mut file := os.read_bytes(path)!
+	original_len := file.len
+	if file.len < macho_header_size || fastc_read_u32_le(file, 0) != macho_magic_64 {
+		return error('`${path}` is not a 64-bit Mach-O file')
+	}
+	mut ncmds := int(fastc_read_u32_le(file, 16))
+	mut sizeofcmds := int(fastc_read_u32_le(file, 20))
+	mut linkedit_cmd := -1
+	mut text_limit := u64(0)
+	mut signature_cmd := -1
+	mut offset := macho_header_size
+	for _ in 0 .. ncmds {
+		if offset + 8 > file.len {
+			return error('`${path}`: truncated load commands')
+		}
+		cmd := fastc_read_u32_le(file, offset)
+		cmdsize := int(fastc_read_u32_le(file, offset + 4))
+		if cmdsize < 8 || offset + cmdsize > file.len {
+			return error('`${path}`: bad load command size')
+		}
+		if cmd == macho_lc_segment_64 {
+			segname := fastc_c_string_at(file, offset + 8, 16)
+			if segname == '__LINKEDIT' {
+				linkedit_cmd = offset
+			} else if segname == '__TEXT' {
+				text_limit = fastc_read_u64_le(file, offset + 48) // filesize
+			}
+		} else if cmd == macho_lc_code_signature {
+			signature_cmd = offset
+		}
+		offset += cmdsize
+	}
+	if linkedit_cmd < 0 {
+		return error('`${path}`: no __LINKEDIT segment')
+	}
+	// The signed range ends where the signature starts: at the old signature
+	// when there is one, else at the (16-byte padded) end of the file.
+	mut code_limit := file.len
+	if signature_cmd >= 0 {
+		code_limit = int(fastc_read_u32_le(file, signature_cmd + 8))
+		if code_limit > file.len {
+			return error('`${path}`: signature past the end of the file')
+		}
+		file.trim(code_limit)
+	} else {
+		load_end := macho_header_size + sizeofcmds
+		if load_end + 16 > file.len {
+			return error('`${path}`: no room for a signature load command')
+		}
+		for k in 0 .. 16 {
+			if file[load_end + k] != 0 {
+				return error('`${path}`: no room for a signature load command')
+			}
+		}
+		signature_cmd = load_end
+		ncmds++
+		sizeofcmds += 16
+		fastc_write_u32_le(mut file, 16, u32(ncmds))
+		fastc_write_u32_le(mut file, 20, u32(sizeofcmds))
+		fastc_write_u32_le(mut file, signature_cmd, macho_lc_code_signature)
+		fastc_write_u32_le(mut file, signature_cmd + 4, 16)
+	}
+	// Only the load commands and the tail from here (padding and signature)
+	// change; they are patched into the file rather than rewriting it all.
+	tail_start := file.len
+	for code_limit % 16 != 0 {
+		file << 0
+		code_limit++
+	}
+	ident := path.all_after_last('/')
+	signature_size := fastc_adhoc_signature_size(ident, code_limit)
+	// The header and __LINKEDIT sizes are part of the hashed pages, so they
+	// are settled before hashing.
+	fastc_write_u32_le(mut file, signature_cmd + 8, u32(code_limit))
+	fastc_write_u32_le(mut file, signature_cmd + 12, u32(signature_size))
+	linkedit_fileoff := fastc_read_u64_le(file, linkedit_cmd + 40)
+	linkedit_filesize := u64(code_limit + signature_size) - linkedit_fileoff
+	linkedit_vmsize := (linkedit_filesize + u64(macho_page_size) - 1) / u64(macho_page_size) * u64(macho_page_size)
+	fastc_write_u64_le(mut file, linkedit_cmd + 32, linkedit_vmsize)
+	fastc_write_u64_le(mut file, linkedit_cmd + 48, linkedit_filesize)
+	signature := fastc_adhoc_signature(file, code_limit, ident, text_limit)
+	if signature.len != signature_size {
+		return error('`${path}`: signature size mismatch')
+	}
+	file << signature
+	load_end := macho_header_size + sizeofcmds
+	mut out := os.open_file(path, 'r+')!
+	out.write_to(0, file[..load_end]) or {
+		out.close()
+		return err
+	}
+	out.write_to(u64(tail_start), file[tail_start..]) or {
+		out.close()
+		return err
+	}
+	if original_len > file.len {
+		// A larger old signature is cut off.
+		out.flush()
+		if C.ftruncate(i32(out.fd), u64(file.len)) != 0 {
+			out.close()
+			return error('`${path}`: could not truncate the old signature')
+		}
+	}
+	out.close()
+}
+
+fn fastc_adhoc_signature_size(ident string, code_limit int) int {
+	n_pages := (code_limit + cs_page_size - 1) / cs_page_size
+	cd_size := 88 + ident.len + 1 + 2 * cs_hash_size + n_pages * cs_hash_size
+	cd_size_aligned := (cd_size + 3) & ~3
+	return 12 + 24 + cd_size_aligned + 12 + 8
+}
+
+// fastc_adhoc_signature builds the embedded signature super blob over the
+// first `code_limit` bytes of `file`.
+fn fastc_adhoc_signature(file []u8, code_limit int, ident string, text_limit u64) []u8 {
+	n_pages := (code_limit + cs_page_size - 1) / cs_page_size
+	ident_len := ident.len + 1
+	n_special_slots := 2
+	cd_header_size := 88
+	ident_offset := cd_header_size
+	hash_offset := ident_offset + ident_len + n_special_slots * cs_hash_size
+	cd_size := hash_offset + n_pages * cs_hash_size
+	cd_size_aligned := (cd_size + 3) & ~3
+	req_size := 12
+	cms_size := 8
+	cd_blob_offset := 12 + 24
+	req_blob_offset := cd_blob_offset + cd_size_aligned
+	cms_blob_offset := req_blob_offset + req_size
+	total_size := cms_blob_offset + cms_size
+	mut sig := []u8{cap: total_size}
+	fastc_push_u32_be(mut sig, cs_super_blob_magic)
+	fastc_push_u32_be(mut sig, u32(total_size))
+	fastc_push_u32_be(mut sig, 3)
+	fastc_push_u32_be(mut sig, 0) // CSSLOT_CODEDIRECTORY
+	fastc_push_u32_be(mut sig, u32(cd_blob_offset))
+	fastc_push_u32_be(mut sig, 2) // CSSLOT_REQUIREMENTS
+	fastc_push_u32_be(mut sig, u32(req_blob_offset))
+	fastc_push_u32_be(mut sig, 0x10000) // CSSLOT_SIGNATURESLOT
+	fastc_push_u32_be(mut sig, u32(cms_blob_offset))
+	fastc_push_u32_be(mut sig, cs_code_directory_magic)
+	fastc_push_u32_be(mut sig, u32(cd_size))
+	fastc_push_u32_be(mut sig, 0x20400) // version
+	fastc_push_u32_be(mut sig, 0x2) // flags: CS_ADHOC
+	fastc_push_u32_be(mut sig, u32(hash_offset))
+	fastc_push_u32_be(mut sig, u32(ident_offset))
+	fastc_push_u32_be(mut sig, u32(n_special_slots))
+	fastc_push_u32_be(mut sig, u32(n_pages))
+	fastc_push_u32_be(mut sig, u32(code_limit))
+	sig << u8(cs_hash_size)
+	sig << u8(2) // CS_HASHTYPE_SHA256
+	sig << u8(0) // platform
+	sig << u8(cs_page_shift)
+	fastc_push_u32_be(mut sig, 0) // spare2
+	fastc_push_u32_be(mut sig, 0) // scatterOffset
+	fastc_push_u32_be(mut sig, 0) // teamOffset
+	fastc_push_u32_be(mut sig, 0) // spare3
+	fastc_push_u64_be(mut sig, 0) // codeLimit64
+	fastc_push_u64_be(mut sig, 0) // execSegBase
+	fastc_push_u64_be(mut sig, text_limit) // execSegLimit
+	fastc_push_u64_be(mut sig, 1) // execSegFlags: CS_EXECSEG_MAIN_BINARY
+	for b in ident.bytes() {
+		sig << b
+	}
+	sig << u8(0)
+	// Special slot -2: the requirements blob's hash; slot -1 (Info.plist): none.
+	mut req_blob := []u8{cap: req_size}
+	fastc_push_u32_be(mut req_blob, cs_requirements_magic)
+	fastc_push_u32_be(mut req_blob, u32(req_size))
+	fastc_push_u32_be(mut req_blob, 0)
+	sig << sha256.sum256(req_blob)
+	for _ in 0 .. cs_hash_size {
+		sig << u8(0)
+	}
+	// The page hashes: the system digest on macOS (where the signature is
+	// used); elsewhere V's SHA-256, which a self-hosted (TinyCC-built)
+	// compiler runs at a few tens of MB/s, so the pages are split over
+	// worker threads.
+	mut page_hashes := []u8{len: n_pages * cs_hash_size}
+	data_ptr := unsafe { &u8(file.data) }
+	hashes_ptr := unsafe { &u8(page_hashes.data) }
+	$if macos {
+		fastc_hash_code_pages_native(data_ptr, hashes_ptr, n_pages, code_limit)
+	} $else {
+		if n_pages >= 64 {
+			worker_count := 8
+			mut workers := [
+				spawn fastc_hash_code_pages(data_ptr, hashes_ptr, 0, n_pages / worker_count, code_limit),
+			]
+			for worker in 1 .. worker_count {
+				start := n_pages * worker / worker_count
+				end := n_pages * (worker + 1) / worker_count
+				workers << spawn fastc_hash_code_pages(data_ptr, hashes_ptr, start, end, code_limit)
+			}
+			for worker in workers {
+				worker.wait()
+			}
+		} else {
+			fastc_hash_code_pages(data_ptr, hashes_ptr, 0, n_pages, code_limit)
+		}
+	}
+	sig << page_hashes
+	for sig.len < req_blob_offset {
+		sig << u8(0)
+	}
+	sig << req_blob
+	fastc_push_u32_be(mut sig, cs_blob_wrapper_magic)
+	fastc_push_u32_be(mut sig, u32(cms_size))
+	return sig
+}
+
+// fastc_hash_code_pages writes the SHA-256 of the pages [page_start, page_end)
+// of the `code_limit` bytes at `data` into `hashes` (32 bytes per page).
+fn fastc_hash_code_pages(data &u8, hashes &u8, page_start int, page_end int, code_limit int) bool {
+	for page in page_start .. page_end {
+		start := page * cs_page_size
+		mut end := start + cs_page_size
+		if end > code_limit {
+			end = code_limit
+		}
+		page_bytes := unsafe { (data + start).vbytes(end - start) }
+		digest := sha256.sum256(page_bytes)
+		unsafe { vmemcpy(hashes + page * cs_hash_size, digest.data, cs_hash_size) }
+	}
+	return true
+}
+
+@[direct_array_access]
+fn fastc_read_u32_le(data []u8, offset int) u32 {
+	return u32(data[offset]) | (u32(data[offset + 1]) << 8) | (u32(data[offset + 2]) << 16) | (u32(data[offset + 3]) << 24)
+}
+
+@[direct_array_access]
+fn fastc_read_u64_le(data []u8, offset int) u64 {
+	return u64(fastc_read_u32_le(data, offset)) | (u64(fastc_read_u32_le(data, offset + 4)) << 32)
+}
+
+@[direct_array_access]
+fn fastc_write_u32_le(mut data []u8, offset int, value u32) {
+	data[offset] = u8(value)
+	data[offset + 1] = u8(value >> 8)
+	data[offset + 2] = u8(value >> 16)
+	data[offset + 3] = u8(value >> 24)
+}
+
+fn fastc_write_u64_le(mut data []u8, offset int, value u64) {
+	fastc_write_u32_le(mut data, offset, u32(value))
+	fastc_write_u32_le(mut data, offset + 4, u32(value >> 32))
+}
+
+fn fastc_push_u32_be(mut data []u8, value u32) {
+	data << u8(value >> 24)
+	data << u8(value >> 16)
+	data << u8(value >> 8)
+	data << u8(value)
+}
+
+fn fastc_push_u64_be(mut data []u8, value u64) {
+	fastc_push_u32_be(mut data, u32(value >> 32))
+	fastc_push_u32_be(mut data, u32(value))
+}
+
+@[direct_array_access]
+fn fastc_c_string_at(data []u8, offset int, max int) string {
+	mut end := offset
+	for end < offset + max && end < data.len && data[end] != 0 {
+		end++
+	}
+	return data[offset..end].bytestr()
+}

--- a/vlib/v3/gen/fastc/macho_sign_darwin.c.v
+++ b/vlib/v3/gen/fastc/macho_sign_darwin.c.v
@@ -1,0 +1,41 @@
+module fastc
+
+#include <CommonCrypto/CommonDigest.h>
+
+fn C.CC_SHA256(data voidptr, len u32, md &u8) &u8
+
+// fastc_hash_code_pages_native writes the SHA-256 of the pages [0, page_count)
+// of `data` (the last one ending at `code_limit`) to `hashes`, with the
+// system's hardware-accelerated digest: a few megabytes per millisecond,
+// where the V implementation compiled by TinyCC manages tens per second.
+// Larger files are split over a few threads (the hashing allocates nothing).
+fn fastc_hash_code_pages_native(data &u8, hashes &u8, page_count int, code_limit int) {
+	if page_count < 256 {
+		fastc_hash_native_range(data, hashes, 0, page_count, code_limit)
+		return
+	}
+	worker_count := 4
+	mut workers := [
+		spawn fastc_hash_native_range(data, hashes, 0, page_count / worker_count, code_limit),
+	]
+	for worker in 1 .. worker_count {
+		workers << spawn fastc_hash_native_range(data, hashes, page_count * worker / worker_count, page_count * (worker + 1) / worker_count, code_limit)
+	}
+	for worker in workers {
+		worker.wait()
+	}
+}
+
+fn fastc_hash_native_range(data &u8, hashes &u8, page_start int, page_end int, code_limit int) bool {
+	for page in page_start .. page_end {
+		start := page * cs_page_size
+		mut end := start + cs_page_size
+		if end > code_limit {
+			end = code_limit
+		}
+		unsafe {
+			C.CC_SHA256(data + start, u32(end - start), hashes + page * cs_hash_size)
+		}
+	}
+	return true
+}

--- a/vlib/v3/gen/fastc/macho_sign_test.v
+++ b/vlib/v3/gen/fastc/macho_sign_test.v
@@ -2,6 +2,21 @@ module fastc
 
 import os
 
+fn test_fastc_codesign_shim_restores_path() {
+	if os.user_os() != 'macos' {
+		return
+	}
+	previous_path := os.getenv_opt('PATH')
+	shim := fastc_codesign_shim_dir()
+	if shim.dir == '' {
+		return
+	}
+	assert os.getenv('PATH').starts_with(shim.dir + ':')
+	fastc_remove_codesign_shim_dir(shim)
+	assert os.getenv_opt('PATH') == previous_path
+	assert !os.exists(shim.dir)
+}
+
 // A TinyCC-linked executable signed in process must run and pass Apple's
 // signature verification.
 fn test_fastc_sign_macho_adhoc_matches_codesign() {

--- a/vlib/v3/gen/fastc/macho_sign_test.v
+++ b/vlib/v3/gen/fastc/macho_sign_test.v
@@ -1,0 +1,70 @@
+module fastc
+
+import os
+
+// A TinyCC-linked executable signed in process must run and pass Apple's
+// signature verification.
+fn test_fastc_sign_macho_adhoc_matches_codesign() {
+	if os.user_os() != 'macos' {
+		return
+	}
+	tcc := os.join_path(@VEXEROOT, 'thirdparty', 'tcc', 'tcc.exe')
+	if !os.is_file(tcc) {
+		return
+	}
+	test_dir := os.join_path(os.temp_dir(), 'fastc_macho_sign_${os.getpid()}')
+	os.mkdir_all(test_dir) or { panic(err) }
+	defer {
+		os.rmdir_all(test_dir) or {}
+	}
+	source_path := os.join_path_single(test_dir, 'hello.c')
+	exe_path := os.join_path_single(test_dir, 'hello')
+	os.write_file(source_path, 'int puts(const char *);\nint main(void) { puts("signed"); return 0; }\n') or {
+		panic(err)
+	}
+	tcc_lib := os.join_path(@VEXEROOT, 'thirdparty', 'tcc', 'lib')
+	mut args := ['-std=gnu11', '-B${tcc_lib}', '-I${os.join_path_single(tcc_lib, 'include')}',
+		'-L${tcc_lib}']
+	mut sdk_root := os.getenv('SDKROOT')
+	if !os.is_dir(sdk_root) {
+		result := os.execute('xcrun --show-sdk-path')
+		if result.exit_code == 0 {
+			sdk_root = result.output.trim_space()
+		}
+	}
+	if os.is_dir(sdk_root) {
+		args << '-L${os.join_path(sdk_root, 'usr', 'lib')}'
+	}
+	args << ['-w', '-o', exe_path, source_path]
+	// Without `codesign` on PATH TinyCC leaves the executable unsigned (and
+	// reports the failed call), which is what the signer is given.
+	old_path := os.getenv('PATH')
+	os.setenv('PATH', '/nonexistent', true)
+	os.execute('${tcc} ${args.join(' ')}')
+	os.setenv('PATH', old_path, true)
+	assert os.is_file(exe_path)
+	unsigned := os.execute(exe_path)
+	assert unsigned.exit_code != 0
+	fastc_sign_macho_adhoc(exe_path) or { panic(err) }
+	signed := os.execute(exe_path)
+	assert signed.exit_code == 0, signed.output
+	assert signed.output.trim_space() == 'signed'
+	verify := os.execute('codesign --verify --strict ${exe_path}')
+	assert verify.exit_code == 0, verify.output
+	// Signing again replaces the signature.
+	fastc_sign_macho_adhoc(exe_path) or { panic(err) }
+	again := os.execute('codesign --verify --strict ${exe_path}')
+	assert again.exit_code == 0, again.output
+	// Re-signing under a shorter name replaces a larger signature (the
+	// identifier is the file name): the file shrinks and still verifies.
+	long_path := os.join_path_single(test_dir, 'hello_with_a_much_longer_file_name')
+	os.cp(exe_path, long_path) or { panic(err) }
+	fastc_sign_macho_adhoc(long_path) or { panic(err) }
+	long_size := os.file_size(long_path)
+	os.mv(long_path, exe_path) or { panic(err) }
+	fastc_sign_macho_adhoc(exe_path) or { panic(err) }
+	assert os.file_size(exe_path) < long_size
+	shrunk := os.execute('codesign --verify --strict ${exe_path}')
+	assert shrunk.exit_code == 0, shrunk.output
+	assert os.execute(exe_path).output.trim_space() == 'signed'
+}

--- a/vlib/v3/gen/fastc/parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/fastc/parallel_notd_v3_no_parallel.v
@@ -56,24 +56,6 @@ fn fastc_wait_interface_dispatches(mut pending FastcPendingInterfaceDispatches) 
 	return pending.workers[0].wait()
 }
 
-// fastc_parallel_worker_limit is the number of worker threads a parallel
-// phase may run at once: the CPU count, overridden by VJOBS, and 1 when
-// parallelism is disabled.
-fn fastc_parallel_worker_limit(prefs &pref.Preferences) int {
-	if prefs.no_parallel {
-		return 1
-	}
-	mut jobs := fastc_nr_cpus()
-	vjobs := os.getenv('VJOBS').int()
-	if vjobs > 0 {
-		jobs = vjobs
-	}
-	if os.getenv('V3_FASTC_NO_PARALLEL') != '' {
-		jobs = 1
-	}
-	return jobs
-}
-
 fn fastc_parallel_job_count(item_count int, prefs &pref.Preferences) int {
 	mut jobs := fastc_parallel_worker_limit(prefs)
 	if jobs > item_count {

--- a/vlib/v3/gen/fastc/stmt.v
+++ b/vlib/v3/gen/fastc/stmt.v
@@ -1888,7 +1888,7 @@ fn (mut g Parser) parse_declaration_after_name(name string, is_mut bool) ! {
 		// literal or C-`int` expression would give C `int` (32-bit), silently
 		// truncating `int` arithmetic. Spell the platform int type explicitly so the
 		// local matches the width used for `int` params, fields, and the C backend.
-		g.write_line('${fastc_platform_int_c_type} ${c_name} = (${expression});')
+		g.write_line('${fastc_platform_int_c_type()} ${c_name} = (${expression});')
 	} else {
 		g.write_line('__typeof__((${expression})) ${c_name} = (${expression});')
 	}

--- a/vlib/v3/gen/fastc/stmt.v
+++ b/vlib/v3/gen/fastc/stmt.v
@@ -1888,7 +1888,7 @@ fn (mut g Parser) parse_declaration_after_name(name string, is_mut bool) ! {
 		// literal or C-`int` expression would give C `int` (32-bit), silently
 		// truncating `int` arithmetic. Spell the platform int type explicitly so the
 		// local matches the width used for `int` params, fields, and the C backend.
-		g.write_line('${fastc_platform_int_c_type()} ${c_name} = (${expression});')
+		g.write_line('${fastc_platform_int_c_type} ${c_name} = (${expression});')
 	} else {
 		g.write_line('__typeof__((${expression})) ${c_name} = (${expression});')
 	}

--- a/vlib/v3/gen/fastc/unit_compile_nix.c.v
+++ b/vlib/v3/gen/fastc/unit_compile_nix.c.v
@@ -1,0 +1,118 @@
+module fastc
+
+import os
+import time
+
+fn C.v_os_exec_capture_start(argv &&char, child_pid &int, read_fd &int) int
+
+fn C.waitpid(pid int, status &int, options int) int
+
+struct FastcUnitCompile {
+	pid     int
+	read_fd int
+	object  string
+}
+
+// fastc_compile_c_units compiles the translation units to objects with
+// concurrent TinyCC processes (started with posix_spawn, which is cheaper
+// than forking the compiler process), and returns the object paths, or the
+// output of the first compile that failed.
+pub fn fastc_compile_c_units(tcc string, base_args []string, unit_paths []string) ![]string {
+	bench_phases := os.getenv('FASTC_BENCH_PHASES') != ''
+	sw := time.new_stopwatch()
+	mut compiles := []FastcUnitCompile{cap: unit_paths.len}
+	mut start_error := ''
+	for unit_path in unit_paths {
+		object := unit_path[..unit_path.len - 2] + '.o'
+		mut args := [tcc]
+		args << base_args
+		args << ['-c', unit_path, '-o', object]
+		mut pid := 0
+		mut read_fd := -1
+		if !fastc_start_capture(args, &pid, &read_fd) {
+			start_error = 'could not start ${tcc} for ${unit_path}'
+			break
+		}
+		compiles << FastcUnitCompile{
+			pid: pid
+			read_fd: read_fd
+			object: object
+		}
+	}
+	if bench_phases {
+		eprintln('fastc-phase tcc.units_started ${sw.elapsed().microseconds()}us')
+	}
+	mut objects := []string{cap: unit_paths.len}
+	mut failure := start_error
+	for compile in compiles {
+		// The merged output is drained before the wait, so a compiler that
+		// prints more than a pipe buffer of diagnostics cannot block.
+		output := os.fd_slurp(compile.read_fd).join('')
+		os.fd_close(compile.read_fd)
+		code := fastc_wait_exit_code(compile.pid)
+		if bench_phases {
+			eprintln('fastc-phase tcc.unit_done ${sw.elapsed().microseconds()}us ${os.file_name(compile.object)}')
+		}
+		if code != 0 && failure == '' {
+			failure = if output.len > 0 { output } else { 'tcc failed on ${compile.object}' }
+		}
+		objects << compile.object
+	}
+	if failure != '' {
+		return error(failure)
+	}
+	return objects
+}
+
+// fastc_run_command runs the program with the argument vector and returns
+// its exit code and merged output, like cmdexec.run, but through posix_spawn
+// and a blocking wait rather than a fork of this (large) process and a
+// polling loop.
+pub fn fastc_run_command(program string, args []string) os.Result {
+	mut argv := [program]
+	argv << args
+	mut pid := 0
+	mut read_fd := -1
+	if !fastc_start_capture(argv, &pid, &read_fd) {
+		return os.Result{
+			exit_code: -1
+			output: 'could not start ${program}'
+		}
+	}
+	output := os.fd_slurp(read_fd).join('')
+	os.fd_close(read_fd)
+	return os.Result{
+		exit_code: fastc_wait_exit_code(pid)
+		output: output
+	}
+}
+
+// fastc_start_capture starts the program of the argument vector with its
+// stdout and stderr merged into a pipe, and reports whether it started.
+fn fastc_start_capture(argv []string, pid &int, read_fd &int) bool {
+	mut cargs := []&char{cap: argv.len + 1}
+	for arg in argv {
+		cargs << &char(arg.str)
+	}
+	cargs << &char(unsafe { nil })
+	return C.v_os_exec_capture_start(cargs.data, pid, read_fd) == 0
+}
+
+// fastc_wait_exit_code waits for the process and returns its exit code; a
+// process killed by a signal reports 128 plus the signal number.
+fn fastc_wait_exit_code(pid int) int {
+	mut status := 0
+	for {
+		C.errno = 0
+		if C.waitpid(pid, &status, 0) != -1 {
+			break
+		}
+		if C.errno != C.EINTR {
+			return -1
+		}
+	}
+	if (status & 0x7f) == 0 {
+		return (status >> 8) & 0xff
+	}
+	return 128 + (status & 0x7f)
+}

--- a/vlib/v3/gen/fastc/unit_compile_windows.c.v
+++ b/vlib/v3/gen/fastc/unit_compile_windows.c.v
@@ -1,0 +1,52 @@
+module fastc
+
+import os
+import v3.cmdexec
+
+struct FastcUnitCompile {
+mut:
+	process &os.Process = unsafe { nil }
+	object  string
+}
+
+// fastc_compile_c_units compiles the translation units to objects with
+// concurrent TinyCC processes and returns the object paths, or the output of
+// the first compile that failed.
+pub fn fastc_compile_c_units(tcc string, base_args []string, unit_paths []string) ![]string {
+	mut compiles := []FastcUnitCompile{cap: unit_paths.len}
+	for unit_path in unit_paths {
+		object := unit_path[..unit_path.len - 2] + '.o'
+		mut args := base_args.clone()
+		args << ['-c', unit_path, '-o', object]
+		mut process := os.new_process(tcc)
+		process.set_args(args)
+		process.set_redirect_stdio_merged()
+		process.run()
+		compiles << FastcUnitCompile{
+			process: process
+			object: object
+		}
+	}
+	mut objects := []string{cap: unit_paths.len}
+	mut failure := ''
+	for mut compile in compiles {
+		compile.process.wait()
+		output := compile.process.stdout_slurp()
+		code := compile.process.code
+		compile.process.close()
+		if code != 0 && failure == '' {
+			failure = if output.len > 0 { output } else { 'tcc failed on ${compile.object}' }
+		}
+		objects << compile.object
+	}
+	if failure != '' {
+		return error(failure)
+	}
+	return objects
+}
+
+// fastc_run_command runs the program with the argument vector and returns
+// its exit code and merged output.
+pub fn fastc_run_command(program string, args []string) os.Result {
+	return cmdexec.run(program, args)
+}


### PR DESCRIPTION
Reduces what TinyCC has to compile for a FastC self-host build, then runs TinyCC concurrently and takes Apple's `codesign` out of the loop. Everything is verified with the self-host chain (`v4 → v5 → v6`, `v5.c == v6.c`, also with `VJOBS=1` and `V3_FASTC_NO_PARALLEL=1`, every output passing `codesign --verify --strict`) and the FastC unit tests (only the 4 known `test_selfhost_*` failures and the known panic remain).

## No `#include` in the generated C
- `gen/fastc/c_abi.v` holds, per target (64-bit macOS, glibc Linux x86_64/aarch64), the C library declarations the emitted code uses: integer/size typedefs, `struct stat`/`dirent`/`timespec`/`timeval`/`tm` layouts, pthread type sizes, `fd_set` with `FD_*` macros, the `O_*`/`S_*`/errno/`SEEK_*`/`PROT_*`/`MAP_*`/... values, `stdin`/`stdout`/`stderr`/`errno`/`environ`, and exact prototypes for ~100 functions (with `__asm__` labels for `realpath$DARWIN_EXTSN` and the x86_64 macOS `$INODE64` family).
- A self-host build replaces the preamble's header block with that prelude, leaves the `#include` lines of V sources out of the output, and inlines V's own C helper headers (`vlib/os/execute_capture_nix.h`, `vlib/sync/thread_helper.h`, ...) after the prelude with their include lines stripped (`thread_helper.h` gained a `V_FASTC_NO_HEADERS` guard). Other targets keep the headers.
- The build passes `-Werror=implicit-function-declaration` and no longer passes `-w` (which silenced it in either order): a C function missing from the table fails the build instead of being called through an implicit `int` prototype that truncates pointer results (that is how a missing `fdopen` crashed a self-host in `flockfile` during this work).
- `c_abi_test.v` compiles the prelude (with a `v_abi_` prefix) next to the real headers with the bundled TinyCC and checks every type size, struct field offset, macro value and prototype (`_Static_assert` + `__builtin_types_compatible_p`), then runs the `PTHREAD_ONCE_INIT`/`FD_SET`/`errno`/stdio/`environ` checks. It runs on whichever host executes the tests, so the Linux tables are checked by the Linux CI jobs.

TinyCC parsed 109,893 preprocessed lines before (64K of them from the headers); it now parses the 42,497 lines of the file itself.

## Reachability prune
The source-level reachability keeps every function that shares a used name, so the self-host C carried ~5K lines of functions nothing calls (`strconv` converters, `map_free`, `wtf8_*`, enum print helpers, ...). Now each generation worker records, per function, its C span, its prototype span and the indexed C names it mentions (an identifier scan for `__`/`v_fastc_` names looked up in a C-name table built from the signature index before generation); the stitch walks from `main`, the lifecycle hooks and every non-body piece (runtime, constants, globals, dispatch tables, spawn helpers, generic instances) and cuts the unreachable functions, their prototypes and the unused enum `str`/print helpers (now per-enum pieces) out of the emitted ranges, with no copy of the kept text. Bare main-module names are not indexed (always kept), and a program without `main` keeps everything. The prune costs about 0.6 ms in the stitch.

## Concurrent TinyCC units
- `fastc_write_c_units` cuts the pieces into up to 8 translation units (`VJOBS` caps it; `VJOBS=1` keeps the single-file build): the head (typedefs, prototypes, runtime) in every unit, the interface dispatch tables, lifecycle functions and `main` only in the first, the file bodies grouped by size; the constants and globals are definitions in the first unit and `extern` declarations in the others. The units are written by concurrent threads (one buffered write each).
- `fastc_compile_c_units` compiles them with concurrent `tcc -c` processes started through `posix_spawn` (`v_os_exec_capture_start`; forking the 220 MB driver with `os.Process` cost 4 ms more), drains their output and waits; one `tcc` call links the objects, also through `posix_spawn` instead of `cmdexec`'s fork-and-poll loop. `-keepc` still writes the whole program as one file, and that file is identical to the single-unit build's.
- `unit_compile_nix.c.v` / `unit_compile_windows.c.v` hold the platform variants (Windows keeps `os.Process`).

## No Apple `codesign`
TinyCC signs the executables it links on macOS by running `codesign -f -s - <file>`, which costs ~50 ms per build. The drivers put a no-op `codesign` (a link to `/usr/bin/true`) first on TinyCC's PATH and ad-hoc sign the Mach-O themselves: `gen/fastc/macho_sign.v` reuses or adds the `LC_CODE_SIGNATURE` load command, patches the `__LINKEDIT` sizes, and appends a SuperBlob with a v0x20400 CodeDirectory (SHA-256 4 KiB page hashes through CommonCrypto on macOS, in about a millisecond), empty requirements and empty CMS wrapper, patched into the file in place. `macho_sign_test.v` links a program with TinyCC without any `codesign`, signs it, runs it, verifies it with `codesign --verify --strict`, re-signs it, and replaces a larger signature.

## Also
- The macOS SDK path is taken from `SDKROOT` or the known SDK directories before `xcrun --show-sdk-path` is run; that call cost 7-9 ms inside every build (master pays it too).
- `fastc_platform_int_c_type` stays a global (master fixed the bootstrap build itself in #28307).
- Both drivers print `tcc.*` phase marks under `FASTC_BENCH_PHASES=1` (units written/started/compiled, linked, signed).

## Numbers (`vlib/v3/v3.v`, 177 files, 70.4K lines; clang `-O2 -gc none -prealloc` drivers, interleaved, quiet machine)
| | master | this PR |
|---|---|---|
| self-host C | 47,106 lines, 38 `#include` | 42.5K lines, 0 `#include`, 8 units |
| driver `fastc parse+gen` row | 14-15.5 ms | 15.5-17.5 ms |
| driver `tcc` row | 99-104 ms | 29-32 ms |
| driver `total` | 115-118 ms | 47-50 ms |
| TinyCC-built self-host, whole `v5 → v6` build | 0.16-0.18 s | 0.10 s |

The `tcc` row is now ~0.8 ms writing the units, ~13-14 ms of concurrent compiles (8 processes on 6 performance cores), ~14 ms of TinyCC linking (7 ms of it fixed even for a tiny object: the `sh -c codesign` call, the stdlib and the output), ~1 ms signing and cleanup. Those floors, plus the ~16 ms of generation, put the whole build at 1.4-1.5M lines/s; the 2.5M lines/s (28 ms) target is not reachable with TinyCC as an external compile-and-link step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
