### PR TITLE
vfmt: stop rewriting a NUL escape into an octal escape

### DIFF
--- a/vlib/v3/gen/v/gen.v
+++ b/vlib/v3/gen/v/gen.v
@@ -4185,10 +4185,11 @@ fn escape_string(s string, quote u8) string {
 			12 {
 				b.write_string('\\f')
 			}
-			0 {
-				b.write_string('\\0')
-			}
 			else {
+				// NUL is written as `\\x00`, never `\\0`: `u8.hex()` always emits two digits, so
+				// the escape cannot absorb a following character, whereas `\\0` before an octal
+				// digit re-parses as one octal escape and silently changes the string's bytes
+				// (`'x\\x0041y'` would come back as `'x\\041y'`, i.e. `x!y`).
 				if c < 32 || c == 127 {
 					b.write_string('\\x${c.hex()}')
 				} else if c == quote {

--- a/vlib/v3/gen/v/gen_test.v
+++ b/vlib/v3/gen/v/gen_test.v
@@ -1591,3 +1591,18 @@ fn test_formatter_keeps_rows_of_small_nested_arrays_on_one_line() {
 	out := vfmt('rows_of_small_nested_arrays', source)
 	assert out == source, out
 }
+
+// A NUL byte must be written as `\x00`, not `\0`. V's octal escape absorbs the digits that
+// follow, so `\0` before an octal digit re-parses as a single escape and the formatter would
+// silently rewrite the string's bytes: `'x\x0041y'` (x, NUL, `4`, `1`, y) came back as
+// `'x\041y'`, which is `x!y`.
+fn test_formatter_keeps_nul_escape_unambiguous() {
+	source := "fn main() {\n\ta := 'x\\x0041y'\n\tb := 'p\\x00q'\n\tc := `\\x00`\n\tprintln(a + b + c.str())\n}\n"
+	out := vfmt('nul_escape', source)
+	assert out.contains("'x\\x0041y'"), out
+	assert !out.contains('\\041'), out
+	assert out.contains("'p\\x00q'"), out
+	assert !out.contains("'p\\0q'"), out
+	assert out.contains('`\\x00`'), out
+	assert vfmt('nul_escape_twice', out) == out
+}


### PR DESCRIPTION
`v fmt -w` silently changes string data.

The V3 formatter stores string literals decoded and re-encodes them, and `escape_string` wrote a NUL byte as `\0`. V's octal escape absorbs the digits that follow it, so whenever a NUL is followed by an octal digit the re-encoded literal parses as a *different* string:

```v
a := 'x\x0041y'   // x, NUL, `4`, `1`, y  ->  [120, 0, 52, 49, 121]
```

after `v fmt -w` becomes

```v
a := 'x\041y'     // x, `!`, y            ->  [120, 33, 121]
```

Five bytes become three, with no diagnostic. Reproduced end to end by running the program before and after formatting.

## Fix

Drop the special case so NUL falls through to the `\x` branch. `u8.hex()` always emits two digits, so `\x00` cannot absorb a following character and the literal round-trips. That branch already handles every other control byte, so this removes a special case rather than adding one. It also covers the same hazard for `` `\0` `` char literals.

## Testing

- New regression test in `vlib/v3/gen/v/gen_test.v`, covering the octal-absorbing case, a plain `\x00`, a char literal, and idempotency. Confirmed it fails without the fix (`assert out.contains("'x\x0041y'")`) and passes with it.
- `v fmt -verify` over the tree accepts exactly the same files as before: 6214 pass, and the same 49 fail — I diffed the failing sets and they are identical. Those 49 fail for unrelated pre-existing reasons (files that match neither the V3 nor the legacy formatter, e.g. `FnWorkItem` in `vlib/v3/transform/transform.v`, where fields were added without re-running vfmt).
- `cmd/tools/vfmt_test.v` fails identically on pristine master (`test_fmt_checks_accept_legacy_formatted_source`), so it is pre-existing and unrelated.

## Not in this PR

While tracking this down I confirmed two further V3-formatter deviations from the legacy formatter, both style rather than correctness, so I left them out to keep this focused:

- `pub type F = fn (a int)` is reformatted to `fn(a int)` — the space is dropped.
- `$if !flag ? {` is reformatted to `$if !flag? {`.

Happy to do either as a follow-up. Note also that `v fmt -w` rewriting legacy-formatted files wholesale is by design — `verify_file` deliberately accepts both formatters during the transition — so that churn is expected, not a bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)