### PR TITLE
v3: avoid duplicating same-directory test imports

### DIFF
--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -13391,13 +13391,23 @@ fn same_dir_module_source_files(test_file string, module_name string, prefs &pre
 	}
 	// V permits a small project fixture to put an imported module beside its
 	// main/test files. Include those directly imported, differently-declared
-	// files in the initial parse so resolving `import localmod` sees the same
-	// sources as the regular compiler.
+	// files in the initial parse when normal module lookup cannot find them.
+	// Resolvable same-directory modules (notably tests under vlib/os that import
+	// os) must remain imports, or their sources are parsed and emitted twice.
+	real_dir := os.real_path(dir)
+	mut normally_resolved_here := map[string]bool{}
+	for imported in imported_modules.keys() {
+		resolved := prefs.get_module_path(imported, test_file)
+		if resolved.len > 0 && os.is_dir(resolved) && os.real_path(resolved) == real_dir {
+			normally_resolved_here[imported] = true
+		}
+	}
 	for file in all_files {
 		if file in files {
 			continue
 		}
-		if imported_modules[declared_module_in_file(file)] {
+		declared_module := declared_module_in_file(file)
+		if imported_modules[declared_module] && !normally_resolved_here[declared_module] {
 			files << file
 		}
 	}

--- a/vlib/v3/driver/environment_test.v
+++ b/vlib/v3/driver/environment_test.v
@@ -55,6 +55,39 @@ fn test_v3_environment_show_test_stats_reads_vtest_show_asserts() {
 	assert v3_environment_show_test_stats()
 }
 
+fn test_single_moduleless_test_does_not_duplicate_a_resolvable_same_dir_module() {
+	root := os.join_path(os.temp_dir(), 'v3_same_dir_test_import_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	module_dir := os.join_path(root, 'vlib', 'sample')
+	os.mkdir_all(module_dir)!
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	test_file := os.join_path(module_dir, 'sample_test.v')
+	module_file := os.join_path(module_dir, 'sample.v')
+	os.write_file(test_file, 'import sample\n\nfn test_sample() {}\n')!
+	os.write_file(module_file, 'module sample\n\npub fn value() int { return 1 }\n')!
+	mut prefs := pref.new_preferences()
+	prefs.vroot = root
+	assert same_dir_module_source_files(test_file, '', prefs) == []
+}
+
+fn test_single_moduleless_test_keeps_an_unresolvable_same_dir_fixture_module() {
+	root := os.join_path(os.temp_dir(), 'v3_same_dir_test_fixture_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root)!
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	test_file := os.join_path(root, 'fixture_test.v')
+	module_file := os.join_path(root, 'helper.v')
+	os.write_file(test_file, 'import helper\n\nfn test_helper() {}\n')!
+	os.write_file(module_file, 'module helper\n\npub fn value() int { return 1 }\n')!
+	mut prefs := pref.new_preferences()
+	prefs.vroot = os.join_path(root, 'toolchain')
+	assert same_dir_module_source_files(test_file, '', prefs) == [module_file]
+}
+
 fn test_v3_diagnostic_color_option() {
 	defer {
 		apply_v3_diagnostic_color_option('-color')


### PR DESCRIPTION
Module-less tests can import a module whose source directory is also the test directory, as the os tests do. V3 added those sources to the initial input set and then resolved the import normally, parsing and emitting the module twice under different identities.

Keep the same-directory fixture fallback only when normal module lookup cannot resolve that module. This removes the private-method diagnostic fan-out and duplicate C definitions in the s390/riscv os test scope while retaining support for colocated fixture modules.

Tests (all single-worker):
- vlib/v3/driver/environment_test.v
- V3 fallback-disabled vlib/os/command_test.v
- V3 fallback-disabled vlib/builtin + vlib/os + vlib/encoding/binary: 67 passed, 2 skipped
- V3 fallback-disabled vlib/v/tests/fns/closure_test.v
- vlib/v/compiler_errors_test.v: 1696 passed, 1 skipped