### PR TITLE
cmd/vvet: format analyze.v and vet_test.v

### DIFF
--- a/cmd/tools/vvet/analyze.v
+++ b/cmd/tools/vvet/analyze.v
@@ -32,10 +32,10 @@ mut:
 	repeated_expr_cutoff     shared map[string]int // repeated code cutoff	
 	repeated_expr            shared map[string]map[string]map[string][]token.Pos // repeated exprs in fn scope
 	potential_non_inlined    shared map[string]map[string]token.Pos              // fns might be inlined
-	call_counter             shared map[string]int // fn call counter
-	unqualified_call_counter shared map[string]int // calls keyed by `<caller module>.<bare name>`
+	call_counter             shared map[string]int  // fn call counter
+	unqualified_call_counter shared map[string]int  // calls keyed by `<caller module>.<bare name>`
 	declared_fns             shared map[string]bool // all function declarations, keyed by fkey
-	cur_fn                   ast.FnDecl            // current fn declaration
+	cur_fn                   ast.FnDecl             // current fn declaration
 }
 
 // stmt checks for repeated code in statements

--- a/cmd/tools/vvet/vet_test.v
+++ b/cmd/tools/vvet/vet_test.v
@@ -78,7 +78,7 @@ fn test_local_function_shadows_builtin_inline_calls() {
 		calls << '\tprintln(my_helper(1, 1))'
 	}
 	os.write_file(os.join_path(tmp, 'caller.v'),
-		"module main\n\n@[inline]\nfn my_helper(a int, b int) int {\n\treturn a + b\n}\n\nfn main() {\n${calls.join('\n')}\n}\n")!
+		'module main\n\n@[inline]\nfn my_helper(a int, b int) int {\n\treturn a + b\n}\n\nfn main() {\n${calls.join('\n')}\n}\n')!
 	res := os.execute('${os.quoted_path(vexe)} vet -nocolor -I ${os.quoted_path(tmp)}')
 	assert res.exit_code >= 0, res.output
 	assert !res.output.contains('my_helper fn might be inlined'), res.output


### PR DESCRIPTION
`./v fmt -verify cmd/` ("Code in cmd/ is formatted") is a step in the tools CI job, and it fails on master. Two files match neither the V3 nor the legacy formatter, so the transition-period check — which deliberately accepts either — still rejects them.

That is what fails `tools-linux`, `tools-macos`, `tools-freebsd`, `tools-openbsd` and `tools-windows`. I reproduced it on pristine master locally:

```
$ ./v fmt -verify cmd/
cmd/tools/vvet/vet_test.v is not vfmt'ed
cmd/tools/vvet/analyze.v is not vfmt'ed
Encountered a total of: 2 formatting errors.
```

## Which formatter

Both files are far closer to legacy than to V3 — 10 and 4 differing lines versus 46 and 25 — so this applies legacy output, which keeps the surrounding style and gives the smaller diff:

- `analyze.v`: a trailing-comment column.
- `vet_test.v`: one double-quoted string.

That string holds `${calls.join('\n')}`, so it ends up single-quoted around nested single quotes inside the interpolation. That is valid V — I checked rather than assumed: `cmd/tools/vvet` still builds and `cmd/tools/vvet/vet_test.v` passes.

## Effect

`./v fmt -verify cmd/` exits 0. Over the whole tree, `v fmt -verify` goes from 49 failing files to 47, and the delta is exactly these two removed — nothing else changed.

The remaining 47 are the same pre-existing set (files that match neither formatter, mostly edits that skipped vfmt); they are outside `cmd/`, so they do not fail this CI step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)