### PR TITLE
cgen: fix remaining master CI regressions

### DIFF
--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -194,8 +194,8 @@ fn (mut g Gen) final_gen_str(typ StrType) {
 			g.gen_str_for_fn_type(sym.info, styp, str_fn_name)
 		}
 		ast.Struct {
-			g.gen_str_for_struct(sym.info, sym.language, styp, g.table.type_to_str(typ.typ),
-				str_fn_name)
+			g.gen_str_for_struct(typ.typ, sym.info, sym.language, styp,
+				g.table.type_to_str(typ.typ), str_fn_name)
 		}
 		ast.Map {
 			g.gen_str_for_map(sym.info, styp, str_fn_name)
@@ -267,7 +267,8 @@ fn (mut g Gen) gen_str_for_option(typ ast.Type, styp string, str_fn_name string,
 			g.auto_str_funcs.writeln('\t\tres = ${parent_str_fn_name}(${deref}it.data);')
 		}
 	}
-	g.auto_str_funcs.writeln('\t\treturn ${str_intp_sub('${type_name}(%%)', 'res')};')
+	option_label := type_name + '(%%)'
+	g.auto_str_funcs.writeln('\t\treturn ${str_intp_sub(option_label, 'res')};')
 	g.auto_str_funcs.writeln('\t}')
 	g.auto_str_funcs.writeln('\treturn _S("${type_name}(none)");')
 	g.auto_str_funcs.writeln('}')
@@ -1139,7 +1140,12 @@ fn (g &Gen) type_to_fmt(typ ast.Type) StrIntpType {
 	return .si_i32
 }
 
-fn (mut g Gen) gen_str_for_struct(info ast.Struct, lang ast.Language, styp string, typ_str string, str_fn_name string) {
+fn guarded_auto_str_fn_name(str_fn_name string) string {
+	return '${str_fn_name}__root'
+}
+
+fn (mut g Gen) gen_str_for_struct(typ ast.Type, info ast.Struct, lang ast.Language, styp string,
+	typ_str string, str_fn_name string) {
 	$if trace_autostr ? {
 		eprintln('> gen_str_for_struct: ${info.parent_type.debug()} | ${styp} | ${str_fn_name}')
 	}
@@ -1148,6 +1154,17 @@ fn (mut g Gen) gen_str_for_struct(info ast.Struct, lang ast.Language, styp strin
 	arg_def := if is_c_struct { '${styp}* it' } else { '${styp} it' }
 	g.definitions.writeln('${g.static_non_parallel}string ${str_fn_name}(${arg_def});')
 	g.auto_str_funcs.writeln('${g.static_non_parallel}string ${str_fn_name}(${arg_def}) { return indent_${str_fn_name}(it, 0);}')
+	if !is_c_struct {
+		root_str_fn_name := guarded_auto_str_fn_name(str_fn_name)
+		g.definitions.writeln('${g.static_non_parallel}string ${root_str_fn_name}(${styp}* it);')
+		g.auto_str_funcs.writeln('${g.static_non_parallel}string ${root_str_fn_name}(${styp}* it) {')
+		g.auto_str_funcs.writeln('\tif (builtin__autostr_addr_type_in_stack((voidptr)it, ${g.type_sidx(typ)})) { return _S("<circular>"); }')
+		g.auto_str_funcs.writeln('\tbuiltin__autostr_addr_type_push((voidptr)it, ${g.type_sidx(typ)});')
+		g.auto_str_funcs.writeln('\tstring res = ${str_fn_name}(*it);')
+		g.auto_str_funcs.writeln('\tbuiltin__autostr_addr_pop();')
+		g.auto_str_funcs.writeln('\treturn res;')
+		g.auto_str_funcs.writeln('}')
+	}
 	g.definitions.writeln('${g.static_non_parallel}string indent_${str_fn_name}(${arg_def}, ${ast.int_type_name} indent_count);')
 	mut fn_builder := strings.new_builder(512)
 	defer {
@@ -1334,7 +1351,7 @@ fn (mut g Gen) gen_str_for_struct(info ast.Struct, lang ast.Language, styp strin
 			is_field_array = true
 		}
 		// handle circular ref type of struct to the struct itself
-		if styp == field_styp && !allow_circular {
+		if styp == field_styp && !allow_circular && !ftyp_noshared.is_ptr() {
 			if is_field_array {
 				tmpvar := g.new_tmp_var()
 				if is_opt_field {
@@ -1362,11 +1379,12 @@ fn (mut g Gen) gen_str_for_struct(info ast.Struct, lang ast.Language, styp strin
 					// This correctly detects actual circular references (same instance)
 					// without false positives from different instances of the same type.
 					tmpvar := g.new_tmp_var()
+					guard_type := g.type_sidx(ftyp_noshared.deref().clear_flag(.option))
 					mut before := '\tstring ${tmpvar};\n'
-					before += '\tif (builtin__isnil((voidptr)${it_field_name}) || builtin__autostr_addr_in_stack((voidptr)${it_field_name})) {\n'
+					before += '\tif (builtin__isnil((voidptr)${it_field_name}) || builtin__autostr_addr_type_in_stack((voidptr)${it_field_name}, ${guard_type})) {\n'
 					before += '\t\t${tmpvar} = ${funcprefix}builtin__isnil((voidptr)${it_field_name}) ? _S("nil") : _S("<circular>");\n'
 					before += '\t} else {\n'
-					before += '\t\tbuiltin__autostr_addr_push((voidptr)${it_field_name});\n'
+					before += '\t\tbuiltin__autostr_addr_type_push((voidptr)${it_field_name}, ${guard_type});\n'
 					before += '\t\t${tmpvar} = ${funcprefix}${func};\n'
 					before += '\t\tbuiltin__autostr_addr_pop();\n'
 					before += '\t}'
@@ -1380,15 +1398,16 @@ fn (mut g Gen) gen_str_for_struct(info ast.Struct, lang ast.Language, styp strin
 					// Use address-based circular reference detection for option pointer fields (?&Struct).
 					// Extract the pointer from the option struct's data field.
 					tmpvar := g.new_tmp_var()
+					guard_type := g.type_sidx(ftyp_noshared.deref().clear_flag(.option))
 					mut before := '\tstring ${tmpvar};\n'
 					before += '\tif (${it_field_name}.state != 0) {\n'
 					before += '\t\t${tmpvar} = ${funcprefix}_S("Option(none)");\n'
 					before += '\t} else {\n'
 					before += '\t\tvoidptr ${tmpvar}_addr = *(voidptr*)${it_field_name}.data;\n'
-					before += '\t\tif (builtin__isnil(${tmpvar}_addr) || builtin__autostr_addr_in_stack(${tmpvar}_addr)) {\n'
+					before += '\t\tif (builtin__isnil(${tmpvar}_addr) || builtin__autostr_addr_type_in_stack(${tmpvar}_addr, ${guard_type})) {\n'
 					before += '\t\t\t${tmpvar} = ${funcprefix}builtin__isnil(${tmpvar}_addr) ? _S("Option(nil)") : _S("<circular>");\n'
 					before += '\t\t} else {\n'
-					before += '\t\t\tbuiltin__autostr_addr_push(${tmpvar}_addr);\n'
+					before += '\t\t\tbuiltin__autostr_addr_type_push(${tmpvar}_addr, ${guard_type});\n'
 					before += '\t\t\t${tmpvar} = ${funcprefix}${func};\n'
 					before += '\t\t\tbuiltin__autostr_addr_pop();\n'
 					before += '\t\t}\n'

--- a/vlib/v/gen/c/consts_and_globals.v
+++ b/vlib/v/gen/c/consts_and_globals.v
@@ -617,6 +617,18 @@ fn (mut g Gen) global_decl(node ast.GlobalDecl) {
 			}
 			continue
 		}
+		if field.name == 'g_autostr_addr_state' && node.mod == 'builtin' {
+			// Recursive automatic stringification state is local to each thread. A
+			// process-global stack lets concurrent interpolations corrupt each other.
+			linkage := '${extern}${field_visibility_kw}'
+			g.write_autostr_tls_global(mut def_builder, linkage, styp, final_c_name)
+			g.global_const_defs[name] = GlobalConstDef{
+				mod:        node.mod
+				def:        def_builder.str()
+				extern_def: g.autostr_tls_global_extern(styp, final_c_name)
+			}
+			continue
+		}
 		if field.is_extern {
 			def_builder.writeln('${extern}${field_visibility_kw}${qualifiers}${styp} ${attributes}${final_c_name}; // global 2')
 			g.global_const_defs[name] = GlobalConstDef{
@@ -727,6 +739,40 @@ fn (mut g Gen) write_prealloc_tls_global(mut def_builder strings.Builder, linkag
 
 fn (g &Gen) prealloc_tls_global_extern(styp string, cname string) string {
 	return '#if defined(__TINYC__) && defined(__APPLE__)\nvoid **v_prealloc_tls_slot(void);\n#define ${cname} (*(${styp} *)v_prealloc_tls_slot())\n#elif defined(__cplusplus)\nextern thread_local ${styp} ${cname};\n#else\nextern _Thread_local ${styp} ${cname};\n#endif'
+}
+
+// write_autostr_tls_global emits the per-thread recursion stack used by automatic str methods.
+// TinyCC uses native OS thread-local slots, while other C compilers use language TLS.
+fn (mut g Gen) write_autostr_tls_global(mut def_builder strings.Builder, linkage string, styp string,
+	cname string) {
+	slot_fn := 'v_${cname}_tls_slot'
+	slot_linkage := if g.pref.parallel_cc { '' } else { 'static ' }
+	def_builder.writeln('#if defined(__TINYC__) && defined(_WIN32)')
+	def_builder.writeln('static DWORD ${cname}_tls_key = 0xFFFFFFFF;')
+	def_builder.writeln('static void WINAPI ${cname}_tls_free(void* p) { free(p); }')
+	def_builder.writeln('static void ${cname}_tls_init(void) __attribute__((constructor));')
+	def_builder.writeln('static void ${cname}_tls_init(void) { ${cname}_tls_key = FlsAlloc(${cname}_tls_free); }')
+	def_builder.writeln('${slot_linkage}${styp}* ${slot_fn}(void) { void* p = FlsGetValue(${cname}_tls_key); if (!p) { p = calloc(1, sizeof(${styp})); FlsSetValue(${cname}_tls_key, p); } return (${styp}*)p; }')
+	def_builder.writeln('#define ${cname} (*${slot_fn}())')
+	def_builder.writeln('#elif defined(__TINYC__)')
+	def_builder.writeln('#include <pthread.h>')
+	def_builder.writeln('static pthread_key_t ${cname}_tls_key;')
+	def_builder.writeln('static pthread_once_t ${cname}_tls_once = PTHREAD_ONCE_INIT;')
+	def_builder.writeln('static void ${cname}_tls_init(void) { pthread_key_create(&${cname}_tls_key, free); }')
+	def_builder.writeln('${slot_linkage}${styp}* ${slot_fn}(void) { pthread_once(&${cname}_tls_once, ${cname}_tls_init); void* p = pthread_getspecific(${cname}_tls_key); if (!p) { p = calloc(1, sizeof(${styp})); pthread_setspecific(${cname}_tls_key, p); } return (${styp}*)p; }')
+	def_builder.writeln('#define ${cname} (*${slot_fn}())')
+	def_builder.writeln('#elif defined(_MSC_VER)')
+	def_builder.writeln('${linkage}__declspec(thread) ${styp} ${cname}; // global 6')
+	def_builder.writeln('#elif defined(__cplusplus)')
+	def_builder.writeln('${linkage}thread_local ${styp} ${cname}; // global 6')
+	def_builder.writeln('#else')
+	def_builder.writeln('${linkage}_Thread_local ${styp} ${cname}; // global 6')
+	def_builder.writeln('#endif')
+}
+
+fn (g &Gen) autostr_tls_global_extern(styp string, cname string) string {
+	slot_fn := 'v_${cname}_tls_slot'
+	return '#if defined(__TINYC__)\n${styp}* ${slot_fn}(void);\n#define ${cname} (*${slot_fn}())\n#elif defined(_MSC_VER)\nextern __declspec(thread) ${styp} ${cname};\n#elif defined(__cplusplus)\nextern thread_local ${styp} ${cname};\n#else\nextern _Thread_local ${styp} ${cname};\n#endif'
 }
 
 fn (mut g Gen) sort_globals_consts() {

--- a/vlib/v/gen/c/coutput_test.v
+++ b/vlib/v/gen/c/coutput_test.v
@@ -878,7 +878,7 @@ fn test_array_sort_with_compare_uses_stable_sort_adapters() {
 
 fn test_array_sort_expression_key_avoids_sanitized_name_collisions() {
 	os.chdir(vroot) or {}
-	test_dir := os.join_path(os.vtmp_dir(), 'coutput_array_sort_expr_collision_${os.getpid()}')
+	test_dir := os.join_path(os.temp_dir(), 'coutput_array_sort_expr_collision_${os.getpid()}')
 	os.mkdir_all(test_dir)!
 	defer {
 		os.rmdir_all(test_dir) or {}

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -4796,6 +4796,8 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 	}
 	left_sym := g.table.sym(left_type)
 	final_left_sym := g.table.final_sym(left_type)
+	left_storage_type := g.table.fully_unaliased_type(left_type)
+	left_type_is_ptr := left_type.is_ptr() || left_storage_type.is_ptr()
 	// In generic functions node.from_embed_types may be stale: the checker overwrites
 	// it on each instantiation pass, so the state of the last checked concrete type
 	// wins (including a possibly empty state). Re-resolve it for the current
@@ -4903,7 +4905,7 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 		name = 'sync__Channel_${method_name}'
 	}
 	mut is_range_slice := false
-	if receiver_type.is_ptr() && !left_type.is_ptr() {
+	if receiver_type.is_ptr() && !left_type_is_ptr {
 		if node.left is ast.IndexExpr {
 			idx := node.left.index
 			if idx is ast.RangeExpr {
@@ -5476,7 +5478,7 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 		}
 	}
 	mut free_receiver_heap_copy := ''
-	if is_free_method && has_method && node.left is ast.Ident && !left_type.is_ptr()
+	if is_free_method && has_method && node.left is ast.Ident && !left_type_is_ptr
 		&& free_method_calls_free_on_receiver(full_method) {
 		left_ident := node.left as ast.Ident
 		if !g.resolved_ident_is_auto_heap(left_ident) {
@@ -5489,17 +5491,17 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 			g.write(stmt_line)
 		}
 	}
+	receiver_storage_type := g.table.fully_unaliased_type(receiver_type)
 	receiver_needs_ref := receiver_type.is_ptr() || receiver_is_mut
 	// g.generate_tmp_autofree_arg_vars(node, name)
-	if !receiver_needs_ref && left_type.is_ptr() && node.kind == .str {
+	if !receiver_needs_ref && left_type_is_ptr && node.kind == .str {
 		if left_type.is_int_valptr() {
 			g.write('builtin__ptr_str(')
 		} else {
 			g.gen_expr_to_string(node.left, left_type)
 			return
 		}
-	} else if receiver_needs_ref && left_type.is_ptr() && node.kind == .str
-		&& !left_sym.has_method('str') {
+	} else if receiver_needs_ref && left_type_is_ptr && node.kind == .str && !has_method {
 		g.gen_expr_to_string(node.left, left_type)
 		return
 	} else {
@@ -5524,7 +5526,7 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 		else {}
 	}
 
-	if free_receiver_heap_copy == '' && receiver_needs_ref && (!left_type.is_ptr()
+	if free_receiver_heap_copy == '' && receiver_needs_ref && (!left_type_is_ptr
 		|| effective_embed_types.len != 0 || (left_type.has_flag(.shared_f) && node.kind != .str)) {
 		// The receiver is a reference, but the caller provided a value
 		// Add `&` automatically.
@@ -5552,14 +5554,17 @@ fn (mut g Gen) method_call(node ast.CallExpr) {
 				cast_n++
 			}
 		}
-	} else if free_receiver_heap_copy == '' && !receiver_needs_ref && left_type.is_ptr()
+	} else if free_receiver_heap_copy == '' && !receiver_needs_ref && left_type_is_ptr
 		&& node.kind != .str && effective_embed_types.len == 0 {
 		if !left_type.has_flag(.shared_f) {
-			g.write('*'.repeat(left_type.nr_muls()))
+			diff := left_storage_type.nr_muls() - receiver_storage_type.nr_muls()
+			if diff > 0 {
+				g.write('*'.repeat(diff))
+			}
 		}
 	} else if free_receiver_heap_copy == '' && !is_range_slice && effective_embed_types.len == 0
 		&& node.kind != .str {
-		diff := left_type.nr_muls() - receiver_type.nr_muls()
+		diff := left_storage_type.nr_muls() - receiver_storage_type.nr_muls()
 		if diff > 0 {
 			g.write('*'.repeat(diff))
 		}

--- a/vlib/v/gen/c/str.v
+++ b/vlib/v/gen/c/str.v
@@ -358,6 +358,15 @@ fn (mut g Gen) gen_expr_to_string(expr ast.Expr, etype ast.Type) {
 		} else {
 			g.get_str_fn(exp_typ)
 		}
+		use_auto_struct_root_guard := sym.kind == .struct && !sym_has_str_method
+			&& !sym.is_c_struct() && !typ.has_option_or_result() && mut_arg_option_type == 0
+			&& (is_ptr || expr.is_lvalue())
+		effective_str_fn_name := if use_auto_struct_root_guard {
+			guarded_auto_str_fn_name(str_fn_name)
+		} else {
+			str_fn_name
+		}
+		effective_str_method_expects_ptr := str_method_expects_ptr || use_auto_struct_root_guard
 		temp_var_needed := expr is ast.CallExpr
 			&& (expr.return_type.is_ptr() || g.table.sym(expr.return_type).is_c_struct())
 		mut tmp_var := ''
@@ -410,8 +419,8 @@ fn (mut g Gen) gen_expr_to_string(expr ast.Expr, etype ast.Type) {
 				g.write(') ? _S("nil") : ')
 			}
 		}
-		g.write2(str_fn_name, '(')
-		if str_method_expects_ptr && (!is_ptr || is_ptr_alias_with_str) {
+		g.write2(effective_str_fn_name, '(')
+		if effective_str_method_expects_ptr && (!is_ptr || is_ptr_alias_with_str) {
 			if is_dump_expr || (g.pref.ccompiler_type != .tinyc && expr is ast.CallExpr) {
 				g.write('ADDR(${g.styp(typ)}, ')
 				defer(fn) {
@@ -428,8 +437,8 @@ fn (mut g Gen) gen_expr_to_string(expr ast.Expr, etype ast.Type) {
 			} else {
 				g.write('*(${g.styp(typ)}*)&')
 			}
-		} else if !str_method_expects_ptr && !is_shared && ((is_ptr && !is_ptr_alias_with_str)
-			|| is_var_mut) {
+		} else if !effective_str_method_expects_ptr && !is_shared
+			&& ((is_ptr && !is_ptr_alias_with_str) || is_var_mut) {
 			if sym.is_c_struct() {
 				g.write(c_struct_ptr(sym, typ, str_method_expects_ptr))
 			} else {

--- a/vlib/v/gen/c/testdata/backend_independent_struct_layout_v3.c.must_have
+++ b/vlib/v/gen/c/testdata/backend_independent_struct_layout_v3.c.must_have
@@ -1,3 +1,3 @@
-COutputPoint point, int delta) {
+COutputPoint point, i64 delta) {
 COutputPoint){.x = point.x + delta
 COutputPoint){.x = 1


### PR DESCRIPTION
Fixes the remaining reproducible failures found while auditing master CI:

- preserve pointer-alias receiver semantics for custom str methods
- guard automatic struct stringification by address and type, including root values and optional pointer fields
- make the automatic-stringification recursion stack thread-local
- avoid a V3 temp-directory cleanup race in the C-output test
- align the V3 struct-layout C expectation with its 64-bit int representation
- keep option auto-str generation bootstrap-stable

Validation (all serial with VJOBS=1 and -no-parallel):

- builtin_strings_and_interpolation: 49/49 passed
- reference/default-format and recursive-struct interpolation under V1 and V3
- pointer-alias regression tests
- compiler_errors_test: 1696 passed, 1 skipped
- coutput_test: 106 output fixtures and 142 C-pattern fixtures passed, expected platform skips only
- vfmt verification for all touched V files

The latest completed macOS failure on master was from an older revision and was superseded by #28317. Current master workflows are still queued in the repository-wide Actions backlog.