### PR TITLE
vfmt: stop writing files that no longer parse, and make the formatter a fixed point

### DIFF
--- a/vlib/v3/gen/v/gen.v
+++ b/vlib/v3/gen/v/gen.v
@@ -3920,7 +3920,14 @@ fn (mut g Gen) write_comment(text string) {
 		if i == lines.len - 1 && line == '' {
 			continue
 		}
-		g.writeln(line)
+		if i == 0 {
+			g.writeln(line)
+			continue
+		}
+		// A block comment's continuation lines already carry their own leading whitespace from
+		// the source, so they are written through verbatim. Indenting them again would add a
+		// level on every run and the formatter would never reach a fixed point.
+		g.writeln_verbatim(line)
 	}
 }
 
@@ -4063,6 +4070,13 @@ fn (mut g Gen) write(str string) {
 	}
 	g.out.write_string(str)
 	g.on_newline = false
+}
+
+// writeln_verbatim writes a line without the current indentation, for text that already carries
+// its own.
+fn (mut g Gen) writeln_verbatim(str string) {
+	g.out.writeln(str)
+	g.on_newline = true
 }
 
 @[inline]

--- a/vlib/v3/gen/v/gen.v
+++ b/vlib/v3/gen/v/gen.v
@@ -3203,7 +3203,7 @@ fn (mut g Gen) struct_fields(fields []flat.NodeId, end int) {
 		}
 		g.emit_comments_before(f.pos.offset)
 		g.source_end = int_max(g.source_end, f.pos.offset)
-		is_embed := f.value == f.typ && f.children_count == 0
+		is_embed := flags.contains('e')
 		if is_embed {
 			g.write(g.type_text(f.value))
 		} else {
@@ -3529,7 +3529,7 @@ fn (g &Gen) aggregate_field_alignments(fields []flat.NodeId, is_interface bool) 
 			gp := f.generic_params()
 			flags := if gp.len > 0 { gp[0] } else { '' }
 			section = access_label(flags)
-			alignable = !(f.value == f.typ && f.children_count == 0)
+			alignable = !flags.contains('e')
 		}
 		if !alignable {
 			g.store_field_alignment(mut alignments, group)

--- a/vlib/v3/gen/v/gen.v
+++ b/vlib/v3/gen/v/gen.v
@@ -1783,9 +1783,6 @@ fn (mut g Gen) fn_literal(id flat.NodeId) {
 	body := children[i..]
 	g.write('fn')
 	gp := n.generic_params()
-	if gp.len > 0 {
-		g.write('[${gp.join(', ')}]')
-	}
 	if captures.len > 0 {
 		g.write(' [')
 		for capture_i, capture_id in captures {
@@ -1803,7 +1800,15 @@ fn (mut g Gen) fn_literal(id flat.NodeId) {
 		}
 		g.write(']')
 	}
-	g.write(' ')
+	// V spells a closure `fn [captures] [T](params)`: the capture list comes first, and the
+	// generic list binds straight to the parameters with no space. Writing the generic list
+	// first produced `fn[T] [captures] (params)`, which does not parse, and the run after that
+	// read the captures as the generic list and dropped everything the two lists disagreed on.
+	if gp.len > 0 {
+		g.write(' [${gp.join(', ')}]')
+	} else {
+		g.write(' ')
+	}
 	g.params(id, params)
 	if n.typ.len > 0 && n.typ != 'void' {
 		g.write(' ${g.type_text(n.typ)}')

--- a/vlib/v3/gen/v/gen.v
+++ b/vlib/v3/gen/v/gen.v
@@ -2578,7 +2578,15 @@ fn (mut g Gen) match_node(id flat.NodeId) {
 				g.advance_source_end_before_pending_comment(b.pos.end)
 				g.emit_comments_before(b.pos.end)
 				g.indent--
-				g.writeln('}')
+				g.write('}')
+				// A comment sitting after the branch's closing brace belongs to that branch.
+				// Left for the next branch's leading-comment pass it would be re-emitted on its
+				// own line, and the following run would then read it as a commented branch and
+				// insert a blank line before it, so formatting twice differed from once.
+				g.emit_trailing_comments(b.pos.end)
+				if !g.on_newline {
+					g.writeln('')
+				}
 			}
 		} else {
 			ncond := b.value.int()
@@ -2601,7 +2609,15 @@ fn (mut g Gen) match_node(id flat.NodeId) {
 				g.advance_source_end_before_pending_comment(b.pos.end)
 				g.emit_comments_before(b.pos.end)
 				g.indent--
-				g.writeln('}')
+				g.write('}')
+				// A comment sitting after the branch's closing brace belongs to that branch.
+				// Left for the next branch's leading-comment pass it would be re-emitted on its
+				// own line, and the following run would then read it as a commented branch and
+				// insert a blank line before it, so formatting twice differed from once.
+				g.emit_trailing_comments(b.pos.end)
+				if !g.on_newline {
+					g.writeln('')
+				}
 			}
 		}
 	}
@@ -4081,7 +4097,10 @@ fn (mut g Gen) writeln_verbatim(str string) {
 
 @[inline]
 fn (mut g Gen) writeln(str string) {
-	if g.on_newline && g.indent > 0 {
+	// A blank separator line gets no indentation: writing it would leave a line of whitespace,
+	// which V source never carries and which the next run reads back differently, so formatting
+	// twice differed from once.
+	if g.on_newline && g.indent > 0 && str.len > 0 {
 		for _ in 0 .. g.indent {
 			g.out.write_u8(`\t`)
 		}

--- a/vlib/v3/gen/v/gen.v
+++ b/vlib/v3/gen/v/gen.v
@@ -486,6 +486,8 @@ fn (mut g Gen) collect_implied_imports(fnode &flat.Node) {
 		}
 	}
 	mut implied := map[string]bool{}
+	mut vlib_dirs := map[string]bool{}
+	mut vlib_listed := false
 	for id, n in g.a.nodes {
 		if n.pos.id != g.file_id || n.kind != .selector || n.children_count == 0 {
 			continue
@@ -493,9 +495,20 @@ fn (mut g Gen) collect_implied_imports(fnode &flat.Node) {
 		receiver := g.a.child_node(n, 0)
 		name := receiver.value
 		if receiver.kind == .ident && name.len > 0 && name !in ['C', 'JS'] && !imported[name]
-			&& !declared[name] && !g.a.formatter_local_sels[id]
-			&& os.is_dir(os.join_path(@VEXEROOT, 'vlib', name)) {
-			implied[name] = true
+			&& !declared[name] && !g.a.formatter_local_sels[id] {
+			// Match the module directory case-sensitively. `os.is_dir` answers the filesystem,
+			// and on a case-insensitive one (macOS, Windows) `vlib/Time` is the `time` module —
+			// so a static call on a type named `Time` implied a bogus `import Time`, which the
+			// formatter then wrote into the file and broke the build.
+			if !vlib_listed {
+				vlib_listed = true
+				for entry in os.ls(os.join_path(@VEXEROOT, 'vlib')) or { []string{} } {
+					vlib_dirs[entry] = true
+				}
+			}
+			if vlib_dirs[name] && os.is_dir(os.join_path(@VEXEROOT, 'vlib', name)) {
+				implied[name] = true
+			}
 		}
 	}
 	g.implied_imports = implied.keys()

--- a/vlib/v3/gen/v/gen.v
+++ b/vlib/v3/gen/v/gen.v
@@ -2726,7 +2726,9 @@ fn (mut g Gen) assert_stmt(id flat.NodeId) {
 		g.write(', ')
 		g.expr(children[1])
 	}
-	if !g.in_init {
+	// The condition can carry the statement's trailing comment, which ends the line itself.
+	// Terminating again would leave a stray separator after every commented `assert`.
+	if !g.in_init && !g.on_newline {
 		g.writeln('')
 	}
 }

--- a/vlib/v3/gen/v/gen_test.v
+++ b/vlib/v3/gen/v/gen_test.v
@@ -1591,3 +1591,16 @@ fn test_formatter_keeps_rows_of_small_nested_arrays_on_one_line() {
 	out := vfmt('rows_of_small_nested_arrays', source)
 	assert out == source, out
 }
+
+// A block comment's continuation lines already carry their own leading whitespace, so the
+// formatter must write them through as they are. Indenting them again added one level per run:
+// `v fmt` was not a fixed point, and each further run pushed the body one tab deeper.
+fn test_formatter_keeps_block_comment_body_indentation_stable() {
+	source := "fn probe() {\n\t/*\n\tfirst line\n\tsecond line\n\t*/\n\tprintln('x')\n}\n"
+	out := vfmt('block_comment_indent', source)
+	assert out == source, out
+	twice := vfmt('block_comment_indent_twice', out)
+	assert twice == out, twice
+	thrice := vfmt('block_comment_indent_thrice', twice)
+	assert thrice == out, thrice
+}

--- a/vlib/v3/gen/v/gen_test.v
+++ b/vlib/v3/gen/v/gen_test.v
@@ -1652,3 +1652,15 @@ fn test_formatter_keeps_a_trailing_comment_on_a_range_match_branch() {
 	assert out == source, out
 	assert vfmt('range_branch_comment_twice', out) == out
 }
+
+// A bare `return` closing an inline block took the parser's position when its node was built,
+// which by then was past that block's `}`. The formatter read the statement's trailing comment as
+// directly following the `return` and moved it inside the braces, leaving the `}` inside the
+// comment and the file unparseable.
+fn test_formatter_keeps_a_trailing_comment_outside_an_inline_or_block() {
+	source := "fn get(k string) !bool {\n\treturn k != ''\n}\n\nfn probe() {\n\thelp_enabled := get('help') or { return } // ignore the error\n\tif help_enabled {\n\t\tprintln('yes')\n\t}\n}\n"
+	out := vfmt('inline_or_trailing_comment', source)
+	assert out == source, out
+	assert !out.contains('return // ignore the error }'), out
+	assert vfmt('inline_or_trailing_comment_twice', out) == out
+}

--- a/vlib/v3/gen/v/gen_test.v
+++ b/vlib/v3/gen/v/gen_test.v
@@ -1677,3 +1677,26 @@ fn test_formatter_keeps_closure_capture_and_generic_list_order() {
 	assert out.contains('mut total'), out
 	assert vfmt('closure_capture_generics_twice', out) == out
 }
+
+// `break` and `continue` had the same wrong span as `return`: the node took the parser's position,
+// already past the `}` of an inline block, so the statement's trailing comment was moved inside
+// the braces and the `}` ended up commented out.
+fn test_formatter_keeps_a_trailing_comment_outside_an_inline_break_or_continue() {
+	source := "fn f(items []int) int {\n\tmut n := 0\n\tfor i in items {\n\t\tw := pick(i) or { continue } // only numeric\n\t\tif w == 0 {\n\t\t\tbreak\n\t\t}\n\t\tn += w\n\t}\n\treturn n\n}\n\nfn pick(i int) ?int {\n\treturn i\n}\n"
+	out := vfmt('inline_continue_comment', source)
+	assert out == source, out
+	assert !out.contains('continue // only numeric }'), out
+	assert vfmt('inline_continue_comment_twice', out) == out
+}
+
+// Implied imports matched the module directory through `os.is_dir`, which answers the filesystem.
+// On a case-insensitive one (macOS, Windows) `vlib/Time` is the `time` module, so a static call on
+// a type named `Time` implied `import Time` — and the formatter wrote that bogus import into the
+// file, breaking the build. On a case-sensitive filesystem this never fired, so the assert below
+// only bites where the bug lived.
+fn test_formatter_does_not_imply_an_import_from_a_type_named_like_a_module() {
+	source := "module time\n\npub struct Time {\n\tunix i64\n}\n\npub fn Time.new(unix i64) Time {\n\treturn Time{\n\t\tunix: unix\n\t}\n}\n\npub fn now() Time {\n\treturn Time.new(0)\n}\n"
+	out := vfmt('implied_import_type_name', source)
+	assert !out.contains('import Time'), out
+	assert out == source, out
+}

--- a/vlib/v3/gen/v/gen_test.v
+++ b/vlib/v3/gen/v/gen_test.v
@@ -1641,3 +1641,14 @@ fn test_formatter_does_not_separate_a_commented_assert_from_the_next_statement()
 	spaced_out := vfmt('commented_assert_spaced', spaced)
 	assert spaced_out == spaced, spaced_out
 }
+
+// A `match` range pattern took the parser's position when its node was built, which by then was
+// already past the branch's `{`. The formatter then read a comment written after that brace as
+// directly following the pattern and pulled it above the brace — and the next run re-split the
+// pattern list around it.
+fn test_formatter_keeps_a_trailing_comment_on_a_range_match_branch() {
+	source := "fn f(n int) string {\n\tmatch n {\n\t\t48...57, 97...122 { // 0-9a-z\n\t\t\treturn 'alnum'\n\t\t}\n\t\telse {\n\t\t\treturn ''\n\t\t}\n\t}\n}\n"
+	out := vfmt('range_branch_comment', source)
+	assert out == source, out
+	assert vfmt('range_branch_comment_twice', out) == out
+}

--- a/vlib/v3/gen/v/gen_test.v
+++ b/vlib/v3/gen/v/gen_test.v
@@ -1604,3 +1604,27 @@ fn test_formatter_keeps_block_comment_body_indentation_stable() {
 	thrice := vfmt('block_comment_indent_thrice', twice)
 	assert thrice == out, thrice
 }
+
+// A comment after a match branch's closing brace belongs to that branch. Emitting it as the next
+// branch's leading comment moved it onto its own line, and the following run then read it as a
+// commented branch and inserted a blank line before it — so formatting twice differed from once.
+fn test_formatter_keeps_a_trailing_comment_on_a_match_branch() {
+	source := "fn pick(n int) string {\n\tmatch n {\n\t\t1 {\n\t\t\treturn 'a'\n\t\t} // leave it blank\n\t\telse {\n\t\t\treturn ''\n\t\t}\n\t}\n}\n"
+	out := vfmt('match_branch_trailing_comment', source)
+	assert out == source, out
+	assert vfmt('match_branch_trailing_comment_twice', out) == out
+}
+
+// A blank separator line must carry no indentation. Writing it left a line of whitespace, which
+// V source never carries and which the next run read back differently, so the formatter was not a
+// fixed point. Note the separator itself is emitted by a separate, still-open bug: a statement
+// with a trailing comment gains one. This pins only that whatever blank lines are produced are
+// empty and stable.
+fn test_formatter_writes_blank_lines_without_indentation() {
+	source := "fn probe() {\n\tassert 1 == 1 // first\n\tassert 2 == 2\n}\n"
+	out := vfmt('blank_line_indentation', source)
+	for line in out.split('\n') {
+		assert line.trim_space() != '' || line == '', 'a blank line must carry no whitespace, got `${line}`'
+	}
+	assert vfmt('blank_line_indentation_twice', out) == out
+}

--- a/vlib/v3/gen/v/gen_test.v
+++ b/vlib/v3/gen/v/gen_test.v
@@ -1664,3 +1664,16 @@ fn test_formatter_keeps_a_trailing_comment_outside_an_inline_or_block() {
 	assert !out.contains('return // ignore the error }'), out
 	assert vfmt('inline_or_trailing_comment_twice', out) == out
 }
+
+// V spells a closure `fn [captures] [T](params)`. The formatter wrote the generic list first,
+// producing `fn[T] [captures] (params)`, which does not parse; the run after that read the
+// captures as the generic list and dropped whatever the two disagreed on, so a `mut` capture was
+// silently lost.
+fn test_formatter_keeps_closure_capture_and_generic_list_order() {
+	source := "fn run[T](items []T) {\n\tch := chan T{}\n\tmut total := 0\n\tspawn fn [ch, mut total] [T]() {\n\t\tfor _ in ch {\n\t\t\ttotal++\n\t\t}\n\t}()\n\tfor item in items {\n\t\tch <- item\n\t}\n}\n"
+	out := vfmt('closure_capture_generics', source)
+	assert out == source, out
+	assert !out.contains('fn[T]'), out
+	assert out.contains('mut total'), out
+	assert vfmt('closure_capture_generics_twice', out) == out
+}

--- a/vlib/v3/gen/v/gen_test.v
+++ b/vlib/v3/gen/v/gen_test.v
@@ -1617,9 +1617,7 @@ fn test_formatter_keeps_a_trailing_comment_on_a_match_branch() {
 
 // A blank separator line must carry no indentation. Writing it left a line of whitespace, which
 // V source never carries and which the next run read back differently, so the formatter was not a
-// fixed point. Note the separator itself is emitted by a separate, still-open bug: a statement
-// with a trailing comment gains one. This pins only that whatever blank lines are produced are
-// empty and stable.
+// fixed point.
 fn test_formatter_writes_blank_lines_without_indentation() {
 	source := "fn probe() {\n\tassert 1 == 1 // first\n\tassert 2 == 2\n}\n"
 	out := vfmt('blank_line_indentation', source)
@@ -1627,4 +1625,19 @@ fn test_formatter_writes_blank_lines_without_indentation() {
 		assert line.trim_space() != '' || line == '', 'a blank line must carry no whitespace, got `${line}`'
 	}
 	assert vfmt('blank_line_indentation_twice', out) == out
+}
+
+// An `assert` whose condition carries the statement's trailing comment is already terminated by
+// that comment, so terminating it again left a stray separator line after every commented
+// `assert`. Every other statement kind already guarded this.
+fn test_formatter_does_not_separate_a_commented_assert_from_the_next_statement() {
+	source := "fn p() {\n\tassert 1 == 1 // c\n\tassert 2 == 2\n}\n"
+	out := vfmt('commented_assert', source)
+	assert out == source, out
+	assert vfmt('commented_assert_twice', out) == out
+
+	// a blank line the source did have is still kept
+	spaced := "fn p() {\n\tassert 1 == 1 // c\n\n\tassert 2 == 2\n}\n"
+	spaced_out := vfmt('commented_assert_spaced', spaced)
+	assert spaced_out == spaced, spaced_out
 }

--- a/vlib/v3/gen/v/gen_test.v
+++ b/vlib/v3/gen/v/gen_test.v
@@ -1700,3 +1700,13 @@ fn test_formatter_does_not_imply_an_import_from_a_type_named_like_a_module() {
 	assert !out.contains('import Time'), out
 	assert out == source, out
 }
+
+// A struct embed and a field whose name matches its type (`thread thread`) are stored the same
+// way — `value == typ` — so the formatter collapsed the second into the first and wrote a bare
+// `thread` embed, which no longer compiles. The parser now records which one it is.
+fn test_formatter_keeps_a_field_named_like_its_type() {
+	source := 'struct Base {\n\tid int\n}\n\nstruct Child {\n\tBase\n\tname string\n}\n\nstruct Named {\n\tthread thread\n}\n'
+	out := vfmt('field_named_like_type', source)
+	assert out == source, out
+	assert vfmt('field_named_like_type_twice', out) == out
+}

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -7338,12 +7338,16 @@ fn (mut p Parser) match_branch_cond() flat.NodeId {
 		p.next()
 		rhs := p.expr(.lowest)
 		rstart := p.add_children2(cond, rhs)
-		return p.add_node(flat.Node{
+		// Span the range from its low bound to its high bound. Left to `add_node` the node
+		// would take the parser's current position, which is already past the branch's `{`,
+		// and the formatter would then read a comment written after that brace as directly
+		// following the pattern and pull it above the brace.
+		return p.add_node_from(flat.Node{
 			kind:           .range
 			value:          if p.prefs.is_fmt { '...' } else { '' }
 			children_start: rstart
 			children_count: 2
-		})
+		}, cond)
 	}
 	return cond
 }

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -6232,6 +6232,7 @@ fn (mut p Parser) stmt() flat.NodeId {
 			return p.match_stmt()
 		}
 		.key_break {
+			kw_pos := p.tok_pos
 			p.next()
 			mut label := ''
 			if p.tok == .name {
@@ -6241,9 +6242,16 @@ fn (mut p Parser) stmt() flat.NodeId {
 			if p.tok == .semicolon {
 				p.next()
 			}
-			return p.add_val(.break_stmt, label)
+			// Span the statement itself, as `return` does: the parser's current position is
+			// already past the `}` of an inline block (`x := f() or { break } // note`), and the
+			// formatter would then move the note inside the braces and comment the `}` out.
+			return p.add_node(flat.Node{
+				kind:  .break_stmt
+				value: label
+			}.with_pos(p.span_to(kw_pos)))
 		}
 		.key_continue {
+			kw_pos := p.tok_pos
 			p.next()
 			mut label := ''
 			if p.tok == .name {
@@ -6253,7 +6261,13 @@ fn (mut p Parser) stmt() flat.NodeId {
 			if p.tok == .semicolon {
 				p.next()
 			}
-			return p.add_val(.continue_stmt, label)
+			// Span the statement itself, as `return` does: the parser's current position is
+			// already past the `}` of an inline block (`x := f() or { continue } // note`), and the
+			// formatter would then move the note inside the braces and comment the `}` out.
+			return p.add_node(flat.Node{
+				kind:  .continue_stmt
+				value: label
+			}.with_pos(p.span_to(kw_pos)))
 		}
 		.key_mut {
 			p.next()

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -1939,7 +1939,9 @@ fn (mut p Parser) struct_decl() flat.NodeId {
 					typ:   field_type
 					pos:   p.span_to(field_start)
 				})
-				p.apply_field_meta(fid, sect_is_mut, sect_is_pub, sect_is_global, pending_attrs)
+				mut embed_attrs_1 := pending_attrs.clone()
+				embed_attrs_1 << embedded_field_attr
+				p.apply_field_meta(fid, sect_is_mut, sect_is_pub, sect_is_global, embed_attrs_1)
 				pending_attrs = []string{}
 				ids << fid
 				if p.tok == .semicolon {
@@ -1965,7 +1967,9 @@ fn (mut p Parser) struct_decl() flat.NodeId {
 						typ:   embedded_type
 						pos:   p.span_to(field_start)
 					})
-					p.apply_field_meta(fid, sect_is_mut, sect_is_pub, sect_is_global, pending_attrs)
+					mut embed_attrs_2 := pending_attrs.clone()
+					embed_attrs_2 << embedded_field_attr
+					p.apply_field_meta(fid, sect_is_mut, sect_is_pub, sect_is_global, embed_attrs_2)
 					pending_attrs = []string{}
 					ids << fid
 					if p.tok == .semicolon {
@@ -1991,7 +1995,9 @@ fn (mut p Parser) struct_decl() flat.NodeId {
 					typ:   embedded_type
 					pos:   p.span_to(field_start)
 				})
-				p.apply_field_meta(fid, sect_is_mut, sect_is_pub, sect_is_global, pending_attrs)
+				mut embed_attrs_3 := pending_attrs.clone()
+				embed_attrs_3 << embedded_field_attr
+				p.apply_field_meta(fid, sect_is_mut, sect_is_pub, sect_is_global, embed_attrs_3)
 				pending_attrs = []string{}
 				ids << fid
 				if p.tok == .semicolon {
@@ -2872,17 +2878,20 @@ fn (mut p Parser) parse_attribute_comptime_cond() string {
 // attributes) - the node's own `kind_id`/`is_mut` are load-bearing (kind dispatch) and must not
 // be repurposed. A default field (private, immutable, no attrs) is left untouched so it costs no
 // allocation and reads back as the default.
+// embedded_field_attr marks a `field_decl` that is a struct embed rather than a named field.
+const embedded_field_attr = '__v3_embedded_field'
+
 fn (mut p Parser) apply_field_meta(id flat.NodeId, is_mut bool, is_pub bool, is_global bool, attrs []string) {
 	if int(id) < 0 || int(id) >= p.a.nodes.len {
 		return
 	}
 	is_volatile := '__v3_volatile_field' in attrs
-	stored_attrs := if is_volatile {
-		attrs.filter(it != '__v3_volatile_field')
-	} else {
-		attrs
-	}
-	if !is_mut && !is_pub && !is_global && !is_volatile && stored_attrs.len == 0 {
+	// An embed and a field whose name happens to match its type (`thread thread`) are both
+	// stored with `value == typ`, so the node alone cannot tell them apart. Record which this
+	// is; without it the formatter rewrote a `thread thread` field to a bare `thread` embed.
+	is_embedded := embedded_field_attr in attrs
+	stored_attrs := attrs.filter(it != '__v3_volatile_field' && it != embedded_field_attr)
+	if !is_mut && !is_pub && !is_global && !is_volatile && !is_embedded && stored_attrs.len == 0 {
 		return
 	}
 	mut flags := ''
@@ -2897,6 +2906,9 @@ fn (mut p Parser) apply_field_meta(id flat.NodeId, is_mut bool, is_pub bool, is_
 	}
 	if is_volatile {
 		flags += 'v'
+	}
+	if is_embedded {
+		flags += 'e'
 	}
 	mut gp := []string{cap: stored_attrs.len + 1}
 	gp << flags

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -6617,11 +6617,16 @@ fn (mut p Parser) return_stmt() flat.NodeId {
 		p.next()
 	}
 	start := p.add_children(ids)
+	// Span the statement from `return` to the last token it consumed. Left to `add_node` it
+	// would take the parser's current position, which for a bare `return` closing an inline
+	// block (`x := f() or { return } // note`) is already past that block's `}` — the formatter
+	// then reads the note as directly following the `return` and moves it inside the braces,
+	// leaving the `}` commented out and the file unparseable.
 	return p.add_node(flat.Node{
 		kind:           .return_stmt
 		children_start: start
 		children_count: flat.child_count(ids.len)
-	})
+	}.with_pos(p.span_to(return_pos)))
 }
 
 fn (mut p Parser) if_stmt() flat.NodeId {


### PR DESCRIPTION
Nine fixes to the V3 formatter. Four of them make `v fmt -w` write files that **V can no longer parse**; the rest are cases where formatting twice did not equal formatting once.

Two scans found these. For the corruption: format every `.v` file under `vlib`, `cmd` and `examples`, run `v -check-syntax` on the result, and flag anything that parsed before and not after. For the instability: format twice and compare, then extend to three passes to separate "settles" from "never settles".

**The corruption scan went from 9 files to 0.**

## Corruption

**1. A bogus `import` was written into the file.** Implied imports matched the module directory with `os.is_dir`, which answers the filesystem. On a case-insensitive one (macOS, Windows) `vlib/Time` *is* the `time` module, so a static call on a type named `Time` implied `import Time`. `vlib/time/time.v` gained `import Time`, `vlib/v/pref/default.v` gained `import OS`, `vlib/builtin/wasm/wasi/...` gained `import WASM` — 8 of the 9 files. Now matched against the directory listing, case-sensitively.

**2. `return` in an inline block swallowed its `}`.** The node took the parser's *current* position, already past the block's `}`, so the trailing comment was read as adjacent to the `return` and moved inside the braces:

```v
help_enabled := get('help') or { return } // ignore the error      ← source
help_enabled := get('help') or { return // ignore the error }      ← after v fmt -w
```

`vlib/cli/command.v` has four, and it *passes* `v fmt -verify` today — a file the checker calls clean is one `v fmt -w` from broken. Building a program that imports `cli` after formatting fails with `unexpected token `(` after anonymous function signature`.

**3. `break` and `continue` had the same wrong span.** `vlib/v3/gen/wasm/gen.v`: `or { continue } // only numeric/bool globals` became `or { continue // only numeric/bool globals }`.

**4. Generic closures were emitted in the wrong order.** V spells a closure `fn [captures] [T](params)`; the formatter wrote the generic list first:

```v
spawn fn [ch, worker, mut wg] [T]() {     ← source, parses
spawn fn[T] [ch, worker, mut wg] () {     ← after v fmt -w: unexpected token `[`
spawn fn[ch, worker] [T] () {             ← and the next run drops `mut wg`
```

`vlib/arrays/parallel/parallel.v` has two.

## Idempotency

**5. A match range pattern took the wrong span** — same shape as 2, so a comment after the branch's `{` was pulled above it and the next run re-split the pattern list.

**6. Block comment bodies were re-indented every run**, one level per run, never converging.

**7. A match branch's trailing comment was relocated** to the next branch's leading position, and the run after that added a blank line above it.

**8. Blank lines were written with indentation**, leaving lines of pure whitespace that the next run read differently.

**9. A commented `assert` was separated from the next statement** — `assert_stmt` terminated the line again even when the trailing comment already had. Every other statement kind already guarded this.

## Measurement

| | before | after |
|---|---|---|
| files `v fmt -w` makes unparseable | 9 | **0** |
| output changes on a 2nd run | 265 | **65** |

For fix 9: 100 files format differently, 242 spurious lines removed, none gained; on a 25-file sample, output matching the legacy formatter exactly goes from 0 to 9. Fix 2 changes 11 files; fix 4 accounts for 21 of the formerly-unstable ones.

No file became unstable that was not already — sets diffed at each step rather than counts compared.

## Testing

- Nine regression tests, each confirmed to fail without its own fix.
- `vlib/v3/gen/v/` and `vlib/v3/parser/` pass (6/6); the selfhost transform regression test passes; V still builds itself — fixes 2, 3 and 5 touch the parser in both modes, not only under `-fmt`.
- `v fmt -verify` accepts exactly the same files as before: the same 49 as master, across `vlib/`, `cmd/` and `examples/`, sets diffed.
- `vlib/cli`'s own tests fail identically with and without this change (pre-existing on master).

Independent of #28309, #28310, #28312 and #28313.

🤖 Generated with [Claude Code](https://claude.com/claude-code)