### PR TITLE
v3: scope C function call metadata by module

### DIFF
--- a/vlib/v3/gen/c/c_fn_module_metadata_test.v
+++ b/vlib/v3/gen/c/c_fn_module_metadata_test.v
@@ -7,13 +7,14 @@ fn test_c_fn_call_metadata_is_module_scoped() {
 	mut a := flat.FlatAst.new()
 	mut tc := types.TypeChecker.new(&a)
 	fixed_params := [types.Type(types.int_), types.Type(types.int_), types.Type(types.int_)]
-	variadic_params := [types.Type(types.u64_)]
+	variadic_params := [types.Type(types.int_), types.Type(types.int_), types.Type(types.u64_)]
 	tc.c_fn_module_ret_types['fixed\x01C.probe'] = types.Type(types.int_)
 	tc.c_fn_module_param_types['fixed\x01C.probe'] = fixed_params
 	tc.c_fn_module_variadic['fixed\x01C.probe'] = false
 	tc.c_fn_module_ret_types['variadic\x01C.probe'] = types.Type(types.int_)
 	tc.c_fn_module_param_types['variadic\x01C.probe'] = variadic_params
 	tc.c_fn_module_variadic['variadic\x01C.probe'] = true
+	tc.c_fn_abi_variadic_prefixes['C.probe'] = 2
 	// Simulate the program-wide compatibility metadata having retained the other view.
 	tc.fn_param_types['C.probe'] = variadic_params
 	tc.c_variadic_fns['C.probe'] = true
@@ -23,11 +24,13 @@ fn test_c_fn_call_metadata_is_module_scoped() {
 
 	tc.cur_module = 'fixed'
 	assert g.param_types_for('C.probe', 'probe') == fixed_params
-	assert !g.c_fn_is_variadic('C.probe', 'probe')
+	assert !(g.module_c_fn_variadic('C.probe', 'probe') or { true })
+	assert g.c_fn_abi_variadic_prefix('C.probe', 'probe', fixed_params) == 2
 
 	tc.fn_param_types['C.probe'] = fixed_params
 	tc.c_variadic_fns['C.probe'] = false
 	tc.cur_module = 'variadic'
 	assert g.param_types_for('C.probe', 'probe') == variadic_params
-	assert g.c_fn_is_variadic('C.probe', 'probe')
+	assert g.module_c_fn_variadic('C.probe', 'probe') or { false }
+	assert g.c_fn_abi_variadic_prefix('C.probe', 'probe', variadic_params) == 2
 }

--- a/vlib/v3/gen/c/c_fn_module_metadata_test.v
+++ b/vlib/v3/gen/c/c_fn_module_metadata_test.v
@@ -1,0 +1,33 @@
+module c
+
+import v3.flat
+import v3.types
+
+fn test_c_fn_call_metadata_is_module_scoped() {
+	mut a := flat.FlatAst.new()
+	mut tc := types.TypeChecker.new(&a)
+	fixed_params := [types.Type(types.int_), types.Type(types.int_), types.Type(types.int_)]
+	variadic_params := [types.Type(types.u64_)]
+	tc.c_fn_module_ret_types['fixed\x01C.probe'] = types.Type(types.int_)
+	tc.c_fn_module_param_types['fixed\x01C.probe'] = fixed_params
+	tc.c_fn_module_variadic['fixed\x01C.probe'] = false
+	tc.c_fn_module_ret_types['variadic\x01C.probe'] = types.Type(types.int_)
+	tc.c_fn_module_param_types['variadic\x01C.probe'] = variadic_params
+	tc.c_fn_module_variadic['variadic\x01C.probe'] = true
+	// Simulate the program-wide compatibility metadata having retained the other view.
+	tc.fn_param_types['C.probe'] = variadic_params
+	tc.c_variadic_fns['C.probe'] = true
+	mut g := FlatGen.new()
+	g.a = &a
+	g.tc = &tc
+
+	tc.cur_module = 'fixed'
+	assert g.param_types_for('C.probe', 'probe') == fixed_params
+	assert !g.c_fn_is_variadic('C.probe', 'probe')
+
+	tc.fn_param_types['C.probe'] = fixed_params
+	tc.c_variadic_fns['C.probe'] = false
+	tc.cur_module = 'variadic'
+	assert g.param_types_for('C.probe', 'probe') == variadic_params
+	assert g.c_fn_is_variadic('C.probe', 'probe')
+}

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -5761,9 +5761,7 @@ fn (mut g FlatGen) gen_c_call_int_out_wrap(id flat.NodeId, node flat.Node) bool 
 		return false
 	}
 	param_types := g.param_types_for(callee_name, callee_name.all_after_last('.'))
-	is_c_variadic_fn := (g.tc.c_variadic_fns[callee_name] or { false }) || (g.tc.c_variadic_fns[fn_node.value] or {
-		false
-	})
+	is_c_variadic_fn := g.c_fn_is_variadic(callee_name, fn_node.value)
 	is_variadic_fn := is_c_variadic_fn || (g.tc.fn_variadic[callee_name] or { false })
 		|| g.fn_decl_is_variadic(callee_name, fn_node.value)
 	is_untyped_variadic := is_variadic_fn && param_types.len > 0
@@ -7155,7 +7153,7 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 				}
 			}
 			num_call_args := node.children_count - arg_start
-			is_c_variadic_fn := is_c_call && (g.tc.c_variadic_fns[actual_fn] or { false })
+			is_c_variadic_fn := is_c_call && g.c_fn_is_variadic(actual_fn, fn_name)
 			is_variadic_fn := !is_method && !is_c_variadic_fn && ((g.tc.fn_variadic[actual_fn] or {
 				false
 			}) || g.fn_decl_is_variadic(actual_fn, fn_name))
@@ -12257,6 +12255,75 @@ fn (g &FlatGen) fn_decl_is_variadic(name string, fallback string) bool {
 	return false
 }
 
+fn c_fn_semantic_name(name string) string {
+	if name.starts_with('C.') {
+		return name
+	}
+	if name.contains('C__') {
+		return 'C.${name.all_after('C__')}'
+	}
+	return 'C.${name.all_after_last('.')}'
+}
+
+fn c_fn_lookup_has_explicit_name(name string, fallback string) bool {
+	return name.starts_with('C.') || fallback.starts_with('C.') || name.contains('C__')
+		|| fallback.contains('C__')
+}
+
+fn (g &FlatGen) module_c_fn_param_types(name string, fallback string) ?[]types.Type {
+	if g.tc == unsafe { nil } || !c_fn_lookup_has_explicit_name(name, fallback) {
+		return none
+	}
+	mut previous := ''
+	for candidate in [name, fallback] {
+		semantic_name := c_fn_semantic_name(candidate)
+		if semantic_name == previous {
+			continue
+		}
+		previous = semantic_name
+		module_key := fn_decl_module_key(g.tc.cur_module, semantic_name)
+		if module_key in g.tc.c_fn_module_ret_types {
+			return g.tc.c_fn_module_param_types[module_key] or { []types.Type{} }
+		}
+	}
+	return none
+}
+
+fn (g &FlatGen) module_c_fn_variadic(name string, fallback string) ?bool {
+	if g.tc == unsafe { nil } {
+		return none
+	}
+	mut previous := ''
+	for candidate in [name, fallback] {
+		semantic_name := c_fn_semantic_name(candidate)
+		if semantic_name == previous {
+			continue
+		}
+		previous = semantic_name
+		module_key := fn_decl_module_key(g.tc.cur_module, semantic_name)
+		if module_key in g.tc.c_fn_module_ret_types {
+			return g.tc.c_fn_module_variadic[module_key] or { false }
+		}
+	}
+	return none
+}
+
+fn (g &FlatGen) c_fn_is_variadic(name string, fallback string) bool {
+	if is_variadic := g.module_c_fn_variadic(name, fallback) {
+		return is_variadic
+	}
+	for candidate in [name, fallback] {
+		if g.tc.c_variadic_fns[candidate] or { false } {
+			return true
+		}
+		semantic_name := c_fn_semantic_name(candidate)
+		if g.tc.c_variadic_fns[semantic_name] or { false } {
+			return true
+		}
+	}
+	return g.fn_decl_is_variadic(name, fallback)
+}
+
 fn (g &FlatGen) fn_decl_variadic_entry(name string) ?bool {
 	if value := g.fn_decl_variadic[name] {
 		return value
@@ -12309,7 +12376,12 @@ fn (g &FlatGen) unique_short_fn_decl_variadic(name string) ?bool {
 }
 
 fn (mut g FlatGen) param_types_for(name string, fallback string) []types.Type {
-	cache_key := if name == fallback { name } else { '${name}\x01${fallback}' }
+	call_key := if name == fallback { name } else { '${name}\x01${fallback}' }
+	cache_key := if c_fn_lookup_has_explicit_name(name, fallback) {
+		'${g.tc.cur_module}\x01${call_key}'
+	} else {
+		call_key
+	}
 	if cached := g.param_types_cache[cache_key] {
 		return cached
 	}
@@ -12319,6 +12391,9 @@ fn (mut g FlatGen) param_types_for(name string, fallback string) []types.Type {
 }
 
 fn (mut g FlatGen) param_types_for_uncached(name string, fallback string) []types.Type {
+	if params := g.module_c_fn_param_types(name, fallback) {
+		return params
+	}
 	if name == 'Array_string__join' || fallback == 'Array_string__join' {
 		if params := g.tc.fn_param_types['[]string.join'] {
 			return params
@@ -14913,7 +14988,7 @@ fn (mut g FlatGen) gen_call_args(fn_name string, node flat.Node, start int) {
 		|| g.call_uses_concrete_optional_params(callee_name)
 		|| g.call_uses_concrete_optional_params(g.direct_call_name(callee_name))
 		|| (callee_uses_specialized_generic_abi && params_have_optional_result(param_types))
-	is_c_variadic_fn := g.tc.c_variadic_fns[fn_name] or { false }
+	is_c_variadic_fn := is_c_call && g.c_fn_is_variadic(fn_name, callee_name)
 	is_variadic_fn := !is_c_variadic_fn && ((g.tc.fn_variadic[fn_name] or { false })
 		|| g.fn_decl_is_variadic(fn_name, callee_name))
 	is_untyped_variadic_fn := is_variadic_fn && param_types.len > 0

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -5761,13 +5761,16 @@ fn (mut g FlatGen) gen_c_call_int_out_wrap(id flat.NodeId, node flat.Node) bool 
 		return false
 	}
 	param_types := g.param_types_for(callee_name, callee_name.all_after_last('.'))
-	is_c_variadic_fn := g.c_fn_is_variadic(callee_name, fn_node.value)
+	c_variadic_prefix := g.c_fn_abi_variadic_prefix(callee_name, fn_node.value, param_types)
+	is_c_variadic_fn := c_variadic_prefix >= 0
 	is_variadic_fn := is_c_variadic_fn || (g.tc.fn_variadic[callee_name] or { false })
 		|| g.fn_decl_is_variadic(callee_name, fn_node.value)
 	is_untyped_variadic := is_variadic_fn && param_types.len > 0
 		&& variadic_array_is_native(param_types[param_types.len - 1])
 	is_native_variadic := is_c_variadic_fn || is_untyped_variadic
-	typed_param_count := if is_native_variadic && param_types.len > 0
+	typed_param_count := if is_c_variadic_fn {
+		c_variadic_prefix
+	} else if is_native_variadic && param_types.len > 0
 		&& param_types[param_types.len - 1] is types.Array {
 		param_types.len - 1
 	} else {
@@ -7153,7 +7156,12 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 				}
 			}
 			num_call_args := node.children_count - arg_start
-			is_c_variadic_fn := is_c_call && g.c_fn_is_variadic(actual_fn, fn_name)
+			c_variadic_prefix := if is_c_call {
+				g.c_fn_abi_variadic_prefix(actual_fn, fn_name, param_types)
+			} else {
+				-1
+			}
+			is_c_variadic_fn := c_variadic_prefix >= 0
 			is_variadic_fn := !is_method && !is_c_variadic_fn && ((g.tc.fn_variadic[actual_fn] or {
 				false
 			}) || g.fn_decl_is_variadic(actual_fn, fn_name))
@@ -7166,7 +7174,9 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 			} else {
 				-1
 			}
-			typed_param_count := if is_native_variadic_fn && param_types.len > 0
+			typed_param_count := if is_c_variadic_fn {
+				c_variadic_prefix
+			} else if is_native_variadic_fn && param_types.len > 0
 				&& param_types[param_types.len - 1] is types.Array {
 				param_types.len - 1
 			} else {
@@ -12308,20 +12318,38 @@ fn (g &FlatGen) module_c_fn_variadic(name string, fallback string) ?bool {
 	return none
 }
 
-fn (g &FlatGen) c_fn_is_variadic(name string, fallback string) bool {
+fn c_fn_variadic_prefix_from_params(param_types []types.Type) int {
+	if param_types.len > 0 && param_types[param_types.len - 1] is types.Array {
+		return param_types.len - 1
+	}
+	return param_types.len
+}
+
+fn (g &FlatGen) c_fn_abi_variadic_prefix(name string, fallback string, param_types []types.Type) int {
+	for candidate in [name, fallback] {
+		semantic_name := c_fn_semantic_name(candidate)
+		if prefix := g.tc.c_fn_abi_variadic_prefixes[semantic_name] {
+			return prefix
+		}
+	}
 	if is_variadic := g.module_c_fn_variadic(name, fallback) {
-		return is_variadic
+		if is_variadic {
+			return c_fn_variadic_prefix_from_params(param_types)
+		}
 	}
 	for candidate in [name, fallback] {
 		if g.tc.c_variadic_fns[candidate] or { false } {
-			return true
+			return c_fn_variadic_prefix_from_params(param_types)
 		}
 		semantic_name := c_fn_semantic_name(candidate)
 		if g.tc.c_variadic_fns[semantic_name] or { false } {
-			return true
+			return c_fn_variadic_prefix_from_params(param_types)
 		}
 	}
-	return g.fn_decl_is_variadic(name, fallback)
+	if g.fn_decl_is_variadic(name, fallback) {
+		return c_fn_variadic_prefix_from_params(param_types)
+	}
+	return -1
 }
 
 fn (g &FlatGen) fn_decl_variadic_entry(name string) ?bool {
@@ -14988,7 +15016,12 @@ fn (mut g FlatGen) gen_call_args(fn_name string, node flat.Node, start int) {
 		|| g.call_uses_concrete_optional_params(callee_name)
 		|| g.call_uses_concrete_optional_params(g.direct_call_name(callee_name))
 		|| (callee_uses_specialized_generic_abi && params_have_optional_result(param_types))
-	is_c_variadic_fn := is_c_call && g.c_fn_is_variadic(fn_name, callee_name)
+	c_variadic_prefix := if is_c_call {
+		g.c_fn_abi_variadic_prefix(fn_name, callee_name, param_types)
+	} else {
+		-1
+	}
+	is_c_variadic_fn := c_variadic_prefix >= 0
 	is_variadic_fn := !is_c_variadic_fn && ((g.tc.fn_variadic[fn_name] or { false })
 		|| g.fn_decl_is_variadic(fn_name, callee_name))
 	is_untyped_variadic_fn := is_variadic_fn && param_types.len > 0
@@ -15000,7 +15033,9 @@ fn (mut g FlatGen) gen_call_args(fn_name string, node flat.Node, start int) {
 	} else {
 		-1
 	}
-	typed_param_count := if is_native_variadic_fn && param_types.len > 0
+	typed_param_count := if is_c_variadic_fn {
+		c_variadic_prefix
+	} else if is_native_variadic_fn && param_types.len > 0
 		&& param_types[param_types.len - 1] is types.Array {
 		param_types.len - 1
 	} else {

--- a/vlib/v3/tests/c_fn_redeclaration_and_empty_struct_test.v
+++ b/vlib/v3/tests/c_fn_redeclaration_and_empty_struct_test.v
@@ -58,7 +58,7 @@ fn test_v3_c_fn_redeclarations_and_empty_struct_defaults() {
 		'v.mod':       "Module { name: 'c_fn_compatible' }\n"
 		'moda/moda.v': 'module moda\n\nstruct C.Display {}\nstruct C.Widget {\n\tvalue int\n}\n\nfn C.compat_probe(value int, data byteptr, display voidptr, mut state usize) int\nfn C.local_make() &C.Widget\n\npub fn touch() {\n\tmut state := usize(0)\n\tC.compat_probe(0, unsafe { nil }, unsafe { nil }, mut state)\n}\n\npub fn value() int {\n\treturn C.local_make().value\n}\n'
 		'modb/modb.v': 'module modb\n\nstruct C.Display {}\nstruct C.Widget {\n\tvalue int\n}\n\ntype CInt = i32\n\nfn C.compat_probe(value CInt, data &u8, display &C.Display, state &usize) i32\nfn C.local_make() voidptr\n\npub fn touch() {\n\tmut state := usize(0)\n\tC.compat_probe(0, unsafe { nil }, unsafe { nil }, &state)\n}\n\npub fn make() voidptr {\n\treturn C.local_make()\n}\n'
-		'main.v':      'module main\n\nimport moda as _\nimport modb as _\nimport net as _\n\nfn C.fcntl(fd int, cmd int, arg int) int\n\nfn main() {\n\t_ = C.fcntl(-1, 0, 0)\n}\n'
+		'main.v':      'module main\n\nimport moda as _\nimport modb as _\nimport net as _\n\nfn C.fcntl(fd int, cmd int, arg int) int\n\nfn main() {\n\targ := 0\n\t_ = C.fcntl(-1, 0, arg)\n}\n'
 	})!
 	defer {
 		os.rmdir_all(compatible_root) or {}
@@ -72,6 +72,10 @@ fn test_v3_c_fn_redeclarations_and_empty_struct_defaults() {
 	compatible_result :=
 		os.execute('${os.quoted_path(v3_bin)} -no-memory-limit ${os.quoted_path(compatible_root)} -b c -o ${os.quoted_path(compatible_out)}')
 	assert compatible_result.exit_code == 0, compatible_result.output
+	compatible_c := os.read_file(compatible_out + '.c')!
+	fcntl_calls := compatible_c.split_into_lines().filter(it.contains('fcntl(-1'))
+	assert fcntl_calls.len == 1, fcntl_calls.str()
+	assert fcntl_calls[0].contains('(int)(arg)'), fcntl_calls[0]
 
 	empty_root := write_c_fn_redecl_v3_project('empty_struct_default', {
 		'main.v': 'struct Empty {}\n\n__global global_empty Empty\n\nfn make_empty() Empty {\n\treturn Empty{}\n}\n\nfn main() {\n\t_ := make_empty()\n\t_ = global_empty\n}\n'

--- a/vlib/v3/tests/c_fn_redeclaration_and_empty_struct_test.v
+++ b/vlib/v3/tests/c_fn_redeclaration_and_empty_struct_test.v
@@ -58,7 +58,7 @@ fn test_v3_c_fn_redeclarations_and_empty_struct_defaults() {
 		'v.mod':       "Module { name: 'c_fn_compatible' }\n"
 		'moda/moda.v': 'module moda\n\nstruct C.Display {}\nstruct C.Widget {\n\tvalue int\n}\n\nfn C.compat_probe(value int, data byteptr, display voidptr, mut state usize) int\nfn C.local_make() &C.Widget\n\npub fn touch() {\n\tmut state := usize(0)\n\tC.compat_probe(0, unsafe { nil }, unsafe { nil }, mut state)\n}\n\npub fn value() int {\n\treturn C.local_make().value\n}\n'
 		'modb/modb.v': 'module modb\n\nstruct C.Display {}\nstruct C.Widget {\n\tvalue int\n}\n\ntype CInt = i32\n\nfn C.compat_probe(value CInt, data &u8, display &C.Display, state &usize) i32\nfn C.local_make() voidptr\n\npub fn touch() {\n\tmut state := usize(0)\n\tC.compat_probe(0, unsafe { nil }, unsafe { nil }, &state)\n}\n\npub fn make() voidptr {\n\treturn C.local_make()\n}\n'
-		'main.v':      'module main\n\nimport moda as _\nimport modb as _\n\nfn main() {}\n'
+		'main.v':      'module main\n\nimport moda as _\nimport modb as _\nimport net as _\n\nfn C.fcntl(fd int, cmd int, arg int) int\n\nfn main() {\n\t_ = C.fcntl(-1, 0, 0)\n}\n'
 	})!
 	defer {
 		os.rmdir_all(compatible_root) or {}

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -690,6 +690,7 @@ pub mut:
 	c_fn_module_ret_types            map[string]Type
 	c_fn_module_param_types          map[string][]Type
 	c_fn_module_variadic             map[string]bool
+	c_fn_abi_variadic_prefixes       map[string]int
 	fn_shared_params                 map[string][]bool
 	mut_receiver_methods             map[string]bool
 	source_no_body_fns               map[string]bool
@@ -1008,6 +1009,7 @@ pub fn TypeChecker.new(a &flat.FlatAst) TypeChecker {
 		c_fn_module_ret_types:                 map[string]Type{}
 		c_fn_module_param_types:               map[string][]Type{}
 		c_fn_module_variadic:                  map[string]bool{}
+		c_fn_abi_variadic_prefixes:            map[string]int{}
 		fn_shared_params:                      map[string][]bool{}
 		mut_receiver_methods:                  map[string]bool{}
 		source_no_body_fns:                    map[string]bool{}
@@ -1169,6 +1171,7 @@ fn (tc &TypeChecker) fork_program_view(ast &flat.FlatAst, direct_dependencies_by
 		c_fn_module_ret_types:              tc.c_fn_module_ret_types
 		c_fn_module_param_types:            tc.c_fn_module_param_types
 		c_fn_module_variadic:               tc.c_fn_module_variadic
+		c_fn_abi_variadic_prefixes:         tc.c_fn_abi_variadic_prefixes
 		fn_shared_params:                   tc.fn_shared_params
 		mut_receiver_methods:               tc.mut_receiver_methods
 		source_no_body_fns:                 tc.source_no_body_fns
@@ -3581,6 +3584,11 @@ fn (mut tc TypeChecker) collect_after_index(a &flat.FlatAst) {
 						false)
 				}
 				if is_variadic {
+					tc.c_fn_abi_variadic_prefixes[c_name] = if ptypes.len > 0 {
+						ptypes.len - 1
+					} else {
+						0
+					}
 					tc.register_c_variadic_fn(node.value)
 				}
 				if !node.value.starts_with('C.') {

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -4048,10 +4048,30 @@ fn c_fn_decl_signatures_compatible(a CFnDeclSignature, b CFnDeclSignature) bool 
 	if !c_fn_decl_abi_types_compatible(a.return_type, b.return_type) {
 		return false
 	}
-	if a.is_variadic != b.is_variadic || a.params.len != b.params.len {
+	if a.is_variadic != b.is_variadic {
+		variadic := if a.is_variadic { a } else { b }
+		fixed := if a.is_variadic { b } else { a }
+		if fixed.params.len < variadic.params.len
+			|| !c_fn_decl_param_prefix_compatible(fixed.params, variadic.params, variadic.params.len) {
+			return false
+		}
+		for i in variadic.params.len .. fixed.params.len {
+			if !c_fn_fixed_param_is_compatible_with_variadic(fixed.params[i]) {
+				return false
+			}
+		}
+		return true
+	}
+	if a.params.len != b.params.len {
 		return false
 	}
 	return c_fn_decl_param_prefix_compatible(a.params, b.params, a.params.len)
+}
+
+fn c_fn_fixed_param_is_compatible_with_variadic(typ string) bool {
+	// These types are changed by C's default argument promotions. A fixed
+	// declaration would therefore not describe the same argument ABI.
+	return typ !in ['i8', 'i16', 'u8', 'u16', 'float', 'char', 'bool']
 }
 
 fn c_fn_decl_param_prefix_compatible(a []string, b []string, count int) bool {


### PR DESCRIPTION
## Summary

- resolve V3 C-call parameter and variadic metadata from the declaration in the current module
- allow ABI-safe fixed declarations to coexist with variadic declarations across modules
- keep fixed/variadic declarations incompatible when C default argument promotions change the ABI
- cover the `fcntl` conflict from #28251 and both directions of module-local CGen metadata lookup

Closes #28251

## Testing

- `VFLAGS="-gc none" ./vnew -old-compiler -gc none -silent test vlib/v3/gen/c/` (18 passed)
- `VFLAGS="-gc none" ./vnew -old-compiler -gc none vlib/v3/tests/c_fn_redeclaration_and_empty_struct_test.v`
- `VFLAGS="-gc none" ./vnew -old-compiler -gc none vlib/v3/tests/c_variadic_call_codegen_test.v`
- `VFLAGS="-gc none" ./vnew -silent vlib/v/compiler_errors_test.v` (1696 passed, 1 skipped)

`vlib/v/gen/c/coutput_test.v` was also attempted, but this checkout does not have the Boehm `gc` library required by its explicit `-gc boehm` fixture.