### PR TITLE
vfmt: keep the space in `fn (` types and before a `$if` flag marker

### DIFF
--- a/vlib/v/tests/anon_fn_map_assign_test.v
+++ b/vlib/v/tests/anon_fn_map_assign_test.v
@@ -2,7 +2,7 @@
 // leak `cur_indexexpr`, so that any later non-scalar map/array assignment in the
 // same compilation unit was generated without the `= ` operator (broken C).
 // See https://github.com/vlang/v/issues (map assignment of fn literal leaks cgen state)
-type AnonFnMapAssignCb = fn(int) int
+type AnonFnMapAssignCb = fn (int) int
 
 struct AnonFnMapAssignPoint {
 	x int

--- a/vlib/v3/fastcdriver/fastcdriver.v
+++ b/vlib/v3/fastcdriver/fastcdriver.v
@@ -393,7 +393,7 @@ pub fn run(args []string) {
 	prefs.ccompiler = 'tinyc'
 	prefs.building_v = real_input.ends_with('/vlib/v3/v3.v')
 	prefs.selfhost = prefs.building_v
-	$if arm64? {
+	$if arm64 ? {
 		prefs.target = pref.Target{
 			os: 'macos'
 			arch: 'arm64'

--- a/vlib/v3/gen/fastc/arm64_test.v
+++ b/vlib/v3/gen/fastc/arm64_test.v
@@ -4,7 +4,7 @@ import os
 import v3.pref
 
 fn test_fastc_parser_emits_arm64_without_c() {
-	$if arm64? {
+	$if arm64 ? {
 		test_dir := os.join_path(os.temp_dir(), 'fastc_arm64_${os.getpid()}')
 		os.rmdir_all(test_dir) or {}
 		os.mkdir_all(test_dir) or { panic(err) }
@@ -30,7 +30,7 @@ fn test_fastc_parser_emits_arm64_without_c() {
 }
 
 fn test_fastc_arm64_lexical_scopes_and_array_mutation() {
-	$if arm64? {
+	$if arm64 ? {
 		test_dir := os.join_path(os.temp_dir(), 'fastc_arm64_scopes_${os.getpid()}')
 		os.rmdir_all(test_dir) or {}
 		os.mkdir_all(test_dir) or { panic(err) }
@@ -581,7 +581,7 @@ fn main() {
 }
 
 fn test_fastc_arm64_map_storage_and_numeric_conversions() {
-	$if arm64? {
+	$if arm64 ? {
 		test_dir := os.join_path(os.temp_dir(), 'fastc_arm64_map_numeric_${os.getpid()}')
 		os.rmdir_all(test_dir) or {}
 		os.mkdir_all(test_dir) or { panic(err) }
@@ -943,7 +943,7 @@ fn main() {
 }
 
 fn test_fastc_arm64_c_variadic_default_promotions() {
-	$if arm64? {
+	$if arm64 ? {
 		test_dir := os.join_path(os.temp_dir(), 'fastc_arm64_c_variadic_${os.getpid()}')
 		os.rmdir_all(test_dir) or {}
 		os.mkdir_all(test_dir) or { panic(err) }
@@ -972,7 +972,7 @@ fn main() {
 }
 
 fn test_fastc_arm64_spawn_for_general_programs() {
-	$if arm64? {
+	$if arm64 ? {
 		test_dir := os.join_path(os.temp_dir(), 'fastc_arm64_spawn_${os.getpid()}')
 		os.rmdir_all(test_dir) or {}
 		os.mkdir_all(test_dir) or { panic(err) }
@@ -1014,7 +1014,7 @@ fn test_fastc_arm64_spawn_for_general_programs() {
 }
 
 fn test_fastc_arm64_binds_c_externs_beyond_the_linker_allowlist() {
-	$if arm64? {
+	$if arm64 ? {
 		test_dir := os.join_path(os.temp_dir(), 'fastc_arm64_cextern_${os.getpid()}')
 		os.rmdir_all(test_dir) or {}
 		os.mkdir_all(test_dir) or { panic(err) }
@@ -1041,7 +1041,7 @@ fn test_fastc_arm64_binds_c_externs_beyond_the_linker_allowlist() {
 }
 
 fn test_fastc_arm64_array_index_bounds() {
-	$if arm64? {
+	$if arm64 ? {
 		test_dir := os.join_path(os.temp_dir(), 'fastc_arm64_bounds_${os.getpid()}')
 		os.rmdir_all(test_dir) or {}
 		os.mkdir_all(test_dir) or { panic(err) }
@@ -1084,7 +1084,7 @@ fn test_fastc_arm64_array_index_bounds() {
 }
 
 fn test_fastc_arm64_sizeof_is_unevaluated_and_array_shrinks_detach() {
-	$if arm64? {
+	$if arm64 ? {
 		test_dir := os.join_path(os.temp_dir(), 'fastc_arm64_sizeof_shrink_${os.getpid()}')
 		os.rmdir_all(test_dir) or {}
 		os.mkdir_all(test_dir) or { panic(err) }
@@ -1164,7 +1164,7 @@ fn main() {
 }
 
 fn test_fastc_arm64_array_aggregate_defaults_and_nested_clones_are_independent() {
-	$if arm64? {
+	$if arm64 ? {
 		test_dir := os.join_path(os.temp_dir(), 'fastc_arm64_array_clone_${os.getpid()}')
 		os.rmdir_all(test_dir) or {}
 		os.mkdir_all(test_dir) or { panic(err) }
@@ -1228,7 +1228,7 @@ fn main() {
 }
 
 fn test_fastc_arm64_cleared_array_growth_and_pointer_index_metadata() {
-	$if arm64? {
+	$if arm64 ? {
 		test_dir := os.join_path(os.temp_dir(), 'fastc_arm64_array_metadata_${os.getpid()}')
 		os.rmdir_all(test_dir) or {}
 		os.mkdir_all(test_dir) or { panic(err) }
@@ -1267,7 +1267,7 @@ fn main() {
 }
 
 fn test_fastc_arm64_array_many_insert_and_slice_byte_offsets() {
-	$if arm64? {
+	$if arm64 ? {
 		test_dir := os.join_path(os.temp_dir(), 'fastc_arm64_insert_slice_${os.getpid()}')
 		os.rmdir_all(test_dir) or {}
 		os.mkdir_all(test_dir) or { panic(err) }
@@ -1304,7 +1304,7 @@ fn main() {
 }
 
 fn test_fastc_arm64_struct_layout_attributes() {
-	$if arm64? {
+	$if arm64 ? {
 		test_dir := os.join_path(os.temp_dir(), 'fastc_arm64_struct_layout_${os.getpid()}')
 		os.rmdir_all(test_dir) or {}
 		os.mkdir_all(test_dir) or { panic(err) }
@@ -1383,7 +1383,7 @@ fn main() {
 }
 
 fn test_fastc_arm64_overaligned_local_stack_storage() {
-	$if arm64? {
+	$if arm64 ? {
 		test_dir := os.join_path(os.temp_dir(), 'fastc_arm64_overaligned_local_${os.getpid()}')
 		os.rmdir_all(test_dir) or {}
 		os.mkdir_all(test_dir) or { panic(err) }
@@ -1421,7 +1421,7 @@ fn main() {
 }
 
 fn test_fastc_arm64_zero_capacity_array_data_is_nil() {
-	$if arm64? {
+	$if arm64 ? {
 		test_dir := os.join_path(os.temp_dir(), 'fastc_arm64_empty_array_${os.getpid()}')
 		os.rmdir_all(test_dir) or {}
 		os.mkdir_all(test_dir) or { panic(err) }
@@ -1459,7 +1459,7 @@ fn test_fastc_arm64_zero_capacity_array_data_is_nil() {
 }
 
 fn test_fastc_arm64_execute_output_is_nul_terminated() {
-	$if arm64? {
+	$if arm64 ? {
 		test_dir := os.join_path(os.temp_dir(), 'fastc_arm64_execute_terminated_${os.getpid()}')
 		os.rmdir_all(test_dir) or {}
 		os.mkdir_all(test_dir) or { panic(err) }
@@ -1492,7 +1492,7 @@ fn main() {
 }
 
 fn test_fastc_arm64_empty_multi_append_preserves_slice_storage() {
-	$if arm64? {
+	$if arm64 ? {
 		test_dir := os.join_path(os.temp_dir(), 'fastc_arm64_empty_append_${os.getpid()}')
 		os.rmdir_all(test_dir) or {}
 		os.mkdir_all(test_dir) or { panic(err) }
@@ -1524,7 +1524,7 @@ fn test_fastc_arm64_empty_multi_append_preserves_slice_storage() {
 }
 
 fn test_fastc_arm64_trim_noop_preserves_slice_storage() {
-	$if arm64? {
+	$if arm64 ? {
 		test_dir := os.join_path(os.temp_dir(), 'fastc_arm64_trim_noop_${os.getpid()}')
 		os.rmdir_all(test_dir) or {}
 		os.mkdir_all(test_dir) or { panic(err) }
@@ -1556,7 +1556,7 @@ fn test_fastc_arm64_trim_noop_preserves_slice_storage() {
 }
 
 fn test_fastc_arm64_nonpositive_raw_push_many_is_noop() {
-	$if arm64? {
+	$if arm64 ? {
 		test_dir := os.join_path(os.temp_dir(), 'fastc_arm64_push_many_noop_${os.getpid()}')
 		os.rmdir_all(test_dir) or {}
 		os.mkdir_all(test_dir) or { panic(err) }
@@ -1586,7 +1586,7 @@ fn test_fastc_arm64_nonpositive_raw_push_many_is_noop() {
 }
 
 fn test_fastc_arm64_string_slice_owns_terminated_storage() {
-	$if arm64? {
+	$if arm64 ? {
 		test_dir := os.join_path(os.temp_dir(), 'fastc_arm64_string_slice_${os.getpid()}')
 		os.rmdir_all(test_dir) or {}
 		os.mkdir_all(test_dir) or { panic(err) }
@@ -1620,7 +1620,7 @@ fn main() {
 }
 
 fn test_fastc_arm64_replays_imported_initializers_in_declaring_module() {
-	$if arm64? {
+	$if arm64 ? {
 		test_dir := os.join_path(os.temp_dir(), 'fastc_arm64_imported_initializers_${os.getpid()}')
 		dependency_dir := os.join_path_single(test_dir, 'dependency')
 		os.rmdir_all(test_dir) or {}
@@ -1670,7 +1670,7 @@ fn main() {
 }
 
 fn test_fastc_arm64_typed_pointer_arithmetic_scales_offsets() {
-	$if arm64? {
+	$if arm64 ? {
 		test_dir := os.join_path(os.temp_dir(), 'fastc_arm64_pointer_arithmetic_${os.getpid()}')
 		os.rmdir_all(test_dir) or {}
 		os.mkdir_all(test_dir) or { panic(err) }
@@ -1702,7 +1702,7 @@ fn test_fastc_arm64_typed_pointer_arithmetic_scales_offsets() {
 }
 
 fn test_fastc_arm64_ownership_returning_collection_methods_deep_clone() {
-	$if arm64? {
+	$if arm64 ? {
 		test_dir := os.join_path(os.temp_dir(), 'fastc_arm64_collection_ownership_${os.getpid()}')
 		os.rmdir_all(test_dir) or {}
 		os.mkdir_all(test_dir) or { panic(err) }
@@ -1759,7 +1759,7 @@ fn main() {
 }
 
 fn test_fastc_arm64_path_overrides_match_os_normalization() {
-	$if arm64? {
+	$if arm64 ? {
 		test_dir := os.join_path(os.temp_dir(), 'fastc_arm64_paths_${os.getpid()}')
 		os.rmdir_all(test_dir) or {}
 		os.mkdir_all(test_dir) or { panic(err) }
@@ -1797,7 +1797,7 @@ fn main() {
 }
 
 fn test_fastc_arm64_join_path_trim_keeps_owned_base_pointer() {
-	$if arm64? {
+	$if arm64 ? {
 		test_dir := os.join_path(os.temp_dir(), 'fastc_arm64_join_owned_${os.getpid()}')
 		os.rmdir_all(test_dir) or {}
 		os.mkdir_all(test_dir) or { panic(err) }
@@ -1831,7 +1831,7 @@ fn main() {
 }
 
 fn test_fastc_arm64_integer_strings_keep_owned_base_pointers() {
-	$if arm64? {
+	$if arm64 ? {
 		test_dir := os.join_path(os.temp_dir(), 'fastc_arm64_integer_owned_${os.getpid()}')
 		os.rmdir_all(test_dir) or {}
 		os.mkdir_all(test_dir) or { panic(err) }
@@ -1867,7 +1867,7 @@ fn main() {
 }
 
 fn test_fastc_arm64_map_rehash_frees_superseded_buckets() {
-	$if arm64? {
+	$if arm64 ? {
 		mut prefs := pref.new_preferences()
 		mut program := FastArm64Program.new(prefs, map[string]bool{}, map[string]FastcFunctionSignature{}, map[string]FastArm64TypeDecl{}, map[string]FastArm64ConstantDecl{}, map[string]FastArm64ConstantDecl{})
 		program.register_functions()
@@ -1894,7 +1894,7 @@ fn test_fastc_arm64_map_rehash_frees_superseded_buckets() {
 }
 
 fn test_fastc_arm64_rejects_fixed_arity_call_mismatches() {
-	$if arm64? {
+	$if arm64 ? {
 		test_dir := os.join_path(os.temp_dir(), 'fastc_arm64_call_arity_${os.getpid()}')
 		os.rmdir_all(test_dir) or {}
 		os.mkdir_all(test_dir) or { panic(err) }
@@ -1945,7 +1945,7 @@ fn main() {
 }
 
 fn test_fastc_arm64_map_move_transfers_state() {
-	$if arm64? {
+	$if arm64 ? {
 		test_dir := os.join_path(os.temp_dir(), 'fastc_arm64_map_move_${os.getpid()}')
 		os.rmdir_all(test_dir) or {}
 		os.mkdir_all(test_dir) or { panic(err) }
@@ -1968,7 +1968,7 @@ fn test_fastc_arm64_map_move_transfers_state() {
 }
 
 fn test_fastc_arm64_source_location_pseudo_values() {
-	$if arm64? {
+	$if arm64 ? {
 		test_dir := os.join_path(os.temp_dir(), 'fastc_arm64_location_${os.getpid()}')
 		os.rmdir_all(test_dir) or {}
 		os.mkdir_all(test_dir) or { panic(err) }
@@ -2009,7 +2009,7 @@ fn main() {
 }
 
 fn test_fastc_arm64_remaining_pseudo_values() {
-	$if arm64? {
+	$if arm64 ? {
 		test_dir := os.join_path(os.temp_dir(), 'fastc_arm64_pseudo_${os.getpid()}')
 		git_dir := os.join_path_single(test_dir, '.git')
 		os.rmdir_all(test_dir) or {}
@@ -2061,7 +2061,7 @@ fn test_fastc_arm64_remaining_pseudo_values() {
 }
 
 fn test_fastc_arm64_c_style_for_assigning_existing_local() {
-	$if arm64? {
+	$if arm64 ? {
 		test_dir := os.join_path(os.temp_dir(), 'fastc_arm64_c_for_assign_${os.getpid()}')
 		os.rmdir_all(test_dir) or {}
 		os.mkdir_all(test_dir) or { panic(err) }
@@ -2094,7 +2094,7 @@ fn main() {
 }
 
 fn test_fastc_arm64_module_lifecycle_hooks() {
-	$if arm64? {
+	$if arm64 ? {
 		test_dir := os.join_path(os.temp_dir(), 'fastc_arm64_lifecycle_${os.getpid()}')
 		dependency_dir := os.join_path_single(test_dir, 'dependency')
 		os.rmdir_all(test_dir) or {}
@@ -2142,7 +2142,7 @@ fn cleanup() {
 }
 
 fn test_fastc_arm64_rejects_imported_source_output() {
-	$if arm64? {
+	$if arm64 ? {
 		test_dir := os.join_path(os.temp_dir(), 'fastc_arm64_output_alias_${os.getpid()}')
 		dependency_dir := os.join_path_single(test_dir, 'dependency')
 		os.rmdir_all(test_dir) or {}

--- a/vlib/v3/gen/v/gen.v
+++ b/vlib/v3/gen/v/gen.v
@@ -4272,7 +4272,7 @@ fn (mut g Gen) type_text(typ string) string {
 		expanded = out.str()
 	}
 	if !g.is_new_int || (!g.is_translated && !g.in_c_function) || !expanded.contains('int') {
-		return expanded
+		return restore_fn_type_space(expanded)
 	}
 	mut out := strings.new_builder(expanded.len)
 	mut i := 0
@@ -4286,6 +4286,30 @@ fn (mut g Gen) type_text(typ string) string {
 			continue
 		}
 		out.write_u8(expanded[i])
+		i++
+	}
+	return restore_fn_type_space(out.str())
+}
+
+// restore_fn_type_space rewrites `fn(` back to `fn (`. The type system spells a function type
+// without the space internally, but V source style keeps it — `type Cb = fn (int) int`, and the
+// same in field, parameter and return positions — so a type rendered straight from the internal
+// name would reformat every function type in the file.
+fn restore_fn_type_space(typ string) string {
+	if !typ.contains('fn(') {
+		return typ
+	}
+	mut out := strings.new_builder(typ.len + 4)
+	mut i := 0
+	for i < typ.len {
+		// Only a standalone `fn` introduces a function type; `myfn(` is an ordinary name.
+		if typ[i] == `f` && i + 3 <= typ.len && typ[i + 1] == `n` && typ[i + 2] == `(`
+			&& (i == 0 || !is_type_ident_char(typ[i - 1])) {
+			out.write_string('fn (')
+			i += 3
+			continue
+		}
+		out.write_u8(typ[i])
 		i++
 	}
 	return out.str()

--- a/vlib/v3/gen/v/gen_test.v
+++ b/vlib/v3/gen/v/gen_test.v
@@ -127,7 +127,7 @@ fn test_formatter_keeps_anon_fn_body_statements_expanded_inside_init() {
 	// `in_init` flag set while emitting its body, collapsing the body statements
 	// (and any nested `or {}` block) onto a single line, e.g.
 	// `c := codem := msg_ = c_ = m}`, which broke compilation.
-	source := "struct Events {\n\ton_error fn(code int, msg string)\n\ton_close fn(id int)\n}\n\nstruct Registry {\nmut:\n\tclosed bool\n}\n\nfn (r &Registry) find(id int) ?int {\n\treturn id\n}\n\nfn handlers() {\n\tmut reg := Registry{}\n\te := Events{\n\t\ton_error: fn (code int, msg string) {\n\t\t\tc := code\n\t\t\tm := msg\n\t\t\t_ = c\n\t\t\t_ = m\n\t\t}\n\t\ton_close: fn (id int) {\n\t\t\tn := reg.find(id) or { return }\n\t\t\t_ = n\n\t\t}\n\t}\n\t_ = e\n\t_ = reg\n}\n"
+	source := "struct Events {\n\ton_error fn (code int, msg string)\n\ton_close fn (id int)\n}\n\nstruct Registry {\nmut:\n\tclosed bool\n}\n\nfn (r &Registry) find(id int) ?int {\n\treturn id\n}\n\nfn handlers() {\n\tmut reg := Registry{}\n\te := Events{\n\t\ton_error: fn (code int, msg string) {\n\t\t\tc := code\n\t\t\tm := msg\n\t\t\t_ = c\n\t\t\t_ = m\n\t\t}\n\t\ton_close: fn (id int) {\n\t\t\tn := reg.find(id) or { return }\n\t\t\t_ = n\n\t\t}\n\t}\n\t_ = e\n\t_ = reg\n}\n"
 	out := vfmt('anon_fn_body_inside_init', source)
 	assert out == source, out
 	assert vfmt('anon_fn_body_inside_init_twice', out) == out
@@ -1590,4 +1590,38 @@ fn test_formatter_keeps_rows_of_small_nested_arrays_on_one_line() {
 '
 	out := vfmt('rows_of_small_nested_arrays', source)
 	assert out == source, out
+}
+
+// V spells a function type with a space before the parameter list. The type system stores it
+// without one (`fn(int) int`), so a type rendered straight from the internal name reformatted
+// every function type in the file — in declarations, fields, parameters and return positions
+// alike.
+fn test_formatter_keeps_the_space_in_a_function_type() {
+	source := 'pub type Cb = fn (a int, b string) !
+
+struct Holder {
+	cb     fn (int) int = unsafe { nil }
+	cbs    []fn (int)
+	m      map[string]fn (int) int
+	opt    ?fn (int)
+	nested fn (cb fn (int) int) fn (int) int
+}
+
+fn takes(cb fn (int) int) fn (int) int {
+	return cb
+}
+'
+	out := vfmt('fn_type_space', source)
+	assert out == source, out
+	assert !out.contains('fn('), out
+}
+
+// The optional-flag marker of a `$if` is written detached (`$if flag ? {`). The condition is
+// stored without that space so flag lookups match on it, so the formatter has to put it back.
+fn test_formatter_keeps_the_space_before_a_comptime_flag_marker() {
+	source := "fn probe() {\n\t\$if !v3_no_parallel ? {\n\t\tprintln('a')\n\t}\n\t\$if linux {\n\t\tprintln('b')\n\t}\n}\n"
+	out := vfmt('comptime_flag_marker', source)
+	assert out == source, out
+	assert !out.contains('parallel?'), out
+	assert vfmt('comptime_flag_marker_twice', out) == out
 }

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -3817,7 +3817,12 @@ fn (mut p Parser) parse_comptime_cond() string {
 		} else {
 			raw_tok_str
 		}
-		if cond.len > 0 && comptime_cond_needs_space(prev_tok_str, tok_str) {
+		// Source style writes the optional-flag marker detached (`$if flag ? {`), but the
+		// condition is otherwise stored without that space so flag lookups can match on it.
+		// Keep it only when formatting, as parse_attribute_comptime_cond does for `@[if flag ?]`.
+		needs_space := comptime_cond_needs_space(prev_tok_str, tok_str)
+			|| (p.prefs.is_fmt && tok_str == '?')
+		if cond.len > 0 && needs_space {
 			cond.write_string(' ')
 		}
 		cond.write_string(tok_str)


### PR DESCRIPTION
Two places where the V3 formatter rewrites source into a spelling the tree does not use, so running `v fmt` on an untouched file produces a diff.

## `fn (int) int` → `fn(int) int`

The type system spells a function type without the space internally, and the formatter renders types straight from that name. Every function type in a file was rewritten — declarations, struct fields, parameters and return types alike:

```v
pub type Cb = fn (a int, b string) !   ->  fn(a int, b string) !
	cb  fn (int) int = unsafe { nil }  ->  fn(int) int
	m   map[string]fn (int) int        ->  map[string]fn(int) int
```

The tree writes `fn (` in 139 files and `fn(` in one; the legacy formatter emits `fn (`. Fixed by restoring the space when rendering a type, guarded so an ordinary name ending in `fn` (`myfn(`) is untouched.

## `$if flag ? {` → `$if flag? {`

The condition is stored without that space so flag lookups can match on it. `parse_attribute_comptime_cond` already makes an `is_fmt` exception for `@[if flag ?]`; `parse_comptime_cond` now makes the same one, so only formatting is affected and flag evaluation is unchanged. The tree writes `? {` in 9 files and `?{` in none.

## Files updated to match the tree

Three files carried the formatter's own spelling and would otherwise start failing `v fmt -verify`:

- `vlib/v/tests/anon_fn_map_assign_test.v` — one `type ... = fn(int) int`, whose own body already used `fn (x int) int`.
- `vlib/v3/fastcdriver/fastcdriver.v` and `vlib/v3/gen/fastc/arm64_test.v` — 34 `$if arm64? {`. I checked the diff is 34 bare `$if` statements and no string literal was touched (`arm64_test.v` embeds V source in a literal that already used the spaced form).

## Testing

- Two new regression tests in `vlib/v3/gen/v/gen_test.v`, both confirmed to fail without their fix, covering every function-type position and idempotency.
- One existing test encoded `fn(` in its expected output; it is about anon-fn body expansion and the spelling was incidental, so the expectation is updated.
- `v fmt -verify` over the tree accepts exactly the same files as before — 6214 pass, the same 49 fail. I diffed the failing sets: identical. (Those 49 fail for unrelated pre-existing reasons; they match neither formatter, mostly from edits that skipped vfmt.)
- `vlib/v3/gen/v/` and `vlib/v3/parser/` suites pass (6/6); `vlib/v3/gen/fastc/arm64_test.v` passes; the compiler still builds itself after the `$if` edits.

## Ordering note

These matter before any tree-wide formatting sweep: a sweep run today would bake `fn(` and `flag?` into every file it touched.

Independent of #28309 (the NUL-escape fix) — different code, no conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)