### PR TITLE
vfmt: preserve gated slice markers

### DIFF
--- a/vlib/v3/gen/v/gen.v
+++ b/vlib/v3/gen/v/gen.v
@@ -1549,8 +1549,9 @@ fn (mut g Gen) index_expr(id flat.NodeId) {
 		return
 	}
 	g.expr(children[0])
+	gate := if n.op == .gated_index { '#' } else { '' }
 	if n.value == 'range' {
-		g.write('[')
+		g.write('${gate}[')
 		if children.len > 1 && int(children[1]) >= 0 {
 			g.expr(children[1])
 		}
@@ -1561,7 +1562,6 @@ fn (mut g Gen) index_expr(id flat.NodeId) {
 		g.write(']')
 		return
 	}
-	gate := if n.op == .gated_index { '#' } else { '' }
 	g.write('${gate}[')
 	g.expr_list(children[1..], ', ')
 	g.write(']')

--- a/vlib/v3/gen/v/gen_test.v
+++ b/vlib/v3/gen/v/gen_test.v
@@ -87,6 +87,13 @@ fn test_formatter_preserves_blank_lines_between_statements() {
 	assert vfmt('statement_blank_lines_twice', out) == out
 }
 
+fn test_formatter_preserves_gated_slices() {
+	source := 'fn slices(body string, items []int, start int, end int) {\n\t_ := body#[start..end]\n\t_ := items#[..end]\n\t_ := items#[start..]\n\t_ := items#[..]\n}\n'
+	out := vfmt('gated_slices', source)
+	assert out == source, out
+	assert vfmt('gated_slices_twice', out) == out
+}
+
 fn test_formatter_preserves_mutability_for_each_multi_decl_target() {
 	source := 'fn pairs() {\n\tmut first, mut second := 1, 2\n\t_ = first\n\t_ = second\n}\n'
 	out := vfmt('multi_decl_mutability', source)


### PR DESCRIPTION
## Summary
- emit the gated `#` marker when V3 formats range slices
- cover bounded, open-ended, and fully open gated slices
- verify the formatter remains a fixed point

## Testing
- `./vnew -silent test vlib/v3/gen/v/gen_test.v`
- `./vnew -silent vlib/v/compiler_errors_test.v`
- `./vnew fmt vlib/net/http/request.v` preserves both affected `body#[...]` expressions
- `./vnew -silent test cmd/tools/vfmt_test.v` reaches an unrelated existing failure in `test_fmt_checks_accept_legacy_formatted_source`: current V3 output preserves a blank line after the header comment

Closes #28315