### PR TITLE
v3: fix shared field stringification lookup

### DIFF
--- a/vlib/v3/gen/c/struct.v
+++ b/vlib/v3/gen/c/struct.v
@@ -3283,16 +3283,22 @@ fn (mut g FlatGen) gen_shared_field_storage_selector(base_id flat.NodeId, base_t
 }
 
 fn (mut g FlatGen) gen_shared_field_value_selector(base_id flat.NodeId, base_type0 types.Type, field string, op flat.Op) bool {
-	mut base_type := types.unwrap_pointer(base_type0)
-	if base_type is types.Alias {
-		base_type = types.unwrap_pointer(base_type.base_type)
+	if g.gen_shared_field_storage_selector(base_id, base_type0, field, op) {
+		g.write('->val')
+		return true
 	}
-	if base_type !is types.Struct {
+	if int(base_id) < 0 || int(base_id) >= g.a.nodes.len {
 		return false
 	}
-	struct_type := base_type as types.Struct
-	_ = g.shared_field_info(struct_type.name, field) or { return false }
-	if !g.gen_shared_field_storage_selector(base_id, base_type0, field, op) {
+	base := g.a.nodes[int(base_id)]
+	if base.typ.len == 0 {
+		return false
+	}
+	// Synthetic string methods can retain a stale short-name scope type while the
+	// exact qualified receiver type remains on the selector's base node.
+	annotated_base_type := g.parse_node_type(&base)
+	if annotated_base_type is types.Unknown || annotated_base_type is types.Void
+		|| !g.gen_shared_field_storage_selector(base_id, annotated_base_type, field, op) {
 		return false
 	}
 	g.write('->val')

--- a/vlib/v3/tests/lock_codegen_test.v
+++ b/vlib/v3/tests/lock_codegen_test.v
@@ -455,3 +455,28 @@ fn main() {
 	assert c_code.contains('\t__shared__Optional_string* b;'), c_code
 	assert !c_code.contains('struct __shared__Optional {\n\tsync__RwMutex mtx;\n\tOptional_string val;'), c_code
 }
+
+fn test_shared_map_field_stringification_reads_payload() {
+	c_code := lock_codegen_gen_c_sources('shared_map_field_stringification', {
+		'main.v':         'module main
+
+import binary
+
+struct SharedFieldStruct {
+	other int
+}
+
+fn main() {
+	println(binary.SharedFieldStruct{})
+}
+'
+		'binary/types.v': 'module binary
+
+pub struct SharedFieldStruct {
+pub mut:
+	values shared map[string]string
+}
+'
+	})
+	assert c_code.contains('.values->val, 1, 1, 0)'), c_code
+}


### PR DESCRIPTION
Fix V3 C generation for shared fields when a synthetic string method retains a stale short-name receiver type.

The generator now retries shared-field lookup with the exact type annotation on the selector base before selecting the shared payload. This fixes encoding/binary/serialize_test.v in the s390 and riscv master jobs.

Tests:
- focused shared-map codegen regression
- direct V3 compile and run of vlib/encoding/binary/serialize_test.v
- vlib/v/compiler_errors_test.v (1696 passed, 1 skipped)
- C output fixture suites (0 errors)
- targeted prealloc/coutput/TCC retry tests