### PR TITLE
v3: apply FastC link options before output setup

### DIFF
--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -7454,6 +7454,12 @@ fn compile_v3_fastc_source(pieces []string, units fastc.FastcUnitLayout, bin_fil
 	if is_debug {
 		cc_args << '-g'
 	}
+	mut final_args := user_c_flags.clone()
+	if uses_threads {
+		final_args << '-lpthread'
+	}
+	final_args << '-lm'
+	final_args << environment_ld_flags
 	mut shim_dir := fastc.FastcCodesignShim{}
 	defer {
 		fastc.fastc_remove_codesign_shim_dir(shim_dir)
@@ -7465,7 +7471,7 @@ fn compile_v3_fastc_source(pieces []string, units fastc.FastcUnitLayout, bin_fil
 		mut compile_args := cc_args.clone()
 		compile_args << user_c_flags
 		link_worker := spawn fastc.fastc_prepare_link(tcc_path,
-			os.join_path_single(tcc_dir, 'lib'), cc_args)
+			os.join_path_single(tcc_dir, 'lib'), cc_args, final_args)
 		unit_objects := fastc.fastc_compile_c_units(tcc_path, compile_args, unit_paths) or {
 			mut prepared_link := link_worker.wait()
 			fastc.fastc_discard_link(mut prepared_link)
@@ -7479,12 +7485,6 @@ fn compile_v3_fastc_source(pieces []string, units fastc.FastcUnitLayout, bin_fil
 			eprintln('fastc-phase tcc.units_compiled ${cc_sw.elapsed().microseconds()}us')
 		}
 		link_inputs := unit_objects.clone()
-		mut final_args := user_c_flags.clone()
-		if uses_threads {
-			final_args << '-lpthread'
-		}
-		final_args << '-lm'
-		final_args << environment_ld_flags
 		mut display_args := cc_args.clone()
 		display_args << ['-o', staged_binary]
 		display_args << link_inputs
@@ -7504,14 +7504,7 @@ fn compile_v3_fastc_source(pieces []string, units fastc.FastcUnitLayout, bin_fil
 		}
 	} else {
 		cc_args << ['-o', 'out', 'src.c']
-		cc_args << user_c_flags
-		if uses_threads {
-			// The emitted spawn runtime calls pthread functions, which live
-			// outside libc on Linux with glibc before 2.34 and on the BSDs.
-			cc_args << '-lpthread'
-		}
-		cc_args << '-lm'
-		cc_args << environment_ld_flags
+		cc_args << final_args
 		command = cmdexec.display(tcc_path, cc_args)
 		shim_dir = fastc.fastc_codesign_shim_dir()
 		sign_in_process = shim_dir.dir != ''

--- a/vlib/v3/fastcdriver/fastcdriver.v
+++ b/vlib/v3/fastcdriver/fastcdriver.v
@@ -497,7 +497,7 @@ pub fn run(args []string) {
 	mut result := os.Result{}
 	mut sign_in_process := false
 	if unit_paths.len > 1 {
-		link_worker := spawn fastc.fastc_prepare_link(tcc, tcc_lib, cc_args)
+		link_worker := spawn fastc.fastc_prepare_link(tcc, tcc_lib, cc_args, link_libs)
 		unit_objects := fastc.fastc_compile_c_units(tcc, cc_args, unit_paths) or {
 			mut prepared_link := link_worker.wait()
 			fastc.fastc_discard_link(mut prepared_link)

--- a/vlib/v3/gen/fastc/link.v
+++ b/vlib/v3/gen/fastc/link.v
@@ -14,9 +14,11 @@ mut:
 
 // fastc_prepare_link initializes the in-process TinyCC linker on macOS. Other
 // platforms retain the executable-based linker and only record its arguments.
-pub fn fastc_prepare_link(program string, tcc_lib string, base_args []string) FastcPreparedLink {
+// `final_args` are supplied here so state-affecting linker options are visible
+// before TinyCC initializes its output state.
+pub fn fastc_prepare_link(program string, tcc_lib string, base_args []string, final_args []string) FastcPreparedLink {
 	$if macos && !fastc_selfhost ? {
-		return fastc_prepare_libtcc_link(program, tcc_lib, base_args)
+		return fastc_prepare_libtcc_link(program, tcc_lib, base_args, final_args)
 	} $else {
 		return FastcPreparedLink{
 			program: program

--- a/vlib/v3/gen/fastc/link_darwin.c.v
+++ b/vlib/v3/gen/fastc/link_darwin.c.v
@@ -106,12 +106,43 @@ fn fastc_libtcc_apply_options(state &C.TCCState, args []string) int {
 	return C.tcc_set_options(state, options.str)
 }
 
-fn fastc_libtcc_option_args(args []string) []string {
+fn fastc_libtcc_output_options(args []string) []string {
 	mut options := []string{cap: args.len}
-	for arg in args {
-		if !fastc_libtcc_is_link_input(arg) {
+	mut i := 0
+	for i < args.len {
+		arg := args[i]
+		is_combined_path_option := arg.len > 2
+			&& (arg.starts_with('-B') || arg.starts_with('-L'))
+		if arg in ['-nostdinc', '-nostdlib'] || is_combined_path_option {
 			options << arg
+			i++
+			continue
 		}
+		if arg in ['-B', '-L'] && i + 1 < args.len {
+			options << [arg, args[i + 1]]
+			i += 2
+			continue
+		}
+		if arg.starts_with('-Wl,') {
+			linker_args := arg[4..].split(',')
+			mut output_linker_args := []string{}
+			mut j := 0
+			for j < linker_args.len {
+				linker_arg := linker_args[j]
+				clean := linker_arg.trim_left('-')
+				if clean == 'nostdlib' || (clean.starts_with('L') && clean.len > 1) {
+					output_linker_args << linker_arg
+				} else if clean == 'L' && j + 1 < linker_args.len {
+					output_linker_args << [linker_arg, linker_args[j + 1]]
+					j++
+				}
+				j++
+			}
+			if output_linker_args.len > 0 {
+				options << '-Wl,${output_linker_args.join(',')}'
+			}
+		}
+		i++
 	}
 	return options
 }
@@ -128,7 +159,7 @@ fn fastc_prepare_libtcc_link(program string, tcc_lib string, base_args []string,
 	C.tcc_set_error_func(state, diagnostics, fastc_libtcc_error_callback)
 	C.tcc_set_lib_path(state, tcc_lib.str)
 	if fastc_libtcc_apply_options(state, base_args) != 0
-		|| fastc_libtcc_apply_options(state, fastc_libtcc_option_args(final_args)) != 0
+		|| fastc_libtcc_apply_options(state, fastc_libtcc_output_options(final_args)) != 0
 		|| C.tcc_set_output_type(state, fastc_tcc_output_exe) != 0 {
 		C.tcc_delete(state)
 		return FastcPreparedLink{
@@ -180,38 +211,68 @@ fn fastc_finish_libtcc_link(mut link FastcPreparedLink, input_paths []string, fi
 			}
 		}
 	}
-	mut expects_library_name := false
-	for arg in final_args {
-		if expects_library_name {
-			if result := fastc_libtcc_add_library(state, arg, diagnostics) {
+	mut pending_options := []string{}
+	mut i := 0
+	for i < final_args.len {
+		arg := final_args[i]
+		if arg == '-l' {
+			if i + 1 >= final_args.len {
+				return os.Result{
+					exit_code: 1
+					output: 'missing library name after `-l`'
+				}
+			}
+			if fastc_libtcc_apply_options(state, pending_options) != 0 {
+				return os.Result{
+					exit_code: 1
+					output: fastc_libtcc_diagnostics(diagnostics, 'TinyCC rejected the link options')
+				}
+			}
+			pending_options.clear()
+			i++
+			if result := fastc_libtcc_add_library(state, final_args[i], diagnostics) {
 				return result
 			}
-			expects_library_name = false
-			continue
-		}
-		if arg == '-l' {
-			expects_library_name = true
+			i++
 			continue
 		}
 		if arg.starts_with('-l') && arg.len > 2 {
+			if fastc_libtcc_apply_options(state, pending_options) != 0 {
+				return os.Result{
+					exit_code: 1
+					output: fastc_libtcc_diagnostics(diagnostics, 'TinyCC rejected the link options')
+				}
+			}
+			pending_options.clear()
 			if result := fastc_libtcc_add_library(state, arg[2..], diagnostics) {
 				return result
 			}
+			i++
 			continue
 		}
 		if fastc_libtcc_is_link_input(arg) {
+			if fastc_libtcc_apply_options(state, pending_options) != 0 {
+				return os.Result{
+					exit_code: 1
+					output: fastc_libtcc_diagnostics(diagnostics, 'TinyCC rejected the link options')
+				}
+			}
+			pending_options.clear()
 			if C.tcc_add_file(state, arg.str) != 0 {
 				return os.Result{
 					exit_code: 1
 					output: fastc_libtcc_diagnostics(diagnostics, 'could not add `${arg}` to the TinyCC link')
 				}
 			}
+		} else {
+			pending_options << arg
 		}
+		i++
 	}
-	if expects_library_name {
+	if fastc_libtcc_apply_options(state, pending_options) != 0 {
 		return os.Result{
 			exit_code: 1
-			output: 'missing library name after `-l`'
+			output: fastc_libtcc_diagnostics(diagnostics, 'TinyCC rejected the link options')
 		}
 	}
 	C.v_fastc_tcc_set_skip_codesign(1)

--- a/vlib/v3/gen/fastc/link_darwin.c.v
+++ b/vlib/v3/gen/fastc/link_darwin.c.v
@@ -29,6 +29,8 @@ fn C.tcc_set_output_type(&C.TCCState, int) int
 
 fn C.tcc_add_file(&C.TCCState, &char) int
 
+fn C.tcc_add_library(&C.TCCState, &char) int
+
 fn C.tcc_output_file(&C.TCCState, &char) int
 
 fn C.v_fastc_tcc_set_skip_codesign(int)
@@ -102,7 +104,17 @@ fn fastc_libtcc_apply_options(state &C.TCCState, args []string) int {
 	return C.tcc_set_options(state, options.str)
 }
 
-fn fastc_prepare_libtcc_link(program string, tcc_lib string, base_args []string) FastcPreparedLink {
+fn fastc_libtcc_option_args(args []string) []string {
+	mut options := []string{cap: args.len}
+	for arg in args {
+		if !fastc_libtcc_is_link_input(arg) {
+			options << arg
+		}
+	}
+	return options
+}
+
+fn fastc_prepare_libtcc_link(program string, tcc_lib string, base_args []string, final_args []string) FastcPreparedLink {
 	state := C.tcc_new()
 	if isnil(state) {
 		return FastcPreparedLink{
@@ -113,8 +125,8 @@ fn fastc_prepare_libtcc_link(program string, tcc_lib string, base_args []string)
 	diagnostics := &FastcLibtccDiagnostics{}
 	C.tcc_set_error_func(state, diagnostics, fastc_libtcc_error_callback)
 	C.tcc_set_lib_path(state, tcc_lib.str)
-	options := fastc_libtcc_options(base_args)
-	if C.tcc_set_options(state, options.str) != 0
+	if fastc_libtcc_apply_options(state, base_args) != 0
+		|| fastc_libtcc_apply_options(state, fastc_libtcc_option_args(final_args)) != 0
 		|| C.tcc_set_output_type(state, fastc_tcc_output_exe) != 0 {
 		C.tcc_delete(state)
 		return FastcPreparedLink{
@@ -131,6 +143,16 @@ fn fastc_prepare_libtcc_link(program string, tcc_lib string, base_args []string)
 
 fn fastc_libtcc_state(link &FastcPreparedLink) &C.TCCState {
 	return unsafe { &C.TCCState(link.state) }
+}
+
+fn fastc_libtcc_add_library(state &C.TCCState, name string, diagnostics &FastcLibtccDiagnostics) ?os.Result {
+	if C.tcc_add_library(state, name.str) != 0 {
+		return os.Result{
+			exit_code: 1
+			output: fastc_libtcc_diagnostics(diagnostics, 'could not add library `${name}` to the TinyCC link')
+		}
+	}
+	return none
 }
 
 fn fastc_finish_libtcc_link(mut link FastcPreparedLink, input_paths []string, final_args []string, output string) os.Result {
@@ -156,30 +178,38 @@ fn fastc_finish_libtcc_link(mut link FastcPreparedLink, input_paths []string, fi
 			}
 		}
 	}
-	mut pending_options := []string{}
+	mut expects_library_name := false
 	for arg in final_args {
-		if fastc_libtcc_is_link_input(arg) {
-			if fastc_libtcc_apply_options(state, pending_options) != 0 {
-				return os.Result{
-					exit_code: 1
-					output: fastc_libtcc_diagnostics(diagnostics, 'TinyCC rejected the link options')
-				}
+		if expects_library_name {
+			if result := fastc_libtcc_add_library(state, arg, diagnostics) {
+				return result
 			}
-			pending_options.clear()
+			expects_library_name = false
+			continue
+		}
+		if arg == '-l' {
+			expects_library_name = true
+			continue
+		}
+		if arg.starts_with('-l') && arg.len > 2 {
+			if result := fastc_libtcc_add_library(state, arg[2..], diagnostics) {
+				return result
+			}
+			continue
+		}
+		if fastc_libtcc_is_link_input(arg) {
 			if C.tcc_add_file(state, arg.str) != 0 {
 				return os.Result{
 					exit_code: 1
 					output: fastc_libtcc_diagnostics(diagnostics, 'could not add `${arg}` to the TinyCC link')
 				}
 			}
-		} else {
-			pending_options << arg
 		}
 	}
-	if fastc_libtcc_apply_options(state, pending_options) != 0 {
+	if expects_library_name {
 		return os.Result{
 			exit_code: 1
-			output: fastc_libtcc_diagnostics(diagnostics, 'TinyCC rejected the link options')
+			output: 'missing library name after `-l`'
 		}
 	}
 	C.v_fastc_tcc_set_skip_codesign(1)

--- a/vlib/v3/gen/fastc/macho_sign_test.v
+++ b/vlib/v3/gen/fastc/macho_sign_test.v
@@ -97,6 +97,59 @@ fn test_fastc_prepared_libtcc_applies_linker_options_before_output_setup() {
 	assert link_result.output.contains("library 'tcc1' not found"), link_result.output
 }
 
+fn test_fastc_prepared_libtcc_preserves_archive_option_order() {
+	if os.user_os() != 'macos' {
+		return
+	}
+	$if tinyc {
+		return
+	}
+	$if fastc_selfhost ? {
+		return
+	}
+	$if v3_backend ? {
+		return
+	}
+	tcc := os.join_path(@VEXEROOT, 'thirdparty', 'tcc', 'tcc.exe')
+	if !os.is_file(tcc) {
+		return
+	}
+	test_dir := os.join_path(os.temp_dir(), 'fastc_libtcc_whole_archive_${os.getpid()}')
+	os.rmdir_all(test_dir) or {}
+	os.mkdir_all(test_dir) or { panic(err) }
+	defer {
+		os.rmdir_all(test_dir) or {}
+	}
+	tcc_lib := os.join_path(@VEXEROOT, 'thirdparty', 'tcc', 'lib')
+	base_args := ['-std=gnu11', '-B${tcc_lib}', '-I${os.join_path_single(tcc_lib, 'include')}',
+		'-L${tcc_lib}']
+	main_source := os.join_path_single(test_dir, 'main.c')
+	main_object := os.join_path_single(test_dir, 'main.o')
+	member_source := os.join_path_single(test_dir, 'member.c')
+	member_object := os.join_path_single(test_dir, 'member.o')
+	archive_path := os.join_path_single(test_dir, 'libmember.a')
+	exe_path := os.join_path_single(test_dir, 'main')
+	os.write_file(main_source, 'int main(void) { return 0; }\n') or { panic(err) }
+	os.write_file(member_source, 'int forced_member(void) { return 73; }\n') or { panic(err) }
+	for source, object in {
+		main_source:   main_object
+		member_source: member_object
+	} {
+		compile := os.execute('${tcc} ${base_args.join(' ')} -c -o ${object} ${source}')
+		assert compile.exit_code == 0, compile.output
+	}
+	archive := os.execute('${tcc} -ar rcs ${archive_path} ${member_object}')
+	assert archive.exit_code == 0, archive.output
+	final_args := ['-Wl,--whole-archive', archive_path, '-Wl,--no-whole-archive']
+	mut prepared := fastc_prepare_link(tcc, tcc_lib, base_args, final_args)
+	assert fastc_prepared_link_skips_codesign(&prepared)
+	link_result := fastc_finish_link(mut prepared, [main_object], final_args, exe_path)
+	assert link_result.exit_code == 0, link_result.output
+	nm_result := os.execute('/usr/bin/nm -g ${exe_path}')
+	assert nm_result.exit_code == 0, nm_result.output
+	assert nm_result.output.contains('forced_member'), nm_result.output
+}
+
 // A TinyCC-linked executable signed in process must run and pass Apple's
 // signature verification.
 fn test_fastc_sign_macho_adhoc_matches_codesign() {

--- a/vlib/v3/gen/fastc/macho_sign_test.v
+++ b/vlib/v3/gen/fastc/macho_sign_test.v
@@ -42,7 +42,7 @@ fn test_fastc_prepared_libtcc_link() {
 		'-L${tcc_lib}']
 	compile := os.execute('${tcc} ${base_args.join(' ')} -c -o ${object_path} ${source_path}')
 	assert compile.exit_code == 0, compile.output
-	mut prepared := fastc_prepare_link(tcc, tcc_lib, base_args)
+	mut prepared := fastc_prepare_link(tcc, tcc_lib, base_args, [])
 	skipped_codesigns := C.v_fastc_tcc_skipped_codesign_count()
 	link_result := fastc_finish_link(mut prepared, [object_path], [], exe_path)
 	assert link_result.exit_code == 0, link_result.output
@@ -50,6 +50,36 @@ fn test_fastc_prepared_libtcc_link() {
 	fastc_sign_macho_adhoc(exe_path) or { panic(err) }
 	assert os.execute(exe_path).output.trim_space() == 'linked'
 	assert os.system('/usr/bin/true') == 0
+}
+
+fn test_fastc_prepared_libtcc_applies_linker_options_before_output_setup() {
+	if os.user_os() != 'macos' {
+		return
+	}
+	tcc := os.join_path(@VEXEROOT, 'thirdparty', 'tcc', 'tcc.exe')
+	if !os.is_file(tcc) {
+		return
+	}
+	test_dir := os.join_path(os.temp_dir(), 'fastc_libtcc_nostdlib_${os.getpid()}')
+	os.rmdir_all(test_dir) or {}
+	os.mkdir_all(test_dir) or { panic(err) }
+	defer {
+		os.rmdir_all(test_dir) or {}
+	}
+	source_path := os.join_path_single(test_dir, 'main.c')
+	object_path := os.join_path_single(test_dir, 'main.o')
+	exe_path := os.join_path_single(test_dir, 'main')
+	os.write_file(source_path, 'int main(void) { return 0; }\n') or { panic(err) }
+	tcc_lib := os.join_path(@VEXEROOT, 'thirdparty', 'tcc', 'lib')
+	base_args := ['-std=gnu11', '-B${tcc_lib}', '-I${os.join_path_single(tcc_lib, 'include')}']
+	compile := os.execute('${tcc} ${base_args.join(' ')} -c -o ${object_path} ${source_path}')
+	assert compile.exit_code == 0, compile.output
+	final_args := ['-Wl,-nostdlib', '-ltcc1']
+	mut prepared := fastc_prepare_link(tcc, tcc_lib, base_args, final_args)
+	assert fastc_prepared_link_skips_codesign(&prepared)
+	link_result := fastc_finish_link(mut prepared, [object_path], final_args, exe_path)
+	assert link_result.exit_code != 0
+	assert link_result.output.contains("library 'tcc1' not found"), link_result.output
 }
 
 // A TinyCC-linked executable signed in process must run and pass Apple's


### PR DESCRIPTION
## Summary

Follow-up to #28321.

- pass final linker arguments into libtcc preparation so all state-affecting options are parsed before `tcc_set_output_type`
- add explicit library and file operands only after output state initialization, matching TinyCC's required API ordering
- add a regression test proving `-Wl,-nostdlib` cannot resolve `libtcc1` through TinyCC's default library path
- preserve the original optimization by keeping preparation concurrent with translation-unit compilation

## Testing

- `./v -g -keepc -o ./vnew cmd/v`
- `./vnew fmt -verify vlib/v3/gen/fastc/link.v vlib/v3/gen/fastc/link_darwin.c.v vlib/v3/driver/driver.v vlib/v3/fastcdriver/fastcdriver.v vlib/v3/gen/fastc/macho_sign_test.v`
- `./vnew vlib/v3/gen/fastc/macho_sign_test.v`
- `./vnew -no-memory-limit vlib/v3/fastcdriver/fastcdriver_test.v`
- optimized-host end-to-end V3 FastC build, strict signature verification, and Hello World compile/run on the original PR branch before transplanting the identical patch

Broad test suites were skipped as requested.
