### PR TITLE
v3: reduce FastC link overhead

### DIFF
--- a/cmd/v/macos_v3_dispatch.c.v
+++ b/cmd/v/macos_v3_dispatch.c.v
@@ -247,6 +247,10 @@ fn is_macos_v3_internal_tool_bootstrap(normalized_path string, is_vchild bool) b
 }
 
 fn launch_macos_v3_compiler(prefs &pref.Preferences, raw_args []string) ?MacosV3CErrorReport {
+	if prefs.is_fastc {
+		launch_macos_v3_fastc_compiler(prefs, raw_args)
+		return none
+	}
 	dispatch_environment := os.environ()
 	caller_environment := macos_v3_original_caller_environment(dispatch_environment)
 	vexe := pref.vexe_path()
@@ -290,6 +294,45 @@ fn launch_macos_v3_compiler(prefs &pref.Preferences, raw_args []string) ?MacosV3
 	os.rm(fallback_file) or {}
 	os.rmdir_all(c_error_dir) or {}
 	exit(0)
+}
+
+fn launch_macos_v3_fastc_compiler(prefs &pref.Preferences, raw_args []string) {
+	vexe := pref.vexe_path()
+	util.set_vroot_folder(os.dir(vexe))
+	forwarded_args := macos_v3_forwarded_args(prefs, raw_args)
+	if prefs.is_verbose {
+		println('Running macOS V3 compiler in process: ${util.args_quote_paths(forwarded_args)}')
+	}
+	preserve_macos_v3_caller_process_value('VEXE', macos_v3_caller_vexe_env,
+		macos_v3_caller_vexe_present_env)
+	preserve_macos_v3_caller_process_value('VCHILD', macos_v3_caller_vchild_env,
+		macos_v3_caller_vchild_present_env)
+	preserve_macos_v3_caller_process_value(macos_v3_no_fallback_env,
+		macos_v3_caller_no_fallback_env, macos_v3_caller_no_fallback_present_env)
+	for private_name in [macos_v3_fallback_file_env, macos_v3_c_error_dir_env,
+		macos_v3_retry_env] {
+		os.unsetenv(private_name)
+	}
+	os.setenv('VCHILD', 'true', true)
+	os.setenv('VEXE', os.real_path(vexe), true)
+	os.setenv(macos_v3_vhash_env, @VHASH, true)
+	os.setenv(macos_v3_vcurrent_hash_env, @VCURRENTHASH, true)
+	os.setenv(macos_v3_embedded_env, '1', true)
+	macos_v3_driver_run(forwarded_args)
+	exit(0)
+}
+
+fn preserve_macos_v3_caller_process_value(name string, value_name string, present_name string) {
+	if os.getenv(present_name) in ['0', '1'] {
+		return
+	}
+	if value := os.getenv_opt(name) {
+		os.setenv(value_name, value, true)
+		os.setenv(present_name, '1', true)
+	} else {
+		os.setenv(value_name, '', true)
+		os.setenv(present_name, '0', true)
+	}
 }
 
 fn replace_macos_v3_process_environment(environment map[string]string) {

--- a/vlib/v3/cmdexec/macos_sdk.v
+++ b/vlib/v3/cmdexec/macos_sdk.v
@@ -1,0 +1,75 @@
+module cmdexec
+
+import os
+
+const macos_sdk_cache_version = '1'
+
+fn macos_sdk_cache_escape(value string) string {
+	return value.replace('\\', '\\\\').replace('|', '\\|').replace('\n', '\\n')
+}
+
+fn macos_sdk_selection_marker() string {
+	mut values := [os.getenv('SDKROOT'), os.getenv('DEVELOPER_DIR'), os.getenv('TOOLCHAINS'),
+		os.getenv('PATH')]
+	xcode_select_link := '/var/db/xcode_select_link'
+	selection := if os.is_link(xcode_select_link) {
+		os.readlink(xcode_select_link) or { '' }
+	} else {
+		''
+	}
+	values << selection
+	for developer_dir in ['/Library/Developer/CommandLineTools',
+		'/Applications/Xcode.app/Contents/Developer'] {
+		values << '${os.is_dir(developer_dir)}:${os.file_last_mod_unix(developer_dir)}'
+	}
+	return values.map(macos_sdk_cache_escape(it)).join('|')
+}
+
+fn macos_sdk_read_cache(path string, marker string) string {
+	content := os.read_file(path) or { return '' }
+	lines := content.split_into_lines()
+	if lines.len != 3 || lines[0] != macos_sdk_cache_version || lines[1] != marker
+		|| !os.is_dir(lines[2]) {
+		return ''
+	}
+	return lines[2]
+}
+
+fn macos_sdk_write_cache(path string, marker string, root string) {
+	if !os.is_dir(root) {
+		return
+	}
+	tmp_path := '${path}.${os.getpid()}.tmp'
+	os.write_file(tmp_path, '${macos_sdk_cache_version}\n${marker}\n${root}\n') or { return }
+	os.rename(tmp_path, path) or { os.rm(tmp_path) or {} }
+}
+
+// macos_sdk_root finds and caches the SDK selected by Apple's command-line tools.
+pub fn macos_sdk_root() string {
+	env_root := os.getenv('SDKROOT')
+	if os.is_dir(env_root) {
+		return env_root
+	}
+	marker := macos_sdk_selection_marker()
+	cache_path := os.join_path_single(os.vtmp_dir(), 'v3_macos_sdk_root')
+	cached_root := macos_sdk_read_cache(cache_path, marker)
+	if cached_root != '' {
+		return cached_root
+	}
+	result := run('xcrun', ['--show-sdk-path'])
+	if result.exit_code == 0 {
+		found := result.output.trim_space()
+		if os.is_dir(found) {
+			macos_sdk_write_cache(cache_path, marker, found)
+			return found
+		}
+	}
+	for candidate in ['/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk',
+		'/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk'] {
+		if os.is_dir(candidate) {
+			macos_sdk_write_cache(cache_path, marker, candidate)
+			return candidate
+		}
+	}
+	return ''
+}

--- a/vlib/v3/cmdexec/macos_sdk_test.v
+++ b/vlib/v3/cmdexec/macos_sdk_test.v
@@ -1,0 +1,20 @@
+module cmdexec
+
+import os
+
+fn test_macos_sdk_cache_requires_matching_selection_and_existing_sdk() {
+	test_dir := os.join_path(os.temp_dir(), 'v3_macos_sdk_cache_${os.getpid()}')
+	os.rmdir_all(test_dir) or {}
+	os.mkdir_all(test_dir) or { panic(err) }
+	defer {
+		os.rmdir_all(test_dir) or {}
+	}
+	sdk_dir := os.join_path_single(test_dir, 'MacOSX.sdk')
+	cache_path := os.join_path_single(test_dir, 'cache')
+	os.mkdir_all(sdk_dir) or { panic(err) }
+	macos_sdk_write_cache(cache_path, 'selected-a', sdk_dir)
+	assert macos_sdk_read_cache(cache_path, 'selected-a') == sdk_dir
+	assert macos_sdk_read_cache(cache_path, 'selected-b') == ''
+	os.rmdir_all(sdk_dir) or { panic(err) }
+	assert macos_sdk_read_cache(cache_path, 'selected-a') == ''
+}

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -1934,28 +1934,8 @@ fn v3_tcc_host_system_flags(target_os string, macos_sdk_root string) []string {
 	return flags
 }
 
-// macos_sdk_root finds the selected macOS SDK. SDKROOT and xcrun are
-// authoritative; the conventional locations are fallbacks for an unavailable
-// or broken xcrun.
 fn macos_sdk_root() string {
-	env_root := os.getenv('SDKROOT')
-	if os.is_dir(env_root) {
-		return env_root
-	}
-	result := cmdexec.run('xcrun', ['--show-sdk-path'])
-	if result.exit_code == 0 {
-		found := result.output.trim_space()
-		if os.is_dir(found) {
-			return found
-		}
-	}
-	for candidate in ['/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk',
-		'/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk'] {
-		if os.is_dir(candidate) {
-			return candidate
-		}
-	}
-	return ''
+	return cmdexec.macos_sdk_root()
 }
 
 // V3MacosSdkRootCache avoids repeating xcrun when a TinyCC build constructs
@@ -7474,18 +7454,21 @@ fn compile_v3_fastc_source(pieces []string, units fastc.FastcUnitLayout, bin_fil
 	if is_debug {
 		cc_args << '-g'
 	}
-	// TinyCC signs the linked executable through `codesign` on macOS; the
-	// shim makes that call a no-op and the executable is signed below.
-	shim_dir := fastc.fastc_codesign_shim_dir()
+	mut shim_dir := fastc.FastcCodesignShim{}
 	defer {
 		fastc.fastc_remove_codesign_shim_dir(shim_dir)
 	}
 	mut result := os.Result{}
 	mut command := ''
+	mut sign_in_process := false
 	if unit_paths.len > 1 {
 		mut compile_args := cc_args.clone()
 		compile_args << user_c_flags
+		link_worker := spawn fastc.fastc_prepare_link(tcc_path,
+			os.join_path_single(tcc_dir, 'lib'), cc_args)
 		unit_objects := fastc.fastc_compile_c_units(tcc_path, compile_args, unit_paths) or {
+			mut prepared_link := link_worker.wait()
+			fastc.fastc_discard_link(mut prepared_link)
 			fastc.write_c_pieces(source_file, pieces) or {}
 			return V3FastCCompileResult{
 				command: cmdexec.display(tcc_path, compile_args)
@@ -7495,16 +7478,27 @@ fn compile_v3_fastc_source(pieces []string, units fastc.FastcUnitLayout, bin_fil
 		if bench_phases {
 			eprintln('fastc-phase tcc.units_compiled ${cc_sw.elapsed().microseconds()}us')
 		}
-		cc_args << ['-o', staged_binary]
-		cc_args << unit_objects
-		cc_args << user_c_flags
+		link_inputs := unit_objects.clone()
+		mut final_args := user_c_flags.clone()
 		if uses_threads {
-			cc_args << '-lpthread'
+			final_args << '-lpthread'
 		}
-		cc_args << '-lm'
-		cc_args << environment_ld_flags
-		command = cmdexec.display(tcc_path, cc_args)
-		result = fastc.fastc_run_command(tcc_path, cc_args)
+		final_args << '-lm'
+		final_args << environment_ld_flags
+		mut display_args := cc_args.clone()
+		display_args << ['-o', staged_binary]
+		display_args << link_inputs
+		display_args << final_args
+		command = cmdexec.display(tcc_path, display_args)
+		mut prepared_link := link_worker.wait()
+		sign_in_process = fastc.fastc_prepared_link_skips_codesign(&prepared_link)
+		if !sign_in_process {
+			// The executable-based linker still needs the PATH shim; the prepared
+			// libtcc linker suppresses its codesign call without a subprocess.
+			shim_dir = fastc.fastc_codesign_shim_dir()
+			sign_in_process = shim_dir.dir != ''
+		}
+		result = fastc.fastc_finish_link(mut prepared_link, link_inputs, final_args, staged_binary)
 		if bench_phases {
 			eprintln('fastc-phase tcc.linked ${cc_sw.elapsed().microseconds()}us')
 		}
@@ -7519,6 +7513,8 @@ fn compile_v3_fastc_source(pieces []string, units fastc.FastcUnitLayout, bin_fil
 		cc_args << '-lm'
 		cc_args << environment_ld_flags
 		command = cmdexec.display(tcc_path, cc_args)
+		shim_dir = fastc.fastc_codesign_shim_dir()
+		sign_in_process = shim_dir.dir != ''
 		result = cmdexec.run_in(tcc_path, cc_args, build_dir)
 	}
 	if result.exit_code != 0 || !os.is_file(staged_binary) {
@@ -7532,7 +7528,7 @@ fn compile_v3_fastc_source(pieces []string, units fastc.FastcUnitLayout, bin_fil
 			output:  result.output
 		}
 	}
-	if shim_dir.dir != '' {
+	if sign_in_process {
 		fastc.fastc_sign_macho_adhoc(staged_binary) or {
 			return V3FastCCompileResult{
 				command: command

--- a/vlib/v3/fastcdriver/fastcdriver.v
+++ b/vlib/v3/fastcdriver/fastcdriver.v
@@ -306,28 +306,8 @@ fn tcc_host_system_flags(target_os string) []string {
 	return flags
 }
 
-// macos_sdk_root finds the selected macOS SDK. SDKROOT and xcrun are
-// authoritative; the conventional locations are fallbacks for an unavailable
-// or broken xcrun.
 fn macos_sdk_root() string {
-	env_root := os.getenv('SDKROOT')
-	if os.is_dir(env_root) {
-		return env_root
-	}
-	result := cmdexec.run('xcrun', ['--show-sdk-path'])
-	if result.exit_code == 0 {
-		found := result.output.trim_space()
-		if os.is_dir(found) {
-			return found
-		}
-	}
-	for candidate in ['/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk',
-		'/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk'] {
-		if os.is_dir(candidate) {
-			return candidate
-		}
-	}
-	return ''
+	return cmdexec.macos_sdk_root()
 }
 
 struct FastcBenchSample {
@@ -513,13 +493,14 @@ pub fn run(args []string) {
 	if bench_phases {
 		eprintln('fastc-phase tcc.units_written ${cc_sw.elapsed().microseconds()}us units=${unit_paths.len}')
 	}
-	// TinyCC signs the linked executable through `codesign` on macOS; the
-	// shim makes that call a no-op and the executable is signed below.
-	shim_dir := fastc.fastc_codesign_shim_dir()
+	mut shim_dir := fastc.FastcCodesignShim{}
 	mut result := os.Result{}
-	mut unit_objects := []string{}
+	mut sign_in_process := false
 	if unit_paths.len > 1 {
-		unit_objects = fastc.fastc_compile_c_units(tcc, cc_args, unit_paths) or {
+		link_worker := spawn fastc.fastc_prepare_link(tcc, tcc_lib, cc_args)
+		unit_objects := fastc.fastc_compile_c_units(tcc, cc_args, unit_paths) or {
+			mut prepared_link := link_worker.wait()
+			fastc.fastc_discard_link(mut prepared_link)
 			fastc.fastc_remove_codesign_shim_dir(shim_dir)
 			fastc.fastc_remove_c_units(unit_paths)
 			// The whole program is kept as one file for the error message.
@@ -529,11 +510,14 @@ pub fn run(args []string) {
 		if bench_phases {
 			eprintln('fastc-phase tcc.units_compiled ${cc_sw.elapsed().microseconds()}us')
 		}
-		mut link_args := cc_args.clone()
-		link_args << ['-o', staged_output]
-		link_args << unit_objects
-		link_args << link_libs
-		result = fastc.fastc_run_command(tcc, link_args)
+		link_inputs := unit_objects.clone()
+		mut prepared_link := link_worker.wait()
+		sign_in_process = fastc.fastc_prepared_link_skips_codesign(&prepared_link)
+		if !sign_in_process {
+			shim_dir = fastc.fastc_codesign_shim_dir()
+			sign_in_process = shim_dir.dir != ''
+		}
+		result = fastc.fastc_finish_link(mut prepared_link, link_inputs, link_libs, staged_output)
 		if bench_phases {
 			eprintln('fastc-phase tcc.linked ${cc_sw.elapsed().microseconds()}us')
 		}
@@ -545,6 +529,8 @@ pub fn run(args []string) {
 		mut single_args := cc_args.clone()
 		single_args << ['-o', staged_output, c_path]
 		single_args << link_libs
+		shim_dir = fastc.fastc_codesign_shim_dir()
+		sign_in_process = shim_dir.dir != ''
 		result = fastc.fastc_run_command(tcc, single_args)
 	}
 	fastc.fastc_remove_codesign_shim_dir(shim_dir)
@@ -552,7 +538,7 @@ pub fn run(args []string) {
 	if result.exit_code != 0 {
 		fail(result.output)
 	}
-	if shim_dir.dir != '' {
+	if sign_in_process {
 		fastc.fastc_sign_macho_adhoc(staged_output) or {
 			fail('could not sign ${staged_output}: ${err.msg()}')
 		}

--- a/vlib/v3/gen/fastc/libtcc_system_darwin.h
+++ b/vlib/v3/gen/fastc/libtcc_system_darwin.h
@@ -1,0 +1,34 @@
+#ifndef V_FASTC_LIBTCC_SYSTEM_DARWIN_H
+#define V_FASTC_LIBTCC_SYSTEM_DARWIN_H
+
+#include <dlfcn.h>
+#include <string.h>
+
+typedef int (*v_fastc_system_fn)(const char *);
+
+static _Thread_local int v_fastc_tcc_skip_codesign;
+static _Thread_local int v_fastc_tcc_skipped_codesigns;
+static _Thread_local v_fastc_system_fn v_fastc_real_system;
+
+int system(const char *command) {
+	static const char codesign_prefix[] = "codesign -f -s - ";
+	if (v_fastc_tcc_skip_codesign && command != NULL
+		&& strncmp(command, codesign_prefix, sizeof(codesign_prefix) - 1) == 0) {
+		v_fastc_tcc_skipped_codesigns++;
+		return 0;
+	}
+	if (v_fastc_real_system == NULL) {
+		v_fastc_real_system = (v_fastc_system_fn)dlsym(RTLD_NEXT, "system");
+	}
+	return v_fastc_real_system == NULL ? -1 : v_fastc_real_system(command);
+}
+
+static void v_fastc_tcc_set_skip_codesign(int skip) {
+	v_fastc_tcc_skip_codesign = skip;
+}
+
+static int v_fastc_tcc_skipped_codesign_count(void) {
+	return v_fastc_tcc_skipped_codesigns;
+}
+
+#endif

--- a/vlib/v3/gen/fastc/link.v
+++ b/vlib/v3/gen/fastc/link.v
@@ -1,0 +1,57 @@
+module fastc
+
+import os
+
+// FastcPreparedLink holds a linker that can be initialized concurrently with
+// the TinyCC processes compiling a program's translation units.
+pub struct FastcPreparedLink {
+mut:
+	state       voidptr
+	diagnostics voidptr
+	program     string
+	base_args   []string
+}
+
+// fastc_prepare_link initializes the in-process TinyCC linker on macOS. Other
+// platforms retain the executable-based linker and only record its arguments.
+pub fn fastc_prepare_link(program string, tcc_lib string, base_args []string) FastcPreparedLink {
+	$if macos && !fastc_selfhost ? {
+		return fastc_prepare_libtcc_link(program, tcc_lib, base_args)
+	} $else {
+		return FastcPreparedLink{
+			program: program
+			base_args: base_args.clone()
+		}
+	}
+}
+
+// fastc_prepared_link_skips_codesign reports whether the prepared linker
+// suppresses TinyCC's codesign subprocess and needs in-process signing.
+pub fn fastc_prepared_link_skips_codesign(link &FastcPreparedLink) bool {
+	$if macos && !fastc_selfhost ? {
+		return !isnil(link.state)
+	} $else {
+		return false
+	}
+}
+
+// fastc_finish_link adds the compiled inputs to a prepared linker and writes
+// the executable. `final_args` contains libraries and other link-only flags.
+pub fn fastc_finish_link(mut link FastcPreparedLink, input_paths []string, final_args []string, output string) os.Result {
+	$if macos && !fastc_selfhost ? {
+		return fastc_finish_libtcc_link(mut link, input_paths, final_args, output)
+	} $else {
+		mut args := link.base_args.clone()
+		args << ['-o', output]
+		args << input_paths
+		args << final_args
+		return fastc_run_command(link.program, args)
+	}
+}
+
+// fastc_discard_link releases a prepared linker after unit compilation fails.
+pub fn fastc_discard_link(mut link FastcPreparedLink) {
+	$if macos && !fastc_selfhost ? {
+		fastc_discard_libtcc_link(mut link)
+	}
+}

--- a/vlib/v3/gen/fastc/link_darwin.c.v
+++ b/vlib/v3/gen/fastc/link_darwin.c.v
@@ -1,0 +1,207 @@
+module fastc
+
+import os
+import strings
+
+#flag darwin -I @VEXEROOT/thirdparty/tcc/include
+
+#flag darwin @VEXEROOT/thirdparty/tcc/lib/libtcc.a
+
+#include "libtcc.h"
+
+$if !fastc_selfhost ? {
+	#insert "@VEXEROOT/vlib/v3/gen/fastc/libtcc_system_darwin.h"
+}
+
+struct C.TCCState {}
+
+fn C.tcc_new() &C.TCCState
+
+fn C.tcc_delete(&C.TCCState)
+
+fn C.tcc_set_lib_path(&C.TCCState, &char)
+
+fn C.tcc_set_error_func(&C.TCCState, voidptr, fn (voidptr, &char))
+
+fn C.tcc_set_options(&C.TCCState, &char) int
+
+fn C.tcc_set_output_type(&C.TCCState, int) int
+
+fn C.tcc_add_file(&C.TCCState, &char) int
+
+fn C.tcc_output_file(&C.TCCState, &char) int
+
+fn C.v_fastc_tcc_set_skip_codesign(int)
+
+fn C.v_fastc_tcc_skipped_codesign_count() int
+
+const fastc_tcc_output_exe = 2
+
+struct FastcLibtccDiagnostics {
+mut:
+	messages []string
+}
+
+fn fastc_libtcc_error_callback(opaque voidptr, message &char) {
+	if isnil(opaque) || isnil(message) {
+		return
+	}
+	mut diagnostics := unsafe { &FastcLibtccDiagnostics(opaque) }
+	diagnostics.messages << unsafe { cstring_to_vstring(message) }.clone()
+}
+
+fn fastc_libtcc_quote_arg(arg string) string {
+	if arg.len > 0 && !arg.contains_any(' \t\r\n\\"') {
+		return arg
+	}
+	mut out := strings.new_builder(arg.len + 2)
+	out.write_u8(`"`)
+	for ch in arg {
+		if ch in [`\\`, `"`] {
+			out.write_u8(`\\`)
+		}
+		out.write_u8(ch)
+	}
+	out.write_u8(`"`)
+	return out.str()
+}
+
+fn fastc_libtcc_options(args []string) string {
+	mut out := strings.new_builder(args.len * 16)
+	for index, arg in args {
+		if index > 0 {
+			out.write_u8(` `)
+		}
+		out.write_string(fastc_libtcc_quote_arg(arg))
+	}
+	return out.str()
+}
+
+fn fastc_libtcc_diagnostics(diagnostics &FastcLibtccDiagnostics, fallback string) string {
+	if diagnostics.messages.len == 0 {
+		return fallback
+	}
+	return diagnostics.messages.join('\n')
+}
+
+fn fastc_libtcc_is_link_input(arg string) bool {
+	if !os.is_file(arg) {
+		return false
+	}
+	lower := arg.to_lower()
+	return lower.ends_with('.o') || lower.ends_with('.obj') || lower.ends_with('.a')
+		|| lower.ends_with('.lib') || lower.ends_with('.dylib') || lower.ends_with('.so')
+		|| lower.contains('.so.')
+}
+
+fn fastc_libtcc_apply_options(state &C.TCCState, args []string) int {
+	if args.len == 0 {
+		return 0
+	}
+	options := fastc_libtcc_options(args)
+	return C.tcc_set_options(state, options.str)
+}
+
+fn fastc_prepare_libtcc_link(program string, tcc_lib string, base_args []string) FastcPreparedLink {
+	state := C.tcc_new()
+	if isnil(state) {
+		return FastcPreparedLink{
+			program: program
+			base_args: base_args.clone()
+		}
+	}
+	diagnostics := &FastcLibtccDiagnostics{}
+	C.tcc_set_error_func(state, diagnostics, fastc_libtcc_error_callback)
+	C.tcc_set_lib_path(state, tcc_lib.str)
+	options := fastc_libtcc_options(base_args)
+	if C.tcc_set_options(state, options.str) != 0
+		|| C.tcc_set_output_type(state, fastc_tcc_output_exe) != 0 {
+		C.tcc_delete(state)
+		return FastcPreparedLink{
+			program: program
+			base_args: base_args.clone()
+		}
+	}
+	return FastcPreparedLink{
+		state: state
+		diagnostics: diagnostics
+		program: program
+	}
+}
+
+fn fastc_libtcc_state(link &FastcPreparedLink) &C.TCCState {
+	return unsafe { &C.TCCState(link.state) }
+}
+
+fn fastc_finish_libtcc_link(mut link FastcPreparedLink, input_paths []string, final_args []string, output string) os.Result {
+	state := fastc_libtcc_state(&link)
+	if isnil(state) || isnil(link.diagnostics) {
+		mut args := link.base_args.clone()
+		args << ['-o', output]
+		args << input_paths
+		args << final_args
+		return fastc_run_command(link.program, args)
+	}
+	mut diagnostics := unsafe { &FastcLibtccDiagnostics(link.diagnostics) }
+	defer {
+		C.tcc_delete(state)
+		link.state = unsafe { nil }
+		link.diagnostics = unsafe { nil }
+	}
+	for input_path in input_paths {
+		if C.tcc_add_file(state, input_path.str) != 0 {
+			return os.Result{
+				exit_code: 1
+				output: fastc_libtcc_diagnostics(diagnostics, 'could not add `${input_path}` to the TinyCC link')
+			}
+		}
+	}
+	mut pending_options := []string{}
+	for arg in final_args {
+		if fastc_libtcc_is_link_input(arg) {
+			if fastc_libtcc_apply_options(state, pending_options) != 0 {
+				return os.Result{
+					exit_code: 1
+					output: fastc_libtcc_diagnostics(diagnostics, 'TinyCC rejected the link options')
+				}
+			}
+			pending_options.clear()
+			if C.tcc_add_file(state, arg.str) != 0 {
+				return os.Result{
+					exit_code: 1
+					output: fastc_libtcc_diagnostics(diagnostics, 'could not add `${arg}` to the TinyCC link')
+				}
+			}
+		} else {
+			pending_options << arg
+		}
+	}
+	if fastc_libtcc_apply_options(state, pending_options) != 0 {
+		return os.Result{
+			exit_code: 1
+			output: fastc_libtcc_diagnostics(diagnostics, 'TinyCC rejected the link options')
+		}
+	}
+	C.v_fastc_tcc_set_skip_codesign(1)
+	output_result := C.tcc_output_file(state, output.str)
+	C.v_fastc_tcc_set_skip_codesign(0)
+	if output_result != 0 {
+		return os.Result{
+			exit_code: 1
+			output: fastc_libtcc_diagnostics(diagnostics, 'TinyCC could not write `${output}`')
+		}
+	}
+	return os.Result{
+		exit_code: 0
+		output: diagnostics.messages.join('\n')
+	}
+}
+
+fn fastc_discard_libtcc_link(mut link FastcPreparedLink) {
+	state := fastc_libtcc_state(&link)
+	if !isnil(state) {
+		C.tcc_delete(state)
+	}
+	link.state = unsafe { nil }
+	link.diagnostics = unsafe { nil }
+}

--- a/vlib/v3/gen/fastc/macho_sign_test.v
+++ b/vlib/v3/gen/fastc/macho_sign_test.v
@@ -17,6 +17,41 @@ fn test_fastc_codesign_shim_restores_path() {
 	assert !os.exists(shim.dir)
 }
 
+fn test_fastc_prepared_libtcc_link() {
+	if os.user_os() != 'macos' {
+		return
+	}
+	tcc := os.join_path(@VEXEROOT, 'thirdparty', 'tcc', 'tcc.exe')
+	if !os.is_file(tcc) {
+		return
+	}
+	test_dir := os.join_path(os.temp_dir(), 'fastc_libtcc_link_${os.getpid()}')
+	os.rmdir_all(test_dir) or {}
+	os.mkdir_all(test_dir) or { panic(err) }
+	defer {
+		os.rmdir_all(test_dir) or {}
+	}
+	source_path := os.join_path_single(test_dir, 'hello.c')
+	object_path := os.join_path_single(test_dir, 'hello.o')
+	exe_path := os.join_path_single(test_dir, 'hello')
+	os.write_file(source_path, 'int puts(const char *);\nint main(void) { puts("linked"); return 0; }\n') or {
+		panic(err)
+	}
+	tcc_lib := os.join_path(@VEXEROOT, 'thirdparty', 'tcc', 'lib')
+	base_args := ['-std=gnu11', '-B${tcc_lib}', '-I${os.join_path_single(tcc_lib, 'include')}',
+		'-L${tcc_lib}']
+	compile := os.execute('${tcc} ${base_args.join(' ')} -c -o ${object_path} ${source_path}')
+	assert compile.exit_code == 0, compile.output
+	mut prepared := fastc_prepare_link(tcc, tcc_lib, base_args)
+	skipped_codesigns := C.v_fastc_tcc_skipped_codesign_count()
+	link_result := fastc_finish_link(mut prepared, [object_path], [], exe_path)
+	assert link_result.exit_code == 0, link_result.output
+	assert C.v_fastc_tcc_skipped_codesign_count() == skipped_codesigns + 1
+	fastc_sign_macho_adhoc(exe_path) or { panic(err) }
+	assert os.execute(exe_path).output.trim_space() == 'linked'
+	assert os.system('/usr/bin/true') == 0
+}
+
 // A TinyCC-linked executable signed in process must run and pass Apple's
 // signature verification.
 fn test_fastc_sign_macho_adhoc_matches_codesign() {


### PR DESCRIPTION
## Summary

- initialize bundled libtcc concurrently with FastC translation-unit compilation and link the objects in process on macOS
- suppress TinyCC's redundant codesign subprocess, then keep V's in-process ad-hoc signing; retain the executable fallback for self-host descendants and non-macOS hosts
- cache the macOS SDK selected by xcrun while invalidating the cache when SDK or toolchain selection changes
- use a lean in-process V3 dispatch path for explicit FastC builds

## Performance

Measured with an optimized V host building an unoptimized V3 compiler (70,991 V LOC across 181 source files):

- isolated 15-run best compiler-phase time: 41.751 ms, or **1.700 MLOC/s**
- isolated 15-run median: 44.095 ms, or **1.610 MLOC/s**
- paired TCC/link/sign median: 31.272 ms -> 25.002 ms (about 20% faster)
- paired full-process wall median: 70.108 ms -> 54.998 ms (about 21.5% faster)

The machine had sustained background load, including an active QEMU VM, so medians varied more than usual. The 1.700 MLOC/s figure is the best compiler-phase repeat, not the full process wall rate.

## Testing

- `./vnew vlib/v3/cmdexec/macos_sdk_test.v`
- `./vnew vlib/v3/gen/fastc/macho_sign_test.v`
- `./vnew -no-memory-limit vlib/v3/fastcdriver/fastcdriver_test.v`
- `./vnew -run-only test_macos_v3_fastc_routes_compiler_selfhost_targets cmd/v/macos_v3_test.v`
- `./v -prod -o ./vnew cmd/v`
- optimized-host end-to-end build of an unoptimized V3 compiler, followed by compiling and running `examples/hello_world.v` with that compiler
- strict codesign verification of both generated executables

Broad test suites were skipped as requested. A full `cmd/v/macos_v3_test.v` run was also attempted, but this host has no iPhoneOS SDK, so its iOS case could not complete.
