### PR TITLE
v3: pass the AST pointer, not its address, to the native-inputs thread args

### DIFF
--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -9260,7 +9260,7 @@ pub fn run(args []string) {
 	native_inputs_done := chan bool{cap: 1}
 	native_inputs_args := PrepareV3CheckerNativeInputsArgs{
 		state:         voidptr(&cache_state)
-		a:             &a
+		a:             a
 		prefs:         prefs
 		user_files:    user_files
 		user_c_flags:  cache_c_flags


### PR DESCRIPTION
`Build V with -cstrict` fails on master, which is what red-lights `clang-macos (macos-14 / macos-15 / macos-26)`:

```
error: incompatible pointer types initializing 'v3__flat__FlatAst *'
(aka 'struct v3__flat__FlatAst *') with an expression of type
'v3__flat__FlatAst **' (aka 'struct v3__flat__FlatAst **'); remove &
[-Werror,-Wincompatible-pointer-types]
```

Reproduced locally on master with `./v -cstrict -o /tmp/v cmd/v`.

## Cause

`PrepareV3CheckerNativeInputsArgs.a` is a `&flat.FlatAst`. In `run`, the local `a` is already one — `mut a := p.a`, and `Parser.a` is `&flat.FlatAst` — so `a: &a` takes the address of that local and yields `&&flat.FlatAst`. The generated C then initializes a `FlatAst *` field from a `FlatAst **`.

V1 folded the extra `&` away, which is why it went unnoticed; V3 emits it as written.

## Fix

Pass `a` directly. Besides being the right type, this stops storing a pointer to a stack local in a struct that is handed to a spawned thread (`spawn prepare_v3_checker_native_inputs_thread(&native_inputs_args)`).

## Testing

- `./v -cstrict -o /tmp/v cmd/v` builds; the generated C now reads `.a = a`.
- V still builds itself and runs.
- `v fmt -verify` over the tree unchanged — the same 49 files as master, sets diffed.
- `vlib/v3/tests/selfhost_transform_regression_test.v` passes.

Note this is one of three separate pre-existing failures currently red on master's CI; the other two (a `[256]int` vs `[256]i32` mismatch in `vlib/x/multiwindow` from the `int`→64-bit change, and the V1 parser rejecting `@[required]` on its own line in `vlib/v/tests/builtin_arrays/sorting_compare_fn_with_mut_reference_test.v`) are untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)