### PR TITLE
ci: update multiwindow native proof hash

### DIFF
--- a/.github/workflows/macos_ci.yml
+++ b/.github/workflows/macos_ci.yml
@@ -168,7 +168,7 @@ jobs:
           set -euo pipefail
 
           source='vlib/x/multiwindow/native_operation_proof_test.v'
-          expected_source_sha256='56931b74007d11de80300c16979d0b8ae30345d1827aa64ffe1c7748d5bdfb4b'
+          expected_source_sha256='e483121f01365b178f93d1c8e8f5f0fd181479a18193b0438be5bcde81cae1b8'
           if [[ "${VFLAGS:-}" != '-cc clang' ]]; then
             echo "native operation V1 compatibility gate VFLAGS mismatch" >&2
             exit 1


### PR DESCRIPTION
The native operation compatibility gate pins the SHA-256 of its V1 proof source. #28317 intentionally changed the proof field type from `int` to `i32`, leaving the gate hash stale and causing the macOS 26 job to fail before running the proof.

Update the pinned hash to match the reviewed source. The expected 53-test invariant remains unchanged.

Validation:
- source SHA-256 matches the workflow pin
- source test count is 53
- workflow parses as YAML
- `git diff --check`